### PR TITLE
feat(frontend): mockStreamGeneration interleaves K chapters + e2e proof

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -322,16 +322,6 @@ Source: net-new (2026-05-21). Spun off from the perf-tuning survey (item C6).
 - _Depends on:_ none.
 - _Benefit (technical):_ avoids 480+ DOM mutations per 800 ms when many waveforms are visible simultaneously. Low real-world impact today (rare to see >3 waveforms at once).
 
-### 26. Interleaved SSE in `mockStreamGeneration` for parallel-chapter e2e
-
-Source: net-new (2026-05-21). Deferred from plan 87 implementation — server side shipped, mock-mode e2e not landed.
-
-- _What:_ Teach `mockStreamGeneration` (`src/lib/api.ts`) to advance multiple chapters concurrently when the generate POST would have been parallel server-side (i.e. when more than one chapter is in `queued` state at start). Today the mock advances exactly one chapter at a time and only flips to the next queued chapter when the active one completes — that hard-codes a serial-loop assumption the real backend no longer holds (plan 87). Then add `e2e/generation-parallel.spec.ts` asserting that chapter 2 emits `chapter:start` BEFORE chapter 1 emits `chapter:done`.
-- _Acceptance:_ in mock mode with K queued chapters, the Generate view's chapter rows show two simultaneous "Generating" pills (not just one). E2e spec passes.
-- _Key files:_ `src/lib/api.ts` (`mockStreamGeneration`); new `e2e/generation-parallel.spec.ts`.
-- _Depends on:_ plan 87 server-side worker pool (shipped).
-- _Benefit (user/technical):_ closes the mock/real parity gap so the parallel SSE wire shape is visually exercised in dev mode and CI gates regressions. Today the parallel orchestration is only pinned at the server vitest layer.
-
 ### 28. Configurable chapter-title silence durations
 
 Source: [`28-chapter-audio-format.md`](features/28-chapter-audio-format.md) follow-up — net-new (2026-05-21). Deferred from PR #101 (`fix/server-voiced-chapter-titles-and-pauses`).

