### PR TITLE
feat(frontend): per-chapter RTF history table in the dev Worktrees view

### DIFF
--- a/docs/features/127-generation-rtf-telemetry.md
+++ b/docs/features/127-generation-rtf-telemetry.md
@@ -7,8 +7,8 @@ owner: null
 # Generation RTF telemetry
 
 > Status: active
-> Key files: `server/tts-sidecar/main.py` (batch log + `SynthBatchResult` genMs/audioMs + frame header), `server/src/tts/sidecar.ts` (parse perf header), `server/src/tts/generation-stats.ts` (chapter + live-batch windows), `server/src/routes/generation-stats.ts`, `server/src/routes/generation.ts` (rollup + `onBatchComplete`), `server/src/tts/synthesise-chapter.ts` (`onBatchComplete`), `src/components/worktrees-rtf-pill.tsx`, `src/lib/api.ts`
-> URL surface: `GET /api/generation/stats`; dev-only top-bar pill
+> Key files: `server/tts-sidecar/main.py` (batch log + `SynthBatchResult` genMs/audioMs + frame header), `server/src/tts/sidecar.ts` (parse perf header), `server/src/tts/generation-stats.ts` (chapter + live-batch windows + per-chapter history ring), `server/src/routes/generation-stats.ts`, `server/src/routes/generation.ts` (rollup + `onBatchComplete`), `server/src/tts/synthesise-chapter.ts` (`onBatchComplete`), `src/components/worktrees-rtf-pill.tsx`, `src/views/worktrees.tsx` (per-chapter throughput table), `src/lib/api.ts`
+> URL surface: `GET /api/generation/stats`; dev-only top-bar pill + dev-only Worktrees-view throughput table
 > OpenAPI ops: none (dev/observability endpoint, not part of the public contract)
 
 ## Benefit / Rationale
@@ -25,7 +25,12 @@ written only at chapter completion) looked stalled when it was fine.
   (updated as each Qwen batch lands) — the figure you can actually act on
   mid-chapter — falling back to the per-chapter rolling figure when no batch is
   recent. The server log also prints a per-chapter rollup (`rtf`, `Nx realtime`,
-  `chapters/hr`) as a lagging summary.
+  `chapters/hr`) as a lagging summary. Clicking the pill opens the dev Worktrees
+  view, which now also renders a **per-chapter throughput table** (newest-first
+  RTF history with a ▲/▼ deterioration cue + a run-summary strip) so the operator
+  can see whether RTF is deteriorating or staying consistent across a run — the
+  same answer that previously required grepping the `[generation] chapter N …
+  rtf=` log lines.
 - **Technical:** the batched forward now emits `qwen batch synth: … rtf=` AND
   reports its `genMs`/`audioMs` in the `/synthesize-batch` frame header, so the
   server can surface a live per-batch RTF — observable and comparable to the
@@ -41,6 +46,14 @@ written only at chapter completion) looked stalled when it was fine.
   idle gap so a stale run never dilutes the current one); `GET
   /api/generation/stats`; `api.getGenerationStats()` (real + mock); the
   `WorktreesRtfPill` component.
+- **Per-chapter history ring (newest-first, capped at `MAX_HISTORY` = 200):** a
+  third in-memory list in `generation-stats.ts`, populated by
+  `recordChapterThroughput` with each finished chapter's own `{ rtf, audioSec,
+  synthSec, title, bookId, modelKey, at }`. Surfaced as
+  `GenerationStatsResponse.recentChapters` and rendered by the
+  `GenerationThroughput` table in `src/views/worktrees.tsx`. In-memory only:
+  survives a sidecar recycle (the Node process persists; only the Python sidecar
+  restarts per-batch), resets on a full server restart.
 - **Invariants preserved:** mock/real api split (mock returns the idle shape);
   the `wt` pill stays dev-only (rendered only when `onOpenWorktrees` is wired,
   which is `import.meta.env.DEV`-gated in `layout.tsx`) and keeps its
@@ -74,6 +87,18 @@ written only at chapter completion) looked stalled when it was fine.
 - `genMs`/`audioMs` are ADDITIVE frame-header keys; an older sidecar that omits
   them leaves `out.genMs` undefined and `synthBatch` simply skips
   `onBatchComplete` (`server/src/tts/sidecar.ts`, `synthesise-chapter.ts`).
+- `recentChapters` is **newest-first**, capped at `MAX_HISTORY`, and **independent
+  of the `RESET_MS` rolling-window reset** — an idle gap blanks the aggregate
+  (`chapters`/`rtf` → null) but must NOT blank the history (its whole value is the
+  cross-pause trend the throughput table draws). The view's deterioration cue
+  relies on `recentChapters[0]` being newest and compares each row to the
+  immediately-older entry (`server/src/tts/generation-stats.ts`,
+  `src/views/worktrees.tsx`).
+- The new `recordChapterThroughput` fields (`title`/`bookId`/`modelKey`) are
+  OPTIONAL and default to `null` — a bare three-field call still records — so the
+  history ring stays back-compatible with existing call sites and tests.
+- Each history `rtf` is `null` (not `0`) when the chapter produced no audio, so
+  the table renders a dash and skips the trend comparison (no `Infinity` row).
 
 ## Test plan
 
@@ -87,19 +112,31 @@ written only at chapter completion) looked stalled when it was fine.
 - Vitest server (`server/src/tts/generation-stats.test.ts`) — per-chapter rolling
   maths + window reset + idle shape, AND the live-batch window (single-batch rtf,
   multi-batch aggregate + latest, idle past `BATCH_IDLE_MS`, independence from the
-  chapter window).
+  chapter window), AND the per-chapter history ring (records every field
+  newest-first, caps at `MAX_HISTORY` keeping the most recent, **survives the
+  rolling-window idle reset**, `rtf=null` on no-audio, back-compat 3-field call,
+  cleared by the reset helper).
 - Vitest server (`server/src/tts/synthesise-chapter.test.ts`) — `onBatchComplete`
   fires once per batch with the sidecar's `genMs`/`audioMs`, and does NOT fire
   when the sidecar omits them.
 - Vitest server (`server/src/routes/generation-stats.test.ts`) — `GET
