### PR TITLE
chore: release v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "audiobook-generator",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "audiobook-generator",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@reduxjs/toolkit": "^2.2.0",
         "@types/qrcode": "^1.5.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audiobook-generator",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "audiobook-generator-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "audiobook-generator-server",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@google/genai": "^2.0.1",
         "@types/yazl": "^3.3.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audiobook-generator-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps both package.json + package-lock.json versions from 1.0.0 to 1.1.0.
- Release notes will land in the annotated `v1.1.0` git tag once this merges, per the convention added in [CONTRIBUTING.md "Release notes"](../blob/main/CONTRIBUTING.md#release-notes).
- README.md landed separately in #3 so GitHub's project landing page is correct the moment v1.1.0 ships.

## What ships in v1.1.0

User-visible since v1.0.0 (full list in the tag annotation):

- **Features** — Dark mode + theme picker (42), auto-start TTS sidecar (43), cover framing + local upload (40), manual continuity link to a prior series book (09), sticky subset-retry (32), cold-boot AnalysisPill rehydrate + paused/halted library badges (32, 41 partial), auto-retry transient TTS sidecar failures, rotating state.json backups + torn-read recovery (27 follow-up), redux-persist on ui + manuscript slices.
- **Fixes** — Sentence reassignment scoped by (chapterId, id) (12a), D2 implicit-reconcile guard for local analysis (32), confirm/ready refetch when cast is empty.
- **Engineering** — state.json schema versioning + migration seam (27), five new Playwright specs + visual baselines, sidecar concurrent-synthesis test, release-notes rules in CONTRIBUTING.md, README at repo root.

## Test plan
- [x] `npm run verify` (pre-push hook) — green
- [ ] After merge: pull main, create annotated `v1.1.0` tag, push the tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)