### PR TITLE
refactor(server): generalise audio encoder dispatch

### DIFF
--- a/server/src/audio/compute-peaks.ts
+++ b/server/src/audio/compute-peaks.ts
@@ -10,7 +10,7 @@
 
    Contract:
    - Input: raw 16-bit signed little-endian MONO PCM (`Buffer`), same shape
-     the sidecar emits and `encodePcmToMp3` consumes. Sample rate is
+     the sidecar emits and `encodePcmToAudio` consumes. Sample rate is
      informational — peak bins are sample-count proportional, not time-
      proportional, so the same PCM at a different sample rate produces the
      same shape. Sample rate is accepted for parity with other helpers in

--- a/server/src/export/build-m4b.test.ts
+++ b/server/src/export/build-m4b.test.ts
@@ -17,7 +17,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, beforeAll, afterAll } from 'vitest';
-import { encodePcmToMp3 } from '../tts/mp3.js';
+import { encodePcmToAudio } from '../tts/mp3.js';
 import { buildM4b, ExportIncompleteError } from './build-m4b.js';
 import type { BookStateJson } from '../workspace/scan.js';
 
@@ -193,7 +193,7 @@ describeIfTools('buildM4b', () => {
        boundaries to zero. */
     const slugs = ['01-chapter-1', '02-chapter-2', '04-chapter-3'];
     for (const slug of slugs) {
-      const mp3 = await encodePcmToMp3(Buffer.alloc(24_000 * 2 * 0.2), 24_000, { quality: 9 });
+      const mp3 = await encodePcmToAudio(Buffer.alloc(24_000 * 2 * 0.2), 24_000, { quality: 9 });
       writeFileSync(join(bookDir, 'audio', `${slug}.mp3`), mp3);
     }
   });
