### PR TITLE
docs(docs): keep in-code plan-98 describe label on archive page

### DIFF
--- a/docs/features/archive/99-voices-pill-merge.md
+++ b/docs/features/archive/99-voices-pill-merge.md
@@ -36,7 +36,7 @@ owner: null
 ### Automated coverage
 
 - Vitest unit (`src/lib/voice-character-link.test.ts` — `describe('pickMergeSurvivor')`) — covers substring rule, longer-name rule, and the stable tiebreaker.
-- Vitest unit (`src/views/voices.test.tsx` — `describe('LibraryView merge-cast-duplicates affordance (plan 99)')`) — covers:
+- Vitest unit (`src/views/voices.test.tsx` — `describe('LibraryView merge-cast-duplicates affordance (plan 98)')`, kept as-is on archive for historical accuracy at ship-time) — covers:
   - Merge button appears with `Merge into <longer-name>` label on 2× same-voice same-book selection.
   - Merge button hidden on a cross-book pair (even with same base voice).
   - Merge button hidden on a different-base-voice pair.
@@ -68,5 +68,5 @@ Run in mock mode (`VITE_USE_MOCKS=true`) at `#/voices` for the global path, or `
 - **Shipped:** 2026-05-22 via PR #167, merge commit `77a9a89`.
 - **No spec delta from the active plan.** Survivor heuristic, pill gating, dark-mode descendant CSS, and all five voices.test.tsx cases shipped exactly as drafted.
 - **Bundled bug fix:** the `.floating-pill-inverse` dark-mode descendant overrides land in the same commit. The bug existed since plan 96 introduced the shell class; was tolerated until the Voices view added a third button (Merge) and the user pointed at the contrast on the existing Compare/Clear pair.
-- **Tests landed and green:** 3 new cases in `src/lib/voice-character-link.test.ts` (`pickMergeSurvivor`), 5 new cases in `src/views/voices.test.tsx` (`describe('LibraryView merge-cast-duplicates affordance (plan 99)')`). Full battery `npm run verify` green on Linux CI; the two flaky Windows-only baselines (`analysing-dark.png`, `confirm-dark.png`) cleared per [feedback_visual_baselines_flaky_on_windows.md].
+- **Tests landed and green:** 3 new cases in `src/lib/voice-character-link.test.ts` (`pickMergeSurvivor`), 5 new cases in `src/views/voices.test.tsx` (`describe('LibraryView merge-cast-duplicates affordance (plan 98)')` — kept as-is for historical accuracy at ship-time). Full battery `npm run verify` green on Linux CI; the two flaky Windows-only baselines (`analysing-dark.png`, `confirm-dark.png`) cleared per [feedback_visual_baselines_flaky_on_windows.md].
 - **No follow-up surfaced.** Out-of-scope items (e2e spec, undo, three-way merge, renaming survivor to a typed third name) remain explicitly out of scope; none has appeared on the BACKLOG.


### PR DESCRIPTION
## Summary

Realigns the plan-99 archive page with the actual test code. `docs/features/archive/99-voices-pill-merge.md` referenced the merge-affordance describe block as `plan 99` in two places (Automated coverage + Ship notes), but the real block in `src/views/voices.test.tsx:784` was deliberately kept as `describe('LibraryView merge-cast-duplicates affordance (plan 98)')` for historical accuracy at ship-time (per PR #169). This reverts the two doc references back to `plan 98` so the archive page matches what greps find in the tree, and adds a short "kept as-is for historical accuracy" note at each site.

This is a rescue of an orphaned commit (`f580f39`) that lived only on two stale remote branches (`docs/docs-plan-98-archive`, `docs/docs-archive-99-plan-label-consistency`) and was never merged. Those two branches are deleted after this lands.

## Test plan

Doc-only change (2 lines in one archived plan file); no code paths touched. CI skips the verify battery for doc-only PRs per plan 101. Verified by grep that the test describe block on `main` reads `plan 98` while the doc read `plan 99` before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
