### PR TITLE
feat(sidecar): apply TF32 + high fp32-matmul precision in torch load paths

### DIFF
--- a/docs/tts-performance.md
+++ b/docs/tts-performance.md
@@ -52,7 +52,7 @@ These are the knobs that change the numbers. **Record any non-default value in t
 | `QWEN_LANGUAGE` | `English` | Default synth language; per-voice manifest overrides. |
 | `QWEN_VOICES_DIR` | `<workspace>/voices/qwen` | Designed-voice embedding cache. |
 
-Load-time (code, not env): `dtype=bfloat16` + `low_cpu_mem_usage=False` (real-tensor load — see [plan 112 post-ship fix #2](features/archive/112-qwen-synth-quick-wins.md)).
+Load-time (code, not env): `dtype=bfloat16` + `low_cpu_mem_usage=False` (real-tensor load — see [plan 112 post-ship fix #2](features/archive/112-qwen-synth-quick-wins.md)). `_apply_torch_perf_flags` (main.py) also enables TF32 once per process in each torch load path — `torch.backends.cuda.matmul.allow_tf32` / `cudnn.allow_tf32` / `set_float32_matmul_precision("high")`. These only affect **fp32** matmuls, so the win is near-zero for bf16 Qwen and lands mostly on Coqui's fp32 residuals — *not* a mover of the dispatch-bound Qwen floor. `cudnn.benchmark` is deliberately left OFF: variable audiobook input lengths make its per-shape autotune re-fire on every new shape, a net loss.
 
 **Preload — cold-start vs. resident VRAM:** `PRELOAD_KOKORO` (on; ~1 GB eager), `PRELOAD_QWEN` (off; warms on first `/load`/synth), `PRELOAD_COQUI` / `PRELOAD_COQUI_MODEL` (off / `xtts_v2`).
 

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -68,6 +68,28 @@ logging.basicConfig(
 )
 log = logging.getLogger("sidecar")
 
+
+def _apply_torch_perf_flags(torch: Any) -> None:
+    """Enable TF32 + high fp32-matmul precision once, idempotently, right
+    after torch is imported in a load path.
+
+    Scope note: these flags only affect *fp32* matmuls, so they help Coqui's
+    fp32 residual ops but barely touch Qwen, which loads in bfloat16 (see
+    `_load_qwen_model`). They are NOT a fix for the dispatch-bound Qwen RTF
+    floor — that would need CUDA graphs, which are blocked by Qwen's
+    DynamicCache (see docs/tts-performance.md). cudnn.benchmark is
+    deliberately left OFF: audiobook input lengths vary wildly, so its
+    per-shape autotune re-fires on every new shape and can regress first-hit
+    latency. Best-effort — any attribute drift across torch versions is
+    swallowed so a model load never fails over a perf knob."""
+    try:
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+        torch.set_float32_matmul_precision("high")
+    except Exception as e:  # pragma: no cover - defensive against API drift
+        log.warning("Could not apply torch perf flags (%s) — continuing.", e)
+
+
 app = FastAPI(title="audiobook-generator local TTS sidecar")
 
 
@@ -391,6 +413,8 @@ class CoquiEngine(Engine):
                 "`.\\.venv\\Scripts\\python.exe -m pip install torch torchaudio "
                 "--index-url https://download.pytorch.org/whl/cpu` in server/tts-sidecar."
             ) from e
+
+        _apply_torch_perf_flags(torch)
 
         model_id = {
             "xtts_v2": "tts_models/multilingual/multi-dataset/xtts_v2",
@@ -913,6 +937,7 @@ class QwenEngine(Engine):
                 "`.\\.venv\\Scripts\\python.exe -m pip install qwen-tts` in "
                 "server/tts-sidecar."
             ) from e
+        _apply_torch_perf_flags(torch)
         attn_impl = os.environ.get("QWEN_ATTN_IMPL", "sdpa")
         # low_cpu_mem_usage=False: full CPU materialisation, no meta-device
         # skeleton, so the move below can never hit "copy out of meta tensor".

--- a/server/tts-sidecar/tests/test_torch_perf_flags.py
+++ b/server/tts-sidecar/tests/test_torch_perf_flags.py
@@ -1,0 +1,64 @@
+"""test_torch_perf_flags.py — TF32 / fp32-matmul-precision flag wiring.
+
+`_apply_torch_perf_flags` is called once in each torch load path (Coqui
+`_ensure_loaded`, Qwen `_load_qwen_model`) right after torch imports. The
+flags only affect fp32 matmuls — marginal for bf16 Qwen, a small win for
+Coqui's fp32 residuals — but like the autocast/bf16 speedups they sit
+alongside, a mis-wire is silent. So pin that the helper sets exactly the
+three intended knobs, leaves cudnn.benchmark alone, and swallows attribute
+drift instead of crashing a model load. See docs/tts-performance.md for why
+cudnn.benchmark is deliberately NOT set.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+
+import main
+
+
+def _make_stub_torch() -> Any:
+    """A torch-shaped stub that records the perf-flag assignments the helper
+    makes (the real torch.backends tree, minus the GPU)."""
+    torch = types.SimpleNamespace()
+    torch.backends = types.SimpleNamespace()
+    torch.backends.cuda = types.SimpleNamespace()
+    torch.backends.cuda.matmul = types.SimpleNamespace(allow_tf32=False)
+    torch.backends.cudnn = types.SimpleNamespace(allow_tf32=False)
+    calls: list[str] = []
+    torch.set_float32_matmul_precision = lambda p: calls.append(p)
+    torch._matmul_precision_calls = calls  # type: ignore[attr-defined]
+    return torch
+
+
+def test_apply_torch_perf_flags_sets_tf32_and_precision():
+    torch = _make_stub_torch()
+    main._apply_torch_perf_flags(torch)
+    assert torch.backends.cuda.matmul.allow_tf32 is True
+    assert torch.backends.cudnn.allow_tf32 is True
+    assert torch._matmul_precision_calls == ["high"]
+
+
+def test_apply_torch_perf_flags_leaves_cudnn_benchmark_off():
+    """cudnn.benchmark stays OFF on purpose — audiobook input lengths vary
+    wildly, so its per-shape autotune would re-fire on every new shape and
+    regress first-hit latency. Flipping it on must be a deliberate, measured
+    choice, never a side effect of this helper."""
+    torch = _make_stub_torch()
+    torch.backends.cudnn.benchmark = False
+    main._apply_torch_perf_flags(torch)
+    assert torch.backends.cudnn.benchmark is False
+
+
+def test_apply_torch_perf_flags_swallows_attribute_drift():
+    """If a future torch renames/removes one of these attributes, the helper
+    must warn and continue — a model load must never die over a perf knob."""
+
+    class _Hostile:
+        @property
+        def backends(self) -> Any:
+            raise AttributeError("torch.backends drifted")
+
+    # Must not raise.
+    main._apply_torch_perf_flags(_Hostile())


### PR DESCRIPTION
## Summary

Adds `_apply_torch_perf_flags(torch)` to the TTS sidecar and calls it once, idempotently, right after torch is imported in the Coqui (`_ensure_loaded`) and Qwen (`_load_qwen_model`) load paths. It sets `torch.backends.cuda.matmul.allow_tf32 = True`, `torch.backends.cudnn.allow_tf32 = True`, and `torch.set_float32_matmul_precision("high")`, wrapped in a best-effort try/except so any torch-version attribute drift is logged and swallowed rather than failing a model load.

**Honest scope (small tidy-up, not a Qwen RTF mover):** these flags only affect *fp32* matmuls. Qwen loads in **bfloat16**, so the win is near-zero for Qwen's decode and lands mostly on Coqui's fp32 residual ops. It does **not** move the dispatch-bound Qwen RTF floor (~RTF 2) — that would need CUDA graphs, which stay blocked by Qwen's `DynamicCache`. On the dev box the two high-value GPU settings (NVCP "Prefer maximum performance" power mode + Hardware-Accelerated GPU Scheduling) are already on, so the OS/driver side is maxed; this is the remaining safe code knob.

`cudnn.benchmark` is **deliberately left OFF**: audiobook sentence lengths vary wildly, so its per-shape autotune would re-fire on every new shape and regress first-hit latency.

## Changes (3 files)

- `server/tts-sidecar/main.py` — new `_apply_torch_perf_flags` helper (defined once at module scope) + two call sites (Coqui + Qwen load paths).
- `server/tts-sidecar/tests/test_torch_perf_flags.py` — new: pins the three flags set, `cudnn.benchmark` left off, and attribute-drift tolerance.
- `docs/tts-performance.md` — "Settings & env vars that affect performance" gains the TF32 load-time note with the honest marginal-for-Qwen framing.

## Test plan

- `tests/test_torch_perf_flags.py` (3 cases) **run locally against the sidecar venv: 3 passed** (exit 0). `import main` succeeds, confirming the helper is defined at module scope (no orphaned call).
- ⚠️ `npm run test:sidecar` is venv-gated and a sidecar-only PR's `verify` job is **skipped on CI**, so the suite does not run on this PR — the local run above is the verification.
- Pure flag-setting behind a defensive try/except; runtime risk is low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)