### PR TITLE
fix(ci): fetch tag annotations in release publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           # Need the tag annotation reachable as the release body.
+          # `fetch-depth: 0` alone fetches all commits but actions/checkout@v4
+          # leaves `fetch-tags: false` by default, so the tag *object* (with
+          # its annotation) is never pulled — `git tag -l --format='%(contents)'`
+          # then falls back to the commit subject and the GitHub Release body
+          # ends up as just "chore: bump version to X.Y.Z". v1.2.2 shipped
+          # with an empty body for exactly this reason.
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

v1.2.2 shipped with a GitHub Release body of just `chore: bump version to 1.2.2` — the long Features / Fixes / Engineering tag annotation never made it to the rendered release page.

Root cause: `actions/checkout@v4` leaves `fetch-tags: false` by default even when `fetch-depth: 0` is set. `fetch-depth` pulls commit history; tag *objects* need their own flag. Without the tag object in the runner's working tree, `git tag -l --format='%(contents)' v1.2.2` falls back to the commit subject and the workflow writes that to `release/tag-notes.md`.

Adds `fetch-tags: true` alongside the existing `fetch-depth: 0` on the publish job's checkout. v1.2.2's release body will be patched manually via `gh release edit` once this merges; all future tag pushes pick up the full annotation through this fix.

Plan 49 follow-up — folds into the ship notes when 49 flips to `stable`.

## Test plan

- [x] `npm run verify` — green (no test surface; the regression is observable only by triggering a tag push)
- [ ] After merge, `gh release edit v1.2.2 --notes-file <path>` restores v1.2.2's body
- [ ] Next tag push (v1.2.3 or v1.3.0) lands with full body from annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)