### PR TITLE
docs(docs): record clean FA2-vs-SDPA benchmark + resolve side-5

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -307,15 +307,7 @@ Source: net-new (2026-05-26). Surfaced in plan 112. Our designed voices use ICL 
 - _Depends on:_ plan 112 shipped (bench harness measures the delta).
 - _Benefit (technical):_ potentially the largest single per-call speedup short of batching — but it trades the very thing the bespoke-voice design exists to guarantee (consistent identity), so it must be measured, not assumed.
 
-#### `side-5` — Make FlashAttention-2 the Qwen default if it benchmarks faster than SDPA
-
-Source: net-new (2026-05-26). Spun off from plan 115, which shipped the opt-in `--flash-attn` wheel install but deliberately kept SDPA the default (plan-112 decision) pending a measurement. FA2's win is largest on long-sequence prefill; for single-token autoregressive TTS decode the gain over SDPA is often modest, so the flip must be earned by numbers, not assumed.
-
-- _What:_ Once the FA2-vs-SDPA RTF benchmark is recorded in plan 115, if `flash_attention_2` measurably beats `sdpa` on the target GPU (serial AND the plan-113 batch path), flip the `QWEN_ATTN_IMPL` default in `server/tts-sidecar/main.py` from `sdpa` to `flash_attention_2`. Keep the existing graceful fallback so a box without the wheel still loads on the library default.
-- _Acceptance:_ Plan 115 carries the recorded RTF numbers; if they favour FA2, `main.py` defaults to `flash_attention_2`, a box WITHOUT the wheel still loads (fallback verified), and `install-qwen3.mjs --flash-attn` is referenced from the default-flip so deployers know to install the wheel. If the numbers DON'T favour FA2, close this item as "measured, SDPA stays" and record why.
-- _Key files:_ `server/tts-sidecar/main.py` (`_load_qwen_model` attn default); `server/tts-sidecar/README.md` (`QWEN_ATTN_IMPL` doc); plan 115 Ship notes + plan 108 install docs.
-- _Depends on:_ plan 115 shipped (the opt-in wheel + bench procedure) and the FA2-vs-SDPA benchmark recorded.
-- _Benefit (technical):_ if FA2 wins, every Qwen synth gets faster for free on a wheel deployers already have an opt-in path to; if it doesn't, the measurement retires a recurring "should we use flash-attn?" question with a number.
+#### `srv-3` — Per-call local→Gemini analyzer overflow
 
 Source: net-new (2026-05-21). Spun off from the perf-tuning survey (item B4).
 

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -87,8 +87,6 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 
 - [113 — Qwen3-TTS true batching](113-qwen-true-batching.md) — `active`. Packs every Qwen sentence in a chapter into `QWEN_BATCH_SIZE`-capped batches synthesised in ONE `generate_voice_clone(text=[…])` call (one batched forward per decode step instead of N), via a new Qwen-only sidecar `POST /synthesize-batch` (length-prefixed binary frame) and an OPTIONAL `TtsProvider.synthesizeBatch` seam. Whole-chapter scatter/gather: batches mix narrator + dialogue voices (per-element prompts) and scatter each chunk back to its own sentence index, so the index-order reassembly + plan-107 determinism are reused verbatim. Independent-sequence batching (not plan-70d string folding) means no shared decode context → no voice drift; the stall heartbeat now covers long batches; `=1` is the per-call kill-switch. Coqui/Kokoro/Gemini untouched. Code + automated tests landed; real-GPU speedup/drift acceptance pending.
 
