### PR TITLE
feat(server): plan 56 — real chapter peaks at encode time

### DIFF
--- a/docs/features/56-real-chapter-peaks.md
+++ b/docs/features/56-real-chapter-peaks.md
@@ -1,0 +1,68 @@
+---
+status: active
+shipped: null
+owner: null
+---
+
+# Real chapter-audio peaks at encode time
+
+> Status: active
+> Key files: `server/src/audio/compute-peaks.ts`, `server/src/tts/mp3.ts`, `server/src/routes/chapter-audio.ts`, `server/src/routes/generation.ts`
+> URL surface: `#/books/:bookId/listen` (waveform card)
+> OpenAPI ops: `GET /api/books/{bookId}/chapters/{chapterId}/audio` (`peaks: number[]` field) — shape unchanged, value now derived from real audio
+
+## Benefit / Rationale
+
+- **User:** the Listen view's waveform card stops lying. Today the bars come from a mock sinusoid the frontend fills in when the server returns `peaks: []`; loud passages, silences, and fades are all invisible. After this plan the bars reflect the real chapter — spotting a stalled / silent / clipped chapter at a glance becomes possible.
+- **Technical:** moves chapter-level audio metadata generation into the encode path where the PCM is already in memory, so the cost is one buffer walk per chapter (≤ a few ms even on 1-hour chapters) and zero re-reads from disk. Establishes a sibling-file pattern (`<slug>.peaks.json`) that future per-chapter audio metadata (loudness / true-peak / channel layout) can extend without renegotiating the wire shape.
+- **Architectural:** keeps the pure-encoder boundary (`encodePcmToMp3` takes no fs, returns a `Buffer`) intact. The new `writeChapterPeaksFile` sibling owns the fs side — same separation of concerns as `writeJsonAtomic` ↔ `JSON.stringify`. Reads are graceful (missing / corrupt file → `peaks: []`), preserving the pre-plan contract for legacy chapters and avoiding a flag-day migration.
+
+## Architectural impact
+
+- **New seam:** `server/src/audio/compute-peaks.ts` — a pure function (`computePeaks(pcm, sampleRate) -> number[240]`). No fs, no shell-out, no timers. Tested in isolation so the reducer's normalization and RMS contract are pinned independently of any wire-up.
+- **New seam:** `writeChapterPeaksFile(pcm, sampleRate, peaksPath)` in `server/src/tts/mp3.ts` — the fs wrapper. Uses the same temp-then-rename atomic-write pattern as `server/src/workspace/state-io.ts`'s `writeJsonAtomic` (write `.tmp-<pid>-<ts>`, rename over target; unlink the temp on terminal failure so the workspace doesn't accumulate droppings).
+- **Invariants preserved:**
+  - `encodePcmToMp3` (`server/src/tts/mp3.ts:30-95`) remains a pure encoder — same signature, same `Buffer` return, no fs reference. The peaks writer is a sibling, not a wrap.
+  - `peaks: number[]` in `openapi.yaml` (and the generated `src/lib/api-types.ts`) is unchanged — the field already existed, only its value source changes. No `openapi:types` regen required.
+  - Pre-plan-56 chapters keep loading: the meta endpoint's missing-file fallback returns `peaks: []` (the documented pre-plan contract), and the frontend's `Waveform` component has always handled empty arrays.
+- **Migration story:** none required. The first regen of any chapter under this build drops a `<slug>.peaks.json` next to the MP3. Until then the meta endpoint returns the legacy `peaks: []` and the Listen card paints whatever the frontend's fallback (today: nothing visible) shows. No state.json bump, no schema version.
+- **Reversibility:** deleting `<bookDir>/audio/<slug>.peaks.json` (or every `.peaks.json` across the workspace) is safe — the chapter-audio meta endpoint falls back to `peaks: []` and the next regen rewrites the file. Removing the writer call from `generation.ts` is a one-line revert; removing the read call from `chapter-audio.ts` is two lines.
+
+## Invariants to preserve
+
+- `computePeaks` always returns exactly `BIN_COUNT` (= 240) numbers, every value finite and in `[0, 1]`. Cited: `server/src/audio/compute-peaks.ts:42-46`.
+- Silence (all-zero PCM, or empty buffer) maps to `[0, 0, …, 0]` — never NaN. The normalization-by-zero branch is gated by `if (peakRms > 0)` (`server/src/audio/compute-peaks.ts:114-117`).
+- Short PCM (`sampleCount < BIN_COUNT`) maps each sample 1:1 onto the leading bins; the trailing bins are zero. We do NOT upsample / repeat — that would smear waveform shape. Cited: `server/src/audio/compute-peaks.ts:64-83`.
+- Long PCM: every sample lands in exactly one bin (`floor(i * N / BIN_COUNT)` window boundaries). No off-by-one drops the last sample. Cited: `server/src/audio/compute-peaks.ts:88-92`.
+- `writeChapterPeaksFile` uses temp-then-rename so a crash mid-write never leaves a half-written `.peaks.json` that a subsequent read would choke on. Cited: `server/src/tts/mp3.ts:130-142`.
+- The chapter-audio meta endpoint (`/api/books/:bookId/chapters/:chapterId/audio` AND `/audio/previous`) returns `peaks: []` when the sibling file is missing OR malformed — both routes go through `readPeaksOrEmpty`. Cited: `server/src/routes/chapter-audio.ts:43-65`.
+- Per-chapter atomic ordering in `generation.ts` (segments JSON → mp3 rename → peaks write) preserves the existing "MP3 on disk = chapter complete" resumability rule. Peaks failure is non-fatal (logged, swallowed) so a peaks-write hiccup never strands an otherwise-finished chapter. Cited: `server/src/routes/generation.ts:511-526`.
+
+## Test plan
+
+### Automated coverage
+
+- Vitest server (`server/src/audio/compute-peaks.test.ts`) — pins the pure reducer's contract across silence, full-scale sine, half-scale-mixed sine, ascending ramp, and very-short PCM. Asserts shape (length 240, finite, `[0, 1]`), normalization (loudest bin = 1.0, half-amplitude segment ≈ 0.5), monotonicity on a ramp, every-sample coverage on long PCM, and the sample-rate-invariance note.
+- Vitest server (`server/src/tts/mp3.test.ts`'s `writeChapterPeaksFile` block) — covers the fs side: writes a valid `{peaks: number[240]}` JSON, creates intermediate directories, leaves no `.tmp-*` droppings on success, serializes all-zero peaks (no NaN) for silent PCM.
+- Vitest server (`server/src/routes/chapter-audio.test.ts`'s `peaks sibling (plan 56)` block) — pins the wire-up: meta endpoint surfaces the sibling file's `peaks` when present (with a deterministic ramp fixture so we verify content flow-through, not just shape), returns `peaks: []` when the sibling is absent (graceful pre-plan-56 contract), absorbs a corrupt `.peaks.json` (returns `[]` instead of 500ing).
+
+### Manual acceptance walkthrough
+
+(Real backend mode — `cd server && npm run dev`. No mock-mode walkthrough; mock `getChapterAudio` already returns a 240-bin sinusoid and is unchanged.)
+
+1. Render a fresh chapter via the Generation view. → `<bookDir>/audio/<slug>.peaks.json` exists on disk with 240 floats in `[0, 1]`.
+2. Open the Listen view. → The waveform card paints the real per-chapter envelope (silences are visibly silent, loud passages are visibly louder).
+3. Hand-delete the `.peaks.json` for one chapter on disk and refresh. → That chapter's waveform card falls back to the empty / mock visual; the Listen view does NOT 500 or surface an error.
+4. Re-render the same chapter. → A new `.peaks.json` lands and the waveform refreshes on the next meta fetch.
+5. Open a chapter generated BEFORE this plan shipped (no `.peaks.json` on disk). → Meta endpoint returns `peaks: []`; Listen view degrades gracefully exactly as in step 3.
+
+## Out of scope
+
+- **Frontend changes.** The Listen view's `Waveform` component already consumes `peaks: number[]`. The `peaks: []` mock-data fallback line in `src/lib/api.ts:795` (the revision-diff mock for the preserved "A" take) is intentionally left as-is — it's mock mode, not the real-mode path this plan touches.
+- **Preserved (`.previous.peaks.json`) emission.** `preserveExistingAsPrevious` does not move peaks alongside the audio + segments pair today; the `/audio/previous` endpoint therefore typically returns `peaks: []` for the audition variant. That's a deliberate trade-off: the audition workflow is short-lived (accept/reject inside one session) and the A/B comparison doesn't lean on the waveform shape. A future preserve extension can light up both sides without a route change — the symmetrical `readPeaksOrEmpty` call is already in place.
+- **Per-chapter loudness / true-peak / channel-layout metadata.** Tracked separately as BACKLOG Could #3; the sibling-file shape (`<slug>.peaks.json` with a single field today) is intentionally extensible — future metadata can land under a new top-level key (`{ peaks, loudness, … }`) without a schema version.
+- **Recomputing peaks for legacy chapters in bulk.** Optional. Could be added later as a `scripts/backfill-peaks.mjs` that walks the workspace and emits sibling files for chapters that have an MP3 but no `.peaks.json`. Out of scope for the initial plan — the meta endpoint's graceful fallback means legacy chapters keep working, just without the new waveform fidelity.
+
+## Ship notes
+
+(Filled in when status flips to `stable`.)

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -86,6 +86,7 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 - [47 — Listening progress / resume bookmarks](archive/47-listen-progress.md) — Per-book sibling `listen-progress.json`; mini-player seeks to the saved point on chapter mount; Listen view "Resume at MM:SS" pill. Shipped 2026-05-18.
 - [32 — Audiobook export](32-audiobook-export.md) — Sideload to PocketBook Reader (Phase A: MP3.ZIP) via LAN download or sync folder; per-chapter ID3v2.4 tags, no re-encode, atomic writes.
 - [34 — MP3-folder export](34-mp3-folder-export.md) — Per-chapter MP3s in a sub-folder for folder-scanning audiobook apps (Smart AudioBook Player, BookPlayer, Audiobookshelf). Sync-folder destination only; APIC cover travels with each chapter.
+- [56 — Real chapter-audio peaks at encode time](56-real-chapter-peaks.md) — Compute a 240-bin RMS envelope alongside the MP3 encode, persist as `<bookDir>/audio/<slug>.peaks.json`, surface from the chapter-audio meta endpoint. Missing-file fallback returns `peaks: []` so legacy chapters keep working. **Status: active.**
 
 ### I. Revisions & drift
 

--- a/server/src/audio/compute-peaks.test.ts
+++ b/server/src/audio/compute-peaks.test.ts
@@ -1,0 +1,209 @@
+/* Unit coverage for the 240-bin RMS reducer behind plan 56. The reducer is
+   pure (no fs / no ffmpeg) so every shape, normalization, and edge-case
+   assertion lives in this file — the higher-level wire-up (write JSON ↔
+   read JSON ↔ serve over HTTP) is covered separately in `../tts/mp3.test.ts`
+   and `../routes/chapter-audio.test.ts`. */
+
+import { describe, it, expect } from 'vitest';
+import { BIN_COUNT, BYTES_PER_SAMPLE, computePeaks } from './compute-peaks.js';
+
+/** Build a length-`sampleCount` int16 LE mono PCM buffer by sampling
+ *  `valueAt(i)` for each sample index. Returns a `Buffer` ready to feed
+ *  to `computePeaks`. `valueAt` should return numbers in `[-32768, 32767]`. */
+function makePcm(sampleCount: number, valueAt: (i: number) => number): Buffer {
+  const buf = Buffer.alloc(sampleCount * BYTES_PER_SAMPLE);
+  for (let i = 0; i < sampleCount; i += 1) {
+    const sample = Math.max(-32768, Math.min(32767, Math.round(valueAt(i))));
+    buf.writeInt16LE(sample, i * BYTES_PER_SAMPLE);
+  }
+  return buf;
+}
+
+function silence(sampleCount: number): Buffer {
+  return makePcm(sampleCount, () => 0);
+}
+
+function sine(sampleCount: number, sampleRate: number, freq: number, amp = 16000): Buffer {
+  return makePcm(sampleCount, (i) => amp * Math.sin((2 * Math.PI * freq * i) / sampleRate));
+}
+
+/** Linear ramp from 0 to ±32000 across the buffer. Useful for asserting
+ *  the reducer respects ordering — a ramp must produce bins in
+ *  monotonically increasing magnitude order. */
+function ramp(sampleCount: number, peak = 32000): Buffer {
+  return makePcm(sampleCount, (i) => Math.round((peak * i) / Math.max(1, sampleCount - 1)));
+}
+
+describe('computePeaks', () => {
+  describe('shape contract', () => {
+    it('always returns exactly BIN_COUNT (240) numbers', () => {
+      const sr = 24_000;
+      for (const n of [0, 1, 100, 240, 241, 1_000, 1_000_000]) {
+        const peaks = computePeaks(silence(n), sr);
+        expect(peaks).toHaveLength(BIN_COUNT);
+      }
+    });
+
+    it('returns finite numbers in [0, 1] for every bin', () => {
+      const sr = 24_000;
+      const pcm = sine(sr * 2, sr, 440); // 2 s @ 24 kHz
+      const peaks = computePeaks(pcm, sr);
+      for (const v of peaks) {
+        expect(Number.isFinite(v)).toBe(true);
+        expect(v).toBeGreaterThanOrEqual(0);
+        expect(v).toBeLessThanOrEqual(1);
+      }
+    });
+
+    it('throws on a non-positive sample rate (mis-wiring should fail loud)', () => {
+      const pcm = silence(1_000);
+      expect(() => computePeaks(pcm, 0)).toThrow(/sampleRate/);
+      expect(() => computePeaks(pcm, -1)).toThrow(/sampleRate/);
+      expect(() => computePeaks(pcm, Number.NaN)).toThrow(/sampleRate/);
+      expect(() => computePeaks(pcm, Number.POSITIVE_INFINITY)).toThrow(/sampleRate/);
+    });
+  });
+
+  describe('silence and empty PCM', () => {
+    it('empty PCM → 240 zeros (no NaN, no normalization-by-zero)', () => {
+      const peaks = computePeaks(Buffer.alloc(0), 24_000);
+      expect(peaks).toEqual(new Array(BIN_COUNT).fill(0));
+    });
+
+    it('all-zero PCM → 240 zeros even when sampleCount >> BIN_COUNT', () => {
+      const peaks = computePeaks(silence(24_000), 24_000);
+      expect(peaks).toEqual(new Array(BIN_COUNT).fill(0));
+    });
+  });
+
+  describe('normalization', () => {
+    it('a steady tone normalizes so the loudest bin reads exactly 1.0', () => {
+      const sr = 24_000;
+      const pcm = sine(sr * 1, sr, 440); // 1 s sine
+      const peaks = computePeaks(pcm, sr);
+      const max = Math.max(...peaks);
+      expect(max).toBeCloseTo(1, 5);
+    });
+
+    it('a steady tone produces (approximately) flat bins across the array', () => {
+      const sr = 24_000;
+      const pcm = sine(sr * 2, sr, 440); // 2 s sine, plenty of cycles per bin
+      const peaks = computePeaks(pcm, sr);
+      /* Each bin sees ~200 samples (48 000 / 240) ≈ 90+ cycles of the 440 Hz
+         tone, so the RMS per bin should be near-identical. Allow ±5% drift —
+         windowing artifacts from non-integer cycles per bin show up at the
+         far edges. */
+      const mean = peaks.reduce((s, v) => s + v, 0) / peaks.length;
+      for (const v of peaks) {
+        expect(v).toBeGreaterThan(mean * 0.9);
+        expect(v).toBeLessThan(mean * 1.1);
+      }
+    });
+
+    it('RMS of a full-scale sine is √(1/2) ≈ 0.707 before normalization, 1.0 after', () => {
+      /* The reducer normalizes against its peak, so we can't read the raw
+         RMS directly. Instead we verify the *relative* RMS by mixing a
+         full-scale sine in the first half with a half-scale sine in the
+         second half: post-normalization the second half should sit near
+         0.5 (the amplitude ratio carries through the linear RMS reduce). */
+      const sr = 24_000;
+      const halfLen = sr; // 1 s
+      const loud = sine(halfLen, sr, 440, 32000);
+      const quiet = sine(halfLen, sr, 440, 16000);
+      const pcm = Buffer.concat([loud, quiet]);
+      const peaks = computePeaks(pcm, sr);
+      /* First-half bins should peak near 1.0, second-half bins near 0.5. */
+      const firstHalfMax = Math.max(...peaks.slice(0, BIN_COUNT / 2));
+      const secondHalfMax = Math.max(...peaks.slice(BIN_COUNT / 2));
+      expect(firstHalfMax).toBeCloseTo(1, 2);
+      expect(secondHalfMax).toBeCloseTo(0.5, 1);
+    });
+  });
+
+  describe('long PCM (downsample)', () => {
+    it('covers every sample exactly once across all bins (no gaps, no overlaps)', () => {
+      /* This is asserted indirectly: feed a buffer where a single non-zero
+         sample at index k lights up exactly one bin, then walk k across
+         the full range and verify each k lights up some bin (i.e. no
+         sample is silently dropped between bins). */
+      const sampleCount = 10_000;
+      for (const k of [0, 1, 100, 5_000, sampleCount - 1]) {
+        const pcm = makePcm(sampleCount, (i) => (i === k ? 32000 : 0));
+        const peaks = computePeaks(pcm, 24_000);
+        /* Exactly one bin should be non-zero (the spike's bin). */
+        const nonZero = peaks.filter((v) => v > 0);
+        expect(nonZero.length).toBe(1);
+      }
+    });
+
+    it('an ascending ramp produces monotonically-non-decreasing bin magnitudes', () => {
+      /* Stronger ordering: the ramp's per-bin RMS is monotone in the bin
+         index because each subsequent bin's window holds strictly larger
+         absolute values. Allow exact equality on adjacent bins for tiny
+         rounding, but reject any descent. */
+      const pcm = ramp(48_000); // 2 s @ 24 kHz
+      const peaks = computePeaks(pcm, 24_000);
+      for (let i = 1; i < peaks.length; i += 1) {
+        expect(peaks[i]).toBeGreaterThanOrEqual(peaks[i - 1] - 1e-9);
+      }
+      /* And the last bin is the global max (the loudest end of the ramp). */
+      expect(peaks[peaks.length - 1]).toBeCloseTo(1, 5);
+    });
+
+    it('handles a very long buffer without overflow', () => {
+      /* 1 h @ 24 kHz = 86.4 M samples. Skip the actual full-length buffer
+         (allocates 172 MB of RAM in tests; bloats CI) and assert the
+         algorithm by feeding a 5-minute buffer instead — same code path,
+         no risk of overflow because each bin normalizes its sum-of-squares
+         in [0,1] space (see compute-peaks.ts implementation note). */
+      const sr = 24_000;
+      const sampleCount = sr * 60 * 5;
+      const pcm = sine(sampleCount, sr, 440);
+      const peaks = computePeaks(pcm, sr);
+      expect(peaks).toHaveLength(BIN_COUNT);
+      for (const v of peaks) expect(Number.isFinite(v)).toBe(true);
+    });
+  });
+
+  describe('short PCM (< BIN_COUNT samples)', () => {
+    it('maps each sample 1:1 to a bin; trailing bins are zero', () => {
+      const sampleCount = 10;
+      /* Ascending magnitudes; every sample lights up a unique bin. */
+      const pcm = makePcm(sampleCount, (i) => 100 * (i + 1));
+      const peaks = computePeaks(pcm, 24_000);
+      /* First 10 bins are non-zero, ordered by magnitude (the post-norm
+         max should be 1.0 from the last sample). */
+      for (let i = 0; i < sampleCount; i += 1) {
+        expect(peaks[i]).toBeGreaterThan(0);
+      }
+      for (let i = sampleCount; i < BIN_COUNT; i += 1) {
+        expect(peaks[i]).toBe(0);
+      }
+      expect(peaks[sampleCount - 1]).toBeCloseTo(1, 5);
+    });
+
+    it('single-sample PCM → bin[0] = 1, rest = 0', () => {
+      const pcm = makePcm(1, () => 16_000);
+      const peaks = computePeaks(pcm, 24_000);
+      expect(peaks[0]).toBeCloseTo(1, 5);
+      for (let i = 1; i < BIN_COUNT; i += 1) expect(peaks[i]).toBe(0);
+    });
+
+    it('does NOT upsample / repeat — silence stays silence', () => {
+      const peaks = computePeaks(silence(50), 24_000);
+      expect(peaks).toEqual(new Array(BIN_COUNT).fill(0));
+    });
+  });
+
+  describe('sample-rate invariance', () => {
+    it('the same sample count produces the same shape regardless of sample rate', () => {
+      /* Reducer is sample-count proportional today (see contract note in
+         compute-peaks.ts). Future time-based reducers may break this — when
+         that happens, this test changes signaling the contract update. */
+      const pcm = sine(2_400, 24_000, 440);
+      const a = computePeaks(pcm, 24_000);
+      const b = computePeaks(pcm, 48_000);
+      expect(a).toEqual(b);
+    });
+  });
+});

--- a/server/src/audio/compute-peaks.ts
+++ b/server/src/audio/compute-peaks.ts
@@ -1,0 +1,116 @@
+/* Fixed-length waveform-envelope reducer for chapter audio.
+
+   Listen view's waveform card paints a `peaks: number[]` array (length 240)
+   into a fixed-width strip of bars. Before this module landed the
+   chapter-audio meta endpoint returned `peaks: []` and the frontend filled
+   in a sinusoidal mock — visually plausible but a lie. `computePeaks`
+   replaces that lie with a real RMS-bin summary of the rendered chapter
+   PCM, emitted at encode time and persisted next to the MP3 (see
+   `server/src/tts/mp3.ts`'s `writeChapterPeaksFile` and BACKLOG Could #35).
+
+   Contract:
+   - Input: raw 16-bit signed little-endian MONO PCM (`Buffer`), same shape
+     the sidecar emits and `encodePcmToMp3` consumes. Sample rate is
+     informational — peak bins are sample-count proportional, not time-
+     proportional, so the same PCM at a different sample rate produces the
+     same shape. Sample rate is accepted for parity with other helpers in
+     this layer and to leave the door open for future time-based reducers.
+   - Output: exactly `BIN_COUNT` (= 240) `number`s in `[0, 1]`.
+   - Reduction: each bin's value is the RMS (root-mean-square) of every
+     sample that falls inside it, normalized by the peak RMS across all
+     bins so the loudest bin reads `1.0`. Silence (entirely zero PCM) maps
+     to `[0, 0, …, 0]` rather than NaN.
+   - Short input (< BIN_COUNT samples): bins map 1:1 onto samples for the
+     first N positions; the trailing `BIN_COUNT - N` bins are 0. We do
+     NOT upsample / repeat — that would smear a real waveform shape, and
+     in practice every chapter rendered by the pipeline is many seconds
+     long. The all-zero tail makes "this chapter is suspiciously tiny"
+     visible at a glance in the Listen waveform.
+   - Long input (>> BIN_COUNT): each bin's sample window is computed in
+     integer-arithmetic-friendly fashion (`floor(i * N / BIN_COUNT)` ..
+     `floor((i+1) * N / BIN_COUNT)`) so every sample lands in exactly one
+     bin and no sample is double-counted. Last bin always includes the
+     final sample (no off-by-one drop).
+
+   Purity: NO file I/O, NO ffmpeg shell-out, NO timers, NO randomness. The
+   wrapper that writes the peaks JSON lives in `mp3.ts` (atomic-write
+   convention matches `state-io.ts`'s `writeJsonAtomic`). */
+
+export const BIN_COUNT = 240;
+export const BYTES_PER_SAMPLE = 2;
+
+/** Reduce raw 16-bit LE mono PCM to a `BIN_COUNT`-length RMS envelope
+ *  normalized to `[0, 1]`. See module header for the full contract.
+ *
+ *  @param pcm Raw 16-bit signed little-endian mono PCM buffer.
+ *  @param sampleRate Hz. Currently informational — see header.
+ *  @returns A length-`BIN_COUNT` array of finite numbers in `[0, 1]`.
+ */
+export function computePeaks(pcm: Buffer, sampleRate: number): number[] {
+  /* sampleRate is accepted but not consumed in the current reduction —
+     RMS-per-bin is sample-count proportional. Validate to surface
+     mis-wiring early (a 0 / NaN / negative rate is always a bug). */
+  if (!Number.isFinite(sampleRate) || sampleRate <= 0) {
+    throw new Error(`computePeaks: sampleRate must be a positive finite number, got ${sampleRate}`);
+  }
+  const sampleCount = Math.floor(pcm.length / BYTES_PER_SAMPLE);
+  const bins = new Array<number>(BIN_COUNT).fill(0);
+  if (sampleCount === 0) return bins;
+
+  if (sampleCount < BIN_COUNT) {
+    /* Map each sample to its own bin; trailing bins stay 0. Absolute
+       sample value (normalized to [0,1] against int16 full scale) is
+       used directly — RMS of a single sample is just |sample|. */
+    let peak = 0;
+    for (let i = 0; i < sampleCount; i += 1) {
+      const sample = pcm.readInt16LE(i * BYTES_PER_SAMPLE);
+      /* 32768 = -INT16_MIN; using it as the denominator means a sample
+         at the negative full-scale (-32768) normalizes to exactly 1.0
+         and positive full-scale (32767) to ~0.99997. Choosing 32768
+         over 32767 avoids the rare case where a positive-clipping
+         signal exceeds 1.0 after the normalization step. */
+      const abs = Math.abs(sample) / 32768;
+      bins[i] = abs;
+      if (abs > peak) peak = abs;
+    }
+    if (peak > 0) {
+      for (let i = 0; i < sampleCount; i += 1) bins[i] = bins[i] / peak;
+    }
+    return bins;
+  }
+
+  /* General case: bucket samples into BIN_COUNT integer windows and
+     compute RMS per window. `start`/`end` use `floor(i * N / BIN_COUNT)`
+     to guarantee complete, non-overlapping coverage of [0, sampleCount). */
+  let peakRms = 0;
+  for (let bin = 0; bin < BIN_COUNT; bin += 1) {
+    const start = Math.floor((bin * sampleCount) / BIN_COUNT);
+    const end = Math.floor(((bin + 1) * sampleCount) / BIN_COUNT);
+    const windowSize = end - start;
+    if (windowSize === 0) {
+      bins[bin] = 0;
+      continue;
+    }
+    let sumOfSquares = 0;
+    for (let i = start; i < end; i += 1) {
+      /* Normalize to [-1, 1] before squaring so the RMS itself is in
+         [0, 1]. Doing this inside the inner loop costs one divide per
+         sample but keeps the running sum from overflowing on long
+         chapters (a 1-hour chapter at 24 kHz is 86.4 M samples; sum of
+         raw int16 squares would breach Number.MAX_SAFE_INTEGER). */
+      const normalized = pcm.readInt16LE(i * BYTES_PER_SAMPLE) / 32768;
+      sumOfSquares += normalized * normalized;
+    }
+    const rms = Math.sqrt(sumOfSquares / windowSize);
+    bins[bin] = rms;
+    if (rms > peakRms) peakRms = rms;
+  }
+
+  /* Normalize so the loudest bin reads 1.0. Silent chapters (peakRms === 0)
+     return the all-zero array we already populated, which is correct: there
+     is no "shape" to render. */
+  if (peakRms > 0) {
+    for (let bin = 0; bin < BIN_COUNT; bin += 1) bins[bin] = bins[bin] / peakRms;
+  }
+  return bins;
+}

--- a/server/src/routes/chapter-audio.test.ts
+++ b/server/src/routes/chapter-audio.test.ts
@@ -120,6 +120,16 @@ function resetAudio() {
   rmIfExists(`${SLUG}.wav`);
   rmIfExists(`${SLUG}.previous.mp3`);
   rmIfExists(`${SLUG}.previous.segments.json`);
+  rmIfExists(`${SLUG}.peaks.json`);
+  rmIfExists(`${SLUG}.previous.peaks.json`);
+}
+
+/** Drop a plan-56 sibling `<slug>.peaks.json` next to the MP3 with a
+ *  deterministic ramp so assertions can pin both presence AND content
+ *  flow-through. */
+function writePeaks(slug = SLUG, count = 240) {
+  const peaks = Array.from({ length: count }, (_, i) => i / Math.max(1, count - 1));
+  writeFileSync(join(audioRoot, `${slug}.peaks.json`), JSON.stringify({ peaks }));
 }
 
 function writePreviousMp3(bytes = 4096) {
@@ -254,6 +264,57 @@ describe('chapter-audio router', () => {
     it('unknown chapterId → 404', async () => {
       const res = await request(app).get(`/api/books/${bookId}/chapters/999/audio`);
       expect(res.status).toBe(404);
+    });
+  });
+
+  describe('peaks sibling (plan 56)', () => {
+    describe('when sibling .peaks.json is present', () => {
+      beforeAll(() => {
+        resetAudio();
+        writeMp3();
+        writePeaks();
+      });
+
+      it('meta endpoint returns the peaks array from disk', async () => {
+        const res = await request(app).get(`/api/books/${bookId}/chapters/1/audio`);
+        expect(res.status).toBe(200);
+        expect(Array.isArray(res.body.peaks)).toBe(true);
+        expect(res.body.peaks).toHaveLength(240);
+        /* Verify it's the content we wrote, not the legacy `[]` fallback —
+           ramp values match the writePeaks fixture above. */
+        expect(res.body.peaks[0]).toBeCloseTo(0, 6);
+        expect(res.body.peaks[239]).toBeCloseTo(1, 6);
+      });
+    });
+
+    describe('when sibling .peaks.json is missing (legacy chapter)', () => {
+      beforeAll(() => {
+        resetAudio();
+        writeMp3();
+      });
+
+      it('meta endpoint returns peaks: [] (graceful pre-plan-56 contract)', async () => {
+        const res = await request(app).get(`/api/books/${bookId}/chapters/1/audio`);
+        expect(res.status).toBe(200);
+        expect(res.body.peaks).toEqual([]);
+      });
+    });
+
+    describe('when sibling .peaks.json is malformed', () => {
+      beforeAll(() => {
+        resetAudio();
+        writeMp3();
+        writeFileSync(join(audioRoot, `${SLUG}.peaks.json`), '{ this is not json');
+      });
+
+      it('meta endpoint absorbs the parse error and returns peaks: []', async () => {
+        const res = await request(app).get(`/api/books/${bookId}/chapters/1/audio`);
+        /* Critical: the route must NOT 500 on a corrupt peaks file —
+           that would take the whole Listen view down for a visualization
+           aid. The fallback path matches the legacy contract. */
+        expect(res.status).toBe(200);
+        expect(res.body.peaks).toEqual([]);
+      });
     });
   });
 

--- a/server/src/routes/chapter-audio.ts
+++ b/server/src/routes/chapter-audio.ts
@@ -41,6 +41,34 @@ import { isGenerationActive } from './generation.js';
 
 const MP3_MIME = 'audio/mpeg';
 
+/** Disk shape mirror of `ChapterPeaksFile` in `server/src/tts/mp3.ts`.
+ *  Kept narrow + local so this route doesn't reach across the TTS module
+ *  boundary just to import a type. */
+interface ChapterPeaksFile {
+  peaks: number[];
+}
+
+/** Read `<bookDir>/audio/<slug>.peaks.json` (or `.previous.peaks.json`)
+ *  when present, returning the 240-bin envelope. Missing file → empty
+ *  array; this is the graceful fallback contract that lets chapters
+ *  generated before plan 56 keep loading. A corrupt / malformed file is
+ *  also treated as missing (logged then absorbed) so a one-off bad write
+ *  doesn't 500 the whole meta endpoint. */
+async function readPeaksOrEmpty(peaksPath: string): Promise<number[]> {
+  if (!existsSync(peaksPath)) return [];
+  try {
+    const file = await readJson<ChapterPeaksFile>(peaksPath);
+    if (!file || !Array.isArray(file.peaks)) return [];
+    return file.peaks;
+  } catch (err) {
+    /* eslint-disable-next-line no-console */
+    console.warn(
+      `[chapter-audio] failed to read peaks file at ${peaksPath}: ${(err as Error).message}`,
+    );
+    return [];
+  }
+}
+
 interface ChapterSegmentsFile {
   bookId: string;
   chapterId: number;
@@ -85,6 +113,14 @@ async function locateChapterAudio(
 ): Promise<{
   audio: ChapterAudioFile;
   segPath: string;
+  /** Sibling `<slug>.peaks.json` (current) or `<slug>.previous.peaks.json`
+   *  (preserved) location. The file is optional — `readPeaksOrEmpty`
+   *  treats absence as `peaks: []`. Plan 56's render path emits the
+   *  current variant; the preserved variant has no writer today (rollback
+   *  preservation in `preserveExistingAsPrevious` does not move peaks),
+   *  so the preserved endpoint reliably returns `[]` for now — a
+   *  deliberately graceful trade-off rather than a missing feature. */
+  peaksPath: string;
   chapterId: number;
   chapterTitle: string;
 } | null> {
@@ -104,7 +140,11 @@ async function locateChapterAudio(
     variant === 'current'
       ? `${root}/${chapter.slug}.segments.json`
       : `${root}/${chapter.slug}.previous.segments.json`;
-  return { audio, segPath, chapterId, chapterTitle: chapter.title };
+  const peaksPath =
+    variant === 'current'
+      ? join(root, `${chapter.slug}.peaks.json`)
+      : join(root, `${chapter.slug}.previous.peaks.json`);
+  return { audio, segPath, peaksPath, chapterId, chapterTitle: chapter.title };
 }
 
 /** Mirror of findChapterAudio but for the `.previous.mp3` sibling. */
@@ -123,18 +163,22 @@ chapterAudioRouter.get(
     /* On-disk segments use `startSec/endSec/sentenceIds[]` (per-group). The
      ChapterAudio contract publishes `start/end/sentenceId` (singular) — map
      each group to one outward segment, using the group's first sentence id
-     as the representative. Peaks: [] for now (MiniPlayer doesn't draw them;
-     Listen's waveform is out of scope here). */
+     as the representative. */
     const segments = (meta?.segments ?? []).map((s) => ({
       start: s.startSec,
       end: s.endSec,
       characterId: s.characterId,
       sentenceId: s.sentenceIds[0],
     }));
+    /* Plan 56: surface the real 240-bin RMS peaks emitted at encode time.
+       Missing file → `[]`, preserving the pre-plan-56 contract so chapters
+       generated before this plan keep loading and the Listen view falls
+       back gracefully. */
+    const peaks = await readPeaksOrEmpty(found.peaksPath);
     res.json({
       url: `/api/books/${encodeURIComponent(req.params.bookId)}/chapters/${found.chapterId}/${found.audio.urlSuffix}`,
       durationSec: meta?.durationSec ?? 0,
-      peaks: [],
+      peaks,
       sampleRate: meta?.sampleRate ?? 24000,
       segments,
     });
@@ -157,10 +201,17 @@ chapterAudioRouter.get(
       characterId: s.characterId,
       sentenceId: s.sentenceIds[0],
     }));
+    /* Plan 56: the preserved audition variant has no peaks writer today
+       (rollback preservation does not move peaks alongside the audio +
+       segments pair). `readPeaksOrEmpty` therefore typically returns `[]`
+       for this path, which the Listen / revision-diff player handles
+       gracefully. Wiring is symmetrical with /audio so a future preserve
+       extension can light up the A/B waveform without a route change. */
+    const peaks = await readPeaksOrEmpty(found.peaksPath);
     res.json({
       url: `/api/books/${encodeURIComponent(req.params.bookId)}/chapters/${found.chapterId}/audio/previous.mp3`,
       durationSec: meta?.durationSec ?? 0,
-      peaks: [],
+      peaks,
       sampleRate: meta?.sampleRate ?? 24000,
       segments,
     });

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -35,7 +35,7 @@ import {
   selectTtsProvider,
   type TtsModelKey,
 } from '../tts/index.js';
-import { encodePcmToMp3 } from '../tts/mp3.js';
+import { encodePcmToMp3, writeChapterPeaksFile } from '../tts/mp3.js';
 import {
   synthesiseChapter,
   type CastCharacter,
@@ -461,6 +461,7 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
       const mp3Buffer = await encodePcmToMp3(result.pcm, result.sampleRate, { quality: 2 });
       const mp3Path = join(audioRoot, `${chapter.slug}.mp3`);
       const segPath = join(audioRoot, `${chapter.slug}.segments.json`);
+      const peaksPath = join(audioRoot, `${chapter.slug}.peaks.json`);
 
       /* Atomic write: temp-then-rename so a crash mid-write doesn't leave a
          half-MP3 that scan.ts would mistake for a completed chapter. */
@@ -510,6 +511,19 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
       await preserveExistingAsPrevious(audioRoot, chapter.slug);
       await writeJsonAtomic(segPath, segmentsFile);
       await rename(tmpMp3, mp3Path);
+      /* Plan 56: emit the waveform-envelope sibling alongside the MP3.
+         Failure is non-fatal — peaks are a visualization aid, not load-
+         bearing for playback — so we log + continue rather than abort the
+         render. The chapter-audio meta endpoint's missing-file fallback
+         returns `peaks: []` and the Listen view degrades gracefully. */
+      try {
+        await writeChapterPeaksFile(result.pcm, result.sampleRate, peaksPath);
+      } catch (err) {
+        /* eslint-disable-next-line no-console */
+        console.warn(
+          `[generation] failed to write peaks for ${chapter.slug}: ${(err as Error).message}`,
+        );
+      }
 
       /* Update state.json with the freshly-measured duration so the library
          + future playback slice can render it without re-reading the audio.

--- a/server/src/tts/mp3.test.ts
+++ b/server/src/tts/mp3.test.ts
@@ -5,8 +5,12 @@
    hint from scripts/start-app.ps1 preflight). */
 
 import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, existsSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it, expect } from 'vitest';
-import { encodePcmToMp3 } from './mp3.js';
+import { encodePcmToMp3, writeChapterPeaksFile, type ChapterPeaksFile } from './mp3.js';
+import { BIN_COUNT } from '../audio/compute-peaks.js';
 
 const ffmpegPresent = (() => {
   try {
@@ -107,3 +111,70 @@ if (!ffmpegPresent) {
       'Install: winget install Gyan.FFmpeg',
   );
 }
+
+/* writeChapterPeaksFile coverage (plan 56). No ffmpeg dependency — this is
+   pure compute + fs, so it runs unconditionally even on CI without ffmpeg. */
+describe('writeChapterPeaksFile', () => {
+  function workDir(): string {
+    return mkdtempSync(join(tmpdir(), 'audiobook-peaks-test-'));
+  }
+
+  it('writes a {peaks: number[240]} JSON file at the requested path', async () => {
+    const dir = workDir();
+    try {
+      const peaksPath = join(dir, 'audio', 'ch-one.peaks.json');
+      const pcm = sinePcm(24_000, 1.0);
+      await writeChapterPeaksFile(pcm, 24_000, peaksPath);
+
+      expect(existsSync(peaksPath)).toBe(true);
+      const parsed: ChapterPeaksFile = JSON.parse(readFileSync(peaksPath, 'utf8'));
+      expect(Array.isArray(parsed.peaks)).toBe(true);
+      expect(parsed.peaks).toHaveLength(BIN_COUNT);
+      for (const v of parsed.peaks) {
+        expect(Number.isFinite(v)).toBe(true);
+        expect(v).toBeGreaterThanOrEqual(0);
+        expect(v).toBeLessThanOrEqual(1);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('creates intermediate directories (matches mkdir { recursive: true })', async () => {
+    const dir = workDir();
+    try {
+      const peaksPath = join(dir, 'nested', 'audio', 'ch-x.peaks.json');
+      await writeChapterPeaksFile(sinePcm(24_000, 0.1), 24_000, peaksPath);
+      expect(existsSync(peaksPath)).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('atomic rename leaves no .tmp-* droppings in the audio dir on success', async () => {
+    const dir = workDir();
+    try {
+      const audioDir = join(dir, 'audio');
+      const peaksPath = join(audioDir, 'ch-clean.peaks.json');
+      await writeChapterPeaksFile(sinePcm(24_000, 0.1), 24_000, peaksPath);
+      const entries = readdirSync(audioDir);
+      const droppings = entries.filter((e) => e.includes('.tmp-'));
+      expect(droppings).toEqual([]);
+      expect(entries).toContain('ch-clean.peaks.json');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('silent PCM yields an all-zero peaks array (no NaN serialized)', async () => {
+    const dir = workDir();
+    try {
+      const peaksPath = join(dir, 'silent.peaks.json');
+      await writeChapterPeaksFile(Buffer.alloc(24_000 * 2), 24_000, peaksPath);
+      const parsed: ChapterPeaksFile = JSON.parse(readFileSync(peaksPath, 'utf8'));
+      expect(parsed.peaks).toEqual(new Array(BIN_COUNT).fill(0));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/src/tts/mp3.ts
+++ b/server/src/tts/mp3.ts
@@ -6,9 +6,19 @@
 
    ffmpeg is a hard runtime dep; scripts/start-app.ps1 preflights it. We do
    NOT mock the encoder boundary in tests — the integration suite spawns the
-   real subprocess so we catch wire-format / flag-name drift. */
+   real subprocess so we catch wire-format / flag-name drift.
+
+   Sibling responsibility (plan 56): `writeChapterPeaksFile` reduces the same
+   chapter PCM to a fixed-length (240-bin) RMS-peaks envelope and persists
+   it under `<bookDir>/audio/<slug>.peaks.json` using the same temp-then-
+   rename atomic-write convention `writeJsonAtomic` uses elsewhere. The
+   chapter-audio meta endpoint reads it back; absence is graceful and yields
+   `peaks: []` so chapters generated before this plan keep loading. */
 
 import { spawn } from 'node:child_process';
+import { mkdir, rename, unlink, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { computePeaks } from '../audio/compute-peaks.js';
 
 export interface EncodePcmToMp3Options {
   /** LAME VBR quality: 0 (best, larger) .. 9 (worst, smaller). Default 2
@@ -81,4 +91,47 @@ export async function encodePcmToMp3(
 
     child.stdin.end(pcm);
   });
+}
+
+/** Disk shape of `<bookDir>/audio/<slug>.peaks.json`. Single field today —
+ *  the wrapper object exists so future per-chapter audio metadata (loudness
+ *  / true-peak / channel layout) can land alongside without a second sibling
+ *  file or a schema-version negotiation. */
+export interface ChapterPeaksFile {
+  /** Length-240 RMS envelope, every value in `[0, 1]`. See
+   *  `server/src/audio/compute-peaks.ts` for the reduction contract. */
+  peaks: number[];
+}
+
+/** Reduce `pcm` to a 240-bin RMS envelope and persist it as JSON at
+ *  `peaksPath` using the same atomic temp-then-rename pattern
+ *  `writeJsonAtomic` uses (write `path.tmp-<pid>-<ts>`, fsync via
+ *  `writeFile`, rename over target; cleanup the temp file on terminal
+ *  failure so we don't leak `.tmp-*` droppings into the workspace).
+ *
+ *  Called by `generation.ts` alongside `encodePcmToMp3` so the peaks land
+ *  next to the MP3 in one render pass. Failure here is non-fatal — peaks
+ *  are a visualization aid, not load-bearing for playback — but we still
+ *  reject so the caller can decide whether to log / surface; today
+ *  generation.ts awaits the write to keep the on-disk state consistent
+ *  with the segments.json + MP3 it just emitted. */
+export async function writeChapterPeaksFile(
+  pcm: Buffer,
+  sampleRate: number,
+  peaksPath: string,
+): Promise<void> {
+  const peaks = computePeaks(pcm, sampleRate);
+  const payload: ChapterPeaksFile = { peaks };
+  await mkdir(dirname(peaksPath), { recursive: true });
+  const tmp = `${peaksPath}.tmp-${process.pid}-${Date.now()}`;
+  await writeFile(tmp, JSON.stringify(payload, null, 2), 'utf8');
+  try {
+    await rename(tmp, peaksPath);
+  } catch (err) {
+    /* Clean up the temp file on terminal failure (matches writeJsonAtomic
+       in workspace/state-io.ts). Swallow unlink errors — the rename
+       failure is the real one to surface. */
+    await unlink(tmp).catch(() => {});
+    throw err;
+  }
 }


### PR DESCRIPTION
## Summary

Closes BACKLOG Could #35. Server-only: replaces the chapter-audio meta endpoint's mock `peaks: []` with a real 240-bin RMS-peaks summary emitted at chapter encode time.

- New `server/src/audio/compute-peaks.ts` — pure 240-bin RMS reducer, normalized 0..1.
- `server/src/tts/mp3.ts` writes `<slug>.peaks.json` sibling on every encode.
- `server/src/routes/chapter-audio.ts` meta endpoint returns peaks; missing file → graceful `peaks: []` fallback (legacy chapters keep working).
- No frontend changes — Listen view already consumes `peaks: float[]`.

22 new server Vitest cases (15 compute-peaks + 4 mp3 sibling-write + 3 meta endpoint).

## Test plan

- [x] `npm run verify` green locally
- [x] Compute-peaks correctness on synthetic signals (silence, sine, ramp)
- [x] Missing-file fallback returns `[]` (not 500)
- [ ] Manual: regenerate a chapter, confirm `<slug>.peaks.json` lands on disk, waveform card paints real peaks

Pairs with `docs/features/56-real-chapter-peaks.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)