### PR TITLE
docs(docs): document the queue auto-drain contract (no "start" gate)

### DIFF
--- a/docs/features/archive/102-global-queue-modal.md
+++ b/docs/features/archive/102-global-queue-modal.md
@@ -58,6 +58,7 @@ owner: null
 5. **Book-delete prunes queue entries atomically.** The existing book-deletion route gains a queue-prune step that removes entries matching the deleted `bookId` in the same write transaction as the directory drop. No orphaned entries can persist.
 6. **`resume_from` is emitted FIRST on every new subscriber.** Before any `progress` / `chapter_assembling` / `chapter_complete` tick. Reconnect after `tsx watch` restart or server bounce — first event the frontend sees is the resume snapshot, then the per-entry catch-up follows.
 7. **Regenerate dispatches NEVER close the active SSE handle.** This is the structural fix for the user-cited "loses all progress" bug. The middleware's hard-interrupt path at `src/store/generation-stream-middleware.ts:325-347` is replaced with an enqueue-only flow that appends to the queue and lets the in-flight entry complete naturally.
+8. **The queue auto-drains when unpaused — there is NO "start" gate.** A queue is a queue: if it has work and `paused === false`, the dispatcher starts the head entry. The server initialises a fresh `.queue.json` with `paused: false` (`queue-migrate.ts`), so enqueuing work (or rehydrating a queue with leftover entries on app boot) begins draining immediately — on any view, without an explicit Resume/Start click. `Pause` (queue modal) is the only opt-out; `Resume` un-pauses a paused queue, it does not "start" an idle one. Plan 102 Should #6 (cross-book dispatcher) extended this so the drain runs regardless of which book is currently viewed (see the Ship notes' deferred-follow-ups list below). (Decision confirmed 2026-05-24: auto-drain is the intended contract; the earlier walkthrough wording implying "Resume to start" was inaccurate and is corrected below.)
 
 ## Test plan
 
@@ -79,8 +80,8 @@ Run with the canonical full-pipeline manuscript `C:\Users\dudar\Downloads\Bonus 
 2. **Upload Keefe + a Pushkin short-story stub.** Analyse both books to completion.
 3. **Enqueue chapter 3 of Book A** from the Generate view's per-chapter "Add to queue" button → toast "Added to queue · 1 entry pending" with a "View queue" CTA. Top-bar queue chip shows `1`.
 4. **Switch to Book B**, enqueue chapter 1 of Book B → toast "Added to queue · 2 entries pending". Queue chip shows `2`.
-5. **Click the queue chip → View queue modal opens.** Two entries visible: `A.ch3` (order 0), `B.ch1` (order 1). Resume button is the only top-level action (queue not yet started).
-6. **Click Resume** → `A.ch3` flips to `in_progress` and pins to the top (non-draggable). Progress bar advances.
+5. **Click the queue chip → View queue modal opens.** Two entries visible: `A.ch3` (order 0), `B.ch1` (order 1). The queue auto-drains when unpaused (invariant 8), so `A.ch3` has **already** flipped to `in_progress` and pinned to the top (non-draggable); `B.ch1` is queued behind it. The modal's top-level control is **Pause** (the queue is running) — there is no "start" button.
+6. **`A.ch3` is mid-flight without any click** — its progress bar advances. (To stop it, you would click Pause; see step 15. Resume un-pauses; it is not needed to begin.)
 7. **While `A.ch3` is mid-flight, enqueue `A.ch7`** from Book A's Generate view → toast fires, `A.ch7` appears at order 2 (bottom), `A.ch3`'s progress bar unaffected (no drop).
 8. **Drag `A.ch7` above `B.ch1` in the modal** → confirmed visual feedback, the next entry to dispatch after `A.ch3` completes is now `A.ch7`.
 9. **`A.ch3` completes** → status flips to `done`, toast "A.ch3 completed". Dispatcher pops `A.ch7`, which flips to `in_progress`.

--- a/src/store/queue-slice.ts
+++ b/src/store/queue-slice.ts
@@ -21,7 +21,18 @@ export interface QueueState {
   entries: QueueEntry[];
   /** Queue-global pause flag — flipped via POST /api/queue/pause. When true
       the dispatcher waits at the next chapter boundary; the in-flight entry
-      runs to completion before the drain stops. */
+      runs to completion before the drain stops.
+
+      DEFAULT IS false → the queue AUTO-DRAINS. There is no "start" gate: when
+      `paused === false` and there is queued work, the dispatcher
+      (`queue-dispatcher-middleware`) begins the head entry as soon as a
+      snapshot loads — on any view, on app boot, without an explicit Resume.
+      `Pause` is the only opt-out; `Resume` un-pauses, it does not "start" an
+      idle queue. Since plan 102 Should #5 this flag is also the open-side gate
+      the generation-stream middleware reads (it replaced the removed
+      `chapters.paused`), so a paused queue suppresses cold-boot auto-resume
+      too. Contract documented in docs/features/archive/102-global-queue-modal.md
+      (invariant 8). */
   paused: boolean;
   /** First-load gate — true after the initial GET /api/queue completes. The
       modal renders empty-state UI vs spinner based on this. */


### PR DESCRIPTION
## Summary

Documentation follow-up to the plan-102 queue work (#196 / #200): make the **auto-drain** contract explicit so it's clear going forward. The queue runs whenever it has work and isn't paused — there is no Resume/Start gate. This was already the shipped behaviour (`.queue.json` defaults `paused: false`), but the canonical doc's walkthrough implied a "Resume to start" flow, and the contract wasn't stated anywhere. Decision confirmed by the user 2026-05-24: auto-drain is intended; Pause (queue modal) is the only opt-out.

No behaviour change — docs + one source comment.

## Changes

- **`docs/features/archive/102-global-queue-modal.md`** — new **invariant 8** ("The queue auto-drains when unpaused — there is NO 'start' gate"), and corrected manual-acceptance walkthrough steps 5–6, which previously said "Resume button is the only top-level action (queue not yet started)" / "Click Resume → A.ch3 flips to in_progress". That never matched the `paused: false` default; the steps now reflect that the head entry is already draining when the modal opens, and Pause is the running queue's control.
- **`src/store/queue-slice.ts`** — expanded the `paused` field comment to spell out the default-false / auto-drain semantics and note it doubles as the generation-stream open-side gate since plan 102 Should #5 (comment-only).

## Test plan

- `npx tsc --noEmit` (frontend) + `npm run lint` green locally. No tests needed — markdown + an inert code comment, zero behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
