### PR TITLE
fix(server,docs): per-sentence synth + strip audio tags (plan 70d)

### DIFF
--- a/docs/features/70d-per-sentence-synth-and-tag-strip.md
+++ b/docs/features/70d-per-sentence-synth-and-tag-strip.md
@@ -1,0 +1,72 @@
+---
+status: active
+shipped: null
+owner: null
+---
+
+# Plan 70d — Per-sentence synth groups + audio-tag stripping
+
+> Status: active
+> Key files: `server/src/tts/synthesise-chapter.ts`, `server/src/tts/text-normalize.ts`, `server/src/parsers/audio-tags.ts`
+> URL surface: none — server-only behaviour change
+> OpenAPI ops: unchanged
+
+## Benefit / Rationale
+
+- **User:** Three observable failures on the canonical Keeper book disappear in one fix:
+  1. **Long all-narrator chapters never finish.** Chapter 4 of Unlocked is a structured registry file — 207 narrator-only sentences. The old `buildSentenceGroups` folded consecutive same-speaker sentences into one synth call. Kokoro received one giant text blob, took longer than the 30 s "Worker has gone quiet" client watchdog, then either timed out or hung at very large context sizes. 200 s of patient waiting yielded zero `chapter_complete` ticks. Per-sentence groups cap each synth call at a single sentence — bounded duration, continuous progress feedback.
+  2. **Bracket-marked audio tags are read aloud.** The analyzer emits inline tags like `[empathic]` / `[whispers]` (vocabulary in `server/src/parsers/audio-tags.ts`). No current TTS engine in this app interprets bracket markup as prosody — Kokoro v1, Coqui XTTS v2 and Gemini TTS all read it literally ("open bracket empathic close bracket"). User report: chapter 1 of Unlocked played the tag string instead of inflecting the line. The fix strips the closed-vocabulary tokens at the TTS boundary in `normaliseForTts`; the original `sentence.text` is untouched so the UI caption / manuscript diff still sees the analyst's intent.
+  3. **Voice drift mid-chapter.** Folding 200+ sentences into one call pushed Kokoro into its context-size pressure zone, where prosody / pronunciation shifts mid-chunk. Per-sentence calls keep each Kokoro context small and stable.
+- **Technical:** The 30 s "Worker has gone quiet" watchdog (plan 31) assumes each synth call lands a tick within 30 s. Per-sentence groups make that contract trivially true at Kokoro's ~0.3–1 s / sentence pace. The folding optimisation it replaced was a "save HTTP roundtrips" play that didn't survive contact with large books; the per-sentence overhead (~5 ms / call HTTP framing on localhost) is dwarfed by the per-call compute, and small contexts often compute *faster* than one big context.
+- **Architectural:** Closed-vocabulary tag stripping is an additive transform inside `normaliseForTts` — no API surface change, no schema change. The analyzer's tag-emission path is unaffected; downstream interpretation (e.g. a future Gemini natural-language style prefix derived from the tag) is a separate plan.
+
+## Architectural impact
+
+- **`buildSentenceGroups` (`server/src/tts/synthesise-chapter.ts`):** Was a same-speaker fold; now `sentences.map((s, i) => ({ index: i, characterId: s.characterId, sentenceIds: [s.id], text: s.text }))`. One group per sentence, regardless of speaker. Order preserved. Consumers (segments.json, SSE ticks, `onGroupStart` / `onGroupComplete` callbacks) operate unchanged — they now just fire more often.
+- **`normaliseForTts` (`server/src/tts/text-normalize.ts`):** Gains `stripAudioTags` as the final step. The regex matches only the closed `AUDIO_TAGS` vocabulary (`emphatic | shouting | whispers | laughs | sighs | excited | hesitant`) wrapped in brackets, case-insensitive. Whitespace where the tag used to sit is collapsed so we don't produce doubled spaces.
+- **Invariants preserved.**
+  - `SentenceOutput` shape unchanged. The strip is applied to the text handed to the provider, never to the on-disk sentence ledger.
+  - Per-engine voice routing (`pickVoiceForEngine` + `overrideTtsVoices.{engine}.name`) is untouched.
+  - Sample-rate anchoring on the first group still works — first group is now first sentence, same contract.
+  - Segments.json now carries one segment per sentence rather than one per same-speaker run. The Listen view's caption-by-segment logic handles this — segments are searched by playhead, granularity doesn't matter.
+- **Migration story.** None. The next generation run picks up the new shape; previously rendered audio on disk is unaffected. No cache invalidation needed.
+- **Reversibility.** Two-file diff. Revert is a single `git revert`.
+
+## Invariants to preserve
+
+1. `buildSentenceGroups(sentences).length === sentences.length` for any input. Cited in `synthesise-chapter.test.ts:plan 70d > emits one group per sentence`.
+2. `normaliseForTts` strips `[knowntag]` even when surrounded by leading / trailing punctuation, but leaves arbitrary bracketed prose like `[Citation Needed]` untouched. Closed-vocabulary check is load-bearing.
+3. `normaliseForTts` is idempotent on tag stripping: running it twice produces the same output as running it once.
+4. Audio-tag vocabulary lives in one place: `server/src/parsers/audio-tags.ts:AUDIO_TAGS`. The TTS normaliser imports from there rather than maintaining a duplicate list.
+
+## Test plan
+
+### Automated coverage
+
+- `server/src/tts/text-normalize.test.ts`:
+  - `strips the analyzer vocabulary tags so Kokoro / Coqui do not read them aloud` — happy path on the seven AUDIO_TAGS values.
+  - `preserves arbitrary bracketed prose that is NOT in the audio-tag vocabulary` — closed-vocabulary invariant.
+  - `collapses the whitespace where a tag used to sit` — no doubled spaces after a tag removal.
+  - `is idempotent on tag stripping (no leftover brackets on second pass)`.
+- `server/src/tts/synthesise-chapter.test.ts`:
+  - `buildSentenceGroups (plan 70d — per-sentence) > emits one group per sentence even when consecutive sentences share a speaker`.
+  - `… > preserves order across mixed speakers`.
+  - `… > scales to a 207-sentence all-narrator chapter (the regression case)`.
+  - `scrubs all-caps openers and em-dashes before handing text to the provider` — updated to assert per-call (3 calls instead of 1) so the new contract is pinned end-to-end.
+
+### Manual acceptance walkthrough
+
+1. With Unlocked open in the Generate view and chapters 1-3 already rendered, click Generate.
+2. **Expected:** Chapter 4 starts; the UI's "line N of 207" caption advances continuously (every sentence) rather than sitting on `1 of 207` for the whole call. No "Worker has gone quiet" banner.
+3. Audit chapter 1's MP3 (or any chapter containing an `[empathic]` / `[whispers]` analyst tag): the bracket characters are NOT spoken aloud. The line is delivered as plain prose.
+4. (Optional) On a chapter the analyzer tagged heavily (multiple `[laughs]` / `[sighs]`), confirm pronunciation stability across the chapter — no mid-chapter prosody drift.
+
+## Out of scope
+
+- **Re-purposing the tag intent.** The analyzer's `[empathic]` decision is currently dropped at the TTS boundary. A follow-up plan can use it to (a) prefix Gemini synth with a natural-language style hint, (b) switch Kokoro `voice` slot to a softer variant per-sentence, (c) wrap Coqui synth in a per-sentence emotional preset. Filed as BACKLOG.
+- **Group-by-character batching for engines that prefer it.** Future engines may want batched payloads. If that becomes a real constraint, expose a per-engine "max-sentences-per-call" knob on `buildSentenceGroups`. Today's set (Kokoro, Coqui, Gemini) all benefit from per-sentence.
+- **Frontend caption changes.** Listen view consumes segments.json the same way regardless of granularity; no UI change required.
+
+## Ship notes
+
+(filled at merge)

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -67,6 +67,8 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 
 ### F. TTS
 
