### PR TITLE
fix(frontend,docs): plan-42 follow-up — dark-mode contrast for red/rose ladder

### DIFF
--- a/docs/features/42-dark-mode.md
+++ b/docs/features/42-dark-mode.md
@@ -147,6 +147,23 @@ dark-mode token / utility edit must preserve these targets:
    ~10–32% alpha overlays on dark; matching text shifts to the
    -300/-400 family. Any new status-colour utility must land an
    override at the same time it's first used in component code.
+6. **Full red/rose ladder coverage** (added 2026-05-18 after the
+   Halted-pill / Analysis-halted-panel bug: the top-bar pill paints
+   `text-rose-800` and the analysing-view error panel paints
+   `text-red-800` / `text-red-900` on red/rose-50 fills — neither
+   utility had a dark override, so both bled dark-on-dark). The dark
+   overrides now cover every red/rose utility used as a text or
+   surface in component code: text shades -600 through -900 (plus
+   their `/70`-`/90` alpha modifiers) collapse to `#fca5a5` (~10:1
+   on `--canvas`); hover variants lift to `#fecaca`; `bg-red-100`,
+   `bg-red-100/60`, `bg-rose-50/30…/80`, and the `hover:bg-rose-100`
+   / `hover:bg-rose-200` / `hover:bg-red-50` surfaces drop to
+   alpha-tinted overlays; `border-red-200` / `border-red-300` join
+   `border-rose-200` at ~30–35% red alpha. Saturated paints
+   (`bg-rose-400/500`, `bg-red-500/600`, `hover:bg-red-700`,
+   `ring-red-400/40`) are intentionally left as-is — they read as
+   destructive-action / dot-indicator hues and already hold contrast
+   on dark.
 
 ## Test plan
 
@@ -183,7 +200,12 @@ dark-mode token / utility edit must preserve these targets:
   `bg-white/70` and their `hover:` counterparts exist under
   `[data-theme='dark']`. Locks the regression where a missing
   base-variant override let the ConnPill paint
-  `text-emerald-700` on a near-white wash in dark mode.
+  `text-emerald-700` on a near-white wash in dark mode. Extended
+  2026-05-18 with the red/rose ladder additions (`text-rose-800`,
+  `text-red-800`, `text-red-900`, the /N alpha modifiers,
+  `bg-red-100`, `hover:bg-rose-100` / `…-200` / `bg-red-50`,
+  `border-red-200`, `border-red-300/60`) so the Halted-pill +
+  Analysis-halted-panel regression can't reopen.
 
 ### Manual acceptance walkthrough
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -184,6 +184,43 @@
 [data-theme='dark'] .bg-red-50 {
   background-color: rgba(239, 68, 68, 0.1);
 }
+[data-theme='dark'] .bg-red-100,
+[data-theme='dark'] .bg-red-100\/60 {
+  background-color: rgba(239, 68, 68, 0.18);
+}
+/* Hover variants of the rose / red status fills. Same selector caveat
+   as `.hover\:bg-white` above — Tailwind compiles
+   `.hover\:bg-rose-100:hover` as its own rule, so the bare `.bg-rose-100`
+   redirect doesn't reach it. Without an override the pill hover flashes
+   back to its near-pink light-mode fill on the dark canvas. Alphas trend
+   one step above the base translucent overlay so the hover elevation
+   still reads. */
+[data-theme='dark'] .hover\:bg-rose-100:hover {
+  background-color: rgba(244, 63, 94, 0.22);
+}
+[data-theme='dark'] .hover\:bg-rose-200:hover {
+  background-color: rgba(244, 63, 94, 0.28);
+}
+[data-theme='dark'] .hover\:bg-red-50:hover {
+  background-color: rgba(239, 68, 68, 0.15);
+}
+/* Translucent `.bg-rose-50\/30` / `/50` / `/70` / `/80` variants used as
+   layered washes on the generation view's progress stripes. Same logic
+   as the `.bg-white\/60` overrides — the bare `.bg-rose-50` rule above
+   targets a different selector, so the /N forms still paint a near-pink
+   wash unless given their own dark override. */
+[data-theme='dark'] .bg-rose-50\/30 {
+  background-color: rgba(244, 63, 94, 0.04);
+}
+[data-theme='dark'] .bg-rose-50\/50 {
+  background-color: rgba(244, 63, 94, 0.06);
+}
+[data-theme='dark'] .bg-rose-50\/70 {
+  background-color: rgba(244, 63, 94, 0.08);
+}
+[data-theme='dark'] .bg-rose-50\/80 {
+  background-color: rgba(244, 63, 94, 0.1);
+}
 [data-theme='dark'] .bg-emerald-50 {
   background-color: rgba(16, 185, 129, 0.1);
 }
@@ -220,8 +257,47 @@
 [data-theme='dark'] .text-rose-300 {
   color: #fca5a5;
 }
