### PR TITLE
docs(docs): add BACKLOG should-#1 for ESLint 8→9 migration

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -49,7 +49,15 @@ Source: net-new (2026-05-20). Captured during planning of the next full version 
 
 ## Should — important, not blocking ship
 
-(none currently)
+### 1. ESLint 8 → 9 migration (drops the `inflight`/`glob@7`/`rimraf@3` deprecation chain)
+
+Source: net-new (2026-05-22). Surfaced by the `deprecated inflight@1.0.6` warning on `npm install`; full triage in `~/.claude/plans/fancy-bouncing-lovelace.md`.
+
+- _What:_ Bump `eslint` `^8.57.1` → `^9.x` and rewrite `.eslintrc.cjs` as flat config (`eslint.config.js`). Bump `@typescript-eslint/{eslint-plugin,parser}` `^7.18.0` → `^8.x` (v8 is the first major that supports ESLint 9), `eslint-plugin-react-hooks` `^4.6.2` → `^5.x`, and audit `eslint-plugin-react` + `eslint-plugin-jsx-a11y` + `eslint-config-prettier` for ESLint-9 compatibility. Re-baseline plan 46's autofix snapshot. Removes the `inflight@1.0.6` / `glob@7.2.3` / `rimraf@3.0.2` transitive chain that lives entirely inside ESLint 8's `file-entry-cache` → `flat-cache` plumbing — no direct dependency on our side.
+- _Acceptance:_ `npm install` no longer prints the `deprecated inflight@1.0.6` warning. `npm ls inflight` returns empty. `npm run lint` passes against the migrated flat config with the same rule set (no rule relaxations to make the migration green). `npm run verify` stays green end-to-end. Plan 46's autofix-baseline snapshot is regenerated and committed.
+- _Key files:_ `package.json` (4 devDeps to bump), new `eslint.config.js` (flat config), delete `.eslintrc.cjs` if present, `docs/features/archive/46-lint-format-a11y.md` (note the migration in Ship notes), any tests under `scripts/tests/` that exercise the lint command.
+- _Depends on:_ none structural. Pure tooling bump.
+- _Benefit (technical / architectural):_ clears the loudest `npm install` deprecation warning. Flat config is the only supported config format going forward; deferring increases migration cost as more transitive deps drop ESLint-8 support.
 
 ---
 


### PR DESCRIPTION
## Summary

Files the `deprecated inflight@1.0.6` npm-install warning as a tracked Should-bucket BACKLOG item rather than silently absorbing it. The deprecation chain (`eslint@8.57.1 → file-entry-cache → flat-cache → rimraf@3.0.2 → glob@7.2.3 → inflight@1.0.6`) is transitive-only — we have zero direct dependency on `inflight`, and the leak that motivated the deprecation message doesn't apply to us in practice (ESLint runs for seconds during `npm run lint`, not as a long-lived request coalescer). The only honest fix is the ESLint 8 → 9 migration itself, which is a non-trivial tooling bump: flat-config conversion (`.eslintrc.cjs` → `eslint.config.js`), `@typescript-eslint` v7 → v8, `eslint-plugin-react-hooks` v4 → v5, and a re-baseline of plan 46's autofix snapshot. That's the work this entry captures.

Filed in the Should bucket (not Could) per user direction.

## What lands

- `docs/BACKLOG.md` — new `Should #1` entry with the full **What / Acceptance / Key files / Depends on / Benefit** structure the bucket convention requires.
- No code changes. No test changes. No behaviour delta.

## Test plan

- [x] `npm run verify:fast` (pre-commit) — green (validator + frontend + server unit/integration).
- [x] `npm run verify` (pre-push) — green (typecheck + all tests + e2e + build).
- [ ] Reviewer: confirm the Should entry is well-scoped (single tooling-bump PR) and that the Could-bucket numbering wasn't accidentally renumbered (item count unchanged at 31 entries — the new entry occupies Should, which was previously empty).

## Related

- Full triage in `~/.claude/plans/fancy-bouncing-lovelace.md` (this repo doesn't carry plan files outside `docs/features/`; the plan file lives in the user's Claude plans directory).
- No regression-plan-doc update needed — this PR is itself the "plan" for a future migration PR; that future PR will live under `docs/features/NN-eslint-9-migration.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)