### PR TITLE
fix(server): voice chapter titles + insert silence between chapters

### DIFF
--- a/docs/features/28-chapter-audio-format.md
+++ b/docs/features/28-chapter-audio-format.md
@@ -1,10 +1,10 @@
 # Audio output format (MP3 VBR V2)
 
 > Status: stable
-> Key files: `server/src/tts/mp3.ts`, `server/src/workspace/chapter-audio-file.ts`, `server/src/routes/generation.ts`, `server/src/routes/chapter-audio.ts`, `server/src/routes/voice-sample.ts`, `scripts/start-app.ps1`
+> Key files: `server/src/tts/mp3.ts`, `server/src/tts/synthesise-chapter.ts`, `server/src/tts/chapter-title-narration.ts`, `server/src/workspace/chapter-audio-file.ts`, `server/src/routes/generation.ts`, `server/src/routes/chapter-audio.ts`, `server/src/routes/voice-sample.ts`, `scripts/start-app.ps1`
 > URL surface: `GET /api/books/:bookId/chapters/:chapterId/audio`, `GET …/audio.mp3`, `POST /api/voices/:voiceId/sample`
 > OpenAPI ops: `ChapterAudio` (`openapi.yaml`) — `url` is `…/audio.mp3`; `getVoiceSample` returns a URL under `/audio/voices/`.
-> Paired tests: `server/src/tts/mp3.test.ts`, `server/src/tts/pcm.test.ts`, `server/src/workspace/chapter-audio-file.test.ts`, `server/src/routes/chapter-audio.test.ts`, `server/src/routes/voice-sample.test.ts`
+> Paired tests: `server/src/tts/mp3.test.ts`, `server/src/tts/pcm.test.ts`, `server/src/tts/chapter-title-narration.test.ts`, `server/src/tts/synthesise-chapter.test.ts`, `server/src/workspace/chapter-audio-file.test.ts`, `server/src/routes/chapter-audio.test.ts`, `server/src/routes/voice-sample.test.ts`
 > Cross-links: [16 — Generation stream](16-generation-stream.md), [10 — Profile drawer](10-profile-drawer.md), [archive/39 — Purge WAV](archive/39-purge-wav.md)
 
 ## What this covers
@@ -35,6 +35,27 @@ chapter through the UI if they need playback.
 
 ### Chapter audio
 
+- Each chapter MP3 opens with **1.5 s of silence**, then the narrator
+  speaks a constructed title narration (e.g. `'Chapter 2. Moolark.'`)
+  built from `chapter.id` + parsed `chapter.title` via
+  `buildChapterTitleNarration` (`server/src/tts/chapter-title-narration.ts`),
+  then **1.5 s of silence**, then the chapter body. The narration is
+  re-emitted from the parsed title pieces so the listener hears a clean
+  two-clause utterance regardless of how the source manuscript
+  punctuated its heading. Bare-name titles ("Prologue", "Day One",
+  "Moolark") are spoken verbatim with no auto-injected `Chapter N`
+  prefix — front-matter stays front-matter. Empty/whitespace titles
+  fall back to `"Chapter <id>."` so every chapter still gets a header
+  beat.
+- The title's TTS response anchors the chapter's sample rate (same
+  invariant that previously applied to the first body group). Body
+  groups at a mismatched rate are resampled to the title anchor.
+- `segments[0].kind === 'title'` marks the title segment in
+  `segments.json`. Body segments leave `kind` undefined. Title segments
+  are filtered out of the `ChapterAudio` API response (`url`/`peaks`/
+  `segments`) — the OpenAPI contract types `sentenceId` as a required
+  integer and title segments have an empty `sentenceIds[]`. On-disk
+  retention lets the writer audit + future timeline UI opt in.
 - Every newly-generated chapter lands on disk as `<slug>.mp3`. The MPEG
   frames are MPEG-2 Layer III mono at the sidecar's native sample rate.
 - `<slug>.mp3.tmp-<pid>-<ts>` is the atomic-write temp path; `rename(2)`
@@ -96,8 +117,12 @@ Run with `VITE_USE_MOCKS=false`, sidecar up, ffmpeg on PATH.
 6. `ffprobe <slug>.mp3` reports `Audio: mp3, 24000 Hz, mono`, bitrate
    ≈ 140–185 kbps VBR, duration close to `state.json` chapter duration.
 7. MiniPlayer plays the chapter, seeks past the midpoint without glitches.
