### PR TITLE
feat(server): VRAM-weighted GPU semaphore (per-engine token cost)

### DIFF
--- a/docs/features/108-qwen-coexistence.md
+++ b/docs/features/108-qwen-coexistence.md
@@ -13,8 +13,8 @@ owner: null
 
 ## Benefit / Rationale
 
-- **User:** a second local TTS engine (Qwen3-TTS 0.6B) can be used *alongside* Kokoro inside one book. A character can be moved to a different engine **and** a specific base voice from the cast view — today impossible for any character not already matched to a library voice. The change propagates across the whole book series. A new "Rebaseline the series" modal LLM-ranks the best voice across the engines the user selects for the principal cast, shows current-vs-proposed with audition, and on approval writes the changes (surfacing as drift) — the fix for "Biana's voice isn't working, put her on a Qwen voice across her series."
-- **Technical:** engine becomes a *per-character* decision rather than one global `modelKey` per generation run. The GPU semaphore becomes VRAM-weighted so two engines never overcommit an 8 GB GPU. The queue surfaces each chapter's required engine set. Loading two engines into VRAM is gated behind a deliberate `dualModelEnabled` user setting.
+- **User:** a second local TTS engine (Qwen3-TTS 0.6B) can be used _alongside_ Kokoro inside one book. A character can be moved to a different engine **and** a specific base voice from the cast view — today impossible for any character not already matched to a library voice. The change propagates across the whole book series. A new "Rebaseline the series" modal LLM-ranks the best voice across the engines the user selects for the principal cast, shows current-vs-proposed with audition, and on approval writes the changes (surfacing as drift) — the fix for "Biana's voice isn't working, put her on a Qwen voice across her series."
+- **Technical:** engine becomes a _per-character_ decision rather than one global `modelKey` per generation run. The GPU semaphore becomes VRAM-weighted so two engines never overcommit an 8 GB GPU. The queue surfaces each chapter's required engine set. Loading two engines into VRAM is gated behind a deliberate `dualModelEnabled` user setting.
 - **Architectural:** establishes "add the Nth TTS engine" as a mechanical change (sidecar engine class + registry entry + server catalog table) and the per-engine `overrideTtsVoices` map as the durable cross-engine cast contract. Closes a long-standing drift gap: a voice change that lives in `overrideTtsVoices` (not `voiceId`) now actually trips drift detection.
 
 ## Architectural impact
@@ -49,7 +49,7 @@ owner: null
 ## Invariants to preserve
 
 - `server/src/gpu/semaphore.ts:96-99` reads `GPU_CONCURRENCY` at module load; the rewrite must keep a singleton, keep FIFO order, and keep `maxConcurrency`/`inFlight`/`queueDepth` getters (consumed by `server/src/tts/synthesise-chapter.ts` poolWidth default and `server/src/routes/gpu-queue.ts`).
-- `server/src/routes/revisions.ts:175-179` currently has NO engine-drift factor and compares `snapshot.voiceId` vs `current.voiceId` only. A rebaseline writes `overrideTtsVoices[engine].name`, NOT `voiceId` — so without the R5 fix (snapshot + compare the *resolved* voice name + engine) it produces zero drift. The fix must add `resolvedVoiceName` to the snapshot and a comparison here.
+- `server/src/routes/revisions.ts:175-179` currently has NO engine-drift factor and compares `snapshot.voiceId` vs `current.voiceId` only. A rebaseline writes `overrideTtsVoices[engine].name`, NOT `voiceId` — so without the R5 fix (snapshot + compare the _resolved_ voice name + engine) it produces zero drift. The fix must add `resolvedVoiceName` to the snapshot and a comparison here.
 - `server/src/routes/generation.ts` resolves engine in three places (resolve, thread into `synthesiseChapter`, drift snapshot `voiceEngine`). All three must become per-character.
 - `server/tts-sidecar/main.py` `ENGINES` registry + `/synthesize` `{engine,model,voice,text}` contract is the single seam for engine addition — do not special-case Qwen elsewhere in the sidecar.
 
@@ -87,9 +87,18 @@ Run against the real backend + sidecar (this feature is sidecar-bound). Canonica
 
 ## Out of scope
 
-- **Multi-language / Russian** — the language half of BACKLOG Must #2 (BCP-47 `language` field, Cyrillic detection, voice-library language filtering, Cyrillic token estimator). This plan delivers only the Qwen *engine* + coexistence. Must #2 stays on the backlog for the language work.
+- **Multi-language / Russian** — the language half of BACKLOG Must #2 (BCP-47 `language` field, Cyrillic detection, voice-library language filtering, Cyrillic token estimator). This plan delivers only the Qwen _engine_ + coexistence. Must #2 stays on the backlog for the language work.
 - **Per-segment / cross-series voice linking** — tracked separately on the backlog.
 
 ## Ship notes
 
 (Filled per wave as each flips to `stable`.)
