### PR TITLE
fix(frontend): show clean book title in Voice Drift Detector

### DIFF
--- a/docs/features/91-cast-drift-consolidation.md
+++ b/docs/features/91-cast-drift-consolidation.md
@@ -39,6 +39,7 @@ owner: null
 - `DriftGroupCard` is wrapped in `React.memo` (`src/modals/drift-report.tsx`); its props must remain referentially stable across unrelated re-renders. The memoised `driftGroupsByBookView` in `layout.tsx` is what enforces this.
 - Single-chapter groups skip the expand toggle and render the action row inline. Multi-chapter groups always render the toggle + bulk actions. The behavioural distinction is `group.events.length === 1`.
 - The detailed `ProfileCompareCard` content stays visible by default at the top of every card — never hide it behind expand. The user explicitly called this out as the surface that makes drift detection meaningful.
+- **Book-title resolution** for the per-section "BOOK" header (`src/components/layout.tsx`'s `driftGroupsByBookView` memo): fall through `bookMeta.saved[bookId]?.title` → `library.books.find(b => b.bookId === bookId)?.title` → raw `bookId`. The middle step is what keeps cross-book drift cards (book never opened this session, so `bookMeta.saved` is empty) from leaking the workspace slug into the header. Don't collapse the chain — the saved-meta step has to win when present (it carries user-edited title overrides), and the raw-bookId tail catches any book whose library entry has been pruned. Pinned by `Layout — drift modal book-title fallback (plan 91)` in `src/components/layout.test.tsx`.
 
 ## Test plan
 

--- a/src/components/layout.test.tsx
+++ b/src/components/layout.test.tsx
@@ -56,6 +56,9 @@ vi.mock('../lib/api', () => ({
     /* The 30 s pollRevisions interval. Resolve to empty so it doesn't
        overwrite the slice between hydrate and the test's assertions. */
     pollRevisions: (...args: unknown[]) => pollRevisionsMock(...args),
+    /* Background bulk-poll fan-out across all known books — stub to
+       empty so the per-render fetch doesn't crash the test harness. */
+    pollRevisionsBulk: vi.fn(async () => ({ byBookId: {} })),
     /* useTtsLifecycle polls /health on mount; resolve to unreachable so
        no pending pill state lands. */
     getSidecarHealth: vi.fn(async () => ({ status: 'unreachable', url: '(test)' })),
@@ -77,6 +80,9 @@ vi.mock('../lib/api', () => ({
 
 import { Layout } from './layout';
 import { uiActions } from '../store/ui-slice';
+import { revisionsActions } from '../store/revisions-slice';
+import { bookMetaActions } from '../store/book-meta-slice';
+import type { DriftEvent, LibraryBook, LibraryResponse } from '../lib/types';
 
 function makeStore() {
   return configureStore({
@@ -322,5 +328,119 @@ describe('Layout — per-book hydration: revisions branch (plan 27)', () => {
       expect(s.revisions.pending).toEqual([]);
       expect(s.revisions.drift).toEqual([]);
     });
+  });
+});
+
+/* Pairs with docs/features/91-cast-drift-consolidation.md — the multi-book
+   drift modal's BOOK header must resolve titles through a saved → library
+   → bookId chain so cross-book groups (book never opened this session, so
+   bookMeta.saved is empty) don't fall back to the raw workspace slug. */
+describe('Layout — drift modal book-title fallback (plan 91)', () => {
+  function makeLibraryBook(over: Partial<LibraryBook> & Pick<LibraryBook, 'bookId' | 'title'>): LibraryBook {
+    return {
+      author: 'Shannon Messenger',
+      series: 'Keeper of the Lost Cities',
+      seriesPosition: 1,
+      isStandalone: false,
+      status: 'complete',
+      chapterCount: 1,
+      completedChapters: 1,
+      characterCount: 1,
+      voiceCount: 1,
+      lastWorkedOn: 'today',
+      coverGradient: ['#000', '#fff'],
+      tags: [],
+      ...over,
+    } as LibraryBook;
+  }
+
+  function makeDriftEvent(over: Partial<DriftEvent> & Pick<DriftEvent, 'id' | 'bookId'>): DriftEvent {
+    return {
+      characterId: 'eliza',
+      chapterId: 1,
+      chapterTitle: 'Chapter 1',
+      severity: 'severe',
+      factor: 'voice',
+      factorLabel: 'Voice',
+      description: 'Voice changed.',
+      autoQueueable: true,
+      detected: '2026-01-01T00:00:00Z',
+      suggestedAction: 'regenerate_chapter',
+      snapshot: { voiceId: 'old', tone: { warmth: 40, pace: 50 }, attributes: [] },
+      current: { voiceId: 'new', tone: { warmth: 40, pace: 50 }, attributes: [] },
+      ...over,
+    } as DriftEvent;
+  }
+
+  it('falls through bookMeta.saved → library.books → bookId for the BOOK header', async () => {
+    const store = makeStore();
+
+    /* Two-book seed: book-A has BOTH bookMeta.saved AND library.books;
+       book-B has ONLY library.books. The new fallback is what surfaces
+       the clean "Exile" title for book-B; before the fix, book-B's
+       header rendered the raw "book-B-slug" string. */
+    const library: LibraryResponse = {
+      authors: [
+        {
+          name: 'Shannon Messenger',
+          series: [
+            {
+              name: 'Keeper of the Lost Cities',
+              books: [
+                makeLibraryBook({ bookId: 'book-A-slug', title: 'Library title — Keeper' }),
+                makeLibraryBook({ bookId: 'book-B-slug', title: 'Exile' }),
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    store.dispatch(librarySlice.actions.hydrate(library));
+
+    /* book-A has a saved-meta entry with a distinct title so we can
+       assert saved beats library (the priority chain's first step). */
+    store.dispatch(
+      bookMetaActions.hydrateFromBookState({
+        bookId: 'book-A-slug',
+        state: { title: 'Saved title — Keeper', author: 'Shannon Messenger', series: 'KotLC' },
+      }),
+    );
+
+    /* One drift event per book, each carrying its own bookId so the
+       selector buckets them into two book entries. bookCount > 1 is
+       what makes drift-report.tsx render the BOOK header at all. */
+    store.dispatch(
+      revisionsActions.hydrateFromBookState({
+        drift: [
+          makeDriftEvent({ id: 'drift:book-A-slug:1:eliza:voice', bookId: 'book-A-slug' }),
+          makeDriftEvent({ id: 'drift:book-B-slug:1:eliza:voice', bookId: 'book-B-slug' }),
+        ],
+      }),
+    );
+
+    store.dispatch(uiActions.setShowDriftReport(true));
+
+    const { findByText, queryByText } = render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/']}>
+          <Routes>
+            <Route path="/" element={<Layout />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+
+    /* book-A: saved meta wins over library entry. */
+    expect(await findByText('Saved title — Keeper')).toBeTruthy();
+    /* book-B: library title surfaces (the fix). Without it the header
+       would render the raw "book-B-slug". */
+    expect(await findByText('Exile')).toBeTruthy();
+    /* Neither raw bookId leaks into the modal as a title. */
+    expect(queryByText('book-A-slug')).toBeNull();
+    expect(queryByText('book-B-slug')).toBeNull();
+    /* The library entry's "Library title — Keeper" must NOT win for
+       book-A; the saved-meta short-circuit guards against a regression
+       that flipped the priority order. */
+    expect(queryByText('Library title — Keeper')).toBeNull();
   });
 });

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -132,11 +132,18 @@ export function Layout() {
     () =>
       driftGroupsByBook.map((g) => ({
         bookId: g.bookId,
-        bookTitle: bookMetaSaved[g.bookId]?.title || g.bookId,
+        /* bookMeta.saved is sparse (only books the user has actively
+           opened/edited this session); library.books always carries a
+           clean workspace-scan title. Fall through saved → library →
+           raw bookId so cross-book drift cards don't show the slug. */
+        bookTitle:
+          bookMetaSaved[g.bookId]?.title ||
+          library.books.find((b) => b.bookId === g.bookId)?.title ||
+          g.bookId,
         characters: g.bookId === bookId ? characters : [],
         groups: g.groups,
       })),
-    [driftGroupsByBook, bookMetaSaved, characters, bookId],
+    [driftGroupsByBook, bookMetaSaved, library.books, characters, bookId],
   );
   const profileVoice = profileCharacter
     ? (voices.find((v) => v.id === profileCharacter.voiceId) ?? null)


### PR DESCRIPTION
## Summary

The Voice Drift Detector modal's per-book BOOK header was rendering the raw workspace slug (e.g. `shannon-messenger__keeper-of-the-lost-cities__keeper-of-the-lost-ci…`) instead of the clean title (e.g. "Keeper of the Lost Cities") whenever the book wasn't present in this session's `bookMeta.saved` map — which is the common cross-book case, since `bookMeta.saved` is only populated for books the user has actively opened/edited. The library slice (`library.books`) always carries a clean workspace-scan `title` for every book the server knows about, so `src/components/layout.tsx`'s `driftGroupsByBookView` memo now falls through `bookMeta.saved[bookId]?.title → library.books.find(b => b.bookId === bookId)?.title → bookId`. Saved-meta still wins when present (carries user-edited title overrides); the bookId tail remains as a last-ditch fallback for books whose library entry has been pruned. Plan 91 (`docs/features/91-cast-drift-consolidation.md`) gains a new "Book-title resolution" invariant under "Invariants to preserve" pinning the priority chain so future refactors don't collapse it.

## Changes

- **Frontend (visible)**: cross-book entries in the Voice Drift Detector modal now display the clean book title in their BOOK header. No layout / interaction changes — only the title string resolved differently. Single-book sessions are unaffected (the header only renders when `bookCount > 1`).
- **Frontend (code)**: `src/components/layout.tsx` `driftGroupsByBookView` memo extended with the library fallback and `library.books` added to the memo deps. ~11 lines of diff.
- **Tests**: new `Layout — drift modal book-title fallback (plan 91)` case in `src/components/layout.test.tsx` — seeds two drift books (one with both saved-meta + library entry; one with library only), opens the modal, asserts saved-meta wins for the first book and library-title surfaces for the second, and neither raw bookId leaks into the modal as a title.
- **Docs**: plan 91 acceptance section gains a one-paragraph invariant for the saved → library → bookId priority chain.

## Test plan

- [x] `npm run verify` (pre-push hook) — green (1 flaky `visual.spec.ts confirm-dark` self-recovered on retry; unrelated to this change — the drift modal does not render on the confirm view)
- [x] New Vitest case in `layout.test.tsx` asserts the title-resolution chain in both directions
- [ ] Manual walkthrough: open a session with drift events spanning multiple books where at least one book hasn't been opened in this session. Confirm every BOOK header in the modal shows the clean library title, not the slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)