### PR TITLE
chore: update README + INSTALL for v1.4.0 release

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -148,17 +148,22 @@ Sidecar will fall back to CPU and log it. Verify `nvidia-smi` works at the OS le
 
 ---
 
-## Switching analyzer to Ollama (local, free, on-device)
+## Setting up the analyzer
 
-The install bundle ships Kokoro for TTS only. The analyzer defaults to Google's free Gemini API. To switch the analyzer to Ollama (private, fully on-device):
+The install bundle ships Kokoro weights for TTS only — the analyzer needs either a local Ollama daemon or a Gemini API key. The server-side default is `ANALYZER=local` (Ollama); if no Ollama daemon is reachable, the analyzer auto-falls back to the Gemini free tier when a key is configured.
 
-1. Install Ollama from <https://ollama.com>.
-2. Pull a model: `ollama pull qwen3.5:4b` (~2.5 GB).
-3. In the app: **Account → Server configuration → Analyzer engine** → "Local Ollama".
-4. **Account → Defaults for new books → Analysis model** → "Qwen3.5 4B (local)".
-5. Save. The next analysis routes to your local Ollama.
+**Option A — Ollama (private, fully on-device).** Since v1.3.0 the Account → Models card in the running app installs Ollama and pulls models without leaving the UI:
 
-> **Coming in a future release**: an "Install Ollama" + "Pull model" UX on the Account tab so you don't have to leave the app for the above. Tracked in [docs/BACKLOG.md](docs/BACKLOG.md) as a Could-bucket item.
+1. Start the app (`npm run start:prod`), open **Account → Models**.
+2. Click **Install Ollama** (platform-aware bootstrap; Windows / macOS / Linux all covered).
+3. Click **Pull model** and pick e.g. `qwen3.5:4b` (~2.5 GB).
+4. **Account → Defaults for new books → Analysis model** → pick the pulled model. Save.
+
+Or the manual path: install Ollama from <https://ollama.com>, `ollama pull qwen3.5:4b`, then set the model in the Account tab.
+
+**Option B — Gemini (cloud, free tier).** Get a key from <https://aistudio.google.com>, paste it into **Account → Server configuration → Gemini API key**. Engine selection follows from the model picker — pick any Gemini model in **Defaults for new books → Analysis model**. Save. The key persists to `server/user-settings.json` (gitignored, plaintext, same trust model as `server/.env`).
+
+**Option C — Pipelined two-model split (v1.4.0).** For long books: Phase 0 (cast detection) runs on Gemma while Phase 1 (sentence attribution) runs on Gemini Flash in parallel, hitting independent rate-limit buckets so effective quota nearly doubles. Configure under **Account → Defaults for new books → Phase 0 model + Phase 1 model + Min-lag chapters** (default 10), or set `ANALYZER_PHASE0_MODEL` / `ANALYZER_PHASE1_MODEL` / `ANALYZER_PHASE1_MIN_LAG_CHAPTERS` in `server/.env`. Manual handoff (`ANALYZER=manual`) short-circuits to sequential — the file-drop cowork loop can't pipeline.
 
 ## Switching TTS to Coqui XTTS v2 (alternate, on-device)
 
@@ -166,13 +171,41 @@ The install bundle ships Kokoro for TTS only. The analyzer defaults to Google's 
 2. **TTS model** → "Coqui XTTS v2".
 3. Save. The first chapter generation triggers a one-time ~2 GB model download.
 
-## Using Gemini for analysis or TTS (cloud, free tier)
+## Using Gemini for TTS (cloud, free tier)
 
