### PR TITLE
feat(frontend): voices global-tab same-book compare (plan 60)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -27,7 +27,7 @@ the same PR — the backlog is only useful while it stays current.
 
 Ranking within each bucket = top is highest priority.
 
-**Counts as of 2026-05-19 (post plans 53–58 merge):** Must 0 · Should 0 · Could 32 · Won't 9
+**Counts as of 2026-05-19 (post plan 60 ship):** Must 0 · Should 0 · Could 31 · Won't 9
 
 ---
 
@@ -157,16 +157,6 @@ Source: net-new (2026-05-18).
 - _Depends on:_ none.
 - _Benefit (user):_ cross-book voice consistency without per-book re-casting. Common need when switching a recurring narrator across a series.
 
-### 16. Voice compare from the global `#/voices` tab for same-book pairs
-
-Source: [`22a-voice-library-compare.md`](features/archive/22a-voice-library-compare.md) v1 scope cut.
-
-- _What:_ When both selected voices in the global `#/voices` tab share a `bookId` (≠ `currentBookId`), fetch that book's cast on demand via `api.getBookState(bookId)` and pass the resolved characters into `CompareCastModal`. Cache the fetched cast for the modal session so re-opens are instant.
-- _Acceptance:_ The Compare button enables in the global tab for a same-`bookId` 2-voice pair; the modal opens with the correct two characters. Vitest covers the on-demand fetch path + the disabled state when the fetch fails. The e2e `voices-compare.spec.ts` gains a global-tab same-book pair assertion.
-- _Key files:_ `src/views/voices.tsx` (gating logic + on-demand fetch); `src/lib/api.ts` (`getBookState`); `e2e/voices-compare.spec.ts`.
-- _Depends on:_ none structural.
-- _Benefit (user):_ closes the gap in the Voice library global view — today the global tab's Compare is fully disabled, even for pairs that would resolve cleanly with one fetch.
-
 ### 17. Cross-book voice compare
 
 Source: [`22a-voice-library-compare.md`](features/archive/22a-voice-library-compare.md) v1 scope cut.
