### PR TITLE
fix(frontend): keep the default-engine TTS pill reachable without an open book

### DIFF
--- a/docs/features/30-global-model-control.md
+++ b/docs/features/30-global-model-control.md
@@ -42,6 +42,11 @@ The pill renders only on book-context stages (`analysing` / `confirm` /
 `ready`) — Books and Upload stages skip it since TTS isn't meaningful
 without a manuscript.
 
+> **Amended 2026-05-29** — see "Shipped: default-engine pill reachable
+> without a book" below. The book-context gate now applies only to the
+> _per-character_ pills (e.g. a Qwen-pinned cast member); the
+> _default/primary_ engine pill is reachable on every view.
+
 ## Shipped in G1 (single poll, consolidated state)
 
 Plan-30 v1 ran two `useTtsLifecycle` instances in parallel — Layout's
@@ -64,6 +69,43 @@ and the banner is shared.
 mounted outside a Layout (e.g. the cross-book title regression test in
 `src/routes/index.test.tsx`). Real call sites always come through
 Layout, so the fallback is never user-reachable.
+
+## Shipped: default-engine pill reachable without a book (2026-05-29)
+
+The original v1 gate (`showGlobalTtsPill` → `analysing | confirm | ready`)
+hid the entire TTS pill cluster on book-less views, so the Status popover's
+**TTS engines** section showed a dead-end *"TTS controls appear once a
+manuscript is open."* A user who wanted to pre-load the default TTS model
+right after launch — before opening any book — had no Load button to click.
+
+The gate is now split in `src/components/layout.tsx`:
+
+- The **default/primary engine** (derived from `account.defaultTtsModelKey`
+  via the new `selectDefaultTtsEngine` selector in
+  `src/store/engines-in-use-selector.ts`) is **always** in the
+  `enginesToShow` set — its Load/Stop pill is reachable on every view,
+  with or without a book open. Gemini contributes no pill (cloud, no VRAM
+  to free), so a Gemini default leaves the cluster empty and the fallback
+  text remains.
+- The **per-character additions** from `selectEnginesInUse` (e.g. a Qwen
+  pill surfaced because a cast member is pinned to Qwen) are unioned in
+  **only** when a book is open (`showGlobalTtsPill`), exactly as before —
+  they depend on a loaded book's cast and make no sense globally.
+
+`showTtsControls = enginesToShow.size > 0` now gates the pill cluster, the
+Status-pill visibility (so the popover is reachable on book-less views),
+and the `TtsNoticeBanner` (so a Load error / analyzer-eviction triggered
+from a book-less view still surfaces).
+
+This does **not** violate the button-driven invariant below: nothing
+auto-loads — the user still clicks Load. It only makes that Load button
+reachable earlier.
+
+Tests: `src/store/engines-in-use-selector.test.ts`
+(`selectDefaultTtsEngine` mapping cases), `src/components/layout.test.tsx`
+(default Kokoro pill renders on the Books view; per-character Qwen pill
+stays gated), and `e2e/default-tts-pill-no-book.spec.ts` (browser golden
+path: Status popover on the library view surfaces the Kokoro control).
 
 ## When to extend the pattern
 
@@ -107,8 +149,12 @@ parallel state to keep in sync.
    `playSampleWithAutoLoad` fires its own warm; once complete, both
    pills flip to "ready" on their next poll. The top-bar pill is
    additive UX, not a precondition for sample playback.
-5. **Stages without book context**: navigate to `/books` → top-bar pill
-   disappears (no manuscript = no TTS need). Open a book → reappears.
+5. **Stages without book context**: navigate to `/books` → the
+   **default-engine** pill (e.g. Kokoro) stays reachable via the Status
+   popover so the model can be pre-loaded before opening a book. Only the
+   per-character pills (e.g. a Qwen pill from a pinned cast member)
+   disappear; they reappear once a book whose cast uses them is open. (A
+   Gemini default shows no pill at all — cloud engine, nothing to load.)
 
 ## Out of scope (don't smuggle into a B4 follow-up)
 

