### PR TITLE
feat(frontend): wire drift modal Listen as A/B compare player

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -830,6 +830,12 @@ export function Layout() {
         <DriftReportModal
           events={drift}
           characters={characters}
+          /* Bug 8 — wire the inline A/B player. Both required for the
+             widget to mount; bookId routes the chapter audio URL, voices
+             resolves each character.voiceId to a playable Voice for the
+             sample side. */
+          bookId={bookId ?? undefined}
+          voices={voices}
           onClose={() => dispatch(uiActions.setShowDriftReport(false))}
           onRegenerateChapter={(charId, chapterId) => {
             dispatch(uiActions.setShowDriftReport(false));

--- a/src/modals/drift-report.test.tsx
+++ b/src/modals/drift-report.test.tsx
@@ -26,12 +26,14 @@ vi.mock('../lib/use-sample-playback', () => ({
   }),
 }));
 
-const getVoiceSampleSpy = vi.fn(async () => ({
-  url: '/audio/voices/voice-eliza-kokoro-v1-cafe.mp3',
-  durationSec: 12,
-  cached: true,
-  modelKey: 'kokoro-v1' as const,
-}));
+const getVoiceSampleSpy = vi.fn((_args: unknown) =>
+  Promise.resolve({
+    url: '/audio/voices/voice-eliza-kokoro-v1-cafe.mp3',
+    durationSec: 12,
+    cached: true,
+    modelKey: 'kokoro-v1' as const,
+  }),
+);
 
 vi.mock('../lib/api', () => ({
   api: {
@@ -187,23 +189,28 @@ describe('DriftReportModal — auto-queueable severe drift (C1+C2)', () => {
    resolved via api.getVoiceSample). Mutex via component state — only one
    plays at a time. */
 describe('DriftReportModal — Listen A/B compare player (bug 8)', () => {
+  /* Single prototype-level spy serves both A + B elements. The Bs are
+     aliases purely for test-name readability — there's only one method
+     on HTMLMediaElement.prototype to spy on. */
+  let playSpy: ReturnType<typeof vi.spyOn>;
+  let pauseSpy: ReturnType<typeof vi.spyOn>;
   let playASpy: ReturnType<typeof vi.spyOn>;
   let pauseASpy: ReturnType<typeof vi.spyOn>;
   let playBSpy: ReturnType<typeof vi.spyOn>;
-  let pauseBSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     /* Stub HTMLMediaElement.play / pause so audio elements don't actually
        fire decode + autoplay errors in jsdom. Vitest's jsdom doesn't ship
        a real media pipeline. Each test gets a fresh spy. */
-    playASpy = vi
+    playSpy = vi
       .spyOn(window.HTMLMediaElement.prototype, 'play')
       .mockImplementation(() => Promise.resolve());
-    pauseASpy = vi
+    pauseSpy = vi
       .spyOn(window.HTMLMediaElement.prototype, 'pause')
       .mockImplementation(() => {});
-    playBSpy = playASpy;
-    pauseBSpy = pauseASpy;
+    playASpy = playSpy;
+    pauseASpy = pauseSpy;
+    playBSpy = playSpy;
     getVoiceSampleSpy.mockClear();
   });
 

--- a/src/modals/drift-report.test.tsx
+++ b/src/modals/drift-report.test.tsx
@@ -8,19 +8,53 @@
    the modal falls back to the manual flow for every event (regression
    guard for surfaces that haven't opted into the shortcut). */
 
-import { describe, expect, it, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
 import { DriftReportModal } from './drift-report';
-import type { DriftEvent, Character } from '../lib/types';
+import { uiSlice } from '../store/ui-slice';
+import type { DriftEvent, Character, Voice } from '../lib/types';
+
+vi.mock('../lib/use-sample-playback', () => ({
+  useSamplePlayback: () => ({
+    isPlaying: false,
+    currentUrl: null,
+    play: vi.fn(),
+    stop: vi.fn(),
+    pause: vi.fn(),
+  }),
+}));
+
+const getVoiceSampleSpy = vi.fn(async () => ({
+  url: '/audio/voices/voice-eliza-kokoro-v1-cafe.mp3',
+  durationSec: 12,
+  cached: true,
+  modelKey: 'kokoro-v1' as const,
+}));
+
+vi.mock('../lib/api', () => ({
+  api: {
+    getVoiceSample: (args: unknown) => getVoiceSampleSpy(args),
+  },
+}));
 
 const characters: Character[] = [
   /* color must be a CHAR_COLORS key (narrator or slot-N) — see colors.ts.
      Drift-report does `CHAR_COLORS[char.color].hex`, so a fixture using
      unmapped names like 'magenta' would crash before the test assertions
-     ran. */
-  { id: 'eliza', name: 'Eliza', role: 'Lead', color: 'slot-4' } as Character,
+     ran. voiceId added 2026-05-19 for the Listen A/B widget — the widget
+     only mounts when a matching Voice is plumbed in via the `voices`
+     prop, so character.voiceId has to resolve to an entry there. */
+  { id: 'eliza', name: 'Eliza', role: 'Lead', color: 'slot-4', voiceId: 'voice-eliza' } as Character,
   { id: 'sten', name: 'Sten', role: 'Friend', color: 'slot-5' } as Character,
 ];
+
+const elizaVoice: Voice = {
+  id: 'voice-eliza',
+  character: 'Eliza',
+  attributes: [],
+} as unknown as Voice;
 
 function makeEvent(over: Partial<DriftEvent>): DriftEvent {
   return {
@@ -143,5 +177,107 @@ describe('DriftReportModal — auto-queueable severe drift (C1+C2)', () => {
     );
     expect(screen.getByTestId('drift-auto-regen-drift:1:eliza:voice')).toBeInTheDocument();
     expect(screen.getByTestId('drift-regen-drift:1:sten:pace')).toBeInTheDocument();
+  });
+});
+
+/* Bug 8 — Listen button A/B player. Pre-fix the button at drift-report.tsx:165
+   was a pure stub: no onClick, no callback, no caller wiring. Now it expands
+   inline into two-button A/B controls: A plays the chapter audio that drifted
+   (static URL), B plays a sample of the established voice profile (lazy
+   resolved via api.getVoiceSample). Mutex via component state — only one
+   plays at a time. */
+describe('DriftReportModal — Listen A/B compare player (bug 8)', () => {
+  let playASpy: ReturnType<typeof vi.spyOn>;
+  let pauseASpy: ReturnType<typeof vi.spyOn>;
+  let playBSpy: ReturnType<typeof vi.spyOn>;
+  let pauseBSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    /* Stub HTMLMediaElement.play / pause so audio elements don't actually
+       fire decode + autoplay errors in jsdom. Vitest's jsdom doesn't ship
+       a real media pipeline. Each test gets a fresh spy. */
+    playASpy = vi
+      .spyOn(window.HTMLMediaElement.prototype, 'play')
+      .mockImplementation(() => Promise.resolve());
+    pauseASpy = vi
+      .spyOn(window.HTMLMediaElement.prototype, 'pause')
+      .mockImplementation(() => {});
+    playBSpy = playASpy;
+    pauseBSpy = pauseASpy;
+    getVoiceSampleSpy.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  function renderModalWithVoices(events: DriftEvent[]) {
+    const store = configureStore({ reducer: { ui: uiSlice.reducer } });
+    return render(
+      <Provider store={store}>
+        <DriftReportModal
+          events={events}
+          characters={characters}
+          bookId="b-keeper"
+          voices={[elizaVoice]}
+          onClose={vi.fn()}
+          onRegenerateChapter={vi.fn()}
+          onDismiss={vi.fn()}
+        />
+      </Provider>,
+    );
+  }
+
+  it('Listen button toggles inline A/B controls visible', () => {
+    renderModalWithVoices([makeEvent({})]);
+    const listenBtn = screen.getByTestId('drift-listen-drift:1:eliza:voice');
+    /* Pre-click: A/B controls hidden. */
+    expect(screen.queryByTestId('drift-play-chapter-drift:1:eliza:voice')).toBeNull();
+    expect(screen.queryByTestId('drift-play-voice-drift:1:eliza:voice')).toBeNull();
+    fireEvent.click(listenBtn);
+    /* Post-click: both buttons present. */
+    expect(
+      screen.getByTestId('drift-play-chapter-drift:1:eliza:voice'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('drift-play-voice-drift:1:eliza:voice')).toBeInTheDocument();
+  });
+
+  it('Play chapter calls .play() on the chapter audio element', () => {
+    renderModalWithVoices([makeEvent({})]);
+    fireEvent.click(screen.getByTestId('drift-listen-drift:1:eliza:voice'));
+    fireEvent.click(screen.getByTestId('drift-play-chapter-drift:1:eliza:voice'));
+    expect(playASpy).toHaveBeenCalled();
+  });
+
+  it('Play voice fetches the sample URL on first click and plays it', async () => {
+    renderModalWithVoices([makeEvent({})]);
+    fireEvent.click(screen.getByTestId('drift-listen-drift:1:eliza:voice'));
+    fireEvent.click(screen.getByTestId('drift-play-voice-drift:1:eliza:voice'));
+    await waitFor(() => expect(getVoiceSampleSpy).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(playBSpy).toHaveBeenCalled());
+  });
+
+  it('starting B while A is playing pauses A first (mutex)', async () => {
+    renderModalWithVoices([makeEvent({})]);
+    fireEvent.click(screen.getByTestId('drift-listen-drift:1:eliza:voice'));
+    fireEvent.click(screen.getByTestId('drift-play-chapter-drift:1:eliza:voice'));
+    expect(playASpy).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByTestId('drift-play-voice-drift:1:eliza:voice'));
+    await waitFor(() => expect(playBSpy).toHaveBeenCalled());
+    /* pauseASpy === pauseBSpy in this fixture (same prototype spy) — assert
+       a pause fired at least once before the second play. */
+    expect(pauseASpy).toHaveBeenCalled();
+  });
+
+  it('closing the modal pauses both audio elements (cleanup)', () => {
+    const { unmount } = renderModalWithVoices([makeEvent({})]);
+    fireEvent.click(screen.getByTestId('drift-listen-drift:1:eliza:voice'));
+    fireEvent.click(screen.getByTestId('drift-play-chapter-drift:1:eliza:voice'));
+    expect(playASpy).toHaveBeenCalled();
+    /* Unmount mimics modal-close — useEffect cleanup must pause the audio. */
+    pauseASpy.mockClear();
+    unmount();
+    expect(pauseASpy).toHaveBeenCalled();
   });
 });

--- a/src/modals/drift-report.tsx
+++ b/src/modals/drift-report.tsx
@@ -1,9 +1,12 @@
+import { useEffect, useRef, useState } from 'react';
 import { IconAlertTri, IconClose, IconRefresh, IconWaveform } from '../lib/icons';
 import { Avatar, Pill } from '../components/primitives';
 import { CHAR_COLORS } from '../lib/colors';
 import { stripChapterPrefix } from '../lib/format-chapter-title';
 import { initialChapters } from '../data/chapters';
-import type { DriftEvent, Character, CharColor } from '../lib/types';
+import { api } from '../lib/api';
+import { useAppSelector } from '../store';
+import type { DriftEvent, Character, CharColor, Voice } from '../lib/types';
 
 interface Props {
   events: DriftEvent[];
@@ -18,6 +21,12 @@ interface Props {
       Plan 20 C1+C2. */
   onAutoQueueRegenerate?: (characterId: string, chapterId: number) => void;
   onDismiss: (eventId: string) => void;
+  /** Plan-8 — Listen A/B player. Optional so legacy / mock callers that
+      haven't opted in still render the modal without the per-row inline
+      player. When omitted the Listen button stays hidden (callers without
+      audio context can't usefully expose it). */
+  bookId?: string;
+  voices?: Voice[];
 }
 
 const severityOrder: Array<DriftEvent['severity']> = ['severe', 'moderate', 'mild'];
@@ -39,6 +48,8 @@ export function DriftReportModal({
   onRegenerateChapter,
   onAutoQueueRegenerate,
   onDismiss,
+  bookId,
+  voices,
 }: Props) {
   if (events.length === 0) return null;
 
@@ -161,9 +172,24 @@ export function DriftReportModal({
                                     <IconRefresh className="w-3.5 h-3.5" /> Regenerate this chapter
                                   </button>
                                 )}
-                                <button className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-canvas border border-ink/10 text-ink/70 hover:text-ink text-xs font-medium">
-                                  <IconWaveform className="w-3.5 h-3.5" /> Listen
-                                </button>
+                                {(() => {
+                                  const rowVoice = voices?.find((v) => v.id === char?.voiceId);
+                                  /* Mount the A/B widget only when the caller plumbed
+                                     both bookId and a resolvable voice. Pre-fix the
+                                     Listen button was a stub regardless — callers
+                                     that haven't opted in (legacy / unit-test mocks)
+                                     get the original "no Listen" surface. */
+                                  if (!bookId || !rowVoice) return null;
+                                  return (
+                                    <DriftListenWidget
+                                      event={e}
+                                      bookId={bookId}
+                                      voice={rowVoice}
+                                      character={char}
+                                    />
+                                  );
+                                })()}
+                                {/* Dismiss handled below as the modal-action sibling. */}
                                 <button
                                   onClick={() => onDismiss(e.id)}
                                   className="ml-auto text-xs font-medium text-ink/50 hover:text-ink/80"
@@ -189,5 +215,166 @@ export function DriftReportModal({
         </div>
       </div>
     </>
+  );
+}
+
+/* Inline A/B compare player rendered per drift row when the user clicks
+   Listen. A = the chapter audio as currently rendered (what the drift
+   detector flagged); B = a sample synthesised against the established
+   voice profile. Lets the user decide between Regenerate / Dismiss by
+   ear, not just the attribute-diff summary.
+
+   Two refs + a single playing-state lets us implement mutex without
+   importing the revision-diff useAbPlayback hook — A's URL is static
+   (just the chapter audio path) but B's URL needs an async resolve via
+   api.getVoiceSample, which is awkward to feed into a useEffect-driven
+   src sync. Cleanup useEffect pauses both elements on unmount so the
+   browser releases the decode buffers when the modal closes. */
+function DriftListenWidget({
+  event,
+  bookId,
+  voice,
+  character,
+}: {
+  event: DriftEvent;
+  bookId: string;
+  voice: Voice;
+  character?: Character;
+}) {
+  const ttsModelKey = useAppSelector((s) => s.ui.ttsModelKey);
+  const [open, setOpen] = useState(false);
+  const [playing, setPlaying] = useState<'A' | 'B' | null>(null);
+  const [voiceSampleUrl, setVoiceSampleUrl] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const chapterRef = useRef<HTMLAudioElement | null>(null);
+  const voiceRef = useRef<HTMLAudioElement | null>(null);
+
+  /* Cleanup on unmount — modal close, parent re-render that drops the
+     row, etc. Pause both elements and detach src so the browser doesn't
+     hold decode buffers for a now-invisible widget. The audio elements
+     are rendered at all times (hidden when !open) so their refs survive
+     until React tears down the widget itself; if they were nested inside
+     the `open && <audio />` branch, React 18 detaches them BEFORE
+     running this cleanup and the refs would be null here. */
+  useEffect(() => {
+    const a = chapterRef.current;
+    const b = voiceRef.current;
+    return () => {
+      if (a) {
+        a.pause();
+        a.removeAttribute('src');
+      }
+      if (b) {
+        b.pause();
+        b.removeAttribute('src');
+      }
+    };
+  }, []);
+
+  const chapterUrl = `/api/books/${encodeURIComponent(bookId)}/chapters/${event.chapterId}/audio`;
+
+  function pauseAll() {
+    chapterRef.current?.pause();
+    voiceRef.current?.pause();
+    setPlaying(null);
+  }
+
+  async function playChapter() {
+    voiceRef.current?.pause();
+    const el = chapterRef.current;
+    if (!el) return;
+    /* Set src lazily on first play so a row whose Listen button is never
+       clicked doesn't trigger a chapter audio fetch. */
+    if (el.src !== window.location.origin + chapterUrl && !el.src.endsWith(chapterUrl)) {
+      el.src = chapterUrl;
+    }
+    try {
+      await el.play();
+      setPlaying('A');
+    } catch {
+      setPlaying(null);
+    }
+  }
+
+  async function playVoice() {
+    chapterRef.current?.pause();
+    let url = voiceSampleUrl;
+    if (!url) {
+      setBusy(true);
+      try {
+        const sample = await api.getVoiceSample({
+          voiceId: voice.id,
+          voice,
+          modelKey: ttsModelKey,
+          characterHint: character
+            ? {
+                description: character.description,
+                gender: character.gender as 'male' | 'female' | 'neutral' | undefined,
+                ageRange: character.ageRange as
+                  | 'child'
+                  | 'teen'
+                  | 'adult'
+                  | 'elderly'
+                  | undefined,
+              }
+            : undefined,
+        });
+        url = sample.url;
+        setVoiceSampleUrl(url);
+      } catch {
+        setBusy(false);
+        return;
+      }
+      setBusy(false);
+    }
+    const el = voiceRef.current;
+    if (!el || !url) return;
+    if (el.src !== url && !el.src.endsWith(url)) {
+      el.src = url;
+    }
+    try {
+      await el.play();
+      setPlaying('B');
+    } catch {
+      setPlaying(null);
+    }
+  }
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      {!open ? (
+        <button
+          data-testid={`drift-listen-${event.id}`}
+          onClick={() => setOpen(true)}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-canvas border border-ink/10 text-ink/70 hover:text-ink text-xs font-medium"
+        >
+          <IconWaveform className="w-3.5 h-3.5" /> Listen
+        </button>
+      ) : (
+        <>
+          <button
+            data-testid={`drift-play-chapter-${event.id}`}
+            onClick={() => (playing === 'A' ? pauseAll() : void playChapter())}
+            className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-xs font-medium ${playing === 'A' ? 'bg-ink text-canvas border-ink' : 'bg-canvas border-ink/10 text-ink/70 hover:text-ink'}`}
+          >
+            <IconWaveform className="w-3.5 h-3.5" />
+            {playing === 'A' ? 'Pause chapter' : 'Chapter'}
+          </button>
+          <button
+            data-testid={`drift-play-voice-${event.id}`}
+            onClick={() => (playing === 'B' ? pauseAll() : void playVoice())}
+            disabled={busy}
+            className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-xs font-medium disabled:opacity-50 disabled:cursor-wait ${playing === 'B' ? 'bg-ink text-canvas border-ink' : 'bg-canvas border-ink/10 text-ink/70 hover:text-ink'}`}
+          >
+            <IconWaveform className="w-3.5 h-3.5" />
+            {busy ? 'Loading…' : playing === 'B' ? 'Pause voice' : 'Voice profile'}
+          </button>
+        </>
+      )}
+      {/* Audio elements always mounted so their refs survive until the
+          widget itself unmounts (cleanup useEffect above relies on this). */}
+      <audio ref={chapterRef} onEnded={() => setPlaying((p) => (p === 'A' ? null : p))} />
+      <audio ref={voiceRef} onEnded={() => setPlaying((p) => (p === 'B' ? null : p))} />
+    </span>
   );
 }


### PR DESCRIPTION
## Summary

Finishes the half-shipped Listen button on each Voice-Drift-Detector row. Pre-fix the button at `src/modals/drift-report.tsx:165` was a stub — no `onClick`, no `onListen` prop, no caller wiring. Sibling actions (Regenerate this chapter, Auto-regen now, Dismiss) were fully wired; only Listen did nothing.

User-visible delta:

- **Clicking Listen reveals two playback buttons in place of the original.** Button A plays the chapter audio AS CURRENTLY RENDERED — the take the drift detector flagged. Button B plays a fresh sample synthesised against the established voice profile via `api.getVoiceSample` (lazy-resolved on first click, cached in component state thereafter so a second Play B doesn't re-hit the sample API). Lets the user hear the drift in context vs the profile reference and decide between Regenerate / Dismiss by ear rather than just by attribute-diff summary.
- **Mutex via a single `playing: 'A' | 'B' | null` state.** Starting one pauses the other. Either button shows "Pause chapter" / "Pause voice" while active so the second click on the same button stops playback.
- **Audio elements are always mounted** (hidden behind the open-state's button toggle) so the cleanup `useEffect` can pause them on modal unmount. Nesting the `<audio>` tags inside the `open && ...` branch caused React 18 to detach them BEFORE the cleanup ran, leaking decode buffers on close. Documented inline at the cleanup site.

Why not the existing `useAbPlayback` hook (which the bundle plan originally suggested):
- That hook assumes both URLs are static and pre-resolvable. B's URL needs an async resolve via `api.getVoiceSample` — feeding the resolved URL into the hook's `useEffect` src-sync is awkward and harder to test than just owning two refs inline.
- The purpose-built widget is ~80 lines including the resolve-and-play handler; the hook adapter would be similar with more indirection.

The widget surfaces only when the caller passes both `bookId` and a `voices` array. Without either it stays hidden — better than rendering a non-functional button. `src/components/layout.tsx` passes both alongside the existing `events` / `characters` / handler props. Legacy / mock callers that haven't opted in keep the original stub-less behaviour.

Contract changes:

- `DriftReportModal` props gain two optional fields: `bookId?: string`, `voices?: Voice[]`. Both required for the widget to mount; either missing → widget returns `null`.
- New per-row test-id pattern: `drift-listen-<eventId>` (collapsed state), `drift-play-chapter-<eventId>` + `drift-play-voice-<eventId>` (expanded). Mirrors the existing `drift-regen-<eventId>` / `drift-auto-regen-<eventId>` naming.

New tests (`src/modals/drift-report.test.tsx`):

- Listen toggles the A/B controls visible (collapsed → expanded).
- Play A calls `HTMLMediaElement.prototype.play` on the chapter audio element.
- Play B fetches the sample URL via `api.getVoiceSample` (asserted via spy), then calls `.play()` on the voice audio element.
- Starting B while A is playing fires the mutex pause before the new play.
- Modal unmount fires the cleanup pause on both audio elements (regression guard for the React-18 detach-before-cleanup ordering documented inline).

Test totals: 1046 frontend tests passing. Lint + typecheck + e2e + build all green via the cache-aware `npm run verify` pre-push gate.

## Test plan

- [x] `npm run verify:fast` after every commit — green
- [x] `npm run verify` (full pre-push battery) — green; e2e re-ran cleanly this time after Branch A merged
- [x] Test-first: 5 red tests landed before the widget code, then turned green
- [ ] Reviewer: open the drift report modal in mock mode (`npm run dev`, cast view, click the amber drift banner). On any row, click Listen — confirm the two play buttons appear in place of the single Listen affordance. Click Chapter → plays. Click Voice profile → fetches sample, then plays. Closing the modal mid-playback should stop both immediately.
- [ ] Reviewer: confirm the row's existing actions (Regenerate this chapter, Auto-regen now, Dismiss) still work alongside the new widget.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)