### PR TITLE
fix(e2e): de-flake cast-drawer + download-tiles vs plan 89 lazy boundaries

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -59,16 +59,6 @@ Source: net-new (2026-05-21). Spun off from the perf-tuning survey at `~/.claude
 - _Depends on:_ none.
 - _Benefit (user):_ unblocks long chapters in the manuscript view — today the worst frontend pain point. Pairs with Could #25 (confirm-cast + listen-chapter virtualisation) which reuses the same dep.
 
-### 2. De-flake `cast-drawer` + `download-tiles` Playwright specs
-
-Source: net-new (2026-05-21). Surfaced during the plan 87/88/89 ship round — both specs failed first run then passed on retry, reliably enough that Playwright marked them "flaky" and exited non-zero, blocking pre-push for unrelated docs branches. User asked for it as Should so it gets done soon.
-
-- _What:_ Investigate the failure mode for `e2e/cast-drawer.spec.ts:24:3` ("clicking a character opens the drawer with evidence + toggleable 'Show more'") and `e2e/download-tiles.spec.ts:29:3` ("plan 57 — M4B tile is live and opens the export modal with m4b pre-selected"). Both fail on `expect(locator).toBeVisible()` — likely timing against the new `React.lazy` Suspense boundaries from plan 89 (route splitting) where the modal/drawer DOM nodes aren't mounted until the lazy chunk loads. Fix is probably either (a) wait for a stable post-suspense locator first (e.g. the route's heading), then drill in; or (b) bump the per-locator timeout for these two assertions. NOT a `test.retry()` band-aid — those would mask real regressions.
-- _Acceptance:_ Run `npm run test:e2e` 5× in succession from a clean main; both specs are green on first attempt every time, no Playwright "flaky" classification, exit code 0. The fix must NOT introduce arbitrary `waitFor(timeout)` constants — use proper element-stability waits.
-- _Key files:_ `e2e/cast-drawer.spec.ts`, `e2e/download-tiles.spec.ts`; potentially `e2e/helpers/*.ts` if a shared "wait for lazy route to mount" helper is needed.
-- _Depends on:_ none.
-- _Benefit (technical):_ restores pre-push as a real merge gate. Today flaky specs train reviewers to retry pre-push reflexively, which masks genuine regressions. Also unblocks future docs-only branches that legitimately don't touch e2e but get gated on these.
-
 ---
 
 ## Could — nice to have, low-cost wins

--- a/e2e/cast-drawer.spec.ts
+++ b/e2e/cast-drawer.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { goToConfirm } from './helpers';
+import { goToConfirm, waitForRouteReady } from './helpers';
 
 /**
  * Cast → profile drawer flow — plan 37 follow-on.
@@ -25,6 +25,7 @@ test.describe('cast view → profile drawer', () => {
     page,
   }) => {
     await goToConfirm(page);
+    await waitForRouteReady(page);
 
     /* Confirm-cast view renders character cards. Each card has
        aria-label="Open profile for <name>" (src/views/confirm-cast.tsx:241).
@@ -37,7 +38,7 @@ test.describe('cast view → profile drawer', () => {
     /* Drawer opens. The "Evidence from the manuscript" section is the
        load-bearing assertion — proves the drawer mounted with the right
        character hydrated. */
-    await expect(page.getByText(/Evidence from the manuscript/i)).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText(/Evidence from the manuscript/i)).toBeVisible({ timeout: 10_000 });
 
     /* Initial state: 3 quotes shown, "+ Show 1 more" toggle visible. */
     const showMore = page.getByRole('button', { name: /Show 1 more/i });

