### PR TITLE
fix(server): persist post-normalisation loudness in lufs sidecar

### DIFF
--- a/docs/features/71-audio-loudness-normalization.md
+++ b/docs/features/71-audio-loudness-normalization.md
@@ -72,9 +72,9 @@ Persisted at `<bookDir>/audio/<chapterSlug>.lufs.json` after every chapter encod
 
 Fields:
 
-- `i` — measured integrated loudness (LUFS) of the rendered chapter. In two-pass mode this is the FIRST-PASS measurement of the source PCM; in single-pass mode it's the nominal target (single-pass doesn't re-measure post-filter).
-- `lra` — measured loudness range (LU). Same caveat as `i` for single-pass.
-- `tp` — measured true peak (dBTP). Same caveat as `i` for single-pass.
+- `i` — measured integrated loudness (LUFS) of the rendered chapter. In two-pass mode this is the POST-normalisation `output_i` parsed from the second-pass loudnorm filter's stderr JSON (per the 2026-05-22 correction below) — i.e. what the chapter actually sounds like after the gain pass, NOT the pre-filter input. In single-pass mode it's the nominal target (single-pass doesn't re-measure post-filter; consumers gate on `twoPass`).
+- `lra` — measured loudness range (LU). Post-normalisation `output_lra` in two-pass mode; nominal target in single-pass.
+- `tp` — measured true peak (dBTP). Post-normalisation `output_tp` in two-pass mode; nominal target in single-pass.
 - `target` — target integrated loudness used for normalisation. Matches `LoudnormOptions.target`.
 - `twoPass` — `true` when the measure-then-apply flow ran; `false` when single-pass streaming normalisation ran. Consumers MUST check this before treating `i`/`lra`/`tp` as ground truth — single-pass values are nominal.
 - `measuredAt` — ISO-8601 timestamp the measurement was taken (encode time).
@@ -106,7 +106,9 @@ The chapter still lands on disk; only the `.lufs.json` sidecar is missing. Real-
 - `server/src/tts/loudnorm.test.ts` — pure unit + real-ffmpeg integration:
   - `parseLoudnormFirstPassJson` — real-shape ffmpeg JSON, missing fields throw, `-inf` is coerced to `-Infinity` (not thrown), non-numeric non-inf strings throw.
   - `isMeasurementUseable` — true on finite stats, false on `-Infinity` (silent source).
-  - `buildSecondPassFilterString` — exact filter string format with all `measured_*` fields + `linear=true:print_format=summary`.
+  - `buildSecondPassFilterString` — exact filter string format with all `measured_*` fields + `linear=true:print_format=json` (the JSON form is what `encodePcmToAudio` parses post-encode to persist `output_i` into the sidecar — see 2026-05-22 correction).
+  - `parseLoudnormSecondPassJson` — input + output stat fields from a real-shape second-pass JSON block, missing `output_i` throws, `-inf` is coerced, missing `normalization_type` (string field) throws.
+  - `isSecondPassMeasurementUseable` — true on finite output stats, false on `-Infinity` (degenerate second pass).
   - `buildSinglePassFilterString` — no `measured_*` fields (single-pass needs no analysis).
   - `runLoudnormFirstPass` (real ffmpeg) — returns finite stats for a non-silent input.
   - `encodePcmToAudio` two-pass (real ffmpeg) — normalised encode is closer to target than baseline encode of the same PCM; `onLoudnessMeasured` fires with `twoPass: true` after a successful encode.
@@ -136,7 +138,7 @@ Requires a real chapter generation against a live sidecar (or the cached PCM tri
 
 - **Per-book toggle UI.** v1 is env-var only. Future surface area: a checkbox in the book-meta modal that overrides the env default per book.
 - **LUFS report card frontend.** Wave 2 (plan 77 when scaffolded) reads the sidecar JSON and renders a "Loudness drift" card on the listen view. This plan only ships the writer side.
-- **Single-pass measurement.** Single-pass mode records the nominal target in the sidecar, not a post-filter re-measurement. If the report card needs accurate single-pass values, Wave 2 must add a post-encode ebur128 pass — out of scope here.
+- **Single-pass measurement.** Single-pass mode records the nominal target in the sidecar, not a post-filter re-measurement. Two-pass mode now captures `output_i` from the encoder's stderr JSON (see the 2026-05-22 post-ship correction); single-pass would need a separate post-encode ebur128 pass — out of scope here.
 - **Voice-sample normalisation.** Voice samples (auditions) stay unnormalised — would add ~20 % latency to every Play-sample click for no listening benefit.
 
 ## Ship notes
@@ -154,3 +156,27 @@ Fix: explicit output `-ar String(opts.sampleRate)` in `server/src/tts/mp3.ts` `b
 Regression test: `server/src/tts/mp3-spawn-args.test.ts` adds three parameterised cases (mp3 / aac-m4a / opus) asserting an output `-ar` flag exists strictly between `-af` and `-c:a` and carries the input sample rate. Contract-level rather than ffprobe-end-to-end because the bug only manifests on real-speech PCM with non-trivial dynamic range — synthetic sine / noise PCM does not reproduce the 3× stretch even on the broken pipeline.
 
 Backfill: re-synthesize the 5 affected Exile chapters (`03-chapter-one-one`, `04-chapter-two-two`, `05-chapter-three-three`, `06-chapter-four-four`, `08-chapter-six-six`) and delete their stale `.previous.mp3` rollback files (same corrupted bytes — accepting a rollback would replay the bug). Discovery rule for any future audit: broken iff `ffprobe duration / segments.json durationSec > 1.5`.
+
+### Post-ship correction (2026-05-22) — sidecar `i` was input loudness, not output
+
+Bug: regenerating a chapter shifted its per-chapter LUFS pill (e.g. -21.9 → -21.5 across sibling chapters of a single book) even though every chapter was normalised to -16 LUFS on disk. User-visible symptom: the Loudness Report card flagged every chapter as drifting by ~6 LU from the -16 LUFS target, and the same chapter regenerated twice showed different pill values within ±1 LU.
+
+Root cause: `encodePcmToAudio`'s two-pass branch wrote `stats.input_i` (the pre-filter measurement of the raw PCM) into the `<slug>.lufs.json` sidecar as the `i` field. The second-pass loudnorm filter was correctly normalising the encoded MP3 to ~-16 LUFS, but the sidecar carried the un-normalised input loudness — so the pill displayed the loudness the chapter *would have had* without normalisation, not what it actually sounds like. Per-regen drift was just variance in the per-render synth PCM (different per-sentence gain, silence-gap distribution, VAD trims) — the on-disk MP3 was correct each time.
+
+The bug was acknowledged in this doc's own field definitions ("In two-pass mode this is the FIRST-PASS measurement") and in the Out of scope ("Wave 2 must add a post-encode ebur128 pass") — but Wave 2 plan 77 shipped the report card UI without the post-encode measurement, so the report card classified every chapter as off-target.
+
+Fix: switch the second-pass filter from `print_format=summary` to `print_format=json` and capture the encoder's stderr during the encode. After a successful encode, parse the trailing JSON block via the new `parseLoudnormSecondPassJson` and persist its `output_i` / `output_lra` / `output_tp` (post-normalisation values reported by the filter) into the sidecar. Zero extra ffmpeg invocations — the second-pass encode already runs `loudnorm` end-to-end, we just consume the existing summary output. On any parse failure (missing JSON block, missing `output_i`, non-finite output), the sidecar falls back to the input-side measurement and a `console.warn` fires — the MP3 is already on disk, a parse failure must not fail the encode.
+
+Required adjustment: `loudnorm` filter only emits its summary at `info` log level. The encode builders previously passed `-loglevel error`; with the fix in place we now pass `-loglevel info -nostats` when `loudnormFilter` is set. `-nostats` suppresses the per-frame progress noise that would otherwise drown the JSON block.
+
+Regression tests:
+- `loudnorm.test.ts` adds `parseLoudnormSecondPassJson` / `isSecondPassMeasurementUseable` unit coverage and a real-ffmpeg integration test (`sidecar i carries the post-normalisation output loudness near the target`) asserting the sidecar value lands within ±2 LU of -16 (rather than 6+ LU off).
+- `mp3-spawn-args.test.ts` adds three two-pass sidecar payload tests: parseable second-pass JSON → sidecar carries `output_i`; malformed stderr (no JSON block) → sidecar falls back to `input_i` with a warning; first-pass-shape JSON (no `output_i`) → same fallback path with a different warning.
+
+Backfill: existing chapters on disk still carry the wrong (input-loudness) sidecar value. The MP3 itself is correct — only the displayed pill is wrong on legacy chapters. `scripts/relufs-existing.mjs` (new in this PR) walks `<workspace>/<bookId>/audio/*.mp3`, runs a one-pass ebur128 measurement on each (cheap — ~3 s per chapter, measurement only, no re-encode), and atomically rewrites the sibling `.lufs.json`. Run once after this fix lands:
+
+```
+node scripts/relufs-existing.mjs            # rewrites every book under the configured workspace
+node scripts/relufs-existing.mjs --dry-run  # prints planned rewrites without touching disk
+node scripts/relufs-existing.mjs --book <bookId>  # restrict to one book
+```

--- a/scripts/relufs-existing.mjs
+++ b/scripts/relufs-existing.mjs
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+/* Backfill: re-measure every chapter MP3 in the workspace and rewrite its
+   sibling `<slug>.lufs.json` with the actual post-encode loudness. Companion
+   to the 2026-05-22 LUFS-drift fix — see
+   `docs/features/71-audio-loudness-normalization.md` for the bug write-up.
+
+   Pre-fix sidecars carry `i = input_i` (pre-normalisation loudness of the
+   raw PCM). The MP3 on disk is already normalised to -16 LUFS, but the
+   sidecar (and therefore the per-chapter pill + report card) shows the
+   pre-filter value. This script re-measures the encoded MP3 via ffmpeg's
+   `ebur128` filter and rewrites the sidecar in place — no re-encode, no
+   regenerate. ~3 s per chapter.
+
+   Usage:
+     node scripts/relufs-existing.mjs                # rewrite every chapter under the configured workspace
+     node scripts/relufs-existing.mjs --dry-run      # print planned rewrites without touching disk
+     node scripts/relufs-existing.mjs --workspace X  # override workspace root (otherwise reads WORKSPACE_DIR
+                                                     # from server/.env, or the ../audiobook-workspace default)
+     node scripts/relufs-existing.mjs --filter SUB   # only chapters whose relative path contains SUB
+
+   Skips chapters without an existing `.lufs.json` sidecar (legacy chapters
+   that were rendered before plan 71 — they have no sidecar to update; the
+   report card already degrades to "no data" for them). */
+
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync, renameSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const SERVER_ROOT = join(REPO_ROOT, 'server');
+
+function parseArgs(argv) {
+  const opts = { dryRun: false, workspace: null, filter: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--dry-run') opts.dryRun = true;
+    else if (a === '--workspace') {
+      opts.workspace = argv[i + 1];
+      i += 1;
+    } else if (a === '--filter') {
+      opts.filter = argv[i + 1];
+      i += 1;
+    } else if (a === '--help' || a === '-h') {
+      printHelpAndExit(0);
+    } else {
+      console.error(`relufs-existing: unknown flag "${a}". Pass --help for usage.`);
+      process.exit(2);
+    }
+  }
+  return opts;
+}
+
+function printHelpAndExit(code) {
+  console.log(`Usage: node scripts/relufs-existing.mjs [--dry-run] [--workspace <path>] [--filter <substring>]
+
+Walks <workspace>/books/**/audio/*.mp3 and rewrites the sibling *.lufs.json
+with a fresh ebur128 measurement of the on-disk MP3. Companion to the
+2026-05-22 LUFS-drift fix. Skips chapters without an existing sidecar.
+
+Options:
+  --dry-run         print planned rewrites without modifying any file
+  --workspace <p>   override workspace root (defaults to server/.env WORKSPACE_DIR
+                    or ../audiobook-workspace relative to the repo root)
+  --filter <sub>    only chapters whose relative path contains <sub>
+  --help, -h        print this help and exit`);
+  process.exit(code);
+}
+
+/* Resolve the workspace root the same way server/src/workspace/paths.ts does
+   at boot — env precedence, then default. Honours the override the server
+   would honour, so this script and a running server agree on the layout. */
+function resolveWorkspaceRoot(explicit) {
+  if (explicit) return resolve(process.cwd(), explicit);
+  loadServerDotEnv();
+  const envDir = process.env.WORKSPACE_DIR?.trim();
+  const dir = envDir && envDir.length > 0 ? envDir : '../audiobook-workspace';
+  return resolve(SERVER_ROOT, dir);
+}
+
+function loadServerDotEnv() {
+  /* Node 20.6+ ships native `process.loadEnvFile`. We use it the same way
+     the server does (see `server/src/load-env.ts`). Silent no-op if the
+     file doesn't exist — common on fresh clones. */
+  const envPath = join(SERVER_ROOT, '.env');
+  if (!existsSync(envPath)) return;
+  try {
+    process.loadEnvFile(envPath);
+  } catch {
+    /* Older Node? Fall back to a minimal parser for KEY=VALUE lines so the
+       script doesn't hard-require 20.6+. */
+    const lines = readFileSync(envPath, 'utf8').split(/\r?\n/);
+    for (const line of lines) {
+      const m = line.match(/^\s*([A-Z_][A-Z0-9_]*)\s*=\s*(.*?)\s*$/);
+      if (m && !(m[1] in process.env)) process.env[m[1]] = m[2];
+    }
+  }
+}
+
+/* Walk every `audio/` directory under `<workspace>/books/` and yield every
+   `*.mp3` that has a sibling `*.lufs.json`. Pre-fix sidecars are exactly
+   what we want to rewrite; chapters with no sidecar are skipped silently
+   (legacy / `AUDIO_LOUDNORM_ENABLED=false` / silent-source fallthrough).
+   Exported so the script test can drive it against a fixture workspace
+   without spawning ffmpeg. */
+export function* iterChapters(booksRoot) {
+  if (!existsSync(booksRoot)) return;
+  /* Workspace layout: <booksRoot>/<Author>/<Series>/<Book>/audio/<slug>.mp3 */
+  for (const author of readdirSync(booksRoot)) {
+    const authorDir = join(booksRoot, author);
+    if (!safeIsDir(authorDir)) continue;
+    for (const series of readdirSync(authorDir)) {
+      const seriesDir = join(authorDir, series);
+      if (!safeIsDir(seriesDir)) continue;
+      for (const book of readdirSync(seriesDir)) {
+        const bookDir = join(seriesDir, book);
+        const audioDir = join(bookDir, 'audio');
+        if (!safeIsDir(audioDir)) continue;
+        for (const entry of readdirSync(audioDir)) {
+          if (!entry.endsWith('.mp3')) continue;
+          const mp3Path = join(audioDir, entry);
+          const lufsPath = join(audioDir, entry.replace(/\.mp3$/, '.lufs.json'));
+          if (!existsSync(lufsPath)) continue;
+          yield { mp3Path, lufsPath, bookDir };
+        }
+      }
+    }
+  }
+}
+
+function safeIsDir(p) {
+  try {
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/* Spawn `ffmpeg -i <mp3> -af ebur128=peak=true -f null -` and parse the
+   integrated loudness + range + true-peak out of the "Summarizing" block at
+   the end of stderr. ebur128 emits per-frame I/M/S lines too; we MUST scope
+   the regex to the trailing summary or we pick up an intermediate gate value. */
+function measureMp3(mp3Path) {
+  return new Promise((res, rej) => {
+    const args = ['-hide_banner', '-nostats', '-i', mp3Path, '-af', 'ebur128=peak=true', '-f', 'null', '-'];
+    const child = spawn('ffmpeg', args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    const chunks = [];
+    child.stderr.on('data', (c) => chunks.push(c));
+    child.on('error', (err) => {
+      rej(
+        new Error(
+          `Failed to spawn ffmpeg for ebur128 measurement: ${err.message}. ` +
+            `Install ffmpeg and ensure it is on PATH (winget install Gyan.FFmpeg).`,
+        ),
+      );
+    });
+    child.on('close', (code) => {
+      const stderr = Buffer.concat(chunks).toString('utf8');
+      if (code !== 0) {
+        rej(new Error(`ffmpeg ebur128 exited ${code}: ${stderr.trim()}`));
+        return;
+      }
+      try {
+        res(parseEbur128Summary(stderr));
+      } catch (e) {
+        rej(e);
+      }
+    });
+  });
+}
+
+/* Parse the `Summarizing` / `Integrated loudness` block from ebur128 stderr.
+   Format (real example):
+       [Parsed_ebur128_0 @ 0x55] Summarizing
+       [Parsed_ebur128_0 @ 0x55]   Integrated loudness:
+       [Parsed_ebur128_0 @ 0x55]     I:         -16.0 LUFS
+       [Parsed_ebur128_0 @ 0x55]     Threshold: -26.1 LUFS
+       [Parsed_ebur128_0 @ 0x55]   Loudness range:
+       [Parsed_ebur128_0 @ 0x55]     LRA:        8.4 LU
+       [Parsed_ebur128_0 @ 0x55]     Threshold: -36.1 LUFS
+       [Parsed_ebur128_0 @ 0x55]     LRA low:   -21.0 LUFS
+       [Parsed_ebur128_0 @ 0x55]     LRA high:  -12.6 LUFS
+       [Parsed_ebur128_0 @ 0x55]   True peak:
+       [Parsed_ebur128_0 @ 0x55]     Peak:      -1.5 dBFS
+   Returns `{ i, lra, tp }` (LUFS, LU, dBTP). */
+export function parseEbur128Summary(stderr) {
+  const summaryIdx = stderr.lastIndexOf('Integrated loudness:');
+  if (summaryIdx < 0) {
+    throw new Error(`ebur128 stderr had no "Integrated loudness:" block: ${stderr.slice(-400)}`);
+  }
+  const summary = stderr.slice(summaryIdx);
+  const iMatch = summary.match(/\bI:\s*(-?[0-9.]+|-?inf)\s*LUFS/);
+  const lraMatch = summary.match(/\bLRA:\s*(-?[0-9.]+|-?inf)\s*LU\b/);
+  /* True peak reports as dBFS in the ebur128 summary even though the field
+     is conceptually dBTP — same scale, same sign convention. */
+  const tpMatch = summary.match(/\bPeak:\s*(-?[0-9.]+|-?inf)\s*dB(?:TP|FS)/);
+  if (!iMatch) throw new Error(`ebur128 summary had no "I:" line: ${summary.slice(0, 400)}`);
+  if (!lraMatch) throw new Error(`ebur128 summary had no "LRA:" line: ${summary.slice(0, 400)}`);
+  if (!tpMatch) throw new Error(`ebur128 summary had no "Peak:" line: ${summary.slice(0, 400)}`);
+  return {
+    i: parseNum(iMatch[1]),
+    lra: parseNum(lraMatch[1]),
+    tp: parseNum(tpMatch[1]),
+  };
+}
+
+function parseNum(s) {
+  if (s === '-inf' || s === '-Inf') return -Infinity;
+  if (s === 'inf' || s === '+inf') return Infinity;
+  return Number(s);
+}
+
+/* Rewrite a sidecar JSON atomically using the same temp-then-rename pattern
+   `writeChapterLufsFile` (in `server/src/tts/mp3.ts`) uses. Preserves the
+   existing `target` so re-measured chapters keep their original normalisation
+   target; sets `twoPass: true` because that's what loudnorm runs at production
+   default (the script is fixing the post-fix sidecar contract — single-pass
+   chapters were always nominal-target and don't need re-measurement). */
+function rewriteSidecar(lufsPath, measurement) {
+  let existing = null;
+  try {
+    existing = JSON.parse(readFileSync(lufsPath, 'utf8'));
+  } catch {
+    /* Malformed existing sidecar — overwrite anyway. The fresh measurement
+       is the right answer regardless of what bytes were there before. */
+  }
+  const target = typeof existing?.target === 'number' ? existing.target : -16;
+  const payload = {
+    i: measurement.i,
+    lra: measurement.lra,
+    tp: measurement.tp,
+    target,
+    twoPass: true,
+    measuredAt: new Date().toISOString(),
+  };
+  const tmp = `${lufsPath}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, JSON.stringify(payload, null, 2), 'utf8');
+  try {
+    renameSync(tmp, lufsPath);
+  } catch (err) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* swallow */
+    }
+    throw err;
+  }
+  return { previousI: typeof existing?.i === 'number' ? existing.i : null, newI: payload.i };
+}
+
+function fmtLufs(v) {
+  if (v === null || Number.isNaN(v)) return '— LUFS';
+  if (!Number.isFinite(v)) return `${v > 0 ? '+' : '-'}∞ LUFS`;
+  return `${v >= 0 ? '+' : '−'}${Math.abs(v).toFixed(1)} LUFS`;
+}
+
+/* Entry point. Returns a summary object for testability (script tests can
+   require this module and call main({ dryRun: true }) against a fixture
+   workspace without re-spawning the script). */
+export async function main(cliOpts = {}) {
+  const opts = { dryRun: false, workspace: null, filter: null, ...cliOpts };
+  const workspaceRoot = resolveWorkspaceRoot(opts.workspace);
+  const booksRoot = join(workspaceRoot, 'books');
+
+  if (!existsSync(booksRoot)) {
+    console.error(`relufs-existing: no books root at ${booksRoot}; nothing to do.`);
+    return { workspaceRoot, processed: 0, rewritten: 0, skipped: 0, failed: 0 };
+  }
+
+  console.log(`relufs-existing: workspace = ${workspaceRoot}`);
+  if (opts.dryRun) console.log('relufs-existing: DRY RUN — no files will be modified.');
+
+  let processed = 0;
+  let rewritten = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const chapter of iterChapters(booksRoot)) {
+    const relPath = relative(booksRoot, chapter.mp3Path);
+    if (opts.filter && !relPath.includes(opts.filter)) {
+      skipped += 1;
+      continue;
+    }
+    processed += 1;
+    try {
+      const measurement = await measureMp3(chapter.mp3Path);
+      if (opts.dryRun) {
+        let previousI = null;
+        try {
+          previousI = JSON.parse(readFileSync(chapter.lufsPath, 'utf8'))?.i ?? null;
+        } catch {
+          /* dry-run swallows read errors */
+        }
+        console.log(`  [dry] ${relPath}: ${fmtLufs(previousI)} → ${fmtLufs(measurement.i)}`);
+        rewritten += 1;
+      } else {
+        const { previousI, newI } = rewriteSidecar(chapter.lufsPath, measurement);
+        console.log(`  ${relPath}: ${fmtLufs(previousI)} → ${fmtLufs(newI)}`);
+        rewritten += 1;
+      }
+    } catch (err) {
+      failed += 1;
+      console.error(`  FAIL ${relPath}: ${(err instanceof Error ? err.message : String(err))}`);
+    }
+  }
+
+  console.log(
+    `relufs-existing: processed ${processed}, rewritten ${rewritten}, skipped ${skipped}, failed ${failed}.`,
+  );
+  return { workspaceRoot, processed, rewritten, skipped, failed };
+}
+
+/* Run main() when invoked directly (not when imported by a test). */
+const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirectly) {
+  const opts = parseArgs(process.argv.slice(2));
+  main(opts).then(
+    (result) => {
+      process.exit(result.failed > 0 ? 1 : 0);
+    },
+    (err) => {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    },
+  );
+}

--- a/scripts/tests/relufs-existing.test.mjs
+++ b/scripts/tests/relufs-existing.test.mjs
@@ -1,0 +1,138 @@
+/* Companion to the 2026-05-22 LUFS-drift backfill script
+   (`scripts/relufs-existing.mjs`). Covers:
+
+   - parseEbur128Summary: real-shape ffmpeg stderr fixtures (production +
+     degenerate -inf cases) → integrated loudness, range, true peak.
+   - iterChapters: workspace walker against a fixture <Author>/<Series>/<Book>
+     tree → only yields MP3s with a sibling .lufs.json.
+
+   We deliberately do NOT exercise the full main() against a fixture
+   workspace from this test — that would require either spawning real ffmpeg
+   on synthetic MP3 bytes (slow + brittle) or mocking the spawn (the
+   existing real-ffmpeg integration in server/src/tts/mp3.test.ts covers
+   the ebur128 measurement seam). The pure parser + walker are what we
+   lock down here. */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { iterChapters, parseEbur128Summary } from '../relufs-existing.mjs';
+
+test('parseEbur128Summary extracts I, LRA, and Peak from a real-shape stderr', () => {
+  /* Verbatim shape ffmpeg's ebur128 filter prints. The per-frame "I:" lines
+     before the "Summarizing" block are intermediate gate values — the parser
+     must scope to the trailing summary, not the first match. */
+  const stderr = `
+[Parsed_ebur128_0 @ 0x55] t: 0.4 I: -22.3 LUFS
+[Parsed_ebur128_0 @ 0x55] t: 1.4 I: -18.1 LUFS
+[Parsed_ebur128_0 @ 0x55] t: 2.4 I: -17.0 LUFS
+[Parsed_ebur128_0 @ 0x55] Summarizing
+[Parsed_ebur128_0 @ 0x55]   Integrated loudness:
+[Parsed_ebur128_0 @ 0x55]     I:         -16.0 LUFS
+[Parsed_ebur128_0 @ 0x55]     Threshold: -26.1 LUFS
+[Parsed_ebur128_0 @ 0x55]   Loudness range:
+[Parsed_ebur128_0 @ 0x55]     LRA:        8.4 LU
+[Parsed_ebur128_0 @ 0x55]     Threshold: -36.1 LUFS
+[Parsed_ebur128_0 @ 0x55]     LRA low:   -21.0 LUFS
+[Parsed_ebur128_0 @ 0x55]     LRA high:  -12.6 LUFS
+[Parsed_ebur128_0 @ 0x55]   True peak:
+[Parsed_ebur128_0 @ 0x55]     Peak:      -1.5 dBFS
+`;
+  const measurement = parseEbur128Summary(stderr);
+  assert.equal(measurement.i, -16.0);
+  assert.equal(measurement.lra, 8.4);
+  assert.equal(measurement.tp, -1.5);
+});
+
+test('parseEbur128Summary coerces "-inf" peak to -Infinity (silent input)', () => {
+  /* Dead-silent / near-silent MP3s report -inf for the integrated loudness
+     and peak. The script wants the raw measurement through so the caller
+     can decide whether to skip; the parser doesn't reject. */
+  const stderr = `
+[Parsed_ebur128_0 @ 0x55] Summarizing
+[Parsed_ebur128_0 @ 0x55]   Integrated loudness:
+[Parsed_ebur128_0 @ 0x55]     I:         -inf LUFS
+[Parsed_ebur128_0 @ 0x55]     Threshold: -70.0 LUFS
+[Parsed_ebur128_0 @ 0x55]   Loudness range:
+[Parsed_ebur128_0 @ 0x55]     LRA:        0.0 LU
+[Parsed_ebur128_0 @ 0x55]   True peak:
+[Parsed_ebur128_0 @ 0x55]     Peak:      -inf dBFS
+`;
+  const measurement = parseEbur128Summary(stderr);
+  assert.equal(measurement.i, -Infinity);
+  assert.equal(measurement.lra, 0);
+  assert.equal(measurement.tp, -Infinity);
+});
+
+test('parseEbur128Summary throws when there is no summary block', () => {
+  /* Defends against the case where ffmpeg ran but exited before emitting
+     the summary (e.g. malformed input file). Caller logs the failure and
+     skips the chapter rather than silently writing NaN to the sidecar. */
+  assert.throws(() => parseEbur128Summary('no ebur128 output here'), /Integrated loudness/);
+});
+
+test('iterChapters yields only MP3s that have a sibling .lufs.json', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'relufs-test-'));
+  try {
+    const books = join(tmp, 'books');
+    const bookAAudio = join(books, 'Author A', 'Series One', 'Book Alpha', 'audio');
+    const bookBAudio = join(books, 'Author B', 'Standalones', 'Book Beta', 'audio');
+    mkdirSync(bookAAudio, { recursive: true });
+    mkdirSync(bookBAudio, { recursive: true });
+
+    /* Book A, chapter 1: MP3 + sidecar → yielded. */
+    writeFileSync(join(bookAAudio, '01-intro.mp3'), 'mp3-bytes');
+    writeFileSync(
+      join(bookAAudio, '01-intro.lufs.json'),
+      JSON.stringify({ i: -22.5, target: -16, twoPass: true }),
+    );
+
+    /* Book A, chapter 2: MP3 only (legacy / loudnorm disabled at render
+       time) → NOT yielded. The backfill won't fabricate sidecars; it
+       only refreshes ones that exist. */
+    writeFileSync(join(bookAAudio, '02-no-sidecar.mp3'), 'mp3-bytes');
+
+    /* Book B, chapter 1: MP3 + sidecar in a different author/series →
+       yielded. Exercises the three-level <Author>/<Series>/<Book> walk. */
+    writeFileSync(join(bookBAudio, '01-only.mp3'), 'mp3-bytes');
+    writeFileSync(
+      join(bookBAudio, '01-only.lufs.json'),
+      JSON.stringify({ i: -18.0, target: -16, twoPass: true }),
+    );
+
+    /* A stray non-MP3 in the audio dir → ignored. */
+    writeFileSync(join(bookAAudio, '01-intro.peaks.json'), '{"peaks": []}');
+
+    const yielded = Array.from(iterChapters(books)).map((c) => c.mp3Path);
+    assert.equal(yielded.length, 2);
+    assert.ok(
+      yielded.some((p) => p.endsWith(join('Book Alpha', 'audio', '01-intro.mp3'))),
+      `expected Book Alpha intro to be yielded, got: ${yielded.join(', ')}`,
+    );
+    assert.ok(
+      yielded.some((p) => p.endsWith(join('Book Beta', 'audio', '01-only.mp3'))),
+      `expected Book Beta to be yielded, got: ${yielded.join(', ')}`,
+    );
+    assert.ok(
+      !yielded.some((p) => p.includes('02-no-sidecar')),
+      'chapter without a sibling .lufs.json must NOT be yielded',
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('iterChapters returns nothing when the books root does not exist', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'relufs-empty-'));
+  try {
+    /* No books/ subdirectory created — the walker must short-circuit
+       without crashing. Fresh-clone workspaces hit this path. */
+    const yielded = Array.from(iterChapters(join(tmp, 'books')));
+    assert.deepEqual(yielded, []);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/server/src/tts/loudnorm.test.ts
+++ b/server/src/tts/loudnorm.test.ts
@@ -11,7 +11,9 @@ import {
   buildSecondPassFilterString,
   buildSinglePassFilterString,
   isMeasurementUseable,
+  isSecondPassMeasurementUseable,
   parseLoudnormFirstPassJson,
+  parseLoudnormSecondPassJson,
   runLoudnormFirstPass,
   DEFAULT_LOUDNORM_OPTIONS,
   type LoudnormFirstPassStats,
@@ -197,11 +199,105 @@ describe('buildSecondPassFilterString', () => {
     };
     const opts: LoudnormOptions = { target: -16, lra: 11, tp: -1.5, twoPass: true };
     const filter = buildSecondPassFilterString(stats, opts);
+    /* print_format=json (not summary) so mp3.ts can parse the post-
+       normalisation output_i out of the encode's stderr. Persisting the
+       output value into the sidecar is the 2026-05-22 LUFS-drift fix. */
     expect(filter).toBe(
       'loudnorm=I=-16:LRA=11:TP=-1.5' +
         ':measured_I=-22.5:measured_LRA=9.4:measured_TP=-2.13' +
-        ':measured_thresh=-32.5:offset=6.45:linear=true:print_format=summary',
+        ':measured_thresh=-32.5:offset=6.45:linear=true:print_format=json',
     );
+  });
+});
+
+describe('parseLoudnormSecondPassJson', () => {
+  /* Fully-populated second-pass JSON block — the input_* fields are the
+     re-reported pre-filter measurement, the output_* fields are the post-
+     filter measurement we actually want to persist. */
+  const realSecondPassJson = `{
+    "input_i" : "-22.50",
+    "input_tp" : "-2.13",
+    "input_lra" : "9.40",
+    "input_thresh" : "-32.50",
+    "output_i" : "-16.02",
+    "output_tp" : "-1.51",
+    "output_lra" : "8.40",
+    "output_thresh" : "-26.10",
+    "normalization_type" : "linear",
+    "target_offset" : "6.45"
+  }`;
+
+  it('parses both input_* and output_* sides into a single stats record', () => {
+    const stats = parseLoudnormSecondPassJson(realSecondPassJson);
+    expect(stats.input_i).toBe(-22.5);
+    expect(stats.input_lra).toBe(9.4);
+    expect(stats.input_tp).toBe(-2.13);
+    expect(stats.output_i).toBe(-16.02);
+    expect(stats.output_lra).toBe(8.4);
+    expect(stats.output_tp).toBe(-1.51);
+    expect(stats.normalization_type).toBe('linear');
+    expect(stats.target_offset).toBe(6.45);
+  });
+
+  it('throws on missing output_i rather than silently fabricating a value', () => {
+    /* The whole point of this fix is to persist the post-normalisation
+       measurement. If the JSON is missing output_i, the caller MUST fall
+       back to the input-side sidecar — not get NaN. */
+    const malformed = `{
+      "input_i": "-22.5", "input_lra": "9.4", "input_tp": "-2.1",
+      "input_thresh": "-32.5", "target_offset": "6.45",
+      "normalization_type": "linear"
+    }`;
+    expect(() => parseLoudnormSecondPassJson(malformed)).toThrow(/output_i/);
+  });
+
+  it('coerces "-inf" output_i to -Infinity (degenerate post-filter case)', () => {
+    /* In practice the second pass should never produce -inf — but if it
+       did, isSecondPassMeasurementUseable returns false and the caller
+       falls back to the input-side sidecar rather than persisting -inf. */
+    const degenerate = `{
+      "input_i": "-22.5", "input_lra": "9.4", "input_tp": "-2.1",
+      "input_thresh": "-32.5",
+      "output_i": "-inf", "output_lra": "0", "output_tp": "-inf",
+      "output_thresh": "-70",
+      "normalization_type": "linear", "target_offset": "6.45"
+    }`;
+    const stats = parseLoudnormSecondPassJson(degenerate);
+    expect(stats.output_i).toBe(-Infinity);
+    expect(isSecondPassMeasurementUseable(stats)).toBe(false);
+  });
+
+  it('throws on missing normalization_type (string field, not numeric)', () => {
+    const noType = `{
+      "input_i": "-22.5", "input_lra": "9.4", "input_tp": "-2.1",
+      "input_thresh": "-32.5",
+      "output_i": "-16", "output_lra": "8", "output_tp": "-1.5",
+      "output_thresh": "-26", "target_offset": "6.45"
+    }`;
+    expect(() => parseLoudnormSecondPassJson(noType)).toThrow(/normalization_type/);
+  });
+});
+
+describe('isSecondPassMeasurementUseable', () => {
+  function fixture(overrides: Partial<{ output_i: number; output_lra: number; output_tp: number; output_thresh: number }>) {
+    return {
+      input_i: -22.5, input_lra: 9.4, input_tp: -2.1, input_thresh: -32.5,
+      output_i: -16, output_lra: 8, output_tp: -1.5, output_thresh: -26,
+      normalization_type: 'linear', target_offset: 6.45,
+      ...overrides,
+    };
+  }
+
+  it('returns true when every output_* field is finite', () => {
+    expect(isSecondPassMeasurementUseable(fixture({}))).toBe(true);
+  });
+
+  it('returns false when output_i is -Infinity', () => {
+    expect(isSecondPassMeasurementUseable(fixture({ output_i: -Infinity }))).toBe(false);
+  });
+
+  it('returns false when output_tp is non-finite', () => {
+    expect(isSecondPassMeasurementUseable(fixture({ output_tp: Infinity }))).toBe(false);
   });
 });
 
@@ -303,6 +399,46 @@ describeIfFfmpeg('encodePcmToAudio with two-pass loudnorm (real ffmpeg)', () => 
     expect(Number.isFinite(stats.tp)).toBe(true);
     expect(typeof stats.measuredAt).toBe('string');
     expect(stats.measuredAt).toMatch(/\dT\d/);
+  }, 60_000);
+
+  /* Regression for the 2026-05-22 LUFS-drift fix: the sidecar payload now
+     carries the POST-normalisation output_i, not the pre-filter input_i.
+     With DEFAULT_LOUDNORM_OPTIONS.target = -16 and twoPass = true, the
+     callback's `i` value must land near the target — not at the raw PCM's
+     pre-filter loudness (which for a -6 dBFS sine is around -9 LUFS). */
+  it('sidecar i carries the post-normalisation output loudness near the target', async () => {
+    const sampleRate = 24_000;
+    /* Two-segment loud+quiet concatenation gives the loudnorm filter
+       enough non-trivial program-loudness variance to settle on a
+       sensible offset; a single uniform sine confuses the gate. */
+    const loud = sinePcm(sampleRate, 2.5, 440, 24000);
+    const quiet = sinePcm(sampleRate, 2.5, 660, 3000);
+    const pcm = Buffer.concat([loud, quiet]);
+
+    /* Capture the un-normalised PCM's input integrated loudness so we can
+       assert the sidecar value is "significantly closer to target than
+       the raw input was" — the literal symptom the user reported. */
+    const firstPass = await runLoudnormFirstPass(pcm, sampleRate, DEFAULT_LOUDNORM_OPTIONS);
+    const rawInputI = firstPass.input_i;
+
+    let sidecar: { i: number; twoPass: boolean; target: number } | null = null;
+    await encodePcmToAudio(pcm, sampleRate, {
+      quality: 2,
+      loudnorm: DEFAULT_LOUDNORM_OPTIONS,
+      onLoudnessMeasured: (s) => {
+        sidecar = s;
+      },
+    });
+    expect(sidecar).not.toBeNull();
+    expect(sidecar!.twoPass).toBe(true);
+    expect(sidecar!.target).toBe(-16);
+    /* Hard contract: the sidecar value is the POST-normalisation reading
+       (within ~2 LU of target — generous to absorb synthetic-sine gate
+       noise), not the pre-filter input. */
+    expect(Math.abs(sidecar!.i - -16)).toBeLessThan(2);
+    /* And the gap from raw-input-to-target must be MUCH wider than the
+       gap from sidecar-to-target — the whole point of the fix. */
+    expect(Math.abs(sidecar!.i - -16)).toBeLessThan(Math.abs(rawInputI - -16) / 2);
   }, 60_000);
 });
 

--- a/server/src/tts/loudnorm.ts
+++ b/server/src/tts/loudnorm.ts
@@ -60,7 +60,15 @@ export interface LoudnormFirstPassStats {
 
 /** Persistent record of a chapter's measured loudness, written next to the
  *  audio as `<chapterSlug>.lufs.json`. Plan 77 (Wave 2 — LUFS report card UI)
- *  reads this back; field names are stable contract. */
+ *  reads this back; field names are stable contract.
+ *
+ *  In two-pass mode `i` / `lra` / `tp` are the POST-normalisation values
+ *  ffmpeg's second-pass loudnorm filter reports as `output_*` — i.e. what
+ *  the chapter actually sounds like after the gain pass, not what the raw
+ *  PCM measured before. In single-pass mode they are the nominal target
+ *  (single-pass doesn't re-measure post filter); consumers MUST check
+ *  `twoPass === true` before treating these fields as ground truth
+ *  (`loudness-report.tsx:classifyDrift`). */
 export interface LoudnormSidecarJson {
   /** Measured integrated loudness (LUFS) of the rendered chapter. */
   i: number;
@@ -76,10 +84,42 @@ export interface LoudnormSidecarJson {
   measuredAt: string;
 }
 
+/** Shape of the JSON block ffmpeg's second-pass `loudnorm` writes to stderr
+ *  when invoked with `print_format=json`. ffmpeg emits BOTH the input_* and
+ *  output_* sides on the second pass; the persisted sidecar uses only the
+ *  output side (post-normalisation), the input side is surfaced here for
+ *  diagnostic logging. */
+export interface LoudnormSecondPassStats {
+  /** Pre-filter input integrated loudness (LUFS) as re-reported by the
+   *  second-pass invocation. Same value as `LoudnormFirstPassStats.input_i`
+   *  from the analysis pass; useful for log copy / drift diagnostics. */
+  input_i: number;
+  input_lra: number;
+  input_tp: number;
+  input_thresh: number;
+  /** Post-filter integrated loudness (LUFS) — what the encoded chapter
+   *  actually sounds like. Persisted to the sidecar as `i`. */
+  output_i: number;
+  /** Post-filter loudness range (LU). Persisted to the sidecar as `lra`. */
+  output_lra: number;
+  /** Post-filter true peak (dBTP). Persisted to the sidecar as `tp`. */
+  output_tp: number;
+  output_thresh: number;
+  /** "linear" | "dynamic" — loudnorm's mode classifier. Linear means a
+   *  single gain offset was applied (preferred — preserves the source
+   *  envelope); dynamic means it had to compress on the fly. Not surfaced
+   *  to the UI today; captured here for log copy. */
+  normalization_type: string;
+  /** Gain offset (LU) actually applied to reach the target. */
+  target_offset: number;
+}
+
 /** Extract the trailing JSON object from ffmpeg stderr. ffmpeg prints
  *  loudnorm's `print_format=json` block at the end of stderr after any
- *  warnings / per-frame logging — we scan for the LAST balanced `{ ... }`. */
-function extractTrailingJsonBlock(stderr: string): string | null {
+ *  warnings / per-frame logging — we scan for the LAST balanced `{ ... }`.
+ *  Exported so `mp3.ts` can reuse the same primitive when parsing the
+ *  second-pass encode's stderr. */
+export function extractTrailingJsonBlock(stderr: string): string | null {
   let depth = 0;
   let lastEnd = -1;
   let lastStart = -1;
@@ -234,8 +274,10 @@ export async function runLoudnormFirstPass(
 /** Build the second-pass `-af` filter string that consumes the first-pass
  *  measurements. `linear=true` requests linear-mode normalisation (a single
  *  gain adjustment derived from the measurement) which preserves the source
- *  envelope. `print_format=summary` makes ffmpeg log a one-line summary on
- *  the second pass — useful when debugging but not parsed by the encoder. */
+ *  envelope. `print_format=json` makes ffmpeg log the full input/output stat
+ *  block on the second pass — `mp3.ts` parses it to persist the actual
+ *  post-normalisation loudness (rather than the pre-filter input value) in
+ *  the chapter sidecar. */
 export function buildSecondPassFilterString(
   stats: LoudnormFirstPassStats,
   opts: LoudnormOptions,
@@ -247,7 +289,65 @@ export function buildSecondPassFilterString(
     `:measured_TP=${stats.input_tp}` +
     `:measured_thresh=${stats.input_thresh}` +
     `:offset=${stats.target_offset}` +
-    `:linear=true:print_format=summary`
+    `:linear=true:print_format=json`
+  );
+}
+
+/** Parse a second-pass loudnorm JSON block (string form) into the post-
+ *  normalisation stats shape. Same trailing-JSON convention as the first
+ *  pass; the field set is the union of `input_*` (re-reported pre-filter)
+ *  and `output_*` (the post-filter values we actually want).
+ *
+ *  Behaviour on non-numeric / non-inf values mirrors `parseLoudnormFirstPassJson`
+ *  — non-finite floats parse to `±Infinity`, missing fields throw. The
+ *  caller (`encodePcmToAudio` in `mp3.ts`) treats a thrown / unparseable
+ *  block as "fall back to writing the first-pass input as the sidecar
+ *  value" rather than failing the encode, since the MP3 is already on disk
+ *  by the time we get here. */
+export function parseLoudnormSecondPassJson(jsonBlock: string): LoudnormSecondPassStats {
+  const raw = JSON.parse(jsonBlock) as Record<string, unknown>;
+  const numericField = (key: string): number => {
+    const v = raw[key];
+    if (typeof v === 'number') return v;
+    if (typeof v === 'string') {
+      const trimmed = v.trim();
+      if (trimmed === '-inf' || trimmed === '-Infinity') return -Infinity;
+      if (trimmed === '+inf' || trimmed === 'inf' || trimmed === 'Infinity') return Infinity;
+      const n = Number(trimmed);
+      if (Number.isFinite(n)) return n;
+      throw new Error(`loudnorm: non-numeric "${key}" value "${v}" in second-pass JSON`);
+    }
+    throw new Error(`loudnorm: missing or non-numeric "${key}" in second-pass JSON`);
+  };
+  const stringField = (key: string): string => {
+    const v = raw[key];
+    if (typeof v === 'string') return v;
+    throw new Error(`loudnorm: missing or non-string "${key}" in second-pass JSON`);
+  };
+  return {
+    input_i: numericField('input_i'),
+    input_lra: numericField('input_lra'),
+    input_tp: numericField('input_tp'),
+    input_thresh: numericField('input_thresh'),
+    output_i: numericField('output_i'),
+    output_lra: numericField('output_lra'),
+    output_tp: numericField('output_tp'),
+    output_thresh: numericField('output_thresh'),
+    normalization_type: stringField('normalization_type'),
+    target_offset: numericField('target_offset'),
+  };
+}
+
+/** True iff every numeric field on `stats` is finite — i.e. ffmpeg's second
+ *  pass produced a usable post-normalisation measurement. Degenerate
+ *  output (output_i = -inf — would happen if the second pass silenced
+ *  everything) falls back to persisting the input-side measurement. */
+export function isSecondPassMeasurementUseable(stats: LoudnormSecondPassStats): boolean {
+  return (
+    Number.isFinite(stats.output_i) &&
+    Number.isFinite(stats.output_lra) &&
+    Number.isFinite(stats.output_tp) &&
+    Number.isFinite(stats.output_thresh)
   );
 }
 

--- a/server/src/tts/mp3-spawn-args.test.ts
+++ b/server/src/tts/mp3-spawn-args.test.ts
@@ -24,13 +24,16 @@ vi.mock('node:child_process', async (importOriginal) => {
   };
 });
 
-function fakeFfmpegChild(): {
+function fakeFfmpegChild(
+  opts: { stderr?: string } = {},
+): {
   on: ReturnType<typeof vi.fn>;
   stdin: { on: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
   stdout: { on: ReturnType<typeof vi.fn> };
   stderr: { on: ReturnType<typeof vi.fn> };
 } {
   let closeHandler: ((code: number) => void) | null = null;
+  let stderrDataHandler: ((chunk: Buffer) => void) | null = null;
   return {
     on: vi.fn((event: string, handler: (code: number) => void) => {
       if (event === 'close') closeHandler = handler;
@@ -39,12 +42,21 @@ function fakeFfmpegChild(): {
       on: vi.fn(),
       end: vi.fn(() => {
         /* Resolve on next microtask so the encoder's awaited Promise has
-           attached its .then chain before we fire 'close'. */
-        queueMicrotask(() => closeHandler?.(0));
+           attached its .then chain before we fire stderr / 'close'. */
+        queueMicrotask(() => {
+          if (opts.stderr && stderrDataHandler) {
+            stderrDataHandler(Buffer.from(opts.stderr, 'utf8'));
+          }
+          closeHandler?.(0);
+        });
       }),
     },
     stdout: { on: vi.fn() },
-    stderr: { on: vi.fn() },
+    stderr: {
+      on: vi.fn((event: string, handler: (chunk: Buffer) => void) => {
+        if (event === 'data') stderrDataHandler = handler;
+      }),
+    },
   };
 }
 
@@ -137,5 +149,138 @@ describe('encodePcmToAudio spawn args', () => {
       expect(args[outputArIdx + 1]).toBe(String(sampleRate));
       expect(args[caIndex + 1]).toMatch(codec);
     });
+  });
+});
+
+/* Two-pass sidecar payload coverage (2026-05-22 LUFS-drift fix). Both passes
+   are spawned through node:child_process; we mock both:
+   - First spawn = analysis pass. Returns a valid first-pass JSON in stderr
+     so the encoder progresses to the second pass.
+   - Second spawn = encode pass. Its stderr is what `parseLoudnormSecondPassJson`
+     consumes. We vary it per case to exercise success + fallback paths.
+
+   These tests assert the sidecar payload shape (onLoudnessMeasured callback
+   value) rather than the args. They live in the spawn-args file because they
+   need the same mocked-spawn primitive. */
+describe('encodePcmToAudio two-pass sidecar payload', () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  /* A complete first-pass JSON block (input_* only — no output_*). Stable
+     real-shape input that makes isMeasurementUseable return true and lets
+     the encoder progress to the second pass. */
+  const firstPassStderr = `[Parsed_loudnorm @ 0x1] \n` +
+    `{\n` +
+    `        "input_i" : "-22.50",\n` +
+    `        "input_tp" : "-2.13",\n` +
+    `        "input_lra" : "9.40",\n` +
+    `        "input_thresh" : "-32.50",\n` +
+    `        "target_offset" : "6.45"\n` +
+    `}\n`;
+
+  /* Real-shape second-pass JSON. output_i is the post-normalisation value
+     we want persisted into the sidecar. */
+  const secondPassStderr = `[Parsed_loudnorm @ 0x1] \n` +
+    `{\n` +
+    `        "input_i" : "-22.50",\n` +
+    `        "input_tp" : "-2.13",\n` +
+    `        "input_lra" : "9.40",\n` +
+    `        "input_thresh" : "-32.50",\n` +
+    `        "output_i" : "-16.02",\n` +
+    `        "output_tp" : "-1.51",\n` +
+    `        "output_lra" : "8.40",\n` +
+    `        "output_thresh" : "-26.10",\n` +
+    `        "normalization_type" : "linear",\n` +
+    `        "target_offset" : "6.45"\n` +
+    `}\n`;
+
+  it('writes output_i to the sidecar when the second-pass stderr is parseable', async () => {
+    spawnMock
+      .mockImplementationOnce(() => fakeFfmpegChild({ stderr: firstPassStderr }))
+      .mockImplementationOnce(() => fakeFfmpegChild({ stderr: secondPassStderr }));
+
+    const { encodePcmToAudio } = await import('./mp3.js');
+    let sidecar: { i: number; lra: number; tp: number; twoPass: boolean; target: number } | null = null;
+    await encodePcmToAudio(Buffer.alloc(2), 24_000, {
+      quality: 2,
+      loudnorm: { target: -16, lra: 11, tp: -1.5, twoPass: true },
+      onLoudnessMeasured: (s) => {
+        sidecar = s;
+      },
+    });
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    expect(sidecar).not.toBeNull();
+    expect(sidecar!.twoPass).toBe(true);
+    expect(sidecar!.target).toBe(-16);
+    /* The fix: i is output_i (-16.02), NOT input_i (-22.50). */
+    expect(sidecar!.i).toBe(-16.02);
+    expect(sidecar!.lra).toBe(8.4);
+    expect(sidecar!.tp).toBe(-1.51);
+  });
+
+  it('falls back to input_i when the second-pass stderr lacks a JSON block', async () => {
+    /* Simulates ffmpeg builds / log levels that suppress the loudnorm
+       summary. The encode still succeeded (MP3 bytes are on disk) — we
+       just persist the pre-filter measurement and log a warning, rather
+       than corrupting the sidecar with NaN or failing the encode. */
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      spawnMock
+        .mockImplementationOnce(() => fakeFfmpegChild({ stderr: firstPassStderr }))
+        .mockImplementationOnce(() => fakeFfmpegChild({ stderr: 'no json here, just text' }));
+
+      const { encodePcmToAudio } = await import('./mp3.js');
+      let sidecar: { i: number; twoPass: boolean } | null = null;
+      await encodePcmToAudio(Buffer.alloc(2), 24_000, {
+        quality: 2,
+        loudnorm: { target: -16, lra: 11, tp: -1.5, twoPass: true },
+        onLoudnessMeasured: (s) => {
+          sidecar = s;
+        },
+      });
+
+      expect(sidecar).not.toBeNull();
+      expect(sidecar!.twoPass).toBe(true);
+      /* Fallback path: persist input_i so the sidecar carries SOMETHING
+         rather than nothing. UI pill will look stale but the MP3 plays. */
+      expect(sidecar!.i).toBe(-22.5);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/second-pass stderr did not include a JSON block/),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('falls back to input_i when the second-pass JSON is missing output_i', async () => {
+    /* Same fallback path, different trigger: stderr DOES have a JSON block
+       (e.g. ffmpeg only printed the first-pass-shape summary) but it
+       lacks the output_* fields parseLoudnormSecondPassJson requires. */
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      spawnMock
+        .mockImplementationOnce(() => fakeFfmpegChild({ stderr: firstPassStderr }))
+        .mockImplementationOnce(() => fakeFfmpegChild({ stderr: firstPassStderr }));
+
+      const { encodePcmToAudio } = await import('./mp3.js');
+      let sidecar: { i: number; twoPass: boolean } | null = null;
+      await encodePcmToAudio(Buffer.alloc(2), 24_000, {
+        quality: 2,
+        loudnorm: { target: -16, lra: 11, tp: -1.5, twoPass: true },
+        onLoudnessMeasured: (s) => {
+          sidecar = s;
+        },
+      });
+
+      expect(sidecar).not.toBeNull();
+      expect(sidecar!.i).toBe(-22.5);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/failed to parse second-pass stderr JSON/),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/server/src/tts/mp3.ts
+++ b/server/src/tts/mp3.ts
@@ -28,8 +28,12 @@ import { computePeaks } from '../audio/compute-peaks.js';
 import {
   buildSecondPassFilterString,
   buildSinglePassFilterString,
+  extractTrailingJsonBlock,
   isMeasurementUseable,
+  isSecondPassMeasurementUseable,
+  parseLoudnormSecondPassJson,
   runLoudnormFirstPass,
+  type LoudnormFirstPassStats,
   type LoudnormOptions,
   type LoudnormSidecarJson,
 } from './loudnorm.js';
@@ -115,14 +119,23 @@ interface FfmpegBuildOpts {
   loudnormFilter?: string | null;
 }
 
+/** Loudnorm's `print_format=json` summary is logged at info level — at the
+ *  default `error` level the encoder's stderr stays empty and the sidecar
+ *  parser has nothing to consume (2026-05-22 fix). When a loudnorm filter
+ *  is present we bump to `info` and add `-nostats` to suppress the per-
+ *  frame progress noise that would otherwise drown the JSON block. */
+function ffmpegLogArgs(opts: FfmpegBuildOpts): string[] {
+  if (opts.loudnormFilter) return ['-loglevel', 'info', '-nostats'];
+  return ['-loglevel', 'error'];
+}
+
 /** Build the ffmpeg arg list for the MP3 (libmp3lame) path. The v1
  *  invocation — preserved byte-identical so existing chapters re-encode
  *  identically — was extracted out of `encodePcmToAudio` when format
  *  dispatch landed. */
 function buildMp3FfmpegArgs(opts: FfmpegBuildOpts): string[] {
   return [
-    '-loglevel',
-    'error',
+    ...ffmpegLogArgs(opts),
     '-f',
     's16le',
     '-ar',
@@ -163,8 +176,7 @@ function buildMp3FfmpegArgs(opts: FfmpegBuildOpts): string[] {
 function buildAacFfmpegArgs(opts: FfmpegBuildOpts): string[] {
   const useFdk = hasLibFdkAac();
   return [
-    '-loglevel',
-    'error',
+    ...ffmpegLogArgs(opts),
     '-f',
     's16le',
     '-ar',
@@ -201,8 +213,7 @@ function buildAacFfmpegArgs(opts: FfmpegBuildOpts): string[] {
  *  the same codec with broader compatibility. */
 function buildOpusFfmpegArgs(opts: FfmpegBuildOpts): string[] {
   return [
-    '-loglevel',
-    'error',
+    ...ffmpegLogArgs(opts),
     '-f',
     's16le',
     '-ar',
@@ -243,15 +254,31 @@ export async function encodePcmToAudio(
      `twoPass: true`, run an analysis pass first then feed the measurements
      into the encode filter; when `twoPass: false`, append a single-pass
      loudnorm filter inline. The composed filter string is threaded into
-     all three codec builders via `FfmpegBuildOpts.loudnormFilter`. */
+     all three codec builders via `FfmpegBuildOpts.loudnormFilter`.
+
+     Two-pass post-encode flow (2026-05-22 fix): the second-pass filter
+     uses `print_format=json` and emits the post-normalisation `output_i`
+     in stderr after the encode. We parse that block below and persist
+     the OUTPUT loudness (what the chapter actually sounds like) into the
+     sidecar rather than the pre-filter input measurement. Falls back to
+     the input measurement if the stderr JSON is missing or malformed —
+     the MP3 is already on disk by then, so a sidecar parse failure must
+     not fail the encode. */
   let loudnormFilter: string | null = null;
-  let measuredStats: LoudnormSidecarJson | null = null;
+  /* Pre-encode sidecar payload. For two-pass: provisional, gets overridden
+     by the parsed output_* stats after the encode succeeds. For single-pass:
+     final (nominal target, no post-encode re-measure). */
+  let pendingSidecar: LoudnormSidecarJson | null = null;
+  let twoPassFirstStats: LoudnormFirstPassStats | null = null;
   if (opts.loudnorm) {
     if (opts.loudnorm.twoPass) {
       const stats = await runLoudnormFirstPass(pcm, sampleRate, opts.loudnorm);
       if (isMeasurementUseable(stats)) {
         loudnormFilter = buildSecondPassFilterString(stats, opts.loudnorm);
-        measuredStats = {
+        twoPassFirstStats = stats;
+        /* Provisional — overridden below with output_* values from the
+           second-pass stderr JSON if parsing succeeds. */
+        pendingSidecar = {
           i: stats.input_i,
           lra: stats.input_lra,
           tp: stats.input_tp,
@@ -271,7 +298,7 @@ export async function encodePcmToAudio(
          Report the target as the (assumed-achieved) measurement so the
          sidecar JSON shape is consistent across modes; record `twoPass:
          false` so consumers know the i/lra/tp are nominal not measured. */
-      measuredStats = {
+      pendingSidecar = {
         i: opts.loudnorm.target,
         lra: opts.loudnorm.lra,
         tp: opts.loudnorm.tp,
@@ -301,54 +328,101 @@ export async function encodePcmToAudio(
     }
   }
 
-  const encoded = await new Promise<Buffer>((resolve, reject) => {
-    const child = spawn('ffmpeg', args, { stdio: ['pipe', 'pipe', 'pipe'] });
+  const encodeResult = await new Promise<{ encoded: Buffer; stderr: string }>(
+    (resolve, reject) => {
+      const child = spawn('ffmpeg', args, { stdio: ['pipe', 'pipe', 'pipe'] });
 
-    const stdoutChunks: Buffer[] = [];
-    const stderrChunks: Buffer[] = [];
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
 
-    child.stdout.on('data', (chunk) => stdoutChunks.push(chunk));
-    child.stderr.on('data', (chunk) => stderrChunks.push(chunk));
+      child.stdout.on('data', (chunk) => stdoutChunks.push(chunk));
+      child.stderr.on('data', (chunk) => stderrChunks.push(chunk));
 
-    child.on('error', (err) => {
-      /* spawn failure: ffmpeg not on PATH. Surface a friendly hint — the
-         preflight in start-app.ps1 should normally prevent this. */
-      reject(
-        new Error(
-          `Failed to spawn ffmpeg: ${err.message}. ` +
-            `Install ffmpeg and ensure it is on PATH (winget install Gyan.FFmpeg).`,
-        ),
-      );
-    });
+      child.on('error', (err) => {
+        /* spawn failure: ffmpeg not on PATH. Surface a friendly hint — the
+           preflight in start-app.ps1 should normally prevent this. */
+        reject(
+          new Error(
+            `Failed to spawn ffmpeg: ${err.message}. ` +
+              `Install ffmpeg and ensure it is on PATH (winget install Gyan.FFmpeg).`,
+          ),
+        );
+      });
 
-    child.on('close', (code) => {
-      if (code === 0) {
-        resolve(Buffer.concat(stdoutChunks));
-      } else {
-        const stderr = Buffer.concat(stderrChunks).toString('utf8').trim();
-        reject(new Error(`ffmpeg exited with code ${code}: ${stderr || '(no stderr)'}`));
+      child.on('close', (code) => {
+        const stderr = Buffer.concat(stderrChunks).toString('utf8');
+        if (code === 0) {
+          resolve({ encoded: Buffer.concat(stdoutChunks), stderr });
+        } else {
+          reject(new Error(`ffmpeg exited with code ${code}: ${stderr.trim() || '(no stderr)'}`));
+        }
+      });
+
+      child.stdin.on('error', (err) => {
+        /* EPIPE if ffmpeg dies before we finish writing the PCM. The 'close'
+           handler will report the real reason via stderr; swallow here so the
+           promise doesn't reject twice. */
+        if ((err as NodeJS.ErrnoException).code !== 'EPIPE') reject(err);
+      });
+
+      child.stdin.end(pcm);
+    },
+  );
+
+  /* Two-pass post-encode upgrade: parse the second-pass loudnorm JSON from
+     stderr and replace the provisional sidecar's input_i value with the
+     actual post-normalisation output_i. On any parse failure we log a
+     warning and keep the provisional input-based sidecar — the chapter
+     plays fine; the UI pill is just less accurate until the next regen. */
+  if (pendingSidecar && twoPassFirstStats && opts.loudnorm?.twoPass) {
+    const jsonBlock = extractTrailingJsonBlock(encodeResult.stderr);
+    if (jsonBlock) {
+      try {
+        const secondPass = parseLoudnormSecondPassJson(jsonBlock);
+        if (isSecondPassMeasurementUseable(secondPass)) {
+          pendingSidecar = {
+            i: secondPass.output_i,
+            lra: secondPass.output_lra,
+            tp: secondPass.output_tp,
+            target: opts.loudnorm.target,
+            twoPass: true,
+            measuredAt: pendingSidecar.measuredAt,
+          };
+        } else {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[loudnorm] second-pass output stats are not finite (output_i=${secondPass.output_i}); ` +
+              `persisting input-side measurement (${twoPassFirstStats.input_i.toFixed(2)} LUFS) ` +
+              `as sidecar value.`,
+          );
+        }
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[loudnorm] failed to parse second-pass stderr JSON (${(e as Error).message}); ` +
+            `persisting input-side measurement (${twoPassFirstStats.input_i.toFixed(2)} LUFS) ` +
+            `as sidecar value.`,
+        );
       }
-    });
-
-    child.stdin.on('error', (err) => {
-      /* EPIPE if ffmpeg dies before we finish writing the PCM. The 'close'
-         handler will report the real reason via stderr; swallow here so the
-         promise doesn't reject twice. */
-      if ((err as NodeJS.ErrnoException).code !== 'EPIPE') reject(err);
-    });
-
-    child.stdin.end(pcm);
-  });
+    } else {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[loudnorm] second-pass stderr did not include a JSON block; ` +
+          `persisting input-side measurement (${twoPassFirstStats.input_i.toFixed(2)} LUFS) ` +
+          `as sidecar value.`,
+      );
+    }
+  }
 
   /* Loudness-stats callback fires AFTER the encode succeeds — that way a
      failed encode doesn't leave a `.lufs.json` sidecar describing audio
      that never landed on disk. Awaited so caller-supplied write errors
      surface as rejections from this function rather than unhandled. */
-  if (measuredStats && opts.onLoudnessMeasured) {
-    await opts.onLoudnessMeasured(measuredStats);
+  if (pendingSidecar && opts.onLoudnessMeasured) {
+    await opts.onLoudnessMeasured(pendingSidecar);
   }
 
-  return encoded;
+  return encodeResult.encoded;
 }
 
 /** Map an `EncodePcmAudioFormat` to the on-disk file extension generation


### PR DESCRIPTION
## Summary

- **Bug:** Regenerating a chapter shifted its per-chapter LUFS pill (e.g. CH 03 → -21.9 LUFS, siblings spanning -21.5 to -22.1 LUFS) even though every chapter was correctly normalised to -16 LUFS on disk. The Loudness Report card flagged every chapter as ~6 LU off-target.
- **Root cause:** `encodePcmToAudio` (two-pass branch) wrote `stats.input_i` — the pre-filter measurement of the raw PCM — into the `<slug>.lufs.json` sidecar instead of the post-normalisation `output_i`. Per-regen drift was just variance in the per-render synth PCM (different per-sentence gain, silence-gap distribution, VAD trims); the MP3 on disk was correct each time. Acknowledged in plan 71's own field doc (`docs/features/71-...md:75`) and Out-of-scope ("Wave 2 must add a post-encode ebur128 pass") — never picked up.
- **Fix:** Switch the second-pass filter to `print_format=json`, parse the encoder's stderr after a successful encode, and persist `output_i` / `output_lra` / `output_tp` into the sidecar. Zero extra ffmpeg invocations — the encode already runs `loudnorm` end-to-end, we just consume the existing summary output. Falls back to the input-side measurement with a `console.warn` if the stderr JSON is missing or malformed.
- **Required adjustment:** `loudnorm`'s summary is logged at info level. The encode builders previously passed `-loglevel error`; with the fix in place they pass `-loglevel info -nostats` whenever `loudnormFilter` is set. `-nostats` suppresses per-frame progress noise.

## What's in this PR

### Code

- `server/src/tts/loudnorm.ts` — `buildSecondPassFilterString` now emits `print_format=json`. New `LoudnormSecondPassStats` interface + `parseLoudnormSecondPassJson` + `isSecondPassMeasurementUseable` exports. `extractTrailingJsonBlock` now exported so `mp3.ts` reuses the same primitive. `LoudnormSidecarJson` doc updated to make the post-normalisation semantics explicit.
- `server/src/tts/mp3.ts` — `encodePcmToAudio` two-pass branch now defers the sidecar build until after the encode, parses the second-pass JSON from stderr, and persists output_* values. New `ffmpegLogArgs` helper bumps loglevel to `info` + adds `-nostats` when loudnorm is on. Single-pass branch unchanged (still records nominal target).

### Tests (+13 new, all green)

- `server/src/tts/loudnorm.test.ts` — `parseLoudnormSecondPassJson` (happy path, missing output_i, -inf coercion, missing normalization_type), `isSecondPassMeasurementUseable`, real-ffmpeg integration test asserting the sidecar value is within ±2 LU of target (was 6+ LU off before the fix). Updated `buildSecondPassFilterString` expected-string assertion to use `print_format=json`.
- `server/src/tts/mp3-spawn-args.test.ts` — Three new two-pass sidecar payload tests using a mocked spawn that emits configurable stderr: parseable second-pass JSON → sidecar carries `output_i`; missing JSON block → fallback to input_i + warning; missing output_i in JSON → same fallback path with a different warning.

### Backfill

- `scripts/relufs-existing.mjs` — Node ESM walker over `<workspace>/books/**/audio/*.mp3` that runs ffmpeg's `ebur128` filter on each chapter and atomically rewrites the sibling `.lufs.json`. Flags: `--dry-run`, `--workspace <path>`, `--filter <substring>`. ~3 s per chapter, no re-encode. Run once after this fix lands: `node scripts/relufs-existing.mjs`.
- `scripts/tests/relufs-existing.test.mjs` — node:test coverage for `parseEbur128Summary` (real-shape stderr, -inf coercion, missing summary throws) and `iterChapters` (fixture <Author>/<Series>/<Book> walk yields only MP3s with sibling sidecars; empty workspace short-circuits). Auto-picked up by `npm run test:hooks` (and therefore `test:fast` / `test:all` / `verify`).

### Docs

- `docs/features/71-audio-loudness-normalization.md` — sidecar field doc rewritten (`i` now means post-normalisation), the "Wave 2 must add a post-encode ebur128 pass" out-of-scope bullet revised, automated-coverage section updated, and a 2026-05-22 post-ship correction subsection added under Ship notes describing the bug, fix, regression tests, and backfill invocation.

## Test plan

- [x] `npm run verify` (typecheck + lint + a11y + frontend + server + scripts + sidecar + e2e + build) — green
- [x] All 13 new tests pass; 1314 unit/integration + 87 e2e tests stay green
- [ ] **After merge:** run `node scripts/relufs-existing.mjs --dry-run` first to preview, then `node scripts/relufs-existing.mjs` to rewrite existing sidecars
- [ ] Reload an open book in the browser — per-chapter pills should now read `~-16.0 LUFS` and the Loudness Report card should bucket every chapter as "On target"
- [ ] Regenerate one chapter and confirm the new sidecar `i` is within ±0.5 LU of -16 LUFS (was previously drifting between -21.5 and -22.1)