### PR TITLE
feat(server,frontend): per-chapter loudness report card (plan 77)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -46,16 +46,6 @@ Ranking within each bucket = top is highest priority.
 
 Ordered in clusters: audio quality → listening UX → library/workflow → cast/revisions → voice library → coverage & ops → streaming/sync → distribution → tracking → deferred listener-app handoffs.
 
-### 3. Per-chapter loudness report / visualization
-
-Source: net-new (2026-05-18). Pairs with Could #1 (loudnorm).
-
-- _What:_ Add a "Loudness report" card to the listen view showing per-chapter integrated loudness (LUFS), peak (dBTP), and LRA, computed at chapter-encode time and persisted alongside the audio. Chapters drifting more than ±2 LU from target highlight red. Click a chapter row → opens that chapter in the listen view with the loudness numbers shown.
-- _Acceptance:_ After loudnorm-enabled chapter encode, each chapter row in the loudness report card shows LUFS / dBTP / LRA. Forced low-loudness mock chapter shows up red. New server Vitest spec covers loudness extraction from `ffmpeg -af ebur128`. Frontend Vitest covers the card rendering + click-through.
-- _Key files:_ new `src/components/loudness-report.tsx`; `src/views/listen.tsx` (mount); `server/src/tts/mp3.ts` (emit loudness metadata to chapter meta); `server/src/routes/chapter-audio.ts` (surface in meta endpoint).
-- _Depends on:_ Could #1 (loudnorm) — without normalization there's no expected target to compare against.
-- _Benefit (user):_ catch problem chapters before export (e.g. a voice that came out 4 LU softer than the rest). Pairs with Could #1 to make loudness drift visible, not just corrected.
-
 ### 12. Multi-step rollback / snapshot-per-entry (revision history)
 
 Source: net-new (2026-05-19). Spun off from plan 55 ship — v1.3.0 plan 55 ships the read-only history view; this entry covers the multi-step rollback that needs snapshot-per-entry storage.

--- a/docs/features/77-loudness-report-card.md
+++ b/docs/features/77-loudness-report-card.md
@@ -1,0 +1,145 @@
+---
+status: stable
+shipped: 2026-05-20
+owner: null
+---
+
+# Per-chapter loudness report card (EBU R128 drift surfacing)
+
+> Status: stable
+> Key files: `src/components/loudness-report.tsx`, `src/components/listen/listen-player-region.tsx`, `src/store/chapters-slice.ts`, `server/src/routes/chapter-audio.ts`, `server/src/routes/book-state.ts`, `openapi.yaml`, `src/lib/types.ts`
+> URL surface: `#/books/<id>/listen` (card is rendered inside the player region, between the chapter list and the share-clip modal)
+> OpenAPI ops: extends `getChapterAudio` response with `lufs` field; book-state response gains a per-chapter `chapterLufs` map (hand-written type — book-state has no OpenAPI binding)
+> Paired tests: `src/components/loudness-report.test.tsx`, `src/components/listen/listen-player-region.test.tsx`, `src/store/chapters-slice.test.ts` (hydration), `server/src/routes/chapter-audio.test.ts` (loudness sidecar section), `server/src/routes/book-state.test.ts` (chapterLufs section), `e2e/listen-loudness-report.spec.ts`
+> Cross-links: [71 — Audio loudness normalization](71-audio-loudness-normalization.md) (the writer this plan consumes), [28 — Audio output format](28-chapter-audio-format.md)
+
+## Benefit / Rationale
+
+Plan 71 writes per-chapter EBU R128 measurements to disk but nothing surfaces them. A loudness-normalised book is supposed to sit at one perceived volume across narrators and chapters — but the user only finds out something drifted when they hear it. This plan closes the loop: every Listen view now shows a colour-coded badge per chapter and a book-level report card so problem chapters are visible before export, not after.
+
+- **User:** at a glance, see which chapters landed on target (green), which drifted a little (amber), and which are off (red). The expandable per-chapter table backs the badge with the actual numbers (i / drift / measured-at) so a user evaluating their book before publishing has the data they need without re-running ffprobe by hand.
+- **Technical:** the chapter-audio meta endpoint and the book-state response both now carry the loudnorm sidecar payload, so the Listen view doesn't have to N-fan-out one fetch per chapter row. The per-row badge consumes the slice; the report card consumes the slice; both read from one source of truth.
+- **Architectural:** the redux Chapter shape gains a `lufs` field that mirrors plan 71's `LoudnormSidecarJson`. The sidecar JSON disk schema is unchanged — this plan is a pure reader. Any future plan that needs the loudness data (cross-book drift comparison, per-chapter re-normalise trigger) reads from the same slice field.
+
+## Architectural impact
+
+- **New seams added:**
+  - `ChapterAudio.lufs` (OpenAPI) — optional, mirrors `LoudnormSidecarJson` on disk. Null when no loudnorm pass landed.
+  - `BookStateResponse.chapterLufs` (hand-written type in `src/lib/types.ts`) — `Record<chapterId, ChapterLoudness | null>`. Empty `{}` when no audio dir; null entry per chapter when sidecar is absent.
+  - `Chapter.lufs` (runtime, UI-only) — populated by `hydrateFromBookState` from the per-book map. `undefined` when the response omits the field (back-compat for older servers); `null` when fetched-but-no-data.
+  - `LoudnessReport` component (`src/components/loudness-report.tsx`) — pure presentational; reads from chapter slice via the listen-player-region wrapper.
+  - `LoudnessBadge` (inline in `listen-player-region.tsx`) — per-row pill gated on `lufs.twoPass === true`.
+  - Helper export `classifyDrift(lufs)` — the single source of truth for the on-target / slight / off-target / no-data buckets, shared between the row badge and the report card.
+- **Invariants preserved:**
+  - The `.lufs.json` sidecar JSON shape is unchanged (plan 71 contract). This plan only adds READ paths; no writer touched.
+  - The chapter-audio meta endpoint's existing fields (`url`, `durationSec`, `peaks`, `sampleRate`, `segments`) round-trip unchanged. `lufs` is additive.
+  - The book-state response's existing fields round-trip unchanged. `chapterLufs` is additive (older clients ignore it).
+  - The `twoPass === true` gate is enforced in TWO places: the per-row badge AND the report card's bucket classifier. Drift comparisons NEVER happen against single-pass values.
+- **Migration story:**
+  - Chapters generated before plan 71 → `chapterLufs[id] = null` → row badge omitted, report card row shows "No measurement" pill.
+  - Books generated before plan 71 with ZERO loudnormed chapters → empty-state copy points the user at `AUDIO_LOUDNORM_ENABLED` (default on since plan 71).
+  - Older server (no `chapterLufs` in response) → slice field stays `undefined` → same UI as legacy chapters.
+- **Reversibility:** revert the slice + UI commits; the server fields stay harmless (any consumer ignores unknown JSON keys).
+
+## Sidecar contract
+
+Persisted by plan 71's encoder at `<bookDir>/audio/<chapterSlug>.lufs.json`. This plan reads it back verbatim — DO NOT redesign:
+
+```json
+{
+  "i": -16.02,
+  "lra": 8.4,
+  "tp": -2.1,
+  "target": -16,
+  "twoPass": true,
+  "measuredAt": "2026-05-20T12:00:00.000Z"
+}
+```
+
+- `i` — measured integrated loudness (LUFS). In TWO-PASS mode this is the FIRST-PASS measurement of the source PCM; in SINGLE-PASS mode it's the nominal target (no re-measurement). Consumers MUST gate drift comparisons on `twoPass === true`.
+- `lra` — measured loudness range (LU). Same single-pass caveat.
+- `tp` — measured true peak (dBTP). Same single-pass caveat.
+- `target` — target integrated loudness used. Default `-16` (ACX audiobook submission target).
+- `twoPass` — `true` when the measure-then-apply flow ran; `false` for single-pass streaming normalisation.
+- `measuredAt` — ISO-8601 timestamp at encode time.
+
+Missing file = no loudnorm pass landed (legacy chapter / `AUDIO_LOUDNORM_ENABLED=false` / silent-source fallthrough). UI degrades to "no data" — no synthesised default target.
+
+## Two-pass vs single-pass gate (CRITICAL)
+
+Single-pass loudnorm writes the NOMINAL TARGET into `i`/`lra`/`tp`, not a re-measurement of the output. A chapter normalised in single-pass mode whose actual integrated loudness is several LU off-target will still report `i === target`. Rendering that as "on target" would silently mislead the user.
+
+The gate is enforced in `classifyDrift()` (single function, single source of truth):
+
+```ts
+if (!lufs || lufs.twoPass !== true) return 'no-data';
+```
+
+Every consumer in the UI calls through this function. The per-row badge renders nothing for single-pass; the report card treats them as no-data (so they roll up under "no measurement" rather than skewing the on-target count). Locked in by `loudness-report.test.tsx`'s "single-pass gate (CRITICAL)" describe block and `listen-player-region.test.tsx`'s "does NOT render a badge when twoPass is false" case.
+
+## Drift thresholds
+
+| drift = `|i − target|` | bucket       | colour | copy            |
+| ---------------------- | ------------ | ------ | --------------- |
+| ≤ 2 LU                 | `on-target`  | green  | On target       |
+| 2 LU < d ≤ 4 LU        | `slight`     | amber  | Slight drift    |
+| > 4 LU                 | `off-target` | rose   | Off target      |
+| no data / single-pass  | `no-data`    | neutral| No measurement  |
+
+The 2 LU boundary is the EBU R128 tolerance the encoder targets; the 4 LU boundary is the audible-on-careful-listening threshold. Numbers locked in by `classifyDrift` and exercised exhaustively in `loudness-report.test.tsx` "bucket thresholds".
+
+## Mount point
+
+The `LoudnessReport` card is mounted inside `ListenPlayerRegion` (`src/components/listen/listen-player-region.tsx`), immediately after the chapter list and before the `ShareClipModal`. Rationale:
+
+- Per CLAUDE.md, `src/views/listen.tsx` is a thin orchestrator and new listen-view features land in the relevant region sub-component.
+- The card SUMMARISES the chapter list directly above it; visual proximity is the whole point.
+- The download section (`listen-download-section.tsx`) is about exports — adding a loudness card there would mix concerns.
+- The header (`listen-header.tsx`) carries top-of-view cover + book-meta; the loudness card is too detail-heavy for that slot.
+
+The per-row badge lives inline in `ChapterListenRow` next to the title, sharing the same line as the resume pill. No layout breakage on rows that lack a measurement — the badge null-renders.
+
+## Invariants to preserve
+
+1. The `.lufs.json` sidecar JSON shape (`LoudnormSidecarJson` in `server/src/tts/loudnorm.ts:64`) is stable contract with plan 71. Adding fields requires a new plan that updates BOTH the writer (loudnorm.ts) and every reader (chapter-audio.ts, book-state.ts, frontend `classifyDrift`).
+2. `classifyDrift()` in `src/components/loudness-report.tsx` is the SOLE bucket-classification function. New consumers MUST import it rather than re-deriving thresholds.
+3. The single-pass gate (`lufs.twoPass !== true → no-data`) MUST stay enforced. Any future "show single-pass anyway" affordance needs a separate signal that doesn't conflate nominal-target with measured-value.
+4. The chapter-audio meta endpoint's `lufs` field is OPTIONAL (`null` when sidecar absent). Removing the null branch in any reader would 500 the listen view on every legacy chapter.
+5. `book-state.ts`'s `chapterLufs` map MUST have a null entry per chapter when the sidecar is absent (not a missing key). The frontend uses the keys to detect "we asked, the answer was no" vs. "older server didn't send it".
+
+## Test plan
+
+### Automated coverage
+
+- **Server `chapter-audio.test.ts` "loudness sidecar" describe block** — 5 cases: two-pass payload round-trips verbatim, single-pass payload surfaces `twoPass: false` unchanged (UI degrades on consumer side), missing sidecar returns `lufs: null`, malformed JSON returns `lufs: null` (no 500), full payload round-trip preserves every field.
+- **Server `book-state.test.ts` "chapterLufs hydration (plan 77)" describe block** — 4 cases: empty `{}` when no audio dir, surfaces per-chapter payload when present, null entry when sidecar missing, null entry on malformed JSON.
+- **Frontend `chapters-slice.test.ts`** — 2 cases: `hydrateFromBookState` copies `chapterLufs[id]` onto each chapter row's `lufs` field; absent map leaves `lufs` undefined.
+- **Frontend `loudness-report.test.tsx`** — 15 cases covering bucket thresholds (≤2 / 2-4 / >4 LU), the single-pass gate (CRITICAL), null/undefined → no-data, mixed-drift summary counts, sparkline column attributes, excluded-chapter filtering, empty state, and expand-collapse of the per-chapter table.
+- **Frontend `listen-player-region.test.tsx`** — 9 cases covering each badge colour, missing-data null render, single-pass gate null render, tooltip content, formatted LUFS value, and the report card mount-point.
+- **E2E `e2e/listen-loudness-report.spec.ts`** — 3 cases: card + summary + sparkline render in a real browser on the Solway Bay mock seed, expandable table toggles open and shows the right buckets per row, per-row badge appears on measured chapters and is absent on single-pass / no-data chapters.
+
+### Manual acceptance walkthrough
+
+Mock mode (`VITE_USE_MOCKS=true`) — the Solway Bay seed in `src/lib/api.ts` ships deterministic chapterLufs payloads that exercise every badge colour.
+
+1. **Open `#/books/sb/listen`** → expected stage = `{ kind: 'ready', view: 'listen', bookId: 'sb' }`, expected UI = listen view with header + chapter list + loudness report card visible below the chapter list.
+2. **Inspect the summary line** → reads "N of M chapters within ±2 LU of -16.0 LUFS" where N counts the chapters with two-pass on-target measurements (15 in the mock seed) and M counts chapters with ANY two-pass measurement (16 — chapters 11 and 15 are single-pass, chapter 14 is null).
+3. **Eyeball the sparkline** → 18 bars total. Chapter 9 (one of the tallest, rose-coloured) is off-target; chapter 4 / 5 (amber-tinted, 2.6 / 0 LU drift respectively) shows the slight bucket; the rest are mostly green; chapter 14 is a tiny neutral stub (no-data).
+4. **Per-chapter row badges** → chapter 1's row shows a green "−15.9 LUFS" pill; chapter 4 shows an amber "−13.4 LUFS" pill; chapter 9 shows a rose "−11.6 LUFS" pill; chapter 11 / 15 have NO badge (single-pass); chapter 14 has NO badge (null).
+5. **Hover a badge** → native tooltip surfaces target + LRA + true peak + measured-at relative time.
+6. **Click "Show per-chapter table"** → the table expands. Each row carries `data-bucket="…"` for the visual regression hook. Single-pass / null rows render `—` in the measured / drift cells with a neutral "No measurement" pill.
+7. **Click "Hide per-chapter table"** → the table collapses back.
+8. **Generate a fresh book end-to-end** (real backend, AUDIO_LOUDNORM_ENABLED=true) → the book's `chapter-audio` meta endpoint surfaces real `lufs` payloads; the listen view shows real per-chapter measurements. Open `<bookDir>/.audiobook/state.json` and compare against the disk `.lufs.json` files to confirm round-trip.
+9. **Set `AUDIO_LOUDNORM_ENABLED=false` and regenerate one chapter** → its `.lufs.json` disappears; the chapter's badge is suppressed on next listen-view load; the report card summary count drops by one but the rest of the book reads unchanged.
+
+## Out of scope
+
+- **No histogram interactivity for v1.** The sparkline is read-only — no hover-to-highlight-row, no click-to-seek. The expandable table is the cross-reference affordance.
+- **No per-chapter "re-normalize" button.** That's a future Could; would require a server-side re-encode endpoint and a queue UI. The current loop is: tweak `AUDIO_LOUDNORM_ENABLED` / target in env → regenerate from the Generate view.
+- **No cross-book drift comparison.** Comparing Book A's loudness curve against Book B's is a future Could; sits more naturally on the workspace activity view.
+- **No telemetry / aggregation.** The per-book card stays per-book. No "your library averages -16.3 LUFS" rollup.
+- **No M4B chapter-level loudness export.** The report is for the audiobook author; the listener gets one normalised stream.
+
+## Ship notes
+
+Shipped 2026-05-20 on branch `feat/frontend-audio-loudness-report` (see end-of-turn summary for the commit SHA). Implementation: server adds `lufs` to chapter-audio meta + `chapterLufs` to book-state response, openapi.yaml gains `ChapterLoudness` schema, frontend Chapter shape gains `lufs?`, new `LoudnessReport` component (~280 lines) plus inline `LoudnessBadge` in listen-player-region. Mock seed populates 18 deterministic chapterLufs entries for Solway Bay so design-system mode has real content. 34 new automated tests: 5 server (chapter-audio) + 4 server (book-state) + 2 frontend slice + 15 frontend report-card + 9 frontend region badge — plus 3 Playwright e2e cases. No `.lufs.json` writer touched; this is a pure read path.

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -93,6 +93,7 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 - [32 — Audiobook export](32-audiobook-export.md) — Sideload to PocketBook Reader (Phase A: MP3.ZIP) via LAN download or sync folder; per-chapter ID3v2.4 tags, no re-encode, atomic writes.
 - [34 — MP3-folder export](34-mp3-folder-export.md) — Per-chapter MP3s in a sub-folder for folder-scanning audiobook apps (Smart AudioBook Player, BookPlayer, Audiobookshelf). Sync-folder destination only; APIC cover travels with each chapter.
 - [67 — Streaming-link download tile](archive/67-streaming-link-tile.md) — Mints a 12-char Crockford base32 slug; `GET /share/:slug` proxies the book's most-recent M4B export off disk. Closes the last "Coming soon" tile on the Listen view. Shipped 2026-05-19.
