### PR TITLE
feat(frontend): plan 102 wave 3 — global queue modal + top-bar chip

### DIFF
--- a/src/components/layout.test.tsx
+++ b/src/components/layout.test.tsx
@@ -30,6 +30,7 @@ import { accountSlice } from '../store/account-slice';
 import { bookMetaSlice } from '../store/book-meta-slice';
 import { exportsSlice } from '../store/exports-slice';
 import { analysisSlice } from '../store/analysis-slice';
+import { queueSlice } from '../store/queue-slice';
 
 const getBookStateMock = vi.fn();
 const pollRevisionsMock = vi.fn();
@@ -104,6 +105,7 @@ function makeStore() {
       bookMeta: bookMetaSlice.reducer,
       exports: exportsSlice.reducer,
       analysis: analysisSlice.reducer,
+      queue: queueSlice.reducer,
     },
   });
 }

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -43,6 +43,8 @@ import { DriftReportModal } from '../modals/drift-report';
 import { ProfileDrawer } from '../modals/profile-drawer';
 import { ReattributeLinesModal } from '../modals/reattribute-lines';
 import { ConfirmDialog } from '../modals/confirm-dialog';
+import { QueueModalContainer } from '../modals/queue-modal';
+import { loadQueue } from '../store/queue-thunks';
 import { ToastStack } from './toast-stack';
 import { RevisionDiffPlayer } from '../views/revision-diff';
 import { RevisionTimelineModal } from './revision-timeline-modal';
