### PR TITLE
fix(scripts): repair start:prod spawn + add start/stop-prod .bat wrappers

### DIFF
--- a/scripts/start-app-prod.mjs
+++ b/scripts/start-app-prod.mjs
@@ -81,14 +81,21 @@ if (alreadyUp) {
 const outLog = openSync(resolve(logDir, 'server.log'), 'a');
 const errLog = openSync(resolve(logDir, 'server.err.log'), 'a');
 
-const isWindows = process.platform === 'win32';
-const npmCmd = isWindows ? 'npm.cmd' : 'npm';
+const serverDir = resolve(repoRoot, 'server');
 
-const child = spawn(npmCmd, ['--prefix', 'server', 'run', 'start'], {
-  cwd: repoRoot,
+/* Spawn the built server directly with the current Node binary instead of going
+   through `npm.cmd` — on Node >=20.6 spawning a `.cmd` without `shell: true`
+   throws EINVAL on Windows (the CVE-2024-27980 mitigation), which broke
+   `npm run start:prod`. Running `node dist/index.js` with cwd=server is simpler
+   and ALSO guarantees `process.loadEnvFile('.env')` resolves server/.env
+   (it's cwd-relative) — so prod gets the same WORKSPACE_DIR / analyzer / GPU
+   tuning the dev server reads. detached + unref so the server outlives this
+   launcher and the console window that double-clicked the .bat. */
+const child = spawn(process.execPath, ['dist/index.js'], {
+  cwd: serverDir,
   env: { ...process.env, NODE_ENV: 'production' },
   stdio: ['ignore', outLog, errLog],
-  detached: !isWindows,
+  detached: true,
   windowsHide: true,
 });
 
@@ -99,7 +106,7 @@ if (typeof child.pid !== 'number') {
 writeFileSync(resolve(runDir, 'server.pid'), String(child.pid), 'utf8');
 info(`[START] server pid=${child.pid} -> logs/server.log (NODE_ENV=production)`);
 
-if (!isWindows) child.unref();
+child.unref();
 
 const ready = await waitForListen(SERVER_PORT, HEALTH_TIMEOUT_MS);
 if (!ready) {

--- a/start-prod.bat
+++ b/start-prod.bat
@@ -1,0 +1,18 @@
+@echo off
+REM ===========================================================================
+REM Start the Audiobook Generator in PRODUCTION mode (built bundle, no watcher).
+REM Double-click this file, or run it from a terminal. The server is launched
+REM detached, so it keeps running after this window closes. Logs go to
+REM logs\server.log; stop it later with stop-prod.bat.
+REM ===========================================================================
+cd /d "%~dp0"
+
+call npm run start:prod
+if errorlevel 1 (
+  echo.
+  echo [start-prod] Launch failed. If the bundle is missing, build it first:
+  echo                npm run build
+)
+
+echo.
+pause

--- a/stop-prod.bat
+++ b/stop-prod.bat
@@ -1,0 +1,12 @@
+@echo off
+REM ===========================================================================
+REM Stop the PRODUCTION Audiobook Generator started by start-prod.bat.
+REM Kills the server + its TTS sidecar (via .run\*.pid), then sweeps any
+REM leftover listeners on :8080 / :9000.
+REM ===========================================================================
+cd /d "%~dp0"
+
+call npm run stop:prod
+
+echo.
+pause


### PR DESCRIPTION
## Summary

Fixes `npm run start:prod` (it was dead on Windows + Node >=20.6) and adds double-clickable start/stop wrappers.

- **`scripts/start-app-prod.mjs` (bug fix):** the launcher spawned `npm.cmd`, which throws `spawn EINVAL` on Node >=20.6 on Windows (the CVE-2024-27980 `.cmd` mitigation) — so `npm run start:prod` crashed before starting anything. It also ran from the repo root, so the server's cwd-relative `process.loadEnvFile('.env')` missed `server/.env` and silently fell back to the wrong in-repo workspace (`<repo>/audiobook-workspace`) with no analyzer/GPU config. Now it spawns `node dist/index.js` directly with `cwd: server/` and the current Node binary: no `.cmd` spawn, and `server/.env` always resolves (correct `WORKSPACE_DIR` / analyzer / GPU tuning). Spawns detached + unref on all platforms so the server outlives the launcher and a closed console window; the recorded PID is now the real server pid.
- **`start-prod.bat` / `stop-prod.bat` (new):** repo-root wrappers over `npm run start:prod` / `npm run stop:prod`. Double-click from Explorer or run from a terminal; they `pause` at the end so the output is readable on double-click.

No linked issue — dev-tooling fix surfaced while bringing the prod server up.

## Test plan

- `npm run start:prod` → comes up clean on `:8080`, no `EINVAL`, log shows `workspace root: C:\AudiobookWorkspace` (proves `server/.env` loaded), `server.pid` written. ✅ verified live on Windows + Node 24.
- `stop-app.mjs` is unchanged and reads the same `server.pid`; not re-run here because the server is in active use, but the PID-file contract it depends on is confirmed present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)