### PR TITLE
feat(server,frontend,openapi): exact per-character progress under parallel synthesis (fs-13)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2807,6 +2807,21 @@ components:
         progress: { type: number, minimum: 0, maximum: 1 }
         currentLine: { type: integer }
         totalLines: { type: integer }
+        completedSentenceIds:
+          type: array
+          items: { type: integer }
+          description: |
+            fs-13 — only on a `progress` tick fired at a GROUP COMPLETION: the
+            manuscript sentence ids of the just-finished same-speaker group
+            (the tick's `characterId` is that group's character). The frontend
+            unions these into a per-chapter completed-id SET so each character's
+            mini-bar reads its EXACT done count under out-of-order completion
+            (poolWidth > 1 + Qwen batching), rather than approximating from the
+            chapter-wide `currentLine` count. Absent on the onGroupStart
+            heartbeat tick and on older servers — the frontend then falls back
+            to the `currentLine`-derived approximation. The chapter-level
+            `currentLine`/`progress` are unchanged (still the monotonic group
+            count).
         runDone:
           type: integer
           description: |

--- a/server/src/routes/generation.test.ts
+++ b/server/src/routes/generation.test.ts
@@ -212,6 +212,71 @@ describe('POST /api/books/:bookId/generation', () => {
     }
   });
 
