### PR TITLE
feat(server): wire Qwen3-TTS engine types + bespoke voice resolution

### DIFF
--- a/server/src/routes/voices.ts
+++ b/server/src/routes/voices.ts
@@ -130,7 +130,13 @@ async function loadVoicesMeta(): Promise<VoicesMetaJson> {
 }
 
 function parseEngine(value: unknown): TtsEngine {
-  if (value === 'gemini' || value === 'coqui' || value === 'piper' || value === 'kokoro')
+  if (
+    value === 'gemini' ||
+    value === 'coqui' ||
+    value === 'piper' ||
+    value === 'kokoro' ||
+    value === 'qwen'
+  )
     return value;
   return 'coqui';
 }
@@ -347,7 +353,8 @@ function parseOverrideField(
     v.engine !== 'coqui' &&
     v.engine !== 'gemini' &&
     v.engine !== 'piper' &&
-    v.engine !== 'kokoro'
+    v.engine !== 'kokoro' &&
+    v.engine !== 'qwen'
   )
     return 'invalid';
   if (v.name.trim().length === 0) return 'invalid';

--- a/server/src/tts/index.test.ts
+++ b/server/src/tts/index.test.ts
@@ -1,0 +1,64 @@
+/* Engine-key plumbing for the TTS provider factory. Pins the pure routing
+   helpers (no side-deps) so adding/renaming an engine key can't silently
+   misroute a model to the wrong provider. Qwen3-TTS (plan 108) is the latest
+   engine added here. */
+
+import { describe, it, expect } from 'vitest';
+import {
+  engineForModelKey,
+  sidecarModelId,
+  isTtsModelKey,
+  TTS_MODEL_LABELS,
+  type TtsModelKey,
+} from './index.js';
+
+describe('engineForModelKey routes each model key to its engine', () => {
+  it.each([
+    ['coqui-xtts-v2', 'coqui'],
+    ['kokoro-v1', 'kokoro'],
+    ['qwen3-tts-0.6b', 'qwen'],
+    ['gemini-2.5-flash', 'gemini'],
+    ['gemini-3.1-flash', 'gemini'],
+    ['piper-en-us-medium', 'piper'],
+  ] as const)('%s -> %s', (key, engine) => {
+    expect(engineForModelKey(key)).toBe(engine);
+  });
+});
+
+describe('sidecarModelId', () => {
+  it('maps local keys to their sidecar model id, incl. qwen', () => {
+    expect(sidecarModelId('coqui-xtts-v2')).toBe('xtts_v2');
+    expect(sidecarModelId('kokoro-v1')).toBe('v1');
+    expect(sidecarModelId('qwen3-tts-0.6b')).toBe('0.6b');
+  });
+
+  it('throws for cloud (non-local) keys', () => {
+    expect(() => sidecarModelId('gemini-2.5-flash')).toThrow();
+  });
+});
+
+describe('isTtsModelKey', () => {
+  it('accepts every known key incl. qwen3-tts-0.6b', () => {
+    const keys: TtsModelKey[] = [
+      'coqui-xtts-v2',
+      'piper-en-us-medium',
+      'kokoro-v1',
+      'qwen3-tts-0.6b',
+      'gemini-2.5-flash',
+      'gemini-3.1-flash',
+    ];
+    for (const k of keys) expect(isTtsModelKey(k)).toBe(true);
+  });
+
+  it('rejects unknown values', () => {
+    expect(isTtsModelKey('qwen')).toBe(false);
+    expect(isTtsModelKey('qwen3-tts')).toBe(false);
+    expect(isTtsModelKey(undefined)).toBe(false);
+  });
+});
+
+describe('TTS_MODEL_LABELS', () => {
+  it('has a human label for the qwen key', () => {
+    expect(TTS_MODEL_LABELS['qwen3-tts-0.6b']).toBe('Qwen3-TTS 0.6B (local)');
+  });
+});

