### PR TITLE
fix(server): surface EADDRINUSE startup collision with an actionable message (srv-17)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -88,14 +88,13 @@ Source: net-new (2026-05-28), filed from the series-reuse repair session. Full s
 - _Benefit (user / technical):_ series continuity survives re-analysis — no re-running a repair after every reparse. Closes the remaining durability gap left after Facet A.
 - _Also remaining (follow-up, surfaced this round):_ a SECOND Phase-0b finalise site in `analysis.ts` — the failed-chapter retry/resume `runChapterCastSubset` path (~L3508, writing cast.json ~L3712) — does NOT run Facet A's link pass, so a book completed exclusively via the chapter-retry path persists an unlinked cast.json until the next full `/analysis/stream`. Belt-and-suspenders; fold into Facet B or a tiny standalone fix.
 
-### `srv-17` — Root-cause the silent server-child death (once plan 145 captures it)
+### `srv-17` — ~~Root-cause the silent server-child death~~ → RESOLVED as a startup port collision (2026-05-31)
 
-Source: net-new (2026-05-30). The generation server's `:8080` child died silently TWICE — no stack trace in `server.err.log`, no heap-OOM, and the second time RAM was 61% free (not the host-leak OOM). `tsx watch`'s wrapper survives but doesn't auto-respawn the child, so the run stalls. Plan 145 added `uncaughtException`/`unhandledRejection` handlers that LOG the cause (and survive rejections), so the NEXT occurrence should finally name what's throwing.
+Source: net-new (2026-05-30). **Resolved 2026-05-31** (branch `fix/server-listen-eaddrinuse`). Plan 145's handlers captured the crash, and it was **not** the hypothesised mid-run silent death: both `[server] FATAL uncaughtException` lines (08:34 + 14:55, `logs/server.err.log`) were `listen EADDRINUSE: address already in use :::8080` at **startup** — a double-start while a prior instance still held the port. The server never logged a mid-run FATAL across the whole run; the perceived "death" was a *stuck* server (the 14:19–14:21 recycle-drain cascade + a handled 600 s ch29 timeout — sidecar instability, see `side-11` / the recycle-drain-cascade) plus a restart that collided on `:8080`.
 
-- _What:_ once plan 145's handler logs a `[server] FATAL …` line (likely an unhandled rejection on an un-awaited/un-caught async path), trace it to the source and add the missing `await`/`.catch()` there. ~~ALSO gate generation dispatch on sidecar readiness so the startup race can't fire spurious failures.~~ **DONE — readiness-gate half shipped as plan 147 (2026-05-30):** `ensureSidecarEngineReady` now POLLS through a respawn (sidecar unreachable / model loading) instead of bailing on the first connection-refused, so a recycle-induced respawn (plan 143) no longer fires a burst of "sidecar not reachable" failures that trips the srv-11 breaker and pauses the queue (the 2026-05-30 incident). **Remaining here:** root-cause the *silent server-child death* itself (the `:8080` process dying with NO stack trace), once a `[server] FATAL …` line captures it.
-- _Acceptance:_ the root rejection/exception is fixed at its source (no longer reaches the process handler). ~~A server restart + immediate queue run doesn't fail the first chapter on "sidecar not reachable"~~ — covered by plan 147 (`ensure-sidecar-loaded.test.ts` pins the poll-through-respawn behavior).
-- _Key files:_ TBD by the captured trace; likely `server/src/routes/generation.ts` (dispatch/SSE error paths), `server/src/tts/sidecar.ts` / `retry.ts`, `server/src/tts/ensure-sidecar-loaded.ts` (readiness gate), `server/src/index.ts` (boot-time preload).
-- _Benefit (user / technical):_ removes the actual crash (plan 145 only makes it visible + survivable), so long runs don't even hit the FATAL path, and a fresh-restart run doesn't spuriously fail its first chapter.
+- _What (done):_ `app.listen` had no `'error'` handler, so the bind failure bubbled to the plan-145 `uncaughtException` handler as a cryptic stack. Added `attachListenErrorHandler(server, port)` (`server/src/crash-logging.ts`) on both the HTTP and HTTPS listeners in `index.ts`: EADDRINUSE → actionable *"Port N is already in use — another server instance is likely already running…"* + clean `exit(1)`; any other bind error → generic FATAL + stack. EADDRINUSE no longer reaches the uncaughtException path.
+- _Acceptance (met):_ paired `crash-logging.test.ts` cases pin `formatListenError` (EADDRINUSE hint vs generic FATAL) and `attachListenErrorHandler` (logs + `exit(1)`). Manual: a second `npm run dev` against an occupied `:8080` prints the actionable line, not a raw stack. Regression: `docs/features/145-server-crash-diagnostics.md` "srv-17 follow-up" section.
+- _Residual watch:_ the mid-run silent-death hypothesis was never reproduced; the plan-145 `uncaughtException`/`unhandledRejection` handlers stay armed as the ongoing watch. The run-instability that *looked* like a death is tracked under `side-11` (eliminate the host-memory leak so the sidecar stops recycling mid-run), not here.
 
 ### `side-11` — Eliminate the variable-input-shape host-memory leak (so recycling isn't needed)
 