-1. Get an API key from <https://aistudio.google.com> (Google account required).
-2. In the app: **Account → Server configuration → Gemini API key** → paste the key → Save.
-3. Engine selection follows from the model picker: choose any Gemini model in **Defaults for new books → Analysis model** (or TTS engine + model). Save.
+The same Gemini key configured for the analyzer (see Option B above) doubles as the TTS provider when picked.
+
+1. Get an API key from <https://aistudio.google.com> (Google account required), saved via **Account → Server configuration → Gemini API key**.
+2. **Account → Defaults for new books → TTS engine** → "Gemini (cloud)".
+3. **TTS model** → pick `gemini-3.1-flash-preview-tts` or `gemini-2.5-flash-preview-tts`. Save.
 
 The key is stored plaintext in `server/user-settings.json` (gitignored, same trust model as `server/.env` for a single-user workspace). The env var `GEMINI_API_KEY` in `server/.env` still wins if both are set — useful for CI / scripted setups.
+
+---
+
+## Picking a chapter audio format (v1.4.0)
+
+Chapter audio defaults to MP3 VBR V2. Two newer codecs are available per-book under **Listen view → metadata editor → Audio format** or in the export modal:
+
+- **MP3** (default) — broadest player support; VBR V2.
+- **AAC / M4A** — smaller files at equal perceived quality; `libfdk_aac` is auto-detected on the host ffmpeg with a graceful fallback to the native AAC encoder.
+- **Opus** — best ratio at very low bitrates; ideal for streaming over LAN.
+
+The `audioFormat` field is new on `BookStateJson` (default `'mp3'`) — existing books carry the default and need no migration. Export shapes mirror the codec: `aac-m4a-zip`, `opus-ogg-zip`, plus the existing `mp3-zip` + `mp3-folder` + `m4b-single`.
+
+Loudness normalization (EBU R128, two-pass, targeting -16 LUFS / 11 LU / -1.5 dBTP) is **on by default** for every newly-rendered chapter. To opt out per server install, set `AUDIO_LOUDNORM_ENABLED=false` in `server/.env`. The Listen view's loudness report card surfaces measured LUFS / LRA / dBTP and flags drift between chapters.
+
+---
+
+## Mobile + tablet access over LAN HTTPS (v1.4.0)
+
+The app drives on phone + tablet via LAN HTTPS using `mkcert` so iOS / Android trust the cert without browser warnings. One-time setup per dev box:
+
+1. Install `mkcert` — `scoop install mkcert` (Windows), `brew install mkcert` (macOS), or `apt install mkcert` (Linux). Then `mkcert -install`.
+2. `npm run install:cert-mobile` — prints LAN URL + QR code + per-OS root-cert install steps.
+3. Install the root CA on each mobile device once (iOS: Settings → Profile downloaded → Install → trust; Android: Settings → Security → Install certificate).
+4. Run the server in LAN mode: `npm run start:lan` for the production bundle on `https://0.0.0.0:8443`, or `npm run dev:lan` for HMR-capable Vite + Node on `https://0.0.0.0:5173`/`:8443`.
+5. Open the printed LAN URL on the device — lock icon, no warning.
 
 ---
 
@@ -187,3 +220,10 @@ A new release is just a new zip — there's no in-app auto-update yet.
 5. `npm run start:prod`.
 
 Your workspace (`WORKSPACE_DIR` from `server/.env`) is separate from the install folder and survives across upgrades unchanged.
+
+### v1.3.x → v1.4.0 notes
+
+- `BookStateJson` gained an optional `audioFormat` field (`'mp3' | 'aac-m4a' | 'opus'`). Existing books default to `'mp3'`; no migration required.
+- Finished exports moved from the hidden `.audiobook/exports/<id>/` jail to a visible `<bookDir>/exports/<slug>.<ext>` sibling to `audio/`. Old exports stay where they were — only new exports land in the new location.
+- Audio loudness normalization is on by default in v1.4.0. Set `AUDIO_LOUDNORM_ENABLED=false` in `server/.env` if you need bit-exact match with previously-rendered chapters; otherwise regenerate to bring older chapters into the loudness target.
+- New optional env knobs: `ANALYZER_PHASE0_MODEL` / `ANALYZER_PHASE1_MODEL` / `ANALYZER_PHASE1_MIN_LAG_CHAPTERS` (pipelined two-model analyzer), `GEN_CHAPTER_CONCURRENCY` (parallel chapter synthesis, default 2). All have safe defaults — leave unset to keep the v1.3.1 behaviour.

