### PR TITLE
feat(frontend): plan 57 — wire M4B + MP3 ZIP download tiles on listen view

### DIFF
--- a/docs/features/57-download-tiles.md
+++ b/docs/features/57-download-tiles.md
@@ -1,0 +1,108 @@
+---
+status: active
+shipped: null
+owner: null
+---
+
+# 57 — Listen-view download tiles
+
+> Status: active
+> Key files: `src/views/listen.tsx`, `src/modals/export-audiobook.tsx` (unchanged — reused via `prefill`)
+> URL surface: indirect — opens the existing `ExportAudiobookModal` from
+> the listen view's "Or download a file" section.
+> OpenAPI ops: `POST /api/books/{bookId}/export` (unchanged — already
+> supports `format: 'm4b'` and `format: 'mp3-zip'`).
+
+## Benefit / Rationale
+
+- **User:** Closes the second-largest "Coming soon" surface on the
+  Listen view. Pre-plan-57 the only direct-artifact path goes through
+  the per-app tiles (PocketBook / Voice / etc.) which gate on a target
+  app. Plan 57 surfaces the same artifacts as plain downloads.
+- **Technical:** Zero new server code. The export route + builders
+  already support `m4b` and `mp3-zip`; this plan is pure UI wiring +
+  one additional `DownloadCard` (the MP3 ZIP tile).
+- **Architectural:** Extends the existing `exportModal.prefill` pattern
+  (introduced by plan 33 voice export) with a non-app-specific
+  `format` channel. Future direct-format tiles (e.g. a "Folder of
+  MP3s" tile if anyone wants it) reuse the same hook.
+
+## Architectural impact
+
+- **New seam:** the `exportModal` state in `listen.tsx` gains an
+  optional `format` field alongside the existing `tab` + `appHint`.
+  When set without `appHint`, the modal opens in its generic two-tab UX
+  but with `prefill.format` pre-selecting the format row.
+- **DownloadCard:** gains an optional `onDownload?: () => void` +
+  `testid?: string`. When `onDownload` is set, the tile is live (button
+  enabled, no Coming-Soon badge); when absent, the tile retains the
+  legacy "Coming soon" appearance.
+- **Invariants preserved:**
+  - Plan 23 (mock toggle): components stay neutral — the live tiles
+    call `setExportModal`, which routes through the same
+    `ExportAudiobookModal` whose backend hits go through the `api`
+    module (real vs. mock).
+  - Plan 24 (OpenAPI source of truth): no schema changes; existing
+    `BookExportJob.format` enum covers both `m4b` and `mp3-zip`.
+  - Plan 26 (RTK Immer drafts): no slice changes.
+
+## v1.3.0 scope
+
+- ✅ **M4B chaptered tile (live):** opens modal pre-set to
+  `format: 'm4b', destination: 'download'`.
+- ✅ **MP3 ZIP tile (NEW, live):** opens modal pre-set to
+  `format: 'mp3-zip', destination: 'download'`.
+- ⏳ **Streaming link tile (Coming soon):** kept as a non-live tile
+  with clarifying copy ("Available in a later release"). Needs a
+  server-minted slugged URL endpoint (`/share/:slug` proxying the M4B
+  off disk) which is a separate piece of work — parked as BACKLOG
+  follow-up.
+
+## Invariants to preserve
+
+1. **`exportModal.format` is non-collapsing.** When the user clicks a
+   download tile, the modal opens in the generic two-tab UX (not
+   collapsed like the `appHint` path). The format picker is pre-set but
+   the user can still flip to a different format or switch to the
+   sync-folder tab. `src/views/listen.tsx`.
+2. **DownloadCard remains the only entry point for the "Or download a
+   file" section.** Listener-app tiles (PocketBook, Voice, etc.) are a
+   sibling section and continue to use `appHint` collapsing.
+3. **The streaming-link tile stays non-live until the slugged URL
+   endpoint exists.** Wiring it before the server endpoint lands would
+   surface a broken download. Better to keep the affordance honest.
+
+## Test plan
+
+### Automated coverage
+
+- New e2e `e2e/download-tiles.spec.ts` (3 specs):
+  - M4B tile is enabled, click opens the modal with M4B pre-selected.
+  - MP3 ZIP tile is enabled, click opens the modal with MP3 ZIP
+    pre-selected.
+  - Streaming link tile remains disabled.
+
+### Manual acceptance walkthrough
+
+1. Open Solway Bay → Listen view.
+2. Scroll to "Or download a file" — three tiles render: Full audiobook
+   (M4B), MP3 ZIP, Streaming link.
+3. Click M4B → ExportAudiobookModal opens in download mode with the M4B
+   format row highlighted. Cancel.
+4. Click MP3 ZIP → same modal, MP3 ZIP format row highlighted. Confirm
+   → job appears in the export queue (real backend) or rejects with a
+   "build incomplete" warning when chapters aren't all rendered.
+5. Streaming link tile shows the Coming Soon affordance and its
+   Download button is disabled.
+
+## Out of scope
+
+- **Streaming-link slugged URL minting.** Needs a new server endpoint
+  (`POST /api/books/:bookId/share` returning a slug + `GET
+  /share/:slug` proxying the M4B). Parked as BACKLOG follow-up.
+- **Export-queue Retry + Download row actions.** BACKLOG Could #34;
+  separate scope, can land independently once Plan 57 is in.
+
+## Ship notes
+
+(Filled in when status flips to `stable`.)

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -87,6 +87,7 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 - [53 — Mini-player feature pack (playback speed + markers + sleep timer)](53-mini-player-feature-pack.md) — Speed picker (0.75× — 2×) persisted per book; user-placed markers (note / rerecord kinds) with a listen-view sidebar; sleep timer with countdown presets + end-of-chapter mode (per-session, not persisted). Extends plan 47's persistence seam.
 - [32 — Audiobook export](32-audiobook-export.md) — Sideload to PocketBook Reader (Phase A: MP3.ZIP) via LAN download or sync folder; per-chapter ID3v2.4 tags, no re-encode, atomic writes.
 - [34 — MP3-folder export](34-mp3-folder-export.md) — Per-chapter MP3s in a sub-folder for folder-scanning audiobook apps (Smart AudioBook Player, BookPlayer, Audiobookshelf). Sync-folder destination only; APIC cover travels with each chapter.
+- [57 — Listen-view download tiles](57-download-tiles.md) — Wires the M4B chaptered + MP3 ZIP tiles on the listen view to open the existing `ExportAudiobookModal` with the format pre-filled; streaming-link tile remains "Coming soon" pending a slugged URL endpoint.
 
 ### I. Revisions & drift
 

--- a/e2e/download-tiles.spec.ts
+++ b/e2e/download-tiles.spec.ts
@@ -28,17 +28,14 @@ test.describe('plan 57 — download tiles', () => {
   test('M4B tile is live and opens the export modal with m4b pre-selected', async ({ page }) => {
     const tile = page.getByTestId('download-tile-m4b');
     await expect(tile).toBeVisible();
-    // Live tile button is enabled (no `disabled` attribute, no Coming-Soon badge).
     const button = tile.getByRole('button', { name: /Download/i });
     await expect(button).toBeEnabled();
     await button.click();
-    // ExportAudiobookModal mounts. The format-picker reflects 'm4b'.
-    // We assert the modal title / dialog role first to confirm it opened,
-    // then check that the m4b row is selected (data attribute or aria-pressed).
-    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 3_000 });
-    // The format toggle exposes data-testid="export-format-m4b" selected state
-    // (or similar). Match the generic check via accessible name "M4B".
-    await expect(page.getByText(/M4B/i).first()).toBeVisible();
+    // Modal mounts. Use the modal's own testid + the format-picker
+    // selected-state attribute exposed by export-audiobook.tsx
+    // (data-testid="export-format-m4b" on the M4B format pill).
+    await expect(page.getByTestId('export-audiobook-modal')).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByTestId('export-format-m4b')).toBeVisible();
   });
 
   test('MP3 ZIP tile is live and opens the export modal with mp3-zip pre-selected', async ({
@@ -49,16 +46,14 @@ test.describe('plan 57 — download tiles', () => {
     const button = tile.getByRole('button', { name: /Download/i });
     await expect(button).toBeEnabled();
     await button.click();
-    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 3_000 });
-    await expect(page.getByText(/MP3.*ZIP/i).first()).toBeVisible();
+    await expect(page.getByTestId('export-audiobook-modal')).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByTestId('export-format-mp3-zip')).toBeVisible();
   });
 
