### PR TITLE
feat(server,openapi): srv-34 — listen-progress client listenedAt + guarded write

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -897,13 +897,19 @@ paths:
       summary: Stamp the per-book resume bookmark
       operationId: putListenProgress
       description: |
-        Persist `{ chapterId, currentSec }` for this book; the server
-        stamps `updatedAt = new Date().toISOString()`. Writes via
-        `writeJsonAtomic` to `listen-progress.json` (no backup
-        rotation — the file is cheap to re-derive on loss, unlike
-        `state.json`). Called debounced from the mini-player's
-        `onTimeUpdate` (once per 5 s) plus one final flush on chapter
-        switch / close. Plan [47](docs/features/archive/47-listen-progress.md).
+        Persist `{ chapterId, currentSec }` for this book. The server
+        stamps `updatedAt = new Date().toISOString()` unless the caller
+        supplies `listenedAt` (srv-34 / plan 188), in which case that
+        client wall-clock time is used instead and a **guarded
+        compare-and-set** applies: the write is committed only if
+        `listenedAt` is strictly newer than the stored record, otherwise
+        the existing (newer) record is returned unchanged so the client
+        reconciles. Writes via `writeJsonAtomic` to
+        `listen-progress.json` (no backup rotation — the file is cheap to
+        re-derive on loss, unlike `state.json`). Called debounced from the
+        mini-player's `onTimeUpdate` (once per 5 s) plus one final flush on
+        chapter switch / close. Plan
+        [47](docs/features/archive/47-listen-progress.md).
       parameters:
         - { in: path, name: bookId, required: true, schema: { type: string } }
       requestBody:
@@ -933,9 +939,21 @@ paths:
                     so the listen-view sidebar can group "general notes"
                     from "re-record" flags.
                   items: { $ref: '#/components/schemas/ListenMarker' }
+                listenedAt:
+                  type: string
+                  format: date-time
+                  description: |
+                    srv-34 (plan 188) — optional client wall-clock time the
+                    user actually listened. When present it stamps
+                    `updatedAt` instead of receive-time and gates a guarded
+                    compare-and-set (the write is rejected if not strictly
+                    newer than the stored record). Lets an offline client
+                    (the Android companion) flush in-car progress on
+                    reconnect without clobbering a newer position made
+                    elsewhere. Rejected (400) if non-date or absurdly future.
       responses:
         '200':
-          description: The just-saved record, including the server-stamped updatedAt
+          description: The saved record (or, on a guard-rejected stale write, the existing newer record), with updatedAt = the client listenedAt when supplied
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ListenProgress' }

