### PR TITLE
docs(docs): README/INSTALL new-stack updates + Node 20.19 engine floor

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,7 +8,7 @@ After install you'll have a single command (`npm run start:prod`) that brings up
 
 ## Prerequisites (all platforms)
 
-- **Node.js 20.6 or newer** — <https://nodejs.org>
+- **Node.js 20.19 or newer** (Vite 8 needs ≥20.19 / ≥22.12; the repo targets Node 24) — <https://nodejs.org>
 - **Python 3.11**
   - Windows: <https://python.org> installer (tick "Add to PATH" during setup)
   - macOS: `brew install python@3.11`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ voice cloning.
 
 **Prerequisites**
 
-- Node 20.6 or newer
+- Node 20.19 or newer (Vite 8 requires ≥20.19 / ≥22.12; the repo targets Node 24 via `.nvmrc`)
 - Python 3.11 (for the TTS sidecar)
 - ffmpeg on `PATH` (checked by `npm run dev` via `scripts/preflight-ffmpeg.cjs`)
 - Windows 11 with PowerShell 5.1+ — the harness ships Windows-native start
@@ -93,7 +93,7 @@ e2e/build), `npm run test:e2e` (Playwright only).
 ## Layout
 
 ```
-src/                  Vite + React 18 + Redux Toolkit frontend
+src/                  Vite 8 (Rolldown) + React 19 + Redux Toolkit frontend
   store/              RTK slices (ui, cast, chapters, revisions, manuscript,
                       book-meta, notifications, broadcast-middleware,
                       engines-in-use-selector)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=20.6.0"
+    "node": ">=20.19.0"
   },
   "scripts": {
     "start": "powershell -ExecutionPolicy Bypass -NoProfile -File scripts/start-app.ps1",


### PR DESCRIPTION
## Summary

Reflect the plan-167 stack upgrade in the install/readme docs (per the post-merge cleanup):

- **README:** frontend stack line `React 18` → `React 19` + `Vite 8 (Rolldown)`; Node prerequisite `20.6` → `20.19` (Vite 8's floor).
- **INSTALL:** Node prerequisite `20.6` → `20.19`.
- **package.json:** `engines.node` `>=20.6.0` → `>=20.19.0` to match Vite 8's actual minimum (≥20.19 / ≥22.12).

A companion **`run-app` skill** (launch + real-browser-drive + verify recipe, with the 'after a pull you must `npm install` first — relaunching ≠ reinstalling' gotcha front-and-centre) was added to `.claude/skills/run-app/` locally; `.claude/` is gitignored in this repo, so it stays a local dev aid rather than a committed asset (say the word if you'd rather un-ignore `.claude/skills/` to share it).

## Test plan
- Docs + a one-line engines bump; no runtime code. Verified the new stack boots clean (Vite 8 / React 19 / router 7) via a live browser drive — app renders, redux-persist rehydrates, hash-router navigation works, 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)