### PR TITLE
fix(server): reset orphaned in_progress queue entries on boot

### DIFF
--- a/docs/features/110-queue-active-generation-honesty.md
+++ b/docs/features/110-queue-active-generation-honesty.md
@@ -76,6 +76,20 @@ Part A is read-side only:
   `reduce` sum across streams, which double-counts (`5/7` + `5/7` → `10/14`).
   The queue-overlay selector (`selectActiveGenerationView`) already picks a
   single representative stream, so only the pill needed this.
+- **No orphaned `in_progress` entries survive a restart.** The frontend
+  dispatcher is the sole entry-lifecycle owner (POST `/start` on claim, POST
+  `/complete` on chapter-stream close) and reconciles only its in-memory
+  `inFlight` map; a server restart / crash / browser reload empties that map
+  while `.queue.json` still lists the entry as `in_progress`, so it would be
+  neither re-run (FILL claims only `queued`) nor reconciled — wedging the
+  chapter forever with an idle GPU. The server therefore sweeps
+  `in_progress` → `queued` on boot (`server/src/workspace/queue-boot.ts`,
+  `resetInProgressToQueued` in `queue-io.ts`), AWAITED before `listen()` so no
+  freshly-connecting client can have a just-claimed entry clobbered. This is
+  server-side + once because two browser tabs each run the dispatcher with
+  independent in-memory maps and a frontend reclaim would double-claim. The
+  narrower browser-refresh-while-server-stays-up orphan is left to Part B
+  (the server owning the entry lifecycle).
 
 ## Test plan
 
@@ -96,6 +110,13 @@ Part A is read-side only:
 - Playwright e2e (`e2e/queue-modal.spec.ts`) — drives a real mock generation
   (queue stubbed empty) and asserts the modal renders
   `queue-modal-active-generation` + "Generating…" instead of "No chapters queued".
+- Vitest unit (`server/src/workspace/queue-io.test.ts`) — `resetInProgressToQueued`:
+  flips every `in_progress` → `queued`, leaves `queued`/`failed` untouched,
+  preserves contiguous order, no-ops on an empty queue.
+- Vitest integration (`server/src/workspace/queue-boot.test.ts`) —
+  `resetOrphanedQueueEntries` against a real `.queue.json`: 3 orphaned
+  `in_progress` entries reset to `queued` (reports `{reset:3}`, order stays
+  contiguous), no-op when nothing is `in_progress`, `paused` flag preserved.
 
 ### Manual acceptance walkthrough
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -63,6 +63,7 @@ import { auditEngineCatalog } from './tts/voice-mapping.js';
 import { WORKSPACE_ROOT, ensureWorkspace } from './workspace/paths.js';
 import { migrateLegacyChangeLogs } from './workspace/changelog-migrate.js';
 import { fsckAllBooks } from './workspace/fsck-orphan-audio.js';
+import { resetOrphanedQueueEntries } from './workspace/queue-boot.js';
 import {
   readUserSettings,
   getResolvedSidecarUrl,
@@ -284,6 +285,28 @@ const listenerCallback = () => {
     });
   })();
 };
