### PR TITLE
docs(docs): re-scope plan 88 to pipelined two-model analyzer with 10-chapter min lag

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -282,17 +282,7 @@ Source: net-new (2026-05-21). Spun off from the perf-tuning survey (item A3).
 - _Depends on:_ none structural. Speed gain conditional on mixed-engine casts.
 - _Benefit (user):_ eliminates the 30 s XTTS cold-load on first use for mixed-engine books; enables fluid engine mixing per character.
 
-### 23. Speculative per-chapter Phase 1 (analyzer)
-
-Source: net-new (2026-05-21). Spun off from the perf-tuning survey (item B2).
-
-- _What:_ Drop the global roster gate at `server/src/routes/analysis.ts:2031-2055`. Once chapter N's Phase 0 completes, fire its Phase 1 against the chapter-local roster; reconcile global character ids at the end by rewriting attributions whose character was a duplicate of one in the merged roster.
-- _Acceptance:_ A long book starts producing attribution results visibly earlier than today (no Phase 0 → Phase 1 wall). Duplicate-character normalisation across chapters (e.g. "Mom" in ch1 == "Mother" in ch7) is correct. Manual cowork flow (`server/handoff/`) still works or is explicitly opt-out.
-- _Key files:_ `server/src/routes/analysis.ts:2031-2055`; `server/src/analyzer/cache.ts` (invalidation rules).
-- _Depends on:_ plan 88 shipped (per-phase analyzer split must land first to keep cache shapes simple).
-- _Benefit (user):_ ~30% end-to-end faster on long books. High regression surface — pursue only if plan 88 leaves attribution latency biting.
-
-### 24. Per-call local→Gemini analyzer overflow
+### 23. Per-call local→Gemini analyzer overflow
 
 Source: net-new (2026-05-21). Spun off from the perf-tuning survey (item B4).
 
@@ -302,7 +292,7 @@ Source: net-new (2026-05-21). Spun off from the perf-tuning survey (item B4).
 - _Depends on:_ plan 88 shipped (its per-phase plumbing is the seam this builds on).
 - _Benefit (user):_ uses idle Gemini quota when local is the bottleneck. Lower priority than plan 88's bucketed split.
 
-### 25. Confirm-cast + listen-chapter list virtualisation
+### 24. Confirm-cast + listen-chapter list virtualisation
 
 Source: net-new (2026-05-21). Spun off from the perf-tuning survey (item C4).
 
@@ -312,7 +302,7 @@ Source: net-new (2026-05-21). Spun off from the perf-tuning survey (item C4).
 - _Depends on:_ Should #1 (shares the virtualiser dep + helper — pair to amortise dep adoption).
 - _Benefit (user):_ only matters above ~40 rows. Most books are below the threshold today.
 
-### 26. Waveform memoisation
+### 25. Waveform memoisation
 
 Source: net-new (2026-05-21). Spun off from the perf-tuning survey (item C6).
 

--- a/docs/features/88-analyzer-per-phase-model.md
+++ b/docs/features/88-analyzer-per-phase-model.md
@@ -4,70 +4,112 @@ shipped: null
 owner: null
 ---
 
-# Analyzer per-phase model selection with attribution warm-up
+# Pipelined two-model analyzer (Gemma cast + Gemini attribution, 10-chapter lag)
 
 > Status: draft
-> Key files: `server/src/analyzer/index.ts:106-210`, `server/src/analyzer/select-analyzer.ts`, `server/src/routes/analysis.ts:1323-1328`, `server/src/analyzer/rate-limit.ts:122`, `server/.env.example`, `docs/features/06-analyzer-gemini.md`
+> Key files: `server/src/analyzer/index.ts:106-210`, `server/src/analyzer/select-analyzer.ts`, `server/src/routes/analysis.ts:1323-1328`, `server/src/routes/analysis.ts:2031-2055`, `server/src/analyzer/rate-limit.ts:122`, new `server/src/analyzer/phase-watermark.ts`, `server/.env.example`, `docs/features/06-analyzer-gemini.md`
 > URL surface: indirect — `#/books/<id>/analysing`; SSE stream emitted by `POST /api/books/:bookId/analyse`
 > OpenAPI ops: none — env-var driven
 
 ## Benefit / Rationale
 
