### PR TITLE
fix(sidecar): single-flight Qwen cold-load to stop dtype-corruption race

### DIFF
--- a/docs/features/113-qwen-true-batching.md
+++ b/docs/features/113-qwen-true-batching.md
@@ -32,6 +32,7 @@ owner: null
 - The dispatch partition in `synthesiseChapter` (`server/src/tts/synthesise-chapter.ts`) only batches a group when `route.engine === 'qwen'` AND the resolved provider exposes `synthesizeBatch`; the up-front anchor group is always a single call; each batched chunk is scattered to its OWN `results[group.index]` slot.
 - `_load_voice_prompt` returns `(prompt, lang, cache_hit)` and is shared by `synthesize` + `synthesize_batch` so they can't drift (and the batch path inherits the plan-112 prompt cache).
 - `synthesize` / `synthesize_batch` / `design_voice` run `generate_voice_clone` (and the design forwards) under the per-engine `_synth_lock` (`server/tts-sidecar/main.py`). The Base forward is **not thread-safe**, so this serialises same-engine GPU forwards; a concurrent Kokoro synth still runs in parallel (separate engine instance + lock). See the concurrency-safety fix below.
+- `_ensure_base_loaded` single-flights the COLD load under `_base_load_lock` (a `threading.Lock`, double-checked) (`server/tts-sidecar/main.py`). It runs on `asyncio.to_thread` worker threads (both the synth path and `/load` offload it), so two workers that both observe a cold `_base` on the first synth after a restart must NOT both `from_pretrained` — the racing loads leave the model half-cast (`float != BFloat16` on every later forward). The asyncio `_load_lock` only serialises concurrent `/load` HTTP calls, NOT the synth-path lazy load, so the threading lock is the actual guarantee.
 
 ## Test plan
 
@@ -42,6 +43,7 @@ owner: null
 - Vitest server (`server/src/tts/sidecar.test.ts`) — the shared error-classification helpers are exercised through `synthesize`; `synthesizeBatch` reuses them unchanged.
 - Vitest frontend (`src/views/generation.test.tsx`) — the "Worker has gone quiet" banner copy now sets the batched-synthesis expectation.
 - `test_synthesize_batch_serialises_concurrent_forwards` — two concurrent batches of DIFFERENT sizes must not overlap inside the model forward (regression for the `8 vs 7` race). Instruments the fake forward to flag concurrent entry; fails without `_synth_lock` (`max_concurrent=2`), passes with it.