+  it('progress tick from a group completion carries that group\'s completed sentence ids (fs-13)', async () => {
+    /* fs-13: each completed-group tick must carry the just-completed group's
+       sentence ids + its character, so the frontend can track an EXACT per-
+       character done set under out-of-order completion — while the chapter
+       counter (currentLine) stays the monotonic group count it is today.
+       Fire two completions out of narrative order (a late-clustered character
+       finishes first) to mirror parallel dispatch. */
+    synthesiseImpl = async (args: unknown) => {
+      const opts = args as {
+        onGroupComplete?: (e: {
+          group: { index: number; characterId: string; sentenceIds: number[] };
+          totalGroups: number;
+          accumulatedSec: number;
+          completed: number;
+        }) => void;
+      };
+      opts.onGroupComplete?.({
+        group: { index: 7, characterId: 'sophie', sentenceIds: [14, 15] },
+        totalGroups: 10,
+        accumulatedSec: 0,
+        completed: 1,
+      });
+      opts.onGroupComplete?.({
+        group: { index: 0, characterId: 'narrator', sentenceIds: [1] },
+        totalGroups: 10,
+        accumulatedSec: 0,
+        completed: 2,
+      });
+      return {
+        pcm: Buffer.alloc(2),
+        sampleRate: 24000,
+        durationSec: 1,
+        segments: [
+          {
+            characterId: 'narrator',
+            voiceName: 'Zephyr',
+            sampleStart: 0,
+            sampleEnd: 1,
+            sentenceIds: [1],
+          },
+        ],
+      };
+    };
+    const res = await request(app)
+      .post(`/api/books/${bookId}/generation`)
+      .send({ modelKey: 'gemini-2.5-flash', force: true });
+    expect(res.status).toBe(200);
+    const ticks = parseTicks(res.text);
+    const completed = ticks.filter(
+      (t) => t.type === 'progress' && Array.isArray((t as { completedSentenceIds?: unknown }).completedSentenceIds),
+    ) as Array<ParsedTick & { completedSentenceIds: number[]; characterId: string; currentLine: number }>;
+    /* Each completed group surfaces its own sentence ids + character. */
+    expect(
+      completed.some((t) => t.characterId === 'sophie' && t.completedSentenceIds.join(',') === '14,15'),
+    ).toBe(true);
+    expect(
+      completed.some((t) => t.characterId === 'narrator' && t.completedSentenceIds.join(',') === '1'),
+    ).toBe(true);
+    /* currentLine stays monotonic within a chapter's completed-group ticks
+       (the chapter-level count is unchanged by fs-13; it resets per chapter). */
+    const ch1Lines = completed.filter((t) => t.chapterId === 1).map((t) => t.currentLine);
+    expect(ch1Lines.length).toBeGreaterThan(0);
+    expect(ch1Lines).toEqual([...ch1Lines].sort((a, b) => a - b));
+  });
+
   it('rejects an unsupported modelKey with a stream-level chapter_failed and ends', async () => {
     const res = await request(app)
       .post(`/api/books/${bookId}/generation`)

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -1270,6 +1270,15 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
             progress,
             currentLine: completed,
             totalLines,
+            /* fs-13 — carry the just-completed group's sentence ids so the
+               frontend can track an EXACT per-character done SET under
+               out-of-order completion (poolWidth > 1 + Qwen batching), instead
+               of approximating each character's bar from the chapter-wide
+               `currentLine` count. The chapter-level count above is unchanged
+               (still the monotonic group count). Only the completion tick
+               carries this — the onGroupStart heartbeat must NOT, or a started-
+               but-unfinished group would read as done. */
+            completedSentenceIds: group.sentenceIds,
           };
           job.lastProgressTick = tick;
           broadcast(job, { type: 'progress', ...tick });

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -2168,6 +2168,20 @@ export interface components {
             currentLine?: number;
             totalLines?: number;
             /**
+             * @description fs-13 — only on a `progress` tick fired at a GROUP COMPLETION: the
+             *     manuscript sentence ids of the just-finished same-speaker group
+             *     (the tick's `characterId` is that group's character). The frontend
+             *     unions these into a per-chapter completed-id SET so each character's
+             *     mini-bar reads its EXACT done count under out-of-order completion
+             *     (poolWidth > 1 + Qwen batching), rather than approximating from the
+             *     chapter-wide `currentLine` count. Absent on the onGroupStart
+             *     heartbeat tick and on older servers — the frontend then falls back
+             *     to the `currentLine`-derived approximation. The chapter-level
+             *     `currentLine`/`progress` are unchanged (still the monotonic group
+             *     count).
+             */
+            completedSentenceIds?: number[];
+            /**
              * @description Aggregate run progress — number of non-excluded chapters in
              *     this book that are currently "done" (audio on disk). Sourced
              *     from server state, NOT computed from the slice, so the global

--- a/src/lib/generation-progress.test.ts
+++ b/src/lib/generation-progress.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import {
   characterLinePositionsByChapter,
   characterRowProgress,
+  characterSentenceIdsByChapter,
   characterStatsByChapter,
   countWords,
   estimateGenMinutes,
@@ -321,5 +322,112 @@ describe('characterRowProgress — the regenerate stale-Done regression', () => 
       currentLine: 50,
     });
     expect(r).toEqual({ derivedDone: 0, fraction: 0, fullyDone: false });
+  });
+});
+
+describe('fs-13 — exact per-character progress from the completed-id set', () => {
+  /* Under parallel synthesis (poolWidth > 1 + Qwen batching) groups complete
+     out of narrative order, so the chapter-wide `currentLine` COUNT can sit
+     ahead of or behind a given character's true done count. The set carries
+     the EXACT sentence ids that finished, so each character's bar reads its
+     real intersection regardless of completion order. */
+  const sentences: Sentence[] = [
+    { id: 1, chapterId: 2, characterId: 'narrator', text: 'a' },
+    { id: 2, chapterId: 2, characterId: 'keefe', text: 'b' },
+    { id: 3, chapterId: 2, characterId: 'narrator', text: 'c' },
+    { id: 4, chapterId: 2, characterId: 'sophie', text: 'd' },
+    { id: 5, chapterId: 2, characterId: 'sophie', text: 'e' },
+  ];
+
+  it('maps each character to their sentence ids per chapter in narrative order', () => {
+    const out = characterSentenceIdsByChapter(sentences);
+    expect(out[2].narrator).toEqual([1, 3]);
+    expect(out[2].keefe).toEqual([2]);
+    expect(out[2].sophie).toEqual([4, 5]);
+  });
+
+  it('reads an EXACT done count for a late-clustered character even when the chapter count is low', () => {
+    /* Only one group has completed so far (count = 1, currentLine = 1), but it
+       was sophie's LAST line (id 5). A currentLine/positions approximation
+       would credit sophie 0 (her positions 4,5 are both > 1); the set credits
+       exactly the one finished sentence. */
+    const ids = characterSentenceIdsByChapter(sentences)[2];
+    const completedSet = new Set([5]);
+    const r = characterRowProgress({
+      chapterState: 'in_progress',
+      status: 'queued',
+      linesTotal: 2,
+      positions: [4, 5],
+      currentLine: 1,
+      sentenceIds: ids.sophie,
+      completedSet,
+    });
+    expect(r.derivedDone).toBe(1);
+    expect(r.fraction).toBeCloseTo(0.5, 5);
+    expect(r.fullyDone).toBe(false);
+  });
+
+  it('does not over-count a character whose lines have NOT finished even when the chapter count is high', () => {
+    /* count is high (3 groups done) but none of them were keefe's line (id 2).
+       The approximation would credit keefe 1 (position 2 ≤ currentLine 3); the
+       set correctly credits 0. */
+    const ids = characterSentenceIdsByChapter(sentences)[2];
+    const completedSet = new Set([1, 3, 5]);
+    const r = characterRowProgress({
+      chapterState: 'in_progress',
+      status: 'queued',
+      linesTotal: 1,
+      positions: [2],
+      currentLine: 3,
+      sentenceIds: ids.keefe,
+      completedSet,
+    });
+    expect(r.derivedDone).toBe(0);
+    expect(r.fullyDone).toBe(false);
+  });
+
+  it('marks a character fully done when all their sentence ids are in the set', () => {
+    const ids = characterSentenceIdsByChapter(sentences)[2];
+    const r = characterRowProgress({
+      chapterState: 'in_progress',
+      status: 'queued',
+      linesTotal: 2,
+      positions: [4, 5],
+      currentLine: 5,
+      sentenceIds: ids.sophie,
+      completedSet: new Set([4, 5]),
+    });
+    expect(r.derivedDone).toBe(2);
+    expect(r.fraction).toBe(1);
+    expect(r.fullyDone).toBe(true);
+  });
+
+  it('falls back to the currentLine approximation when no completed set is present (older server)', () => {
+    /* No set / undefined → behave exactly as before: linesDoneAt(positions, currentLine). */
+    const r = characterRowProgress({
+      chapterState: 'in_progress',
+      status: 'queued',
+      linesTotal: 9,
+      positions: [10, 41, 75, 90, 101, 120, 140, 160, 175],
+      currentLine: 80,
+      sentenceIds: undefined,
+      completedSet: undefined,
+    });
+    expect(r.derivedDone).toBe(3);
+    expect(r.fraction).toBeCloseTo(3 / 9, 5);
+  });
+
+  it('still honors chapter_complete (whole chapter done) over the set', () => {
+    const ids = characterSentenceIdsByChapter(sentences)[2];
+    const r = characterRowProgress({
+      chapterState: 'done',
+      status: 'done',
+      linesTotal: 2,
+      positions: [4, 5],
+      currentLine: 0,
+      sentenceIds: ids.sophie,
+      completedSet: new Set<number>(),
+    });
+    expect(r).toEqual({ derivedDone: 2, fraction: 1, fullyDone: true });
   });
 });

