### PR TITLE
refactor(frontend): activeStream -> per-book map (plan 111 wave 2)

### DIFF
--- a/docs/features/111-queue-worker-pool.md
+++ b/docs/features/111-queue-worker-pool.md
@@ -6,7 +6,7 @@ owner: null
 
 # Persisted queue as the single source of truth + N configurable generation workers
 
-> Status: active (Wave 1 shipped — the `generationWorkers` setting; Waves 2–4 in flight)
+> Status: active (Waves 1–2 shipped — the `generationWorkers` setting + the per-book `activeStreams` map; Waves 3–4 in flight)
 > Key files: `src/store/generation-stream-runner.ts`, `src/store/queue-dispatcher-middleware.ts`, `src/store/chapters-slice.ts`, `src/store/generation-stream-middleware.ts`, `server/src/routes/generation.ts`, `src/views/account.tsx`
 > URL surface: `#/books/<id>/generate`, global queue modal + top-bar pill, Account view
 > OpenAPI ops: `GET/PUT /api/user/settings` (new `generationWorkers` field); generation SSE unchanged
@@ -30,7 +30,7 @@ Completes plan 102's intended migration. The leftover "generating override" — 
 ## Wave sequence (each wave = one PR, ordered so there is NO parallelism-regression window)
 
 - **Wave 1 (shipped) — `generationWorkers` setting end-to-end.** openapi `UserSettings`/`UserSettingsPatch`; `server/src/workspace/user-settings.ts` (`z.number().int().min(1).max(4)`, default 2, `getResolvedGenerationWorkers()` resolver: `GEN_WORKERS` env > legacy `GEN_CHAPTER_CONCURRENCY` env > setting > 2); `generation.ts` pool width reads the resolver; `account-defaults.ts` + `account-slice.ts` (`setGenerationWorkers`) + `account.tsx` (number input). The setting immediately tunes within-book fan-out via the existing pool; cross-book lands in Wave 3. No behavior change at the default (2).
-- **Wave 2 — `activeStream` → per-book map (client-only).** `activeStreams: Record<bookId, snapshot>` + reducers + `selectActiveStreams`/`selectAnyActiveStream`; migrate the top-bar pill (aggregate), broadcast-middleware, local-analyzer guard. Runner still single-handle (N=1, behaviour identical).
+- **Wave 2 (shipped) — `activeStream` → per-book map (client-only).** `activeStreams: Record<bookId, snapshot>` + reducers (`setActiveStream` keyed by bookId, `clearActiveStream(bookId)`, `updateActiveStreamProgress({bookId,…})`) + `selectActiveStreams`/`selectAnyActiveStream`; cross-book guard reframed for the map; migrated the top-bar pill (aggregates done/total/inProgress, stalled iff every stream quiet, onClick → queue modal when >1 book), broadcast-middleware (wire still one snapshot), local-analyzer guard, queue-slice Part-A overlay selectors, dispatcher single-in-flight gate. Runner still single-handle (N=1, behaviour identical).
 - **Wave 3 — worker pool.** Runner → `Map<bookId, handle>` + per-stream tick routing; dispatcher fills up to N slots (claim Set, group-by-book), reads `generationWorkers`; remove the `hasWork` override + add the enqueue-on-work observer; collapse the `regenerateChapter` round-trip. Client concurrency goes live here.
 - **Wave 4 — retire `GEN_CHAPTER_CONCURRENCY`.** Drop the legacy env-name fallback; rename test env to `GEN_WORKERS`; update plan-87 test/doc descriptions. Cleanup, strictly after Wave 3.
 

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -5,7 +5,7 @@ import { useAppDispatch, useAppSelector, useAppSelectorShallow } from '../store'
 import { uiActions } from '../store/ui-slice';
 import { castActions } from '../store/cast-slice';
 import { fetchAccountSettings } from '../store/account-slice';
-import { chaptersActions, STALL_THRESHOLD_MS } from '../store/chapters-slice';
+import { chaptersActions, selectActiveStreams, STALL_THRESHOLD_MS } from '../store/chapters-slice';
 import { manuscriptActions } from '../store/manuscript-slice';
 import { analysisActions } from '../store/analysis-slice';
 import { revisionsActions, selectDriftGroupsByBook } from '../store/revisions-slice';
