### PR TITLE
fix(server): supervise an adopted sidecar so a recycle is recovered (srv-15)

### DIFF
--- a/docs/features/142-generation-recovery.md
+++ b/docs/features/142-generation-recovery.md
@@ -32,6 +32,11 @@ A sidecar host-RAM leak (plan 141) OOM-killed the Node server mid-run. Two laten
 - `index.ts`: replaced the one-shot `spawnSidecar` + module `sidecarHandle` with `sidecarSupervisor`; `start()` on boot, `stop()` in the SIGINT/SIGTERM handler (stop sets the stopped flag BEFORE reaping, so the teardown kill can't trigger a respawn race).
 - **Scope note (closed by plan 148 / srv-17c):** an in-flight chapter at the moment of sidecar death still fails its synth (the existing `withTtsRetry` window is shorter than a Qwen cold reload) and is recovered by the queue re-dispatch + srv-16's audio-exists skip — i.e. the *run* self-heals, not necessarily the exact in-flight chapter without a blip. **[148-recycle-inflight-recovery.md](148-recycle-inflight-recovery.md) now closes this**: the worker rides out the respawn (srv-17b gate) and re-renders the in-flight chapter in place, and the sidecar drains in-flight synth before the recycle exit — so the exact in-flight chapter no longer blips to `failed`.
 
+## srv-15 follow-up — adopt-supervision (2026-06-01 dev-reload stall)
+
+- **The gap:** srv-15 only wires `onExit` when it actually *spawns* a child. When `spawnSidecar` finds a fresh sidecar already listening on `:9000`, it honours it (`current sidecar honoured`) and returns `null` — no handle, no `onExit`, so supervision goes **dormant**. The common trigger is a `tsx watch` dev-server reload (an edit to any server file): the reloaded server adopts the orphaned sidecar from the previous process instead of spawning its own child. On 2026-06-01 an overnight Qwen run hit exactly this — the adopted sidecar crossed its committed-memory restart ceiling and did its designed soft-recycle self-exit (code 43, plan 143), but nothing respawned it. Generation looped on "sidecar unavailable mid-synth — riding out the respawn" and chapter 27 failed `Local TTS sidecar not reachable`. Production (`npm start`, no watch) spawns the sidecar as an owned child and is unaffected — this bites the exact dev path long unattended renders run on.
+- **The fix:** a new `onAdoptExisting?({ host, port })` seam on `SpawnSidecarOpts`, invoked **only** in the fresh-reuse branch (the not-ours / stale / disabled `null` paths stay silent, so the supervisor never respawns over a process we deliberately left alone). The supervisor passes a callback that starts a lightweight watchdog: it polls the adopted port every `DEFAULT_ADOPTED_POLL_MS` (1.5 s) and, when the port goes silent, respawns an **owned** child via `spawnOnce` — which re-establishes full `onExit` supervision (or re-arms the watch if it adopts again). The poll cadence is short enough to respawn inside the generation path's ride-out window (srv-17b), but doesn't disturb the multi-minute drain (the draining sidecar keeps the port up, so the watchdog just keeps polling until the real exit). An `adoptedWatching` flag prevents a duplicate loop, and the existing `stopped` flag halts the watch on shutdown (no respawn after `stop()`).
+
 ## srv-16 — server-authoritative queue completion
 
 - `generation.ts` Hook 1: right after the `chapter_complete` broadcast (chapter rendered + persisted), the server marks the queue entry done for a genuine single-chapter queue job (`job.queueEntryId != null && job.chapterId === chapter.id`). No longer depends on the frontend `/complete`.
@@ -48,7 +53,8 @@ A sidecar host-RAM leak (plan 141) OOM-killed the Node server mid-run. Two laten
 ## Invariants to preserve
 
 - The supervisor is the ONLY wirer of `onExit`; each (re)spawn registers it afresh.
-- `stop()` MUST set `stopped` before reaping, so a shutdown kill never respawns.
+- The supervisor is also the only wirer of `onAdoptExisting`; only the fresh-reuse branch fires it, so an adopted (already-listening) sidecar is watched and respawned on disappearance, while a disabled / not-ours / stale-unreplaceable `null` stays dormant.
+- `stop()` MUST set `stopped` before reaping, so a shutdown kill never respawns — this also halts the adopt watchdog.
 - Server-side queue completion MUST be idempotent (skip-if-absent) and serialized, so it can't double-prune or race the frontend `/complete` / orphan-recovery.
 - Hook 1 fires only for single-chapter queue jobs (`chapterId === chapter.id`), never the back-compat `*` walker (chapterId null).
 
@@ -56,8 +62,8 @@ A sidecar host-RAM leak (plan 141) OOM-killed the Node server mid-run. Two laten
 
 Automated (`npm run test:server`):
 
-- `server/src/tts/sidecar-supervisor.test.ts` (6): start spawns once; respawn on exit; respawn on poison code 42; crash-loop cap warns + stops; long-lived child resets the counter; `stop()` reaps + blocks respawn. All timing injected (delayFn/nowFn) — deterministic.
-- `server/src/tts/spawn-sidecar.test.ts`: added a case asserting `onExit(42, null)` fires on child exit.
+- `server/src/tts/sidecar-supervisor.test.ts` (8): start spawns once; respawn on exit; respawn on poison code 42; crash-loop cap warns + stops; long-lived child resets the counter; `stop()` reaps + blocks respawn; **adopt-supervision — watches an adopted sidecar and respawns an owned child when it vanishes; `stop()` halts the adopt watchdog (no respawn after stop)**. All timing injected (delayFn/probeFn/nowFn) — deterministic.
+- `server/src/tts/spawn-sidecar.test.ts`: added a case asserting `onExit(42, null)` fires on child exit; and a case asserting the fresh-reuse branch fires `onAdoptExisting({ host, port })` (so the supervisor can watch an adopted sidecar).
 - `server/src/routes/generation-orphan-recovery.test.ts`: updated the completed-run case to assert srv-16 server-side done-pruning (entry gone, never reset to queued); added a Hook 2 case (chapter audio already on disk + non-force → entry done-pruned, synth never called).
 
 Manual acceptance (pending): start a multi-chapter Qwen run, `taskkill` the sidecar mid-chapter → the server respawns it (backoff) and the queue finishes the book; verify a completed chapter is not re-rendered after a restart.

--- a/server/src/tts/sidecar-supervisor.test.ts
+++ b/server/src/tts/sidecar-supervisor.test.ts
@@ -122,4 +122,76 @@ describe('sidecar supervisor (srv-15)', () => {
     await new Promise((r) => setTimeout(r, 20));
     expect(spawn.fn).toHaveBeenCalledTimes(1);
   });
+
+  /* Adopt-supervision: when the server honours an ALREADY-listening sidecar
+     (no child spawned, so no onExit can fire), the supervisor must watch the
+     port and respawn an OWNED child once that adopted sidecar disappears.
+     Without this, a self-recycle of an adopted sidecar — e.g. after a `tsx
+     watch` dev reload re-adopted the orphan (the 2026-06-01 stall) — is never
+     recovered and generation wedges on "sidecar not reachable". */
+  it('watches an adopted sidecar and respawns an owned child when it vanishes', async () => {
+    const handles: ReturnType<typeof makeHandle>[] = [];
+    let calls = 0;
+    const spawnFn = vi.fn(async (opts: SpawnSidecarOpts) => {
+      calls += 1;
+      if (calls === 1) {
+        // A fresh sidecar is already listening → honour it, announce the adopt.
+        opts.onAdoptExisting?.({ host: '127.0.0.1', port: 9000 });
+        return null;
+      }
+      const h = makeHandle();
+      handles.push(h);
+      return h as SidecarHandle;
+    });
+    // The adopted sidecar answers two polls, then the port goes silent.
+    const probes = [true, true, false];
+    let pi = 0;
+    const probeFn = vi.fn(async () => probes[Math.min(pi++, probes.length - 1)]);
+    const sup = createSidecarSupervisor({
+      buildOpts: async () => BASE_OPTS,
+      spawnFn,
+      probeFn,
+      delayFn: async () => {},
+      adoptedPollMs: 1,
+      warn: vi.fn(),
+      log: vi.fn(),
+    });
+    await sup.start();
+    expect(spawnFn).toHaveBeenCalledTimes(1); // adopted — nothing spawned yet
+    expect(sup.current()).toBeNull();
+    // Watcher polls; on the silent poll it respawns an owned, supervised child.
+    await vi.waitFor(() => expect(spawnFn).toHaveBeenCalledTimes(2));
+    expect(sup.current()).toBe(handles[0]);
+  });
+
+  it('stops watching an adopted sidecar after stop() (no respawn)', async () => {
+    let calls = 0;
+    const spawnFn = vi.fn(async (opts: SpawnSidecarOpts) => {
+      calls += 1;
+      if (calls === 1) {
+        opts.onAdoptExisting?.({ host: '127.0.0.1', port: 9000 });
+        return null;
+      }
+      return makeHandle() as SidecarHandle;
+    });
+    // Gate the watcher's first delay so we can stop() before it polls.
+    let releaseDelay = () => {};
+    const delayFn = () => new Promise<void>((r) => (releaseDelay = r));
+    const probeFn = vi.fn(async () => false); // would trigger a respawn if reached
+    const sup = createSidecarSupervisor({
+      buildOpts: async () => BASE_OPTS,
+      spawnFn,
+      probeFn,
+      delayFn,
+      adoptedPollMs: 1,
+      warn: vi.fn(),
+      log: vi.fn(),
+    });
+    await sup.start();
+    await sup.stop();
+    releaseDelay(); // watcher resumes, sees stopped → bails before probing
+    await new Promise((r) => setTimeout(r, 20));
+    expect(probeFn).not.toHaveBeenCalled();
+    expect(spawnFn).toHaveBeenCalledTimes(1); // no respawn after stop
+  });
 });

