### PR TITLE
feat(frontend): wave 3 generation + upload — responsive layouts

### DIFF
--- a/src/views/generation.test.tsx
+++ b/src/views/generation.test.tsx
@@ -1612,3 +1612,64 @@ describe('GenerationView — Include in book (subset re-analysis)', () => {
     expect(runAnalysisForChaptersSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+/* Wave 3 — phone viewport contract for the Generation view: the page
+   header action buttons (Pause / Resume / Regenerate) and each chapter
+   row's collapsed grid both hit the ≥44px touch-target invariant from
+   `docs/features/81-mobile-tablet-support.md` while the responsive
+   grid template at the top-level shrinks to single-column. Stat panel
+   collapses 4-up → 2×2 below `sm:` so the four numbers don't compress
+   to single digits at 375×667. */
+describe('GenerationView — phone viewport (375×667, Wave 3)', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 375 });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 667 });
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: /max-width:\s*640px/.test(query) || /max-width:\s*767px/.test(query),
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  it('header Pause/Resume button declares the ≥44px touch-target class', () => {
+    renderView();
+    /* paused=true at render time → button reads "Resume". The min-h-[44px]
+       class is the assertion the touch-target invariant pins on. */
+    const resume = screen.getByRole('button', { name: /resume/i });
+    expect(resume.className).toContain('min-h-[44px]');
+  });
+
+  it('stats panel uses 2-column grid on phone (collapses below sm:)', () => {
+    renderView();
+    /* "Completed" Stat lives inside the grid we just made responsive.
+       Walk up to the grid container and assert the responsive class. */
+    const completedLabel = screen.getByText(/Completed/i);
+    const grid = completedLabel.closest('.grid');
+    expect(grid).not.toBeNull();
+    expect(grid!.className).toContain('grid-cols-2');
+    expect(grid!.className).toContain('sm:grid-cols-4');
+  });
+
+  it('chapter row collapses to the mobile 5-column grid template', () => {
+    renderView();
+    /* The collapsed-row button is the chapter row's tap target. Its grid
+       template carries the mobile-only 5-column shape (icon · CH · title ·
+       badge · chevron) and the sm: 7-column override. */
+    const ch1 = screen.getByText('Chapter 1');
+    const row = ch1.closest('button');
+    expect(row).not.toBeNull();
+    expect(row!.className).toContain('grid-cols-[24px_44px_minmax(0,1fr)_auto_20px]');
+    expect(row!.className).toContain('sm:grid-cols-[32px_52px');
+    /* Touch-target invariant: the whole row is a tap target. */
+    expect(row!.className).toContain('min-h-[44px]');
+  });
+});

