### PR TITLE
feat(server,frontend): GPU-arbitration semaphore for parallel sessions

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -78,17 +78,7 @@ Source: net-new (2026-05-21). Surfaced while smoke-testing PR #107 — a `tsx` r
 - _Depends on:_ none. Self-contained inside the streaming surface.
 - _Benefit (dev / technical):_ no more false "stalled" banners during interactive development. Same fix incidentally covers production crash-recovery (Node OOM, manual restart) so users running long books survive a sidecar/server bounce without losing the visible progress thread.
 
-### 3. GPU-arbitration semaphore for parallel Claude Code sessions
-
-Source: net-new (2026-05-19). Spun off from the parallel-sessions tooling — `scripts/wt-new.mjs` resolves port collisions but leaves GPU/VRAM contention as a manual-coordination concern documented in CONTRIBUTING.md.
-
-- _What:_ Add a small server-side semaphore around heavy-GPU operations (analyzer's chat completion path + sidecar's `/synthesize`) so concurrent requests from N parallel sessions get serialized rather than fighting over VRAM on an 8 GB GPU. Default concurrency = 1 GPU operation at a time; configurable via `GPU_CONCURRENCY` env var. Surface the queue depth in the existing top-bar pill state so the user sees "Queued (1 ahead)".
-- _Acceptance:_ Two parallel sessions both kick off `/analyse` → second request waits in queue until first completes (no VRAM spill, no silent OOM). The top-bar pill in the waiting session shows "Queued". New server Vitest spec covers the semaphore behaviour; existing tests stay green.
-- _Key files:_ new `server/src/gpu/semaphore.ts`; `server/src/analyzer/ollama.ts` (wrap chat calls); `server/src/routes/sidecar-synth.ts` (wrap synth proxy); `src/components/layout.tsx` (consume queue-depth from existing pill polling).
-- _Depends on:_ none. Pairs with the worktree parallel-sessions tooling — without the semaphore, users must queue heavy operations by hand per the CONTRIBUTING.md "GPU + shared-resource caveats" note.
-- _Benefit (user):_ removes the silent VRAM-spillover-to-RAM slowdown when two sessions hit the analyzer or sidecar concurrently. Today a parallel run can take 5–10× longer than serial because both processes thrash the GPU.
-
-### 4. In-app LAN HTTPS banner under dev settings
+### 3. In-app LAN HTTPS banner under dev settings
 
 Source: net-new (2026-05-21). Plan 81 wave 1 / 2 deferred item.
 
@@ -98,7 +88,7 @@ Source: net-new (2026-05-21). Plan 81 wave 1 / 2 deferred item.
 - _Depends on:_ plan 81 shipped.
 - _Benefit (user):_ surfaces the LAN access flow inside the app instead of requiring the user to read terminal output. Especially valuable for users who first installed via the alpha release zip (no terminal interaction expected).
 
-### 5. Streaming audio for live playback during chapter generation
+### 4. Streaming audio for live playback during chapter generation
 
 Source: [`28-chapter-audio-format.md`](features/28-chapter-audio-format.md) follow-ups.
 
@@ -107,7 +97,7 @@ Source: [`28-chapter-audio-format.md`](features/28-chapter-audio-format.md) foll
 - _Key files:_ `server/src/tts/synthesise-chapter.ts`; `server/src/tts/mp3.ts`; `src/components/mini-player.tsx` for the MediaSource consumer.
 - _Benefit (user):_ "listen as it generates" is the magic moment audiobook tools sell on.
 
-### 6. ESLint 8 → 9 migration (drops the `inflight`/`glob@7`/`rimraf@3` deprecation chain)
+### 5. ESLint 8 → 9 migration (drops the `inflight`/`glob@7`/`rimraf@3` deprecation chain)
 
 Source: net-new (2026-05-22). Surfaced by the `deprecated inflight@1.0.6` warning on `npm install`; full triage in `~/.claude/plans/fancy-bouncing-lovelace.md`.
 
@@ -117,7 +107,7 @@ Source: net-new (2026-05-22). Surfaced by the `deprecated inflight@1.0.6` warnin
 - _Depends on:_ none structural. Pure tooling bump.
 - _Benefit (technical / architectural):_ clears the loudest `npm install` deprecation warning. Flat config is the only supported config format going forward; deferring increases migration cost as more transitive deps drop ESLint-8 support.
 
-### 7. Multer 1.x → 2.x security upgrade (server file uploads)
+### 6. Multer 1.x → 2.x security upgrade (server file uploads)
 
 Source: net-new (2026-05-22). Surfaced by `npm warn deprecated multer@1.4.5-lts.2: Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x.` on `npm install --prefix server`. Full deprecation audit notes in `~/.claude/plans/fancy-bouncing-lovelace.md`.
 
