### PR TITLE
fix(server): pin output -ar after loudnorm filter for ffmpeg 8.x

### DIFF
--- a/docs/features/71-audio-loudness-normalization.md
+++ b/docs/features/71-audio-loudness-normalization.md
@@ -115,6 +115,7 @@ The chapter still lands on disk; only the `.lufs.json` sidecar is missing. Real-
 - `server/src/tts/mp3-spawn-args.test.ts` — module-level mock of `node:child_process.spawn`:
   - No `loudnorm` option → no `-af loudnorm` flag in args (back-compat).
   - `twoPass: false` → exactly one ffmpeg spawn with `-af loudnorm=I=-16:LRA=11:TP=-1.5:linear=true`.
+  - With loudnorm → every codec builder (mp3 / aac-m4a / opus) emits an output `-ar` between `-af` and `-c:a` matching the input sample rate (locks the 2026-05-21 ffmpeg-8 fix — see "Post-ship correction" below).
 - `server/src/tts/mp3.test.ts` — `writeChapterLufsFile` coverage: round-trips payload, atomic rename leaves no `.tmp-*` droppings.
 
 ### Manual acceptance walkthrough
@@ -141,3 +142,15 @@ Requires a real chapter generation against a live sidecar (or the cached PCM tri
 ## Ship notes
 
 Shipped 2026-05-20 on branch `feat/server-audio-loudnorm`. Implementation adds `server/src/tts/loudnorm.ts` (new file, ~220 lines) + extends `server/src/tts/mp3.ts` with the `loudnorm` option + sibling `writeChapterLufsFile`. Generation call site at `server/src/routes/generation.ts` wires `AUDIO_LOUDNORM_ENABLED` (default ON) and the sidecar write callback. Voice-sample call site annotated to make the deliberate skip explicit. 17 new automated tests across `loudnorm.test.ts` (12), `mp3-spawn-args.test.ts` (2), `mp3.test.ts` (3 — `writeChapterLufsFile` coverage).
+
+### Post-ship correction (2026-05-21) — ffmpeg 8.x sample-rate output drift
+
+Bug: 5 chapters of *Exile* regenerated on 2026-05-21 produced MP3s with duration **3.05–3.07× the segments.json `durationSec`**. Audio played at correct pitch and ran the full inflated length on disk (verified: `ffprobe 03-chapter-one-one.mp3` = 2061 s vs `segments.json.durationSec` = 674 s). Chapters generated 2026-05-20 with the same engine / sample rate / loudnorm config were unaffected.
+
+Root cause: ffmpeg's `loudnorm` filter resamples internally to 192 kHz for EBU R128 processing. Under ffmpeg 7.x the filter chain reached libmp3lame at the input sample rate; under ffmpeg 8.x (the user upgraded from 7.x to 8.1.1-full_build-www.gyan.dev between the two synth dates) the filter's output stream metadata reached the encoder at the wrong rate, producing the 3.05× duration stretch on 24 kHz mono Kokoro PCM. The MP3 declares 48 kHz / 32 kbps — both wrong (input is 24 kHz, V2 VBR should be ~190 kbps) and both explained by the broken sample-rate pipeline.
+
+Fix: explicit output `-ar String(opts.sampleRate)` in `server/src/tts/mp3.ts` `buildMp3FfmpegArgs` / `buildAacFfmpegArgs` / `buildOpusFfmpegArgs`, threaded between the `-af <filter>` and `-c:a <codec>` flags. The encoder boundary now owns the rate contract regardless of filter-chain behaviour. Filter strings in `loudnorm.ts` unchanged.
+
+Regression test: `server/src/tts/mp3-spawn-args.test.ts` adds three parameterised cases (mp3 / aac-m4a / opus) asserting an output `-ar` flag exists strictly between `-af` and `-c:a` and carries the input sample rate. Contract-level rather than ffprobe-end-to-end because the bug only manifests on real-speech PCM with non-trivial dynamic range — synthetic sine / noise PCM does not reproduce the 3× stretch even on the broken pipeline.
+
+Backfill: re-synthesize the 5 affected Exile chapters (`03-chapter-one-one`, `04-chapter-two-two`, `05-chapter-three-three`, `06-chapter-four-four`, `08-chapter-six-six`) and delete their stale `.previous.mp3` rollback files (same corrupted bytes — accepting a rollback would replay the bug). Discovery rule for any future audit: broken iff `ffprobe duration / segments.json durationSec > 1.5`.

--- a/server/src/tts/mp3-spawn-args.test.ts
+++ b/server/src/tts/mp3-spawn-args.test.ts
@@ -84,4 +84,58 @@ describe('encodePcmToAudio spawn args', () => {
     expect(args[afIndex + 1]).toBe('loudnorm=I=-16:LRA=11:TP=-1.5:linear=true');
     expect(args[afIndex + 1]).not.toContain('measured_');
   });
+
+  /* Regression for the ffmpeg 8.x loudnorm sample-rate drift (5 Exile
+     chapters corrupted on 2026-05-21 — 3.05x duration MP3s on 24 kHz
+     Kokoro PCM). The loudnorm filter resamples internally to 192 kHz;
+     ffmpeg 7.x followed the input rate at the filter output, 8.x did
+     not. Fix: every codec builder must emit an explicit output `-ar`
+     AFTER the `-af` flag, BEFORE the `-c:a` flag, so the encoder
+     receives stream metadata pinned to the input rate regardless of
+     filter-chain behaviour. */
+  describe.each([
+    {
+      format: 'mp3' as const,
+      codec: 'libmp3lame',
+    },
+    {
+      format: 'aac-m4a' as const,
+      codec: /^(libfdk_aac|aac)$/,
+    },
+    {
+      format: 'opus' as const,
+      codec: 'libopus',
+    },
+  ])('$format loudnorm output rate pinning', ({ format, codec }) => {
+    it('emits an output -ar matching the input rate between -af and -c:a', async () => {
+      const { encodePcmToAudio } = await import('./mp3.js');
+      const sampleRate = 24_000;
+      await encodePcmToAudio(Buffer.alloc(2), sampleRate, {
+        format,
+        quality: 2,
+        loudnorm: { target: -16, lra: 11, tp: -1.5, twoPass: false },
+      });
+
+      const args = spawnMock.mock.calls[0][1] as string[];
+      const afIndex = args.indexOf('-af');
+      const caIndex = args.indexOf('-c:a');
+      expect(afIndex).toBeGreaterThanOrEqual(0);
+      expect(caIndex).toBeGreaterThan(afIndex);
+
+      /* The output `-ar` that fixes the bug lives between `-af` and `-c:a`.
+         There is also an input `-ar` BEFORE the `-i pipe:0` flag; that one
+         must NOT be confused for the output one. We look for `-ar` strictly
+         in the (afIndex, caIndex) window. */
+      let outputArIdx = -1;
+      for (let i = afIndex + 2; i < caIndex; i += 1) {
+        if (args[i] === '-ar') {
+          outputArIdx = i;
+          break;
+        }
+      }
+      expect(outputArIdx, 'output -ar missing between -af and -c:a').toBeGreaterThan(-1);
+      expect(args[outputArIdx + 1]).toBe(String(sampleRate));
+      expect(args[caIndex + 1]).toMatch(codec);
+    });
+  });
 });

