### PR TITLE
fix(scripts): pass --cleanup=verbatim to git tag in bump-version.mjs

### DIFF
--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -179,12 +179,17 @@ git([
 ]);
 git(['commit', '-m', `chore: bump version to ${newVersion}`]);
 
-// Annotated tag.
+// Annotated tag. `--cleanup=verbatim` is load-bearing: git's default
+// cleanup mode for both `-m` and `-F` strips lines starting with `#`
+// as commentary, which silently eats the `## Features` / `## Fixes` /
+// `## Engineering` section headers CONTRIBUTING.md "Release notes"
+// mandates. v1.4.0 shipped with stripped headers and had to be patched
+// in place; preserve them by default from here on.
 info('[STEP] git tag ...');
 if (args.notesFile) {
-  git(['tag', '-a', newTag, '-F', resolve(args.notesFile)]);
+  git(['tag', '--cleanup=verbatim', '-a', newTag, '-F', resolve(args.notesFile)]);
 } else {
-  git(['tag', '-a', newTag, '-m', `Audiobook generator ${newTag}`]);
+  git(['tag', '--cleanup=verbatim', '-a', newTag, '-m', `Audiobook generator ${newTag}`]);
 }
 
 info('');

--- a/scripts/tests/bump-version.test.mjs
+++ b/scripts/tests/bump-version.test.mjs
@@ -288,3 +288,42 @@ test('polluted GIT_* env cannot misdirect subprocess from throwaway repo', () =>
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+/* Regression for the v1.4.0 ship: the bumper invoked `git tag -a -F` with
+   git's default cleanup mode, which strips lines starting with `#` as
+   commentary. The CONTRIBUTING.md "Release notes" spec mandates `##
+   Features` / `## Fixes` / `## Engineering` section headers; default
+   cleanup silently ate all three on the v1.4.0 tag, so the GitHub
+   Release body rendered as one long blob. Fix is `--cleanup=verbatim`
+   in scripts/bump-version.mjs. This test pins the survival of `##`
+   headers so the regression can't sneak back. */
+test('bump-version preserves ## section headers in the tag annotation', () => {
+  const dir = setupRepo('1.0.0');
+  try {
+    const notes = resolve(tmpdir(), `bump-notes-headers-${process.pid}-${Date.now()}.md`);
+    writeFileSync(
+      notes,
+      'v1.0.1 — headline\n' +
+        '\nIntro paragraph.\n' +
+        '\n## Features\n' +
+        '\n**Surface area.** Body paragraph.\n' +
+        '\n## Fixes\n' +
+        '\n- Bug fixed.\n' +
+        '\n## Engineering\n' +
+        '\n- Mechanical detail.\n',
+    );
+    const out = runBump(dir, ['--level', 'patch', '--notes-file', notes]);
+    rmSync(notes, { force: true });
+    assert.equal(out.status, 0, out.stderr);
+
+    const annotation = gitExec(['tag', '-l', '--format=%(contents)', 'v1.0.1'], {
+      cwd: dir,
+      encoding: 'utf8',
+    });
+    assert.match(annotation, /^## Features$/m, 'expected ## Features header to survive');
+    assert.match(annotation, /^## Fixes$/m, 'expected ## Fixes header to survive');
+    assert.match(annotation, /^## Engineering$/m, 'expected ## Engineering header to survive');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- The v1.4.0 ship surfaced this: `git tag -a -F <notes>` defaults to `--cleanup=strip`, which removes lines starting with `#` as commentary. The `## Features` / `## Fixes` / `## Engineering` section headers CONTRIBUTING.md "Release notes" mandates were silently eaten on the v1.4.0 tag annotation; the GitHub Release rendered as one long blob with no section breaks.
- Pass `--cleanup=verbatim` on both the `-F <notes-file>` path and the fallback `-m <placeholder>` path so future releases preserve headers verbatim.
- New regression test (`bump-version preserves ## section headers in the tag annotation`) writes a notes file with all three section headers and asserts each one survives the bump. Confirmed locally: 10/10 in `scripts/tests/bump-version.test.mjs`.

The v1.4.0 release body is being patched in place via `gh release edit v1.4.0 --notes-file <fixed>` + force-update of the v1.4.0 tag annotation (separate operation, out of band of this PR).

## Test plan

- [x] `node --test scripts/tests/bump-version.test.mjs` → 10/10 green locally (the new test runs in 1.25 s)
- [x] Pre-commit `verify:fast` green via cached run
- [x] Manual: removing `--cleanup=verbatim` and rerunning the new test confirms it correctly fails (the regression test catches the bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)