### PR TITLE
chore(scripts): add series-reuse + sample-cache-scope repair tools

### DIFF
--- a/scripts/repair-sample-cache-scope.mjs
+++ b/scripts/repair-sample-cache-scope.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/* Maintenance tool — voice-sample cache scope migration (one-time / dev-only).
+ *
+ * The voice-sample cache filename is `<scope>-<modelKey>-<hash>.<ext>`, where
+ * `scope = sampleScopeFor(character) = character.voiceId ?? char-<id>` and
+ * `hash` is derived from (text, voiceName). Two changes can move a character's
+ * scope without changing the audio:
+ *   1. The `sampleScopeFor` fix (stop keying on the timing-dependent library
+ *      `voice?.id`) → a voiceId-less character moves `<id>` → `char-<id>`.
+ *   2. The series-reuse backfill (`repair-series-reuse.mjs`) unifies `voiceId`
+ *      → a relinked character moves `char-<id>` / `<id>` → `<voiceId>`.
+ * After either, the player computes the NEW scope and misses the audition that
+ * was cached under the OLD scope → an avoidable re-synthesis.
+ *
+ * This copies (never deletes) each cached file from its old scope to the
+ * character's current `sampleScopeFor` scope, PRESERVING the `-<modelKey>-<hash>`
+ * suffix. SAFETY: the hash encodes (text, voiceName), so a wrong copy simply
+ * never gets hit (hash mismatch) — it can NEVER serve the wrong voice. Worst
+ * case is a harmless orphan file.
+ *
+ * Usage:
+ *   node scripts/repair-sample-cache-scope.mjs            # dry run (no writes)
+ *   node scripts/repair-sample-cache-scope.mjs --apply    # copy files
+ * Env: BASE (default http://localhost:8080), CACHE_DIR (default server/audio/voices).
+ * Requires the dev server running (reads casts via GET /api/books/:id/state).
+ */
+import { readdirSync, copyFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const BASE = process.env.BASE ?? 'http://localhost:8080';
+const CACHE_DIR = process.env.CACHE_DIR ?? resolve('server', 'audio', 'voices');
+const APPLY = process.argv.includes('--apply');
+
+/* Longest-first so e.g. `gemini-2.5-flash` is matched before a bare `gemini`. */
+const MODEL_KEYS = [
+  'qwen3-tts-0.6b',
+  'coqui-xtts-v2',
+  'kokoro-v1',
+  'gemini-3.1-flash',
+  'gemini-2.5-flash',
+  'piper-en-us-medium',
+].sort((a, b) => b.length - a.length);
+
+/** Split `<scope>-<modelKey>[-<hash>].<ext>` → { scope, suffix } (suffix keeps
+ *  modelKey + hash + ext). Returns null for files that don't carry a known
+ *  model key (and for `raw-*` base-voice samples, which aren't char-scoped). */
+function parseFile(name) {
+  if (name.startsWith('raw-')) return null;
+  for (const mk of MODEL_KEYS) {
+    const marker = `-${mk}`;
+    const i = name.indexOf(marker);
+    if (i > 0) return { scope: name.slice(0, i), suffix: name.slice(i + 1) };
+  }
+  return null;
+}
+
+const sampleScopeFor = (c) => c.voiceId ?? `char-${c.id}`;
+
+const lib = await (await fetch(`${BASE}/api/library`)).json();
+const bookIds = lib.authors.flatMap((a) => a.series.flatMap((s) => s.books.map((b) => b.bookId)));
+
+/* scope → set of current scopes any character with that old-scope candidate
+   now resolves to. */
+const remap = new Map();
+const addRemap = (from, to) => {
+  if (from === to) return;
+  if (!remap.has(from)) remap.set(from, new Set());
+  remap.get(from).add(to);
+};
+
+for (const bookId of bookIds) {
+  const st = await (await fetch(`${BASE}/api/books/${encodeURIComponent(bookId)}/state`)).json();
+  for (const c of st.cast?.characters ?? []) {
+    const now = sampleScopeFor(c);
+    for (const cand of new Set([`char-${c.id}`, c.id, c.voiceId].filter(Boolean))) {
+      addRemap(cand, now);
+    }
+  }
+}
+
+const files = existsSync(CACHE_DIR) ? readdirSync(CACHE_DIR) : [];
+const planned = [];
+for (const name of files) {
+  const parsed = parseFile(name);
+  if (!parsed) continue;
+  const targets = remap.get(parsed.scope);
+  if (!targets) continue;
+  for (const ns of targets) {
+    const target = `${ns}-${parsed.suffix}`;
+    if (target === name) continue;
+    if (existsSync(resolve(CACHE_DIR, target))) continue;
+    if (planned.some((p) => p.target === target)) continue;
+    planned.push({ from: name, target });
+  }
+}
+
+console.log(`cache dir: ${CACHE_DIR}`);
+console.log(`files scanned: ${files.length} | planned copies: ${planned.length}\n`);
+for (const p of planned) console.log(`  ${p.from}  →  ${p.target}`);
+
+if (APPLY) {
+  for (const p of planned) copyFileSync(resolve(CACHE_DIR, p.from), resolve(CACHE_DIR, p.target));
+  console.log(`\nCOPIED ${planned.length} file(s).`);
+} else {
+  console.log(`\nDRY RUN (no writes). Re-run with --apply to copy.`);
+}

--- a/scripts/repair-series-reuse.mjs
+++ b/scripts/repair-series-reuse.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/* Maintenance tool — series cross-book reuse backfill (one-time / dev-only).
+ *
+ * Auto "reuse" (the voice-match pipeline) and manual "link" (link-prior) both
+ * stamp `matchedFrom` + a unified `voiceId` on a recurring character so it
+ * reads "Reused" and shares the prior book's designed voice. Characters that
+ * predate those flows (or were linked before `matchedFrom` persisted — see
+ * PR #301) carry no `matchedFrom`, so the Reused badge + merge-picker
+ * "already linked" suppression never fire.
+ *
+ * For each series, this links every character in book N (N>1) that recurs by
+ * name/alias to its EARLIEST-book counterpart: stamps `matchedFrom` + unifies
+ * `voiceId` (+ `voiceState:'reused'` unless tuned/locked), via PUT /state
+ * (slice `cast`) — the same durable end-state a manual link / auto-reuse
+ * produces. Read-only unless `--apply` is passed.
+ *
+ * Skips: characters that already have `matchedFrom`; pairs the user marked
+ * `notLinkedTo`; the unknown-male / unknown-female buckets (per-book, never
+ * reused).
+ *
+ * Usage:
+ *   node scripts/repair-series-reuse.mjs           # dry run (no writes)
+ *   node scripts/repair-series-reuse.mjs --apply   # write cast.json via PUT
+ * Env: BASE (default http://localhost:8080). Requires the dev server running.
+ * Back up first (the casts are mutated): copy each book's cast via
+ * GET /api/books/:id/state before applying.
+ */
+const BASE = process.env.BASE ?? 'http://localhost:8080';
+const APPLY = process.argv.includes('--apply');
+
+const norm = (s) => (s ?? '').trim().toLowerCase();
+const SKIP_IDS = new Set(['unknown-male', 'unknown-female']);
+const surfaceForms = (c) => [c.name, ...(c.aliases ?? [])].map(norm).filter(Boolean);
+
+const lib = await (await fetch(`${BASE}/api/library`)).json();
+
+for (const author of lib.authors) {
+  for (const series of author.series) {
+    const books = [...series.books].sort(
+      (a, b) => (a.seriesPosition ?? 999) - (b.seriesPosition ?? 999),
+    );
+    if (books.length < 2) continue;
+
+    const casts = [];
+    for (const b of books) {
+      const st = await (
+        await fetch(`${BASE}/api/books/${encodeURIComponent(b.bookId)}/state`)
+      ).json();
+      casts.push({ book: b, characters: st.cast?.characters ?? [] });
+    }
+
+    console.log(`\n=== SERIES: ${series.name} (${books.length} books) ===`);
+    const byBook = new Map();
+
+    for (let i = 1; i < casts.length; i += 1) {
+      const { book, characters } = casts[i];
+      for (const c of characters) {
+        if (SKIP_IDS.has(c.id) || c.matchedFrom) continue;
+        const forms = new Set(surfaceForms(c));
+        let origin = null;
+        for (let j = 0; j < i && !origin; j += 1) {
+          const ob = casts[j].book;
+          for (const oc of casts[j].characters) {
+            if (SKIP_IDS.has(oc.id)) continue;
+            const notLinked = (c.notLinkedTo ?? []).some(
+              (p) => p.bookId === ob.bookId && p.characterId === oc.id,
+            );
+            if (notLinked) continue;
+            if (surfaceForms(oc).some((f) => forms.has(f))) {
+              origin = { book: ob, char: oc };
+              break;
+            }
+          }
+        }
+        if (!origin) continue;
+        if (!byBook.has(book.bookId)) byBook.set(book.bookId, { book, links: [] });
+        byBook.get(book.bookId).links.push({
+          charId: c.id,
+          charName: c.name,
+          fromBookId: origin.book.bookId,
+          fromCharId: origin.char.id,
+          fromBookTitle: origin.book.title,
+          voiceId: origin.char.voiceId ?? origin.char.id,
+        });
+      }
+    }
+
+    let total = 0;
+    for (const { book, links } of byBook.values()) {
+      console.log(`  ${book.title}: ${links.length} links`);
+      for (const l of links) {
+        console.log(`    ${l.charName} (${l.charId}) → ${l.fromBookTitle}/${l.fromCharId}  voiceId=${l.voiceId}`);
+      }
+      total += links.length;
+    }
+    console.log(`  TOTAL proposed links in series: ${total}`);
+
+    if (APPLY && total) {
+      for (const { book, links } of byBook.values()) {
+        const cast = casts.find((c) => c.book.bookId === book.bookId);
+        const map = new Map(links.map((l) => [l.charId, l]));
+        const next = cast.characters.map((c) => {
+          const l = map.get(c.id);
+          if (!l) return c;
+          const out = {
+            ...c,
+            voiceId: l.voiceId,
+            matchedFrom: {
+              bookId: l.fromBookId,
+              characterId: l.fromCharId,
+              bookTitle: l.fromBookTitle,
+              confidence: 1,
+            },
+          };
+          if (c.voiceState !== 'locked' && c.voiceState !== 'tuned') out.voiceState = 'reused';
+          return out;
+        });
+        const res = await fetch(`${BASE}/api/books/${encodeURIComponent(book.bookId)}/state`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ slice: 'cast', patch: { characters: next } }),
+        });
+        console.log(`  [apply] ${book.title}: PUT ${res.status}`);
+      }
+    }
+  }
+}
+console.log(APPLY ? '\nAPPLIED.' : '\nDRY RUN (no writes). Re-run with --apply to write.');