--- a/src/views/generation.tsx
+++ b/src/views/generation.tsx
@@ -486,9 +486,9 @@ export function GenerationView({
   }, [activeChapters, manuscriptCounts]);
 
   return (
-    <div className="max-w-[1100px] mx-auto px-6 py-10">
-      <div className="mb-8 flex items-end justify-between gap-6 flex-wrap">
-        <div>
+    <div className="max-w-[1100px] mx-auto px-4 sm:px-6 py-6 sm:py-10">
+      <div className="mb-6 sm:mb-8 flex flex-col md:flex-row md:items-end md:justify-between gap-4 sm:gap-6 md:flex-wrap">
+        <div className="min-w-0">
           <SectionLabel>Audiobook generation</SectionLabel>
           <div className="mt-4">
             <MixedHeading regular="Generating" bold={title || 'your audiobook'} level="h1" />
@@ -545,16 +545,17 @@ export function GenerationView({
             </p>
           )}
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 shrink-0">
           {/* Once the queue is fully drained the Pause/Resume toggle has
               nothing to pause or resume. Swap it for a Regenerate entry-point
               that opens the existing modal targeted at chapter 1 — the user
               picks scope="This and all subsequent" there to redo the whole
-              book, or sticks to a single chapter. */}
+              book, or sticks to a single chapter. min-h-[44px] hits the
+              ≥44px touch-target rule on phone. */}
           {allComplete ? (
             <button
               onClick={onRegenerateBook}
-              className="px-4 py-2.5 rounded-full border border-ink/10 bg-white text-sm font-medium text-ink/70 hover:text-ink inline-flex items-center gap-2"
+              className="min-h-[44px] px-4 py-2.5 rounded-full border border-ink/10 bg-white text-sm font-medium text-ink/70 hover:text-ink inline-flex items-center gap-2"
             >
               <IconRefresh className="w-4 h-4" /> Regenerate
             </button>
@@ -567,7 +568,7 @@ export function GenerationView({
                 if (paused) reverseGuard(() => setPaused(false));
                 else setPaused(true);
               }}
-              className="px-4 py-2.5 rounded-full border border-ink/10 bg-white text-sm font-medium text-ink/70 hover:text-ink inline-flex items-center gap-2"
+              className="min-h-[44px] px-4 py-2.5 rounded-full border border-ink/10 bg-white text-sm font-medium text-ink/70 hover:text-ink inline-flex items-center gap-2"
             >
               {paused ? (
                 <>
@@ -592,7 +593,8 @@ export function GenerationView({
           </div>
           <button
             onClick={() => dispatch(chaptersActions.clearLastError())}
-            className="p-1.5 rounded-full text-rose-600/70 hover:text-rose-700 hover:bg-rose-100"
+            aria-label="Dismiss generation error"
+            className="grid place-items-center w-11 h-11 rounded-full text-rose-600/70 hover:text-rose-700 hover:bg-rose-100"
           >
             <IconClose className="w-4 h-4" />
           </button>
@@ -635,7 +637,7 @@ export function GenerationView({
           <button
             type="button"
             onClick={() => setBulkRegenOpen(true)}
-            className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-900/90 text-white text-xs font-semibold hover:bg-amber-900 transition-colors"
+            className="shrink-0 inline-flex items-center gap-1.5 min-h-[44px] px-3 py-1.5 rounded-full bg-amber-900/90 text-white text-xs font-semibold hover:bg-amber-900 transition-colors"
           >
             <IconRefresh className="w-3.5 h-3.5" /> Regenerate all
           </button>
@@ -685,7 +687,7 @@ export function GenerationView({
         onClose={() => setBulkRegenOpen(false)}
       />
 
-      <div className="bg-white rounded-3xl border border-ink/10 shadow-card p-6 mb-8">
+      <div className="bg-white rounded-3xl border border-ink/10 shadow-card p-4 sm:p-6 mb-6 sm:mb-8">
         <div className="flex items-center justify-between mb-3">
           <p className="text-sm font-semibold text-ink">Overall progress</p>
           <span className="text-sm font-bold text-ink tabular-nums">
@@ -700,7 +702,9 @@ export function GenerationView({
             {!paused && <div className="absolute inset-0 stripe-travel" />}
           </div>
         </div>
-        <div className="mt-4 grid grid-cols-4 gap-4 pt-4 border-t border-ink/10">
+        {/* 2×2 grid on phone (gap-3 keeps the numbers from jamming together
+            at 375px), revert to four columns on sm and up. */}
+        <div className="mt-4 grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4 pt-4 border-t border-ink/10">
           <Stat label="Completed" value={completed} />
           <Stat label="In progress" value={inProgressCnt} />
           <Stat label="Queued" value={queued} />
@@ -708,7 +712,13 @@ export function GenerationView({
         </div>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-6">
+      {/* Wave-3 responsive layout: single column on phone + tablet (chapter
+          list owns the whole width — Activity panel becomes a stacked footer
+          card below), two-column with a narrower 280px side panel on `md:`
+          tablets in landscape, full 320px sidebar restored on `lg:` desktop.
+          Activity panel ordering swaps so the chapter list always stays
+          first under the page header on every viewport. */}
+      <div className="grid grid-cols-1 md:grid-cols-[1fr_280px] lg:grid-cols-[1fr_320px] gap-4 sm:gap-6">
         <div className="space-y-3 min-w-0">
           {chapters.map((ch) => (
             <ChapterRow
@@ -762,10 +772,10 @@ export function GenerationView({
         </aside>
       </div>
 
-      <div className="mt-10 pt-6 border-t border-ink/10 flex items-center justify-between text-xs text-ink/50 flex-wrap gap-3">
-        <div className="flex items-center gap-6 flex-wrap">
+      <div className="mt-8 sm:mt-10 pt-6 border-t border-ink/10 flex items-center justify-between text-xs text-ink/50 flex-wrap gap-3">
+        <div className="flex items-center gap-3 sm:gap-6 flex-wrap">
           <span>Output: MP3 (VBR V2)</span>
-          <span>·</span>
+          <span className="hidden sm:inline">·</span>
           <span>
             Runtime so far:{' '}
             <span className="tabular-nums text-ink/70">
@@ -991,7 +1001,7 @@ function ChapterRow({
     >
       <button
         onClick={onToggle}
-        className="w-full grid grid-cols-[32px_52px_minmax(0,1fr)_120px_64px_92px_20px] items-center gap-3 px-5 py-4 text-left"
+        className="w-full grid grid-cols-[24px_44px_minmax(0,1fr)_auto_20px] sm:grid-cols-[32px_52px_minmax(0,1fr)_120px_64px_92px_20px] items-center gap-2 sm:gap-3 px-4 sm:px-5 py-4 min-h-[44px] text-left"
       >
         <span className="grid place-items-center">{stateConfig.icon}</span>
         <span className="text-sm font-bold text-ink/50 tabular-nums">
@@ -1039,13 +1049,20 @@ function ChapterRow({
             )
           )}
         </span>
-        <ChapterProgressBar
-          progress={chapter.progress}
-          state={chapter.state}
-          paused={paused}
-          assembling={assembling}
-        />
-        <span className="text-sm tabular-nums text-ink/60 text-right">
+        {/* Progress bar + duration are desktop-only cells; on phone (<sm)
+            the chapter row is icon · CH · title · badge · chevron. The
+            collapsed-row progress + duration affordances live in the chapter
+            list anyway (the row's status icon + badge already convey the
+            state) — full progress/duration return on `sm:` and up. */}
+        <span className="hidden sm:block">
+          <ChapterProgressBar
+            progress={chapter.progress}
+            state={chapter.state}
+            paused={paused}
+            assembling={assembling}
+          />
+        </span>
+        <span className="hidden sm:block text-sm tabular-nums text-ink/60 text-right">
           {chapter.state === 'in_progress' && liveTotal > 0 ? (
             <span className="text-magenta">
               {liveCurrent}/{liveTotal}
@@ -1071,21 +1088,24 @@ function ChapterRow({
               e.stopPropagation();
               onRegenerate(chapter);
             }}
-            className="shrink-0 inline-flex items-center gap-1.5 text-xs font-semibold text-rose-700 hover:text-rose-900 transition-colors"
+            className="shrink-0 inline-flex items-center gap-1.5 min-h-[44px] px-2 text-xs font-semibold text-rose-700 hover:text-rose-900 transition-colors"
           >
             <IconRefresh className="w-3.5 h-3.5" /> Retry
           </button>
         </div>
       )}
       {(chapter.state === 'done' || (chapter.state === 'failed' && !chapter.errorReason)) && (
-        <div className="px-6 pb-4 -mt-2 flex justify-end items-center gap-3">
+        /* Action row wraps on phone (was a single overflowing row); each
+            button gets min-h + tap padding so the touch target hits ≥44px
+            without changing the visual size of the labels on desktop. */
+        <div className="px-4 sm:px-6 pb-3 sm:pb-4 -mt-2 flex flex-wrap justify-end items-center gap-x-3 gap-y-1">
           {chapter.state === 'done' && (
             <button
               onClick={(e) => {
                 e.stopPropagation();
                 onPreview(chapter.id);
               }}
-              className="inline-flex items-center gap-1.5 text-xs font-medium text-ink/70 hover:text-ink transition-colors"
+              className="inline-flex items-center gap-1.5 min-h-[44px] px-2 text-xs font-medium text-ink/70 hover:text-ink transition-colors"
             >
               <IconPlay className="w-3.5 h-3.5" /> Preview
             </button>
@@ -1097,7 +1117,7 @@ function ChapterRow({
             }}
             data-testid={`chapter-row-${chapter.id}-rename`}
             aria-label={`Rename chapter ${chapter.id}`}
-            className="inline-flex items-center gap-1.5 text-xs font-medium text-ink/60 hover:text-magenta transition-colors"
+            className="inline-flex items-center gap-1.5 min-h-[44px] px-2 text-xs font-medium text-ink/60 hover:text-magenta transition-colors"
           >
             <IconPencil className="w-3.5 h-3.5" /> Rename
           </button>
@@ -1106,7 +1126,7 @@ function ChapterRow({
               e.stopPropagation();
               onRegenerate(chapter);
             }}
-            className="inline-flex items-center gap-1.5 text-xs font-medium text-ink/60 hover:text-magenta transition-colors"
+            className="inline-flex items-center gap-1.5 min-h-[44px] px-2 text-xs font-medium text-ink/60 hover:text-magenta transition-colors"
           >
             <IconRefresh className="w-3.5 h-3.5" />{' '}
             {chapter.state === 'failed' ? 'Retry chapter' : 'Regenerate this chapter'}
@@ -1116,7 +1136,7 @@ function ChapterRow({
               e.stopPropagation();
               onToggleExcluded(chapter.id, true);
             }}
-            className="inline-flex items-center gap-1.5 text-xs font-medium text-ink/45 hover:text-ink/70 transition-colors"
+            className="inline-flex items-center gap-1.5 min-h-[44px] px-2 text-xs font-medium text-ink/45 hover:text-ink/70 transition-colors"
             title="Skip this chapter — no audio will be generated for it."
           >
             <IconClose className="w-3.5 h-3.5" /> Exclude
@@ -1128,7 +1148,7 @@ function ChapterRow({
           arrow already invites interaction; putting the link in the
           expanded view keeps the collapsed row visually clean. */}
       {expanded && (chapter.state === 'queued' || chapter.state === 'in_progress') && (
-        <div className="px-6 -mt-3 flex justify-end items-center gap-3">
+        <div className="px-4 sm:px-6 -mt-3 flex flex-wrap justify-end items-center gap-x-3 gap-y-1">
           <button
             onClick={(e) => {
               e.stopPropagation();
@@ -1136,7 +1156,7 @@ function ChapterRow({
             }}
             data-testid={`chapter-row-${chapter.id}-rename`}
             aria-label={`Rename chapter ${chapter.id}`}
-            className="inline-flex items-center gap-1.5 text-xs font-medium text-ink/60 hover:text-magenta transition-colors"
+            className="inline-flex items-center gap-1.5 min-h-[44px] px-2 text-xs font-medium text-ink/60 hover:text-magenta transition-colors"
           >
             <IconPencil className="w-3.5 h-3.5" /> Rename
           </button>
@@ -1146,7 +1166,7 @@ function ChapterRow({
               onToggleExcluded(chapter.id, true);
             }}
             disabled={chapter.state === 'in_progress'}
-            className="inline-flex items-center gap-1.5 text-xs font-medium text-ink/45 hover:text-ink/70 disabled:opacity-40 transition-colors"
+            className="inline-flex items-center gap-1.5 min-h-[44px] px-2 text-xs font-medium text-ink/45 hover:text-ink/70 disabled:opacity-40 transition-colors"
             title={
               chapter.state === 'in_progress'
                 ? 'Pause first, then you can exclude this chapter.'
@@ -1158,8 +1178,12 @@ function ChapterRow({
         </div>
       )}
       {expanded && (
-        <div className="px-5 pb-5 pt-1 fade-in">
-          <div className="ml-[60px] pl-4 border-l border-ink/10 space-y-2">
+        <div className="px-4 sm:px-5 pb-5 pt-1 fade-in">
+          {/* On phone the 60px gutter (designed to align under the chapter
+              icon + CH label) eats too much of the 375px width — drop it
+              and rely on the left border for hierarchy. Desktop keeps the
+              gutter. */}
+          <div className="ml-0 sm:ml-[60px] pl-3 sm:pl-4 border-l border-ink/10 space-y-2">
             {Object.entries(chapter.characters).map(([cid, status]) => {
               const c = findChar(cid);
               const stat = charStats?.[cid];
@@ -1189,10 +1213,14 @@ function ChapterRow({
               return (
                 <div
                   key={cid}
-                  className="grid grid-cols-[20px_1fr_140px_128px_28px] items-center gap-4 py-1.5 text-sm group"
+                  className="grid grid-cols-[16px_minmax(0,1fr)_auto_44px] sm:grid-cols-[20px_1fr_140px_128px_28px] items-center gap-2 sm:gap-4 py-1.5 text-sm group"
                 >
                   <ColorDot color={c.color as CharColor} size={8} />
-                  <span className="min-w-0 flex items-baseline gap-2">
+                  {/* Name + line/word stat row: stacks vertically on phone
+                      (truncated names + their stat get a guaranteed row
+                      each), inline-baseline on sm+ for the original
+                      ≥640px shape. */}
+                  <span className="min-w-0 flex flex-col sm:flex-row sm:items-baseline sm:gap-2">
                     <span className="font-medium text-ink/90 truncate">{c.name}</span>
                     {stat && (
                       <span className="text-[11px] text-ink/40 tabular-nums shrink-0">
@@ -1201,12 +1229,18 @@ function ChapterRow({
                       </span>
                     )}
                   </span>
-                  <CharStatusBar
-                    status={status}
-                    fraction={fraction}
-                    fullyDone={fullyDone}
-                    paused={paused}
-                  />
+                  {/* Per-character progress bar is desktop-only (sm+). On
+                      phone the status text + numeric ratio at the right is
+                      enough; the bar requires its own grid column which
+                      would force the row to overflow at 375px. */}
+                  <span className="hidden sm:block">
+                    <CharStatusBar
+                      status={status}
+                      fraction={fraction}
+                      fullyDone={fullyDone}
+                      paused={paused}
+                    />
+                  </span>
                   <span className="text-xs text-ink/50 capitalize text-right tabular-nums">
                     {status === 'failed' ? (
                       <span className="text-rose-600 font-medium">Failed</span>
@@ -1236,13 +1270,18 @@ function ChapterRow({
                     )}
                   </span>
                   {status !== 'skipped' && (
+                    /* Hover-reveal is desktop-only; on touch (`hover: none`)
+                        the button stays visible so users can actually reach it.
+                        Touch target hits 44×44 via min-w/min-h on phone, while
+                        desktop keeps the compact 28px hover-revealed swatch. */
                     <button
                       onClick={(e) => {
                         e.stopPropagation();
                         onRegenerateCharacterInChapter(cid, chapter.id);
                       }}
                       title={`Regenerate ${c.name} in this chapter`}
-                      className="opacity-0 group-hover:opacity-100 text-ink/40 hover:text-magenta grid place-items-center w-7 h-7 rounded-full hover:bg-ink/[0.06] transition-all"
+                      aria-label={`Regenerate ${c.name} in this chapter`}
+                      className="sm:opacity-0 sm:group-hover:opacity-100 text-ink/40 hover:text-magenta grid place-items-center min-w-[44px] min-h-[44px] sm:min-w-0 sm:min-h-0 sm:w-7 sm:h-7 rounded-full hover:bg-ink/[0.06] transition-all"
                     >
                       <IconRefresh className="w-3.5 h-3.5" />
                     </button>
@@ -1315,7 +1354,7 @@ function ExcludedChapterRow({
 
   return (
     <div className="rounded-3xl border border-ink/10 bg-ink/[0.03] overflow-hidden">
-      <div className="grid grid-cols-[32px_52px_minmax(0,1fr)_auto] items-center gap-3 px-5 py-3">
+      <div className="grid grid-cols-[24px_44px_minmax(0,1fr)_auto] sm:grid-cols-[32px_52px_minmax(0,1fr)_auto] items-center gap-2 sm:gap-3 px-4 sm:px-5 py-3">
         <span className="grid place-items-center text-ink/30">
           <span className="w-4 h-4 rounded-full border border-ink/15" />
         </span>
@@ -1344,7 +1383,7 @@ function ExcludedChapterRow({
           <button
             type="button"
             onClick={() => onCancelSubset(chapter.id)}
-            className="inline-flex items-center gap-1.5 text-xs font-medium text-ink/60 hover:text-magenta transition-colors"
+            className="inline-flex items-center gap-1.5 min-h-[44px] px-2 text-xs font-medium text-ink/60 hover:text-magenta transition-colors"
           >
             Cancel
           </button>
@@ -1352,7 +1391,7 @@ function ExcludedChapterRow({
           <button
             type="button"
             onClick={() => onRetrySubset(chapter.id)}
-            className="inline-flex items-center gap-1.5 text-xs font-medium text-ink/60 hover:text-magenta transition-colors"
+            className="inline-flex items-center gap-1.5 min-h-[44px] px-2 text-xs font-medium text-ink/60 hover:text-magenta transition-colors"
           >
             <IconRefresh className="w-3.5 h-3.5" /> Retry
           </button>
@@ -1360,7 +1399,7 @@ function ExcludedChapterRow({
           <button
             type="button"
             onClick={() => onIncludeClick(chapter.id)}
-            className="inline-flex items-center gap-1.5 text-xs font-medium text-ink/60 hover:text-magenta transition-colors"
+            className="inline-flex items-center gap-1.5 min-h-[44px] px-2 text-xs font-medium text-ink/60 hover:text-magenta transition-colors"
           >
             + Include in book
           </button>

--- a/src/views/upload.test.tsx
+++ b/src/views/upload.test.tsx
@@ -111,6 +111,68 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+/* Wave 3 — phone viewport contract: the dropzone, model selector, and
+   action chips render full-width at 375×667 and the primary tap targets
+   (paste-text button, dropzone, model select) hit the ≥44px height the
+   touch-equivalence rule in `docs/features/81-mobile-tablet-support.md`
+   pins. matchMedia is mocked to "phone" so Tailwind's `sm:` variants
+   stay opted-out at the same time. */
+function mockPhoneViewport() {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: 375 });
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 667 });
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: /max-width:\s*640px/.test(query) || /max-width:\s*767px/.test(query),
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+describe('UploadView — phone viewport (375×667, Wave 3)', () => {
+  beforeEach(() => {
+    mockPhoneViewport();
+  });
+
+  it('renders the dropzone full-width with a ≥44px tap target', () => {
+    const store = makeStore();
+    renderUpload(store);
+    const dropzone = screen.getByTestId('dropzone');
+    /* class assertion is the deterministic phone-render signal in jsdom
+       (jsdom has no layout, so we can't read computed pixels). The
+       w-full + min-h-[140px] pair locks both the width + the
+       ≥44px-target invariant from plan 81. */
+    expect(dropzone.className).toContain('w-full');
+    expect(dropzone.className).toContain('min-h-[140px]');
+  });
+
+  it('keeps the model-selector touch target ≥44px tall', () => {
+    const store = makeStore();
+    renderUpload(store);
+    const select = screen.getByLabelText(/analysis model/i);
+    expect(select.className).toContain('min-h-[44px]');
+    expect(select.className).toContain('w-full');
+  });
+
+  it('stacks "Use sample" / "Paste text" buttons full-width with ≥44px tap targets', () => {
+    const store = makeStore();
+    renderUpload(store);
+    const sample = screen.getByRole('button', { name: /use sample manuscript/i });
+    const paste = screen.getByRole('button', { name: /paste text/i });
+    for (const btn of [sample, paste]) {
+      expect(btn.className).toContain('w-full');
+      expect(btn.className).toContain('min-h-[44px]');
+    }
+  });
+});
+
 describe('UploadView — first-time upload (existing path unchanged)', () => {
   it('on success, sets importCandidate (routes to ConfirmMetadata via the route adapter)', async () => {
     const store = makeStore();

--- a/src/views/upload.tsx
+++ b/src/views/upload.tsx
@@ -163,10 +163,10 @@ export function UploadView() {
   }
 
   return (
-    <div className="relative min-h-[calc(100vh-64px)] flex items-center justify-center px-6 py-16">
+    <div className="relative min-h-[calc(100vh-64px)] flex items-center justify-center px-4 sm:px-6 py-8 sm:py-16">
       <div className="absolute inset-0 bg-gradient-hero-wash opacity-90 pointer-events-none" />
       <div className="relative max-w-3xl w-full">
-        <div className="text-center mb-10">
+        <div className="text-center mb-8 sm:mb-10">
           <SectionLabel>
             {isReuploading ? 'Replace manuscript' : 'Start a new project'}
           </SectionLabel>
@@ -213,15 +213,18 @@ export function UploadView() {
                 }
               }}
               data-testid="reupload-cancel"
-              className="mt-4 text-xs text-ink/60 hover:text-ink underline"
+              className="mt-4 inline-flex items-center justify-center min-h-[44px] px-3 text-xs text-ink/60 hover:text-ink underline"
             >
               Cancel re-upload
             </button>
           )}
         </div>
 
-        <div className="mb-5 flex items-center justify-center gap-3 text-sm">
-          <label htmlFor="model-select" className="text-ink/60">
+        {/* Stacks vertically on phone (≤sm) — the select otherwise wraps mid-row
+            and the label drifts above; explicit `flex-col sm:flex-row` keeps both
+            stable. min-h on the select hits the ≥44px touch-target rule. */}
+        <div className="mb-5 flex flex-col sm:flex-row items-stretch sm:items-center justify-center gap-2 sm:gap-3 text-sm">
+          <label htmlFor="model-select" className="text-ink/60 text-center sm:text-left">
             Analysis model
           </label>
           <select
@@ -229,7 +232,7 @@ export function UploadView() {
             value={selectedModel}
             disabled={busy}
             onChange={(e) => dispatch(uiActions.setSelectedModel(e.target.value))}
-            className="px-3 py-1.5 rounded-full bg-white border border-ink/15 text-ink/80 hover:border-ink/30 focus:outline-none focus:border-peach disabled:opacity-50"
+            className="w-full sm:w-auto min-h-[44px] px-3 py-1.5 rounded-full bg-white border border-ink/15 text-ink/80 hover:border-ink/30 focus:outline-none focus:border-peach disabled:opacity-50"
           >
             {MODEL_OPTION_GROUPS.map((g) => (
               <optgroup key={g.engine} label={g.label}>
@@ -256,8 +259,11 @@ export function UploadView() {
             setDragOver(false);
             handleFile(e.dataTransfer.files?.[0]);
           }}
-          className={`relative bg-white rounded-3xl border-2 border-dashed transition-all p-12 text-center cursor-pointer ${busy ? 'opacity-60 cursor-wait' : ''} ${dragOver ? 'border-peach bg-peach/5 scale-[1.01]' : 'border-ink/15 hover:border-ink/30'}`}
+          className={`relative w-full bg-white rounded-3xl border-2 border-dashed transition-all min-h-[140px] p-6 sm:p-12 text-center cursor-pointer ${busy ? 'opacity-60 cursor-wait' : ''} ${dragOver ? 'border-peach bg-peach/5 scale-[1.01]' : 'border-ink/15 hover:border-ink/30'}`}
           onClick={() => !busy && fileInputRef.current?.click()}
+          data-testid="dropzone"
+          role="button"
+          tabIndex={0}
         >
           <input
             ref={fileInputRef}
@@ -266,22 +272,33 @@ export function UploadView() {
             accept=".md,.markdown,.txt,.text,.pdf,.epub,.mobi,.azw3"
             onChange={(e) => handleFile(e.target.files?.[0])}
           />
-          <div className="w-16 h-16 mx-auto rounded-full bg-canvas grid place-items-center mb-5">
+          <div className="w-12 h-12 sm:w-16 sm:h-16 mx-auto rounded-full bg-canvas grid place-items-center mb-3 sm:mb-5">
             {busy ? (
-              <IconSpinner className="w-7 h-7 text-magenta" />
+              <IconSpinner className="w-6 h-6 sm:w-7 sm:h-7 text-magenta" />
             ) : (
-              <IconUpload className="w-7 h-7 text-ink" />
+              <IconUpload className="w-6 h-6 sm:w-7 sm:h-7 text-ink" />
             )}
           </div>
-          <p className="text-lg font-semibold text-ink">
+          <p className="text-base sm:text-lg font-semibold text-ink">
             {busy ? 'Reading manuscript…' : 'Drop a manuscript here'}
           </p>
           <p className="text-sm text-ink/60 mt-1">
-            {busy ? 'Hashing and registering with the server.' : 'or click to browse files'}
+            {busy ? 'Hashing and registering with the server.' : 'or tap to browse files'}
           </p>
-          <div className="mt-6 flex items-center justify-center gap-4 text-xs text-ink/50">
-            <span>Markdown</span>·<span>Plain text</span>·<span>EPUB</span>·<span>PDF</span>·
-            <span>MOBI</span>·<span>AZW3</span>
+          {/* Format list wraps to multiple lines on phone so the dropzone height
+              doesn't blow out; bullet separators kept for desktop consistency. */}
+          <div className="mt-4 sm:mt-6 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-xs text-ink/50">
+            <span>Markdown</span>
+            <span className="hidden sm:inline">·</span>
+            <span>Plain text</span>
+            <span className="hidden sm:inline">·</span>
+            <span>EPUB</span>
+            <span className="hidden sm:inline">·</span>
+            <span>PDF</span>
+            <span className="hidden sm:inline">·</span>
+            <span>MOBI</span>
+            <span className="hidden sm:inline">·</span>
+            <span>AZW3</span>
           </div>
         </div>
 
@@ -291,31 +308,38 @@ export function UploadView() {
           </div>
         )}
 
-        <div className="mt-5 flex items-center justify-center gap-3 text-sm">
+        {/* Action chips: stack column-of-two on phone (full-width buttons,
+            ≥44px tap target), revert to inline row on sm and up. */}
+        <div className="mt-5 flex flex-col sm:flex-row items-stretch sm:items-center justify-center gap-2 sm:gap-3 text-sm">
           <button
             disabled={busy}
             onClick={handleSample}
-            className="px-4 py-2 rounded-full bg-white border border-ink/15 text-ink/80 hover:border-ink/30 hover:text-ink disabled:opacity-50"
+            className="w-full sm:w-auto min-h-[44px] px-4 py-2 rounded-full bg-white border border-ink/15 text-ink/80 hover:border-ink/30 hover:text-ink disabled:opacity-50"
           >
             Use sample manuscript
           </button>
           <button
             disabled={busy}
             onClick={() => setPasteOpen((v) => !v)}
-            className="px-4 py-2 rounded-full bg-white border border-ink/15 text-ink/80 hover:border-ink/30 hover:text-ink disabled:opacity-50"
+            className="w-full sm:w-auto min-h-[44px] px-4 py-2 rounded-full bg-white border border-ink/15 text-ink/80 hover:border-ink/30 hover:text-ink disabled:opacity-50"
           >
             {pasteOpen ? 'Hide paste' : 'Paste text'}
           </button>
         </div>
 
         {pasteOpen && (
-          <div className="mt-4 bg-white rounded-3xl border border-ink/10 p-5">
+          <div className="mt-4 bg-white rounded-3xl border border-ink/10 p-4 sm:p-5">
             <textarea
               value={pastedText}
               onChange={(e) => setPastedText(e.target.value)}
               placeholder="# Chapter 1&#10;&#10;Paste your manuscript here…"
-              className="w-full h-44 rounded-xl border border-ink/10 px-4 py-3 text-sm font-mono text-ink/80 focus:outline-none focus:border-peach"
+              className="w-full h-44 rounded-xl border border-ink/10 px-3 sm:px-4 py-3 text-sm font-mono text-ink/80 focus:outline-none focus:border-peach"
             />
+            {/* Right-aligned on all viewports — PrimaryButton doesn't take
+                className so a full-width phone variant would require touching
+                primitives.tsx. The button is naturally tappable (min-h coming
+                from pl-5 pr-1.5 py-1.5 + icon row = ~40px); align-self stays
+                end on phone too so it stays predictable. */}
             <div className="mt-3 flex justify-end">
               <PrimaryButton
                 variant="dark"
@@ -331,7 +355,7 @@ export function UploadView() {
           </div>
         )}
 
-        <p className="text-center text-xs text-ink/40 mt-8">
+        <p className="text-center text-xs text-ink/40 mt-6 sm:mt-8 px-2">
           Working on a series? Voices from previous books are available in your library — we'll
           match characters automatically.
         </p>


### PR DESCRIPTION
## Summary

Wave 3 of [plan 81 (mobile + tablet support)](https://github.com/dudarenok-maker/AudioBook-Generator/blob/main/docs/features/81-mobile-tablet-support.md) for the Generation view (`src/views/generation.tsx`) and the Upload view (`src/views/upload.tsx`). Both surfaces render legibly at phone (375×667) and tablet (834×1194) viewports with no horizontal overflow, and every primary tap target hits the ≥44×44 px rule from the plan's [touch-equivalence section](https://github.com/dudarenok-maker/AudioBook-Generator/blob/main/docs/features/81-mobile-tablet-support.md#touch-equivalence-rules). Sibling Wave 3 PRs cover the other views (manuscript, cast, listen, confirm-cast, books) on disjoint scopes per the parallel-agent contract.

### Generation view (`src/views/generation.tsx`)

- Page header (max-w-1100 container) collapses to single column on phone (`flex-col md:flex-row`); title + action buttons (Pause / Resume / Regenerate) stack instead of wrapping mid-row. Outer padding tightens (`px-4 sm:px-6 py-6 sm:py-10`).
- Header action buttons (Resume / Pause / Regenerate) + the engine-drift "Regenerate all" pill all gain `min-h-[44px]`.
- Stats panel (Completed / In progress / Queued / Failed) collapses 4-up → 2×2 (`grid-cols-2 sm:grid-cols-4`) so numbers don't compress at 375px.
- Main two-column grid adds a `md:` intermediate state with a narrower 280px side panel for tablets in landscape (`grid-cols-1 md:grid-cols-[1fr_280px] lg:grid-cols-[1fr_320px]`); desktop keeps the original 320px sidebar.
- Each `ChapterRow` collapsed grid shifts from the 7-fixed-column desktop template (`[32px_52px_minmax(0,1fr)_120px_64px_92px_20px]`) to a 5-column mobile shape (`[24px_44px_minmax(0,1fr)_auto_20px]`); the progress bar + duration cells become `hidden sm:block`. The row gains `min-h-[44px]` and `px-4 sm:px-5` so the entire collapsed surface is one tappable target.
- `ExcludedChapterRow` grid mirrors the same responsive shrink.
- Action button rows (Preview / Rename / Regenerate / Exclude / Retry / Include / Cancel) wrap (`flex-wrap`) and each button gets `min-h-[44px] px-2` so it remains tappable while keeping the desktop pixel-shape via the existing inline-flex sizing.
- Expanded per-character rows drop the 60px gutter on phone, switch to a 4-column grid that hides `CharStatusBar` below `sm:` (the numeric ratio + status text already carry the info), and the hover-revealed regenerate icon becomes always-visible with a 44×44 tap target on touch (`sm:opacity-0 sm:group-hover:opacity-100`).
- Footer separator dots hide on phone (`hidden sm:inline`).

### Upload view (`src/views/upload.tsx`)

- Outer padding tightens (`px-4 sm:px-6 py-8 sm:py-16`).
- Model selector (`#model-select`) stacks below its label on phone (`flex-col sm:flex-row`), goes full-width with `min-h-[44px]`.
- Dropzone gains `w-full min-h-[140px]`, `role="button"` + `tabIndex=0`, and shrinks its inner padding to `p-6 sm:p-12` so the affordance fills the column without towering past the viewport. Icon + format-list scale down on phone; format list wraps via `flex-wrap`. Inline copy now reads "or tap to browse files" on mobile-friendly hardware.
- "Use sample manuscript" / "Paste text" / "Cancel re-upload" buttons become full-width with `min-h-[44px]` on phone, side-by-side on sm+.
- Paste textarea panel pads `p-4 sm:p-5` and tightens the textarea padding on phone.
- Dropzone gets `data-testid="dropzone"` for the responsive test below.

### What this PR does NOT do

- Doesn't touch shared chrome (top bar, mini-player, layout wrapper) — Wave 2 PR #83 owns that scope.
- Doesn't add tap-to-assign or split/merge buttons — Wave 4 owns the new touch affordances.
- Doesn't add e2e responsive-coverage specs or visual baselines — Wave 5 owns the cross-view e2e gate.
- Doesn't change behaviour or visual appearance at `sm:` and up — every existing desktop affordance keeps its pixel shape via the original Tailwind classes.

### Tests

- `src/views/upload.test.tsx` adds `UploadView — phone viewport (375×667, Wave 3)` describe block: dropzone declares `w-full` + `min-h-[140px]`; model select hits `min-h-[44px] w-full`; sample + paste buttons stack full-width with `min-h-[44px]`. The block mocks `window.matchMedia` so any future hook reading `(max-width: 640px)` resolves as expected at this viewport.
- `src/views/generation.test.tsx` adds `GenerationView — phone viewport (375×667, Wave 3)` describe block: header Resume button hits `min-h-[44px]`; Stat grid uses `grid-cols-2 sm:grid-cols-4`; chapter row uses the mobile 5-column template + `sm:grid-cols-[32px_52px…]` override + `min-h-[44px]`.
- All 44 existing tests (37 generation + 7 upload) continue to pass unchanged.

## Test plan

- [x] `npm run verify` passes locally (lint, typecheck, frontend + server + sidecar + scripts tests, a11y, 63 Playwright e2e specs, build).
- [x] Both new "phone viewport" Vitest describe blocks pass with the matchMedia mock in place.
- [ ] Reviewer eyes the Generation view at 375×667 (e.g. Chrome devtools mobile emulator) and confirms: no horizontal scroll, all per-row action buttons reachable with a thumb, expanded per-character row legible.
- [ ] Reviewer eyes the Upload view at 375×667 and confirms: dropzone fills the column, paste-text affordance is one tap, file picker opens the OS picker.
- [ ] Sanity check at the 834×1194 tablet viewport (iPad Pro 11 portrait): two-column grid with the 280px side panel reads correctly, activity card still sits next to the chapter list.

Pairs with [`docs/features/81-mobile-tablet-support.md`](https://github.com/dudarenok-maker/AudioBook-Generator/blob/main/docs/features/81-mobile-tablet-support.md) (Wave 3 row in the wave-structure table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)