### PR TITLE
fix(frontend): preserve overrideTtsVoices through cast-update merge (#518)

### DIFF
--- a/src/store/cast-slice.test.ts
+++ b/src/store/cast-slice.test.ts
@@ -217,6 +217,29 @@ describe('castSlice — mergeCharacters (Phase 0a live cast snapshots)', () => {
     expect(sophie.description).toBe('Updated richer description.');
   });
 
+  it('preserves a designed Qwen voice (overrideTtsVoices) through a voiceless cast-update (#518)', () => {
+    /* Re-analysis streams a voiceless snapshot (analyzer doesn't produce voice
+       design). mergeCharacters must NOT drop overrideTtsVoices — the designed
+       Qwen voice lives there for generated characters with no voiceId. Dropping
+       it then persisting cast.json is what stripped Maruca/Grizel/Trix. */
+    const start = baseState([
+      makeChar('maruca', {
+        voiceState: 'generated',
+        overrideTtsVoices: { qwen: { name: 'qwen-maruca' } },
+      }),
+    ]);
+    const next = castSlice.reducer(
+      start,
+      castActions.mergeCharacters([
+        { id: 'maruca', name: 'Maruca', role: 'Peer', color: 'slot-18', description: 'Re-attributed.' },
+      ]),
+    );
+    const maruca = next.characters.find((c) => c.id === 'maruca')!;
+    expect(maruca.overrideTtsVoices).toEqual({ qwen: { name: 'qwen-maruca' } });
+    expect(maruca.voiceState).toBe('generated');
+    expect(maruca.description).toBe('Re-attributed.'); // fresh fields still flow
+  });
+
   it('appends new characters from a later snapshot at the end (preserves discovery order)', () => {
     const start = baseState([makeChar('sophie'), makeChar('keefe')]);
     const next = castSlice.reducer(

--- a/src/store/cast-slice.ts
+++ b/src/store/cast-slice.ts
@@ -104,16 +104,22 @@ export const castSlice = createSlice({
       for (const inc of incoming) {
         const existing = byId.get(inc.id);
         if (existing) {
-          /* Preserve voiceId / matchedFrom / matchFactors / voiceState
-             from the local entry — those came from voice matching or
-             user edits and shouldn't get clobbered by an analyser
-             snapshot that doesn't know about them. */
+          /* Preserve voice matching / design fields from the local entry —
+             those came from voice matching or the user's voice design and must
+             NOT be clobbered by an analyser snapshot that doesn't know about
+             them. `overrideTtsVoices` holds the designed Qwen voice for
+             generated characters (no voiceId); omitting it here dropped the
+             voice in Redux and a later cast persist wrote it out of cast.json
+             (#518 — Maruca/Grizel/Trix stripped on re-analysis). */
           next.push({
             ...inc,
             voiceId: existing.voiceId ?? inc.voiceId,
             matchedFrom: existing.matchedFrom ?? inc.matchedFrom,
             matchFactors: existing.matchFactors ?? inc.matchFactors,
             voiceState: existing.voiceState ?? inc.voiceState ?? 'generated',
+            overrideTtsVoices: existing.overrideTtsVoices ?? inc.overrideTtsVoices,
+            ttsEngine: existing.ttsEngine ?? inc.ttsEngine,
+            voiceStyle: existing.voiceStyle ?? inc.voiceStyle,
           });
         } else {
           next.push(inc.voiceState ? inc : { ...inc, voiceState: 'generated' });


### PR DESCRIPTION
## Summary

The **client‑side companion** to plan 183 — and the piece that was still stripping designed voices on re‑analysis.

`mergeCharacters` (the cast reducer that applies every analyzer `cast-update` during re‑analysis) preserved `voiceId` / `matchedFrom` / `matchFactors` / `voiceState` from the existing character — but **dropped `overrideTtsVoices`**, where the designed **Qwen** voice lives for *generated* characters (which have no `voiceId`). So:

1. Re‑analysis streamed a voiceless snapshot → `mergeCharacters` spread the incoming char and re‑added voiceId/voiceState but **lost `overrideTtsVoices`** in Redux.
2. A later cast persist wrote that voiceless roster to `cast.json` → strip (Maruca, Grizel, Trix, …).

This is why the server‑side merge (plan 183, #521) *looked* insufficient: the strip was happening in a **Redux reducer**, downstream of the server. It also matches the data exactly — reused chars kept `voiceId` but lost `overrideTtsVoices`; generated chars (no `voiceId`, only `overrideTtsVoices`) lost everything voice‑related.

## Fix

Add `overrideTtsVoices`, `ttsEngine`, `voiceStyle` to the preserve list in `mergeCharacters` (`src/store/cast-slice.ts`).

## Test plan

- `src/store/cast-slice.test.ts`: new case — a designed Qwen voice (`overrideTtsVoices`) survives a voiceless `cast-update`, while fresh attribution fields still flow through.
- `npm run verify` green locally (lint, typecheck, all test tiers, e2e, visual, build). Frontend 2264, server 2007 + slow 173.

Together with plan 183 (#521, server‑side cast writes) and the relink recovery script, re‑analysis now preserves designed voices end‑to‑end — server *and* client.

Refs #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)
