### PR TITLE
docs(docs): release-notes Fixes section is bullet-per-bug in user vocabulary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -391,6 +391,14 @@ and not an inventory of parked work.
    release. One bullet per shipped capability.
 2. **Fixes.** Bugs that escaped the previous release and that users
    actually hit. Omit this section entirely on an initial release.
+   **One bullet per bug, written from the user's perspective** — describe
+   the symptom the listener / deployer / operator saw, not the internal
+   cause. A reader who has never touched the code should understand what
+   was wrong from the bullet alone. Avoid CSS-class names, slice names,
+   middleware names, file paths, line numbers, and selector specificity
+   arguments — those belong in the commit message or the regression plan,
+   not the release body. Reference the regression plan number in parens
+   at the end of the bullet if there is one.
 3. **Retirements.** Behavior that **shipped in a previous release** and
    is now removed or downgraded. Tell users what to do instead.
 4. **Engineering.** Changes to the test harness, build, install
@@ -426,4 +434,13 @@ and not an inventory of parked work.
    leave it out.
 4. Write the tag message with the four sections (omit any that are
    empty). Reference plan numbers in parens.
-5. `git tag -a vX.Y.Z` and `git push --tags` once the user approves.
+5. **Fixes bullets get a second pass for user vocabulary.** Re-read each
+   one and ask: would a deployer who has never seen the codebase know
+   what was broken? Replace `bg-white/60`, `book-meta-slice`,
+   `persistence-middleware`, `floating-pill-inverse`, `z-[60]`, etc. with
+   the symptom: "the connection pill rendered light-on-light", "the
+   book description silently failed to save", "the match-detail drawer
+   opened underneath the profile drawer". Internal vocabulary in a Fix
+   bullet is a signal it was written from the diff, not from the user's
+   chair.
+6. `git tag -a vX.Y.Z` and `git push --tags` once the user approves.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -388,7 +388,16 @@ and not an inventory of parked work.
 ### Sections, in order
 
 1. **Features.** User-visible additions or expansions since the previous
-   release. One bullet per shipped capability.
+   release. **One bullet per shipped capability, written from the user's
+   perspective** — describe what a listener / deployer / operator can now
+   do that they couldn't before. Lead with the affordance ("A new Models
+   card on Account…", "The character profile drawer now has…"), name the
+   benefit ("…without opening a terminal", "…remembers the choice per
+   book"), and leave architecture out. State machines, middleware names,
+   slice names, SSE channel mechanics, redux action shapes, regex
+   patterns, and library / dependency choices belong in the commit
+   message and the regression plan, not the release body. Reference the
+   regression plan number in parens at the end of the bullet.
 2. **Fixes.** Bugs that escaped the previous release and that users
    actually hit. Omit this section entirely on an initial release.
    **One bullet per bug, written from the user's perspective** — describe
@@ -434,13 +443,20 @@ and not an inventory of parked work.
    leave it out.
 4. Write the tag message with the four sections (omit any that are
    empty). Reference plan numbers in parens.
-5. **Fixes bullets get a second pass for user vocabulary.** Re-read each
-   one and ask: would a deployer who has never seen the codebase know
-   what was broken? Replace `bg-white/60`, `book-meta-slice`,
-   `persistence-middleware`, `floating-pill-inverse`, `z-[60]`, etc. with
-   the symptom: "the connection pill rendered light-on-light", "the
-   book description silently failed to save", "the match-detail drawer
-   opened underneath the profile drawer". Internal vocabulary in a Fix
-   bullet is a signal it was written from the diff, not from the user's
-   chair.
+5. **Features AND Fixes bullets both get a second pass for user
+   vocabulary.** Re-read each one and ask: would a deployer who has never
+   seen the codebase know what shipped / what was broken? Replace
+   `bg-white/60`, `book-meta-slice`, `persistence-middleware`,
+   `floating-pill-inverse`, `z-[60]`, `BroadcastChannel('audiobook-state')`,
+   `instanceId tag + inbound-action allowlist`, `state machine (idle →
+   detecting → downloading → installed)`, `NDJSON progress stream`,
+   `ffmpeg -ss / -t / -c copy`, `acceptedSelections map`, etc. with the
+   user-facing capability or symptom: "install Ollama and pull a model
+   without opening a terminal", "open the same book in two tabs and both
+   stay in sync", "audio is sliced from the existing recording, no
+   re-encode, no quality loss". Internal vocabulary in a Features or
+   Fixes bullet is a signal it was written from the diff, not from the
+   user's chair. **Engineering** bullets are exempt — that section is
+   explicitly for contributors / operators, so test-harness names, CI
+   step names, and refactor mechanics are fine there.
 6. `git tag -a vX.Y.Z` and `git push --tags` once the user approves.


### PR DESCRIPTION
## Summary

Adds two pieces of guidance to the release-notes specification in `CONTRIBUTING.md`:

- **Sections, in order → Fixes** — one bullet per bug, written from the user's perspective. Describe the symptom the listener / deployer / operator saw, not the internal cause. CSS class names, slice names, middleware names, file paths, line numbers, and selector specificity arguments belong in the commit message and the regression plan, not the release body. Reference the regression plan number in parens at the end of the bullet if there is one.
- **Recipe → step 5** — "Fixes bullets get a second pass for user vocabulary." Re-read each bullet and ask: would a deployer who has never seen the codebase know what was broken? `bg-white/60`, `book-meta-slice`, `persistence-middleware`, `floating-pill-inverse`, `z-[60]` etc. all get replaced with the symptom. Internal vocabulary in a Fix bullet is a signal it was written from the diff, not from the user's chair.

**v1.3.0 release body was rewritten out-of-band** under the new rule — the 10 paragraph-buried bugs that shipped earlier today are now 10 bullets, each named by symptom rather than by selector / slice / middleware. The v1.3.0 release page already reflects the new style: <https://github.com/dudarenok-maker/AudioBook-Generator/releases/tag/v1.3.0>.

Sequencing note: this PR is the precondition the user wanted before merging the in-flight release-workflow fix (PR #60). Both should land in either order; the workflow fix doesn't depend on this doc change.

## Test plan

- [x] `npm run verify` — cached green (CONTRIBUTING-only diff)
- [x] v1.3.0 release body re-applied via `gh release edit --notes-file` and visually confirmed
- [ ] Reviewer reads the new Fixes guidance and confirms the v1.3.0 Fixes bullets satisfy it

🤖 Generated with [Claude Code](https://claude.com/claude-code)