-  /api/generation/stats` returns the idle shape, then reflects a recorded chapter.
+  /api/generation/stats` returns the idle shape, reflects a recorded chapter, and
+  serialises the per-chapter history with `title`/`bookId`/`modelKey`.
 - Vitest frontend (`src/components/worktrees-rtf-pill.test.tsx`) — idle shows
   just "wt"; generating shows the live per-batch RTF; the live per-batch figure
   is preferred over the per-chapter rollup; falls back to per-chapter when no
   batch is recent; click still navigates; fetch failure degrades to no readout.
+- Vitest frontend (`src/views/worktrees.test.tsx`) — the throughput table renders
+  one row per chapter newest-first; a slower-than-previous chapter is tinted ▲ and
+  a faster one ▼ (oldest row, with nothing to compare, has no glyph); a null-rtf
+  row renders a dash with no trend; the empty-state copy shows when no chapters
+  are recorded; the run-summary strip appears only when a summary figure is set.
 
-Not adding an e2e spec: the pill is dev-only and the readout is a polled number,
-not a router/redux/layout seam — unit coverage is the right bar here.
+Not adding an e2e spec: the pill and the Worktrees view are dev-only and the
+readouts are polled numbers, not a router/redux/layout seam — unit coverage is
+the right bar here. The mock `getGenerationStats` now ships a synthetic
+rising-rtf history so any e2e visiting the dev view exercises the table without
+crashing.
 
 ### Manual acceptance walkthrough
 
@@ -113,6 +150,12 @@ not a router/redux/layout seam — unit coverage is the right bar here.
    `wt 1.1` (the LIVE per-batch RTF, magenta) updating every ~batch; once a
    chapter completes and no batch is mid-flight it shows the per-chapter figure;
    idle → just `wt`. Clicking still opens the worktrees dashboard.
+4. **Dev Worktrees view, during/after a run** → below the worktrees list, the
+   **Generation throughput** table fills newest-first as each chapter completes;
+   its RTF column matches the `[generation] chapter N … rtf=` log lines, a
+   chapter that ran slower than the one before shows a ▲ (rose), faster shows ▼
+   (green); the run-summary strip mirrors the pill's figures. The history
+   persists across a sidecar recycle and clears on a full server restart.
 
 ## Out of scope
 

--- a/server/src/routes/generation-stats.test.ts
+++ b/server/src/routes/generation-stats.test.ts
@@ -34,4 +34,25 @@ describe('GET /api/generation/stats', () => {
     expect(res.body.rtf).toBeCloseTo(0.5, 5);
     expect(res.body.last.chapterId).toBe(3);
   });
+
+  it('serialises the per-chapter history with title/book/engine', async () => {
+    recordChapterThroughput({
+      chapterId: 5,
+      audioSec: 120,
+      synthMs: 60_000,
+      title: 'Chapter 5',
+      bookId: 'book-a',
+      modelKey: 'qwen3-tts',
+    });
+    const res = await request(app).get('/api/generation/stats');
+    expect(res.status).toBe(200);
+    expect(res.body.recentChapters).toHaveLength(1);
+    expect(res.body.recentChapters[0]).toMatchObject({
+      chapterId: 5,
+      title: 'Chapter 5',
+      bookId: 'book-a',
+      modelKey: 'qwen3-tts',
+      rtf: 0.5,
+    });
+  });
 });

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -1298,7 +1298,14 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
       const synthSec = (Date.now() - synthStartMs) / 1000;
       const audioSec = result.durationSec;
       const chapterRtf = audioSec > 0 ? synthSec / audioSec : 0;
-      const roll = recordChapterThroughput({ chapterId: chapter.id, audioSec, synthMs: Date.now() - synthStartMs });
+      const roll = recordChapterThroughput({
+        chapterId: chapter.id,
+        audioSec,
+        synthMs: Date.now() - synthStartMs,
+        title: chapter.title ?? null,
+        bookId: job.bookId,
+        modelKey,
+      });
       console.info(
         `[generation] chapter ${chapter.id} "${chapter.title ?? ''}" rendered: ` +
           `lines=${totalLines} groups=${result.segments.length} ` +

--- a/server/src/tts/generation-stats.test.ts
+++ b/server/src/tts/generation-stats.test.ts
@@ -106,3 +106,80 @@ describe('generation-stats live per-batch window', () => {
     expect(s.liveBatchRtf).toBeCloseTo(1.5, 5);
   });
 });
