### PR TITLE
fix(frontend): preserve designed-in-book voices through hydrateFromAnalysis (confirm strip)

### DIFF
--- a/src/store/cast-slice.test.ts
+++ b/src/store/cast-slice.test.ts
@@ -162,6 +162,85 @@ describe('castSlice — hydrateFromAnalysis', () => {
     const next = castSlice.reducer(start, castActions.hydrateFromAnalysis(baseAnalysis([])));
     expect(next.characters).toEqual(start.characters);
   });
+
+  it('preserves a designed-in-this-book Qwen voice when the analysis payload returns it voiceless (confirm-screen strip)', () => {
+    /* The /confirm payload (AnalysingView onComplete → hydrateFromAnalysis) carries
+       voice continuity only for characters matched against OTHER books in the series.
+       A character DESIGNED IN THIS BOOK (overrideTtsVoices.qwen, no matchedFrom) finds
+       no series match and arrives voiceless, so a flat replace stripped it on the
+       confirm screen — rendering "No voice designed yet" for Maruca/Grizel/Trix even
+       though cast.json on disk still held the voice. Mirror the mergeCharacters #518
+       overlay: preserve voice-design fields by id from the existing slice. */
+    const start = baseState([
+      makeChar('maruca', {
+        voiceState: 'generated',
+        overrideTtsVoices: { qwen: { name: 'qwen-maruca' } },
+        ttsEngine: 'qwen',
+        voiceStyle: 'a bright, eager teenage girl, quick and clear.',
+      }),
+    ]);
+    const next = castSlice.reducer(
+      start,
+      castActions.hydrateFromAnalysis(
+        baseAnalysis([
+          {
+            id: 'maruca',
+            name: 'Maruca',
+            role: 'Peer',
+            color: 'slot-18',
+            description: 'Re-attributed.',
+          } as Character,
+        ]),
+      ),
+    );
+    const maruca = next.characters.find((c) => c.id === 'maruca')!;
+    expect(maruca.overrideTtsVoices).toEqual({ qwen: { name: 'qwen-maruca' } });
+    expect(maruca.ttsEngine).toBe('qwen');
+    expect(maruca.voiceStyle).toBe('a bright, eager teenage girl, quick and clear.');
+    expect(maruca.voiceState).toBe('generated');
+    /* Fresh analyzer-owned fields still flow through. */
+    expect(maruca.description).toBe('Re-attributed.');
+  });
+
+  it('preserves a reused/linked voice but lets a fresh series-reuse link flow through', () => {
+    /* Existing reused link must survive a voiceless re-analysis; a NEWLY stamped
+       matchedFrom on a previously-voiceless character (the analyzer's series-reuse
+       pass) must still flow through (existing-wins only when existing has it). */
+    const start = baseState([
+      makeChar('lord-cassius', {
+        voiceState: 'reused',
+        voiceId: 'qwen-lord-cassius',
+        matchedFrom: { bookTitle: 'Everblaze', confidence: 0.9 },
+      }),
+      makeChar('newcomer', { voiceState: 'generated' }),
+    ]);
+    const next = castSlice.reducer(
+      start,
+      castActions.hydrateFromAnalysis(
+        baseAnalysis([
+          {
+            id: 'lord-cassius',
+            name: 'Lord Cassius',
+            role: 'Antagonist',
+            color: 'slot-2',
+          } as Character,
+          {
+            id: 'newcomer',
+            name: 'Newcomer',
+            role: 'Peer',
+            color: 'slot-9',
+            matchedFrom: { bookTitle: 'Exile', confidence: 0.88 },
+          } as Character,
+        ]),
+      ),
+    );
+    const cassius = next.characters.find((c) => c.id === 'lord-cassius')!;
+    expect(cassius.voiceId).toBe('qwen-lord-cassius');
+    expect(cassius.voiceState).toBe('reused');
+    expect(cassius.matchedFrom).toEqual({ bookTitle: 'Everblaze', confidence: 0.9 });
+    const newcomer = next.characters.find((c) => c.id === 'newcomer')!;
+    expect(newcomer.matchedFrom).toEqual({ bookTitle: 'Exile', confidence: 0.88 });
+  });
 });
 
 describe('castSlice — initial state (mock-leak regression)', () => {
@@ -231,7 +310,13 @@ describe('castSlice — mergeCharacters (Phase 0a live cast snapshots)', () => {
     const next = castSlice.reducer(
       start,
       castActions.mergeCharacters([
-        { id: 'maruca', name: 'Maruca', role: 'Peer', color: 'slot-18', description: 'Re-attributed.' },
+        {
+          id: 'maruca',
+          name: 'Maruca',
+          role: 'Peer',
+          color: 'slot-18',
+          description: 'Re-attributed.',
+        },
       ]),
     );
     const maruca = next.characters.find((c) => c.id === 'maruca')!;
@@ -489,9 +574,7 @@ describe('castSlice — applyUnlinkAlias (POST /cast/unlink-alias response)', ()
   });
 
   it('is case-insensitive and trim-tolerant when matching the alias to strip', () => {
-    const start = baseState([
-      makeChar('neverseen-figure', { aliases: ['  Sandor  ', 'Jurek'] }),
-    ]);
+    const start = baseState([makeChar('neverseen-figure', { aliases: ['  Sandor  ', 'Jurek'] })]);
     const next = castSlice.reducer(
       start,
       castActions.applyUnlinkAlias({
@@ -510,10 +593,7 @@ describe('castSlice — applyUnlinkAlias (POST /cast/unlink-alias response)', ()
 
   it('is idempotent when the new character already exists (network retry safety)', () => {
     const existing = makeChar('sandor', { voiceState: 'tuned', voiceId: 'v_sandor' });
-    const start = baseState([
-      makeChar('neverseen-figure', { aliases: ['Sandor'] }),
-      existing,
-    ]);
+    const start = baseState([makeChar('neverseen-figure', { aliases: ['Sandor'] }), existing]);
     const next = castSlice.reducer(
       start,
       castActions.applyUnlinkAlias({
@@ -536,9 +616,7 @@ describe('castSlice — applyUnlinkAlias (POST /cast/unlink-alias response)', ()
 
 describe('castSlice — applyAddAlias (POST /cast/add-alias response)', () => {
   it('appends a new alias to the target character', () => {
-    const start = baseState([
-      makeChar('sophie', { aliases: ['Foster'], name: 'Sophie Foster' }),
-    ]);
+    const start = baseState([makeChar('sophie', { aliases: ['Foster'], name: 'Sophie Foster' })]);
     const next = castSlice.reducer(
       start,
       castActions.applyAddAlias({ characterId: 'sophie', aliasName: 'Sofi' }),
@@ -547,9 +625,7 @@ describe('castSlice — applyAddAlias (POST /cast/add-alias response)', () => {
   });
 
   it('dedupes case-insensitively and trim-tolerantly', () => {
-    const start = baseState([
-      makeChar('sophie', { aliases: ['Foster'], name: 'Sophie Foster' }),
-    ]);
+    const start = baseState([makeChar('sophie', { aliases: ['Foster'], name: 'Sophie Foster' })]);
     const next = castSlice.reducer(
       start,
       castActions.applyAddAlias({ characterId: 'sophie', aliasName: '  foster  ' }),
@@ -558,7 +634,7 @@ describe('castSlice — applyAddAlias (POST /cast/add-alias response)', () => {
     expect(next.characters[0].aliases).toEqual(['Foster']);
   });
 
-  it('refuses to add the character\'s own name as an alias', () => {
+  it("refuses to add the character's own name as an alias", () => {
     const start = baseState([makeChar('sophie', { name: 'Sophie Foster' })]);
     const next = castSlice.reducer(
       start,
@@ -568,9 +644,7 @@ describe('castSlice — applyAddAlias (POST /cast/add-alias response)', () => {
   });
 
   it('no-ops for an unknown characterId or empty alias', () => {
-    const start = baseState([
-      makeChar('sophie', { aliases: ['Foster'], name: 'Sophie Foster' }),
-    ]);
+    const start = baseState([makeChar('sophie', { aliases: ['Foster'], name: 'Sophie Foster' })]);
     const r1 = castSlice.reducer(
       start,
       castActions.applyAddAlias({ characterId: 'ghost', aliasName: 'Foo' }),
@@ -696,10 +770,7 @@ describe('castSlice — renameCharacter (rename + promote alias)', () => {
 describe('castSlice — setRenderedFallback (fe-16)', () => {
   it('overwrites the fallback map from the book-state hydrate', () => {
     const start = { characters: [makeChar('sweeney')], renderedFallbackByCharacter: {} };
-    const next = castSlice.reducer(
-      start,
-      castActions.setRenderedFallback({ sweeney: 'kokoro' }),
-    );
+    const next = castSlice.reducer(start, castActions.setRenderedFallback({ sweeney: 'kokoro' }));
     expect(next.renderedFallbackByCharacter).toEqual({ sweeney: 'kokoro' });
   });
 
@@ -779,7 +850,6 @@ describe('castSlice — applyNotLinked / removeNotLinked (cross-book variant, pl
   });
 });
 
-
 describe('castSlice — mergeCharacters (srv-13 preservation)', () => {
   it('preserves voice fields, notLinkedTo and unions aliases on a surviving character', () => {
     const start = baseState([
@@ -798,9 +868,7 @@ describe('castSlice — mergeCharacters (srv-13 preservation)', () => {
     // a sparser alias set.
     const next = castSlice.reducer(
       start,
-      castActions.mergeCharacters([
-        makeChar('keefe', { aliases: ['Keefe', 'Mr. Sencen'] }),
-      ]),
+      castActions.mergeCharacters([makeChar('keefe', { aliases: ['Keefe', 'Mr. Sencen'] })]),
     );
     const keefe = next.characters[0];
     expect(keefe.voiceId).toBe('keefe');

--- a/src/store/cast-slice.ts
+++ b/src/store/cast-slice.ts
@@ -106,11 +106,36 @@ export const castSlice = createSlice({
        instead of nothing. */
     hydrateFromAnalysis: (s, a: PayloadAction<AnalyseResponse>) => {
       const { characters } = a.payload;
-      if (characters?.length) {
-        s.characters = characters.map((c) =>
-          c.voiceState ? c : { ...c, voiceState: 'generated' },
-        );
-      }
+      if (!characters?.length) return;
+      /* Overlay the existing slice's voice-design fields onto the freshly-analysed
+         roster, matched by id — the SAME preservation mergeCharacters already does
+         for live Phase-0a snapshots (#518). The analysis-complete payload that lands
+         on /confirm carries voice continuity only for characters matched against
+         OTHER books in the series (the series-reuse pass); a character DESIGNED IN
+         THIS BOOK (overrideTtsVoices.qwen, no voiceId/matchedFrom) finds no match and
+         arrives voiceless. A flat replace dropped it in Redux, so /confirm rendered
+         "No voice designed yet" for Maruca/Grizel/Trix even though cast.json on disk
+         still held the voice. Existing-wins ONLY when the existing entry has the
+         field, so a fresh reuse link stamped this run still flows through. */
+      const byId = new Map(s.characters.map((c) => [c.id, c]));
+      s.characters = characters.map((inc) => {
+        const existing = byId.get(inc.id);
+        if (!existing) return inc.voiceState ? inc : { ...inc, voiceState: 'generated' };
+        return {
+          ...inc,
+          voiceId: existing.voiceId ?? inc.voiceId,
+          matchedFrom: existing.matchedFrom ?? inc.matchedFrom,
+          /* matchFactors is voice-match-only — the analyzer payload never carries
+             it, so there is no incoming value to fall back to; just keep ours. */
+          matchFactors: existing.matchFactors,
+          voiceState: existing.voiceState ?? inc.voiceState ?? 'generated',
+          overrideTtsVoices: existing.overrideTtsVoices ?? inc.overrideTtsVoices,
+          ttsEngine: existing.ttsEngine ?? inc.ttsEngine,
+          voiceStyle: existing.voiceStyle ?? inc.voiceStyle,
+          notLinkedTo: existing.notLinkedTo ?? inc.notLinkedTo,
+          aliases: unionAliases(existing.aliases, inc.aliases),
+        };
+      });
     },
     /* Live cast-update events from Phase 0a (per-chapter cast detection).
        Each event carries the running roster snapshot — upsert by id so
@@ -225,9 +250,7 @@ export const castSlice = createSlice({
       const key = aliasName.trim().toLowerCase();
       const source = s.characters.find((c) => c.id === sourceCharacterId);
       if (source) {
-        source.aliases = (source.aliases ?? []).filter(
-          (n) => n.trim().toLowerCase() !== key,
-        );
+        source.aliases = (source.aliases ?? []).filter((n) => n.trim().toLowerCase() !== key);
       }
       /* Append the new standalone character. Idempotent on id (double-
          dispatch under network retry leaves the existing entry in place,
@@ -244,10 +267,7 @@ export const castSlice = createSlice({
        to a character's aliases array. Idempotent (case-insensitive
        dedup), rejects self-aliases silently (server returns 400 in that
        case — surfaced as an error toast at the dispatch site). */
-    applyAddAlias: (
-      s,
-      a: PayloadAction<{ characterId: string; aliasName: string }>,
-    ) => {
+    applyAddAlias: (s, a: PayloadAction<{ characterId: string; aliasName: string }>) => {
       const { characterId, aliasName } = a.payload;
       const trimmed = aliasName.trim();
       if (!trimmed) return;
@@ -268,10 +288,7 @@ export const castSlice = createSlice({
        the aliases list so it doesn't double up. Dedup is case-insensitive,
        trim-tolerant; display casing is preserved. Persisted to cast.json via
        the 'cast/renameCharacter' rule in persistence-middleware.ts. */
-    renameCharacter: (
-      s,
-      a: PayloadAction<{ characterId: string; name: string }>,
-    ) => {
+    renameCharacter: (s, a: PayloadAction<{ characterId: string; name: string }>) => {
       const { characterId, name } = a.payload;
       const trimmed = name.trim();
       if (!trimmed) return;
@@ -336,11 +353,7 @@ export const castSlice = createSlice({
       const c = s.characters.find((x) => x.id === characterId);
       if (!c) return;
       const existing = c.notLinkedTo ?? [];
-      if (
-        existing.some(
-          (p) => p.bookId === otherBookId && p.characterId === otherCharacterId,
-        )
-      ) {
+      if (existing.some((p) => p.bookId === otherBookId && p.characterId === otherCharacterId)) {
         return;
       }
       c.notLinkedTo = [...existing, { bookId: otherBookId, characterId: otherCharacterId }];


### PR DESCRIPTION
## Summary

The `/confirm` cast review screen showed characters **designed in this book** (Qwen `overrideTtsVoices`, no cross-book `matchedFrom`) as "No voice designed yet" after a re-analysis/regenerate, even though their voice was intact on disk.

`castActions.hydrateFromAnalysis` (`src/store/cast-slice.ts`, dispatched from `src/routes/index.tsx` on analysis-complete) flat-replaced the cast slice with the analysis payload, preserving no voice-design fields. That payload only carries voice continuity for characters matched against **other** books in the series (the series-reuse pass), so a character designed in *this* book matches nothing and arrives voiceless → dropped in Redux → rendered voiceless on `/confirm`. Disk stayed correct (server self-merge + the #534 cast-PUT guard), so a reload masked it.

This is the exact gap **#518** closed for the sibling reducer `mergeCharacters` (live Phase-0a snapshots) but never applied to `hydrateFromAnalysis` (the `/confirm` path). The fix mirrors that overlay: match the existing slice by id and keep `voiceId / matchedFrom / matchFactors / voiceState / overrideTtsVoices / ttsEngine / voiceStyle / notLinkedTo` (union aliases). Existing-wins **only when present**, so a fresh series-reuse link stamped this run still flows through — matching the server-side `mergeAnalysisResultWithExistingCast` semantics.

## Test plan

- Two new `src/store/cast-slice.test.ts` cases (RED→GREEN watched):
  - a designed-in-this-book Qwen voice survives a voiceless analysis payload
  - a reused/linked voice survives **and** a freshly-stamped series-reuse link still flows through
- `npm run test` (frontend): **2288 passed**
- `tsc --noEmit` clean (caught a real slip — `AnalyseResponse` chars have no `matchFactors`)
- ESLint + Prettier clean

Closes #559