### PR TITLE
feat(frontend): plan 102 wave 2b — queue slice + thunks + SSE auto-reconnect

### DIFF
--- a/src/lib/api-stream-reconnect.test.ts
+++ b/src/lib/api-stream-reconnect.test.ts
@@ -1,0 +1,133 @@
+/* Plan 102 — realStreamGeneration auto-reconnects on unexpected SSE end.
+ *
+ * Two scenarios verified:
+ *   1. Stream ends cleanly with no `idle` tick after at least one real tick →
+ *      reconnect once, deliver the next batch of ticks.
+ *   2. Stream ends with an `idle` tick → no reconnect (queue drained naturally).
+ *   3. Caller cancels via the returned canceller → no reconnect, even if no
+ *      idle tick was seen (user-initiated stop).
+ *
+ * Mocks `fetch` to return a streaming Response whose ReadableStream emits a
+ * controlled sequence of SSE frames, then closes. The reconnect strategy
+ * matches plan 102 invariant 6 (the resume_from server-side ack is the
+ * complementary piece, tested separately in
+ * server/src/routes/generation-resume-from.test.ts). */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** Build a Response whose body emits the given SSE frames then closes. */
+function sseResponse(frames: string[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const frame of frames) {
+        controller.enqueue(encoder.encode(`data: ${frame}\n\n`));
+      }
+      controller.close();
+    },
+  });
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    body: stream,
+    text: () => Promise.resolve(''),
+  } as unknown as Response;
+}
+
+/** Wait one macrotask so awaited fetches settle. */
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 25));
+
+describe('realStreamGeneration auto-reconnect', () => {
+  it('reconnects when the stream closes without an idle tick after seeing ticks', async () => {
+    const { api } = await import('./api');
+    /* First fetch: emit one progress tick then close (simulates tsx watch
+       restart mid-run). Second fetch: emit a chapter_complete + idle. */
+    fetchMock
+      .mockResolvedValueOnce(sseResponse([JSON.stringify({ type: 'progress', progress: 0.3 })]))
+      .mockResolvedValueOnce(
+        sseResponse([
+          JSON.stringify({ type: 'chapter_complete', chapterId: 1 }),
+          JSON.stringify({ type: 'idle' }),
+        ]),
+      );
+    const ticks: { type: string }[] = [];
+    const cancel = api.streamGeneration({
+      bookId: 'book-A',
+      modelKey: 'kokoro-v1',
+      chapterIds: [1],
+      queueEntryId: 'queue-entry-xyz',
+      onTick: (t) => ticks.push(t),
+    });
+    /* Wait long enough for backoff (500ms) + second fetch + tick parsing. */
+    await new Promise((r) => setTimeout(r, 800));
+    cancel();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    /* Both fetches POSTed with the same body — queueEntryId is preserved. */
+    expect(fetchMock.mock.calls[0][1].body).toContain('"queueEntryId":"queue-entry-xyz"');
+    expect(fetchMock.mock.calls[1][1].body).toContain('"queueEntryId":"queue-entry-xyz"');
+    /* All ticks delivered: progress + chapter_complete + idle. */
+    expect(ticks.map((t) => t.type)).toEqual(['progress', 'chapter_complete', 'idle']);
+  });
+
+  it('does NOT reconnect after receiving the idle tick (clean queue drain)', async () => {
+    const { api } = await import('./api');
+    fetchMock.mockResolvedValueOnce(
+      sseResponse([JSON.stringify({ type: 'progress' }), JSON.stringify({ type: 'idle' })]),
+    );
+    const ticks: { type: string }[] = [];
+    api.streamGeneration({
+      bookId: 'book-A',
+      modelKey: 'kokoro-v1',
+      onTick: (t) => ticks.push(t),
+    });
+    await flush();
+    await new Promise((r) => setTimeout(r, 600));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(ticks.map((t) => t.type)).toEqual(['progress', 'idle']);
+  });
+
+  it('does NOT reconnect when cancelled by the caller mid-stream', async () => {
+    const { api } = await import('./api');
+    fetchMock.mockResolvedValueOnce(
+      sseResponse([JSON.stringify({ type: 'progress' })]),
+      /* Second fetch would happen IF we reconnected — gate with a flag. */
+    );
+    const ticks: { type: string }[] = [];
+    const cancel = api.streamGeneration({
+      bookId: 'book-A',
+      modelKey: 'kokoro-v1',
+      onTick: (t) => ticks.push(t),
+    });
+    await flush();
+    cancel();
+    await new Promise((r) => setTimeout(r, 700));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT reconnect when the FIRST fetch never delivered a tick (setup error)', async () => {
+    const { api } = await import('./api');
+    /* Empty stream — server closed immediately. */
+    fetchMock.mockResolvedValueOnce(sseResponse([]));
+    const ticks: { type: string }[] = [];
+    api.streamGeneration({
+      bookId: 'book-A',
+      modelKey: 'kokoro-v1',
+      onTick: (t) => ticks.push(t),
+    });
+    await new Promise((r) => setTimeout(r, 600));
+    /* Only one fetch (no reconnect). */
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -403,6 +403,13 @@ export interface StreamArgs {
       the e2e harness can additionally seed `window.__mockGenConcurrency` to
       override without touching the middleware. */
   mockGenConcurrency?: number;
+  /** Plan 102 — workspace queue entry id this stream is fulfilling. Threaded
+      to the server so it can stamp every tick (including the new `resume_from`
+      ack) with the id, letting the frontend dispatcher correlate ticks back
+      to the right queue row even when entries from different books interleave.
+      Optional for back-compat — pre-plan-102 callers still work, ticks just
+      don't carry the field. */
+  queueEntryId?: string;
 }
 export interface AudioArgs {
   bookId: string;
@@ -2759,23 +2766,54 @@ async function realGetBaseVoiceSample({
 
 /* Real SSE reader for chapter generation. Mirrors the analysis-stream pattern
    above: open a long-running POST, parse `data: <json>` frames, dispatch each
-   payload to onTick. Returns a canceller that aborts the fetch. */
+   payload to onTick. Returns a canceller that aborts the fetch.
+
+   Plan 102 — auto-reconnect on unexpected stream end. Two failure modes today
+   would surface as "Worker has gone quiet" until pause-and-resume: (a) `tsx
+   watch` restarts the Node server during dev, (b) the server bounces in
+   production (Node OOM, manual restart). Both close the SSE without an
+   `idle` tick — the server-side `RunningJob` keeps generating (or restarts
+   from disk state) but the frontend stops listening. The reconnect loop
+   below reopens the same POST so the server emits its `resume_from` ack and
+   the queue keeps draining. Bounded by RECONNECT_MAX_ATTEMPTS and gated on
+   "we never saw an idle tick" — a clean idle is the only signal that the
+   run drained naturally, in which case there's nothing to reconnect to.
+   Absorbs former BACKLOG Should #1. */
+const RECONNECT_MAX_ATTEMPTS = 5;
+const RECONNECT_BACKOFF_MS = [500, 1000, 2000, 4000, 8000];
+
 function realStreamGeneration({
   bookId,
   modelKey,
   chapterIds,
   force,
+  queueEntryId,
   onTick: rawOnTick,
 }: StreamArgs): () => void {
   const onTick = safeOnTick(rawOnTick);
   const controller = new AbortController();
+  let attempt = 0;
+  let sawIdle = false;
+  let sawAnyTick = false;
+  let cancelled = false;
+  /* Track whether the controller has aborted so the inner catch can
+     distinguish "user clicked stop" (AbortError) from "fetch died mid-stream
+     and we want to reconnect". */
+  controller.signal.addEventListener('abort', () => {
+    cancelled = true;
+  });
 
-  void (async () => {
+  const openOnce = async (): Promise<{ shouldReconnect: boolean }> => {
     try {
       const res = await fetch(`/api/books/${encodeURIComponent(bookId)}/generation`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ modelKey, chapterIds, force }),
+        body: JSON.stringify({
+          modelKey,
+          chapterIds,
+          force,
+          ...(queueEntryId ? { queueEntryId } : {}),
+        }),
         signal: controller.signal,
       });
       if (!res.ok || !res.body) {
@@ -2784,7 +2822,7 @@ function realStreamGeneration({
           type: 'chapter_failed',
           errorReason: `Generation stream failed (${res.status}): ${detail || res.statusText}`,
         });
-        return;
+        return { shouldReconnect: false };
       }
 
       const reader = res.body.getReader();
@@ -2806,21 +2844,53 @@ function realStreamGeneration({
           if (!dataLines.length) continue;
           try {
             const payload = JSON.parse(dataLines.join('\n')) as GenerationTick;
+            sawAnyTick = true;
+            if (payload.type === 'idle') sawIdle = true;
             onTick(payload);
           } catch (e) {
             console.warn('[api] malformed generation tick:', dataLines.join('\n'), e);
           }
         }
       }
+      /* Stream ended cleanly (reader returned done: true). Reconnect only
+         when we haven't seen `idle` yet AND we saw at least one real tick
+         (so we know the server was alive — a 0-tick close is more likely a
+         setup error than a mid-flight bounce). */
+      return { shouldReconnect: !cancelled && !sawIdle && sawAnyTick };
     } catch (e) {
-      /* Aborts surface as DOMException 'AbortError' — that's the canceller
-         doing its job, not a real failure. Anything else is worth surfacing
-         as a failed tick so the UI can show something instead of hanging. */
-      if ((e as { name?: string })?.name === 'AbortError') return;
+      if ((e as { name?: string })?.name === 'AbortError') return { shouldReconnect: false };
+      /* Network error / server bounce mid-stream lands here. If we'd already
+         seen ticks, reconnect — the queue likely still has work. Otherwise
+         the failure is the first POST itself; surface to the caller. */
+      if (sawAnyTick && !sawIdle) {
+        return { shouldReconnect: true };
+      }
       onTick({
         type: 'chapter_failed',
         errorReason: (e as Error).message ?? 'Generation stream failed.',
       });
+      return { shouldReconnect: false };
+    }
+  };
+
+  void (async () => {
+    while (attempt < RECONNECT_MAX_ATTEMPTS) {
+      const { shouldReconnect } = await openOnce();
+      if (!shouldReconnect || cancelled) return;
+      const backoff = RECONNECT_BACKOFF_MS[Math.min(attempt, RECONNECT_BACKOFF_MS.length - 1)];
+      attempt += 1;
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(() => {
+          controller.signal.removeEventListener('abort', cancelDuringWait);
+          resolve();
+        }, backoff);
+        const cancelDuringWait = () => {
+          clearTimeout(timer);
+          resolve();
+        };
+        controller.signal.addEventListener('abort', cancelDuringWait);
+      });
+      if (cancelled) return;
     }
   })();
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -43,6 +43,7 @@ import { exportsSlice } from './exports-slice';
 import { analysisSlice } from './analysis-slice';
 import { notificationsSlice } from './notifications-slice';
 import { listenProgressSlice } from './listen-progress-slice';
+import { queueSlice } from './queue-slice';
 import { persistenceMiddleware } from './persistence-middleware';
 import { generationStreamMiddleware } from './generation-stream-middleware';
 import { analysisStreamMiddleware } from './analysis-stream-middleware';
@@ -121,6 +122,7 @@ export const store = configureStore({
     analysis: analysisSlice.reducer,
     notifications: notificationsSlice.reducer,
     listenProgress: listenProgressSlice.reducer,
+    queue: queueSlice.reducer,
   },
   middleware: (getDefault) =>
     getDefault({

--- a/src/store/queue-slice.test.ts
+++ b/src/store/queue-slice.test.ts
@@ -1,0 +1,119 @@
+/* Unit tests for queue-slice (plan 102). */
+
+import { describe, it, expect } from 'vitest';
+import {
+  queueActions,
+  queueSlice,
+  selectInFlightEntry,
+  selectQueueByBook,
+  selectQueueCount,
+  selectQueueEntries,
+  selectQueueEntryById,
+  selectQueueLoaded,
+  selectQueuePaused,
+  type QueueEntry,
+  type QueueState,
+} from './queue-slice';
+
+const sampleEntry = (overrides: Partial<QueueEntry> = {}): QueueEntry => ({
+  id: 'e1',
+  bookId: 'book-A',
+  chapterId: 1,
+  scope: 'this',
+  addedAt: '2026-05-23T00:00:00.000Z',
+  status: 'queued',
+  order: 0,
+  ...overrides,
+});
+
+const initial: QueueState = queueSlice.getInitialState();
+
+describe('queueSlice.setSnapshot', () => {
+  it('replaces entries + paused + flips loaded=true', () => {
+    const next = queueSlice.reducer(
+      initial,
+      queueActions.setSnapshot({
+        entries: [sampleEntry({ id: 'e1', order: 0 }), sampleEntry({ id: 'e2', order: 1 })],
+        paused: true,
+      }),
+    );
+    expect(next.entries).toHaveLength(2);
+    expect(next.paused).toBe(true);
+    expect(next.loaded).toBe(true);
+  });
+
+  it('overwrites prior entries (server-authoritative)', () => {
+    let s = queueSlice.reducer(
+      initial,
+      queueActions.setSnapshot({ entries: [sampleEntry({ id: 'old' })], paused: false }),
+    );
+    s = queueSlice.reducer(
+      s,
+      queueActions.setSnapshot({
+        entries: [sampleEntry({ id: 'new', chapterId: 2, order: 0 })],
+        paused: false,
+      }),
+    );
+    expect(s.entries.map((e) => e.id)).toEqual(['new']);
+  });
+});
+
+describe('queueSlice.reset', () => {
+  it('flips back to initial state', () => {
+    const populated = queueSlice.reducer(
+      initial,
+      queueActions.setSnapshot({ entries: [sampleEntry()], paused: true }),
+    );
+    expect(queueSlice.reducer(populated, queueActions.reset())).toEqual(initial);
+  });
+});
+
+describe('selectors', () => {
+  const populated: { queue: QueueState } = {
+    queue: {
+      entries: [
+        sampleEntry({ id: 'a1', bookId: 'book-A', chapterId: 1, order: 0, status: 'in_progress' }),
+        sampleEntry({ id: 'b1', bookId: 'book-B', chapterId: 5, order: 1 }),
+        sampleEntry({ id: 'a2', bookId: 'book-A', chapterId: 2, order: 2 }),
+      ],
+      paused: false,
+      loaded: true,
+    },
+  };
+
+  it('selectQueueEntries returns the array', () => {
+    expect(selectQueueEntries(populated)).toHaveLength(3);
+  });
+
+  it('selectQueuePaused returns the flag', () => {
+    expect(selectQueuePaused(populated)).toBe(false);
+  });
+
+  it('selectQueueLoaded returns the load flag', () => {
+    expect(selectQueueLoaded(populated)).toBe(true);
+  });
+
+  it('selectQueueCount returns the length', () => {
+    expect(selectQueueCount(populated)).toBe(3);
+  });
+
+  it('selectQueueEntryById finds an entry by id', () => {
+    expect(selectQueueEntryById('b1')(populated)?.chapterId).toBe(5);
+    expect(selectQueueEntryById('missing')(populated)).toBeUndefined();
+  });
+
+  it('selectQueueByBook groups by bookId in arrival order', () => {
+    const grouped = selectQueueByBook(populated);
+    expect(grouped.map((g) => g.bookId)).toEqual(['book-A', 'book-B']);
+    expect(grouped[0].entries.map((e) => e.id)).toEqual(['a1', 'a2']);
+    expect(grouped[1].entries.map((e) => e.id)).toEqual(['b1']);
+  });
+
+  it('selectInFlightEntry returns the in_progress entry or null', () => {
+    expect(selectInFlightEntry(populated)?.id).toBe('a1');
+    const empty: { queue: QueueState } = {
+      queue: { entries: [sampleEntry()], paused: false, loaded: true },
+    };
+    expect(selectInFlightEntry(empty)).toBeNull();
+  });
+});

--- a/src/store/queue-slice.ts
+++ b/src/store/queue-slice.ts
@@ -1,0 +1,92 @@
+/* Plan 102 — workspace-level chapter-generation queue slice.
+ *
+ * Mirrors `<workspace>/.queue.json` (server-side persistence at
+ * server/src/workspace/queue-io.ts). Reducers are pure derivations of the
+ * server file shape; mutations route through `queue-thunks.ts` which POSTs
+ * to /api/queue/* then dispatches the resulting snapshot back.
+ *
+ * The slice is the source of truth for what the queue modal renders. The
+ * generation-stream-middleware reads from it to decide what to dispatch
+ * next (Wave 4 — the dispatcher rewrite that consumes this slice landed
+ * separately so Wave 2b stays focused on the foundation + reconnect). */
+
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import type { components } from '../lib/api-types';
+
+export type QueueEntry = components['schemas']['QueueEntry'];
+export type QueueScope = QueueEntry['scope'];
+export type QueueStatus = QueueEntry['status'];
+
+export interface QueueState {
+  entries: QueueEntry[];
+  /** Queue-global pause flag — flipped via POST /api/queue/pause. When true
+      the dispatcher waits at the next chapter boundary; the in-flight entry
+      runs to completion before the drain stops. */
+  paused: boolean;
+  /** First-load gate — true after the initial GET /api/queue completes. The
+      modal renders empty-state UI vs spinner based on this. */
+  loaded: boolean;
+}
+
+const initialState: QueueState = {
+  entries: [],
+  paused: false,
+  loaded: false,
+};
+
+export const queueSlice = createSlice({
+  name: 'queue',
+  initialState,
+  reducers: {
+    /** Replace the whole snapshot — called by every queue-thunk after a
+        successful round-trip. The server is authoritative; the slice is a
+        mirror. */
+    setSnapshot: (s, a: PayloadAction<{ entries: QueueEntry[]; paused: boolean }>) => {
+      s.entries = a.payload.entries;
+      s.paused = a.payload.paused;
+      s.loaded = true;
+    },
+    /** Mark the queue as not-yet-loaded — used when the slice is reset
+        (e.g. workspace switch in future multi-workspace mode). */
+    reset: () => initialState,
+  },
+});
+
+export const queueActions = queueSlice.actions;
+
+/* --- Selectors ------------------------------------------------- */
+
+interface RootSliceShape {
+  queue: QueueState;
+}
+
+export const selectQueueEntries = (s: RootSliceShape): QueueEntry[] => s.queue.entries;
+export const selectQueuePaused = (s: RootSliceShape): boolean => s.queue.paused;
+export const selectQueueLoaded = (s: RootSliceShape): boolean => s.queue.loaded;
+export const selectQueueCount = (s: RootSliceShape): number => s.queue.entries.length;
+
+/** Find an entry by id — used by the modal's per-row reorder/cancel buttons. */
+export const selectQueueEntryById = (id: string) => (s: RootSliceShape): QueueEntry | undefined =>
+  s.queue.entries.find((e) => e.id === id);
+
+/** Entries grouped by bookId, preserving cross-book order. Cheap to recompute
+    per render because the modal needs both the flat list AND the per-book
+    grouping (for the "Book A · n chapters" headers). */
+export const selectQueueByBook = (s: RootSliceShape): { bookId: string; entries: QueueEntry[] }[] => {
+  const grouped: Record<string, QueueEntry[]> = {};
+  const order: string[] = [];
+  for (const entry of s.queue.entries) {
+    if (!grouped[entry.bookId]) {
+      grouped[entry.bookId] = [];
+      order.push(entry.bookId);
+    }
+    grouped[entry.bookId].push(entry);
+  }
+  return order.map((bookId) => ({ bookId, entries: grouped[bookId] }));
+};
+
+/** The current in-flight entry (status === 'in_progress'), or null. Pinned at
+    order=0 by the server-side queue-io contract; the modal uses this to know
+    which row is non-draggable. */
+export const selectInFlightEntry = (s: RootSliceShape): QueueEntry | null =>
+  s.queue.entries.find((e) => e.status === 'in_progress') ?? null;

--- a/src/store/queue-thunks.test.ts
+++ b/src/store/queue-thunks.test.ts
@@ -1,0 +1,180 @@
+/* Unit tests for queue-thunks (plan 102).
+ *
+ * Mocks `fetch` and asserts (a) the request shape sent to /api/queue/*,
+ * (b) the dispatched setSnapshot action carries the parsed response,
+ * (c) the toast fires on enqueue / cancel-of-in_progress. */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { configureStore } from '@reduxjs/toolkit';
+import { queueSlice, type QueueEntry } from './queue-slice';
+import { notificationsSlice } from './notifications-slice';
+import {
+  cancelQueueEntry,
+  enqueueQueueEntries,
+  loadQueue,
+  reorderQueue,
+  setQueuePaused,
+} from './queue-thunks';
+
+const sampleEntry = (overrides: Partial<QueueEntry> = {}): QueueEntry => ({
+  id: 'e1',
+  bookId: 'book-A',
+  chapterId: 1,
+  scope: 'this',
+  addedAt: '2026-05-23T00:00:00.000Z',
+  status: 'queued',
+  order: 0,
+  ...overrides,
+});
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/* Test store typed with AppDispatch so dispatch(thunk) typechecks the same
+   way it does in the real store. */
+type TestDispatch = (action: unknown) => Promise<unknown>;
+function makeStore(): {
+  getState: () => { queue: ReturnType<typeof queueSlice.reducer>; notifications: ReturnType<typeof notificationsSlice.reducer> };
+  dispatch: TestDispatch;
+} {
+  const store = configureStore({
+    reducer: { queue: queueSlice.reducer, notifications: notificationsSlice.reducer },
+  });
+  return store as unknown as {
+    getState: typeof store.getState;
+    dispatch: TestDispatch;
+  };
+}
+
+function mockJsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'ERR',
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+describe('loadQueue', () => {
+  it('GETs /api/queue and dispatches setSnapshot', async () => {
+    fetchMock.mockResolvedValue(
+      mockJsonResponse({ entries: [sampleEntry({ id: 'q1' })], paused: false }),
+    );
+    const store = makeStore();
+    await store.dispatch(loadQueue());
+    expect(fetchMock).toHaveBeenCalledWith('/api/queue');
+    expect(store.getState().queue.entries).toHaveLength(1);
+    expect(store.getState().queue.entries[0].id).toBe('q1');
+    expect(store.getState().queue.loaded).toBe(true);
+  });
+
+  it('throws on non-2xx', async () => {
+    fetchMock.mockResolvedValue(mockJsonResponse({ error: 'workspace missing' }, 500));
+    const store = makeStore();
+    await expect(store.dispatch(loadQueue())).rejects.toThrowError(/workspace missing/);
+  });
+});
+
+describe('enqueueQueueEntries', () => {
+  it('POSTs the entries to /api/queue/enqueue + dispatches the snapshot + fires toast', async () => {
+    fetchMock.mockResolvedValue(
+      mockJsonResponse({
+        entries: [sampleEntry({ id: 'a1' }), sampleEntry({ id: 'a2', chapterId: 2, order: 1 })],
+        paused: false,
+      }),
+    );
+    const store = makeStore();
+    await store.dispatch(
+      enqueueQueueEntries([
+        { id: 'a1', bookId: 'book-A', chapterId: 1, scope: 'this' },
+        { id: 'a2', bookId: 'book-A', chapterId: 2, scope: 'this' },
+      ]),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/queue/enqueue',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: expect.stringContaining('"id":"a1"'),
+      }),
+    );
+    expect(store.getState().queue.entries).toHaveLength(2);
+    /* Toast pushed via notificationsActions.pushToast — assert via slice. */
+    const toasts = store.getState().notifications.toasts;
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].message).toContain('Added to queue');
+    expect(toasts[0].message).toContain('2 entries pending');
+  });
+
+  it('singularises the toast message when count === 1', async () => {
+    fetchMock.mockResolvedValue(
+      mockJsonResponse({ entries: [sampleEntry({ id: 'a1' })], paused: false }),
+    );
+    const store = makeStore();
+    await store.dispatch(
+      enqueueQueueEntries([{ id: 'a1', bookId: 'book-A', chapterId: 1, scope: 'this' }]),
+    );
+    expect(store.getState().notifications.toasts[0].message).toContain('1 entry pending');
+  });
+});
+
+describe('reorderQueue', () => {
+  it('POSTs the desired order + dispatches the snapshot', async () => {
+    fetchMock.mockResolvedValue(
+      mockJsonResponse({
+        entries: [sampleEntry({ id: 'a2', order: 0 }), sampleEntry({ id: 'a1', order: 1 })],
+        paused: false,
+      }),
+    );
+    const store = makeStore();
+    await store.dispatch(reorderQueue(['a2', 'a1']));
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/queue/reorder',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ order: ['a2', 'a1'] }),
+      }),
+    );
+    expect(store.getState().queue.entries.map((e) => e.id)).toEqual(['a2', 'a1']);
+  });
+});
+
+describe('setQueuePaused', () => {
+  it('flips the global pause flag via /api/queue/pause', async () => {
+    fetchMock.mockResolvedValue(mockJsonResponse({ entries: [], paused: true }));
+    const store = makeStore();
+    await store.dispatch(setQueuePaused(true));
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/queue/pause',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ paused: true }) }),
+    );
+    expect(store.getState().queue.paused).toBe(true);
+  });
+});
+
+describe('cancelQueueEntry', () => {
+  it('DELETEs and dispatches the snapshot on success', async () => {
+    fetchMock.mockResolvedValue(mockJsonResponse({ entries: [], paused: false }));
+    const store = makeStore();
+    await store.dispatch(cancelQueueEntry('e1'));
+    expect(fetchMock).toHaveBeenCalledWith('/api/queue/e1', { method: 'DELETE' });
+  });
+
+  it('on 409 pops a warn toast + re-throws so the caller can recover', async () => {
+    fetchMock.mockResolvedValue(mockJsonResponse({ error: 'entry is in_progress' }, 409));
+    const store = makeStore();
+    await expect(store.dispatch(cancelQueueEntry('inflight'))).rejects.toThrowError(/in_progress/);
+    const toasts = store.getState().notifications.toasts;
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].kind).toBe('warn');
+    expect(toasts[0].message).toContain('Pause the queue');
+  });
+});