-- [115 — Opt-in FlashAttention-2 install (Windows)](115-flash-attn-opt-in.md) — `active`. `install-qwen3.mjs --flash-attn` (or `QWEN_INSTALL_FLASH_ATTN=1`) pip-installs a pinned community prebuilt wheel (`flash_attn 2.7.4` / `cu124` / `torch2.6.0` / `cp311` / `win_amd64`) matching the sidecar venv exactly — the backend `qwen_tts` is built for but PyPI ships no Windows wheel of. Platform/version-gated + non-fatal via the pure `resolveFlashAttnInstall()`; SDPA stays the default (plan 112) and activation is manual via `QWEN_ATTN_IMPL=flash_attention_2`. Installer + node:test gate + docs landed; FA2-vs-SDPA benchmark and the default-flip decision pending.
-
 ### G. Generation
 
 - [16 — Generation stream](16-generation-stream.md) — Chapter audio SSE stream. Cross-links to plan 28 for the on-disk format.
@@ -169,6 +167,7 @@ Plans that shipped and are no longer load-bearing for in-flight work live in
 [`archive/`](archive/README.md). The git log is the changelog; this section is a
 breadcrumb so cross-references still resolve.
 
+- [115 — Opt-in FlashAttention-2 install (Windows)](archive/115-flash-attn-opt-in.md) — `install-qwen3.mjs --flash-attn` / `QWEN_INSTALL_FLASH_ATTN=1` pip-installs a pinned community prebuilt wheel (`flash_attn 2.7.4` / `cu124` / `torch2.6.0` / `cp311` / `win_amd64`); platform/version-gated + non-fatal via the pure `resolveFlashAttnInstall()`. SDPA stays the default — benchmarked 2026-05-26: FA2 ≈ SDPA (modest, noisy edge; TTS is decode-bound), so `side-5` resolved "SDPA stays". Full data in [tts-performance.md](../tts-performance.md). Shipped 2026-05-26 (PR #260).
 - [22a — Voice library compare](archive/22a-voice-library-compare.md) — Two-cast-member compare entry point on the Voices tab; reuses `CompareCastModal`; same-/different-base-voice badge on the selection pill. Shipped 2026-05-17.
 - [39 — Purge WAV (MP3 is the only format)](archive/39-purge-wav.md) — Dropped the legacy-WAV fallback once documented in plan 28; locator + routes + types now MP3-only. Shipped 2026-05-17.
 - [40 — Cover framing + local-disk upload](archive/40-cover-framing-and-upload.md) — Three-tab CoverPicker (Search / Upload / Frame), PNG → JPEG transcode server-side, render-time pan + zoom via `object-position` + `transform`, account-level default for the initial tab. Shipped 2026-05-17.

--- a/docs/features/archive/115-flash-attn-opt-in.md
+++ b/docs/features/archive/115-flash-attn-opt-in.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: stable
 shipped: null
 owner: null
 ---
@@ -56,16 +56,16 @@ Fully reversible: the flag is opt-in, the wheel is a single pip package (`pip un
 
 **Benchmark results (RTX 4070, 2026-05-26):**
 
-SDPA default — baseline:
+SDPA — initial baseline (⚠️ later found **contention-confounded**: VRAM was ~97% full; the clean re-measure below is 3–5× faster):
 
 | Run | RTF | Note |
 |---|---|---|
 | Serial `/synthesize`, cold | 8.52 | first call |
-| Serial `/synthesize`, warm | 6.6–8.3 | warm barely helps |
-| Batch `/synthesize-batch`, 8 same-voice | 2.61 | clean best case |
-| Full pipeline, real mixed-cast chapter | 4.12 | the number that actually matters |
+| Serial `/synthesize`, warm | 6.6–8.3 | contended |
+| Batch `/synthesize-batch`, 8 same-voice | 2.61 | contended |
+| Full pipeline, real mixed-cast chapter | 4.12 | contended |
 
-The `flash_attention_2` comparison is **still pending** — `side-5` (the default-flip decision) stays open until those numbers land here. Note the dominant lever in this data is **batching** (2.61 batched vs 6.6–8.3 serial ≈ 3×), NOT the attention backend — that's `side-3` (true batching, in flight), and these numbers reinforce it. FA2's expected ceiling for single-token autoregressive decode is modest, so it's unlikely to move the 4.12 full-pipeline figure much regardless.
+**FA2 vs SDPA — clean-VRAM re-measure (RTX 4070, 2026-05-26).** With the GPU freed, SDPA batch-8 is ~1.0–1.3 RTF (not 2.6), and **FA2 ≈ SDPA**: FA2 modestly faster at B=4 (~1.45 vs ~1.85) and posts the single fastest result (B=8 0.83) but is **noisier** (a 1.81 stall), while SDPA is rock-stable (B=8 1.28). Concurrency 2 adds ~27% throughput; 4 plateaus. TTS is token-by-token **decode**, so FA2's prefill optimization is a small, inconsistent edge. **Decision: SDPA stays the default; FA2 stays opt-in** — `side-5` resolved (see Ship notes). Full data + tables: [docs/tts-performance.md](../../tts-performance.md). The dominant lever is **batching** (`QWEN_BATCH_SIZE`, plan 113) + VRAM headroom, not the attention backend.
 
 ## Out of scope
 
@@ -76,4 +76,8 @@ The `flash_attention_2` comparison is **still pending** — `side-5` (the defaul
 
 ## Ship notes
 
-(Filled in when status flips to `stable`. Pending: the FA2-vs-SDPA benchmark outcome and the default-flip decision.)
+Shipped 2026-05-26. The opt-in installer (`install-qwen3.mjs --flash-attn` / `QWEN_INSTALL_FLASH_ATTN=1`; pinned `flash_attn-2.7.4+cu124torch2.6.0cxx11abiFALSE-cp311-cp311-win_amd64.whl`) merged via **PR #260**; SDPA stays the default, no `main.py` change.
+
+FA2-vs-SDPA was benchmarked on the RTX 4070 (clean VRAM) on 2026-05-26 — full data in [docs/tts-performance.md](../../tts-performance.md). **FA2 ≈ SDPA**: modestly faster at small batch and the single fastest result (batch-8 0.83 RTF) but with high run-to-run variance (a 1.81 stall), versus rock-stable SDPA (batch-8 1.28). TTS is decode-bound, so FA2's prefill optimization yields only a small, noisy edge — not enough to justify flipping the default.
+
+**Decision: SDPA stays the Qwen default; FA2 remains opt-in for the keen.** `side-5` (the default-flip) is resolved as "measured — SDPA stays" and removed from the backlog. A side benefit confirmed during the run: clearing VRAM matters far more than the attention backend — the earlier 6.6–8.3 serial / 4.12 pipeline figures were contention artifacts (VRAM at 97%); clean batch-8 is ~1.0–1.3 RTF, so a full novel is an ~8–10 h overnight job, not the ~40 h first implied.

--- a/docs/tts-performance.md
+++ b/docs/tts-performance.md
@@ -57,7 +57,9 @@ Load-time (code, not env): `dtype=bfloat16` + `low_cpu_mem_usage=False` (real-te
 
 ## Records
 
-### Qwen3-TTS 0.6B — sdpa, bf16, 4070 — 2026-05-26
+### Qwen3-TTS 0.6B — sdpa, bf16, 4070 — 2026-05-26 ⚠️ contention-confounded
+
+> **Superseded by the clean run below.** Every number in this section was measured while VRAM sat at **~97% full** (the app's idle Qwen on `:9000` + repeated GPU hammering). Re-measured on a freed GPU, the figures are **3–5× faster** — so the "RTF 4–8 / ~40 h per novel / too slow for books" read here was wrong. Kept for history per the append-only rule; do not cite these numbers.
 
 _Settings:_ `QWEN_ATTN_IMPL=sdpa` (**confirmed** from the model-load log), `dtype=bfloat16`, `low_cpu_mem_usage=False`. The full-pipeline row used the running `server/.env` values for `QWEN_BATCH_SIZE` and `GPU_VRAM_BUDGET` (deploy defaults are `4` and `2`) — not independently re-verified for this run. The serial and batch micro-bench rows hit the sidecar's `/synthesize` and `/synthesize-batch` **directly**, bypassing the server-side `QWEN_BATCH_SIZE`/semaphore — the batch row was one explicit 8-item call.
 
@@ -81,6 +83,37 @@ _Settings:_ `QWEN_ATTN_IMPL=sdpa` (**confirmed** from the model-load log), `dtyp
 - Real mixed-cast chapters run at ~RTF 4 → **~2 h of compute per chapter**.
 - **Kokoro (sub-1 RTF) stays the workhorse** for anything book-length; Qwen bespoke per-character voices are a "render a few chapters and wait" / overnight feature.
 
+### Qwen3-TTS 0.6B — clean VRAM, SDPA vs FA2 + concurrency — 2026-05-26 (supersedes the above)
+
+_Settings:_ dedicated benchmark sidecar on `:9001`, `PRELOAD_QWEN=1`, **Kokoro/Coqui not loaded**, the app's `:9000` Qwen unloaded → **VRAM ~0.8 GB base** (vs ~97% full for the run above — that contention was the whole 3–5× gap). `dtype=bfloat16`, `low_cpu_mem_usage=False`. Attention impl **confirmed from each load log** (`flash_attention_2` did NOT silently fall back to sdpa). flash-attn 2.7.4 wheel installed via plan 115. Each batch = one `/synthesize-batch` call of N items; concurrency = N such calls fired in parallel. 2 samples per cell.
+
+**SDPA vs FlashAttention-2** (RTF = wall ÷ audio; lower is better; real "DAY ONE" Keefe prose, `qwen-narrator`):
+
+| Batch | SDPA | FA2 |
+|---|---|---|
+| serial `/synthesize` | 3.2, 3.4 | 3.1, 3.8 — *serial is high-variance; judge on batch* |
+| B=4 | 1.80, 1.91 | **1.41, 1.50** |
+| B=6 | 1.13, 1.14 | 1.16, **0.97** |
+| B=8 | **1.28, 1.28** (stable) | **0.83**, 1.81 (bimodal — one stall) |
+
+**Concurrency** (SDPA, batch-8 per stream — the `GPU_VRAM_BUDGET` lever):
+
+| Parallel streams | Aggregate throughput |
+|---|---|
+| 1 | 0.96× realtime |
+| 2 | **1.22× realtime** (+27%) |
+| 4 | 1.20× realtime (plateau) |
+
+**Findings:**
+
+- **Batching is the dominant lever** — serial ~3.3 → batch-8 ~1.0–1.3 RTF; bigger batch = better, B=6–8 the sweet spot.
+- **FA2 ≈ SDPA.** FA2 is modestly faster at B=4 and posts the single fastest result (B=8 0.83), but is **noisier** (the 1.81 stall) while SDPA is rock-stable. Consistent with the prefill-vs-decode theory: TTS is token-by-token decode, so FA2's optimization yields only a small, inconsistent edge. **SDPA stays the sensible default; FA2 is a legit opt-in.** (Resolves `side-5`; see plan 115 Ship notes.)
+- **Concurrency 2 adds ~27%; 4 plateaus** → `GPU_VRAM_BUDGET=2` is optimal. 4-wide wastes VRAM (and risks OOM on 8 GB) for no throughput gain — confirms `side-3`'s "batching scales, concurrency plateaus".
+
+**Optimal config on the 4070:** `QWEN_BATCH_SIZE=8`, `GPU_VRAM_BUDGET=2`, `QWEN_ATTN_IMPL=sdpa` (FA2 optional), no other models co-resident.
+
+**Corrected full-book reality:** a ~10 h-audio novel ≈ **~8–10 h** (overnight), **not** the ~40 h the contended run implied. Caveat: these are **micro-bench** (raw model). The real per-character pipeline adds per-voice batch fragmentation + MP3 assembly, so end-to-end chapters run somewhat slower than the micro RTF — but far better than the contended 4.12. A clean full-pipeline re-measure is still owed for the true end-to-end number.
+
 ### Kokoro v1 — 4070 — _TODO_
 
 Not yet benchmarked here. Expected sub-1 RTF on GPU. Run `bench-tts.py --engine kokoro --voice af_heart` and add a row as the reference point.
@@ -90,5 +123,6 @@ Not yet benchmarked here. Expected sub-1 RTF on GPU. Run `bench-tts.py --engine 
 1. **Cross-voice batching** — batch mixed-cast sentences in one forward regardless of voice (each item keeps its own clone prompt). Would close the 4.1-vs-2.6 mixed-cast gap; the single biggest realistic win for real chapters.
 2. **Larger batch sizes** (VRAM-permitting) + a **concurrency sweep** (`bench-tts.py --concurrency 1/2/4`) to confirm batching scales where concurrency plateaus.
 3. **`x_vector_only_mode=True`** ([`side-4`](BACKLOG.md)) — drop the ICL prefix; speed vs. fidelity A/B.
-4. **flash-attn** wheel on Windows (vs. the current SDPA path).
+4. ~~**flash-attn** wheel on Windows~~ — **measured 2026-05-26: FA2 ≈ SDPA (modest + noisy); SDPA stays default, FA2 opt-in** (plan 115 / `side-5` resolved).
 5. **Quantization** (int8/fp8) of the 0.6B base.
+6. **Clean full-pipeline re-measure** — real per-character chapter under freed VRAM, for the true end-to-end RTF (the micro-bench is raw-model only).


### PR DESCRIPTION
## Summary

Benchmarked **FlashAttention-2 vs SDPA** for Qwen3-TTS on the RTX 4070 (plan 115's wheel, dedicated `:9001` sidecar, attn impl confirmed from each load log). Two findings reshape the record:

1. **My earlier perf numbers were contention-confounded** — measured with VRAM at ~97% (app's idle Qwen + hammering). Clean SDPA **batch-8 is ~1.0–1.3 RTF**, not 2.6 → a full ~10 h-audio novel is an **~8–10 h overnight job, not ~40 h**.
2. **FA2 ≈ SDPA** — FA2 modestly faster at small batch and the single fastest result (batch-8 **0.83**) but **noisier** (a 1.81 stall) vs rock-stable SDPA (1.28). TTS is decode-bound, so FA2's prefill optimization is a small, inconsistent edge.

| Batch | SDPA | FA2 |
|---|---|---|
| B=4 | 1.80/1.91 | **1.41/1.50** |
| B=6 | 1.13/1.14 | 1.16/**0.97** |
| B=8 | **1.28/1.28** | **0.83**/1.81 |

Concurrency: K=2 **+27%**, K=4 plateaus → `GPU_VRAM_BUDGET=2` is the sweet spot. **Optimal config:** `QWEN_BATCH_SIZE=8`, `GPU_VRAM_BUDGET=2`, SDPA default (FA2 opt-in).

## Changes

- **docs/tts-performance.md** — flag the earlier record as contention-confounded/superseded (kept for history per the append-only rule), add a clean SDPA-vs-FA2 + concurrency record with the corrected verdict, mark the flash-attn open-lever measured.
- **docs/features/115-flash-attn-opt-in.md** — `active` → `stable`; baseline flagged contended + clean re-measure added; Ship notes filled with the FA2 outcome + "SDPA stays default" decision; `git mv` to `archive/` and re-pointed in INDEX (Plans-by-area → Shipped archive).
- **docs/BACKLOG.md** — removed `side-5` (resolved: "measured, SDPA stays"). **Also fixed a pre-existing defect:** PR #260 had overwritten the `#### srv-3` header with `#### side-5`, orphaning srv-3's body ("Per-call local→Gemini analyzer overflow") — restored srv-3's header.

## Test plan

Doc-only (CI verify skipped per the plan-101 docs-only fast-path). All RTF numbers are live measurements on the 4070; FA2 engagement was confirmed from the sidecar load log (`attn_implementation=flash_attention_2`, not a silent fallback). torch held at 2.6.0+cu124 after the wheel install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)