### PR TITLE
feat(server): srv-20 — opt-in LAN shared-secret token guard (middleware)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -64,6 +64,7 @@ import { chaptersRestructureRouter } from './routes/chapters-restructure.js';
 import { exportRouter } from './routes/export.js';
 import { exportLanRouter, enumerateLanUrls, isLanHttpsEnabled } from './routes/export-lan.js';
 import { certRootRouter } from './routes/cert-root.js';
+import { requireLanToken } from './lan-auth.js';
 import { portableExportRouter, portableImportRouter } from './routes/exports-portable.js';
 import { shareRouter, sharePublicRouter } from './routes/share.js';
 import { revisionsRouter, revisionsBulkRouter } from './routes/revisions.js';
@@ -159,6 +160,11 @@ void fsckAllBooks()
     }
   })
   .catch((err) => console.warn('[fsck] sweep skipped:', err));
+
+/* srv-20 — optional shared-secret token guard for the LAN exposure surface.
+   Scoped to /api + /workspace; /cert/root.crt + /audio stay open. OFF unless
+   LAN HTTPS mode is on AND LAN_AUTH_TOKEN is set; loopback always bypasses. */
+app.use(['/api', '/workspace'], requireLanToken);
 app.use('/workspace', express.static(WORKSPACE_ROOT, { fallthrough: true, maxAge: '1h' }));
 
 app.get('/api/health', (_req, res) => {

--- a/server/src/lan-auth.test.ts
+++ b/server/src/lan-auth.test.ts
@@ -1,0 +1,139 @@
+/* srv-20 — LAN shared-secret token guard. Unit-tests the middleware
+   against mocked req/res so no HTTP server is needed. */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  requireLanToken,
+  isLanTokenEnforced,
+  extractToken,
+  getLanAuthToken,
+} from './lan-auth.js';
+
+interface ReqOpts {
+  ip?: string;
+  headers?: Record<string, string>;
+  query?: Record<string, unknown>;
+}
+function mkReq(opts: ReqOpts = {}) {
+  const ip = opts.ip ?? '203.0.113.5'; // documentation range — non-loopback by default
+  return {
+    ip,
+    socket: { remoteAddress: ip },
+    headers: opts.headers ?? {},
+    query: opts.query ?? {},
+  } as never;
+}
+function mkRes() {
+  const res = { statusCode: 200, body: undefined as unknown };
+  return {
+    status(code: number) {
+      res.statusCode = code;
+      return this;
+    },
+    json(b: unknown) {
+      res.body = b;
+      return this;
+    },
+    _res: res,
+  } as never as { _res: { statusCode: number; body: unknown } };
+}
+
+describe('lan-auth (srv-20)', () => {
+  const origHttps = process.env.LAN_HTTPS;
+  const origToken = process.env.LAN_AUTH_TOKEN;
+  afterEach(() => {
+    if (origHttps === undefined) delete process.env.LAN_HTTPS;
+    else process.env.LAN_HTTPS = origHttps;
+    if (origToken === undefined) delete process.env.LAN_AUTH_TOKEN;
+    else process.env.LAN_AUTH_TOKEN = origToken;
+  });
+
+  it('is OFF unless LAN mode AND a token are both set', () => {
+    delete process.env.LAN_HTTPS;
+    delete process.env.LAN_AUTH_TOKEN;
+    expect(isLanTokenEnforced()).toBe(false);
+    process.env.LAN_HTTPS = '1';
+    expect(isLanTokenEnforced()).toBe(false); // no token
+    process.env.LAN_AUTH_TOKEN = 'secret';
+    expect(isLanTokenEnforced()).toBe(true);
+    process.env.LAN_HTTPS = '0';
+    expect(isLanTokenEnforced()).toBe(false); // not LAN mode
+  });
+
+  it('getLanAuthToken treats empty/unset as no token', () => {
+    delete process.env.LAN_AUTH_TOKEN;
+    expect(getLanAuthToken()).toBeUndefined();
+    process.env.LAN_AUTH_TOKEN = '';
+    expect(getLanAuthToken()).toBeUndefined();
+    process.env.LAN_AUTH_TOKEN = 'x';
+    expect(getLanAuthToken()).toBe('x');
+  });
+
+  it('passes through (calls next) when the guard is not enforced', () => {
+    delete process.env.LAN_HTTPS;
+    delete process.env.LAN_AUTH_TOKEN;
+    let called = false;
+    const res = mkRes();
+    requireLanToken(mkReq({ headers: {} }), res as never, () => {
+      called = true;
+    });
+    expect(called).toBe(true);
+    expect(res._res.statusCode).toBe(200);
+  });
+
+  describe('enforced (LAN mode + token set)', () => {
+    beforeEach(() => {
+      process.env.LAN_HTTPS = '1';
+      process.env.LAN_AUTH_TOKEN = 'sekret-token';
+    });
+
+    it('bypasses loopback requests', () => {
+      let called = false;
+      requireLanToken(mkReq({ ip: '127.0.0.1' }), mkRes() as never, () => {
+        called = true;
+      });
+      expect(called).toBe(true);
+    });
+
+    it('401s a non-loopback request with no token', () => {
+      let called = false;
+      const res = mkRes();
+      requireLanToken(mkReq(), res as never, () => {
+        called = true;
+      });
+      expect(called).toBe(false);
+      expect(res._res.statusCode).toBe(401);
+    });
+
+    it('401s a non-loopback request with the wrong token', () => {
+      let called = false;
+      const res = mkRes();
+      requireLanToken(mkReq({ headers: { authorization: 'Bearer nope' } }), res as never, () => {
+        called = true;
+      });
+      expect(called).toBe(false);
+      expect(res._res.statusCode).toBe(401);
+    });
+
+    it('accepts the correct token via Authorization: Bearer, X-Lan-Token, or ?token', () => {
+      const ways: ReqOpts[] = [
+        { headers: { authorization: 'Bearer sekret-token' } },
+        { headers: { 'x-lan-token': 'sekret-token' } },
+        { query: { token: 'sekret-token' } },
+      ];
+      for (const w of ways) {
+        let called = false;
+        requireLanToken(mkReq(w), mkRes() as never, () => {
+          called = true;
+        });
+        expect(called).toBe(true);
+      }
+    });
+  });
+
+  it('extractToken reads Bearer / X-Lan-Token / ?token, else undefined', () => {
+    expect(extractToken(mkReq({ headers: { authorization: 'Bearer abc' } }))).toBe('abc');
+    expect(extractToken(mkReq({ headers: { 'x-lan-token': 'xyz' } }))).toBe('xyz');
+    expect(extractToken(mkReq({ query: { token: 'qqq' } }))).toBe('qqq');
+    expect(extractToken(mkReq())).toBeUndefined();
+  });
+});

--- a/server/src/lan-auth.ts
+++ b/server/src/lan-auth.ts
@@ -1,0 +1,65 @@
+/* srv-20 (plan 188 / BACKLOG #425) — optional shared-secret token guard
+   for the opt-in LAN exposure surface.
+
+   OFF by default: the guard enforces ONLY when LAN HTTPS mode is on AND a
+   token is configured via `LAN_AUTH_TOKEN`. So `npm start` (loopback) and
+   existing LAN users who haven't set the env are completely unaffected —
+   enabling it is a deliberate opt-in. Loopback requests always bypass.
+
+   Mounted on `/api` + `/workspace`. `/cert/root.crt` (the public mkcert CA
+   the companion fetches over the untrusted bootstrap channel *before* it
+   can pin + present a token) and `/audio` are deliberately NOT guarded. */
+import { timingSafeEqual } from 'node:crypto';
+import type { Request, Response, NextFunction } from './http.js';
+import { isLanHttpsEnabled } from './routes/export-lan.js';
+
+/* The configured shared secret, or undefined when unset/empty. */
+export function getLanAuthToken(): string | undefined {
+  const t = process.env.LAN_AUTH_TOKEN;
+  return typeof t === 'string' && t.length > 0 ? t : undefined;
+}
+
+const LOOPBACK = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
+
+export function isLoopbackRequest(req: Request): boolean {
+  const ip = req.ip ?? req.socket?.remoteAddress ?? '';
+  return LOOPBACK.has(ip);
+}
+
+/* Pull the token from `Authorization: Bearer …`, the `X-Lan-Token`
+   header, or a `?token=` query param (the QR can carry it either way). */
+export function extractToken(req: Request): string | undefined {
+  const auth = req.headers['authorization'];
+  if (typeof auth === 'string' && auth.startsWith('Bearer ')) {
+    const t = auth.slice('Bearer '.length).trim();
+    if (t.length > 0) return t;
+  }
+  const header = req.headers['x-lan-token'];
+  if (typeof header === 'string' && header.length > 0) return header;
+  const q = req.query?.token;
+  if (typeof q === 'string' && q.length > 0) return q;
+  return undefined;
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+/* True when the guard is live for this process (LAN mode + token set). */
+export function isLanTokenEnforced(): boolean {
+  return isLanHttpsEnabled() && getLanAuthToken() !== undefined;
+}
+
+export function requireLanToken(req: Request, res: Response, next: NextFunction): void {
+  if (!isLanTokenEnforced()) return next();
+  if (isLoopbackRequest(req)) return next();
+  const expected = getLanAuthToken();
+  const provided = extractToken(req);
+  if (expected !== undefined && provided !== undefined && safeEqual(provided, expected)) {
+    return next();
+  }
+  res.status(401).json({ error: 'Missing or invalid LAN access token.' });
+}


### PR DESCRIPTION
## Summary

Opt-in LAN shared-secret token guard — the auth primitive the Android companion's pairing depends on (plan 188, `app-2` / D1). New `lan-auth.ts` middleware on `/api` + `/workspace`.

- **OFF by default** — enforced only when LAN HTTPS mode is on (`LAN_HTTPS=1`) **and** `LAN_AUTH_TOKEN` is set. Loopback always bypasses, so `npm start` and existing token-less LAN users are completely unaffected.
- `/cert/root.crt` (the public mkcert CA the companion fetches over the untrusted bootstrap channel before it can pin) and `/audio` stay open.
- Token read from `Authorization: Bearer`, the `X-Lan-Token` header, or a `?token` query param; timing-safe compare.

`Refs #425` — remaining small follow-ups for `srv-20`: surface the token + CA SHA-256 fingerprint in the `/api/export/lan` pairing payload (D2), and the web app's token attachment over LAN — both pair with the frontend pairing-QR work.

## Test plan

- `lan-auth.test.ts` (8 tests): off-by-default matrix (LAN mode × token), loopback bypass, 401 on missing/wrong token, accept via all three carriers, `extractToken`.
- Server typecheck clean; `npm run verify` (pre-push) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