-- **User:** improves attribution accuracy on the harder reasoning task (Phase 1 — speaker attribution per sentence) by using a smarter model (`gemini-3.1-flash-lite`) for the bulk of the book, while keeping the first W chapters of Phase 1 anchored to the same model that built the roster (`gemma-4-31b-it`). This cuts the worst-case **cross-model attribution drift** — early-book misattributions that compound — without eliminating it. Per [feedback_warmup_window_for_model_splits], the warm-up window is a MUST when swapping models mid-book.
-- **Technical:** quota effectively doubled. Phase 0 (`gemma-4-31b-it`, 1,500 RPD bucket, no TPM cap) and Phase 1 (`gemini-3.1-flash-lite`, 500 RPD bucket) run against independent rate-limit buckets that `server/src/analyzer/rate-limit.ts:122` already supports. Phase 0's load can't starve Phase 1 (and vice versa). Phase 1 is `STAGE2_STRETCH = 5.0` × the wall-clock of Phase 0 (`server/src/routes/analysis.ts:453`) per chapter, so optimising the smarter model on attribution is the bigger lever.
-- **Architectural:** introduces a per-phase analyzer selection seam (`selectAnalyzerForPhase`). The seam is the prerequisite for both BACKLOG Could #23 (speculative per-chapter Phase 1 / B2) and BACKLOG Could #24 (per-call local→Gemini overflow / B4).
+- **User (throughput):** Phase 1 attribution overlaps with Phase 0 cast detection instead of waiting for it. Today Phase 0 → Phase 1 is a hard wall (`analysis.ts:2031-2055`); a 30-chapter book waits for all 30 Phase-0 chapters to complete + the Phase 0b roster merge before any Phase 1 attribution begins. Pipelined, Gemini starts attribution on chapter 0 as soon as Gemma has finished chapter 9 (10-chapter lag satisfied) and the two run in parallel from then on. Because Phase 1 is `STAGE2_STRETCH = 5.0` × the wall-clock of Phase 0 per chapter, Gemini keeps churning long after Gemma finishes — so the wall-clock saved is roughly "Gemma's full Phase 0 time minus the 10-chapter lag."
+- **User (quality):** Gemma's cast roster anchors the attribution. The 10-chapter MINIMUM lag ensures Gemini never attributes against a roster snapshot that lags Gemma's current view by less than 10 chapters of context. If Gemini catches up (e.g. Gemma is rate-limited or Gemini is unexpectedly fast), Gemini pauses on a back-pressure semaphore until Gemma pulls ahead again. Most major characters appear in the first 10 chapters of typical books, so by the time Gemini starts chapter 0 it's working against a ~10-chapter-thick roster — near-final for character coverage. Cast-matching drift is bounded, not eliminated.
+- **Technical:** quota effectively doubled — gemma-4-31b-it's 1,500 RPD bucket and gemini-3.1-flash-lite's 500 RPD bucket are independent (`server/src/analyzer/rate-limit.ts:122` is already per-model). The pipeline lets both buckets advance simultaneously.
+- **Architectural:** introduces a phase-watermark + back-pressure seam (`server/src/analyzer/phase-watermark.ts`) that future work can extend (per-character regen against partial roster, multi-tier model fan-out, etc.).
 
 ## Architectural impact
 