+/* Mid-ladder rose text. The light palette uses rose-600/800 on pale
+   fills (book-library "Halted" pill, export-audiobook quota notice,
+   generation view error rows). Collapsing to the same legible tint as
+   rose-700/900 keeps every rose-text paint at ~10:1 on the dark canvas
+   — verified against the contrast invariant in
+   docs/features/42-dark-mode.md. The /70 /80 /90 alpha modifiers
+   ride along on the same lightened tint; flattening the alpha is fine
+   on dark since the underlying text is already light. */
+[data-theme='dark'] .text-rose-600,
+[data-theme='dark'] .text-rose-600\/70,
+[data-theme='dark'] .text-rose-800,
+[data-theme='dark'] .text-rose-800\/90 {
+  color: #fca5a5;
+}
+/* Hover lifts to a brighter rose so the interactive affordance is still
+   visible against the static text colour above. */
+[data-theme='dark'] .hover\:text-rose-700:hover,
+[data-theme='dark'] .hover\:text-rose-800:hover,
+[data-theme='dark'] .hover\:text-rose-900:hover {
+  color: #fecaca;
+}
 [data-theme='dark'] .text-red-700 {
   color: #fca5a5;
+}
+/* Mid-ladder red text. The analysing-view error panel and a handful of
+   modal "remove" affordances paint -600/-800/-900 on red-50 / red-100
+   washes. Same collapse-to-one-legible-tint approach as rose above. */
+[data-theme='dark'] .text-red-600,
+[data-theme='dark'] .text-red-600\/80,
+[data-theme='dark'] .text-red-600\/90,
+[data-theme='dark'] .text-red-700\/70,
+[data-theme='dark'] .text-red-700\/80,
+[data-theme='dark'] .text-red-800,
+[data-theme='dark'] .text-red-800\/90,
+[data-theme='dark'] .text-red-900,
+[data-theme='dark'] .text-red-900\/80 {
+  color: #fca5a5;
+}
+[data-theme='dark'] .hover\:text-red-800:hover,
+[data-theme='dark'] .hover\:text-red-900:hover {
+  color: #fecaca;
 }
 [data-theme='dark'] .text-emerald-800 {
   color: #6ee7b7;
@@ -263,6 +339,13 @@
 }
 [data-theme='dark'] .border-rose-200 {
   border-color: rgba(244, 63, 94, 0.3);
+}
+[data-theme='dark'] .border-red-200 {
+  border-color: rgba(239, 68, 68, 0.3);
+}
+[data-theme='dark'] .border-red-300,
+[data-theme='dark'] .border-red-300\/60 {
+  border-color: rgba(239, 68, 68, 0.35);
 }
 
 /* Page chrome -------------------------------------------------------------- */

--- a/src/test/dark-mode-css.test.ts
+++ b/src/test/dark-mode-css.test.ts
@@ -38,6 +38,26 @@ describe('dark-mode CSS overrides (styles.css)', () => {
     { selector: '.hover\\:bg-white:hover', label: 'hover solid white' },
     { selector: '.hover\\:bg-white\\/60:hover', label: 'hover /60' },
     { selector: '.hover\\:bg-white\\/70:hover', label: 'hover /70' },
+    /* Plan-42 follow-up (2026-05-18): the analysing-view error panel
+       and the top-bar Halted pill paint -800/-900 red/rose text on
+       pale red/rose fills. Without a dark override they bleed
+       dark-on-dark — the exact bug the user hit in the screenshot
+       that opened this round. */
+    { selector: '.text-rose-800', label: 'rose-800 pill text' },
+    { selector: '.text-rose-600', label: 'rose-600 muted text' },
+    { selector: '.text-red-800', label: 'red-800 error body text' },
+    { selector: '.text-red-900', label: 'red-900 error header text' },
+    { selector: '.text-red-600', label: 'red-600 modal-action text' },
+    { selector: '.text-red-700\\/70', label: 'red-700 /70 caption text' },
+    { selector: '.text-red-800\\/90', label: 'red-800 /90 body text' },
+    { selector: '.text-red-900\\/80', label: 'red-900 /80 label text' },
+    { selector: '.bg-red-100', label: 'red-100 fill' },
+    { selector: '.bg-red-100\\/60', label: 'red-100 /60 fill (details pre)' },
+    { selector: '.hover\\:bg-rose-100:hover', label: 'hover rose-100' },
+    { selector: '.hover\\:bg-rose-200:hover', label: 'hover rose-200 (Halted pill)' },
+    { selector: '.hover\\:bg-red-50:hover', label: 'hover red-50' },
+    { selector: '.border-red-200', label: 'red-200 panel border' },
+    { selector: '.border-red-300\\/60', label: 'red-300 /60 select border' },
   ])('repaints $label ($selector) under [data-theme=\'dark\']', ({ selector }) => {
     const pattern = new RegExp(
       String.raw`\[data-theme='dark'\][^{]*` +


### PR DESCRIPTION
## Summary

- Adds dark-mode overrides in `src/styles.css` for every red/rose text, surface, hover, and border utility used in component code that wasn't already overridden. Fixes the contrast bugs reported in dark mode: the top-bar "Halted" pill (`text-rose-800` on darkened rose fill) and the analysing-view error panel ("Analysis halted" header in `text-red-900`, body in `text-red-800` on darkened red fill) — both painted dark-on-dark and were unreadable.
- Saturated paints (`bg-rose-400/500`, `bg-red-500/600`, `hover:bg-red-700`, `ring-red-400/40`) are intentionally left untouched — they read as dot-indicators / destructive-action hues and already hold contrast on dark.
- Extends `src/test/dark-mode-css.test.ts` with 15 new utility-presence assertions (21 total) so the regression can't reopen.
- Appends a contrast-invariant #6 + a 2026-05-18 follow-up note to `docs/features/42-dark-mode.md`.

## Test plan

- [x] `npx vitest run src/test/dark-mode-css.test.ts` — all 21 assertions pass.
- [x] `npm run verify` — green against the changes in this PR (typecheck + all tests + e2e + build) when run with only this PR's files in the tree.
- [ ] Manual: open the analysing view in dark mode with a halted analysis and confirm both the top-bar Halted pill and the "Analysis halted" error panel read clearly.
- [ ] Manual: spot-check the other surfaces touching the new utilities — `ModelControlPill` halted state, `toast-stack` error toasts, `book-library` Halted pills, `generation` view error rows, `export-audiobook` quota notice — all should hold ≥4.5:1 text contrast on the dark canvas.

Regression plan: `docs/features/42-dark-mode.md` (`Contrast invariants` #6 + extended test plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)