### PR TITLE
ci(ci): install ffmpeg per-OS before release verify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,24 @@ jobs:
       - name: Install server deps
         run: npm --prefix server ci
 
+      # The server pretest hook (`scripts/preflight-ffmpeg.cjs`) refuses to
+      # run when ffmpeg isn't on PATH — the MP3 encoder in
+      # `server/src/tts/mp3.ts` shells out to it. GitHub runners don't ship
+      # ffmpeg pre-installed on any of the three OSes, so we install it
+      # here before verify. `SKIP_FFMPEG_PREFLIGHT=1` exists as an escape
+      # hatch but it makes `mp3.test.ts` silently skip — we want the gate.
+      - name: Install ffmpeg (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: Install ffmpeg (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install ffmpeg
+
+      - name: Install ffmpeg (Windows)
+        if: matrix.os == 'windows-latest'
+        run: choco install ffmpeg -y --no-progress
+
       # `verify:quick` is `test:all` (hooks + frontend + server + scripts +
       # sidecar). Scripts use PowerShell — Windows has it natively; macOS
       # and Ubuntu both ship `pwsh` on the GitHub runner images, so Pester


### PR DESCRIPTION
## Summary

The release workflow's verify matrix (Ubuntu / macOS / Windows) failed on every leg against the v1.2.0 tag with `[preflight] ffmpeg not found on PATH`. The server's pretest hook (`scripts/preflight-ffmpeg.cjs`) refuses to run when ffmpeg isn't installed — the MP3 encoder in `server/src/tts/mp3.ts` shells out to it. GitHub runners don't ship ffmpeg pre-installed on any of the three OSes. Local pre-push verify passed because the maintainer has ffmpeg on their machine, masking the gap.

Install ffmpeg explicitly per-OS (`apt-get`, `brew`, `choco`) before invoking `verify:quick`. `SKIP_FFMPEG_PREFLIGHT=1` is the documented escape hatch but it causes `mp3.test.ts` to silently skip — we want the gate live in CI.

Companion to [docs/features/49-release-package.md](../blob/main/docs/features/49-release-package.md) — fold the install requirement into plan 49's Ship notes when v1.2.x lands.

## Test plan

- [ ] `npm run verify` — green (no source changes; cache holds)
- [ ] Push v1.2.1 tag after merge; release workflow goes green on all three OS legs
- [ ] Publish job produces `audiobook-generator-v1.2.1.zip` + `.sha256` and the GitHub Release lands with the tag annotation as the body

🤖 Generated with [Claude Code](https://claude.com/claude-code)