-  test('Streaming link tile remains "Coming soon"', async ({ page }) => {
-    /* The streaming-link tile has no data-testid (intentionally — it's
-       not live in v1.3.0). Locate it by its visible heading and assert
-       its Download button is disabled. */
-    const streamingTile = page.getByText(/Streaming link/i).locator('xpath=ancestor::div[1]');
-    const button = streamingTile.getByRole('button', { name: /Download/i });
+  test('Streaming link tile remains "Coming soon" in v1.3.0', async ({ page }) => {
+    const tile = page.getByTestId('download-tile-streaming');
+    await expect(tile).toBeVisible();
+    const button = tile.getByRole('button', { name: /Download/i });
     await expect(button).toBeDisabled();
   });
 });

--- a/e2e/download-tiles.spec.ts
+++ b/e2e/download-tiles.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Plan 57 — Listen-view download tiles e2e.
+ *
+ * Three "Or download a file" tiles on the listen view:
+ *  - Full audiobook (m4b chaptered) — LIVE
+ *  - MP3 ZIP — LIVE
+ *  - Streaming link — Coming soon
+ *
+ * Each live tile opens the ExportAudiobookModal pre-set to the right
+ * format + destination via the `prefill` prop. This spec walks the
+ * click-through for the two live tiles and confirms the modal mounts
+ * with the right format selected.
+ *
+ * Pairs with docs/features/57-download-tiles.md.
+ */
+test.describe.configure({ mode: 'serial' });
+
+test.describe('plan 57 — download tiles', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/#/books/sb/listen');
+    await expect(page.getByRole('heading', { name: /Solway Bay/i, level: 1 })).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test('M4B tile is live and opens the export modal with m4b pre-selected', async ({ page }) => {
+    const tile = page.getByTestId('download-tile-m4b');
+    await expect(tile).toBeVisible();
+    // Live tile button is enabled (no `disabled` attribute, no Coming-Soon badge).
+    const button = tile.getByRole('button', { name: /Download/i });
+    await expect(button).toBeEnabled();
+    await button.click();
+    // ExportAudiobookModal mounts. The format-picker reflects 'm4b'.
+    // We assert the modal title / dialog role first to confirm it opened,
+    // then check that the m4b row is selected (data attribute or aria-pressed).
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 3_000 });
+    // The format toggle exposes data-testid="export-format-m4b" selected state
+    // (or similar). Match the generic check via accessible name "M4B".
+    await expect(page.getByText(/M4B/i).first()).toBeVisible();
+  });
+
+  test('MP3 ZIP tile is live and opens the export modal with mp3-zip pre-selected', async ({
+    page,
+  }) => {
+    const tile = page.getByTestId('download-tile-mp3-zip');
+    await expect(tile).toBeVisible();
+    const button = tile.getByRole('button', { name: /Download/i });
+    await expect(button).toBeEnabled();
+    await button.click();
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByText(/MP3.*ZIP/i).first()).toBeVisible();
+  });
+
+  test('Streaming link tile remains "Coming soon"', async ({ page }) => {
+    /* The streaming-link tile has no data-testid (intentionally — it's
+       not live in v1.3.0). Locate it by its visible heading and assert
+       its Download button is disabled. */
+    const streamingTile = page.getByText(/Streaming link/i).locator('xpath=ancestor::div[1]');
+    const button = streamingTile.getByRole('button', { name: /Download/i });
+    await expect(button).toBeDisabled();
+  });
+});

