### PR TITLE
perf(frontend): prefetch the GenerationView chunk to kill the slow "Loading…"

### DIFF
--- a/docs/features/archive/89-frontend-perf-pass.md
+++ b/docs/features/archive/89-frontend-perf-pass.md
@@ -78,3 +78,12 @@ Shipped **2026-05-21** via PR [#104](https://github.com/dudarenok-maker/AudioBoo
 Plan 63 narrow-scope BroadcastChannel rule preserved: broadcast action allowlist unchanged; diff scope strictly inside `activeStream`. Narrow-scope test cases (per-chapter row, inbound `applyExternal*` reducer) still red-line non-broadcast behaviour.
 
 One pre-existing intermittent `Worker exited unexpectedly` flake in `test:server` exists on `main` — verified via stash-round-trip during this round; caught + re-ran cleanly so verify cache stayed green. Tracked as part of **BACKLOG Should #3** (the broader pre-push gate de-flake work).
+
+### Follow-up — GenerationView chunk prefetch (2026-05-26)
+
+C5's lazy boundary meant the Generate view's chunk only began downloading on first navigation to it. Under a heavy generation run the main thread is busy, so that cold download stretched the route Suspense fallback into a multi-second "Loading…" — read as a stall. Fix: proactively warm the Generate chunk so it's resolved before navigation.
+
+- **`src/routes/prefetch.ts` (new):** `importGenerationView = () => import('../views/generation')` — the single dynamic-import specifier shared by both the `React.lazy` def in `src/routes/index.tsx` and the prefetch, so Vite warms the exact chunk the route awaits.
+- **`src/components/layout.tsx`:** a one-shot `useEffect` (ref-guarded) fires `importGenerationView()` once the user is inside a book (`stageKind === 'ready'`) OR any generation stream is live (`activeStreams.length > 0`). `import()` is idempotent, so warming is free if the chunk already loaded.
+- **C5 invariant preserved:** the view stays lazy (no eager-import bloat on the library landing route); only the _download timing_ moves earlier. Behaviourally invisible — the view renders identically.
+- **Tests:** `src/routes/prefetch.test.ts` locks that the shared thunk resolves the `GenerationView` module (a path typo would silently no-op the prefetch). No new e2e — the Generate view's load/render seam is already covered (`e2e/responsive/coverage.spec.ts`, `e2e/generation-parallel.spec.ts`, `e2e/queue-modal.spec.ts`), and the optimization is load-timing, which CI (warm chunks) can't observe deterministically.

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -51,6 +51,7 @@ import { ConfirmDialog } from '../modals/confirm-dialog';
 import { QueueModalContainer } from '../modals/queue-modal';
 import { loadQueue, enqueueQueueEntries } from '../store/queue-thunks';
 import { selectGenerationActivityCount } from '../store/queue-slice';
+import { importGenerationView } from '../routes/prefetch';
 import { ToastStack } from './toast-stack';
 import { RevisionDiffPlayer } from '../views/revision-diff';
 import { RevisionTimelineModal } from './revision-timeline-modal';
@@ -130,6 +131,21 @@ export function Layout() {
      it from either stage variant. */
   const openProfileId =
     stage.kind === 'ready' || stage.kind === 'confirm' ? stage.openProfileId : null;
+
+  /* Prefetch the lazy GenerationView chunk (routes/index.tsx loads it via
+     React.lazy) once the user is inside a book OR any generation run is live,
+     so opening the Generate view paints from cache instead of showing the
+     route Suspense fallback while a cold chunk downloads — which reads as
+     "stuck on Loading…" worst when the main thread is busy mid-generation.
+     import() is idempotent (Vite dedupes to the same chunk the lazy awaits);
+     the ref keeps it to a single fire. */
+  const generationChunkWarmed = useRef(false);
+  useEffect(() => {
+    if (generationChunkWarmed.current) return;
+    if (stageKind !== 'ready' && activeStreams.length === 0) return;
+    generationChunkWarmed.current = true;
+    void importGenerationView();
+  }, [stageKind, activeStreams.length]);
 
   const matchCharacter = ui.matchDetailFor
     ? (characters.find((c) => c.id === ui.matchDetailFor) ?? null)

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -36,6 +36,7 @@ import { useLocalAnalyzerGuard } from '../hooks/use-local-analyzer-guard';
    sub-routes (ReadyRoute's switch, UploadRoute's conditional) where the
    eager cost is negligible OR they are the landing route and lazy-loading
    them would only slow first paint. */
+import { importGenerationView } from './prefetch';
 const UploadView = lazy(() => import('../views/upload').then((m) => ({ default: m.UploadView })));
 const AnalysingView = lazy(() =>
   import('../views/analysing').then((m) => ({ default: m.AnalysingView })),
@@ -47,7 +48,7 @@ const ManuscriptView = lazy(() =>
 const CastView = lazy(() => import('../views/cast').then((m) => ({ default: m.CastView })));
 const LibraryView = lazy(() => import('../views/voices').then((m) => ({ default: m.LibraryView })));
 const GenerationView = lazy(() =>
-  import('../views/generation').then((m) => ({ default: m.GenerationView })),
+  importGenerationView().then((m) => ({ default: m.GenerationView })),
 );
 const ListenView = lazy(() => import('../views/listen').then((m) => ({ default: m.ListenView })));
 import { BookLibraryView } from '../views/book-library';

--- a/src/routes/prefetch.test.ts
+++ b/src/routes/prefetch.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { importGenerationView } from './prefetch';
+
+/* The prefetch warms the Generate view's chunk before navigation. This guards
+   that the shared import specifier still resolves the GenerationView module —
+   a path typo here would silently no-op the prefetch (and, because the same
+   thunk backs the React.lazy in routes/index.tsx, also break the route), with
+   no behavioural test catching it since the view would still lazy-load. */
+describe('importGenerationView', () => {
+  it('resolves the module exposing GenerationView so the prefetch warms the right chunk', async () => {
+    const mod = await importGenerationView();
+    expect(typeof mod.GenerationView).toBe('function');
+  });
+});

--- a/src/routes/prefetch.ts
+++ b/src/routes/prefetch.ts
@@ -1,0 +1,14 @@
+/* Shared dynamic-import thunk for the lazy GenerationView chunk.
+ *
+ * Exported so BOTH the React.lazy definition (routes/index.tsx) and the
+ * proactive prefetch (components/layout.tsx) reference the EXACT same import
+ * specifier. Vite code-splits a given dynamic specifier into one chunk, so
+ * warming it via the prefetch resolves the very module the route lazy awaits —
+ * the Generate view then paints from cache instead of showing the route
+ * Suspense fallback while a cold chunk downloads (worst right when the main
+ * thread is busy mid-generation, which is exactly when the user opens it).
+ *
+ * Lives in its own module to avoid a circular import: routes/index.tsx imports
+ * Layout, and layout.tsx imports this — a shared specifier here keeps that edge
+ * acyclic (this module imports nothing from either). */
+export const importGenerationView = () => import('../views/generation');


### PR DESCRIPTION
## Summary

Fixes the Generate view sometimes sitting on a centered **"Loading…"** spinner for seconds before it appears, especially while a generation run is busy.

The spinner is the route-level Suspense fallback (`DelayedSpinner`), painted while the lazy `GenerationView` chunk downloads (plan 89 C5 code-split the route-leaf views). On first navigation to Generate the chunk downloads cold; with the main thread busy mid-generation that stretches into a multi-second "stuck on Loading…". This PR proactively **warms the chunk before navigation** so the view paints from cache.

- **`src/routes/prefetch.ts` (new):** `importGenerationView = () => import('../views/generation')` — one dynamic-import specifier shared by *both* the `React.lazy` definition in `src/routes/index.tsx` and the prefetch, so Vite code-splits them into the same chunk and the prefetch warms exactly what the route awaits.
- **`src/components/layout.tsx`:** a ref-guarded one-shot `useEffect` fires `importGenerationView()` once the user is inside a book (`stageKind === 'ready'`) OR any generation stream is live (`activeStreams.length > 0`). `import()` is idempotent (Vite dedupes), so warming is free if the chunk already loaded.

The view **stays lazy** — no eager-import bloat on the library landing route (plan 89 C5 preserved); only the *download timing* moves earlier. Behaviourally invisible: the Generate view renders identically, and the build still emits a separate `generation-*.js` chunk.

## Test plan

- **`src/routes/prefetch.test.ts` (new)** — asserts the shared `importGenerationView()` thunk resolves the module exposing `GenerationView`. This locks the prefetch path/wiring: a typo would silently no-op the prefetch (and, since the same thunk backs the route `React.lazy`, the test guards that too).
- **No new e2e** — the Generate view's load/render seam is already covered (`e2e/responsive/coverage.spec.ts` navigates to `/#/books/sb/generate`, plus `e2e/generation-parallel.spec.ts` + `e2e/queue-modal.spec.ts`). The optimization is load-*timing*, which CI (warm chunks) can't observe deterministically, so a dedicated prefetch spec would assert nothing the existing coverage doesn't.
- `npm run verify` green locally (lint + typecheck + frontend/server/sidecar/scripts tests + e2e + visual + build).

Regression plan: follow-up note in [docs/features/archive/89-frontend-perf-pass.md](docs/features/archive/89-frontend-perf-pass.md) (the C5 lazy-load/Suspense owner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)