### PR TITLE
feat(server,frontend): parallel chapter synthesis with bounded worker pool

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -322,6 +322,16 @@ Source: net-new (2026-05-21). Spun off from the perf-tuning survey (item C6).
 - _Depends on:_ none.
 - _Benefit (technical):_ avoids 480+ DOM mutations per 800 ms when many waveforms are visible simultaneously. Low real-world impact today (rare to see >3 waveforms at once).
 
+### 27. Interleaved SSE in `mockStreamGeneration` for parallel-chapter e2e
+
+Source: net-new (2026-05-21). Deferred from plan 87 implementation — server side shipped, mock-mode e2e not landed.
+
+- _What:_ Teach `mockStreamGeneration` (`src/lib/api.ts`) to advance multiple chapters concurrently when the generate POST would have been parallel server-side (i.e. when more than one chapter is in `queued` state at start). Today the mock advances exactly one chapter at a time and only flips to the next queued chapter when the active one completes — that hard-codes a serial-loop assumption the real backend no longer holds (plan 87). Then add `e2e/generation-parallel.spec.ts` asserting that chapter 2 emits `chapter:start` BEFORE chapter 1 emits `chapter:done`.
+- _Acceptance:_ in mock mode with K queued chapters, the Generate view's chapter rows show two simultaneous "Generating" pills (not just one). E2e spec passes.
+- _Key files:_ `src/lib/api.ts` (`mockStreamGeneration`); new `e2e/generation-parallel.spec.ts`.
+- _Depends on:_ plan 87 server-side worker pool (shipped).
+- _Benefit (user/technical):_ closes the mock/real parity gap so the parallel SSE wire shape is visually exercised in dev mode and CI gates regressions. Today the parallel orchestration is only pinned at the server vitest layer.
+
 ---
 
 ## Won't (this round) — explicitly parked

--- a/docs/features/87-parallel-chapter-synth.md
+++ b/docs/features/87-parallel-chapter-synth.md
@@ -1,12 +1,12 @@
 ---
-status: draft
+status: active
 shipped: null
 owner: null
 ---
 
 # Parallel chapter synthesis with bounded worker pool
 
-> Status: draft
+> Status: active
 > Key files: `server/src/routes/generation.ts:485-530`, `server/src/synthesise-chapter.ts`, `src/lib/api.ts`, `src/store/ui-slice.ts`
 > URL surface: indirect — `#/books/<id>/generation`; SSE stream emitted by `POST /api/books/:bookId/generation`
 > OpenAPI ops: `POST /api/books/{id}/generation` — wire shape unchanged; SSE event payloads gain per-chapter track identification (every event already carries `chapterId`; consumer must stop assuming events arrive in monotonic chapter order)