-   Network panel: `GET …/audio` returns 200 JSON; `GET …/audio.mp3` with a
-   `Range` header returns 206.
+   The chapter opens with 1.5 s of silence, the narrator announces the
+   chapter (e.g. `"Chapter 1."` or `"Chapter 2. Moolark."`), then 1.5 s
+   of silence, then the body begins. Listener can audibly distinguish
+   the chapter boundary across the chapter-1 → chapter-2 hand-off.
+   Network panel: `GET …/audio` returns 200 JSON; `GET …/audio.mp3`
+   with a `Range` header returns 206.
 8. (Optional) change a voice assignment for one character and re-generate
    chapter 1. The new MP3 replaces the old one atomically — no half-file
    ever observable on disk, the file size and `state.json` duration update,
@@ -116,8 +141,11 @@ rather than inventing new fixtures.
 - AAC/M4A or Opus output. The encoder boundary in `encodePcmToMp3` is
   small enough that swapping `libmp3lame` for `aac`/`libopus` is the only
   change needed; left for a future PR with a deliberate codec choice.
-- Gapless concatenation across chapters. Each chapter is independent;
-  inter-chapter playback is the player's concern.
+- Configurable silence durations per book or per cast preference. Today
+  the 1.5 s leading + 1.5 s post-title constants live next to
+  `synthesiseChapter` (`server/src/tts/synthesise-chapter.ts`). The
+  inter-chapter break itself is no longer the player's concern — the
+  producer now bakes the leading pause into each chapter file.
 - Sidecar-side encoding. The PCM wire protocol is intentionally lossless
   to keep the Python boundary simple; revisit only if Node-side encoding
   becomes a measurable bottleneck.

