### PR TITLE
fix(server,scripts): analysis-pass observability + cache-shape guard (post-incident)

### DIFF
--- a/scripts/repair-reanalysis-dropped-chapters.mjs
+++ b/scripts/repair-reanalysis-dropped-chapters.mjs
@@ -119,12 +119,14 @@ for (const [chId, sentences] of [...bupByChapter].sort((a, b) => a[0] - b[0])) {
   const insertAt = liveEdits.sentences.findIndex((s) => s.chapterId > chId);
   const idx = insertAt === -1 ? liveEdits.sentences.length : insertAt;
   liveEdits.sentences.splice(idx, 0, ...sentences);
-  // (b) rebuild cache.chapters[chId] as the sentence-index map (key = id-1)
+  // (b) rebuild cache.chapters[chId] as an ARRAY of sentence objects, ascending
+  //     by id — the analyzer cache shape is Record<number, SentenceOutput[]>
+  //     (server/src/store/analysis-cache.ts: chapters[n].map(...)), NOT an
+  //     index-keyed object. Writing an object here makes the cache load throw
+  //     "sentences.map is not a function".
   cache.chapters ??= {};
   if (!cache.chapters[String(chId)]) {
-    const map = {};
-    for (const s of sentences) map[String(s.id - 1)] = s;
-    cache.chapters[String(chId)] = map;
+    cache.chapters[String(chId)] = [...sentences].sort((a, b) => a.id - b.id);
   }
   restoredChapters.push(`${chId} (${sentences.length} sentences)`);
 }

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -1892,8 +1892,14 @@ export async function runMainAnalyzerJob(
     broadcastToJob(job, payload);
     trackForReplay(job, payload);
   };
+  /* `lastStep` mirrors the most recent phase milestone to the server log (so a
+     stall's last log line names where it wedged) and feeds the fatal-error log
+     below (so a failure names its phase, not just a stack). */
+  let lastStep = 'init';
   const log = (phaseId: number, message: string) => {
     send({ kind: 'log', phaseId, message });
+    lastStep = `phase=${phaseId} ${message}`;
+    console.log(`[analysis] mns=${manuscriptId} ${lastStep}`);
   };
 
   const startedAt = Date.now();
