### PR TITLE
fix(sidecar): load Qwen sdpa without device_map (meta-tensor /load crash)

### DIFF
--- a/docs/features/archive/112-qwen-synth-quick-wins.md
+++ b/docs/features/archive/112-qwen-synth-quick-wins.md
@@ -31,7 +31,7 @@ Generation with the Qwen engine is 5–10× slower than Kokoro. Investigation ag
 - `QwenEngine.synthesize` resolves the voice prompt (`_load_voice_prompt`) **before** `_ensure_base_loaded()`, so an undesigned voice raises without paying the model load (`main.py`).
 - `_load_voice_prompt` releases `_cache_lock` across `torch.load` — a concurrent double-miss double-loads (benign, same content); it never holds the lock during I/O.
 - `design_voice` calls `self._prompt_cache.pop(voice_id, None)` (evict, **not** warm) after writing the `.pt`/`.json`, so the next synth reloads the fresh embedding.
-- `_load_qwen_model` retries `from_pretrained` without `attn_implementation` if the kwarg is rejected — a load must never harden into a failure over the attention knob.
+- `_load_qwen_model` is two-tier: the sdpa fast-path passes `attn_implementation` **without** `device_map` then `model.to(device)`; on **any** exception it retries the proven-good `device_map` + library-default (eager) config — a load must never harden into a failure over the attention knob. (Broadened from the original `(ValueError, TypeError)`-only catch — see Post-ship fix below.)
 
 ## Test plan
 
@@ -43,7 +43,9 @@ Pytest sidecar (`server/tts-sidecar/tests/test_qwen3.py`):
 - `test_redesign_evicts_cached_prompt` — re-design drops the cache entry; next synth reloads.
 - `test_unload_clears_prompt_cache` — `unload()` empties `_prompt_cache`.
 - `test_load_passes_sdpa_attn_by_default` / `test_load_honours_qwen_attn_impl_env` — loader passes `attn_implementation="sdpa"` by default, honours `QWEN_ATTN_IMPL`.
-- `test_load_falls_back_when_attn_kwarg_rejected` — kwarg rejection → retry without it, load still succeeds.
+- `test_load_falls_back_when_attn_kwarg_rejected` — kwarg rejection (ValueError) → retry without it, load still succeeds.
+- `test_load_falls_back_when_sdpa_dispatch_fails` — sdpa **accepted then breaks** dispatch (meta-tensor `NotImplementedError`) → fast-path drops `device_map`, fallback restores it; load still succeeds (Post-ship fix regression test).
+- `test_load_passes_sdpa_attn_by_default` also asserts the fast-path passes **no** `device_map`.
 - Existing `test_synthesize_reuses_cached_voice` (asserts `weights_only=False` on the disk load) stays green — design evicts, so the first synth still loads from disk.
 
 Whole sidecar suite green via `npm run test:sidecar` (≈141 cases, exit 0).