--- a/server/src/routes/book-state.test.ts
+++ b/server/src/routes/book-state.test.ts
@@ -11,7 +11,7 @@
    module imports so paths.ts picks up WORKSPACE_DIR, supertest against
    the real router. */
 
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'vitest';
 import {
   rmSync,
   mkdirSync,
@@ -1405,5 +1405,94 @@ describe('book-state router — listen-progress slice (plan 47)', () => {
       });
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/createdAt/);
+  });
+
+  /* srv-34 (plan 188) — optional client `listenedAt` (offline-correct
+     ordering) + guarded compare-and-set so a late offline push can't
+     clobber a newer position made elsewhere. Each test starts clean. */
+  describe('srv-34 — client listenedAt + guarded compare-and-set', () => {
+    const lpFile = () => join(lpBookDir, '.audiobook', 'listen-progress.json');
+    const T1 = '2026-01-01T10:00:00.000Z';
+    const T2 = '2026-01-01T11:00:00.000Z';
+    const T3 = '2026-01-01T12:00:00.000Z';
+
+    beforeEach(() => {
+      rmSync(lpFile(), { force: true });
+    });
+
+    it('accepts a client listenedAt and stamps it as updatedAt', async () => {
+      const put = await request(app)
+        .put(`/api/books/${lpBookId}/listen-progress`)
+        .set('Content-Type', 'application/json')
+        .send({ chapterId: 1, currentSec: 50, listenedAt: T2 });
+      expect(put.status).toBe(200);
+      expect(put.body.updatedAt).toBe(T2);
+    });
+
+    it('400s on a non-date listenedAt', async () => {
+      const res = await request(app)
+        .put(`/api/books/${lpBookId}/listen-progress`)
+        .set('Content-Type', 'application/json')
+        .send({ chapterId: 1, currentSec: 5, listenedAt: 'not-a-date' });
+      expect(res.status).toBe(400);
+    });
+
+    it('400s on a listenedAt far in the future (clock-skew guard)', async () => {
+      const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      const res = await request(app)
+        .put(`/api/books/${lpBookId}/listen-progress`)
+        .set('Content-Type', 'application/json')
+        .send({ chapterId: 1, currentSec: 5, listenedAt: future });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects a stale listenedAt: keeps + returns the newer stored record', async () => {
+      await request(app)
+        .put(`/api/books/${lpBookId}/listen-progress`)
+        .set('Content-Type', 'application/json')
+        .send({ chapterId: 1, currentSec: 100, listenedAt: T2 });
+      const stale = await request(app)
+        .put(`/api/books/${lpBookId}/listen-progress`)
+        .set('Content-Type', 'application/json')
+        .send({ chapterId: 2, currentSec: 5, listenedAt: T1 });
+      expect(stale.status).toBe(200);
+      expect(stale.body.chapterId).toBe(1);
+      expect(stale.body.currentSec).toBe(100);
+      expect(stale.body.updatedAt).toBe(T2);
+
+      const get = await request(app).get(`/api/books/${lpBookId}/listen-progress`);
+      expect(get.body.chapterId).toBe(1);
+      expect(get.body.updatedAt).toBe(T2);
+    });
+
+    it('accepts a newer listenedAt and overwrites', async () => {
+      await request(app)
+        .put(`/api/books/${lpBookId}/listen-progress`)
+        .set('Content-Type', 'application/json')
+        .send({ chapterId: 1, currentSec: 100, listenedAt: T2 });
+      const newer = await request(app)
+        .put(`/api/books/${lpBookId}/listen-progress`)
+        .set('Content-Type', 'application/json')
+        .send({ chapterId: 2, currentSec: 5, listenedAt: T3 });
+      expect(newer.status).toBe(200);
+      expect(newer.body.chapterId).toBe(2);
+      expect(newer.body.updatedAt).toBe(T3);
+    });
+
+    it('without listenedAt keeps legacy behaviour: server-stamps + always writes', async () => {
+      await request(app)
+        .put(`/api/books/${lpBookId}/listen-progress`)
+        .set('Content-Type', 'application/json')
+        .send({ chapterId: 1, currentSec: 100, listenedAt: T2 });
+      const before = Date.now();
+      const legacy = await request(app)
+        .put(`/api/books/${lpBookId}/listen-progress`)
+        .set('Content-Type', 'application/json')
+        .send({ chapterId: 2, currentSec: 5 });
+      expect(legacy.status).toBe(200);
+      expect(legacy.body.chapterId).toBe(2);
+      expect(legacy.body.currentSec).toBe(5);
+      expect(Date.parse(legacy.body.updatedAt)).toBeGreaterThanOrEqual(before);
+    });
   });
 });

