### PR TITLE
fix(frontend): scope sentence reassignment by chapterId

### DIFF
--- a/docs/features/12-manuscript-view.md
+++ b/docs/features/12-manuscript-view.md
@@ -1,9 +1,10 @@
 # Manuscript view
 
 > Status: stable (manuscript-edits hydrate, persist, and survive reparse)
-> Key files: `src/views/manuscript.tsx`, `src/store/manuscript-slice.ts` (`setSentenceCharacter`, `splitSentence`, `hydrateFromAnalysis` merge), `src/lib/types.ts` (`Sentence`), `server/src/routes/book-state.ts` (GET filter + reparse migration)
+> Key files: `src/views/manuscript.tsx`, `src/store/manuscript-slice.ts` (`setSentenceCharacter`, `setSentencesCharacter`, `splitSentence`, `hydrateFromAnalysis` merge), `src/lib/types.ts` (`Sentence`), `server/src/routes/book-state.ts` (GET filter + reparse migration)
 > URL surface: `#/books/:bookId/manuscript?chapter=N`
 > OpenAPI ops: `PUT /api/books/:bookId/state` with `slice: 'manuscript'`
+> Cross-links: [12a — Fix: sentence reassignment scoped by (chapterId, id)](12a-fix-reassign-cross-chapter-id.md) — patches the original single-id keying in the reassign reducers and the inspector prop.
 
 ## What this covers
 
@@ -13,7 +14,7 @@ Renders the manuscript a chapter at a time, sentence-by-sentence, with each sent
 
 - `Sentence` type extends the OpenAPI shape with an optional `confidence?: number` (`src/lib/types.ts:10-12`). Confidence is 0–1; absent means "unknown / not analysed."
 - Low-confidence sentences are visually flagged (e.g. dashed border) but the auto-attributed speaker is never silently replaced — the user has to act.
-- Reassignment dispatches `manuscriptActions.setSentenceCharacter({ sentenceId, characterId })` and triggers `PUT /api/books/:bookId/state` with `{ slice: 'manuscript', patch: { sentences: [...] } }` (`src/lib/types.ts:131-134`).
+- Reassignment dispatches `manuscriptActions.setSentenceCharacter({ chapterId, sentenceId, characterId })` (or `setSentencesCharacter` / `splitSentence` for the batch + split paths — same `chapterId` scoping) and triggers `PUT /api/books/:bookId/state` with `{ slice: 'manuscript', patch: { sentences: [...] } }` (`src/lib/types.ts:131-134`). Sentence ids restart at 1 in every chapter, so all sentence-targeting reducers match by `(chapterId, id)` — mirrors the hydrate-merge keying at `src/store/manuscript-slice.ts:86-88`. See [12a — Fix](12a-fix-reassign-cross-chapter-id.md) for the regression history.
 - `hydrateFromAnalysis` MERGES rather than overwrites once a manuscriptId is set: incoming sentences refresh fields (text, etc.) from analysis where ids match, but the slice's existing `characterId` is preserved. Split-sentence offsprings (ids the analyzer didn't emit) survive in narrative order. First-call hydrate (manuscriptId null) replaces wholesale.
 - Reparse PRESERVES `manuscript-edits.json`. The GET-side merge in `server/src/routes/book-state.ts` filters edits against the analysis cache: edit ids present in cache are kept; edit ids above the cache's max id are kept (likely split offsprings); edits with ids in the cache range but absent from cache are dropped as orphans. A `'reparse'` change-log entry records the count carried forward.
 - Audio tags (see `07-audio-tag-vocabulary.md`) render inline in the sentence text as badges, not stripped.

