### PR TITLE
feat(openapi,docs): plan 102 global queue modal — shape + design doc

### DIFF
--- a/docs/features/102-global-queue-modal.md
+++ b/docs/features/102-global-queue-modal.md
@@ -1,0 +1,105 @@
+---
+status: active
+shipped: null
+owner: null
+---
+
+# Global queue modal for chapter generation
+
+> Status: active (Round 1 of 1; six waves — see `~/.claude/plans/a-large-piece-of-refactored-bird.md` for the wave decomposition)
+> Key files: `src/store/queue-slice.ts` (Wave 2b), `src/store/queue-thunks.ts` (Wave 2b), `src/store/generation-stream-middleware.ts` (Wave 2b — rewrite), `src/modals/queue-modal.tsx` (Wave 3), `src/components/queue-entry-row.tsx` (Wave 3), `server/src/workspace/queue-io.ts` (Wave 2a), `server/src/routes/queue.ts` (Wave 2a), `server/src/routes/generation.ts` (Wave 2a — `resume_from` ack)
+> URL surface: Modal mounted globally in `src/components/layout.tsx`; clicking a queue entry pushes `#/books/<bookId>/generate?chapter=<chapterId>` and the Generate view scroll consumer reacts to `currentChapterId`.
+> OpenAPI ops: `GET /api/queue`, `POST /api/queue/enqueue`, `POST /api/queue/reorder`, `POST /api/queue/pause`, `DELETE /api/queue/{entryId}` + new `resume_from` SSE event on `POST /api/books/{bookId}/generation`.
+
+## Benefit / Rationale
+
+- **User:** closes two cited bugs that the v1 chapter-queue model cannot fix structurally. (1) **Regenerate-during-regenerate no longer drops in-flight work** — today's middleware closes the SSE handle on every `regenerateChapter*` action (`src/store/generation-stream-middleware.ts:325-347`), abandoning the partial chapter audio. The FIFO replaces the hard interrupt with append-and-wait, so the current chapter completes before the next one starts. (2) **Cross-book voice-drift fixes stop racing** — batch regenerate across multiple books today fires N `pendingRegen` dispatches that fight over the single-book `currentBookId` guard at `generation-stream-middleware.ts:279`. The cross-book queue with explicit `order` removes the race; the user can mix-and-match "regenerate these 2 chapters of Book 1, then these 5 of Book 5, then all of Book 6" in one queue and the dispatcher drains in the chosen order.
+- **Technical:** decouples scheduling from book-active state. The queue is the source of truth, not the chapter-slice's implicit `state ∈ {queued, in_progress}` ordering. SSE survives `tsx watch` hot-reload during dev AND production server bounce / Node OOM — the consumer reconnects, the server emits a `resume_from` ack on every new subscriber, no replay of already-completed work. Same seam handles both paths (absorbs former BACKLOG Should #1).
+- **Architectural:** locks in the standing memory's concurrent-multibook invariant (`project_concurrent_multibook_workflow.md`) as a tested property of the queue dispatcher instead of a fragile cross-slice handshake. Lays the seam for future "Schedule overnight" / "Generate when GPU is idle" / "Pause this book, prioritise that one" affordances that are out of scope for v1 but trivial to layer on once the queue exists. Foundation also enables Could-#13 (within-chapter sentence parallelism) — the queue dispatcher is the natural place to gate K-wide synth dispatch per entry.
+
+## Architectural impact
+
+### New seams / extension points
+
+- New `queue-slice` (`src/store/queue-slice.ts`) is the **single source of truth for scheduling**. Every regenerate trigger site dispatches `queueActions.enqueue` (via `queue-thunks.ts`) rather than `chaptersActions.regenerate*`. The 10 existing trigger sites enumerated in BACKLOG Must #3 and the per-wave key-files list are all rewired to this seam in Wave 4.
+- New workspace-level `<workspace>/.queue.json` (one file holds the cross-book queue, NOT per-book) persisted via the existing `writeJsonAtomic` contract from `server/src/workspace/state-io.ts`. Chosen over per-book `<bookDir>/.audiobook/queue.json` because the user's first-class operation is cross-book reordering — keeping ordering in one file removes the need to aggregate-and-reconcile on every read and makes the reorder API trivially atomic.
+- New `resume_from` SSE event type on the generation stream. Emitted as the FIRST event on every new subscriber connection (cold connect AND post-reconnect). Carries `resumeFromCompletedChapterIds: number[]` for the active queue entry so the frontend can skip the existing per-chapter catch-up replay (today's `chapter_complete` catch-up at `server/src/routes/generation.ts:19` for already-done chapters) when it already has those rows in state.
+- New `QUEUE_BROADCAST_ACTIONS` set in `src/store/broadcast-middleware.ts` for cross-tab queue mutations. Per-entry progress ticks stay non-broadcast (single-user-per-workspace contract, plan 63 invariant intact).
+- New cross-book sequencing rule in the generation-stream middleware FIFO drainer: one SSE handle per book at a time (existing contract), books with queued work alternate at chapter boundaries based on `queue.order` regardless of which book is currently viewed.
+
+### Invariants preserved
+
+- **Per-book SSE contract (plan 16).** One handle per book — the queue dispatcher opens a handle only when a queued entry's book matches the slice's `currentBookId` for that handle's stream, AND the active handle for that book is the one carrying the current queue entry. No two handles per book.
+- **Sticky generation across navigation (plan 31, invariant 1a).** The server-side `RunningJob` (`server/src/routes/generation.ts:1-78`) keeps a generation alive across SSE subscribers; reload mid-generation re-subscribes the new client. This contract is unchanged — the queue layer sits on top and chooses *which* `RunningJob` is current, but each job's stream-handle behaviour is identical.
+- **Reverse-local-analyzer guard (`generation-stream-middleware.ts:284-320`).** When a local Ollama analysis is running on the same book, the middleware auto-pauses generation to avoid GPU contention. Preserved verbatim — the queue dispatcher consults this guard before opening a handle, same as today.
+- **Single-user-per-workspace cross-tab contract (plan 63).** Per-chapter ticks are not broadcast across tabs; queue mutations ARE broadcast (a queue is shared workspace state, not per-tab UI state). Net: opening the modal in two tabs shows the same queue in both; pausing in one pauses in both.
+- **Audio-on-disk completion semantic (plan 16).** "A chapter is complete iff `.mp3` exists for it on disk." Queue `status: 'done'` mirrors this — flips to `done` when the corresponding `chapter_complete` tick fires (which itself implies the `.mp3` is on disk).
+- **Engine-drift detection (plan 35).** Drift detection compares `chapter.audioModelKey !== currentModelKey` at render time and surfaces the "Regenerate all" banner. The drift banner's regen path is one of the 10 trigger sites rewired in Wave 4; the drift detection itself is unchanged.
+
+### Migration story
+
+- `<workspace>/.queue.json` is **net-new**. On first read after upgrade, an empty queue is materialised. No existing user data needs migration. A schema-version stamp follows the `server/src/workspace/state-migrate.ts:33-100` pattern (Wave 2a: `server/src/workspace/queue-migrate.ts`) so future shape changes are migratable, and the file slots into Must-#1 (in-app upgrade pathway)'s broader migration family when that ships.
+- `src/store/chapters-slice.ts` loses three fields: `pendingRegen` (no longer needed — the queue holds pending regens), `regenEpoch` (no longer needed — the middleware drives off queue mutations, not slice mutations), `paused` (migrated to queue-global on `queue-slice`). The per-chapter `state` field is preserved as-is so the UI keeps rendering per-chapter status the same way.
+- All 10 existing regenerate trigger sites switch from `chaptersActions.regenerate*` to `queueActions.enqueue`. The dispatch shape changes; the UI affordances are unchanged at each site except Generate view's per-chapter button which gains a paired "Add to queue" + "View queue" affordance.
+- `src/components/generation-view`'s Resume / Pause control (`src/views/generation.tsx:587-607`) is **relocated** to the queue modal — it does not move to a different button on the Generate view. The Generate view header gains a "View queue" affordance instead.
+
+### Reversibility
+
+- If the modal UI ships and proves a poor mental model: the slice + dispatcher + persistence stay (they're a strict superset of today's implicit queue); the modal is replaced or hidden behind a feature flag.
+- If the cross-book ordering proves more flexibility than the user wants: a UI-only constraint enforcing per-book grouping in the modal is cheap to add. The on-disk model already supports cross-book ordering, so the constraint is purely cosmetic.
+- The `<workspace>/.queue.json` file can be safely deleted at any time to reset the queue — the server treats absence as empty queue, the frontend re-renders the modal as empty.
+
+## Invariants to preserve
+
+1. **`QueueEntry` shape** (`openapi.yaml` lines added by Wave 1; mirrored in `src/lib/api-types.ts`): `{ id, bookId, chapterId, scope, characterId?, addedAt, status, order, progress?, errorReason? }`. The `scope` enum is `'this' | 'character'` only — the BACKLOG-cited `'forward'` scope is **expanded at enqueue time** by the frontend into multiple `'this'` entries, one per affected chapter, so the slice and on-disk shape never carry `'forward'` as a single row.
+2. **The in-flight queue entry is non-draggable.** Reorder requests that move the `in_progress` entry return 409 from `POST /api/queue/reorder`. The frontend's drag-handle grays out / disappears on `status === 'in_progress'`. The reorder request body sends the desired order **excluding** the in-flight entry; the server validates this constraint.
+3. **`paused` is queue-global, not per-book.** One Pause stops every book's drain at its next chapter boundary; Resume restarts the whole queue. Per-book pause is explicitly out of scope (see Out of scope below).
+4. **FIFO with cross-book interleave.** The dispatcher walks entries in `order` ascending. When the active entry's book has more queued entries (e.g. `A.ch5` then `A.ch7`), it stays on Book A until those drain OR the user reorders a different-book entry to the top. No round-robin enforcement; the user owns the ordering.
+5. **Book-delete prunes queue entries atomically.** The existing book-deletion route gains a queue-prune step that removes entries matching the deleted `bookId` in the same write transaction as the directory drop. No orphaned entries can persist.
+6. **`resume_from` is emitted FIRST on every new subscriber.** Before any `progress` / `chapter_assembling` / `chapter_complete` tick. Reconnect after `tsx watch` restart or server bounce — first event the frontend sees is the resume snapshot, then the per-entry catch-up follows.
+7. **Regenerate dispatches NEVER close the active SSE handle.** This is the structural fix for the user-cited "loses all progress" bug. The middleware's hard-interrupt path at `src/store/generation-stream-middleware.ts:325-347` is replaced with an enqueue-only flow that appends to the queue and lets the in-flight entry complete naturally.
+
+## Test plan
+
+### Automated coverage
+
+Per CLAUDE.md "Testing discipline (REQUIRED for every change)": every wave ships paired tests in the same PR as the code.
+
+- **Wave 2a:** new `queue-io.test.ts` (round-trip + atomic write + concurrent read on the workspace file), new `queue.test.ts` (route handlers including enqueue + reorder + cancel + pause), new `generation-resume-from.test.ts` (subscriber gets `resume_from` ack before progress ticks; the snapshot lists exactly the chapter ids on disk), new `queue-migrate.test.ts` (absence-means-v1 back-compat, refuses future schemas), new `book-delete-prune.test.ts` (deleting a book with N queue entries drops all N from `.queue.json` atomically).
+- **Wave 2b:** new `queue-slice.test.ts` (reducers + selectors + persistence + cross-book ordering + forward-expansion at enqueue time), new `queue-thunks.test.ts` (enqueue + reorder + cancel + toast dispatch via `notifications-slice.pushToast`), `generation-stream-middleware.test.ts` updated (FIFO drain order, in-flight pinning, regen-as-enqueue does NOT close the handle, cross-book alternation at chapter boundaries, reconnect-with-`resume_from` honoured), `chapters-slice.test.ts` updates (existing tests still pass after `pendingRegen` / `regenEpoch` / `paused` removal), `broadcast-middleware.test.ts` extension for queue actions.
+- **Wave 3:** new `queue-modal.test.tsx` (renders entries grouped by book, in-flight entry non-draggable, click → router push to `#/books/<bookId>/generate?chapter=<chapterId>`), new `queue-entry-row.test.tsx` (drag + tap pills, both code paths), `generation.test.tsx` updates (Resume / Pause removed, View queue + Add to queue buttons present, scroll-to-chapter fires on `currentChapterId` change), `layout.test.tsx` extension (modal mount + Resume / Pause relocation), `top-bar.test.tsx` extension (queue count chip).
+- **Wave 4:** existing per-site regen-trigger tests updated — each asserts the new `queueActions.enqueue` dispatch shape and the per-site toast assertion.
+- **Wave 5:** new `e2e/queue-modal.spec.ts` driving enqueue → reorder → pause → resume → reconnect across all three responsive projects (chromium + mobile-chrome + tablet-chrome) per CLAUDE.md mobile protocol. `e2e/responsive/coverage.spec.ts` extended with the queue modal case so it auto-runs at every viewport.
+
+### Manual acceptance walkthrough
+
+Run with the canonical full-pipeline manuscript `C:\Users\dudar\Downloads\Bonus Keefe Story.txt` (CLAUDE.md "Canonical end-to-end manuscript"). Reboot before any timing assertion (`feedback_reboot_before_perf_baselines.md`).
+
+1. **Cold boot at `#/`** → expected stage `{ kind: 'books' }`, library view, top-bar shows no queue chip (queue is empty).
+2. **Upload Keefe + a Pushkin short-story stub.** Analyse both books to completion.
+3. **Enqueue chapter 3 of Book A** from the Generate view's per-chapter "Add to queue" button → toast "Added to queue · 1 entry pending" with a "View queue" CTA. Top-bar queue chip shows `1`.
+4. **Switch to Book B**, enqueue chapter 1 of Book B → toast "Added to queue · 2 entries pending". Queue chip shows `2`.
+5. **Click the queue chip → View queue modal opens.** Two entries visible: `A.ch3` (order 0), `B.ch1` (order 1). Resume button is the only top-level action (queue not yet started).
+6. **Click Resume** → `A.ch3` flips to `in_progress` and pins to the top (non-draggable). Progress bar advances.
+7. **While `A.ch3` is mid-flight, enqueue `A.ch7`** from Book A's Generate view → toast fires, `A.ch7` appears at order 2 (bottom), `A.ch3`'s progress bar unaffected (no drop).
+8. **Drag `A.ch7` above `B.ch1` in the modal** → confirmed visual feedback, the next entry to dispatch after `A.ch3` completes is now `A.ch7`.
+9. **`A.ch3` completes** → status flips to `done`, toast "A.ch3 completed". Dispatcher pops `A.ch7`, which flips to `in_progress`.
+10. **Click an entry's "Open in Generate view" affordance** (or the row itself) → router lands on `#/books/<A>/generate?chapter=7`, the Generate view auto-scrolls to chapter 7's row.
+11. **Edit any file under `server/src/`** → `tsx watch` restarts the Node server → within ~3 s the frontend reconnects, `resume_from` ack restores the progress bar without replaying completed chapters, the queue keeps draining. "Worker has gone quiet" banner does NOT appear.
+12. **Browser hard-refresh mid-queue** → queue restores from `<workspace>/.queue.json`, the in-flight entry resumes its SSE, no progress lost.
+13. **Delete Book A from the library** → modal warns the user that 2 queue entries (`A.ch7`, plus any already-done `A.ch3`) will be dropped; on confirm, the entries vanish from the modal in the same write that drops the book directory. `B.ch1` remains.
+14. **Voice-drift batch scenario:** with Books A + B both having drift, open `DriftReportModal` and batch-regenerate 3 chapters spanning both books → 3 queue entries land in order, drain sequentially, no in-flight work dropped.
+15. **Pause-global:** Click Pause in the modal → both books stop at next chapter boundary. Resume → drain continues from where it stopped.
+16. **Phone + tablet (LAN HTTPS, plan 81):** `npm run dev:lan`, open LAN URL on phone → modal renders full-screen, drag handles replaced with tap "Move up / Move down" pills. Tablet → dialog rendering with drag handles. Touch targets ≥44×44 px.
+
+## Out of scope
+
+- **Per-book pause inside the modal** — queue-global Pause is the v1 contract. Per-book Pause is a UI-only refinement on top of the same dispatcher; deferred to BACKLOG.
+- **"Schedule overnight" / "Generate when GPU is idle"** — the queue dispatcher is the seam; UI lands separately when the user asks for it.
+- **Within-chapter sentence parallelism (Could-#13)** — orthogonal to queue scheduling; the queue dispatcher is the natural place to gate K-wide dispatch, but plan 87 is the prerequisite.
+- **Per-segment regen (Could-#1)** — entry shape stays "whole chapter or whole character-in-chapter" for v1.
+- **Schema-version migration coordination with Must-#1 (in-app upgrade)** — plan 102's `queue-migrate.ts` is structured to slot into Must-#1's migration family when that ships; no cross-coordination required during v1 of the queue.
+
+## Ship notes
+
+_(Filled in when status flips to `stable`. Append: shipped date, commit SHAs per merged wave PR, any behaviour delta vs. the original spec.)_

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -92,6 +92,7 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 - [31 — Sticky generation across navigation](31-sticky-generation.md) — Generation survives every navigation except an explicit Stop or queue drain; local-analyzer triggers prompt for pause-and-analyse when a run is alive.
 - [32 — Sticky analysis across navigation](32-sticky-analysis.md) — Analysis survives every navigation except `/pause` or `fresh:true` displacement; server-owned job + multi-subscriber catch-up replay; `AnalysisPill` in the top-bar mirrors the generation pill.
 - [35 — Per-chapter engine drift detection](35-engine-drift-detection.md) — Stamp each rendered chapter with its TTS engine; surface drift when the project's active engine differs.
+- [102 — Global queue modal for chapter generation](102-global-queue-modal.md) — Cross-book, reorderable, regen-safe FIFO queue persisted to `<workspace>/.queue.json`. Replaces the implicit per-book `state ∈ {queued, in_progress}` queue and the hard-interrupt regen path. Modal mounted globally in Layout hosts the relocated Resume / Pause control + reorder UI. All 10 regenerate trigger sites funnel through `queueActions.enqueue`. SSE survival + idempotent server-side `resume_from` ack absorbs former BACKLOG Should #1 (Node hot-reload + production crash recovery). Six-wave delivery; Round 1 active.
 
 ### H. Playback & listen
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -931,6 +931,105 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/VoiceMatchResponse' }
 
+  /api/queue:
+    get:
+      summary: Read the workspace-level chapter-generation queue
+      operationId: getQueue
+      description: |
+        Single-file workspace queue persisted to `<workspace>/.queue.json`.
+        Aggregated across all books — entries from different books interleave
+        based on `order`. Drains FIFO, one entry at a time. Read on app cold
+        boot to restore the queue across reloads. See plan
+        `docs/features/102-global-queue-modal.md`.
+      responses:
+        '200':
+          description: Queue snapshot
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/QueueListResponse' }
+
+  /api/queue/enqueue:
+    post:
+      summary: Append entries to the workspace queue
+      operationId: enqueueQueueEntries
+      description: |
+        Appends one or more entries to the bottom of the queue. The frontend
+        pre-expands `scope: 'forward'` (regenerate chapter N + all subsequent)
+        into per-chapter ids before posting, so this route only sees scoped
+        entries that map 1:1 to a chapter id.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/QueueEnqueueRequest' }
+      responses:
+        '200':
+          description: Resulting queue snapshot
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/QueueListResponse' }
+
+  /api/queue/reorder:
+    post:
+      summary: Reorder the workspace queue (excluding the in-flight pinned entry)
+      operationId: reorderQueue
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/QueueReorderRequest' }
+      responses:
+        '200':
+          description: Resulting queue snapshot
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/QueueListResponse' }
+        '409':
+          description: Order list doesn't match current non-pinned entries (e.g. stale view after a concurrent enqueue).
+
+  /api/queue/pause:
+    post:
+      summary: Toggle queue-global pause
+      operationId: setQueuePaused
+      description: |
+        Sets the queue-global `paused` flag. When true, the dispatcher waits
+        at the next chapter boundary — the currently in-flight chapter runs
+        to completion, then the queue stops. Resume by POSTing `{ paused:
+        false }`. Persists to `<workspace>/.queue.json`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [paused]
+              properties:
+                paused: { type: boolean }
+      responses:
+        '200':
+          description: Resulting queue snapshot
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/QueueListResponse' }
+
+  /api/queue/{entryId}:
+    delete:
+      summary: Cancel (remove) a queued entry
+      operationId: cancelQueueEntry
+      description: |
+        Removes the entry from the queue. Refuses with 409 if the entry is
+        currently `in_progress` — the user must Pause first.
+      parameters:
+        - { in: path, name: entryId, required: true, schema: { type: string } }
+      responses:
+        '200':
+          description: Resulting queue snapshot
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/QueueListResponse' }
+        '409':
+          description: Entry is in_progress; pause the queue first.
+
   /api/books/{bookId}/generation:
     post:
       summary: Generate chapter audio with progress streaming
@@ -941,7 +1040,12 @@ paths:
         analysis`). Each `data: <json>` payload follows the GenerationTick
         schema. Synthesises chapters one at a time; per-chapter completion
         writes `audio/<chapterSlug>.mp3` + `audio/<chapterSlug>.segments.json`
-        into the workspace book directory.
+        into the workspace book directory. On every new subscriber (cold
+        connect AND post-reconnect during dev `tsx watch` restarts or
+        production server bounce), the server emits a `resume_from` ack as
+        the first event carrying the snapshot of completed chapter ids for
+        the active queue entry so the reconnect doesn't replay. See plan
+        `docs/features/102-global-queue-modal.md`.
       parameters:
         - { in: path, name: bookId, required: true, schema: { type: string } }
       requestBody:
@@ -2200,12 +2304,17 @@ components:
       properties:
         type:
           type: string
-          enum: [progress, chapter_assembling, chapter_complete, chapter_failed, idle]
+          enum: [progress, chapter_assembling, chapter_complete, chapter_failed, idle, resume_from]
           description: |
             `chapter_assembling` is emitted between the last per-group synthesis
             tick and `chapter_complete`, while the server concatenates the PCM,
             writes the MP3 + segments JSON, and updates state.json. Surfaces
             the disk-write phase so the UI doesn't look stalled at 99 %.
+            `resume_from` is emitted as the FIRST event on every new subscriber
+            (cold connect AND reconnect after `tsx watch` restart or server
+            bounce) and carries a snapshot of completed chapter ids for the
+            active queue entry so the reconnect doesn't replay completed work.
+            See plan `docs/features/102-global-queue-modal.md`.
         chapterId: { type: integer }
         characterId:
           type: string
@@ -2259,6 +2368,113 @@ components:
             engine-drift badge appear only after page navigation). See
             `docs/features/35-engine-drift-detection.md`.
         errorReason: { type: string, nullable: true }
+        queueEntryId:
+          type: string
+          description: |
+            On `progress`, `chapter_assembling`, `chapter_complete`,
+            `chapter_failed`, and `resume_from` — the workspace queue entry
+            this tick belongs to. Lets the frontend map ticks to the right
+            queue row even when entries from different books interleave.
+            Optional for backward compat — older servers (pre-plan-102) omit
+            it and the frontend falls back to (bookId, chapterId) matching.
+        resumeFromCompletedChapterIds:
+          type: array
+          items: { type: integer }
+          description: |
+            Only on `resume_from` — list of chapter ids already complete on
+            disk for the active queue entry's containing run, so the frontend
+            can skip replaying `chapter_complete` ticks for them when the
+            server catches a new subscriber up.
+
+    # --- Generation queue ------------------------------------------
+
+    QueueEntry:
+      type: object
+      required: [id, bookId, chapterId, scope, addedAt, status, order]
+      properties:
+        id:
+          type: string
+          description: Stable unique entry id. Frontend-minted at enqueue time.
+        bookId: { type: string }
+        chapterId: { type: integer }
+        scope:
+          type: string
+          enum: [this, character]
+          description: |
+            `this` = (re)generate the named chapter. `character` = regenerate
+            the named character's lines in this chapter only. `forward` scope
+            (regenerate chapter N + all subsequent) is expanded by the
+            frontend at enqueue time into one `this` entry per affected
+            chapter — the slice never carries `forward` as a single row, so
+            every queue entry maps 1:1 to a chapter and the user can reorder
+            each chapter in a forward range individually.
+        characterId:
+          type: string
+          nullable: true
+          description: Required when scope === 'character'; null otherwise.
+        addedAt:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp the entry was enqueued. Drives FIFO ordering when ties on `order` occur during concurrent enqueues.
+        status:
+          type: string
+          enum: [queued, in_progress, paused, done, failed]
+          description: |
+            `queued` = waiting. `in_progress` = currently synthesising
+            (pinned; non-draggable in the modal). `paused` = queue-global
+            pause flipped; still ordered, drains on resume. `done` = audio
+            on disk for this entry's chapter. `failed` = synthesis errored;
+            surfaces in the modal with a retry affordance.
+        order:
+          type: integer
+          description: Cross-book ordinal within the workspace queue. 0 = first to drain. Renumbered on every reorder.
+        progress:
+          type: number
+          minimum: 0
+          maximum: 1
+          description: Per-entry render progress (0..1), mirrored from the active GenerationTick.
+        errorReason:
+          type: string
+          nullable: true
+          description: Populated when status === 'failed'.
+
+    QueueListResponse:
+      type: object
+      required: [entries, paused]
+      properties:
+        entries:
+          type: array
+          items: { $ref: '#/components/schemas/QueueEntry' }
+          description: All workspace queue entries, sorted by `order` ascending.
+        paused:
+          type: boolean
+          description: Queue-global pause flag. When true, the dispatcher waits at the next chapter boundary.
+
+    QueueEnqueueRequest:
+      type: object
+      required: [bookId, chapterIds]
+      properties:
+        bookId: { type: string }
+        chapterIds:
+          type: array
+          items: { type: integer }
+          description: One or more chapter ids to enqueue. The frontend pre-expands `forward` scope into per-chapter ids before posting.
+        scope:
+          type: string
+          enum: [this, character]
+          default: this
+        characterId:
+          type: string
+          description: Required when scope === 'character'.
+
+    QueueReorderRequest:
+      type: object
+      required: [order]
+      properties:
+        order:
+          type: array
+          items: { type: string }
+          description: Full list of entry ids in the desired final order. Server validates the list matches the current queue minus the in-flight pinned entry; mismatch returns 409 (concurrent enqueue happened; client refetches and retries).
 
     # --- Voice samples ---------------------------------------------
     VoiceSampleRequest:

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -629,6 +629,114 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/queue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Read the workspace-level chapter-generation queue
+         * @description Single-file workspace queue persisted to `<workspace>/.queue.json`.
+         *     Aggregated across all books — entries from different books interleave
+         *     based on `order`. Drains FIFO, one entry at a time. Read on app cold
+         *     boot to restore the queue across reloads. See plan
+         *     `docs/features/102-global-queue-modal.md`.
+         */
+        get: operations["getQueue"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/queue/enqueue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Append entries to the workspace queue
+         * @description Appends one or more entries to the bottom of the queue. The frontend
+         *     pre-expands `scope: 'forward'` (regenerate chapter N + all subsequent)
+         *     into per-chapter ids before posting, so this route only sees scoped
+         *     entries that map 1:1 to a chapter id.
+         */
+        post: operations["enqueueQueueEntries"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/queue/reorder": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reorder the workspace queue (excluding the in-flight pinned entry) */
+        post: operations["reorderQueue"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/queue/pause": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Toggle queue-global pause
+         * @description Sets the queue-global `paused` flag. When true, the dispatcher waits
+         *     at the next chapter boundary — the currently in-flight chapter runs
+         *     to completion, then the queue stops. Resume by POSTing `{ paused:
+         *     false }`. Persists to `<workspace>/.queue.json`.
+         */
+        post: operations["setQueuePaused"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/queue/{entryId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Cancel (remove) a queued entry
+         * @description Removes the entry from the queue. Refuses with 409 if the entry is
+         *     currently `in_progress` — the user must Pause first.
+         */
+        delete: operations["cancelQueueEntry"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/books/{bookId}/generation": {
         parameters: {
             query?: never;
@@ -645,7 +753,12 @@ export interface paths {
          *     analysis`). Each `data: <json>` payload follows the GenerationTick
          *     schema. Synthesises chapters one at a time; per-chapter completion
          *     writes `audio/<chapterSlug>.mp3` + `audio/<chapterSlug>.segments.json`
-         *     into the workspace book directory.
+         *     into the workspace book directory. On every new subscriber (cold
+         *     connect AND post-reconnect during dev `tsx watch` restarts or
+         *     production server bounce), the server emits a `resume_from` ack as
+         *     the first event carrying the snapshot of completed chapter ids for
+         *     the active queue entry so the reconnect doesn't replay. See plan
+         *     `docs/features/102-global-queue-modal.md`.
          */
         post: operations["streamGeneration"];
         delete?: never;
@@ -1631,9 +1744,14 @@ export interface components {
              *     tick and `chapter_complete`, while the server concatenates the PCM,
              *     writes the MP3 + segments JSON, and updates state.json. Surfaces
              *     the disk-write phase so the UI doesn't look stalled at 99 %.
+             *     `resume_from` is emitted as the FIRST event on every new subscriber
+             *     (cold connect AND reconnect after `tsx watch` restart or server
+             *     bounce) and carries a snapshot of completed chapter ids for the
+             *     active queue entry so the reconnect doesn't replay completed work.
+             *     See plan `docs/features/102-global-queue-modal.md`.
              * @enum {string}
              */
-            type: "progress" | "chapter_assembling" | "chapter_complete" | "chapter_failed" | "idle";
+            type: "progress" | "chapter_assembling" | "chapter_complete" | "chapter_failed" | "idle" | "resume_from";
             chapterId?: number;
             /** @description null = chapter-wide tick (not character-specific). */
             characterId?: string | null;
@@ -1682,6 +1800,83 @@ export interface components {
              */
             audioModelKey?: "kokoro-v1" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
             errorReason?: string | null;
+            /**
+             * @description On `progress`, `chapter_assembling`, `chapter_complete`,
+             *     `chapter_failed`, and `resume_from` — the workspace queue entry
+             *     this tick belongs to. Lets the frontend map ticks to the right
+             *     queue row even when entries from different books interleave.
+             *     Optional for backward compat — older servers (pre-plan-102) omit
+             *     it and the frontend falls back to (bookId, chapterId) matching.
+             */
+            queueEntryId?: string;
+            /**
+             * @description Only on `resume_from` — list of chapter ids already complete on
+             *     disk for the active queue entry's containing run, so the frontend
+             *     can skip replaying `chapter_complete` ticks for them when the
+             *     server catches a new subscriber up.
+             */
+            resumeFromCompletedChapterIds?: number[];
+        };
+        QueueEntry: {
+            /** @description Stable unique entry id. Frontend-minted at enqueue time. */
+            id: string;
+            bookId: string;
+            chapterId: number;
+            /**
+             * @description `this` = (re)generate the named chapter. `character` = regenerate
+             *     the named character's lines in this chapter only. `forward` scope
+             *     (regenerate chapter N + all subsequent) is expanded by the
+             *     frontend at enqueue time into one `this` entry per affected
+             *     chapter — the slice never carries `forward` as a single row, so
+             *     every queue entry maps 1:1 to a chapter and the user can reorder
+             *     each chapter in a forward range individually.
+             * @enum {string}
+             */
+            scope: "this" | "character";
+            /** @description Required when scope === 'character'; null otherwise. */
+            characterId?: string | null;
+            /**
+             * Format: date-time
+             * @description ISO 8601 timestamp the entry was enqueued. Drives FIFO ordering when ties on `order` occur during concurrent enqueues.
+             */
+            addedAt: string;
+            /**
+             * @description `queued` = waiting. `in_progress` = currently synthesising
+             *     (pinned; non-draggable in the modal). `paused` = queue-global
+             *     pause flipped; still ordered, drains on resume. `done` = audio
+             *     on disk for this entry's chapter. `failed` = synthesis errored;
+             *     surfaces in the modal with a retry affordance.
+             * @enum {string}
+             */
+            status: "queued" | "in_progress" | "paused" | "done" | "failed";
+            /** @description Cross-book ordinal within the workspace queue. 0 = first to drain. Renumbered on every reorder. */
+            order: number;
+            /** @description Per-entry render progress (0..1), mirrored from the active GenerationTick. */
+            progress?: number;
+            /** @description Populated when status === 'failed'. */
+            errorReason?: string | null;
+        };
+        QueueListResponse: {
+            /** @description All workspace queue entries, sorted by `order` ascending. */
+            entries: components["schemas"]["QueueEntry"][];
+            /** @description Queue-global pause flag. When true, the dispatcher waits at the next chapter boundary. */
+            paused: boolean;
+        };
+        QueueEnqueueRequest: {
+            bookId: string;
+            /** @description One or more chapter ids to enqueue. The frontend pre-expands `forward` scope into per-chapter ids before posting. */
+            chapterIds: number[];
+            /**
+             * @default this
+             * @enum {string}
+             */
+            scope: "this" | "character";
+            /** @description Required when scope === 'character'. */
+            characterId?: string;
+        };
+        QueueReorderRequest: {
+            /** @description Full list of entry ids in the desired final order. Server validates the list matches the current queue minus the in-flight pinned entry; mismatch returns 409 (concurrent enqueue happened; client refetches and retries). */
+            order: string[];
         };
         VoiceSampleRequest: {
             /**
@@ -3365,6 +3560,136 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["VoiceMatchResponse"];
                 };
+            };
+        };
+    };
+    getQueue: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Queue snapshot */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["QueueListResponse"];
+                };
+            };
+        };
+    };
+    enqueueQueueEntries: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["QueueEnqueueRequest"];
+            };
+        };
+        responses: {
+            /** @description Resulting queue snapshot */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["QueueListResponse"];
+                };
+            };
+        };
+    };
+    reorderQueue: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["QueueReorderRequest"];
+            };
+        };
+        responses: {
+            /** @description Resulting queue snapshot */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["QueueListResponse"];
+                };
+            };
+            /** @description Order list doesn't match current non-pinned entries (e.g. stale view after a concurrent enqueue). */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    setQueuePaused: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    paused: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description Resulting queue snapshot */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["QueueListResponse"];
+                };
+            };
+        };
+    };
+    cancelQueueEntry: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                entryId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Resulting queue snapshot */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["QueueListResponse"];
+                };
+            };
+            /** @description Entry is in_progress; pause the queue first. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };


### PR DESCRIPTION
## Summary

Wave 1 of the global-queue-modal refactor (BACKLOG Must #3, plan 102). Lands the wire-level shape + the long-form design doc so all later waves can import types and consult invariants from a stable seam. No code wiring yet; Waves 2a (server) + 2b (frontend) follow in parallel once this lands.

**OpenAPI additions** (`openapi.yaml` + regenerated `src/lib/api-types.ts`):

- New `QueueEntry` schema (`{ id, bookId, chapterId, scope: 'this' | 'character', characterId?, addedAt, status, order, progress?, errorReason? }`). The BACKLOG-cited `scope: 'forward'` is expanded by the frontend at enqueue time into per-chapter entries so the wire shape never carries `'forward'` as a row — every queue entry maps 1:1 to a chapter, which keeps reorder freedom maximal.
- New `QueueListResponse`, `QueueEnqueueRequest`, `QueueReorderRequest` payload shapes.
- Five new routes: `GET /api/queue`, `POST /api/queue/enqueue`, `POST /api/queue/reorder`, `POST /api/queue/pause`, `DELETE /api/queue/{entryId}`.
- New `resume_from` event variant on the existing `GenerationTick` SSE schema. Two new fields: `queueEntryId` (mapping every progress / assembling / complete / failed tick back to its queue row even when entries from different books interleave) and `resumeFromCompletedChapterIds[]` (snapshot of completed chapter ids for the active queue entry). The ack is emitted as the FIRST event on every new subscriber — cold connect AND post-reconnect after `tsx watch` restart in dev or server bounce in production. Absorbs former BACKLOG Should #1.

**Design doc** (`docs/features/102-global-queue-modal.md`, `status: active`): full Benefit / Rationale, Architectural impact (new seams, invariants preserved, migration story, reversibility), 7 numbered invariants to preserve (cited with file:line refs to the existing surface), test plan with per-wave automated coverage + 16-step manual acceptance walkthrough using the canonical `C:\Users\dudar\Downloads\Bonus Keefe Story.txt` manuscript. References `~/.claude/plans/a-large-piece-of-refactored-bird.md` for the six-wave decomposition (scope-disjoint where parallel — `server` || `frontend.store` for Waves 2a/2b — serialized where shared hot files, integration branch only needed at the Wave 2a + 2b parallel split).

**INDEX.md entry** slotted under "G. Generation" alongside plan 16 (generation-stream) / 17 (regenerate this/forward) / 28 (chapter-audio-format) / 35 (engine-drift).

## Test plan

- [x] `npm run openapi:types` regenerated `src/lib/api-types.ts` cleanly (90.9ms).
- [x] `npm run typecheck` green on both frontend (`tsc --noEmit`) and server (`tsc --noEmit -p .`) — no consumer breakage from the new schema/route additions.
- [x] Pre-commit `npm run verify:fast` passed (validator + 1214 frontend tests + server tests).
- [x] Pre-push `npm run verify` passed end-to-end (typecheck + all tests + e2e + build).
- [ ] Consumers (queue slice, queue thunks, queue routes, queue modal) land in Waves 2a / 2b / 3 / 4 and ship their own paired tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)