### PR TITLE
fix(frontend): live-sync listen row time to the player; hide resume pill while playing

### DIFF
--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -115,6 +115,7 @@ When a plan reaches **stable** AND has a filled **Ship notes** section, move it 
 - [34 — MP3-folder export](34-mp3-folder-export.md) — Per-chapter MP3s in a sub-folder for folder-scanning audiobook apps (Smart AudioBook Player, BookPlayer, Audiobookshelf). Sync-folder destination only; APIC cover travels with each chapter.
 - [67 — Streaming-link download tile](archive/67-streaming-link-tile.md) — Mints a 12-char Crockford base32 slug; `GET /share/:slug` proxies the book's most-recent M4B export off disk. Closes the last "Coming soon" tile on the Listen view. Shipped 2026-05-19.
 - [77 — Per-chapter loudness report card](77-loudness-report-card.md) — Consumes plan 71's `<slug>.lufs.json` sidecars and surfaces them in the Listen view as (a) a colour-coded per-row drift pill (≤2 / 2–4 / >4 LU buckets) and (b) an expandable report card with summary line + sparkline + per-chapter table. Drift comparisons gated on `twoPass === true`; single-pass values degrade to neutral.
+- [125 — Listen row mirrors the live playhead](archive/125-listen-row-live-progress.md) — The actively-playing chapter row's elapsed time + waveform now track the real audio (and match the bottom mini-player's total to the second) instead of a decorative animation; the "Resume at" pill is suppressed on the playing row. New ephemeral `livePlayback` slice channel + narrowed `selectLivePlaybackFor` selector so only the playing row re-renders on the ~2 Hz tick. No on-disk change. Shipped 2026-05-28.
 
 ### I. Revisions & drift
 

--- a/docs/features/archive/125-listen-row-live-progress.md
+++ b/docs/features/archive/125-listen-row-live-progress.md
@@ -1,0 +1,64 @@
+---
+status: stable
+shipped: 2026-05-28
+owner: null
+---
+
+# Listen-view chapter row mirrors the live playhead
+
+> Status: stable
+> Key files: `src/store/listen-progress-slice.ts`, `src/components/mini-player.tsx`, `src/components/listen/listen-player-region.tsx`
+> URL surface: `#/books/<id>/listen`
+> OpenAPI ops: none (ephemeral, in-memory only — no on-disk shape change)
+
+Extends [47 — listen-progress](47-listen-progress.md) and
+[53 — mini-player feature pack](53-mini-player-feature-pack.md).
+
+## Benefit / Rationale
+
+- **User:** the actively-playing chapter row's elapsed time + waveform now track the real audio, agreeing with the bottom mini-player to the second. Before, the row ran a decorative animation (`progress += 0.012` every 800 ms) that drifted far from the true playhead — the bug report showed a row reading `0:29 / 00:45` while the player read `0:44 / 0:44`, plus a frozen "Resume at 0:10" pill.
+- **Technical:** completes the intent the slice's `update` reducer already documented ("so the Listen pill's MM:SS stays fresh during continuous playback") via a dedicated ephemeral channel, without churning the persisted resume bookmark or the disk-save cadence.
+- **Architectural:** introduces a narrowed-selector pattern (`selectLivePlaybackFor`) so a ~2 Hz live tick re-renders only the one playing row — preserving the re-render-economy reason the mini-player originally avoided dispatching per-tick.
+
+## Architectural impact
+
+- **New seam:** `ListenProgressState.livePlayback: LivePlayback | null` — a single global ephemeral record (one `<audio>` element plays at a time), with `setLivePlayback` / `clearLivePlayback` actions and the `selectLivePlaybackFor(bookId, chapterId)` selector. **Not persisted** (no redux-persist, no disk write); distinct from the `byBook` resume bookmark.
+- **Invariants preserved:**
+  - The persisted resume bookmark (`byBook[bookId]`) and its disk-save path (debounced PUT, 5 s gate + ≤5 s noise floor in `mini-player.tsx`) are untouched. `listen-progress.json` shape is unchanged (plan 47 invariant).
+  - OpenAPI remains the type source of truth — no contract change (plan 24).
+  - RTK Immer reducers (plan 26) — `setLivePlayback`/`clearLivePlayback` mutate drafts.
+- **Migration story:** none — the field is ephemeral and initialises to `null`.
+- **Reversibility:** revert the three-file diff; nothing on disk or in the API depends on it.
+
+## Invariants to preserve
+
+- `selectLivePlaybackFor` returns the **stored** `livePlayback` reference (not a fresh object) when `bookId` + `chapterId` match, else a stable `null` — `listen-progress-slice.ts`. Returning a fresh object would re-render every chapter row on every unrelated dispatch.
+- The mini-player's live dispatch is throttled by `lastLiveDispatchRef` (≥500 ms), **separate** from `lastSavedAtRef` (the 5 s disk-save gate) — `mini-player.tsx` `onTimeUpdate`. The live tick has **no** ≤5 s noise floor (the row must track from 0:00); the disk save keeps its noise floor.
+- The live dispatch carries `durationSec = totalSec` (`audio.durationSec || parseDuration(chapter.duration)`) — the same resolved total the player renders — so the row matches the player's total exactly while playing.
+- `ChapterListenRow` gates `showResume` on `!isPlaying` — the "Resume at" pill is suppressed on the actively-playing chapter and still shows on other bookmarked, idle rows — `listen-player-region.tsx`.
+- The chapter-mount-effect cleanup dispatches `clearLivePlayback()` so a stale live record can't outlive the audio element.
+
+## Test plan
+
+### Automated coverage
+
+- Vitest unit (`src/store/listen-progress-slice.test.ts`) — `setLivePlayback` stores / replaces; `clearLivePlayback` nulls; `selectLivePlaybackFor` returns the stored reference on match, `null` for other book/chapter/empty/absent-slice; live writes leave `byBook` untouched.
+- Vitest unit (`src/components/mini-player.test.tsx`) — `onTimeUpdate` publishes `livePlayback` with `currentSec` + resolved `durationSec`; throttle skips a second tick within 500 ms and fires past it (mocked `Date.now`); unmount clears the record. Existing plan-47 PUT-cadence assertions stay green (disk path untouched).
+- Vitest unit (`src/components/listen/listen-player-region.test.tsx`) — a playing row shows `formatTime(currentSec) / formatTime(durationSec)` (e.g. `0:44 / 0:44`, matching the player, not the `00:45` metadata); the playing row hides its Resume pill; a bookmarked idle row still shows it.
+- Playwright e2e (`e2e/listen-resume.spec.ts`) — clicking a bookmarked chapter's play button hides its "Resume at" pill (walks click → `currentTrack` redux → row `!isPlaying` gate in a real browser; deterministic because the gate keys on `currentTrack`, not the audio playhead). The three prior resume-pill specs remain green.
+
+### Manual acceptance walkthrough
+
+1. **`#/books/<id>/listen`, click a chapter to play** → the row's elapsed time advances in lock-step with the bottom mini-player; the waveform fills proportionally to real progress; the row total equals the player's total to the second.
+2. **Resume pill** is gone from the actively-playing row, and still shows on any other bookmarked, idle row.
+3. **Scrub via the player** → the row tracks within ~0.5 s.
+4. **Switch chapters** → the previous row reverts to its static metadata duration; the new row live-syncs.
+
+## Out of scope
+
+- Unifying the *idle* (not-playing) row's duration label with the player's PCM-exact value — idle rows keep the canonical `chapter.duration` metadata string (consistent with the book runtime totals). Only the actively-playing row mirrors the player exactly.
+- Share-clip default playhead still centres on the last-saved resume bookmark (`byBook`), not the live tick — unchanged from plan 69.
+
+## Ship notes
+
+Shipped 2026-05-28 on branch `fix/frontend-plan-125`. Three-file change + paired tests across all four affected harnesses (slice unit, mini-player unit, row unit, e2e). No on-disk / OpenAPI change. Replaced the prototype-era decorative row animation (`setInterval` `progress += 0.012`) with a throttled live playhead published from the mini-player via the new ephemeral `livePlayback` slice channel; suppressed the Resume pill on the playing row; matched the playing row's total to the player's resolved duration.