--- a/server/src/routes/chapter-audio.ts
+++ b/server/src/routes/chapter-audio.ts
@@ -105,6 +105,14 @@ interface ChapterSegmentsFile {
     sentenceIds: number[];
     startSec: number;
     endSec: number;
+    /** `'title'` on the synthetic narrator-voiced chapter-title segment
+        (see `synthesise-chapter.ts`). Filtered out before publishing to
+        the `ChapterAudio` API segments[] because the wire contract types
+        `sentenceId` as a required integer and title segments have an
+        empty sentenceIds[]. The on-disk record stays so the writer can
+        audit / future UI can opt in to rendering the title beat on the
+        timeline. */
+    kind?: 'title';
   }>;
   /** Per-character voice snapshot captured at synthesis time. Read by the
       revisions route to surface drift. Older segments files (pre-snapshot
@@ -197,13 +205,17 @@ chapterAudioRouter.get(
     /* On-disk segments use `startSec/endSec/sentenceIds[]` (per-group). The
      ChapterAudio contract publishes `start/end/sentenceId` (singular) — map
      each group to one outward segment, using the group's first sentence id
-     as the representative. */
-    const segments = (meta?.segments ?? []).map((s) => ({
-      start: s.startSec,
-      end: s.endSec,
-      characterId: s.characterId,
-      sentenceId: s.sentenceIds[0],
-    }));
+     as the representative. Filter out title segments (`kind === 'title'`)
+     so the wire shape stays clean: title segments have an empty sentenceIds[]
+     and the OpenAPI contract types sentenceId as a required integer. */
+    const segments = (meta?.segments ?? [])
+      .filter((s) => s.kind !== 'title')
+      .map((s) => ({
+        start: s.startSec,
+        end: s.endSec,
+        characterId: s.characterId,
+        sentenceId: s.sentenceIds[0],
+      }));
     /* Plan 56: surface the real 240-bin RMS peaks emitted at encode time.
        Missing file → `[]`, preserving the pre-plan-56 contract so chapters
        generated before this plan keep loading and the Listen view falls
@@ -238,12 +250,14 @@ chapterAudioRouter.get(
     const found = await locateChapterAudio(req.params.bookId, req.params.chapterId, 'previous');
     if (!found) return res.status(404).json({ message: 'No preserved previous audio.' });
     const meta = await readJson<ChapterSegmentsFile>(found.segPath);
-    const segments = (meta?.segments ?? []).map((s) => ({
-      start: s.startSec,
-      end: s.endSec,
-      characterId: s.characterId,
-      sentenceId: s.sentenceIds[0],
-    }));
+    const segments = (meta?.segments ?? [])
+      .filter((s) => s.kind !== 'title')
+      .map((s) => ({
+        start: s.startSec,
+        end: s.endSec,
+        characterId: s.characterId,
+        sentenceId: s.sentenceIds[0],
+      }));
     /* Plan 56: the preserved audition variant has no peaks writer today
        (rollback preservation does not move peaks alongside the audio +
        segments pair). `readPeaksOrEmpty` therefore typically returns `[]`

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -57,6 +57,7 @@ import {
   type CastCharacter,
   type ChapterSegment,
 } from '../tts/synthesise-chapter.js';
+import { buildChapterTitleNarration } from '../tts/chapter-title-narration.js';
 import { describeSynthesisError, newCascadeState, recordNonFatal } from './generation-error.js';
 
 export const generationRouter = Router();
@@ -482,6 +483,13 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
     broadcast(job, { type: 'progress', ...initialTick });
 
     try {
+      /* Build the spoken chapter-title phrase from chapter.id + chapter.title.
+         Returns null only when both inputs are unusable (defensive — every
+         confirmed chapter has at least an id), in which case `?? undefined`
+         lets `synthesiseChapter` skip the title beat the same way it does
+         for callers that haven't opted in. */
+      const chapterTitleNarration =
+        buildChapterTitleNarration({ id: chapter.id, title: chapter.title }) ?? undefined;
       const result = await synthesiseChapter({
         sentences,
         cast: cast.characters,
@@ -489,6 +497,23 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
         modelKey,
         engine,
         signal: controller.signal,
+        chapterTitleNarration,
+        narratorCharacterId: 'narrator',
+        /* Title-beat ticks so the SSE stream doesn't go silent while the
+           pre-body title synth runs (Coqui can take a couple of seconds for
+           a short phrase, the stall detector fires at 30 s). currentLine: 0
+           keeps the UI's "line N of M" caption at the pre-body state. */
+        onTitleStart: () => {
+          const tick = {
+            chapterId: chapter.id,
+            characterId: 'narrator',
+            progress: 0.005,
+            currentLine: 0,
+            totalLines,
+          };
+          job.lastProgressTick = tick;
+          broadcast(job, { type: 'progress', ...tick });
+        },
         /* Tick AT THE START of each group so the client's 30s "Worker has
            gone quiet" stall detector resets even when a single group is a
            multi-minute synth call (long narrator block on CPU XTTS).

--- a/server/src/tts/chapter-title-narration.test.ts
+++ b/server/src/tts/chapter-title-narration.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { buildChapterTitleNarration } from './chapter-title-narration.js';
+
+describe('buildChapterTitleNarration', () => {
+  it.each<[string, { id: number; title: string | null | undefined }, string | null]>([
+    /* Parser's combined-form output → clean two-clause utterance. */
+    ['Chapter N + em-dash + name', { id: 3, title: 'Chapter 3 — The Beginning' }, 'Chapter 3. The Beginning.'],
+    ['Chapter N + colon + name', { id: 3, title: 'Chapter 3: The Beginning' }, 'Chapter 3. The Beginning.'],
+    ['Chapter N + en-dash + name', { id: 3, title: 'Chapter 3 – The Beginning' }, 'Chapter 3. The Beginning.'],
+    ['Chapter N + ASCII hyphen + name', { id: 3, title: 'Chapter 3 - The Beginning' }, 'Chapter 3. The Beginning.'],
+    ['Chapter N alone', { id: 5, title: 'Chapter 5' }, 'Chapter 5.'],
+    ['Chapter N with trailing colon only', { id: 5, title: 'Chapter 5:' }, 'Chapter 5.'],
+
+    /* Bare-name titles — speak verbatim, do NOT auto-inject Chapter N. */
+    ['Prologue', { id: 1, title: 'Prologue' }, 'Prologue.'],
+    ['Day One (parsed casing)', { id: 1, title: 'Day One' }, 'Day One.'],
+    ['DAY ONE (decoration-stripped)', { id: 1, title: 'DAY ONE' }, 'DAY ONE.'],
+    ['Moolark (bare name)', { id: 2, title: 'Moolark' }, 'Moolark.'],
+
+    /* Alternate chapter-prefix vocabulary. */
+    ['Part N + name', { id: 2, title: 'Part 2: Beyond' }, 'Part 2. Beyond.'],
+    ['Book N + name', { id: 4, title: 'Book 4 — The Reckoning' }, 'Book 4. The Reckoning.'],
+    ['Ch. abbreviated form', { id: 7, title: 'Ch. 7: The Crossing' }, 'Ch. 7. The Crossing.'],
+
+    /* Roman numerals + spelled-out forms. */
+    ['Chapter IV alone', { id: 4, title: 'Chapter IV' }, 'Chapter IV.'],
+    ['Chapter Two — spelled', { id: 2, title: 'Chapter Two — Moolark' }, 'Chapter Two. Moolark.'],
+
+    /* Defensive fallbacks. */
+    ['Empty string falls back to id', { id: 7, title: '' }, 'Chapter 7.'],
+    ['Whitespace-only falls back to id', { id: 7, title: '   ' }, 'Chapter 7.'],
+    ['Null title falls back to id', { id: 7, title: null }, 'Chapter 7.'],
+    ['Undefined title falls back to id', { id: 7, title: undefined }, 'Chapter 7.'],
+
+    /* Pathological — no usable id AND no usable title → null so caller skips
+       the title beat entirely rather than emitting "Chapter NaN." */
+    ['Both id and title missing returns null', { id: Number.NaN, title: '' }, null],
+  ])('%s', (_label, input, expected) => {
+    expect(buildChapterTitleNarration(input)).toBe(expected);
+  });
+});