--- a/e2e/download-tiles.spec.ts
+++ b/e2e/download-tiles.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { waitForRouteReady } from './helpers';
 
 /**
  * Plan 57 + plan 67 — Listen-view download tiles e2e.
@@ -24,6 +25,7 @@ test.describe('plan 57 — download tiles', () => {
     await expect(page.getByRole('heading', { name: /Solway Bay/i, level: 1 })).toBeVisible({
       timeout: 10_000,
     });
+    await waitForRouteReady(page);
   });
 
   test('M4B tile is live and opens the export modal with m4b pre-selected', async ({ page }) => {
@@ -35,7 +37,7 @@ test.describe('plan 57 — download tiles', () => {
     // Modal mounts. Use the modal's own testid + the format-picker
     // selected-state attribute exposed by export-audiobook.tsx
     // (data-testid="export-format-m4b" on the M4B format pill).
-    await expect(page.getByTestId('export-audiobook-modal')).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByTestId('export-audiobook-modal')).toBeVisible({ timeout: 10_000 });
     await expect(page.getByTestId('export-format-m4b')).toBeVisible();
   });
 
@@ -47,7 +49,7 @@ test.describe('plan 57 — download tiles', () => {
     const button = tile.getByRole('button', { name: /Download/i });
     await expect(button).toBeEnabled();
     await button.click();
-    await expect(page.getByTestId('export-audiobook-modal')).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByTestId('export-audiobook-modal')).toBeVisible({ timeout: 10_000 });
     await expect(page.getByTestId('export-format-mp3-zip')).toBeVisible();
   });
 
@@ -61,11 +63,11 @@ test.describe('plan 57 — download tiles', () => {
     await button.click();
 
     // Share-link modal mounts with the slugged URL in a copyable input.
-    await expect(page.getByTestId('share-link-modal')).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByTestId('share-link-modal')).toBeVisible({ timeout: 10_000 });
     const urlInput = page.getByTestId('share-link-url');
     // Mock createBookShareLink resolves to `${origin}/share/<12-char slug>`.
     await expect(urlInput).toHaveValue(/\/share\/[0-9ABCDEFGHJKMNPQRSTVWXYZ]{12}$/, {
-      timeout: 3_000,
+      timeout: 10_000,
     });
     const copyButton = page.getByTestId('share-link-copy');
     await expect(copyButton).toBeEnabled();

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -62,3 +62,14 @@ export async function goToConfirm(page: Page): Promise<void> {
     page.getByRole('button', { name: /Confirm cast and review manuscript/i }),
   ).toBeVisible({ timeout: 5_000 });
 }
+
+/* Plan 89 C5 — DelayedSpinner paints at +150 ms while a React.lazy chunk
+ * is in flight. Waiting for it to detach gives the lazy view a determi-
+ * nistic mount point regardless of cache warmth. Warm cache: spinner
+ * never paints; this resolves immediately. Cold cache: blocks until the
+ * lazy chunk resolves and Suspense swaps to the real view. */
+export async function waitForRouteReady(page: Page): Promise<void> {
+  await page
+    .locator('[data-testid="route-suspense-fallback"]')
+    .waitFor({ state: 'detached', timeout: 15_000 });
+}


### PR DESCRIPTION
## Summary

Both `e2e/cast-drawer.spec.ts` and `e2e/download-tiles.spec.ts` raced the React.lazy + Suspense + DelayedSpinner chain plan 89 C5 introduced (archive: `docs/features/archive/89-frontend-perf-pass.md`). cast-drawer had a 5s timeout on the post-click drawer mount and download-tiles had three 3s timeouts on post-click modal mounts — both tighter than Playwright's own 5s default. On cold-cache first runs the lazy chunk would lose the race; Playwright classified the specs flaky and exited non-zero, blocking pre-push for unrelated branches.

## What changed

- **`e2e/helpers.ts`** — new `waitForRouteReady(page)` export. Waits for `[data-testid="route-suspense-fallback"]` to detach. Warm cache: no-op. Cold cache: blocks until the lazy chunk resolves and Suspense swaps. Uses the existing testid from `src/components/delayed-spinner.tsx:47` — no app code changes.
- **`e2e/cast-drawer.spec.ts`** — calls `waitForRouteReady(page)` after `goToConfirm(page)` and before clicking the character card; bumps the "Evidence from the manuscript" assertion timeout from 5s to 10s.
- **`e2e/download-tiles.spec.ts`** — calls `waitForRouteReady(page)` in `beforeEach` after the heading wait; bumps three modal-visibility assertions (M4B export modal, MP3 ZIP export modal, share-link modal) + the share-link URL value assertion from 3s to 10s.
- **`docs/BACKLOG.md`** — strikes the Should bullet for this work.

## Test plan

- [x] 5x clean run of both specs (`npx playwright test e2e/cast-drawer.spec.ts e2e/download-tiles.spec.ts --project=chromium --retries=0`) — green every time, no "flaky" classification.
- [x] Full `npm run verify` — all 9 steps green (pre-push battery).
- [x] No app code touched — purely a test-suite hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)