### PR TITLE
fix(frontend): status-on-default-engine, dark-mode search contrast, stable sample scope

### DIFF
--- a/src/components/searchable-picker.test.tsx
+++ b/src/components/searchable-picker.test.tsx
@@ -81,6 +81,19 @@ describe('SearchablePicker', () => {
     expect(screen.getByLabelText('Search fruit…')).toHaveFocus();
   });
 
+  it('gives the search input a themeable background (not the un-themeable bg-canvas opacity)', () => {
+    /* Regression: `bg-canvas/40` produced no valid rule (there is no
+       `--canvas-rgb` channel for the alpha), so the input fell back to the UA
+       white field — invisible light-on-white text in dark mode. The field must
+       use a background that flips with the theme (bg-white has an explicit
+       [data-theme='dark'] override) plus an explicit ink text colour. */
+    renderPicker();
+    const input = screen.getByLabelText('Search fruit…');
+    expect(input.className).not.toMatch(/bg-canvas\//);
+    expect(input.className).toContain('bg-white');
+    expect(input.className).toContain('text-ink');
+  });
+
   it('renders all groups with separator above labelled groups', () => {
     renderPicker();
     const picker = screen.getByRole('dialog', { name: 'Fruit picker' });

--- a/src/components/searchable-picker.tsx
+++ b/src/components/searchable-picker.tsx
@@ -267,7 +267,7 @@ export function SearchablePicker<T>({
               }}
               placeholder={searchPlaceholder}
               aria-label={searchPlaceholder}
-              className="w-full rounded-lg border border-ink/10 bg-canvas/40 pl-7 pr-2 py-1.5 text-xs focus:outline-none focus:border-peach"
+              className="w-full rounded-lg border border-ink/10 bg-white pl-7 pr-2 py-1.5 text-xs text-ink placeholder:text-ink/40 focus:outline-none focus:border-peach"
             />
           </label>
         </div>

--- a/src/lib/sample-scope.test.ts
+++ b/src/lib/sample-scope.test.ts
@@ -2,20 +2,25 @@ import { describe, it, expect } from 'vitest';
 import { sampleScopeFor } from './sample-scope';
 
 describe('sampleScopeFor', () => {
-  it('keys on the stable voiceId even when the voice is not resolved in the library', () => {
-    /* The regression: at design time the library entry often isn't loaded,
-       so the old `voice ? voice.id : char-<id>` produced `char-grady`, but at
-       play time the entry resolved and it produced `grady` — a cache miss. */
-    expect(sampleScopeFor({ id: 'grady', voiceId: 'grady' }, undefined)).toBe('grady');
-    expect(sampleScopeFor({ id: 'grady', voiceId: 'grady' }, { id: 'grady' })).toBe('grady');
-  });
-
-  it('uses a resolved voice id when present', () => {
-    expect(sampleScopeFor({ id: 'biana', voiceId: 'biana' }, { id: 'biana' })).toBe('biana');
+  it('keys on the persisted voiceId', () => {
+    expect(sampleScopeFor({ id: 'grady', voiceId: 'grady' })).toBe('grady');
+    expect(sampleScopeFor({ id: 'biana', voiceId: 'biana' })).toBe('biana');
   });
 
   it('falls back to the char-namespaced id for a character with no voiceId', () => {
-    expect(sampleScopeFor({ id: 'new-char' }, undefined)).toBe('char-new-char');
-    expect(sampleScopeFor({ id: 'new-char', voiceId: null }, null)).toBe('char-new-char');
+    expect(sampleScopeFor({ id: 'new-char' })).toBe('char-new-char');
+    expect(sampleScopeFor({ id: 'new-char', voiceId: null })).toBe('char-new-char');
+  });
+
+  it('is STABLE for a voiceId-less character regardless of library state (the design→play miss)', () => {
+    /* Regression: a freshly-designed Qwen character (no voiceId) had its
+       audition cached at design time under `char-sophie`, but the "Play 12s"
+       player resolved a same-id library voice by play-time and the old
+       `voice?.id ??` form flipped the scope to `sophie` — a cache miss that
+       re-synthesised the same line. The scope must not depend on whether a
+       library voice happens to be resolved, so the function no longer takes a
+       `voice` argument at all. */
+    expect(sampleScopeFor({ id: 'sophie' })).toBe('char-sophie');
+    expect(sampleScopeFor({ id: 'sophie', voiceId: undefined })).toBe('char-sophie');
   });
 });

--- a/src/lib/sample-scope.ts
+++ b/src/lib/sample-scope.ts
@@ -14,14 +14,18 @@
 
    Keying on the persisted `character.voiceId` (the identity a matched voice
    resolves to anyway) removes the timing dependency: design-time and
-   play-time agree by construction. `voice?.id` stays first so an explicitly
-   resolved voice still wins; the `char-<id>` namespace is the fallback for
-   characters with no voiceId, keeping their per-character samples distinct
-   from library-voice samples. Mirrors the `voice?.id ?? character.voiceId ??
-   id` identity already used for the override API in profile-drawer.tsx. */
-export function sampleScopeFor(
-  character: { id: string; voiceId?: string | null },
-  voice?: { id: string } | null,
-): string {
-  return voice?.id ?? character.voiceId ?? `char-${character.id}`;
+   play-time agree by construction. The `char-<id>` namespace is the fallback
+   for characters with no voiceId, keeping their per-character samples distinct
+   from library-voice samples.
+
+   It deliberately does NOT consult the resolved library `voice`: the earlier
+   "`voice?.id ?? character.voiceId ?? …`" form still flipped for a character
+   with NO `voiceId` (e.g. a freshly-designed Qwen voice), because
+   `findVoiceForCharacter` resolves a same-id library entry by play-time but
+   not by design-time — so the audition cached under `char-sophie` was re-synth-
+   ised under `sophie`. When `voiceId` IS set it equals the matched `voice.id`
+   anyway, so dropping `voice` loses nothing and makes the scope stable for
+   both cases. */
+export function sampleScopeFor(character: { id: string; voiceId?: string | null }): string {
+  return character.voiceId ?? `char-${character.id}`;
 }

--- a/src/lib/voice-status.test.ts
+++ b/src/lib/voice-status.test.ts
@@ -1,11 +1,13 @@
 /* resolveVoiceStatus — the two-dimension Status resolver shared by the cast
    view's Status column and the profile drawer's Voice-profile header. Locks
-   the split that lets a reused Qwen voice read "Designed/Generated · Reused"
-   instead of collapsing to a lone "Reused" pill. */
+   (a) the split that lets a reused Qwen voice read "Designed/Generated · Reused"
+   instead of collapsing to a lone "Reused" pill, and (b) the effective-engine
+   contract: a DEFAULT-engine character on a Qwen project follows the Qwen
+   lifecycle ("Needs voice" when undesigned), not a stale preset pill. */
 
 import { describe, it, expect } from 'vitest';
 import { resolveVoiceStatus } from './voice-status';
-import type { Character, Voice } from './types';
+import type { Character, Voice, TtsEngine } from './types';
 
 function char(partial: Partial<Character>): Character {
   return {
@@ -42,88 +44,109 @@ const matchedFrom = {
   confidence: 0.9,
 };
 
-describe('resolveVoiceStatus — lifecycle pill', () => {
+/* Convenience: the caller passes the EFFECTIVE engine (the character's own
+   override folded over the project default). `KOKORO` exercises the preset
+   branch; `QWEN` the bespoke lifecycle. */
+const KOKORO: TtsEngine = 'kokoro';
+const QWEN: TtsEngine = 'qwen';
+
+describe('resolveVoiceStatus — lifecycle pill (preset engine)', () => {
   it('maps preset voiceState values to their lifecycle pills', () => {
-    expect(resolveVoiceStatus(char({ voiceState: 'generated' }), undefined).lifecycle).toEqual({
+    expect(resolveVoiceStatus(char({ voiceState: 'generated' }), undefined, KOKORO).lifecycle).toEqual({
       label: 'Matched',
       color: 'success',
     });
-    expect(resolveVoiceStatus(char({ voiceState: 'tuned' }), undefined).lifecycle).toEqual({
+    expect(resolveVoiceStatus(char({ voiceState: 'tuned' }), undefined, KOKORO).lifecycle).toEqual({
       label: 'Tuned',
       color: 'warning',
     });
-    expect(resolveVoiceStatus(char({ voiceState: 'locked' }), undefined).lifecycle).toEqual({
+    expect(resolveVoiceStatus(char({ voiceState: 'locked' }), undefined, KOKORO).lifecycle).toEqual({
       label: 'Locked',
       color: 'neutral',
     });
   });
 
   it('treats a reused preset voiceState as "Matched" (provenance moves to the badge)', () => {
-    expect(resolveVoiceStatus(char({ voiceState: 'reused' }), undefined).lifecycle).toEqual({
+    expect(resolveVoiceStatus(char({ voiceState: 'reused' }), undefined, KOKORO).lifecycle).toEqual({
       label: 'Matched',
       color: 'success',
     });
   });
 
-  it('returns null lifecycle for a stateless row', () => {
-    expect(resolveVoiceStatus(char({}), undefined).lifecycle).toBeNull();
+  it('returns null lifecycle for a stateless preset row', () => {
+    expect(resolveVoiceStatus(char({}), undefined, KOKORO).lifecycle).toBeNull();
+  });
+});
+
+describe('resolveVoiceStatus — Qwen lifecycle', () => {
+  it('reads "Needs voice" for a Qwen effective engine with no designed voice', () => {
+    expect(resolveVoiceStatus(char({}), undefined, QWEN).lifecycle).toEqual({
+      label: 'Needs voice',
+      color: 'warning',
+    });
   });
 
-  describe('Qwen lifecycle', () => {
-    it('reads "Needs voice" for a Qwen-pinned character with no designed voice', () => {
-      const c = char({ ttsEngine: 'qwen' });
-      expect(resolveVoiceStatus(c, undefined).lifecycle).toEqual({
-        label: 'Needs voice',
-        color: 'warning',
-      });
+  it('reads "Needs voice" for a DEFAULT-engine character on a Qwen project (the Lady Alexine bug)', () => {
+    /* Effective engine is the project default (Qwen) even though the character
+       carries no per-character `ttsEngine`. A stale preset pill ("Matched")
+       from the default voiceState must NOT win here. */
+    const c = char({ voiceState: 'generated' }); // no ttsEngine, no override
+    expect(resolveVoiceStatus(c, undefined, QWEN).lifecycle).toEqual({
+      label: 'Needs voice',
+      color: 'warning',
     });
+  });
 
-    it('reads "Designed" for a designed Qwen voice that has not rendered audio', () => {
-      const c = char({ ttsEngine: 'qwen', overrideTtsVoices: { qwen: { name: 'qwen-x' } } });
-      expect(resolveVoiceStatus(c, voice({ generated: false })).lifecycle).toEqual({
-        label: 'Designed',
-        color: 'library',
-      });
+  it('reads "Designed" for a designed Qwen voice that has not rendered audio', () => {
+    const c = char({ overrideTtsVoices: { qwen: { name: 'qwen-x' } } });
+    expect(resolveVoiceStatus(c, voice({ generated: false }), QWEN).lifecycle).toEqual({
+      label: 'Designed',
+      color: 'library',
     });
+  });
 
-    it('reads "Generated" once the matched voice is flagged generated', () => {
-      const c = char({ ttsEngine: 'qwen', overrideTtsVoices: { qwen: { name: 'qwen-x' } } });
-      expect(resolveVoiceStatus(c, voice({ generated: true })).lifecycle).toEqual({
-        label: 'Generated',
-        color: 'success',
-      });
+  it('reads "Generated" once the matched voice is flagged generated', () => {
+    const c = char({ overrideTtsVoices: { qwen: { name: 'qwen-x' } } });
+    expect(resolveVoiceStatus(c, voice({ generated: true }), QWEN).lifecycle).toEqual({
+      label: 'Generated',
+      color: 'success',
     });
+  });
 
-    it('treats a REUSED voice whose matched Voice is Qwen as a Qwen lifecycle, even when the character is not pinned to Qwen', () => {
-      /* The drawer/table divergence the split fixes: the reuse path leaves
-         the character's own ttsEngine/override empty and carries the Qwen
-         voice on the matched Voice. */
-      const c = char({ voiceState: 'reused', matchedFrom });
-      const v = voice({
-        generated: true,
-        ttsVoice: { provider: 'qwen', name: 'qwen-narrator', description: 'Designed voice' },
-      });
-      expect(resolveVoiceStatus(c, v).lifecycle).toEqual({ label: 'Generated', color: 'success' });
+  it('treats a REUSED voice whose matched Voice is Qwen as a Qwen lifecycle even when the effective engine is a preset', () => {
+    /* The reuse path leaves the character's own ttsEngine/override empty and
+       carries the Qwen voice on the matched Voice — so the Qwen branch must
+       also fire off `voice.ttsVoice.provider`, regardless of project engine. */
+    const c = char({ voiceState: 'reused', matchedFrom });
+    const v = voice({
+      generated: true,
+      ttsVoice: { provider: 'qwen', name: 'qwen-narrator', description: 'Designed voice' },
+    });
+    expect(resolveVoiceStatus(c, v, KOKORO).lifecycle).toEqual({
+      label: 'Generated',
+      color: 'success',
     });
   });
 });
 
 describe('resolveVoiceStatus — Reused badge (provenance)', () => {
   it('is true whenever matchedFrom is set', () => {
-    expect(resolveVoiceStatus(char({ matchedFrom }), undefined).reused).toBe(true);
+    expect(resolveVoiceStatus(char({ matchedFrom }), undefined, KOKORO).reused).toBe(true);
   });
 
   it('survives a later tune/lock (keyed off matchedFrom, not voiceState)', () => {
-    expect(resolveVoiceStatus(char({ voiceState: 'tuned', matchedFrom }), undefined).reused).toBe(
-      true,
-    );
-    expect(resolveVoiceStatus(char({ voiceState: 'locked', matchedFrom }), undefined).reused).toBe(
-      true,
-    );
+    expect(
+      resolveVoiceStatus(char({ voiceState: 'tuned', matchedFrom }), undefined, KOKORO).reused,
+    ).toBe(true);
+    expect(
+      resolveVoiceStatus(char({ voiceState: 'locked', matchedFrom }), undefined, KOKORO).reused,
+    ).toBe(true);
   });
 
   it('is false for a character with no match provenance', () => {
-    expect(resolveVoiceStatus(char({ voiceState: 'generated' }), undefined).reused).toBe(false);
+    expect(resolveVoiceStatus(char({ voiceState: 'generated' }), undefined, KOKORO).reused).toBe(
+      false,
+    );
   });
 
   it('coexists with the lifecycle pill — a reused Qwen voice yields both', () => {
@@ -132,7 +155,7 @@ describe('resolveVoiceStatus — Reused badge (provenance)', () => {
       generated: true,
       ttsVoice: { provider: 'qwen', name: 'qwen-narrator', description: 'Designed voice' },
     });
-    const status = resolveVoiceStatus(c, v);
+    const status = resolveVoiceStatus(c, v, QWEN);
     expect(status.lifecycle).toEqual({ label: 'Generated', color: 'success' });
     expect(status.reused).toBe(true);
   });

--- a/src/lib/voice-status.ts
+++ b/src/lib/voice-status.ts
@@ -3,20 +3,26 @@
    `voiceState`-driven pill collapsed them, so "Reused" hid "Generated"):
 
      1. `lifecycle` — the primary status pill ("tag"): the engine-aware
-        Designed / Generated / Tuned / Locked / Matched state.
+        Designed / Generated / Tuned / Locked / Matched / Needs-voice state.
      2. `reused` — a provenance flag rendered as a small badge beside the
         pill, true whenever this character's voice was matched/reused from a
         prior book in the series.
 
    Consumed by the cast view's Status column (`StatusPill`) and the profile
-   drawer's Voice-profile header so both surfaces agree. The Qwen branch
-   mirrors `resolveDisplayTtsVoice` in `src/views/cast.tsx`: a reused character
-   carries its bespoke Qwen voice on the matched library `Voice`, not on its
-   own `ttsEngine`/`overrideTtsVoices`, so the lifecycle must look at the
-   matched voice too — otherwise a reused Qwen character reads "Matched"
-   instead of "Designed/Generated". */
+   drawer's Voice-profile header so both surfaces agree.
 
-import type { Character, Voice } from './types';
+   The caller passes the character's EFFECTIVE engine — its per-character
+   `ttsEngine` override folded over the project default (cast view) / the live
+   engine-picker choice (drawer). This matters because a DEFAULT-engine
+   character on a Qwen project still synthesises via Qwen, so it follows the
+   bespoke design → generate lifecycle (Needs voice → Designed → Generated),
+   not the preset `voiceState` pill — without the effective engine the resolver
+   can't tell a Qwen project's undesigned character ("Needs voice") from an
+   auto-assigned preset one ("Matched"). The Qwen branch also fires when the
+   matched library `voice` itself resolves to Qwen (a reused character carries
+   its bespoke voice on the matched `Voice`, not its own fields). */
+
+import type { Character, Voice, TtsEngine } from './types';
 
 export type StatusPillColor = 'success' | 'warning' | 'library' | 'neutral';
 
@@ -31,19 +37,15 @@ export interface VoiceStatusBadges {
   reused: boolean;
 }
 
-/* Does this character resolve to a bespoke Qwen voice? Either it's pinned to
-   the Qwen engine per-character, OR it reused a library voice that itself
-   resolves to Qwen (the reuse path leaves `ttsEngine` unset on the character
-   and carries the Qwen voice on the matched Voice). */
-function resolvesToQwen(c: Character, voice: Voice | undefined): boolean {
-  return c.ttsEngine === 'qwen' || voice?.ttsVoice?.provider === 'qwen';
-}
-
 function resolveLifecyclePill(
   c: Character,
   voice: Voice | undefined,
+  effectiveEngine: TtsEngine,
 ): { label: string; color: StatusPillColor } | null {
-  if (resolvesToQwen(c, voice)) {
+  /* Qwen lifecycle when the character synthesises via Qwen (its own override
+     OR the project default — both folded into `effectiveEngine`), OR when the
+     matched library voice itself resolves to Qwen. */
+  if (effectiveEngine === 'qwen' || voice?.ttsVoice?.provider === 'qwen') {
     const hasVoice = !!c.overrideTtsVoices?.qwen?.name || voice?.ttsVoice?.provider === 'qwen';
     if (!hasVoice) return { label: 'Needs voice', color: 'warning' };
     if (voice?.generated) return { label: 'Generated', color: 'success' };
@@ -65,9 +67,13 @@ function resolveLifecyclePill(
   }
 }
 
-export function resolveVoiceStatus(c: Character, voice: Voice | undefined): VoiceStatusBadges {
+export function resolveVoiceStatus(
+  c: Character,
+  voice: Voice | undefined,
+  effectiveEngine: TtsEngine,
+): VoiceStatusBadges {
   return {
-    lifecycle: resolveLifecyclePill(c, voice),
+    lifecycle: resolveLifecyclePill(c, voice, effectiveEngine),
     reused: !!c.matchedFrom,
   };
 }

--- a/src/modals/compare-cast-modal.tsx
+++ b/src/modals/compare-cast-modal.tsx
@@ -381,7 +381,7 @@ function buildSideContext(
      buildCharacterHint(character, draft). */
   const merged = mergeDraft(c, draft);
   const matched = findVoiceForCharacter(c, library);
-  const sampleVoiceId = sampleScopeFor(c, matched);
+  const sampleVoiceId = sampleScopeFor(c);
   const ttsVoice = matched?.ttsVoice ?? resolveTtsVoiceForCharacter(merged, engine);
   const subject: Voice = matched ?? {
     id: sampleVoiceId,

--- a/src/modals/profile-drawer.tsx
+++ b/src/modals/profile-drawer.tsx
@@ -391,7 +391,7 @@ export function ProfileDrawer({
      character-derived stub so brand-new (unmatched) characters can still
      preview their attributes. Server file is namespaced `char-<id>` for
      character samples to keep them separate from library voice samples. */
-  const sampleVoiceId = sampleScopeFor(character, voice);
+  const sampleVoiceId = sampleScopeFor(character);
   /* Recompute against the *edited* identity so the displayed TTS voice
      updates live as the user changes the dropdowns. Saving the drawer
      persists these values; until then the recompute is local-only. */
@@ -686,7 +686,7 @@ export function ProfileDrawer({
                     cast view's Status column so the two surfaces agree (a
                     reused Qwen voice shows "Designed/Generated · Reused"). */}
                 {(() => {
-                  const { lifecycle, reused } = resolveVoiceStatus(character, voice);
+                  const { lifecycle, reused } = resolveVoiceStatus(character, voice, effectiveEngine);
                   return (
                     <>
                       {lifecycle && <Pill color={lifecycle.color}>{lifecycle.label}</Pill>}

--- a/src/views/cast.test.tsx
+++ b/src/views/cast.test.tsx
@@ -462,6 +462,36 @@ describe('CastView Qwen status pill (plan 117)', () => {
     /* No matched voice ⇒ generated unknown ⇒ conservative "Designed". */
     expect(within(row).getByText('Designed')).toBeInTheDocument();
   });
+
+  it('shows "Needs voice" for a DEFAULT-engine character on a Qwen project (not a stale "Matched")', () => {
+    /* The Lady Alexine bug: a character with no per-character `ttsEngine`
+       still synthesises via the project default (Qwen), so an undesigned one
+       must read "Needs voice" — not the preset "Matched" pill its voiceState
+       would otherwise produce. The Status column resolves the effective engine
+       (c.ttsEngine ?? project engine), so flipping the project to Qwen flips
+       the pill. */
+    const store = configureStore({ reducer: { ui: uiSlice.reducer, cast: castSlice.reducer } });
+    store.dispatch(uiSlice.actions.setTtsModelKey('qwen3-tts-0.6b'));
+    /* sweeney: voiceState 'generated', no ttsEngine, no qwen override; empty
+       library ⇒ no matched voice. */
+    render(
+      <Provider store={store}>
+        <CastView
+          characters={[sweeney]}
+          setCharacters={() => {}}
+          library={[]}
+          title="The Northern Star"
+          onOpenProfile={() => {}}
+          onShowMatchDetail={() => {}}
+          driftEvents={[]}
+          onShowDrift={() => {}}
+        />
+      </Provider>,
+    );
+    const row = rowFor('Mr. Sweeney');
+    expect(within(row).getByText('Needs voice')).toBeInTheDocument();
+    expect(within(row).queryByText('Matched')).toBeNull();
+  });
 });
 
 /* Plan 81 wave 3 — responsive layout coverage.

--- a/src/views/cast.tsx
+++ b/src/views/cast.tsx
@@ -134,7 +134,7 @@ export function CastView({
   const effectiveEngineFor = (c: Character): TtsEngine => c.ttsEngine ?? ttsEngine;
 
   async function playSampleFor(c: Character, voice: Voice | undefined) {
-    const sampleVoiceId = sampleScopeFor(c, voice);
+    const sampleVoiceId = sampleScopeFor(c);
     const effectiveEngine = effectiveEngineFor(c);
     const effectiveModelKey = sampleModelKeyForEngine(effectiveEngine, ttsModelKey);
     /* Server appends a hash of (text, voiceName) to the cached filename so
@@ -399,7 +399,7 @@ export function CastView({
             const voice = findVoiceForCharacter(c, library);
             const ttsVoice = resolveDisplayTtsVoice(c, voice, ttsEngine);
             const isDropTarget = dropTargetCharId === c.id;
-            const sampleVoiceId = sampleScopeFor(c, voice);
+            const sampleVoiceId = sampleScopeFor(c);
             const samplePrefix = `/audio/voices/${encodeURIComponent(sampleVoiceId)}-${sampleModelKeyForEngine(
               effectiveEngineFor(c),
               ttsModelKey,
@@ -522,7 +522,7 @@ export function CastView({
                   ))}
                 </span>
                 <span>
-                  <StatusPill c={c} voice={voice} />
+                  <StatusPill c={c} voice={voice} projectEngine={ttsEngine} />
                 </span>
                 <span
                   onClick={(e) => e.stopPropagation()}
@@ -587,7 +587,7 @@ export function CastView({
             const voice = findVoiceForCharacter(c, library);
             const ttsVoice = resolveDisplayTtsVoice(c, voice, ttsEngine);
             const isDropTarget = dropTargetCharId === c.id;
-            const sampleVoiceId = sampleScopeFor(c, voice);
+            const sampleVoiceId = sampleScopeFor(c);
             const samplePrefix = `/audio/voices/${encodeURIComponent(sampleVoiceId)}-${sampleModelKeyForEngine(
               effectiveEngineFor(c),
               ttsModelKey,
@@ -720,7 +720,7 @@ export function CastView({
                 )}
                 <div className="flex items-center justify-between gap-3">
                   <span>
-                    <StatusPill c={c} voice={voice} />
+                    <StatusPill c={c} voice={voice} projectEngine={ttsEngine} />
                   </span>
                   <button
                     type="button"
@@ -959,8 +959,19 @@ function resolveDisplayTtsVoice(
    small Reused badge whenever the voice was matched from a prior book — so a
    reused Qwen voice reads "Generated · Reused" instead of collapsing to a lone
    "Reused" pill. See src/lib/voice-status.ts for the resolution rules. */
-function StatusPill({ c, voice }: { c: Character; voice: Voice | undefined }) {
-  const { lifecycle, reused } = resolveVoiceStatus(c, voice);
+function StatusPill({
+  c,
+  voice,
+  projectEngine,
+}: {
+  c: Character;
+  voice: Voice | undefined;
+  projectEngine: TtsEngine;
+}) {
+  /* Effective engine = the character's own override folded over the project
+     default — so a default-engine character on a Qwen project follows the Qwen
+     lifecycle (e.g. "Needs voice"), not a stale preset `voiceState` pill. */
+  const { lifecycle, reused } = resolveVoiceStatus(c, voice, c.ttsEngine ?? projectEngine);
   if (!lifecycle && !reused) return null;
   return (
     <span className="inline-flex items-center gap-1.5 flex-wrap">

--- a/src/views/manuscript.tsx
+++ b/src/views/manuscript.tsx
@@ -859,7 +859,7 @@ function SidebarPanels({
               onChange={(e) => setChapterFilter(e.target.value)}
               placeholder="Filter chapters…"
               aria-label="Filter chapters"
-              className="w-full rounded-lg border border-ink/10 bg-canvas/40 pl-8 pr-2 py-1.5 text-xs focus:outline-none focus:border-peach"
+              className="w-full rounded-lg border border-ink/10 bg-white pl-8 pr-2 py-1.5 text-xs text-ink placeholder:text-ink/40 focus:outline-none focus:border-peach"
             />
           </label>
         </div>


### PR DESCRIPTION
## Summary

Three frontend bugs reported together (all confirmed against live data / the compiled CSS / the on-disk sample cache).

### 1. Status pill wrong on the default engine
A DEFAULT-engine character on a Qwen project with no designed voice (e.g. *Lady Alexine*) showed its preset `voiceState` pill ("Matched") instead of the Qwen lifecycle **"Needs voice"** — and the drawer's own card ("No voice designed yet") contradicted its badge. `resolveVoiceStatus` didn't know the project engine. It now takes the **effective engine** (`c.ttsEngine ?? projectEngine` in the cast view; the live engine-picker choice in the drawer), so an undesigned Qwen-project character reads "Needs voice" and the card + badge agree.

### 2. Search-box text invisible in dark mode
The merge/link-prior picker and the manuscript chapter-filter used `bg-canvas/40`. `--canvas` has no `--canvas-rgb` channel, so the `/40` alpha can't compile to a valid rule — the input fell back to the UA-default **white** field (invisible light-on-white text in dark mode). Switched both to the canonical themed `bg-white` + explicit `text-ink placeholder:text-ink/40` (which have `[data-theme='dark']` overrides). `bg-white`/`bg-ink/X` search boxes were already fine.

### 3. Designed 12 s preview not reused → double generation
Confirmed from the on-disk cache: a character had samples under **two scopes** (`char-sophie-…-xdp4s8` *and* `sophie-…-xdp4s8` — identical synth, two scopes). `sampleScopeFor` used `voice?.id` first, which flips by play-time for a character with **no `voiceId`** (a freshly-designed Qwen voice): `findVoiceForCharacter` resolves a same-id library entry at play-time but not design-time, so the audition cached under `char-sophie` was re-synthesised under `sophie`. It now keys purely on `character.voiceId ?? char-<id>` (when `voiceId` is set it equals `voice.id` anyway), independent of library state; the `voice` argument is dropped from the signature + all five call sites.

## Test plan

- `src/lib/voice-status.test.ts` — effective-engine resolution incl. "Needs voice" for a default-engine Qwen-project character.
- `src/views/cast.test.tsx` — a default-engine row on a Qwen project shows "Needs voice", not "Matched".
- `src/components/searchable-picker.test.tsx` — the search input uses a themeable background (not `bg-canvas/` opacity) + `text-ink`.
- `src/lib/sample-scope.test.ts` — scope is stable for a voiceId-less character regardless of library state.
- `npm run verify` green end-to-end (lint, typecheck, all unit suites, e2e, **visual**, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)