@@ -127,7 +117,7 @@ Source: net-new (2026-05-22). Surfaced by `npm warn deprecated multer@1.4.5-lts.
 - _Depends on:_ none. Pure dep bump + small middleware adaptation.
 - _Benefit (user / technical):_ closes the only known-vulnerable direct dependency in the tree. Multer 1.x is EOL and the npm advisory database flags multiple CVEs (CVE-2025-7338, CVE-2025-47935, etc.) that 2.x patches. Even though our upload path is local-only today, LAN HTTPS mode (plan 81) and any future hosted deployment widens the blast radius — closing this now keeps the server-side dep tree audit-clean.
 
-### 8. Merge journal for deterministic alias un-link
+### 7. Merge journal for deterministic alias un-link
 
 Source: plan 95 ship (2026-05-22) — Out of scope. PR [#142](https://github.com/dudarenok-maker/AudioBook-Generator/pull/142) shipped editable cast aliases with a Reattribute Lines modal that uses the preserved Phase-0a `chapterCast` as a lineage proxy to narrow the user's manual reattribution from "whole book" to "these N chapters." It works, but it's not deterministic — a chapter shows up if the alias was in its Phase-0a roster, even when the merge that put the alias on the source character happened mid-book and didn't actually rewrite any chapter-1 sentences. The user has to skim and reassign.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1483,6 +1483,32 @@ paths:
         '409':
           description: No M4B export ready for this book
 
+  /api/gpu/queue:
+    get:
+      summary: GPU semaphore state for the top-bar pill
+      operationId: getGpuQueueState
+      description: |
+        Returns the live state of the server's GpuSemaphore — the FIFO
+        queue that serialises GPU-heavy operations (Ollama analyzer
+        chat completions + sidecar /synthesize) so two parallel Claude
+        Code sessions don't fight over VRAM on an 8 GB GPU.
+
+        Polled by `useTtsLifecycle()` on the same 30 s cadence as
+        `/api/sidecar/health`. When `depth > 0` the frontend prefixes
+        the top-bar pill label with `"Queued (N ahead) ·"` so the
+        waiting session can see why it's not starting.
+
+        `max` is the configured `GPU_CONCURRENCY` ceiling (default 1,
+        configurable via server env var). `inFlight` is bounded by
+        `max`; `depth` is the number of waiters queued behind. The
+        endpoint is cheap (no I/O) and safe to poll.
+      responses:
+        '200':
+          description: GPU queue state
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/GpuQueueState' }
+
   /api/export/lan:
     get:
       summary: Enumerate the server's reachable LAN URLs
@@ -3092,3 +3118,20 @@ components:
         urls:
           type: array
           items: { type: string, description: "Reachable URL, e.g. 'http://192.168.1.42:8080' or 'https://192.168.1.42:8443'" }
+
+    GpuQueueState:
+      type: object
+      required: [depth, inFlight, max]
+      properties:
+        depth:
+          type: integer
+          minimum: 0
+          description: "Number of acquires waiting in the FIFO queue behind the in-flight ops. The frontend pill renders 'Queued (N ahead) ·' when this is > 0."
+        inFlight:
+          type: integer
+          minimum: 0
+          description: "Number of GPU ops currently holding a slot (analyzer + sidecar combined). Capped at `max`."
+        max:
+          type: integer
+          minimum: 1
+          description: "Configured concurrency ceiling — the GPU_CONCURRENCY env var (default 1). Bump only after measuring VRAM headroom on the target GPU."

--- a/server/.env.example
+++ b/server/.env.example
@@ -84,6 +84,9 @@ GEMINI_MODEL=gemma-4-31b-it
 #   GEMINI_RPD_GEMINI_3_1_FLASH_LITE=1000
 # Set TPM to `unlimited` for models with no per-minute token cap.
 
+# GPU arbitration — max concurrent GPU ops (analyzer + sidecar combined). Bump only after measuring VRAM headroom.
+GPU_CONCURRENCY=1
+
 # ---------------------------------------------------------------------------
 # TTS. Provider is now chosen per-request by the modelKey the UI sends.
 # Local engines (coqui-*, piper-*, kokoro-*) hit the sidecar at LOCAL_TTS_URL.

--- a/server/src/analyzer/ollama.ts
+++ b/server/src/analyzer/ollama.ts
@@ -13,6 +13,7 @@
 import { writeFile } from 'node:fs/promises';
 import type { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
+import { gpuSemaphore } from '../gpu/semaphore.js';
 import { writeInbox, errorPath, rawAttemptPath, type HandoffKey } from '../handoff/protocol.js';
 import {
   stage1Schema,
@@ -386,118 +387,132 @@ export class OllamaAnalyzer implements Analyzer {
       );
     }
 
-    let response: Response;
-    try {
-      response = await fetch(`${this.url}/api/chat`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-        signal,
-      });
-    } catch (err) {
-      if (signal?.aborted) {
-        throw new AnalysisAbortedError(`Ollama ${this.model} fetch aborted (client disconnected).`);
-      }
-      throw classifyConnectError(err, this.url);
-    }
-
-    if (!response.ok) {
-      /* Reachable but errored — hard-fail. Surface the body verbatim so
-         operator can diagnose ("model not found", "invalid format", …). */
-      const text = await response.text().catch(() => '');
-      throw new Error(
-        `Ollama ${this.url} returned ${response.status} ${response.statusText}: ${text.slice(0, 500)}`,
-      );
-    }
-
-    if (!response.body) {
-      throw new Error(`Ollama ${this.url} returned an empty body (no readable stream).`);
-    }
-
-    const reader = response.body.getReader();
-    const decoder = new TextDecoder('utf-8');
-    let buf = ''; // assembled assistant content
-    let lineBuf = ''; // partial NDJSON line carried across reads
-    let firstByteSeen = false;
-    const start = Date.now();
-    let lastChunkAt = start;
+    /* GPU arbitration — acquire a slot before the fetch so two parallel
+       Claude Code sessions don't fight over VRAM on an 8 GB GPU. The
+       slot is held across the full streamed response (fetch + read
+       loop) and released in the outer `finally` below; that covers
+       abort paths, fetch-throws, non-2xx responses, and mid-stream
+       errors equally well. See server/src/gpu/semaphore.ts. */
+    const releaseGpu = await gpuSemaphore.acquire();
 
     try {
-      for (;;) {
+      let response: Response;
+      try {
+        response = await fetch(`${this.url}/api/chat`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+          signal,
+        });
+      } catch (err) {
         if (signal?.aborted) {
-          /* Caller (the route's req.on('close') handler) aborted while we
-             were mid-stream. Tear down cleanly rather than burning more
-             tokens on output the client will never see. */
           throw new AnalysisAbortedError(
-            `Ollama ${this.model} stream aborted (client disconnected).`,
+            `Ollama ${this.model} fetch aborted (client disconnected).`,
           );
         }
-        let result: { done: boolean; value?: Uint8Array };
-        try {
-          result = await reader.read();
-        } catch (err) {
+        throw classifyConnectError(err, this.url);
+      }
+
+      if (!response.ok) {
+        /* Reachable but errored — hard-fail. Surface the body verbatim so
+           operator can diagnose ("model not found", "invalid format", …). */
+        const text = await response.text().catch(() => '');
+        throw new Error(
+          `Ollama ${this.url} returned ${response.status} ${response.statusText}: ${text.slice(0, 500)}`,
+        );
+      }
+
+      if (!response.body) {
+        throw new Error(`Ollama ${this.url} returned an empty body (no readable stream).`);
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder('utf-8');
+      let buf = ''; // assembled assistant content
+      let lineBuf = ''; // partial NDJSON line carried across reads
+      let firstByteSeen = false;
+      const start = Date.now();
+      let lastChunkAt = start;
+
+      try {
+        for (;;) {
           if (signal?.aborted) {
+            /* Caller (the route's req.on('close') handler) aborted while we
+               were mid-stream. Tear down cleanly rather than burning more
+               tokens on output the client will never see. */
             throw new AnalysisAbortedError(
               `Ollama ${this.model} stream aborted (client disconnected).`,
             );
           }
-          /* A connection drop mid-stream — daemon was up, then went away.
-             If we've already seen bytes, this is a partial-stream failure
-             (hard-fail). If we haven't, treat as unreachable. */
-          if (!firstByteSeen) throw classifyConnectError(err, this.url);
-          throw new Error(`Ollama ${this.url} stream interrupted: ${(err as Error).message}`);
-        }
-        if (result.done) break;
-        firstByteSeen = true;
-        lineBuf += decoder.decode(result.value ?? new Uint8Array(), { stream: true });
-
-        let nl: number;
-        while ((nl = lineBuf.indexOf('\n')) >= 0) {
-          const line = lineBuf.slice(0, nl).trim();
-          lineBuf = lineBuf.slice(nl + 1);
-          if (!line) continue;
-
-          let parsed: { message?: { content?: string }; done?: boolean; error?: string };
+          let result: { done: boolean; value?: Uint8Array };
           try {
-            parsed = JSON.parse(line);
-          } catch {
-            /* Skip a corrupted NDJSON line rather than abort the stream —
-               Ollama very occasionally emits keep-alive noise. If the whole
-               stream produces no content, the empty-buffer check below
-               will hard-fail. */
-            continue;
+            result = await reader.read();
+          } catch (err) {
+            if (signal?.aborted) {
+              throw new AnalysisAbortedError(
+                `Ollama ${this.model} stream aborted (client disconnected).`,
+              );
+            }
+            /* A connection drop mid-stream — daemon was up, then went away.
+               If we've already seen bytes, this is a partial-stream failure
+               (hard-fail). If we haven't, treat as unreachable. */
+            if (!firstByteSeen) throw classifyConnectError(err, this.url);
+            throw new Error(`Ollama ${this.url} stream interrupted: ${(err as Error).message}`);
           }
+          if (result.done) break;
+          firstByteSeen = true;
+          lineBuf += decoder.decode(result.value ?? new Uint8Array(), { stream: true });
 
-          if (parsed.error) {
-            throw new Error(`Ollama ${this.url} stream error: ${parsed.error}`);
-          }
+          let nl: number;
+          while ((nl = lineBuf.indexOf('\n')) >= 0) {
+            const line = lineBuf.slice(0, nl).trim();
+            lineBuf = lineBuf.slice(nl + 1);
+            if (!line) continue;
 
-          const piece = parsed.message?.content;
-          if (piece) {
-            buf += piece;
-            const now = Date.now();
-            onChunk?.({
-              receivedBytes: buf.length,
-              receivedText: buf,
-              sinceLastChunkMs: now - lastChunkAt,
-              elapsedMs: now - start,
-            });
-            lastChunkAt = now;
+            let parsed: { message?: { content?: string }; done?: boolean; error?: string };
+            try {
+              parsed = JSON.parse(line);
+            } catch {
+              /* Skip a corrupted NDJSON line rather than abort the stream —
+                 Ollama very occasionally emits keep-alive noise. If the whole
+                 stream produces no content, the empty-buffer check below
+                 will hard-fail. */
+              continue;
+            }
+
+            if (parsed.error) {
+              throw new Error(`Ollama ${this.url} stream error: ${parsed.error}`);
+            }
+
+            const piece = parsed.message?.content;
+            if (piece) {
+              buf += piece;
+              const now = Date.now();
+              onChunk?.({
+                receivedBytes: buf.length,
+                receivedText: buf,
+                sinceLastChunkMs: now - lastChunkAt,
+                elapsedMs: now - start,
+              });
+              lastChunkAt = now;
+            }
           }
         }
+      } finally {
+        try {
+          reader.releaseLock();
+        } catch {
+          /* already released */
+        }
       }
-    } finally {
-      try {
-        reader.releaseLock();
-      } catch {
-        /* already released */
-      }
-    }
 
-    if (!buf) {
-      throw new Error(`Ollama ${this.model} returned an empty response.`);
+      if (!buf) {
+        throw new Error(`Ollama ${this.model} returned an empty response.`);
+      }
+      return buf;
+    } finally {
+      releaseGpu();
     }
-    return buf;
   }
 }
 

--- a/server/src/gpu/semaphore.test.ts
+++ b/server/src/gpu/semaphore.test.ts
@@ -1,0 +1,156 @@
+/* GpuSemaphore — FIFO arbitration around the analyzer + sidecar GPU
+   call sites. Three contract guarantees this spec pins:
+
+   1. Capacity:    `new GpuSemaphore(2)` admits two acquires concurrently
+                   and forces the third to wait until one releases.
+   2. FIFO order:  acquires that block on a full semaphore release in the
+                   order they queued — A finishes, B runs, C waits; B
+                   releases, C runs; etc.
+   3. Queue depth: `queueDepth` reflects waiters not yet running and
+                   ticks down on every release while waiters exist.
+
+   These guarantees feed the frontend pill's "Queued (N ahead) ·"
+   prefix (see src/lib/use-tts-lifecycle.ts + src/components/layout.tsx),
+   so a regression in any of them silently breaks the parallel-sessions
+   UX. */
+
+import { describe, it, expect } from 'vitest';
+import { GpuSemaphore } from './semaphore.js';
+
+/** Helper: a queued microtask flush, so a Promise resolved by a
+    release fn settles before the next assertion. Cheaper than waiting
+    on a setTimeout(0) shim — Vitest's default node env executes
+    microtasks synchronously after `await Promise.resolve()`. */
+async function flush(): Promise<void> {
+  /* Two micro-ticks: one for the release-fn shift(), one for the
+     newly-resolved waiter's `.then(...)` continuation to run. */
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('GpuSemaphore', () => {
+  it('admits up to `max` acquires concurrently and queues the rest', async () => {
+    const sem = new GpuSemaphore(2);
+
+    /* First two acquires resolve immediately — synchronous slot grab. */
+    const releaseA = await sem.acquire();
+    const releaseB = await sem.acquire();
+    expect(sem.inFlight).toBe(2);
+    expect(sem.queueDepth).toBe(0);
+
+    /* Third acquire queues; tracked but not yet resolved. */
+    let cResolved = false;
+    const cPromise = sem.acquire().then((rel) => {
+      cResolved = true;
+      return rel;
+    });
+    await flush();
+    expect(cResolved).toBe(false);
+    expect(sem.inFlight).toBe(2);
+    expect(sem.queueDepth).toBe(1);
+
+    /* Releasing A passes the slot to C without bumping the in-flight
+       count (still 2 — A's slot is now C's). */
+    releaseA();
+    await flush();
+    expect(cResolved).toBe(true);
+    expect(sem.inFlight).toBe(2);
+    expect(sem.queueDepth).toBe(0);
+
+    /* Drain: release B + C; the counter must end at 0. */
+    const releaseC = await cPromise;
+    releaseB();
+    releaseC();
+    expect(sem.inFlight).toBe(0);
+    expect(sem.queueDepth).toBe(0);
+  });
+
+  it('serialises max=1 acquires in strict FIFO order', async () => {
+    const sem = new GpuSemaphore(1);
+    const completed: string[] = [];
+
+    /* Kick off a worker that acquires, records its label, then
+       releases on a follow-up tick. Returned promise resolves when the
+       worker has fully released its slot. */
+    const runWorker = async (label: string): Promise<void> => {
+      const release = await sem.acquire();
+      completed.push(label);
+      /* Yield a microtask before releasing so the next-in-line waiter
+         visibly sequences after this one rather than racing. */
+      await Promise.resolve();
+      release();
+    };
+
+    /* A acquires immediately (slot was empty); B/C/D queue behind it. */
+    const aDone = runWorker('A');
+    const bDone = runWorker('B');
+    const cDone = runWorker('C');
+    const dDone = runWorker('D');
+
+    await Promise.all([aDone, bDone, cDone, dDone]);
+    expect(completed).toEqual(['A', 'B', 'C', 'D']);
+  });
+
+  it('reports queue depth that ticks down on each release', async () => {
+    const sem = new GpuSemaphore(1);
+
+    const releaseA = await sem.acquire();
+    expect(sem.inFlight).toBe(1);
+    expect(sem.queueDepth).toBe(0);
+
+    /* Two waiters pile up behind A. Resolved-tracking flags so we can
+       check that each waiter only runs when the slot is actually
+       handed to it. */
+    let bRunning = false;
+    let cRunning = false;
+    const bPromise = sem.acquire().then((rel) => {
+      bRunning = true;
+      return rel;
+    });
+    const cPromise = sem.acquire().then((rel) => {
+      cRunning = true;
+      return rel;
+    });
+    await flush();
+    expect(sem.queueDepth).toBe(2);
+    expect(bRunning).toBe(false);
+    expect(cRunning).toBe(false);
+
+    /* Release A → B advances to running, depth ticks from 2 to 1. */
+    releaseA();
+    await flush();
+    expect(bRunning).toBe(true);
+    expect(cRunning).toBe(false);
+    expect(sem.queueDepth).toBe(1);
+
+    /* Release B → C advances, depth → 0. */
+    const releaseB = await bPromise;
+    releaseB();
+    await flush();
+    expect(cRunning).toBe(true);
+    expect(sem.queueDepth).toBe(0);
+
+    /* Drain. */
+    const releaseC = await cPromise;
+    releaseC();
+    expect(sem.inFlight).toBe(0);
+  });
+
+  it('treats double-release as a no-op so finally blocks are safe to chain', async () => {
+    /* Both call sites invoke release() inside a try/finally; a defensive
+       second call (e.g. the caller wraps acquire() in a helper that also
+       releases) must not double-count. Without this guard a max=1
+       semaphore would over-release and never block, defeating the
+       arbitration. */
+    const sem = new GpuSemaphore(1);
+    const release = await sem.acquire();
+    release();
+    release();
+    expect(sem.inFlight).toBe(0);
+
+    /* The slot is genuinely free — next acquire resolves immediately. */
+    const next = await sem.acquire();
+    expect(sem.inFlight).toBe(1);
+    next();
+  });
+});

--- a/server/src/gpu/semaphore.ts
+++ b/server/src/gpu/semaphore.ts
@@ -1,0 +1,99 @@
+/* GpuSemaphore — single-instance FIFO arbitration around heavy-GPU work.
+   Two parallel Claude Code sessions on the same dev box can both kick off
+   `/analyse` (Ollama) or `/synthesize` (TTS sidecar) at once; on an 8 GB
+   GPU the second op spills into shared system RAM and BOTH runs slow by
+   5-10x. Serialising at the Node layer keeps the GPU saturated by one op
+   at a time and lets the waiting session show a "Queued (N ahead)" pill
+   instead of silently thrashing.
+
+   Hand-rolled (no p-limit / p-queue dep) — 40 lines isn't worth a new
+   transitive tree, and the contract is small: acquire returns a release
+   function the caller invokes in `finally`. FIFO order is preserved by
+   shift()-ing the queue head when a release fires while waiters are
+   pending. Concurrency cap reads from `GPU_CONCURRENCY` at module load,
+   matching `rate-limit.ts`'s env-at-load idiom — bump it only after
+   measuring VRAM headroom on the target GPU.
+
+   Wired into:
+     - server/src/analyzer/ollama.ts  — wraps the /api/chat fetch.
+     - server/src/tts/sidecar.ts      — wraps the /synthesize fetch +
+                                        arrayBuffer() read so a single
+                                        release covers the full GPU op.
+     - server/src/routes/gpu-queue.ts — exposes inFlight + depth to the
+                                        frontend pill via GET /api/gpu/queue. */
+
+type Waiter = { resolve: (release: () => void) => void };
+
+export class GpuSemaphore {
+  private current = 0;
+  private readonly max: number;
+  private readonly queue: Waiter[] = [];
+
+  constructor(max: number) {
+    /* Clamp to >= 1 — a max of 0 would deadlock every caller, and
+       negative values are nonsensical. Defensive against bad env vars. */
+    this.max = Math.max(1, Math.floor(max));
+  }
+
+  /** Acquire one GPU slot. Resolves with a single-use release function;
+      the caller MUST invoke it (typically inside a `finally`) so a
+      waiter — or, if none are queued, the counter — can advance. */
+  async acquire(): Promise<() => void> {
+    if (this.current < this.max) {
+      this.current += 1;
+      return this.makeRelease();
+    }
+    return new Promise<() => void>((resolve) => {
+      this.queue.push({ resolve: (release) => resolve(release) });
+    });
+  }
+
+  /** Build a fresh single-use release function for the slot that just
+      went in-flight. When invoked, either hands the slot to the next
+      waiter (with their own fresh release) or decrements the counter
+      so the next `acquire()` call can short-circuit. */
+  private makeRelease(): () => void {
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      const next = this.queue.shift();
+      if (next) {
+        /* Slot stays in-flight — `current` doesn't change. Hand the
+           waiter a NEW release function so they get their own
+           single-use semantics. */
+        next.resolve(this.makeRelease());
+      } else {
+        this.current -= 1;
+      }
+    };
+  }
+
+  /** Number of acquires waiting in the FIFO queue. Drives the
+      "Queued (N ahead) ·" pill prefix in the frontend layout. */
+  get queueDepth(): number {
+    return this.queue.length;
+  }
+
+  /** Number of acquires currently holding a slot (capped at `max`).
+      Exposed so the gpu-queue route can surface the full triple
+      (depth, inFlight, max) for diagnostics. */
+  get inFlight(): number {
+    return this.current;
+  }
+
+  /** Configured concurrency cap. */
+  get maxConcurrency(): number {
+    return this.max;
+  }
+}
+
+/* Singleton — both call sites (analyzer + sidecar) import this so a
+   queue depth of 1 in the analyzer is visible to a sidecar caller and
+   vice versa. `GPU_CONCURRENCY` env var lets an operator bump the cap
+   once they've measured the GPU can survive two ops simultaneously;
+   default 1 is the conservative pick for an 8 GB box. */
+const RAW_MAX = Number(process.env.GPU_CONCURRENCY ?? '1');
+export const gpuSemaphore = new GpuSemaphore(
+  Number.isFinite(RAW_MAX) && RAW_MAX > 0 ? RAW_MAX : 1,
+);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -53,6 +53,7 @@ import { shareRouter, sharePublicRouter } from './routes/share.js';
 import { revisionsRouter, revisionsBulkRouter } from './routes/revisions.js';
 import { sidecarHealthRouter } from './routes/sidecar-health.js';
 import { ollamaHealthRouter } from './routes/ollama-health.js';
+import { gpuQueueRouter } from './routes/gpu-queue.js';
 import { workspaceRouter } from './routes/workspace.js';
 import { userSettingsRouter } from './routes/user-settings.js';
 import { runCatalogAudit } from './tts/coqui-catalog-audit.js';
@@ -166,6 +167,7 @@ app.use('/api/voices', voicesRouter); // mounts GET / + PUT /:voiceId/pin
 app.use('/api/voices', voiceSampleRouter); // mounts POST /:voiceId/sample
 app.use('/api/sidecar', sidecarHealthRouter); // mounts GET /health
 app.use('/api/ollama', ollamaHealthRouter); // mounts GET /health (local LLM analyzer)
+app.use('/api/gpu', gpuQueueRouter); // mounts GET /queue (semaphore depth + inFlight for the top-bar pill)
 
 /* Production-mode frontend serving. Helper resolves whether to mount based
    on NODE_ENV=production OR the existence of dist/index.html. Mounted AFTER

--- a/server/src/routes/gpu-queue.ts
+++ b/server/src/routes/gpu-queue.ts
@@ -1,0 +1,23 @@
+/* GET /api/gpu/queue — surfaces the GpuSemaphore's current state so the
+   frontend top-bar pill can prefix "Queued (N ahead) ·" when a session
+   is waiting behind another's analyzer or sidecar call. Polled on the
+   same 30 s cadence as /api/sidecar/health by useTtsLifecycle().
+
+   Concerns are deliberately split from /api/sidecar/health: the
+   semaphore covers BOTH analyzer (Ollama chat) and sidecar
+   (/synthesize) ops, so a sidecar-health response can't represent its
+   full state. A separate endpoint keeps each surface answering exactly
+   one question. */
+
+import { Router, type Request, type Response } from 'express';
+import { gpuSemaphore } from '../gpu/semaphore.js';
+
+export const gpuQueueRouter = Router();
+
+gpuQueueRouter.get('/queue', (_req: Request, res: Response) => {
+  res.json({
+    depth: gpuSemaphore.queueDepth,
+    inFlight: gpuSemaphore.inFlight,
+    max: gpuSemaphore.maxConcurrency,
+  });
+});

--- a/server/src/tts/sidecar.ts
+++ b/server/src/tts/sidecar.ts
@@ -11,6 +11,7 @@
 
 import type { SynthesizeInput, SynthesizeOutput, TtsProvider, TtsEngine } from './index.js';
 import { sidecarModelId } from './index.js';
+import { gpuSemaphore } from '../gpu/semaphore.js';
 
 interface SidecarOptions {
   url: string;
@@ -39,85 +40,97 @@ export class SidecarTtsProvider implements TtsProvider {
       text,
     });
 
-    let response: Response;
+    /* GPU arbitration — acquire a slot before the fetch so the synth
+       doesn't race the analyzer (or another concurrent synth) for VRAM
+       on an 8 GB GPU. Held across the buffered arrayBuffer() read
+       below; the sidecar response is NOT streaming, so a single
+       release after the read covers the whole GPU op. See
+       server/src/gpu/semaphore.ts. */
+    const releaseGpu = await gpuSemaphore.acquire();
+
     try {
-      response = await fetch(`${this.url}/synthesize`, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body,
-        signal,
-      });
-    } catch (e) {
-      /* AbortError is the caller cancelling on purpose — let it propagate so
-         the outer handler can shut down cleanly instead of mistaking it for
-         a sidecar-down failure. */
-      if ((e as { name?: string })?.name === 'AbortError') throw e;
-      const msg = (e as Error).message || String(e);
-      /* Node's fetch surfaces ECONNREFUSED as `fetch failed` with a cause.
-         Give the user the one piece of info that actually unblocks them.
-         Annotated `transient: true` so the auto-retry wrapper in
-         `synthesise-chapter.ts` can absorb a brief network blip (e.g. the
-         sidecar restarting after a CUDA poison) without wedging the queue.
-         Genuine "sidecar isn't running" → all retries also fail with the
-         same message, so the user-facing error text is unchanged. */
-      throw Object.assign(
-        new Error(
-          `Local TTS sidecar not reachable at ${this.url}. Start it with \`npm run tts:sidecar\`. (${msg})`,
-        ),
-        { transient: true as const, cause: 'network' as const },
-      );
+      let response: Response;
+      try {
+        response = await fetch(`${this.url}/synthesize`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body,
+          signal,
+        });
+      } catch (e) {
+        /* AbortError is the caller cancelling on purpose — let it propagate so
+           the outer handler can shut down cleanly instead of mistaking it for
+           a sidecar-down failure. */
+        if ((e as { name?: string })?.name === 'AbortError') throw e;
+        const msg = (e as Error).message || String(e);
+        /* Node's fetch surfaces ECONNREFUSED as `fetch failed` with a cause.
+           Give the user the one piece of info that actually unblocks them.
+           Annotated `transient: true` so the auto-retry wrapper in
+           `synthesise-chapter.ts` can absorb a brief network blip (e.g. the
+           sidecar restarting after a CUDA poison) without wedging the queue.
+           Genuine "sidecar isn't running" → all retries also fail with the
+           same message, so the user-facing error text is unchanged. */
+        throw Object.assign(
+          new Error(
+            `Local TTS sidecar not reachable at ${this.url}. Start it with \`npm run tts:sidecar\`. (${msg})`,
+          ),
+          { transient: true as const, cause: 'network' as const },
+        );
+      }
+
+      if (!response.ok) {
+        const bodyText = await safeReadText(response);
+        const trimmed = bodyText.length > 240 ? `${bodyText.slice(0, 240)}…` : bodyText;
+        /* Classify for the retry wrapper.
+           - `poisoned: true` body → the sidecar's CUDA context is corrupted
+             for the lifetime of that process; only a restart fixes it. Retry
+             would just replay the fast-fail 503 — surface immediately so the
+             UI can render the "needs restart" banner.
+           - Other 5xx → transient. The most common shape (503 during model
+             load on first call, 502 from a reverse proxy mid-restart, 504
+             from a hung connection) recovers in ≤ 2.5 s of backoff.
+           - 408 Request Timeout → transient.
+           - 4xx other than 408 → client-side; retry won't help. */
+        const poisoned = isPoisonedBody(bodyText);
+        const transient =
+          !poisoned && (response.status === 408 || (response.status >= 500 && response.status < 600));
+        throw Object.assign(
+          new Error(
+            `Local TTS sidecar returned ${response.status}: ${trimmed || response.statusText}`,
+          ),
+          { transient, status: response.status, poisoned },
+        );
+      }
+
+      const buf = Buffer.from(await response.arrayBuffer());
+      if (buf.length === 0) {
+        throw new Error('Local TTS sidecar returned an empty audio body.');
+      }
+
+      const mimeType = response.headers.get('content-type') ?? 'audio/L16;codec=pcm;rate=24000';
+      const headerRate = response.headers.get('x-sample-rate');
+      const sampleRate = headerRate ? Number(headerRate) : parseRateFromMime(mimeType);
+
+      /* When the sidecar's speaker manifest doesn't contain the voice we
+         asked for, it substitutes a safe fallback and tells us via this
+         header. The synth still completed (so we don't fail the chapter),
+         but the user's chapter ends up speaking in a different voice than
+         the cast view shows. Log loudly so we can fix server/src/tts/
+         voice-mapping.ts when this happens — the catalog and the model's
+         actual speaker list have drifted. */
+      const substitutedFrom = response.headers.get('x-voice-substituted-from');
+      if (substitutedFrom) {
+        console.warn(
+          `[tts] Sidecar substituted voice: requested "${substitutedFrom}" not in XTTS v2 manifest. ` +
+            `Update server/src/tts/voice-mapping.ts to remove this name. ` +
+            `Run \`curl ${this.url}/speakers\` to see the model's actual speaker list.`,
+        );
+      }
+
+      return { pcm: buf, sampleRate, mimeType };
+    } finally {
+      releaseGpu();
     }
