### PR TITLE
feat(server,frontend,docs): plan 52 — MOBI/AZW3 upload support

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -27,7 +27,7 @@ the same PR — the backlog is only useful while it stays current.
 
 Ranking within each bucket = top is highest priority.
 
-**Counts as of 2026-05-18 (post plan 51 ship):** Must 0 · Should 2 · Could 32 · Won't 9
+**Counts as of 2026-05-18 (post plan 52 commit):** Must 0 · Should 2 · Could 33 · Won't 9
 
 ---
 
@@ -381,6 +381,16 @@ Source: net-new (2026-05-18). Plan 49 (release packaging) ships with a Kokoro-on
 - _Key files:_ `src/views/account.tsx` (extend with Models section), new `src/components/ollama-install.tsx`, new `src/components/model-pull-status.tsx`, `server/src/routes/ollama-health.ts` (extend with `POST /pull`), new `server/src/ollama/install-bootstrap.ts`, new `server/tts-sidecar/scripts/install-coqui.{sh,ps1}`.
 - _Depends on:_ none structural — the Account UX seam exists from plan 49. Unparks the install-and-pull-from-UI subset of Won't #1 ("Auto-install Ollama / auto-pull models"); the headless-CI variant of Won't #1 stays parked.
 - _Benefit (user):_ closes the gap that plan 49's Kokoro-only install leaves. Today a deployer who wants Ollama or Coqui XTTS must drop to a terminal; this UX keeps the install + model-management flow entirely in-app, matching the deployer-first promise of plan 49.
