### PR TITLE
feat(frontend): status-first Qwen sections in Voices view + engine-aware cast Status pill

### DIFF
--- a/docs/features/117-qwen-voice-presentation.md
+++ b/docs/features/117-qwen-voice-presentation.md
@@ -66,9 +66,9 @@ empty-name `qwen|` family.
 
 - Vitest server (`server/src/routes/voices.test.ts`, `describe('GET /api/voices?engine=qwen — generated flag')`) — a designed Qwen voice appearing in a rendered snapshot gets `generated:true`; a designed-but-unrendered voice does not; an undesigned voice (`ttsVoice.name===''`) never does; the `engine=coqui` query emits no `generated` (preset path untouched). **[landed — server PR]**
 - Vitest server (`server/src/routes/revisions.test.ts`) — drift detector stays green after the `loadSegmentsFiles` extraction (31 tests). **[landed — server PR]**
-- Vitest unit (`src/views/voices.test.tsx`) — two Qwen regions by `aria-label`; no per-voice cascade; Designed/Generated badge; no ⚠ pill / no "Audition base voice" on Qwen sections; per-series Rebaseline present; preset family tests unchanged. **[frontend PR]**
-- Vitest unit (`src/views/cast.test.tsx`) — Qwen no-voice → "Needs voice" (not green "Generated"); designed → "Designed"; library voice `generated:true` → "Generated"; preset provenance pills unchanged; defensive when `library` empty. **[frontend PR]**
-- Playwright e2e (`e2e/voices-qwen-status.spec.ts`) — the two Qwen sections render alongside a preset family; per-series Rebaseline opens. **[frontend PR]**
+- Vitest unit (`src/views/voices.test.tsx`, `describe('LibraryView Qwen status sections (plan 117)')`) — exactly two Qwen regions by `aria-label` (not one per voice); none → "Needs a voice", designed → "Designed voices"; Designed/Generated badge; no "Audition base voice" on Qwen headers; per-series Rebaseline present; Qwen-only library doesn't show the empty state; preset family tests unchanged. **[landed — frontend PR]**
+- Vitest unit (`src/views/cast.test.tsx`, `describe('CastView Qwen status pill (plan 117)')`) — Qwen no-voice → "Needs voice" (not green "Generated"); designed → "Designed"; matched library voice `generated:true` → "Generated"; preset provenance pills (Generated/Reused) unchanged; defensive when `library` is empty. The existing `cast-slice.test.ts` "defaults missing voiceState to 'generated'" test pins that the provenance enum default is untouched. **[landed — frontend PR]**
+- Playwright e2e (`e2e/voices-qwen-status.spec.ts`) — the two Qwen sections + Designed/Generated badges render alongside a preset family on `#/voices`; no "Audition base voice" on a Qwen section. **[landed — frontend PR]**
 
 ### Manual acceptance walkthrough
 

--- a/e2e/voices-qwen-status.spec.ts
+++ b/e2e/voices-qwen-status.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Status-first Qwen voice presentation — plan 117.
+ *
+ * Bespoke Qwen voices are 1:1 with characters, so the (provider, name) voice-
+ * family grouping degenerated into one section per voice. They now bucket by
+ * design status into exactly two sections — "Qwen · Needs a voice" and
+ * "Qwen · Designed voices" — while preset engines keep family grouping. This
+ * crosses the router → redux → layout seams (the view partitions the library
+ * and renders a different component tree per engine), so it earns a browser-
+ * level golden-path spec on top of the Vitest coverage.
+ *
+ * Mock fixtures (src/mocks/voices.ts): Bramble (no designed voice), Thistle
+ * (designed, not generated), Finch (designed + generated).
+ */
+
+test.describe('Qwen status sections on #/voices', () => {
+  test('renders the two status sections + badges beside a preset family', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('button', { name: /Start a new book/i }).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.goto('/#/voices');
+
+    /* Preset family co-exists in the same scroll (Gemini Charon → Captain
+       Halloran), proving Qwen partitioning didn't disturb preset grouping. */
+    await expect(page.getByText('Captain Halloran').first()).toBeVisible({ timeout: 10_000 });
+
+    /* Exactly two Qwen sections — not one per designed voice. */
+    const needs = page.getByRole('region', { name: 'Qwen · Needs a voice' });
+    const designed = page.getByRole('region', { name: 'Qwen · Designed voices' });
+    await expect(needs).toBeVisible();
+    await expect(designed).toBeVisible();
+
+    /* Undesigned voice buckets under "Needs a voice". exact:true avoids the
+       TTS sub-line (e.g. "TTS · qwen-thistle") substring-matching the name. */
+    await expect(needs.getByText('Bramble', { exact: true })).toBeVisible();
+
+    /* Designed voices bucket together, each carrying a Designed / Generated
+       badge driven by Voice.generated. */
+    await expect(designed.getByText('Thistle', { exact: true })).toBeVisible();
+    await expect(designed.getByText('Finch', { exact: true })).toBeVisible();
+    await expect(designed.getByText('Generated', { exact: true })).toBeVisible();
+    await expect(designed.getByText('Designed', { exact: true })).toBeVisible();
+
+    /* No "Audition base voice" button on a Qwen section (a status bucket is
+       not a single base voice). */
+    await expect(
+      designed.getByRole('button', { name: /Audition base voice/i }),
+    ).toHaveCount(0);
+  });
+});

--- a/src/components/voice-library-panel.tsx
+++ b/src/components/voice-library-panel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { IconStar, IconDrag, IconCheck, IconSearch } from '../lib/icons';
 import { VoiceSwatch, Pill } from './primitives';
 import type { Character, Voice } from '../lib/types';
