### PR TITLE
fix(frontend): dark-mode contrast for bg-white/{60,70} surfaces

### DIFF
--- a/docs/features/42-dark-mode.md
+++ b/docs/features/42-dark-mode.md
@@ -136,7 +136,14 @@ dark-mode token / utility edit must preserve these targets:
    `hover:bg-white/70` must paint a _darker_ surface than the bare
    `bg-white` redirect (#1F1B19), one that still keeps the on-top
    text legible. They MUST NOT paint pure white.
-4. **Status pills** — rose / emerald / amber backgrounds drop to
+4. **Translucent base surfaces** — `bg-white/60` and `bg-white/70`
+   need their own dark overrides (separate selector from `.bg-white`,
+   so the solid redirect doesn't reach them). Without these the
+   Analysing-view ConnPill paints `text-emerald-700` light-emerald
+   text on a ~70% white wash → light-on-light, unreadable. Alpha
+   sits one step below the matching `hover:` variants so the base→
+   hover elevation ordering is preserved.
+5. **Status pills** — rose / emerald / amber backgrounds drop to
    ~10–32% alpha overlays on dark; matching text shifts to the
    -300/-400 family. Any new status-colour utility must land an
    override at the same time it's first used in component code.
@@ -171,6 +178,12 @@ dark-mode token / utility edit must preserve these targets:
   baselines (`library-dark`, `upload-dark`, `analysing-dark`,
   `confirm-dark`, `ready-dark`, `listen-dark`) blessed alongside
   the existing six light baselines.
+- Vitest unit (`src/test/dark-mode-css.test.ts`) — asserts the
+  surface-utility overrides for `bg-white`, `bg-white/60`,
+  `bg-white/70` and their `hover:` counterparts exist under
+  `[data-theme='dark']`. Locks the regression where a missing
+  base-variant override let the ConnPill paint
+  `text-emerald-700` on a near-white wash in dark mode.
 
 ### Manual acceptance walkthrough
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -132,6 +132,22 @@
   background-color: #1f1b19;
 }
 
+/* Translucent variants of bg-white. Tailwind generates `.bg-white\/60`
+   / `.bg-white\/70` as `rgb(255 255 255 / 0.X)` — a different selector
+   from the bare `.bg-white` rule above, so the dark redirect doesn't
+   reach them and they paint as a near-cream wash (~70% white) over
+   the dark canvas. The ConnPill on the Analysing view sits on
+   `bg-white/70` with `text-emerald-700` text → light-on-light when
+   streaming. Drop these to subtle ink-overlays so the on-top text
+   reads. Alpha sits one step below the hover variants below so the
+   "base → hover" elevation ordering is preserved. */
+[data-theme='dark'] .bg-white\/60 {
+  background-color: rgba(244, 239, 236, 0.04);
+}
+[data-theme='dark'] .bg-white\/70 {
+  background-color: rgba(244, 239, 236, 0.05);
+}
+
 /* Hover variants of bg-white. Tailwind generates these as
    `.hover\:bg-white:hover` etc., a different selector than the bare
    `.bg-white` rule above, so they need their own dark overrides —

--- a/src/test/dark-mode-css.test.ts
+++ b/src/test/dark-mode-css.test.ts
@@ -1,0 +1,48 @@
+/* Regression coverage for the dark-mode token overrides in
+   `src/styles.css`. The dark theme repaints a handful of Tailwind
+   utilities via `[data-theme='dark']` selectors instead of migrating
+   every component over to design tokens; that fan-out makes the file
+   the actual contract for "every utility used as a surface has a
+   dark counterpart." If a future edit drops one of those overrides
+   the bug surfaces as low-contrast text on a near-white pill — the
+   exact regression that put the streaming-state ConnPill on
+   `bg-white/70` with `text-emerald-700` text on top, which on the
+   dark canvas painted light-emerald-on-cream and was unreadable.
+
+   Asserting the rule's text presence is brittler than a computed-
+   style check, but jsdom doesn't apply external stylesheets so
+   `getComputedStyle()` in Vitest can't catch the bug. Playwright
+   visual baselines for `analysing-dark.png` cover the pre-start
+   state only — the streaming pill never appears in the screenshot.
+   This unit closes the gap until an e2e visual lands for the
+   streaming state. */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const stylesPath = resolve(__dirname, '..', 'styles.css');
+const css = readFileSync(stylesPath, 'utf8');
+
+describe('dark-mode CSS overrides (styles.css)', () => {
+  it.each([
+    /* Each entry is a Tailwind utility that's used in component code
+       as a surface (background) or hovered surface. If the dark
+       theme doesn't repaint it, light-mode pales (white, near-white,
+       pastel pills) bleed through and break the contrast contract
+       documented in docs/features/42-dark-mode.md "Contrast
+       invariants". */
+    { selector: '.bg-white', label: 'solid white surface' },
+    { selector: '.bg-white\\/60', label: 'translucent /60 surface' },
+    { selector: '.bg-white\\/70', label: 'translucent /70 surface' },
+    { selector: '.hover\\:bg-white:hover', label: 'hover solid white' },
+    { selector: '.hover\\:bg-white\\/60:hover', label: 'hover /60' },
+    { selector: '.hover\\:bg-white\\/70:hover', label: 'hover /70' },
+  ])('repaints $label ($selector) under [data-theme=\'dark\']', ({ selector }) => {
+    const pattern = new RegExp(
+      String.raw`\[data-theme='dark'\][^{]*` +
+        selector.replace(/[.*+?^${}()|[\]\\]/g, (m) => '\\' + m),
+    );
+    expect(css).toMatch(pattern);
+  });
+});


### PR DESCRIPTION
## Summary

- The Analysing-view ConnPill sits on `bg-white/70` with `text-emerald-700` text. The dark-mode redirect in `src/styles.css` only overrode bare `.bg-white` — Tailwind's `.bg-white\/70` is a different selector, so the pill painted ~70% white over the dark canvas and the light-emerald label rendered as light-on-light while streaming.
- Adds base-variant overrides for `.bg-white\/60` and `.bg-white\/70` at alphas one step below the existing `hover:` counterparts, preserving the base→hover elevation ordering documented in `docs/features/42-dark-mode.md`.
- Locks the regression with `src/test/dark-mode-css.test.ts` — a text probe over `styles.css` asserting both base and `hover:` variants of the surface utilities have `[data-theme='dark']` overrides. jsdom can't compute external CSS, so a text-level assertion is the cheapest lock for the streaming-pill state that the existing `analysing-dark.png` visual baseline doesn't cover (baseline captures pre-start only).

Plan: [docs/features/42-dark-mode.md](docs/features/42-dark-mode.md) — added Contrast invariant #4 (translucent base surfaces) and listed the new test in Automated coverage.

## Test plan

- [x] `npm run verify:fast` — frontend (941 tests) + server (930 tests) green
- [x] New `src/test/dark-mode-css.test.ts` fails before the CSS fix (verified via `git stash` round-trip) and passes after
- [ ] Visual smoke: open Analysing view in dark mode while SSE is streaming → "Streaming live" pill reads cleanly against the canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)