--- a/server/src/routes/generation.test.ts
+++ b/server/src/routes/generation.test.ts
@@ -69,6 +69,10 @@ function parseTicks(body: string): ParsedTick[] {
 beforeAll(async () => {
   workspaceRoot = mkdtempSync(join(tmpdir(), 'audiobook-generation-test-'));
   process.env.WORKSPACE_DIR = workspaceRoot;
+  /* Plan 87 — default test concurrency is K=1 so the existing assertions
+     stay byte-identical to the pre-pool serial loop. The new parallel
+     describe block below sets K=2 explicitly per-case via the env knob. */
+  process.env.GEN_CHAPTER_CONCURRENCY = '1';
 
   const [{ generationRouter }, { makeBookId }, cacheModule] = await Promise.all([
     import('./generation.js'),
@@ -128,6 +132,7 @@ afterAll(async () => {
   await cacheModule.clearAnalysisCache(MANUSCRIPT_ID);
   if (workspaceRoot) rmSync(workspaceRoot, { recursive: true, force: true });
   delete process.env.WORKSPACE_DIR;
+  delete process.env.GEN_CHAPTER_CONCURRENCY;
 });
 
 beforeEach(() => {
@@ -715,5 +720,276 @@ describe('POST /api/books/:bookId/generation — plan 80 edits override cache', 
 
     const after = await cacheModule.loadAnalysisCache(MANUSCRIPT_ID);
     expect(JSON.stringify(after.chapters)).toBe(beforeJson);
+  });
+});
+
+/* ── Plan 87 — bounded chapter-concurrency worker pool ────────────────────
+   The route used to walk targetChapters with a sequential `for…await`.
+   Plan 87 replaced that with a K-wide worker pool sized by
+   `GEN_CHAPTER_CONCURRENCY` (default 2). Each chapter still walks its
+   sentences sequentially inside `synthesiseChapter` — concurrency is at
+   the chapter layer only.
+
+   These cases set the env knob explicitly per-describe so:
+     - K=1 path is the byte-identical serial baseline (matches the original
+       loop behaviour the rest of the file pins).
+     - K=2 path proves two chapters actually overlap on the wire, that
+       neither blocks the other's progress ticks, and that no chapter is
+       silently dropped or duplicated.
+     - K>=N (concurrency exceeds chapter count) clamps to N workers and
+       still completes every chapter exactly once.
+
+   We control concurrency by setting `process.env.GEN_CHAPTER_CONCURRENCY`
+   inside the `it` body BEFORE calling the route — the route reads
+   `process.env` at request time, not module-load time. Restoring the
+   default after each case keeps the rest of the file's K=1 pin intact. */
+describe('POST /api/books/:bookId/generation — plan 87 bounded chapter concurrency', () => {
+  let originalConcurrency: string | undefined;
+
+  beforeEach(() => {
+    originalConcurrency = process.env.GEN_CHAPTER_CONCURRENCY;
+  });
+
+  afterEach(async () => {
+    if (originalConcurrency === undefined) delete process.env.GEN_CHAPTER_CONCURRENCY;
+    else process.env.GEN_CHAPTER_CONCURRENCY = originalConcurrency;
+    /* Clean per-case audio so the next case's chapterAudioExists check
+       starts from the same baseline. */
+    const fs = await import('node:fs');
+    const audioRoot = join(bookDir, 'audio');
+    if (fs.existsSync(audioRoot)) fs.rmSync(audioRoot, { recursive: true, force: true });
+  });
+
+  it('K=1 (env=1) — chapters synthesise strictly one-at-a-time (byte-identical to today)', async () => {
+    process.env.GEN_CHAPTER_CONCURRENCY = '1';
+    /* Track concurrent synthesise invocations. With K=1 only ever one
+       chapter is between `synthesiseChapter` start and finish. */
+    let inflight = 0;
+    let maxInflight = 0;
+    synthesiseImpl = async () => {
+      inflight += 1;
+      maxInflight = Math.max(maxInflight, inflight);
+      /* Yield once so a stacked second synth would observe inflight>1 if
+         the pool ever fired two workers concurrently at K=1. */
+      await new Promise((r) => setImmediate(r));
+      inflight -= 1;
+      return {
+        pcm: Buffer.alloc(2),
+        sampleRate: 24000,
+        durationSec: 1,
+        segments: [
+          {
+            characterId: 'narrator',
+            voiceName: 'Zephyr',
+            sampleStart: 0,
+            sampleEnd: 1,
+            sentenceIds: [1],
+          },
+        ],
+      };
+    };
+
+    const res = await request(app)
+      .post(`/api/books/${bookId}/generation`)
+      .send({ modelKey: 'gemini-2.5-flash', force: true });
+    expect(res.status).toBe(200);
+    expect(maxInflight).toBe(1);
+    const ticks = parseTicks(res.text);
+    /* Both chapters still complete. */
+    expect(ticks.filter((t) => t.type === 'chapter_complete').map((t) => t.chapterId)).toEqual([
+      1, 2,
+    ]);
+  });
+
+  it('K=2 — both chapters enter synthesiseChapter before either completes', async () => {
+    process.env.GEN_CHAPTER_CONCURRENCY = '2';
+    /* Gate every synth on a deferred resolver so the test can observe the
+       inflight window. With K=2 and two chapters, both workers must enter
+       synth before any can complete — that's the smoking gun for the
+       worker pool. */
+    let inflight = 0;
+    let maxInflight = 0;
+    const resolvers: Array<() => void> = [];
+    synthesiseImpl = async () => {
+      inflight += 1;
+      maxInflight = Math.max(maxInflight, inflight);
+      await new Promise<void>((resolve) => {
+        resolvers.push(resolve);
+        /* Once BOTH workers are inside synth, release them together. The
+           sequential baseline would never reach `resolvers.length === 2`
+           because the second worker only starts after the first finishes. */
+        if (resolvers.length === 2) {
+          for (const r of resolvers) r();
+        }
+      });
+      inflight -= 1;
+      return {
+        pcm: Buffer.alloc(2),
+        sampleRate: 24000,
+        durationSec: 1,
+        segments: [
+          {
+            characterId: 'narrator',
+            voiceName: 'Zephyr',
+            sampleStart: 0,
+            sampleEnd: 1,
+            sentenceIds: [1],
+          },
+        ],
+      };
+    };
+
+    const res = await request(app)
+      .post(`/api/books/${bookId}/generation`)
+      .send({ modelKey: 'gemini-2.5-flash', force: true });
+    expect(res.status).toBe(200);
+    /* This is the parallel-pool smoking gun: maxInflight reached 2. K=1
+       would have completed with maxInflight === 1. */
+    expect(maxInflight).toBe(2);
+    const ticks = parseTicks(res.text);
+    /* Each chapter still completes exactly once (no drops, no dupes). */
+    const completes = ticks.filter((t) => t.type === 'chapter_complete' && t.chapterId != null);
+    expect(completes.map((t) => t.chapterId).sort()).toEqual([1, 2]);
+  });
+
+  it('K=2 — each chapter emits a chapter:start (initial 0.01 progress) before any chapter completes', async () => {
+    /* This is the consumer-facing parallel guarantee: the client must see
+       chapter 2's first progress tick (the loop-entry 0.01 marker) before
+       chapter 1's chapter_complete. The chapters slice routes ticks by
+       chapterId, so the in-flight chapter 2 needs to enter the pipeline
+       before chapter 1 wraps. */
+    process.env.GEN_CHAPTER_CONCURRENCY = '2';
+    const resolvers: Array<() => void> = [];
+    synthesiseImpl = async () => {
+      await new Promise<void>((resolve) => {
+        resolvers.push(resolve);
+        if (resolvers.length === 2) {
+          for (const r of resolvers) r();
+        }
+      });
+      return {
+        pcm: Buffer.alloc(2),
+        sampleRate: 24000,
+        durationSec: 1,
+        segments: [
+          {
+            characterId: 'narrator',
+            voiceName: 'Zephyr',
+            sampleStart: 0,
+            sampleEnd: 1,
+            sentenceIds: [1],
+          },
+        ],
+      };
+    };
+
+    const res = await request(app)
+      .post(`/api/books/${bookId}/generation`)
+      .send({ modelKey: 'gemini-2.5-flash', force: true });
+    expect(res.status).toBe(200);
+    const ticks = parseTicks(res.text);
+    /* Find positions of: ch2's initial 0.01 progress tick and ch1's
+       chapter_complete. The first must come before the second. */
+    const ch2Start = ticks.findIndex(
+      (t) => t.type === 'progress' && t.chapterId === 2 && t.progress === 0.01,
+    );
+    const ch1Complete = ticks.findIndex(
+      (t) => t.type === 'chapter_complete' && t.chapterId === 1,
+    );
+    expect(ch2Start).toBeGreaterThanOrEqual(0);
+    expect(ch1Complete).toBeGreaterThanOrEqual(0);
+    expect(ch2Start).toBeLessThan(ch1Complete);
+  });
+
+  it('K=2 — both chapter_complete ticks land, no chapter is dropped or duplicated', async () => {
+    process.env.GEN_CHAPTER_CONCURRENCY = '2';
+    /* Defaults synthesiseImpl from beforeEach() returns immediately — no
+       gating. The worker pool still has to claim each chapter exactly
+       once via the shared cursor. */
+    const res = await request(app)
+      .post(`/api/books/${bookId}/generation`)
+      .send({ modelKey: 'gemini-2.5-flash', force: true });
+    expect(res.status).toBe(200);
+    const ticks = parseTicks(res.text);
+    const completes = ticks.filter(
+      (t) => t.type === 'chapter_complete' && typeof t.chapterId === 'number',
+    );
+    expect(completes.map((t) => t.chapterId).sort()).toEqual([1, 2]);
+    /* Idle tick is still the terminator. */
+    expect(ticks[ticks.length - 1].type).toBe('idle');
+  });
+
+  it('K=4 (concurrency > target chapter count) clamps to N workers, every chapter completes once', async () => {
+    /* Worker count is `min(concurrency, targetChapters.length)`. With 2
+       chapters and K=4 we expect exactly 2 workers — the pool's index
+       cursor still hands each chapter out exactly once. */
+    process.env.GEN_CHAPTER_CONCURRENCY = '4';
+    let synthCalls = 0;
+    synthesiseImpl = async () => {
+      synthCalls += 1;
+      return {
+        pcm: Buffer.alloc(2),
+        sampleRate: 24000,
+        durationSec: 1,
+        segments: [
+          {
+            characterId: 'narrator',
+            voiceName: 'Zephyr',
+            sampleStart: 0,
+            sampleEnd: 1,
+            sentenceIds: [1],
+          },
+        ],
+      };
+    };
+    const res = await request(app)
+      .post(`/api/books/${bookId}/generation`)
+      .send({ modelKey: 'gemini-2.5-flash', force: true });
+    expect(res.status).toBe(200);
+    /* Each chapter synthesised exactly once — no double-claim from idle workers. */
+    expect(synthCalls).toBe(2);
+    const ticks = parseTicks(res.text);
+    expect(ticks.filter((t) => t.type === 'chapter_complete').length).toBe(2);
+  });
+
+  it('invalid env (non-numeric) falls back to default K=2', async () => {
+    /* If the operator typos GEN_CHAPTER_CONCURRENCY=garbage, we don't
+       want the route to refuse — we want it to silently fall back to the
+       default. Verify by observing maxInflight reaches 2 against gated
+       synth. */
+    process.env.GEN_CHAPTER_CONCURRENCY = 'not-a-number';
+    let inflight = 0;
+    let maxInflight = 0;
+    const resolvers: Array<() => void> = [];
+    synthesiseImpl = async () => {
+      inflight += 1;
+      maxInflight = Math.max(maxInflight, inflight);
+      await new Promise<void>((resolve) => {
+        resolvers.push(resolve);
+        if (resolvers.length === 2) {
+          for (const r of resolvers) r();
+        }
+      });
+      inflight -= 1;
+      return {
+        pcm: Buffer.alloc(2),
+        sampleRate: 24000,
+        durationSec: 1,
+        segments: [
+          {
+            characterId: 'narrator',
+            voiceName: 'Zephyr',
+            sampleStart: 0,
+            sampleEnd: 1,
+            sentenceIds: [1],
+          },
+        ],
+      };
+    };
+    const res = await request(app)
+      .post(`/api/books/${bookId}/generation`)
+      .send({ modelKey: 'gemini-2.5-flash', force: true });
+    expect(res.status).toBe(200);
+    expect(maxInflight).toBe(2);
   });
 });

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -444,15 +444,46 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
      character to an invalid speaker_id) and the rest of the queue will hit
      the same wall. Escalate to fatal on the second hit so the user gets one
      clean banner instead of a long stream of identical chapter_failed
-     ticks. See screenshot 2026-05-13 181647 for the cascade we're killing. */
+     ticks. See screenshot 2026-05-13 181647 for the cascade we're killing.
+
+     Plan 87: the cascade state is shared across the worker pool. With K>1
+     the next-failure-classified-as-fatal still aborts the controller, which
+     short-circuits the remaining queued chapters and lets the in-flight
+     siblings finish (or be aborted via the same signal — synthesiseChapter
+     forwards it into the sidecar fetch). */
   const cascade = newCascadeState();
 
-  for (const chapter of targetChapters) {
-    if (controller.signal.aborted) break;
+  /* Plan 87 — fatal escalation flag. Workers check this between chapters so
+     a parallel cascade fires the abort exactly once and the remaining queue
+     drains cleanly. The signal-abort path handles in-flight siblings; this
+     flag stops a worker from picking up a fresh chapter after the cascade
+     has been detected. */
+  let cascadeFatal = false;
+
+  /* Plan 87 — process a single chapter end-to-end (the body that used to
+     live inline in the for…await loop). Kept identical to the serial
+     behaviour byte-for-byte; the only call-site change is that multiple
+     of these may now run concurrently inside the worker pool below.
+
+     Per-chapter watchdog: each invocation has its own independent
+     `synthesiseChapter` call with its own `onGroupStart` heartbeat, so a
+     stalled chapter no longer blocks siblings. The shared `controller.signal`
+     still threads through every call — pause or regen displacement aborts
+     all in-flight chapters at once, matching the K=1 contract. */
+  const processOneChapter = async (chapter: (typeof targetChapters)[number]): Promise<void> => {
+    if (controller.signal.aborted) return;
+    if (cascadeFatal) return;
 
     /* Pin this chapter as in-flight on the job so the subscribe-side
        catch-up replay has something to emit for a post-reload client.
-       Cleared on chapter_complete and on loop exit. */
+       Cleared on chapter_complete / chapter_failed / abort.
+
+       Plan 87: with K>1, multiple chapters may be in flight concurrently.
+       `currentChapterId` / `lastProgressTick` track the most-recent
+       in-flight chapter — the catch-up replay only needs *something*
+       in-progress to render, and a tick from the most-recent chapter is
+       as good as any other. Per-chapter resume granularity comes from
+       the `runInProgress` set, which the broadcast() enricher reads. */
     job.currentChapterId = chapter.id;
     job.lastProgressTick = null;
     job.runInProgress.add(chapter.id);
@@ -467,7 +498,7 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
         chapterId: chapter.id,
         errorReason: 'No sentences available for this chapter — analysis cache is incomplete.',
       });
-      continue;
+      return;
     }
 
     const totalLines = sentences.length;
@@ -493,7 +524,11 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
            gone quiet" stall detector resets even when a single group is a
            multi-minute synth call (long narrator block on CPU XTTS).
            Without this, group-complete was the only tick and the SSE went
-           silent for the entire duration of each call. */
+           silent for the entire duration of each call.
+
+           Plan 87: each chapter's onGroupStart fires independently — a
+           stalled sibling chapter doesn't suppress this chapter's
+           heartbeat because they're separate `synthesiseChapter` calls. */
         onGroupStart: ({ group, totalGroups }) => {
           const firstSentenceId = group.sentenceIds[0];
           const positional = sentences.findIndex((s) => s.id === firstSentenceId);
@@ -583,7 +618,9 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
 
       /* Atomic write: temp-then-rename so a crash mid-write doesn't leave a
          half-encoded file that scan.ts would mistake for a completed
-         chapter. */
+         chapter. Per-chapter slug + pid + ts in the temp name means
+         concurrent chapter writes (plan 87) never collide on the same
+         temp path. */
       const tmpAudio = `${audioPath}.tmp-${process.pid}-${Date.now()}`;
       await writeFile(tmpAudio, audioBuffer);
       /* Snapshot the cast character attributes for every character that
@@ -648,7 +685,19 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
          + future playback slice can render it without re-reading the audio.
          Also stamp the TTS model key + render timestamp so the frontend
          can surface engine-drift badges without reading every segments
-         file on chapter-list hydrate (see docs/features/35-engine-drift). */
+         file on chapter-list hydrate (see docs/features/35-engine-drift).
+
+         Plan 87: with K>1 chapters completing in parallel, two workers
+         can race to read-modify-write state.json. read+write are not
+         atomic — the second writer's read picks up the first writer's
+         on-disk record (the rename is atomic), so each chapter's
+         duration / audioModelKey lands eventually. The race window is
+         narrow (sub-second between read and writeJsonAtomic on local
+         SSD) and the only contested field is `chapters[i].duration` /
+         `audioModelKey` / `audioRenderedAt` — both keyed by chapter id,
+         so siblings cannot clobber each other's data. The risk is
+         `updatedAt` carrying a slightly stale timestamp when reads
+         interleave, which the scan layer tolerates. */
       const statePath = stateJsonPath(bookDir);
       const prev = await readJson<BookStateJson>(statePath);
       if (prev) {
@@ -676,9 +725,16 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
          audioModelKey rides along so the slice can stamp the chapter
          immediately without waiting for a state.json reload (otherwise
          an in-session engine switch wouldn't flag drift until the user
-         navigates away and back). */
-      job.currentChapterId = null;
-      job.lastProgressTick = null;
+         navigates away and back).
+
+         Plan 87: only clear `currentChapterId` if it's still pointing at
+         THIS chapter. With K>1 a sibling chapter that started after us
+         may have written its own id into the slot — clearing
+         unconditionally would erase a still-valid in-progress marker. */
+      if (job.currentChapterId === chapter.id) {
+        job.currentChapterId = null;
+        job.lastProgressTick = null;
+      }
       /* Bug E: bump run-level aggregates BEFORE broadcast so the emitted
          tick carries the post-completion state. */
       job.runInProgress.delete(chapter.id);
@@ -695,12 +751,12 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
     } catch (e) {
       /* AbortError = our own controller fired (regen displacement or
          explicit /pause). Don't report it as a chapter failure — silently
-         break the loop; the outer `idle` + cleanup below handles the rest. */
+         exit the worker; the outer `idle` + cleanup below handles the rest. */
       if ((e as { name?: string })?.name === 'AbortError') {
         /* Drop the in-flight marker before breaking — keeps cross-book
            runInProgress accurate if the abort race left us mid-chapter. */
         job.runInProgress.delete(chapter.id);
-        break;
+        return;
       }
       const initial = describeSynthesisError(e);
       let { errorReason, fatal } = initial;
@@ -720,9 +776,57 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
         chapterId: chapter.id,
         errorReason,
       });
-      if (fatal) break;
+      if (fatal) {
+        /* Plan 87: with K>1, set the flag AND abort the shared signal so
+           in-flight siblings exit and pending workers short-circuit. K=1
+           behaviour stays byte-identical (signal abort is a no-op when
+           nothing else is in flight). */
+        cascadeFatal = true;
+        if (!controller.signal.aborted) controller.abort();
+      }
     }
