### PR TITLE
perf(frontend): prefetch the UploadView chunk to kill the slow "Loading…" on #/new

### DIFF
--- a/docs/features/archive/89-frontend-perf-pass.md
+++ b/docs/features/archive/89-frontend-perf-pass.md
@@ -87,3 +87,12 @@ C5's lazy boundary meant the Generate view's chunk only began downloading on fir
 - **`src/components/layout.tsx`:** a one-shot `useEffect` (ref-guarded) fires `importGenerationView()` once the user is inside a book (`stageKind === 'ready'`) OR any generation stream is live (`activeStreams.length > 0`). `import()` is idempotent, so warming is free if the chunk already loaded.
 - **C5 invariant preserved:** the view stays lazy (no eager-import bloat on the library landing route); only the _download timing_ moves earlier. Behaviourally invisible — the view renders identically.
 - **Tests:** `src/routes/prefetch.test.ts` locks that the shared thunk resolves the `GenerationView` module (a path typo would silently no-op the prefetch). No new e2e — the Generate view's load/render seam is already covered (`e2e/responsive/coverage.spec.ts`, `e2e/generation-parallel.spec.ts`, `e2e/queue-modal.spec.ts`), and the optimization is load-timing, which CI (warm chunks) can't observe deterministically.
+
+### Follow-up — UploadView chunk prefetch (2026-05-27)
+
+Same C5 cold-chunk symptom reported on the `#/new` route: the first navigation to the upload view sat on the route Suspense fallback ("Loading…") for several seconds while the dev server transformed/downloaded the upload chunk graph. That graph is heavy — `upload.tsx` plus its `manuscript-diff.tsx` dependency are the two largest modules in it — so the cold first hit is the worst case. (Production serves pre-built chunks, so the delay is dominated by the dev-server on-demand transform; the fix still warms the prod cold-cache case.) Fix mirrors the GenerationView prefetch above.
+
+- **`src/routes/prefetch.ts`:** add `importUploadView = () => import('../views/upload')` alongside `importGenerationView`, again the single shared specifier behind both the `React.lazy` def and the prefetch.
+- **`src/components/layout.tsx`:** a second ref-guarded one-shot `useEffect` fires `importUploadView()` while the user sits on the library landing page (`stageKind === 'books'`) — the page hosting the "New project" entry, i.e. the most likely next click. Gated on the books stage so it doesn't compete with first paint of any in-book view.
+- **C5 invariant preserved:** the view stays lazy; only the download timing moves earlier. Behaviourally invisible.
+- **Tests:** extended `src/routes/prefetch.test.ts` with a sibling case asserting the thunk resolves the `UploadView` module. No new e2e — same load-timing rationale as above; the upload view's render seam is already covered by `e2e/responsive/coverage.spec.ts`.

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -50,7 +50,7 @@ import { ConfirmDialog } from '../modals/confirm-dialog';
 import { QueueModalContainer } from '../modals/queue-modal';
 import { loadQueue, enqueueQueueEntries } from '../store/queue-thunks';
 import { selectGenerationActivityCount } from '../store/queue-slice';
-import { importGenerationView } from '../routes/prefetch';
+import { importGenerationView, importUploadView } from '../routes/prefetch';
 import { ToastStack } from './toast-stack';
 import { RevisionDiffPlayer } from '../views/revision-diff';
 import { RevisionTimelineModal } from './revision-timeline-modal';
@@ -145,6 +145,20 @@ export function Layout() {
     generationChunkWarmed.current = true;
     void importGenerationView();
   }, [stageKind, activeStreams.length]);
+
+  /* Same trick for the lazy UploadView chunk: warm it while the user sits on
+     the library landing page, the page hosting the "New project" entry. The
+     upload chunk graph is heavy (upload.tsx + manuscript-diff.tsx), so the
+     first cold download otherwise stretches the "#/new" route Suspense
+     fallback into a multi-second "Loading…". Gated on the books stage so it
+     doesn't compete with first paint of any in-book view; one-shot via ref. */
+  const uploadChunkWarmed = useRef(false);
+  useEffect(() => {
+    if (uploadChunkWarmed.current) return;
+    if (stageKind !== 'books') return;
+    uploadChunkWarmed.current = true;
+    void importUploadView();
+  }, [stageKind]);
 
   const matchCharacter = ui.matchDetailFor
     ? (characters.find((c) => c.id === ui.matchDetailFor) ?? null)

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -36,8 +36,8 @@ import { useLocalAnalyzerGuard } from '../hooks/use-local-analyzer-guard';
    sub-routes (ReadyRoute's switch, UploadRoute's conditional) where the
    eager cost is negligible OR they are the landing route and lazy-loading
    them would only slow first paint. */
-import { importGenerationView } from './prefetch';
-const UploadView = lazy(() => import('../views/upload').then((m) => ({ default: m.UploadView })));
+import { importGenerationView, importUploadView } from './prefetch';
+const UploadView = lazy(() => importUploadView().then((m) => ({ default: m.UploadView })));
 const AnalysingView = lazy(() =>
   import('../views/analysing').then((m) => ({ default: m.AnalysingView })),
 );

--- a/src/routes/prefetch.test.ts
+++ b/src/routes/prefetch.test.ts
@@ -1,14 +1,21 @@
 import { describe, it, expect } from 'vitest';
-import { importGenerationView } from './prefetch';
+import { importGenerationView, importUploadView } from './prefetch';
 
