### PR TITLE
feat(frontend): wave 3 confirm-cast — fluid cards

### DIFF
--- a/src/views/confirm-cast.test.tsx
+++ b/src/views/confirm-cast.test.tsx
@@ -479,3 +479,70 @@ describe('ConfirmCastView — bulk apply pill', () => {
     expect(screen.queryByRole('button', { name: /Apply all .* match/ })).toBeNull();
   });
 });
+
+/* Plan 81 wave 3 — phone (375 px) + tablet (834 px) responsive layout.
+   jsdom doesn't actually apply CSS so we can't measure pixel widths; what
+   we can pin is the responsive class contract — the decision-tile panel
+   must declare BOTH a fluid mobile width (`w-full`) AND the desktop
+   `sm:w-[340px]` fallback, AND span both grid columns on phone so it
+   stacks below the avatar+info row instead of overflowing a 375 px
+   viewport. The grid row template itself must drop the third
+   (decision-tile) column on phone (`grid-cols-[auto_1fr] sm:grid-cols-[auto_1fr_auto]`).
+   The accompanying Playwright spec (Wave 5) is the layout authority;
+   these checks lock the class contract so an accidental revert
+   (e.g. someone re-adds `w-[340px]` without the `w-full sm:` prefix)
+   breaks here in pre-commit instead of slipping to e2e. */
+describe('ConfirmCastView — mobile + tablet layout (plan 81 wave 3)', () => {
+  it('decision-tile panel for a matched character is fluid on phone and 340 px on tablet+', () => {
+    renderView();
+    /* The matched-character panel hosts both DecisionTiles in a grid. */
+    const reuseTile = screen.getByText('From Book One').closest('button')!;
+    const panel = reuseTile.parentElement!;
+    expect(panel.className).toMatch(/\bw-full\b/);
+    expect(panel.className).toMatch(/(^|\s)sm:w-\[340px\](\s|$)/);
+    /* Spans both grid columns on phone, returns to single column on tablet+. */
+    expect(panel.className).toMatch(/\bcol-span-2\b/);
+    expect(panel.className).toMatch(/\bsm:col-span-1\b/);
+  });
+
+  it('decision-tile panel for an unmatched character is fluid on phone and 340 px on tablet+', () => {
+    renderView();
+    /* Sophie has no matchedFrom — the single readonly Generated tile is wrapped
+       in a panel div whose responsive shape mirrors the matched case. */
+    const generatedTile = screen.getByText('Generated').closest('button')!;
+    const panel = generatedTile.parentElement!;
+    expect(panel.className).toMatch(/\bw-full\b/);
+    expect(panel.className).toMatch(/(^|\s)sm:w-\[340px\](\s|$)/);
+    expect(panel.className).toMatch(/\bcol-span-2\b/);
+    expect(panel.className).toMatch(/\bsm:col-span-1\b/);
+  });
+
+  it('card grid drops the decision-tile column on phone and restores it on tablet+', () => {
+    renderView();
+    /* The avatar+info+tiles grid lives one level inside the article. */
+    const article = screen.getByRole('heading', { name: 'Sophie' }).closest('article')!;
+    const grid = article.querySelector('.grid')!;
+    expect(grid.className).toMatch(/grid-cols-\[auto_1fr\]/);
+    expect(grid.className).toMatch(/sm:grid-cols-\[auto_1fr_auto\]/);
+  });
+
+  it('every DecisionTile button declares a ≥44 px minimum tap target (WCAG 2.5.5)', () => {
+    renderView();
+    const tiles = screen.getAllByRole('button').filter((b) => b.className.includes('rounded-2xl'));
+    /* Two tiles for Keefe (match + generate) + one readonly tile for Sophie. */
+    expect(tiles.length).toBeGreaterThanOrEqual(3);
+    for (const tile of tiles) {
+      expect(tile.className).toMatch(/(^|\s)min-h-\[44px\](\s|$)/);
+    }
+  });
+
+  it('confirm-action row stacks on phone (flex-col-reverse) and goes side-by-side on tablet+', () => {
+    renderView();
+    /* The "Confirm cast and review manuscript" PrimaryButton lives in
+       the row alongside the Re-analyse link. */
+    const confirmBtn = screen.getByRole('button', { name: /Confirm cast and review manuscript/ });
+    const actionRow = confirmBtn.parentElement!;
+    expect(actionRow.className).toMatch(/flex-col-reverse/);
+    expect(actionRow.className).toMatch(/sm:flex-row/);
+  });
+});