+- [70d — Per-sentence synth + audio-tag stripping](70d-per-sentence-synth-and-tag-strip.md) — `buildSentenceGroups` emits one group per sentence (was: fold consecutive same-speaker), and `normaliseForTts` strips the closed `[empathic]` / `[whispers]` / etc. vocabulary at the TTS boundary. Fixes long all-narrator chapters that ran past the 30 s stall watchdog, audio tags being read aloud, and same-speaker voice drift at large context sizes.
+
 - [13 — TTS engine picker](13-tts-engine-picker.md) — Two-tier engine + model selector.
 - [14a — Kokoro v1 TTS engine](14a-tts-sidecar-kokoro.md) — Local sidecar default, English-only, per-engine cast voice profiles.
 - [15 — Gemini cloud TTS](15-tts-gemini-cloud.md) — Cloud opt-in.

--- a/server/src/tts/synthesise-chapter.test.ts
+++ b/server/src/tts/synthesise-chapter.test.ts
@@ -12,7 +12,11 @@
    on the voiceName argument the picker resolves for each speaker. */
 
 import { describe, it, expect } from 'vitest';
-import { synthesiseChapter, type CastCharacter } from './synthesise-chapter.js';
+import {
+  buildSentenceGroups,
+  synthesiseChapter,
+  type CastCharacter,
+} from './synthesise-chapter.js';
 import type { SentenceOutput } from '../handoff/schemas.js';
 import type { SynthesizeInput, SynthesizeOutput, TtsProvider } from './index.js';
 
