### PR TITLE
fix(frontend): dedupe generation pill total per book (no 10/14 double count)

### DIFF
--- a/docs/features/110-queue-active-generation-honesty.md
+++ b/docs/features/110-queue-active-generation-honesty.md
@@ -16,7 +16,7 @@ owner: null
 A book mid-generation showed three contradictory "queue" readouts: the Generate
 header said `IN PROGRESS 2 / QUEUED 42` (live), the "Generation Queue" modal said
 `Empty — No chapters queued`, and the top bar said `Queued (3 ahead)`. Three
-*independent* subsystems share the word "queue".
+_independent_ subsystems share the word "queue".
 
 - **User:** the queue modal + "Queue · N" chip no longer claim "Empty"/0 while a
   book is visibly generating; the top-bar GPU-contention badge no longer reads
@@ -67,6 +67,15 @@ Part A is read-side only:
   different book) shows only the done/total summary (`view.chapters === null`).
 - Excluded chapters are filtered out of the rows + count, mirroring
   `snapshotFromChapters` (runner) and `hasWork` (middleware).
+- The top-bar generation pill's `done/total` is computed per BOOK, not per
+  stream. Each `activeStreams` snapshot is book-wide (`snapshotFromChapters`
+  counts every active chapter of its book), so two concurrent same-book
+  chapter streams each report the book's full `done/total`. `layout.tsx` MUST
+  aggregate via `aggregateStreamsByBook` (`chapters-slice.ts`) — dedupe per
+  `bookId` (per-book max), then sum across DISTINCT books — never a naive
+  `reduce` sum across streams, which double-counts (`5/7` + `5/7` → `10/14`).
+  The queue-overlay selector (`selectActiveGenerationView`) already picks a
+  single representative stream, so only the pill needed this.
 
 ## Test plan
 
@@ -80,6 +89,10 @@ Part A is read-side only:
 - Vitest RTL (`src/modals/queue-modal.test.tsx`) — modal shows the
   active-generation section + "Generating…" header (not "Empty") when the queue
   is empty but a stream is live; real entries suppress the overlay.
+- Vitest unit (`src/store/chapters-slice.test.ts`) — `aggregateStreamsByBook`:
+  two same-book streams reporting `5/7` each collapse to `5/7` (not `10/14`);
+  per-book max absorbs tick skew; distinct books sum (`book-A 1/5` + `book-B
+2/7` → `3/12`); empty → zeros.
 - Playwright e2e (`e2e/queue-modal.spec.ts`) — drives a real mock generation
   (queue stubbed empty) and asserts the modal renders
   `queue-modal-active-generation` + "Generating…" instead of "No chapters queued".

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -5,7 +5,12 @@ import { useAppDispatch, useAppSelector, useAppSelectorShallow } from '../store'
 import { uiActions } from '../store/ui-slice';
 import { castActions } from '../store/cast-slice';
 import { fetchAccountSettings } from '../store/account-slice';
-import { chaptersActions, selectActiveStreams, STALL_THRESHOLD_MS } from '../store/chapters-slice';
+import {
+  aggregateStreamsByBook,
+  chaptersActions,
+  selectActiveStreams,
+  STALL_THRESHOLD_MS,
+} from '../store/chapters-slice';
 import { manuscriptActions } from '../store/manuscript-slice';
 import { analysisActions } from '../store/analysis-slice';
 import { revisionsActions, selectDriftGroupsByBook } from '../store/revisions-slice';
