### PR TITLE
fix(frontend): relabel preset Status pill "Generated" to "Matched"

### DIFF
--- a/docs/features/archive/117-qwen-voice-presentation.md
+++ b/docs/features/archive/117-qwen-voice-presentation.md
@@ -97,4 +97,8 @@ Shipped 2026-05-27 across two PRs:
 
 Deltas vs. the original spec: none material. The chosen UX was "two sections + per-card Designed/Generated badge" (not three top sections) and per-character precise `generated`, both confirmed with the user before build.
 
+## Amendment (2026-05-27) — preset pill relabel "Generated" → "Matched"
+
+The preset (`voiceState`) Status pill for `voiceState: 'generated'` was relabeled from **Generated** to **Matched** (`resolveStatusPill`, `src/views/cast.tsx`). Rationale: in the provenance enum, `'generated'` means "voice auto-matched/assigned during analysis" — not "audio rendered" — so "Matched" reads accurately and removes the wording collision with the Qwen-lifecycle **Generated** pill (which genuinely means rendered audio and is unchanged). Only the preset path changed; the Qwen lifecycle (Needs voice / Designed / Generated) is untouched. The `cast.test.tsx` "keeps the preset provenance pills" case now asserts **Matched**.
+
 Known simplification (carried as designed): `Voice.generated` is populated only when the library is fetched with `engine=qwen` — i.e. when the project is on Qwen, which is also the only time Qwen sections/rows appear. Mixed-engine setups conservatively render "Designed". No BACKLOG follow-up filed; revisit only if cross-book over-report proves confusing in practice.

--- a/src/views/cast.test.tsx
+++ b/src/views/cast.test.tsx
@@ -414,10 +414,10 @@ describe('CastView Qwen status pill (plan 117)', () => {
     expect(within(row).getByText('Generated')).toBeInTheDocument();
   });
 
-  it('keeps the preset provenance pills (Generated / Reused) for non-Qwen rows', () => {
+  it('keeps the preset provenance pills (Matched / Reused) for non-Qwen rows', () => {
     renderView();
     /* sweeney: coqui, voiceState 'generated'; narrator: voiceState 'reused'. */
-    expect(within(rowFor('Mr. Sweeney')).getByText('Generated')).toBeInTheDocument();
+    expect(within(rowFor('Mr. Sweeney')).getByText('Matched')).toBeInTheDocument();
     expect(within(rowFor('Narrator')).getByText('Reused')).toBeInTheDocument();
   });
 

--- a/src/views/cast.tsx
+++ b/src/views/cast.tsx
@@ -949,7 +949,7 @@ function resolveStatusPill(
   }
   switch (c.voiceState) {
     case 'generated':
-      return { label: 'Generated', color: 'success' };
+      return { label: 'Matched', color: 'success' };
     case 'tuned':
       return { label: 'Tuned', color: 'warning' };
     case 'reused':


### PR DESCRIPTION
## Summary

The cast Status column resolves a Qwen character via its bespoke design lifecycle (Needs voice / Designed / Generated) but a preset-engine character (Kokoro / Coqui / Gemini) via the `voiceState` provenance enum. In that enum, `voiceState: 'generated'` means "voice auto-matched/assigned during analysis" — not "audio rendered" — so the preset pill now reads **Matched**. This is semantically accurate and removes the wording collision with the Qwen-lifecycle **Generated** pill (which genuinely means rendered audio and is left unchanged). Scope is the preset path only (`resolveStatusPill` `case 'generated'`); the Qwen path is untouched.

User-visible delta: a preset-engine character whose voice was auto-assigned during analysis now shows a green **Matched** pill instead of **Generated**. Qwen-only projects see no change (their green pills come from the untouched Qwen path).

## Test plan

- `src/views/cast.test.tsx` "keeps the preset provenance pills" regression case updated to assert **Matched** (description + assertion); the Qwen-path "Generated" assertions are unchanged.
- `npm test` -> 1877 passed; `npm run verify` green on push (typecheck + all tests + e2e + build).
- Regression plan: amended `docs/features/archive/117-qwen-voice-presentation.md` with a dated note recording the relabel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)