### PR TITLE
fix(ci,e2e): bootstrap BASELINE_DIR via workflow mkdir; revert argv bypass

### DIFF
--- a/.github/workflows/regen-visual-baselines.yml
+++ b/.github/workflows/regen-visual-baselines.yml
@@ -86,6 +86,17 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
+      # Pre-create the baseline directory so the per-platform skip in
+      # `e2e/responsive/visual.spec.ts:85` + `:168` (which checks
+      # `existsSync(BASELINE_DIR)`) does NOT fire on a fresh Linux runner.
+      # Without this, all 14 visual specs are skipped before
+      # --update-snapshots has any chance to write PNGs, the artifact
+      # upload step finds nothing, and the matrix leg fails. The actual
+      # PNGs land in this same directory once playwright writes them
+      # below.
+      - name: Bootstrap baseline directory
+        run: mkdir -p e2e/linux/responsive/visual.spec.ts/${{ matrix.project }}
+
       # `--update-snapshots` writes the PNGs in-place under
       # `e2e/linux/responsive/visual.spec.ts/<project>/*.png` (per
       # snapshotPathTemplate in playwright.config.ts). `--workers=1` keeps

--- a/e2e/responsive/visual.spec.ts
+++ b/e2e/responsive/visual.spec.ts
@@ -55,11 +55,14 @@ import { goToAnalysing, goToConfirm, waitForConfirmViewReady, waitForListenViewR
    `e2e/linux/responsive/visual.spec.ts/`). Linux baselines are tracked
    as Should #1 in docs/BACKLOG.md. */
 const BASELINE_DIR = resolve(process.cwd(), 'e2e', process.platform, 'responsive', 'visual.spec.ts');
-/* Don't skip while we're being asked to BLESS new baselines — the regen
-   workflow can't seed an initial Linux directory if the skip fires
-   before --update-snapshots gets a chance to write any PNGs. */
-const IS_UPDATING_SNAPSHOTS = process.argv.includes('--update-snapshots');
-const SHOULD_SKIP_VISUAL = !IS_UPDATING_SNAPSHOTS && !existsSync(BASELINE_DIR);
+/* The regen workflow at `.github/workflows/regen-visual-baselines.yml`
+   pre-creates this directory before invoking playwright, so the skip
+   doesn't fire on the initial Linux regen run. For local regen on an
+   un-blessed platform: `mkdir -p e2e/<platform>/responsive/visual.spec.ts`
+   first, then `npm run verify:visual -- --update-snapshots`.
+   (Playwright's worker `process.argv` does NOT include the CLI's
+   `--update-snapshots` flag — checking it here was tried in PR #178
+   and silently no-op'd; the mkdir bootstrap is the supported pathway.) */
 const SKIP_REASON =
   `No visual baselines committed for ${process.platform}. ` +
   `Run \`npm run verify:visual -- --update-snapshots\` to bless on this platform.`;
@@ -87,7 +90,7 @@ test.describe.configure({ mode: 'serial' });
 const VISUAL_DIFF_OPTS = { maxDiffPixelRatio: 0.05 } as const;
 
 test.describe('visual baselines', () => {
-  test.skip(SHOULD_SKIP_VISUAL, SKIP_REASON);
+  test.skip(!existsSync(BASELINE_DIR), SKIP_REASON);
   test('library', async ({ page }) => {
     await page.goto('/');
     await expect(page.getByRole('button', { name: /Start a new book/i }).first()).toBeVisible({
@@ -170,7 +173,7 @@ test.describe('visual baselines', () => {
  *   npm run test:e2e:visual -- --update-snapshots
  */
 test.describe('visual baselines (dark theme)', () => {
-  test.skip(SHOULD_SKIP_VISUAL, SKIP_REASON);
+  test.skip(!existsSync(BASELINE_DIR), SKIP_REASON);
 
   test.beforeEach(async ({ context }) => {
     /* Seed the redux-persist 'persist:ui' blob before any page in this


### PR DESCRIPTION
## Summary

- PR #178's `process.argv.includes('--update-snapshots')` bypass is silently a no-op: Playwright's CLI parses the flag into the config object and worker `process.argv` does NOT carry it through. Run [#26313768433](https://github.com/dudarenok-maker/AudioBook-Generator/actions/runs/26313768433) still logged `14 skipped` on every matrix leg and the empty-artifact upload still failed.
- Fix lives in the workflow: new `Bootstrap baseline directory` step runs `mkdir -p e2e/linux/responsive/visual.spec.ts/<project>` before invoking playwright. `existsSync(BASELINE_DIR)` now returns true, the skip doesn't fire, tests run, `--update-snapshots` writes the 14 PNGs into the (now-existing) dir, artifact upload succeeds, consolidation opens the auto-PR.
- Reverts PR #178's spec change to the original `!existsSync(BASELINE_DIR)` form. Updated comment cites the argv finding so we don't try this approach again and points at the workflow's mkdir as the supported regen pathway.
- No behaviour change for the normal verify path — Linux PR Verify still skips visuals until the auto-PR lands.

## Test plan

- [x] `npm run verify:fast` green pre-commit (cached).
- [x] Verified the failure mode against run #26313768433's log: 14 specs reported as skipped, no PNGs written, artifact-upload `if-no-files-found: error` is what produced the matrix failures.
- [ ] After merge: re-trigger `gh workflow run regen-visual-baselines.yml --ref main`; matrix legs should now report 14 passed each and the consolidation job should open the 42-PNG auto-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)