### PR TITLE
fix(sidecar): serialise Qwen model forward to fix concurrent-batch tensor race

### DIFF
--- a/docs/features/113-qwen-true-batching.md
+++ b/docs/features/113-qwen-true-batching.md
@@ -31,6 +31,7 @@ owner: null
 - `parseBatchFrame` (`server/src/tts/sidecar.ts`) splits on the FIRST `0x0A` only and verifies the declared `lengths` sum equals the body length.
 - The dispatch partition in `synthesiseChapter` (`server/src/tts/synthesise-chapter.ts`) only batches a group when `route.engine === 'qwen'` AND the resolved provider exposes `synthesizeBatch`; the up-front anchor group is always a single call; each batched chunk is scattered to its OWN `results[group.index]` slot.
 - `_load_voice_prompt` returns `(prompt, lang, cache_hit)` and is shared by `synthesize` + `synthesize_batch` so they can't drift (and the batch path inherits the plan-112 prompt cache).
+- `synthesize` / `synthesize_batch` / `design_voice` run `generate_voice_clone` (and the design forwards) under the per-engine `_synth_lock` (`server/tts-sidecar/main.py`). The Base forward is **not thread-safe**, so this serialises same-engine GPU forwards; a concurrent Kokoro synth still runs in parallel (separate engine instance + lock). See the concurrency-safety fix below.
 
 ## Test plan
 
@@ -40,6 +41,7 @@ owner: null
 - Vitest server (`server/src/tts/synthesise-chapter.test.ts`, `describe('Qwen true batching (plan 112)')`) — byte-identical batched (size 8) vs per-call (size 1); mixes voices in one batch; scatter-back preserves narrative order + timing; mixed Qwen+Kokoro (Kokoro one-per-call, Qwen batched); batchSize-cap splitting; abort propagation + signal forwarding; back-compat fallback when `synthesizeBatch` is absent; heartbeat re-fires during a pending batch.
 - Vitest server (`server/src/tts/sidecar.test.ts`) — the shared error-classification helpers are exercised through `synthesize`; `synthesizeBatch` reuses them unchanged.
 - Vitest frontend (`src/views/generation.test.tsx`) — the "Worker has gone quiet" banner copy now sets the batched-synthesis expectation.
+- `test_synthesize_batch_serialises_concurrent_forwards` — two concurrent batches of DIFFERENT sizes must not overlap inside the model forward (regression for the `8 vs 7` race). Instruments the fake forward to flag concurrent entry; fails without `_synth_lock` (`max_concurrent=2`), passes with it.
 
 ### Manual acceptance walkthrough (real GPU — replaces the deferred spike)
 
@@ -47,6 +49,10 @@ owner: null
 2. Generate one chapter at `QWEN_BATCH_SIZE=1`, then again at `QWEN_BATCH_SIZE=4` (or higher). Expect: **per-line audio perceptually identical** (no drift), no reordered/wrong-voice lines, and a meaningfully shorter wall-clock at the larger batch size.
 3. During a batch, confirm the Generate view never false-trips "Worker has gone quiet" (the heartbeat ticks every 10 s, under the 30 s watchdog).
 4. If drift or VRAM pressure appears, drop `QWEN_BATCH_SIZE` (or `=1` to disable). Canonical manuscript: `C:\Users\dudar\Downloads\Bonus Keefe Story.txt` (do not commit).
+
+### Concurrency-safety fix (2026-05-26)
+
+The real-GPU walkthrough at `QWEN_BATCH_SIZE=8` with `GPU_VRAM_BUDGET=2` surfaced an **intermittent** (~2 of 3 chapter runs) `size of tensor a (8) must match tensor b (7) at non-singleton dimension 0` 500 — only at batch sizes that leave a remainder, only with the N-worker parallelism. Root cause: the Base model's `generate_voice_clone` is **not thread-safe**, and two batched forwards of DIFFERENT sizes dispatched in parallel (a full batch of 8 overlapping a chapter's 7-item remainder) collide on shared model state. Confirmed deterministically (6/6) by firing concurrent 8- and 7-item batches; fixed (0/6) by the per-engine `_synth_lock` serialising the forward. The single-voice micro-bench never hit it (parallel calls had identical shapes), and serial replays of the real chapter all passed — the trigger was strictly concurrent different-size forwards. Note this means `GPU_VRAM_BUDGET>1` gives **no safe same-engine Qwen parallelism** (batching is the throughput lever); it still benefits cross-engine coexistence (Kokoro + Qwen).
 
 ## Out of scope
 