--- a/server/src/tts/mp3.ts
+++ b/server/src/tts/mp3.ts
@@ -132,6 +132,13 @@ function buildMp3FfmpegArgs(opts: FfmpegBuildOpts): string[] {
     '-i',
     'pipe:0',
     ...(opts.loudnormFilter ? ['-af', opts.loudnormFilter] : []),
+    /* Pin the output sample rate. The loudnorm filter resamples internally
+       to 192 kHz; ffmpeg 8.x stopped resampling back to the input rate at
+       the filter output, which left libmp3lame encoding at the wrong rate
+       and produced 3.05x duration MP3s on 24 kHz Kokoro PCM. Explicit
+       output `-ar` constrains the encoder regardless of filter behaviour. */
+    '-ar',
+    String(opts.sampleRate),
     '-c:a',
     'libmp3lame',
     '-q:a',
@@ -167,6 +174,11 @@ function buildAacFfmpegArgs(opts: FfmpegBuildOpts): string[] {
     '-i',
     'pipe:0',
     ...(opts.loudnormFilter ? ['-af', opts.loudnormFilter] : []),
+    /* See buildMp3FfmpegArgs for the rationale — pin output `-ar` so the
+       loudnorm filter's 192 kHz internal stream doesn't reach the encoder
+       at the wrong rate under ffmpeg 8.x. */
+    '-ar',
+    String(opts.sampleRate),
     ...(useFdk ? ['-c:a', 'libfdk_aac', '-vbr', '4'] : ['-c:a', 'aac', '-b:a', '128k']),
     /* Fragmented mp4 so the muxer can stream to stdout: `empty_moov`
        skips the seek-back-and-write-moov dance; `frag_keyframe` starts a
@@ -200,6 +212,12 @@ function buildOpusFfmpegArgs(opts: FfmpegBuildOpts): string[] {
     '-i',
     'pipe:0',
     ...(opts.loudnormFilter ? ['-af', opts.loudnormFilter] : []),
+    /* See buildMp3FfmpegArgs for the rationale — pin output `-ar`. libopus
+       only accepts 8/12/16/24/48 kHz internally and will resample as
+       needed; the explicit `-ar` keeps the filter chain from pushing
+       192 kHz samples into the encoder unannounced. */
+    '-ar',
+    String(opts.sampleRate),
     '-c:a',
     'libopus',
     '-b:a',


### PR DESCRIPTION
## Summary

ffmpeg 8.x changed the `loudnorm` filter's sample-rate output handling. Five chapters of *Exile* regenerated on 2026-05-21 against `ffmpeg 8.1.1-full_build-www.gyan.dev` ended up as 8.2 MB / 32 kbps / 2061 s MP3s instead of the expected 16 MB / 190 kbps / 674 s — playable but **3.058× too long on disk**, breaking the listen-view chapter row vs mini-player total-time agreement. Older chapters generated on ffmpeg 7.x with identical engine / sample rate / loudnorm config played correctly. Root cause: loudnorm resamples internally to 192 kHz; 7.x followed the input rate at the filter output, 8.x doesn't, leaving libmp3lame to encode at the wrong rate on 24 kHz Kokoro PCM.

- **Encoder fix** — `server/src/tts/mp3.ts` `buildMp3FfmpegArgs` / `buildAacFfmpegArgs` / `buildOpusFfmpegArgs` now each emit an explicit output `-ar String(opts.sampleRate)` between the `-af` and `-c:a` flags. The encoder boundary owns the rate contract regardless of filter-chain behaviour, so future ffmpeg version drift on the loudnorm filter cannot re-introduce this class of bug. Filter strings in `loudnorm.ts` unchanged — single seam, minimal change.
- **Regression test** — `server/src/tts/mp3-spawn-args.test.ts` adds three parameterised cases (mp3 / aac-m4a / opus) asserting an output `-ar` exists strictly between `-af` and `-c:a` and carries the input sample rate. Stashing the fix and rerunning makes all three fail with `output -ar missing between -af and -c:a` — confirmed as the regression gate. Contract-level rather than ffprobe-end-to-end because the bug only manifests on real-speech PCM with non-trivial dynamic range; synthetic sine / noise PCM does not reproduce the 3× stretch even on the broken pipeline.
- **Plan 71 ship-notes** — `docs/features/71-audio-loudness-normalization.md` gets a "Post-ship correction (2026-05-21)" section documenting the symptom, root cause, fix, regression-test rationale, and backfill steps. Test plan section gets one new bullet covering the new spawn-args case.

## User-visible / operator delta

- After this lands, every chapter encode with loudnorm produces a correct-duration audio file regardless of which ffmpeg major version is installed. No frontend / OpenAPI / state.json / segments.json shape changes.
- **Backfill required** for any chapter rendered between the ffmpeg 7→8 upgrade and this fix landing. Discovery rule for an audit: broken iff `ffprobe duration / segments.json durationSec > 1.5`. In the user's workspace today this is exactly 5 files, all in *Exile*: `03-chapter-one-one`, `04-chapter-two-two`, `05-chapter-three-three`, `06-chapter-four-four`, `08-chapter-six-six`. Re-synthesize on the fixed code; delete the matching `.previous.mp3` rollback files (same corrupted bytes — accepting a rollback would replay the bug). No way to recover from the existing MP3 bytes alone.

## Test plan

- [x] `npm run verify:fast` (pre-commit gate) — 1249 passed / 8 skipped on `cd server`.
- [x] `npm run verify` (pre-push gate) — typecheck + frontend + server + sidecar + scripts + e2e + build all green.
- [x] Stash the encoder edits, rerun `server && npm test src/tts/mp3-spawn-args.test.ts` — three new cases fail with `output -ar missing between -af and -c:a`. Pop the stash, rerun — all five pass. Confirms the regression gate works on both directions.
- [ ] Post-merge manual: regenerate one of the 5 affected Exile chapters. `ffprobe -show_entries format=duration -of csv=p=0` on the resulting MP3 should be within 0.5 s of `segments.json.durationSec` (was 3.058× over before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)