--- a/server/src/tts/index.ts
+++ b/server/src/tts/index.ts
@@ -35,7 +35,7 @@ export interface TtsProvider {
 /* Engine groupings. Local engines all share the sidecar provider; only the
    `model` field on the sidecar request differs. Gemini is its own provider
    (direct Google API). */
-export type TtsEngine = 'coqui' | 'piper' | 'kokoro' | 'gemini';
+export type TtsEngine = 'coqui' | 'piper' | 'kokoro' | 'gemini' | 'qwen';
 
 /* UI-stable namespaced keys. The engine half drives provider selection; the
    model half is forwarded to the engine as-is. New local engines/voices slot
@@ -44,6 +44,7 @@ export type TtsModelKey =
   | 'coqui-xtts-v2' // local default
   | 'piper-en-us-medium' // future local
   | 'kokoro-v1' // future local
+  | 'qwen3-tts-0.6b' // local bespoke-voice engine (plan 108)
   | 'gemini-2.5-flash' // cloud fallback
   | 'gemini-3.1-flash';
 
@@ -51,6 +52,7 @@ export const TTS_MODEL_LABELS: Record<TtsModelKey, string> = {
   'coqui-xtts-v2': 'Coqui XTTS v2 (local)',
   'piper-en-us-medium': 'Piper en-US medium (local)',
   'kokoro-v1': 'Kokoro v1 (local)',
+  'qwen3-tts-0.6b': 'Qwen3-TTS 0.6B (local)',
   'gemini-2.5-flash': 'Gemini 2.5 Flash TTS',
   'gemini-3.1-flash': 'Gemini 3.1 Flash TTS',
 };
@@ -73,6 +75,7 @@ export function isTtsModelKey(value: unknown): value is TtsModelKey {
     value === 'coqui-xtts-v2' ||
     value === 'piper-en-us-medium' ||
     value === 'kokoro-v1' ||
+    value === 'qwen3-tts-0.6b' ||
     value === 'gemini-2.5-flash' ||
     value === 'gemini-3.1-flash'
   );
@@ -82,6 +85,7 @@ export function engineForModelKey(key: TtsModelKey): TtsEngine {
   if (key.startsWith('coqui-')) return 'coqui';
   if (key.startsWith('piper-')) return 'piper';
   if (key.startsWith('kokoro-')) return 'kokoro';
+  if (key.startsWith('qwen')) return 'qwen';
   return 'gemini';
 }
 
@@ -91,6 +95,9 @@ export function sidecarModelId(key: TtsModelKey): string {
   if (key === 'coqui-xtts-v2') return 'xtts_v2';
   if (key === 'piper-en-us-medium') return 'en-us-medium';
   if (key === 'kokoro-v1') return 'v1';
+  // Qwen ignores the model field at synth (voice = designed voiceId), but the
+  // sidecar /synthesize contract requires a non-empty model string.
+  if (key === 'qwen3-tts-0.6b') return '0.6b';
   throw new Error(`sidecarModelId called with non-local key: ${key}`);
 }
 

--- a/server/src/tts/voice-mapping.test.ts
+++ b/server/src/tts/voice-mapping.test.ts
@@ -9,7 +9,12 @@
    side of the pair fails the test instead of shipping silently. */
 
 import { describe, it, expect } from 'vitest';
-import { auditEngineCatalog, pickVoiceForEngine, KOKORO_PROFILE_VOICES } from './voice-mapping.js';
+import {
+  auditEngineCatalog,
+  pickVoiceForEngine,
+  resolveVoiceAssignment,
+  KOKORO_PROFILE_VOICES,
+} from './voice-mapping.js';
 
 describe('voice-mapping catalogs are self-consistent', () => {
   it('coqui: every picker voice has a description and every described voice is routable', () => {
@@ -193,5 +198,82 @@ describe('pickVoiceForEngine honours the per-cast overrideTtsVoice', () => {
       { gender: 'male' },
     );
     expect(withNull).toBe(withoutKey);
+  });
+});
+
+describe('qwen is a bespoke-voice engine — no catalog inference (plan 108)', () => {
+  /* Qwen voices are designed per character (design -> clone -> cache ->
+     reuse), not picked from a profile table. A Qwen character MUST carry an
+     explicit designed voiceId in overrideTtsVoices.qwen; with none, there's
+     nothing to infer — the picker returns '' (not a fallback voice). */
+
+  it('returns the designed voiceId from the qwen override slot', () => {
+    const picked = pickVoiceForEngine(
+      'qwen',
+      {
+        id: 'char-biana',
+        character: 'Biana',
+        attributes: ['Female', 'Teen'],
+        overrideTtsVoices: { qwen: { name: 'biana-bright-teen' } },
+      },
+      { gender: 'female', ageRange: 'teen' },
+    );
+    expect(picked).toBe('biana-bright-teen');
+  });
+
+  it('returns "" (no fallback) when no qwen voice has been designed', () => {
+    /* The load-bearing invariant: unlike the preset engines, Qwen does NOT
+       fall through to attribute inference — there is no catalog. An empty
+       string signals "design one first" to the UI / generation path. */
+    const picked = pickVoiceForEngine(
+      'qwen',
+      { id: 'char-biana', character: 'Biana', attributes: ['Female', 'Teen'] },
+      { gender: 'female', ageRange: 'teen' },
+    );
+    expect(picked).toBe('');
+  });
+
+  it('ignores a non-qwen override slot (each engine reads its own slot)', () => {
+    const picked = pickVoiceForEngine(
+      'qwen',
+      {
+        id: 'char-biana',
+        character: 'Biana',
+        attributes: [],
+        overrideTtsVoices: { kokoro: { name: 'af_bella' } },
+      },
+      { gender: 'female' },
+    );
+    expect(picked).toBe('');
+  });
+
+  it('resolveVoiceAssignment labels designed vs undesigned qwen voices', () => {
+    const undesigned = resolveVoiceAssignment(
+      'qwen',
+      { id: 'char-x', character: 'X', attributes: [] },
+      { gender: 'female' },
+    );
+    expect(undesigned).toEqual({
+      provider: 'qwen',
+      name: '',
+      description: 'No voice designed yet',
+    });
+    const designed = resolveVoiceAssignment('qwen', {
+      id: 'char-x',
+      character: 'X',
+      attributes: [],
+      overrideTtsVoices: { qwen: { name: 'x-voice' } },
+    });
+    expect(designed).toEqual({ provider: 'qwen', name: 'x-voice', description: 'Designed voice' });
+  });
+
+  it('auditEngineCatalog reports an empty audit for qwen (no static catalog)', () => {
+    const audit = auditEngineCatalog('qwen');
+    expect(audit).toEqual({
+      engine: 'qwen',
+      missingDescriptions: [],
+      unrouted: [],
+      routedCount: 0,
+    });
   });
 });

--- a/server/src/tts/voice-mapping.ts
+++ b/server/src/tts/voice-mapping.ts
@@ -234,6 +234,13 @@ export function pickVoiceForEngine(
   ) {
     return voice.overrideTtsVoice.name;
   }
+  /* Qwen voices are BESPOKE (designed per character, plan 108) — there is NO
+     profile catalog to infer from. A character on the Qwen engine MUST carry
+     an explicit designed voiceId in overrideTtsVoices.qwen; with none, there's
+     nothing to pick. Return '' so the cast view can show "no voice designed
+     yet"; the generation path treats a Qwen character without a designed voice
+     as an error or routes it to the default engine (plan 108 Wave 2b). */
+  if (engine === 'qwen') return '';
   const profile = inferProfile(voice, hint);
   const table = catalogForEngine(engine);
   const options = table[profile];
@@ -271,6 +278,9 @@ function describeVoice(engine: TtsEngine, name: string): string {
   if (engine === 'gemini') return GEMINI_VOICE_DESCRIPTIONS[name] ?? 'Prebuilt voice';
   if (engine === 'coqui') return COQUI_VOICE_DESCRIPTIONS[name] ?? 'Local voice';
   if (engine === 'kokoro') return KOKORO_VOICE_DESCRIPTIONS[name] ?? 'Local voice';
+  /* Qwen voices are designed bespoke per character — no static descriptor
+     table. An empty name means none has been designed yet. */
+  if (engine === 'qwen') return name ? 'Designed voice' : 'No voice designed yet';
   return 'Local voice';
 }
 
@@ -455,6 +465,11 @@ export interface CatalogConsistency {
 }
 
 export function auditEngineCatalog(engine: TtsEngine): CatalogConsistency {
+  /* Qwen has no static catalog to audit — its voices are designed bespoke per
+     character at runtime (plan 108). Nothing to diff; report an empty audit. */
+  if (engine === 'qwen') {
+    return { engine, missingDescriptions: [], unrouted: [], routedCount: 0 };
+  }
   const profiles =
     engine === 'gemini'
       ? GEMINI_PROFILE_VOICES


### PR DESCRIPTION
## Summary

Plan 108 **Wave 2a** — wires Qwen3-TTS into the server's engine-key plumbing and voice resolution. Pure server types/logic; no generation behavior changes yet (that's Wave 2b).

- `server/src/tts/index.ts`: `'qwen'` added to `TtsEngine`; `'qwen3-tts-0.6b'` added to `TtsModelKey` (+ `TTS_MODEL_LABELS`, `isTtsModelKey`, `engineForModelKey` via the `qwen` prefix, `sidecarModelId` → `'0.6b'`). `selectTtsProvider` routes it through the existing `SidecarTtsProvider` path unchanged.
- `server/src/tts/voice-mapping.ts`: Qwen handled as a **bespoke** engine — `pickVoiceForEngine('qwen', …)` returns the designed voiceId from `overrideTtsVoices.qwen` and otherwise `''` with **no profile-catalog fallback** (the load-bearing difference from the preset engines — Qwen voices are designed per character, plan 108). `describeVoice` labels designed vs undesigned; `auditEngineCatalog('qwen')` returns an empty audit (no static catalog).
- `server/src/routes/voices.ts`: `parseEngine` + `parseOverrideField` accept `'qwen'`.

## Test plan

- `npm run typecheck` clean — the new `'qwen'` union member is total across every `TtsEngine` consumer.
- New `server/src/tts/index.test.ts` (engine routing / `sidecarModelId` / `isTtsModelKey` / label incl. qwen) + extended `voice-mapping.test.ts` (pins the **no-catalog-fallback** invariant: undesigned Qwen → `''`, designed → the voiceId; designed/undesigned descriptions; empty audit). 37 server tests green.
- Pre-push `npm run verify` passed (the e2e leg flaked once on a server-startup race — this branch touches zero frontend surface — and passed clean on retry).
