### PR TITLE
docs(docs): plan 49 release package + backlog entries

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -27,7 +27,7 @@ the same PR — the backlog is only useful while it stays current.
 
 Ranking within each bucket = top is highest priority.
 
-**Counts as of 2026-05-18:** Must 1 · Should 0 · Could 12 · Won't 9
+**Counts as of 2026-05-18:** Must 1 · Should 1 · Could 14 · Won't 9
 
 ---
 
@@ -47,7 +47,15 @@ Source: net-new (2026-05-18). Follow-up to plan 45 (Vitest pool tuning + one-ret
 
 ## Should — important, not blocking ship
 
-(empty — every Should item has shipped or moved to Could.)
+### 1. Release packages on git-tag push
+
+Source: net-new (2026-05-18) — user-requested ahead of handing the app to a deployer. Full plan in [`49-release-package.md`](features/49-release-package.md) (status: draft).
+
+- _What:_ Add `scripts/bump-version.ps1 -Level (patch|minor|major)` that rewrites both `package.json` versions + lockfiles, creates the `chore: bump version to X.Y.Z` commit, and creates the annotated `vX.Y.Z` tag locally. Add `.github/workflows/release.yml` that fires on `push: tags: ['v*.*.*']`, runs `npm run verify:quick && npm run build`, assembles `audiobook-generator-vX.Y.Z.zip` via a new `scripts/build-release-zip.mjs` (manifest-driven include / exclude rules), computes SHA-256, and uploads both as a GitHub Release with the tag annotation as the release notes. Ship a top-level `INSTALL.md` walking a deployer through extracting the zip, prerequisites, `install-kokoro.ps1`, and `npm start`. Add a "Releasing" section to CONTRIBUTING.md.
+- _Acceptance:_ (1) `pwsh scripts/bump-version.ps1 -Level patch` on a clean main bumps both `package.json` versions in lockstep, regenerates both lockfiles, commits with the standard subject, and tags `v<new>`. (2) `git push origin main && git push origin v<new>` triggers `release.yml`; the workflow ends green with a `audiobook-generator-v<new>.zip` + `.sha256` asset on the matching GitHub release. (3) Extracting the zip on a clean Windows 11 host and following INSTALL.md yields a runnable app at `http://localhost:5173`. (4) New Pester test `scripts/tests/bump-version.Tests.ps1` locks the bump-script post-state; new Vitest spec `scripts/tests/release-manifest.test.mjs` locks the include / exclude manifest.
+- _Key files:_ new `.github/workflows/release.yml`, `scripts/bump-version.ps1`, `scripts/build-release-zip.mjs`, `scripts/tests/bump-version.Tests.ps1`, `scripts/tests/release-manifest.test.mjs`, `INSTALL.md`, `docs/features/49-release-package.md`; edited `docs/features/INDEX.md`, `README.md` (Releases link), `CONTRIBUTING.md` (Releasing section), `.gitignore`.
+- _Depends on:_ none. Pairs naturally with Could #1 (CI integration for the test suite) — both add GitHub Actions workflows; if shipped together the same caching infrastructure is reusable.
+- _Benefit (user / technical):_ user can hand a downloadable artefact to a deployer instead of walking them through a git-clone + dev-from-source flow. Cutting a release becomes one command instead of a 4-file edit. Establishes the release seam that Could #16 (Windows installer) and Could #17 (Docker image) hang off — both extend `release.yml` rather than spawn parallel pipelines.
 
 ---
 
@@ -167,6 +175,26 @@ Source: plan 46 ship (2026-05-18). Two specs `test.fixme`'d when plan 46 landed.
 - _Key files:_ `e2e/listen-playback.spec.ts:15`, `e2e/new-book-flow.spec.ts:32`, `playwright.config.ts:14-26`, `e2e/helpers.ts`, `src/mocks/canned-data.ts` (if mock-tick determinism turns out to be the fix).
 - _Depends on:_ none.
 - _Benefit (technical):_ restores the two e2e specs that cover the highest-blast-radius surfaces (mini-player play + full new-book cold-boot walk). Until then both code paths only have Vitest+jsdom coverage, which is known to lie about audio playback and SSE timing.
+
+### 16. Windows installer (Inno Setup or NSIS) wrapping the release zip
+
+Source: net-new (2026-05-18). Deferred follow-up to Should #1 ([`49-release-package.md`](features/49-release-package.md)).
+
+- _What:_ Add an Inno Setup (or NSIS) script that wraps the `audiobook-generator-vX.Y.Z.zip` produced by Should #1 into a signed `.exe` installer. Installer extracts to `%LocalAppData%\AudiobookGenerator`, drops a Start Menu entry, runs prerequisite checks (Node 20.6+, Python 3.11, ffmpeg on PATH) with download links shown for any missing dep, and offers to run `install-kokoro.ps1` post-install. Extend `release.yml` with a follow-on job that builds the installer (on a Windows runner) and uploads it as a second release asset.
+- _Acceptance:_ Double-clicking the installer on a clean Windows 11 box yields a runnable app reachable at `http://localhost:5173`, with no terminal interaction required from the deployer. SmartScreen warning cleared after one user "Run anyway" click (full reputation requires an EV code-signing cert — out of scope until the cert is procured).
+- _Key files:_ new `installer/audiobook-generator.iss` (Inno Setup), new `installer/build-installer.ps1`, `.github/workflows/release.yml` (add `installer` job on `windows-latest` that runs after the zip job and uploads to the same release).
+- _Depends on:_ Should #1 shipped (the installer wraps the existing zip — no point building before the zip pipeline exists).
+- _Benefit (user):_ friction-free install for non-developers. Today's Should #1 deployer must read INSTALL.md and run PowerShell commands by hand; the installer reduces that to a click.
+
+### 17. Docker image + compose file for headless / Linux deployment
+
+Source: net-new (2026-05-18). Deferred follow-up to Should #1 ([`49-release-package.md`](features/49-release-package.md)).
+
+- _What:_ Add a multi-stage `Dockerfile` (frontend build → node runtime stage → sidecar Python stage) and a `docker-compose.yml` that wires the three services on `:5173 / :8080 / :9000`. Document the NVIDIA Container Toolkit GPU-passthrough prereq. Resolve whether `WORKSPACE_DIR` is bind-mounted from the host or held in a named volume (host-bind recommended — keeps per-book `.audiobook/state.json` portable across container rebuilds). Extend `release.yml` with `docker/build-push-action` to publish the image to `ghcr.io/dudarenok-maker/audiobook-generator:vX.Y.Z` on tag push.
+- _Acceptance:_ `docker compose up` on a host with NVIDIA Container Toolkit installed brings up the three-service stack reachable on the documented ports. The published image works against a fresh `WORKSPACE_DIR` bind mount; tagged versions are pullable from GHCR.
+- _Key files:_ new `Dockerfile`, new `docker-compose.yml`, new `docs/features/50-docker-image.md` (when this graduates from BACKLOG to active), `.github/workflows/release.yml` (extend with the GHCR push job).
+- _Depends on:_ Should #1 shipped (reuses the same tag-push trigger and version source); resolving the workspace-mount question.
+- _Benefit (user):_ enables hosting on a Linux box with a GPU (home server, single-tenant VPS) — the Windows-only PowerShell orchestration is the current ceiling for that use case.
 
 ---
 

--- a/docs/features/49-release-package.md
+++ b/docs/features/49-release-package.md
@@ -1,0 +1,70 @@
+---
+status: draft
+shipped: null
+owner: null
+---
+
+# 49 — Release packages on git-tag push
+
+> Status: draft
+> Key files: `.github/workflows/release.yml` (new), `scripts/bump-version.ps1` (new), `scripts/build-release-zip.mjs` (new), `INSTALL.md` (new), `docs/BACKLOG.md` (entries), `README.md` (Releases link), `CONTRIBUTING.md` (Releasing section)
+> URL surface: none — CI / packaging
+> OpenAPI ops: none
+
+## Benefit / Rationale
+
+- **User:** the repo owner can hand a downloadable artefact to a deployer ("here, run this") instead of walking them through a git clone + dev-from-source flow. Cutting a release becomes one command (`pwsh scripts/bump-version.ps1 -Level minor && git push origin main vX.Y.Z`) instead of four manual file edits + a tag.
+- **Technical:** introduces the first CI workflow that *writes* to GitHub state (Releases). Codifies a reproducible-from-tag build manifest so every release is rebuildable from its git ref alone.
+- **Architectural:** establishes the release seam that the deferred [Could #15 — Windows installer](../BACKLOG.md) and [Could #16 — Docker image](../BACKLOG.md) hang off. Both extend `release.yml` with additional asset-upload steps; neither needs a separate pipeline.
+
+## Architectural impact
+
+- **New seams / extension points:**
+  - `.github/workflows/release.yml` — tag-triggered build pipeline. Could-bucket installer / Docker items extend this same workflow (additional jobs / steps) rather than spawning sibling workflows.
+  - `scripts/build-release-zip.mjs` — exports a manifest constant (include / exclude rules); both the script and the Vitest test import from this single source.
+  - `scripts/bump-version.ps1` — sole sanctioned path for advancing version numbers; replaces ad-hoc file editing.
+- **Invariants preserved:**
+  - The CI gate from plan 38 / plan 44 (PR title + commit convention) is unaffected — the release workflow runs on tag push, not on PRs.
+  - The pre-push `npm run verify` gate from CLAUDE.md "Commit gate" remains the source-of-truth correctness check; the release workflow re-runs `verify:quick` as a sanity net but is **not** the primary test gate.
+  - Plan 27 book-state persistence is unaffected — the release zip ships application code only; per-book `state.json` lives under `WORKSPACE_DIR` which is operator-configured, not bundled.
+- **Migration story:** none. Versions today (1.1.0 in both `package.json` files per commit `887368`) are already in lockstep; the bump script preserves that invariant going forward.
+- **Reversibility:** delete the workflow file + the bump script + the plan; tags and releases on GitHub can be deleted via `gh release delete` and `git push origin :vX.Y.Z`. Per-release artefacts can be re-uploaded manually with `gh release upload` if the workflow is removed.
+
+## Invariants to preserve
+
+1. **Version lockstep** — `package.json:3` and `server/package.json:3` MUST always carry the same version string. `scripts/bump-version.ps1` enforces this both as a pre-flight check (refuses to run if the two have drifted) and as a post-condition (writes both simultaneously via `npm version`).
+2. **Tag ↔ commit lockstep** — every `vX.Y.Z` tag MUST point at the `chore: bump version to X.Y.Z` commit. The bump script creates them together; the workflow never creates tags.
+3. **Reproducibility from tag** — the release zip MUST be reproducible from the tagged commit alone. No `main`-vs-tag drift; no environment-derived metadata (build date is fine; build host name is not) embedded in the artefact.
+4. **Asset-exclusion list** — the release zip MUST NOT include any of: `.env*` (except `.env.example`), `node_modules/`, `.venv/`, `voices/kokoro/*.onnx` (the ~1 GB Kokoro weights — deployer fetches via `install-kokoro.ps1`), `.git/`, `*.log`, `.run/`, `logs/`, `.verify-cache.json`, `e2e/`, `src/` (already pre-built into `dist/`), `CLAUDE.md`, `CONTRIBUTING.md`, anything under `scripts/tests/`.
+5. **Verify gate** — the workflow MUST NOT publish the release if `npm run verify:quick` or `npm run build` fail on the tagged commit. (`verify:quick` not full `verify`: the tagged commit already passed pre-push verify on the developer machine; the release workflow's job is rebuild + sanity, not full re-test.)
+6. **Release notes from git** — the GitHub release notes MUST be sourced from the annotated tag's message (`git tag -l --format='%(contents)' vX.Y.Z`), not hand-typed in the GitHub UI. Notes live in git.
+
+## Test plan
+
+### Automated coverage
+
+- **Pester** (`scripts/tests/bump-version.Tests.ps1`, new): in a temp-dir copy of the two `package.json` files + lockfiles, runs the bump script and asserts: (a) both versions advance by the requested level, (b) lockfiles regenerate, (c) the commit is created with the expected `chore: bump version to X.Y.Z` subject, (d) the tag is created with an annotation containing the version. Mock or short-circuit `git` writes so the test does not pollute the real repo.
+- **Vitest** (`scripts/tests/release-manifest.test.mjs`, new): imports the manifest constant from `scripts/build-release-zip.mjs` and asserts the path-matcher decisions for representative files — includes `server/tts-sidecar/main.py`, excludes `server/tts-sidecar/voices/kokoro/kokoro-v1.0.onnx`, excludes `node_modules/foo`, excludes `src/main.tsx` (pre-built), includes `scripts/lib/log-utils.psm1`, excludes `scripts/tests/foo.Tests.ps1`. Wired into the existing `npm run test` discovery (or into `test:hooks` if it stays at the `scripts/tests/` root).
+- **No new e2e** — packaging surface; e2e adds no signal. The end-to-end check is the manual tag-push dry-run below.
+
+### Manual acceptance walkthrough
+
+1. On a scratch branch off `main`, run `pwsh scripts/bump-version.ps1 -Level patch -Force` (`-Force` bypasses the "must be on main" guard). Expected: four files modified (`package.json`, `package-lock.json`, `server/package.json`, `server/package-lock.json`), one commit created, one annotated tag (`v<new>`) created locally.
+2. `pwsh scripts/bump-version.ps1 -Level patch -DryRun` on a clean tree prints the planned changes without mutating anything.
+3. `node scripts/build-release-zip.mjs --version v0.0.0-dry --dry-run` lists the manifest entries without writing the zip; sanity-check the exclusion list.
+4. `git push origin <scratch-branch> && git push origin v<new>` — observe `.github/workflows/release.yml` run in the Actions tab. Green = `verify:quick` + `build` + zip + sha256 + `gh release create` all succeeded.
+5. Open the release page; download `audiobook-generator-v<new>.zip` and `.sha256`; verify the checksum.
+6. On a clean Windows 11 host (or a sandboxed folder), extract the zip; follow `INSTALL.md` step-by-step; expect `npm start` to bring up the app at `http://localhost:5173` with the library visible.
+7. Cleanup: `git push origin :v<new>` (delete remote tag), `gh release delete v<new>` (delete release), delete the scratch branch.
+
+## Out of scope
+
+- **Windows installer (Inno Setup / NSIS).** See [`docs/BACKLOG.md`](../BACKLOG.md) Could #15. Extends `release.yml` with a second asset.
+- **Docker image + compose file.** See [`docs/BACKLOG.md`](../BACKLOG.md) Could #16. Extends `release.yml` with a `docker/build-push-action` job.
+- **Code-signing / SmartScreen reputation.** Tracked alongside Could #15 (installer).
+- **In-app auto-update.** Not a v1 concern; deployer manually re-extracts on upgrade per `INSTALL.md`.
+- **Bundling Kokoro weights into the release artefact.** Decided 2026-05-18 — weights stay separately fetched via `install-kokoro.ps1` to keep the release zip small and within GitHub's 2 GB per-asset limit.
+
+## Ship notes
+
+(Filled when status flips to `stable`. Append: shipped date, commit SHA, first real tag pushed, release URL, any deltas vs. this spec.)

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -111,6 +111,7 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 - [38 — Branching & commit convention](38-branching-and-commit-convention.md) — Trunk-based branching + Conventional-Commits subject format; `.husky/commit-msg` gates the convention.
 - [44 — Pull request hygiene](44-pr-hygiene.md) — PR template + PR-title lint workflow + merge-commit-only / delete-branch-on-merge repo settings; codifies the Summary / Test plan shape PRs #1-#4 already use.
 - [45 — Vitest pool tuning + one-retry policy](45-vitest-pool-tuning.md) — Caps the server-suite forks pool at 4 and turns on `retry: 1` on both Vitest configs so transient tinypool "Worker exited unexpectedly" failures no longer force a full pre-push re-run.
+- [49 — Release packages on git-tag push](49-release-package.md) — `scripts/bump-version.ps1` + `.github/workflows/release.yml` produce a downloadable `audiobook-generator-vX.Y.Z.zip` on GitHub Releases whenever a `v*.*.*` tag is pushed. **Status: draft.**
 - [46 — Lint, format, a11y baseline](archive/46-lint-format-a11y.md) — ESLint 8 + Prettier 3 + axe-core on four core views; lint prepended to `verify`. Shipped 2026-05-18.
 - [48 — Global toast surface](archive/48-toast-surface.md) — `notifications` slice + `<ToastStack/>`; stream-middleware halts + export 5xx dispatch through it; dedupe-by-key collapses repeats; auto-dismiss 6 s. Shipped 2026-05-18.
 


### PR DESCRIPTION
## Summary

- Round 0 docs PR for the release-package work — formal plan + backlog
  entries land first so the implementation PR has a tracked home.
- `docs/features/49-release-package.md` (new, status: draft) — plan for
  tag-push GitHub Releases producing a portable zip, paired with
  `scripts/bump-version.ps1` for one-command version bumps.
- `docs/BACKLOG.md` — Should #1 (plan 49 itself), Could #16 (Windows
  installer wrapping the zip), Could #17 (Docker image + compose). Both
  Could entries extend the same `release.yml` workflow rather than
  spawn parallel pipelines.
- `docs/features/INDEX.md` — plan 49 linked under section K
  (Cross-cutting invariants) alongside the other CI/release plans.

No implementation — scripts, workflow, and INSTALL.md will land on a
separate `feat/ci-release-package` branch.

## Test plan

- [x] `npm run verify` green (pre-push hook ran full battery)
- [x] BACKLOG counts updated (Should 0 → 1, Could 12 → 14)
- [x] New plan numbered 49 (46/47/48 already taken by shipped archive plans)
- [ ] Manual: confirm PR title passes the `pr-title-lint` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)