### PR TITLE
docs(openapi,frontend): backfill openapi for not-linked-to + book-state GET

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1729,6 +1729,92 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/ExportLanInfo' }
 
+  /api/books/{bookId}/state:
+    get:
+      summary: Book-open hydrate composite (state + cast + manuscript meta + revisions + …)
+      operationId: getBookState
+      description: |
+        The single payload the layout reads when a book is opened: `state.json`,
+        the on-disk cast, lightweight manuscript meta, pending revisions/drift,
+        completed-chapter slugs, per-chapter loudness, and (fe-16) the
+        per-character render-time engine-fallback map. The full per-field shape
+        is hand-modeled in `src/lib/types.ts:BookStateResponse`; the schema here
+        enumerates the top-level keys and references the component schemas that
+        exist, keeping `state` (`BookStateJson`) and the loose `Record` maps
+        permissive rather than duplicating those large shapes.
+      parameters:
+        - { in: path, name: bookId, required: true, schema: { type: string } }
+      responses:
+        '200':
+          description: Book-open composite
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/BookStateResponse' }
+        '404':
+          description: Book not found
+
+  /api/books/{bookId}/cast/{characterId}/not-linked-to:
+    post:
+      summary: Mark a cross-book duplicate pair as intentionally separate (plan 101)
+      operationId: markNotLinkedTo
+      description: |
+        "These two cross-book characters look like duplicates to the voices-view
+        detector, but they ARE intentionally separate people (e.g. teenage
+        Sophie vs adult Sophie)." Writes a symmetric `notLinkedTo` pair to BOTH
+        books' cast.json so the duplicate-candidate predicate stops surfacing
+        the pair on either side. Cross-book only (same author + series, neither
+        standalone); self-pair and same-book pairs are rejected. Idempotent — an
+        already-present pair is a no-op on that side.
+      parameters:
+        - { in: path, name: bookId, required: true, schema: { type: string } }
+        - { in: path, name: characterId, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/NotLinkedToRequest' }
+      responses:
+        '200':
+          description: The symmetric pair that was written
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/NotLinkedToResponse' }
+        '400':
+          description: Missing fields, self-pair, or same-book pair
+        '404':
+          description: Source/other book or character not found, or not a series-mate
+        '409':
+          description: Source or other book has no cast on disk yet
+    delete:
+      summary: Undo a "different on purpose" decision (fs-11)
+      operationId: removeNotLinkedTo
+      description: |
+        Removes the symmetric `notLinkedTo` pair from BOTH books' cast.json so
+        the voices-view duplicate detector starts surfacing the pair again. Same
+        guards + body shape as the POST (cross-book only, series-mate scope,
+        self-pair rejected). Fully idempotent: an absent pair on either side is a
+        no-op for that side and the route still 200s.
+      parameters:
+        - { in: path, name: bookId, required: true, schema: { type: string } }
+        - { in: path, name: characterId, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/NotLinkedToRequest' }
+      responses:
+        '200':
+          description: The symmetric pair that was removed
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/NotLinkedToResponse' }
+        '400':
+          description: Missing fields, self-pair, or same-book pair
+        '404':
+          description: Source/other book or character not found, or not a series-mate
+        '409':
+          description: Source or other book has no cast on disk yet
+
 # ---------------------------------------------------------------------
 # Schemas
 # ---------------------------------------------------------------------
@@ -3648,3 +3734,128 @@ components:
           type: integer
           minimum: 1
           description: "Configured concurrency ceiling — the GPU_CONCURRENCY env var (default 1). Bump only after measuring VRAM headroom on the target GPU."
+
+    # --- Cross-book duplicate "not linked to" (plan 101 + fs-11) -----
+    NotLinkedToRequest:
+      type: object
+      required: [otherBookId, otherCharacterId]
+      description: |
+        The OTHER side of a cross-book pair. The source side comes from the
+        path (`bookId` + `characterId`).
+      properties:
+        otherBookId: { type: string }
+        otherCharacterId: { type: string }
+    CastCharacterRef:
+      type: object
+      required: [bookId, characterId]
+      properties:
+        bookId: { type: string }
+        characterId: { type: string }
+    NotLinkedToResponse:
+      type: object
+      required: [pair]
+      description: The symmetric pair written to (or removed from) both books.
+      properties:
+        pair:
+          type: object
+          required: [a, b]
+          properties:
+            a: { $ref: '#/components/schemas/CastCharacterRef' }
+            b: { $ref: '#/components/schemas/CastCharacterRef' }
+
+    # --- Book-open hydrate composite (GET /api/books/{bookId}/state) --
+    BookStateResponse:
+      type: object
+      description: |
+        Book-open hydrate composite. Canonical per-field shape is hand-modeled
+        in `src/lib/types.ts:BookStateResponse`; this schema enumerates the
+        top-level keys and references the component schemas that exist, keeping
+        `state` (`BookStateJson`) and the loose `Record` maps permissive rather
+        than duplicating those large shapes here.
+      required: [state, cast, manuscript, manuscriptEdits, revisions, completedSlugs, changeLog]
+      properties:
+        state:
+          type: object
+          additionalProperties: true
+          description: |
+            `BookStateJson` from `<bookDir>/.audiobook/state.json` (title,
+            author, series, castConfirmed, tags, language, …). Hand-modeled in
+            `src/lib/types.ts`; kept permissive here rather than duplicated.
+        cast:
+          type: object
+          nullable: true
+          required: [characters]
+          properties:
+            characters:
+              type: array
+              items: { $ref: '#/components/schemas/Character' }
+        manuscript:
+          type: object
+          nullable: true
+          required: [wordCount, format]
+          description: Lightweight manuscript meta pulled from the in-memory ManuscriptRecord.
+          properties:
+            wordCount: { type: integer }
+            format: { type: string }
+        manuscriptEdits:
+          type: object
+          nullable: true
+          properties:
+            sentences:
+              type: array
+              items: { $ref: '#/components/schemas/Sentence' }
+        revisions:
+          type: object
+          nullable: true
+          properties:
+            pending:
+              type: array
+              items: { $ref: '#/components/schemas/Revision' }
+            drift:
+              type: array
+              items: { $ref: '#/components/schemas/DriftEvent' }
+            dismissed:
+              type: array
+              items: { type: string }
+            acceptedSelections:
+              type: object
+              additionalProperties: true
+              description: revisionId → { segmentIndex → 'A' | 'B' } captured at accept time.
+        completedSlugs:
+          type: array
+          items: { type: string }
+          description: Slugs of chapters that already have an audio file on disk.
+        chapterLufs:
+          type: object
+          additionalProperties: true
+          description: |
+            chapterId → EBU R128 loudness sidecar payload (a `ChapterLoudness`,
+            or null when the sidecar is missing). Permissive map; the value
+            shape is `ChapterLoudness`.
+        chapterCharacters:
+          type: object
+          description: chapterId → analysed speaker ids that actually speak in the chapter.
+          additionalProperties:
+            type: array
+            items: { type: string }
+        renderedFallbackByCharacter:
+          type: object
+          description: |
+            fe-16 — characterId → the engine the character ACTUALLY rendered in
+            when it differs from its configured engine (`kokoro` when a Qwen
+            character fell back across any rendered chapter). Threaded into
+            `resolveVoiceStatus` so the cast Status pill reads
+            "Fallback (Kokoro)". Empty/absent when nothing fell back.
+          additionalProperties: { type: string }
+        changeLog:
+          type: array
+          nullable: true
+          items: { $ref: '#/components/schemas/ChangeLogEvent' }
+          description: Editorial activity trail; null when no change-log.json exists yet.
+        analysis:
+          type: object
+          description: Persistent analysis state for the analysing view's per-chapter Retry buttons.
+          properties:
+            failedChapterIds:
+              type: array
+              items: { type: integer }

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1346,6 +1346,67 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/books/{bookId}/state": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Book-open hydrate composite (state + cast + manuscript meta + revisions + …)
+         * @description The single payload the layout reads when a book is opened: `state.json`,
+         *     the on-disk cast, lightweight manuscript meta, pending revisions/drift,
+         *     completed-chapter slugs, per-chapter loudness, and (fe-16) the
+         *     per-character render-time engine-fallback map. The full per-field shape
+         *     is hand-modeled in `src/lib/types.ts:BookStateResponse`; the schema here
+         *     enumerates the top-level keys and references the component schemas that
+         *     exist, keeping `state` (`BookStateJson`) and the loose `Record` maps
+         *     permissive rather than duplicating those large shapes.
+         */
+        get: operations["getBookState"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/books/{bookId}/cast/{characterId}/not-linked-to": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Mark a cross-book duplicate pair as intentionally separate (plan 101)
+         * @description "These two cross-book characters look like duplicates to the voices-view
+         *     detector, but they ARE intentionally separate people (e.g. teenage
+         *     Sophie vs adult Sophie)." Writes a symmetric `notLinkedTo` pair to BOTH
+         *     books' cast.json so the duplicate-candidate predicate stops surfacing
+         *     the pair on either side. Cross-book only (same author + series, neither
+         *     standalone); self-pair and same-book pairs are rejected. Idempotent — an
+         *     already-present pair is a no-op on that side.
+         */
+        post: operations["markNotLinkedTo"];
+        /**
+         * Undo a "different on purpose" decision (fs-11)
+         * @description Removes the symmetric `notLinkedTo` pair from BOTH books' cast.json so
+         *     the voices-view duplicate detector starts surfacing the pair again. Same
+         *     guards + body shape as the POST (cross-book only, series-mate scope,
+         *     self-pair rejected). Fully idempotent: an absent pair on either side is a
+         *     no-op for that side and the route still 200s.
+         */
+        delete: operations["removeNotLinkedTo"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -2742,6 +2803,92 @@ export interface components {
             inFlight: number;
             /** @description Configured concurrency ceiling — the GPU_CONCURRENCY env var (default 1). Bump only after measuring VRAM headroom on the target GPU. */
             max: number;
+        };
+        /**
+         * @description The OTHER side of a cross-book pair. The source side comes from the
+         *     path (`bookId` + `characterId`).
+         */
+        NotLinkedToRequest: {
+            otherBookId: string;
+            otherCharacterId: string;
+        };
+        CastCharacterRef: {
+            bookId: string;
+            characterId: string;
+        };
+        /** @description The symmetric pair written to (or removed from) both books. */
+        NotLinkedToResponse: {
+            pair: {
+                a: components["schemas"]["CastCharacterRef"];
+                b: components["schemas"]["CastCharacterRef"];
+            };
+        };
+        /**
+         * @description Book-open hydrate composite. Canonical per-field shape is hand-modeled
+         *     in `src/lib/types.ts:BookStateResponse`; this schema enumerates the
+         *     top-level keys and references the component schemas that exist, keeping
+         *     `state` (`BookStateJson`) and the loose `Record` maps permissive rather
+         *     than duplicating those large shapes here.
+         */
+        BookStateResponse: {
+            /**
+             * @description `BookStateJson` from `<bookDir>/.audiobook/state.json` (title,
+             *     author, series, castConfirmed, tags, language, …). Hand-modeled in
+             *     `src/lib/types.ts`; kept permissive here rather than duplicated.
+             */
+            state: {
+                [key: string]: unknown;
+            };
+            cast: {
+                characters: components["schemas"]["Character"][];
+            } | null;
+            /** @description Lightweight manuscript meta pulled from the in-memory ManuscriptRecord. */
+            manuscript: {
+                wordCount: number;
+                format: string;
+            } | null;
+            manuscriptEdits: {
+                sentences?: components["schemas"]["Sentence"][];
+            } | null;
+            revisions: {
+                pending?: components["schemas"]["Revision"][];
+                drift?: components["schemas"]["DriftEvent"][];
+                dismissed?: string[];
+                /** @description revisionId → { segmentIndex → 'A' | 'B' } captured at accept time. */
+                acceptedSelections?: {
+                    [key: string]: unknown;
+                };
+            } | null;
+            /** @description Slugs of chapters that already have an audio file on disk. */
+            completedSlugs: string[];
+            /**
+             * @description chapterId → EBU R128 loudness sidecar payload (a `ChapterLoudness`,
+             *     or null when the sidecar is missing). Permissive map; the value
+             *     shape is `ChapterLoudness`.
+             */
+            chapterLufs?: {
+                [key: string]: unknown;
+            };
+            /** @description chapterId → analysed speaker ids that actually speak in the chapter. */
+            chapterCharacters?: {
+                [key: string]: string[];
+            };
+            /**
+             * @description fe-16 — characterId → the engine the character ACTUALLY rendered in
+             *     when it differs from its configured engine (`kokoro` when a Qwen
+             *     character fell back across any rendered chapter). Threaded into
+             *     `resolveVoiceStatus` so the cast Status pill reads
+             *     "Fallback (Kokoro)". Empty/absent when nothing fell back.
+             */
+            renderedFallbackByCharacter?: {
+                [key: string]: string;
+            };
+            /** @description Editorial activity trail; null when no change-log.json exists yet. */
+            changeLog: components["schemas"]["ChangeLogEvent"][] | null;
+            /** @description Persistent analysis state for the analysing view's per-chapter Retry buttons. */
+            analysis?: {
+                failedChapterIds?: number[];
+            };
         };
     };
     responses: never;
@@ -4694,6 +4841,131 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["ExportLanInfo"];
                 };
+            };
+        };
+    };
+    getBookState: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                bookId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Book-open composite */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BookStateResponse"];
+                };
+            };
+            /** @description Book not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    markNotLinkedTo: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                bookId: string;
+                characterId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["NotLinkedToRequest"];
+            };
+        };
+        responses: {
+            /** @description The symmetric pair that was written */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotLinkedToResponse"];
+                };
+            };
+            /** @description Missing fields, self-pair, or same-book pair */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Source/other book or character not found, or not a series-mate */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Source or other book has no cast on disk yet */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    removeNotLinkedTo: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                bookId: string;
+                characterId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["NotLinkedToRequest"];
+            };
+        };
+        responses: {
+            /** @description The symmetric pair that was removed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotLinkedToResponse"];
+                };
+            };
+            /** @description Missing fields, self-pair, or same-book pair */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Source/other book or character not found, or not a series-mate */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Source or other book has no cast on disk yet */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };


### PR DESCRIPTION
## Summary

Follow-up to PR #348 — backfills `openapi.yaml` for the three routes that shipped contract-by-test in the backlog-cleanup round, so the OpenAPI spec becomes the documented source of truth for them.

- **`POST /api/books/{bookId}/cast/{characterId}/not-linked-to`** (plan 101) — mark a cross-book duplicate pair as intentionally separate. Was only referenced in prose before; now a full operation.
- **`DELETE …/not-linked-to`** (fs-11) — undo a "different on purpose" decision (symmetric pair removal, idempotent).
- **`GET /api/books/{bookId}/state`** — the book-open hydrate composite, added with a new `BookStateResponse` component. The **fe-16 `renderedFallbackByCharacter`** field is documented explicitly; the large `state` (`BookStateJson`) and the loose `Record` maps are kept permissive (canonical shape stays in `src/lib/types.ts:BookStateResponse`) rather than reverse-engineered into a drift-prone half-spec.

New components: `NotLinkedToRequest`, `NotLinkedToResponse`, `CastCharacterRef`, `BookStateResponse`. Regenerated `src/lib/api-types.ts` via `npm run openapi:types` (+272 lines, additions only — no reformatting of existing types). Hand-written `api.ts` types already matched the routes, so this is a pure contract/doc backfill with no runtime change.

## Test plan

- `npm run openapi:types` regenerates cleanly (spec is valid OpenAPI 3.0.3); the generated types compile.
- Local verify was run up to `test:server` (green on isolated re-run; the one red was the known `toVoiceLike` parallel-mock flake, unrelated to a types-only diff). **CI runs the full battery here** — local hooks were skipped at the author's request because a generation run was in flight on the dev box.
- No behaviour change: contract documentation + regenerated type definitions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