--- a/README.md
+++ b/README.md
@@ -74,50 +74,79 @@ e2e/build), `npm run test:e2e` (Playwright only).
 
 ## Features
 
-- **Manuscript ingestion** — paste or upload `.md`, `.txt`, `.epub`, `.pdf`, `.mobi`, or `.azw3`; chapter names extracted, low-confidence speaker assignments surfaced for review. DRM-protected MOBI files are rejected up-front with a clear error.
-- **Analyzer choice** — local Ollama (default, no API key required), Gemini free-tier (cloud, 1500 RPD), or manual file-drop coworking with any chat model. Sticky across navigation and process restarts. **In-app multi-model management (v1.3.0)** — Install Ollama, pull a model, and pre-fetch Coqui XTTS from the Account → Models card without dropping to a terminal.
+- **Manuscript ingestion** — paste or upload `.md`, `.txt`, `.epub`, `.pdf`, `.mobi`, or `.azw3`; chapter names extracted, low-confidence speaker assignments surfaced for review. DRM-protected MOBI files are rejected up-front with a clear error. **Diff-on-reupload (v1.4.0)** — side-by-side sentence-level diff (LCS + char-level inner highlight) gates any re-upload of an existing book before slice mutation; an amber banner flags renamed chapters whose sticky title overrides won't match the new parse.
+- **Manuscript editing** — per-sentence speaker reassign, chapter merge/split/reorder, manual chapter rename with a sticky `titleOverridden` flag (v1.4.0) preserved across heuristic refresh passes. **Low-confidence triage polish (v1.4.0)** — J/K shortcuts jump to the next misattribution and auto-open the inspector; a typeahead `<CharacterSearchPicker>` lists local cast + recurring series-mates so a missing series character can be materialised from the prior roster in one click.
+- **Analyzer choice** — local Ollama (default, no API key required), Gemini free-tier (cloud, 1500 RPD), or manual file-drop coworking with any chat model. Sticky across navigation and process restarts. **In-app multi-model management (v1.3.0)** — Install Ollama, pull a model, and pre-fetch Coqui XTTS from the Account → Models card without dropping to a terminal. **Pipelined two-model analyzer (v1.4.0)** — opt-in Phase 0 (cast detection, e.g. `gemma-4-31b-it`) and Phase 1 (sentence attribution, e.g. `gemini-3.1-flash-lite`) run in parallel with a configurable 10-chapter minimum lag, hitting independent rate-limit buckets so effective quota nearly doubles. Phase model picker + min-lag knob live on the Account tab.
 - **Voice library** — per-engine catalogs, family grouping, drag-to-assign, per-character overrides, sample playback, side-by-side cast comparison. **Same-book cast compare from the global Voices tab (v1.3.0)** — on-demand fetches the foreign book's cast so you can audition two characters from a different book side-by-side.