--- a/e2e/listen-resume.spec.ts
+++ b/e2e/listen-resume.spec.ts
@@ -104,4 +104,38 @@ test.describe('listen-progress resume', () => {
     await expect(chapter1).toBeVisible();
     await expect(chapter1.getByText(/Resume at/i)).not.toBeVisible();
   });
+
+  /* Plan 125 — once the bookmarked chapter is actively playing the
+     "Resume at" pill is moot (the live row time covers it), so the row
+     suppresses it. This walks the click → currentTrack (redux) → row
+     `!isPlaying` gate at the browser level; deterministic because the
+     gate keys on currentTrack, not on the audio playhead. */
+  test('hides the Resume pill once the bookmarked chapter starts playing', async ({ page }) => {
+    await page.goto('/#/books/sb/listen');
+    await expect(page.getByRole('heading', { name: /Solway Bay/i, level: 1 })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.evaluate(async () => {
+      const store = (
+        window as unknown as {
+          __store__: { dispatch: (a: unknown) => void };
+        }
+      ).__store__;
+      store.dispatch({
+        type: 'listenProgress/hydrate',
+        payload: {
+          bookId: 'sb',
+          progress: { chapterId: 1, currentSec: 67, updatedAt: new Date().toISOString() },
+        },
+      });
+    });
+
+    const chapter1 = page.getByTestId('chapter-row-1');
+    await expect(chapter1.getByText(/Resume at/i)).toBeVisible({ timeout: 3_000 });
+
+    /* Start playback from this chapter's row → pill vanishes. */
+    await chapter1.getByRole('button', { name: /Play chapter 1/i }).click();
+    await expect(chapter1.getByText(/Resume at/i)).not.toBeVisible();
+  });
 });

