### PR TITLE
feat(frontend): plan 18a slice — cover Replace/Regenerate + queue copy/remove

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -27,7 +27,7 @@ the same PR — the backlog is only useful while it stays current.
 
 Ranking within each bucket = top is highest priority.
 
-**Counts as of 2026-05-18 (post plan 37 ship):** Must 0 · Should 3 · Could 31 · Won't 9
+**Counts as of 2026-05-18 (post plan 18a slice):** Must 0 · Should 3 · Could 34 · Won't 9
 
 ---
 
@@ -381,6 +381,36 @@ Source: plan 18 follow-up (2026-05-18). Deferred from plan 18b scope.
 - _Key files:_ `src/components/app-handoff-modal.tsx`; `src/data/listener-apps.ts`; `src/views/settings.tsx` (Plex token field — see Could #24 power-user panel); new `server/src/export/plex.ts` for the optional upload path.
 - _Depends on:_ plan 18b shipped; ideally Could #24 (power-user panel) for the token storage.
 - _Benefit (user):_ closes one more "Coming soon" tile; opens the door to direct upload integration.
+
+### 33. Listen-view download tiles wiring (m4b chaptered / MP3 zip / streaming link)
+
+Source: plan 18 follow-up (2026-05-18). Deferred from plan 18a (Listen view wiring) — scope-cut because the download paths need new server endpoints (MP3 zip bundling + streaming-link minting), which is more than a single PR.
+
+- _What:_ Replace the three "Coming soon" download tiles on the Listen view with live affordances. M4B chaptered already has a working pipeline (plan 33 voice export) — wire that tile to open the existing `ExportAudiobookModal` pre-filled to `format: 'm4b'`. MP3 ZIP needs a new `server/src/export/build-mp3-zip.ts` that walks the chapter MP3s and bundles them via Node's `node:stream` + a streaming zip writer. Streaming link needs a server-minted shareable URL (likely a slugged route under `/share/:slug` that proxies the M4B from disk).
+- _Acceptance:_ Each tile's Download button enabled; clicking M4B chaptered opens the export modal in M4B mode; MP3 ZIP triggers a `POST /api/books/:bookId/export` with `format: 'mp3-zip'` and the job appears in the rail; streaming link mints a URL the user can copy + share. Server Vitest covers the MP3-zip builder; new Playwright spec covers the three-tile flow.
+- _Key files:_ `src/views/listen.tsx` (DownloadCard wiring); new `server/src/export/build-mp3-zip.ts`; `server/src/routes/exports.ts` (extend to handle mp3-zip + streaming-link formats); `openapi.yaml` (extend `BookExportJob.format` enum if streaming-link is added).
+- _Depends on:_ none structural. Tile wiring is straightforward; the MP3-zip builder is the meatiest piece.
+- _Benefit (user):_ closes the second-largest "Coming soon" surface on the Listen view. Today the user can only export via the listener-app tiles (which gate on a target app); these download tiles offer direct artifact retrieval.
+
+### 34. Export queue Retry + Download row actions
+
+Source: plan 18 follow-up (2026-05-18). Deferred from plan 18a — needs middleware integration to re-fire a failed export, which is bigger than a row-handler wiring.
+
+- _What:_ The Listen view's Export queue surfaces Retry (on `failed` rows) and Download (on `done` rows without a URL) as wired buttons. Retry re-fires the original `POST /api/books/:bookId/export` with the same payload via a middleware action that reads the job's recorded `format`/`destination`/`syncPath`. Download triggers a `GET /api/exports/:exportId/download` redirect (or a `window.location.assign(item.url)` when the job already carries `downloadUrl`).
+- _Acceptance:_ Click Retry on a failed row → a new export job appears with the same parameters and the failed row is dismissed. Click Download on a done-with-URL row → file downloads. Vitest covers the middleware re-fire path; e2e covers the visible buttons.
+- _Key files:_ `src/views/listen.tsx` (ExportQueue handlers); `src/store/exports-middleware.ts` (extend with `retryExport` thunk); `server/src/routes/exports.ts` (add `/exports/:exportId/download` redirect if needed).
+- _Depends on:_ Could #33 (download tiles) for the underlying export endpoints to be live.
+- _Benefit (user):_ closes the remaining "Coming soon" stubs in the queue rail. Today copy + remove work (shipped in plan 18a); retry + download are the other two row actions promised by the design.
+
+### 35. Listen-view waveform card driven by real chapter peaks
+
+Source: plan 18 known gap (2026-05-18). The chapter-audio meta endpoint currently returns `peaks: []`; the Listen view's waveform card derives its bars from a mock `peaks: float[240]` array that doesn't reflect the actual chapter audio.
+
+- _What:_ Extend the chapter encode pipeline (`server/src/tts/synthesise-chapter.ts` or the MP3 step) to compute a fixed-length (240-bin) RMS-peaks summary alongside the MP3 and persist it under `<bookDir>/audio/<slug>.peaks.json`. The chapter-audio meta endpoint (`server/src/routes/chapter-audio.ts`) reads + returns it. Listen view consumes it via the existing `peaks` field — no frontend changes beyond removing the `peaks: []` fallback path.
+- _Acceptance:_ Generate a chapter from scratch → `<slug>.peaks.json` exists on disk with 240 floats. Open Listen view → the waveform card paints those peaks (not mock). Server Vitest covers the peak-compute + read paths.
+- _Key files:_ `server/src/tts/mp3.ts` (extend to emit peaks during encode); `server/src/routes/chapter-audio.ts` (read + return peaks); new `server/src/audio/compute-peaks.ts` (240-bin RMS reducer).
+- _Depends on:_ none structural. Pairs naturally with Could #3 (per-chapter loudness report) — both emit chapter-level audio metadata at encode time.
+- _Benefit (user):_ the Listen view's waveform card stops lying about chapter shape (loud passages, silences, fades all become visible). Spotting problem chapters at a glance.
 
 ---
 

--- a/docs/features/18-listen-view.md
+++ b/docs/features/18-listen-view.md
@@ -95,12 +95,18 @@ Run against the canonical e2e manuscript (`~/Downloads/Bonus Keefe Story.txt`, s
 
 ## KNOWN: scaffolded
 
+What's still scaffolded after plan 18a (cover + queue-action wiring slice, shipped 2026-05-18):
+
 - `mockGetChapterAudio` returns `url: null`; no audio plays in mock mode by design.
-- Listen-view waveform card still derives from the mock `peaks: float[240]`; the real chapter-audio meta endpoint returns `peaks: []` because the mini-player doesn't draw a waveform. Wiring real peaks into the Listen-view waveform is a follow-up that ships only when the visual is worth the extra disk write.
-- Export queue is hardcoded fixture; row actions are explicitly disabled with "Coming soon" affordances.
-- Listener-app "Send to …" buttons are disabled; the `AppHandoffModal` walkthrough is unreachable from this view until per-app handoff (likely PocketBook first) lands.
-- Download tiles and header Download/Share buttons are non-functional stubs marked "Coming soon".
-- Cover-art Replace and Regenerate in the metadata editor are also non-functional stubs.
+- Listen-view waveform card still derives from the mock `peaks: float[240]`; the real chapter-audio meta endpoint returns `peaks: []`. Tracked as `[BACKLOG Could #35]`.
+- Listener-app "Send to …" buttons (BookPlayer / Smart AudioBook Player / Apple Books / Plex) are disabled; the `AppHandoffModal` walkthrough is unreachable from those tiles. Plan 18b wires PocketBook + Audiobookshelf; the other four are tracked as `[BACKLOG Could #29-32]` per-app.
+- Download tiles (m4b chaptered, MP3 ZIP, streaming link) and the header Download/Share buttons remain non-functional stubs. Tracked as `[BACKLOG Could #33]`.
+- Export queue Retry + Download row actions remain disabled. Tracked as `[BACKLOG Could #34]`. Copy link + Remove are wired (plan 18a).
+
+Shipped in plan 18a (2026-05-18):
+
+- Metadata-editor cover Replace + Regenerate buttons. Replace opens `CoverPicker` on Upload tab; Regenerate opens it on Search tab. The existing per-card cover-tile click was already wired; the editor buttons now route through the same modal via a new `initialTab` prop on `CoverPicker`.
+- Export-queue row actions: **Copy link** writes the row's URL to `navigator.clipboard` + pushes an `info` toast via the plan 48 notification surface; **Remove** dispatches `exportsActions.exportDismissed({ bookId, exportId })`. Mock-fallback fixture rows (synthetic IDs) accept the dispatch as a no-op since they don't live in `byBookId` — acceptable mock-mode degradation. Pinned by `src/views/listen.test.tsx` "metadata-editor cover buttons" + "export-queue per-row actions" describes.
 
 ## Out of scope
 

--- a/src/modals/cover-picker.tsx
+++ b/src/modals/cover-picker.tsx
@@ -41,6 +41,12 @@ interface Props {
       update its local LibraryBook.coverFraming for instant feedback in
       other surfaces (BookCard, CoverArt) without re-fetching. */
   onFramingChanged?: (framing: CoverFraming) => void;
+  /** Optional one-shot tab override applied each time `open` flips true.
+      Beats the account-default for that opening only; the user can still
+      switch tabs once the modal is mounted. Used by the Listen view to
+      route the metadata-editor "Replace" button → Upload tab and
+      "Regenerate" button → Search tab. */
+  initialTab?: 'search' | 'upload';
 }
 
 type TabKey = 'search' | 'upload' | 'frame';
@@ -67,10 +73,25 @@ export function CoverPicker(props: Props) {
     onClose,
     onPicked,
     onFramingChanged,
+    initialTab,
   } = props;
 
   const accountDefaultTab = useAppSelector((s) => s.account.coverPickerDefaultTab ?? 'search');
-  const [tab, setTab] = useState<TabKey>(accountDefaultTab === 'upload' ? 'upload' : 'search');
+  const [tab, setTab] = useState<TabKey>(
+    initialTab ?? (accountDefaultTab === 'upload' ? 'upload' : 'search'),
+  );
+
+  /* When the modal re-opens with a different initialTab override (e.g.
+     Replace vs Regenerate buttons in the metadata editor), honour the
+     fresh override on each open. Once the modal is mounted the user can
+     still switch tabs freely. */
+  const prevOpen = useRef(open);
+  useEffect(() => {
+    if (open && !prevOpen.current && initialTab) {
+      setTab(initialTab);
+    }
+    prevOpen.current = open;
+  }, [open, initialTab]);
 
   /* Search-tab state */
   const [state, setState] = useState<LoadState>({ kind: 'idle' });

--- a/src/views/listen.test.tsx
+++ b/src/views/listen.test.tsx
@@ -4,11 +4,26 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
+
+/* CoverPicker's real implementation runs network-y effects on mount
+   (findCoverCandidates). Stub it with a marker that surfaces the
+   open/initialTab props so the cover-button wiring tests can assert
+   *which* tab the parent asked the modal to open with, without
+   re-doing the picker's own test coverage. The modal's behaviour is
+   pinned by src/modals/cover-picker.test.tsx. */
+vi.mock('../modals/cover-picker', () => ({
+  CoverPicker: (props: { open: boolean; initialTab?: 'search' | 'upload' }) =>
+    props.open ? (
+      <div data-testid="cover-picker-stub" data-initial-tab={props.initialTab ?? 'none'} />
+    ) : null,
+}));
+
 import { ListenView } from './listen';
-import { exportsSlice } from '../store/exports-slice';
+import { exportsSlice, exportsActions } from '../store/exports-slice';
 import { accountSlice } from '../store/account-slice';
 import { uiSlice } from '../store/ui-slice';
-import type { Chapter, Character, Voice } from '../lib/types';
+import { notificationsSlice } from '../store/notifications-slice';
+import type { Chapter, Character, Voice, BookExportJob } from '../lib/types';
 import type { EditableBookMeta } from '../store/book-meta-slice';
 
 const chapters: Chapter[] = [
@@ -65,6 +80,7 @@ function makeStore() {
       exports: exportsSlice.reducer,
       account: accountSlice.reducer,
       ui: uiSlice.reducer,
+      notifications: notificationsSlice.reducer,
     },
   });
 }