+- [77 — Per-chapter loudness report card](77-loudness-report-card.md) — Consumes plan 71's `<slug>.lufs.json` sidecars and surfaces them in the Listen view as (a) a colour-coded per-row drift pill (≤2 / 2–4 / >4 LU buckets) and (b) an expandable report card with summary line + sparkline + per-chapter table. Drift comparisons gated on `twoPass === true`; single-pass values degrade to neutral.
 
 ### I. Revisions & drift
 

--- a/e2e/listen-loudness-report.spec.ts
+++ b/e2e/listen-loudness-report.spec.ts
@@ -1,0 +1,91 @@
+/* Plan 77 — browser-level coverage for the per-chapter loudness report
+   card + the per-row drift badge. The mock seed for Solway Bay (in
+   `src/lib/api.ts`) ships a deterministic chapterLufs payload that
+   mixes on-target / slight / off-target / no-data / single-pass rows,
+   so the report card has real content to render under mocks.
+
+   This pins the public test hooks (testids + bucket attributes) that
+   the unit tests also assert on; the end-to-end pass verifies the
+   redux hydration + view layout actually surface them in a real
+   browser. */
+
+import { test, expect } from '@playwright/test';
+
+/* Same parallel-worker contention story as listen-playback.spec.ts:
+   chapter-row hydration races other workers' SSE traffic on Windows.
+   Serial mode within this file keeps the spec stable while other files
+   parallelise. */
+test.describe.configure({ mode: 'serial' });
+
+test.describe('listen loudness report card', () => {
+  test('renders the report card + summary + sparkline on the Listen view', async ({ page }) => {
+    await page.goto('/#/books/sb/listen');
+    await expect(page).toHaveURL(/#\/books\/sb\/listen/);
+
+    /* Wait for hydration: the loudness card only renders once the
+       chapters slice has the mock chapterLufs map. The empty book-meta
+       header would race past us otherwise. */
+    await expect(page.getByRole('heading', { name: /Solway Bay/i, level: 1 })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const card = page.getByTestId('loudness-report');
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    /* Summary line names a per-book on-target count + the formatted
+       target. Mock seed is centred at -16 LUFS. */
+    const summary = page.getByTestId('loudness-report-summary');
+    await expect(summary).toBeVisible();
+    await expect(summary).toContainText(/of \d+ chapters within ±2 LU/);
+    /* Sparkline renders one column per chapter — the mock seed has 18
+       chapters, all listenable. */
+    await expect(page.getByTestId('loudness-report-sparkline')).toBeVisible();
+  });
+
+  test('expandable per-chapter table toggles open and surfaces row buckets', async ({ page }) => {
+    await page.goto('/#/books/sb/listen');
+    /* Wait for header → confirms book-meta hydrated → chapters slice
+       is also populated by then (same hydration effect). */
+    await expect(page.getByRole('heading', { name: /Solway Bay/i, level: 1 })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId('loudness-report')).toBeVisible({ timeout: 10_000 });
+
+    const toggle = page.getByTestId('loudness-report-toggle');
+    await expect(toggle).toBeVisible();
+    /* Table is collapsed by default. */
+    await expect(page.getByTestId('loudness-report-table')).not.toBeVisible();
+    await toggle.click();
+    await expect(page.getByTestId('loudness-report-table')).toBeVisible();
+    /* The mock seed puts a 4.4 LU off-target on chapter 9 — check that
+       the row carries the right data-bucket attribute. */
+    const row9 = page.getByTestId('loudness-report-row-9');
+    await expect(row9).toBeVisible();
+    await expect(row9).toHaveAttribute('data-bucket', 'off-target');
+    /* Chapter 1 (delta 0.1) is on-target. */
+    const row1 = page.getByTestId('loudness-report-row-1');
+    await expect(row1).toHaveAttribute('data-bucket', 'on-target');
+  });
+
+  test('per-row drift badge appears on the chapter list for measured chapters', async ({
+    page,
+  }) => {
+    await page.goto('/#/books/sb/listen');
+    /* Wait for header → chapters slice is hydrated. */
+    await expect(page.getByRole('heading', { name: /Solway Bay/i, level: 1 })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId('chapter-row-1')).toBeVisible({ timeout: 10_000 });
+    /* Chapter 1 has two-pass data at +0.1 LU drift — badge present,
+       bucket on-target. */
+    const badge1 = page.getByTestId('chapter-row-1-lufs-badge');
+    await expect(badge1).toBeVisible({ timeout: 5_000 });
+    await expect(badge1).toHaveAttribute('data-bucket', 'on-target');
+    /* Chapter 11 is single-pass-only in the mock seed — badge must
+       NOT render (the critical gate from plan 71). */
+    await expect(page.getByTestId('chapter-row-11')).toBeVisible();
+    await expect(page.getByTestId('chapter-row-11-lufs-badge')).toHaveCount(0);
+    /* Chapter 14 has null lufs in the seed — badge must NOT render. */
+    await expect(page.getByTestId('chapter-row-14')).toBeVisible();
+    await expect(page.getByTestId('chapter-row-14-lufs-badge')).toHaveCount(0);
+  });
+});

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2314,6 +2314,61 @@ components:
               end: { type: number, description: 'seconds' }
               characterId: { type: string }
               sentenceId: { type: integer }
+        lufs:
+          $ref: '#/components/schemas/ChapterLoudness'
+          nullable: true
+          description: |
+            EBU R128 loudness measurement persisted next to the chapter
+            audio as `<slug>.lufs.json` (plan 71). Null when no loudnorm
+            pass landed — legacy chapter, `AUDIO_LOUDNORM_ENABLED=false`,
+            or silent-source fallthrough. Consumers MUST gate any
+            drift-vs-ground-truth comparison on `twoPass === true`;
+            single-pass values are nominal target values, not real
+            post-filter measurements. Plan 77 (LUFS report card UI)
+            reads this back to surface per-chapter drift badges and a
+            book-level loudness summary card on the Listen view.
+
+    ChapterLoudness:
+      type: object
+      required: [i, lra, tp, target, twoPass, measuredAt]
+      description: |
+        Per-chapter loudness payload written by the encoder's `loudnorm`
+        filter. Mirrors `LoudnormSidecarJson` in
+        `server/src/tts/loudnorm.ts`; field names are stable contract
+        with the on-disk sidecar JSON (do not rename without bumping the
+        sidecar schema). See `docs/features/71-audio-loudness-normalization.md`.
+      properties:
+        i:
+          type: number
+          description: |
+            Measured integrated loudness (LUFS). In two-pass mode this is
+            the FIRST-pass measurement of the source PCM; in single-pass
+            mode it is the nominal target (no re-measurement is done).
+        lra:
+          type: number
+          description: |
+            Measured loudness range (LU). Same single-pass caveat as `i`.
+        tp:
+          type: number
+          description: |
+            Measured true peak (dBTP). Same single-pass caveat as `i`.
+        target:
+          type: number
+          description: |
+            Target integrated loudness (LUFS) the chapter was normalised
+            to. Matches `LoudnormOptions.target`. Default is `-16` (ACX
+            audiobook submission target).
+        twoPass:
+          type: boolean
+          description: |
+            `true` when the measure-then-apply flow ran (±0.5 LU vs target);
+            `false` for single-pass streaming normalisation. UI consumers
+            MUST gate drift comparisons on this — single-pass `i`/`lra`/`tp`
+            are NOT post-filter measurements.
+        measuredAt:
+          type: string
+          format: date-time
+          description: ISO-8601 timestamp the measurement was taken (encode time).
 
     # --- Workspace change log ---------------------------------------
     ChangeLogEvent:

--- a/server/src/routes/book-state.test.ts
+++ b/server/src/routes/book-state.test.ts
@@ -133,6 +133,57 @@ describe('book-state router — changeLog slice', () => {
   });
 });
 