+
+### 38. E2E coverage for the binary-upload flow (EPUB / PDF / MOBI / AZW3)
+
+Source: [`52-mobi-parsing.md`](features/52-mobi-parsing.md) Out-of-scope follow-up (2026-05-18). Plan 52 explicitly deferred this — EPUB and PDF have never had dedicated Playwright coverage either, and MOBI shouldn't be the exception that sets a new bar in the same PR that ships it.
+
+- _What:_ Add a single Playwright spec under `e2e/binary-upload.spec.ts` that drops each of the four binary fixtures (EPUB / PDF / MOBI / AZW3) onto `#/new` in mock mode and asserts the confirm-metadata screen renders with the expected title / chapter count. Wire it into `npm run test:e2e`. Fixtures: reuse `server/src/parsers/__fixtures__/sample.epub` for the EPUB case; generate a tiny MOBI/AZW3 either by checking in a small Project Gutenberg-derived file or by extending `scripts/gen-parser-fixtures.mjs` to call out to Calibre's `ebook-convert` (Calibre is a prerequisite, not bundled).
+- _Acceptance:_ `npm run test:e2e` includes the new spec; CI run in `verify` passes with the spec exercising all four formats. A regression like "MOBI parser threw on real-world files" gets caught browser-side, not just at the unit level.
+- _Key files:_ new `e2e/binary-upload.spec.ts`; possibly extend `scripts/gen-parser-fixtures.mjs` for MOBI/AZW3 generation (Calibre-dependent); `docs/features/52-mobi-parsing.md` "Test plan" section updates to cite the new spec.
+- _Depends on:_ plan 52 shipped (the parser must already accept MOBI/AZW3). Independent of the existing flaky e2e items (Could #20).
+- _Benefit (technical):_ binary parsers are the highest-risk seam in the upload flow — third-party libs (epub2 / pdf-parse / @lingo-reader/mobi-parser) have real-world quirks that unit tests with mocked libraries can't catch. Browser-level coverage locks the integration contract.
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -384,11 +384,11 @@ Source: net-new (2026-05-18). Plan 49 (release packaging) ships with a Kokoro-on
 
 ### 38. E2E coverage for the binary-upload flow (EPUB / PDF / MOBI / AZW3)
 
-Source: [`52-mobi-parsing.md`](features/52-mobi-parsing.md) Out-of-scope follow-up (2026-05-18). Plan 52 explicitly deferred this — EPUB and PDF have never had dedicated Playwright coverage either, and MOBI shouldn't be the exception that sets a new bar in the same PR that ships it.
+Source: [`52-mobi-parsing.md`](features/archive/52-mobi-parsing.md) Out-of-scope follow-up (2026-05-18). Plan 52 explicitly deferred this — EPUB and PDF have never had dedicated Playwright coverage either, and MOBI shouldn't be the exception that sets a new bar in the same PR that ships it.
 
 - _What:_ Add a single Playwright spec under `e2e/binary-upload.spec.ts` that drops each of the four binary fixtures (EPUB / PDF / MOBI / AZW3) onto `#/new` in mock mode and asserts the confirm-metadata screen renders with the expected title / chapter count. Wire it into `npm run test:e2e`. Fixtures: reuse `server/src/parsers/__fixtures__/sample.epub` for the EPUB case; generate a tiny MOBI/AZW3 either by checking in a small Project Gutenberg-derived file or by extending `scripts/gen-parser-fixtures.mjs` to call out to Calibre's `ebook-convert` (Calibre is a prerequisite, not bundled).
 - _Acceptance:_ `npm run test:e2e` includes the new spec; CI run in `verify` passes with the spec exercising all four formats. A regression like "MOBI parser threw on real-world files" gets caught browser-side, not just at the unit level.
-- _Key files:_ new `e2e/binary-upload.spec.ts`; possibly extend `scripts/gen-parser-fixtures.mjs` for MOBI/AZW3 generation (Calibre-dependent); `docs/features/52-mobi-parsing.md` "Test plan" section updates to cite the new spec.
+- _Key files:_ new `e2e/binary-upload.spec.ts`; possibly extend `scripts/gen-parser-fixtures.mjs` for MOBI/AZW3 generation (Calibre-dependent); `docs/features/archive/52-mobi-parsing.md` "Test plan" section updates to cite the new spec.
 - _Depends on:_ plan 52 shipped (the parser must already accept MOBI/AZW3). Independent of the existing flaky e2e items (Could #20).
 - _Benefit (technical):_ binary parsers are the highest-risk seam in the upload flow — third-party libs (epub2 / pdf-parse / @lingo-reader/mobi-parser) have real-world quirks that unit tests with mocked libraries can't catch. Browser-level coverage locks the integration contract.
 

--- a/docs/features/02-upload-paste-or-file.md
+++ b/docs/features/02-upload-paste-or-file.md
@@ -7,12 +7,16 @@
 
 ## What this covers
 
-The upload screen accepts either inline pasted text or a binary file drop (`.md/.markdown/.txt/.text/.epub/.pdf`). Format is inferred from filename extension; word count and byte size are computed locally for previewing. On submit, the server stores the manuscript and the app transitions to the analysing stage.
+The upload screen accepts either inline pasted text or a binary file drop (`.md/.markdown/.txt/.text/.epub/.pdf/.mobi/.azw3`). Format is inferred from filename extension; word count and byte size are computed locally for previewing. On submit, the server stores the manuscript and the app transitions to the analysing stage.
+
+MOBI / AZW3 parsing is owned by [`52-mobi-parsing.md`](52-mobi-parsing.md) — that
+plan covers the parser module, DRM detection, and the extension-preserving
+persist path. This plan owns the upload UI surface only.
 
 ## Invariants to preserve
 
 - `UploadArgs` requires `text` OR `file`; both real and mock throw "requires either `text` or `file`" if neither is supplied (`src/lib/api.ts:336, 394`).
-- `inferFormat` recognises extensions `md|markdown|txt|text|epub|pdf` only (`src/lib/api.ts:30-39`). Unknown extensions return `null` and fall through to `'markdown'` default.
+- `inferFormat` recognises extensions `md|markdown|txt|text|epub|pdf|mobi|azw3` only (`src/lib/api.ts:65-78`). Unknown extensions return `null` and fall through to `'markdown'` default. `.azw3` maps to format `'mobi'` (shared parser identity); the original extension is preserved on persist by `server/src/routes/import.ts`, not by `inferFormat`.
 - Word count = `text.trim().split(/\s+/).filter(Boolean).length`. Byte size = `file.size` for files, `new Blob([text]).size` for paste. These are computed client-side for preview; the server may recompute its own canonical value.
 - The view never imports `mockXxx`/`realXxx` directly — it goes through `api.uploadManuscript` only (see `23-mock-toggle.md`).
 - On successful upload, dispatches `manuscriptUploaded({ bookId, manuscriptId })` which transitions stage `'upload' → 'analysing'` (guarded by `ui-slice.ts:61-64`).

--- a/docs/features/02-upload-paste-or-file.md
+++ b/docs/features/02-upload-paste-or-file.md
@@ -9,7 +9,7 @@
 
 The upload screen accepts either inline pasted text or a binary file drop (`.md/.markdown/.txt/.text/.epub/.pdf/.mobi/.azw3`). Format is inferred from filename extension; word count and byte size are computed locally for previewing. On submit, the server stores the manuscript and the app transitions to the analysing stage.
 
-MOBI / AZW3 parsing is owned by [`52-mobi-parsing.md`](52-mobi-parsing.md) — that
+MOBI / AZW3 parsing is owned by [`52-mobi-parsing.md`](archive/52-mobi-parsing.md) — that
 plan covers the parser module, DRM detection, and the extension-preserving
 persist path. This plan owns the upload UI surface only.
 

--- a/docs/features/52-mobi-parsing.md
+++ b/docs/features/52-mobi-parsing.md
@@ -1,0 +1,164 @@
+---
+status: active
+shipped: null
+owner: null
+---
+
+# MOBI / AZW3 manuscript upload support
+
+> Status: active
+> Key files: `server/src/parsers/mobi.ts`, `server/src/parsers/html-utils.ts`,
+> `server/src/parsers/index.ts`, `server/src/routes/import.ts`,
+> `src/views/upload.tsx`, `src/lib/api.ts`, `openapi.yaml`
+> URL surface: `#/new` (no new routes)
+> OpenAPI ops: `POST /api/import`, `POST /api/books` (existing; format enum extended)
+
+## Benefit / Rationale
+
+- **User:** Kindle / Calibre users can drop `.mobi` and `.azw3` files straight
+  into the upload screen. Previously they had to round-trip through Calibre
+  → EPUB conversion before the analyzer could see the manuscript. One less
+  manual step in the onboarding flow.
+- **Technical:** Adds `@lingo-reader/mobi-parser` (handles both legacy MOBI
+  / PalmDOC and KF8 / AZW3) and a small DRM detector so Kindle-Store
+  purchases are rejected up-front with an actionable error message rather
+  than producing an opaque parse failure deep inside the library.
+- **Architectural:** Hoists `stripHtml` / `extractFirstHeading` /
+  `GENERIC_NCX_RE` out of `epub.ts` into a shared `html-utils.ts` module
+  so EPUB and MOBI use the same chapter-body normalisation and title-
+  fallback logic. Reduces duplicate regex maintenance going forward.
+
+## Architectural impact
+
+- **New parser module.** `server/src/parsers/mobi.ts` mirrors the EPUB
+  parser shape (spine → HTML → stripHtml + audio tags → `ChapterHint[]`).
+  Dispatch via `server/src/parsers/index.ts` `EXT_TO_FORMAT` — same
+  extension-driven pattern already used by EPUB / PDF / markdown.
+- **DRM detection runs BEFORE the library is invoked.** The PalmDOC
+  encryption byte is read from the buffer directly (no library dep, no
+  parse round-trip). `DrmProtectedError` is exported from
+  `parsers/index.ts` and mapped to HTTP 415 with
+  `{ error: 'drm_protected', message }` body in
+  `server/src/routes/import.ts:144`.
+- **Original extension preserved on persist.** A `.azw3` upload writes
+  to `manuscript.azw3` (not `manuscript.mobi`) so re-parse at hydrate
+  time routes to `initKf8File` instead of `initMobiFile`. Logic at
+  `server/src/routes/import.ts:208` switches on
+  `entry.originalFileName` when format is `'mobi'`.
+- **OpenAPI contract extended.** `ImportCandidate.format` and
+  `UploadResponse.format` enums gain `mobi` (`.azw3` shares the `mobi`
+  format value but persists with its own extension; the wire shape only
+  cares about parser identity, not on-disk file type).
+- **HTML-utils refactor.** `server/src/parsers/html-utils.ts` is the new
+  shared home for `stripHtml`, `extractFirstHeading`, and
+  `GENERIC_NCX_RE`. `epub.ts` imports them; `mobi.ts` imports them. This
+  is a touch-shared-file refactor — no behaviour change in the EPUB
+  path, locked by the existing `epub.test.ts` suite (14 cases).
+
+## Invariants to preserve
+
+- **DRM rejection is library-independent.** The encryption byte at
+  PalmDOC header offset `0x0C` must be checked from the raw buffer
+  before any `initMobiFile` / `initKf8File` call. Detector lives in
+  `server/src/parsers/mobi.ts` (`readMobiEncryptionType`). Non-zero
+  values throw `DrmProtectedError` (`server/src/parsers/mobi.ts`).
+- **`.azw3` routes to KF8.** `server/src/parsers/mobi.ts` selects
+  `initKf8File` when the filename extension is `.azw3`, otherwise
+  `initMobiFile`. This decision happens AFTER the DRM check.
+- **Original bytes persisted verbatim.** Same regression as EPUB
+  (`server/src/routes/import.test.ts` "binary preservation"). Uploaded
+  MOBI/AZW3 bytes must round-trip byte-for-byte to
+  `manuscript.<ext>`.
+- **Format enum sync.** `ManuscriptFormat` in
+  `server/src/store/manuscripts.ts:12`, `EXT_TO_FORMAT` value type in
+  `server/src/parsers/index.ts:11`, `EXT_BY_FORMAT` keys in
+  `server/src/routes/import.ts:44`, the `format` enum in
+  `openapi.yaml:1497` / `:1575`, and the `inferFormat` map in
+  `src/lib/api.ts:65` all carry `'mobi'`. Any new format must touch all
+  five.
+
+## Test plan
+
+### Automated coverage
+
+- **Vitest server (`server/src/parsers/mobi.test.ts`) — 19 cases:**
+  - DRM guard: encryption byte 1 / 2 throws `DrmProtectedError`; library
+    is never invoked on the DRM path; encryption byte 0 proceeds.
+  - Ext routing: `.mobi` → `initMobiFile`, `.azw3` → `initKf8File`,
+    missing fileName falls back to `initMobiFile`.
+  - Metadata: format `'mobi'`; library title wins over filename
+    fallback; filename `Author - Series N - Title.mobi` populates
+    author/series/seriesPosition/title; first author from author[]
+    array.
+  - Chapters: spine → chapter mapping; HTML stripping preserves visible
+    text; `<em>` → `[emphatic]` audio tag; TOC labels as titles;
+    generic TOC + descriptive `<h1>` merges to "Chapter 1 — Title";
+    "Chapter N" fallback when neither TOC nor body heading present;
+    empty-HTML spine entries skipped; throws when no chapter has body.
+- **Vitest server (`server/src/routes/import.test.ts`) — 1 new case:**
+  - `POST /api/import` with a hand-crafted DRM-flagged MOBI buffer →
+    HTTP 415, body `{ error: 'drm_protected', message: /DRM-protected/ }`.
+- **Vitest server (`server/src/parsers/epub.test.ts`) — unchanged.**
+  Locks the html-utils refactor — same 14 cases pass after the move.
+- **Frontend (`src/lib/api.ts`):** `inferFormat` is covered indirectly
+  by the upload-flow snapshot tests; no new unit test specifically for
+  the extension map is added (matches the existing pattern — there is
+  no `inferFormat.test.ts` today).
+- **E2E:** no Playwright spec added in this plan. Upload flow already
+  lacks a dedicated e2e (covered indirectly by the canonical
+  manuscript run). A future "E2E for upload flow including binary
+  formats" item belongs on the BACKLOG, not this plan.
+
+### Manual acceptance walkthrough
+
+Run with the real server (`cd server && npm run dev`) and frontend
+(`npm run dev`), not mocks — mocks bypass the parser entirely.
+
+1. **Download a public-domain MOBI fixture.** Project Gutenberg #1342
+   (*Pride and Prejudice*) is a good choice — ~600 KB, 61 chapters,
+   well-formed metadata. Direct URL pattern:
+   `https://www.gutenberg.org/cache/epub/1342/pg1342.epub` (PG no longer
+   ships .mobi directly; use Calibre `ebook-convert pg1342.epub
+   pg1342.mobi` to produce one). Same trick for AZW3:
+   `ebook-convert pg1342.epub pg1342.azw3`.
+2. **Drop the `.mobi`** on `#/new`. Expect: spinner → confirm-metadata
+   screen showing title "Pride and Prejudice", author "Jane Austen",
+   and 60+ chapters detected (PG MOBIs include a TOC-derived chapter
+   tree).
+3. **Click Confirm.** Expect: HTTP 201, stage transitions to
+   `analysing`. Inspect `workspace/books/Jane Austen/Pride and
+   Prejudice/manuscript.mobi` — bytes match the original MOBI
+   (SHA-256-equal).
+4. **Repeat with the `.azw3`.** Expect: same flow, persists to
+   `manuscript.azw3` (extension preserved), chapter list may differ
+   slightly because KF8 has its own spine structure.
+5. **DRM negative path.** Try uploading a real Kindle-Store-purchased
+   `.azw` file if one is available. Expect: HTTP 415 surfaced to the UI
+   as "This file is DRM-protected (likely a Kindle Store purchase).
+   Convert it with Calibre to a non-DRM format first…". The upload
+   screen stays interactive and the file input is cleared.
+6. **Unsupported-extension negative path.** Drop a `.docx`. Expect: the
+   client-side error "DOCX files aren't supported. Try .md, .txt,
+   .pdf, .epub, .mobi, or .azw3."
+
+## Out of scope
+
+- **`.azw` (pre-KF8 Kindle, pre-2012):** Same parser family but rare in
+  real-world libraries. Can be added as a one-line `EXT_TO_FORMAT`
+  extension if a user surfaces a need.
+- **`.kfx` (Kindle's newest format, post-2015):** No Node library
+  exists. Calibre needs a paid plugin for KFX itself. Permanently out
+  of scope.
+- **DRM removal:** Illegal under DMCA, not engineering work. The DRM
+  detector explicitly tells the user to convert with Calibre instead.
+- **Cover-image extraction:** MOBI carries a cover thumbnail at a
+  record offset, but the post-import cover-fetch already uses Open
+  Library / Google Books for covers (`server/src/cover/openlibrary.ts`).
+  Skipping MOBI cover extraction is not a regression.
+- **E2E for the binary-upload flow:** Backlog candidate. None of the
+  existing binary formats (EPUB / PDF) has dedicated e2e coverage
+  today; MOBI doesn't need to be the exception that sets a new bar.
+
+## Ship notes
+
+(Filled in when status flips to `stable`.)

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -43,7 +43,6 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 
 - [02 — Upload (paste or file)](02-upload-paste-or-file.md) — `.md/.txt/.epub/.pdf/.mobi/.azw3` upload + paste flow.
 - [03 — Import & confirm metadata](03-import-confirm-metadata.md) — Parse-only import then confirm-write to disk.
-- [52 — MOBI / AZW3 parsing](52-mobi-parsing.md) — Kindle / Calibre format parser + DRM detection.
 
 ### C. Analysis pipeline
 
@@ -150,3 +149,4 @@ breadcrumb so cross-references still resolve.
 - [20 — Revisions & drift](archive/20-revisions-and-drift.md) — Pending drafts + drift events + a/b audio audition (rollback-preserved previous audio) + stale-audio banner on voice edits. Close-out adds startup fsck for half-preserved rollback pairs + mid-flight Reject toast. Shipped 2026-05-18.
 - [18 — Listen view](archive/18-listen-view.md) — Cover, chapter list, mini-player, metadata editor, listener-app tiles (5 of 7 live via export modal), export queue, cover Replace/Regenerate. Plan 18a slice + 18b correction shipped 2026-05-18; remaining gaps tracked as BACKLOG Could #31/#32/#33/#34/#35.
 - [51 — Chapter restructure panel](archive/51-restructure-chapters.md) — Three-way structural edit surface (merge / split / drag-reorder) at ready-stage `view: 'restructure'`. Pure-remap semantics preserve sentence text + characterId + voice assignment; content-changed chapters' audio is deleted, renumbered-only chapters' audio is renamed in place (two-pass via temp + segments.json metadata rewrite). Shipped 2026-05-18.
+- [52 — MOBI / AZW3 parsing](archive/52-mobi-parsing.md) — `.mobi` + `.azw3` upload via `@lingo-reader/mobi-parser`; KF8 routes through `initKf8File`, legacy MOBI through `initMobiFile`; DRM-protected files rejected up-front with HTTP 415 by reading the PalmDOC encryption byte; original `.azw3` extension preserved on persist; `stripHtml` / `extractFirstHeading` / `GENERIC_NCX_RE` hoisted from `epub.ts` into shared `html-utils.ts`. Shipped 2026-05-18.

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -41,8 +41,9 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 
 ### B. Upload & import
 
-- [02 — Upload (paste or file)](02-upload-paste-or-file.md) — `.md/.txt/.epub/.pdf` upload + paste flow.
+- [02 — Upload (paste or file)](02-upload-paste-or-file.md) — `.md/.txt/.epub/.pdf/.mobi/.azw3` upload + paste flow.
 - [03 — Import & confirm metadata](03-import-confirm-metadata.md) — Parse-only import then confirm-write to disk.
+- [52 — MOBI / AZW3 parsing](52-mobi-parsing.md) — Kindle / Calibre format parser + DRM detection.
 
 ### C. Analysis pipeline
 

--- a/docs/features/archive/52-mobi-parsing.md
+++ b/docs/features/archive/52-mobi-parsing.md
@@ -1,12 +1,12 @@
 ---
-status: active
-shipped: null
+status: stable
+shipped: 2026-05-18
 owner: null
 ---
 
 # MOBI / AZW3 manuscript upload support
 
-> Status: active
+> Status: stable
 > Key files: `server/src/parsers/mobi.ts`, `server/src/parsers/html-utils.ts`,
 > `server/src/parsers/index.ts`, `server/src/routes/import.ts`,
 > `src/views/upload.tsx`, `src/lib/api.ts`, `openapi.yaml`
@@ -161,4 +161,21 @@ Run with the real server (`cd server && npm run dev`) and frontend
 
 ## Ship notes
 
-(Filled in when status flips to `stable`.)
+**Shipped 2026-05-18** in commit `64c42e4` (`feat(server,frontend,docs): plan 52 — MOBI/AZW3 upload support`), branch `feat/server+frontend-plan-52-mobi-support`, PR [#26](https://github.com/dudarenok-maker/AudioBook-Generator/pull/26).
+
+**Spec deltas vs. the original plan write-up:**
+
+- **Binary fixtures dropped.** The original plan called for a `sample.mobi` / `sample.azw3` / `sample-drm.mobi` checked into `server/src/parsers/__fixtures__/`. Mirrored the `pdf.test.ts` pattern instead — mock `@lingo-reader/mobi-parser` so the wrapper logic is exercised in isolation, and hand-craft DRM-flagged buffers inline. End-to-end MOBI parsing against a real Project Gutenberg file is the manual verification step + the deferred [BACKLOG #38 e2e item](../BACKLOG.md), not unit-test scope.
+- **Original-extension preservation moved into the route layer.** `server/src/routes/import.ts:208-216` now switches `manuscript.<ext>` on `entry.originalFileName` when `format === 'mobi'`, so `.azw3` files round-trip as `manuscript.azw3` and re-parse correctly through `initKf8File`. The plan had flagged this as a parser concern; landed it in the route instead because the parser is extension-agnostic by design.
+- **OpenAPI `format` enum extended in both `ImportCandidate` and `UploadResponse`.** The original plan only mentioned `ImportCandidate`; `UploadResponse` needed the same enum extension for `inferFormat`'s typed return to flow through `UploadResponse['format']`.
+
+**Follow-ups landed as BACKLOG entries:**
+
+- [Could #38 — E2E coverage for the binary-upload flow](../BACKLOG.md). Covers EPUB / PDF / MOBI / AZW3 in a single Playwright spec; depends on this plan shipping.
+
+**Out-of-scope items NOT promoted to backlog** (documented for future-you so a hallway question doesn't re-litigate):
+
+- `.azw` / `.azw1` (pre-KF8 Kindle): rare in real-world libraries; one-line `EXT_TO_FORMAT` extension if a user surfaces a need.
+- `.kfx` (Kindle's newest format): no Node library exists. Permanently parked.
+- DRM removal: illegal under DMCA.
+- MOBI cover-image extraction: post-import cover-fetch already uses Open Library / Google Books.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1494,7 +1494,7 @@ components:
       type: object
       required: [format, title, sourceText, wordCount, byteSize, chapters]
       properties:
-        format: { type: string, enum: [markdown, plaintext, epub, pdf] }
+        format: { type: string, enum: [markdown, plaintext, epub, pdf, mobi] }
         title: { type: string }
         author: { type: string, nullable: true }
         series: { type: string, nullable: true }
@@ -1572,7 +1572,7 @@ components:
       required: [manuscriptId, format, title, wordCount, byteSize, uploadedAt, sourceText]
       properties:
         manuscriptId: { type: string, example: 'mns_abc123' }
-        format: { type: string, enum: [markdown, plaintext, epub, pdf] }
+        format: { type: string, enum: [markdown, plaintext, epub, pdf, mobi] }
         title: { type: string }
         wordCount: { type: integer }
         byteSize: { type: integer }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.0",
       "dependencies": {
         "@google/genai": "^2.0.1",
+        "@lingo-reader/mobi-parser": "^0.4.6",
         "@types/yazl": "^3.3.1",
         "epub2": "^3.0.2",
         "express": "^4.19.2",
@@ -1028,6 +1029,27 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@lingo-reader/mobi-parser": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@lingo-reader/mobi-parser/-/mobi-parser-0.4.6.tgz",
+      "integrity": "sha512-/TDhO4IuKI04Ci5Bg8294GBhg5tnYzRM+RDlZQFE4HW2hvQHYb03dObZsOIE5gg7huwRovxpso/sWTWoZVHD7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lingo-reader/shared": "^0.4.6",
+        "fflate": "^0.8.2"
+      }
+    },
+    "node_modules/@lingo-reader/shared": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@lingo-reader/shared/-/shared-0.4.6.tgz",
+      "integrity": "sha512-h3PhmidyYabbO5k74H9bUkMJS9Zy2YqCTod8ssZ+/oQ48+/hhS3KSqOkwQks2hrDY7nHqjniNysvzJzukedEkA==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.3.0",
+        "path-browserify": "^1.0.1",
+        "sax": "^1.4.1"
+      }
     },
     "node_modules/@napi-rs/canvas": {
       "version": "0.1.100",
@@ -2680,6 +2702,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2771,6 +2802,12 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/finalhandler": {
       "version": "1.3.2",
@@ -3433,6 +3470,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.13",

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@google/genai": "^2.0.1",
+    "@lingo-reader/mobi-parser": "^0.4.6",
     "@types/yazl": "^3.3.1",
     "epub2": "^3.0.2",
     "express": "^4.19.2",

--- a/server/src/parsers/epub.ts
+++ b/server/src/parsers/epub.ts
@@ -8,58 +8,8 @@ import { join } from 'node:path';
 import type { ChapterHint } from '../store/manuscripts.js';
 import type { ParsedManuscript } from './text.js';
 import { parseFilenameMetadata } from './text.js';
-import {
-  tagExcitedDialog,
-  tagHesitantDialog,
-  tagHtmlEmphasis,
-  tagShoutingDialog,
-} from './audio-tags.js';
-
-function stripHtml(html: string): string {
-  return tagHtmlEmphasis(html)
-    .replace(/<\s*br\s*\/?>/gi, '\n')
-    .replace(/<\/p>/gi, '\n\n')
-    .replace(/<[^>]+>/g, '')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/[ \t]+\n/g, '\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
-}
-
-/* Pull the first h1/h2/h3 text from chapter HTML so we have a fallback
-   when the NCX entry's title is missing or generic. Strips inline tags
-   (`<em>`, `<strong>`, `<span>`) from the heading text and collapses
-   whitespace. Returns null when no heading is present in the first ~8 KB
-   of the document. */
-const FIRST_HEADING_RE = /<h[1-3][^>]*>([\s\S]{0,400}?)<\/h[1-3]>/i;
-function extractFirstHeading(html: string): string | null {
-  const m = FIRST_HEADING_RE.exec(html);
-  if (!m) return null;
-  const raw = m[1]
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/\s+/g, ' ')
-    .trim();
-  if (raw.length === 0 || raw.length > 200) return null;
-  return raw;
-}
-
-/* "Chapter 1" / "Chapter IV" / "Chapter Twelve" with nothing else.
-   Used to detect generic NCX titles that should be augmented with the
-   body's <h1>. Mirrors the bare-numbered-heading test in text.ts but
-   self-contained here to keep the parsers loosely coupled. */
-const GENERIC_NCX_RE =
-  /^chapter\s+(?:[ivxlcdm\d]+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety|hundred)(?:[-\s](?:one|two|three|four|five|six|seven|eight|nine))?\s*$/i;
+import { tagExcitedDialog, tagHesitantDialog, tagShoutingDialog } from './audio-tags.js';
+import { stripHtml, extractFirstHeading, GENERIC_NCX_RE } from './html-utils.js';
 
 export async function parseEpub(
   buffer: Buffer,

--- a/server/src/parsers/html-utils.ts
+++ b/server/src/parsers/html-utils.ts
@@ -1,0 +1,55 @@
+/* Shared HTML helpers for the EPUB and MOBI parsers. Both formats expose
+   chapter bodies as HTML strings, so the strip / heading-extract / generic-
+   chapter-label logic is identical between them. */
+
+import { tagHtmlEmphasis } from './audio-tags.js';
+
+/* Strip HTML tags from a chapter body, decode common entities, and convert
+   block-level breaks to plain-text newlines. Folds `<em>/<i>/<strong>` into
+   `[emphasis]…[/emphasis]` tags via tagHtmlEmphasis before stripping so the
+   audio-tag information survives the strip. */
+export function stripHtml(html: string): string {
+  return tagHtmlEmphasis(html)
+    .replace(/<\s*br\s*\/?>/gi, '\n')
+    .replace(/<\/p>/gi, '\n\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/* Pull the first h1/h2/h3 text from chapter HTML so we have a fallback
+   when the NCX / spine title is missing or generic. Strips inline tags
+   (`<em>`, `<strong>`, `<span>`) from the heading text and collapses
+   whitespace. Returns null when no heading is present in the first ~8 KB
+   of the document. */
+const FIRST_HEADING_RE = /<h[1-3][^>]*>([\s\S]{0,400}?)<\/h[1-3]>/i;
+export function extractFirstHeading(html: string): string | null {
+  const m = FIRST_HEADING_RE.exec(html);
+  if (!m) return null;
+  const raw = m[1]
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (raw.length === 0 || raw.length > 200) return null;
+  return raw;
+}
+
+/* "Chapter 1" / "Chapter IV" / "Chapter Twelve" with nothing else.
+   Used to detect generic NCX titles that should be augmented with the
+   body's <h1>. Mirrors the bare-numbered-heading test in text.ts but
+   self-contained here to keep the parsers loosely coupled. */
+export const GENERIC_NCX_RE =
+  /^chapter\s+(?:[ivxlcdm\d]+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety|hundred)(?:[-\s](?:one|two|three|four|five|six|seven|eight|nine))?\s*$/i;

--- a/server/src/parsers/index.ts
+++ b/server/src/parsers/index.ts
@@ -5,16 +5,20 @@
 import { parseText, type ParsedManuscript } from './text.js';
 import { parsePdf } from './pdf.js';
 import { parseEpub } from './epub.js';
+import { parseMobi } from './mobi.js';
 
 export type { ParsedManuscript };
+export { DrmProtectedError } from './mobi.js';
 
-const EXT_TO_FORMAT: Record<string, 'markdown' | 'plaintext' | 'pdf' | 'epub'> = {
+const EXT_TO_FORMAT: Record<string, 'markdown' | 'plaintext' | 'pdf' | 'epub' | 'mobi'> = {
   md: 'markdown',
   markdown: 'markdown',
   txt: 'plaintext',
   text: 'plaintext',
   pdf: 'pdf',
   epub: 'epub',
+  mobi: 'mobi',
+  azw3: 'mobi',
 };
 
 function extOf(fileName?: string): string | null {
@@ -52,6 +56,13 @@ export async function parseManuscript(input: {
   }
   if (format === 'epub' || input.mimeType === 'application/epub+zip') {
     return parseEpub(input.buffer, { fileName: input.fileName, sourcePath: input.sourcePath });
+  }
+  if (
+    format === 'mobi' ||
+    input.mimeType === 'application/x-mobipocket-ebook' ||
+    input.mimeType === 'application/vnd.amazon.ebook'
+  ) {
+    return parseMobi(input.buffer, { fileName: input.fileName });
   }
   if (format === 'markdown' || format === 'plaintext') {
     return parseText(input.buffer.toString('utf8'), { fileName: input.fileName, format });

--- a/server/src/parsers/mobi.test.ts
+++ b/server/src/parsers/mobi.test.ts
@@ -1,0 +1,262 @@
+// Pairs with docs/features/52-mobi-parsing.md.
+//
+// parseMobi wraps @lingo-reader/mobi-parser. Following the pdf.test.ts
+// pattern, the upstream library is mocked so each case exercises a
+// specific contract — DRM detection, AZW3 ext routing, TOC label
+// resolution, metadata precedence, audio-tag enrichment. End-to-end
+// MOBI parsing against a real Project Gutenberg file is the manual
+// verification step in plan 52; see "Verification" there.
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+let lastInitMobiCalledWith: { data: Uint8Array; resourceDir: string } | null = null;
+let lastInitKf8CalledWith: { data: Uint8Array; resourceDir: string } | null = null;
+
+interface MockMetadata {
+  title?: string;
+  author?: string[];
+  publisher?: string;
+}
+interface MockTocItem {
+  label: string;
+  href: string;
+  children?: MockTocItem[];
+}
+interface MockChapter {
+  id: string;
+  html: string;
+}
+
+let metadataMock: MockMetadata = {};
+let tocMock: MockTocItem[] = [];
+let chaptersMock: MockChapter[] = [];
+
+function makeMockParser() {
+  return {
+    getMetadata: () => metadataMock,
+    getToc: () => tocMock,
+    getSpine: () => chaptersMock.map((c) => ({ id: c.id })),
+    loadChapter: (id: string) => {
+      const found = chaptersMock.find((c) => c.id === id);
+      return found ? { html: found.html, css: [] } : undefined;
+    },
+    destroy: () => undefined,
+  };
+}
+
+vi.mock('@lingo-reader/mobi-parser', () => ({
+  initMobiFile: async (data: Uint8Array, resourceDir: string) => {
+    lastInitMobiCalledWith = { data, resourceDir };
+    return makeMockParser();
+  },
+  initKf8File: async (data: Uint8Array, resourceDir: string) => {
+    lastInitKf8CalledWith = { data, resourceDir };
+    return makeMockParser();
+  },
+}));
+
+import { parseMobi, DrmProtectedError } from './mobi.js';
+
+/* Build a minimal MOBI-shaped Buffer with a controllable encryption byte
+   at the PalmDOC header position. PDB header is 78 bytes; record 0
+   offset is at byte 78 (u32 BE); encryption type sits at record0Offset +
+   0x0C (u16 BE). We pad to 256 bytes so reads don't fall off the end.
+   Used by the DRM tests below — no real MOBI parsing happens because
+   the library is mocked, but readMobiEncryptionType runs against the
+   buffer bytes before the mock is reached. */
+function mobiBufferWithEncryption(encType: number): Buffer {
+  const buf = Buffer.alloc(256, 0);
+  /* Record 0 starts at offset 96 (arbitrary but past the PDB header). */
+  const record0 = 96;
+  buf.writeUInt32BE(record0, 78);
+  buf.writeUInt16BE(encType, record0 + 0x0c);
+  return buf;
+}
+
+beforeEach(() => {
+  lastInitMobiCalledWith = null;
+  lastInitKf8CalledWith = null;
+  metadataMock = {};
+  tocMock = [];
+  chaptersMock = [];
+});
+
+describe('parseMobi — DRM guard', () => {
+  it('throws DrmProtectedError when encryption byte is 1 (old Mobipocket DRM)', async () => {
+    const buf = mobiBufferWithEncryption(1);
+    await expect(parseMobi(buf, { fileName: 'book.mobi' })).rejects.toBeInstanceOf(
+      DrmProtectedError,
+    );
+  });
+
+  it('throws DrmProtectedError when encryption byte is 2 (Kindle Store DRM)', async () => {
+    const buf = mobiBufferWithEncryption(2);
+    await expect(parseMobi(buf, { fileName: 'book.mobi' })).rejects.toThrow(/DRM-protected/);
+  });
+
+  it('does not invoke the library when DRM is detected', async () => {
+    const buf = mobiBufferWithEncryption(2);
+    chaptersMock = [{ id: 'c1', html: '<p>Body</p>' }];
+    await expect(parseMobi(buf, { fileName: 'book.mobi' })).rejects.toBeInstanceOf(
+      DrmProtectedError,
+    );
+    expect(lastInitMobiCalledWith).toBeNull();
+    expect(lastInitKf8CalledWith).toBeNull();
+  });
+
+  it('proceeds when encryption byte is 0 (no DRM)', async () => {
+    const buf = mobiBufferWithEncryption(0);
+    chaptersMock = [{ id: 'c1', html: '<p>Hello world.</p>' }];
+    const out = await parseMobi(buf, { fileName: 'book.mobi' });
+    expect(out.format).toBe('mobi');
+    expect(out.chapters).toHaveLength(1);
+  });
+});
+
+describe('parseMobi — ext routing', () => {
+  it('uses initMobiFile for .mobi files', async () => {
+    const buf = mobiBufferWithEncryption(0);
+    chaptersMock = [{ id: 'c1', html: '<p>x</p>' }];
+    await parseMobi(buf, { fileName: 'book.mobi' });
+    expect(lastInitMobiCalledWith).not.toBeNull();
+    expect(lastInitKf8CalledWith).toBeNull();
+  });
+
+  it('uses initKf8File for .azw3 files', async () => {
+    const buf = mobiBufferWithEncryption(0);
+    chaptersMock = [{ id: 'c1', html: '<p>x</p>' }];
+    await parseMobi(buf, { fileName: 'book.azw3' });
+    expect(lastInitKf8CalledWith).not.toBeNull();
+    expect(lastInitMobiCalledWith).toBeNull();
+  });
+
+  it('falls back to initMobiFile when no filename is supplied', async () => {
+    const buf = mobiBufferWithEncryption(0);
+    chaptersMock = [{ id: 'c1', html: '<p>x</p>' }];
+    await parseMobi(buf, {});
+    expect(lastInitMobiCalledWith).not.toBeNull();
+  });
+});
+
+describe('parseMobi — metadata', () => {
+  it('returns format: "mobi"', async () => {
+    const buf = mobiBufferWithEncryption(0);
+    chaptersMock = [{ id: 'c1', html: '<p>body</p>' }];
+    const out = await parseMobi(buf, { fileName: 'book.mobi' });
+    expect(out.format).toBe('mobi');
+  });
+
+  it('uses the library metadata title when present', async () => {
+    const buf = mobiBufferWithEncryption(0);
+    metadataMock = { title: 'The Real Title' };
+    chaptersMock = [{ id: 'c1', html: '<p>body</p>' }];
+    const out = await parseMobi(buf, { fileName: 'whatever.mobi' });
+    expect(out.title).toBe('The Real Title');
+  });
+
+  it('falls back to filename-derived metadata when library has no title', async () => {
+    const buf = mobiBufferWithEncryption(0);
+    chaptersMock = [{ id: 'c1', html: '<p>body</p>' }];
+    /* FILENAME_RE in text.ts expects `Author - Series N - Title` (space-N-
+       space, not `#N`); see server/src/parsers/text.ts:139. */
+    const out = await parseMobi(buf, {
+      fileName: 'Tolkien - Lord of the Rings 2 - The Two Towers.mobi',
+    });
+    expect(out.title).toBe('The Two Towers');
+    expect(out.author).toBe('Tolkien');
+    expect(out.series).toBe('Lord of the Rings');
+    expect(out.seriesPosition).toBe(2);
+  });
+
+  it('exposes the first author from the metadata author array', async () => {
+    const buf = mobiBufferWithEncryption(0);
+    metadataMock = { title: 'X', author: ['Jane Doe', 'Co Author'] };
+    chaptersMock = [{ id: 'c1', html: '<p>body</p>' }];
+    const out = await parseMobi(buf, { fileName: 'x.mobi' });
+    expect(out.author).toBe('Jane Doe');
+  });
+});
+
+describe('parseMobi — chapters', () => {
+  it('turns each spine entry into a chapter', async () => {
+    const buf = mobiBufferWithEncryption(0);
+    chaptersMock = [
+      { id: 'c1', html: '<p>First chapter body.</p>' },
+      { id: 'c2', html: '<p>Second chapter body.</p>' },
+    ];
+    const out = await parseMobi(buf, { fileName: 'x.mobi' });
+    expect(out.chapters).toHaveLength(2);
+  });
+
+  it('strips HTML tags but keeps visible text', async () => {
+    const buf = mobiBufferWithEncryption(0);
+    chaptersMock = [{ id: 'c1', html: '<p>The tower stood at the edge of the world.</p>' }];
+    const out = await parseMobi(buf, { fileName: 'x.mobi' });
+    const body = out.chapters[0].body;
+    expect(body).toContain('The tower stood at the edge of the world.');
+    expect(body).not.toContain('<p>');
+  });
+
+  it('converts <em> emphasis into [emphatic] audio tags', async () => {
+    /* The audio-tag vocabulary uses [emphatic] (not [emphasis]) — see
+       server/src/parsers/audio-tags.ts:7. tagHtmlEmphasis emits
+       `[emphatic] <body>` form (lead tag, no closing tag). */
+    const buf = mobiBufferWithEncryption(0);
+    chaptersMock = [{ id: 'c1', html: '<p>She was <em>very</em> tired.</p>' }];
+    const out = await parseMobi(buf, { fileName: 'x.mobi' });
+    expect(out.chapters[0].body).toMatch(/\[emphatic\]\s+very/);
+  });
+
+  it('uses TOC labels as chapter titles when present', async () => {
+    const buf = mobiBufferWithEncryption(0);
+    tocMock = [
+      { label: 'The Berth at Liverpool', href: 'c1' },
+      { label: 'Storm at Sea', href: 'c2' },
+    ];
+    chaptersMock = [
+      { id: 'c1', html: '<p>body 1</p>' },
+      { id: 'c2', html: '<p>body 2</p>' },
+    ];
+    const out = await parseMobi(buf, { fileName: 'x.mobi' });
+    expect(out.chapters.map((c) => c.title)).toEqual([
+      'The Berth at Liverpool',
+      'Storm at Sea',
+    ]);
+  });
+
+  it('merges generic TOC label with body <h1> when the heading is descriptive', async () => {
+    const buf = mobiBufferWithEncryption(0);
+    tocMock = [{ label: 'Chapter 1', href: 'c1' }];
+    chaptersMock = [
+      { id: 'c1', html: '<h1>The Berth at Liverpool</h1><p>body</p>' },
+    ];
+    const out = await parseMobi(buf, { fileName: 'x.mobi' });
+    expect(out.chapters[0].title).toBe('Chapter 1 — The Berth at Liverpool');
+  });
+
+  it('falls back to "Chapter N" when neither TOC nor body heading is present', async () => {
+    const buf = mobiBufferWithEncryption(0);
+    chaptersMock = [{ id: 'c1', html: '<p>bare body</p>' }];
+    const out = await parseMobi(buf, { fileName: 'x.mobi' });
+    expect(out.chapters[0].title).toBe('Chapter 1');
+  });
+
+  it('skips spine entries with empty HTML', async () => {
+    const buf = mobiBufferWithEncryption(0);
+    chaptersMock = [
+      { id: 'c1', html: '' },
+      { id: 'c2', html: '<p>real body</p>' },
+    ];
+    const out = await parseMobi(buf, { fileName: 'x.mobi' });
+    expect(out.chapters).toHaveLength(1);
+    expect(out.chapters[0].body).toContain('real body');
+  });
+
+  it('throws when the spine yields no extractable text', async () => {
+    const buf = mobiBufferWithEncryption(0);
+    chaptersMock = [{ id: 'c1', html: '' }];
+    await expect(parseMobi(buf, { fileName: 'x.mobi' })).rejects.toThrow(
+      /no extractable text/i,
+    );
+  });
+});

--- a/server/src/parsers/mobi.test.ts
+++ b/server/src/parsers/mobi.test.ts
@@ -1,4 +1,4 @@
-// Pairs with docs/features/52-mobi-parsing.md.
+// Pairs with docs/features/archive/52-mobi-parsing.md.
 //
 // parseMobi wraps @lingo-reader/mobi-parser. Following the pdf.test.ts
 // pattern, the upstream library is mocked so each case exercises a

--- a/server/src/parsers/mobi.ts
+++ b/server/src/parsers/mobi.ts
@@ -1,0 +1,193 @@
+/* MOBI / AZW3 (KF8) parser via @lingo-reader/mobi-parser. Mirrors the EPUB
+   parser shape: spine entries → HTML body → stripHtml + audio tags → ChapterHint[].
+
+   Two file flavors handled:
+   - `.mobi` (legacy Mobipocket / PalmDOC) — `initMobiFile`. Dual-format MOBI
+     files that also contain a KF8 section have their legacy section
+     extracted; the KF8 boundary record is ignored. Text content is usually
+     identical between the two so this is a safe default.
+   - `.azw3` (KF8) — `initKf8File`. The modern Amazon Kindle format.
+
+   DRM detection runs FIRST, before invoking the parser. The PalmDOC header
+   carries an "Encryption Type" byte at offset 0x0C inside the first record
+   payload. Non-zero values (1 = old Mobipocket DRM, 2 = Mobipocket/Kindle
+   DRM, including all Kindle-Store purchases) throw DrmProtectedError which
+   the route layer maps to 415. We cannot legally decrypt these. */
+
+import { initMobiFile, initKf8File } from '@lingo-reader/mobi-parser';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ChapterHint } from '../store/manuscripts.js';
+import type { ParsedManuscript } from './text.js';
+import { parseFilenameMetadata } from './text.js';
+import { tagExcitedDialog, tagHesitantDialog, tagShoutingDialog } from './audio-tags.js';
+import { stripHtml, extractFirstHeading, GENERIC_NCX_RE } from './html-utils.js';
+
+/* Thrown when the MOBI / AZW3 file is DRM-protected. The route layer maps
+   this to HTTP 415 with `{ error: 'drm_protected', message }` body so the
+   frontend can surface a specific "Convert with Calibre first" prompt
+   instead of a generic parse failure. */
+export class DrmProtectedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DrmProtectedError';
+  }
+}
+
+/* Read the PalmDOC encryption byte. PDB header is 78 bytes; record 0
+   offset is at byte 78 (u32 big-endian). Encryption type sits at
+   record0Offset + 0x0C (u16 big-endian).
+
+   Returns 0 (no encryption) on any unexpected shape rather than throwing —
+   the underlying parser will fail with a clearer error if the file is
+   genuinely malformed. We only want this check to FIRE on the specific
+   case of "file is structurally a MOBI but flagged DRM". */
+function readMobiEncryptionType(buffer: Buffer): number {
+  if (buffer.length < 78 + 4 + 0x0E) return 0;
+  const record0Offset = buffer.readUInt32BE(78);
+  if (record0Offset + 0x0E > buffer.length) return 0;
+  return buffer.readUInt16BE(record0Offset + 0x0C);
+}
+
+/* Resolve a chapter id to its TOC label. The library's spine entries
+   carry only an `id` (no title); the TOC carries `label` + `href` where
+   the `href` is the chapter id or a fragment inside it (e.g. `chap1` or
+   `chap1#section`). Walk the TOC recursively and match the leading
+   chapter id segment. */
+interface TocItem {
+  label: string;
+  href: string;
+  children?: TocItem[];
+}
+function buildTocLabelMap(toc: TocItem[]): Map<string, string> {
+  const map = new Map<string, string>();
+  function walk(items: TocItem[]): void {
+    for (const item of items) {
+      if (item.href && item.label) {
+        // Strip any anchor fragment so `chap1#section` maps to `chap1`.
+        const id = item.href.split('#')[0]?.split('/').pop() ?? '';
+        if (id && !map.has(id)) map.set(id, item.label.trim());
+      }
+      if (item.children?.length) walk(item.children);
+    }
+  }
+  walk(toc);
+  return map;
+}
+
+interface MobiLikeParser {
+  getMetadata(): {
+    title?: string;
+    author?: string[];
+    publisher?: string;
+    language?: string;
+    description?: string;
+  };
+  getSpine(): Array<{ id: string }>;
+  getToc(): TocItem[];
+  loadChapter(id: string): { html: string } | undefined;
+  destroy(): void;
+}
+
+export async function parseMobi(
+  buffer: Buffer,
+  opts: { fileName?: string },
+): Promise<ParsedManuscript> {
+  /* DRM guard. Runs before any parser library call so we can surface a
+     specific actionable error message. */
+  const encryption = readMobiEncryptionType(buffer);
+  if (encryption !== 0) {
+    throw new DrmProtectedError(
+      'This file is DRM-protected (likely a Kindle Store purchase). ' +
+        'Convert it with Calibre to a non-DRM format first, or use a different source.',
+    );
+  }
+
+  /* AZW3 extension → KF8 init. Plain .mobi (and unknown extensions that
+     fall through here) → legacy MOBI init. Dual-format .mobi files
+     extract their legacy section, which is fine for our text-only
+     analysis use case. */
+  const ext = opts.fileName?.toLowerCase().match(/\.([a-z0-9]+)$/)?.[1];
+  const useKf8 = ext === 'azw3';
+
+  /* The library writes any extracted image resources to disk. We don't
+     need the images, but we want them landing in a temp dir we can clean
+     up, not in the cwd's `./images`. */
+  const resourceDir = await mkdtemp(join(tmpdir(), 'mobi-resources-'));
+  let parser: MobiLikeParser | null = null;
+  try {
+    const data = new Uint8Array(buffer);
+    parser = (
+      useKf8 ? await initKf8File(data, resourceDir) : await initMobiFile(data, resourceDir)
+    ) as unknown as MobiLikeParser;
+
+    const meta = parser.getMetadata();
+    const headerTitle = (meta.title ?? '').trim();
+    const headerAuthor =
+      Array.isArray(meta.author) && meta.author[0] ? meta.author[0].trim() : null;
+
+    const tocLabels = buildTocLabelMap(parser.getToc() ?? []);
+    const spine = parser.getSpine();
+    const chapters: ChapterHint[] = [];
+
+    for (let i = 0; i < spine.length; i++) {
+      const entry = spine[i];
+      if (!entry?.id) continue;
+      const chapter = parser.loadChapter(entry.id);
+      const html = chapter?.html ?? '';
+      if (!html.trim()) continue;
+      const body = tagHesitantDialog(tagExcitedDialog(tagShoutingDialog(stripHtml(html))));
+      if (!body) continue;
+
+      /* Title resolution mirrors the EPUB parser:
+         - TOC label is the primary source.
+         - Missing TOC entry → use the body's first <h1> as fallback, else
+           "Chapter N".
+         - TOC label generic ("Chapter 1") + body heading descriptive →
+           merge as "Chapter 1 — The Real Title".
+         - Both descriptive or both generic → keep TOC label as-is. */
+      const tocTitle = tocLabels.get(entry.id)?.trim() ?? '';
+      const bodyHeading = extractFirstHeading(html);
+      let chTitle: string;
+      if (!tocTitle) {
+        chTitle = bodyHeading || `Chapter ${chapters.length + 1}`;
+      } else if (
+        GENERIC_NCX_RE.test(tocTitle) &&
+        bodyHeading &&
+        !GENERIC_NCX_RE.test(bodyHeading)
+      ) {
+        chTitle = `${tocTitle} — ${bodyHeading}`;
+      } else {
+        chTitle = tocTitle;
+      }
+      chapters.push({ id: chapters.length + 1, title: chTitle, body });
+    }
+
+    if (chapters.length === 0) {
+      throw new Error('MOBI had no extractable text in its spine.');
+    }
+
+    const sourceText = chapters.map((c) => c.body).join('\n\n');
+    const fileMeta = parseFilenameMetadata(opts.fileName);
+    return {
+      format: 'mobi',
+      title:
+        headerTitle || fileMeta.title || opts.fileName?.replace(/\.[^.]+$/, '') || 'Untitled MOBI',
+      sourceText,
+      chapters,
+      author: headerAuthor || fileMeta.author,
+      series: fileMeta.series,
+      seriesPosition: fileMeta.seriesPosition,
+    };
+  } finally {
+    /* Always destroy the parser instance (frees in-memory blob caches)
+       and clean up the resource temp dir. */
+    try {
+      parser?.destroy();
+    } catch {
+      /* best-effort */
+    }
+    await rm(resourceDir, { recursive: true, force: true });
+  }
+}

--- a/server/src/routes/import.test.ts
+++ b/server/src/routes/import.test.ts
@@ -207,6 +207,31 @@ describe('POST /api/import → POST /api/books — excluded chapters round-trip'
     expect(stateByTitle.get('chapter one')?.excluded).toBeFalsy();
   });
 
+  it('returns 415 with error: "drm_protected" when a MOBI file has the encryption byte set', async () => {
+    /* Hand-crafted MOBI-shaped buffer with encryption byte 2 (Kindle
+       Store DRM). The DRM detector in parseMobi reads bytes 78..82 for
+       the record-0 offset and then the u16 at offset+0x0C; we set those
+       directly and pad the rest with zeros. The library is NEVER
+       invoked on this path — readMobiEncryptionType returns non-zero
+       and parseMobi throws DrmProtectedError before init*File is
+       called. Pairs with the unit tests in mobi.test.ts that pin the
+       detection bytes. */
+    const drmBuffer = Buffer.alloc(256, 0);
+    const record0 = 96;
+    drmBuffer.writeUInt32BE(record0, 78);
+    drmBuffer.writeUInt16BE(2, record0 + 0x0c);
+
+    const importRes = await request(app)
+      .post('/api/import')
+      .attach('file', drmBuffer, {
+        filename: 'drm-protected.mobi',
+        contentType: 'application/x-mobipocket-ebook',
+      });
+    expect(importRes.status).toBe(415);
+    expect(importRes.body.error).toBe('drm_protected');
+    expect(importRes.body.message).toMatch(/DRM-protected/i);
+  });
+
   it('leaves every chapter included when excludedSlugs is absent', async () => {
     const md = '# A Book\n\n## Chapter One\n\nLine one. Line two. Line three.';
     const importRes = await request(app)

--- a/server/src/routes/import.ts
+++ b/server/src/routes/import.ts
@@ -20,7 +20,7 @@ import { nanoid } from 'nanoid';
 import { existsSync } from 'node:fs';
 import { writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import { parseManuscript, UnsupportedFormatError } from '../parsers/index.js';
+import { parseManuscript, UnsupportedFormatError, DrmProtectedError } from '../parsers/index.js';
 import { putManuscript, type ManuscriptRecord, type ChapterHint } from '../store/manuscripts.js';
 import { getStaging, putStaging, dropStaging, type StagedImport } from '../store/import-staging.js';
 import {
@@ -46,6 +46,7 @@ const EXT_BY_FORMAT: Record<ManuscriptRecord['format'], string> = {
   plaintext: 'txt',
   epub: 'epub',
   pdf: 'pdf',
+  mobi: 'mobi',
 };
 
 function deterministicGradient(seed: string): [string, string] {
@@ -141,6 +142,9 @@ importRouter.post('/import', upload.single('file'), async (req: Request, res: Re
       },
     });
   } catch (e) {
+    if (e instanceof DrmProtectedError) {
+      return res.status(415).json({ error: 'drm_protected', message: e.message });
+    }
     if (e instanceof UnsupportedFormatError) {
       return res.status(415).json({ error: e.message });
     }
@@ -201,7 +205,14 @@ importRouter.post('/books', async (req: Request, res: Response) => {
 
     const manuscriptId = 'mns_' + nanoid(10);
     const bookId = makeBookId(author, series, title);
-    const manuscriptFile = `manuscript.${EXT_BY_FORMAT[entry.format]}`;
+    /* MOBI and AZW3 share the same ManuscriptFormat ('mobi') but the file
+       extension matters at re-parse time: .azw3 routes to initKf8File,
+       .mobi routes to initMobiFile. Preserve the original extension when
+       it is .azw3; otherwise fall back to the format → ext map. */
+    const originalExt = entry.originalFileName?.match(/\.([a-z0-9]+)$/i)?.[1]?.toLowerCase();
+    const manuscriptExt =
+      entry.format === 'mobi' && originalExt === 'azw3' ? 'azw3' : EXT_BY_FORMAT[entry.format];
+    const manuscriptFile = `manuscript.${manuscriptExt}`;
     const manuscriptPath = join(bookDir, manuscriptFile);
 
     await mkdir(bookDir, { recursive: true });

--- a/server/src/store/manuscripts.ts
+++ b/server/src/store/manuscripts.ts
@@ -9,7 +9,7 @@ import { join } from 'node:path';
 import { findBookByManuscriptId } from '../workspace/scan.js';
 import { parseManuscript } from '../parsers/index.js';
 
-export type ManuscriptFormat = 'markdown' | 'plaintext' | 'epub' | 'pdf';
+export type ManuscriptFormat = 'markdown' | 'plaintext' | 'epub' | 'pdf' | 'mobi';
 
 export interface ChapterHint {
   /** 1-based index used as the canonical chapter id. */

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1124,7 +1124,7 @@ export interface components {
         };
         ImportCandidate: {
             /** @enum {string} */
-            format: "markdown" | "plaintext" | "epub" | "pdf";
+            format: "markdown" | "plaintext" | "epub" | "pdf" | "mobi";
             title: string;
             author?: string | null;
             series?: string | null;
@@ -1173,7 +1173,7 @@ export interface components {
             /** @example mns_abc123 */
             manuscriptId: string;
             /** @enum {string} */
-            format: "markdown" | "plaintext" | "epub" | "pdf";
+            format: "markdown" | "plaintext" | "epub" | "pdf" | "mobi";
             title: string;
             wordCount: number;
             byteSize: number;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -62,17 +62,21 @@ function wait(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-function inferFormat(fileName?: string): 'markdown' | 'plaintext' | 'epub' | 'pdf' | null {
+function inferFormat(
+  fileName?: string,
+): 'markdown' | 'plaintext' | 'epub' | 'pdf' | 'mobi' | null {
   if (!fileName) return null;
   const m = fileName.toLowerCase().match(/\.([a-z0-9]+)$/);
   if (!m) return null;
-  const map: Record<string, 'markdown' | 'plaintext' | 'epub' | 'pdf'> = {
+  const map: Record<string, 'markdown' | 'plaintext' | 'epub' | 'pdf' | 'mobi'> = {
     md: 'markdown',
     markdown: 'markdown',
     txt: 'plaintext',
     text: 'plaintext',
     epub: 'epub',
     pdf: 'pdf',
+    mobi: 'mobi',
+    azw3: 'mobi',
   };
   return map[m[1]] ?? null;
 }
@@ -85,7 +89,7 @@ export interface UploadArgs {
   /** Raw file (used for binary formats like PDF/EPUB). */
   file?: File;
   fileName?: string;
-  format?: 'markdown' | 'plaintext' | 'epub' | 'pdf';
+  format?: 'markdown' | 'plaintext' | 'epub' | 'pdf' | 'mobi';
 }
 /** Realtime "what's running right now" payload piggybacked on phase ticks.
     Server emits one of these every 500ms while any stage-2 chapter is in

--- a/src/views/upload.tsx
+++ b/src/views/upload.tsx
@@ -11,7 +11,7 @@ import { manuscriptActions } from '../store/manuscript-slice';
 import { useLocalAnalyzerGuard } from '../hooks/use-local-analyzer-guard';
 
 const TEXT_EXT_RE = /\.(md|markdown|txt|text)$/i;
-const BINARY_EXT_RE = /\.(pdf|epub)$/i;
+const BINARY_EXT_RE = /\.(pdf|epub|mobi|azw3)$/i;
 
 export function UploadView() {
   const dispatch = useAppDispatch();
@@ -61,7 +61,7 @@ export function UploadView() {
       return;
     }
     setError(
-      `${file.name.split('.').pop()?.toUpperCase()} files aren't supported. Try .md, .txt, .pdf, or .epub.`,
+      `${file.name.split('.').pop()?.toUpperCase()} files aren't supported. Try .md, .txt, .pdf, .epub, .mobi, or .azw3.`,
     );
   }
 
@@ -131,7 +131,7 @@ export function UploadView() {
             ref={fileInputRef}
             type="file"
             hidden
-            accept=".md,.markdown,.txt,.text,.pdf,.epub"
+            accept=".md,.markdown,.txt,.text,.pdf,.epub,.mobi,.azw3"
             onChange={(e) => handleFile(e.target.files?.[0])}
           />
           <div className="w-16 h-16 mx-auto rounded-full bg-canvas grid place-items-center mb-5">
@@ -148,7 +148,8 @@ export function UploadView() {
             {busy ? 'Hashing and registering with the server.' : 'or click to browse files'}
           </p>
           <div className="mt-6 flex items-center justify-center gap-4 text-xs text-ink/50">
-            <span>Markdown</span>·<span>Plain text</span>·<span>EPUB</span>·<span>PDF</span>
+            <span>Markdown</span>·<span>Plain text</span>·<span>EPUB</span>·<span>PDF</span>·
+            <span>MOBI</span>·<span>AZW3</span>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

Adds `.mobi` and `.azw3` to the supported manuscript-upload formats via [`@lingo-reader/mobi-parser`](https://www.npmjs.com/package/@lingo-reader/mobi-parser). KF8 (`.azw3`) routes to `initKf8File`; legacy `.mobi` routes to `initMobiFile`. DRM-protected files (Kindle Store purchases) are detected up-front by reading the PalmDOC encryption byte and rejected with HTTP 415 `{ error: 'drm_protected' }` so the UI can surface a "convert with Calibre" prompt rather than an opaque parse failure. Original extension is preserved on persist so `.azw3` re-parse still routes to KF8.

Implements [docs/features/52-mobi-parsing.md](docs/features/52-mobi-parsing.md) — plan currently `active`; will flip to `stable` with Ship notes after manual real-world MOBI verification (recipe in plan §"Manual acceptance walkthrough").

`stripHtml` / `extractFirstHeading` / `GENERIC_NCX_RE` hoisted from `epub.ts` into a shared `parsers/html-utils.ts` so EPUB and MOBI use the same chapter-body normalisation. EPUB tests unchanged and still green.

Backlog follow-up filed as [Could #38 in docs/BACKLOG.md](docs/BACKLOG.md): e2e Playwright coverage for the binary-upload flow (EPUB / PDF / MOBI / AZW3).

## Test plan

- [x] `npm run verify` (pre-push hook) — green: 930 server tests + e2e 26 (2 unrelated retries) + build.
- [x] 19 new vitest unit cases in `server/src/parsers/mobi.test.ts` covering: DRM guard (encryption byte 1/2 throws, byte 0 proceeds, library never invoked on DRM path), ext routing (`.mobi` → `initMobiFile`, `.azw3` → `initKf8File`), metadata fallback chain, TOC label resolution + generic-merge with body `<h1>`, audio-tag enrichment.
- [x] 1 new integration case in `server/src/routes/import.test.ts` asserting the 415 + `error: 'drm_protected'` contract end-to-end via `POST /api/import`.
- [ ] **Reviewer:** spot-check `server/src/parsers/mobi.ts:42-52` (`readMobiEncryptionType`) against the [MobileRead PalmDOC header spec](https://wiki.mobileread.com/wiki/PDB#PalmDOC) — encryption byte is at PalmDOC offset `0x0C`.
- [ ] **Reviewer:** confirm `server/src/routes/import.ts:208` correctly preserves the `.azw3` extension when persisting.
- [ ] **Manual (post-merge):** drop a Project Gutenberg-derived `.mobi` on `#/new`, verify confirm screen renders with correct title + chapter list, confirm bytes round-trip to `workspace/books/.../manuscript.mobi`. Recipe in plan 52 §"Manual acceptance walkthrough".

🤖 Generated with [Claude Code](https://claude.com/claude-code)