### PR TITLE
docs(docs): point INSTALL Updating section at BACKLOG MUST #1

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -211,7 +211,7 @@ The app drives on phone + tablet via LAN HTTPS using `mkcert` so iOS / Android t
 
 ## Updating
 
-A new release is just a new zip — there's no in-app auto-update yet.
+A new release is just a new zip — there's no in-app auto-update yet. Tracked as [`docs/BACKLOG.md`](docs/BACKLOG.md) MUST #1 (in-app upgrade pathway): when that ships, the five-step manual sequence below becomes a single click in the Account tab. For now, work the manual path.
 
 1. `npm run stop:prod` in the existing install folder.
 2. Download the new `audiobook-generator-vX.Y.Z.zip`.


### PR DESCRIPTION
## Summary

- Single-line addition to the INSTALL.md "Updating" section: an honest forward-pointer to `docs/BACKLOG.md` MUST #1 (in-app upgrade pathway) so the alpha tester reading the current five-step manual sequence knows the one-click flow is the priority next round of work, not vague "someday" backlog.
- Follow-up to PR #129 (which filed the MUST #1 entry itself). No code, no contract change, no test impact.

## Test plan

- [x] Pre-commit `verify:fast` and pre-push `verify` both green (cache-hit on every step — INSTALL.md isn't in any test-input hash, so the prior PR's cache was reused).
- [ ] Reviewer reads INSTALL.md "Updating" section after the merge and confirms the forward-pointer is clear without overpromising a timeline.