### PR TITLE
fix(e2e): bypass per-platform visual skip when --update-snapshots is in argv

### DIFF
--- a/e2e/responsive/visual.spec.ts
+++ b/e2e/responsive/visual.spec.ts
@@ -55,6 +55,11 @@ import { goToAnalysing, goToConfirm, waitForConfirmViewReady, waitForListenViewR
    `e2e/linux/responsive/visual.spec.ts/`). Linux baselines are tracked
    as Should #1 in docs/BACKLOG.md. */
 const BASELINE_DIR = resolve(process.cwd(), 'e2e', process.platform, 'responsive', 'visual.spec.ts');
+/* Don't skip while we're being asked to BLESS new baselines — the regen
+   workflow can't seed an initial Linux directory if the skip fires
+   before --update-snapshots gets a chance to write any PNGs. */
+const IS_UPDATING_SNAPSHOTS = process.argv.includes('--update-snapshots');
+const SHOULD_SKIP_VISUAL = !IS_UPDATING_SNAPSHOTS && !existsSync(BASELINE_DIR);
 const SKIP_REASON =
   `No visual baselines committed for ${process.platform}. ` +
   `Run \`npm run verify:visual -- --update-snapshots\` to bless on this platform.`;
@@ -82,7 +87,7 @@ test.describe.configure({ mode: 'serial' });
 const VISUAL_DIFF_OPTS = { maxDiffPixelRatio: 0.05 } as const;
 
 test.describe('visual baselines', () => {
-  test.skip(!existsSync(BASELINE_DIR), SKIP_REASON);
+  test.skip(SHOULD_SKIP_VISUAL, SKIP_REASON);
   test('library', async ({ page }) => {
     await page.goto('/');
     await expect(page.getByRole('button', { name: /Start a new book/i }).first()).toBeVisible({
@@ -165,7 +170,7 @@ test.describe('visual baselines', () => {
  *   npm run test:e2e:visual -- --update-snapshots
  */
 test.describe('visual baselines (dark theme)', () => {
-  test.skip(!existsSync(BASELINE_DIR), SKIP_REASON);
+  test.skip(SHOULD_SKIP_VISUAL, SKIP_REASON);
 
   test.beforeEach(async ({ context }) => {
     /* Seed the redux-persist 'persist:ui' blob before any page in this


### PR DESCRIPTION
## Summary

- `e2e/responsive/visual.spec.ts:85` + `:168` skip the visual describe blocks when `e2e/<platform>/responsive/visual.spec.ts/` doesn't exist. Designed to auto-enable as soon as a new platform's baselines land, but creates a chicken-and-egg for the regen workflow PR #172 just added: `workflow_dispatch` runs `playwright test … --update-snapshots` on ubuntu-latest expecting to bless the initial Linux baselines, but the skip fires first and no PNGs ever get written. Run [#26287350071](https://github.com/dudarenok-maker/AudioBook-Generator/actions/runs/26287350071) failed on all 3 matrix legs with `No files were found with the provided path: e2e/linux/responsive/visual.spec.ts/<project>/`.
- Adds a `process.argv.includes('--update-snapshots')` bypass to the skip condition. When the runner is being asked to bless new baselines, the skip step doesn't fire; when it's the normal verify path (no `--update-snapshots`), behaviour is unchanged.
- After merge: re-run `gh workflow run regen-visual-baselines.yml --ref main`. Matrix legs now write PNGs; artifact upload finds them; consolidation job opens its auto-PR as designed.

## Test plan

- [x] `npm run verify:fast` green pre-commit (cached — no source-test impact).
- [x] Logic verified against Playwright CLI: `npx playwright test --update-snapshots` puts `--update-snapshots` into `process.argv` of the worker process; `npm run test:e2e:visual` doesn't (verifies non-regression on the normal verify path).
- [ ] After merge: re-trigger the regen workflow and confirm the auto-PR opens with 42 PNGs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)