+- `test_ensure_base_loaded_single_flights_concurrent_cold_loads` — 8 threads released by a barrier call `_ensure_base_loaded` against a cold `_base` with a slow counting loader; must load **exactly once**. Fails without `_base_load_lock` (`8 concurrent loads` → the `float != BFloat16` dtype-corruption race that 500'd every batch after a restart), passes with it.
 
 ### Manual acceptance walkthrough (real GPU — replaces the deferred spike)
 

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -738,6 +738,16 @@ class QwenEngine(Engine):
         # engine instance, separate lock). Batching — not concurrency — is the
         # throughput lever on a single autoregressive model anyway.
         self._synth_lock = threading.Lock()
+        # Serialises the COLD model load. `_ensure_base_loaded` runs on
+        # asyncio.to_thread worker threads (both the synth path and the /load
+        # route offload it there), so a plain threading.Lock — NOT the asyncio
+        # `_load_lock` above, which a worker thread can't acquire — is what makes
+        # the load single-flight. Without it, two workers that both observe
+        # `_base is None` on a cold start each call `from_pretrained` +
+        # `.to(device)`, and the racing loads leave the model in a half-cast
+        # dtype state → every later forward dies with "expected mat1 and mat2 to
+        # have the same dtype, float != BFloat16". Double-checked inside.
+        self._base_load_lock = threading.Lock()
         # Monotonic timestamp of the last voice-design activity. The startup
         # idle watchdog frees the heavy transient VoiceDesign model once this
         # goes stale (QWEN_DESIGN_IDLE_TTL), so a cast-review session's rapid
@@ -832,10 +842,18 @@ class QwenEngine(Engine):
         return model
 
     def _ensure_base_loaded(self) -> None:
-        if self._base is None:
-            log.info("Loading Qwen Base model=%s on %s …", self.BASE_MODEL, self._device)
-            self._base = self._load_qwen_model(self.BASE_MODEL)
-            log.info("Qwen Base loaded.")
+        # Fast path: already loaded, no lock needed (the assignment below is the
+        # only writer and it publishes a fully-built model).
+        if self._base is not None:
+            return
+        # Single-flight the cold load — see `_base_load_lock`. Double-checked so
+        # the loser of the race returns the winner's model instead of loading a
+        # second copy (which would corrupt the dtype state).
+        with self._base_load_lock:
+            if self._base is None:
+                log.info("Loading Qwen Base model=%s on %s …", self.BASE_MODEL, self._device)
+                self._base = self._load_qwen_model(self.BASE_MODEL)
+                log.info("Qwen Base loaded.")
 
     def _ensure_design_loaded(self) -> None:
         if self._design is None:

--- a/server/tts-sidecar/tests/test_batch_synthesis.py
+++ b/server/tts-sidecar/tests/test_batch_synthesis.py
@@ -554,3 +554,48 @@ def test_synthesize_batch_serialises_concurrent_forwards(qwen_batch_runtime, mon
         f"Base forwards overlapped (max_concurrent={state['max_concurrent']}) — "
         "_synth_lock is not serialising same-engine synthesis"
     )
+
+
+def test_ensure_base_loaded_single_flights_concurrent_cold_loads(
+    qwen_batch_runtime, monkeypatch
+) -> None:
+    """Regression (sidecar-qwen-cold-load-race): `_ensure_base_loaded` ran
+    UNLOCKED, so two synth workers that both observed a cold `_base` on the first
+    synth after a sidecar restart each loaded the Base model. The racing loads
+    left the model in a half-cast dtype state and every later forward died with
+    "expected mat1 and mat2 to have the same dtype, float != BFloat16" (199 such
+    500s in the wild). The threading lock + double-check must collapse N racing
+    callers to exactly ONE load."""
+    import threading
+    import time
+
+    engine = qwen_batch_runtime["engine"]
+    engine._base = None
+
+    load_count = 0
+    count_guard = threading.Lock()
+
+    def slow_load(model_id):
+        nonlocal load_count
+        with count_guard:
+            load_count += 1
+        time.sleep(0.05)  # widen the race window so a missing lock double-loads
+        return object()  # stand-in model
+
+    monkeypatch.setattr(engine, "_load_qwen_model", slow_load)
+
+    # Release all callers at once for maximal contention on the cold check.
+    barrier = threading.Barrier(8)
+
+    def call():
+        barrier.wait()
+        engine._ensure_base_loaded()
+
+    threads = [threading.Thread(target=call) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert load_count == 1, f"cold load raced: {load_count} concurrent loads (want 1)"
+    assert engine._base is not None


### PR DESCRIPTION
## Summary

`QwenEngine._ensure_base_loaded` ran **unlocked**. With `generationWorkers=2` (or within-chapter parallelism), the first synth after a sidecar restart fires from two worker threads at once; both see `_base is None` and both call `from_pretrained` + `.to(device)`. The racing loads leave the model half-cast, so every later forward dies with `expected mat1 and mat2 to have the same dtype, float != BFloat16` — 500ing every batch.

Evidence it's the cold-load race (not the telemetry change): 199 such 500s in the log since **2026-05-26** (two days before the telemetry work), traceback entirely inside `qwen_tts`'s `q_proj` forward, and two `Loading Qwen Base` lines at the **same timestamp** (14:41:55) on the failing restart.

The asyncio `_load_lock` only serialises concurrent `/load` HTTP calls — it can't be acquired from the `asyncio.to_thread` worker threads where the synth-path lazy load runs. Fix: a `threading.Lock` (`_base_load_lock`) + double-check inside `_ensure_base_loaded`, so N racing callers collapse to exactly ONE load and the losers return the winner's model. Bonus: every other worker now blocks on the lock until the model is ready — "pause until ready", in code.

## Test plan

- [x] `test_ensure_base_loaded_single_flights_concurrent_cold_loads` — 8 barrier-released threads against a cold `_base` with a slow counting loader must load exactly once. **Fails before** the fix (8 concurrent loads), **passes after** (verified by reverting).
- [x] Full `npm run verify` green (sidecar pytest runs via the dev-box venv; worktree verify skips it as venv-gated, so the test was run manually against the bootstrapped venv).

Regression plan: `docs/features/113-qwen-true-batching.md` (invariant + test added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)