### PR TITLE
fix(sidecar): load Qwen by moving inner module, not device_map (meta-tensor crash)

### DIFF
--- a/docs/features/archive/112-qwen-synth-quick-wins.md
+++ b/docs/features/archive/112-qwen-synth-quick-wins.md
@@ -31,7 +31,7 @@ Generation with the Qwen engine is 5–10× slower than Kokoro. Investigation ag
 - `QwenEngine.synthesize` resolves the voice prompt (`_load_voice_prompt`) **before** `_ensure_base_loaded()`, so an undesigned voice raises without paying the model load (`main.py`).
 - `_load_voice_prompt` releases `_cache_lock` across `torch.load` — a concurrent double-miss double-loads (benign, same content); it never holds the lock during I/O.
 - `design_voice` calls `self._prompt_cache.pop(voice_id, None)` (evict, **not** warm) after writing the `.pt`/`.json`, so the next synth reloads the fresh embedding.
-- `_load_qwen_model` is two-tier: the sdpa fast-path passes `attn_implementation` **without** `device_map` then `model.to(device)`; on **any** exception it retries the proven-good `device_map` + library-default (eager) config — a load must never harden into a failure over the attention knob. (Broadened from the original `(ValueError, TypeError)`-only catch — see Post-ship fix below.)
+- `_load_qwen_model` does a **single** load with **no `device_map`** and `low_cpu_mem_usage=False` (real tensors, no meta-device skeleton), then moves the **inner** module `model.model` to the device and resyncs `model.device` — `Qwen3TTSModel` is a wrapper with no `.to()`, and `device_map` 500s with a meta-tensor `NotImplementedError` on this stack. A `(ValueError, TypeError)` retry drops only `attn_implementation` (still no `device_map`, still `low_cpu_mem_usage=False`) so a build that rejects the kwarg can't harden into a load failure. (See Post-ship fix #2 below — supersedes the original two-tier `device_map`-fallback shape.)
 
 ## Test plan
 
@@ -43,9 +43,9 @@ Pytest sidecar (`server/tts-sidecar/tests/test_qwen3.py`):
 - `test_redesign_evicts_cached_prompt` — re-design drops the cache entry; next synth reloads.
 - `test_unload_clears_prompt_cache` — `unload()` empties `_prompt_cache`.
 - `test_load_passes_sdpa_attn_by_default` / `test_load_honours_qwen_attn_impl_env` — loader passes `attn_implementation="sdpa"` by default, honours `QWEN_ATTN_IMPL`.
-- `test_load_falls_back_when_attn_kwarg_rejected` — kwarg rejection (ValueError) → retry without it, load still succeeds.
-- `test_load_falls_back_when_sdpa_dispatch_fails` — sdpa **accepted then breaks** dispatch (meta-tensor `NotImplementedError`) → fast-path drops `device_map`, fallback restores it; load still succeeds (Post-ship fix regression test).
-- `test_load_passes_sdpa_attn_by_default` also asserts the fast-path passes **no** `device_map`.
+- `test_load_falls_back_when_attn_kwarg_rejected` — kwarg rejection (ValueError) → retry without it; load still succeeds, and **neither** attempt uses `device_map` (the retry keeps `low_cpu_mem_usage=False`).
+- `test_load_moves_inner_model_and_resyncs_device` — Post-ship fix #2 regression: the loader passes **no** `device_map`, forces `low_cpu_mem_usage=False`, moves the inner `model.model` to the device, and resyncs `model.device` (never calls the nonexistent `wrapper.to()`). Fails against the old `device_map`-fallback loader.
+- `test_load_passes_sdpa_attn_by_default` also asserts the load passes **no** `device_map` and `low_cpu_mem_usage=False`.
 - Existing `test_synthesize_reuses_cached_voice` (asserts `weights_only=False` on the disk load) stays green — design evicts, so the first synth still loads from disk.
 
 Whole sidecar suite green via `npm run test:sidecar` (≈141 cases, exit 0).