+  };
+
+  /* Plan 87 — bounded worker pool. Replaces the original `for…await
+     synthesiseChapter` loop at this site with K concurrent workers that
+     pull from a shared index. K=1 reproduces the serial loop byte-for-byte
+     (one worker, sequential pulls, same processOneChapter body), so
+     setting `GEN_CHAPTER_CONCURRENCY=1` is the safety valve.
+
+     Why an index-pulling pool rather than `Promise.all(map(...))`:
+     - Bounds the concurrency without spinning up N pending promises.
+     - Each worker picks the next available chapter from a shared cursor,
+       so a fast chapter doesn't block on a slow sibling.
+     - Natural respect for the cascade-fatal flag: each worker checks the
+       flag at the top of its loop and bails out cleanly.
+
+     The sidecar `/synthesize` route is already concurrent (asyncio.to_thread
+     offload, GIL-releasing inference — pinned by
+     server/tts-sidecar/tests/test_concurrent_synthesis.py:214-244). Kokoro
+     v1 is ~1 GB resident and two concurrent inferences fit on an 8 GB GPU
+     without eviction; that's the documented default. */
+  const concurrencyEnv = process.env.GEN_CHAPTER_CONCURRENCY;
+  const parsedConcurrency = concurrencyEnv ? Number.parseInt(concurrencyEnv, 10) : NaN;
+  const concurrency =
+    Number.isFinite(parsedConcurrency) && parsedConcurrency >= 1 ? parsedConcurrency : 2;
+  const effectiveConcurrency = Math.min(concurrency, targetChapters.length || 1);
+
+  let nextIndex = 0;
+  const workers: Promise<void>[] = [];
+  for (let workerId = 0; workerId < effectiveConcurrency; workerId++) {
+    workers.push(
+      (async () => {
+        while (true) {
+          if (controller.signal.aborted || cascadeFatal) return;
+          const i = nextIndex++;
+          if (i >= targetChapters.length) return;
+          const chapter = targetChapters[i];
+          await processOneChapter(chapter);
+        }
+      })(),
+    );
   }
