### PR TITLE
docs(docs): fill plan 116 ship notes with PR #266 + merge SHA

### DIFF
--- a/docs/features/116-epub-parsing.md
+++ b/docs/features/116-epub-parsing.md
@@ -125,8 +125,7 @@ Run with the real server (`cd server && npm run dev`) — mocks bypass the parse
 
 ## Ship notes
 
-**Shipped 2026-05-26** on branch `fix/server-epub-prefixed-opf-fallback`
-(PR to `main`). Bug fix — diagnosed against the real failing file
+**Shipped 2026-05-26** in merge commit `82215df` (`fix(server): recover namespace-prefixed-OPF EPUBs via raw-zip fallback`, commit `c24ec2e`), branch `fix/server-epub-prefixed-opf-fallback`, PR [#266](https://github.com/dudarenok-maker/AudioBook-Generator/pull/266). Bug fix — diagnosed against the real failing file
 `Calibre Library/Shannon Messenger/Stellarlune (655)/Stellarlune - Shannon Messenger.epub`,
 whose `OEBPS/content.opf` (a valid `version="2.0"` package) prefixes every
 element with `opf:`, defeating epub2's `parseManifest`/`parseSpine`.


### PR DESCRIPTION
## Summary

Records the shipped state of the EPUB namespace-prefixed-OPF fallback (plan 116 / PR #266) in its ship notes: merge commit `82215df`, fix commit `c24ec2e`, PR #266. The pre-merge ship note only carried the branch name + date because the PR number and merge SHA don't exist until the PR lands.

Doc-only change — skips `verify.yml` via the plan-101 `paths-ignore` fast-path.

## Test plan

n/a — single-line documentation update (ship-note finalization). No code or test surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
