### PR TITLE
fix(ci): restore annotated tag after actions/checkout strips it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,15 +85,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Need the tag annotation reachable as the release body.
           # `fetch-depth: 0` alone fetches all commits but actions/checkout@v4
           # leaves `fetch-tags: false` by default, so the tag *object* (with
-          # its annotation) is never pulled — `git tag -l --format='%(contents)'`
-          # then falls back to the commit subject and the GitHub Release body
-          # ends up as just "chore: bump version to X.Y.Z". v1.2.2 shipped
-          # with an empty body for exactly this reason.
+          # its annotation) is never pulled. With `fetch-tags: true` the FIRST
+          # fetch pulls the annotated tag — but actions/checkout then runs a
+          # second `git fetch --no-tags origin +<SHA>:refs/tags/<tag>` that
+          # silently overwrites it with a lightweight tag pointing at the same
+          # commit. From that point on `git tag -l --format='%(contents)'`
+          # returns the commit subject and the GitHub Release body ends up as
+          # just "chore: bump version to X.Y.Z". v1.2.2 and v1.3.0 both shipped
+          # with empty bodies for exactly this reason; the explicit re-fetch
+          # below restores the annotated tag object.
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Restore annotated tag (actions/checkout strips the annotation)
+        run: |
+          git tag -d "${{ github.ref_name }}" || true
+          git fetch --tags --force origin \
+            "refs/tags/${{ github.ref_name }}:refs/tags/${{ github.ref_name }}"
+          # Sanity-check: cat-file should now report `tag` (annotated), not
+          # `commit` (lightweight). Fail loudly if the restore didn't take.
+          type="$(git cat-file -t "refs/tags/${{ github.ref_name }}")"
+          if [ "$type" != "tag" ]; then
+            echo "::error::Expected annotated tag, got $type. Release body will be wrong."
+            exit 1
+          fi
+          echo "tag type: $type — annotation restored"
 
       - name: Set up Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

v1.2.2 and v1.3.0 both shipped with their GitHub Release body set to the bump commit's subject (`chore: bump version to X.Y.Z`) instead of the full tag annotation. PR #32 thought it fixed this by adding `fetch-tags: true`, but the fix was incomplete.

**Root cause.** `actions/checkout@v4` runs TWO fetches when checking out a tag:

1. First fetch: `git fetch --prune origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*` — pulls the annotated tag object correctly.
2. Second fetch: `git fetch --no-tags --prune origin +<SHA>:refs/tags/<tag>` — silently **overwrites** the annotated tag with a lightweight tag pointing at the same commit.

From that point on `git tag -l --format='%(contents)' "v1.3.0"` returns `chore: bump version to 1.3.0` (the commit subject) instead of the annotated body. The release body comes out empty.

**Fix.** A new `Restore annotated tag` step runs after checkout. It deletes the lightweight tag actions/checkout left behind, then `git fetch --tags --force origin refs/tags/<tag>:refs/tags/<tag>` re-pulls the annotated object. A `git cat-file -t` sanity check fails the job loudly if the restore didn't take (returns `commit` instead of `tag`), so we don't silently re-ship an empty body.

**v1.3.0 already restored** out-of-band via `gh release edit --notes-file` ahead of this PR. This commit prevents the bug for v1.4.0+.

## Test plan

- [x] `npm run verify` — cached green (CI-config-only diff)
- [ ] Reviewer reads the new step; confirms the cat-file gate is on a fail-loud failure path (`exit 1` + `::error::`)
- [ ] Validated end-to-end on the next release (v1.4.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)