+describe('book-state router — chapterLufs hydration (plan 77)', () => {
+  /* Plan 77 surfaces per-chapter EBU R128 sidecar payloads (plan 71's
+     `<slug>.lufs.json`) in the book-state response so the listen-view
+     report card can render without N-fan-out chapter-audio meta
+     fetches. */
+  it('returns chapterLufs: {} when no audio dir / sidecars exist', async () => {
+    const res = await request(app).get(`/api/books/${bookId}/state`);
+    expect(res.status).toBe(200);
+    expect(res.body.chapterLufs).toEqual({});
+  });
+
+  it('surfaces per-chapter sidecar payloads keyed by chapter id when present', async () => {
+    const audioRoot = join(bookDir, 'audio');
+    mkdirSync(audioRoot, { recursive: true });
+    /* The test chapter is id=1, slug='chapter-one' (from beforeAll). */
+    const payload = {
+      i: -15.7,
+      lra: 8.2,
+      tp: -1.9,
+      target: -16,
+      twoPass: true,
+      measuredAt: '2026-05-20T12:34:56.000Z',
+    };
+    writeFileSync(join(audioRoot, 'chapter-one.lufs.json'), JSON.stringify(payload));
+    const res = await request(app).get(`/api/books/${bookId}/state`);
+    expect(res.status).toBe(200);
+    expect(res.body.chapterLufs).toEqual({ 1: payload });
+  });
+
+  it('returns chapterLufs[id]: null for chapters whose sidecar is missing', async () => {
+    /* Audio dir exists from the previous test; remove the sidecar to
+       verify the read path emits a null entry (NOT a missing key) so
+       the frontend's empty-state detection works. */
+    const audioRoot = join(bookDir, 'audio');
+    rmSync(join(audioRoot, 'chapter-one.lufs.json'), { force: true });
+    const res = await request(app).get(`/api/books/${bookId}/state`);
+    expect(res.status).toBe(200);
+    expect(res.body.chapterLufs).toEqual({ 1: null });
+  });
+
+  it('absorbs malformed sidecar JSON and degrades to null for that chapter', async () => {
+    const audioRoot = join(bookDir, 'audio');
+    writeFileSync(join(audioRoot, 'chapter-one.lufs.json'), '{ this is not json');
+    const res = await request(app).get(`/api/books/${bookId}/state`);
+    expect(res.status).toBe(200);
+    expect(res.body.chapterLufs).toEqual({ 1: null });
+    /* Clean up so the rest of the suite stays predictable. */
+    rmSync(join(audioRoot, 'chapter-one.lufs.json'), { force: true });
+  });
+});
+
 describe('book-state router — dropped-quotes endpoint', () => {
   it('GET dropped-quotes returns an empty envelope when the file does not exist', async () => {
     /* The book was created in beforeAll with no dropped-quotes.json on

--- a/server/src/routes/book-state.ts
+++ b/server/src/routes/book-state.ts
@@ -41,6 +41,7 @@ import { loadDroppedQuotes } from '../store/dropped-quotes.js';
 import { parseManuscript } from '../parsers/index.js';
 import { CHAPTER_TITLE_PARSER_VERSION } from '../parsers/version.js';
 import { snapshotInFlightAnalysis } from './analysis.js';
+import type { LoudnormSidecarJson } from '../tts/loudnorm.js';
 
 export const bookStateRouter = Router();
 
@@ -240,6 +241,45 @@ bookStateRouter.get('/:bookId/state', async (req: Request, res: Response) => {
       /* fall through with empty list */
     }
 
+    /* Plan 77 — per-chapter EBU R128 loudness sidecar payloads keyed by
+       chapter id. Read once on book-open so the LUFS report card in the
+       Listen view doesn't have to N-fan-out one chapter-audio meta fetch
+       per chapter row. Missing/malformed sidecar → null entry; the
+       frontend uses absence to render a neutral "no data" badge and
+       gates drift comparisons on `twoPass === true`. Tolerant of
+       directory absence (no audio generated yet) — `chapterLufs` stays
+       empty in that case. */
+    const chapterLufs: Record<number, LoudnormSidecarJson | null> = {};
+    try {
+      if (existsSync(audioDir(bookDir))) {
+        for (const ch of state.chapters) {
+          const lufsPath = join(audioDir(bookDir), `${ch.slug}.lufs.json`);
+          if (!existsSync(lufsPath)) {
+            chapterLufs[ch.id] = null;
+            continue;
+          }
+          try {
+            const payload = await readJson<LoudnormSidecarJson>(lufsPath);
+            if (
+              payload &&
+              typeof payload.i === 'number' &&
+              typeof payload.target === 'number'
+            ) {
+              chapterLufs[ch.id] = payload;
+            } else {
+              chapterLufs[ch.id] = null;
+            }
+          } catch {
+            /* malformed sidecar — degrade to null rather than failing
+               the whole book-state request. */
+            chapterLufs[ch.id] = null;
+          }
+        }
+      }
+    } catch {
+      /* fall through — chapterLufs stays {} */
+    }
+
     /* Rehydrate the in-memory ManuscriptRecord if missing (after a server
        restart). Must parse the manuscript fully — a previous version read
        the file as utf-8 bytes with empty chapter bodies, which for EPUB
@@ -260,6 +300,7 @@ bookStateRouter.get('/:bookId/state', async (req: Request, res: Response) => {
       revisions: revs,
       completedSlugs,
       chapterCharacters,
+      chapterLufs,
       changeLog: changeLog?.events ?? null,
       analysis: { failedChapterIds },
     });

--- a/server/src/routes/chapter-audio.test.ts
+++ b/server/src/routes/chapter-audio.test.ts
@@ -122,6 +122,41 @@ function resetAudio() {
   rmIfExists(`${SLUG}.previous.segments.json`);
   rmIfExists(`${SLUG}.peaks.json`);
   rmIfExists(`${SLUG}.previous.peaks.json`);
+  rmIfExists(`${SLUG}.lufs.json`);
+  rmIfExists(`${SLUG}.previous.lufs.json`);
+}
+
+/** Drop a plan-71 sibling `<slug>.lufs.json` next to the MP3 with a
+ *  realistic two-pass payload so the meta endpoint can be pinned to
+ *  read it back verbatim. */
+function writeLufs(
+  slug = SLUG,
+  payload: {
+    i: number;
+    lra: number;
+    tp: number;
+    target: number;
+    twoPass: boolean;
+    measuredAt?: string;
+  } = {
+    i: -16.02,
+    lra: 8.4,
+    tp: -2.1,
+    target: -16,
+    twoPass: true,
+  },
+) {
+  writeFileSync(
+    join(audioRoot, `${slug}.lufs.json`),
+    JSON.stringify({
+      i: payload.i,
+      lra: payload.lra,
+      tp: payload.tp,
+      target: payload.target,
+      twoPass: payload.twoPass,
+      measuredAt: payload.measuredAt ?? '2026-05-20T12:00:00.000Z',
+    }),
+  );
 }
 
 /** Drop a plan-56 sibling `<slug>.peaks.json` next to the MP3 with a
@@ -314,6 +349,105 @@ describe('chapter-audio router', () => {
            aid. The fallback path matches the legacy contract. */
         expect(res.status).toBe(200);
         expect(res.body.peaks).toEqual([]);
+      });
+    });
+  });
+
+  describe('loudness sidecar (plan 77 consumer of plan 71 writer)', () => {
+    describe('when sibling .lufs.json is present (two-pass)', () => {
+      beforeAll(() => {
+        resetAudio();
+        writeMp3();
+        writeLufs();
+      });
+
+      it('meta endpoint surfaces the lufs payload verbatim', async () => {
+        const res = await request(app).get(`/api/books/${bookId}/chapters/1/audio`);
+        expect(res.status).toBe(200);
+        expect(res.body.lufs).toEqual({
+          i: -16.02,
+          lra: 8.4,
+          tp: -2.1,
+          target: -16,
+          twoPass: true,
+          measuredAt: '2026-05-20T12:00:00.000Z',
+        });
+      });
+    });
+
+    describe('when sibling .lufs.json is present (single-pass)', () => {
+      /* Single-pass values are the nominal target restated, not a real
+         post-filter measurement — the wire payload still carries them
+         (the gate is `twoPass === true` on the consumer side, not on
+         the route). */
+      beforeAll(() => {
+        resetAudio();
+        writeMp3();
+        writeLufs(SLUG, {
+          i: -16,
+          lra: 11,
+          tp: -1.5,
+          target: -16,
+          twoPass: false,
+        });
+      });
+
+      it('meta endpoint surfaces twoPass: false unchanged so the UI can degrade to neutral', async () => {
+        const res = await request(app).get(`/api/books/${bookId}/chapters/1/audio`);
+        expect(res.status).toBe(200);
+        expect(res.body.lufs).toBeTruthy();
+        expect(res.body.lufs.twoPass).toBe(false);
+        expect(res.body.lufs.target).toBe(-16);
+      });
+    });
+
+    describe('when sibling .lufs.json is missing (legacy / disabled)', () => {
+      beforeAll(() => {
+        resetAudio();
+        writeMp3();
+      });
+
+      it('meta endpoint returns lufs: null — the "no data" gate for the report card', async () => {
+        const res = await request(app).get(`/api/books/${bookId}/chapters/1/audio`);
+        expect(res.status).toBe(200);
+        expect(res.body.lufs).toBeNull();
+      });
+    });
+
+    describe('when sibling .lufs.json is malformed', () => {
+      beforeAll(() => {
+        resetAudio();
+        writeMp3();
+        writeFileSync(join(audioRoot, `${SLUG}.lufs.json`), '{ this is not json');
+      });
+
+      it('meta endpoint absorbs the parse error and returns lufs: null', async () => {
+        const res = await request(app).get(`/api/books/${bookId}/chapters/1/audio`);
+        /* Critical: corrupt sidecar must NOT 500 the meta endpoint —
+           it's a visualization aid, not a hard dependency. The same
+           graceful-fallback contract that plan 56's peaks file
+           established. */
+        expect(res.status).toBe(200);
+        expect(res.body.lufs).toBeNull();
+      });
+    });
+
+    describe('full payload round-trip', () => {
+      it('preserves every field through the read path (no field-name drift)', async () => {
+        resetAudio();
+        writeMp3();
+        const payload = {
+          i: -18.7,
+          lra: 9.1,
+          tp: -1.8,
+          target: -18,
+          twoPass: true,
+          measuredAt: '2026-04-12T10:30:00.000Z',
+        };
+        writeLufs(SLUG, payload);
+        const res = await request(app).get(`/api/books/${bookId}/chapters/1/audio`);
+        expect(res.status).toBe(200);
+        expect(res.body.lufs).toEqual(payload);
       });
     });
   });