@@ -366,26 +365,6 @@ Source: net-new (2026-05-31), security review finding #6 (supply-chain). `script
 - _Key files:_ `scripts/install-kokoro.ps1` (post-download `Get-FileHash` compare), `server/tts-sidecar/scripts/install-qwen3.mjs` (`FLASH_ATTN_WHEEL_URL` verify + pip pinning), `scripts/lib/` if a shared verify helper is warranted, `scripts/tests/`.
 - _Depends on:_ none.
 - _Benefit (user / technical):_ closes the supply-chain gap on the binaries that run with the user's privileges on install — the sharpest of these is the single-maintainer community FA2 wheel. Cheap relative to the RCE blast radius.
-
-#### `ops-3` — Serialize the `regen-visual-baselines.yml` 3-leg matrix
-
-Source: net-new (2026-05-23). Surfaced during the plan-103 CI cost audit.
-
-- _What:_ `regen-visual-baselines.yml` fans out across three Playwright projects (chromium / mobile-chrome / tablet-chrome) as a parallel matrix, paying a full cold-start (checkout + npm ci + Playwright install) per leg. Collapse into a single job that runs all three `--update-snapshots` passes sequentially, so the setup tax is paid once. Only fires on `workflow_dispatch` (~2 runs/month), so the saving is bursty rather than steady.
-- _Acceptance:_ A single `workflow_dispatch` run regenerates all 42 PNGs (14 per project × 3) in one job and still opens the auto-PR. Billed minutes for a regen drop from ~3× cold-start to ~1×.
-- _Key files:_ `.github/workflows/regen-visual-baselines.yml` (collapse `strategy.matrix.project` into a sequential step loop; consolidate the artifact upload).
-- _Depends on:_ none.
-- _Benefit (technical):_ ~60 billed min/month freed on regen days; tidier workflow.
-
-#### `ops-6` — Refresh stale `docs/features/<NN>.md` path pointers in source comments
-
-Source: net-new (2026-05-29). Fallout from the plan-archiving sweep that moved ~56 shipped plans into `docs/features/archive/`. The rendered markdown links in `CLAUDE.md` / `CONTRIBUTING.md` / `README.md` / `BACKLOG.md` / `INDEX.md` were updated in that same PR, but plain-text "Pairs with `docs/features/<NN>-…md`" pointers in `.ts` / `.tsx` test + source comments, `openapi.yaml` description strings, and `skills/*.md` were intentionally left alone — editing them would have broken the doc-only CI fast-path and coupled unrelated scope into a docs PR.
-
-- _What:_ Sweep the non-doc tree for `docs/features/<NN>-…md` comment pointers to now-archived plans and rewrite them to `docs/features/archive/<NN>-…md`. Mechanical; group into one commit. (~40 files: see `git grep "docs/features/" -- '*.ts' '*.tsx' '*.mjs' openapi.yaml skills`.)
-- _Acceptance:_ `git grep "docs/features/[0-9]" -- '*.ts' '*.tsx' '*.mjs' openapi.yaml skills | grep -v archive/` returns only references to plans that are still top-level (active/deferred).
-- _Key files:_ assorted `*.test.ts(x)` + `server/src/**` comments, `openapi.yaml`, `skills/audiobook-character-detection-per-chapter.md`.
-- _Depends on:_ none.
-- _Benefit (technical):_ a dev following a "Pairs with …" pointer lands on the file instead of a 404; keeps the regression-plan ↔ test linkage navigable. Low urgency — the plans are findable by slug via `git grep`.
 
 #### `srv-4` — Track upstream-blocked deprecation chains (~~jsdom~~ · ~~archiver~~ · @google/genai)
 