+
+describe('generation-stats per-chapter history ring', () => {
+  it('records every field of a finished chapter newest-first', () => {
+    const s = recordChapterThroughput(
+      {
+        chapterId: 12,
+        audioSec: 120,
+        synthMs: 60_000,
+        title: 'Chapter 12',
+        bookId: 'book-a',
+        modelKey: 'qwen3-tts',
+      },
+      T0,
+    );
+    expect(s.recentChapters).toHaveLength(1);
+    expect(s.recentChapters[0]).toEqual({
+      chapterId: 12,
+      title: 'Chapter 12',
+      bookId: 'book-a',
+      modelKey: 'qwen3-tts',
+      rtf: 0.5, // 60 s synth / 120 s audio
+      audioSec: 120,
+      synthSec: 60,
+      at: new Date(T0).toISOString(),
+    });
+  });
+
+  it('keeps the newest chapter first', () => {
+    recordChapterThroughput({ chapterId: 1, audioSec: 100, synthMs: 50_000 }, T0);
+    const s = recordChapterThroughput(
+      { chapterId: 2, audioSec: 100, synthMs: 50_000 },
+      T0 + 60_000,
+    );
+    expect(s.recentChapters.map((c) => c.chapterId)).toEqual([2, 1]);
+  });
+
+  it('caps the ring at MAX_HISTORY (200), keeping the most recent', () => {
+    for (let i = 1; i <= 205; i++) {
+      recordChapterThroughput({ chapterId: i, audioSec: 100, synthMs: 50_000 }, T0 + i * 1000);
+    }
+    const s = getGenerationStats(T0 + 205_000);
+    expect(s.recentChapters).toHaveLength(200);
+    expect(s.recentChapters[0].chapterId).toBe(205); // newest kept
+    expect(s.recentChapters[199].chapterId).toBe(6); // oldest 5 dropped
+  });
+
+  it('survives the rolling-window idle reset — the trend is not blanked', () => {
+    recordChapterThroughput({ chapterId: 3, audioSec: 100, synthMs: 50_000 }, T0);
+    // Read well past RESET_MS: the aggregate empties but the history must not.
+    const s = getGenerationStats(T0 + 11 * 60_000);
+    expect(s.chapters).toBe(0); // rolling window reset
+    expect(s.rtf).toBeNull();
+    expect(s.recentChapters).toHaveLength(1); // history preserved
+    expect(s.recentChapters[0].chapterId).toBe(3);
+  });
+
+  it('records rtf=null (not 0/Infinity) for a chapter with no audio', () => {
+    const s = recordChapterThroughput({ chapterId: 7, audioSec: 0, synthMs: 30_000 }, T0);
+    expect(s.recentChapters[0].rtf).toBeNull();
+  });
+
+  it('defaults title/bookId/modelKey to null for a bare 3-field call (back-compat)', () => {
+    const s = recordChapterThroughput({ chapterId: 9, audioSec: 100, synthMs: 50_000 }, T0);
+    expect(s.recentChapters[0]).toMatchObject({
+      chapterId: 9,
+      title: null,
+      bookId: null,
+      modelKey: null,
+    });
+  });
+
+  it('is cleared by the test reset helper', () => {
+    recordChapterThroughput({ chapterId: 1, audioSec: 100, synthMs: 50_000 }, T0);
+    __resetGenerationStatsForTest();
+    expect(getGenerationStats(T0).recentChapters).toHaveLength(0);
+  });
+});

--- a/server/src/tts/generation-stats.ts
+++ b/server/src/tts/generation-stats.ts
@@ -12,8 +12,16 @@
         (genMs) + audio (audioMs); we keep the recent few so the dev pill shows
         a number that moves every ~batch. This is the figure the user can ACT
         on mid-chapter (the per-chapter rollup is too coarse).
+     3. PER-CHAPTER history ring — a bounded, newest-first list of each finished
+        chapter's own RTF (+ title/book/engine) so the dev Worktrees view can
+        render the trend across a run ("is it deteriorating or consistent?")
+        without grepping logs. INDEPENDENT of the rolling window's RESET_MS
+        idle reset — an idle gap blanks the aggregate but must NOT blank the
+        history. In-memory only: survives a sidecar recycle (this Node process
+        persists; only the Python sidecar restarts per-batch), resets on a full
+        server restart (a restart is a new session).
 
-   A tiny GET endpoint exposes both so the user self-monitors speed without
+   A tiny GET endpoint exposes all three so the user self-monitors speed without
    grepping logs.
 
    RTF convention matches the sidecar everywhere: rtf = wall / audio, so < 1 is
@@ -21,6 +29,21 @@
    window groups one run; a gap > RESET_MS starts fresh so yesterday's stat
    never dilutes today's. The batch window is independent — it reports while the
    FIRST chapter is still rendering (when the chapter window is still empty). */
