### PR TITLE
feat(frontend,server,openapi): plan 53 — playback speed + markers + sleep timer

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -27,7 +27,7 @@ the same PR — the backlog is only useful while it stays current.
 
 Ranking within each bucket = top is highest priority.
 
-**Counts as of 2026-05-18 (post plan 52 commit):** Must 0 · Should 2 · Could 33 · Won't 9
+**Counts as of 2026-05-19 (post plan 53 commit):** Must 0 · Should 1 · Could 31 · Won't 9
 
 ---
 
@@ -38,16 +38,6 @@ Ranking within each bucket = top is highest priority.
 ---
 
 ## Should — important, not blocking ship
-
-### 1. Playback speed control in the mini-player
-
-Source: net-new (2026-05-18). Promoted from Could to Should in Round 0 re-prioritisation — table-stakes audiobook listener feature, missing today.
-
-- _What:_ Add a speed-selector affordance to the mini-player exposing 0.75x / 1.0x / 1.25x / 1.5x / 1.75x / 2.0x rates. Uses `HTMLMediaElement.playbackRate` (browser-native, no audio reprocessing). Selection persists per book in `listen-progress.json` so a chosen rate carries across sessions.
-- _Acceptance:_ Play chapter, click 1.5x → playback speeds up immediately, pitch unchanged. Refresh → still at 1.5x. Vitest covers the slice extension; e2e covers the speed-change + persistence flow.
-- _Key files:_ `src/components/mini-player.tsx` (speed picker UI); `src/store/listen-progress-slice.ts` (extend with `playbackRate`); `server/src/routes/listen-progress.ts` (payload extension); new `e2e/playback-speed.spec.ts`.
-- _Depends on:_ plan 47 (listen progress) shipped — relies on the same persistence seam.
-- _Benefit (user):_ standard audiobook player feature; users expect 0.75x–2x as basic controls. Today only 1x is available, forcing browser zoom-and-pinch or per-chapter regeneration workarounds.
 
 ### 2. Extend verify-cache to `verify:fast` (pre-commit gate)
 
@@ -94,26 +84,6 @@ Source: net-new (2026-05-18). Pairs with Could #1 (loudnorm).
 - _Key files:_ new `src/components/loudness-report.tsx`; `src/views/listen.tsx` (mount); `server/src/tts/mp3.ts` (emit loudness metadata to chapter meta); `server/src/routes/chapter-audio.ts` (surface in meta endpoint).
 - _Depends on:_ Could #1 (loudnorm) — without normalization there's no expected target to compare against.
 - _Benefit (user):_ catch problem chapters before export (e.g. a voice that came out 4 LU softer than the rest). Pairs with Could #1 to make loudness drift visible, not just corrected.
-
-### 4. User-placed markers / bookmarks in the listen view
-
-Source: net-new (2026-05-18). Builds on plan 47's `listen-progress.json` persistence seam.
-
-- _What:_ Extend `listen-progress.json` to carry a `markers: Array<{ id, chapterId, sec, label, kind: 'note' | 'rerecord', createdAt }>` list per book. Listen-view mini-player exposes "Add bookmark here" affordance (keyboard shortcut + button) that captures the current `chapterId + currentSec`. Sidebar lists all markers per chapter, click → seek to that position. Each marker has a short editable label and a kind toggle (general note vs flag for re-record).
-- _Acceptance:_ Drop a marker at 1:23 in chapter 3 with label "re-record this", reload page, marker persists and click-to-seek returns to 1:23 ±1s. Vitest covers the slice (add/edit/delete marker, payload roundtrip). Server Vitest covers the marker payload extension. New e2e spec covers add-marker + reload + seek.
-- _Key files:_ `src/store/listen-progress-slice.ts` (extend reducers); `src/views/listen.tsx` (sidebar + add-button); `src/components/mini-player.tsx` (shortcut); `server/src/routes/listen-progress.ts` (payload extension); new `e2e/listen-bookmarks.spec.ts`.
-- _Depends on:_ plan 47 shipped (already shipped 2026-05-17).
-- _Benefit (user):_ today re-record candidates have nowhere to live — the user must remember a timestamp manually. Markers give a per-book scratchpad of "fix this later" annotations without leaving the listen view.
-
-### 5. Sleep timer + auto-stop on chapter boundary
-
-Source: net-new (2026-05-18). Validated absent in `src/components/mini-player.tsx`.
-
-- _What:_ Add a sleep-timer affordance to the mini-player: countdown picker (15 / 30 / 45 / 60 min, plus "End of chapter" option). When the timer expires, the player pauses and saves the listen-progress position. The "End of chapter" mode pauses at the next chapter boundary regardless of elapsed time. Picker UI is a dropdown menu off a clock icon in the mini-player.
-- _Acceptance:_ Set 5-minute timer, leave playing, after 5 min mini-player auto-pauses and listen-progress is saved. Set "End of chapter" while at 2:00/15:00 → auto-pauses at 15:00 (chapter end). Vitest covers the timer state machine; e2e spec covers the "end of chapter" boundary case.
-- _Key files:_ `src/components/mini-player.tsx`; new `src/lib/sleep-timer.ts` (state machine); `src/store/listen-progress-slice.ts` (no changes — relies on existing save).
-- _Depends on:_ plan 47 shipped (relies on the same save seam).
-- _Benefit (user):_ standard audiobook listener pattern — most listeners fall asleep mid-chapter and want playback to stop at a natural boundary. Parity with standalone audiobook apps.
 
 ### 6. Share a 30-second chapter clip as MP3
 

--- a/docs/features/53-mini-player-feature-pack.md
+++ b/docs/features/53-mini-player-feature-pack.md
@@ -1,0 +1,91 @@
+---
+status: active
+shipped: null
+owner: null
+---
+
+# Mini-player feature pack (playback speed + markers + sleep timer)
+
+> Status: active
+> Key files: `src/components/mini-player.tsx`, `src/views/listen.tsx`, `src/store/listen-progress-slice.ts`, `src/lib/sleep-timer.ts`, `server/src/routes/book-state.ts`
+> URL surface: indirect — mini-player is mounted by `src/components/layout.tsx` whenever `stage.kind === 'ready'` AND `ui.currentTrack != null`; markers sidebar lives inside `#/books/<id>/listen`.
+> OpenAPI ops: `PUT /api/books/{bookId}/listen-progress` (request body extended with optional `playbackRate` + `markers`); `ListenProgress` + new `ListenMarker` schemas.
+
+## Benefit / Rationale
+
+Three table-stakes audiobook-player affordances shipped together because they touch the same surface (mini-player toolbar + listen-progress persistence) and the same slice extension. Splitting into three PRs would mean three round-trip slice migrations + three server-validator passes for what's structurally one change.
+
+- **User (playback speed):** standard audiobook player feature; users expect 0.75× — 2× as basic controls. Today only 1.0× is available, forcing browser zoom-and-pinch or per-chapter regeneration workarounds.
+- **User (markers / bookmarks):** today re-record candidates have nowhere to live — the user has to remember a timestamp manually. Markers give a per-book scratchpad of "fix this later" annotations without leaving the listen view.
+- **User (sleep timer):** standard audiobook listener pattern; most listeners fall asleep mid-chapter and want playback to stop at a natural boundary. Parity with standalone audiobook apps.
+- **Technical:** all three reuse the plan-47 persistence seam (`.audiobook/listen-progress.json` + the slice's per-book Map) instead of opening fresh on-disk JSON files. The sleep timer is per-session by design; the other two persist via the existing debounced-PUT path.
+- **Architectural:** the sleep-timer state machine (`src/lib/sleep-timer.ts`) is a pure JS module with NO React dependencies. The mini-player owns the timer reference; the player's own onTimeUpdate + onEnded handlers feed the machine. This keeps the React component readable and the state transitions unit-testable in isolation.
+
+## Architectural impact
+
+**New seams / extension points:**
+
+- `src/lib/sleep-timer.ts` — pure state machine; takes `now` as a seam so tests don't have to mock `Date.now()`.
+- `src/store/listen-progress-slice.ts` — extended with `playbackRate?: number`, `markers?: ListenMarker[]`, and a one-shot `pendingSeek` channel for the marker-click → mini-player seek path. New reducers: `setPlaybackRate`, `addMarker`, `editMarker`, `deleteMarker`, `requestSeek`, `consumeSeek`. New selector: `selectPendingSeek`. New helper: `getPlaybackRate(record)` returns 1.0 when the field is absent (lazy-migration for pre-plan-53 on-disk records).
+- `server/src/routes/book-state.ts` — PUT validator gains optional `playbackRate` (range 0.25 – 4.0) and `markers` (each validated through `validateMarker`). Bad `kind` → 400 with `markers[N]: marker.kind must be one of: note, rerecord`. Marker shape: `{ id, chapterId, sec, label, kind, createdAt }`.
+- `openapi.yaml` — `ListenProgress` extended; new `ListenMarker` schema with `kind: enum [note, rerecord]`. Regenerated `src/lib/api-types.ts` reflects both.
+- `src/lib/api.ts` — `ListenProgress` type + `mockPutListenProgress` extended with the two optional fields; `PutListenProgressArgs` exported for the mini-player's typed call sites.
+
+**Invariants preserved from plan 47 (the listen-progress predecessor):**
+
+- The PUT debounce stays at 5 s wall-clock + 5 s minimum position (`onTimeUpdate` only fires the position save once per 5 s of wall time, and never below 5 s into the chapter). The new `playbackRate` save happens out-of-band on the picker click and is NOT subject to this debounce — the user expects an instant on-disk update after a rate change.
+- `onLoadedMetadata` still applies the resume bookmark via `pendingSeekRef`. The new code path (marker-click on the currently-playing chapter) re-uses the same ref for the case where the audio isn't yet loaded; for the loaded case it sets `el.currentTime` directly.
+- No `redux-persist`; the slice stays in-memory only, the server file at `.audiobook/listen-progress.json` is authoritative.
+- The `update` reducer now PRESERVES `playbackRate` + `markers` across position-only updates so the debounced PUT (which carries only `chapterId` + `currentSec`) doesn't accidentally drop the user's chosen rate or marker list between saves.
+
+**Migration story:**
+
+- On-disk records written before plan 53 have neither `playbackRate` nor `markers`. The slice + server treat both as optional; `getPlaybackRate()` returns 1.0 when missing. No re-write at hydrate — the next PUT round-trip drops the new fields onto disk naturally.
+
+**Reversibility:**
+
+- All three features are additive. Reverting the plan would leave pre-plan-53 records intact on disk; the fields would just be dropped on the next PUT. The sleep timer is per-session memory only, so a revert has no on-disk footprint.
+
+## Invariants to preserve
+
+Numbered list of structural rules a refactor must not break.
+
+1. The PUT debounce in `src/components/mini-player.tsx` onTimeUpdate handler stays gated on `(now - lastSavedAtRef.current >= 5000)` AND `(t > 5)`. Position-only updates never carry `playbackRate` or `markers` — those flow through their dedicated handlers (`onChangePlaybackRate`, `commitMarkerDraft`).
+2. `pendingSeekRef` in the mini-player is consumed exactly once per chapter-mount in `onLoadedMetadata`, capped at `d - 1` so a resume parked near the end doesn't immediately trigger `onEnded`. Plan 53 reuses the same ref for the marker-click-but-audio-not-loaded path.
+3. The sleep-timer state machine's transitions are exhaustively: `idle → countdown` (startCountdown), `idle → end-of-chapter` (startEndOfChapter), `countdown → fired` (tick past firesAt), `end-of-chapter → fired` (notifyChapterEnded), `* → idle` (cancel). `tick` is a no-op on non-countdown states; `notifyChapterEnded` is a no-op on non-end-of-chapter states. The mini-player flips `* → idle` after consuming the fire (so a fresh play click isn't instantly re-paused).
+4. The `requestSeek` / `consumeSeek` action pair in the listen-progress slice uses a monotonic `requestId`, NOT payload equality, to determine consumption. Two marker clicks at the same sec must still fire two seeks; `consumeSeek` with a stale `requestId` is a no-op.
+5. Marker kind enum is exactly `'note' | 'rerecord'`. Frontend `LISTEN_MARKER_KINDS` and server `LISTEN_MARKER_KINDS` carry the same literal; openapi.yaml `enum: [note, rerecord]` matches. Adding a kind requires touching all three.
+6. The mini-player's `M` keyboard shortcut never fires when the active element is an `INPUT`, `TEXTAREA`, or `contentEditable` — typing M in the marker label field doesn't trip a recursive marker-drop.
+
+## Test plan
+
+### Automated coverage
+
+- Vitest unit (`src/lib/sleep-timer.test.ts`) — 13 tests covering: `startCountdown` stamps `firesAt`; `tick` is a no-op before `firesAt`, transitions to `fired` at/past `firesAt`; `notifyChapterEnded` transitions only the `end-of-chapter` state; `cancel` before fire is a no-op on the eventual fire path; `remainingMs` counts down and clamps to 0; the preset list is the documented `[15, 30, 45, 60]`.
+- Vitest unit (`src/store/listen-progress-slice.test.ts`) — extended with: `playbackRate` hydrate roundtrip + default-1.0 fallback + `update` preserves rate across position updates + `setPlaybackRate` writes / seeds; `addMarker` / `editMarker` / `deleteMarker` + missing-id no-op + `update` preserves markers; `LISTEN_MARKER_KINDS` matches the documented enum; `requestSeek` / `consumeSeek` with monotonic requestId + stale-id no-op.
+- Vitest server (`server/src/routes/book-state.test.ts`) — extended with 6 cases: PUT round-trips `playbackRate`; 400 when rate is out of range or non-numeric; PUT round-trips `markers`; 400 when a marker carries an unknown `kind`; 400 when `markers` isn't an array; 400 when a marker is missing a required field.
+- Playwright e2e (`e2e/mini-player-features.spec.ts`) — 5 specs: picker selects 1.5× and the `<audio>` element's `playbackRate` reflects it; rehydrate-from-slice path adopts a pre-primed 1.5× rate; add marker + sidebar appearance + click-to-seek; end-of-chapter mode pauses on the audio onEnded event; countdown preset installs the remaining-time pill + cancel restores idle.
+
+### Manual acceptance walkthrough
+
+Run in mock mode (`VITE_USE_MOCKS=true`).
+
+1. **Cold boot at `#/`** → click "Solway Bay" library card → navigates to `#/books/sb/listen`.
+2. **Click "Play from the start"** → mini-player mounts at the bottom of the screen, chapter 1 audio starts playing, speed-toggle reads "1.0×".
+3. **Click the speed toggle, pick 1.5×** → the popover closes, the toggle label flips to "1.5×", and the audio noticeably speeds up. Reload the page (without closing the player) → on next play, the rate is still 1.5×.
+4. **Drop a marker via the Add button** → inline form appears under the player; type "re-record this", click Save. The "Markers" panel above the chapters list appears with the new entry under the current chapter's header. Click the trash-style ×, the marker disappears.
+5. **Drop a second marker, click its label in the panel** → the audio element seeks to that marker's position (visible as a jump in the play timestamp inside the player strip).
+6. **Open the sleep-timer menu, pick "End of chapter"** → the clock-icon button gets a small "End of ch" pill next to it. Skip to the last ~5 seconds of a chapter (via the scrubber) and let it play out → at the chapter end, the player pauses and the sleep pill disappears.
+7. **Open the sleep-timer menu, pick "15 min"** → a countdown pill appears showing mm:ss remaining. Click the toggle again, click "Cancel timer" → the pill disappears, the player keeps playing.
+8. **Hit `M` while the player is mounted** → the inline marker form opens (same as the button). Hit `Esc` → the form closes without saving.
+
+## Out of scope
+
+- Per-chapter loudness normalization, AAC/Opus output, manuscript diff viewer, and the other listening-UX items in `docs/BACKLOG.md` Could #1, #2, #6, #7, #8, #10 are independent rounds.
+- Custom keyboard shortcut config (only `M` for now); plan 30's keybinding surface is the place to extend if needed.
+- Marker labels rich text / colour tagging; current shape is plain string + 2-kind enum.
+- Server-side schema migration / on-disk version bump — pre-plan-53 records are lazily upgraded on the next PUT without explicit migration code.
+
+## Ship notes
+
+(Filled in when status flips to `stable`.)

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -84,6 +84,7 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 
 - [19 — Listener preview](19-preview-listener.md) — Listener-POV full-screen preview.
 - [47 — Listening progress / resume bookmarks](archive/47-listen-progress.md) — Per-book sibling `listen-progress.json`; mini-player seeks to the saved point on chapter mount; Listen view "Resume at MM:SS" pill. Shipped 2026-05-18.
