### PR TITLE
fix(scripts): wt-new auto-installs root + server deps in fresh worktrees

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,9 +123,13 @@ node scripts/wt-new.mjs feat/server-batch-retry
 
 The helper creates `../wt-batch-retry` on the new branch, writes a
 `.env.local` with this worktree's port assignments (so its `npm run dev`
-doesn't fight the main tree's `:5173` / `:8080` / `:9000` / `:5174`), and
-prints a copy-pasteable block with `cd …` + `npm install` + `npm run dev` +
-`claude` for the new terminal. Slot N gets ports offset by `N * 10`.
+doesn't fight the main tree's `:5173` / `:8080` / `:9000` / `:5174`), then
+runs `npm install` (root, which activates husky hooks via the `prepare`
+script) and `npm install --prefix server` inside the worktree so it's
+immediately ready for `npm run dev` / `npm run verify`. Finally prints a
+copy-pasteable `cd …` + `npm run dev` + `claude` block. Pass `--no-install`
+to skip the installs (the helper then falls back to printing both commands
+in the next-steps block). Slot N gets ports offset by `N * 10`.
 
 **List active worktrees + their port assignments:**
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -69,6 +69,16 @@ Source: net-new (2026-05-22). Surfaced by the `deprecated inflight@1.0.6` warnin
 - _Depends on:_ none structural. Pure tooling bump.
 - _Benefit (technical / architectural):_ clears the loudest `npm install` deprecation warning. Flat config is the only supported config format going forward; deferring increases migration cost as more transitive deps drop ESLint-8 support.
 
+### 2. Multer 1.x → 2.x security upgrade (server file uploads)
+
+Source: net-new (2026-05-22). Surfaced by `npm warn deprecated multer@1.4.5-lts.2: Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x.` on `npm install --prefix server`. Full deprecation audit notes in `~/.claude/plans/fancy-bouncing-lovelace.md`.
+
+- _What:_ Bump `multer` in `server/package.json` from `^1.4.5-lts.2` to `^2.0.x` and adapt the upload middleware to the 2.x API. The breaking changes are mostly file-size limits + the `req.file` / `req.files` shape (still backwards-compatible on the request-handler side, but `MulterError` codes and middleware error semantics changed). Manuscript upload (`server/src/routes/upload.ts` or similar) and any binary-upload e2e (`e2e/binary-upload.spec.ts`) need a once-over.
+- _Acceptance:_ `npm install --prefix server` no longer prints the `multer@1.4.5-lts.2` deprecation warning. `npm ls multer` returns `multer@^2.x`. Manuscript-upload + binary-upload e2e specs stay green. `server/src/routes/*upload*.ts` Vitest coverage extended to pin the new `MulterError` codes (specifically `LIMIT_FILE_SIZE` and `LIMIT_UNEXPECTED_FILE`, which 2.x renamed/regrouped).
+- _Key files:_ `server/package.json` (dep bump); `server/src/routes/*upload*.ts` (middleware shape); any test under `server/src/routes/*upload*.test.ts`; `e2e/binary-upload.spec.ts` (regression). Migration guide: https://github.com/expressjs/multer/blob/master/UPGRADING.md.
+- _Depends on:_ none. Pure dep bump + small middleware adaptation.
+- _Benefit (user / technical):_ closes the only known-vulnerable direct dependency in the tree. Multer 1.x is EOL and the npm advisory database flags multiple CVEs (CVE-2025-7338, CVE-2025-47935, etc.) that 2.x patches. Even though our upload path is local-only today, LAN HTTPS mode (plan 81) and any future hosted deployment widens the blast radius — closing this now keeps the server-side dep tree audit-clean.
+
 ---
 
 ## Could — nice to have, low-cost wins