-- **TTS engines** — Kokoro v1 (eager-loaded English-only, 28 voices), Coqui XTTS v2 (button-driven, zero-shot cloning), Gemini cloud. Per-character voice profiles persist across engine switches. **Voice preview while editing (v1.3.0)** — audition multiple voice candidates inside the profile drawer with a user-editable sample line, without committing the assignment.
-- **Generation** — per-chapter SSE stream, sticky across navigation, cold-boot resumable. Auto-retry on transient sidecar failures. **Cross-tab state sync (v1.3.0)** — open the same book in two tabs and the analysis / generation pills update in lockstep via `BroadcastChannel`, no round-trip needed.
-- **Revisions & drift** — pending-revisions pill, A/B audio audition with rollback preservation, full diff view, engine-drift detection per chapter. **Revision history timeline (v1.3.0)** — read-only chronological log of accept/reject events per chapter, surfaced from the existing A/B player modal.
-- **Listening surface (overhauled in v1.3.0)** — playback speed picker (0.75×–2×, persisted per book), user-placed markers (note / rerecord) with a listen-view sidebar, sleep timer with countdown presets + end-of-chapter mode, true RMS waveform peaks computed at encode time, listening-progress resume bookmarks, per-book editorial notes (collapsible card), share a 30-second clip of any chapter as MP3, mint a slugged share URL for the whole book M4B.
-- **Library covers** — auto-fetch from OpenLibrary on import, manual picker with three tabs (search, upload, frame), drag-pan + zoom framing without re-encoding the source JPEG.
-- **Export** — M4B (with cover, chapter atoms, optional descriptions), MP3 zip, per-chapter MP3 folder, sync-folder save, LAN download with QR. Chapter audio is MP3 VBR V2.
+- **TTS engines** — Kokoro v1 (eager-loaded English-only, 28 voices), Coqui XTTS v2 (button-driven, zero-shot cloning), Gemini cloud. Per-character voice profiles persist across engine switches. **Voice preview while editing (v1.3.0)** — audition multiple voice candidates inside the profile drawer with a user-editable sample line, without committing the assignment. **Kokoro stop pill (v1.4.0)** — top-bar pill evicts Kokoro to free ~1 GB VRAM for an XTTS warm or a heavier analyzer model without restarting the sidecar.
+- **Generation** — per-chapter SSE stream, sticky across navigation, cold-boot resumable. Auto-retry on transient sidecar failures. **Cross-tab state sync (v1.3.0)** — open the same book in two tabs and the analysis / generation pills update in lockstep via `BroadcastChannel`, no round-trip needed. **Parallel chapter synthesis (v1.4.0)** — bounded worker pool over chapters via `GEN_CHAPTER_CONCURRENCY` (default 2); per-chapter SSE tracks isolated through the chapters slice so interleaved events never cross. **Voiced chapter titles + inter-chapter silence (v1.4.0)** — each chapter audio now opens with the title rendered as a period-separated clause (`Chapter 2. Moolark.`) in the project's narrator voice, followed by a baked-in silence; reads cleanly across Coqui / Kokoro / Gemini.
+- **Revisions & drift** — pending-revisions pill, A/B audio audition with rollback preservation, full diff view, engine-drift detection per chapter. **Revision history timeline (v1.3.0)** — read-only chronological log of accept/reject events per chapter, surfaced from the existing A/B player modal. **Cast Drift consolidation (v1.4.0)** — drift report modal collapses by `(book × character × snapshot)` — ~300 events surface as ~6–18 cards with bulk Regen-all / Dismiss-all / Auto-regen-all on multi-chapter groups. **Background drift polling (v1.4.0)** — `GET /api/revisions?bookIds=...` bulk endpoint + two-tier poller (30 s active, 120 s background) surfaces drift on non-active books within ~2 min without a navigate.
+- **Listening surface (overhauled in v1.3.0)** — playback speed picker (0.75×–2×, persisted per book), user-placed markers (note / rerecord) with a listen-view sidebar, sleep timer with countdown presets + end-of-chapter mode, true RMS waveform peaks computed at encode time, listening-progress resume bookmarks, per-book editorial notes (collapsible card), share a 30-second clip of any chapter as MP3, mint a slugged share URL for the whole book M4B. **Loudness report card (v1.4.0)** — colour-coded per-row drift pill (≤2 / 2–4 / >4 LU buckets) + expandable card with summary line, sparkline, and per-chapter table.
+- **Library** — auto-fetched OpenLibrary covers on import; manual cover picker with three tabs (search, upload, frame), drag-pan + zoom framing without re-encoding the source JPEG. **Library polish (v1.4.0)** — debounced title/author search + tag-chip filter; card↔table view toggle with series grouping; portable book bundle (`.zip` of state + manuscript + audio + cover + change-log + MANIFEST) for export and import.
+- **Export** — M4B (with cover, chapter atoms, optional descriptions), AAC/M4A zip, Opus zip, MP3 zip, per-chapter MP3 folder, portable book bundle (v1.4.0), sync-folder save, LAN download with QR. **Per-book audio format (v1.4.0)** — `BookStateJson.audioFormat` (default `'mp3'`, also `'aac-m4a'` or `'opus'`) drives the chapter encode + matching export shapes; libfdk_aac auto-detects with native AAC fallback. **EBU R128 loudness normalization (v1.4.0)** — two-pass `loudnorm` at -16 LUFS / 11 LU / -1.5 dBTP on by default (`AUDIO_LOUDNORM_ENABLED=false` opts out); voice samples deliberately skip the pass.
+- **Exports + sync folder (v1.4.0)** — finished artifacts now land at `<bookDir>/exports/<slug>.<ext>` (visible) rather than the hidden `.audiobook/exports/<id>/` jail; export modal auto-saves the sync folder on blur with an inline error banner and a "Test" probe button; widened `renameWithRetry` covers Google Drive for Desktop and OneDrive virtual-FS EACCES/EIO hiccups with destination-specific hints.
 - **Persistence** — per-book `state.json` + `cast.json` + `manuscript-edits.json` with rotating backups, torn-read recovery, and schema versioning for forward-compatible migrations.
 - **Themes (stable in v1.3.0)** — Light / Dark / System toggle with an account-managed first-visit default. Full dark-mode coverage across white / amber / red / rose ladders + bespoke `floating-pill-inverse` utility for the cast-view selection bar.
