### PR TITLE
fix(frontend): expose Qwen3-TTS in the TTS model dropdowns

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1058,7 +1058,7 @@ paths:
               properties:
                 modelKey:
                   type: string
-                  enum: [kokoro-v1, coqui-xtts-v2, gemini-2.5-flash, gemini-3.1-flash]
+                  enum: [kokoro-v1, qwen3-tts-0.6b, coqui-xtts-v2, gemini-2.5-flash, gemini-3.1-flash]
                   description: TTS model key. Local engines (kokoro-, coqui-) route to the sidecar; gemini-* keys route to Google's TTS API.
                 chapterIds:
                   type: array
@@ -1699,7 +1699,7 @@ components:
             Used to filter the model dropdown's initial state.
         defaultTtsModelKey:
           type: string
-          enum: [kokoro-v1, coqui-xtts-v2, gemini-2.5-flash, gemini-3.1-flash]
+          enum: [kokoro-v1, qwen3-tts-0.6b, coqui-xtts-v2, gemini-2.5-flash, gemini-3.1-flash]
           description: |
             TTS model key from src/lib/tts-models.ts. Used as the initial
             value of ui.ttsModelKey when a book has no persisted TTS-model
@@ -1864,7 +1864,7 @@ components:
         defaultTtsEngine: { type: string, enum: [local, gemini] }
         defaultTtsModelKey:
           type: string
-          enum: [kokoro-v1, coqui-xtts-v2, gemini-2.5-flash, gemini-3.1-flash]
+          enum: [kokoro-v1, qwen3-tts-0.6b, coqui-xtts-v2, gemini-2.5-flash, gemini-3.1-flash]
         sidecarUrl: { type: string }
         analysisEngine: { type: string, enum: [local, gemini] }
         ollamaUrl: { type: string }
@@ -2393,7 +2393,7 @@ components:
             the next page reload.
         audioModelKey:
           type: string
-          enum: [kokoro-v1, coqui-xtts-v2, gemini-2.5-flash, gemini-3.1-flash]
+          enum: [kokoro-v1, qwen3-tts-0.6b, coqui-xtts-v2, gemini-2.5-flash, gemini-3.1-flash]
           description: |
             Only on `chapter_complete` — the TTS model key that produced
             this chapter's audio. Carries the engine forward so the
@@ -2517,7 +2517,7 @@ components:
       properties:
         modelKey:
           type: string
-          enum: [kokoro-v1, coqui-xtts-v2, gemini-2.5-flash, gemini-3.1-flash]
+          enum: [kokoro-v1, qwen3-tts-0.6b, coqui-xtts-v2, gemini-2.5-flash, gemini-3.1-flash]
           description: UI-stable TTS model key. The engine prefix (kokoro-, coqui-, gemini-) drives provider selection server-side.
         voice:
           type: object
@@ -2583,7 +2583,7 @@ components:
         cached: { type: boolean }
         modelKey:
           type: string
-          enum: [kokoro-v1, coqui-xtts-v2, gemini-2.5-flash, gemini-3.1-flash]
+          enum: [kokoro-v1, qwen3-tts-0.6b, coqui-xtts-v2, gemini-2.5-flash, gemini-3.1-flash]
 
     # --- Voice library ---------------------------------------------
     TtsVoiceAssignment:
@@ -3218,7 +3218,7 @@ components:
           }
         audioModelKey:
           type: string
-          enum: [kokoro-v1, coqui-xtts-v2, gemini-2.5-flash, gemini-3.1-flash]
+          enum: [kokoro-v1, qwen3-tts-0.6b, coqui-xtts-v2, gemini-2.5-flash, gemini-3.1-flash]
           description: |
             TTS model key that produced this chapter's existing audio
             file. Stamped at render time and backfilled from the
@@ -3281,7 +3281,7 @@ components:
               excluded: { type: boolean }
               audioModelKey:
                 type: string
