### PR TITLE
feat(frontend): plan 102 wave 4b — rewire 4 remaining regen sites + character-scope dispatcher

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1006,7 +1006,22 @@ export function Layout() {
                   ),
                 );
               }
-              dispatch(chaptersActions.regenerateCharacter({ characterId, chapterIds }));
+              if (bookId) {
+                /* Plan 102 — one queue entry per (chapter, character)
+                   tuple so the modal can reorder each independently. */
+                const rand = Math.random().toString(36).slice(2, 8);
+                void dispatch(
+                  enqueueQueueEntries(
+                    chapterIds.map((chId) => ({
+                      id: `regen-char-${bookId}-${characterId}-${chId}-${rand}`,
+                      bookId,
+                      chapterId: chId,
+                      scope: 'character',
+                      characterId,
+                    })),
+                  ),
+                );
+              }
               dispatch(uiActions.changeView('generate'));
             });
           }}
@@ -1034,7 +1049,26 @@ export function Layout() {
                   ),
                 );
               }
-              dispatch(chaptersActions.batchRegenerateCharacters({ characterIds, chapterIds }));
+              if (bookId) {
+                /* Plan 102 — batch character regen → one entry per
+                   (character, chapter) cell. M characters × N chapters
+                   = M*N queue entries; the dispatcher drains them
+                   serially. */
+                const rand = Math.random().toString(36).slice(2, 8);
+                const entries = [];
+                for (const cid of characterIds) {
+                  for (const chId of chapterIds) {
+                    entries.push({
+                      id: `regen-batch-char-${bookId}-${cid}-${chId}-${rand}`,
+                      bookId,
+                      chapterId: chId,
+                      scope: 'character' as const,
+                      characterId: cid,
+                    });
+                  }
+                }
+                if (entries.length) void dispatch(enqueueQueueEntries(entries));
+              }
               dispatch(uiActions.changeView('generate'));
             });
           }}
@@ -1080,12 +1114,24 @@ export function Layout() {
                   ),
                 );
               }
-              dispatch(
-                chaptersActions.regenerateCharacter({
-                  characterId: charId,
-                  chapterIds: [chapterId],
-                }),
-              );
+              if (bookId) {
+                /* Plan 102 — drift auto-queue (severe) now enqueues
+                   instead of dispatching directly. Serialised through
+                   the dispatcher so it can't drop in-flight work
+                   (same fix as the regen-modal path). */
+                const rand = Math.random().toString(36).slice(2, 8);
+                void dispatch(
+                  enqueueQueueEntries([
+                    {
+                      id: `drift-auto-${bookId}-${charId}-${chapterId}-${rand}`,
+                      bookId,
+                      chapterId,
+                      scope: 'character',
+                      characterId: charId,
+                    },
+                  ]),
+                );
+              }
               dispatch(uiActions.changeView('generate'));
             });
           }}

--- a/src/components/stale-audio-banner.test.tsx
+++ b/src/components/stale-audio-banner.test.tsx
@@ -10,6 +10,8 @@ import { uiSlice } from '../store/ui-slice';
 import { castSlice } from '../store/cast-slice';
 import { chaptersSlice } from '../store/chapters-slice';
 import { changeLogSlice } from '../store/change-log-slice';
+import { queueSlice } from '../store/queue-slice';
+import { notificationsSlice } from '../store/notifications-slice';
 import { StaleAudioBanner } from './stale-audio-banner';
 import type { Character } from '../lib/types';
 
@@ -32,6 +34,8 @@ function makeStore() {
       cast: castSlice.reducer,
       chapters: chaptersSlice.reducer,
       changeLog: changeLogSlice.reducer,
+      queue: queueSlice.reducer,
+      notifications: notificationsSlice.reducer,
     },
   });
 }
@@ -131,7 +135,7 @@ describe('StaleAudioBanner', () => {
     expect(screen.getByText(/1 chapter\b/)).toBeInTheDocument();
   });
 
