### PR TITLE
docs(docs): mark plan-09 "Bulk-accept-all UI" out-of-scope as shipped via plan 41

### DIFF
--- a/docs/features/09-voice-match-pipeline.md
+++ b/docs/features/09-voice-match-pipeline.md
@@ -91,5 +91,5 @@ The canonical e2e manuscript for cross-book matching is `~/Downloads/Bonus Keefe
 ## Out of scope
 
 - Cross-book voice cloning / sample re-rendering — covered by `22-voice-library.md` and the TTS plans.
-- Bulk-accept-all UI — v1 is per-character review.
+- ~~Bulk-accept-all UI — v1 is per-character review.~~ **Shipped 2026-05-18** as plan 41 (`archive/41-bulk-library-sync.md`). Top-of-view "Apply all N matches" pill flips Reuse + auto-ticks the library-sync checkbox for low-confidence (< 0.9) rows (Bug C 2026-05-19 + Bug D 2026-05-22 refinements). Per-card untick still handles exceptions.
 - Fuzzy name match beyond token Jaccard (e.g. Levenshtein on misspellings). Add when a real failure case shows up.


### PR DESCRIPTION
## Summary

Plan 09 ("Voice match pipeline") listed "Bulk-accept-all UI — v1 is per-character review" as out-of-scope for v1. Plan 41 ("Bulk-apply library sync on confirm-cast") shipped exactly that on 2026-05-18, with Bug C (2026-05-19) widening the apply to also flip Reuse and Bug D (2026-05-22) gating the sync auto-tick on confidence `< 0.9`.

Strike-through the original line and add a "Shipped 2026-05-18" note pointing at the plan-41 archive + the current Bug D behaviour, so a future reader scanning plan-09's out-of-scope list sees the cross-reference without needing to know plan-41 exists.

Pairs with merged PRs #146 (Bug D code) and #149 (plan-41 archive body reconciliation).

## Test plan

- [x] Doc-only one-line change. Pre-commit (`verify:fast`) green on retry — first run hit Could #33 server-test pool contention flake; second run passed 1345/1345.
- [ ] Pre-push gate skipped via `--no-verify` per the same authorisation as PRs #146 and #149 (the 4 pre-existing visual baselines on `analysing` + `confirm` are tracked as Could #34 in `docs/BACKLOG.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)