### PR TITLE
test(server): plan 14 close-out — sidecar classification + failure-path docs

### DIFF
--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -67,7 +67,6 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 ### F. TTS
 
 - [13 — TTS engine picker](13-tts-engine-picker.md) — Two-tier engine + model selector.
-- [14 — Coqui XTTS sidecar](14-tts-sidecar-coqui.md) — Local sidecar alternate (zero-shot voice cloning).
 - [14a — Kokoro v1 TTS engine](14a-tts-sidecar-kokoro.md) — Local sidecar default, English-only, per-engine cast voice profiles.
 - [15 — Gemini cloud TTS](15-tts-gemini-cloud.md) — Cloud opt-in.
 - [43 — Auto-start TTS sidecar](43-auto-start-sidecar.md) — Per-user `autoStartSidecar` preference (default ON); Node owns the sidecar child-process lifecycle so `start-app.bat` brings up TTS in one shot. **Status: active.**
@@ -148,3 +147,4 @@ breadcrumb so cross-references still resolve.
 - [47 — Listening progress / resume bookmarks](archive/47-listen-progress.md) — Per-book sibling `listen-progress.json`; mini-player seeks to the saved position on chapter mount via debounced PUT + onLoadedMetadata; Listen view "Resume at MM:SS" pill. Shipped 2026-05-18.
 - [50 — Verify-cache for cheap retries after flake](archive/50-verify-cache.md) — Per-step input-hash cache on `npm run verify`; skips green steps when inputs (filtered from `git ls-files` + lockfiles + Pester/pytest tool fingerprints) match the last green hash. Cold ~120s → warm ~1s; flake recovery drops from the full pipeline to one re-run. Shipped 2026-05-18.
 - [37 — Playwright e2e harness](archive/37-e2e-playwright.md) — Browser-level smoke + on-ramp for visual regression; 14 specs / 30 tests at ship, covering library, upload, analysing, confirm, ready, listen, voices, cast/drawer, theme, toast, manual continuity, revision diff, bulk sync, cover framing, plus per-surface visual baselines (light + dark). Shipped 2026-05-18.
+- [14 — Coqui XTTS sidecar](archive/14-tts-sidecar-coqui.md) — Local sidecar TTS alternate (zero-shot voice cloning); bounded-retry with provider-side classification of transient (network blip / 5xx / 408) vs non-transient (4xx / CUDA-poisoned 503) failures; full failure-path table. Shipped 2026-05-18.

--- a/docs/features/archive/14-tts-sidecar-coqui.md
+++ b/docs/features/archive/14-tts-sidecar-coqui.md
@@ -1,7 +1,13 @@
+---
+status: stable
+shipped: 2026-05-18
+owner: null
+---
+
 # Coqui XTTS sidecar
 
 > Status: KNOWN: operational dependency
-> Key files: `server/src/tts/sidecar.ts`, `server/src/tts/index.ts`, `server/src/tts/text-normalize.ts`, `server/src/tts/synthesise-chapter.ts`, `server/tts-sidecar/`
+> Key files: `server/src/tts/sidecar.ts`, `server/src/tts/index.ts`, `server/src/tts/retry.ts`, `server/src/tts/text-normalize.ts`, `server/src/tts/synthesise-chapter.ts`, `server/tts-sidecar/`
 > URL surface: none
 > OpenAPI ops: `POST /api/voices/:voiceId/sample`, `POST /api/books/:bookId/generation`
 
@@ -40,15 +46,52 @@ off in `#/account` and `npm run tts:sidecar` in a second terminal.
 8. **First synth is fast** — after a clean `npm run tts:sidecar`, the first chapter's first group lands a synth response within seconds, not minutes. The preload at startup is what makes this true.
 9. **GPU mode is live (NVIDIA boxes only)** — after the README's "GPU install" + `COQUI_DEVICE=cuda` / `COQUI_HALF=1` / `COQUI_DEEPSPEED=1` in `server/.env`, restart the sidecar. The first startup log line shows `device=cuda half=True deepspeed=True`, followed by `DeepSpeed inference enabled.` and `Model cast to fp16.`. While a chapter synth is in flight, `nvidia-smi` shows the venv's `python.exe` holding ~2–3 GB VRAM with >50% GPU-Util, and `logs/tts.err.log` reports `Real-time factor: 0.1–0.3` per group (down from 2.5–3.7 on CPU). A 30-minute chapter drops from ~90 min wall time to ~5 min.
 
-## KNOWN: scaffolded behavior
+## Failure paths
 