@@ -83,3 +83,14 @@ Open (non-blocking) manual acceptance: the baseline-vs-SDPA RTF delta and the co
 The shipped `_load_qwen_model` passed `attn_implementation="sdpa"` **alongside** `device_map="cuda:0"`. The kwarg is accepted (sdpa is valid), but `device_map` routes the load through accelerate's `dispatch_model`, which leaves attention params on the `meta` device and then raises `NotImplementedError: Cannot copy out of meta tensor` when it tries to move them. The original fallback only caught `(ValueError, TypeError)` (a kwarg *rejection*), so this dispatch-time failure escaped: `POST /load` 500'd, the Qwen pill spun ~5s and reverted to "Qwen idle" — the model never loaded. (Ground truth: `logs/tts.err.log` traceback at `main.py` `_load_qwen_model` → `accelerate/big_modeling.py:dispatch_model` → `model.to(device)`.)
 
 Fix: the loader is now two-tier — the sdpa fast-path loads **without** `device_map` then calls `model.to(self._device)` (real tensors, no meta dispatch, sdpa still honoured), and the `except` is broadened to `Exception` so any fast-path failure retries the pre-sdpa `device_map` + default-attention config that always worked. Regression test `test_load_falls_back_when_sdpa_dispatch_fails` reproduces the meta-tensor `NotImplementedError` and asserts the fallback. Shipped via the `fix/sidecar-qwen-sdpa-meta-tensor-load` branch.
+
+### Post-ship fix #2 (2026-05-26) — meta-tensor crash, real root cause
+
+Post-ship fix #1 above was wrong about the cause, and **both** of its tiers actually failed (confirmed against `logs/tts.err.log`, 30 fast-path + 40 fallback failures in one session):
+
+1. **Fast-path** — `Qwen3TTSModel` is a thin **wrapper**, not an `nn.Module`: it holds the real module at `.model` and caches the device at `.device`, and has **no `.to()`**. So `model.to(self._device)` raised `AttributeError: 'Qwen3TTSModel' object has no attribute 'to'` (not a meta error at all) and was swallowed by the broad `except`.
+2. **Fallback** — `device_map=self._device` routes through accelerate's `dispatch_model`, which on this composite model (talker / code_predictor / encoder sub-modules built from default configs, so not every param is in the checkpoint) leaves params on the `meta` device and then `.to()`s them → the meta-tensor `NotImplementedError`. This tier had no `try`/`except`, so it **propagated** — the error the user saw. (Premise of fix #1 — "`attn_implementation` leaves attn params on meta" — is false: the fallback passes no `attn_implementation` and still hit meta.) Fix #1's regression test passed only because the test fake had a `.to()` the real wrapper lacks.
+
+Stack: torch 2.6.0+cu124, transformers 4.57.3, accelerate 1.12.0.
+
+Fix: `_load_qwen_model` now does a **single** `from_pretrained` with **no `device_map`** and `low_cpu_mem_usage=False` (full real-tensor materialisation, no meta-device skeleton), then moves the **inner** `model.model` to the device and resyncs `model.device` (load-bearing — the wrapper sends generate-time inputs to `self.device`, so a stale CPU value would mismatch GPU weights mid-synth). The only retry is the narrow `(ValueError, TypeError)` kwarg-rejection case (drops `attn_implementation`, keeps the real-tensor shape; **never** uses `device_map`). The test fake (`_FakeQwenModel`) was corrected to match the real API — no wrapper `.to()`, an inner `.model` with the `.to()` — and `test_load_falls_back_when_sdpa_dispatch_fails` was replaced by `test_load_moves_inner_model_and_resyncs_device`. Shipped via the `fix/sidecar-qwen-meta-tensor-load` branch.

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -726,30 +726,32 @@ class QwenEngine(Engine):
     # --- qwen_tts integration shims (the only model-API-coupled surface) ---
 
     def _load_qwen_model(self, model_id: str) -> Any:
-        """Load a Qwen3TTSModel. Isolated so the import + from_pretrained
-        signature lives in exactly one place.
+        """Load a Qwen3TTSModel onto self._device. Isolated so the import +
+        from_pretrained signature lives in exactly one place.
 