--- a/docs/features/12a-fix-reassign-cross-chapter-id.md
+++ b/docs/features/12a-fix-reassign-cross-chapter-id.md
@@ -1,0 +1,86 @@
+---
+status: active
+shipped: null
+owner: null
+---
+
+# Fix — sentence reassignment scoped by (chapterId, id)
+
+> Status: active (must-have, sibling fix to plan 12)
+> Cross-links: [12 — Manuscript view](12-manuscript-view.md) — this plan patches invariant 4 and the **Key files** line of plan 12 to reflect the chapterId-scoping contract.
+> Key files: `src/store/manuscript-slice.ts` (`setSentenceCharacter`, `setSentencesCharacter`, `splitSentence`), `src/views/manuscript.tsx` (`commitBoundaryMove`, `reassignSegment`, `assignSelectionTo`, inline `onReassignSentence`, `SegmentInspector` prop), `src/store/manuscript-slice.test.ts`, `src/views/manuscript.test.tsx`
+> URL surface: `#/books/:bookId/manuscript?chapter=N` — fix is invisible at the URL layer; the bug surfaced as "clicks do nothing" in chapters whose sentence ids collide with chapter 1's.
+> OpenAPI ops: none — the on-the-wire `PUT /api/books/:bookId/state` payload (a full sentences array) doesn't change. Only in-memory action payloads change.
+
+## Benefit / Rationale
+
+- **User:** clicking a character chip in the Manuscript inspector now actually reassigns the sentence the user clicked, on any chapter — not just chapter 1. Before the fix, reassigning a sentence in chapter 2+ silently mutated chapter 1's same-id sentence and the visible chapter didn't update. Surfaced by the user as "clicks don't do anything".
+- **Technical:** the three sentence-targeting reducers now match the same `(chapterId, id)` keying the hydrate merge already used (`src/store/manuscript-slice.ts:86-88`). One internal contract, three reducers, four callsites.
+- **Architectural:** locks the keying invariant for any future sentence-targeting reducer. Anyone adding `markSentenceAsTagged` or similar will inherit the right contract by example.
+
+## Why this regressed
+
+Plan 12's invariants documented the *public* shape of reassignment (action name, PUT payload) but never the *internal* keying. The hydrate merge picked up `(chapterId, id)` keying when the "whole book under the last chapter" bug forced the issue, but the reassign reducers were written earlier against the single-chapter fixture (`src/data/sentences.ts`, all chapter 3) and never re-examined. Unit tests in `manuscript-slice.test.ts` for `setSentenceCharacter` / `setSentencesCharacter` only used chapter-1 sentences, so the collision was invisible to the suite. There was no existing jsdom integration or e2e for the reassign flow, so the prop-wiring seam was uncovered too.
+
+## Architectural impact
+
+- **Action payload signature change** (in-process only — does not cross the OpenAPI boundary). Three reducers gain a required `chapterId: number`:
+  - `setSentenceCharacter({ chapterId, sentenceId, characterId })`
+  - `setSentencesCharacter({ chapterId, sentenceIds, characterId })`
+  - `splitSentence({ chapterId, sentenceId, offsets, characterIds })`
+- **Callsites in `src/views/manuscript.tsx` (4)** all already have the chapterId in scope:
+  - `commitBoundaryMove` — segments are built per current chapter; passes `currentChapterId`.
+  - `reassignSegment` — segment is single-chapter; passes `seg.sentences[0].chapterId`.
+  - `assignSelectionTo` — also fixed the standalone `sentences.find(s => s.id === selection.sentenceId)` to scope by `currentChapterId`; passes `currentChapterId` to the reducer.
+  - Inline `onReassignSentence` — `SegmentInspector` prop widened to `(chapterId, sentenceId, newCharId) => void` so the inspector forwards `s.chapterId`.
+- **`SegmentInspector` prop signature change** is local to `src/views/manuscript.tsx` — no other consumers.
+- **Invariants preserved (00, 24, 25, 26):** the discriminated-union `ui.stage`, the OpenAPI types, `Sentence` shape, design tokens, and the RTK Immer mutation pattern are all untouched.
+- **PUT payload (`src/lib/types.ts:131-134`) is unaffected** — the slice still ships its full `sentences[]` to disk and the server still merges. Only the in-memory reducer scoping changes.
+- **Migration story:** none — no on-disk format change, no env flag, no fixture migration.
+- **Reversibility:** straightforward `git revert` — the change is a contained signature widen across one slice, one view, two test files.
+
+## Invariants to preserve
+
+1. **Reassignment reducers scope by `(chapterId, id)`, not `id` alone.** Enforced in `src/store/manuscript-slice.ts` — `setSentenceCharacter`, `setSentencesCharacter`, and `splitSentence` find sentences using both fields. Mirrors the `${x.chapterId}:${x.id}` keying that `hydrateFromAnalysis` (`src/store/manuscript-slice.ts:86-88`) already uses.
+2. **Callers always pass the chapterId of the sentence(s) being mutated.** In `src/views/manuscript.tsx`, the chapterId either comes from `currentChapterId` (selection / boundary drag) or from `seg.sentences[0].chapterId` (segment inspector, since segments are built per chapter at `src/views/manuscript.tsx:80-90`).
+3. **`SegmentInspector.onReassignSentence` prop signature is `(chapterId: number, sentenceId: number, newCharId: string) => void`** — the inspector forwards `s.chapterId` from the per-sentence reassign callback so the parent does not need to look the chapterId up again.
+4. **No on-the-wire shape change.** The `PUT /api/books/:bookId/state` body remains `{ slice: 'manuscript', patch: { sentences: Sentence[] } }`. Each `Sentence` already carries `chapterId`, so the server side needs no updates.
+
+## Test plan
+
+### Automated coverage
+
+- **Vitest unit (`src/store/manuscript-slice.test.ts`)** — three new regression specs added next to the existing reducer specs, mirroring the hydrate-merge "keeps per-chapter sentence ids distinct" pattern:
+  - `setSentenceCharacter scopes by chapterId — chapter 2 reassignment leaves chapter 1 untouched`
+  - `setSentencesCharacter scopes by chapterId — chapter 2 batch leaves chapter 1 untouched`
+  - `splitSentence scopes by chapterId — chapter 2 split leaves chapter 1 untouched`
+  
+  Each one fails against the pre-fix reducer (matching by `id` alone returns the wrong chapter's sentence) and passes after the chapterId scoping lands. The existing `splitSentence` describe also gained `chapterId: 1` in every payload — behaviour they assert is unchanged.
+
+- **Vitest jsdom integration (`src/views/manuscript.test.tsx`)** — new spec `ManuscriptView — cross-chapter reassign isolation` renders the full view with two chapters sharing sentence id=1, opens the SegmentInspector on chapter 2, clicks the Eliza chip in "Reassign whole segment to", and asserts via `store.getState().manuscript.sentences` that chapter 2's sentence is reassigned and chapter 1's same-id sentence is untouched. Pins the prop wiring (`SegmentInspector.onReassignSentence(chapterId, sentenceId, newCharId)`) end-to-end through real React + real redux.
+
+- **No Playwright e2e** — the bug is a logic bug in the reducer + a one-line prop wiring change. It does not touch router, layout, focus, or hashchange seams (the cases CLAUDE.md cites jsdom as unreliable for). A Playwright spec would require either fixture surgery on the single-chapter `initialSentences` or a programmatic store-population shim; neither pays for itself given the slice unit tests already pin the reducer contract three ways and the jsdom integration test pins the prop wiring. If a future fixture refresh lands multi-chapter sentences as the default mock, file a backlog item to add `e2e/manuscript-reassign.spec.ts`.
+
+### Manual acceptance walkthrough
+
+Run `VITE_USE_MOCKS=true`, navigate to `#/books/<id>/manuscript`.
+
+1. **Pick a multi-chapter book** → sidebar shows ≥ 2 chapters.
+2. **Click chapter 2** in the sidebar → URL becomes `…?chapter=2`; sentences for chapter 2 render.
+3. **Click any paragraph** → SegmentInspector opens on the right.
+4. **In "Per-sentence reassign", expand the first sentence and click a different character chip** → the sentence's left-border colour updates immediately.
+5. **Click chapter 1** in the sidebar → URL becomes `…?chapter=1`; chapter 1's same-id sentence still shows its original colour. **This is the regression check.** Before the fix, chapter 1's sentence would have stolen the reassignment.
+6. **In "Reassign whole segment to" on chapter 2, click a different character** → all sentences in that segment recolour. Switch to chapter 1 → its same-id sentences are unaffected.
+7. **Selection-popover path:** in chapter 2, highlight a few characters inside a sentence and assign to a different character via the popover. Chapter 1's same-id sentence is unaffected; chapter 2's sentence splits as expected.
+8. **Boundary drag:** drag a paragraph boundary in chapter 2. Chapter 1 is untouched.
+9. **Real mode** (`npm run dev` + `cd server && npm run dev`): repeat steps 4 and 5. Reload — the reassignment persists in chapter 2 and chapter 1 is still untouched.
+
+## Out of scope
+
+- **On-disk format migration.** `manuscript-edits.json` already stores `Sentence[]` with `chapterId` per entry, so no migration is needed.
+- **Backfilling other under-tested reducers** in this slice. Scope strictly to the three reducers the bug touches.
+- **Playwright e2e for the manuscript reassign flow.** See Automated coverage above for the trade-off.
+
+## Ship notes
+
+(Filled in when status flips to `stable`. Append: shipped date, merge commit SHA, link to the regression specs that pin it. This sibling fix plan retires alongside plan 12 if/when plan 12 ever archives.)

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -58,6 +58,7 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 
 ### E. Manuscript editing
 - [12 — Manuscript view](12-manuscript-view.md) — Sentence list, low-confidence flagging, speaker reassignment.
+- [12a — Fix: sentence reassignment scoped by (chapterId, id)](12a-fix-reassign-cross-chapter-id.md) — Reassign reducers + inspector prop scope by both chapter and sentence id; pre-fix, clicks on chapter 2+ silently mutated chapter 1. **Status: active.**
 
 ### F. TTS
 - [13 — TTS engine picker](13-tts-engine-picker.md) — Two-tier engine + model selector.

--- a/src/store/manuscript-slice.test.ts
+++ b/src/store/manuscript-slice.test.ts
@@ -25,7 +25,7 @@ describe('manuscriptSlice — splitSentence', () => {
     ]));
     const next = manuscriptSlice.reducer(
       start,
-      manuscriptActions.splitSentence({ sentenceId: 1, offsets: [6], characterIds: ['narrator', 'eliza'] }),
+      manuscriptActions.splitSentence({ chapterId: 1, sentenceId: 1, offsets: [6], characterIds: ['narrator', 'eliza'] }),
     );
     expect(next.sentences).toHaveLength(2);
     expect(next.sentences[0]).toMatchObject({ id: 1, text: 'Hello ', characterId: 'narrator' });