@@ -437,5 +453,158 @@ describe('ListenView — chapter list scroll cap', () => {
     const scroller = screen.getByTestId('listen-chapters-scroll');
     expect(within(scroller).getByText('The Approach')).toBeInTheDocument();
     expect(within(scroller).getByText('Into the Fog')).toBeInTheDocument();
+  });
+});
+
+describe('ListenView — export-queue per-row actions (plan 18a)', () => {
+  /* The Copy link button writes to navigator.clipboard and fires an info
+     toast. The Remove button dispatches exportsActions.exportDismissed
+     so the live row leaves the rail. Mock-fallback rows (design-system
+     fixtures with synthetic ids) dispatch the same action but with no
+     matching entry in `byBookId`, so the dispatch is a no-op visually —
+     that's an acceptable mock-mode degradation since real exports
+     replace the fixture entirely. */
+
+  it('Copy link button on a URL row writes to clipboard and pushes an info toast', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: { clipboard: { writeText } },
+    });
+
+    const store = configureStore({
+      reducer: {
+        exports: exportsSlice.reducer,
+        account: accountSlice.reducer,
+        ui: uiSlice.reducer,
+        notifications: notificationsSlice.reducer,
+      },
+    });
+    /* Seed one live export job. downloadUrl is what the adapter maps to
+       ExportQueueItem.url, which the row uses to render the Copy button
+       (instead of the Download button). */
+    const job: BookExportJob = {
+      id: 'job-1',
+      bookId: 'demo__sa__test',
+      status: 'done',
+      format: 'm4b',
+      destination: 'download',
+      downloadUrl: 'https://example.com/listen/abc',
+      createdAt: new Date().toISOString(),
+      progress: 1,
+      filename: 'Demo — Full audiobook.m4b',
+      sizeBytes: 1234,
+    };
+    store.dispatch(exportsActions.exportStarted(job));
+
+    const handlers = baseHandlers();
+    render(
+      <Provider store={store}>
+        <ListenView
+          bookId="demo__sa__test"
+          chapters={chapters}
+          characters={characters}
+          library={voices}
+          currentTrack={null}
+          bookMeta={baseMeta()}
+          bookCoverGradient={['#2C7A4B', '#0F3A23']}
+          bookCoverImageUrl={null}
+          isMetaDirty={false}
+          {...handlers}
+        />
+      </Provider>,
+    );
+
+    fireEvent.click(screen.getByTitle('Copy link'));
+
+    // Wait one microtask for the await writeText() to resolve.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(writeText).toHaveBeenCalledWith('https://example.com/listen/abc');
+    const toasts = store.getState().notifications.toasts;
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].message).toMatch(/copied/i);
+    expect(toasts[0].kind).toBe('info');
+  });
+
+  it('Remove button on a live row dispatches exportDismissed', () => {
+    const store = configureStore({
+      reducer: {
+        exports: exportsSlice.reducer,
+        account: accountSlice.reducer,
+        ui: uiSlice.reducer,
+        notifications: notificationsSlice.reducer,
+      },
+    });
+    const job: BookExportJob = {
+      id: 'job-2',
+      bookId: 'demo__sa__test',
+      status: 'done',
+      format: 'm4b',
+      destination: 'download',
+      downloadUrl: 'https://example.com/file.m4b',
+      createdAt: new Date().toISOString(),
+      progress: 1,
+      filename: 'Demo — Full audiobook.m4b',
+      sizeBytes: 1234,
+    };
+    store.dispatch(exportsActions.exportStarted(job));
+
+    expect(store.getState().exports.byBookId['demo__sa__test']).toHaveLength(1);
+
+    const handlers = baseHandlers();
+    render(
+      <Provider store={store}>
+        <ListenView
+          bookId="demo__sa__test"
+          chapters={chapters}
+          characters={characters}
+          library={voices}
+          currentTrack={null}
+          bookMeta={baseMeta()}
+          bookCoverGradient={['#2C7A4B', '#0F3A23']}
+          bookCoverImageUrl={null}
+          isMetaDirty={false}
+          {...handlers}
+        />
+      </Provider>,
+    );
+
+    fireEvent.click(screen.getByTitle('Remove'));
+
+    expect(store.getState().exports.byBookId['demo__sa__test']).toHaveLength(0);
+  });
+});
+
+describe('ListenView — metadata-editor cover buttons (plan 18a)', () => {
+  /* Before plan 18a these two buttons rendered as disabled "Coming soon"
+     stubs. Now they open the CoverPicker; Replace routes to Upload tab,
+     Regenerate to Search tab. The modal's own behaviour is covered in
+     cover-picker.test.tsx; here we pin the parent's open/route wiring. */
+
+  it('cover Replace button is enabled and opens the picker on Upload tab', () => {
+    renderView();
+    const replace = screen.getByTestId('meta-cover-replace');
+    expect(replace).not.toBeDisabled();
+    /* Modal is unmounted before click. */
+    expect(screen.queryByTestId('cover-picker-stub')).not.toBeInTheDocument();
+
+    fireEvent.click(replace);
+
+    const stub = screen.getByTestId('cover-picker-stub');
+    expect(stub.getAttribute('data-initial-tab')).toBe('upload');
+  });
+
+  it('cover Regenerate button is enabled and opens the picker on Search tab', () => {
+    renderView();
+    const regenerate = screen.getByTestId('meta-cover-regenerate');
+    expect(regenerate).not.toBeDisabled();
+    expect(screen.queryByTestId('cover-picker-stub')).not.toBeInTheDocument();
+
+    fireEvent.click(regenerate);
+
+    const stub = screen.getByTestId('cover-picker-stub');
+    expect(stub.getAttribute('data-initial-tab')).toBe('search');
   });
 });

