### PR TITLE
docs(docs): file Could #28 + #29 follow-ups from PR #101 chapter-title work

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -322,6 +322,26 @@ Source: net-new (2026-05-21). Deferred from plan 87 implementation — server si
 - _Depends on:_ plan 87 server-side worker pool (shipped).
 - _Benefit (user/technical):_ closes the mock/real parity gap so the parallel SSE wire shape is visually exercised in dev mode and CI gates regressions. Today the parallel orchestration is only pinned at the server vitest layer.
 
+### 28. Configurable chapter-title silence durations
+
+Source: [`28-chapter-audio-format.md`](features/28-chapter-audio-format.md) follow-up — net-new (2026-05-21). Deferred from PR #101 (`fix/server-voiced-chapter-titles-and-pauses`).
+
+- _What:_ Promote the two hard-coded constants `CHAPTER_LEAD_SILENCE_SEC = 1.5` and `CHAPTER_POST_TITLE_SILENCE_SEC = 1.5` in `server/src/tts/synthesise-chapter.ts` to a per-book setting on `state.json`. Surface in the Listen view's metadata editor (the same panel that already edits narratorCredit / genre / etc.) as a "Chapter break duration" slider with a small preset list (e.g. 0.5/1/1.5/2/3 s) for the leading + post-title legs. Generation route reads the per-book values and forwards into `synthesiseChapter` opts.
+- _Acceptance:_ Editing a book's silence durations and regenerating one chapter produces an MP3 whose leading + post-title silence matches the new setting (ffprobe / spectrogram). Default for legacy books stays 1.5 + 1.5. Existing chapter-audio-format paired tests stay green.
+- _Key files:_ `server/src/tts/synthesise-chapter.ts` (params); `server/src/routes/generation.ts` (forward); `server/src/workspace/scan.ts` (state-json field); `src/components/listen/listen-header.tsx` or sibling metadata editor (UI); `openapi.yaml` (book-state shape).
+- _Depends on:_ none.
+- _Benefit (user):_ lets the user pace chapter breaks to match book length / mood (a tight 0.5 s for a short kids' book, a longer 3 s for a slow-burn novel) without code changes. Today the 3.0 s default is "audiobook-standard" but not universally right.
+
+### 29. Render the chapter-title segment on the Listen view timeline
+
+Source: [`28-chapter-audio-format.md`](features/28-chapter-audio-format.md) follow-up — net-new (2026-05-21). Deferred from PR #101 (`fix/server-voiced-chapter-titles-and-pauses`).
+
+- _What:_ The new title segment in `segments.json` (kind: `'title'`, empty `sentenceIds[]`) is currently filtered out at the `ChapterAudio` API boundary in `server/src/routes/chapter-audio.ts` because the wire contract types `sentenceId` as a required integer. To surface the title on the listen-view timeline (a labelled "TITLE" pill anchored at the start of the chapter, ~3 s wide including silence), widen the API segment shape so `sentenceId` is optional and add an optional `kind?: 'title' | 'sentence'` discriminator, regenerate `src/lib/api-types.ts`, then teach `src/components/listen/listen-player-region.tsx` to render title-kind segments differently from sentence-kind segments.
+- _Acceptance:_ The listen view's chapter timeline shows a short "TITLE" pill at the head of each chapter rendered after this lands. Clicking it seeks to t=0. Pre-existing chapters whose `segments.json` has no title-kind row degrade gracefully (no title pill — same as today).
+- _Key files:_ `openapi.yaml` (ChapterAudio segments shape); `src/lib/api-types.ts` (regenerated); `server/src/routes/chapter-audio.ts` (drop the filter, pass kind through); `src/components/listen/listen-player-region.tsx`.
+- _Depends on:_ none (the on-disk segment shape already carries `kind: 'title'` since PR #101).
+- _Benefit (user):_ visual cue that matches the audible cue — listener sees "you're hearing the title now" before the body segments start. Today the title beat is audible-only.
+
 ---
 
 ## Won't (this round) — explicitly parked


### PR DESCRIPTION
## Summary

PR #101 (`fix/server-voiced-chapter-titles-and-pauses`) called out two follow-ups under its plan's "Out of scope" section that should sit on BACKLOG so they're picked up in a future round rather than getting lost. Both are net-new Could-bucket items, appended at the bottom of the Could bucket per the no-renumber convention.

## What's filed

**#28 Configurable chapter-title silence durations** — promote the hard-coded `CHAPTER_LEAD_SILENCE_SEC = 1.5` and `CHAPTER_POST_TITLE_SILENCE_SEC = 1.5` in `server/src/tts/synthesise-chapter.ts` to a per-book state-json setting with a Listen-view metadata-editor slider (e.g. 0.5/1/1.5/2/3 s presets). Default stays 1.5 + 1.5 for legacy books. _Benefit:_ lets the user pace chapter breaks to match book length / mood without code changes.

**#29 Render the chapter-title segment on the listen-view timeline** — title segments already land in `segments.json` with `kind: 'title'` since PR #101, but the `ChapterAudio` API filters them out because `sentenceId` is typed as a required integer. Widen the wire shape (sentenceId optional, add kind discriminator), regenerate `src/lib/api-types.ts`, and render title-kind segments as a labelled pill at the head of each chapter timeline. _Benefit:_ visual cue that matches the audible cue.

## Why a separate docs PR

CLAUDE.md's convention is to file follow-ups in the same PR that ships the parent work. PR #101 already merged, so the next-best is a tight docs PR that keeps BACKLOG current before the items are forgotten.

## Test plan

- [x] BACKLOG.md edits append cleanly at the bottom of the Could bucket (#28 + #29; no renumber).
- [x] `npm run verify` pre-push gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)