@@ -89,6 +91,9 @@ export function Layout() {
   const stage = useAppSelector((s) => s.ui.stage);
   const ui = useAppSelector((s) => s.ui);
   const userDisplayName = useAppSelector((s) => s.account.displayName);
+  /* Plan 102 — workspace queue count drives the top-bar queue chip + the
+     Generate view's "View queue" button visibility. */
+  const queueCount = useAppSelector((s) => s.queue.entries.length);
   /* Plan 89 C3 — `characters` and `chapters.chapters` are large arrays the
      Layout reads every render. Use shallow equality so unrelated slice mutations
      (e.g. a foreign book's drift poll bumping `revisions`, or a heartbeat tick
@@ -208,6 +213,15 @@ export function Layout() {
   const navigate = useNavigate();
   const location = useLocation();
   const skipFirst = useRef(true);
+  /* Plan 102 — cold-boot hydrate of the workspace queue. One call per app
+     mount; the modal re-fetches on every open to catch cross-tab mutations
+     since we deliberately don't broadcast queue actions over BroadcastChannel
+     in v1 (single-writer per-workspace contract holds). */
+  useEffect(() => {
+    dispatch(loadQueue()).catch((e: unknown) => {
+      console.warn('[layout] initial loadQueue failed', e);
+    });
+  }, [dispatch]);
   useEffect(() => {
     if (skipFirst.current) {
       skipFirst.current = false;
@@ -868,6 +882,8 @@ export function Layout() {
           import.meta.env.DEV ? () => dispatch(uiActions.openWorktrees()) : undefined
         }
         userDisplayName={userDisplayName}
+        queueCount={queueCount}
+        onOpenQueue={() => dispatch(uiActions.openQueueModal())}
       />
 
       {/* Plan 89 C5 — single shared Suspense boundary for the route-leaf
@@ -1234,6 +1250,8 @@ export function Layout() {
           onClose={() => setReattributeModal(null)}
         />
       )}
+      <QueueModalContainer />
+
       {ui.showRevisionPlayer && pending[0] && bookId && (
         <RevisionDiffPlayer
           revision={pending[0]}

--- a/src/components/theme-toggle.test.tsx
+++ b/src/components/theme-toggle.test.tsx
@@ -44,6 +44,7 @@ function makeStore({
     ttsModelKeyExplicit: false,
     themeOverride,
     reuploadingBookId: null,
+    queueModalOpen: false,
   };
   const accountPreloaded: AccountState = {
     ...FRONTEND_ACCOUNT_DEFAULTS,

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -81,6 +81,12 @@ interface TopBarProps {
       driven by `useTtsLifecycle()` mounted once in Layout, so its state stays
       in sync with whatever the Generation view's local pill is showing. */
   ttsPill?: ReactNode;
+  /** Plan 102 — workspace queue count. When > 0, renders a compact chip in
+      the top-right cluster that opens the global queue modal on click. When
+      0, the chip is hidden. */
+  queueCount?: number;
+  /** Plan 102 — click handler for the queue chip; dispatched by Layout. */
+  onOpenQueue?: () => void;
 }
 
 const TABS: Array<{ id: View; label: string }> = [
@@ -118,6 +124,8 @@ export function TopBar({
   generationPill,
   analysisPill,
   ttsPill,
+  queueCount,
+  onOpenQueue,
 }: TopBarProps) {
   const showGlobalNav = stage === 'books' || stage === 'voices' || stage === 'changelog';
   const onGlobal = (id: 'books' | 'voices' | 'changelog') => {
@@ -224,6 +232,18 @@ export function TopBar({
               className={`text-xs font-mono px-2 py-1 rounded-md transition-colors hover:bg-ink/5 ${stage === 'worktrees' ? 'bg-ink/10 ring-1 ring-ink/20' : 'text-ink/50'}`}
             >
               wt
+            </button>
+          )}
+          {(queueCount ?? 0) > 0 && onOpenQueue && (
+            <button
+              type="button"
+              onClick={onOpenQueue}
+              aria-label={`Generation queue — ${queueCount} pending`}
+              title="Generation queue"
+              data-testid="topbar-queue-chip"
+              className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-peach/15 hover:bg-peach/25 text-magenta text-xs font-semibold min-h-[44px] sm:min-h-0"
+            >
+              Queue · {queueCount}
             </button>
           )}
           <ThemeToggleButton />

--- a/src/lib/use-theme.test.tsx
+++ b/src/lib/use-theme.test.tsx
@@ -45,6 +45,7 @@ function makeStore({
     ttsModelKeyExplicit: false,
     themeOverride,
     reuploadingBookId: null,
+    queueModalOpen: false,
   };
   const accountPreloaded: AccountState = {
     ...FRONTEND_ACCOUNT_DEFAULTS,

--- a/src/modals/queue-modal.test.tsx
+++ b/src/modals/queue-modal.test.tsx
@@ -1,0 +1,220 @@
+/* Plan 102 — QueueModal RTL tests. Asserts:
+ *   - opens/closes via ui-slice state
+ *   - renders entries grouped by book with book-title resolution
+ *   - in-flight entry has no reorder/cancel buttons (pinned + non-droppable)
+ *   - Move-up / Move-down buttons dispatch reorder thunk with correct order
+ *   - Cancel button dispatches cancel thunk
+ *   - Pause toggle dispatches setPaused thunk with the inverted flag
+ *   - On open, loadQueue() is dispatched (cross-tab freshness) */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { QueueModal } from './queue-modal';
+import { queueSlice, type QueueEntry } from '../store/queue-slice';
+import { notificationsSlice } from '../store/notifications-slice';
+import { librarySlice } from '../store/library-slice';
+import type { LibraryBook } from '../lib/types';
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const entry = (overrides: Partial<QueueEntry> = {}): QueueEntry => ({
+  id: 'e1',
+  bookId: 'book-A',
+  chapterId: 1,
+  scope: 'this',
+  addedAt: '2026-05-23T00:00:00.000Z',
+  status: 'queued',
+  order: 0,
+  ...overrides,
+});
+
+const libraryBook = (bookId: string, title: string): LibraryBook => ({
+  bookId,
+  title,
+  author: 'Test Author',
+  status: 'complete',
+  thumbnail: null,
+  manuscriptId: 'm_test',
+  chapters: [],
+  characters: [],
+  updatedAt: '2026-05-23T00:00:00.000Z',
+  series: 'Standalones',
+  audioFormat: 'mp3',
+} as unknown as LibraryBook);
+
+function renderModal(entries: QueueEntry[], opts: { paused?: boolean; books?: LibraryBook[] } = {}) {
+  const store = configureStore({
+    reducer: {
+      queue: queueSlice.reducer,
+      notifications: notificationsSlice.reducer,
+      library: librarySlice.reducer,
+    },
+    preloadedState: {
+      queue: { entries, paused: opts.paused ?? false, loaded: true },
+      library: {
+        books: opts.books ?? [],
+        pausedSnapshots: {},
+      } as ReturnType<typeof librarySlice.reducer>,
+    },
+  });
+  /* loadQueue thunk fires on open — return an empty snapshot so the re-fetch
+     doesn't blow away the preloaded state. */
+  fetchMock.mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ entries, paused: opts.paused ?? false }),
+  });
+  const onClose = vi.fn();
+  return {
+    store,
+    onClose,
+    ...render(
+      <Provider store={store}>
+        <QueueModal open={true} onClose={onClose} />
+      </Provider>,
+    ),
+  };
+}
+
+describe('QueueModal', () => {
+  it('renders the empty state when no entries are queued', () => {
+    renderModal([]);
+    expect(screen.getByText('Empty')).toBeInTheDocument();
+    expect(screen.getByText(/No chapters queued/)).toBeInTheDocument();
+  });
+
+  it('renders entries grouped by book with the book title from library', () => {
+    renderModal(
+      [
+        entry({ id: 'a1', bookId: 'book-A', chapterId: 1, order: 0 }),
+        entry({ id: 'b1', bookId: 'book-B', chapterId: 5, order: 1 }),
+      ],
+      { books: [libraryBook('book-A', 'Book Alpha'), libraryBook('book-B', 'Book Beta')] },
+    );
+    expect(screen.getByText('Book Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Book Beta')).toBeInTheDocument();
+    expect(screen.getByTestId('queue-entry-a1')).toBeInTheDocument();
+    expect(screen.getByTestId('queue-entry-b1')).toBeInTheDocument();
+  });
+
+  it('falls back to bookId when the library doesn\'t know the book', () => {
+    renderModal([entry({ id: 'a1', bookId: 'unknown-book' })]);
+    expect(screen.getByText('unknown-book')).toBeInTheDocument();
+  });
+
+  it('shows "n entries pending" with plural agreement in the header', () => {
+    renderModal([entry({ id: 'a1' })]);
+    expect(screen.getByText('1 entry pending')).toBeInTheDocument();
+  });
+
+  it('pluralizes correctly when count > 1', () => {
+    renderModal([
+      entry({ id: 'a1', order: 0 }),
+      entry({ id: 'a2', chapterId: 2, order: 1 }),
+    ]);
+    expect(screen.getByText('2 entries pending')).toBeInTheDocument();
+  });
+
+  it('marks the in-flight entry visually + hides its reorder/cancel buttons', () => {
+    renderModal([
+      entry({ id: 'a1', status: 'in_progress', order: 0, progress: 0.42 }),
+      entry({ id: 'a2', chapterId: 2, order: 1 }),
+    ]);
+    /* In-flight entry has no move/cancel buttons. */
+    expect(screen.queryByTestId('queue-entry-a1-up')).toBeNull();
+    expect(screen.queryByTestId('queue-entry-a1-down')).toBeNull();
+    expect(screen.queryByTestId('queue-entry-a1-cancel')).toBeNull();
+    /* The other entry has them. */
+    expect(screen.getByTestId('queue-entry-a2-up')).toBeInTheDocument();
+    expect(screen.getByTestId('queue-entry-a2-down')).toBeInTheDocument();
+    expect(screen.getByTestId('queue-entry-a2-cancel')).toBeInTheDocument();
+    /* In-flight status line shows progress. */
+    expect(screen.getByText(/In flight · 42%/)).toBeInTheDocument();
+  });
+
+  it('Move-down dispatches reorder thunk excluding the in-flight pinned entry', async () => {
+    renderModal([
+      entry({ id: 'a1', status: 'in_progress', order: 0 }),
+      entry({ id: 'a2', chapterId: 2, order: 1 }),
+      entry({ id: 'a3', chapterId: 3, order: 2 }),
+    ]);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ entries: [], paused: false }),
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('queue-entry-a2-down'));
+    });
+    const reorderCall = fetchMock.mock.calls.find((c) => c[0] === '/api/queue/reorder');
+    expect(reorderCall).toBeDefined();
+    /* In-flight a1 is excluded from the order array; a3 moves before a2. */
+    expect(reorderCall![1].body).toContain('"order":["a3","a2"]');
+  });
+
+  it('Cancel dispatches the cancel thunk', async () => {
+    renderModal([
+      entry({ id: 'a1', status: 'in_progress' }),
+      entry({ id: 'a2', chapterId: 2, order: 1 }),
+    ]);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ entries: [], paused: false }),
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('queue-entry-a2-cancel'));
+    });
+    const cancelCall = fetchMock.mock.calls.find((c) => c[0] === '/api/queue/a2');
+    expect(cancelCall).toBeDefined();
+    expect(cancelCall![1].method).toBe('DELETE');
+  });
+
+  it('Pause toggle flips paused via /api/queue/pause', async () => {
+    renderModal([entry({ id: 'a1' })]);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ entries: [entry({ id: 'a1' })], paused: true }),
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('queue-modal-pause'));
+    });
+    const pauseCall = fetchMock.mock.calls.find((c) => c[0] === '/api/queue/pause');
+    expect(pauseCall).toBeDefined();
+    expect(pauseCall![1].body).toBe('{"paused":true}');
+  });
+
+  it('shows Resume button when paused', () => {
+    renderModal([entry({ id: 'a1' })], { paused: true });
+    expect(screen.getByText('Resume')).toBeInTheDocument();
+  });
+
+  it('closes via the backdrop click', () => {
+    const { onClose } = renderModal([entry({ id: 'a1' })]);
+    fireEvent.click(screen.getByTestId('queue-modal-backdrop'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('dispatches loadQueue on open (cross-tab freshness)', async () => {
+    renderModal([]);
+    /* The mount-time loadQueue fires; assert via fetchMock since the
+       thunk routes through fetch. */
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+    const loadCall = fetchMock.mock.calls.find((c) => c[0] === '/api/queue');
+    expect(loadCall).toBeDefined();
+  });
+});

--- a/src/modals/queue-modal.tsx
+++ b/src/modals/queue-modal.tsx
@@ -1,0 +1,279 @@
+/* Plan 102 — global queue modal.
+ *
+ * Mounted in Layout; renders nothing when `ui.queueModalOpen` is false.
+ * Lists every workspace queue entry grouped by book, with per-row
+ * Move-up / Move-down / Cancel actions and a queue-global Resume / Pause
+ * control at the top. The in-flight entry is pinned at the top of its book
+ * group and the reorder pills are hidden on it.
+ *
+ * Responsive per CLAUDE.md mobile protocol:
+ *   - phone (`<640px`)  → full-screen sheet
+ *   - tablet/desktop     → dialog centered on screen
+ *
+ * The reorder UI is tap-pill only for v1 (Move up / Move down buttons).
+ * Drag-to-reorder lives in a follow-up (BACKLOG) — tap pills satisfy the
+ * touch-equivalence rule for desktop AND mobile in one path, keeping the
+ * shipped modal small. Touch targets are ≥44×44 px per WCAG 2.5.5. */
+
+import { useMemo, useEffect } from 'react';
+import { useAppDispatch, useAppSelector } from '../store';
+import {
+  selectInFlightEntry,
+  selectQueueByBook,
+  selectQueueCount,
+  selectQueueLoaded,
+  selectQueuePaused,
+  type QueueEntry,
+} from '../store/queue-slice';
+import {
+  cancelQueueEntry,
+  loadQueue,
+  reorderQueue,
+  setQueuePaused,
+} from '../store/queue-thunks';
+import { uiActions } from '../store/ui-slice';
+import { IconClose, IconPause, IconPlay, IconTrash } from '../lib/icons';
+import { PrimaryButton } from '../components/primitives';
+
+interface QueueModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function QueueModal({ open, onClose }: QueueModalProps) {
+  const dispatch = useAppDispatch();
+  const groupedByBook = useAppSelector(selectQueueByBook);
+  const paused = useAppSelector(selectQueuePaused);
+  const loaded = useAppSelector(selectQueueLoaded);
+  const count = useAppSelector(selectQueueCount);
+  const inFlight = useAppSelector(selectInFlightEntry);
+  const bookTitles = useAppSelector((s) => s.library.books);
+
+  /* Refresh the queue snapshot whenever the modal opens — covers the
+     cross-tab case where another tab mutated the queue while ours was
+     closed. Cheap call (one /api/queue GET). */
+  useEffect(() => {
+    if (open) {
+      dispatch(loadQueue()).catch((e: unknown) => {
+        console.warn('[queue-modal] loadQueue failed', e);
+      });
+    }
+  }, [open, dispatch]);
+
+  const lookupBookTitle = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const b of bookTitles) map.set(b.bookId, b.title);
+    return (bookId: string): string => map.get(bookId) ?? bookId;
+  }, [bookTitles]);
+
+  if (!open) return null;
+
+  const togglePause = (): void => {
+    dispatch(setQueuePaused(!paused)).catch((e: unknown) => {
+      console.warn('[queue-modal] setPaused failed', e);
+    });
+  };
+
+  return (
+    <>
+      <div
+        onClick={onClose}
+        className="fixed inset-0 bg-ink/40 z-50 fade-in"
+        data-testid="queue-modal-backdrop"
+      />
+      <div
+        className="fixed inset-0 z-50 grid sm:place-items-center sm:p-6 pointer-events-none"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Generation queue"
+      >
+        <div className="bg-white sm:rounded-3xl shadow-float w-full h-full sm:h-auto sm:max-w-2xl sm:max-h-[90vh] pointer-events-auto fade-in flex flex-col">
+          {/* Header */}
+          <div className="px-6 py-4 border-b border-ink/10 flex items-center gap-3 sticky top-0 bg-white/95 backdrop-blur-md">
+            <div className="flex-1 min-w-0">
+              <p className="text-[10px] uppercase tracking-widest text-ink/50 font-semibold">
+                Generation queue
+              </p>
+              <h3 className="text-base font-bold text-ink">
+                {count === 0 ? 'Empty' : `${count} ${count === 1 ? 'entry' : 'entries'} pending`}
+              </h3>
+            </div>
+            {count > 0 && (
+              <button
+                onClick={togglePause}
+                className="inline-flex items-center gap-1.5 px-3 py-2 rounded-full bg-ink/5 hover:bg-ink/10 text-sm font-medium text-ink min-h-[44px] sm:min-h-0"
+                data-testid="queue-modal-pause"
+              >
+                {paused ? (
+                  <>
+                    <IconPlay className="w-4 h-4" /> Resume
+                  </>
+                ) : (
+                  <>
+                    <IconPause className="w-4 h-4" /> Pause
+                  </>
+                )}
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="p-2 rounded-full hover:bg-ink/5 text-ink/60 min-h-[44px] min-w-[44px] sm:min-h-0 sm:min-w-0"
+              aria-label="Close queue"
+            >
+              <IconClose className="w-4 h-4" />
+            </button>
+          </div>
+
+          {/* Body */}
+          <div className="px-6 py-5 flex-1 overflow-y-auto">
+            {!loaded ? (
+              <p className="text-sm text-ink/60">Loading queue…</p>
+            ) : count === 0 ? (
+              <div className="py-10 text-center">
+                <p className="text-sm text-ink/60">No chapters queued.</p>
+                <p className="text-xs text-ink/40 mt-1">
+                  Click "Add to queue" on any chapter to start.
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-6">
+                {groupedByBook.map(({ bookId, entries }) => (
+                  <BookGroup
+                    key={bookId}
+                    title={lookupBookTitle(bookId)}
+                    entries={entries}
+                    inFlightId={inFlight?.id ?? null}
+                    onReorder={(newOrderForGroup) => {
+                      /* Reorder within the GROUP requires building the full
+                         workspace-level order: keep the in-flight entry first
+                         (pinned), then this group's new order, then any other
+                         book's entries in their existing order. */
+                      const orderable = groupedByBook
+                        .flatMap((g) =>
+                          g.bookId === bookId ? newOrderForGroup : g.entries,
+                        )
+                        .filter((e) => e.id !== inFlight?.id)
+                        .map((e) => e.id);
+                      dispatch(reorderQueue(orderable)).catch((e: unknown) => {
+                        console.warn('[queue-modal] reorder failed', e);
+                      });
+                    }}
+                    onCancel={(entryId) => {
+                      dispatch(cancelQueueEntry(entryId)).catch(() => {
+                        /* Toast surfaced inside the thunk's 409 handler. */
+                      });
+                    }}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+interface BookGroupProps {
+  title: string;
+  entries: QueueEntry[];
+  inFlightId: string | null;
+  onReorder: (entries: QueueEntry[]) => void;
+  onCancel: (entryId: string) => void;
+}
+
+function BookGroup({ title, entries, inFlightId, onReorder, onCancel }: BookGroupProps) {
+  const moveUp = (idx: number): void => {
+    if (idx <= 0) return;
+    const next = [...entries];
+    [next[idx - 1], next[idx]] = [next[idx], next[idx - 1]];
+    onReorder(next);
+  };
+  const moveDown = (idx: number): void => {
+    if (idx >= entries.length - 1) return;
+    const next = [...entries];
+    [next[idx], next[idx + 1]] = [next[idx + 1], next[idx]];
+    onReorder(next);
+  };
+
+  return (
+    <section>
+      <h4 className="text-xs uppercase tracking-widest text-ink/50 font-semibold mb-2">
+        {title}
+      </h4>
+      <ul className="space-y-1.5" data-testid={`queue-modal-group-${title}`}>
+        {entries.map((entry, idx) => {
+          const isInFlight = entry.id === inFlightId;
+          return (
+            <li
+              key={entry.id}
+              data-testid={`queue-entry-${entry.id}`}
+              className={`flex items-center gap-2 px-3 py-2 rounded-2xl border ${
+                isInFlight ? 'border-magenta/40 bg-magenta/5' : 'border-ink/10 bg-white'
+              }`}
+            >
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-medium text-ink truncate">
+                  Chapter {entry.chapterId}
+                  {entry.characterId ? ` · ${entry.characterId}` : ''}
+                </div>
+                <div className="text-xs text-ink/50">
+                  {isInFlight
+                    ? `In flight${entry.progress != null ? ` · ${Math.round(entry.progress * 100)}%` : ''}`
+                    : entry.status === 'failed'
+                      ? `Failed${entry.errorReason ? ` · ${entry.errorReason}` : ''}`
+                      : entry.status === 'paused'
+                        ? 'Paused'
+                        : 'Queued'}
+                </div>
+              </div>
+              {!isInFlight && (
+                <>
+                  <button
+                    onClick={() => moveUp(idx)}
+                    disabled={idx === 0}
+                    aria-label="Move up"
+                    className="p-2 rounded-full hover:bg-ink/5 text-ink/60 disabled:opacity-30 disabled:cursor-not-allowed min-h-[44px] min-w-[44px] sm:min-h-0 sm:min-w-0"
+                    data-testid={`queue-entry-${entry.id}-up`}
+                  >
+                    ↑
+                  </button>
+                  <button
+                    onClick={() => moveDown(idx)}
+                    disabled={idx === entries.length - 1}
+                    aria-label="Move down"
+                    className="p-2 rounded-full hover:bg-ink/5 text-ink/60 disabled:opacity-30 disabled:cursor-not-allowed min-h-[44px] min-w-[44px] sm:min-h-0 sm:min-w-0"
+                    data-testid={`queue-entry-${entry.id}-down`}
+                  >
+                    ↓
+                  </button>
+                  <button
+                    onClick={() => onCancel(entry.id)}
+                    aria-label="Cancel entry"
+                    className="p-2 rounded-full hover:bg-red-50 text-ink/60 hover:text-red-700 min-h-[44px] min-w-[44px] sm:min-h-0 sm:min-w-0"
+                    data-testid={`queue-entry-${entry.id}-cancel`}
+                  >
+                    <IconTrash className="w-4 h-4" />
+                  </button>
+                </>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+/** Convenience component that wires the modal to ui-slice state — mount this
+    directly in Layout instead of QueueModal so callers don't have to plumb
+    open/onClose. */
+export function QueueModalContainer(): JSX.Element {
+  const dispatch = useAppDispatch();
+  const open = useAppSelector((s) => s.ui.queueModalOpen);
+  return <QueueModal open={open} onClose={() => dispatch(uiActions.closeQueueModal())} />;
+}
+
+/* Re-export from primitives for direct consumers; unused here but the
+   modal's "View queue" CTA in callers may want a typed button. */
+export { PrimaryButton };

--- a/src/store/ui-slice.test.ts
+++ b/src/store/ui-slice.test.ts
@@ -29,6 +29,7 @@ const baseState = (stage: Stage): UiState => ({
   ttsModelKeyExplicit: false,
   themeOverride: null,
   reuploadingBookId: null,
+  queueModalOpen: false,
 });
 
 describe('uiSlice — openBook status→stage routing', () => {

--- a/src/store/ui-slice.ts
+++ b/src/store/ui-slice.ts
@@ -79,6 +79,10 @@ export interface UiState {
       Apply / Discard or whenever the upload stage exits. Transient —
       not persisted. */
   reuploadingBookId: string | null;
+  /** Plan 102 — true while the global Queue modal is open. The modal is
+      mounted in Layout and reachable from the top-bar queue chip + the
+      Generate view's "View queue" button. */
+  queueModalOpen: boolean;
 }
 
 const initialState: UiState = {
@@ -102,6 +106,7 @@ const initialState: UiState = {
   ttsModelKeyExplicit: false,
   themeOverride: null,
   reuploadingBookId: null,
+  queueModalOpen: false,
 };
 
 export const uiSlice = createSlice({
@@ -267,6 +272,15 @@ export const uiSlice = createSlice({
     },
     setThemeOverride: (s, a: PayloadAction<'light' | 'dark' | 'system'>) => {
       s.themeOverride = a.payload;
+    },
+    /* Plan 102 — global Queue modal open/close. The modal is mounted in
+       Layout and renders nothing when closed; both the top-bar queue chip
+       and the Generate view's "View queue" button dispatch openQueueModal. */
+    openQueueModal: (s) => {
+      s.queueModalOpen = true;
+    },
+    closeQueueModal: (s) => {
+      s.queueModalOpen = false;
     },
     clearThemeOverride: (s) => {
       s.themeOverride = null;


### PR DESCRIPTION
## Summary

Wave 3 lands the user-visible surfaces for the queue: a responsive modal mounted globally in Layout and a top-bar queue chip that opens it. The chip is hidden when count===0 so it stays out of the way for users who never enqueue work.

**Plan deferral:** the Generate-view button changes — View queue + Add to queue buttons, Resume/Pause relocation, chapter row id + scroll consumer — intentionally defer to Wave 4 alongside the regen-site rewiring. They live in the same `generation.tsx` body and coordinate cleanly with the dispatch-target swap from `chaptersActions.regenerate*` to `queueThunks.enqueueQueueEntries`.

**New files:**

- `src/modals/queue-modal.tsx` — exports `QueueModal` (presentational, props-driven open/onClose) plus `QueueModalContainer` (wired to `ui.queueModalOpen` via `useAppSelector` + dispatches `ui-slice` `closeQueueModal`). Responsive per CLAUDE.md mobile protocol: full-screen sheet on `<640px`, centered dialog with `rounded-3xl` + `shadow-float` on `≥sm`. Renders entries grouped by book with book-title resolution via `library.books` fallback to `bookId`. Per-row Move-up / Move-down / Cancel buttons; in-flight entry (`status === 'in_progress'`) is pinned with the magenta-tinted border AND has its action buttons hidden so it's non-droppable visually + functionally. Move pills compute the new desired order by interleaving the group's reordered entries with other books' existing order, then dispatch `reorderQueue` thunk with the in-flight entry excluded. Touch targets ≥44×44 px per WCAG 2.5.5. Modal re-fetches queue on every open (`loadQueue`) for cross-tab freshness.

**Existing-file edits:**

- `src/store/ui-slice.ts` adds `queueModalOpen: boolean` state + `openQueueModal`/`closeQueueModal` reducers.
- `src/components/layout.tsx` mounts `QueueModalContainer`, adds mount-time `loadQueue` dispatch, passes `queueCount` + `onOpenQueue` to `TopBar`.
- `src/components/top-bar.tsx` adds optional `queueCount` + `onOpenQueue` props; chip uses peach/magenta palette + aria-label includes the count.

**Test-fixture fixups:** four existing test files extended with `queueModalOpen: false` UiState field / `queueSlice.reducer` store entry.

## Test plan

- [x] `npm run typecheck` — green (frontend + server).
- [x] `npm test` — 1625 passed across 110 files (+12 new queue-modal cases).
- [x] `npm run lint` — clean.
- [x] Pre-commit + pre-push verify both green (took two amends: one for an unused-var lint warning, one for a misplaced `LibraryBook` type import — both caught by hooks on push attempts before the third succeeded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)