@@ -174,7 +164,7 @@ Source: [`22a-voice-library-compare.md`](features/archive/22a-voice-library-comp
 - _What:_ Lift the cross-book guard. When the two selected voices belong to different `bookId`s, fetch each book's cast (one of them may be the open book — short-circuit) and pass both characters into `CompareCastModal`. Decide and document: do we route saves back to each character's source book's cast slice, or refuse the save and surface a "viewing only" banner?
 - _Acceptance:_ The Compare button enables for cross-book pairs; the modal opens with both characters; the Save behaviour is documented and tested. The e2e gains a cross-book pair assertion.
 - _Key files:_ `src/views/voices.tsx`; `src/store/cast-slice.ts` (Save routing); `src/modals/compare-cast-modal.tsx` (if the viewing-only banner is needed).
-- _Depends on:_ Could #16 (the same on-demand fetch machinery).
+- _Depends on:_ plan 60 shipped (same on-demand fetch machinery is already in place; this entry lifts the cross-book guard and decides foreign-book save routing).
 - _Benefit (user):_ enables A/B for users who reuse the same TTS voice across books — e.g. comparing the same narrator across two books in a series to spot drift.
 
 ### 18. CI integration for the test suite

--- a/docs/features/60-voices-global-tab-compare.md
+++ b/docs/features/60-voices-global-tab-compare.md
@@ -1,0 +1,94 @@
+---
+status: stable
+shipped: 2026-05-19
+owner: null
+---
+
+# Voices global-tab same-book compare
+
+> Status: stable
+> Key files: `src/views/voices.tsx` (gating logic + on-demand fetch), `src/lib/api.ts` (`getBookState` consumer + `ns` mock seed), `e2e/voices-compare.spec.ts`
+> URL surface: `#/voices`
+> OpenAPI ops: `GET /api/books/{id}/state` (consumer only — no new endpoints)
+
+## Benefit / Rationale
+
+Closes the v1 scope cut from plan 22a (`docs/features/archive/22a-voice-library-compare.md`): on the global `#/voices` tab, the Compare button was disabled outright with the tooltip "Open a book to compare its voices" — even for pairs that would resolve cleanly with one fetch.
+
+- **User:** the global `#/voices` tab can now compare any two voices that share the same `bookId`, regardless of whether that book is currently open. Today's friction (open book → navigate to Voices → compare) collapses to "select two voices anywhere in the global library, click Compare". Closes BACKLOG #16.
+- **Technical:** the on-demand fetch lives in component-local state (`useState<Map<bookId, Character[]>>`) — no new redux slice, no persistent cache, no eviction policy to maintain. Plan 22a's `CompareCastModal` consumer is unchanged; only the cast resolution path was rerouted to consult the cache when the pair lives outside the open book.
+- **Architectural:** unblocks BACKLOG #17 (cross-book compare) by introducing the foreign-cast hydrate machinery the cross-book case will reuse. The save-routing decision (does saving a foreign-book character write through to its source book's slice?) is deliberately scoped out of this plan and surfaced as part of #17.
+
+## Architectural impact
+
+- **New seams:**
+  - `LibraryView` (`src/views/voices.tsx`) gains three local-state shards: `globalCastCache: Map<bookId, Character[]>` (resolved foreign casts), `globalCastFailed: Set<bookId>` (so a failed fetch disables the button retroactively without retrying on every render), and `globalCastFetching: bookId | null` (so a double-click on Compare can't fire two parallel requests).
+  - `compareDerivations` now exposes `sharedBookId` so the modal-mount path can pick the right cast source (redux for the open book; cache otherwise).
+  - `fetchAndOpenForeignCast(bookId, voicePair)` — async handler invoked by the Compare button click on the foreign-book path. Hits `api.getBookState(bookId)`, populates the cache on success, dispatches a `notificationsActions.pushToast` + records `bookId` in `globalCastFailed` on failure or empty-cast response.
+- **Cast-save routing:** when the open pair belongs to the currently-open book, `onSaveSide` continues to dispatch `castActions.updateCharacter` (unchanged plan 22a path). For foreign-book pairs, `onSaveSide` becomes a no-op — the modal still tracks the in-flight draft so the user can audition tone changes, but no redux mutation persists. Persisting foreign-book edits is part of BACKLOG #17.
+- **Mock-state surface:** `src/lib/api.ts` now seeds the Northern Star (`ns`) book in `MOCK_BOOK_STATES` with `cast: { characters: initialCharacters }` — needed so the e2e and any manual walkthrough under `VITE_USE_MOCKS=true` can resolve the global-tab fetch. The existing Solway Bay (`sb`) seed deliberately keeps `cast: null` so plan 22a's per-book disabled-button assertion still holds.
+- **Invariants preserved:**
+  - `CompareCastModal`'s props (`src/modals/compare-cast-modal.tsx:32-39`) are byte-identical — the modal is consumer-side only.
+  - Plan 22a's selection pill, same-/different-base-voice badge, "Cross-book compare not supported yet" tooltip on cross-`bookId` pairs, and "Select exactly 2 voices" gate at 0/1/3+ all stay green.
+  - Drag-to-reassign on `VoiceCard` is untouched.
+- **Reversibility:** removing the `globalCast*` state + the `fetchAndOpenForeignCast` helper + the `castSource` branch in the modal mount path restores plan 22a exactly. The `ns` mock seed is independently useful (currently unconsumed elsewhere) but trivially removable.
+
+## Cast resolution decision tree
+
+After selection (exactly 2 voices), the `sharedBookId` derivation drives gating:
+
+| Selection state                                | `sharedBookId`    | Cast source                        | Compare button             |
+| ---------------------------------------------- | ----------------- | ---------------------------------- | -------------------------- |
+| 0/1/3+ selected                                | n/a               | n/a                                | disabled — "Select exactly 2 voices" |
+| 2 voices, different `bookId`s                  | null              | n/a                                | disabled — "Cross-book compare not supported yet" (BACKLOG #17) |
+| 2 voices, shared `bookId === currentBookId`    | currentBookId     | `state.cast.characters` (redux)    | enabled iff both voices resolve to characters; disabled with "Selected voice is no longer linked to a character" otherwise |
+| 2 voices, shared foreign `bookId`              | foreign bookId    | `globalCastCache.get(bookId)`      | enabled (cache miss → click triggers fetch); after fetch fails: disabled with "Could not load that book — try again later" |
+
+## Invariants to preserve
+
+- `Voice.bookId` is non-nullable per `openapi.yaml` `Voice` schema — `selectedVoices[0].bookId !== selectedVoices[1].bookId` is a safe cross-book check.
+- `api.getBookState(bookId)` returns `BookStateResponse | null` and may resolve with `cast: null` for books the workspace hasn't analysed yet — both paths flow through the catch branch in `fetchAndOpenForeignCast` and surface the same "Could not load that book" toast.
+- `globalCastCache` lives in the component's `useState`; navigating away from `#/voices` unmounts `LibraryView` and clears it. This is by design — the cache is per modal session, not per workspace. A workspace-level cache would require redux + invalidation policy + cross-tab sync (BACKLOG-grade work).
+- `notificationsActions.pushToast` is the single error surface — no inline banner, no modal. `dedupeKey: 'voices-compare-fetch:${bookId}'` collapses repeated attempts on the same failing book.
+
+## Test plan
+
+### Automated coverage
+
+- Vitest unit (`src/views/voices.test.tsx`, `LibraryView compare-two-voices affordance (plan 22a) > global-tab same-book fetch path (plan 60)` describe block):
+  - **fetches foreign cast via api.getBookState and mounts the modal on Compare click** — asserts the happy path: `getBookState` called once with the correct bookId, dialog mounts after the fetch resolves.
+  - **pushes a toast and retroactively disables Compare when the fetch fails** — asserts the error path: no dialog mounts, Compare re-asserts disabled with the documented tooltip.
+  - **also disables Compare when the fetched book has no cast at all** — asserts the empty-cast guard (`res.cast === null` or `cast.characters === []` both route through the failure branch).
+  - **caches the foreign cast so re-opens skip the second fetch** — asserts the cache-hit path: second Compare click does NOT increment `getBookState` call count.
+  - **enables Compare on the global tab for a same-bookId pair (plan 60)** — replaces the plan-22a "disables Compare on the global tab" assertion that the global-tab gate-closed contract used to enforce.
+- Playwright e2e (`e2e/voices-compare.spec.ts`):
+  - **global #/voices tab fetches foreign cast and opens Compare modal (plan 60)** — Halloran + Eliza Gray (both `ns`) under mocks; click Compare → `getRole('dialog')` becomes visible.
+  - **global #/voices tab still disables Compare on cross-book pairs (plan 60)** — Halloran (`ns`) + Narrator (`sb`); Compare stays disabled with the documented cross-book tooltip.
+
+### Manual acceptance walkthrough
+
+Run `VITE_USE_MOCKS=true`.
+
+1. **Open `#/voices`** → global tab loads with the full library of mock voices spanning `ns`, `sb`, `cc`.
+2. **Click the select checkbox on Captain Halloran (`ns`) and Eliza Gray (`ns`)** → pill renders with "different base voices" badge (Halloran → Charon, Eliza → Kore). Compare button enabled.
+3. **Click Compare** → after ~60 ms (the mock's `wait`), `CompareCastModal` mounts with both characters as A/B sides.
+4. **Close the modal, leaving both voices selected, click Compare again** → modal re-mounts instantly. No network round-trip in the dev-tools network tab.
+5. **Select Captain Halloran (`ns`) and Narrator (`sb`)** → Compare disabled with tooltip "Cross-book compare not supported yet".
+6. **Navigate to `#/` then back to `#/voices`** → the foreign-cast cache is gone (component remounted); the next Compare click re-fetches.
+
+## Out of scope
+
+- **Cross-book compare** — BACKLOG #17. Lifts the `selectedVoices[0].bookId !== selectedVoices[1].bookId` guard. Depends on this plan's fetch machinery; defers the save-routing decision (does a foreign-book Save write through to its source book's slice?).
+- **Workspace-level cast cache** — the current cache lives in `useState`. Promoting it to a redux slice + cross-tab sync + invalidation policy is much bigger than this entry's scope and isn't blocking any in-flight work.
+- **Pre-warming the cache on hover** — would mask the latency of the first click but adds complexity for a 60-ms saving under mocks (real backend latency is similar). Reconsiderable if users report click-then-wait friction.
+- **Foreign-book Save persistence** — `onSaveSide` becomes a no-op on foreign-book pairs; the modal still tracks drafts so audition still works, but no redux mutation. Persisting is part of BACKLOG #17.
+
+## Ship notes
+
+- **Shipped:** 2026-05-19.
+- **Commit SHA:** filled in at merge.
+- **Drift corrections vs. the brief:** none — the brief's `api.getBookState(bookId)` is the exact name; the `response.cast.characters` shape matches what `BookStateResponse` exposes (`src/lib/types.ts:180`); the notifications slice is `src/store/notifications-slice.ts` with `notificationsActions.pushToast({kind:'error', message, dedupeKey})`.
+- **Tests landed:**
+  - `src/views/voices.test.tsx` — five new cases under the plan-60 describe block (happy path, fetch-fails path, empty-cast path, cache-on-second-open, global-tab-enabled-pair); one plan-22a test rewritten from "disables Compare on global tab" to "enables Compare on global tab for same-bookId pair".
+  - `e2e/voices-compare.spec.ts` — two new specs replace the old "global tab disables Compare" spec: happy-path (fetch + modal mounts) and cross-book negative case.
+  - `src/lib/api.ts` — `buildNorthernStarMockState()` + `seedDefaultMockBookStates()` add `ns` to `MOCK_BOOK_STATES` with `cast: { characters: initialCharacters }`. The existing `sb` seed deliberately keeps `cast: null` so plan 22a's per-book disabled assertion holds.

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -58,6 +58,7 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 - [09 — Voice match pipeline](09-voice-match-pipeline.md) — Post-analysis library matching.
 - [10 — Profile drawer](10-profile-drawer.md) — Character edit drawer + sample preview + evidence toggle.
 - [11 — Batch character regenerate](11-batch-character-regenerate.md) — Multi-select character → chapter-range regen.
+- [60 — Voices global-tab same-book compare](60-voices-global-tab-compare.md) — Lifts plan 22a's "Open a book to compare" gate for global-tab pairs that share a `bookId`: `api.getBookState(bookId)` resolves the foreign cast on demand, cached for the modal session. Cross-book pairs remain disabled (BACKLOG #17). Shipped 2026-05-19.
 
 ### E. Manuscript editing
 

--- a/e2e/voices-compare.spec.ts
+++ b/e2e/voices-compare.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * Voice library compare entry point — plan 22a.
+ * Voice library compare entry point — plan 22a + plan 60.
  *
  * Asserts the browser-level seam that Vitest+jsdom can lie about: the
  * per-book Voices tab renders multi-select checkboxes on `VoiceCard`s,
@@ -9,14 +9,14 @@ import { test, expect } from '@playwright/test';
  * the same-/different-base-voice badge, and the Compare button gates on
  * 2-selected within-book + cast hydration.
  *
- * Scope note: under mocks, `getBookState` throws (Must #3 on the backlog),
- * so the cast slice stays empty when navigating to `/books/sb/library`.
- * The Compare button therefore stays disabled even at exactly 2 selections
- * — the gating logic surfaces the "Selected voice is no longer linked to
- * a character" tooltip. That's the correct behaviour under the current
- * mock state; the dialog-open assertion will become reachable once Must #3
- * lands and the mock seeds the cast slice. Until then this spec covers
- * the selection + pill + badge + tooltip path.
+ * Per-book tab scope note: under mocks, `sb`'s mock state explicitly
+ * keeps `cast: null` so the per-book Compare button stays disabled with
+ * the "Selected voice is no longer linked to a character" tooltip.
+ *
+ * Global tab (plan 60): when both selected voices share a non-null
+ * `bookId`, the view fetches that book's cast via `api.getBookState`
+ * on demand and mounts `CompareCastModal` with the resolved
+ * characters. Cross-book pairs remain disabled (BACKLOG #17).
  */
 
 test.describe('voice library compare entry point', () => {
@@ -68,7 +68,9 @@ test.describe('voice library compare entry point', () => {
     await expect(page.getByText(/^Selected$/)).toHaveCount(0);
   });
 
-  test('global #/voices tab disables Compare with the documented tooltip', async ({ page }) => {
+  test('global #/voices tab fetches foreign cast and opens Compare modal (plan 60)', async ({
+    page,
+  }) => {
     await page.goto('/');
     /* Two buttons match: the top-bar CTA and the empty-state dropzone card. .first() picks the deterministic one. */
     await expect(page.getByRole('button', { name: /Start a new book/i }).first()).toBeVisible({
@@ -85,10 +87,45 @@ test.describe('voice library compare entry point', () => {
     const elizaCard = page.locator('div.group', { hasText: 'Eliza Gray' }).first();
     await elizaCard.getByLabel('Select voice for compare').click();
 
-    /* Pill renders, Compare disabled with the "Open a book" tooltip. */
+    /* Pill renders with the amber "different base voices" badge (Halloran
+       resolves to Charon, Eliza to Kore) — both still belong to bookId
+       'ns', so the Compare button is enabled (plan 60 same-book global
+       compare). */
+    await expect(page.getByText('Selected', { exact: true })).toBeVisible();
+    await expect(page.getByText('different base voices')).toBeVisible();
+    const compareBtn = page.getByRole('button', { name: 'Compare', exact: true });
+    await expect(compareBtn).toBeEnabled();
+
+    /* Click Compare → on-demand `api.getBookState('ns')` resolves the
+       Northern Star cast → `CompareCastModal` mounts with both
+       characters as A/B sides. */
+    await compareBtn.click();
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('global #/voices tab still disables Compare on cross-book pairs (plan 60)', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await expect(page.getByRole('button', { name: /Start a new book/i }).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.goto('/#/voices');
+    await expect(page.getByText('Captain Halloran').first()).toBeVisible({ timeout: 10_000 });
+    /* Narrator lives in book `sb`; Halloran lives in book `ns`. The
+       cross-book guard fires for this pair — BACKLOG #17 owns lifting
+       it. */
+    await expect(page.getByText('Narrator').first()).toBeVisible();
+
+    const hallCard = page.locator('div.group', { hasText: 'Captain Halloran' }).first();
+    await hallCard.getByLabel('Select voice for compare').click();
+    const narratorCard = page.locator('div.group', { hasText: 'Narrator' }).first();
+    await narratorCard.getByLabel('Select voice for compare').click();
+
     await expect(page.getByText('Selected', { exact: true })).toBeVisible();
     const compareBtn = page.getByRole('button', { name: 'Compare', exact: true });
     await expect(compareBtn).toBeDisabled();
-    await expect(compareBtn).toHaveAttribute('title', 'Open a book to compare its voices');
+    await expect(compareBtn).toHaveAttribute('title', 'Cross-book compare not supported yet');
   });
 });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -38,6 +38,7 @@ import type {
   TtsEngine,
 } from './types';
 import { FRONTEND_ACCOUNT_DEFAULTS } from './account-defaults';
+import { initialCharacters } from '../data/characters';
 import { ANALYSIS_NORTHERN_STAR } from '../mocks/canned-data';
 import { MOCK_LIBRARY } from '../mocks/library';
 import { MOCK_BASE_VOICES, MOCK_VOICE_LIBRARY } from '../mocks/voices';
@@ -465,10 +466,51 @@ function buildSolwayBayMockState(): BookStateResponse {
   };
 }
 
+/* Northern Star — primary mock book referenced by mostly every test
+   fixture (`ANALYSIS_NORTHERN_STAR`, profile-drawer specs, voice-mapping
+   specs). Plan 60 (voice library global-tab compare) needs a non-null
+   `cast` field so `api.getBookState('ns')` resolves the initial cast
+   when the user kicks off Compare from the global `#/voices` tab. The
+   rest of the response is minimal — only the fields the global-compare
+   flow reads (cast) and a barebones `state` so type-narrowing doesn't
+   surprise downstream callers if they bump into it. */
+function buildNorthernStarMockState(): BookStateResponse {
+  const now = new Date().toISOString();
+  return {
+    state: {
+      bookId: 'ns',
+      manuscriptId: 'mns_ns',
+      title: 'The Northern Star',
+      author: 'Mike Dudarenok',
+      series: 'Northern Coast Trilogy',
+      seriesPosition: 2,
+      isStandalone: false,
+      manuscriptFile: 'manuscript.epub',
+      castConfirmed: true,
+      chapters: [],
+      coverGradient: ['#3C194F', '#0F0E0D'],
+      createdAt: now,
+      updatedAt: now,
+      narratorCredit: null,
+      genre: null,
+      publicationDate: null,
+    },
+    cast: { characters: initialCharacters },
+    manuscript: { wordCount: 78_300, format: 'epub' },
+    manuscriptEdits: null,
+    revisions: null,
+    completedSlugs: [],
+    chapterCharacters: undefined,
+    changeLog: null,
+    analysis: undefined,
+  };
+}
+
 /* Seed the default fixtures. Called at module init AND from
    _resetMockBookStates so per-test resets restore the default surface. */
 function seedDefaultMockBookStates(): void {
   MOCK_BOOK_STATES.set('sb', buildSolwayBayMockState());
+  MOCK_BOOK_STATES.set('ns', buildNorthernStarMockState());
 }
 seedDefaultMockBookStates();
 

--- a/src/views/voices.test.tsx
+++ b/src/views/voices.test.tsx
@@ -1,27 +1,32 @@
 // Pairs with docs/features/22-voice-library.md
 
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { act, render, screen, fireEvent, within } from '@testing-library/react';
 import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
 import { castSlice } from '../store/cast-slice';
 import { manuscriptSlice } from '../store/manuscript-slice';
+import { notificationsSlice } from '../store/notifications-slice';
 import { uiSlice } from '../store/ui-slice';
 import { voicesSlice } from '../store/voices-slice';
 import { LibraryView } from './voices';
-import type { BaseVoice, Character, Sentence, Voice } from '../lib/types';
+import type { BaseVoice, BookStateResponse, Character, Sentence, Voice } from '../lib/types';
 
 const setVoicePin = vi.fn((_voiceId: string, _pinned: boolean) => Promise.resolve());
 const getBaseVoices = vi.fn<() => Promise<{ voices: BaseVoice[] }>>(() =>
   Promise.resolve({ voices: [] }),
 );
 const setVoiceOverride = vi.fn();
+const getBookState = vi.fn<(bookId: string) => Promise<BookStateResponse | null>>(() =>
+  Promise.resolve(null),
+);
 
 vi.mock('../lib/api', () => ({
   api: {
     setVoicePin: (voiceId: string, pinned: boolean) => setVoicePin(voiceId, pinned),
     getBaseVoices: () => getBaseVoices(),
     setVoiceOverride: (...args: unknown[]) => setVoiceOverride(...args),
+    getBookState: (bookId: string) => getBookState(bookId),
   },
 }));
 
@@ -83,6 +88,7 @@ function makeStore() {
       cast: castSlice.reducer,
       manuscript: manuscriptSlice.reducer,
       voices: voicesSlice.reducer,
+      notifications: notificationsSlice.reducer,
     },
   });
   store.dispatch(castSlice.actions.setCharacters(characters));
@@ -109,6 +115,8 @@ beforeEach(() => {
   getBaseVoices.mockClear();
   getBaseVoices.mockResolvedValue({ voices: [] });
   setVoiceOverride.mockClear();
+  getBookState.mockReset();
+  getBookState.mockResolvedValue(null);
 });
 
 describe('LibraryView voice-family grouping', () => {
@@ -363,17 +371,26 @@ describe('LibraryView compare-two-voices affordance (plan 22a)', () => {
     expect(compareBtn.getAttribute('title')).toBe('Select exactly 2 voices');
   });
 
-  it('disables Compare on the global tab (no open book) with the documented tooltip (plan 22a)', () => {
+  it('enables Compare on the global tab for a same-bookId pair (plan 60)', () => {
     /* `stageBookId=null` puts ui.stage on `{kind:'voices'}` — the global
-       tab. Even with a valid 2-voice pair the gate stays closed because
-       the cast slice of the foreign book is not hydrated here. */
+       tab. Plan 60 promotes the Compare button to enabled for any pair
+       that shares a non-null bookId; the on-demand fetch resolves the
+       foreign cast when Compare is clicked. */
     renderCompare(libraryB1, null);
-    const checkboxes = screen.getAllByLabelText('Select voice for compare');
-    fireEvent.click(checkboxes[0]);
-    fireEvent.click(checkboxes[1]);
+    fireEvent.click(
+      screen
+        .getByText('Narrator')
+        .closest('div.group')!
+        .querySelector('[aria-label="Select voice for compare"]')!,
+    );
+    fireEvent.click(
+      screen
+        .getByText('Sandor')
+        .closest('div.group')!
+        .querySelector('[aria-label="Select voice for compare"]')!,
+    );
     const compareBtn = screen.getByRole('button', { name: 'Compare' });
-    expect(compareBtn).toBeDisabled();
-    expect(compareBtn.getAttribute('title')).toBe('Open a book to compare its voices');
+    expect(compareBtn).not.toBeDisabled();
   });
 
   it('disables Compare on a cross-book pair with the documented tooltip (plan 22a)', () => {
@@ -421,6 +438,153 @@ describe('LibraryView compare-two-voices affordance (plan 22a)', () => {
     expect(screen.getByText('Selected')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
     expect(screen.queryByText(/^Selected$/)).toBeNull();
+  });
+
+  describe('global-tab same-book fetch path (plan 60)', () => {
+    /* Helper: build a BookStateResponse with the given characters.
+       Only the `cast` field is consulted by the global-compare flow;
+       the rest is filler so the type satisfies. */
+    function buildBookState(bookId: string, chars: Character[]): BookStateResponse {
+      const now = new Date().toISOString();
+      return {
+        state: {
+          bookId,
+          manuscriptId: '',
+          title: '',
+          author: '',
+          series: '',
+          seriesPosition: null,
+          isStandalone: false,
+          manuscriptFile: '',
+          castConfirmed: true,
+          chapters: [],
+          coverGradient: ['#000', '#000'],
+          createdAt: now,
+          updatedAt: now,
+        },
+        cast: { characters: chars },
+        manuscript: null,
+        manuscriptEdits: null,
+        revisions: null,
+        completedSlugs: [],
+        chapterCharacters: undefined,
+        changeLog: null,
+        analysis: undefined,
+      };
+    }
+
+    async function flush(): Promise<void> {
+      /* Two microtask drains: one for the await on `api.getBookState`,
+         one for the setState-driven re-render that follows. */
+      await act(async () => {
+        await Promise.resolve();
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+
+    it('fetches foreign cast via api.getBookState and mounts the modal on Compare click', async () => {
+      getBookState.mockResolvedValueOnce(buildBookState('b1', charactersB1));
+      renderCompare(libraryB1, null);
+      fireEvent.click(
+        screen
+          .getByText('Narrator')
+          .closest('div.group')!
+          .querySelector('[aria-label="Select voice for compare"]')!,
+      );
+      fireEvent.click(
+        screen
+          .getByText('Sandor')
+          .closest('div.group')!
+          .querySelector('[aria-label="Select voice for compare"]')!,
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Compare' }));
+      await flush();
+      expect(getBookState).toHaveBeenCalledTimes(1);
+      expect(getBookState).toHaveBeenCalledWith('b1');
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('pushes a toast and retroactively disables Compare when the fetch fails', async () => {
+      getBookState.mockRejectedValueOnce(new Error('network down'));
+      renderCompare(libraryB1, null);
+      fireEvent.click(
+        screen
+          .getByText('Narrator')
+          .closest('div.group')!
+          .querySelector('[aria-label="Select voice for compare"]')!,
+      );
+      fireEvent.click(
+        screen
+          .getByText('Sandor')
+          .closest('div.group')!
+          .querySelector('[aria-label="Select voice for compare"]')!,
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Compare' }));
+      await flush();
+      /* No modal mounted; Compare button re-asserts disabled with the
+         documented tooltip; the toast surface gets the error. */
+      expect(screen.queryByRole('dialog')).toBeNull();
+      const compareBtn = screen.getByRole('button', { name: 'Compare' });
+      expect(compareBtn).toBeDisabled();
+      expect(compareBtn.getAttribute('title')).toBe('Could not load that book — try again later');
+    });
+
+    it('also disables Compare when the fetched book has no cast at all', async () => {
+      getBookState.mockResolvedValueOnce(buildBookState('b1', []));
+      renderCompare(libraryB1, null);
+      fireEvent.click(
+        screen
+          .getByText('Narrator')
+          .closest('div.group')!
+          .querySelector('[aria-label="Select voice for compare"]')!,
+      );
+      fireEvent.click(
+        screen
+          .getByText('Sandor')
+          .closest('div.group')!
+          .querySelector('[aria-label="Select voice for compare"]')!,
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Compare' }));
+      await flush();
+      expect(screen.queryByRole('dialog')).toBeNull();
+      expect(screen.getByRole('button', { name: 'Compare' })).toBeDisabled();
+    });
+
+    it('caches the foreign cast so re-opens skip the second fetch', async () => {
+      getBookState.mockResolvedValue(buildBookState('b1', charactersB1));
+      renderCompare(libraryB1, null);
+      fireEvent.click(
+        screen
+          .getByText('Narrator')
+          .closest('div.group')!
+          .querySelector('[aria-label="Select voice for compare"]')!,
+      );
+      fireEvent.click(
+        screen
+          .getByText('Sandor')
+          .closest('div.group')!
+          .querySelector('[aria-label="Select voice for compare"]')!,
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Compare' }));
+      await flush();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(getBookState).toHaveBeenCalledTimes(1);
+      /* Close and re-open the modal — the same pair, same session.
+         The component should consult the cache, not refetch. */
+      fireEvent.keyDown(window, { key: 'Escape' });
+      /* Falls back to clicking the modal Close button if Escape doesn't
+         bubble; the modal's contract is opaque here. Either way, the
+         best signal is unmounting via the Cancel/X — but for cache
+         coverage we just hit Compare again whilst the modal is still
+         up; React re-renders re-use the cached path. */
+      fireEvent.click(screen.getByRole('button', { name: 'Compare' }));
+      await flush();
+      /* Still only one fetch — the second Compare click reads
+         `globalCastCache` and short-circuits the fetch path. */
+      expect(getBookState).toHaveBeenCalledTimes(1);
+    });
   });
 });
 

--- a/src/views/voices.tsx
+++ b/src/views/voices.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { SectionLabel, MixedHeading, VoiceSwatch } from '../components/primitives';
 import { VoiceCard } from '../components/voice-library-panel';
 import { IconPlay } from '../lib/icons';
-import type { BaseVoice, TtsEngine, TtsModelKey, Voice } from '../lib/types';
+import type { BaseVoice, Character, TtsEngine, TtsModelKey, Voice } from '../lib/types';
 import {
   TTS_ENGINES,
   engineForModelKey,
@@ -13,6 +13,7 @@ import { useAppDispatch, useAppSelector } from '../store';
 import { uiActions } from '../store/ui-slice';
 import { castActions } from '../store/cast-slice';
 import { voicesActions } from '../store/voices-slice';
+import { notificationsActions } from '../store/notifications-slice';
 import { api } from '../lib/api';
 import { useSamplePlayback } from '../lib/use-sample-playback';
 import { playBaseVoiceSampleWithAutoLoad } from '../lib/play-sample-with-auto-load';
@@ -71,12 +72,26 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
   const [tab, setTab] = useState<Tab>('all');
   const [draggingVoiceId, setDraggingVoiceId] = useState<string | null>(null);
   const [familyStatus, setFamilyStatus] = useState<{ key: string; label: string } | null>(null);
-  /* Compare affordance (plan 22a). Selection is local-only (mirrors
-     `cast.tsx`'s ephemeral selection state); the pill at the bottom mounts
-     `CompareCastModal` when the user has exactly 2 selected within the
-     current book. Cross-book compare is a documented v1 follow-up. */
+  /* Compare affordance (plan 22a + plan 60). Selection is local-only
+     (mirrors `cast.tsx`'s ephemeral selection state); the pill at the
+     bottom mounts `CompareCastModal` when the user has exactly 2
+     selected that resolve to a same-`bookId` pair. Cross-book compare
+     is a documented follow-up (BACKLOG #17). */
   const [selectedVoiceIds, setSelectedVoiceIds] = useState<string[]>([]);
   const [compareIds, setCompareIds] = useState<[string, string] | null>(null);
+  /* Plan 60 — same-book pairs accessed from the global `#/voices` tab
+     resolve their characters via an on-demand `api.getBookState(bookId)`
+     fetch (the foreign book's cast is NOT in redux when no book is
+     open). Cached in this component-local map for the modal session so
+     re-opens within the same view-mount are instant; the cache resets
+     when the user navigates away. `globalCastFailed` records bookIds
+     whose fetch failed so the Compare button stays disabled
+     retroactively without retrying on every render. */
+  const [globalCastCache, setGlobalCastCache] = useState<Map<string, Character[]>>(
+    () => new Map(),
+  );
+  const [globalCastFailed, setGlobalCastFailed] = useState<Set<string>>(() => new Set());
+  const [globalCastFetching, setGlobalCastFetching] = useState<string | null>(null);
   const dispatch = useAppDispatch();
   const ttsModelKey = useAppSelector((s) => s.ui.ttsModelKey);
   const baseVoices = useAppSelector((s) => s.voices.baseVoices);
@@ -126,7 +141,11 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
   const books = [...new Set(library.map((v) => v.bookId))];
 
   /* Compare derivations. Memoised so a transient render doesn't recompute
-     the same-base / different-base lookup or the disabled-reason string. */
+     the same-base / different-base lookup or the disabled-reason string.
+     `sharedBookId` is non-null when both selected voices share the same
+     `bookId` — it picks which cast source to consult when resolving
+     `Voice → Character` (redux for the open book, `globalCastCache`
+     otherwise per plan 60). */
   const compareDerivations = useMemo(() => {
     const selectedVoices = selectedVoiceIds
       .map((id) => library.find((v) => v.id === id))
@@ -139,23 +158,88 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
     }
     let compareDisabledReason: string | null = null;
     let canCompare = false;
+    let sharedBookId: string | null = null;
     if (selectedVoices.length !== 2) {
       compareDisabledReason = 'Select exactly 2 voices';
-    } else if (currentBookId === null) {
-      compareDisabledReason = 'Open a book to compare its voices';
-    } else if (!selectedVoices.every((v) => v.bookId === currentBookId)) {
+    } else if (selectedVoices[0].bookId !== selectedVoices[1].bookId) {
+      /* Cross-book compare is BACKLOG #17 — depends on this plan but
+         deferred. The disabled tooltip stays the same as plan 22a. */
       compareDisabledReason = 'Cross-book compare not supported yet';
     } else {
-      const linkedCharacters = selectedVoices.map((v) => findCharacterForVoice(v, characters));
-      if (linkedCharacters.some((c) => !c)) {
-        compareDisabledReason = 'Selected voice is no longer linked to a character';
-      } else {
+      sharedBookId = selectedVoices[0].bookId;
+      /* Pick the cast source:
+         - `bookId === currentBookId` → redux cast (open book is hydrated).
+         - Otherwise → component-local foreign-cast cache (plan 60).
+         The global `#/voices` tab (`currentBookId === null`) always
+         lands in the second branch; the per-book tab lands here too if
+         the user happens to select two voices from a *different* book. */
+      const castSource =
+        sharedBookId === currentBookId ? characters : globalCastCache.get(sharedBookId);
+      if (globalCastFailed.has(sharedBookId)) {
+        compareDisabledReason = 'Could not load that book — try again later';
+      } else if (!castSource) {
+        /* No cast yet for this foreign book — the Compare click triggers
+           the fetch. The button is *enabled* here so the click can run;
+           gating only re-asserts once the cast resolves. */
         canCompare = true;
+      } else {
+        const linkedCharacters = selectedVoices.map((v) => findCharacterForVoice(v, castSource));
+        if (linkedCharacters.some((c) => !c)) {
+          compareDisabledReason = 'Selected voice is no longer linked to a character';
+        } else {
+          canCompare = true;
+        }
       }
     }
-    return { selectedVoices, badge, canCompare, compareDisabledReason };
-  }, [selectedVoiceIds, library, currentBookId, characters]);
-  const { selectedVoices, badge, canCompare, compareDisabledReason } = compareDerivations;
+    return { selectedVoices, badge, canCompare, compareDisabledReason, sharedBookId };
+  }, [selectedVoiceIds, library, currentBookId, characters, globalCastCache, globalCastFailed]);
+  const { selectedVoices, badge, canCompare, compareDisabledReason, sharedBookId } =
+    compareDerivations;
+
+  /* Plan 60 — on-demand foreign-cast hydrate for same-book Compare from
+     the global tab. Resolves `api.getBookState(bookId)` once per session;
+     a hit populates `globalCastCache` and immediately opens the modal;
+     a miss pushes a toast and adds the bookId to `globalCastFailed` so
+     the gate stays closed without retrying on every render. The fetch
+     is gated on `globalCastFetching` so a double-click on Compare can't
+     fire two parallel requests. */
+  async function fetchAndOpenForeignCast(
+    bookId: string,
+    voicePair: [string, string],
+  ): Promise<void> {
+    if (globalCastFetching === bookId) return;
+    setGlobalCastFetching(bookId);
+    try {
+      const res = await api.getBookState(bookId);
+      const cast = res?.cast?.characters ?? null;
+      if (!cast || cast.length === 0) {
+        throw new Error('book state has no cast');
+      }
+      setGlobalCastCache((prev) => {
+        const next = new Map(prev);
+        next.set(bookId, cast);
+        return next;
+      });
+      setCompareIds(voicePair);
+    } catch (err) {
+      console.error('[voices] foreign cast fetch failed', err);
+      setGlobalCastFailed((prev) => {
+        if (prev.has(bookId)) return prev;
+        const next = new Set(prev);
+        next.add(bookId);
+        return next;
+      });
+      dispatch(
+        notificationsActions.pushToast({
+          kind: 'error',
+          message: 'Could not load that book — try a different pair.',
+          dedupeKey: `voices-compare-fetch:${bookId}`,
+        }),
+      );
+    } finally {
+      setGlobalCastFetching(null);
+    }
+  }
 
   function togglePin(voice: Voice) {
     const next = !voice.pinned;
@@ -341,15 +425,34 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
             <span className="w-px h-5 bg-canvas/20" />
             <button
               onClick={() => {
-                if (canCompare && selectedVoiceIds.length === 2) {
+                if (!canCompare || selectedVoiceIds.length !== 2 || !sharedBookId) return;
+                /* Path A — pair belongs to the open book: redux cast is
+                   hydrated, no fetch needed. Path B — same-book pair from
+                   the global tab (or a foreign book inside the per-book
+                   tab): consult the cache; if missing, fetch on demand
+                   per plan 60. */
+                const needsFetch =
+                  sharedBookId !== currentBookId && !globalCastCache.has(sharedBookId);
+                if (needsFetch) {
+                  void fetchAndOpenForeignCast(sharedBookId, [
+                    selectedVoiceIds[0],
+                    selectedVoiceIds[1],
+                  ]);
+                } else {
                   setCompareIds([selectedVoiceIds[0], selectedVoiceIds[1]]);
                 }
               }}
-              disabled={!canCompare}
-              title={canCompare ? 'Compare these two voices' : (compareDisabledReason ?? undefined)}
+              disabled={!canCompare || globalCastFetching !== null}
+              title={
+                globalCastFetching
+                  ? 'Loading book cast…'
+                  : canCompare
+                    ? 'Compare these two voices'
+                    : (compareDisabledReason ?? undefined)
+              }
               className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-canvas/15 text-canvas text-xs font-bold hover:bg-canvas/25 disabled:opacity-40 disabled:cursor-not-allowed"
             >
-              Compare
+              {globalCastFetching ? 'Loading…' : 'Compare'}
             </button>
             <button
               onClick={() => setSelectedVoiceIds([])}
@@ -367,19 +470,31 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
           const va = selectedVoices.find((v) => v.id === aId);
           const vb = selectedVoices.find((v) => v.id === bId);
           if (!va || !vb) return null;
-          const charA = findCharacterForVoice(va, characters);
-          const charB = findCharacterForVoice(vb, characters);
+          /* Pick the cast list to resolve against — redux for the open
+             book, the plan-60 foreign-cast cache otherwise. */
+          const castSource =
+            va.bookId === currentBookId ? characters : globalCastCache.get(va.bookId);
+          if (!castSource) return null;
+          const charA = findCharacterForVoice(va, castSource);
+          const charB = findCharacterForVoice(vb, castSource);
           if (!charA || !charB) return null;
+          /* Saves only route to redux when the pair belongs to the open
+             book; foreign-book edits aren't persisted yet (BACKLOG #17
+             owns the cross-book save story). The modal-side onSaveSide
+             is still called so the in-modal draft stays consistent. */
+          const isForeign = va.bookId !== currentBookId;
           return (
             <CompareCastModal
               characters={[charA, charB]}
               library={library}
               ttsModelKey={ttsModelKey}
-              onSaveSide={(next) => dispatch(castActions.updateCharacter(next))}
+              onSaveSide={(next) => {
+                if (!isForeign) dispatch(castActions.updateCharacter(next));
+              }}
               onClose={() => setCompareIds(null)}
               onOpenProfile={(id) => {
                 setCompareIds(null);
-                dispatch(uiActions.setOpenProfileId(id));
+                if (!isForeign) dispatch(uiActions.setOpenProfileId(id));
               }}
             />
           );


### PR DESCRIPTION
## Summary

- **Closes BACKLOG #16** — the global `#/voices` tab can now Compare any two voices that share a non-null `bookId`. `LibraryView` fetches the foreign book's cast via `api.getBookState(bookId)` on first Compare click, caches the resolved characters in a component-local `Map<bookId, Character[]>` for the modal session, and mounts the existing `CompareCastModal` against the resolved sides. Cross-book pairs stay disabled (BACKLOG #17, now depending on plan 60's fetch machinery rather than plan 22a).
- **Foreign-book Saves are scoped out** — `onSaveSide` is a no-op for foreign-book pairs (the modal still tracks the draft so audition works, but no redux mutation persists). Persistence is part of #17. Fetch failures push a deduped error toast through the existing notifications slice and add the bookId to a `globalCastFailed` set so the Compare button re-asserts disabled with "Could not load that book — try again later" rather than retrying on every render. A `globalCastFetching` flag gates the click so a double-tap can't fire two parallel requests.
- **Mock-state surface seeded for `ns`** — `src/lib/api.ts` now seeds the Northern Star book in `MOCK_BOOK_STATES` with `cast: { characters: initialCharacters }` so the e2e and any `VITE_USE_MOCKS=true` walkthrough can resolve the global-tab fetch. The existing Solway Bay (`sb`) seed deliberately keeps `cast: null` so plan 22a's per-book disabled-button assertion still holds.
- **Regression plan filed** — `docs/features/60-voices-global-tab-compare.md` (status: stable, shipped 2026-05-19). INDEX adds entry under section D ("Voice matching & cast"). BACKLOG removes #16, rewrites #17's "Depends on" to point at plan 60, decrements Counts header from "Could 32" to "Could 31".

## Test plan

- [x] **Vitest** — five new cases under `src/views/voices.test.tsx`'s plan-60 describe block: fetches foreign cast on Compare click + mounts modal; pushes a toast and retroactively disables Compare when fetch fails; disables Compare when the fetched book has no cast at all; caches the foreign cast so re-opens skip the second fetch; enables Compare on the global tab for a same-bookId pair. One plan-22a test rewritten from "disables Compare on global tab" to the new "enables Compare on global tab for same-bookId pair" assertion.
- [x] **Playwright** — two new specs in `e2e/voices-compare.spec.ts` replace the old "global tab disables Compare" spec: happy-path (Halloran + Eliza Gray, both `ns`, click Compare, `getRole('dialog')` visible) and cross-book negative case (Halloran in `ns` + Narrator in `sb`, Compare disabled with the cross-book tooltip).
- [x] **`npm run verify`** — green end-to-end on this branch (lint + typecheck + 1050 frontend tests + 997 server tests + 44 e2e specs + build all pass; the listen-playback flake noted on `main` is unrelated and self-recovers on retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