+
+### Wave 1 — `feat/gpu-vram-weighted-semaphore`
+
+- `server/src/gpu/semaphore.ts` rewritten from a flat count semaphore to a VRAM token-budget semaphore. `acquire(cost = 1)` now takes `cost` tokens; grants immediately only when no waiter is queued ahead AND `used + cost <= budget`, else queues FIFO and drains as many head-of-line waiters as fit on each release. `cost` is clamped into `[1, budget]` (a `cost > budget` runs alone instead of deadlocking; `cost < 1` floors to 1). The single-use double-release guard is preserved.
+- Singleton budget resolves from new env `GPU_VRAM_BUDGET`; when unset/invalid it falls back to `GPU_CONCURRENCY` (default 1) — so a single-engine box with every caller at the default cost 1 behaves byte-identically to the old count semaphore. Retained getters: `queueDepth`, `inFlight` (holder count), `maxConcurrency` (returns budget, so `synthesise-chapter.ts`'s poolWidth default is unchanged). Added `budget` + `usedTokens`.
+- New `server/src/tts/engine-vram-cost.ts`: provisional `ENGINE_VRAM_COST` (`kokoro 1, qwen 1, coqui 3, gemini 0, analyzer 4`), `costForEngine(engine)` (unknown → 1), and `DEFAULT_GPU_VRAM_BUDGET = 4`. Values are estimates — tuning tracked in BACKLOG #39.
+- Acquire sites now charge per-engine cost: `sidecar.ts` → `costForEngine(this.engine)`, `ollama.ts` → `costForEngine('analyzer')`. `gpu-queue.ts` JSON gains `budget` + `usedTokens` additively (`max` still aliases the budget).
+- `server/.env.example` documents `GPU_VRAM_BUDGET` with the fallback-to-`GPU_CONCURRENCY` note.
+- Tests: `server/src/gpu/semaphore.test.ts` (weighted acquire/release at budget 4, `cost > budget` clamp, `cost < 1` clamp, head-of-line FIFO blocking, weighted double-release no-leak, plus the back-compat invariant that budget = N + cost 1 == old count semaphore max = N) and new `server/src/tts/engine-vram-cost.test.ts`.

--- a/server/.env.example
+++ b/server/.env.example
@@ -87,6 +87,15 @@ GEMINI_MODEL=gemma-4-31b-it
 # GPU arbitration — max concurrent GPU ops (analyzer + sidecar combined). Bump only after measuring VRAM headroom.
 GPU_CONCURRENCY=1
 
+# GPU arbitration — total VRAM token budget for the weighted semaphore. Each GPU op
+# takes tokens equal to its engine's VRAM weight (kokoro 1, qwen 1, coqui 3, gemini 0,
+# analyzer 4 — provisional; see server/src/tts/engine-vram-cost.ts + BACKLOG #39), and
+# the semaphore admits a combination only when the summed cost fits this budget. On an
+# 8 GB box, 4 lets Kokoro+Qwen (1+1) run together while Coqui (3) or the analyzer (4)
+# serialise heavier work. When UNSET, the budget falls back to GPU_CONCURRENCY (default 1)
+# and every op costs 1, so behaviour is byte-identical to the old count semaphore.
+# GPU_VRAM_BUDGET=4
+
 # ---------------------------------------------------------------------------
 # TTS. Provider is now chosen per-request by the modelKey the UI sends.
 # Local engines (coqui-*, piper-*, kokoro-*) hit the sidecar at LOCAL_TTS_URL.

--- a/server/src/analyzer/ollama.ts
+++ b/server/src/analyzer/ollama.ts
@@ -14,6 +14,7 @@ import { writeFile } from 'node:fs/promises';
 import type { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { gpuSemaphore } from '../gpu/semaphore.js';
+import { costForEngine } from '../tts/engine-vram-cost.js';
 import { writeInbox, errorPath, rawAttemptPath, type HandoffKey } from '../handoff/protocol.js';
 import {
   stage1Schema,
@@ -392,8 +393,10 @@ export class OllamaAnalyzer implements Analyzer {
        slot is held across the full streamed response (fetch + read
        loop) and released in the outer `finally` below; that covers
        abort paths, fetch-throws, non-2xx responses, and mid-stream
-       errors equally well. See server/src/gpu/semaphore.ts. */
-    const releaseGpu = await gpuSemaphore.acquire();
+       errors equally well. The analyzer's VRAM weight (engine-vram-cost.ts)
+       is large enough to serialise it against any TTS op — they already
+       evict each other on the GPU. See server/src/gpu/semaphore.ts. */
+    const releaseGpu = await gpuSemaphore.acquire(costForEngine('analyzer'));
 
     try {
       let response: Response;

--- a/server/src/gpu/semaphore.test.ts
+++ b/server/src/gpu/semaphore.test.ts
@@ -1,13 +1,19 @@
-/* GpuSemaphore — FIFO arbitration around the analyzer + sidecar GPU
-   call sites. Three contract guarantees this spec pins:
+/* GpuSemaphore — VRAM-weighted FIFO arbitration around the analyzer +
+   sidecar GPU call sites. Guarantees this spec pins:
 
-   1. Capacity:    `new GpuSemaphore(2)` admits two acquires concurrently
-                   and forces the third to wait until one releases.
+   1. Capacity:    `new GpuSemaphore(2)` admits two cost-1 acquires
+                   concurrently and forces the third to wait until one
+                   releases.
    2. FIFO order:  acquires that block on a full semaphore release in the
                    order they queued — A finishes, B runs, C waits; B
                    releases, C runs; etc.
    3. Queue depth: `queueDepth` reflects waiters not yet running and
                    ticks down on every release while waiters exist.
+   4. Weighting:   `acquire(cost)` takes `cost` tokens of the budget — two
+                   cost-2 ops fit a budget-4 semaphore, a third waits; a
+                   cost > budget clamps to the budget (never deadlocks).
+   5. Back-compat: budget = N with every acquire at cost 1 behaves exactly
+                   like the old count semaphore with max = N.
 
    These guarantees feed the frontend pill's "Queued (N ahead) ·"
    prefix (see src/lib/use-tts-lifecycle.ts + src/components/layout.tsx),
@@ -152,5 +158,179 @@ describe('GpuSemaphore', () => {
     const next = await sem.acquire();
     expect(sem.inFlight).toBe(1);
     next();
+  });
+
+  it('does not leak tokens on double-release of a weighted hold', async () => {
+    /* A cost-3 hold double-released must free exactly 3 tokens, not 6 —
+       otherwise `usedTokens` would underflow and the semaphore would
+       over-admit. */
+    const sem = new GpuSemaphore(4);
+    const release = await sem.acquire(3);
+    expect(sem.usedTokens).toBe(3);
+    release();
+    release();
+    expect(sem.usedTokens).toBe(0);
+    expect(sem.inFlight).toBe(0);
+  });
+});
+
+describe('GpuSemaphore — VRAM-weighted acquire', () => {
+  it('admits acquires whose summed cost fits the budget and queues the rest', async () => {
+    const sem = new GpuSemaphore(4);
+
+    /* Two cost-2 acquires fit (2 + 2 = 4). */
+    const releaseA = await sem.acquire(2);
+    const releaseB = await sem.acquire(2);
+    expect(sem.usedTokens).toBe(4);
+    expect(sem.inFlight).toBe(2);
+    expect(sem.queueDepth).toBe(0);
+
+    /* A third cost-2 would overcommit (4 + 2 > 4) → queues. */
+    let cResolved = false;
+    const cPromise = sem.acquire(2).then((rel) => {
+      cResolved = true;
+      return rel;
+    });
+    await flush();
+    expect(cResolved).toBe(false);
+    expect(sem.usedTokens).toBe(4);
+    expect(sem.queueDepth).toBe(1);
+
+    /* Releasing A frees 2 tokens → C wakes and takes them. */
+    releaseA();
+    await flush();
+    expect(cResolved).toBe(true);
+    expect(sem.usedTokens).toBe(4);
+    expect(sem.queueDepth).toBe(0);
+
+    const releaseC = await cPromise;
+    releaseB();
+    releaseC();
+    expect(sem.usedTokens).toBe(0);
+    expect(sem.inFlight).toBe(0);
+  });
+
+  it('clamps cost > budget down to the budget so it never deadlocks', async () => {
+    const sem = new GpuSemaphore(4);
+
+    /* cost 10 on a budget-4 semaphore behaves as cost 4 — it runs alone and
+       releasing it returns the full budget. */
+    const release = await sem.acquire(10);
+    expect(sem.usedTokens).toBe(4);
+    expect(sem.inFlight).toBe(1);
+
+    /* Anything else must wait while the over-budget op holds everything. */
+    let nextResolved = false;
+    const nextPromise = sem.acquire(1).then((rel) => {
+      nextResolved = true;
+      return rel;
+    });
+    await flush();
+    expect(nextResolved).toBe(false);
+
+    release();
+    await flush();
+    expect(nextResolved).toBe(true);
+    const next = await nextPromise;
+    expect(sem.usedTokens).toBe(1);
+    next();
+    expect(sem.usedTokens).toBe(0);
+  });
+
+  it('clamps cost < 1 up to 1', async () => {
+    const sem = new GpuSemaphore(2);
+    const release = await sem.acquire(0);
+    expect(sem.usedTokens).toBe(1);
+    release();
+    expect(sem.usedTokens).toBe(0);
+  });
+
+  it('head-of-line blocks: a cheap later waiter cannot jump an expensive head that does not fit', async () => {
+    /* Budget 4, fully held by two cost-2 holders (A1, A2). B (cost 3) queues
+       at the head; C (cost 1) queues behind it. Release ONE holder → 2 tokens
+       free. B (3) still doesn't fit, so it stays blocked — and FIFO means C
+       (which WOULD fit the 2 free tokens) must NOT jump ahead of B. Nothing
+       wakes until B can run. */
+    const sem = new GpuSemaphore(4);
+    const order: string[] = [];
+
+    const releaseA1 = await sem.acquire(2);
+    const releaseA2 = await sem.acquire(2);
+    expect(sem.usedTokens).toBe(4);
+
+    const bPromise = sem.acquire(3).then((rel) => {
+      order.push('B');
+      return rel;
+    });
+    const cPromise = sem.acquire(1).then((rel) => {
+      order.push('C');
+      return rel;
+    });
+    await flush();
+    expect(order).toEqual([]);
+    expect(sem.queueDepth).toBe(2);
+
+    /* Free 2 tokens — not enough for B (3). C must stay blocked behind B. */
+    releaseA1();
+    await flush();
+    expect(order).toEqual([]);
+    expect(sem.usedTokens).toBe(2);
+    expect(sem.queueDepth).toBe(2);
+
+    /* Free the other 2 → 4 free. B fits (3) and wakes first; C then fits the
+       remaining 1. FIFO order: B before C. */
+    releaseA2();
+    await flush();
+    expect(order).toEqual(['B', 'C']);
+    expect(sem.usedTokens).toBe(4);
+
+    const releaseB = await bPromise;
+    const releaseC = await cPromise;
+    releaseB();
+    releaseC();
+    expect(sem.usedTokens).toBe(0);
+    expect(sem.inFlight).toBe(0);
+  });
+
+  describe('backward-compat: budget = N + cost 1 === old count semaphore max = N', () => {
+    it('serialises at budget 1', async () => {
+      const sem = new GpuSemaphore(1);
+      const completed: string[] = [];
+      const runWorker = async (label: string): Promise<void> => {
+        const release = await sem.acquire(); // default cost 1
+        completed.push(label);
+        await Promise.resolve();
+        release();
+      };
+      await Promise.all([runWorker('A'), runWorker('B'), runWorker('C')]);
+      expect(completed).toEqual(['A', 'B', 'C']);
+    });
+
+    it('admits exactly 2 concurrently at budget 2', async () => {
+      const sem = new GpuSemaphore(2);
+      const releaseA = await sem.acquire();
+      const releaseB = await sem.acquire();
+      expect(sem.inFlight).toBe(2);
+      expect(sem.queueDepth).toBe(0);
+
+      let cResolved = false;
+      sem.acquire().then(() => {
+        cResolved = true;
+      });
+      await flush();
+      expect(cResolved).toBe(false);
+      expect(sem.queueDepth).toBe(1);
+
+      releaseA();
+      await flush();
+      expect(cResolved).toBe(true);
+      releaseB();
+    });
+
+    it('exposes budget via maxConcurrency for the poolWidth default', () => {
+      expect(new GpuSemaphore(1).maxConcurrency).toBe(1);
+      expect(new GpuSemaphore(4).maxConcurrency).toBe(4);
+      expect(new GpuSemaphore(4).budget).toBe(4);
+    });
   });
 });

--- a/server/src/gpu/semaphore.ts
+++ b/server/src/gpu/semaphore.ts
@@ -1,72 +1,105 @@
-/* GpuSemaphore — single-instance FIFO arbitration around heavy-GPU work.
-   Two parallel Claude Code sessions on the same dev box can both kick off
-   `/analyse` (Ollama) or `/synthesize` (TTS sidecar) at once; on an 8 GB
-   GPU the second op spills into shared system RAM and BOTH runs slow by
-   5-10x. Serialising at the Node layer keeps the GPU saturated by one op
-   at a time and lets the waiting session show a "Queued (N ahead)" pill
+/* GpuSemaphore — single-instance FIFO arbitration around heavy-GPU work,
+   weighted by VRAM cost. Two parallel Claude Code sessions on the same dev
+   box can both kick off `/analyse` (Ollama) or `/synthesize` (TTS sidecar)
+   at once; on an 8 GB GPU the second op spills into shared system RAM and
+   BOTH runs slow by 5-10x. Arbitrating at the Node layer keeps the GPU from
+   overcommitting and lets a waiting session show a "Queued (N ahead)" pill
    instead of silently thrashing.
 
-   Hand-rolled (no p-limit / p-queue dep) — 40 lines isn't worth a new
-   transitive tree, and the contract is small: acquire returns a release
-   function the caller invokes in `finally`. FIFO order is preserved by
-   shift()-ing the queue head when a release fires while waiters are
-   pending. Concurrency cap reads from `GPU_CONCURRENCY` at module load,
-   matching `rate-limit.ts`'s env-at-load idiom — bump it only after
-   measuring VRAM headroom on the target GPU.
+   Earlier this was a flat *count* semaphore (max from GPU_CONCURRENCY). It's
+   now a *token budget*: each caller takes `cost` tokens — the VRAM weight of
+   its engine (see server/src/tts/engine-vram-cost.ts). Two cheap engines can
+   run concurrently while a heavy one serialises, so we never overcommit the
+   GPU and never needlessly serialise two ops that genuinely fit together.
+
+   Backward-compat: when GPU_VRAM_BUDGET is unset, the budget falls back to
+   GPU_CONCURRENCY (default 1) and every caller's default cost is 1 — so the
+   weighted semaphore behaves byte-identically to the old count semaphore.
+
+   Hand-rolled (no p-limit / p-queue dep) — the contract is small: acquire
+   returns a release function the caller invokes in `finally`. FIFO order is
+   preserved by shift()-ing the queue head and granting it as soon as enough
+   tokens free up.
 
    Wired into:
      - server/src/analyzer/ollama.ts  — wraps the /api/chat fetch.
      - server/src/tts/sidecar.ts      — wraps the /synthesize fetch +
                                         arrayBuffer() read so a single
                                         release covers the full GPU op.
-     - server/src/routes/gpu-queue.ts — exposes inFlight + depth to the
-                                        frontend pill via GET /api/gpu/queue. */
+     - server/src/routes/gpu-queue.ts — exposes inFlight + depth + budget +
+                                        usedTokens to the frontend pill via
+                                        GET /api/gpu/queue. */
 
-type Waiter = { resolve: (release: () => void) => void };
+type Waiter = { cost: number; resolve: (release: () => void) => void };
 
 export class GpuSemaphore {
-  private current = 0;
-  private readonly max: number;
+  private used = 0;
+  private holders = 0;
+  private readonly capacity: number;
   private readonly queue: Waiter[] = [];
 
-  constructor(max: number) {
-    /* Clamp to >= 1 — a max of 0 would deadlock every caller, and
+  constructor(budget: number) {
+    /* Clamp to >= 1 — a budget of 0 would deadlock every caller, and
        negative values are nonsensical. Defensive against bad env vars. */
-    this.max = Math.max(1, Math.floor(max));
+    this.capacity = Math.max(1, Math.floor(budget));
   }
 
-  /** Acquire one GPU slot. Resolves with a single-use release function;
-      the caller MUST invoke it (typically inside a `finally`) so a
-      waiter — or, if none are queued, the counter — can advance. */
-  async acquire(): Promise<() => void> {
-    if (this.current < this.max) {
-      this.current += 1;
-      return this.makeRelease();
+  /** Acquire `cost` GPU tokens. Resolves with a single-use release function;
+      the caller MUST invoke it (typically inside a `finally`) so queued
+      waiters — or, if none are queued, the token counter — can advance.
+
+      `cost` is clamped into [1, budget]: a cost above the budget would
+      otherwise deadlock forever (no release can ever free enough tokens), so
+      it's pinned to the full budget and runs alone; a cost below 1 is pinned
+      to 1 so every acquire consumes at least one token. */
+  async acquire(cost = 1): Promise<() => void> {
+    const want = this.clampCost(cost);
+    /* Grant immediately only when no one is queued ahead of us AND the
+       tokens are free. Honouring the queue even when tokens happen to be
+       free preserves strict FIFO — a late cheap acquire can't jump a
+       waiting expensive one. */
+    if (this.queue.length === 0 && this.used + want <= this.capacity) {
+      this.used += want;
+      this.holders += 1;
+      return this.makeRelease(want);
     }
     return new Promise<() => void>((resolve) => {
-      this.queue.push({ resolve: (release) => resolve(release) });
+      this.queue.push({ cost: want, resolve });
     });
   }
 
-  /** Build a fresh single-use release function for the slot that just
-      went in-flight. When invoked, either hands the slot to the next
-      waiter (with their own fresh release) or decrements the counter
-      so the next `acquire()` call can short-circuit. */
-  private makeRelease(): () => void {
+  private clampCost(cost: number): number {
+    const c = Math.floor(cost);
+    if (!Number.isFinite(c) || c < 1) return 1;
+    if (c > this.capacity) return this.capacity;
+    return c;
+  }
+
+  /** Build a fresh single-use release function for the `cost` tokens that
+      just went in-flight. When invoked, frees the tokens and then drains as
+      many FIFO-head waiters as now fit. */
+  private makeRelease(cost: number): () => void {
     let released = false;
     return () => {
       if (released) return;
       released = true;
-      const next = this.queue.shift();
-      if (next) {
-        /* Slot stays in-flight — `current` doesn't change. Hand the
-           waiter a NEW release function so they get their own
-           single-use semantics. */
-        next.resolve(this.makeRelease());
-      } else {
-        this.current -= 1;
-      }
+      this.used -= cost;
+      this.holders -= 1;
+      this.drain();
     };
+  }
+
+  /** Grant the FIFO head while it fits in the freed tokens. Strictly
+      head-of-line: a waiter that doesn't fit blocks the ones behind it even
+      if a later (cheaper) waiter would fit — that's what keeps wake order
+      FIFO and starvation-free. */
+  private drain(): void {
+    while (this.queue.length > 0 && this.used + this.queue[0].cost <= this.capacity) {
+      const next = this.queue.shift()!;
+      this.used += next.cost;
+      this.holders += 1;
+      next.resolve(this.makeRelease(next.cost));
+    }
   }
 
   /** Number of acquires waiting in the FIFO queue. Drives the
@@ -75,25 +108,42 @@ export class GpuSemaphore {
     return this.queue.length;
   }
 
-  /** Number of acquires currently holding a slot (capped at `max`).
-      Exposed so the gpu-queue route can surface the full triple
-      (depth, inFlight, max) for diagnostics. */
+  /** Number of acquires currently holding tokens. Exposed so the gpu-queue
+      route can surface it for diagnostics. */
   get inFlight(): number {
-    return this.current;
+    return this.holders;
   }
 
-  /** Configured concurrency cap. */
+  /** Total token budget. Returned by `maxConcurrency` too, so
+      `synthesise-chapter.ts`'s poolWidth default (budget 1 ⇒ serial) is
+      preserved across the count→token migration. */
+  get budget(): number {
+    return this.capacity;
+  }
+
+  /** Tokens currently committed across all in-flight holders. */
+  get usedTokens(): number {
+    return this.used;
+  }
+
+  /** Configured token budget. Alias of `budget` retained for the existing
+      poolWidth default in synthesise-chapter.ts. */
   get maxConcurrency(): number {
-    return this.max;
+    return this.capacity;
   }
 }
 
-/* Singleton — both call sites (analyzer + sidecar) import this so a
-   queue depth of 1 in the analyzer is visible to a sidecar caller and
-   vice versa. `GPU_CONCURRENCY` env var lets an operator bump the cap
-   once they've measured the GPU can survive two ops simultaneously;
-   default 1 is the conservative pick for an 8 GB box. */
-const RAW_MAX = Number(process.env.GPU_CONCURRENCY ?? '1');
-export const gpuSemaphore = new GpuSemaphore(
-  Number.isFinite(RAW_MAX) && RAW_MAX > 0 ? RAW_MAX : 1,
-);
+/* Singleton — both call sites (analyzer + sidecar) import this so a queue
+   depth of 1 in the analyzer is visible to a sidecar caller and vice versa.
+   Budget comes from GPU_VRAM_BUDGET when set; otherwise it falls back to
+   GPU_CONCURRENCY (default 1) so single-engine boxes that never set the new
+   var keep the exact old behaviour. */
+const RAW_BUDGET = Number(process.env.GPU_VRAM_BUDGET);
+const RAW_CONCURRENCY = Number(process.env.GPU_CONCURRENCY ?? '1');
+const resolvedBudget =
+  Number.isFinite(RAW_BUDGET) && RAW_BUDGET > 0
+    ? RAW_BUDGET
+    : Number.isFinite(RAW_CONCURRENCY) && RAW_CONCURRENCY > 0
+      ? RAW_CONCURRENCY
+      : 1;
+export const gpuSemaphore = new GpuSemaphore(resolvedBudget);

--- a/server/src/routes/gpu-queue.ts
+++ b/server/src/routes/gpu-queue.ts
@@ -18,6 +18,11 @@ gpuQueueRouter.get('/queue', (_req: Request, res: Response) => {
   res.json({
     depth: gpuSemaphore.queueDepth,
     inFlight: gpuSemaphore.inFlight,
+    /* `max` is the legacy field the frontend pill reads; kept aliased to the
+       token budget so the existing shape never breaks. `budget`/`usedTokens`
+       are additive — the VRAM-weighted view for diagnostics. */
     max: gpuSemaphore.maxConcurrency,
+    budget: gpuSemaphore.budget,
+    usedTokens: gpuSemaphore.usedTokens,
   });
 });

--- a/server/src/tts/engine-vram-cost.test.ts
+++ b/server/src/tts/engine-vram-cost.test.ts
@@ -1,0 +1,42 @@
+/* engine-vram-cost — the per-engine VRAM weights the GPU semaphore charges
+   each acquire. Pins the provisional values (so a future tuning pass is a
+   visible diff here) and the unknown-engine fallback (cost 1, never grabs
+   the whole budget by accident). */
+
+import { describe, it, expect } from 'vitest';
+import { ENGINE_VRAM_COST, costForEngine, DEFAULT_GPU_VRAM_BUDGET } from './engine-vram-cost.js';
+
+describe('engine-vram-cost', () => {
+  it('exposes the provisional per-engine weights', () => {
+    expect(ENGINE_VRAM_COST).toMatchObject({
+      kokoro: 1,
+      qwen: 1,
+      coqui: 3,
+      gemini: 0,
+      analyzer: 4,
+    });
+  });
+
+  it('returns the mapped cost for a known engine', () => {
+    expect(costForEngine('kokoro')).toBe(1);
+    expect(costForEngine('coqui')).toBe(3);
+    expect(costForEngine('gemini')).toBe(0);
+    expect(costForEngine('analyzer')).toBe(4);
+    expect(costForEngine('qwen')).toBe(1);
+  });
+
+  it('falls back to cost 1 for an unknown engine', () => {
+    expect(costForEngine('piper')).toBe(1);
+    expect(costForEngine('totally-new-engine')).toBe(1);
+    expect(costForEngine('')).toBe(1);
+  });
+
+  it('documents a default budget that fits Kokoro + Qwen together', () => {
+    expect(DEFAULT_GPU_VRAM_BUDGET).toBe(4);
+    expect(ENGINE_VRAM_COST.kokoro + ENGINE_VRAM_COST.qwen).toBeLessThanOrEqual(
+      DEFAULT_GPU_VRAM_BUDGET,
+    );
+    /* Two Coqui ops would spill the budget → serialise. */
+    expect(ENGINE_VRAM_COST.coqui * 2).toBeGreaterThan(DEFAULT_GPU_VRAM_BUDGET);
+  });
+});

--- a/server/src/tts/engine-vram-cost.ts
+++ b/server/src/tts/engine-vram-cost.ts
@@ -1,0 +1,40 @@
+/* Per-engine VRAM cost weights for the GPU semaphore (server/src/gpu/
+   semaphore.ts). Each TTS engine — plus the analyzer (Ollama) — takes a
+   number of tokens proportional to its VRAM footprint, so the semaphore
+   admits a combination of ops only when their summed cost fits the budget.
+
+   PROVISIONAL VALUES — these are first-cut estimates, not measured. They
+   WILL be tuned once we have real VRAM telemetry on the target 8 GB box;
+   see BACKLOG #39. The rationale behind DEFAULT_GPU_VRAM_BUDGET below
+   documents the intended fits.
+
+   Keyed loosely as Record<string, number> on purpose: the future `qwen`
+   engine isn't yet in the TtsEngine union (added in a later wave), and the
+   analyzer isn't a TtsEngine at all — so we don't tie this map to that
+   union. Unknown keys fall back to cost 1 via costForEngine. */
+export const ENGINE_VRAM_COST: Record<string, number> = {
+  kokoro: 1,
+  qwen: 1,
+  coqui: 3,
+  gemini: 0,
+  analyzer: 4,
+};
+
+/** VRAM token cost for an engine name (or 'analyzer'). Unknown names cost 1
+    so a new engine never silently grabs the whole budget. */
+export function costForEngine(engine: string): number {
+  return ENGINE_VRAM_COST[engine] ?? 1;
+}
+
+/* Suggested GPU_VRAM_BUDGET for an 8 GB GPU. NOTE: this is only the value to
+   document in server/.env.example — when GPU_VRAM_BUDGET is UNSET the
+   semaphore falls back to GPU_CONCURRENCY (default 1), NOT this constant.
+
+   Budget 4 fits the intended concurrency story:
+     - Kokoro (1) + Qwen (1) run together (2 ≤ 4) — the common dual-TTS case.
+     - Coqui (3) fits on its own and even leaves room for one Kokoro (3+1=4).
+     - Coqui (3) + another Coqui (3) = 6 > 4 → the second serialises.
+     - The analyzer (4) consumes the whole budget, so analysis serialises
+       against any TTS op — analyzer and TTS already evict each other on the
+       GPU, so co-residence would just thrash. */
+export const DEFAULT_GPU_VRAM_BUDGET = 4;

--- a/server/src/tts/sidecar.ts
+++ b/server/src/tts/sidecar.ts
@@ -12,6 +12,7 @@
 import type { SynthesizeInput, SynthesizeOutput, TtsProvider, TtsEngine } from './index.js';
 import { sidecarModelId } from './index.js';
 import { gpuSemaphore } from '../gpu/semaphore.js';
+import { costForEngine } from './engine-vram-cost.js';
 
 interface SidecarOptions {
   url: string;
@@ -44,9 +45,10 @@ export class SidecarTtsProvider implements TtsProvider {
        doesn't race the analyzer (or another concurrent synth) for VRAM
        on an 8 GB GPU. Held across the buffered arrayBuffer() read
        below; the sidecar response is NOT streaming, so a single
-       release after the read covers the whole GPU op. See
-       server/src/gpu/semaphore.ts. */
-    const releaseGpu = await gpuSemaphore.acquire();
+       release after the read covers the whole GPU op. Cost is the engine's
+       VRAM weight (engine-vram-cost.ts) so a heavy engine takes more of the
+       budget than a light one. See server/src/gpu/semaphore.ts. */
+    const releaseGpu = await gpuSemaphore.acquire(costForEngine(this.engine));
 
     try {
       let response: Response;
@@ -93,7 +95,8 @@ export class SidecarTtsProvider implements TtsProvider {
            - 4xx other than 408 → client-side; retry won't help. */
         const poisoned = isPoisonedBody(bodyText);
         const transient =
-          !poisoned && (response.status === 408 || (response.status >= 500 && response.status < 600));
+          !poisoned &&
+          (response.status === 408 || (response.status >= 500 && response.status < 600));
         throw Object.assign(
           new Error(
             `Local TTS sidecar returned ${response.status}: ${trimmed || response.statusText}`,


### PR DESCRIPTION
## Summary

Wave 1 of [plan 108](docs/features/108-qwen-coexistence.md). Replaces the flat **count** `GpuSemaphore` with a **VRAM-weighted token** semaphore so two TTS engines (Kokoro + a future Qwen) never overcommit an 8 GB GPU. `GEN_CHAPTER_CONCURRENCY` stays global and untouched — only the GPU semaphore becomes weighted.

Behavior / contract deltas:

- **`server/src/gpu/semaphore.ts` rewritten** from a count semaphore to a token-budget semaphore. The constructor takes a **budget** (tokens, integer >= 1). `acquire(cost = 1)` takes `cost` tokens: it grants immediately only when no waiter is queued ahead **and** `used + cost <= budget`, otherwise it FIFO-queues and is woken when a release frees enough tokens (`drain()` wakes as many head-of-line waiters as fit). `cost` is clamped into `[1, budget]` — a `cost > budget` op runs alone instead of deadlocking, a `cost < 1` floors to 1. The single-use double-release guard is preserved, and strict FIFO wake order is preserved (a late cheap acquire cannot jump a queued expensive one).
- **Singleton budget source changed.** New env **`GPU_VRAM_BUDGET`** sets the budget; when unset/invalid it **falls back to `GPU_CONCURRENCY` (default 1)**. So a single-engine box with every caller at the default cost 1 behaves byte-identically to the old count semaphore. Retained getters: `queueDepth`, `inFlight` (holder count), `maxConcurrency` (returns the budget, so `synthesise-chapter.ts`'s poolWidth default is preserved — budget 1 ⇒ serial). Added `budget` + `usedTokens` getters.
- **New `server/src/tts/engine-vram-cost.ts`.** Exports `ENGINE_VRAM_COST` (PROVISIONAL: `kokoro 1, qwen 1, coqui 3, gemini 0, analyzer 4`), `costForEngine(engine)` (unknown engine → cost 1), and `DEFAULT_GPU_VRAM_BUDGET = 4` (documented rationale: Kokoro+Qwen fit; Coqui fits alone; Coqui + another spills → serialized). Keyed loosely as `Record<string, number>` so it doesn't depend on the `TtsEngine` union (`qwen` lands in a later wave). Tuning against real hardware is tracked in **BACKLOG #39**.
- **Acquire sites charge per-engine cost.** `server/src/tts/sidecar.ts` → `gpuSemaphore.acquire(costForEngine(this.engine))`; `server/src/analyzer/ollama.ts` → `gpuSemaphore.acquire(costForEngine('analyzer'))`. No other behavior change at those sites.
- **`GET /api/gpu/queue` additively exposes `budget` + `usedTokens`.** The existing `depth`/`inFlight`/`max` fields are unchanged and `max` still aliases the budget, so the frontend pill's read shape is preserved.
- **New env var `GPU_VRAM_BUDGET`** documented in `server/.env.example` with the fallback-to-`GPU_CONCURRENCY` note.

New tests:

- `server/src/gpu/semaphore.test.ts` — added weighted acquire/release (budget 4: two cost-2 run concurrently, a third waits, releasing one wakes it), `cost > budget` clamp (cost 10 on budget 4 behaves as cost 4, never deadlocks), `cost < 1` clamp, head-of-line FIFO blocking (a cheap later waiter cannot jump an expensive head that doesn't fit), weighted double-release no-leak, and the back-compat invariant (budget = N + every acquire at cost 1 == old count semaphore max = N; serialize at N=1, 2 concurrent at N=2).
- `server/src/tts/engine-vram-cost.test.ts` — the cost map values, known-engine lookups, unknown-engine fallback to 1, and the DEFAULT_GPU_VRAM_BUDGET fit math.

Plan 108's Ship notes gained a Wave 1 entry; the plan frontmatter stays `draft` (later waves still pending).

## Test plan

- `npm run typecheck` — green (frontend + server).
- `npm run lint` (ESLint) + `prettier --check` on all touched files — green.
- `cd server && npx vitest run src/gpu/ src/tts/` — 187 server-tts/gpu tests pass (16 in the two new/edited gpu+cost files).
- Pre-commit hook ran `verify:fast` (full server suite: 1280 passed) at commit time.
- Pre-push hook ran the full `npm run verify` battery (typecheck + all tests + e2e + build) — green; branch pushed to origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)