--- a/docs/tts-performance.md
+++ b/docs/tts-performance.md
@@ -101,18 +101,29 @@ _Settings:_ dedicated benchmark sidecar on `:9001`, `PRELOAD_QWEN=1`, **Kokoro/C
 | Parallel streams | Aggregate throughput |
 |---|---|
 | 1 | 0.96× realtime |
-| 2 | **1.22× realtime** (+27%) |
+| 2 | 1.22× realtime (+27%) |
 | 4 | 1.20× realtime (plateau) |
+
+> ⚠️ **This +27% is unsafe — disregard it.** These parallel streams were *identical-size* batches, so they didn't crash, but the Qwen forward is **not thread-safe**: *different-size* concurrent batches corrupt each other (the `8 vs 7` chapter-generation bug — see the end-to-end record below + plan 113). The fix serialises same-engine forwards, so `GPU_VRAM_BUDGET>1` yields **no** safe same-engine Qwen parallelism; it only helps cross-engine coexistence (Kokoro + Qwen).
 
 **Findings:**
 
-- **Batching is the dominant lever** — serial ~3.3 → batch-8 ~1.0–1.3 RTF; bigger batch = better, B=6–8 the sweet spot.
-- **FA2 ≈ SDPA.** FA2 is modestly faster at B=4 and posts the single fastest result (B=8 0.83), but is **noisier** (the 1.81 stall) while SDPA is rock-stable. Consistent with the prefill-vs-decode theory: TTS is token-by-token decode, so FA2's optimization yields only a small, inconsistent edge. **SDPA stays the sensible default; FA2 is a legit opt-in.** (Resolves `side-5`; see plan 115 Ship notes.)
-- **Concurrency 2 adds ~27%; 4 plateaus** → `GPU_VRAM_BUDGET=2` is optimal. 4-wide wastes VRAM (and risks OOM on 8 GB) for no throughput gain — confirms `side-3`'s "batching scales, concurrency plateaus".
+- **Batching is the dominant — and only safe — lever** — serial ~3.3 → batch-8 ~1.0–1.3 RTF; bigger batch = better, B=6–8 the sweet spot.
+- **FA2 ≈ SDPA.** FA2 is modestly faster at B=4 and posts the single fastest micro result (B=8 0.83) but is noisier; SDPA is rock-stable. End-to-end (below) they tie, SDPA marginally ahead. TTS is decode-bound, so FA2's prefill optimization is a small, inconsistent edge. **SDPA stays the default; FA2 is a legit opt-in.** (Resolves `side-5`; see plan 115 Ship notes.)
+- **Concurrency is not a safe Qwen lever** — see the warning above; same-engine Qwen runs effectively serial after the fix.
 
-**Optimal config on the 4070:** `QWEN_BATCH_SIZE=8`, `GPU_VRAM_BUDGET=2`, `QWEN_ATTN_IMPL=sdpa` (FA2 optional), no other models co-resident.
+**Optimal config on the 4070:** `QWEN_BATCH_SIZE=8` (the throughput lever — **safe** now that the concurrent-batch race is fixed, plan 113), `QWEN_ATTN_IMPL=sdpa` (FA2 ≈ SDPA, not worth flipping). `GPU_VRAM_BUDGET=2` is fine for cross-engine coexistence but adds no same-engine Qwen throughput. No other models co-resident.
 
