### PR TITLE
fix(scripts): scrub GIT_DIR env in bump-version.test.mjs subprocess calls

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -69,16 +69,6 @@ Source: net-new (2026-05-21). Surfaced during the plan 87/88/89 ship round — b
 - _Depends on:_ none.
 - _Benefit (technical):_ restores pre-push as a real merge gate. Today flaky specs train reviewers to retry pre-push reflexively, which masks genuine regressions. Also unblocks future docs-only branches that legitimately don't touch e2e but get gated on these.
 
-### 3. Fix `bump-version.test.mjs` GIT_DIR leak that breaks worktree pre-commit
-
-Source: net-new (2026-05-21). Surfaced again during the plan 87/88/89 ship round; documented as a workaround in user memory `feedback_worktree_precommit_git_env_leak` since 2026-05 but no permanent fix in tree. Memory says "commit from main checkout until BACKLOG #25 lands" — that's the workaround, not the fix.
-
-- _What:_ In `scripts/tests/bump-version.test.mjs`, the test inherits the husky hook's env (including `GIT_DIR`, `GIT_WORK_TREE`) into its git subprocess calls. When the test runs as part of pre-commit inside a worktree, those leaked vars point its subprocess at the wrong git directory, producing the cryptic `expected: /Fixes:/ … actual: ''` assertion failure even though standalone `npm run test:hooks` passes 190/190. Fix: explicitly scrub the inherited `GIT_*` env vars in the subprocess spawn (e.g. `{ env: { ...filterGitEnv(process.env) } }`), so the test always operates against the checked-out repo, regardless of whether it's invoked from a husky hook, a worktree, or a bare shell.
-- _Acceptance:_ Commit from a worktree (e.g. `node scripts/wt-new.mjs <branch>`, edit anything, `git commit`) — pre-commit runs cleanly without the GIT_DIR leak. The "commit from main checkout" workaround in `feedback_worktree_precommit_git_env_leak` becomes obsolete; memory updates to drop the workaround line. Pester or node-test suite gains a regression case that simulates a polluted env and asserts the subprocess still sees the right repo.
-- _Key files:_ `scripts/tests/bump-version.test.mjs`; possibly `scripts/lib/git-helpers.mjs` if env scrubbing is hoisted to a shared helper.
-- _Depends on:_ none.
-- _Benefit (technical):_ unblocks the always-worktree standard. Today every committer in a worktree has to either bypass with `--no-verify` (against the rules) or context-switch back to main checkout for every commit. The leak has been documented for ~2 weeks; time to actually fix it.
-
 ---
 
 ## Could — nice to have, low-cost wins

