### PR TITLE
chore(frontend): ignore .claude/ in eslint flat config

### DIFF
--- a/docs/features/104-eslint-flat-config.md
+++ b/docs/features/104-eslint-flat-config.md
@@ -66,6 +66,7 @@ Two of the five plugins (`eslint-plugin-react`, `eslint-plugin-jsx-a11y`) do NOT
 5. **`eslintConfigPrettier` is LAST** in the `tseslint.config(...)` array so it wins the cascade and disables every formatting rule the earlier configs turn on.
 6. **The TS parser is scoped to `**/*.{ts,tsx,mts,cts}` only**, so `scripts/**` CommonJS/ESM files parse with espree (the old `parser: 'espree'` override behaviour).
 7. **`verify.yml`'s `frontend` scope-detector matches `eslint.config.(js|mjs)$`** so a lint-config-only PR still runs the frontend leg in CI.
+8. **`.claude/` stays in the global-ignores object.** The Claude Code harness directory holds settings JSON (not linted) and transient agent worktrees that each carry their own built `dist/` output. Without this ignore, `eslint .` walks into `.claude/worktrees/<agent>/server/dist/` (the root `server/dist/` ignore is relative to repo root and does NOT match the nested copy) and floods thousands of errors, blocking every push while a worktree exists. Added 2026-05-23 after the gap surfaced on an unrelated push.
 
 ## Test plan
 
@@ -113,3 +114,4 @@ Fresh `npm install` at root after the bumps:
 - jsdom 25 → 29 and archiver 7 → 8 both landed (BACKLOG #32 chains cleared); only `@google/genai`'s `node-domexception` chain remains tracked. One frontend spec (jsdom CSS canonicalisation) and one release script (archiver ESM/class API) needed adapting; both pinned by tests.
 - The autofix re-baseline (`eslint . --fix` + targeted `prettier --write` on the touched files) removed dead `eslint-disable` directives across 24 files (ESLint 9 flat config defaults `reportUnusedDisableDirectives` to `warn`; the legacy eslintrc default was `off`). No behaviour change.
 - Companion: re-link plan `docs/features/archive/46-lint-format-a11y.md` Ship notes → this plan.
+- Follow-up 2026-05-23 (branch `chore/frontend-eslint-ignore-worktrees`): added `.claude/` to the global-ignores object (invariant #8). The flat-config migration carried the plan-46 ignores verbatim but those predate agent worktrees living under `.claude/worktrees/`; once such a worktree exists with built `server/dist/` output, `eslint .` walked into it and the `--max-warnings 0` gate blocked every push. The root `server/dist/` entry is repo-root-relative and didn't match the nested path.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,6 +32,10 @@ export default tseslint.config(
     ignores: [
       'dist/',
       'node_modules/',
+      // Claude Code harness dir: settings JSON (not linted) + transient agent
+      // worktrees that carry their own built `dist/` output. Without this, lint
+      // walks into `.claude/worktrees/<agent>/server/dist/` and floods errors.
+      '.claude/',
       'server/dist/',
       'server/tts-sidecar/.venv/',
       'server/handoff/',


### PR DESCRIPTION
## Summary

Adds `.claude/` to the ESLint flat-config global-ignores object (`eslint.config.js`), closing a gap that blocked pushes whenever a Claude Code agent worktree existed on disk.

The plan-104 flat-config migration carried the plan-46 ignore list verbatim, but those entries predate agent worktrees living under `.claude/worktrees/`. Once such a worktree exists carrying its own built `server/dist/` output, `eslint .` walks into `.claude/worktrees/<agent>/server/dist/` — the root `server/dist/` ignore is repo-root-relative and does NOT match the nested copy — and the `--max-warnings 0` ratchet floods thousands of errors, failing the pre-push hook for everyone with a live worktree. (This is exactly what blocked PR #197's push, which had to use `--no-verify`.) The `.claude/` directory holds only settings JSON (not linted) and transient worktrees — no tracked project source — so ignoring the whole harness dir is safe and future-proof.

Operator-visible delta: `npm run lint` / `npm run verify` no longer fail when agent worktrees are present; no more `--no-verify` workaround on pushes.

## Test plan

- `npm run lint` → exits 0 with agent worktrees present on disk (errored with 5,329 problems before this change).
- `npm run verify` (full pre-push battery: lint + typecheck + all tests + e2e + build) → green. This push went through the hook with NO `--no-verify`.
- No dedicated unit test: the flat config is exercised by every PR's `npm run lint` (plan-104 test-plan rationale, "No dedicated test for the lint config itself"). The fails-before/passes-after regression signal is the lint step itself.

Documented as plan-104 invariant #8 + a dated ship-note in `docs/features/104-eslint-flat-config.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)