### PR TITLE
fix(frontend): narrow per-character progress bar to free up cast-name width

### DIFF
--- a/src/views/generation.tsx
+++ b/src/views/generation.tsx
@@ -1229,7 +1229,7 @@ function ChapterRow({
               return (
                 <div
                   key={cid}
-                  className="grid grid-cols-[16px_minmax(0,1fr)_auto_44px] sm:grid-cols-[20px_1fr_140px_128px_28px] items-center gap-2 sm:gap-4 py-1.5 text-sm group"
+                  className="grid grid-cols-[16px_minmax(0,1fr)_auto_44px] sm:grid-cols-[20px_1fr_96px_128px_28px] items-center gap-2 sm:gap-4 py-1.5 text-sm group"
                 >
                   <ColorDot color={c.color as CharColor} size={8} />
                   {/* Name + line/word stat row: stacks vertically on phone


### PR DESCRIPTION
## Summary

The expanded-chapter cast list truncated character names aggressively — "Councilo…", "Sophie F…", "Lady Alexi…" — because the flexible `1fr` name column was competing with a fixed **140px** green per-character progress-bar column (plus the 128px status column and 16px gaps). This narrows the progress-bar column to **96px** so the freed ~44px flows straight into the name column. The bar renders full-width inside its grid cell, so it simply draws shorter; no other layout impact across any state (Done / Generating… / partial / Queued / Failed). Single-line presentational change in `src/views/generation.tsx` (the `ChapterRow` cast-row grid template). Mobile template, gaps, status column, and regenerate button are untouched.

## Test plan

- `npm run verify` — full battery (lint + typecheck + frontend + server + server-slow + e2e + build) passed locally before push.
- No unit test asserts on this grid template; this is a presentational column-width tweak with no behavioural seam to cover. Existing specs stay green.
- Manual: expanded a chapter with long cast names and confirmed more characters render before the ellipsis while the green bars stay clearly readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