@@ -40,7 +40,7 @@ describe('manuscriptSlice — splitSentence', () => {
     const next = manuscriptSlice.reducer(
       start,
       manuscriptActions.splitSentence({
-        sentenceId: 5, offsets: [3, 7],
+        chapterId: 1, sentenceId: 5, offsets: [3, 7],
         characterIds: ['narrator', 'halloran', 'eliza'],
       }),
     );
@@ -60,7 +60,7 @@ describe('manuscriptSlice — splitSentence', () => {
     const next = manuscriptSlice.reducer(
       start,
       manuscriptActions.splitSentence({
-        sentenceId: 1, offsets: [0, 3],
+        chapterId: 1, sentenceId: 1, offsets: [0, 3],
         characterIds: ['skip-a', 'narrator', 'skip-b'],
       }),
     );
@@ -75,7 +75,7 @@ describe('manuscriptSlice — splitSentence', () => {
     const next = manuscriptSlice.reducer(
       start,
       manuscriptActions.splitSentence({
-        sentenceId: 1, offsets: [4, 2],
+        chapterId: 1, sentenceId: 1, offsets: [4, 2],
         characterIds: ['a', 'b', 'c'],
       }),
     );
@@ -89,7 +89,7 @@ describe('manuscriptSlice — splitSentence', () => {
     ]));
     const next = manuscriptSlice.reducer(
       start,
-      manuscriptActions.splitSentence({ sentenceId: 3, offsets: [3], characterIds: ['narrator', 'narrator'] }),
+      manuscriptActions.splitSentence({ chapterId: 1, sentenceId: 3, offsets: [3], characterIds: ['narrator', 'narrator'] }),
     );
     const ids = next.sentences.map(s => s.id);
     expect(ids).toEqual([3, 100, 99]);
@@ -101,7 +101,7 @@ describe('manuscriptSlice — splitSentence', () => {
     ]));
     const next = manuscriptSlice.reducer(
       start,
-      manuscriptActions.splitSentence({ sentenceId: 1, offsets: [2], characterIds: ['eliza'] }),
+      manuscriptActions.splitSentence({ chapterId: 1, sentenceId: 1, offsets: [2], characterIds: ['eliza'] }),
     );
     expect(next.sentences).toEqual([
       expect.objectContaining({ id: 1, text: 'ab', characterId: 'eliza' }),
@@ -115,9 +115,35 @@ describe('manuscriptSlice — splitSentence', () => {
     ]));
     const next = manuscriptSlice.reducer(
       start,
-      manuscriptActions.splitSentence({ sentenceId: 999, offsets: [1], characterIds: ['a', 'b'] }),
+      manuscriptActions.splitSentence({ chapterId: 1, sentenceId: 999, offsets: [1], characterIds: ['a', 'b'] }),
     );
     expect(next.sentences).toEqual(start.sentences);
+  });
+
+  /* Regression: same (chapterId, id) scoping bug as the reassign reducers
+     above — splitSentence used findIndex by id alone, so requesting a split
+     in chapter 2 would have sliced up chapter 1's same-id sentence instead. */
+  it('splitSentence scopes by chapterId — chapter 2 split leaves chapter 1 untouched', () => {
+    const start = baseState([
+      { id: 1, chapterId: 1, text: 'ch1-keep', characterId: 'narrator' },
+      { id: 3, chapterId: 1, text: 'ch1-id3-keep', characterId: 'eliza' },
+      { id: 1, chapterId: 2, text: 'ch2-keep', characterId: 'narrator' },
+      { id: 3, chapterId: 2, text: 'abcdef', characterId: 'narrator' },
+    ]);
+    const next = manuscriptSlice.reducer(
+      start,
+      manuscriptActions.splitSentence({
+        chapterId: 2, sentenceId: 3, offsets: [3],
+        characterIds: ['narrator', 'halloran'],
+      }),
+    );
+    expect(next.sentences.map(s => ({ chapterId: s.chapterId, id: s.id, text: s.text, characterId: s.characterId }))).toEqual([
+      { chapterId: 1, id: 1, text: 'ch1-keep',      characterId: 'narrator' },
+      { chapterId: 1, id: 3, text: 'ch1-id3-keep', characterId: 'eliza'    }, // untouched
+      { chapterId: 2, id: 1, text: 'ch2-keep',      characterId: 'narrator' },
+      { chapterId: 2, id: 3, text: 'abc',           characterId: 'narrator' }, // first split-piece keeps original id
+      { chapterId: 2, id: 4, text: 'def',           characterId: 'halloran' }, // new id, inserted after
+    ]);
   });
 });
 
@@ -129,7 +155,7 @@ describe('manuscriptSlice — setSentenceCharacter / setSentencesCharacter', () 
     ]));
     const next = manuscriptSlice.reducer(
       start,
-      manuscriptActions.setSentenceCharacter({ sentenceId: 2, characterId: 'eliza' }),
+      manuscriptActions.setSentenceCharacter({ chapterId: 1, sentenceId: 2, characterId: 'eliza' }),
     );
     expect(next.sentences[1].characterId).toBe('eliza');
     expect(next.sentences[0].characterId).toBe('narrator');
