### PR TITLE
test(e2e): plan 58 — un-quarantine + binary upload + serial-mode contention fix

### DIFF
--- a/docs/features/58-e2e-coverage-refresh.md
+++ b/docs/features/58-e2e-coverage-refresh.md
@@ -1,0 +1,131 @@
+---
+status: active
+shipped: null
+owner: null
+---
+
+# 58 — E2E coverage refresh
+
+> Status: active
+> Key files: `e2e/listen-playback.spec.ts`, `e2e/new-book-flow.spec.ts`,
+> `e2e/binary-upload.spec.ts` (NEW), plus serial-mode fixes on
+> `cover-framing`, `smoke`, `revision-diff`, `toast-surface`,
+> `theme-toggle` (six spec files total).
+> URL surface: none (test-only).
+> OpenAPI ops: none.
+
+## Benefit / Rationale
+
+- **Technical:** Restores e2e coverage on the two highest-blast-radius
+  surfaces (mini-player play + new-book cold-boot walk) that plan 46
+  parked when they flaked under parallel-worker contention. Until this
+  plan, both code paths had only Vitest+jsdom coverage — which is known
+  to lie about audio playback timing and SSE phase ordering.
+- **Technical:** Adds binary-upload coverage for EPUB / PDF / MOBI /
+  AZW3 (the four extensions plan 52 enabled). Today only the text-paste
+  path is exercised in e2e; the binary route is unit-tested at the
+  parser level but the browser-level handleFile → setImportCandidate →
+  confirm-metadata seam was untested.
+- **Technical:** Eliminates the flaky e2e specs that hard-failed across
+  multiple verify runs under contention (cover-framing, smoke, toast-
+  surface, theme-toggle, revision-diff). Each now uses file-level
+  `test.describe.configure({ mode: 'serial' })` so its tests run in
+  one worker while other spec files still parallelise — recovers
+  stability without sacrificing overall throughput.
+
+## Architectural impact
+
+- **No production changes.** Plan 58 is purely test-side.
+- **New seam:** none. The file-level `test.describe.configure({ mode:
+  'serial' })` directive is a Playwright primitive used as a workaround
+  for worker-contention races that don't reflect a real product bug.
+- **Invariants preserved:**
+  - Plan 37 (Playwright e2e harness): chromium-only, mock mode on
+    port 5174, same `playwright.config.ts` worker/retry policy.
+  - Plan 46 (lint baseline): test files satisfy ESLint defaults.
+  - Plan 52 (MOBI/AZW3 parsing): the new binary-upload spec uses dummy
+    buffers, not real binary fixtures — mock api.uploadManuscript
+    accepts any file payload. Real-binary coverage for MOBI/AZW3
+    remains an open follow-up (BACKLOG): needs Calibre's `ebook-
+    convert` to generate fixtures, which is a per-developer install.
+
+## v1.3.0 scope
+
+- ✅ Un-quarantine `e2e/listen-playback.spec.ts`. Replace `test.fixme`
+  with file-level serial mode.
+- ✅ Un-quarantine `e2e/new-book-flow.spec.ts`. Same treatment.
+- ✅ Apply file-level serial mode to five other consistently-flaky
+  spec files: `cover-framing`, `smoke`, `revision-diff`,
+  `toast-surface`, `theme-toggle`. These weren't quarantined but
+  hard-failed in multiple verify runs across the v1.3.0 development.
+- ✅ Add `e2e/binary-upload.spec.ts` — covers EPUB / PDF / MOBI /
+  AZW3 upload routing through the mock api. 4 specs, one per
+  extension.
+- ⏳ Real-binary fixtures for MOBI/AZW3 — punted. Requires Calibre
+  install + `scripts/gen-parser-fixtures.mjs` extension. Documented
+  in this plan's Out-of-scope section.
+
+## Invariants to preserve
+
+1. **Serial mode is per-file, not global.** Each affected spec carries
+   its own `test.describe.configure({ mode: 'serial' })` at the file
+   top. Other spec files keep running in parallel — the contention
+   isolation is just within a problematic file's own tests, not across
+   the suite.
+2. **Mock-mode upload accepts any file.** The binary-upload spec
+   relies on `mockUploadManuscript` (`src/lib/api.ts`) not parsing
+   file content — it just generates a random `manuscriptId` and
+   returns an `UploadResponse`. The spec's dummy buffers are valid
+   inputs.
+3. **The two un-quarantined specs (`listen-playback`,
+   `new-book-flow`) cover golden-path behaviour that no other spec
+   pins.** They're the primary regression tests for the
+   `<audio>`-play + new-book-cold-boot seams.
+
+## Test plan
+
+### Automated coverage
+
+This entire plan IS the automated coverage. Specifically:
+
+- `e2e/listen-playback.spec.ts` (un-quarantined, serial) — 1 spec.
+- `e2e/new-book-flow.spec.ts` (un-quarantined, serial) — 1 spec.
+- `e2e/binary-upload.spec.ts` (NEW, serial) — 4 specs (one per
+  extension).
+- `e2e/cover-framing.spec.ts` (serial added) — no spec changes,
+  contention fix.
+- `e2e/smoke.spec.ts` (serial added) — contention fix.
+- `e2e/revision-diff.spec.ts` (serial added) — contention fix.
+- `e2e/toast-surface.spec.ts` (serial added) — contention fix.
+- `e2e/theme-toggle.spec.ts` (serial added) — contention fix.
+
+### Acceptance
+
+`npm run verify` lands green at least 5 times in a row on a Windows
+host with default parallel workers. (Plan 46 quarantined the two
+worst offenders because they were 0-for-N green on a busy Windows
+box; plan 58's serial-mode fix should make all eight affected files
+deterministically green.)
+
+## Out of scope
+
+- **Real MOBI / AZW3 fixtures.** Needs Calibre's `ebook-convert` and
+  a per-developer install. The current binary-upload spec covers the
+  routing seam with dummy buffers; full parser-integration coverage
+  would need real fixtures. BACKLOG follow-up item — keep the entry
+  open after this plan ships.
+- **Per-worker tuning of `playwright.config.ts`.** File-level serial
+  mode is the right fix because the contention is inside specific
+  specs (audio timing, SSE phase, localStorage round-trips); a global
+  workers=1 would tank overall runtime needlessly.
+- **Fixing the `visual.spec.ts` flakes (visual library/upload).**
+  Those are flaky-but-pass-on-retry, not hard-failing. They likely
+  need their own investigation (likely a layout race during the first
+  paint). Tracked separately.
+- **Removing the BACKLOG entry for "e2e binary-upload coverage".**
+  Plan 58 partially closes it (routing seam); the entry stays open
+  until the real MOBI/AZW3 fixture path lands.
+
+## Ship notes
+
+(Filled in when status flips to `stable`.)

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -105,6 +105,7 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 - [26 — RTK Immer drafts](26-rtk-immer.md) — Reducers mutate, never spread.
 - [38 — Branching & commit convention](38-branching-and-commit-convention.md) — Trunk-based branching + Conventional-Commits subject format; `.husky/commit-msg` gates the convention.
 - [44 — Pull request hygiene](44-pr-hygiene.md) — PR template + PR-title lint workflow + merge-commit-only / delete-branch-on-merge repo settings; codifies the Summary / Test plan shape PRs #1-#4 already use.
+- [58 — E2E coverage refresh](58-e2e-coverage-refresh.md) — Un-quarantines `listen-playback` + `new-book-flow`, adds binary-upload coverage (EPUB/PDF/MOBI/AZW3), and applies file-level serial mode to five contention-flaky spec files (cover-framing, smoke, revision-diff, toast-surface, theme-toggle).
 - [45 — Vitest pool tuning + one-retry policy](45-vitest-pool-tuning.md) — Caps the server-suite forks pool at 4 and turns on `retry: 1` on both Vitest configs so transient tinypool "Worker exited unexpectedly" failures no longer force a full pre-push re-run.
 - [46 — Lint, format, a11y baseline](archive/46-lint-format-a11y.md) — ESLint 8 + Prettier 3 + axe-core on four core views; lint prepended to `verify`. Shipped 2026-05-18.
 - [48 — Global toast surface](archive/48-toast-surface.md) — `notifications` slice + `<ToastStack/>`; stream-middleware halts + export 5xx dispatch through it; dedupe-by-key collapses repeats; auto-dismiss 6 s. Shipped 2026-05-18.

--- a/e2e/binary-upload.spec.ts
+++ b/e2e/binary-upload.spec.ts
@@ -1,0 +1,55 @@
+/* Plan 58 — binary-upload coverage for EPUB / PDF / MOBI / AZW3.
+ *
+ * Walks the upload flow once per binary extension to confirm the
+ * router's BINARY_EXT_RE branch is wired and the mock upload api
+ * routes the parsed candidate into the confirm-metadata view.
+ *
+ * Under VITE_USE_MOCKS=true the mock api.uploadManuscript accepts any
+ * file — it doesn't try to parse it. So we use small dummy buffers
+ * with the right extensions to exercise the upload UI's
+ * extension-routing seam without needing real MOBI/AZW3 fixtures
+ * (those would need Calibre to generate — out of scope here).
+ *
+ * Pairs with docs/features/58-e2e-coverage-refresh.md +
+ * docs/features/archive/52-mobi-parsing.md.
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.describe.configure({ mode: 'serial' });
+
+const FORMATS: Array<{ ext: 'epub' | 'pdf' | 'mobi' | 'azw3'; mimeType: string }> = [
+  { ext: 'epub', mimeType: 'application/epub+zip' },
+  { ext: 'pdf', mimeType: 'application/pdf' },
+  { ext: 'mobi', mimeType: 'application/x-mobipocket-ebook' },
+  { ext: 'azw3', mimeType: 'application/vnd.amazon.ebook' },
+];
+
+test.describe('plan 58 — binary upload (mock)', () => {
+  for (const { ext, mimeType } of FORMATS) {
+    test(`uploads a .${ext} and lands on the confirm-metadata view`, async ({ page }) => {
+      await page.goto('/#/new');
+      await expect(page).toHaveURL(/#\/new$/);
+
+      /* Locate the hidden file input. The Upload view's <input> has
+         accept="...,.{ext}" — the browser DOES enforce accept on file
+         pickers, but setInputFiles bypasses that to simulate a drag-
+         drop drop. We submit a tiny dummy buffer with the right
+         extension; the mock api routes purely on file.name. */
+      const fileInput = page.locator('input[type="file"]');
+      await fileInput.setInputFiles({
+        name: `sample.${ext}`,
+        mimeType,
+        // Non-empty buffer so the mock upload's byteSize > 0.
+        buffer: Buffer.from('binary fixture content for plan 58 e2e'),
+      });
+
+      /* Mock-mode handleFile → guardedUpload → setImportCandidate →
+         UploadRoute swaps in the confirm-metadata view. Same URL
+         (#/new), different view. Assert the submit button visible. */
+      await expect(page.getByRole('button', { name: /Save book and start analysis/i })).toBeVisible(
+        { timeout: 5_000 },
+      );
+    });
+  }
+});

--- a/e2e/cover-framing.spec.ts
+++ b/e2e/cover-framing.spec.ts
@@ -9,6 +9,11 @@
 
 import { test, expect } from '@playwright/test';
 
+/* Plan 58 — file-level serial mode. The CoverPicker upload flow
+   flaked under parallel-worker contention (file-upload + auto-tab-
+   switch race other workers' Vite asset traffic on Windows). */
+test.describe.configure({ mode: 'serial' });
+
 const TINY_PNG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
 

--- a/e2e/listen-playback.spec.ts
+++ b/e2e/listen-playback.spec.ts
@@ -11,13 +11,15 @@
 
 import { test, expect } from '@playwright/test';
 
+/* Plan 58 — un-quarantined 2026-05-19. The earlier quarantine was a
+   parallel-worker contention problem: the audio.currentTime poll
+   raced other workers' SSE traffic on Windows. file-level serial mode
+   keeps this spec's tests in one worker while other spec files still
+   parallelise, recovering most throughput without the flake. */
+test.describe.configure({ mode: 'serial' });
+
 test.describe('listen view + mini-player', () => {
-  /* Quarantined 2026-05-18 (plan 46): the audio.currentTime poll at
-     line ~69 fails under Playwright parallel-worker contention on
-     Windows but passes consistently in isolation. Two retries don't
-     clear it. Not a real regression — see BACKLOG Could "e2e
-     parallel-worker contention" for the follow-up. */
-  test.fixme('opens Solway Bay listen view, clicks play, audio src + paused flip', async ({ page }) => {
+  test('opens Solway Bay listen view, clicks play, audio src + paused flip', async ({ page }) => {
     /* Direct navigation rather than clicking through the library so this
        spec stays orthogonal to the library-card click path covered by
        revision-diff.spec.ts. The mock seed populates state for 'sb'

--- a/e2e/new-book-flow.spec.ts
+++ b/e2e/new-book-flow.spec.ts
@@ -28,14 +28,15 @@ async function getStageKind(page: Page): Promise<string> {
   });
 }
 
+/* Plan 58 — un-quarantined 2026-05-19. Earlier quarantine was a
+   parallel-worker contention problem: SSE phase transitions in this
+   long cold-boot walk could miss their event window when other
+   workers' Vite/SSE traffic backed up. file-level serial mode keeps
+   this spec in one worker while other spec files still parallelise. */
+test.describe.configure({ mode: 'serial' });
+
 test.describe('new book flow', () => {
-  /* Quarantined 2026-05-18 (plan 46): the full cold-boot →
-     upload → analysing → confirm → ready walk races on SSE phase
-     transitions under Playwright parallel-worker contention. Passes
-     in isolation; two retries don't clear it under load. Not a real
-     regression — see BACKLOG Could "e2e parallel-worker contention"
-     for the follow-up. */
-  test.fixme('cold boot → upload → analysing → confirm → ready', async ({ page }) => {
+  test('cold boot → upload → analysing → confirm → ready', async ({ page }) => {
     /* Step 1: cold boot lands on the library. */
     await page.goto('/');
     await expect(page.getByRole('button', { name: /Start a new book/i }).first()).toBeVisible({

--- a/e2e/revision-diff.spec.ts
+++ b/e2e/revision-diff.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '@playwright/test';
 
+/* Plan 58 — file-level serial mode. The revisions poll cycle's SSE-
+   like timing intermittently raced under parallel-worker contention. */
+test.describe.configure({ mode: 'serial' });
+
 /**
  * Revision-diff a/b audition pill — plan 20 follow-on (backlog Must #2).
  *

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '@playwright/test';
 
+/* Plan 58 — file-level serial mode. The cold-boot smoke test
+   intermittently raced other workers' Vite startup under contention. */
+test.describe.configure({ mode: 'serial' });
+
 /**
  * Golden-path smoke test — first Playwright spec.
  *

--- a/e2e/theme-toggle.spec.ts
+++ b/e2e/theme-toggle.spec.ts
@@ -16,6 +16,10 @@
 
 import { test, expect } from '@playwright/test';
 
+/* Plan 58 — file-level serial mode. The localStorage-driven theme
+   override + reload assertions intermittently raced under contention. */
+test.describe.configure({ mode: 'serial' });
+
 test.describe('plan 41 — theme toggle', () => {
   test('cycles system → light → dark and persists across a reload', async ({ page }) => {
     await page.goto('/');

--- a/e2e/toast-surface.spec.ts
+++ b/e2e/toast-surface.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '@playwright/test';
 
+/* Plan 58 — file-level serial mode. The auto-dismiss 6s window
+   timing intermittently raced under parallel-worker contention. */
+test.describe.configure({ mode: 'serial' });
+
 /**
  * Browser-level coverage for the global toast surface (plan 48).
  *


### PR DESCRIPTION
## Summary

Closes BACKLOG Could #20 (un-quarantine listen-playback + new-book-flow) and partially closes Could #38 (binary-upload e2e coverage).

- Un-quarantines `e2e/listen-playback.spec.ts` (mini-player play golden path) and `e2e/new-book-flow.spec.ts` (full cold-boot → ready walk). Both used `test.fixme` since plan 46 due to parallel-worker contention.
- Applies `test.describe.configure({ mode: 'serial' })` at the file top of those two plus five other consistently-failing specs: `cover-framing`, `smoke`, `revision-diff`, `toast-surface`, `theme-toggle`. Each runs its tests in one worker; other spec files still parallelise.
- Adds `e2e/binary-upload.spec.ts` covering EPUB / PDF / MOBI / AZW3 upload routing through the mock api. 4 specs.

Verify result before plan 58: 3-5 hard failures per run. After: 33 passed, 1 flaky-passed-on-retry, 0 hard-failures.

## Test plan

- [x] `npm run test:e2e` locally → 33 passed, 1 flaky, 0 hard fail
- [ ] Confirm pre-existing flakes are now stable across 5 consecutive runs

Pairs with `docs/features/58-e2e-coverage-refresh.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)