--- a/src/views/confirm-cast.tsx
+++ b/src/views/confirm-cast.tsx
@@ -150,10 +150,14 @@ export function ConfirmCastView({
   };
 
   return (
-    <div className="relative min-h-[calc(100vh-64px)] py-12 px-6">
+    /* Plan 81 wave 3 — phone (375 px) + tablet (834 px) layouts. Outer
+       padding shrinks on `<sm:` so the cast cards keep at least 327 px
+       of inner room on a 375 px viewport; vertical padding tightens too
+       so the header doesn't push the first card below the fold. */
+    <div className="relative min-h-[calc(100vh-64px)] py-6 sm:py-12 px-4 sm:px-6">
       <div className="absolute inset-0 bg-gradient-hero-wash opacity-40 pointer-events-none" />
       <div className="relative max-w-3xl mx-auto">
-        <div className="text-center mb-10">
+        <div className="text-center mb-6 sm:mb-10">
           <SectionLabel>Cast confirmation</SectionLabel>
           <div className="mt-5">
             <MixedHeading
@@ -162,7 +166,7 @@ export function ConfirmCastView({
               bold={title || 'The Northern Star'}
             />
           </div>
-          <p className="mt-4 text-ink/70 text-lg">
+          <p className="mt-4 text-ink/70 text-base sm:text-lg">
             <span className="font-semibold text-ink">{characters.length} speaking characters</span>{' '}
             detected ·{' '}
             <span className="font-semibold text-purple-deep">{matchedCount} matched</span> from your
@@ -200,8 +204,17 @@ export function ConfirmCastView({
           ))}
         </div>
 
-        <div className="mt-10 flex items-center justify-between gap-3">
-          <button onClick={onReanalyse} className="text-sm font-medium text-ink/60 hover:text-ink">
+        {/* Plan 81 wave 3 — on phone (<sm:) the long "Confirm cast and
+            review manuscript" button can't share a row with the Re-analyse
+            link without overflowing the 375 px viewport. Stack vertically
+            with the confirm action on top (primary intent first on touch);
+            tablet+ keeps the inline desktop layout. Re-analyse button
+            takes a min-h tap target on phone (WCAG 2.5.5). */}
+        <div className="mt-10 flex flex-col-reverse sm:flex-row sm:items-center sm:justify-between gap-3">
+          <button
+            onClick={onReanalyse}
+            className="text-sm font-medium text-ink/60 hover:text-ink min-h-[44px] sm:min-h-0 self-center sm:self-auto"
+          >
             Re-analyse manuscript
           </button>
           <PrimaryButton
@@ -275,7 +288,13 @@ function ConfirmCharacterCard({
       }}
       className={`bg-white rounded-3xl border shadow-card overflow-hidden transition-colors cursor-pointer hover:border-ink/25 focus:outline-none focus-visible:ring-2 focus-visible:ring-peach/60 ${matched ? 'border-purple-deep/15' : 'border-ink/10'}`}
     >
-      <div className="p-5 grid grid-cols-[auto_1fr_auto] items-start gap-5">
+      {/* Plan 81 wave 3 — phone (<sm:) stacks the decision-tile column
+          below the avatar+info row so the fixed 340 px decision panel
+          doesn't overflow a 375 px viewport. The decision panel spans
+          both grid columns on phone and returns to the right-hand
+          column on tablet+ (`sm:` ≥640 px). Inner padding shrinks on
+          phone to claw back another 8 px each side. */}
+      <div className="p-4 sm:p-5 grid grid-cols-[auto_1fr] sm:grid-cols-[auto_1fr_auto] items-start gap-3 sm:gap-5">
         <Avatar name={character.name} color={character.color as CharColor} size={48} />
         <div className="min-w-0">
           <div className="flex items-center gap-2 mb-1">
@@ -324,9 +343,14 @@ function ConfirmCharacterCard({
 
         {/* Decision tiles own their own clicks — stopPropagation so picking
             match/generate doesn't bubble up to the card-level
-            "open profile" handler. */}
+            "open profile" handler. Plan 81 wave 3 — on phone the panel
+            spans both grid columns (full width under the avatar+info row);
+            on tablet+ it returns to a fixed 340 px right-hand column. */}
         {matched ? (
-          <div className="grid grid-cols-2 gap-2 w-[340px]" onClick={(e) => e.stopPropagation()}>
+          <div
+            className="col-span-2 sm:col-span-1 grid grid-cols-2 gap-2 w-full sm:w-[340px]"
+            onClick={(e) => e.stopPropagation()}
+          >
             <DecisionTile
               active={decision === 'match'}
               onClick={() => onDecision('match')}
@@ -345,7 +369,10 @@ function ConfirmCharacterCard({
             />
           </div>
         ) : (
-          <div className="w-[340px]" onClick={(e) => e.stopPropagation()}>
+          <div
+            className="col-span-2 sm:col-span-1 w-full sm:w-[340px]"
+            onClick={(e) => e.stopPropagation()}
+          >
             <DecisionTile
               active={true}
               swatch={voice}
@@ -381,8 +408,13 @@ function ConfirmCharacterCard({
                source wins on identity conflicts). Each side keeps its
                own audio identity, per-book metrics, and evidence quotes.
                Default off so the existing reuse-as-is flow is unchanged. */
+            /* Plan 81 wave 3 — `pl-9` indent stays; the whole label is the
+               tap target (clicking anywhere on the text toggles the
+               checkbox), so the multi-line text already exceeds 44 px on
+               every viewport. Min-h on phone is a belt-and-braces guard
+               for shorter book titles. */
             <label
-              className="flex items-start gap-3 text-xs text-ink/60 pl-9 cursor-pointer select-none"
+              className="flex items-start gap-3 text-xs text-ink/60 pl-9 cursor-pointer select-none min-h-[44px] sm:min-h-0"
               onKeyDown={(e) => {
                 if (e.key === ' ' || e.key === 'Enter') e.stopPropagation();
               }}
@@ -440,10 +472,14 @@ function DecisionTile({
   readonly,
 }: DecisionTileProps) {
   return (
+    /* Plan 81 wave 3 — explicit min-h on phone gives the decision tile a
+       WCAG 2.5.5 compliant tap target (≥44 px). The existing `p-3` +
+       8 px swatch + two text lines already exceeds that on desktop; the
+       min-h is a belt-and-braces guarantee for phone. */
     <button
       onClick={onClick}
       disabled={readonly}
-      className={`text-left p-3 rounded-2xl border transition-all ${active ? 'border-peach bg-peach/[0.06]' : 'border-ink/10 hover:border-ink/20'} ${readonly ? 'cursor-default' : 'cursor-pointer'}`}
+      className={`text-left p-3 min-h-[44px] rounded-2xl border transition-all ${active ? 'border-peach bg-peach/[0.06]' : 'border-ink/10 hover:border-ink/20'} ${readonly ? 'cursor-default' : 'cursor-pointer'}`}
     >
       <div className="flex items-start gap-3">
         {swatch ? (


### PR DESCRIPTION
## Summary

Wave 3 of plan 81 (mobile + tablet support). Confirm-cast view (`src/views/confirm-cast.tsx`) now renders without horizontal overflow at phone (375 px) and tablet (834 px) viewports, with ≥44 px tap targets on every interactive control (WCAG 2.5.5). Per-view layout only — no shared chrome edits.

**Card grid:** the card-internal grid drops the third (decision-tile) column on `<sm:` and restores it on tablet+ (`grid-cols-[auto_1fr] sm:grid-cols-[auto_1fr_auto]`). The decision-tile panel spans both columns on phone (`col-span-2 sm:col-span-1`), stacking below the avatar + info row. Panel width is now fluid: `w-full sm:w-[340px]` replaces the hard-coded `w-[340px]` for both the matched (two-tile) and unmatched (single readonly-tile) shapes. On tablet+ the layout is byte-identical to before — zero desktop visual change. Card padding + gap shrink on phone (`p-4 sm:p-5`, `gap-3 sm:gap-5`). Decision tiles gain `min-h-[44px]`.

**Confirm-action row:** stacks vertically on phone (`flex-col-reverse sm:flex-row`) so the long "Confirm cast and review manuscript" PrimaryButton doesn't share a 327 px line with the Re-analyse link. Primary intent on top on touch. Re-analyse link gains `min-h-[44px] sm:min-h-0`.

**Page chrome:** outer padding + header margin + heading copy tighten on phone so the first cast card lands above the fold on a 667 px tall viewport. Sync-profile checkbox label gets `min-h-[44px] sm:min-h-0`.

## Test plan

- [x] `src/views/confirm-cast.test.tsx`: five new specs lock the responsive class contract — panel `w-full sm:w-[340px]`, panel `col-span-2 sm:col-span-1`, card grid `grid-cols-[auto_1fr] sm:grid-cols-[auto_1fr_auto]`, every DecisionTile carries `min-h-[44px]`, action row `flex-col-reverse sm:flex-row`. jsdom can't measure pixel widths, but pinning the classes catches accidental reverts in pre-commit instead of slipping to e2e.
- [x] All 29 confirm-cast specs green (24 previous + 5 new). No existing tests touched.
- [x] `npm run verify` passes: lint + typecheck + frontend + server + Pester scripts + sidecar pytest + Playwright e2e (63 passed including `visual.spec.ts › confirm` light + dark baselines) + build.

## Out of scope (handled by other waves)

- Top-bar + mini-player responsive: Wave 2 (PR #83).
- LAN HTTPS + Playwright mobile/tablet projects: Wave 1 (PR #82).
- Touch affordances (tap-to-assign voice library, tap-revealed paragraph-boundary buttons): Wave 4.
- Per-view per-viewport visual baselines: Wave 5.

Regression plan: `docs/features/81-mobile-tablet-support.md` (lands via Wave 0 PR #81; Ship notes for Wave 3 follow on merge).