+- **Mobile + tablet (v1.4.0)** — every view re-laid out across three Tailwind viewport tiers (`<640px` phone, `640–1024px` tablet, `≥1024px` desktop); LAN HTTPS via `mkcert` (`npm run install:cert-mobile` prints LAN URL + QR + per-OS root-cert install steps; `npm run dev:lan` / `start:lan` brings Vite + Node up on `https://0.0.0.0:5173`/`:8443`); touch-equivalence for every drag/hover affordance (tap-to-assign voice pill, PointerEvents on manuscript paragraph boundaries, `coarse-pointer:` Tailwind variant for hover-reveal labels); 44×44 px touch targets enforced.
+- **Frontend performance (v1.4.0)** — `useWindowVirtualizer` from `@tanstack/react-virtual` wraps the manuscript segment list above 60 segments, and the confirm-cast picker + listen chapter list above 40 rows (short books stay on the flat-render path). Broadcast-middleware shallow-diffs snapshots, `useAppSelectorShallow` applied at five large-slice sites, route-level `React.lazy` code-split. Main bundle 410 kB → 345 kB (gzip 108 kB → 91 kB).
 
 ## Layout
 
 ```
 src/                  Vite + React 18 + Redux Toolkit frontend
   store/              RTK slices (ui, cast, chapters, revisions, manuscript,
-                      book-meta, notifications, broadcast-middleware)
+                      book-meta, notifications, broadcast-middleware,
+                      engines-in-use-selector)
   views/              Stage views (books, upload, analysing, confirm, ready, listen,
-                      account); listen.tsx is an orchestrator over the sub-components
-                      below (decomposed in v1.3.0)
-  components/         Shared UI primitives
+                      account, worktrees); listen.tsx is an orchestrator over the
+                      sub-components below (decomposed in v1.3.0); book-library.tsx
+                      is a thin orchestrator over src/components/library/* (v1.4.0)
+  components/         Shared UI primitives — including character-search-picker (v1.4.0),
+                      manuscript-diff, loudness-report, delayed-spinner, stat-tiles
     listen/           Listen-view region sub-components — listen-header,
                       listen-player-region, listen-download-section (v1.3.0)
+    library/          Library-view sub-components — library-chrome (search + tags +
+                      view toggle), library-grid, library-table, library-status-ui,
+                      library-empty-states (v1.4.0)
   modals/             Profile drawer, cover picker, compare-cast, share-clip,
-                      share-link, etc.
-  lib/                api, router, types, generated api-types
+                      share-link, edit-book-meta, edit-chapter-title (v1.4.0), etc.
+  lib/                api, router, types, generated api-types, manuscript-diff,
+                      chapter-override-conflict, use-debounced-value
   mocks/              VITE_USE_MOCKS=1 fixtures
 server/               Node + Express API (TypeScript)
   src/
-    routes/           HTTP routes including new /api/books/:bookId/share +
+    routes/           HTTP routes including /api/books/:bookId/share +
                       /share/:slug + /api/books/:bookId/chapters/:chapterId/clip
-                      (v1.3.0)
+                      (v1.3.0); /api/books/:id/export/portable + /api/import/portable
+                      + /api/books/:bookId/cast/add-from-roster +
+                      /api/books/:bookId/chapters/:chapterId/rename +
+                      /api/revisions?bookIds=... + /api/worktrees +
+                      /api/user/settings/sync-folder/test +
+                      /api/sidecar/{load,unload} + /cert-root (v1.4.0)
+    analyzer/         phase-watermark + select-analyzer for the pipelined
+                      two-model Phase 0/1 split (v1.4.0)
+    tts/              loudnorm.ts (EBU R128 two-pass), aac.ts, opus.ts,
+                      synthesise-chapter.ts (parallel-friendly extracted entry),
+                      chapter-title-narration.ts (v1.4.0)
+    export/           build-portable-book.ts, build-codec-zip.ts (v1.4.0)
+    import/           scan-import-folder.ts (v1.4.0)
     ollama/           Vendor-installer bootstrap (v1.3.0)
   tts-sidecar/        Python FastAPI TTS sidecar (Coqui + Kokoro)
     scripts/          install-kokoro.{sh,ps1} + install-coqui.{sh,ps1} (v1.3.0)
   handoff/            Manual-analyzer inbox/outbox (when ANALYZER=manual)
-e2e/                  Playwright specs against Vite in mock mode
+e2e/                  Playwright specs against Vite in mock mode (chromium-only
+                      pre-push); responsive/* runs against mobile-chrome (Pixel 7)
+                      and tablet-chrome (iPad Pro 11) via npm run test:e2e:mobile
+                      (v1.4.0)
 scripts/              Orchestration (start/stop/install/preflight) — primarily
                       Node ESM since v1.2.2; wt-new.mjs spawns parallel Claude
                       worktrees, wt-list.mjs shows their port assignments,
                       wt-merge.mjs (v1.3.1) drives the integration-branch
-                      reconciliation pattern
-.github/workflows/    CI — release.yml on tag push, verify.yml on every PR (v1.3.0)
+                      reconciliation pattern, setup-lan-certs.mjs +
+                      print-cert-install-instructions.mjs bootstrap mkcert
+                      HTTPS for mobile testing (v1.4.0)
+.github/workflows/    CI — release.yml on tag push, verify.yml on every PR (v1.3.0);
+                      Node 24 since v1.4.0
 docs/
   features/           Living per-feature regression plans (INDEX.md)
   features/archive/   Plans that shipped and are no longer load-bearing
@@ -134,12 +163,34 @@ Copy `server/.env.example` as a starting point. Notable knobs:
 - `ANALYZER` — `local` (default, Ollama), `manual`, or `gemini`.
 - `GEMINI_API_KEY`, `GEMINI_MODEL`, and the per-model RPM / TPM / RPD
   caps when `ANALYZER=gemini`.
+- `ANALYZER_PHASE0_MODEL` / `ANALYZER_PHASE1_MODEL` /
+  `ANALYZER_PHASE1_MIN_LAG_CHAPTERS` (v1.4.0) — opt-in pipelined
+  two-model analyzer (Gemma cast + Gemini attribution by default,
+  10-chapter min lag). Set both phase vars to enable; legacy
+  single-model `ANALYZER=…` path preserved verbatim when unset. The
+  Account tab UI mirrors the same knobs per-book.
 - `PRELOAD_COQUI` — `0` (default; Coqui loads on demand) or `1`.
+- `GEN_CHAPTER_CONCURRENCY` (v1.4.0) — bounded worker pool size for
+  parallel chapter synthesis. Default `2`.
+- `AUDIO_LOUDNORM_ENABLED` (v1.4.0) — `true` (default; two-pass EBU R128
+  at -16 LUFS / 11 LU / -1.5 dBTP on every newly-rendered chapter) or
+  `false` to opt out per server install. Voice samples deliberately
+  skip the pass.
 - `WORKSPACE_DIR` — where per-book `.audiobook/` folders live.
 
 Frontend reads `VITE_USE_MOCKS` from `.env.development`. Mock mode
 round-trips against an in-memory store and is what the Playwright e2e
 suite runs against.
+
+### Mobile + tablet over LAN HTTPS (v1.4.0)
+
+1. One-time per dev box: `scoop install mkcert` (Windows), `brew install mkcert` (macOS), or `apt install mkcert` (Linux), then `mkcert -install`.
+2. `npm run install:cert-mobile` — prints LAN URL + QR code + per-OS root-cert install steps.
+3. Install the root CA on each mobile device once (iOS: Settings → Profile downloaded → Install → trust; Android: Settings → Security → Install certificate).
+4. `npm run dev:lan` (HMR-capable Vite + Node at `https://0.0.0.0:5173`/`:8443`) or `npm run build && npm run start:lan` (production bundle at `https://0.0.0.0:8443`).
+5. Open the printed LAN URL on the device — lock icon, no warning.
+
+E2E across phone (Pixel 7) and tablet (iPad Pro 11) viewports is opt-in via `npm run test:e2e:mobile` (~10–15 min); the pre-push gate (`npm run test:e2e`) is chromium-only.
 
 ## Parallel sessions (developer-only)
 