--- a/e2e/default-tts-pill-no-book.spec.ts
+++ b/e2e/default-tts-pill-no-book.spec.ts
@@ -1,0 +1,45 @@
+/* Browser-level golden path for the default-engine TTS control being
+ * reachable WITHOUT an open book.
+ *
+ * Runs against Vite in mock mode (`.env.e2e`) where the mock api keeps
+ * Kokoro (the account default per FRONTEND_ACCOUNT_DEFAULTS) pre-loaded at
+ * startup. The user lands on the Books/library view (no book open) — the
+ * Status pill must now render there (because a default TTS control is
+ * available), and opening its popover must surface the Kokoro Load/Stop
+ * control instead of the old "TTS controls appear once a manuscript is open"
+ * dead-end text. This lets the user pre-load the model right after launch.
+ *
+ * Pairs with docs/features/14a-model-control-pill.md (default-engine pill
+ * reachable on book-less views) and crosses the redux/layout/popover seam
+ * Vitest+jsdom can't fully exercise (the Status pill's render gate +
+ * popover open + per-engine pill render). */
+
+import { test, expect } from '@playwright/test';
+import { waitForLibraryViewReady } from './helpers';
+
+test.describe('Default-engine TTS pill — reachable on the Books view (no book open)', () => {
+  test('surfaces the Kokoro control in the Status popover before any book is opened', async ({
+    page,
+  }) => {
+    /* Cold boot lands on the library view — no book in scope. */
+    await page.goto('/');
+    await waitForLibraryViewReady(page);
+
+    /* The Status pill now renders even with no book open, because the default
+       engine's control is available. Open its popover (clicking pins it). */
+    await page.getByTestId('status-pill').click();
+    await expect(page.getByTestId('status-popover')).toBeVisible({ timeout: 5_000 });
+
+    /* The Kokoro control is reachable — mock keeps it pre-loaded, so it reads
+       "Kokoro ready" with a Stop button. */
+    await expect(page.getByText(/Kokoro ready/i).first()).toBeVisible({ timeout: 5_000 });
+    await expect(
+      page.getByRole('button', { name: /^stop \(tts model\)$/i }).first(),
+    ).toBeVisible();
+
+    /* The dead-end fallback must be gone. */
+    await expect(
+      page.getByText(/TTS controls appear once a manuscript is open/i),
+    ).toHaveCount(0);
+  });
+});

--- a/src/components/layout.test.tsx
+++ b/src/components/layout.test.tsx
@@ -518,6 +518,64 @@ describe('Layout — global TTS pills: per-character Qwen (plan 108)', () => {
   });
 });
 
