### PR TITLE
fix(scripts): make bump-version import.meta-main guard symlink-tolerant

### DIFF
--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -21,7 +21,7 @@
 // be run only from a clean working tree, on `main`, by a maintainer.
 
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
@@ -416,6 +416,16 @@ async function main() {
 
 // Guarded so tests can import the pure helpers (semverBump, pickWorkflowRun)
 // without executing the release procedure (matches install-qwen3.mjs).
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+//
+// `process.argv[1]` is resolved through realpathSync before the compare: Node
+// realpaths `import.meta.url` (symlinks resolved unless --preserve-symlinks),
+// but `pathToFileURL(process.argv[1])` keeps the symlinked invocation path. On
+// macOS the temp dir is a symlink (`/var/folders` → `/private/var/folders`), so
+// running the script from there (e.g. the bump-version test's throwaway repo)
+// left the two hrefs unequal — the guard was false, main() silently never ran,
+// and the script exited 0 with empty output. realpathing argv[1] makes both
+// sides the canonical path so the guard holds regardless of symlinks.
+const invokedHref = process.argv[1] ? pathToFileURL(realpathSync(process.argv[1])).href : '';
+if (invokedHref && import.meta.url === invokedHref) {
   await main();
 }


### PR DESCRIPTION
## Summary

The v1.5.0 release cut's cross-OS gate (plan 127) — the **first macOS run** of the bump-version tests — failed all 13 cases on `macos-latest` with empty stdout and exit 0 (even the should-fail cases). The product code and Windows + mobile-e2e legs all passed; this is purely a release-tooling bug.

**Root cause:** Node realpaths `import.meta.url` (symlinks resolved), but `pathToFileURL(process.argv[1])` keeps the symlinked invocation path. macOS `TMPDIR` is a symlink (`/var/folders` → `/private/var/folders`), so the bump-version test's throwaway repo runs the script from a symlinked path → the `import.meta`-main guard was false → `main()` never ran → the script exited 0 silently. (Latent until now because plan 127's cut-gate is the first macOS run of these tests; Linux `/tmp` isn't symlinked, so per-PR CI never hit it.)

**Fix:** resolve `process.argv[1]` through `realpathSync` before the guard compare, so both hrefs are canonical regardless of symlinks. No behaviour change on a non-symlinked path.

This unblocks the v1.5.0 cut (which re-runs this same gate).

## Test plan

`npm run test:hooks` green locally (Windows) — all 12 bump-version cases pass unchanged; they're the regression. The macOS proof comes from the re-cut's cross-OS gate (per-PR CI is Linux, which never reproduced the symlink path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)