-        Attention impl: the model supports both SDPA and flash-attn but our
-        load passed neither, so it resolved to whatever transformers picked
-        (often the slow eager path — qwen_tts even warns "Will only run the
-        manual PyTorch version" on import when flash-attn is absent). SDPA
-        ships inside PyTorch (no extra dependency, builds on Windows) and is
-        the right default for the autoregressive decode loop. QWEN_ATTN_IMPL
-        overrides it (e.g. "eager" to benchmark the baseline, or
-        "flash_attention_2" if a flash-attn wheel is installed).
+        Two facts about the real qwen_tts API + this transformers/accelerate
+        stack drive the load shape (both confirmed against logs/tts.err.log):
 
-        Loading is two-tier so the sdpa win can't harden into a load failure:
-          1. PREFERRED — request attn_implementation WITHOUT device_map, then
-             move the model ourselves. Passing device_map routes the load
-             through accelerate's dispatch_model, which leaves attention params
-             on the `meta` device when attn_implementation is set and then 500s
-             trying to move them ("Cannot copy out of meta tensor"). Without
-             device_map every weight is a real tensor, so the (0.6B bf16) model
-             moves to the target device cleanly and sdpa is honoured.
-          2. FALLBACK — on ANY failure of the fast-path (an old build rejecting
-             the kwarg, OR an accelerate/transformers combo that breaks the
-             dispatch), retry the proven-good config: device_map + the library
-             default attention. The single retry's own error propagates."""
+          1. `Qwen3TTSModel` is a thin WRAPPER, not an nn.Module — it holds the
+             real module at `.model` and caches the device at `.device`. It has
+             NO `.to()`, so calling `model.to(device)` raises AttributeError. We
+             move `model.model` ourselves and resync `model.device`; the wrapper
+             sends generate-time inputs to `self.device`
+             (qwen3_tts_model.py: `input_ids.to(self.device)`), so a stale CPU
+             value there would mismatch the GPU weights mid-synth.
+          2. Passing `device_map` routes the load through accelerate's
+             dispatch_model, which on this composite model (talker /
+             code_predictor / encoder sub-modules built from default configs)
+             leaves some params on the `meta` device and then 500s moving them
+             ("Cannot copy out of meta tensor"). We avoid device_map entirely
+             and force `low_cpu_mem_usage=False` so every weight materialises as
+             a real tensor that `.to()` can move.
+
+        Attention impl defaults to sdpa (PyTorch-native, no extra dep, the right
+        default for the autoregressive decode loop); QWEN_ATTN_IMPL overrides it
+        (e.g. "eager" to bench the baseline, "flash_attention_2" with a wheel).
+        A build that *rejects* the kwarg retries without it — the load never
+        hardens into a failure over the attention knob."""
         try:
             import torch  # type: ignore
             from qwen_tts import Qwen3TTSModel  # type: ignore
@@ -760,33 +762,42 @@ class QwenEngine(Engine):
                 "server/tts-sidecar."
             ) from e
         attn_impl = os.environ.get("QWEN_ATTN_IMPL", "sdpa")
+        # low_cpu_mem_usage=False: full CPU materialisation, no meta-device
+        # skeleton, so the move below can never hit "copy out of meta tensor".
+        common = {"dtype": torch.bfloat16, "low_cpu_mem_usage": False}
         try:
             model = Qwen3TTSModel.from_pretrained(
-                model_id,
-                dtype=torch.bfloat16,
-                attn_implementation=attn_impl,
+                model_id, attn_implementation=attn_impl, **common
             )
-            model.to(self._device)
-        except Exception as e:
-            # Catch broadly: sdpa can be rejected (ValueError/TypeError) OR
-            # accepted-then-break dispatch (the meta-tensor NotImplementedError
-            # we hit on this box). Either way, fall back to the pre-sdpa load
-            # that always worked — device_map dispatch + default (eager) attn.
+        except (ValueError, TypeError) as e:
+            # Only an old transformers/qwen_tts build that doesn't know the
+            # kwarg lands here — retry with library-default attention. (A
+            # device_map fallback is deliberately NOT used: it is the path that
+            # 500s with the meta-tensor NotImplementedError on this stack.)
             log.warning(
-                "Qwen load: sdpa fast-path failed (attn_implementation=%r): %s; "
-                "falling back to device_map + library-default attention.",
+                "Qwen load: attn_implementation=%r rejected (%s); retrying without it.",
                 attn_impl, e,
             )
-            model = Qwen3TTSModel.from_pretrained(
-                model_id,
-                device_map=self._device,
-                dtype=torch.bfloat16,
-            )
+            model = Qwen3TTSModel.from_pretrained(model_id, **common)
+        # Move the inner nn.Module to the device and resync the wrapper's cached
+        # device (the wrapper has no `.to()` — see docstring point 1).
+        inner = getattr(model, "model", None)
+        if inner is not None and hasattr(inner, "to"):
+            inner.to(self._device)
+        else:  # defensive: wrapper-API drift moved the module — move the object.
+            model.to(self._device)
+        try:
+            model.device = torch.device(self._device)
+        except Exception:
+            pass
         # Surface the impl that actually took effect (getattr-guarded — the
         # nested attribute path can drift across qwen_tts/transformers versions).
         resolved = getattr(getattr(model, "model", None), "config", None)
         resolved_impl = getattr(resolved, "_attn_implementation", "unknown")
-        log.info("Qwen model=%s attn_implementation=%s", model_id, resolved_impl)
+        log.info(
+            "Qwen model=%s attn_implementation=%s device=%s",
+            model_id, resolved_impl, self._device,
+        )
         return model
 
     def _ensure_base_loaded(self) -> None:

--- a/server/tts-sidecar/tests/test_batch_synthesis.py
+++ b/server/tts-sidecar/tests/test_batch_synthesis.py
@@ -89,14 +89,31 @@ class _FakePromptItem:
         self.ref_code = _ref_marker(ref_text)
 
 
+class _BatchFakeInner:
+    """Inner nn.Module of the Qwen3TTSModel wrapper — the ONLY object with a
+    `.to()`. The wrapper itself has none (the loader moves `model.model` and
+    resyncs `model.device`), so the fake must too."""
+
+    def __init__(self) -> None:
+        self.device: Any = None
+        self.config = types.SimpleNamespace(_attn_implementation="sdpa")
+
+    def to(self, device: Any) -> "_BatchFakeInner":
+        self.device = device
+        return self
+
+
 class _BatchFakeQwen:
     """Stand-in for qwen_tts.Qwen3TTSModel that honours LIST inputs: returns one
     wav per text element, each stamped with its text + prompt so demux swaps and
     cross-item bleed are detectable. Records every generate_voice_clone call so
-    the list-form invariant can be asserted."""
+    the list-form invariant can be asserted. A thin WRAPPER with no `.to()` (the
+    real nn.Module lives at `.model`), matching the real API."""
 
     def __init__(self, model_id: str) -> None:
         self.model_id = model_id
+        self.model = _BatchFakeInner()  # the inner module the loader moves
+        self.device: Any = None  # resynced by the loader after the move
         self.clone_calls: list[dict[str, Any]] = []
 
     @classmethod
@@ -155,6 +172,7 @@ def qwen_batch_runtime(monkeypatch, tmp_path):
     fake_torch.save = _save  # type: ignore[attr-defined]
     fake_torch.load = _load  # type: ignore[attr-defined]
     fake_torch.bfloat16 = "bfloat16"  # type: ignore[attr-defined]
+    fake_torch.device = lambda d: d  # type: ignore[attr-defined]  # loader resyncs model.device
     fake_torch.cuda = types.SimpleNamespace(  # type: ignore[attr-defined]
         is_available=lambda: False, empty_cache=lambda: None
     )

--- a/server/tts-sidecar/tests/test_qwen3.py
+++ b/server/tts-sidecar/tests/test_qwen3.py
@@ -37,14 +37,31 @@ if str(SIDECAR_ROOT) not in sys.path:
 import main  # noqa: E402
 
 
+class _FakeInnerModule:
+    """Stand-in for the real nn.Module at Qwen3TTSModel.model. The WRAPPER is
+    not an nn.Module and has no `.to()`; only this inner object does. Faithful
+    to the real qwen_tts API so a regression back to `wrapper.to()` fails here
+    the same way it does on the real weights (AttributeError on the wrapper)."""
+
+    def __init__(self) -> None:
+        self.device: Any = None
+        self.config = types.SimpleNamespace(_attn_implementation="sdpa")
+
+    def to(self, device: Any) -> "_FakeInnerModule":
+        self.device = device
+        return self
+
+
 class _FakeQwenModel:
-    """Stand-in for qwen_tts.Qwen3TTSModel. Implements just the surface
-    QwenEngine touches. Audio is a flat-zero float32 buffer at 24 kHz —
-    enough to exercise the int16 conversion + the (wavs, sr) return shape."""
+    """Stand-in for qwen_tts.Qwen3TTSModel — a thin WRAPPER (NOT an nn.Module).
+    The real nn.Module lives at `.model`; the wrapper caches its device at
+    `.device` and has NO `.to()`. Audio is a flat-zero float32 buffer at 24 kHz
+    — enough to exercise the int16 conversion + the (wavs, sr) return shape."""
 
     def __init__(self, model_id: str) -> None:
         self.model_id = model_id
-        self.device: Any = None
+        self.model = _FakeInnerModule()  # the real nn.Module the loader moves
+        self.device: Any = None  # resynced by the loader after the move
         self.design_calls: list[tuple[str, str, str]] = []
         self.clone_calls: list[tuple[Any, Any]] = []
         self.prompt_calls: list[tuple[Any, str]] = []
@@ -53,11 +70,8 @@ class _FakeQwenModel:
     def from_pretrained(cls, model_id: str, **_kwargs: Any) -> "_FakeQwenModel":
         return cls(model_id)
 
-    def to(self, device: Any) -> "_FakeQwenModel":
-        # The sdpa fast-path loads WITHOUT device_map then moves the model
-        # itself, so the loader now calls model.to(device). Record + chain.
-        self.device = device
-        return self
+    # NB: deliberately NO `.to()` — the real wrapper has none. The loader must
+    # move `self.model` (the inner module) and resync `self.device`.
 
     def generate_voice_design(self, text: str, language: str, instruct: str):
         self.design_calls.append((text, language, instruct))
@@ -101,6 +115,7 @@ def fake_qwen_runtime(monkeypatch, tmp_path):
     fake_torch.save = _save  # type: ignore[attr-defined]
     fake_torch.load = _load  # type: ignore[attr-defined]
     fake_torch.bfloat16 = "bfloat16"  # type: ignore[attr-defined]
+    fake_torch.device = lambda d: d  # type: ignore[attr-defined]  # loader resyncs model.device
     fake_cuda = types.SimpleNamespace(is_available=lambda: False, empty_cache=lambda: None)
     fake_torch.cuda = fake_cuda  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "torch", fake_torch)
