### PR TITLE
feat(frontend): cross-book queue dispatcher via shared stream runner

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -78,7 +78,7 @@ Source: [`28-chapter-audio-format.md`](features/28-chapter-audio-format.md) foll
 - _Key files:_ `server/src/tts/synthesise-chapter.ts`; `server/src/tts/mp3.ts`; `src/components/mini-player.tsx` for the MediaSource consumer.
 - _Benefit (user):_ "listen as it generates" is the magic moment audiobook tools sell on.
 
-### 5. Merge journal for deterministic alias un-link
+### 3. Merge journal for deterministic alias un-link
 
 Source: plan 95 ship (2026-05-22) — Out of scope. PR [#142](https://github.com/dudarenok-maker/AudioBook-Generator/pull/142) shipped editable cast aliases with a Reattribute Lines modal that uses the preserved Phase-0a `chapterCast` as a lineage proxy to narrow the user's manual reattribution from "whole book" to "these N chapters." It works, but it's not deterministic — a chapter shows up if the alias was in its Phase-0a roster, even when the merge that put the alias on the source character happened mid-book and didn't actually rewrite any chapter-1 sentences. The user has to skim and reassign.
 
@@ -88,17 +88,7 @@ Source: plan 95 ship (2026-05-22) — Out of scope. PR [#142](https://github.com
 - _Migration:_ books that pre-date the journal still get the `chapterCast` fallback (today's behaviour); only newly-merged ones benefit. No backfill — the lineage was lost at the old merges and there's no way to reconstruct it.
 - _Benefit (user):_ reattribute modal becomes a precise checklist instead of a scoped review — every row the user sees is provably their merge's work, no third-party sentences to skip over. Big quality-of-life win for series-2-into-1 cleanups where merges pile up.
 
-### 6. Cross-book queue dispatcher (plan 102 follow-up — closes bug #2)
-
-Source: plan 102 ship (2026-05-23) — Out of scope for the v1 ship. The queue dispatcher at `src/store/queue-dispatcher-middleware.ts:96` gates on `chapters.currentBookId === head.bookId` before firing the regenerate that the existing `generation-stream-middleware` translates into an SSE open. Queue entries for other books sit waiting until the user navigates to that book. Plan-102 bug #2 (cross-book voice-drift races) is half-fixed by Waves 4a + 4b: the queue serialises the entries so they no longer fight, but the dispatcher only acts on entries for the currently-loaded book.
-
-- _What:_ Lift the same-book gate. The dispatcher calls `api.streamGeneration` directly for cross-book entries (reusing the existing fetch-SSE pipeline; no duplication), tracks the cancel + cross-book `activeStream` snapshot in middleware-local state, and tears down on idle. The slice's `applyGenerationTick` reducer already has a cross-book guard at `src/store/chapters-slice.ts:309` that skips per-chapter mutations when the tick's bookId differs from the slice's loaded book — so ticks from the cross-book stream won't clobber the user's currently-viewed book's rows. Per-chapter detail for the cross-book entry stays absent until the user navigates to that book and the slice hydrates fresh from disk (`hydrateFromBookState`). The global top-bar pill keeps moving via the cross-book `activeStream` snapshot regardless of which book is viewed.
-- _Acceptance:_ With Books A + B both having queued work and the user viewing Book A: enqueue A.ch5 → drains. While A.ch5 is mid-synth, enqueue B.ch3 → enters the queue. A.ch5 completes → dispatcher fires generation for B.ch3 WITHOUT the user navigating. Top-bar pill correctly reflects B.ch3's progress. Voice-drift fix from `DriftReportModal` covering 3 chapters across Books A + B → all 3 drain serially regardless of which book is viewed. New Vitest pin in `queue-dispatcher-middleware.test.ts` for the cross-book branch (mocks `api.streamGeneration` and asserts the tick → DELETE round-trip on idle). Playwright spec extension in `e2e/queue-modal.spec.ts` driving a cross-book scenario via `page.route` injecting two books' worth of queue entries.
-- _Key files:_ `src/store/queue-dispatcher-middleware.ts` (lift the same-book gate; branch to a `streamCrossBook` helper that calls `api.streamGeneration` and tracks the cancel + sets `chapters.activeStream` via `chaptersActions.setActiveStream`); `src/lib/api.ts` (already exports `streamGeneration` — no contract change); `src/store/chapters-slice.ts` (cross-book guard at `applyGenerationTick` already exists — verify it still skips correctly when called from the dispatcher's onTick); `src/store/queue-dispatcher-middleware.test.ts` (new cross-book cases); `e2e/queue-modal.spec.ts` (cross-book scenario).
-- _Depends on:_ plan 102 (shipped).
-- _Benefit (user / architectural):_ closes bug #2 from plan 102. The user can mix-and-match cross-book ordering — "regenerate ch5 of Book A, then ch3 of Book B, then ch7 of Book A" — and the dispatcher honours the explicit order without requiring per-book navigation. Architecturally, decouples generation scheduling from the slice's loaded-book state, which is the seam future "Schedule overnight" / "Pause this book, prioritise that one" affordances will plug into.
-
-### 7. Strip chapters-slice generation control fields (plan 102 cleanup)
+### 4. Strip chapters-slice generation control fields (plan 102 cleanup)
 
 Source: plan 102 ship (2026-05-23) — Out of scope for the v1 ship. The dispatcher relies on the existing `generation-stream-middleware`'s `pendingRegen` consumption path — when the dispatcher fires `chaptersActions.regenerateChapter`, the slice sets `pendingRegen` + bumps `regenEpoch`, and the existing middleware reconciles by opening the SSE. Stripping those fields prematurely would break the slice→middleware handshake the dispatcher relies on.
 
@@ -345,6 +335,16 @@ Source: net-new (2026-05-23). Surfaced during the plan-103 CI cost audit.
 - _Key files:_ `.github/workflows/regen-visual-baselines.yml` (collapse `strategy.matrix.project` into a sequential step loop; consolidate the artifact upload).
 - _Depends on:_ none.
 - _Benefit (technical):_ ~60 billed min/month freed on regen days; tidier workflow.
+
+### 38. Pre-seed pending-revision stubs for cross-book character regens
+
+Source: plan 102 Should #6 ship (2026-05-23) — known limitation called out in the cross-book dispatcher PR. When the dispatcher opens a CROSS-book entry whose scope is `character`, it does not enqueue a pending-revision stub the way the same-book path does (`generation-stream-middleware`'s regen observer keys off the `regenerateCharacter` action, which the cross-book path deliberately does not dispatch — it would mutate the viewed book's rows). The revision still renders once the user opens that book and its revisions hydrate from disk; only the eager in-session stub is missing.
+
+- _What:_ When the dispatcher's cross-book branch opens a `character`-scoped entry, enqueue the pending-revision stub directly from the queue entry's `{ bookId, chapterId, characterId }` rather than from the viewed book's `Chapter`/`Character` objects (which aren't in the slice while a different book is viewed). Requires either teaching `buildPendingRevisionStub` to accept the minimal id triple, or hydrating the other book's chapter/character names from the library/cast caches.
+- _Acceptance:_ Enqueue a character-scoped regen for Book B while viewing Book A; without navigating to B, a pending revision stub for that (chapter, character) exists in `revisions.pending` (playable=false), and flips to playable on the cross-book stream's `chapter_complete`.
+- _Key files:_ `src/store/queue-dispatcher-middleware.ts` (cross-book branch), `src/lib/build-pending-revision.ts` (accept minimal input), `src/store/revisions-slice.ts`.
+- _Depends on:_ Should #6 (cross-book dispatcher) shipped.
+- _Benefit (user):_ the diff player's pending-revision list is complete for cross-book character regens without requiring a navigate-to-book round-trip first. Low priority — the revision is recoverable on book open today.
 
 ---
 

--- a/docs/features/archive/102-global-queue-modal.md
+++ b/docs/features/archive/102-global-queue-modal.md
@@ -117,7 +117,7 @@ Run with the canonical full-pipeline manuscript `C:\Users\dudar\Downloads\Bonus 
 
 **Deferred to follow-up plans (filed on BACKLOG):**
 
-- Cross-book dispatcher (bug #2) — dispatcher gates on `chapters.currentBookId === head.bookId`. Cross-book sequencing requires either a cross-book SSE arbitration layer or direct fetch bypass of the existing generation-stream-middleware's gate.
+- Cross-book dispatcher (bug #2) — dispatcher gates on `chapters.currentBookId === head.bookId`. Cross-book sequencing requires either a cross-book SSE arbitration layer or direct fetch bypass of the existing generation-stream-middleware's gate. **SHIPPED 2026-05-23 (BACKLOG Should #6):** extracted a shared `generation-stream-runner.ts` driven by both the generation-stream-middleware (same-book) and the queue-dispatcher-middleware (cross-book open), so the same-book gate is lifted and the "one SSE at a time" invariant lives in one place.
 - `chapters-slice` strip of `pendingRegen` / `regenEpoch` / `paused` — keep until the existing generation-stream-middleware is rewritten to consume queue state directly. Removing prematurely breaks the slice→middleware handshake the dispatcher relies on.
 - Drag-to-reorder in modal — tap-pill (Move up / Move down) covers both desktop and mobile in one path; pointer-event drag is a polish item.
 - Visual baselines for queue modal — Wave 5 didn't regen baselines (Windows host flake per `feedback_visual_baselines_flaky_on_windows.md`). Linux CI run picks them up next push, or trigger explicitly via `npm run test:e2e:visual -- --update-snapshots`.

--- a/e2e/queue-modal.spec.ts
+++ b/e2e/queue-modal.spec.ts
@@ -16,11 +16,17 @@
  *     reflects "Paused" in the modal header.
  *   - Generate view "View queue" button opens the modal as an alternate
  *     entry point.
+ *   - Cross-book entries (Should #6): two books' entries render grouped in
+ *     the modal while viewing one book, and the OTHER book's entry can be
+ *     cancelled without navigating to it.
  *
  * Not covered (out of scope for this spec; covered elsewhere):
  *   - SSE reconnect during generation — pinned by api-stream-reconnect.test.ts.
- *   - Dispatcher drain semantics — pinned by queue-dispatcher-middleware.test.ts.
- *   - Cross-book ordering across two real books — same dispatcher tests. */
+ *   - Dispatcher drain semantics (incl. the cross-book open → idle → DELETE
+ *     round-trip) — pinned by queue-dispatcher-middleware.test.ts. Driving a
+ *     real cross-book SSE drain in mock mode is intentionally avoided here
+ *     (the mock stream reads the viewed book's chapters); the dispatcher unit
+ *     tests pin that path deterministically. */
 
 import { test, expect, type Route } from '@playwright/test';
 
@@ -37,8 +43,16 @@ interface QueueEntryShape {
 
 /* Helper: install a per-test in-memory queue + intercept every /api/queue
    route against it. Returns a `state` ref so the spec can mutate the
-   fixture mid-test if needed. */
-function installQueueRoutes(entries: QueueEntryShape[], initialPaused = false) {
+   fixture mid-test if needed.
+
+   Defaults to PAUSED. Since Should #6 lifted the same-book gate, the queue
+   dispatcher drains any UNPAUSED queue with work the moment the snapshot
+   loads — regardless of which view the user is on. These specs inspect the
+   queue UI (chip count, grouping, cancel), not the drain, so a paused
+   fixture keeps the injected entries put. Drain semantics (incl. the
+   cross-book open → idle → DELETE round-trip) are pinned by
+   queue-dispatcher-middleware.test.ts. Pass `false` to exercise draining. */
+function installQueueRoutes(entries: QueueEntryShape[], initialPaused = true) {
   const state = { entries: [...entries], paused: initialPaused };
 
   const respondSnapshot = (route: Route): Promise<void> =>
@@ -133,6 +147,64 @@ test.describe('queue modal (plan 102)', () => {
     await cancelBtn.click();
     /* After the DELETE round-trip the modal re-renders empty. */
     await expect(page.getByText(/Empty/i).first()).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('cross-book entries render grouped and the other book’s entry cancels while viewing one book', async ({
+    page,
+  }) => {
+    /* Should #6 — two books' worth of queue entries injected via page.route.
+       The user is viewing Solway Bay (sb); a Northern Star (ns) entry is also
+       queued. Both render in the modal (grouped by book), and the ns entry —
+       a DIFFERENT book than the one on screen — can be cancelled without
+       navigating to it. This is the cross-book queue surface; the dispatcher
+       unit tests cover the actual cross-book drain. */
+    const { state, respondSnapshot } = installQueueRoutes([
+      {
+        id: 'sb-c1',
+        bookId: 'sb',
+        chapterId: 1,
+        scope: 'this',
+        addedAt: new Date().toISOString(),
+        status: 'queued',
+        order: 0,
+      },
+      {
+        id: 'ns-c3',
+        bookId: 'ns',
+        chapterId: 3,
+        scope: 'this',
+        addedAt: new Date().toISOString(),
+        status: 'queued',
+        order: 1,
+      },
+    ]);
+    await page.route('**/api/queue', respondSnapshot);
+    await page.route('**/api/queue/*', (route) => {
+      if (route.request().method() === 'DELETE') {
+        const id = new URL(route.request().url()).pathname.split('/').pop();
+        state.entries = state.entries.filter((e) => e.id !== id);
+      }
+      void respondSnapshot(route);
+    });
+
+    await page.goto('/#/books/sb/listen');
+    const chip = page.getByTestId('topbar-queue-chip');
+    await chip.waitFor({ state: 'visible', timeout: 10_000 });
+    await expect(chip).toContainText('Queue · 2');
+    await chip.click();
+    await expect(page.getByRole('dialog', { name: /Generation queue/i })).toBeVisible({
+      timeout: 5_000,
+    });
+
+    /* Both books' entries render (grouped by book in the modal). */
+    await expect(page.getByTestId('queue-entry-sb-c1')).toBeVisible();
+    await expect(page.getByTestId('queue-entry-ns-c3')).toBeVisible();
+
+    /* Cancel the OTHER book's entry (ns) while still on sb's listen view. */
+    await page.getByTestId('queue-entry-ns-c3-cancel').click();
+    await expect(page.getByTestId('queue-entry-ns-c3')).toHaveCount(0, { timeout: 5_000 });
+    /* The viewed book's entry is untouched. */
+    await expect(page.getByTestId('queue-entry-sb-c1')).toBeVisible();
   });
 
   test('Generate view "View queue" button opens the modal', async ({ page }) => {

--- a/src/store/generation-stream-middleware.test.ts
+++ b/src/store/generation-stream-middleware.test.ts
@@ -14,6 +14,7 @@ import { castSlice } from './cast-slice';
 import { revisionsSlice } from './revisions-slice';
 import { analysisSlice, analysisActions, type AnalysisStreamSnapshot } from './analysis-slice';
 import { generationStreamMiddleware } from './generation-stream-middleware';
+import { createStreamRunner, type StreamRunner } from './generation-stream-runner';
 import type { Chapter, GenerationTick, Character } from '../lib/types';
 
 const streamGenerationMock = vi.fn();
@@ -34,7 +35,12 @@ vi.mock('../lib/api', () => ({
 }));
 
 function makeStore() {
-  return configureStore({
+  /* The runner needs the store (dispatch/getState), which only exists after
+     configureStore returns — so the middleware gets a lazy accessor and we
+     bind the runner right after. One runner per store keeps tests isolated. */
+  let runner: StreamRunner | null = null;
+  const getRunner = (): StreamRunner => runner!;
+  const store = configureStore({
     reducer: {
       ui: uiSlice.reducer,
       chapters: chaptersSlice.reducer,
@@ -44,8 +50,10 @@ function makeStore() {
       revisions: revisionsSlice.reducer,
       analysis: analysisSlice.reducer,
     },
-    middleware: (gd) => gd().concat(generationStreamMiddleware),
+    middleware: (gd) => gd().concat(generationStreamMiddleware(getRunner)),
   });
+  runner = createStreamRunner(store);
+  return store;
 }
 
 const ch = (id: number, overrides: Partial<Chapter> = {}): Chapter => ({

--- a/src/store/generation-stream-middleware.ts
+++ b/src/store/generation-stream-middleware.ts
@@ -1,4 +1,4 @@
-/* Generation-stream middleware — owns the SSE handle so generation keeps
+/* Generation-stream middleware — drives the SSE handle so generation keeps
    running while the user navigates anywhere in the app, not just inside
    the generating book.
 
@@ -13,48 +13,46 @@
    switched to a different book — so the user couldn't start a new import
    or open another book without "bumping" generation.
 
-   v3 (current) decouples the stream from `stage.bookId` entirely. Once a
-   handle opens for book X, it's pinned to book X and ignores every
-   navigation that follows. The only ways to stop the run are:
-     - chapters/setPaused(true), dispatched by the Generate-view Stop
-       button or by the local-analyzer confirm prompt (see
-       src/hooks/use-local-analyzer-guard.tsx) when a Qwen-backed import
+   v3 decoupled the stream from `stage.bookId` entirely. Once a handle opens
+   for book X, it's pinned to book X and ignores every navigation that
+   follows.
+
+   v4 (current — plan 102 Should #6) moves the SSE handle + lifecycle into a
+   shared `StreamRunner` (src/store/generation-stream-runner.ts) so the queue
+   dispatcher can open a CROSS-BOOK stream through the same lifecycle. This
+   middleware now owns only the OPEN-SIDE DECISION for same-book streams
+   (reconcile + the reverse-local-analyzer guard) and the per-tick
+   delegation to `runner.handleTick`. The ways a run stops are unchanged:
+     - chapters/setPaused(true), from the local-analyzer confirm prompt (see
+       src/hooks/use-local-analyzer-guard.tsx) when a local-engine import
        would compete with TTS for GPU.
-     - the queue draining (final idle tick from the server).
+     - the queue draining (final idle tick from the server → runner closes).
 
    To keep the global header pill alive while the user is on a different
-   book, the middleware publishes an out-of-band `chapters.activeStream`
+   book, the runner publishes an out-of-band `chapters.activeStream`
    snapshot — done/total/inProgress/lastTickAt — that survives slice
    re-hydration. Reducers in chapters-slice ignore tick payloads when the
-   slice has drifted to a different book (see the cross-book guard at the
-   top of applyGenerationTick).
+   slice has drifted to a different book (the cross-book guard at the top of
+   applyGenerationTick).
 
-   Side responsibility: emit `generation_started` / `generation_run_complete` /
-   `chapter_failed` change-log events from the same vantage point. The
-   per-chapter `chapter_complete` ticks are accumulated on the handle and
-   collapsed into a single rollup event on closeHandle — the activity feed
-   used to drown in per-chapter audit rows on long runs.
+   Side responsibility (still observed here, delegated to the runner): emit
+   `generation_started` / `generation_run_complete` / `chapter_failed`
+   change-log events; enqueue pending-revision stubs on character regens.
 
    Skipped under VITE_USE_MOCKS=true? — NO. The mock SSE depends on a long-
    lived caller; the whole point of this middleware is to BE that caller. */
 
-import type { Dispatch, Middleware } from '@reduxjs/toolkit';
+import type { Middleware } from '@reduxjs/toolkit';
 import { api } from '../lib/api';
-import {
-  buildGenerationStartedEvent,
-  buildGenerationRunCompleteEvent,
-  buildChapterFailedEvent,
-} from '../lib/change-log';
 import { chaptersActions } from './chapters-slice';
-import { changeLogActions } from './change-log-slice';
 import { revisionsActions } from './revisions-slice';
-import { notificationsActions } from './notifications-slice';
 import { buildPendingRevisionStub } from '../lib/build-pending-revision';
-import type { ActiveStreamSnapshot, ChaptersState } from './chapters-slice';
+import type { StreamRunner } from './generation-stream-runner';
+import type { ChaptersState } from './chapters-slice';
 import type { CastState } from './cast-slice';
 import type { UiState } from './ui-slice';
 import type { AnalysisState } from './analysis-slice';
-import type { Chapter, GenerationTick, TtsModelKey } from '../lib/types';
+import type { Chapter, GenerationTick } from '../lib/types';
 
 interface StreamableRootState {
   ui: UiState;
@@ -77,34 +75,13 @@ function bookIdFromState(s: StreamableRootState): string | null {
 function hasWork(chapters: Chapter[]): boolean {
   /* Excluded chapters are skipped by the server's target loop
      (server/src/routes/generation.ts) and the active-subset counters /
-     snapshotFromChapters below — so they must also be excluded here, or
-     a pre-run exclude leaves a 'queued' row that keeps the SSE handle
-     (and the global "Generating · N/N · 100%" pill) alive forever after
-     the last real chapter finishes. */
+     snapshotFromChapters in the runner — so they must also be excluded
+     here, or a pre-run exclude leaves a 'queued' row that keeps the SSE
+     handle (and the global "Generating · N/N · 100%" pill) alive forever
+     after the last real chapter finishes. */
   return chapters.some(
     (c) => !c.excluded && (c.state === 'in_progress' || c.state === 'queued'),
   );
-}
-
-function snapshotFromChapters(
-  bookId: string,
-  modelKey: TtsModelKey,
-  state: ChaptersState,
-): ActiveStreamSnapshot {
-  /* Counters mirror the active-subset filter used in the Generate view
-     (`activeChapters` in src/views/generation.tsx): excluded chapters
-     never queue or synthesise, so they must not inflate `total` or
-     stall the cross-book top-bar pill's done/total readout. */
-  const active = state.chapters.filter((c) => !c.excluded);
-  return {
-    bookId,
-    modelKey,
-    done: active.filter((c) => c.state === 'done').length,
-    total: active.length,
-    inProgress: active.filter((c) => c.state === 'in_progress').length,
-    lastTickAt: state.lastTickAt,
-    halted: state.lastError != null,
-  };
 }
 
 /* The set of action types that *might* require us to open or close the SSE.
@@ -137,346 +114,184 @@ const TRIGGER_TYPES = new Set<string>([
   'ui/changeView',
 ]);
 
-interface OpenHandle {
-  cancel: () => void;
-  bookId: string;
-  modelKey: TtsModelKey;
-  /* Per-run rollup accumulator. Every chapter_complete tick pushes its
-     chapterId here; on run end (closeHandle) we emit one
-     generation_run_complete event with the full list. This is what keeps
-     the activity feed from getting flooded — a 14-chapter run used to write
-     14 chapter_complete entries; now it writes one rollup. */
-  completedChapterIds: number[];
+/* Regen actions need an explicit close *before* reconcile so the new spec
+   gets a fresh stream — without this, the existing handle stays open and
+   reconcile sees the runner already open and skips the open that would
+   forward `chapterIds + force`. Only relevant when the user is acting on
+   the same book the handle is streaming for — regen from a different book
+   context would be a no-op for the existing stream anyway. */
+const REGEN_TYPES = new Set<string>([
+  'chapters/regenerateChapter',
+  'chapters/regenerateChapterIds',
+  'chapters/regenerateCharacter',
+  'chapters/batchRegenerateCharacters',
+]);
+
+export function generationStreamMiddleware(getRunner: () => StreamRunner): Middleware {
+  return (store) => {
+    const dispatch = store.dispatch;
+
+    const reconcile = () => {
+      const runner = getRunner();
+      const after = store.getState() as StreamableRootState;
+      const stageBookId = bookIdFromState(after);
+      const modelKey = after.ui.ttsModelKey;
+      const { chapters, paused, pendingRegen, currentBookId } = after.chapters;
+
+      /* Pause is the universal user-initiated stop. It is dispatched only
+         from contexts that mean "stop the active stream": the
+         local-analyzer confirm prompt (handles cross-book pause). Fire an
+         explicit /pause to the server so the run stops server-side (closing
+         the SSE alone is no longer enough — the server now treats SSE close
+         as "unsubscribe this observer", which is what lets a browser reload
+         survive without killing the run), then close our local handle. */
+      if (runner.isOpen() && paused) {
+        const pauseBookId = runner.getBookId();
+        if (pauseBookId) void api.pauseGeneration({ bookId: pauseBookId });
+        runner.close();
+        return;
+      }
+
+      /* Sticky semantics: once a handle is open for book X, it stays open
+         across goHome, openBook(otherBook), changeView, setTtsModelKey, and
+         every other transition. The only termination is pause (above) or
+         queue drain (below, when shouldOpen = false). Notably:
+           - We do NOT close on stageBookId == null. The user is allowed to
+             navigate Books → Voices → Upload while the stream keeps running
+             in the background.
+           - We do NOT close on stageBookId != handle.bookId. The user is
+             allowed to open another book; the slice gets repopulated but the
+             handle keeps streaming for the original book, and the
+             applyGenerationTick reducer's cross-book guard prevents the
+             drift from clobbering the other book's rows.
+           - We do NOT close on modelKey change. Switching the TTS model in
+             Account settings or anywhere else takes effect on the NEXT
+             generation start, not the live one. */
+      if (runner.isOpen()) {
+        /* Already streaming — nothing to do on the open side. The only
+           remaining close trigger is the queue-drain check the slice runs
+           itself on the final idle tick, which will leave hasWork(chapters)
+           false on the next reconcile pass. */
+        if (currentBookId === runner.getBookId()) {
+          const shouldOpen = pendingRegen != null || hasWork(chapters);
+          if (!shouldOpen) runner.close();
+        }
+        return;
+      }
+
+      /* No handle. Open only when the slice and the URL agree on which book
+         we're on, there's work in scope, and the user hasn't paused. */
+      if (!stageBookId) return;
+      if (currentBookId !== stageBookId) return;
+      if (paused) return;
+      const shouldOpen = pendingRegen != null || hasWork(chapters);
+      if (!shouldOpen) return;
+
+      /* Plan 32 D2 follow-up: REVERSE-LOCAL-ANALYZER GUARD (implicit
+         path). The D2 hook gates EXPLICIT user-initiated TTS-start
+         callsites (Resume button, Regenerate modal confirms). This
+         block closes the parallel implicit seam: cold-boot rehydration
+         of a book with both `analysis.activeStream.engine === 'local'`
+         (an alive local analysis on the same book) AND a non-empty
+         generation queue would otherwise auto-fire generation behind
+         the user's back, competing for the same GPU.
+         Rule mirrors the hook (use-reverse-local-analyzer-guard.tsx):
+         - engine === 'local' — Gemini analyses don't compete for GPU,
+           so the gate doesn't fire on them.
+         - bookId matches — a local analysis on book A shouldn't block
+           generation on unrelated book B.
+         - state !== 'paused' / 'halted' — a user-paused or halted
+           analysis is already not competing for GPU; respecting that
+           matches the existing sticky-generation contract (the user
+           explicitly stopped the analysis).
+         Refusal mechanism: flip the slice to paused. The user reads
+         the analysis pill, knows what's running, and resumes
+         generation when ready. No new modal — we're not nagging on
+         every navigation, we're refusing to act without consent. */
+      /* Defensive read: a handful of legacy test harnesses build a
+         store without the analysis slice. Production always has it
+         (configured in src/store/index.ts). */
+      const analysisSnap =
+        (after as { analysis?: { activeStream?: typeof after.analysis.activeStream } }).analysis
+          ?.activeStream ?? null;
+      if (
+        analysisSnap != null &&
+        analysisSnap.engine === 'local' &&
+        analysisSnap.bookId === stageBookId &&
+        analysisSnap.state !== 'paused' &&
+        analysisSnap.state !== 'halted'
+      ) {
+        dispatch(chaptersActions.setPaused(true));
+        return;
+      }
+
+      runner.open(stageBookId, modelKey, pendingRegen, { consumePendingRegen: true });
+    };
+
+    return (next) => (action) => {
+      const result = next(action);
+      const a = action as { type?: string };
+      const type = a?.type;
+      if (!type || !TRIGGER_TYPES.has(type)) return result;
+
+      const runner = getRunner();
+
+      if (REGEN_TYPES.has(type) && runner.isOpen()) {
+        const after = store.getState() as StreamableRootState;
+        if (after.chapters.currentBookId === runner.getBookId()) runner.close();
+      }
+
+      /* Enqueue pending-revision stubs on regen dispatch. One per
+         (characterId, chapterId) tuple — the slice's dedupe-by-id collapses
+         restarts. The stub carries playable=false; chapter_complete flips
+         it (handled in the runner's handleTick). Out-of-scope for
+         chapter-only regens (regenerateChapter / regenerateChapterIds)
+         since those don't carry a character to attribute the diff to. */
+      if (type === 'chapters/regenerateCharacter') {
+        const payload = (a as { payload?: { characterId: string; chapterIds: number[] } }).payload;
+        if (payload) {
+          const after = store.getState() as StreamableRootState;
+          const character = after.cast.characters.find((c) => c.id === payload.characterId);
+          if (character) {
+            for (const chapterId of payload.chapterIds) {
+              const chapter = after.chapters.chapters.find((c) => c.id === chapterId);
+              if (!chapter) continue;
+              dispatch(
+                revisionsActions.enqueuePending(buildPendingRevisionStub({ chapter, character })),
+              );
+            }
+          }
+        }
+      } else if (type === 'chapters/batchRegenerateCharacters') {
+        const payload = (a as { payload?: { characterIds: string[]; chapterIds: number[] } })
+          .payload;
+        if (payload) {
+          const after = store.getState() as StreamableRootState;
+          for (const characterId of payload.characterIds) {
+            const character = after.cast.characters.find((c) => c.id === characterId);
+            if (!character) continue;
+            for (const chapterId of payload.chapterIds) {
+              const chapter = after.chapters.chapters.find((c) => c.id === chapterId);
+              if (!chapter) continue;
+              dispatch(
+                revisionsActions.enqueuePending(buildPendingRevisionStub({ chapter, character })),
+              );
+            }
+          }
+        }
+      }
+
+      /* Per-tick side-effects (snapshot refresh, rollup, completion / failure
+         events, idle teardown) live in the shared runner so cross-book
+         streams opened by the queue dispatcher get them too. We observe the
+         action here (post-reducer) and delegate. */
+      if (type === 'chapters/applyGenerationTick') {
+        const ev = (a as { payload?: GenerationTick }).payload;
+        runner.handleTick(ev);
+      }
+
+      reconcile();
+      return result;
+    };
+  };
 }
-
-export const generationStreamMiddleware: Middleware = (store) => {
-  let handle: OpenHandle | null = null;
-
-  const dispatch = store.dispatch as Dispatch;
-
-  const closeHandle = () => {
-    if (!handle) return;
-    /* Flush the per-run rollup before tearing down. Empty runs (pause before
-       any chapter finished, queue drained immediately) write nothing — there
-       was already a generation_started anchor for those. */
-    if (handle.completedChapterIds.length > 0) {
-      dispatch(
-        changeLogActions.appendLogEvent(
-          buildGenerationRunCompleteEvent({ chapterIds: handle.completedChapterIds }),
-        ),
-      );
-    }
-    handle.cancel();
-    handle = null;
-    dispatch(chaptersActions.clearActiveStream());
-  };
-
-  const openHandle = (
-    bookId: string,
-    modelKey: TtsModelKey,
-    spec: ChaptersState['pendingRegen'],
-  ) => {
-    /* Emit a system-level "generation started" event so the activity feed has
-       a beat for the user's Regenerate click (or Resume). The chapterIds
-       reflect either the regen spec or the broader queued/in-progress set
-       the server will resume against. */
-    const after = store.getState() as StreamableRootState;
-    const ids =
-      spec?.chapterIds && spec.chapterIds.length > 0
-        ? spec.chapterIds
-        : after.chapters.chapters
-            .filter((c) => c.state === 'in_progress' || c.state === 'queued')
-            .map((c) => c.id);
-    dispatch(changeLogActions.appendLogEvent(buildGenerationStartedEvent({ chapterIds: ids })));
-
-    /* Seed the cross-book snapshot from the slice's current rows — at open
-       time the slice IS the generating book's data. Subsequent ticks will
-       refresh it; once the user navigates into a different book the slice
-       drifts but the snapshot freezes at whatever it was just before, so
-       the pill keeps showing the last-known progress. */
-    dispatch(
-      chaptersActions.setActiveStream(snapshotFromChapters(bookId, modelKey, after.chapters)),
-    );
-
-    const cancel = api.streamGeneration({
-      bookId,
-      modelKey,
-      chapterIds: spec?.chapterIds,
-      force: spec?.force,
-      /* The mock implementation reads live chapter state via this callback;
-         the real fetch-based stream ignores it. Either way we close over the
-         store, not over any view's props, so generation continues after the
-         Generate view unmounts. */
-      getChapters: () => (store.getState() as StreamableRootState).chapters.chapters,
-      onTick: (ev: GenerationTick) => dispatch(chaptersActions.applyGenerationTick(ev)),
-    });
-    handle = { cancel, bookId, modelKey, completedChapterIds: [] };
-    /* Drain the spec the instant the SSE owns it — same Pause→Resume rationale
-       documented on the slice reducer: without this, an aborted SSE never
-       delivers `idle` so `pendingRegen` would stick around forever and every
-       Resume would re-force-regen the original target set. */
-    if (spec) dispatch(chaptersActions.consumePendingRegen());
-  };
-
-  const reconcile = () => {
-    const after = store.getState() as StreamableRootState;
-    const stageBookId = bookIdFromState(after);
-    const modelKey = after.ui.ttsModelKey;
-    const { chapters, paused, pendingRegen, currentBookId } = after.chapters;
-
-    /* Pause is the universal user-initiated stop. It is dispatched only
-       from contexts that mean "stop the active stream": the Generate-view
-       Stop button (current book is the streaming book), or the
-       local-analyzer confirm prompt (handles cross-book pause). Either
-       way: fire an explicit /pause to the server so the run stops
-       server-side (closing the SSE alone is no longer enough — the server
-       now treats SSE close as "unsubscribe this observer", which is what
-       lets a browser reload survive without killing the run), then close
-       our local handle. */
-    if (handle && paused) {
-      const pauseBookId = handle.bookId;
-      void api.pauseGeneration({ bookId: pauseBookId });
-      closeHandle();
-      return;
-    }
-
-    /* Sticky semantics: once a handle is open for book X, it stays open
-       across goHome, openBook(otherBook), changeView, setTtsModelKey, and
-       every other transition. The only termination is pause (above) or
-       queue drain (below, when shouldOpen = false). Notably:
-         - We do NOT close on stageBookId == null. The user is allowed to
-           navigate Books → Voices → Upload while the stream keeps running
-           in the background.
-         - We do NOT close on stageBookId != handle.bookId. The user is
-           allowed to open another book; the slice gets repopulated but the
-           handle keeps streaming for the original book, and the
-           applyGenerationTick reducer's cross-book guard prevents the
-           drift from clobbering the other book's rows.
-         - We do NOT close on modelKey change. Switching the TTS model in
-           Account settings or anywhere else takes effect on the NEXT
-           generation start, not the live one. */
-
-    /* Open-side reconcile only fires when the slice's currently-loaded
-       book is the same as `stage.bookId`. If the user is on Books home or
-       another book entirely, we never auto-open a stream for the absent
-       book; opens happen when the user actually returns to the generating
-       book's Generate view and the SSE finds work waiting. */
-    if (handle) {
-      /* Already streaming — nothing to do on the open side. The only
-         remaining close trigger is the queue-drain check the slice runs
-         itself on the final idle tick, which will leave hasWork(chapters)
-         false on the next reconcile pass. */
-      if (currentBookId === handle.bookId) {
-        const shouldOpen = pendingRegen != null || hasWork(chapters);
-        if (!shouldOpen) closeHandle();
-      }
-      return;
-    }
-
-    /* No handle. Open only when the slice and the URL agree on which book
-       we're on, there's work in scope, and the user hasn't paused. */
-    if (!stageBookId) return;
-    if (currentBookId !== stageBookId) return;
-    if (paused) return;
-    const shouldOpen = pendingRegen != null || hasWork(chapters);
-    if (!shouldOpen) return;
-
-    /* Plan 32 D2 follow-up: REVERSE-LOCAL-ANALYZER GUARD (implicit
-       path). The D2 hook gates EXPLICIT user-initiated TTS-start
-       callsites (Resume button, Regenerate modal confirms). This
-       block closes the parallel implicit seam: cold-boot rehydration
-       of a book with both `analysis.activeStream.engine === 'local'`
-       (an alive local analysis on the same book) AND a non-empty
-       generation queue would otherwise auto-fire generation behind
-       the user's back, competing for the same GPU.
-       Rule mirrors the hook (use-reverse-local-analyzer-guard.tsx):
-       - engine === 'local' — Gemini analyses don't compete for GPU,
-         so the gate doesn't fire on them.
-       - bookId matches — a local analysis on book A shouldn't block
-         generation on unrelated book B.
-       - state !== 'paused' / 'halted' — a user-paused or halted
-         analysis is already not competing for GPU; respecting that
-         matches the existing sticky-generation contract (the user
-         explicitly stopped the analysis).
-       Refusal mechanism: flip the slice to paused. The user reads
-       the analysis pill, knows what's running, and resumes
-       generation when ready. No new modal — we're not nagging on
-       every navigation, we're refusing to act without consent. */
-    /* Defensive read: a handful of legacy test harnesses build a
-       store without the analysis slice. Production always has it
-       (configured in src/store/index.ts). */
-    const analysisSnap =
-      (after as { analysis?: { activeStream?: typeof after.analysis.activeStream } }).analysis
-        ?.activeStream ?? null;
-    if (
-      analysisSnap != null &&
-      analysisSnap.engine === 'local' &&
-      analysisSnap.bookId === stageBookId &&
-      analysisSnap.state !== 'paused' &&
-      analysisSnap.state !== 'halted'
-    ) {
-      dispatch(chaptersActions.setPaused(true));
-      return;
-    }
-
-    openHandle(stageBookId, modelKey, pendingRegen);
-  };
-
-  /* Regen actions need an explicit close *before* reconcile so the new spec
-     gets a fresh stream — without this, the existing handle stays open and
-     reconcile sees `handle != null` and skips the openHandle that would
-     forward `chapterIds + force`. Only relevant when the user is acting on
-     the same book the handle is streaming for — regen from a different
-     book context would be a no-op for the existing stream anyway. */
-  const REGEN_TYPES = new Set<string>([
-    'chapters/regenerateChapter',
-    'chapters/regenerateChapterIds',
-    'chapters/regenerateCharacter',
-    'chapters/batchRegenerateCharacters',
-  ]);
-
-  return (next) => (action) => {
-    const result = next(action);
-    const a = action as { type?: string };
-    const type = a?.type;
-    if (!type || !TRIGGER_TYPES.has(type)) return result;
-
-    if (REGEN_TYPES.has(type) && handle) {
-      const after = store.getState() as StreamableRootState;
-      if (after.chapters.currentBookId === handle.bookId) closeHandle();
-    }
-
-    /* Enqueue pending-revision stubs on regen dispatch. One per
-       (characterId, chapterId) tuple — the slice's dedupe-by-id collapses
-       restarts. The stub carries playable=false; chapter_complete flips
-       it (handled in the applyGenerationTick branch below). Out-of-scope
-       for chapter-only regens (regenerateChapter / regenerateChapterIds)
-       since those don't carry a character to attribute the diff to. */
-    if (type === 'chapters/regenerateCharacter') {
-      const payload = (a as { payload?: { characterId: string; chapterIds: number[] } }).payload;
-      if (payload) {
-        const after = store.getState() as StreamableRootState;
-        const character = after.cast.characters.find((c) => c.id === payload.characterId);
-        if (character) {
-          for (const chapterId of payload.chapterIds) {
-            const chapter = after.chapters.chapters.find((c) => c.id === chapterId);
-            if (!chapter) continue;
-            dispatch(
-              revisionsActions.enqueuePending(buildPendingRevisionStub({ chapter, character })),
-            );
-          }
-        }
-      }
-    } else if (type === 'chapters/batchRegenerateCharacters') {
-      const payload = (a as { payload?: { characterIds: string[]; chapterIds: number[] } }).payload;
-      if (payload) {
-        const after = store.getState() as StreamableRootState;
-        for (const characterId of payload.characterIds) {
-          const character = after.cast.characters.find((c) => c.id === characterId);
-          if (!character) continue;
-          for (const chapterId of payload.chapterIds) {
-            const chapter = after.chapters.chapters.find((c) => c.id === chapterId);
-            if (!chapter) continue;
-            dispatch(
-              revisionsActions.enqueuePending(buildPendingRevisionStub({ chapter, character })),
-            );
-          }
-        }
-      }
-    }
-
-    /* Emit per-tick log events using the post-reducer state — that's where
-       the chapter has already flipped to done/failed. Also refresh the
-       cross-book snapshot so the global header pill keeps moving even
-       when the user is on a different book and the per-chapter reducer
-       skipped its mutation. */
-    if (type === 'chapters/applyGenerationTick' && handle) {
-      const ev = (a as { payload?: GenerationTick }).payload;
-      const after = store.getState() as StreamableRootState;
-      const sliceMatchesHandle = after.chapters.currentBookId === handle.bookId;
-      if (sliceMatchesHandle) {
-        /* Slice has this book's rows — derive counters from rows so we
-           pick up any user-side mutations (excluded toggles etc.). */
-        dispatch(
-          chaptersActions.setActiveStream(
-            snapshotFromChapters(handle.bookId, handle.modelKey, after.chapters),
-          ),
-        );
-      } else if (ev && ev.type !== 'idle') {
-        /* Bug E — cross-book path. The slice is on a different book so
-           the per-chapter tick reducer's cross-book guard short-circuits
-           and the snapshot stops refreshing (counters AND lastTickAt
-           freeze). Pull counters straight from the tick payload's run
-           aggregates so the pill keeps moving and the stall check stays
-           fresh. Older servers don't emit the run* fields — in that
-           case `updateActiveStreamProgress` still bumps lastTickAt so
-           the pill at minimum doesn't go spuriously stalled. */
-        const evRecord = ev as unknown as Record<string, unknown>;
-        const runDone = typeof evRecord.runDone === 'number' ? evRecord.runDone : undefined;
-        const runTotal = typeof evRecord.runTotal === 'number' ? evRecord.runTotal : undefined;
-        const runInProgress =
-          typeof evRecord.runInProgress === 'number' ? evRecord.runInProgress : undefined;
-        dispatch(
-          chaptersActions.updateActiveStreamProgress({
-            done: runDone,
-            total: runTotal,
-            inProgress: runInProgress,
-          }),
-        );
-      }
-      if (ev && ev.type === 'chapter_complete' && ev.chapterId != null && sliceMatchesHandle) {
-        /* Accumulate — do NOT dispatch a per-chapter event. The rollup goes
-           out once on closeHandle (run drain / pause). De-dupe so a retry
-           tick or re-emitted SSE message doesn't double-count. */
-        if (!handle.completedChapterIds.includes(ev.chapterId)) {
-          handle.completedChapterIds.push(ev.chapterId);
-        }
-        /* Flip any pending revisions for this chapter to playable. The
-           new render is on disk now, so the diff player can fetch it.
-           No-op when no pending revision targets the chapter (e.g.
-           plain regenerateChapter without a character). */
-        dispatch(revisionsActions.markRevisionPlayable({ chapterId: ev.chapterId }));
-      } else if (ev && ev.type === 'chapter_failed' && ev.chapterId != null && sliceMatchesHandle) {
-        const ch = after.chapters.chapters.find((c) => c.id === ev.chapterId);
-        if (ch) {
-          dispatch(
-            changeLogActions.appendLogEvent(
-              buildChapterFailedEvent({
-                chapter: ch,
-                errorReason: ev.errorReason ?? ch.errorReason ?? 'Synthesis failed.',
-              }),
-            ),
-          );
-        }
-      } else if (ev && ev.type === 'chapter_failed' && ev.chapterId == null && sliceMatchesHandle) {
-        /* Stream-level halt (setup / sidecar / cast issue — chapter id
-           absent). The chapters reducer flipped any in-flight chapter
-           to 'failed' and set lastError; per-chapter rows already
-           surface that. This toast covers the "did anything happen?"
-           gap when the user is on a different view (Cast, Library)
-           when the stream dies. Dedupe on 'generation-stream' so a
-           burst of halt ticks doesn't stack. */
-        dispatch(
-          notificationsActions.pushToast({
-            kind: 'error',
-            message: ev.errorReason ?? 'Generation halted.',
-            dedupeKey: 'generation-stream',
-          }),
-        );
-      } else if (ev && ev.type === 'idle') {
-        /* Server's idle tick is the unambiguous "no more work" end-of-
-           stream signal (server/src/routes/generation.ts emits it once
-           the target loop drains). Tear down the handle here regardless
-           of which book the slice currently reflects — the reconcile-
-           based close below only runs when currentBookId === handle.bookId,
-           so an idle tick delivered while the user is on a different book
-           (or a global view) would otherwise leave the handle live and
-           the global pill stuck at "100%". */
-        closeHandle();
-      }
-    }
-
-    reconcile();
-    return result;
-  };
-};

--- a/src/store/generation-stream-runner.ts
+++ b/src/store/generation-stream-runner.ts
@@ -1,0 +1,300 @@
+/* Generation-stream runner — owns the single SSE handle and its lifecycle.
+
+   Extracted from generation-stream-middleware (plan 102 Should #6) so the
+   queue dispatcher can open a CROSS-BOOK stream through the exact same
+   lifecycle the same-book reconcile path uses: one handle, one
+   `chapters.activeStream` snapshot, one per-run rollup, one idle teardown.
+
+   A single shared instance is created in `src/store/index.ts` and injected
+   into BOTH `generation-stream-middleware` (same-book, reconcile-driven
+   opens) and `queue-dispatcher-middleware` (cross-book, dispatch-driven
+   opens). Because the handle lives here and not in either middleware, the
+   "only one SSE at a time" invariant is structural rather than conventional,
+   and the per-tick side-effects (snapshot refresh, rollup, completion /
+   failure events, idle close) fire for cross-book streams too — the
+   generation-stream-middleware still observes every `applyGenerationTick`
+   and delegates to `runner.handleTick`, regardless of which middleware
+   opened the stream. */
+
+import type { Dispatch } from '@reduxjs/toolkit';
+import { api } from '../lib/api';
+import {
+  buildGenerationStartedEvent,
+  buildGenerationRunCompleteEvent,
+  buildChapterFailedEvent,
+} from '../lib/change-log';
+import { chaptersActions } from './chapters-slice';
+import { changeLogActions } from './change-log-slice';
+import { revisionsActions } from './revisions-slice';
+import { notificationsActions } from './notifications-slice';
+import type { ActiveStreamSnapshot, ChaptersState } from './chapters-slice';
+import type { GenerationTick, TtsModelKey } from '../lib/types';
+
+/** What the stream should render. Mirrors the old `chapters.pendingRegen`
+    shape (`{ chapterIds, force }`) so the same-book reconcile path can pass
+    its spec through unchanged; the cross-book dispatch path constructs one
+    from the head queue entry. */
+export interface StreamSpec {
+  chapterIds?: number[];
+  force?: boolean;
+}
+
+export interface StreamOpenOpts {
+  /** Same-book reconcile path passes true: the spec came from the slice's
+      `pendingRegen`, so drain it the instant the SSE owns it (the
+      Pause→Resume rationale documented on the slice reducer). Cross-book
+      dispatch passes false — there is no slice-level `pendingRegen` to drain
+      (it would belong to the currently-viewed book, not the streaming one). */
+  consumePendingRegen?: boolean;
+  /** Queue entry this stream fulfils. Threaded to the server so per-chapter
+      ticks correlate to the right queue row when entries from different
+      books interleave. */
+  queueEntryId?: string;
+}
+
+/** Minimal store surface the runner needs. Satisfied by the configured RTK
+    store; kept narrow (only `chapters`) so the runner doesn't import the
+    store's circular `RootState` and stays usable from lean test stores. */
+export interface StreamRunnerStore {
+  dispatch: Dispatch;
+  getState: () => { chapters: ChaptersState };
+}
+
+interface OpenHandle {
+  cancel: () => void;
+  bookId: string;
+  modelKey: TtsModelKey;
+  /* Per-run rollup accumulator. Every chapter_complete tick pushes its
+     chapterId here; on run end (close) we emit one generation_run_complete
+     event with the full list — keeps the activity feed from drowning in
+     per-chapter audit rows on long runs. */
+  completedChapterIds: number[];
+}
+
+export interface StreamRunner {
+  /** Open an SSE for `bookId` with the given spec. No-ops if a handle is
+      already open (the single-SSE invariant — callers gate on
+      `chapters.activeStream` first, this is belt-and-braces). */
+  open(
+    bookId: string,
+    modelKey: TtsModelKey,
+    spec: StreamSpec | null,
+    opts?: StreamOpenOpts,
+  ): void;
+  /** Tear down the active handle (flushing the run rollup) and clear the
+      cross-book snapshot. No-op when nothing is open. */
+  close(): void;
+  isOpen(): boolean;
+  getBookId(): string | null;
+  /** Drive the per-tick side-effects. Called by the generation-stream
+      middleware on every `chapters/applyGenerationTick`, after the reducer
+      has run, so post-tick state is visible here. */
+  handleTick(ev: GenerationTick | undefined): void;
+}
+
+function snapshotFromChapters(
+  bookId: string,
+  modelKey: TtsModelKey,
+  state: ChaptersState,
+): ActiveStreamSnapshot {
+  /* Counters mirror the active-subset filter used in the Generate view
+     (`activeChapters` in src/views/generation.tsx): excluded chapters
+     never queue or synthesise, so they must not inflate `total` or
+     stall the cross-book top-bar pill's done/total readout. */
+  const active = state.chapters.filter((c) => !c.excluded);
+  return {
+    bookId,
+    modelKey,
+    done: active.filter((c) => c.state === 'done').length,
+    total: active.length,
+    inProgress: active.filter((c) => c.state === 'in_progress').length,
+    lastTickAt: state.lastTickAt,
+    halted: state.lastError != null,
+  };
+}
+
+export function createStreamRunner(store: StreamRunnerStore): StreamRunner {
+  let handle: OpenHandle | null = null;
+  const dispatch = store.dispatch;
+
+  const close = (): void => {
+    if (!handle) return;
+    /* Flush the per-run rollup before tearing down. Empty runs (pause before
+       any chapter finished, queue drained immediately) write nothing — there
+       was already a generation_started anchor for those. */
+    if (handle.completedChapterIds.length > 0) {
+      dispatch(
+        changeLogActions.appendLogEvent(
+          buildGenerationRunCompleteEvent({ chapterIds: handle.completedChapterIds }),
+        ),
+      );
+    }
+    handle.cancel();
+    handle = null;
+    dispatch(chaptersActions.clearActiveStream());
+  };
+
+  const open = (
+    bookId: string,
+    modelKey: TtsModelKey,
+    spec: StreamSpec | null,
+    opts: StreamOpenOpts = {},
+  ): void => {
+    /* Single-SSE invariant — never stack a second stream. Callers gate on
+       chapters.activeStream first; this guards the seam directly so a future
+       caller can't bypass it. */
+    if (handle) return;
+
+    const after = store.getState();
+
+    /* Emit a system-level "generation started" event so the activity feed has
+       a beat for the user's Regenerate click (or Resume). The chapterIds
+       reflect either the regen spec or the broader queued/in-progress set
+       the server will resume against. For a cross-book open the slice holds a
+       DIFFERENT book's rows, so fall back only when the spec is empty AND the
+       slice is on this book. */
+    const sliceOnThisBook = after.chapters.currentBookId === bookId;
+    const ids =
+      spec?.chapterIds && spec.chapterIds.length > 0
+        ? spec.chapterIds
+        : sliceOnThisBook
+          ? after.chapters.chapters
+              .filter((c) => c.state === 'in_progress' || c.state === 'queued')
+              .map((c) => c.id)
+          : [];
+    dispatch(changeLogActions.appendLogEvent(buildGenerationStartedEvent({ chapterIds: ids })));
+
+    /* Seed the cross-book snapshot. Same-book: derive from the slice's rows
+       (it IS this book's data right now). Cross-book: the slice holds the
+       wrong book, so seed a minimal placeholder; the first tick's run*
+       aggregates refresh it via updateActiveStreamProgress in handleTick. */
+    const seed: ActiveStreamSnapshot = sliceOnThisBook
+      ? snapshotFromChapters(bookId, modelKey, after.chapters)
+      : {
+          bookId,
+          modelKey,
+          done: 0,
+          total: spec?.chapterIds?.length ?? 1,
+          inProgress: 1,
+          lastTickAt: null,
+          halted: false,
+        };
+    dispatch(chaptersActions.setActiveStream(seed));
+
+    const cancel = api.streamGeneration({
+      bookId,
+      modelKey,
+      chapterIds: spec?.chapterIds,
+      force: spec?.force,
+      ...(opts.queueEntryId ? { queueEntryId: opts.queueEntryId } : {}),
+      /* The mock implementation reads live chapter state via this callback;
+         the real fetch-based stream ignores it. Either way we close over the
+         store, not over any view's props, so generation continues after the
+         Generate view unmounts. */
+      getChapters: () => store.getState().chapters.chapters,
+      onTick: (ev: GenerationTick) => dispatch(chaptersActions.applyGenerationTick(ev)),
+    });
+    handle = { cancel, bookId, modelKey, completedChapterIds: [] };
+
+    /* Drain the spec the instant the SSE owns it — same Pause→Resume rationale
+       documented on the slice reducer: without this, an aborted SSE never
+       delivers `idle` so `pendingRegen` would stick around forever and every
+       Resume would re-force-regen the original target set. Only the same-book
+       reconcile path consumes it; cross-book has no slice pendingRegen. */
+    if (opts.consumePendingRegen && spec) dispatch(chaptersActions.consumePendingRegen());
+  };
+
+  const handleTick = (ev: GenerationTick | undefined): void => {
+    if (!handle) return;
+    const after = store.getState();
+    const sliceMatchesHandle = after.chapters.currentBookId === handle.bookId;
+    if (sliceMatchesHandle) {
+      /* Slice has this book's rows — derive counters from rows so we
+         pick up any user-side mutations (excluded toggles etc.). */
+      dispatch(
+        chaptersActions.setActiveStream(
+          snapshotFromChapters(handle.bookId, handle.modelKey, after.chapters),
+        ),
+      );
+    } else if (ev && ev.type !== 'idle') {
+      /* Bug E — cross-book path. The slice is on a different book so
+         the per-chapter tick reducer's cross-book guard short-circuits
+         and the snapshot stops refreshing (counters AND lastTickAt
+         freeze). Pull counters straight from the tick payload's run
+         aggregates so the pill keeps moving and the stall check stays
+         fresh. Older servers don't emit the run* fields — in that
+         case `updateActiveStreamProgress` still bumps lastTickAt so
+         the pill at minimum doesn't go spuriously stalled. */
+      const evRecord = ev as unknown as Record<string, unknown>;
+      const runDone = typeof evRecord.runDone === 'number' ? evRecord.runDone : undefined;
+      const runTotal = typeof evRecord.runTotal === 'number' ? evRecord.runTotal : undefined;
+      const runInProgress =
+        typeof evRecord.runInProgress === 'number' ? evRecord.runInProgress : undefined;
+      dispatch(
+        chaptersActions.updateActiveStreamProgress({
+          done: runDone,
+          total: runTotal,
+          inProgress: runInProgress,
+        }),
+      );
+    }
+    if (ev && ev.type === 'chapter_complete' && ev.chapterId != null && sliceMatchesHandle) {
+      /* Accumulate — do NOT dispatch a per-chapter event. The rollup goes
+         out once on close (run drain / pause). De-dupe so a retry tick or
+         re-emitted SSE message doesn't double-count. */
+      if (!handle.completedChapterIds.includes(ev.chapterId)) {
+        handle.completedChapterIds.push(ev.chapterId);
+      }
+      /* Flip any pending revisions for this chapter to playable. The
+         new render is on disk now, so the diff player can fetch it.
+         No-op when no pending revision targets the chapter (e.g.
+         plain regenerateChapter without a character). */
+      dispatch(revisionsActions.markRevisionPlayable({ chapterId: ev.chapterId }));
+    } else if (ev && ev.type === 'chapter_failed' && ev.chapterId != null && sliceMatchesHandle) {
+      const ch = after.chapters.chapters.find((c) => c.id === ev.chapterId);
+      if (ch) {
+        dispatch(
+          changeLogActions.appendLogEvent(
+            buildChapterFailedEvent({
+              chapter: ch,
+              errorReason: ev.errorReason ?? ch.errorReason ?? 'Synthesis failed.',
+            }),
+          ),
+        );
+      }
+    } else if (ev && ev.type === 'chapter_failed' && ev.chapterId == null && sliceMatchesHandle) {
+      /* Stream-level halt (setup / sidecar / cast issue — chapter id
+         absent). The chapters reducer flipped any in-flight chapter
+         to 'failed' and set lastError; per-chapter rows already
+         surface that. This toast covers the "did anything happen?"
+         gap when the user is on a different view (Cast, Library)
+         when the stream dies. Dedupe on 'generation-stream' so a
+         burst of halt ticks doesn't stack. */
+      dispatch(
+        notificationsActions.pushToast({
+          kind: 'error',
+          message: ev.errorReason ?? 'Generation halted.',
+          dedupeKey: 'generation-stream',
+        }),
+      );
+    } else if (ev && ev.type === 'idle') {
+      /* Server's idle tick is the unambiguous "no more work" end-of-
+         stream signal (server/src/routes/generation.ts emits it once
+         the target loop drains). Tear down the handle here regardless
+         of which book the slice currently reflects — the reconcile-
+         based close only runs when currentBookId === handle.bookId, so
+         an idle tick delivered while the user is on a different book
+         (or a global view) would otherwise leave the handle live and
+         the global pill stuck at "100%". */
+      close();
+    }
+  };
+
+  return {
+    open,
+    close,
+    isOpen: () => handle != null,
+    getBookId: () => handle?.bookId ?? null,
+    handleTick,
+  };
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -49,6 +49,7 @@ import { generationStreamMiddleware } from './generation-stream-middleware';
 import { analysisStreamMiddleware } from './analysis-stream-middleware';
 import { broadcastMiddleware } from './broadcast-middleware';
 import { queueDispatcherMiddleware } from './queue-dispatcher-middleware';
+import { createStreamRunner, type StreamRunner } from './generation-stream-runner';
 
 /** Persisted ui-slice keys. Stage so refresh restores the same view +
  *  chapter + drawer; model selectors so the user's per-session picks
@@ -107,6 +108,22 @@ const manuscriptPersistConfig: PersistConfig<ManuscriptState> = {
 const persistedUiReducer = persistReducer(uiPersistConfig, uiSlice.reducer);
 const persistedManuscriptReducer = persistReducer(manuscriptPersistConfig, manuscriptSlice.reducer);
 
+/* Single shared SSE-stream runner (plan 102 Should #6). Both the
+   generation-stream-middleware (same-book opens) and the
+   queue-dispatcher-middleware (cross-book opens) drive ONE runner instance,
+   so the "only one SSE at a time" invariant + the cross-book activeStream
+   snapshot live in exactly one place. The runner needs the store's
+   dispatch/getState, which only exist after configureStore returns — so the
+   middlewares receive a lazy `getStreamRunner` accessor (called at action
+   time, by which point `streamRunnerInstance` is assigned). */
+let streamRunnerInstance: StreamRunner | null = null;
+const getStreamRunner = (): StreamRunner => {
+  if (!streamRunnerInstance) {
+    throw new Error('stream runner accessed before store initialisation');
+  }
+  return streamRunnerInstance;
+};
+
 export const store = configureStore({
   reducer: {
     ui: persistedUiReducer,
@@ -137,12 +154,17 @@ export const store = configureStore({
       },
     }).concat(
       persistenceMiddleware,
-      generationStreamMiddleware,
+      generationStreamMiddleware(getStreamRunner),
       analysisStreamMiddleware,
       broadcastMiddleware,
-      queueDispatcherMiddleware,
+      queueDispatcherMiddleware(getStreamRunner),
     ),
 });
+
+/* Bind the shared runner now that the store (dispatch + getState) exists.
+   Safe before the first action dispatches — middleware bodies only call
+   `getStreamRunner()` at action time. */
+streamRunnerInstance = createStreamRunner(store);
 
 /** Persistor for the store. Wrap the app in `<PersistGate>` from
  *  `redux-persist/integration/react` if you want to delay first render

--- a/src/store/queue-dispatcher-middleware.test.ts
+++ b/src/store/queue-dispatcher-middleware.test.ts
@@ -14,6 +14,23 @@ import { chaptersSlice } from './chapters-slice';
 import { uiSlice } from './ui-slice';
 import { notificationsSlice } from './notifications-slice';
 import { queueDispatcherMiddleware } from './queue-dispatcher-middleware';
+import { createStreamRunner, type StreamRunner } from './generation-stream-runner';
+
+/* The cross-book branch opens the SSE directly via the shared runner, which
+   calls api.streamGeneration. Mock it so we can assert the open args; the
+   DELETE round-trip still goes through the global fetch mock (queue-thunks
+   uses fetch directly, not the api module). */
+const streamGenerationMock = vi.fn();
+const cancelStreamMock = vi.fn();
+vi.mock('../lib/api', () => ({
+  api: {
+    streamGeneration: (args: unknown) => {
+      streamGenerationMock(args);
+      return cancelStreamMock;
+    },
+    pauseGeneration: () => Promise.resolve(),
+  },
+}));
 
 const entry = (overrides: Partial<QueueEntry> = {}): QueueEntry => ({
   id: 'e1',
@@ -31,6 +48,8 @@ let fetchMock: ReturnType<typeof vi.fn>;
 beforeEach(() => {
   fetchMock = vi.fn();
   vi.stubGlobal('fetch', fetchMock);
+  streamGenerationMock.mockClear();
+  cancelStreamMock.mockClear();
 });
 
 afterEach(() => {
@@ -47,7 +66,12 @@ function jsonResp(body: unknown, status = 200): Response {
 }
 
 function makeStore() {
-  return configureStore({
+  /* One runner per store (test isolation). Lazy accessor breaks the
+     store↔runner creation cycle — see src/store/index.ts for the same
+     pattern in production. */
+  let runner: StreamRunner | null = null;
+  const getRunner = (): StreamRunner => runner!;
+  const store = configureStore({
     reducer: {
       ui: uiSlice.reducer,
       queue: queueSlice.reducer,
@@ -55,8 +79,10 @@ function makeStore() {
       notifications: notificationsSlice.reducer,
     },
     middleware: (getDefault) =>
-      getDefault({ serializableCheck: false }).concat(queueDispatcherMiddleware),
+      getDefault({ serializableCheck: false }).concat(queueDispatcherMiddleware(getRunner)),
   });
+  runner = createStreamRunner(store);
+  return store;
 }
 
 /** Helper — flush microtasks (the dispatcher defers tick() via
@@ -111,7 +137,15 @@ describe('queue-dispatcher-middleware', () => {
     expect(store.getState().chapters.pendingRegen).toBeNull();
   });
 
-  it('does not dispatch when the head entry is for a different book (same-book gate)', async () => {
+  it('opens a CROSS-book entry directly via the runner without dispatching a regenerate (Wave 4b)', async () => {
+    /* The user is viewing book-A; the head entry is for book-B. The
+       same-book gate is lifted (Should #6): instead of waiting for the user
+       to navigate, the dispatcher opens the SSE for book-B directly through
+       the shared runner. It must NOT dispatch a regenerate action — that
+       would mutate book-A's rows (the slice holds book-A). So pendingRegen
+       stays null, but streamGeneration fires for book-B with the explicit
+       spec + queueEntryId, and the cross-book activeStream snapshot is
+       seeded so the global pill keeps moving. */
     const store = makeStore();
     store.dispatch(chaptersSlice.actions.setCurrentBookId('book-A'));
     store.dispatch(
@@ -121,12 +155,87 @@ describe('queue-dispatcher-middleware', () => {
     );
     store.dispatch(
       queueSlice.actions.setSnapshot({
-        entries: [entry({ bookId: 'book-B' })],
+        entries: [entry({ id: 'xb1', bookId: 'book-B', chapterId: 7 })],
         paused: false,
       }),
     );
     await flushMicro();
+
+    /* No slice-level regen — book-A's rows are untouched. */
     expect(store.getState().chapters.pendingRegen).toBeNull();
+    /* The cross-book stream opened with the right spec + entry correlation. */
+    expect(streamGenerationMock).toHaveBeenCalledTimes(1);
+    const args = streamGenerationMock.mock.calls[0]?.[0] as {
+      bookId?: string;
+      chapterIds?: number[];
+      force?: boolean;
+      queueEntryId?: string;
+    };
+    expect(args.bookId).toBe('book-B');
+    expect(args.chapterIds).toEqual([7]);
+    expect(args.force).toBe(true);
+    expect(args.queueEntryId).toBe('xb1');
+    /* Cross-book snapshot seeded for the streaming book, not the viewed one. */
+    expect(store.getState().chapters.activeStream?.bookId).toBe('book-B');
+  });
+
+  it('does not open a SECOND stream for a cross-book head while one is already in flight', async () => {
+    const store = makeStore();
+    store.dispatch(chaptersSlice.actions.setCurrentBookId('book-A'));
+    store.dispatch(
+      chaptersSlice.actions.setChapters([
+        { id: 3, title: 'Chapter 3', state: 'done', progress: 1, duration: '0:30', characters: {} },
+      ] as never),
+    );
+    /* A stream is already open (some other book's work). */
+    store.dispatch(
+      chaptersSlice.actions.setActiveStream({
+        bookId: 'book-C',
+        modelKey: 'kokoro-v1',
+        done: 0,
+        total: 3,
+        inProgress: 1,
+        lastTickAt: Date.now(),
+        halted: false,
+      } as never),
+    );
+    store.dispatch(
+      queueSlice.actions.setSnapshot({
+        entries: [entry({ id: 'xb2', bookId: 'book-B' })],
+        paused: false,
+      }),
+    );
+    await flushMicro();
+    /* The activeStream gate holds — no second SSE. */
+    expect(streamGenerationMock).not.toHaveBeenCalled();
+  });
+
+  it('DELETEs the cross-book entry when its SSE finishes (idle → clearActiveStream)', async () => {
+    const store = makeStore();
+    store.dispatch(chaptersSlice.actions.setCurrentBookId('book-A'));
+    store.dispatch(
+      chaptersSlice.actions.setChapters([
+        { id: 3, title: 'Chapter 3', state: 'done', progress: 1, duration: '0:30', characters: {} },
+      ] as never),
+    );
+    store.dispatch(
+      queueSlice.actions.setSnapshot({
+        entries: [entry({ id: 'xb3', bookId: 'book-B', chapterId: 7 })],
+        paused: false,
+      }),
+    );
+    await flushMicro();
+    /* Cross-book stream opened + activeStream seeded by the runner. */
+    expect(streamGenerationMock).toHaveBeenCalledTimes(1);
+    expect(store.getState().chapters.activeStream?.bookId).toBe('book-B');
+
+    /* SSE drains — runner closes → clearActiveStream. Dispatcher then DELETEs
+       the entry it was tracking (inFlightEntryId = 'xb3'). */
+    fetchMock.mockResolvedValueOnce(jsonResp({ entries: [], paused: false }));
+    store.dispatch(chaptersSlice.actions.clearActiveStream());
+    await flushMicro();
+    await flushMicro();
+    expect(fetchMock).toHaveBeenCalledWith('/api/queue/xb3', { method: 'DELETE' });
   });
 
   it('does not dispatch while an SSE handle is open (activeStream non-null)', async () => {

--- a/src/store/queue-dispatcher-middleware.ts
+++ b/src/store/queue-dispatcher-middleware.ts
@@ -1,28 +1,39 @@
-/* Plan 102 Wave 4a — queue dispatcher middleware.
+/* Plan 102 — queue dispatcher middleware.
  *
  * Drains the workspace queue (queue-slice mirror of <workspace>/.queue.json)
- * one chapter at a time. The contract is intentionally narrow so the existing
- * generation-stream middleware keeps owning the SSE lifecycle:
+ * one chapter at a time. The contract is intentionally narrow so the shared
+ * StreamRunner keeps owning the SSE lifecycle:
  *
- *   1. Pick the head queued entry whose bookId matches the slice's currently
- *      loaded book (same-book gate — cross-book dispatch is Wave 4b).
- *   2. Dispatch chaptersActions.regenerateChapter for that chapter; the
- *      existing middleware opens the SSE for it.
- *   3. When the SSE finishes (idle tick → activeStream cleared), DELETE
- *      the entry from the server queue. The resulting setSnapshot fires
- *      tick() again, which picks the next entry (or stops).
+ *   1. Pick the head queued entry.
+ *   2a. SAME-BOOK (entry.bookId === slice's currentBookId): dispatch
+ *       chaptersActions.regenerateChapter/Character; the
+ *       generation-stream-middleware reconciles and opens the SSE via the
+ *       runner (the slice round-trip drives per-chapter UI feedback +
+ *       pending-revision enqueue).
+ *   2b. CROSS-BOOK (Wave 4b — plan 102 Should #6): open the SSE DIRECTLY via
+ *       the shared runner with an explicit spec. We do NOT dispatch a
+ *       regenerate action — that would mutate the currently-VIEWED book's
+ *       chapter rows (the slice holds the viewed book, not the streaming
+ *       one). The slice's applyGenerationTick cross-book guard
+ *       (chapters-slice.ts) drops per-chapter ticks for the non-viewed book;
+ *       the runner's activeStream snapshot keeps the global top-bar pill
+ *       moving regardless of which book is on screen.
+ *   3. When the SSE finishes (idle tick → activeStream cleared), DELETE the
+ *      entry from the server queue. The resulting setSnapshot fires tick()
+ *      again, which picks the next entry (or stops).
  *
- * Local state (inFlightEntryId) is the source of truth for "which entry
- * did I dispatch a regenerate for." The server-side status field stays
- * "queued" the whole way; we never call /start. The modal infers in-flight
- * visually by correlating the head entry's bookId/chapterId with the
- * chapters slice's activeStream snapshot (Wave 4b).
+ * Local state (inFlightEntryId) is the source of truth for "which entry did
+ * I dispatch/open generation for." The server-side status field stays
+ * "queued" the whole way; we never call /start. A book can have several
+ * queued entries, so the runner's open-state ("a stream is open, for which
+ * book") is not enough to know WHICH entry just finished — inFlightEntryId
+ * provides that id-level correlation.
  *
  * Bug fix surface (per plan 102 doc):
- *   - Regenerate-during-regenerate no longer drops in-flight work.
- *     The 10 regen sites now append to the queue instead of dispatching
- *     regenerateChapter directly. The dispatcher serialises them so the
- *     in-flight chapter keeps streaming uninterrupted. */
+ *   - bug #1: regenerate-during-regenerate no longer drops in-flight work.
+ *     The 10 regen sites append to the queue; the dispatcher serialises them.
+ *   - bug #2: cross-book sequencing now drains without per-book navigation
+ *     (Wave 4b, this file's cross-book branch). */
 
 import type { Middleware, MiddlewareAPI } from '@reduxjs/toolkit';
 import { chaptersActions, type ChaptersState } from './chapters-slice';
@@ -30,6 +41,7 @@ import { queueActions, type QueueState } from './queue-slice';
 import { cancelQueueEntry } from './queue-thunks';
 import type { UiState } from './ui-slice';
 import type { AppDispatch } from './index';
+import type { StreamRunner } from './generation-stream-runner';
 
 interface DispatcherRootState {
   ui: UiState;
@@ -37,106 +49,120 @@ interface DispatcherRootState {
   queue: QueueState;
 }
 
-export const queueDispatcherMiddleware: Middleware = (storeApi: MiddlewareAPI) => {
-  /* Which entry did the dispatcher last fire regenerateChapter for. The
-     entry is DELETEd from the server queue when the SSE completes (idle
-     tick → clearActiveStream). Null between drains. */
-  let inFlightEntryId: string | null = null;
+export function queueDispatcherMiddleware(getRunner: () => StreamRunner): Middleware {
+  return (storeApi: MiddlewareAPI) => {
+    /* Which entry did the dispatcher last fire generation for. The entry is
+       DELETEd from the server queue when the SSE completes (idle tick →
+       clearActiveStream). Null between drains. */
+    let inFlightEntryId: string | null = null;
 
-  const dispatch = storeApi.dispatch as AppDispatch;
+    const dispatch = storeApi.dispatch as AppDispatch;
 
-  const tick = (): void => {
-    const state = storeApi.getState() as DispatcherRootState;
-    const { queue, chapters } = state;
+    const tick = (): void => {
+      const state = storeApi.getState() as DispatcherRootState;
+      const { queue, chapters, ui } = state;
 
-    /* Cold-boot gate — wait for the initial GET /api/queue before doing
-       anything. Without this, an empty pre-load snapshot would tempt the
-       dispatcher to do nothing (correct) but also masks the "is the queue
-       authoritative yet?" question for tests. */
-    if (!queue.loaded) return;
+      /* Cold-boot gate — wait for the initial GET /api/queue before doing
+         anything. Without this, an empty pre-load snapshot would tempt the
+         dispatcher to do nothing (correct) but also masks the "is the queue
+         authoritative yet?" question for tests. */
+      if (!queue.loaded) return;
 
-    /* Queue-global pause stops the drain at the next boundary. The
-       in-flight chapter (if any) finishes — the existing middleware
-       handles its own teardown — but the dispatcher won't pick up the
-       next entry while paused. */
-    if (queue.paused) return;
+      /* Queue-global pause stops the drain at the next boundary. The
+         in-flight chapter (if any) finishes — the runner handles its own
+         teardown — but the dispatcher won't pick up the next entry while
+         paused. */
+      if (queue.paused) return;
 
-    /* If an SSE handle is open, wait for it to drain. This covers both
-       (a) our own regenerate that's still in flight, and (b) any other
-       open path the existing middleware drove (e.g. cold-boot auto-
-       resume of slice-queued chapters). We never run two SSEs at once. */
-    if (chapters.activeStream) return;
+      /* If an SSE handle is open, wait for it to drain. This covers both
+         (a) our own generation that's still in flight, and (b) any other
+         open path the generation-stream-middleware drove (e.g. cold-boot
+         auto-resume of slice-queued chapters). We never run two SSEs at
+         once. */
+      if (chapters.activeStream) return;
 
-    /* activeStream is null. If we were tracking an entry, the chapter
-       just completed (or the stream was torn down — pause, halt, etc.).
-       DELETE the entry from the server queue then return; the resulting
-       setSnapshot re-fires tick() to pick up the next entry. */
-    if (inFlightEntryId) {
-      const completed = inFlightEntryId;
-      inFlightEntryId = null;
-      void dispatch(cancelQueueEntry(completed)).catch(() => {
-        /* 409 — server thinks the entry is in_progress (shouldn't happen
-           on the same-book path because we never call /start, but be
-           defensive); or 404 — already gone (idempotent). Swallow either
-           way; the queue snapshot will catch up on the next /api/queue
-           hit. */
-      });
-      return;
-    }
+      /* activeStream is null. If we were tracking an entry, the chapter
+         just completed (or the stream was torn down — pause, halt, etc.).
+         DELETE the entry from the server queue then return; the resulting
+         setSnapshot re-fires tick() to pick up the next entry. */
+      if (inFlightEntryId) {
+        const completed = inFlightEntryId;
+        inFlightEntryId = null;
+        void dispatch(cancelQueueEntry(completed)).catch(() => {
+          /* 409 — server thinks the entry is in_progress (shouldn't happen
+             because we never call /start, but be defensive); or 404 —
+             already gone (idempotent). Swallow either way; the queue
+             snapshot will catch up on the next /api/queue hit. */
+        });
+        return;
+      }
 
-    /* Find the next entry whose status is 'queued'. Skip 'failed' /
-       'paused' entries — those linger for the user to inspect or act on
-       manually, the dispatcher doesn't touch them. */
-    const head = queue.entries.find((e) => e.status === 'queued');
-    if (!head) return;
+      /* Find the next entry whose status is 'queued'. Skip 'failed' /
+         'paused' entries — those linger for the user to inspect or act on
+         manually, the dispatcher doesn't touch them. */
+      const head = queue.entries.find((e) => e.status === 'queued');
+      if (!head) return;
 
-    /* Wave 4a same-book gate. Wave 4b lifts this — the cross-book
-       dispatcher will switch the active book context (or POST
-       /generation directly bypassing the existing middleware's gate). */
-    if (chapters.currentBookId !== head.bookId) return;
+      inFlightEntryId = head.id;
 
-    /* Dispatch the regenerate. The existing generation-stream-middleware
-       reacts: sets pendingRegen, reconciles, opens SSE for the
-       chapter / character target. */
-    inFlightEntryId = head.id;
-    if (head.scope === 'character' && head.characterId) {
-      /* Per-character-in-chapter entries dispatch regenerateCharacter
-         scoped to a single chapter. Multi-chapter character regen is
-         expanded at enqueue time into one entry per chapter so each
-         is independently reorderable in the modal. */
-      dispatch(
-        chaptersActions.regenerateCharacter({
-          characterId: head.characterId,
-          chapterIds: [head.chapterId],
-        }),
+      if (chapters.currentBookId === head.bookId) {
+        /* SAME-BOOK. Dispatch the regenerate; the generation-stream-
+           middleware reacts: sets pendingRegen, reconciles, opens the SSE
+           for the chapter / character target via the runner. */
+        if (head.scope === 'character' && head.characterId) {
+          /* Per-character-in-chapter entries dispatch regenerateCharacter
+             scoped to a single chapter. Multi-chapter character regen is
+             expanded at enqueue time into one entry per chapter so each is
+             independently reorderable in the modal. */
+          dispatch(
+            chaptersActions.regenerateCharacter({
+              characterId: head.characterId,
+              chapterIds: [head.chapterId],
+            }),
+          );
+        } else {
+          dispatch(chaptersActions.regenerateChapter({ chapterId: head.chapterId, scope: 'this' }));
+        }
+        return;
+      }
+
+      /* CROSS-BOOK (Wave 4b). Open the SSE directly via the shared runner —
+         no regenerate dispatch (it would clobber the viewed book's rows).
+         The runner seeds a cross-book activeStream snapshot (the slice holds
+         the wrong book, so it can't derive counters from rows) and the first
+         tick's run* aggregates refresh it. queueEntryId correlates the
+         server's per-chapter ticks back to this row. */
+      getRunner().open(
+        head.bookId,
+        ui.ttsModelKey,
+        { chapterIds: [head.chapterId], force: true },
+        { queueEntryId: head.id },
       );
-    } else {
-      dispatch(chaptersActions.regenerateChapter({ chapterId: head.chapterId, scope: 'this' }));
-    }
-  };
+    };
 
-  return (next) => (action) => {
-    const result = next(action);
-    const a = action as { type?: string };
-    const type = a?.type;
-    /* React to anything that could change the dispatcher's decision:
-       - queue/setSnapshot — entries or paused flag changed.
-       - chapters/setActiveStream + clearActiveStream — SSE opened/closed.
-       - chapters/setCurrentBookId + hydrateFromBookState — slice's
-         loaded book changed (gate may flip from "wrong book" to "right
-         book" without any queue mutation). */
-    if (
-      type === queueActions.setSnapshot.type ||
-      type === 'chapters/setActiveStream' ||
-      type === 'chapters/clearActiveStream' ||
-      type === 'chapters/setCurrentBookId' ||
-      type === 'chapters/hydrateFromBookState'
-    ) {
-      /* Defer to a microtask so the existing generation-stream-middleware
-         reconcile completes first — its setActiveStream / clearActiveStream
-         calls land before we re-read chapters.activeStream. */
-      queueMicrotask(() => tick());
-    }
-    return result;
+    return (next) => (action) => {
+      const result = next(action);
+      const a = action as { type?: string };
+      const type = a?.type;
+      /* React to anything that could change the dispatcher's decision:
+         - queue/setSnapshot — entries or paused flag changed.
+         - chapters/setActiveStream + clearActiveStream — SSE opened/closed.
+         - chapters/setCurrentBookId + hydrateFromBookState — slice's
+           loaded book changed (gate may flip from "wrong book" to "right
+           book" without any queue mutation). */
+      if (
+        type === queueActions.setSnapshot.type ||
+        type === 'chapters/setActiveStream' ||
+        type === 'chapters/clearActiveStream' ||
+        type === 'chapters/setCurrentBookId' ||
+        type === 'chapters/hydrateFromBookState'
+      ) {
+        /* Defer to a microtask so the generation-stream-middleware reconcile
+           completes first — its setActiveStream / clearActiveStream calls
+           land before we re-read chapters.activeStream. */
+        queueMicrotask(() => tick());
+      }
+      return result;
+    };
   };
-};
+}

--- a/src/views/generation.test.tsx
+++ b/src/views/generation.test.tsx
@@ -13,6 +13,7 @@ import { castSlice } from '../store/cast-slice';
 import { librarySlice } from '../store/library-slice';
 import { accountSlice } from '../store/account-slice';
 import { generationStreamMiddleware } from '../store/generation-stream-middleware';
+import { createStreamRunner, type StreamRunner } from '../store/generation-stream-runner';
 import { queueSlice } from '../store/queue-slice';
 import { GenerationView } from './generation';
 import { useTtsLifecycle } from '../lib/use-tts-lifecycle';
@@ -784,6 +785,8 @@ describe('generationStreamMiddleware — Pause/Resume regenerate loop (regressio
        dispatch consumePendingRegen immediately after the middleware opens
        the SSE. This regression used to live in the Generate view's effect;
        it now lives in `generationStreamMiddleware`. */
+    let runner: StreamRunner | null = null;
+    const getRunner = (): StreamRunner => runner!;
     const store = configureStore({
       reducer: {
         ui: uiSlice.reducer,
@@ -794,8 +797,9 @@ describe('generationStreamMiddleware — Pause/Resume regenerate loop (regressio
         library: librarySlice.reducer,
         queue: queueSlice.reducer,
       },
-      middleware: (gd) => gd().concat(generationStreamMiddleware),
+      middleware: (gd) => gd().concat(generationStreamMiddleware(getRunner)),
     });
+    runner = createStreamRunner(store);
     /* Middleware skips opens unless a book is in scope AND the chapters
        slice has claimed that book via setCurrentBookId (cross-book guard
        requires the pair to agree before reconcile opens or closes). */


### PR DESCRIPTION
## Summary

Plan 102 **Should #6** — closes plan-102 **bug #2** (cross-book voice-drift races). The queue dispatcher previously gated on `chapters.currentBookId === head.bookId`, so queued entries for any book other than the one on screen sat idle until the user navigated there. This lifts that gate: an unpaused queue now drains every book's work regardless of which view the user is on — e.g. generate Book B in the background while listening to Book A (the concurrent-multibook workflow).

To do it without duplicating the SSE lifecycle, the handle + lifecycle is extracted from `generation-stream-middleware` into a new shared `generation-stream-runner.ts`. One runner instance is created in the store and injected into both middlewares, so the "only one SSE at a time" invariant lives in exactly one place and cross-book streams get the same tick side-effects (snapshot refresh, run rollup, completion/failure events, idle teardown).

## What changed (reviewer-visible deltas)

- **New `src/store/generation-stream-runner.ts`** — factory `createStreamRunner(store)` returning `{ open, close, isOpen, getBookId, handleTick }`. Owns the `OpenHandle`, the per-run `completedChapterIds` rollup, the `activeStream` seeding, and the per-tick side-effects (moved verbatim out of the middleware). `open()` takes an explicit spec `{ chapterIds, force }` + opts `{ consumePendingRegen?, queueEntryId? }`, and seeds a minimal cross-book snapshot when the slice holds a different book.
- **`generation-stream-middleware.ts`** — now a factory `(getRunner) => Middleware`. Keeps the same-book reconcile decision, the reverse-local-analyzer guard, the `REGEN_TYPES` close-before-reopen, and the pending-revision enqueue; delegates open/close/tick to the shared runner. Same-book behaviour is unchanged.
- **`queue-dispatcher-middleware.ts`** — now a factory `(getRunner) => Middleware`. Same-book entries still dispatch `regenerateChapter`/`regenerateCharacter` (drives per-chapter UI + pending-revision enqueue). **Cross-book** entries open the SSE directly via `runner.open(bookId, modelKey, { chapterIds:[id], force:true }, { queueEntryId })` — no regenerate dispatch (it would clobber the viewed book's rows). The single-SSE `activeStream` gate and the `inFlightEntryId` → DELETE-on-idle teardown are unchanged.
- **`src/store/index.ts`** — one shared runner created after `configureStore`, injected into both middlewares via a lazy accessor (breaks the store↔runner creation cycle).

## Behaviour change to note

With the gate lifted, an **unpaused** queue with work now starts draining the moment its snapshot loads, on any view — previously the same-book gate effectively suppressed draining on non-generate views. This is the intended cross-book feature. The server default remains `paused: false` (unchanged); whether the queue should default to paused / require an explicit Resume is a separate product question this PR does not touch.

## Tests

- `queue-dispatcher-middleware.test.ts` — new cross-book cases: opens via the runner with the correct `{ bookId, chapterIds, force, queueEntryId }` and **no** regenerate dispatch; does not open a second stream while one is in flight; idle → `clearActiveStream` → `DELETE /api/queue/:id` round-trip. Existing same-book cases unchanged.
- `generation-stream-middleware.test.ts` + `views/generation.test.tsx` — harnesses updated to wire the shared runner; all existing assertions stay green (extraction is behaviour-preserving).
- `e2e/queue-modal.spec.ts` — new cross-book scenario: two books' entries render grouped while viewing one book, and the *other* book's entry cancels without navigating to it. `installQueueRoutes` now defaults to a paused fixture (an unpaused fixture would be drained by the dispatcher).

## Docs

- Removed the cross-book dispatcher entry from `docs/BACKLOG.md`'s Should bucket and renumbered the bucket contiguous (it had a gap after the ESLint item shipped in #195).
- Filed the cross-book character pending-revision-stub limitation as **Could #40** (cross-book character regens don't pre-seed a revision stub; it still renders on book open).
- Noted the ship in plan 102's deferred list (`docs/features/archive/102-global-queue-modal.md`).

## Test plan

- `npm run verify` green locally (typecheck + lint [ESLint 9 flat config] + all unit/integration tests + e2e + build). One `test:server-slow` worker-exit flake in `gemini.test.ts` (unrelated — no server changes in this branch) cleared on isolated re-run (156/156).
- This PR is stacked under a follow-up (Should #5, strip `chapters-slice` generation-control fields) which builds on the shared runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