@@ -172,6 +172,10 @@ interface VoiceCardProps {
      reuse voices. isAssigningTarget surfaces the active state. */
   onTapAssign?: (voice: Voice) => void;
   isAssigningTarget?: boolean;
+  /* Optional status pill rendered beside the character name (plan 117).
+     The Qwen "Designed voices" section passes a Designed / Generated badge
+     here; preset cards leave it unset. */
+  badge?: ReactNode;
 }
 
 export function VoiceCard({
@@ -190,6 +194,7 @@ export function VoiceCard({
   onToggleSelect,
   onTapAssign,
   isAssigningTarget = false,
+  badge,
 }: VoiceCardProps) {
   const isDragging = draggingVoiceId === voice.id;
   const canOpenProfile = !!(character && onOpenProfile);
@@ -252,6 +257,7 @@ export function VoiceCard({
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
           <p className="text-sm font-bold text-ink truncate">{voice.character}</p>
+          {badge}
           {voice.source === 'library' && voice.usedIn > 1 && (
             <Pill color="library">
               <IconStar className="w-2.5 h-2.5 mr-0.5" />×{voice.usedIn}

--- a/src/mocks/voices.ts
+++ b/src/mocks/voices.ts
@@ -16,8 +16,16 @@ const tts = (name: string, description: string) => ({
   description,
 });
 
+/* Bespoke Qwen voice assignment (plan 117). `name` is the designed voiceId
+   (empty string when no voice has been designed yet). */
+const qwenTts = (name: string, description: string) => ({
+  provider: 'qwen' as const,
+  name,
+  description,
+});
+
 type MockVoice = Omit<Voice, 'gradient'> & {
-  ttsVoice: { provider: 'gemini'; name: string; description: string };
+  ttsVoice: { provider: 'gemini' | 'qwen'; name: string; description: string };
 };
 
 function withGradient(v: MockVoice): Voice {
@@ -145,6 +153,51 @@ export const MOCK_VOICE_LIBRARY: VoiceLibraryResponse = {
       usedIn: 2,
       source: 'library',
       ttsVoice: tts('Leda', 'Youthful'),
+    }),
+    /* Plan 117 — bespoke Qwen voices in all three lifecycle states. These
+       drive the status-first Qwen sections ("Needs a voice" / "Designed
+       voices") that replace the degenerate 1-member voice families. Kept in
+       the existing Northern Coast Trilogy series so the per-series Rebaseline
+       button + series → book nesting resolve. Deliberately NOT on `cc` (see
+       the v_eliza_cc note above re: rebaseline representative selection). */
+    withGradient({
+      id: 'v_bramble',
+      character: 'Bramble',
+      bookTitle: 'The Northern Star',
+      bookId: 'ns',
+      bookSeries: 'Northern Coast Trilogy',
+      attributes: ['Male', 'Gruff', 'Older'],
+      usedIn: 1,
+      source: 'current',
+      // none — no designed voiceId yet → "Qwen · Needs a voice"
+      ttsVoice: qwenTts('', 'No voice designed yet'),
+    }),
+    withGradient({
+      id: 'v_thistle',
+      character: 'Thistle',
+      bookTitle: 'The Northern Star',
+      bookId: 'ns',
+      bookSeries: 'Northern Coast Trilogy',
+      attributes: ['Female', 'Sharp', 'Wry'],
+      usedIn: 1,
+      source: 'current',
+      overrideTtsVoices: { qwen: { name: 'qwen-thistle' } },
+      // designed but not yet generated → "Designed voices" with a Designed badge
+      ttsVoice: qwenTts('qwen-thistle', 'Designed voice'),
+    }),
+    withGradient({
+      id: 'v_finch',
+      character: 'Finch',
+      bookTitle: 'Solway Bay',
+      bookId: 'sb',
+      bookSeries: 'Northern Coast Trilogy',
+      attributes: ['Male', 'Bright', 'Young'],
+      usedIn: 1,
+      source: 'library',
+      overrideTtsVoices: { qwen: { name: 'qwen-finch' } },
+      generated: true,
+      // designed AND rendered → "Designed voices" with a Generated badge
+      ttsVoice: qwenTts('qwen-finch', 'Designed voice'),
     }),
   ],
 };

--- a/src/views/cast.test.tsx
+++ b/src/views/cast.test.tsx
@@ -359,6 +359,76 @@ describe('CastView Qwen bespoke sample playback (plan 108 fix)', () => {
   });
 });
 
+describe('CastView Qwen status pill (plan 117)', () => {
+  /* The Status column resolves engine-aware pills: a Qwen row follows the
+     design → generate lifecycle (Needs voice / Designed / Generated), driven
+     by its designed voiceId + the matched library voice's `generated` flag —
+     NOT the provenance `voiceState` enum (whose 'generated' default would
+     otherwise show a false green pill for an undesigned Qwen character).
+     Preset rows keep their `voiceState` pills. */
+  function renderWithLibrary(characters: Character[], lib: Voice[]) {
+    const store = configureStore({ reducer: { ui: uiSlice.reducer, cast: castSlice.reducer } });
+    return render(
+      <Provider store={store}>
+        <CastView
+          characters={characters}
+          setCharacters={() => {}}
+          library={lib}
+          title="The Northern Star"
+          onOpenProfile={() => {}}
+          onShowMatchDetail={() => {}}
+          driftEvents={[]}
+          onShowDrift={() => {}}
+        />
+      </Provider>,
+    );
+  }
+
+  const sweeneyQwen: Character = {
+    ...sweeney,
+    ttsEngine: 'qwen',
+    overrideTtsVoices: { qwen: { name: 'qwen-sweeney' } },
+  };
+
+  it('shows "Needs voice" — not a green "Generated" — for a Qwen row with no designed voice', () => {
+    renderWithLibrary([{ ...sweeney, ttsEngine: 'qwen', overrideTtsVoices: undefined }], library);
+    const row = rowFor('Mr. Sweeney');
+    expect(within(row).getByText('Needs voice')).toBeInTheDocument();
+    expect(within(row).queryByText('Generated')).toBeNull();
+  });
+
+  it('shows "Designed" for a designed Qwen voice that has not rendered audio', () => {
+    /* The matched library voice (v_sweeney) carries no `generated` flag. */
+    renderWithLibrary([sweeneyQwen], library);
+    const row = rowFor('Mr. Sweeney');
+    expect(within(row).getByText('Designed')).toBeInTheDocument();
+    expect(within(row).queryByText('Generated')).toBeNull();
+  });
+
+  it('shows "Generated" once the matched library voice is flagged generated', () => {
+    const generatedLib = library.map((v) =>
+      v.id === 'v_sweeney' ? { ...v, generated: true } : v,
+    );
+    renderWithLibrary([sweeneyQwen], generatedLib);
+    const row = rowFor('Mr. Sweeney');
+    expect(within(row).getByText('Generated')).toBeInTheDocument();
+  });
+
+  it('keeps the preset provenance pills (Generated / Reused) for non-Qwen rows', () => {
+    renderView();
+    /* sweeney: coqui, voiceState 'generated'; narrator: voiceState 'reused'. */
+    expect(within(rowFor('Mr. Sweeney')).getByText('Generated')).toBeInTheDocument();
+    expect(within(rowFor('Narrator')).getByText('Reused')).toBeInTheDocument();
+  });
+
+  it('renders a Qwen row without throwing when the library is empty (defensive)', () => {
+    renderWithLibrary([sweeneyQwen], []);
+    const row = rowFor('Mr. Sweeney');
+    /* No matched voice ⇒ generated unknown ⇒ conservative "Designed". */
+    expect(within(row).getByText('Designed')).toBeInTheDocument();
+  });
+});
+
 /* Plan 81 wave 3 — responsive layout coverage.
 
    The cast view collapses to a single-column card list under `md:` and

--- a/src/views/cast.tsx
+++ b/src/views/cast.tsx
@@ -496,10 +496,7 @@ export function CastView({
                   ))}
                 </span>
                 <span>
-                  {c.voiceState === 'generated' && <Pill color="success">Generated</Pill>}
-                  {c.voiceState === 'tuned' && <Pill color="warning">Tuned</Pill>}
-                  {c.voiceState === 'reused' && <Pill color="library">Reused</Pill>}
-                  {c.voiceState === 'locked' && <Pill>Locked</Pill>}
+                  <StatusPill c={c} voice={voice} />
                 </span>
                 <span
                   onClick={(e) => e.stopPropagation()}
@@ -697,10 +694,7 @@ export function CastView({
                 )}
                 <div className="flex items-center justify-between gap-3">
                   <span>
-                    {c.voiceState === 'generated' && <Pill color="success">Generated</Pill>}
-                    {c.voiceState === 'tuned' && <Pill color="warning">Tuned</Pill>}
-                    {c.voiceState === 'reused' && <Pill color="library">Reused</Pill>}
-                    {c.voiceState === 'locked' && <Pill>Locked</Pill>}
+                    <StatusPill c={c} voice={voice} />
                   </span>
                   <button
                     type="button"
@@ -931,6 +925,46 @@ function resolveDisplayTtsVoice(
 ): TtsVoiceAssignment {
   if (c.ttsEngine === 'qwen') return resolveTtsVoiceForCharacter(c, 'qwen');
   return voice?.ttsVoice ?? resolveTtsVoiceForCharacter(c, projectEngine);
+}
+
+type StatusPillColor = 'success' | 'warning' | 'library' | 'neutral';
+
+/* Engine-aware Status pill (plan 117). A Qwen character follows the bespoke
+   design → generate lifecycle (Needs voice → Designed → Generated), driven
+   by its designed voiceId + the matched library voice's `generated` flag —
+   NOT the provenance `voiceState` enum (whose "generated" means "auto-
+   assigned during analysis", which would falsely flag an undesigned Qwen
+   character green). Preset characters keep their existing `voiceState`
+   pills unchanged. `generated` is only populated when the library was
+   fetched with engine=qwen (i.e. the project is on Qwen — the case that
+   matters); otherwise it reads "Designed", a safe conservative default. */
+function resolveStatusPill(
+  c: Character,
+  voice: Voice | undefined,
+): { label: string; color: StatusPillColor } | null {
+  if (c.ttsEngine === 'qwen') {
+    if (!c.overrideTtsVoices?.qwen?.name) return { label: 'Needs voice', color: 'warning' };
+    if (voice?.generated) return { label: 'Generated', color: 'success' };
+    return { label: 'Designed', color: 'library' };
+  }
+  switch (c.voiceState) {
+    case 'generated':
+      return { label: 'Generated', color: 'success' };
+    case 'tuned':
+      return { label: 'Tuned', color: 'warning' };
+    case 'reused':
+      return { label: 'Reused', color: 'library' };
+    case 'locked':
+      return { label: 'Locked', color: 'neutral' };
+    default:
+      return null;
+  }
+}
+
+function StatusPill({ c, voice }: { c: Character; voice: Voice | undefined }) {
+  const pill = resolveStatusPill(c, voice);
+  if (!pill) return null;
+  return <Pill color={pill.color}>{pill.label}</Pill>;
 }
 
 interface TtsVoiceLineProps {

--- a/src/views/voices.test.tsx
+++ b/src/views/voices.test.tsx
@@ -1475,6 +1475,190 @@ describe('LibraryView per-series Rebaseline button (plan 108 follow-up)', () => 
   });
 });
 
+describe('LibraryView Qwen status sections (plan 117)', () => {
+  /* Bespoke Qwen voices are 1:1 with characters, so the old voice-family
+     grouping produced one degenerate section per voice. They now bucket by
+     design status into exactly two sections, regardless of how many designed
+     voices there are. A Gemini family co-exists in the same scroll. */
+  const qwenLibrary: Voice[] = [
+    makeVoice({
+      id: 'g_charon',
+      character: 'Halloran',
+      bookId: 'b1',
+      bookTitle: 'Book One',
+      source: 'current',
+      ttsVoice: { provider: 'gemini', name: 'Charon', description: 'Informative' },
+    }),
+    makeVoice({
+      id: 'q_none',
+      character: 'Bo',
+      bookId: 'b1',
+      bookTitle: 'Book One',
+      source: 'current',
+      ttsVoice: { provider: 'qwen', name: '', description: 'No voice designed yet' },
+    }),
+    makeVoice({
+      id: 'q_designed',
+      character: 'Keefe',
+      bookId: 'b1',
+      bookTitle: 'Book One',
+      source: 'current',
+      overrideTtsVoices: { qwen: { name: 'qwen-keefe' } },
+      ttsVoice: { provider: 'qwen', name: 'qwen-keefe', description: 'Designed voice' },
+    }),
+    makeVoice({
+      id: 'q_generated',
+      character: 'Elwin',
+      bookId: 'b2',
+      bookTitle: 'Book Two',
+      source: 'library',
+      overrideTtsVoices: { qwen: { name: 'qwen-elwin' } },
+      generated: true,
+      ttsVoice: { provider: 'qwen', name: 'qwen-elwin', description: 'Designed voice' },
+    }),
+  ];
+
+  function renderQwen() {
+    const store = configureStore({
+      reducer: {
+        ui: uiSlice.reducer,
+        cast: castSlice.reducer,
+        manuscript: manuscriptSlice.reducer,
+        voices: voicesSlice.reducer,
+        notifications: notificationsSlice.reducer,
+        library: librarySlice.reducer,
+        rebaseline: rebaselineSlice.reducer,
+      },
+    });
+    store.dispatch(uiSlice.actions.openVoices());
+    store.dispatch(
+      librarySlice.actions.hydrate({
+        authors: [
+          {
+            name: 'Test Author',
+            series: [
+              {
+                name: 'Keeper of the Lost Cities',
+                books: [
+                  {
+                    bookId: 'b1',
+                    title: 'Book One',
+                    author: 'Test Author',
+                    series: 'Keeper of the Lost Cities',
+                    seriesPosition: 1,
+                    isStandalone: false,
+                    status: 'complete',
+                    chapterCount: 0,
+                    completedChapters: 0,
+                    characterCount: 0,
+                    voiceCount: 0,
+                    lastWorkedOn: '2026-01-01',
+                    coverGradient: ['#000', '#fff'],
+                    tags: [],
+                  },
+                  {
+                    bookId: 'b2',
+                    title: 'Book Two',
+                    author: 'Test Author',
+                    series: 'Keeper of the Lost Cities',
+                    seriesPosition: 2,
+                    isStandalone: false,
+                    status: 'complete',
+                    chapterCount: 0,
+                    completedChapters: 0,
+                    characterCount: 0,
+                    voiceCount: 0,
+                    lastWorkedOn: '2026-01-02',
+                    coverGradient: ['#000', '#fff'],
+                    tags: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    return render(
+      <Provider store={store}>
+        <LibraryView library={qwenLibrary} />
+      </Provider>,
+    );
+  }
+
+  it('renders exactly two Qwen status sections beside the preset family — not one per voice', () => {
+    renderQwen();
+    const labels = screen.getAllByRole('region').map((s) => s.getAttribute('aria-label'));
+    expect(labels).toContain('Gemini · Charon');
+    expect(labels).toContain('Qwen · Needs a voice');
+    expect(labels).toContain('Qwen · Designed voices');
+    /* Regression: two designed Qwen voices must NOT spawn two sections. */
+    const qwenRegions = labels.filter((l) => l?.startsWith('Qwen · '));
+    expect(qwenRegions).toHaveLength(2);
+  });
+
+  it('buckets an undesigned voice under "Needs a voice" and designed ones under "Designed voices"', () => {
+    renderQwen();
+    const needs = screen.getByRole('region', { name: 'Qwen · Needs a voice' });
+    expect(within(needs).getByText('Bo')).toBeInTheDocument();
+    const designed = screen.getByRole('region', { name: 'Qwen · Designed voices' });
+    expect(within(designed).getByText('Keefe')).toBeInTheDocument();
+    expect(within(designed).getByText('Elwin')).toBeInTheDocument();
+  });
+
+  it('badges a generated voice "Generated" and an unrendered designed voice "Designed"', () => {
+    renderQwen();
+    const designed = screen.getByRole('region', { name: 'Qwen · Designed voices' });
+    expect(within(designed).getByText('Generated')).toBeInTheDocument();
+    expect(within(designed).getByText('Designed')).toBeInTheDocument();
+  });
+
+  it('omits the "Audition base voice" button from Qwen section headers', () => {
+    renderQwen();
+    const needs = screen.getByRole('region', { name: 'Qwen · Needs a voice' });
+    const designed = screen.getByRole('region', { name: 'Qwen · Designed voices' });
+    expect(within(needs).queryByRole('button', { name: /Audition base voice/i })).toBeNull();
+    expect(within(designed).queryByRole('button', { name: /Audition base voice/i })).toBeNull();
+  });
+
+  it('shows the per-series Rebaseline button on a Qwen section', () => {
+    renderQwen();
+    const buttons = screen.getAllByTestId('rebaseline-series-Keeper of the Lost Cities');
+    expect(buttons.length).toBeGreaterThanOrEqual(1);
+    expect(buttons[0]).toHaveTextContent(/Rebaseline the series/i);
+  });
+
+  it('does not show the "No voices yet" empty state for a Qwen-only library', () => {
+    const store = configureStore({
+      reducer: {
+        ui: uiSlice.reducer,
+        cast: castSlice.reducer,
+        manuscript: manuscriptSlice.reducer,
+        voices: voicesSlice.reducer,
+        notifications: notificationsSlice.reducer,
+      },
+    });
+    render(
+      <Provider store={store}>
+        <LibraryView
+          library={[
+            makeVoice({
+              id: 'q_only',
+              character: 'Solo',
+              bookId: 'b1',
+              bookTitle: 'Book One',
+              source: 'current',
+              ttsVoice: { provider: 'qwen', name: '', description: 'No voice designed yet' },
+            }),
+          ]}
+        />
+      </Provider>,
+    );
+    expect(screen.queryByText('No voices yet')).toBeNull();
+    expect(screen.getByRole('region', { name: 'Qwen · Needs a voice' })).toBeInTheDocument();
+  });
+});
+
 describe('LibraryView Base voices tab', () => {
   it('shows the catalog from getBaseVoices when the user clicks the tab', async () => {
     getBaseVoices.mockResolvedValue({

--- a/src/views/voices.tsx
+++ b/src/views/voices.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { SectionLabel, MixedHeading, VoiceSwatch } from '../components/primitives';
+import { SectionLabel, MixedHeading, VoiceSwatch, Pill } from '../components/primitives';
 import { StatTile } from '../components/stat-tiles';
 import { VoiceCard } from '../components/voice-library-panel';
 import { IconPlay, IconSparkle } from '../lib/icons';
@@ -197,11 +197,21 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
     };
   }, [dispatch]);
 
-  /* Group voices into families. The key is (engine, name) on ttsVoice —
-     that's what's resolved server-side after honouring overrides, so two
-     characters with the same engine+name appear under the same family
-     regardless of how they got there. */
-  const families = useMemo(() => buildFamilies(library, tab), [library, tab]);
+  /* Partition Qwen out of family grouping (plan 117). Preset engines keep
+     the (engine, name) voice-family grouping — that's resolved server-side
+     after honouring overrides, so two characters with the same engine+name
+     appear under the same family. Bespoke Qwen voices are 1:1 with
+     characters, so they go through status buckets instead. */
+  const presetLibrary = useMemo(
+    () => library.filter((v) => v.ttsVoice?.provider !== 'qwen'),
+    [library],
+  );
+  const qwenLibrary = useMemo(
+    () => library.filter((v) => v.ttsVoice?.provider === 'qwen'),
+    [library],
+  );
+  const families = useMemo(() => buildFamilies(presetLibrary, tab), [presetLibrary, tab]);
+  const qwenGroups = useMemo(() => buildQwenStatusGroups(qwenLibrary, tab), [qwenLibrary, tab]);
   const books = [...new Set(library.map((v) => v.bookId))];
 
   /* Compare derivations. Memoised so a transient render doesn't recompute
@@ -751,8 +761,13 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
     { id: 'base', label: `Base voices${baseVoicesLoaded ? ` (${baseVoices.length})` : ''}` },
   ];
 
+  /* Count preset families only — bespoke Qwen voices no longer form
+     families (they bucket by status), so counting them here would inflate
+     the tile with one-per-character noise (plan 117). */
   const familyCount = new Set(
-    library.filter((v) => v.ttsVoice).map((v) => `${v.ttsVoice!.provider}|${v.ttsVoice!.name}`),
+    presetLibrary
+      .filter((v) => v.ttsVoice)
+      .map((v) => `${v.ttsVoice!.provider}|${v.ttsVoice!.name}`),
   ).size;
 
   return (
@@ -815,7 +830,7 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
           onPlay={playBaseVoice}
           status={familyStatus}
         />
-      ) : families.length === 0 ? (
+      ) : families.length === 0 && qwenGroups.length === 0 ? (
         <div className="bg-white rounded-3xl border border-ink/10 shadow-card p-10 text-center">
           <p className="text-sm font-bold text-ink">No voices yet</p>
           <p className="mt-2 text-xs text-ink/60 max-w-md mx-auto">
@@ -839,6 +854,22 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
               onToggleSelect={toggleSelect}
               duplicateCandidates={candidatesByFamily.get(f.key) ?? []}
               onReviewDuplicate={openDuplicateReview}
+              representativeBookIdBySeries={representativeBookIdBySeries}
+              onRebaselineSeries={(bookId) =>
+                dispatch(uiActions.openRebaselineModal({ bookId }))
+              }
+            />
+          ))}
+          {qwenGroups.map((g) => (
+            <QwenStatusSection
+              key={g.status}
+              group={g}
+              draggingVoiceId={draggingVoiceId}
+              setDraggingVoiceId={setDraggingVoiceId}
+              onTogglePin={togglePin}
+              onOpenCharacter={onOpenCharacter}
+              selectedVoiceIds={selectedVoiceIds}
+              onToggleSelect={toggleSelect}
               representativeBookIdBySeries={representativeBookIdBySeries}
               onRebaselineSeries={(bookId) =>
                 dispatch(uiActions.openRebaselineModal({ bookId }))
@@ -1075,17 +1106,47 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
   );
 }
 
-/* Internal accumulator — kept module-local so the public VoiceFamily type
-   stays free of the per-build Map plumbing. */
-interface FamilyAccumulator extends VoiceFamily {
-  books: Map<string, BookGroup>;
-  seriesOrder: Map<string, string | null>;
-  seriesBuckets: Map<string, BookGroup[]>;
+/* Shared series → book nesting used by BOTH the preset voice-family builder
+   and the Qwen status-bucket builder. Members are grouped by book in
+   first-seen order, books bucketed by series; then books sort by title
+   within a series and series sort alphabetically (standalones — null
+   series — sort last under the '~' sentinel). */
+function nestBySeriesBook(members: Voice[]): SeriesGroup[] {
+  const books = new Map<string, BookGroup>();
+  const seriesBuckets = new Map<string, BookGroup[]>();
+  const seriesOrder = new Map<string, string | null>();
+  for (const v of members) {
+    /* `bookSeries` is null for standalones — bucket those under a synthetic
+       'standalone' key so the render path can flatten. */
+    const seriesKey = v.bookSeries ?? 'standalone';
+    let bg = books.get(v.bookId);
+    if (!bg) {
+      bg = { bookId: v.bookId, bookTitle: v.bookTitle, voices: [] };
+      books.set(v.bookId, bg);
+      const bucket = seriesBuckets.get(seriesKey) ?? [];
+      bucket.push(bg);
+      seriesBuckets.set(seriesKey, bucket);
+      seriesOrder.set(seriesKey, v.bookSeries ?? null);
+    }
+    bg.voices.push(v);
+  }
+  const seriesGroups: SeriesGroup[] = [];
+  for (const [seriesKey, bks] of seriesBuckets) {
+    seriesGroups.push({
+      series: seriesKey === 'standalone' ? null : (seriesOrder.get(seriesKey) as string | null),
+      books: bks.sort((a, b) => a.bookTitle.localeCompare(b.bookTitle)),
+    });
+  }
+  seriesGroups.sort((a, b) => (a.series ?? '~').localeCompare(b.series ?? '~'));
+  return seriesGroups;
 }
 
 /* Build voice families from the flat library list. Filters by tab first
    (so 'current' / 'library' don't leak voices the user isn't asking about
-   into the family count), then groups, then sub-groups by series → book. */
+   into the family count), then groups by (provider, name), then sub-groups
+   by series → book. Pass only NON-Qwen voices — bespoke Qwen voices are 1:1
+   with characters, so family grouping degenerates; they go through
+   buildQwenStatusGroups instead. */
 function buildFamilies(
   library: Voice[],
   tab: Tab,
@@ -1094,7 +1155,7 @@ function buildFamilies(
     if (tab === 'all' || tab === 'base') return true;
     return v.source === tab;
   });
-  const byKey = new Map<string, FamilyAccumulator>();
+  const byKey = new Map<string, VoiceFamily>();
   for (const v of filtered) {
     if (!v.ttsVoice) continue;
     const key = `${v.ttsVoice.provider}|${v.ttsVoice.name}`;
@@ -1110,54 +1171,16 @@ function buildFamilies(
         primary: v,
         anyPinned: false,
         gradient: gradientForTtsVoice(v.ttsVoice.name, key) as [string, string],
-        books: new Map(),
-        seriesOrder: new Map(),
-        seriesBuckets: new Map(),
       };
       byKey.set(key, fam);
     }
     fam.members.push(v);
     fam.totalUsedIn += v.usedIn;
     if (v.pinned) fam.anyPinned = true;
-    /* Nested grouping. `bookSeries` is null for standalones — bucket those
-       under a synthetic 'standalone' key so the render path can flatten. */
-    const seriesKey = v.bookSeries ?? 'standalone';
-    let bg = fam.books.get(v.bookId);
-    if (!bg) {
-      bg = { bookId: v.bookId, bookTitle: v.bookTitle, voices: [] };
-      fam.books.set(v.bookId, bg);
-      const bucket = fam.seriesBuckets.get(seriesKey) ?? [];
-      bucket.push(bg);
-      fam.seriesBuckets.set(seriesKey, bucket);
-      fam.seriesOrder.set(seriesKey, v.bookSeries ?? null);
-    }
-    bg.voices.push(v);
   }
-  /* Project each accumulator into a clean public VoiceFamily with a
-     flattened seriesGroups list. */
   const out: Array<VoiceFamily & { seriesGroups: SeriesGroup[] }> = [];
   for (const fam of byKey.values()) {
-    const seriesGroups: SeriesGroup[] = [];
-    for (const [seriesKey, books] of fam.seriesBuckets) {
-      seriesGroups.push({
-        series:
-          seriesKey === 'standalone' ? null : (fam.seriesOrder.get(seriesKey) as string | null),
-        books: books.sort((a, b) => a.bookTitle.localeCompare(b.bookTitle)),
-      });
-    }
-    seriesGroups.sort((a, b) => (a.series ?? '~').localeCompare(b.series ?? '~'));
-    out.push({
-      key: fam.key,
-      engine: fam.engine,
-      name: fam.name,
-      description: fam.description,
-      members: fam.members,
-      totalUsedIn: fam.totalUsedIn,
-      primary: fam.primary,
-      anyPinned: fam.anyPinned,
-      gradient: fam.gradient,
-      seriesGroups,
-    });
+    out.push({ ...fam, seriesGroups: nestBySeriesBook(fam.members) });
   }
   /* Family sort: pinned (any member) first, then total usedIn desc, then
      by speaker name so the order is stable across renders. */
@@ -1166,6 +1189,54 @@ function buildFamilies(
     if (a.totalUsedIn !== b.totalUsedIn) return b.totalUsedIn - a.totalUsedIn;
     return a.name.localeCompare(b.name);
   });
+  return out;
+}
+
+type QwenStatus = 'none' | 'designed';
+
+interface QwenStatusGroup {
+  status: QwenStatus;
+  title: string;
+  members: Voice[];
+  totalUsedIn: number;
+  anyPinned: boolean;
+  seriesGroups: SeriesGroup[];
+}
+
+/* Bespoke Qwen voices are designed 1:1 per character (plan 108), so the
+   (provider, name) voice-family grouping collapses into degenerate
+   single-member sections. Instead bucket Qwen voices by design status:
+     - 'none'     → ttsVoice.name empty (no designed voiceId) → "Needs a voice"
+     - 'designed' → has a designed voiceId → "Designed voices"
+   In "Designed voices" each card carries a Designed / Generated badge driven
+   by `voice.generated`. Same tab filter + series → book nesting as
+   buildFamilies; "Needs a voice" sorts first so action-needed is at the top. */
+function buildQwenStatusGroups(library: Voice[], tab: Tab): QwenStatusGroup[] {
+  const filtered = library.filter((v) => {
+    if (tab === 'all' || tab === 'base') return true;
+    return v.source === tab;
+  });
+  const buckets: Record<QwenStatus, Voice[]> = { none: [], designed: [] };
+  for (const v of filtered) {
+    buckets[v.ttsVoice?.name ? 'designed' : 'none'].push(v);
+  }
+  const order: Array<{ status: QwenStatus; title: string }> = [
+    { status: 'none', title: 'Needs a voice' },
+    { status: 'designed', title: 'Designed voices' },
+  ];
+  const out: QwenStatusGroup[] = [];
+  for (const { status, title } of order) {
+    const members = buckets[status];
+    if (members.length === 0) continue;
+    out.push({
+      status,
+      title,
+      members,
+      totalUsedIn: members.reduce((n, v) => n + v.usedIn, 0),
+      anyPinned: members.some((v) => !!v.pinned),
+      seriesGroups: nestBySeriesBook(members),
+    });
+  }
   return out;
 }
 
@@ -1325,6 +1396,119 @@ function VoiceFamilySection({
                   </div>
                 </div>
               ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+interface QwenSectionProps {
+  group: QwenStatusGroup;
+  draggingVoiceId: string | null;
+  setDraggingVoiceId: (id: string | null) => void;
+  onTogglePin: (v: Voice) => void;
+  onOpenCharacter?: (voice: Voice) => void;
+  selectedVoiceIds: string[];
+  onToggleSelect: (v: Voice) => void;
+  /* Per-series Rebaseline (plan 108 follow-up) — reused verbatim from
+     VoiceFamilySection. Rebaseline *creates* designed Qwen voices, so it
+     sits naturally on the Qwen sections' series-group headers. */
+  representativeBookIdBySeries: Map<string, string>;
+  onRebaselineSeries: (bookId: string) => void;
+}
+
+/* Status-bucketed Qwen section (plan 117): "Needs a voice" / "Designed
+   voices", each nested series → book → character. No "Audition base voice"
+   (a status bucket is not one voice) and no ⚠ duplicate pill (unique Qwen
+   voiceIds never share a base voice). The "Designed voices" cards carry a
+   Designed / Generated badge. */
+function QwenStatusSection({
+  group,
+  draggingVoiceId,
+  setDraggingVoiceId,
+  onTogglePin,
+  onOpenCharacter,
+  selectedVoiceIds,
+  onToggleSelect,
+  representativeBookIdBySeries,
+  onRebaselineSeries,
+}: QwenSectionProps) {
+  const seriesGroups = group.seriesGroups;
+  return (
+    <section aria-label={`Qwen · ${group.title}`}>
+      <header className="mb-3 flex items-center justify-between gap-4 flex-wrap">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h2 className="text-base font-bold text-ink truncate">{group.title}</h2>
+            <span className="text-[11px] uppercase tracking-wider font-semibold text-ink/40 shrink-0">
+              {ENGINE_LABEL.qwen}
+            </span>
+          </div>
+          <p className="text-xs text-ink/50">
+            {group.members.length} {group.members.length === 1 ? 'cast member' : 'cast members'}{' '}
+            · {seriesGroups.length}{' '}
+            {seriesGroups.length === 1 ? 'series/standalone bucket' : 'series/standalone buckets'}
+          </p>
+        </div>
+      </header>
+      <div className="space-y-4">
+        {seriesGroups.map((sg) => {
+          const repBookId = sg.series ? representativeBookIdBySeries.get(sg.series) : undefined;
+          return (
+            <div key={sg.series ?? '~standalone'} className="pl-2 border-l-2 border-ink/[0.06]">
+              {sg.series && (
+                <div className="flex items-center justify-between gap-3 mb-2 pl-2 flex-wrap">
+                  <p className="text-[11px] uppercase tracking-wider font-semibold text-ink/40">
+                    {sg.series}
+                  </p>
+                  {repBookId && (
+                    <button
+                      type="button"
+                      onClick={() => onRebaselineSeries(repBookId)}
+                      data-testid={`rebaseline-series-${sg.series}`}
+                      title="Move the principal cast onto bespoke Qwen voices across this series"
+                      className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-magenta text-white text-[11px] font-semibold hover:bg-magenta/90 transition-colors min-h-[44px] sm:min-h-0"
+                    >
+                      <IconSparkle className="w-3.5 h-3.5" /> Rebaseline the series
+                    </button>
+                  )}
+                </div>
+              )}
+              <div className="space-y-3">
+                {sg.books.map((b) => (
+                  <div key={b.bookId}>
+                    <p className="text-xs font-semibold text-ink/70 mb-1.5 pl-2">{b.bookTitle}</p>
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3 pl-2">
+                      {b.voices.map((v) => (
+                        <VoiceCard
+                          key={v.id}
+                          voice={v}
+                          draggingVoiceId={draggingVoiceId}
+                          setDraggingVoiceId={setDraggingVoiceId}
+                          compact={false}
+                          showBookTitle={false}
+                          pinned={!!v.pinned}
+                          onTogglePin={onTogglePin}
+                          onSelect={onOpenCharacter}
+                          selected={selectedVoiceIds.includes(v.id)}
+                          onToggleSelect={onToggleSelect}
+                          badge={
+                            group.status === 'designed' ? (
+                              v.generated ? (
+                                <Pill color="success">Generated</Pill>
+                              ) : (
+                                <Pill color="library">Designed</Pill>
+                              )
+                            ) : undefined
+                          }
+                        />
+                      ))}
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
           );


### PR DESCRIPTION
## Summary

Frontend half of plan 117 (status-first Qwen voice presentation) — consumes the `Voice.generated` flag added server-side in #272.

**Voices view (`#/voices`)**
- Bespoke Qwen voices are designed 1:1 per character, so the `(provider, name)` voice-family grouping collapsed into a degenerate one-section-per-voice cascade (each repeating "1 cast member · 1 bucket", "Audition base voice", "Rebaseline"). Qwen voices now bucket by **design status** into two sections — **`Qwen · Needs a voice`** (no designed voiceId) and **`Qwen · Designed voices`** — each nested series → book → character.
- Inside "Designed voices" every card carries a **Designed / Generated** badge driven by `Voice.generated`.
- **Dropped for Qwen:** the "Audition base voice" header button (a status bucket is not one voice) and the ⚠ cross-book duplicate pill (unique Qwen voiceIds never share a base voice). **Kept:** the per-series "Rebaseline the series" button on the Qwen section's series-group header, and the Compare/Merge selection pill.
- **Preset engines (kokoro/coqui/gemini/piper) are untouched** — they keep `(provider, name)` family grouping; the two engine worlds co-exist in the same scroll. The "Families" StatTile now counts preset families only (Qwen no longer inflates it).

**Cast table (`#/books/<id>/cast`)**
- The Status column is now **engine-aware**. A Qwen row follows the design → generate lifecycle — **Needs voice / Designed / Generated** — instead of the provenance `voiceState` enum (whose `'generated'` default falsely showed a green "Generated" pill on an *undesigned* Qwen character). Preset rows keep their `voiceState` pills.
- The lifecycle reads `Voice.generated` off the matched library voice (`library` prop). The `voiceState` enum is **not** repurposed — the naming collision ("generated" provenance vs "generated" = rendered) is resolved at the presentation layer only.

**Implementation notes**
- Extracted a shared `nestBySeriesBook` helper used by both `buildFamilies` (now Qwen-free) and the new `buildQwenStatusGroups`.
- Added an optional `badge` prop to `VoiceCard`; added `resolveStatusPill` + `StatusPill` in the cast view.
- Mock fixtures (`src/mocks/voices.ts`) gain three Qwen voices in the three lifecycle states (Bramble = none, Thistle = designed, Finch = generated), kept in the existing Northern Coast Trilogy series and off `cc` (rebaseline-representative guard).

**Known simplification:** `Voice.generated` is populated only when the library is fetched with `engine=qwen` (i.e. the project is on Qwen — the case where Qwen sections/rows appear). Mixed-engine setups conservatively show "Designed".

## Test plan

- `src/views/voices.test.tsx` — `describe('LibraryView Qwen status sections (plan 117)')`: exactly two Qwen regions by `aria-label` (regression: NOT one per voice); none→"Needs a voice", designed→"Designed voices"; Designed/Generated badges; no "Audition base voice" on Qwen headers; per-series Rebaseline present; Qwen-only library doesn't show the empty state; preset family tests unchanged.
- `src/views/cast.test.tsx` — `describe('CastView Qwen status pill (plan 117)')`: Qwen no-voice → "Needs voice" (not green "Generated", the bug-fix regression); designed → "Designed"; matched library voice `generated:true` → "Generated"; preset Generated/Reused pills unchanged; defensive when `library` empty.
- `e2e/voices-qwen-status.spec.ts` — the two Qwen sections + badges render alongside a preset family on `#/voices`; no "Audition base voice" on a Qwen section.
- `npm run verify` — full battery green locally.

Regression plan: [`docs/features/117-qwen-voice-presentation.md`](docs/features/117-qwen-voice-presentation.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
