### PR TITLE
feat(frontend): BACKLOG Could #40 — drag-to-reorder for the queue modal

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -396,16 +396,6 @@ Source: net-new (2026-05-23). Surfaced during plan-103 implementation.
 - _Depends on:_ plan 103 merged.
 - _Benefit (technical):_ trims the rare wasted weekly mobile-e2e run; mostly tidiness.
 
-### 40. Drag-to-reorder for the queue modal (plan 102 polish)
-
-Source: plan 102 ship (2026-05-23) — Out of scope for the v1 ship. The queue modal at `src/modals/queue-modal.tsx` reorders via tap pills (Move up / Move down) which satisfies the touch-equivalence rule from CLAUDE.md plan 81 and works on desktop AND mobile in one code path. Drag-to-reorder is purely additive polish for desktop users with a mouse.
-
-- _What:_ Add a PointerEvent-based drag handle on the left edge of each queue entry row (desktop only — `hidden sm:flex`). Reuses the existing PointerEvent pattern from `src/views/manuscript.tsx:377-451` (paragraph boundary handle). On drop, dispatch `reorderQueue(desiredOrderIds)` which POSTs `/api/queue/reorder` — the same thunk the tap pills already call, just with a different desiredOrder computation. The in-flight (pinned) entry remains non-draggable; the drag handle is suppressed on `entry.status === 'in_progress'` rows.
-- _Acceptance:_ On desktop, hovering a queue row reveals a `⋮⋮` drag handle on the left. Dragging it onto another row reorders the queue via `/api/queue/reorder`. The in-flight row shows no handle. On touch devices, the handle is hidden and the existing tap pills remain the only reorder affordance.
-- _Key files:_ `src/modals/queue-modal.tsx` (PointerEvent listener on each non-pinned row + drop-zone math); `src/modals/queue-modal.test.tsx` (paired Vitest pin for the drag-reorder dispatch shape).
-- _Depends on:_ plan 102 (shipped).
-- _Benefit (user):_ desktop users get a one-gesture reorder instead of multiple tap-pill clicks. Minor — current pill UX is already functional — but a small polish win for users juggling 10+ queue entries.
-
 ---
 
 ## Won't (this round) — explicitly parked