-/* The prefetch warms the Generate view's chunk before navigation. This guards
-   that the shared import specifier still resolves the GenerationView module —
-   a path typo here would silently no-op the prefetch (and, because the same
-   thunk backs the React.lazy in routes/index.tsx, also break the route), with
-   no behavioural test catching it since the view would still lazy-load. */
+/* The prefetch warms a route's chunk before navigation. These guard that the
+   shared import specifiers still resolve the right module — a path typo here
+   would silently no-op the prefetch (and, because the same thunk backs the
+   React.lazy in routes/index.tsx, also break the route), with no behavioural
+   test catching it since the view would still lazy-load. */
 describe('importGenerationView', () => {
   it('resolves the module exposing GenerationView so the prefetch warms the right chunk', async () => {
     const mod = await importGenerationView();
     expect(typeof mod.GenerationView).toBe('function');
+  });
+});
+
+describe('importUploadView', () => {
+  it('resolves the module exposing UploadView so the prefetch warms the right chunk', async () => {
+    const mod = await importUploadView();
+    expect(typeof mod.UploadView).toBe('function');
   });
 });

--- a/src/routes/prefetch.ts
+++ b/src/routes/prefetch.ts
@@ -1,14 +1,22 @@
-/* Shared dynamic-import thunk for the lazy GenerationView chunk.
+/* Shared dynamic-import thunks for lazy route chunks.
  *
- * Exported so BOTH the React.lazy definition (routes/index.tsx) and the
- * proactive prefetch (components/layout.tsx) reference the EXACT same import
- * specifier. Vite code-splits a given dynamic specifier into one chunk, so
- * warming it via the prefetch resolves the very module the route lazy awaits —
- * the Generate view then paints from cache instead of showing the route
- * Suspense fallback while a cold chunk downloads (worst right when the main
- * thread is busy mid-generation, which is exactly when the user opens it).
+ * Each thunk is exported so BOTH the React.lazy definition (routes/index.tsx)
+ * and the proactive prefetch (components/layout.tsx) reference the EXACT same
+ * import specifier. Vite code-splits a given dynamic specifier into one chunk,
+ * so warming it via the prefetch resolves the very module the route lazy
+ * awaits — the view then paints from cache instead of showing the route
+ * Suspense fallback while a cold chunk downloads (which reads as a stall).
  *
  * Lives in its own module to avoid a circular import: routes/index.tsx imports
  * Layout, and layout.tsx imports this — a shared specifier here keeps that edge
- * acyclic (this module imports nothing from either). */
+ * acyclic (this module imports nothing from either).
+ *
+ * - GenerationView: warmed once the user is inside a book / a run is live;
+ *   worst case is a cold download while the main thread is busy mid-generation.
+ * - UploadView: warmed while the user sits on the library landing page (the
+ *   page hosting the "New project" entry). Its chunk graph is heavy
+ *   (upload.tsx + manuscript-diff.tsx), so the first cold transform/download
+ *   otherwise stretches the "#/new" route Suspense fallback into a multi-second
+ *   "Loading…". */
 export const importGenerationView = () => import('../views/generation');
+export const importUploadView = () => import('../views/upload');


### PR DESCRIPTION
## Summary

Reported symptom: navigating to `#/new` (the New-project / upload screen) sat on a "Loading…" spinner for ~5–10 s before the view appeared.

Root cause: `#/new` lazy-loads `UploadView` (plan 89 C5 code-split), so its chunk only began downloading/transforming on the *first* navigation there. That chunk graph is the heaviest of the route leaves — `upload.tsx` plus its `manuscript-diff.tsx` dependency are the two biggest modules in it — so the cold first hit stretched the route Suspense fallback (`DelayedSpinner`) into a multi-second "Loading…". It was never a hang: the modules transform fine and subsequent navigations are instant. The delay is dominated by the **Vite dev-server on-demand transform** (production serves pre-built static chunks), but the fix also warms the prod cold-cache case.

Fix mirrors the `GenerationView` chunk prefetch from PR #246 (`ba3c855`): warm the upload chunk *before* navigation, from the eagerly-loaded library landing page, so clicking "New" paints from cache.

- **`src/routes/prefetch.ts`** — added `importUploadView = () => import('../views/upload')` alongside `importGenerationView`. The single dynamic-import specifier is shared by both the `React.lazy` def in `routes/index.tsx` and the prefetch, so Vite warms the *exact* chunk the route awaits (same specifier → same chunk).
- **`src/routes/index.tsx`** — the `UploadView` lazy def now routes through that shared thunk.
- **`src/components/layout.tsx`** — a second ref-guarded one-shot `useEffect` fires `importUploadView()` while the user sits on the library landing page (`stageKind === 'books'`) — the page hosting the "New project" entry, i.e. the most likely next click. Gated on the books stage so it doesn't compete with first paint of any in-book view. `import()` is idempotent, so warming is free if the chunk already loaded.
- The view stays lazy — no eager-import bloat on the landing route; only the download timing moves earlier. Behaviourally invisible (the view renders identically), so no regression in the plan-89 code-split.
- **`docs/features/archive/89-frontend-perf-pass.md`** — recorded the follow-up alongside the existing GenerationView prefetch note.

## Test plan

- `src/routes/prefetch.test.ts` — extended with a sibling case asserting `importUploadView` resolves the `UploadView` module (a path typo would silently no-op the prefetch *and* break the route's lazy def, with no behavioural test catching it). Both prefetch cases green.
- No new e2e — the upload view's render seam is already covered by `e2e/responsive/coverage.spec.ts`, and the optimization is load-*timing*, which CI (warm chunks) can't observe deterministically. Same rationale as PR #246.
- Full `npm run verify` run locally and green (the first run tripped the known intermittent `tinypool` "Worker exited unexpectedly" server-test flake — unrelated to this frontend-only diff; cleared on a cache-aware re-run with all server files passing).

Regression plan: [docs/features/archive/89-frontend-perf-pass.md](docs/features/archive/89-frontend-perf-pass.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)