### PR TITLE
feat(frontend): plan 102 wave 4a — queue dispatcher middleware + Generate view rewire

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -44,7 +44,7 @@ import { ProfileDrawer } from '../modals/profile-drawer';
 import { ReattributeLinesModal } from '../modals/reattribute-lines';
 import { ConfirmDialog } from '../modals/confirm-dialog';
 import { QueueModalContainer } from '../modals/queue-modal';
-import { loadQueue } from '../store/queue-thunks';
+import { loadQueue, enqueueQueueEntries } from '../store/queue-thunks';
 import { ToastStack } from './toast-stack';
 import { RevisionDiffPlayer } from '../views/revision-diff';
 import { RevisionTimelineModal } from './revision-timeline-modal';
@@ -944,9 +944,15 @@ export function Layout() {
                (rendered below) doesn't stack on top of it. */
             dispatch(uiActions.setRegenChapter(null));
             reverseAnalyzerGuard(() => {
-              if (chapter) {
-                const affectedCount =
-                  scope === 'forward' ? chapters.filter((c) => c.id >= chapter.id).length : 1;
+              if (chapter && bookId) {
+                /* Plan 102 — expand 'forward' at enqueue time into one
+                   queue entry per affected chapter so the user can
+                   reorder each one individually in the modal. 'this'
+                   stays a single entry. */
+                const targetIds =
+                  scope === 'forward'
+                    ? chapters.filter((c) => c.id >= chapter.id).map((c) => c.id)
+                    : [chapter.id];
                 dispatch(
                   changeLogActions.appendLogEvent(
                     buildChapterRegenEvent({
@@ -954,11 +960,25 @@ export function Layout() {
                       scope,
                       reason,
                       note,
-                      affectedChapterCount: affectedCount,
+                      affectedChapterCount: targetIds.length,
                     }),
                   ),
                 );
-                dispatch(chaptersActions.regenerateChapter({ chapterId: chapter.id, scope }));
+                /* Server requires unique entry ids. Prefix with source +
+                   chapter id + a short rand suffix so the same chapter
+                   can be enqueued twice from different sessions without
+                   colliding. */
+                const rand = Math.random().toString(36).slice(2, 8);
+                void dispatch(
+                  enqueueQueueEntries(
+                    targetIds.map((chapterId) => ({
+                      id: `regen-modal-${bookId}-${chapterId}-${rand}`,
+                      bookId,
+                      chapterId,
+                      scope: 'this',
+                    })),
+                  ),
+                );
               }
               dispatch(uiActions.changeView('generate'));
             });

--- a/src/routes/index.test.tsx
+++ b/src/routes/index.test.tsx
@@ -18,6 +18,7 @@ import { castSlice, castActions } from '../store/cast-slice';
 import { chaptersSlice } from '../store/chapters-slice';
 import { manuscriptSlice, manuscriptActions } from '../store/manuscript-slice';
 import { librarySlice, libraryActions } from '../store/library-slice';
+import { queueSlice } from '../store/queue-slice';
 import { revisionsSlice } from '../store/revisions-slice';
 import { voicesSlice } from '../store/voices-slice';
 import { changeLogSlice } from '../store/change-log-slice';
@@ -114,6 +115,7 @@ function makeStore() {
       changeLog: changeLogSlice.reducer,
       account: accountSlice.reducer,
       bookMeta: bookMetaSlice.reducer,
+      queue: queueSlice.reducer,
     },
   });
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -48,6 +48,7 @@ import { persistenceMiddleware } from './persistence-middleware';
 import { generationStreamMiddleware } from './generation-stream-middleware';
 import { analysisStreamMiddleware } from './analysis-stream-middleware';
 import { broadcastMiddleware } from './broadcast-middleware';
+import { queueDispatcherMiddleware } from './queue-dispatcher-middleware';
 
 /** Persisted ui-slice keys. Stage so refresh restores the same view +
  *  chapter + drawer; model selectors so the user's per-session picks
@@ -139,6 +140,7 @@ export const store = configureStore({
       generationStreamMiddleware,
       analysisStreamMiddleware,
       broadcastMiddleware,
+      queueDispatcherMiddleware,
     ),
 });
 

--- a/src/store/queue-dispatcher-middleware.test.ts
+++ b/src/store/queue-dispatcher-middleware.test.ts
@@ -1,0 +1,210 @@
+/* Unit tests for queue-dispatcher-middleware (plan 102 Wave 4a).
+ *
+ * The dispatcher drains the workspace queue by dispatching regenerateChapter
+ * for the head entry when same-book conditions are met. These tests use a
+ * minimal store wiring the queue + chapters slices and the dispatcher
+ * middleware; they assert (a) when a regenerate fires, (b) when it doesn't,
+ * (c) that completion (clearActiveStream) triggers a DELETE round-trip,
+ * (d) pause halts dispatch. */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { configureStore } from '@reduxjs/toolkit';
+import { queueSlice, type QueueEntry } from './queue-slice';
+import { chaptersSlice } from './chapters-slice';
+import { uiSlice } from './ui-slice';
+import { notificationsSlice } from './notifications-slice';
+import { queueDispatcherMiddleware } from './queue-dispatcher-middleware';
+
+const entry = (overrides: Partial<QueueEntry> = {}): QueueEntry => ({
+  id: 'e1',
+  bookId: 'book-A',
+  chapterId: 3,
+  scope: 'this',
+  addedAt: '2026-05-23T00:00:00.000Z',
+  status: 'queued',
+  order: 0,
+  ...overrides,
+});
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function jsonResp(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: () => Promise.resolve(body),
+  } as Response;
+}
+
+function makeStore() {
+  return configureStore({
+    reducer: {
+      ui: uiSlice.reducer,
+      queue: queueSlice.reducer,
+      chapters: chaptersSlice.reducer,
+      notifications: notificationsSlice.reducer,
+    },
+    middleware: (getDefault) =>
+      getDefault({ serializableCheck: false }).concat(queueDispatcherMiddleware),
+  });
+}
+
+/** Helper — flush microtasks (the dispatcher defers tick() via
+    queueMicrotask). */
+async function flushMicro(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('queue-dispatcher-middleware', () => {
+  it('dispatches regenerateChapter for the head entry when book matches and no stream is active', async () => {
+    const store = makeStore();
+    /* Seed currentBookId so the same-book gate clears. */
+    store.dispatch(chaptersSlice.actions.setCurrentBookId('book-A'));
+    /* Seed a chapter row so regenerateChapter has something to mutate. */
+    store.dispatch(
+      chaptersSlice.actions.setChapters([
+        {
+          id: 3,
+          title: 'Chapter 3',
+          state: 'done',
+          progress: 1,
+          duration: '0:30',
+          characters: {},
+        },
+      ] as never),
+    );
+
+    /* Cold-boot snapshot — first GET landed, empty queue. */
+    store.dispatch(queueSlice.actions.setSnapshot({ entries: [], paused: false }));
+    await flushMicro();
+    expect(store.getState().chapters.pendingRegen).toBeNull();
+
+    /* Now an entry arrives via setSnapshot — dispatcher should fire. */
+    store.dispatch(
+      queueSlice.actions.setSnapshot({ entries: [entry()], paused: false }),
+    );
+    await flushMicro();
+    expect(store.getState().chapters.pendingRegen).toEqual({ chapterIds: [3], force: true });
+  });
+
+  it('does not dispatch when the queue is paused', async () => {
+    const store = makeStore();
+    store.dispatch(chaptersSlice.actions.setCurrentBookId('book-A'));
+    store.dispatch(
+      chaptersSlice.actions.setChapters([
+        { id: 3, title: 'Chapter 3', state: 'done', progress: 1, duration: '0:30', characters: {} },
+      ] as never),
+    );
+    store.dispatch(queueSlice.actions.setSnapshot({ entries: [entry()], paused: true }));
+    await flushMicro();
+    expect(store.getState().chapters.pendingRegen).toBeNull();
+  });
+
+  it('does not dispatch when the head entry is for a different book (same-book gate)', async () => {
+    const store = makeStore();
+    store.dispatch(chaptersSlice.actions.setCurrentBookId('book-A'));
+    store.dispatch(
+      chaptersSlice.actions.setChapters([
+        { id: 3, title: 'Chapter 3', state: 'done', progress: 1, duration: '0:30', characters: {} },
+      ] as never),
+    );
+    store.dispatch(
+      queueSlice.actions.setSnapshot({
+        entries: [entry({ bookId: 'book-B' })],
+        paused: false,
+      }),
+    );
+    await flushMicro();
+    expect(store.getState().chapters.pendingRegen).toBeNull();
+  });
+
+  it('does not dispatch while an SSE handle is open (activeStream non-null)', async () => {
+    const store = makeStore();
+    store.dispatch(chaptersSlice.actions.setCurrentBookId('book-A'));
+    store.dispatch(
+      chaptersSlice.actions.setChapters([
+        { id: 3, title: 'Chapter 3', state: 'done', progress: 1, duration: '0:30', characters: {} },
+      ] as never),
+    );
+    /* Simulate the existing middleware having opened an SSE for some other
+       work. */
+    store.dispatch(
+      chaptersSlice.actions.setActiveStream({
+        bookId: 'book-A',
+        modelKey: 'kokoro-v1',
+        done: 0,
+        total: 5,
+        inProgress: 1,
+        lastTickAt: Date.now(),
+        halted: false,
+      } as never),
+    );
+    store.dispatch(queueSlice.actions.setSnapshot({ entries: [entry()], paused: false }));
+    await flushMicro();
+    expect(store.getState().chapters.pendingRegen).toBeNull();
+  });
+
+  it('DELETEs the in-flight entry when the SSE finishes (clearActiveStream)', async () => {
+    const store = makeStore();
+    store.dispatch(chaptersSlice.actions.setCurrentBookId('book-A'));
+    store.dispatch(
+      chaptersSlice.actions.setChapters([
+        { id: 3, title: 'Chapter 3', state: 'done', progress: 1, duration: '0:30', characters: {} },
+      ] as never),
+    );
+    /* Seed the queue + let dispatcher fire regenerate. */
+    store.dispatch(queueSlice.actions.setSnapshot({ entries: [entry()], paused: false }));
+    await flushMicro();
+    expect(store.getState().chapters.pendingRegen).not.toBeNull();
+
+    /* Simulate the existing middleware opening the SSE → setActiveStream. */
+    store.dispatch(
+      chaptersSlice.actions.setActiveStream({
+        bookId: 'book-A',
+        modelKey: 'kokoro-v1',
+        done: 0,
+        total: 1,
+        inProgress: 1,
+        lastTickAt: Date.now(),
+        halted: false,
+      } as never),
+    );
+    await flushMicro();
+
+    /* Now the SSE finishes — closeHandle dispatches clearActiveStream. */
+    fetchMock.mockResolvedValueOnce(jsonResp({ entries: [], paused: false }));
+    store.dispatch(chaptersSlice.actions.clearActiveStream());
+    await flushMicro();
+    await flushMicro();
+
+    /* Dispatcher should have fired DELETE /api/queue/e1. */
+    expect(fetchMock).toHaveBeenCalledWith('/api/queue/e1', { method: 'DELETE' });
+  });
+
+  it('waits for the cold-boot snapshot before doing anything', async () => {
+    const store = makeStore();
+    store.dispatch(chaptersSlice.actions.setCurrentBookId('book-A'));
+    store.dispatch(
+      chaptersSlice.actions.setChapters([
+        { id: 3, title: 'Chapter 3', state: 'done', progress: 1, duration: '0:30', characters: {} },
+      ] as never),
+    );
+    /* No setSnapshot yet — loaded is false. Even if the queue magically had
+       entries (it can't until setSnapshot fires, but defense-in-depth), the
+       dispatcher would do nothing. We assert by checking that just setting
+       chapters (which is a trigger type) doesn't fire a regenerate. */
+    await flushMicro();
+    expect(store.getState().chapters.pendingRegen).toBeNull();
+  });
+});

--- a/src/store/queue-dispatcher-middleware.ts
+++ b/src/store/queue-dispatcher-middleware.ts
@@ -1,0 +1,128 @@
+/* Plan 102 Wave 4a — queue dispatcher middleware.
+ *
+ * Drains the workspace queue (queue-slice mirror of <workspace>/.queue.json)
+ * one chapter at a time. The contract is intentionally narrow so the existing
+ * generation-stream middleware keeps owning the SSE lifecycle:
+ *
+ *   1. Pick the head queued entry whose bookId matches the slice's currently
+ *      loaded book (same-book gate — cross-book dispatch is Wave 4b).
+ *   2. Dispatch chaptersActions.regenerateChapter for that chapter; the
+ *      existing middleware opens the SSE for it.
+ *   3. When the SSE finishes (idle tick → activeStream cleared), DELETE
+ *      the entry from the server queue. The resulting setSnapshot fires
+ *      tick() again, which picks the next entry (or stops).
+ *
+ * Local state (inFlightEntryId) is the source of truth for "which entry
+ * did I dispatch a regenerate for." The server-side status field stays
+ * "queued" the whole way; we never call /start. The modal infers in-flight
+ * visually by correlating the head entry's bookId/chapterId with the
+ * chapters slice's activeStream snapshot (Wave 4b).
+ *
+ * Bug fix surface (per plan 102 doc):
+ *   - Regenerate-during-regenerate no longer drops in-flight work.
+ *     The 10 regen sites now append to the queue instead of dispatching
+ *     regenerateChapter directly. The dispatcher serialises them so the
+ *     in-flight chapter keeps streaming uninterrupted. */
+
+import type { Middleware, MiddlewareAPI } from '@reduxjs/toolkit';
+import { chaptersActions, type ChaptersState } from './chapters-slice';
+import { queueActions, type QueueState } from './queue-slice';
+import { cancelQueueEntry } from './queue-thunks';
+import type { UiState } from './ui-slice';
+import type { AppDispatch } from './index';
+
+interface DispatcherRootState {
+  ui: UiState;
+  chapters: ChaptersState;
+  queue: QueueState;
+}
+
+export const queueDispatcherMiddleware: Middleware = (storeApi: MiddlewareAPI) => {
+  /* Which entry did the dispatcher last fire regenerateChapter for. The
+     entry is DELETEd from the server queue when the SSE completes (idle
+     tick → clearActiveStream). Null between drains. */
+  let inFlightEntryId: string | null = null;
+
+  const dispatch = storeApi.dispatch as AppDispatch;
+
+  const tick = (): void => {
+    const state = storeApi.getState() as DispatcherRootState;
+    const { queue, chapters } = state;
+
+    /* Cold-boot gate — wait for the initial GET /api/queue before doing
+       anything. Without this, an empty pre-load snapshot would tempt the
+       dispatcher to do nothing (correct) but also masks the "is the queue
+       authoritative yet?" question for tests. */
+    if (!queue.loaded) return;
+
+    /* Queue-global pause stops the drain at the next boundary. The
+       in-flight chapter (if any) finishes — the existing middleware
+       handles its own teardown — but the dispatcher won't pick up the
+       next entry while paused. */
+    if (queue.paused) return;
+
+    /* If an SSE handle is open, wait for it to drain. This covers both
+       (a) our own regenerate that's still in flight, and (b) any other
+       open path the existing middleware drove (e.g. cold-boot auto-
+       resume of slice-queued chapters). We never run two SSEs at once. */
+    if (chapters.activeStream) return;
+
+    /* activeStream is null. If we were tracking an entry, the chapter
+       just completed (or the stream was torn down — pause, halt, etc.).
+       DELETE the entry from the server queue then return; the resulting
+       setSnapshot re-fires tick() to pick up the next entry. */
+    if (inFlightEntryId) {
+      const completed = inFlightEntryId;
+      inFlightEntryId = null;
+      void dispatch(cancelQueueEntry(completed)).catch(() => {
+        /* 409 — server thinks the entry is in_progress (shouldn't happen
+           on the same-book path because we never call /start, but be
+           defensive); or 404 — already gone (idempotent). Swallow either
+           way; the queue snapshot will catch up on the next /api/queue
+           hit. */
+      });
+      return;
+    }
+
+    /* Find the next entry whose status is 'queued'. Skip 'failed' /
+       'paused' entries — those linger for the user to inspect or act on
+       manually, the dispatcher doesn't touch them. */
+    const head = queue.entries.find((e) => e.status === 'queued');
+    if (!head) return;
+
+    /* Wave 4a same-book gate. Wave 4b lifts this — the cross-book
+       dispatcher will switch the active book context (or POST
+       /generation directly bypassing the existing middleware's gate). */
+    if (chapters.currentBookId !== head.bookId) return;
+
+    /* Dispatch the regenerate. The existing generation-stream-middleware
+       reacts: sets pendingRegen, reconciles, opens SSE for the chapter. */
+    inFlightEntryId = head.id;
+    dispatch(chaptersActions.regenerateChapter({ chapterId: head.chapterId, scope: 'this' }));
+  };
+
+  return (next) => (action) => {
+    const result = next(action);
+    const a = action as { type?: string };
+    const type = a?.type;
+    /* React to anything that could change the dispatcher's decision:
+       - queue/setSnapshot — entries or paused flag changed.
+       - chapters/setActiveStream + clearActiveStream — SSE opened/closed.
+       - chapters/setCurrentBookId + hydrateFromBookState — slice's
+         loaded book changed (gate may flip from "wrong book" to "right
+         book" without any queue mutation). */
+    if (
+      type === queueActions.setSnapshot.type ||
+      type === 'chapters/setActiveStream' ||
+      type === 'chapters/clearActiveStream' ||
+      type === 'chapters/setCurrentBookId' ||
+      type === 'chapters/hydrateFromBookState'
+    ) {
+      /* Defer to a microtask so the existing generation-stream-middleware
+         reconcile completes first — its setActiveStream / clearActiveStream
+         calls land before we re-read chapters.activeStream. */
+      queueMicrotask(() => tick());
+    }
+    return result;
+  };
+};

--- a/src/views/generation.test.tsx
+++ b/src/views/generation.test.tsx
@@ -12,8 +12,8 @@ import { changeLogSlice } from '../store/change-log-slice';
 import { castSlice } from '../store/cast-slice';
 import { librarySlice } from '../store/library-slice';
 import { accountSlice } from '../store/account-slice';
-import { analysisSlice, analysisActions } from '../store/analysis-slice';
 import { generationStreamMiddleware } from '../store/generation-stream-middleware';
+import { queueSlice } from '../store/queue-slice';
 import { GenerationView } from './generation';
 import { useTtsLifecycle } from '../lib/use-tts-lifecycle';
 import type { LayoutContext } from '../components/layout';
@@ -175,6 +175,7 @@ function makeStore() {
       changeLog: changeLogSlice.reducer,
       cast: castSlice.reducer,
       library: librarySlice.reducer,
+      queue: queueSlice.reducer,
       /* Account slice powers the engines-in-use selector that determines
          which engine pill(s) render in the Generate header. Defaults to
          the same Coqui modelKey the view receives so the existing button-
@@ -281,6 +282,7 @@ describe('GenerationView — counters exclude ignored chapters (regression)', ()
         changeLog: changeLogSlice.reducer,
         cast: castSlice.reducer,
         library: librarySlice.reducer,
+        queue: queueSlice.reducer,
       },
     });
     store.dispatch(chaptersSlice.actions.setChapters([ch1Done, ch2Queued, ch3Excluded]));
@@ -347,6 +349,7 @@ describe('GenerationView — early-tick render guards (regression)', () => {
         changeLog: changeLogSlice.reducer,
         cast: castSlice.reducer,
         library: librarySlice.reducer,
+        queue: queueSlice.reducer,
       },
     });
     store.dispatch(chaptersSlice.actions.setChapters([live]));
@@ -461,6 +464,7 @@ describe('GenerationView — per-character progress is derived from the manuscri
         changeLog: changeLogSlice.reducer,
         cast: castSlice.reducer,
         library: librarySlice.reducer,
+        queue: queueSlice.reducer,
       },
     });
     store.dispatch(chaptersSlice.actions.setChapters([liveChapter]));
@@ -543,6 +547,7 @@ describe('GenerationView — heartbeat / stalled state', () => {
         changeLog: changeLogSlice.reducer,
         cast: castSlice.reducer,
         library: librarySlice.reducer,
+        queue: queueSlice.reducer,
       },
     });
     store.dispatch(chaptersSlice.actions.setChapters([live]));
@@ -610,6 +615,7 @@ describe('GenerationView — activity sidebar', () => {
         changeLog: changeLogSlice.reducer,
         cast: castSlice.reducer,
         library: librarySlice.reducer,
+        queue: queueSlice.reducer,
       },
     });
     store.dispatch(chaptersSlice.actions.setChapters([chapter1, chapter2]));
@@ -676,6 +682,7 @@ describe('GenerationView — header action once the run is complete', () => {
         changeLog: changeLogSlice.reducer,
         cast: castSlice.reducer,
         library: librarySlice.reducer,
+        queue: queueSlice.reducer,
       },
     });
     store.dispatch(chaptersSlice.actions.setChapters([allDone1, allDone2]));
@@ -717,7 +724,11 @@ describe('GenerationView — header action once the run is complete', () => {
     expect(onRegenerateBook).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps Pause/Resume while any chapter is still queued or in progress', () => {
+  it('renders the View queue CTA in the header while work is queued (plan 102)', () => {
+    /* Wave 4a moved Pause/Resume out of the Generate view into the queue
+       modal — what used to be the Pause/Resume slot is now occupied by a
+       "View queue" button that opens the modal. The book-level Regenerate
+       still shows up when allComplete is true (separate test above). */
     const store = configureStore({
       reducer: {
         ui: uiSlice.reducer,
@@ -726,6 +737,7 @@ describe('GenerationView — header action once the run is complete', () => {
         changeLog: changeLogSlice.reducer,
         cast: castSlice.reducer,
         library: librarySlice.reducer,
+        queue: queueSlice.reducer,
       },
     });
     store.dispatch(chaptersSlice.actions.setChapters([chapter1, chapter2]));
@@ -757,146 +769,15 @@ describe('GenerationView — header action once the run is complete', () => {
       </Provider>,
     );
 
-    expect(screen.getByRole('button', { name: /Resume/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Pause|Resume/ })).not.toBeInTheDocument();
+    expect(screen.getByTestId('generation-view-queue')).toBeInTheDocument();
   });
 });
 
-describe('GenerationView — reverse local-analyzer guard on Resume (D2)', () => {
-  /* When a local analysis is alive somewhere in the workspace, clicking
-     Resume in the Generate view should prompt the user before flipping
-     the slice's paused flag (which the middleware reconciles into a
-     fresh openHandle, competing for the GPU). Pause -> Resume is the
-     explicit user-driven start the reverse guard is supposed to gate;
-     the implicit reconcile path (no user click) is intentionally left
-     alone. */
-
-  function makeStoreWithAnalysis(opts: { engine?: 'local' | 'gemini' } = {}) {
-    const store = configureStore({
-      reducer: {
-        ui: uiSlice.reducer,
-        chapters: chaptersSlice.reducer,
-        manuscript: manuscriptSlice.reducer,
-        changeLog: changeLogSlice.reducer,
-        cast: castSlice.reducer,
-        library: librarySlice.reducer,
-        analysis: analysisSlice.reducer,
-      },
-    });
-    store.dispatch(chaptersSlice.actions.setChapters([chapter1, chapter2]));
-    store.dispatch(
-      manuscriptSlice.actions.hydrateFromAnalysis({
-        bookId: 'b1',
-        characters,
-        chapters: [chapter1, chapter2],
-        sentences,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any),
-    );
-    store.dispatch(
-      analysisActions.setActiveStream({
-        bookId: 'other_book',
-        manuscriptId: 'm_other',
-        bookTitle: 'Other Book Mid-Analysis',
-        engine: opts.engine ?? 'local',
-        phaseId: 0,
-        phaseLabel: 'Detecting characters',
-        phaseProgress: 0.1,
-        remainingMs: null,
-        lastTickAt: Date.now(),
-        state: 'running',
-      }),
-    );
-    return store;
-  }
-
-  it('opens the "Pause analysis to generate?" modal when Resume is clicked with a local analysis alive', () => {
-    const store = makeStoreWithAnalysis({ engine: 'local' });
-    const setPaused = vi.fn();
-
-    render(
-      <Provider store={store}>
-        <HostedGenerationView
-          chapters={[chapter1, chapter2]}
-          characters={characters}
-          paused
-          title="Bonus Keefe Story"
-          bookId="b1"
-          modelKey="coqui-xtts-v2"
-          setPaused={setPaused}
-          onRegenerate={() => {}}
-          onRegenerateBook={() => {}}
-          onRegenerateCharacterInChapter={() => {}}
-          onPreview={() => {}}
-        />
-      </Provider>,
-    );
-
-    fireEvent.click(screen.getByRole('button', { name: /Resume/ }));
-
-    /* Modal renders, setPaused(false) NOT yet called. */
-    expect(screen.getByText('Pause analysis to generate?')).toBeInTheDocument();
-    expect(setPaused).not.toHaveBeenCalled();
-  });
-
-  it('passes through to setPaused(false) without a modal when the analysis is on a remote engine', () => {
-    const store = makeStoreWithAnalysis({ engine: 'gemini' });
-    const setPaused = vi.fn();
-
-    render(
-      <Provider store={store}>
-        <HostedGenerationView
-          chapters={[chapter1, chapter2]}
-          characters={characters}
-          paused
-          title="Bonus Keefe Story"
-          bookId="b1"
-          modelKey="coqui-xtts-v2"
-          setPaused={setPaused}
-          onRegenerate={() => {}}
-          onRegenerateBook={() => {}}
-          onRegenerateCharacterInChapter={() => {}}
-          onPreview={() => {}}
-        />
-      </Provider>,
-    );
-
-    fireEvent.click(screen.getByRole('button', { name: /Resume/ }));
-
-    expect(screen.queryByText('Pause analysis to generate?')).not.toBeInTheDocument();
-    expect(setPaused).toHaveBeenCalledWith(false);
-  });
-
-  it('does NOT prompt when Pause (running -> paused) is clicked, even with a local analysis alive', () => {
-    /* Pausing TTS doesn't compete for GPU — only resuming / starting
-       does. The reverse guard must stay silent on the Pause direction
-       so the user can always stop generation cleanly. */
-    const store = makeStoreWithAnalysis({ engine: 'local' });
-    const setPaused = vi.fn();
-
-    render(
-      <Provider store={store}>
-        <HostedGenerationView
-          chapters={[chapter1, chapter2]}
-          characters={characters}
-          paused={false}
-          title="Bonus Keefe Story"
-          bookId="b1"
-          modelKey="coqui-xtts-v2"
-          setPaused={setPaused}
-          onRegenerate={() => {}}
-          onRegenerateBook={() => {}}
-          onRegenerateCharacterInChapter={() => {}}
-          onPreview={() => {}}
-        />
-      </Provider>,
-    );
-
-    fireEvent.click(screen.getByRole('button', { name: /Pause/ }));
-
-    expect(screen.queryByText('Pause analysis to generate?')).not.toBeInTheDocument();
-    expect(setPaused).toHaveBeenCalledWith(true);
-  });
-});
+/* Plan 102 Wave 4a — the "Reverse local-analyzer guard on Resume" suite
+   that used to live here covered the per-view Resume button which is now
+   in the queue modal. Wave 4b adds the equivalent guard test to the
+   QueueModal pause/resume control where the affordance lives now. */
 
 describe('generationStreamMiddleware — Pause/Resume regenerate loop (regression)', () => {
   beforeEach(() => {
@@ -919,6 +800,7 @@ describe('generationStreamMiddleware — Pause/Resume regenerate loop (regressio
         changeLog: changeLogSlice.reducer,
         cast: castSlice.reducer,
         library: librarySlice.reducer,
+        queue: queueSlice.reducer,
       },
       middleware: (gd) => gd().concat(generationStreamMiddleware),
     });
@@ -1076,6 +958,7 @@ describe('GenerationView — engine drift detection (plan 35)', () => {
         changeLog: changeLogSlice.reducer,
         cast: castSlice.reducer,
         library: librarySlice.reducer,
+        queue: queueSlice.reducer,
       },
     });
     store.dispatch(chaptersSlice.actions.setChapters(chapters));
@@ -1190,6 +1073,7 @@ describe('GenerationView — bulk Regenerate all drifted (plan 35 follow-up)', (
         changeLog: changeLogSlice.reducer,
         cast: castSlice.reducer,
         library: librarySlice.reducer,
+        queue: queueSlice.reducer,
       },
     });
     store.dispatch(chaptersSlice.actions.setChapters(chapters));
@@ -1384,6 +1268,7 @@ describe('GenerationView — Include in book (subset re-analysis)', () => {
         changeLog: changeLogSlice.reducer,
         cast: castSlice.reducer,
         library: librarySlice.reducer,
+        queue: queueSlice.reducer,
       },
     });
     store.dispatch(chaptersSlice.actions.setChapters([chapter1, chapter2, ch3Excluded]));
@@ -1652,12 +1537,13 @@ describe('GenerationView — phone viewport (375×667, Wave 3)', () => {
     });
   });
 
