### PR TITLE
fix(frontend): stop the top bar overflowing the phone viewport

### DIFF
--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -223,7 +223,16 @@ export function TopBar({
      without changing the desktop sizing. */
   return (
     <header className="sticky top-0 z-40 bg-canvas/85 backdrop-blur-md border-b border-ink/10">
-      <div className="max-w-[1500px] mx-auto px-3 sm:px-6 h-16 flex items-center gap-3 sm:gap-8">
+      {/* overflow-x-clip — sticky chrome must never create page-level horizontal
+          scroll. On a book route the breadcrumb + the shrink-0 right cluster can
+          tip a hair past the 412px phone viewport (a 9px overflow that surfaced
+          only on the Linux mobile-chrome runner, where font metrics render
+          wider than Windows/macOS); the middle strip already scrolls. Paired
+          with hiding the redundant VersionPill on phone (below) so the clip is
+          pure insurance and never cuts a visible control. clip (not hidden)
+          leaves the y-axis visible so the portaled status/account popovers are
+          unaffected. Caught by e2e/responsive/baseline.spec.ts at Pixel-7. */}
+      <div className="max-w-[1500px] mx-auto px-3 sm:px-6 h-16 flex items-center gap-3 sm:gap-8 overflow-x-clip">
         <button
           onClick={onHome}
           className="font-bold text-base tracking-tight inline-flex items-center gap-1 hover:opacity-80 transition-opacity shrink-0 min-h-[44px]"
@@ -294,7 +303,12 @@ export function TopBar({
               Queue · {queueCount}
             </button>
           )}
-          <VersionPill onClick={onOpenAccount} />
+          {/* Hidden on phone — the version is also in the footer + Account, and
+              dropping it here gives the book-route top bar comfortable margin at
+              the 412px viewport (see overflow-x-clip note above). */}
+          <span className="hidden sm:inline-flex">
+            <VersionPill onClick={onOpenAccount} />
+          </span>
           <ThemeToggleButton />
           <button
             type="button"

--- a/src/views/listen.tsx
+++ b/src/views/listen.tsx
@@ -155,13 +155,7 @@ export function ListenView({
     (s) => s.library?.books?.find((b) => b.bookId === bookId)?.language ?? 'en',
   );
   return (
-    /* overflow-x-clip — the Listen view is a vertical reading column and must
-       never scroll sideways. Guards against sub-pixel horizontal drift on the
-       phone viewport (a 9px overflow surfaced only on the Linux mobile-chrome
-       runner, where classic scrollbar metrics + scrollbar-gutter:stable on the
-       in-card lists render a hair wider than Windows/macOS). Desktop layout is
-       unaffected. Caught by e2e/responsive/baseline.spec.ts at Pixel-7. */
-    <div className="max-w-[1200px] mx-auto px-4 sm:px-6 py-6 sm:py-10 overflow-x-clip">
+    <div className="max-w-[1200px] mx-auto px-4 sm:px-6 py-6 sm:py-10">
       <ListenHeader
         title={title}
         author={author}


### PR DESCRIPTION
## Summary
Real fix for the ~9px horizontal overflow on the Listen view at Pixel-7 (Linux mobile-chrome only). A mobile-e2e diagnostic showed the page-pusher is the **shared top bar**, not the listen content: on a **book route** the breadcrumb (project title) appears — absent on the library route, which is why library passed — and combined with the `shrink-0` right cluster (Admin pill + version pill + theme toggle + avatar) the row's intrinsic width tips a hair past 412px under Linux's wider font metrics.

Two changes in `src/components/top-bar.tsx`:
1. `overflow-x-clip` on the sticky header inner row — chrome must never create page-level horizontal scroll. `clip` (not `hidden`) leaves the y-axis visible so the portaled status/account popovers are unaffected.
2. Hide the redundant `VersionPill` on phone (`hidden sm:inline-flex`) — it's also in the footer + Account — so the clip is pure insurance and never cuts a visible control.

Also reverts the earlier ineffective `overflow-x-clip` on the Listen content column (PR #497) — that container was never the offender. Desktop layout unchanged; no behaviour change.

## Test plan
- Validated by the `cross-os.yml` mobile-chrome leg (the only env that reproduces it; pinpointed via a temporary diagnostic that dumped the offending elements).
- `npm run typecheck` + frontend Vitest (2211) green locally.

Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)