### PR TITLE
feat(frontend,server,sidecar,scripts): in-app multi-model management UX (plan 61)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -27,7 +27,7 @@ the same PR — the backlog is only useful while it stays current.
 
 Ranking within each bucket = top is highest priority.
 
-**Counts as of 2026-05-19 (post plans 53–58 merge):** Must 0 · Should 0 · Could 32 · Won't 9
+**Counts as of 2026-05-19 (post plan 61 ship):** Must 0 · Should 0 · Could 31 · Won't 9
 
 ---
 
@@ -313,16 +313,6 @@ Source: plan 20 close-out (2026-05-18). The `revisions.acceptedSelections` map i
 - _Key files:_ new `server/src/routes/revisions-commit-segments.ts`; `server/src/tts/synthesise-chapter.ts` (extend for per-segment paths); `src/views/revision-diff.tsx` (dispatch through the new endpoint); `src/store/revisions-slice.ts` (mark the revision as committed once the segment-level synth completes).
 - _Depends on:_ plan 20 shipped (acceptedSelections persistence is already on disk). Pairs with Could #12 (revision history timeline) — the timeline becomes meaningful once per-segment commits land separately from full regens.
 - _Benefit (user):_ true segment-level revision control. Today accept/reject is whole-revision swap — if the user likes 9 of 10 segments in the new take but wants segment 7 from the original, they have to regenerate the whole chapter under different prompts to recover that one segment. This closes the loop the slice has been quietly capturing since plan 20 v1.
-
-### 37. In-app multi-model management UX
-
-Source: net-new (2026-05-18). Plan 49 (release packaging) ships with a Kokoro-only install bundle and an in-app Gemini API key field; the rest of the multi-model story still needs the deployer to drop to a terminal. This item closes that gap.
-
-- _What:_ Add to the Account view (or a sibling Models tab): (a) "Install Ollama" affordance that detects the platform, downloads the vendor installer, and walks the user through setup; (b) "Pull model" UI on the analyzer section — lists models present on disk, exposes a Pull button for the configured-default that doesn't shell to a terminal; (c) "Refresh available models" button that re-hits `/api/ollama/health` and updates the dropdown without a page reload; (d) optional Coqui XTTS pre-install script (POSIX `.sh` + PowerShell `.ps1` parallels to `install-kokoro.*`) that fetches weights ahead of first generation.
-- _Acceptance:_ Fresh deployer install (Kokoro only) → Account → Models → Install Ollama → Pull qwen3.5:4b → analyze a book, all without leaving the app. Coqui XTTS users can pre-fetch weights similarly. New Vitest specs cover the per-step state machine; one Playwright spec covers the install → pull → analyze loop end-to-end (mock the actual download).
-- _Key files:_ `src/views/account.tsx` (extend with Models section), new `src/components/ollama-install.tsx`, new `src/components/model-pull-status.tsx`, `server/src/routes/ollama-health.ts` (extend with `POST /pull`), new `server/src/ollama/install-bootstrap.ts`, new `server/tts-sidecar/scripts/install-coqui.{sh,ps1}`.
-- _Depends on:_ none structural — the Account UX seam exists from plan 49. Unparks the install-and-pull-from-UI subset of Won't #1 ("Auto-install Ollama / auto-pull models"); the headless-CI variant of Won't #1 stays parked.
-- _Benefit (user):_ closes the gap that plan 49's Kokoro-only install leaves. Today a deployer who wants Ollama or Coqui XTTS must drop to a terminal; this UX keeps the install + model-management flow entirely in-app, matching the deployer-first promise of plan 49.
 
 ### 38. Real-binary MOBI / AZW3 fixtures for the binary-upload e2e
 

--- a/docs/features/61-in-app-model-management.md
+++ b/docs/features/61-in-app-model-management.md
@@ -1,0 +1,98 @@
+---
+status: stable
+shipped: 2026-05-19
+owner: null
+---
+
+# 61 — In-app multi-model management UX
+
+> Status: stable
+> Key files: `src/views/account.tsx` (Models card), `src/components/ollama-install.tsx`, `src/components/model-pull-status.tsx`, `server/src/routes/ollama-health.ts` (extended), `server/src/ollama/install-bootstrap.ts`, `server/src/ollama/pull-bootstrap.ts`, `server/tts-sidecar/scripts/install-coqui.{sh,ps1}`
+> URL surface: `#/account` (the Models card sits inside the existing Account view)
+> OpenAPI ops: `GET /api/ollama/detect`, `POST /api/ollama/install`, `GET /api/ollama/install/:id`, `POST /api/ollama/install/:id/recheck`, `POST /api/ollama/pull`, `GET /api/ollama/pull/:id`, `POST /api/ollama/refresh` (all new in this plan)
+
+## Benefit / Rationale
+
+- **User:** closes the gap that plan 49's Kokoro-only install left. A deployer who shipped via the release bundle could only ever use Gemini (cloud) or pre-pull Ollama from a terminal. The Models card now lets them install Ollama, pull qwen3.5:4b, and analyze a book without leaving the app — matching plan 49's "deployer-first, no terminal needed" promise.
+- **Technical:** introduces a small, dependency-injectable state-machine pattern (`InstallBootstrap` + `PullBootstrap`) that the route layer drives via 202 + poll. Tests stub `httpFn` / `spawnFn` / `fetchFn` so the entire surface is exercised offline.
+- **Architectural:** keeps the existing `GET /api/ollama/health` envelope load-bearing — the new `/refresh` endpoint just re-runs the same probe with POST semantics so the UI can request a re-read without conflating it with normal polling. Install + pull are kept in separate modules under `server/src/ollama/` so the surface area can grow (e.g. multi-engine install) without re-touching `ollama-health.ts`.
+
+## Architectural impact
+
+**New seams / extension points:**
+
+- `server/src/ollama/install-bootstrap.ts`: `InstallBootstrap` class with injectable `resolveAssetUrl` / `httpFn` / `spawnFn` / `detectOllama` / `getPlatform` / `getArch` / `downloadDir`. Tests use a fully stubbed bootstrap; production uses the module-level singleton wired to `process.platform` + global `fetch` + `node:child_process.spawn`.
+- `server/src/ollama/pull-bootstrap.ts`: `PullBootstrap` with injectable `fetchFn`. The static `DEFAULT_ALLOWED_MODELS` set (mirroring the analyzer's `MODEL_OPTIONS`) refuses non-allowlisted tags at the route layer, so the user can't `/pull` arbitrary upstream tags from the UI.
+- `setOllamaBootstraps({...})` + `_resetOllamaBootstraps()` in `server/src/routes/ollama-health.ts` — dependency-injection seam for the route's tests.
+- Frontend: `OllamaInstall` + `ModelPullStatus` components are self-contained (no redux). They own their own poll loops and tear down on terminal states.
+
+**Invariants preserved:**
+
+- `GET /api/ollama/health` (plan 29) untouched. The new `POST /api/ollama/refresh` re-runs the same probe but is a separate route so existing pollers in `useTtsLifecycle.ts` keep working unchanged.
+- `POST /api/ollama/{load,unload}` (plan 30) untouched — the in-app pill semantics still warm/evict using Ollama's `keep_alive` idiom.
+- `MODEL_OPTIONS` (`src/lib/models.ts`) remains the source of truth for which tags the analyzer supports. `DEFAULT_ALLOWED_MODELS` in the server is a static mirror; if a new tag lands in `MODEL_OPTIONS`, update the server allowlist in the same PR.
+- `start-app.bat` + the release bundle's `install-kokoro.{ps1,sh}` still handle Kokoro v1 weights; this plan ADDS `install-coqui.{ps1,sh}` for XTTS v2. Kokoro stays the default-resident TTS.
+
+**Migration story:** None. The new endpoints + UI are additive; existing settings remain in `server/user-settings.json` untouched. A user who never visits Account → Models gets the same behaviour they had before this plan.
+
+**Reversibility:** Drop the Models card from `account.tsx`, drop the new route handlers from `ollama-health.ts`, drop `server/src/ollama/`. The install-coqui scripts can stay or be deleted — they're idempotent and harmless.
+
+## Invariants to preserve
+
+1. **Install allowlist** — `DEFAULT_ALLOWED_MODELS` in `server/src/ollama/pull-bootstrap.ts:64-72` MUST mirror the local-engine subset of `MODEL_OPTIONS` (`src/lib/models.ts:19-38`). Drift means the UI offers Pull buttons for tags the analyzer can't dispatch, OR refuses Pull for tags the analyzer would happily use.
+2. **No auto-pull on first run** — the install state machine never spawns a pull. Pull is always a separate, explicit user click. Surfaced in `server/src/ollama/install-bootstrap.ts:25-29` (module docstring).
+3. **State machines are linear + terminal** — `idle → detecting → downloading → installing → installed` for install; `idle → pulling → pulled` for pull. Errors short-circuit to terminal `error`. No mid-flight branching.
+4. **Windows is GUI-install only** — `runInstaller` in `install-bootstrap.ts:251-272` refuses to run an `.exe` headlessly. The job parks in `installing` with `manualInstallerPath` set; the user double-clicks and clicks "I've finished — re-check" to flip the state.
+5. **Coqui scripts are venv-aware** — `install-coqui.{sh,ps1}` MUST refuse to run if the sidecar venv isn't bootstrapped. Otherwise we'd silently use the system Python, which doesn't have the `TTS` lib.
+6. **All routes are dependency-injectable from tests** — `setOllamaBootstraps()` swaps both bootstraps. Tests MUST `_resetOllamaBootstraps()` in `afterEach` so cross-test leakage doesn't surface as a flake.
+
+## Test plan
+
+### Automated coverage
+
+- Vitest server (`server/src/ollama/install-bootstrap.test.ts`) — walks the full state machine (detect short-circuit, linux happy path, windows GUI park, download error, byte-truncation error, progress reporting, coalescing parallel `start()`).
+- Vitest server (`server/src/ollama/pull-bootstrap.test.ts`) — allowlist enforcement, NDJSON progress consumption, error-line short-circuit, coalescing same-model pulls, distinct ids for different models.
+- Vitest server (`server/src/routes/ollama-health.test.ts`) — extended with `/detect`, `/install`, `/install/:id`, `/pull`, `/pull/:id`, `/refresh` coverage. Existing `/health`, `/load`, `/unload` assertions still pass unchanged.
+- Vitest frontend (`src/components/ollama-install.test.tsx`) — detected / not-detected / windows-manual / error render branches, click → POST /install → render job card transition.
+- Vitest frontend (`src/components/model-pull-status.test.tsx`) — present/absent row rendering, configured-default highlight, daemon-unreachable banner, pull POST + progress bar, allowlist-error rendering, refresh button re-renders.
+- Vitest frontend (`src/views/account.test.tsx`) — the Models card mounts + lists both POSIX + PowerShell install snippets for Coqui.
+- Playwright e2e (`e2e/account-models.spec.ts`) — install → pull → ready loop with mocked routes. Walks the install state machine through two ticks, pulls qwen3.5:4b, confirms the row flips to "on disk." Refresh button re-runs `/refresh`.
+
+### Manual acceptance walkthrough
+
+1. **Cold boot** at `#/account` → Models card appears below "Server configuration." → `OllamaInstall` reports "Ollama is not installed" (assuming a fresh box).
+2. Click **Install Ollama** → job card appears, status flips to `downloading` with a progress bar. → Job card status flips to `installing` (linux/macOS auto-runs the installer; windows stops at "double-click this file"). → Job card eventually flips to `installed`, and the green ready pill replaces the job card.
+3. The **Analyzer models** list now shows `qwen3.5:4b` (and the other allowlist entries) as "Not pulled yet."
+4. Click **Pull** on `qwen3.5:4b` → progress bar appears. NDJSON status messages cycle (`pulling manifest` → `downloading` → `verifying sha256 digest` → `success`).
+5. Once pulled, the row flips to "On disk" + the Pull button becomes "Pulled" (disabled).
+6. Click **Refresh available models** → POSTs `/api/ollama/refresh`; the dropdown stays in sync.
+7. Navigate to `#/` → click **Start a new book** → pick `qwen3.5:4b` as the analysis model → analysis runs end-to-end against the freshly-pulled local model.
+8. Open `server/tts-sidecar/scripts/install-coqui.sh` on macOS/Linux (or `.ps1` on Windows) → script pre-fetches XTTS v2 weights into `voices/coqui/`, skips on re-run.
+
+## Out of scope
+
+- **Headless / CI auto-install** stays parked as BACKLOG Won't #1. This plan unparks the install-and-pull-from-UI subset only.
+- **Auto-pull on first run** — explicit opt-in only. Pull is always a button click.
+- **Multi-engine install** (e.g. fetching Kokoro weights via the UI) — Kokoro v1 ships pre-installed via plan 49's bundle; if a user wants the alt path, they run `scripts/install-kokoro.{sh,ps1}` manually. The state-machine pattern would generalise, but the trigger doesn't exist.
+- **GPU concurrency arbitration** when multiple pulls hit Ollama at once — Ollama itself serialises pulls. Our state machine just polls; we don't gate.
+- **Coqui XTTS in-app install button** — the in-app affordance is a docs-only snippet (POSIX + PowerShell). A real button would have to spawn Python from the server, which is materially more complex than the bash/ps1 scripts the deployer can run from the bundle. Tracked as a follow-up if the bash/ps1 path proves friction-iest.
+
+## Known multi-model gaps after this ship
+
+Per the [packaging multi-model-gap memory](../../C:%5CUsers%5Cdudar%5C.claude%5Cprojects%5CC--Claude-Projects-Audiobook-Generator%5Cmemory%5CMEMORY.md): this plan does NOT close every gap. Remaining gaps a fresh deployer must work around:
+
+1. **Kokoro v1 weights** are still bundled via plan 49's `install-kokoro.{ps1,sh}` — eager-loaded at sidecar startup; no in-app affordance to re-install if the weights file is deleted. (Wake when: deployers report deletion-and-re-install confusion.)
+2. **Coqui XTTS v2 install is script-driven, not in-app** — the Account → Models card surfaces the script paths and the command but does not run them via a button. Reason: the script needs the sidecar venv's Python on PATH, which the Node server can't reliably locate from an arbitrary install location. The script itself handles that, but spawning it from the UI is a follow-up. Workaround: deployer runs the script from the release bundle once. The on-disk pre-fetch is OPTIONAL — XTTS auto-downloads on first synth call anyway, so this is only a "skip the first-synth wait" affordance.
+3. **Ollama install on Windows requires a GUI double-click** — the vendor only ships an `.exe` GUI installer. The job parks in `installing` with `manualInstallerPath` set; the user double-clicks, then clicks "I've finished — re-check." Closing the full headless loop on Windows requires either bundling a portable Ollama (license risk) or scripting the .exe in silent mode (vendor doesn't document a flag).
+4. **Allowlist drift** — adding a new analyzer tag to `src/lib/models.ts` MUST also add it to `server/src/ollama/pull-bootstrap.ts` `DEFAULT_ALLOWED_MODELS`. There's no test that pins the two sets to each other yet. Tracked as a follow-up.
+5. **Linux distro coverage** — the `bash <installer>` step assumes the vendor script works against the host's package manager. Tested by the vendor against Ubuntu/Debian/Fedora; behaviour on Arch / Alpine / NixOS may need manual intervention. Surfaces as an error toast, not a hang.
+
+## Ship notes
+
+Shipped 2026-05-19 on branch `feat/frontend+server-in-app-model-mgmt`.
+
+- Server: new modules under `server/src/ollama/` (`install-bootstrap.ts` + `pull-bootstrap.ts`), seven new routes on `ollama-health.ts` (`/detect`, `/install`, `/install/:id`, `/install/:id/recheck`, `/pull`, `/pull/:id`, `/refresh`).
+- Frontend: `OllamaInstall` + `ModelPullStatus` components, `ModelsCard` section appended to the Account view below the existing server-config card.
+- Sidecar scripts: `install-coqui.sh` (POSIX) + `install-coqui.ps1` (Windows) parallel to the existing `install-kokoro.*` pair.
+- Tests: 4 new spec files (server install + pull bootstraps, frontend ollama-install + model-pull-status), extended `ollama-health.test.ts` + `account.test.tsx`, one new Playwright spec (`e2e/account-models.spec.ts`).
+- Closes BACKLOG Could #37. Unparks the install-and-pull-from-UI subset of Won't #1; the headless-CI variant stays parked.

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -50,6 +50,7 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 - [05 — Manual handoff analyzer](05-analyzer-manual-handoff.md) — `ANALYZER=manual` file-drop cowork loop.
 - [06 — Gemini analyzer](06-analyzer-gemini.md) — `ANALYZER=gemini` direct-API mode (also the fallback when local is unreachable).
 - [29 — Local Ollama analyzer + fallback](29-analyzer-ollama-local.md) — `ANALYZER=local` default; auto-fallback to Gemini only when daemon is unreachable.
+- [61 — In-app multi-model management UX](61-in-app-model-management.md) — Account → Models card; install Ollama, pull analyzer model weights, pre-fetch Coqui XTTS without dropping to a terminal. Closes plan 49's deployer-first gap for non-Kokoro engines. **Status: stable.**
 - [07 — Audio tag vocabulary](07-audio-tag-vocabulary.md) — `[tag]` vocabulary UI ↔ parser sync.
 - [08 — Audio tag auto-detection](08-audio-tag-auto-detection.md) — Server-side auto-tagging from punctuation/markdown/HTML.
 

--- a/e2e/account-models.spec.ts
+++ b/e2e/account-models.spec.ts
@@ -1,0 +1,212 @@
+/* Plan 61 — Account → Models card e2e.
+ *
+ * Asserts the install → pull → analyze loop end-to-end from the browser,
+ * with the actual network calls intercepted and replayed via Playwright's
+ * route stubs so the spec stays offline. The mocked install + mocked
+ * pull walk through their state machines tick-by-tick. */
+
+import { test, expect } from '@playwright/test';
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('plan 61 — in-app multi-model management UX', () => {
+  test('install Ollama → pull qwen3.5:4b → ready for analysis', async ({ page }) => {
+    /* Track which step of the install state machine we're on. */
+    let installPolls = 0;
+    let detectInstalled = false;
+
+    await page.route('**/api/ollama/detect', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(
+          detectInstalled
+            ? { installed: true, version: 'ollama version 0.5.4 (mock)' }
+            : { installed: false, version: null },
+        ),
+      });
+    });
+
+    await page.route('**/api/ollama/install', async (route) => {
+      if (route.request().method() !== 'POST') return route.continue();
+      await route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: '1',
+          status: 'downloading',
+          platform: 'linux',
+          arch: 'x64',
+          bytesReceived: 0,
+          bytesTotal: 1_000_000,
+          manualInstallerPath: null,
+          error: null,
+          startedAt: Date.now(),
+          updatedAt: Date.now(),
+        }),
+      });
+    });
+
+    await page.route('**/api/ollama/install/1', async (route) => {
+      installPolls += 1;
+      /* Walk the state machine across two ticks:
+           poll 1 → downloading 50%
+           poll 2+ → installed (and detect flips to true) */
+      let body: Record<string, unknown>;
+      if (installPolls === 1) {
+        body = {
+          id: '1',
+          status: 'downloading',
+          platform: 'linux',
+          arch: 'x64',
+          bytesReceived: 500_000,
+          bytesTotal: 1_000_000,
+          manualInstallerPath: null,
+          error: null,
+          startedAt: 0,
+          updatedAt: 0,
+        };
+      } else {
+        detectInstalled = true;
+        body = {
+          id: '1',
+          status: 'installed',
+          platform: 'linux',
+          arch: 'x64',
+          bytesReceived: 1_000_000,
+          bytesTotal: 1_000_000,
+          manualInstallerPath: null,
+          error: null,
+          startedAt: 0,
+          updatedAt: 0,
+        };
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(body),
+      });
+    });
+
+    let pullPolls = 0;
+    let modelOnDisk = false;
+    await page.route('**/api/ollama/pull', async (route) => {
+      if (route.request().method() !== 'POST') return route.continue();
+      const body = JSON.parse(route.request().postData() ?? '{}');
+      expect(body.model).toBe('qwen3.5:4b');
+      await route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: '7',
+          model: 'qwen3.5:4b',
+          status: 'pulling',
+          lastStatusMessage: 'pulling manifest',
+          bytesReceived: 0,
+          bytesTotal: 1_000_000,
+          error: null,
+          startedAt: 0,
+          updatedAt: 0,
+        }),
+      });
+    });
+
+    await page.route('**/api/ollama/pull/7', async (route) => {
+      pullPolls += 1;
+      let body: Record<string, unknown>;
+      if (pullPolls === 1) {
+        body = {
+          id: '7',
+          model: 'qwen3.5:4b',
+          status: 'pulling',
+          lastStatusMessage: 'downloading',
+          bytesReceived: 500_000,
+          bytesTotal: 1_000_000,
+          error: null,
+          startedAt: 0,
+          updatedAt: 0,
+        };
+      } else {
+        modelOnDisk = true;
+        body = {
+          id: '7',
+          model: 'qwen3.5:4b',
+          status: 'pulled',
+          lastStatusMessage: 'success',
+          bytesReceived: 1_000_000,
+          bytesTotal: 1_000_000,
+          error: null,
+          startedAt: 0,
+          updatedAt: 0,
+        };
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(body),
+      });
+    });
+
+    await page.route('**/api/ollama/health', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          status: 'reachable',
+          url: 'http://localhost:11434',
+          models: modelOnDisk ? ['qwen3.5:4b'] : [],
+          expectedModel: 'qwen3.5:4b',
+          modelPulled: modelOnDisk,
+          resident: [],
+          modelResident: false,
+        }),
+      });
+    });
+
+    await page.route('**/api/ollama/refresh', async (route) => {
+      if (route.request().method() !== 'POST') return route.continue();
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          status: 'reachable',
+          url: 'http://localhost:11434',
+          models: modelOnDisk ? ['qwen3.5:4b'] : [],
+          expectedModel: 'qwen3.5:4b',
+          modelPulled: modelOnDisk,
+        }),
+      });
+    });
+
+    await page.goto('/#/account');
+
+    /* Step 1 — Models card surfaces. */
+    const card = page.getByTestId('account-models-card');
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    /* Step 2 — Ollama not detected; click Install. */
+    await expect(page.getByTestId('ollama-install-not-detected')).toBeVisible();
+    await page.getByRole('button', { name: /install ollama/i }).click();
+
+    /* Step 3 — wait for the job card to flip through to installed.
+       The poll loop is on a 1s interval; allow ample time. */
+    await expect(page.getByTestId('ollama-install-job')).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId('ollama-install-ready')).toBeVisible({ timeout: 10_000 });
+
+    /* Step 4 — pull qwen3.5:4b. */
+    await page.getByTestId('model-pull-qwen3.5:4b').click();
+    await expect(page.getByTestId('model-pull-progress-qwen3.5:4b')).toBeVisible({
+      timeout: 3_000,
+    });
+
+    /* Step 5 — once the pull completes, the refresh hook should
+       re-render the row as "on disk." */
+    await expect(page.getByTestId('model-row-qwen3.5:4b')).toContainText(/on disk/i, {
+      timeout: 10_000,
+    });
+
+    /* Step 6 — Refresh available models button re-runs /refresh. */
+    await page.getByTestId('model-pull-refresh').click();
+    await expect(page.getByTestId('model-row-qwen3.5:4b')).toContainText(/on disk/i);
+  });
+});