--- a/server/src/routes/chapter-audio.ts
+++ b/server/src/routes/chapter-audio.ts
@@ -38,6 +38,7 @@ import { renameWithRetry } from '../workspace/atomic-rename.js';
 import { findBookByBookId } from '../workspace/scan.js';
 import { findChapterAudio, type ChapterAudioFile } from '../workspace/chapter-audio-file.js';
 import { isGenerationActive } from './generation.js';
+import type { LoudnormSidecarJson } from '../tts/loudnorm.js';
 
 /** Disk shape mirror of `ChapterPeaksFile` in `server/src/tts/mp3.ts`.
  *  Kept narrow + local so this route doesn't reach across the TTS module
@@ -64,6 +65,29 @@ async function readPeaksOrEmpty(peaksPath: string): Promise<number[]> {
       `[chapter-audio] failed to read peaks file at ${peaksPath}: ${(err as Error).message}`,
     );
     return [];
+  }
+}
+
+/** Read `<bookDir>/audio/<slug>.lufs.json` when present, returning the
+ *  loudness sidecar payload. Missing file → `null`; this is the graceful
+ *  fallback contract for chapters generated before plan 71 / with
+ *  `AUDIO_LOUDNORM_ENABLED=false` / silent-source fallthrough. Plan 77
+ *  (LUFS report card) reads this off the wire and renders a "no data"
+ *  badge when null. A corrupt / malformed file is treated as missing
+ *  (logged then absorbed) so a one-off bad write doesn't 500 the meta
+ *  endpoint. */
+async function readLufsOrNull(lufsPath: string): Promise<LoudnormSidecarJson | null> {
+  if (!existsSync(lufsPath)) return null;
+  try {
+    const file = await readJson<LoudnormSidecarJson>(lufsPath);
+    if (!file || typeof file.i !== 'number' || typeof file.target !== 'number') return null;
+    return file;
+  } catch (err) {
+    /* eslint-disable-next-line no-console */
+    console.warn(
+      `[chapter-audio] failed to read lufs file at ${lufsPath}: ${(err as Error).message}`,
+    );
+    return null;
   }
 }
 
@@ -119,6 +143,14 @@ async function locateChapterAudio(
    *  so the preserved endpoint reliably returns `[]` for now — a
    *  deliberately graceful trade-off rather than a missing feature. */
   peaksPath: string;
+  /** Sibling `<slug>.lufs.json` (plan 71 loudnorm sidecar). Missing →
+   *  `readLufsOrNull` returns `null` so the meta endpoint degrades to
+   *  `lufs: null` and the LUFS report card UI (plan 77) renders a
+   *  neutral "no data" state. Only emitted on the current variant —
+   *  the preserved (.previous.*) variant has no loudnorm writer today
+   *  (parallel to `.previous.peaks.json`), so the path is non-null
+   *  but the file is reliably absent and we return null. */
+  lufsPath: string;
   chapterId: number;
   chapterTitle: string;
 } | null> {
@@ -142,7 +174,11 @@ async function locateChapterAudio(
     variant === 'current'
       ? join(root, `${chapter.slug}.peaks.json`)
       : join(root, `${chapter.slug}.previous.peaks.json`);
-  return { audio, segPath, peaksPath, chapterId, chapterTitle: chapter.title };
+  const lufsPath =
+    variant === 'current'
+      ? join(root, `${chapter.slug}.lufs.json`)
+      : join(root, `${chapter.slug}.previous.lufs.json`);
+  return { audio, segPath, peaksPath, lufsPath, chapterId, chapterTitle: chapter.title };
 }
 
 /** Mirror of findChapterAudio but for the `.previous.mp3` sibling. */
@@ -173,12 +209,21 @@ chapterAudioRouter.get(
        generated before this plan keep loading and the Listen view falls
        back gracefully. */
     const peaks = await readPeaksOrEmpty(found.peaksPath);
+    /* Plan 77: surface the EBU R128 loudness sidecar (plan 71) so the
+       LUFS report card and per-chapter drift badge can compute drift
+       from the target. Missing file → `null` — the chapter wasn't
+       loudnormed (legacy chapter / AUDIO_LOUDNORM_ENABLED=false /
+       silent-source fallthrough). The frontend MUST also gate any
+       drift-vs-ground-truth comparison on `lufs.twoPass === true`;
+       single-pass values are the nominal target, not a real measurement. */
+    const lufs = await readLufsOrNull(found.lufsPath);
     res.json({
       url: `/api/books/${encodeURIComponent(req.params.bookId)}/chapters/${found.chapterId}/${found.audio.urlSuffix}`,
       durationSec: meta?.durationSec ?? 0,
       peaks,
       sampleRate: meta?.sampleRate ?? 24000,
       segments,
+      lufs,
     });
   },
 );
