### PR TITLE
docs(docs): plan 51 post-ship cleanup — flip to stable, archive, drop BACKLOG #9

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -27,7 +27,7 @@ the same PR — the backlog is only useful while it stays current.
 
 Ranking within each bucket = top is highest priority.
 
-**Counts as of 2026-05-18 (post plan 49 ship):** Must 0 · Should 2 · Could 33 · Won't 9
+**Counts as of 2026-05-18 (post plan 51 ship):** Must 0 · Should 2 · Could 32 · Won't 9
 
 ---
 
@@ -144,16 +144,6 @@ Source: net-new (2026-05-18).
 - _Key files:_ new `src/components/manuscript-diff.tsx`; new `src/lib/manuscript-diff.ts` (diff algorithm — leverage `diff` npm package); `src/views/upload.tsx`; new server endpoint for diff-friendly fetch of the previous manuscript.
 - _Depends on:_ none.
 - _Benefit (user):_ re-uploading a manuscript today shows no indication of what changed — the user must manually re-read or trust external version control. Diff view closes that gap.
-
-### 9. Chapter reorder / restructure panel
-
-Source: net-new (2026-05-18).
-
-- _What:_ Add a "Restructure chapters" affordance in the confirm view (and re-accessible from the ready view). Operations: renumber, merge two adjacent chapters, split a chapter at a sentence boundary, reorder via drag. Operations are applied to `state.json` and any existing per-chapter audio is invalidated with a regen prompt.
-- _Acceptance:_ Merge chapters 3+4 → chapter 3 contains both bodies, chapter 4 is gone, original chapter 5 becomes chapter 4. Split chapter 5 at sentence index 12 → chapters 5a (sentences 0-11) and 5b (sentences 12-end). Reorder chapter 7 before chapter 4 → renumbering follows. Existing audio invalidated. Vitest covers the slice ops; e2e covers merge + split + reorder.
-- _Key files:_ new `src/components/restructure-chapters.tsx`; `src/store/chapters-slice.ts` (reducers); `server/src/workspace/scan.ts` (persistence); `server/src/routes/chapter-audio.ts` (invalidation on restructure).
-- _Depends on:_ none.
-- _Benefit (user):_ post-analysis restructuring without re-uploading the whole manuscript. Common need when the analyzer's chapter boundaries don't match the author's intent.
 
 ### 10. Portable book export with embedded state
 

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -63,7 +63,6 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 
 - [12 — Manuscript view](12-manuscript-view.md) — Sentence list, low-confidence flagging, speaker reassignment.
 - [12a — Fix: sentence reassignment scoped by (chapterId, id)](12a-fix-reassign-cross-chapter-id.md) — Reassign reducers + inspector prop scope by both chapter and sentence id; pre-fix, clicks on chapter 2+ silently mutated chapter 1. Shipped 2026-05-18.
-- [51 — Chapter restructure panel (merge / split / reorder)](51-restructure-chapters.md) — Three-way structural edit surface mounted at ready-stage `view: 'restructure'`. Pure-remap semantics preserve sentence text + characterId + voice assignment; audio for content-changed chapters is deleted, renumbered-only chapters keep their audio (two-pass rename + segments.json metadata rewrite).
 
 ### F. TTS
 
@@ -149,3 +148,4 @@ breadcrumb so cross-references still resolve.
 - [33 — Voice export](archive/33-voice-export.md) — Live Voice (Android audiobook player) tile on the Listen tab; M4B-standards conformance (`stik = 2` + `desc` / `ldes`) regression-guarded; defaults to M4B + sync-folder. Long-form description field shipped alongside. Shipped 2026-05-18.
 - [20 — Revisions & drift](archive/20-revisions-and-drift.md) — Pending drafts + drift events + a/b audio audition (rollback-preserved previous audio) + stale-audio banner on voice edits. Close-out adds startup fsck for half-preserved rollback pairs + mid-flight Reject toast. Shipped 2026-05-18.
 - [18 — Listen view](archive/18-listen-view.md) — Cover, chapter list, mini-player, metadata editor, listener-app tiles (5 of 7 live via export modal), export queue, cover Replace/Regenerate. Plan 18a slice + 18b correction shipped 2026-05-18; remaining gaps tracked as BACKLOG Could #31/#32/#33/#34/#35.
+- [51 — Chapter restructure panel](archive/51-restructure-chapters.md) — Three-way structural edit surface (merge / split / drag-reorder) at ready-stage `view: 'restructure'`. Pure-remap semantics preserve sentence text + characterId + voice assignment; content-changed chapters' audio is deleted, renumbered-only chapters' audio is renamed in place (two-pass via temp + segments.json metadata rewrite). Shipped 2026-05-18.

--- a/docs/features/archive/51-restructure-chapters.md
+++ b/docs/features/archive/51-restructure-chapters.md
@@ -1,12 +1,12 @@
 ---
-status: draft
-shipped: null
+status: stable
+shipped: 2026-05-18
 owner: null
 ---
 
 # Chapter restructure panel (merge / split / reorder)
 
-> Status: draft
+> Status: stable
 > Key files: `server/src/workspace/restructure.ts`, `server/src/routes/chapters-restructure.ts`, `server/src/audio/rewrite-chapter-slugs.ts`, `src/components/restructure-chapters-panel.tsx`, `src/views/restructure.tsx`
 > URL surface: `#/books/<id>/restructure`
 > OpenAPI ops: `POST /api/books/{bookId}/chapters/merge`, `POST .../chapters/split`, `POST .../chapters/reorder`
@@ -75,4 +75,9 @@ Against the real backend, the same walkthrough works on the canonical `C:\Users\
 
 ## Ship notes
 
-(Filled in when status flips to `stable`.)
+- **Shipped:** 2026-05-18 via PR #23 (merge commit `024af60`), feature commit `6ad7af0`, visual-baseline refresh `19e6fe8`.
+- **Delta vs spec:**
+  - Confirm-cast modal entry deferred to a follow-up — single entry point shipped: listen-view header button (`src/views/listen.tsx`). Restructuring still works pre-generation; the user just navigates listen → restructure → back rather than confirm → modal → confirm.
+  - Per-book write lock implemented as a `Map<bookId, Promise<void>>` chain in `server/src/routes/chapters-restructure.ts:54-74`.
+  - The split-locator paragraph-bisection fallback logs via `console.warn`; the test in `server/src/workspace/restructure.test.ts` asserts the structural shape via `vi.spyOn(console, 'warn')`.
+- **Test footprint:** 53 new tests (16 pure-transform + 8 audio-helper + 17 route end-to-end + 3 reducer + 9 panel component), all green in `npm run verify`. Visual baselines for the listen view (light + dark) re-captured in commit `19e6fe8` to account for the new header button.


### PR DESCRIPTION
## Summary

Post-ship paperwork for plan 51 (chapter restructure panel, merged in #23):

- Move `docs/features/51-restructure-chapters.md` → `docs/features/archive/` with `status: stable`, `shipped: 2026-05-18`, and a filled **Ship notes** section referencing PR #23 + commit SHAs.
- `docs/features/INDEX.md`: remove the top-level area-E entry, add the archive entry under **Shipped (archive)**.
- `docs/BACKLOG.md`: remove **Could #9** (the entry plan 51 closed); update count line to `Must 0 · Should 2 · Could 32 · Won't 9`.

## Test plan

- [x] `npm run verify` clean (pre-push hook ran the full battery — lint + typecheck + 930 unit/integration + Pester + sidecar pytest + Playwright e2e + production build all green)
- Docs-only diff; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)