### PR TITLE
fix(frontend): clip horizontal overflow on the Listen view (mobile)

### DIFF
--- a/src/views/listen.tsx
+++ b/src/views/listen.tsx
@@ -155,7 +155,13 @@ export function ListenView({
     (s) => s.library?.books?.find((b) => b.bookId === bookId)?.language ?? 'en',
   );
   return (
-    <div className="max-w-[1200px] mx-auto px-4 sm:px-6 py-6 sm:py-10">
+    /* overflow-x-clip — the Listen view is a vertical reading column and must
+       never scroll sideways. Guards against sub-pixel horizontal drift on the
+       phone viewport (a 9px overflow surfaced only on the Linux mobile-chrome
+       runner, where classic scrollbar metrics + scrollbar-gutter:stable on the
+       in-card lists render a hair wider than Windows/macOS). Desktop layout is
+       unaffected. Caught by e2e/responsive/baseline.spec.ts at Pixel-7. */
+    <div className="max-w-[1200px] mx-auto px-4 sm:px-6 py-6 sm:py-10 overflow-x-clip">
       <ListenHeader
         title={title}
         author={author}


### PR DESCRIPTION
## Summary
Fixes a ~9px horizontal overflow on the Listen view at the phone viewport (Pixel 7), caught by `e2e/responsive/baseline.spec.ts` on the **Linux mobile-chrome** runner only (Windows + macOS verify pass). The Listen view is a vertical reading column and must never scroll sideways, so its root content wrapper now carries `overflow-x-clip`. Desktop layout unaffected; no behaviour change.

Root cause is Linux sub-pixel scrollbar drift (classic scrollbar metrics + `scrollbar-gutter: stable` on the in-card lists). Pre-existing on `main` (post-2026-06-01, ~fs-2 / Tailwind 4); surfaced by the v1.6.0 release cross-OS gate, not caused by PR #495.

## Test plan
- Validated by the `cross-os.yml` mobile-chrome leg (the only environment that reproduces it).
- `npm run typecheck` + frontend Vitest (2211) green locally; no unit assertion exists for sub-pixel overflow (Linux-only), so the e2e responsive baseline is the regression net.

Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)