### PR TITLE
feat(server,sidecar,frontend): live per-batch generation RTF

### DIFF
--- a/docs/features/127-generation-rtf-telemetry.md
+++ b/docs/features/127-generation-rtf-telemetry.md
@@ -7,7 +7,7 @@ owner: null
 # Generation RTF telemetry
 
 > Status: active
-> Key files: `server/tts-sidecar/main.py` (batch log), `server/src/tts/generation-stats.ts`, `server/src/routes/generation-stats.ts`, `server/src/routes/generation.ts` (rollup), `src/components/worktrees-rtf-pill.tsx`, `src/lib/api.ts`
+> Key files: `server/tts-sidecar/main.py` (batch log + `SynthBatchResult` genMs/audioMs + frame header), `server/src/tts/sidecar.ts` (parse perf header), `server/src/tts/generation-stats.ts` (chapter + live-batch windows), `server/src/routes/generation-stats.ts`, `server/src/routes/generation.ts` (rollup + `onBatchComplete`), `server/src/tts/synthesise-chapter.ts` (`onBatchComplete`), `src/components/worktrees-rtf-pill.tsx`, `src/lib/api.ts`
 > URL surface: `GET /api/generation/stats`; dev-only top-bar pill
 > OpenAPI ops: none (dev/observability endpoint, not part of the public contract)
 
@@ -20,11 +20,16 @@ that actually does generation, target RTF ~1) logged **nothing** — so the only
 RTF in the log was misleadingly slow, and a long in-progress chapter (audio is
 written only at chapter completion) looked stalled when it was fine.
 
-- **User:** can self-monitor generation speed two ways — the server log prints a
-  per-chapter rollup (`rtf`, `Nx realtime`, `chapters/hr`), and the dev top-bar
-  `wt` pill shows a live rolling RTF — without asking an agent to grep logs.
-- **Technical:** the batched forward now emits `qwen batch synth: … rtf=`, so
-  batch throughput is finally observable and comparable to the single-call line.
+- **User:** can self-monitor generation speed without grepping logs. The dev
+  top-bar `wt` pill shows a **live per-batch RTF** that moves every ~batch
+  (updated as each Qwen batch lands) — the figure you can actually act on
+  mid-chapter — falling back to the per-chapter rolling figure when no batch is
+  recent. The server log also prints a per-chapter rollup (`rtf`, `Nx realtime`,
+  `chapters/hr`) as a lagging summary.
+- **Technical:** the batched forward now emits `qwen batch synth: … rtf=` AND
+  reports its `genMs`/`audioMs` in the `/synthesize-batch` frame header, so the
+  server can surface a live per-batch RTF — observable and comparable to the
+  single-call line.
 - **Architectural:** a single module-level throughput accumulator
   (`generation-stats.ts`) is the one source of truth, surfaced over one tiny GET
   endpoint; no new SSE event-type churn, no per-book plumbing.
@@ -61,6 +66,14 @@ written only at chapter completion) looked stalled when it was fine.
 - `getGenerationStats()` returns the all-null idle shape when no chapter is in
   the rolling window (`server/src/tts/generation-stats.ts`) — the pill relies on
   `rtf === null` to render just "wt".
+- The chapter window and the live-batch window are INDEPENDENT: batch fields
+  (`liveBatchRtf` etc.) report while the first chapter is still rendering (chapter
+  window still empty), and idle on their own `BATCH_IDLE_MS` (5 min) — so a
+  chapter-window reset can't blank a live batch readout, and vice versa
+  (`server/src/tts/generation-stats.ts`).
+- `genMs`/`audioMs` are ADDITIVE frame-header keys; an older sidecar that omits
+  them leaves `out.genMs` undefined and `synthBatch` simply skips
+  `onBatchComplete` (`server/src/tts/sidecar.ts`, `synthesise-chapter.ts`).
 
 ## Test plan
 
@@ -68,14 +81,22 @@ written only at chapter completion) looked stalled when it was fine.
 
 - Pytest sidecar (`server/tts-sidecar/tests/test_batch_synthesis.py::test_synthesize_batch_logs_aggregate_rtf`)
   — asserts `synthesize_batch` emits exactly one `qwen batch synth: items=… voices=… text_len=… … rtf=…` line with the right item/voice/text-length counts and a parseable rtf.
-- Vitest server (`server/src/tts/generation-stats.test.ts`) — rolling rtf /
-  xRealtime / chapters-per-hour maths, window reset after the idle gap, idle
-  shape.
+- Pytest sidecar (`…::test_route_header_carries_batch_perf`) — the
+  `/synthesize-batch` frame header carries `genMs`/`audioMs` (additive to
+  `sampleRate`/`lengths`).
+- Vitest server (`server/src/tts/generation-stats.test.ts`) — per-chapter rolling
+  maths + window reset + idle shape, AND the live-batch window (single-batch rtf,
+  multi-batch aggregate + latest, idle past `BATCH_IDLE_MS`, independence from the
+  chapter window).
+- Vitest server (`server/src/tts/synthesise-chapter.test.ts`) — `onBatchComplete`
+  fires once per batch with the sidecar's `genMs`/`audioMs`, and does NOT fire
+  when the sidecar omits them.
 - Vitest server (`server/src/routes/generation-stats.test.ts`) — `GET
   /api/generation/stats` returns the idle shape, then reflects a recorded chapter.
 - Vitest frontend (`src/components/worktrees-rtf-pill.test.tsx`) — idle shows