@@ -3492,6 +3498,8 @@ export async function runMainAnalyzerJob(
        reads the same on both sides. */
     const parsedLog = tryParseApiError((e as Error)?.message ?? String(e));
     console.error('[analysis] failed', {
+      manuscriptId,
+      lastStep,
       model: activeModelId,
       name: (e as Error)?.name,
       status: (e as { status?: number })?.status,
@@ -3755,8 +3763,16 @@ async function runSubsetAnalyzerJob(
     broadcastToJob(job, payload);
     trackForReplay(job, payload);
   };
+  /* `lastStep` is a breadcrumb of the most recent phase milestone — mirrored to
+     the server log (so a stall's last server-log line names where it wedged)
+     and folded into the fatal-error log below (so a failure names the phase it
+     died in, not a bare stack). The 2026-06-06 ch12 incident surfaced only as
+     "sentences.map is not a function" with no phase/chapter context. */
+  let lastStep = 'init';
   const log = (phaseId: number, message: string) => {
     send({ kind: 'log', phaseId, message });
+    lastStep = `phase=${phaseId} ${message}`;
+    console.log(`[analysis-subset] mns=${manuscriptId} ${lastStep}`);
   };
 
   /* Preserve designed-voice links across a subset re-analysis (#518) — snapshot
@@ -4301,7 +4317,13 @@ async function runSubsetAnalyzerJob(
       return;
     }
     const { code, message, detail } = describeError(e, analyzerLabel);
-    console.error('[analysis-subset] failed', { manuscriptId, code, message });
+    console.error('[analysis-subset] failed', {
+      manuscriptId,
+      code,
+      message,
+      lastStep,
+      stack: (e as Error)?.stack,
+    });
     endJob(job, { kind: 'error', code, message, detail });
   }
 }

--- a/server/src/store/analysis-cache.shape.test.ts
+++ b/server/src/store/analysis-cache.shape.test.ts
@@ -1,0 +1,43 @@
+/* Guard: a malformed analysis cache (a chapter entry that isn't an array of
+   sentences) must fail LOUD and CONTEXTFUL, not with a bare
+   "sentences.map is not a function".
+
+   The 2026-06-06 incident: a recovery script rebuilt a dropped chapter as an
+   index-keyed object ({"0":{...},"1":{...}}) instead of the array shape the
+   analyzer writes (Record<number, SentenceOutput[]>). The cache save then threw
+   the context-free TypeError deep inside seedEmotionsFromTags, surfacing in the
+   UI as "Re-analysis failed: sentences.map is not a function" with no hint of
+   WHICH chapter or that the cache file was corrupt. assertCacheChaptersShape
+   turns that into an actionable error naming the chapter + manuscript. */
+
+import { describe, it, expect } from 'vitest';
+import { assertCacheChaptersShape } from './analysis-cache.js';
+
+describe('assertCacheChaptersShape', () => {
+  it('passes for well-formed chapters (every entry an array)', () => {
+    const chapters = {
+      3: [{ id: 1, chapterId: 3, characterId: 'narrator', text: 'PREFACE' }],
+      4: [],
+    } as never;
+    expect(() => assertCacheChaptersShape(chapters)).not.toThrow();
+  });
+
+  it('throws naming the chapter when an entry is an object map (the recovery bug)', () => {
+    const chapters = {
+      3: { '0': { id: 1, chapterId: 3, text: 'PREFACE' } }, // object, not array
+      4: [],
+    } as never;
+    expect(() => assertCacheChaptersShape(chapters, 'mns_X')).toThrowError(/chapter 3/);
+    expect(() => assertCacheChaptersShape(chapters, 'mns_X')).toThrowError(/mns_X/);
+  });
+
+  it('throws for a null entry, reporting the type', () => {
+    const chapters = { 5: null } as never;
+    expect(() => assertCacheChaptersShape(chapters)).toThrowError(/chapter 5/);
+    expect(() => assertCacheChaptersShape(chapters)).toThrowError(/null/);
+  });
+
+  it('does not throw on an empty cache', () => {
+    expect(() => assertCacheChaptersShape({} as never)).not.toThrow();
+  });
+});

--- a/server/src/store/analysis-cache.ts
+++ b/server/src/store/analysis-cache.ts
@@ -18,7 +18,32 @@ import { readJson, writeJsonAtomic } from '../workspace/state-io.js';
    text, so the retired tag system leaves no residue in new caches. Idempotent:
    already-clean sentences pass through unchanged, and an existing `emotion`
    (manual or analyzer-set) is never overridden. */
+/* Validate the on-disk cache shape before anything iterates it. Each chapter
+   entry must be an array of sentences (`Record<number, SentenceOutput[]>`).
+   A malformed entry — e.g. an index-keyed object `{ "0": {...} }` written by a
+   buggy external repair — otherwise throws a context-free
+   "sentences.map is not a function" deep in seedEmotionsFromTags, which the UI
+   surfaces as an inscrutable "Re-analysis failed". Failing here names the
+   manuscript + chapter so the corruption is actionable (re-run that chapter or
+   restore the cache). Asserts the type so callers narrow to the array shape. */
+export function assertCacheChaptersShape(
+  chapters: Record<number, unknown>,
+  manuscriptId?: string,
+): asserts chapters is Record<number, SentenceOutput[]> {
+  for (const [chapterId, sentences] of Object.entries(chapters)) {
+    if (!Array.isArray(sentences)) {
+      const got = sentences === null ? 'null' : typeof sentences;
+      throw new Error(
+        `Analysis cache${manuscriptId ? ` for ${manuscriptId}` : ''} chapter ${chapterId} is ` +
+          `malformed: expected an array of sentences, got ${got}. The cache file is corrupt — ` +
+          `re-run analysis for this chapter or restore the cache from a backup.`,
+      );
+    }
+  }
+}
+
 function seedEmotionsFromTags(chapters: Record<number, SentenceOutput[]>): Record<number, SentenceOutput[]> {
+  assertCacheChaptersShape(chapters);
   const out: Record<number, SentenceOutput[]> = {};
   for (const [chapterId, sentences] of Object.entries(chapters)) {
     out[Number(chapterId)] = sentences.map((s) => {
@@ -67,6 +92,10 @@ function cachePath(manuscriptId: string): string {
 export async function loadAnalysisCache(manuscriptId: string): Promise<AnalysisCache> {
   const cache = await readJson<AnalysisCache>(cachePath(manuscriptId));
   if (!cache) return { chapters: {} };
+  /* Fail loud + contextful on a corrupt cache (a chapter entry that isn't an
+     array) before any phase does work, instead of a context-free TypeError on
+     the next save. */
+  assertCacheChaptersShape(cache.chapters ?? {}, manuscriptId);
   /* JSON parse turns the chapter-id keys into strings, but the route uses
      numeric ids. Coerce shape so callers can use cache.chapters[chapterId]
      directly. */


### PR DESCRIPTION
## Summary

Hardens the analysis pass so a stall or cache corruption is self-diagnosable — prompted by the 2026-06-06 ch12 re-analysis that surfaced only as **"Re-analysis failed: sentences.map is not a function"** with no phase, no chapter, and no hint the analysis cache was corrupt.

**Root cause:** the Stellarlune Preface recovery script rebuilt a dropped chapter as an index-keyed object (`{"0":{...}}`) instead of the array shape the analyzer writes (`Record<number, SentenceOutput[]>`). The cache **save** then threw a context-free `TypeError` deep inside `seedEmotionsFromTags`. The Gemini layer itself was never the problem (it has an idle watchdog + retries) — the "stall" was the post-call cache save dying.

Three changes:

1. **`assertCacheChaptersShape` (analysis-cache.ts)** — validates every chapter entry is an array on **both load and save**. A malformed entry now throws a contextful error naming the manuscript + chapter (`Analysis cache for mns_X chapter 3 is malformed: expected an array of sentences, got object. The cache file is corrupt — re-run analysis for this chapter or restore from a backup.`) instead of a bare `sentences.map is not a function`. Caught on **load**, before any phase does work.

2. **Phase breadcrumbs to the server log** — the per-phase `log()` helper in both `runMainAnalyzerJob` and `runSubsetAnalyzerJob` previously emitted only to the SSE/UI. It now also mirrors each milestone to the server log (`[analysis] mns=… phase=N …`) and tracks a `lastStep`, so a stall's **last server-log line names where it wedged**.

3. **Fatal-error logs carry `manuscriptId` + `lastStep`** (+ stack for the subset job), so a job failure names the phase it died in rather than a context-free error object.

Also fixes the `repair-reanalysis-dropped-chapters.mjs` script that caused the incident — it now rebuilds `cache.chapters[N]` as an **array** sorted by id (was an index-keyed object).

## Test plan

- `server/src/store/analysis-cache.shape.test.ts` — 4 cases: well-formed passes, object-map throws naming the chapter + manuscript, null entry reports the type, empty cache no-op.
- Full local `npm --prefix server run test` = **2091 passing** (the run also tripped one vitest worker-fork crash from GPU/CPU contention with the live app — not an assertion failure; CI runs this leg clean on a dedicated runner).
- Existing analysis route (94) + pipelining + stage2-coverage suites stay green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