### PR DESCRIPTION
## Summary

- Refresh README.md to call out every v1.4.0 delta across Features (mobile + tablet, EBU R128 loudness + report card, AAC/Opus codecs, library search + table view + portable bundle, manuscript diff on re-upload + chapter rename + low-confidence triage polish, pipelined two-model analyzer, parallel chapter synthesis, cast drift consolidation, frontend perf pass with virtualisation + bundle split). Update the Layout tree with the new modules under `src/components/library/`, `server/src/{tts,analyzer,export,import}/`, and the e2e responsive harness. Add the new env knobs (`ANALYZER_PHASE{0,1}_MODEL`, `GEN_CHAPTER_CONCURRENCY`, `AUDIO_LOUDNORM_ENABLED`) and a Mobile + tablet over LAN HTTPS sub-section.
- Fix INSTALL.md staleness: the analyzer default was misdescribed as Gemini (it's actually `ANALYZER=local` with Gemini auto-fallback when Ollama is unreachable), and the "Coming in a future release" callout for the Account → Models card was stale (shipped in v1.3.0). Split analyzer setup into Option A (Ollama via the in-app Models card), Option B (Gemini key), and Option C (pipelined two-model split). Add sections covering chapter audio format (mp3 / aac-m4a / opus), the loudness normalisation default-on knob, LAN HTTPS via mkcert, and a v1.3.x → v1.4.0 update sub-section listing the new `BookStateJson.audioFormat` field, exports moving to `<bookDir>/exports/`, and the new optional env knobs.

Docs-only; no source code, tests, or build config touched.

This PR is the prep step for cutting the v1.4.0 release tag. After merge: `node scripts/bump-version.mjs --level minor --notes-file <path>` on main, then push the tag.

## Test plan

- [x] `npm run verify` green on the worktree (all eight steps cached on rerun)
- [x] README links to existing files (`docs/features/86-worktree-dashboard.md`, `docs/features/85-wt-merge-helper.md`, `CONTRIBUTING.md`)
- [x] INSTALL knob references match `server/.env.example` (`ANALYZER_PHASE0_MODEL`, `ANALYZER_PHASE1_MODEL`, `ANALYZER_PHASE1_MIN_LAG_CHAPTERS`, `GEN_CHAPTER_CONCURRENCY`, `AUDIO_LOUDNORM_ENABLED`)
- [x] Layout tree paths exist on disk (spot-checked `src/components/library/*`, `server/src/tts/loudnorm.ts`, `server/src/analyzer/phase-watermark.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)