-  it('header Pause/Resume button declares the ≥44px touch-target class', () => {
+  it('header View queue button declares the ≥44px touch-target class (plan 102)', () => {
+    /* Wave 4a moved Resume/Pause into the queue modal; the header slot
+       now hosts the View queue CTA which must hit the same WCAG 2.5.5
+       touch-target rule. */
     renderView();
-    /* paused=true at render time → button reads "Resume". The min-h-[44px]
-       class is the assertion the touch-target invariant pins on. */
-    const resume = screen.getByRole('button', { name: /resume/i });
-    expect(resume.className).toContain('min-h-[44px]');
+    const viewQueue = screen.getByTestId('generation-view-queue');
+    expect(viewQueue.className).toContain('min-h-[44px]');
   });
 
   it('stats panel uses 2-column grid on phone (collapses below sm:)', () => {

--- a/src/views/generation.tsx
+++ b/src/views/generation.tsx
@@ -43,6 +43,8 @@ import { chaptersActions, STALL_THRESHOLD_MS } from '../store/chapters-slice';
 import { castActions } from '../store/cast-slice';
 import { manuscriptActions } from '../store/manuscript-slice';
 import { analysisActions } from '../store/analysis-slice';
+import { uiActions } from '../store/ui-slice';
+import { selectQueueCount } from '../store/queue-slice';
 import { api, AnalysisError } from '../lib/api';
 import { useLocalAnalyzerGuard } from '../hooks/use-local-analyzer-guard';
 import { useReverseLocalAnalyzerGuard } from '../hooks/use-reverse-local-analyzer-guard';
@@ -117,7 +119,6 @@ export function GenerationView({
   title,
   bookId,
   modelKey,
-  setPaused,
   onRegenerate,
   onRegenerateBook,
   onRegenerateCharacterInChapter,
@@ -130,6 +131,29 @@ export function GenerationView({
   const sentences = useAppSelector((s) => s.manuscript.sentences);
   const manuscriptId = useAppSelector((s) => s.manuscript.manuscriptId);
   const activityEvents = useAppSelector((s) => s.changeLog.events);
+  /* Plan 102 — drives the "View queue · N" pill in the header. Reads the
+     workspace queue mirror so the count tracks cross-book entries (the
+     reason for moving the queue out of the slice in the first place). */
+  const queueCount = useAppSelector(selectQueueCount);
+  /* Plan 102 — Generate view scroll consumer. ui.stage.currentChapterId
+     is set by the queue modal's "Jump to chapter" affordance (modal pushes
+     #/books/<bookId>/generate?chapter=<id>); we scroll the chapter row
+     into view here so the user lands at the right card instead of the
+     top of the chapter list. */
+  const currentChapterId = useAppSelector((s) =>
+    s.ui.stage.kind === 'ready' ? s.ui.stage.currentChapterId : null,
+  );
+  useEffect(() => {
+    if (currentChapterId == null) return;
+    const el = document.getElementById(`chapter-${currentChapterId}`);
+    if (!el) return;
+    /* Defer a frame so any layout shift from view-switch settles before
+       the scroll fires; without this, the target row is sometimes still
+       being laid out and the scroll lands a few hundred pixels short. */
+    requestAnimationFrame(() => {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    });
+  }, [currentChapterId]);
   /* Default analyzer engine used by the subset retry below (un-exclude
      path). Read at click time, not memoised, so a model switch between
      un-excludes is reflected on the next retry. */
@@ -157,10 +181,12 @@ export function GenerationView({
 
   /* Reverse guard (plan 32, D2): when the user explicitly resumes TTS
      generation here AND a local analysis is running somewhere in the
-     workspace, prompt before proceeding. The implicit reconcile-driven
-     path in generation-stream-middleware stays unguarded — the user
-     already consented when they originally started generation. */
-  const { guard: reverseGuard, modal: reverseGuardModal } = useReverseLocalAnalyzerGuard();
+     workspace, prompt before proceeding. The modal-only destructure (no
+     `guard:`) reflects Wave 4a: the local Resume/Pause button moved to
+     the queue modal, so the only caller of `guard` lives there now. The
+     modal mount stays here because the prompt is rendered next to the
+     Generate view's content. */
+  const { modal: reverseGuardModal } = useReverseLocalAnalyzerGuard();
 
   const patchSubset = (chapterId: number, patch: Partial<SubsetProgress>) => {
     setSubsetByChapter((prev) => {
@@ -570,39 +596,31 @@ export function GenerationView({
           )}
         </div>
         <div className="flex items-center gap-3 shrink-0">
-          {/* Once the queue is fully drained the Pause/Resume toggle has
-              nothing to pause or resume. Swap it for a Regenerate entry-point
-              that opens the existing modal targeted at chapter 1 — the user
-              picks scope="This and all subsequent" there to redo the whole
-              book, or sticks to a single chapter. min-h-[44px] hits the
-              ≥44px touch-target rule on phone. */}
-          {allComplete ? (
+          {/* Plan 102 — header CTAs.
+              - "View queue" replaces the old Resume/Pause toggle; pause moved
+                to the queue modal (it's queue-global now, not per-book-active-
+                handle).
+              - "Regenerate" (allComplete branch) stays — it opens the per-
+                chapter modal scoped to chapter 1 + forward (= whole book),
+                whose onConfirm enqueues each chapter individually.
+              - min-h-[44px] hits the ≥44px touch-target rule on phone. */}
+          <button
+            type="button"
+            onClick={() => dispatch(uiActions.openQueueModal())}
+            data-testid="generation-view-queue"
+            aria-label={
+              queueCount > 0 ? `View queue — ${queueCount} pending` : 'View queue'
+            }
+            className="min-h-[44px] px-4 py-2.5 rounded-full border border-ink/10 bg-white text-sm font-medium text-ink/70 hover:text-ink inline-flex items-center gap-2"
+          >
+            View queue{queueCount > 0 && <span className="text-magenta">· {queueCount}</span>}
+          </button>
+          {allComplete && (
             <button
               onClick={onRegenerateBook}
               className="min-h-[44px] px-4 py-2.5 rounded-full border border-ink/10 bg-white text-sm font-medium text-ink/70 hover:text-ink inline-flex items-center gap-2"
             >
               <IconRefresh className="w-4 h-4" /> Regenerate
-            </button>
-          ) : (
-            <button
-              onClick={() => {
-                /* paused -> running is the explicit "start TTS work"
-                   transition the reverse guard cares about. Running ->
-                   paused is the user choosing to STOP; no guard needed. */
-                if (paused) reverseGuard(() => setPaused(false));
-                else setPaused(true);
-              }}
-              className="min-h-[44px] px-4 py-2.5 rounded-full border border-ink/10 bg-white text-sm font-medium text-ink/70 hover:text-ink inline-flex items-center gap-2"
-            >
-              {paused ? (
-                <>
-                  <IconPlay className="w-4 h-4" /> Resume
-                </>
-              ) : (
-                <>
-                  <IconPause className="w-4 h-4" /> Pause
-                </>
-              )}
             </button>
           )}
         </div>
@@ -1004,6 +1022,7 @@ function ChapterRow({
 
   return (
     <div
+      id={`chapter-${chapter.id}`}
       className={`rounded-3xl border border-ink/10 shadow-card overflow-hidden ${stateConfig.tint}`}
     >
       <button


### PR DESCRIPTION
## Summary

Activates the workspace queue end-to-end for the same-book regenerate-during-regenerate scenario (bug #1 in plan 102). The 9 remaining regen sites + cross-book dispatch + chapters-slice strip land in Wave 4b.

Bug fix surface — clicking Regenerate on chapter N while chapter M is mid-synth no longer drops M's in-flight progress. The new path is: per-chapter Regenerate → opens RegenerateModal → onConfirm now dispatches `enqueueQueueEntries(...)` (was: `chaptersActions.regenerateChapter(...)`) → queue-dispatcher-middleware sees the entry land, waits for the active SSE to drain, then dispatches `regenerateChapter` for the head entry → existing generation-stream-middleware opens the SSE → on idle (chapter complete) the dispatcher DELETEs the entry and picks the next one.

## Changes

**Dispatcher**

- `src/store/queue-dispatcher-middleware.ts` (new) drains the queue one chapter at a time. Reacts to `queue/setSnapshot` + `chapters/{set,clear}ActiveStream` + `setCurrentBookId` + `hydrateFromBookState`. Same-book gate: only fires when head entry's `bookId` matches `chapters.currentBookId`. Local `inFlightEntryId` tracks the dispatched entry so the dispatcher can `DELETE /api/queue/{entryId}` once the SSE closes (idle tick → `clearActiveStream`). Cross-book dispatch is Wave 4b.
- `src/store/index.ts` mounts `queueDispatcherMiddleware` after `broadcastMiddleware`.

**Generate view**

- `src/views/generation.tsx` — Resume/Pause header button removed (pause is queue-global now and lives in the QueueModal). Replaced with a `View queue · N` button that opens the modal via `uiActions.openQueueModal()`. Added `id={` + "`" + `chapter-${id}` + "`" + `}` to ChapterRow + a scroll-into-view useEffect reacting to `ui.stage.currentChapterId` so the modal's jump-to-chapter affordance lands the user on the right card. Dropped the now-unused `setPaused` prop destructure and the `guard` half of `useReverseLocalAnalyzerGuard` (the modal owns the guard now; the modal mount stays).

**Per-chapter regen rewire (proof of new path)**

- `src/components/layout.tsx` — `RegenerateModal` `onConfirm` now enqueues queue entries via `enqueueQueueEntries`. `forward` scope expands at enqueue time into one entry per affected chapter so each is independently reorderable in the modal. Entry ids are minted client-side with a `regen-modal-` prefix + bookId + chapterId + short rand suffix to keep them unique across sessions.

## Tests

- `src/store/queue-dispatcher-middleware.test.ts` (new) — 6 cases covering: fires regenerate when head entry matches and no stream active; doesn't fire when paused / wrong book / SSE already active; DELETEs entry on clearActiveStream; waits for cold-boot snapshot.
- `src/views/generation.test.tsx` — updated Pause/Resume button assertions to View queue. Deleted the `reverse local-analyzer guard on Resume (D2)` describe block (button moved to modal; Wave 4b adds the equivalent QueueModal coverage). Added `queue: queueSlice.reducer` to every test store. Touch-target test now asserts the View queue button has `min-h-[44px]`.
- `src/routes/index.test.tsx` — added `queueSlice.reducer` to `makeStore()` so the cross-book Generate title regression no longer crashes `selectQueueCount`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (zero warnings, --max-warnings 0)
- [x] Frontend Vitest: 1628/1628 pass
- [x] Server Vitest: 1260/1268 pass (8 pre-existing skips, none new)
- [x] Pre-push `npm run verify` battery — green (build, typecheck, all tests, e2e)

## What lands in Wave 4b (follow-up)

- Rewire the other 9 regen sites (listen-player-region, cast selection-pill, drift-report per-chapter, layout drift auto-queue, stale-audio-banner, profile-drawer, regenerate-modal, character-regenerate-modal, batch-character-regenerate-modal).
- Cross-book dispatcher (lifts the same-book gate).
- Strip `pendingRegen` / `regenEpoch` / `paused` from `chapters-slice`.
- QueueModal pause/resume reverse-analyzer guard coverage.

Plan: docs/features/102-global-queue-modal.md