--- a/server/src/tts/chapter-title-narration.ts
+++ b/server/src/tts/chapter-title-narration.ts
@@ -1,0 +1,53 @@
+/* Build the spoken phrase the narrator says at the top of each chapter.
+
+   The display title on disk (set by `server/src/parsers/text.ts:284–304`)
+   co-encodes the chapter number and an optional name into one string via
+   `:` / `—` / `–` / `-` separators — e.g. "Chapter 3 — The Beginning" or
+   "Chapter 2". The narrator must speak number and name as a clean
+   two-clause utterance ("Chapter 3. The Beginning.") rather than reading
+   the punctuation aloud. This module re-emits the title as TTS-friendly
+   prose; the caller in `synthesise-chapter.ts` then prepends one TTS call
+   with this string spoken by the narrator voice. */
+
+const CHAPTER_PREFIX_AND_NUMBER = (() => {
+  const word = '(?:Chapter|Ch\\.?|Part|Book)';
+  const arabic = '\\d+';
+  const roman = '[IVXLCDM]+';
+  const spelled =
+    '(?:One|Two|Three|Four|Five|Six|Seven|Eight|Nine|Ten|Eleven|Twelve|Thirteen|Fourteen|Fifteen|Sixteen|Seventeen|Eighteen|Nineteen|Twenty)';
+  const num = `(?:${arabic}|${roman}|${spelled})`;
+  const sep = '\\s*[:\\-–—]\\s*';
+  return new RegExp(`^(${word}\\s+${num})(?:${sep}(.+))?$`, 'i');
+})();
+
+/* Trailing separator/whitespace stripper. A parser output like "Chapter 5:"
+   (the author wrote `Chapter 5:` followed by an empty subtitle line) should
+   render as "Chapter 5." — without this, the regex below treats the trailing
+   colon as bare-name content and emits "Chapter 5:." which TTS reads as
+   "Chapter five colon period." */
+const TRAILING_SEPARATORS = /[\s:\-–—]+$/;
+
+export function buildChapterTitleNarration(chapter: {
+  id: number;
+  title: string | null | undefined;
+}): string | null {
+  const raw = (chapter.title ?? '').trim().replace(TRAILING_SEPARATORS, '');
+  if (!raw) {
+    if (!Number.isFinite(chapter.id)) return null;
+    return `Chapter ${chapter.id}.`;
+  }
+
+  const m = CHAPTER_PREFIX_AND_NUMBER.exec(raw);
+  if (m) {
+    const chapterPart = m[1].trim();
+    const namePart = m[2]?.trim();
+    return namePart ? `${chapterPart}. ${namePart}.` : `${chapterPart}.`;
+  }
+
+  /* Manuscript labelled this chapter purely by name (e.g. "Prologue",
+     "Day One", "Moolark"). Speak it verbatim — do NOT auto-inject
+     "Chapter N." because that mispronounces front-matter like Prologue
+     as "Chapter 1. Prologue." The user can rename the chapter via the
+     existing rename UI if they want a numbered announcement. */
+  return `${raw}.`;
+}

--- a/server/src/tts/synthesise-chapter.test.ts
+++ b/server/src/tts/synthesise-chapter.test.ts
@@ -608,6 +608,177 @@ describe('synthesiseChapter auto-retry on transient TTS failures', () => {
   });
 });
 
