### PR TITLE
docs(docs): open plan 108 (Qwen3-TTS coexistence) + reconcile backlog

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -49,6 +49,8 @@ Source: net-new (2026-05-22). Captured during planning of the cross-version upgr
 
 Source: net-new (2026-05-20). Captured during planning of the next full version update; user-flagged as critical for the next full version update.
 
+> **Scope note (2026-05-24):** the **engine** half of this item — adding Qwen3-TTS 0.6B as a coexisting sidecar engine + per-engine voice plumbing + cross-platform install script — is being delivered by [plan 108](features/108-qwen-coexistence.md) (Kokoro + Qwen coexistence, English). What remains HERE is the **language** half: the BCP-47 `language` field on `BookStateJson`/`Book`/`Character`, Cyrillic auto-detection + confirm-metadata override, voice-library `language` filtering + auto-load on Russian-book select, the Cyrillic-aware Gemini token estimator, the analyzer language preamble, and the never-cross-language invariant. Re-scope the _What_/_Key files_ below to the language work when this item opens; the Qwen engine, `overrideTtsVoices` map, and install-script shape will already exist.
+
 - _What:_ Lift the implicit English-only assumption across the stack. Add `language` (BCP-47 string, default `"en"`) to `BookStateJson` and the OpenAPI `Book` + `Character` schemas. Add **Qwen3-TTS 0.6B** as a third sidecar engine (Alibaba, Apache 2.0, ~2.5 GB on disk, 4–6 GB VRAM during synth — fits the existing analyzer-eviction pattern) with its own cross-platform install script. Pipe `book.language` through to every sidecar `/synthesize` call. Auto-detect language on manuscript drop (≥30% Cyrillic codepoints → `"ru"`) with a chip + override on the confirm-metadata view. Filter the voice library panel by `voice.language === book.language` and auto-load Qwen3 when a Russian book becomes active. Fix the Gemini analyzer's Latin-only chars/4 token estimator for Cyrillic. Inject a language preamble into analyzer skill prompts for non-English manuscripts. Listen-header language badge + dedicated library language filter pill (separate from free-text tags). **Hard invariant: never cross-language** — Russian voices never read English text, English voices never read Russian text.
 - _Acceptance:_ Upload an English manuscript → behaviour unchanged from today (regression). Upload a Russian public-domain fixture (Pushkin / Chekhov — NOT the Keefe Story, that's English) → confirm-metadata chip detects Russian + allows override → opening the book auto-loads Qwen3 with the existing analyzer-eviction banner → cast picker shows ONLY Russian voices → preview button speaks a Russian pangram → generated chapter audio is Russian with zero English bleed-through. Cyrillic token estimate within ±10% of actual `usage.input_tokens` on a long chapter. Library `Russian` filter pill ANDs with existing tag filters. Concurrent-multibook invariant holds: starting Russian Book A then switching to English Book B mid-flight keeps Book B's picker English and Book A's in-flight analysis Russian. On a fresh clone with no Qwen3 weights, opening a Russian book surfaces a clear "run `npm run install:qwen3`" call-to-action — not a silent 404. New Vitest + Playwright coverage on every new seam (detect-language helper, voice-library filter, preview-text switch, listen-header badge, library language pill); new pytest case in `server/tts-sidecar/tests/test_qwen3.py` (Cyrillic input + `language: "ru"` → non-empty PCM, no cross-bleed under concurrent synth).
 - _Key files:_ `openapi.yaml` (add `language` to `Book` + `Character`; `BaseVoice.language` already half-extended at `openapi.yaml:2181-2185`); `src/lib/types.ts:135-185` (`BookStateJson`); `src/store/book-meta-slice.ts:22-38` (`EditableBookMeta`); server state.json reader (default-back-fill migration on read). Sidecar: `server/tts-sidecar/main.py:176,403-409,436,468,527-532` + new `server/tts-sidecar/engines/qwen3.py` + new `server/tts-sidecar/scripts/install-qwen3.mjs` (Node ESM, cross-platform) + thin `scripts/install-qwen3.ps1` wrapper for Windows discoverability. Server: `server/src/tts/voice-mapping.ts:104-146,223-242` (add Qwen3 profile tables, language-aware `pickVoiceForEngine`), `server/src/tts/synthesise-chapter.ts` (thread `book.language` to sidecar), `server/src/tts/base-voices.ts:36-41` (populate the existing-but-unfilled `language` field on every voice), `server/src/analyzer/gemini.ts:553-562` (Cyrillic-aware `estimateInputTokens`), analyzer skill-prompt loader (language preamble injection). Frontend: `src/views/upload.tsx:141-163` + new `src/lib/detect-language.ts` + the confirm-metadata view (chip + override); `src/components/listen/listen-header.tsx:219-234` (badge); `src/components/voice-library-panel.tsx` (language filter), `src/components/voice-preview-button.tsx` (per-language sample text), `src/components/model-control-pill.tsx` (Qwen3 button + auto-load on Russian-book select); `src/components/library/library-chrome.tsx:49-56` + `src/store/library-slice.ts:111` (language filter pill ANDed with tag intersection). Tailwind config needs no work — General Sans / Lora / Inter all support Cyrillic. Full design intent + wave decomposition captured in `~/.claude/plans/ok-lets-do-a-delightful-kahn.md`; move into `docs/features/NN-multi-language-russian.md` when the next round opens.
@@ -117,6 +119,8 @@ Source: net-new (2026-05-19). Spun off from plan 55 ship — v1.3.0 plan 55 ship
 ### 3. Batch voice-replace across all books
 
 Source: net-new (2026-05-18).
+
+> **Scope note (2026-05-24):** largely subsumed by [plan 108](features/108-qwen-coexistence.md)'s "Rebaseline the series" modal + series-scoped override write (`PUT /api/voices/:voiceId/override?scope=series`), which lets the user re-map any character's engine + base voice across a series with current-vs-proposed audition. What this item retains that plan 108 does not cover: the *library-level* "pick voice A → replace with voice B everywhere across ALL books (not just one series)" bulk affordance + multi-book audio invalidation. Re-scope to that workspace-wide bulk replace, or close, once plan 108 ships.
 
 - _What:_ Add a "Replace voice everywhere" affordance in the voice library: pick a current voice, pick a replacement, see a preview of all (book, character) pairs that would be affected, confirm. Affected books' cast slices are mutated; audio is invalidated (regen prompt per book).
 - _Acceptance:_ Three books each use voice `am_michael` for one character → batch replace `am_michael` → `am_eric` shows 3 affected pairs, confirm rewrites all three cast.json files, audio marked stale. Vitest covers the dry-run preview + write logic; e2e covers the modal flow.
@@ -217,6 +221,8 @@ Source: net-new (2026-05-21). Plan 81 wave 4 deferred item.
 
 Source: net-new (2026-05-21). Spun off from the perf-tuning survey (item A3).
 
+> **Scope note (2026-05-24):** being delivered by [plan 108](features/108-qwen-coexistence.md) as the deliberate `dualModelEnabled` user setting (default off) — generalised to Kokoro + Qwen, with the same idea applying to Kokoro + XTTS. When `dualModelEnabled` is on, both engines stay resident (Ollama auto-evicts during generation via the existing banner); when off, a mixed-engine book pays the engine-swap cost with an inline warning. Remove this item when plan 108's dual-model wave ships.
+
 - _What:_ Drop the eviction wiring between Kokoro and XTTS; keep both engines loaded. Per-character voice profiles already carry `overrideTtsVoices: { coqui?, kokoro? }` per CLAUDE.md — pick at synth time. VRAM math (Kokoro 1 GB + XTTS 3 GB + Ollama analyzer ~7 GB = 11 GB on an 8 GB GPU) requires Ollama auto-eviction during generation, with the existing "TTS / Analyzer unloaded to free VRAM" banner.
 - _Acceptance:_ A mixed-engine book (Coqui voice on character A, Kokoro on character B) renders without engine-swap latency between sentences. First XTTS use no longer pays the ~30 s cold-load. Ollama auto-eviction surfaces a clear banner during generation; re-loads on analysis trigger.
 - _Key files:_ `server/tts-sidecar/main.py` (eviction wiring removal); `src/components/model-control-pill.tsx`; analyzer eviction at `server/src/analyzer/ollama.ts:92`.
@@ -278,7 +284,9 @@ Source: net-new (2026-05-22). Surfaced by the full `npm install` deprecation aud
 
 ### 33. Per-voice row sample-preview button inside `<VoiceOverridePicker>`
 
-Source: net-new (2026-05-22). Deferred from the picker-autocomplete bundle — the model-voice override picker now uses the shared `<SearchablePicker>` primitive but renders each voice row as just `name`. The original plan reserved a tiny `▶` slot on each row for in-list auditioning so the user can preview a voice without committing the override; v1 ships with the row label only, matching the legacy `<select>` parity.
+Source: net-new (2026-05-22).
+
+> **Scope note (2026-05-24):** [plan 108](features/108-qwen-coexistence.md) surfaces `<VoiceOverridePicker>` for every character (not just library-matched ones) and reuses `playSampleWithAutoLoad` for current-vs-proposed audition in the rebaseline modal — so the in-row `▶` affordance described here is a natural add inside the same picker work. Land it as part of plan 108's Wave 4 per-character picker, or keep as a standalone follow-up. Deferred from the picker-autocomplete bundle — the model-voice override picker now uses the shared `<SearchablePicker>` primitive but renders each voice row as just `name`. The original plan reserved a tiny `▶` slot on each row for in-list auditioning so the user can preview a voice without committing the override; v1 ships with the row label only, matching the legacy `<select>` parity.
 
 - _What:_ Add a per-row Play button that routes through `playSampleWithAutoLoad` (same helper the existing "Preview voice" / cast-row swatch use). Hover/focus reveals the icon on pointer devices; `coarse-pointer:opacity-60` keeps it faintly visible on touch. Sample text comes from the same drawer-level `previewText` the candidate-preview block uses. Single-row in-flight gate (the helper already coalesces concurrent clicks).
 - _Acceptance:_ Open the Profile Drawer's voice-override picker on the Kokoro tab. Click the `▶` next to a voice → that voice's sample plays without changing the current override. Pick the voice → override commits. Concurrent rapid clicks across rows fire one synth at a time.
@@ -335,6 +343,36 @@ Source: plan 102 Should #6 ship (2026-05-23) — known limitation called out in 
 - _Key files:_ `src/store/queue-dispatcher-middleware.ts` (cross-book branch), `src/lib/build-pending-revision.ts` (accept minimal input), `src/store/revisions-slice.ts`.
 - _Depends on:_ Should #6 (cross-book dispatcher) shipped.
 - _Benefit (user):_ the diff player's pending-revision list is complete for cross-book character regens without requiring a navigate-to-book round-trip first. Low priority — the revision is recoverable on book open today.
+
+### 39. Tune per-engine VRAM cost map against real hardware
+
+Source: net-new (2026-05-24). Spun off from [plan 108](features/108-qwen-coexistence.md) — the VRAM-weighted GPU semaphore ships with provisional per-engine costs (R2).
+
+- _What:_ The `ENGINE_VRAM_COST` map in `server/src/tts/engine-vram-cost.ts` and the default `GPU_VRAM_BUDGET` ship as estimates (analyzer ≈ budget, coqui ≈ 3, kokoro ≈ 1, qwen ≈ 1, gemini = 0; budget ≈ 4). Measure actual peak VRAM per engine during synth on the target 8 GB GPU (per the reboot-before-perf-baselines protocol) and correct the constants so two engines pack without spilling and a single heavy engine doesn't over-serialize.
+- _Acceptance:_ With corrected costs, a Kokoro+Qwen mixed-engine run holds both resident with headroom for the analyzer to evict-and-reload; `nvidia-smi` peak stays under the card's VRAM; no spill-to-RAM slowdown. Numbers documented in plan 108's Ship notes.
+- _Key files:_ `server/src/tts/engine-vram-cost.ts`; `server/.env.example` (`GPU_VRAM_BUDGET` doc); plan 108 Ship notes.
+- _Depends on:_ plan 108 Wave 1 (the weighted semaphore) shipped.
+- _Benefit (technical):_ correct VRAM accounting is the difference between two engines coexisting smoothly and thrashing the GPU. Estimates unblock the feature; measured values make it reliable.
+
+### 40. Engine-drift factor polish + `resolvedVoiceName` backfill
+
+Source: net-new (2026-05-24). Spun off from [plan 108](features/108-qwen-coexistence.md)'s R5 drift fix.
+
+- _What:_ Plan 108 adds an explicit engine-drift factor and snapshots the *resolved* voice name (`CharacterSnapshot.resolvedVoiceName`) so override-only voice changes trip drift. Chapters rendered BEFORE that change have no `resolvedVoiceName` and degrade to "no signal." Add a one-shot backfill script (mirror `scripts/relufs-existing.mjs`) that recomputes `resolvedVoiceName` for existing `segments.json` from the cast at render time where derivable, so legacy chapters participate in override-drift detection.
+- _Acceptance:_ Running the backfill over a book generated before plan 108 populates `resolvedVoiceName` on its `segments.json` snapshots; a subsequent rebaseline of that book surfaces voice drift on those legacy chapters.
+- _Key files:_ new `scripts/backfill-resolved-voice-name.mjs`; `server/src/routes/revisions.ts` (drift comparison); `server/src/tts/synthesise-chapter.ts` (snapshot writer).
+- _Depends on:_ plan 108 Wave 4 (R5 drift fix) shipped.
+- _Benefit (user):_ rebaseline drift is complete for books generated before the feature landed, not just new ones.
+
+### 41. Cross-series voice linking
+
+Source: net-new (2026-05-24). Surfaced during [plan 108](features/108-qwen-coexistence.md) planning — series scoping stops at the `(author, series)` boundary.
+
+- _What:_ Plan 108's per-character engine + voice changes propagate across one series via `findAuthorSeriesForBookId`. A character who recurs across DIFFERENT series by the same author (or a shared-universe crossover) is not covered — the rebaseline / per-character write stops at the series boundary by design. Add an explicit cross-series link affordance (extend `Character.aliases` / a new link record) so a deliberate "this is the same voice across series X and Y" decision propagates voice + engine across both.
+- _Acceptance:_ Link character A in series X to character B in series Y; a voice/engine change on A also writes B's cast.json. No implicit cross-series propagation without an explicit link (preserves the current series-boundary default).
+- _Key files:_ `server/src/workspace/series-cast-scan.ts`; `server/src/routes/voices.ts` (cross-series write path); a new link record on `Character`.
+- _Depends on:_ plan 108 (series-scoped write) shipped.
+- _Benefit (user):_ recurring narrators / crossover characters stay consistent across an author's whole catalogue, not just within one series.
 
 ---
 

--- a/docs/features/108-qwen-coexistence.md
+++ b/docs/features/108-qwen-coexistence.md
@@ -1,0 +1,95 @@
+---
+status: draft
+shipped: null
+owner: null
+---
+
+# 108 — Qwen3-TTS coexistence + per-character engine/voice + series rebaseline
+
+> Status: draft — implemented across waves (see "Implementation waves" below). Each wave's PR flips the relevant section to `stable` and fills Ship notes.
+> Key files: `server/tts-sidecar/engines/qwen3.py`, `server/src/tts/index.ts`, `server/src/tts/voice-mapping.ts`, `server/src/tts/synthesise-chapter.ts`, `server/src/tts/per-character-engine.ts`, `server/src/gpu/semaphore.ts`, `server/src/routes/rebaseline.ts`, `src/modals/rebaseline-modal.tsx`, `src/components/voice-engine-picker.tsx`, `src/views/account.tsx`
+> URL surface: `#/cast` (per-character picker + rebaseline trigger), Account tab (dual-model flag + Qwen install), the global queue modal (engine badges)
+> OpenAPI ops: `PUT /api/voices/{voiceId}/override` (+`scope`/`bookId`), new `POST /api/series/{bookId}/rebaseline/{propose,apply}`, `GET/PUT /api/user/settings` (+`dualModelEnabled`), sidecar `POST /load`,`/unload`,`/synthesize` (+`qwen` engine)
+
+## Benefit / Rationale
+
+- **User:** a second local TTS engine (Qwen3-TTS 0.6B) can be used *alongside* Kokoro inside one book. A character can be moved to a different engine **and** a specific base voice from the cast view — today impossible for any character not already matched to a library voice. The change propagates across the whole book series. A new "Rebaseline the series" modal LLM-ranks the best voice across the engines the user selects for the principal cast, shows current-vs-proposed with audition, and on approval writes the changes (surfacing as drift) — the fix for "Biana's voice isn't working, put her on a Qwen voice across her series."
+- **Technical:** engine becomes a *per-character* decision rather than one global `modelKey` per generation run. The GPU semaphore becomes VRAM-weighted so two engines never overcommit an 8 GB GPU. The queue surfaces each chapter's required engine set. Loading two engines into VRAM is gated behind a deliberate `dualModelEnabled` user setting.
+- **Architectural:** establishes "add the Nth TTS engine" as a mechanical change (sidecar engine class + registry entry + server catalog table) and the per-engine `overrideTtsVoices` map as the durable cross-engine cast contract. Closes a long-standing drift gap: a voice change that lives in `overrideTtsVoices` (not `voiceId`) now actually trips drift detection.
+
+## Architectural impact
+
+### New seams / extension points
+
+- **Sidecar engine registry** — `server/tts-sidecar/main.py` `ENGINES` dict gains `"qwen": QwenEngine()` (lazy, opt-in `PRELOAD_QWEN=0`). New `server/tts-sidecar/engines/qwen3.py` mirrors `KokoroEngine`. The `/synthesize` `{engine,model,voice,text}` contract is unchanged — new engines route through it transparently.
+- **Per-character engine** — new optional `Character.ttsEngine?: TtsEngine`. New `server/src/tts/per-character-engine.ts#resolveCharacterEngine(c, projectDefaultEngine)`: precedence `c.ttsEngine → projectDefaultEngine`. Absent field reproduces today's behavior (back-compat).
+- **VRAM-weighted semaphore** — `server/src/gpu/semaphore.ts` rewritten to a token budget (`GPU_VRAM_BUDGET`, derived from legacy `GPU_CONCURRENCY` when unset). `acquire(cost=1)` takes cost-many tokens; per-engine costs in new `server/src/tts/engine-vram-cost.ts`. `maxConcurrency`/`inFlight`/`queueDepth` getters retained so `synthesise-chapter.ts` and `gpu-queue.ts` keep working.
+- **Series-scoped override write** — `PUT /api/voices/:voiceId/override` gains `scope`/`bookId` params; new `applyOverrideToSeries`. New `findAuthorSeriesForBookId` exported from `series-cast-scan.ts`.
+- **Rebaseline** — new `POST /api/series/:bookId/rebaseline/{propose,apply}` (`server/src/routes/rebaseline.ts`) backed by `server/src/analyzer/rebaseline-rank.ts` (a minimal `generateJson` path through `selectAnalyzer({})` + the GPU semaphore).
+- **`dualModelEnabled`** user setting (default `false`) — openapi → `user-settings.ts` zod → `account-slice.ts` → `account.tsx`.
+
+### Invariants preserved
+
+- **OpenAPI is the type source of truth** (plan 24): `ttsEngine`, `dualModelEnabled`, rebaseline shapes, override `scope` all land in `openapi.yaml` first.
+- **RTK Immer drafts** (plan 26): new `rebaseline-slice` mutates drafts.
+- **Mock toggle** (plan 23): new endpoints get mock implementations behind `api.*`.
+- **Concurrent multi-book workflow** (project invariant): mixed-engine generation and rebaseline must not break cross-book queue dispatch; global pills stay live regardless of viewed book.
+- **`GEN_CHAPTER_CONCURRENCY` stays global** (plan 87) — only the GPU semaphore becomes VRAM-weighted.
+- **Single-engine behavior unchanged**: with only one engine used and `GPU_VRAM_BUDGET` unset, generation and GPU arbitration are byte-identical to today.
+
+### Migration story
+
+- `Character.ttsEngine` and `CharacterSnapshot.resolvedVoiceName` are additive optional fields — absence means "no signal" (same lazy-tolerance as today's optional snapshot fields). No backfill.
+- `overrideTtsVoices` already migrates legacy `overrideTtsVoice` lazily at cast.json read (`normaliseCastCharacter`, `server/src/routes/voices.ts`); the new `qwen` slot is just another key.
+
+### Reversibility
+
+- Each wave is its own branch/PR and individually revertable. The sidecar engine is opt-in (`PRELOAD_QWEN=0`), the dual-model flag defaults off, and the semaphore falls back to count-equivalent behavior when `GPU_VRAM_BUDGET` is unset — so reverting any single wave leaves the rest functional.
+
+## Invariants to preserve
+
+- `server/src/gpu/semaphore.ts:96-99` reads `GPU_CONCURRENCY` at module load; the rewrite must keep a singleton, keep FIFO order, and keep `maxConcurrency`/`inFlight`/`queueDepth` getters (consumed by `server/src/tts/synthesise-chapter.ts` poolWidth default and `server/src/routes/gpu-queue.ts`).
+- `server/src/routes/revisions.ts:175-179` currently has NO engine-drift factor and compares `snapshot.voiceId` vs `current.voiceId` only. A rebaseline writes `overrideTtsVoices[engine].name`, NOT `voiceId` — so without the R5 fix (snapshot + compare the *resolved* voice name + engine) it produces zero drift. The fix must add `resolvedVoiceName` to the snapshot and a comparison here.
+- `server/src/routes/generation.ts` resolves engine in three places (resolve, thread into `synthesiseChapter`, drift snapshot `voiceEngine`). All three must become per-character.
+- `server/tts-sidecar/main.py` `ENGINES` registry + `/synthesize` `{engine,model,voice,text}` contract is the single seam for engine addition — do not special-case Qwen elsewhere in the sidecar.
+
+## Implementation waves
+
+- **Round 0 (this PR)** — docs/backlog reconciliation + this plan. No code.
+- **Wave 1 (3 parallel):** `feat/sidecar-qwen3-engine` (engine + install + spike), `feat/gpu-vram-weighted-semaphore`, `feat/account-dual-model-flag`.
+- **Wave 2 (sequential):** `feat/tts-qwen-engine-types` → `feat/generation-per-character-engine`.
+- **Wave 3 (∥ Wave 4):** `feat/queue-multi-tts-indicators`.
+- **Wave 4 (∥ Wave 3):** `feat/cast-per-character-engine-voice` (+ R5 drift fix + series-scoped write).
+- **Wave 5 (last):** `feat/voice-rebaseline-series`.
+
+Full design detail (per-wave file scopes, the engine-swap path, the LLM prompt shape, risks) lives in `~/.claude/plans/ok-i-want-to-sparkling-acorn.md`.
+
+## Test plan
+
+### Automated coverage
+
+- **Sidecar pytest** `server/tts-sidecar/tests/test_qwen3.py` — `engine:"qwen"` → non-empty int16 PCM + sample-rate header; voice substitution + `substituted_from`; `/health` qwen fields. Extend `test_concurrent_synthesis.py` — Kokoro+Qwen run in parallel, no cross-bleed, no deadlock.
+- **Server Vitest** `semaphore.test.ts` (weighted acquire/release, `cost>budget` clamp, FIFO, counted==weighted back-compat, no deadlock); `voice-mapping.test.ts` (Qwen catalog audit + override/inference resolve); `index.test.ts` (engineForModelKey/sidecarModelId/label); `synthesise-chapter.test.ts` (mixed-engine chapter — two providers, index-order concat, resample; no-`ttsEngine` == today); generation route (dual-model OFF mixed → `engine_swap`+`warning`, correct audio; ON → no swap); `chapter-engine-set.test.ts`; `queue.test.ts` (stamps `requiredEngines`/`multiTts`); `voices.test.ts` (`scope=series` writes only that series); `revisions.test.ts` (override/engine change → severe drift — the R5 fix); `rebaseline-rank.test.ts` + `rebaseline.test.ts`.
+- **Frontend Vitest** `account-slice.test.ts` (dualModel reducer/dirty/patch); `principal-cast.test.ts` (80%-of-lines ex-narrator: narrator excluded even if top, ties, <80% edge); `profile-drawer.test.tsx` (engine+voice picker for a non-library character writes the series override); `voices-slice.test.ts`; `queue-slice.test.ts`; `rebaseline-slice.test.ts`; `rebaseline-modal.test.tsx` (default = principal cast, audition).
+- **Pester** `scripts/tests/` — `install-qwen3.ps1` wrapper.
+- **Playwright e2e** `account.spec.ts` (dual-model checkbox + Qwen install card), `queue.spec.ts` (engine badge + dual-model-off warning), `cast.spec.ts` (change a character to Qwen + voice, persists), `rebaseline.spec.ts` (propose → approve → drift report shows entries).
+
+### Manual acceptance walkthrough
+
+Run against the real backend + sidecar (this feature is sidecar-bound). Canonical manuscript: `C:\Users\dudar\Downloads\Bonus Keefe Story.txt` (English, do not commit).
+
+1. **Account tab** → Qwen install card visible → install → enable the dual-model flag (default off) → `GET /api/sidecar/health` reports `qwen_loaded` after a load.
+2. **Cast view** → open a character's profile → switch engine to Qwen → pick a base voice → audition plays the Qwen voice → save → open another book in the same series → the character shows the Qwen voice (series-scoped).
+3. **Generate** a chapter where two characters use different engines: dual-model ON → no engine swap; toggle OFF + re-run → inline warning recommends enabling dual-model, audio still correct.
+4. **Queue modal** → enqueue one single-engine chapter and one multi-engine chapter → badges name the engines; the multi one warns when dual-model is OFF.
+5. **Voice tab** → "Rebaseline the series" → principal cast (~80% of non-narrator lines) pre-selected → pick Kokoro+Qwen → review LLM proposals with current-vs-proposed audition → approve → drift report shows new severe voice/engine entries for already-generated chapters.
+6. **Concurrency** → `GPU_VRAM_BUDGET=4` → mixed-engine run shows Kokoro+Qwen concurrent via `GET /api/gpu/queue` but Coqui+anything serializes; unset budget + Kokoro-only reproduces current single-engine timing.
+
+## Out of scope
+
+- **Multi-language / Russian** — the language half of BACKLOG Must #2 (BCP-47 `language` field, Cyrillic detection, voice-library language filtering, Cyrillic token estimator). This plan delivers only the Qwen *engine* + coexistence. Must #2 stays on the backlog for the language work.
+- **Per-segment / cross-series voice linking** — tracked separately on the backlog.
+
+## Ship notes
+
+(Filled per wave as each flips to `stable`.)

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -83,6 +83,7 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 - [13 — TTS engine picker](13-tts-engine-picker.md) — Two-tier engine + model selector.
 - [14a — Kokoro v1 TTS engine](14a-tts-sidecar-kokoro.md) — Local sidecar default, English-only, per-engine cast voice profiles.
 - [15 — Gemini cloud TTS](15-tts-gemini-cloud.md) — Cloud opt-in.
+- [108 — Qwen3-TTS coexistence + per-character engine/voice + series rebaseline](108-qwen-coexistence.md) — `draft`. Adds Qwen3-TTS 0.6B as a coexisting sidecar engine alongside Kokoro; makes TTS engine a per-character (`Character.ttsEngine`) decision threaded through generation + drift; a cast-view picker to change a character's engine + base voice with series-wide propagation; a "Rebaseline the series" modal that LLM-ranks the best voice across selected engines for the principal cast (~80% of non-narrator lines) and writes changes as drift; a VRAM-weighted GPU semaphore (`GPU_VRAM_BUDGET`); a deliberate `dualModelEnabled` account flag; queue badges naming each chapter's required engines. Delivers the engine half of BACKLOG Must #2 (language half deferred). Implemented across waves; Round 0 opens the round.
 
 ### G. Generation
 


### PR DESCRIPTION
## Summary

Round 0 (docs-only) opens the **Qwen3-TTS coexistence** round. No code — this PR lands the master regression plan and reconciles the backlog so the implementation waves have a clean target.

- **New plan:** `docs/features/108-qwen-coexistence.md` (`status: draft`) — the master regression plan covering: Qwen3-TTS 0.6B as a sidecar engine coexisting with Kokoro within one book; TTS engine as a *per-character* decision (`Character.ttsEngine`) threaded through generation + drift; a cast-view picker to change a character's engine + base voice with **series-wide** propagation; a "Rebaseline the series" modal that LLM-ranks the best voice across the user-selected engines for the **principal cast (~80% of non-narrator lines)** and writes changes as drift; a **VRAM-weighted GPU semaphore** (`GPU_VRAM_BUDGET`, `GEN_CHAPTER_CONCURRENCY` stays global); a deliberate **`dualModelEnabled`** account flag; and **queue badges** naming each chapter's required engine(s). Documents the implementation waves, the invariants to preserve, and the R5 drift-gap fix (a rebaseline writes `overrideTtsVoices`, not `voiceId`, so today's `revisions.ts:175-179` comparison would create zero drift — the plan snapshots the resolved voice name + engine and adds the comparison).
- **`docs/BACKLOG.md` reconciliation:**
  - **Must #2 (multi-language)** re-scoped via a scope note — the *engine* half (Qwen + per-engine plumbing + install script) is delegated to plan 108; the *language* half (BCP-47 field, Cyrillic detection, language filtering, token estimator, never-cross-language invariant) remains here.
  - **Could #14** (both engines resident) annotated as being delivered by plan 108's `dualModelEnabled`.
  - **Could #3** (batch voice-replace) annotated as largely subsumed by plan 108's series-scoped override write; retains only the workspace-wide bulk-replace.
  - **Could #33** (per-row sample preview) annotated as reused by plan 108's audition.
  - **New follow-ups appended** (bottom of the Could bucket): **#39** per-engine VRAM cost tuning against real hardware, **#40** engine-drift factor polish + `resolvedVoiceName` backfill, **#41** cross-series voice linking.
- **`docs/features/INDEX.md`:** plan 108 listed under section F (TTS).

Full per-wave design (file scopes, the engine-swap path, the LLM prompt shape, risks) lives in the approved local plan `~/.claude/plans/ok-i-want-to-sparkling-acorn.md`, referenced from plan 108.

## Test plan

Docs-only — no automated tests change. Local pre-push `npm run verify` ran: all unit/e2e legs `[cached]` (no source touched), `build` ran fresh and passed. CI's doc-only fast-path (plan 101) skips `verify.yml` for this PR; the PR-title lint + conflict check still apply.