+
+/** One finished chapter's own throughput, for the history ring. `rtf` is
+    `synthSec / audioSec` (< 1 = faster than realtime) or `null` when the
+    chapter produced no audio (guards a divide-by-zero from corrupting the
+    deterioration comparison the view draws). */
+export interface ChapterThroughputRecord {
+  chapterId: number | string;
+  title: string | null;
+  bookId: string | null;
+  modelKey: string | null;
+  rtf: number | null;
+  audioSec: number;
+  synthSec: number;
+  at: string;
+}
 
 export interface GenerationStats {
   // ── per-chapter rolling window (lagging summary) ──────────────────────
@@ -56,6 +79,12 @@ export interface GenerationStats {
   batchesInWindow: number;
   /** ISO timestamp of the most-recent batch, or null when none is recent. */
   batchUpdatedAt: string | null;
+
+  // ── per-chapter history ring (trend, newest-first) ────────────────────
+  /** Recent finished chapters, NEWEST-FIRST, capped at MAX_HISTORY. Survives
+      the rolling-window RESET_MS reset (its whole value is the cross-pause
+      trend). The dev Worktrees view renders this as the throughput table. */
+  recentChapters: ChapterThroughputRecord[];
 }
 
 /* Gap (ms) after the last chapter beyond which the next chapter opens a fresh
@@ -69,6 +98,9 @@ const BATCH_IDLE_MS = 5 * 60_000;
 /* Cap the live window so `liveBatchRtf` stays "recent" (and memory is bounded)
    — an aggregate over roughly the last dozen batches. */
 const MAX_BATCHES = 12;
+/* Cap the per-chapter history ring. ~200 small records covers multiple books /
+   a long run while keeping memory trivial — the big-book ceiling is ~60 chapters. */
+const MAX_HISTORY = 200;
 
 interface WindowState {
   startMs: number;
@@ -87,6 +119,7 @@ interface BatchRecord {
 
 let state: WindowState | null = null;
 let batches: BatchRecord[] = [];
+let history: ChapterThroughputRecord[] = [];
 
 const emptyChapter = (): Pick<
   GenerationStats,
@@ -142,7 +175,14 @@ const projectBatch = (
     snapshot. `synthMs` is the wall time spent inside `synthesiseChapter`
     (all TTS — title beat + body, excludes encode/disk). */
 export function recordChapterThroughput(
-  input: { chapterId: number | string; audioSec: number; synthMs: number },
+  input: {
+    chapterId: number | string;
+    audioSec: number;
+    synthMs: number;
+    title?: string | null;
+    bookId?: string | null;
+    modelKey?: string | null;
+  },
   now: number = Date.now(),
 ): GenerationStats {
   const synthSec = input.synthMs / 1000;
@@ -153,6 +193,21 @@ export function recordChapterThroughput(
     synthSec,
     at: new Date(now).toISOString(),
   };
+
+  /* History ring — push BEFORE the window-reset branch so it always records,
+     independent of the RESET_MS idle reset. Newest-first, capped. `rtf` is
+     null (not 0) on no-audio so the view renders a dash and skips the tint. */
+  history.unshift({
+    chapterId: input.chapterId,
+    title: input.title ?? null,
+    bookId: input.bookId ?? null,
+    modelKey: input.modelKey ?? null,
+    rtf: input.audioSec > 0 ? synthSec / input.audioSec : null,
+    audioSec: input.audioSec,
+    synthSec,
+    at: new Date(now).toISOString(),
+  });
+  history = history.slice(0, MAX_HISTORY);
 
   /* Fresh window on first fold or after an idle gap. Anchor the window start
      at this chapter's synth START (now − synthMs) so chapters/hr counts the
@@ -198,11 +253,14 @@ export function recordBatchThroughput(
 export function getGenerationStats(now: number = Date.now()): GenerationStats {
   const chapter =
     state && now - state.updatedAtMs <= RESET_MS ? projectChapter(state) : emptyChapter();
-  return { ...chapter, ...projectBatch(now) };
+  /* `history` is already newest-first and capped; the RESET_MS reset above
+     blanks the aggregate but must NOT touch the history trend. */
+  return { ...chapter, ...projectBatch(now), recentChapters: history };
 }
 
 /** Test-only: drop both windows so cases don't bleed into each other. */
 export function __resetGenerationStatsForTest(): void {
   state = null;
   batches = [];
+  history = [];
 }

--- a/src/components/worktrees-rtf-pill.test.tsx
+++ b/src/components/worktrees-rtf-pill.test.tsx
@@ -20,6 +20,7 @@ const idle = {
   lastBatchRtf: null,
   batchesInWindow: 0,
   batchUpdatedAt: null,
+  recentChapters: [],
 };
 
 const mockStats = vi.mocked(api.getGenerationStats);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4504,22 +4504,53 @@ const mock = {
   }> => {
     return { worktrees: [] };
   },
-  /* Mock has no real generation pipeline — always idle. */
-  getGenerationStats: async (): Promise<GenerationStatsResponse> => ({
-    chapters: 0,
-    audioSec: 0,
-    synthSec: 0,
-    rtf: null,
-    xRealtime: null,
-    chaptersPerHour: null,
-    last: null,
-    updatedAt: null,
-    liveBatchRtf: null,
-    lastBatchRtf: null,
-    batchesInWindow: 0,
-    batchUpdatedAt: null,
-  }),
+  /* Mock has no live pipeline (liveBatchRtf stays null), but ships a small
+     deterministic history with a deliberately rising rtf (newest-first) so the
+     dev Worktrees throughput table + deterioration tint are exercisable under
+     VITE_USE_MOCKS. Fixed ISO timestamps (no Date.now()) keep snapshots stable. */
+  getGenerationStats: async (): Promise<GenerationStatsResponse> => {
+    const recentChapters = [2.41, 2.12, 1.78, 1.5, 1.31, 1.12, 0.94].map((rtf, i) => ({
+      chapterId: 7 - i,
+      title: `Chapter ${7 - i}`,
+      bookId: 'mock-book',
+      modelKey: 'qwen3-tts',
+      rtf,
+      audioSec: 600,
+      synthSec: Math.round(600 * rtf),
+      // Newest-first: index 0 is the latest. 9-minute spacing, fixed base.
+      at: new Date(Date.parse('2026-06-01T09:00:00Z') + (6 - i) * 9 * 60_000).toISOString(),
+    }));
+    return {
+      chapters: recentChapters.length,
+      audioSec: 4200,
+      synthSec: 6700,
+      rtf: 1.6,
+      xRealtime: 0.63,
+      chaptersPerHour: 6.4,
+      last: null,
+      updatedAt: recentChapters[0].at,
+      liveBatchRtf: null,
+      lastBatchRtf: null,
+      batchesInWindow: 0,
+      batchUpdatedAt: null,
+      recentChapters,
+    };
+  },
 };
+
+/** One finished chapter's own throughput, for the dev Worktrees throughput
+    table. `rtf` is synth-wall ÷ audio (< 1 = faster than realtime) or null when
+    the chapter produced no audio. Mirrors the server's `ChapterThroughputRecord`. */
+export interface RecentChapter {
+  chapterId: number | string;
+  title: string | null;
+  bookId: string | null;
+  modelKey: string | null;
+  rtf: number | null;
+  audioSec: number;
+  synthSec: number;
+  at: string;
+}
 
 /** Live generation-throughput snapshot — mirrors the server's
     `generation-stats` accumulator. Backs the dev top-bar RTF pill. */
@@ -4547,6 +4578,9 @@ export interface GenerationStatsResponse {
   lastBatchRtf: number | null;
   batchesInWindow: number;
   batchUpdatedAt: string | null;
+  /** Recent finished chapters, NEWEST-FIRST, capped server-side. Survives the
+      rolling-window idle reset — backs the dev Worktrees throughput table. */
+  recentChapters: RecentChapter[];
 }
 
 export const api = USE_MOCKS ? mock : real;

--- a/src/views/worktrees.test.tsx
+++ b/src/views/worktrees.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { WorktreesView } from './worktrees';
+import { api } from '../lib/api';
+import type { GenerationStatsResponse, RecentChapter } from '../lib/api';
+
+vi.mock('../lib/api', () => ({
+  api: { getWorktrees: vi.fn(), getGenerationStats: vi.fn() },
+}));
+
+const mockWorktrees = vi.mocked(api.getWorktrees);
+const mockStats = vi.mocked(api.getGenerationStats);
+
+const idleStats: GenerationStatsResponse = {
+  chapters: 0,
+  audioSec: 0,
+  synthSec: 0,
+  rtf: null,
+  xRealtime: null,
+  chaptersPerHour: null,
+  last: null,
+  updatedAt: null,
+  liveBatchRtf: null,
+  lastBatchRtf: null,
+  batchesInWindow: 0,
+  batchUpdatedAt: null,
+  recentChapters: [],
+};
+
+const chapter = (over: Partial<RecentChapter>): RecentChapter => ({
+  chapterId: 1,
+  title: 'Chapter 1',
+  bookId: 'book-a',
+  modelKey: 'qwen3-tts',
+  rtf: 1,
+  audioSec: 600,
+  synthSec: 600,
+  at: '2026-06-01T09:00:00Z',
+  ...over,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWorktrees.mockResolvedValue({ worktrees: [] });
+});
+
+describe('WorktreesView — generation throughput table', () => {
+  it('renders one row per chapter, newest-first as delivered', async () => {
+    // Newest-first: ch 3 (rtf 2.1) is slower than ch 2 (1.0) → deterioration.
+    mockStats.mockResolvedValue({
+      ...idleStats,
+      recentChapters: [
+        chapter({ chapterId: 3, title: 'Gamma', rtf: 2.1 }),
+        chapter({ chapterId: 2, title: 'Beta', rtf: 1.0 }),
+        chapter({ chapterId: 1, title: 'Alpha', rtf: 1.5 }),
+      ],
+    });
+    render(<WorktreesView />);
+
+    const table = await screen.findByTestId('generation-throughput-table');
+    const rows = within(table).getAllByTestId(/^throughput-row-/);
+    expect(rows.map((r) => r.getAttribute('data-testid'))).toEqual([
+      'throughput-row-3',
+      'throughput-row-2',
+      'throughput-row-1',
+    ]);
+    expect(within(rows[0]).getByText('Gamma')).toBeInTheDocument();
+  });
+
+  it('tints a slower-than-previous chapter and not a faster one', async () => {
+    mockStats.mockResolvedValue({
+      ...idleStats,
+      recentChapters: [
+        chapter({ chapterId: 3, title: 'Gamma', rtf: 2.1 }), // slower than ch 2 → ▲
+        chapter({ chapterId: 2, title: 'Beta', rtf: 1.0 }), // faster than ch 1 → ▼
+        chapter({ chapterId: 1, title: 'Alpha', rtf: 1.5 }), // no older entry → no glyph
+      ],
+    });
+    render(<WorktreesView />);
+
+    const table = await screen.findByTestId('generation-throughput-table');
+    expect(within(within(table).getByTestId('throughput-row-3')).getByText('▲')).toBeInTheDocument();
+    expect(within(within(table).getByTestId('throughput-row-2')).getByText('▼')).toBeInTheDocument();
+    // Oldest row has nothing to compare against → no trend glyph.
+    expect(within(within(table).getByTestId('throughput-row-1')).queryByText('▲')).toBeNull();
+    expect(within(within(table).getByTestId('throughput-row-1')).queryByText('▼')).toBeNull();
+  });
+
+  it('renders a dash and no trend for a null-rtf chapter', async () => {
+    mockStats.mockResolvedValue({
+      ...idleStats,
+      recentChapters: [
+        chapter({ chapterId: 2, title: 'Beta', rtf: null }),
+        chapter({ chapterId: 1, title: 'Alpha', rtf: 1.5 }),
+      ],
+    });
+    render(<WorktreesView />);
+
+    const table = await screen.findByTestId('generation-throughput-table');
+    const row = within(table).getByTestId('throughput-row-2');
+    expect(within(row).getByText('–')).toBeInTheDocument();
+    expect(within(row).queryByText('▲')).toBeNull();
+  });
+
+  it('shows the empty-state copy when no chapters have been recorded', async () => {
+    mockStats.mockResolvedValue(idleStats);
+    render(<WorktreesView />);
+    await waitFor(() => expect(mockStats).toHaveBeenCalled());
+    expect(screen.queryByTestId('generation-throughput-table')).toBeNull();
+    expect(screen.getByText(/No chapters recorded yet/i)).toBeInTheDocument();
+  });
+
+  it('shows the run-summary strip only when a summary figure is present', async () => {
+    mockStats.mockResolvedValue({
+      ...idleStats,
+      rtf: 1.6,
+      chaptersPerHour: 6.4,
+      recentChapters: [chapter({ chapterId: 1, rtf: 1.6 })],
+    });
+    render(<WorktreesView />);
+
+    const summary = await screen.findByTestId('throughput-summary');
+    expect(within(summary).getByText('1.60')).toBeInTheDocument();
+    expect(within(summary).getByText('6.4')).toBeInTheDocument();
+  });
+
+  it('hides the run-summary strip when all summary figures are null', async () => {
+    mockStats.mockResolvedValue({
+      ...idleStats,
+      recentChapters: [chapter({ chapterId: 1, rtf: 1.0 })],
+    });
+    render(<WorktreesView />);
+    await screen.findByTestId('generation-throughput-table');
+    expect(screen.queryByTestId('throughput-summary')).toBeNull();
+  });
+});

--- a/src/views/worktrees.tsx
+++ b/src/views/worktrees.tsx
@@ -4,10 +4,16 @@
    every 10 s. Dev-only — production builds hide the top-bar entry and
    the server route 404s.
 
-   Click a row → opens that worktree's dev URL in a new tab. */
+   Click a row → opens that worktree's dev URL in a new tab.
+
+   Plan 127 — also renders a per-chapter generation-throughput table fed by
+   GET /api/generation/stats (the same source as the top-bar `wt` RTF pill), so
+   the operator can see whether RTF is deteriorating or staying consistent across
+   a run without grepping logs. */
 
 import { useEffect, useState } from 'react';
-import { api } from '../lib/api';
+import { api, type GenerationStatsResponse, type RecentChapter } from '../lib/api';
+import { formatDuration } from '../lib/time';
 
 interface WorktreeRow {
   path: string;
@@ -18,10 +24,41 @@ interface WorktreeRow {
   alive: boolean;
 }
 
+/* Poll the throughput stats at the pill's cadence, independent of the 10 s
+   worktree refresh. */
+const STATS_POLL_MS = 4000;
+/* Ignore sub-noise rtf wobble when deciding the up/down trend arrow. */
+const TREND_EPSILON = 0.02;
+
+const fmtRtf = (rtf: number | null): string => (rtf == null ? '–' : rtf.toFixed(2));
+
+const fmtClock = (iso: string): string => {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? '' : d.toLocaleTimeString([], { hour12: false });
+};
+
+/* Compare a row to the immediately-older entry (next in the newest-first list).
+   Rising rtf = slower = deteriorating. null on either side → no verdict. */
+type Trend = 'up' | 'down' | 'flat' | 'none';
+const trendOf = (rtf: number | null, olderRtf: number | null | undefined): Trend => {
+  if (rtf == null || olderRtf == null) return 'none';
+  if (rtf > olderRtf + TREND_EPSILON) return 'up';
+  if (rtf < olderRtf - TREND_EPSILON) return 'down';
+  return 'flat';
+};
+
+const TREND_STYLE: Record<Trend, { cls: string; glyph: string; label: string }> = {
+  up: { cls: 'text-rose-600', glyph: '▲', label: 'slower than previous chapter' },
+  down: { cls: 'text-green-600', glyph: '▼', label: 'faster than previous chapter' },
+  flat: { cls: 'text-ink/70', glyph: '→', label: 'about the same as previous chapter' },
+  none: { cls: 'text-ink/70', glyph: '', label: '' },
+};
+
 export function WorktreesView() {
   const [rows, setRows] = useState<WorktreeRow[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
+  const [stats, setStats] = useState<GenerationStatsResponse | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -41,6 +78,27 @@ export function WorktreesView() {
         });
     fetchOnce();
     const t = setInterval(fetchOnce, 10000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, []);
+
+  /* Separate poller so a stats failure can't blank the worktree list (and vice
+     versa), and so it ticks at the pill's 4 s cadence not the 10 s refresh. */
+  useEffect(() => {
+    let cancelled = false;
+    const fetchStats = () =>
+      api
+        .getGenerationStats()
+        .then((res) => {
+          if (!cancelled) setStats(res);
+        })
+        .catch(() => {
+          /* Telemetry is best-effort; leave the last good snapshot in place. */
+        });
+    fetchStats();
+    const t = setInterval(fetchStats, STATS_POLL_MS);
     return () => {
       cancelled = true;
       clearInterval(t);
@@ -102,6 +160,107 @@ export function WorktreesView() {
           ))}
         </div>
       )}
+
+      <GenerationThroughput stats={stats} />
+    </div>
+  );
+}
+
+/* Per-chapter RTF history — newest-first, with a deterioration cue (rising rtf
+   = slower) and a header strip of the run-level figures. Fed by the same
+   GET /api/generation/stats source as the top-bar `wt` pill. */
+function GenerationThroughput({ stats }: { stats: GenerationStatsResponse | null }) {
+  const recent = stats?.recentChapters ?? [];
+  const hasSummary =
+    stats != null &&
+    (stats.rtf != null || stats.liveBatchRtf != null || stats.chaptersPerHour != null);
+
+  return (
+    <section className="mt-10">
+      <h3 className="text-lg font-medium tracking-tight text-ink mb-1">Generation throughput</h3>
+      <p className="text-sm text-ink/60 mb-4">
+        Per-chapter RTF (synth-wall ÷ audio; &lt; 1 = faster than realtime), newest first.
+        A <span className="text-rose-600">▲</span> means the chapter ran slower than the one
+        before it.
+      </p>
+
+      {hasSummary && (
+        <div className="flex flex-wrap gap-x-8 gap-y-2 mb-4 text-sm" data-testid="throughput-summary">
+          <SummaryStat label="Run RTF" value={fmtRtf(stats!.rtf)} />
+          <SummaryStat label="Live batch RTF" value={fmtRtf(stats!.liveBatchRtf)} />
+          <SummaryStat
+            label="Chapters/hr"
+            value={stats!.chaptersPerHour == null ? '–' : stats!.chaptersPerHour.toFixed(1)}
+          />
+        </div>
+      )}
+
+      {recent.length === 0 ? (
+        <p className="text-sm text-ink/50">No chapters recorded yet this session.</p>
+      ) : (
+        <div
+          className="bg-white rounded-3xl border border-ink/10 shadow-card overflow-hidden"
+          data-testid="generation-throughput-table"
+        >
+          <div className="grid grid-cols-[1fr_auto_auto_auto_auto] gap-x-3 sm:gap-x-6 px-4 py-2 text-[11px] uppercase tracking-wide text-ink/40 border-b border-ink/5">
+            <span>Chapter</span>
+            <span className="text-right hidden sm:block">Engine</span>
+            <span className="text-right hidden md:block">Audio</span>
+            <span className="text-right hidden md:block">Synth</span>
+            <span className="text-right">RTF</span>
+          </div>
+          <div className="divide-y divide-ink/5">
+            {recent.map((c, i) => (
+              <ThroughputRow key={`${c.bookId ?? ''}:${c.chapterId}:${c.at}`} chapter={c} olderRtf={recent[i + 1]?.rtf} />
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function SummaryStat({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="flex items-baseline gap-1.5">
+      <span className="text-ink/50">{label}</span>
+      <span className="font-mono font-medium text-ink tabular-nums">{value}</span>
+    </span>
+  );
+}
+
+function ThroughputRow({ chapter, olderRtf }: { chapter: RecentChapter; olderRtf: number | null | undefined }) {
+  const trend = trendOf(chapter.rtf, olderRtf);
+  const style = TREND_STYLE[trend];
+  return (
+    <div
+      className="grid grid-cols-[1fr_auto_auto_auto_auto] gap-x-3 sm:gap-x-6 items-center px-4 py-2.5 text-sm"
+      data-testid={`throughput-row-${chapter.chapterId}`}
+    >
+      <span className="min-w-0 truncate text-ink">
+        <span className="text-ink/40 font-mono mr-2">#{chapter.chapterId}</span>
+        {chapter.title ?? <span className="text-ink/40">(untitled)</span>}
+      </span>
+      <span className="text-right text-xs text-ink/50 font-mono hidden sm:block">
+        {chapter.modelKey ?? '–'}
+      </span>
+      <span className="text-right text-xs text-ink/50 font-mono tabular-nums hidden md:block">
+        {formatDuration(chapter.audioSec)}
+      </span>
+      <span className="text-right text-xs text-ink/50 font-mono tabular-nums hidden md:block">
+        {formatDuration(chapter.synthSec)}
+      </span>
+      <span
+        className={`text-right font-mono font-medium tabular-nums ${style.cls}`}
+        title={`${fmtClock(chapter.at)}${style.label ? ` · ${style.label}` : ''}`}
+      >
+        {style.glyph && (
+          <span className="mr-1 text-xs" aria-label={style.label}>
+            {style.glyph}
+          </span>
+        )}
+        {fmtRtf(chapter.rtf)}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The dev top-bar `wt` pill shows a single live RTF number; clicking it opens the dev-only **Worktrees** view. During a long render the operator wants to know whether RTF is **deteriorating or staying consistent across chapters** — which previously meant grepping the `[generation] chapter N … rtf=` log lines, because the throughput accumulator retained only the single most-recent chapter as `last`.

This adds a **per-chapter RTF history table** to the Worktrees view, fed by the same `GET /api/generation/stats` source as the pill.

**What landed:**
- **Server (`generation-stats.ts`):** a bounded in-memory per-chapter history ring — `recentChapters`, newest-first, capped at `MAX_HISTORY` (200). Each record carries `{ chapterId, title, bookId, modelKey, rtf, audioSec, synthSec, at }`. Populated from the existing `recordChapterThroughput` call in `generation.ts` (which already had `bookId`, `title`, `modelKey` in scope). **No new endpoint, no per-book / `state.json` plumbing.**
- **Independence invariant:** the ring is independent of the rolling window's 10-min idle reset — an idle gap blanks the aggregate (`chapters`/`rtf` → null) but must NOT blank the trend history. `rtf` is `null` (not `0`) on a no-audio chapter so the table renders a dash and skips the comparison.
- **API (`api.ts`):** new `RecentChapter` type + `recentChapters` on `GenerationStatsResponse`. Mock `getGenerationStats` now ships a synthetic rising-rtf history so the table is exercisable under `VITE_USE_MOCKS` (and any e2e visiting the dev view doesn't hit `undefined.map`).
- **Frontend (`worktrees.tsx`):** a "Generation throughput" table below the worktree list — newest-first, with a ▲/▼ deterioration cue (a chapter slower than the one before is tinted rose, faster is green) and a run-summary strip (Run RTF · Live batch RTF · Chapters/hr). Polls on its own 4 s timer, independent of the 10 s worktree refresh, so a stats failure can't blank the list and vice versa.
- **Lifetime:** in-memory only — survives a sidecar recycle (the Node process persists; only the Python sidecar restarts per-batch), resets on a full server restart.
- **Back-compat:** the new `recordChapterThroughput` fields are optional and default to `null`; existing call sites/tests are unchanged.

Extends regression plan **`docs/features/127-generation-rtf-telemetry.md`** (same module/endpoint/dev surface — not a new doc).

Dev-only throughout: the view + pill are gated behind `import.meta.env.DEV` via `onOpenWorktrees` in `layout.tsx`. Nothing new ships to production builds.

## Test plan

- **Server unit** (`generation-stats.test.ts`): new `per-chapter history ring` block — records every field newest-first, caps at 200 keeping the most recent, **survives the rolling-window idle reset**, `rtf=null` on no-audio, back-compat 3-field call, cleared by the reset helper.
- **Server route** (`generation-stats.test.ts`): `GET /api/generation/stats` serialises the history with `title`/`bookId`/`modelKey`.
- **Frontend render** (`src/views/worktrees.test.tsx`, new): one row per chapter newest-first; ▲ on a slower-than-previous chapter, ▼ on faster, no glyph on the oldest; null-rtf renders a dash with no trend; empty-state copy when no chapters; summary strip only when a figure is set.
- Local: `npm run typecheck`, `eslint` on touched files, the three test tiers above, and the scoped pre-commit fast suite (1672 server + frontend) all green.
- **Draft + CI-gate:** opened as draft because a local generation run is active (the full `npm run verify` flakes `test:server-slow` + visual e2e under GPU/CPU contention). I'll run `gh pr ready` to fire one CI verify run when you're ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