-- No auto-start of the sidecar; user must run it manually before analysis.
-- Health-check endpoint exists at `GET /health` and is proxied as `GET /api/sidecar/health`. The Generate screen polls it for the status pill.
-- No automatic retry; transient failures (e.g. sidecar restart mid-flight) require manual user action (click Retry).
-- Document the failure paths explicitly; do not assert "audio always plays."
+Every sidecar synth call passes through the bounded-retry wrapper
+`withTtsRetry` (`server/src/tts/retry.ts`). Classification happens at the
+sidecar boundary in `SidecarTtsProvider.synthesize` — each thrown error
+carries a `transient: boolean` flag (and supplementary `status` /
+`cause` / `poisoned` fields) that the retry helper reads to decide
+whether to back off and retry, or surface immediately.
+
+Default retry schedule: 1 primary attempt + 2 retries, backoffs at 500 ms
+and 2 s. Caller-driven `AbortSignal` short-circuits both the sleep and
+any pending retry. Persistent failures re-throw the LAST transient error
+so the SSE `chapter_failed` tick carries the actual upstream message,
+not a meta "retries exhausted" wrapper.
+
+| Failure mode                            | Annotated as                              | Retry?  | User-visible behaviour                                                                                                                                                                                                              |
+| --------------------------------------- | ----------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ECONNREFUSED` / `ETIMEDOUT` / DNS fail | `transient: true, cause: 'network'`       | Yes (×2) | "Local TTS sidecar not reachable at \<url\>. Start it with `npm run tts:sidecar`." Brief blips (sidecar restarting, network flapping) absorbed transparently; persistent down → all 3 attempts fail → message surfaces in `chapter_failed`. |
+| HTTP 503 with `{ poisoned: true }` body | `transient: false, status: 503, poisoned: true` | **No** | Surfaces immediately. The CUDA context is corrupted process-wide; only a sidecar restart clears it (see `server/tts-sidecar/main.py` `_schedule_poison_exit`). UI renders "needs restart" framing.                          |
+| HTTP 503 (model loading, transient)     | `transient: true, status: 503`            | Yes (×2) | Most common at the very first synth call after sidecar boot — the model-load takes 30-60 s, the proxy gives up earlier. Backoff usually catches it on attempt 2. |
+| HTTP 502 (reverse proxy mid-restart)    | `transient: true, status: 502`            | Yes (×2) | Same retry shape as 503. |
+| HTTP 504 (gateway timeout)              | `transient: true, status: 504`            | Yes (×2) | Same retry shape as 503. |
+| HTTP 408 (request timeout)              | `transient: true, status: 408`            | Yes (×2) | Treated like 5xx — the request didn't reach the model or the response stalled; safe to retry. |
+| HTTP 4xx (any other 400/401/403/404/…)  | `transient: false, status: 4xx`           | **No** | Client-side; the request shape itself is wrong. Surfaces immediately; the UI shows the upstream status text. |
+| Empty 200 response (no audio bytes)     | Plain `Error`, no `transient` flag        | **No** | "Local TTS sidecar returned an empty audio body." Surfaces immediately — silent retry would just replay the same shape. |
+| AbortError (caller-driven stop)         | `name: 'AbortError'` (no `transient` flag)| **No** | Passed through unchanged so the queue tears down cleanly. The retry helper's signal check also tears down any pending sleep mid-backoff. |
+| Disk full at cache-write step           | I/O error from fs.writeFile (downstream)  | n/a | Not a sidecar-side failure — the synth succeeded but the chapter cache write didn't. SSE stream surfaces the I/O error on `chapter_failed`. |
+
+Classification is pinned by `server/src/tts/sidecar.test.ts`; the
+wrapper itself is pinned by `server/src/tts/retry.test.ts`; the
+end-to-end shape (two 503s then a 200 → one successful chapter group)
+is pinned by `synthesise-chapter.test.ts`'s
+"does NOT retry a poisoned-CUDA 503" / "retries on transient throw"
+cases.
 
 ## Out of scope
 
 - Sidecar-internal model swapping (Coqui vs Piper vs Kokoro) — each gets its own model key prefix and provider.
 - GPU vs CPU performance tuning beyond the documented env knobs — the sidecar's `COQUI_DEVICE` / `COQUI_HALF` / `COQUI_DEEPSPEED` cover the common path; bespoke kernel tuning is out of scope. The Node side reads no device info.
-- Streaming PCM — the sidecar returns a whole utterance per call.
+- Streaming PCM — the sidecar returns a whole utterance per call. Tracked as `[BACKLOG Could #25]`.
+
+## Ship notes
+
+- **Shipped:** 2026-05-18.
+- **What closed the scaffolding:** the three KNOWN-scaffolded items at landing-time are all addressed —
+  - Auto-start of the sidecar shipped earlier as plan [43 — Auto-start TTS sidecar](43-auto-start-sidecar.md); the per-user `autoStartSidecar` preference (default ON) means `start-app.bat` brings up TTS in one shot.
+  - Automatic retry shipped via the provider-agnostic `withTtsRetry` helper in `server/src/tts/retry.ts` wired into `synthesise-chapter.ts:241` — pinned by `retry.test.ts` (10 cases) and end-to-end retry behaviour by `synthesise-chapter.test.ts`.
+  - Failure-path documentation is the **Failure paths** table above; the boundary classification is now pinned by the new `server/src/tts/sidecar.test.ts` (10 cases) so a future refactor that flips a transient↔non-transient mapping fails fast at the boundary instead of in chapter orchestration.
+- **What remains intentionally out of scope:** streaming PCM (the sidecar still returns a whole utterance per call; streaming is `[BACKLOG Could #25]`).

--- a/server/src/tts/sidecar.test.ts
+++ b/server/src/tts/sidecar.test.ts
@@ -1,0 +1,214 @@
+/* Classification coverage for SidecarTtsProvider.
+ *
+ * The retry helper (`server/src/tts/retry.ts`) is provider-agnostic — it
+ * just reads the `transient` flag the provider stuck on the thrown error.
+ * That means the *classification* (network blip → transient, 5xx →
+ * transient, poisoned-CUDA → non-transient, 4xx → non-transient) is the
+ * boundary contract the retry wrapper depends on. retry.test.ts covers
+ * the wrapper's behaviour given annotated errors; this file covers the
+ * sidecar's *annotation*: the assertion that the same input shapes
+ * produce the same flags.
+ *
+ * Without this, a future refactor that flips a transient→non-transient
+ * mapping (or vice versa) would only break in end-to-end retry tests in
+ * synthesise-chapter.test.ts, with the failure attributed to chapter
+ * orchestration rather than the actual mis-classification.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { SidecarTtsProvider } from './sidecar.js';
+import type { SynthesizeInput } from './index.js';
+
+function makeProvider() {
+  return new SidecarTtsProvider({ url: 'http://localhost:6006/', engine: 'coqui' });
+}
+
+const SYNTH_INPUT: SynthesizeInput = {
+  text: 'hello',
+  voiceName: 'Asya Anara',
+  modelKey: 'coqui-xtts-v2',
+};
+
+function stubFetch(impl: typeof fetch) {
+  vi.stubGlobal('fetch', impl);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('SidecarTtsProvider error classification', () => {
+  it('annotates network failure as transient with cause=network', async () => {
+    stubFetch(async () => {
+      throw new TypeError('fetch failed');
+    });
+
+    const err = await makeProvider()
+      .synthesize(SYNTH_INPUT)
+      .then(
+        () => null,
+        (e) => e,
+      );
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.transient).toBe(true);
+    expect(err.cause).toBe('network');
+    expect(err.message).toMatch(/Local TTS sidecar not reachable/);
+  });
+
+  it('propagates AbortError unchanged (no transient flag)', async () => {
+    stubFetch(async () => {
+      throw Object.assign(new Error('aborted'), { name: 'AbortError' });
+    });
+
+    const err = await makeProvider()
+      .synthesize(SYNTH_INPUT)
+      .then(
+        () => null,
+        (e) => e,
+      );
+
+    expect(err?.name).toBe('AbortError');
+    /* Critically — the helper does NOT decorate AbortError. The retry
+       wrapper relies on this to bail out of a caller-driven stop. */
+    expect(err?.transient).toBeUndefined();
+  });
+
+  it('classifies 503 with poisoned body as non-transient + poisoned=true', async () => {
+    const body = JSON.stringify({ detail: 'CUDA crashed', poisoned: true });
+    stubFetch(
+      async () =>
+        new Response(body, {
+          status: 503,
+          statusText: 'Service Unavailable',
+          headers: { 'content-type': 'application/json' },
+        }),
+    );
+
+    const err = await makeProvider()
+      .synthesize(SYNTH_INPUT)
+      .then(
+        () => null,
+        (e) => e,
+      );
+
+    expect(err.transient).toBe(false);
+    expect(err.poisoned).toBe(true);
+    expect(err.status).toBe(503);
+  });
+
+  it('classifies 503 without poisoned body as transient', async () => {
+    stubFetch(
+      async () =>
+        new Response('model loading', { status: 503, statusText: 'Service Unavailable' }),
+    );
+
+    const err = await makeProvider()
+      .synthesize(SYNTH_INPUT)
+      .then(
+        () => null,
+        (e) => e,
+      );
+
+    expect(err.transient).toBe(true);
+    expect(err.poisoned).toBe(false);
+    expect(err.status).toBe(503);
+  });
+
+  it('classifies 502 (reverse proxy mid-restart) as transient', async () => {
+    stubFetch(async () => new Response('bad gateway', { status: 502, statusText: 'Bad Gateway' }));
+
+    const err = await makeProvider()
+      .synthesize(SYNTH_INPUT)
+      .then(
+        () => null,
+        (e) => e,
+      );
+
+    expect(err.transient).toBe(true);
+    expect(err.status).toBe(502);
+  });
+
+  it('classifies 408 (request timeout) as transient', async () => {
+    stubFetch(
+      async () => new Response('timeout', { status: 408, statusText: 'Request Timeout' }),
+    );
+
+    const err = await makeProvider()
+      .synthesize(SYNTH_INPUT)
+      .then(
+        () => null,
+        (e) => e,
+      );
+
+    expect(err.transient).toBe(true);
+    expect(err.status).toBe(408);
+  });
+
+  it('classifies 400 (bad request) as non-transient', async () => {
+    stubFetch(async () => new Response('bad input', { status: 400, statusText: 'Bad Request' }));
+
+    const err = await makeProvider()
+      .synthesize(SYNTH_INPUT)
+      .then(
+        () => null,
+        (e) => e,
+      );
+
+    expect(err.transient).toBe(false);
+    expect(err.status).toBe(400);
+  });
+
+  it('classifies 404 (missing route) as non-transient', async () => {
+    stubFetch(async () => new Response('not found', { status: 404, statusText: 'Not Found' }));
+
+    const err = await makeProvider()
+      .synthesize(SYNTH_INPUT)
+      .then(
+        () => null,
+        (e) => e,
+      );
+
+    expect(err.transient).toBe(false);
+    expect(err.status).toBe(404);
+  });
+
+  it('throws on empty audio body without classifying as transient', async () => {
+    /* Empty 200 means the sidecar returned success-but-no-audio. Don't
+       silently retry — surface to the caller so it can fail the group. */
+    stubFetch(
+      async () =>
+        new Response(new ArrayBuffer(0), {
+          status: 200,
+          headers: { 'content-type': 'audio/L16;codec=pcm;rate=24000', 'x-sample-rate': '24000' },
+        }),
+    );
+
+    const err = await makeProvider()
+      .synthesize(SYNTH_INPUT)
+      .then(
+        () => null,
+        (e) => e,
+      );
+
+    expect(err.message).toMatch(/empty audio body/i);
+    expect(err.transient).toBeUndefined();
+  });
+
+  it('returns parsed PCM + sampleRate from a 200 response', async () => {
+    const pcm = Buffer.from([0x00, 0x10, 0x20, 0x30, 0x40, 0x50]);
+    stubFetch(
+      async () =>
+        new Response(pcm, {
+          status: 200,
+          headers: { 'content-type': 'audio/L16;codec=pcm;rate=22050', 'x-sample-rate': '22050' },
+        }),
+    );
+
+    const result = await makeProvider().synthesize(SYNTH_INPUT);
+
+    expect(result.pcm.equals(pcm)).toBe(true);
+    expect(result.sampleRate).toBe(22050);
+    expect(result.mimeType).toMatch(/audio\/L16/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the three KNOWN-scaffolded items in [plan 14 (Coqui XTTS sidecar)](https://github.com/dudarenok-maker/AudioBook-Generator/blob/feat/server-plan-14-sidecar-retry/docs/features/archive/14-tts-sidecar-coqui.md):

- **Auto-start** — already shipped as [plan 43](https://github.com/dudarenok-maker/AudioBook-Generator/blob/main/docs/features/43-auto-start-sidecar.md). Removed from KNOWN list.
- **Automatic retry** — already shipped via the provider-agnostic `withTtsRetry` helper in `server/src/tts/retry.ts`, wired into `synthesise-chapter.ts:241`. Removed from KNOWN list.
- **Document failure paths explicitly** — full **Failure paths** table added to plan 14, mapping every failure mode (network blip / 5xx / 408 / poisoned-CUDA / 4xx / empty body / AbortError / disk full) to its `transient` annotation and retry behaviour.

New `server/src/tts/sidecar.test.ts` (10 cases) pins `SidecarTtsProvider`'s error-annotation contract directly. retry.test.ts already covers wrapper behaviour given annotated errors; this file covers the *annotation*. Without it, a future refactor that flips a transient↔non-transient mapping would only fail in end-to-end chapter orchestration tests, with the failure attributed to chapter logic rather than the actual mis-classification.

Plan 14 flips `status: ?` → `status: stable` (frontmatter added), KNOWN-scaffolded list empty, file archived under `docs/features/archive/`.

## Test plan

- [x] `npx vitest run src/tts/sidecar.test.ts` — 10/10 passing.
- [x] `npm run verify` — green end-to-end.
- [x] Plan 14 frontmatter is `status: stable`, file under `archive/`, INDEX entry moved to Shipped section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)