### PR TITLE
feat(server,frontend): plan 20 close-out — rollback fsck + mid-flight Reject toast

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -27,7 +27,7 @@ the same PR — the backlog is only useful while it stays current.
 
 Ranking within each bucket = top is highest priority.
 
-**Counts as of 2026-05-18 (post plan 33 ship):** Must 0 · Should 3 · Could 33 · Won't 9
+**Counts as of 2026-05-18 (post plan 20 ship):** Must 0 · Should 3 · Could 34 · Won't 9
 
 ---
 
@@ -401,6 +401,16 @@ Source: plan 18 known gap (2026-05-18). The chapter-audio meta endpoint currentl
 - _Key files:_ `server/src/tts/mp3.ts` (extend to emit peaks during encode); `server/src/routes/chapter-audio.ts` (read + return peaks); new `server/src/audio/compute-peaks.ts` (240-bin RMS reducer).
 - _Depends on:_ none structural. Pairs naturally with Could #3 (per-chapter loudness report) — both emit chapter-level audio metadata at encode time.
 - _Benefit (user):_ the Listen view's waveform card stops lying about chapter shape (loud passages, silences, fades all become visible). Spotting problem chapters at a glance.
+
+### 36. Per-segment regen consumer for `revisions.acceptedSelections`
+
+Source: plan 20 close-out (2026-05-18). The `revisions.acceptedSelections` map is persisted by `revisionsActions.acceptRevision` but no in-app code reads it back — per-segment splicing of accepted takes was explicitly "Out of scope" for plan 20 v1, and remains so in the v1 close-out.
+
+- _What:_ Add a per-segment regen path that consumes `acceptedSelections[revisionId]` to re-render only the segments the user flipped to 'B' (the new take) while preserving 'A' (the original) segments verbatim. This requires (a) a server endpoint that accepts `{ revisionId, segmentSelections }` and dispatches per-segment synth, (b) a segments-manifest merge step that interleaves the two takes on disk, (c) a frontend trigger from the revision-diff player's "Commit selection" action.
+- _Acceptance:_ Open a pending revision, toggle segments 3 + 7 to 'B' (others 'A'), click "Commit selection" → the chapter MP3 is rewritten with segments 3 + 7 re-rendered from the new take, all other segments byte-identical to the preserved (A) take. Server Vitest covers the manifest merge + per-segment synth; frontend Vitest covers the action dispatch shape; e2e covers the audition-then-commit flow.
+- _Key files:_ new `server/src/routes/revisions-commit-segments.ts`; `server/src/tts/synthesise-chapter.ts` (extend for per-segment paths); `src/views/revision-diff.tsx` (dispatch through the new endpoint); `src/store/revisions-slice.ts` (mark the revision as committed once the segment-level synth completes).
+- _Depends on:_ plan 20 shipped (acceptedSelections persistence is already on disk). Pairs with Could #12 (revision history timeline) — the timeline becomes meaningful once per-segment commits land separately from full regens.
+- _Benefit (user):_ true segment-level revision control. Today accept/reject is whole-revision swap — if the user likes 9 of 10 segments in the new take but wants segment 7 from the original, they have to regenerate the whole chapter under different prompts to recover that one segment. This closes the loop the slice has been quietly capturing since plan 20 v1.
 
 ---
 

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -90,7 +90,6 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 
 ### I. Revisions & drift
 
-- [20 — Revisions & drift](20-revisions-and-drift.md) — Pending drafts + drift events + a/b audio audition (rollback-preserved previous audio) + stale-audio banner on voice edits.
 
 ### J. Library & workspace
 
@@ -148,3 +147,4 @@ breadcrumb so cross-references still resolve.
 - [37 — Playwright e2e harness](archive/37-e2e-playwright.md) — Browser-level smoke + on-ramp for visual regression; 14 specs / 30 tests at ship, covering library, upload, analysing, confirm, ready, listen, voices, cast/drawer, theme, toast, manual continuity, revision diff, bulk sync, cover framing, plus per-surface visual baselines (light + dark). Shipped 2026-05-18.
 - [14 — Coqui XTTS sidecar](archive/14-tts-sidecar-coqui.md) — Local sidecar TTS alternate (zero-shot voice cloning); bounded-retry with provider-side classification of transient (network blip / 5xx / 408) vs non-transient (4xx / CUDA-poisoned 503) failures; full failure-path table. Shipped 2026-05-18.
 - [33 — Voice export](archive/33-voice-export.md) — Live Voice (Android audiobook player) tile on the Listen tab; M4B-standards conformance (`stik = 2` + `desc` / `ldes`) regression-guarded; defaults to M4B + sync-folder. Long-form description field shipped alongside. Shipped 2026-05-18.