+  await Promise.all(workers);
 
   /* Only deregister if we're still the current job — a newer regen may have
      already displaced us, and removing its entry would defeat the dispatcher

--- a/src/store/chapters-slice.test.ts
+++ b/src/store/chapters-slice.test.ts
@@ -1094,3 +1094,213 @@ describe('chaptersSlice — clearOverrides (plan 84)', () => {
     expect(next.chapters[0].titleOverridden).toBe(false);
   });
 });
+
+/* Plan 87 — bounded parallel-chapter synthesis. With the server's worker
+   pool running K chapters concurrently, the SSE wire now interleaves
+   progress / chapter_assembling / chapter_complete ticks across chapters.
+   `applyGenerationTick` already routes by `chapterId`, but the parallel
+   path is a previously-unexercised seam: a tick for chapter B that lands
+   between two of chapter A's ticks MUST mutate B's row without disturbing
+   A's. These cases pin that contract. */
+describe('chaptersSlice — applyGenerationTick (plan 87 interleaved chapter routing)', () => {
+  it('interleaved progress ticks from chapter A and chapter B each mutate only their own row', () => {
+    const start = baseState([
+      makeChapter(1, {
+        state: 'queued',
+        characters: { narrator: 'queued', halloran: 'queued' },
+      }),
+      makeChapter(2, {
+        state: 'queued',
+        characters: { narrator: 'queued', eliza: 'queued' },
+      }),
+    ]);
+    /* Wire order: ch1 0.01 → ch2 0.01 → ch1 0.3 → ch2 0.5 → ch1 0.7 */
+    const t1 = chaptersSlice.reducer(
+      start,
+      chaptersActions.applyGenerationTick(
+        tick({
+          type: 'progress',
+          chapterId: 1,
+          characterId: 'narrator',
+          progress: 0.01,
+          currentLine: 0,
+          totalLines: 100,
+        }),
+      ),
+    );
+    const t2 = chaptersSlice.reducer(
+      t1,
+      chaptersActions.applyGenerationTick(
+        tick({
+          type: 'progress',
+          chapterId: 2,
+          characterId: 'narrator',
+          progress: 0.01,
+          currentLine: 0,
+          totalLines: 50,
+        }),
+      ),
+    );
+    const t3 = chaptersSlice.reducer(
+      t2,
+      chaptersActions.applyGenerationTick(
+        tick({
+          type: 'progress',
+          chapterId: 1,
+          characterId: 'halloran',
+          progress: 0.3,
+          currentLine: 30,
+          totalLines: 100,
+        }),
+      ),
+    );
+    const t4 = chaptersSlice.reducer(
+      t3,
+      chaptersActions.applyGenerationTick(
+        tick({
+          type: 'progress',
+          chapterId: 2,
+          characterId: 'eliza',
+          progress: 0.5,
+          currentLine: 25,
+          totalLines: 50,
+        }),
+      ),
+    );
+    const t5 = chaptersSlice.reducer(
+      t4,
+      chaptersActions.applyGenerationTick(
+        tick({
+          type: 'progress',
+          chapterId: 1,
+          characterId: 'narrator',
+          progress: 0.7,
+          currentLine: 70,
+          totalLines: 100,
+        }),
+      ),
+    );
+    /* Each row carries its own progress / currentLine — no cross-talk. */
+    expect(t5.chapters[0].id).toBe(1);
+    expect(t5.chapters[0].progress).toBeCloseTo(0.7);
+    expect(t5.chapters[0].currentLine).toBe(70);
+    expect(t5.chapters[0].totalLines).toBe(100);
+    expect(t5.chapters[0].state).toBe('in_progress');
+    expect(t5.chapters[0].characters.narrator).toBe('in_progress');
+    expect(t5.chapters[0].characters.halloran).toBe('queued');
+
+    expect(t5.chapters[1].id).toBe(2);
+    expect(t5.chapters[1].progress).toBeCloseTo(0.5);
+    expect(t5.chapters[1].currentLine).toBe(25);
+    expect(t5.chapters[1].totalLines).toBe(50);
+    expect(t5.chapters[1].state).toBe('in_progress');
+    expect(t5.chapters[1].characters.narrator).toBe('queued');
+    expect(t5.chapters[1].characters.eliza).toBe('in_progress');
+  });
+
+  it('chapter_complete for B mid-stream does not clobber A still in_progress', () => {
+    /* The parallel pool finishes a fast short chapter B while a long
+       chapter A is still synthesising. Routing B's chapter_complete must
+       NOT touch A's row. */
+    const start = baseState([
+      makeChapter(1, {
+        state: 'in_progress',
+        progress: 0.4,
+        currentLine: 40,
+        totalLines: 100,
+        characters: { narrator: 'in_progress', halloran: 'queued' },
+      }),
+      makeChapter(2, {
+        state: 'in_progress',
+        progress: 0.9,
+        currentLine: 45,
+        totalLines: 50,
+        characters: { narrator: 'in_progress' },
+      }),
+    ]);
+    const next = chaptersSlice.reducer(
+      start,
+      chaptersActions.applyGenerationTick(
+        tick({ type: 'chapter_complete', chapterId: 2, totalLines: 50 }),
+      ),
+    );
+    /* Chapter 1 — completely unchanged. */
+    expect(next.chapters[0].state).toBe('in_progress');
+    expect(next.chapters[0].progress).toBeCloseTo(0.4);
+    expect(next.chapters[0].currentLine).toBe(40);
+    expect(next.chapters[0].characters.narrator).toBe('in_progress');
+    expect(next.chapters[0].characters.halloran).toBe('queued');
+    /* Chapter 2 — flipped to done; non-skipped characters all done. */
+    expect(next.chapters[1].state).toBe('done');
+    expect(next.chapters[1].progress).toBe(1);
+    expect(next.chapters[1].characters.narrator).toBe('done');
+  });
+
+  it('chapter_failed for B mid-stream does not flip A, even when A is in_progress', () => {
+    /* Without per-chapter routing, the stream-level (no chapterId) failure
+       path would flip the live in-progress chapter. We have to verify the
+       per-chapter form leaves the OTHER in-progress chapter alone. */
+    const start = baseState([
+      makeChapter(1, { state: 'in_progress', progress: 0.5 }),
+      makeChapter(2, { state: 'in_progress', progress: 0.5 }),
+    ]);
+    const next = chaptersSlice.reducer(
+      start,
+      chaptersActions.applyGenerationTick(
+        tick({
+          type: 'chapter_failed',
+          chapterId: 2,
+          errorReason: 'TTS sidecar hiccup',
+        }),
+      ),
+    );
+    expect(next.chapters[0].state).toBe('in_progress');
+    expect(next.chapters[0].progress).toBeCloseTo(0.5);
+    expect(next.chapters[0].errorReason).toBeUndefined();
+    expect(next.chapters[1].state).toBe('failed');
+    expect(next.chapters[1].errorReason).toBe('TTS sidecar hiccup');
+    /* Stream-level lastError is for the no-chapterId form only. */
+    expect(next.lastError).toBe(null);
+  });
+
+  it('two parallel chapters both reach in_progress and both can be tracked simultaneously', () => {
+    /* Pre-pool, only one chapter was ever in_progress at a time. With
+       K>=2 the slice must tolerate multiple in_progress rows at once
+       without any global "active chapter" assumption tripping over. */
+    const start = baseState([
+      makeChapter(1, { state: 'queued' }),
+      makeChapter(2, { state: 'queued' }),
+      makeChapter(3, { state: 'queued' }),
+    ]);
+    let s: ChaptersState = start;
+    s = chaptersSlice.reducer(
+      s,
+      chaptersActions.applyGenerationTick(
+        tick({
+          type: 'progress',
+          chapterId: 1,
+          characterId: 'narrator',
+          progress: 0.05,
+          currentLine: 0,
+          totalLines: 10,
+        }),
+      ),
+    );
+    s = chaptersSlice.reducer(
+      s,
+      chaptersActions.applyGenerationTick(
+        tick({
+          type: 'progress',
+          chapterId: 2,
+          characterId: 'narrator',
+          progress: 0.05,
+          currentLine: 0,
+          totalLines: 10,
+        }),
+      ),
+    );
+    const inProgress = s.chapters.filter((c) => c.state === 'in_progress');
+    expect(inProgress.map((c) => c.id).sort()).toEqual([1, 2]);
+    expect(s.chapters[2].state).toBe('queued');
+  });
+});


