### PR TITLE
fix(server,scripts): durable cast-PUT guard preserves designed voices + Stellarlune recovery

### DIFF
--- a/scripts/repair-reanalysis-dropped-chapters.mjs
+++ b/scripts/repair-reanalysis-dropped-chapters.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/* Repair a book whose re-analysis loop dropped narration data.
+
+   The 2026-06-05 Stellarlune incident: navigating a confirmed book into the
+   analysing -> cast-confirm flow re-parsed the manuscript and re-ran analysis,
+   which (a) cleared the `excluded` flags on non-narration chapters (Cover,
+   Dedication, back-matter) so the book's status flipped back to 'analysing',
+   and (b) dropped a chapter that had been added post-hoc via the Generate
+   screen (the Preface, ch3) from BOTH manuscript-edits.json and the analysis
+   cache — even though its audio was already rendered. With one narration
+   chapter missing from the cache, `analysisComplete` (server/src/workspace/
+   scan.ts) never reaches true, so the book is stranded on the strip-prone
+   analysing flow.
+
+   This restores, from a known-good UPGRADE BACKUP of the same book:
+     1. `excluded: true` flags present in the backup but missing in live
+        state.json (only ADDS flags — never removes a live one).
+     2. manuscript-edits.json sentences for any NON-EXCLUDED chapter present in
+        the backup but absent in live (inserted in ascending chapterId order;
+        per-chapter sentence ids are preserved, nothing is renumbered).
+     3. cache.chapters[<id>] for each such restored chapter, rebuilt as the
+        sentence-index map the analyzer writes ({ "0": {id:1,...}, ... }) from
+        the backup sentences — the cache itself is never backed up, so it is
+        reconstructed from the backup manuscript-edits (identical sentence
+        shape: id/chapterId/characterId/text/confidence).
+
+   Live chapters that already have data are left untouched (idempotent). Every
+   written file is copied to `<file>.bak-repair-<ts>` first.
+
+   Dry-run by default. Pass --apply to write.
+
+   Config via env (defaults target the Stellarlune incident):
+     BOOK_DIR        live book dir (contains .audiobook/, audio/)
+     BACKUP_BOOK_DIR known-good backup of the same book dir
+     CACHE_FILE      analysis cache json (server/handoff/cache/<manuscriptId>.json)
+
+   Usage:
+     node scripts/repair-reanalysis-dropped-chapters.mjs           # dry-run
+     node scripts/repair-reanalysis-dropped-chapters.mjs --apply    # write
+*/
+
+import { readFileSync, writeFileSync, copyFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const APPLY = process.argv.includes('--apply');
+
+const BOOK_DIR =
+  process.env.BOOK_DIR ??
+  'C:/AudiobookWorkspace/books/Shannon Messenger/Keeper of the Lost Cities/Stellarlune';
+const BACKUP_BOOK_DIR =
+  process.env.BACKUP_BOOK_DIR ??
+  'C:/AudiobookWorkspace/.upgrade-backups/from-1.5.1-to-1.6.0-2026-06-03T08-50-28-849Z/books/Shannon Messenger/Keeper of the Lost Cities/Stellarlune';
+const CACHE_FILE =
+  process.env.CACHE_FILE ?? 'server/handoff/cache/mns_SrHkwRVFEu.json';
+
+const readJson = (p) => JSON.parse(readFileSync(p, 'utf8'));
+const stamp = () => new Date().toISOString().replace(/[:.]/g, '-');
+
+function backupThenWrite(path, value) {
+  if (!APPLY) return;
+  if (existsSync(path)) copyFileSync(path, `${path}.bak-repair-${stamp()}`);
+  writeFileSync(path, JSON.stringify(value, null, 2));
+}
+
+const liveStatePath = join(BOOK_DIR, '.audiobook', 'state.json');
+const liveEditsPath = join(BOOK_DIR, '.audiobook', 'manuscript-edits.json');
+const bupStatePath = join(BACKUP_BOOK_DIR, '.audiobook', 'state.json');
+const bupEditsPath = join(BACKUP_BOOK_DIR, '.audiobook', 'manuscript-edits.json');
+
+for (const p of [liveStatePath, liveEditsPath, bupStatePath, bupEditsPath, CACHE_FILE]) {
+  if (!existsSync(p)) {
+    console.error(`MISSING required file: ${p}`);
+    process.exit(1);
+  }
+}
+
+const liveState = readJson(liveStatePath);
+const bupState = readJson(bupStatePath);
+const liveEdits = readJson(liveEditsPath);
+const bupEdits = readJson(bupEditsPath);
+const cache = readJson(CACHE_FILE);
+
+console.log(`Mode: ${APPLY ? 'APPLY (writing)' : 'DRY-RUN (no writes)'}`);
+console.log(`Book:   ${BOOK_DIR}`);
+console.log(`Backup: ${BACKUP_BOOK_DIR}`);
+console.log(`Cache:  ${CACHE_FILE}\n`);
+
+/* --- 1. Restore missing `excluded` flags ------------------------------- */
+const bupExcluded = new Set(
+  (bupState.chapters ?? []).filter((c) => c.excluded).map((c) => c.id),
+);
+const liveById = new Map((liveState.chapters ?? []).map((c) => [c.id, c]));
+const flagsToRestore = [];
+for (const id of bupExcluded) {
+  const live = liveById.get(id);
+  if (live && !live.excluded) {
+    flagsToRestore.push(`${id}:${live.title}`);
+    live.excluded = true;
+  }
+}
+console.log(`[1] excluded flags to restore (${flagsToRestore.length}): ${flagsToRestore.join(', ') || 'none'}`);
+
+/* --- 2 & 3. Restore dropped NON-EXCLUDED chapters --------------------- */
+const liveExcludedNow = new Set(
+  (liveState.chapters ?? []).filter((c) => c.excluded).map((c) => c.id),
+);
+const liveEditChapterIds = new Set(liveEdits.sentences.map((s) => s.chapterId));
+const bupByChapter = new Map();
+for (const s of bupEdits.sentences) {
+  if (!bupByChapter.has(s.chapterId)) bupByChapter.set(s.chapterId, []);
+  bupByChapter.get(s.chapterId).push(s);
+}
+
+const restoredChapters = [];
+for (const [chId, sentences] of [...bupByChapter].sort((a, b) => a[0] - b[0])) {
+  if (liveExcludedNow.has(chId)) continue; // non-narration — flag only
+  if (liveEditChapterIds.has(chId)) continue; // already present in live
+  // (a) insert sentences into manuscript-edits, keeping ascending chapterId order
+  const insertAt = liveEdits.sentences.findIndex((s) => s.chapterId > chId);
+  const idx = insertAt === -1 ? liveEdits.sentences.length : insertAt;
+  liveEdits.sentences.splice(idx, 0, ...sentences);
+  // (b) rebuild cache.chapters[chId] as the sentence-index map (key = id-1)
+  cache.chapters ??= {};
+  if (!cache.chapters[String(chId)]) {
+    const map = {};
+    for (const s of sentences) map[String(s.id - 1)] = s;
+    cache.chapters[String(chId)] = map;
+  }
+  restoredChapters.push(`${chId} (${sentences.length} sentences)`);
+}
+console.log(`[2] manuscript-edits chapters restored (${restoredChapters.length}): ${restoredChapters.join(', ') || 'none'}`);
+console.log(`[3] cache.chapters keys restored: ${restoredChapters.length ? restoredChapters.map((c) => c.split(' ')[0]).join(', ') : 'none'}`);
+
+/* --- write ------------------------------------------------------------- */
+if (flagsToRestore.length) backupThenWrite(liveStatePath, liveState);
+if (restoredChapters.length) {
+  backupThenWrite(liveEditsPath, liveEdits);
+  backupThenWrite(CACHE_FILE, cache);
+}
+
+console.log(
+  `\n${APPLY ? 'Done — files written (originals backed up to .bak-repair-*).' : 'Dry-run complete. Re-run with --apply to write.'}`,
+);

--- a/server/src/routes/book-state-preserve-voices.test.ts
+++ b/server/src/routes/book-state-preserve-voices.test.ts
@@ -1,0 +1,145 @@
+/* Durable guard regression — PUT /:bookId/state slice=cast must never strip a
+   designed Qwen voice off a GENERATED character (the 2026-06-05 Stellarlune
+   incident).
+
+   A generated character stores its bespoke voice in `overrideTtsVoices.qwen`
+   with NO `voiceId` (unlike a reused character). The srv-14 denormalise pass
+   only fills voices for REUSED characters (it walks `matchedFrom`), so it can't
+   protect a generated one. When the analysing→cast-confirm flow persisted a
+   voiceless in-memory cast, the PUT overwrote cast.json and erased the designed
+   voice. `preserveDesignedVoicesOnCastWrite` (wired ahead of the denormalise
+   pass) fills the dropped voice-design fields from the on-disk character.
+
+   Kept in its own fast-tier file (NOT book-state.test.ts, pinned slow) so the
+   fixture setup doesn't compound the slow-run hook-timeout pressure. */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { rmSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import express, { type Express } from 'express';
+import request from 'supertest';
+
+const AUTHOR = 'Preserve Author';
+const SERIES = 'Preserve Series';
+const TITLE = 'Only Book';
+
+let workspaceRoot: string;
+let app: Express;
+let bookId: string;
+let bookDir: string;
+
+function writeBook(dir: string, id: string, characters: unknown[]): void {
+  mkdirSync(join(dir, '.audiobook'), { recursive: true });
+  writeFileSync(
+    join(dir, '.audiobook', 'state.json'),
+    JSON.stringify({
+      bookId: id,
+      manuscriptId: `m_${TITLE}`,
+      title: TITLE,
+      author: AUTHOR,
+      series: SERIES,
+      seriesPosition: 1,
+      isStandalone: false,
+      manuscriptFile: 'manuscript.txt',
+      castConfirmed: true,
+      chapters: [{ id: 1, title: 'Chapter 1', slug: 'chapter-one' }],
+      coverGradient: ['#000', '#fff'],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }),
+  );
+  writeFileSync(join(dir, 'manuscript.txt'), 'placeholder');
+  writeFileSync(join(dir, '.audiobook', 'cast.json'), JSON.stringify({ characters }));
+}
+
+function onDiskCast(): { characters: Array<Record<string, unknown> & { id: string }> } {
+  return JSON.parse(readFileSync(join(bookDir, '.audiobook', 'cast.json'), 'utf8'));
+}
+
+beforeAll(async () => {
+  workspaceRoot = await mkdtemp(join(tmpdir(), 'audiobook-preserve-voices-test-'));
+  process.env.WORKSPACE_DIR = workspaceRoot;
+
+  const [{ bookStateRouter }, { makeBookId }] = await Promise.all([
+    import('./book-state.js'),
+    import('../workspace/paths.js'),
+  ]);
+  bookId = makeBookId(AUTHOR, SERIES, TITLE);
+  bookDir = join(workspaceRoot, 'books', AUTHOR, SERIES, TITLE);
+
+  /* Maruca — a GENERATED character (no voiceId): her designed voice lives
+     only in overrideTtsVoices.qwen. */
+  writeBook(bookDir, bookId, [
+    {
+      id: 'maruca',
+      name: 'Maruca',
+      role: 'minor',
+      color: '#abc',
+      voiceState: 'generated',
+      ttsEngine: 'qwen',
+      overrideTtsVoices: { qwen: { name: 'qwen-maruca' } },
+      voiceStyle: 'a wry, steady woman',
+    },
+  ]);
+
+  app = express();
+  app.use(express.json());
+  app.use('/api/books', bookStateRouter);
+});
+
+afterAll(() => {
+  if (workspaceRoot) rmSync(workspaceRoot, { recursive: true, force: true });
+  delete process.env.WORKSPACE_DIR;
+});
+
+describe('book-state PUT cast — designed-voice preservation (durable strip guard)', () => {
+  it('preserves a generated character\'s designed voice when the UI sends a voiceless cast', async () => {
+    /* The strip payload: the cast-confirm flow re-derived the roster and lost
+       Maruca's voice fields entirely. */
+    const incoming = {
+      slice: 'cast',
+      patch: {
+        characters: [{ id: 'maruca', name: 'Maruca', role: 'minor', color: '#abc', voiceState: 'generated' }],
+      },
+    };
+    const res = await request(app)
+      .put(`/api/books/${bookId}/state`)
+      .set('Content-Type', 'application/json')
+      .send(incoming);
+    expect(res.status).toBe(204);
+
+    const maruca = onDiskCast().characters.find((c) => c.id === 'maruca')!;
+    expect(maruca.overrideTtsVoices).toEqual({ qwen: { name: 'qwen-maruca' } });
+    expect(maruca.ttsEngine).toBe('qwen');
+    expect(maruca.voiceStyle).toBe('a wry, steady woman');
+  });
+
+  it('lets a deliberate re-design overwrite the on-disk voice (incoming wins)', async () => {
+    const incoming = {
+      slice: 'cast',
+      patch: {
+        characters: [
+          {
+            id: 'maruca',
+            name: 'Maruca',
+            role: 'minor',
+            color: '#abc',
+            voiceState: 'generated',
+            ttsEngine: 'qwen',
+            overrideTtsVoices: { qwen: { name: 'qwen-maruca-v2' } },
+          },
+        ],
+      },
+    };
+    const res = await request(app)
+      .put(`/api/books/${bookId}/state`)
+      .set('Content-Type', 'application/json')
+      .send(incoming);
+    expect(res.status).toBe(204);
+
+    const maruca = onDiskCast().characters.find((c) => c.id === 'maruca')!;
+    expect(maruca.overrideTtsVoices).toEqual({ qwen: { name: 'qwen-maruca-v2' } });
+  });
+});

--- a/server/src/routes/book-state.ts
+++ b/server/src/routes/book-state.ts
@@ -49,6 +49,7 @@ import { snapshotInFlightAnalysis } from './analysis.js';
 import { hydrateCastReusedVoices } from '../tts/hydrate-reused-voice-workspace.js';
 import type { ReuseHydratable } from '../tts/hydrate-reused-voice.js';
 import { PRESERVED_VOICE_FIELDS } from '../store/merge-analysis-cast.js';
+import { preserveDesignedVoicesOnCastWrite } from '../workspace/preserve-cast-voices.js';
 import { collectRenderedFallbackEngines } from '../audio/segments-io.js';
 import type { LoudnormSidecarJson } from '../tts/loudnorm.js';
 
@@ -74,6 +75,26 @@ async function denormaliseCastReusedVoices(patch: unknown): Promise<unknown> {
   }
   const cast = patch as { characters: ReuseHydratable[] };
   const characters = await hydrateCastReusedVoices(cast.characters);
+  return { ...cast, characters };
+}
+
+/* Fill any incoming character's missing voice-DESIGN fields from the on-disk
+   cast.json before the persist (the durable guard against the 2026-06-05
+   Stellarlune strip, where the analysing→cast-confirm flow persisted a
+   voiceless in-memory cast and erased the designed Qwen voices). INCOMING WINS
+   when present; the existing value fills only the gap. Reuse-link fields are
+   left to `denormaliseCastReusedVoices` so unlink still works. Tolerates a
+   non-cast-shaped patch (returns it untouched) so the funnel stays generic. */
+async function preserveDesignedVoices(bookDir: string, patch: unknown): Promise<unknown> {
+  if (!patch || typeof patch !== 'object' || !Array.isArray((patch as { characters?: unknown }).characters)) {
+    return patch;
+  }
+  const cast = patch as { characters: Array<{ id: string } & Record<string, unknown>> };
+  const existing = await readJson<{ characters?: Array<{ id: string } & Record<string, unknown>> }>(
+    castJsonPath(bookDir),
+  );
+  const existingChars = existing?.characters ?? [];
+  const characters = preserveDesignedVoicesOnCastWrite(existingChars, cast.characters);
   return { ...cast, characters };
 }
 
@@ -450,9 +471,11 @@ bookStateRouter.put('/:bookId/state', async (req: Request, res: Response) => {
 
     const { bookDir, state } = located;
     switch (body.slice) {
-      case 'cast':
-        await writeJsonAtomic(castJsonPath(bookDir), await denormaliseCastReusedVoices(body.patch));
+      case 'cast': {
+        const guarded = await preserveDesignedVoices(bookDir, body.patch);
+        await writeJsonAtomic(castJsonPath(bookDir), await denormaliseCastReusedVoices(guarded));
         break;
+      }
       case 'manuscript':
         await writeJsonAtomic(manuscriptEditsJsonPath(bookDir), body.patch);
         break;

--- a/server/src/workspace/preserve-cast-voices.test.ts
+++ b/server/src/workspace/preserve-cast-voices.test.ts
@@ -1,0 +1,68 @@
+/* Durable guard: a cast write (PUT /api/books/:id/state slice:'cast') must never
+   strip a designed voice. Every frontend cast write funnels through that one
+   handler — the persistence middleware (auto-save on cast actions), manual cast
+   edits, and the cast-confirm/rebaseline screen. The 2026-06-05 incident: the
+   book routed to the analysing→cast-confirm flow, which persisted a voiceless
+   in-memory cast and overwrote the designed Qwen voices on disk.
+
+   `preserveDesignedVoicesOnCastWrite` fills each incoming character's missing
+   voice-DESIGN fields (`overrideTtsVoices`, `ttsEngine`, `voiceStyle`) from the
+   existing on-disk character — INCOMING WINS when present (so a deliberate
+   re-design still writes), existing fills only the gap. Reuse-link fields
+   (voiceId / matchedFrom / voiceState) are NOT touched: those have legitimate
+   clear flows (unlink) and are already hydrated by denormaliseCastReusedVoices. */
+
+import { describe, it, expect } from 'vitest';
+import { preserveDesignedVoicesOnCastWrite } from './preserve-cast-voices.js';
+
+type C = Record<string, unknown> & { id: string };
+
+describe('preserveDesignedVoicesOnCastWrite', () => {
+  it('fills a dropped overrideTtsVoices from the existing cast (the strip fix)', () => {
+    const existing: C[] = [
+      { id: 'maruca', name: 'Maruca', voiceState: 'generated', overrideTtsVoices: { qwen: { name: 'qwen-maruca' } } },
+    ];
+    const incoming: C[] = [{ id: 'maruca', name: 'Maruca', voiceState: 'generated' }]; // voiceless
+    const out = preserveDesignedVoicesOnCastWrite(existing, incoming);
+    expect(out[0].overrideTtsVoices).toEqual({ qwen: { name: 'qwen-maruca' } });
+  });
+
+  it('lets a deliberate re-design win (incoming overrideTtsVoices present)', () => {
+    const existing: C[] = [{ id: 'maruca', overrideTtsVoices: { qwen: { name: 'qwen-maruca' } } }];
+    const incoming: C[] = [{ id: 'maruca', overrideTtsVoices: { qwen: { name: 'qwen-maruca-v2' } } }];
+    const out = preserveDesignedVoicesOnCastWrite(existing, incoming);
+    expect(out[0].overrideTtsVoices).toEqual({ qwen: { name: 'qwen-maruca-v2' } });
+  });
+
+  it('preserves ttsEngine and voiceStyle the same way', () => {
+    const existing: C[] = [{ id: 'x', ttsEngine: 'qwen', voiceStyle: 'a warm voice' }];
+    const incoming: C[] = [{ id: 'x' }];
+    const out = preserveDesignedVoicesOnCastWrite(existing, incoming);
+    expect(out[0].ttsEngine).toBe('qwen');
+    expect(out[0].voiceStyle).toBe('a warm voice');
+  });
+
+  it('does NOT touch reuse-link fields (voiceId / matchedFrom / voiceState) — unlink must work', () => {
+    const existing: C[] = [{ id: 'flori', voiceId: 'flori', matchedFrom: { bookId: 'u' }, voiceState: 'reused' }];
+    const incoming: C[] = [{ id: 'flori' }]; // user unlinked → cleared
+    const out = preserveDesignedVoicesOnCastWrite(existing, incoming);
+    expect(out[0].voiceId).toBeUndefined();
+    expect(out[0].matchedFrom).toBeUndefined();
+    expect(out[0].voiceState).toBeUndefined();
+  });
+
+  it('keeps a new character (not in existing) untouched and carries fresh fields through', () => {
+    const existing: C[] = [{ id: 'a', overrideTtsVoices: { qwen: { name: 'qwen-a' } } }];
+    const incoming: C[] = [{ id: 'a', name: 'A', description: 'updated' }, { id: 'b', name: 'B' }];
+    const out = preserveDesignedVoicesOnCastWrite(existing, incoming);
+    expect(out.map((c) => c.id)).toEqual(['a', 'b']);
+    expect(out[0].overrideTtsVoices).toEqual({ qwen: { name: 'qwen-a' } });
+    expect(out[0].description).toBe('updated'); // fresh fields flow
+    expect(out[1].overrideTtsVoices).toBeUndefined();
+  });
+
+  it('returns the incoming unchanged when there is no existing cast', () => {
+    const incoming: C[] = [{ id: 'a' }];
+    expect(preserveDesignedVoicesOnCastWrite([], incoming)).toEqual(incoming);
+  });
+});

--- a/server/src/workspace/preserve-cast-voices.ts
+++ b/server/src/workspace/preserve-cast-voices.ts
@@ -1,0 +1,37 @@
+/* Durable guard against stripping designed voices on a cast write.
+
+   Every frontend cast write goes through the PUT /api/books/:id/state
+   slice:'cast' handler — the persistence middleware's auto-save, manual cast
+   edits, and the cast-confirm/rebaseline screen. That handler overwrites
+   cast.json with whatever the UI sends. If the UI's in-memory cast lost a
+   character's designed Qwen voice (a stale bundle, an analyzer cast-update, the
+   confirm screen), the write erases it from disk — the 2026-06-05 Stellarlune
+   incident, where the analysing→cast-confirm flow stripped Maruca/Grizel/Trix.
+
+   This fills each incoming character's missing voice-DESIGN fields from the
+   existing on-disk character. INCOMING WINS when present (a deliberate
+   re-design still writes its new value); the existing value fills only the gap.
+   Reuse-link fields (`voiceId` / `matchedFrom` / `voiceState`) are deliberately
+   NOT preserved — those have legitimate clear flows (unlink) and are hydrated
+   separately by `denormaliseCastReusedVoices`. */
+
+/** Voice-DESIGN fields the analyzer / persistence never legitimately clears, so
+    a write that omits them is an accidental strip, not an intentional change. */
+const PRESERVED_DESIGN_FIELDS = ['overrideTtsVoices', 'ttsEngine', 'voiceStyle'] as const;
+
+export function preserveDesignedVoicesOnCastWrite<T extends { id: string }>(
+  existing: ReadonlyArray<{ id: string } & Record<string, unknown>>,
+  incoming: T[],
+): T[] {
+  if (!existing.length) return incoming;
+  const byId = new Map(existing.map((c) => [c.id, c]));
+  return incoming.map((inc) => {
+    const old = byId.get(inc.id);
+    if (!old) return inc;
+    const merged = { ...(inc as Record<string, unknown>) };
+    for (const key of PRESERVED_DESIGN_FIELDS) {
+      if (merged[key] === undefined && old[key] !== undefined) merged[key] = old[key];
+    }
+    return merged as T;
+  });
+}


### PR DESCRIPTION
## Summary

The definitive, server-side fix for the 2026-06-05 Stellarlune voice-strip (reopened #518). After #521 (re-analysis write sites) and #522 (frontend `mergeCharacters` reducer), voices **still** didn't hold — because a third layer was exposed: the generic cast persist handler `PUT /api/books/:id/state` slice=`cast`. Every frontend cast write funnels through it (persistence-middleware auto-save, manual edits, the cast-confirm/rebaseline screen), and it overwrote `cast.json` with whatever the UI sent. The srv-14 `denormaliseCastReusedVoices` pass only guards **reused** characters (it walks `matchedFrom`); a **generated** character stores its designed voice in `overrideTtsVoices.qwen` with no `voiceId`, so nothing protected it. When the analysing→cast-confirm flow persisted a voiceless in-memory cast, the handler erased the on-disk voices.

`preserveDesignedVoicesOnCastWrite(existing, incoming)` (new `server/src/workspace/preserve-cast-voices.ts`) fills each incoming character's missing voice-DESIGN fields (`overrideTtsVoices`, `ttsEngine`, `voiceStyle`) from the on-disk character before the persist. **Incoming wins** when present (a deliberate re-design still writes); the existing value fills only the gap. Reuse-link fields (`voiceId`/`matchedFrom`/`voiceState`) are deliberately **not** preserved so unlink still works — they stay hydrated by `denormaliseCastReusedVoices`. Wired ahead of the denormalise pass in the cast PUT case.

This completes defense-in-depth across all three strip vectors:
- plan 183 / #521 — re-analysis cast writes (server)
- #522 — `mergeCharacters` Redux reducer (frontend)
- **this PR** — the generic cast persist handler (server) ← the last line of defence

### Also: Stellarlune recovery tool

`scripts/repair-reanalysis-dropped-chapters.mjs` (dry-run default, `--apply`; env `BOOK_DIR`/`BACKUP_BOOK_DIR`/`CACHE_FILE`) restores re-analysis-dropped narration data from a known-good upgrade backup: missing `excluded` flags, missing `manuscript-edits.json` chapters, and the `cache.chapters[N]` sentence-index map (the analysis cache is never backed up, so it is rebuilt from the backup `manuscript-edits` — identical sentence shape). Used to recover Stellarlune's **Preface (ch3)**, which had been added post-hoc via the Generate screen and was dropped from the cache + edits — leaving 50 of 51 active chapters cached, so `analysisComplete` never reached true and the book was stranded on the strip-prone analysing flow despite its audio already being rendered. After `--apply`: activeChapters 51 / analysed 51 / `analysisComplete` true → the book opens straight to the finished view.

## Test plan

- `server/src/workspace/preserve-cast-voices.test.ts` — 6 unit cases: dropped voice filled from existing (the strip fix), incoming-wins re-design, `ttsEngine`/`voiceStyle` same treatment, reuse-link fields untouched (unlink works), new-character pass-through, empty-existing pass-through.
- `server/src/routes/book-state-preserve-voices.test.ts` — 2 route-level cases against the real `bookStateRouter`: the **generated-character** strip scenario the denormalise pass can't cover, and incoming-wins re-design.
- Full `npm run verify` green (cache-aware, all legs cached/passed). Existing `book-state-reuse-denormalise.test.ts` (srv-14) stays green with the guard wired ahead of it.

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)
