### PR TITLE
fix(server): drift detects engine + override-only voice changes (R5)

### DIFF
--- a/server/src/routes/revisions.test.ts
+++ b/server/src/routes/revisions.test.ts
@@ -52,6 +52,7 @@ interface CharacterSnapshot {
   ageRange?: 'child' | 'teen' | 'adult' | 'elderly';
   voiceId?: string;
   voiceEngine?: string;
+  resolvedVoiceName?: string;
   attributes?: string[];
 }
 
@@ -121,6 +122,8 @@ interface SeedOpts {
     ageRange?: 'child' | 'teen' | 'adult' | 'elderly';
     voiceId?: string;
     attributes?: string[];
+    ttsEngine?: string;
+    overrideTtsVoices?: Record<string, { name: string }>;
   }>;
   dismissed?: string[];
 }
@@ -523,5 +526,62 @@ describe('GET /api/books/:bookId/revisions — dismissed filter', () => {
     const res = await request(app).get(`/api/books/${bookId}/revisions`);
     const factors = (res.body.drift as DriftEventOut[]).map((d) => d.factor);
     expect(factors).toEqual(['gender']);
+  });
+});
+
+describe('GET .../revisions — engine + resolved-voice drift (plan 108 R5)', () => {
+  it('fires both engine drift AND voice drift when a character moves to a new engine + designed voice', async () => {
+    seed({
+      snapshots: {
+        biana: { voiceId: 'lib-biana', voiceEngine: 'kokoro', resolvedVoiceName: 'af_bella' },
+      },
+      cast: [
+        {
+          id: 'biana',
+          voiceId: 'lib-biana',
+          ttsEngine: 'qwen',
+          overrideTtsVoices: { qwen: { name: 'biana-designed' } },
+        },
+      ],
+    });
+    const res = await request(app).get(`/api/books/${bookId}/revisions`);
+    expect(res.status).toBe(200);
+    const drift = res.body.drift as DriftEventOut[];
+    const engineEvent = drift.find((d) => d.factor === 'engine');
+    const voiceEvent = drift.find((d) => d.factor === 'voice');
+    // Engine changed kokoro -> qwen.
+    expect(engineEvent, 'expected an engine drift event').toBeTruthy();
+    expect(engineEvent!.severity).toBe('severe');
+    // Resolved voice name changed af_bella -> biana-designed (the qwen override).
+    expect(voiceEvent, 'expected a voice drift event').toBeTruthy();
+    expect(voiceEvent!.severity).toBe('severe');
+  });
+
+  it('catches an override-ONLY voice change (same voiceId) via resolvedVoiceName, with no engine drift', async () => {
+    seed({
+      snapshots: {
+        biana: { voiceId: 'lib-biana', voiceEngine: 'kokoro', resolvedVoiceName: 'af_bella' },
+      },
+      // voiceId unchanged; only the per-engine override flipped af_bella -> af_nicole.
+      cast: [
+        { id: 'biana', voiceId: 'lib-biana', overrideTtsVoices: { kokoro: { name: 'af_nicole' } } },
+      ],
+    });
+    const res = await request(app).get(`/api/books/${bookId}/revisions`);
+    const drift = res.body.drift as DriftEventOut[];
+    const voiceEvent = drift.find((d) => d.factor === 'voice');
+    expect(voiceEvent, 'override-only change must still fire voice drift').toBeTruthy();
+    // Engine unchanged (still kokoro) → no engine drift.
+    expect(drift.find((d) => d.factor === 'engine')).toBeFalsy();
+  });
+
+  it('pre-108 snapshot (no resolvedVoiceName) falls back to the voiceId comparison', async () => {
+    seed({
+      // No resolvedVoiceName — legacy segment. Same voiceId → no voice drift.
+      snapshots: { biana: { voiceId: 'lib-biana', voiceEngine: 'kokoro' } },
+      cast: [{ id: 'biana', voiceId: 'lib-biana' }],
+    });
+    const res = await request(app).get(`/api/books/${bookId}/revisions`);
+    expect(res.body.drift).toEqual([]);
   });
 });

--- a/server/src/routes/revisions.ts
+++ b/server/src/routes/revisions.ts
@@ -18,6 +18,10 @@ import { existsSync, readdirSync } from 'node:fs';
 import { audioDir, castJsonPath, revisionsJsonPath } from '../workspace/paths.js';
 import { readJson } from '../workspace/state-io.js';
 import { findBookByBookId } from '../workspace/scan.js';