+/* ── Chapter-title beat + leading/trailing silence ───────────────────
+   Production bug: chapter titles were never voiced and chapters
+   concatenated gaplessly. The synth path now prepends
+   `[1.5s silence] + [narrator voicing the title] + [1.5s silence]`
+   when the caller supplies a `chapterTitleNarration`. These tests pin
+   the contract: title is narrator-voiced, silences bracket it at the
+   title's sample rate, body segments stay monotonic after the prepend,
+   and the legacy no-title path keeps the original zero-padding shape. */
+describe('synthesiseChapter chapter-title beat', () => {
+  it('prepends a narrator-voiced title segment with leading + trailing silence', async () => {
+    const cast: CastCharacter[] = [
+      { id: 'narrator', name: 'Narrator', attributes: ['observational'] },
+      { id: 'keefe', name: 'Keefe', gender: 'male', attributes: ['witty'] },
+    ];
+    const provider = makeProvider();
+
+    const result = await synthesiseChapter({
+      sentences: [sentence(1, 'keefe', 'Body line one.')],
+      cast,
+      provider,
+      modelKey: 'gemini-2.5-flash',
+      engine: 'gemini',
+      chapterTitleNarration: 'Chapter 2. Moolark.',
+    });
+
+    /* Two provider calls: title first, then body. The title's voiceName
+       comes from the narrator bucket — confirms the narrator routing
+       runs for the synthetic title beat the same way it runs for the
+       narrator's own sentences. */
+    expect(provider.calls).toHaveLength(2);
+    expect(provider.calls[0].text).toBe('Chapter 2. Moolark.');
+    expect(GEMINI_NARRATOR_VOICES, `title voiced by ${provider.calls[0].voiceName}`).toContain(
+      provider.calls[0].voiceName,
+    );
+
+    /* Title segment lands first with kind: 'title', empty sentenceIds[],
+       and starts AFTER the 1.5s leading silence. */
+    expect(result.segments[0].kind).toBe('title');
+    expect(result.segments[0].characterId).toBe('narrator');
+    expect(result.segments[0].sentenceIds).toEqual([]);
+    expect(result.segments[0].startSec).toBeCloseTo(1.5, 3);
+
+    /* Body segment starts AFTER the title beat + the 1.5s post-title
+       silence. The fake provider returns a 1-sample (≈ 41.7 µs at
+       24 kHz) PCM for the title, so titleEndSec ≈ 1.5 + 0.0000417 and
+       body startSec ≈ 1.5 + 0.0000417 + 1.5 ≈ 3.0. */
+    expect(result.segments[1].kind).toBeUndefined();
+    expect(result.segments[1].characterId).toBe('keefe');
+    expect(result.segments[1].startSec).toBeCloseTo(3.0, 2);
+  });
+
+  it('skips the title beat AND silence when chapterTitleNarration is empty/blank', async () => {
+    /* Legacy path: callers that don't opt in get the original zero-padding
+       shape. Body segment starts at t=0 exactly. */
+    const cast: CastCharacter[] = [
+      { id: 'narrator', name: 'Narrator', attributes: ['observational'] },
+    ];
+    const provider = makeProvider();
+
+    const result = await synthesiseChapter({
+      sentences: [sentence(1, 'narrator', 'Body only.')],
+      cast,
+      provider,
+      modelKey: 'gemini-2.5-flash',
+      engine: 'gemini',
+      chapterTitleNarration: '   ',
+    });
+
+    expect(provider.calls).toHaveLength(1);
+    expect(result.segments).toHaveLength(1);
+    expect(result.segments[0].startSec).toBe(0);
+    expect(result.segments[0].kind).toBeUndefined();
+  });
+
+  it('anchors the chapter sample rate on the title response (Kokoro/Coqui co-cast with title)', async () => {
+    /* When a title is prepended, the title's sampleRate becomes the chapter
+       anchor — NOT the first body group's. Pin: title at 24 kHz, body at
+       22.05 kHz → the final concatenated buffer stays at 24 kHz throughout
+       (the body group gets resampled). Catches a future refactor that
+       accidentally lets the body loop re-anchor mid-chapter. */
+    const cast: CastCharacter[] = [
+      { id: 'narrator', name: 'Narrator', attributes: ['observational'] },
+      { id: 'elwin', name: 'Elwin', gender: 'male', attributes: ['caring'] },
+    ];
+    let callIndex = 0;
+    const provider: TtsProvider = {
+      async synthesize(_input: SynthesizeInput): Promise<SynthesizeOutput> {
+        const sampleRate = callIndex++ === 0 ? 24000 : 22050;
+        const pcm = Buffer.alloc(10 * 2);
+        for (let i = 0; i < 10; i++) pcm.writeInt16LE(1000 + i * 100, i * 2);
+        return { pcm, sampleRate, mimeType: 'audio/pcm' };
+      },
+    };
+
+    const result = await synthesiseChapter({
+      sentences: [sentence(1, 'elwin', 'Body line at a mismatched rate.')],
+      cast,
+      provider,
+      modelKey: 'gemini-2.5-flash',
+      engine: 'gemini',
+      chapterTitleNarration: 'Chapter 1.',
+    });
+
+    expect(result.sampleRate).toBe(24000);
+    /* Two segments: title (kind: 'title') + one body group. Both timed
+       against the 24 kHz anchor. */
+    expect(result.segments).toHaveLength(2);
+    expect(result.segments[0].kind).toBe('title');
+    expect(result.segments[1].startSec).toBeGreaterThanOrEqual(result.segments[0].endSec);
+  });
+
+  it('fires onTitleStart and onTitleComplete around the title synth call', async () => {
+    const cast: CastCharacter[] = [
+      { id: 'narrator', name: 'Narrator', attributes: ['observational'] },
+    ];
+    const events: string[] = [];
+    const provider: TtsProvider = {
+      async synthesize(input: SynthesizeInput): Promise<SynthesizeOutput> {
+        events.push(`synth:${input.text}`);
+        return { pcm: Buffer.alloc(2), sampleRate: 24000, mimeType: 'audio/pcm' };
+      },
+    };
+
+    await synthesiseChapter({
+      sentences: [sentence(1, 'narrator', 'Body.')],
+      cast,
+      provider,
+      modelKey: 'gemini-2.5-flash',
+      engine: 'gemini',
+      chapterTitleNarration: 'Chapter 1.',
+      onTitleStart: () => events.push('title-start'),
+      onTitleComplete: ({ accumulatedSec }) => events.push(`title-complete:${accumulatedSec > 1 ? 'past-leading-silence' : 'too-early'}`),
+    });
+
+    /* Ordering: onTitleStart fires BEFORE the title synth (so the SSE
+       stall timer resets), onTitleComplete fires AFTER. Body synth
+       follows. The accumulatedSec at title-complete must be past the
+       1.5 s leading silence — sanity-check that the silence padding
+       actually contributed to runningBytes. */
+    expect(events[0]).toBe('title-start');
+    expect(events[1]).toBe('synth:Chapter 1.');
+    expect(events[2]).toBe('title-complete:past-leading-silence');
+    expect(events[3]).toBe('synth:Body.');
+  });
+
+  it('uses the fallback narrator hint when the cast has no narrator row', async () => {
+    /* Defensive: a cast without a `narrator` row still gets a narrator-bucket
+       voice for the title beat. The fallback character is constructed inline
+       with no gender/age hints; pickVoiceForEngine routes that to the
+       narrator-cool bucket (which IS what we want for chapter titles). */
+    const cast: CastCharacter[] = [
+      { id: 'keefe', name: 'Keefe', gender: 'male', attributes: ['witty'] },
+    ];
+    const provider = makeProvider();
+
+    await synthesiseChapter({
+      sentences: [sentence(1, 'keefe', 'Body.')],
+      cast,
+      provider,
+      modelKey: 'gemini-2.5-flash',
+      engine: 'gemini',
+      chapterTitleNarration: 'Chapter 1.',
+    });
+
+    expect(provider.calls).toHaveLength(2);
+    expect(GEMINI_NARRATOR_VOICES, `title voiced by ${provider.calls[0].voiceName}`).toContain(
+      provider.calls[0].voiceName,
+    );
+  });
+});
+
 /* ── plan 70d — buildSentenceGroups emits one group per sentence ─────
    Earlier code folded consecutive same-speaker sentences into one
    synth call to cut HTTP roundtrips. That folding produced a 207-

--- a/server/src/tts/synthesise-chapter.ts
+++ b/server/src/tts/synthesise-chapter.ts
@@ -67,6 +67,30 @@ export interface ChapterSegment {
   startSec: number;
   /** Exclusive end time in the chapter audio, in seconds. */
   endSec: number;