--- a/docs/features/145-server-crash-diagnostics.md
+++ b/docs/features/145-server-crash-diagnostics.md
@@ -31,6 +31,25 @@ The likeliest trigger: an **unhandled promise rejection** on an un-awaited/un-ca
 
 If a future crash STILL leaves no log, it's native/external (segfault, OS/AV kill) — itself a diagnostic narrowing.
 
+## srv-17 follow-up — what the handlers captured (2026-05-31)
+
+The handlers worked, and the captured evidence **disproved the mid-run silent-death hypothesis above**. Across a full 2026-05-31 generation run, the server never logged a mid-run FATAL. The only two `[server] FATAL uncaughtException` lines (`logs/server.err.log`, 08:34 and 14:55) were both:
+
+```
+[server] FATAL uncaughtException — Error: listen EADDRINUSE: address already in use :::8080
+    at app.listen (…/express/lib/application.js:635)
+    at <anonymous> (…/server/src/index.ts)
+```
+
+i.e. a **startup port collision**, not a process dying mid-run. The timeline shows the server stayed alive throughout: the 14:19–14:21 churn was the recycle-drain cascade (ch17–28 all 503'd while the sidecar recycled — `side-11` / the recycle-drain-cascade), and ch29 hit a *handled* 600 s `ChapterSynthTimeoutError` at 14:37. At 14:55 a **second** server instance tried to bind `:8080` while the first still held it → the bind error bubbled to `uncaughtException` as a cryptic stack. The perceived "silent death" was a *stuck* server (sidecar instability) plus a restart that collided on the port — not a server crash.
+
+**The fix:** `attachListenErrorHandler(server, port)` (in `crash-logging.ts`) is now attached to the listener on both the HTTP and HTTPS paths in `index.ts`. A bind failure is intercepted on the listener's own `'error'` event:
+
+- **`EADDRINUSE`** → `formatListenError` prints an actionable line — *"Port N is already in use — another server instance is likely already running. Stop it first … or set PORT to a free port, then retry."* — then `exit(1)`.
+- **Any other bind error** → a generic `[server] FATAL listen error on port N — <stack>` + `exit(1)`.
+
+Because the handler lives on the listener, EADDRINUSE no longer reaches the `uncaughtException` path — cleaner attribution, actionable message. The plan-145 `uncaughtException`/`unhandledRejection` handlers stay in place as the ongoing watch for a genuine mid-run FATAL (none observed to date).
+
 ## Architectural impact
 
 - **New seam:** `crash-logging.ts` (`formatCrash`, `installCrashHandlers` with injectable `onLog`/`onExit`/`target` for tests).
@@ -44,9 +63,9 @@ If a future crash STILL leaves no log, it's native/external (segfault, OS/AV kil
 
 ## Test plan
 
-Automated (`npm run test:server`, `crash-logging.test.ts`): `formatCrash` carries the Error stack / stringifies a non-Error reason; `uncaughtException` → `onLog` + `onExit(1)`; `unhandledRejection` → `onLog` (incl. "survived") + NO exit. Driven via an injected `EventEmitter` so the real process is untouched.
+Automated (`npm run test:server`, `crash-logging.test.ts`): `formatCrash` carries the Error stack / stringifies a non-Error reason; `uncaughtException` → `onLog` + `onExit(1)`; `unhandledRejection` → `onLog` (incl. "survived") + NO exit. **srv-17 cases:** `formatListenError` EADDRINUSE → actionable "already in use" hint naming the port (not a raw FATAL dump); non-EADDRINUSE → generic FATAL line + stack; `attachListenErrorHandler` emits `error` against an injected `EventEmitter` → `onLog` + `onExit(1)` for both EADDRINUSE and a generic bind error. Driven via injected emitters so the real process is untouched.
 
-Manual acceptance (pending): on the next server crash, confirm `server.err.log` now contains a `[server] FATAL …` line naming the cause; confirm a transient sidecar-fetch rejection is logged-and-survived rather than killing the run.
+Manual acceptance: ✅ the next FATAL **was** captured (two EADDRINUSE startup collisions, 2026-05-31). After this fix — with the app already on `:8080`, start a second `cd server && npm run dev` → `server.err.log` shows the actionable `Port 8080 is already in use …` line + clean exit, NOT a `FATAL uncaughtException` stack. The mid-run silent-death watch (plan-145 handlers) remains armed.
 
 ## Ship notes
 

--- a/server/src/crash-logging.test.ts
+++ b/server/src/crash-logging.test.ts
@@ -6,7 +6,12 @@
  * so the test drives the handlers without touching the real process. */
 import { describe, it, expect, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
-import { formatCrash, installCrashHandlers } from './crash-logging.js';
+import {
+  formatCrash,
+  installCrashHandlers,
+  formatListenError,
+  attachListenErrorHandler,
+} from './crash-logging.js';
 
 describe('formatCrash', () => {
   it('includes the kind and the Error stack', () => {
@@ -47,5 +52,56 @@ describe('installCrashHandlers', () => {
     expect(onLog).toHaveBeenCalledWith(expect.stringContaining('transient sidecar fetch failed'));
     expect(onLog).toHaveBeenCalledWith(expect.stringContaining('survived'));
     expect(onExit).not.toHaveBeenCalled(); // the run keeps serving
+  });
+});
+
+/* srv-17 — the captured FATALs were `listen EADDRINUSE` at startup (a
+ * double-start), not a mid-run death. These pin the actionable bind-error
+ * handling that keeps EADDRINUSE off the uncaughtException path. */
+describe('formatListenError', () => {
+  it('EADDRINUSE → actionable "already in use" hint naming the port', () => {
+    const err: NodeJS.ErrnoException = Object.assign(new Error('listen EADDRINUSE'), {
+      code: 'EADDRINUSE',
+    });
+    const line = formatListenError(8080, err);
+    expect(line).toContain('8080');
+    expect(line).toContain('already in use');
+    expect(line).toContain('already running'); // points at the double-start cause
+    expect(line).not.toContain('FATAL'); // friendly, not a raw crash dump
+  });
+
+  it('non-EADDRINUSE → generic FATAL line with the stack', () => {
+    const err: NodeJS.ErrnoException = Object.assign(new Error('permission denied'), {
+      code: 'EACCES',
+    });
+    const line = formatListenError(8443, err);
+    expect(line).toContain('FATAL listen error on port 8443');
+    expect(line).toContain(err.stack ?? 'permission denied');
+  });
+});
+
+describe('attachListenErrorHandler', () => {
+  it('EADDRINUSE error → logs the actionable line AND exits(1)', () => {
+    const server = new EventEmitter();
+    const onLog = vi.fn();
+    const onExit = vi.fn();
+    attachListenErrorHandler(server, 8080, { onLog, onExit });
+
+    server.emit('error', Object.assign(new Error('listen EADDRINUSE'), { code: 'EADDRINUSE' }));
+
+    expect(onLog).toHaveBeenCalledWith(expect.stringContaining('already in use'));
+    expect(onExit).toHaveBeenCalledWith(1);
+  });
+
+  it('a generic listen error → logs the FATAL line AND exits(1)', () => {
+    const server = new EventEmitter();
+    const onLog = vi.fn();
+    const onExit = vi.fn();
+    attachListenErrorHandler(server, 8443, { onLog, onExit });
+
+    server.emit('error', Object.assign(new Error('permission denied'), { code: 'EACCES' }));
+
+    expect(onLog).toHaveBeenCalledWith(expect.stringContaining('FATAL listen error'));
+    expect(onExit).toHaveBeenCalledWith(1);
   });
 });

--- a/server/src/crash-logging.ts
+++ b/server/src/crash-logging.ts
@@ -18,6 +18,14 @@
  *     serving. (If a future crash STILL leaves no log, it's native/external —
  *     itself a diagnostic clue.)
  *
+ * srv-17 — once the plan-145 handlers above were live they captured the actual
+ * crash, and it was NOT the hypothesised mid-run silent death: both FATALs were
+ * `listen EADDRINUSE` at startup (a double-start while a prior instance still
+ * held the port). A raw bind failure bubbling to uncaughtException prints a
+ * cryptic Node stack; `attachListenErrorHandler` below intercepts it on the
+ * listener itself and prints an actionable "a server is already running" line
+ * before a clean exit, so EADDRINUSE never reaches the uncaughtException path.
+ *
  * console.* is already timestamp-patched (logger.installTimestamps), so the
  * messages here inherit the standard `YYYY-MM-DD HH:mm:ss.SSS [server]` stamp.
  */
@@ -57,5 +65,46 @@ export function installCrashHandlers(hooks: CrashHandlerHooks = {}): void {
 
   target.on('unhandledRejection', (reason: unknown) => {
     log(`${formatCrash('unhandledRejection', reason)} (survived — server continues)`);
+  });
+}
+
+/* ---- srv-17: actionable listen-error handling ---------------------------- */
+
+/** A freshly-created HTTP/HTTPS listener — just the slice we attach to. */
+export interface ListenErrorTarget {
+  on(event: 'error', cb: (err: NodeJS.ErrnoException) => void): void;
+}
+
+/** Format a listen-error line. EADDRINUSE — the only one we've actually seen
+ *  (a double-start) — gets an actionable hint pointing at the likely cause;
+ *  any other bind error gets the generic FATAL form with the stack. No
+ *  timestamp — the console patch adds it. */
+export function formatListenError(port: number, err: NodeJS.ErrnoException): string {
+  if (err.code === 'EADDRINUSE') {
+    return (
+      `[server] Port ${port} is already in use — another server instance is likely ` +
+      `already running. Stop it first (stop-app, or Ctrl+C the existing run) or set ` +
+      `PORT to a free port, then retry.`
+    );
+  }
+  return `[server] FATAL listen error on port ${port} — ${err.stack ?? `${err.name}: ${err.message}`}`;
+}
+
+/** Attach an `'error'` handler to a freshly-created listener so a bind failure
+ *  (EADDRINUSE on a double-start, or a stale instance still holding the port)
+ *  surfaces an actionable message and a clean exit, instead of bubbling to the
+ *  uncaughtException handler as a cryptic stack. `onLog` / `onExit` default to
+ *  console.error / process.exit and are injectable for tests, mirroring
+ *  `installCrashHandlers`. */
+export function attachListenErrorHandler(
+  server: ListenErrorTarget,
+  port: number,
+  hooks: { onLog?: (msg: string) => void; onExit?: (code: number) => void } = {},
+): void {
+  const log = hooks.onLog ?? ((m: string) => console.error(m));
+  const exit = hooks.onExit ?? ((c: number) => process.exit(c));
+  server.on('error', (err) => {
+    log(formatListenError(port, err));
+    exit(1);
   });
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -21,7 +21,7 @@ installTimestamps();
    server vanishing silently (it died twice on 2026-05-30 with no trace). Also
    makes a stray unhandled rejection survivable so a transient async error can't
    take down an unattended generation run. See crash-logging.ts. */
-import { installCrashHandlers } from './crash-logging.js';
+import { installCrashHandlers, attachListenErrorHandler } from './crash-logging.js';
 installCrashHandlers();
 
 import express from 'express';
@@ -365,9 +365,11 @@ if (lanHttps) {
   }
   const key = readFileSync(LAN_KEY_FILE);
   const cert = readFileSync(LAN_CERT_FILE);
-  createHttpsServer({ key, cert }, app).listen(LAN_HTTPS_PORT, listenerCallback);
+  const server = createHttpsServer({ key, cert }, app).listen(LAN_HTTPS_PORT, listenerCallback);
+  attachListenErrorHandler(server, LAN_HTTPS_PORT);
 } else {
-  app.listen(PORT, listenerCallback);
+  const server = app.listen(PORT, listenerCallback);
+  attachListenErrorHandler(server, PORT);
 }
 
 /* On Ctrl+C or kill, reap the sidecar tree before exit so port 9000 is

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -1218,7 +1218,7 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
          + future playback slice can render it without re-reading the audio.
          Also stamp the TTS model key + render timestamp so the frontend
          can surface engine-drift badges without reading every segments
-         file on chapter-list hydrate (see docs/features/35-engine-drift).
+         file on chapter-list hydrate (see docs/features/archive/35-engine-drift-detection.md).
 
          With sibling chapters of the same book completing in parallel
          (separate dispatcher POSTs now), two handlers can race to


### PR DESCRIPTION
## Summary

Resolves **srv-17**. Plan 145's crash handlers captured the FATAL the item was filed for — and it was **not** the hypothesised mid-run silent death. Both `[server] FATAL uncaughtException` lines on 2026-05-31 (`logs/server.err.log`) were `listen EADDRINUSE: address already in use :::8080` at **startup** — a double-start while a prior instance still held the port. The server never logged a mid-run FATAL across the whole run; the perceived "death" was a *stuck* server (the 14:19–14:21 recycle-drain cascade + a handled 600 s chapter timeout — sidecar instability, tracked under `side-11`) plus a restart that collided on `:8080`.

Root cause of the captured bug: `app.listen` had no `'error'` handler, so the bind failure bubbled to the plan-145 `uncaughtException` handler as a cryptic Node stack.

### What changed

- **`server/src/crash-logging.ts`** — new `formatListenError(port, err)` + `attachListenErrorHandler(server, port, hooks?)` (mirrors the existing `installCrashHandlers` injectable-hooks shape). EADDRINUSE → actionable *"Port N is already in use — another server instance is likely already running…"* + clean `exit(1)`; any other bind error → generic `[server] FATAL listen error on port N` + stack + `exit(1)`.
- **`server/src/index.ts`** — attach the handler to both the HTTP and HTTPS listeners. EADDRINUSE no longer reaches the `uncaughtException` path (cleaner attribution, actionable message). The plan-145 handlers stay armed as the ongoing watch for a genuine mid-run FATAL.
- **`docs/features/145-server-crash-diagnostics.md`** — new "srv-17 follow-up" section recording the captured evidence + the fix; test plan updated; manual-acceptance ticked.
- **`docs/BACKLOG.md`** — `srv-17` reframed as resolved (residual run-instability watch points at `side-11`). `ops-3` and `ops-6` bullets removed (both shipped in `1feccba`; only hygiene remained).
- **`server/src/routes/generation.ts`** — **ops-6 straggler**: the one comment pointer the archived-plan sweep missed (incomplete, `.md`-less `docs/features/35-engine-drift`) → `docs/features/archive/35-engine-drift-detection.md`. The acceptance grep is now clean of real stale pointers.

## Test plan

- `server/src/crash-logging.test.ts` gains 4 cases: `formatListenError` (EADDRINUSE actionable hint vs generic FATAL+stack) and `attachListenErrorHandler` (logs + `exit(1)` for both EADDRINUSE and a generic bind error), driven via an injected `EventEmitter` — 8/8 green.
- `npm run typecheck` ✅, `npm run test:server` (128 files / 1659 tests) ✅, full `npm run verify` ✅ (pre-push).
- Manual: with the app already on `:8080`, a second `cd server && npm run dev` now prints the actionable `Port 8080 is already in use …` line + clean exit, not a raw `FATAL uncaughtException` stack.

Regression plan: `docs/features/145-server-crash-diagnostics.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