-- **New seam:** `selectAnalyzerForPhase(phase, chapterIndex, opts)` returning the chosen `Analyzer` instance per three env knobs:
-  - `ANALYZER_PHASE0_MODEL` — default `gemma-4-31b-it`.
-  - `ANALYZER_PHASE1_MODEL` — default `gemini-3.1-flash-lite` (used only after the warm-up window).
-  - `ANALYZER_PHASE1_WARMUP_CHAPTERS` — default `10`. Set to `0` to force-split from chapter 1.
-- **Threading:** chapter index flows from the Phase 1 worker into the analyzer selection so each chapter's dispatch picks the right model. Phase 0a workers always use the Phase-0 model; Phase 1 workers with `chapterIndex < W` use the Phase-0 model (warm-up); Phase 1 workers with `chapterIndex >= W` use the Phase-1 model.
-- **Rate-limit buckets** at `server/src/analyzer/rate-limit.ts:122` are already keyed per model — no changes needed; concurrent warm-up + post-warm-up calls don't compete.
-- **Migration:** legacy single-model `ANALYZER=<engine>` env keeps working when none of the three new vars are set. Fall-through resolution: if `ANALYZER_PHASE{0,1}_MODEL` unset, both phases use today's `ANALYZER`-selected analyzer (Gemini / local / manual / fallback).
-- **Reversibility:** unset the three new env vars to revert to today's single-model behaviour.
+### Three env knobs
+
+- `ANALYZER_PHASE0_MODEL` — default **`gemma-4-31b-it`**. Drives Phase 0a (cast detection) on every chapter.
+- `ANALYZER_PHASE1_MODEL` — default **`gemini-3.1-flash-lite`**. Drives Phase 1 (attribution) on every chapter.
+- `ANALYZER_PHASE1_MIN_LAG_CHAPTERS` — default **`10`**. Gemini's chapter K is dispatchable only when Gemma has *completed* chapter `K + LAG - 1` (i.e. Gemma's watermark `>= K + LAG`). The lag is a MINIMUM — if Gemini catches up, the back-pressure semaphore makes Gemini wait. Set `0` to release the lag constraint (pipelining still happens; Gemini just dispatches as soon as the per-chapter roster snapshot exists for its chapter).
+
+Fall-through: if none of the three env vars are set → falls back to today's single-model `ANALYZER=…` resolution AND today's sequential phase-gate behaviour. This is the regression case the test suite pins.
+
+### Phase watermark + back-pressure semaphore
+
+New module `server/src/analyzer/phase-watermark.ts` exposes:
+
+- `markPhase0ChapterComplete(chapterIndex)` — Gemma's Phase 0 workers call this on each chapter completion. Monotonic increment of the watermark.
+- `markPhase0AllDone()` — called after Phase 0b roster consolidation finishes; releases the lag constraint entirely so any remaining Gemini chapters can dispatch immediately against the final roster.
+- `awaitPhase1Dispatch(chapterIndex)` — Gemini's Phase 1 workers `await` this before dispatching their chapter; resolves when `watermark >= chapterIndex + LAG` OR `phase0Done === true`. If the condition isn't satisfied at call time, the worker parks on an internal `EventEmitter` / promise-resolver; new watermark events re-evaluate all waiters.
+
+The watermark is monotonic; the back-pressure check fires every time the watermark advances. **If Gemini catches up** (e.g. Gemma stalled on rate limit; Gemini's already-dispatched workers complete fast; the next Gemini chapter's lag constraint is no longer satisfied), `awaitPhase1Dispatch` blocks until Gemma's next chapter completes. This is the "keep 10 chapters between them" semantic the user asked for.
+
+### Roster shape change
+
+Today: Phase 0b runs once at the end of Phase 0, producing the final roster. Phase 1 reads this final roster.
+
+Pipelined: Phase 0b merging happens incrementally — each Gemma chapter's character detections are folded into a *rolling roster* on completion. Each Gemini worker takes a snapshot of the rolling roster at dispatch time and attributes against that snapshot.
+
+After Gemma finishes its last chapter, Phase 0b runs once more for the final consolidation (resolves any cross-chapter aliases that the rolling merge missed — e.g. "Mom" vs "Mother" disambiguation). The final roster supersedes the rolling roster; any Gemini chapters dispatched *after* `markPhase0AllDone()` use the final roster.
+
+### Late-character drift handling (v1: pragmatic)
+
+If Gemma identifies a character first in chapter 20, Gemini's chapter 5 (dispatched against a rolling-roster snapshot taken when Gemma's watermark was 15) won't have that character in its candidate set — some sentences spoken by that character may be attributed to `narrator` / unknown.
+
+**v1 is pragmatic:** the 10-chapter lag covers the typical case (major characters appear early in the book). Residual drift for late-introduced characters is documented as a known limitation. The phase-watermark seam already knows which chapters dispatched against which roster snapshot, so a future reconciliation pass can rewrite them — that's deferred as out-of-scope here.
+
+### Migration / reversibility
+
+- Removing the new env vars entirely reverts to today's sequential behaviour (single-model `ANALYZER=…`, hard phase gate).
+- Setting `ANALYZER_PHASE1_MODEL` equal to `ANALYZER_PHASE0_MODEL` is valid — pipelines on a single model; still gains throughput from running Phase 1 chapter K while Phase 0 chapter K+10 is in flight.
+- The phase gate at `analysis.ts:2031-2055` is **replaced** by the watermark seam, not preserved.
 
 ## Invariants to preserve
 
