### PR TITLE
fix(frontend): dedupe drift chapter strip + count unique chapters

### DIFF
--- a/docs/features/archive/91-cast-drift-consolidation.md
+++ b/docs/features/archive/91-cast-drift-consolidation.md
@@ -25,7 +25,6 @@ owner: null
   - `DriftBookGroupView` exported from `src/modals/drift-report.tsx` for layout-level callers.
   - Snapshot fingerprint format (private `snapshotKey` in `revisions-slice.ts`) — derived from the same fields the compare card reads; changing the compare card's fields means the fingerprint must extend in lockstep.
 - **Invariants preserved**:
-  - Modal header chapter count remains *per-event*, not per-card (matches today's "N chapters flagged" surface).
   - Severity buckets (severe → moderate → mild) still order cards within a book.
   - Per-chapter Regen / Listen / Dismiss surfaces are preserved one-for-one; `onRegenerateChapter`, `onAutoQueueRegenerate`, `onDismiss` callbacks unchanged.
   - First-appearance bookId ordering preserved (anti-flicker for mid-render polls — plan 83 invariant).
@@ -37,7 +36,7 @@ owner: null
 - `selectDriftByBook` in `src/store/revisions-slice.ts:269` remains exported and stable-referenced — the slice's unit tests pin both the grouping behaviour and the reference-equality memoisation. Don't remove or break it.
 - `groupDriftEvents` produces deterministic `groupId` strings — `(bookId, characterId, snapshotKey)` joined by `|`. Tests rely on this being a stable string the testids can substring-match.
 - `DriftGroupCard` is wrapped in `React.memo` (`src/modals/drift-report.tsx`); its props must remain referentially stable across unrelated re-renders. The memoised `driftGroupsByBookView` in `layout.tsx` is what enforces this.
-- Single-chapter groups skip the expand toggle and render the action row inline. Multi-chapter groups always render the toggle + bulk actions. The behavioural distinction is `group.events.length === 1`.
+- Single-chapter groups skip the expand toggle and render the action row inline. Multi-chapter groups always render the toggle + bulk actions. The behavioural distinction is `group.chapters.length === 1` (was `group.events.length === 1` pre-correction — see "Post-ship correction" below).
 - The detailed `ProfileCompareCard` content stays visible by default at the top of every card — never hide it behind expand. The user explicitly called this out as the surface that makes drift detection meaningful.
 - **Book-title resolution** for the per-section "BOOK" header (`src/components/layout.tsx`'s `driftGroupsByBookView` memo): fall through `bookMeta.saved[bookId]?.title` → `library.books.find(b => b.bookId === bookId)?.title` → raw `bookId`. The middle step is what keeps cross-book drift cards (book never opened this session, so `bookMeta.saved` is empty) from leaking the workspace slug into the header. Don't collapse the chain — the saved-meta step has to win when present (it carries user-edited title overrides), and the raw-bookId tail catches any book whose library entry has been pruned. Pinned by `Layout — drift modal book-title fallback (plan 91)` in `src/components/layout.test.tsx`.
 - **Per-character entry scopes the modal**: clicking the amber drift pill on a cast row opens the modal scoped to that single character — both `src/views/cast.tsx` per-row click handlers (table + card layouts) dispatch `uiActions.openDriftReportForCharacter(c.id)` instead of the unscoped `setShowDriftReport(true)`. The top "Voice drift detected in N chapters" banner stays unscoped (calls `onShowDrift()` with no argument). The modal honours `filterCharacterId` by pruning each book's groups to that one character + surfaces a "Showing X · Show all characters" banner that calls `onClearFilter` to drop the filter without closing. `setShowDriftReport(false)` clears the filter so the next top-banner open starts on the full list. Race-condition guard: when the filter points at a character with zero events (drift dismissed between dispatch and render), the modal returns null instead of an empty shell. Pinned by `DriftReportModal — per-character filter (pill-click entry)` (3 cases) in `src/modals/drift-report.test.tsx` and `CastView drift pill — per-character entry to the Voice Drift Detector` in `src/views/cast.test.tsx`.
@@ -63,7 +62,7 @@ owner: null
   - `Regenerate all` fires `onRegenerateChapter` once per chapter in the group.
   - `Auto-regen all` only present when every event is `autoQueueable`; fires once per chapter when present.
   - `Dismiss all` fires `onDismiss` once per event in the group.
-  - Header "N chapters flagged" still counts every event, not every card.
+  - Header "N chapters flagged" counts unique chapters (post-correction — see "Post-ship correction" below; the original plan shipped per-event counts and was corrected later the same day).
 - **Playwright e2e** (`e2e/drift-report-multibook.spec.ts`): extended with a second case that opens the modal, asserts the consolidated Eliza card with `Show 4 chapters` toggle + bulk Regen-all + exactly one toggle (since Halloran and Marcus are single-chapter groups). Fixture extended in `src/data/drift.ts` with 3 more Eliza events sharing one snapshot — exercises the real-world bug being fixed.
 - **Book-title fallback** (`src/components/layout.test.tsx`, PR #141): 1 case `Layout — drift modal book-title fallback (plan 91)` seeds two drift books — one with both `bookMeta.saved` + `library.books`, one with library-only — asserts saved-meta wins for the first book, library-title surfaces for the second, neither raw bookId leaks into the modal as a title.
 - **Per-character filter** (`src/modals/drift-report.test.tsx`, PR #145): 3 cases under `DriftReportModal — per-character filter (pill-click entry)`: (a) `filterCharacterId` prunes non-matching cards + the banner names the filtered character + header count reflects the filtered view, (b) the "Show all characters" button calls `onClearFilter` exactly once, (c) returns null (not an empty modal shell) when the filter points at a character with zero events (race-condition guard).
@@ -113,3 +112,23 @@ Plan 91 shipped in three increments. The original consolidation landed first; bo
 - **PR #145** (merge `d2fac41`, 2026-05-22): per-character pill scope. Clicking the amber drift pill on a cast row used to open the full unscoped modal — user had to scroll to find the character. Added `ui.driftReportCharacterFilter` state field + `openDriftReportForCharacter` / `clearDriftReportCharacterFilter` actions; `DriftReportModal` now accepts `filterCharacterId` + `onClearFilter`; an in-modal "Showing X · Show all characters" banner is the escape hatch. Closing the modal also clears the filter. Invariant added under "Invariants to preserve"; 4 paired cases across `src/modals/drift-report.test.tsx` (3) + `src/views/cast.test.tsx` (1).
 
 No behaviour delta vs. the plan body — both follow-ups landed as additive invariants under the plan's original "Invariants to preserve" section, not as scope changes.
+
+## Post-ship correction (2026-05-22)
+
+The original plan preserved one invariant that turned out to be wrong: *"Modal header chapter count remains per-event, not per-card."* The server emits one `DriftEvent` per drift factor (voice / gender / ageRange / 4 tone metrics / attributes), so a single chapter that fires three factors produced three events. The "{N} chapters flagged" label was counting those events — a Keefe chapter with `voice + warmth + attributes` drift contributed +3 to the banner. The chapter strip also rendered one row per event, so the same CH NN appeared three times in a row.
+
+User-visible bug: the Voice Drift Detector showed "30 chapters flagged across 2 books" when only ~10 unique chapters were actually flagged, and the per-character "Show chapters" expander listed each chapter 2-3× depending on how many factors fired.
+
+Correction:
+
+- `groupDriftEvents` now derives a `chapters: DriftChapterEntry[]` rollup per group — one entry per unique `chapterId`, with the underlying factor-events folded into `eventIds[]`, `factors[]`, per-chapter `topSeverity`, and a `representativeEvent` for the listen-back probe.
+- The chapter strip renders `group.chapters.map(...)` instead of `group.events.map(...)`.
+- Modal banner total, per-book "{N} flagged" badge, card chapter count, and the Show/Hide toggle label all switch to `group.chapters.length`.
+- `group.severityCounts` is now per-chapter top-severity counts (so a single severe+moderate+mild chapter contributes +1 to "severe", not +1 to every bucket).
+- `single`-chapter optimisation uses `group.chapters.length === 1`, not `events.length`.
+- Regen-all + Auto-regen-all loop over `group.chapters` (was `group.events`) — one regen per chapter, not per factor.
+- Dismiss-all still loops over `group.events` because every factor-event must be dismissed individually so the chapter doesn't resurface on the next poll. Per-row Dismiss now does the same loop internally via `entry.eventIds`.
+- `group.events[]` stays exported — used by Dismiss-all and by any future surface that wants the raw event stream.
+- Per-factor labels remain visible at the card scope via the existing `group.factors` chip strip.
+
+Pinned by 4 new cases in `src/store/revisions-slice.test.ts` (`selectDriftGroupsByBook — per-chapter rollup (multi-factor dedup)`) + 2 new cases in `src/modals/drift-report.test.tsx` (`dedupes multi-factor events on the same chapter to one row + unique-chapter header count` and `single-row Dismiss on a multi-factor chapter dismisses every underlying factor-event`).

--- a/src/modals/drift-report.test.tsx
+++ b/src/modals/drift-report.test.tsx
@@ -599,10 +599,10 @@ describe('DriftReportModal — consolidated (book × character × snapshot) grou
     expect(onDismiss).toHaveBeenCalledTimes(3);
   });
 
-  it('header summary counts every event across every group (matches today\'s shape)', () => {
-    /* The "{N} chapters flagged" line in the modal header has been the
-       canonical drift-count surface since multi-book landed; the
-       consolidation must not change this number — only the *card* count. */
+  it('header summary counts unique chapters across every group', () => {
+    /* The "{N} chapters flagged" line in the modal header counts unique
+       chapters (post-correction; the pre-correction shape that counted
+       per-factor events is preserved as an archive note on plan 91). */
     render(
       <DriftReportModal
         groupsByBook={[
@@ -622,6 +622,90 @@ describe('DriftReportModal — consolidated (book × character × snapshot) grou
     expect(screen.getByText(/5 chapters flagged/)).toBeInTheDocument();
     /* Only 2 cards though — one per snapshot. */
     expect(screen.getAllByTestId(/^drift-group-/).length).toBeGreaterThanOrEqual(2);
+  });
+
+  /* Regression for the Voice Drift Detector "duplicated chapter rows"
+     bug — multi-factor events on the same chapter must collapse to one
+     row in the chapter strip, and the header count must reflect unique
+     chapters, not per-factor events. */
+  it('dedupes multi-factor events on the same chapter to one row + unique-chapter header count', () => {
+    const onRegenerateChapter = vi.fn();
+    const onDismiss = vi.fn();
+    /* Three chapters × two factors each = 6 events. Expected: 3 chapter
+       rows, header reads "3 chapters flagged", Regen-all fires 3×, but
+       Dismiss-all still fires 6× (one per underlying factor-event). */
+    const events: DriftEvent[] = [];
+    for (const chapterId of [3, 4, 5]) {
+      events.push(
+        makeChapterEvent(chapterId, {
+          id: `drift:book-A:${chapterId}:eliza:voice`,
+          factor: 'voice',
+          severity: 'severe',
+          autoQueueable: true,
+        }),
+        makeChapterEvent(chapterId, {
+          id: `drift:book-A:${chapterId}:eliza:warmth`,
+          factor: 'warmth',
+          severity: 'moderate',
+          autoQueueable: false,
+        }),
+      );
+    }
+    render(
+      <DriftReportModal
+        groupsByBook={[group(events)]}
+        onClose={vi.fn()}
+        onRegenerateChapter={onRegenerateChapter}
+        onDismiss={onDismiss}
+      />,
+    );
+    /* Header: 3 unique chapters, not 6 events. */
+    expect(screen.getByText(/3 chapters flagged/)).toBeInTheDocument();
+    /* Expand the chapter strip and count rows: one per chapter. */
+    fireEvent.click(screen.getByText(/Show 3 chapters/i));
+    const rows = screen.getAllByTestId(/^drift-event-/);
+    /* Each chapter's representative event is the top-severity one
+       (voice → severe). That's the testid we'd see surface. */
+    expect(rows).toHaveLength(3);
+    expect(screen.getByTestId('drift-event-drift:book-A:3:eliza:voice')).toBeInTheDocument();
+    expect(screen.getByTestId('drift-event-drift:book-A:4:eliza:voice')).toBeInTheDocument();
+    expect(screen.getByTestId('drift-event-drift:book-A:5:eliza:voice')).toBeInTheDocument();
+    /* Regen-all → 3 chapter callbacks (was 6 pre-correction). */
+    fireEvent.click(screen.getByTestId(/^drift-group-regen-all-/));
+    expect(onRegenerateChapter).toHaveBeenCalledTimes(3);
+    /* Dismiss-all → 6 event callbacks (every factor-event must be
+       dismissed individually so the chapter doesn't reappear). */
+    fireEvent.click(screen.getByTestId(/^drift-group-dismiss-all-/));
+    expect(onDismiss).toHaveBeenCalledTimes(6);
+  });
+
+  it('single-row Dismiss on a multi-factor chapter dismisses every underlying factor-event', () => {
+    const onDismiss = vi.fn();
+    const events = [
+      makeChapterEvent(3, {
+        id: 'drift:book-A:3:eliza:voice',
+        factor: 'voice',
+        severity: 'severe',
+      }),
+      makeChapterEvent(3, {
+        id: 'drift:book-A:3:eliza:warmth',
+        factor: 'warmth',
+        severity: 'moderate',
+      }),
+    ];
+    render(
+      <DriftReportModal
+        groupsByBook={[group(events)]}
+        onClose={vi.fn()}
+        onRegenerateChapter={vi.fn()}
+        onDismiss={onDismiss}
+      />,
+    );
+    /* Single-chapter (after dedup) → inline action row, no expand. */
+    fireEvent.click(screen.getByTestId('drift-dismiss-drift:book-A:3:eliza:voice'));
+    expect(onDismiss).toHaveBeenCalledTimes(2);
+    expect(onDismiss).toHaveBeenCalledWith('drift:book-A:3:eliza:voice');
+    expect(onDismiss).toHaveBeenCalledWith('drift:book-A:3:eliza:warmth');
   });
 });
 

--- a/src/modals/drift-report.tsx
+++ b/src/modals/drift-report.tsx
@@ -5,7 +5,7 @@ import { CHAR_COLORS } from '../lib/colors';
 import { stripChapterPrefix } from '../lib/format-chapter-title';
 import { api } from '../lib/api';
 import { useAppSelector } from '../store';
-import type { DriftGroup } from '../store/revisions-slice';
+import type { DriftGroup, DriftChapterEntry } from '../store/revisions-slice';
 import type { DriftEvent, Character, CharColor, Voice } from '../lib/types';
 
 /* The modal renders one card per `(book × character × snapshot)` group
@@ -107,12 +107,17 @@ export function DriftReportModal({
   const filterCharacterName = filterCharacterId
     ? findFilterCharacterName(groupsByBook, filterCharacterId)
     : null;
+  /* Total = unique flagged chapters across every visible group. Pre-
+     correction (plan 91 archive) this counted per-factor events, which
+     inflated the "{N} chapters flagged" label whenever the server
+     emitted multiple drift factors for the same chapter (voice + tone
+     + attributes on the same Keefe chapter → 3× count). */
   const totalCount = visibleGroupsByBook.reduce(
-    (acc, g) => acc + g.groups.reduce((sub, gr) => sub + gr.events.length, 0),
+    (acc, g) => acc + g.groups.reduce((sub, gr) => sub + gr.chapters.length, 0),
     0,
   );
   /* Edge case: filter is set but the matching character has zero
-     events (race between dispatch + drift slice update). Render
+     chapters (race between dispatch + drift slice update). Render
      nothing rather than an empty modal — same null-return contract as
      the unfiltered empty case below. */
   if (totalCount === 0) return null;
@@ -214,7 +219,7 @@ function DriftBookSection({
     return acc;
   }, [view.groups]);
   const totalChapters = useMemo(
-    () => view.groups.reduce((acc, g) => acc + g.events.length, 0),
+    () => view.groups.reduce((acc, g) => acc + g.chapters.length, 0),
     [view.groups],
   );
   const findChar = (id: string) => view.characters.find((c) => c.id === id);
@@ -289,7 +294,7 @@ const DriftGroupCard = memo(function DriftGroupCard({
   const displayName = character?.name || current?.name || group.characterId;
   const colorKey = (character?.color as CharColor | undefined) || 'narrator';
   const rowVoice = voices?.find((v) => v.id === character?.voiceId);
-  const single = group.events.length === 1;
+  const single = group.chapters.length === 1;
   const [expanded, setExpanded] = useState(single);
 
   /* Highlight any row whose snapshot ≠ current — the consolidated card
@@ -311,7 +316,7 @@ const DriftGroupCard = memo(function DriftGroupCard({
             <h4 className="text-sm font-bold text-ink">{displayName}</h4>
             <span className="text-xs text-ink/50">·</span>
             <span className="text-xs font-semibold text-ink tabular-nums">
-              {group.events.length} chapter{group.events.length === 1 ? '' : 's'}
+              {group.chapters.length} chapter{group.chapters.length === 1 ? '' : 's'}
             </span>
             {!single && (
               <span className="text-[10px] text-ink/45 tabular-nums">
@@ -345,8 +350,9 @@ const DriftGroupCard = memo(function DriftGroupCard({
           />
 
           {single ? (
-            <ChapterRow
-              event={group.events[0]}
+            <ChapterEntryRow
+              entry={group.chapters[0]}
+              characterId={group.characterId}
               bookId={bookId}
               character={character}
               voice={rowVoice}
@@ -367,17 +373,21 @@ const DriftGroupCard = memo(function DriftGroupCard({
                 />
                 {expanded
                   ? 'Hide chapters'
-                  : `Show ${group.events.length} chapter${group.events.length === 1 ? '' : 's'}`}
+                  : `Show ${group.chapters.length} chapter${group.chapters.length === 1 ? '' : 's'}`}
               </button>
               {expanded && (
                 <ul
                   className="mt-2 divide-y divide-ink/5 rounded-xl border border-ink/10 overflow-hidden"
                   data-testid={`drift-group-chapters-${group.groupId}`}
                 >
-                  {group.events.map((e) => (
-                    <li key={e.id} className="p-2 bg-white">
-                      <ChapterRow
-                        event={e}
+                  {group.chapters.map((entry) => (
+                    <li
+                      key={`${bookId}|${group.characterId}|${entry.chapterId}`}
+                      className="p-2 bg-white"
+                    >
+                      <ChapterEntryRow
+                        entry={entry}
+                        characterId={group.characterId}
                         bookId={bookId}
                         character={character}
                         voice={rowVoice}
@@ -394,8 +404,8 @@ const DriftGroupCard = memo(function DriftGroupCard({
                 {group.allAutoQueueable && onAutoQueueRegenerate && (
                   <button
                     onClick={() => {
-                      for (const e of group.events) {
-                        onAutoQueueRegenerate(bookId, e.characterId, e.chapterId);
+                      for (const ch of group.chapters) {
+                        onAutoQueueRegenerate(bookId, group.characterId, ch.chapterId);
                       }
                     }}
                     data-testid={`drift-group-auto-regen-all-${group.groupId}`}
@@ -406,8 +416,8 @@ const DriftGroupCard = memo(function DriftGroupCard({
                 )}
                 <button
                   onClick={() => {
-                    for (const e of group.events) {
-                      onRegenerateChapter(bookId, e.characterId, e.chapterId);
+                    for (const ch of group.chapters) {
+                      onRegenerateChapter(bookId, group.characterId, ch.chapterId);
                     }
                   }}
                   data-testid={`drift-group-regen-all-${group.groupId}`}
@@ -417,6 +427,9 @@ const DriftGroupCard = memo(function DriftGroupCard({
                 </button>
                 <button
                   onClick={() => {
+                    /* Dismiss-all still loops over EVERY event (every
+                       factor-event must be dismissed individually so a
+                       chapter doesn't reappear on the next poll). */
                     for (const e of group.events) onDismiss(e.id);
                   }}
                   data-testid={`drift-group-dismiss-all-${group.groupId}`}
@@ -437,9 +450,17 @@ const DriftGroupCard = memo(function DriftGroupCard({
    the expanded chapter strip (smaller rows + reduced metadata); the
    non-compact form is the single-chapter optimisation that renders
    inline at the bottom of the card. Both render the same Regen / Listen
-   / Dismiss surface. */
-function ChapterRow({
-  event,
+   / Dismiss surface.
+
+   Takes a `DriftChapterEntry` (one per unique chapter — multi-factor
+   events on the same chapter are pre-aggregated upstream in
+   `groupDriftEvents`), not a single `DriftEvent`. Dismiss loops over
+   every underlying eventId so a one-click dismiss takes down every
+   factor-event for the chapter; otherwise the chapter would resurface
+   on the next poll for any factor still flagging. */
+function ChapterEntryRow({
+  entry,
+  characterId,
   bookId,
   character,
   voice,
@@ -448,7 +469,8 @@ function ChapterRow({
   onDismiss,
   compact,
 }: {
-  event: DriftEvent;
+  entry: DriftChapterEntry;
+  characterId: string;
   bookId: string;
   character?: Character;
   voice?: Voice;
@@ -457,21 +479,28 @@ function ChapterRow({
   onDismiss: (eventId: string) => void;
   compact?: boolean;
 }) {
+  /* Substring-stable test ids — the original per-event ids stay valid
+     for existing tests (a one-factor chapter still matches
+     `drift-event-drift:book-A:1:eliza:voice`). A new per-chapter id
+     lets dedup-aware tests assert on chapter-scoped selectors. */
+  const eventTestId = entry.representativeEvent.id;
+  const chapterTestId = `drift-chapter-${bookId}-${characterId}-${entry.chapterId}`;
   return (
     <div
       className={`flex items-center gap-2 flex-wrap ${compact ? '' : 'mt-3'}`}
-      data-testid={`drift-event-${event.id}`}
+      data-testid={`drift-event-${eventTestId}`}
+      data-chapter-testid={chapterTestId}
     >
       <span className="text-xs font-semibold text-ink tabular-nums">
-        CH {String(event.chapterId).padStart(2, '0')}
+        CH {String(entry.chapterId).padStart(2, '0')}
       </span>
       <span className="text-xs text-ink/70 flex-1 min-w-0 truncate">
-        {stripChapterPrefix(event.chapterTitle)}
+        {stripChapterPrefix(entry.chapterTitle)}
       </span>
-      {event.autoQueueable && onAutoQueueRegenerate ? (
+      {entry.autoQueueable && onAutoQueueRegenerate ? (
         <button
-          onClick={() => onAutoQueueRegenerate(bookId, event.characterId, event.chapterId)}
-          data-testid={`drift-auto-regen-${event.id}`}
+          onClick={() => onAutoQueueRegenerate(bookId, characterId, entry.chapterId)}
+          data-testid={`drift-auto-regen-${eventTestId}`}
           title="Skip the confirmation modal — auto-queue this regeneration"
           className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-peach text-ink text-[11px] font-semibold hover:bg-peach/85"
         >
@@ -479,19 +508,26 @@ function ChapterRow({
         </button>
       ) : (
         <button
-          onClick={() => onRegenerateChapter(bookId, event.characterId, event.chapterId)}
-          data-testid={`drift-regen-${event.id}`}
+          onClick={() => onRegenerateChapter(bookId, characterId, entry.chapterId)}
+          data-testid={`drift-regen-${eventTestId}`}
           className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-ink text-canvas text-[11px] font-semibold hover:bg-ink-soft"
         >
           <IconRefresh className="w-3 h-3" /> Regenerate
         </button>
       )}
       {voice && (
-        <DriftListenWidget event={event} bookId={bookId} voice={voice} character={character} />
+        <DriftListenWidget
+          event={entry.representativeEvent}
+          bookId={bookId}
+          voice={voice}
+          character={character}
+        />
       )}
       <button
-        onClick={() => onDismiss(event.id)}
-        data-testid={`drift-dismiss-${event.id}`}
+        onClick={() => {
+          for (const id of entry.eventIds) onDismiss(id);
+        }}
+        data-testid={`drift-dismiss-${eventTestId}`}
         className="text-[11px] font-medium text-ink/50 hover:text-ink/80"
       >
         Dismiss

--- a/src/store/revisions-slice.test.ts
+++ b/src/store/revisions-slice.test.ts
@@ -662,6 +662,140 @@ describe('selectDriftGroupsByBook — (book × character × snapshot) consolidat
   });
 });
 
+describe('selectDriftGroupsByBook — per-chapter rollup (multi-factor dedup)', () => {
+  /* Regression for the Voice Drift Detector "duplicated chapter rows"
+     bug: the server emits one DriftEvent per drift factor (voice / tone
+     metrics / attributes / …), and the modal's chapter strip must
+     collapse those to one row per chapter. The slice's `chapters[]`
+     derivation is where that collapse happens. */
+  const snapA: DriftEvent['snapshot'] = {
+    voiceId: 'old-voice',
+    tone: { warmth: 40, pace: 50 },
+    attributes: ['warm'],
+  };
+  const cur: DriftEvent['current'] = {
+    voiceId: 'new-voice',
+    tone: { warmth: 80, pace: 50 },
+    attributes: ['warm', 'tense'],
+  };
+
+  it('collapses N factor-events on the same chapter into one chapters[] entry', () => {
+    const s = revisionsSlice.reducer(
+      undefined,
+      revisionsActions.applyPoll({
+        drift: [
+          drift('drift:book-A:3:keefe:voice', {
+            bookId: 'book-A',
+            chapterId: 3,
+            characterId: 'keefe',
+            snapshot: snapA,
+            current: cur,
+            factor: 'voice',
+            severity: 'severe',
+          }),
+          drift('drift:book-A:3:keefe:warmth', {
+            bookId: 'book-A',
+            chapterId: 3,
+            characterId: 'keefe',
+            snapshot: snapA,
+            current: cur,
+            factor: 'warmth',
+            severity: 'moderate',
+          }),
+          drift('drift:book-A:3:keefe:attributes', {
+            bookId: 'book-A',
+            chapterId: 3,
+            characterId: 'keefe',
+            snapshot: snapA,
+            current: cur,
+            factor: 'attributes',
+            severity: 'moderate',
+          }),
+        ],
+      }),
+    );
+    const g = selectDriftGroupsByBook({ revisions: s })[0].groups[0];
+    /* events[] keeps every factor-event (dismiss-all loops over them). */
+    expect(g.events).toHaveLength(3);
+    /* chapters[] dedupes to one row for the chapter. */
+    expect(g.chapters).toHaveLength(1);
+    const entry = g.chapters[0];
+    expect(entry.chapterId).toBe(3);
+    expect(entry.eventIds.sort()).toEqual([
+      'drift:book-A:3:keefe:attributes',
+      'drift:book-A:3:keefe:voice',
+      'drift:book-A:3:keefe:warmth',
+    ]);
+    expect(entry.factors.sort()).toEqual(['attributes', 'voice', 'warmth']);
+    /* Top severity of the chapter is the max across its events. */
+    expect(entry.topSeverity).toBe('severe');
+    /* Representative event is the top-severity one (drives the
+       DriftListenWidget audio probe). */
+    expect(entry.representativeEvent.id).toBe('drift:book-A:3:keefe:voice');
+  });
+
+  it('chapters[] sorts by chapterId ascending even when events arrive out of order', () => {
+    const s = revisionsSlice.reducer(
+      undefined,
+      revisionsActions.applyPoll({
+        drift: [
+          drift('d-c5', { bookId: 'book-A', chapterId: 5, snapshot: snapA, current: cur, factor: 'voice' }),
+          drift('d-c2-v', { bookId: 'book-A', chapterId: 2, snapshot: snapA, current: cur, factor: 'voice' }),
+          drift('d-c2-w', { bookId: 'book-A', chapterId: 2, snapshot: snapA, current: cur, factor: 'warmth' }),
+          drift('d-c9', { bookId: 'book-A', chapterId: 9, snapshot: snapA, current: cur, factor: 'voice' }),
+        ],
+      }),
+    );
+    const g = selectDriftGroupsByBook({ revisions: s })[0].groups[0];
+    expect(g.chapters.map((c) => c.chapterId)).toEqual([2, 5, 9]);
+    /* Chapter 2 has two factors collapsed; 5 and 9 have one each. */
+    expect(g.chapters[0].eventIds).toHaveLength(2);
+    expect(g.chapters[1].eventIds).toHaveLength(1);
+    expect(g.chapters[2].eventIds).toHaveLength(1);
+  });
+
+  it('per-chapter autoQueueable is the AND over its events; group.allAutoQueueable is the AND over chapters', () => {
+    const s = revisionsSlice.reducer(
+      undefined,
+      revisionsActions.applyPoll({
+        drift: [
+          /* CH 1: voice severe (auto) + warmth moderate (NOT auto) → chapter NOT auto. */
+          drift('d1v', { bookId: 'book-A', chapterId: 1, snapshot: snapA, current: cur, factor: 'voice', autoQueueable: true }),
+          drift('d1w', { bookId: 'book-A', chapterId: 1, snapshot: snapA, current: cur, factor: 'warmth', autoQueueable: false }),
+          /* CH 2: voice severe (auto only) → chapter IS auto. */
+          drift('d2v', { bookId: 'book-A', chapterId: 2, snapshot: snapA, current: cur, factor: 'voice', autoQueueable: true }),
+        ],
+      }),
+    );
+    const g = selectDriftGroupsByBook({ revisions: s })[0].groups[0];
+    expect(g.chapters[0].autoQueueable).toBe(false);
+    expect(g.chapters[1].autoQueueable).toBe(true);
+    /* Group rolls up to false because CH 1 isn't all-auto. */
+    expect(g.allAutoQueueable).toBe(false);
+  });
+
+  it('severityCounts counts CHAPTERS (top-severity per chapter), not raw events', () => {
+    /* Pre-correction (plan 91 archive) severityCounts summed events,
+       so a chapter that fired severe+moderate+mild contributed +1 to
+       each bucket. Post-correction it contributes only to the chapter's
+       top bucket ("severe"). */
+    const s = revisionsSlice.reducer(
+      undefined,
+      revisionsActions.applyPoll({
+        drift: [
+          drift('d1s', { bookId: 'book-A', chapterId: 1, snapshot: snapA, current: cur, factor: 'voice', severity: 'severe' }),
+          drift('d1mod', { bookId: 'book-A', chapterId: 1, snapshot: snapA, current: cur, factor: 'warmth', severity: 'moderate' }),
+          drift('d1mild', { bookId: 'book-A', chapterId: 1, snapshot: snapA, current: cur, factor: 'attributes', severity: 'mild' }),
+          drift('d2mod', { bookId: 'book-A', chapterId: 2, snapshot: snapA, current: cur, factor: 'voice', severity: 'moderate' }),
+        ],
+      }),
+    );
+    const g = selectDriftGroupsByBook({ revisions: s })[0].groups[0];
+    /* CH 1 top = severe; CH 2 top = moderate. */
+    expect(g.severityCounts).toEqual({ severe: 1, moderate: 1, mild: 0 });
+  });
+});
+
 describe('revisionsSlice — enqueuePending', () => {
   it('appends a new pending revision', () => {
     const start = revisionsSlice.reducer(

--- a/src/store/revisions-slice.ts
+++ b/src/store/revisions-slice.ts
@@ -300,17 +300,46 @@ export interface DriftGroup {
   /** Live profile from the latest cast. Shared by every event in this
       group; the modal renders the snapshot→current diff once. */
   current: DriftEvent['current'];
-  /** Max severity across the group's events — drives the group's pill. */
+  /** Max severity across the group's chapters — drives the group's pill. */
   topSeverity: DriftEvent['severity'];
+  /** Per-chapter top-severity counts. NOT per-event — the server emits
+      one DriftEvent per drift factor (voice / tone / attributes / …), so
+      a chapter that fires 3 factors would otherwise inflate these counts
+      3×. Pre-correction (plan 91 archive) this counted events. */
   severityCounts: Record<DriftEvent['severity'], number>;
   /** Union of `factor` strings across events in the group — surface what
       triggered the drift in factor-chip form. */
   factors: string[];
-  /** Per-chapter events, sorted by chapterId ascending. */
+  /** Raw per-event list, sorted by chapterId ascending. Used by
+      bulk-dismiss (every factor-event must be dismissed individually so
+      the chapter doesn't reappear on the next poll). */
   events: DriftEvent[];
+  /** Per-chapter rollup. The modal's chapter strip renders ONE row per
+      chapter — multi-factor events on the same chapter collapse here.
+      Sorted by chapterId ascending. */
+  chapters: DriftChapterEntry[];
   /** True iff every event in the group is `autoQueueable`. Controls the
       "Auto-regen all" bulk action's availability. */
   allAutoQueueable: boolean;
+}
+
+/* One row in the chapter strip. Aggregates every drift event the group
+   has for `chapterId` so the strip can show one row even when multiple
+   factors fired on the same chapter. */
+export interface DriftChapterEntry {
+  chapterId: number;
+  chapterTitle: string;
+  topSeverity: DriftEvent['severity'];
+  /** Union of factor strings that fired on this chapter. */
+  factors: string[];
+  /** True iff every underlying event is autoQueueable. */
+  autoQueueable: boolean;
+  /** Every underlying event id. Dismiss-one-row loops over these so a
+      single click takes down every factor-event for the chapter. */
+  eventIds: string[];
+  /** Top-severity event for this chapter — fed to DriftListenWidget
+      (which takes a single event) and used for stable test ids. */
+  representativeEvent: DriftEvent;
 }
 
 const severityRank: Record<DriftEvent['severity'], number> = {
@@ -343,9 +372,19 @@ function snapshotKey(snap: DriftEvent['snapshot']): string {
 
 /* Collapse a flat list of drift events into `(book × character ×
    snapshot)` groups. Pure helper — also reused by tests that need to
-   build a `groupsByBook` prop without going through redux. */
+   build a `groupsByBook` prop without going through redux.
+
+   The grouping key intentionally OMITS `factor` — the server emits one
+   event per drift factor (voice / gender / ageRange / 4 tone metrics /
+   attributes), and all factor-events for the same `(book, character,
+   snapshot)` share one compare card. The same omission means multiple
+   factor-events for the same chapter must be folded into one
+   `DriftChapterEntry` so the chapter strip doesn't duplicate rows. */
 export function groupDriftEvents(events: DriftEvent[]): DriftGroup[] {
-  const byGroupId = new Map<string, DriftGroup>();
+  const byGroupId = new Map<
+    string,
+    DriftGroup & { _byChapter: Map<number, DriftChapterEntry> }
+  >();
   for (const event of events) {
     const bid = event.bookId ?? '';
     const gid = `${bid}|${event.characterId}|${snapshotKey(event.snapshot)}`;
@@ -361,12 +400,13 @@ export function groupDriftEvents(events: DriftEvent[]): DriftGroup[] {
         severityCounts: { severe: 0, moderate: 0, mild: 0 },
         factors: [],
         events: [],
+        chapters: [],
         allAutoQueueable: true,
+        _byChapter: new Map(),
       };
       byGroupId.set(gid, group);
     }
     group.events.push(event);
-    group.severityCounts[event.severity] = (group.severityCounts[event.severity] ?? 0) + 1;
     if (severityRank[event.severity] > severityRank[group.topSeverity]) {
       group.topSeverity = event.severity;
     }
@@ -378,13 +418,62 @@ export function groupDriftEvents(events: DriftEvent[]): DriftGroup[] {
        the live cast on every emit, so the last-seen wins. Snapshot is
        immutable per groupId by construction. */
     if (event.current) group.current = event.current;
+
+    /* Per-chapter rollup. First event for a chapter seeds the entry;
+       subsequent events for the same chapter raise top-severity, union
+       factors, AND autoQueueable, push the eventId, and swap the
+       representative event when a more-severe one arrives. */
+    let entry = group._byChapter.get(event.chapterId);
+    if (!entry) {
+      entry = {
+        chapterId: event.chapterId,
+        chapterTitle: event.chapterTitle,
+        topSeverity: event.severity,
+        factors: event.factor ? [event.factor] : [],
+        autoQueueable: event.autoQueueable ?? false,
+        eventIds: [event.id],
+        representativeEvent: event,
+      };
+      group._byChapter.set(event.chapterId, entry);
+    } else {
+      entry.eventIds.push(event.id);
+      if (event.factor && !entry.factors.includes(event.factor)) {
+        entry.factors.push(event.factor);
+      }
+      if (!event.autoQueueable) entry.autoQueueable = false;
+      if (severityRank[event.severity] > severityRank[entry.topSeverity]) {
+        entry.topSeverity = event.severity;
+        entry.representativeEvent = event;
+      }
+      /* Prefer the freshest non-empty chapterTitle (server stamps it
+         per-event; older events occasionally fall through to "Chapter
+         N" — let later events upgrade). */
+      if (event.chapterTitle && !entry.chapterTitle.trim()) {
+        entry.chapterTitle = event.chapterTitle;
+      }
+    }
   }
-  /* Sort each group's events by chapterId so the affected-chapters
-     strip reads in order. */
-  return Array.from(byGroupId.values()).map((g) => ({
-    ...g,
-    events: g.events.slice().sort((a, b) => a.chapterId - b.chapterId),
-  }));
+  /* Final pass: sort events + chapters by chapterId, derive
+     per-chapter severityCounts (NOT per-event — see DriftGroup doc),
+     drop the private _byChapter Map from the returned shape. */
+  return Array.from(byGroupId.values()).map((g) => {
+    const chapters = Array.from(g._byChapter.values()).sort(
+      (a, b) => a.chapterId - b.chapterId,
+    );
+    const severityCounts: Record<DriftEvent['severity'], number> = {
+      severe: 0,
+      moderate: 0,
+      mild: 0,
+    };
+    for (const ch of chapters) severityCounts[ch.topSeverity] += 1;
+    const { _byChapter: _unused, ...rest } = g;
+    return {
+      ...rest,
+      events: g.events.slice().sort((a, b) => a.chapterId - b.chapterId),
+      chapters,
+      severityCounts,
+    };
+  });
 }
 
 /* Selector: collapse the flat drift list into `(book × character ×


### PR DESCRIPTION
## Summary

The Voice Drift Detector modal was showing duplicated chapter rows (CH 03 ONE × 2, CH 04 TWO × 2, CH 05 THREE × 2 when clicking through from Neverseen → Keefe) and inflating the "{N} chapters flagged" banner. Root cause was architectural: the server emits one `DriftEvent` per drift factor (voice / gender / ageRange / 4 tone metrics / attributes), and `groupDriftEvents` aggregated by `(bookId, characterId, snapshotKey)` without per-chapter folding. A Keefe chapter with voice + warmth + attributes drift produced 3 identical CH-rows and counted 3× in the banner.

- **Slice (`src/store/revisions-slice.ts`)**: `groupDriftEvents` now derives a `chapters: DriftChapterEntry[]` rollup per group alongside `events[]`. Each entry folds every factor-event for a single chapter into `eventIds[]`, union `factors[]`, per-chapter `topSeverity`, AND-rolled `autoQueueable`, and a top-severity `representativeEvent`. `group.severityCounts` switches to per-chapter (no more triple-counting a single severe+moderate+mild chapter). `group.allAutoQueueable` rolls up from chapters.
- **Modal (`src/modals/drift-report.tsx`)**: chapter strip renders `group.chapters.map(...)` — one row per unique chapter. Modal banner total, per-book "{N} flagged" badge, card "{N} chapters" count, Show/Hide toggle label, and the `single`-chapter optimisation all switch to `group.chapters.length`. Regen-all + Auto-regen-all loop over chapters (one regen per chapter, not per factor). Dismiss-all still loops over `group.events` so every factor-event is dismissed individually — otherwise the chapter resurfaces on the next poll. Per-row Dismiss does the same via `entry.eventIds`. Per-factor labels remain visible at card scope via the existing `group.factors` chip strip.
- **New invariants pinned**: 4 cases in `src/store/revisions-slice.test.ts` (`selectDriftGroupsByBook — per-chapter rollup (multi-factor dedup)`) + 2 cases in `src/modals/drift-report.test.tsx` (multi-factor 6 events → 3 rows + "3 chapters flagged" header; per-row Dismiss dismisses every underlying factor-event).
- **Plan 91 archive doc** (`docs/features/archive/91-cast-drift-consolidation.md`) gets a `## Post-ship correction (2026-05-22)` section documenting the invariant flip (per-event count → per-chapter count) and the related touched invariants (single-chapter optimisation now keys off `group.chapters.length`; bulk Regen iterates chapters not events). The original "Modal header chapter count remains per-event" bullet is dropped from the Invariants section.
- **No backend changes**: the server's per-factor emission stays as-is — the per-factor breakdown remains valuable in the snapshot/current diff. Aggregation is a UI concern.

## Test plan

- [x] `npm run typecheck` — green.
- [x] `npm run test -- src/store/revisions-slice.test.ts src/modals/drift-report.test.tsx src/views/cast.test.tsx src/components/layout.test.tsx` — 101 cases green (46 slice + 29 modal + 22 cast + 4 layout).
- [x] `npm run verify` — full battery green (typecheck + frontend + server + server-slow + scripts + sidecar + e2e + visual + build).
- [ ] Manual: open Cast view in a multi-chapter book; edit a character's voice + one tone slider; open the drift detector via the cast row's pill; confirm each affected chapter appears exactly once in the strip and the banner reads `N chapters flagged` where N matches the chapter count.
- [ ] Manual: open a second book with the same character; force drift in both; click through from Cast → character pill in Book A; confirm two cards (one per book) each with deduped chapter strips.
- [ ] Manual: Dismiss on one chapter row removes the entire chapter (not just one factor) from the strip; Regenerate all fires the regen modal / auto-queue exactly once per chapter.

Regression plan: [docs/features/archive/91-cast-drift-consolidation.md](docs/features/archive/91-cast-drift-consolidation.md) (Post-ship correction section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)