@@ -143,9 +169,55 @@ describe('manuscriptSlice — setSentenceCharacter / setSentencesCharacter', () 
     ]));
     const next = manuscriptSlice.reducer(
       start,
-      manuscriptActions.setSentencesCharacter({ sentenceIds: [1, 3], characterId: 'halloran' }),
+      manuscriptActions.setSentencesCharacter({ chapterId: 1, sentenceIds: [1, 3], characterId: 'halloran' }),
     );
     expect(next.sentences.map(s => s.characterId)).toEqual(['halloran', 'narrator', 'halloran']);
+  });
+
+  /* Regression: sentence ids restart at 1 in every chapter (the hydrate merge
+     keys by `${chapterId}:${id}` for the same reason — see the
+     "keeps per-chapter sentence ids distinct" test below). The reassign
+     reducers must scope by (chapterId, id), not id alone. Before the fix,
+     clicking a character chip in the SegmentInspector for a chapter-2
+     sentence silently mutated chapter 1's sentence with the same id and
+     left the visible chapter unchanged — surfaced by the user as "clicks
+     don't do anything". */
+  it('setSentenceCharacter scopes by chapterId — chapter 2 reassignment leaves chapter 1 untouched', () => {
+    const start = baseState([
+      { id: 1, chapterId: 1, text: 'ch1-s1', characterId: 'narrator' },
+      { id: 2, chapterId: 1, text: 'ch1-s2', characterId: 'narrator' },
+      { id: 1, chapterId: 2, text: 'ch2-s1', characterId: 'narrator' },
+      { id: 2, chapterId: 2, text: 'ch2-s2', characterId: 'narrator' },
+    ]);
+    const next = manuscriptSlice.reducer(
+      start,
+      manuscriptActions.setSentenceCharacter({ chapterId: 2, sentenceId: 2, characterId: 'eliza' }),
+    );
+    expect(next.sentences.map(s => ({ chapterId: s.chapterId, id: s.id, characterId: s.characterId }))).toEqual([
+      { chapterId: 1, id: 1, characterId: 'narrator' },
+      { chapterId: 1, id: 2, characterId: 'narrator' }, // untouched — same id, different chapter
+      { chapterId: 2, id: 1, characterId: 'narrator' },
+      { chapterId: 2, id: 2, characterId: 'eliza'    }, // the one we asked for
+    ]);
+  });
+
+  it('setSentencesCharacter scopes by chapterId — chapter 2 batch leaves chapter 1 untouched', () => {
+    const start = baseState([
+      { id: 1, chapterId: 1, text: 'ch1-s1', characterId: 'narrator' },
+      { id: 2, chapterId: 1, text: 'ch1-s2', characterId: 'narrator' },
+      { id: 1, chapterId: 2, text: 'ch2-s1', characterId: 'narrator' },
+      { id: 2, chapterId: 2, text: 'ch2-s2', characterId: 'narrator' },
+    ]);
+    const next = manuscriptSlice.reducer(
+      start,
+      manuscriptActions.setSentencesCharacter({ chapterId: 2, sentenceIds: [1, 2], characterId: 'halloran' }),
+    );
+    expect(next.sentences.map(s => ({ chapterId: s.chapterId, id: s.id, characterId: s.characterId }))).toEqual([
+      { chapterId: 1, id: 1, characterId: 'narrator' }, // untouched
+      { chapterId: 1, id: 2, characterId: 'narrator' }, // untouched
+      { chapterId: 2, id: 1, characterId: 'halloran' },
+      { chapterId: 2, id: 2, characterId: 'halloran' },
+    ]);
   });
 });
 