-- Plan 04 SSE event shape unchanged (analysing-view consumer doesn't care which model produced a chunk).
-- Plan 06 manual handoff flow at `server/src/routes/analysis.ts:2031-2055` (Phase 0 → Phase 1 phase gate) UNTOUCHED — this plan only changes which analyzer Phase 1 dispatches to, not when Phase 1 starts.
-- Plan 29 local-Ollama analyzer + fallback path unchanged. When `ANALYZER=local` is set, `selectAnalyzerForPhase` returns the Ollama analyzer for both phases unless a phase-model override is set. The `FallbackAnalyzer` Gemini-on-`LocalUnreachableError` route at `server/src/analyzer/index.ts:159-210` continues to wrap the selected analyzer.
-- Per [feedback_warmup_window_for_model_splits]: the 10-chapter warm-up is the default — anchors attribution to the roster-author model first. Without it, the first 10 chapters' attribution may drift from the roster's interpretive baseline.
+- Plan 04 SSE event shape unchanged. Analysing-view consumer doesn't care that Phase 0 and Phase 1 are now interleaved on the wire — events still carry chapter id + phase id, so the per-phase progress bars stay coherent.
+- Plan 06 manual handoff flow (`ANALYZER=manual`, `server/handoff/`) — when manual, the pipeline collapses to today's sequential behaviour. The manual cowork loop fundamentally can't pipeline (waits for human input between phases). Detect this case and short-circuit the watermark seam.
+- Plan 29 local Ollama analyzer + fallback path unchanged. `FallbackAnalyzer` (`server/src/analyzer/index.ts:159-210`) keeps wrapping whichever analyzer is selected; local-unreachable → Gemini fallback continues to work per phase.
+- Rate-limit buckets at `server/src/analyzer/rate-limit.ts:122` already per-model — concurrent two-model traffic gets independent buckets.
+- Per [feedback_warmup_window_for_model_splits]: the 10-chapter constraint anchors attribution to the roster-author model's interpretive baseline. Reframed: the lag *is* the warm-up, but expressed as a runtime back-pressure rather than a per-chapter model selection.
 
 ## Test plan
 
 ### Automated coverage
 
-- Vitest server (`server/src/analyzer/select-analyzer.test.ts`):
-  - (a) Phase 0a always returns the Phase-0 analyzer regardless of chapterIndex.
-  - (b) Phase 1 chapter 0 returns the Phase-0 analyzer (warm-up window active).
-  - (c) Phase 1 chapter `W` (default 10) returns the Phase-1 analyzer (boundary case).
-  - (d) `ANALYZER_PHASE1_WARMUP_CHAPTERS=0` makes Phase 1 chapter 0 already pick the Phase-1 model.
-  - (e) Limiter counters split correctly when both models are in flight simultaneously (Phase 0a on gemma + Phase 1 chapter 20 on gemini-3.1-flash-lite); two independent buckets advance without cross-decrement.
-  - (f) Legacy single-model `ANALYZER=…` env keeps working when none of the new vars are set (regression).
-- Vitest server (`server/src/routes/analysis.test.ts`) — threads chapterIndex into the Phase 1 dispatch and asserts the right analyzer is invoked per chapter.
+- Vitest server (`server/src/analyzer/phase-watermark.test.ts`, new):
+  - (a) `awaitPhase1Dispatch(0)` resolves once `markPhase0ChapterComplete` is called 10 times (default LAG).
+  - (b) `awaitPhase1Dispatch(5)` resolves once watermark reaches 15.
+  - (c) `markPhase0AllDone()` releases all pending waiters immediately, regardless of watermark.
+  - (d) **Back-pressure (the user's "if Gemini catches up, slow it down" case):** simulate Gemma's watermark stalling at 12; dispatch Gemini chapters 0, 1, 2 (all satisfied because watermark=12 >= chapter+10); Gemini chapter 3 must wait (12 < 3+10=13); when `markPhase0ChapterComplete(13)` fires, chapter 3 dispatches; chapter 4 stays pending until watermark=14.
+  - (e) `MIN_LAG_CHAPTERS=0` makes chapter K dispatchable as soon as Phase 0 chapter K is marked complete.
+  - (f) Watermark is monotonic — `markPhase0ChapterComplete(5)` followed by `markPhase0ChapterComplete(3)` keeps watermark at 5 (out-of-order completion is tolerated; never regresses).
+- Vitest server (`server/src/analyzer/select-analyzer.test.ts`, new):
+  - Phase 0 work always returns the Phase-0 analyzer.
+  - Phase 1 work always returns the Phase-1 analyzer.
+  - Legacy single-model `ANALYZER=…` env keeps working when none of the new vars are set (regression).
+- Vitest server (`server/src/routes/analysis.test.ts`, extend):
+  - End-to-end pipelined flow on a mock book — Phase 0 watermark advances, Phase 1 workers fire as their lag is satisfied, final consolidation runs, all Phase 1 chapters complete.
+  - Rolling roster snapshot: Gemini worker for chapter 5 reads a snapshot containing Gemma's chapters 0–14 (snapshot taken at dispatch time when watermark=15).
+  - Manual handoff regression: `ANALYZER=manual` collapses to sequential phase gate (watermark seam short-circuited).
+- Vitest server (`server/src/analyzer/rate-limit.test.ts`, extend if needed): limiter counters split correctly when both models are in flight simultaneously (Gemma + Gemini concurrent calls); two independent buckets advance without cross-decrement.
 
 ### Manual acceptance walkthrough
 
-1. **Pre-reboot baseline** per [feedback_reboot_before_perf_baselines]: reboot; record telemetry for a `ANALYZER=gemini` single-model run on `C:\Users\dudar\Downloads\Bonus Keefe Story.txt` (chapter count, per-phase wall-clock, RPM/TPM usage).
-2. **Default-split run:** unset `ANALYZER_PHASE0_MODEL` / `ANALYZER_PHASE1_MODEL` / `ANALYZER_PHASE1_WARMUP_CHAPTERS` → all defaults apply. Re-run analysis. Verify telemetry shows:
-   - Phase 0a uses gemma only.
-   - Phase 1 chapters 0–9 use gemma (warm-up).
-   - Phase 1 chapter 10+ uses gemini-3.1-flash-lite.
-   - Quota counters in `rate-limit.ts` split correctly across the two model buckets (no cross-decrement).
-3. **Attribution spot-check:** sample chapters 1, 10, and 25 attribution against the prior single-model baseline; verify chapter-10 attribution remains coherent across the W-boundary (no abrupt name-resolution shift).
-4. **Force-split:** set `ANALYZER_PHASE1_WARMUP_CHAPTERS=0`; verify chapter 0 of Phase 1 already on gemini-3.1-flash-lite.
-5. **Legacy fallback:** unset all three new vars; `ANALYZER=gemini`; verify behaviour identical to today's single-model run.
+1. **Reboot** for clean GPU/process state per [feedback_reboot_before_perf_baselines].
+2. **Default-run on the canonical manuscript** (`C:\Users\dudar\Downloads\Bonus Keefe Story.txt`): all three env knobs at defaults. Watch telemetry:
+   - Gemma chapter 9 completes (`gemma.phase0.chapter=9 watermark=10`); within ~50 ms Gemini chapter 0 dispatches (`gemini.phase1.chapter=0 roster_snapshot_size=10`).
+   - Gemma and Gemini chapters interleave in the SSE stream from that point on.
+   - Gemma finishes its last chapter + Phase 0b consolidation; Gemini still has N - lag_release_point chapters left.
+   - Gemini continues solo; each remaining chapter logs `roster_snapshot=final`.
+   - Quota counters: gemma's bucket and gemini's bucket advance independently; no cross-decrement.
+3. **Back-pressure observable test:** rate-limit Gemma artificially (e.g. via a `GEMINI_RPM=2` style env override on the Gemma model) so Gemma stalls mid-book. Gemini should NEVER catch up within 9 chapters of Gemma's watermark. Telemetry should show occasional `gemini.phase1.chapter=K backpressure_wait_ms=…` log lines when Gemini hits the semaphore.
+4. **Attribution spot-check vs prior single-model baseline:** chapters 1, 10, 25, last-3. Quality should be at least as good as today's single-Gemini run; ideally better in early chapters because the roster is anchored to Gemma's interpretive baseline.
+5. **Lag-zero force-pipeline:** `ANALYZER_PHASE1_MIN_LAG_CHAPTERS=0` — Gemini's chapter K dispatches as soon as Gemma's chapter K is marked complete (1-chapter rolling lead). Use only for empirical comparison; expect more cast-matching drift in early chapters.
+6. **Legacy regression:** unset all three new vars + set `ANALYZER=gemini` → identical to today's single-model sequential run (no telemetry split, no watermark seam engaged).
+7. **Manual handoff regression:** `ANALYZER=manual` → pipeline collapses to today's sequential phase-gate behaviour (the file-drop cowork loop can't pipeline). Verify by walking through the `server/handoff/inbox/` → `server/handoff/outbox/` exchange.
 
 ## Out of scope
 
-- **B2 — speculative per-chapter Phase 1** (drop the global roster gate) → BACKLOG Could #23. High regression surface; depends on this plan shipping first.
-- **B4 — per-call local→Gemini overflow** (route partial load when local is slow, not just unreachable) → BACKLOG Could #24. Different from this plan: per-call not per-phase.
-- **B3 — bump `STAGE2_CONCURRENCY`** — env-var tweak only; not a structural change. May be folded into this plan during implementation if the limiter handles the burst cleanly, otherwise punted to a follow-up.
+- **Full reconciliation pass** for characters first discovered in late Phase 0 chapters — pragmatic v1 accepts residual drift; spin off to a fresh BACKLOG entry if empirical testing shows the residual bites.
+- **B4 — per-call local→Gemini overflow** (route partial load when local is slow) → stays at BACKLOG Could (renumbers after this re-scope removes the now-superseded B2 entry).
+- **Multi-tier model fan-out** (e.g. three models, three phases) — single-axis pipeline only in v1.
 - **A1 — parallel chapter synthesis** → plan 87 (parallel branch).
 - **C2/C3/C5 — frontend perf bundle** → plan 89 (parallel branch).
 
 ## Ship notes
 
-_(filled when status flips to `stable` — shipped date, commit SHA, observed quota / attribution delta on the canonical manuscript)_
+_(filled when status flips to `stable` — shipped date, commit SHA, observed wall-clock and quota delta on the canonical manuscript; especially the Gemma-finish-to-Gemini-finish gap which is the headline pipelining win)_

--- a/docs/features/89-frontend-perf-pass.md
+++ b/docs/features/89-frontend-perf-pass.md
@@ -55,8 +55,8 @@ Three independent micro-optimisations on the frontend that share a deployment sh
 ## Out of scope
 
 - **C1 — Manuscript view virtualisation** → BACKLOG Should #1. Explicitly demoted from MUST in the survey — current feel is bearable, but >300 sentences during boundary drag is the next-priority frontend item.
-- **C4 — Confirm-cast + listen-chapter list virtualisation** → BACKLOG Could #25. Only matters above ~40 rows; depends on Should #1 to amortise the `@tanstack/react-virtual` dep.
-- **C6 — Waveform memoisation** → BACKLOG Could #26. Low real-world impact today.
+- **C4 — Confirm-cast + listen-chapter list virtualisation** → BACKLOG Could #24. Only matters above ~40 rows; depends on Should #1 to amortise the `@tanstack/react-virtual` dep.
+- **C6 — Waveform memoisation** → BACKLOG Could #25. Low real-world impact today.
 - **A1 — Parallel chapter synthesis** → plan 87 (parallel branch).
 - **B1 — Per-phase analyzer model** → plan 88 (parallel branch).
 


### PR DESCRIPTION
## Summary

Re-scopes plan 88 from "sequential per-phase model split with chapter-warm-up" to a **pipelined two-model analyzer** where Gemma's Phase 0 and Gemini's Phase 1 run in parallel, with Gemini's chapter index always staying at least 10 chapters behind Gemma's watermark. The 10-chapter lag is a HARD MINIMUM — if Gemini ever catches up (Gemma rate-limited, Gemini unexpectedly fast), Gemini pauses on a back-pressure semaphore until Gemma pulls ahead again. Phase 1 is ~5× the wall-clock of Phase 0 per chapter, so Gemini keeps churning long after Gemma's Phase 0 + Phase 0b consolidation finishes — the wall-clock win is roughly "Gemma's full Phase 0 time minus the 10-chapter lag." User clarified the original sequential model-split framing was wrong; intent is pipelined execution with bounded lag, not per-phase model anchoring.

- **`docs/features/88-analyzer-per-phase-model.md`** (full rewrite): new title "Pipelined two-model analyzer (Gemma cast + Gemini attribution, 10-chapter lag)". New module `server/src/analyzer/phase-watermark.ts` exposes `markPhase0ChapterComplete` / `markPhase0AllDone` / `awaitPhase1Dispatch`. Env knob renamed `ANALYZER_PHASE1_WARMUP_CHAPTERS` → **`ANALYZER_PHASE1_MIN_LAG_CHAPTERS`** (default `10`). The phase gate at `analysis.ts:2031-2055` is **replaced** by the watermark seam. Rolling roster snapshots replace one-shot Phase 0b; each Gemini worker reads the snapshot at dispatch time. Late-character drift handling is pragmatic in v1; full reconciliation deferred. Manual handoff flow detected and short-circuits to today's sequential behaviour.
- **`docs/BACKLOG.md`**: removes Could #23 (Speculative per-chapter Phase 1 / B2) — now absorbed by plan 88's re-scope. Renumbers Could #24/#25/#26 → #23/#24/#25.
- **`docs/features/89-frontend-perf-pass.md`**: updates the Could-#25/#26 cross-references to match the new #24/#25 numbering.

Status stays `draft` — the implementation agent will flip to `active` on Round 2 respawn. `npm run verify` green locally.

## Test plan

- [x] `npm run verify` green locally — `[cached]` on every step (docs-only diff).
- [x] Pre-commit hook accepted (`verify:fast` cached).
- [x] Pre-push hook accepted (`verify` cached).
- [ ] PR title-lint workflow accepts `docs(docs):`.
- [ ] CI Verify on the PR turns green.
- [ ] User confirms the pipelined design matches intent before merge; once approved, this lands, and I respawn the Round 2 worktree agent against the revised plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)