@@ -76,7 +81,11 @@ export interface LayoutContext {
      or any other "did anything happen?" signal needs surfacing
      without interrupting focus. dedupeKey collapses repeated pushes
      into a single timer-bumped toast. */
-  pushToast: (args: { kind: 'error' | 'warn' | 'info'; message: string; dedupeKey?: string }) => void;
+  pushToast: (args: {
+    kind: 'error' | 'warn' | 'info';
+    message: string;
+    dedupeKey?: string;
+  }) => void;
   ttsLifecycle: TtsLifecycle;
   /* Prior-series roster for the currently-open book. Lazily fetched
      once per book — empty array until the fetch lands or if the book
@@ -467,7 +476,9 @@ export function Layout() {
           }),
         );
         dispatch(
-          revisionsActions.hydrateFromBookState(res.revisions ? { bookId, ...res.revisions } : null),
+          revisionsActions.hydrateFromBookState(
+            res.revisions ? { bookId, ...res.revisions } : null,
+          ),
         );
         dispatch(changeLogActions.hydrateFromBookState(res.changeLog ?? null));
         /* Editable Listen-view metadata: seed from state.json's editorial
@@ -730,8 +741,7 @@ export function Layout() {
      GPU-heavy ops at GPU_CONCURRENCY=1 so two parallel Claude Code
      sessions don't thrash an 8 GB GPU's VRAM. */
   const gpuQueueDepth = ttsLifecycle.gpuQueueDepth;
-  const showGpuQueueBadge =
-    typeof gpuQueueDepth === 'number' && gpuQueueDepth > 0;
+  const showGpuQueueBadge = typeof gpuQueueDepth === 'number' && gpuQueueDepth > 0;
   const ttsPillElement = showGlobalTtsPill ? (
     <span className="inline-flex items-center gap-2 flex-wrap">
       {showGpuQueueBadge && (
@@ -808,12 +818,13 @@ export function Layout() {
      keeps the "stalled" check fresh against Date.now(). */
   const generationPill: GenerationPillData | null = (() => {
     if (activeStreams.length === 0) return null;
-    /* Aggregate across every open stream (Wave 3 may have several books
-       generating at once). With one stream this is byte-identical to the
-       prior single-snapshot pill. */
-    const done = activeStreams.reduce((acc, s) => acc + s.done, 0);
-    const total = activeStreams.reduce((acc, s) => acc + s.total, 0);
-    const inProgress = activeStreams.reduce((acc, s) => acc + s.inProgress, 0);
+    /* Aggregate across every open stream, deduped per book (Wave 3 may have
+       several books generating at once). Each snapshot is book-wide, so two
+       concurrent chapters of the SAME book would otherwise double-count
+       (`5/7` + `5/7` → `10/14`); aggregateStreamsByBook collapses per book
+       first, then sums across distinct books. With one stream this is
+       byte-identical to the prior single-snapshot pill. */
+    const { done, total, inProgress } = aggregateStreamsByBook(activeStreams);
     const halted = activeStreams.some((s) => s.halted);
     const percent = total > 0 ? Math.round((done / total) * 100) : 0;
     /* Stalled only when EVERY in-flight stream is quiet — one moving stream

--- a/src/store/chapters-slice.test.ts
+++ b/src/store/chapters-slice.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import {
+  aggregateStreamsByBook,
   chaptersSlice,
   chaptersActions,
   selectActiveStreams,
@@ -1063,22 +1064,53 @@ describe('chaptersSlice — activeStreams per-stream map (queue-sole concurrency
     expect(after.activeStreams['book-Z::9']).toBeUndefined();
   });
 
-  it('the layout pill aggregates two same-book chapter streams', () => {
-    /* The pill selectors aggregate across Object.values, so two same-book
-       chapter streams sum into one book's done/total readout. */
+  it('the layout pill dedupes two same-book chapter streams (no double count)', () => {
+    /* Each stream's snapshot is BOOK-WIDE (snapshotFromChapters counts every
+       active chapter of the book), so two same-book chapter streams each
+       report the book's full done/total. Naively summing yields 2×total
+       (the `10/14` bug); aggregateStreamsByBook must collapse them to ONE
+       book's `done/total/inProgress`. */
     let s = chaptersSlice.reducer(
       baseState([]),
-      chaptersActions.setActiveStream(snap('book-A', 1, { done: 1, total: 5, inProgress: 1 })),
+      chaptersActions.setActiveStream(snap('book-A', 1, { done: 5, total: 7, inProgress: 2 })),
     );
     s = chaptersSlice.reducer(
       s,
-      chaptersActions.setActiveStream(snap('book-A', 2, { done: 1, total: 5, inProgress: 1 })),
+      chaptersActions.setActiveStream(snap('book-A', 2, { done: 5, total: 7, inProgress: 2 })),
     );
-    const streams = selectActiveStreams({ chapters: s });
-    const done = streams.reduce((a, st) => a + st.done, 0);
-    const inProgress = streams.reduce((a, st) => a + st.inProgress, 0);
-    expect(done).toBe(2);
-    expect(inProgress).toBe(2);
+    const agg = aggregateStreamsByBook(selectActiveStreams({ chapters: s }));
+    expect(agg).toEqual({ done: 5, total: 7, inProgress: 2 });
+  });
+
+  describe('aggregateStreamsByBook', () => {
+    it('returns zeros for no streams', () => {
+      expect(aggregateStreamsByBook([])).toEqual({ done: 0, total: 0, inProgress: 0 });
+    });
+
+    it('passes a single stream through unchanged', () => {
+      expect(
+        aggregateStreamsByBook([snap('book-A', 1, { done: 3, total: 9, inProgress: 1 })]),
+      ).toEqual({ done: 3, total: 9, inProgress: 1 });
+    });
+
+    it('dedupes same-book streams by taking the per-book max, absorbing tick skew', () => {
+      /* Two snapshots of the same book momentarily disagree (one tick ahead);
+         max picks the fresher counters rather than summing them. */
+      const agg = aggregateStreamsByBook([
+        snap('book-A', 1, { done: 5, total: 7, inProgress: 2 }),
+        snap('book-A', 2, { done: 4, total: 7, inProgress: 3 }),
+      ]);
+      expect(agg).toEqual({ done: 5, total: 7, inProgress: 3 });
+    });
+
+    it('sums across DISTINCT books (Wave-3 multi-book run)', () => {
+      const agg = aggregateStreamsByBook([
+        snap('book-A', 1, { done: 1, total: 5, inProgress: 1 }),
+        snap('book-A', 2, { done: 1, total: 5, inProgress: 1 }),
+        snap('book-B', 1, { done: 2, total: 7, inProgress: 1 }),
+      ]);
+      expect(agg).toEqual({ done: 3, total: 12, inProgress: 2 });
+    });
   });
 
   it('selectActiveStreams / selectAnyActiveStream read the map', () => {

--- a/src/store/chapters-slice.ts
+++ b/src/store/chapters-slice.ts
@@ -693,3 +693,41 @@ export const selectActiveStreams = (s: ChaptersRootShape): ActiveStreamSnapshot[
     `if (chapters.activeStream)` truthiness checks. */
 export const selectAnyActiveStream = (s: ChaptersRootShape): boolean =>
   Object.keys(s.chapters.activeStreams).length > 0;
+
+/** Collapse the per-chapter stream snapshots into one done/total/inProgress
+    triple for the top-bar generation pill.
+
+    Each stream's snapshot is BOOK-WIDE — `snapshotFromChapters` counts every
+    active chapter of the stream's book, not just the one chapter it renders
+    (see generation-stream-runner.ts). So two concurrent chapters of the same
+    book both report e.g. `5/7`; naively summing across streams yields `10/14`.
+    We therefore dedupe by `bookId` (taking the max of each counter per book —
+    same-book snapshots should be equal, `max` just absorbs transient
+    tick-to-tick skew) and only then sum across DISTINCT books, which keeps the
+    Wave-3 multi-book case (book A + book B generating at once) correct. */
+export function aggregateStreamsByBook(streams: ActiveStreamSnapshot[]): {
+  done: number;
+  total: number;
+  inProgress: number;
+} {
+  const byBook = new Map<string, { done: number; total: number; inProgress: number }>();
+  for (const s of streams) {
+    const cur = byBook.get(s.bookId);
+    if (!cur) {
+      byBook.set(s.bookId, { done: s.done, total: s.total, inProgress: s.inProgress });
+    } else {
+      cur.done = Math.max(cur.done, s.done);
+      cur.total = Math.max(cur.total, s.total);
+      cur.inProgress = Math.max(cur.inProgress, s.inProgress);
+    }
+  }
+  let done = 0;
+  let total = 0;
+  let inProgress = 0;
+  for (const b of byBook.values()) {
+    done += b.done;
+    total += b.total;
+    inProgress += b.inProgress;
+  }
+  return { done, total, inProgress };
+}


### PR DESCRIPTION
## Summary

The top-bar generation pill double-counted the chapter total whenever more than one chapter of the **same book** streamed at once — it read `Generating · 10/14 · 71%` for a 7-chapter book with 2 chapters in flight (`2×5 / 2×7`), instead of the true `5/7`.

Root cause: under queue-sole concurrency (plan 111) each open stream gets its own `activeStreams` snapshot, but every snapshot is **book-wide** — `snapshotFromChapters` counts every active chapter of the stream's book, not just the one chapter it renders. The pill in `layout.tsx` then summed `done`/`total`/`inProgress` across all streams with a naive `reduce`, so N same-book streams multiplied the book's counts by N. (The queue-overlay selector `selectActiveGenerationView` already collapses to a single representative stream, so only the pill was wrong.)

Changes:
- **New pure helper `aggregateStreamsByBook` (`src/store/chapters-slice.ts`)** — dedupes the snapshots per `bookId` (per-book `max` of each counter, which absorbs tick-to-tick skew between two same-book snapshots), then sums across **distinct** books so the Wave-3 multi-book case (book A + book B generating at once) still totals correctly.
- **`src/components/layout.tsx`** — the generation pill now derives `done`/`total`/`inProgress` from `aggregateStreamsByBook(activeStreams)` instead of three `reduce` sums. `halted` (`some`) and the `stalled` check (`every` quiet) deliberately stay on the **full** stream set — any single moving stream still means the run is alive.
- **Docs** — records the "pill aggregates per book, never a naive cross-stream sum" invariant in `docs/features/110-queue-active-generation-honesty.md`.

No data-shape, storage, or API change; pure read-side aggregation. Revert is a one-line swap back to the `reduce` sums.

## Test plan

- **Rewrote the test that *encoded* the bug** (`src/store/chapters-slice.test.ts`): the old `the layout pill aggregates two same-book chapter streams` asserted `done=2` for two same-book streams reporting `done=1` each (i.e. it asserted the double count). It now asserts two same-book `5/7` streams collapse to `5/7`.
- **New `aggregateStreamsByBook` unit tests**: empty → zeros; single stream pass-through; same-book per-book `max` absorbs tick skew; distinct books sum (`book-A 1/5` + `book-B 2/7` → `3/12`).
- `npm run verify` green locally (lint + typecheck + frontend/server/sidecar/scripts tests + e2e + visual + build). 1764 frontend tests pass.
- e2e note: a true two-same-book-stream browser scenario in mock mode is high-effort to stage; the pure-function unit coverage + the rewritten slice test are the practical regression bar here.

Regression plan: [docs/features/110-queue-active-generation-honesty.md](docs/features/110-queue-active-generation-honesty.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)