-                enum: [kokoro-v1, coqui-xtts-v2, gemini-2.5-flash, gemini-3.1-flash]
+                enum: [kokoro-v1, qwen3-tts-0.6b, coqui-xtts-v2, gemini-2.5-flash, gemini-3.1-flash]
               audioRenderedAt: { type: string, format: date-time }
               titleOverridden: { type: boolean }
         sentenceRemap:

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1298,7 +1298,7 @@ export interface components {
              *     choice (seed-only). Default for new accounts is `kokoro-v1`.
              * @enum {string}
              */
-            defaultTtsModelKey: "kokoro-v1" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
+            defaultTtsModelKey: "kokoro-v1" | "qwen3-tts-0.6b" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
             /**
              * @description Overrides the LOCAL_TTS_URL env var. Re-read on every request
              *     by the sidecar provider + health probe.
@@ -1445,7 +1445,7 @@ export interface components {
             /** @enum {string} */
             defaultTtsEngine?: "local" | "gemini";
             /** @enum {string} */
-            defaultTtsModelKey?: "kokoro-v1" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
+            defaultTtsModelKey?: "kokoro-v1" | "qwen3-tts-0.6b" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
             sidecarUrl?: string;
             /** @enum {string} */
             analysisEngine?: "local" | "gemini";
@@ -1818,7 +1818,7 @@ export interface components {
              *     `docs/features/35-engine-drift-detection.md`.
              * @enum {string}
              */
-            audioModelKey?: "kokoro-v1" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
+            audioModelKey?: "kokoro-v1" | "qwen3-tts-0.6b" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
             errorReason?: string | null;
             /**
              * @description On `progress`, `chapter_assembling`, `chapter_complete`,
@@ -1903,7 +1903,7 @@ export interface components {
              * @description UI-stable TTS model key. The engine prefix (kokoro-, coqui-, gemini-) drives provider selection server-side.
              * @enum {string}
              */
-            modelKey: "kokoro-v1" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
+            modelKey: "kokoro-v1" | "qwen3-tts-0.6b" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
             /** @description Frontend Voice payload (attributes drive the prebuilt-voice picker). */
             voice?: {
                 id?: string;
@@ -1958,7 +1958,7 @@ export interface components {
             durationSec?: number | null;
             cached: boolean;
             /** @enum {string} */
-            modelKey: "kokoro-v1" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
+            modelKey: "kokoro-v1" | "qwen3-tts-0.6b" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
         };
         /**
          * @description The TTS provider voice this Voice resolves to. Computed server-side by
@@ -2396,7 +2396,7 @@ export interface components {
              *     `docs/features/35-engine-drift-detection.md`).
              * @enum {string}
              */
-            audioModelKey?: "kokoro-v1" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
+            audioModelKey?: "kokoro-v1" | "qwen3-tts-0.6b" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
             /**
              * Format: date-time
              * @description ISO timestamp from when the audio was synthesised. Mirrors
@@ -2441,7 +2441,7 @@ export interface components {
                 duration?: string;
                 excluded?: boolean;
                 /** @enum {string} */
-                audioModelKey?: "kokoro-v1" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
+                audioModelKey?: "kokoro-v1" | "qwen3-tts-0.6b" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
                 /** Format: date-time */
                 audioRenderedAt?: string;
                 titleOverridden?: boolean;
@@ -3766,7 +3766,7 @@ export interface operations {
                      * @description TTS model key. Local engines (kokoro-, coqui-) route to the sidecar; gemini-* keys route to Google's TTS API.
                      * @enum {string}
                      */
-                    modelKey: "kokoro-v1" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
+                    modelKey: "kokoro-v1" | "qwen3-tts-0.6b" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
                     /** @description Optional subset of chapters to (re)generate. Defaults to all chapters lacking an audio file. */
                     chapterIds?: number[];
                     /** @description Re-synthesise even if an audio file already exists on disk. */

--- a/src/lib/tts-models.test.ts
+++ b/src/lib/tts-models.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TTS_ENGINES,
+  TTS_MODEL_OPTIONS,
+  ttsModelLabel,
+  engineForModelKey,
+  engineGroupForModelKey,
+} from './tts-models';
+
+describe('tts-models catalog includes Qwen3-TTS (plan 108)', () => {
+  it('lists qwen3-tts-0.6b under the Local engine group (so it shows in the model dropdowns)', () => {
+    const local = TTS_ENGINES.find((g) => g.id === 'local');
+    expect(local, 'local engine group exists').toBeTruthy();
+    const ids = local!.models.map((m) => m.id);
+    expect(ids).toContain('qwen3-tts-0.6b');
+    expect(ids).toContain('kokoro-v1'); // unchanged
+  });
+
+  it('exposes qwen in the flat option list with a label', () => {
+    expect(TTS_MODEL_OPTIONS.map((m) => m.id)).toContain('qwen3-tts-0.6b');
+    expect(ttsModelLabel('qwen3-tts-0.6b')).toBe('Qwen3-TTS 0.6B');
+  });
+
+  it('routes the qwen model key to the qwen engine + the local group', () => {
+    expect(engineForModelKey('qwen3-tts-0.6b')).toBe('qwen');
+    expect(engineGroupForModelKey('qwen3-tts-0.6b')).toBe('local');
+  });
+
+  it('keeps the existing engine routing intact', () => {
+    expect(engineForModelKey('kokoro-v1')).toBe('kokoro');
+    expect(engineForModelKey('coqui-xtts-v2')).toBe('coqui');
+    expect(engineForModelKey('gemini-2.5-flash')).toBe('gemini');
+    expect(engineGroupForModelKey('gemini-2.5-flash')).toBe('gemini');
+  });
+});

--- a/src/lib/tts-models.ts
+++ b/src/lib/tts-models.ts
@@ -31,6 +31,11 @@ export const TTS_ENGINES: TtsEngineGroup[] = [
     models: [
       { id: 'kokoro-v1', label: 'Kokoro v1', hint: 'Default · 28 English voices · quality-tuned' },
       {
+        id: 'qwen3-tts-0.6b',
+        label: 'Qwen3-TTS 0.6B',
+        hint: 'Bespoke per-character voices · designed from a persona',
+      },
+      {
         id: 'coqui-xtts-v2',
         label: 'Coqui XTTS v2',
         hint: 'Alternate · 30 baked voices · zero-shot cloning',
@@ -70,10 +75,13 @@ export const DEFAULT_TTS_MODEL: TtsModelKey = FRONTEND_ACCOUNT_DEFAULTS.defaultT
 /* Mirror of the backend's engineForModelKey — keeps the UI honest about
    which sidecar/cloud it will hit when a sample is requested. Add new
    prefixes here in lockstep with server/src/tts/index.ts. */
-export function engineForModelKey(key: TtsModelKey): 'coqui' | 'piper' | 'kokoro' | 'gemini' {
+export function engineForModelKey(
+  key: TtsModelKey,
+): 'coqui' | 'piper' | 'kokoro' | 'qwen' | 'gemini' {
   if (key.startsWith('coqui-')) return 'coqui';
   if (key.startsWith('piper-')) return 'piper';
   if (key.startsWith('kokoro-')) return 'kokoro';
+  if (key.startsWith('qwen')) return 'qwen';
   return 'gemini';
 }
 

--- a/src/views/confirm-cast.tsx
+++ b/src/views/confirm-cast.tsx
@@ -254,7 +254,7 @@ export function ConfirmCastView({
 interface CardProps {
   character: Character;
   voice: Voice | undefined;
-  ttsEngine: 'coqui' | 'gemini' | 'piper' | 'kokoro';
+  ttsEngine: 'coqui' | 'gemini' | 'piper' | 'kokoro' | 'qwen';
   decision: Decision | undefined;
   onDecision: (d: Decision) => void;
   /** Current state of the "Update library profile from this manuscript"
@@ -292,7 +292,7 @@ function CharacterList({
 }: {
   characters: Character[];
   findVoice: (id: string | undefined) => Voice | undefined;
-  ttsEngine: 'coqui' | 'gemini' | 'piper' | 'kokoro';
+  ttsEngine: 'coqui' | 'gemini' | 'piper' | 'kokoro' | 'qwen';
   decisions: Record<string, Decision>;
   setDecisions: (d: Record<string, Decision>) => void;
   overrides: Record<string, boolean>;


### PR DESCRIPTION
## Summary

Plan 108 follow-up — Qwen3-TTS was wired server-side but never surfaced in the UI model selectors (Account 'Defaults for new books' + the Voices-view Engine/Model picker both showed only Kokoro + Coqui).

Root causes + fixes:
- The frontend model catalog `src/lib/tts-models.ts` (`TTS_ENGINES` local group) omitted `qwen3-tts-0.6b`, and its `engineForModelKey` mirror didn't handle the `qwen` prefix → added Qwen to the local group (with a bespoke-voice hint) + taught `engineForModelKey` the prefix (return type widened to include `'qwen'`).
- The frontend `TtsModelKey` derives from openapi `VoiceSampleRequest.modelKey`, whose enum (repeated 9× across schemas) never listed `qwen3-tts-0.6b` → added it to all 9 enums + regenerated `api-types.ts`.
- Widened the `CharacterList` engine prop unions in `confirm-cast.tsx` (the wider `engineForModelKey` return flowed there).

One catalog fix covers every model-dropdown surface (account, voices, generation, confirm).

## Test plan

New `src/lib/tts-models.test.ts` pins Qwen in the local group + the engine/group routing + unchanged routing for the others. `typecheck` + `lint` clean; full frontend suite (1688) green; pre-push `npm run verify` passed (e2e flaked once on the server-startup race, green on retry).