--- a/server/src/tts/sidecar-supervisor.ts
+++ b/server/src/tts/sidecar-supervisor.ts
@@ -13,7 +13,7 @@
  * respawns. `buildOpts` is async + re-evaluated per respawn so a settings
  * change (eager-load prefs, model key) is picked up by the next process. */
 import type { SidecarHandle, SpawnSidecarOpts } from './spawn-sidecar.js';
-import { spawnSidecar } from './spawn-sidecar.js';
+import { spawnSidecar, probeListening } from './spawn-sidecar.js';
 
 /* A child that dies faster than this counts toward the crash-loop cap; one
    that lived longer is treated as a fresh incident and resets the counter, so
@@ -22,6 +22,11 @@ import { spawnSidecar } from './spawn-sidecar.js';
 const QUICK_DEATH_MS = 30_000;
 const DEFAULT_BACKOFFS_MS = [2_000, 5_000, 15_000];
 const DEFAULT_MAX_CONSECUTIVE_FAILURES = 5;
+/* How often to poll an ADOPTED (already-listening, not-owned) sidecar for
+   disappearance. Short enough that a self-recycle is detected and a fresh
+   owned child respawned inside the generation path's ride-out window, but not
+   so chatty that it spams the port during a normal multi-minute drain. */
+const DEFAULT_ADOPTED_POLL_MS = 1_500;
 
 export interface SidecarSupervisorOpts {
   /** Builds the base spawn opts for each (re)spawn. Async so it can re-read
@@ -36,6 +41,10 @@ export interface SidecarSupervisorOpts {
   nowFn?: () => number;
   backoffsMs?: number[];
   maxConsecutiveFailures?: number;
+  /* Probe whether something still holds the adopted sidecar's port. */
+  probeFn?: (host: string, port: number) => Promise<boolean>;
+  /* Poll interval for the adopted-sidecar watchdog. */
+  adoptedPollMs?: number;
 }
 
 export interface SidecarSupervisor {
@@ -59,22 +68,67 @@ export function createSidecarSupervisor(opts: SidecarSupervisorOpts): SidecarSup
     nowFn = () => Date.now(),
     backoffsMs = DEFAULT_BACKOFFS_MS,
     maxConsecutiveFailures = DEFAULT_MAX_CONSECUTIVE_FAILURES,
+    probeFn = probeListening,
+    adoptedPollMs = DEFAULT_ADOPTED_POLL_MS,
   } = opts;
 
   let stopped = false;
   let handle: SidecarHandle | null = null;
   let consecutiveFailures = 0;
   let lastSpawnAt = 0;