--- a/src/lib/generation-progress.ts
+++ b/src/lib/generation-progress.ts
@@ -59,6 +59,26 @@ export function characterLinePositionsByChapter(
   return out;
 }
 
+/** Map of chapterId → characterId → that character's sentence ids in the
+   chapter, in narrative order.
+
+   fs-13 — the completed-id SET carried on the SSE tick keys on manuscript
+   sentence ids (the stable identity the server folds into a group), not line
+   positions. Intersecting a character's sentence ids with the chapter's
+   completed set yields an EXACT done count that holds under out-of-order
+   completion, where the `currentLine`-count approximation (`linesDoneAt`) can
+   read a character slightly high or low. */
+export function characterSentenceIdsByChapter(
+  sentences: Sentence[],
+): Record<number, Record<string, number[]>> {
+  const out: Record<number, Record<string, number[]>> = {};
+  for (const s of sentences) {
+    const chap = out[s.chapterId] ?? (out[s.chapterId] = {});
+    (chap[s.characterId] ??= []).push(s.id);
+  }
+  return out;
+}
+
 /** Count of positions ≤ currentLine. `positions` must be sorted ascending
    (which `characterLinePositionsByChapter` guarantees because it walks the
    chapter's sentences in narrative order). Binary search keeps this O(log N)
@@ -97,17 +117,33 @@ export function characterRowProgress(args: {
   linesTotal: number;
   positions: number[] | undefined;
   currentLine: number;
+  /* fs-13 — the EXACT path. When both are present, the character's done count
+     is the size of (their sentence ids ∩ the chapter's completed-id set),
+     which holds under out-of-order completion. When either is absent (older
+     server that doesn't emit `completedSentenceIds`, or before the first
+     completion tick) we fall back to the `linesDoneAt(positions, currentLine)`
+     approximation — identical to pre-fs-13 behaviour. */
+  sentenceIds?: number[] | undefined;
+  completedSet?: ReadonlySet<number> | undefined;
 }): { derivedDone: number; fraction: number; fullyDone: boolean } {
-  const { chapterState, status, linesTotal, positions, currentLine } = args;
+  const { chapterState, status, linesTotal, positions, currentLine, sentenceIds, completedSet } =
+    args;
   const chapterDone = chapterState === 'done';
-  const derivedDone = chapterDone
-    ? linesTotal
-    : status === 'skipped'
-      ? 0
+  const exactDone =
+    completedSet && sentenceIds
+      ? countInSet(sentenceIds, completedSet)
       : linesDoneAt(positions, currentLine);
+  const derivedDone = chapterDone ? linesTotal : status === 'skipped' ? 0 : exactDone;
   const fraction = linesTotal > 0 ? Math.min(1, derivedDone / linesTotal) : 0;
   const fullyDone = chapterDone || (linesTotal > 0 && derivedDone >= linesTotal);
   return { derivedDone, fraction, fullyDone };
+}
+
+/** Count how many of `ids` are present in `set`. fs-13 exact-intersection. */
+function countInSet(ids: number[], set: ReadonlySet<number>): number {
+  let n = 0;
+  for (const id of ids) if (set.has(id)) n += 1;
+  return n;
 }
 
 /** Target real-time factor: generation seconds per second of finished audio.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -23,6 +23,15 @@ export type Character = components['schemas']['Character'] & {
 export type Chapter = components['schemas']['Chapter'] & {
   phase?: 'assembling' | null;
   lufs?: components['schemas']['ChapterLoudness'] | null;
+  /* fs-13 — accumulated SET (as a Redux-serialisable array) of manuscript
+     sentence ids whose same-speaker group has COMPLETED during the live run.
+     Unioned from each progress tick's `completedSentenceIds`; cleared when the
+     chapter (re)starts. Lets the Generate view derive each character's EXACT
+     done count under out-of-order completion (poolWidth > 1 + Qwen batching)
+     instead of approximating from the chapter-wide `currentLine` count.
+     UI-only / not persisted. Absent → fall back to the `currentLine`
+     approximation (older server, or before the first completion tick). */
+  completedSentenceIds?: number[];
 };
 
 /* Sentence follows the OpenAPI spec; the optional `confidence` is a UI-only

--- a/src/store/chapters-slice.test.ts
+++ b/src/store/chapters-slice.test.ts
@@ -239,6 +239,69 @@ describe('chaptersSlice — applyGenerationTick', () => {
         eliza: 'skipped',
       });
     });
+
+    describe('fs-13 completedSentenceIds set', () => {
+      it('unions each completion tick\'s sentence ids into the chapter set, even out of narrative order', () => {
+        let state = baseState([
+          makeChapter(3, {
+            state: 'in_progress',
+            characters: { narrator: 'in_progress', halloran: 'queued', eliza: 'queued' },
+          }),
+        ]);
+        /* A late-clustered character (eliza) completes BEFORE an earlier one —
+           the set must reflect exactly what finished, not a position watermark. */
+        state = chaptersSlice.reducer(
+          state,
+          chaptersActions.applyGenerationTick(
+            tick({ type: 'progress', chapterId: 3, characterId: 'eliza', currentLine: 1, completedSentenceIds: [40, 41] }),
+          ),
+        );
+        state = chaptersSlice.reducer(
+          state,
+          chaptersActions.applyGenerationTick(
+            tick({ type: 'progress', chapterId: 3, characterId: 'narrator', currentLine: 2, completedSentenceIds: [1] }),
+          ),
+        );
+        expect([...(state.chapters[0].completedSentenceIds ?? [])].sort((a, b) => a - b)).toEqual([
+          1, 40, 41,
+        ]);
+      });
+
+      it('de-dupes a sentence id re-delivered by a heartbeat replay (idempotent union)', () => {
+        let state = baseState([makeChapter(3, { state: 'in_progress' })]);
+        const dup = tick({
+          type: 'progress',
+          chapterId: 3,
+          characterId: 'narrator',
+          currentLine: 1,
+          completedSentenceIds: [7, 8],
+        });
+        state = chaptersSlice.reducer(state, chaptersActions.applyGenerationTick(dup));
+        state = chaptersSlice.reducer(state, chaptersActions.applyGenerationTick(dup));
+        expect([...(state.chapters[0].completedSentenceIds ?? [])].sort((a, b) => a - b)).toEqual([
+          7, 8,
+        ]);
+      });
+
+      it('clears a stale set when a not-in-progress chapter receives a fresh progress tick (restart)', () => {
+        /* A chapter that was done/queued/failed and gets a new progress tick is
+           (re)starting — the prior run's completed set must not leak into it. */
+        let state = baseState([
+          makeChapter(3, {
+            state: 'done',
+            completedSentenceIds: [1, 2, 3, 4, 5],
+            characters: { narrator: 'done', halloran: 'done', eliza: 'done' },
+          }),
+        ]);
+        state = chaptersSlice.reducer(
+          state,
+          chaptersActions.applyGenerationTick(
+            tick({ type: 'progress', chapterId: 3, characterId: 'narrator', currentLine: 1, completedSentenceIds: [1] }),
+          ),
+        );
+        expect(state.chapters[0].completedSentenceIds).toEqual([1]);
+      });
+    });
   });
 
   describe('chapter_assembling', () => {

--- a/src/store/chapters-slice.ts
+++ b/src/store/chapters-slice.ts
@@ -434,11 +434,28 @@ export const chaptersSlice = createSlice({
       /* type === 'progress' — flip the live character and advance counters.
          Use the real `characterId` from the tick rather than progress
          thresholds; the server emits one per same-speaker group. */
+      /* fs-13 — a progress tick on a chapter that wasn't already in_progress
+         means a (re)start (queued→running, or a regenerate of a done/failed
+         chapter). Clear any completed-id set carried over from a prior run
+         BEFORE flipping the state below, so last run's exact bars can't leak
+         into the fresh one. Covers every restart path in one place. */
+      if (ch.state !== 'in_progress') ch.completedSentenceIds = [];
       ch.state = 'in_progress';
       ch.phase = null;
       ch.progress = ev.progress ?? ch.progress;
       if (ev.currentLine != null) ch.currentLine = ev.currentLine;
       if (ev.totalLines != null) ch.totalLines = ev.totalLines;
+      /* fs-13 — union the just-completed group's sentence ids into the
+         chapter's completed SET (the view intersects this with each
+         character's sentence ids for an EXACT done count under out-of-order
+         completion). Idempotent: a heartbeat-replayed id is absorbed by the
+         Set. Only completion ticks carry this; the onGroupStart heartbeat
+         omits it, so a started-but-unfinished group never counts as done. */
+      if (ev.completedSentenceIds && ev.completedSentenceIds.length > 0) {
+        const merged = new Set(ch.completedSentenceIds ?? []);
+        for (const id of ev.completedSentenceIds) merged.add(id);
+        ch.completedSentenceIds = [...merged];
+      }
       if (ev.characterId) {
         /* Only reconcile per-character state when the tick names a character
            we can promote. If the live speaker isn't in this chapter's cast
@@ -492,6 +509,10 @@ export const chaptersSlice = createSlice({
              doesn't show stale fractions in the gap between regenerate
              firing and the first fresh `progress` tick landing. */
           currentLine: 0,
+          /* fs-13 — drop the prior run's completed-id set so the gap between
+             regenerate firing and the first fresh progress tick doesn't show
+             stale exact bars (the first tick clears it again, belt-and-suspenders). */
+          completedSentenceIds: [],
           characters: Object.fromEntries(
             Object.entries(c.characters).map(([k, v]) => [k, v === 'done' ? 'queued' : v]),
           ) as Chapter['characters'],
@@ -529,6 +550,8 @@ export const chaptersSlice = createSlice({
           generationErrorCode: undefined,
           generationRemediation: undefined,
           currentLine: 0,
+          /* fs-13 — see regenerate-from reducer above. */
+          completedSentenceIds: [],
           characters: Object.fromEntries(
             Object.entries(c.characters).map(([k, v]) => [k, v === 'done' ? 'queued' : v]),
           ) as Chapter['characters'],

--- a/src/views/generation.tsx
+++ b/src/views/generation.tsx
@@ -59,6 +59,7 @@ import { stripChapterPrefix } from '../lib/format-chapter-title';
 import {
   characterLinePositionsByChapter,
   characterRowProgress,
+  characterSentenceIdsByChapter,
   characterStatsByChapter,
   overallProgress,
   sentencesPerChapter,
@@ -404,6 +405,11 @@ export function GenerationView({
      fractional bar in the expanded row instead of the slice's "active
      speaker only" status field. See generation-progress.ts. */
   const characterPositions = useMemo(() => characterLinePositionsByChapter(sentences), [sentences]);
+  /* fs-13 — per-character sentence ids inside each chapter. Intersected with
+     the chapter's live completed-id set for an EXACT per-character done count
+     under out-of-order completion (the positions+currentLine map above is the
+     fallback when the set is absent). */
+  const characterSentenceIds = useMemo(() => characterSentenceIdsByChapter(sentences), [sentences]);
 
   /* SSE ownership lives in src/store/generation-stream-middleware.ts so the
      stream survives navigating away from this view. The view is a pure
@@ -810,6 +816,7 @@ export function GenerationView({
               stalled={stalled}
               charStats={characterStats[ch.id]}
               charPositions={characterPositions[ch.id]}
+              charSentenceIds={characterSentenceIds[ch.id]}
               onRegenerate={onRegenerate}
               onGenerateChapter={handleGenerateChapter}
               onRegenerateCharacterInChapter={onRegenerateCharacterInChapter}
@@ -917,6 +924,9 @@ interface ChapterRowProps {
   stalled: boolean;
   charStats: Record<string, { lines: number; words: number }> | undefined;
   charPositions: Record<string, number[]> | undefined;
+  /** fs-13 — per-character sentence ids in this chapter, intersected with
+      `chapter.completedSentenceIds` for an EXACT per-character done count. */
+  charSentenceIds: Record<string, number[]> | undefined;
   onRegenerate: (ch: Chapter) => void;
   /** Escape hatch for a stuck/never-rendered `queued` row: enqueues this one
       chapter directly (no reason prompt) so the dispatcher picks it up. */
@@ -955,6 +965,7 @@ function ChapterRow({
   stalled,
   charStats,
   charPositions,
+  charSentenceIds,
   onRegenerate,
   onGenerateChapter,
   onRegenerateCharacterInChapter,
@@ -967,6 +978,19 @@ function ChapterRow({
   subsetProgress,
   activeModelKey,
 }: ChapterRowProps) {
+  /* fs-13 — the chapter's live completed sentence-id SET, built once per row
+     render and shared by every per-character bar below. Absent (undefined)
+     when the server hasn't sent any `completedSentenceIds` yet (older server,
+     or pre-first-completion) — characterRowProgress then falls back to the
+     currentLine approximation. Declared before the early return so the hook
+     order stays stable. */
+  const completedSet = useMemo(
+    () =>
+      chapter.completedSentenceIds && chapter.completedSentenceIds.length > 0
+        ? new Set(chapter.completedSentenceIds)
+        : undefined,
+    [chapter.completedSentenceIds],
+  );
   /* Render the greyed-out variant when the chapter is excluded OR a
      subset re-analysis is in flight for it. The transitional case
      (excluded flipped to false server-side but analysis is still
@@ -1316,6 +1340,11 @@ function ChapterRow({
                 linesTotal,
                 positions: charPositions?.[cid],
                 currentLine: chapter.currentLine ?? 0,
+                /* fs-13 — when the live completed-id set is present, derive this
+                   character's done count EXACTLY (set ∩ their sentence ids);
+                   otherwise fall back to the positions+currentLine count. */
+                sentenceIds: charSentenceIds?.[cid],
+                completedSet,
               });
               return (
                 <div


### PR DESCRIPTION
## Summary

Under parallel synthesis (`GPU_VRAM_BUDGET>1` + Qwen batching) groups complete out of narrative order. The per-character mini-bars in the Generate view derived their count from the chapter-wide **monotonic** `currentLine` count via `linesDoneAt(positions, currentLine)`, so a character whose lines cluster early/late could read slightly high/low until the count caught up (the residue left by PR #308, which correctly made `currentLine` a monotonic group count). `fs-13` makes each character's bar **exact** while keeping the chapter-level counter monotonic.

What landed:

- **Server (`generation.ts`)** — the `onGroupComplete` progress tick now stamps `completedSentenceIds: group.sentenceIds` (the just-finished same-speaker group's manuscript sentence ids; the tick's `characterId` is that group's character). The `onGroupStart` heartbeat deliberately omits it, so a started-but-unfinished group never counts as done. Chapter-level `currentLine`/`progress` are unchanged (still the monotonic group count).
- **Contract (`openapi.yaml` + regenerated `api-types.ts`)** — new optional `GenerationTick.completedSentenceIds: integer[]`.
- **Frontend store (`chapters-slice.ts`)** — unions each completion tick's ids into a per-chapter `completedSentenceIds` set (idempotent under heartbeat replay) and **clears** it whenever a chapter (re)starts: a not-in-progress chapter receiving a fresh progress tick (covers every restart path), plus the two regenerate reducers for the pre-tick gap.
- **Derivation (`generation-progress.ts`)** — new `characterSentenceIdsByChapter` + an exact path in `characterRowProgress` that intersects a character's sentence ids with the completed set. When the set is absent (older server, or before the first completion tick) it falls back to the existing `linesDoneAt(positions, currentLine)` approximation — identical to pre-`fs-13` behaviour.
- **View (`generation.tsx`)** — feeds the per-character sentence ids + the chapter's completed-id set into `characterRowProgress`.

**Back-compatible:** an older server that doesn't emit the field, and any chapter before its first completion tick, render exactly as before. The mock SSE is intentionally left unchanged (it advances by progress fraction and has no per-group sentence granularity), so mock mode exercises the fallback path.

## Test plan

- `server/src/routes/generation.test.ts` — a progress tick fired at a group completion carries that group's `completedSentenceIds` + character, and the per-chapter `currentLine` counter stays monotonic under out-of-order completion. (Runs in the `test:server-slow` pool.)
- `src/store/chapters-slice.test.ts` — union across out-of-order completion ticks, idempotent de-dupe on heartbeat replay, and stale-set clear when a not-in-progress chapter gets a fresh progress tick.
- `src/lib/generation-progress.test.ts` — exact per-character counts under out-of-order completion (late-clustered character reads its true done; a not-yet-finished character is not over-counted even when the chapter count is high), full-done detection, and the no-set fallback to the `currentLine` approximation.
- `npm run verify` green locally (typecheck + all tests incl. server-slow + e2e + build).

No dedicated Playwright spec: the change crosses the SSE/redux seam but not router/layout, and the visible delta (exact vs approximate bar) can only be driven through a real sentence-granular SSE stream — the mock has no per-group granularity, so an e2e would only exercise the unchanged fallback. The exact path is pinned by the unit + server-integration tests above.

Refs #422