--- a/src/store/queue-thunks.ts
+++ b/src/store/queue-thunks.ts
@@ -1,0 +1,135 @@
+/* Plan 102 — workspace queue CRUD thunks.
+ *
+ * Wrap the /api/queue/* routes (server side: server/src/routes/queue.ts) and
+ * dispatch the resulting snapshot back to queue-slice. Every thunk follows
+ * the same shape:
+ *   1. POST/GET/DELETE the route.
+ *   2. Parse response { entries, paused }.
+ *   3. Dispatch queueActions.setSnapshot(...).
+ *   4. Fire a notifications toast on enqueue (mirrors the spec — "Added to
+ *      queue · n entries pending" with a "View queue" CTA).
+ *
+ * All thunks throw on non-2xx; callers wrap in try/catch when they want to
+ * surface a specific error UI (the existing 10 regenerate sites already
+ * have error-handling wrappers — they'll route their existing flows into
+ * `enqueueQueueEntries` in Wave 4). */
+
+import type { AppDispatch } from './index';
+import { queueActions, type QueueEntry, type QueueScope } from './queue-slice';
+import { notificationsActions } from './notifications-slice';
+
+export interface EnqueueInput {
+  /** Frontend-minted unique id. Deterministic for tests; in production we
+      use a crypto.randomUUID() prefixed by the source ("regen-modal-...") for
+      easier debugging. */
+  id: string;
+  bookId: string;
+  chapterId: number;
+  scope: QueueScope;
+  /** Required when scope === 'character'. */
+  characterId?: string;
+  addedAt?: string;
+}
+
+interface QueueSnapshotResponse {
+  entries: QueueEntry[];
+  paused: boolean;
+}
+
+async function readSnapshot(res: Response): Promise<QueueSnapshotResponse> {
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? `${res.status} ${res.statusText}`);
+  }
+  return res.json() as Promise<QueueSnapshotResponse>;
+}
+
+/** GET /api/queue — cold-boot hydrate. Mount-time effect in Layout should
+    call this once on app start so the modal renders the persisted queue
+    even across hard reload / server bounce. */
+export function loadQueue() {
+  return async (dispatch: AppDispatch): Promise<void> => {
+    const res = await fetch('/api/queue');
+    const snapshot = await readSnapshot(res);
+    dispatch(queueActions.setSnapshot(snapshot));
+  };
+}
+
+/** POST /api/queue/enqueue — append one or more entries. The 10 regenerate
+    trigger sites funnel through here (Wave 4). Pops a toast with the new
+    count + a "View queue" CTA. */
+export function enqueueQueueEntries(entries: EnqueueInput[]) {
+  return async (dispatch: AppDispatch): Promise<QueueSnapshotResponse> => {
+    const res = await fetch('/api/queue/enqueue', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ entries }),
+    });
+    const snapshot = await readSnapshot(res);
+    dispatch(queueActions.setSnapshot(snapshot));
+    const count = snapshot.entries.length;
+    dispatch(
+      notificationsActions.pushToast({
+        kind: 'info',
+        message: `Added to queue · ${count} ${count === 1 ? 'entry' : 'entries'} pending.`,
+        dedupeKey: 'queue-enqueue',
+      }),
+    );
+    return snapshot;
+  };
+}
+
+/** POST /api/queue/reorder — move non-pinned entries to the desired order.
+    The modal calls this on drop / tap-pill release. */
+export function reorderQueue(desiredOrder: string[]) {
+  return async (dispatch: AppDispatch): Promise<QueueSnapshotResponse> => {
+    const res = await fetch('/api/queue/reorder', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ order: desiredOrder }),
+    });
+    const snapshot = await readSnapshot(res);
+    dispatch(queueActions.setSnapshot(snapshot));
+    return snapshot;
+  };
+}
+
+/** POST /api/queue/pause — flip the queue-global pause flag. The relocated
+    Resume/Pause control inside the modal calls this. */
+export function setQueuePaused(paused: boolean) {
+  return async (dispatch: AppDispatch): Promise<QueueSnapshotResponse> => {
+    const res = await fetch('/api/queue/pause', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ paused }),
+    });
+    const snapshot = await readSnapshot(res);
+    dispatch(queueActions.setSnapshot(snapshot));
+    return snapshot;
+  };
+}
+
+/** DELETE /api/queue/:entryId — cancel a queued entry. The modal's per-row
+    cancel button calls this. Server 409s if the entry is in_progress; we
+    surface a toast in that case rather than re-throwing because the user's
+    intent is clear (they wanted to drop the entry) and surfacing a
+    structured error keeps the flow self-explanatory. */
+export function cancelQueueEntry(entryId: string) {
+  return async (dispatch: AppDispatch): Promise<QueueSnapshotResponse> => {
+    const res = await fetch(`/api/queue/${encodeURIComponent(entryId)}`, { method: 'DELETE' });
+    if (res.status === 409) {
+      dispatch(
+        notificationsActions.pushToast({
+          kind: 'warn',
+          message: 'Pause the queue before cancelling the in-flight entry.',
+          dedupeKey: `queue-cancel-${entryId}`,
+        }),
+      );
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      throw new Error(body.error ?? '409 entry is in_progress');
+    }
+    const snapshot = await readSnapshot(res);
+    dispatch(queueActions.setSnapshot(snapshot));
+    return snapshot;
+  };
+}


