### PR TITLE
docs(docs): plan 43 ship + archive — auto-start TTS sidecar

### DIFF
--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -69,7 +69,6 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 - [13 — TTS engine picker](13-tts-engine-picker.md) — Two-tier engine + model selector.
 - [14a — Kokoro v1 TTS engine](14a-tts-sidecar-kokoro.md) — Local sidecar default, English-only, per-engine cast voice profiles.
 - [15 — Gemini cloud TTS](15-tts-gemini-cloud.md) — Cloud opt-in.
-- [43 — Auto-start TTS sidecar](43-auto-start-sidecar.md) — Per-user `autoStartSidecar` preference (default ON); Node owns the sidecar child-process lifecycle so `start-app.bat` brings up TTS in one shot. **Status: active.**
 
 ### G. Generation
 
@@ -157,3 +156,4 @@ breadcrumb so cross-references still resolve.
 - [57 — Listen-view download tiles](archive/57-download-tiles.md) — Wires the M4B chaptered + new MP3 ZIP tiles on the listen view to open `ExportAudiobookModal` with the format pre-filled; streaming-link tile remains "Coming soon" pending a slugged URL endpoint. Shipped 2026-05-19.
 - [58 — E2E coverage refresh](archive/58-e2e-coverage-refresh.md) — Un-quarantines `listen-playback` + `new-book-flow`; adds `binary-upload.spec.ts` covering EPUB / PDF / MOBI / AZW3 routing; applies file-level serial mode to five contention-flaky spec files. From 3-5 hard failures per `verify` run to 0. Shipped 2026-05-19.
 - [59 — Parallel Claude Code sessions](archive/59-parallel-claude-sessions.md) — `scripts/wt-new.mjs` spawns a git worktree on a new branch with non-colliding dev-server ports so multiple top-level `claude` sessions can run in parallel without fighting over `:5173` / `:8080` / `:9000` / `:5174`. Slot N → ports offset by `N*10`. `scripts/wt-list.mjs` lists active worktrees + their assignments. `vite.config.ts` + `playwright.config.ts` now env-driven; stock defaults preserved for the main worktree. Shipped 2026-05-19.
