### PR TITLE
chore: repoint archived-plan path pointers in source comments

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ See CONTRIBUTING.md "Pull requests" for the full spec.
 
 <!--
 1-3 sentences: what changes, why. If a regression plan under docs/features/ applies,
-link it here (e.g. "Implements docs/features/44-pr-hygiene.md."). If this PR fills
+link it here (e.g. "Implements docs/features/archive/44-pr-hygiene.md."). If this PR fills
 in a plan's Ship notes, say so.
 -->
 

--- a/e2e/library-search-tags.spec.ts
+++ b/e2e/library-search-tags.spec.ts
@@ -10,7 +10,7 @@ import { test, expect } from '@playwright/test';
  *   - cc (Carrick's Compass)  → []
  *   - ts (Twilight Stations)  → ['favourite']
  *
- * Pairs with docs/features/73-library-search-tags.md.
+ * Pairs with docs/features/archive/73-library-search-tags.md.
  *
  * Each card carries `data-testid="book-meta-strip-<bookId>"` (plan 9
  * always-visible metadata strip), which we use as the per-card visibility

--- a/e2e/manual-continuity-link.spec.ts
+++ b/e2e/manual-continuity-link.spec.ts
@@ -13,7 +13,7 @@
  * branch) so the test is self-contained — no fixture shortcuts.
  *
  * Wall-clock budget: ~16 s warm (analyser mock ~7.6 s + UI). Pairs with
- * docs/features/09-voice-match-pipeline.md §"Manual continuity link". */
+ * docs/features/archive/09-voice-match-pipeline.md §"Manual continuity link". */
 
 import { test, expect } from '@playwright/test';
 

--- a/e2e/manuscript-reupload-diff.spec.ts
+++ b/e2e/manuscript-reupload-diff.spec.ts
@@ -5,7 +5,7 @@
  * surfaces the changed sentence → click Apply → modal closes + slice
  * commits.
  *
- * Pairs with docs/features/74-manuscript-diff-on-reupload.md. */
+ * Pairs with docs/features/archive/74-manuscript-diff-on-reupload.md. */
 
 import { test, expect, type Page } from '@playwright/test';
 

--- a/e2e/portable-book-roundtrip.spec.ts
+++ b/e2e/portable-book-roundtrip.spec.ts
@@ -12,7 +12,7 @@ import { test, expect } from '@playwright/test';
  * importPortable echoes a synthesised bookId so the library can refresh
  * without disturbing the canned data.
  *