--- a/scripts/tests/bump-version.test.mjs
+++ b/scripts/tests/bump-version.test.mjs
@@ -146,11 +146,10 @@ test('bump-version --level patch advances both versions, commits, tags', () => {
     const tags = gitExec( ['tag', '--list'], { cwd: dir, encoding: 'utf8' }).trim();
     assert.equal(tags, 'v1.2.4');
 
-    const annotation = execFileSync(
-      'git',
-      ['tag', '-l', '--format=%(contents)', 'v1.2.4'],
-      { cwd: dir, encoding: 'utf8' },
-    );
+    const annotation = gitExec(['tag', '-l', '--format=%(contents)', 'v1.2.4'], {
+      cwd: dir,
+      encoding: 'utf8',
+    });
     assert.match(annotation, /v1\.2\.4/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -214,11 +213,10 @@ test('bump-version --notes-file uses file content as the tag annotation', () => 
     rmSync(notes, { force: true });
     assert.equal(out.status, 0, out.stderr);
 
-    const annotation = execFileSync(
-      'git',
-      ['tag', '-l', '--format=%(contents)', 'v1.0.1'],
-      { cwd: dir, encoding: 'utf8' },
-    );
+    const annotation = gitExec(['tag', '-l', '--format=%(contents)', 'v1.0.1'], {
+      cwd: dir,
+      encoding: 'utf8',
+    });
     assert.match(annotation, /Fixes:/);
     assert.match(annotation, /the bug/);
   } finally {
@@ -245,6 +243,48 @@ test('bump-version refuses a dirty tree (unless --dry-run)', () => {
     assert.notEqual(out.status, 0);
     assert.match(out.stderr, /Working tree is not clean/);
   } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/* Regression for BACKLOG Should #3: a polluted GIT_DIR / GIT_WORK_TREE /
+   GIT_INDEX_FILE env (the shape husky's pre-commit hook produces when run
+   inside a worktree) must NOT misdirect any subprocess call in this test
+   to the parent repo. Before the fix, two bare execFileSync('git', …)
+   callsites bypassed gitExec()'s env scrubbing — they read `git tag -l`
+   from whichever repo the leaked GIT_DIR pointed at, which in worktree
+   pre-commit was the parent .git (no v1.0.1 tag there → empty annotation
+   → `assert.match(annotation, /Fixes:/)` fails with actual: ''). */
+test('polluted GIT_* env cannot misdirect subprocess from throwaway repo', () => {
+  const dir = setupRepo('1.0.0');
+  const saved = {
+    GIT_DIR: process.env.GIT_DIR,
+    GIT_WORK_TREE: process.env.GIT_WORK_TREE,
+    GIT_INDEX_FILE: process.env.GIT_INDEX_FILE,
+  };
+  try {
+    process.env.GIT_DIR = resolve(tmpdir(), 'sentinel.git');
+    process.env.GIT_WORK_TREE = resolve(tmpdir(), 'sentinel-worktree');
+    process.env.GIT_INDEX_FILE = resolve(tmpdir(), 'sentinel-index');
+
+    const notes = resolve(tmpdir(), `bump-notes-leak-${process.pid}-${Date.now()}.md`);
+    writeFileSync(notes, '# v1.0.1\n\nFixes:\n- the leak\n');
+    const out = runBump(dir, ['--level', 'patch', '--notes-file', notes]);
+    rmSync(notes, { force: true });
+    assert.equal(out.status, 0, out.stderr);
+
+    /* Tag-annotation read was the canonical failing line pre-fix. */
+    const annotation = gitExec(['tag', '-l', '--format=%(contents)', 'v1.0.1'], {
+      cwd: dir,
+      encoding: 'utf8',
+    });
+    assert.match(annotation, /Fixes:/);
+    assert.match(annotation, /the leak/);
+  } finally {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
     rmSync(dir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary

Removes the long-standing GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE leak that broke `scripts/tests/bump-version.test.mjs` whenever it ran from inside a husky pre-commit hook in a worktree context. The test was 90 % env-clean already — a `cleanGitEnv()` helper plus a `gitExec()` wrapper covered every spawn — but two bare `execFileSync('git', ['tag', '-l', '--format=%(contents)', …])` callsites at lines 149 and 217 bypassed the wrapper. Under a worktree pre-commit, the inherited env vars pointed those subprocess reads at the parent repo (no `vX.Y.Z` tag there → empty annotation → `assert.match(annotation, /Fixes:/)` failed with the famous `actual: ''`). Standalone `npm run test:hooks` always passed, which made the leak hard to diagnose — only the hook context tripped it.

## What changed

- **`scripts/tests/bump-version.test.mjs`** — both bare `execFileSync` calls converted to `gitExec()` so they pick up `cleanGitEnv()` like every other git spawn in the file.
- **New regression test** (`polluted GIT_* env cannot misdirect subprocess from throwaway repo`) — explicitly sets `process.env.GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE` to sentinel paths, runs the full `--notes-file` bump flow, and asserts the tag annotation still contains the expected text. Restores the saved env in `finally` so it doesn't leak into sibling tests.
- **`docs/BACKLOG.md`** — Should #3 bullet removed. Backlog hygiene per CLAUDE.md.
- **User memory `feedback_worktree_precommit_git_env_leak.md`** — deleted (workaround no longer needed; the bug is fixed in tree).

## Test plan

- [x] `npm run test:hooks` — 191/191 green (was 190 — new regression test added).
- [x] Shell-level smoke: `env GIT_DIR=/tmp/sentinel.git GIT_WORK_TREE=/tmp/sentinel-worktree GIT_INDEX_FILE=/tmp/sentinel.index npm run test:hooks` — also 191/191. Confirms the fix holds even when the leak comes from the parent shell rather than the in-test sentinel.
- [x] Pre-commit + pre-push hooks fired locally on this branch — all green, including the cached pre-push battery.
- [ ] Post-merge: worktree pre-commit smoke — spawn `node scripts/wt-new.mjs <branch>`, edit anything, `git commit`. Pre-commit should run clean. (Will validate as the Wave 2 worktrees spawn against the merged main.)

## Unblocks

Wave 2 of the current round (Should #2 + Could #26 + Could #31) all want fresh worktrees per user memory `feedback_worktree_when_parallel_agents_possible`. Until this leak was fixed, worktree pre-commits failed mysteriously and every committer had to either bypass with `--no-verify` (against repo policy) or context-switch back to the main checkout. Shipping this first makes the Wave 2 branches commit cleanly from their own worktrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)