### PR TITLE
fix(frontend): reset window scroll on hash-route change

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -219,6 +219,19 @@ export function Layout() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [stage]);
 
+  /* Reset window scroll on hash-route change. React Router v6 does not
+     restore scroll for hash routes by default and we never added a
+     <ScrollRestoration>, so without this the scroll position from one
+     view (e.g. the new-book upload form auto-scrolled to a deeper textarea)
+     leaks into the next view's landing (e.g. confirm-cast loaded at
+     scrollY ≈ 157, hiding the "Cast confirmation / Meet the cast" hero).
+     Watches `location.pathname` so view-toggles within a book (manuscript
+     → cast → listen, all under #/books/<id>/*) also re-anchor to the top
+     instead of inheriting the previous view's scroll depth. */
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [location.pathname]);
+
   /* Account hydration — fetch user-level account settings once on mount so
      the avatar can show the persisted display name and book hydration can
      read defaults from the account slice. Fires once per app boot. */


### PR DESCRIPTION
## Summary

React Router v6 doesn't restore scroll position for hash routes by default, and the app never added a `<ScrollRestoration>` component. The result: scroll position leaked across SPA navigations. The new-book upload form's textarea auto-scrolls to ~552 px on focus; that scroll then carried through `#/books/<id>/analysing` → `#/books/<id>/confirm`, leaving the confirm view landing at `scrollY ≈ 157` with the "**Cast confirmation** / Meet the cast of **<Title>**" hero (`src/views/confirm-cast.tsx:162-168`) pushed above the fold.

Surfaced as 4 visual baselines drifting cumulatively against `e2e/win32/visual.spec.ts/{analysing,confirm}{,-dark}.png`. The e2e helper `goToConfirm` walks the same route chain the visual tests then screenshot, so each route hop accumulated more scroll until the snapshot stopped matching. Confirmed via a temporary diagnostic spec logging `scrollY` at each step:

```
/                       0
/new   (post-upload)  552
/new   (post-save)    313
/analysing            260
/confirm              157
```

The fix is a one-line `useEffect` in `Layout` that calls `window.scrollTo(0, 0)` whenever `location.pathname` changes. It sits alongside the existing Redux→URL sync effect (`layout.tsx:211-220`) and re-anchors every cross-view navigation to the top — covering both the new-book onboarding chain and intra-book view toggles (`/books/<id>/{manuscript,cast,listen,generate}`).

## Files touched

- `src/components/layout.tsx` (+13 lines) — new `useEffect` on `[location.pathname]`.

## Test plan

- [x] **The 4 affected visual baselines** now pass on first attempt in this worktree: `analysing`, `confirm`, `analysing (dark)`, `confirm (dark)`.
- [x] **The other 14 visual baselines** (`library`, `upload`, `ready (manuscript)`, `listen`, `voices`, `generate`, plus dark variants) pass in serial mode. Some flake under parallel-worker contention with the same retry-recovered profile they had pre-fix — separate pre-existing issue covered by the user's MEMORY.md note "visual.spec confirm + analysing baselines flake pre-push on Windows" + plan 45's `retry: 1`.
- [x] `npm run lint`, `npm run typecheck`, frontend `npm run test`, `cd server && npm run test` (in isolation): all clean. Under full-suite parallel contention, `server/src/routes/analysis-pipelining.test.ts > rolling roster snapshot` timed out at 180 s — passes in 353 ms in isolation; same flake profile as the visual baselines (unrelated to this fix).
- [x] Pushed with `--no-verify` per the MEMORY.md guidance for these known Windows-only contention flakes; CI (Linux, `workers: 1`) handles them deterministically.

## No new automated test

The 4 visual baselines themselves are the regression net — they fail without this change and pass with it. A Vitest unit test for the `useEffect` would require mocking `useLocation` + `window.scrollTo`, which is heavier ceremony for less signal than the visual baselines already provide.

## Why no `<ScrollRestoration>` instead

React Router's `<ScrollRestoration>` works with the data-router APIs (`createBrowserRouter`, `loaders`). This app uses `createHashRouter` with the older route-element API and per-route URL ↔ Redux hydration via `useHydrateStage`. Wiring `ScrollRestoration` would touch the routing graph; a one-line `useEffect` is the minimal targeted fix for the actual symptom.

## Out of scope

- **Per-view scroll restoration on browser back/forward.** Today's fix scrolls to 0 on every pathname change, including `POP` (browser-back). That's fine for v1 in a hash-routed SPA where users mostly navigate via in-app clicks. If we ever want native-style restore-on-back, that's a follow-up using `useNavigationType()` to skip the reset for `POP` navigations + a per-key scroll-position map.