--- a/server/src/ollama/install-bootstrap.test.ts
+++ b/server/src/ollama/install-bootstrap.test.ts
@@ -1,0 +1,312 @@
+/* Plan 61 — install-bootstrap state machine.
+ *
+ * Drives the full
+ *   idle → detecting → downloading → installing → installed
+ * sweep with fully stubbed http + spawn + detect. No real network, no
+ * real process spawn — the suite must pass on CI runners with no
+ * Ollama installed. */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+import {
+  InstallBootstrap,
+  defaultResolveAssetUrl,
+  type HttpFn,
+  type SpawnFn,
+} from './install-bootstrap.js';
+
+function makeFakeChild(opts: { exitCode?: number; stdout?: string; err?: Error } = {}) {
+  const emitter = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+  };
+  emitter.stdout = new EventEmitter();
+  emitter.stderr = new EventEmitter();
+  setImmediate(() => {
+    if (opts.err) {
+      emitter.emit('error', opts.err);
+      return;
+    }
+    if (opts.stdout) emitter.stdout.emit('data', Buffer.from(opts.stdout, 'utf8'));
+    emitter.emit('close', opts.exitCode ?? 0);
+  });
+  return emitter;
+}
+
+function makeBytes(size: number): Buffer {
+  return Buffer.alloc(size, 'x');
+}
+
+function makeHttpFn(opts: {
+  ok?: boolean;
+  status?: number;
+  body?: Buffer;
+}): HttpFn {
+  return () => {
+    const body = opts.body ?? makeBytes(4096);
+    /* Readable.from([Buffer]) defaults to object mode. We need a real
+       byte stream so pipe() into a fs WriteStream actually writes
+       bytes and stat() sees the on-disk size. */
+    return Promise.resolve({
+      ok: opts.ok ?? true,
+      status: opts.status ?? 200,
+      contentLength: body.length,
+      body: new Readable({
+        read() {
+          this.push(body);
+          this.push(null);
+        },
+      }),
+    });
+  };
+}
+
+/* Pure helper for the unit-suite that doesn't poke the state machine. */
+describe('defaultResolveAssetUrl', () => {
+  it('returns the macOS zip on darwin', () => {
+    expect(defaultResolveAssetUrl('darwin', 'arm64')).toContain('Ollama-darwin.zip');
+  });
+  it('returns the linux amd64 tarball on linux/x64', () => {
+    expect(defaultResolveAssetUrl('linux', 'x64')).toContain('linux-amd64.tgz');
+  });
+  it('returns the linux arm64 tarball on linux/arm64', () => {
+    expect(defaultResolveAssetUrl('linux', 'arm64')).toContain('linux-arm64.tgz');
+  });
+  it('returns the windows .exe on win32', () => {
+    expect(defaultResolveAssetUrl('win32', 'x64')).toContain('OllamaSetup.exe');
+  });
+  it('throws for unknown platforms', () => {
+    expect(() => defaultResolveAssetUrl('freebsd' as NodeJS.Platform, 'x64')).toThrow();
+  });
+});
+
+describe('InstallBootstrap.detect', () => {
+  it('returns installed=true with the version when `ollama -v` succeeds', async () => {
+    const spawnFn = vi.fn().mockReturnValue(
+      makeFakeChild({ stdout: 'ollama version 0.5.4\n', exitCode: 0 }),
+    ) as unknown as SpawnFn;
+    const boot = new InstallBootstrap({ spawnFn });
+    const r = await boot.detect();
+    expect(r.installed).toBe(true);
+    expect(r.version).toBe('ollama version 0.5.4');
+  });
+
+  it('returns installed=false when the spawn throws', async () => {
+    const spawnFn = vi.fn().mockImplementation(() => {
+      throw new Error('ENOENT');
+    }) as unknown as SpawnFn;
+    const boot = new InstallBootstrap({ spawnFn });
+    const r = await boot.detect();
+    expect(r.installed).toBe(false);
+    expect(r.version).toBeNull();
+  });
+
+  it('returns installed=false when the child exits non-zero', async () => {
+    const spawnFn = vi
+      .fn()
+      .mockReturnValue(makeFakeChild({ exitCode: 1 })) as unknown as SpawnFn;
+    const boot = new InstallBootstrap({ spawnFn });
+    const r = await boot.detect();
+    expect(r.installed).toBe(false);
+  });
+});
+
+describe('InstallBootstrap.start — state machine', () => {
+  let downloadDir: string;
+  beforeEach(() => {
+    downloadDir = mkdtempSync(join(tmpdir(), 'ollama-install-test-'));
+  });
+
+  it('short-circuits to "installed" when ollama is already on PATH', async () => {
+    const detect = vi.fn().mockResolvedValue('ollama version 0.5.4');
+    const httpFn = vi.fn() as unknown as HttpFn;
+    const boot = new InstallBootstrap({
+      detectOllama: detect,
+      httpFn,
+      downloadDir,
+    });
+    const job = boot.start();
+    /* run() is async — give it a tick to complete the short-circuit. */
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    const finalJob = boot.getJob(job.id);
+    expect(finalJob?.status).toBe('installed');
+    /* No network roundtrip — we short-circuited. */
+    expect(httpFn).not.toHaveBeenCalled();
+  });
+
+  it('walks detecting → downloading → installing → installed on linux', async () => {
+    /* First detect call (in run): returns null = not installed.
+       Second detect call (post-install): returns the version. */
+    const detect = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce('ollama version 0.5.4');
+    const httpFn = makeHttpFn({ ok: true, body: makeBytes(8 * 1024) });
+    /* The installer subprocess (bash <path>) — return success. */
+    const spawnFn = vi.fn().mockImplementation(() =>
+      makeFakeChild({ exitCode: 0 }),
+    ) as unknown as SpawnFn;
+    const boot = new InstallBootstrap({
+      detectOllama: detect,
+      httpFn,
+      spawnFn,
+      getPlatform: () => 'linux',
+      getArch: () => 'x64',
+      downloadDir,
+    });
+    const job = boot.start();
+    expect(job.status).toBe('detecting');
+    /* Drain microtasks until the state machine completes. We bound
+       this to 200 ticks so a hung test fails loudly. */
+    for (let i = 0; i < 200; i++) {
+      await new Promise((r) => setTimeout(r, 5));
+      const j = boot.getJob(job.id);
+      if (j?.status === 'installed' || j?.status === 'error') break;
+    }
+    const finalJob = boot.getJob(job.id);
+    expect(finalJob?.status).toBe('installed');
+    expect(finalJob?.error).toBeNull();
+    expect(detect).toHaveBeenCalledTimes(2);
+    expect(spawnFn).toHaveBeenCalledWith('bash', expect.any(Array));
+  });
+
+  it('windows path stays in "installing" with manualInstallerPath set after download', async () => {
+    const detect = vi.fn().mockResolvedValue(null);
+    const httpFn = makeHttpFn({ ok: true, body: makeBytes(8 * 1024) });
+    const spawnFn = vi.fn() as unknown as SpawnFn;
+    const boot = new InstallBootstrap({
+      detectOllama: detect,
+      httpFn,
+      spawnFn,
+      getPlatform: () => 'win32',
+      getArch: () => 'x64',
+      downloadDir,
+    });
+    const job = boot.start();
+    for (let i = 0; i < 200; i++) {
+      await new Promise((r) => setTimeout(r, 5));
+      const j = boot.getJob(job.id);
+      if (j?.status === 'installing' && j.manualInstallerPath) break;
+    }
+    const finalJob = boot.getJob(job.id);
+    expect(finalJob?.status).toBe('installing');
+    expect(finalJob?.manualInstallerPath).toMatch(/OllamaSetup\.exe$/);
+    /* We did NOT call spawn — Windows installer is GUI-only. */
+    expect(spawnFn).not.toHaveBeenCalled();
+    /* The downloaded bytes really landed on disk. */
+    expect(readFileSync(finalJob!.manualInstallerPath!).length).toBeGreaterThanOrEqual(8 * 1024);
+  });
+
+  it('windows recheck promotes installing → installed when ollama appears on PATH', async () => {
+    /* Stage the job in "installing" then flip the detector. */
+    const detect = vi
+      .fn()
+      .mockResolvedValueOnce(null) // first call inside run()
+      .mockResolvedValueOnce('ollama version 0.5.4'); // recheck call
+    const httpFn = makeHttpFn({ body: makeBytes(8 * 1024) });
+    const spawnFn = vi.fn() as unknown as SpawnFn;
+    const boot = new InstallBootstrap({
+      detectOllama: detect,
+      httpFn,
+      spawnFn,
+      getPlatform: () => 'win32',
+      getArch: () => 'x64',
+      downloadDir,
+    });
+    const job = boot.start();
+    for (let i = 0; i < 200; i++) {
+      await new Promise((r) => setTimeout(r, 5));
+      if (boot.getJob(job.id)?.status === 'installing') break;
+    }
+    const after = await boot.recheck(job.id);
+    expect(after?.status).toBe('installed');
+  });
+
+  it('transitions to error when the download HTTP call fails', async () => {
+    const detect = vi.fn().mockResolvedValue(null);
+    const httpFn = makeHttpFn({ ok: false, status: 502 });
+    const boot = new InstallBootstrap({
+      detectOllama: detect,
+      httpFn,
+      getPlatform: () => 'linux',
+      downloadDir,
+    });
+    const job = boot.start();
+    for (let i = 0; i < 200; i++) {
+      await new Promise((r) => setTimeout(r, 5));
+      if (boot.getJob(job.id)?.status === 'error') break;
+    }
+    const j = boot.getJob(job.id);
+    expect(j?.status).toBe('error');
+    expect(j?.error).toMatch(/502/);
+  });
+
+  it('transitions to error when the downloaded bytes are < 1KB (looks like an error page)', async () => {
+    const detect = vi.fn().mockResolvedValue(null);
+    const httpFn = makeHttpFn({ ok: true, body: makeBytes(100) });
+    const boot = new InstallBootstrap({
+      detectOllama: detect,
+      httpFn,
+      getPlatform: () => 'linux',
+      downloadDir,
+    });
+    const job = boot.start();
+    for (let i = 0; i < 200; i++) {
+      await new Promise((r) => setTimeout(r, 5));
+      if (boot.getJob(job.id)?.status === 'error') break;
+    }
+    const j = boot.getJob(job.id);
+    expect(j?.status).toBe('error');
+    expect(j?.error).toMatch(/100 bytes/);
+  });
+
+  it('reports bytesReceived progressively while downloading', async () => {
+    /* Use a 512 KB body so two progress ticks fire (256 KB threshold). */
+    const httpFn = makeHttpFn({ body: makeBytes(512 * 1024) });
+    const spawnFn = vi.fn().mockImplementation(() =>
+      makeFakeChild({ exitCode: 0 }),
+    ) as unknown as SpawnFn;
+    const detectAfter = vi.fn().mockResolvedValue('ollama version 0.5.4');
+    const boot = new InstallBootstrap({
+      detectOllama: vi.fn().mockResolvedValueOnce(null).mockImplementation(detectAfter),
+      httpFn,
+      spawnFn,
+      getPlatform: () => 'linux',
+      downloadDir,
+    });
+    const job = boot.start();
+    for (let i = 0; i < 400; i++) {
+      await new Promise((r) => setTimeout(r, 5));
+      if (boot.getJob(job.id)?.status === 'installed') break;
+    }
+    const j = boot.getJob(job.id);
+    expect(j?.bytesReceived).toBe(512 * 1024);
+    expect(j?.bytesTotal).toBe(512 * 1024);
+  });
+
+  it('coalesces parallel start() calls — only one active job at a time', () => {
+    const httpFn = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        contentLength: 4096,
+        /* Never-resolving body keeps the job pinned in "downloading" */
+        body: new Readable({ read() { /* idle */ } }),
+      }),
+    ) as unknown as HttpFn;
+    const boot = new InstallBootstrap({
+      detectOllama: () => Promise.resolve(null),
+      httpFn,
+      getPlatform: () => 'linux',
+      downloadDir,
+    });
+    const a = boot.start();
+    const b = boot.start();
+    expect(b.id).toBe(a.id);
+  });
+});