+- [43 — Auto-start TTS sidecar](archive/43-auto-start-sidecar.md) — Per-user `autoStartSidecar` preference (default ON); Node owns the sidecar child-process lifecycle (port-9000 probe → spawn → `.run/tts.pid` → `win32` `taskkill /T /F` tree-kill on SIGINT/SIGTERM). `start-app.bat` brings up frontend + server + sidecar in one shot. `PRELOAD_COQUI` env propagation gated on `defaultTtsModelKey === 'coqui-xtts-v2'` (Kokoro's eager-load is unconditional inside the sidecar). 6-case Vitest covers the spawn/probe/tree-kill contract. Shipped 2026-05-17.

--- a/docs/features/archive/43-auto-start-sidecar.md
+++ b/docs/features/archive/43-auto-start-sidecar.md
@@ -1,12 +1,12 @@
 ---
-status: active
-shipped: null
+status: stable
+shipped: 2026-05-17
 owner: dudarenok-maker
 ---
 
 # Auto-start TTS sidecar (user preference)
 
-> Status: active
+> Status: stable
 > Key files: `server/src/workspace/user-settings.ts`, `server/src/tts/spawn-sidecar.ts`, `server/src/index.ts`, `scripts/start-app.ps1`, `src/views/account.tsx`
 > URL surface: `#/account` (toggle)
 > OpenAPI ops: `GET /api/user/settings`, `PUT /api/user/settings`
@@ -172,6 +172,22 @@ listening on :9000, skipping spawn`. The manual sidecar keeps
 
 ## Ship notes
 
-(Filled in when status flips to `stable`. Append: shipped date, commit SHA,
-any behaviour delta vs. the original spec. Move to
-`docs/features/archive/` in the same PR as the ship.)
+Shipped 2026-05-17 in `bf1444c` (`feat(server,frontend,docs): plan 43 — auto-start TTS sidecar via user preference`).
+
+**Files at ship:** all six cited Key files landed under that single commit:
+
+- `server/src/workspace/user-settings.ts` — `autoStartSidecar?: boolean` field (optional, defaults `true`), `getResolvedAutoStartSidecar()` resolver with `DISABLE_AUTOSTART_SIDECAR=1` env override.
+- `server/src/tts/spawn-sidecar.ts` — child-process spawn module with port-9000 probe, PID file write to `.run/tts.pid`, and `win32` `taskkill /T /F /PID` tree-kill handle. Injectable `spawnFn` / `probeFn` for testability.
+- `server/src/tts/spawn-sidecar.test.ts` — 6 Vitest cases pinning the spawn / probe / `PRELOAD_COQUI` / tree-kill contract.
+- `server/src/index.ts` — wires `spawnSidecar()` at `app.listen()` and tears it down on `SIGINT` / `SIGTERM`.
+- `scripts/start-app.ps1` — `$services` array no longer includes `tts`; Node owns the spawn now.
+- `src/views/account.tsx` — Account view toggle for `autoStartSidecar`, restart-required pill on dirty state.
+
+**Touch-ups after ship (no behaviour delta):**
+
+- `5e16f0c` (2026-05-18, plan 49): `server/src/workspace/user-settings.ts` extended with `geminiApiKey` field (plan 49 scope, not plan 43) — no functional impact on the auto-start spawn lifecycle.
+- `0b08e37` (2026-05-18): `eslint --fix` + `prettier --write` baseline pass — formatting only.
+
+**No behaviour deltas vs the original spec.** The plan body's eight invariants and the Vitest + frontend test suite all match what landed. The `Out of scope` items (engine-switch hot-swap, venv auto-install, Ollama auto-pull) remain out of scope.
+
+The frontmatter `status: active` flag stayed unflipped between ship (2026-05-17) and this close-out (2026-05-19) — pure bookkeeping lag, not a functional gap.


### PR DESCRIPTION
## Summary

Closes out plan 43 (`docs/features/43-auto-start-sidecar.md`) — flips `status: active` → `status: stable`, sets `shipped: 2026-05-17` (the actual ship date; implementation landed in bf1444c on 2026-05-17 but the frontmatter was never flipped), fills Ship notes with the six cited key files at ship + the two no-behaviour-delta touch-ups since, and moves the file to `docs/features/archive/43-auto-start-sidecar.md`. `docs/features/INDEX.md` updated: plan 43 removed from F. TTS section, breadcrumb entry added under Shipped (archive).

Wave 1.C2 of the v1.4.0 alpha-launch pre-cutover slate. No code changes — implementation landed two days ago in `bf1444c`. This is a pure docs flip + archive move.

**Ship notes capture:**

- `bf1444c` (2026-05-17) — single commit shipping all six cited Key files (`server/src/workspace/user-settings.ts`, `server/src/tts/spawn-sidecar.ts`, `server/src/tts/spawn-sidecar.test.ts`, `server/src/index.ts`, `scripts/start-app.ps1`, `src/views/account.tsx`).
- `5e16f0c` (2026-05-18) — `user-settings.ts` extended with `geminiApiKey` field (plan 49 scope, not plan 43). No functional impact on the auto-start spawn lifecycle.
- `0b08e37` (2026-05-18) — eslint baseline pass. Formatting only.

**No behaviour deltas vs the original spec.** The eight invariants and the Vitest + frontend test suite all match what landed. The `Out of scope` items (engine-switch hot-swap, venv auto-install, Ollama auto-pull) remain out of scope.

**Active-status sweep:** with this and PR #47 merged, no plan under `docs/features/` retains `status: active`. The alpha-launch readiness sweep is clean.

Branch naming caveat: branched as `feat/server-plan-43-finalise` ahead of inspecting the actual implementation state. Once I found bf1444c had already shipped everything, the work scope collapsed to docs-only — would have used `docs/docs-` if I'd checked first. The commit subject is correctly `docs(docs):` so the commit-msg + PR-title gates both pass.

## Test plan

- [x] `npm run verify` — green (cached via plan 50, docs-only diff)
- [ ] Reviewer confirms shipped date 2026-05-17 (matches bf1444c) — not 2026-05-19 (today's bookkeeping date)
- [ ] Reviewer confirms the "No behaviour deltas vs the original spec" claim against bf1444c's diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)