+  /** Discriminator for synthetic segments that aren't backed by a manuscript
+      sentence. `'title'` marks the narrator-voiced chapter-title beat
+      prepended to each chapter (see CHAPTER_LEAD_SILENCE_SEC below). Body
+      sentences leave this field undefined so the on-disk segments.json
+      shape stays backwards-compatible with pre-title chapters. */
+  kind?: 'title';
+}
+
+/** Silence padding bookending the spoken chapter-title narration. Each chapter
+    MP3 now opens with `[lead silence] + [narrator: title] + [post silence] +
+    [body sentences]`. Defaults match standard audiobook chapter breaks —
+    3.0 s of total padding is enough for the listener to register the
+    boundary without dragging. Tuned together with the documented invariant
+    in `docs/features/28-chapter-audio-format.md`; adjust both at once. */
+const CHAPTER_LEAD_SILENCE_SEC = 1.5;
+const CHAPTER_POST_TITLE_SILENCE_SEC = 1.5;
+
+/** Build a zero-filled mono 16-bit LE PCM buffer of the requested duration.
+    Matches the per-chapter PCM contract — same byte layout as what the TTS
+    providers return, so the rest of the synth pipeline (concat, encode,
+    loudnorm) treats it identically to spoken audio. */
+function buildSilencePcm16(sampleRate: number, seconds: number): Buffer {
+  const samples = Math.round(sampleRate * seconds);
+  return Buffer.alloc(samples * 2);
 }
 
 export interface ChapterSynthesisResult {
@@ -119,6 +143,33 @@ export interface SynthesiseChapterOpts {
       the per-bookId server mutex to stop a stale generation handler when a
       new POST arrives for the same book. */
   signal?: AbortSignal;
+  /** Pre-built spoken phrase for the chapter title (e.g. `"Chapter 2.
+      Moolark."`). Built by `buildChapterTitleNarration` in
+      `chapter-title-narration.ts` from `chapter.id` + parsed `chapter.title`.
+      When non-empty, the synth loop prepends
+      `[CHAPTER_LEAD_SILENCE_SEC of silence] + [narrator voicing this string]
+      + [CHAPTER_POST_TITLE_SILENCE_SEC of silence]` ahead of the body
+      sentences. The title's TTS response anchors the chapter's sample rate
+      (same rule the first body group used before this feature). Undefined or
+      blank skips the title beat AND the silence padding — legacy behaviour
+      for callers that don't opt in. */
+  chapterTitleNarration?: string;
+  /** Cast id used to look up the voice for the chapter-title narration.
+      Defaults to `'narrator'`, the special-cased narrator character
+      (`src/views/listen.tsx:139`). The picker falls through to a
+      narrator-voice bucket when the character has no gender / age / tone
+      hints, which is the correct routing for the title regardless of
+      whether the cast actually contains a `'narrator'` row. */
+  narratorCharacterId?: string;
+  /** Tick BEFORE the chapter-title TTS call begins. Lets the SSE route emit
+      a "Synthesising chapter title…" hint so the client's stall detector
+      doesn't fire while the (potentially multi-second) title synth runs.
+      Mirrors `onGroupStart` for body groups. */
+  onTitleStart?: () => void;
+  /** Tick AFTER the chapter-title TTS call completes. The accumulated
+      duration is the audio time at the end of the title segment (i.e. the
+      moment the post-title silence begins). */
+  onTitleComplete?: (e: { accumulatedSec: number }) => void;
 }
 
 /** One group per sentence. Plan 70d — earlier code folded consecutive
@@ -194,6 +245,10 @@ export async function synthesiseChapter(
     onGroupComplete,
     onGroupRetry,
     signal,
+    chapterTitleNarration,
+    narratorCharacterId = 'narrator',
+    onTitleStart,
+    onTitleComplete,
   } = opts;
 
   const castById = new Map(cast.map((c) => [c.id, c]));
@@ -203,6 +258,67 @@ export async function synthesiseChapter(
   const segments: ChapterSegment[] = [];
   let runningBytes = 0;
   let sampleRate = 24000; // first call sets this; default matches Gemini's documented rate.
+
+  /* Title beat: when the caller supplies a pre-built spoken phrase, prepend
+     `[lead silence] + [narrator voicing the title] + [post silence]` ahead
+     of the body groups. The title's TTS response anchors the chapter's
+     sample rate, so the silence buffers can be sized correctly without
+     guessing — we synth the title first, set the anchor from its response,
+     then bracket it with silence. The title contributes one synthetic
+     segment with `kind: 'title'` and an empty sentenceIds[]; the silence
+     padding is deliberately NOT recorded as segments (it's not narration,
+     it's structural padding, and the listen view's timeline shouldn't show
+     dead-air rows). */
+  const titleText = chapterTitleNarration?.trim();
+  if (titleText) {
+    if (signal?.aborted) {
+      throw new DOMException('synthesiseChapter aborted', 'AbortError');
+    }
+    const narratorChar =
+      castById.get(narratorCharacterId) ?? { id: narratorCharacterId, name: 'Narrator' };
+    const narratorVoice = pickVoiceForEngine(
+      engine,
+      toVoiceLike(narratorChar),
+      buildHintFromCast(narratorChar),
+    );
+
+    onTitleStart?.();
+
+    const titleResult = await withTtsRetry(
+      () =>
+        provider.synthesize({
+          text: normaliseForTts(titleText),
+          voiceName: narratorVoice,
+          modelKey,
+          signal,
+        }),
+      { signal },
+    );
+
+    sampleRate = titleResult.sampleRate;
+    const leadSilence = buildSilencePcm16(sampleRate, CHAPTER_LEAD_SILENCE_SEC);
+    const postSilence = buildSilencePcm16(sampleRate, CHAPTER_POST_TITLE_SILENCE_SEC);
+
+    chunks.push(leadSilence);
+    runningBytes += leadSilence.length;
+    const titleStartSec = pcmDurationSec(runningBytes, sampleRate);
+    chunks.push(titleResult.pcm);
+    runningBytes += titleResult.pcm.length;
+    const titleEndSec = pcmDurationSec(runningBytes, sampleRate);
+    chunks.push(postSilence);
+    runningBytes += postSilence.length;
+
+    segments.push({
+      groupIndex: -1,
+      characterId: narratorChar.id,
+      sentenceIds: [],
+      startSec: titleStartSec,
+      endSec: titleEndSec,
+      kind: 'title',
+    });
+
+    onTitleComplete?.({ accumulatedSec: titleEndSec });
+  }
 
   for (const group of groups) {
     /* Cheap abort check between groups — covers the common case where the


### PR DESCRIPTION
## Summary

Two production bugs in audiobook generation: chapter titles were never voiced and chapters concatenated gaplessly, so the listener heard one uninterrupted stream with no audible cue when a new chapter began. Each chapter MP3 now opens with 1.5s of silence, then the narrator speaks a constructed title narration, then 1.5s of silence, then the chapter body.

The narration is built from `chapter.id` + the parser-stored display title via the new `buildChapterTitleNarration` helper. Listener hears `"Chapter 2. Moolark."` even when the parser co-encoded number and name as `"Chapter 2 — Moolark"` (or with `:` / `-` / `–` separators). Bare-name titles like `"Prologue"`, `"Day One"`, `"Moolark"` are spoken verbatim — no auto `Chapter N` injection so front-matter never mispronounces as `"Chapter 1. Prologue."`. Empty / whitespace titles fall back to `"Chapter <id>."` so every chapter still gets a header beat.

## User-visible delta

- Every newly-generated chapter MP3 now has audible chapter-start cue: `[1.5s silence] + [narrator says title] + [1.5s silence] + [body]`. Chapter boundaries are audibly distinguishable when listening straight through.
- Total per-chapter duration grows by ~3.0s of silence plus however long the title takes to speak (typically 1–2s on a short numbered title).

## Operator / dev-visible delta

- New helper `buildChapterTitleNarration({ id, title })` in `server/src/tts/chapter-title-narration.ts` parses `Chapter|Ch.|Part|Book` + (Arabic / Roman / spelled-out N) + optional separator + name into a clean two-clause spoken phrase. Strips trailing `: - – —` separators. Pure function, fully unit-tested.
- `synthesiseChapter()` gains two opt-in fields on `SynthesiseChapterOpts`: `chapterTitleNarration?: string` and `narratorCharacterId?: string` (defaults to `'narrator'`). Plus `onTitleStart?` / `onTitleComplete?` SSE-tick hooks. Legacy callers without these stay on the original zero-padding shape.
- The title's TTS response now anchors the chapter sample rate. Mid-chapter sample-rate mismatches (Kokoro 24kHz + Coqui 22.05kHz co-cast) resample against the title anchor instead of the first body group.
- Title narration is routed through `pickVoiceForEngine` against the `'narrator'` cast id. Cast without a narrator row falls through to the narrator-cool voice bucket (correct routing for a chapter announcement regardless of cast shape).

## Contract changes

- `ChapterSegment` gains an optional `kind?: 'title'` discriminator. Title segments land in `segments.json` with `kind: 'title'`, `groupIndex: -1`, `sentenceIds: []`. Body segments leave `kind` undefined.
- `ChapterAudio` API response shape unchanged on the wire — title segments are filtered out at the boundary in `server/src/routes/chapter-audio.ts` because the OpenAPI contract types `sentenceId` as a required integer and title segments have an empty `sentenceIds[]`. On-disk retention lets future timeline UI opt in to rendering the title beat.
- No `openapi.yaml` change needed.

## New tests

- `server/src/tts/chapter-title-narration.test.ts` — 20-case table-driven test covering em-dash / colon / hyphen / Roman / spelled-out / `Part N` / `Book N` / `Ch.` / bare-name / empty / whitespace / null / undefined inputs.
- `server/src/tts/synthesise-chapter.test.ts` — 5 new regression tests under a new `describe('synthesiseChapter chapter-title beat')` block: title segment shape + voice routing, legacy no-title path, title-anchored sample rate vs. mismatched body, `onTitleStart` / `onTitleComplete` ordering around the synth, narrator fallback when cast has no `narrator` row.

## Docs

- `docs/features/28-chapter-audio-format.md` — invariants updated with the new title-beat + silence-padding contract. Key-files list and paired-tests list extended. Acceptance walkthrough step 7 expanded with the title cue. The "gapless concatenation across chapters" out-of-scope note retired (the producer now bakes the leading pause into each chapter).

## Migration

New renders only. Existing on-disk MP3s untouched. User re-generates a chapter via the Listen view to refresh.

## Test plan

- [x] `npm run verify:fast` — 1236 passed, 8 skipped.
- [x] `npm run typecheck` — clean.
- [x] `npm run verify` pre-push gate — green (typecheck + all tests + e2e + build).
- [ ] End-to-end manual against the canonical Keefe manuscript (`C:\Users\dudar\Downloads\Bonus Keefe Story.txt`): upload → analyse → confirm cast → Generate chapter 1 → MiniPlayer play-through hears `[1.5s silence]` → narrator says `"Chapter 1."` (or `"Chapter 1. <subtitle>."`) → `[1.5s silence]` → body. Generate chapter 2 and verify the chapter-1 → chapter-2 boundary is audibly distinguishable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)