### PR DESCRIPTION
## Summary

Adds two dev-only, **dry-run-by-default** maintenance tools (joining the existing `scripts/recover-missing-character.mjs` / `relufs-existing.mjs` convention) used to repair existing workspace data after this session's cast-reuse + sample-scope fixes (PRs #300, #301). Going forward, one-off data-repair scripts are committed here as proper tools rather than throwaway temp files.

- **`scripts/repair-series-reuse.mjs`** — backfills cross-book continuity: links each recurring character in book N>1 to its earliest-book counterpart by name/alias (`matchedFrom` + unified `voiceId` + `voiceState:'reused'`), respecting `notLinkedTo` and skipping the unknown buckets. Produces the same durable end-state a manual link / auto-reuse does, for characters that predate `matchedFrom` persistence. Writes via `PUT /state` (slice `cast`); back up casts first.
- **`scripts/repair-sample-cache-scope.mjs`** — copies cached voice-sample auditions from their old scope to each character's current `sampleScopeFor` scope (`voiceId ?? char-<id>`), preserving the `-<modelKey>-<hash>` suffix, so a "Play 12s" after the scope fix / `voiceId` unification hits instead of re-synthesising. **Non-destructive** (copies only); safe by construction — the hash encodes `(text, voiceName)`, so a mis-scoped copy is a miss, never a wrong-voice hit.

Both read casts via the running dev server (`GET /api/books/:id/state`), default to dry-run, and require `--apply` to write. `BASE` / `CACHE_DIR` env overrides.

Already used this session: 56 series links backfilled (Everblaze/Unlocked/Stellarlune) + 38 cache files migrated.

## Test plan

- Standalone maintenance `.mjs` (operational, not app logic) — lint-clean (`eslint` mjs glob); not type/test-covered, consistent with the sibling repair scripts. Exercised live against the workspace (dry-run reviewed, then `--apply`, then re-run to confirm convergence to 0).
- `npm run verify` green (lint + cached suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)