+describe('Layout — default-engine TTS pill reachable without an open book', () => {
+  /* The default/primary engine's Load/Stop pill must be reachable on book-less
+     views (Books home) so the model can be pre-loaded right after launch. The
+     per-character Qwen pill, by contrast, stays gated behind an open book. */
+  it('shows the default Kokoro pill in the Status popover on the Books view (no book open)', async () => {
+    const store = makeStore();
+    /* Pin the default engine deterministically (the account slice seeds this,
+       but make the test independent of hydration). Stay on the initial
+       'books' stage — no openBook dispatch. */
+    store.dispatch(accountSlice.actions.setDefaultTtsModelKey('kokoro-v1'));
+
+    const { findByTestId, findByRole, queryByText } = render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/']}>
+          <Routes>
+            <Route path="/" element={<Layout />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+
+    /* The Status pill renders even with no book in scope because a default
+       TTS control is now available; open it to reach the TTS section. */
+    fireEvent.click(await findByTestId('status-pill'));
+    expect(await findByRole('group', { name: /^Kokoro / })).toBeTruthy();
+    /* The dead-end fallback must NOT render — the control is reachable. */
+    expect(queryByText(/TTS controls appear once a manuscript is open/i)).toBeNull();
+  });
+
+  it('keeps the per-character Qwen pill gated behind an open book', async () => {
+    const store = makeStore();
+    store.dispatch(accountSlice.actions.setDefaultTtsModelKey('kokoro-v1'));
+    /* A Qwen-pinned character exists in the cast slice, but we're on the
+       book-less 'books' stage — the Qwen pill (a per-character signal) must
+       stay hidden while the default Kokoro pill still shows. */
+    store.dispatch(
+      castSlice.actions.setCharacters([
+        { id: 'narrator', name: 'Narrator', role: 'Observer', color: 'narrator' },
+        { id: 'halloran', name: 'Halloran', role: 'Captain', color: 'halloran', ttsEngine: 'qwen' },
+      ] as never),
+    );
+
+    const { findByTestId, findByRole, queryByRole } = render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/']}>
+          <Routes>
+            <Route path="/" element={<Layout />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+
+    fireEvent.click(await findByTestId('status-pill'));
+    expect(await findByRole('group', { name: /^Kokoro / })).toBeTruthy();
+    expect(queryByRole('group', { name: /^Qwen / })).toBeNull();
+  });
+});
+
 describe('Layout — voices re-hydrate as generation renders chapters', () => {
   /* Regression: a bespoke Qwen voice's `generated` flag (cast Status column:
      "Designed" vs "Generated") is derived server-side from rendered segments.

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -42,7 +42,11 @@ import {
 import { ModelControlPill } from './ModelControlPill';
 import { TtsNoticeBanner } from './tts-notice-banner';
 import { useTtsLifecycle, type TtsLifecycle } from '../lib/use-tts-lifecycle';
-import { selectEnginesInUse } from '../store/engines-in-use-selector';
+import {
+  selectEnginesInUse,
+  selectDefaultTtsEngine,
+  type EngineFamily,
+} from '../store/engines-in-use-selector';
 import { useTheme } from '../lib/use-theme';
 import { useReverseLocalAnalyzerGuard } from '../hooks/use-reverse-local-analyzer-guard';
 import { MiniPlayer } from './mini-player';
@@ -782,6 +786,20 @@ export function Layout() {
      per-character `ttsEngine` overrides (see selectEnginesInUse).
      Gemini has no Stop pill (cloud, no VRAM to free). */
   const enginesInUse = useAppSelector(selectEnginesInUse);
+  /* The user-wide default/primary engine. Its Load/Stop pill stays reachable
+     on every view (incl. book-less ones like Books home) so the model can be
+     pre-loaded right after launch — whereas the per-character additions in
+     `enginesInUse` (e.g. a Qwen-pinned cast member) only surface once a book
+     is open. Gemini has no pill (cloud, no VRAM to free), so a Gemini default
+     contributes nothing here and the popover keeps its fallback text. */
+  const defaultEngine = useAppSelector(selectDefaultTtsEngine);
+  const enginesToShow = (() => {
+    const set = new Set<EngineFamily>();
+    if (defaultEngine && defaultEngine !== 'gemini') set.add(defaultEngine);
+    if (showGlobalTtsPill) for (const e of enginesInUse) set.add(e);
+    return set;
+  })();
+  const showTtsControls = enginesToShow.size > 0;
   /* GPU semaphore badge — prefixes the TTS pill cluster with
      "GPU busy · N waiting ·" when this session is waiting behind another
      session's analyzer / sidecar call. Worded to NOT collide with the
@@ -793,7 +811,7 @@ export function Layout() {
      sessions don't thrash an 8 GB GPU's VRAM. */
   const gpuQueueDepth = ttsLifecycle.gpuQueueDepth;
   const showGpuQueueBadge = typeof gpuQueueDepth === 'number' && gpuQueueDepth > 0;
-  const ttsPillElement = showGlobalTtsPill ? (
+  const ttsPillElement = showTtsControls ? (
     <span className="inline-flex items-center gap-2 flex-wrap">
       {showGpuQueueBadge && (
         <span
@@ -803,7 +821,7 @@ export function Layout() {
           GPU busy · {gpuQueueDepth} waiting ·
         </span>
       )}
-      {enginesInUse.has('kokoro') && (
+      {enginesToShow.has('kokoro') && (
         <ModelControlPill
           kind="tts"
           engineLabel="Kokoro"
@@ -817,7 +835,7 @@ export function Layout() {
           }}
         />
       )}
-      {enginesInUse.has('coqui') && (
+      {enginesToShow.has('coqui') && (
         <ModelControlPill
           kind="tts"
           engineLabel="Coqui XTTS"
@@ -831,7 +849,7 @@ export function Layout() {
           }}
         />
       )}
-      {enginesInUse.has('qwen') && (
+      {enginesToShow.has('qwen') && (
         <ModelControlPill
           kind="tts"
           engineLabel="Qwen"
@@ -958,17 +976,17 @@ export function Layout() {
      compact Status pill renders. Computed inline (not memoised) so the
      per-second forceClockTick above keeps the "stalled" rung fresh against
      Date.now(), same as the pill IIFEs. `anyModelLoading` only counts engines
-     the current book actually uses. */
+     whose pill is actually shown. */
   const anyModelLoading = (['kokoro', 'coqui', 'qwen'] as const).some(
-    (e) => enginesInUse.has(e) && ttsLifecycle[e].state === 'loading',
+    (e) => enginesToShow.has(e) && ttsLifecycle[e].state === 'loading',
   );
-  /* Show the Status pill whenever there's a book in scope (so the TTS
-     model controls are always reachable) OR there's cross-book activity /
-     pending revisions to surface. On an idle global view (Books / Voices /
-     Change log with nothing running) the pill is hidden — matching the
-     pre-120 empty cluster — so the workspace doesn't show a dead pill. */
+  /* Show the Status pill whenever a TTS model control is shown (so the default
+     engine's Load/Stop is always reachable, even on book-less views) OR there's
+     cross-book activity / pending revisions to surface. On a fully idle global
+     view with no pill to show (e.g. a Gemini default), the pill stays hidden so
+     the workspace doesn't show a dead pill. */
   const showStatus =
-    showGlobalTtsPill ||
+    showTtsControls ||
     analysisPill !== null ||
     generationPill !== null ||
     pending.length > 0;
@@ -1023,8 +1041,8 @@ export function Layout() {
           top-bar pill is visible on every stage that shows the pill —
           previously these only surfaced in generation.tsx, so a top-bar Load
           error silently reverted the pill to idle. Gated on the same flag as
-          the pill itself. */}
-      {showGlobalTtsPill && (
+          the pill itself, so notices from a book-less Load also surface. */}
+      {showTtsControls && (
         <TtsNoticeBanner
           evictionNotice={ttsLifecycle.evictionNotice}
           loadErrorNotice={ttsLifecycle.loadErrorNotice}

--- a/src/store/engines-in-use-selector.test.ts
+++ b/src/store/engines-in-use-selector.test.ts
@@ -4,7 +4,7 @@
    widens the result transparently. */
 
 import { describe, expect, it } from 'vitest';
-import { selectEnginesInUse } from './engines-in-use-selector';
+import { selectEnginesInUse, selectDefaultTtsEngine } from './engines-in-use-selector';
 import type { RootState } from './index';
 import type { Character } from '../lib/types';
 
@@ -81,5 +81,31 @@ describe('selectEnginesInUse', () => {
       charWithEngine('halloran', 'kokoro'),
     ]);
     expect(selectEnginesInUse(state)).toEqual(new Set(['kokoro']));
+  });
+});
+
+describe('selectDefaultTtsEngine', () => {
+  /* The default/primary engine, independent of any loaded book's cast — the
+     top bar keeps this engine's pill reachable on book-less views. */
+  it('maps kokoro-v1 → kokoro', () => {
+    expect(selectDefaultTtsEngine(makeState('kokoro-v1'))).toBe('kokoro');
+  });
+
+  it('maps a Qwen key → qwen', () => {
+    expect(selectDefaultTtsEngine(makeState('qwen3-tts-0.6b'))).toBe('qwen');
+  });
+
+  it('maps coqui-xtts-v2 → coqui (and folds piper into coqui)', () => {
+    expect(selectDefaultTtsEngine(makeState('coqui-xtts-v2'))).toBe('coqui');
+    expect(selectDefaultTtsEngine(makeState('piper-en-amy'))).toBe('coqui');
+  });
+
+  it('maps a Gemini key → gemini (cloud, no pill)', () => {
+    expect(selectDefaultTtsEngine(makeState('gemini-2.5-flash'))).toBe('gemini');
+  });
+
+  it('returns null when defaultTtsModelKey has not hydrated yet', () => {
+    const empty = { account: { defaultTtsModelKey: undefined } } as unknown as RootState;
+    expect(selectDefaultTtsEngine(empty)).toBeNull();
   });
 });

--- a/src/store/engines-in-use-selector.ts
+++ b/src/store/engines-in-use-selector.ts
@@ -52,3 +52,15 @@ export function selectEnginesInUse(state: RootState): Set<EngineFamily> {
   }
   return result;
 }
+
+/* selectDefaultTtsEngine — the user-wide default/primary engine derived from
+   `account.defaultTtsModelKey`, independent of any loaded book or its cast.
+   The top bar uses this to keep the default engine's Load/Stop pill reachable
+   on book-less views (Books home, Voices, …) so the model can be pre-loaded
+   right after launch — whereas the per-character additions in
+   `selectEnginesInUse` (e.g. a Qwen-pinned cast member) stay gated behind an
+   open book. Returns null when no default key has hydrated yet. */
+export function selectDefaultTtsEngine(state: RootState): EngineFamily | null {
+  const modelKey = state.account?.defaultTtsModelKey;
+  return modelKey ? engineFamilyForKey(modelKey) : null;
+}


### PR DESCRIPTION
## Summary

The top-bar **Status popover → TTS engines** section was gated entirely behind a book being open (`showGlobalTtsPill` = `analysing | confirm | ready`). On the Books home view (app start, no book open) it showed a dead-end *"TTS controls appear once a manuscript is open."*, so a user couldn't pre-load the default TTS model right after launch — they had to open a book first.

This splits the gate so the **default/primary engine** is reachable on every view, while the **per-character** engine pills stay book-gated:

- New selector `selectDefaultTtsEngine` (`src/store/engines-in-use-selector.ts`) derives the default engine family from `account.defaultTtsModelKey`, independent of any loaded book or its cast.
- `layout.tsx` now builds an `enginesToShow` set that always includes the default engine (when it's a pill engine — Kokoro / Coqui / Qwen) and unions in the per-character additions from `selectEnginesInUse` (e.g. a Qwen-pinned cast member) **only** when a book is open. A new `showTtsControls = enginesToShow.size > 0` flag drives the pill cluster, the Status-pill visibility (so the popover is reachable on book-less views), and the `TtsNoticeBanner` (so a Load error / analyzer-eviction from a book-less Load still surfaces).
- A **Gemini default** contributes no pill (cloud, no VRAM to free), so the cluster stays empty and the fallback text remains there.

This does **not** auto-load anything — it only makes the existing Load button reachable earlier, so CLAUDE.md's button-driven model-lifecycle rule is preserved.

## User-visible delta

- **Before:** Books view → Status popover → "TTS controls appear once a manuscript is open" (no control).
- **After:** Books view (and every other book-less view) → Status popover surfaces the default engine's Load/Stop pill (Kokoro by default), so the model can be pre-loaded before opening a book. The Status pill itself now renders on these views because a control is available. Per-character Qwen pills still only appear once a book whose cast uses them is open.

## Test plan

- `src/store/engines-in-use-selector.test.ts` — `selectDefaultTtsEngine` maps `kokoro-v1`→kokoro, Qwen→qwen, coqui/piper→coqui, Gemini→gemini, and returns `null` when unhydrated.
- `src/components/layout.test.tsx` — on the Books stage the default Kokoro pill renders in the Status popover and the fallback text is absent; a Qwen-pinned cast member does **not** add a Qwen pill while book-less.
- `e2e/default-tts-pill-no-book.spec.ts` — browser golden path: land on the library view, open the Status popover, the Kokoro control is reachable and the fallback is gone.
- `npm run verify` green locally (lint + typecheck + all tests + e2e + visual + build).

Regression plan: [`docs/features/30-global-model-control.md`](docs/features/30-global-model-control.md) amended (split-gate "Shipped" section + acceptance step 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