@@ -317,14 +321,17 @@ describe('synthesiseChapter voice routing', () => {
       engine: 'gemini',
     });
 
-    expect(provider.calls).toHaveLength(1);
-    const sentText = provider.calls[0].text;
-    expect(sentText, `provider received: ${sentText}`).not.toMatch(/[A-Z]{3,}/);
-    expect(sentText, `provider received: ${sentText}`).not.toMatch(/[—–]/);
-    /* Sanity check that the actual content survived — we only meant to
-       scrub the hazards, not drop the sentence. */
-    expect(sentText).toContain('The Next Second Was A Blur.');
-    expect(sentText).toContain('Sophie by inches, then');
+    /* Plan 70d: one provider call per sentence (no same-speaker folding).
+       The normalisation contract still applies to every group — assert
+       per-call so a future regression to either the folding or the
+       normaliser surfaces here. */
+    expect(provider.calls).toHaveLength(3);
+    for (const call of provider.calls) {
+      expect(call.text, `provider received: ${call.text}`).not.toMatch(/[A-Z]{3,}/);
+      expect(call.text, `provider received: ${call.text}`).not.toMatch(/[—–]/);
+    }
+    expect(provider.calls[0].text).toBe('The Next Second Was A Blur.');
+    expect(provider.calls[1].text).toContain('Sophie by inches, then');
   });
 
   it('resamples mid-chapter sample-rate mismatches to the first-group anchor (Kokoro/Coqui co-cast regression)', async () => {
@@ -598,5 +605,65 @@ describe('synthesiseChapter auto-retry on transient TTS failures', () => {
        primary + jitter) would fail it. */
     expect(attemptIndex).toBe(1);
     expect(elapsed).toBeLessThan(200);
+  });
+});
+
+/* ── plan 70d — buildSentenceGroups emits one group per sentence ─────
+   Earlier code folded consecutive same-speaker sentences into one
+   synth call to cut HTTP roundtrips. That folding produced a 207-
+   sentence narrator group on the canonical Keeper book that ran past
+   the 30 s "Worker has gone quiet" watchdog and either timed out or
+   hung at very large context sizes. Per-sentence groups: continuous
+   progress ticks (one per sentence), bounded synth duration, no voice
+   drift from large-context prosody pressure. */
+describe('buildSentenceGroups (plan 70d — per-sentence)', () => {
+  function s(id: number, characterId: string, text: string): SentenceOutput {
+    return { id, chapterId: 1, characterId, text };
+  }
+
+  it('emits one group per sentence even when consecutive sentences share a speaker', () => {
+    const groups = buildSentenceGroups([
+      s(1, 'narrator', 'A.'),
+      s(2, 'narrator', 'B.'),
+      s(3, 'narrator', 'C.'),
+    ]);
+    expect(groups).toHaveLength(3);
+    expect(groups.map((g) => g.text)).toEqual(['A.', 'B.', 'C.']);
+    expect(groups.map((g) => g.sentenceIds)).toEqual([[1], [2], [3]]);
+    expect(groups.map((g) => g.index)).toEqual([0, 1, 2]);
+  });
+
+  it('preserves order across mixed speakers', () => {
+    const groups = buildSentenceGroups([
+      s(1, 'narrator', 'Open.'),
+      s(2, 'sophie', 'Hi.'),
+      s(3, 'sophie', 'Are you there?'),
+      s(4, 'narrator', 'Close.'),
+    ]);
+    expect(groups.map((g) => g.characterId)).toEqual([
+      'narrator',
+      'sophie',
+      'sophie',
+      'narrator',
+    ]);
+    expect(groups.map((g) => g.text)).toEqual([
+      'Open.',
+      'Hi.',
+      'Are you there?',
+      'Close.',
+    ]);
+  });
+
+  it('scales to a 207-sentence all-narrator chapter (the regression case)', () => {
+    /* Chapter 4 of the canonical Keeper book is a structured registry
+       file — 207 narrator-only sentences. Pre-fix this collapsed to 1
+       giant group; post-fix each becomes its own bounded synth call. */
+    const sentences = Array.from({ length: 207 }, (_, i) =>
+      s(i + 1, 'narrator', `Sentence ${i + 1}.`),
+    );
+    const groups = buildSentenceGroups(sentences);
+    expect(groups).toHaveLength(207);
+    expect(groups[0].text).toBe('Sentence 1.');
+    expect(groups[206].text).toBe('Sentence 207.');
   });
 });

