### PR TITLE
fix(server): report cuda in health GPU row when only Qwen is loaded

### DIFF
--- a/server/src/routes/diagnostics.test.ts
+++ b/server/src/routes/diagnostics.test.ts
@@ -110,10 +110,39 @@ describe('GET /api/diagnostics', () => {
   });
 
   it('treats a CPU-only sidecar as ok (no GPU is not a failure)', async () => {
-    probeSidecarHealth.mockResolvedValue({ status: 'reachable', url: '', proxy: 'sidecar', device: null });
+    /* CPU-only = device null AND no VRAM figures (torch.cuda.is_available() is
+       false, so the sidecar reports no vramTotalMb). */
+    probeSidecarHealth.mockResolvedValue({
+      status: 'reachable',
+      url: '',
+      proxy: 'sidecar',
+      device: null,
+      vramTotalMb: null,
+    });
     const res = await request(makeApp()).get('/api/diagnostics');
     expect(byId(res.body.checks, 'gpu').status).toBe('ok');
     expect(byId(res.body.checks, 'gpu').detail).toMatch(/CPU/i);
+  });
+
+  it('reports cuda for a Qwen-on-GPU sidecar even when device is null (Coqui idle)', async () => {
+    /* Regression: the GPU row used to key off the Coqui-only `device` field, so a
+       Qwen run (Coqui not loaded → device null) showed "CPU — no GPU detected"
+       despite VRAM figures proving CUDA is present. */
+    probeSidecarHealth.mockResolvedValue({
+      status: 'reachable',
+      url: '',
+      proxy: 'sidecar',
+      device: null,
+      vramReservedMb: 3072,
+      vramTotalMb: 8192,
+      qwenLoaded: true,
+    });
+    const res = await request(makeApp()).get('/api/diagnostics');
+    const gpu = byId(res.body.checks, 'gpu');
+    expect(gpu.status).toBe('ok');
+    expect(gpu.detail).toMatch(/cuda/);
+    expect(gpu.detail).toMatch(/8\.0 GB/);
+    expect(gpu.detail).not.toMatch(/CPU/i);
   });
 
   it('skips the Ollama analyzer check when the engine is Gemini', async () => {

--- a/server/src/routes/diagnostics.ts
+++ b/server/src/routes/diagnostics.ts
@@ -91,7 +91,15 @@ diagnosticsRouter.get('/', async (_req: Request, res: Response) => {
         };
       }
       const device = sidecar.device ?? null;
-      if (device !== 'cuda') {
+      const reserved = sidecar.vramReservedMb;
+      const total = sidecar.vramTotalMb;
+      /* CUDA presence is engine-independent: the sidecar reports vramTotalMb iff
+         torch.cuda.is_available() (see _cuda_vram_mb). Don't key off the `device`
+         field alone — it only reflects the Coqui engine and only when Coqui is
+         loaded, so a Qwen-only run (Coqui idle) reports device=null while the GPU
+         is plainly in use. */
+      const cudaPresent = device === 'cuda' || total != null;
+      if (!cudaPresent) {
         return {
           id: 'gpu',
           label: 'GPU / VRAM',
@@ -99,8 +107,6 @@ diagnosticsRouter.get('/', async (_req: Request, res: Response) => {
           detail: device ? `device: ${device}` : 'CPU — no GPU detected',
         };
       }
-      const reserved = sidecar.vramReservedMb;
-      const total = sidecar.vramTotalMb;
       const queue = readGpuQueueState();
       const ratio = reserved != null && total != null && total > 0 ? reserved / total : null;
       const status: CheckStatus = ratio != null && ratio > 0.85 ? 'warn' : 'ok';


### PR DESCRIPTION
## Summary

The Admin → Health board showed **GPU / VRAM: "CPU — no GPU detected"** during normal Qwen generation, even though the discrete NVIDIA GPU was present and in active use (the same board reads *TTS sidecar: reachable · qwen*, and Qwen only loads on CUDA).

Root cause: the sidecar `/health` `device` field is populated **only from the Coqui engine, and only when Coqui has a model loaded** (`server/tts-sidecar/main.py:2423-2432`). A Qwen-only run leaves Coqui idle → `device: null` → the diagnostics aggregator (`server/src/routes/diagnostics.ts`) mapped `null` to "CPU — no GPU detected" and returned early, ignoring the truthful VRAM figures already in the same response.

Fix: key the GPU row off the engine-independent `vramTotalMb` (the sidecar reports it iff `torch.cuda.is_available()`) instead of the Coqui-only `device` string. A genuinely CPU-only sidecar (no VRAM figures) still correctly reads "no GPU detected". No sidecar change needed — the figure was already on the wire, and the top-level `device` field has no other consumer.

## Test plan

- New regression test in `diagnostics.test.ts`: a Qwen-on-GPU sidecar (`device: null`, `vramTotalMb: 8192`, `qwenLoaded: true`) now yields an `ok` gpu row whose detail reads `cuda · … GB reserved` — fails before the fix, passes after.
- Tightened the existing CPU-only test to pin the verdict on absence of VRAM figures, not merely a null device.
- `npm run verify` green locally (typecheck + all tests + e2e + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)