+- [20 — Revisions & drift](archive/20-revisions-and-drift.md) — Pending drafts + drift events + a/b audio audition (rollback-preserved previous audio) + stale-audio banner on voice edits. Close-out adds startup fsck for half-preserved rollback pairs + mid-flight Reject toast. Shipped 2026-05-18.

--- a/docs/features/archive/20-revisions-and-drift.md
+++ b/docs/features/archive/20-revisions-and-drift.md
@@ -1,6 +1,12 @@
+---
+status: stable
+shipped: 2026-05-18
+owner: null
+---
+
 # Revisions & drift
 
-> Status: stable — drift detection + pending-revisions a/b audio playback fully wired; pending revisions support per-item or bulk accept/reject with a/b audition driven by server-side rollback preservation
+> Status: stable — drift detection + pending-revisions a/b audio playback fully wired; pending revisions support per-item or bulk accept/reject with a/b audition driven by server-side rollback preservation; startup fsck reconciles half-preserved rollback pairs; mid-flight Reject failures surface via the toast surface.
 > Key files: `src/views/revision-diff.tsx` (a/b player + segment seek), `src/lib/use-ab-playback.ts` (mutual-exclusion hook), `src/lib/build-pending-revision.ts`, `src/modals/drift-report.tsx`, `src/components/stale-audio-banner.tsx`, `src/store/revisions-slice.ts` (`acceptRevision`, `rejectRevision`, `enqueuePending`, `markRevisionPlayable`, `acceptAllPending`, `rejectAllPending`, `dismissDrift`, `hydrateFromBookState`), `src/store/generation-stream-middleware.ts` (enqueue on regen + flip playable on chapter_complete), `src/lib/api.ts` (`pollRevisions`, `getChapterAudioPrevious`, `acceptChapterRevision`, `rejectChapterRevision`), `src/components/layout.tsx` (poll effect + RevisionDiffPlayer wiring + auto-regen handler + onSave-driven stale-audio banner), `server/src/routes/revisions.ts` (drift detector + `autoQueueable` flag), `server/src/routes/generation.ts` (`characterSnapshots` write + `preserveExistingAsPrevious` call), `server/src/workspace/preserve-previous-audio.ts` (rollback helper), `server/src/routes/chapter-audio.ts` (`/audio/previous`, accept/reject endpoints)
 > URL surface: indirect — revisions diff opens from `ready` views; drift report is a modal
 > OpenAPI ops: `GET /api/books/:bookId/revisions` (real backend computes drift from per-chapter snapshots); `GET/DELETE /api/books/:bookId/chapters/:chapterId/audio/previous` and `POST .../audio/previous/restore` (a/b audition + accept/reject server side-effects)
@@ -55,18 +61,24 @@ Run `VITE_USE_MOCKS=true`, navigate to a `ready` book view.
 10. Dismiss a drift event. Reload the page. Wait < 30 s. The event does NOT reappear (dismissed id is filtered server-side).
 11. **Attribute drift via library-cast override** (paired with `09-voice-match-pipeline.md`). After confirming cast with the "Sync profile with …" checkbox ticked, open the library (target) book. Within 30 s a `moderate` drift event with factor `attributes` should appear in the drift report for each character whose attribute set differs from the synthesis-time snapshot. Dismissing it stays dismissed across reloads. Changing only attribute ORDER or case (e.g. via a future re-analysis) must NOT re-fire the event.
 
-## KNOWN: scaffolded
+## Shipped as part of plan 20 close-out (2026-05-18)
 