@@ -351,6 +361,19 @@ Source: net-new (2026-05-22, surfaced during v1.4.0 ship). Two consecutive `npm 
 - _Key files:_ `playwright.config.ts` (worker count, default test timeout), `src/components/layout.tsx` (route-level Suspense boundary added in plan 89), `src/components/delayed-spinner.tsx` (the delay knob that's racing the assertion budget), `e2e/account-analyzer-knobs.spec.ts` + `e2e/account-models.spec.ts` + `e2e/bulk-sync-library.spec.ts` + `e2e/binary-upload.spec.ts` (the flaky specs seen in the v1.4.0 push attempts).
 - _Depends on:_ none.
 - _Benefit (dev / technical):_ removes the local-only false-positive pattern that forced a release-day `--no-verify` bypass. Keeps the pre-push gate trustworthy as the suite grows past 80 specs — without this, every future minor release risks the same dance.
+
+### 32. Track upstream-blocked deprecation chains (jsdom · archiver · @google/genai)
+
+Source: net-new (2026-05-22). Surfaced by the full `npm install` deprecation audit in `~/.claude/plans/fancy-bouncing-lovelace.md`. Pure tracking item — no direct fix; we wait for upstream majors. Companion to Should-#1 (ESLint 8 → 9, once that lands) and Should-#2 (Multer 1 → 2) which cover the chains we CAN fix today.
+
+- _What:_ Periodically re-run the deprecation audit (`npm install` at root + `npm install --prefix server` on a fresh clone, grep `npm warn deprecated`) and bump direct deps whose upstream majors drop one of these transitives. The currently-unfixable chains (as of 2026-05-22) are:
+  - `jsdom@25 → html-encoding-sniffer + whatwg-encoding@3.1.1` — deprecation says "Use @exodus/bytes". Waiting on jsdom upstream to migrate.
+  - `archiver@7 → archiver-utils → glob@10.5.0` — deprecation says "Old versions of glob are not supported". Waiting on archiver upstream to bump glob to v11+.
+  - `@google/genai@2 → google-auth-library → gaxios → node-fetch → fetch-blob → node-domexception@1.0.0` — deprecation says "Use your platform's native DOMException". Deep transitive via the Gemini SDK; waiting for `node-fetch`/`fetch-blob`/`google-auth-library` upstream to migrate to native DOMException.
+- _Acceptance:_ each time a direct dep is bumped (jsdom, archiver, or @google/genai), re-run the audit and tick off the resolved chain in this entry. Entry is removed from BACKLOG when all three resolve.
+- _Key files:_ `package.json` (jsdom + archiver direct), `server/package.json` (@google/genai direct). No source changes — purely a dep-bump tracking item.
+- _Depends on:_ upstream releases. Not on our schedule.
+- _Benefit (technical):_ keeps the `npm install` warning surface clean over time. Without explicit tracking, deprecation messages accumulate, new ones get lost in the noise, and the eventual audit becomes harder. This item is the watchdog that says "yes, we know, we're waiting on these three upstreams." Pairs with Should-#1 (ESLint chain) and Should-#2 (multer security) which together account for every deprecation warning surfaced on a fresh 2026-05-22 install.
 
 ---
 

--- a/scripts/tests/wt-new.test.mjs
+++ b/scripts/tests/wt-new.test.mjs
@@ -1,11 +1,20 @@
 // Tests for scripts/wt-new.mjs port-allocation + branch-name validation +
-// .env.local rendering, and for scripts/lib/branch-name.mjs.
+// .env.local rendering + install-step wiring, and for scripts/lib/branch-name.mjs.
 // Run via `npm run test:hooks` (node --test, no extra deps).
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { parseBranchName } from '../lib/branch-name.mjs';
-import { computePorts, renderEnvLocal } from '../wt-new.mjs';
+import {
+  buildInstallCommands,
+  computePorts,
+  parseArgs,
+  renderEnvLocal,
+  renderLaunchBlock,
+} from '../wt-new.mjs';
 import { parseEnvLocal, parseWorktreePorcelain } from '../wt-list.mjs';
 
 // ---- parseBranchName --------------------------------------------------------
@@ -172,4 +181,103 @@ test('parseEnvLocal skips comments and blank lines', () => {
   const parsed = parseEnvLocal(text);
   assert.equal(parsed.VITE_PORT, '5183');
   assert.equal(parsed.PORT, '8090');
+});
+
+// ---- parseArgs (CLI flags) --------------------------------------------------
+
+test('parseArgs defaults: install = true, from = main', () => {
+  const args = parseArgs(['feat/server-foo']);
+  assert.equal(args.branch, 'feat/server-foo');
+  assert.equal(args.from, 'main');
+  assert.equal(args.install, true);
+});
+
+test('parseArgs honours --no-install', () => {
+  const args = parseArgs(['feat/server-foo', '--no-install']);
+  assert.equal(args.branch, 'feat/server-foo');
+  assert.equal(args.install, false);
+});
+
+test('parseArgs --no-install order-independent (flag before branch)', () => {
+  const args = parseArgs(['--no-install', 'feat/server-foo']);
+  assert.equal(args.branch, 'feat/server-foo');
+  assert.equal(args.install, false);
+});
+
+test('parseArgs --from coexists with --no-install', () => {
+  const args = parseArgs(['feat/server-foo', '--from', 'release/v2', '--no-install']);
+  assert.equal(args.branch, 'feat/server-foo');
+  assert.equal(args.from, 'release/v2');
+  assert.equal(args.install, false);
+});
+
+test('parseArgs rejects unknown flags including typos like --noinstall', () => {
+  assert.throws(() => parseArgs(['feat/server-foo', '--noinstall']));
+  assert.throws(() => parseArgs(['feat/server-foo', '--bogus']));
+});
+
+// ---- buildInstallCommands ---------------------------------------------------
+
+function makeTmpWorktree(layout = 'with-server') {
+  const dir = mkdtempSync(join(tmpdir(), 'wt-new-test-'));
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'audiobook-generator' }));
+  if (layout === 'with-server') {
+    mkdirSync(join(dir, 'server'));
+    writeFileSync(join(dir, 'server', 'package.json'), JSON.stringify({ name: 'audiobook-generator-server' }));
+  }
+  return dir;
+}
+
+test('buildInstallCommands returns root + server when both package.json exist', () => {
+  const dir = makeTmpWorktree('with-server');
+  try {
+    const cmds = buildInstallCommands(dir);
+    assert.equal(cmds.length, 2);
+    assert.deepEqual(cmds[0].args, ['install']);
+    assert.equal(cmds[0].cwd, dir);
+    assert.equal(cmds[0].label, 'root');
+    assert.deepEqual(cmds[1].args, ['install', '--prefix', 'server']);
+    assert.equal(cmds[1].cwd, dir);
+    assert.equal(cmds[1].label, 'server');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('buildInstallCommands skips server when server/package.json is missing', () => {
+  const dir = makeTmpWorktree('no-server');
+  try {
+    const cmds = buildInstallCommands(dir);
+    assert.equal(cmds.length, 1);
+    assert.equal(cmds[0].label, 'root');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---- renderLaunchBlock install-aware output ---------------------------------
+
+test('renderLaunchBlock omits npm install when install=true (auto-installed)', () => {
+  const block = renderLaunchBlock({
+    worktreePath: 'C:/Claude/Projects/wt-foo',
+    branch: 'feat/server-foo',
+    ports: computePorts(1),
+    slot: 1,
+    install: true,
+  });
+  // Body of the launch block should not tell the user to run npm install again.
+  assert.doesNotMatch(block, /^\s*npm install\b/m, 'auto-install mode should not print npm install lines');
+  assert.match(block, /npm run dev/);
+});
+
+test('renderLaunchBlock includes both npm install lines when install=false', () => {
+  const block = renderLaunchBlock({
+    worktreePath: 'C:/Claude/Projects/wt-foo',
+    branch: 'feat/server-foo',
+    ports: computePorts(1),
+    slot: 1,
+    install: false,
+  });
+  assert.match(block, /npm install\b.*husky hooks/);
+  assert.match(block, /npm install --prefix server/);
 });

--- a/scripts/wt-new.mjs
+++ b/scripts/wt-new.mjs
@@ -4,11 +4,12 @@
 // repo without fighting over :5173 / :8080 / :9000 / :5174.
 //
 // Usage:
-//   node scripts/wt-new.mjs <type>/<scope>-<slug> [--from <base-branch>]
+//   node scripts/wt-new.mjs <type>/<scope>-<slug> [--from <base-branch>] [--no-install]
 //
 // Example:
 //   node scripts/wt-new.mjs feat/server-batch-retry
 //   node scripts/wt-new.mjs fix/frontend-toolbar --from main
+//   node scripts/wt-new.mjs chore/frontend-tidy --no-install
 //
 // What it does:
 //   1. Validates the branch name (CONTRIBUTING.md "Branch naming").
@@ -16,7 +17,11 @@
 //   3. Creates ../wt-<slug> via `git worktree add -b <branch> <path> <base>`.
 //   4. Writes <worktree>/.env.local with VITE_PORT / PORT / VITE_API_PORT /
 //      LOCAL_TTS_PORT / PLAYWRIGHT_PORT for this slot.
-//   5. Prints a copy-pasteable launch block.
+//   5. Runs `npm install` (root, which also activates husky hooks via the
+//      `prepare` script) + `npm install --prefix server` inside the worktree
+//      so it's ready for `npm run dev` / `npm run verify` immediately. Pass
+//      `--no-install` to skip both — falls back to printing the commands.
+//   6. Prints a copy-pasteable launch block.
 //
 // See CONTRIBUTING.md "Running multiple Claude Code conversations" for the
 // scope-discipline + GPU-coordination caveats.
@@ -49,13 +54,15 @@ function usage(extra) {
   return lines.join('\n');
 }
 
-function parseArgs(argv) {
-  const args = { branch: null, from: 'main' };
+export function parseArgs(argv) {
+  const args = { branch: null, from: 'main', install: true };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--from') {
       args.from = argv[++i];
       if (!args.from) throw new Error('--from requires a value');
+    } else if (a === '--no-install') {
+      args.install = false;
     } else if (a === '-h' || a === '--help') {
       args.help = true;
     } else if (a.startsWith('--')) {
@@ -121,9 +128,37 @@ function repoRoot() {
   return gitOrThrow(['rev-parse', '--show-toplevel']).trim();
 }
 
-function renderLaunchBlock({ worktreePath, branch, ports, slot }) {
+export function buildInstallCommands(worktreePath) {
+  const cmds = [
+    { label: 'root', args: ['install'], cwd: worktreePath },
+  ];
+  if (existsSync(join(worktreePath, 'server', 'package.json'))) {
+    cmds.push({ label: 'server', args: ['install', '--prefix', 'server'], cwd: worktreePath });
+  }
+  return cmds;
+}
+
+function runInstalls(worktreePath) {
+  const cmds = buildInstallCommands(worktreePath);
+  for (const { label, args, cwd } of cmds) {
+    process.stdout.write(`[wt-new] ${label} install: npm ${args.join(' ')} (in ${cwd})\n`);
+    const result = spawnSync('npm', args, {
+      cwd,
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
+    if (result.error) {
+      throw new Error(`npm ${label} install failed to spawn: ${result.error.message}`);
+    }
+    if (result.status !== 0) {
+      throw new Error(`npm ${label} install exited ${result.status}`);
+    }
+  }
+}
+
+export function renderLaunchBlock({ worktreePath, branch, ports, slot, install }) {
   const winPath = worktreePath.replace(/\//g, '\\');
-  return [
+  const lines = [
     ``,
     `[wt-new] slot ${slot} → ports VITE=${ports.VITE_PORT} API=${ports.PORT} TTS=${ports.LOCAL_TTS_PORT} E2E=${ports.PLAYWRIGHT_PORT}`,
     `[wt-new] worktree created at ${worktreePath}`,
@@ -132,12 +167,16 @@ function renderLaunchBlock({ worktreePath, branch, ports, slot }) {
     `Next steps — paste into a new terminal:`,
     ``,
     `  cd "${winPath}"`,
-    `  npm install        # first time in a new worktree only`,
-    `  npm run dev        # frontend :${ports.VITE_PORT}, server :${ports.PORT}`,
-    `  # in another tab:`,
-    `  claude             # launch a parallel Claude Code session here`,
-    ``,
-  ].join('\n');
+  ];
+  if (install === false) {
+    lines.push(`  npm install                  # root deps + husky hooks (skipped: --no-install)`);
+    lines.push(`  npm install --prefix server  # server-side deps (skipped: --no-install)`);
+  }
+  lines.push(`  npm run dev        # frontend :${ports.VITE_PORT}, server :${ports.PORT}`);
+  lines.push(`  # in another tab:`);
+  lines.push(`  claude             # launch a parallel Claude Code session here`);
+  lines.push(``);
+  return lines.join('\n');
 }
 
 export async function main(argv) {
@@ -186,7 +225,22 @@ export async function main(argv) {
   writeFileSync(envPath, renderEnvLocal({ slot, branch: args.branch, ports }), 'utf8');
   process.stdout.write(`[wt-new] wrote ${envPath}\n`);
 
-  process.stdout.write(renderLaunchBlock({ worktreePath, branch: args.branch, ports, slot }));
+  if (args.install) {
+    try {
+      runInstalls(worktreePath);
+    } catch (err) {
+      process.stderr.write(`[wt-new] install step failed: ${err.message}\n`);
+      process.stderr.write(`[wt-new] worktree at ${worktreePath} is created but deps are NOT installed.\n`);
+      process.stderr.write(`[wt-new] resume manually: cd "${worktreePath}" && npm install && npm install --prefix server\n`);
+      return 1;
+    }
+  } else {
+    process.stdout.write(`[wt-new] --no-install: skipping npm install steps\n`);
+  }
+
+  process.stdout.write(
+    renderLaunchBlock({ worktreePath, branch: args.branch, ports, slot, install: args.install }),
+  );
   return 0;
 }
 


### PR DESCRIPTION
## Summary

Two-commit PR. Both fall out of a deprecation/setup audit triggered by PR #126's `wt-new` run hitting a missing-server-deps trap.

### Commit 1 — `fix(scripts)`: wt-new auto-installs both packages

Fixes a setup-friction trap surfaced during PR #126: the helper created a worktree off main, but `npm install` at root left `server/node_modules` empty. Pre-commit then failed on `zod-to-json-schema` in `server/src/analyzer/ollama.ts` because the dep tree was incomplete. Invisible until the first commit that touches anything server tests cover — a quiet footgun every fresh worktree had.

After this PR, `scripts/wt-new.mjs` runs `npm install` (root, which also activates husky via the `prepare` lifecycle script) followed by `npm install --prefix server` inside the worktree as part of its execution. Worktrees are immediately ready for `npm run dev`, `npm run verify`, and pre-commit. A `--no-install` flag opt-out preserves the previous behaviour for power users; the printed next-steps block then includes both install commands so the manual recovery path stays discoverable.

CONTRIBUTING.md "Running multiple Claude Code conversations" updated to match.

### Commit 2 — `docs(docs)`: BACKLOG entries for remaining npm-install deprecation warnings

Audits the full `npm install` warning surface on a fresh clone (root + server). PR #126's Should-#1 already covers 5 of the 8 root warnings (the ESLint 8 chain: `inflight`, `glob@7`, `rimraf@3`, `@humanwhocodes/config-array`, `@humanwhocodes/object-schema`, plus `eslint@8.57.1` itself). This commit files the remaining 5:

- **Should-#1 (this branch)**: Multer 1.x → 2.x security upgrade — `multer@1.4.5-lts.2` is a direct server dep with known CVEs (CVE-2025-7338, CVE-2025-47935) that 2.x patches. Small middleware adaptation; only known-vulnerable direct dep in the tree.
- **Could-#32**: Upstream-blocked deprecation tracker — three transitive chains we can't fix until upstream majors land (`jsdom@25 → whatwg-encoding@3`, `archiver@7 → glob@10`, `@google/genai → … → node-domexception@1`). Visibility item to keep the audit honest.

When PR #126 lands first (likely), this branch's Should-#1 will rebase to Should-#2 per the BACKLOG renumbering convention. No content conflict expected.

## What lands

- **`scripts/wt-new.mjs`** — adds `--no-install` flag parsing, exports `parseArgs` / `buildInstallCommands` / `renderLaunchBlock` (was previously private), and chains both `npm install` commands inside the worktree after creation. Existing `--from <base-branch>` flag and slot/port allocation unchanged.
- **`scripts/tests/wt-new.test.mjs`** — 9 new `node:test` cases covering `parseArgs` default + `--no-install` parsing, `buildInstallCommands` topology (root-only when no server, root+server when both present), and `renderLaunchBlock` install-aware output. All 201 hook tests green via `npm run test:hooks`.
- **`CONTRIBUTING.md`** — "Running multiple Claude Code conversations" section updated to describe the new auto-install behaviour and the `--no-install` opt-out.
- **`docs/BACKLOG.md`** — Should-#1 (multer) and Could-#32 (upstream tracker) entries with the full What/Acceptance/Key files/Depends on/Benefit structure.

No source-code changes outside `scripts/`. No behavioural change for users not using `wt-new.mjs`.

## Test plan

- [x] `npm run verify:fast` (pre-commit) — green (hooks + frontend + server unit/integration). Cached for the second commit since only docs changed.
- [x] `npm run verify` (pre-push) — green (typecheck + all tests + e2e + build).
- [x] 9 new unit tests pass; total 201 hook tests green.
- [ ] Reviewer: confirm Should/Could entry numbering will rebase cleanly against PR #126 (Should bucket goes from empty → 1 entry in either order; merge order determines renumbering).
- [ ] Reviewer: confirm `--no-install` opt-out is the right shape (alternative considered: separate `--no-install-root` / `--no-install-server` flags — rejected as over-engineering for v1).

## Related

- Triage trail in `~/.claude/plans/fancy-bouncing-lovelace.md`.
- PR #126 (`docs/docs-backlog-eslint-9-migration`) covers the ESLint chain (5 of 8 root warnings); this PR covers the remaining 5 (multer + 3 upstream-blocked).
- Follow-up: update memory `feedback_run_prepare_in_fresh_worktree.md` post-merge — the "run npm run prepare in fresh worktrees" guidance becomes obsolete once this lands, since wt-new now handles it. Filed as out-of-PR follow-up so this stays test-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)