--- a/src/store/manuscript-slice.ts
+++ b/src/store/manuscript-slice.ts
@@ -136,18 +136,24 @@ export const manuscriptSlice = createSlice({
       s.importCandidate = null;
     },
 
-    /* User edit: reassign a single sentence to a different character. */
-    setSentenceCharacter: (s, a: PayloadAction<{ sentenceId: number; characterId: string }>) => {
-      const sent = s.sentences.find(x => x.id === a.payload.sentenceId);
+    /* User edit: reassign a single sentence to a different character.
+       Scopes by (chapterId, sentenceId) — sentence ids restart at 1 in
+       every chapter, so a single-id match would silently mutate the wrong
+       chapter's same-id sentence. Mirrors the hydrate-merge keying above. */
+    setSentenceCharacter: (s, a: PayloadAction<{ chapterId: number; sentenceId: number; characterId: string }>) => {
+      const sent = s.sentences.find(x => x.chapterId === a.payload.chapterId && x.id === a.payload.sentenceId);
       if (sent) sent.characterId = a.payload.characterId;
     },
 
     /* User edit: reassign a batch of sentences at once. Used by the
-       boundary-drag handle and the segment inspector. */
-    setSentencesCharacter: (s, a: PayloadAction<{ sentenceIds: number[]; characterId: string }>) => {
+       boundary-drag handle and the segment inspector. Scoped to one
+       chapter — the caller batches ids from a single chapter's segments. */
+    setSentencesCharacter: (s, a: PayloadAction<{ chapterId: number; sentenceIds: number[]; characterId: string }>) => {
       const ids = new Set(a.payload.sentenceIds);
       for (const sent of s.sentences) {
-        if (ids.has(sent.id)) sent.characterId = a.payload.characterId;
+        if (sent.chapterId === a.payload.chapterId && ids.has(sent.id)) {
+          sent.characterId = a.payload.characterId;
+        }
       }
     },
 
@@ -156,9 +162,10 @@ export const manuscriptSlice = createSlice({
        0-based character positions within the original sentence text.
        characterIds.length must equal offsets.length + 1. The first piece
        keeps the original sentence's id; subsequent pieces get new ids
-       (max + 1, +2, …) inserted right after it. Empty pieces are skipped. */
-    splitSentence: (s, a: PayloadAction<{ sentenceId: number; offsets: number[]; characterIds: string[] }>) => {
-      const idx = s.sentences.findIndex(x => x.id === a.payload.sentenceId);
+       (max + 1, +2, …) inserted right after it. Empty pieces are skipped.
+       Scoped to one chapter — sentence ids restart per chapter. */
+    splitSentence: (s, a: PayloadAction<{ chapterId: number; sentenceId: number; offsets: number[]; characterIds: string[] }>) => {
+      const idx = s.sentences.findIndex(x => x.chapterId === a.payload.chapterId && x.id === a.payload.sentenceId);
       if (idx < 0) return;
       const original = s.sentences[idx];
       const text = original.text;

--- a/src/views/manuscript.test.tsx
+++ b/src/views/manuscript.test.tsx
@@ -312,3 +312,78 @@ describe('ManuscriptView — inspector with large cast', () => {
     }
   });
 });
+
+/* Cross-chapter reassign — regression for the bug where clicking a
+   character chip in the SegmentInspector on a non-first chapter silently
+   mutated chapter 1's same-id sentence (because the reducer matched by id
+   alone, but sentence ids restart at 1 per chapter). The slice unit tests
+   in src/store/manuscript-slice.test.ts cover the reducer in isolation;
+   this test pins the prop wiring end-to-end through real React + real
+   redux: SegmentInspector must forward `s.chapterId` to onReassignSentence
+   so the dispatch carries the right chapter scope. */
+describe('ManuscriptView — cross-chapter reassign isolation', () => {
+  it('reassigning a chapter-2 sentence via the inspector leaves chapter 1\'s same-id sentence untouched', async () => {
+    const user = userEvent.setup();
+    const reassignCharacters: Character[] = [
+      { id: 'narrator', name: 'Narrator', role: 'Narrator', color: 'narrator' },
+      { id: 'eliza',    name: 'Eliza',    role: 'Cast',     color: 'narrator' },
+    ];
+    const twoChapters: Chapter[] = [
+      { id: 1, title: 'Chapter One', duration: '10:00', state: 'done', progress: 1, characters: {} },
+      { id: 2, title: 'Chapter Two', duration: '10:00', state: 'done', progress: 1, characters: {} },
+    ];
+    /* Both chapters carry id=1 — the collision the bug used to glob onto. */
+    const twoChapterSentences: Sentence[] = [
+      { id: 1, chapterId: 1, characterId: 'narrator', text: 'Chapter one opening line.' },
+      { id: 1, chapterId: 2, characterId: 'narrator', text: 'Chapter two opening line.' },
+    ];
+    const store = configureStore({
+      reducer: {
+        manuscript: manuscriptSlice.reducer,
+        changeLog:  changeLogSlice.reducer,
+      },
+      preloadedState: {
+        manuscript: {
+          bookId: null, manuscriptId: null, title: null, format: null,
+          wordCount: 0, sourceText: null,
+          sentences: twoChapterSentences,
+          importCandidate: null,
+        },
+      },
+    });
+    render(
+      <Provider store={store}>
+        <ManuscriptView
+          characters={reassignCharacters}
+          chapters={twoChapters}
+          currentChapterId={2}
+          setCurrentChapterId={() => {}}
+          sentencesFromStore={twoChapterSentences}
+        />
+      </Provider>,
+    );
+
+    /* Open the inspector by clicking chapter 2's sentence. */
+    await user.click(screen.getByText('Chapter two opening line.'));
+    expect(screen.getByText('Reassign whole segment to')).toBeInTheDocument();
+
+    /* Click the Eliza chip in the "Reassign whole segment to" list. The
+       inspector lists every cast member; Eliza appears once in the list
+       and once in the sidebar (Detected), so use getAllByText and click
+       the inspector copy (last in DOM order under the inspector card). */
+    const elizaButtons = screen.getAllByRole('button', { name: /Eliza/ });
+    /* The inspector copy is inside the inspector card — its parent button
+       has the role and contains the colour dot + name. Pick the last one
+       because the inspector card renders below the sidebar card in DOM
+       order. */
+    await user.click(elizaButtons[elizaButtons.length - 1]);
+
+    /* Store assertion is the regression contract. Chapter 2's sentence
+       reassigned; chapter 1's same-id sentence untouched. */
+    const after = store.getState().manuscript.sentences;
+    expect(after).toEqual([
+      { id: 1, chapterId: 1, characterId: 'narrator', text: 'Chapter one opening line.' },
+      { id: 1, chapterId: 2, characterId: 'eliza',    text: 'Chapter two opening line.' },
+    ]);
+  });
+});

--- a/src/views/manuscript.tsx
+++ b/src/views/manuscript.tsx
@@ -131,11 +131,9 @@ export function ManuscriptView({ characters, chapters, currentChapterId, setCurr
       newCharacterId = segAbove.characterId;
       for (let i = anchorIdx; i <= candIdx; i++) ids.push(sentences[i].id);
     }
-    if (ids.length) {
-      dispatch(manuscriptActions.setSentencesCharacter({ sentenceIds: ids, characterId: newCharacterId }));
-      if (currentChapterId != null) {
-        dispatch(changeLogActions.bumpBoundaryMove({ chapterId: currentChapterId, count: ids.length }));
-      }
+    if (ids.length && currentChapterId != null) {
+      dispatch(manuscriptActions.setSentencesCharacter({ chapterId: currentChapterId, sentenceIds: ids, characterId: newCharacterId }));
+      dispatch(changeLogActions.bumpBoundaryMove({ chapterId: currentChapterId, count: ids.length }));
     }
   }
 
@@ -163,36 +161,42 @@ export function ManuscriptView({ characters, chapters, currentChapterId, setCurr
   }, [drag?.boundaryIdx]);
 
   function reassignSegment(seg: Segment, newCharId: string) {
+    /* Segments are built per current chapter (src/views/manuscript.tsx:80-90),
+       so every sentence inside one segment shares the same chapterId. */
+    const chapterId = seg.sentences[0]?.chapterId;
+    if (chapterId == null) return;
     const ids = seg.sentences.map(s => s.id);
     dispatch(manuscriptActions.setSentencesCharacter({
+      chapterId,
       sentenceIds: ids,
       characterId: newCharId,
     }));
-    if (currentChapterId != null) {
-      dispatch(changeLogActions.bumpBoundaryMove({ chapterId: currentChapterId, count: ids.length }));
-    }
+    dispatch(changeLogActions.bumpBoundaryMove({ chapterId, count: ids.length }));
   }
 
   function assignSelectionTo(newCharacterId: string) {
-    if (!selection) return;
-    const sentence = sentences.find(s => s.id === selection.sentenceId);
+    if (!selection || currentChapterId == null) return;
+    /* Scope the lookup to the current chapter — sentence ids restart at 1
+       per chapter, so a `s.id === selection.sentenceId` match alone would
+       silently return chapter 1's same-id sentence when the user is on a
+       later chapter. */
+    const sentence = sentences.find(s => s.chapterId === currentChapterId && s.id === selection.sentenceId);
     if (!sentence) return;
     const len = sentence.text.length;
     /* Whole sentence selected → simple reassign. Otherwise split into
        three pieces with the middle reassigned. The reducer drops empty
        pieces, so leading/trailing zero-length splits are safe. */
     if (selection.start <= 0 && selection.end >= len) {
-      dispatch(manuscriptActions.setSentenceCharacter({ sentenceId: selection.sentenceId, characterId: newCharacterId }));
+      dispatch(manuscriptActions.setSentenceCharacter({ chapterId: currentChapterId, sentenceId: selection.sentenceId, characterId: newCharacterId }));
     } else {
       dispatch(manuscriptActions.splitSentence({
+        chapterId: currentChapterId,
         sentenceId: selection.sentenceId,
         offsets: [selection.start, selection.end],
         characterIds: [sentence.characterId, newCharacterId, sentence.characterId],
       }));
     }
-    if (currentChapterId != null) {
-      dispatch(changeLogActions.bumpBoundaryMove({ chapterId: currentChapterId, count: 1 }));
-    }
+    dispatch(changeLogActions.bumpBoundaryMove({ chapterId: currentChapterId, count: 1 }));
     window.getSelection()?.removeAllRanges();
   }
 
@@ -422,11 +426,9 @@ export function ManuscriptView({ characters, chapters, currentChapterId, setCurr
             reassignSegment(seg, newCharId);
             setSelectedSeg(null);
           }}
-          onReassignSentence={(sentenceId, newCharId) => {
-            dispatch(manuscriptActions.setSentenceCharacter({ sentenceId, characterId: newCharId }));
-            if (currentChapterId != null) {
-              dispatch(changeLogActions.bumpBoundaryMove({ chapterId: currentChapterId, count: 1 }));
-            }
+          onReassignSentence={(chapterId, sentenceId, newCharId) => {
+            dispatch(manuscriptActions.setSentenceCharacter({ chapterId, sentenceId, characterId: newCharId }));
+            dispatch(changeLogActions.bumpBoundaryMove({ chapterId, count: 1 }));
           }}
           onOpenProfile={onOpenProfile}
         />
@@ -539,7 +541,7 @@ interface InspectorProps {
   findChar: (id: string) => Character | undefined;
   onClose: () => void;
   onReassignSegment: (seg: Segment, newCharId: string) => void;
-  onReassignSentence: (sentenceId: number, newCharId: string) => void;
+  onReassignSentence: (chapterId: number, sentenceId: number, newCharId: string) => void;
   onOpenProfile?: (id: string) => void;
 }
 
@@ -622,7 +624,7 @@ function SegmentInspector({ seg, characters, findChar, onClose, onReassignSegmen
                     <summary className="text-[11px] text-ink/60 cursor-pointer hover:text-ink">Reassign just this one</summary>
                     <div className="mt-2 flex flex-wrap gap-1">
                       {characters.map(cand => (
-                        <button key={cand.id} onClick={() => onReassignSentence(s.id, cand.id)}
+                        <button key={cand.id} onClick={() => onReassignSentence(s.chapterId, s.id, cand.id)}
                                 className={`inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] ${cand.id === seg.characterId ? 'bg-ink/[0.06] text-ink/60' : 'bg-white border border-ink/10 hover:border-ink/30'}`}>
                           <ColorDot color={cand.color as CharColor} size={8}/>
                           <span>{cand.name}</span>


### PR DESCRIPTION
## Summary

- **Bug:** clicking a character chip in the Manuscript SegmentInspector on chapter 2+ silently mutated chapter 1's same-id sentence and the visible chapter didn't update — surfaced by the user as "clicks don't do anything".
- **Root cause:** the three sentence-targeting reducers in `src/store/manuscript-slice.ts` (`setSentenceCharacter`, `setSentencesCharacter`, `splitSentence`) found sentences by `id` alone, but sentence ids restart at 1 in every chapter (load-bearing keying that `hydrateFromAnalysis` already uses at `src/store/manuscript-slice.ts:86-88`).
- **Fix:** widen all three payload signatures to require `chapterId` and scope the `find` / `findIndex` / `Set.has` lookups by `(chapterId, id)`. Update the four callsites in `src/views/manuscript.tsx` (`commitBoundaryMove`, `reassignSegment`, `assignSelectionTo`, inline `onReassignSentence` handler) to pass the chapterId already in scope. Widen the `SegmentInspector.onReassignSentence` prop to `(chapterId, sentenceId, newCharId)` so the inspector forwards `s.chapterId`. Also fix the standalone `sentences.find(s => s.id === selection.sentenceId)` lookup in `assignSelectionTo` to scope by `currentChapterId`.

## Regression coverage

- **`src/store/manuscript-slice.test.ts`** — 3 new specs, one per reducer, mirroring the existing "keeps per-chapter sentence ids distinct" hydrate test:
  - `setSentenceCharacter scopes by chapterId — chapter 2 reassignment leaves chapter 1 untouched`
  - `setSentencesCharacter scopes by chapterId — chapter 2 batch leaves chapter 1 untouched`
  - `splitSentence scopes by chapterId — chapter 2 split leaves chapter 1 untouched`
  
  Each one fails before the fix (matching by `id` alone returns the wrong chapter's sentence) and passes after. Existing splitSentence specs widened to include `chapterId: 1`; behaviour assertions unchanged.

- **`src/views/manuscript.test.tsx`** — new spec `ManuscriptView — cross-chapter reassign isolation` renders the full view with two chapters sharing sentence id=1, opens the SegmentInspector on chapter 2, clicks a different character chip in "Reassign whole segment to", and asserts via `store.getState().manuscript.sentences` that chapter 2's sentence is reassigned and chapter 1's is untouched. Pins the prop wiring end-to-end through real React + real redux.

No Playwright e2e: the bug is a logic bug in the reducer + a one-line prop wiring change. It does not touch router, layout, focus, or hashchange seams. See plan 12a's Test plan for the cost/value reasoning.

## Docs

- New sibling plan `docs/features/12a-fix-reassign-cross-chapter-id.md` documents the bug, the fix, the architectural impact, and the new chapterId-scoping invariant.
- `docs/features/12-manuscript-view.md`: invariant 4 + Key files line updated to reflect the `(chapterId, id)` keying contract; cross-link to 12a added.
- `docs/features/INDEX.md`: 12a entry added under E. Manuscript editing.

## Test plan

- [x] \`npm run verify\` locally (typecheck + all tests + e2e + build) — green; 4 unrelated e2e flakes auto-passed on Playwright retry.
- [x] Manual walkthrough in mock mode: clicking "Elwyn" on chapter 2's per-sentence reassign list now updates the visible chapter; switching to chapter 1 shows its same-id sentence is unchanged.
- [ ] Reviewer: spot-check the 4 callsites in \`src/views/manuscript.tsx\` and confirm each callsite's chapterId source is the one the reducer expects.
- [ ] Reviewer: confirm plan 12a's "Why this regressed" section reads correctly as the regression history record.