### PR TITLE
docs(docs): propagate Qwen concurrency-fix findings to env/README/backlog/perf-doc

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -283,29 +283,7 @@ Source: net-new (2026-05-24). Spun off from [plan 108](features/108-qwen-coexist
 - _Key files:_ `server/src/tts/engine-vram-cost.ts`; `server/.env.example` (`GPU_VRAM_BUDGET` doc); plan 108 Ship notes.
 - _Depends on:_ plan 108 Wave 1 (the weighted semaphore) shipped.
 - _Benefit (technical):_ correct VRAM accounting is the difference between two engines coexisting smoothly and thrashing the GPU. Estimates unblock the feature; measured values make it reliable.
-
-#### `side-3` — Batch multiple sentences into one Qwen `generate_voice_clone` call
-
-**In flight (parallel agent, 2026-05-26)** — being implemented on a separate branch; don't double-up. Remove this entry when that work merges.
-
-Source: net-new (2026-05-26). Surfaced answering "why is Qwen 5–10× slower than Kokoro, and does more concurrency help?" during plan 112. The honest answer: most of the gap is the autoregressive model class, and firing N concurrent `/synthesize` calls at one GPU + one model does NOT scale — concurrent decode loops time-slice the same SMs and contend on the GIL during sampling, plus each holds its own KV cache (VRAM pressure → spill-to-RAM risk on the 8 GB card). The one lever that genuinely scales throughput on a single GPU is **true batching**: `generate_voice_clone` already accepts `text=[s1, s2, …]` and runs a single batched forward per decode step instead of N separate ones.
-
-- _What:_ Assemble same-voice (and same-engine) sentence groups in `synthesise-chapter.ts` into a single batched `/synthesize`-equivalent call, demux the returned `List[np.ndarray]` back to per-sentence PCM, and preserve the plan-107 ordering + sample-rate-anchor contract. Needs a batched sidecar route (or a `texts[]` body on `/synthesize`) and careful handling of ragged batch lengths.
-- _Acceptance:_ A chapter of N same-voice sentences synthesises in materially less wall time than N serial calls at equal quality; per-sentence PCM is byte-identical to the unbatched path (determinism); ordering + sample rate unchanged. Bench (`bench-tts.py`) shows aggregate throughput rising with batch size where concurrency did not.
-- _Key files:_ `server/tts-sidecar/main.py` (`QwenEngine.synthesize` → a batch entry); `server/src/tts/synthesise-chapter.ts` (group assembly + demux); `server/src/tts/sidecar.ts` (wire a batched request).
-- _Depends on:_ plan 112 shipped (the prompt cache + RTF logs land first; the bench harness measures the win).
-- _Benefit (technical):_ the only real throughput multiplier for an autoregressive TTS model on a single GPU — concurrency knobs (`generationWorkers`, `sentenceConcurrency`) plateau once the GPU saturates, batching does not.
-- _Measured baseline + ongoing runs:_ [docs/tts-performance.md](tts-performance.md). Same-voice batching already lands ~RTF 2.6 (vs ~8.3 serial) on the 4070, but a **real mixed-cast chapter still runs ~RTF 4.1** because the pipeline batches per-voice only — **cross-voice batching** (one forward across mixed dialogue voices) is the open lever this item should close. Append new runs there as settings change.
-
-#### `side-4` — A/B Qwen `x_vector_only_mode=True` (speed vs. fidelity)
-
-Source: net-new (2026-05-26). Surfaced in plan 112. Our designed voices use ICL mode (`x_vector_only_mode=False`): the cached clone prompt drags the reference clip's audio-codec tokens through the context on every decode step, and the vocoder even decodes that reference span before slicing it off (`qwen_tts/.../qwen3_tts_model.py:614-629` — wasted work). `x_vector_only_mode=True` drops the ICL prefix and conditions on the speaker embedding alone → shorter context, faster steps, no wasted ref decode. The cost is voice fidelity/consistency, so this is a deliberate listen-test, not a blind flip.
-
-- _What:_ Add an env/per-voice toggle for `x_vector_only_mode` plumbed through `design_voice` (the prompt is built x-vector-only) and `synthesize`; design one voice both ways and A/B the audition + a full chapter for identity drift vs. speed.
-- _Acceptance:_ Documented RTF delta (ICL vs x-vector-only) on the target 4070 and a subjective fidelity verdict; ship the faster mode as default only if the quality cost is acceptable, else leave ICL default with the toggle available.
-- _Key files:_ `server/tts-sidecar/main.py` (`QwenEngine.design_voice` / `synthesize`); a per-voice manifest field.
-- _Depends on:_ plan 112 shipped (bench harness measures the delta).
-- _Benefit (technical):_ potentially the largest single per-call speedup short of batching — but it trades the very thing the bespoke-voice design exists to guarantee (consistent identity), so it must be measured, not assumed.
+- _Update (2026-05-26):_ the plan-113 fix serialises the Qwen forward per-engine (it isn't thread-safe), so budget>1 gives **no same-engine Qwen parallelism** — the cost map matters only for **cross-engine** packing (Kokoro 1 + Qwen 1 coexisting, vs Coqui 3 / analyzer 4). Empirically `GPU_VRAM_BUDGET=2` + `QWEN_BATCH_SIZE=8` ran an end-to-end Qwen chapter without VRAM trouble on the 4070; what's still unmeasured is true per-engine *peak* VRAM for the cross-engine packing case.
 
 #### `srv-3` — Per-call local→Gemini analyzer overflow
 
@@ -450,6 +428,13 @@ Source: [`32-audiobook-export.md`](features/32-audiobook-export.md) follow-ups.
 ## Won't (this round) — explicitly parked
 
 Specific items someone might reasonably re-propose. Each carries a _Why parked_ (the v1 design or operational constraint) and a _Wake when_ (the trigger that makes us reopen). The broad "v1 scope freeze" and "no visual redesign" are covered by CLAUDE.md "Out of scope" and don't need restating here — this list is for tracked-specific decisions only.
+
+### `side-4` — A/B Qwen `x_vector_only_mode=True` (speed vs. fidelity)
+
+Source: net-new (2026-05-26), plan 112. ICL mode drags the reference clip's codec tokens through context every decode step; `x_vector_only_mode=True` drops that for shorter/faster steps, at a fidelity/consistency cost.
+
+- _Why parked (2026-05-26):_ the perf problem that motivated it is solved — after the plan-113 batching + the concurrent-batch race fix, end-to-end Qwen chapters run at **~RTF 1.15** (a ~10 h novel ≈ overnight). That's acceptable, so trading the bespoke-voice identity-consistency this feature exists to guarantee for a marginal further speedup isn't worth it this round.
+- _Wake when:_ Qwen synthesis becomes a real bottleneck again (much longer books, a slower GPU, or a per-quote-emotion feature that inflates decode cost) AND a listen-test shows x-vector-only holds identity acceptably.
 
 ### `ops-4` — Auto-install Ollama / auto-pull models
 

--- a/docs/tts-performance.md
+++ b/docs/tts-performance.md
@@ -20,6 +20,8 @@ RTF = generation wall time ÷ produced audio seconds. **< 1 is faster than real-
 - **Batch path (Qwen production path):** `POST /synthesize-batch` with N `{voice,text}` items in one call.
 - **Full pipeline (truest):** `POST /api/books/:bookId/generation {modelKey, chapterIds:[id], force:true}` (SSE) — real per-character chapter. Effective RTF = wall ÷ chapter audio seconds; **ffprobe the produced MP3** for ground-truth duration rather than trusting the tick.
 
+> **Benchmarking gotchas (cost hours once):** (1) the server resolves the sidecar URL from **`user-settings.json`** (→ `localhost:9000`), **not** the `LOCAL_TTS_URL` env — so to point the full pipeline at a custom/fixed sidecar you must **replace the `:9000` sidecar process itself**, not set `LOCAL_TTS_URL`. (2) `QWEN_BATCH_SIZE` *does* read straight from `process.env` (a shell value wins over `server/.env`), while most other server knobs come from `.env` via `loadEnvFile`. Verify which path each knob takes before trusting a run. (3) VRAM contention silently inflates RTF 3–5× — free the GPU first (the original 4.12 figure was a contention artifact).
+
 ## Settings & env vars that affect performance
 
 These are the knobs that change the numbers. **Record any non-default value in the run's row/notes** — a row without its settings isn't reproducible. Defaults below are what the code + `server/.env.example` ship.

--- a/server/.env.example
+++ b/server/.env.example
@@ -101,6 +101,10 @@ GPU_CONCURRENCY=1
 # 8 GB box, 4 lets Kokoro+Qwen (1+1) run together while Coqui (3) or the analyzer (4)
 # serialise heavier work. When UNSET, the budget falls back to GPU_CONCURRENCY (default 1)
 # and every op costs 1, so behaviour is byte-identical to the old count semaphore.
+# NOTE (plan 113): the Qwen model forward is serialised per-engine (it is not
+# thread-safe), so budget>1 gives NO extra SAME-engine Qwen throughput — it only lets
+# DIFFERENT engines overlap (Kokoro narrator + Qwen dialogue). Qwen's throughput lever
+# is batching (QWEN_BATCH_SIZE below), not this.
 # GPU_VRAM_BUDGET=4
 
 # Generation queue concurrency — how many chapters the queue synthesises at once
@@ -112,11 +116,20 @@ GPU_CONCURRENCY=1
 # Qwen true batching (plan 113) — how many Qwen sentences to pack into one
 # batched generate_voice_clone call. Qwen-only (Coqui/Kokoro/Gemini have no
 # list API and stay one-per-call). One batched forward per decode step replaces
-# N separate ones, so a Qwen-heavy chapter renders faster. Default 4
-# (conservative — raise after observing VRAM headroom; larger batches use more
-# VRAM). Set to 1 to disable batching entirely (every Qwen sentence becomes a
-# single synth call — the per-call kill-switch).
+# N separate ones, so a Qwen-heavy chapter renders faster. 4 is conservative;
+# 8 is validated on an RTX 4070 (end-to-end chapter, 3/3 clean, RTF ~1.15) and
+# recommended there. Larger batches use more VRAM; a genuine CUDA OOM surfaces as
+# a sidecar 500 — drop the number if that happens. Set to 1 to disable batching
+# (per-call kill-switch). (The old intermittent "size of tensor a (8) must match
+# tensor b (7)" 500 at batch 8 was a concurrent-batch thread-safety race, fixed in
+# plan 113 by serialising the Qwen forward — NOT OOM — so 8 is safe now.)
 # QWEN_BATCH_SIZE=4
+
+# Qwen attention backend (sidecar env; inherited by the server-spawned sidecar).
+# Default sdpa. flash_attention_2 needs the flash-attn wheel (install-qwen3.mjs
+# --flash-attn, plan 115) and benchmarked ≈ SDPA on the 4070 (TTS is decode-bound,
+# not prefill-bound), so it is not worth flipping. See server/tts-sidecar/README.md.
+# QWEN_ATTN_IMPL=sdpa
 
 # ---------------------------------------------------------------------------
 # TTS. Provider is now chosen per-request by the modelKey the UI sends.

--- a/server/tts-sidecar/README.md
+++ b/server/tts-sidecar/README.md
@@ -418,10 +418,13 @@ model-load line: `Qwen model=… attn_implementation=flash_attention_2`.
 > banner — though that line is benign (transformers prints it whenever FA2 isn't
 > present) and SDPA is unaffected either way.
 
-> **Worth it?** Benchmark before adopting. FA2's win is largest on long-sequence
-> *prefill*; for single-token TTS decode the gain over SDPA is often modest. Use
-> `scripts/bench-tts.py` (below) to compare RTF, and only flip the default if FA2
-> measurably wins on your GPU.
+> **Worth it? Measured 2026-05-26 (RTX 4070): no — FA2 ≈ SDPA.** FA2's win is
+> largest on long-sequence *prefill*; TTS is single-token *decode*, so the gain is
+> small and inconsistent. End-to-end chapter generation at `QWEN_BATCH_SIZE=8` was
+> RTF ~1.19 (FA2) vs ~1.15 (SDPA) — SDPA marginally ahead and more stable. **SDPA
+> stays the default; FA2 is a legit opt-in but not worth flipping.** Full data:
+> [docs/tts-performance.md](../../docs/tts-performance.md). Re-measure on your GPU
+> with `scripts/bench-tts.py` (below) if you want to confirm.
 
 ## Benchmarking
 


### PR DESCRIPTION
## Summary

Propagates the plan-113 concurrent-batch race fix (PR #263) + the FA2-vs-SDPA benchmark across the docs/config surface so nothing gets lost.

- **`server/.env.example`** — `QWEN_BATCH_SIZE` (8 validated e2e RTF ~1.15; the old `8 vs 7` 500 was the race, not OOM — safe now); `GPU_VRAM_BUDGET` (Qwen forward serialised per-engine → budget>1 gives no same-engine Qwen parallelism, cross-engine only); new `QWEN_ATTN_IMPL` line (sdpa default, FA2 ≈ SDPA).
- **`server/tts-sidecar/README.md`** — FlashAttention "Worth it?" now carries the measured verdict (FA2 ≈ SDPA on the 4070; SDPA stays default).
- **`docs/tts-performance.md`** — benchmarking gotchas added (sidecar URL resolves from `user-settings.json`, not `LOCAL_TTS_URL`; `QWEN_BATCH_SIZE` reads `process.env` directly; VRAM contention inflates RTF 3–5×).
- **`docs/BACKLOG.md`** — retired `side-3` (true batching, shipped as plan 113); moved `side-4` (x_vector_only_mode) to Won't (Qwen now ~RTF 1.15, identity-risk speed lever not worth it); annotated `srv-5` with the serialization finding.

(`server/.env` is gitignored; its notes were updated locally to match.)

## Test plan

Doc/config-comment only (CI verify skipped per the plan-101 docs-only fast-path). All figures trace to the merged PR #263 benchmark runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)