--- a/src/views/listen.tsx
+++ b/src/views/listen.tsx
@@ -31,8 +31,10 @@ import { stripChapterPrefix } from '../lib/format-chapter-title';
 import { SUPPORTED_APPS } from '../data/listener-apps';
 import { EXPORT_QUEUE } from '../data/export-queue';
 import { bookExportJobToQueueItem } from '../lib/export-queue-adapter';
-import { useAppSelector } from '../store';
+import { useAppDispatch, useAppSelector } from '../store';
 import { selectListenProgress } from '../store/listen-progress-slice';
+import { exportsActions } from '../store/exports-slice';
+import { notificationsActions } from '../store/notifications-slice';
 import type { Chapter, Character, Voice, ListenerApp, ExportQueueItem } from '../lib/types';
 import type { EditableBookMeta, EditableBookMetaField } from '../store/book-meta-slice';
 
@@ -91,7 +93,17 @@ export function ListenView({
      on the next library hydrate). Empty string = the user just removed
      the cover; ignore the prop until the slice refresh resolves. Same
      pattern as BookCard in book-library.tsx. */
+  const dispatch = useAppDispatch();
   const [coverPickerOpen, setCoverPickerOpen] = useState(false);
+  /* Per-open tab override. Reset when the modal closes so the next
+     cover-tile click defaults back to the account preference. */
+  const [coverPickerInitialTab, setCoverPickerInitialTab] = useState<
+    'search' | 'upload' | undefined
+  >(undefined);
+  const openCoverPicker = (tab?: 'search' | 'upload') => {
+    setCoverPickerInitialTab(tab);
+    setCoverPickerOpen(true);
+  };
   const [coverOverride, setCoverOverride] = useState<string | null>(null);
   /* Local framing override mirrors coverOverride for instant feedback
      between the picker's debounced PATCH and the slice rehydrate. */
@@ -156,7 +168,7 @@ export function ListenView({
           onImageError={() => setCoverLoadFailed(true)}
           runtime={formatTime(totalSec)}
           narrator={narratorName}
-          onChangeCover={() => setCoverPickerOpen(true)}
+          onChangeCover={() => openCoverPicker()}
         />
         <div>
           <SectionLabel>Audiobook · ready to listen</SectionLabel>
@@ -276,7 +288,33 @@ export function ListenView({
           setExportModal({ tab: 'sync-folder', appHint: 'audiobookshelf' })
         }
       />
-      <ExportQueue items={queueItems} />
+      <ExportQueue
+        items={queueItems}
+        onCopyLink={async (item) => {
+          if (!item.url) return;
+          try {
+            await navigator.clipboard.writeText(item.url);
+            dispatch(
+              notificationsActions.pushToast({
+                kind: 'info',
+                message: 'Link copied to clipboard',
+                dedupeKey: 'export-link-copied',
+              }),
+            );
+          } catch {
+            dispatch(
+              notificationsActions.pushToast({
+                kind: 'warn',
+                message: 'Could not copy — clipboard permission denied',
+                dedupeKey: 'export-link-copy-failed',
+              }),
+            );
+          }
+        }}
+        onRemove={(item) => {
+          dispatch(exportsActions.exportDismissed({ bookId, exportId: item.id }));
+        }}
+      />
 
       <section className="mb-12">
         <div className="flex items-center justify-between mb-3 flex-wrap gap-2">
@@ -306,6 +344,8 @@ export function ListenView({
           onCommit={onCommitMeta}
           onCancel={onCancelMeta}
           isDirty={isMetaDirty}
+          onReplaceCover={() => openCoverPicker('upload')}
+          onRegenerateCover={() => openCoverPicker('search')}
         />
       </section>
 
@@ -334,7 +374,11 @@ export function ListenView({
         bookAuthor={author}
         currentCoverUrl={effectiveCoverUrl ?? undefined}
         currentFraming={effectiveFraming}
-        onClose={() => setCoverPickerOpen(false)}
+        initialTab={coverPickerInitialTab}
+        onClose={() => {
+          setCoverPickerOpen(false);
+          setCoverPickerInitialTab(undefined);
+        }}
         onPicked={(newUrl) => {
           setCoverLoadFailed(false);
           /* Empty string from a "Remove cover" pick — shadow the slice
@@ -572,6 +616,8 @@ interface MetadataEditorProps {
   onCommit: () => void;
   onCancel: () => void;
   isDirty: boolean;
+  onReplaceCover: () => void;
+  onRegenerateCover: () => void;
 }
 
 function MetadataEditor({
@@ -580,6 +626,8 @@ function MetadataEditor({
   onCommit,
   onCancel,
   isDirty,
+  onReplaceCover,
+  onRegenerateCover,
 }: MetadataEditorProps) {
   if (!bookMeta) {
     return (
@@ -631,18 +679,22 @@ function MetadataEditor({
             <div className="w-16 h-16 rounded-xl bg-gradient-cta shadow-card" />
             <div className="flex items-center gap-2">
               <button
-                disabled
-                title="Replace cover — coming soon"
-                className="px-3 py-2 rounded-full border border-ink/15 text-xs font-medium text-ink/40 inline-flex items-center gap-1.5 cursor-not-allowed"
+                type="button"
+                onClick={onReplaceCover}
+                title="Upload a new cover from disk"
+                data-testid="meta-cover-replace"
+                className="px-3 py-2 rounded-full border border-ink/15 text-xs font-medium text-ink/80 hover:text-ink hover:bg-ink/[0.04] inline-flex items-center gap-1.5 transition-colors"
               >
-                <IconUpload className="w-3.5 h-3.5" /> Replace <ComingSoonBadge />
+                <IconUpload className="w-3.5 h-3.5" /> Replace
               </button>
               <button
-                disabled
-                title="Regenerate cover — coming soon"
-                className="px-3 py-2 rounded-full border border-ink/15 text-xs font-medium text-ink/40 inline-flex items-center gap-1.5 cursor-not-allowed"
+                type="button"
+                onClick={onRegenerateCover}
+                title="Search OpenLibrary for a fresh cover candidate"
+                data-testid="meta-cover-regenerate"
+                className="px-3 py-2 rounded-full border border-ink/15 text-xs font-medium text-ink/80 hover:text-ink hover:bg-ink/[0.04] inline-flex items-center gap-1.5 transition-colors"
               >
-                <IconRefresh className="w-3.5 h-3.5" /> Regenerate <ComingSoonBadge />
+                <IconRefresh className="w-3.5 h-3.5" /> Regenerate
               </button>
             </div>
           </div>
@@ -820,7 +872,15 @@ function ListenerAppCard({ app, onSend: _onSend, onOpenLiveExport }: ListenerApp
 
 type QueueFilter = 'all' | 'done' | 'in_progress' | 'failed';
 
-function ExportQueue({ items }: { items: ExportQueueItem[] }) {
+function ExportQueue({
+  items,
+  onCopyLink,
+  onRemove,
+}: {
+  items: ExportQueueItem[];
+  onCopyLink?: (item: ExportQueueItem) => void;
+  onRemove?: (item: ExportQueueItem) => void;
+}) {
   const [filter, setFilter] = useState<QueueFilter>('all');
   const visible = items.filter((it) => filter === 'all' || it.status === filter);
   const counts = {
@@ -866,6 +926,8 @@ function ExportQueue({ items }: { items: ExportQueueItem[] }) {
                   }
                 : undefined
             }
+            onCopyLink={onCopyLink}
+            onRemove={onRemove}
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary

Wires three previously-disabled Listen-view affordances. Plan 18 ([Listen view](https://github.com/dudarenok-maker/AudioBook-Generator/blob/feat/frontend-plan-18a-listen-cover-and-queue/docs/features/18-listen-view.md)) stays scaffolded — the remaining stubs are split out into focused follow-ups (BACKLOG Could #29-35) so this PR stays reviewable rather than sprawling across server endpoints, peaks-compute, and three handoff modals.

### What this PR ships

- **Metadata-editor cover Replace + Regenerate buttons.** Replace opens the existing CoverPicker on Upload tab; Regenerate opens it on Search tab. New `initialTab` prop on `CoverPicker` routes the per-button intent — useEffect-syncs on each open transition so the right tab shows up regardless of mount state.
- **Export-queue Copy link row action.** `navigator.clipboard.writeText` + `notificationsActions.pushToast({ kind: 'info', dedupeKey: 'export-link-copied' })` — uses the plan 48 toast surface; dedupe-by-key collapses fast-double-clicks.
- **Export-queue Remove row action.** Dispatches `exportsActions.exportDismissed({ bookId, exportId })`. Mock-fallback fixture rows (synthetic IDs not in `byBookId`) accept the dispatch as a no-op — acceptable mock-mode degradation since real exports replace the fixture entirely.

### What this PR explicitly defers (filed as new BACKLOG entries)

- **Could #33 — Download tiles wiring** (m4b chaptered / MP3 ZIP / streaming link). Needs new server endpoints; bigger than a wiring PR.
- **Could #34 — Queue Retry + Download row actions.** Needs middleware integration for re-fire.
- **Could #35 — Waveform peaks from real chapter audio.** Needs `<slug>.peaks.json` emit at encode time.

The four listener-app handoffs (BookPlayer / Smart AudioBook Player / Apple Books / Plex) stay as Could #29-32 — plan 18b will close PocketBook + Audiobookshelf only.

## Test plan

- [x] `npx vitest run src/views/listen.test.tsx` — 34/34 passing (2 new for cover Replace/Regenerate, 2 new for queue Copy/Remove).
- [x] `npm run verify` — green end-to-end (all 9 steps).
- [x] Plan 18's KNOWN-scaffolded section updated to point at the new BACKLOG Could #29-35 entries; counts header in BACKLOG updated to Should 3 / Could 34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)