### PR TITLE
fix(frontend,sidecar): gate Qwen A/B compare on an existing voice + harden the design-model race

### DIFF
--- a/e2e/cast.spec.ts
+++ b/e2e/cast.spec.ts
@@ -7,10 +7,12 @@ import { goToConfirm, waitForRouteReady } from './helpers';
  * Drives a fresh book to the confirm-cast view, opens a character's
  * profile drawer, switches the per-character TTS engine to Qwen, and
  * exercises the bespoke voice-design sub-flow: the persona auto-fills
- * (mock returns a canned persona), the "Design & compare" button stages a
- * preview design and opens the A/B "current vs proposed" compare modal
- * (plan 161), "Use proposed voice" promotes + stages it, the designed
- * confirmation surfaces, and Save closes the drawer.
+ * (mock returns a canned persona). The FIRST design has nothing to compare
+ * against, so "Design & preview" auditions in place (no compare modal) and
+ * the designed confirmation surfaces. A second design — now that a voice
+ * exists — reads "Design & compare", stages a preview, and opens the A/B
+ * "current vs proposed" modal (plan 161); "Use proposed voice" promotes +
+ * stages it. Save then closes the drawer.
  *
  * Why browser-level: the engine selector → Qwen panel reveal crosses
  * redux (Character.ttsEngine state), the design fetch returns a binary
@@ -53,10 +55,19 @@ test.describe('cast view → profile drawer → per-character Qwen voice', () =>
     /* The preset Model-voice picker is hidden while Qwen is selected. */
     await expect(page.getByText(/Model voice/i)).toHaveCount(0);
 
-    /* Design & compare — stages a preview design (mock) and opens the A/B
-       "current vs proposed" compare modal (plan 161). */
+    /* First design — nothing to compare against yet, so this is the one-shot
+       "Design & preview": no compare modal, the designed confirmation surfaces
+       directly. */
     const designBtn = page.getByTestId('qwen-design-voice');
+    await expect(designBtn).toHaveText(/Design & preview/i);
     await expect(designBtn).toBeEnabled();
+    await designBtn.click();
+    await expect(page.getByTestId('qwen-designed-confirm')).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId('voice-compare-overlay')).toHaveCount(0);
+
+    /* Re-design — now a voice exists, so the button reads "Design & compare"
+       and opens the A/B "current vs proposed" modal (plan 161). */
+    await expect(designBtn).toHaveText(/Design & compare/i);
     await designBtn.click();
     await expect(page.getByTestId('voice-compare-overlay')).toBeVisible({ timeout: 5_000 });
     /* Both audition sides + the editable proposed persona render. */

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -951,6 +951,17 @@ class QwenEngine(Engine):
         # back-to-back designs stay warm (no reload) while a pause reclaims
         # ~4–5 GB. 0.0 until the first design.
         self._design_last_used: float = 0.0
+        # Count of in-flight design_voice() calls. The idle watchdog must NOT
+        # free the VoiceDesign model out from under an active design — the
+        # plan-161 A/B compare makes the user dwell long enough for the idle TTL
+        # to elapse mid-design, and a watchdog free in the unguarded window
+        # between _ensure_design_loaded() and the _synth_lock forward nulls
+        # `_design` → "'NoneType' object has no attribute 'generate_voice_design'".
+        # Incremented at entry / decremented in a finally; `maybe_free_idle_design`
+        # bails while it's > 0. Read/written under the GIL (simple int), which is
+        # sufficient here: the airtight backstop is the re-ensure under _synth_lock
+        # inside design_voice — this guard just stops the wasteful, racy free.
+        self._design_in_flight: int = 0
         # Designed-voice embeddings cache. Default lives next to this file
         # under voices/qwen/ (exact back-compat when QWEN_VOICES_DIR unset).
         # The Node server points QWEN_VOICES_DIR at the per-workspace tree