-- `acceptedSelections` is persisted but not yet consumed by anything in-app. Future per-segment TTS regen will read it to know which takes to re-render.
-- Rollback atomicity: the preserve helper renames two files (audio + segments.json). A crash between them leaves a half-preserved state. A startup `fsck` in `server/src/workspace/scan.ts` that pairs orphan halves is a documented follow-up — the gap is small (sub-millisecond window) and recoverable (orphan halves are harmless until a manual cleanup runs).
-- Mid-flight Reject surfaces as a console warning, not a user-facing toast — UI polish follow-up.
+- **Rollback fsck on server startup** — `server/src/workspace/fsck-orphan-audio.ts` walks every book's `audio/` root on startup, promotes `.previous.mp3` back to live when the live counterpart is missing (regen-crash recovery), and drops orphan `.previous.segments.json` files. Fire-and-forget from `server/src/index.ts`. Pinned by `fsck-orphan-audio.test.ts` (7 cases covering the four valid states and a multi-orphan sweep).
+- **Mid-flight Reject toast** — the 409 (or any) failure path on `api.rejectChapterRevision` (and `acceptChapterRevision`) now pushes a `warn` toast via the plan 48 notification surface with a dedupe-by-key. Replaces the silent `console.warn` so the user knows to retry once generation pauses.
 
-## Out of scope
+## Out of scope (still deferred)
 
-- Per-segment splicing of accepted takes — `acceptedSelections` still write-only; v1 accept/reject is whole-revision swap via `.previous.*` rollback.
+- **`acceptedSelections` consumer** — the slice persists per-segment A/B selections on accept, but no in-app code reads them back. Per-segment splicing of accepted takes is a bigger pipeline change (it interacts with the segments-manifest format, the regen API shape, and the chapter encoder); tracked as `[BACKLOG Could #36]`. Plan 20's "Out of scope" line on per-segment splicing remains the v1 contract.
+
+## Out of scope (architectural, unchanged from v1)
+
 - Cross-book drift detection — single-book scope.
 - Automatic auto-accept when drift severity is below threshold.
 
 ## Ship notes
 
-- Shipped: 2026-05-17. Bundles backlog Must #2 (a/b audio for revisions) + Must #4 (mock audio assets). Closes the "out of scope: a/b playback" caveat from plan 20 v1.
+- **v1 shipped: 2026-05-17.** Bundled backlog Must #2 (a/b audio for revisions) + Must #4 (mock audio assets). Closed the "out of scope: a/b playback" caveat from plan 20 v0.
+- **Close-out shipped: 2026-05-18.** Cleared the three KNOWN-scaffolded items:
+  - Rollback fsck → new `server/src/workspace/fsck-orphan-audio.ts` + 7-case Vitest spec; wired fire-and-forget from `server/src/index.ts` on startup.
+  - Mid-flight Reject toast → wired `notificationsActions.pushToast` (plan 48 surface) on `api.{accept,reject}ChapterRevision` failure paths, with dedupe-by-key.
+  - `acceptedSelections` consumer → explicitly deferred (was already "Out of scope" for per-segment splicing in v1); filed as `[BACKLOG Could #36]` so the slice's write-only persistence remains documented and trackable.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -46,6 +46,7 @@ import { runCatalogAudit } from './tts/coqui-catalog-audit.js';
 import { auditEngineCatalog } from './tts/voice-mapping.js';
 import { WORKSPACE_ROOT, ensureWorkspace } from './workspace/paths.js';
 import { migrateLegacyChangeLogs } from './workspace/changelog-migrate.js';
+import { fsckAllBooks } from './workspace/fsck-orphan-audio.js';
 import {
   readUserSettings,
   getResolvedSidecarUrl,
@@ -87,6 +88,30 @@ void migrateLegacyChangeLogs()
     }
   })
   .catch((err) => console.warn('[changelog] migration skipped:', err));