-  just "wt", generating shows the live RTF, click still navigates, fetch failure
-  degrades to no readout.
+  just "wt"; generating shows the live per-batch RTF; the live per-batch figure
+  is preferred over the per-chapter rollup; falls back to per-chapter when no
+  batch is recent; click still navigates; fetch failure degrades to no readout.
 
 Not adding an e2e spec: the pill is dev-only and the readout is a polled number,
 not a router/redux/layout seam — unit coverage is the right bar here.
@@ -89,14 +110,15 @@ not a router/redux/layout seam — unit coverage is the right bar here.
    items=8 voices=… … rtf=…` lines (the ~1 target), distinct from the slow
    `qwen synth:` audition lines.
 3. **Dev frontend, top bar** → while a book renders, the `wt` pill shows
-   `wt 2.3` (the rolling RTF, magenta); idle → just `wt`. Clicking still opens
-   the worktrees dashboard.
+   `wt 1.1` (the LIVE per-batch RTF, magenta) updating every ~batch; once a
+   chapter completes and no batch is mid-flight it shows the per-chapter figure;
+   idle → just `wt`. Clicking still opens the worktrees dashboard.
 
 ## Out of scope
 
-- Per-sentence / live per-batch RTF over the wire to the pill (the pill polls a
-  rolling per-chapter aggregate, updated as chapters finish — good enough for
-  eyeballing speed; a live per-batch feed would need new SSE plumbing).
+- Per-sentence RTF (single-call `/synthesize` groups, e.g. a Kokoro narrator)
+  feeding the live window — only Qwen batches report `genMs`/`audioMs` today;
+  single calls log their own `rtf=` but don't drive the pill.
 - The bouncing chapter progress counter (active-line pointer vs completed count)
   — owned by a separate change.
 

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -62,7 +62,7 @@ import {
   type ChapterSegment,
 } from '../tts/synthesise-chapter.js';
 import { buildChapterTitleNarration } from '../tts/chapter-title-narration.js';
-import { recordChapterThroughput } from '../tts/generation-stats.js';
+import { recordBatchThroughput, recordChapterThroughput } from '../tts/generation-stats.js';
 import { describeSynthesisError, newCascadeState, recordNonFatal } from './generation-error.js';
 
 export const generationRouter = Router();
@@ -775,6 +775,12 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
           };
           job.lastProgressTick = tick;
           broadcast(job, { type: 'progress', ...tick });
+        },
+        /* Live per-batch RTF (plan 127). Each completed Qwen batch feeds the
+           rolling live-batch window so the dev pill shows throughput that moves
+           mid-chapter, not just the per-chapter rollup below. */
+        onBatchComplete: ({ genMs, audioMs }) => {
+          recordBatchThroughput({ genMs, audioMs });
         },
       });
 

--- a/server/src/tts/generation-stats.test.ts
+++ b/server/src/tts/generation-stats.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   __resetGenerationStatsForTest,
   getGenerationStats,
+  recordBatchThroughput,
   recordChapterThroughput,
 } from './generation-stats.js';
 
@@ -66,5 +67,42 @@ describe('generation-stats accumulator', () => {
     recordChapterThroughput({ chapterId: 3, audioSec: 100, synthMs: 50_000 }, T0);
     expect(getGenerationStats(T0 + 60_000).chapters).toBe(1);
     expect(getGenerationStats(T0 + 11 * 60_000).chapters).toBe(0);
+  });
+});
+
+describe('generation-stats live per-batch window', () => {
+  it('reports liveBatchRtf for a single batch (genMs ÷ audioMs)', () => {
+    // 90 s compute for 30 s of audio → rtf 3.0.
+    const s = recordBatchThroughput({ genMs: 90_000, audioMs: 30_000 }, T0);
+    expect(s.liveBatchRtf).toBeCloseTo(3, 5);
+    expect(s.lastBatchRtf).toBeCloseTo(3, 5);
+    expect(s.batchesInWindow).toBe(1);
+    expect(s.batchUpdatedAt).toBe(new Date(T0).toISOString());
+  });
+
+  it('aggregates recent batches and tracks the latest separately', () => {
+    recordBatchThroughput({ genMs: 90_000, audioMs: 30_000 }, T0); // rtf 3.0
+    const s = recordBatchThroughput({ genMs: 30_000, audioMs: 30_000 }, T0 + 90_000); // rtf 1.0
+    // aggregate: 120 000 ms gen / 60 000 ms audio = 2.0; last batch = 1.0.
+    expect(s.liveBatchRtf).toBeCloseTo(2, 5);
+    expect(s.lastBatchRtf).toBeCloseTo(1, 5);
+    expect(s.batchesInWindow).toBe(2);
+  });
+
+  it('drops the batch readout once no batch is recent (idle past 5 min)', () => {
+    recordBatchThroughput({ genMs: 90_000, audioMs: 30_000 }, T0);
+    expect(getGenerationStats(T0 + 60_000).liveBatchRtf).toBeCloseTo(3, 5);
+    const idle = getGenerationStats(T0 + 6 * 60_000);
+    expect(idle.liveBatchRtf).toBeNull();
+    expect(idle.batchesInWindow).toBe(0);
+    expect(idle.batchUpdatedAt).toBeNull();
+  });
+
+  it('is independent of the chapter window — live while the first chapter is still rendering', () => {
+    // No chapter completed yet (chapters stays 0), but batches are landing.
+    const s = recordBatchThroughput({ genMs: 45_000, audioMs: 30_000 }, T0);
+    expect(s.chapters).toBe(0);
+    expect(s.rtf).toBeNull();
+    expect(s.liveBatchRtf).toBeCloseTo(1.5, 5);
   });
 });

--- a/server/src/tts/generation-stats.ts
+++ b/server/src/tts/generation-stats.ts
@@ -3,19 +3,28 @@
    The sidecar logs a per-batch `rtf` (pure forward compute) and the single
    /synthesize path logs a per-call `rtf`, but neither answers the operator's
    actual question while a long book renders: "how fast is the whole pipeline
-   going right now?" This module folds each finished chapter's audio-seconds vs
-   synth-wall into a ROLLING window so `generation.ts` can log a per-chapter
-   rollup AND a tiny GET endpoint can feed the dev top-bar pill — letting the
-   user self-monitor speed without grepping logs.
+   going right now?" This module tracks two things `generation.ts` feeds it:
 
-   RTF convention matches the sidecar: rtf = synthWall / audio, so < 1 is
-   faster-than-realtime. `xRealtime` is the inverse (audio / synthWall), the
-   "Nx realtime" figure. A run is grouped into one rolling window; a gap longer
-   than RESET_MS (a fresh generation session, or simple idleness) starts a new
-   window so a stat from yesterday never dilutes today's number. */
+     1. PER-CHAPTER rolling window — folds each finished chapter's audio vs
+        synth-wall. A lagging SUMMARY (updates only when a chapter completes,
+        ~tens of minutes apart).
+     2. PER-BATCH live window — each Qwen batch reports its sidecar compute
+        (genMs) + audio (audioMs); we keep the recent few so the dev pill shows
+        a number that moves every ~batch. This is the figure the user can ACT
+        on mid-chapter (the per-chapter rollup is too coarse).
+
+   A tiny GET endpoint exposes both so the user self-monitors speed without
+   grepping logs.
+
+   RTF convention matches the sidecar everywhere: rtf = wall / audio, so < 1 is
+   faster-than-realtime. `xRealtime` is the inverse (audio / wall). The chapter
+   window groups one run; a gap > RESET_MS starts fresh so yesterday's stat
+   never dilutes today's. The batch window is independent — it reports while the
+   FIRST chapter is still rendering (when the chapter window is still empty). */
 
 export interface GenerationStats {
-  /** Rolling window: chapters folded in since the window opened. */
+  // ── per-chapter rolling window (lagging summary) ──────────────────────
+  /** Chapters folded in since the window opened. */
   chapters: number;
   /** Rolling totals over the window. */
   audioSec: number;
@@ -34,15 +43,32 @@ export interface GenerationStats {
     synthSec: number;
     at: string;
   } | null;
-  /** ISO timestamp of the last fold, or null when the window is empty. */
+  /** ISO timestamp of the last chapter fold, or null when the window is empty. */
   updatedAt: string | null;
+
+  // ── per-batch live window (responsive, the actionable number) ─────────
+  /** Aggregate ΣgenMs / ΣaudioMs over the recent-batch window (< 1 = faster
+      than realtime). The headline LIVE figure; null when no batch is recent. */
+  liveBatchRtf: number | null;
+  /** The single most-recent batch's rtf. */
+  lastBatchRtf: number | null;
+  /** How many batches the live window is averaging. */
+  batchesInWindow: number;
+  /** ISO timestamp of the most-recent batch, or null when none is recent. */
+  batchUpdatedAt: string | null;
 }
 
 /* Gap (ms) after the last chapter beyond which the next chapter opens a fresh
-   rolling window. Chapters in a continuous run complete well inside this; a
-   gap this long means the run finished/stalled, so the next chapter is a new
-   session and shouldn't be averaged against the old one. */
+   rolling window. Chapters in a continuous run complete well inside this. */
 const RESET_MS = 10 * 60_000;
+
+/* A batch older than this (no batch in the last N min) means generation is no
+   longer live → the pill drops the readout. Generous vs the ~90 s batch cadence
+   so the number doesn't flicker to null between batches. */
+const BATCH_IDLE_MS = 5 * 60_000;
+/* Cap the live window so `liveBatchRtf` stays "recent" (and memory is bounded)
+   — an aggregate over roughly the last dozen batches. */
+const MAX_BATCHES = 12;
 
 interface WindowState {
   startMs: number;
@@ -53,9 +79,19 @@ interface WindowState {
   updatedAtMs: number;
 }
 
-let state: WindowState | null = null;
+interface BatchRecord {
+  at: number;
+  genMs: number;
+  audioMs: number;
+}
 
-const emptyStats = (): GenerationStats => ({
+let state: WindowState | null = null;
+let batches: BatchRecord[] = [];
+
+const emptyChapter = (): Pick<
+  GenerationStats,
+  'chapters' | 'audioSec' | 'synthSec' | 'rtf' | 'xRealtime' | 'chaptersPerHour' | 'last' | 'updatedAt'
+> => ({
   chapters: 0,
   audioSec: 0,
   synthSec: 0,
@@ -66,7 +102,7 @@ const emptyStats = (): GenerationStats => ({
   updatedAt: null,
 });
 
-const project = (s: WindowState): GenerationStats => {
+const projectChapter = (s: WindowState) => {
   const synthSec = s.synthMs / 1000;
   const windowSec = Math.max((s.updatedAtMs - s.startMs) / 1000, 0);
   return {
@@ -78,6 +114,27 @@ const project = (s: WindowState): GenerationStats => {
     chaptersPerHour: windowSec > 0 ? (s.chapters / windowSec) * 3600 : null,
     last: s.last,
     updatedAt: new Date(s.updatedAtMs).toISOString(),
+  };
+};
+
+const projectBatch = (
+  now: number,
+): Pick<
+  GenerationStats,
+  'liveBatchRtf' | 'lastBatchRtf' | 'batchesInWindow' | 'batchUpdatedAt'
+> => {
+  const recent = batches.filter((b) => now - b.at <= BATCH_IDLE_MS);
+  if (recent.length === 0) {
+    return { liveBatchRtf: null, lastBatchRtf: null, batchesInWindow: 0, batchUpdatedAt: null };
+  }
+  const genMs = recent.reduce((a, b) => a + b.genMs, 0);
+  const audioMs = recent.reduce((a, b) => a + b.audioMs, 0);
+  const latest = recent[recent.length - 1];
+  return {
+    liveBatchRtf: audioMs > 0 ? genMs / audioMs : null,
+    lastBatchRtf: latest.audioMs > 0 ? latest.genMs / latest.audioMs : null,
+    batchesInWindow: recent.length,
+    batchUpdatedAt: new Date(latest.at).toISOString(),
   };
 };
 
@@ -109,7 +166,7 @@ export function recordChapterThroughput(
       last,
       updatedAtMs: now,
     };
-    return project(state);
+    return getGenerationStats(now);
   }
 
   state.chapters += 1;
@@ -117,17 +174,35 @@ export function recordChapterThroughput(
   state.synthMs += input.synthMs;
   state.last = last;
   state.updatedAtMs = now;
-  return project(state);
+  return getGenerationStats(now);
 }
 
-/** Current rolling snapshot. Returns the empty shape (all-null) when no
-    chapter has been recorded yet or the window has gone idle past RESET_MS. */
+/** Fold one completed Qwen batch into the LIVE window and return the updated
+    snapshot. `genMs` is the sidecar's forward-compute wall, `audioMs` the audio
+    the batch produced — so `liveBatchRtf` is genMs ÷ audioMs over recent
+    batches, the responsive figure the pill shows mid-chapter. */
+export function recordBatchThroughput(
+  input: { genMs: number; audioMs: number },
+  now: number = Date.now(),
+): GenerationStats {
+  batches.push({ at: now, genMs: input.genMs, audioMs: input.audioMs });
+  // Bound to recent + capped count so the live aggregate stays current.
+  batches = batches.filter((b) => now - b.at <= BATCH_IDLE_MS).slice(-MAX_BATCHES);
+  return getGenerationStats(now);
+}
+
+/** Current snapshot. Chapter fields go all-null once the chapter window idles
+    past RESET_MS; batch fields go all-null once no batch is within
+    BATCH_IDLE_MS. The two are independent — the batch readout is live while the
+    first chapter is still rendering (chapter window still empty). */
 export function getGenerationStats(now: number = Date.now()): GenerationStats {
-  if (!state || now - state.updatedAtMs > RESET_MS) return emptyStats();
-  return project(state);
+  const chapter =
+    state && now - state.updatedAtMs <= RESET_MS ? projectChapter(state) : emptyChapter();
+  return { ...chapter, ...projectBatch(now) };
 }
 
-/** Test-only: drop the rolling window so cases don't bleed into each other. */
+/** Test-only: drop both windows so cases don't bleed into each other. */
 export function __resetGenerationStatsForTest(): void {
   state = null;
+  batches = [];
 }

--- a/server/src/tts/index.ts
+++ b/server/src/tts/index.ts
@@ -47,6 +47,11 @@ export interface SynthesizeBatchOutput {
   pcms: Buffer[];
   /** Single sample rate shared by the whole batch (one batched forward). */
   sampleRate: number;
+  /** Sidecar's forward-compute wall for this batch, ms. Drives live per-batch
+      RTF telemetry (plan 127). Undefined if the sidecar didn't report it. */
+  genMs?: number;
+  /** Total audio the batch produced, ms (the RTF denominator). */
+  audioMs?: number;
 }
 
 export interface TtsProvider {

--- a/server/src/tts/sidecar.ts
+++ b/server/src/tts/sidecar.ts
@@ -125,7 +125,7 @@ export class SidecarTtsProvider implements TtsProvider {
         throw new Error('Local TTS sidecar returned an empty batch body.');
       }
 
-      const { sampleRate, pcms } = parseBatchFrame(buf);
+      const { sampleRate, pcms, genMs, audioMs } = parseBatchFrame(buf);
       /* Hard invariant — one PCM chunk per requested item. A mismatch means the
          sidecar demux drifted; fail loudly rather than scatter misaligned audio
          back onto the wrong sentences. */
@@ -134,7 +134,7 @@ export class SidecarTtsProvider implements TtsProvider {
           `Local TTS sidecar batch returned ${pcms.length} chunks for ${items.length} items.`,
         );
       }
-      return { pcms, sampleRate };
+      return { pcms, sampleRate, genMs, audioMs };
     } finally {
       releaseGpu();
     }
@@ -198,12 +198,17 @@ async function throwForResponse(response: Response): Promise<never> {
    Split on the FIRST newline only — the JSON header is newline-free, so PCM
    payload bytes that happen to equal 0x0A (a valid 16-bit sample byte) are
    never mis-parsed. */
-function parseBatchFrame(buf: Buffer): { sampleRate: number; pcms: Buffer[] } {
+function parseBatchFrame(buf: Buffer): {
+  sampleRate: number;
+  pcms: Buffer[];
+  genMs?: number;
+  audioMs?: number;
+} {
   const nl = buf.indexOf(0x0a);
   if (nl < 0) {
     throw new Error('Local TTS sidecar batch frame is missing its header terminator.');
   }
-  let header: { sampleRate?: unknown; lengths?: unknown };
+  let header: { sampleRate?: unknown; lengths?: unknown; genMs?: unknown; audioMs?: unknown };
   try {
     header = JSON.parse(buf.subarray(0, nl).toString('utf8'));
   } catch {
@@ -214,6 +219,10 @@ function parseBatchFrame(buf: Buffer): { sampleRate: number; pcms: Buffer[] } {
   if (!Array.isArray(lengths) || !Number.isFinite(sampleRate)) {
     throw new Error('Local TTS sidecar batch frame header is missing sampleRate/lengths.');
   }
+  /* Optional perf fields (plan 127 live per-batch RTF) — older sidecars omit
+     them, so treat a non-finite value as "not reported". */
+  const genMs = Number(header.genMs);
+  const audioMs = Number(header.audioMs);
 
   const pcms: Buffer[] = [];
   let off = nl + 1;
@@ -227,7 +236,12 @@ function parseBatchFrame(buf: Buffer): { sampleRate: number; pcms: Buffer[] } {
         `got ${buf.length - (nl + 1)}).`,
     );
   }
-  return { sampleRate, pcms };
+  return {
+    sampleRate,
+    pcms,
+    genMs: Number.isFinite(genMs) ? genMs : undefined,
+    audioMs: Number.isFinite(audioMs) ? audioMs : undefined,
+  };
 }
 
 function parseRateFromMime(mime: string): number {

--- a/server/src/tts/synthesise-chapter.test.ts
+++ b/server/src/tts/synthesise-chapter.test.ts
@@ -1448,6 +1448,51 @@ describe('synthesiseChapter Qwen true batching (plan 112)', () => {
     }
   });
 
+  it('fires onBatchComplete with the sidecar perf (genMs/audioMs) for live RTF', async () => {
+    const provider: TtsProvider = {
+      async synthesize(input: SynthesizeInput): Promise<SynthesizeOutput> {
+        return { pcm: Buffer.alloc(input.text.length * 2), sampleRate: 24000, mimeType: 'audio/pcm' };
+      },
+      async synthesizeBatch({ items }: SynthesizeBatchInput): Promise<SynthesizeBatchOutput> {
+        return {
+          pcms: items.map((it) => Buffer.alloc(it.text.length * 2)),
+          sampleRate: 24000,
+          genMs: 1234,
+          audioMs: 567,
+        };
+      },
+    };
+    const batches: { batchSize: number; genMs: number; audioMs: number }[] = [];
+    await synthesiseChapter({
+      sentences: MIXED_SENTENCES,
+      cast: QWEN_CAST,
+      provider,
+      modelKey: 'qwen3-tts-0.6b',
+      engine: 'qwen',
+      qwenBatchSize: 8,
+      onBatchComplete: (e) => batches.push(e),
+    });
+    /* groups[1..4] land as ONE batch (groups[0] is the up-front anchor single,
+       which does not fire onBatchComplete). */
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toMatchObject({ batchSize: 4, genMs: 1234, audioMs: 567 });
+  });
+
+  it('does not fire onBatchComplete when the sidecar omits perf fields (older sidecar)', async () => {
+    const provider = makeBatchProvider(); // batch output carries no genMs/audioMs
+    const batches: unknown[] = [];
+    await synthesiseChapter({
+      sentences: MIXED_SENTENCES,
+      cast: QWEN_CAST,
+      provider,
+      modelKey: 'qwen3-tts-0.6b',
+      engine: 'qwen',
+      qwenBatchSize: 8,
+      onBatchComplete: (e) => batches.push(e),
+    });
+    expect(batches).toHaveLength(0);
+  });
+
   it('keeps non-Qwen sentences one-per-call while batching the Qwen ones (mixed-engine chapter)', async () => {
     const cast: CastCharacter[] = [
       { id: 'narrator', name: 'Narrator' }, // default engine (qwen)

--- a/server/src/tts/synthesise-chapter.ts
+++ b/server/src/tts/synthesise-chapter.ts
@@ -189,6 +189,13 @@ export interface SynthesiseChapterOpts {
     backoffMs: number;
     reason: string;
   }) => void;
+  /** Notification on each completed Qwen BATCH (plan 127 live RTF). `genMs` is
+      the sidecar's forward-compute wall for the batch and `audioMs` the audio
+      it produced, so the caller can record a per-batch RTF (genMs ÷ audioMs)
+      and surface a live throughput readout — far more responsive than the
+      per-chapter rollup. Only fires when the sidecar reported the perf fields;
+      single-group (non-batched) work does not fire it. */
+  onBatchComplete?: (e: { batchSize: number; genMs: number; audioMs: number }) => void;
   /** Optional abort signal — checked between groups and forwarded to the
       provider so an in-flight TTS call can be cancelled mid-call. Used by
       the per-bookId server mutex to stop a stale generation handler when a
@@ -326,6 +333,7 @@ export async function synthesiseChapter(
     onGroupStart,
     onGroupComplete,
     onGroupRetry,
+    onBatchComplete,
     signal,
     chapterTitleNarration,
     narratorCharacterId = 'narrator',
@@ -559,7 +567,7 @@ export async function synthesiseChapter(
       const { voiceName } = resolveGroup(g);
       return { text: normaliseForTts(g.text), voiceName };
     });
-    return withHeartbeat(lead, () =>
+    const out = await withHeartbeat(lead, () =>
       withTtsRetry(() => batchFn.call(route.provider, { items, modelKey: route.modelKey, signal }), {
         signal,
         onRetry: (info) =>
@@ -572,6 +580,12 @@ export async function synthesiseChapter(
           }),
       }),
     );
+    /* Live per-batch RTF beacon (plan 127). Only when the sidecar reported its
+       compute timing; a zero/absent audioMs means "not reported", skip. */
+    if (out.genMs != null && out.audioMs != null && out.audioMs > 0) {
+      onBatchComplete?.({ batchSize: batchGroups.length, genMs: out.genMs, audioMs: out.audioMs });
+    }
+    return out;
   }
 
   /* Body dispatch — bounded-concurrency worker pool over WORK ITEMS (plan 107

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -142,12 +142,25 @@ class SynthBatchResult:
     single sample rate the model produced. Qwen-only — `generate_voice_clone`
     runs the N sequences in one batched forward, so the whole batch shares a
     rate. The /synthesize-batch route frames these as a length-prefixed binary
-    body (header line + concatenated PCM)."""
-    __slots__ = ("pcms", "sample_rate")
+    body (header line + concatenated PCM).
 
-    def __init__(self, pcms: list[bytes], sample_rate: int) -> None:
+    gen_ms / audio_ms are the batch's forward-compute wall and the total audio
+    it produced — the server reads them off the frame header to surface a LIVE
+    per-batch RTF (gen_ms ÷ audio_ms) while a chapter renders, instead of only a
+    per-chapter summary."""
+    __slots__ = ("pcms", "sample_rate", "gen_ms", "audio_ms")
+
+    def __init__(
+        self,
+        pcms: list[bytes],
+        sample_rate: int,
+        gen_ms: float = 0.0,
+        audio_ms: float = 0.0,
+    ) -> None:
         self.pcms = pcms
         self.sample_rate = sample_rate
+        self.gen_ms = gen_ms
+        self.audio_ms = audio_ms
 
 
 class Engine:
@@ -1200,7 +1213,9 @@ class QwenEngine(Engine):
             gen_ms, audio_ms, (gen_ms / audio_ms if audio_ms > 0 else 0.0),
         )
         pcms = [_float_audio_to_int16_le(w) for w in wavs]
-        return SynthBatchResult(pcms=pcms, sample_rate=int(sr))
+        return SynthBatchResult(
+            pcms=pcms, sample_rate=int(sr), gen_ms=gen_ms, audio_ms=audio_ms
+        )
 
 
 ENGINES: dict[str, Engine] = {
@@ -1784,8 +1799,16 @@ async def synthesize_batch(req: Request) -> Response:
 
     import json as _json
 
+    # genMs/audioMs ride in the header so the server can surface a LIVE per-batch
+    # RTF (gen_ms ÷ audio_ms) as each batch lands — the per-chapter rollup is too
+    # coarse to act on. Additive keys; older clients ignore them.
     header = _json.dumps(
-        {"sampleRate": result.sample_rate, "lengths": [len(p) for p in result.pcms]},
+        {
+            "sampleRate": result.sample_rate,
+            "lengths": [len(p) for p in result.pcms],
+            "genMs": round(result.gen_ms, 1),
+            "audioMs": round(result.audio_ms, 1),
+        },
         separators=(",", ":"),
     )
     frame = header.encode("utf-8") + b"\n" + b"".join(result.pcms)

--- a/server/tts-sidecar/tests/test_batch_synthesis.py
+++ b/server/tts-sidecar/tests/test_batch_synthesis.py
@@ -410,6 +410,25 @@ def test_route_frames_length_prefixed_binary(qwen_batch_runtime) -> None:
     assert _read_sample(chunks[1], 1) == refs["b"]
 
 
+def test_route_header_carries_batch_perf(qwen_batch_runtime) -> None:
+    """The frame header must carry genMs/audioMs (additive to sampleRate/lengths)
+    so the server can surface a LIVE per-batch RTF as each batch lands — the
+    per-chapter rollup is too coarse to act on."""
+    engine = qwen_batch_runtime["engine"]
+    _design(engine, "a")
+    client = TestClient(main.app)
+    resp = client.post(
+        "/synthesize-batch",
+        json={"engine": "qwen", "model": "0.6b", "items": [{"voice": "a", "text": "Hello there."}]},
+    )
+    assert resp.status_code == 200
+    header, _chunks = _parse_frame(resp.content)
+    assert "genMs" in header and "audioMs" in header
+    assert isinstance(header["genMs"], (int, float)) and header["genMs"] >= 0
+    # The fake wav has samples → non-zero audio duration.
+    assert isinstance(header["audioMs"], (int, float)) and header["audioMs"] > 0
+
+
 def test_route_rejects_non_qwen_engine(qwen_batch_runtime) -> None:
     client = TestClient(main.app)
     resp = client.post(

--- a/src/components/worktrees-rtf-pill.test.tsx
+++ b/src/components/worktrees-rtf-pill.test.tsx
@@ -16,6 +16,10 @@ const idle = {
   chaptersPerHour: null,
   last: null,
   updatedAt: null,
+  liveBatchRtf: null,
+  lastBatchRtf: null,
+  batchesInWindow: 0,
+  batchUpdatedAt: null,
 };
 
 const mockStats = vi.mocked(api.getGenerationStats);
@@ -31,7 +35,22 @@ describe('WorktreesRtfPill', () => {
     expect(screen.getByTestId('topbar-worktrees-link')).toHaveTextContent('wt');
   });
 
-  it('renders the live RTF value while generating', async () => {
+  it('renders the live per-batch RTF while generating', async () => {
+    mockStats.mockResolvedValue({ ...idle, liveBatchRtf: 1.12, batchesInWindow: 5 });
+    render(<WorktreesRtfPill onClick={() => {}} active={false} pollMs={10_000} />);
+    const readout = await screen.findByTestId('topbar-rtf');
+    expect(readout).toHaveTextContent('1.12');
+  });
+
+  it('prefers the live per-batch RTF over the per-chapter rollup', async () => {
+    // Both present mid-chapter — the responsive batch figure wins.
+    mockStats.mockResolvedValue({ ...idle, rtf: 2.34, liveBatchRtf: 1.12, batchesInWindow: 5 });
+    render(<WorktreesRtfPill onClick={() => {}} active={false} pollMs={10_000} />);
+    const readout = await screen.findByTestId('topbar-rtf');
+    expect(readout).toHaveTextContent('1.12');
+  });
+
+  it('falls back to the per-chapter RTF when no batch is recent', async () => {
     mockStats.mockResolvedValue({ ...idle, chapters: 3, rtf: 2.34, xRealtime: 0.43 });
     render(<WorktreesRtfPill onClick={() => {}} active={false} pollMs={10_000} />);
     const readout = await screen.findByTestId('topbar-rtf');

--- a/src/components/worktrees-rtf-pill.tsx
+++ b/src/components/worktrees-rtf-pill.tsx
@@ -13,24 +13,34 @@ const DEFAULT_POLL_MS = 4000;
 
 /* Dev-only top-bar pill. Serves two purposes now: it's still the plan-86
    worktrees-dashboard link, AND a live generation-RTF readout. While a book
-   renders it shows the rolling synth-wall ÷ audio figure from
-   GET /api/generation/stats, so the user can eyeball generation speed without
-   grepping logs. Idle (nothing generating) → it's just the "wt" link.
+   renders it shows the LIVE per-batch RTF from GET /api/generation/stats
+   (`liveBatchRtf`, updated as each Qwen batch lands ~every batch), falling back
+   to the per-chapter rolling figure (`rtf`) when no batch is recent — so the
+   number moves mid-chapter, not just at chapter boundaries. Idle (nothing
+   generating) → it's just the "wt" link.
 
-   RTF convention matches the sidecar logs: synth-wall ÷ audio, so < 1 is
+   RTF convention matches the sidecar logs: wall ÷ audio, so < 1 is
    faster-than-realtime. Only mounted in DEV builds (see top-bar.tsx), so the
    4 s poll never runs in production. */
 export function WorktreesRtfPill({ onClick, active, pollMs = DEFAULT_POLL_MS }: Props) {
   const [rtf, setRtf] = useState<number | null>(null);
+  const [live, setLive] = useState(false);
 
   useEffect(() => {
     let alive = true;
     const tick = async () => {
       try {
         const stats = await api.getGenerationStats();
-        if (alive) setRtf(stats.rtf);
+        if (!alive) return;
+        // Prefer the live per-batch figure; fall back to the per-chapter rollup.
+        const next = stats.liveBatchRtf ?? stats.rtf;
+        setRtf(next);
+        setLive(stats.liveBatchRtf != null);
       } catch {
-        if (alive) setRtf(null);
+        if (alive) {
+          setRtf(null);
+          setLive(false);
+        }
       }
     };
     void tick();
@@ -43,7 +53,7 @@ export function WorktreesRtfPill({ onClick, active, pollMs = DEFAULT_POLL_MS }: 
 
   const generating = rtf != null;
   const label = generating
-    ? `Worktrees (dev) · live generation RTF ${rtf.toFixed(2)} — synth-wall ÷ audio (<1 = faster than realtime)`
+    ? `Worktrees (dev) · ${live ? 'live per-batch' : 'per-chapter'} generation RTF ${rtf.toFixed(2)} — wall ÷ audio (<1 = faster than realtime)`
     : 'Worktrees (dev)';
 
   return (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4313,6 +4313,10 @@ const mock = {
     chaptersPerHour: null,
     last: null,
     updatedAt: null,
+    liveBatchRtf: null,
+    lastBatchRtf: null,
+    batchesInWindow: 0,
+    batchUpdatedAt: null,
   }),
 };
 
@@ -4335,6 +4339,13 @@ export interface GenerationStatsResponse {
     at: string;
   } | null;
   updatedAt: string | null;
+  /** Aggregate rtf over the recent-batch window — the LIVE figure that moves
+      mid-chapter (< 1 = faster than realtime). null when no batch is recent. */
+  liveBatchRtf: number | null;
+  /** The single most-recent batch's rtf. */
+  lastBatchRtf: number | null;
+  batchesInWindow: number;
+  batchUpdatedAt: string | null;
 }
 
 export const api = USE_MOCKS ? mock : real;


### PR DESCRIPTION
## Summary

Follow-up to the RTF telemetry (plan 127). Per-chapter RTF only updates when a chapter completes (~tens of minutes apart) — too coarse to act on mid-render. This adds a LIVE per-batch RTF that moves as each Qwen batch lands, surfaced in the dev `wt` pill.

- **Sidecar**: `SynthBatchResult` carries the batch's `gen_ms`/`audio_ms` (already computed for the log line), and `/synthesize-batch` reports them in the frame header (additive keys; older clients ignore them).
- **Server**: `sidecar.ts` parses the header into `SynthesizeBatchOutput.genMs/audioMs`; `synthesiseChapter` fires a new `onBatchComplete({ batchSize, genMs, audioMs })` per batch; `generation.ts` feeds it to `recordBatchThroughput`. `generation-stats.ts` gains an independent rolling live-batch window (`liveBatchRtf` = ΣgenMs ÷ ΣaudioMs over the recent ~dozen batches, idle past 5 min), exposed on `GET /api/generation/stats`. It's independent of the per-chapter window, so it reports while the FIRST chapter is still rendering.
- **Frontend**: the `wt` pill prefers `liveBatchRtf` (updates ~every batch) and falls back to the per-chapter `rtf` when no batch is recent.

## Test plan

- [x] Pytest sidecar — `/synthesize-batch` frame header carries `genMs`/`audioMs`.
- [x] Vitest server — live-batch window maths (single / aggregate+latest / idle / independence from chapter window); `onBatchComplete` fires-with-perf / skips-without; route reflects a recorded chapter.
- [x] Vitest frontend — pill prefers live per-batch, falls back to per-chapter, idle shows just "wt", click navigates, fetch failure degrades.
- [x] Full battery green across runs (typecheck + frontend + server + server-slow [isolated] + e2e 115 + build). One pre-push failure was the known tinypool "Worker exited unexpectedly" flake (passes 155/155 in isolation).

Regression plan: `docs/features/127-generation-rtf-telemetry.md` (updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)