-**Corrected full-book reality:** a ~10 h-audio novel ≈ **~8–10 h** (overnight), **not** the ~40 h the contended run implied. Caveat: these are **micro-bench** (raw model). The real per-character pipeline adds per-voice batch fragmentation + MP3 assembly, so end-to-end chapters run somewhat slower than the micro RTF — but far better than the contended 4.12. A clean full-pipeline re-measure is still owed for the true end-to-end number.
+### Qwen3-TTS 0.6B — end-to-end (real pipeline) — 2026-05-26
+
+The true per-chapter number through the full server pipeline (per-character voice routing + `QWEN_BATCH_SIZE=8` batching + MP3 assembly), generating "Bonus Keefe Story" ch.2 "DAY ONE" (87 sentences, 4 voices, ~290 s audio) on a freed GPU, **after the concurrent-batch race fix** (plan 113):
+
+| Engine | RTF (3 runs) | Mean | Failures |
+|---|---|---|---|
+| **SDPA** | 1.23 / 1.14 / 1.08 | **1.15** | 0/3 |
+| **FA2** | 1.23 / 1.18 / 1.15 | **1.19** | 0/3 |
+
+**Before the fix, ~2 of 3 runs 500'd** with `size of tensor a (8) must match tensor b (7)` (concurrent different-size batches racing the non-thread-safe forward). After the fix: **3/3 clean** for both backends, SDPA marginally faster, both stable. So end-to-end batch-8 is **~RTF 1.15–1.2** — a ~10 h-audio novel ≈ **~11–12 h** (overnight), not the ~40 h the original contention-confounded run implied.
 
 ### Kokoro v1 — 4070 — _TODO_
 