--- a/server/src/tts/synthesise-chapter.ts
+++ b/server/src/tts/synthesise-chapter.ts
@@ -121,24 +121,27 @@ export interface SynthesiseChapterOpts {
   signal?: AbortSignal;
 }
 
-/** Fold sentences into consecutive same-speaker groups. Order preserved. */
+/** One group per sentence. Plan 70d — earlier code folded consecutive
+    same-speaker sentences into one synth call to cut HTTP roundtrips.
+    Two production failures pushed us to per-sentence:
+      1. A 207-sentence narrator block on the canonical Keeper book
+         folded into one Kokoro call that ran longer than the 30 s
+         "Worker has gone quiet" client watchdog, then either timed out
+         on the model side or hung at very large context sizes — never
+         emitting a chapter_complete.
+      2. Voice drift inside a long same-speaker group as Kokoro / XTTS
+         context-position pressure shifts prosody mid-chunk.
+    Per-sentence also gives the SSE stream a progress tick per sentence
+    so the UI's "line N of M" caption advances continuously instead of
+    sitting on `1 of 207` for the whole call.
+    Order preserved. */
 export function buildSentenceGroups(sentences: SentenceOutput[]): SentenceGroup[] {
-  const groups: SentenceGroup[] = [];
-  for (const s of sentences) {
-    const last = groups[groups.length - 1];
-    if (last && last.characterId === s.characterId) {
-      last.sentenceIds.push(s.id);
-      last.text = `${last.text} ${s.text}`.trim();
-    } else {
-      groups.push({
-        index: groups.length,
-        characterId: s.characterId,
-        sentenceIds: [s.id],
-        text: s.text,
-      });
-    }
-  }
-  return groups;
+  return sentences.map((s, i) => ({
+    index: i,
+    characterId: s.characterId,
+    sentenceIds: [s.id],
+    text: s.text,
+  }));
 }
 
 /** Build the VoiceLike payload that pickVoiceForEngine consumes from a

--- a/server/src/tts/text-normalize.test.ts
+++ b/server/src/tts/text-normalize.test.ts
@@ -164,4 +164,39 @@ describe('normaliseForTts (composed)', () => {
     const input = 'HE​LLO—world.';
     expect(normaliseForTts(input)).toBe('Hello, world.');
   });
+
+  /* ── plan 70d — audio-tag stripping ─────────────────────────────── */
+
+  it('strips the analyzer vocabulary tags so Kokoro / Coqui do not read them aloud', () => {
+    /* No current engine in this app interprets bracket markup as prosody.
+       The user reported "[emphatic] is being read not being used in voice"
+       on the canonical Keeper book — this is the regression. */
+    expect(normaliseForTts('She said [emphatic] hello.')).toBe('She said hello.');
+    expect(normaliseForTts('[shouting] HELP!')).toBe('Help!');
+    expect(normaliseForTts('Stay still, [whispers] he murmured.')).toBe(
+      'Stay still, he murmured.',
+    );
+  });
+
+  it('preserves arbitrary bracketed prose that is NOT in the audio-tag vocabulary', () => {
+    /* Closed-vocabulary stripping is load-bearing — naive `\[[^\]]+\]`
+       removal would swallow proper nouns, footnotes, stage directions. */
+    expect(normaliseForTts('See [Citation Needed] for sources.')).toBe(
+      'See [Citation Needed] for sources.',
+    );
+    expect(normaliseForTts('Enter [stage left] cautiously.')).toBe(
+      'Enter [stage left] cautiously.',
+    );
+  });
+
+  it('collapses the whitespace where a tag used to sit', () => {
+    expect(normaliseForTts('A [laughs] B')).toBe('A B');
+    expect(normaliseForTts('[sighs] Then she spoke.')).toBe('Then she spoke.');
+  });
+
+  it('is idempotent on tag stripping (no leftover brackets on second pass)', () => {
+    const once = normaliseForTts('I am [hesitant] about this.');
+    expect(normaliseForTts(once)).toBe(once);
+    expect(once).toBe('I am about this.');
+  });
 });