@@ -1207,12 +1218,39 @@ class QwenEngine(Engine):
         `ttl_seconds` since the last design. Returns True if it freed. Driven by
         the startup watchdog: rapid back-to-back designs keep it warm (no
         per-design reload — the user's explicit preference), but a quiet pause
-        reclaims ~4–5 GB. Cheap no-op when nothing is resident."""
-        if self._design is None:
+        reclaims ~4–5 GB. Cheap no-op when nothing is resident.
+
+        The idle test is re-validated UNDER `_synth_lock` and skipped entirely
+        while a design is in flight (`_design_in_flight`), so the watchdog can
+        never free `_design` out from under an active design — the plan-161
+        race. Nulls `_design` inline rather than calling `unload_design()`
+        (which re-acquires the non-reentrant `_synth_lock` → deadlock); the
+        gc/empty_cache reclaim runs after the lock is released."""
+        # Cheap, lock-free fast-outs first (no model, or recently used).
+        if self._design is None or self._design_in_flight > 0:
             return False
         if time.monotonic() - self._design_last_used <= ttl_seconds:
             return False
-        self.unload_design()
+        # Re-validate under the lock: design_voice refreshes `_design_last_used`
+        # and runs its forward while holding `_synth_lock`, so a check that still
+        # finds it idle here cannot be mid-forward.
+        with self._synth_lock:
+            if self._design is None or self._design_in_flight > 0:
+                return False
+            if time.monotonic() - self._design_last_used <= ttl_seconds:
+                return False
+            self._design = None
+        # Mirror unload_design()'s reclaim: collect the dropped VoiceDesign
+        # reference cycles before freeing VRAM (the 2026-05-30 host leak).
+        gc.collect()
+        try:
+            import torch  # type: ignore
+
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+        except Exception:
+            pass
+        log.info("Qwen VoiceDesign unloaded (Base stays resident).")
         return True
 
     def list_voices(self) -> list[str]:
@@ -1251,66 +1289,84 @@ class QwenEngine(Engine):
         # caller sent nothing.
         audition_text = (calibration_text or self.CALIBRATION_TEXT).strip() or self.CALIBRATION_TEXT
 
-        # Mark the design model active up front so the idle watchdog can't free
-        # it out from under this in-flight design; refreshed again on completion
-        # so the TTL counts idle from when the design finished.
+        # Mark the design model active up front AND register an in-flight design
+        # so the idle watchdog can't free the VoiceDesign model out from under
+        # it. The timestamp alone is a TOCTOU (the watchdog can read a stale value
+        # and free in the gap before the _synth_lock forward); `_design_in_flight`
+        # + the re-ensure under the lock below close that race. Decremented in the
+        # finally so a failure can't leave the guard stuck > 0.
         self._design_last_used = time.monotonic()
-        self._ensure_design_loaded()
-        self._ensure_base_loaded()
-        # Serialise the GPU forwards against any concurrent synth/design — see
-        # `_synth_lock` in __init__ (the Base model isn't thread-safe).
-        with self._synth_lock:
-            # 1. design a reference clip from the persona instruction.
-            ref_wavs, ref_sr = self._design.generate_voice_design(
-                text=ref_text, language=lang, instruct=instruct
-            )
-            ref_audio = ref_wavs[0]
+        self._design_in_flight += 1
+        try:
+            self._ensure_design_loaded()
+            self._ensure_base_loaded()
+            # Serialise the GPU forwards against any concurrent synth/design — see
+            # `_synth_lock` in __init__ (the Base model isn't thread-safe).
+            with self._synth_lock:
+                # Re-ensure the models UNDER the lock. Every in-place nuller of
+                # `_design`/`_base` (the idle watchdog, a concurrent
+                # /synthesize's unload_design, a full /unload) holds `_synth_lock`,
+                # so a model ensured before we took the lock may have been freed
+                # in the gap. Re-ensuring here is the airtight backstop against
+                # "'NoneType' object has no attribute 'generate_voice_design'".
+                # Idempotent / a no-op on the warm path; `_ensure_*` don't take
+                # `_synth_lock`, so this can't deadlock.
+                self._ensure_design_loaded()
+                self._ensure_base_loaded()
+                # 1. design a reference clip from the persona instruction.
+                ref_wavs, ref_sr = self._design.generate_voice_design(
+                    text=ref_text, language=lang, instruct=instruct
+                )
+                ref_audio = ref_wavs[0]
 
-            # 2. distil into a reusable clone prompt on the Base model.
-            prompt = self._base.create_voice_clone_prompt(
-                ref_audio=(ref_audio, ref_sr), ref_text=ref_text
-            )
+                # 2. distil into a reusable clone prompt on the Base model.
+                prompt = self._base.create_voice_clone_prompt(
+                    ref_audio=(ref_audio, ref_sr), ref_text=ref_text
+                )
 
-        # 3. cache prompt + manifest to disk (workspace-shared, keyed by voiceId).
-        os.makedirs(self._voices_dir, exist_ok=True)
-        pt_path, json_path = self._voice_paths(voice_id)
-        torch.save(prompt, pt_path)
-        import json as _json
+            # 3. cache prompt + manifest to disk (workspace-shared, keyed by voiceId).
+            os.makedirs(self._voices_dir, exist_ok=True)
+            pt_path, json_path = self._voice_paths(voice_id)
+            torch.save(prompt, pt_path)
+            import json as _json
 
-        with open(json_path, "w", encoding="utf-8") as fh:
-            _json.dump(
-                {
-                    "voiceId": voice_id,
-                    "instruct": instruct,
-                    "language": lang,
-                    "refText": ref_text,
-                    "baseModel": self.BASE_MODEL,
-                    "designModel": self.VOICEDESIGN_MODEL,
-                },
-                fh,
-                ensure_ascii=False,
-                indent=2,
-            )
-        log.info("Designed + cached Qwen voice '%s' (instruct=%r).", voice_id, instruct[:80])
+            with open(json_path, "w", encoding="utf-8") as fh:
+                _json.dump(
+                    {
+                        "voiceId": voice_id,
+                        "instruct": instruct,
+                        "language": lang,
+                        "refText": ref_text,
+                        "baseModel": self.BASE_MODEL,
+                        "designModel": self.VOICEDESIGN_MODEL,
+                    },
+                    fh,
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            log.info("Designed + cached Qwen voice '%s' (instruct=%r).", voice_id, instruct[:80])
 
-        # Evict any stale in-memory entry so a RE-designed voice can't keep
-        # serving the previous embedding — the next synth reloads the fresh
-        # .pt we just wrote. (We don't warm it here: the audition preview
-        # below uses `prompt` directly, and the first real synth's single
-        # disk load is negligible.)
-        with self._cache_lock:
-            self._prompt_cache.pop(voice_id, None)
+            # Evict any stale in-memory entry so a RE-designed voice can't keep
+            # serving the previous embedding — the next synth reloads the fresh
+            # .pt we just wrote. (We don't warm it here: the audition preview
+            # below uses `prompt` directly, and the first real synth's single
+            # disk load is negligible.)
+            with self._cache_lock:
+                self._prompt_cache.pop(voice_id, None)
 
-        # 4. audition preview — speak the caller's calibration line in the new
-        #    voice (the full evidence quote, NOT the short reference text).
-        with self._synth_lock:
-            wavs, sr = self._base.generate_voice_clone(
-                text=[audition_text], language=[lang], voice_clone_prompt=prompt
-            )
-        # Idle clock starts now (design finished) — back-to-back designs keep
-        # the model warm; a pause past the TTL lets the watchdog reclaim it.
-        self._design_last_used = time.monotonic()
-        return SynthResult(pcm=_float_audio_to_int16_le(wavs[0]), sample_rate=int(sr))
+            # 4. audition preview — speak the caller's calibration line in the new
+            #    voice (the full evidence quote, NOT the short reference text).
+            with self._synth_lock:
+                self._ensure_base_loaded()  # re-ensure under the lock — see above
+                wavs, sr = self._base.generate_voice_clone(
+                    text=[audition_text], language=[lang], voice_clone_prompt=prompt
+                )
+            # Idle clock starts now (design finished) — back-to-back designs keep
+            # the model warm; a pause past the TTL lets the watchdog reclaim it.
+            self._design_last_used = time.monotonic()
+            return SynthResult(pcm=_float_audio_to_int16_le(wavs[0]), sample_rate=int(sr))
+        finally:
+            self._design_in_flight -= 1
 
     def _load_voice_prompt(self, voice: str) -> tuple[Any, str, bool]:
         """Return (clone_prompt, language, cache_hit) for a designed voice.
@@ -1377,6 +1433,10 @@ class QwenEngine(Engine):
         gen_start = time.perf_counter()
         # Serialise the forward — see `_synth_lock` in __init__.
         with self._synth_lock:
+            # Re-ensure under the lock: a concurrent /unload (analyzer/XTTS evict)
+            # holds `_synth_lock` to null `_base`, so a model ensured before the
+            # lock can be gone in the gap. No-op on the warm path.
+            self._ensure_base_loaded()
             wavs, sr = self._base.generate_voice_clone(
                 text=[text], language=[lang], voice_clone_prompt=prompt
             )
@@ -1453,6 +1513,9 @@ class QwenEngine(Engine):
         # on shared model state → "size of tensor a (8) must match tensor b (7)".
         gen_start = time.perf_counter()
         with self._synth_lock:
+            # Re-ensure under the lock — a concurrent /unload holds `_synth_lock`
+            # to null `_base`; see synthesize(). No-op on the warm path.
+            self._ensure_base_loaded()
             wavs, sr = self._base.generate_voice_clone(
                 text=texts, language=langs, voice_clone_prompt=prompts
             )

--- a/server/tts-sidecar/tests/test_qwen3.py
+++ b/server/tts-sidecar/tests/test_qwen3.py
@@ -221,6 +221,61 @@ def test_design_voice_falls_back_to_calibration_pangram_when_unset(fake_qwen_run
     assert engine._base.clone_calls[-1][0] == [engine.CALIBRATION_TEXT]
 
 
+# ── design-model race / idle-watchdog (2026-06-02 regression) ────────────
+
+def test_design_voice_survives_design_model_freed_in_the_gap(
+    fake_qwen_runtime, monkeypatch
+) -> None:
+    """The idle watchdog (or a concurrent /synthesize's unload_design) can null
+    `_design` in the unguarded window between `_ensure_design_loaded()` and the
+    `_synth_lock` forward. design_voice used to crash there with
+    "'NoneType' object has no attribute 'generate_voice_design'". The fix
+    re-ensures the model UNDER the lock, so the design completes regardless of a
+    free landing in the gap.
+
+    We simulate the free deterministically (no threads): wrap `_ensure_base_loaded`
+    — which runs in that gap — to null `_design` on its FIRST call only (the
+    pre-lock ensure), leaving the re-ensure inside the lock to reload it."""
+    engine = fake_qwen_runtime["engine"]
+    orig_ensure_base = engine._ensure_base_loaded
+    fired = {"n": 0}
+
+    def racing_ensure_base() -> None:
+        orig_ensure_base()
+        if fired["n"] == 0:  # only the pre-lock ensure, not the in-lock re-ensure
+            fired["n"] += 1
+            engine._design = None  # a watchdog free lands in the gap
+
+    monkeypatch.setattr(engine, "_ensure_base_loaded", racing_ensure_base)
+
+    # Must NOT raise AttributeError: 'NoneType' … generate_voice_design.
+    result = engine.design_voice("dex", "a witty teenage boy", "English", None)
+
+    assert isinstance(result.pcm, bytes) and len(result.pcm) > 0
+    assert result.sample_rate == 24000
+    assert fired["n"] == 1  # the model really was nulled in the gap …
+    assert engine._design is not None  # … and re-ensured under the lock
+
+
+def test_watchdog_does_not_free_design_while_in_flight(fake_qwen_runtime) -> None:
+    """`maybe_free_idle_design` must refuse to free the VoiceDesign model while a
+    design is in flight (`_design_in_flight` > 0), even past the idle TTL — the
+    plan-161 race where a long compare-modal dwell crosses the TTL mid-design.
+    Once nothing is in flight, an idle model is freed as before."""
+    engine = fake_qwen_runtime["engine"]
+    engine._ensure_design_loaded()
+    assert engine._design is not None
+    engine._design_last_used = 0.0  # ancient → past any ttl
+
+    engine._design_in_flight = 1
+    assert engine.maybe_free_idle_design(0.0) is False
+    assert engine._design is not None  # NOT freed while a design is in flight
+
+    engine._design_in_flight = 0
+    assert engine.maybe_free_idle_design(0.0) is True
+    assert engine._design is None  # freed once idle AND not in flight
+
+
 def test_synthesize_reuses_cached_voice(fake_qwen_runtime) -> None:
     engine = fake_qwen_runtime["engine"]
     engine.design_voice("biana", "a bright, confident teenage girl", "English", None)

--- a/src/components/voice-engine-picker.tsx
+++ b/src/components/voice-engine-picker.tsx
@@ -189,7 +189,9 @@ export function VoiceEnginePicker({
             ) : (
               <>
                 <IconSparkle className="w-4 h-4" />
-                <span>Design &amp; compare</span>
+                {/* "compare" only when a bespoke voice already exists to put on
+                    Side A of the A/B; a first design just previews (no compare). */}
+                <span>{designedVoiceId ? 'Design & compare' : 'Design & preview'}</span>
               </>
             )}
           </button>

--- a/src/modals/profile-drawer.test.tsx
+++ b/src/modals/profile-drawer.test.tsx
@@ -1074,15 +1074,25 @@ describe('ProfileDrawer per-character engine + Qwen bespoke voice (plan 108)', (
     });
   });
 
-  it('Design & compare stages a PREVIEW design and opens the A/B modal; approve stages it (plan 161)', async () => {
+  it('RE-design (existing voice) stages a PREVIEW + opens the A/B compare; approve promotes it (plan 161)', async () => {
+    /* A character that ALREADY has a designed bespoke voice has something to
+       put on Side A, so re-designing opens the A/B compare against it. */
     designQwenVoice.mockClear();
     promoteQwenVoice.mockClear();
-    renderWithBook({ ...baseChar, voiceStyle: 'a steady adult voice' });
+    renderWithBook({
+      ...baseChar,
+      ttsEngine: 'qwen',
+      voiceId: 'v_hal',
+      overrideTtsVoices: { qwen: { name: 'qwen-halloran' } },
+      voiceStyle: 'a steady adult voice',
+    });
     selectQwen();
+    /* The button reads "Design & compare" when there's an existing voice. */
+    expect(screen.getByTestId('qwen-design-voice').textContent).toMatch(/Design & compare/i);
     fireEvent.click(screen.getByTestId('qwen-design-voice'));
     await waitFor(() => {
-      /* The persona still flows through; preview:true stages a sibling id so
-         the live voice isn't overwritten while the user compares. */
+      /* preview:true stages a `…-preview` sibling so the live voice isn't
+         overwritten while the user compares. */
       expect(designQwenVoice).toHaveBeenCalledWith(
         'book-1',
         'halloran',
@@ -1094,16 +1104,45 @@ describe('ProfileDrawer per-character engine + Qwen bespoke voice (plan 108)', (
         }),
       );
     });
-    /* The compare modal opens; the designed-confirm is NOT shown yet (staging
-       is deferred to approve). */
+    /* The compare modal opens; staging the promoted voice is deferred to approve
+       (promote not called until the user keeps the proposed voice). */
     await waitFor(() => expect(screen.getByTestId('voice-compare-overlay')).toBeTruthy());
-    expect(screen.queryByTestId('qwen-designed-confirm')).toBeNull();
+    expect(promoteQwenVoice).not.toHaveBeenCalled();
 
-    /* Approve → promote the preview, then the drawer stages the real voice and
-       surfaces the designed confirmation. */
     fireEvent.click(screen.getByTestId('voice-compare-approve'));
     await waitFor(() => expect(promoteQwenVoice).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.queryByTestId('voice-compare-overlay')).toBeNull());
+  });
+
+  it('FIRST design (no existing voice) auditions in place — no compare modal (nothing to compare)', async () => {
+    /* A/B compare is only useful when there is something to compare to. A
+       first-time design has no current bespoke voice, so it falls back to the
+       one-shot "Design & preview": design in place (preview:false), stage it,
+       and play — without opening the compare modal. */
+    designQwenVoice.mockClear();
+    promoteQwenVoice.mockClear();
+    renderWithBook({ ...baseChar, voiceStyle: 'a steady adult voice' });
+    selectQwen();
+    /* No existing voice → the button reads "Design & preview". */
+    expect(screen.getByTestId('qwen-design-voice').textContent).toMatch(/Design & preview/i);
+    fireEvent.click(screen.getByTestId('qwen-design-voice'));
+    await waitFor(() => {
+      expect(designQwenVoice).toHaveBeenCalledWith(
+        'book-1',
+        'halloran',
+        expect.objectContaining({
+          persona: 'a steady adult voice',
+          modelKey: 'qwen3-tts-0.6b',
+          sampleVoiceId: expect.any(String),
+          preview: false,
+        }),
+      );
+    });
+    /* Stages the voice directly (designed-confirm) and never opens the compare
+       modal or promotes (there's no preview to promote). */
     await waitFor(() => expect(screen.getByTestId('qwen-designed-confirm')).toBeTruthy());
+    expect(screen.queryByTestId('voice-compare-overlay')).toBeNull();
+    expect(promoteQwenVoice).not.toHaveBeenCalled();
   });
 
   it('on Save writes ttsEngine=qwen + the qwen override series-scoped', async () => {
@@ -1111,11 +1150,10 @@ describe('ProfileDrawer per-character engine + Qwen bespoke voice (plan 108)', (
     const onSave = vi.fn();
     renderWithBook({ ...baseChar, voiceId: 'v_hal', voiceStyle: 'a steady adult voice' }, onSave);
     selectQwen();
-    /* Design opens the compare modal; approving promotes + stages the voiceId. */
+    /* First design (no existing voice) stages the designed voiceId directly —
+       no compare modal — then Save persists it. */
     fireEvent.click(screen.getByTestId('qwen-design-voice'));
     await waitFor(() => expect(designQwenVoice).toHaveBeenCalled());
-    await waitFor(() => expect(screen.getByTestId('voice-compare-approve')).toBeTruthy());
-    fireEvent.click(screen.getByTestId('voice-compare-approve'));
     await waitFor(() => expect(screen.getByTestId('qwen-designed-confirm')).toBeTruthy());
 
     fireEvent.click(screen.getByRole('button', { name: /Save changes/i }));
@@ -1213,11 +1251,9 @@ describe('ProfileDrawer per-character engine + Qwen bespoke voice (plan 108)', (
     expect(
       (screen.getByRole('button', { name: /Play 12s sample/i }) as HTMLButtonElement).disabled,
     ).toBe(true);
-    /* Design → compare → approve stages the voiceId returned by the mock
-       (qwen-halloran). */
+    /* First design (one-shot, no compare) stages the voiceId returned by the
+       mock (qwen-halloran) directly. */
     fireEvent.click(screen.getByTestId('qwen-design-voice'));
-    await waitFor(() => expect(screen.getByTestId('voice-compare-approve')).toBeTruthy());
-    fireEvent.click(screen.getByTestId('voice-compare-approve'));
     await waitFor(() => expect(screen.getByTestId('qwen-designed-confirm')).toBeTruthy());
     const playBtn = screen.getByRole('button', { name: /Play 12s sample/i }) as HTMLButtonElement;
     expect(playBtn.disabled).toBe(false);

--- a/src/modals/profile-drawer.tsx
+++ b/src/modals/profile-drawer.tsx
@@ -699,6 +699,12 @@ export function ProfileDrawer({
     }
     setDesignBusy(true);
     setEngineError(null);
+    /* The A/B "current vs proposed" compare is only meaningful when the
+       character ALREADY has a designed bespoke voice to put on Side A. On a
+       FIRST design there is nothing to compare against, so fall back to the
+       one-shot "design & preview": design in place and play it. `designedVoiceId`
+       is non-null iff a bespoke voice already exists for this character. */
+    const isRedesign = designedVoiceId !== null;
     try {
       /* Pass the same cache identity the "Play 12s" player uses so the
          audition is rendered straight into the sample cache — designing here
@@ -707,12 +713,22 @@ export function ProfileDrawer({
         persona: trimmed,
         sampleVoiceId,
         modelKey: effectiveSampleModelKey,
-        preview: true,
+        /* Re-design stages a `…-preview` sibling so the live voice survives a
+           Cancel; first design has no live voice to protect, so design in place. */
+        preview: isRedesign,
       });
-      /* Open the A/B compare with the staged preview. Staging into the drawer
-         (designedVoiceId / persona) is deferred to the modal's approve, so
-         Cancel leaves the character's live voice untouched. */
-      setVoiceCompareInitial({ voiceId, previewUrl, persona: trimmed });
+      if (isRedesign) {
+        /* Open the A/B compare with the staged preview. Staging into the drawer
+           (designedVoiceId / persona) is deferred to the modal's approve, so
+           Cancel leaves the character's live voice untouched. */
+        setVoiceCompareInitial({ voiceId, previewUrl, persona: trimmed });
+      } else {
+        /* One-shot: stage the freshly designed voice straight into the drawer
+           and audition it (no compare modal — there's nothing to compare to). */
+        designPreviewUrlRef.current = previewUrl;
+        setDesignedVoiceId(voiceId);
+        await playback.play(previewUrl);
+      }
     } catch (e) {
       setEngineError((e as Error).message || 'Voice design failed.');
     } finally {


### PR DESCRIPTION
## Summary

Fixes the broken Qwen "Design & compare" flow (`Closes #488`). Designing a Qwen voice failed with `'NoneType' object has no attribute 'generate_voice_design'` and, on retry, a 180s timeout. It worked for days and regressed with the plan-161 A/B "current-vs-proposed" audition (e37bc15). Two distinct causes, both fixed here.

**Part 1 (frontend) — A/B compare only when there is something to compare to.** Plan 161 made *every* design — even a first one — stage a preview and open the two-pane compare modal with Side A = the character's current voice. A first design has no current bespoke voice, so Side A had nothing to audition. `designVoice()` now branches on `designedVoiceId` (non-null iff a bespoke voice already exists): a **re-design** stages a `…-preview` sibling and opens the A/B compare (unchanged); a **first design** falls back to the pre-161 one-shot "Design & preview" — designs in place, stages the voice, and auditions it, with no compare modal. The design button label follows ("Design & compare" vs "Design & preview").

**Part 2 (sidecar) — defense-in-depth for the latent race plan 161 exposed.** `design_voice` ensured `_design`/`_base` *outside* the `_synth_lock` that guards their use, so any in-place nuller that holds the lock (the idle watchdog freeing after 120s, a concurrent `/synthesize`'s `unload_design`, a full `/unload`) could null the model in the gap before the forward. The compare modal's long dwell time made the watchdog free `_design` mid-design routinely (confirmed in `logs/tts.err.log` — the watchdog free landed at the instant of the crash). Three layers: (1) re-ensure the model *under* `_synth_lock` immediately before every forward (design, audition, synthesize, synthesize_batch) — airtight since all nullers hold the lock; (2) `maybe_free_idle_design` re-validates the idle window under the lock and nulls inline (no `unload_design` re-entrancy); (3) a `_design_in_flight` guard the watchdog honors so it never frees during an active design.

## Test plan

- **Frontend** `src/modals/profile-drawer.test.tsx` — first design takes the one-shot path (`preview:false`, no overlay, stages directly); re-design opens the compare overlay + promotes on approve. Button label asserted both ways.
- **E2E** `e2e/cast.spec.ts` — updated to the first-design (no overlay, designed-confirm directly) → re-design (compare overlay → "Use proposed voice") flow.
- **Sidecar** `server/tts-sidecar/tests/test_qwen3.py` — deterministic repro of a watchdog free in the ensure→lock gap (design completes via the re-ensure), plus the `_design_in_flight` guard. (Venv-gated → CI-skipped; ran locally.)
- Local: frontend **2171** passed, sidecar **197** passed, typecheck, lint, e2e all green.

Regression source: [plan 161](docs/features/161-voice-design-compare.md). No persisted shape or server route changed.
