### PR TITLE
fix(frontend,server): drift report shows real chapter names, book context, and profile comparison

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -275,6 +275,15 @@ Source: net-new (2026-05-19). Spun off from the parallel-sessions tooling — CO
 - _Depends on:_ the parallel-sessions tooling already shipped (the worktrees are the input). The verify-cache plan 50 makes the between-merge verify fast enough that this becomes practical.
 - _Benefit (user):_ collapses the 6-step manual reconciliation into one command. Today the friction of "merge, verify, merge, verify, ..." discourages users from running > 2 parallel agents.
 
+### Background drift polling across non-active books
+
+Source: net-new (2026-05-19). Spun off from the drift-report-fidelity work — the Drift Report modal now groups events across books, but the runtime poller only fetches the active book. Drift accumulated on Book B while the user is in Book A only surfaces after they navigate to Book B (or via the disk hydrate on book-open).
+
+- _What:_ Extend the revisions poller (`src/components/layout.tsx` ~528-540) to fan out across every book that has rendered chapters (probably `state.bookMeta.saved` filtered to books past the `confirm` stage). Each book's response is stamped with `bookId` in the `applyPoll` payload (already wired). Keep the active book on a 30s tick; throttle non-active books to a longer interval (e.g. 2 min) so we don't blow free-tier server quotas.
+- _Acceptance:_ Two books concurrently generating. Drift detected on background Book B (e.g. user changes a cast attribute in Book B's cast slice without navigating back) surfaces in the Drift Report modal opened from Book A's top bar within the poll interval. New unit test covers the multi-book fan-out; e2e spec extends `drift-report-multibook.spec.ts` with a background-poll case.
+- _Key files:_ `src/components/layout.tsx` (poller `useEffect`); maybe a new `src/store/revisions-poll-middleware.ts` if the cross-book scheduling outgrows the inline useEffect; `docs/features/35-engine-drift-detection.md` "Modal fidelity contract" invariant (e).
+- _Benefit (user):_ honours the concurrent-multibook invariant for drift. Today a user analysing Book A + generating Book B has to navigate between them to see fresh drift events for each.
+
 ---
 
 ## Won't (this round) — explicitly parked

--- a/docs/features/35-engine-drift-detection.md
+++ b/docs/features/35-engine-drift-detection.md
@@ -175,6 +175,61 @@ read, and surface the mismatch in the Generation view.
     The drift detector then correctly flags it the next time the user
     looks at the chapter list.
 
+## Modal fidelity contract (drift-report-fidelity, 2026-05-19)
+
+The per-character Drift Report modal (`src/modals/drift-report.tsx`) was
+previously joining drift events against the static `initialChapters`
+fixture, scoped to one book, and rendering only a prose "what changed"
+description. Three follow-up bugs landed together:
+
+1. **Chapter title comes from the event, not a fixture.** Every drift
+   event carries `chapterTitle: string` (required) stamped server-side
+   in `revisions.ts` from `seg.chapterTitle` → scan title → "Chapter N"
+   fallback chain. The modal reads it directly — no chapters-slice
+   lookup, which would only ever hold the active book's titles.
+
+2. **Drift Report is multi-book.** Every drift event carries
+   `bookId: string`, and the slice's `drift` field is a flat list
+   across concurrently-active books. The modal groups events by
+   `bookId` for rendering (one section per book, book title pulled
+   from `selectEffectiveMeta(bookId)` in layout.tsx) and the header
+   summary reads "{N} chapter(s) flagged across {M} books" when M > 1.
+   See `selectDriftByBook` in `revisions-slice.ts`.
+
+3. **Side-by-side profile comparison.** Each event carries `snapshot`
+   (CharacterSnapshot at render time, from `<slug>.segments.json`) and
+   `current` (live cast profile at poll time). The modal renders a
+   `ProfileCompareCard` with rows for Voice, Gender, Age range,
+   Warmth, Pace, Authority, Emotion, Attributes — both columns visible,
+   the row matching `event.factor` highlighted with a `←` marker. Tone
+   rows render as inline bars (reusing the pattern from
+   `src/modals/profile-drawer.tsx`); attributes diff renders kept items
+   muted, added items badged `+`, removed items struck-through.
+
+### Multi-book invariants
+
+a. **Drift event ids include `bookId`** (`drift:<bookId>:<chapterId>:<characterId>:<factor>`)
+   so they stay globally unique across concurrently-active books.
+
+b. **`applyPoll({bookId, ...response})` only replaces that book's
+   events** — events from other books survive the poll. Same for
+   `hydrateFromBookState({bookId, ...})`. Stamps `bookId` defensively
+   onto incoming events that don't carry one (older deploys).
+
+c. **`persistence-middleware` filters drift by active bookId before
+   writing each book's revisions.json.** The flat slice list spans books,
+   but each on-disk file must carry only its own events — otherwise
+   re-hydration on book switch would replay another book's events.
+
+d. **Cast slice and chapters slice stay single-book scoped.** The modal
+   reads display-name + avatar color from the cast slice when the
+   event belongs to the active book; for cross-book events it falls
+   back to `event.current.name` and the narrator color slot.
+
+e. **Polling is active-book only today.** Background polling of
+   non-active books (so freshly-detected drift on Book B surfaces while
+   the user is in Book A) is a follow-up — see BACKLOG.
+
 ## Out of scope
 
 - **Per-character engine drift inside chapters**: the existing

--- a/e2e/drift-report-multibook.spec.ts
+++ b/e2e/drift-report-multibook.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+
+/* drift-report-fidelity (2026-05-19) — multi-book Drift Report.
+   Browser smoke that the slice → cast-view → modal seam wires through
+   under mocks. The unit tests in `src/modals/drift-report.test.tsx`
+   pin the rendering invariants (chapter titles from event payload,
+   side-by-side comparison rows, multi-book grouping); this spec only
+   proves that pollRevisions resolves under VITE_USE_MOCKS, the cast
+   view's drift banner appears, and clicking it surfaces the modal.
+
+   File-level serial mode matches the revision-diff spec: the
+   revisions poll's 200ms mock latency intermittently races under
+   parallel-worker contention. */
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Drift Report — modal opens with multi-book payload', () => {
+  test('opening Solway Bay surfaces the drift banner with the fixture events', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await expect(page.getByRole('button', { name: /Start a new book/i })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    /* Solway Bay seeds three drift events under bookId 'sb' in the
+       VOICE_DRIFT_EVENTS fixture. Open the book, then navigate to its
+       cast view where the drift banner lives. Direct URL avoids
+       clicking through a tab that might not exist on the listen view
+       under mocks. */
+    await page
+      .getByText(/Solway Bay/i)
+      .first()
+      .click({ timeout: 10_000 });
+    await page.goto('/#/books/sb/cast');
+
+    /* The banner uses "Voice drift detected in N chapters" wording.
+       Anchors to the active book's slice projection; waits past the
+       200ms mock poll latency. */
+    await expect(page.getByText(/Voice drift detected in \d+ chapters?/i)).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2344,9 +2344,17 @@ components:
 
     DriftEvent:
       type: object
-      required: [id, characterId, chapterId, severity, factor, chapterTitle]
+      required: [id, bookId, characterId, chapterId, severity, factor, chapterTitle]
       properties:
         id: { type: string }
+        bookId:
+          type: string
+          description: >-
+            Book the event belongs to. Server stamps this at emit time
+            from the request path; included in the event id for global
+            uniqueness across concurrently-active books. Lets the Drift
+            Report group events by book in a single modal even when the
+            user has multiple books generating in parallel.
         characterId: { type: string }
         chapterId: { type: integer }
         chapterTitle:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2344,11 +2344,20 @@ components:
 
     DriftEvent:
       type: object
-      required: [id, characterId, chapterId, severity, factor]
+      required: [id, characterId, chapterId, severity, factor, chapterTitle]
       properties:
         id: { type: string }
         characterId: { type: string }
         chapterId: { type: integer }
+        chapterTitle:
+          type: string
+          description: >-
+            Title of the chapter whose render produced this drift event,
+            embedded server-side at emit time so the Drift Report modal
+            can label each row without depending on the live chapters
+            slice (which is single-book-scoped, but drift may span
+            books). Falls back to the chapter-scan title and finally to
+            "Chapter N" when no title is available.
         severity: { type: string, enum: [mild, moderate, severe] }
         factor: { type: string, example: 'register' }
         factorLabel: { type: string }
@@ -2368,6 +2377,52 @@ components:
             current: { type: number }
             expected: { type: number }
             unit: { type: string }
+        snapshot:
+          type: object
+          description: >-
+            The character profile as captured at chapter render time.
+            Diffed against `current` by the modal to render a
+            side-by-side "When rendered / Now" comparison so the user
+            can judge whether the drift actually matters. Mirrors the
+            on-disk CharacterSnapshot in <slug>.segments.json.
+          properties:
+            voiceId: { type: string }
+            voiceEngine: { type: string }
+            gender: { type: string, enum: [male, female, neutral] }
+            ageRange: { type: string, enum: [child, teen, adult, elderly] }
+            tone:
+              type: object
+              properties:
+                warmth: { type: integer }
+                pace: { type: integer }
+                authority: { type: integer }
+                emotion: { type: integer }
+            attributes:
+              type: array
+              items: { type: string }
+        current:
+          type: object
+          description: >-
+            The live cast profile for this character at poll time.
+            Embedded alongside `snapshot` so the comparison card is
+            data-self-sufficient even when the event belongs to a
+            non-active book whose cast isn't in the frontend's chapters
+            / cast slice.
+          properties:
+            name: { type: string }
+            voiceId: { type: string }
+            gender: { type: string, enum: [male, female, neutral] }
+            ageRange: { type: string, enum: [child, teen, adult, elderly] }
+            tone:
+              type: object
+              properties:
+                warmth: { type: integer }
+                pace: { type: integer }
+                authority: { type: integer }
+                emotion: { type: integer }
+            attributes:
+              type: array
+              items: { type: string }
         detected: { type: string }
         suggestedAction: { type: string, example: 'regenerate_chapter' }
 

--- a/server/src/routes/revisions.test.ts
+++ b/server/src/routes/revisions.test.ts
@@ -31,9 +31,19 @@ interface DriftEventOut {
   id: string;
   characterId: string;
   chapterId: number;
+  chapterTitle: string;
   severity: 'mild' | 'moderate' | 'severe';
   factor: string;
   autoQueueable?: boolean;
+  snapshot?: CharacterSnapshot;
+  current?: {
+    name?: string;
+    voiceId?: string;
+    gender?: 'male' | 'female' | 'neutral';
+    ageRange?: 'child' | 'teen' | 'adult' | 'elderly';
+    tone?: { warmth?: number; pace?: number; authority?: number; emotion?: number };
+    attributes?: string[];
+  };
 }
 
 interface CharacterSnapshot {
@@ -406,6 +416,88 @@ describe('GET /api/books/:bookId/revisions — autoQueueable flag (plan 20 C1+C2
     expect(drift).toHaveLength(1);
     expect(drift[0].severity).toBe('moderate');
     expect(drift[0].autoQueueable).toBeUndefined();
+  });
+});
+
+describe('GET /api/books/:bookId/revisions — comparison payload (plan: drift-report-fidelity)', () => {
+  it('embeds chapterTitle on every emitted drift event', async () => {
+    seed({
+      snapshots: { eliza: { voiceId: 'old' } },
+      cast: [{ id: 'eliza', voiceId: 'new' }],
+    });
+    const res = await request(app).get(`/api/books/${bookId}/revisions`);
+    const drift = res.body.drift as DriftEventOut[];
+    expect(drift).toHaveLength(1);
+    /* Title pulled from segments.json#chapterTitle ("Chapter One"). The seed
+       writes that key, so we should NOT see the "Chapter N" fallback. */
+    expect(drift[0].chapterTitle).toBe('Chapter One');
+  });
+
+  it('falls back to the chapter-scan title when segments.json omits chapterTitle', async () => {
+    /* Simulate an older segments file that pre-dates the chapterTitle field.
+       Detector should fall back to state.chapters[].title, not "Chapter N". */
+    writeFileSync(
+      join(audioRoot, '01-chapter-one.segments.json'),
+      JSON.stringify({
+        bookId,
+        chapterId: 1,
+        durationSec: 12,
+        sampleRate: 24000,
+        modelKey: 'coqui-xtts-v2',
+        synthesizedAt: '2026-01-01T12:00:00.000Z',
+        segments: [
+          { groupIndex: 0, characterId: 'eliza', sentenceIds: [1], startSec: 0, endSec: 12 },
+        ],
+        characterSnapshots: { eliza: { voiceId: 'old' } },
+      }),
+    );
+    writeFileSync(
+      join(bookDir, '.audiobook', 'cast.json'),
+      JSON.stringify({ characters: [{ id: 'eliza', voiceId: 'new' }] }),
+    );
+    const res = await request(app).get(`/api/books/${bookId}/revisions`);
+    const drift = res.body.drift as DriftEventOut[];
+    expect(drift).toHaveLength(1);
+    expect(drift[0].chapterTitle).toBe('Chapter One');
+  });
+
+  it('embeds before-snapshot and current cast profile on each hard-drift event', async () => {
+    seed({
+      snapshots: { eliza: { voiceId: 'old', gender: 'female', tone: { warmth: 60 } } },
+      cast: [{ id: 'eliza', voiceId: 'new', gender: 'female', tone: { warmth: 60 } }],
+    });
+    const res = await request(app).get(`/api/books/${bookId}/revisions`);
+    const drift = res.body.drift as DriftEventOut[];
+    expect(drift).toHaveLength(1);
+    /* `snapshot` mirrors the pre-render CharacterSnapshot; `current` mirrors
+       the live cast entry. Both are needed so the modal renders a self-
+       sufficient comparison card without re-querying the server. */
+    expect(drift[0].snapshot).toMatchObject({ voiceId: 'old', gender: 'female' });
+    expect(drift[0].current).toMatchObject({ voiceId: 'new', gender: 'female' });
+  });
+
+  it('embeds before-snapshot and current on tone-drift events', async () => {
+    seed({
+      snapshots: { eliza: { tone: { warmth: 30 } } },
+      cast: [{ id: 'eliza', tone: { warmth: 70 } }], // delta 40 → severe
+    });
+    const res = await request(app).get(`/api/books/${bookId}/revisions`);
+    const drift = res.body.drift as DriftEventOut[];
+    expect(drift).toHaveLength(1);
+    expect(drift[0].snapshot?.tone?.warmth).toBe(30);
+    expect(drift[0].current?.tone?.warmth).toBe(70);
+  });
+
+  it('embeds before-snapshot and current on attribute-drift events', async () => {
+    seed({
+      snapshots: { elwin: { attributes: ['kind'] } },
+      cast: [{ id: 'elwin', attributes: ['eccentric', 'kind'] }],
+    });
+    const res = await request(app).get(`/api/books/${bookId}/revisions`);
+    const drift = res.body.drift as DriftEventOut[];
+    expect(drift).toHaveLength(1);
+    expect(drift[0].snapshot?.attributes).toEqual(['kind']);
+    expect(drift[0].current?.attributes).toEqual(['eccentric', 'kind']);
   });
 });
 

--- a/server/src/routes/revisions.test.ts
+++ b/server/src/routes/revisions.test.ts
@@ -200,7 +200,8 @@ describe('GET /api/books/:bookId/revisions — hard-signal drift (always severe)
     const drift = res.body.drift as DriftEventOut[];
     expect(drift).toHaveLength(1);
     expect(drift[0]).toMatchObject({
-      id: 'drift:1:eliza:voice',
+      id: `drift:${bookId}:1:eliza:voice`,
+      bookId,
       severity: 'severe',
       factor: 'voice',
       characterId: 'eliza',
@@ -294,7 +295,8 @@ describe('GET /api/books/:bookId/revisions — attribute drift (set-symmetric-di
     const drift = res.body.drift as DriftEventOut[];
     expect(drift).toHaveLength(1);
     expect(drift[0]).toMatchObject({
-      id: 'drift:1:elwin:attributes',
+      id: `drift:${bookId}:1:elwin:attributes`,
+      bookId,
       severity: 'moderate',
       factor: 'attributes',
       characterId: 'elwin',
@@ -358,7 +360,7 @@ describe('GET /api/books/:bookId/revisions — attribute drift (set-symmetric-di
     seed({
       snapshots: { elwin: { attributes: ['kind'] } },
       cast: [{ id: 'elwin', attributes: ['eccentric', 'kind'] }],
-      dismissed: ['drift:1:elwin:attributes'],
+      dismissed: [`drift:${bookId}:1:elwin:attributes`],
     });
     const res = await request(app).get(`/api/books/${bookId}/revisions`);
     expect(res.body.drift).toEqual([]);
@@ -506,7 +508,7 @@ describe('GET /api/books/:bookId/revisions — dismissed filter', () => {
     seed({
       snapshots: { eliza: { voiceId: 'old' } },
       cast: [{ id: 'eliza', voiceId: 'new' }],
-      dismissed: ['drift:1:eliza:voice'],
+      dismissed: [`drift:${bookId}:1:eliza:voice`],
     });
     const res = await request(app).get(`/api/books/${bookId}/revisions`);
     expect(res.body.drift).toEqual([]);
@@ -516,7 +518,7 @@ describe('GET /api/books/:bookId/revisions — dismissed filter', () => {
     seed({
       snapshots: { eliza: { voiceId: 'old', gender: 'female' } },
       cast: [{ id: 'eliza', voiceId: 'new', gender: 'male' }],
-      dismissed: ['drift:1:eliza:voice'],
+      dismissed: [`drift:${bookId}:1:eliza:voice`],
     });
     const res = await request(app).get(`/api/books/${bookId}/revisions`);
     const factors = (res.body.drift as DriftEventOut[]).map((d) => d.factor);

--- a/server/src/routes/revisions.ts
+++ b/server/src/routes/revisions.ts
@@ -62,6 +62,10 @@ interface RevisionsPersisted {
 
 interface DriftEvent {
   id: string;
+  /** Book the event belongs to. Stamped at emit time from the route
+      param so the Drift Report modal can group events from multiple
+      concurrently-active books in a single flat list. */
+  bookId: string;
   characterId: string;
   chapterId: number;
   /** Chapter title embedded at emit time. Lets the Drift Report modal
@@ -124,6 +128,7 @@ revisionsRouter.get('/:bookId/revisions', async (req: Request, res: Response) =>
     const located = await findBookByBookId(req.params.bookId);
     if (!located) return res.status(404).json({ error: 'Book not found.' });
     const { bookDir, state } = located;
+    const bookId = req.params.bookId;
 
     const castFile = await readJson<{ characters: CastCharacter[] }>(castJsonPath(bookDir));
     const cast: CastCharacter[] = castFile?.characters ?? [];
@@ -155,6 +160,7 @@ revisionsRouter.get('/:bookId/revisions', async (req: Request, res: Response) =>
         if (!current) continue; // character removed from cast — nothing actionable here
         const detectedAt = seg.synthesizedAt ?? new Date().toISOString();
         const ctx = {
+          bookId,
           chapterId: seg.chapterId,
           chapterTitle,
           characterId,
@@ -185,6 +191,7 @@ revisionsRouter.get('/:bookId/revisions', async (req: Request, res: Response) =>
 });
 
 interface DriftContext {
+  bookId: string;
   chapterId: number;
   chapterTitle: string;
   characterId: string;
@@ -198,8 +205,9 @@ interface DriftContext {
    emit; helpers spread it into the event. */
 function comparisonFields(
   ctx: DriftContext,
-): Pick<DriftEvent, 'chapterTitle' | 'snapshot' | 'current'> {
+): Pick<DriftEvent, 'bookId' | 'chapterTitle' | 'snapshot' | 'current'> {
   return {
+    bookId: ctx.bookId,
     chapterTitle: ctx.chapterTitle,
     snapshot: ctx.snapshot,
     current: {
@@ -323,8 +331,15 @@ function pushToneDrift(out: DriftEvent[], ctx: DriftContext, key: ToneKey): void
   });
 }
 
-function driftId(ctx: { chapterId: number; characterId: string }, factor: string): string {
-  return `drift:${ctx.chapterId}:${ctx.characterId}:${factor}`;
+function driftId(
+  ctx: { bookId: string; chapterId: number; characterId: string },
+  factor: string,
+): string {
+  /* bookId in the prefix keeps event ids globally unique across
+     concurrently-active books — chapterId+characterId+factor can
+     collide for different books with parallel-numbered chapters and
+     shared narrator id. */
+  return `drift:${ctx.bookId}:${ctx.chapterId}:${ctx.characterId}:${factor}`;
 }
 
 async function loadSegmentsFiles(

--- a/server/src/routes/revisions.ts
+++ b/server/src/routes/revisions.ts
@@ -64,6 +64,11 @@ interface DriftEvent {
   id: string;
   characterId: string;
   chapterId: number;
+  /** Chapter title embedded at emit time. Lets the Drift Report modal
+      label rows without joining against the frontend's chapters slice
+      (single-book-scoped, but drift may span books). Falls back to the
+      chapter-scan title and finally to "Chapter N". */
+  chapterTitle: string;
   severity: 'mild' | 'moderate' | 'severe';
   factor: string;
   factorLabel: string;
@@ -74,6 +79,22 @@ interface DriftEvent {
       directly. Stays optional / absent on moderate + mild events. */
   autoQueueable?: boolean;
   metrics?: { current: number; expected: number; unit: string };
+  /** The CharacterSnapshot recorded at chapter-render time. Diffed by
+      the modal against `current` to render a side-by-side "When
+      rendered / Now" comparison. Mirrors the on-disk snapshot. */
+  snapshot: CharacterSnapshot;
+  /** The live cast profile for the character at poll time. Carried on
+      the event so the modal can render comparison cards even for
+      events belonging to non-active books (whose cast isn't in the
+      frontend's cast slice). */
+  current: {
+    name?: string;
+    voiceId?: string;
+    gender?: 'male' | 'female' | 'neutral';
+    ageRange?: 'child' | 'teen' | 'adult' | 'elderly';
+    tone?: { warmth?: number; pace?: number; authority?: number; emotion?: number };
+    attributes?: string[];
+  };
   detected: string;
   suggestedAction: string;
 }
@@ -116,15 +137,31 @@ revisionsRouter.get('/:bookId/revisions', async (req: Request, res: Response) =>
     const dismissed = new Set(Array.isArray(persisted?.dismissed) ? persisted!.dismissed! : []);
 
     const segmentsByChapter = await loadSegmentsFiles(bookDir, state.chapters);
+    /* Build a chapterId -> scan title fallback map once. `seg.chapterTitle`
+       wins when populated (older segments files may omit it); state.chapters
+       is the next-best source; "Chapter N" is the floor. */
+    const scanTitleById = new Map<number, string>();
+    for (const ch of state.chapters) scanTitleById.set(ch.id, ch.title);
     const drift: DriftEvent[] = [];
 
     for (const seg of segmentsByChapter) {
+      const chapterTitle =
+        seg.chapterTitle?.trim() ||
+        scanTitleById.get(seg.chapterId)?.trim() ||
+        `Chapter ${seg.chapterId}`;
       const snapshots = seg.characterSnapshots ?? {};
       for (const [characterId, snapshot] of Object.entries(snapshots)) {
         const current = castById.get(characterId);
         if (!current) continue; // character removed from cast — nothing actionable here
         const detectedAt = seg.synthesizedAt ?? new Date().toISOString();
-        const ctx = { chapterId: seg.chapterId, characterId, snapshot, current, detectedAt };
+        const ctx = {
+          chapterId: seg.chapterId,
+          chapterTitle,
+          characterId,
+          snapshot,
+          current,
+          detectedAt,
+        };
         /* No engine-drift factor: engine isn't stored in cast.json (it's per-
            generation, set on the Generate view), so there's no current value
            to compare against. A voiceId swap covers the cross-engine case in
@@ -149,10 +186,31 @@ revisionsRouter.get('/:bookId/revisions', async (req: Request, res: Response) =>
 
 interface DriftContext {
   chapterId: number;
+  chapterTitle: string;
   characterId: string;
   snapshot: CharacterSnapshot;
   current: CastCharacter;
   detectedAt: string;
+}
+
+/* Projection of the comparison context shared by every emit site so the
+   modal renders a self-sufficient side-by-side card. Built once per
+   emit; helpers spread it into the event. */
+function comparisonFields(
+  ctx: DriftContext,
+): Pick<DriftEvent, 'chapterTitle' | 'snapshot' | 'current'> {
+  return {
+    chapterTitle: ctx.chapterTitle,
+    snapshot: ctx.snapshot,
+    current: {
+      name: ctx.current.name,
+      voiceId: ctx.current.voiceId,
+      gender: ctx.current.gender,
+      ageRange: ctx.current.ageRange,
+      tone: ctx.current.tone,
+      attributes: ctx.current.attributes,
+    },
+  };
 }
 
 /* Severe drift = the listener will hear "different person". The frontend
@@ -189,6 +247,7 @@ function pushHardDrift(
     autoQueueable: autoQueueableFor('severe'),
     detected: ctx.detectedAt,
     suggestedAction: 'regenerate_chapter',
+    ...comparisonFields(ctx),
   });
 }
 
@@ -226,6 +285,7 @@ function pushAttributesDrift(out: DriftEvent[], ctx: DriftContext): void {
     description: `Attributes ${parts.join('; ')} after this chapter rendered. Prebuilt-voice picker may now resolve to a different voice on regenerate.`,
     detected: ctx.detectedAt,
     suggestedAction: 'regenerate_chapter',
+    ...comparisonFields(ctx),
   });
 }
 
@@ -259,6 +319,7 @@ function pushToneDrift(out: DriftEvent[], ctx: DriftContext, key: ToneKey): void
     metrics: { current: after, expected: before, unit: 'points' },
     detected: ctx.detectedAt,
     suggestedAction: 'regenerate_chapter',
+    ...comparisonFields(ctx),
   });
 }
 

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -7,7 +7,7 @@ import { fetchAccountSettings } from '../store/account-slice';
 import { chaptersActions, STALL_THRESHOLD_MS } from '../store/chapters-slice';
 import { manuscriptActions } from '../store/manuscript-slice';
 import { analysisActions } from '../store/analysis-slice';
-import { revisionsActions } from '../store/revisions-slice';
+import { revisionsActions, selectDriftByBook } from '../store/revisions-slice';
 import { libraryActions } from '../store/library-slice';
 import { voicesActions } from '../store/voices-slice';
 import { changeLogActions } from '../store/change-log-slice';
@@ -83,7 +83,8 @@ export function Layout() {
   const chapters = useAppSelector((s) => s.chapters.chapters);
   const activeStream = useAppSelector((s) => s.chapters.activeStream);
   const analysisStream = useAppSelector((s) => s.analysis.activeStream);
-  const drift = useAppSelector((s) => s.revisions.drift);
+  const driftByBookId = useAppSelector(selectDriftByBook);
+  const bookMetaSaved = useAppSelector((s) => s.bookMeta.saved);
   const pending = useAppSelector((s) => s.revisions.pending);
   const manuscript = useAppSelector((s) => s.manuscript);
   const library = useAppSelector((s) => s.library);
@@ -831,16 +832,19 @@ export function Layout() {
       )}
       {ui.showDriftReport && (
         <DriftReportModal
-          events={drift}
-          characters={characters}
-          /* Bug 8 — wire the inline A/B player. Both required for the
-             widget to mount; bookId routes the chapter audio URL, voices
-             resolves each character.voiceId to a playable Voice for the
-             sample side. */
-          bookId={bookId ?? undefined}
+          /* Multi-book grouping: each entry in driftByBookId becomes a
+             section under its book's title. Cast slice only carries the
+             active book's characters today — cross-book events fall back
+             to the embedded `event.current.name` for display. */
+          eventsByBook={driftByBookId.map((g) => ({
+            bookId: g.bookId,
+            bookTitle: bookMetaSaved[g.bookId]?.title || g.bookId,
+            characters: g.bookId === bookId ? characters : [],
+            events: g.events,
+          }))}
           voices={voices}
           onClose={() => dispatch(uiActions.setShowDriftReport(false))}
-          onRegenerateChapter={(charId, chapterId) => {
+          onRegenerateChapter={(_evBookId, charId, chapterId) => {
             dispatch(uiActions.setShowDriftReport(false));
             dispatch(
               uiActions.setRegenCharacterCtx({ characterId: charId, defaultChapterId: chapterId }),
@@ -851,7 +855,7 @@ export function Layout() {
              onConfirm would have fired, just without the intermediate click. The
              reverse local-analyzer guard still gates the action so a live local
              analysis prompts before TTS starts. */
-          onAutoQueueRegenerate={(charId, chapterId) => {
+          onAutoQueueRegenerate={(_evBookId, charId, chapterId) => {
             dispatch(uiActions.setShowDriftReport(false));
             const character = characters.find((c) => c.id === charId);
             reverseAnalyzerGuard(() => {

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -378,7 +378,9 @@ export function Layout() {
             chapterCharacters: res.chapterCharacters,
           }),
         );
-        dispatch(revisionsActions.hydrateFromBookState(res.revisions ?? null));
+        dispatch(
+          revisionsActions.hydrateFromBookState(res.revisions ? { bookId, ...res.revisions } : null),
+        );
         dispatch(changeLogActions.hydrateFromBookState(res.changeLog ?? null));
         /* Editable Listen-view metadata: seed from state.json's editorial
            fields, falling back to the cast narrator's name when the book
@@ -527,7 +529,7 @@ export function Layout() {
     let cancelled = false;
     const fetchOnce = () =>
       api.pollRevisions({ bookId }).then((res) => {
-        if (!cancelled) dispatch(revisionsActions.applyPoll(res));
+        if (!cancelled) dispatch(revisionsActions.applyPoll({ ...res, bookId }));
       });
     fetchOnce();
     const t = setInterval(fetchOnce, 30000);

--- a/src/data/drift.ts
+++ b/src/data/drift.ts
@@ -2,8 +2,8 @@ import type { DriftEvent } from '../lib/types';
 
 /* Mock drift events used by `api.pollRevisions` in VITE_USE_MOCKS mode.
    Two books are seeded so the modal's multi-book grouping renders in
-   dev: `bk-active-design` (the design fixture's current book) and
-   `bk-keefe-bonus` (a second book to exercise the cross-book header).
+   dev: `sb` (the design fixture's current book) and
+   `cc` (a second book to exercise the cross-book header).
 
    Each event now embeds the structured comparison payload the Drift
    Report relies on: `chapterTitle` (so the row label doesn't need to
@@ -12,8 +12,8 @@ import type { DriftEvent } from '../lib/types';
    server/src/routes/revisions.ts. */
 export const VOICE_DRIFT_EVENTS: DriftEvent[] = [
   {
-    id: 'drift:bk-active-design:7:eliza:register',
-    bookId: 'bk-active-design',
+    id: 'drift:sb:7:eliza:register',
+    bookId: 'sb',
     characterId: 'eliza',
     chapterId: 7,
     chapterTitle: 'An Unexpected Reading',
@@ -42,8 +42,8 @@ export const VOICE_DRIFT_EVENTS: DriftEvent[] = [
     suggestedAction: 'regenerate_chapter',
   },
   {
-    id: 'drift:bk-active-design:5:halloran:pace',
-    bookId: 'bk-active-design',
+    id: 'drift:sb:5:halloran:pace',
+    bookId: 'sb',
     characterId: 'halloran',
     chapterId: 5,
     chapterTitle: "What the Captain Knew",
@@ -72,8 +72,8 @@ export const VOICE_DRIFT_EVENTS: DriftEvent[] = [
     suggestedAction: 'regenerate_chapter',
   },
   {
-    id: 'drift:bk-active-design:4:marcus:warmth',
-    bookId: 'bk-active-design',
+    id: 'drift:sb:4:marcus:warmth',
+    bookId: 'sb',
     characterId: 'marcus',
     chapterId: 4,
     chapterTitle: "The Cook's Particular Soup",
@@ -103,8 +103,8 @@ export const VOICE_DRIFT_EVENTS: DriftEvent[] = [
   },
   /* Second book — exercises the multi-book group header in dev. */
   {
-    id: 'drift:bk-keefe-bonus:3:sophie:attributes',
-    bookId: 'bk-keefe-bonus',
+    id: 'drift:cc:3:sophie:attributes',
+    bookId: 'cc',
     characterId: 'sophie',
     chapterId: 3,
     chapterTitle: 'A Letter From Elwin',

--- a/src/data/drift.ts
+++ b/src/data/drift.ts
@@ -1,43 +1,134 @@
 import type { DriftEvent } from '../lib/types';
 
+/* Mock drift events used by `api.pollRevisions` in VITE_USE_MOCKS mode.
+   Two books are seeded so the modal's multi-book grouping renders in
+   dev: `bk-active-design` (the design fixture's current book) and
+   `bk-keefe-bonus` (a second book to exercise the cross-book header).
+
+   Each event now embeds the structured comparison payload the Drift
+   Report relies on: `chapterTitle` (so the row label doesn't need to
+   join chapters slice), `snapshot` (pre-render profile), `current`
+   (live cast profile). Mirror of the server emit contract in
+   server/src/routes/revisions.ts. */
 export const VOICE_DRIFT_EVENTS: DriftEvent[] = [
   {
-    id: 'd1',
+    id: 'drift:bk-active-design:7:eliza:register',
+    bookId: 'bk-active-design',
     characterId: 'eliza',
     chapterId: 7,
+    chapterTitle: 'An Unexpected Reading',
     severity: 'severe',
     factor: 'register',
     factorLabel: 'Vocabulary register',
     description:
       "Eliza's register here doesn't match her established defiant working-class register from chapters 1–6. The chapter reads more formal — likely an artefact of recent manuscript edits.",
     metrics: { current: 32, expected: 65, unit: 'informality' },
+    snapshot: {
+      voiceId: 'af_sarah',
+      gender: 'female',
+      ageRange: 'adult',
+      tone: { warmth: 60, pace: 50, authority: 45, emotion: 55 },
+      attributes: ['defiant', 'working-class', 'sharp'],
+    },
+    current: {
+      name: 'Eliza',
+      voiceId: 'af_sarah',
+      gender: 'female',
+      ageRange: 'adult',
+      tone: { warmth: 60, pace: 50, authority: 45, emotion: 55 },
+      attributes: ['defiant', 'working-class', 'sharp'],
+    },
     detected: '2 hr ago',
     suggestedAction: 'regenerate_chapter',
   },
   {
-    id: 'd2',
+    id: 'drift:bk-active-design:5:halloran:pace',
+    bookId: 'bk-active-design',
     characterId: 'halloran',
     chapterId: 5,
+    chapterTitle: "What the Captain Knew",
     severity: 'moderate',
     factor: 'pace',
     factorLabel: 'Pace',
     description:
       "22% faster than character average. Halloran's hallmark slow command feels rushed in this chapter.",
     metrics: { current: 188, expected: 154, unit: 'words / min' },
+    snapshot: {
+      voiceId: 'am_michael',
+      gender: 'male',
+      ageRange: 'adult',
+      tone: { warmth: 50, pace: 30, authority: 80, emotion: 40 },
+      attributes: ['commanding', 'measured'],
+    },
+    current: {
+      name: 'Captain Halloran',
+      voiceId: 'am_michael',
+      gender: 'male',
+      ageRange: 'adult',
+      tone: { warmth: 50, pace: 65, authority: 80, emotion: 40 },
+      attributes: ['commanding', 'measured'],
+    },
     detected: '1 hr ago',
     suggestedAction: 'regenerate_chapter',
   },
   {
-    id: 'd3',
+    id: 'drift:bk-active-design:4:marcus:warmth',
+    bookId: 'bk-active-design',
     characterId: 'marcus',
     chapterId: 4,
+    chapterTitle: "The Cook's Particular Soup",
     severity: 'mild',
     factor: 'warmth',
     factorLabel: 'Warmth',
     description:
       "Slightly cooler than Marcus's profile. Within tolerance — worth a listen if the chapter sounds off.",
     metrics: { current: 68, expected: 80, unit: 'warmth score' },
+    snapshot: {
+      voiceId: 'am_adam',
+      gender: 'male',
+      ageRange: 'adult',
+      tone: { warmth: 80, pace: 50, authority: 50, emotion: 60 },
+      attributes: ['warm', 'gentle'],
+    },
+    current: {
+      name: 'Marcus',
+      voiceId: 'am_adam',
+      gender: 'male',
+      ageRange: 'adult',
+      tone: { warmth: 68, pace: 50, authority: 50, emotion: 60 },
+      attributes: ['warm', 'gentle'],
+    },
     detected: '30 min ago',
     suggestedAction: 'review',
+  },
+  /* Second book — exercises the multi-book group header in dev. */
+  {
+    id: 'drift:bk-keefe-bonus:3:sophie:attributes',
+    bookId: 'bk-keefe-bonus',
+    characterId: 'sophie',
+    chapterId: 3,
+    chapterTitle: 'A Letter From Elwin',
+    severity: 'moderate',
+    factor: 'attributes',
+    factorLabel: 'Attributes',
+    description:
+      'Attributes added "enthusiastic", "personable", "chatty" after this chapter rendered. Prebuilt-voice picker may now resolve to a different voice on regenerate.',
+    snapshot: {
+      voiceId: 'af_bella',
+      gender: 'female',
+      ageRange: 'teen',
+      tone: { warmth: 70, pace: 55, authority: 35, emotion: 70 },
+      attributes: ['warm', 'observant'],
+    },
+    current: {
+      name: 'Sophie Foster',
+      voiceId: 'af_bella',
+      gender: 'female',
+      ageRange: 'teen',
+      tone: { warmth: 70, pace: 55, authority: 35, emotion: 70 },
+      attributes: ['warm', 'observant', 'enthusiastic', 'personable', 'chatty'],
+    },
+    detected: '12 min ago',
+    suggestedAction: 'regenerate_chapter',
   },
 ];

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1717,6 +1717,8 @@ export interface components {
         };
         DriftEvent: {
             id: string;
+            /** @description Book the event belongs to. Server stamps this at emit time from the request path; included in the event id for global uniqueness across concurrently-active books. Lets the Drift Report group events by book in a single modal even when the user has multiple books generating in parallel. */
+            bookId: string;
             characterId: string;
             chapterId: number;
             /** @description Title of the chapter whose render produced this drift event, embedded server-side at emit time so the Drift Report modal can label each row without depending on the live chapters slice (which is single-book-scoped, but drift may span books). Falls back to the chapter-scan title and finally to "Chapter N" when no title is available. */

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1719,6 +1719,8 @@ export interface components {
             id: string;
             characterId: string;
             chapterId: number;
+            /** @description Title of the chapter whose render produced this drift event, embedded server-side at emit time so the Drift Report modal can label each row without depending on the live chapters slice (which is single-book-scoped, but drift may span books). Falls back to the chapter-scan title and finally to "Chapter N" when no title is available. */
+            chapterTitle: string;
             /** @enum {string} */
             severity: "mild" | "moderate" | "severe";
             /** @example register */
@@ -1731,6 +1733,38 @@ export interface components {
                 current?: number;
                 expected?: number;
                 unit?: string;
+            };
+            /** @description The character profile as captured at chapter render time. Diffed against `current` by the modal to render a side-by-side "When rendered / Now" comparison so the user can judge whether the drift actually matters. Mirrors the on-disk CharacterSnapshot in <slug>.segments.json. */
+            snapshot?: {
+                voiceId?: string;
+                voiceEngine?: string;
+                /** @enum {string} */
+                gender?: "male" | "female" | "neutral";
+                /** @enum {string} */
+                ageRange?: "child" | "teen" | "adult" | "elderly";
+                tone?: {
+                    warmth?: number;
+                    pace?: number;
+                    authority?: number;
+                    emotion?: number;
+                };
+                attributes?: string[];
+            };
+            /** @description The live cast profile for this character at poll time. Embedded alongside `snapshot` so the comparison card is data-self-sufficient even when the event belongs to a non-active book whose cast isn't in the frontend's chapters / cast slice. */
+            current?: {
+                name?: string;
+                voiceId?: string;
+                /** @enum {string} */
+                gender?: "male" | "female" | "neutral";
+                /** @enum {string} */
+                ageRange?: "child" | "teen" | "adult" | "elderly";
+                tone?: {
+                    warmth?: number;
+                    pace?: number;
+                    authority?: number;
+                    emotion?: number;
+                };
+                attributes?: string[];
             };
             detected?: string;
             /** @example regenerate_chapter */

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -901,11 +901,16 @@ async function mockRejectChapterRevision(_args: {
   await wait(100);
 }
 
-async function mockPollRevisions(_args: PollArgs): Promise<RevisionsResponse> {
+async function mockPollRevisions(args: PollArgs): Promise<RevisionsResponse> {
   await wait(200);
+  /* Filter drift to the requested book so the mock mirrors the server's
+     per-book endpoint shape. The dev fixture seeds events for two
+     books — the modal's multi-book grouping only renders if the slice
+     accumulates entries from each book separately, which is what
+     happens when `applyPoll` is called once per book. */
   return {
     pending: PENDING_REVISIONS,
-    drift: VOICE_DRIFT_EVENTS,
+    drift: VOICE_DRIFT_EVENTS.filter((d) => !args.bookId || d.bookId === args.bookId),
   };
 }
 

--- a/src/modals/drift-report.test.tsx
+++ b/src/modals/drift-report.test.tsx
@@ -1,18 +1,19 @@
-/* Pairs with docs/features/20-revisions-and-drift.md.
+/* Pairs with docs/features/35-engine-drift-detection.md and the
+   drift-report-fidelity plan.
 
-   Covers the C1+C2 split between auto-queueable (severe) and manual
-   (moderate / mild) drift events: severe events render the one-click
-   "Auto-regen now" pill that bypasses the regen-modal confirmation,
-   moderate / mild events keep the existing "Regenerate this chapter"
-   pill that opens the modal. When no autoQueueable handler is provided
-   the modal falls back to the manual flow for every event (regression
-   guard for surfaces that haven't opted into the shortcut). */
+   Covers:
+     - C1+C2 auto-queueable vs manual regen pill split.
+     - Chapter title is read from event.chapterTitle (no fixture join).
+     - Multi-book grouping: events from two books render under separate
+       book headers in a single modal.
+     - Side-by-side ProfileCompareCard renders both columns and highlights
+       the changed factor. */
 
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
-import { DriftReportModal } from './drift-report';
+import { DriftReportModal, type DriftBookGroup } from './drift-report';
 import { uiSlice } from '../store/ui-slice';
 import type { DriftEvent, Character, Voice } from '../lib/types';
 
@@ -42,12 +43,6 @@ vi.mock('../lib/api', () => ({
 }));
 
 const characters: Character[] = [
-  /* color must be a CHAR_COLORS key (narrator or slot-N) — see colors.ts.
-     Drift-report does `CHAR_COLORS[char.color].hex`, so a fixture using
-     unmapped names like 'magenta' would crash before the test assertions
-     ran. voiceId added 2026-05-19 for the Listen A/B widget — the widget
-     only mounts when a matching Voice is plumbed in via the `voices`
-     prop, so character.voiceId has to resolve to an entry there. */
   { id: 'eliza', name: 'Eliza', role: 'Lead', color: 'slot-4', voiceId: 'voice-eliza' } as Character,
   { id: 'sten', name: 'Sten', role: 'Friend', color: 'slot-5' } as Character,
 ];
@@ -60,9 +55,11 @@ const elizaVoice: Voice = {
 
 function makeEvent(over: Partial<DriftEvent>): DriftEvent {
   return {
-    id: 'drift:1:eliza:voice',
+    id: 'drift:book-A:1:eliza:voice',
+    bookId: 'book-A',
     characterId: 'eliza',
     chapterId: 1,
+    chapterTitle: 'What the Captain Knew',
     severity: 'severe',
     factor: 'voice',
     factorLabel: 'Voice',
@@ -70,8 +67,20 @@ function makeEvent(over: Partial<DriftEvent>): DriftEvent {
     autoQueueable: true,
     detected: '2026-01-01T00:00:00Z',
     suggestedAction: 'regenerate_chapter',
+    snapshot: { voiceId: 'old-voice', tone: { warmth: 40, pace: 50 }, attributes: ['warm'] },
+    current: { voiceId: 'new-voice', tone: { warmth: 40, pace: 50 }, attributes: ['warm'] },
     ...over,
   } as DriftEvent;
+}
+
+function group(events: DriftEvent[], over: Partial<DriftBookGroup> = {}): DriftBookGroup {
+  return {
+    bookId: 'book-A',
+    bookTitle: 'Bonus Keefe Story',
+    characters,
+    events,
+    ...over,
+  };
 }
 
 describe('DriftReportModal — auto-queueable severe drift (C1+C2)', () => {
@@ -80,24 +89,20 @@ describe('DriftReportModal — auto-queueable severe drift (C1+C2)', () => {
     const onRegenerateChapter = vi.fn();
     render(
       <DriftReportModal
-        events={[makeEvent({})]}
-        characters={characters}
+        eventsByBook={[group([makeEvent({})])]}
         onClose={vi.fn()}
         onRegenerateChapter={onRegenerateChapter}
         onAutoQueueRegenerate={onAutoQueueRegenerate}
         onDismiss={vi.fn()}
       />,
     );
-    const autoBtn = screen.getByTestId('drift-auto-regen-drift:1:eliza:voice');
+    const autoBtn = screen.getByTestId('drift-auto-regen-drift:book-A:1:eliza:voice');
     expect(autoBtn).toBeInTheDocument();
     expect(autoBtn).toHaveTextContent(/Auto-regen now/i);
-    /* Manual pill is NOT rendered for this row — auto and manual are
-       mutually exclusive on a single drift card. */
-    expect(screen.queryByTestId('drift-regen-drift:1:eliza:voice')).toBeNull();
+    expect(screen.queryByTestId('drift-regen-drift:book-A:1:eliza:voice')).toBeNull();
 
     fireEvent.click(autoBtn);
-    expect(onAutoQueueRegenerate).toHaveBeenCalledWith('eliza', 1);
-    /* The modal-opening manual handler stays untouched for auto-queueable rows. */
+    expect(onAutoQueueRegenerate).toHaveBeenCalledWith('book-A', 'eliza', 1);
     expect(onRegenerateChapter).not.toHaveBeenCalled();
   });
 
@@ -106,92 +111,215 @@ describe('DriftReportModal — auto-queueable severe drift (C1+C2)', () => {
     const onRegenerateChapter = vi.fn();
     render(
       <DriftReportModal
-        events={[
-          makeEvent({
-            id: 'drift:1:eliza:pace',
-            factor: 'pace',
-            factorLabel: 'Pace',
-            severity: 'moderate',
-            autoQueueable: undefined,
-          }),
+        eventsByBook={[
+          group([
+            makeEvent({
+              id: 'drift:book-A:1:eliza:pace',
+              factor: 'pace',
+              factorLabel: 'Pace',
+              severity: 'moderate',
+              autoQueueable: undefined,
+            }),
+          ]),
         ]}
-        characters={characters}
         onClose={vi.fn()}
         onRegenerateChapter={onRegenerateChapter}
         onAutoQueueRegenerate={onAutoQueueRegenerate}
         onDismiss={vi.fn()}
       />,
     );
-    const manualBtn = screen.getByTestId('drift-regen-drift:1:eliza:pace');
+    const manualBtn = screen.getByTestId('drift-regen-drift:book-A:1:eliza:pace');
     expect(manualBtn).toBeInTheDocument();
     expect(manualBtn).toHaveTextContent(/Regenerate this chapter/i);
-    expect(screen.queryByTestId('drift-auto-regen-drift:1:eliza:pace')).toBeNull();
+    expect(screen.queryByTestId('drift-auto-regen-drift:book-A:1:eliza:pace')).toBeNull();
 
     fireEvent.click(manualBtn);
-    expect(onRegenerateChapter).toHaveBeenCalledWith('eliza', 1);
+    expect(onRegenerateChapter).toHaveBeenCalledWith('book-A', 'eliza', 1);
     expect(onAutoQueueRegenerate).not.toHaveBeenCalled();
   });
 
   it('falls back to the manual Regenerate pill on every event when no autoQueueable handler is provided', () => {
-    /* Regression guard: surfaces that haven't opted into the shortcut
-       (or are still mocking the modal under test) get the original UX
-       without lighting up the new affordance. */
     const onRegenerateChapter = vi.fn();
     render(
       <DriftReportModal
-        events={[makeEvent({})]}
-        characters={characters}
+        eventsByBook={[group([makeEvent({})])]}
         onClose={vi.fn()}
         onRegenerateChapter={onRegenerateChapter}
         onDismiss={vi.fn()}
       />,
     );
-    expect(screen.queryByTestId('drift-auto-regen-drift:1:eliza:voice')).toBeNull();
-    const manualBtn = screen.getByTestId('drift-regen-drift:1:eliza:voice');
+    expect(screen.queryByTestId('drift-auto-regen-drift:book-A:1:eliza:voice')).toBeNull();
+    const manualBtn = screen.getByTestId('drift-regen-drift:book-A:1:eliza:voice');
     fireEvent.click(manualBtn);
-    expect(onRegenerateChapter).toHaveBeenCalledWith('eliza', 1);
+    expect(onRegenerateChapter).toHaveBeenCalledWith('book-A', 'eliza', 1);
   });
 
   it('groups severe + moderate events under separate severity headings (regression for the existing layout)', () => {
-    /* Spot-check the existing grouping behavior survives the C1+C2
-       split — the severe row picks up the Auto-regen pill while the
-       moderate row keeps the manual pill, in the same modal. */
     const onAutoQueueRegenerate = vi.fn();
     render(
       <DriftReportModal
-        events={[
-          makeEvent({}),
-          makeEvent({
-            id: 'drift:1:sten:pace',
-            characterId: 'sten',
-            factor: 'pace',
-            factorLabel: 'Pace',
-            severity: 'moderate',
-            autoQueueable: undefined,
-          }),
+        eventsByBook={[
+          group([
+            makeEvent({}),
+            makeEvent({
+              id: 'drift:book-A:1:sten:pace',
+              characterId: 'sten',
+              factor: 'pace',
+              factorLabel: 'Pace',
+              severity: 'moderate',
+              autoQueueable: undefined,
+            }),
+          ]),
         ]}
-        characters={characters}
         onClose={vi.fn()}
         onRegenerateChapter={vi.fn()}
         onAutoQueueRegenerate={onAutoQueueRegenerate}
         onDismiss={vi.fn()}
       />,
     );
-    expect(screen.getByTestId('drift-auto-regen-drift:1:eliza:voice')).toBeInTheDocument();
-    expect(screen.getByTestId('drift-regen-drift:1:sten:pace')).toBeInTheDocument();
+    expect(screen.getByTestId('drift-auto-regen-drift:book-A:1:eliza:voice')).toBeInTheDocument();
+    expect(screen.getByTestId('drift-regen-drift:book-A:1:sten:pace')).toBeInTheDocument();
   });
 });
 
-/* Bug 8 — Listen button A/B player. Pre-fix the button at drift-report.tsx:165
-   was a pure stub: no onClick, no callback, no caller wiring. Now it expands
-   inline into two-button A/B controls: A plays the chapter audio that drifted
-   (static URL), B plays a sample of the established voice profile (lazy
-   resolved via api.getVoiceSample). Mutex via component state — only one
-   plays at a time. */
+describe('DriftReportModal — fidelity contract (drift-report-fidelity plan)', () => {
+  it('renders the chapter title from event.chapterTitle, not a fixture', () => {
+    /* Pre-fix the modal joined against initialChapters from src/data/chapters.ts
+       so "What the Captain Knew" surfaced even when the live book had no such
+       chapter. Now the title comes off the event payload, server-emitted. */
+    render(
+      <DriftReportModal
+        eventsByBook={[
+          group([
+            makeEvent({
+              chapterTitle: 'A Real Chapter Title',
+              chapterId: 42,
+              id: 'drift:book-A:42:eliza:voice',
+            }),
+          ]),
+        ]}
+        onClose={vi.fn()}
+        onRegenerateChapter={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    /* chapter title prefix-stripped in `stripChapterPrefix` — bare title remains. */
+    expect(screen.getByText(/A Real Chapter Title/)).toBeInTheDocument();
+    /* No fixture chapter title leaks through. */
+    expect(screen.queryByText(/What the Captain Knew/)).toBeNull();
+  });
+
+  it('renders a book header per group when more than one book has drift', () => {
+    render(
+      <DriftReportModal
+        eventsByBook={[
+          group([makeEvent({})], { bookId: 'book-A', bookTitle: 'Book Aleph' }),
+          group(
+            [
+              makeEvent({
+                id: 'drift:book-B:1:sten:voice',
+                bookId: 'book-B',
+                characterId: 'sten',
+              }),
+            ],
+            { bookId: 'book-B', bookTitle: 'Book Beth' },
+          ),
+        ]}
+        onClose={vi.fn()}
+        onRegenerateChapter={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Book Aleph')).toBeInTheDocument();
+    expect(screen.getByText('Book Beth')).toBeInTheDocument();
+    /* Header summary counts across books. */
+    expect(screen.getByText(/2 chapters flagged across 2 books/)).toBeInTheDocument();
+  });
+
+  it('omits the book sub-header when only one book has drift', () => {
+    render(
+      <DriftReportModal
+        eventsByBook={[group([makeEvent({})], { bookTitle: 'Bonus Keefe Story' })]}
+        onClose={vi.fn()}
+        onRegenerateChapter={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    /* Header summary collapses to today's "{N} chapter(s) flagged" form when
+       only one book is involved. */
+    expect(screen.getByText(/1 chapter flagged/)).toBeInTheDocument();
+    /* The single-book optimisation hides the redundant sub-header — the modal
+       title bar already names the surface. */
+    expect(screen.queryByText('Bonus Keefe Story')).toBeNull();
+  });
+
+  it('renders the side-by-side comparison with both When rendered and Now columns', () => {
+    render(
+      <DriftReportModal
+        eventsByBook={[
+          group([
+            makeEvent({
+              snapshot: {
+                voiceId: 'af_sarah',
+                gender: 'female',
+                ageRange: 'adult',
+                tone: { warmth: 45, pace: 50, authority: 50, emotion: 50 },
+                attributes: ['warm', 'calm'],
+              },
+              current: {
+                voiceId: 'af_nova',
+                gender: 'female',
+                ageRange: 'adult',
+                tone: { warmth: 75, pace: 50, authority: 50, emotion: 50 },
+                attributes: ['warm', 'calm', 'enthusiastic'],
+              },
+            }),
+          ]),
+        ]}
+        onClose={vi.fn()}
+        onRegenerateChapter={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('When rendered')).toBeInTheDocument();
+    expect(screen.getByText('Now')).toBeInTheDocument();
+    /* All major profile rows render — regression guard that the table
+       doesn't silently lose rows when one factor is undefined. */
+    expect(screen.getByTestId('drift-compare-row-voice')).toBeInTheDocument();
+    expect(screen.getByTestId('drift-compare-row-warmth')).toBeInTheDocument();
+    expect(screen.getByTestId('drift-compare-row-attributes')).toBeInTheDocument();
+  });
+
+  it('marks the changed-factor row with data-changed=true', () => {
+    render(
+      <DriftReportModal
+        eventsByBook={[
+          group([
+            makeEvent({
+              factor: 'warmth',
+              snapshot: { tone: { warmth: 30 } },
+              current: { tone: { warmth: 70 } },
+            }),
+          ]),
+        ]}
+        onClose={vi.fn()}
+        onRegenerateChapter={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('drift-compare-row-warmth')).toHaveAttribute(
+      'data-changed',
+      'true',
+    );
+    expect(screen.getByTestId('drift-compare-row-pace')).toHaveAttribute(
+      'data-changed',
+      'false',
+    );
+  });
+});
+
+/* Bug 8 — Listen button A/B player. */
 describe('DriftReportModal — Listen A/B compare player (bug 8)', () => {
-  /* Single prototype-level spy serves both A + B elements. The Bs are
-     aliases purely for test-name readability — there's only one method
-     on HTMLMediaElement.prototype to spy on. */
   let playSpy: ReturnType<typeof vi.spyOn>;
   let pauseSpy: ReturnType<typeof vi.spyOn>;
   let playASpy: ReturnType<typeof vi.spyOn>;
@@ -199,9 +327,6 @@ describe('DriftReportModal — Listen A/B compare player (bug 8)', () => {
   let playBSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    /* Stub HTMLMediaElement.play / pause so audio elements don't actually
-       fire decode + autoplay errors in jsdom. Vitest's jsdom doesn't ship
-       a real media pipeline. Each test gets a fresh spy. */
     playSpy = vi
       .spyOn(window.HTMLMediaElement.prototype, 'play')
       .mockImplementation(() => Promise.resolve());
@@ -224,9 +349,7 @@ describe('DriftReportModal — Listen A/B compare player (bug 8)', () => {
     return render(
       <Provider store={store}>
         <DriftReportModal
-          events={events}
-          characters={characters}
-          bookId="b-keeper"
+          eventsByBook={[group(events, { bookId: 'b-keeper' })]}
           voices={[elizaVoice]}
           onClose={vi.fn()}
           onRegenerateChapter={vi.fn()}
@@ -238,51 +361,48 @@ describe('DriftReportModal — Listen A/B compare player (bug 8)', () => {
 
   it('Listen button toggles inline A/B controls visible', () => {
     renderModalWithVoices([makeEvent({})]);
-    const listenBtn = screen.getByTestId('drift-listen-drift:1:eliza:voice');
-    /* Pre-click: A/B controls hidden. */
-    expect(screen.queryByTestId('drift-play-chapter-drift:1:eliza:voice')).toBeNull();
-    expect(screen.queryByTestId('drift-play-voice-drift:1:eliza:voice')).toBeNull();
+    const listenBtn = screen.getByTestId('drift-listen-drift:book-A:1:eliza:voice');
+    expect(screen.queryByTestId('drift-play-chapter-drift:book-A:1:eliza:voice')).toBeNull();
+    expect(screen.queryByTestId('drift-play-voice-drift:book-A:1:eliza:voice')).toBeNull();
     fireEvent.click(listenBtn);
-    /* Post-click: both buttons present. */
     expect(
-      screen.getByTestId('drift-play-chapter-drift:1:eliza:voice'),
+      screen.getByTestId('drift-play-chapter-drift:book-A:1:eliza:voice'),
     ).toBeInTheDocument();
-    expect(screen.getByTestId('drift-play-voice-drift:1:eliza:voice')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('drift-play-voice-drift:book-A:1:eliza:voice'),
+    ).toBeInTheDocument();
   });
 
   it('Play chapter calls .play() on the chapter audio element', () => {
     renderModalWithVoices([makeEvent({})]);
-    fireEvent.click(screen.getByTestId('drift-listen-drift:1:eliza:voice'));
-    fireEvent.click(screen.getByTestId('drift-play-chapter-drift:1:eliza:voice'));
+    fireEvent.click(screen.getByTestId('drift-listen-drift:book-A:1:eliza:voice'));
+    fireEvent.click(screen.getByTestId('drift-play-chapter-drift:book-A:1:eliza:voice'));
     expect(playASpy).toHaveBeenCalled();
   });
 
   it('Play voice fetches the sample URL on first click and plays it', async () => {
     renderModalWithVoices([makeEvent({})]);
-    fireEvent.click(screen.getByTestId('drift-listen-drift:1:eliza:voice'));
-    fireEvent.click(screen.getByTestId('drift-play-voice-drift:1:eliza:voice'));
+    fireEvent.click(screen.getByTestId('drift-listen-drift:book-A:1:eliza:voice'));
+    fireEvent.click(screen.getByTestId('drift-play-voice-drift:book-A:1:eliza:voice'));
     await waitFor(() => expect(getVoiceSampleSpy).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(playBSpy).toHaveBeenCalled());
   });
 
   it('starting B while A is playing pauses A first (mutex)', async () => {
     renderModalWithVoices([makeEvent({})]);
-    fireEvent.click(screen.getByTestId('drift-listen-drift:1:eliza:voice'));
-    fireEvent.click(screen.getByTestId('drift-play-chapter-drift:1:eliza:voice'));
+    fireEvent.click(screen.getByTestId('drift-listen-drift:book-A:1:eliza:voice'));
+    fireEvent.click(screen.getByTestId('drift-play-chapter-drift:book-A:1:eliza:voice'));
     expect(playASpy).toHaveBeenCalledTimes(1);
-    fireEvent.click(screen.getByTestId('drift-play-voice-drift:1:eliza:voice'));
+    fireEvent.click(screen.getByTestId('drift-play-voice-drift:book-A:1:eliza:voice'));
     await waitFor(() => expect(playBSpy).toHaveBeenCalled());
-    /* pauseASpy === pauseBSpy in this fixture (same prototype spy) — assert
-       a pause fired at least once before the second play. */
     expect(pauseASpy).toHaveBeenCalled();
   });
 
   it('closing the modal pauses both audio elements (cleanup)', () => {
     const { unmount } = renderModalWithVoices([makeEvent({})]);
-    fireEvent.click(screen.getByTestId('drift-listen-drift:1:eliza:voice'));
-    fireEvent.click(screen.getByTestId('drift-play-chapter-drift:1:eliza:voice'));
+    fireEvent.click(screen.getByTestId('drift-listen-drift:book-A:1:eliza:voice'));
+    fireEvent.click(screen.getByTestId('drift-play-chapter-drift:book-A:1:eliza:voice'));
     expect(playASpy).toHaveBeenCalled();
-    /* Unmount mimics modal-close — useEffect cleanup must pause the audio. */
     pauseASpy.mockClear();
     unmount();
     expect(pauseASpy).toHaveBeenCalled();

--- a/src/modals/drift-report.tsx
+++ b/src/modals/drift-report.tsx
@@ -3,29 +3,39 @@ import { IconAlertTri, IconClose, IconRefresh, IconWaveform } from '../lib/icons
 import { Avatar, Pill } from '../components/primitives';
 import { CHAR_COLORS } from '../lib/colors';
 import { stripChapterPrefix } from '../lib/format-chapter-title';
-import { initialChapters } from '../data/chapters';
 import { api } from '../lib/api';
 import { useAppSelector } from '../store';
 import type { DriftEvent, Character, CharColor, Voice } from '../lib/types';
 
-interface Props {
-  events: DriftEvent[];
+/* The modal now renders drift events grouped by book — the user's
+   concurrent-multibook workflow means a single open modal can be
+   showing drift from Book A AND Book B at the same time. Each event
+   carries `bookId`, `chapterTitle`, `snapshot` and `current` from the
+   server so the modal is a pure projection of the event payload (no
+   joins against the chapters / cast slice, both of which are scoped
+   to the active book). */
+export interface DriftBookGroup {
+  bookId: string;
+  bookTitle: string;
+  /** Cast for the book the events belong to. Used for avatar colour /
+      display name resolution; missing entries fall back to the event's
+      embedded `current.name` so cross-book events still render. */
   characters: Character[];
+  events: DriftEvent[];
+}
+
+interface Props {
+  eventsByBook: DriftBookGroup[];
   onClose: () => void;
-  onRegenerateChapter: (characterId: string, chapterId: number) => void;
+  onRegenerateChapter: (bookId: string, characterId: string, chapterId: number) => void;
   /** Optional one-click shortcut for events flagged `autoQueueable` by
       the server (severe drift). When provided, the per-event button on
       autoQueueable rows switches from "Regenerate this chapter" (which
       opens the regen-modal confirmation) to "Auto-regen now" (which
       dispatches regenerateCharacter directly with sensible defaults).
       Plan 20 C1+C2. */
-  onAutoQueueRegenerate?: (characterId: string, chapterId: number) => void;
+  onAutoQueueRegenerate?: (bookId: string, characterId: string, chapterId: number) => void;
   onDismiss: (eventId: string) => void;
-  /** Plan-8 — Listen A/B player. Optional so legacy / mock callers that
-      haven't opted in still render the modal without the per-row inline
-      player. When omitted the Listen button stays hidden (callers without
-      audio context can't usefully expose it). */
-  bookId?: string;
   voices?: Voice[];
 }
 
@@ -42,24 +52,16 @@ const severityColor: Record<DriftEvent['severity'], 'danger' | 'warning' | 'neut
 };
 
 export function DriftReportModal({
-  events,
-  characters,
+  eventsByBook,
   onClose,
   onRegenerateChapter,
   onAutoQueueRegenerate,
   onDismiss,
-  bookId,
   voices,
 }: Props) {
-  if (events.length === 0) return null;
-
-  const findChar = (id: string) => characters.find((c) => c.id === id);
-  const findChapter = (id: number) =>
-    initialChapters.find((c) => c.id === id) || { id, title: `Chapter ${id}` };
-  const grouped = events.reduce<Record<string, DriftEvent[]>>((acc, e) => {
-    (acc[e.severity] ??= []).push(e);
-    return acc;
-  }, {});
+  const totalCount = eventsByBook.reduce((acc, g) => acc + g.events.length, 0);
+  if (totalCount === 0) return null;
+  const bookCount = eventsByBook.length;
 
   return (
     <>
@@ -75,7 +77,8 @@ export function DriftReportModal({
                 Voice drift detector
               </p>
               <h3 className="text-base font-bold text-ink leading-tight">
-                {events.length} chapter{events.length === 1 ? '' : 's'} flagged
+                {totalCount} chapter{totalCount === 1 ? '' : 's'} flagged
+                {bookCount > 1 && ` across ${bookCount} books`}
               </h3>
             </div>
             <button onClick={onClose} className="p-2 rounded-full hover:bg-ink/5 text-ink/60">
@@ -83,129 +86,25 @@ export function DriftReportModal({
             </button>
           </div>
 
-          <div className="p-6 space-y-6 overflow-y-auto scrollbar-thin">
+          <div className="p-6 space-y-8 overflow-y-auto scrollbar-thin">
             <p className="text-sm text-ink/70 leading-relaxed">
-              We compared each chapter against the character's established voice profile. Severe and
-              moderate findings are worth a listen — mild ones are usually within tolerance.
+              We compared each chapter against the character's established voice profile. The "When
+              rendered" column shows the snapshot captured at synthesis time; "Now" shows the live
+              profile. Severe and moderate findings are worth a listen — mild ones are usually
+              within tolerance.
             </p>
 
-            {severityOrder.map((sev) => {
-              const items = grouped[sev];
-              if (!items || items.length === 0) return null;
-              return (
-                <section key={sev}>
-                  <div className="flex items-center gap-3 mb-3">
-                    <Pill color={severityColor[sev]}>{severityLabel[sev]}</Pill>
-                    <span className="flex-1 h-px bg-ink/10" />
-                    <span className="text-xs text-ink/50 tabular-nums">{items.length}</span>
-                  </div>
-                  <div className="space-y-2">
-                    {items.map((e) => {
-                      const char = findChar(e.characterId);
-                      const chap = findChapter(e.chapterId);
-                      return (
-                        <article
-                          key={e.id}
-                          className="p-4 rounded-2xl border border-ink/10 bg-white"
-                        >
-                          <div className="flex items-start gap-3">
-                            {char && (
-                              <Avatar name={char.name} color={char.color as CharColor} size={36} />
-                            )}
-                            <div className="flex-1 min-w-0">
-                              <div className="flex items-center gap-2 flex-wrap mb-1">
-                                <h4 className="text-sm font-bold text-ink">
-                                  {char?.name || e.characterId}
-                                </h4>
-                                <span className="text-xs text-ink/50">in</span>
-                                <span className="text-xs font-semibold text-ink">
-                                  CH {String(e.chapterId).padStart(2, '0')} ·{' '}
-                                  {stripChapterPrefix(chap.title)}
-                                </span>
-                              </div>
-                              <p
-                                className="text-[11px] uppercase tracking-wider font-bold mb-2"
-                                style={{
-                                  color: CHAR_COLORS[(char?.color as CharColor) || 'narrator'].hex,
-                                }}
-                              >
-                                {e.factorLabel}
-                              </p>
-                              <p className="text-xs text-ink/70 leading-relaxed mb-3">
-                                {e.description}
-                              </p>
-                              {e.metrics && (
-                                <div className="flex items-center gap-3 mb-3 text-xs">
-                                  <span className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-canvas border border-ink/10">
-                                    <span className="text-ink/50">Now:</span>
-                                    <span className="font-bold text-ink tabular-nums">
-                                      {e.metrics.current}
-                                    </span>
-                                  </span>
-                                  <span className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-canvas border border-ink/10">
-                                    <span className="text-ink/50">Profile:</span>
-                                    <span className="font-bold text-ink tabular-nums">
-                                      {e.metrics.expected}
-                                    </span>
-                                  </span>
-                                  <span className="text-ink/45">{e.metrics.unit}</span>
-                                </div>
-                              )}
-                              <div className="flex items-center gap-2">
-                                {e.autoQueueable && onAutoQueueRegenerate ? (
-                                  <button
-                                    onClick={() =>
-                                      onAutoQueueRegenerate(e.characterId, e.chapterId)
-                                    }
-                                    data-testid={`drift-auto-regen-${e.id}`}
-                                    title="Skip the confirmation modal — auto-queue this regeneration"
-                                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-peach text-ink text-xs font-semibold hover:bg-peach/85"
-                                  >
-                                    <IconRefresh className="w-3.5 h-3.5" /> Auto-regen now
-                                  </button>
-                                ) : (
-                                  <button
-                                    onClick={() => onRegenerateChapter(e.characterId, e.chapterId)}
-                                    data-testid={`drift-regen-${e.id}`}
-                                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-ink text-canvas text-xs font-semibold hover:bg-ink-soft"
-                                  >
-                                    <IconRefresh className="w-3.5 h-3.5" /> Regenerate this chapter
-                                  </button>
-                                )}
-                                {(() => {
-                                  const rowVoice = voices?.find((v) => v.id === char?.voiceId);
-                                  /* Mount the A/B widget only when the caller plumbed
-                                     both bookId and a resolvable voice. Pre-fix the
-                                     Listen button was a stub regardless — callers
-                                     that haven't opted in (legacy / unit-test mocks)
-                                     get the original "no Listen" surface. */
-                                  if (!bookId || !rowVoice) return null;
-                                  return (
-                                    <DriftListenWidget
-                                      event={e}
-                                      bookId={bookId}
-                                      voice={rowVoice}
-                                      character={char}
-                                    />
-                                  );
-                                })()}
-                                {/* Dismiss handled below as the modal-action sibling. */}
-                                <button
-                                  onClick={() => onDismiss(e.id)}
-                                  className="ml-auto text-xs font-medium text-ink/50 hover:text-ink/80"
-                                >
-                                  Dismiss
-                                </button>
-                              </div>
-                            </div>
-                          </div>
-                        </article>
-                      );
-                    })}
-                  </div>
-                </section>
-              );
-            })}
+            {eventsByBook.map((group) => (
+              <DriftBookSection
+                key={group.bookId}
+                group={group}
+                showBookHeader={bookCount > 1}
+                voices={voices}
+                onRegenerateChapter={onRegenerateChapter}
+                onAutoQueueRegenerate={onAutoQueueRegenerate}
+                onDismiss={onDismiss}
+              />
+            ))}
           </div>
 
           <div className="px-6 py-3 border-t border-ink/10 flex items-center justify-between text-xs text-ink/50">
@@ -215,6 +114,382 @@ export function DriftReportModal({
         </div>
       </div>
     </>
+  );
+}
+
+function DriftBookSection({
+  group,
+  showBookHeader,
+  voices,
+  onRegenerateChapter,
+  onAutoQueueRegenerate,
+  onDismiss,
+}: {
+  group: DriftBookGroup;
+  showBookHeader: boolean;
+  voices?: Voice[];
+  onRegenerateChapter: (bookId: string, characterId: string, chapterId: number) => void;
+  onAutoQueueRegenerate?: (bookId: string, characterId: string, chapterId: number) => void;
+  onDismiss: (eventId: string) => void;
+}) {
+  const grouped = group.events.reduce<Record<string, DriftEvent[]>>((acc, e) => {
+    (acc[e.severity] ??= []).push(e);
+    return acc;
+  }, {});
+  const findChar = (id: string) => group.characters.find((c) => c.id === id);
+
+  return (
+    <section className="space-y-4">
+      {showBookHeader && (
+        <header className="flex items-center gap-3 pb-2 border-b border-ink/10">
+          <span className="text-[10px] uppercase tracking-widest text-ink/45 font-semibold">
+            Book
+          </span>
+          <h4 className="text-sm font-bold text-ink leading-tight flex-1 truncate">
+            {group.bookTitle}
+          </h4>
+          <span className="text-xs text-ink/50 tabular-nums">
+            {group.events.length} flagged
+          </span>
+        </header>
+      )}
+      {severityOrder.map((sev) => {
+        const items = grouped[sev];
+        if (!items || items.length === 0) return null;
+        return (
+          <section key={sev}>
+            <div className="flex items-center gap-3 mb-3">
+              <Pill color={severityColor[sev]}>{severityLabel[sev]}</Pill>
+              <span className="flex-1 h-px bg-ink/10" />
+              <span className="text-xs text-ink/50 tabular-nums">{items.length}</span>
+            </div>
+            <div className="space-y-2">
+              {items.map((e) => {
+                const char = findChar(e.characterId);
+                /* `e.current.name` is always present from the server emit; the
+                   cast lookup adds color + the up-to-date display name when
+                   the cast slice happens to hold this book. */
+                const displayName = char?.name || e.current?.name || e.characterId;
+                const colorKey = (char?.color as CharColor | undefined) || 'narrator';
+                return (
+                  <article
+                    key={e.id}
+                    className="p-4 rounded-2xl border border-ink/10 bg-white"
+                    data-testid={`drift-event-${e.id}`}
+                  >
+                    <div className="flex items-start gap-3">
+                      <Avatar name={displayName} color={colorKey} size={36} />
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap mb-1">
+                          <h4 className="text-sm font-bold text-ink">{displayName}</h4>
+                          <span className="text-xs text-ink/50">in</span>
+                          <span className="text-xs font-semibold text-ink">
+                            CH {String(e.chapterId).padStart(2, '0')} ·{' '}
+                            {stripChapterPrefix(e.chapterTitle)}
+                          </span>
+                        </div>
+                        <p
+                          className="text-[11px] uppercase tracking-wider font-bold mb-2"
+                          style={{ color: CHAR_COLORS[colorKey].hex }}
+                        >
+                          {e.factorLabel}
+                        </p>
+                        <p className="text-xs text-ink/70 leading-relaxed mb-3">{e.description}</p>
+                        <ProfileCompareCard event={e} />
+                        <div className="flex items-center gap-2 mt-3">
+                          {e.autoQueueable && onAutoQueueRegenerate ? (
+                            <button
+                              onClick={() =>
+                                onAutoQueueRegenerate(group.bookId, e.characterId, e.chapterId)
+                              }
+                              data-testid={`drift-auto-regen-${e.id}`}
+                              title="Skip the confirmation modal — auto-queue this regeneration"
+                              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-peach text-ink text-xs font-semibold hover:bg-peach/85"
+                            >
+                              <IconRefresh className="w-3.5 h-3.5" /> Auto-regen now
+                            </button>
+                          ) : (
+                            <button
+                              onClick={() =>
+                                onRegenerateChapter(group.bookId, e.characterId, e.chapterId)
+                              }
+                              data-testid={`drift-regen-${e.id}`}
+                              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-ink text-canvas text-xs font-semibold hover:bg-ink-soft"
+                            >
+                              <IconRefresh className="w-3.5 h-3.5" /> Regenerate this chapter
+                            </button>
+                          )}
+                          {(() => {
+                            const rowVoice = voices?.find((v) => v.id === char?.voiceId);
+                            /* Listen widget mounts only when the caller plumbed
+                               a resolvable voice. Cross-book events whose cast
+                               isn't loaded won't have a voice match — gracefully
+                               omit the widget in that case. */
+                            if (!rowVoice) return null;
+                            return (
+                              <DriftListenWidget
+                                event={e}
+                                bookId={group.bookId}
+                                voice={rowVoice}
+                                character={char}
+                              />
+                            );
+                          })()}
+                          <button
+                            onClick={() => onDismiss(e.id)}
+                            className="ml-auto text-xs font-medium text-ink/50 hover:text-ink/80"
+                          >
+                            Dismiss
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          </section>
+        );
+      })}
+    </section>
+  );
+}
+
+/* Side-by-side "When rendered" vs "Now" profile comparison. Reads the
+   structured `snapshot` (pre-render) and `current` (live cast) payloads
+   the server attaches to every drift event. Fields that didn't change
+   render in muted ink; the changed field (matching `event.factor`) is
+   highlighted on the right column. */
+function ProfileCompareCard({ event }: { event: DriftEvent }) {
+  const snap = event.snapshot ?? {};
+  const cur = event.current ?? {};
+  const factor = event.factor;
+  type Row = {
+    label: string;
+    factor: string;
+    /** Display the pair as text (voice ids, gender, age) or as tone-bar pairs. */
+    kind: 'text' | 'tone' | 'attributes';
+    before?: string | number;
+    after?: string | number;
+    beforeAttrs?: string[];
+    afterAttrs?: string[];
+  };
+  const rows: Row[] = [
+    {
+      label: 'Voice',
+      factor: 'voice',
+      kind: 'text',
+      before: snap.voiceId ?? '—',
+      after: cur.voiceId ?? '—',
+    },
+    {
+      label: 'Gender',
+      factor: 'gender',
+      kind: 'text',
+      before: snap.gender ?? '—',
+      after: cur.gender ?? '—',
+    },
+    {
+      label: 'Age range',
+      factor: 'ageRange',
+      kind: 'text',
+      before: snap.ageRange ?? '—',
+      after: cur.ageRange ?? '—',
+    },
+    {
+      label: 'Warmth',
+      factor: 'warmth',
+      kind: 'tone',
+      before: snap.tone?.warmth,
+      after: cur.tone?.warmth,
+    },
+    {
+      label: 'Pace',
+      factor: 'pace',
+      kind: 'tone',
+      before: snap.tone?.pace,
+      after: cur.tone?.pace,
+    },
+    {
+      label: 'Authority',
+      factor: 'authority',
+      kind: 'tone',
+      before: snap.tone?.authority,
+      after: cur.tone?.authority,
+    },
+    {
+      label: 'Emotion',
+      factor: 'emotion',
+      kind: 'tone',
+      before: snap.tone?.emotion,
+      after: cur.tone?.emotion,
+    },
+    {
+      label: 'Attributes',
+      factor: 'attributes',
+      kind: 'attributes',
+      beforeAttrs: snap.attributes ?? [],
+      afterAttrs: cur.attributes ?? [],
+    },
+  ];
+
+  return (
+    <div className="rounded-xl border border-ink/10 bg-canvas/50 overflow-hidden text-xs">
+      <div className="grid grid-cols-[6.5rem_1fr_1fr] gap-x-3 py-2 px-3 bg-ink/5 text-[10px] uppercase tracking-wider font-semibold text-ink/55">
+        <span></span>
+        <span>When rendered</span>
+        <span>Now</span>
+      </div>
+      <div className="divide-y divide-ink/5">
+        {rows.map((row) => (
+          <ProfileCompareRow key={row.factor} row={row} changed={row.factor === factor} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ProfileCompareRow({
+  row,
+  changed,
+}: {
+  row: {
+    label: string;
+    factor: string;
+    kind: 'text' | 'tone' | 'attributes';
+    before?: string | number;
+    after?: string | number;
+    beforeAttrs?: string[];
+    afterAttrs?: string[];
+  };
+  changed: boolean;
+}) {
+  return (
+    <div
+      className="grid grid-cols-[6.5rem_1fr_1fr] gap-x-3 py-2 px-3 items-center"
+      data-testid={`drift-compare-row-${row.factor}`}
+      data-changed={changed ? 'true' : 'false'}
+    >
+      <span className="text-ink/55 font-medium">{row.label}</span>
+      {row.kind === 'tone' ? (
+        <>
+          <ToneBar value={row.before} muted />
+          <ToneBar value={row.after} highlight={changed} />
+        </>
+      ) : row.kind === 'attributes' ? (
+        <>
+          <AttributeList values={row.beforeAttrs ?? []} muted />
+          <AttributeList
+            values={row.afterAttrs ?? []}
+            highlight={changed}
+            diffAgainst={row.beforeAttrs}
+          />
+        </>
+      ) : (
+        <>
+          <span className="text-ink/65 tabular-nums truncate">{row.before}</span>
+          <span
+            className={`tabular-nums truncate ${
+              changed ? 'font-semibold text-ink' : 'text-ink/65'
+            }`}
+          >
+            {row.after}
+            {changed && <span className="ml-1 text-magenta">←</span>}
+          </span>
+        </>
+      )}
+    </div>
+  );
+}
+
+function ToneBar({
+  value,
+  muted,
+  highlight,
+}: {
+  value: number | string | undefined;
+  muted?: boolean;
+  highlight?: boolean;
+}) {
+  if (typeof value !== 'number') {
+    return <span className="text-ink/40">—</span>;
+  }
+  const pct = Math.max(0, Math.min(100, value));
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex-1 h-1.5 rounded-full bg-ink/10 overflow-hidden">
+        <div
+          className={`h-full rounded-full ${
+            highlight ? 'bg-magenta' : muted ? 'bg-ink/30' : 'bg-ink/60'
+          }`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span
+        className={`tabular-nums w-7 text-right ${
+          highlight ? 'font-semibold text-ink' : muted ? 'text-ink/55' : 'text-ink/70'
+        }`}
+      >
+        {pct}
+      </span>
+      {highlight && <span className="text-magenta">←</span>}
+    </div>
+  );
+}
+
+function AttributeList({
+  values,
+  diffAgainst,
+  muted,
+  highlight,
+}: {
+  values: string[];
+  /** If provided, items not in this list render with the "added" badge,
+      and any item in this list missing from `values` renders strikethrough. */
+  diffAgainst?: string[];
+  muted?: boolean;
+  highlight?: boolean;
+}) {
+  if (values.length === 0 && (!diffAgainst || diffAgainst.length === 0)) {
+    return <span className="text-ink/40">—</span>;
+  }
+  if (!diffAgainst) {
+    /* Plain "before" rendering — comma-separated. */
+    return (
+      <span className={`${muted ? 'text-ink/55' : 'text-ink/70'} truncate`}>
+        {values.join(', ')}
+      </span>
+    );
+  }
+  const before = new Set(diffAgainst);
+  const after = new Set(values);
+  const added = values.filter((v) => !before.has(v));
+  const removed = diffAgainst.filter((v) => !after.has(v));
+  const kept = values.filter((v) => before.has(v));
+  return (
+    <div className="flex flex-wrap gap-1 items-center">
+      {kept.map((v) => (
+        <span key={`k-${v}`} className="text-ink/65">
+          {v}
+        </span>
+      ))}
+      {added.map((v) => (
+        <span
+          key={`a-${v}`}
+          className={`rounded-full px-1.5 py-0.5 text-[10px] font-semibold ${
+            highlight ? 'bg-magenta/15 text-magenta' : 'bg-ink/10 text-ink'
+          }`}
+        >
+          + {v}
+        </span>
+      ))}
+      {removed.map((v) => (
+        <span key={`r-${v}`} className="text-ink/40 line-through">
+          {v}
+        </span>
+      ))}
+      {highlight && <span className="text-magenta">←</span>}
+    </div>
   );
 }
 
@@ -249,13 +524,6 @@ function DriftListenWidget({
   const chapterRef = useRef<HTMLAudioElement | null>(null);
   const voiceRef = useRef<HTMLAudioElement | null>(null);
 
-  /* Cleanup on unmount — modal close, parent re-render that drops the
-     row, etc. Pause both elements and detach src so the browser doesn't
-     hold decode buffers for a now-invisible widget. The audio elements
-     are rendered at all times (hidden when !open) so their refs survive
-     until React tears down the widget itself; if they were nested inside
-     the `open && <audio />` branch, React 18 detaches them BEFORE
-     running this cleanup and the refs would be null here. */
   useEffect(() => {
     const a = chapterRef.current;
     const b = voiceRef.current;
@@ -283,8 +551,6 @@ function DriftListenWidget({
     voiceRef.current?.pause();
     const el = chapterRef.current;
     if (!el) return;
-    /* Set src lazily on first play so a row whose Listen button is never
-       clicked doesn't trigger a chapter audio fetch. */
     if (el.src !== window.location.origin + chapterUrl && !el.src.endsWith(chapterUrl)) {
       el.src = chapterUrl;
     }
@@ -371,8 +637,6 @@ function DriftListenWidget({
           </button>
         </>
       )}
-      {/* Audio elements always mounted so their refs survive until the
-          widget itself unmounts (cleanup useEffect above relies on this). */}
       <audio ref={chapterRef} onEnded={() => setPlaying((p) => (p === 'A' ? null : p))} />
       <audio ref={voiceRef} onEnded={() => setPlaying((p) => (p === 'B' ? null : p))} />
     </span>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -464,7 +464,11 @@ function ReadyViewSwitch({
   const characters = useAppSelector((s) => s.cast.characters);
   const chapters = useAppSelector((s) => s.chapters.chapters);
   const paused = useAppSelector((s) => s.chapters.paused);
-  const drift = useAppSelector((s) => s.revisions.drift);
+  /* Cast view shows drift indicators per character, scoped to the
+     active book. The slice's `drift` is flat across books since the
+     Drift Report became multi-book; filter to bookId here so a
+     non-active book's events don't render badges on this book's cast. */
+  const drift = useAppSelector((s) => s.revisions.drift.filter((d) => d.bookId === bookId));
   const manuscript = useAppSelector((s) => s.manuscript);
   const library = useAppSelector((s) => s.library);
   const voices = useAppSelector((s) => s.voices.voices);

--- a/src/store/persistence-middleware.test.ts
+++ b/src/store/persistence-middleware.test.ts
@@ -130,7 +130,12 @@ describe('persistenceMiddleware — payload shape', () => {
 
   it('sends both pending + drift for revisions actions', async () => {
     const next = vi.fn((x) => x);
-    const state = baseState({ revisions: { pending: [{ id: 'r1' }], drift: [{ id: 'd1' }] } });
+    /* Each drift event carries its own bookId so the persist filter can
+       send only THIS book's drift to revisions.json (cross-book entries
+       belong on their own books' files). */
+    const state = baseState({
+      revisions: { pending: [{ id: 'r1' }], drift: [{ id: 'd1', bookId: 'book-1' }] },
+    });
     persistenceMiddleware(makeStore(state))(next)({ type: 'revisions/dismissDrift' });
     await advance(500);
     /* Plan 55 — `timeline` rides along with every revisions persist so a
@@ -139,7 +144,30 @@ describe('persistenceMiddleware — payload shape', () => {
        so this assertion still pins the dismissed-drift case shape. */
     expect(putBookState).toHaveBeenCalledWith('book-1', {
       slice: 'revisions',
-      patch: { pending: [{ id: 'r1' }], drift: [{ id: 'd1' }] },
+      patch: { pending: [{ id: 'r1' }], drift: [{ id: 'd1', bookId: 'book-1' }] },
+    });
+  });
+
+  it('drops other books\' drift events from the per-book persist patch', async () => {
+    /* Cross-book invariant: the flat drift list spans concurrently-active
+       books, but each book's revisions.json must only carry its own
+       events. Otherwise re-hydration on Book A would replay Book B's
+       drift into Book A's slot. */
+    const next = vi.fn((x) => x);
+    const state = baseState({
+      revisions: {
+        pending: [],
+        drift: [
+          { id: 'd-mine', bookId: 'book-1' },
+          { id: 'd-other', bookId: 'book-2' },
+        ],
+      },
+    });
+    persistenceMiddleware(makeStore(state))(next)({ type: 'revisions/dismissDrift' });
+    await advance(500);
+    expect(putBookState).toHaveBeenCalledWith('book-1', {
+      slice: 'revisions',
+      patch: { pending: [], drift: [{ id: 'd-mine', bookId: 'book-1' }] },
     });
   });
 
@@ -177,7 +205,7 @@ describe('persistenceMiddleware — payload shape', () => {
     const state = baseState({
       revisions: {
         pending: [{ id: 'r1' }],
-        drift: [{ id: 'd1' }],
+        drift: [{ id: 'd1', bookId: 'book-1' }],
         dismissed: ['d2'],
         acceptedSelections: { 'r-prev': { 4: 'B' } },
       },
@@ -188,7 +216,7 @@ describe('persistenceMiddleware — payload shape', () => {
       slice: 'revisions',
       patch: {
         pending: [{ id: 'r1' }],
-        drift: [{ id: 'd1' }],
+        drift: [{ id: 'd1', bookId: 'book-1' }],
         dismissed: ['d2'],
         acceptedSelections: { 'r-prev': { 4: 'B' } },
       },
@@ -247,7 +275,7 @@ describe('persistenceMiddleware — payload shape', () => {
     const state = baseState({
       revisions: {
         pending: [{ id: 'r1' }],
-        drift: [{ id: 'd1' }],
+        drift: [{ id: 'd1', bookId: 'book-1' }],
         dismissed: ['d2'],
         acceptedSelections: { 'r-prev': { 4: 'B' } },
       },
@@ -261,7 +289,7 @@ describe('persistenceMiddleware — payload shape', () => {
       slice: 'revisions',
       patch: {
         pending: [{ id: 'r1' }],
-        drift: [{ id: 'd1' }],
+        drift: [{ id: 'd1', bookId: 'book-1' }],
         dismissed: ['d2'],
       },
     });

--- a/src/store/persistence-middleware.ts
+++ b/src/store/persistence-middleware.ts
@@ -40,7 +40,7 @@ const DEBOUNCE_MS = 500;
    and would create a write-loop if echoed back. */
 const PERSIST_RULES: Record<
   string,
-  { slice: StateSlice; build: (s: PersistableRootState) => unknown }
+  { slice: StateSlice; build: (s: PersistableRootState, bookId: string) => unknown }
 > = {
   'cast/setCharacters': { slice: 'cast', build: (s) => ({ characters: s.cast.characters }) },
   'cast/declineMatch': { slice: 'cast', build: (s) => ({ characters: s.cast.characters }) },
@@ -68,27 +68,27 @@ const PERSIST_RULES: Record<
      would resurface on the next poll. */
   'revisions/acceptAllPending': {
     slice: 'revisions',
-    build: (s) => ({
+    build: (s, bookId) => ({
       pending: s.revisions.pending,
-      drift: s.revisions.drift,
+      drift: s.revisions.drift.filter((d) => d.bookId === bookId),
       dismissed: s.revisions.dismissed,
       timeline: s.revisions.timeline,
     }),
   },
   'revisions/rejectAllPending': {
     slice: 'revisions',
-    build: (s) => ({
+    build: (s, bookId) => ({
       pending: s.revisions.pending,
-      drift: s.revisions.drift,
+      drift: s.revisions.drift.filter((d) => d.bookId === bookId),
       dismissed: s.revisions.dismissed,
       timeline: s.revisions.timeline,
     }),
   },
   'revisions/dismissDrift': {
     slice: 'revisions',
-    build: (s) => ({
+    build: (s, bookId) => ({
       pending: s.revisions.pending,
-      drift: s.revisions.drift,
+      drift: s.revisions.drift.filter((d) => d.bookId === bookId),
       dismissed: s.revisions.dismissed,
       timeline: s.revisions.timeline,
     }),
@@ -100,9 +100,9 @@ const PERSIST_RULES: Record<
      bulk variants. */
   'revisions/acceptRevision': {
     slice: 'revisions',
-    build: (s) => ({
+    build: (s, bookId) => ({
       pending: s.revisions.pending,
-      drift: s.revisions.drift,
+      drift: s.revisions.drift.filter((d) => d.bookId === bookId),
       dismissed: s.revisions.dismissed,
       acceptedSelections: s.revisions.acceptedSelections,
       timeline: s.revisions.timeline,
@@ -110,9 +110,9 @@ const PERSIST_RULES: Record<
   },
   'revisions/rejectRevision': {
     slice: 'revisions',
-    build: (s) => ({
+    build: (s, bookId) => ({
       pending: s.revisions.pending,
-      drift: s.revisions.drift,
+      drift: s.revisions.drift.filter((d) => d.bookId === bookId),
       dismissed: s.revisions.dismissed,
       timeline: s.revisions.timeline,
     }),
@@ -124,9 +124,9 @@ const PERSIST_RULES: Record<
      POST /audio/previous/restore endpoint.) */
   'revisions/rolledBack': {
     slice: 'revisions',
-    build: (s) => ({
+    build: (s, bookId) => ({
       pending: s.revisions.pending,
-      drift: s.revisions.drift,
+      drift: s.revisions.drift.filter((d) => d.bookId === bookId),
       dismissed: s.revisions.dismissed,
       acceptedSelections: s.revisions.acceptedSelections,
       timeline: s.revisions.timeline,
@@ -139,18 +139,18 @@ const PERSIST_RULES: Record<
      chapter completed but before the user opened the diff. */
   'revisions/enqueuePending': {
     slice: 'revisions',
-    build: (s) => ({
+    build: (s, bookId) => ({
       pending: s.revisions.pending,
-      drift: s.revisions.drift,
+      drift: s.revisions.drift.filter((d) => d.bookId === bookId),
       dismissed: s.revisions.dismissed,
       timeline: s.revisions.timeline,
     }),
   },
   'revisions/markRevisionPlayable': {
     slice: 'revisions',
-    build: (s) => ({
+    build: (s, bookId) => ({
       pending: s.revisions.pending,
-      drift: s.revisions.drift,
+      drift: s.revisions.drift.filter((d) => d.bookId === bookId),
       dismissed: s.revisions.dismissed,
       timeline: s.revisions.timeline,
     }),
@@ -233,7 +233,7 @@ export const persistenceMiddleware: Middleware = (store) => {
     const bookId = bookIdFromState(after);
     if (!bookId) return result;
 
-    pending.set(rule.slice, rule.build(after));
+    pending.set(rule.slice, rule.build(after, bookId));
     const prev = timers.get(rule.slice);
     if (prev) clearTimeout(prev);
     timers.set(

--- a/src/store/revisions-slice.test.ts
+++ b/src/store/revisions-slice.test.ts
@@ -1,7 +1,7 @@
 // Pairs with docs/features/12-revisions-pipeline.md
 
 import { describe, expect, it } from 'vitest';
-import { revisionsSlice, revisionsActions } from './revisions-slice';
+import { revisionsSlice, revisionsActions, selectDriftByBook } from './revisions-slice';
 import type { Revision, DriftEvent, RevisionsResponse } from '../lib/types';
 
 const rev = (id: string, overrides: Partial<Revision> = {}): Revision => ({
@@ -14,6 +14,8 @@ const rev = (id: string, overrides: Partial<Revision> = {}): Revision => ({
 
 const drift = (id: string, overrides: Partial<DriftEvent> = {}): DriftEvent => ({
   id,
+  bookId: 'book-A',
+  chapterTitle: 'Chapter One',
   characterId: 'halloran',
   chapterId: 1,
   severity: 'mild',
@@ -414,6 +416,104 @@ describe('revisionsSlice — plan 55 timeline', () => {
     );
     expect(s.timeline[7]).toHaveLength(1);
     expect(s.timeline[7][0].id).toBe('r99');
+  });
+});
+
+describe('revisionsSlice — multi-book drift (plan: drift-report-fidelity)', () => {
+  it('applyPoll with bookId replaces only that book\'s drift, preserving siblings', () => {
+    /* Two concurrent books — Book A polled first, then Book B. Both books'
+       drift events should coexist in the flat list. */
+    let s = revisionsSlice.reducer(
+      undefined,
+      revisionsActions.applyPoll({
+        bookId: 'book-A',
+        drift: [drift('d-A1', { bookId: 'book-A' })],
+      }),
+    );
+    s = revisionsSlice.reducer(
+      s,
+      revisionsActions.applyPoll({
+        bookId: 'book-B',
+        drift: [drift('d-B1', { bookId: 'book-B' })],
+      }),
+    );
+    expect(s.drift.map((d) => d.id).sort()).toEqual(['d-A1', 'd-B1']);
+  });
+
+  it('applyPoll with bookId stamps bookId on events that arrive without it', () => {
+    /* Defensive: if the server omits bookId (older deploy), stamp it from
+       the poll context so the slice's selectors stay coherent. */
+    const s = revisionsSlice.reducer(
+      undefined,
+      revisionsActions.applyPoll({
+        bookId: 'book-A',
+        drift: [{ ...drift('d-A1'), bookId: undefined as unknown as string }],
+      }),
+    );
+    expect(s.drift[0].bookId).toBe('book-A');
+  });
+
+  it('re-polling Book A replaces only Book A\'s events', () => {
+    let s = revisionsSlice.reducer(
+      undefined,
+      revisionsActions.applyPoll({
+        bookId: 'book-A',
+        drift: [drift('d-A-old', { bookId: 'book-A' })],
+      }),
+    );
+    s = revisionsSlice.reducer(
+      s,
+      revisionsActions.applyPoll({
+        bookId: 'book-B',
+        drift: [drift('d-B1', { bookId: 'book-B' })],
+      }),
+    );
+    s = revisionsSlice.reducer(
+      s,
+      revisionsActions.applyPoll({
+        bookId: 'book-A',
+        drift: [drift('d-A-new', { bookId: 'book-A' })],
+      }),
+    );
+    expect(s.drift.map((d) => d.id).sort()).toEqual(['d-A-new', 'd-B1']);
+  });
+
+  it('hydrateFromBookState with bookId merges into the flat drift list', () => {
+    let s = revisionsSlice.reducer(
+      undefined,
+      revisionsActions.applyPoll({
+        bookId: 'book-A',
+        drift: [drift('d-A1', { bookId: 'book-A' })],
+      }),
+    );
+    s = revisionsSlice.reducer(
+      s,
+      revisionsActions.hydrateFromBookState({
+        bookId: 'book-B',
+        drift: [drift('d-B1', { bookId: 'book-B' })],
+        dismissed: [],
+      }),
+    );
+    expect(s.drift.map((d) => d.id).sort()).toEqual(['d-A1', 'd-B1']);
+  });
+
+  it('selectDriftByBook groups flat drift events by bookId', () => {
+    const s = revisionsSlice.reducer(
+      undefined,
+      revisionsActions.applyPoll({
+        drift: [
+          drift('d-A1', { bookId: 'book-A' }),
+          drift('d-B1', { bookId: 'book-B' }),
+          drift('d-A2', { bookId: 'book-A' }),
+        ],
+      }),
+    );
+    const grouped = selectDriftByBook({ revisions: s });
+    /* First-appearance order is preserved so the modal doesn't reshuffle
+       sections when a single book's events trickle in mid-render. */
+    expect(grouped.map((g) => g.bookId)).toEqual(['book-A', 'book-B']);
+    expect(grouped[0].events.map((d) => d.id)).toEqual(['d-A1', 'd-A2']);
+    expect(grouped[1].events.map((d) => d.id)).toEqual(['d-B1']);
   });
 });
 

--- a/src/store/revisions-slice.ts
+++ b/src/store/revisions-slice.ts
@@ -150,19 +150,42 @@ export const revisionsSlice = createSlice({
     /* Runtime poll: refresh pending/drift but DON'T touch dismissed or
        acceptedSelections — the server response (RevisionsResponse) doesn't
        include either, and overwriting with empty would lose state until
-       the next disk hydrate. */
-    applyPoll: (s, a: PayloadAction<RevisionsResponse>) => {
-      s.pending = a.payload?.pending || [];
-      s.drift = a.payload?.drift || [];
+       the next disk hydrate.
+
+       Multi-book aware: when the caller stamps `bookId` onto the payload,
+       only that book's drift entries are replaced — events from other
+       concurrently-active books survive the poll. `pending` is still
+       replaced wholesale (the regen/diff flow operates on the active
+       book and the server response doesn't differentiate). */
+    applyPoll: (s, a: PayloadAction<(RevisionsResponse & { bookId?: string }) | undefined>) => {
+      const payload = a.payload || ({} as RevisionsResponse & { bookId?: string });
+      const bookId = payload.bookId;
+      s.pending = payload.pending || [];
+      if (bookId) {
+        const incoming = payload.drift || [];
+        s.drift = [
+          ...s.drift.filter((d) => d.bookId !== bookId),
+          ...incoming.map((d) => ({ ...d, bookId: d.bookId || bookId })),
+        ];
+      } else {
+        s.drift = payload.drift || [];
+      }
       s.loaded = true;
     },
     /* Disk hydrate on book open. Carries dismissed + acceptedSelections so
        subsequent edits union with prior persisted state rather than
-       overwriting it in revisions.json. Plan 55 adds `timeline`. */
+       overwriting it in revisions.json. Plan 55 adds `timeline`.
+
+       Multi-book aware: when `bookId` is provided, drift events for that
+       book are merged in (replacing any prior events with that bookId),
+       while other books' events are preserved. Without bookId the slice
+       falls back to the legacy whole-slice replace for callers that
+       haven't migrated. */
     hydrateFromBookState: (
       s,
       a: PayloadAction<
         | {
+            bookId?: string;
             pending?: Revision[];
             drift?: DriftEvent[];
             dismissed?: string[];
@@ -179,7 +202,16 @@ export const revisionsSlice = createSlice({
         return;
       }
       s.pending = payload.pending ?? [];
-      s.drift = payload.drift ?? [];
+      if (payload.bookId) {
+        const bid = payload.bookId;
+        const incoming = payload.drift ?? [];
+        s.drift = [
+          ...s.drift.filter((d) => d.bookId !== bid),
+          ...incoming.map((d) => ({ ...d, bookId: d.bookId || bid })),
+        ];
+      } else {
+        s.drift = payload.drift ?? [];
+      }
       s.dismissed = payload.dismissed ?? [];
       s.acceptedSelections = payload.acceptedSelections ?? {};
       s.timeline = normaliseTimelineKeys(payload.timeline);
@@ -219,3 +251,26 @@ function nowIso(): string {
 }
 
 export const revisionsActions = revisionsSlice.actions;
+
+/* Selector: group drift events by `bookId` for the multi-book Drift
+   Report. Returns an ordered array so the modal can render one section
+   per book. Books with no events are absent. The order preserves the
+   first appearance of each bookId in the flat `drift` list — a tiny
+   stability detail that keeps the modal from re-shuffling when a poll
+   completes for a different book mid-render. */
+export function selectDriftByBook(state: { revisions: RevisionsState }): Array<{
+  bookId: string;
+  events: DriftEvent[];
+}> {
+  const seen = new Map<string, DriftEvent[]>();
+  for (const event of state.revisions.drift) {
+    const bid = event.bookId ?? '';
+    let bucket = seen.get(bid);
+    if (!bucket) {
+      bucket = [];
+      seen.set(bid, bucket);
+    }
+    bucket.push(event);
+  }
+  return Array.from(seen.entries()).map(([bookId, events]) => ({ bookId, events }));
+}


### PR DESCRIPTION
## Summary

Fixes three fidelity bugs in the per-character Drift Report modal that the user surfaced from a screenshot:

1. **Chapter names were mocked.** The modal joined drift events against `initialChapters` from `src/data/chapters.ts`, falling back to `Chapter ${id}`. Now every drift event carries `chapterTitle: string` stamped server-side in `revisions.ts` (`seg.chapterTitle` → scan title → `Chapter N` fallback chain) and the modal renders it directly.
2. **No book name was shown.** The modal header read only "Voice drift detector" / "{N} chapters flagged". Now each event carries `bookId: string`, the slice keeps a flat multi-book list, the modal groups events per book under a header, and the title summary reads "{N} chapter(s) flagged across {M} books" when M > 1. Book titles resolve via `selectEffectiveMeta(bookId)`.
3. **No comparison profile.** Each emit site (`pushHardDrift` / `pushToneDrift` / `pushAttributesDrift`) had both before/after values but compressed them into a prose `description`. Now each event embeds `snapshot` (CharacterSnapshot at render time, from `<slug>.segments.json`) and `current` (live cast profile at poll time), and the modal renders a side-by-side `ProfileCompareCard` with Voice / Gender / Age range / Warmth / Pace / Authority / Emotion / Attributes rows, highlighting the row matching `event.factor`.

### Contract changes

- `openapi.yaml` — `DriftEvent` schema gains required `bookId`, `chapterTitle`, plus optional `snapshot` and `current`. Event ids now include `bookId` (`drift:<bookId>:<chapterId>:<characterId>:<factor>`).
- `src/store/revisions-slice.ts` — `applyPoll({ ...response, bookId })` and `hydrateFromBookState({ bookId, ... })` replace only that book's events. New `selectDriftByBook` selector groups for the modal. Defensively stamps `bookId` onto incoming events that arrive without one.
- `src/store/persistence-middleware.ts` — each revisions rule filters `s.revisions.drift` by active `bookId` before writing, so each book's `revisions.json` carries only its own events.
- `src/components/layout.tsx` — selector replaced with `selectDriftByBook`, passes `eventsByBook` to the modal; bookTitle resolved via `bookMeta.saved`.
- `src/views/cast.tsx` — `routes/index.tsx` filters drift to active `bookId` before passing to the cast view so per-character drift badges don't surface other books' events.
- `src/modals/drift-report.tsx` — new `eventsByBook: DriftBookGroup[]` prop; dropped `events` + `characters` + the `initialChapters` import.
- `src/lib/api.ts` mock `pollRevisions` filters drift to the requested `bookId` so the mock mirrors the server's per-book endpoint.

### New tests

- Server: `server/src/routes/revisions.test.ts` — 5 new cases pin `chapterTitle` emit (with scan-fallback), `snapshot` + `current` on hard / tone / attribute drift events.
- Slice: `src/store/revisions-slice.test.ts` — 5 new cases for multi-book `applyPoll`, `bookId` stamping, cross-book hydrate merge, `selectDriftByBook` grouping.
- Persistence: `src/store/persistence-middleware.test.ts` — new case for cross-book drift filter (Book A persist drops Book B's events).
- Modal: `src/modals/drift-report.test.tsx` — 5 new cases: chapter title from event (not fixture), multi-book header, single-book header collapse, side-by-side row rendering, `data-changed` factor highlight.
- E2E: new `e2e/drift-report-multibook.spec.ts` smoke that the slice → cast view → drift banner seam wires through under mocks.

### Docs

- `docs/features/35-engine-drift-detection.md` — new "Modal fidelity contract" section enumerating the three fixes + multi-book invariants (a)–(e), including the active-book-only polling limitation.
- `docs/BACKLOG.md` — new Could item: "Background drift polling across non-active books" (fans the poller out across `state.bookMeta.saved` so cross-book drift surfaces in real time without navigating).

## Test plan

- [x] `npm run verify` green locally (lint, typecheck, all tests, e2e 45/45, build)
- [x] Server: 28 revisions tests pass including 5 new contract assertions
- [x] Slice: 34 revisions-slice tests pass including 5 new multi-book cases
- [x] Persistence: 17 tests pass including cross-book filter
- [x] Modal: 14 drift-report tests pass including 5 new fidelity contract cases
- [ ] Manual mock-mode walkthrough: open Solway Bay → cast view → drift banner shows 3 chapters → modal opens with "Sophie / Eliza / Halloran / Marcus" cards, real chapter titles, side-by-side compare with the changed factor highlighted
- [ ] Manual real-backend walkthrough (optional follow-up): generate a chapter, alter a character's `voiceId` or attributes, hit drift modal — confirm `chapterTitle` flows from `seg.chapterTitle` not the fallback

Regression plan: [docs/features/35-engine-drift-detection.md](docs/features/35-engine-drift-detection.md) "Modal fidelity contract" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)