@@ -104,7 +104,7 @@ export function Layout() {
      array identity is structurally unchanged. */
   const characters = useAppSelectorShallow((s) => s.cast.characters);
   const chapters = useAppSelectorShallow((s) => s.chapters.chapters);
-  const activeStream = useAppSelector((s) => s.chapters.activeStream);
+  const activeStreams = useAppSelectorShallow(selectActiveStreams);
   const analysisStream = useAppSelector((s) => s.analysis.activeStream);
   const driftGroupsByBook = useAppSelector(selectDriftGroupsByBook);
   const bookMetaSaved = useAppSelector((s) => s.bookMeta.saved);
@@ -792,7 +792,7 @@ export function Layout() {
      keeps the SSE open across all navigation; this is purely a UI tick to
      surface elapsed-since-last-tick. */
   const [, forceClockTick] = useState(0);
-  const pillAlive = activeStream != null;
+  const pillAlive = activeStreams.length > 0;
   useEffect(() => {
     if (!pillAlive) return;
     const id = setInterval(() => forceClockTick((n) => n + 1), 1000);
@@ -807,21 +807,35 @@ export function Layout() {
      Computed inline (not memoised) so the per-second forceClockTick above
      keeps the "stalled" check fresh against Date.now(). */
   const generationPill: GenerationPillData | null = (() => {
-    if (!activeStream) return null;
-    const { bookId: streamBookId, done, total, inProgress, lastTickAt, halted } = activeStream;
+    if (activeStreams.length === 0) return null;
+    /* Aggregate across every open stream (Wave 3 may have several books
+       generating at once). With one stream this is byte-identical to the
+       prior single-snapshot pill. */
+    const done = activeStreams.reduce((acc, s) => acc + s.done, 0);
+    const total = activeStreams.reduce((acc, s) => acc + s.total, 0);
+    const inProgress = activeStreams.reduce((acc, s) => acc + s.inProgress, 0);
+    const halted = activeStreams.some((s) => s.halted);
     const percent = total > 0 ? Math.round((done / total) * 100) : 0;
+    /* Stalled only when EVERY in-flight stream is quiet — one moving stream
+       means the run is alive. */
     const stalled =
       !halted &&
       inProgress > 0 &&
-      lastTickAt != null &&
-      Date.now() - lastTickAt > STALL_THRESHOLD_MS;
+      activeStreams.every(
+        (s) => s.lastTickAt != null && Date.now() - s.lastTickAt > STALL_THRESHOLD_MS,
+      );
     const state: GenerationPillData['state'] = halted ? 'halted' : stalled ? 'stalled' : 'running';
     return {
       state,
       done,
       total,
       percent,
-      onClick: () => navigate(`/books/${streamBookId}/generate`),
+      /* One book → jump to its Generate view; several → open the queue modal
+         (no single book to navigate to). */
+      onClick:
+        activeStreams.length === 1
+          ? () => navigate(`/books/${activeStreams[0].bookId}/generate`)
+          : () => dispatch(uiActions.openQueueModal()),
     };
   })();
 

--- a/src/hooks/use-local-analyzer-guard.tsx
+++ b/src/hooks/use-local-analyzer-guard.tsx
@@ -35,6 +35,7 @@
 
 import { useState, type ReactNode } from 'react';
 import { useAppDispatch, useAppSelector } from '../store';
+import { selectAnyActiveStream } from '../store/chapters-slice';
 import { haltActiveGeneration } from '../store/queue-thunks';
 import { MODEL_OPTIONS } from '../lib/models';
 import { ConfirmDialog } from '../modals/confirm-dialog';
@@ -61,7 +62,10 @@ interface GuardResult {
 export function useLocalAnalyzerGuard({ generatingBookTitle }: GuardOptions = {}): GuardResult {
   const dispatch = useAppDispatch();
   const selectedModel = useAppSelector((s) => s.ui.selectedModel);
-  const activeStream = useAppSelector((s) => s.chapters.activeStream);
+  const anyActiveStream = useAppSelector(selectAnyActiveStream);
+  /* A representative generating book for the modal copy (advisory). Stable
+     string read so this hook doesn't re-render on every progress tick. */
+  const activeBookId = useAppSelector((s) => Object.keys(s.chapters.activeStreams)[0] ?? null);
   const libraryBooks = useAppSelector((s) => s.library.books);
 
   /* Stash the proceed callback in state — the modal needs to call it on
@@ -74,7 +78,7 @@ export function useLocalAnalyzerGuard({ generatingBookTitle }: GuardOptions = {}
   const engine = MODEL_OPTIONS.find((m) => m.id === selectedModel)?.engine ?? 'gemini';
 
   const guard: GuardResult['guard'] = (proceed) => {
-    if (engine !== 'local' || !activeStream) {
+    if (engine !== 'local' || !anyActiveStream) {
       proceed();
       return;
     }
@@ -83,11 +87,11 @@ export function useLocalAnalyzerGuard({ generatingBookTitle }: GuardOptions = {}
 
   const close = () => setPending(null);
 
-  const titleFromLibrary = activeStream
-    ? (libraryBooks.find((b) => b.bookId === activeStream.bookId)?.title ?? null)
+  const titleFromLibrary = activeBookId
+    ? (libraryBooks.find((b) => b.bookId === activeBookId)?.title ?? null)
     : null;
   const resolvedTitle =
-    generatingBookTitle ?? titleFromLibrary ?? activeStream?.bookId ?? 'the other book';
+    generatingBookTitle ?? titleFromLibrary ?? activeBookId ?? 'the other book';
 
   const modal = (
     <ConfirmDialog

--- a/src/modals/edit-chapter-title.test.tsx
+++ b/src/modals/edit-chapter-title.test.tsx
@@ -56,7 +56,7 @@ function renderModal(
         regenEpoch: 0,
         lastTickAt: null,
         currentBookId: null,
-        activeStream: null,
+        activeStreams: {},
       },
     },
   });

--- a/src/modals/queue-modal.test.tsx
+++ b/src/modals/queue-modal.test.tsx
@@ -96,7 +96,9 @@ function renderModal(
         ...chaptersSlice.getInitialState(),
         ...(opts.activeGeneration
           ? {
-              activeStream: opts.activeGeneration.activeStream,
+              activeStreams: {
+                [opts.activeGeneration.activeStream.bookId]: opts.activeGeneration.activeStream,
+              },
               currentBookId: opts.activeGeneration.currentBookId,
               chapters: (opts.activeGeneration.chapters ??
                 []) as ReturnType<typeof chaptersSlice.reducer>['chapters'],

--- a/src/store/broadcast-middleware.test.ts
+++ b/src/store/broadcast-middleware.test.ts
@@ -472,7 +472,7 @@ describe('broadcastMiddleware — inbound', () => {
         snapshot: chaptersSnap,
       },
     );
-    expect(store.getState().chapters.activeStream).toEqual(chaptersSnap);
+    expect(store.getState().chapters.activeStreams).toEqual({ [chaptersSnap.bookId]: chaptersSnap });
     expect(mock.sent).toHaveLength(0);
   });
 
@@ -564,7 +564,7 @@ describe('broadcastMiddleware — inbound', () => {
       },
     );
     expect(store.getState().analysis.activeStream).toEqual(yokoSnap);
-    expect(store.getState().chapters.activeStream).toBeNull();
+    expect(store.getState().chapters.activeStreams).toEqual({});
     expect(mock.sent).toHaveLength(0);
   });
 
@@ -574,7 +574,7 @@ describe('broadcastMiddleware — inbound', () => {
     onmsg({ data: null } as MessageEvent);
     onmsg({ data: { kind: 'sync:unknown', instanceId: 'x', bookId: null, mode: 'full' } } as MessageEvent);
     expect(store.getState().analysis.activeStream).toBeNull();
-    expect(store.getState().chapters.activeStream).toBeNull();
+    expect(store.getState().chapters.activeStreams).toEqual({});
   });
 });
 

--- a/src/store/broadcast-middleware.ts
+++ b/src/store/broadcast-middleware.ts
@@ -174,7 +174,7 @@ const CHAPTERS_BROADCAST_ACTIONS: ReadonlySet<string> = new Set([
     locally to avoid a circular type back through `RootState`. */
 interface BroadcastableRootState {
   analysis: { activeStream: AnalysisStreamSnapshot | null };
-  chapters: { activeStream: ActiveStreamSnapshot | null };
+  chapters: { activeStreams: Record<string, ActiveStreamSnapshot> };
 }
 
 /** Random 16-char hex id. Crypto-grade not required — collision risk
@@ -316,7 +316,9 @@ export function createBroadcastMiddleware(opts?: {
           } else if (msg.mode === 'full') {
             store.dispatch(chaptersActions.applyExternalChaptersSnapshot(msg.snapshot));
           } else if (msg.mode === 'diff') {
-            const current = (store.getState() as BroadcastableRootState).chapters.activeStream;
+            const current =
+              Object.values((store.getState() as BroadcastableRootState).chapters.activeStreams)[0] ??
+              null;
             if (current) {
               store.dispatch(
                 chaptersActions.applyExternalChaptersSnapshot({ ...current, ...msg.diff }),
@@ -408,7 +410,10 @@ export function createBroadcastMiddleware(opts?: {
 
       if (CHAPTERS_BROADCAST_ACTIONS.has(type)) {
         const state = store.getState() as BroadcastableRootState;
-        const snapshot = state.chapters.activeStream;
+        /* The wire still carries a single snapshot. Through Wave 2 there is at
+           most one open stream, so the single value is unambiguous; pick the
+           first if several ever coexist (the pill aggregates locally anyway). */
+        const snapshot = Object.values(state.chapters.activeStreams)[0] ?? null;
         const bookId = snapshot?.bookId ?? null;
         const now = outbound.now();
 

--- a/src/store/chapters-slice.test.ts
+++ b/src/store/chapters-slice.test.ts
@@ -1,7 +1,14 @@
 // Pairs with docs/features/16-generation-stream.md
 
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
-import { chaptersSlice, chaptersActions, type ChaptersState } from './chapters-slice';
+import {
+  chaptersSlice,
+  chaptersActions,
+  selectActiveStreams,
+  selectAnyActiveStream,
+  type ActiveStreamSnapshot,
+  type ChaptersState,
+} from './chapters-slice';
 import type { Chapter, GenerationTick } from '../lib/types';
 
 const makeChapter = (id: number, overrides: Partial<Chapter> = {}): Chapter => ({
@@ -20,7 +27,7 @@ const baseState = (chapters: Chapter[]): ChaptersState => ({
   generationStartedAt: null,
   lastTickAt: null,
   currentBookId: null,
-  activeStream: null,
+  activeStreams: {},
 });
 
 const tick = (t: Partial<GenerationTick> & { type: GenerationTick['type'] }): GenerationTick =>
@@ -936,7 +943,7 @@ describe('chaptersSlice — applyExternalChaptersSnapshot (cross-tab inbound, pl
      stay untouched (broadcasting them would fan out regen side-
      effects across tabs, which is the racing-writes case parked
      as Won't #3). */
-  it('replaces activeStream verbatim with the inbound snapshot', () => {
+  it('mirrors the inbound snapshot as the per-book stream map', () => {
     const sibling = {
       bookId: 'book-sibling',
       modelKey: 'kokoro-v1' as const,
@@ -951,7 +958,7 @@ describe('chaptersSlice — applyExternalChaptersSnapshot (cross-tab inbound, pl
       start,
       chaptersActions.applyExternalChaptersSnapshot(sibling),
     );
-    expect(next.activeStream).toEqual(sibling);
+    expect(next.activeStreams).toEqual({ 'book-sibling': sibling });
     /* Per-chapter rows / pendingRegen / regenEpoch UNCHANGED — proves
        the cross-tab message doesn't contaminate per-tab UI state.
        This is the cross-bookId-isolation invariant the plan locks in. */
@@ -962,21 +969,97 @@ describe('chaptersSlice — applyExternalChaptersSnapshot (cross-tab inbound, pl
   it('accepts null to mirror a sibling clearActiveStream', () => {
     const start: ChaptersState = {
       ...baseState([]),
-      activeStream: {
-        bookId: 'book-x',
-        modelKey: 'kokoro-v1',
-        done: 5,
-        total: 10,
-        inProgress: 0,
-        lastTickAt: 1000,
-        halted: false,
+      activeStreams: {
+        'book-x': {
+          bookId: 'book-x',
+          modelKey: 'kokoro-v1',
+          done: 5,
+          total: 10,
+          inProgress: 0,
+          lastTickAt: 1000,
+          halted: false,
+        },
       },
     };
     const next = chaptersSlice.reducer(
       start,
       chaptersActions.applyExternalChaptersSnapshot(null),
     );
-    expect(next.activeStream).toBeNull();
+    expect(next.activeStreams).toEqual({});
+  });
+});
+
+describe('chaptersSlice — activeStreams per-book map (plan 111 Wave 2)', () => {
+  const snap = (bookId: string, over: Partial<ActiveStreamSnapshot> = {}): ActiveStreamSnapshot => ({
+    bookId,
+    modelKey: 'kokoro-v1',
+    done: 0,
+    total: 5,
+    inProgress: 1,
+    lastTickAt: 1000,
+    halted: false,
+    ...over,
+  });
+
+  it('setActiveStream keys by bookId so concurrent streams coexist', () => {
+    let s = chaptersSlice.reducer(baseState([]), chaptersActions.setActiveStream(snap('book-A')));
+    s = chaptersSlice.reducer(s, chaptersActions.setActiveStream(snap('book-B', { done: 2 })));
+    expect(Object.keys(s.activeStreams).sort()).toEqual(['book-A', 'book-B']);
+    expect(s.activeStreams['book-B'].done).toBe(2);
+  });
+
+  it('clearActiveStream(bookId) removes only that book’s stream', () => {
+    let s = chaptersSlice.reducer(baseState([]), chaptersActions.setActiveStream(snap('book-A')));
+    s = chaptersSlice.reducer(s, chaptersActions.setActiveStream(snap('book-B')));
+    s = chaptersSlice.reducer(s, chaptersActions.clearActiveStream('book-A'));
+    expect(Object.keys(s.activeStreams)).toEqual(['book-B']);
+  });
+
+  it('updateActiveStreamProgress targets the named book and bumps lastTickAt', () => {
+    let s = chaptersSlice.reducer(baseState([]), chaptersActions.setActiveStream(snap('book-A')));
+    s = chaptersSlice.reducer(s, chaptersActions.setActiveStream(snap('book-B')));
+    s = chaptersSlice.reducer(
+      s,
+      chaptersActions.updateActiveStreamProgress({ bookId: 'book-B', done: 4, inProgress: 2 }),
+    );
+    expect(s.activeStreams['book-B'].done).toBe(4);
+    expect(s.activeStreams['book-B'].inProgress).toBe(2);
+    /* book-A untouched. */
+    expect(s.activeStreams['book-A'].done).toBe(0);
+    /* No-op when the book has no open stream. */
+    const after = chaptersSlice.reducer(
+      s,
+      chaptersActions.updateActiveStreamProgress({ bookId: 'book-Z', done: 9 }),
+    );
+    expect(after.activeStreams['book-Z']).toBeUndefined();
+  });
+
+  it('selectActiveStreams / selectAnyActiveStream read the map', () => {
+    const empty = { chapters: baseState([]) };
+    expect(selectActiveStreams(empty)).toEqual([]);
+    expect(selectAnyActiveStream(empty)).toBe(false);
+    const live = {
+      chapters: chaptersSlice.reducer(baseState([]), chaptersActions.setActiveStream(snap('book-A'))),
+    };
+    expect(selectActiveStreams(live).map((x) => x.bookId)).toEqual(['book-A']);
+    expect(selectAnyActiveStream(live)).toBe(true);
+  });
+
+  it('cross-book guard: a tick is dropped when a stream is open but not for the viewed book', () => {
+    /* Slice holds book-A rows; a stream is open for book-B only. A progress
+       tick for chapter 1 (which exists in book-A's rows) must NOT mutate them
+       — it belongs to book-B (chapter ids collide across books). */
+    let s: ChaptersState = {
+      ...baseState([makeChapter(1, { state: 'queued' })]),
+      currentBookId: 'book-A',
+    };
+    s = chaptersSlice.reducer(s, chaptersActions.setActiveStream(snap('book-B')));
+    const after = chaptersSlice.reducer(
+      s,
+      chaptersActions.applyGenerationTick({ type: 'progress', chapterId: 1, progress: 0.9 } as GenerationTick),
+    );
+    expect(after.chapters[0].state).toBe('queued');
+    expect(after.chapters[0].progress).toBe(0);
   });
 });
 

--- a/src/store/chapters-slice.ts
+++ b/src/store/chapters-slice.ts
@@ -74,9 +74,12 @@ export interface ChaptersState {
       mid-run the slice gets repopulated with that book's rows, and ticks
       from the still-running stream would otherwise clobber them. */
   currentBookId: string | null;
-  /** Cross-book progress snapshot — see ActiveStreamSnapshot. Non-null
-      means a generation stream is open somewhere. */
-  activeStream: ActiveStreamSnapshot | null;
+  /** Cross-book progress snapshots, keyed by bookId — see ActiveStreamSnapshot.
+      A non-empty map means at least one generation stream is open somewhere.
+      Through plan 111 Wave 2 the runner is still single-handle, so this holds
+      0 or 1 entries; Wave 3's worker pool populates several (one per book
+      generating concurrently). */
+  activeStreams: Record<string, ActiveStreamSnapshot>;
 }
 
 const initialState: ChaptersState = {
@@ -85,7 +88,7 @@ const initialState: ChaptersState = {
   generationStartedAt: null,
   lastTickAt: null,
   currentBookId: null,
-  activeStream: null,
+  activeStreams: {},
 };
 
 export const chaptersSlice = createSlice({
@@ -119,18 +122,20 @@ export const chaptersSlice = createSlice({
       s.currentBookId = a.payload;
     },
 
-    /** Middleware → slice handshake: sets the cross-book snapshot when a
-        stream opens, and replaces it on every non-idle tick with a fresh
-        derive of done/total/inProgress/lastTickAt. */
+    /** Middleware → slice handshake: sets the cross-book snapshot for a book
+        when its stream opens, and replaces it on every non-idle tick with a
+        fresh derive of done/total/inProgress/lastTickAt. Keyed by the
+        snapshot's own bookId so concurrent streams (Wave 3) don't clobber
+        each other. */
     setActiveStream: (s, a: PayloadAction<ActiveStreamSnapshot>) => {
-      s.activeStream = a.payload;
+      s.activeStreams[a.payload.bookId] = a.payload;
     },
 
-    /** Middleware → slice handshake: cleared on closeHandle (pause,
-        queue drain, store teardown). The header pill hides entirely when
-        this is null. */
-    clearActiveStream: (s) => {
-      s.activeStream = null;
+    /** Middleware → slice handshake: cleared on closeHandle (pause, queue
+        drain, store teardown) for the book whose stream closed. The header
+        pill hides entirely when no streams remain. */
+    clearActiveStream: (s, a: PayloadAction<string>) => {
+      delete s.activeStreams[a.payload];
     },
 
     /** Bug E — cross-book heartbeat + counter refresh from a server tick
@@ -141,17 +146,18 @@ export const chaptersSlice = createSlice({
         per-chapter tick reducer's cross-book guard would otherwise drop
         the tick on the floor. Slice-matches-handle path keeps using
         `setActiveStream(snapshotFromChapters(...))` because the slice
-        rows are authoritative there. */
+        rows are authoritative there. Targets the snapshot for `bookId`. */
     updateActiveStreamProgress: (
       s,
-      a: PayloadAction<{ done?: number; total?: number; inProgress?: number }>,
+      a: PayloadAction<{ bookId: string; done?: number; total?: number; inProgress?: number }>,
     ) => {
-      if (!s.activeStream) return;
-      s.activeStream.lastTickAt = Date.now();
+      const snap = s.activeStreams[a.payload.bookId];
+      if (!snap) return;
+      snap.lastTickAt = Date.now();
       const { done, total, inProgress } = a.payload;
-      if (done != null) s.activeStream.done = done;
-      if (total != null) s.activeStream.total = total;
-      if (inProgress != null) s.activeStream.inProgress = inProgress;
+      if (done != null) snap.done = done;
+      if (total != null) snap.total = total;
+      if (inProgress != null) snap.inProgress = inProgress;
     },
 
     hydrateFromAnalysis: (s, a: PayloadAction<AnalyseResponse>) => {
@@ -276,9 +282,21 @@ export const chaptersSlice = createSlice({
          slice gets re-hydrated with that other book's chapter rows. The
          middleware's still-open handle keeps streaming for the original
          book, but its ticks must NOT mutate the now-irrelevant slice — the
-         cross-book progress snapshot (activeStream) keeps the header pill
-         alive instead. The middleware updates activeStream out-of-band. */
-      if (s.activeStream && s.currentBookId && s.activeStream.bookId !== s.currentBookId) return;
+         cross-book progress snapshot (activeStreams) keeps the header pill
+         alive instead. The middleware updates activeStreams out-of-band.
+
+         Map form: if a stream is open but NOT for the viewed book, this tick
+         is for another book — drop it (chapter ids collide across books).
+         Through Wave 2 there is at most one open stream, so this is exactly
+         the old `activeStream.bookId !== currentBookId` guard; Wave 3 routes
+         ticks by bookId in the runner so a viewed-book stream + foreign-book
+         stream can't be confused. */
+      if (
+        s.currentBookId &&
+        Object.keys(s.activeStreams).length > 0 &&
+        !s.activeStreams[s.currentBookId]
+      )
+        return;
 
       /* Start the ETA clock on the first real progress signal of a run. */
       if (
@@ -609,7 +627,10 @@ export const chaptersSlice = createSlice({
        reflects the sibling activity. Echo suppression lives in the
        middleware (instanceId tag on outbound, ignore self-broadcasts). */
     applyExternalChaptersSnapshot: (s, a: PayloadAction<ActiveStreamSnapshot | null>) => {
-      s.activeStream = a.payload;
+      /* The broadcast wire still carries a single snapshot (a sibling tab has
+         at most one stream through Wave 2). Mirror it as the whole map: a
+         snapshot replaces the map with just that book; null clears it. */
+      s.activeStreams = a.payload ? { [a.payload.bookId]: a.payload } : {};
     },
 
     batchRegenerateCharacters: (
@@ -650,3 +671,20 @@ export const chaptersSlice = createSlice({
 });
 
 export const chaptersActions = chaptersSlice.actions;
+
+/* --- Active-stream selectors (plan 111 Wave 2) ----------------------------
+   The single `activeStream` field became a per-book map; these give consumers
+   a stable read surface that works whether 0, 1, or N streams are open. */
+
+interface ChaptersRootShape {
+  chapters: ChaptersState;
+}
+
+/** All open generation streams (one per book generating). Empty when idle. */
+export const selectActiveStreams = (s: ChaptersRootShape): ActiveStreamSnapshot[] =>
+  Object.values(s.chapters.activeStreams);
+
+/** True when any generation stream is open. Replaces the old
+    `if (chapters.activeStream)` truthiness checks. */
+export const selectAnyActiveStream = (s: ChaptersRootShape): boolean =>
+  Object.keys(s.chapters.activeStreams).length > 0;

--- a/src/store/generation-stream-middleware.test.ts
+++ b/src/store/generation-stream-middleware.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { configureStore } from '@reduxjs/toolkit';
-import { chaptersSlice } from './chapters-slice';
+import { chaptersSlice, type ActiveStreamSnapshot } from './chapters-slice';
 import { manuscriptSlice } from './manuscript-slice';
 import { uiSlice } from './ui-slice';
 import { changeLogSlice } from './change-log-slice';
@@ -21,6 +21,13 @@ import type { Chapter, GenerationTick, Character } from '../lib/types';
 const streamGenerationMock = vi.fn();
 const cancelMock = vi.fn();
 const pauseGenerationMock = vi.fn();
+
+/* Plan 111 Wave 2 — `activeStream` became a per-book map. Through Wave 2 the
+   runner is still single-handle, so these tests assert on the single open
+   stream. */
+const firstActiveStream = (s: {
+  chapters: { activeStreams: Record<string, ActiveStreamSnapshot> };
+}): ActiveStreamSnapshot | null => Object.values(s.chapters.activeStreams)[0] ?? null;
 
 vi.mock('../lib/api', () => ({
   api: {
@@ -150,7 +157,7 @@ describe('generationStreamMiddleware', () => {
     store.dispatch(chaptersSlice.actions.requestStreamHalt());
     expect(cancelMock).toHaveBeenCalledTimes(1);
     /* clearActiveStream fires on close, so the snapshot disappears. */
-    expect(store.getState().chapters.activeStream).toBeNull();
+    expect(firstActiveStream(store.getState())).toBeNull();
 
     /* requestStreamHalt skips reconcile; a later trigger re-runs it. This
        store has no queue slice (queue.paused defaults false), so the still
@@ -218,7 +225,7 @@ describe('generationStreamMiddleware', () => {
 
     store.dispatch(uiSlice.actions.goHome());
     expect(cancelMock).toHaveBeenCalledTimes(0);
-    expect(store.getState().chapters.activeStream?.bookId).toBe('b1');
+    expect(firstActiveStream(store.getState())?.bookId).toBe('b1');
   });
 
   it('keeps the SSE alive across startNewBook (Upload screen) — the canonical "I want to import while gen runs" path', () => {
@@ -230,7 +237,7 @@ describe('generationStreamMiddleware', () => {
     store.dispatch(uiSlice.actions.goHome());
     store.dispatch(uiSlice.actions.startNewBook());
     expect(cancelMock).toHaveBeenCalledTimes(0);
-    expect(store.getState().chapters.activeStream?.bookId).toBe('b1');
+    expect(firstActiveStream(store.getState())?.bookId).toBe('b1');
   });
 
   it('keeps the SSE alive when the user opens a different book — and refuses to start a second stream for it', () => {
@@ -249,7 +256,7 @@ describe('generationStreamMiddleware', () => {
     expect(cancelMock).toHaveBeenCalledTimes(0);
     expect(streamGenerationMock).toHaveBeenCalledTimes(1);
     /* activeStream still describes the original generating book. */
-    expect(store.getState().chapters.activeStream?.bookId).toBe('b1');
+    expect(firstActiveStream(store.getState())?.bookId).toBe('b1');
   });
 
   it('keeps the SSE alive when the TTS model is switched mid-run (new model applies to the NEXT run)', () => {
@@ -311,7 +318,7 @@ describe('generationStreamMiddleware', () => {
     store.dispatch(chaptersSlice.actions.applyGenerationTick({ type: 'idle' } as GenerationTick));
 
     expect(cancelMock).toHaveBeenCalled();
-    expect(store.getState().chapters.activeStream).toBeNull();
+    expect(firstActiveStream(store.getState())).toBeNull();
 
     streamGenerationMock.mockClear();
     store.dispatch(chaptersSlice.actions.applyGenerationTick({ type: 'idle' } as GenerationTick));
@@ -412,14 +419,14 @@ describe('generationStreamMiddleware', () => {
   it('publishes an activeStream snapshot on open and clears it on close', () => {
     const store = makeStore();
     store.dispatch(uiSlice.actions.openBook({ id: 'b1', status: 'generating' }));
-    expect(store.getState().chapters.activeStream).toBeNull();
+    expect(firstActiveStream(store.getState())).toBeNull();
 
     seedBook(store, 'b1', [
       ch(1, { state: 'done', progress: 1, characters: { narrator: 'done' } }),
       ch(2, { state: 'in_progress', progress: 0.5 }),
       ch(3, { state: 'queued' }),
     ]);
-    const snap = store.getState().chapters.activeStream;
+    const snap = firstActiveStream(store.getState());
     expect(snap).not.toBeNull();
     expect(snap!.bookId).toBe('b1');
     expect(snap!.done).toBe(1);
@@ -428,7 +435,7 @@ describe('generationStreamMiddleware', () => {
 
     /* Halt → snapshot cleared. */
     store.dispatch(chaptersSlice.actions.requestStreamHalt());
-    expect(store.getState().chapters.activeStream).toBeNull();
+    expect(firstActiveStream(store.getState())).toBeNull();
   });
 
   it('enqueues a pending revision per (characterId, chapterId) on regenerateCharacter', () => {
@@ -534,7 +541,7 @@ describe('generationStreamMiddleware', () => {
       ch(3, { state: 'queued', excluded: true }),
       ch(4, { state: 'queued', excluded: true }),
     ]);
-    const snap = store.getState().chapters.activeStream;
+    const snap = firstActiveStream(store.getState());
     expect(snap).not.toBeNull();
     expect(snap!.total).toBe(2);
     expect(snap!.done).toBe(1);
@@ -556,7 +563,7 @@ describe('generationStreamMiddleware', () => {
       ch(2, { state: 'queued', excluded: true }),
     ]);
     expect(streamGenerationMock).toHaveBeenCalledTimes(1);
-    expect(store.getState().chapters.activeStream).not.toBeNull();
+    expect(firstActiveStream(store.getState())).not.toBeNull();
 
     /* Complete the only non-excluded chapter. After the reducer flips it
        to 'done', reconcile should consider the queue drained (the
@@ -569,7 +576,7 @@ describe('generationStreamMiddleware', () => {
     );
 
     expect(cancelMock).toHaveBeenCalled();
-    expect(store.getState().chapters.activeStream).toBeNull();
+    expect(firstActiveStream(store.getState())).toBeNull();
   });
 
   it('closes the SSE on idle even when the slice has drifted to a different book', () => {
@@ -591,7 +598,7 @@ describe('generationStreamMiddleware', () => {
        to b1 per the sticky-generation contract. */
     store.dispatch(chaptersSlice.actions.setCurrentBookId('b2'));
     expect(cancelMock).not.toHaveBeenCalled();
-    expect(store.getState().chapters.activeStream?.bookId).toBe('b1');
+    expect(firstActiveStream(store.getState())?.bookId).toBe('b1');
 
     /* Final idle arrives for the still-streaming b1 job. The slice is
        on b2 so reconcile's cross-book guard would return early — only
@@ -600,7 +607,7 @@ describe('generationStreamMiddleware', () => {
     store.dispatch(chaptersSlice.actions.applyGenerationTick({ type: 'idle' } as GenerationTick));
 
     expect(cancelMock).toHaveBeenCalled();
-    expect(store.getState().chapters.activeStream).toBeNull();
+    expect(firstActiveStream(store.getState())).toBeNull();
   });
 });
 
@@ -725,7 +732,7 @@ describe('generationStreamMiddleware — Bug E cross-book heartbeat + counters',
       ch(3),
     ]);
     expect(streamGenerationMock).toHaveBeenCalledTimes(1);
-    const openTickAt = store.getState().chapters.activeStream?.lastTickAt;
+    const openTickAt = firstActiveStream(store.getState())?.lastTickAt;
 
     /* User navigates to a different book. Layout would dispatch
        setCurrentBookId('b2') + setChapters(b2's chapters). */
@@ -753,7 +760,7 @@ describe('generationStreamMiddleware — Bug E cross-book heartbeat + counters',
     } as unknown as GenerationTick;
     store.dispatch(chaptersSlice.actions.applyGenerationTick(tick));
 
-    const snap = store.getState().chapters.activeStream;
+    const snap = firstActiveStream(store.getState());
     expect(snap?.bookId).toBe('b1'); /* still describes the generating book */
     expect(snap?.done).toBe(32);
     expect(snap?.total).toBe(63);
@@ -772,7 +779,7 @@ describe('generationStreamMiddleware — Bug E cross-book heartbeat + counters',
       ch(1, { state: 'in_progress', progress: 0.1 }),
       ch(2),
     ]);
-    const openSnap = store.getState().chapters.activeStream;
+    const openSnap = firstActiveStream(store.getState());
     expect(openSnap).not.toBeNull();
     const openDone = openSnap!.done;
     const openTotal = openSnap!.total;
@@ -794,7 +801,7 @@ describe('generationStreamMiddleware — Bug E cross-book heartbeat + counters',
     } as unknown as GenerationTick;
     store.dispatch(chaptersSlice.actions.applyGenerationTick(tick));
 
-    const snap = store.getState().chapters.activeStream;
+    const snap = firstActiveStream(store.getState());
     /* Counters stay at their open-time values (the slice didn't have b1's
        rows to recompute, and the payload didn't carry server aggregates). */
     expect(snap?.done).toBe(openDone);
@@ -814,7 +821,7 @@ describe('generationStreamMiddleware — Bug E cross-book heartbeat + counters',
     store.dispatch(uiSlice.actions.openBook({ id: 'b2', status: 'generating' }));
     seedBook(store, 'b2', [ch(7, { state: 'queued' })]);
 
-    const beforeIdle = store.getState().chapters.activeStream?.lastTickAt;
+    const beforeIdle = firstActiveStream(store.getState())?.lastTickAt;
     /* Sleep a moment so a misfiring refresh would show a higher number. */
     const wallBefore = Date.now() + 1;
     while (Date.now() < wallBefore) {
@@ -830,7 +837,7 @@ describe('generationStreamMiddleware — Bug E cross-book heartbeat + counters',
     } as unknown as GenerationTick;
     store.dispatch(chaptersSlice.actions.applyGenerationTick(idleTick));
 
-    const snap = store.getState().chapters.activeStream;
+    const snap = firstActiveStream(store.getState());
     /* Idle skipped both the slice mutation AND the cross-book refresh. */
     expect(snap?.lastTickAt).toBe(beforeIdle);
   });

--- a/src/store/generation-stream-runner.ts
+++ b/src/store/generation-stream-runner.ts
@@ -123,9 +123,10 @@ export function createStreamRunner(store: StreamRunnerStore): StreamRunner {
         ),
       );
     }
+    const closedBookId = handle.bookId;
     handle.cancel();
     handle = null;
-    dispatch(chaptersActions.clearActiveStream());
+    dispatch(chaptersActions.clearActiveStream(closedBookId));
   };
 
   const open = (
@@ -219,6 +220,7 @@ export function createStreamRunner(store: StreamRunnerStore): StreamRunner {
         typeof evRecord.runInProgress === 'number' ? evRecord.runInProgress : undefined;
       dispatch(
         chaptersActions.updateActiveStreamProgress({
+          bookId: handle.bookId,
           done: runDone,
           total: runTotal,
           inProgress: runInProgress,

--- a/src/store/queue-dispatcher-middleware.test.ts
+++ b/src/store/queue-dispatcher-middleware.test.ts
@@ -185,7 +185,7 @@ describe('queue-dispatcher-middleware', () => {
     expect(args.force).toBe(true);
     expect(args.queueEntryId).toBe('xb1');
     /* Cross-book snapshot seeded for the streaming book, not the viewed one. */
-    expect(store.getState().chapters.activeStream?.bookId).toBe('book-B');
+    expect((Object.values(store.getState().chapters.activeStreams)[0] ?? null)?.bookId).toBe('book-B');
   });
 
   it('does not open a SECOND stream for a cross-book head while one is already in flight', async () => {
@@ -236,12 +236,12 @@ describe('queue-dispatcher-middleware', () => {
     await flushMicro();
     /* Cross-book stream opened + activeStream seeded by the runner. */
     expect(streamGenerationMock).toHaveBeenCalledTimes(1);
-    expect(store.getState().chapters.activeStream?.bookId).toBe('book-B');
+    expect((Object.values(store.getState().chapters.activeStreams)[0] ?? null)?.bookId).toBe('book-B');
 
     /* SSE drains — runner closes → clearActiveStream. Dispatcher then DELETEs
        the entry it was tracking (inFlightEntryId = 'xb3'). */
     fetchMock.mockResolvedValueOnce(jsonResp({ entries: [], paused: false }));
-    store.dispatch(chaptersSlice.actions.clearActiveStream());
+    store.dispatch(chaptersSlice.actions.clearActiveStream('book-B'));
     await flushMicro();
     await flushMicro();
     expect(fetchMock).toHaveBeenCalledWith('/api/queue/xb3', { method: 'DELETE' });
@@ -304,7 +304,7 @@ describe('queue-dispatcher-middleware', () => {
 
     /* Now the SSE finishes — closeHandle dispatches clearActiveStream. */
     fetchMock.mockResolvedValueOnce(jsonResp({ entries: [], paused: false }));
-    store.dispatch(chaptersSlice.actions.clearActiveStream());
+    store.dispatch(chaptersSlice.actions.clearActiveStream('book-A'));
     await flushMicro();
     await flushMicro();
 

--- a/src/store/queue-dispatcher-middleware.ts
+++ b/src/store/queue-dispatcher-middleware.ts
@@ -78,8 +78,8 @@ export function queueDispatcherMiddleware(getRunner: () => StreamRunner): Middle
          (a) our own generation that's still in flight, and (b) any other
          open path the generation-stream-middleware drove (e.g. cold-boot
          auto-resume of slice-queued chapters). We never run two SSEs at
-         once. */
-      if (chapters.activeStream) return;
+         once (through Wave 2; Wave 3's pool lifts this to an N-slot gate). */
+      if (Object.keys(chapters.activeStreams).length > 0) return;
 
       /* activeStream is null. If we were tracking an entry, the chapter
          just completed (or the stream was torn down — pause, halt, etc.).

--- a/src/store/queue-slice.test.ts
+++ b/src/store/queue-slice.test.ts
@@ -169,7 +169,7 @@ describe('active-generation selectors', () => {
       generationStartedAt: null,
       lastTickAt: null,
       currentBookId: opts.currentBookId,
-      activeStream: opts.activeStream,
+      activeStreams: opts.activeStream ? { [opts.activeStream.bookId]: opts.activeStream } : {},
     }) as ChaptersState;
 
   const emptyQueue: QueueState = { entries: [], paused: false, loaded: true };

--- a/src/store/queue-slice.ts
+++ b/src/store/queue-slice.ts
@@ -159,8 +159,16 @@ export const selectActiveGenerationView = (
 ): ActiveGenerationView | null => {
   if (s.queue.entries.length > 0) return null;
   const chapters = s.chapters;
-  const active = chapters?.activeStream ?? null;
-  if (!chapters || !active) return null;
+  if (!chapters) return null;
+  /* Prefer the stream for the currently-viewed book (so the overlay lists its
+     rows); else any open stream. With one stream this is exactly the prior
+     single-snapshot behaviour. */
+  const streams = Object.values(chapters.activeStreams);
+  const active =
+    (chapters.currentBookId ? chapters.activeStreams[chapters.currentBookId] : undefined) ??
+    streams[0] ??
+    null;
+  if (!active) return null;
   const sameBook = chapters.currentBookId === active.bookId;
   /* Excluded chapters never queue or synthesise — mirror the filter in the
      runner's snapshotFromChapters + middleware hasWork so the row count agrees


### PR DESCRIPTION
## Summary

Wave 2 of **plan 111**. Replaces the single `chapters.activeStream` snapshot with `activeStreams: Record<bookId, ActiveStreamSnapshot>` so the generation engine can track several concurrent streams once the worker pool lands in wave 3. **Behaviour is identical through this wave** — the runner is still single-handle, so the map holds 0 or 1 entries.

- `chapters-slice`: reducers keyed by bookId — `setActiveStream` uses the snapshot's own bookId; `clearActiveStream(bookId)` and `updateActiveStreamProgress({bookId,…})` target one book; `applyExternalChaptersSnapshot` mirrors the single broadcast snapshot into the map. The cross-book tick guard is reframed for the map (drop a tick when a stream is open but not for the viewed book). New `selectActiveStreams` / `selectAnyActiveStream` selectors.
- Consumers migrated: the top-bar pill aggregates `done`/`total`/`inProgress` across streams (stalled iff every stream is quiet; `onClick` opens the queue modal when >1 book is generating), `use-local-analyzer-guard`, `broadcast-middleware` (wire still carries one snapshot), the queue-slice Part-A overlay selectors, the `generation-stream-runner` (`close(bookId)`), and the dispatcher single-in-flight gate.

## Test plan

- `chapters-slice.test.ts` — new per-book-map suite: coexisting streams, per-book clear, targeted progress + no-op for unknown book, `selectActiveStreams`/`selectAnyActiveStream`, and the cross-book guard dropping a foreign-book tick.
- Updated `generation-stream-middleware` / `queue-dispatcher-middleware` / `broadcast-middleware` / `queue-modal` / `queue-slice` / `edit-chapter-title` / `layout` tests to the map shape.
- Full `npm run verify` green. (One transient e2e run failed with `ERR_CONNECTION_REFUSED` — the Vite e2e server crashed mid-run; all specs, including the live-generation overlay, pass in isolation and on re-run.)

## Follow-up

Wave 3 (the worker pool: multi-handle runner + dispatcher N-slots + remove the `hasWork` override + enqueue-on-work) and Wave 4 (retire `GEN_CHAPTER_CONCURRENCY`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