@@ -238,7 +238,7 @@ describeIfTools('buildM4b', () => {
   it('refuses with ExportIncompleteError when a non-excluded chapter has no audio file', async () => {
     const incompleteDir = join(tmpRoot, 'incomplete', 'audio');
     mkdirSync(incompleteDir, { recursive: true });
-    const mp3 = await encodePcmToMp3(Buffer.alloc(24_000 * 2 * 0.2), 24_000, { quality: 9 });
+    const mp3 = await encodePcmToAudio(Buffer.alloc(24_000 * 2 * 0.2), 24_000, { quality: 9 });
     writeFileSync(join(incompleteDir, '01-chapter-1.mp3'), mp3);
     /* No audio at all for chapter 2 — precheck must reject. */
 

--- a/server/src/export/build-mp3-folder.test.ts
+++ b/server/src/export/build-mp3-folder.test.ts
@@ -15,7 +15,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, beforeAll, afterAll } from 'vitest';
-import { encodePcmToMp3 } from '../tts/mp3.js';
+import { encodePcmToAudio } from '../tts/mp3.js';
 import { buildMp3Folder } from './build-mp3-folder.js';
 import { ExportIncompleteError } from './build-mp3-zip.js';
 import type { BookStateJson } from '../workspace/scan.js';
@@ -87,7 +87,7 @@ describeIfFfmpeg('buildMp3Folder', () => {
 
     const slugs = ['01-chapter-1', '02-chapter-2'];
     for (const slug of slugs) {
-      const mp3 = await encodePcmToMp3(Buffer.alloc(24_000 * 2 * 0.2), 24_000, { quality: 9 });
+      const mp3 = await encodePcmToAudio(Buffer.alloc(24_000 * 2 * 0.2), 24_000, { quality: 9 });
       writeFileSync(join(bookDir, 'audio', `${slug}.mp3`), mp3);
     }
   });
@@ -119,7 +119,7 @@ describeIfFfmpeg('buildMp3Folder', () => {
   it('refuses with ExportIncompleteError when a non-excluded chapter has no audio file', async () => {
     const incompleteAudio = join(tmpRoot, 'incomplete-book', 'audio');
     mkdirSync(incompleteAudio, { recursive: true });
-    const mp3 = await encodePcmToMp3(Buffer.alloc(24_000 * 2 * 0.2), 24_000, { quality: 9 });
+    const mp3 = await encodePcmToAudio(Buffer.alloc(24_000 * 2 * 0.2), 24_000, { quality: 9 });
     writeFileSync(join(incompleteAudio, '01-chapter-1.mp3'), mp3);
     /* No audio at all for chapter 2 — precheck must reject. */
 

--- a/server/src/export/build-mp3-zip.test.ts
+++ b/server/src/export/build-mp3-zip.test.ts
@@ -12,7 +12,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'nod
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, beforeAll, afterAll } from 'vitest';
-import { encodePcmToMp3 } from '../tts/mp3.js';
+import { encodePcmToAudio } from '../tts/mp3.js';
 import { buildMp3Zip, ExportIncompleteError, sanitiseForZip } from './build-mp3-zip.js';
 import type { BookStateJson } from '../workspace/scan.js';
 
@@ -163,7 +163,7 @@ describeIfFfmpeg('buildMp3Zip', () => {
     /* Tiny silent MP3s for the three non-excluded chapters. */
     const slugs = ['01-chapter-1', '02-chapter-2', '04-chapter-3'];
     for (const slug of slugs) {
-      const mp3 = await encodePcmToMp3(Buffer.alloc(24_000 * 2 * 0.2), 24_000, { quality: 9 });
+      const mp3 = await encodePcmToAudio(Buffer.alloc(24_000 * 2 * 0.2), 24_000, { quality: 9 });
       writeFileSync(join(bookDir, 'audio', `${slug}.mp3`), mp3);
     }
   });
@@ -196,7 +196,7 @@ describeIfFfmpeg('buildMp3Zip', () => {
   it('refuses with ExportIncompleteError when a non-excluded chapter has no audio file', async () => {
     const incompleteDir = join(tmpRoot, 'incomplete', 'audio');
     mkdirSync(incompleteDir, { recursive: true });
-    const mp3 = await encodePcmToMp3(Buffer.alloc(24_000 * 2 * 0.2), 24_000, { quality: 9 });
+    const mp3 = await encodePcmToAudio(Buffer.alloc(24_000 * 2 * 0.2), 24_000, { quality: 9 });
     writeFileSync(join(incompleteDir, '01-chapter-1.mp3'), mp3);
     /* No MP3 (or anything) for chapter 2 — precheck must reject. */
 

--- a/server/src/export/id3-tags.test.ts
+++ b/server/src/export/id3-tags.test.ts
@@ -11,7 +11,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { encodePcmToMp3 } from '../tts/mp3.js';
+import { encodePcmToAudio } from '../tts/mp3.js';
 import { applyId3v24Tags } from './id3-tags.js';
 
 const ffmpegPresent = (() => {
@@ -115,7 +115,7 @@ describeIf('applyId3v24Tags', () => {
   beforeAll(async () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'id3-tags-'));
     srcPath = join(tmpDir, 'src.mp3');
-    const mp3 = await encodePcmToMp3(silencePcm(24_000, 0.5), 24_000, { quality: 2 });
+    const mp3 = await encodePcmToAudio(silencePcm(24_000, 0.5), 24_000, { quality: 2 });
     writeFileSync(srcPath, mp3);
     srcBytes = mp3;
   });

--- a/server/src/export/id3-tags.ts
+++ b/server/src/export/id3-tags.ts
@@ -1,7 +1,7 @@
 /* ID3v2.4 re-tagger. Takes an existing MP3 on disk, writes a new MP3 to
    `destPath` with the supplied tags and the input's audio frames copied
    byte-for-byte (`-c:a copy`). No re-encode — the LAME VBR V2 bytes
-   produced by encodePcmToMp3 survive intact.
+   produced by encodePcmToAudio survive intact.
 
    ffmpeg strips inbound MP3 tags by default when remuxing to mp3, so the
    destination ends up with only the tags we pass via `-metadata`. We

--- a/server/src/routes/export.test.ts
+++ b/server/src/routes/export.test.ts
@@ -18,7 +18,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import express, { type Express } from 'express';
 import request from 'supertest';
-import { encodePcmToMp3 } from '../tts/mp3.js';
+import { encodePcmToAudio } from '../tts/mp3.js';
 
 const ffmpegPresent = (() => {
   try {
@@ -91,7 +91,7 @@ beforeAll(async () => {
   );
   writeFileSync(join(bookDir, 'manuscript.txt'), 'placeholder');
 
-  const mp3 = await encodePcmToMp3(Buffer.alloc(24_000 * 2 * 0.2), 24_000, { quality: 9 });
+  const mp3 = await encodePcmToAudio(Buffer.alloc(24_000 * 2 * 0.2), 24_000, { quality: 9 });
   writeFileSync(join(audioRoot, '01-chapter-one.mp3'), mp3);
   writeFileSync(join(audioRoot, '02-chapter-two.mp3'), mp3);
 
@@ -185,7 +185,7 @@ describeIfFfmpeg('POST /api/books/:bookId/exports + GET status + download', () =
       expect(res.body.error).toBe('export_incomplete');
       expect(res.body.missing).toContain('02-chapter-two');
     } finally {
-      const mp3 = await encodePcmToMp3(Buffer.alloc(24_000 * 2 * 0.2), 24_000, { quality: 9 });
+      const mp3 = await encodePcmToAudio(Buffer.alloc(24_000 * 2 * 0.2), 24_000, { quality: 9 });
       writeFileSync(ch2, mp3);
     }
   });

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -41,7 +41,7 @@ import {
   selectTtsProvider,
   type TtsModelKey,
 } from '../tts/index.js';
-import { encodePcmToMp3, writeChapterPeaksFile } from '../tts/mp3.js';
+import { encodePcmToAudio, writeChapterPeaksFile } from '../tts/mp3.js';
 import {
   synthesiseChapter,
   type CastCharacter,
@@ -528,7 +528,7 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
         durationSec: result.durationSec,
       });
 
-      const mp3Buffer = await encodePcmToMp3(result.pcm, result.sampleRate, { quality: 2 });
+      const mp3Buffer = await encodePcmToAudio(result.pcm, result.sampleRate, { quality: 2 });
       const mp3Path = join(audioRoot, `${chapter.slug}.mp3`);
       const segPath = join(audioRoot, `${chapter.slug}.segments.json`);
       const peaksPath = join(audioRoot, `${chapter.slug}.peaks.json`);

--- a/server/src/routes/voice-sample.ts
+++ b/server/src/routes/voice-sample.ts
@@ -3,7 +3,7 @@
    `modelKey` (local sidecar or Gemini) and serves it from the static /audio
    mount. Files are cached on disk keyed by voiceId + modelKey + paramHash,
    so a repeat click is instant and engine-specific. Encoded to MP3 via the
-   same `encodePcmToMp3` boundary used by chapter audio (plan 28). */
+   same `encodePcmToAudio` boundary used by chapter audio (plan 28). */
 
 import { Router, type Request, type Response } from 'express';
 import { existsSync } from 'node:fs';
@@ -18,7 +18,7 @@ import {
   type TtsEngine,
   type TtsModelKey,
 } from '../tts/index.js';
-import { encodePcmToMp3 } from '../tts/mp3.js';
+import { encodePcmToAudio } from '../tts/mp3.js';
 import { pcmDurationSec } from '../tts/pcm.js';
 import { pickVoiceForEngine, type CharacterHint, type VoiceLike } from '../tts/voice-mapping.js';
 
@@ -195,7 +195,7 @@ voiceSampleRouter.post('/:voiceId/sample', async (req: Request, res: Response) =
     /* Compute duration from raw PCM before encode — MP3 frame counting would
        force a probe step. PCM bytes/sec is exact for 16-bit mono. */
     const durationSec = pcmDurationSec(pcm.length, sampleRate);
-    const mp3 = await encodePcmToMp3(pcm, sampleRate);
+    const mp3 = await encodePcmToAudio(pcm, sampleRate);
     await writeFile(filePath, mp3);
     return res.json({ url: publicUrl, durationSec, cached: false, modelKey });
   } catch (err) {

--- a/server/src/tts/mp3.test.ts
+++ b/server/src/tts/mp3.test.ts
@@ -1,4 +1,4 @@
-/* Real-ffmpeg integration test for encodePcmToMp3. We deliberately do NOT
+/* Real-ffmpeg integration test for encodePcmToAudio. We deliberately do NOT
    mock the subprocess — the value of this suite is catching wire-format or
    flag-name drift in the actual encoder boundary. If ffmpeg is missing the
    suite skips with a loud reason (CI must install it; users get a one-line
@@ -9,7 +9,7 @@ import { mkdtempSync, readFileSync, rmSync, existsSync, readdirSync } from 'node
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect } from 'vitest';
-import { encodePcmToMp3, writeChapterPeaksFile, type ChapterPeaksFile } from './mp3.js';
+import { encodePcmToAudio, writeChapterPeaksFile, type ChapterPeaksFile } from './mp3.js';
 import { BIN_COUNT } from '../audio/compute-peaks.js';
 
 const ffmpegPresent = (() => {
@@ -61,11 +61,11 @@ function findMpegSync(b: Buffer): number {
   return -1;
 }
 
-describeIfFfmpeg('encodePcmToMp3', () => {
+describeIfFfmpeg('encodePcmToAudio', () => {
   it('encodes 24 kHz mono PCM to a valid MPEG-2 Layer III mono stream', async () => {
     const sampleRate = 24_000;
     const pcm = sinePcm(sampleRate, 1.0);
-    const mp3 = await encodePcmToMp3(pcm, sampleRate, { quality: 2 });
+    const mp3 = await encodePcmToAudio(pcm, sampleRate, { quality: 2 });
 
     expect(mp3.length).toBeGreaterThan(1024); // ~1s @ V2 ≈ 18 KB, won't be tiny
 
@@ -90,14 +90,14 @@ describeIfFfmpeg('encodePcmToMp3', () => {
 
   it('rejects when ffmpeg exits non-zero (invalid sample rate)', async () => {
     const pcm = sinePcm(24_000, 0.1);
-    await expect(encodePcmToMp3(pcm, 0, { quality: 2 })).rejects.toThrow(/ffmpeg/i);
+    await expect(encodePcmToAudio(pcm, 0, { quality: 2 })).rejects.toThrow(/ffmpeg/i);
   });
 
   it('rejects with a friendly hint if ffmpeg is not on PATH', async () => {
     // We can't realistically uninstall ffmpeg per-test, but we can verify
     // the error path by spawning a guaranteed-missing binary via a child
     // module copy that takes the binary name. Skip this corner — covered
-    // by the friendly-hint string baked into encodePcmToMp3 and exercised
+    // by the friendly-hint string baked into encodePcmToAudio and exercised
     // only when users misconfigure their machine.
     // (Kept as a placeholder so future refactors that abstract the binary
     // name remember to add this assertion.)

--- a/server/src/tts/mp3.ts
+++ b/server/src/tts/mp3.ts
@@ -20,17 +20,31 @@ import { mkdir, rename, unlink, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { computePeaks } from '../audio/compute-peaks.js';
 
-export interface EncodePcmToMp3Options {
+/** Supported output container/codec. Single-value union today; future PRs
+ *  will widen to e.g. `'mp3' | 'm4a' | 'opus'` and dispatch on this field. */
+export type EncodePcmAudioFormat = 'mp3';
+
+export interface EncodePcmToAudioOptions {
+  /** Output format. Defaults to `'mp3'`. Single-value union for now —
+   *  the dispatch on this field is the seam future encoder additions
+   *  (AAC/M4A, Opus) extend without changing this function's signature. */
+  format?: EncodePcmAudioFormat;
   /** LAME VBR quality: 0 (best, larger) .. 9 (worst, smaller). Default 2
       ≈ V2, the LAME preset-standard. */
   quality?: number;
 }
 
-export async function encodePcmToMp3(
+export async function encodePcmToAudio(
   pcm: Buffer,
   sampleRate: number,
-  opts: EncodePcmToMp3Options = {},
+  opts: EncodePcmToAudioOptions = {},
 ): Promise<Buffer> {
+  /* Read but don't yet branch on `format` — we accept the discriminator and
+     default it to 'mp3' so callers can already pass it explicitly, but the
+     ffmpeg invocation below is the existing MP3 path verbatim. Future PRs
+     (AAC/M4A, Opus) dispatch from here. */
+  const format: EncodePcmAudioFormat = opts.format ?? 'mp3';
+  void format;
   const quality = opts.quality ?? 2;
 
   const args = [
@@ -109,7 +123,7 @@ export interface ChapterPeaksFile {
  *  `writeFile`, rename over target; cleanup the temp file on terminal
  *  failure so we don't leak `.tmp-*` droppings into the workspace).
  *
- *  Called by `generation.ts` alongside `encodePcmToMp3` so the peaks land
+ *  Called by `generation.ts` alongside `encodePcmToAudio` so the peaks land
  *  next to the MP3 in one render pass. Failure here is non-fatal — peaks
  *  are a visualization aid, not load-bearing for playback — but we still
  *  reject so the caller can decide whether to log / surface; today


### PR DESCRIPTION
## Summary

Wave-0 prep refactor for the post-v1.3.1 audio-quality bundle. Behaviour-neutral rename of `encodePcmToMp3` → `encodePcmToAudio` in `server/src/tts/mp3.ts`, plus a `format?: 'mp3'` discriminator on the options type. `'mp3'` is the only supported value today — the follow-on PRs (EBU R128 loudnorm; AAC/M4A and Opus codecs) widen the discriminator and add per-format ffmpeg dispatch without re-touching this signature.

- `server/src/tts/mp3.ts` — function rename + new `EncodePcmAudioFormat` type + `format?: 'mp3'` option, default `'mp3'`; ffmpeg invocation unchanged
- Call sites updated: `server/src/routes/generation.ts:531`, `server/src/routes/voice-sample.ts:198`, the 5 `server/src/export/*.test.ts` files, and incidental comment refs in `server/src/audio/compute-peaks.ts` + `server/src/export/id3-tags.ts`
- Renamed type `EncodePcmToMp3Options` → `EncodePcmToAudioOptions`; existing options (bitrate/quality/peaks-file path) untouched
- `encodePcmToAudio` reads `opts.format ?? 'mp3'` into a typed local with `void format;` to mark it as read-but-not-yet-branched-on. This is the seam the EBU R128 and AAC/Opus follow-ons extend

## Contract / API surface

No openapi changes. No `BookStateJson` field changes. No new dependencies. No ffmpeg invocation changes (same args, same pipes, same return shape).

## Tests

- Existing `server/src/tts/mp3.test.ts` — assertions stay green; only `describe`/`it` strings updated to match the new function name
- No new tests added — the rename is behaviour-neutral by definition; the follow-on PRs ship new tests for loudnorm + each new codec
- Full `npm run verify` green: lint, typecheck, test:hooks, test (1140 frontend), test:server (1095 across 78 files), test:scripts, test:sidecar, test:e2e (42 + 4 flaky-then-passed + 2 skipped), build

## Test plan

- [x] `cd server && npm run test` (1095 server tests) green
- [x] `npm run typecheck` green
- [x] `npm run verify` full battery green
- [x] No call site missed — Grep for `encodePcmToMp3` and `EncodePcmToMp3Options` across `server/src/` returns zero hits post-refactor

## Notes

A pre-existing flake on `src/analyzer/gemini.test.ts` (timer-sensitive retry/watchdog suite) surfaced once under `--no-cache` verify and passed on a clean re-run. Unrelated to this refactor — flagging for visibility, not blocking. Doc-side references to the old name in `docs/BACKLOG.md` and `docs/features/archive/56-real-chapter-peaks.md` were left alone: the BACKLOG entry literally describes the follow-on AAC/M4A work, and the archived plan-56 ship notes correctly describe the encoder boundary at the moment plan 56 shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)