### PR TITLE
fix(server): regenerate no-op when chapter audio already exists

### DIFF
--- a/docs/features/31-sticky-generation.md
+++ b/docs/features/31-sticky-generation.md
@@ -58,6 +58,15 @@ Regenerate stays as displacement: a POST with `chapterIds + force`
 aborts the existing job before starting a fresh one with the new
 spec.
 
+The catch-up `chapter_complete` replay skips any chapter in the
+current run's scope (force-regen targets whose audio still exists on
+disk because the synthesis loop hasn't overwritten it yet). Emitting
+a "complete" tick for an in-scope chapter would race the live run and
+snap the row back to "Done" before the first live progress tick
+lands — exactly the failure mode that made the regen look like a
+no-op pre-fix. Pinned by `generation.test.ts > catch-up replay skips
+in-scope chapters so a force-regen does not snap back to "Done"`.
+
 2. **The `chapters.activeStream` snapshot is the source of truth for
    the global header pill.** It is set on `openHandle`, refreshed on
    every non-idle `applyGenerationTick`, and cleared on `closeHandle`.

--- a/server/src/routes/generation.test.ts
+++ b/server/src/routes/generation.test.ts
@@ -358,6 +358,60 @@ describe('POST /api/books/:bookId/generation', () => {
     ).toEqual({ prior: true });
   });
 