--- a/e2e/generation-parallel.spec.ts
+++ b/e2e/generation-parallel.spec.ts
@@ -1,0 +1,225 @@
+/* Browser-level proof of the parallel-chapter SSE contract — plan 87
+ * follow-up (BACKLOG Could #26, archive: docs/features/archive/87-parallel-chapter-synth.md).
+ *
+ * Plan 87 added a bounded worker pool on the server (default
+ * `GEN_CHAPTER_CONCURRENCY=2`) so progress / chapter_complete events
+ * for multiple chapters interleave on the SSE wire — each keyed by
+ * `chapterId`. The mock implementation in `src/lib/api.ts`
+ * (`mockStreamGeneration`) was a serial loop until BACKLOG #26: find a
+ * singular active chapter, increment progress, only advance the next
+ * queued chapter when active.progress >= 1. That left the parallel-SSE
+ * orchestration server-vitest-pinned but not browser-e2e-pinned.
+ *
+ * This spec exercises the user-observable invariant in chromium against
+ * Vite in mock mode:
+ *
+ *   1. Two or more chapters reach `state === 'in_progress'` simultaneously.
+ *   2. Chapter 2's first `in_progress` transition lands BEFORE chapter 1
+ *      transitions to `done` — the wire-shape proof that the K-wide
+ *      in-flight set is real (and not the legacy "advance-next-on-complete"
+ *      cadence).
+ *   3. The Generate view renders ≥2 "Generating" pills concurrently —
+ *      the user-visible payoff of the parallel pool.
+ *
+ * Window-level knob: the spec seeds `window.__mockGenConcurrency = 2`
+ * (read by mockStreamGeneration) so the value is deterministic. The mock
+ * defaults to 2 even without the knob — the seed is belt-and-suspenders
+ * against future default drift.
+ *
+ * Wall-clock budget: <30 s on a warm cache. The mock SSE ticks at 1200ms;
+ * a chapter takes ~50 ticks to complete (0.02 per tick), but a chapter
+ * 2 in_progress transition lands on the very first tick (cold start
+ * promotes min(K, queued.length) chapters in the same tick). */
+
+import { test, expect, type Page } from '@playwright/test';
+import { goToConfirm } from './helpers';
+
+/* Plan 58 — file-level serial mode keeps long cold-boot walks in one
+   worker so SSE phase transitions don't miss their event window when
+   other workers' Vite traffic backs up. Same rationale as
+   new-book-flow.spec.ts. */
+test.describe.configure({ mode: 'serial' });
+
+interface ChapterSnapshot {
+  id: number;
+  state: string;
+  progress?: number;
+}
+
+/* Read the live chapter rows from the store. Exposed on `window.__store__`
+   in DEV + e2e Vite modes (see src/main.tsx). */
+async function getChapters(page: Page): Promise<ChapterSnapshot[]> {
+  return page.evaluate(() => {
+    const s = (
+      window as unknown as {
+        __store__?: {
+          getState: () => {
+            chapters: { chapters: Array<{ id: number; state: string; progress?: number }> };
+          };
+        };
+      }
+    ).__store__;
+    if (!s)
+      throw new Error('window.__store__ is not exposed — main.tsx DEV/e2e gate may have regressed');
+    return s.getState().chapters.chapters.map((c) => ({
+      id: c.id,
+      state: c.state,
+      progress: c.progress,
+    }));
+  });
+}
+
+async function getBookId(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const s = (
+      window as unknown as {
+        __store__?: { getState: () => { ui: { stage: { bookId?: string } } } };
+      }
+    ).__store__;
+    if (!s) throw new Error('window.__store__ is not exposed');
+    const bookId = s.getState().ui.stage.bookId;
+    if (!bookId) throw new Error('stage has no bookId — expected ready/confirm stage');
+    return bookId;
+  });
+}
+
+test.describe('parallel chapter generation (BACKLOG #26, plan 87)', () => {
+  test('two chapters in_progress concurrently and ≥2 Generating pills render', async ({
+    page,
+  }) => {
+    /* Walk budget: ~7.6 s of mock analysis stream + cold goto + ≤20 s of
+       parallel-chapter polling. The Playwright default 30 s test timeout
+       is too tight when chromium cold-boots a fresh worker (page.goto can
+       take 5-10 s on a cold Vite cache). Bumped to 60 s — same headroom
+       as the spec's `navigationTimeout` ceiling in playwright.config.ts. */
+    test.setTimeout(60_000);
+
+    /* Seed the concurrency knob BEFORE any in-app code reads it. The mock
+       defaults to 2 anyway, but the explicit seed is a future-proof anchor:
+       if the default ever changes, this spec still asserts K=2. The flag
+       lives on `window` so the mock can read it without re-plumbing the
+       generation-stream middleware. */
+    await page.addInitScript(() => {
+      (window as unknown as { __mockGenConcurrency: number }).__mockGenConcurrency = 2;
+    });
+
+    /* Drive from cold boot through analysing → confirm → ready. The
+       canned analysis fixture (ANALYSIS_NORTHERN_STAR in
+       src/mocks/canned-data.ts) seeds `initialChapters` which has
+       multiple queued chapters (4-9 inclusive) — enough work for the
+       K=2 pool to interleave. */
+    await goToConfirm(page);
+    await page.getByRole('button', { name: /Confirm cast and review manuscript/i }).click();
+    await expect(page).toHaveURL(/#\/books\/.+\/manuscript/, { timeout: 5_000 });
+
+    /* Navigate to the Generate tab. confirmCast lands on view='manuscript';
+       the user clicks "Generate" in the top-bar tab strip to land on
+       `#/books/:bookId/generate`. The streamGeneration middleware opens
+       the SSE handle on ui/changeView when there's queued work — see
+       TRIGGER_TYPES in src/store/generation-stream-middleware.ts. */
+    const bookId = await getBookId(page);
+    await page.getByRole('button', { name: /^Generate$/ }).click();
+    await expect(page).toHaveURL(new RegExp(`#/books/${bookId}/generate`), { timeout: 5_000 });
+
+    /* Poll for the parallel-SSE proof: chapter 2's first in_progress
+       transition lands BEFORE chapter 1 completes. We track the first
+       observation of every chapter id we ever see in_progress, plus the
+       first observation of any chapter reaching `done` after the
+       analysis-seeded done set (chapters 1 + 2 are already done from
+       the fixture — we watch the rows that START queued/in_progress
+       and transition over the live SSE).
+
+       The serial-loop legacy would only ever show one chapter in
+       in_progress at a time post-fixture-seed. The K-wide pool shows
+       two. */
+    type Transition = { id: number; firstInProgressAt: number | null; firstDoneAt: number | null };
+    const transitions = new Map<number, Transition>();
+    const start = Date.now();
+
+    /* The fixture pre-seeds chapter 3 in_progress and chapters 1+2 done.
+       After confirmCast the slice carries those rows. The K-wide pool
+       should pull chapter 4 (the first queued row) into in_progress on
+       the very first tick alongside the still-running chapter 3, so we
+       expect two distinct chapters in_progress within a couple of
+       ticks (~2.4 s at 1200 ms cadence). */
+    await expect
+      .poll(
+        async () => {
+          const now = Date.now() - start;
+          const chapters = await getChapters(page);
+          for (const c of chapters) {
+            const t = transitions.get(c.id) ?? {
+              id: c.id,
+              firstInProgressAt: null,
+              firstDoneAt: null,
+            };
+            if (c.state === 'in_progress' && t.firstInProgressAt === null) {
+              t.firstInProgressAt = now;
+            }
+            if (c.state === 'done' && t.firstDoneAt === null) {
+              t.firstDoneAt = now;
+            }
+            transitions.set(c.id, t);
+          }
+          const concurrentInProgress = chapters.filter((c) => c.state === 'in_progress').length;
+          return concurrentInProgress;
+        },
+        {
+          timeout: 20_000,
+          intervals: [200, 400, 800],
+          message: 'expected ≥2 chapters concurrently in_progress (K=2 worker pool)',
+        },
+      )
+      .toBeGreaterThanOrEqual(2);
+
+    /* The cross-chapter ordering check. We want chapter N+1's first
+       in_progress timestamp to be EARLIER than the moment ANY chapter
+       first reached `done` after the run started — i.e. the new chapter
+       didn't have to wait for a completion. Equivalently: the first
+       "second concurrent in_progress" observation happened before the
+       first "newly done" observation, where "newly" means we saw the
+       chapter transition from a non-done state. We use the simpler
+       inverse: at the moment we observed 2 concurrent in_progress
+       chapters above, no NEW chapter had yet transitioned to done. The
+       fixture pre-seeds chapters 1+2 done — those don't count as
+       transitions because we only mark firstDoneAt when we OBSERVE
+       state==='done' on a chapter we've also seen in_progress (or that
+       was queued at first poll). */
+    const observedInProgress = Array.from(transitions.values())
+      .filter((t) => t.firstInProgressAt !== null)
+      .sort(
+        (a, b) => (a.firstInProgressAt as number) - (b.firstInProgressAt as number),
+      );
+    expect(
+      observedInProgress.length,
+      'expected ≥2 chapters to have entered in_progress',
+    ).toBeGreaterThanOrEqual(2);
+
+    const secondInProgressEntry = observedInProgress[1];
+    /* No chapter that was ever in_progress should have reached `done`
+       before the second concurrent chapter even started. */
+    for (const t of transitions.values()) {
+      if (t.firstInProgressAt === null) continue;
+      if (t.firstDoneAt === null) continue;
+      expect(
+        t.firstDoneAt,
+        `chapter ${t.id} reached done at ${t.firstDoneAt} ms — before the second concurrent ` +
+          `chapter ${secondInProgressEntry.id} entered in_progress at ` +
+          `${secondInProgressEntry.firstInProgressAt} ms. The K-wide pool should advance ` +
+          `chapter N+1 before chapter N completes.`,
+      ).toBeGreaterThan(secondInProgressEntry.firstInProgressAt as number);
+    }
+
+    /* DOM proof: ≥2 "Generating" pills render simultaneously in the
+       Generate view's chapter rows. The pill is `<Pill color="peach">
+       Generating</Pill>` (src/views/generation.tsx:943) — a span whose
+       textContent is exactly "Generating". `Generating…` (with the
+       ellipsis) is a different affordance (the inline per-character
+       caption in the expanded chapter row), so the exact-string locator
+       avoids accidental matches. */
+    const generatingPills = page.locator('span', { hasText: /^Generating$/ });
+    await expect(generatingPills.nth(1)).toBeVisible({ timeout: 10_000 });
+    const pillCount = await generatingPills.count();
+    expect(pillCount, `expected ≥2 'Generating' pills, saw ${pillCount}`).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -290,6 +290,15 @@ export interface StreamArgs {
     characters: Record<string, string>;
   }>;
   onTick: (ev: GenerationTick & { type: GenerationTick['type'] }) => void;
+  /** Mock-only: number of chapters to keep in-flight in parallel. Mirrors the
+      server's `GEN_CHAPTER_CONCURRENCY` (default 2 — see plan 87 archive). The
+      real `streamGeneration` ignores this; the mock uses it to interleave SSE
+      events across K chapters so browser-level specs can pin the parallel-SSE
+      contract. Defaults to 2 when unset, capped by the number of queued
+      chapters at tick time. Vitest callers pass through the StreamArgs object;
+      the e2e harness can additionally seed `window.__mockGenConcurrency` to
+      override without touching the middleware. */
+  mockGenConcurrency?: number;
 }
 export interface AudioArgs {
   bookId: string;
@@ -827,35 +836,94 @@ function safeOnTick(onTick: StreamArgs['onTick']): StreamArgs['onTick'] {
   };
 }
 
-function mockStreamGeneration({ getChapters, onTick: rawOnTick }: StreamArgs): () => void {
+function mockStreamGeneration({
+  getChapters,
+  onTick: rawOnTick,
+  mockGenConcurrency,
+}: StreamArgs): () => void {
   const onTick = safeOnTick(rawOnTick);
-  /* Mock the real server's "one progress tick per same-speaker group" cadence
-     well enough that the Generate view's line / character counters tick
-     visibly. Two behaviours that matter:
+  /* Mock the real server's parallel-chapter SSE cadence (plan 87 archive,
+     `GEN_CHAPTER_CONCURRENCY`, default 2). The server keeps K chapters
+     in-flight on a bounded worker pool, so progress / chapter_complete
+     events for multiple chapters interleave on the wire — each keyed by
+     `chapterId`. Three behaviours that matter:
 
-     1. Auto-promote: when the active chapter completes, advance the next
-        queued chapter into in_progress on the next tick — the real server
-        does this implicitly by emitting a `progress` tick for chapter N+1
-        right after chapter N's complete. Without this, the mock just
-        emits `idle` forever once chapter 1 is done, the heartbeat goes
-        cold, and the stall banner pops up while the queue still has work.
-     2. Cycle characters: rotate the active character every few ticks so
-        the per-character `in_progress` pill actually moves through the
-        cast, the active-speaker caption updates, and the user gets a
-        steady "something is happening" signal even before chapter %
-        ticks visibly. */
+     1. K-wide in-flight set: every tick advances every chapter that is
+        currently `in_progress` and emits a `progress` or `chapter_complete`
+        event keyed by that chapter's id. The serial-loop assumption
+        (singular `active`) was the gap plan 87 broke server-side and the
+        reason the parallel SSE orchestration was only server-vitest-pinned,
+        not browser-e2e-pinned.
+     2. Auto-promote on completion: when an in-flight chapter crosses
+        progress >= 1 (chapter_complete), pull the next queued chapter into
+        the set in the SAME tick with its initial 0.01 progress event so
+        the K-wide capacity stays saturated. Without this, the heartbeat
+        goes cold between chapter N's complete and chapter N+1's first
+        progress event and the stall banner pops up while the queue still
+        has work.
+     3. Cycle characters: rotate the active character per chapter every
+        few ticks so the per-character `in_progress` pill walks through
+        the cast and the active-speaker caption updates.
+
+     `mockGenConcurrency` (default 2) caps the in-flight set width and
+     mirrors `GEN_CHAPTER_CONCURRENCY` on the server. Browser-level e2e
+     specs can seed `window.__mockGenConcurrency` to force the value
+     deterministically without re-plumbing the middleware. */
+  const requestedK =
+    mockGenConcurrency ??
+    (typeof window !== 'undefined'
+      ? (window as unknown as { __mockGenConcurrency?: number }).__mockGenConcurrency
+      : undefined) ??
+    2;
+  const targetK = Math.max(1, Math.floor(requestedK));
+
   const tick = () => {
     const chapters = getChapters?.() ?? [];
-    const active = chapters.find((c) => c.state === 'in_progress');
-    if (!active) {
-      const nextUp = chapters.find((c) => c.state === 'queued');
-      if (!nextUp) {
-        onTick({ type: 'idle' });
-        return;
-      }
-      /* Bootstrap the next chapter with a tiny non-zero progress so the
-         live `chapter.state` flips to in_progress on the slice and our
-         next tick finds it. */
+    const inFlight = chapters.filter((c) => c.state === 'in_progress');
+    const queued = chapters.filter((c) => c.state === 'queued');
+
+    if (inFlight.length === 0 && queued.length === 0) {
+      onTick({ type: 'idle' });
+      return;
+    }
+
+    /* Advance every chapter currently in-flight. Track which ones complete
+       on this tick so we can backfill the K-wide set from `queued` in the
+       same tick. */
+    let completedThisTick = 0;
+    for (const active of inFlight) {
+      const totalLines = active.totalLines || 600;
+      const nextProgress = Math.min(1, (active.progress || 0) + 0.02);
+      const currentLine = Math.round(totalLines * nextProgress);
+      const cast = Object.keys(active.characters).filter(
+        (k) => active.characters[k] !== 'skipped',
+      );
+      const characterId =
+        cast.length > 0
+          ? cast[Math.min(cast.length - 1, Math.floor(nextProgress * cast.length))]
+          : null;
+      if (nextProgress >= 1) completedThisTick += 1;
+      onTick({
+        type: nextProgress >= 1 ? 'chapter_complete' : 'progress',
+        chapterId: active.id,
+        characterId,
+        progress: nextProgress,
+        currentLine,
+        totalLines,
+      });
+    }
+
+    /* Backfill the in-flight set up to K. Two paths land here:
+       1. Cold start: nothing was in-flight (`inFlight.length === 0`), pull
+          min(K, queued.length) chapters in.
+       2. Steady state: a chapter completed this tick, pull `completedThisTick`
+          replacements in (still capped by remaining queue).
+       Both paths emit an initial 0.01 `progress` event per pulled chapter,
+       interleaved with the in-flight ticks already emitted above. */
+    const stillInFlight = inFlight.length - completedThisTick;
+    const slotsToFill = Math.max(0, targetK - stillInFlight);
+    const toPromote = queued.slice(0, Math.min(slotsToFill, queued.length));
+    for (const nextUp of toPromote) {
       onTick({
         type: 'progress',
         chapterId: nextUp.id,
@@ -864,27 +932,7 @@ function mockStreamGeneration({ getChapters, onTick: rawOnTick }: StreamArgs): (
         currentLine: 0,
         totalLines: nextUp.totalLines || 600,
       });
-      return;
     }
-    const totalLines = active.totalLines || 600;
-    const nextProgress = Math.min(1, (active.progress || 0) + 0.02);
-    const currentLine = Math.round(totalLines * nextProgress);
-    /* Pick a non-skipped character to surface as the live speaker, cycling
-       proportionally with progress so the per-character pill walks through
-       the cast in roughly the order they appear. */
-    const cast = Object.keys(active.characters).filter((k) => active.characters[k] !== 'skipped');
-    const characterId =
-      cast.length > 0
-        ? cast[Math.min(cast.length - 1, Math.floor(nextProgress * cast.length))]
-        : null;
-    onTick({
-      type: nextProgress >= 1 ? 'chapter_complete' : 'progress',
-      chapterId: active.id,
-      characterId,
-      progress: nextProgress,
-      currentLine,
-      totalLines,
-    });
   };
   const handle = setInterval(tick, 1200);
   return () => clearInterval(handle);


### PR DESCRIPTION
## Summary

Plan 87 (archive `docs/features/archive/87-parallel-chapter-synth.md`, shipped 2026-05-21) added a bounded worker pool on the server (`GEN_CHAPTER_CONCURRENCY`, default 2) so SSE events from multiple chapters interleave on the wire keyed by `chapterId`. But `mockStreamGeneration` kept the serial-loop assumption — finds a singular active chapter, advances its progress, only flips to the next queued chapter when active.progress >= 1. The mock/real wire-shape parity gap meant the parallel SSE orchestration was server-vitest-pinned but not browser-e2e-pinned.

## What changed

- **`src/lib/api.ts`** — `mockStreamGeneration` refactored to track a K-wide in-flight set (default K=2, configurable via `mockGenConcurrency` on the StreamArgs object). Each tick advances every in-flight chapter; when one completes, the next queued chapter is pulled into the set in the same tick with its initial 0.01-progress event interleaved with the still-running chapter's tick. Public function signature unchanged beyond the optional `mockGenConcurrency` field.
- **`e2e/generation-parallel.spec.ts`** — new spec. Drives a book through `goToConfirm` → ready → generate, kicks off generation, polls `window.__store__.getState().chapters.chapters` and asserts that chapter 2 transitions to `in_progress` BEFORE chapter 1 transitions to `complete`. Visual proof: asserts ≥2 "Generating" pills are present simultaneously in the Generate view's chapter rows (exact-string regex to avoid colliding with the inline `Generating…` per-character caption).
- **`docs/BACKLOG.md`** — strikes the Could bullet for this work.

## Deviation notes

- `mockGenConcurrency` is read from BOTH the StreamArgs field AND `window.__mockGenConcurrency` (set via `addInitScript` in the e2e spec) because the api-middleware doesn't propagate options through to the mock layer. Belt-and-suspenders — the mock still defaults to 2 either way; Vitest cases can pass directly via the field.
- The new spec sets `test.setTimeout(60_000)` to absorb cold-boot + analysis-stream (~7.6s mock SSE) + multi-poll budget. Default 30s was too tight on first run.

## Test plan

- [x] 5x clean run of `e2e/generation-parallel.spec.ts` — green every time.
- [x] Existing Vitest battery (`npm run test`) — unchanged green; mock-shape change doesn't break per-chapter progress demuxer.
- [x] Full `npm run verify` — all 9 steps green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)