### PR TITLE
fix(server): upgrade multer 1.x -> 2.x for the upload-route CVE patch

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -78,16 +78,6 @@ Source: [`28-chapter-audio-format.md`](features/28-chapter-audio-format.md) foll
 - _Key files:_ `server/src/tts/synthesise-chapter.ts`; `server/src/tts/mp3.ts`; `src/components/mini-player.tsx` for the MediaSource consumer.
 - _Benefit (user):_ "listen as it generates" is the magic moment audiobook tools sell on.
 
-### 3. Multer 1.x → 2.x security upgrade (server file uploads)
-
-Source: net-new (2026-05-22). Surfaced by `npm warn deprecated multer@1.4.5-lts.2: Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x.` on `npm install --prefix server`. Full deprecation audit notes in `~/.claude/plans/fancy-bouncing-lovelace.md`.
-
-- _What:_ Bump `multer` in `server/package.json` from `^1.4.5-lts.2` to `^2.0.x` and adapt the upload middleware to the 2.x API. The breaking changes are mostly file-size limits + the `req.file` / `req.files` shape (still backwards-compatible on the request-handler side, but `MulterError` codes and middleware error semantics changed). Manuscript upload (`server/src/routes/upload.ts` or similar) and any binary-upload e2e (`e2e/binary-upload.spec.ts`) need a once-over.
-- _Acceptance:_ `npm install --prefix server` no longer prints the `multer@1.4.5-lts.2` deprecation warning. `npm ls multer` returns `multer@^2.x`. Manuscript-upload + binary-upload e2e specs stay green. `server/src/routes/*upload*.ts` Vitest coverage extended to pin the new `MulterError` codes (specifically `LIMIT_FILE_SIZE` and `LIMIT_UNEXPECTED_FILE`, which 2.x renamed/regrouped).
-- _Key files:_ `server/package.json` (dep bump); `server/src/routes/*upload*.ts` (middleware shape); any test under `server/src/routes/*upload*.test.ts`; `e2e/binary-upload.spec.ts` (regression). Migration guide: https://github.com/expressjs/multer/blob/master/UPGRADING.md.
-- _Depends on:_ none. Pure dep bump + small middleware adaptation.
-- _Benefit (user / technical):_ closes the only known-vulnerable direct dependency in the tree. Multer 1.x is EOL and the npm advisory database flags multiple CVEs (CVE-2025-7338, CVE-2025-47935, etc.) that 2.x patches. Even though our upload path is local-only today, LAN HTTPS mode (plan 81) and any future hosted deployment widens the blast radius — closing this now keeps the server-side dep tree audit-clean.
-
 ### 5. Merge journal for deterministic alias un-link
 
 Source: plan 95 ship (2026-05-22) — Out of scope. PR [#142](https://github.com/dudarenok-maker/AudioBook-Generator/pull/142) shipped editable cast aliases with a Reattribute Lines modal that uses the preserved Phase-0a `chapterCast` as a lineage proxy to narrow the user's manual reattribution from "whole book" to "these N chapters." It works, but it's not deterministic — a chapter shows up if the alias was in its Phase-0a roster, even when the merge that put the alias on the source character happened mid-book and didn't actually rewrite any chapter-1 sentences. The user has to skim and reassign.

--- a/docs/features/105-multer-2-upgrade.md
+++ b/docs/features/105-multer-2-upgrade.md
@@ -1,0 +1,66 @@
+---
+status: stable
+shipped: 2026-05-23
+owner: null
+---
+
+# 105 — Multer 1.x → 2.x security upgrade (server file uploads)
+
+> Status: stable
+> Key files: `server/package.json`, `server/src/routes/cover.ts`, `server/src/routes/import.ts`, `server/src/routes/manuscripts.ts`, `server/src/routes/exports-portable.ts`
+> URL surface: `POST /api/books/:bookId/cover/upload`, `POST /api/import`, `POST /api/manuscripts`, `POST /api/import/portable`
+> OpenAPI ops: the four multipart upload endpoints above (contract unchanged by this bump)
+
+## Benefit / Rationale
+
+- **User:** no behavioural change — uploads work exactly as before. The win is invisible-but-real: the server's only known-vulnerable direct dependency is gone.
+- **Technical:** closes the `multer@1.4.5-lts.x` deprecation warning that fired on every `npm install --prefix server`, and removes a string of CVEs that the 1.x line never patched (it is EOL). Multer 2.x patches `CVE-2025-47935`, `CVE-2025-47944`, `CVE-2025-48997`, `CVE-2025-7338`, plus the 2.1.x-line advisories `CVE-2026-2359`, `CVE-2026-3304`, and `CVE-2026-3520`.
+- **Architectural:** keeps the server-side dependency tree audit-clean ahead of LAN HTTPS mode (plan 81) and any future hosted deployment, where a multipart-upload DoS or busboy-abort bug would have a wider blast radius than the local-only path has today.
+
+## Architectural impact
+
+- **API-compatible bump, not a rewrite.** Multer 2.x is a security/maintenance major: the only declared breaking change in the 2.0.0 release is the Node floor moving to `>=10.16.0` (we run Node 20+). The request-handler surface this codebase uses — `multer.memoryStorage()`, `upload.single(field)`, `req.file` (`{ buffer, mimetype, originalname, size }`), and the `multer.MulterError` class with its `.code` / `.field` properties — is preserved verbatim. The `MulterError` code strings (`LIMIT_FILE_SIZE`, `LIMIT_UNEXPECTED_FILE`, …) are byte-identical between 1.x and 2.x (`lib/multer-error.js`).
+- **Types stay external.** Multer 2.x does **not** bundle its own TypeScript declarations (no `types` field in its `package.json`), so `@types/multer` remains a devDependency — bumped `^1.4.11` → `^2.1.0` to match the runtime major (DefinitelyTyped maps `ts5.4` → `@types/multer@2.1.0`).
+- **One route owns explicit upload-error handling.** Only `cover.ts` wraps `upload.single('image')` in an error-forwarding closure that maps the error to an HTTP status. That branch was hardened from a bare `(err as {code?}).code === 'LIMIT_FILE_SIZE'` check to a proper `err instanceof multer.MulterError` guard (so a non-multer middleware error can't masquerade as an upload-limit response), with an explicit `LIMIT_UNEXPECTED_FILE` → 400 branch added alongside the existing `LIMIT_FILE_SIZE` → 413 branch.
+- **The other three routes mount `upload.single(field)` as plain middleware** with no bespoke error branch — a `MulterError` there propagates to Express's error chain unchanged under 2.x (no code change required; behaviour is identical to 1.x).
+- **Reversibility:** revert the two `server/package.json` lines + the `cover.ts` middleware diff + `npm install --prefix server`. No on-disk data shape, no state.json, no openapi.yaml change.
+
+## Invariants to preserve
+
+- The four upload routes all use `multer.memoryStorage()` (in-RAM buffer, no temp files on disk) — `server/src/routes/{cover,import,manuscripts,exports-portable}.ts`. Buffers are validated/persisted by the route, not multer.
+- `cover.ts` upload-error mapping: oversize (`LIMIT_FILE_SIZE`) → **413** with `{ kind: 'oversize' }`; unexpected field (`LIMIT_UNEXPECTED_FILE`) → **400** with `{ kind: 'unexpected_field' }`; any other multipart error → 400 generic (`server/src/routes/cover.ts`, the `uploadMw.single('image')` closure).
+- Per-route `fileSize` limits unchanged: cover `MAX_UPLOAD_BYTES` = 10 MiB (`server/src/cover/upload.ts:24`); import 50 MiB; manuscripts 20 MiB; portable-import 50 MiB.
+- `@types/multer` stays a devDependency (multer 2.x ships no bundled types).
+
+## Test plan
+
+### Automated coverage
+
+- Vitest server (`server/src/routes/cover.test.ts`) — two new cases pin the 2.x `MulterError` paths through the route's explicit handler:
+  - oversize upload (11 MiB buffer > 10 MiB `MAX_UPLOAD_BYTES`) → **413** with `body.kind === 'oversize'` (`LIMIT_FILE_SIZE`).
+  - file attached under an unexpected field name (`wrongField` vs the configured `image`) → **400** with `body.kind === 'unexpected_field'` (`LIMIT_UNEXPECTED_FILE`).
+- Vitest server (`server/src/routes/import.test.ts`) — one new case asserts a file riding an unexpected field name does NOT 200 (multer 2.x still raises `LIMIT_UNEXPECTED_FILE` so the route never sees a valid `req.file`); the request is rejected (≥400).
+- Playwright e2e (`e2e/binary-upload.spec.ts`) — existing regression that drives EPUB / PDF / MOBI / AZW3 multipart uploads through `POST /api/import`; stays green under multer 2.x (the happy-path `upload.single('file')` contract is unchanged).
+- The other ~30 server route tests that exercise multipart uploads (cover upload happy path, portable import) all stay green — multer 2.x preserves the `req.file` shape they assert against.
+
+### Manual acceptance walkthrough
+
+1. `npm install --prefix server` → no `multer@…` deprecation warning printed (the remaining `node-domexception` warning is the `@google/genai` chain, tracked separately under BACKLOG Could #32 — not multer's).
+2. `npm ls multer --prefix server` → `multer@2.1.1`. `npm ls @types/multer --prefix server` → `@types/multer@2.1.0`.
+3. In the running app (`npm start`), upload a local cover JPEG via the listen-header Cover picker → still writes `cover.jpg`, patches `state.json` with `source: 'local'`.
+4. Attempt to upload a >10 MiB cover → 413 with the "Cover must be under …" message and the gradient stays.
+5. Upload a manuscript (`.epub` / `.txt`) via the upload view → parses and lands on the analysing/confirm stage as before.
+
+## Out of scope
+
+- The `@google/genai` → `node-domexception@1.0.0` deprecation chain — still on `@google/genai` major 2 (no v3); tracked in BACKLOG Could #32 (jsdom · archiver · @google/genai). No server-side change here.
+- ESLint 8 → 10 flat-config migration + jsdom/archiver bumps — Cluster A of this round (root deps), separate branch.
+
+## Ship notes
+
+Shipped 2026-05-23 on branch `fix/server-multer-2-upgrade`.
+
+- `server/package.json`: `multer` `^1.4.5-lts.1` → `^2.1.1`; `@types/multer` `^1.4.11` → `^2.1.0`. Resolved to `multer@2.1.1` + `@types/multer@2.1.0`.
+- Confirmed via the upstream CHANGELOG that 2.x is API-compatible for this codebase's usage (the only declared breaking change is the Node `>=10.16.0` floor); `MulterError` codes and the `multer.MulterError` / `memoryStorage` / `upload.single` / `req.file` surface are unchanged. The upstream `UPGRADING.md` referenced by the BACKLOG entry no longer exists in the repo (the migration is documented in the CHANGELOG + README instead).
+- `cover.ts` error branch hardened to `err instanceof multer.MulterError` + explicit `LIMIT_UNEXPECTED_FILE` → 400. The other three routes needed no change (they forward multer errors to Express unchanged).
+- `npm install --prefix server` no longer prints a multer deprecation warning. `npm run test:server` (1263 passed / 8 skipped) + `npm run test:server-slow` (156 passed) green; the 3 new MulterError test cases pass.

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -43,6 +43,7 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 
 - [02 — Upload (paste or file)](02-upload-paste-or-file.md) — `.md/.txt/.epub/.pdf/.mobi/.azw3` upload + paste flow.
 - [03 — Import & confirm metadata](03-import-confirm-metadata.md) — Parse-only import then confirm-write to disk.
+- [105 — Multer 1.x → 2.x security upgrade](105-multer-2-upgrade.md) — Bumps `multer` `^1.4.5-lts.1` → `^2.1.1` (+ `@types/multer` `^2.1.0`, kept external since 2.x ships no bundled types) across the four multipart upload routes (cover / import / manuscripts / portable). API-compatible bump — `memoryStorage` / `upload.single` / `req.file` / `MulterError` codes all preserved; the only declared 2.0.0 breaking change is the Node `>=10.16.0` floor. Closes the `multer@1.4.5-lts.x` deprecation warning + the EOL-1.x CVE string (CVE-2025-47935 / -47944 / -48997 / -7338, CVE-2026-2359 / -3304 / -3520). `cover.ts` error branch hardened to `err instanceof multer.MulterError` with an explicit `LIMIT_UNEXPECTED_FILE` → 400 alongside `LIMIT_FILE_SIZE` → 413; new MulterError test cases in `cover.test.ts` + `import.test.ts`. Shipped 2026-05-23.
 
 ### C. Analysis pipeline
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,7 +14,7 @@
         "@types/yazl": "^3.3.1",
         "epub2": "^3.0.2",
         "express": "^4.19.2",
-        "multer": "^1.4.5-lts.1",
+        "multer": "^2.1.1",
         "nanoid": "^5.0.7",
         "pdf-parse": "^1.1.1",
         "pdfjs-dist": "^4.10.38",
@@ -26,7 +26,7 @@
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
-        "@types/multer": "^1.4.11",
+        "@types/multer": "^2.1.0",
         "@types/node": "^20.12.7",
         "@types/pdf-parse": "^1.1.4",
         "@types/supertest": "^6.0.3",
@@ -1877,9 +1877,9 @@
       "license": "MIT"
     },
     "node_modules/@types/multer": {
-      "version": "1.4.13",
-      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.13.tgz",
-      "integrity": "sha512-bhhdtPw7JqCiEfC9Jimx5LqX9BDIPJEh2q/fQ4bqbBPtyEZYr3cvF22NwG0DmPZNYA0CAf2CnqDB4KIGGpJcaw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2390,17 +2390,17 @@
       }
     },
     "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "engines": [
-        "node >= 0.8"
+        "node >= 6.0"
       ],
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
+        "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
       }
     },