@@ -75,3 +77,9 @@ Shipped exactly as specced: SDPA attention by default (`QWEN_ATTN_IMPL`, ships b
 Deploy-box config: `GPU_VRAM_BUDGET=2` set in `server/.env` on the target 4070, so `sentenceConcurrency`/`poolWidth` defaults to 2 (two concurrent Qwen synths per chapter; Kokoro+Qwen coexistence preserved at cost 1 each).
 
 Open (non-blocking) manual acceptance: the baseline-vs-SDPA RTF delta and the concurrency curve were NOT captured before close-out — run `bench-tts.py` per the "Manual acceptance walkthrough" anytime to record them. The real throughput lever (sentence batching) is tracked as `side-3` (in flight); `side-4` covers the `x_vector_only_mode` fidelity tradeoff.
+
+### Post-ship fix (2026-05-26) — sdpa + device_map meta-tensor crash
+
+The shipped `_load_qwen_model` passed `attn_implementation="sdpa"` **alongside** `device_map="cuda:0"`. The kwarg is accepted (sdpa is valid), but `device_map` routes the load through accelerate's `dispatch_model`, which leaves attention params on the `meta` device and then raises `NotImplementedError: Cannot copy out of meta tensor` when it tries to move them. The original fallback only caught `(ValueError, TypeError)` (a kwarg *rejection*), so this dispatch-time failure escaped: `POST /load` 500'd, the Qwen pill spun ~5s and reverted to "Qwen idle" — the model never loaded. (Ground truth: `logs/tts.err.log` traceback at `main.py` `_load_qwen_model` → `accelerate/big_modeling.py:dispatch_model` → `model.to(device)`.)
+
+Fix: the loader is now two-tier — the sdpa fast-path loads **without** `device_map` then calls `model.to(self._device)` (real tensors, no meta dispatch, sdpa still honoured), and the `except` is broadened to `Exception` so any fast-path failure retries the pre-sdpa `device_map` + default-attention config that always worked. Regression test `test_load_falls_back_when_sdpa_dispatch_fails` reproduces the meta-tensor `NotImplementedError` and asserts the fallback. Shipped via the `fix/sidecar-qwen-sdpa-meta-tensor-load` branch.

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -736,7 +736,20 @@ class QwenEngine(Engine):
         ships inside PyTorch (no extra dependency, builds on Windows) and is
         the right default for the autoregressive decode loop. QWEN_ATTN_IMPL
         overrides it (e.g. "eager" to benchmark the baseline, or
-        "flash_attention_2" if a flash-attn wheel is installed)."""
+        "flash_attention_2" if a flash-attn wheel is installed).
+
+        Loading is two-tier so the sdpa win can't harden into a load failure:
+          1. PREFERRED — request attn_implementation WITHOUT device_map, then
+             move the model ourselves. Passing device_map routes the load
+             through accelerate's dispatch_model, which leaves attention params
+             on the `meta` device when attn_implementation is set and then 500s
+             trying to move them ("Cannot copy out of meta tensor"). Without
+             device_map every weight is a real tensor, so the (0.6B bf16) model
+             moves to the target device cleanly and sdpa is honoured.
+          2. FALLBACK — on ANY failure of the fast-path (an old build rejecting
+             the kwarg, OR an accelerate/transformers combo that breaks the
+             dispatch), retry the proven-good config: device_map + the library
+             default attention. The single retry's own error propagates."""
         try:
             import torch  # type: ignore
             from qwen_tts import Qwen3TTSModel  # type: ignore
@@ -750,17 +763,18 @@ class QwenEngine(Engine):
         try:
             model = Qwen3TTSModel.from_pretrained(
                 model_id,
-                device_map=self._device,
                 dtype=torch.bfloat16,
                 attn_implementation=attn_impl,
             )
-        except (ValueError, TypeError) as e:
-            # A transformers build (or qwen_tts wrapper) that rejects the
-            # attn_implementation kwarg must not harden into a load failure —
-            # fall back to the library default and carry on.
+            model.to(self._device)
+        except Exception as e:
+            # Catch broadly: sdpa can be rejected (ValueError/TypeError) OR
+            # accepted-then-break dispatch (the meta-tensor NotImplementedError
+            # we hit on this box). Either way, fall back to the pre-sdpa load
+            # that always worked — device_map dispatch + default (eager) attn.
             log.warning(
-                "Qwen load: attn_implementation=%r rejected (%s); "
-                "retrying with the library default.",
+                "Qwen load: sdpa fast-path failed (attn_implementation=%r): %s; "
+                "falling back to device_map + library-default attention.",
                 attn_impl, e,
             )
             model = Qwen3TTSModel.from_pretrained(

--- a/server/tts-sidecar/tests/test_qwen3.py
+++ b/server/tts-sidecar/tests/test_qwen3.py
@@ -44,6 +44,7 @@ class _FakeQwenModel:
 
     def __init__(self, model_id: str) -> None:
         self.model_id = model_id
+        self.device: Any = None
         self.design_calls: list[tuple[str, str, str]] = []
         self.clone_calls: list[tuple[Any, Any]] = []
         self.prompt_calls: list[tuple[Any, str]] = []
@@ -51,6 +52,12 @@ class _FakeQwenModel:
     @classmethod
     def from_pretrained(cls, model_id: str, **_kwargs: Any) -> "_FakeQwenModel":
         return cls(model_id)
+
+    def to(self, device: Any) -> "_FakeQwenModel":
+        # The sdpa fast-path loads WITHOUT device_map then moves the model
+        # itself, so the loader now calls model.to(device). Record + chain.
+        self.device = device
+        return self
 
     def generate_voice_design(self, text: str, language: str, instruct: str):
         self.design_calls.append((text, language, instruct))
@@ -275,6 +282,11 @@ def test_load_passes_sdpa_attn_by_default(fake_qwen_runtime, monkeypatch) -> Non
 
     engine._load_qwen_model(engine.BASE_MODEL)
     assert captured["kwargs"].get("attn_implementation") == "sdpa"
+    # The sdpa fast-path must NOT pass device_map: device_map routes through
+    # accelerate's dispatch_model, which leaves attn params on the meta device
+    # when attn_implementation is set and then 500s moving them ("Cannot copy
+    # out of meta tensor"). We load real-tensor then move via model.to().
+    assert "device_map" not in captured["kwargs"]
 
 
 def test_load_honours_qwen_attn_impl_env(fake_qwen_runtime, monkeypatch) -> None:
@@ -308,6 +320,43 @@ def test_load_falls_back_when_attn_kwarg_rejected(fake_qwen_runtime, monkeypatch
     assert model is not None
     assert len(calls) == 2  # first attempt + retry
     assert "attn_implementation" in calls[0]
+    assert "attn_implementation" not in calls[1]
+
+
+def test_load_falls_back_when_sdpa_dispatch_fails(fake_qwen_runtime, monkeypatch) -> None:
+    """Regression (plan 112): attn_implementation=sdpa can be ACCEPTED but then
+    break accelerate's device_map dispatch with a meta-tensor NotImplementedError
+    ("Cannot copy out of meta tensor") — the model 500s on /load and the pill
+    reverts. The narrow (ValueError, TypeError) catch let this escape; the loader
+    must catch ANY sdpa-path failure and retry the proven-good device_map +
+    library-default-attention config."""
+    engine = fake_qwen_runtime["engine"]
+    import qwen_tts
+
+    calls: list[dict[str, Any]] = []
+
+    def flaky(model_id, **kwargs):
+        calls.append(kwargs)
+        if "attn_implementation" in kwargs:
+            # The exact failure from logs/tts.err.log: sdpa loads fine until
+            # accelerate's dispatch_model calls model.to() on meta tensors.
+            raise NotImplementedError(
+                "Cannot copy out of meta tensor; no data! Please use "
+                "torch.nn.Module.to_empty() instead of torch.nn.Module.to() "
+                "when moving module from meta to a different device."
+            )
+        return _FakeQwenModel(model_id)
+
+    monkeypatch.setattr(qwen_tts.Qwen3TTSModel, "from_pretrained", flaky)
+
+    model = engine._load_qwen_model(engine.BASE_MODEL)
+    assert model is not None
+    assert len(calls) == 2  # sdpa fast-path + device_map fallback
+    # Fast-path: attn requested, no device_map (so it loads real tensors).
+    assert "attn_implementation" in calls[0]
+    assert "device_map" not in calls[0]
+    # Fallback: device_map restored, attn dropped (library default = eager).
+    assert "device_map" in calls[1]
     assert "attn_implementation" not in calls[1]
 
 


### PR DESCRIPTION
## Summary

Fixes the Qwen **Load model** button: it spun ~5s then reverted to "Qwen idle" — the model never loaded.

**Root cause (regression from plan 112 / PR #247).** `4d82286` added `attn_implementation="sdpa"` to `QwenEngine._load_qwen_model` but kept `device_map="cuda:0"`. The kwarg is *accepted* (sdpa is valid), but `device_map` routes the load through accelerate's `dispatch_model`, which leaves attention params on the `meta` device and then raises `NotImplementedError: Cannot copy out of meta tensor` when moving them. The existing fallback only caught `(ValueError, TypeError)` — a kwarg *rejection* — so this dispatch-time failure escaped: `POST /load` returned 500, the pill reverted, no model loaded. Ground truth was the traceback in `logs/tts.err.log` (`_load_qwen_model` → `accelerate/big_modeling.py:dispatch_model` → `model.to(device)`).

**Fix.** `_load_qwen_model` is now two-tier. The sdpa fast-path requests `attn_implementation` **without** `device_map`, then `model.to(self._device)` — every weight stays a real tensor (no accelerate meta dispatch), the 0.6B bf16 model moves cleanly, and sdpa is still honoured (the perf win from plan 112 actually engages where the box supports it). The `except` is broadened to `Exception`, so any fast-path failure — old build rejecting the kwarg, or a transformers/accelerate combo that breaks the dispatch — retries the proven-good pre-sdpa config (`device_map` + library-default eager attention). The single retry's own error propagates (no loop). Loading can no longer harden into a failure over the attention knob.

### User / operator-visible delta
- Clicking **Load model** on the Qwen pill loads the model and goes green, instead of reverting to "Qwen idle".
- **Operators must restart the sidecar** to pick up the new `main.py` (it's a running Python process). `Ctrl+C` the `npm start` and re-run.
- The `attn_implementation=…` line in the sidecar log is the verdict: `sdpa` = fast-path engaged; if it logs the fallback warning + an eager impl, loading still succeeds (correctness guaranteed) — file a follow-up if sdpa never engages on a given GPU.

### Contract changes
None. Endpoints, request/response shapes, and on-disk voice formats are unchanged.

## Test plan

- `npm run test:sidecar` — `server/tts-sidecar/tests/test_qwen3.py`:
  - **new** `test_load_falls_back_when_sdpa_dispatch_fails` — reproduces the meta-tensor `NotImplementedError`; asserts the fast-path drops `device_map` and the fallback restores it. **Fails before this fix** (the error escapes the narrow catch), passes after.
  - `test_load_passes_sdpa_attn_by_default` — extended to assert **no** `device_map` on the fast path.
  - `_FakeQwenModel` gains a chaining `.to()` so the success path's `model.to(device)` is exercised; existing `test_load_*` cases stay green.
  - Full sidecar suite green (112 cases). Verified red→green against the worktree source with the bootstrapped venv.
- No frontend/server/TypeScript lines changed, so the other `npm run verify` legs are unaffected; CI's path filter runs the sidecar leg for this PR.

Regression plan: [docs/features/archive/112-qwen-synth-quick-wins.md](docs/features/archive/112-qwen-synth-quick-wins.md) — updated invariant + coverage + a **Post-ship fix** note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