@@ -282,11 +297,12 @@ def test_load_passes_sdpa_attn_by_default(fake_qwen_runtime, monkeypatch) -> Non
 
     engine._load_qwen_model(engine.BASE_MODEL)
     assert captured["kwargs"].get("attn_implementation") == "sdpa"
-    # The sdpa fast-path must NOT pass device_map: device_map routes through
-    # accelerate's dispatch_model, which leaves attn params on the meta device
-    # when attn_implementation is set and then 500s moving them ("Cannot copy
-    # out of meta tensor"). We load real-tensor then move via model.to().
+    # The loader must NOT pass device_map: device_map routes through accelerate's
+    # dispatch_model, which leaves params on the meta device on this composite
+    # model and then 500s moving them ("Cannot copy out of meta tensor"). We
+    # force real tensors (low_cpu_mem_usage=False) then move the inner module.
     assert "device_map" not in captured["kwargs"]
+    assert captured["kwargs"].get("low_cpu_mem_usage") is False
 
 
 def test_load_honours_qwen_attn_impl_env(fake_qwen_runtime, monkeypatch) -> None:
@@ -321,43 +337,33 @@ def test_load_falls_back_when_attn_kwarg_rejected(fake_qwen_runtime, monkeypatch
     assert len(calls) == 2  # first attempt + retry
     assert "attn_implementation" in calls[0]
     assert "attn_implementation" not in calls[1]
+    # Neither attempt may use device_map (the meta-tensor 500 path) — the retry
+    # only drops the attention knob, it keeps the real-tensor load shape.
+    assert "device_map" not in calls[0]
+    assert "device_map" not in calls[1]
+    assert calls[1].get("low_cpu_mem_usage") is False
 
 
-def test_load_falls_back_when_sdpa_dispatch_fails(fake_qwen_runtime, monkeypatch) -> None:
-    """Regression (plan 112): attn_implementation=sdpa can be ACCEPTED but then
-    break accelerate's device_map dispatch with a meta-tensor NotImplementedError
-    ("Cannot copy out of meta tensor") — the model 500s on /load and the pill
-    reverts. The narrow (ValueError, TypeError) catch let this escape; the loader
-    must catch ANY sdpa-path failure and retry the proven-good device_map +
-    library-default-attention config."""
+def test_load_moves_inner_model_and_resyncs_device(fake_qwen_runtime, monkeypatch) -> None:
+    """Regression (the meta-tensor /load crash): Qwen3TTSModel is a WRAPPER with
+    no `.to()`, and passing device_map 500s with a meta-tensor
+    NotImplementedError on this transformers/accelerate stack. So the loader
+    must (a) never pass device_map and force low_cpu_mem_usage=False for real
+    tensors, and (b) move the inner nn.Module (`model.model`) and resync
+    `model.device` — NOT call `wrapper.to()` (which AttributeErrors on the real
+    weights, and on _FakeQwenModel which deliberately omits `.to()`)."""
     engine = fake_qwen_runtime["engine"]
-    import qwen_tts
-
-    calls: list[dict[str, Any]] = []
-
-    def flaky(model_id, **kwargs):
-        calls.append(kwargs)
-        if "attn_implementation" in kwargs:
-            # The exact failure from logs/tts.err.log: sdpa loads fine until
-            # accelerate's dispatch_model calls model.to() on meta tensors.
-            raise NotImplementedError(
-                "Cannot copy out of meta tensor; no data! Please use "
-                "torch.nn.Module.to_empty() instead of torch.nn.Module.to() "
-                "when moving module from meta to a different device."
-            )
-        return _FakeQwenModel(model_id)
-
-    monkeypatch.setattr(qwen_tts.Qwen3TTSModel, "from_pretrained", flaky)
+    captured = _patch_from_pretrained(fake_qwen_runtime, monkeypatch)
 
     model = engine._load_qwen_model(engine.BASE_MODEL)
-    assert model is not None
-    assert len(calls) == 2  # sdpa fast-path + device_map fallback
-    # Fast-path: attn requested, no device_map (so it loads real tensors).
-    assert "attn_implementation" in calls[0]
-    assert "device_map" not in calls[0]
-    # Fallback: device_map restored, attn dropped (library default = eager).
-    assert "device_map" in calls[1]
-    assert "attn_implementation" not in calls[1]
+
+    # No device_map ever; real-tensor load forced.
+    assert "device_map" not in captured["kwargs"]
+    assert captured["kwargs"].get("low_cpu_mem_usage") is False
+    # The inner module was moved to the engine device; the wrapper's cached
+    # device was resynced to match (so generate-time inputs land on the GPU).
+    assert model.model.device == engine._device
+    assert model.device == engine._device
 
 
 # ── QWEN_VOICES_DIR relocation + legacy migration (sidecar-qwen-voice-dir) ──
@@ -405,6 +411,7 @@ def test_designed_voice_survives_restart_at_env_dir(monkeypatch, tmp_path) -> No
     fake_torch.save = _save  # type: ignore[attr-defined]
     fake_torch.load = _load  # type: ignore[attr-defined]
     fake_torch.bfloat16 = "bfloat16"  # type: ignore[attr-defined]
+    fake_torch.device = lambda d: d  # type: ignore[attr-defined]
     fake_torch.cuda = types.SimpleNamespace(  # type: ignore[attr-defined]
         is_available=lambda: False, empty_cache=lambda: None
     )


### PR DESCRIPTION
## Summary

Fixes the `NotImplementedError: Cannot copy out of meta tensor` crash that made **every** Qwen3-TTS load fail — `POST /load {engine:"qwen"}` (and the first synth of any Qwen voice) 500'd, the Qwen pill spun ~5s and reverted to "Qwen idle", so no Qwen voice could synthesize at all. PR #250 attempted this fix but was incomplete and built on a wrong root-cause theory.

### Root cause (confirmed against `logs/tts.err.log` — 30 fast-path + 40 fallback failures in one session)

`QwenEngine._load_qwen_model` was two-tier and **both tiers failed**, for two different reasons:

1. **Fast-path** — `Qwen3TTSModel` is a thin **wrapper**, not an `nn.Module`: it holds the real module at `.model`, caches the device at `.device`, and has **no `.to()`**. So `model.to(device)` raised `AttributeError: 'Qwen3TTSModel' object has no attribute 'to'` (not a meta error at all), swallowed by the broad `except`.
2. **Fallback** — `device_map=` routes the load through accelerate's `dispatch_model`, which on this composite model (talker / code_predictor / encoder sub-modules built from default configs, not all in the checkpoint) leaves params on the `meta` device and then `.to()`s them → the meta-tensor `NotImplementedError`. This tier had no `try`/`except`, so it propagated — the error users saw.

PR #250's premise ("`attn_implementation` leaves attn params on meta") was false: the fallback passes no `attn_implementation` and still hit meta. Its regression test passed only because the test fake had a `.to()` the real wrapper lacks.

Stack: torch 2.6.0+cu124, transformers 4.57.3, accelerate 1.12.0.

### Fix

`_load_qwen_model` now does a **single** `from_pretrained` with **no `device_map`** and `low_cpu_mem_usage=False` (full real-tensor materialisation — no meta-device skeleton), then moves the **inner** `model.model` to the device and resyncs `model.device`. The resync is load-bearing: the wrapper sends generate-time inputs to `self.device`, so a stale CPU value would mismatch the GPU weights mid-synth. The only retry is the narrow `(ValueError, TypeError)` attn-kwarg-rejection case (drops `attn_implementation`, keeps the real-tensor shape; **never** uses `device_map`). The `device_map` fallback is removed entirely — it was the broken path.

## Changes

- **`server/tts-sidecar/main.py`** — rewrite `_load_qwen_model` (single real-tensor load, move inner module, resync device; rewritten docstring documenting the wrapper-not-nn.Module fact and the no-`device_map` rationale).
- **`server/tts-sidecar/tests/test_qwen3.py`** — `_FakeQwenModel` corrected to match the real wrapper API (no wrapper `.to()`, an inner `.model` with the `.to()`); `fake_torch.device` added; `test_load_passes_sdpa_attn_by_default` and `test_load_falls_back_when_attn_kwarg_rejected` assert no `device_map` + `low_cpu_mem_usage=False`; `test_load_falls_back_when_sdpa_dispatch_fails` **replaced** by `test_load_moves_inner_model_and_resyncs_device` (fails against the old loader, passes after).
- **`server/tts-sidecar/tests/test_batch_synthesis.py`** — `_BatchFakeQwen` given the same faithful inner `.model` (it also lacked one — it passed before only because the old `device_map` fallback never called `.to()`).
- **`docs/features/archive/112-qwen-synth-quick-wins.md`** — "Post-ship fix #2" note correcting the root cause and the `_load_qwen_model` invariant + test-list.

## Test plan

- **Sidecar pytest:** 113 passed. The new `test_load_moves_inner_model_and_resyncs_device` **fails against the pre-fix loader** (wrapper `.to()` AttributeError) and passes after — verified via a `git stash` of `main.py` round-trip.
- **Real GPU (the actual bug):** both the 0.6B Base and 1.7B VoiceDesign models load onto `cuda:0` — log `Qwen model=… attn_implementation=sdpa device=cuda:0`, no meta-tensor traceback — and a full design → clone → synth produced audio (24 kHz PCM), proving the `model.device` resync (no device-mismatch at generate time).
- **typecheck + frontend + server + build:** green. (e2e was run separately and passes in isolation; the full-battery e2e timeouts were environmental flakes unrelated to this sidecar-only change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