@@ -2445,12 +2445,6 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/crlf-normalize": {
@@ -3166,12 +3160,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -3300,27 +3288,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -3328,22 +3295,22 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "1.4.5-lts.2",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.2.tgz",
-      "integrity": "sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==",
-      "deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
-        "busboy": "^1.0.0",
-        "concat-stream": "^1.5.2",
-        "mkdirp": "^0.5.4",
-        "object-assign": "^4.1.1",
-        "type-is": "^1.6.4",
-        "xtend": "^4.0.0"
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/nanoid": {
@@ -3415,15 +3382,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -3600,12 +3558,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
-    },
     "node_modules/protobufjs": {
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.7.tgz",
@@ -3683,25 +3635,18 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
       "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
-    },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -4037,19 +3982,13 @@
       }
     },
     "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
-    },
-    "node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
     },
     "node_modules/superagent": {
       "version": "10.3.0",
@@ -5025,15 +4964,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/yauzl": {

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
     "@types/yazl": "^3.3.1",
     "epub2": "^3.0.2",
     "express": "^4.19.2",
-    "multer": "^1.4.5-lts.1",
+    "multer": "^2.1.1",
     "nanoid": "^5.0.7",
     "pdf-parse": "^1.1.1",
     "pdfjs-dist": "^4.10.38",
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
-    "@types/multer": "^1.4.11",
+    "@types/multer": "^2.1.0",
     "@types/node": "^20.12.7",
     "@types/pdf-parse": "^1.1.4",
     "@types/supertest": "^6.0.3",

--- a/server/src/routes/cover.test.ts
+++ b/server/src/routes/cover.test.ts
@@ -270,6 +270,40 @@ describe('POST /:bookId/cover/upload (plan 40)', () => {
     expect(res.body.kind).toBe('invalid_mime');
   });
 
+  /* Plan 105 — multer 2.x MulterError paths. multer 2.x preserves the
+     1.x `.code` strings (LIMIT_FILE_SIZE / LIMIT_UNEXPECTED_FILE) and
+     still raises a `multer.MulterError` instance, which the route's
+     middleware now gates on via `instanceof` before branching. These
+     two cases pin that the upgraded error semantics still surface as
+     413 (oversize) and 400 (unexpected field). */
+  it('413s with kind="oversize" when the upload exceeds the fileSize limit (LIMIT_FILE_SIZE)', async () => {
+    // MAX_UPLOAD_BYTES is 10 MiB — a 10.5 MiB buffer trips multer's
+    // fileSize limit before validateUpload ever runs.
+    const tooBig = Buffer.alloc(11 * 1024 * 1024, 0x41);
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cover/upload`)
+      .attach('image', tooBig, { filename: 'huge.jpg', contentType: 'image/jpeg' });
+    expect(res.status).toBe(413);
+    expect(res.body.kind).toBe('oversize');
+    expect(res.body.error).toMatch(/under/i);
+  });
+
+  it('400s with kind="unexpected_field" when the file rides an unexpected field name (LIMIT_UNEXPECTED_FILE)', async () => {
+    const sharp = (await import('sharp')).default;
+    const jpeg = await sharp({
+      create: { width: 4, height: 4, channels: 3, background: { r: 0, g: 0, b: 0 } },
+    })
+      .jpeg()
+      .toBuffer();
+    // The route configures upload.single('image'); attaching under
+    // 'wrongField' makes multer raise LIMIT_UNEXPECTED_FILE.
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cover/upload`)
+      .attach('wrongField', jpeg, { filename: 'mine.jpg', contentType: 'image/jpeg' });
+    expect(res.status).toBe(400);
+    expect(res.body.kind).toBe('unexpected_field');
+  });
+
   it('400s when the multipart body has no image field', async () => {
     const res = await request(app).post(`/api/books/${bookId}/cover/upload`).send();
     expect(res.status).toBe(400);

--- a/server/src/routes/cover.ts
+++ b/server/src/routes/cover.ts
@@ -147,12 +147,24 @@ coverRouter.post(
   (req: Request, res: Response, next: (err?: unknown) => void) => {
     uploadMw.single('image')(req, res, (err: unknown) => {
       if (err) {
-        const code = (err as { code?: string }).code;
-        if (code === 'LIMIT_FILE_SIZE') {
-          return res.status(413).json({
-            error: `Cover must be under ${MAX_UPLOAD_BYTES} bytes.`,
-            kind: 'oversize',
-          });
+        /* multer 2.x still raises MulterError with the same `.code`
+           strings as 1.x (LIMIT_FILE_SIZE, LIMIT_UNEXPECTED_FILE …).
+           Gate on the instanceof so a non-multer middleware error can't
+           masquerade as an upload-limit response, then branch on the
+           stable code. */
+        if (err instanceof multer.MulterError) {
+          if (err.code === 'LIMIT_FILE_SIZE') {
+            return res.status(413).json({
+              error: `Cover must be under ${MAX_UPLOAD_BYTES} bytes.`,
+              kind: 'oversize',
+            });
+          }
+          if (err.code === 'LIMIT_UNEXPECTED_FILE') {
+            return res.status(400).json({
+              error: `Unexpected upload field "${err.field ?? ''}" — use the "image" field.`,
+              kind: 'unexpected_field',
+            });
+          }
         }
         return res.status(400).json({ error: (err as Error).message || 'Upload error.' });
       }

--- a/server/src/routes/import.test.ts
+++ b/server/src/routes/import.test.ts
@@ -261,6 +261,30 @@ describe('POST /api/import → POST /api/books — excluded chapters round-trip'
   });
 });
 
+/* Plan 105 — multer 2.x guard. The import route mounts
+   `upload.single('file')` with no bespoke MulterError branch, so an
+   upload riding an unexpected field name raises a MulterError
+   (LIMIT_UNEXPECTED_FILE) that propagates to Express's error chain
+   rather than being parsed as a manuscript. This pins that multer 2.x
+   still rejects the wrong-field upload (it never reaches the route
+   handler as a valid `req.file`). */
+describe('POST /api/import — multer 2.x unexpected-field rejection', () => {
+  it('does not 200 a file uploaded under an unexpected field name', async () => {
+    const res = await request(app)
+      .post('/api/import')
+      .attach('notTheFileField', Buffer.from('hello world'), {
+        filename: 'x.txt',
+        contentType: 'text/plain',
+      });
+    /* multer raises LIMIT_UNEXPECTED_FILE → the route never sees a valid
+       req.file or req.body.text, so the request is rejected (Express's
+       default error handler yields 500; the route's own no-file branch
+       would yield 400). Either way it is NOT a 200 parse success. */
+    expect(res.status).not.toBe(200);
+    expect(res.status).toBeGreaterThanOrEqual(400);
+  });
+});
+
 /* Bug B: the staging response surfaces `seriesFromTitle` so the
    confirm-metadata view can render the "auto-extracted" chip. */
 describe('POST /api/import — seriesFromTitle plumbing', () => {


### PR DESCRIPTION
## Summary

Bumps `multer` `^1.4.5-lts.1` -> `^2.1.1` and `@types/multer` `^1.4.11` -> `^2.1.0` in `server/package.json`, closing the only known-vulnerable direct dependency in the server tree. Multer 1.x is EOL; the npm advisory database flags a string of CVEs the 1.x line never patched. Multer 2.x closes `CVE-2025-47935`, `CVE-2025-47944`, `CVE-2025-48997`, `CVE-2025-7338`, plus the 2.1.x-line advisories `CVE-2026-2359`, `CVE-2026-3304`, and `CVE-2026-3520` — and clears the `multer@1.4.5-lts.x` deprecation warning that fired on every `npm install --prefix server`. Closes BACKLOG Should #4.

This is an API-compatible bump for this codebase's usage. The only declared breaking change in multer 2.0.0 is the Node floor moving to `>=10.16.0` (we run Node 20+). The request-handler surface in use — `multer.memoryStorage()`, `upload.single(field)`, `req.file` (`{ buffer, mimetype, originalname, size }`), and the `multer.MulterError` class with its `.code`/`.field` props — is preserved verbatim, and the `MulterError` code strings (`LIMIT_FILE_SIZE`, `LIMIT_UNEXPECTED_FILE`, ...) are byte-identical between 1.x and 2.x (verified against the upstream `lib/multer-error.js` at tag `v2.1.1`). Multer 2.x ships no bundled TypeScript declarations, so `@types/multer` stays an external devDependency (bumped to the 2.1.0 line that DefinitelyTyped maps to TS 5.4).

Routes touched: all four multipart upload routes were verified against 2.x — `server/src/routes/cover.ts`, `import.ts`, `manuscripts.ts`, `exports-portable.ts`. Only `cover.ts` owns explicit upload-error mapping; its `upload.single('image')` error closure was hardened from a bare `(err as {code?}).code === 'LIMIT_FILE_SIZE'` check to a proper `err instanceof multer.MulterError` guard (so a non-multer middleware error can no longer masquerade as an upload-limit response), with an explicit `LIMIT_UNEXPECTED_FILE` -> 400 (`kind: 'unexpected_field'`) branch added next to the existing `LIMIT_FILE_SIZE` -> 413 (`kind: 'oversize'`) branch. The other three routes mount `upload.single(field)` as plain middleware and forward multer errors to Express unchanged under 2.x — no code change required.

Note: the upstream `UPGRADING.md` referenced by the old BACKLOG entry no longer exists in the multer repo; the migration is documented in the CHANGELOG + README, both confirming 2.x is a security/maintenance major with no handler-API breakage. The remaining `node-domexception` deprecation warning on `npm install --prefix server` is the `@google/genai` chain (BACKLOG Could #32), not multer.

## Test plan

- New: `server/src/routes/cover.test.ts` — two cases pin the 2.x MulterError paths through the route's explicit handler: an 11 MiB upload (> 10 MiB `MAX_UPLOAD_BYTES`) -> 413 with `kind: 'oversize'` (`LIMIT_FILE_SIZE`); a file attached under an unexpected field name -> 400 with `kind: 'unexpected_field'` (`LIMIT_UNEXPECTED_FILE`).
- New: `server/src/routes/import.test.ts` — a file riding an unexpected field name does NOT 200 (multer 2.x still raises `LIMIT_UNEXPECTED_FILE`, so the route never sees a valid `req.file`); the request is rejected (>=400).
- Regression: `e2e/binary-upload.spec.ts` (EPUB / PDF / MOBI / AZW3 multipart uploads) stays green under 2.x.
- `npm ls multer --prefix server` -> `multer@2.1.1`; `npm ls @types/multer --prefix server` -> `@types/multer@2.1.0`. `npm install --prefix server` prints no multer deprecation warning.
- Local: full `npm run verify` battery green at push time (typecheck + frontend Vitest + `test:server` 1263 passed / 8 skipped + `test:server-slow` 156 passed + e2e + build). No flaky visual-baseline drift this run.

Regression plan: `docs/features/105-multer-2-upgrade.md` (new) + `docs/features/INDEX.md` entry under Upload & import. BACKLOG Should #4 removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)