### PR DESCRIPTION
## Summary

Frontend foundation for the global queue modal (plan 102). Scoped tightly: lands the queue-slice + queue-thunks (CRUD wrappers around the `/api/queue` routes from Wave 2a #183) and the SSE auto-reconnect inside `realStreamGeneration`.

**Plan rebaseline:** the original Wave 2b spec lumps the generation-stream middleware rewrite + chapters-slice strip into this PR. Those pieces are load-bearing only when the 10 regenerate sites actually start dispatching through the queue — which is Wave 4's work anyway. Splitting Wave 2b this way lets Wave 3 (modal UI) start in parallel against the slice without waiting for a middleware rewrite that doesn't change observable behaviour for an empty queue. The middleware rewrite + `chapters-slice` strip + `broadcast-middleware` extension follow in Wave 4 alongside the regen-site rewiring (where the old code path can be removed atomically with the new dispatch routes).

**New files:**

- `src/store/queue-slice.ts` — createSlice + 7 selectors (`selectQueueEntries`, `selectQueuePaused`, `selectQueueLoaded`, `selectQueueCount`, `selectQueueEntryById`, `selectQueueByBook` for cross-book grouping in the modal headers, `selectInFlightEntry`). Server-authoritative model: every mutator route returns the full snapshot which is set wholesale via `queueActions.setSnapshot`.
- `src/store/queue-thunks.ts` — five thunks (`loadQueue`, `enqueueQueueEntries`, `reorderQueue`, `setQueuePaused`, `cancelQueueEntry`). Each: `fetch` → parse → `setSnapshot`. `enqueueQueueEntries` also pops a notifications toast "Added to queue · N entries pending" with singular/plural agreement. `cancelQueueEntry`'s 409 path pops a warn toast "Pause the queue before cancelling the in-flight entry" before re-throwing.

**Existing-file edits:**

- `src/store/index.ts` wires `queue-slice` into the root reducer alongside `listenProgress` (the previous bottom-of-the-list slot).
- `src/lib/api.ts` adds optional `queueEntryId` to `StreamArgs`; threads it into the `/api/books/:bookId/generation` POST body; adds auto-reconnect to `realStreamGeneration`. Reconnect strategy: bounded retries (`RECONNECT_MAX_ATTEMPTS=5`) with exponential backoff (500ms → 1s → 2s → 4s → 8s); only reconnects when the stream closed without an `idle` tick AND at least one tick was seen (so we know the server was alive — a 0-tick close is a setup error, not a mid-flight bounce); cancellation via the returned canceller suppresses reconnect cleanly even during the backoff sleep. **Absorbs former BACKLOG Should #1** — paired with Wave 2a's `resume_from` server-side ack, the user no longer sees "Worker has gone quiet" after a `tsx watch` restart in dev or a production server bounce.

**Paired tests** (3 new files, 22 new test cases):

- `queue-slice.test.ts` — reducers (setSnapshot replaces wholesale, flips loaded=true; reset returns to initial) + every selector (entries, paused, loaded, count, entryById, byBook grouping, inFlightEntry).
- `queue-thunks.test.ts` — mocks fetch + asserts request shape (URL + method + body) + dispatched setSnapshot + toast side effects (count agreement, kind=warn on 409).
- `api-stream-reconnect.test.ts` — builds streaming ReadableStream Responses to drive the SSE parser; pins (a) reconnect happens when stream closes without idle after tick activity, (b) no reconnect after idle, (c) no reconnect when caller cancels mid-stream, (d) no reconnect when first fetch never delivered a tick.

## Test plan

- [x] `npm run typecheck` green (frontend + server).
- [x] `npm test` — 1613 passed across 109 files (+22 new vs 1591 baseline).
- [x] Pre-commit `npm run verify:fast` + pre-push `npm run verify` both passed (after one Windows-cosmetic Vitest worker-teardown flake retry on the first push attempt).
- [ ] Middleware rewrite + `chapters-slice` strip + broadcast extension — deferred to Wave 4 with the regen-site rewiring; called out explicitly in the commit body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)