- * Pairs with docs/features/75-portable-book-export.md.
+ * Pairs with docs/features/archive/75-portable-book-export.md.
  */
 test.describe('plan 75 — portable book bundle round-trip', () => {
   test('Listen view: Portable bundle tile is live and triggers a download', async ({ page }) => {

--- a/e2e/profile-drawer-merge.spec.ts
+++ b/e2e/profile-drawer-merge.spec.ts
@@ -7,7 +7,7 @@
  *
  * Same cold-boot → upload → analysing → confirm walk as the sibling
  * spec so the test is self-contained. Wall-clock budget: ~16 s warm.
- * Pairs with docs/features/10-profile-drawer.md "Merge / downgrade
+ * Pairs with docs/features/archive/10-profile-drawer.md "Merge / downgrade
  * controls" + the searchable-picker bullet added with this change.
  */
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2547,7 +2547,7 @@ components:
             frontend can update `chapter.audioModelKey` without waiting
             for a state.json reload (which would otherwise let an
             engine-drift badge appear only after page navigation). See
-            `docs/features/35-engine-drift-detection.md`.
+            `docs/features/archive/35-engine-drift-detection.md`.
         errorReason: { type: string, nullable: true }
         code:
           type: string
@@ -3430,7 +3430,7 @@ components:
             segments file for legacy chapters. Absent on never-rendered
             chapters. The frontend compares against the project's
             current `ui.ttsModelKey` to surface engine-drift badges (see
-            `docs/features/35-engine-drift-detection.md`).
+            `docs/features/archive/35-engine-drift-detection.md`).
         audioRenderedAt:
           type: string
           format: date-time

--- a/scripts/recover-missing-character.mjs
+++ b/scripts/recover-missing-character.mjs
@@ -9,13 +9,13 @@
    minLines: 3) then drops anyone who did slip through with <3 attributed
    lines. The combined effect: an entire category of named characters
    silently absent from the cast roster. Concrete example caught in
-   docs/features/96-recover-missing-character.md: Grizel (Fitz's goblin
+   docs/features/archive/96-recover-missing-character.md: Grizel (Fitz's goblin
    bodyguard) and Sandor (Sophie's goblin bodyguard) both missing from
    Neverseen's cast.json across all ~65 Phase 0a stage1 outputs.
 
    This script lets the user manually fill the gap WITHOUT re-running Phase 0a
    (which would just miss them again for the same reason). Layer 2 in
-   docs/features/97-narrator-only-named-characters.md fixes the analyzer to
+   docs/features/archive/97-narrator-only-named-characters.md fixes the analyzer to
    stop dropping them in future books.
 
    Usage:

--- a/scripts/validate-commit-msg.mjs
+++ b/scripts/validate-commit-msg.mjs
@@ -1,5 +1,5 @@
 // Conventional-Commits subject validator for .husky/commit-msg.
-// See CONTRIBUTING.md and docs/features/38-branching-and-commit-convention.md
+// See CONTRIBUTING.md and docs/features/archive/38-branching-and-commit-convention.md
 // for the spec and rationale.
 
 import { readFileSync } from 'node:fs';

--- a/server/src/analyzer/fold-minor-cast.test.ts
+++ b/server/src/analyzer/fold-minor-cast.test.ts
@@ -1,6 +1,6 @@
-/* Pairs with docs/features/06-analyzer-gemini.md — minor-cast fold pass.
+/* Pairs with docs/features/archive/06-analyzer-gemini.md — minor-cast fold pass.
    Protected-role-exemption coverage added per
-   docs/features/97-narrator-only-named-characters.md. */
+   docs/features/archive/97-narrator-only-named-characters.md. */
 
 import { describe, it, expect } from 'vitest';
 import {

--- a/server/src/analyzer/fold-minor-cast.ts
+++ b/server/src/analyzer/fold-minor-cast.ts
@@ -61,7 +61,7 @@ export interface FoldOptions {
       the protection: bodyguards / mentors / family who are mentioned
       heavily in narration but rarely quote dialogue (e.g. Grizel and
       Sandor in Lost Cities Neverseen — see
-      docs/features/97-narrator-only-named-characters.md) would
+      docs/features/archive/97-narrator-only-named-characters.md) would
       otherwise be silently dropped or bucketed into
       unknown-male/female. */
   protectedRoles?: string[];

--- a/server/src/analyzer/rate-limit.ts
+++ b/server/src/analyzer/rate-limit.ts
@@ -31,7 +31,7 @@ const FALLBACK_LIMITS: ModelLimits = { rpm: 5, tpm: 100_000, rpd: 50 };
 
 /* Built-in limits per model id. Values pulled live from AI Studio on
    2026-05-16 — keep in lockstep with the table in
-   docs/features/06-analyzer-gemini.md (regression plan) when limits
+   docs/features/archive/06-analyzer-gemini.md (regression plan) when limits
    change. */
 const BUILTIN_LIMITS: Record<string, ModelLimits> = {
   'gemini-3.1-flash-lite': { rpm: 15, tpm: 250_000, rpd: 500 },

--- a/server/src/export/build-m4b.ts
+++ b/server/src/export/build-m4b.ts
@@ -4,7 +4,7 @@
    QuickTime-style chapter atoms via an FFMETADATA sidecar. PocketBook
    surfaces the resulting `.m4b` under Audiobooks (not Music), with
    chapter UI and resume-position state — see
-   `docs/features/32-audiobook-export.md`.
+   `docs/features/archive/32-audiobook-export.md`.
 
    Re-encodes (unlike Phase A's MP3.ZIP which is `-c:a copy`): 24 kHz
    mono MP3 → 44.1 kHz mono AAC-LC @ 96 kbps. The re-encode tolerates

--- a/server/src/parsers/pdf.test.ts
+++ b/server/src/parsers/pdf.test.ts
@@ -4,7 +4,7 @@
 // precedence (info-dict Title/Author > parseText-derived) and delegating
 // body splitting to parseText. Mocking pdf-parse isolates that contract;
 // pdfjs end-to-end correctness is covered by the canonical e2e manuscript
-// run (see CLAUDE.md, docs/features/28-chapter-audio-format.md).
+// run (see CLAUDE.md, docs/features/archive/28-chapter-audio-format.md).
 
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 

--- a/server/src/routes/book-state.test.ts
+++ b/server/src/routes/book-state.test.ts
@@ -987,7 +987,7 @@ describe('book-state router — state slice series-membership + on-disk rename',
 /* Cold-boot rehydration for the AnalysisPill across browser reload +
    server restart. The endpoint reads from .audiobook/analysis-state.json
    (written by analysis.ts at phase boundaries and on terminal events).
-   See docs/features/32-sticky-analysis.md "Cold-boot rehydration". */
+   See docs/features/archive/32-sticky-analysis.md "Cold-boot rehydration". */
 describe('book-state router — GET /:bookId/analysis/state', () => {
   const COLD_BOOT_AUTHOR = 'ColdBoot Author';
   const COLD_BOOT_SERIES = 'Standalones';

--- a/server/src/routes/book-state.ts
+++ b/server/src/routes/book-state.ts
@@ -347,7 +347,7 @@ bookStateRouter.get('/:bookId/state', async (req: Request, res: Response) => {
       Resume to re-attach.
    4. Else 404 (no rehydratable state).
 
-   See docs/features/32-sticky-analysis.md "Cold-boot rehydration"
+   See docs/features/archive/32-sticky-analysis.md "Cold-boot rehydration"
    for the full invariant set. */
 bookStateRouter.get('/:bookId/analysis/state', async (req: Request, res: Response) => {
   try {

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -432,7 +432,7 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
      (sidecar-health.ts) now blocks that specific cause, but a genuinely
      uninstalled / weights-missing / load-failed Qwen still lands here, and that
      downgrade must be visible, not silent. (Stale-build incident, 2026-05-29 —
-     docs/features/135-qwen-loud-fallback.md.) */
+     docs/features/archive/135-qwen-loud-fallback.md.) */
   if (qwenUnavailable) {
     const message =
       `Qwen is unavailable (install-state: ${qwenState}), so every Qwen character ` +

--- a/server/src/routes/sidecar-health.ts
+++ b/server/src/routes/sidecar-health.ts
@@ -79,7 +79,7 @@ function normaliseQwenInstallState(raw: unknown): QwenInstallState {
    getLastKnownQwenInstallState() and makes generation silently fall EVERY Qwen
    character back to Kokoro — wrong engine, wrong voices, no warning. A loaded
    model can never be "not installed", so honour it. (Stale-build incident,
-   2026-05-29 — see docs/features/135-qwen-loud-fallback.md.) */
+   2026-05-29 — see docs/features/archive/135-qwen-loud-fallback.md.) */
 function deriveQwenInstallState(body: SidecarHealthBody): QwenInstallState {
   if (body.qwen_loaded === true) return 'loaded';
   return normaliseQwenInstallState(body.qwen_install_state);

--- a/server/src/store/dropped-quotes.test.ts
+++ b/server/src/store/dropped-quotes.test.ts
@@ -1,5 +1,5 @@
 /* Unit tests for the dropped-quotes ledger module. Pairs with
-   docs/features/04-analysing-view-progress.md — the panel under the
+   docs/features/archive/04-analysing-view-progress.md — the panel under the
    cast preview reads from the file these helpers produce. */
 
 import { describe, expect, it, beforeEach, afterEach } from 'vitest';

--- a/server/src/tts/synthesise-chapter.ts
+++ b/server/src/tts/synthesise-chapter.ts
@@ -148,7 +148,7 @@ export interface ChapterSegment {
     [body sentences]`. Defaults match standard audiobook chapter breaks —
     3.0 s of total padding is enough for the listener to register the
     boundary without dragging. Tuned together with the documented invariant
-    in `docs/features/28-chapter-audio-format.md`; adjust both at once. */
+    in `docs/features/archive/28-chapter-audio-format.md`; adjust both at once. */
 const CHAPTER_LEAD_SILENCE_SEC = 1.5;
 const CHAPTER_POST_TITLE_SILENCE_SEC = 1.5;
 

--- a/server/src/workspace/state-migrate.test.ts
+++ b/server/src/workspace/state-migrate.test.ts
@@ -1,4 +1,4 @@
-/* Pairs with docs/features/27-book-state-persistence.md.
+/* Pairs with docs/features/archive/27-book-state-persistence.md.
  *
  * Pins the migration seam contract: CURRENT_STATE_SCHEMA is 1 today;
  * legacy files without the field load as v1; explicitly v1-stamped

--- a/server/src/workspace/state-migrate.ts
+++ b/server/src/workspace/state-migrate.ts
@@ -16,7 +16,7 @@
  * edits the book.
  *
  * Rename-vs-add policy (documented in
- * docs/features/27-book-state-persistence.md):
+ * docs/features/archive/27-book-state-persistence.md):
  *   - Adding an OPTIONAL field is backwards-compatible. No schema bump.
  *     The old reader ignores the new field; the new writer keeps writing
  *     it. This is the common case.
@@ -25,7 +25,7 @@
  *     widening) breaks readers. Bump CURRENT_STATE_SCHEMA and add a
  *     migration branch below.
  *
- * Pairs with docs/features/27-book-state-persistence.md. */
+ * Pairs with docs/features/archive/27-book-state-persistence.md. */
 
 import type { BookStateJson } from './scan.js';
 import { writeJsonAtomic, readJsonWithRecovery } from './state-io.js';

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -6,7 +6,7 @@ import { defineConfig } from 'vitest/config';
    subprocess spawn + libmp3lame init costs a few hundred ms cold.
 
    Pool concurrency is capped (maxForks=2) and one retry is allowed: see
-   docs/features/45-vitest-pool-tuning.md for the rationale. The default
+   docs/features/archive/45-vitest-pool-tuning.md for the rationale. The default
    forks pool grows to N=logical-CPUs (16+ on dev boxes); with subprocess-
    spawning tests (ffmpeg, supertest servers, sidecar mocks) that exhausts
    pipe/handle budgets and one worker dies mid-suite ("Worker exited

--- a/skills/audiobook-character-detection-per-chapter.md
+++ b/skills/audiobook-character-detection-per-chapter.md
@@ -151,7 +151,7 @@ bodyguards / mentors / family on the roster even when their attributed
 line count would normally fold them into the unknown-male / unknown-female
 buckets. Without this signal, characters like Grizel and Sandor (Lost
 Cities Neverseen — see
-`docs/features/97-narrator-only-named-characters.md`) get silently
+`docs/features/archive/97-narrator-only-named-characters.md`) get silently
 erased from the cast at the post-stage-2 fold pass.
 
 If a character previously had dialogue in an earlier chapter (already on

--- a/src/components/analysing/phase-card.test.tsx
+++ b/src/components/analysing/phase-card.test.tsx
@@ -1,4 +1,4 @@
-// Pairs with docs/features/04-analysing-view-progress.md
+// Pairs with docs/features/archive/04-analysing-view-progress.md
 
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';

--- a/src/components/layout.test.tsx
+++ b/src/components/layout.test.tsx
@@ -1,4 +1,4 @@
-/* Pairs with docs/features/27-book-state-persistence.md.
+/* Pairs with docs/features/archive/27-book-state-persistence.md.
 
    Pins the per-book hydration effect's revisions branch: when the user
    lands on a book stage and `getBookState` resolves with a `revisions`

--- a/src/components/manuscript-diff.test.tsx
+++ b/src/components/manuscript-diff.test.tsx
@@ -1,4 +1,4 @@
-// Pairs with docs/features/74-manuscript-diff-on-reupload.md
+// Pairs with docs/features/archive/74-manuscript-diff-on-reupload.md
 
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';

--- a/src/hooks/use-local-analyzer-guard.tsx
+++ b/src/hooks/use-local-analyzer-guard.tsx
@@ -19,7 +19,7 @@
        </>
      );
 
-   Pairs with docs/features/31-sticky-generation.md.
+   Pairs with docs/features/archive/31-sticky-generation.md.
 
    Reverse direction (D2 in plan 32): the symmetric guard — gate
    TTS-start callsites when a local analysis is alive — lives in
@@ -31,7 +31,7 @@
    `src/views/generation.tsx` and at the three regenerate-modal
    onConfirm callbacks in `src/components/layout.tsx`. The implicit
    reconcile-driven generation start is intentionally NOT gated; see
-   docs/features/32-sticky-analysis.md for the rationale. */
+   docs/features/archive/32-sticky-analysis.md for the rationale. */
 
 import { useState, type ReactNode } from 'react';
 import { useAppDispatch, useAppSelector } from '../store';

--- a/src/hooks/use-reverse-local-analyzer-guard.test.tsx
+++ b/src/hooks/use-reverse-local-analyzer-guard.test.tsx
@@ -7,7 +7,7 @@
      - Title fallback chain: body uses the snapshot's bookTitle when set,
        else the library entry, else the bookId.
 
-   Pairs with docs/features/32-sticky-analysis.md (D2). */
+   Pairs with docs/features/archive/32-sticky-analysis.md (D2). */
 
 import { describe, it, expect, vi } from 'vitest';
 import { configureStore } from '@reduxjs/toolkit';

--- a/src/lib/api-analysis-state.test.ts
+++ b/src/lib/api-analysis-state.test.ts
@@ -5,7 +5,7 @@
    the 404→null short-circuit, the non-200→throw branch, and the
    pass-through of the response body. Layout integration is
    exercised end-to-end via the acceptance walkthrough in
-   docs/features/32-sticky-analysis.md. */
+   docs/features/archive/32-sticky-analysis.md. */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { api } from './api';

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1961,7 +1961,7 @@ export interface components {
              *     frontend can update `chapter.audioModelKey` without waiting
              *     for a state.json reload (which would otherwise let an
              *     engine-drift badge appear only after page navigation). See
-             *     `docs/features/35-engine-drift-detection.md`.
+             *     `docs/features/archive/35-engine-drift-detection.md`.
              * @enum {string}
              */
             audioModelKey?: "kokoro-v1" | "qwen3-tts-0.6b" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
@@ -2576,7 +2576,7 @@ export interface components {
              *     segments file for legacy chapters. Absent on never-rendered
              *     chapters. The frontend compares against the project's
              *     current `ui.ttsModelKey` to surface engine-drift badges (see
-             *     `docs/features/35-engine-drift-detection.md`).
+             *     `docs/features/archive/35-engine-drift-detection.md`).
              * @enum {string}
              */
             audioModelKey?: "kokoro-v1" | "qwen3-tts-0.6b" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";

--- a/src/lib/api.mock-state.test.ts
+++ b/src/lib/api.mock-state.test.ts
@@ -1,4 +1,4 @@
-/* Pairs with docs/features/27-book-state-persistence.md.
+/* Pairs with docs/features/archive/27-book-state-persistence.md.
 
    Covers the in-memory mock backing store for book state — the round-trip
    contract that lets jsdom tests and design fixtures exercise the persist

--- a/src/lib/generation-progress.test.ts
+++ b/src/lib/generation-progress.test.ts
@@ -1,4 +1,4 @@
-// Pairs with docs/features/16-generation-stream.md
+// Pairs with docs/features/archive/16-generation-stream.md
 
 import { describe, expect, it } from 'vitest';
 import {

--- a/src/lib/manuscript-diff.test.ts
+++ b/src/lib/manuscript-diff.test.ts
@@ -1,4 +1,4 @@
-// Pairs with docs/features/74-manuscript-diff-on-reupload.md
+// Pairs with docs/features/archive/74-manuscript-diff-on-reupload.md
 
 import { describe, it, expect } from 'vitest';
 import {

--- a/src/lib/play-sample-with-auto-load.test.ts
+++ b/src/lib/play-sample-with-auto-load.test.ts
@@ -1,4 +1,4 @@
-/* Pairs with docs/features/10-profile-drawer.md — the JIT TTS load path
+/* Pairs with docs/features/archive/10-profile-drawer.md — the JIT TTS load path
    triggered by the profile-drawer / cast-row Play button. */
 
 import { describe, expect, it, vi, beforeEach } from 'vitest';

--- a/src/lib/router.test.ts
+++ b/src/lib/router.test.ts
@@ -1,4 +1,4 @@
-// Pairs with docs/features/01-hash-router.md
+// Pairs with docs/features/archive/01-hash-router.md
 
 import { describe, expect, it } from 'vitest';
 import { stageToHash, stageEqual } from './router';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -288,7 +288,7 @@ export interface DroppedQuotesResponse {
    reload + server restart. Matches the on-disk
    .audiobook/analysis-state.json shape one-for-one (the server
    returns it verbatim once the running→paused coercion has been
-   applied). See docs/features/32-sticky-analysis.md "Cold-boot
+   applied). See docs/features/archive/32-sticky-analysis.md "Cold-boot
    rehydration". */
 /** Wire shape for `GET /api/library/active-analyses` — every book in the
     workspace whose `.audiobook/analysis-state.json` snapshot resolves to

--- a/src/modals/drift-report.test.tsx
+++ b/src/modals/drift-report.test.tsx
@@ -1,4 +1,4 @@
-/* Pairs with docs/features/35-engine-drift-detection.md and the
+/* Pairs with docs/features/archive/35-engine-drift-detection.md and the
    drift-report-fidelity plan.
 
    Covers:

--- a/src/modals/export-audiobook.test.tsx
+++ b/src/modals/export-audiobook.test.tsx
@@ -1,4 +1,4 @@
-/* Pairs with docs/features/32-audiobook-export.md.
+/* Pairs with docs/features/archive/32-audiobook-export.md.
 
    Covers the modal's job lifecycle: open, render both tabs, submit,
    poll a job through in_progress → done, and surface a 409

--- a/src/modals/profile-drawer.test.tsx
+++ b/src/modals/profile-drawer.test.tsx
@@ -1,4 +1,4 @@
-// Pairs with docs/features/10-profile-drawer.md
+// Pairs with docs/features/archive/10-profile-drawer.md
 
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';

--- a/src/routes/index.test.tsx
+++ b/src/routes/index.test.tsx
@@ -1,4 +1,4 @@
-// Pairs with docs/features/00-stage-machine.md and 21-book-library.md
+// Pairs with docs/features/archive/00-stage-machine.md and 21-book-library.md
 //
 // Regression for the "No manuscript loaded" banner that appeared on the
 // Analysing screen after a page refresh / deep link / confirm→reanalyse:
@@ -239,7 +239,7 @@ describe('AnalysingRoute manuscriptId derivation', () => {
        now matters. In real usage both ids ARE the same — the upload
        seeds both — so we test the realistic shape here. The
        precedence-when-divergent question is captured as a follow-up
-       TODO in docs/features/00-stage-machine.md.) */
+       TODO in docs/features/archive/00-stage-machine.md.) */
     const store = makeStore();
     store.dispatch(uiActions.startNewBook());
     store.dispatch(uiActions.manuscriptUploaded({ bookId: 'b1', manuscriptId: 'mns-from-upload' }));

--- a/src/store/analysis-slice.test.ts
+++ b/src/store/analysis-slice.test.ts
@@ -1,4 +1,4 @@
-/* Pairs with docs/features/32-sticky-analysis.md.
+/* Pairs with docs/features/archive/32-sticky-analysis.md.
 
    The analysis slice is intentionally narrow: an out-of-band snapshot for
    the (future B3) AnalysisPill, plus a paused/halted flag that the

--- a/src/store/analysis-stream-middleware.test.ts
+++ b/src/store/analysis-stream-middleware.test.ts
@@ -1,4 +1,4 @@
-/* Pairs with docs/features/32-sticky-analysis.md.
+/* Pairs with docs/features/archive/32-sticky-analysis.md.
 
    Pre-D1 this file pinned only the pause-bridge: setPaused →
    api.pauseAnalysis. D1 grew the middleware into a full reconcile

--- a/src/store/analysis-stream-middleware.ts
+++ b/src/store/analysis-stream-middleware.ts
@@ -37,7 +37,7 @@
    dispatching the snapshot subset is intentional and idempotent: the
    slice's applyAnalysisSnapshotTick takes the latest tick.
 
-   Pairs with docs/features/32-sticky-analysis.md. */
+   Pairs with docs/features/archive/32-sticky-analysis.md. */
 
 import type { Dispatch, Middleware } from '@reduxjs/toolkit';
 import { api, AnalysisError } from '../lib/api';

--- a/src/store/cast-slice.test.ts
+++ b/src/store/cast-slice.test.ts
@@ -1,4 +1,4 @@
-// Pairs with docs/features/09-voice-match-pipeline.md
+// Pairs with docs/features/archive/09-voice-match-pipeline.md
 
 import { describe, expect, it } from 'vitest';
 import { castSlice, castActions } from './cast-slice';

--- a/src/store/chapters-slice.test.ts
+++ b/src/store/chapters-slice.test.ts
@@ -1,4 +1,4 @@
-// Pairs with docs/features/16-generation-stream.md
+// Pairs with docs/features/archive/16-generation-stream.md
 
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import {

--- a/src/store/generation-stream-middleware.ts
+++ b/src/store/generation-stream-middleware.ts
@@ -68,7 +68,7 @@ function bookIdFromState(s: StreamableRootState): string | null {
    start is now an explicit user action, never a side effect of navigation. NOT
    the regen actions either (those enqueue explicitly via their own callsites) and
    NOT applyGenerationTick (the runner self-drives ticks). See
-   docs/features/137-reopen-never-auto-enqueues.md. */
+   docs/features/archive/137-reopen-never-auto-enqueues.md. */
 const ENQUEUE_TRIGGER_TYPES = new Set<string>(['ui/requestStartGeneration']);
 
 export function generationStreamMiddleware(getRunner: () => StreamRunner): Middleware {

--- a/src/store/manuscript-slice.test.ts
+++ b/src/store/manuscript-slice.test.ts
@@ -1,4 +1,4 @@
-// Pairs with docs/features/12-manuscript-view.md
+// Pairs with docs/features/archive/12-manuscript-view.md
 
 import { describe, expect, it } from 'vitest';
 import { manuscriptSlice, manuscriptActions } from './manuscript-slice';

--- a/src/store/ui-slice.test.ts
+++ b/src/store/ui-slice.test.ts
@@ -1,4 +1,4 @@
-// Pairs with docs/features/00-stage-machine.md, docs/features/01-hash-router.md
+// Pairs with docs/features/archive/00-stage-machine.md, docs/features/archive/01-hash-router.md
 
 import { describe, expect, it } from 'vitest';
 import { uiSlice, uiActions, type UiState } from './ui-slice';

--- a/src/store/ui-slice.ts
+++ b/src/store/ui-slice.ts
@@ -213,7 +213,7 @@ export const uiSlice = createSlice({
        no state and never persists — it exists solely so the generation-stream
        middleware can auto-enqueue the book's queued chapters on this ONE action
        and never on a passive open/hydrate/view-switch. See
-       docs/features/137-reopen-never-auto-enqueues.md. */
+       docs/features/archive/137-reopen-never-auto-enqueues.md. */
     requestStartGeneration: () => {},
     setCurrentChapterId: (s, a: PayloadAction<number>) => {
       if (s.stage.kind !== 'ready') return;

--- a/src/views/analysing.test.tsx
+++ b/src/views/analysing.test.tsx
@@ -1,4 +1,4 @@
-// Pairs with docs/features/04-analysing-view-progress.md
+// Pairs with docs/features/archive/04-analysing-view-progress.md
 
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';

--- a/src/views/book-library.test.tsx
+++ b/src/views/book-library.test.tsx
@@ -1,5 +1,5 @@
 /* BookLibraryView — three-state render: skeleton / empty / populated.
-   Pairs with docs/features/21-book-library.md (Loading affordance section). */
+   Pairs with docs/features/archive/21-book-library.md (Loading affordance section). */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { configureStore } from '@reduxjs/toolkit';

--- a/src/views/confirm-cast.test.tsx
+++ b/src/views/confirm-cast.test.tsx
@@ -1,7 +1,7 @@
 /* ConfirmCastView — verifies that a character carrying matchedFrom from
    the voice-match response renders the "Matched · N%" pill and lands in
    the "Reuse" decision tile by default. Pairs with
-   docs/features/09-voice-match-pipeline.md. */
+   docs/features/archive/09-voice-match-pipeline.md. */
 
 import { describe, it, expect, vi } from 'vitest';
 import { configureStore } from '@reduxjs/toolkit';

--- a/src/views/confirm-metadata.test.tsx
+++ b/src/views/confirm-metadata.test.tsx
@@ -1,5 +1,5 @@
 /* ConfirmMetadataView — Book # input behaviour and Submit gating.
-   Pairs with docs/features/03-import-confirm-metadata.md. */
+   Pairs with docs/features/archive/03-import-confirm-metadata.md. */
 
 import { describe, it, expect } from 'vitest';
 import { configureStore } from '@reduxjs/toolkit';

--- a/src/views/generation.test.tsx
+++ b/src/views/generation.test.tsx
@@ -1,4 +1,4 @@
-// Pairs with docs/features/16-generation-stream.md
+// Pairs with docs/features/archive/16-generation-stream.md
 
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';

--- a/src/views/upload.test.tsx
+++ b/src/views/upload.test.tsx
@@ -1,5 +1,5 @@
-// Pairs with docs/features/02-upload-paste-or-file.md (existing path)
-//       AND docs/features/74-manuscript-diff-on-reupload.md (new path).
+// Pairs with docs/features/archive/02-upload-paste-or-file.md (existing path)
+//       AND docs/features/archive/74-manuscript-diff-on-reupload.md (new path).
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { configureStore } from '@reduxjs/toolkit';

--- a/src/views/voices.test.tsx
+++ b/src/views/voices.test.tsx
@@ -1,4 +1,4 @@
-// Pairs with docs/features/22-voice-library.md
+// Pairs with docs/features/archive/22-voice-library.md
 
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { act, render, screen, fireEvent, within, waitFor } from '@testing-library/react';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     ],
     /* One retry to absorb transient jsdom/timer flakes inside a single
        verify run instead of forcing a full pre-push re-execution. See
-       docs/features/45-vitest-pool-tuning.md. Pool concurrency left at
+       docs/features/archive/45-vitest-pool-tuning.md. Pool concurrency left at
        Vitest's defaults — jsdom suites are CPU-bound, not subprocess-
        bound; the server suite is where the worker-crash pattern lives. */
     retry: 1,


### PR DESCRIPTION
## Summary

Closes backlog `ops-6`. Follow-up to the plan-archiving sweep (#345), which moved 56 shipped plans into `docs/features/archive/` and fixed the rendered markdown links but deliberately left plain-text path pointers in source comments untouched (so that PR could stay on the doc-only CI fast-path).

This repoints all **58** such references from `docs/features/<NN>.md` → `docs/features/archive/<NN>.md`, for the exact set of moved plans only:
- e2e specs, server + frontend source/tests, `scripts/`, `openapi.yaml`, `skills/`, the PR template, and the generated `src/lib/api-types.ts`.
- `openapi.yaml` + `api-types.ts` kept in sync via `npm run openapi:types` (the two engine-drift description lines).

Intentionally **left alone**: pre-existing stale/typo refs (e.g. `06-manuscript-parsing.md`, `22-book-library.md`) and refs to plans archived in earlier rounds (`102`/`104`/`109`) — none are in this move's set.

Comment-only change — no behaviour, no types affected.

## Test plan

- [x] `npm run typecheck` green.
- [x] `npm run openapi:types` produces no further diff (hand-edit matches generator).
- [x] `git grep "docs/features/<moved-slug>.md" | grep -v archive/` → none for any moved plan.
- [x] Pre-push `npm run verify` passed.