+  it('catch-up replay skips in-scope chapters so a force-regen does not snap back to "Done"', async () => {
+    /* Repro for screenshot 2026-05-21 174722: user changed a voice setting
+       on Exile (every chapter Done with audio on disk), hit "Regenerate
+       this chapter" on ch3, the activity log fired the right events but
+       the chapter row immediately snapped back to "Done" and no progress
+       UI ever appeared. Root cause: the catch-up replay (designed to snap
+       a reconnecting client to current on-disk state) was emitting a
+       chapter_complete for the very chapter about to be regenerated,
+       which raced the synthesis loop and froze the frontend row at the
+       stale duration.
+
+       Fix: the catch-up replay must skip any chapter in the current run's
+       scope. This test pins that invariant — and the negative control
+       (chapter 2 is OUT of scope and still gets its catch-up tick)
+       confirms the replay is still doing its job for unrelated chapters.
+
+       Catch-up tick convention (see Bug E doc-comment below): catch-up
+       ticks lack runTotal; live ticks always carry it. */
+    const fs = await import('node:fs');
+    const audioRoot = join(bookDir, 'audio');
+    if (fs.existsSync(audioRoot)) fs.rmSync(audioRoot, { recursive: true, force: true });
+    fs.mkdirSync(audioRoot, { recursive: true });
+    /* Both chapters have audio on disk before the request — like Exile. */
+    fs.writeFileSync(join(audioRoot, '01-chapter-one.mp3'), 'PRIOR-ch1');
+    fs.writeFileSync(join(audioRoot, '01-chapter-one.segments.json'), '{}');
+    fs.writeFileSync(join(audioRoot, '02-chapter-two.mp3'), 'PRIOR-ch2');
+    fs.writeFileSync(join(audioRoot, '02-chapter-two.segments.json'), '{}');
+
+    const res = await request(app)
+      .post(`/api/books/${bookId}/generation`)
+      .send({ modelKey: 'gemini-2.5-flash', force: true, chapterIds: [1] });
+    expect(res.status).toBe(200);
+    const ticks = parseTicks(res.text);
+
+    /* In-scope chapter (ch1): NO catch-up chapter_complete (would lack
+       runTotal), MUST have at least one live one (carries runTotal). */
+    const ch1Completes = ticks.filter(
+      (t) => t.type === 'chapter_complete' && t.chapterId === 1,
+    );
+    const ch1Catchup = ch1Completes.filter((t) => typeof t.runTotal !== 'number');
+    const ch1Live = ch1Completes.filter((t) => typeof t.runTotal === 'number');
+    expect(ch1Catchup).toHaveLength(0);
+    expect(ch1Live.length).toBeGreaterThan(0);
+
+    /* Out-of-scope chapter (ch2): MUST get a catch-up chapter_complete
+       (proves the replay still works for chapters not in the regen
+       target). No live one — ch2 isn't synthesised this run. */
+    const ch2Completes = ticks.filter(
+      (t) => t.type === 'chapter_complete' && t.chapterId === 2,
+    );
+    const ch2Catchup = ch2Completes.filter((t) => typeof t.runTotal !== 'number');
+    expect(ch2Catchup).toHaveLength(1);
+  });
+
   it('classifies XTTS "index out of range in self" as fatal on first hit', async () => {
     synthesiseImpl = async () => {
       throw new Error('Local TTS sidecar returned 500: {"detail":"index out of range in self"}');

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -304,6 +304,23 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
   const audioRoot = audioDir(bookDir);
   await mkdir(audioRoot, { recursive: true });
 
+  /* Decide which chapters to (re)generate. Default: every chapter that does
+     not already have an audio file on disk. `force` overrides existence.
+     Excluded chapters (front/back-matter the user opted out of narrating)
+     are always skipped — even an explicit requestedIds=[...] that lists an
+     excluded chapter is filtered out, since generating audio for an
+     excluded chapter would silently undo the user's choice.
+
+     Computed BEFORE the catch-up replay so the replay can skip in-scope
+     chapters (see comment on the replay loop). */
+  const targetChapters = state.chapters.filter((c) => {
+    if (c.excluded) return false;
+    if (requestedIds && !requestedIds.includes(c.id)) return false;
+    if (force) return true;
+    return !chapterAudioExists(audioRoot, c.slug);
+  });
+  const targetIdSet = new Set(targetChapters.map((c) => c.id));
+
   /* Catch-up replay: emit a chapter_complete for every chapter already on
      disk so a reconnecting client (post-pause, page refresh, etc.) snaps to
      the latest state without needing a separate GET. Cheap — one tick per
@@ -312,9 +329,18 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
 
      Excluded chapters are skipped — even if stale audio is still on disk
      from before they were excluded, we don't want to tell the frontend
-     the chapter is "complete" when the user opted out of narrating it. */
+     the chapter is "complete" when the user opted out of narrating it.
+
+     In-scope chapters (force-regen targets whose audio still exists on
+     disk because the synthesis loop hasn't overwritten it yet) are also
+     skipped — emitting chapter_complete here would race the live run and
+     snap the chapter's UI back to "Done" before the synthesis loop's
+     first progress tick lands, freezing the row at the stale duration
+     and making the regen look like a no-op. (Repro that prompted this
+     guard: screenshot 2026-05-21 174722.) */
   for (const ch of state.chapters) {
     if (ch.excluded) continue;
+    if (targetIdSet.has(ch.id)) continue;
     if (chapterAudioExists(audioRoot, ch.slug)) {
       const cachedSentences = analysis.chapters[ch.id] ?? [];
       send({
@@ -332,19 +358,6 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
       });
     }
   }
-
-  /* Decide which chapters to (re)generate. Default: every chapter that does
-     not already have an audio file on disk. `force` overrides existence.
-     Excluded chapters (front/back-matter the user opted out of narrating)
-     are always skipped — even an explicit requestedIds=[...] that lists an
-     excluded chapter is filtered out, since generating audio for an
-     excluded chapter would silently undo the user's choice. */
-  const targetChapters = state.chapters.filter((c) => {
-    if (c.excluded) return false;
-    if (requestedIds && !requestedIds.includes(c.id)) return false;
-    if (force) return true;
-    return !chapterAudioExists(audioRoot, c.slug);
-  });
 
   if (targetChapters.length === 0) {
     send({ type: 'idle' });
@@ -410,7 +423,6 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
      overwritten — done count rebounds via completedThisRun as it
      finishes). */
   const nonExcluded = state.chapters.filter((c) => !c.excluded);
-  const targetIdSet = new Set(targetChapters.map((c) => c.id));
   const runDoneBase = nonExcluded.filter(
     (c) => !targetIdSet.has(c.id) && chapterAudioExists(audioRoot, c.slug),
   ).length;


### PR DESCRIPTION
## Summary

Force-regen of a chapter whose audio file is still on disk (the usual case after a voice-tuning change) was a visible no-op: the activity log fired the expected events ("Generation started — 1 chapter", "Regenerated Chapter 3 — voice tuning updated"), but the chapter row immediately snapped back to **Done** with the old duration. Repro: screenshot 2026-05-21 174722 (Exile, 63 of 63 chapters Done, voice-tuning regen on chapter 3).

Root cause was server-side. The SSE catch-up replay in `server/src/routes/generation.ts:307-334` iterates every non-excluded chapter and, if its audio file exists on disk, emits `chapter_complete` so a reconnecting client snaps to current state without a separate GET. That replay was designed for the post-reload "subscribe" branch — but it also runs on the "start / displace" branch, which is what a force-regen lands on. Because the replay ran BEFORE `targetChapters` was computed, it had no notion of which chapters were about to be re-synthesised, and the chapter being regenerated got a `chapter_complete` tick in the catch-up frame. The frontend's `applyGenerationTick` reducer flipped the row back to `state='done'`, `progress=1` before the synthesis loop's first live progress tick could land — the synthesis ran but the UI never visibly left "Done".

Fix: reorder the route so `targetChapters` / `targetIdSet` are computed **before** the catch-up replay, then skip any in-scope chapter inside the replay loop. The existing `runDoneBase` aggregate already filtered `!targetIdSet.has(c.id)` for the same reason — we apply the same guard one layer up. No call-site changes elsewhere: the synthesis loop and `nonExcluded` consume the same variables as before.

## What landed

- **server/src/routes/generation.ts** — moved `targetChapters` filter + `targetIdSet` derivation above the catch-up replay; added `if (targetIdSet.has(ch.id)) continue;` guard inside the replay loop; updated the replay comment to call out the new guard and link the repro screenshot; deleted the now-duplicate `targetIdSet` derivation further down.
- **server/src/routes/generation.test.ts** — new regression test \`catch-up replay skips in-scope chapters so a force-regen does not snap back to "Done"\`. Seeds audio on disk for chapters 1 and 2, POSTs a force-regen scoped to chapter 1, asserts (a) no catch-up `chapter_complete` for chapter 1 (only a live one with `runTotal` set), (b) chapter 2 still gets its catch-up `chapter_complete` (negative control proves the replay still works for out-of-scope chapters). Negative-control run with the production fix stashed produced exactly the bug shape (1 catch-up tick for ch1 where 0 are expected).
- **docs/features/31-sticky-generation.md** — added a paragraph to invariant 1a calling out that the catch-up replay must skip in-scope chapters, with a pointer to the new regression test.

## Contract changes

None at the API surface. The behaviour change is observable only in the SSE event stream for a force-regen against chapters whose audio still exists on disk: pre-fix you saw `chapter_complete` for the in-scope chapter twice (once catch-up, once live), post-fix only the live one fires.

## Test coverage

- New regression test in `server/src/routes/generation.test.ts` (above). All 17 tests in that file pass; full server suite green at 1237 passed / 8 skipped.
- `npm run verify` cache-green on every step (lint, typecheck, test:hooks, test, test:server, test:scripts, test:sidecar, test:e2e, build).

## Test plan

- [x] `cd server && npm run test -- generation.test.ts` — new spec passes; existing tests stay green.
- [x] Negative control: stash production fix, re-run new spec → fails with expected shape (1 catch-up tick for ch1 where 0 expected).
- [x] `npm run verify` — full battery green.
- [ ] Manual: `npm start`, open Generation view for a book with all chapters Done, change a voice setting, click **Regenerate this chapter** on a mid-book chapter → confirm row flips Done → Queued → Synthesising (with a moving progress bar) → Done with a **fresh** duration / timestamp. Repeat with the top-right **Regenerate** button (forward scope) for the whole book.

🤖 Generated with [Claude Code](https://claude.com/claude-code)