-
-    if (!response.ok) {
-      const bodyText = await safeReadText(response);
-      const trimmed = bodyText.length > 240 ? `${bodyText.slice(0, 240)}…` : bodyText;
-      /* Classify for the retry wrapper.
-         - `poisoned: true` body → the sidecar's CUDA context is corrupted
-           for the lifetime of that process; only a restart fixes it. Retry
-           would just replay the fast-fail 503 — surface immediately so the
-           UI can render the "needs restart" banner.
-         - Other 5xx → transient. The most common shape (503 during model
-           load on first call, 502 from a reverse proxy mid-restart, 504
-           from a hung connection) recovers in ≤ 2.5 s of backoff.
-         - 408 Request Timeout → transient.
-         - 4xx other than 408 → client-side; retry won't help. */
-      const poisoned = isPoisonedBody(bodyText);
-      const transient =
-        !poisoned && (response.status === 408 || (response.status >= 500 && response.status < 600));
-      throw Object.assign(
-        new Error(
-          `Local TTS sidecar returned ${response.status}: ${trimmed || response.statusText}`,
-        ),
-        { transient, status: response.status, poisoned },
-      );
-    }
-
-    const buf = Buffer.from(await response.arrayBuffer());
-    if (buf.length === 0) {
-      throw new Error('Local TTS sidecar returned an empty audio body.');
-    }
-
-    const mimeType = response.headers.get('content-type') ?? 'audio/L16;codec=pcm;rate=24000';
-    const headerRate = response.headers.get('x-sample-rate');
-    const sampleRate = headerRate ? Number(headerRate) : parseRateFromMime(mimeType);
-
-    /* When the sidecar's speaker manifest doesn't contain the voice we
-       asked for, it substitutes a safe fallback and tells us via this
-       header. The synth still completed (so we don't fail the chapter),
-       but the user's chapter ends up speaking in a different voice than
-       the cast view shows. Log loudly so we can fix server/src/tts/
-       voice-mapping.ts when this happens — the catalog and the model's
-       actual speaker list have drifted. */
-    const substitutedFrom = response.headers.get('x-voice-substituted-from');
-    if (substitutedFrom) {
-      console.warn(
-        `[tts] Sidecar substituted voice: requested "${substitutedFrom}" not in XTTS v2 manifest. ` +
-          `Update server/src/tts/voice-mapping.ts to remove this name. ` +
-          `Run \`curl ${this.url}/speakers\` to see the model's actual speaker list.`,
-      );
-    }
-
-    return { pcm: buf, sampleRate, mimeType };
   }
 }
 