+
+/* Plan: server-boot orphan sweep for the chapter-generation queue. A restart
+   / crash / browser reload can strand entries `in_progress` on disk with no
+   live stream behind them; the frontend dispatcher then neither re-runs them
+   (FILL claims only `queued`) nor reconciles them (its in-memory inFlight map
+   is empty on a fresh boot), so the chapter wedges and the GPU sits idle.
+   Flipping them back to `queued` lets the dispatcher re-claim and finish them.
+   Safe because a server restart kills all in-flight synthesis (the server owns
+   the generation SSE). AWAITED before listen — not fire-and-forget — so no
+   freshly-connecting frontend can /start a queued entry in the gap between the
+   sweep's read and write and have it clobbered. The inner .catch keeps a queue
+   read error from blocking startup. See workspace/queue-boot.ts. */
+await resetOrphanedQueueEntries()
+  .then((r) => {
+    if (r.reset > 0) {
+      console.log(
+        `[queue] reset ${r.reset} orphaned in_progress entr${r.reset === 1 ? 'y' : 'ies'} ` +
+          `to queued on boot (workspace/queue-boot.ts).`,
+      );
+    }
+  })
+  .catch((err) => console.warn('[queue] orphan reset skipped:', err));
 
 if (lanHttps) {
   if (!existsSync(LAN_CERT_FILE) || !existsSync(LAN_KEY_FILE)) {

--- a/server/src/workspace/queue-boot.test.ts
+++ b/server/src/workspace/queue-boot.test.ts
@@ -1,0 +1,90 @@
+/* Integration test for the server-boot queue orphan sweep (queue-boot.ts).
+ *
+ * Drives resetOrphanedQueueEntries against a real .queue.json in an isolated
+ * WORKSPACE_DIR, the same harness shape as routes/queue.test.ts. */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { QueueFile } from './queue-io.js';
+
+let workspaceRoot: string;
+let resetOrphanedQueueEntries: () => Promise<{ reset: number }>;
+let readQueueFile: (path: string) => Promise<QueueFile>;
+let writeQueueFile: (path: string, file: QueueFile) => Promise<void>;
+let queueJsonPath: () => string;
+
+beforeAll(async () => {
+  workspaceRoot = await mkdtemp(join(tmpdir(), 'queue-boot-test-'));
+  process.env.WORKSPACE_DIR = workspaceRoot;
+  /* Import AFTER WORKSPACE_DIR is set so paths.ts captures the override. */
+  ({ resetOrphanedQueueEntries } = await import('./queue-boot.js'));
+  ({ readQueueFile, writeQueueFile } = await import('./queue-migrate.js'));
+  ({ queueJsonPath } = await import('./paths.js'));
+});
+
+afterAll(async () => {
+  await rm(workspaceRoot, { recursive: true, force: true });
+});
+
+const entry = (id: string, chapterId: number, status: QueueFile['entries'][number]['status']) => ({
+  id,
+  bookId: 'book-A',
+  chapterId,
+  scope: 'this' as const,
+  addedAt: '2026-05-25T09:12:04.500Z',
+  status,
+  order: 0,
+});
+
+describe('resetOrphanedQueueEntries (boot sweep)', () => {
+  it('flips orphaned in_progress entries to queued and reports the count', async () => {
+    await writeQueueFile(queueJsonPath(), {
+      entries: [
+        entry('e2', 2, 'in_progress'),
+        entry('e3', 3, 'in_progress'),
+        entry('e5', 5, 'in_progress'),
+        entry('e6', 6, 'queued'),
+        entry('e7', 7, 'queued'),
+      ],
+      paused: false,
+    });
+
+    const result = await resetOrphanedQueueEntries();
+    expect(result).toEqual({ reset: 3 });
+
+    const after = await readQueueFile(queueJsonPath());
+    expect(after.entries.map((e) => [e.id, e.status])).toEqual([
+      ['e2', 'queued'],
+      ['e3', 'queued'],
+      ['e5', 'queued'],
+      ['e6', 'queued'],
+      ['e7', 'queued'],
+    ]);
+    /* Order stays contiguous after the sweep. */
+    expect(after.entries.map((e) => e.order)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('no-ops (reset: 0) when nothing is in_progress', async () => {
+    await writeQueueFile(queueJsonPath(), {
+      entries: [entry('e6', 6, 'queued'), entry('e7', 7, 'queued')],
+      paused: false,
+    });
+    const result = await resetOrphanedQueueEntries();
+    expect(result).toEqual({ reset: 0 });
+    const after = await readQueueFile(queueJsonPath());
+    expect(after.entries.map((e) => e.status)).toEqual(['queued', 'queued']);
+  });
+
+  it('preserves the paused flag while sweeping', async () => {
+    await writeQueueFile(queueJsonPath(), {
+      entries: [entry('e2', 2, 'in_progress')],
+      paused: true,
+    });
+    await resetOrphanedQueueEntries();
+    const after = await readQueueFile(queueJsonPath());
+    expect(after.paused).toBe(true);
+    expect(after.entries[0].status).toBe('queued');
+  });
+});

--- a/server/src/workspace/queue-boot.ts
+++ b/server/src/workspace/queue-boot.ts
@@ -1,0 +1,36 @@
+/* Server-boot sweep for the workspace chapter-generation queue.
+ *
+ * A server restart / crash / browser reload can leave queue entries stuck in
+ * `in_progress` on disk with no live stream behind them. The frontend
+ * dispatcher (src/store/queue-dispatcher-middleware.ts) is the sole
+ * stream-opener: on a fresh boot its in-memory `inFlight` map is empty, so it
+ * neither reconciles those orphans (STEP 1 only walks its own map) nor
+ * re-runs them (STEP 2 FILL claims only `queued` entries). The chapter then
+ * appears "generating" forever while the GPU sits idle — the wedge this sweep
+ * unblocks.
+ *
+ * Flipping orphaned `in_progress` → `queued` on boot is safe because a server
+ * restart kills all in-flight synthesis (the server owns the generation SSE);
+ * any entry still `in_progress` at boot is definitionally orphaned. The sweep
+ * runs once, on the server, before it accepts requests — a frontend cold-boot
+ * reclaim would be unsafe because two browser tabs each run the dispatcher
+ * with independent in-memory maps and would double-claim. */
+
+import { queueJsonPath } from './paths.js';
+import { readQueueFile, writeQueueFile } from './queue-migrate.js';
+import { resetInProgressToQueued } from './queue-io.js';
+
+/** Reset orphaned `in_progress` queue entries back to `queued`. Reads +
+ *  rewrites <workspace>/.queue.json. No-ops (no write) when nothing is
+ *  in_progress or the file is absent (readQueueFile returns an empty queue).
+ *  Returns the number of entries reset. Never throws on a malformed/missing
+ *  file beyond what readQueueFile surfaces — callers should still guard with
+ *  .catch so a queue read error can't block server startup. */
+export async function resetOrphanedQueueEntries(): Promise<{ reset: number }> {
+  const path = queueJsonPath();
+  const before = await readQueueFile(path);
+  const orphaned = before.entries.filter((e) => e.status === 'in_progress').length;
+  if (orphaned === 0) return { reset: 0 };
+  await writeQueueFile(path, resetInProgressToQueued(before));
+  return { reset: orphaned };
+}

--- a/server/src/workspace/queue-io.test.ts
+++ b/server/src/workspace/queue-io.test.ts
@@ -9,6 +9,7 @@ import {
   markInProgress,
   pruneByBook,
   reorder,
+  resetInProgressToQueued,
   setPaused,
   startEntry,
   updateProgress,
@@ -196,6 +197,46 @@ describe('queue-io.markInProgress', () => {
     f = markInProgress(f, 'e1');
     f = markInProgress(f, 'e1');
     expect(f.entries[0].status).toBe('in_progress');
+  });
+});
+
+describe('queue-io.resetInProgressToQueued', () => {
+  it('flips every in_progress entry back to queued (boot orphan sweep)', () => {
+    let f = enqueue(emptyFile(), [sampleEntry('e1'), sampleEntry('e2'), sampleEntry('e3')]);
+    f = markInProgress(f, 'e1');
+    f = markInProgress(f, 'e2');
+    const swept = resetInProgressToQueued(f);
+    expect(swept.entries.map((e) => [e.id, e.order, e.status])).toEqual([
+      ['e1', 0, 'queued'],
+      ['e2', 1, 'queued'],
+      ['e3', 2, 'queued'],
+    ]);
+  });
+
+  it('leaves queued / failed entries untouched', () => {
+    let f = enqueue(emptyFile(), [sampleEntry('e1'), sampleEntry('e2')]);
+    f = markInProgress(f, 'e2');
+    f = completeEntry(f, 'e2', 'failed', 'sidecar 500');
+    const swept = resetInProgressToQueued(f);
+    /* e1 was already queued; e2 is failed (lingers for inspection) — neither
+       is in_progress, so both pass through unchanged. */
+    expect(swept.entries.map((e) => [e.id, e.status])).toEqual([
+      ['e1', 'queued'],
+      ['e2', 'failed'],
+    ]);
+  });
+
+  it('is a no-op (preserves order) when nothing is in_progress', () => {
+    const f = enqueue(emptyFile(), [sampleEntry('e1'), sampleEntry('e2')]);
+    const swept = resetInProgressToQueued(f);
+    expect(swept.entries.map((e) => [e.id, e.order, e.status])).toEqual([
+      ['e1', 0, 'queued'],
+      ['e2', 1, 'queued'],
+    ]);
+  });
+
+  it('handles an empty queue', () => {
+    expect(resetInProgressToQueued(emptyFile()).entries).toEqual([]);
   });
 });
 

--- a/server/src/workspace/queue-io.ts
+++ b/server/src/workspace/queue-io.ts
@@ -223,6 +223,23 @@ export function pruneByBook(file: QueueFile, bookId: string): QueueFile {
   });
 }
 
+/** Reset every `in_progress` entry back to `queued` — the server-boot orphan
+ *  sweep. A server restart kills all in-flight synthesis (the server owns the
+ *  generation SSE), so any entry left `in_progress` on disk is an orphan with
+ *  no live stream behind it. Left as-is the frontend dispatcher would neither
+ *  re-run it (FILL claims only `queued` entries) nor reconcile it (its
+ *  in-memory inFlight map is empty on a fresh boot), wedging that chapter
+ *  forever. Other statuses (queued / failed / done / paused) are untouched.
+ *  Order is preserved (renumber keeps the contiguous-order invariant). */
+export function resetInProgressToQueued(file: QueueFile): QueueFile {
+  return renumber({
+    ...file,
+    entries: file.entries.map(
+      (e): QueueEntry => (e.status === 'in_progress' ? { ...e, status: 'queued' } : e),
+    ),
+  });
+}
+
 /** Recompute `order` to be contiguous 0..N-1 after any mutation. The
  *  in_progress entry (if present) stays at order=0; the rest follow in
  *  their current array order. */


### PR DESCRIPTION
## Summary

Fixes **generation stalling permanently** after a server restart / crash / browser reload, with the GPU sitting idle and chapters showing "generating" forever.

Diagnosed live: the GPU semaphore was idle (`inFlight:0`), the sidecar was healthy (Qwen loaded), but `.queue.json` had chapters stuck in `in_progress` from a previous day. The frontend dispatcher (`src/store/queue-dispatcher-middleware.ts`) is the **sole** queue-entry-lifecycle owner — it POSTs `/start` on claim, `/complete` on chapter-stream close, reconciles only its **in-memory** `inFlight` map, and FILL claims only `queued` entries. After a fresh boot that in-memory map is empty, so a leftover `in_progress` entry is **never re-run and never reconciled** → the chapter wedges and nothing reaches the GPU.

This PR adds a **server-boot orphan sweep**: flip every `in_progress` entry back to `queued` on startup. Safe because a server restart kills all in-flight synthesis (the server owns the generation SSE), so any `in_progress` entry at boot is definitionally an orphan with no live stream. It's done server-side + once on purpose: two browser tabs each run the dispatcher with independent in-memory maps, so a frontend "reclaim orphans" would double-claim.

Changes:
- **`resetInProgressToQueued` (`server/src/workspace/queue-io.ts`)** — pure mutator: flips `in_progress` → `queued`, leaves `queued`/`failed`/`done`/`paused` untouched, preserves the contiguous-order invariant.
- **`server/src/workspace/queue-boot.ts` (new)** — `resetOrphanedQueueEntries()` reads + rewrites `<workspace>/.queue.json`, no-ops (no write) when nothing is `in_progress` or the file is absent, returns the reset count.
- **`server/src/index.ts`** — runs the sweep alongside the other one-shot boot reconciles (changelog migrate, audio fsck), but **`await`-ed before `app.listen()`** rather than fire-and-forget: this closes a narrow clobber race where a freshly-connecting client could `/start` a queued entry in the gap between the sweep's read and write. An inner `.catch` keeps a queue read error from blocking startup (`ES2022`/`NodeNext` → top-level await is supported).

No API/route/data-shape change. Operator-visible: a `[queue] reset N orphaned in_progress entr… to queued on boot` log line when it acts.

### Known gap (out of scope — plan 110 Part B)

A browser refresh **while the server stays up** still strands the entry (the server doesn't own the entry lifecycle, and a frontend reclaim is unsafe across tabs). That belongs to plan 110's deferred "authoritative queue" work where the server owns completion/abort. This PR fixes the dominant case (server restart, which `npm start` performs).

## Test plan

- **`server/src/workspace/queue-io.test.ts`** — unit: `resetInProgressToQueued` flips every `in_progress`→`queued`, leaves `queued`/`failed` untouched, preserves contiguous order, no-ops on an empty queue.
- **`server/src/workspace/queue-boot.test.ts` (new)** — integration against a real `.queue.json` in an isolated `WORKSPACE_DIR`: 3 orphaned `in_progress` entries reset to `queued` (reports `{reset:3}`, order contiguous), no-op (`{reset:0}`) when nothing is `in_progress`, `paused` flag preserved through the sweep.
- `npm run verify` green locally (lint + typecheck + frontend/server/sidecar/scripts tests + e2e + visual + build).

Regression plan: [docs/features/110-queue-active-generation-honesty.md](docs/features/110-queue-active-generation-honesty.md) — new "No orphaned `in_progress` entries survive a restart" invariant + test notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)