--- a/src/modals/queue-modal.test.tsx
+++ b/src/modals/queue-modal.test.tsx
@@ -207,6 +207,63 @@ describe('QueueModal', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it('drag-to-reorder dispatches reorder thunk with the new global order (BACKLOG Could #40)', async () => {
+    renderModal([
+      entry({ id: 'a1', chapterId: 1, order: 0 }),
+      entry({ id: 'a2', chapterId: 2, order: 1 }),
+      entry({ id: 'a3', chapterId: 3, order: 2 }),
+    ]);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ entries: [], paused: false }),
+    });
+
+    const handle = screen.getByTestId('queue-entry-a1-drag');
+    const targetRow = screen.getByTestId('queue-entry-a3');
+
+    /* jsdom's elementFromPoint returns null; stub it to return the row
+       we want the pointer to be "over" during the pointermove. */
+    const originalEFP = document.elementFromPoint;
+    document.elementFromPoint = (): Element => targetRow;
+
+    /* Separate act blocks so React commits between events — the
+       window-level pointermove listener is registered by a useEffect
+       that runs AFTER pointerdown's setDrag commit. */
+    await act(async () => {
+      fireEvent.pointerDown(handle, { clientX: 0, clientY: 0, pointerId: 1 });
+    });
+    await act(async () => {
+      /* jsdom doesn't ship PointerEvent — fake it with a plain Event +
+         the two properties our handler reads (clientX/Y). */
+      const moveEv = new Event('pointermove') as Event & { clientX: number; clientY: number };
+      moveEv.clientX = 100;
+      moveEv.clientY = 100;
+      window.dispatchEvent(moveEv);
+    });
+    await act(async () => {
+      window.dispatchEvent(new Event('pointerup'));
+    });
+
+    document.elementFromPoint = originalEFP;
+
+    const reorderCall = fetchMock.mock.calls.find((c) => c[0] === '/api/queue/reorder');
+    expect(reorderCall).toBeDefined();
+    /* a1 was dragged to a3's slot — within Book A the new order is
+       a2, a3, a1 (a1 spliced into a3's index, which was 2). */
+    expect(reorderCall![1].body).toContain('"order":["a2","a3","a1"]');
+  });
+
+  it('drag handle is absent on the in-flight pinned row (no drop target either)', () => {
+    renderModal([
+      entry({ id: 'a1', status: 'in_progress', order: 0 }),
+      entry({ id: 'a2', chapterId: 2, order: 1 }),
+    ]);
+    /* a1 (in-flight) has no drag handle; a2 (queued) does. */
+    expect(screen.queryByTestId('queue-entry-a1-drag')).not.toBeInTheDocument();
+    expect(screen.getByTestId('queue-entry-a2-drag')).toBeInTheDocument();
+  });
+
   it('dispatches loadQueue on open (cross-tab freshness)', async () => {
     renderModal([]);
     /* The mount-time loadQueue fires; assert via fetchMock since the

--- a/src/modals/queue-modal.tsx
+++ b/src/modals/queue-modal.tsx
@@ -15,7 +15,7 @@
  * touch-equivalence rule for desktop AND mobile in one path, keeping the
  * shipped modal small. Touch targets are ≥44×44 px per WCAG 2.5.5. */
 
-import { useMemo, useEffect } from 'react';
+import { useMemo, useEffect, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../store';
 import {
   selectInFlightEntry,
@@ -32,7 +32,7 @@ import {
   setQueuePaused,
 } from '../store/queue-thunks';
 import { uiActions } from '../store/ui-slice';
-import { IconClose, IconPause, IconPlay, IconTrash } from '../lib/icons';
+import { IconClose, IconDrag, IconPause, IconPlay, IconTrash } from '../lib/icons';
 import { PrimaryButton } from '../components/primitives';
 
 interface QueueModalProps {
@@ -196,6 +196,70 @@ function BookGroup({ title, entries, inFlightId, onReorder, onCancel }: BookGrou
     onReorder(next);
   };
 
+  /* Plan 102 polish (BACKLOG Could #40) — desktop drag-to-reorder.
+     Pointer-events based for browser breadth; the handle is hidden via
+     `hidden sm:flex` on coarse-pointer devices so touch users continue to
+     rely on the Move up / Move down pills.
+
+     Drag model: pointerdown on the ⋮⋮ handle captures the dragged entry
+     id; window-level pointermove tracks which row the pointer is over
+     (via [data-entry-id] on each li); pointerup commits the reorder by
+     splicing the dragged entry into the drop target's slot in the
+     group's order, then bubbling the new order via onReorder. */
+  const [drag, setDrag] = useState<{ fromId: string; overId: string | null } | null>(null);
+
+  useEffect(() => {
+    if (!drag) return;
+    const onMove = (e: globalThis.PointerEvent): void => {
+      const el = document.elementFromPoint(e.clientX, e.clientY) as HTMLElement | null;
+      const rowEl = el?.closest?.('[data-entry-id]') as HTMLElement | null;
+      const id = rowEl?.dataset.entryId ?? null;
+      /* Skip self-hover and the in-flight pinned row — neither is a
+         valid drop target. */
+      const valid = id != null && id !== drag.fromId && id !== inFlightId;
+      setDrag((d) => (d && d.overId !== (valid ? id : null) ? { ...d, overId: valid ? id : null } : d));
+    };
+    const onUp = (): void => {
+      setDrag((d) => {
+        if (d && d.overId) {
+          const fromIdx = entries.findIndex((e) => e.id === d.fromId);
+          const toIdx = entries.findIndex((e) => e.id === d.overId);
+          if (fromIdx !== -1 && toIdx !== -1 && fromIdx !== toIdx) {
+            const next = [...entries];
+            const [moved] = next.splice(fromIdx, 1);
+            next.splice(toIdx, 0, moved);
+            onReorder(next);
+          }
+        }
+        return null;
+      });
+      document.body.classList.remove('dragging-queue-entry');
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointercancel', onUp);
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onUp);
+    };
+    /* `entries` + `inFlightId` are captured at drag-start time intentionally —
+       reordering during an in-flight drag is rare and would require resync;
+       eslint exhaustive-deps would force a re-subscribe on every queue mutation. */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [drag?.fromId]);
+
+  const onDragStart = (fromId: string) => (e: React.PointerEvent<HTMLButtonElement>): void => {
+    e.preventDefault();
+    setDrag({ fromId, overId: null });
+    document.body.classList.add('dragging-queue-entry');
+    try {
+      (e.target as Element).setPointerCapture?.(e.pointerId);
+    } catch {
+      /* Older browsers may throw on capture — fall through. */
+    }
+  };
+
   return (
     <section>
       <h4 className="text-xs uppercase tracking-widest text-ink/50 font-semibold mb-2">
@@ -208,10 +272,32 @@ function BookGroup({ title, entries, inFlightId, onReorder, onCancel }: BookGrou
             <li
               key={entry.id}
               data-testid={`queue-entry-${entry.id}`}
-              className={`flex items-center gap-2 px-3 py-2 rounded-2xl border ${
-                isInFlight ? 'border-magenta/40 bg-magenta/5' : 'border-ink/10 bg-white'
+              data-entry-id={entry.id}
+              className={`flex items-center gap-2 px-3 py-2 rounded-2xl border transition-colors ${
+                isInFlight
+                  ? 'border-magenta/40 bg-magenta/5'
+                  : drag?.overId === entry.id
+                    ? 'border-magenta/60 bg-magenta/10'
+                    : drag?.fromId === entry.id
+                      ? 'border-ink/10 bg-white opacity-40'
+                      : 'border-ink/10 bg-white'
               }`}
             >
+              {!isInFlight && (
+                /* Desktop-only drag handle — hidden on touch so users
+                   fall back to the Move up / Move down pills (which work
+                   on every viewport per the CLAUDE.md touch-equivalence
+                   rule). Cursor reflects drag state for clarity. */
+                <button
+                  type="button"
+                  onPointerDown={onDragStart(entry.id)}
+                  aria-label="Drag to reorder"
+                  data-testid={`queue-entry-${entry.id}-drag`}
+                  className="hidden sm:flex items-center justify-center text-ink/30 hover:text-ink/60 cursor-grab active:cursor-grabbing touch-none p-1 -ml-1"
+                >
+                  <IconDrag className="w-4 h-4" />
+                </button>
+              )}
               <div className="flex-1 min-w-0">
                 <div className="text-sm font-medium text-ink truncate">
                   Chapter {entry.chapterId}


### PR DESCRIPTION
## Summary

Desktop drag handle on the left edge of each non-pinned queue entry row. Pointer-events based for browser breadth; hidden via `hidden sm:flex` on coarse-pointer devices so touch users continue to rely on the existing Move up / Move down pills (touch-equivalence rule preserved per CLAUDE.md plan 81).

## Changes

- **`src/modals/queue-modal.tsx`** — adds `useState<{fromId, overId}>` drag state inside `BookGroup`. Drag handle (`IconDrag`, ⋮⋮ visual) on each non-in-flight row carries `onPointerDown` that captures the pointer + sets drag state + adds a body class for global cursor feedback. Window-level `pointermove` (via `useEffect`) reads `document.elementFromPoint` → `closest('[data-entry-id]')`; skips self and the in-flight row as invalid drop targets. `pointerup` commits the reorder by splicing the dragged entry into the drop target's slot in the group's order, then bubbling the new order via `onReorder` (same thunk path the Move up/down pills use — the per-book → workspace-order translation stays intact). Visual feedback: dragged row goes `opacity-40`, drop target gets magenta border tint.
- The in-flight (pinned) row deliberately renders no drag handle and is skipped as a drop target — matches the server-side `queue-io` invariant that the in-progress entry is pinned at order=0.

## Tests

- **`src/modals/queue-modal.test.tsx`** — 2 new cases:
  1. **drag-to-reorder dispatches reorder thunk with the new global order** — stubs `document.elementFromPoint` (jsdom returns null otherwise), fires `pointerdown` on `a1`'s handle + `pointermove` (window event) + `pointerup`, asserts `/api/queue/reorder` POST body carries the spliced order `["a2","a3","a1"]`.
  2. **drag handle is absent on the in-flight pinned row** (no drop target either) — pin `a1` as `in_progress`, assert `queryByTestId('queue-entry-a1-drag')` is null while `a2`'s handle is present.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] Frontend Vitest: 1631/1631 pass (+2 new)
- [x] All 12 existing queue-modal cases still green
- [x] Pre-push `npm run verify` — green (build, typecheck, all tests, e2e)

## What this does NOT change

- Touch behaviour: tap pills (Move up / Move down) remain the touch reorder affordance; drag handle is `hidden sm:flex`.
- Server contract: same `POST /api/queue/reorder` body shape — no `openapi.yaml` change.
- In-flight pinning: dispatcher + server-side `queue-io.reorder` already reject reorder-of-in_progress; this just hides the affordance.

Closes BACKLOG Could #40.