+  /* True while a watchdog loop is polling an adopted sidecar's port. Guards
+     against starting a second loop if the adopt callback fires again before
+     the first loop has released. */
+  let adoptedWatching = false;
 
   async function spawnOnce(): Promise<void> {
     if (stopped) return;
     lastSpawnAt = nowFn();
     const base = await buildOpts();
-    /* spawnSidecar returns null for benign no-spawn (autoStart off, a healthy
-       sidecar already listening) AND for a spawn error. Either way there's no
-       child, so no onExit fires and supervision is dormant until something is
-       actually spawned — matching the pre-supervisor contract. */
-    handle = await spawnFn({ ...base, onExit: onChildExit });
+    /* spawnSidecar returns null for benign no-spawn (autoStart off, a spawn
+       error, or an already-listening healthy sidecar we adopt). For the adopt
+       case it invokes onAdoptExisting first, so the watchdog below can respawn
+       an owned child once that process disappears; the other null paths fire no
+       callback and leave supervision dormant — matching the pre-supervisor
+       contract (don't resurrect a disabled or deliberately-untouched sidecar). */
+    handle = await spawnFn({ ...base, onExit: onChildExit, onAdoptExisting: onAdopt });
+  }
+
+  /* Watch an adopted (already-listening, not-owned) sidecar. When its port goes
+     silent — e.g. the committed-memory soft-recycle self-exit (code 43) — bring
+     up a fresh OWNED child via spawnOnce, which re-establishes full onExit
+     supervision (or re-arms this watch if it adopts again). */
+  function onAdopt(info: { host: string; port: number }): void {
+    if (stopped || adoptedWatching) return;
+    adoptedWatching = true;
+    log(
+      `[sidecar] supervisor: watching adopted sidecar on :${info.port} ` +
+        `(not our child) — will respawn an owned process if it exits.`,
+    );
+    void (async () => {
+      while (!stopped) {
+        await delayFn(adoptedPollMs);
+        if (stopped) break;
+        if (await probeFn(info.host, info.port)) continue; // still up
+        /* Gone. Release the flag BEFORE respawning so a re-adopt inside
+           spawnOnce can arm a fresh watch, then respawn an owned child. */
+        adoptedWatching = false;
+        warn(
+          `[sidecar] supervisor: adopted sidecar on :${info.port} disappeared ` +
+            `(likely a self-recycle) — respawning a supervised child.`,
+        );
+        try {
+          await spawnOnce();
+        } catch (err) {
+          warn(
+            `[sidecar] supervisor: respawn after adopted-exit failed ` +
+              `(${(err as Error).message}).`,
+          );
+        }
+        return;
+      }
+      adoptedWatching = false;
+    })();
   }
 
   function onChildExit(code: number | null, signal: NodeJS.Signals | null): void {

--- a/server/src/tts/spawn-sidecar.test.ts
+++ b/server/src/tts/spawn-sidecar.test.ts
@@ -104,6 +104,36 @@ describe('spawnSidecar', () => {
     expect(log).toHaveBeenCalledWith(expect.stringContaining('current sidecar honoured'));
   });
 
+  it('announces an adopted sidecar via onAdoptExisting so the supervisor can watch it', async () => {
+    probeFn.mockResolvedValueOnce(true);
+    const healthProbeFn = vi.fn(async () => ({
+      reachable: true,
+      looksLikeSidecar: true,
+      protocolVersion: 1,
+    }));
+    const onAdoptExisting = vi.fn();
+
+    const handle = await spawnSidecar({
+      autoStart: true,
+      modelKey: 'kokoro-v1',
+      eagerLoadKokoro: true,
+      eagerLoadQwen: true,
+      repoRoot,
+      port: 9000,
+      host: '127.0.0.1',
+      spawnFn: spawnFn as unknown as typeof import('node:child_process').spawn,
+      probeFn,
+      healthProbeFn,
+      log,
+      warn,
+      onAdoptExisting,
+    });
+
+    expect(handle).toBeNull();
+    expect(spawnFn).not.toHaveBeenCalled();
+    expect(onAdoptExisting).toHaveBeenCalledWith({ host: '127.0.0.1', port: 9000 });
+  });
+
   it('does NOT touch a listening process that is not our sidecar', async () => {
     /* Reachable-but-not-ours (or hung/non-HTTP): never kill an unknown process,
        just leave it and let the health route surface TTS-down. */

--- a/server/src/tts/spawn-sidecar.ts
+++ b/server/src/tts/spawn-sidecar.ts
@@ -61,6 +61,16 @@ export interface SpawnSidecarOpts {
      stalls generation with no recovery. Not called when the child is never
      spawned (autoStart off / reuse / spawn failure returns null). */
   onExit?: (code: number | null, signal: NodeJS.Signals | null) => void;
+  /* srv-15 (adopt-supervision) — invoked when an already-listening FRESH
+     sidecar is honoured instead of spawning. We don't own that process, so
+     `onExit` can never fire for it; the supervisor passes a callback that
+     watches the port and respawns an OWNED child once the adopted sidecar
+     disappears. Without it, a self-recycle of an adopted sidecar — e.g. after
+     a `tsx watch` dev reload re-adopted the orphan (the 2026-06-01 stall) — is
+     never recovered and generation wedges on "sidecar not reachable". Only the
+     fresh-reuse branch calls this; the not-ours / stale / disabled paths don't,
+     so the supervisor never respawns over a process we deliberately left alone. */
+  onAdoptExisting?: (info: { host: string; port: number }) => void;
 }
 
 export interface SidecarHandle {
@@ -276,6 +286,7 @@ export async function spawnSidecar(opts: SpawnSidecarOpts): Promise<SidecarHandl
     healthProbeFn = (h, p) => probeSidecarHealth(h, p),
     findPidFn = (p) => findListenerPid(p),
     onExit,
+    onAdoptExisting,
   } = opts;
 
   if (!autoStart) {
@@ -299,6 +310,7 @@ export async function spawnSidecar(opts: SpawnSidecarOpts): Promise<SidecarHandl
       log(
         `[sidecar] already listening on :${port} (protocol v${health.protocolVersion}), skipping spawn (current sidecar honoured)`,
       );
+      onAdoptExisting?.({ host, port });
       return null;
     }
     if (!health.looksLikeSidecar) {


### PR DESCRIPTION
## Summary

Fixes the 2026-06-01 overnight-run stall where the TTS sidecar "crashed" — it didn't crash, it did its designed soft-recycle (committed-memory ceiling → code-43 self-exit, plan 143) and was never respawned.

**Root cause.** The srv-15 supervisor only wires `onExit` when it actually *spawns* a child. When `spawnSidecar` finds a fresh sidecar already listening on `:9000`, it honours it (`current sidecar honoured`) and returns `null` — no handle, no `onExit` — so supervision goes **dormant**. A `tsx watch` dev-server reload (an edit to any server file) triggers exactly this: the reloaded server *adopts* the orphaned sidecar from the previous process instead of spawning its own child. So when the adopted sidecar self-recycled, nothing brought it back; generation looped on "sidecar unavailable mid-synth — riding out the respawn" and chapter 27 failed `Local TTS sidecar not reachable`. Production (`npm start`, no watch) spawns an owned child and is unaffected — this bites the exact dev path long unattended renders run on.

**Fix.** A new `onAdoptExisting?({ host, port })` seam on `SpawnSidecarOpts`, fired **only** in the fresh-reuse branch (the not-ours / stale / disabled `null` paths stay silent, so we never respawn over a process we deliberately left alone). The supervisor passes a callback that starts a lightweight watchdog: it polls the adopted port every 1.5 s and, when the port goes silent, respawns an **owned** child via `spawnOnce` — re-establishing full `onExit` supervision (or re-arming the watch if it adopts again). An `adoptedWatching` flag prevents a duplicate loop; the existing `stopped` flag halts the watchdog on shutdown (no respawn after `stop()`).

This does **not** touch the underlying variable-shape memory leak that *forces* the recycle (still `side-11`) — it only makes the recycle survivable when the sidecar was adopted rather than spawned.

### Changes
- `server/src/tts/spawn-sidecar.ts` — new `onAdoptExisting` opt; invoked in the fresh-reuse branch before `return null`.
- `server/src/tts/sidecar-supervisor.ts` — `probeFn` + `adoptedPollMs` seams; `onAdopt` watchdog wired into every `spawnOnce`.
- `docs/features/142-generation-recovery.md` — new "srv-15 follow-up — adopt-supervision" section + updated invariants/test plan.

## Test plan
- `server/src/tts/sidecar-supervisor.test.ts` (+2): watches an adopted sidecar and respawns an owned child when it vanishes; `stop()` halts the adopt watchdog (no respawn after stop). Timing injected (delayFn/probeFn) — deterministic.
- `server/src/tts/spawn-sidecar.test.ts` (+1): the fresh-reuse branch fires `onAdoptExisting({ host, port })`.
- `npm run verify` green locally (lint, typecheck, all unit/server/slow/sidecar/scripts tests, e2e + visual, build).

Regression plan: [docs/features/142-generation-recovery.md](docs/features/142-generation-recovery.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
