### PR TITLE
fix(sidecar): flatten Qwen batch prompt items (fix 'list' has no attribute ref_code)

### DIFF
--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -1064,7 +1064,16 @@ class QwenEngine(Engine):
                 raise RuntimeError(f"batch item {i} (voice={voice!r}): {e}") from e
             texts.append(text)
             langs.append(lang)
-            prompts.append(prompt)
+            # A designed voice's cached prompt is a LIST of VoiceClonePromptItem
+            # (qwen_tts create_voice_clone_prompt's return shape), normally
+            # length 1. generate_voice_clone wants a FLAT prompt-item list with
+            # one item per text — it does `[it.ref_code for it in items]`
+            # internally. Appending the per-voice list verbatim builds a
+            # list-of-LISTS, so `it` is a list → "'list' object has no attribute
+            # 'ref_code'". Flatten so prompt item i lines up with text i. (The
+            # single /synthesize path passes the whole length-1 list for its one
+            # text, which is why it never tripped this.)
+            prompts.extend(prompt if isinstance(prompt, list) else [prompt])
 
         self._ensure_base_loaded()
         wavs, sr = self._base.generate_voice_clone(

--- a/server/tts-sidecar/tests/test_batch_synthesis.py
+++ b/server/tts-sidecar/tests/test_batch_synthesis.py
@@ -74,6 +74,21 @@ def _read_sample(pcm: bytes, i: int) -> int:
     return (hi << 8) | lo
 
 
+class _FakePromptItem:
+    """Mirror qwen_tts.VoiceClonePromptItem. The real library reads `.ref_code`
+    (and `.ref_text`) off EACH item in the prompt list — see
+    `_prompt_items_to_voice_clone_prompt`: `ref_code=[it.ref_code for it in
+    items]`. So if the batch passes a list-of-LISTS, `it` is a list and that
+    blows up with "'list' object has no attribute 'ref_code'" — the exact 500
+    we shipped. Modelling the item as an object (not a dict) keeps the fake
+    faithful to that attribute access, so the existing batch tests now catch a
+    regression in the prompt shape."""
+
+    def __init__(self, ref_text: str) -> None:
+        self.ref_text = ref_text
+        self.ref_code = _ref_marker(ref_text)
+
+
 class _BatchFakeQwen:
     """Stand-in for qwen_tts.Qwen3TTSModel that honours LIST inputs: returns one
     wav per text element, each stamped with its text + prompt so demux swaps and
@@ -92,22 +107,29 @@ class _BatchFakeQwen:
         return [np.zeros(24000, dtype=np.float32)], 24000
 
     def create_voice_clone_prompt(self, ref_audio: Any, ref_text: str, **_kwargs: Any):
-        # Carry ref_text so the synth output can prove which voice's prompt was
-        # used for which item.
-        return {"_prompt": True, "ref_text": ref_text}
+        # The REAL library returns List[VoiceClonePromptItem] (length 1 here) —
+        # NOT a bare object. That list shape is exactly what the batch path must
+        # flatten; carrying ref_text lets the synth output prove which voice's
+        # prompt was used for which item.
+        return [_FakePromptItem(ref_text)]
 
     def generate_voice_clone(self, text: Any, language: Any, voice_clone_prompt: Any):
         texts = text if isinstance(text, list) else [text]
         langs = language if isinstance(language, list) else [language]
-        prompts = (
+        prompt_items = (
             voice_clone_prompt
             if isinstance(voice_clone_prompt, list)
             else [voice_clone_prompt]
         )
-        self.clone_calls.append({"text": texts, "language": langs, "prompt": prompts})
+        self.clone_calls.append(
+            {"text": texts, "language": langs, "prompt": prompt_items}
+        )
         # The model contract: in batch mode the list args must match length.
-        assert len(texts) == len(prompts) == len(langs)
-        wavs = [_wav_for(t, p.get("ref_text", "")) for t, p in zip(texts, prompts)]
+        assert len(texts) == len(prompt_items) == len(langs)
+        # Read `.ref_text` off each item exactly as the library reads `.ref_code`
+        # — raises AttributeError if an item is itself a list (the list-of-lists
+        # bug), so a wrong prompt shape can't pass silently.
+        wavs = [_wav_for(t, p.ref_text) for t, p in zip(texts, prompt_items)]
         return wavs, 24000
 
 
@@ -128,7 +150,7 @@ def qwen_batch_runtime(monkeypatch, tmp_path):
             fh.write(b"\x00")  # presence marker for isfile()
 
     def _load(path: str, **_kwargs: Any) -> Any:
-        return _store.get(str(path), {"_prompt": True, "ref_text": ""})
+        return _store.get(str(path), [_FakePromptItem("")])
 
     fake_torch.save = _save  # type: ignore[attr-defined]
     fake_torch.load = _load  # type: ignore[attr-defined]
@@ -179,7 +201,10 @@ def test_synthesize_batch_is_one_call_with_matching_lists(qwen_batch_runtime) ->
     # independent sequences, never a concatenated string).
     assert call["text"] == ["Apple.", "Banana!!", "Cat"]
     assert len(call["text"]) == len(call["language"]) == len(call["prompt"]) == 3
-    assert all(isinstance(p, dict) for p in call["prompt"])
+    # FLAT prompt-item list (one item per text), NOT a list-of-lists — the shape
+    # the library's `[it.ref_code for it in items]` demands.
+    assert all(not isinstance(p, list) for p in call["prompt"])
+    assert all(hasattr(p, "ref_code") for p in call["prompt"])
     assert res.sample_rate == 24000
     assert len(res.pcms) == 3
 
@@ -202,6 +227,29 @@ def test_synthesize_batch_preserves_order_text_and_voice(qwen_batch_runtime) -> 
         assert _read_sample(pcm, 1) == _ref_marker(refs[item["voice"]])
         # byte length tracks text length (independent ordering signal).
         assert len(pcm) == 2 * max(2, len(item["text"]))
+
+
+def test_batch_flattens_per_voice_prompt_item_lists(qwen_batch_runtime) -> None:
+    """Regression: each designed voice's cached prompt is a LIST of prompt items
+    (create_voice_clone_prompt's shape), so synthesize_batch must FLATTEN them
+    into one item per text. Appending the per-voice lists verbatim shipped a
+    list-of-lists, which made the library's `[it.ref_code for it in items]` raise
+    "'list' object has no attribute 'ref_code'" — a 500 on every batched Qwen
+    chapter."""
+    engine = qwen_batch_runtime["engine"]
+    for v in ("a", "b"):
+        _design(engine, v)
+    engine._base.clone_calls.clear()
+
+    res = engine.synthesize_batch(
+        "0.6b", [{"voice": "a", "text": "Hi."}, {"voice": "b", "text": "Yo."}]
+    )
+
+    prompts = engine._base.clone_calls[0]["prompt"]
+    assert len(prompts) == 2  # one prompt item per text, not two nested lists
+    assert all(not isinstance(p, list) for p in prompts)
+    assert all(hasattr(p, "ref_code") for p in prompts)
+    assert len(res.pcms) == 2
 
 
 def test_batch_of_one_matches_single_call(qwen_batch_runtime) -> None:


### PR DESCRIPTION
## Summary

Every batched Qwen chapter failed with `Local TTS sidecar returned 500: {"detail":"'list' object has no attribute 'ref_code'"}`, so regenerating a book produced nothing.

**Root cause (regression from PR #249, Qwen true batching).** A designed voice's cached clone prompt is a `List[VoiceClonePromptItem]` — that's what qwen_tts `create_voice_clone_prompt` returns (normally length 1). `synthesize_batch` did `prompts.append(prompt)` per item, building a **list-of-lists**, and passed it as `voice_clone_prompt`. The library's `_prompt_items_to_voice_clone_prompt` does `ref_code=[it.ref_code for it in items]`, so each `it` was a list → `AttributeError` → HTTP 500. The single `/synthesize` path passes the whole length-1 list for its one text, which is why single-voice work succeeded while every batched chapter failed. Ground truth: the traceback in `logs/tts.err.log` at `synthesize_batch` → `generate_voice_clone` → `[it.ref_code for it in items]`.

**Fix.** Flatten in `synthesize_batch`: `prompts.extend(prompt if isinstance(prompt, list) else [prompt])`, so `voice_clone_prompt` is a flat `[item0, item1, …]` with one prompt item per text. The library indexes `ref_code_list[i]` per text, so mixed-voice batches still bind each sentence to its own voice — no cross-bleed, no drift.

### User-visible delta
- Batched Qwen chapters synthesize again instead of 500ing on every sentence group. The batching perf path (plan 113, `QWEN_BATCH_SIZE`, default 4) works as intended.
- **Operators must restart the sidecar** to pick up the new `main.py` (running Python process).
- Immediate workaround without this build: set `QWEN_BATCH_SIZE=1` in `server/.env` (per-call kill-switch — routes Qwen through the proven single `/synthesize` path), then restart.

### Contract changes
None.

## Test plan

- `npm run test:sidecar` — `server/tts-sidecar/tests/test_batch_synthesis.py`:
  - The fake's `create_voice_clone_prompt` returned a bare **dict** — that unfaithfulness is exactly why the bug shipped green (a flat list of dicts works; a flat list of *lists* doesn't). Made it faithful: new `_FakePromptItem` (carries `.ref_code` + `.ref_text`), `create_voice_clone_prompt` returns `[_FakePromptItem(...)]`, and `generate_voice_clone` reads `.ref_text` off each item exactly as the library reads `.ref_code` (raises if an item is a list).
  - This turns the existing ordering/demux/one-call tests into regression coverage, plus a new explicit `test_batch_flattens_per_voice_prompt_item_lists`.
  - **Verified red→green**: stash the `main.py` fix → batch tests reproduce `'list' object has no attribute 'ref_text'`; restore → green. Full sidecar suite green (113 cases).
- No frontend/server/TS lines changed, so the other `npm run verify` legs are unaffected; CI's path filter runs the sidecar leg.

## Note — separate queue bug (follow-up, not in this PR)

The user also reported that failed Qwen jobs get stuck "in flight" in the generation queue and can't be deleted, accumulating as failures occur. That's a distinct server+frontend bug (the synth-failure path broadcasts `chapter_failed` but never transitions the queue entry off `in_progress`, and the cancel route 409s on `in_progress` entries). It's being addressed in a separate PR. Restarting the server clears already-stuck entries (`resetOrphanedQueueEntries()` runs on boot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