--- a/src/components/layout.test.tsx
+++ b/src/components/layout.test.tsx
@@ -62,6 +62,11 @@ vi.mock('../lib/api', () => ({
     /* useTtsLifecycle polls /health on mount; resolve to unreachable so
        no pending pill state lands. */
     getSidecarHealth: vi.fn(async () => ({ status: 'unreachable', url: '(test)' })),
+    /* useTtsLifecycle also polls /api/gpu/queue on the same cadence (the
+       GPU semaphore depth that drives the "Queued (N ahead) ·" pill
+       prefix). Stub to an empty queue so the pill renders without the
+       prefix in these tests. */
+    getGpuQueueState: vi.fn(async () => ({ depth: 0, inFlight: 0, max: 1 })),
     /* Voice matching fires on the confirm stage only; we render at
        'ready' here so it shouldn't trigger, but keep a stub so any
        drift in that guard doesn't crash the test. */

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -703,8 +703,26 @@ export function Layout() {
      room for per-character engine overrides without churning consumers.
      Gemini has no Stop pill (cloud, no VRAM to free). */
   const enginesInUse = useAppSelector(selectEnginesInUse);
+  /* GPU semaphore queue badge — prefixes the TTS pill cluster with
+     "Queued (N ahead) ·" when this session is waiting behind another
+     session's analyzer / sidecar call. Hidden when depth is 0 or
+     undefined (older server that doesn't expose /api/gpu/queue). The
+     server-side semaphore in server/src/gpu/semaphore.ts serialises
+     GPU-heavy ops at GPU_CONCURRENCY=1 so two parallel Claude Code
+     sessions don't thrash an 8 GB GPU's VRAM. */
+  const gpuQueueDepth = ttsLifecycle.gpuQueueDepth;
+  const showGpuQueueBadge =
+    typeof gpuQueueDepth === 'number' && gpuQueueDepth > 0;
   const ttsPillElement = showGlobalTtsPill ? (
     <span className="inline-flex items-center gap-2 flex-wrap">
+      {showGpuQueueBadge && (
+        <span
+          className="text-xs text-ink/70 tabular-nums"
+          aria-label={`GPU queue: ${gpuQueueDepth} ahead`}
+        >
+          Queued ({gpuQueueDepth} ahead) ·
+        </span>
+      )}
       {enginesInUse.has('kokoro') && (
         <ModelControlPill
           kind="tts"

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1084,6 +1084,39 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/gpu/queue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * GPU semaphore state for the top-bar pill
+         * @description Returns the live state of the server's GpuSemaphore — the FIFO
+         *     queue that serialises GPU-heavy operations (Ollama analyzer
+         *     chat completions + sidecar /synthesize) so two parallel Claude
+         *     Code sessions don't fight over VRAM on an 8 GB GPU.
+         *
+         *     Polled by `useTtsLifecycle()` on the same 30 s cadence as
+         *     `/api/sidecar/health`. When `depth > 0` the frontend prefixes
+         *     the top-bar pill label with `"Queued (N ahead) ·"` so the
+         *     waiting session can see why it's not starting.
+         *
+         *     `max` is the configured `GPU_CONCURRENCY` ceiling (default 1,
+         *     configurable via server env var). `inFlight` is bounded by
+         *     `max`; `depth` is the number of waiters queued behind. The
+         *     endpoint is cheap (no I/O) and safe to poll.
+         */
+        get: operations["getGpuQueueState"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/export/lan": {
         parameters: {
             query?: never;
@@ -2252,6 +2285,14 @@ export interface components {
              */
             protocol: "http" | "https";
             urls: string[];
+        };
+        GpuQueueState: {
+            /** @description Number of acquires waiting in the FIFO queue behind the in-flight ops. The frontend pill renders 'Queued (N ahead) ·' when this is > 0. */
+            depth: number;
+            /** @description Number of GPU ops currently holding a slot (analyzer + sidecar combined). Capped at `max`. */
+            inFlight: number;
+            /** @description Configured concurrency ceiling — the GPU_CONCURRENCY env var (default 1). Bump only after measuring VRAM headroom on the target GPU. */
+            max: number;
         };
     };
     responses: never;
@@ -3947,6 +3988,26 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    getGpuQueueState: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description GPU queue state */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GpuQueueState"];
+                };
             };
         };
     };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3388,6 +3388,41 @@ async function mockGetExportLanUrls(): Promise<ExportLanInfo> {
   return { urls: ['http://192.168.1.42:8080'], port: 8080, protocol: 'http' };
 }
 
+/* GPU semaphore state — surfaces the depth/inFlight/max triple from the
+   server's GpuSemaphore so the top-bar pill can prefix "Queued (N ahead) ·"
+   when a session is waiting behind another's analyzer / sidecar call.
+   See server/src/gpu/semaphore.ts + server/src/routes/gpu-queue.ts. */
+export interface GpuQueueState {
+  /** Number of acquires waiting in the FIFO queue behind in-flight ops. */
+  depth: number;
+  /** Number of GPU ops currently holding a slot (analyzer + sidecar combined). */
+  inFlight: number;
+  /** Configured concurrency ceiling (GPU_CONCURRENCY env var, default 1). */
+  max: number;
+}
+
+async function realGetGpuQueueState(): Promise<GpuQueueState> {
+  /* Permissive: a 404 / 5xx (older server, partial deploy, hot-reload
+     mid-poll) shouldn't surface as a user-visible failure. The
+     useTtsLifecycle caller treats a rejected promise as "clear the
+     depth" — the pill drops back to its default label. */
+  const res = await fetch('/api/gpu/queue');
+  if (!res.ok) {
+    throw new Error(`GPU queue probe HTTP ${res.status}`);
+  }
+  return (await res.json()) as GpuQueueState;
+}
+
+async function mockGetGpuQueueState(): Promise<GpuQueueState> {
+  /* Mocks don't run a real semaphore — generation is local + synchronous
+     under VITE_USE_MOCKS=true, so the queue is always empty. The shape
+     stays contract-correct so any future visual regression on the pill's
+     "Queued (N ahead) ·" prefix can be exercised by stubbing the api
+     surface in tests. */
+  await wait(20);
+  return { depth: 0, inFlight: 0, max: 1 };
+}
+
 async function mockGetSidecarHealth(): Promise<SidecarHealth> {
   /* Mocks pretend everything's healthy — generation is local and synchronous
      under VITE_USE_MOCKS=true, so there's no real sidecar to probe. */
@@ -3568,6 +3603,7 @@ const real = {
   pauseGeneration: realPauseGeneration,
   pauseAnalysis: realPauseAnalysis,
   getSidecarHealth: realGetSidecarHealth,
+  getGpuQueueState: realGetGpuQueueState,
   getOllamaHealth: realGetOllamaHealth,
   loadSidecar: realLoadSidecar,
   unloadSidecar: realUnloadSidecar,
@@ -3742,6 +3778,7 @@ const mock = {
   pauseGeneration: mockPauseGeneration,
   pauseAnalysis: mockPauseAnalysis,
   getSidecarHealth: mockGetSidecarHealth,
+  getGpuQueueState: mockGetGpuQueueState,
   getOllamaHealth: mockGetOllamaHealth,
   loadSidecar: mockLoadSidecar,
   unloadSidecar: mockUnloadSidecar,

--- a/src/lib/use-tts-lifecycle.test.ts
+++ b/src/lib/use-tts-lifecycle.test.ts
@@ -18,6 +18,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const { mocks } = vi.hoisted(() => ({
   mocks: {
     getSidecarHealth: vi.fn(),
+    getGpuQueueState: vi.fn(),
     getOllamaHealth: vi.fn(),
     unloadAnalyzer: vi.fn(),
     loadSidecar: vi.fn(),
@@ -38,6 +39,10 @@ beforeEach(() => {
     kokoroLoaded: false,
     kokoroLoading: false,
   });
+  /* GPU semaphore queue probe — runs on the same 30 s tick as /health.
+     Default to an empty queue so the "Queued (N ahead) ·" pill prefix
+     stays hidden in tests that don't exercise contention. */
+  mocks.getGpuQueueState.mockResolvedValue({ depth: 0, inFlight: 0, max: 1 });
   mocks.getOllamaHealth.mockResolvedValue({
     status: 'reachable',
     modelResident: true,
@@ -249,6 +254,31 @@ describe('useTtsLifecycle', () => {
       resolveUnload({ status: 'idle' });
       await stopPromise;
     });
+  });
+
+  it('exposes the GPU semaphore queue depth from /api/gpu/queue on the same tick', async () => {
+    /* Hook polls /api/gpu/queue alongside /api/sidecar/health so the
+       top-bar pill can prefix "Queued (N ahead) ·". When depth > 0 the
+       hook surfaces it on TtsLifecycle.gpuQueueDepth; consumer
+       (layout.tsx) decides whether to render the prefix. */
+    mocks.getGpuQueueState.mockResolvedValueOnce({ depth: 2, inFlight: 1, max: 1 });
+    const { result } = renderHook(() => useTtsLifecycle());
+    await waitFor(() => expect(result.current.gpuQueueDepth).toBe(2));
+    expect(result.current.gpuInFlight).toBe(1);
+  });
+
+  it('clears gpuQueueDepth to undefined when /api/gpu/queue rejects (older server graceful-degrade)', async () => {
+    /* A partial deploy where the Node server is older than the
+       frontend (no /api/gpu/queue route) shouldn't surface as a
+       user-facing error — the pill just drops back to its default
+       label. */
+    mocks.getGpuQueueState.mockRejectedValueOnce(new Error('HTTP 404'));
+    const { result } = renderHook(() => useTtsLifecycle());
+    /* First wait for the sidecar probe to settle so the hook is past
+       its initial mount before we assert on the queue field. */
+    await waitFor(() => expect(result.current.coqui.state).toBe('idle'));
+    expect(result.current.gpuQueueDepth).toBeUndefined();
+    expect(result.current.gpuInFlight).toBeUndefined();
   });
 
   it('dismissNotices clears both banner strings without calling the API', async () => {

--- a/src/lib/use-tts-lifecycle.ts
+++ b/src/lib/use-tts-lifecycle.ts
@@ -24,7 +24,7 @@
    warm independently. Plan 30 explicitly preserves that path. */
 
 import { useEffect, useState } from 'react';
-import { api, type SidecarHealth } from './api';
+import { api, type SidecarHealth, type GpuQueueState } from './api';
 import type { ModelControlState } from '../components/ModelControlPill';
 
 export interface EngineLifecycle {
@@ -50,12 +50,26 @@ export interface TtsLifecycle {
       notice state because both pills share it; either surface clearing it
       should clear it everywhere. */
   dismissNotices: () => void;
+  /** GPU semaphore queue depth — number of GPU ops queued behind the
+      in-flight ones. Drives the "Queued (N ahead) ·" prefix on the
+      top-bar pill so a session waiting on another's analyzer / sidecar
+      call can see why it's not starting. `undefined` when the server
+      doesn't expose `/api/gpu/queue` (older builds / partial deploys)
+      — UI degrades to no prefix in that case. */
+  gpuQueueDepth?: number;
+  /** Companion to `gpuQueueDepth` — number of GPU ops currently
+      holding a slot. Exposed for diagnostics; not currently rendered
+      anywhere but cheap to keep on the shape so future surfaces (a
+      developer-tools view, a metric overlay) can read it without a
+      second poll. */
+  gpuInFlight?: number;
 }
 
 type EngineId = 'coqui' | 'kokoro';
 
 export function useTtsLifecycle(): TtsLifecycle {
   const [sidecarHealth, setSidecarHealth] = useState<SidecarHealth | null>(null);
+  const [gpuQueue, setGpuQueue] = useState<GpuQueueState | null>(null);
   const [healthProbeKey, setHealthProbeKey] = useState(0);
   /* Pending UI override — per-engine, set immediately on Load/Stop click so
      the right pill reports the intended next state while /health catches up.
@@ -82,6 +96,22 @@ export function useTtsLifecycle(): TtsLifecycle {
           setSidecarHealth({ status: 'unreachable', url: '', error: 'Probe failed.' });
           setPendingCoqui(null);
           setPendingKokoro(null);
+        });
+
+      /* GPU queue state — same cadence, separate endpoint. Permissive
+         error handling: an older server (or a transient 404 / 5xx) just
+         clears the depth so the pill drops back to its default label;
+         it does NOT surface as a user-facing error. The semaphore is
+         opportunistic UX, not a hard contract. */
+      api
+        .getGpuQueueState()
+        .then((q) => {
+          if (cancelled) return;
+          setGpuQueue(q);
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setGpuQueue(null);
         });
     };
     probe();
@@ -194,5 +224,7 @@ export function useTtsLifecycle(): TtsLifecycle {
     evictionNotice,
     loadErrorNotice,
     dismissNotices,
+    gpuQueueDepth: gpuQueue?.depth,
+    gpuInFlight: gpuQueue?.inFlight,
   };
 }

--- a/src/routes/index.test.tsx
+++ b/src/routes/index.test.tsx
@@ -69,6 +69,10 @@ vi.mock('../lib/api', () => ({
         modelResident: true,
       }),
     getSidecarHealth: () => Promise.resolve({ status: 'unreachable', url: '(test)' }),
+    /* useTtsLifecycle also polls /api/gpu/queue on the same tick. Stub
+       to an empty queue so the "Queued (N ahead) ·" prefix stays
+       hidden in these tests. */
+    getGpuQueueState: () => Promise.resolve({ depth: 0, inFlight: 0, max: 1 }),
     loadSidecar: () => Promise.resolve({ status: 'idle' }),
     unloadSidecar: () => Promise.resolve({ status: 'idle' }),
     loadAnalyzer: () => Promise.resolve({ status: 'ready' }),

--- a/src/views/generation.test.tsx
+++ b/src/views/generation.test.tsx
@@ -73,6 +73,10 @@ vi.mock('../lib/api', () => ({
        so the pill renders the green variant without spamming console
        warnings during the test render. */
     getSidecarHealth: () => getSidecarHealthSpy(),
+    /* useTtsLifecycle also polls /api/gpu/queue on the same tick.
+       Stub to an empty queue so the "Queued (N ahead) ·" pill prefix
+       stays hidden in these tests. */
+    getGpuQueueState: () => Promise.resolve({ depth: 0, inFlight: 0, max: 1 }),
     /* The Generate-screen Load TTS button checks analyzer health to decide
        whether to surface the auto-evict banner — wire a controllable stub
        so each test can simulate "analyzer loaded" vs "nothing to evict". */


### PR DESCRIPTION
## Summary

- **Server.** New `GpuSemaphore` (`server/src/gpu/semaphore.ts`, hand-rolled FIFO, no new npm dep) wraps Ollama analyzer's `chat()` fetch (`server/src/analyzer/ollama.ts`) and `SidecarTtsProvider.synthesize()` (`server/src/tts/sidecar.ts`) so GPU-heavy ops serialize at `GPU_CONCURRENCY=1` (default, configurable). Slot is acquired before the fetch, released in an outer `finally` covering abort / classify-connect-error / poisoned-body paths verbatim. New `GET /api/gpu/queue` route returns `{ depth, inFlight, max }`; mounted in `server/src/index.ts`. `server/.env.example` gets a `GPU_CONCURRENCY=1` line.
- **Frontend.** `useTtsLifecycle()` polls `/api/gpu/queue` on the same 30 s tick as `/api/sidecar/health`, exposes `gpuQueueDepth` / `gpuInFlight` on the returned shape, and degrades gracefully to `undefined` if the route 404s. `src/components/layout.tsx` renders a `"Queued (N ahead) ·"` prefix in the global TTS pill cluster when `gpuQueueDepth > 0`; pill styling / ARIA / click behaviour unchanged.
- **Contract.** New `GpuQueueState` schema + `/api/gpu/queue` path in `openapi.yaml`; `src/lib/api-types.ts` regenerated via `npm run openapi:types`. New `api.getGpuQueueState()` wrapper (real + mock) on the client-side `api.ts` surface.
- **Tests.** New `server/src/gpu/semaphore.test.ts` pins four guarantees: capacity (max=2 admits 2, queues 3rd), FIFO order (max=1 serialises A→B→C→D), depth-ticks-down on every release, and double-release no-op. `src/lib/use-tts-lifecycle.test.ts` gets two new cases (depth surfaces; rejected probe → `undefined`). Test mocks updated in `src/components/layout.test.tsx`, `src/routes/index.test.tsx`, `src/views/generation.test.tsx` so the new poll doesn't TypeError.
- **BACKLOG.** Removes the post-rebase Should #3 (GPU-arbitration semaphore) per the BACKLOG update rule; Should #4–#8 renumber down to #3–#7.

Closes the post-rebase Should #3 entry in `docs/BACKLOG.md`. Pairs with `scripts/wt-new.mjs` (parallel-sessions tooling) — the port-collision resolver was already there; this closes the matching GPU-contention gap CONTRIBUTING.md called out manually.

## Test plan

- [x] `npm run verify` — green (cached after the green pre-push run).
- [x] `cd server && npx vitest run src/gpu/semaphore.test.ts` — 4/4 green in isolation.
- [ ] Manual smoke (deferred to merge): start the server, hit `/api/gpu/queue` directly; returns `{ depth: 0, inFlight: 0, max: 1 }` at rest.
- [ ] Manual smoke (deferred to merge): kick off two parallel `/analyse` calls; second waits, the layout pill shows `"Queued (1 ahead) · …"` until the first releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)