-  it('Regenerate now dispatches regenerateCharacter + clears banner + switches to generate view', () => {
+  it('Regenerate now enqueues one queue entry per stale chapter + clears banner + switches to generate view (plan 102)', async () => {
     sharedStore.dispatch(
       uiSlice.actions.setStaleAudio({
         characterId: 'halloran',
@@ -139,8 +143,8 @@ describe('StaleAudioBanner', () => {
         chapterIds: [1, 3],
       }),
     );
-    /* Need a ready stage for changeView to actually change anything;
-       set one explicitly. */
+    /* Need a ready stage so bookId resolves + changeView actually moves
+       the stage; the banner aborts if bookId is null. */
     sharedStore.dispatch(uiSlice.actions.openBook({ id: 'b1', status: 'complete' }));
     sharedStore.dispatch(
       uiSlice.actions.setStaleAudio({
@@ -150,20 +154,45 @@ describe('StaleAudioBanner', () => {
       }),
     );
 
+    /* Plan 102 — enqueue is the new dispatch path; mock fetch. */
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve({ entries: [], paused: false }),
+    } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
     renderBanner();
     fireEvent.click(screen.getByRole('button', { name: /Regenerate now/i }));
 
-    const state = sharedStore.getState();
-    /* Slice state confirms the dispatch chain landed: stale cleared,
-       chapters slice carries pendingRegen for the right chapters, change
-       log captured the event. */
-    expect(state.ui.staleAudio).toBeNull();
-    expect(state.chapters.pendingRegen?.chapterIds).toEqual([1, 3]);
-    expect(state.chapters.pendingRegen?.force).toBe(true);
+    /* Banner clears + view switches synchronously; the enqueue thunk's
+       fetch lands one microtask later. */
+    const stateImmediate = sharedStore.getState();
+    expect(stateImmediate.ui.staleAudio).toBeNull();
+    expect((stateImmediate.ui.stage as { view?: string }).view).toBe('generate');
     expect(
-      state.changeLog.events.some((e) => e.type === 'regenerate' && e.title?.includes('Halloran')),
+      stateImmediate.changeLog.events.some(
+        (e) => e.type === 'regenerate' && e.title?.includes('Halloran'),
+      ),
     ).toBe(true);
-    expect((state.ui.stage as { view?: string }).view).toBe('generate');
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/queue/enqueue',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    const call = fetchMock.mock.calls.find((c) => c[0] === '/api/queue/enqueue');
+    const body = JSON.parse((call?.[1] as { body: string }).body) as {
+      entries: { bookId: string; chapterId: number; scope: string; characterId?: string }[];
+    };
+    expect(body.entries.map((e) => e.chapterId)).toEqual([1, 3]);
+    expect(body.entries.every((e) => e.scope === 'character' && e.characterId === 'halloran')).toBe(
+      true,
+    );
+    vi.unstubAllGlobals();
   });
 
   it('Dismiss clears the slice flag without dispatching regenerate', () => {

--- a/src/components/stale-audio-banner.tsx
+++ b/src/components/stale-audio-banner.tsx
@@ -9,7 +9,7 @@
 
 import { useAppDispatch, useAppSelector } from '../store';
 import { uiActions } from '../store/ui-slice';
-import { chaptersActions } from '../store/chapters-slice';
+import { enqueueQueueEntries } from '../store/queue-thunks';
 import { changeLogActions } from '../store/change-log-slice';
 import { buildCharacterRegenEvent } from '../lib/change-log';
 import { IconRefresh, IconClose } from '../lib/icons';
@@ -18,6 +18,9 @@ export function StaleAudioBanner() {
   const dispatch = useAppDispatch();
   const stale = useAppSelector((s) => s.ui.staleAudio);
   const characters = useAppSelector((s) => s.cast.characters);
+  const bookId = useAppSelector((s) =>
+    s.ui.stage.kind === 'ready' ? s.ui.stage.bookId : null,
+  );
   if (!stale) return null;
   const n = stale.chapterIds.length;
   if (n === 0) return null;
@@ -25,7 +28,7 @@ export function StaleAudioBanner() {
   const character = characters.find((c) => c.id === stale.characterId);
 
   function onRegenerate() {
-    if (!stale || !character) return;
+    if (!stale || !character || !bookId) return;
     dispatch(
       changeLogActions.appendLogEvent(
         buildCharacterRegenEvent({
@@ -36,11 +39,21 @@ export function StaleAudioBanner() {
         }),
       ),
     );
-    dispatch(
-      chaptersActions.regenerateCharacter({
-        characterId: stale.characterId,
-        chapterIds: stale.chapterIds,
-      }),
+    /* Plan 102 — stale-audio "Regenerate now" enqueues one
+       per-character entry per stale chapter; the dispatcher drains
+       them serially, so a regen mid-stream can no longer drop the
+       in-flight chapter. */
+    const rand = Math.random().toString(36).slice(2, 8);
+    void dispatch(
+      enqueueQueueEntries(
+        stale.chapterIds.map((chId) => ({
+          id: `stale-audio-${bookId}-${stale.characterId}-${chId}-${rand}`,
+          bookId,
+          chapterId: chId,
+          scope: 'character',
+          characterId: stale.characterId,
+        })),
+      ),
     );
     dispatch(uiActions.clearStaleAudio());
     dispatch(uiActions.changeView('generate'));

--- a/src/store/queue-dispatcher-middleware.test.ts
+++ b/src/store/queue-dispatcher-middleware.test.ts
@@ -192,6 +192,37 @@ describe('queue-dispatcher-middleware', () => {
     expect(fetchMock).toHaveBeenCalledWith('/api/queue/e1', { method: 'DELETE' });
   });
 
+  it('dispatches regenerateCharacter when the head entry is scope=character (Wave 4b)', async () => {
+    const store = makeStore();
+    store.dispatch(chaptersSlice.actions.setCurrentBookId('book-A'));
+    store.dispatch(
+      chaptersSlice.actions.setChapters([
+        {
+          id: 3,
+          title: 'Chapter 3',
+          state: 'done',
+          progress: 1,
+          duration: '0:30',
+          /* Character must exist on the row for regenerateCharacter to
+             mutate it (the reducer no-ops when the character is missing
+             or 'skipped'). */
+          characters: { narrator: 'done' },
+        },
+      ] as never),
+    );
+    store.dispatch(
+      queueSlice.actions.setSnapshot({
+        entries: [entry({ scope: 'character', characterId: 'narrator' })],
+        paused: false,
+      }),
+    );
+    await flushMicro();
+    /* regenerateCharacter sets pendingRegen the same way regenerateChapter
+       does — the dispatcher's scope branch routes to the right action. */
+    expect(store.getState().chapters.pendingRegen).toEqual({ chapterIds: [3], force: true });
+    expect(store.getState().chapters.chapters[0].characters.narrator).toBe('queued');
+  });
+
   it('waits for the cold-boot snapshot before doing anything', async () => {
     const store = makeStore();
     store.dispatch(chaptersSlice.actions.setCurrentBookId('book-A'));

--- a/src/store/queue-dispatcher-middleware.ts
+++ b/src/store/queue-dispatcher-middleware.ts
@@ -96,9 +96,23 @@ export const queueDispatcherMiddleware: Middleware = (storeApi: MiddlewareAPI) =
     if (chapters.currentBookId !== head.bookId) return;
 
     /* Dispatch the regenerate. The existing generation-stream-middleware
-       reacts: sets pendingRegen, reconciles, opens SSE for the chapter. */
+       reacts: sets pendingRegen, reconciles, opens SSE for the
+       chapter / character target. */
     inFlightEntryId = head.id;
-    dispatch(chaptersActions.regenerateChapter({ chapterId: head.chapterId, scope: 'this' }));
+    if (head.scope === 'character' && head.characterId) {
+      /* Per-character-in-chapter entries dispatch regenerateCharacter
+         scoped to a single chapter. Multi-chapter character regen is
+         expanded at enqueue time into one entry per chapter so each
+         is independently reorderable in the modal. */
+      dispatch(
+        chaptersActions.regenerateCharacter({
+          characterId: head.characterId,
+          chapterIds: [head.chapterId],
+        }),
+      );
+    } else {
+      dispatch(chaptersActions.regenerateChapter({ chapterId: head.chapterId, scope: 'this' }));
+    }
   };
 
   return (next) => (action) => {

--- a/src/views/generation.test.tsx
+++ b/src/views/generation.test.tsx
@@ -1109,7 +1109,7 @@ describe('GenerationView — bulk Regenerate all drifted (plan 35 follow-up)', (
     );
   }
 
-  it('confirm dialog names the source engine, target engine, and dispatches regenerateChapterIds with the full drifted list', () => {
+  it('confirm dialog names the source engine, target engine, and enqueues one queue entry per drifted chapter (plan 102)', async () => {
     const drifted1: Chapter = { ...chapter1, audioModelKey: 'coqui-xtts-v2' };
     const drifted3: Chapter = {
       id: 3,
@@ -1122,6 +1122,24 @@ describe('GenerationView — bulk Regenerate all drifted (plan 35 follow-up)', (
     };
     const store = makeDriftStore([drifted1, chapter2, drifted3]);
     renderDrift(store, [drifted1, chapter2, drifted3]);
+
+    /* Plan 102 — drift bulk regen now POSTs /api/queue/enqueue (one
+       entry per drifted chapter) instead of dispatching
+       regenerateChapterIds. Stub fetch and assert the request body. */
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () =>
+        Promise.resolve({
+          entries: [
+            { id: 'e1', bookId: 'b1', chapterId: 1, scope: 'this', status: 'queued', order: 0, addedAt: '2026-05-23T00:00:00Z' },
+            { id: 'e2', bookId: 'b1', chapterId: 3, scope: 'this', status: 'queued', order: 1, addedAt: '2026-05-23T00:00:00Z' },
+          ],
+          paused: false,
+        }),
+    } as Response);
+    vi.stubGlobal('fetch', fetchMock);
 
     /* Banner button opens the confirm dialog. */
     const bannerBtn = screen.getByRole('button', { name: /^Regenerate all$/ });
@@ -1137,14 +1155,25 @@ describe('GenerationView — bulk Regenerate all drifted (plan 35 follow-up)', (
     /* Confirm — the button label includes the count for plural cases. */
     fireEvent.click(screen.getByRole('button', { name: /Regenerate all 2/ }));
 
-    /* Slice transitions: head id (1) flips in_progress, second (3)
-       queues; chapter 2 (queued, never drifted) is untouched. */
-    const state = store.getState();
-    expect(state.chapters.pendingRegen).toEqual({ chapterIds: [1, 3], force: true });
-    expect(state.chapters.chapters.find((c) => c.id === 1)?.state).toBe('in_progress');
-    expect(state.chapters.chapters.find((c) => c.id === 2)?.state).toBe('queued');
-    expect(state.chapters.chapters.find((c) => c.id === 3)?.state).toBe('queued');
-    expect(state.chapters.regenEpoch).toBe(1);
+    /* The enqueue thunk fires /api/queue/enqueue with the drifted ids
+       expanded to one queue entry each. Wait a microtask so the thunk's
+       fetch lands before the assertion. */
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/queue/enqueue',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const call = fetchMock.mock.calls.find((c) => c[0] === '/api/queue/enqueue');
+    const body = JSON.parse((call?.[1] as { body: string }).body) as {
+      entries: { bookId: string; chapterId: number; scope: string }[];
+    };
+    expect(body.entries.map((e) => e.chapterId)).toEqual([1, 3]);
+    expect(body.entries.every((e) => e.scope === 'this' && e.bookId === 'b1')).toBe(true);
+    vi.unstubAllGlobals();
   });
 
   it('singular copy when only one chapter is drifted', () => {

--- a/src/views/generation.tsx
+++ b/src/views/generation.tsx
@@ -45,6 +45,7 @@ import { manuscriptActions } from '../store/manuscript-slice';
 import { analysisActions } from '../store/analysis-slice';
 import { uiActions } from '../store/ui-slice';
 import { selectQueueCount } from '../store/queue-slice';
+import { enqueueQueueEntries } from '../store/queue-thunks';
 import { api, AnalysisError } from '../lib/api';
 import { useLocalAnalyzerGuard } from '../hooks/use-local-analyzer-guard';
 import { useReverseLocalAnalyzerGuard } from '../hooks/use-reverse-local-analyzer-guard';
@@ -719,10 +720,24 @@ export function GenerationView({
         confirmLabel={`Regenerate ${driftedCount === 1 ? '1 chapter' : `all ${driftedCount}`}`}
         cancelLabel="Cancel"
         onConfirm={() => {
-          dispatch(
-            chaptersActions.regenerateChapterIds({
-              chapterIds: driftedChapters.map((c) => c.id),
-            }),
+          /* Plan 102 — drift bulk regen now enqueues one entry per
+             drifted chapter (was: single regenerateChapterIds dispatch
+             that hard-interrupted any in-flight chapter). Each entry
+             rides through the queue dispatcher serially, so an
+             in-flight chapter completes before the next drift target
+             starts. Entry ids include a short rand suffix so two
+             back-to-back drift runs in the same session don't collide
+             on duplicate ids. */
+          const rand = Math.random().toString(36).slice(2, 8);
+          void dispatch(
+            enqueueQueueEntries(
+              driftedChapters.map((c) => ({
+                id: `drift-bulk-${bookId}-${c.id}-${rand}`,
+                bookId,
+                chapterId: c.id,
+                scope: 'this',
+              })),
+            ),
           );
           setBulkRegenOpen(false);
         }}


### PR DESCRIPTION
## Summary

Extends Wave 4a so the queue path covers every chapter-level AND character-level regenerate dispatch from the four sites that still went straight to `chaptersActions.regenerate*`. Bug #1 from plan 102 (regenerate-during-regenerate drops in-flight progress) is now fixed across every same-book entry point.

## Changes

**Dispatcher**

- `src/store/queue-dispatcher-middleware.ts` now branches on `entry.scope`. `scope: 'character'` entries dispatch `chaptersActions.regenerateCharacter` scoped to the entry's single chapter; `scope: 'this'` keeps the existing `regenerateChapter` path. Multi-chapter character regen is expanded into one entry per chapter at enqueue time so each is independently reorderable in the modal.

**Rewired sites**

- `src/views/generation.tsx` — engine-drift "Regenerate all" banner enqueues one entry per drifted chapter (was: single `regenerateChapterIds` dispatch that hard-interrupted any in-flight chapter).
- `src/components/layout.tsx` — `CharacterRegenerateModal.onConfirm` enqueues one entry per (character, chapter) tuple. `BatchCharacterRegenerateModal.onConfirm` enqueues one per (character × chapter) cell so the M×N batch rides through the dispatcher serially. Drift-report auto-queue path (severe drift) enqueues a single character entry. Entry ids carry a short rand suffix so back-to-back actions can't collide on duplicate ids.
- `src/components/stale-audio-banner.tsx` — "Regenerate now" enqueues per-character entries keyed to the stale chapter list. New `bookId` selector + early return when stage isn't ready.

**Sites still using the old path (deliberate, follow-up)**

- `chapters-slice` fields `pendingRegen` / `regenEpoch` / `paused` — keep until the existing generation-stream-middleware is rewritten to consume queue state directly instead of `pendingRegen`. Removing them prematurely would break the slice→middleware handshake the dispatcher currently relies on.
- `batchRegenerateCharacters` action — no longer dispatched but kept in the slice for the chapters-slice test fixtures that pin its reducer behavior; remove when those tests are rewritten.
- Cross-book dispatch — dispatcher still gates on `chapters.currentBookId === head.bookId`. Same-book bug fixed; cross-book follows.

## Tests

- `src/store/queue-dispatcher-middleware.test.ts` — new case asserts `scope='character'` entries dispatch `regenerateCharacter` with single-chapter `chapterIds` + flips the character cell to `queued`.
- `src/views/generation.test.tsx` — drift bulk regen now asserts the `/api/queue/enqueue` POST body shape (chapterIds expanded, scope='this', bookId set).
- `src/components/stale-audio-banner.test.tsx` — Regenerate now asserts the enqueue POST body shape (per-chapter entries, `scope='character'`, `characterId` set). Added `queueSlice` + `notificationsSlice` reducers to the test store.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (zero warnings, `--max-warnings 0`)
- [x] Frontend Vitest: 1629/1629 pass
- [x] Server Vitest: 1260/1268 pass (8 pre-existing skips, none new)
- [x] Pre-push `npm run verify` — green (build, typecheck, all tests, e2e)

## Bug fix summary across Waves 4a + 4b

Bug #1 (regenerate-during-regenerate drops in-flight progress) is now resolved for every same-book entry point:

- Per-chapter "Regenerate this chapter" → enqueue (Wave 4a, via RegenerateModal)
- Header "Regenerate" (all-done state) → same flow as above (Wave 4a)
- Engine-drift "Regenerate all" banner → enqueue (Wave 4b)
- Cast view per-character regen → enqueue (Wave 4b, via CharacterRegenerateModal)
- Cast view multi-character batch regen → enqueue (Wave 4b)
- Drift-report per-chapter regen → enqueue (Wave 4a, funnels through RegenerateModal)
- Drift-report auto-queue path (severe drift) → enqueue (Wave 4b)
- Voice-edit stale-audio "Regenerate now" → enqueue (Wave 4b)
- Listen-view per-chapter regen → enqueue (Wave 4a, funnels through RegenerateModal)
- Profile-drawer per-character regen → enqueue (Wave 4a, funnels through CharacterRegenerateModal)

Plan: docs/features/102-global-queue-modal.md