### PR TITLE
test(server): lock all writable user-settings through PUT/GET/disk round-trip

### DIFF
--- a/docs/features/14a-tts-sidecar-kokoro.md
+++ b/docs/features/14a-tts-sidecar-kokoro.md
@@ -75,6 +75,15 @@ the cast UI ever surfaces "upload a reference clip per character").
    chapters as drifted in the Generation view so the user knows to
    regenerate for book-wide voice consistency.
 
+7. **Account TTS defaults persist round-trip.** The engine/model picker
+   and the `eagerLoadKokoro` toggle (Account → "Defaults for new books")
+   write through `PUT /api/user/settings` and re-hydrate on the boot-time
+   `GET`. Every writable user-setting field is asserted to survive
+   PUT → GET → disk by `server/src/routes/user-settings.test.ts` ("round-trips
+   every writable field"), guarding the allow-list-gap class of bug that
+   silently dropped `qwen3-tts-0.6b` until `fb094e2` — a saved default that
+   400s on PUT "reverts" to the built-in default on the next load.
+
 ## Critical files
 
 - `server/tts-sidecar/main.py` — `KokoroEngine` class, `/speakers`

--- a/server/src/routes/user-settings.test.ts
+++ b/server/src/routes/user-settings.test.ts
@@ -23,10 +23,13 @@ import { join } from 'node:path';
 import express, { type Express } from 'express';
 import request from 'supertest';
 
+type SettingsModule = typeof import('../workspace/user-settings.js');
+
 let workspaceRoot: string;
 let app: Express;
 let userSettingsPath: string;
 let resetCache: () => void;
+let userSettingsSchema: SettingsModule['userSettingsSchema'];
 
 beforeAll(async () => {
   workspaceRoot = mkdtempSync(join(tmpdir(), 'audiobook-user-settings-test-'));
@@ -40,6 +43,7 @@ beforeAll(async () => {
 
   userSettingsPath = settings.USER_SETTINGS_PATH;
   resetCache = settings._resetUserSettingsCache;
+  userSettingsSchema = settings.userSettingsSchema;
 
   app = express();
   app.use(express.json());
@@ -202,6 +206,62 @@ describe('user-settings router', () => {
 
     const onDisk = JSON.parse(readFileSync(userSettingsPath, 'utf8'));
     expect(onDisk.defaultTtsModelKey).toBe('qwen3-tts-0.6b');
+  });
+
+  /* Regression — EVERY writable setting must survive PUT → GET → disk.
+     The qwen bug above shipped because a new model key was added to the
+     schema but missed from the PUT allow-list, so its save silently 400'd
+     and the value "reverted" on the next load (the user-reported symptom,
+     also seen with eagerLoadKokoro). This locks the whole object: one
+     non-default sample per writable field, asserted in the PUT echo AND on
+     disk. The key list is derived from the schema, so a future field added
+     without a sample value fails the guard below — forcing it to be
+     covered. geminiApiKey is excluded: it's intentionally stripped from the
+     general PUT (see the secret-stripping test) and has its own endpoint. */
+  it('PUT round-trips every writable field onto disk and back (no silent drops)', async () => {
+    const SAMPLE_VALUES: Record<string, unknown> = {
+      displayName: 'Round Trip User',
+      defaultAnalysisModel: 'gemini-2.5-flash',
+      defaultTtsEngine: 'gemini',
+      /* The user's exact TTS-model choice. The server stores engine +
+         modelKey independently (no cross-field coherence check), so this is
+         a valid persistence probe even though the UI pairs Qwen with the
+         `local` engine. */
+      defaultTtsModelKey: 'qwen3-tts-0.6b',
+      sidecarUrl: 'http://localhost:9100',
+      analysisEngine: 'local',
+      ollamaUrl: 'http://localhost:11500',
+      workspaceDirOverride: 'D:/audiobooks-ws',
+      exportSyncFolder: '/tmp/export-sync',
+      minorCastMinLines: 7,
+      coverPickerDefaultTab: 'upload',
+      defaultThemePreference: 'dark',
+      autoStartSidecar: false,
+      analyzerPhase0Model: 'gemma-4-31b-it',
+      analyzerPhase1Model: 'gemini-3.1-flash-lite',
+      analyzerPhase1MinLagChapters: 5,
+      dualModelEnabled: true,
+      /* The user's other reported field — eager-load off for a Qwen-primary
+         setup. */
+      eagerLoadKokoro: false,
+      generationWorkers: 4,
+    };
+
+    /* Guard: every writable schema field has a sample value here. A field
+       added to userSettingsSchema without one trips this assertion. */
+    const writableKeys = Object.keys(userSettingsSchema.shape).filter((k) => k !== 'geminiApiKey');
+    for (const key of writableKeys) {
+      expect(SAMPLE_VALUES, `add a SAMPLE_VALUES entry for new field "${key}"`).toHaveProperty(key);
+    }
+
+    const res = await request(app).put('/api/user/settings').send(SAMPLE_VALUES);
+    expect(res.status).toBe(200);
+
+    const onDisk = JSON.parse(readFileSync(userSettingsPath, 'utf8'));
+    for (const key of writableKeys) {
+      expect(res.body[key], `GET echo for "${key}"`).toEqual(SAMPLE_VALUES[key]);
+      expect(onDisk[key], `on-disk value for "${key}"`).toEqual(SAMPLE_VALUES[key]);
+    }
   });
 
   /* Plan 49 — dedicated Gemini-key PUT endpoint. The general PUT still


### PR DESCRIPTION
## Summary

Investigated a report that the **Account → "Defaults for new books" TTS model** reverts to Kokoro v1 after restart (and that the Kokoro eager-load toggle didn't stick). Root cause was the **already-fixed** allow-list-gap bug: `fb094e2` (2026-05-25) added `qwen3-tts-0.6b` to the server's `PUT /api/user/settings` enum. Before that fix a Qwen save returned HTTP 400, the save silently failed, and the next boot-time `GET` re-hydrated the built-in default — the exact "revert" symptom. The user was exercising a server process started before that fix landed; verified live that `GET /api/user/settings` now returns the persisted `qwen3-tts-0.6b` + `eagerLoadKokoro:false`, and `server/user-settings.json` holds the same. **No product code change needed.**

This PR closes the door on that class of regression for the whole settings object.

## What changed

- **New regression test** (`server/src/routes/user-settings.test.ts`): PUTs a non-default value for **every writable `UserSettings` field** and asserts each survives in both the PUT echo body and the on-disk JSON. The writable-key list is derived from `userSettingsSchema.shape`, so any future field added to the schema without a sample value trips an explicit guard assertion — forcing it to be covered. The two user-reported fields (`defaultTtsModelKey=qwen3-tts-0.6b`, `eagerLoadKokoro=false`) are named in the assertions. `geminiApiKey` stays excluded (intentionally stripped from the general PUT; covered by the dedicated `/gemini-key` tests).
- **Docs**: new invariant #7 in `docs/features/14a-tts-sidecar-kokoro.md` — account TTS defaults (engine, model, eager-load) persist round-trip, locked by the new test.

## Test plan

- `npx vitest run src/routes/user-settings.test.ts` → 19/19 green (the new "round-trips every writable field" case included).
- Server typecheck (`tsc --noEmit -p .`) clean.
- Full frontend (1589) + server suites green in isolation.
- Live: `GET /api/user/settings` against the running server returns the persisted qwen + eager-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)