+
+/* Plan 20 — sibling fsck for the rollback-preservation pair. The
+   preserve helper (`workspace/preserve-previous-audio.ts`) renames two
+   files (audio + segments) sequentially; a crash between them leaves a
+   half-preserved state. On startup we walk every book's audio root,
+   promote any `.previous.mp3` back to live when the live counterpart
+   is missing (regen crash recovery), and drop orphan
+   `.previous.segments.json` files. Fire-and-forget: never blocks
+   listen, never throws. */
+void fsckAllBooks()
+  .then((r) => {
+    if (r.recovered.length > 0) {
+      console.log(
+        `[fsck] reconciled ${r.recovered.length} rollback-pair half-state(s) on startup ` +
+          `(see workspace/fsck-orphan-audio.ts).`,
+      );
+    }
+    if (r.errors.length > 0) {
+      for (const e of r.errors) {
+        console.warn(`[fsck] ${e.action} failed for ${e.slug}: ${e.message}`);
+      }
+    }
+  })
+  .catch((err) => console.warn('[fsck] sweep skipped:', err));
 app.use('/workspace', express.static(WORKSPACE_ROOT, { fallthrough: true, maxAge: '1h' }));
 
 app.get('/api/health', (_req, res) => {

--- a/server/src/workspace/fsck-orphan-audio.test.ts
+++ b/server/src/workspace/fsck-orphan-audio.test.ts
@@ -1,0 +1,135 @@
+/* Unit coverage for the rollback-preservation fsck (plan 20).
+ *
+ * Pins three on-disk shapes the preserve helper's two-rename window can
+ * leave behind plus the inert no-op case:
+ *   (1) `<slug>.previous.mp3` alone with no live `<slug>.mp3` →
+ *       promote `.previous.*` back to live.
+ *   (2) `<slug>.previous.segments.json` alone (no audio sibling) →
+ *       drop the orphan.
+ *   (3) Live + previous both present → valid pending-revision; leave
+ *       both files untouched.
+ *   (4) Both previous halves present without a live → promote the
+ *       audio AND its matching segments file in one go.
+ *
+ * The fsck is fire-and-forget safe (never throws); every assertion
+ * here goes through the function's normal return path. */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fsckOrphanAudio } from './fsck-orphan-audio.js';
+
+let workRoot: string;
+let audioRoot: string;
+
+beforeEach(() => {
+  workRoot = mkdtempSync(join(tmpdir(), 'fsck-orphan-audio-'));
+  audioRoot = join(workRoot, 'audio');
+  mkdirSync(audioRoot, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(workRoot, { recursive: true, force: true });
+});
+
+function seedFile(name: string, contents = 'x'): void {
+  writeFileSync(join(audioRoot, name), contents);
+}
+
+describe('fsckOrphanAudio', () => {
+  it('promotes <slug>.previous.mp3 back to live when <slug>.mp3 is missing (regen crash recovery)', async () => {
+    seedFile('01-chapter-1.previous.mp3', 'preserved audio bytes');
+
+    const result = await fsckOrphanAudio(audioRoot);
+
+    expect(result.errors).toEqual([]);
+    expect(result.recovered).toEqual([
+      { audioRoot, slug: '01-chapter-1', action: 'promoted-previous-to-live' },
+    ]);
+    expect(existsSync(join(audioRoot, '01-chapter-1.mp3'))).toBe(true);
+    expect(existsSync(join(audioRoot, '01-chapter-1.previous.mp3'))).toBe(false);
+  });
+
+  it('also promotes the matching segments file when both previous halves are orphaned', async () => {
+    seedFile('02-chapter-2.previous.mp3');
+    seedFile('02-chapter-2.previous.segments.json', '{"segments":[]}');
+
+    const result = await fsckOrphanAudio(audioRoot);
+
+    expect(result.errors).toEqual([]);
+    /* Single recovered entry — segments promotion is bundled into the
+       audio recovery action so the report stays per-slug. */
+    expect(result.recovered).toEqual([
+      { audioRoot, slug: '02-chapter-2', action: 'promoted-previous-to-live' },
+    ]);
+    expect(existsSync(join(audioRoot, '02-chapter-2.mp3'))).toBe(true);
+    expect(existsSync(join(audioRoot, '02-chapter-2.segments.json'))).toBe(true);
+    expect(existsSync(join(audioRoot, '02-chapter-2.previous.mp3'))).toBe(false);
+    expect(existsSync(join(audioRoot, '02-chapter-2.previous.segments.json'))).toBe(false);
+  });
+
+  it('drops orphan <slug>.previous.segments.json when no preserved audio matches it', async () => {
+    seedFile('03-chapter-3.previous.segments.json', '{"segments":[]}');
+
+    const result = await fsckOrphanAudio(audioRoot);
+
+    expect(result.errors).toEqual([]);
+    expect(result.recovered).toEqual([
+      { audioRoot, slug: '03-chapter-3', action: 'dropped-orphan-segments' },
+    ]);
+    expect(existsSync(join(audioRoot, '03-chapter-3.previous.segments.json'))).toBe(false);
+  });
+
+  it('leaves a valid pending-revision pair (.mp3 + .previous.mp3 + .previous.segments.json) untouched', async () => {
+    seedFile('04-chapter-4.mp3', 'live bytes');
+    seedFile('04-chapter-4.previous.mp3', 'preserved bytes');
+    seedFile('04-chapter-4.previous.segments.json', '{"segments":[]}');
+
+    const result = await fsckOrphanAudio(audioRoot);
+
+    expect(result.errors).toEqual([]);
+    expect(result.recovered).toEqual([]);
+    expect(existsSync(join(audioRoot, '04-chapter-4.mp3'))).toBe(true);
+    expect(existsSync(join(audioRoot, '04-chapter-4.previous.mp3'))).toBe(true);
+    expect(existsSync(join(audioRoot, '04-chapter-4.previous.segments.json'))).toBe(true);
+  });
+
+  it('is a no-op on a fresh book with only live files', async () => {
+    seedFile('05-chapter-5.mp3', 'live bytes');
+    seedFile('05-chapter-5.segments.json', '{"segments":[]}');
+
+    const result = await fsckOrphanAudio(audioRoot);
+
+    expect(result.recovered).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('returns an empty result on a non-existent audio root (fire-and-forget safe)', async () => {
+    const result = await fsckOrphanAudio(join(workRoot, 'does-not-exist'));
+    expect(result.recovered).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('handles multiple orphans in a single sweep without crosstalk', async () => {
+    seedFile('06-chapter-6.previous.mp3'); // case 1
+    seedFile('07-chapter-7.previous.segments.json', '{"segments":[]}'); // case 2
+    seedFile('08-chapter-8.mp3'); // valid live, no previous
+    seedFile('09-chapter-9.mp3'); // valid live
+    seedFile('09-chapter-9.previous.mp3'); // pending revision — leave alone
+
+    const result = await fsckOrphanAudio(audioRoot);
+
+    expect(result.errors).toEqual([]);
+    const actions = result.recovered.map((r) => `${r.slug}:${r.action}`).sort();
+    expect(actions).toEqual([
+      '06-chapter-6:promoted-previous-to-live',
+      '07-chapter-7:dropped-orphan-segments',
+    ]);
+    /* Chapter 6 promoted, chapter 7 cleaned, chapter 8 untouched, chapter 9 pair preserved. */
+    expect(existsSync(join(audioRoot, '06-chapter-6.mp3'))).toBe(true);
+    expect(existsSync(join(audioRoot, '07-chapter-7.previous.segments.json'))).toBe(false);
+    expect(existsSync(join(audioRoot, '09-chapter-9.mp3'))).toBe(true);
+    expect(existsSync(join(audioRoot, '09-chapter-9.previous.mp3'))).toBe(true);
+  });
+});

--- a/server/src/workspace/fsck-orphan-audio.ts
+++ b/server/src/workspace/fsck-orphan-audio.ts
@@ -1,0 +1,161 @@
+/* Sibling fsck for the chapter-audio rollback-preservation pair (plan 20).
+ *
+ * The preserve helper (`preserve-previous-audio.ts`) renames two files —
+ * `<slug>.mp3` and `<slug>.segments.json` — to `<slug>.previous.*` before
+ * a regen clobbers the live render. The renames are sequential, not
+ * atomic: a crash between them leaves a half-preserved state.
+ *
+ * Three recovery cases this fsck handles, run once on server startup:
+ *
+ *   (1) `<slug>.previous.mp3` exists, `<slug>.mp3` does NOT.
+ *       — Interpretation: the rename succeeded but the new render never
+ *         landed (regen aborted / crashed before writing the new audio).
+ *         Recovery: promote the preserved take back to live so the user
+ *         doesn't see the chapter as missing audio.
+ *
+ *   (2) `<slug>.previous.segments.json` exists, `<slug>.previous.mp3`
+ *       does NOT.
+ *       — Interpretation: orphan segments file. The audio was either
+ *         already promoted out (accept/reject path) or the audio rename
+ *         failed first. Either way the segments file is dead state.
+ *         Recovery: delete the orphan.
+ *
+ *   (3) Both `<slug>.previous.mp3` and `<slug>.mp3` exist.
+ *       — Interpretation: valid pending-revision state. Leave alone.
+ *
+ * Safe to run on every server start: the operations are idempotent and
+ * only ever rename / delete the `.previous.*` halves — the live `.mp3`
+ * is never touched by this fsck. */
+
+import { existsSync, readdirSync } from 'node:fs';
+import { unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { renameWithRetry } from './atomic-rename.js';
+import { BOOKS_ROOT, audioDir, bookDirByDisplay } from './paths.js';
+
+const PREV_MP3_RE = /^(.+)\.previous\.mp3$/i;
+const PREV_SEGMENTS_RE = /^(.+)\.previous\.segments\.json$/i;
+
+export interface FsckOrphanAudioResult {
+  /** Per-(audioRoot, slug) entry that the fsck recovered or repaired.
+      Empty in the no-op case (nothing on disk needed touching). */
+  recovered: Array<{ audioRoot: string; slug: string; action: FsckAction }>;
+  errors: Array<{ audioRoot: string; slug: string; action: FsckAction; message: string }>;
+}
+
+export type FsckAction =
+  | 'promoted-previous-to-live'
+  | 'dropped-orphan-segments';
+
+/** Walk a single book's audio root and reconcile half-preserved
+    rollback pairs. Mutates the on-disk state; returns a report of
+    actions taken plus any per-action errors that didn't halt the
+    sweep. The function never throws — it is fire-and-forget safe. */
+export async function fsckOrphanAudio(audioRoot: string): Promise<FsckOrphanAudioResult> {
+  const recovered: FsckOrphanAudioResult['recovered'] = [];
+  const errors: FsckOrphanAudioResult['errors'] = [];
+
+  if (!existsSync(audioRoot)) return { recovered, errors };
+
+  let entries: string[];
+  try {
+    entries = readdirSync(audioRoot);
+  } catch {
+    return { recovered, errors };
+  }
+
+  const prevMp3Slugs = new Set<string>();
+  const prevSegmentsSlugs = new Set<string>();
+  for (const name of entries) {
+    const mp3 = PREV_MP3_RE.exec(name);
+    if (mp3) {
+      prevMp3Slugs.add(mp3[1]);
+      continue;
+    }
+    const seg = PREV_SEGMENTS_RE.exec(name);
+    if (seg) prevSegmentsSlugs.add(seg[1]);
+  }
+
+  /* Case 1: previous audio alive without a live counterpart → promote
+     it back to live. The corresponding segments file (if any) is
+     promoted alongside. */
+  for (const slug of prevMp3Slugs) {
+    const livePath = join(audioRoot, `${slug}.mp3`);
+    if (existsSync(livePath)) continue; // case 3 — leave the pair alone
+    try {
+      await renameWithRetry(join(audioRoot, `${slug}.previous.mp3`), livePath);
+      if (prevSegmentsSlugs.has(slug)) {
+        await renameWithRetry(
+          join(audioRoot, `${slug}.previous.segments.json`),
+          join(audioRoot, `${slug}.segments.json`),
+        );
+        prevSegmentsSlugs.delete(slug);
+      }
+      recovered.push({ audioRoot, slug, action: 'promoted-previous-to-live' });
+    } catch (err) {
+      errors.push({
+        audioRoot,
+        slug,
+        action: 'promoted-previous-to-live',
+        message: (err as Error).message,
+      });
+    }
+  }
+
+  /* Case 2: orphan segments without a matching audio (live OR previous)
+     → drop. We re-check disk state because case 1 may have just
+     promoted the matching previous segments. */
+  for (const slug of prevSegmentsSlugs) {
+    const previousMp3 = join(audioRoot, `${slug}.previous.mp3`);
+    if (existsSync(previousMp3)) continue; // pair survived — leave alone
+    const orphan = join(audioRoot, `${slug}.previous.segments.json`);
+    if (!existsSync(orphan)) continue; // already cleaned
+    try {
+      await unlink(orphan);
+      recovered.push({ audioRoot, slug, action: 'dropped-orphan-segments' });
+    } catch (err) {
+      errors.push({
+        audioRoot,
+        slug,
+        action: 'dropped-orphan-segments',
+        message: (err as Error).message,
+      });
+    }
+  }
+
+  return { recovered, errors };
+}
+
+/** Walk every book on disk and run the fsck against its `audio/` root.
+    Called once on server startup via a fire-and-forget pattern in
+    `server/src/index.ts`; safe to invoke from anywhere. Returns the
+    aggregated report so the caller can log a summary. */
+export async function fsckAllBooks(): Promise<FsckOrphanAudioResult> {
+  const recovered: FsckOrphanAudioResult['recovered'] = [];
+  const errors: FsckOrphanAudioResult['errors'] = [];
+
+  if (!existsSync(BOOKS_ROOT)) return { recovered, errors };
+
+  const safeReaddir = (p: string): string[] => {
+    try {
+      return readdirSync(p);
+    } catch {
+      return [];
+    }
+  };
+
+  for (const author of safeReaddir(BOOKS_ROOT)) {
+    const authorDir = join(BOOKS_ROOT, author);
+    for (const series of safeReaddir(authorDir)) {
+      const seriesDir = join(authorDir, series);
+      for (const title of safeReaddir(seriesDir)) {
+        const bookDir = bookDirByDisplay(author, series, title);
+        const result = await fsckOrphanAudio(audioDir(bookDir));
+        recovered.push(...result.recovered);
+        errors.push(...result.errors);
+      }
+    }
+  }
+
+  return { recovered, errors };
+}

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1021,8 +1021,13 @@ export function Layout() {
             dispatch(revisionsActions.acceptRevision({ revisionId: id, selection }));
             dispatch(uiActions.setShowRevisionPlayer(false));
             api.acceptChapterRevision({ bookId, chapterId }).catch((err) => {
-              /* eslint-disable-next-line no-console */
-              console.warn('[revision-diff] accept network call failed:', err);
+              dispatch(
+                notificationsActions.pushToast({
+                  kind: 'warn',
+                  message: `Couldn't accept the revision — ${(err as Error).message ?? 'network error'}.`,
+                  dedupeKey: 'revision-accept-failed',
+                }),
+              );
             });
           }}
           onReject={() => {
@@ -1035,8 +1040,18 @@ export function Layout() {
             dispatch(revisionsActions.rejectRevision(id));
             dispatch(uiActions.setShowRevisionPlayer(false));
             api.rejectChapterRevision({ bookId, chapterId }).catch((err) => {
-              /* eslint-disable-next-line no-console */
-              console.warn('[revision-diff] reject network call failed:', err);
+              /* Plan 20 — mid-flight Reject lands here when the server
+                 returns 409 (generation in progress, can't promote the
+                 previous take over a live render). Surface via the toast
+                 surface so the user knows to wait + retry instead of
+                 staring at a silent UI. dedupeKey collapses rapid retries. */
+              dispatch(
+                notificationsActions.pushToast({
+                  kind: 'warn',
+                  message: `Couldn't reject the revision — ${(err as Error).message ?? 'try again once generation pauses'}.`,
+                  dedupeKey: 'revision-reject-failed',
+                }),
+              );
             });
           }}
         />


### PR DESCRIPTION
## Summary

Closes two of the three KNOWN-scaffolded items in [plan 20 (Revisions & drift)](https://github.com/dudarenok-maker/AudioBook-Generator/blob/feat/server-plan-20-fsck-and-toast/docs/features/archive/20-revisions-and-drift.md):

- **Rollback fsck on server startup.** New `server/src/workspace/fsck-orphan-audio.ts` walks every book's `audio/` root and reconciles half-preserved rollback pairs from `preserveExistingAsPrevious`'s two-rename window. Three cases handled: `<slug>.previous.mp3` alone → promote back to live (regen-crash recovery); orphan `<slug>.previous.segments.json` → drop; live + previous both present → leave alone (valid pending-revision). Fire-and-forget from `server/src/index.ts`.
- **Mid-flight Reject toast.** Replaced the silent `console.warn` in `layout.tsx` (revision-diff onReject + onAccept failure paths) with `notificationsActions.pushToast` through the plan 48 toast surface. dedupe-by-key collapses fast retries. 409 (generation in progress) failures now surface to the user.

The third KNOWN-scaffolded item — `acceptedSelections` consumer — was explicitly "Out of scope" in plan 20 v1 ("Per-segment splicing of accepted takes — acceptedSelections still write-only"). Per-segment regen is a bigger pipeline change (segments-manifest merge, per-segment synth, segment-level commit endpoint). Filed as `[BACKLOG Could #36]` so the slice's write-only persistence stays documented and trackable.

## Test plan

- [x] `npx vitest run server/src/workspace/fsck-orphan-audio.test.ts` — 7/7 passing (each recovery path, valid-pair preservation, no-op on clean book, non-existent root, multi-orphan single sweep).
- [x] `npm run verify` — green end-to-end (all 9 steps; 67 server test files / 879 cases).
- [x] Plan 20 frontmatter is `status: stable`, file under `archive/`, INDEX entry moved to Shipped section. BACKLOG counts: Must 0 · Should 3 · Could 34 · Won't 9 (added #36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)