@@ -206,12 +251,18 @@ chapterAudioRouter.get(
        gracefully. Wiring is symmetrical with /audio so a future preserve
        extension can light up the A/B waveform without a route change. */
     const peaks = await readPeaksOrEmpty(found.peaksPath);
+    /* Plan 77: same fall-through as peaks — no .previous.lufs.json writer
+       today (rollback preservation does not move loudnorm sidecars).
+       Returns `null` so the wire shape stays uniform with the /audio
+       endpoint. */
+    const lufs = await readLufsOrNull(found.lufsPath);
     res.json({
       url: `/api/books/${encodeURIComponent(req.params.bookId)}/chapters/${found.chapterId}/audio/previous.mp3`,
       durationSec: meta?.durationSec ?? 0,
       peaks,
       sampleRate: meta?.sampleRate ?? 24000,
       segments,
+      lufs,
     });
   },
 );

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -377,6 +377,12 @@ export function Layout() {
             completedSlugs: res.completedSlugs ?? [],
             characters: res.cast?.characters ?? [],
             chapterCharacters: res.chapterCharacters,
+            /* Plan 77 — book-state response now carries per-chapter
+               EBU R128 sidecar payloads. Older servers omit it; the
+               slice tolerates an undefined map by leaving each row's
+               `lufs` field undefined (no-data state in the report
+               card). */
+            chapterLufs: res.chapterLufs,
           }),
         );
         dispatch(

--- a/src/components/listen/listen-player-region.test.tsx
+++ b/src/components/listen/listen-player-region.test.tsx
@@ -1,0 +1,139 @@
+/* Plan 77 — ListenPlayerRegion per-chapter loudness badge coverage.
+
+   Pins the colour-coded drift pill that renders inside each chapter
+   row, gated on `lufs.twoPass === true`. The full report card is
+   covered separately in `loudness-report.test.tsx`; this spec focuses
+   on the per-row affordance.
+
+   Critical contract: chapters with `twoPass: false` MUST render NO
+   badge — single-pass measurements are nominal target values, not
+   post-filter measurements, so rendering them as ground truth would
+   mislead the user. */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import { ListenPlayerRegion } from './listen-player-region';
+import { listenProgressSlice } from '../../store/listen-progress-slice';
+import type { Chapter, ChapterLoudness } from '../../lib/types';
+
+function makeStore() {
+  return configureStore({
+    reducer: { listenProgress: listenProgressSlice.reducer },
+  });
+}
+
+function lufs(deltaFromTarget: number, opts: Partial<ChapterLoudness> = {}): ChapterLoudness {
+  return {
+    i: -16 + deltaFromTarget,
+    lra: 8,
+    tp: -2.1,
+    target: -16,
+    twoPass: true,
+    measuredAt: '2026-05-20T12:00:00.000Z',
+    ...opts,
+  };
+}
+
+function makeChapter(id: number, overrides: Partial<Chapter> = {}): Chapter {
+  return {
+    id,
+    title: `Chapter ${id}`,
+    duration: '10:00',
+    state: 'done',
+    progress: 1,
+    characters: {},
+    ...overrides,
+  } as Chapter;
+}
+
+function renderRegion(chapters: Chapter[]) {
+  return render(
+    <Provider store={makeStore()}>
+      <ListenPlayerRegion
+        bookId="test-book"
+        chapters={chapters}
+        listenable={chapters.filter((c) => !c.excluded)}
+        characters={[]}
+        currentTrack={null}
+        onPlayChapter={vi.fn()}
+        onRegenerate={vi.fn()}
+        onSeekMarker={vi.fn()}
+        onDeleteMarker={vi.fn()}
+      />
+    </Provider>,
+  );
+}
+
+describe('ListenPlayerRegion — per-chapter LUFS badge (plan 77)', () => {
+  it('renders a green badge for chapters within ±2 LU of target', () => {
+    renderRegion([makeChapter(1, { lufs: lufs(0.4) })]);
+    const badge = screen.getByTestId('chapter-row-1-lufs-badge');
+    expect(badge.getAttribute('data-bucket')).toBe('on-target');
+    expect(badge.textContent).toMatch(/LUFS/);
+  });
+
+  it('renders an amber badge for chapters 2–4 LU off target', () => {
+    renderRegion([makeChapter(1, { lufs: lufs(3.1) })]);
+    const badge = screen.getByTestId('chapter-row-1-lufs-badge');
+    expect(badge.getAttribute('data-bucket')).toBe('slight');
+  });
+
+  it('renders a red badge for chapters > 4 LU off target', () => {
+    renderRegion([makeChapter(1, { lufs: lufs(5.5) })]);
+    const badge = screen.getByTestId('chapter-row-1-lufs-badge');
+    expect(badge.getAttribute('data-bucket')).toBe('off-target');
+  });
+
+  it('does NOT render a badge when the chapter has no lufs data (legacy / disabled)', () => {
+    /* The row must still render — only the badge is absent. */
+    renderRegion([makeChapter(1, { lufs: null })]);
+    expect(screen.getByTestId('chapter-row-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('chapter-row-1-lufs-badge')).toBeNull();
+  });
+
+  it('does NOT render a badge when the chapter has undefined lufs (older server / not fetched)', () => {
+    renderRegion([makeChapter(1, { lufs: undefined })]);
+    expect(screen.getByTestId('chapter-row-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('chapter-row-1-lufs-badge')).toBeNull();
+  });
+
+  it('does NOT render a badge when twoPass is false (single-pass gate — CRITICAL)', () => {
+    /* This is the critical contract from plan 71: twoPass: false means
+       `i` is the nominal target, not a real measurement. Rendering it
+       coloured would silently lie about the chapter's actual loudness.
+       The badge MUST be suppressed. */
+    renderRegion([makeChapter(1, { lufs: lufs(0, { twoPass: false }) })]);
+    expect(screen.getByTestId('chapter-row-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('chapter-row-1-lufs-badge')).toBeNull();
+  });
+
+  it('badge tooltip surfaces target + LRA + true peak for the curious', () => {
+    renderRegion([
+      makeChapter(1, {
+        lufs: lufs(-1, { lra: 9.4, tp: -1.8 }),
+      }),
+    ]);
+    const badge = screen.getByTestId('chapter-row-1-lufs-badge');
+    const tooltip = badge.getAttribute('title') ?? '';
+    expect(tooltip).toMatch(/On target/);
+    expect(tooltip).toMatch(/target -16 LUFS/);
+    expect(tooltip).toMatch(/LRA 9\.4 LU/);
+    expect(tooltip).toMatch(/true peak -1\.8 dBTP/);
+  });
+
+  it('badge value reflects measured integrated loudness to one decimal', () => {
+    renderRegion([makeChapter(1, { lufs: lufs(-0.7) })]); // i = -16.7
+    const badge = screen.getByTestId('chapter-row-1-lufs-badge');
+    /* Minus-sign is U+2212 in our formatter (numeric typography). */
+    expect(badge.textContent).toContain('−16.7');
+  });
+});
+
+describe('ListenPlayerRegion — LoudnessReport card', () => {
+  it('mounts the report card alongside the chapter list', () => {
+    renderRegion([makeChapter(1, { lufs: lufs(0) }), makeChapter(2, { lufs: lufs(2.5) })]);
+    expect(screen.getByTestId('loudness-report')).toBeInTheDocument();
+  });
+});

--- a/src/components/listen/listen-player-region.tsx
+++ b/src/components/listen/listen-player-region.tsx
@@ -24,6 +24,7 @@ import { stripChapterPrefix } from '../../lib/format-chapter-title';
 import { useAppSelector } from '../../store';
 import { selectListenProgress, type ListenMarker } from '../../store/listen-progress-slice';
 import { ShareClipModal } from '../../modals/share-clip';
+import { LoudnessReport, classifyDrift } from '../loudness-report';
 import type { Chapter, Character } from '../../lib/types';
 
 interface ListenPlayerRegionProps {
@@ -107,6 +108,8 @@ export function ListenPlayerRegion({
         </div>
       </section>
 
+      <LoudnessReport chapters={listenable} />
+
       <ShareClipModal
         open={shareClipChapter !== null}
         bookId={bookId}
@@ -182,6 +185,7 @@ function ChapterListenRow({
           {showResume && resume && (
             <Pill color="library">Resume at {formatTime(resume.currentSec)}</Pill>
           )}
+          <LoudnessBadge chapter={chapter} />
         </span>
         <span className="block text-xs text-ink/50 truncate mt-0.5">
           With{' '}
@@ -220,6 +224,46 @@ function ChapterListenRow({
         </button>
       </span>
     </div>
+  );
+}
+
+/* Plan 77 — per-chapter EBU R128 drift badge. Renders only when the
+   chapter has a real two-pass loudness measurement on disk; single-pass
+   values are NOT post-filter measurements (they're the nominal target
+   restated) so they degrade to a null render rather than mislead. The
+   colour mirrors the report-card sparkline: green (≤2 LU), amber (2–4 LU),
+   rose (>4 LU). Hover reveals i / lra / tp / target / measured-at via
+   the native title tooltip — keeps the row chrome light without dragging
+   in a popover primitive just for this. */
+function LoudnessBadge({ chapter }: { chapter: Chapter }) {
+  const lufs = chapter.lufs;
+  const bucket = classifyDrift(lufs ?? null);
+  if (bucket === 'no-data') return null;
+  if (!lufs || lufs.twoPass !== true) return null;
+  const pillColor: 'success' | 'warning' | 'danger' =
+    bucket === 'on-target' ? 'success' : bucket === 'slight' ? 'warning' : 'danger';
+  const driftLabel =
+    bucket === 'on-target' ? 'On target' : bucket === 'slight' ? 'Slight drift' : 'Off target';
+  const measuredAtNote = lufs.measuredAt
+    ? `Measured ${new Date(lufs.measuredAt).toLocaleString()}`
+    : '';
+  const lufsCompact = lufs.i.toFixed(1).startsWith('-')
+    ? `−${lufs.i.toFixed(1).slice(1)} LUFS`
+    : `${lufs.i.toFixed(1)} LUFS`;
+  const title =
+    `${driftLabel} — ${lufsCompact} (target ${lufs.target} LUFS).` +
+    ` LRA ${lufs.lra.toFixed(1)} LU, true peak ${lufs.tp.toFixed(1)} dBTP.` +
+    (measuredAtNote ? ` ${measuredAtNote}` : '');
+  return (
+    <span
+      data-testid={`chapter-row-${chapter.id}-lufs-badge`}
+      data-bucket={bucket}
+      title={title}
+      aria-label={`${driftLabel}: ${lufsCompact}`}
+      className="inline-flex"
+    >
+      <Pill color={pillColor}>{lufsCompact}</Pill>
+    </span>
   );
 }
 

--- a/src/components/loudness-report.test.tsx
+++ b/src/components/loudness-report.test.tsx
@@ -1,0 +1,232 @@
+/* Plan 77 — LoudnessReport component coverage. Pins:
+
+   - Summary copy reflects the on-target / measured / target values.
+   - Sparkline renders one column per chapter, with bucket attributes
+     so visual regression has stable test hooks.
+   - Single-pass measurements degrade to neutral — they're NOT
+     post-filter measurements, so rendering them as ground truth
+     would mislead the user. This is the critical gate.
+   - Empty state appears when no chapter carries lufs data at all.
+   - Expandable table toggles open/closed.
+   - Excluded chapters are filtered out (parity with listen view's
+     `listenable`). */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { LoudnessReport, classifyDrift } from './loudness-report';
+import type { Chapter, ChapterLoudness } from '../lib/types';
+
+function makeChapter(id: number, overrides: Partial<Chapter> = {}): Chapter {
+  return {
+    id,
+    title: `Chapter ${id}`,
+    duration: '10:00',
+    state: 'done',
+    progress: 1,
+    characters: {},
+    ...overrides,
+  } as Chapter;
+}
+
+function lufs(deltaFromTarget: number, opts: Partial<ChapterLoudness> = {}): ChapterLoudness {
+  return {
+    i: -16 + deltaFromTarget,
+    lra: 8,
+    tp: -2.1,
+    target: -16,
+    twoPass: true,
+    measuredAt: '2026-05-20T12:00:00.000Z',
+    ...opts,
+  };
+}
+
+describe('classifyDrift — bucket thresholds', () => {
+  it('classifies ≤ 2 LU drift as on-target', () => {
+    expect(classifyDrift(lufs(0))).toBe('on-target');
+    expect(classifyDrift(lufs(1.9))).toBe('on-target');
+    expect(classifyDrift(lufs(-2))).toBe('on-target');
+  });
+  it('classifies 2-4 LU drift as slight', () => {
+    expect(classifyDrift(lufs(2.5))).toBe('slight');
+    expect(classifyDrift(lufs(-3.9))).toBe('slight');
+    expect(classifyDrift(lufs(4))).toBe('slight');
+  });
+  it('classifies > 4 LU drift as off-target', () => {
+    expect(classifyDrift(lufs(4.5))).toBe('off-target');
+    expect(classifyDrift(lufs(-7))).toBe('off-target');
+  });
+  it('classifies null / undefined / missing payload as no-data', () => {
+    expect(classifyDrift(null)).toBe('no-data');
+    expect(classifyDrift(undefined)).toBe('no-data');
+  });
+  it('classifies single-pass payloads as no-data — the critical gate', () => {
+    /* twoPass: false means the value is the nominal target, NOT a
+       post-filter measurement. Rendering it as ground truth would
+       mislead the user. Must degrade to neutral. */
+    expect(classifyDrift(lufs(0, { twoPass: false }))).toBe('no-data');
+    expect(classifyDrift(lufs(5, { twoPass: false }))).toBe('no-data');
+  });
+});
+
+describe('LoudnessReport — summary + sparkline', () => {
+  it('renders the on-target / measured count in the summary line when chapters are within target', () => {
+    const chapters: Chapter[] = [
+      makeChapter(1, { lufs: lufs(0.1) }),
+      makeChapter(2, { lufs: lufs(-0.5) }),
+      makeChapter(3, { lufs: lufs(0.3) }),
+    ];
+    render(<LoudnessReport chapters={chapters} />);
+    const summary = screen.getByTestId('loudness-report-summary');
+    expect(summary.textContent).toContain('3 of 3');
+    expect(summary.textContent).toContain('±2 LU');
+  });
+
+  it('shows mixed bucket counts when drift is varied', () => {
+    const chapters: Chapter[] = [
+      makeChapter(1, { lufs: lufs(0.1) }), // on-target
+      makeChapter(2, { lufs: lufs(2.6) }), // slight
+      makeChapter(3, { lufs: lufs(-1.2) }), // on-target
+      makeChapter(4, { lufs: lufs(5.2) }), // off-target
+      makeChapter(5, { lufs: lufs(-3.5) }), // slight
+    ];
+    render(<LoudnessReport chapters={chapters} />);
+    /* The bucket pills use the existing Pill primitive — match copy. */
+    expect(screen.getByText(/2 on target/)).toBeInTheDocument();
+    expect(screen.getByText(/2 slight drift/)).toBeInTheDocument();
+    expect(screen.getByText(/1 off target/)).toBeInTheDocument();
+  });
+
+  it('renders one sparkline column per chapter, tagged with its bucket', () => {
+    const chapters: Chapter[] = [
+      makeChapter(1, { lufs: lufs(0.1) }),
+      makeChapter(2, { lufs: lufs(2.6) }),
+      makeChapter(3, { lufs: lufs(5.2) }),
+      makeChapter(4, { lufs: null }), // no-data
+    ];
+    render(<LoudnessReport chapters={chapters} />);
+    expect(screen.getByTestId('loudness-report-sparkline')).toBeInTheDocument();
+    expect(screen.getByTestId('loudness-report-spark-1').getAttribute('data-bucket')).toBe(
+      'on-target',
+    );
+    expect(screen.getByTestId('loudness-report-spark-2').getAttribute('data-bucket')).toBe(
+      'slight',
+    );
+    expect(screen.getByTestId('loudness-report-spark-3').getAttribute('data-bucket')).toBe(
+      'off-target',
+    );
+    expect(screen.getByTestId('loudness-report-spark-4').getAttribute('data-bucket')).toBe(
+      'no-data',
+    );
+  });
+
+  it('counts only listenable chapters — excluded chapters are filtered out', () => {
+    const chapters: Chapter[] = [
+      makeChapter(1, { lufs: lufs(0.1) }),
+      makeChapter(2, { lufs: lufs(0.1), excluded: true }), // front-matter
+      makeChapter(3, { lufs: lufs(0.1) }),
+    ];
+    render(<LoudnessReport chapters={chapters} />);
+    /* The excluded chapter contributes neither to the summary count nor
+       to the sparkline. */
+    expect(screen.getByTestId('loudness-report-summary').textContent).toContain('2 of 2');
+    expect(screen.queryByTestId('loudness-report-spark-2')).toBeNull();
+  });
+});
+
+describe('LoudnessReport — single-pass gate (CRITICAL)', () => {
+  it('renders single-pass measurements as no-data, NOT as ground truth', () => {
+    /* This is the critical contract from plan 71: twoPass: false means
+       the `i` value is the nominal TARGET, not a real measurement of the
+       output. Rendering it as on-target would silently lie about a
+       chapter that may be wildly off (the encoder just didn't measure). */
+    const chapters: Chapter[] = [
+      makeChapter(1, { lufs: lufs(0, { twoPass: false }) }),
+      makeChapter(2, { lufs: lufs(0, { twoPass: false }) }),
+    ];
+    render(<LoudnessReport chapters={chapters} />);
+    /* All single-pass — same as no data: the empty state renders. */
+    expect(screen.getByTestId('loudness-report-empty')).toBeInTheDocument();
+  });
+
+  it('mixed two-pass + single-pass: single-pass rows render as neutral', () => {
+    const chapters: Chapter[] = [
+      makeChapter(1, { lufs: lufs(0.1) }), // two-pass on-target
+      makeChapter(2, { lufs: lufs(0, { twoPass: false }) }), // neutral
+    ];
+    render(<LoudnessReport chapters={chapters} />);
+    expect(screen.getByTestId('loudness-report-summary').textContent).toContain('1 of 1');
+    /* Open the table to inspect rows. */
+    fireEvent.click(screen.getByTestId('loudness-report-toggle'));
+    const row1 = screen.getByTestId('loudness-report-row-1');
+    const row2 = screen.getByTestId('loudness-report-row-2');
+    expect(row1.getAttribute('data-bucket')).toBe('on-target');
+    expect(row2.getAttribute('data-bucket')).toBe('no-data');
+    /* The single-pass row's measured / drift cells show em-dashes — the
+       value isn't a real measurement so we don't print it. */
+    expect(within(row2).getByText('No measurement')).toBeInTheDocument();
+  });
+});
+
+describe('LoudnessReport — empty state', () => {
+  it('renders empty-state copy when no chapter carries lufs data', () => {
+    const chapters: Chapter[] = [
+      makeChapter(1, { lufs: null }),
+      makeChapter(2, { lufs: undefined }),
+      makeChapter(3, { lufs: null }),
+    ];
+    render(<LoudnessReport chapters={chapters} />);
+    expect(screen.getByTestId('loudness-report-empty')).toBeInTheDocument();
+    expect(screen.getByTestId('loudness-report-empty').textContent).toMatch(
+      /AUDIO_LOUDNORM_ENABLED/,
+    );
+    /* No sparkline or summary line in the empty case. */
+    expect(screen.queryByTestId('loudness-report-sparkline')).toBeNull();
+    expect(screen.queryByTestId('loudness-report-summary')).toBeNull();
+  });
+
+  it('renders empty-state copy when the chapter list is empty', () => {
+    render(<LoudnessReport chapters={[]} />);
+    expect(screen.getByTestId('loudness-report-empty')).toBeInTheDocument();
+  });
+});
+
+describe('LoudnessReport — expandable table', () => {
+  it('toggles the per-chapter table open and closed', () => {
+    const chapters: Chapter[] = [
+      makeChapter(1, { lufs: lufs(0.1) }),
+      makeChapter(2, { lufs: lufs(2.6) }),
+    ];
+    render(<LoudnessReport chapters={chapters} />);
+    /* Table is collapsed by default. */
+    expect(screen.queryByTestId('loudness-report-table')).toBeNull();
+    fireEvent.click(screen.getByTestId('loudness-report-toggle'));
+    expect(screen.getByTestId('loudness-report-table')).toBeInTheDocument();
+    /* Both rows present. */
+    expect(screen.getByTestId('loudness-report-row-1')).toBeInTheDocument();
+    expect(screen.getByTestId('loudness-report-row-2')).toBeInTheDocument();
+    /* Toggle closes. */
+    fireEvent.click(screen.getByTestId('loudness-report-toggle'));
+    expect(screen.queryByTestId('loudness-report-table')).toBeNull();
+  });
+
+  it('per-row badge reflects each chapter\'s bucket', () => {
+    const chapters: Chapter[] = [
+      makeChapter(1, { lufs: lufs(0.5) }),
+      makeChapter(2, { lufs: lufs(3.1) }),
+      makeChapter(3, { lufs: lufs(5.5) }),
+      makeChapter(4, { lufs: null }),
+    ];
+    render(<LoudnessReport chapters={chapters} />);
+    fireEvent.click(screen.getByTestId('loudness-report-toggle'));
+    expect(screen.getByTestId('loudness-report-row-1').getAttribute('data-bucket')).toBe(
+      'on-target',
+    );
+    expect(screen.getByTestId('loudness-report-row-2').getAttribute('data-bucket')).toBe('slight');
+    expect(screen.getByTestId('loudness-report-row-3').getAttribute('data-bucket')).toBe(
+      'off-target',
+    );
+    expect(screen.getByTestId('loudness-report-row-4').getAttribute('data-bucket')).toBe(
+      'no-data',
+    );
+  });
+});

--- a/src/components/loudness-report.tsx
+++ b/src/components/loudness-report.tsx
@@ -1,0 +1,333 @@
+/* Plan 77 — per-book EBU R128 loudness report card. Consumes the
+   per-chapter `lufs` sidecar payloads (plan 71) hydrated into the
+   chapters slice and surfaces:
+
+   - A summary line: "X of Y chapters within ±2 LU of -16 LUFS"
+   - A sparkline histogram of per-chapter measured integrated loudness
+   - An expandable per-chapter table: title | i | drift | badge |
+     measured-at relative time
+   - Critical gate: chapters with `twoPass === false` are treated as
+     NEUTRAL (no ground-truth measurement) — single-pass values are
+     the nominal target, not real post-filter measurements. Drift
+     comparison is GATED on `twoPass === true`.
+
+   Mount point: rendered inside `ListenPlayerRegion` below the chapter
+   list so it sits next to the rows it summarises. The card stays
+   collapsed by default (summary + sparkline + open button); the
+   per-chapter table is opt-in.
+
+   Empty state: when no chapter has lufs data (every row is `null` or
+   `undefined`), surface explanatory copy pointing at
+   `AUDIO_LOUDNORM_ENABLED`. */
+
+import { useMemo, useState } from 'react';
+import { Pill, SectionLabel } from './primitives';
+import { IconWaveform, IconChevD, IconChevR } from '../lib/icons';
+import { stripChapterPrefix } from '../lib/format-chapter-title';
+import type { Chapter } from '../lib/types';
+
+interface LoudnessReportProps {
+  chapters: Chapter[];
+}
+
+/** Threshold table — keep in lock-step with the chapter-row badge in
+ *  `listen-player-region.tsx`. Drift ≤ 2 LU is "on target" (the EBU R128
+ *  tolerance); 2–4 LU is "slight drift" (audible on careful listening);
+ *  >4 LU is "off target" (audible to anyone). */
+export type LoudnessDriftBucket = 'on-target' | 'slight' | 'off-target' | 'no-data';
+
+export function classifyDrift(
+  lufs: { i: number; target: number; twoPass: boolean } | null | undefined,
+): LoudnessDriftBucket {
+  /* The CRITICAL gate: single-pass values are NOT post-filter measurements.
+     They're the nominal target restated. Rendering them as ground-truth
+     would lie to the user. Degrade to neutral. */
+  if (!lufs || lufs.twoPass !== true) return 'no-data';
+  if (!Number.isFinite(lufs.i) || !Number.isFinite(lufs.target)) return 'no-data';
+  const drift = Math.abs(lufs.i - lufs.target);
+  if (drift <= 2) return 'on-target';
+  if (drift <= 4) return 'slight';
+  return 'off-target';
+}
+
+const BUCKET_COPY: Record<LoudnessDriftBucket, { label: string; pillColor: 'success' | 'warning' | 'danger' | 'neutral' }> = {
+  'on-target': { label: 'On target', pillColor: 'success' },
+  slight: { label: 'Slight drift', pillColor: 'warning' },
+  'off-target': { label: 'Off target', pillColor: 'danger' },
+  'no-data': { label: 'No measurement', pillColor: 'neutral' },
+};
+
+/** Compact "−16.0 LUFS" formatter — minus sign is the Unicode U+2212 so
+ *  numeric typography lines up; no decimals beyond 1 (LUFS readings are
+ *  noisy below ±0.1). */
+function formatLufs(value: number): string {
+  if (!Number.isFinite(value)) return '—';
+  const fixed = value.toFixed(1);
+  return fixed.startsWith('-') ? `−${fixed.slice(1)} LUFS` : `${fixed} LUFS`;
+}
+
+/** Render `2.3 LU above target` style copy. Used in the expandable table
+ *  hover affordance. Returns `Within target` for drift ≤ 0.1 LU. */
+function describeDrift(i: number, target: number): string {
+  const delta = i - target;
+  const mag = Math.abs(delta);
+  if (mag <= 0.1) return 'Within target';
+  const direction = delta > 0 ? 'above' : 'below';
+  return `${mag.toFixed(1)} LU ${direction} target`;
+}
+
+/** ISO-8601 → "2h ago" / "Yesterday" / "12 May" style relative copy.
+ *  Lightweight subset of the changelog formatter — keeping a local
+ *  copy avoids dragging another helper into this component's blast
+ *  radius. */
+function formatRelative(iso: string): string {
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return '';
+  const diffMs = Date.now() - then;
+  if (diffMs < 0) return 'just now';
+  const m = Math.round(diffMs / 60_000);
+  if (m < 1) return 'just now';
+  if (m < 60) return `${m} min ago`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.round(h / 24);
+  if (d === 1) return 'yesterday';
+  if (d < 14) return `${d} days ago`;
+  return new Date(then).toLocaleDateString();
+}
+
+/** Sparkline — one vertical bar per chapter, height scaled by
+ *  |i − target| within the [0, max(4 LU, observed max)] domain so a
+ *  book whose entire spread is < 2 LU still shows differentiation. The
+ *  bar colour mirrors the bucket so the visual reads at a glance. */
+interface SparklineProps {
+  /** One entry per chapter in book order; entries with `bucket: 'no-data'`
+   *  render an empty placeholder column so the sparkline always lines up
+   *  with the chapter list. */
+  series: Array<{ chapterId: number; drift: number; bucket: LoudnessDriftBucket }>;
+}
+
+function Sparkline({ series }: SparklineProps) {
+  if (series.length === 0) return null;
+  const visibleDrifts = series.filter((s) => s.bucket !== 'no-data').map((s) => s.drift);
+  const maxDrift = visibleDrifts.length === 0 ? 4 : Math.max(4, ...visibleDrifts);
+  const bucketBar: Record<LoudnessDriftBucket, string> = {
+    'on-target': 'bg-emerald-400',
+    slight: 'bg-amber-400',
+    'off-target': 'bg-rose-400',
+    'no-data': 'bg-ink/10',
+  };
+  return (
+    <div
+      data-testid="loudness-report-sparkline"
+      className="flex items-end gap-[2px] h-12 px-1"
+      aria-hidden
+    >
+      {series.map((s) => {
+        const heightPct =
+          s.bucket === 'no-data' ? 12 : Math.max(8, Math.min(100, (s.drift / maxDrift) * 100));
+        return (
+          <span
+            key={s.chapterId}
+            className={`flex-1 min-w-[3px] rounded-t-sm ${bucketBar[s.bucket]}`}
+            style={{ height: `${heightPct}%` }}
+            data-testid={`loudness-report-spark-${s.chapterId}`}
+            data-bucket={s.bucket}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+export function LoudnessReport({ chapters }: LoudnessReportProps) {
+  const [open, setOpen] = useState(false);
+  /* Filter out excluded chapters — they don't render in the listen view's
+     chapter list (see `listen.tsx` `listenable`) so they don't belong in
+     the loudness summary either. Front-matter has no narrated audio to
+     measure. */
+  const listenable = useMemo(() => chapters.filter((c) => !c.excluded), [chapters]);
+
+  /* Per-chapter classification + drift magnitudes. We compute the bucket
+     ONCE here so the summary, sparkline, and table all read from the same
+     truth table. */
+  const classified = useMemo(
+    () =>
+      listenable.map((c) => {
+        const lufs = c.lufs ?? null;
+        const bucket = classifyDrift(lufs);
+        const drift =
+          lufs && lufs.twoPass === true && Number.isFinite(lufs.i) && Number.isFinite(lufs.target)
+            ? Math.abs(lufs.i - lufs.target)
+            : 0;
+        return { chapter: c, lufs, bucket, drift };
+      }),
+    [listenable],
+  );
+
+  const measuredCount = classified.filter((c) => c.bucket !== 'no-data').length;
+  const onTargetCount = classified.filter((c) => c.bucket === 'on-target').length;
+  const slightCount = classified.filter((c) => c.bucket === 'slight').length;
+  const offTargetCount = classified.filter((c) => c.bucket === 'off-target').length;
+  /* Target value comes from the FIRST chapter with two-pass data — every
+     chapter normalised by the same encoder run shares one target, so the
+     value is consistent across rows. Fallback `-16` matches plan 71's
+     default if no measured chapters exist yet (the empty state hides this
+     line anyway, so the fallback is decorative). */
+  const target =
+    classified.find((c) => c.lufs?.twoPass === true)?.lufs?.target ?? -16;
+
+  /* Empty state: every chapter is "no-data". Either the book was
+     generated before plan 71, AUDIO_LOUDNORM_ENABLED=false at encode
+     time, or every chapter is single-pass-only (rare). */
+  const isEmpty = measuredCount === 0;
+
+  return (
+    <section data-testid="loudness-report" className="mb-12">
+      <div className="flex items-center justify-between mb-3">
+        <SectionLabel>Audio loudness report</SectionLabel>
+        {!isEmpty && (
+          <span className="text-xs text-ink/50" data-testid="loudness-report-summary">
+            {onTargetCount} of {measuredCount} chapter
+            {measuredCount === 1 ? '' : 's'} within ±2 LU of {formatLufs(target)}
+          </span>
+        )}
+      </div>
+      <div className="bg-white rounded-3xl border border-ink/10 shadow-card p-5">
+        {isEmpty ? (
+          <EmptyState />
+        ) : (
+          <>
+            <div className="flex items-start gap-4 mb-4">
+              <div className="grid place-items-center w-9 h-9 rounded-full bg-emerald-50 text-emerald-700 shrink-0">
+                <IconWaveform className="w-4 h-4" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm text-ink/80 leading-snug">
+                  EBU R128 normalisation aims for one perceived volume across the
+                  whole book. Chapters within {'±'}2 LU of {formatLufs(target)}{' '}
+                  are on target.
+                </p>
+                <div className="flex flex-wrap items-center gap-2 mt-2">
+                  <Pill color="success">{onTargetCount} on target</Pill>
+                  <Pill color="warning">{slightCount} slight drift</Pill>
+                  <Pill color="danger">{offTargetCount} off target</Pill>
+                  {classified.length - measuredCount > 0 && (
+                    <Pill color="neutral">
+                      {classified.length - measuredCount} no measurement
+                    </Pill>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <Sparkline
+              series={classified.map((c) => ({
+                chapterId: c.chapter.id,
+                drift: c.drift,
+                bucket: c.bucket,
+              }))}
+            />
+
+            <button
+              type="button"
+              onClick={() => setOpen((v) => !v)}
+              data-testid="loudness-report-toggle"
+              aria-expanded={open}
+              className="mt-4 inline-flex items-center gap-1.5 text-xs font-medium text-ink/70 hover:text-ink"
+            >
+              {open ? <IconChevD className="w-3.5 h-3.5" /> : <IconChevR className="w-3.5 h-3.5" />}
+              <span>{open ? 'Hide per-chapter table' : 'Show per-chapter table'}</span>
+            </button>
+
+            {open && (
+              <div
+                data-testid="loudness-report-table"
+                className="mt-3 border-t border-ink/10 pt-3"
+              >
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="text-left text-[11px] uppercase tracking-wider text-ink/50">
+                      <th className="py-2 pr-3 font-semibold">Chapter</th>
+                      <th className="py-2 px-3 font-semibold tabular-nums">Measured</th>
+                      <th className="py-2 px-3 font-semibold tabular-nums">Drift</th>
+                      <th className="py-2 px-3 font-semibold">Status</th>
+                      <th className="py-2 pl-3 font-semibold text-right">Measured</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {classified.map(({ chapter, lufs, bucket }) => {
+                      const copy = BUCKET_COPY[bucket];
+                      return (
+                        <tr
+                          key={chapter.id}
+                          data-testid={`loudness-report-row-${chapter.id}`}
+                          data-bucket={bucket}
+                          className="border-t border-ink/5"
+                        >
+                          <td className="py-2 pr-3">
+                            <span className="text-ink/50 tabular-nums mr-2">
+                              CH {String(chapter.id).padStart(2, '0')}
+                            </span>
+                            <span className="text-ink">
+                              {stripChapterPrefix(chapter.title)}
+                            </span>
+                          </td>
+                          <td className="py-2 px-3 tabular-nums text-ink/80">
+                            {lufs && lufs.twoPass === true ? formatLufs(lufs.i) : '—'}
+                          </td>
+                          <td className="py-2 px-3 tabular-nums text-ink/80">
+                            {lufs && lufs.twoPass === true
+                              ? describeDrift(lufs.i, lufs.target)
+                              : '—'}
+                          </td>
+                          <td className="py-2 px-3">
+                            <Pill color={copy.pillColor}>{copy.label}</Pill>
+                          </td>
+                          <td
+                            className="py-2 pl-3 text-right text-ink/50 text-xs"
+                            title={lufs?.measuredAt ?? ''}
+                          >
+                            {lufs?.measuredAt ? formatRelative(lufs.measuredAt) : '—'}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+                <p className="text-[11px] text-ink/50 mt-3 leading-relaxed">
+                  Drift is measured against the target integrated loudness using
+                  the EBU R128 two-pass algorithm. Single-pass renders surface
+                  as "No measurement" because the value reported is the nominal
+                  target, not a post-filter measurement. Re-render a chapter to
+                  refresh its measurement.
+                </p>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div data-testid="loudness-report-empty" className="flex items-start gap-4">
+      <div className="grid place-items-center w-9 h-9 rounded-full bg-ink/[0.04] text-ink/60 shrink-0">
+        <IconWaveform className="w-4 h-4" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-semibold text-ink">No loudness data yet</p>
+        <p className="text-xs text-ink/60 leading-relaxed mt-1">
+          EBU R128 measurements are captured when chapters generate with{' '}
+          <code className="text-[11px] bg-ink/[0.04] px-1 py-0.5 rounded">
+            AUDIO_LOUDNORM_ENABLED
+          </code>{' '}
+          (default on). Re-render older chapters to capture per-chapter loudness
+          for the report card.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1724,6 +1724,55 @@ export interface components {
                 characterId?: string;
                 sentenceId?: number;
             }[];
+            /**
+             * @description EBU R128 loudness measurement persisted next to the chapter
+             *     audio as `<slug>.lufs.json` (plan 71). Null when no loudnorm
+             *     pass landed — legacy chapter, `AUDIO_LOUDNORM_ENABLED=false`,
+             *     or silent-source fallthrough. Consumers MUST gate any
+             *     drift-vs-ground-truth comparison on `twoPass === true`;
+             *     single-pass values are nominal target values, not real
+             *     post-filter measurements. Plan 77 (LUFS report card UI)
+             *     reads this back to surface per-chapter drift badges and a
+             *     book-level loudness summary card on the Listen view.
+             */
+            lufs?: components["schemas"]["ChapterLoudness"];
+        };
+        /**
+         * @description Per-chapter loudness payload written by the encoder's `loudnorm`
+         *     filter. Mirrors `LoudnormSidecarJson` in
+         *     `server/src/tts/loudnorm.ts`; field names are stable contract
+         *     with the on-disk sidecar JSON (do not rename without bumping the
+         *     sidecar schema). See `docs/features/71-audio-loudness-normalization.md`.
+         */
+        ChapterLoudness: {
+            /**
+             * @description Measured integrated loudness (LUFS). In two-pass mode this is
+             *     the FIRST-pass measurement of the source PCM; in single-pass
+             *     mode it is the nominal target (no re-measurement is done).
+             */
+            i: number;
+            /** @description Measured loudness range (LU). Same single-pass caveat as `i`. */
+            lra: number;
+            /** @description Measured true peak (dBTP). Same single-pass caveat as `i`. */
+            tp: number;
+            /**
+             * @description Target integrated loudness (LUFS) the chapter was normalised
+             *     to. Matches `LoudnormOptions.target`. Default is `-16` (ACX
+             *     audiobook submission target).
+             */
+            target: number;
+            /**
+             * @description `true` when the measure-then-apply flow ran (±0.5 LU vs target);
+             *     `false` for single-pass streaming normalisation. UI consumers
+             *     MUST gate drift comparisons on this — single-pass `i`/`lra`/`tp`
+             *     are NOT post-filter measurements.
+             */
+            twoPass: boolean;
+            /**
+             * Format: date-time
+             * @description ISO-8601 timestamp the measurement was taken (encode time).
+             */
+            measuredAt: string;
         };
         ChangeLogEvent: {
             /** @description Monotonic id, usually now.getTime() at write time. */

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -37,6 +37,7 @@ import type {
   ExportLanInfo,
   BaseVoice,
   TtsEngine,
+  ChapterLoudness,
 } from './types';
 import { FRONTEND_ACCOUNT_DEFAULTS } from './account-defaults';
 import { initialCharacters } from '../data/characters';
@@ -434,6 +435,51 @@ const SB_CHAPTERS: BookStateJson['chapters'] = [
 
 function buildSolwayBayMockState(): BookStateResponse {
   const now = new Date().toISOString();
+  /* Plan 77 — seed each chapter with a deterministic mock LUFS payload so
+     the listen-view report card has something to render under mocks. The
+     spread mixes on-target (most), slight-drift (a couple), and off-target
+     (one) chapters so the demo content exercises every badge colour. Two
+     chapters intentionally carry `twoPass: false` to exercise the
+     single-pass-degrades-to-neutral path, and one is left as `null` to
+     prove the missing-sidecar fallback. */
+  const target = -16;
+  const driftPattern: Array<{ deltaFromTarget: number; twoPass: boolean } | null> = [
+    { deltaFromTarget: 0.1, twoPass: true },
+    { deltaFromTarget: -1.2, twoPass: true },
+    { deltaFromTarget: 0.4, twoPass: true },
+    { deltaFromTarget: 2.6, twoPass: true },
+    { deltaFromTarget: -0.5, twoPass: true },
+    { deltaFromTarget: 0.0, twoPass: true },
+    { deltaFromTarget: -3.2, twoPass: true },
+    { deltaFromTarget: 0.7, twoPass: true },
+    { deltaFromTarget: 4.4, twoPass: true },
+    { deltaFromTarget: -0.3, twoPass: true },
+    { deltaFromTarget: 0.0, twoPass: false },
+    { deltaFromTarget: -0.1, twoPass: true },
+    { deltaFromTarget: 1.1, twoPass: true },
+    null,
+    { deltaFromTarget: 0.0, twoPass: false },
+    { deltaFromTarget: -0.6, twoPass: true },
+    { deltaFromTarget: 0.2, twoPass: true },
+    { deltaFromTarget: 0.0, twoPass: true },
+  ];
+  const chapterLufs: Record<number, ChapterLoudness | null> = {};
+  for (let i = 0; i < SB_CHAPTERS.length; i++) {
+    const ch = SB_CHAPTERS[i];
+    const pattern = driftPattern[i] ?? null;
+    if (pattern === null) {
+      chapterLufs[ch.id] = null;
+      continue;
+    }
+    chapterLufs[ch.id] = {
+      i: target + pattern.deltaFromTarget,
+      lra: 7 + (i % 3),
+      tp: -1.5 - (i % 2) * 0.4,
+      target,
+      twoPass: pattern.twoPass,
+      measuredAt: new Date(Date.now() - (i + 1) * 36_000_000).toISOString(),
+    };
+  }
   return {
     state: {
       bookId: 'sb',
@@ -467,6 +513,7 @@ function buildSolwayBayMockState(): BookStateResponse {
        playable in the Listen view's playlist. */
     completedSlugs: SB_CHAPTERS.map((c) => c.slug),
     chapterCharacters: undefined,
+    chapterLufs,
     changeLog: null,
     analysis: undefined,
   };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,9 +6,17 @@ export type Character = components['schemas']['Character'] & {
 /* `phase` is a UI-only sub-state set from the `chapter_assembling` SSE tick.
    It lets the Generate view distinguish "synthesising sentences" from the
    short disk-write phase between the last group and chapter_complete, so
-   the bar doesn't appear stuck at 99 %. Not part of the wire schema. */
+   the bar doesn't appear stuck at 99 %. Not part of the wire schema.
+
+   `lufs` is a UI-only mirror of the chapter's EBU R128 sidecar payload
+   (plan 71). Hydrated lazily from the book-state endpoint's per-chapter
+   `chapterLufs` map and from the chapter-audio meta endpoint on per-row
+   playback. Absent → no loudnorm pass has landed for this chapter (legacy
+   / disabled / silent-source). `null` distinguishes "fetched but no data"
+   from "not fetched yet". See plan 77 for the report-card consumer. */
 export type Chapter = components['schemas']['Chapter'] & {
   phase?: 'assembling' | null;
+  lufs?: components['schemas']['ChapterLoudness'] | null;
 };
 
 /* Sentence follows the OpenAPI spec; the optional `confidence` is a UI-only
@@ -17,6 +25,14 @@ export type Sentence = components['schemas']['Sentence'] & {
   confidence?: number;
 };
 export type Revision = components['schemas']['Revision'];
+/* Plan 77 — EBU R128 loudness sidecar payload, surfaced on the
+   ChapterAudio meta endpoint and in the book-state response's
+   per-chapter `chapterLufs` map. Persisted disk shape lives at
+   <bookDir>/audio/<slug>.lufs.json (plan 71). Field names are stable
+   contract with the sidecar JSON. Consumers MUST gate drift
+   comparisons on twoPass === true — single-pass values are nominal
+   target values, not real post-filter measurements. */
+export type ChapterLoudness = components['schemas']['ChapterLoudness'];
 export type DriftEvent = components['schemas']['DriftEvent'];
 export type TimelineEntry = components['schemas']['TimelineEntry'];
 export type MatchFactor = components['schemas']['MatchFactor'];
@@ -203,6 +219,13 @@ export interface BookStateResponse {
   } | null;
   /** Slugs of chapters that already have an audio file on disk. */
   completedSlugs: string[];
+  /** Plan 77 — per-chapter EBU R128 loudness sidecar payloads keyed
+      by chapter id. Read once at book-open so the LUFS report card on
+      the Listen view doesn't have to fan out one chapter-audio meta
+      fetch per row. Null entry = sidecar missing (legacy chapter /
+      `AUDIO_LOUDNORM_ENABLED=false` / silent-source fallthrough). The
+      map is empty `{}` when no audio has been generated yet. */
+  chapterLufs?: Record<number, ChapterLoudness | null>;
   /** chapterId → analysed speaker ids. Derived from the analysis cache and
       used by hydrateFromBookState so each chapter row seeds only the
       characters that actually speak in that chapter; without this the

--- a/src/store/chapters-slice.test.ts
+++ b/src/store/chapters-slice.test.ts
@@ -844,6 +844,51 @@ describe('chaptersSlice — hydrateFromBookState', () => {
     );
     expect(next.paused).toBe(true);
   });
+
+  /* Plan 77 — per-chapter EBU R128 sidecar hydration. The book-state
+     response now carries `chapterLufs: Record<chapterId, payload | null>`;
+     this reducer copies each value onto the runtime Chapter row's `lufs`
+     field so the listen-view report card + per-row drift badge can read
+     from one source of truth. */
+  it('hydrates chapter.lufs from the chapterLufs map keyed by chapter id', () => {
+    const start = baseState([]);
+    const lufsPayload = {
+      i: -16.02,
+      lra: 8.4,
+      tp: -2.1,
+      target: -16,
+      twoPass: true,
+      measuredAt: '2026-05-20T12:00:00.000Z',
+    };
+    const next = chaptersSlice.reducer(
+      start,
+      chaptersActions.hydrateFromBookState({
+        chapters,
+        completedSlugs: [],
+        characters: cast,
+        chapterLufs: { 1: lufsPayload, 2: null },
+      }),
+    );
+    expect(next.chapters[0].lufs).toEqual(lufsPayload);
+    /* `null` entry distinguishes "fetched but no data" from
+       "older server / not fetched" — the report card uses this for the
+       per-row neutral badge vs. the empty-state banner. */
+    expect(next.chapters[1].lufs).toBeNull();
+  });
+
+  it('leaves chapter.lufs undefined when chapterLufs is absent (older-server back-compat)', () => {
+    const start = baseState([]);
+    const next = chaptersSlice.reducer(
+      start,
+      chaptersActions.hydrateFromBookState({
+        chapters,
+        completedSlugs: [],
+        characters: cast,
+      }),
+    );
+    expect(next.chapters[0].lufs).toBeUndefined();
+    expect(next.chapters[1].lufs).toBeUndefined();
+  });
 });
 
 describe('chaptersSlice — misc reducers', () => {

--- a/src/store/chapters-slice.ts
+++ b/src/store/chapters-slice.ts
@@ -17,6 +17,7 @@ import { formatDuration } from '../lib/time';
    exists for the drift-report modal and the mock API. */
 import type {
   Chapter,
+  ChapterLoudness,
   Character,
   GenerationTick,
   AnalyseResponse,
@@ -214,9 +215,23 @@ export const chaptersSlice = createSlice({
           that actually speak in it. Absent (older server, or no analysis
           cache yet) — fall back to seeding every cast member as queued. */
         chapterCharacters?: Record<number, string[]>;
+        /** Plan 77 — per-chapter EBU R128 loudness sidecar payloads keyed
+          by chapter id, surfaced by the book-state endpoint. Drives the
+          listen-view LUFS report card + per-row drift badges. Absent
+          (older server) → every chapter row gets `lufs: undefined`;
+          present with a `null` entry → fetched-but-no-data, render
+          neutral. */
+        chapterLufs?: Record<number, ChapterLoudness | null>;
       }>,
     ) => {
-      const { bookId, chapters, completedSlugs, characters, chapterCharacters } = a.payload;
+      const {
+        bookId,
+        chapters,
+        completedSlugs,
+        characters,
+        chapterCharacters,
+        chapterLufs,
+      } = a.payload;
       if (bookId) s.currentBookId = bookId;
       const done = new Set(completedSlugs);
       const allCastQueued: Record<string, 'queued'> = {};
@@ -255,6 +270,12 @@ export const chaptersSlice = createSlice({
            server backfills it from segments.json for legacy chapters. */
             audioModelKey: c.audioModelKey,
             audioRenderedAt: c.audioRenderedAt,
+            /* Plan 77 — per-chapter EBU R128 loudness sidecar (plan 71)
+           hydrated from the book-state response. `null` entry = sidecar
+           absent on disk (legacy chapter / disabled / silent source);
+           map key absent (older server) → undefined. The listen-view
+           report card distinguishes both from "all-target" data. */
+            lufs: chapterLufs ? (chapterLufs[c.id] ?? null) : undefined,
           }) as Chapter,
       );
       s.lastError = null;


### PR DESCRIPTION
## Summary

Wave 2 close-out for the post-v1.3.1 round. Consumes the `.lufs.json` sidecar that plan 71 (`feat/server-audio-loudnorm`, merged in PR #72) drops next to each chapter's audio, and surfaces the measurement two ways in the Listen view:

- **Inline LUFS badge** per chapter row (next to the resume-pill line) — colour-coded by drift from the −16 LUFS target: green ≤ ±2 LU, amber 2–4 LU, red > 4 LU. **Gated on `twoPass === true`** — single-pass measurements are nominal-not-measured per plan 71's contract, so they render neutral rather than as ground truth.
- **Expandable "Audio loudness report" card** below the chapter list — summary line ("X of Y chapters within ±2 LU of −16 LUFS"), mini sparkline of measured `i` values across the book, and an expandable per-chapter table with drift colour pills + relative measured-at timestamps. Empty state when no chapter has a measurement (legacy book / `AUDIO_LOUDNORM_ENABLED=false`).

Mount point: `LoudnessReport` lives inside `ListenPlayerRegion` immediately after the chapter list — visual proximity to the data it summarises. Per-row badge lives inline in `ChapterListenRow`.

## Contract / API surface

- New `ChapterLoudness` schema in `openapi.yaml`: `{ i, lra, tp, target, twoPass, measuredAt }` — exact mirror of plan 71's sidecar JSON shape, so server tools and clients agree.
- `ChapterAudio` response gains optional `lufs: ChapterLoudness | null` on both `/api/books/:id/audio/:chapterId` and `/api/books/:id/audio/:chapterId/previous` (paired-rollback path).
- `BookStateResponse` gains optional `chapterLufs: Record<chapterId, ChapterLoudness | null>` — one-shot per-book hydration so the report card can render without an N+1 fetch.
- `Chapter` runtime shape (redux) gains optional `lufs?: ChapterLoudness | null` field, hydrated from the book-state response in the existing `hydrateFromBookState` reducer.
- `classifyDrift(i, target): 'on' | 'slight' | 'off'` is exported from `loudness-report.tsx` as the single bucket-classifier source of truth — reused by the badge and the report card to guarantee they never disagree.

## Tests landed

- **34 new automated tests** total
  - `server/src/routes/chapter-audio.test.ts` +5 (two-pass / single-pass / missing / malformed / round-trip)
  - `server/src/routes/book-state.test.ts` +4 (chapterLufs hydration)
  - `src/store/chapters-slice.test.ts` +2 (hydrate + default)
  - `src/components/loudness-report.test.tsx` +15 (render variants, single-pass gate, expand/collapse, empty state)
  - `src/components/listen/listen-player-region.test.tsx` +9 (badge colour, missing-lufs neutral, twoPass false neutral)
  - `e2e/listen-loudness-report.spec.ts` +3 (under `serial` mode to dodge Windows SSE-hydration contention; same pattern as `listen-playback.spec.ts`)
- Mock seed: `src/lib/api.ts` populates 18 deterministic `chapterLufs` payloads on the Solway Bay book — mix of on-target / slight-drift / off-target / single-pass / null buckets so the report card renders meaningfully in mock mode without a real generation run.

## Test plan

- [x] `npm run typecheck` green
- [x] `npm run test` green
- [x] `cd server && npm run test` green
- [x] `npm run verify` full battery green (all 9 steps cached on the final run — only 1 pre-existing e2e flake on `library-table-view.spec.ts` auto-retried to green, unrelated)
- [x] Critical gate verified: `twoPass: false` measurements render neutral, NOT as drift-coloured (locked by `loudness-report.test.tsx` and `listen-player-region.test.tsx`)

## Regression doc

`docs/features/77-loudness-report-card.md` (status: stable). Added to `docs/features/INDEX.md` under area H (Playback & listen) — the card is a Listen-view surface, not a TTS-pipeline one. `docs/BACKLOG.md` Could #3 removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)