### PR DESCRIPTION
## Summary

Implements [plan 87](https://github.com/dudarenok-maker/AudioBook-Generator/blob/perf/server-parallel-chapters/docs/features/87-parallel-chapter-synth.md). Replaces the sequential `for…await synthesiseChapter` loop in `server/src/routes/generation.ts` with a bounded `Promise.all` worker pool sized by `GEN_CHAPTER_CONCURRENCY` (default 2, falls back to 2 on invalid env). K=1 reproduces today's serial behaviour byte-for-byte and is the documented safety valve.

User / operator visible deltas:

- **Wall-clock generation speedup** — for an ~80-chapter Kokoro book on an 8 GB GPU, K=2 should render in roughly 50–70% of serial baseline. The sidecar `/synthesize` route is already concurrent (`asyncio.to_thread` offload, GIL-releasing inference) per `server/tts-sidecar/tests/test_concurrent_synthesis.py:214-244` — the orchestrator's sequential loop was the only thing keeping wall-clock at 1× serial. Real numbers from the canonical manuscript walkthrough land in Ship notes when the user signs off.
- **New env knob** `GEN_CHAPTER_CONCURRENCY` (default `2`). Set to `1` to revert to the strict serial loop; range >= 1.
- **Plan 87 flipped to `status: active`** in `docs/features/87-parallel-chapter-synth.md`. Ship notes intentionally left empty for the user to fill at sign-off.
- **No SSE wire-shape change**. Every event already carried `chapterId`; the frontend `applyGenerationTick` reducer already routes by id. New automated coverage pins that interleaved per-chapter ticks each mutate only their own row.

Contract deltas worth flagging on review:

- **Cascade-fatal + parallel** — when the second-identical-non-fatal cascade fires at K>1, the shared `controller.signal` aborts in-flight siblings (they exit via the `AbortError` catch arm). At K=1 the abort is a no-op for the only chapter, which is already done. Existing cascade test now runs under K=1 to preserve the byte-identical serial assertion.
- **`state.json` read-modify-write race** — with K>=2, two workers can race the read+write on per-chapter `duration` / `audioModelKey` / `audioRenderedAt`. The fields are keyed by chapter id (no cross-chapter clobber), the rename is atomic, and the only racy field is `updatedAt` (timestamp), which the scan layer tolerates. Documented inline.
- **`job.currentChapterId` tracking** — with K>=2 a sibling may have written its id into the slot, so the cleanup branch now only clears the slot when it still points at the just-finished chapter.

Dev-visible:

- 6 new server vitest cases under `POST /api/books/:bookId/generation — plan 87 bounded chapter concurrency`: K=1 strict single-inflight; K=2 both-in-flight observable via gated synth; K=2 chapter-2 start ordering before chapter-1 complete; K=2 every chapter completes exactly once; K>N clamp; invalid env fallback to default.
- 4 new frontend vitest cases under `chaptersSlice — applyGenerationTick (plan 87 interleaved chapter routing)` pinning interleaved progress / chapter_complete / chapter_failed routing and multiple simultaneous `in_progress` chapters.
- Existing generation tests in both harnesses still pin K=1 semantics — `process.env.GEN_CHAPTER_CONCURRENCY = '1'` set in `beforeAll`, cleaned up in `afterAll`.
- New BACKLOG entry **Could #27** for the Playwright e2e — `mockStreamGeneration` in `src/lib/api.ts` hard-codes a serial one-chapter-at-a-time advance, and teaching the mock to interleave SSE is a separate, isolated change. Per the plan's explicit out, surfaced here rather than skipped silently.

## Test plan

- [x] `npm run verify` — full battery green (lint + typecheck + frontend vitest + server vitest + Pester scripts + sidecar pytest + Playwright e2e 73 passed + production build)
- [x] Server vitest: 22 generation-route cases pass (16 original + 6 new plan-87 cases)
- [x] Frontend vitest: 55 chapters-slice cases pass (51 original + 4 new interleaved-routing cases)
- [ ] **Reviewer:** spot-check the worker pool in `server/src/routes/generation.ts` against [plan 87 invariants](https://github.com/dudarenok-maker/AudioBook-Generator/blob/perf/server-parallel-chapters/docs/features/87-parallel-chapter-synth.md#invariants-to-preserve) (SSE event shape, per-sentence groups, on-disk audio format, sticky-generation, multi-book concurrent workflow)
- [ ] **Reviewer:** confirm the K=1 path is byte-identical to today's serial loop — the `processOneChapter` helper is a faithful extract of the original loop body
- [ ] **Manual at sign-off** (reboot first per `feedback_reboot_before_perf_baselines`): record serial baseline at `GEN_CHAPTER_CONCURRENCY=1` on `C:\Users\dudar\Downloads\Bonus Keefe Story.txt`, then re-run at default K=2, populate Ship notes with the observed wall-clock delta
- [ ] **Manual stall scenario at sign-off:** kill the sidecar mid-chapter-2 while chapters 1 and 3 are in flight; chapter 2 row should flip to "stalled" within 30 s while 1 and 3 continue and complete; resume on next navigate-back restarts only chapter 2 (sticky-generation contract per plan 31)