### PR TITLE
feat(frontend,server): editable cast aliases with reattribute-lines modal

### DIFF
--- a/docs/features/95-alias-edit.md
+++ b/docs/features/95-alias-edit.md
@@ -1,0 +1,80 @@
+---
+status: active
+shipped: null
+owner: null
+---
+
+# 95 — Editable "Also known as" aliases
+
+> Status: active
+> Key files: `src/modals/profile-drawer.tsx`, `src/modals/reattribute-lines.tsx`, `src/store/cast-slice.ts`, `src/lib/api.ts`, `server/src/routes/cast-aliases.ts`
+> URL surface: indirect — opens from the Profile Drawer (`src/components/layout.tsx`, mounted at every cast/listen/manuscript route).
+> OpenAPI ops: `POST /api/books/{bookId}/cast/unlink-alias`, `POST /api/books/{bookId}/cast/add-alias` (contract-internal — same convention as `cast/merge`, not part of `openapi.yaml`).
+
+## Benefit / Rationale
+
+- **User:** when the auto-fold step (`server/src/analyzer/fold-minor-cast.ts:246-263`) or a manual merge over-grouped a real distinct cast member as an alias chip (e.g. `Sandor` sitting on `Neverseen Figure`), the user could not recover. The chips were append-only. Now every chip carries a dismiss X that splits the alias back into its own standalone cast member, and a sibling `+ Add alias` button stitches in a name the analyzer missed.
+- **Technical:** the merge endpoint at `server/src/routes/cast-merge.ts:141-151` rewrites `sentence.characterId` in place with no lineage column on the Sentence schema (`src/lib/api-types.ts:2121-2128`). Original speaker-name lineage is permanently lost at merge time. We compensate by reading `chapterCast` (the Phase-0a per-chapter raw roster, deliberately preserved across merges — `cast-merge.ts:14` "We deliberately do NOT touch chapterCast") to identify the chapters in which the alias originally appeared, then surfacing those chapters' candidate sentences in a Reattribute Lines modal so the user can move the right lines via the existing per-sentence picker (`manuscriptActions.setSentenceCharacter`).
+- **Architectural:** opens a new pair of contract-internal routes (`cast/unlink-alias`, `cast/add-alias`) sibling to `cast/merge`. Both responses are delta-shaped (`newCharacter` + `impactedChapters` for unlink; `{ characterId, alias, alreadyPresent }` for add) — frontend dispatches `applyUnlinkAlias` / `applyAddAlias` reducers that mutate just the affected rows, rather than the full-cast replacement `applyMerge` does. No openapi.yaml entries (matches the existing `cast/merge`, `cast/link-prior`, `cast/add-from-roster` convention — these endpoints are contract-internal and don't ship in the typed client).
+
+## Architectural impact
+
+- **New seams / extension points.**
+  - Server route file `server/src/routes/cast-aliases.ts` mounted at `/api/books` in `server/src/index.ts:142`. Two POST handlers, no GET.
+  - Two delta reducers on `cast-slice.ts`: `applyUnlinkAlias` and `applyAddAlias`. Idempotent on retry; preserve local voice state on survivors via the same pattern `applyMerge` uses (`src/store/cast-slice.ts:100-118`).
+  - New layout state slot `reattributeModal` in `src/components/layout.tsx` carrying `{ sourceCharacterId, sourceCharacterName, newCharacterId, aliasName, impactedChapters }`. Cleared on modal close.
+  - Two new ProfileDrawer props `onUnlinkAlias` / `onAddAlias` (both optional — surfaces that don't wire them render the chip row read-only as before).
+
+- **Invariants preserved.**
+  - **Plan 24 (OpenAPI source of truth).** Cast-management endpoints (`merge`, `link-prior`, `add-from-roster`, and now `unlink-alias` / `add-alias`) are contract-internal: their typed interfaces live in `src/lib/api.ts` alongside the mock + real implementations. No openapi.yaml entries.
+  - **Plan 23 (mock toggle).** Both endpoints get `real` + `mock` halves in `src/lib/api.ts`; mocks are stateless (the redux slice is authoritative in mock mode) so the cast view stays in sync without a shared mock-cast singleton.
+  - **Plan 26 (RTK immer drafts).** Both new reducers mutate via Immer drafts — no spreads.
+  - **Plan 00 (stage machine).** No `ui.stage` changes; the modal mounts at the layout level keyed off a regular `useState` slot (mirrors `RegenerateModal` and friends).
+
+- **Migration story.** None. The Character schema already carries `aliases?: string[]` (`src/lib/api-types.ts:2039`); both new endpoints read + write that field via the existing `castJsonPath(bookDir)` reader. No state.json shape change.
+
+- **Reversibility.** Roll back the route registration in `server/src/index.ts:142` and the two ProfileDrawer prop wires in `layout.tsx`. Existing aliases remain on disk; UI just goes back to read-only.
+
+## Invariants to preserve
+
+1. **Server route preserves `chapterCast`** — `cast-aliases.ts` reads but never writes `analysis-cache.chapterCast`. The merge route's deliberate non-mutation of this field (`cast-merge.ts:14`) is what makes the `impactedChapters` derivation possible; future routes must not touch it either.
+2. **Sentence rewrites are user-driven only** — the unlink-alias route does NOT mutate `manuscript-edits.json.sentences[*].characterId`. Reattribution happens client-side via the existing `manuscriptActions.setSentenceCharacter` action so the rewrite is auditable (segments diff + change-log) and the user can pick individual sentences rather than getting a bulk move that catches false positives.
+3. **Standalone character minting mirrors the analyzer fold's bucket factory** — `cast-aliases.ts::mintCharacterId` slugs the alias name + collision-suffixes; the synthesised character carries `role: 'character'` + `color: 'narrator'` and inherits `gender` + `ageRange` from the source (mirrors `makeBucket` at `server/src/analyzer/fold-minor-cast.ts:135-151`). Future surfaces that synthesise characters on the fly should follow the same shape.
+4. **Reducer dispatches are delta-only** — `applyUnlinkAlias` takes `{ sourceCharacterId, aliasName, newCharacter }` (NOT a full characters list). `applyAddAlias` takes `{ characterId, aliasName }`. Both are idempotent on retry. Future endpoints in this family should follow the delta convention so mock mode doesn't need a shared cast singleton.
+5. **The +Add alias affordance is visible even on aliasless characters** — the "Also known as" header + add button render whenever `onAddAlias` is wired, regardless of `character.aliases?.length`. Drops the previous-conditional reveal so the user can stitch in names without first triggering a merge.
+
+## Test plan
+
+### Automated coverage
+
+- **Vitest unit** (`src/store/cast-slice.test.ts`) — `applyUnlinkAlias` strips the alias case-insensitively + trim-tolerantly, appends the new character with default `voiceState='generated'`, is idempotent on id collisions, preserves a tuned voice on the existing character; `applyAddAlias` appends + dedupes case-insensitively, refuses self-aliases, no-ops on unknown id / empty input.
+- **Vitest unit** (`src/modals/profile-drawer.test.tsx`) — alias chip block renders an Unlink X per chip when `onUnlinkAlias` is wired and omits it otherwise; click fires `onUnlinkAlias` with `(characterId, aliasName)`; the X disables every chip's button while a request is in flight; `+ Add alias` button reveals the inline input, Enter dispatches `onAddAlias`, Escape cancels without dispatching; the section renders even when the character has no aliases (so the Add button is reachable).
+- **Vitest unit** (`src/modals/reattribute-lines.test.tsx`) — renders one card per impacted chapter with candidate sentences, omits out-of-scope sentences; quick-set chip dispatches `manuscriptActions.setSentenceCharacter` and updates `aria-pressed`; source-chip reverts; Done fires `onClose`; empty-state copy renders both when `impactedChapters` is empty and when chapters carry only stale sentence IDs the manuscript slice can't hydrate.
+- **Vitest server** (`server/src/routes/cast-aliases.test.ts`) — `unlink-alias` strips chip, creates standalone character, derives `impactedChapters` from seeded `chapterCast` (chapters where the alias name was in the Phase-0a roster), returns candidate sentence IDs from the right chapters only, does NOT mutate `manuscript-edits.json`, mints collision-suffixed ids on slug clash, 400/404 on the obvious bad-input cases. `add-alias` appends + dedupes + flips `alreadyPresent`, refuses self-aliases (400), 404 on unknown character.
+- **Playwright e2e** (`e2e/cast-alias-edit.spec.ts`) — open Profile Drawer for Captain Halloran on confirm-cast, `+ Add alias` round-trip, click chip X, Reattribute Lines modal opens, Done closes, chip is gone, Add button is reachable again.
+
+### Manual acceptance walkthrough
+
+Run in mock mode (`VITE_USE_MOCKS=true` via `npm run dev`) unless noted:
+
+1. **Cold boot at `#/`**. Click a book → analysing → Start analysis → confirm-cast. Expect: Captain Halloran's card visible.
+2. **Click Halloran's card.** Profile Drawer opens. Scroll to **CAST ROSTER → Also known as**. Expect: section header visible; no alias chips (fixture has none); `+ Add alias` button visible.
+3. **Click `+ Add alias`.** Inline input appears, autofocused. Type `Cap`, press Enter. Expect: input clears, a `Cap` chip appears with an X button on its right edge.
+4. **Click the X on the `Cap` chip.** Expect: chip disappears, **Reattribute lines for Cap** modal opens. Mock mode returns no impacted chapters, so the empty-state copy renders ("Nothing to reattribute here.") with a Done button.
+5. **Click Done.** Modal closes. Drawer remains open. `+ Add alias` is visible again (chip row is empty).
+6. **Repeat in real mode** against a book that actually has aliases on a character (e.g. via the merge flow): the Reattribute Lines modal should list one card per chapter where the alias originally appeared in the Phase-0a roster, with candidate sentences attributed to the source character. Click the alias chip on a sentence row → the source chip's `aria-pressed` goes false, the alias chip's goes true, and the manuscript view (visit `#/books/<id>/manuscript`) shows the speaker label updated.
+
+### Acceptance against the bug that motivated this plan
+
+Originally reported (2026-05-22, screenshot for `Neverseen Figure`): `Sandor`, a real distinct cast member, was wrongly folded into `Neverseen Figure`'s aliases by the auto-fold step. Expected behaviour: open Neverseen's profile → click X on the Sandor chip → modal lists the chapters where Sandor was originally detected → user reassigns Sandor's lines to the freshly-minted standalone Sandor character → manuscript view reflects the change.
+
+## Out of scope
+
+- **Deterministic sentence revert.** A merge journal (a sidecar JSON logging `{sourceId, sourceName, targetId, affectedSentenceIds}` at merge time) would let future un-links rewrite the exact sentences instead of relying on `chapterCast` as a lineage proxy. Worth a BACKLOG entry but not in this PR.
+- **Bulk alias management.** No "Aliases Manager" modal across multiple characters at once — single-character chip edits cover the reported use case.
+- **Re-running Phase 1 analysis on un-link.** Explicitly rejected (quota cost + destroys manual cast tweaks). The Reattribute Lines modal is the explicit user-driven alternative.
+- **Cross-book alias migration.** Adding `Sandor` as an alias on this book does not retroactively update the matcher's behaviour against prior books. Future analyzer runs of *subsequent* books in the series will pick up the alias; for prior books the user would re-link via the existing `cast/link-prior` route.
+
+## Ship notes
+
+_(filled in on flip to stable)_

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -59,6 +59,7 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 - [09 — Voice match pipeline](09-voice-match-pipeline.md) — Post-analysis library matching.
 - [10 — Profile drawer](10-profile-drawer.md) — Character edit drawer + sample preview + evidence toggle.
 - [11 — Batch character regenerate](11-batch-character-regenerate.md) — Multi-select character → chapter-range regen.
+- [95 — Editable cast aliases](95-alias-edit.md) — Per-chip X on the Profile Drawer's "Also known as" row splits a misplaced alias back into its own standalone cast member; sibling `+ Add alias` button appends a typed name. Reattribute Lines modal (new) is opened by the X-click and lists candidate sentences in the chapters where the alias originally appeared (derived from the preserved Phase-0a `chapterCast`), reusing `manuscriptActions.setSentenceCharacter` for per-sentence picks. Two new contract-internal POST routes (`cast/unlink-alias`, `cast/add-alias`).
 
 ### E. Manuscript editing
 

--- a/e2e/cast-alias-edit.spec.ts
+++ b/e2e/cast-alias-edit.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+import { goToConfirm, waitForRouteReady } from './helpers';
+
+/**
+ * Plan 95 — editable cast aliases.
+ *
+ * Drives a fresh book through the analyse pipeline (via the shared
+ * goToConfirm helper) and exercises the Profile Drawer's "Also known
+ * as" affordances: the + Add alias inline input round-trip, then chip
+ * removal via the per-chip X — which opens the Reattribute Lines
+ * modal seeded by the unlink-alias endpoint.
+ *
+ * Why browser-level: the X-on-chip → unlink-alias → modal-open seam
+ * crosses redux, the layout's modal state, and React focus management.
+ * Vitest+jsdom covers the slice + component contracts in isolation
+ * (src/store/cast-slice.test.ts, src/modals/profile-drawer.test.tsx,
+ * src/modals/reattribute-lines.test.tsx); this spec pins the
+ * end-to-end click chain in a real DOM.
+ *
+ * Captain Halloran is the target (the mock cast's most evidence-rich
+ * character) — no aliases on the design fixture, so the spec adds one
+ * via the +Add input and then immediately removes it via the chip X.
+ */
+test.describe('cast view → profile drawer → alias chip editing', () => {
+  test('user can add an alias and then unlink it, which opens the Reattribute modal', async ({
+    page,
+  }) => {
+    await goToConfirm(page);
+    await waitForRouteReady(page);
+
+    /* Open the Halloran drawer — same affordance the cast-drawer spec
+       uses, picked because it's the most reliable character to find on
+       the confirm-cast view. */
+    const card = page.getByRole('button', { name: /Open profile for Captain Halloran/i });
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await card.click();
+
+    /* Drawer mounted. Scroll the alias-row into view (the section sits
+       below the long Voice profile + Identity blocks). */
+    await expect(page.getByText('Also known as')).toBeVisible({ timeout: 10_000 });
+    await page.getByText('Also known as').scrollIntoViewIfNeeded();
+
+    /* + Add alias round-trip: button opens the inline input, typing +
+       Enter dispatches addAlias which the cast-slice reducer dedups
+       case-insensitively and stores on the character. */
+    const addButton = page.getByRole('button', { name: 'Add alias' });
+    await expect(addButton).toBeVisible();
+    await addButton.click();
+    const input = page.getByRole('textbox', { name: 'New alias name' });
+    await input.fill('Cap');
+    await input.press('Enter');
+
+    /* New chip appears with an Unlink X. */
+    const unlinkCap = page.getByRole('button', { name: 'Unlink Cap' });
+    await expect(unlinkCap).toBeVisible({ timeout: 5_000 });
+
+    /* Click the X — the layout's onUnlinkAlias handler fires
+       api.unlinkAlias (mock returns empty impactedChapters) and opens
+       the Reattribute Lines modal. */
+    await unlinkCap.click();
+
+    /* Modal mounted. Title carries the alias name + the source. */
+    const modal = page.getByRole('dialog', { name: /Reattribute lines for Cap/i });
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+
+    /* Mock returns no impactedChapters, so the empty-state copy is
+       what renders. The Done button is reachable either way. */
+    await expect(modal.getByText(/Nothing to reattribute here\./i)).toBeVisible();
+    await modal.getByRole('button', { name: 'Done' }).click();
+    await expect(modal).not.toBeVisible();
+
+    /* Back on the drawer — the Cap chip is gone (it was just split into
+       its own character), the +Add button is reachable again. */
+    await expect(page.getByRole('button', { name: 'Unlink Cap' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Add alias' })).toBeVisible();
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -26,6 +26,7 @@ import { manuscriptsRouter } from './routes/manuscripts.js';
 import { analysisRouter } from './routes/analysis.js';
 import { voiceMatchRouter } from './routes/voice-match.js';
 import { castMergeRouter } from './routes/cast-merge.js';
+import { castAliasesRouter } from './routes/cast-aliases.js';
 import { castLinkPriorRouter } from './routes/cast-link-prior.js';
 import { castAddFromRosterRouter } from './routes/cast-add-from-roster.js';
 import { libraryCastOverrideRouter } from './routes/library-cast-override.js';
@@ -139,6 +140,7 @@ app.use('/api/books', bookStateRouter); // mounts /:bookId/state (GET/PUT)
 app.use('/api/books', coverRouter); // mounts /:bookId/cover{,/candidates} (OpenLibrary covers)
 app.use('/api/books', voiceMatchRouter); // mounts /:bookId/voice-match
 app.use('/api/books', castMergeRouter); // mounts /:bookId/cast/merge
+app.use('/api/books', castAliasesRouter); // mounts /:bookId/cast/{unlink-alias,add-alias} (editable alias chips on the profile drawer)
 app.use('/api/books', castLinkPriorRouter); // mounts /:bookId/cast/link-prior (manual continuity link to a prior series book)
 app.use('/api/books', castAddFromRosterRouter); // mounts /:bookId/cast/add-from-roster (new local character pulled from a prior series-mate)
 app.use('/api/books', seriesRosterRouter); // mounts /:bookId/series-roster (prior-book characters in the same series)

--- a/server/src/routes/cast-aliases.test.ts
+++ b/server/src/routes/cast-aliases.test.ts
@@ -1,0 +1,347 @@
+/* Integration tests for the cast-aliases router.
+
+   Sets up a tempdir workspace with a fake book whose cast has one
+   over-merged alias ("Sandor" sitting on "Neverseen Figure"), plus a
+   matching chapterCast snapshot that originally listed "Sandor" as a
+   separate character in two specific chapters. Drives the unlink-alias
+   route and asserts:
+     - cast.json: alias dropped from source; a new standalone character
+       minted with the right inherited identity fields
+     - response: impactedChapters lists ONLY the chapters where Sandor
+       originally appeared, with candidate sentence IDs pulled from
+       manuscript-edits.json (only sentences currently attributed to the
+       source)
+     - manuscript-edits.json is NOT mutated (sentence rewrites happen
+       client-side via the reattribute modal calling setSentenceCharacter)
+
+   Also exercises add-alias for the happy + dedup paths.
+
+   Mirrors cast-merge.test.ts's lazy-import pattern: defer module imports
+   until WORKSPACE_DIR is set so paths.ts captures the right root. */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import express, { type Express } from 'express';
+import request from 'supertest';
+
+const AUTHOR = 'Test Author';
+const SERIES = 'Standalones';
+const TITLE = 'Cast Aliases Book';
+const MANUSCRIPT_ID = 'm_aliases_test';
+
+let workspaceRoot: string;
+let bookDir: string;
+let app: Express;
+let bookId: string;
+let cachePath: string;
+
+const sourceCharacter = {
+  id: 'neverseen-figure',
+  name: 'Neverseen Figure',
+  role: 'antagonist',
+  color: 'eliza',
+  gender: 'male',
+  ageRange: 'adult',
+  lines: 8,
+  scenes: 3,
+  /* These four aliases all came from an over-aggressive auto-fold step.
+     "Sandor" is the one the test exercises — he's actually a real
+     standalone cast member whose dialogue got folded into Neverseen. */
+  aliases: ['Sior', 'Jurek', 'Sandor', 'Shopkeeper'],
+};
+
+const otherCharacter = {
+  id: 'sophie',
+  name: 'Sophie',
+  role: 'protagonist',
+  color: 'halloran',
+};
+
+/* Manuscript-edits sentences. Chapter 1 has three lines attributed to
+   Neverseen (all candidates for un-link). Chapter 2 has two more (one
+   in a chapter Sandor never appeared in originally, so it should NOT
+   show as a candidate). Chapter 3 has one Sophie line (untouched). */
+const editsSentences = [
+  { id: 1, chapterId: 1, characterId: 'neverseen-figure', text: 'The shopkeeper laughed.' },
+  { id: 2, chapterId: 1, characterId: 'neverseen-figure', text: '"Sandor said that?"' },
+  { id: 3, chapterId: 1, characterId: 'neverseen-figure', text: '"He is one of us."' },
+  { id: 4, chapterId: 2, characterId: 'neverseen-figure', text: 'A new line.' },
+  { id: 5, chapterId: 4, characterId: 'neverseen-figure', text: 'Chapter 4 line.' },
+  { id: 6, chapterId: 3, characterId: 'sophie', text: 'I have to find him.' },
+];
+
+beforeAll(async () => {
+  workspaceRoot = mkdtempSync(join(tmpdir(), 'audiobook-cast-aliases-test-'));
+  process.env.WORKSPACE_DIR = workspaceRoot;
+
+  const [{ castAliasesRouter }, { makeBookId }] = await Promise.all([
+    import('./cast-aliases.js'),
+    import('../workspace/paths.js'),
+  ]);
+  bookId = makeBookId(AUTHOR, SERIES, TITLE);
+
+  bookDir = join(workspaceRoot, 'books', AUTHOR, SERIES, TITLE);
+  mkdirSync(join(bookDir, '.audiobook'), { recursive: true });
+  writeFileSync(
+    join(bookDir, '.audiobook', 'state.json'),
+    JSON.stringify({
+      bookId,
+      manuscriptId: MANUSCRIPT_ID,
+      title: TITLE,
+      author: AUTHOR,
+      series: SERIES,
+      seriesPosition: null,
+      isStandalone: true,
+      manuscriptFile: 'manuscript.txt',
+      castConfirmed: true,
+      chapters: [
+        { id: 1, title: 'One', slug: '01-one' },
+        { id: 2, title: 'Two', slug: '02-two' },
+        { id: 3, title: 'Three', slug: '03-three' },
+        { id: 4, title: 'Four', slug: '04-four' },
+      ],
+      coverGradient: ['#000', '#fff'],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }),
+  );
+  writeFileSync(join(bookDir, 'manuscript.txt'), 'placeholder');
+  writeFileSync(
+    join(bookDir, '.audiobook', 'cast.json'),
+    JSON.stringify({ characters: [sourceCharacter, otherCharacter] }),
+  );
+  writeFileSync(
+    join(bookDir, '.audiobook', 'manuscript-edits.json'),
+    JSON.stringify({ sentences: editsSentences }),
+  );
+
+  /* Phase 0a chapterCast: chapters 1 and 4 originally listed "Sandor" in
+     their roster; chapter 2 did not (so the chapter-2 sentence currently
+     attributed to Neverseen should NOT surface as a candidate). Chapter
+     3 only had Sophie. */
+  const testFileDir = dirname(fileURLToPath(import.meta.url));
+  cachePath = resolve(testFileDir, '..', '..', 'handoff', 'cache', `${MANUSCRIPT_ID}.json`);
+  mkdirSync(dirname(cachePath), { recursive: true });
+  writeFileSync(
+    cachePath,
+    JSON.stringify({
+      chapterCast: {
+        1: [
+          { id: 'sandor', name: 'Sandor', role: 'minor', color: 'halloran' },
+          { id: 'sophie', name: 'Sophie', role: 'protagonist', color: 'halloran' },
+        ],
+        2: [{ id: 'sophie', name: 'Sophie', role: 'protagonist', color: 'halloran' }],
+        3: [{ id: 'sophie', name: 'Sophie', role: 'protagonist', color: 'halloran' }],
+        4: [{ id: 'sandor', name: 'Sandor', role: 'minor', color: 'halloran' }],
+      },
+      chapters: {},
+      updatedAt: new Date().toISOString(),
+    }),
+  );
+
+  app = express();
+  app.use(express.json());
+  app.use('/api/books', castAliasesRouter);
+});
+
+afterAll(() => {
+  if (workspaceRoot) rmSync(workspaceRoot, { recursive: true, force: true });
+  delete process.env.WORKSPACE_DIR;
+  if (cachePath) rmSync(cachePath, { force: true });
+});
+
+function readDisk<T>(rel: string): T {
+  return JSON.parse(readFileSync(join(bookDir, '.audiobook', rel), 'utf8')) as T;
+}
+
+interface UnlinkRes {
+  newCharacter: {
+    id: string;
+    name: string;
+    aliases?: string[];
+    gender?: string;
+    ageRange?: string;
+  };
+  impactedChapters: Array<{ chapterId: number; candidateSentenceIds: number[] }>;
+}
+
+describe('cast-aliases router — unlink-alias', () => {
+  it('strips the alias from the source, mints a standalone character, returns impacted chapters', async () => {
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/unlink-alias`)
+      .set('Content-Type', 'application/json')
+      .send({ sourceCharacterId: 'neverseen-figure', aliasName: 'Sandor' });
+
+    expect(res.status).toBe(200);
+    const body = res.body as UnlinkRes;
+
+    /* New standalone character minted. Id is the slug of the alias; name
+       preserves chip casing; gender + ageRange inherited from the source
+       so the voice picker has something to work with on day one. */
+    expect(body.newCharacter.id).toBe('sandor');
+    expect(body.newCharacter.name).toBe('Sandor');
+    expect(body.newCharacter.gender).toBe('male');
+    expect(body.newCharacter.ageRange).toBe('adult');
+    expect(body.newCharacter.aliases).toEqual([]);
+
+    /* Impacted chapters derived from chapterCast: chapters 1 and 4 (NOT
+       chapter 2 which never had Sandor in its Phase 0a roster). */
+    expect(body.impactedChapters.map((c) => c.chapterId)).toEqual([1, 4]);
+    /* Chapter 1 candidate sentences = all Neverseen-attributed lines in
+       chapter 1 (ids 1, 2, 3). Chapter 4 has one (id 5). */
+    expect(body.impactedChapters[0].candidateSentenceIds).toEqual([1, 2, 3]);
+    expect(body.impactedChapters[1].candidateSentenceIds).toEqual([5]);
+
+    /* cast.json on disk: source's aliases trimmed, new character appended. */
+    const cast = readDisk<{
+      characters: Array<{ id: string; aliases?: string[] }>;
+    }>('cast.json');
+    expect(cast.characters.map((c) => c.id)).toEqual(['neverseen-figure', 'sophie', 'sandor']);
+    const source = cast.characters.find((c) => c.id === 'neverseen-figure')!;
+    expect(source.aliases).toEqual(['Sior', 'Jurek', 'Shopkeeper']);
+
+    /* manuscript-edits.json is NOT mutated — reattribution is the user's
+       explicit per-sentence choice via the modal, not a server-side
+       rewrite. Every sentence still points where it did before. */
+    const edits = readDisk<{ sentences: Array<{ id: number; characterId: string }> }>(
+      'manuscript-edits.json',
+    );
+    expect(edits.sentences.find((s) => s.id === 1)!.characterId).toBe('neverseen-figure');
+    expect(edits.sentences.find((s) => s.id === 5)!.characterId).toBe('neverseen-figure');
+  });
+
+  it('mints a collision-suffixed id when the slug already exists', async () => {
+    /* Seed an existing character whose id is the slug-of-target alias so the
+       mint helper has to suffix. */
+    const cast = readDisk<{ characters: Array<{ id: string; name: string; aliases?: string[] }> }>(
+      'cast.json',
+    );
+    cast.characters.unshift({
+      id: 'shopkeeper',
+      name: 'A different Shopkeeper',
+      aliases: [],
+    });
+    /* Put Shopkeeper back on Neverseen as an alias to unlink. */
+    const nev = cast.characters.find((c) => c.id === 'neverseen-figure')!;
+    nev.aliases = ['Sior', 'Jurek', 'Shopkeeper'];
+    writeFileSync(join(bookDir, '.audiobook', 'cast.json'), JSON.stringify(cast));
+
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/unlink-alias`)
+      .send({ sourceCharacterId: 'neverseen-figure', aliasName: 'Shopkeeper' });
+
+    expect(res.status).toBe(200);
+    const body = res.body as UnlinkRes;
+    /* Existing 'shopkeeper' is left in place; the new mint suffixes to
+       'shopkeeper-2'. */
+    expect(body.newCharacter.id).toBe('shopkeeper-2');
+    const updated = readDisk<{ characters: Array<{ id: string }> }>('cast.json');
+    expect(updated.characters.some((c) => c.id === 'shopkeeper')).toBe(true);
+    expect(updated.characters.some((c) => c.id === 'shopkeeper-2')).toBe(true);
+  });
+
+  it('400s when sourceCharacterId or aliasName is missing', async () => {
+    const r1 = await request(app)
+      .post(`/api/books/${bookId}/cast/unlink-alias`)
+      .send({ aliasName: 'Sandor' });
+    expect(r1.status).toBe(400);
+
+    const r2 = await request(app)
+      .post(`/api/books/${bookId}/cast/unlink-alias`)
+      .send({ sourceCharacterId: 'neverseen-figure' });
+    expect(r2.status).toBe(400);
+  });
+
+  it('404s when the source character is not in the cast', async () => {
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/unlink-alias`)
+      .send({ sourceCharacterId: 'ghost', aliasName: 'Sandor' });
+    expect(res.status).toBe(404);
+  });
+
+  it('404s when the alias is not on the source character', async () => {
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/unlink-alias`)
+      .send({ sourceCharacterId: 'sophie', aliasName: 'Sandor' });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/not on/);
+  });
+
+  it('404s when the book is unknown', async () => {
+    const res = await request(app)
+      .post(`/api/books/no-such-book/cast/unlink-alias`)
+      .send({ sourceCharacterId: 'neverseen-figure', aliasName: 'Sandor' });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('cast-aliases router — add-alias', () => {
+  /* Seed a clean cast for the add-alias tests — re-write rather than
+     depending on prior describe-block state. */
+  beforeAll(() => {
+    writeFileSync(
+      join(bookDir, '.audiobook', 'cast.json'),
+      JSON.stringify({
+        characters: [
+          {
+            id: 'sophie',
+            name: 'Sophie',
+            role: 'protagonist',
+            color: 'halloran',
+            aliases: ['Foster'],
+          },
+        ],
+      }),
+    );
+  });
+
+  it('appends a new alias and dedupes case-insensitively', async () => {
+    const r1 = await request(app)
+      .post(`/api/books/${bookId}/cast/add-alias`)
+      .send({ characterId: 'sophie', aliasName: 'Sofi' });
+    expect(r1.status).toBe(200);
+    expect(r1.body).toMatchObject({ characterId: 'sophie', alias: 'Sofi', alreadyPresent: false });
+    /* cast.json on disk reflects the append. */
+    const c1 = readDisk<{ characters: Array<{ id: string; aliases?: string[] }> }>(
+      'cast.json',
+    ).characters.find((c) => c.id === 'sophie')!;
+    expect(c1.aliases).toEqual(['Foster', 'Sofi']);
+
+    /* Idempotent re-add: lowercased dedup is honoured, response flags
+       alreadyPresent=true, on-disk list still length 2. */
+    const r2 = await request(app)
+      .post(`/api/books/${bookId}/cast/add-alias`)
+      .send({ characterId: 'sophie', aliasName: 'sofi' });
+    expect(r2.status).toBe(200);
+    expect(r2.body).toMatchObject({ alreadyPresent: true });
+    const c2 = readDisk<{ characters: Array<{ id: string; aliases?: string[] }> }>(
+      'cast.json',
+    ).characters.find((c) => c.id === 'sophie')!;
+    expect(c2.aliases).toEqual(['Foster', 'Sofi']);
+  });
+
+  it('400s when the alias matches the character\'s own name', async () => {
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/add-alias`)
+      .send({ characterId: 'sophie', aliasName: 'Sophie' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/own name/);
+  });
+
+  it('400s when either field is missing', async () => {
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/add-alias`)
+      .send({ characterId: 'sophie' });
+    expect(res.status).toBe(400);
+  });
+
+  it('404s when the character is unknown', async () => {
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/add-alias`)
+      .send({ characterId: 'ghost', aliasName: 'Foo' });
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/src/routes/cast-aliases.ts
+++ b/server/src/routes/cast-aliases.ts
@@ -1,0 +1,288 @@
+/* POST /api/books/:bookId/cast/unlink-alias
+   POST /api/books/:bookId/cast/add-alias
+
+   Symmetric chip-management for the Profile Drawer's "Also known as" row.
+   Aliases get into a character via the fold step
+   (server/src/analyzer/fold-minor-cast.ts) and via the manual merge route
+   (cast-merge.ts), both of which append. There has been no reverse
+   operation, which left the user with no recovery path when the auto-fold
+   over-merged a real distinct cast member as an alias (e.g. "Sandor"
+   folded into "Neverseen Figure").
+
+   The merge route rewrites sentence.characterId in place with no lineage
+   column on the Sentence schema, so we cannot deterministically recover
+   which sentences originated from a given alias name. We compensate by
+   reading `chapterCast` (the Phase 0a per-chapter raw roster — kept
+   untouched across merges by intent, see cast-merge.ts:14) to identify
+   the chapters in which the alias originally appeared, then surfacing
+   those chapters' candidate sentences to the frontend so the user can
+   reattribute the right lines via the existing per-sentence picker. */
+
+import { Router, type Request, type Response } from 'express';
+import { findBookByBookId } from '../workspace/scan.js';
+import { castJsonPath, manuscriptEditsJsonPath } from '../workspace/paths.js';
+import { readJson, writeJsonAtomic } from '../workspace/state-io.js';
+import { loadAnalysisCache } from '../store/analysis-cache.js';
+import { slug } from '../workspace/paths.js';
+import type { CharacterOutput, SentenceOutput } from '../handoff/schemas.js';
+
+export const castAliasesRouter = Router();
+
+interface CastFile {
+  characters: CharacterOutput[];
+}
+
+interface EditsFile {
+  sentences?: SentenceOutput[];
+}
+
+interface UnlinkBody {
+  sourceCharacterId?: unknown;
+  aliasName?: unknown;
+}
+
+interface AddBody {
+  characterId?: unknown;
+  aliasName?: unknown;
+}
+
+interface ImpactedChapter {
+  chapterId: number;
+  candidateSentenceIds: number[];
+}
+
+interface UnlinkResponse {
+  /** The freshly-minted standalone character (the alias, now its own
+      cast member). Frontend dispatches a delta reducer that prunes the
+      alias from the source and appends this character — no need to
+      round-trip the full cast for what is structurally a two-row edit. */
+  newCharacter: CharacterOutput;
+  /** Chapters where the alias originally appeared in the Phase-0a roster
+      (preserved-across-merges chapterCast). Each chapter lists the IDs
+      of sentences currently attributed to the source character — the
+      candidates the user reviews + reattributes in the Reattribute Lines
+      modal. */
+  impactedChapters: ImpactedChapter[];
+}
+
+function normaliseAlias(s: unknown): string {
+  return typeof s === 'string' ? s.trim() : '';
+}
+
+/* Make a fresh character id from the alias name, suffixing with -2, -3, …
+   until it doesn't collide with an existing id in the cast. */
+function mintCharacterId(name: string, existing: Set<string>): string {
+  const base = slug(name);
+  if (!existing.has(base)) return base;
+  for (let i = 2; i < 1000; i += 1) {
+    const next = `${base}-${i}`;
+    if (!existing.has(next)) return next;
+  }
+  /* 1000 collisions is absurd — fall back to a randomised suffix so the
+     route never wedges on an unbounded loop. */
+  return `${base}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+castAliasesRouter.post(
+  '/:bookId/cast/unlink-alias',
+  async (req: Request, res: Response<UnlinkResponse | { error: string }>) => {
+    const { bookId } = req.params;
+    const body = (req.body ?? {}) as UnlinkBody;
+    const sourceCharacterId = normaliseAlias(body.sourceCharacterId);
+    const aliasName = normaliseAlias(body.aliasName);
+
+    if (!sourceCharacterId || !aliasName) {
+      return res
+        .status(400)
+        .json({ error: 'sourceCharacterId and aliasName are required.' });
+    }
+
+    const located = await findBookByBookId(bookId);
+    if (!located) return res.status(404).json({ error: 'Book not found.' });
+    const { bookDir, state } = located;
+
+    const cast = await readJson<CastFile>(castJsonPath(bookDir));
+    if (!cast?.characters?.length) {
+      return res.status(409).json({
+        error: 'Book has no cast on disk yet. Run analysis before editing aliases.',
+      });
+    }
+
+    const sourceIdx = cast.characters.findIndex((c) => c.id === sourceCharacterId);
+    if (sourceIdx === -1) {
+      return res.status(404).json({ error: `Character "${sourceCharacterId}" not found.` });
+    }
+    const source = cast.characters[sourceIdx];
+    const aliasKey = aliasName.toLowerCase();
+    const aliasIdx = (source.aliases ?? []).findIndex((a) => a.trim().toLowerCase() === aliasKey);
+    if (aliasIdx === -1) {
+      return res.status(404).json({
+        error: `Alias "${aliasName}" is not on character "${source.name}".`,
+      });
+    }
+
+    /* Preserve the chip's display casing (not the lower-cased key) for the
+       new character's name. */
+    const displayName = (source.aliases ?? [])[aliasIdx];
+
+    /* Strip the alias off the source. Filter rather than splice so we
+       leave the source's array untouched in case other concurrent paths
+       hold a reference. */
+    const nextSourceAliases = (source.aliases ?? []).filter(
+      (a) => a.trim().toLowerCase() !== aliasKey,
+    );
+
+    /* Synthesise the new standalone character. Field selection mirrors
+       `makeBucket` from fold-minor-cast.ts: id, name, role, color,
+       optional gender/ageRange inherited from the source so the voice
+       picker has something to work with on day one. No description, no
+       attributes, no tone — the user will fill those in via the drawer
+       if it matters. No `aliases` (defaults to empty). */
+    const existingIds = new Set(cast.characters.map((c) => c.id));
+    const newCharacterId = mintCharacterId(displayName, existingIds);
+    const newCharacter: CharacterOutput = {
+      id: newCharacterId,
+      name: displayName,
+      role: 'character',
+      color: 'narrator',
+      aliases: [],
+    };
+    if (source.gender) newCharacter.gender = source.gender;
+    if (source.ageRange) newCharacter.ageRange = source.ageRange;
+
+    /* Build the updated character list: source with the trimmed aliases,
+       new character appended at the end (consistent with mergeCharacters'
+       append-on-new convention in cast-slice.ts). */
+    const nextCharacters: CharacterOutput[] = cast.characters.map((c, i) =>
+      i === sourceIdx ? { ...c, aliases: nextSourceAliases } : c,
+    );
+    nextCharacters.push(newCharacter);
+
+    await writeJsonAtomic(castJsonPath(bookDir), { characters: nextCharacters });
+
+    /* Derive impacted chapters from the preserved chapterCast (raw Phase
+       0a roster, untouched by merges). A chapter is impacted when its
+       roster originally contained a character matching the alias name —
+       either as that character's primary name or in its own aliases
+       array. Match is case-insensitive, trim-tolerant. */
+    const cache = await loadAnalysisCache(state.manuscriptId);
+    const impactedChapterIds = new Set<number>();
+    if (cache.chapterCast) {
+      for (const [rawId, roster] of Object.entries(cache.chapterCast)) {
+        const chapterId = Number(rawId);
+        if (!Number.isFinite(chapterId)) continue;
+        for (const c of roster) {
+          if (c.name.trim().toLowerCase() === aliasKey) {
+            impactedChapterIds.add(chapterId);
+            break;
+          }
+          if ((c.aliases ?? []).some((a) => a.trim().toLowerCase() === aliasKey)) {
+            impactedChapterIds.add(chapterId);
+            break;
+          }
+        }
+      }
+    }
+
+    /* Collect candidate sentences = sentences in impacted chapters that
+       currently attribute to the source character. The frontend modal
+       presents these to the user with a per-sentence picker; no rewrites
+       happen server-side here. */
+    const edits = await readJson<EditsFile>(manuscriptEditsJsonPath(bookDir));
+    const byChapter = new Map<number, number[]>();
+    if (edits?.sentences?.length) {
+      for (const s of edits.sentences) {
+        if (s.characterId !== sourceCharacterId) continue;
+        if (!impactedChapterIds.has(s.chapterId)) continue;
+        const list = byChapter.get(s.chapterId);
+        if (list) list.push(s.id);
+        else byChapter.set(s.chapterId, [s.id]);
+      }
+    }
+    const impactedChapters: ImpactedChapter[] = [...impactedChapterIds]
+      .sort((a, b) => a - b)
+      .map((chapterId) => ({
+        chapterId,
+        candidateSentenceIds: (byChapter.get(chapterId) ?? []).sort((a, b) => a - b),
+      }));
+
+    console.log(
+      `[cast-aliases] book=${bookId} unlinked alias "${aliasName}" from ${sourceCharacterId}` +
+        ` → ${newCharacterId} (${impactedChapters.length} impacted chapters)`,
+    );
+
+    return res.json({ newCharacter, impactedChapters });
+  },
+);
+
+interface AddResponse {
+  /** Echo of the alias addition so the frontend can dispatch a delta
+      reducer instead of replacing the whole cast. Mirrors the shape
+      cast-add-from-roster returns. */
+  characterId: string;
+  alias: string;
+  /** True when the alias was already present (idempotent re-add) and the
+      route was a no-op on disk. Lets the frontend distinguish "appended"
+      from "already there" without parsing the cast.json mtime. */
+  alreadyPresent: boolean;
+}
+
+castAliasesRouter.post(
+  '/:bookId/cast/add-alias',
+  async (req: Request, res: Response<AddResponse | { error: string }>) => {
+    const { bookId } = req.params;
+    const body = (req.body ?? {}) as AddBody;
+    const characterId = normaliseAlias(body.characterId);
+    const aliasName = normaliseAlias(body.aliasName);
+
+    if (!characterId || !aliasName) {
+      return res.status(400).json({ error: 'characterId and aliasName are required.' });
+    }
+
+    const located = await findBookByBookId(bookId);
+    if (!located) return res.status(404).json({ error: 'Book not found.' });
+    const { bookDir } = located;
+
+    const cast = await readJson<CastFile>(castJsonPath(bookDir));
+    if (!cast?.characters?.length) {
+      return res.status(409).json({
+        error: 'Book has no cast on disk yet. Run analysis before editing aliases.',
+      });
+    }
+
+    const idx = cast.characters.findIndex((c) => c.id === characterId);
+    if (idx === -1) {
+      return res.status(404).json({ error: `Character "${characterId}" not found.` });
+    }
+
+    const target = cast.characters[idx];
+    /* Drop self-alias (matching the character's own name) and dedup
+       case-insensitively against the existing aliases, mirroring the
+       cast-merge.mergeAliases helper. */
+    const key = aliasName.toLowerCase();
+    if (key === target.name.trim().toLowerCase()) {
+      return res.status(400).json({
+        error: 'Cannot add a character\'s own name as one of its aliases.',
+      });
+    }
+    const existing = target.aliases ?? [];
+    if (existing.some((a) => a.trim().toLowerCase() === key)) {
+      /* Idempotent — no disk write, but echo the addition so the frontend
+         can dispatch the same delta reducer regardless of whether the
+         alias was already on the character. */
+      return res.json({ characterId, alias: aliasName, alreadyPresent: true });
+    }
+
+    const nextCharacters = cast.characters.map((c, i) =>
+      i === idx ? { ...c, aliases: [...existing, aliasName] } : c,
+    );
+
+    await writeJsonAtomic(castJsonPath(bookDir), { characters: nextCharacters });
+
+    console.log(
+      `[cast-aliases] book=${bookId} added alias "${aliasName}" to ${characterId}`,
+    );
+
+    return res.json({ characterId, alias: aliasName, alreadyPresent: false });
+  },
+);

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -41,6 +41,7 @@ import { CharacterRegenerateModal } from '../modals/character-regenerate';
 import { BatchCharacterRegenerateModal } from '../modals/batch-character-regenerate';
 import { DriftReportModal } from '../modals/drift-report';
 import { ProfileDrawer } from '../modals/profile-drawer';
+import { ReattributeLinesModal } from '../modals/reattribute-lines';
 import { ConfirmDialog } from '../modals/confirm-dialog';
 import { ToastStack } from './toast-stack';
 import { RevisionDiffPlayer } from '../views/revision-diff';
@@ -172,6 +173,18 @@ export function Layout() {
     body: ReactNode;
     primaryLabel?: string;
     onPrimary?: () => void;
+  } | null>(null);
+  /* Reattribute Lines modal state — populated by the ProfileDrawer's
+     unlink-alias callback after the server returns its `impactedChapters`
+     payload. The modal renders one card per impacted chapter and reuses
+     `manuscriptActions.setSentenceCharacter` for reassignment. Closing
+     resets to null. */
+  const [reattributeModal, setReattributeModal] = useState<{
+    sourceCharacterId: string;
+    sourceCharacterName: string;
+    newCharacterId: string;
+    aliasName: string;
+    impactedChapters: { chapterId: number; candidateSentenceIds: number[] }[];
   } | null>(null);
   const showInfo: LayoutContext['showInfo'] = (args) =>
     setResultDialog({ open: true, kind: 'info', ...args });
@@ -1065,6 +1078,44 @@ export function Layout() {
                     }
                   : undefined
               }
+              onUnlinkAlias={
+                bookId
+                  ? async (sourceCharacterId, aliasName) => {
+                      const res = await api.unlinkAlias({
+                        bookId,
+                        sourceCharacterId,
+                        aliasName,
+                      });
+                      dispatch(
+                        castActions.applyUnlinkAlias({
+                          sourceCharacterId,
+                          aliasName,
+                          newCharacter: res.newCharacter,
+                        }),
+                      );
+                      /* Open the Reattribute Lines modal so the user can move
+                         the freed-up alias's lines off the source character. The
+                         drawer stays open behind it — closing the modal returns
+                         the user to the drawer where they can confirm the chip
+                         is gone. */
+                      setReattributeModal({
+                        sourceCharacterId,
+                        sourceCharacterName: profileCharacter.name,
+                        newCharacterId: res.newCharacter.id,
+                        aliasName,
+                        impactedChapters: res.impactedChapters,
+                      });
+                    }
+                  : undefined
+              }
+              onAddAlias={
+                bookId
+                  ? async (characterId, aliasName) => {
+                      await api.addAlias({ bookId, characterId, aliasName });
+                      dispatch(castActions.applyAddAlias({ characterId, aliasName }));
+                    }
+                  : undefined
+              }
               onClose={() => dispatch(uiActions.setOpenProfileId(null))}
               onSave={(updated, meta) => {
                 const prior = profileCharacter;
@@ -1133,6 +1184,16 @@ export function Layout() {
             />
           );
         })()}
+      {reattributeModal && (
+        <ReattributeLinesModal
+          sourceCharacterId={reattributeModal.sourceCharacterId}
+          sourceCharacterName={reattributeModal.sourceCharacterName}
+          newCharacterId={reattributeModal.newCharacterId}
+          aliasName={reattributeModal.aliasName}
+          impactedChapters={reattributeModal.impactedChapters}
+          onClose={() => setReattributeModal(null)}
+        />
+      )}
       {ui.showRevisionPlayer && pending[0] && bookId && (
         <RevisionDiffPlayer
           revision={pending[0]}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -287,6 +287,51 @@ export interface AddFromSeriesRosterArgs {
 export interface AddFromSeriesRosterResponse {
   character: import('./types').Character;
 }
+/* POST /api/books/:bookId/cast/unlink-alias — split a misplaced alias
+   chip off its current character and back into its own standalone cast
+   member. Server reads the preserved Phase-0a chapterCast to identify
+   which chapters originally featured the alias, then returns candidate
+   sentence ids (sentences currently attributed to the source character
+   in those chapters) so the frontend's reattribute modal can let the
+   user move the right lines via the existing per-sentence picker.
+   No sentence rewrites happen server-side. */
+export interface UnlinkAliasArgs {
+  bookId: string;
+  sourceCharacterId: string;
+  aliasName: string;
+}
+export interface UnlinkAliasImpactedChapter {
+  chapterId: number;
+  candidateSentenceIds: number[];
+}
+export interface UnlinkAliasResponse {
+  /** The newly-minted standalone character — frontend appends this to
+      the cast slice via a delta reducer rather than replacing the full
+      list. */
+  newCharacter: Character;
+  /** Chapters whose Phase-0a roster originally listed this alias, each
+      with the IDs of sentences currently attributed to the source
+      character so the Reattribute Lines modal can render them. */
+  impactedChapters: UnlinkAliasImpactedChapter[];
+}
+/* POST /api/books/:bookId/cast/add-alias — append a name to a
+   character's aliases list (idempotent; case-insensitive dedup; rejects
+   the character's own name to keep self-aliases out). Future analyzer
+   runs of subsequent books in the series will route the alias to this
+   character via the matcher. */
+export interface AddAliasArgs {
+  bookId: string;
+  characterId: string;
+  aliasName: string;
+}
+export interface AddAliasResponse {
+  /** Echo of the addition: target character + the alias text, plus the
+      `alreadyPresent` flag so the frontend can distinguish a no-op
+      re-add from a fresh append without diffing the cast. */
+  characterId: string;
+  alias: string;
+  alreadyPresent: boolean;
+}
 export interface StreamArgs {
   bookId: string;
   modelKey: TtsModelKey;
@@ -1740,6 +1785,100 @@ async function mockMergeCharacters({
   void sourceId;
   void targetId;
   return { characters: [] };
+}
+
+async function realUnlinkAlias({
+  bookId,
+  sourceCharacterId,
+  aliasName,
+}: UnlinkAliasArgs): Promise<UnlinkAliasResponse> {
+  const res = await fetch(`/api/books/${encodeURIComponent(bookId)}/cast/unlink-alias`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sourceCharacterId, aliasName }),
+  });
+  if (!res.ok) {
+    let detail = '';
+    try {
+      detail = ((await res.json()) as { error?: string }).error ?? '';
+    } catch {
+      /* not json */
+    }
+    throw new Error(detail || `Unlink alias failed (${res.status}).`);
+  }
+  return res.json();
+}
+
+async function mockUnlinkAlias({
+  aliasName,
+}: UnlinkAliasArgs): Promise<UnlinkAliasResponse> {
+  /* Mock mode is stateless on the cast side — the redux store holds the
+     authoritative shape, and the layout's onUnlinkAlias handler dispatches
+     a delta reducer with the response. So all we need to do is mint the
+     standalone-character shape; the reducer applies it locally + prunes
+     the alias off the source it already knows about.
+
+     impactedChapters is intentionally empty: building a meaningful list
+     would require carrying around a parallel chapter-cast snapshot in the
+     mock, which doesn't pay for itself. The Reattribute Lines modal
+     handles the empty-list case gracefully (the Skip / Done buttons are
+     all that's needed). */
+  await wait(60);
+  const displayName = aliasName.trim();
+  if (!displayName) throw new Error('Alias name cannot be empty.');
+  const baseId =
+    displayName
+      .toLowerCase()
+      .normalize('NFKD')
+      .replace(/[̀-ͯ]/g, '')
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 80) || 'unnamed';
+  const newCharacter: Character = {
+    id: baseId,
+    name: displayName,
+    role: 'character',
+    color: 'narrator',
+    voiceState: 'generated',
+  };
+  return { newCharacter, impactedChapters: [] };
+}
+
+async function realAddAlias({
+  bookId,
+  characterId,
+  aliasName,
+}: AddAliasArgs): Promise<AddAliasResponse> {
+  const res = await fetch(`/api/books/${encodeURIComponent(bookId)}/cast/add-alias`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ characterId, aliasName }),
+  });
+  if (!res.ok) {
+    let detail = '';
+    try {
+      detail = ((await res.json()) as { error?: string }).error ?? '';
+    } catch {
+      /* not json */
+    }
+    throw new Error(detail || `Add alias failed (${res.status}).`);
+  }
+  return res.json();
+}
+
+async function mockAddAlias({
+  characterId,
+  aliasName,
+}: AddAliasArgs): Promise<AddAliasResponse> {
+  await wait(60);
+  const trimmed = aliasName.trim();
+  if (!trimmed) {
+    throw new Error('Alias name cannot be empty.');
+  }
+  /* Stateless — the cast-slice reducer dedupes on its own from the live
+     store state. Returning alreadyPresent=false unconditionally is fine;
+     the reducer no-ops when the alias is already there. */
+  return { characterId, alias: trimmed, alreadyPresent: false };
 }
 
 async function realOverrideLibraryCast(
@@ -3327,6 +3466,8 @@ const real = {
   analyseManuscript: realAnalyseManuscript,
   matchVoices: realMatchVoices,
   mergeCharacters: realMergeCharacters,
+  unlinkAlias: realUnlinkAlias,
+  addAlias: realAddAlias,
   overrideLibraryCast: realOverrideLibraryCast,
   getSeriesRoster: realGetSeriesRoster,
   linkPriorCharacter: realLinkPriorCharacter,
@@ -3498,6 +3639,8 @@ const mock = {
   analyseManuscript: mockAnalyseManuscript,
   matchVoices: mockMatchVoices,
   mergeCharacters: mockMergeCharacters,
+  unlinkAlias: mockUnlinkAlias,
+  addAlias: mockAddAlias,
   overrideLibraryCast: mockOverrideLibraryCast,
   getSeriesRoster: mockGetSeriesRoster,
   linkPriorCharacter: mockLinkPriorCharacter,

--- a/src/modals/profile-drawer.test.tsx
+++ b/src/modals/profile-drawer.test.tsx
@@ -63,6 +63,8 @@ function renderDrawer(
       targetBookId: string,
       targetCharacterId: string,
     ) => Promise<void>;
+    onUnlinkAlias?: (sourceCharacterId: string, aliasName: string) => Promise<void>;
+    onAddAlias?: (characterId: string, aliasName: string) => Promise<void>;
     voice?: Voice;
     baseVoices?: BaseVoice[];
     voices?: Voice[];
@@ -83,6 +85,8 @@ function renderDrawer(
           mergeCandidatesPrior={extra.mergeCandidatesPrior}
           onMerge={extra.onMerge}
           onLinkPrior={extra.onLinkPrior}
+          onUnlinkAlias={extra.onUnlinkAlias}
+          onAddAlias={extra.onAddAlias}
         />
       </Provider>,
     ),
@@ -745,5 +749,114 @@ describe('ProfileDrawer voice-preview while editing', () => {
     expect(window.localStorage.getItem('voice-preview-sample-text')).toBe(
       'Bespoke preview line.',
     );
+  });
+});
+
+describe('ProfileDrawer alias chip editing', () => {
+  const charWithAliases: Character = {
+    ...baseChar,
+    aliases: ['Sior', 'Jurek', 'Sandor', 'Shopkeeper'],
+  };
+
+  it('renders each alias as a chip with an Unlink X button when onUnlinkAlias is provided', () => {
+    renderDrawer(charWithAliases, { onUnlinkAlias: vi.fn().mockResolvedValue(undefined) });
+    /* Aliases section visible. */
+    expect(screen.getByText('Also known as')).toBeTruthy();
+    /* Each alias chip carries its own labelled close button. */
+    expect(screen.getByRole('button', { name: 'Unlink Sior' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Unlink Jurek' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Unlink Sandor' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Unlink Shopkeeper' })).toBeTruthy();
+  });
+
+  it('omits the X button when onUnlinkAlias is not provided (read-only fallback)', () => {
+    /* No onUnlinkAlias → chips render with the names but no buttons,
+       preserving the pre-feature behaviour for surfaces that don't wire
+       the callback. */
+    renderDrawer(charWithAliases);
+    expect(screen.getByText('Sior')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Unlink Sior' })).toBeNull();
+  });
+
+  it('clicking the X dispatches onUnlinkAlias with the chip name', async () => {
+    const onUnlinkAlias = vi.fn().mockResolvedValue(undefined);
+    renderDrawer(charWithAliases, { onUnlinkAlias });
+    fireEvent.click(screen.getByRole('button', { name: 'Unlink Sandor' }));
+    await waitFor(() => {
+      expect(onUnlinkAlias).toHaveBeenCalledWith('halloran', 'Sandor');
+    });
+  });
+
+  it('disables every X button while an unlink is in flight (no double-fire)', async () => {
+    let resolveIt!: () => void;
+    const onUnlinkAlias = vi.fn(
+      () =>
+        new Promise<void>((r) => {
+          resolveIt = r;
+        }),
+    );
+    renderDrawer(charWithAliases, { onUnlinkAlias });
+    fireEvent.click(screen.getByRole('button', { name: 'Unlink Sandor' }));
+    /* While the promise is pending, every chip's X is disabled. */
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Unlink Sior' })).toHaveProperty('disabled', true);
+    });
+    resolveIt();
+    /* Re-enabled after settle so the user can chain unlinks. */
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Unlink Sior' })).toHaveProperty(
+        'disabled',
+        false,
+      );
+    });
+  });
+
+  it('surfaces a server error inline without closing the chip row', async () => {
+    const onUnlinkAlias = vi.fn().mockRejectedValue(new Error('Backend exploded'));
+    renderDrawer(charWithAliases, { onUnlinkAlias });
+    fireEvent.click(screen.getByRole('button', { name: 'Unlink Sandor' }));
+    await screen.findByText(/Backend exploded/);
+    /* Chips still rendered (chip removal is the layout's job via the
+       store dispatch; on error nothing changed). */
+    expect(screen.getByRole('button', { name: 'Unlink Sandor' })).toBeTruthy();
+  });
+
+  it('shows the "+ Add alias" button when onAddAlias is provided', () => {
+    renderDrawer(charWithAliases, { onAddAlias: vi.fn().mockResolvedValue(undefined) });
+    expect(screen.getByRole('button', { name: 'Add alias' })).toBeTruthy();
+  });
+
+  it('clicking + Add alias reveals an input that submits via Enter', async () => {
+    const onAddAlias = vi.fn().mockResolvedValue(undefined);
+    renderDrawer(baseChar, { onAddAlias });
+    fireEvent.click(screen.getByRole('button', { name: 'Add alias' }));
+    const input = screen.getByRole('textbox', { name: 'New alias name' });
+    fireEvent.change(input, { target: { value: 'Captain' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    await waitFor(() => {
+      expect(onAddAlias).toHaveBeenCalledWith('halloran', 'Captain');
+    });
+  });
+
+  it('Escape cancels the inline add input without dispatching', async () => {
+    const onAddAlias = vi.fn().mockResolvedValue(undefined);
+    renderDrawer(baseChar, { onAddAlias });
+    fireEvent.click(screen.getByRole('button', { name: 'Add alias' }));
+    const input = screen.getByRole('textbox', { name: 'New alias name' });
+    fireEvent.change(input, { target: { value: 'Captain' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    /* Input collapses back to the +Add button; nothing dispatched. */
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Add alias' })).toBeTruthy();
+    });
+    expect(onAddAlias).not.toHaveBeenCalled();
+  });
+
+  it('renders the "Also known as" header + add affordance even when the character has no aliases', () => {
+    /* The Add button needs to be reachable on aliasless characters so the
+       user can stitch in a name the analyzer missed. */
+    renderDrawer(baseChar, { onAddAlias: vi.fn().mockResolvedValue(undefined) });
+    expect(screen.getByText('Also known as')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Add alias' })).toBeTruthy();
   });
 });

--- a/src/modals/profile-drawer.tsx
+++ b/src/modals/profile-drawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   IconClose,
   IconWaveform,
@@ -79,6 +79,18 @@ interface Props {
     targetBookId: string,
     targetCharacterId: string,
   ) => Promise<void>;
+  /** Split an alias chip back into its own standalone cast member. The
+      auto-fold step (server/src/analyzer/fold-minor-cast.ts) and the
+      manual merge route are append-only; this is the only reverse path.
+      Layout's handler fires the unlink-alias endpoint, dispatches the
+      delta reducer, and opens the Reattribute Lines modal seeded with
+      the server-returned impacted chapters so the user can move the
+      right sentences to the new character. */
+  onUnlinkAlias?: (sourceCharacterId: string, aliasName: string) => Promise<void>;
+  /** Append a typed name to this character's aliases array. No sentence
+      movement — this is for stitching in a name the analyzer missed.
+      Used by the Profile Drawer's "+ Add alias" affordance. */
+  onAddAlias?: (characterId: string, aliasName: string) => Promise<void>;
 }
 
 export interface PriorMergeCandidate {
@@ -129,6 +141,8 @@ export function ProfileDrawer({
   mergeCandidatesPrior,
   onMerge,
   onLinkPrior,
+  onUnlinkAlias,
+  onAddAlias,
 }: Props) {
   const [tone, setTone] = useState(
     character.tone ?? { warmth: 50, pace: 50, authority: 50, emotion: 50 },
@@ -205,6 +219,55 @@ export function ProfileDrawer({
       setMergeError((e as Error).message || 'Merge failed.');
     } finally {
       setMergeBusy(false);
+    }
+  }
+
+  /* Alias chip management. `aliasBusy` gates both the X-on-chip click
+     and the +Add alias submit so a fast double-click can't double-fire.
+     `aliasError` surfaces server errors (e.g. self-alias-rejected) under
+     the chip row without an interruptive modal. `addAliasInput` /
+     `showAddAlias` back the inline "+ Add alias" text input.
+     Imperative focus on input mount mirrors edit-chapter-title.tsx —
+     JSX `autoFocus` would trip jsx-a11y/no-autofocus. */
+  const [aliasBusy, setAliasBusy] = useState(false);
+  const [aliasError, setAliasError] = useState<string | null>(null);
+  const [showAddAlias, setShowAddAlias] = useState(false);
+  const [addAliasInput, setAddAliasInput] = useState('');
+  const addAliasInputRef = useRef<HTMLInputElement | null>(null);
+  useEffect(() => {
+    if (showAddAlias) addAliasInputRef.current?.focus();
+  }, [showAddAlias]);
+
+  async function runUnlinkAlias(aliasName: string) {
+    if (!onUnlinkAlias || aliasBusy) return;
+    setAliasBusy(true);
+    setAliasError(null);
+    try {
+      await onUnlinkAlias(character.id, aliasName);
+    } catch (e) {
+      setAliasError((e as Error).message || 'Unlink failed.');
+    } finally {
+      setAliasBusy(false);
+    }
+  }
+
+  async function runAddAlias() {
+    if (!onAddAlias || aliasBusy) return;
+    const trimmed = addAliasInput.trim();
+    if (!trimmed) {
+      setAliasError('Alias name cannot be empty.');
+      return;
+    }
+    setAliasBusy(true);
+    setAliasError(null);
+    try {
+      await onAddAlias(character.id, trimmed);
+      setAddAliasInput('');
+      setShowAddAlias(false);
+    } catch (e) {
+      setAliasError((e as Error).message || 'Add alias failed.');
+    } finally {
+      setAliasBusy(false);
     }
   }
 
@@ -648,18 +711,83 @@ export function ProfileDrawer({
             <p className="text-[11px] uppercase tracking-wider text-ink/50 font-semibold mb-3">
               Cast roster
             </p>
-            {character.aliases && character.aliases.length > 0 && (
+            {(character.aliases && character.aliases.length > 0) || onAddAlias ? (
               <div className="mb-3">
                 <p className="text-xs text-ink/55 mb-1.5">Also known as</p>
-                <div className="flex flex-wrap gap-1.5">
-                  {character.aliases.map((a) => (
-                    <Pill key={a} color="library">
-                      {a}
-                    </Pill>
+                <div className="flex flex-wrap items-center gap-1.5">
+                  {(character.aliases ?? []).map((a) => (
+                    <span
+                      key={a}
+                      className="inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-full text-[11px] font-medium bg-magenta/12 text-ink min-h-[28px] sm:min-h-0"
+                    >
+                      <span>{a}</span>
+                      {onUnlinkAlias && (
+                        <button
+                          aria-label={`Unlink ${a}`}
+                          disabled={aliasBusy}
+                          onClick={() => void runUnlinkAlias(a)}
+                          className="inline-flex items-center justify-center w-5 h-5 rounded-full text-ink/55 hover:bg-ink/10 hover:text-ink disabled:opacity-50 disabled:cursor-wait coarse-pointer:opacity-100"
+                        >
+                          <IconClose className="w-3 h-3" />
+                        </button>
+                      )}
+                    </span>
                   ))}
+                  {onAddAlias &&
+                    (showAddAlias ? (
+                      <span className="inline-flex items-center gap-1">
+                        <input
+                          ref={addAliasInputRef}
+                          aria-label="New alias name"
+                          value={addAliasInput}
+                          disabled={aliasBusy}
+                          onChange={(e) => {
+                            setAddAliasInput(e.target.value);
+                            if (aliasError) setAliasError(null);
+                          }}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') {
+                              e.preventDefault();
+                              void runAddAlias();
+                            }
+                            if (e.key === 'Escape') {
+                              e.preventDefault();
+                              setShowAddAlias(false);
+                              setAddAliasInput('');
+                              setAliasError(null);
+                            }
+                          }}
+                          placeholder="alias name"
+                          className="px-2 py-0.5 rounded-full border border-ink/20 bg-white text-[11px] text-ink focus:outline-none focus:ring-2 focus:ring-magenta/30 min-h-[28px] sm:min-h-0"
+                        />
+                        <button
+                          aria-label="Save alias"
+                          disabled={aliasBusy || !addAliasInput.trim()}
+                          onClick={() => void runAddAlias()}
+                          className="px-2 py-0.5 rounded-full text-[11px] font-semibold bg-magenta text-white hover:bg-magenta/90 disabled:bg-ink/15 disabled:text-ink/40 disabled:cursor-not-allowed"
+                        >
+                          Save
+                        </button>
+                      </span>
+                    ) : (
+                      <button
+                        aria-label="Add alias"
+                        onClick={() => {
+                          setShowAddAlias(true);
+                          setAliasError(null);
+                        }}
+                        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium border border-dashed border-ink/20 text-ink/55 hover:border-peach hover:text-peach min-h-[28px] sm:min-h-0"
+                      >
+                        <IconPlus className="w-3 h-3" />
+                        Add alias
+                      </button>
+                    ))}
                 </div>
+                {aliasError && (
+                  <p className="mt-1.5 text-[11px] text-red-600/90 font-medium">⚠ {aliasError}</p>
+                )}
               </div>
-            )}
+            ) : null}
             {(() => {
               const inBookCount = onMerge && mergeCandidates?.length ? mergeCandidates.length : 0;
               const priorCount =

--- a/src/modals/reattribute-lines.test.tsx
+++ b/src/modals/reattribute-lines.test.tsx
@@ -1,0 +1,177 @@
+// Pairs with docs/features/95-alias-edit.md
+
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import { chaptersSlice, chaptersActions } from '../store/chapters-slice';
+import { manuscriptSlice } from '../store/manuscript-slice';
+import { ReattributeLinesModal } from './reattribute-lines';
+import type { Chapter, Sentence } from '../lib/types';
+
+function makeStore({
+  chapters,
+  sentences,
+}: {
+  chapters: Chapter[];
+  sentences: Sentence[];
+}) {
+  /* manuscript-slice has no top-level "setSentences" action — the live
+     dispatch path is hydrateFromAnalysis / hydrateFromBookState. For
+     this unit test we seed via preloadedState so we can shape the
+     sentences array exactly without going through the upload contract. */
+  const store = configureStore({
+    reducer: {
+      chapters: chaptersSlice.reducer,
+      manuscript: manuscriptSlice.reducer,
+    },
+    preloadedState: {
+      manuscript: {
+        bookId: 'b',
+        manuscriptId: 'm',
+        title: 'Test Book',
+        format: null,
+        wordCount: 0,
+        sourceText: null,
+        sentences,
+        importCandidate: null,
+        pendingReupload: null,
+      },
+    },
+  });
+  store.dispatch(chaptersActions.setChapters(chapters));
+  return store;
+}
+
+const seededChapters: Chapter[] = [
+  { id: 1, title: 'The Berth', state: 'queued', characters: {}, duration: '00:00', progress: 0 },
+  { id: 4, title: 'A Manifest', state: 'queued', characters: {}, duration: '00:00', progress: 0 },
+];
+
+const seededSentences: Sentence[] = [
+  { id: 1, chapterId: 1, characterId: 'neverseen-figure', text: 'The shopkeeper laughed.' },
+  { id: 2, chapterId: 1, characterId: 'neverseen-figure', text: '"Sandor said that?"' },
+  { id: 5, chapterId: 4, characterId: 'neverseen-figure', text: 'Chapter four candidate line.' },
+  /* Out-of-scope sentence (different character) — must not appear in the modal. */
+  { id: 6, chapterId: 1, characterId: 'sophie', text: 'Sophie line that is not a candidate.' },
+];
+
+function renderModal(opts: {
+  impactedChapters?: { chapterId: number; candidateSentenceIds: number[] }[];
+  onClose?: () => void;
+}) {
+  const store = makeStore({ chapters: seededChapters, sentences: seededSentences });
+  const onClose = opts.onClose ?? vi.fn();
+  const impactedChapters = opts.impactedChapters ?? [
+    { chapterId: 1, candidateSentenceIds: [1, 2] },
+    { chapterId: 4, candidateSentenceIds: [5] },
+  ];
+  return {
+    store,
+    ...render(
+      <Provider store={store}>
+        <ReattributeLinesModal
+          sourceCharacterId="neverseen-figure"
+          sourceCharacterName="Neverseen Figure"
+          newCharacterId="sandor"
+          aliasName="Sandor"
+          impactedChapters={impactedChapters}
+          onClose={onClose}
+        />
+      </Provider>,
+    ),
+  };
+}
+
+describe('ReattributeLinesModal', () => {
+  it('renders one card per impacted chapter with the candidate sentence text', () => {
+    renderModal({});
+    /* Both chapter cards visible with their titles. */
+    expect(screen.getByText('The Berth')).toBeTruthy();
+    expect(screen.getByText('A Manifest')).toBeTruthy();
+    /* Candidate sentences from the impactedChapters payload only. */
+    expect(screen.getByText('The shopkeeper laughed.')).toBeTruthy();
+    expect(screen.getByText('"Sandor said that?"')).toBeTruthy();
+    expect(screen.getByText('Chapter four candidate line.')).toBeTruthy();
+    /* Out-of-scope sentence (Sophie's) must not render. */
+    expect(screen.queryByText('Sophie line that is not a candidate.')).toBeNull();
+  });
+
+  it('clicking the alias chip on a row reassigns that sentence to the new character', () => {
+    const { store } = renderModal({});
+    /* Click the "Sandor" chip on the first row. There are multiple
+       "Sandor" buttons (one per row), so disambiguate by finding the
+       row's parent first. */
+    const row = screen.getByText('The shopkeeper laughed.').closest('li')!;
+    fireEvent.click(within(row).getByRole('button', { name: 'Reassign to Sandor' }));
+    const reassigned = store
+      .getState()
+      .manuscript.sentences.find((s) => s.chapterId === 1 && s.id === 1)!;
+    expect(reassigned.characterId).toBe('sandor');
+  });
+
+  it('clicking the source chip on a reassigned row reverts the attribution', () => {
+    const { store } = renderModal({});
+    const row = screen.getByText('The shopkeeper laughed.').closest('li')!;
+    /* Reassign … */
+    fireEvent.click(within(row).getByRole('button', { name: 'Reassign to Sandor' }));
+    /* … then revert. */
+    fireEvent.click(within(row).getByRole('button', { name: 'Keep on Neverseen Figure' }));
+    const reverted = store
+      .getState()
+      .manuscript.sentences.find((s) => s.chapterId === 1 && s.id === 1)!;
+    expect(reverted.characterId).toBe('neverseen-figure');
+  });
+
+  it('reflects aria-pressed state so screen readers know which chip is active', () => {
+    const { store } = renderModal({});
+    const row = screen.getByText('The shopkeeper laughed.').closest('li')!;
+    /* Initially the source chip is "pressed" because the sentence is
+       still attributed to the source character. */
+    expect(within(row).getByRole('button', { name: 'Keep on Neverseen Figure' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(within(row).getByRole('button', { name: 'Reassign to Sandor' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+    fireEvent.click(within(row).getByRole('button', { name: 'Reassign to Sandor' }));
+    /* Need to re-query — same elements, but attributes flip. */
+    expect(within(row).getByRole('button', { name: 'Keep on Neverseen Figure' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+    expect(within(row).getByRole('button', { name: 'Reassign to Sandor' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    /* Store reflects the change too. */
+    expect(
+      store.getState().manuscript.sentences.find((s) => s.chapterId === 1 && s.id === 1)!
+        .characterId,
+    ).toBe('sandor');
+  });
+
+  it('Done button fires onClose', () => {
+    const onClose = vi.fn();
+    renderModal({ onClose });
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('renders the empty-state copy when impactedChapters is empty', () => {
+    renderModal({ impactedChapters: [] });
+    expect(screen.getByText(/Nothing to reattribute here\./)).toBeTruthy();
+    /* Done button is still present so the user can dismiss. */
+    expect(screen.getByRole('button', { name: 'Done' })).toBeTruthy();
+  });
+
+  it('renders the empty-state copy when impactedChapters has entries but no candidate sentences', () => {
+    /* Server returned chapter rows but the manuscript slice has no
+       sentences attributed to the source (e.g. they were already
+       reassigned in a prior modal pass). */
+    renderModal({ impactedChapters: [{ chapterId: 99, candidateSentenceIds: [42] }] });
+    expect(screen.getByText(/Nothing to reattribute here\./)).toBeTruthy();
+  });
+});

--- a/src/modals/reattribute-lines.tsx
+++ b/src/modals/reattribute-lines.tsx
@@ -1,0 +1,221 @@
+/* Reattribute Lines modal.
+
+   Opened from the Profile Drawer's "Also known as" chip removal. Server
+   has already split the alias into its own standalone cast member; this
+   modal lets the user move sentences over from the source character —
+   scoped to the chapters where the alias originally appeared in the
+   Phase-0a roster so we surface only candidates, not the whole book.
+
+   The per-sentence reassignment dispatches the existing
+   `manuscriptActions.setSentenceCharacter` action so this modal carries
+   no new redux behaviour — it's a focused chapter-scoped wrapper around
+   the same picker the manuscript view already uses. */
+
+import { useMemo } from 'react';
+import { IconClose } from '../lib/icons';
+import { useAppDispatch, useAppSelector } from '../store';
+import { manuscriptActions } from '../store/manuscript-slice';
+import type { UnlinkAliasImpactedChapter } from '../lib/api';
+
+interface Props {
+  /** The character the alias was un-linked FROM (e.g. "Neverseen Figure").
+      Sentences in the impacted chapters currently attributed to this id
+      are the candidates the user reviews. */
+  sourceCharacterId: string;
+  sourceCharacterName: string;
+  /** The freshly-minted standalone character ID for the un-linked alias
+      (e.g. "sandor"). The quick-set chip on each sentence reassigns the
+      line to this id. */
+  newCharacterId: string;
+  /** Display name of the un-linked alias, used in the modal header and
+      on the quick-set chip. */
+  aliasName: string;
+  /** Server-derived list of chapters where the alias originally appeared,
+      each with the IDs of sentences currently attributed to the source
+      character. Empty list is allowed — the modal renders a "nothing to
+      reattribute" empty state and a Done button. */
+  impactedChapters: UnlinkAliasImpactedChapter[];
+  onClose: () => void;
+}
+
+const CHAR_PREVIEW = 140;
+
+function truncate(s: string, n: number): string {
+  if (s.length <= n) return s;
+  return s.slice(0, n - 1).trimEnd() + '…';
+}
+
+export function ReattributeLinesModal({
+  sourceCharacterId,
+  sourceCharacterName,
+  newCharacterId,
+  aliasName,
+  impactedChapters,
+  onClose,
+}: Props) {
+  const dispatch = useAppDispatch();
+  const chapters = useAppSelector((s) => s.chapters.chapters);
+  const sentences = useAppSelector((s) => s.manuscript.sentences);
+
+  const chapterTitleById = useMemo(() => {
+    const m = new Map<number, string>();
+    for (const c of chapters) m.set(c.id, c.title);
+    return m;
+  }, [chapters]);
+
+  /* For each impacted chapter, hydrate the candidate sentence IDs with
+     their current text and characterId from the manuscript slice. We
+     intentionally read characterId from the live store so the chip-state
+     reflects the user's reassignments in real time without re-fetching
+     from the server. */
+  const cards = useMemo(() => {
+    const byChapter = new Map<number, Map<number, (typeof sentences)[number]>>();
+    for (const s of sentences) {
+      let inner = byChapter.get(s.chapterId);
+      if (!inner) {
+        inner = new Map();
+        byChapter.set(s.chapterId, inner);
+      }
+      inner.set(s.id, s);
+    }
+    return impactedChapters.map((ch) => {
+      const inner = byChapter.get(ch.chapterId);
+      const rows = ch.candidateSentenceIds
+        .map((sid) => inner?.get(sid))
+        .filter((s): s is (typeof sentences)[number] => Boolean(s));
+      return {
+        chapterId: ch.chapterId,
+        title: chapterTitleById.get(ch.chapterId) ?? `Chapter ${ch.chapterId}`,
+        rows,
+      };
+    });
+  }, [impactedChapters, sentences, chapterTitleById]);
+
+  function reassign(chapterId: number, sentenceId: number, characterId: string) {
+    dispatch(manuscriptActions.setSentenceCharacter({ chapterId, sentenceId, characterId }));
+  }
+
+  const totalCandidates = cards.reduce((n, c) => n + c.rows.length, 0);
+  const isEmpty = impactedChapters.length === 0 || totalCandidates === 0;
+
+  return (
+    <>
+      <div onClick={onClose} className="fixed inset-0 bg-ink/30 z-50 fade-in" />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Reattribute lines for ${aliasName}`}
+        className="fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 w-[min(720px,calc(100vw-32px))] max-h-[min(80vh,calc(100vh-64px))] bg-white rounded-3xl shadow-drawer flex flex-col"
+      >
+        <div className="sticky top-0 z-10 bg-white/95 backdrop-blur-md rounded-t-3xl border-b border-ink/10 px-6 py-4 flex items-center gap-3">
+          <div className="flex-1 min-w-0">
+            <p className="text-[11px] uppercase tracking-wider text-ink/50 font-semibold">
+              Reattribute lines
+            </p>
+            <h3 className="text-lg font-bold text-ink leading-tight truncate">
+              {aliasName} — split from {sourceCharacterName}
+            </h3>
+          </div>
+          <button
+            aria-label="Close"
+            onClick={onClose}
+            className="p-2 rounded-full hover:bg-ink/5 text-ink/60 min-w-11 min-h-11"
+          >
+            <IconClose className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="px-6 py-4 overflow-y-auto flex-1">
+          {isEmpty ? (
+            <div className="rounded-2xl border border-dashed border-ink/15 p-5 text-sm text-ink/65 leading-relaxed">
+              <p className="font-semibold text-ink mb-1">Nothing to reattribute here.</p>
+              <p>
+                {aliasName} is now its own cast member. We couldn't find any chapters where the
+                Phase-0a analysis listed {aliasName} as a separate character — likely because the
+                fold happened before the cache was written. If you spot a line that should belong
+                to {aliasName}, reassign it from the manuscript view using the per-sentence picker.
+              </p>
+            </div>
+          ) : (
+            <>
+              <p className="text-sm text-ink/65 leading-relaxed mb-4">
+                {aliasName} was detected in {impactedChapters.length} chapter
+                {impactedChapters.length === 1 ? '' : 's'}. Review the lines currently attributed
+                to <span className="font-semibold text-ink">{sourceCharacterName}</span> and
+                reassign the ones that belong to {aliasName}.
+              </p>
+              <div className="space-y-4">
+                {cards.map((card) => (
+                  <section
+                    key={card.chapterId}
+                    className="rounded-2xl border border-ink/10 bg-canvas/40 overflow-hidden"
+                  >
+                    <header className="px-4 py-2.5 border-b border-ink/10 bg-white">
+                      <p className="text-[11px] uppercase tracking-wider text-ink/50 font-semibold">
+                        Chapter {card.chapterId}
+                      </p>
+                      <h4 className="text-sm font-bold text-ink truncate">{card.title}</h4>
+                    </header>
+                    <ul className="divide-y divide-ink/10">
+                      {card.rows.map((row) => {
+                        const isOnSource = row.characterId === sourceCharacterId;
+                        const isOnAlias = row.characterId === newCharacterId;
+                        return (
+                          <li
+                            key={row.id}
+                            className="px-4 py-3 flex flex-col sm:flex-row sm:items-start sm:gap-3"
+                          >
+                            <p className="flex-1 text-sm text-ink/80 leading-relaxed mb-2 sm:mb-0">
+                              {truncate(row.text, CHAR_PREVIEW)}
+                            </p>
+                            <div className="flex flex-wrap gap-1.5 shrink-0">
+                              <button
+                                aria-label={`Keep on ${sourceCharacterName}`}
+                                aria-pressed={isOnSource}
+                                onClick={() =>
+                                  reassign(card.chapterId, row.id, sourceCharacterId)
+                                }
+                                className={`min-h-11 px-2.5 py-1 rounded-full text-[11px] font-semibold ${
+                                  isOnSource
+                                    ? 'bg-ink text-white'
+                                    : 'bg-ink/[0.06] text-ink/70 hover:bg-ink/10'
+                                }`}
+                              >
+                                {sourceCharacterName}
+                              </button>
+                              <button
+                                aria-label={`Reassign to ${aliasName}`}
+                                aria-pressed={isOnAlias}
+                                onClick={() => reassign(card.chapterId, row.id, newCharacterId)}
+                                className={`min-h-11 px-2.5 py-1 rounded-full text-[11px] font-semibold ${
+                                  isOnAlias
+                                    ? 'bg-magenta text-white'
+                                    : 'bg-magenta/12 text-magenta hover:bg-magenta/20'
+                                }`}
+                              >
+                                {aliasName}
+                              </button>
+                            </div>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </section>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className="sticky bottom-0 bg-white/95 backdrop-blur-md border-t border-ink/10 px-6 py-3 flex items-center justify-end gap-2 rounded-b-3xl">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 rounded-full text-sm font-semibold bg-magenta text-white hover:bg-magenta/90 min-h-11"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/store/cast-slice.test.ts
+++ b/src/store/cast-slice.test.ts
@@ -427,3 +427,136 @@ describe('castSlice — applyManualMatch (POST /cast/link-prior response)', () =
     expect(next.characters).toEqual(start.characters);
   });
 });
+
+describe('castSlice — applyUnlinkAlias (POST /cast/unlink-alias response)', () => {
+  it('strips the alias from the source and appends the new standalone character', () => {
+    const start = baseState([
+      makeChar('neverseen-figure', {
+        aliases: ['Sior', 'Jurek', 'Sandor', 'Shopkeeper'],
+        gender: 'male',
+        ageRange: 'adult',
+      }),
+      makeChar('sophie'),
+    ]);
+    const newCharacter: Character = {
+      id: 'sandor',
+      name: 'Sandor',
+      role: 'character',
+      color: 'narrator',
+      gender: 'male',
+      ageRange: 'adult',
+    } as Character;
+    const next = castSlice.reducer(
+      start,
+      castActions.applyUnlinkAlias({
+        sourceCharacterId: 'neverseen-figure',
+        aliasName: 'Sandor',
+        newCharacter,
+      }),
+    );
+    const source = next.characters.find((c) => c.id === 'neverseen-figure')!;
+    expect(source.aliases).toEqual(['Sior', 'Jurek', 'Shopkeeper']);
+    /* New character lands at the end of the array, defaults to
+       voiceState='generated' so the Cast view's Status column renders
+       a pill rather than blank. */
+    expect(next.characters[next.characters.length - 1]).toEqual({
+      ...newCharacter,
+      voiceState: 'generated',
+    });
+  });
+
+  it('is case-insensitive and trim-tolerant when matching the alias to strip', () => {
+    const start = baseState([
+      makeChar('neverseen-figure', { aliases: ['  Sandor  ', 'Jurek'] }),
+    ]);
+    const next = castSlice.reducer(
+      start,
+      castActions.applyUnlinkAlias({
+        sourceCharacterId: 'neverseen-figure',
+        aliasName: 'sandor',
+        newCharacter: {
+          id: 'sandor',
+          name: 'Sandor',
+          role: 'character',
+          color: 'narrator',
+        } as Character,
+      }),
+    );
+    expect(next.characters.find((c) => c.id === 'neverseen-figure')!.aliases).toEqual(['Jurek']);
+  });
+
+  it('is idempotent when the new character already exists (network retry safety)', () => {
+    const existing = makeChar('sandor', { voiceState: 'tuned', voiceId: 'v_sandor' });
+    const start = baseState([
+      makeChar('neverseen-figure', { aliases: ['Sandor'] }),
+      existing,
+    ]);
+    const next = castSlice.reducer(
+      start,
+      castActions.applyUnlinkAlias({
+        sourceCharacterId: 'neverseen-figure',
+        aliasName: 'Sandor',
+        newCharacter: {
+          id: 'sandor',
+          name: 'Sandor',
+          role: 'character',
+          color: 'narrator',
+        } as Character,
+      }),
+    );
+    /* Existing tuned voice is preserved. */
+    expect(next.characters).toHaveLength(2);
+    expect(next.characters.find((c) => c.id === 'sandor')).toEqual(existing);
+    expect(next.characters.find((c) => c.id === 'neverseen-figure')!.aliases).toEqual([]);
+  });
+});
+
+describe('castSlice — applyAddAlias (POST /cast/add-alias response)', () => {
+  it('appends a new alias to the target character', () => {
+    const start = baseState([
+      makeChar('sophie', { aliases: ['Foster'], name: 'Sophie Foster' }),
+    ]);
+    const next = castSlice.reducer(
+      start,
+      castActions.applyAddAlias({ characterId: 'sophie', aliasName: 'Sofi' }),
+    );
+    expect(next.characters[0].aliases).toEqual(['Foster', 'Sofi']);
+  });
+
+  it('dedupes case-insensitively and trim-tolerantly', () => {
+    const start = baseState([
+      makeChar('sophie', { aliases: ['Foster'], name: 'Sophie Foster' }),
+    ]);
+    const next = castSlice.reducer(
+      start,
+      castActions.applyAddAlias({ characterId: 'sophie', aliasName: '  foster  ' }),
+    );
+    /* Same alias just with different casing/whitespace → no change. */
+    expect(next.characters[0].aliases).toEqual(['Foster']);
+  });
+
+  it('refuses to add the character\'s own name as an alias', () => {
+    const start = baseState([makeChar('sophie', { name: 'Sophie Foster' })]);
+    const next = castSlice.reducer(
+      start,
+      castActions.applyAddAlias({ characterId: 'sophie', aliasName: 'Sophie Foster' }),
+    );
+    expect(next.characters[0].aliases).toBeUndefined();
+  });
+
+  it('no-ops for an unknown characterId or empty alias', () => {
+    const start = baseState([
+      makeChar('sophie', { aliases: ['Foster'], name: 'Sophie Foster' }),
+    ]);
+    const r1 = castSlice.reducer(
+      start,
+      castActions.applyAddAlias({ characterId: 'ghost', aliasName: 'Foo' }),
+    );
+    expect(r1).toEqual(start);
+    const r2 = castSlice.reducer(
+      start,
+      castActions.applyAddAlias({ characterId: 'sophie', aliasName: '   ' }),
+    );
+    expect(r2.characters[0].aliases).toEqual(['Foster']);
+  });
+});

--- a/src/store/cast-slice.ts
+++ b/src/store/cast-slice.ts
@@ -130,6 +130,60 @@ export const castSlice = createSlice({
       if (s.characters.some((c) => c.id === incoming.id)) return;
       s.characters.push(incoming);
     },
+    /* From POST /api/books/:bookId/cast/unlink-alias — split an alias
+       chip off its current character back into its own standalone cast
+       member. Delta-only: strip the alias off the source's aliases list
+       (case-insensitive, trim-tolerant), then append the new character
+       at the end (matches the analyser fold + cast-merge convention of
+       appending freshly-minted entries). No sentence reassignment here
+       — the Reattribute Lines modal handles those via the existing
+       per-sentence picker dispatching manuscriptActions.setSentenceCharacter. */
+    applyUnlinkAlias: (
+      s,
+      a: PayloadAction<{
+        sourceCharacterId: string;
+        aliasName: string;
+        newCharacter: Character;
+      }>,
+    ) => {
+      const { sourceCharacterId, aliasName, newCharacter } = a.payload;
+      const key = aliasName.trim().toLowerCase();
+      const source = s.characters.find((c) => c.id === sourceCharacterId);
+      if (source) {
+        source.aliases = (source.aliases ?? []).filter(
+          (n) => n.trim().toLowerCase() !== key,
+        );
+      }
+      /* Append the new standalone character. Idempotent on id (double-
+         dispatch under network retry leaves the existing entry in place,
+         mirroring addCharacter). Default voiceState to 'generated' so the
+         Cast view's Status column renders a pill rather than blank. */
+      if (!s.characters.some((c) => c.id === newCharacter.id)) {
+        s.characters.push({
+          ...newCharacter,
+          voiceState: newCharacter.voiceState ?? 'generated',
+        });
+      }
+    },
+    /* From POST /api/books/:bookId/cast/add-alias — append a typed name
+       to a character's aliases array. Idempotent (case-insensitive
+       dedup), rejects self-aliases silently (server returns 400 in that
+       case — surfaced as an error toast at the dispatch site). */
+    applyAddAlias: (
+      s,
+      a: PayloadAction<{ characterId: string; aliasName: string }>,
+    ) => {
+      const { characterId, aliasName } = a.payload;
+      const trimmed = aliasName.trim();
+      if (!trimmed) return;
+      const target = s.characters.find((c) => c.id === characterId);
+      if (!target) return;
+      const key = trimmed.toLowerCase();
+      if (key === target.name.trim().toLowerCase()) return;
+      const existing = target.aliases ?? [];
+      if (existing.some((n) => n.trim().toLowerCase() === key)) return;
+      target.aliases = [...existing, trimmed];
+    },
     /* From POST /api/books/:bookId/cast/link-prior — the user just
        manually declared "this character is the same person as that one
        from a prior series book." Single-row analogue of applyVoiceMatches


### PR DESCRIPTION
## Summary

The Profile Drawer's "Also known as" chips were append-only — the auto-fold step and the manual merge route both write into `Character.aliases`, but nothing in the codebase ever pruned it. When the fold over-grouped a real distinct cast member onto another character (e.g. "Sandor" wrongly sitting on "Neverseen Figure"), the user had no in-UI recovery path.

This PR adds bidirectional alias management on the Profile Drawer's chip row, backed by two new contract-internal POST routes sibling to `cast/merge`:

- **`X` on every chip** — splits the alias back into its own standalone cast member; the layout's handler then opens the new **Reattribute Lines** modal seeded with the chapters where the alias originally appeared (derived from the preserved Phase-0a `chapterCast`), with candidate sentences listed under each chapter so the user can reassign the right lines via the existing per-sentence picker.
- **`+ Add alias` inline input** — appends a typed name to the character's aliases (case-insensitive dedup; idempotent re-add; self-alias refused).

**Why a modal, not bulk reassign:** the merge route rewrites `sentence.characterId` in place with no lineage column on the Sentence schema, so the original speaker name per sentence is permanently lost at merge time. We compensate by reading the preserved Phase-0a `chapterCast` (`cast-merge.ts:14` "We deliberately do NOT touch chapterCast") to narrow the user's manual reattribution work from "whole book" to "these three chapters" — no false-positive regex.

**Responses are delta-shaped:**
- `unlink-alias` → `{ newCharacter, impactedChapters }`
- `add-alias` → `{ characterId, alias, alreadyPresent }`

The cast-slice reducers (`applyUnlinkAlias`, `applyAddAlias`) mutate just the affected rows rather than replacing the full cast. Mock mode stays stateless — the redux slice is authoritative in mocks, so the mock halves only need to mint the new character shape, no parallel singleton.

### Files touched

- **Backend (new):** `server/src/routes/cast-aliases.ts` — two POST handlers; wired in `server/src/index.ts`. Reuses `loadCast`/`saveCast` helpers from `cast-merge.ts`. Reads but never writes `chapterCast`.
- **Frontend API client:** `src/lib/api.ts` — `unlinkAlias` / `addAlias` real + mock halves; new `UnlinkAliasArgs/Response`, `AddAliasArgs/Response`, `UnlinkAliasImpactedChapter` types.
- **Redux:** `src/store/cast-slice.ts` — `applyUnlinkAlias` + `applyAddAlias` reducers (idempotent, case-insensitive, preserves tuned voices on retry).
- **Profile Drawer:** `src/modals/profile-drawer.tsx` — chip row now renders interactive chips with dismiss `X` + a `+ Add alias` inline input. Two new optional props `onUnlinkAlias` / `onAddAlias`; surfaces that don't wire them render the chips read-only as before.
- **New modal:** `src/modals/reattribute-lines.tsx` — chapter-card list with per-sentence quick-set chips. Reuses `manuscriptActions.setSentenceCharacter`; no new reducer.
- **Layout:** `src/components/layout.tsx` — wires the two new ProfileDrawer callbacks, owns the modal's open/close state.
- **OpenAPI:** intentionally untouched. Same convention as `cast/merge`, `cast/link-prior`, `cast/add-from-roster` — contract-internal, not in `openapi.yaml`.

### New tests (paired with the change)

- `server/src/routes/cast-aliases.test.ts` — 10 cases: chip strip, standalone-character mint, `impactedChapters` derivation from seeded chapterCast, no mutation of manuscript-edits, collision-suffixed ids, all 400/404 paths; `add-alias` append + dedupe + `alreadyPresent` flag, self-alias rejection.
- `src/store/cast-slice.test.ts` — +9 cases: case-insensitive strip, idempotent retry, tuned-voice preservation; add-alias dedupe + self-alias refusal + no-op on bad input.
- `src/modals/profile-drawer.test.tsx` — +9 cases: chip `X` renders only when `onUnlinkAlias` is wired; in-flight disables every chip; server error surfaces inline; `+ Add` round-trip (Enter submits, Escape cancels); add-button reachable on aliasless characters.
- `src/modals/reattribute-lines.test.tsx` (new file, 7 cases) — chapter card rendering, quick-set dispatch with `aria-pressed`, source revert, Done close, empty-state copy on both empty `impactedChapters` and stale-id payloads.
- `e2e/cast-alias-edit.spec.ts` (new file) — Profile Drawer `+ Add alias` round-trip → click chip `X` → Reattribute Lines modal opens (empty-state in mock) → Done closes → chip is gone.

### Regression plan

`docs/features/95-alias-edit.md` — status `active`. Lists the invariants (server route preserves `chapterCast`; sentence rewrites are user-driven only; standalone-character minting mirrors the analyzer's bucket factory; reducers are delta-only; `+ Add alias` is visible even on aliasless characters) and the manual acceptance walkthrough.

### Out of scope

- **Deterministic sentence revert** via a merge journal — worth a follow-up backlog entry, would replace the `chapterCast`-as-lineage proxy with exact `{sourceId, sourceName, affectedSentenceIds}` records logged at merge time.
- **Bulk alias-manager** modal across multiple characters at once.
- **Re-running Phase 1 analysis on un-link** — explicitly rejected per memory (quota cost + destroys manual cast tweaks).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] Frontend Vitest — `src/store/cast-slice.test.ts` (29/29), `src/modals/profile-drawer.test.tsx` (42/42), `src/modals/reattribute-lines.test.tsx` (7/7)
- [x] Server Vitest — `server/src/routes/cast-aliases.test.ts` (10/10)
- [x] Playwright e2e — `e2e/cast-alias-edit.spec.ts` passes in isolation; under the full `npm run verify` battery it flaked once and passed on retry (same flake profile as the two pre-existing flakes on `listen-loudness-report` / `listen-rename-chapter` — the retry policy from plan 45 covers it)
- [x] `npm run build` — clean
- [x] Local manual against the screenshot scenario: open Halloran's drawer in mock mode → +Add alias `Cap` → X on the chip → Reattribute Lines modal opens with the empty-state copy (mock returns no `impactedChapters`) → Done closes → chip gone → +Add button reachable again