@@ -125,4 +136,4 @@ Not yet benchmarked here. Expected sub-1 RTF on GPU. Run `bench-tts.py --engine 
 3. **`x_vector_only_mode=True`** ([`side-4`](BACKLOG.md)) — drop the ICL prefix; speed vs. fidelity A/B.
 4. ~~**flash-attn** wheel on Windows~~ — **measured 2026-05-26: FA2 ≈ SDPA (modest + noisy); SDPA stays default, FA2 opt-in** (plan 115 / `side-5` resolved).
 5. **Quantization** (int8/fp8) of the 0.6B base.
-6. **Clean full-pipeline re-measure** — real per-character chapter under freed VRAM, for the true end-to-end RTF (the micro-bench is raw-model only).
+6. ~~**Clean full-pipeline re-measure**~~ — **done 2026-05-26** (end-to-end record above: batch-8 ~RTF 1.15–1.2; surfaced + fixed the concurrent-batch race, plan 113).

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -713,6 +713,18 @@ class QwenEngine(Engine):
         # is harmless, but the lock is cheap and keeps hit/miss accounting honest.
         self._prompt_cache: dict[str, tuple[Any, str]] = {}
         self._cache_lock = threading.Lock()
+        # Serialises the GPU model forward. The Qwen Base model's batched
+        # `generate_voice_clone` is NOT thread-safe: two overlapping forwards of
+        # different batch sizes (which the Node side issues when GPU_VRAM_BUDGET>1
+        # runs N workers — e.g. a full batch of 8 overlapping a chapter's 7-item
+        # remainder) collide on shared model state and raise "size of tensor a
+        # (8) must match tensor b (7)". Synth runs on asyncio.to_thread worker
+        # threads, so a plain threading.Lock here serialises same-engine forwards
+        # without blocking the event loop (asyncio offload + /health stay live).
+        # Per-engine: a concurrent Kokoro synth still runs in parallel (separate
+        # engine instance, separate lock). Batching — not concurrency — is the
+        # throughput lever on a single autoregressive model anyway.
+        self._synth_lock = threading.Lock()
         # Designed-voice embeddings cache. Default lives next to this file
         # under voices/qwen/ (exact back-compat when QWEN_VOICES_DIR unset).
         # The Node server points QWEN_VOICES_DIR at the per-workspace tree
@@ -921,17 +933,20 @@ class QwenEngine(Engine):
         ref_text = (calibration_text or self.CALIBRATION_TEXT).strip() or self.CALIBRATION_TEXT
 
         self._ensure_design_loaded()
-        # 1. design a reference clip from the persona instruction.
-        ref_wavs, ref_sr = self._design.generate_voice_design(
-            text=ref_text, language=lang, instruct=instruct
-        )
-        ref_audio = ref_wavs[0]
-
-        # 2. distil into a reusable clone prompt on the Base model.
         self._ensure_base_loaded()
-        prompt = self._base.create_voice_clone_prompt(
-            ref_audio=(ref_audio, ref_sr), ref_text=ref_text
-        )
+        # Serialise the GPU forwards against any concurrent synth/design — see
+        # `_synth_lock` in __init__ (the Base model isn't thread-safe).
+        with self._synth_lock:
+            # 1. design a reference clip from the persona instruction.
+            ref_wavs, ref_sr = self._design.generate_voice_design(
+                text=ref_text, language=lang, instruct=instruct
+            )
+            ref_audio = ref_wavs[0]
+
+            # 2. distil into a reusable clone prompt on the Base model.
+            prompt = self._base.create_voice_clone_prompt(
+                ref_audio=(ref_audio, ref_sr), ref_text=ref_text
+            )
 
         # 3. cache prompt + manifest to disk (workspace-shared, keyed by voiceId).
         os.makedirs(self._voices_dir, exist_ok=True)
@@ -964,9 +979,10 @@ class QwenEngine(Engine):
             self._prompt_cache.pop(voice_id, None)
 
         # 4. audition preview — speak the calibration line in the new voice.
-        wavs, sr = self._base.generate_voice_clone(
-            text=[ref_text], language=[lang], voice_clone_prompt=prompt
-        )
+        with self._synth_lock:
+            wavs, sr = self._base.generate_voice_clone(
+                text=[ref_text], language=[lang], voice_clone_prompt=prompt
+            )
         return SynthResult(pcm=_float_audio_to_int16_le(wavs[0]), sample_rate=int(sr))
 
     def _load_voice_prompt(self, voice: str) -> tuple[Any, str, bool]:
@@ -1024,9 +1040,11 @@ class QwenEngine(Engine):
 
         self._ensure_base_loaded()
         gen_start = time.perf_counter()
-        wavs, sr = self._base.generate_voice_clone(
-            text=[text], language=[lang], voice_clone_prompt=prompt
-        )
+        # Serialise the forward — see `_synth_lock` in __init__.
+        with self._synth_lock:
+            wavs, sr = self._base.generate_voice_clone(
+                text=[text], language=[lang], voice_clone_prompt=prompt
+            )
         gen_ms = (time.perf_counter() - gen_start) * 1000.0
 
         audio = wavs[0]
@@ -1087,9 +1105,14 @@ class QwenEngine(Engine):
             prompts.extend(prompt if isinstance(prompt, list) else [prompt])
 
         self._ensure_base_loaded()
-        wavs, sr = self._base.generate_voice_clone(
-            text=texts, language=langs, voice_clone_prompt=prompts
-        )
+        # Serialise the forward — see `_synth_lock` in __init__. Without this,
+        # two concurrent batches of different sizes (e.g. a full 8 overlapping a
+        # 7-item remainder, which GPU_VRAM_BUDGET>1 schedules in parallel) race
+        # on shared model state → "size of tensor a (8) must match tensor b (7)".
+        with self._synth_lock:
+            wavs, sr = self._base.generate_voice_clone(
+                text=texts, language=langs, voice_clone_prompt=prompts
+            )
         # Hard invariant: one wav per input item, in order. A mismatch means a
         # library API drift — fail loudly rather than silently misalign audio
         # with sentences (which would scramble the chapter).

--- a/server/tts-sidecar/tests/test_batch_synthesis.py
+++ b/server/tts-sidecar/tests/test_batch_synthesis.py
@@ -412,3 +412,64 @@ def test_frame_splits_on_first_newline_only(qwen_batch_runtime, monkeypatch) -> 
     assert header["lengths"] == [4, 2]
     assert chunks[0] == pcm_a
     assert chunks[1] == pcm_b
+
+
+# ── concurrency: the Base forward is serialised (sidecar-qwen-concurrent-batch-race) ──
+
+def test_synthesize_batch_serialises_concurrent_forwards(qwen_batch_runtime, monkeypatch) -> None:
+    """Regression: the Qwen Base `generate_voice_clone` forward is NOT thread-safe.
+    When GPU_VRAM_BUDGET>1 runs N workers, two batched forwards of DIFFERENT sizes
+    (e.g. a full 8 overlapping a chapter's 7-item remainder) overlap and collide on
+    shared model state — reproducibly raising "size of tensor a (8) must match
+    tensor b (7) at non-singleton dimension 0" (confirmed 6/6 on the real model).
+    `QwenEngine._synth_lock` must serialise same-engine forwards. This instruments
+    the fake model's forward to flag any concurrent entry; with the lock it must
+    never observe overlap (and no call must fail)."""
+    import threading
+    import time
+
+    engine = qwen_batch_runtime["engine"]
+    for v in ("a", "b", "c", "d"):
+        _design(engine, v)
+    base = engine._base  # the loaded _BatchFakeQwen
+
+    state = {"inside": 0, "max_concurrent": 0}
+    guard = threading.Lock()
+    real = base.generate_voice_clone
+
+    def instrumented(text, language, voice_clone_prompt):
+        with guard:
+            state["inside"] += 1
+            state["max_concurrent"] = max(state["max_concurrent"], state["inside"])
+        try:
+            time.sleep(0.05)  # widen the overlap window so a missing lock is caught
+            return real(text, language, voice_clone_prompt)
+        finally:
+            with guard:
+                state["inside"] -= 1
+
+    monkeypatch.setattr(base, "generate_voice_clone", instrumented)
+
+    # Two concurrent batches of DIFFERENT sizes — the exact real-world trigger.
+    items8 = [{"voice": v, "text": f"s{i}"} for i, v in enumerate(["a", "b", "c", "d", "a", "b", "c", "d"])]
+    items7 = [{"voice": v, "text": f"t{i}"} for i, v in enumerate(["a", "b", "c", "d", "a", "b", "c"])]
+    errors: list[Exception] = []
+
+    def worker(items):
+        try:
+            engine.synthesize_batch("0.6b", items)
+        except Exception as e:  # pragma: no cover - only on regression
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker, args=(items8,)),
+               threading.Thread(target=worker, args=(items7,))]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"concurrent batches errored: {errors}"
+    assert state["max_concurrent"] == 1, (
+        f"Base forwards overlapped (max_concurrent={state['max_concurrent']}) — "
+        "_synth_lock is not serialising same-engine synthesis"
+    )


### PR DESCRIPTION
## Summary

Generating a Qwen-voiced chapter at `QWEN_BATCH_SIZE=8` with `GPU_VRAM_BUDGET=2` intermittently 500'd (~2 of 3 chapter runs) with `The size of tensor a (8) must match the size of tensor b (7) at non-singleton dimension 0`, failing the whole chapter.

**Root cause:** the Qwen Base model's batched `generate_voice_clone` forward is **not thread-safe**. With `GPU_VRAM_BUDGET>1` the server dispatches batches in parallel, and two batched forwards of **different sizes** (a full batch of 8 overlapping the chapter's 7-item remainder) collide on shared model state. Confirmed deterministically: concurrent 8- and 7-item batches reproduce it **6/6**; the single-voice micro-bench never hit it (parallel calls had identical shapes) and serial replays all passed — the trigger is strictly concurrent **different-size** forwards.

**Fix:** a per-engine `threading.Lock` (`_synth_lock`) wraps the `generate_voice_clone` forward in `QwenEngine.synthesize` / `synthesize_batch` (and the design forwards). Synth runs on `asyncio.to_thread` workers, so the lock serialises same-engine GPU forwards **without blocking the event loop**; a concurrent Kokoro synth still runs in parallel (separate engine + lock).

## Verification

- **Isolated repro → fixed:** concurrent 8‖7 batches go **6/6 errors → 0/6** on the real GPU.
- **Regression test** `test_synthesize_batch_serialises_concurrent_forwards`: flags concurrent entry into the forward — **fails without the lock** (`max_concurrent=2`), **passes with it**.
- **Full sidecar suite:** 114 passed.
- **End-to-end:** chapter 2 at batch=8 via the real server pipeline now generates **3/3 clean** (was ~2/3 failing), RTF ~1.15.

## Implication

`GPU_VRAM_BUDGET>1` gives **no safe same-engine Qwen parallelism** — batching (`QWEN_BATCH_SIZE`) is the single-model throughput lever; it still benefits cross-engine coexistence. (A follow-up commit corrects the perf doc's earlier "concurrency +27%" claim, which was an unsafe same-shape overlap.)

## Test plan

`npm run test:sidecar` (114 passed). Plan 113 updated with the invariant + a "Concurrency-safety fix" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)