+- [53 — Mini-player feature pack (playback speed + markers + sleep timer)](53-mini-player-feature-pack.md) — Speed picker (0.75× — 2×) persisted per book; user-placed markers (note / rerecord kinds) with a listen-view sidebar; sleep timer with countdown presets + end-of-chapter mode (per-session, not persisted). Extends plan 47's persistence seam.
 - [32 — Audiobook export](32-audiobook-export.md) — Sideload to PocketBook Reader (Phase A: MP3.ZIP) via LAN download or sync folder; per-chapter ID3v2.4 tags, no re-encode, atomic writes.
 - [34 — MP3-folder export](34-mp3-folder-export.md) — Per-chapter MP3s in a sub-folder for folder-scanning audiobook apps (Smart AudioBook Player, BookPlayer, Audiobookshelf). Sync-folder destination only; APIC cover travels with each chapter.
 

--- a/e2e/mini-player-features.spec.ts
+++ b/e2e/mini-player-features.spec.ts
@@ -10,6 +10,12 @@
 
 import { test, expect, type Page } from '@playwright/test';
 
+/* Serial within this file so the audio-element tests don't race each other
+   under parallel-worker contention on Windows. Other spec files still run
+   in parallel. Pattern mirrors what plan 58 applies to listen-playback +
+   new-book-flow. */
+test.describe.configure({ mode: 'serial' });
+
 async function openSolwayBay(page: Page): Promise<void> {
   await page.goto('/#/books/sb/listen');
   await expect(page.getByRole('heading', { name: /Solway Bay/i, level: 1 })).toBeVisible({

--- a/e2e/mini-player-features.spec.ts
+++ b/e2e/mini-player-features.spec.ts
@@ -1,0 +1,206 @@
+/* Browser-level coverage for plan 53 mini-player feature pack:
+ * playback speed picker, user-placed markers, sleep timer.
+ *
+ * Pairs with docs/features/53-mini-player-feature-pack.md.
+ *
+ * Persistence-across-reload is covered by the Vitest server spec for
+ * the PUT validator + the slice-roundtrip Vitest spec; here we drive
+ * the same flow through the real browser to lock the UI wiring +
+ * audio-element behaviour. */
+
+import { test, expect, type Page } from '@playwright/test';
+
+async function openSolwayBay(page: Page): Promise<void> {
+  await page.goto('/#/books/sb/listen');
+  await expect(page.getByRole('heading', { name: /Solway Bay/i, level: 1 })).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+async function startPlaybackFromStart(page: Page): Promise<void> {
+  const playButton = page.getByRole('button', { name: /Play from the start/i });
+  await expect(playButton).toBeVisible({ timeout: 5_000 });
+  await expect(playButton).toBeEnabled({ timeout: 5_000 });
+  await playButton.click();
+  await expect(page.locator('audio')).toHaveCount(1, { timeout: 3_000 });
+}
+
+test.describe('plan 53 — playback speed picker', () => {
+  test('selecting 1.5× updates the audio element playbackRate AND label', async ({ page }) => {
+    await openSolwayBay(page);
+    await startPlaybackFromStart(page);
+
+    const audio = page.locator('audio');
+    const speedToggle = page.getByTestId('mini-player-speed-toggle');
+    await expect(speedToggle).toBeVisible();
+    await expect(speedToggle).toHaveText(/1\.0×/);
+
+    /* Default rate before any user interaction is 1.0. */
+    await expect(audio).toHaveJSProperty('playbackRate', 1, { timeout: 3_000 });
+
+    /* Open picker, pick 1.5×. */
+    await speedToggle.click();
+    await page.getByTestId('mini-player-speed-option-1.5').click();
+    /* Label flips + the live audio element reflects the change. */
+    await expect(speedToggle).toHaveText(/1\.5×/);
+    await expect(audio).toHaveJSProperty('playbackRate', 1.5, { timeout: 3_000 });
+  });
+
+  test('rate selection persists after pre-priming the listen-progress slice (reload path)', async ({
+    page,
+  }) => {
+    /* Skip the picker-flow and seed the slice directly via
+       window.__store__, then assert that on a fresh chapter mount the
+       mini-player adopts the persisted rate. This is the second half
+       of the persistence story — Vitest covers the PUT path; here we
+       cover the rehydrate path through the browser. */
+    await openSolwayBay(page);
+    await page.evaluate(async () => {
+      const store = (
+        window as unknown as {
+          __store__: { dispatch: (a: unknown) => void };
+        }
+      ).__store__;
+      store.dispatch({
+        type: 'listenProgress/hydrate',
+        payload: {
+          bookId: 'sb',
+          progress: {
+            chapterId: 1,
+            currentSec: 0,
+            updatedAt: new Date().toISOString(),
+            playbackRate: 1.5,
+          },
+        },
+      });
+    });
+    await startPlaybackFromStart(page);
+    const audio = page.locator('audio');
+    await expect(audio).toHaveJSProperty('playbackRate', 1.5, { timeout: 5_000 });
+    await expect(page.getByTestId('mini-player-speed-toggle')).toHaveText(/1\.5×/);
+  });
+});
+
+test.describe('plan 53 — markers / bookmarks', () => {
+  test('add marker with label, marker appears in sidebar, click seeks the player', async ({
+    page,
+  }) => {
+    await openSolwayBay(page);
+    await startPlaybackFromStart(page);
+    const audio = page.locator('audio');
+
+    /* Pick a marker position inside the stub MP3's actual duration
+       (~0.65 s for stub-b.mp3) — seeking past the real audio's end
+       gets clamped + triggers onEnded, which the marker spec
+       shouldn't depend on. Wait for the duration to settle first so
+       the seek lands inside a valid window. */
+    await expect
+      .poll(async () => audio.evaluate((el: HTMLAudioElement) => el.duration), {
+        timeout: 5_000,
+      })
+      .toBeGreaterThan(0);
+    const dur = await audio.evaluate((el: HTMLAudioElement) => el.duration);
+    /* Halfway through the stub is a deterministic spot well inside
+       the valid range. Floor to two decimals so floating-point
+       drift doesn't push the assertion off by a frame. */
+    const markerSec = Math.max(0.1, Math.min(dur - 0.1, dur / 2));
+
+    /* Park the playhead at the chosen position before the marker drop
+       so the captured `currentSec` matches. Pause + seek + tick so
+       onTimeUpdate fires through currentSecRef. */
+    await audio.evaluate((el: HTMLAudioElement, s: number) => {
+      el.pause();
+      el.currentTime = s;
+      el.dispatchEvent(new Event('timeupdate'));
+    }, markerSec);
+
+    /* Drop a marker via the button (Plan 53 — `M` shortcut hits the
+       same path; button click is the more stable e2e affordance). */
+    await page.getByTestId('mini-player-add-marker').click();
+    const form = page.getByTestId('mini-player-marker-form');
+    await expect(form).toBeVisible({ timeout: 2_000 });
+
+    const input = page.getByTestId('mini-player-marker-input');
+    await input.fill('re-record this');
+    await page.getByTestId('mini-player-marker-save').click();
+    await expect(form).toBeHidden({ timeout: 2_000 });
+
+    /* Markers sidebar lights up with the new entry. */
+    const panel = page.getByTestId('listen-markers-panel');
+    await expect(panel).toBeVisible({ timeout: 3_000 });
+    await expect(panel.getByText(/re-record this/)).toBeVisible();
+
+    /* Move the playhead AWAY from the marker so the upcoming click is
+       a real seek (otherwise we'd be asserting that the audio stayed
+       at the same place — no signal). Seek to start. */
+    await audio.evaluate((el: HTMLAudioElement) => {
+      el.currentTime = 0;
+    });
+    await expect
+      .poll(async () => audio.evaluate((el: HTMLAudioElement) => el.currentTime), {
+        timeout: 2_000,
+      })
+      .toBeLessThan(0.1);
+
+    /* Click the marker → mini-player consumes pendingSeek via the
+       slice and snaps the audio element back to markerSec. */
+    await panel.locator('[data-testid^="listen-marker-seek-"]').first().click();
+    await expect
+      .poll(async () => audio.evaluate((el: HTMLAudioElement) => el.currentTime), {
+        timeout: 5_000,
+      })
+      .toBeGreaterThan(markerSec - 0.1);
+    const t = await audio.evaluate((el: HTMLAudioElement) => el.currentTime);
+    expect(t).toBeLessThan(markerSec + 0.5);
+  });
+});
+
+test.describe('plan 53 — sleep timer', () => {
+  test('end-of-chapter mode pauses the player on the audio onEnded event', async ({ page }) => {
+    /* Wall-clock countdown firing is unit-tested in
+       src/lib/sleep-timer.test.ts (deterministic via injected `now`).
+       End-of-chapter is the browser-driven path that needs an e2e
+       lock: only the live <audio> element emits `ended`. */
+    await openSolwayBay(page);
+    await startPlaybackFromStart(page);
+    const audio = page.locator('audio');
+    await expect(audio).toHaveJSProperty('paused', false, { timeout: 3_000 });
+
+    /* Arm end-of-chapter mode. */
+    await page.getByTestId('mini-player-sleep-toggle').click();
+    await page.getByTestId('mini-player-sleep-option-end-of-chapter').click();
+    await expect(page.getByTestId('mini-player-sleep-pill')).toHaveText(/end of ch/i, {
+      timeout: 2_000,
+    });
+
+    /* Fire the chapter-end event on the audio element. The
+       mini-player's onEnded handler sets playing=false AND notifies
+       the sleep-timer state machine, which transitions to fired and
+       triggers the pause path through the existing effect. */
+    await audio.evaluate((el: HTMLAudioElement) => {
+      el.dispatchEvent(new Event('ended'));
+    });
+
+    /* Player paused; the sleep-pill clears back to idle. */
+    await expect(audio).toHaveJSProperty('paused', true, { timeout: 3_000 });
+    await expect(page.getByTestId('mini-player-sleep-pill')).toBeHidden();
+  });
+
+  test('selecting a countdown preset surfaces the remaining-time pill', async ({ page }) => {
+    /* Sanity check that the countdown picker installs the pill — the
+       actual tick → fired transition is unit-tested deterministically
+       in sleep-timer.test.ts. */
+    await openSolwayBay(page);
+    await startPlaybackFromStart(page);
+
+    await page.getByTestId('mini-player-sleep-toggle').click();
+    await page.getByTestId('mini-player-sleep-option-15').click();
+    /* Pill renders with mm:ss countdown copy. */
+    await expect(page.getByTestId('mini-player-sleep-pill')).toBeVisible({ timeout: 2_000 });
+
+    /* Cancel restores the idle state — pill disappears. */
+    await page.getByTestId('mini-player-sleep-toggle').click();
+    await page.getByTestId('mini-player-sleep-cancel').click();
+    await expect(page.getByTestId('mini-player-sleep-pill')).toBeHidden();
+  });
+});

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -703,13 +703,30 @@ paths:
               properties:
                 chapterId: { type: integer, minimum: 0 }
                 currentSec: { type: number, minimum: 0 }
+                playbackRate:
+                  type: number
+                  minimum: 0.25
+                  maximum: 4.0
+                  description: |
+                    Plan 53 — per-book playback rate
+                    (`HTMLMediaElement.playbackRate`). Optional; absent on
+                    pre-plan-53 records. Server validates 0.25 <= rate <= 4.0
+                    so a malformed PUT can't poison the on-disk JSON.
+                markers:
+                  type: array
+                  description: |
+                    Plan 53 — user-placed bookmarks. Optional; absent on
+                    pre-plan-53 records. Each marker carries a label + kind
+                    so the listen-view sidebar can group "general notes"
+                    from "re-record" flags.
+                  items: { $ref: '#/components/schemas/ListenMarker' }
       responses:
         '200':
           description: The just-saved record, including the server-stamped updatedAt
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ListenProgress' }
-        '400': { description: Body missing chapterId or currentSec, or contains non-numeric values }
+        '400': { description: Body missing chapterId or currentSec, or contains non-numeric values, or contains a marker with an unrecognised kind }
         '404': { description: Book not found }
 
   /api/voices/base:
@@ -1383,7 +1400,9 @@ components:
         to seek the audio element. Persisted as a sibling
         `listen-progress.json` next to `state.json` so the
         schema-versioning shape from plan 27 stays stable. Plan
-        [47](docs/features/47-listen-progress.md).
+        [47](docs/features/47-listen-progress.md); extended by plan
+        [53](docs/features/53-mini-player-feature-pack.md) with
+        `playbackRate` + `markers`.
       properties:
         chapterId:
           type: integer
@@ -1397,6 +1416,52 @@ components:
           type: string
           format: date-time
           description: 'Server-stamped ISO timestamp. Clients only read this; PUT body omits it.'
+        playbackRate:
+          type: number
+          minimum: 0.25
+          maximum: 4.0
+          description: |
+            Plan 53 — per-book playback rate
+            (`HTMLMediaElement.playbackRate`). Optional / absent on
+            pre-plan-53 records; clients default to 1.0.
+        markers:
+          type: array
+          description: |
+            Plan 53 — user-placed bookmarks. Optional / absent on
+            pre-plan-53 records.
+          items: { $ref: '#/components/schemas/ListenMarker' }
+
+    ListenMarker:
+      type: object
+      required: [id, chapterId, sec, label, kind, createdAt]
+      description: |
+        Plan 53 — user-placed bookmark inside a book. The listen-view
+        sidebar lists these per chapter; click → seek to `sec`.
+      properties:
+        id:
+          type: string
+          description: 'Client-minted UUID. Server treats as opaque.'
+        chapterId:
+          type: integer
+          minimum: 0
+          description: 'Chapter the marker was dropped in.'
+        sec:
+          type: number
+          minimum: 0
+          description: 'Playback position within the chapter, in seconds.'
+        label:
+          type: string
+          description: 'User-editable short label. Empty string is allowed.'
+        kind:
+          type: string
+          enum: [note, rerecord]
+          description: |
+            `note` = general bookmark; `rerecord` = flag for another voice
+            take. Server rejects any other value with 400.
+        createdAt:
+          type: string
+          format: date-time
+          description: 'Client-stamped ISO timestamp at marker creation.'
 
     CoverFraming:
       type: object

--- a/server/src/routes/book-state.test.ts
+++ b/server/src/routes/book-state.test.ts
@@ -1119,4 +1119,111 @@ describe('book-state router — listen-progress slice (plan 47)', () => {
       .send({ chapterId: 1, currentSec: 5 });
     expect(res.status).toBe(404);
   });
+
+  /* Plan 53 — validator accepts + persists the optional playbackRate
+     and markers fields. */
+  it('PUT round-trips an optional playbackRate field', async () => {
+    const put = await request(app)
+      .put(`/api/books/${lpBookId}/listen-progress`)
+      .set('Content-Type', 'application/json')
+      .send({ chapterId: 1, currentSec: 10, playbackRate: 1.5 });
+    expect(put.status).toBe(200);
+    expect(put.body.playbackRate).toBe(1.5);
+
+    const get = await request(app).get(`/api/books/${lpBookId}/listen-progress`);
+    expect(get.body.playbackRate).toBe(1.5);
+  });
+
+  it('PUT 400s when playbackRate is below 0.25 or above 4.0', async () => {
+    const low = await request(app)
+      .put(`/api/books/${lpBookId}/listen-progress`)
+      .set('Content-Type', 'application/json')
+      .send({ chapterId: 1, currentSec: 10, playbackRate: 0.1 });
+    expect(low.status).toBe(400);
+
+    const high = await request(app)
+      .put(`/api/books/${lpBookId}/listen-progress`)
+      .set('Content-Type', 'application/json')
+      .send({ chapterId: 1, currentSec: 10, playbackRate: 10 });
+    expect(high.status).toBe(400);
+
+    const nonNumeric = await request(app)
+      .put(`/api/books/${lpBookId}/listen-progress`)
+      .set('Content-Type', 'application/json')
+      .send({ chapterId: 1, currentSec: 10, playbackRate: 'fast' });
+    expect(nonNumeric.status).toBe(400);
+  });
+
+  it('PUT round-trips an optional markers array', async () => {
+    const markers = [
+      {
+        id: 'mk_1',
+        chapterId: 2,
+        sec: 83.5,
+        label: 're-record this',
+        kind: 'rerecord',
+        createdAt: '2026-05-19T10:00:00.000Z',
+      },
+      {
+        id: 'mk_2',
+        chapterId: 1,
+        sec: 10,
+        label: '',
+        kind: 'note',
+        createdAt: '2026-05-19T10:01:00.000Z',
+      },
+    ];
+    const put = await request(app)
+      .put(`/api/books/${lpBookId}/listen-progress`)
+      .set('Content-Type', 'application/json')
+      .send({ chapterId: 1, currentSec: 5, markers });
+    expect(put.status).toBe(200);
+    expect(put.body.markers).toEqual(markers);
+
+    const get = await request(app).get(`/api/books/${lpBookId}/listen-progress`);
+    expect(get.body.markers).toEqual(markers);
+  });
+
+  it('PUT 400s when a marker carries an unknown kind', async () => {
+    const res = await request(app)
+      .put(`/api/books/${lpBookId}/listen-progress`)
+      .set('Content-Type', 'application/json')
+      .send({
+        chapterId: 1,
+        currentSec: 5,
+        markers: [
+          {
+            id: 'mk_bad',
+            chapterId: 1,
+            sec: 5,
+            label: 'huh',
+            kind: 'mystery',
+            createdAt: '2026-05-19T10:00:00.000Z',
+          },
+        ],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/kind/i);
+  });
+
+  it('PUT 400s when markers is not an array', async () => {
+    const res = await request(app)
+      .put(`/api/books/${lpBookId}/listen-progress`)
+      .set('Content-Type', 'application/json')
+      .send({ chapterId: 1, currentSec: 5, markers: { not: 'an array' } });
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT 400s when a marker is missing required fields', async () => {
+    const res = await request(app)
+      .put(`/api/books/${lpBookId}/listen-progress`)
+      .set('Content-Type', 'application/json')
+      .send({
+        chapterId: 1,
+        currentSec: 5,
+        markers: [{ id: 'mk_partial', chapterId: 1, sec: 5, label: 'x', kind: 'note' }],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/createdAt/);
+  });
 });

--- a/server/src/routes/book-state.ts
+++ b/server/src/routes/book-state.ts
@@ -833,10 +833,63 @@ bookStateRouter.delete('/:bookId', async (req: Request, res: Response) => {
    null on first read for a book; PUT body is `{ chapterId, currentSec }`
    and the server stamps `updatedAt` on write. */
 
+/* Plan 53 — marker kind enum. Server keeps its own copy (rather
+   than reaching into the frontend slice) so the route boundary is
+   self-contained. Frontend mirror lives in
+   src/store/listen-progress-slice.ts (LISTEN_MARKER_KINDS). */
+const LISTEN_MARKER_KINDS = ['note', 'rerecord'] as const;
+type ListenMarkerKind = (typeof LISTEN_MARKER_KINDS)[number];
+
+interface ListenMarker {
+  id: string;
+  chapterId: number;
+  sec: number;
+  label: string;
+  kind: ListenMarkerKind;
+  createdAt: string;
+}
+
 interface ListenProgressFile {
   chapterId: number;
   currentSec: number;
   updatedAt: string;
+  /* Plan 53 — per-book playback rate
+     (`HTMLMediaElement.playbackRate`). Optional; absent on
+     pre-plan-53 records, in which case clients default to 1.0. */
+  playbackRate?: number;
+  /* Plan 53 — user-placed bookmarks. Optional; absent on pre-plan-53
+     records. */
+  markers?: ListenMarker[];
+}
+
+/* Plan 53 — bounds on playback rate. Mirrors the openapi.yaml
+   schema (0.25 - 4.0). The bottom matches HTMLMediaElement's
+   browser-supported floor; the top is well past what any audiobook
+   listener would realistically pick but generous enough to allow
+   user experimentation without 400s. */
+const PLAYBACK_RATE_MIN = 0.25;
+const PLAYBACK_RATE_MAX = 4.0;
+
+/* Plan 53 — server-side validator for an individual marker payload.
+   Returns null when valid, or a short reason string for the 400. */
+function validateMarker(raw: unknown): string | null {
+  if (!raw || typeof raw !== 'object') return 'marker must be an object';
+  const m = raw as Record<string, unknown>;
+  if (typeof m.id !== 'string' || m.id.length === 0) return 'marker.id must be a non-empty string';
+  if (typeof m.chapterId !== 'number' || !Number.isFinite(m.chapterId) || m.chapterId < 0) {
+    return 'marker.chapterId must be a finite number >= 0';
+  }
+  if (typeof m.sec !== 'number' || !Number.isFinite(m.sec) || m.sec < 0) {
+    return 'marker.sec must be a finite number >= 0';
+  }
+  if (typeof m.label !== 'string') return 'marker.label must be a string';
+  if (typeof m.kind !== 'string' || !(LISTEN_MARKER_KINDS as readonly string[]).includes(m.kind)) {
+    return `marker.kind must be one of: ${LISTEN_MARKER_KINDS.join(', ')}`;
+  }
+  if (typeof m.createdAt !== 'string' || m.createdAt.length === 0) {
+    return 'marker.createdAt must be a non-empty string';
+  }
+  return null;
 }
 
 bookStateRouter.get('/:bookId/listen-progress', async (req: Request, res: Response) => {
@@ -855,17 +908,57 @@ bookStateRouter.put('/:bookId/listen-progress', async (req: Request, res: Respon
   try {
     const located = await findBookByBookId(req.params.bookId);
     if (!located) return res.status(404).json({ error: 'Book not found.' });
-    const body = req.body as Partial<{ chapterId: unknown; currentSec: unknown }> | undefined;
+    const body = req.body as
+      | Partial<{
+          chapterId: unknown;
+          currentSec: unknown;
+          playbackRate: unknown;
+          markers: unknown;
+        }>
+      | undefined;
     if (!body || typeof body.chapterId !== 'number' || !Number.isFinite(body.chapterId)) {
       return res.status(400).json({ error: 'chapterId must be a finite number.' });
     }
     if (typeof body.currentSec !== 'number' || !Number.isFinite(body.currentSec) || body.currentSec < 0) {
       return res.status(400).json({ error: 'currentSec must be a finite number >= 0.' });
     }
+    /* Plan 53 — optional playbackRate. Absent / undefined is fine
+       (legacy callers); when present, must be a finite number in the
+       documented browser-supported range. NaN/Infinity rejected. */
+    let playbackRate: number | undefined;
+    if (body.playbackRate !== undefined) {
+      if (
+        typeof body.playbackRate !== 'number' ||
+        !Number.isFinite(body.playbackRate) ||
+        body.playbackRate < PLAYBACK_RATE_MIN ||
+        body.playbackRate > PLAYBACK_RATE_MAX
+      ) {
+        return res.status(400).json({
+          error: `playbackRate must be a finite number between ${PLAYBACK_RATE_MIN} and ${PLAYBACK_RATE_MAX}.`,
+        });
+      }
+      playbackRate = body.playbackRate;
+    }
+    /* Plan 53 — optional markers. Each entry validated through
+       validateMarker; first failure short-circuits with 400 so the
+       on-disk record never contains a partially-valid list. */
+    let markers: ListenMarker[] | undefined;
+    if (body.markers !== undefined) {
+      if (!Array.isArray(body.markers)) {
+        return res.status(400).json({ error: 'markers must be an array.' });
+      }
+      for (let i = 0; i < body.markers.length; i++) {
+        const reason = validateMarker(body.markers[i]);
+        if (reason) return res.status(400).json({ error: `markers[${i}]: ${reason}` });
+      }
+      markers = body.markers as ListenMarker[];
+    }
     const record: ListenProgressFile = {
       chapterId: body.chapterId,
       currentSec: body.currentSec,
       updatedAt: new Date().toISOString(),
+      ...(playbackRate !== undefined ? { playbackRate } : {}),
+      ...(markers !== undefined ? { markers } : {}),
     };
     await writeJsonAtomic(listenProgressJsonPath(located.bookDir), record);
     res.json(record);

--- a/src/components/mini-player.test.tsx
+++ b/src/components/mini-player.test.tsx
@@ -10,10 +10,28 @@
    The fix resets audio={url:null,...} synchronously inside Effect 1 so
    Effect 2 immediately strips the element's src and stops playback. */
 
+import type React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, waitFor, act } from '@testing-library/react';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
 import { MiniPlayer } from './mini-player';
 import type { Chapter, ChapterAudio } from '../lib/types';
+import { listenProgressSlice } from '../store/listen-progress-slice';
+
+/* Plan 53 — every MiniPlayer render now needs a Redux store
+   because the component reads/writes the listen-progress slice for
+   per-book playbackRate + markers. A fresh store per render keeps
+   the existing chapter-switch + plan-47 specs hermetic. */
+function makeStore() {
+  return configureStore({
+    reducer: { listenProgress: listenProgressSlice.reducer },
+  });
+}
+
+function renderPlayer(ui: React.ReactElement) {
+  return render(<Provider store={makeStore()}>{ui}</Provider>);
+}
 
 type Resolver = (meta: ChapterAudio) => void;
 const pendingByChapter = new Map<number, Resolver>();
@@ -118,16 +136,22 @@ async function resolveChapter(id: number, url: string) {
 
 describe('MiniPlayer — chapter switch', () => {
   it('clears the audio element src when the chapter prop changes, then loads the new URL once metadata arrives', async () => {
+    /* Use a single shared store across the rerender so the slice
+       state survives the prop swap (matches production where the
+       MiniPlayer sits inside one Provider across the whole session). */
+    const store = makeStore();
     const { container, rerender } = render(
-      <MiniPlayer
-        chapter={chapter1}
-        bookId="book-1"
-        onClose={noop}
-        onPrev={noop}
-        onNext={noop}
-        prevAvailable={false}
-        nextAvailable={true}
-      />,
+      <Provider store={store}>
+        <MiniPlayer
+          chapter={chapter1}
+          bookId="book-1"
+          onClose={noop}
+          onPrev={noop}
+          onNext={noop}
+          prevAvailable={false}
+          nextAvailable={true}
+        />
+      </Provider>,
     );
 
     const audioEl = container.querySelector('audio');
@@ -141,15 +165,17 @@ describe('MiniPlayer — chapter switch', () => {
        regression: src used to stay pinned to chapter 1 here, so chapter 1
        kept playing under the chapter 2 UI. */
     rerender(
-      <MiniPlayer
-        chapter={chapter2}
-        bookId="book-1"
-        onClose={noop}
-        onPrev={noop}
-        onNext={noop}
-        prevAvailable={true}
-        nextAvailable={false}
-      />,
+      <Provider store={store}>
+        <MiniPlayer
+          chapter={chapter2}
+          bookId="book-1"
+          onClose={noop}
+          onPrev={noop}
+          onNext={noop}
+          prevAvailable={true}
+          nextAvailable={false}
+        />
+      </Provider>,
     );
 
     await waitFor(() => expect(audioEl!.getAttribute('src')).toBeNull());
@@ -195,7 +221,7 @@ describe('MiniPlayer — plan 47 resume + flush', () => {
       currentSec: 42,
       updatedAt: '2026-05-18T01:00:00.000Z',
     });
-    const { container } = render(
+    const { container } = renderPlayer(
       <MiniPlayer
         chapter={chapter1}
         bookId="book-1"
@@ -222,7 +248,7 @@ describe('MiniPlayer — plan 47 resume + flush', () => {
       currentSec: 42,
       updatedAt: '2026-05-18T01:00:00.000Z',
     });
-    const { container } = render(
+    const { container } = renderPlayer(
       <MiniPlayer
         chapter={chapter1}
         bookId="book-1"
@@ -248,7 +274,7 @@ describe('MiniPlayer — plan 47 resume + flush', () => {
       currentSec: 599.5,
       updatedAt: '2026-05-18T01:00:00.000Z',
     });
-    const { container } = render(
+    const { container } = renderPlayer(
       <MiniPlayer
         chapter={chapter1}
         bookId="book-1"
@@ -267,7 +293,7 @@ describe('MiniPlayer — plan 47 resume + flush', () => {
   });
 
   it('debounced save fires at the first onTimeUpdate past the 5 s threshold and not before', async () => {
-    const { container } = render(
+    const { container } = renderPlayer(
       <MiniPlayer
         chapter={chapter1}
         bookId="book-1"
@@ -290,16 +316,19 @@ describe('MiniPlayer — plan 47 resume + flush', () => {
   });
 
   it('flushes a final save on chapter switch when currentSec is past 5 s', async () => {
+    const store = makeStore();
     const { container, rerender } = render(
-      <MiniPlayer
-        chapter={chapter1}
-        bookId="book-1"
-        onClose={noop}
-        onPrev={noop}
-        onNext={noop}
-        prevAvailable={false}
-        nextAvailable={true}
-      />,
+      <Provider store={store}>
+        <MiniPlayer
+          chapter={chapter1}
+          bookId="book-1"
+          onClose={noop}
+          onPrev={noop}
+          onNext={noop}
+          prevAvailable={false}
+          nextAvailable={true}
+        />
+      </Provider>,
     );
     const audioEl = container.querySelector('audio') as HTMLAudioElement;
     await resolveChapter(1, '/api/books/book-1/chapters/1/audio.mp3');
@@ -310,22 +339,24 @@ describe('MiniPlayer — plan 47 resume + flush', () => {
        chapter 1 with the latest currentSec (17). */
     await act(async () => {
       rerender(
-        <MiniPlayer
-          chapter={chapter2}
-          bookId="book-1"
-          onClose={noop}
-          onPrev={noop}
-          onNext={noop}
-          prevAvailable={true}
-          nextAvailable={false}
-        />,
+        <Provider store={store}>
+          <MiniPlayer
+            chapter={chapter2}
+            bookId="book-1"
+            onClose={noop}
+            onPrev={noop}
+            onNext={noop}
+            prevAvailable={true}
+            nextAvailable={false}
+          />
+        </Provider>,
       );
     });
     expect(putListenProgressMock).toHaveBeenCalledWith('book-1', { chapterId: 1, currentSec: 17 });
   });
 
   it('does NOT flush on unmount when playback stayed under the 5 s noise floor', async () => {
-    const { container, unmount } = render(
+    const { container, unmount } = renderPlayer(
       <MiniPlayer
         chapter={chapter1}
         bookId="book-1"

--- a/src/components/mini-player.tsx
+++ b/src/components/mini-player.tsx
@@ -1,17 +1,39 @@
-import { useEffect, useRef, useState, type MouseEvent } from 'react';
+import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react';
 import {
-  IconWaveform,
-  IconRewind,
+  IconBook,
+  IconClock,
+  IconClose,
+  IconForward,
   IconPause,
   IconPlay,
-  IconForward,
+  IconRewind,
   IconVolume,
-  IconClose,
+  IconWaveform,
 } from '../lib/icons';
 import { api } from '../lib/api';
 import { parseDuration, formatTime } from '../lib/time';
 import { stripChapterPrefix } from '../lib/format-chapter-title';
 import type { Chapter, ChapterAudio } from '../lib/types';
+import { useAppDispatch, useAppSelector } from '../store';
+import {
+  getPlaybackRate,
+  listenProgressActions,
+  selectListenProgress,
+  selectPendingSeek,
+  type ListenMarker,
+} from '../store/listen-progress-slice';
+import {
+  IDLE,
+  SLEEP_TIMER_PRESETS_MIN,
+  cancel as sleepCancel,
+  isFired as sleepIsFired,
+  notifyChapterEnded as sleepNotifyChapterEnded,
+  remainingMs as sleepRemainingMs,
+  startCountdown as sleepStartCountdown,
+  startEndOfChapter as sleepStartEndOfChapter,
+  tick as sleepTick,
+  type SleepTimerState,
+} from '../lib/sleep-timer';
 
 interface MiniPlayerProps {
   chapter: Chapter | null;
@@ -21,6 +43,18 @@ interface MiniPlayerProps {
   onNext: () => void;
   prevAvailable: boolean;
   nextAvailable: boolean;
+}
+
+/* Plan 53 — playback-rate picker presets. Exposed at module scope so
+   the e2e spec can assert against the same list without importing the
+   component. */
+export const PLAYBACK_RATE_OPTIONS = [0.75, 1.0, 1.25, 1.5, 1.75, 2.0] as const;
+
+/* Format a playbackRate as the picker label ("1.5×"). Single digit
+   fractions get a trailing × to mirror standalone-app conventions
+   (Voice / BookPlayer / Smart AudioBook Player). */
+function formatRate(rate: number): string {
+  return `${Number.isInteger(rate) ? rate.toFixed(1) : rate}×`;
 }
 
 export function MiniPlayer({
@@ -49,6 +83,33 @@ export function MiniPlayer({
   const pendingSeekRef = useRef<number | null>(null);
   const currentSecRef = useRef(0);
   const lastSavedAtRef = useRef(0);
+
+  /* Plan 53 — playback rate + markers + sleep timer.
+
+     The slice is read once at chapter mount so the rate sticks
+     across reload (per-book persistence). Local component state
+     drives the picker UI immediately; the same handler then dispatches
+     the slice update AND the optional PUT to keep on-disk in sync. */
+  const dispatch = useAppDispatch();
+  const persisted = useAppSelector(selectListenProgress(bookId));
+  const [playbackRate, setPlaybackRate] = useState<number>(() => getPlaybackRate(persisted));
+  /* Ref so onLoadedMetadata + the audio.url effect can set
+     el.playbackRate without re-running on every rate change. */
+  const playbackRateRef = useRef(playbackRate);
+  playbackRateRef.current = playbackRate;
+  /* (Marker list itself is read in the Listen view sidebar via the
+     same selector — the mini-player only owns the add-marker entry
+     point.) */
+  /* Sleep timer — per-session, NOT persisted to listen-progress.json
+     (matches every standalone audiobook player). State lives in the
+     mini-player so closing it cancels the timer. */
+  const [sleepTimer, setSleepTimer] = useState<SleepTimerState>(IDLE);
+  /* Hover-driven popovers for the two RHS toolbar buttons. */
+  const [speedMenuOpen, setSpeedMenuOpen] = useState(false);
+  const [sleepMenuOpen, setSleepMenuOpen] = useState(false);
+  /* Marker-add inline form — opens under the player when the user
+     drops a marker so they can type a label without leaving listen. */
+  const [markerDraft, setMarkerDraft] = useState<{ chapterId: number; sec: number } | null>(null);
 
   /* Fetch the audio meta (url, durationSec, segments) whenever the chapter
      changes. We don't store the chapter id on the audio element because the
@@ -117,7 +178,11 @@ export function MiniPlayer({
   }, [bookId, chapter?.id, chapter?.duration]);
 
   /* When the URL lands, point the audio element at it. Resetting src + load
-     also clears any prior playback state from the previous chapter. */
+     also clears any prior playback state from the previous chapter.
+     Plan 53: re-apply the persisted playbackRate every time the
+     element reloads — el.playbackRate snaps back to 1.0 on every
+     new src/load cycle, which would silently undo a 1.5× selection
+     across chapter switches without this. */
   useEffect(() => {
     const el = audioRef.current;
     if (!el) return;
@@ -125,6 +190,7 @@ export function MiniPlayer({
       el.src = audio.url;
       el.load();
       el.currentTime = 0;
+      el.playbackRate = playbackRateRef.current;
       if (playing)
         void el.play().catch(() => {
           /* user-gesture errors surface via <audio onerror> */
@@ -135,6 +201,61 @@ export function MiniPlayer({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [audio.url]);
+
+  /* Plan 53 — reflect the picker selection onto the live element.
+     Separate effect (vs. folding into the url effect) so the user can
+     change rate mid-playback without forcing a re-load. */
+  useEffect(() => {
+    const el = audioRef.current;
+    if (!el) return;
+    el.playbackRate = playbackRate;
+  }, [playbackRate]);
+
+  /* Plan 53 — rehydrate the local playbackRate from the slice when
+     the persisted record lands (Layout's per-book hydrate effect
+     resolves asynchronously, so on first paint persisted=null and
+     the local state defaulted to 1.0; once the slice has a value we
+     adopt it). Guard on chapter so we don't re-stomp on every render. */
+  const persistedRate = persisted?.playbackRate;
+  useEffect(() => {
+    if (persistedRate !== undefined && persistedRate !== playbackRate) {
+      setPlaybackRate(persistedRate);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [persistedRate]);
+
+  /* Plan 53 — one-shot seek requested by the listen-view marker
+     click. When the request targets the currently-playing chapter,
+     the mini-player's own chapter-mount path doesn't fire (chapter
+     id unchanged), so this effect carries the seek through. When the
+     request targets a DIFFERENT chapter, setCurrentTrack in the
+     listen view has already fired and the mini-player will remount
+     with a fresh pendingSeekRef path; the request still gets
+     consumed here so it doesn't re-fire on the next pass. */
+  const pendingSeek = useAppSelector(selectPendingSeek(bookId));
+  useEffect(() => {
+    if (!pendingSeek || !chapter) return;
+    if (pendingSeek.chapterId !== chapter.id) {
+      /* Chapter-switch case — let the chapter-mount effect's
+         listen-progress fetch carry the seek through pendingSeekRef.
+         Stamp the same value into pendingSeekRef directly so the
+         next onLoadedMetadata fires it (the fetch resolves async). */
+      pendingSeekRef.current = pendingSeek.sec;
+      dispatch(listenProgressActions.consumeSeek({ requestId: pendingSeek.requestId }));
+      return;
+    }
+    const el = audioRef.current;
+    if (el && Number.isFinite(el.duration) && el.duration > 0) {
+      el.currentTime = pendingSeek.sec;
+      setCurrentSec(pendingSeek.sec);
+      currentSecRef.current = pendingSeek.sec;
+    } else {
+      /* Audio not yet loaded for this chapter — stash for the next
+         onLoadedMetadata to consume (same path as the resume seek). */
+      pendingSeekRef.current = pendingSeek.sec;
+    }
+    dispatch(listenProgressActions.consumeSeek({ requestId: pendingSeek.requestId }));
+  }, [pendingSeek, chapter, dispatch]);
 
   /* Reflect the React `playing` flag onto the element. Browsers may also flip
      `playing` externally (ended → false) — those paths use setPlaying directly
@@ -150,6 +271,127 @@ export function MiniPlayer({
       el.pause();
     }
   }, [playing, audio.url]);
+
+  /* Plan 53 — playback-rate picker handler. Three fan-outs:
+     - local state for instant UI feedback
+     - slice update so other surfaces (sidebar pill, future surfaces)
+       see the same rate without re-fetching
+     - PUT to disk so the rate survives reload. Position-only PUTs
+       from onTimeUpdate stay light (no rate echo) because the slice
+       remembers the rate locally; this single rate PUT keeps disk
+       authoritative. */
+  const onChangePlaybackRate = useCallback(
+    (rate: number) => {
+      setPlaybackRate(rate);
+      setSpeedMenuOpen(false);
+      dispatch(listenProgressActions.setPlaybackRate({ bookId, playbackRate: rate }));
+      if (!chapter) return;
+      const chapterId = chapter.id;
+      const sec = currentSecRef.current;
+      void api
+        .putListenProgress(bookId, {
+          chapterId,
+          currentSec: sec,
+          playbackRate: rate,
+        })
+        .catch((err) => {
+          console.warn('[mini-player] playback-rate save failed', (err as Error).message);
+        });
+    },
+    [bookId, chapter, dispatch],
+  );
+
+  /* Plan 53 — marker-add. Captures current chapter + position, opens
+     the inline label form. The actual slice + disk write fires on
+     form submit (or implicit submit when the user closes without
+     typing — empty label is allowed). */
+  const startMarkerDraft = useCallback(() => {
+    if (!chapter) return;
+    setMarkerDraft({ chapterId: chapter.id, sec: currentSecRef.current });
+  }, [chapter]);
+
+  const commitMarkerDraft = useCallback(
+    (label: string) => {
+      if (!markerDraft) return;
+      /* crypto.randomUUID exists in Chromium 92+ / Safari 15.4+; both
+         our e2e + production browsers are well past that. Fall back
+         to a timestamp-id so a stub environment (jsdom < 21) doesn't
+         null-deref. */
+      const id =
+        typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+          ? crypto.randomUUID()
+          : `mk_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+      const marker: ListenMarker = {
+        id,
+        chapterId: markerDraft.chapterId,
+        sec: markerDraft.sec,
+        label,
+        kind: 'note',
+        createdAt: new Date().toISOString(),
+      };
+      dispatch(listenProgressActions.addMarker({ bookId, marker }));
+      setMarkerDraft(null);
+      /* Persist the new full marker list. Read the slice for the
+         freshest list rather than appending here — Immer + the
+         dispatch above are synchronous so the next selector call
+         would land the new marker, but we already have it in scope. */
+      const nextMarkers = [...(persisted?.markers ?? []), marker];
+      const chapterId = chapter?.id ?? markerDraft.chapterId;
+      void api
+        .putListenProgress(bookId, {
+          chapterId,
+          currentSec: currentSecRef.current,
+          markers: nextMarkers,
+        })
+        .catch((err) => {
+          console.warn('[mini-player] marker save failed', (err as Error).message);
+        });
+    },
+    [bookId, chapter?.id, dispatch, markerDraft, persisted?.markers],
+  );
+
+  const cancelMarkerDraft = useCallback(() => setMarkerDraft(null), []);
+
+  /* Plan 53 — `M` keyboard shortcut. Bound to window so the user can
+     drop a marker without focusing the mini-player. Inputs / textareas
+     get a pass so typing M inside the marker-label field doesn't trip
+     a recursive marker-drop. */
+  useEffect(() => {
+    if (!chapter) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== 'm' && e.key !== 'M') return;
+      const target = e.target as HTMLElement | null;
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+        return;
+      }
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      e.preventDefault();
+      startMarkerDraft();
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [chapter, startMarkerDraft]);
+
+  /* Plan 53 — sleep-timer countdown tick. Only mounted while the
+     timer is in the countdown state; ticks once per second. End-of-
+     chapter mode is driven by the audio onEnded handler below. */
+  useEffect(() => {
+    if (sleepTimer.kind !== 'countdown') return;
+    const id = setInterval(() => {
+      setSleepTimer((prev) => sleepTick(prev));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [sleepTimer.kind]);
+
+  /* Plan 53 — react to the timer firing. Pauses the player + clears
+     the timer back to idle so the user's next play click isn't
+     instantly re-paused. The existing onTimeUpdate flush will catch
+     the resulting position on the next render. */
+  useEffect(() => {
+    if (!sleepIsFired(sleepTimer)) return;
+    setPlaying(false);
+    setSleepTimer(IDLE);
+  }, [sleepTimer]);
 
   if (!chapter) return null;
   const totalSec = audio.durationSec || parseDuration(chapter.duration);
@@ -229,7 +471,149 @@ export function MiniPlayer({
               {formatTime(totalSec)}
             </span>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 relative">
+            {/* Plan 53 — playback-speed picker. Click toggles a popover
+                with the six preset rates; the current rate sits in
+                the button label so the user can see it at a glance
+                without opening the menu. */}
+            <div className="relative">
+              <button
+                type="button"
+                onClick={() => {
+                  setSpeedMenuOpen((v) => !v);
+                  setSleepMenuOpen(false);
+                }}
+                aria-label="Playback speed"
+                data-testid="mini-player-speed-toggle"
+                aria-expanded={speedMenuOpen}
+                aria-haspopup="menu"
+                className="px-2.5 py-1 rounded-full hover:bg-canvas/10 text-[11px] tabular-nums font-semibold text-canvas/80"
+              >
+                {formatRate(playbackRate)}
+              </button>
+              {speedMenuOpen && (
+                <div
+                  role="menu"
+                  data-testid="mini-player-speed-menu"
+                  className="absolute bottom-full right-0 mb-2 min-w-[100px] rounded-xl bg-ink-soft border border-canvas/10 shadow-float py-1 z-10"
+                >
+                  {PLAYBACK_RATE_OPTIONS.map((r) => (
+                    <button
+                      key={r}
+                      type="button"
+                      role="menuitemradio"
+                      aria-checked={playbackRate === r}
+                      data-testid={`mini-player-speed-option-${r}`}
+                      onClick={() => onChangePlaybackRate(r)}
+                      className={`block w-full text-left px-3 py-1.5 text-xs tabular-nums hover:bg-canvas/10 ${
+                        playbackRate === r ? 'text-canvas font-semibold' : 'text-canvas/70'
+                      }`}
+                    >
+                      {formatRate(r)}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+            {/* Plan 53 — drop-marker button. Captures chapterId +
+                currentSec into a draft, which the inline form below
+                the player commits. `M` shortcut hits the same path. */}
+            <button
+              type="button"
+              onClick={startMarkerDraft}
+              aria-label="Add marker (M)"
+              data-testid="mini-player-add-marker"
+              title="Add marker (M)"
+              className="p-2 rounded-full hover:bg-canvas/10 hidden md:grid place-items-center"
+            >
+              <IconBook className="w-4 h-4" />
+            </button>
+            {/* Plan 53 — sleep timer. Clock icon toggles a popover with
+                the four preset countdowns + end-of-chapter mode. When
+                a timer is armed the button surfaces the remaining
+                time. */}
+            <div className="relative">
+              <button
+                type="button"
+                onClick={() => {
+                  setSleepMenuOpen((v) => !v);
+                  setSpeedMenuOpen(false);
+                }}
+                aria-label="Sleep timer"
+                data-testid="mini-player-sleep-toggle"
+                aria-expanded={sleepMenuOpen}
+                aria-haspopup="menu"
+                title="Sleep timer"
+                className="p-2 rounded-full hover:bg-canvas/10 hidden md:grid place-items-center"
+              >
+                <IconClock className="w-4 h-4" />
+              </button>
+              {sleepMenuOpen && (
+                <div
+                  role="menu"
+                  data-testid="mini-player-sleep-menu"
+                  className="absolute bottom-full right-0 mb-2 min-w-[160px] rounded-xl bg-ink-soft border border-canvas/10 shadow-float py-1 z-10"
+                >
+                  {SLEEP_TIMER_PRESETS_MIN.map((min) => (
+                    <button
+                      key={min}
+                      type="button"
+                      role="menuitem"
+                      data-testid={`mini-player-sleep-option-${min}`}
+                      onClick={() => {
+                        setSleepTimer(sleepStartCountdown(min * 60_000));
+                        setSleepMenuOpen(false);
+                      }}
+                      className="block w-full text-left px-3 py-1.5 text-xs tabular-nums hover:bg-canvas/10 text-canvas/80"
+                    >
+                      {min} min
+                    </button>
+                  ))}
+                  <button
+                    type="button"
+                    role="menuitem"
+                    data-testid="mini-player-sleep-option-end-of-chapter"
+                    onClick={() => {
+                      setSleepTimer(sleepStartEndOfChapter());
+                      setSleepMenuOpen(false);
+                    }}
+                    className="block w-full text-left px-3 py-1.5 text-xs hover:bg-canvas/10 text-canvas/80"
+                  >
+                    End of chapter
+                  </button>
+                  {sleepTimer.kind !== 'idle' && (
+                    <button
+                      type="button"
+                      role="menuitem"
+                      data-testid="mini-player-sleep-cancel"
+                      onClick={() => {
+                        setSleepTimer(sleepCancel());
+                        setSleepMenuOpen(false);
+                      }}
+                      className="block w-full text-left px-3 py-1.5 text-xs hover:bg-canvas/10 text-rose-300 border-t border-canvas/10 mt-1 pt-1.5"
+                    >
+                      Cancel timer
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+            {sleepTimer.kind === 'countdown' && (
+              <span
+                data-testid="mini-player-sleep-pill"
+                className="text-[10px] tabular-nums text-canvas/60 hidden md:inline"
+              >
+                {formatTime(Math.ceil((sleepRemainingMs(sleepTimer) ?? 0) / 1000))}
+              </span>
+            )}
+            {sleepTimer.kind === 'end-of-chapter' && (
+              <span
+                data-testid="mini-player-sleep-pill"
+                className="text-[10px] uppercase tracking-widest text-canvas/60 hidden md:inline"
+              >
+                End of ch
+              </span>
+            )}
             <button className="p-2 rounded-full hover:bg-canvas/10 hidden md:grid place-items-center">
               <IconVolume className="w-4 h-4" />
             </button>
@@ -238,6 +622,14 @@ export function MiniPlayer({
             </button>
           </div>
         </div>
+        {markerDraft && (
+          <MarkerDraftForm
+            chapterId={markerDraft.chapterId}
+            sec={markerDraft.sec}
+            onCommit={commitMarkerDraft}
+            onCancel={cancelMarkerDraft}
+          />
+        )}
         <audio
           ref={audioRef}
           preload="metadata"
@@ -280,13 +672,92 @@ export function MiniPlayer({
                 currentSecRef.current = pending;
               }
               pendingSeekRef.current = null;
+              /* Plan 53 — re-apply the picked playback rate. Browsers
+                 reset el.playbackRate on every load, even when load is
+                 driven by the same src; without this the user's 1.5×
+                 selection silently undoes after the resume seek. */
+              target.playbackRate = playbackRateRef.current;
             }
           }}
-          onEnded={() => setPlaying(false)}
+          onEnded={() => {
+            setPlaying(false);
+            /* Plan 53 — feed the chapter-end event into the sleep
+               timer state machine. End-of-chapter mode transitions
+               to fired here; countdown / idle states ignore it. */
+            setSleepTimer((prev) => sleepNotifyChapterEnded(prev));
+          }}
           onError={() => setError('Audio failed to load.')}
           className="hidden"
         />
       </div>
     </div>
+  );
+}
+
+/* Plan 53 — inline marker-label form. Renders under the mini-player
+   strip when the user clicks "Add marker" or hits M. Submitting (with
+   or without a label) commits to the slice + disk; Esc / clicking
+   Cancel discards. Kept local to the mini-player so the marker-add
+   flow is self-contained. */
+interface MarkerDraftFormProps {
+  chapterId: number;
+  sec: number;
+  onCommit: (label: string) => void;
+  onCancel: () => void;
+}
+function MarkerDraftForm({ chapterId, sec, onCommit, onCancel }: MarkerDraftFormProps) {
+  const [label, setLabel] = useState('');
+  /* Imperative focus on mount via useEffect — the JSX `autoFocus`
+     attribute trips a11y lint (jsx-a11y/no-autofocus) because it
+     hijacks focus on every page load, but a one-shot focus inside a
+     just-opened inline form IS the right UX (user clicked Add
+     marker and wants to type immediately). */
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+  return (
+    <form
+      data-testid="mini-player-marker-form"
+      onSubmit={(e) => {
+        e.preventDefault();
+        onCommit(label);
+      }}
+      className="max-w-[1500px] mx-auto px-6 py-2 flex items-center gap-3 bg-ink/95 border-t border-canvas/10"
+    >
+      <span className="text-[10px] uppercase tracking-widest text-canvas/50 shrink-0">
+        Marker · CH {String(chapterId).padStart(2, '0')} · {formatTime(sec)}
+      </span>
+      <input
+        ref={inputRef}
+        type="text"
+        value={label}
+        onChange={(e) => setLabel(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            e.preventDefault();
+            onCancel();
+          }
+        }}
+        placeholder="Label (optional)…"
+        data-testid="mini-player-marker-input"
+        className="flex-1 bg-transparent border-b border-canvas/20 text-sm text-canvas placeholder:text-canvas/30 focus:outline-none focus:border-canvas/60 py-1"
+      />
+      <button
+        type="submit"
+        data-testid="mini-player-marker-save"
+        className="px-3 py-1 rounded-full bg-canvas text-ink text-xs font-semibold hover:bg-white"
+      >
+        Save
+      </button>
+      <button
+        type="button"
+        onClick={onCancel}
+        data-testid="mini-player-marker-cancel"
+        className="px-3 py-1 rounded-full text-canvas/60 text-xs hover:text-canvas"
+      >
+        Cancel
+      </button>
+    </form>
   );
 }

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1052,7 +1052,9 @@ export interface components {
          *     to seek the audio element. Persisted as a sibling
          *     `listen-progress.json` next to `state.json` so the
          *     schema-versioning shape from plan 27 stays stable. Plan
-         *     [47](docs/features/47-listen-progress.md).
+         *     [47](docs/features/47-listen-progress.md); extended by plan
+         *     [53](docs/features/53-mini-player-feature-pack.md) with
+         *     `playbackRate` + `markers`.
          */
         ListenProgress: {
             /** @description Chapter that was playing when the record was last stamped. */
@@ -1064,6 +1066,42 @@ export interface components {
              * @description Server-stamped ISO timestamp. Clients only read this; PUT body omits it.
              */
             updatedAt: string;
+            /**
+             * @description Plan 53 — per-book playback rate
+             *     (`HTMLMediaElement.playbackRate`). Optional / absent on
+             *     pre-plan-53 records; clients default to 1.0.
+             */
+            playbackRate?: number;
+            /**
+             * @description Plan 53 — user-placed bookmarks. Optional / absent on
+             *     pre-plan-53 records.
+             */
+            markers?: components["schemas"]["ListenMarker"][];
+        };
+        /**
+         * @description Plan 53 — user-placed bookmark inside a book. The listen-view
+         *     sidebar lists these per chapter; click → seek to `sec`.
+         */
+        ListenMarker: {
+            /** @description Client-minted UUID. Server treats as opaque. */
+            id: string;
+            /** @description Chapter the marker was dropped in. */
+            chapterId: number;
+            /** @description Playback position within the chapter, in seconds. */
+            sec: number;
+            /** @description User-editable short label. Empty string is allowed. */
+            label: string;
+            /**
+             * @description `note` = general bookmark; `rerecord` = flag for another voice
+             *     take. Server rejects any other value with 400.
+             * @enum {string}
+             */
+            kind: "note" | "rerecord";
+            /**
+             * Format: date-time
+             * @description Client-stamped ISO timestamp at marker creation.
+             */
+            createdAt: string;
         };
         /**
          * @description Pan + zoom transform applied to the on-disk cover image at render
@@ -2555,6 +2593,20 @@ export interface operations {
                 "application/json": {
                     chapterId: number;
                     currentSec: number;
+                    /**
+                     * @description Plan 53 — per-book playback rate
+                     *     (`HTMLMediaElement.playbackRate`). Optional; absent on
+                     *     pre-plan-53 records. Server validates 0.25 <= rate <= 4.0
+                     *     so a malformed PUT can't poison the on-disk JSON.
+                     */
+                    playbackRate?: number;
+                    /**
+                     * @description Plan 53 — user-placed bookmarks. Optional; absent on
+                     *     pre-plan-53 records. Each marker carries a label + kind
+                     *     so the listen-view sidebar can group "general notes"
+                     *     from "re-record" flags.
+                     */
+                    markers?: components["schemas"]["ListenMarker"][];
                 };
             };
         };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -566,13 +566,20 @@ export async function mockGetListenProgress(bookId: string): Promise<ListenProgr
 
 export async function mockPutListenProgress(
   bookId: string,
-  args: { chapterId: number; currentSec: number },
+  args: {
+    chapterId: number;
+    currentSec: number;
+    playbackRate?: number;
+    markers?: ListenProgressMarker[];
+  },
 ): Promise<ListenProgress> {
   await wait(15);
   const record: ListenProgress = {
     chapterId: args.chapterId,
     currentSec: args.currentSec,
     updatedAt: new Date().toISOString(),
+    ...(args.playbackRate !== undefined ? { playbackRate: args.playbackRate } : {}),
+    ...(args.markers !== undefined ? { markers: args.markers } : {}),
   };
   MOCK_LISTEN_PROGRESS.set(bookId, record);
   return record;
@@ -1008,11 +1015,35 @@ async function realPutBookState(bookId: string, req: PutStateRequest): Promise<v
    updatedAt and returns the saved record. The mini-player calls PUT
    debounced (~once per 5 s) during playback, plus a final flush on
    chapter switch / close. The Listen view reads GET on book hydrate
-   for the "Resume at MM:SS" pill. */
+   for the "Resume at MM:SS" pill.
+   Extended in plan 53 with optional `playbackRate` + `markers`. */
+export interface ListenProgressMarker {
+  id: string;
+  chapterId: number;
+  sec: number;
+  label: string;
+  kind: 'note' | 'rerecord';
+  createdAt: string;
+}
+
 export interface ListenProgress {
   chapterId: number;
   currentSec: number;
   updatedAt: string;
+  /* Plan 53. */
+  playbackRate?: number;
+  markers?: ListenProgressMarker[];
+}
+
+/* Plan 53 — PUT body extension. chapterId/currentSec stay required so
+   the mini-player's debounced position save needs no extra arguments;
+   playbackRate + markers are opt-in patches the picker / marker UI
+   pass. */
+export interface PutListenProgressArgs {
+  chapterId: number;
+  currentSec: number;
+  playbackRate?: number;
+  markers?: ListenProgressMarker[];
 }
 
 async function realGetListenProgress(bookId: string): Promise<ListenProgress | null> {
@@ -1026,7 +1057,7 @@ async function realGetListenProgress(bookId: string): Promise<ListenProgress | n
 
 async function realPutListenProgress(
   bookId: string,
-  args: { chapterId: number; currentSec: number },
+  args: PutListenProgressArgs,
 ): Promise<ListenProgress> {
   const res = await fetch(`/api/books/${encodeURIComponent(bookId)}/listen-progress`, {
     method: 'PUT',

--- a/src/lib/sleep-timer.test.ts
+++ b/src/lib/sleep-timer.test.ts
@@ -1,0 +1,107 @@
+// Pairs with docs/features/53-mini-player-feature-pack.md
+
+import { describe, expect, it } from 'vitest';
+import {
+  IDLE,
+  SLEEP_TIMER_PRESETS_MIN,
+  cancel,
+  isFired,
+  notifyChapterEnded,
+  remainingMs,
+  startCountdown,
+  startEndOfChapter,
+  tick,
+} from './sleep-timer';
+
+describe('sleep-timer — startCountdown + tick', () => {
+  it('startCountdown stamps firesAt = now + durationMs', () => {
+    const state = startCountdown(5 * 60 * 1000, 1_000);
+    expect(state).toEqual({ kind: 'countdown', firesAt: 1_000 + 5 * 60 * 1000, durationMs: 300_000 });
+  });
+
+  it('tick before firesAt returns the same countdown state untouched', () => {
+    const start = startCountdown(60_000, 1_000);
+    const next = tick(start, 30_000);
+    expect(next).toBe(start);
+  });
+
+  it('tick at exactly firesAt transitions to fired', () => {
+    const start = startCountdown(60_000, 1_000);
+    const next = tick(start, start.firesAt);
+    expect(next).toEqual({ kind: 'fired', cause: 'countdown' });
+  });
+
+  it('tick past firesAt transitions to fired', () => {
+    const start = startCountdown(60_000, 1_000);
+    const next = tick(start, start.firesAt + 999);
+    expect(isFired(next)).toBe(true);
+  });
+
+  it('tick is a no-op on idle / end-of-chapter / fired states', () => {
+    expect(tick(IDLE, 99_999)).toBe(IDLE);
+    const eoc = startEndOfChapter();
+    expect(tick(eoc, 99_999)).toBe(eoc);
+    const fired = tick(startCountdown(1, 0), 100);
+    expect(tick(fired, 200)).toBe(fired);
+  });
+});
+
+describe('sleep-timer — end-of-chapter mode', () => {
+  it('notifyChapterEnded transitions end-of-chapter → fired with cause=end-of-chapter', () => {
+    const state = startEndOfChapter();
+    const next = notifyChapterEnded(state);
+    expect(next).toEqual({ kind: 'fired', cause: 'end-of-chapter' });
+  });
+
+  it('notifyChapterEnded is a no-op on countdown / idle / fired states', () => {
+    /* The countdown is wall-clock driven and ignores chapter boundaries. */
+    const c = startCountdown(60_000);
+    expect(notifyChapterEnded(c)).toBe(c);
+    expect(notifyChapterEnded(IDLE)).toBe(IDLE);
+    const fired = tick(startCountdown(1, 0), 100);
+    expect(notifyChapterEnded(fired)).toBe(fired);
+  });
+});
+
+describe('sleep-timer — cancel', () => {
+  it('cancel before fire is a no-op on the eventual fire path', () => {
+    /* Start a countdown, cancel it, then advance past the original
+       firesAt — must NOT fire because cancel() returned idle. */
+    const original = startCountdown(60_000, 1_000);
+    const cancelled = cancel();
+    expect(cancelled).toEqual(IDLE);
+    const ticked = tick(cancelled, original.firesAt + 10_000);
+    expect(isFired(ticked)).toBe(false);
+    expect(ticked).toBe(cancelled);
+  });
+
+  it('cancel idempotent on already-idle state', () => {
+    expect(cancel()).toEqual(IDLE);
+    expect(cancel()).toEqual(cancel());
+  });
+});
+
+describe('sleep-timer — remainingMs + presets', () => {
+  it('remainingMs returns null for non-countdown states', () => {
+    expect(remainingMs(IDLE, 100)).toBeNull();
+    expect(remainingMs(startEndOfChapter(), 100)).toBeNull();
+    const fired = tick(startCountdown(1, 0), 100);
+    expect(remainingMs(fired, 100)).toBeNull();
+  });
+
+  it('remainingMs counts down from durationMs to 0', () => {
+    const state = startCountdown(60_000, 1_000);
+    expect(remainingMs(state, 1_000)).toBe(60_000);
+    expect(remainingMs(state, 31_000)).toBe(30_000);
+    expect(remainingMs(state, state.firesAt)).toBe(0);
+  });
+
+  it('remainingMs clamps to 0 when now > firesAt', () => {
+    const state = startCountdown(60_000, 1_000);
+    expect(remainingMs(state, state.firesAt + 10_000)).toBe(0);
+  });
+
+  it('exposes the documented preset list (15 / 30 / 45 / 60 min)', () => {
+    expect(SLEEP_TIMER_PRESETS_MIN).toEqual([15, 30, 45, 60]);
+  });
+});

--- a/src/lib/sleep-timer.ts
+++ b/src/lib/sleep-timer.ts
@@ -1,0 +1,118 @@
+/* Sleep-timer state machine — plan 53.
+ *
+ * Pure JS state machine driving the mini-player's optional "stop
+ * after N minutes" or "stop at the end of the current chapter"
+ * affordance. NO React dependencies — the component owns its own
+ * useRef/useEffect glue (so the timer survives chapter-switch
+ * re-renders) and just polls/feeds events into this machine.
+ *
+ * Two flavours:
+ *
+ *   - **countdown**: timer fires after `durationMs` of wall-clock
+ *     time. The component pauses playback (and the existing plan
+ *     47 onTimeUpdate flush handles the listen-progress save on
+ *     the next pause-driven render).
+ *
+ *   - **end-of-chapter**: timer fires when the audio element emits
+ *     `ended`. No duration involved — the player just calls
+ *     `notifyChapterEnded()` from its onEnded handler.
+ *
+ * The state is intentionally **per-session only**. Reload =
+ * cleared timer. This matches every standalone audiobook player
+ * (BookPlayer, Smart AudioBook Player, Voice) — persisting the
+ * picked duration across reloads would surprise the user who
+ * picked "30 min" last night and reopened the app a day later. */
+
+export type SleepTimerMode = 'countdown' | 'end-of-chapter';
+
+/** Pre-baked countdown durations exposed in the picker. Kept here
+ *  (not in the component) so the test suite asserts against the
+ *  canonical list without duplicating literals. */
+export const SLEEP_TIMER_PRESETS_MIN = [15, 30, 45, 60] as const;
+export type SleepTimerPresetMin = (typeof SLEEP_TIMER_PRESETS_MIN)[number];
+
+export interface SleepTimerIdle {
+  kind: 'idle';
+}
+
+export interface SleepTimerCountdown {
+  kind: 'countdown';
+  /** Wall-clock ms at which the timer fires. */
+  firesAt: number;
+  /** Original picker selection — surfaces in the UI label. */
+  durationMs: number;
+}
+
+export interface SleepTimerEndOfChapter {
+  kind: 'end-of-chapter';
+}
+
+export interface SleepTimerFired {
+  kind: 'fired';
+  /** Which mode produced the fire, for UI copy. */
+  cause: SleepTimerMode;
+}
+
+export type SleepTimerState =
+  | SleepTimerIdle
+  | SleepTimerCountdown
+  | SleepTimerEndOfChapter
+  | SleepTimerFired;
+
+/** Idle factory — exported so tests + components share one literal. */
+export const IDLE: SleepTimerIdle = { kind: 'idle' };
+
+/** Start a fresh countdown that fires after `durationMs` of
+ *  wall-clock time. `now` parameter is a seam for tests; production
+ *  callers pass `Date.now()`. */
+export function startCountdown(durationMs: number, now: number = Date.now()): SleepTimerCountdown {
+  return { kind: 'countdown', firesAt: now + durationMs, durationMs };
+}
+
+/** Start an end-of-chapter timer. Fires the next time the audio
+ *  element emits `ended`. */
+export function startEndOfChapter(): SleepTimerEndOfChapter {
+  return { kind: 'end-of-chapter' };
+}
+
+/** Cancel any active timer back to idle. Idempotent on the idle /
+ *  fired states. */
+export function cancel(): SleepTimerIdle {
+  return IDLE;
+}
+
+/** Tick the countdown forward. Returns the same state unless the
+ *  wall-clock has crossed `firesAt`, in which case we transition to
+ *  `fired`. Caller is responsible for invoking this from a
+ *  setInterval / requestAnimationFrame / audio onTimeUpdate seam —
+ *  the machine itself owns no timers. */
+export function tick(state: SleepTimerState, now: number = Date.now()): SleepTimerState {
+  if (state.kind !== 'countdown') return state;
+  if (now >= state.firesAt) return { kind: 'fired', cause: 'countdown' };
+  return state;
+}
+
+/** Tell the machine the audio element just emitted `ended`. Only
+ *  the end-of-chapter mode reacts to this — countdown is wall-clock
+ *  driven, idle/fired are no-ops. */
+export function notifyChapterEnded(state: SleepTimerState): SleepTimerState {
+  if (state.kind === 'end-of-chapter') return { kind: 'fired', cause: 'end-of-chapter' };
+  return state;
+}
+
+/** Convenience for the UI: how many ms remain before the countdown
+ *  fires. Returns null for non-countdown states. Negative values
+ *  clamp to 0 (the countdown should already have ticked into
+ *  `fired` by that point, but the floor keeps the UI honest if a
+ *  tick was missed). */
+export function remainingMs(state: SleepTimerState, now: number = Date.now()): number | null {
+  if (state.kind !== 'countdown') return null;
+  return Math.max(0, state.firesAt - now);
+}
+
+/** Predicate — is the player supposed to pause RIGHT NOW because
+ *  the timer fired? Caller flips this back to idle after acting on
+ *  the fire so we don't pause every render. */
+export function isFired(state: SleepTimerState): state is SleepTimerFired {
+  return state.kind === 'fired';
+}

--- a/src/store/listen-progress-slice.test.ts
+++ b/src/store/listen-progress-slice.test.ts
@@ -1,21 +1,36 @@
 // Pairs with docs/features/archive/47-listen-progress.md
+// Extended by plan 53 (playbackRate + markers).
 
 import { describe, expect, it } from 'vitest';
 import {
+  DEFAULT_PLAYBACK_RATE,
+  LISTEN_MARKER_KINDS,
+  getPlaybackRate,
   listenProgressSlice,
   listenProgressActions,
   selectListenProgress,
+  type ListenMarker,
   type ListenProgressRecord,
   type ListenProgressState,
 } from './listen-progress-slice';
 
-const empty = (): ListenProgressState => ({ byBook: {} });
+const empty = (): ListenProgressState => ({ byBook: {}, pendingSeek: null });
 
 const sample: ListenProgressRecord = {
   chapterId: 3,
   currentSec: 83.5,
   updatedAt: '2026-05-18T01:30:00.000Z',
 };
+
+const marker = (over: Partial<ListenMarker> = {}): ListenMarker => ({
+  id: 'mk_1',
+  chapterId: 3,
+  sec: 83.5,
+  label: 're-record this',
+  kind: 'rerecord',
+  createdAt: '2026-05-19T10:00:00.000Z',
+  ...over,
+});
 
 describe('listenProgressSlice — hydrate', () => {
   it('seeds byBook[bookId] from a non-null record', () => {
@@ -29,6 +44,7 @@ describe('listenProgressSlice — hydrate', () => {
   it('null progress clears any existing entry for the book without touching others', () => {
     const start: ListenProgressState = {
       byBook: { b1: sample, b2: { ...sample, chapterId: 5 } },
+      pendingSeek: null,
     };
     const next = listenProgressSlice.reducer(
       start,
@@ -51,7 +67,7 @@ describe('listenProgressSlice — update', () => {
   });
 
   it('overwrites the prior chapterId / currentSec for the same book', () => {
-    const start: ListenProgressState = { byBook: { b1: sample } };
+    const start: ListenProgressState = { byBook: { b1: sample }, pendingSeek: null };
     const next = listenProgressSlice.reducer(
       start,
       listenProgressActions.update({ bookId: 'b1', chapterId: 9, currentSec: 99 }),
@@ -74,7 +90,7 @@ describe('listenProgressSlice — update', () => {
   });
 
   it('leaves entries for other books intact', () => {
-    const start: ListenProgressState = { byBook: { b1: sample } };
+    const start: ListenProgressState = { byBook: { b1: sample }, pendingSeek: null };
     const next = listenProgressSlice.reducer(
       start,
       listenProgressActions.update({ bookId: 'b2', chapterId: 1, currentSec: 2 }),
@@ -88,6 +104,7 @@ describe('listenProgressSlice — clear', () => {
   it('removes one book without touching others', () => {
     const start: ListenProgressState = {
       byBook: { b1: sample, b2: { ...sample, chapterId: 11 } },
+      pendingSeek: null,
     };
     const next = listenProgressSlice.reducer(start, listenProgressActions.clear({ bookId: 'b1' }));
     expect(next.byBook.b1).toBeUndefined();
@@ -97,22 +114,222 @@ describe('listenProgressSlice — clear', () => {
 
 describe('selectListenProgress', () => {
   it('returns the record for the given book when present', () => {
-    const state = { listenProgress: { byBook: { b1: sample } } };
+    const state = { listenProgress: { byBook: { b1: sample }, pendingSeek: null } };
     expect(selectListenProgress('b1')(state)).toEqual(sample);
   });
 
   it('returns null when the book has no entry', () => {
-    const state = { listenProgress: { byBook: {} } };
+    const state = { listenProgress: { byBook: {}, pendingSeek: null } };
     expect(selectListenProgress('b1')(state)).toBeNull();
   });
 
   it('returns null when bookId is null (pre-ready stages have no active book)', () => {
-    const state = { listenProgress: { byBook: { b1: sample } } };
+    const state = { listenProgress: { byBook: { b1: sample }, pendingSeek: null } };
     expect(selectListenProgress(null)(state)).toBeNull();
   });
 
   it('returns null defensively when the slice is absent from the store', () => {
     const state: { listenProgress?: ListenProgressState } = {};
     expect(selectListenProgress('b1')(state)).toBeNull();
+  });
+});
+
+describe('listenProgressSlice — plan 53 playbackRate', () => {
+  it('hydrate round-trips a playbackRate field', () => {
+    const next = listenProgressSlice.reducer(
+      empty(),
+      listenProgressActions.hydrate({
+        bookId: 'b1',
+        progress: { ...sample, playbackRate: 1.5 },
+      }),
+    );
+    expect(next.byBook.b1?.playbackRate).toBe(1.5);
+  });
+
+  it('getPlaybackRate falls back to 1.0 when the field is absent', () => {
+    expect(getPlaybackRate(sample)).toBe(DEFAULT_PLAYBACK_RATE);
+    expect(DEFAULT_PLAYBACK_RATE).toBe(1.0);
+  });
+
+  it('getPlaybackRate ignores non-finite values defensively', () => {
+    expect(getPlaybackRate({ ...sample, playbackRate: Number.NaN })).toBe(1.0);
+    expect(getPlaybackRate({ ...sample, playbackRate: Number.POSITIVE_INFINITY })).toBe(1.0);
+    expect(getPlaybackRate(null)).toBe(1.0);
+  });
+
+  it('setPlaybackRate writes onto an existing record without losing position', () => {
+    const start: ListenProgressState = { byBook: { b1: sample }, pendingSeek: null };
+    const next = listenProgressSlice.reducer(
+      start,
+      listenProgressActions.setPlaybackRate({ bookId: 'b1', playbackRate: 1.75 }),
+    );
+    expect(next.byBook.b1?.playbackRate).toBe(1.75);
+    expect(next.byBook.b1?.chapterId).toBe(sample.chapterId);
+    expect(next.byBook.b1?.currentSec).toBe(sample.currentSec);
+  });
+
+  it('setPlaybackRate seeds a minimal record when none exists', () => {
+    const next = listenProgressSlice.reducer(
+      empty(),
+      listenProgressActions.setPlaybackRate({ bookId: 'b1', playbackRate: 1.25 }),
+    );
+    expect(next.byBook.b1?.playbackRate).toBe(1.25);
+    expect(next.byBook.b1?.chapterId).toBe(0);
+    expect(next.byBook.b1?.currentSec).toBe(0);
+  });
+
+  it('update preserves a previously-set playbackRate across position updates', () => {
+    const start: ListenProgressState = {
+      byBook: { b1: { ...sample, playbackRate: 1.5 } },
+      pendingSeek: null,
+    };
+    const next = listenProgressSlice.reducer(
+      start,
+      listenProgressActions.update({ bookId: 'b1', chapterId: 4, currentSec: 200 }),
+    );
+    expect(next.byBook.b1?.playbackRate).toBe(1.5);
+    expect(next.byBook.b1?.chapterId).toBe(4);
+    expect(next.byBook.b1?.currentSec).toBe(200);
+  });
+});
+
+describe('listenProgressSlice — plan 53 markers', () => {
+  it('addMarker appends to the markers array', () => {
+    const start: ListenProgressState = { byBook: { b1: sample }, pendingSeek: null };
+    const next = listenProgressSlice.reducer(
+      start,
+      listenProgressActions.addMarker({ bookId: 'b1', marker: marker() }),
+    );
+    expect(next.byBook.b1?.markers).toEqual([marker()]);
+  });
+
+  it('addMarker preserves existing markers', () => {
+    const start: ListenProgressState = {
+      byBook: { b1: { ...sample, markers: [marker({ id: 'mk_a' })] } },
+      pendingSeek: null,
+    };
+    const next = listenProgressSlice.reducer(
+      start,
+      listenProgressActions.addMarker({ bookId: 'b1', marker: marker({ id: 'mk_b' }) }),
+    );
+    expect(next.byBook.b1?.markers?.map((m) => m.id)).toEqual(['mk_a', 'mk_b']);
+  });
+
+  it('addMarker seeds a record when none exists yet (user marks before first save)', () => {
+    const next = listenProgressSlice.reducer(
+      empty(),
+      listenProgressActions.addMarker({
+        bookId: 'b1',
+        marker: marker({ chapterId: 5, sec: 12 }),
+      }),
+    );
+    expect(next.byBook.b1?.markers).toHaveLength(1);
+    expect(next.byBook.b1?.chapterId).toBe(5);
+    expect(next.byBook.b1?.currentSec).toBe(12);
+  });
+
+  it('editMarker patches label + kind in place; leaves siblings alone', () => {
+    const start: ListenProgressState = {
+      byBook: {
+        b1: {
+          ...sample,
+          markers: [marker({ id: 'mk_a' }), marker({ id: 'mk_b', label: 'untouched', kind: 'note' })],
+        },
+      },
+      pendingSeek: null,
+    };
+    const next = listenProgressSlice.reducer(
+      start,
+      listenProgressActions.editMarker({
+        bookId: 'b1',
+        markerId: 'mk_a',
+        patch: { label: 'updated', kind: 'note' },
+      }),
+    );
+    const ms = next.byBook.b1?.markers ?? [];
+    expect(ms.find((m) => m.id === 'mk_a')?.label).toBe('updated');
+    expect(ms.find((m) => m.id === 'mk_a')?.kind).toBe('note');
+    expect(ms.find((m) => m.id === 'mk_b')?.label).toBe('untouched');
+  });
+
+  it('editMarker missing markerId is a silent no-op', () => {
+    const start: ListenProgressState = {
+      byBook: { b1: { ...sample, markers: [marker({ id: 'mk_a' })] } },
+      pendingSeek: null,
+    };
+    const next = listenProgressSlice.reducer(
+      start,
+      listenProgressActions.editMarker({
+        bookId: 'b1',
+        markerId: 'mk_ghost',
+        patch: { label: 'no-op' },
+      }),
+    );
+    expect(next.byBook.b1?.markers?.[0].label).toBe('re-record this');
+  });
+
+  it('deleteMarker removes the matching marker only', () => {
+    const start: ListenProgressState = {
+      byBook: {
+        b1: { ...sample, markers: [marker({ id: 'mk_a' }), marker({ id: 'mk_b' })] },
+      },
+      pendingSeek: null,
+    };
+    const next = listenProgressSlice.reducer(
+      start,
+      listenProgressActions.deleteMarker({ bookId: 'b1', markerId: 'mk_a' }),
+    );
+    expect(next.byBook.b1?.markers?.map((m) => m.id)).toEqual(['mk_b']);
+  });
+
+  it('update preserves markers across position updates', () => {
+    const start: ListenProgressState = {
+      byBook: { b1: { ...sample, markers: [marker()] } },
+      pendingSeek: null,
+    };
+    const next = listenProgressSlice.reducer(
+      start,
+      listenProgressActions.update({ bookId: 'b1', chapterId: 4, currentSec: 200 }),
+    );
+    expect(next.byBook.b1?.markers).toEqual([marker()]);
+  });
+
+  it('exposes the documented marker-kind enum (note / rerecord)', () => {
+    expect(LISTEN_MARKER_KINDS).toEqual(['note', 'rerecord']);
+  });
+});
+
+describe('listenProgressSlice — plan 53 pendingSeek (marker-click → mini-player)', () => {
+  it('requestSeek stamps a fresh pendingSeek with an incrementing requestId', () => {
+    const first = listenProgressSlice.reducer(
+      empty(),
+      listenProgressActions.requestSeek({ bookId: 'b1', chapterId: 3, sec: 12 }),
+    );
+    expect(first.pendingSeek).toEqual({ bookId: 'b1', chapterId: 3, sec: 12, requestId: 1 });
+    const second = listenProgressSlice.reducer(
+      first,
+      listenProgressActions.requestSeek({ bookId: 'b1', chapterId: 3, sec: 12 }),
+    );
+    expect(second.pendingSeek?.requestId).toBe(2);
+  });
+
+  it('consumeSeek clears the matching requestId; stale ids are ignored', () => {
+    const after = listenProgressSlice.reducer(
+      empty(),
+      listenProgressActions.requestSeek({ bookId: 'b1', chapterId: 3, sec: 12 }),
+    );
+    const id = after.pendingSeek!.requestId;
+    /* Stale id — no-op. */
+    const stale = listenProgressSlice.reducer(
+      after,
+      listenProgressActions.consumeSeek({ requestId: id + 99 }),
+    );
+    expect(stale.pendingSeek?.requestId).toBe(id);
+    /* Real id — cleared. */
+    const cleared = listenProgressSlice.reducer(
+      after,
+      listenProgressActions.consumeSeek({ requestId: id }),
+    );
+    expect(cleared.pendingSeek).toBeNull();
   });
 });

--- a/src/store/listen-progress-slice.ts
+++ b/src/store/listen-progress-slice.ts
@@ -11,21 +11,78 @@
  *   2. Persisting would put the bookmark in two places of truth;
  *      a stale rehydrate could clobber a fresh server-side write.
  *
- * Plan 47. */
+ * Plan 47, extended by plan 53 with `playbackRate` (per-book
+ * playback-speed memory) and `markers` (user-placed bookmarks). */
 
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+/* Plan 53 — marker kind enum. `note` is a general bookmark, `rerecord`
+   flags a spot that needs another voice take. Server validator (plan
+   53, server/src/routes/book-state.ts) rejects any other string so the
+   on-disk shape stays canonical. */
+export type ListenMarkerKind = 'note' | 'rerecord';
+export const LISTEN_MARKER_KINDS: readonly ListenMarkerKind[] = ['note', 'rerecord'] as const;
+
+export interface ListenMarker {
+  id: string;
+  chapterId: number;
+  sec: number;
+  label: string;
+  kind: ListenMarkerKind;
+  createdAt: string;
+}
 
 export interface ListenProgressRecord {
   chapterId: number;
   currentSec: number;
   updatedAt: string;
+  /* Plan 53 — per-book playback rate (HTMLMediaElement.playbackRate).
+     Optional / lazy: pre-plan-53 records on disk lack the field and
+     callers default to 1.0 via getPlaybackRate(). */
+  playbackRate?: number;
+  /* Plan 53 — user-placed bookmarks. Optional + defaults to [] for
+     records written before plan 53. */
+  markers?: ListenMarker[];
+}
+
+/* Plan 53 — explicit "seek requested" signal so the listen-view
+   marker-click can hop the mini-player to a position WITHIN the
+   currently-playing chapter (where the chapter-mount seek path
+   wouldn't re-fire because the chapter id didn't change). The
+   mini-player consumes this with an effect, fires
+   el.currentTime = sec, then dispatches consumeSeek to clear it. */
+export interface PendingSeek {
+  bookId: string;
+  chapterId: number;
+  sec: number;
+  /* Monotonic counter so two marker clicks at the same sec still
+     trigger a fresh seek (the effect compares the requestId, not the
+     payload). */
+  requestId: number;
 }
 
 export interface ListenProgressState {
   byBook: Record<string, ListenProgressRecord>;
+  /* Plan 53 — one-shot seek request consumed by the mini-player.
+     Null between requests. */
+  pendingSeek: PendingSeek | null;
 }
 
-const initialState: ListenProgressState = { byBook: {} };
+const initialState: ListenProgressState = { byBook: {}, pendingSeek: null };
+
+/* Default playback rate when the record omits the field (pre-plan-53
+   data on disk, or a brand-new book that hasn't picked a rate yet). */
+export const DEFAULT_PLAYBACK_RATE = 1.0;
+
+/** Helper used by the mini-player to read the rate with a guaranteed
+ *  numeric fallback. Saves every caller from `?? 1.0` plumbing and keeps
+ *  the default centralised. */
+export function getPlaybackRate(record: ListenProgressRecord | null | undefined): number {
+  if (!record || typeof record.playbackRate !== 'number' || !Number.isFinite(record.playbackRate)) {
+    return DEFAULT_PLAYBACK_RATE;
+  }
+  return record.playbackRate;
+}
 
 export const listenProgressSlice = createSlice({
   name: 'listenProgress',
@@ -44,20 +101,123 @@ export const listenProgressSlice = createSlice({
     /* Optimistic update after a debounced PUT. Server's response will
        arrive with a real updatedAt; the slice carries the local timer's
        Date.now() value until then so the Listen pill's MM:SS stays
-       fresh during continuous playback. */
+       fresh during continuous playback.
+       Plan 53: preserves `playbackRate` + `markers` across position
+       updates — the mini-player's debounced PUT only carries chapter
+       + position, so without this guard the slice would drop the
+       user's chosen rate and markers between saves. */
     update: (
       s,
       a: PayloadAction<{ bookId: string; chapterId: number; currentSec: number; updatedAt?: string }>,
     ) => {
       const { bookId, chapterId, currentSec, updatedAt } = a.payload;
+      const prev = s.byBook[bookId];
       s.byBook[bookId] = {
         chapterId,
         currentSec,
         updatedAt: updatedAt ?? new Date().toISOString(),
+        ...(prev?.playbackRate !== undefined ? { playbackRate: prev.playbackRate } : {}),
+        ...(prev?.markers ? { markers: prev.markers } : {}),
       };
+    },
+    /* Plan 53 — playback-rate change from the mini-player picker.
+       Preserves the existing position + markers; stamps a fresh
+       updatedAt so the disk write that fans out from the same picker
+       handler echoes the user's clock. */
+    setPlaybackRate: (
+      s,
+      a: PayloadAction<{ bookId: string; playbackRate: number; updatedAt?: string }>,
+    ) => {
+      const { bookId, playbackRate, updatedAt } = a.payload;
+      const prev = s.byBook[bookId];
+      if (prev) {
+        prev.playbackRate = playbackRate;
+        prev.updatedAt = updatedAt ?? new Date().toISOString();
+        return;
+      }
+      /* No prior record (user picked a rate before any playback
+         actually advanced). Seed a minimal record so the rate survives
+         the first PUT-then-hydrate round-trip. */
+      s.byBook[bookId] = {
+        chapterId: 0,
+        currentSec: 0,
+        updatedAt: updatedAt ?? new Date().toISOString(),
+        playbackRate,
+      };
+    },
+    /* Plan 53 — add a marker. Reducer is silent on duplicate ids; the
+       caller is the only id minter (uses crypto.randomUUID() in the
+       mini-player) and we don't want to throw inside Immer. */
+    addMarker: (
+      s,
+      a: PayloadAction<{ bookId: string; marker: ListenMarker }>,
+    ) => {
+      const { bookId, marker } = a.payload;
+      const prev = s.byBook[bookId];
+      if (prev) {
+        prev.markers = [...(prev.markers ?? []), marker];
+        return;
+      }
+      /* No prior record — same minimal-seed pattern as
+         setPlaybackRate. The mini-player only fires this from inside
+         the chapter context, so chapterId/currentSec from the marker
+         are sensible defaults for the parent record. */
+      s.byBook[bookId] = {
+        chapterId: marker.chapterId,
+        currentSec: marker.sec,
+        updatedAt: new Date().toISOString(),
+        markers: [marker],
+      };
+    },
+    /* Plan 53 — edit a marker's label and/or kind. Missing markerId is
+       a silent no-op (caller is the sole id minter; no real session can
+       hit this). */
+    editMarker: (
+      s,
+      a: PayloadAction<{
+        bookId: string;
+        markerId: string;
+        patch: Partial<Pick<ListenMarker, 'label' | 'kind'>>;
+      }>,
+    ) => {
+      const { bookId, markerId, patch } = a.payload;
+      const prev = s.byBook[bookId];
+      if (!prev?.markers) return;
+      const target = prev.markers.find((m) => m.id === markerId);
+      if (!target) return;
+      if (patch.label !== undefined) target.label = patch.label;
+      if (patch.kind !== undefined) target.kind = patch.kind;
+    },
+    /* Plan 53 — delete a marker. Missing id is a silent no-op. */
+    deleteMarker: (
+      s,
+      a: PayloadAction<{ bookId: string; markerId: string }>,
+    ) => {
+      const { bookId, markerId } = a.payload;
+      const prev = s.byBook[bookId];
+      if (!prev?.markers) return;
+      prev.markers = prev.markers.filter((m) => m.id !== markerId);
     },
     clear: (s, a: PayloadAction<{ bookId: string }>) => {
       delete s.byBook[a.payload.bookId];
+    },
+    /* Plan 53 — request a seek inside the current chapter. The mini-
+       player's effect compares requestId against its last-consumed
+       and fires el.currentTime = sec. */
+    requestSeek: (
+      s,
+      a: PayloadAction<{ bookId: string; chapterId: number; sec: number }>,
+    ) => {
+      const prevId = s.pendingSeek?.requestId ?? 0;
+      s.pendingSeek = {
+        bookId: a.payload.bookId,
+        chapterId: a.payload.chapterId,
+        sec: a.payload.sec,
+        requestId: prevId + 1,
+      };
+    },
+    consumeSeek: (s, a: PayloadAction<{ requestId: number }>) => {
+      if (s.pendingSeek?.requestId === a.payload.requestId) s.pendingSeek = null;
     },
   },
 });
@@ -73,4 +233,15 @@ export const selectListenProgress =
   (s: { listenProgress?: ListenProgressState }): ListenProgressRecord | null => {
     if (!bookId) return null;
     return s.listenProgress?.byBook[bookId] ?? null;
+  };
+
+/* Plan 53 — selector for the one-shot pending seek. Null when no
+   marker click is waiting, or when the slice isn't registered. */
+export const selectPendingSeek =
+  (bookId: string | null) =>
+  (s: { listenProgress?: ListenProgressState }): PendingSeek | null => {
+    if (!bookId) return null;
+    const ps = s.listenProgress?.pendingSeek;
+    if (!ps || ps.bookId !== bookId) return null;
+    return ps;
   };

--- a/src/views/listen.tsx
+++ b/src/views/listen.tsx
@@ -33,7 +33,12 @@ import { EXPORT_QUEUE } from '../data/export-queue';
 import { bookExportJobToQueueItem } from '../lib/export-queue-adapter';
 import { useAppDispatch, useAppSelector } from '../store';
 import { uiActions } from '../store/ui-slice';
-import { selectListenProgress } from '../store/listen-progress-slice';
+import {
+  listenProgressActions,
+  selectListenProgress,
+  type ListenMarker,
+} from '../store/listen-progress-slice';
+import { api } from '../lib/api';
 import { exportsActions } from '../store/exports-slice';
 import { notificationsActions } from '../store/notifications-slice';
 import type { Chapter, Character, Voice, ListenerApp, ExportQueueItem } from '../lib/types';
@@ -248,6 +253,57 @@ export function ListenView({
           </div>
         </div>
       </section>
+
+      <MarkersPanel
+        bookId={bookId}
+        chapters={chapters}
+        onSeek={(marker) => {
+          /* Plan 53 — click a marker → reload that chapter into the
+             mini-player AND stamp the per-book resume bookmark to
+             marker.sec so the mini-player's onLoadedMetadata seek
+             lands at the marker position. Persist as well so a
+             reload arrives at the same spot.
+
+             Two paths the mini-player needs covered:
+             (a) marker chapter != currently-playing chapter → setCurrentTrack
+                 triggers the chapter-mount effect, which reads
+                 pendingSeekRef → onLoadedMetadata applies it.
+             (b) marker chapter == currently-playing chapter → no
+                 remount fires; the requestSeek dispatch below feeds
+                 the mini-player's seek effect via the pendingSeek
+                 selector. */
+          dispatch(
+            listenProgressActions.update({
+              bookId,
+              chapterId: marker.chapterId,
+              currentSec: marker.sec,
+            }),
+          );
+          /* Fire-and-forget — listen-view marker clicks are
+             non-blocking. The mini-player's hydrate effect will
+             re-fetch this on the next mount, so even a transient
+             network failure isn't fatal. */
+          void api
+            .putListenProgress(bookId, {
+              chapterId: marker.chapterId,
+              currentSec: marker.sec,
+            })
+            .catch(() => {
+              /* swallow — slice already optimistically updated */
+            });
+          dispatch(
+            listenProgressActions.requestSeek({
+              bookId,
+              chapterId: marker.chapterId,
+              sec: marker.sec,
+            }),
+          );
+          setCurrentTrack(marker.chapterId);
+        }}
+        onDelete={(markerId) => {
+          dispatch(listenProgressActions.deleteMarker({ bookId, markerId }));
+        }}
+      />
 
       <section className="mb-12">
         <div className="flex items-center justify-between mb-3">
@@ -582,6 +638,91 @@ function ChapterListenRow({
         </button>
       </span>
     </div>
+  );
+}
+
+/* Plan 53 — markers sidebar panel. Reads the per-book bookmarks
+   from the listen-progress slice, groups by chapter, and renders
+   click-to-seek + delete affordances. Null-renders when the book has
+   no markers so the listen view stays uncluttered for fresh books. */
+interface MarkersPanelProps {
+  bookId: string;
+  chapters: Chapter[];
+  onSeek: (marker: ListenMarker) => void;
+  onDelete: (markerId: string) => void;
+}
+function MarkersPanel({ bookId, chapters, onSeek, onDelete }: MarkersPanelProps) {
+  const progress = useAppSelector(selectListenProgress(bookId));
+  const markers = progress?.markers ?? [];
+  if (markers.length === 0) return null;
+  /* Group markers by chapter for the sidebar; chapter order matches
+     the chapters prop so a re-ordered restructure (plan 51) keeps the
+     panel coherent. */
+  const byChapter = new Map<number, ListenMarker[]>();
+  for (const m of markers) {
+    const list = byChapter.get(m.chapterId) ?? [];
+    list.push(m);
+    byChapter.set(m.chapterId, list);
+  }
+  /* Sort each chapter's markers by position so the UI reads top-to-
+     bottom by play order. */
+  for (const list of byChapter.values()) list.sort((a, b) => a.sec - b.sec);
+  const groups: Array<{ chapter: Chapter; markers: ListenMarker[] }> = [];
+  for (const ch of chapters) {
+    const list = byChapter.get(ch.id);
+    if (list && list.length > 0) groups.push({ chapter: ch, markers: list });
+  }
+  return (
+    <section data-testid="listen-markers-panel" className="mb-12">
+      <div className="flex items-center justify-between mb-3">
+        <SectionLabel>Markers</SectionLabel>
+        <span className="text-xs text-ink/50">
+          {markers.length} bookmark{markers.length === 1 ? '' : 's'}
+        </span>
+      </div>
+      <div className="bg-white rounded-3xl border border-ink/10 shadow-card overflow-hidden divide-y divide-ink/5">
+        {groups.map((g) => (
+          <div key={g.chapter.id} className="px-5 py-4">
+            <p className="text-[11px] uppercase tracking-wider font-semibold text-ink/50 mb-2">
+              CH {String(g.chapter.id).padStart(2, '0')} · {stripChapterPrefix(g.chapter.title)}
+            </p>
+            <ul className="space-y-1">
+              {g.markers.map((m) => (
+                <li
+                  key={m.id}
+                  data-testid={`listen-marker-${m.id}`}
+                  className="flex items-center gap-3 text-sm text-ink/80"
+                >
+                  <button
+                    type="button"
+                    onClick={() => onSeek(m)}
+                    data-testid={`listen-marker-seek-${m.id}`}
+                    className="flex-1 flex items-center gap-3 text-left hover:text-ink"
+                  >
+                    <span className="tabular-nums text-xs text-ink/50 w-12">
+                      {formatTime(m.sec)}
+                    </span>
+                    <span className="truncate">{m.label || <em className="text-ink/40">No label</em>}</span>
+                    {m.kind === 'rerecord' && (
+                      <Pill color="library">re-record</Pill>
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onDelete(m.id)}
+                    aria-label="Delete marker"
+                    data-testid={`listen-marker-delete-${m.id}`}
+                    className="text-ink/40 hover:text-rose-500 text-xs px-2"
+                  >
+                    ×
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </section>
   );
 }
 


### PR DESCRIPTION
## Summary

Closes BACKLOG Should #1 + Could #4 + Could #5 — three mini-player features bundled in one cohesive change. All three touch the same files (mini-player + listen-progress slice + PUT validator), so bundling saves three serial PR cycles + three slice migrations.

- **Playback speed picker** — 6 presets (0.75× — 2.0×), persisted per book via new optional `playbackRate` field on `listen-progress.json`. Pure `HTMLMediaElement.playbackRate`.
- **User-placed markers** — button + `M` shortcut captures `chapterId + currentSec` with label + `note|rerecord` kind. Listen view renders a sidebar grouped by chapter; click → seek. Markers persist on listen-progress.json.
- **Sleep timer** — 15/30/45/60-min countdown + end-of-chapter mode. Pure state machine in `src/lib/sleep-timer.ts`. Per-session by design.

Tests: Frontend +9 (985 total), Server +7 (959 total), E2E +5 specs. Plus a follow-up commit applying file-level serial mode to the new e2e spec (mirrors plan 58's fix for the existing flakes).

## Test plan

- [x] `npm run verify` green
- [x] `e2e/mini-player-features.spec.ts` (5 specs) — passes with serial mode
- [ ] Manual: set 1.5× → reload → still 1.5×; drop marker → reload → still there; click marker → seek ±1s; set 5-min timer → fast-forward → auto-pause

Pairs with `docs/features/53-mini-player-feature-pack.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)