### PR TITLE
fix(frontend): derive regenerate ETA from audio duration x target RTF

### DIFF
--- a/docs/features/17-regenerate-this-or-forward.md
+++ b/docs/features/17-regenerate-this-or-forward.md
@@ -1,7 +1,7 @@
 # Regenerate (this or forward)
 
 > Status: stable
-> Key files: `src/modals/regenerate.tsx`, `src/store/chapters-slice.ts` (`regenerateChapter`, `regenerateChapterIds`), `src/store/ui-slice.ts` (`setRegenChapter`, `setRegenInitialScope`)
+> Key files: `src/modals/regenerate.tsx`, `src/modals/character-regenerate.tsx`, `src/lib/generation-progress.ts` (`TARGET_RTF`, `estimateGenMinutes`), `src/lib/time.ts` (`parseDuration`), `src/store/chapters-slice.ts` (`regenerateChapter`, `regenerateChapterIds`), `src/store/ui-slice.ts` (`setRegenChapter`, `setRegenInitialScope`)
 > URL surface: modal overlay, no URL component
 > OpenAPI ops: indirect — drives `POST /api/books/:bookId/generation` (often with subset + `force: true`)
 
@@ -28,6 +28,7 @@ opt-in preview).
 - Both confirm and cancel are flat overlays (not stage-guarded); cancel never enqueues.
 - `chaptersActions.regenerateChapter` takes scope + chapter id and expands `'forward'` into the chapter id list; `regenerateChapterIds` flips an explicit chapter-id list (head → `in_progress`, rest → `queued`). Every regen enqueues whole-chapter entries (`scope:'this'`) — there is no `scope:'character'` producer anymore (plan 114).
 - A successful chapter regen overwrites the chapter's `audioModelKey` / `audioRenderedAt` stamp with the active engine (see plan 35). So regenerating a drifted chapter clears its drift caption + banner contribution automatically — no separate "clear drift" affordance is needed.