+import { resolveCharacterEngine } from '../tts/per-character-engine.js';
+import { pickVoiceForEngine } from '../tts/voice-mapping.js';
+import { toVoiceLike, buildHintFromCast, type CastCharacter } from '../tts/synthesise-chapter.js';
+import type { TtsEngine } from '../tts/index.js';
 
 interface CharacterSnapshot {
   tone?: { warmth?: number; pace?: number; authority?: number; emotion?: number };
@@ -25,6 +29,11 @@ interface CharacterSnapshot {
   ageRange?: 'child' | 'teen' | 'adult' | 'elderly';
   voiceId?: string;
   voiceEngine?: string;
+  /** The voice NAME resolved at render time (plan 108 Wave 2b). Lets the
+      detector catch an override-only change (same voiceId, different
+      per-engine override) that the voiceId comparison misses. Absent on
+      pre-108 segments → fall back to voiceId. */
+  resolvedVoiceName?: string;
   /** Attribute list captured at synthesis time, sorted by
       generation.ts. Compared against the current cast's attributes —
       any non-empty symmetric difference fires a moderate-severity drift
@@ -39,15 +48,10 @@ interface SegmentsFile {
   characterSnapshots?: Record<string, CharacterSnapshot>;
 }
 
-interface CastCharacter {
-  id: string;
-  name?: string;
-  voiceId?: string;
-  gender?: 'male' | 'female' | 'neutral';
-  ageRange?: 'child' | 'teen' | 'adult' | 'elderly';
-  tone?: { warmth?: number; pace?: number; authority?: number; emotion?: number };
-  attributes?: string[];
-}
+/* CastCharacter is imported from synthesise-chapter.ts (plan 108 R5) so the
+   resolved-voice drift comparison below can reuse toVoiceLike +
+   buildHintFromCast on the live cast row — it needs the override / evidence /
+   ttsEngine fields the old narrow local shape lacked. */
 
 interface RevisionsPersisted {
   pending?: unknown[];
@@ -172,11 +176,29 @@ export async function getRevisionsForBook(
         current,
         detectedAt,
       };
-      /* No engine-drift factor: engine isn't stored in cast.json (it's per-
-         generation, set on the Generate view), so there's no current value
-         to compare against. A voiceId swap covers the cross-engine case in
-         practice — voice ids are engine-scoped. */
-      pushHardDrift(drift, ctx, 'voice', 'Voice', snapshot.voiceId, current.voiceId);
+      /* Engine drift (plan 108): the character's resolved engine changed since
+         this chapter rendered (e.g. Biana moved from Kokoro to Qwen). Use the
+         rendered engine as the fallback default so a character with no explicit
+         ttsEngine and an unchanged engine doesn't false-fire. */
+      const renderedEngine = (snapshot.voiceEngine as TtsEngine | undefined) ?? 'kokoro';
+      const currentEngine = resolveCharacterEngine(current, renderedEngine);
+      if (snapshot.voiceEngine) {
+        pushHardDrift(drift, ctx, 'engine', 'Engine', snapshot.voiceEngine, currentEngine);
+      }
+      /* Voice drift: prefer the resolved voice NAME (catches an override-only
+         change that keeps voiceId constant — the rebaseline / per-character
+         picker case), falling back to voiceId for pre-108 snapshots that have
+         no resolvedVoiceName. */
+      if (snapshot.resolvedVoiceName) {
+        const currentName = pickVoiceForEngine(
+          currentEngine,
+          toVoiceLike(current),
+          buildHintFromCast(current),
+        );
+        pushHardDrift(drift, ctx, 'voice', 'Voice', snapshot.resolvedVoiceName, currentName);
+      } else {
+        pushHardDrift(drift, ctx, 'voice', 'Voice', snapshot.voiceId, current.voiceId);
+      }
       pushHardDrift(drift, ctx, 'gender', 'Gender', snapshot.gender, current.gender);
       pushHardDrift(drift, ctx, 'ageRange', 'Age range', snapshot.ageRange, current.ageRange);
       for (const key of TONE_KEYS) {
@@ -276,7 +298,7 @@ function autoQueueableFor(severity: DriftEvent['severity']): boolean | undefined
 function pushHardDrift(
   out: DriftEvent[],
   ctx: DriftContext,
-  factor: 'voice' | 'gender' | 'ageRange',
+  factor: 'voice' | 'engine' | 'gender' | 'ageRange',
   factorLabel: string,
   before: string | undefined,
   after: string | undefined,


### PR DESCRIPTION
## Summary

Plan 108 **R5 comparison half** (the snapshot half — recording per-character `voiceEngine` + `resolvedVoiceName` — shipped in Wave 2b #210). This closes the drift gap where a rebaseline / per-character override change produced **no drift** because it keeps `voiceId` constant.

`server/src/routes/revisions.ts`:
- **New `engine` drift factor** — compares `snapshot.voiceEngine` vs the character's current resolved engine (`resolveCharacterEngine`), so moving a character to a new engine (Kokoro → Qwen) surfaces as severe drift.
- **Resolved-name voice drift** — compares `pickVoiceForEngine(currentEngine, …)` on the live cast row against `snapshot.resolvedVoiceName`, so an **override-only** change (same `voiceId`, different per-engine override — exactly what the per-character picker + rebaseline produce) now trips voice drift. Falls back to the `voiceId` comparison for pre-108 snapshots with no `resolvedVoiceName` (no false drift on legacy audio).
- `CastCharacter` is now imported from `synthesise-chapter.ts` so `toVoiceLike` + `buildHintFromCast` run on the live cast row; removed the obsolete "no engine-drift factor" comment.

## Test plan

3 new `revisions.test.ts` cases — (1) engine move + designed voice → both `engine` and `voice` severe drift; (2) override-only change (same voiceId) → voice drift, no engine drift; (3) pre-108 snapshot (no `resolvedVoiceName`) → falls back to voiceId, no false drift. The existing 28 cases stay green; typecheck clean. Pre-push `npm run verify` passed.
