### PR TITLE
fix(server): extend rolling-roster pipelining test budget for verify.yml ubuntu-latest

### DIFF
--- a/server/src/routes/analysis-pipelining.test.ts
+++ b/server/src/routes/analysis-pipelining.test.ts
@@ -477,11 +477,14 @@ describe('runMainAnalyzerJob — rolling roster snapshot', () => {
       });
 
       /* Wait until Phase 1 chapter 6 (index 5, needs watermark>=10) has
-         dispatched. Warm-cache local runs land in <600 ms; release.yml's
-         windows-latest runner is the slow leg (v1.4.0 attempt deterministically
-         timed out at 30 s twice, even after the ca4f318 shrink). 30 s inner
-         budget + 90 s per-test budget gives the windows-latest runner room
-         without slowing healthy runs. */
+         dispatched. Warm-cache local runs land in <600 ms; CI cold-start
+         runners are the slow leg. 840194b bumped to 30 s inner + 90 s
+         per-test for release.yml's windows-latest. PR #131 then surfaced
+         the same edge on verify.yml's ubuntu-latest (timed out at exactly
+         90 000 ms; local pre-push observed 90 347 ms). The per-test budget
+         bumps to 180 s here — well above worst-case observed CI runtime
+         on either OS; healthy runs short-circuit via the inner waitFor
+         the moment the trace lands, so no slowdown for warm caches. */
       await waitFor(
         () => fixture.trace.some((t) => t.phase === 1 && t.chapterId === 6),
         30_000,
@@ -507,7 +510,7 @@ describe('runMainAnalyzerJob — rolling roster snapshot', () => {
       removeManuscript(manuscriptId);
       await clearAnalysisCache(manuscriptId);
     }
-  }, 90_000);
+  }, 180_000);
 });
 
 /* ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Bumps the per-test budget on the plan-88 rolling-roster test (`server/src/routes/analysis-pipelining.test.ts:510`) from 90 s to 180 s.
- 840194b extended this same budget 30 s → 90 s after release.yml's windows-latest leg hit the wall during the v1.4.0 ship attempt. PR #131's verify.yml run then deterministically timed out at exactly 90 000 ms on ubuntu-latest, and a local pre-push observed 90 347 ms — the test is grazing the budget on both runners now, not just Windows.
- Inner `waitFor` budget (30 s) untouched — that's the actual race the assertion is gating, and healthy runs short-circuit the moment Phase 1 chapter 6 dispatches (< 600 ms warm-cache local). The 180 s envelope only materialises on cold-start CI runners.
- No invariant change. The assertion shape (`roster ⊇ ch1..ch11 + narrator`, `not.toContain ch12-char`) and the held-chapter-12 setup are identical. Pure timing-budget bump.

## Test plan

- [x] Local `npm run verify:fast` green (pre-commit) — `test:server` ran 1316 / 1316 in 187.5 s with the new budget; rolling-roster passes comfortably under 90 s on a warm cache, well under 180 s on a cold run.
- [x] Local `npm run verify` green (pre-push) — typecheck + frontend + server + e2e + build all pass against the bumped budget.
- [ ] verify.yml ubuntu-latest CI run completes within the new budget without timeout (the deliberate signal — this PR's own verify run is the test of the fix).
- [ ] No regression: the assertion teeth on `not.toContain ch12-char` remain — chapter 12 stays held until after the snapshot assertion lands, then is released for the final `runPromise` await.

## Follow-up context

This is a follow-up to the docs round PR #129 + #131 that filed and forward-pointed the in-app upgrade pathway BACKLOG entry. The CI flake surfaced AFTER those merged — pre-existing edge that PR #131's verify.yml run happened to tip over. Filing as `fix(server)` keeps the docs scope clean (per CLAUDE.md: do not bundle pre-existing test breakage into unrelated diffs).