--- a/src/views/listen.test.tsx
+++ b/src/views/listen.test.tsx
@@ -334,13 +334,20 @@ describe('ListenView — coming-soon affordances', () => {
     expect(within(appleBooksCard).getByTestId('coming-soon-badge')).toBeInTheDocument();
   });
 
-  it('disables the two remaining "Or download a file" tiles and tags them with Soon', () => {
+  it('enables M4B + MP3 ZIP download tiles, keeps streaming link as Coming soon (plan 57)', () => {
     renderView();
-    /* Phase A removed the per-chapter MP3 zip tile — the modal supersedes it.
-       Two future-affordance tiles remain (M4B + streaming link). */
+    /* Plan 57 wired the M4B + MP3 ZIP tiles to the export modal via
+       `prefill`. The streaming-link tile stays Coming soon pending a
+       slugged URL endpoint. */
     const downloads = screen.getAllByRole('button', { name: /^Download$/ });
-    expect(downloads.length).toBe(2);
-    for (const btn of downloads) expect(btn).toBeDisabled();
+    expect(downloads.length).toBe(3);
+    /* The two live tiles are enabled. */
+    expect(screen.getByTestId('download-tile-m4b').querySelector('button')).toBeEnabled();
+    expect(screen.getByTestId('download-tile-mp3-zip').querySelector('button')).toBeEnabled();
+    /* The streaming-link tile (no testid by design — it's not live) is
+       the only remaining disabled tile. */
+    const disabled = downloads.filter((b) => b.hasAttribute('disabled'));
+    expect(disabled.length).toBe(1);
   });
 
   it('shows the one remaining mocked-preview banner (listener apps)', () => {

--- a/src/views/listen.tsx
+++ b/src/views/listen.tsx
@@ -412,6 +412,7 @@ export function ListenView({
             format="Shareable URL"
             size="—"
             description="Hosted link a listener can open in a browser. Available in a later release."
+            testid="download-tile-streaming"
           />
         </div>
       </section>

--- a/src/views/listen.tsx
+++ b/src/views/listen.tsx
@@ -129,6 +129,11 @@ export function ListenView({
   const [exportModal, setExportModal] = useState<{
     tab: 'download' | 'sync-folder';
     appHint?: 'voice' | 'smart_audiobook' | 'bookplayer' | 'audiobookshelf';
+    /* Plan 57 — direct-format prefill from the download tiles (M4B,
+       MP3 ZIP). Distinct from `appHint` which collapses the modal to a
+       tile-specific UX; `format` keeps the generic two-tab UX with the
+       picker pre-set. */
+    format?: 'm4b' | 'mp3-zip' | 'mp3-folder';
   } | null>(null);
 
   /* Live job list from the store, with the visual fixtures as a fallback
@@ -385,18 +390,28 @@ export function ListenView({
           <SectionLabel>Or download a file</SectionLabel>
           <span className="text-xs text-ink/50">For sideloading or archival</span>
         </div>
-        <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="mt-3 grid grid-cols-1 md:grid-cols-3 gap-4">
           <DownloadCard
             title="Full audiobook"
             format="m4b chaptered"
             size="—"
-            description="Single file with embedded chapter markers. Coming in Phase B."
+            description="Single file with embedded chapter markers. Universal across audiobook apps."
+            testid="download-tile-m4b"
+            onDownload={() => setExportModal({ tab: 'download', format: 'm4b' })}
+          />
+          <DownloadCard
+            title="MP3 ZIP"
+            format="zipped per-chapter mp3s"
+            size="—"
+            description="One zip with every chapter as an MP3 inside. Good for folder-scanning players."
+            testid="download-tile-mp3-zip"
+            onDownload={() => setExportModal({ tab: 'download', format: 'mp3-zip' })}
           />
           <DownloadCard
             title="Streaming link"
             format="Shareable URL"
-            size="Hosted"
-            description="Send a link to listeners. Optional password protection."
+            size="—"
+            description="Hosted link a listener can open in a browser. Available in a later release."
           />
         </div>
       </section>
@@ -426,7 +441,9 @@ export function ListenView({
                 ? { format: 'mp3-folder', destination: 'sync-folder', appHint: 'bookplayer' }
                 : exportModal?.appHint === 'audiobookshelf'
                   ? { format: 'mp3-folder', destination: 'sync-folder', appHint: 'audiobookshelf' }
-                  : undefined
+                  : exportModal?.format
+                    ? { format: exportModal.format, destination: exportModal.tab }
+                    : undefined
         }
         onClose={() => setExportModal(null)}
       />
@@ -731,17 +748,29 @@ function DownloadCard({
   format,
   size,
   description,
+  onDownload,
+  testid,
 }: {
   title: string;
   format: string;
   size: string;
   description: string;
+  /** Plan 57 — when present, the tile is live: the button is enabled
+      and clicking it invokes the handler (typically opens the export
+      modal with the right format/destination pre-filled). Tiles without
+      a handler retain the "Coming soon" affordance. */
+  onDownload?: () => void;
+  testid?: string;
 }) {
+  const live = onDownload != null;
   return (
-    <div className="rounded-3xl border p-6 transition-all bg-white border-ink/10 shadow-card relative">
+    <div
+      className="rounded-3xl border p-6 transition-all bg-white border-ink/10 shadow-card relative"
+      data-testid={testid}
+    >
       <div className="flex items-start justify-between mb-3">
         <p className="text-[11px] uppercase tracking-wider font-semibold text-ink/50">{format}</p>
-        <ComingSoonBadge />
+        {!live && <ComingSoonBadge />}
       </div>
       <div className="flex items-baseline justify-between gap-3 mb-2">
         <h3 className="text-lg font-bold text-ink">{title}</h3>
@@ -749,9 +778,15 @@ function DownloadCard({
       </div>
       <p className="text-xs leading-relaxed mb-5 text-ink/60">{description}</p>
       <button
-        disabled
-        title="Download — coming soon"
-        className="w-full inline-flex items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition-colors bg-ink/[0.03] text-ink/40 cursor-not-allowed"
+        type="button"
+        onClick={live ? onDownload : undefined}
+        disabled={!live}
+        title={live ? 'Download' : 'Download — coming soon'}
+        className={
+          live
+            ? 'w-full inline-flex items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition-colors bg-ink text-canvas hover:bg-ink/90'
+            : 'w-full inline-flex items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition-colors bg-ink/[0.03] text-ink/40 cursor-not-allowed'
+        }
       >
         <IconDownload className="w-4 h-4" /> Download
       </button>


### PR DESCRIPTION
## Summary

Closes most of BACKLOG Could #33. Wires the M4B chaptered + MP3 ZIP download tiles on the Listen view; streaming-link stays "Coming soon" pending a slugged-URL minting endpoint.

- M4B "Full audiobook" tile → opens `ExportAudiobookModal` with `prefill: { format: 'm4b', destination: 'download' }`.
- NEW MP3 ZIP tile → opens modal with `prefill: { format: 'mp3-zip', destination: 'download' }`.
- Streaming link tile → kept as Coming soon with clarifying copy.
- Zero server changes — both formats already supported by the existing export route.

`DownloadCard` gains optional `onDownload` + `testid` props; the `exportModal` state shape extended with optional `format` field.

## Test plan

- [x] `npm run typecheck`, frontend tests green (1 existing assertion updated)
- [x] New `e2e/download-tiles.spec.ts` — 3 specs (M4B, MP3 ZIP, streaming-link disabled)
- [ ] Manual: click M4B → modal opens with M4B selected; click MP3 ZIP → modal opens with MP3 ZIP selected; streaming-link button disabled

Pairs with `docs/features/57-download-tiles.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)