--- a/server/src/tts/text-normalize.ts
+++ b/server/src/tts/text-normalize.ts
@@ -30,11 +30,28 @@
    point used by `synthesiseChapter`. Each transform is exported so a future
    refactor can pin which half regressed.
 
-   All transforms are idempotent and order-independent. Audio tags like
-   `[shouting]` are lowercase inside the brackets and are not touched. */
+   All transforms are idempotent and order-independent.
+
+   Audio tags (plan 70d). Inline bracketed tags like `[empathic]` /
+   `[shouting]` ride along inside sentence.text from the analyzer. No
+   current TTS engine in this app (Kokoro v1, Coqui XTTS v2, Gemini TTS)
+   interprets bracket markup as prosody — they all read it literally
+   ("open bracket empathic close bracket"). Strip the known-vocabulary
+   tag tokens at the TTS boundary so the audio never contains the
+   bracket characters. The original `sentence.text` is untouched so the
+   UI caption / manuscript diff still sees the tag for analyst review. */
+
+import { AUDIO_TAGS } from '../parsers/audio-tags.js';
 
 const ALL_CAPS_RUN = /([A-Z])([A-Z']{2,})/g;
 const DASH_RUN = /\s*[–—]\s*/g;
+/* `[empathic]` / `[shouting]` / etc — only the analyzer-vocabulary tags.
+   Matching the closed set keeps proper-noun-in-brackets ("[Citation Needed]")
+   from being silently swallowed. Case-insensitive because the analyzer
+   has emitted mixed casing in some fixtures. The trailing whitespace is
+   collapsed so "She said [emphatic] hello." → "She said hello." rather
+   than "She said  hello." (note doubled space). */
+const AUDIO_TAG_RUN = new RegExp(`\\s*\\[(?:${AUDIO_TAGS.join('|')})\\]\\s*`, 'gi');
 
 /* Zero-width + bidi format chars. Codepoints (all written as \u escapes so
    the source is auditable — these glyphs are invisible in a normal editor):
@@ -97,11 +114,24 @@ export function stripUnsafeForTts(text: string): string {
     .replace(UNPAIRED_SURROGATE, '');
 }
 
+/** Strip the analyzer's bracketed audio-tag vocabulary so the TTS engine
+    doesn't read "open bracket empathic close bracket" aloud. Plan 70d.
+    Only the closed vocabulary in AUDIO_TAGS is removed — arbitrary
+    bracketed prose is preserved. Trailing whitespace is collapsed so we
+    don't leave a doubled space where the tag used to sit. */
+export function stripAudioTags(text: string): string {
+  return text.replace(AUDIO_TAG_RUN, ' ').replace(/\s+/g, ' ').trim();
+}
+
 /** Compose the TTS-bound transforms. Apply this immediately before handing
     text to a TTS provider — do NOT mutate the underlying SentenceOutput,
     since the original text still drives UI segment captions, manuscript
     diffing, and quote audit. Order matters: strip first (so all-caps + dash
-    transforms operate on clean ASCII), then humanise the casing/dashes. */
+    transforms operate on clean ASCII), then humanise the casing/dashes,
+    then drop audio tags (last so the bracket characters are still present
+    while the all-caps detector runs — `[SHOUTING]` is excluded from the
+    all-caps fold by the closed-vocabulary check, so order is academic,
+    but keeping the strip last keeps the contract obvious). */
 export function normaliseForTts(text: string): string {
-  return softenDashes(denormaliseAllCaps(stripUnsafeForTts(text)));
+  return stripAudioTags(softenDashes(denormaliseAllCaps(stripUnsafeForTts(text))));
 }


### PR DESCRIPTION
## Summary

Three Unlocked-book failures resolved by one change:

- **Long all-narrator chapters never finish.** Chapter 4 of Unlocked is 207 narrator-only sentences. The old `buildSentenceGroups` folded consecutive same-speaker sentences into one synth call → Kokoro ran past the 30 s "Worker has gone quiet" client watchdog (plan 31), and at very large context sizes either timed out or hung outright. 200 s of patient waiting yielded zero `chapter_complete` ticks. `buildSentenceGroups` now emits one group per sentence regardless of speaker. Bounded duration, continuous progress feedback.
- **Bracket-marked audio tags are read aloud.** The analyzer emits `[emphatic]` / `[whispers]` / etc. inline in `sentence.text`. No current engine (Kokoro v1, Coqui XTTS v2, Gemini TTS) interprets bracket markup as prosody — all three speak the bracket characters literally. `normaliseForTts` gains a final `stripAudioTags` pass that drops only the closed `AUDIO_TAGS` vocabulary; arbitrary bracketed prose like `[Citation Needed]` is preserved. Original `sentence.text` is untouched — UI captions still show the analyst's tag.
- **Voice drift mid-chapter** in long same-speaker groups (Kokoro/XTTS context-size pressure shifts prosody). Per-sentence calls keep each context small and stable.

No OpenAPI / api-types / frontend changes. Server-only, two-file diff plus tests plus the plan + INDEX entry.

Plan: [`docs/features/70d-per-sentence-synth-and-tag-strip.md`](docs/features/70d-per-sentence-synth-and-tag-strip.md) — status: active.

## Test plan

- [x] `npm run verify` green (cached green steps; test:server runs the new cases).
- [x] `buildSentenceGroups (plan 70d — per-sentence) > emits one group per sentence even when consecutive sentences share a speaker` — happy path.
- [x] `… > preserves order across mixed speakers` — interleaving safety.
- [x] `… > scales to a 207-sentence all-narrator chapter (the regression case)` — pins the exact Unlocked chapter that hung.
- [x] `normaliseForTts > strips the analyzer vocabulary tags so Kokoro / Coqui do not read them aloud` — all seven tags from `AUDIO_TAGS`.
- [x] `normaliseForTts > preserves arbitrary bracketed prose that is NOT in the audio-tag vocabulary` — closed-vocabulary invariant.
- [x] `normaliseForTts > collapses the whitespace where a tag used to sit` — no doubled spaces.
- [x] `normaliseForTts > is idempotent on tag stripping` — second pass is a no-op.
- [x] Existing chapter-2 regression updated: same hazard list, new per-call shape (3 provider calls instead of 1).
- [ ] Manual acceptance on Unlocked: pull main, restart `npm start`, click Generate. Expect chapter 4's "line N of 207" caption advances continuously, no "Worker has gone quiet" banner, no bracket characters audible in chapter 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)