### PR TITLE
feat(sidecar): apply TF32 + high fp32-matmul precision in torch load paths

### DIFF
--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -844,6 +844,7 @@ class QwenEngine(Engine):
                 "`.\\.venv\\Scripts\\python.exe -m pip install qwen-tts` in "
                 "server/tts-sidecar."
             ) from e
+        _apply_torch_perf_flags(torch)
         attn_impl = os.environ.get("QWEN_ATTN_IMPL", "sdpa")
         # low_cpu_mem_usage=False: full CPU materialisation, no meta-device
         # skeleton, so the move below can never hit "copy out of meta tensor".

--- a/server/tts-sidecar/tests/test_torch_perf_flags.py
+++ b/server/tts-sidecar/tests/test_torch_perf_flags.py
@@ -1,0 +1,64 @@
+"""test_torch_perf_flags.py — TF32 / fp32-matmul-precision flag wiring.
+
+`_apply_torch_perf_flags` is called once in each torch load path (Coqui
+`_ensure_loaded`, Qwen `_load_qwen_model`) right after torch imports. The
+flags only affect fp32 matmuls — marginal for bf16 Qwen, a small win for
+Coqui's fp32 residuals — but like the autocast/bf16 speedups they sit
+alongside, a mis-wire is silent. So pin that the helper sets exactly the
+three intended knobs, leaves cudnn.benchmark alone, and swallows attribute
+drift instead of crashing a model load. See docs/tts-performance.md for why
+cudnn.benchmark is deliberately NOT set.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+
+import main
+
+
+def _make_stub_torch() -> Any:
+    """A torch-shaped stub that records the perf-flag assignments the helper
+    makes (the real torch.backends tree, minus the GPU)."""
+    torch = types.SimpleNamespace()
+    torch.backends = types.SimpleNamespace()
+    torch.backends.cuda = types.SimpleNamespace()
+    torch.backends.cuda.matmul = types.SimpleNamespace(allow_tf32=False)
+    torch.backends.cudnn = types.SimpleNamespace(allow_tf32=False)
+    calls: list[str] = []
+    torch.set_float32_matmul_precision = lambda p: calls.append(p)
+    torch._matmul_precision_calls = calls  # type: ignore[attr-defined]
+    return torch
+
+
+def test_apply_torch_perf_flags_sets_tf32_and_precision():
+    torch = _make_stub_torch()
+    main._apply_torch_perf_flags(torch)
+    assert torch.backends.cuda.matmul.allow_tf32 is True
+    assert torch.backends.cudnn.allow_tf32 is True
+    assert torch._matmul_precision_calls == ["high"]
+
+
+def test_apply_torch_perf_flags_leaves_cudnn_benchmark_off():
+    """cudnn.benchmark stays OFF on purpose — audiobook input lengths vary
+    wildly, so its per-shape autotune would re-fire on every new shape and
+    regress first-hit latency. Flipping it on must be a deliberate, measured
+    choice, never a side effect of this helper."""
+    torch = _make_stub_torch()
+    torch.backends.cudnn.benchmark = False
+    main._apply_torch_perf_flags(torch)
+    assert torch.backends.cudnn.benchmark is False
+
+
+def test_apply_torch_perf_flags_swallows_attribute_drift():
+    """If a future torch renames/removes one of these attributes, the helper
+    must warn and continue — a model load must never die over a perf knob."""
+
+    class _Hostile:
+        @property
+        def backends(self) -> Any:
+            raise AttributeError("torch.backends drifted")
+
+    # Must not raise.
+    main._apply_torch_perf_flags(_Hostile())


### PR DESCRIPTION
## Summary

Adds `_apply_torch_perf_flags(torch)` to the TTS sidecar and calls it once, idempotently, right after torch is imported in the Coqui (`_ensure_loaded`) and Qwen (`_load_qwen_model`) load paths. It sets `torch.backends.cuda.matmul.allow_tf32 = True`, `torch.backends.cudnn.allow_tf32 = True`, and `torch.set_float32_matmul_precision("high")`, wrapped in a best-effort try/except so any torch-version attribute drift is logged and swallowed rather than failing a model load.

**Honest scope (this is a small tidy-up, not a Qwen RTF mover):** these flags only affect *fp32* matmuls. Qwen loads in **bfloat16**, so the win is near-zero for Qwen's decode and lands mostly on Coqui's fp32 residual ops. It does **not** move the dispatch-bound Qwen RTF floor (~RTF 2, batch-16/single-worker) — that would need CUDA graphs, which stay blocked by Qwen's `DynamicCache`. On the dev box the two high-value GPU settings (NVCP "Prefer maximum performance" power mode + Hardware-Accelerated GPU Scheduling) are already on, so the OS/driver side is maxed; this is the remaining safe code knob.

`cudnn.benchmark` is **deliberately left OFF**: audiobook sentence lengths vary wildly, so its per-shape autotune would re-fire on every new shape and regress first-hit latency.

## Changes

- `server/tts-sidecar/main.py` — new `_apply_torch_perf_flags` helper + two call sites (Coqui + Qwen load paths).
- `server/tts-sidecar/tests/test_torch_perf_flags.py` — new: pins the three flags set, `cudnn.benchmark` left off, and attribute-drift tolerance.
- `server/tts-sidecar/docs/tts-performance.md` — "Knobs that DID help" gains an honest bullet (marginal-for-Qwen) + a note that the OS/driver side is already maxed.

## Test plan

- New `tests/test_torch_perf_flags.py` (3 cases) added next to `test_runtime_wiring.py`.
- ⚠️ **`npm run test:sidecar` is venv-gated and is skipped on CI** (the sidecar venv is never bootstrapped on runners), so the new pytest does **not** execute on this PR. It runs only on a dev box with the venv bootstrapped. It was authored but **not yet run** (a generation job was occupying the local GPU). Run `npm run test:sidecar` locally to confirm before relying on it.
- The change is pure flag-setting behind a defensive try/except; runtime risk is low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)