### PR TITLE
docs(docs): security review 2026-05-31 + backlog findings

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -106,6 +106,16 @@ Source: net-new (2026-05-30), from the live leak investigation (plan 143 + the u
 - _Key files:_ `server/tts-sidecar/main.py` (model load / mkldnn flag), `server/src/tts/synthesise-chapter.ts` (batch shaping / bucketing), `server/src/tts/spawn-sidecar.ts` (env injection like `PYTORCH_CUDA_ALLOC_CONF`).
 - _Benefit (user / technical):_ no mid-run recycle interruptions or dropped in-flight chapters (`srv-17c`) on long books — the cleanest end-to-end improvement now that RTF is acceptable. Pairs with `srv-17c` (drain/requeue the in-flight chapter): fixing the leak removes the recycle that triggers it. The `docs/tts-performance.md` "open levers" list points here as the next thing to play with.
 
+### `srv-19` — Default-bind the server to loopback; require an explicit opt-in to expose all interfaces
+
+Source: net-new (2026-05-31), from the [security review](security/2026-05-31-security-review.md) (findings #1 + #2). The default HTTP dev mode (`app.listen(PORT)` with no host) binds `0.0.0.0`, so on a shared/untrusted network every unauthenticated route — including the `/workspace` static mount that serves all manuscripts + audio + `state.json`/`cast.json` — is reachable by any LAN peer. The opt-in `LAN_HTTPS` mobile flow is *meant* to be reachable; the default dev mode is not.
+
+- _What:_ pass an explicit host to the HTTP `app.listen` so the default bind is `127.0.0.1`, and only bind `0.0.0.0` when LAN mode is on (the existing `isLanHttpsEnabled()` already gates the HTTPS listener — reuse it, plus a `BIND_HOST`/`HOST` env override for power users). The LAN HTTPS path keeps binding all interfaces (unchanged). No new abstraction — one host argument threaded through the existing `listenerCallback` wiring.
+- _Acceptance:_ with no env flags, `npm start` is reachable at `http://127.0.0.1:8080` but NOT from another machine on the LAN (connection refused). `npm run start:lan` (LAN_HTTPS=1) stays reachable on the LAN exactly as today. A `BIND_HOST=0.0.0.0` (or equivalent) escape hatch restores all-interface HTTP for users who want it. New server vitest pins the host argument selection for {default, LAN, override}; the existing LAN-mode tests stay green.
+- _Key files:_ `server/src/index.ts` (the `PORT`/`LAN_HTTPS_PORT` listen block ~L360-362 + `listenerCallback`; reuse `isLanHttpsEnabled()`).
+- _Depends on:_ none.
+- _Benefit (user / technical):_ removes the "any device on the Wi-Fi can read all your books and burn your Gemini quota" exposure in the default mode, at the cost of one host argument — the cheapest meaningful hardening from the review. The deliberate mobile flow is untouched.
+
 ---
 
 ## Could — nice to have, low-cost wins
@@ -311,7 +321,71 @@ Source: net-new (2026-05-21). Plan 81 wave 4 deferred item.
 - _Depends on:_ plan 81 shipped.
 - _Benefit (user):_ touch users get every action that mouse users do, without needing to discover hidden affordances.
 
+### Security & hardening
+
+Source for the whole sub-group: the [2026-05-31 security review](security/2026-05-31-security-review.md). All are scoped to the **opt-in LAN exposure surface** (`npm run start:lan`) or local-only defense-in-depth — the app is single-user/local-first by design, so these harden the hostile-LAN and local-write threat models rather than fixing an exploited-today hole. `srv-19` (Should) is the partner default-bind fix.
+
+#### `srv-20` — Optional shared-secret token for the LAN flow
+
+Source: net-new (2026-05-31), security review findings #1–#4 (hostile-LAN scope). `srv-19` closes the default mode by binding loopback; the *deliberate* mobile flow still needs the LAN to reach it, and today does so with zero auth — so any peer on the same Wi-Fi has full unauthenticated API access while the phone/tablet is in use.
+
+- _What:_ a single shared-secret token (env-configured, surfaced in the LAN URL / QR alongside the existing cert flow) checked by a small Express middleware on `/api/*` and the `/workspace` mount when LAN mode is on. Loopback requests bypass the check (so `npm start` is unaffected). Reuse the existing LAN-URL/QR plumbing (`GET /api/export/lan`, `npm run install:cert-mobile`) to carry the token.
+- _Acceptance:_ with LAN_HTTPS=1 + a token set, a LAN request without the token gets 401; the printed LAN URL/QR embeds the token so the phone authenticates transparently; loopback requests need no token. New server vitest covers the middleware's {loopback-bypass, missing-token, valid-token} branches.
+- _Key files:_ new `server/src/middleware/lan-auth.ts`; `server/src/index.ts` (mount before routers + the `/workspace` static); `server/src/routes/export-lan.ts` (embed token in the LAN URL); `scripts/install-cert-mobile.*` (show token in QR).
+- _Depends on:_ `srv-19` (loopback-default) — the token only matters once LAN exposure is the explicit, narrowed surface.
+- _Benefit (user):_ the mobile flow stops being "open to everyone on the network" without re-introducing friction — the token rides the URL the user already scans.
+
+#### `srv-21` — Validate `sidecarUrl` (scheme + private-host allowlist) before fetch
+
+Source: net-new (2026-05-31), security review finding #3 (SSRF). `sidecarUrl` from user-settings is validated only as `z.string().min(1).max(2000)`, then fetched directly (`sidecar-health.ts` + `/load`/`/unload`). Normally self-set, but reachable via the unauthenticated settings PUT over LAN (#1), so a peer could point it at an internal service and read probe responses.
+
+- _What:_ tighten the zod validator (or a dedicated `assertSafeSidecarUrl`) to require `http`/`https` and a loopback/private-range host before any outbound fetch; reject otherwise with a clear 400 on the settings PUT.
+- _Acceptance:_ setting `sidecarUrl` to a non-http scheme or a public host is rejected at PUT time; localhost / 127.0.0.1 / LAN-private hosts still accepted; sidecar health/load/unload behave unchanged for valid URLs. New vitest covers the allow/deny matrix.
+- _Key files:_ `server/src/workspace/user-settings.ts` (the `sidecarUrl` zod field), `server/src/tts/sidecar-url.ts` or the resolver behind `getResolvedSidecarUrl()`, `server/src/routes/sidecar-health.ts`.
+- _Depends on:_ none (independent of `srv-19`/`srv-20`, but lower-risk once those land).
+- _Benefit (technical):_ closes the SSRF primitive; makes the sidecar-URL contract explicit instead of "any string we'll fetch".
+
+#### `srv-22` — Constrain / document the `sync-folder/test` write-probe path
+
+Source: net-new (2026-05-31), security review finding #4. `POST /api/user/settings/sync-folder/test` does `mkdir(recursive)` + `writeFile('ok')` + `unlink` on an arbitrary body-supplied `path` (validated as `z.string().max(2000)` only) — an arbitrary-mkdir / limited-clobber primitive reachable unauth over LAN.
+
+- _What:_ the probe is a legitimate "is this folder writable" UX check, so the fix is proportionate: keep the feature but (a) refuse obviously-dangerous targets (system roots), and/or (b) document the trust boundary explicitly and lean on `srv-19`/`srv-20` to remove the unauth-LAN reachability. Decide between hard-constraint vs. document-and-gate when the item opens.
+- _Acceptance:_ the probe still reports writability for a normal user-chosen sync folder; a system-root or traversal-y target is refused (if the hard-constraint path is chosen) or the reachability is closed by the bind/auth items; behaviour documented inline. New vitest pins the accept/refuse cases.
+- _Key files:_ `server/src/routes/user-settings.ts:128-152` (the probe handler).
+- _Depends on:_ pairs with `srv-19`/`srv-20` (which remove the unauth-LAN reach); standalone-fixable too.
+- _Benefit (technical):_ removes a small unauthenticated filesystem-touch primitive without breaking the Test button.
+
+#### `side-12` — Load Qwen voice `.pt` prompts with `weights_only=True` (or a safe format)
+
+Source: net-new (2026-05-31), security review finding #5. `main.py:1251` does `torch.load(pt_path, weights_only=False)` on cached voice prompts in `QWEN_VOICES_DIR`. The file is app-written and the sidecar binds loopback, so it's not network-reachable — but `weights_only=False` deserialises arbitrary pickled objects, so anyone who can drop a `.pt` into the voices dir gets RCE in the sidecar process.
+
+- _What:_ switch the voice-prompt load to `weights_only=True`; if the saved payload isn't a pure tensor/state-dict, migrate the design-time save (`design_voice`) to a safe container (safetensors, or JSON sidecar + tensors) so the load no longer needs arbitrary unpickling. One-time read-compat shim for already-cached `.pt` files (re-derive or one-shot re-save).
+- _Acceptance:_ a freshly designed voice round-trips (design → cache → reuse) with `weights_only=True`; a crafted malicious `.pt` no longer executes code on load (raises instead); existing cached voices still work (via shim or re-save). New pytest in the sidecar suite covers the safe-load path + the rejection.
+- _Key files:_ `server/tts-sidecar/main.py` (the `torch.load` at ~L1251 + the `design_voice` save site that writes the `.pt`); `server/tts-sidecar/tests/` (new case).
+- _Depends on:_ none.
+- _Benefit (technical):_ removes a local RCE-on-untrusted-file footgun; aligns with torch's `weights_only` default direction.
+
+#### `side-13` — Cap `/synthesize` input length
+
+Source: net-new (2026-05-31), security review finding #7. The sidecar checks for non-empty text but enforces no maximum, so a giant payload drives unbounded VRAM/CPU. Loopback-only, so low real exposure — pure resource-exhaustion hardening.
+
+- _What:_ add a generous `MAX_TEXT_LENGTH` guard (env-overridable) to the `/synthesize` (and `/design_voice`) request validation; return 400 with a clear message past the cap. Set the default well above any real per-sentence/batch payload the server sends.
+- _Acceptance:_ a normal chapter batch synthesises unchanged; an over-cap payload returns 400 without touching the model; the cap is env-tunable. New pytest covers under/over-cap.
+- _Key files:_ `server/tts-sidecar/main.py` (the `/synthesize` + `/design_voice` body validation); `server/tts-sidecar/tests/`.
+- _Depends on:_ none.
+- _Benefit (technical):_ bounds a trivial local DoS; cheap and self-contained.
+
 ### Ops, CI & distribution
+
+#### `ops-7` — Pin SHA256 for model + wheel downloads
+
+Source: net-new (2026-05-31), security review finding #6 (supply-chain). `scripts/install-kokoro.ps1` downloads GitHub-release `.onnx`/`.bin` and `server/tts-sidecar/scripts/install-qwen3.mjs` runs `pip install -U qwen-tts` plus a third-party community FlashAttention wheel from `huggingface.co/lldacing/…`. All over HTTPS (wire-MITM covered) but with **no integrity pin** — a compromised upstream account or registry package serves trojaned binaries that execute at load/install time. Matters most because these scripts run on alpha-tester machines from the release bundle.
+
+- _What:_ pin a known-good SHA256 for each downloaded artifact and verify after download (refuse + delete on mismatch): the kokoro `.onnx`/`.bin` release assets, and the FlashAttention wheel URL. For the pip installs, evaluate `pip install --require-hashes` against a pinned requirements set for the opt-in Qwen/FA2 deps (or at minimum pin exact versions). Surface a clear failure message pointing at the expected hash.
+- _Acceptance:_ a tampered/partial download fails the hash check with an actionable error and leaves nothing installed; an untampered install succeeds unchanged; the FA2 wheel install verifies its hash before `pip install`. New Pester case for the PowerShell hash check; the `install-qwen3.mjs` hash check exercised in its existing test harness.
+- _Key files:_ `scripts/install-kokoro.ps1` (post-download `Get-FileHash` compare), `server/tts-sidecar/scripts/install-qwen3.mjs` (`FLASH_ATTN_WHEEL_URL` verify + pip pinning), `scripts/lib/` if a shared verify helper is warranted, `scripts/tests/`.
+- _Depends on:_ none.
+- _Benefit (user / technical):_ closes the supply-chain gap on the binaries that run with the user's privileges on install — the sharpest of these is the single-maintainer community FA2 wheel. Cheap relative to the RCE blast radius.
 
 #### `ops-3` — Serialize the `regen-visual-baselines.yml` 3-leg matrix
 

--- a/docs/security/2026-05-31-security-review.md
+++ b/docs/security/2026-05-31-security-review.md
@@ -1,0 +1,174 @@
+# Security review — 2026-05-31
+
+A point-in-time security review of the audiobook-generator. Read-only audit; no
+code was changed in the review pass. Findings that become work are filed in
+[`../BACKLOG.md`](../BACKLOG.md) under their area prefix (cross-referenced per
+finding below).
+
+## Scope & method
+
+Reviewed: the Node/Express server (`server/src/`), the Python FastAPI TTS
+sidecar (`server/tts-sidecar/`), the PowerShell/Node install scripts
+(`scripts/`, `server/tts-sidecar/scripts/`), and the Vite/React frontend
+(`src/`) plus root config and the secret/dependency surface.
+
+Three parallel exploration sweeps produced candidate findings; every
+high-impact or uncertain claim was then **re-verified against the source** —
+several initially-flagged "Critical" items did not survive verification and are
+recorded as downgraded below, with the verification note, so the next reviewer
+doesn't re-raise them.
+
+## Threat model
+
+The app has **no authentication anywhere** — by design, for a single-user,
+local-first tool (the backlog explicitly parks multi-user collaboration:
+`fe-11`, `srv-10`, `srv-9`). Severity is therefore almost entirely a function
+of **who can reach the listener**, so every finding is rated for two scopes:
+
+- **Loopback** — the default `npm start` on a trusted personal machine. An
+  attacker already on `localhost` has bigger levers than the app.
+- **Hostile-LAN** — the documented opt-in phone/tablet flow (`npm run start:lan`)
+  deliberately binds the home Wi-Fi, *and* the default HTTP dev mode also binds
+  all interfaces (see #1). On a shared/untrusted network, every unauthenticated
+  route is reachable by any peer.
+
+This is realistic but not the common case — most users run loopback-only on a
+trusted home network. The dual-column ratings let each item be prioritized on
+its own merits.
+
+## Severity matrix
+
+| # | Finding | Loopback | Hostile-LAN | Backlog |
+|---|---------|----------|-------------|---------|
+| 1 | No auth + all-interface bind by default | Low | **High** | `srv-19`, `srv-20` |
+| 2 | `/workspace` static mount serves whole workspace (content, not secrets) | Low | **High** | `srv-19`, `srv-20` |
+| 3 | SSRF via user-set `sidecarUrl` | Low | **Medium** | `srv-21` |
+| 4 | `sync-folder/test` arbitrary-path probe write | Low | **Medium** | `srv-22` |
+| 5 | `torch.load(weights_only=False)` on cached voice `.pt` | **Medium** | Medium | `side-12` |
+| 6 | No checksum/signature pin on model + wheel downloads | **Medium** | **Medium** | `ops-7` |
+| 7 | No `/synthesize` input-length cap | **Low-Med** | Low-Med | `side-13` |
+| 8 | BroadcastChannel message shape not validated | Info | Info | — |
+| 9 | DEV/E2E `window.__store__` hooks | Info | Info | — |
+| 10 | `spawn-sidecar` port string-interpolation | Info | Info | — |
+| 12 | `server/.env` key (verified never in git) | Info | Info | — |
+
+(#11 is the "no XSS sinks" verification, recorded under *Verified secure*.)
+
+---
+
+## Findings
+
+### Worth fixing
+
+**#1 — No auth + server binds all interfaces by default.**
+`server/src/index.ts:362` — plain `app.listen(PORT)` with no host binds to
+`0.0.0.0`, not `127.0.0.1` (the file's own comment at `:231` confirms this).
+LAN HTTPS mode (`:360`) is *meant* to be reachable, but the **default HTTP dev
+mode also binds every interface**, and there is no auth on any route. A LAN peer
+can trigger Gemini analysis (burns quota/$), enumerate/download every book, and
+mutate settings/cast.
+*Direction:* bind `127.0.0.1` unless LAN mode is explicitly on (`srv-19`);
+optionally a shared-secret token for the LAN flow (`srv-20`).
+
+**#2 — `/workspace` static mount serves the entire workspace unauthenticated.**
+`server/src/index.ts:149` — `express.static(WORKSPACE_ROOT)` exposes all
+manuscripts, audio, `state.json`, `cast.json`, and queue files to anyone who can
+reach the port. **Verified the key is *not* here:** `user-settings.json` (which
+holds `geminiApiKey`) lives at `~/.audiobook-generator/`
+(`server/src/workspace/user-settings.ts:38`), *outside* `WORKSPACE_ROOT`
+(`server/src/workspace/paths.ts:31`), and `geminiApiKey` is in `FORBIDDEN_KEYS`
+(stripped from PUT/GET). So this leaks *content* (copyrighted manuscripts +
+finished audio), not credentials. Mitigated by the same bind/auth fix as #1.
+
+**#3 — SSRF via user-settable `sidecarUrl`.**
+`server/src/routes/sidecar-health.ts` (and the `/load`, `/unload` paths) fetch
+`${getResolvedSidecarUrl()}/health`, where `sidecarUrl` is validated only as
+`z.string().min(1).max(2000)` — no scheme/host check. Normally self-inflicted
+(the user sets their own sidecar URL), **but** because the settings PUT is
+unauthenticated (#1), a LAN attacker could point it at an internal service and
+read the probe responses. *Direction:* validate to `http(s)` + a private-host
+allowlist before any fetch (`srv-21`).
+
+**#4 — `sync-folder/test` writes a probe file to an arbitrary path.**
+`server/src/routes/user-settings.ts:138-142` — takes `path` from the body
+(`z.string().max(2000)` only), does `mkdir(recursive)` + `writeFile` + `unlink`.
+Content is a fixed `'ok'` immediately unlinked, so it's an **arbitrary-mkdir /
+limited-clobber** primitive, not arbitrary-content write. Reachable unauth over
+LAN (#1). *Direction:* confirm the path resolves under an expected root or at
+least document the trust boundary (`srv-22`).
+
+**#5 — Sidecar `torch.load(..., weights_only=False)` on cached voice `.pt`.**
+`server/tts-sidecar/main.py:1251` loads pickled voice prompts from
+`QWEN_VOICES_DIR`. The code correctly notes the file is app-written, and the
+**sidecar binds `127.0.0.1`** (verified, `server/tts-sidecar/start.ps1:94`), so
+this is *not* network-reachable. Residual risk: anyone who can drop a `.pt` into
+the voices dir gets RCE in the sidecar process. *Direction:* `weights_only=True`
+or a safetensors/JSON embedding format if the payload allows (`side-12`).
+
+**#6 — Model/wheel downloads have no checksum or signature pin.**
+`scripts/install-kokoro.ps1` (GitHub release `.onnx`/`.bin`) and
+`server/tts-sidecar/scripts/install-qwen3.mjs` (`pip install -U qwen-tts`, plus
+a **third-party community FlashAttention wheel** from `huggingface.co/lldacing/…`).
+All over HTTPS (wire-MITM mitigated), but **no SHA256 pin** — a compromised
+upstream account or PyPI/HF package serves trojaned binaries that execute at
+load/install. The community FA2 wheel is the sharpest (untrusted single-maintainer
+repo, opt-in via `--flash-attn`). *Direction:* pin SHA256 for the kokoro release
+assets + the FA2 wheel; consider `pip install --require-hashes` (`ops-7`).
+
+**#7 — `/synthesize` has no input-length cap.**
+`server/tts-sidecar/main.py` validates non-empty text but no max length →
+unbounded VRAM/CPU on a giant payload. Loopback-only, so low real exposure.
+*Direction:* a generous `MAX_TEXT_LENGTH` 400-guard (`side-13`).
+
+### Informational / defense-in-depth (not currently worth a fix)
+
+**#8 — BroadcastChannel messages aren't strictly shape-validated.**
+`src/store/broadcast-middleware.ts` checks `typeof msg === 'object'` then spreads
+`msg.diff` into store state. Same-origin-only by spec, and **no XSS vector
+exists** (see #11), so this is only reachable *after* a hypothetical XSS. Noted,
+not prioritized.
+
+**#9 — DEV/E2E `window.__store__` / `window.__mockQueue` hooks.**
+`src/main.tsx:50-66` — tree-shaken out of production builds. Intentional and
+documented.
+
+**#10 — `spawn-sidecar.ts` shell-string port interpolation.**
+`server/src/tts/spawn-sidecar.ts:136-146` — initially flagged as Critical command
+injection. **Verified false alarm:** `port` is a hardcoded `Number` (9000), never
+request-derived, and args go through `spawn(file, args[])`. Keep it numeric;
+don't elevate.
+
+### Verified secure
+
+- **#11 — No XSS sinks:** no `dangerouslySetInnerHTML`, `innerHTML`, `eval`,
+  `new Function`, or `javascript:` URIs anywhere in `src/`. Manuscript/chapter
+  text renders as plain JSX text.
+- **No secrets in the client bundle:** only `VITE_USE_MOCKS` / port vars are
+  `VITE_`-prefixed; the Gemini key is server-only and stripped from API responses.
+- **`.gitignore` covers** `.env`, certs/keys, workspace, venv; no `*.pem`/`*.key`
+  tracked.
+- **Sidecar binds `127.0.0.1`** by default (`start.ps1:94`), not `0.0.0.0`.
+- **Qwen voice-id path sanitization** (`main.py:1010`) correctly blocks `..`.
+
+### Verified — no action
+
+**#12 — `server/.env` contains a live Gemini API key (local hygiene only).**
+Verified this review: `git ls-files` shows the file is untracked,
+`git log --all -- server/.env` shows no commit ever touched it, and
+`git log --all -S 'AIzaSy'` shows the key prefix never appears anywhere in
+history. So this is a **correctly-gitignored local dev secret, not a
+disclosure** — no forced rotation. Optional hygiene: rotate if the dev machine
+is ever shared/imaged. (The key value is deliberately not reproduced here.)
+
+---
+
+## Follow-up tracking
+
+Items #1–#7 are filed in [`../BACKLOG.md`](../BACKLOG.md):
+`srv-19` (default-bind loopback, Should), and under a new Could "Security &
+hardening" sub-group `srv-20` (LAN auth token), `srv-21` (`sidecarUrl`
+validation), `srv-22` (sync-folder path constraint), `side-12`
+(`weights_only=True`), `side-13` (`/synthesize` length cap); plus `ops-7`
+(download checksum pinning) under Ops. Each fix ships its paired test per the
+project's testing discipline (server vitest, sidecar pytest, Pester for the
+install-script hashes).


### PR DESCRIPTION
## Summary

Read-only security review of the audiobook-generator (server, TTS sidecar, install scripts, frontend) plus a triaged report and the resulting backlog entries. **No code changes** — docs only.

Three parallel exploration sweeps produced candidate findings; every high-impact or uncertain claim was re-verified against source. Several initially-flagged "Critical" items did **not** survive verification and are recorded as downgraded so they aren't re-raised:

- The unauthenticated `/workspace` static mount leaks manuscript/audio **content** but **not** the Gemini key — `user-settings.json` lives at `~/.audiobook-generator/`, outside `WORKSPACE_ROOT`, and `geminiApiKey` is in `FORBIDDEN_KEYS` (stripped from PUT/GET).
- The `spawn-sidecar.ts` "command injection" is a hardcoded numeric port (`9000`), never request-derived.
- `server/.env` contains a live Gemini key but it was **verified never to have entered git history** (untracked; no commit ever touched it; the `AIzaSy` prefix appears nowhere in `git log -S`). Local hygiene only — not a disclosure.

Findings are rated for **both** threat models (Loopback and Hostile-LAN), because the app is single-user / local-first with no auth by design — severity hinges on who can reach the listener. The hostile-LAN scope is the opt-in `npm run start:lan` mobile flow.

### What's in this PR

- **New report:** `docs/security/2026-05-31-security-review.md` — full findings with `file:line`, the dual-column severity matrix, verification notes, and the verified-secure list (no XSS sinks, no bundled secrets, sidecar binds loopback, clean `.gitignore`).
- **Backlog entries** (`docs/BACKLOG.md`) for the 7 actionable findings:
  - `srv-19` (Should) — default-bind the server to `127.0.0.1`; require an explicit opt-in to expose all interfaces.
  - New Could **"Security & hardening"** sub-group: `srv-20` (LAN auth token), `srv-21` (`sidecarUrl` scheme/host validation — SSRF), `srv-22` (`sync-folder/test` probe-path constraint), `side-12` (`torch.load(weights_only=True)` on voice `.pt`), `side-13` (`/synthesize` length cap).
  - `ops-7` (Ops) — pin SHA256 for model + FlashAttention-wheel downloads (supply-chain).

## Test plan

Doc-only change — the doc-only CI fast-path (`paths-ignore`) skips `verify.yml`. No automated test applies to a report; each filed fix ships its own paired test when implemented (server vitest, sidecar pytest, Pester for the install-script hashes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)