### PR TITLE
feat(frontend): wave 3 books — responsive card grid

### DIFF
--- a/src/views/book-library.test.tsx
+++ b/src/views/book-library.test.tsx
@@ -1,7 +1,7 @@
 /* BookLibraryView — three-state render: skeleton / empty / populated.
    Pairs with docs/features/21-book-library.md (Loading affordance section). */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
 import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
@@ -487,6 +487,73 @@ describe('BookLibraryView — loading affordance', () => {
       expect(
         screen.getByRole('heading', { level: 2, name: 'Shannon Messenger' }),
       ).toBeInTheDocument();
+    });
+  });
+
+  /* Plan 81 (Wave 3, books) — phone viewports (<640px) must render the
+     card grid even when the user's persisted localStorage preference
+     is "table". Stub matchMedia so jsdom resolves the
+     (max-width: 639px) query to true, then assert the orchestrator
+     ignores the stored preference. The stored value is NOT cleared —
+     a desktop session in the same workspace must still resume "table"
+     when matchMedia goes false. */
+  describe('mobile-viewport override (plan 81)', () => {
+    let originalMatchMedia: typeof window.matchMedia | undefined;
+
+    beforeEach(() => {
+      try {
+        localStorage.removeItem('library.viewMode');
+      } catch {
+        /* swallow */
+      }
+      originalMatchMedia = window.matchMedia;
+    });
+
+    afterEach(() => {
+      if (originalMatchMedia) {
+        window.matchMedia = originalMatchMedia;
+      }
+    });
+
+    function stubMatchMedia(matches: boolean) {
+      /* Minimal MediaQueryList shim — only the surface
+         useIsMobileViewport reads. addEventListener / removeEventListener
+         take the modern path; addListener / removeListener stay as
+         no-ops so legacy fallback doesn't throw. */
+      window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })) as unknown as typeof window.matchMedia;
+    }
+
+    it('forces card view on phone (375×667) even when localStorage requests table', () => {
+      localStorage.setItem('library.viewMode', 'table');
+      stubMatchMedia(true);
+      renderView({ loaded: true, authors: [oneAuthor] });
+      /* Card branch: h2 with the author name renders. Table branch
+         renders <tr data-testid="library-table-row-…"> instead. */
+      expect(
+        screen.getByRole('heading', { level: 2, name: 'Shannon Messenger' }),
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId('library-table-row-b1')).not.toBeInTheDocument();
+      /* The stored preference is intact — desktop will resume table next session. */
+      expect(localStorage.getItem('library.viewMode')).toBe('table');
+    });
+
+    it('honours stored table preference on tablet/desktop (matchMedia false)', () => {
+      localStorage.setItem('library.viewMode', 'table');
+      stubMatchMedia(false);
+      renderView({ loaded: true, authors: [oneAuthor] });
+      expect(screen.getByTestId('library-table-row-b1')).toBeInTheDocument();
+      expect(
+        screen.queryByRole('heading', { level: 2, name: 'Shannon Messenger' }),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/views/book-library.tsx
+++ b/src/views/book-library.tsx
@@ -124,6 +124,16 @@ export function BookLibraryView({
   useEffect(() => {
     writeStoredViewMode(viewMode);
   }, [viewMode]);
+  /* Plan 81 (Wave 3, books) — phone viewports (<640px) can't fit the
+     wide multi-column table without horizontal scroll, and the user
+     research bar for v1 says "no horizontal overflow at 375×667". On
+     phone we force the card layout regardless of the persisted
+     viewMode preference, so a tablet/desktop user whose stored
+     preference is "table" still sees usable cards when they open the
+     same workspace from a phone. The stored preference itself stays
+     unchanged — when they go back to desktop, table re-appears. */
+  const isMobileViewport = useIsMobileViewport();
+  const effectiveViewMode: LibraryViewMode = isMobileViewport ? 'card' : viewMode;
   /* First word of the user's display name → "Welcome back, Mike". Falls back
      to "back" when the user hasn't set a name (keeps the heading grammatical). */
   const displayName = useAppSelector((s) => s.account.displayName);
@@ -232,7 +242,7 @@ export function BookLibraryView({
     loaded && authors.length > 0 && hasActiveSearchOrTag && matchedBookCount === 0;
 
   return (
-    <div className="max-w-[1400px] mx-auto px-6 py-10">
+    <div className="max-w-[1400px] mx-auto px-4 py-6 sm:px-6 sm:py-10">
       <LibraryChrome
         firstName={firstName}
         workspace={workspace}
@@ -253,7 +263,7 @@ export function BookLibraryView({
       />
       {showNoResults ? (
         <NoResults onClear={clearFilters} />
-      ) : viewMode === 'card' ? (
+      ) : effectiveViewMode === 'card' ? (
         <LibraryGrid
           loaded={loaded}
           isLibraryEmpty={authors.length === 0}
@@ -267,21 +277,54 @@ export function BookLibraryView({
           onStartNew={onStartNew}
         />
       ) : (
-        <LibraryTable
-          loaded={loaded}
-          isLibraryEmpty={authors.length === 0}
-          authors={filteredAuthors}
-          activeBookId={activeBookId}
-          onOpenBook={onOpenBook}
-          onDeleteBook={onDeleteBook}
-          onReparseBook={onReparseBook}
-          onEditBook={onEditBook}
-          onCoverChanged={onCoverChanged}
-          onStartNew={onStartNew}
-        />
+        /* Plan 81 (Wave 3, books) — wrap the dense table in an
+           overflow-x container so a narrow tablet (640–767px) that
+           still resolves to the table branch (matchMedia <640 only
+           forces card mode) keeps any horizontal overflow scoped to
+           the table itself, not the document body. Desktop ≥md
+           viewports never overflow this wrapper, so the visual is
+           a no-op there. */
+        <div className="overflow-x-auto -mx-4 px-4 sm:-mx-6 sm:px-6 md:mx-0 md:px-0">
+          <LibraryTable
+            loaded={loaded}
+            isLibraryEmpty={authors.length === 0}
+            authors={filteredAuthors}
+            activeBookId={activeBookId}
+            onOpenBook={onOpenBook}
+            onDeleteBook={onDeleteBook}
+            onReparseBook={onReparseBook}
+            onEditBook={onEditBook}
+            onCoverChanged={onCoverChanged}
+            onStartNew={onStartNew}
+          />
+        </div>
       )}
     </div>
   );
+}
+
+/* Subscribes to a `(max-width: 639px)` matchMedia query so the
+   orchestrator can flip viewMode → card on phone viewports without
+   stomping the user's persisted preference. SSR / jsdom-without-mock
+   safe — returns `false` until the first effect runs. */
+function useIsMobileViewport(): boolean {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mql = window.matchMedia('(max-width: 639px)');
+    setIsMobile(mql.matches);
+    const onChange = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    /* addEventListener is the modern API; the legacy addListener fallback
+       covers Safari < 14. Match the same pattern use-theme.ts uses. */
+    if (typeof mql.addEventListener === 'function') {
+      mql.addEventListener('change', onChange);
+      return () => mql.removeEventListener('change', onChange);
+    }
+    /* Legacy fallback — webkit Safari < 14. */
+    mql.addListener(onChange);
+    return () => mql.removeListener(onChange);
+  }, []);
+  return isMobile;
 }
 
 /* Distinct "no results" pane — fires when search/tags narrow the


### PR DESCRIPTION
## Summary

Plan 81 Wave 3 (books view) — phone viewports (<640px) now force the library into card mode regardless of the persisted card↔table preference. The dense multi-column table from plan 76 can't fit at 375×667 without horizontal overflow, so the orchestrator flips on matchMedia rather than rejecting the user's stored preference outright. When the same session moves back to a desktop viewport, the stored "table" value still wins. Outer page padding tightens to px-4 py-6 below the sm: breakpoint and stays px-6 py-10 above. The table branch additionally gets an overflow-x-auto wrapper so the 640–767 tablet range — where matchMedia <640 has not yet flipped to card mode — scopes any horizontal scroll to the table, not the document body.

## What changed

- **`src/views/book-library.tsx`**
  - New `useIsMobileViewport` hook driven by `window.matchMedia('(max-width: 639px)')`. Subscribes to the `change` event with the modern `addEventListener` API and falls back to legacy `addListener` for Safari < 14 — same shape as `src/lib/use-theme.ts`. SSR / jsdom-without-mock returns `false` (desktop layout) until the first effect, so existing render assertions don't shift.
  - `effectiveViewMode` derives from `isMobileViewport ? 'card' : viewMode`. The persisted `viewMode` state is untouched, so the user's preference round-trips across viewport changes.
  - Outer wrapper: `max-w-[1400px] mx-auto px-4 py-6 sm:px-6 sm:py-10` (was always `px-6 py-10`).
  - Table branch wrapped in `<div className="overflow-x-auto -mx-4 px-4 sm:-mx-6 sm:px-6 md:mx-0 md:px-0">` — neutralised at md: and up, no visual change on desktop.

- **`src/views/book-library.test.tsx`** — `mobile-viewport override (plan 81)` describe block, two cases:
  - Phone matchMedia stub (`matches: true`) + `localStorage.viewMode = 'table'` → card branch renders (`screen.getByRole('heading', { level: 2, name: 'Shannon Messenger' })`), table row absent, persisted preference still `'table'`.
  - matchMedia stub `matches: false` + same stored preference → table branch renders, card-branch h2 absent.
  - Test teardown restores the original `window.matchMedia` so the stubbing doesn't leak across the file's other 27 specs.

## Scope discipline

Only edits `src/views/book-library.tsx` + paired test. Sub-components (`library-chrome.tsx`, `library-grid.tsx`, `library-table.tsx`) are unchanged — their per-component responsive deltas land via sibling agents on the integration branch. No top-bar / mini-player edits (Wave 2 PR #83), no Playwright project edits (Wave 1 PR #82).

The card grid columns themselves (`grid-cols-1 md:grid-cols-2 lg:grid-cols-3`) already live in `library-grid.tsx` and were not touched in this PR — they already cover the spec's "1 col phone / 2 col tablet / 3+ col desktop" requirement.

## Plan reference

`docs/features/81-mobile-tablet-support.md` (lives on `docs/docs-mobile-tablet-round-0` / PR #81 — not yet merged to main, so not edited here; the plan's Wave 3 test-coverage row matches the assertions landed in `book-library.test.tsx`).

## Test plan

- [x] `npx vitest run src/views/book-library.test.tsx` — 29/29 green (27 existing + 2 new mobile-viewport cases)
- [x] `npm run verify` — full battery green (lint + typecheck + test:hooks + test + test:server + test:scripts + test:sidecar + test:e2e + build). One flaky e2e on `listen-playback` auto-retried and passed, unrelated to this scope (no listen-view code touched).
- [ ] Manual: open the library at 375×667 in Chrome devtools mobile emulator — expect single-column cards, no horizontal scroll on the body. Toggle to a desktop viewport, confirm the stored "table" preference re-applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)