### PR TITLE
docs(docs): close-out cleanup for testing-flake round

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,8 @@ without changing component code.
 - `npm run dev` — Vite dev server (HMR) on `http://localhost:5173`.
 - `npm run typecheck` — `tsc --noEmit` (frontend + server).
 - `npm test` — Vitest single-run for the frontend.
-- `npm run test:server` — Vitest single-run for the server.
+- `npm run test:server` — Vitest single-run for the server (parallel, excludes the 5 hot files routed to `test:server-slow`).
+- `npm run test:server-slow` — Vitest single-run for 5 timeout-prone server test files (analyzer/gemini + 4 routes test files), pinned to one fork via `server/vitest.config.slow.ts`. Runs in pre-push `verify` after `test:server`; not in `verify:fast` pre-commit. See `docs/features/45-vitest-pool-tuning.md` for the rationale.
 - `npm run test:scripts` — Pester 5 single-run for `scripts/lib/` PowerShell helpers
   (log rotation/pruning). Requires Pester >= 5.0; install once with
   `Install-Module -Name Pester -Scope CurrentUser -Force -SkipPublisherCheck`.
@@ -18,9 +19,10 @@ without changing component code.
   Uses the sidecar venv at `server/tts-sidecar/.venv\Scripts\python.exe`; emits
   a SKIP banner and exits 0 when the venv isn't bootstrapped yet (fresh clone).
 - `npm run test:e2e` — Playwright (chromium) against Vite in mock mode on port 5174.
-  Requires one-time `npx playwright install chromium`. See `docs/features/37-e2e-playwright.md`.
+  Requires one-time `npx playwright install chromium`. Excludes the visual baselines (run via `test:e2e:visual` separately). See `docs/features/archive/37-e2e-playwright.md`.
+- `npm run test:e2e:visual` — Playwright visual-snapshot specs at `e2e/responsive/visual.spec.ts`, chromium-only, `--workers=1` so per-snapshot Windows font-hinting drift can't race against the parallel `test:e2e` battery. Lands in pre-push `verify`.
 - `npm run test:fast` — frontend + server only (matches the pre-commit hook).
-- `npm run test:all` — frontend + server + PowerShell-scripts + sidecar tests (no e2e).
+- `npm run test:all` — frontend + server + server-slow + PowerShell-scripts + sidecar tests (no e2e).
 - `npm run verify` — full battery: typecheck + all tests + e2e + build (matches the pre-push hook).
 - `npm run verify:quick` — all tests (no e2e, no typecheck, no build) — alias for `test:all`.
 - `npm run verify:fast` — fast tests only (alias for `test:fast`) — pre-commit gate.

--- a/e2e/responsive/visual.spec.ts
+++ b/e2e/responsive/visual.spec.ts
@@ -162,7 +162,7 @@ test.describe('visual baselines', () => {
  * one-frame light flash.
  *
  * Same regenerate command as the light pass:
- *   npm run test:e2e -- --update-snapshots visual.spec.ts
+ *   npm run test:e2e:visual -- --update-snapshots
  */
 test.describe('visual baselines (dark theme)', () => {
   test.skip(!existsSync(BASELINE_DIR), SKIP_REASON);


### PR DESCRIPTION
## Summary

Final close-out doc PR for the testing-flake round (PRs #158, #163, #166 all merged). Two small fixups:

- **`CLAUDE.md` Commands list** now enumerates the two new script names introduced by the round:
  - `test:server-slow` — 5 serial server tests, runs in pre-push verify after test:server, NOT in verify:fast pre-commit. References plan 45 (vitest-pool-tuning) for the rationale.
  - `test:e2e:visual` — chromium visuals, --workers=1, hoisted off the parallel test:e2e battery.
  - `test:e2e` description updated to note the new visuals exclusion via `--grep-invert`.
  - `test:all` description updated to include `server-slow`.

- **`e2e/responsive/visual.spec.ts:165`** regenerate-command comment in the dark-theme describe block fixed: was `npm run test:e2e -- --update-snapshots visual.spec.ts`, now `npm run test:e2e:visual -- --update-snapshots` since `test:e2e` no longer matches visual specs.

## Test plan

- [x] Local `npm run verify` end-to-end green.
- [x] Pre-push hook clean.
- [ ] CI Verify ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)