--- a/e2e/listen-resume.spec.ts
+++ b/e2e/listen-resume.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { waitForListenViewReady } from './helpers';
 
 /**
  * Browser-level coverage for plan 47 listen-progress.
@@ -112,9 +113,10 @@ test.describe('listen-progress resume', () => {
      gate keys on currentTrack, not on the audio playhead. */
   test('hides the Resume pill once the bookmarked chapter starts playing', async ({ page }) => {
     await page.goto('/#/books/sb/listen');
-    await expect(page.getByRole('heading', { name: /Solway Bay/i, level: 1 })).toBeVisible({
-      timeout: 10_000,
-    });
+    /* Wait for the chapters slice to hydrate (Play-from-start enabled) so
+       the row's play handler is wired before we click — otherwise the
+       click can land pre-hydration and currentTrack never updates. */
+    await waitForListenViewReady(page, /Solway Bay/i);
 
     await page.evaluate(async () => {
       const store = (
@@ -134,8 +136,14 @@ test.describe('listen-progress resume', () => {
     const chapter1 = page.getByTestId('chapter-row-1');
     await expect(chapter1.getByText(/Resume at/i)).toBeVisible({ timeout: 3_000 });
 
-    /* Start playback from this chapter's row → pill vanishes. */
+    /* Start playback from this chapter's row. Assert the button flips to
+       "Pause chapter 1" first — that proves currentTrack propagated and
+       isPlaying is true (the actionable gate, same pattern as
+       listen-playback.spec) — then the pill must be gone. */
     await chapter1.getByRole('button', { name: /Play chapter 1/i }).click();
+    await expect(chapter1.getByRole('button', { name: /Pause chapter 1/i })).toBeVisible({
+      timeout: 5_000,
+    });
     await expect(chapter1.getByText(/Resume at/i)).not.toBeVisible();
   });
 });

--- a/src/components/listen/listen-player-region.test.tsx
+++ b/src/components/listen/listen-player-region.test.tsx
@@ -11,11 +11,11 @@
    mislead the user. */
 
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
 import { ListenPlayerRegion } from './listen-player-region';
-import { listenProgressSlice } from '../../store/listen-progress-slice';
+import { listenProgressSlice, listenProgressActions } from '../../store/listen-progress-slice';
 import type { Chapter, ChapterLoudness } from '../../lib/types';
 
 function makeStore() {
@@ -159,5 +159,84 @@ describe('ListenPlayerRegion — chapter-list virtualisation threshold (plan 93)
   it('switches to the virtualised container at or above the threshold', () => {
     renderRegion(manyChapters(60));
     expect(screen.getByTestId('listen-chapters-virtual-container')).toBeInTheDocument();
+  });
+});
+
+/* Plan 125 — the playing row mirrors the mini-player's real playhead
+   (elapsed + total, matched to the second) instead of a decorative
+   animation, and the "Resume at" pill is suppressed on the actively-
+   playing chapter while still showing on other bookmarked rows. */
+describe('ListenPlayerRegion — live row sync + pill-hidden-while-playing (plan 125)', () => {
+  function renderPlaying(
+    store: ReturnType<typeof makeStore>,
+    chapters: Chapter[],
+    currentTrack: number | null,
+  ) {
+    return render(
+      <Provider store={store}>
+        <ListenPlayerRegion
+          bookId="test-book"
+          chapters={chapters}
+          listenable={chapters.filter((c) => !c.excluded)}
+          characters={[]}
+          currentTrack={currentTrack}
+          onPlayChapter={vi.fn()}
+          onRegenerate={vi.fn()}
+          onSeekMarker={vi.fn()}
+          onDeleteMarker={vi.fn()}
+        />
+      </Provider>,
+    );
+  }
+
+  it('the playing row shows live elapsed / total matching the player to the second', () => {
+    const store = makeStore();
+    /* currentSec 44.4 → formatTime "0:44"; durationSec 44.8 → "0:44" (PCM-
+       exact total the player displays, distinct from the "00:45" metadata). */
+    store.dispatch(
+      listenProgressActions.setLivePlayback({
+        bookId: 'test-book',
+        chapterId: 1,
+        currentSec: 44.4,
+        durationSec: 44.8,
+      }),
+    );
+    renderPlaying(store, [makeChapter(1, { duration: '00:45' })], 1);
+    expect(screen.getByTestId('chapter-row-1')).toHaveTextContent('0:44 / 0:44');
+  });
+
+  it('hides the Resume pill on the actively-playing chapter', () => {
+    const store = makeStore();
+    store.dispatch(
+      listenProgressActions.hydrate({
+        bookId: 'test-book',
+        progress: { chapterId: 1, currentSec: 30, updatedAt: '2026-05-28T00:00:00.000Z' },
+      }),
+    );
+    store.dispatch(
+      listenProgressActions.setLivePlayback({
+        bookId: 'test-book',
+        chapterId: 1,
+        currentSec: 44,
+        durationSec: 45,
+      }),
+    );
+    renderPlaying(store, [makeChapter(1)], 1);
+    const row = screen.getByTestId('chapter-row-1');
+    expect(within(row).queryByText(/Resume at/i)).toBeNull();
+  });
+
+  it('still shows the Resume pill on a bookmarked row that is NOT playing', () => {
+    const store = makeStore();
+    store.dispatch(
+      listenProgressActions.hydrate({
+        bookId: 'test-book',
+        progress: { chapterId: 2, currentSec: 30, updatedAt: '2026-05-28T00:00:00.000Z' },
+      }),
+    );
+    /* Chapter 1 is playing; chapter 2 is bookmarked + idle → pill stays. */
+    renderPlaying(store, [makeChapter(1), makeChapter(2)], 1);
+    const row2 = screen.getByTestId('chapter-row-2');
+    expect(within(row2).getByText(/Resume at/i)).toBeInTheDocument();
   });
 });

--- a/src/components/listen/listen-player-region.tsx
+++ b/src/components/listen/listen-player-region.tsx
@@ -10,7 +10,7 @@
    shell (not on the listen view), so this region only exposes the
    chapter-row triggers + the markers sidebar. */
 
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import {
   IconPlay,
@@ -24,7 +24,11 @@ import { Waveform } from '../waveform';
 import { parseDuration, formatTime } from '../../lib/time';
 import { stripChapterPrefix } from '../../lib/format-chapter-title';
 import { useAppSelector } from '../../store';
-import { selectListenProgress, type ListenMarker } from '../../store/listen-progress-slice';
+import {
+  selectListenProgress,
+  selectLivePlaybackFor,
+  type ListenMarker,
+} from '../../store/listen-progress-slice';
 import { ShareClipModal } from '../../modals/share-clip';
 import { EditChapterTitleModal } from '../../modals/edit-chapter-title';
 import { LoudnessReport, classifyDrift } from '../loudness-report';
@@ -222,20 +226,21 @@ function ChapterListenRow({
   onShareClip,
   onRename,
 }: ChapterListenRowProps) {
-  /* Plan 47 — read the per-book resume bookmark. The pill renders
-     only when it points at THIS chapter and the user got past the
-     first 5 s (same noise-floor as the mini-player's save gate). */
+  /* Plan 47 — read the per-book resume bookmark. The pill renders only
+     when it points at THIS chapter and the user got past the first 5 s
+     (same noise-floor as the mini-player's save gate). Plan 125: suppress
+     it while THIS chapter is actively playing — once you're listening past
+     the bookmark, "Resume at …" is noise (the live row time covers it). */
   const resume = useAppSelector(selectListenProgress(bookId));
-  const showResume = resume?.chapterId === chapter.id && resume.currentSec > 5;
-  const [progress, setProgress] = useState(0);
-  useEffect(() => {
-    if (!isPlaying) return;
-    setProgress(0);
-    const t = setInterval(() => setProgress((p) => (p >= 1 ? p : Math.min(1, p + 0.012))), 800);
-    return () => clearInterval(t);
-  }, [isPlaying]);
-  const totalSec = parseDuration(chapter.duration);
-  const elapsedSec = Math.floor(totalSec * progress);
+  const showResume = !isPlaying && resume?.chapterId === chapter.id && resume.currentSec > 5;
+  /* Plan 125 — mirror the mini-player's real playhead. The narrowed
+     selector returns null for every row except the one actually playing,
+     so only that row re-renders on each ~2 Hz tick. Falls back to the
+     chapter-metadata duration until the first live tick lands. */
+  const live = useAppSelector(selectLivePlaybackFor(bookId, chapter.id));
+  const totalSec = live?.durationSec || parseDuration(chapter.duration);
+  const elapsedSec = live ? Math.min(live.currentSec, totalSec) : 0;
+  const progress = totalSec ? elapsedSec / totalSec : 0;
   return (
     <div
       data-testid={`chapter-row-${chapter.id}`}
@@ -296,7 +301,7 @@ function ChapterListenRow({
           <span className="text-sm tabular-nums text-ink/60 md:text-right flex-1 md:flex-none">
             {isPlaying ? (
               <span className="text-ink font-semibold">
-                {formatTime(elapsedSec)} / {chapter.duration}
+                {formatTime(elapsedSec)} / {formatTime(totalSec)}
               </span>
             ) : (
               chapter.duration

--- a/src/components/mini-player.test.tsx
+++ b/src/components/mini-player.test.tsx
@@ -437,3 +437,111 @@ describe('MiniPlayer — plan 109 duration source of truth', () => {
     expect(container.textContent).toContain('10:00'); // formatTime(600)
   });
 });
+
+describe('MiniPlayer — plan 125 live playhead → Redux', () => {
+  async function fireLoadedMetadata(audioEl: HTMLAudioElement, durationSec: number) {
+    Object.defineProperty(audioEl, 'duration', { configurable: true, value: durationSec });
+    await act(async () => {
+      audioEl.dispatchEvent(new Event('loadedmetadata'));
+    });
+  }
+  async function fireTimeUpdate(audioEl: HTMLAudioElement, currentTimeSec: number) {
+    Object.defineProperty(audioEl, 'currentTime', {
+      configurable: true,
+      writable: true,
+      value: currentTimeSec,
+    });
+    await act(async () => {
+      audioEl.dispatchEvent(new Event('timeupdate'));
+    });
+  }
+
+  it('publishes the live playhead on timeupdate with currentSec + resolved durationSec', async () => {
+    const store = makeStore();
+    const { container } = render(
+      <Provider store={store}>
+        <MiniPlayer
+          chapter={chapter1}
+          bookId="book-1"
+          onClose={noop}
+          onPrev={noop}
+          onNext={noop}
+          prevAvailable={false}
+          nextAvailable={true}
+        />
+      </Provider>,
+    );
+    const audioEl = container.querySelector('audio') as HTMLAudioElement;
+    /* resolveChapter resolves with durationSec: 600 → totalSec = 600. */
+    await resolveChapter(1, '/api/books/book-1/chapters/1/audio.mp3');
+    await fireLoadedMetadata(audioEl, 600);
+    await fireTimeUpdate(audioEl, 42);
+    expect(store.getState().listenProgress.livePlayback).toMatchObject({
+      bookId: 'book-1',
+      chapterId: 1,
+      currentSec: 42,
+      durationSec: 600,
+    });
+  });
+
+  it('throttles repeat ticks to ~2 Hz (skips a second tick within 500 ms)', async () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    try {
+      const store = makeStore();
+      const { container } = render(
+        <Provider store={store}>
+          <MiniPlayer
+            chapter={chapter1}
+            bookId="book-1"
+            onClose={noop}
+            onPrev={noop}
+            onNext={noop}
+            prevAvailable={false}
+            nextAvailable={true}
+          />
+        </Provider>,
+      );
+      const audioEl = container.querySelector('audio') as HTMLAudioElement;
+      await resolveChapter(1, '/api/books/book-1/chapters/1/audio.mp3');
+      await fireLoadedMetadata(audioEl, 600);
+      /* First tick fires (lastLiveDispatchRef starts at 0). */
+      await fireTimeUpdate(audioEl, 10);
+      expect(store.getState().listenProgress.livePlayback?.currentSec).toBe(10);
+      /* Same wall-clock → second tick is throttled, value unchanged. */
+      await fireTimeUpdate(audioEl, 11);
+      expect(store.getState().listenProgress.livePlayback?.currentSec).toBe(10);
+      /* Past the 500 ms window → fires again. */
+      now.mockReturnValue(1_000_600);
+      await fireTimeUpdate(audioEl, 12);
+      expect(store.getState().listenProgress.livePlayback?.currentSec).toBe(12);
+    } finally {
+      now.mockRestore();
+    }
+  });
+
+  it('clears the live playhead on unmount / chapter teardown', async () => {
+    const store = makeStore();
+    const { container, unmount } = render(
+      <Provider store={store}>
+        <MiniPlayer
+          chapter={chapter1}
+          bookId="book-1"
+          onClose={noop}
+          onPrev={noop}
+          onNext={noop}
+          prevAvailable={false}
+          nextAvailable={true}
+        />
+      </Provider>,
+    );
+    const audioEl = container.querySelector('audio') as HTMLAudioElement;
+    await resolveChapter(1, '/api/books/book-1/chapters/1/audio.mp3');
+    await fireLoadedMetadata(audioEl, 600);
+    await fireTimeUpdate(audioEl, 30);
+    expect(store.getState().listenProgress.livePlayback).not.toBeNull();
+    await act(async () => {
+      unmount();
+    });
+    expect(store.getState().listenProgress.livePlayback).toBeNull();
+  });
+});

--- a/src/components/mini-player.tsx
+++ b/src/components/mini-player.tsx
@@ -83,6 +83,10 @@ export function MiniPlayer({
   const pendingSeekRef = useRef<number | null>(null);
   const currentSecRef = useRef(0);
   const lastSavedAtRef = useRef(0);
+  /* Plan 125 — separate, faster throttle for the in-memory live-playhead
+     dispatch (the Listen-view row mirrors it). Independent of the 5 s
+     disk-save gate above: this only churns Redux, never the disk. */
+  const lastLiveDispatchRef = useRef(0);
 
   /* Plan 53 — playback rate + markers + sleep timer.
 
@@ -160,6 +164,10 @@ export function MiniPlayer({
       });
     return () => {
       cancelled = true;
+      /* Plan 125 — drop the live playhead for the chapter we're leaving so
+         a stale entry can't linger past this chapter (or past the player
+         closing). The next chapter's first onTimeUpdate re-publishes. */
+      dispatch(listenProgressActions.clearLivePlayback());
       /* Flush-on-unmount: persist the latest position if the user got
          past the first 5 s. Skipping when <= 5 s avoids polluting the
          resume point with accidental click-and-close noise. */
@@ -650,6 +658,26 @@ export function MiniPlayer({
             const t = e.currentTarget.currentTime;
             setCurrentSec(t);
             currentSecRef.current = t;
+            /* Plan 125 — publish the live playhead (throttled, ~2 Hz) so
+               the Listen-view chapter row mirrors elapsed + waveform
+               instead of running a decorative animation. No noise floor
+               (the row tracks from 0:00) and independent of the disk-save
+               gate below. `totalSec` is the same resolved value the player
+               displays, so the row matches its total to the second. */
+            if (chapter) {
+              const liveNow = Date.now();
+              if (liveNow - lastLiveDispatchRef.current >= 500) {
+                lastLiveDispatchRef.current = liveNow;
+                dispatch(
+                  listenProgressActions.setLivePlayback({
+                    bookId,
+                    chapterId: chapter.id,
+                    currentSec: t,
+                    durationSec: totalSec,
+                  }),
+                );
+              }
+            }
             /* Plan 47 — debounced save. Once per 5 s of wall-clock,
                post the position so a refresh / close / app crash
                loses at most ~5 s of resume accuracy. Don't dispatch

--- a/src/store/listen-progress-slice.test.ts
+++ b/src/store/listen-progress-slice.test.ts
@@ -9,12 +9,14 @@ import {
   listenProgressSlice,
   listenProgressActions,
   selectListenProgress,
+  selectLivePlaybackFor,
   type ListenMarker,
   type ListenProgressRecord,
   type ListenProgressState,
+  type LivePlayback,
 } from './listen-progress-slice';
 
-const empty = (): ListenProgressState => ({ byBook: {}, pendingSeek: null });
+const empty = (): ListenProgressState => ({ byBook: {}, pendingSeek: null, livePlayback: null });
 
 const sample: ListenProgressRecord = {
   chapterId: 3,
@@ -45,6 +47,7 @@ describe('listenProgressSlice — hydrate', () => {
     const start: ListenProgressState = {
       byBook: { b1: sample, b2: { ...sample, chapterId: 5 } },
       pendingSeek: null,
+      livePlayback: null,
     };
     const next = listenProgressSlice.reducer(
       start,
@@ -67,7 +70,11 @@ describe('listenProgressSlice — update', () => {
   });
 
   it('overwrites the prior chapterId / currentSec for the same book', () => {
-    const start: ListenProgressState = { byBook: { b1: sample }, pendingSeek: null };
+    const start: ListenProgressState = {
+      byBook: { b1: sample },
+      pendingSeek: null,
+      livePlayback: null,
+    };
     const next = listenProgressSlice.reducer(
       start,
       listenProgressActions.update({ bookId: 'b1', chapterId: 9, currentSec: 99 }),
@@ -90,7 +97,11 @@ describe('listenProgressSlice — update', () => {
   });
 
   it('leaves entries for other books intact', () => {
-    const start: ListenProgressState = { byBook: { b1: sample }, pendingSeek: null };
+    const start: ListenProgressState = {
+      byBook: { b1: sample },
+      pendingSeek: null,
+      livePlayback: null,
+    };
     const next = listenProgressSlice.reducer(
       start,
       listenProgressActions.update({ bookId: 'b2', chapterId: 1, currentSec: 2 }),
@@ -105,6 +116,7 @@ describe('listenProgressSlice — clear', () => {
     const start: ListenProgressState = {
       byBook: { b1: sample, b2: { ...sample, chapterId: 11 } },
       pendingSeek: null,
+      livePlayback: null,
     };
     const next = listenProgressSlice.reducer(start, listenProgressActions.clear({ bookId: 'b1' }));
     expect(next.byBook.b1).toBeUndefined();
@@ -114,17 +126,17 @@ describe('listenProgressSlice — clear', () => {
 
 describe('selectListenProgress', () => {
   it('returns the record for the given book when present', () => {
-    const state = { listenProgress: { byBook: { b1: sample }, pendingSeek: null } };
+    const state = { listenProgress: { byBook: { b1: sample }, pendingSeek: null, livePlayback: null } };
     expect(selectListenProgress('b1')(state)).toEqual(sample);
   });
 
   it('returns null when the book has no entry', () => {
-    const state = { listenProgress: { byBook: {}, pendingSeek: null } };
+    const state = { listenProgress: { byBook: {}, pendingSeek: null, livePlayback: null } };
     expect(selectListenProgress('b1')(state)).toBeNull();
   });
 
   it('returns null when bookId is null (pre-ready stages have no active book)', () => {
-    const state = { listenProgress: { byBook: { b1: sample }, pendingSeek: null } };
+    const state = { listenProgress: { byBook: { b1: sample }, pendingSeek: null, livePlayback: null } };
     expect(selectListenProgress(null)(state)).toBeNull();
   });
 
@@ -158,7 +170,11 @@ describe('listenProgressSlice — plan 53 playbackRate', () => {
   });
 
   it('setPlaybackRate writes onto an existing record without losing position', () => {
-    const start: ListenProgressState = { byBook: { b1: sample }, pendingSeek: null };
+    const start: ListenProgressState = {
+      byBook: { b1: sample },
+      pendingSeek: null,
+      livePlayback: null,
+    };
     const next = listenProgressSlice.reducer(
       start,
       listenProgressActions.setPlaybackRate({ bookId: 'b1', playbackRate: 1.75 }),
@@ -182,6 +198,7 @@ describe('listenProgressSlice — plan 53 playbackRate', () => {
     const start: ListenProgressState = {
       byBook: { b1: { ...sample, playbackRate: 1.5 } },
       pendingSeek: null,
+      livePlayback: null,
     };
     const next = listenProgressSlice.reducer(
       start,
@@ -195,7 +212,11 @@ describe('listenProgressSlice — plan 53 playbackRate', () => {
 
 describe('listenProgressSlice — plan 53 markers', () => {
   it('addMarker appends to the markers array', () => {
-    const start: ListenProgressState = { byBook: { b1: sample }, pendingSeek: null };
+    const start: ListenProgressState = {
+      byBook: { b1: sample },
+      pendingSeek: null,
+      livePlayback: null,
+    };
     const next = listenProgressSlice.reducer(
       start,
       listenProgressActions.addMarker({ bookId: 'b1', marker: marker() }),
@@ -207,6 +228,7 @@ describe('listenProgressSlice — plan 53 markers', () => {
     const start: ListenProgressState = {
       byBook: { b1: { ...sample, markers: [marker({ id: 'mk_a' })] } },
       pendingSeek: null,
+      livePlayback: null,
     };
     const next = listenProgressSlice.reducer(
       start,
@@ -237,6 +259,7 @@ describe('listenProgressSlice — plan 53 markers', () => {
         },
       },
       pendingSeek: null,
+      livePlayback: null,
     };
     const next = listenProgressSlice.reducer(
       start,
@@ -256,6 +279,7 @@ describe('listenProgressSlice — plan 53 markers', () => {
     const start: ListenProgressState = {
       byBook: { b1: { ...sample, markers: [marker({ id: 'mk_a' })] } },
       pendingSeek: null,
+      livePlayback: null,
     };
     const next = listenProgressSlice.reducer(
       start,
@@ -274,6 +298,7 @@ describe('listenProgressSlice — plan 53 markers', () => {
         b1: { ...sample, markers: [marker({ id: 'mk_a' }), marker({ id: 'mk_b' })] },
       },
       pendingSeek: null,
+      livePlayback: null,
     };
     const next = listenProgressSlice.reducer(
       start,
@@ -286,6 +311,7 @@ describe('listenProgressSlice — plan 53 markers', () => {
     const start: ListenProgressState = {
       byBook: { b1: { ...sample, markers: [marker()] } },
       pendingSeek: null,
+      livePlayback: null,
     };
     const next = listenProgressSlice.reducer(
       start,
@@ -331,5 +357,76 @@ describe('listenProgressSlice — plan 53 pendingSeek (marker-click → mini-pla
       listenProgressActions.consumeSeek({ requestId: id }),
     );
     expect(cleared.pendingSeek).toBeNull();
+  });
+});
+
+describe('listenProgressSlice — plan 125 livePlayback (mini-player → listen row)', () => {
+  const live = (over: Partial<LivePlayback> = {}): LivePlayback => ({
+    bookId: 'b1',
+    chapterId: 3,
+    currentSec: 44.4,
+    durationSec: 44.8,
+    ...over,
+  });
+
+  it('setLivePlayback stores the record', () => {
+    const next = listenProgressSlice.reducer(empty(), listenProgressActions.setLivePlayback(live()));
+    expect(next.livePlayback).toEqual(live());
+  });
+
+  it('setLivePlayback replaces the prior live record each tick', () => {
+    const first = listenProgressSlice.reducer(
+      empty(),
+      listenProgressActions.setLivePlayback(live({ currentSec: 10 })),
+    );
+    const second = listenProgressSlice.reducer(
+      first,
+      listenProgressActions.setLivePlayback(live({ currentSec: 11 })),
+    );
+    expect(second.livePlayback?.currentSec).toBe(11);
+  });
+
+  it('clearLivePlayback nulls the live record', () => {
+    const start: ListenProgressState = { byBook: {}, pendingSeek: null, livePlayback: live() };
+    const next = listenProgressSlice.reducer(start, listenProgressActions.clearLivePlayback());
+    expect(next.livePlayback).toBeNull();
+  });
+
+  it('does not touch the persisted resume bookmark (byBook) — live is ephemeral', () => {
+    const start: ListenProgressState = { byBook: { b1: sample }, pendingSeek: null, livePlayback: null };
+    const next = listenProgressSlice.reducer(start, listenProgressActions.setLivePlayback(live()));
+    expect(next.byBook.b1).toEqual(sample);
+  });
+
+  describe('selectLivePlaybackFor', () => {
+    const state = { listenProgress: { byBook: {}, pendingSeek: null, livePlayback: live() } };
+
+    it('returns the stored record for the matching book + chapter', () => {
+      expect(selectLivePlaybackFor('b1', 3)(state)).toEqual(live());
+    });
+
+    it('returns the SAME reference (stable identity drives single-row re-render)', () => {
+      expect(selectLivePlaybackFor('b1', 3)(state)).toBe(state.listenProgress.livePlayback);
+    });
+
+    it('returns null for a different chapter', () => {
+      expect(selectLivePlaybackFor('b1', 4)(state)).toBeNull();
+    });
+
+    it('returns null for a different book', () => {
+      expect(selectLivePlaybackFor('b2', 3)(state)).toBeNull();
+    });
+
+    it('returns null when nothing is playing', () => {
+      expect(
+        selectLivePlaybackFor('b1', 3)({
+          listenProgress: { byBook: {}, pendingSeek: null, livePlayback: null },
+        }),
+      ).toBeNull();
+    });
+
+    it('returns null defensively when the slice is absent', () => {
+      expect(selectLivePlaybackFor('b1', 3)({})).toBeNull();
+    });
   });
 });

--- a/src/store/listen-progress-slice.ts
+++ b/src/store/listen-progress-slice.ts
@@ -61,14 +61,37 @@ export interface PendingSeek {
   requestId: number;
 }
 
+/* Plan 125 — ephemeral live playhead, published by the mini-player so the
+   Listen view's chapter row can mirror the real audio position (elapsed +
+   waveform) instead of running a decorative animation. Distinct from the
+   persisted resume bookmark (`byBook`): never written to disk, holds the
+   PCM-exact `durationSec` the player displays, and only one chapter plays
+   globally (one <audio> element) so a single record suffices. */
+export interface LivePlayback {
+  bookId: string;
+  chapterId: number;
+  currentSec: number;
+  /* Resolved total the mini-player renders (server PCM-exact durationSec, or
+     parseDuration(chapter.duration) fallback) — lets the row match the
+     player's total to the second. */
+  durationSec: number;
+}
+
 export interface ListenProgressState {
   byBook: Record<string, ListenProgressRecord>;
   /* Plan 53 — one-shot seek request consumed by the mini-player.
      Null between requests. */
   pendingSeek: PendingSeek | null;
+  /* Plan 125 — ephemeral live playhead (see LivePlayback). Null when
+     nothing is playing. */
+  livePlayback: LivePlayback | null;
 }
 
-const initialState: ListenProgressState = { byBook: {}, pendingSeek: null };
+const initialState: ListenProgressState = {
+  byBook: {},
+  pendingSeek: null,
+  livePlayback: null,
+};
 
 /* Default playback rate when the record omits the field (pre-plan-53
    data on disk, or a brand-new book that hasn't picked a rate yet). */
@@ -219,6 +242,18 @@ export const listenProgressSlice = createSlice({
     consumeSeek: (s, a: PayloadAction<{ requestId: number }>) => {
       if (s.pendingSeek?.requestId === a.payload.requestId) s.pendingSeek = null;
     },
+    /* Plan 125 — publish the live playhead from the mini-player's
+       throttled onTimeUpdate. Replaces the whole record each tick (the
+       selector hands the stored reference to the matching row, so only
+       that row re-renders; non-matching rows get a stable null). */
+    setLivePlayback: (s, a: PayloadAction<LivePlayback>) => {
+      s.livePlayback = a.payload;
+    },
+    /* Plan 125 — drop the live playhead on player teardown / chapter
+       switch so a stale entry can't outlive the audio element. */
+    clearLivePlayback: (s) => {
+      s.livePlayback = null;
+    },
   },
 });
 
@@ -244,4 +279,17 @@ export const selectPendingSeek =
     const ps = s.listenProgress?.pendingSeek;
     if (!ps || ps.bookId !== bookId) return null;
     return ps;
+  };
+
+/* Plan 125 — narrowed live-playhead selector. Returns the STORED record
+   reference (stable across unrelated dispatches; changes only when
+   setLivePlayback fires) when it points at this exact book + chapter,
+   else a stable null. The narrowing is what keeps the per-tick re-render
+   confined to the single playing row. */
+export const selectLivePlaybackFor =
+  (bookId: string | null, chapterId: number) =>
+  (s: { listenProgress?: ListenProgressState }): LivePlayback | null => {
+    const lp = s.listenProgress?.livePlayback;
+    if (!bookId || !lp || lp.bookId !== bookId || lp.chapterId !== chapterId) return null;
+    return lp;
   };


### PR DESCRIPTION
## Summary

The actively-playing chapter row in the Listen view drove its elapsed time + waveform from a decorative local animation (`progress += 0.012` every 800 ms) that never read the real audio, so the row drifted from the bottom mini-player. The reported screenshot showed CH 03 reading `0:29 / 00:45` with a frozen "Resume at 0:10" pill while the player read `0:44 / 0:44` — three independent values disagreeing.

This wires the row to the real playhead and tidies the redundant pill:

- **New ephemeral `livePlayback` slice channel** (`setLivePlayback` / `clearLivePlayback` + a narrowed `selectLivePlaybackFor(bookId, chapterId)` selector). It is in-memory only — distinct from the persisted resume bookmark (`byBook`), no on-disk shape change, no OpenAPI change. The selector returns the *stored* record reference so only the one playing row re-renders on each tick.
- **The mini-player publishes the real playhead** at ~2 Hz from `onTimeUpdate` via its own throttle ref (separate from the 5 s disk-save gate, which is untouched), carrying the same resolved `durationSec` it displays, and clears it on chapter teardown.
- **The chapter row** now derives elapsed + waveform + total from the live playhead — matching the bottom player to the second — instead of the animation, and **suppresses the "Resume at" pill while that chapter is actively playing** (still shown on other bookmarked, idle rows). Idle rows keep the canonical `chapter.duration` metadata label.

This completes the behaviour the slice's `update` reducer already documented ("so the Listen pill's MM:SS stays fresh during continuous playback") through a dedicated channel, rather than churning the persisted bookmark.

Regression plan: `docs/features/archive/125-listen-row-live-progress.md` (extends plan 47 / 53); INDEX updated.

## Test plan

- `src/store/listen-progress-slice.test.ts` — `setLivePlayback` stores/replaces, `clearLivePlayback` nulls, `selectLivePlaybackFor` returns the stored reference only on a book+chapter match (null otherwise / absent-slice), and live writes leave `byBook` intact.
- `src/components/mini-player.test.tsx` — `onTimeUpdate` publishes the live record with `currentSec` + resolved `durationSec`; the ~500 ms throttle skips a same-clock second tick and fires past the window (mocked `Date.now`); unmount clears it. Existing plan-47 disk-PUT cadence assertions stay green.
- `src/components/listen/listen-player-region.test.tsx` — a playing row shows `formatTime(currentSec) / formatTime(durationSec)` (matches the player, not the `00:45` metadata) and hides its Resume pill; a bookmarked idle row still shows it.
- `e2e/listen-resume.spec.ts` — clicking a bookmarked chapter's play button hides its Resume pill (walks click → currentTrack redux → row `!isPlaying` gate in a real browser).
- `npm run verify` green locally (lint + typecheck + all unit/integration suites + e2e + visual e2e + build).