+- **ETA derives from audio duration × target RTF**, not a flat per-chapter constant. TTS generation wall-clock tracks the real-time factor (`generation_time ≈ audio_seconds × TARGET_RTF`, `TARGET_RTF = 2.5` in `src/lib/generation-progress.ts`, tunable). The chapter modal estimates from `chapter.duration` (scope `'this'`) or the summed forward-set duration passed as `forwardDurationSec` (scope `'forward'`); the character modal (`character-regenerate.tsx`) sums the duration of every chapter the character speaks in. All three go through `estimateGenMinutes(audioSec)` (rounds to the nearest minute, floors at 1) and render minutes under 60 as `"N min"`, longer as `formatHours` (`"Xh Ym"`). Durations are parsed with `parseDuration`, which accepts both `MM:SS` and `HH:MM:SS`.
 
 ## Acceptance walkthrough
 

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -31,6 +31,7 @@ import {
 import { api, type SeriesRosterEntry } from '../lib/api';
 import { engineForModelKey } from '../lib/tts-models';
 import { computeOverallProgress } from '../lib/analysis-progress';
+import { parseDuration } from '../lib/time';
 import { stageToHash } from '../lib/router';
 import {
   TopBar,
@@ -1107,6 +1108,9 @@ export function Layout() {
           chapter={ui.regenChapter}
           defaultScope={ui.regenInitialScope ?? 'this'}
           forwardCount={chapters.filter((c) => c.id >= ui.regenChapter!.id).length}
+          forwardDurationSec={chapters
+            .filter((c) => c.id >= ui.regenChapter!.id)
+            .reduce((acc, c) => acc + parseDuration(c.duration), 0)}
           onClose={() => dispatch(uiActions.setRegenChapter(null))}
           onConfirm={({ reason, scope, note }) => {
             const chapter = ui.regenChapter;

--- a/src/lib/generation-progress.test.ts
+++ b/src/lib/generation-progress.test.ts
@@ -6,9 +6,11 @@ import {
   characterRowProgress,
   characterStatsByChapter,
   countWords,
+  estimateGenMinutes,
   linesDoneAt,
   overallProgress,
   sentencesPerChapter,
+  TARGET_RTF,
 } from './generation-progress';
 import type { Chapter, Sentence } from './types';
 
@@ -41,6 +43,24 @@ describe('countWords', () => {
   it('returns 0 for empty / whitespace-only strings', () => {
     expect(countWords('')).toBe(0);
     expect(countWords('   ')).toBe(0);
+  });
+});
+
+describe('estimateGenMinutes — RTF-based regenerate ETA', () => {
+  it('scales generation minutes by the target RTF', () => {
+    /* 600s of audio × 2.5 = 1500s = 25 min. */
+    expect(estimateGenMinutes(600)).toBe(Math.round((600 * TARGET_RTF) / 60));
+    expect(estimateGenMinutes(600)).toBe(25);
+  });
+
+  it('rounds to the nearest minute', () => {
+    /* 45s × 2.5 = 112.5s = 1.875 min → 2. */
+    expect(estimateGenMinutes(45)).toBe(2);
+  });
+
+  it('floors at 1 minute so a tiny chapter never reads as "0 min"', () => {
+    expect(estimateGenMinutes(1)).toBe(1);
+    expect(estimateGenMinutes(0)).toBe(1);
   });
 });
 

--- a/src/lib/generation-progress.ts
+++ b/src/lib/generation-progress.ts
@@ -110,6 +110,18 @@ export function characterRowProgress(args: {
   return { derivedDone, fraction, fullyDone };
 }
 
+/** Target real-time factor: generation seconds per second of finished audio.
+    ~2 on the 4070 batch path; 2.5 bakes in dispatch overhead so the estimate
+    biases toward over- rather than under-promising. Tune here. */
+export const TARGET_RTF = 2.5;
+
+/** Estimated wall-clock generation minutes for `audioSec` seconds of audio at
+    the current target RTF, rounded to the nearest minute, floored at 1 so a
+    tiny chapter never reads as "0 min". */
+export function estimateGenMinutes(audioSec: number): number {
+  return Math.max(1, Math.round((audioSec * TARGET_RTF) / 60));
+}
+
 export function countWords(text: string): number {
   const stripped = text.replace(/\[[^\]]*\]/g, ' ');
   const m = stripped.match(/\S+/g);

--- a/src/lib/time.test.ts
+++ b/src/lib/time.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { parseDuration, formatDuration } from './time';
+
+describe('parseDuration', () => {
+  it('parses MM:SS', () => {
+    expect(parseDuration('12:48')).toBe(12 * 60 + 48);
+    expect(parseDuration('00:45')).toBe(45);
+  });
+
+  it('parses HH:MM:SS (a chapter longer than an hour)', () => {
+    expect(parseDuration('1:02:30')).toBe(3600 + 2 * 60 + 30);
+  });
+
+  it('round-trips formatDuration for both shapes (true inverse)', () => {
+    for (const sec of [0, 45, 768, 3750]) {
+      expect(parseDuration(formatDuration(sec))).toBe(sec);
+    }
+  });
+});

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,6 +1,8 @@
+/** Inverse of `formatDuration` — accepts both `MM:SS` and `HH:MM:SS`. Folds
+    the colon-separated segments base-60 so an hour-long chapter parses
+    correctly rather than dropping the seconds field. */
 export function parseDuration(s: string): number {
-  const [m, sec] = s.split(':').map(Number);
-  return m * 60 + sec;
+  return s.split(':').reduce((acc, seg) => acc * 60 + Number(seg), 0);
 }
 
 export function formatTime(totalSec: number): string {

--- a/src/modals/character-regenerate.test.tsx
+++ b/src/modals/character-regenerate.test.tsx
@@ -72,4 +72,24 @@ describe('CharacterRegenerateModal', () => {
     expect(screen.getByTestId('regen-character-all')).toBeDisabled();
     expect(screen.getByTestId('regen-character-preview')).toBeDisabled();
   });
+
+  it('estimates the ETA from the affected chapters audio duration × RTF', () => {
+    /* Keefe speaks in ch1 + ch4, each 10:00 → 1200s × 2.5 = 3000s = 50 min. */
+    render(
+      <CharacterRegenerateModal character={keefe} chapters={chapters} onClose={() => {}} onConfirm={() => {}} />,
+    );
+    expect(screen.getByText('≈50 min')).toBeInTheDocument();
+  });
+
+  it('shows "—" for the ETA when the character speaks in no chapters', () => {
+    render(
+      <CharacterRegenerateModal
+        character={keefe}
+        chapters={[ch(2, { narrator: 'done' })]}
+        onClose={() => {}}
+        onConfirm={() => {}}
+      />,
+    );
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
 });

--- a/src/modals/character-regenerate.tsx
+++ b/src/modals/character-regenerate.tsx
@@ -4,6 +4,8 @@ import { Avatar } from '../components/primitives';
 import { CHAR_COLORS } from '../lib/colors';
 import { stripChapterPrefix } from '../lib/format-chapter-title';
 import { REGEN_REASONS } from '../data/regen-reasons';
+import { parseDuration, formatHours } from '../lib/time';
+import { estimateGenMinutes } from '../lib/generation-progress';
 import type { Character, Chapter, CharColor } from '../lib/types';
 
 interface Props {
@@ -40,8 +42,12 @@ export function CharacterRegenerateModal({ character, chapters, onClose, onConfi
   const previewChapter = speakingChapters[0] ?? null;
   const n = speakingChapters.length;
 
-  const lines = character.lines ?? 0;
-  const eta = lines > 0 ? `≈${Math.max(1, Math.round(lines / 60))} min` : '—';
+  /* Each affected chapter is re-rendered in full, so the wall-clock estimate
+     is the combined audio length of those chapters × the target RTF — the
+     same model the chapter Regenerate modal uses. */
+  const totalSec = speakingChapters.reduce((acc, ch) => acc + parseDuration(ch.duration), 0);
+  const minutes = estimateGenMinutes(totalSec);
+  const eta = n > 0 ? `≈${minutes < 60 ? `${minutes} min` : formatHours(minutes)}` : '—';
 
   const fire = (preview: boolean) =>
     onConfirm({ characterId: character.id, chapterIds, reason, note, preview });

--- a/src/modals/regenerate.test.tsx
+++ b/src/modals/regenerate.test.tsx
@@ -72,3 +72,31 @@ describe('RegenerateModal — forward ETA reflects actual affected count', () =>
     expect(screen.getByText(/for 1 chapter\b/)).toBeInTheDocument();
   });
 });
+
+describe('RegenerateModal — ETA scales with audio duration × RTF', () => {
+  /* Previously the single-chapter ETA was the hardcoded string "≈3 min"
+     regardless of the chapter's length. Generation wall-clock tracks the
+     real-time factor (~2.5), so a 10-minute chapter takes ~25 min, not 3. */
+  const tenMin: Chapter = { ...chapter, duration: '10:00' };
+
+  it('derives the single-chapter ETA from the chapter duration (≈25 min for 10:00)', () => {
+    render(<RegenerateModal chapter={tenMin} onClose={() => {}} onConfirm={() => {}} />);
+    expect(screen.getByText('≈25 min')).toBeInTheDocument();
+    expect(screen.queryByText('≈3 min')).not.toBeInTheDocument();
+  });
+
+  it('derives the forward ETA from forwardDurationSec, not a flat per-chapter number', () => {
+    render(
+      <RegenerateModal
+        chapter={tenMin}
+        defaultScope="forward"
+        forwardCount={3}
+        /* 3 × 10:00 = 1800s → 1800 × 2.5 = 4500s = 75 min → "1h 15m". */
+        forwardDurationSec={1800}
+        onClose={() => {}}
+        onConfirm={() => {}}
+      />,
+    );
+    expect(screen.getByText('≈1h 15m for 3 chapters')).toBeInTheDocument();
+  });
+});

--- a/src/modals/regenerate.tsx
+++ b/src/modals/regenerate.tsx
@@ -3,6 +3,8 @@ import { IconRefresh, IconClose, IconClock } from '../lib/icons';
 import { PrimaryButton } from '../components/primitives';
 import { REGEN_REASONS } from '../data/regen-reasons';
 import { stripChapterPrefix } from '../lib/format-chapter-title';
+import { parseDuration, formatHours } from '../lib/time';
+import { estimateGenMinutes } from '../lib/generation-progress';
 import type { Chapter } from '../lib/types';
 
 export type RegenScope = 'this' | 'forward';
@@ -18,16 +20,20 @@ interface Props {
       this chapter plus every later one. Defaults to 1 so callers that forget
       to pass it get a sensible (if unhelpful) ETA rather than a stale "4". */
   forwardCount?: number;
+  /** Combined audio seconds of the forward set (this chapter + every later
+      one). The ETA is `audioSec × TARGET_RTF`, so we need the real durations,
+      not just the count. Falls back to a uniform-length guess off this
+      chapter when the caller omits it. */
+  forwardDurationSec?: number;
   onClose: () => void;
   onConfirm: (args: { reason: string; scope: RegenScope; note: string }) => void;
 }
-
-const MINUTES_PER_CHAPTER = 3.5;
 
 export function RegenerateModal({
   chapter,
   defaultScope = 'this',
   forwardCount = 1,
+  forwardDurationSec,
   onClose,
   onConfirm,
 }: Props) {
@@ -35,9 +41,15 @@ export function RegenerateModal({
   const [scope, setScope] = useState<RegenScope>(defaultScope);
   const [note, setNote] = useState('');
   if (!chapter) return null;
-  const forwardMinutes = Math.max(1, Math.round(forwardCount * MINUTES_PER_CHAPTER));
+  /* Generation wall-clock tracks the real-time factor: it takes ~RTF seconds
+     to synthesise one second of finished audio. So the ETA scales with the
+     chapter's audio length, not a flat per-chapter constant. */
+  const thisSec = parseDuration(chapter.duration);
+  const forwardSec = forwardDurationSec ?? thisSec * forwardCount;
+  const minutes = estimateGenMinutes(scope === 'this' ? thisSec : forwardSec);
+  const etaTime = minutes < 60 ? `${minutes} min` : formatHours(minutes);
   const forwardChaptersLabel = `${forwardCount} chapter${forwardCount === 1 ? '' : 's'}`;
-  const eta = scope === 'this' ? '≈3 min' : `≈${forwardMinutes} min for ${forwardChaptersLabel}`;
+  const eta = scope === 'this' ? `≈${etaTime}` : `≈${etaTime} for ${forwardChaptersLabel}`;
   return (
     <>
       <div onClick={onClose} className="fixed inset-0 bg-ink/40 z-50 fade-in" />


### PR DESCRIPTION
## Summary

The Regenerate modal's **Estimated time** was a flat constant — `≈3 min` hardcoded for a single chapter, `3.5 min × chapter count` for the forward scope — so a 12-minute chapter and a 1-minute chapter both read `≈3 min`. TTS generation wall-clock tracks the **real-time factor** (`generation_time ≈ audio_seconds × RTF`), so the estimate now scales with the chapter's actual audio length.

- New `TARGET_RTF` (2.5 — RTF ~2 on the 4070 batch path plus dispatch headroom, so the estimate biases toward over- rather than under-promising) and `estimateGenMinutes(audioSec)` in `src/lib/generation-progress.ts` (rounds to nearest minute, floors at 1).
- **Chapter Regenerate modal** (`src/modals/regenerate.tsx`): estimates from `chapter.duration` for scope `this`, or a new `forwardDurationSec` prop (summed forward-set audio, computed in `layout.tsx`) for scope `forward`. Drops the hardcoded `≈3 min` and the `MINUTES_PER_CHAPTER` constant.
- **Character Regenerate modal** (`src/modals/character-regenerate.tsx`): replaces its `lines / 60` guess with the same model summed over the chapters the character speaks in.
- `parseDuration` (`src/lib/time.ts`) now folds colon segments base-60, so `HH:MM:SS` (hour-plus chapters) parses correctly — a true inverse of `formatDuration`. Previously only `MM:SS` parsed.
- Display: minutes under 60 render as `N min`, longer as `formatHours` (`Xh Ym`).

### Contract change

`RegenerateModal` gains an optional `forwardDurationSec?: number` prop. When omitted it falls back to `thisChapterSec × forwardCount` (uniform-length guess), so existing callers keep a sensible estimate.

### Unrelated fix (called out)

`e2e/build-stamp.spec.ts` pinned `v1.4.0`, but the app version was bumped to `v1.5.0` in `a2dc60f` and this assertion was never updated — full `npm run verify` was red on `main` independent of this change. Bumped to `v1.5.0` in its own commit (`test(e2e): bump stale build-stamp assertion`). *Follow-up worth filing: make this assertion read the version from `package.json` so it can't rot on the next bump.*

## Test plan

- `src/lib/generation-progress.test.ts` — `estimateGenMinutes` scales by RTF, rounds to nearest, floors at 1.
- `src/lib/time.test.ts` (new) — `parseDuration` handles `MM:SS` + `HH:MM:SS` and round-trips `formatDuration`.
- `src/modals/regenerate.test.tsx` — single-chapter ETA derives from duration (`10:00 → ≈25 min`, old `≈3 min` gone); forward ETA derives from `forwardDurationSec` (`1800s → ≈1h 15m for 3 chapters`).
- `src/modals/character-regenerate.test.tsx` — ETA from summed affected-chapter duration × RTF; `—` when the character speaks in no chapters.
- `npm run verify` run locally — green except the documented Windows-only `visual.spec › confirm` font-hinting baseline drift (whole-page sub-pixel ghost, unrelated to this change; Linux CI uses its own baselines).

Regression plan: [`docs/features/17-regenerate-this-or-forward.md`](docs/features/17-regenerate-this-or-forward.md) updated with the ETA invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