--- a/server/src/ollama/install-bootstrap.ts
+++ b/server/src/ollama/install-bootstrap.ts
@@ -1,0 +1,406 @@
+/* Plan 61 — in-app Ollama install bootstrap.
+ *
+ * Background:
+ *   `feat(frontend,server,sidecar,scripts): in-app multi-model management UX`
+ *   adds an "Install Ollama" affordance to the Account → Models pane so a
+ *   fresh deployer who shipped via the plan-49 release zip can go from
+ *   Kokoro-only → local-Ollama analyzer without touching a terminal.
+ *
+ * This module owns the asynchronous job state machine for the install:
+ *
+ *   idle → detecting → downloading → installing → installed
+ *                                      └─ error  ↗
+ *
+ *   detecting   — probe `ollama -v` on PATH; if found, jump straight to
+ *                 `installed`.
+ *   downloading — pull the vendor installer for the host platform from
+ *                 https://ollama.com/download/<asset>. Tracks bytes seen.
+ *   installing  — spawn the installer in non-interactive mode (or guide
+ *                 the user to run it). On macOS/Linux the installer is a
+ *                 script; on Windows it's an .exe that requires a GUI
+ *                 click — we surface a "downloaded, please double-click"
+ *                 state in that case (see WINDOWS_NOTE).
+ *   installed   — re-probe `ollama -v`; on success, terminal state.
+ *   error       — surface .error for the UI; the job is removed on the
+ *                 next POST /install kick.
+ *
+ * Dependency-injectable. `httpFn` and `spawnFn` are constructor params so
+ * the route's vitest harness can run the full state machine offline. The
+ * default exports use real `fetch` + `child_process.spawn`.
+ *
+ * IMPORTANT: we never auto-pull a model after install. That's a separate
+ * user click. See plan 61's "Out of scope" — auto-pull would silently
+ * burn GB of disk on first-run UX. Always explicit.
+ */
+
+import { createWriteStream } from 'node:fs';
+import { mkdir, stat, chmod } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+import { spawn as realSpawn, type ChildProcess } from 'node:child_process';
+
+export type InstallJobStatus =
+  | 'idle'
+  | 'detecting'
+  | 'downloading'
+  | 'installing'
+  | 'installed'
+  | 'error';
+
+export interface InstallJob {
+  id: string;
+  status: InstallJobStatus;
+  platform: NodeJS.Platform;
+  arch: string;
+  bytesReceived: number;
+  bytesTotal: number | null;
+  /* When platform === 'win32', the installer is a GUI .exe that we
+     can't drive headlessly. After download we set
+     `manualInstallerPath` so the UI can render "double-click this file
+     to finish the install." */
+  manualInstallerPath: string | null;
+  error: string | null;
+  startedAt: number;
+  updatedAt: number;
+}
+
+export interface HttpResponse {
+  ok: boolean;
+  status: number;
+  contentLength: number | null;
+  body: NodeJS.ReadableStream | null;
+}
+
+export type HttpFn = (url: string) => Promise<HttpResponse>;
+
+export type SpawnFn = (
+  cmd: string,
+  args: readonly string[],
+  opts?: { env?: NodeJS.ProcessEnv },
+) => ChildProcess;
+
+export interface InstallBootstrapOptions {
+  /* Override the asset URL builder. Tests stub this to point at a local
+     mock so no real download happens. */
+  resolveAssetUrl?: (platform: NodeJS.Platform, arch: string) => string;
+  httpFn?: HttpFn;
+  spawnFn?: SpawnFn;
+  /* Stubbable platform/arch lookup so tests can simulate macOS from a
+     Windows CI runner and vice versa. Defaults to process.platform /
+     process.arch. */
+  getPlatform?: () => NodeJS.Platform;
+  getArch?: () => string;
+  /* Stubbable Ollama detection. Returns the version string if found,
+     or null if `ollama -v` is not on PATH. */
+  detectOllama?: () => Promise<string | null>;
+  /* Directory the installer downloads to. Defaults to OS temp.
+     Tests pass an isolated dir. */
+  downloadDir?: string;
+}
+
+/** Default vendor URL builder. Mirrors https://ollama.com/download. */
+export function defaultResolveAssetUrl(platform: NodeJS.Platform, arch: string): string {
+  /* Vendor naming convention as of 2026-05.
+     - macOS: Ollama-darwin.zip (universal arm64+x64 in the same archive).
+     - Linux: install.sh (the canonical curl|sh path).
+     - Windows: OllamaSetup.exe (GUI installer; user must click).
+  */
+  if (platform === 'darwin') return 'https://ollama.com/download/Ollama-darwin.zip';
+  if (platform === 'linux') {
+    const arm = arch === 'arm64' || arch === 'aarch64';
+    return arm
+      ? 'https://ollama.com/download/ollama-linux-arm64.tgz'
+      : 'https://ollama.com/download/ollama-linux-amd64.tgz';
+  }
+  if (platform === 'win32') return 'https://ollama.com/download/OllamaSetup.exe';
+  throw new Error(`Ollama installer is not available for platform '${platform}'.`);
+}
+
+/** Default detector: spawn `ollama -v` and read its first line. */
+async function defaultDetectOllama(spawnFn: SpawnFn): Promise<string | null> {
+  return new Promise((resolve) => {
+    let proc: ChildProcess;
+    try {
+      proc = spawnFn('ollama', ['-v']);
+    } catch {
+      resolve(null);
+      return;
+    }
+    let stdout = '';
+    proc.stdout?.on('data', (b: Buffer) => {
+      stdout += b.toString('utf8');
+    });
+    proc.on('error', () => resolve(null));
+    proc.on('close', (code) => {
+      if (code === 0 && stdout.trim().length > 0) {
+        resolve(stdout.trim().split('\n')[0]);
+      } else {
+        resolve(null);
+      }
+    });
+  });
+}
+
+/** Default HTTP fetcher — adapts global fetch to our HttpResponse shape. */
+async function defaultHttpFn(url: string): Promise<HttpResponse> {
+  const res = await fetch(url, { method: 'GET', redirect: 'follow' });
+  const cl = res.headers.get('content-length');
+  const total = cl ? Number(cl) : null;
+  return {
+    ok: res.ok,
+    status: res.status,
+    contentLength: Number.isFinite(total) ? total : null,
+    body: res.body ? (Readable.fromWeb(res.body as unknown as ReadableStream) as Readable) : null,
+  };
+}
+
+/**
+ * In-memory job registry. We keep at most one active install job; the
+ * registry is keyed by job id so the UI can re-fetch status by id.
+ *
+ * Singleton pattern matches the existing `runCatalogAudit` cache (one
+ * cache key per kind of operation) — install is rare enough that
+ * supporting concurrent installs would be a YAGNI win for the user.
+ */
+export class InstallBootstrap {
+  private jobs = new Map<string, InstallJob>();
+  private active: string | null = null;
+  private nextId = 1;
+
+  private readonly resolveAssetUrl: (platform: NodeJS.Platform, arch: string) => string;
+  private readonly httpFn: HttpFn;
+  private readonly spawnFn: SpawnFn;
+  private readonly getPlatform: () => NodeJS.Platform;
+  private readonly getArch: () => string;
+  private readonly detectOllamaFn: () => Promise<string | null>;
+  private readonly downloadDir: string;
+
+  constructor(opts: InstallBootstrapOptions = {}) {
+    this.resolveAssetUrl = opts.resolveAssetUrl ?? defaultResolveAssetUrl;
+    this.httpFn = opts.httpFn ?? defaultHttpFn;
+    this.spawnFn = opts.spawnFn ?? (realSpawn as unknown as SpawnFn);
+    this.getPlatform = opts.getPlatform ?? (() => process.platform);
+    this.getArch = opts.getArch ?? (() => process.arch);
+    this.detectOllamaFn = opts.detectOllama ?? (() => defaultDetectOllama(this.spawnFn));
+    this.downloadDir = opts.downloadDir ?? tmpdir();
+  }
+
+  /** Detect Ollama without kicking off a job. Used by GET /detect. */
+  async detect(): Promise<{ installed: boolean; version: string | null }> {
+    const version = await this.detectOllamaFn();
+    return { installed: version !== null, version };
+  }
+
+  /** Get the current job snapshot (or null if no install kicked yet). */
+  getJob(id: string): InstallJob | null {
+    return this.jobs.get(id) ?? null;
+  }
+
+  /** Get the most-recent / active job, or null. */
+  getActiveJob(): InstallJob | null {
+    return this.active ? this.jobs.get(this.active) ?? null : null;
+  }
+
+  /**
+   * Kick off (or resume) an install job. Returns the job snapshot
+   * synchronously — the actual work runs in the background and the
+   * caller polls GET /install/:id for status.
+   */
+  start(): InstallJob {
+    /* If a job is already active (not terminal), return it as-is rather
+       than spawning a parallel install. Last writer wins on terminal
+       states; the UI is expected to remove a finished job before
+       starting a new one. */
+    const existing = this.getActiveJob();
+    if (existing && existing.status !== 'installed' && existing.status !== 'error') {
+      return existing;
+    }
+    const id = String(this.nextId++);
+    const platform = this.getPlatform();
+    const arch = this.getArch();
+    const job: InstallJob = {
+      id,
+      status: 'detecting',
+      platform,
+      arch,
+      bytesReceived: 0,
+      bytesTotal: null,
+      manualInstallerPath: null,
+      error: null,
+      startedAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    this.jobs.set(id, job);
+    this.active = id;
+    /* Fire-and-forget the state machine. The catch is the safety net —
+       any throw inside `run` lands in the job's error state. */
+    void this.run(job).catch((err) => {
+      this.transition(job, 'error', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+    return job;
+  }
+
+  /** Drive the job through its states. Pure side-effect; mutates the
+      job in the registry as it progresses. */
+  private async run(job: InstallJob): Promise<void> {
+    /* Step 1: detect. If Ollama is already on PATH, short-circuit
+       straight to installed without touching the network. This is the
+       common case for upgrade-flow users who already have Ollama from
+       a prior install. */
+    const existing = await this.detectOllamaFn();
+    if (existing !== null) {
+      this.transition(job, 'installed');
+      return;
+    }
+
+    /* Step 2: resolve + download. We refuse to spawn before the bytes
+       are on disk so a half-download doesn't leave a corrupt
+       installer in the temp dir. */
+    const url = this.resolveAssetUrl(job.platform, job.arch);
+    this.transition(job, 'downloading');
+    const destPath = await this.download(job, url);
+
+    /* Step 3: install. Windows uses a GUI .exe — we surface the path
+       and stop, letting the user double-click. macOS/Linux use a
+       headless install script or tarball, which we can run directly. */
+    if (job.platform === 'win32') {
+      this.transition(job, 'installing', { manualInstallerPath: destPath });
+      /* Mark installed only after the user finishes; the UI re-probes
+         via POST /install/:id/recheck. */
+      return;
+    }
+
+    this.transition(job, 'installing');
+    await this.runInstaller(destPath, job.platform);
+
+    /* Step 4: re-probe. The installer succeeded — confirm Ollama is
+       now on PATH. */
+    const post = await this.detectOllamaFn();
+    if (post === null) {
+      this.transition(job, 'error', {
+        error: 'Installer ran but `ollama -v` still failed. Restart your shell or check the install logs.',
+      });
+      return;
+    }
+    this.transition(job, 'installed');
+  }
+
+  /** Manually re-probe Ollama (used for the Windows GUI install path
+      and any "Refresh" affordance). Promotes the job to installed if
+      the probe succeeds, leaves it in installing otherwise. */
+  async recheck(id: string): Promise<InstallJob | null> {
+    const job = this.jobs.get(id);
+    if (!job) return null;
+    const v = await this.detectOllamaFn();
+    if (v !== null && (job.status === 'installing' || job.status === 'error')) {
+      this.transition(job, 'installed');
+    }
+    return this.jobs.get(id) ?? null;
+  }
+
+  private async download(job: InstallJob, url: string): Promise<string> {
+    const res = await this.httpFn(url);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch installer from ${url} (HTTP ${res.status})`);
+    }
+    if (!res.body) {
+      throw new Error(`Installer response from ${url} had no body.`);
+    }
+    if (res.contentLength) {
+      this.update(job, { bytesTotal: res.contentLength });
+    }
+    await mkdir(this.downloadDir, { recursive: true });
+    const filename = url.split('/').pop() ?? 'ollama-installer.bin';
+    const destPath = join(this.downloadDir, filename);
+    const out = createWriteStream(destPath);
+    let received = 0;
+    const stream = res.body;
+    await new Promise<void>((resolve, reject) => {
+      stream.on('data', (chunk: Buffer) => {
+        received += chunk.length;
+        /* Throttle update writes — every 256 KB is enough for a smooth
+           progress bar without thrashing the job-poll layer. */
+        if (received - job.bytesReceived >= 256 * 1024) {
+          this.update(job, { bytesReceived: received });
+        }
+      });
+      stream.on('end', () => {
+        this.update(job, { bytesReceived: received });
+        out.end(resolve);
+      });
+      stream.on('error', reject);
+      stream.pipe(out);
+    });
+    /* Sanity check: a < 1 KB "download" is almost certainly an error
+       page, not the real binary. */
+    const s = await stat(destPath);
+    if (s.size < 1024) {
+      throw new Error(
+        `Downloaded installer from ${url} is only ${s.size} bytes — likely an error page, not the real binary.`,
+      );
+    }
+    return destPath;
+  }
+
+  private async runInstaller(path: string, platform: NodeJS.Platform): Promise<void> {
+    if (platform === 'darwin') {
+      /* macOS: the zip drops Ollama.app — we extract via `unzip` (BSD
+         system tool) into /Applications/. We don't auto-launch the
+         app — the user kicks it manually after the install completes,
+         keeping the GUI-app contract honest. */
+      await this.spawnAndWait('unzip', ['-o', path, '-d', '/Applications/']);
+      return;
+    }
+    if (platform === 'linux') {
+      /* Linux: chmod +x then run the bash installer script that
+         downloaded earlier. The vendor script wraps tarball-extract +
+         systemd unit + PATH update. */
+      await chmod(path, 0o755);
+      await this.spawnAndWait('bash', [path]);
+      return;
+    }
+    throw new Error(`runInstaller does not support platform '${platform}'.`);
+  }
+
+  private spawnAndWait(cmd: string, args: readonly string[]): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const proc = this.spawnFn(cmd, args);
+      proc.on('error', reject);
+      proc.on('close', (code) => {
+        if (code === 0) resolve();
+        else reject(new Error(`${cmd} exited with code ${code}`));
+      });
+    });
+  }
+
+  /** Atomically transition + update job state. Mutates in place +
+      bumps updatedAt so the UI can sense progress. */
+  private transition(
+    job: InstallJob,
+    status: InstallJobStatus,
+    extra: Partial<InstallJob> = {},
+  ): void {
+    job.status = status;
+    Object.assign(job, extra);
+    job.updatedAt = Date.now();
+  }
+
+  private update(job: InstallJob, patch: Partial<InstallJob>): void {
+    Object.assign(job, patch);
+    job.updatedAt = Date.now();
+  }
+
+  /** Reset for tests — drops all jobs. */
+  _reset(): void {
+    this.jobs.clear();
+    this.active = null;
+    this.nextId = 1;
+  }
+}
+
+/** Module-level singleton. The route layer imports this; tests
+    construct their own InstallBootstrap with stubs. */
+export const installBootstrap = new InstallBootstrap();

--- a/server/src/ollama/pull-bootstrap.test.ts
+++ b/server/src/ollama/pull-bootstrap.test.ts
@@ -1,0 +1,164 @@
+/* Plan 61 — pull-bootstrap state machine.
+ *
+ * Drives the NDJSON-progress consumer end-to-end without touching a
+ * real Ollama daemon. The fetchFn is fully stubbed; the assertions
+ * focus on:
+ *   1. allowlist enforcement (the route MUST refuse non-allowlisted tags),
+ *   2. progress line consumption (bytesReceived / bytesTotal /
+ *      lastStatusMessage all flow through),
+ *   3. terminal-state transitions on "success" and on error envelopes. */
+
+import { describe, it, expect, vi } from 'vitest';
+import { PullBootstrap, DEFAULT_ALLOWED_MODELS } from './pull-bootstrap.js';
+
+function makeStreamBody(lines: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (i >= lines.length) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(encoder.encode(lines[i] + '\n'));
+      i++;
+    },
+  });
+}
+
+describe('PullBootstrap — allowlist', () => {
+  it('rejects models outside the allowlist with an error job', () => {
+    const boot = new PullBootstrap();
+    const job = boot.start('http://localhost:11434', 'evil:7b');
+    expect(job.status).toBe('error');
+    expect(job.error).toMatch(/allowlist/i);
+  });
+
+  it('accepts every default-allowed tag without going to error before fetch', () => {
+    const fetchFn = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        body: makeStreamBody(['{"status":"success"}']),
+        text: () => Promise.resolve(''),
+      }),
+    );
+    const boot = new PullBootstrap({ fetchFn });
+    for (const model of DEFAULT_ALLOWED_MODELS) {
+      const job = boot.start('http://localhost:11434', model);
+      expect(job.status).toBe('pulling');
+    }
+  });
+});
+
+describe('PullBootstrap — progress streaming', () => {
+  it('walks pulling → pulled, surfacing bytesReceived and lastStatusMessage', async () => {
+    const fetchFn = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        body: makeStreamBody([
+          '{"status":"pulling manifest"}',
+          '{"status":"downloading","total":4096,"completed":1024}',
+          '{"status":"downloading","total":4096,"completed":4096}',
+          '{"status":"verifying sha256 digest"}',
+          '{"status":"success"}',
+        ]),
+        text: () => Promise.resolve(''),
+      }),
+    );
+    const boot = new PullBootstrap({ fetchFn });
+    const job = boot.start('http://localhost:11434', 'qwen3.5:4b');
+    for (let i = 0; i < 200; i++) {
+      await new Promise((r) => setImmediate(r));
+      if (boot.getJob(job.id)?.status === 'pulled') break;
+    }
+    const j = boot.getJob(job.id);
+    expect(j?.status).toBe('pulled');
+    expect(j?.bytesReceived).toBe(4096);
+    expect(j?.bytesTotal).toBe(4096);
+    expect(j?.lastStatusMessage).toBe('success');
+  });
+
+  it('transitions to error when Ollama responds non-2xx', async () => {
+    const fetchFn = vi.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        body: null,
+        text: () => Promise.resolve('upstream blew up'),
+      }),
+    );
+    const boot = new PullBootstrap({ fetchFn });
+    const job = boot.start('http://localhost:11434', 'qwen3.5:4b');
+    for (let i = 0; i < 200; i++) {
+      await new Promise((r) => setImmediate(r));
+      if (boot.getJob(job.id)?.status === 'error') break;
+    }
+    const j = boot.getJob(job.id);
+    expect(j?.status).toBe('error');
+    expect(j?.error).toMatch(/500/);
+  });
+
+  it('transitions to error when an NDJSON line carries error', async () => {
+    const fetchFn = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        body: makeStreamBody([
+          '{"status":"pulling manifest"}',
+          '{"error":"pull model manifest: file does not exist"}',
+        ]),
+        text: () => Promise.resolve(''),
+      }),
+    );
+    const boot = new PullBootstrap({ fetchFn });
+    const job = boot.start('http://localhost:11434', 'qwen3.5:4b');
+    for (let i = 0; i < 200; i++) {
+      await new Promise((r) => setImmediate(r));
+      if (boot.getJob(job.id)?.status === 'error') break;
+    }
+    const j = boot.getJob(job.id);
+    expect(j?.status).toBe('error');
+    expect(j?.error).toMatch(/file does not exist/);
+  });
+
+  it('coalesces a second start() for the same model into the active job', () => {
+    const fetchFn = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        /* Never-emitting stream keeps the job pinned in "pulling". */
+        body: new ReadableStream({ pull() { /* idle */ } }),
+        text: () => Promise.resolve(''),
+      }),
+    );
+    const boot = new PullBootstrap({ fetchFn });
+    const a = boot.start('http://localhost:11434', 'qwen3.5:4b');
+    const b = boot.start('http://localhost:11434', 'qwen3.5:4b');
+    expect(b.id).toBe(a.id);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT coalesce a pull for a different model', () => {
+    const fetchFn = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        body: new ReadableStream({ pull() { /* idle */ } }),
+        text: () => Promise.resolve(''),
+      }),
+    );
+    const boot = new PullBootstrap({ fetchFn });
+    const a = boot.start('http://localhost:11434', 'qwen3.5:4b');
+    const b = boot.start('http://localhost:11434', 'llama3.1:8b');
+    expect(b.id).not.toBe(a.id);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/server/src/ollama/pull-bootstrap.ts
+++ b/server/src/ollama/pull-bootstrap.ts
@@ -1,0 +1,224 @@
+/* Plan 61 — in-app `ollama pull` proxy.
+ *
+ * Wraps the local Ollama daemon's POST /api/pull endpoint and tracks
+ * progress for the UI. Unlike install-bootstrap.ts (which handles
+ * "Ollama itself isn't on the box yet"), this assumes the daemon is
+ * already up — we hit its native pull endpoint and surface streamed
+ * progress.
+ *
+ * State machine:
+ *   idle → pulling → pulled
+ *                 └─ error
+ *
+ * The Ollama upstream API is NDJSON-streamed:
+ *   {"status":"pulling manifest"}
+ *   {"status":"downloading","digest":"sha256:…","total":…,"completed":…}
+ *   {"status":"verifying sha256 digest"}
+ *   {"status":"writing manifest"}
+ *   {"status":"success"}
+ *
+ * We collapse those into one progress envelope (lastStatus + bytes).
+ * On the legacy non-streaming path we just wait for the final response.
+ *
+ * Dependency-injectable: `fetchFn` is a constructor param so tests
+ * never hit a live Ollama. The route does not auto-pull — it only
+ * pulls the model the user explicitly clicked to pull.
+ */
+
+export type PullJobStatus = 'idle' | 'pulling' | 'pulled' | 'error';
+
+export interface PullJob {
+  id: string;
+  model: string;
+  status: PullJobStatus;
+  lastStatusMessage: string;
+  bytesReceived: number;
+  bytesTotal: number | null;
+  error: string | null;
+  startedAt: number;
+  updatedAt: number;
+}
+
+export type FetchFn = (
+  url: string,
+  init: { method: string; body: string; signal?: AbortSignal },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  statusText: string;
+  body: ReadableStream<Uint8Array> | null;
+  text(): Promise<string>;
+}>;
+
+export interface PullBootstrapOptions {
+  fetchFn?: FetchFn;
+  /** Allowlist of model tags the route is willing to pull. Defaults to
+      the analyzer-supported set in src/lib/models.ts; the route layer
+      enforces this so the user can't /pull arbitrary upstream tags. */
+  allowedModels?: ReadonlySet<string>;
+}
+
+/** Conservative allowlist — mirrors the analyzer's MODEL_OPTIONS so the
+    UI can only pull tags the rest of the app actually supports. */
+export const DEFAULT_ALLOWED_MODELS: ReadonlySet<string> = new Set([
+  'qwen3.5:4b',
+  'qwen3.5:9b',
+  'llama3.1:8b',
+  'llama3.2:3b',
+  'gemma3:4b',
+]);
+
+const defaultFetchFn: FetchFn = (url, init) =>
+  fetch(url, init) as unknown as ReturnType<FetchFn>;
+
+export class PullBootstrap {
+  private jobs = new Map<string, PullJob>();
+  private active: string | null = null;
+  private nextId = 1;
+  private readonly fetchFn: FetchFn;
+  private readonly allowedModels: ReadonlySet<string>;
+
+  constructor(opts: PullBootstrapOptions = {}) {
+    this.fetchFn = opts.fetchFn ?? defaultFetchFn;
+    this.allowedModels = opts.allowedModels ?? DEFAULT_ALLOWED_MODELS;
+  }
+
+  isAllowed(model: string): boolean {
+    return this.allowedModels.has(model);
+  }
+
+  getJob(id: string): PullJob | null {
+    return this.jobs.get(id) ?? null;
+  }
+
+  getActiveJob(): PullJob | null {
+    return this.active ? this.jobs.get(this.active) ?? null : null;
+  }
+
+  /** Kick off a pull for `model` against `ollamaUrl`. Returns the
+      job snapshot synchronously; UI polls GET /pull/:id for progress. */
+  start(ollamaUrl: string, model: string): PullJob {
+    if (!this.isAllowed(model)) {
+      const id = String(this.nextId++);
+      const job: PullJob = {
+        id,
+        model,
+        status: 'error',
+        lastStatusMessage: '',
+        bytesReceived: 0,
+        bytesTotal: null,
+        error: `Model '${model}' is not in the in-app pull allowlist. Pull it via the terminal if needed.`,
+        startedAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+      this.jobs.set(id, job);
+      return job;
+    }
+    /* Coalesce: if an active job is already pulling THIS model, reuse it. */
+    const existing = this.getActiveJob();
+    if (existing && existing.model === model && existing.status === 'pulling') {
+      return existing;
+    }
+    const id = String(this.nextId++);
+    const job: PullJob = {
+      id,
+      model,
+      status: 'pulling',
+      lastStatusMessage: 'pulling manifest',
+      bytesReceived: 0,
+      bytesTotal: null,
+      error: null,
+      startedAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    this.jobs.set(id, job);
+    this.active = id;
+    void this.run(job, ollamaUrl).catch((err) => {
+      this.transition(job, 'error', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+    return job;
+  }
+
+  private async run(job: PullJob, ollamaUrl: string): Promise<void> {
+    const url = `${ollamaUrl.replace(/\/+$/, '')}/api/pull`;
+    const res = await this.fetchFn(url, {
+      method: 'POST',
+      body: JSON.stringify({ name: job.model, stream: true }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`Ollama /api/pull returned ${res.status} ${res.statusText}: ${text.slice(0, 200)}`);
+    }
+    if (!res.body) {
+      /* Non-streamed response — we treat any 2xx as success. */
+      this.transition(job, 'pulled', { lastStatusMessage: 'success' });
+      return;
+    }
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder('utf-8');
+    let lineBuf = '';
+    for (;;) {
+      const result = await reader.read();
+      if (result.done) break;
+      lineBuf += decoder.decode(result.value, { stream: true });
+      let nl: number;
+      while ((nl = lineBuf.indexOf('\n')) >= 0) {
+        const line = lineBuf.slice(0, nl).trim();
+        lineBuf = lineBuf.slice(nl + 1);
+        if (!line) continue;
+        this.consumeProgressLine(job, line);
+      }
+    }
+    if (job.status === 'pulling') {
+      this.transition(job, 'pulled', { lastStatusMessage: 'success' });
+    }
+  }
+
+  private consumeProgressLine(job: PullJob, line: string): void {
+    let parsed: {
+      status?: string;
+      total?: number;
+      completed?: number;
+      error?: string;
+    };
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      /* Ollama very occasionally emits keep-alive noise; skip. */
+      return;
+    }
+    if (parsed.error) {
+      this.transition(job, 'error', { error: parsed.error });
+      return;
+    }
+    const patch: Partial<PullJob> = {};
+    if (parsed.status) patch.lastStatusMessage = parsed.status;
+    if (typeof parsed.completed === 'number') patch.bytesReceived = parsed.completed;
+    if (typeof parsed.total === 'number') patch.bytesTotal = parsed.total;
+    this.update(job, patch);
+    if (parsed.status === 'success') {
+      this.transition(job, 'pulled', { lastStatusMessage: 'success' });
+    }
+  }
+
+  private transition(job: PullJob, status: PullJobStatus, extra: Partial<PullJob> = {}): void {
+    job.status = status;
+    Object.assign(job, extra);
+    job.updatedAt = Date.now();
+  }
+
+  private update(job: PullJob, patch: Partial<PullJob>): void {
+    Object.assign(job, patch);
+    job.updatedAt = Date.now();
+  }
+
+  _reset(): void {
+    this.jobs.clear();
+    this.active = null;
+    this.nextId = 1;
+  }
+}
+
+export const pullBootstrap = new PullBootstrap();

--- a/server/src/routes/ollama-health.test.ts
+++ b/server/src/routes/ollama-health.test.ts
@@ -5,8 +5,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import express from 'express';
 import request from 'supertest';
-import { ollamaHealthRouter } from './ollama-health.js';
+import {
+  ollamaHealthRouter,
+  setOllamaBootstraps,
+  _resetOllamaBootstraps,
+} from './ollama-health.js';
 import { _resetUserSettingsCache } from '../workspace/user-settings.js';
+import { InstallBootstrap } from '../ollama/install-bootstrap.js';
+import { PullBootstrap } from '../ollama/pull-bootstrap.js';
 
 function makeApp() {
   const app = express();
@@ -25,6 +31,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  _resetOllamaBootstraps();
 });
 
 /* /api/ollama/health now fans out across /api/tags AND /api/ps so the
@@ -196,5 +203,142 @@ describe('POST /api/ollama/unload', () => {
     const res = await request(makeApp()).post('/api/ollama/unload');
     expect(res.status).toBe(503);
     expect(res.body.status).toBe('error');
+  });
+});
+
+/* ============================================================
+ * Plan 61 — install / pull / refresh
+ * ============================================================ */
+
+describe('GET /api/ollama/detect', () => {
+  it('returns installed:true with the version when ollama is on PATH', async () => {
+    setOllamaBootstraps({
+      install: new InstallBootstrap({
+        detectOllama: () => Promise.resolve('ollama version 0.5.4'),
+      }),
+    });
+    const res = await request(makeApp()).get('/api/ollama/detect');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ installed: true, version: 'ollama version 0.5.4' });
+  });
+
+  it('returns installed:false when ollama is missing', async () => {
+    setOllamaBootstraps({
+      install: new InstallBootstrap({ detectOllama: () => Promise.resolve(null) }),
+    });
+    const res = await request(makeApp()).get('/api/ollama/detect');
+    expect(res.body).toEqual({ installed: false, version: null });
+  });
+});
+
+describe('POST /api/ollama/install', () => {
+  it('starts a job and returns 202 with the initial snapshot', async () => {
+    setOllamaBootstraps({
+      install: new InstallBootstrap({
+        detectOllama: () => Promise.resolve('ollama version 0.5.4'),
+      }),
+    });
+    const res = await request(makeApp()).post('/api/ollama/install');
+    expect(res.status).toBe(202);
+    expect(res.body.id).toBeTruthy();
+    expect(['detecting', 'installed']).toContain(res.body.status);
+  });
+
+  it('GET /api/ollama/install/:id returns 404 for unknown id', async () => {
+    setOllamaBootstraps({ install: new InstallBootstrap() });
+    const res = await request(makeApp()).get('/api/ollama/install/does-not-exist');
+    expect(res.status).toBe(404);
+  });
+
+  it('GET /api/ollama/install/:id returns the job snapshot for a real id', async () => {
+    setOllamaBootstraps({
+      install: new InstallBootstrap({
+        detectOllama: () => Promise.resolve('ollama version 0.5.4'),
+      }),
+    });
+    const post = await request(makeApp()).post('/api/ollama/install');
+    const id = post.body.id;
+    /* short-circuit means it might already be installed */
+    await new Promise((r) => setImmediate(r));
+    const get = await request(makeApp()).get(`/api/ollama/install/${id}`);
+    expect(get.status).toBe(200);
+    expect(get.body.id).toBe(id);
+  });
+});
+
+describe('POST /api/ollama/pull', () => {
+  it('400s on missing model body', async () => {
+    setOllamaBootstraps({ pull: new PullBootstrap() });
+    const res = await request(makeApp())
+      .post('/api/ollama/pull')
+      .send({})
+      .set('Content-Type', 'application/json');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/model/);
+  });
+
+  it('400s on non-allowlisted model tag', async () => {
+    setOllamaBootstraps({ pull: new PullBootstrap() });
+    const res = await request(makeApp())
+      .post('/api/ollama/pull')
+      .send({ model: 'evil-narrator:13b' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/allowlist/);
+  });
+
+  it('starts a pull job and returns 202 with the initial snapshot', async () => {
+    /* Stub fetch on the bootstrap so no real Ollama is needed. */
+    const fakeFetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        body: new ReadableStream({
+          pull(controller) {
+            controller.enqueue(new TextEncoder().encode('{"status":"success"}\n'));
+            controller.close();
+          },
+        }),
+        text: () => Promise.resolve(''),
+      }),
+    );
+    setOllamaBootstraps({ pull: new PullBootstrap({ fetchFn: fakeFetch }) });
+    const res = await request(makeApp())
+      .post('/api/ollama/pull')
+      .send({ model: 'qwen3.5:4b' });
+    expect(res.status).toBe(202);
+    expect(res.body.status).toBe('pulling');
+    expect(res.body.model).toBe('qwen3.5:4b');
+  });
+
+  it('GET /api/ollama/pull/:id returns 404 for unknown id', async () => {
+    setOllamaBootstraps({ pull: new PullBootstrap() });
+    const res = await request(makeApp()).get('/api/ollama/pull/does-not-exist');
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/ollama/refresh', () => {
+  it('returns the same envelope as GET /health when the daemon answers', async () => {
+    mockOllamaProbes({
+      tags: [{ name: 'qwen3.5:4b' }],
+      ps: [{ name: 'qwen3.5:4b' }],
+    });
+    const res = await request(makeApp()).post('/api/ollama/refresh');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('reachable');
+    expect(res.body.models).toEqual(['qwen3.5:4b']);
+    expect(res.body.modelPulled).toBe(true);
+    expect(res.body.modelResident).toBe(true);
+  });
+
+  it('returns unreachable when the daemon refuses connection', async () => {
+    fetchMock.mockRejectedValue(
+      Object.assign(new TypeError('fetch failed'), {
+        cause: Object.assign(new Error('ECONNREFUSED'), { code: 'ECONNREFUSED' }),
+      }),
+    );
+    const res = await request(makeApp()).post('/api/ollama/refresh');
+    expect(res.body.status).toBe('unreachable');
   });
 });

--- a/server/src/routes/ollama-health.ts
+++ b/server/src/routes/ollama-health.ts
@@ -10,8 +10,35 @@
 import { Router, type Request, type Response } from 'express';
 import { getResolvedOllamaUrl, getResolvedOllamaModel } from '../workspace/user-settings.js';
 import { ANALYZER_NUM_CTX, ANALYZER_NUM_GPU } from '../analyzer/ollama.js';
+import {
+  installBootstrap as defaultInstallBootstrap,
+  type InstallBootstrap,
+} from '../ollama/install-bootstrap.js';
+import {
+  pullBootstrap as defaultPullBootstrap,
+  type PullBootstrap,
+} from '../ollama/pull-bootstrap.js';
 
 export const ollamaHealthRouter = Router();
+
+/* Plan 61 — injectable bootstraps. The default exports are the
+   module-level singletons; tests swap them via setOllamaBootstraps() so
+   the entire install/pull surface can run offline. */
+let installBootstrap: InstallBootstrap = defaultInstallBootstrap;
+let pullBootstrap: PullBootstrap = defaultPullBootstrap;
+
+export function setOllamaBootstraps(opts: {
+  install?: InstallBootstrap;
+  pull?: PullBootstrap;
+}): void {
+  if (opts.install) installBootstrap = opts.install;
+  if (opts.pull) pullBootstrap = opts.pull;
+}
+
+export function _resetOllamaBootstraps(): void {
+  installBootstrap = defaultInstallBootstrap;
+  pullBootstrap = defaultPullBootstrap;
+}
 
 /* Same 2s budget as the sidecar probe: a hung daemon mustn't pin a UI
    polling request. Ollama's /api/tags is a list of pulled models — trivial
@@ -211,4 +238,146 @@ ollamaHealthRouter.post('/unload', async (_req: Request, res: Response) => {
     return res.status(result.status).json({ status: 'error', error: result.error });
   }
   return res.json({ status: 'unloaded' });
+});
+
+/* ============================================================
+ * Plan 61 — in-app multi-model management UX
+ * ============================================================
+ *
+ * GET  /api/ollama/detect       — is `ollama` already on PATH?
+ * POST /api/ollama/install      — kick off the vendor installer download
+ * GET  /api/ollama/install/:id  — poll install-job progress
+ * POST /api/ollama/install/:id/recheck — re-probe (used after Windows GUI install)
+ * POST /api/ollama/pull         — start `ollama pull <model>`
+ * GET  /api/ollama/pull/:id     — poll pull-job progress
+ * POST /api/ollama/refresh      — re-probe daemon + return /health envelope
+ *
+ * Endpoints are designed so the UI never has to drop to a terminal.
+ * Test injection: setOllamaBootstraps({...}) above swaps in mocked
+ * InstallBootstrap / PullBootstrap so tests run offline. */
+
+ollamaHealthRouter.get('/detect', async (_req: Request, res: Response) => {
+  const result = await installBootstrap.detect();
+  return res.json(result);
+});
+
+ollamaHealthRouter.post('/install', (_req: Request, res: Response) => {
+  const job = installBootstrap.start();
+  return res.status(202).json(job);
+});
+
+ollamaHealthRouter.get('/install/:id', (req: Request, res: Response) => {
+  const job = installBootstrap.getJob(req.params.id);
+  if (!job) {
+    return res.status(404).json({ error: `No install job '${req.params.id}'` });
+  }
+  return res.json(job);
+});
+
+ollamaHealthRouter.post('/install/:id/recheck', async (req: Request, res: Response) => {
+  const job = await installBootstrap.recheck(req.params.id);
+  if (!job) {
+    return res.status(404).json({ error: `No install job '${req.params.id}'` });
+  }
+  return res.json(job);
+});
+
+ollamaHealthRouter.post('/pull', (req: Request, res: Response) => {
+  const model = typeof req.body?.model === 'string' ? req.body.model.trim() : '';
+  if (!model) {
+    return res.status(400).json({ error: 'Body must include { model: <tag> }' });
+  }
+  if (!pullBootstrap.isAllowed(model)) {
+    return res.status(400).json({
+      error: `Model '${model}' is not in the in-app pull allowlist. Pull it via the terminal if needed.`,
+    });
+  }
+  const job = pullBootstrap.start(getResolvedOllamaUrl(), model);
+  return res.status(202).json(job);
+});
+
+ollamaHealthRouter.get('/pull/:id', (req: Request, res: Response) => {
+  const job = pullBootstrap.getJob(req.params.id);
+  if (!job) {
+    return res.status(404).json({ error: `No pull job '${req.params.id}'` });
+  }
+  return res.json(job);
+});
+
+/* POST /api/ollama/refresh — a thin alias for the existing GET /health.
+   The UI uses POST semantically ("re-probe now") and we re-export the
+   same envelope so the dropdown updates without a page reload. */
+ollamaHealthRouter.post('/refresh', async (_req: Request, res: Response) => {
+  /* Inline-dispatch into the existing GET handler by re-invoking the
+     same probe. We can't just `res.redirect()` because the caller wants
+     the body now, and the GET handler isn't memoised. Easiest: build a
+     fake req+res chain. Instead we just re-implement the small probe
+     here — it's already a one-liner that returns the JSON. */
+  const url = getResolvedOllamaUrl();
+  const expectedModel = getResolvedOllamaModel();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+  try {
+    const [tagsResp, psResp] = await Promise.all([
+      fetch(`${url}/api/tags`, { method: 'GET', signal: controller.signal }),
+      fetch(`${url}/api/ps`, { method: 'GET', signal: controller.signal }),
+    ]);
+    clearTimeout(timer);
+    if (!tagsResp.ok) {
+      return res.json({
+        status: 'unreachable',
+        url,
+        error: `Ollama returned ${tagsResp.status} ${tagsResp.statusText}`,
+      });
+    }
+    const tagsBody = (await tagsResp.json().catch(() => ({}))) as {
+      models?: Array<{ name?: string; model?: string }>;
+    };
+    const models = Array.isArray(tagsBody.models)
+      ? tagsBody.models.map((m) => m.name ?? m.model ?? '').filter(Boolean)
+      : [];
+    const expectedRoot = expectedModel.split(':')[0];
+    const hasExpected = models.some(
+      (m) =>
+        m === expectedModel ||
+        m.startsWith(`${expectedModel}-`) ||
+        (m.split(':')[0] === expectedRoot && m.startsWith(`${expectedRoot}:`)),
+    );
+    let resident: string[] = [];
+    let expectedResident = false;
+    if (psResp.ok) {
+      const psBody = (await psResp.json().catch(() => ({}))) as {
+        models?: Array<{ name?: string; model?: string }>;
+      };
+      resident = Array.isArray(psBody.models)
+        ? psBody.models.map((m) => m.name ?? m.model ?? '').filter(Boolean)
+        : [];
+      expectedResident = resident.some(
+        (m) =>
+          m === expectedModel ||
+          m.startsWith(`${expectedModel}-`) ||
+          (m.split(':')[0] === expectedRoot && m.startsWith(`${expectedRoot}:`)),
+      );
+    }
+    return res.json({
+      status: 'reachable',
+      url,
+      models,
+      expectedModel,
+      modelPulled: hasExpected,
+      resident,
+      modelResident: expectedResident,
+    });
+  } catch (e) {
+    clearTimeout(timer);
+    const err = e as { name?: string; message?: string };
+    const isTimeout = err.name === 'AbortError';
+    return res.json({
+      status: 'unreachable',
+      url,
+      error: isTimeout
+        ? `No response from ${url} within ${PROBE_TIMEOUT_MS}ms`
+        : err.message || 'Ollama fetch failed.',
+    });
+  }
 });

--- a/server/tts-sidecar/scripts/install-coqui.ps1
+++ b/server/tts-sidecar/scripts/install-coqui.ps1
@@ -1,0 +1,102 @@
+# install-coqui.ps1 -- pre-fetch the Coqui XTTS v2 model weights so the
+# sidecar doesn't pay the ~2 GB download tax on the first synth call.
+#
+# Plan 61: parallel to install-kokoro.ps1, ships in the release bundle
+# so a Windows deployer who wants XTTS doesn't have to drop to a terminal.
+#
+# Strategy mirrors install-coqui.sh exactly:
+#   - locate the sidecar venv's python.exe
+#   - point TTS_HOME at server/tts-sidecar/voices/coqui/
+#   - invoke `python -c "from TTS.api import TTS; TTS('xtts_v2')"` to
+#     trigger the lib's auto-downloader into TTS_HOME
+#   - skip if XTTS-v2 manifest dir is already present
+#
+# ASCII-only per repo convention (Windows PowerShell 5.1 reads UTF-8
+# without BOM as Win-1252 and mojibakes em-dashes/smart-quotes).
+
+[CmdletBinding()]
+param(
+    [string]$TargetDir = ''
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Step([string]$msg) {
+    Write-Host "[install-coqui] $msg"
+}
+
+# Resolve script + sidecar dirs at runtime.
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+if (-not $ScriptDir) {
+    $ScriptDir = (Get-Location).Path
+}
+$SidecarDir = (Resolve-Path -LiteralPath (Join-Path $ScriptDir '..')).Path
+
+if (-not $TargetDir) {
+    $TargetDir = Join-Path $SidecarDir 'voices\coqui'
+}
+
+# Locate python in the sidecar venv. Two layouts to try:
+$Python = $null
+$candidates = @(
+    (Join-Path $SidecarDir '.venv\Scripts\python.exe'),
+    (Join-Path $SidecarDir '.venv\bin\python.exe'),
+    (Join-Path $SidecarDir '.venv\bin\python')
+)
+foreach ($cand in $candidates) {
+    if (Test-Path -LiteralPath $cand) {
+        $Python = $cand
+        break
+    }
+}
+
+if (-not $Python) {
+    Write-Step "FAIL: sidecar venv not bootstrapped at $SidecarDir\.venv."
+    Write-Step "      Run 'python -m venv .venv; .venv\Scripts\pip install -r requirements.txt'"
+    Write-Step "      from $SidecarDir first, then re-run this script."
+    exit 1
+}
+
+if (-not (Test-Path -LiteralPath $TargetDir)) {
+    Write-Step "Creating $TargetDir"
+    New-Item -ItemType Directory -Path $TargetDir -Force | Out-Null
+}
+
+# Skip download when the manifest dir is already populated.
+$XttsDir = Join-Path $TargetDir 'tts\tts_models--multilingual--multi-dataset--xtts_v2'
+$ModelPath = Join-Path $XttsDir 'model.pth'
+$ConfigPath = Join-Path $XttsDir 'config.json'
+
+if ((Test-Path -LiteralPath $ModelPath) -and (Test-Path -LiteralPath $ConfigPath)) {
+    Write-Step "Skipping -- XTTS v2 weights already present at $XttsDir"
+    exit 0
+}
+
+Write-Step "Pre-fetching XTTS v2 into $TargetDir via the TTS lib (~1.8 GB, expect 2-5 min on a fast link)..."
+
+# Force a Python that uses our TTS_HOME and silently agrees to the
+# license click-through (script invocation is the consent).
+$env:TTS_HOME = $TargetDir
+$env:COQUI_TOS_AGREED = '1'
+
+# Use TLS 1.2 for any pip-style fallback. The TTS lib uses requests under
+# the hood, which honours the system trust store.
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+
+$pyArgs = @('-c', "from TTS.api import TTS; TTS('tts_models/multilingual/multi-dataset/xtts_v2')")
+& $Python @pyArgs
+if ($LASTEXITCODE -ne 0) {
+    Write-Step "FAIL: XTTS v2 pre-fetch failed. Check network + sidecar venv."
+    exit 1
+}
+
+if (-not (Test-Path -LiteralPath $ModelPath)) {
+    Write-Step "FAIL: model.pth not at $XttsDir after fetch. Lib changed path?"
+    exit 1
+}
+
+$size = (Get-Item -LiteralPath $ModelPath).Length
+$mb = [math]::Round($size / 1MB, 1)
+Write-Step "Done. XTTS v2 weights at $XttsDir (model.pth $mb MB)."
+Write-Step "Restart the sidecar with PRELOAD_COQUI=1 to eagerly load on boot,"
+Write-Step "or leave defaults to load XTTS lazily on first synth call."

--- a/server/tts-sidecar/scripts/install-coqui.sh
+++ b/server/tts-sidecar/scripts/install-coqui.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# install-coqui.sh -- pre-fetch the Coqui XTTS v2 model weights so the
+# sidecar doesn't pay the ~2 GB download tax on the first synth call.
+#
+# Plan 61: parallel to install-kokoro.sh, ships in the release bundle
+# so a deployer who wants XTTS doesn't have to drop to a terminal.
+#
+# Strategy:
+#   The official path is `coqui-tts` / `TTS` Python lib's auto-downloader.
+#   We invoke it directly from the sidecar venv with TTS_HOME pointed at
+#   the sidecar's `voices/coqui/` so the weights land in a known place
+#   (vs. the per-user $HOME/.local/share/tts default).
+#
+#   The first import triggers the download from
+#     https://huggingface.co/coqui/XTTS-v2 (model.pth + config.json +
+#     vocab.json + speakers_xtts.pth)
+#   into TTS_HOME. Total ~1.8 GB. We don't re-download if the manifest
+#   directory already exists -- the Python lib handles idempotency.
+#
+# Idempotent: re-runs skip when XTTS-v2 is already present.
+# Failure-tolerant: a half-finished download leaves a partial dir that
+# the Python lib will resume on next run.
+#
+# Cross-platform: tested on macOS (zsh + bash) and Ubuntu/Debian. The
+# .ps1 variant remains the Windows path.
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SIDECAR_DIR="$( cd "${SCRIPT_DIR}/.." && pwd )"
+TARGET_DIR="${TARGET_DIR:-${SIDECAR_DIR}/voices/coqui}"
+
+log() {
+    echo "[install-coqui] $*"
+}
+
+# Locate the sidecar venv's python. Two layouts to support:
+#   - server/tts-sidecar/.venv/bin/python   (POSIX)
+#   - server/tts-sidecar/.venv/Scripts/python.exe (Windows under WSL, etc.)
+# We prefer POSIX; if neither exists, we ask the user to bootstrap the venv.
+PY=""
+if [[ -x "${SIDECAR_DIR}/.venv/bin/python" ]]; then
+    PY="${SIDECAR_DIR}/.venv/bin/python"
+elif [[ -x "${SIDECAR_DIR}/.venv/bin/python3" ]]; then
+    PY="${SIDECAR_DIR}/.venv/bin/python3"
+else
+    log "FAIL: sidecar venv not bootstrapped at ${SIDECAR_DIR}/.venv."
+    log "      Run 'python3 -m venv .venv && .venv/bin/pip install -r requirements.txt'"
+    log "      from ${SIDECAR_DIR} first, then re-run this script."
+    exit 1
+fi
+
+mkdir -p "${TARGET_DIR}"
+
+# Skip the download when the model dir already has the manifest files
+# the XTTS loader expects. The lib persists into
+# $TTS_HOME/tts/tts_models--multilingual--multi-dataset--xtts_v2/
+# but we set TTS_HOME so it lands directly under TARGET_DIR.
+XTTS_DIR="${TARGET_DIR}/tts/tts_models--multilingual--multi-dataset--xtts_v2"
+if [[ -f "${XTTS_DIR}/model.pth" && -f "${XTTS_DIR}/config.json" ]]; then
+    log "Skipping -- XTTS v2 weights already present at ${XTTS_DIR}"
+    exit 0
+fi
+
+log "Pre-fetching XTTS v2 into ${TARGET_DIR} via the TTS lib (~1.8 GB, expect 2-5 min on a fast link)..."
+
+# The Python TTS lib agrees to a license click-through on first use; we
+# auto-accept here since the script's invocation is itself the consent.
+# TOS env var is the documented bypass:
+#   https://github.com/coqui-ai/TTS/blob/main/TTS/utils/manage.py
+export TTS_HOME="${TARGET_DIR}"
+export COQUI_TOS_AGREED=1
+
+if ! "${PY}" -c "from TTS.api import TTS; TTS('tts_models/multilingual/multi-dataset/xtts_v2')"; then
+    log "FAIL: XTTS v2 pre-fetch failed. Check network + sidecar venv."
+    exit 1
+fi
+
+# Sanity check.
+if [[ ! -f "${XTTS_DIR}/model.pth" ]]; then
+    log "FAIL: model.pth not at ${XTTS_DIR} after fetch. Lib changed path?"
+    exit 1
+fi
+
+SIZE=$( wc -c < "${XTTS_DIR}/model.pth" | tr -d ' ' )
+MB=$(( SIZE / 1024 / 1024 ))
+log "Done. XTTS v2 weights at ${XTTS_DIR} (model.pth ${MB} MB)."
+log "Restart the sidecar with PRELOAD_COQUI=1 to eagerly load on boot,"
+log "or leave defaults to load XTTS lazily on first synth call."

--- a/src/components/model-pull-status.test.tsx
+++ b/src/components/model-pull-status.test.tsx
@@ -1,0 +1,181 @@
+/* Plan 61 — ModelPullStatus per-row state machine. */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { ModelPullStatus } from './model-pull-status';
+
+const fetchMock = vi.fn();
+
+function jsonResponse(body: unknown, init: { status?: number } = {}) {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const PULLABLE = ['qwen3.5:4b', 'llama3.1:8b'] as const;
+
+describe('ModelPullStatus — render', () => {
+  it('marks present models with the on-disk pill and disables their Pull button', () => {
+    render(
+      <ModelPullStatus
+        pullableModels={PULLABLE}
+        health={{
+          status: 'reachable',
+          url: 'http://localhost:11434',
+          models: ['qwen3.5:4b'],
+          expectedModel: 'qwen3.5:4b',
+        }}
+      />,
+    );
+    const row = screen.getByTestId('model-row-qwen3.5:4b');
+    expect(row).toHaveTextContent(/on disk/i);
+    expect(row).toHaveTextContent(/configured default/i);
+    /* Pulled button is rendered but disabled. */
+    const btn = screen.getByTestId('model-pull-qwen3.5:4b') as HTMLButtonElement;
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveTextContent(/pulled/i);
+  });
+
+  it('shows "Not pulled yet" for absent models and enables Pull only when daemon is reachable', () => {
+    render(
+      <ModelPullStatus
+        pullableModels={PULLABLE}
+        health={{
+          status: 'reachable',
+          url: 'http://localhost:11434',
+          models: [],
+          expectedModel: 'qwen3.5:4b',
+        }}
+      />,
+    );
+    const row = screen.getByTestId('model-row-llama3.1:8b');
+    expect(row).toHaveTextContent(/not pulled yet/i);
+    expect(screen.getByTestId('model-pull-llama3.1:8b')).not.toBeDisabled();
+  });
+
+  it('disables Pull and surfaces an unreachable banner when the daemon is unreachable', () => {
+    render(
+      <ModelPullStatus
+        pullableModels={PULLABLE}
+        health={{ status: 'unreachable', url: '', error: 'ECONNREFUSED' }}
+      />,
+    );
+    expect(screen.getByText(/local ollama daemon is unreachable/i)).toBeInTheDocument();
+    expect(screen.getByTestId('model-pull-qwen3.5:4b')).toBeDisabled();
+  });
+});
+
+describe('ModelPullStatus — pull flow', () => {
+  it('clicking Pull POSTs /api/ollama/pull and renders the progress bar', async () => {
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === '/api/ollama/pull' && init?.method === 'POST') {
+        return Promise.resolve(
+          jsonResponse(
+            {
+              id: '1',
+              model: 'qwen3.5:4b',
+              status: 'pulling',
+              lastStatusMessage: 'pulling manifest',
+              bytesReceived: 0,
+              bytesTotal: 1_000_000,
+              error: null,
+              startedAt: 0,
+              updatedAt: 0,
+            },
+            { status: 202 },
+          ),
+        );
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    render(
+      <ModelPullStatus
+        pullableModels={PULLABLE}
+        health={{
+          status: 'reachable',
+          url: 'http://localhost:11434',
+          models: [],
+          expectedModel: 'qwen3.5:4b',
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('model-pull-qwen3.5:4b'));
+    await waitFor(() => {
+      expect(screen.getByTestId('model-pull-progress-qwen3.5:4b')).toBeInTheDocument();
+    });
+  });
+
+  it('renders an error card if the pull POST 400s with an allowlist error', async () => {
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === '/api/ollama/pull' && init?.method === 'POST') {
+        return Promise.resolve(
+          jsonResponse({ error: "Model 'foo:9b' is not in the allowlist" }, { status: 400 }),
+        );
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    /* We render with a fake "foo:9b" in the pullable list to drive the
+       click — the component normally trusts the prop. */
+    render(
+      <ModelPullStatus
+        pullableModels={['foo:9b'] as readonly string[]}
+        health={{
+          status: 'reachable',
+          url: 'http://localhost:11434',
+          models: [],
+          expectedModel: 'qwen3.5:4b',
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('model-pull-foo:9b'));
+    await waitFor(() => {
+      expect(screen.getByText(/not in the allowlist/i)).toBeInTheDocument();
+    });
+  });
+});
+
+describe('ModelPullStatus — refresh', () => {
+  it('clicking "Refresh available models" POSTs /api/ollama/refresh and updates the rows', async () => {
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === '/api/ollama/refresh' && init?.method === 'POST') {
+        return Promise.resolve(
+          jsonResponse({
+            status: 'reachable',
+            url: 'http://localhost:11434',
+            models: ['qwen3.5:4b'],
+            expectedModel: 'qwen3.5:4b',
+            modelPulled: true,
+          }),
+        );
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    render(
+      <ModelPullStatus
+        pullableModels={PULLABLE}
+        health={{
+          status: 'reachable',
+          url: 'http://localhost:11434',
+          models: [],
+          expectedModel: 'qwen3.5:4b',
+        }}
+      />,
+    );
+    /* Pre-refresh: qwen row shows "Not pulled yet". */
+    expect(screen.getByTestId('model-row-qwen3.5:4b')).toHaveTextContent(/not pulled yet/i);
+    fireEvent.click(screen.getByTestId('model-pull-refresh'));
+    await waitFor(() => {
+      expect(screen.getByTestId('model-row-qwen3.5:4b')).toHaveTextContent(/on disk/i);
+    });
+  });
+});

--- a/src/components/model-pull-status.tsx
+++ b/src/components/model-pull-status.tsx
@@ -1,0 +1,248 @@
+/* Plan 61 — model pull UI on the analyzer section.
+ *
+ * Surfaces:
+ *   - which models are present on disk (from /api/ollama/health.models)
+ *   - which model is the configured default (highlight)
+ *   - a "Pull" button that fires POST /api/ollama/pull and tracks the
+ *     resulting job via GET /api/ollama/pull/:id
+ *   - a "Refresh available models" button that POSTs /api/ollama/refresh
+ *     and re-renders the list
+ *
+ * Per-step state machine surfaced via the pull job:
+ *   idle → pulling (bytesReceived / bytesTotal / lastStatusMessage)
+ *        → pulled  → terminal
+ *        → error   → terminal (with retry)
+ *
+ * Pure UI — no redux, no global state. Tests render this directly with
+ * `fetch` mocked. */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface PullJob {
+  id: string;
+  model: string;
+  status: 'idle' | 'pulling' | 'pulled' | 'error';
+  lastStatusMessage: string;
+  bytesReceived: number;
+  bytesTotal: number | null;
+  error: string | null;
+  startedAt: number;
+  updatedAt: number;
+}
+
+export interface OllamaHealthEnvelope {
+  status: 'reachable' | 'unreachable';
+  url: string;
+  models?: string[];
+  expectedModel?: string;
+  modelPulled?: boolean;
+  error?: string;
+}
+
+interface ModelPullStatusProps {
+  /** Initial health envelope — typically passed in from the parent so
+      the component doesn't need a redundant probe on mount. */
+  health: OllamaHealthEnvelope | null;
+  /** Allowlist of pullable models — mirror DEFAULT_ALLOWED_MODELS on
+      the server. Centralised here so the UI can grey out anything
+      not pullable. */
+  pullableModels: readonly string[];
+}
+
+const POLL_INTERVAL_MS = 1_000;
+
+function formatMB(bytes: number): string {
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+export function ModelPullStatus({ health, pullableModels }: ModelPullStatusProps) {
+  const [localHealth, setLocalHealth] = useState<OllamaHealthEnvelope | null>(health);
+  const [refreshing, setRefreshing] = useState(false);
+  const [pullJob, setPullJob] = useState<PullJob | null>(null);
+  const [pullError, setPullError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    setLocalHealth(health);
+  }, [health]);
+
+  const refresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      const res = await fetch('/api/ollama/refresh', { method: 'POST' });
+      if (!res.ok) throw new Error(`refresh failed: HTTP ${res.status}`);
+      const body = (await res.json()) as OllamaHealthEnvelope;
+      setLocalHealth(body);
+    } catch (e) {
+      setPullError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setRefreshing(false);
+    }
+  }, []);
+
+  /* Poll the active pull job until it reaches a terminal state. */
+  useEffect(() => {
+    if (!pullJob) return;
+    if (pullJob.status === 'pulled' || pullJob.status === 'error') {
+      /* Terminal — one final refresh so the "pulled" indicator updates. */
+      if (pullJob.status === 'pulled') {
+        void refresh();
+      }
+      return;
+    }
+    if (pollRef.current) clearTimeout(pollRef.current);
+    pollRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/ollama/pull/${pullJob.id}`);
+        if (!res.ok) throw new Error(`pull poll failed: HTTP ${res.status}`);
+        const body = (await res.json()) as PullJob;
+        setPullJob(body);
+      } catch (e) {
+        setPullError(e instanceof Error ? e.message : String(e));
+      }
+    }, POLL_INTERVAL_MS);
+    return () => {
+      if (pollRef.current) clearTimeout(pollRef.current);
+    };
+  }, [pullJob, refresh]);
+
+  const startPull = async (model: string) => {
+    setPullError(null);
+    try {
+      const res = await fetch('/api/ollama/pull', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model }),
+      });
+      const body = (await res.json()) as PullJob | { error: string };
+      if (!res.ok) {
+        setPullError('error' in body ? body.error : `HTTP ${res.status}`);
+        return;
+      }
+      setPullJob(body as PullJob);
+    } catch (e) {
+      setPullError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const presentTags = new Set<string>(localHealth?.models ?? []);
+  const expectedModel = localHealth?.expectedModel;
+  const isReachable = localHealth?.status === 'reachable';
+
+  return (
+    <div data-testid="model-pull-status" className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-ink/55">
+          Models currently on disk (via <code className="font-mono">ollama list</code>).
+        </p>
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={refreshing}
+          data-testid="model-pull-refresh"
+          className="px-3 py-1.5 rounded-full border border-ink/15 bg-white text-xs text-ink hover:bg-ink/5 disabled:opacity-50"
+        >
+          {refreshing ? 'Refreshing…' : 'Refresh available models'}
+        </button>
+      </div>
+
+      {!isReachable && (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900">
+          Local Ollama daemon is unreachable. Pulls go through the daemon — start it (or
+          install Ollama in the section above) and click "Refresh available models."
+        </div>
+      )}
+
+      <ul className="divide-y divide-ink/5 rounded-xl border border-ink/10 overflow-hidden">
+        {pullableModels.map((model) => {
+          const present = presentTags.has(model) || isPrefixMatch(model, presentTags);
+          const isDefault = model === expectedModel;
+          const isActivePull =
+            pullJob && pullJob.model === model && pullJob.status === 'pulling';
+          return (
+            <li
+              key={model}
+              data-testid={`model-row-${model}`}
+              className="flex items-center gap-3 px-3 py-2 bg-white"
+            >
+              <span
+                className={`w-2 h-2 rounded-full ${
+                  present ? 'bg-emerald-600' : 'bg-ink/20'
+                }`}
+                aria-hidden
+              />
+              <div className="flex-1">
+                <p className="text-sm font-mono text-ink">{model}</p>
+                <p className="text-xs text-ink/55">
+                  {present ? 'On disk' : 'Not pulled yet'}
+                  {isDefault ? ' · configured default' : ''}
+                </p>
+              </div>
+              {isActivePull ? (
+                <PullProgress job={pullJob} />
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => startPull(model)}
+                  disabled={!isReachable || present}
+                  data-testid={`model-pull-${model}`}
+                  className="px-3 py-1.5 rounded-full bg-ink text-canvas text-xs disabled:opacity-30 disabled:cursor-not-allowed hover:bg-ink-soft"
+                >
+                  {present ? 'Pulled' : 'Pull'}
+                </button>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+
+      {pullJob && pullJob.status === 'error' && (
+        <div className="rounded-xl border border-rose-200 bg-rose-50 p-3 text-xs text-rose-900">
+          <p className="font-semibold">Pull failed.</p>
+          <p>{pullJob.error}</p>
+        </div>
+      )}
+      {pullError && <p className="text-xs text-rose-700">{pullError}</p>}
+    </div>
+  );
+}
+
+function PullProgress({ job }: { job: PullJob }) {
+  const pct = job.bytesTotal && job.bytesTotal > 0
+    ? Math.round((job.bytesReceived / job.bytesTotal) * 100)
+    : null;
+  return (
+    <div
+      data-testid={`model-pull-progress-${job.model}`}
+      className="w-48 space-y-1"
+    >
+      <div className="h-1.5 rounded-full bg-ink/10 overflow-hidden">
+        <div
+          className="h-full bg-magenta transition-all"
+          style={{ width: `${pct ?? 5}%` }}
+        />
+      </div>
+      <p className="text-[10px] font-mono text-ink/55">
+        {job.lastStatusMessage}
+        {' · '}
+        {pct !== null
+          ? `${pct}% (${formatMB(job.bytesReceived)} / ${formatMB(job.bytesTotal ?? 0)})`
+          : formatMB(job.bytesReceived)}
+      </p>
+    </div>
+  );
+}
+
+/* Ollama canonicalises tags — `qwen3.5:4b` may surface as
+   `qwen3.5:4b-instruct-q4_K_M`. Treat the family root as present
+   whenever a prefix match exists, mirroring the server-side health
+   check at server/src/routes/ollama-health.ts. */
+function isPrefixMatch(model: string, tags: Set<string>): boolean {
+  for (const t of tags) {
+    if (t === model || t.startsWith(`${model}-`)) return true;
+    if (t.split(':')[0] === model.split(':')[0] && t.startsWith(`${model.split(':')[0]}:`)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/components/ollama-install.test.tsx
+++ b/src/components/ollama-install.test.tsx
@@ -1,0 +1,170 @@
+/* Plan 61 — OllamaInstall component state-machine spec. */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { OllamaInstall } from './ollama-install';
+
+const fetchMock = vi.fn();
+
+function jsonResponse(body: unknown, init: { status?: number } = {}) {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('OllamaInstall — detected', () => {
+  it('renders the "Ollama is installed" pill when /detect returns installed:true', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes('/detect')) {
+        return Promise.resolve(jsonResponse({ installed: true, version: 'ollama version 0.5.4' }));
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    render(<OllamaInstall />);
+    await waitFor(() => {
+      expect(screen.getByTestId('ollama-install-ready')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/ollama version 0\.5\.4/i)).toBeInTheDocument();
+  });
+});
+
+describe('OllamaInstall — not detected', () => {
+  it('renders the "Install Ollama" button when /detect returns installed:false', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes('/detect')) {
+        return Promise.resolve(jsonResponse({ installed: false, version: null }));
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    render(<OllamaInstall />);
+    await waitFor(() => {
+      expect(screen.getByTestId('ollama-install-not-detected')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /install ollama/i })).toBeInTheDocument();
+  });
+
+  it('clicking "Install Ollama" POSTs /install and renders the job card', async () => {
+    fetchMock.mockImplementation((url: string, init: RequestInit | undefined) => {
+      if (url.endsWith('/detect')) {
+        return Promise.resolve(jsonResponse({ installed: false, version: null }));
+      }
+      if (url.endsWith('/install') && init?.method === 'POST') {
+        return Promise.resolve(
+          jsonResponse(
+            {
+              id: '1',
+              status: 'downloading',
+              platform: 'linux',
+              arch: 'x64',
+              bytesReceived: 0,
+              bytesTotal: 1_000_000,
+              manualInstallerPath: null,
+              error: null,
+              startedAt: 0,
+              updatedAt: 0,
+            },
+            { status: 202 },
+          ),
+        );
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    render(<OllamaInstall />);
+    await waitFor(() => {
+      expect(screen.getByTestId('ollama-install-not-detected')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /install ollama/i }));
+    await waitFor(() => {
+      const node = screen.getByTestId('ollama-install-job');
+      expect(node).toBeInTheDocument();
+      expect(node.getAttribute('data-job-status')).toBe('downloading');
+    });
+    expect(screen.getByTestId('ollama-install-progress-bar')).toBeInTheDocument();
+  });
+
+  it('renders the Windows-manual-installer banner when manualInstallerPath is set', async () => {
+    fetchMock.mockImplementation((url: string, init: RequestInit | undefined) => {
+      if (url.endsWith('/detect')) {
+        return Promise.resolve(jsonResponse({ installed: false, version: null }));
+      }
+      if (url.endsWith('/install') && init?.method === 'POST') {
+        return Promise.resolve(
+          jsonResponse(
+            {
+              id: '7',
+              status: 'installing',
+              platform: 'win32',
+              arch: 'x64',
+              bytesReceived: 100_000_000,
+              bytesTotal: 100_000_000,
+              manualInstallerPath: 'C:\\Users\\me\\AppData\\Local\\Temp\\OllamaSetup.exe',
+              error: null,
+              startedAt: 0,
+              updatedAt: 0,
+            },
+            { status: 202 },
+          ),
+        );
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    render(<OllamaInstall />);
+    await waitFor(() => {
+      expect(screen.getByTestId('ollama-install-not-detected')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /install ollama/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/double-click this file/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/OllamaSetup\.exe/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /re-check/i })).toBeInTheDocument();
+  });
+
+  it('renders the error card when the job ends in error state', async () => {
+    fetchMock.mockImplementation((url: string, init: RequestInit | undefined) => {
+      if (url.endsWith('/detect')) {
+        return Promise.resolve(jsonResponse({ installed: false, version: null }));
+      }
+      if (url.endsWith('/install') && init?.method === 'POST') {
+        return Promise.resolve(
+          jsonResponse(
+            {
+              id: '99',
+              status: 'error',
+              platform: 'linux',
+              arch: 'x64',
+              bytesReceived: 0,
+              bytesTotal: null,
+              manualInstallerPath: null,
+              error: 'Failed to fetch installer (HTTP 502)',
+              startedAt: 0,
+              updatedAt: 0,
+            },
+            { status: 202 },
+          ),
+        );
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    render(<OllamaInstall />);
+    await waitFor(() => {
+      expect(screen.getByTestId('ollama-install-not-detected')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /install ollama/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/Install failed/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/HTTP 502/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/ollama-install.tsx
+++ b/src/components/ollama-install.tsx
@@ -1,0 +1,247 @@
+/* Plan 61 — in-app Ollama install affordance.
+ *
+ * State machine surfaced to the user:
+ *   not-detected → installing (with progress %) → installed-and-ready
+ *
+ * Backed by:
+ *   GET  /api/ollama/detect      → { installed, version }
+ *   POST /api/ollama/install     → { id, status, ... } (202)
+ *   GET  /api/ollama/install/:id → poll
+ *   POST /api/ollama/install/:id/recheck → re-probe (Windows GUI path)
+ *
+ * The component is intentionally self-contained — it owns its polling
+ * loop and doesn't reach into redux. The Account → Models pane mounts
+ * it and renders it as a fully-encapsulated card. */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { PrimaryButton } from './primitives';
+
+export interface InstallJob {
+  id: string;
+  status: 'idle' | 'detecting' | 'downloading' | 'installing' | 'installed' | 'error';
+  platform: string;
+  arch: string;
+  bytesReceived: number;
+  bytesTotal: number | null;
+  manualInstallerPath: string | null;
+  error: string | null;
+  startedAt: number;
+  updatedAt: number;
+}
+
+interface DetectResp {
+  installed: boolean;
+  version: string | null;
+}
+
+/* Poll interval while a job is mid-flight. Slow enough to keep the
+   server happy, fast enough that a progress bar feels responsive. */
+const POLL_INTERVAL_MS = 1_000;
+
+function pct(job: InstallJob): number | null {
+  if (job.status === 'installed') return 100;
+  if (!job.bytesTotal || job.bytesTotal === 0) return null;
+  return Math.round((job.bytesReceived / job.bytesTotal) * 100);
+}
+
+function formatMB(bytes: number): string {
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+export function OllamaInstall() {
+  const [detect, setDetect] = useState<DetectResp | null>(null);
+  const [job, setJob] = useState<InstallJob | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const doDetect = useCallback(async () => {
+    try {
+      const res = await fetch('/api/ollama/detect');
+      if (!res.ok) throw new Error(`detect failed: HTTP ${res.status}`);
+      const body = (await res.json()) as DetectResp;
+      setDetect(body);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    void doDetect();
+  }, [doDetect]);
+
+  /* Poll the active job once we have one. The polling loop tears
+     itself down on terminal states ('installed' / 'error'). */
+  useEffect(() => {
+    if (!job) return;
+    if (job.status === 'installed' || job.status === 'error') return;
+    if (pollRef.current) clearTimeout(pollRef.current);
+    pollRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/ollama/install/${job.id}`);
+        if (!res.ok) throw new Error(`poll failed: HTTP ${res.status}`);
+        const body = (await res.json()) as InstallJob;
+        setJob(body);
+        /* If the job finished while we were polling, refresh the
+           top-level detect probe too so the "installed" banner shows
+           the new version string. */
+        if (body.status === 'installed') {
+          void doDetect();
+        }
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    }, POLL_INTERVAL_MS);
+    return () => {
+      if (pollRef.current) clearTimeout(pollRef.current);
+    };
+  }, [job, doDetect]);
+
+  const startInstall = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      const res = await fetch('/api/ollama/install', { method: 'POST' });
+      if (!res.ok) throw new Error(`start failed: HTTP ${res.status}`);
+      const body = (await res.json()) as InstallJob;
+      setJob(body);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const recheck = async () => {
+    if (!job) return;
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/ollama/install/${job.id}/recheck`, { method: 'POST' });
+      if (!res.ok) throw new Error(`recheck failed: HTTP ${res.status}`);
+      const body = (await res.json()) as InstallJob;
+      setJob(body);
+      void doDetect();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  /* Three top-level states the UI surfaces:
+       1. installed (either detected at boot or the job just finished)
+       2. in-flight job (detecting / downloading / installing)
+       3. not-installed, no active job — show the "Install Ollama" button
+     Plus error overlays. */
+
+  if (detect?.installed) {
+    return (
+      <div
+        data-testid="ollama-install-ready"
+        className="rounded-2xl border border-emerald-200 bg-emerald-50 p-4"
+      >
+        <div className="flex items-center gap-3">
+          <span className="w-2 h-2 rounded-full bg-emerald-600" />
+          <div className="flex-1">
+            <p className="text-sm font-semibold text-emerald-900">Ollama is installed</p>
+            <p className="text-xs text-emerald-900/70 font-mono">
+              {detect.version ?? 'version unknown'}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={doDetect}
+            disabled={busy}
+            className="px-3 py-1.5 rounded-full border border-emerald-300 bg-white text-xs text-emerald-900 hover:bg-emerald-100 disabled:opacity-50"
+          >
+            Re-check
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (job && job.status !== 'idle') {
+    const progress = pct(job);
+    return (
+      <div
+        data-testid="ollama-install-job"
+        data-job-status={job.status}
+        className="rounded-2xl border border-ink/10 bg-white p-4 space-y-3"
+      >
+        <div className="flex items-center justify-between">
+          <p className="text-sm font-semibold text-ink">
+            {job.status === 'detecting' && 'Checking your system…'}
+            {job.status === 'downloading' && 'Downloading Ollama installer…'}
+            {job.status === 'installing' && 'Installing Ollama…'}
+            {job.status === 'installed' && 'Ollama installed.'}
+            {job.status === 'error' && 'Install failed.'}
+          </p>
+          <span className="text-xs font-mono text-ink/55">
+            {job.platform}/{job.arch}
+          </span>
+        </div>
+
+        {job.status === 'downloading' && (
+          <div>
+            <div className="h-2 rounded-full bg-ink/10 overflow-hidden">
+              <div
+                data-testid="ollama-install-progress-bar"
+                className="h-full bg-magenta transition-all"
+                style={{ width: `${progress ?? 0}%` }}
+              />
+            </div>
+            <p className="mt-1 text-xs text-ink/60">
+              {progress !== null ? `${progress}%` : 'Starting…'}
+              {' · '}
+              {formatMB(job.bytesReceived)}
+              {job.bytesTotal ? ` / ${formatMB(job.bytesTotal)}` : ''}
+            </p>
+          </div>
+        )}
+
+        {job.status === 'installing' && job.manualInstallerPath && (
+          <div className="rounded-xl bg-amber-50 border border-amber-200 p-3 space-y-2">
+            <p className="text-xs text-amber-900">
+              Windows installer is GUI-based. Double-click this file to finish the install:
+            </p>
+            <p className="text-xs font-mono text-amber-900/85 break-all">
+              {job.manualInstallerPath}
+            </p>
+            <PrimaryButton variant="dark" onClick={recheck} icon={false}>
+              {busy ? 'Re-checking…' : "I've finished — re-check"}
+            </PrimaryButton>
+          </div>
+        )}
+
+        {job.status === 'error' && (
+          <div className="rounded-xl bg-rose-50 border border-rose-200 p-3 space-y-2">
+            <p className="text-xs text-rose-900">{job.error ?? 'Install failed.'}</p>
+            <PrimaryButton variant="dark" onClick={startInstall} icon={false}>
+              {busy ? 'Retrying…' : 'Try again'}
+            </PrimaryButton>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="ollama-install-not-detected"
+      className="rounded-2xl border border-ink/10 bg-white p-4 space-y-3"
+    >
+      <div>
+        <p className="text-sm font-semibold text-ink">Ollama is not installed</p>
+        <p className="mt-1 text-xs text-ink/55">
+          The local analyzer needs Ollama to run on-device. Install it here, or set the analyzer
+          engine to Gemini above.
+        </p>
+      </div>
+      <PrimaryButton variant="dark" onClick={startInstall} disabled={busy} icon={false}>
+        {busy ? 'Starting…' : 'Install Ollama'}
+      </PrimaryButton>
+      {error && <p className="text-xs text-rose-700">{error}</p>}
+    </div>
+  );
+}

--- a/src/views/account.test.tsx
+++ b/src/views/account.test.tsx
@@ -473,3 +473,49 @@ describe('AccountView — TTS sidecar auto-start (plan 43)', () => {
     expect(screen.getByText(/restart the server to apply this change/i)).toBeInTheDocument();
   });
 });
+
+describe('AccountView — Models card (plan 61)', () => {
+  it('renders the Models section with the in-app Ollama install card', async () => {
+    /* The OllamaInstall component fires /api/ollama/detect on mount —
+       stub the global fetch so it returns "not installed" without
+       hitting the network. */
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ installed: false, version: null }), { status: 200 }),
+      );
+    try {
+      renderView();
+      const card = await screen.findByTestId('account-models-card');
+      expect(card).toBeInTheDocument();
+      expect(card).toHaveTextContent(/local analyzer/i);
+      expect(card).toHaveTextContent(/analyzer models/i);
+      expect(card).toHaveTextContent(/coqui xtts/i);
+      /* OllamaInstall renders "not detected" once /detect resolves. */
+      await waitFor(() => {
+        expect(screen.getByTestId('ollama-install-not-detected')).toBeInTheDocument();
+      });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('renders the cross-platform Coqui install snippet (both POSIX + PowerShell)', () => {
+    /* The card cites both `install-coqui.sh` and `install-coqui.ps1`
+       in the same block — the user must be able to copy/paste their
+       platform's command without scrolling. */
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ installed: false, version: null }), { status: 200 }),
+      );
+    try {
+      renderView();
+      const pre = screen.getByTestId('account-coqui-install-cmd');
+      expect(pre.textContent).toMatch(/install-coqui\.ps1/);
+      expect(pre.textContent).toMatch(/install-coqui\.sh/);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});

--- a/src/views/account.tsx
+++ b/src/views/account.tsx
@@ -18,6 +18,13 @@ import {
   saveAccountSettings,
   saveGeminiApiKey,
 } from '../store/account-slice';
+import { OllamaInstall } from '../components/ollama-install';
+import { ModelPullStatus } from '../components/model-pull-status';
+
+/* Plan 61 — mirror server/src/ollama/pull-bootstrap.ts DEFAULT_ALLOWED_MODELS.
+   Centralised here so the Models card can render rows without re-fetching
+   the allowlist from the backend (it's static per release). */
+const PULLABLE_MODELS = ['qwen3.5:4b', 'qwen3.5:9b', 'llama3.1:8b', 'llama3.2:3b', 'gemma3:4b'] as const;
 
 export function AccountView() {
   const dispatch = useAppDispatch();
@@ -477,6 +484,8 @@ export function AccountView() {
           />
         </FormCard>
 
+        <ModelsCard />
+
         <div className="flex items-center gap-4">
           <PrimaryButton variant={dirty ? 'dark' : 'ghost'} onClick={onSave} icon={false}>
             {saving ? 'Saving…' : 'Save changes'}
@@ -659,5 +668,94 @@ function GeminiKeyField({
         {flash && <span className="text-xs text-magenta font-semibold">{flash}</span>}
       </div>
     </div>
+  );
+}
+
+/* Plan 61 — Models card. Hosts the in-app Install Ollama affordance +
+   per-model Pull controls. The card sits below the server-config card
+   so the user lands on it after seeing their analyzer-engine + Ollama
+   URL choices.
+
+   On mount, GETs /api/ollama/health directly (bypassing the mock
+   layer) so the ModelPullStatus row list reflects current on-disk
+   state. The "Refresh available models" button inside ModelPullStatus
+   re-probes via POST /refresh without going through this card.
+
+   Direct-fetch is deliberate: in mock mode the api.getOllamaHealth
+   mock returns the model as already pulled, which would make the
+   Pull buttons permanently disabled. The Models card needs the real
+   health envelope from the server (or whatever the e2e route-mock
+   provides). */
+function ModelsCard() {
+  const [health, setHealth] = useState<import('../components/model-pull-status').OllamaHealthEnvelope | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch('/api/ollama/health');
+        if (!res.ok) return;
+        const body = await res.json();
+        if (!cancelled) setHealth(body);
+      } catch {
+        /* Best-effort probe — leave health null and let ModelPullStatus
+           render the "daemon unreachable" banner. */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <section
+      data-testid="account-models-card"
+      className="rounded-2xl border border-ink/10 bg-white p-6 shadow-card"
+    >
+      <h2 className="text-base font-semibold text-ink">Models</h2>
+      <p className="mt-1 text-xs text-ink/55">
+        Install Ollama, pull analyzer model weights, and pre-fetch Coqui XTTS — all without
+        dropping to a terminal. Kokoro v1 ships pre-installed via the release bundle, so
+        nothing on this page applies to it.
+      </p>
+
+      <div className="mt-4 space-y-6">
+        <div>
+          <h3 className="text-sm font-medium text-ink">Local analyzer (Ollama)</h3>
+          <p className="mt-1 mb-3 text-xs text-ink/55">
+            Required when "Analyzer engine" above is set to Local.
+          </p>
+          <OllamaInstall />
+        </div>
+
+        <div>
+          <h3 className="text-sm font-medium text-ink">Analyzer models</h3>
+          <p className="mt-1 mb-3 text-xs text-ink/55">
+            Pulled tags appear in the Analysis-model dropdown above. The configured default is
+            highlighted.
+          </p>
+          <ModelPullStatus health={health} pullableModels={PULLABLE_MODELS} />
+        </div>
+
+        <div>
+          <h3 className="text-sm font-medium text-ink">Coqui XTTS v2 (optional TTS engine)</h3>
+          <p className="mt-1 text-xs text-ink/55">
+            XTTS v2 is downloaded on first synth (~1.8 GB), or pre-fetched via{' '}
+            <code className="font-mono">install-coqui</code> in the release bundle:
+          </p>
+          <pre
+            data-testid="account-coqui-install-cmd"
+            className="mt-2 rounded-xl bg-ink/[0.04] p-3 text-xs font-mono text-ink/80 overflow-x-auto"
+          >{`# Windows
+pwsh server/tts-sidecar/scripts/install-coqui.ps1
+
+# macOS / Linux
+bash server/tts-sidecar/scripts/install-coqui.sh`}</pre>
+          <p className="mt-2 text-xs text-ink/55">
+            One-shot pre-fetch is optional; the sidecar auto-downloads on first synth call.
+          </p>
+        </div>
+      </div>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary

Closes BACKLOG Could #37. Adds a Models card to the Account view so a deployer who shipped via plan 49's Kokoro-only release bundle can install Ollama, pull analyzer model weights (qwen3.5:4b etc.), and pre-fetch Coqui XTTS v2 — all without dropping to a terminal. Matches the deployer-first promise of plan 49 for the rest of the multi-model story.

Wide 4-way scope (frontend + server + sidecar + scripts) is deliberate per CONTRIBUTING.md — the install/pull state machines, the UI, and the pre-install scripts must land together so a fresh deployer flow works end-to-end.

## User-visible deltas

- Account view → new **Models** card below "Server configuration." Three sub-sections:
  - **Local analyzer (Ollama):** in-app install affordance with three render branches — not-detected (with "Install Ollama" button), in-flight (downloading % / Windows-manual-installer / error), installed-and-ready pill.
  - **Analyzer models:** per-model row list driven by `/api/ollama/health`. Each row shows on-disk vs. not-pulled, highlights the configured default, and exposes a Pull button. "Refresh available models" button re-probes via `POST /api/ollama/refresh`.
  - **Coqui XTTS v2:** docs-only block with copy-pasteable POSIX + PowerShell pre-install commands (the scripts ship in this PR).
- Windows install path parks at "double-click the downloaded `OllamaSetup.exe`, then click I've finished — re-check" (vendor doesn't ship a silent installer).
- No auto-pull on first run — every Pull is an explicit user click.

## Operator-visible deltas (server contract changes)

Seven new routes under `/api/ollama/`. All additive — existing `/health`, `/load`, `/unload` (plans 29, 30) untouched:

- `GET  /api/ollama/detect` → `{ installed: bool, version: string | null }`
- `POST /api/ollama/install` → 202 + `InstallJob` snapshot (kicks off async download + install state machine)
- `GET  /api/ollama/install/:id` → poll `InstallJob` progress
- `POST /api/ollama/install/:id/recheck` → re-probe (Windows GUI install completion)
- `POST /api/ollama/pull` → 202 + `PullJob` snapshot (body: `{ model }`; rejects non-allowlisted tags with 400)
- `GET  /api/ollama/pull/:id` → poll `PullJob` progress
- `POST /api/ollama/refresh` → re-runs the health probe with POST semantics so the UI can request a re-read distinct from polling

State machines: `idle → detecting → downloading → installing → installed (or error)` for install; `idle → pulling → pulled (or error)` for pull. Both linear + terminal. Both dependency-injectable from tests (no real network in the test suite).

## Dev-visible deltas

- New modules: `server/src/ollama/install-bootstrap.ts`, `server/src/ollama/pull-bootstrap.ts`. The route layer exposes `setOllamaBootstraps({...})` so tests stub the entire surface. `_resetOllamaBootstraps()` in `afterEach` prevents cross-test leakage.
- Pull allowlist (`DEFAULT_ALLOWED_MODELS` in `pull-bootstrap.ts:64-72`) mirrors the local-engine subset of `src/lib/models.ts` `MODEL_OPTIONS`. Centralised so the UI cannot request arbitrary upstream tags.
- New scripts: `server/tts-sidecar/scripts/install-coqui.sh` (POSIX) + `install-coqui.ps1` (Windows). Both invoke the Coqui TTS lib's auto-downloader against `TTS_HOME=<sidecar>/voices/coqui/`. Idempotent — skip when the manifest dir is present. Both refuse to run if the sidecar venv isn't bootstrapped.

## Tests

New automated coverage:

- `server/src/ollama/install-bootstrap.test.ts` (16 cases) — detect short-circuit, linux happy path, windows GUI park, recheck → installed promotion, HTTP error, byte-truncation error, progressive bytesReceived, parallel `start()` coalescing.
- `server/src/ollama/pull-bootstrap.test.ts` (7 cases) — allowlist enforcement, NDJSON progress consumption, error-line short-circuit, same-model coalescing, distinct ids for different models.
- `server/src/routes/ollama-health.test.ts` — extended with `/detect`, `/install`, `/install/:id`, `/pull`, `/pull/:id`, `/refresh` coverage. Existing `/health`, `/load`, `/unload` assertions unchanged.
- `src/components/ollama-install.test.tsx` (5 cases) — detected / not-detected / downloading-progress / windows-manual-banner / error branches.
- `src/components/model-pull-status.test.tsx` (6 cases) — present/absent row rendering, configured-default highlight, daemon-unreachable banner, pull POST + progress bar, allowlist error, refresh re-renders.
- `src/views/account.test.tsx` — Models card mounts; both POSIX + PowerShell Coqui install snippets render in the same code block.
- `e2e/account-models.spec.ts` — full install → pull → ready loop with mocked routes, walks both state machines tick-by-tick offline.

## Known multi-model gaps after this ship

Per the packaging-multi-model-gap memory, this PR does NOT close every gap. Documented in `docs/features/61-in-app-model-management.md` "Known multi-model gaps after this ship":

1. **Kokoro v1 weights** still bundled via plan 49's `install-kokoro.{ps1,sh}` — no in-app re-install affordance if the weights file is deleted.
2. **Coqui XTTS v2 install is script-driven, not in-app** — the Models card surfaces the script paths and commands but doesn't run them via a button (the script needs the sidecar venv's Python on PATH, which the Node server can't reliably locate from an arbitrary install location). Workaround: deployer runs the script from the release bundle once. The on-disk pre-fetch is OPTIONAL — XTTS auto-downloads on first synth call.
3. **Ollama install on Windows requires a GUI double-click** — vendor only ships an `.exe` GUI installer. Bundling a portable Ollama is a license risk; scripting silent mode isn't documented.
4. **Allowlist drift** — adding a new analyzer tag to `src/lib/models.ts` MUST also add it to `DEFAULT_ALLOWED_MODELS` in `pull-bootstrap.ts`. No test pins the two sets together yet.
5. **Linux distro coverage** — the install step assumes the vendor's bash installer works against the host's package manager. Tested by the vendor on Ubuntu/Debian/Fedora; Arch/Alpine/NixOS may need manual intervention.

## Plan / docs

- New plan: [docs/features/61-in-app-model-management.md](docs/features/61-in-app-model-management.md) (status: stable, shipped: 2026-05-19).
- Indexed under "C. Analysis pipeline" in `docs/features/INDEX.md` near plans 06 / 29.
- BACKLOG Could #37 removed; Could count decremented 32 → 31.
- Unparks the install-and-pull-from-UI subset of Won't #1 ("Auto-install Ollama / auto-pull models"); the headless-CI variant stays parked.

## Test plan

- [x] `npm run typecheck` — frontend + server clean
- [x] `npm test -- --run` — 74 files, 1059 passes
- [x] `npm run test:server` — 75 files, 1031 passes
- [x] `npm run lint` — 0 warnings
- [x] `npm run test:e2e` — 44 passes including new `account-models.spec.ts`
- [x] `npm run verify` — full battery green
- [ ] Manual: fresh deployer install → Account → Models → Install Ollama → Pull qwen3.5:4b → analyze a book (deferred to user smoke; the headless test suite mocks the actual downloads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)