--- a/server/src/routes/book-state.ts
+++ b/server/src/routes/book-state.ts
@@ -1082,6 +1082,11 @@ interface ListenProgressFile {
 const PLAYBACK_RATE_MIN = 0.25;
 const PLAYBACK_RATE_MAX = 4.0;
 
+/* srv-34 (plan 188) — a small tolerance for a client-supplied
+   `listenedAt`. A device clock a little ahead is fine; one absurdly in
+   the future is rejected so it can't poison last-write-wins ordering. */
+const LISTENED_AT_FUTURE_SKEW_MS = 5 * 60 * 1000;
+
 /* Plan 53 — server-side validator for an individual marker payload.
    Returns null when valid, or a short reason string for the 400. */
 function validateMarker(raw: unknown): string | null {
@@ -1126,6 +1131,7 @@ bookStateRouter.put('/:bookId/listen-progress', async (req: Request, res: Respon
           currentSec: unknown;
           playbackRate: unknown;
           markers: unknown;
+          listenedAt: unknown;
         }>
       | undefined;
     if (!body || typeof body.chapterId !== 'number' || !Number.isFinite(body.chapterId)) {
@@ -1165,10 +1171,40 @@ bookStateRouter.put('/:bookId/listen-progress', async (req: Request, res: Respon
       }
       markers = body.markers as ListenMarker[];
     }
+    /* srv-34 (plan 188) — optional client `listenedAt`. When present it
+       stamps `updatedAt` (the wall-clock time the user actually listened,
+       which may be earlier than this request when a phone flushes offline
+       progress on reconnect) instead of receive-time. Validated as a real
+       date and rejected if absurdly future (clock-skew guard). */
+    let effectiveUpdatedAt = new Date().toISOString();
+    let listenedAtMs: number | null = null;
+    if (body.listenedAt !== undefined) {
+      if (typeof body.listenedAt !== 'string' || Number.isNaN(Date.parse(body.listenedAt))) {
+        return res.status(400).json({ error: 'listenedAt must be an ISO date-time string.' });
+      }
+      listenedAtMs = Date.parse(body.listenedAt);
+      if (listenedAtMs > Date.now() + LISTENED_AT_FUTURE_SKEW_MS) {
+        return res.status(400).json({ error: 'listenedAt is too far in the future.' });
+      }
+      effectiveUpdatedAt = new Date(listenedAtMs).toISOString();
+    }
+    /* srv-34 — guarded compare-and-set. ONLY when the caller supplies a
+       `listenedAt` (the companion's offline-correct ordering signal) do we
+       refuse to overwrite a strictly-newer stored record, returning that
+       record so the client reconciles. Legacy callers that omit
+       `listenedAt` keep last-write-wins-by-receive-time. */
+    if (listenedAtMs !== null) {
+      const existing = await readJson<ListenProgressFile>(
+        listenProgressJsonPath(located.bookDir),
+      );
+      if (existing && Date.parse(existing.updatedAt) >= listenedAtMs) {
+        return res.json(existing);
+      }
+    }
     const record: ListenProgressFile = {
       chapterId: body.chapterId,
       currentSec: body.currentSec,
-      updatedAt: new Date().toISOString(),
+      updatedAt: effectiveUpdatedAt,
       ...(playbackRate !== undefined ? { playbackRate } : {}),
       ...(markers !== undefined ? { markers } : {}),
     };

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -600,13 +600,19 @@ export interface paths {
         get: operations["getListenProgress"];
         /**
          * Stamp the per-book resume bookmark
-         * @description Persist `{ chapterId, currentSec }` for this book; the server
-         *     stamps `updatedAt = new Date().toISOString()`. Writes via
-         *     `writeJsonAtomic` to `listen-progress.json` (no backup
-         *     rotation — the file is cheap to re-derive on loss, unlike
-         *     `state.json`). Called debounced from the mini-player's
-         *     `onTimeUpdate` (once per 5 s) plus one final flush on chapter
-         *     switch / close. Plan [47](docs/features/archive/47-listen-progress.md).
+         * @description Persist `{ chapterId, currentSec }` for this book. The server
+         *     stamps `updatedAt = new Date().toISOString()` unless the caller
+         *     supplies `listenedAt` (srv-34 / plan 188), in which case that
+         *     client wall-clock time is used instead and a **guarded
+         *     compare-and-set** applies: the write is committed only if
+         *     `listenedAt` is strictly newer than the stored record, otherwise
+         *     the existing (newer) record is returned unchanged so the client
+         *     reconciles. Writes via `writeJsonAtomic` to
+         *     `listen-progress.json` (no backup rotation — the file is cheap to
+         *     re-derive on loss, unlike `state.json`). Called debounced from the
+         *     mini-player's `onTimeUpdate` (once per 5 s) plus one final flush on
+         *     chapter switch / close. Plan
+         *     [47](docs/features/archive/47-listen-progress.md).
          */
         put: operations["putListenProgress"];
         post?: never;
@@ -4393,11 +4399,23 @@ export interface operations {
                      *     from "re-record" flags.
                      */
                     markers?: components["schemas"]["ListenMarker"][];
+                    /**
+                     * Format: date-time
+                     * @description srv-34 (plan 188) — optional client wall-clock time the
+                     *     user actually listened. When present it stamps
+                     *     `updatedAt` instead of receive-time and gates a guarded
+                     *     compare-and-set (the write is rejected if not strictly
+                     *     newer than the stored record). Lets an offline client
+                     *     (the Android companion) flush in-car progress on
+                     *     reconnect without clobbering a newer position made
+                     *     elsewhere. Rejected (400) if non-date or absurdly future.
+                     */
+                    listenedAt?: string;
                 };
             };
         };
         responses: {
-            /** @description The just-saved record, including the server-stamped updatedAt */
+            /** @description The saved record (or, on a guard-rejected stale write, the existing newer record), with updatedAt = the client listenedAt when supplied */
             200: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
## Summary

First server prerequisite of the **Android companion app** (plan 188, Wave 1). The `PUT /api/books/:id/listen-progress` route now accepts an optional client **`listenedAt`** (ISO date-time):

- When present, it stamps `updatedAt` with the wall-clock time the user actually listened (which may be earlier than the request when an offline client flushes progress on reconnect), validated as a real date and rejected (400) if non-date or absurdly future (5-min skew guard).
- **Guarded compare-and-set:** the write commits only if `listenedAt` is strictly newer than the stored record; otherwise the existing (newer) record is returned unchanged so the client reconciles.
- **Backward compatible:** legacy callers that omit `listenedAt` keep last-write-wins-by-receive-time, so the web player is unaffected.

Fixes the verified offline-overwrite race (a late mobile push clobbering a newer position made elsewhere) and unblocks `app-6` (two-way resume sync). `openapi.yaml` + regenerated `api-types.ts` updated.

## Test plan

- New `book-state.test.ts` cases (slow config): accept+stamp `listenedAt`; 400 on non-date; 400 on future; stale write rejected → returns the newer stored record; newer write overwrites; legacy no-`listenedAt` path still server-stamps + always writes.
- Full `book-state.test.ts` green (71/71).
- `npm run verify` (pre-push) green.

Closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)
