### PR TITLE
docs(docs): plans 87 + 88 + 89 perf tuning — Round 0 docs

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -49,7 +49,15 @@ Source: net-new (2026-05-20). Captured during planning of the next full version 
 
 ## Should — important, not blocking ship
 
-(empty — Should #2 verify-cache fast shipped in plan 54 on 2026-05-19.)
+### 1. Manuscript view virtualisation
+
+Source: net-new (2026-05-21). Spun off from the perf-tuning survey at `~/.claude/plans/want-to-focus-this-bright-donut.md` (item C1). Explicitly demoted from MUST during the survey lock — current feel is bearable, but the manuscript view is the frontend's worst offender (renders every sentence/segment as DOM nodes with per-boundary listeners) and chapters above ~300 sentences feel janky during boundary drag.
+
+- _What:_ Wrap the segment list in `src/views/manuscript.tsx:507-1040` with a virtualiser (`@tanstack/react-virtual`). Render only segments in the viewport plus a buffer. Adjust the boundary-drag PointerEvent handler at `:524-530` for absolute scroll offsets, and route the inspector's "scroll to selected sentence" through `virtualiser.scrollToIndex`.
+- _Acceptance:_ a 500-sentence chapter mounts with ~20 DOM nodes (not 500) plus the surrounding buffer. Boundary drag stays smooth at any chapter size. The "scroll to selected sentence" affordance still lands on the right sentence with the inspector open. New Vitest cases for virtualised boundary behaviour + one e2e for scroll-to-selected.
+- _Key files:_ `src/views/manuscript.tsx` (segment list + boundary handler); `package.json` (new dep); new Vitest in `src/views/manuscript.test.ts`; new Playwright spec under `e2e/`.
+- _Depends on:_ none.
+- _Benefit (user):_ unblocks long chapters in the manuscript view — today the worst frontend pain point. Pairs with Could #25 (confirm-cast + listen-chapter virtualisation) which reuses the same dep.
 
 ---
 
@@ -253,6 +261,66 @@ Source: net-new (2026-05-21). Plan 81 wave 4 deferred item.
 - _Key files:_ grep `src/**/*.tsx` for `group-hover:` / `peer-hover:` / `hover:opacity-0`; apply per-component judgement.
 - _Depends on:_ plan 81 shipped.
 - _Benefit (user):_ touch users get every action that mouse users do, without needing to discover hidden affordances.
+
+### 21. Within-chapter sentence parallelism
+
+Source: net-new (2026-05-21). Spun off from the perf-tuning survey at `~/.claude/plans/want-to-focus-this-bright-donut.md` (item A2). Stacks on plan 87.
+
+- _What:_ Inside `synthesiseChapter`, dispatch K sentence groups concurrently to the sidecar `/synthesize` (currently 1 at a time per plan 70d). Per-engine determinism + voice non-drift must be re-pinned in `server/tts-sidecar/tests/test_concurrent_synthesis.py`; per-group `onGroupStart` heartbeats must still reset the 30 s stall detector correctly; emitted PCM order preserved by indexing.
+- _Acceptance:_ K parallel sentence groups inside one chapter render with no audible drift artefacts on Coqui (XTTS more drift-prone than Kokoro per plan 70d's findings); the stall watchdog still trips correctly on an actual stall; PCM order matches single-threaded baseline. Pytest pin + Vitest server pin both green.
+- _Key files:_ `server/src/synthesise-chapter.ts:138-145`; `server/tts-sidecar/tests/test_concurrent_synthesis.py` (additional cases).
+- _Depends on:_ plan 87 shipped + measurement showing GPU headroom remains under default chapter concurrency.
+- _Benefit (user):_ another ~2× per chapter on top of plan 87 (so 4× headline if GPU survives). Only worth pursuing once plan 87's envelope is known.
+
+### 22. Both TTS engines resident (Kokoro + XTTS)
+
+Source: net-new (2026-05-21). Spun off from the perf-tuning survey (item A3).
+
+- _What:_ Drop the eviction wiring between Kokoro and XTTS; keep both engines loaded. Per-character voice profiles already carry `overrideTtsVoices: { coqui?, kokoro? }` per CLAUDE.md — pick at synth time. VRAM math (Kokoro 1 GB + XTTS 3 GB + Ollama analyzer ~7 GB = 11 GB on an 8 GB GPU) requires Ollama auto-eviction during generation, with the existing "TTS / Analyzer unloaded to free VRAM" banner.
+- _Acceptance:_ A mixed-engine book (Coqui voice on character A, Kokoro on character B) renders without engine-swap latency between sentences. First XTTS use no longer pays the ~30 s cold-load. Ollama auto-eviction surfaces a clear banner during generation; re-loads on analysis trigger.
+- _Key files:_ `server/tts-sidecar/main.py` (eviction wiring removal); `src/components/model-control-pill.tsx`; analyzer eviction at `server/src/analyzer/ollama.ts:92`.
+- _Depends on:_ none structural. Speed gain conditional on mixed-engine casts.
+- _Benefit (user):_ eliminates the 30 s XTTS cold-load on first use for mixed-engine books; enables fluid engine mixing per character.
+
+### 23. Speculative per-chapter Phase 1 (analyzer)
+
+Source: net-new (2026-05-21). Spun off from the perf-tuning survey (item B2).
+
+- _What:_ Drop the global roster gate at `server/src/routes/analysis.ts:2031-2055`. Once chapter N's Phase 0 completes, fire its Phase 1 against the chapter-local roster; reconcile global character ids at the end by rewriting attributions whose character was a duplicate of one in the merged roster.
+- _Acceptance:_ A long book starts producing attribution results visibly earlier than today (no Phase 0 → Phase 1 wall). Duplicate-character normalisation across chapters (e.g. "Mom" in ch1 == "Mother" in ch7) is correct. Manual cowork flow (`server/handoff/`) still works or is explicitly opt-out.
+- _Key files:_ `server/src/routes/analysis.ts:2031-2055`; `server/src/analyzer/cache.ts` (invalidation rules).
+- _Depends on:_ plan 88 shipped (per-phase analyzer split must land first to keep cache shapes simple).
+- _Benefit (user):_ ~30% end-to-end faster on long books. High regression surface — pursue only if plan 88 leaves attribution latency biting.
+
+### 24. Per-call local→Gemini analyzer overflow
+
+Source: net-new (2026-05-21). Spun off from the perf-tuning survey (item B4).
+
+- _What:_ Extend `FallbackAnalyzer` (`server/src/analyzer/index.ts:159-210`) to route partial load to Gemini when local Ollama is slow (not just unreachable). Different from plan 88's per-phase split — this is per-call. Roster names + attribution patterns must normalise across the mixed-analyzer run to avoid duplicate characters.
+- _Acceptance:_ With both local Ollama and Gemini configured, long-book analysis bursts overflow to Gemini under local slowness; the final roster contains no duplicates from cross-analyzer name variants.
+- _Key files:_ `server/src/analyzer/index.ts:159-210`; `server/src/analyzer/select-analyzer.ts`.
+- _Depends on:_ plan 88 shipped (its per-phase plumbing is the seam this builds on).
+- _Benefit (user):_ uses idle Gemini quota when local is the bottleneck. Lower priority than plan 88's bucketed split.
+
+### 25. Confirm-cast + listen-chapter list virtualisation
+
+Source: net-new (2026-05-21). Spun off from the perf-tuning survey (item C4).
+
+- _What:_ Apply Should #1's `@tanstack/react-virtual` pattern to `src/views/confirm-cast.tsx:187-205` and `src/components/listen/listen-player-region.tsx:93-117`. Same virtualiser dep + helper shape.
+- _Acceptance:_ Books with >40 characters mount without confirm-cast jank; books with >40 chapters mount without listen-region jank. Existing tests still green.
+- _Key files:_ `src/views/confirm-cast.tsx`; `src/components/listen/listen-player-region.tsx`; shared dep from Should #1.
+- _Depends on:_ Should #1 (shares the virtualiser dep + helper — pair to amortise dep adoption).
+- _Benefit (user):_ only matters above ~40 rows. Most books are below the threshold today.
+
+### 26. Waveform memoisation
+
+Source: net-new (2026-05-21). Spun off from the perf-tuning survey (item C6).
+
+- _What:_ In `src/components/waveform.tsx`, stabilise the 48-bar `useMemo` (memo key invariant against re-mount) and lift the animation interval to the parent so it ticks once per listen-view mount (not per waveform instance).
+- _Acceptance:_ Listen view with N visible waveforms ticks on one shared interval (not N intervals); the rendered output is visually unchanged from today.
+- _Key files:_ `src/components/waveform.tsx`; parent in `src/components/listen/listen-player-region.tsx`.
+- _Depends on:_ none.
+- _Benefit (technical):_ avoids 480+ DOM mutations per 800 ms when many waveforms are visible simultaneously. Low real-world impact today (rare to see >3 waveforms at once).
 
 ---
 

--- a/docs/features/87-parallel-chapter-synth.md
+++ b/docs/features/87-parallel-chapter-synth.md
@@ -1,0 +1,63 @@
+---
+status: draft
+shipped: null
+owner: null
+---
+
+# Parallel chapter synthesis with bounded worker pool
+
+> Status: draft
+> Key files: `server/src/routes/generation.ts:485-530`, `server/src/synthesise-chapter.ts`, `src/lib/api.ts`, `src/store/ui-slice.ts`
+> URL surface: indirect — `#/books/<id>/generation`; SSE stream emitted by `POST /api/books/:bookId/generation`
+> OpenAPI ops: `POST /api/books/{id}/generation` — wire shape unchanged; SSE event payloads gain per-chapter track identification (every event already carries `chapterId`; consumer must stop assuming events arrive in monotonic chapter order)
+
+## Benefit / Rationale
+
+- **User:** for an 80-chapter book, ~2× faster generation on a single 8 GB GPU. Kokoro v1 is ~1 GB resident and two concurrent inferences fit without eviction. The user perceives this as "the book renders in half the wall-clock" — directly visible in the generation pill and on-disk arrival of `<bookDir>/audio/<slug>.mp3` files.
+- **Technical:** the sidecar `/synthesize` route is already concurrent (`asyncio.to_thread` offload, GIL-releasing inference). `server/tts-sidecar/tests/test_concurrent_synthesis.py:214-244` pins that N concurrent calls run in wall-clock ~single-call time per engine. The bottleneck is the orchestrator's sequential `for…await synthesiseChapter` at `server/src/routes/generation.ts:485-530` — replacing that loop with a bounded `Promise.all` pool extracts the parallelism the sidecar already supports.
+- **Architectural:** opens a per-chapter SSE track shape that future per-sentence parallelism (BACKLOG Could #21 / A2) can stack on without re-plumbing the consumer.
+
+## Architectural impact
+
+- **New seam:** `GEN_CHAPTER_CONCURRENCY` env (default `2`); bounded worker pool over the chapter array. Each chapter still walks its sentences sequentially per plan 70d.
+- **SSE consumer change:** events from multiple chapters interleave on the wire. The frontend consumer (`src/lib/api.ts`) routes by `chapterId` into per-chapter progress tracks in `src/store/ui-slice.ts`. The global ETA derivation switches from "cumulative seconds remaining on the current chapter" to "max(per-chapter ETA)" across the in-flight set.
+- **Stall watchdog stays per-chapter:** the `onGroupStart` heartbeat (plan 16) fires once per sentence group within a chapter; concurrent chapters each have their own watchdog timer (no shared 30 s window). One stalled chapter no longer blocks siblings — it surfaces as a per-track "stalled" pill while the others keep advancing.
+- **Disk-write contention:** negligible. Per-chapter `<bookDir>/audio/<slug>.mp3` paths differ by `chapterId`, no overlap.
+- **Migration:** none. Existing `BookStateJson` fields unchanged. Old in-flight generation streams (resumed from sticky state per plan 31) keep working — when concurrency env is unset or `1`, behaviour reverts to today's serial loop exactly.
+- **Reversibility:** flip `GEN_CHAPTER_CONCURRENCY=1` to disable. The serial branch is preserved in the code as the `K=1` case of the same pool.
+
+## Invariants to preserve
+
+- Plan 16 SSE event shape — chapter ids unchanged, event types (`chapter:start`, `chapter:sentence-done`, `chapter:done`, etc.) unchanged.
+- Plan 70d per-sentence groups inside `synthesiseChapter` unchanged — concurrency is at the chapter layer only, not the sentence layer.
+- Plan 28 on-disk audio format unchanged (MP3 VBR V2 + `<slug>.mp3` + segments.json metadata).
+- Plan 31 sticky-generation contract unchanged — resume after navigation still works; the per-chapter track shape is computed deterministically from the (active book, chapter array, in-flight set) tuple.
+- [project_concurrent_multibook_workflow] preserved — per-chapter dist folders prevent cross-book / cross-chapter collisions.
+
+## Test plan
+
+### Automated coverage
+
+- Vitest server (`server/src/routes/generation.test.ts`) — asserts the worker pool starts exactly K chapters concurrently when K = `GEN_CHAPTER_CONCURRENCY`; remaining chapters queue and start as siblings finish; K=1 path is byte-identical to today's serial behaviour.
+- Vitest frontend (`src/store/ui-slice.test.ts` and `src/lib/api.test.ts`) — asserts per-chapter ETA tracking and SSE event routing by `chapterId` (interleaved events from chapter A and chapter B route to the correct track).
+- Playwright e2e (`e2e/generation-parallel.spec.ts`, new) — in mock mode, asserts chapter 2 emits `chapter:start` before chapter 1's `chapter:done`. Mock mode is sufficient because we're verifying orchestrator shape, not GPU throughput.
+
+### Manual acceptance walkthrough
+
+Real-backend regression on the canonical end-to-end manuscript:
+
+1. **Pre-reboot baseline:** per [feedback_reboot_before_perf_baselines], reboot first; record `GEN_CHAPTER_CONCURRENCY=1` wall-clock for `C:\Users\dudar\Downloads\Bonus Keefe Story.txt` end-to-end generation (single Kokoro engine, no other GPU consumers).
+2. **Default-concurrency run:** set `GEN_CHAPTER_CONCURRENCY=2`, regenerate same book; expect 50–70% of serial baseline wall-clock (target: 2× speedup minus orchestrator overhead).
+3. **Pill UI:** generation pill shows aggregated "K of N" + per-chapter mini-bars (UI detail TBD during implementation).
+4. **Stall scenario:** kill the sidecar mid-chapter-2 while chapters 1 and 3 are in flight; chapter 2 track shows "stalled" pill within 30 s; chapters 1 and 3 continue and complete; resume mode (plan 31) restarts only chapter 2 on the next navigate-back.
+
+## Out of scope
+
+- **A2 — within-chapter sentence parallelism** → BACKLOG Could #21. Stacks on this plan; defer until measurement shows GPU headroom remains under default concurrency.
+- **A3 — both engines (Kokoro + XTTS) resident** → BACKLOG Could #22. Independent of chapter concurrency; speed gain conditional on mixed-engine casts.
+- **B1 — per-phase analyzer model** → plan 88 (parallel branch).
+- **C2/C3/C5 — frontend perf bundle** → plan 89 (parallel branch).
+
+## Ship notes
+
+_(filled when status flips to `stable` — shipped date, commit SHA, observed wall-clock delta on the canonical manuscript)_

--- a/docs/features/88-analyzer-per-phase-model.md
+++ b/docs/features/88-analyzer-per-phase-model.md
@@ -1,0 +1,73 @@
+---
+status: draft
+shipped: null
+owner: null
+---
+
+# Analyzer per-phase model selection with attribution warm-up
+
+> Status: draft
+> Key files: `server/src/analyzer/index.ts:106-210`, `server/src/analyzer/select-analyzer.ts`, `server/src/routes/analysis.ts:1323-1328`, `server/src/analyzer/rate-limit.ts:122`, `server/.env.example`, `docs/features/06-analyzer-gemini.md`
+> URL surface: indirect — `#/books/<id>/analysing`; SSE stream emitted by `POST /api/books/:bookId/analyse`
+> OpenAPI ops: none — env-var driven
+
+## Benefit / Rationale
+
+- **User:** improves attribution accuracy on the harder reasoning task (Phase 1 — speaker attribution per sentence) by using a smarter model (`gemini-3.1-flash-lite`) for the bulk of the book, while keeping the first W chapters of Phase 1 anchored to the same model that built the roster (`gemma-4-31b-it`). This cuts the worst-case **cross-model attribution drift** — early-book misattributions that compound — without eliminating it. Per [feedback_warmup_window_for_model_splits], the warm-up window is a MUST when swapping models mid-book.
+- **Technical:** quota effectively doubled. Phase 0 (`gemma-4-31b-it`, 1,500 RPD bucket, no TPM cap) and Phase 1 (`gemini-3.1-flash-lite`, 500 RPD bucket) run against independent rate-limit buckets that `server/src/analyzer/rate-limit.ts:122` already supports. Phase 0's load can't starve Phase 1 (and vice versa). Phase 1 is `STAGE2_STRETCH = 5.0` × the wall-clock of Phase 0 (`server/src/routes/analysis.ts:453`) per chapter, so optimising the smarter model on attribution is the bigger lever.
+- **Architectural:** introduces a per-phase analyzer selection seam (`selectAnalyzerForPhase`). The seam is the prerequisite for both BACKLOG Could #23 (speculative per-chapter Phase 1 / B2) and BACKLOG Could #24 (per-call local→Gemini overflow / B4).
+
+## Architectural impact
+
+- **New seam:** `selectAnalyzerForPhase(phase, chapterIndex, opts)` returning the chosen `Analyzer` instance per three env knobs:
+  - `ANALYZER_PHASE0_MODEL` — default `gemma-4-31b-it`.
+  - `ANALYZER_PHASE1_MODEL` — default `gemini-3.1-flash-lite` (used only after the warm-up window).
+  - `ANALYZER_PHASE1_WARMUP_CHAPTERS` — default `10`. Set to `0` to force-split from chapter 1.
+- **Threading:** chapter index flows from the Phase 1 worker into the analyzer selection so each chapter's dispatch picks the right model. Phase 0a workers always use the Phase-0 model; Phase 1 workers with `chapterIndex < W` use the Phase-0 model (warm-up); Phase 1 workers with `chapterIndex >= W` use the Phase-1 model.
+- **Rate-limit buckets** at `server/src/analyzer/rate-limit.ts:122` are already keyed per model — no changes needed; concurrent warm-up + post-warm-up calls don't compete.
+- **Migration:** legacy single-model `ANALYZER=<engine>` env keeps working when none of the three new vars are set. Fall-through resolution: if `ANALYZER_PHASE{0,1}_MODEL` unset, both phases use today's `ANALYZER`-selected analyzer (Gemini / local / manual / fallback).
+- **Reversibility:** unset the three new env vars to revert to today's single-model behaviour.
+
+## Invariants to preserve
+
+- Plan 04 SSE event shape unchanged (analysing-view consumer doesn't care which model produced a chunk).
+- Plan 06 manual handoff flow at `server/src/routes/analysis.ts:2031-2055` (Phase 0 → Phase 1 phase gate) UNTOUCHED — this plan only changes which analyzer Phase 1 dispatches to, not when Phase 1 starts.
+- Plan 29 local-Ollama analyzer + fallback path unchanged. When `ANALYZER=local` is set, `selectAnalyzerForPhase` returns the Ollama analyzer for both phases unless a phase-model override is set. The `FallbackAnalyzer` Gemini-on-`LocalUnreachableError` route at `server/src/analyzer/index.ts:159-210` continues to wrap the selected analyzer.
+- Per [feedback_warmup_window_for_model_splits]: the 10-chapter warm-up is the default — anchors attribution to the roster-author model first. Without it, the first 10 chapters' attribution may drift from the roster's interpretive baseline.
+
+## Test plan
+
+### Automated coverage
+
+- Vitest server (`server/src/analyzer/select-analyzer.test.ts`):
+  - (a) Phase 0a always returns the Phase-0 analyzer regardless of chapterIndex.
+  - (b) Phase 1 chapter 0 returns the Phase-0 analyzer (warm-up window active).
+  - (c) Phase 1 chapter `W` (default 10) returns the Phase-1 analyzer (boundary case).
+  - (d) `ANALYZER_PHASE1_WARMUP_CHAPTERS=0` makes Phase 1 chapter 0 already pick the Phase-1 model.
+  - (e) Limiter counters split correctly when both models are in flight simultaneously (Phase 0a on gemma + Phase 1 chapter 20 on gemini-3.1-flash-lite); two independent buckets advance without cross-decrement.
+  - (f) Legacy single-model `ANALYZER=…` env keeps working when none of the new vars are set (regression).
+- Vitest server (`server/src/routes/analysis.test.ts`) — threads chapterIndex into the Phase 1 dispatch and asserts the right analyzer is invoked per chapter.
+
+### Manual acceptance walkthrough
+
+1. **Pre-reboot baseline** per [feedback_reboot_before_perf_baselines]: reboot; record telemetry for a `ANALYZER=gemini` single-model run on `C:\Users\dudar\Downloads\Bonus Keefe Story.txt` (chapter count, per-phase wall-clock, RPM/TPM usage).
+2. **Default-split run:** unset `ANALYZER_PHASE0_MODEL` / `ANALYZER_PHASE1_MODEL` / `ANALYZER_PHASE1_WARMUP_CHAPTERS` → all defaults apply. Re-run analysis. Verify telemetry shows:
+   - Phase 0a uses gemma only.
+   - Phase 1 chapters 0–9 use gemma (warm-up).
+   - Phase 1 chapter 10+ uses gemini-3.1-flash-lite.
+   - Quota counters in `rate-limit.ts` split correctly across the two model buckets (no cross-decrement).
+3. **Attribution spot-check:** sample chapters 1, 10, and 25 attribution against the prior single-model baseline; verify chapter-10 attribution remains coherent across the W-boundary (no abrupt name-resolution shift).
+4. **Force-split:** set `ANALYZER_PHASE1_WARMUP_CHAPTERS=0`; verify chapter 0 of Phase 1 already on gemini-3.1-flash-lite.
+5. **Legacy fallback:** unset all three new vars; `ANALYZER=gemini`; verify behaviour identical to today's single-model run.
+
+## Out of scope
+
+- **B2 — speculative per-chapter Phase 1** (drop the global roster gate) → BACKLOG Could #23. High regression surface; depends on this plan shipping first.
+- **B4 — per-call local→Gemini overflow** (route partial load when local is slow, not just unreachable) → BACKLOG Could #24. Different from this plan: per-call not per-phase.
+- **B3 — bump `STAGE2_CONCURRENCY`** — env-var tweak only; not a structural change. May be folded into this plan during implementation if the limiter handles the burst cleanly, otherwise punted to a follow-up.
+- **A1 — parallel chapter synthesis** → plan 87 (parallel branch).
+- **C2/C3/C5 — frontend perf bundle** → plan 89 (parallel branch).
+
+## Ship notes
+
+_(filled when status flips to `stable` — shipped date, commit SHA, observed quota / attribution delta on the canonical manuscript)_

--- a/docs/features/89-frontend-perf-pass.md
+++ b/docs/features/89-frontend-perf-pass.md
@@ -1,0 +1,65 @@
+---
+status: draft
+shipped: null
+owner: null
+---
+
+# Frontend perf pass — broadcast diffing + selector equality + route code-split
+
+> Status: draft
+> Key files: `src/store/broadcast-middleware.ts:171-189`, `src/store/index.ts:151`, `src/views/listen.tsx:121`, `src/lib/icons.tsx`, `vite.config.ts`
+> URL surface: indirect — every routed view (lazy boundaries appear at first navigation)
+> OpenAPI ops: none
+
+## Benefit / Rationale
+
+Three independent micro-optimisations on the frontend that share a deployment shape (one PR, one risk surface). Each item is ~half a day; bundling avoids three separate review cycles for ~1 day of work total.
+
+- **User (C2):** idle tabs stop receiving 10+ KB messages per analyzer tick — long-running analysis becomes invisible to other tabs of the same workspace. Matters most for the concurrent-multi-book workflow ([project_concurrent_multibook_workflow]) where a user might keep three tabs open on three different books.
+- **User (C3):** Listen view stops re-rendering on unrelated book's export-state changes — relevant in the same multi-book workflow. Today a tick on Book B's export queue forces a re-render of Book A's Listen view.
+- **User (C5):** faster initial paint, especially on cold mobile loads (per plan 81 — mobile + tablet support). Route-level splitting means the library view doesn't pay the cost of the manuscript-editor bundle.
+- **Technical:** locks in three patterns (shallow-diff broadcasts, selector equality wrappers, React.lazy boundaries) that future frontend work can replicate without re-deciding.
+
+## Architectural impact
+
+- **C2 — Broadcast middleware diffing (`src/store/broadcast-middleware.ts:171-189`):** replace full `activeStream` snapshots with shallow-diffed payloads. Skip broadcasting when only `phaseProgress` numbers ticked (debounce). The recipient applies the diff onto its local snapshot.
+- **C3 — Selector equality (`src/store/index.ts:151`):** add a `shallowEqual` wrapper for `useAppSelector` and apply to the top-5 large-slice readers. Primary offender: `src/views/listen.tsx:121` reading `s.exports.byBookId[bookId]`. NOT a codebase sweep — five targeted sites, audited during implementation.
+- **C5 — Route code-split (`src/routes/`, `src/lib/icons.tsx`, `vite.config.ts`):** lazy-import `src/views/*.tsx` via `React.lazy`; split `src/lib/icons.tsx` by view-area. Single shared Suspense fallback in the layout shell — flash-of-spinner risk on first nav per route; we mitigate by mounting the fallback only after a ~150 ms delay (no flash for cached routes).
+- **Migration:** none — all three changes are runtime-only.
+- **Reversibility:** each item is independently revert-able (single import-shape change + slice middleware change + Vite chunk config change).
+
+## Invariants to preserve
+
+- **Plan 63 narrow-scope BroadcastChannel rule:** only `activeStream` slots — never per-chapter rows / cast / manuscript. The C2 diff implementation operates inside that scope (diff over `activeStream`'s sub-fields), not extending it.
+- **Plan 23 mock toggle:** mock layer unaffected (C2/C3/C5 are all post-API).
+- **Plan 27 single-user-per-workspace contract:** preserved — BroadcastChannel is still echo-suppressed via per-tab `instanceId` tag + inbound-action allowlist (plan 63).
+- **[project_concurrent_multibook_workflow]:** preserved and improved — multi-book tabs see lower message volume + fewer re-renders, but cross-tab pill state remains live.
+- **Plan 81 mobile budget:** route splitting helps mobile cold-loads (compatible direction).
+
+## Test plan
+
+### Automated coverage
+
+- Vitest frontend (`src/store/broadcast-middleware.test.ts`) — asserts: (a) shallow-diff payload omits unchanged fields; (b) debounce collapses N phaseProgress-only ticks in <T ms into one broadcast; (c) recipient's local snapshot equals the sender's snapshot after diff-apply; (d) plan 63 scope rule still enforced (non-`activeStream` actions never broadcast).
+- Vitest frontend (`src/store/index.test.ts` or per-view) — asserts: (a) `useAppSelector` with `shallowEqual` doesn't re-render when an unrelated key changes; (b) the top-5 offender call sites use the wrapper.
+- Playwright e2e (`e2e/concurrent-multi-book.spec.ts`, new) — opens two tabs (Book A in tab 1, Book B in tab 2), starts Book A analysis, asserts Book B's Listen view does NOT re-render in response to Book A's analyser ticks (component instance counter, render-count probe, or DOM-mutation observer).
+- Playwright e2e (`e2e/route-lazy.spec.ts`, new) — asserts first navigation to `#/books/<id>/listen` shows the shared Suspense fallback briefly; second navigation does not (cached).
+
+### Manual acceptance walkthrough
+
+1. **Multi-book idle-tab test:** open two tabs on different books; start analysis on Book A; verify (via DevTools Performance / React Profiler) that Book B's tab issues zero re-renders against unrelated book state during the run.
+2. **Listen-view selector test:** open Book A's Listen view; queue an export on Book B (via mock mode or a second tab); verify Listen view's component-render counter doesn't tick when Book B's export progresses.
+3. **Cold-load timing:** Lighthouse the library route on a clean cache; the initial bundle should shrink by the size of the manuscript editor + cast view + listen view chunks. Mobile budget per plan 81 maintained.
+4. **Suspense flash:** navigate to a fresh route; the Suspense fallback should not flash for already-cached routes.
+
+## Out of scope
+
+- **C1 — Manuscript view virtualisation** → BACKLOG Should #1. Explicitly demoted from MUST in the survey — current feel is bearable, but >300 sentences during boundary drag is the next-priority frontend item.
+- **C4 — Confirm-cast + listen-chapter list virtualisation** → BACKLOG Could #25. Only matters above ~40 rows; depends on Should #1 to amortise the `@tanstack/react-virtual` dep.
+- **C6 — Waveform memoisation** → BACKLOG Could #26. Low real-world impact today.
+- **A1 — Parallel chapter synthesis** → plan 87 (parallel branch).
+- **B1 — Per-phase analyzer model** → plan 88 (parallel branch).
+
+## Ship notes
+
+_(filled when status flips to `stable` — shipped date, commit SHA, observed message-volume + render-count delta in the concurrent-multi-book scenario)_

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -50,6 +50,7 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 - [05 — Manual handoff analyzer](05-analyzer-manual-handoff.md) — `ANALYZER=manual` file-drop cowork loop.
 - [06 — Gemini analyzer](06-analyzer-gemini.md) — `ANALYZER=gemini` direct-API mode (also the fallback when local is unreachable).
 - [29 — Local Ollama analyzer + fallback](29-analyzer-ollama-local.md) — `ANALYZER=local` default; auto-fallback to Gemini only when daemon is unreachable.
+- [88 — Analyzer per-phase model](88-analyzer-per-phase-model.md) — Phase 0 / Phase 1 use independent models with a chapter-index warm-up window; `ANALYZER_PHASE{0,1}_MODEL` + `ANALYZER_PHASE1_WARMUP_CHAPTERS` env knobs; rate-limit buckets already per-model.
 - [07 — Audio tag vocabulary](07-audio-tag-vocabulary.md) — `[tag]` vocabulary UI ↔ parser sync.
 - [08 — Audio tag auto-detection](08-audio-tag-auto-detection.md) — Server-side auto-tagging from punctuation/markdown/HTML.
 
@@ -87,6 +88,7 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 - [31 — Sticky generation across navigation](31-sticky-generation.md) — Generation survives every navigation except an explicit Stop or queue drain; local-analyzer triggers prompt for pause-and-analyse when a run is alive.
 - [32 — Sticky analysis across navigation](32-sticky-analysis.md) — Analysis survives every navigation except `/pause` or `fresh:true` displacement; server-owned job + multi-subscriber catch-up replay; `AnalysisPill` in the top-bar mirrors the generation pill.
 - [35 — Per-chapter engine drift detection](35-engine-drift-detection.md) — Stamp each rendered chapter with its TTS engine; surface drift when the project's active engine differs.
+- [87 — Parallel chapter synthesis](87-parallel-chapter-synth.md) — Bounded worker pool over chapters via `GEN_CHAPTER_CONCURRENCY` (default 2); per-chapter SSE tracks; sidecar `/synthesize` already concurrent per plan 70d.
 
 ### H. Playback & listen
 
@@ -121,6 +123,7 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 - [44 — Pull request hygiene](44-pr-hygiene.md) — PR template + PR-title lint workflow + merge-commit-only / delete-branch-on-merge repo settings; codifies the Summary / Test plan shape PRs #1-#4 already use.
 - [85 — `wt-merge.mjs` reconciliation helper](85-wt-merge-helper.md) — One-command driver for CONTRIBUTING.md "Reconciliation pattern": cut `integration/<date>` off `main`, merge each agent branch in sequence, `npm run verify` between merges, abort on conflict (exit 2) or verify failure (exit 3) with a suggested follow-up that drops the offending branch. Idempotent re-runs; `--dry-run` previews the plan.
 - [86 — Live worktree dashboard](86-worktree-dashboard.md) — Dev-only `#/worktrees` view + `GET /api/worktrees` route. Lists every git worktree visible to `git worktree list --porcelain` with its branch, ports, and a live TCP probe of each VITE_PORT. Click a green row → opens that worktree's dev URL in a new tab. Top-bar `wt` chip gated on `import.meta.env.DEV`; server route 404s in production.
+- [89 — Frontend perf pass](89-frontend-perf-pass.md) — Broadcast-middleware diffing + `useAppSelector` shallowEqual sweep + `React.lazy` route splitting; preserves plan 63 narrow-scope BroadcastChannel rule.
 - [45 — Vitest pool tuning + one-retry policy](45-vitest-pool-tuning.md) — Caps the server-suite forks pool at 4 and turns on `retry: 1` on both Vitest configs so transient tinypool "Worker exited unexpectedly" failures no longer force a full pre-push re-run.
 - [46 — Lint, format, a11y baseline](archive/46-lint-format-a11y.md) — ESLint 8 + Prettier 3 + axe-core on four core views; lint prepended to `verify`. Shipped 2026-05-18.
 - [48 — Global toast surface](archive/48-toast-surface.md) — `notifications` slice + `<ToastStack/>`; stream-middleware halts + export 5xx dispatch through it; dedupe-by-key collapses repeats; auto-dismiss 6 s. Shipped 2026-05-18.


### PR DESCRIPTION
## Summary

Round 0 of the perf-tuning round locked in `~/.claude/plans/want-to-focus-this-bright-donut.md`. Docs-only — no code yet. Files the contracts for the three implementation branches that open after merge, plus seven BACKLOG entries for items the survey explicitly deferred.

- **`docs/features/87-parallel-chapter-synth.md`** (new, `status: draft`) — bounded `Promise.all` worker pool over chapters via `GEN_CHAPTER_CONCURRENCY` (default 2). Sidecar `/synthesize` is already concurrent per `test_concurrent_synthesis.py:214-244`; bottleneck is the orchestrator's sequential `for…await` at `generation.ts:485-530`. Per-chapter SSE tracks; stall watchdog stays per-chapter; plan 16 / 28 / 31 / 70d invariants preserved.
- **`docs/features/88-analyzer-per-phase-model.md`** (new, `status: draft`) — per-phase analyzer selection with chapter-index warm-up. Three env knobs (`ANALYZER_PHASE0_MODEL=gemma-4-31b-it`, `ANALYZER_PHASE1_MODEL=gemini-3.1-flash-lite`, `ANALYZER_PHASE1_WARMUP_CHAPTERS=10`) plug into a new `selectAnalyzerForPhase`. Rate-limit buckets at `rate-limit.ts:122` already per-model. Manual cowork flow at `analysis.ts:2031-2055` untouched. Legacy single-model `ANALYZER=…` env keeps working.
- **`docs/features/89-frontend-perf-pass.md`** (new, `status: draft`) — single-PR bundle of C2 (broadcast-middleware diffing + phaseProgress debounce), C3 (`useAppSelector` `shallowEqual` wrapper applied to top-5 large-slice readers), C5 (`React.lazy` route splitting + per-area icon split). Preserves plan 63 narrow-scope BroadcastChannel rule.
- **`docs/BACKLOG.md`** — Should #1 (Manuscript view virtualisation, C1, explicitly demoted from MUST in survey); Could #21–#26 (A2 within-chapter sentence parallelism, A3 both engines resident, B2 speculative per-chapter Phase 1, B4 per-call local→Gemini overflow, C4 confirm-cast + listen-chapter virtualisation, C6 waveform memoisation). All appended at bottom of their respective buckets.
- **`docs/features/INDEX.md`** — three new single-line entries: 87 under G. Generation, 88 under C. Analysis pipeline, 89 under K. Cross-cutting invariants.

Mirrors the `e8366b5` (plan 81 Round 0) precedent. `npm run verify` is fully `[cached]` since no source code is touched.

After merge: three feature branches open in parallel worktrees per the locked direction — `perf/server-parallel-chapters`, `perf/server-analyzer-phase-split`, `perf/frontend-selectors-and-broadcast`. Scopes audited as non-overlapping. A Round 4 (A2 / C1) is optional, gated on measurement from Rounds 1–3.

## Test plan

- [x] `npm run verify` green locally — all steps `[cached]` (docs-only diff).
- [x] Pre-commit hook accepted the commit (`verify:fast` cached).
- [x] Pre-push hook accepted the push (`verify` cached).
- [ ] CI Verify on the PR turns green.
- [ ] PR title-lint workflow accepts the `docs(docs):` subject.
- [ ] User reviews the three plan skeletons + seven BACKLOG entries before merge; once approved, merge unlocks Rounds 1–3 in parallel worktrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)