### PR TITLE
fix(server): hide console windows for all child_process spawns on Windows

### DIFF
--- a/server/src/diagnostics/ffmpeg.ts
+++ b/server/src/diagnostics/ffmpeg.ts
@@ -18,7 +18,7 @@ export interface FfmpegProbe {
    PATH (ENOENT), so the strict `=== 0` correctly reports absence. */
 function present(bin: string): boolean {
   try {
-    return spawnSync(bin, ['-version'], { stdio: 'ignore' }).status === 0;
+    return spawnSync(bin, ['-version'], { stdio: 'ignore', windowsHide: true }).status === 0;
   } catch {
     return false;
   }

--- a/server/src/export/build-m4b.ts
+++ b/server/src/export/build-m4b.ts
@@ -211,7 +211,7 @@ function probeDurationSec(mp3Path: string): Promise<number> {
       'default=nw=1:nk=1',
       mp3Path,
     ];
-    const child = spawn('ffprobe', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const child = spawn('ffprobe', args, { stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true });
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];
     child.stdout.on('data', (c) => stdoutChunks.push(c));
@@ -307,7 +307,7 @@ function runFfmpegMux(opts: RunFfmpegMuxOptions): Promise<void> {
       'mp4',
       outPath,
     ];
-    const child = spawn('ffmpeg', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const child = spawn('ffmpeg', args, { stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true });
     const stderrChunks: Buffer[] = [];
 
     /* Bridge AbortSignal → child process. ffmpeg responds to SIGTERM on

--- a/server/src/export/id3-tags.ts
+++ b/server/src/export/id3-tags.ts
@@ -77,7 +77,7 @@ export async function applyId3v24Tags(
   args.push('-f', 'mp3', destPath);
 
   await new Promise<void>((resolve, reject) => {
-    const child = spawn('ffmpeg', args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    const child = spawn('ffmpeg', args, { stdio: ['ignore', 'ignore', 'pipe'], windowsHide: true });
     const stderrChunks: Buffer[] = [];
     child.stderr.on('data', (chunk) => stderrChunks.push(chunk));
     child.on('error', (err) =>

--- a/server/src/routes/clip.ts
+++ b/server/src/routes/clip.ts
@@ -101,7 +101,7 @@ clipRouter.get(
 
     let child;
     try {
-      child = spawn('ffmpeg', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+      child = spawn('ffmpeg', args, { stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true });
     } catch (err) {
       return res.status(500).json({
         message: `Failed to spawn ffmpeg: ${(err as Error).message}. ` +

--- a/server/src/routes/worktrees.ts
+++ b/server/src/routes/worktrees.ts
@@ -82,7 +82,10 @@ worktreesRouter.get('/worktrees', async (_req: Request, res: Response) => {
     return res.status(404).end();
   }
   try {
-    const porcelain = spawnSync('git', ['worktree', 'list', '--porcelain'], { encoding: 'utf8' });
+    const porcelain = spawnSync('git', ['worktree', 'list', '--porcelain'], {
+      encoding: 'utf8',
+      windowsHide: true,
+    });
     if (porcelain.status !== 0) {
       return res
         .status(500)

--- a/server/src/spawn-windows-hide.test.ts
+++ b/server/src/spawn-windows-hide.test.ts
@@ -1,0 +1,156 @@
+/* Console-window-flash regression guard (windowsHide invariant).
+ *
+ * Symptom this locks down: on Windows, a prod app launched without an
+ * attached console (the fs-1 versioned-dir launcher runs detached) gives
+ * every spawned console program — ffmpeg.exe, ffprobe.exe, git.exe, the
+ * Python sidecar — its OWN new console window, which flashes open and
+ * vanishes. During audio generation/export the server spawns ffmpeg per
+ * sentence and per chapter, so the windows flash "constantly". In dev
+ * (`npm start` from a terminal) the children inherit the existing console,
+ * so the bug is invisible there — which is exactly how it slipped in.
+ *
+ * The fix is `windowsHide: true` on EVERY child_process call. Rather than
+ * unit-test each call site, this scans the whole server source tree and
+ * asserts the invariant globally: any new spawn that forgets the flag
+ * fails here, before it can ever ship a flashing window to a user.
+ *
+ * Scope: production server source only (`server/src/**`, excluding tests).
+ * Launcher scripts under `scripts/*.mjs` already carry the flag and are
+ * out of this suite's reach. */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const SRC_ROOT = import.meta.dirname;
+
+/* child_process entry points that launch an OS process (and therefore can
+   pop a console window on Windows). Bare `exec`/`execSync` are included for
+   completeness even though the codebase doesn't use them today. */
+const SPAWN_NAMES = ['spawnSync', 'spawn', 'execFileSync', 'execFile', 'execSync', 'exec'];
+
+/* Lookbehind rejects member calls and same-suffix identifiers so we never
+   match `someRegex.exec(...)`, `child.spawn(...)`, or a local `respawn(...)`
+   helper — only top-level `spawn(`, `spawnSync(`, `execFile(`, etc. */
+const CALL_RE = new RegExp(String.raw`(?<![.\w])(${SPAWN_NAMES.join('|')})\s*\(`, 'g');
+
+function listSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+      out.push(...listSourceFiles(full));
+      continue;
+    }
+    if (!entry.name.endsWith('.ts')) continue;
+    if (entry.name.endsWith('.test.ts') || entry.name.endsWith('.spec.ts')) continue;
+    if (entry.name === 'test-setup.ts') continue;
+    out.push(full);
+  }
+  return out;
+}
+
+/* Blank out comments AND string/template literals so prose that merely
+   mentions a spawn call — a doc comment, or a log line like
+   "skipping spawn (current sidecar honoured)" — is never matched. Replaced
+   characters become spaces (newlines kept) so byte offsets and line numbers
+   stay accurate for error reporting. Single-pass lexer because regex can't
+   disambiguate a `//` inside a string from a real line comment. */
+function blankCommentsAndStrings(src: string): string {
+  const out: string[] = [];
+  let i = 0;
+  const keepWhitespace = (ch: string) => (ch === '\n' ? '\n' : ' ');
+  while (i < src.length) {
+    const ch = src[i];
+    const next = src[i + 1];
+    if (ch === '/' && next === '/') {
+      while (i < src.length && src[i] !== '\n') out.push(keepWhitespace(src[i++]));
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      out.push('  ');
+      i += 2;
+      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) out.push(keepWhitespace(src[i++]));
+      if (i < src.length) {
+        out.push('  ');
+        i += 2;
+      }
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      const quote = ch;
+      out.push(' ');
+      i += 1;
+      while (i < src.length && src[i] !== quote) {
+        if (src[i] === '\\') {
+          out.push('  ');
+          i += 2;
+          continue;
+        }
+        out.push(keepWhitespace(src[i++]));
+      }
+      if (i < src.length) {
+        out.push(' ');
+        i += 1;
+      }
+      continue;
+    }
+    out.push(ch);
+    i += 1;
+  }
+  return out.join('');
+}
+
+/* Given the index of a call's opening paren, return the argument text up to
+   its balanced closing paren. Nested parens (e.g. `shell: isWin()`) are
+   handled by depth counting; our spawn args contain no parens inside string
+   literals, so naive counting is sufficient here. */
+function extractCallArgs(src: string, openParenIdx: number): string {
+  let depth = 0;
+  for (let i = openParenIdx; i < src.length; i += 1) {
+    const ch = src[i];
+    if (ch === '(') depth += 1;
+    else if (ch === ')') {
+      depth -= 1;
+      if (depth === 0) return src.slice(openParenIdx, i + 1);
+    }
+  }
+  return src.slice(openParenIdx); // unbalanced — treat the rest as the call
+}
+
+describe('windowsHide invariant (no flashing console windows in prod)', () => {
+  const files = listSourceFiles(SRC_ROOT).filter((f) =>
+    readFileSync(f, 'utf8').includes('child_process'),
+  );
+
+  it('finds at least the known ffmpeg/sidecar spawners (scan is wired up)', () => {
+    /* Guard against the scan silently matching nothing (e.g. a refactor that
+       moves all spawns) and giving a false green. */
+    expect(files.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('every child_process spawn passes windowsHide: true', () => {
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      const src = blankCommentsAndStrings(readFileSync(file, 'utf8'));
+      for (const match of src.matchAll(CALL_RE)) {
+        const name = match[1];
+        const openParenIdx = match.index + match[0].length - 1;
+        const callText = extractCallArgs(src, openParenIdx);
+        if (!/windowsHide\s*:\s*true/.test(callText)) {
+          const rel = file.slice(SRC_ROOT.length + 1).replace(/\\/g, '/');
+          const upToMatch = src.slice(0, match.index);
+          const line = upToMatch.split('\n').length;
+          offenders.push(`${rel}:${line} — ${name}(...) missing windowsHide: true`);
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      `child_process calls missing windowsHide (would flash a console window in prod):\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+});

--- a/server/src/tts/gain-pcm.ts
+++ b/server/src/tts/gain-pcm.ts
@@ -44,7 +44,7 @@ export async function applyGainToPcm(
   ];
 
   return new Promise<Buffer>((resolve, reject) => {
-    const child = spawn('ffmpeg', args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    const child = spawn('ffmpeg', args, { stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true });
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];
     child.stdout.on('data', (c) => stdoutChunks.push(c));

--- a/server/src/tts/loudnorm.ts
+++ b/server/src/tts/loudnorm.ts
@@ -222,7 +222,7 @@ export async function runLoudnormFirstPass(
   ];
 
   return await new Promise<LoudnormFirstPassStats>((resolve, reject) => {
-    const child = spawn('ffmpeg', args, { stdio: ['pipe', 'ignore', 'pipe'] });
+    const child = spawn('ffmpeg', args, { stdio: ['pipe', 'ignore', 'pipe'], windowsHide: true });
     const stderrChunks: Buffer[] = [];
 
     child.stderr.on('data', (chunk) => stderrChunks.push(chunk));

--- a/server/src/tts/mp3.ts
+++ b/server/src/tts/mp3.ts
@@ -93,6 +93,7 @@ export function hasLibFdkAac(): boolean {
     const result = spawnSync('ffmpeg', ['-hide_banner', '-codecs'], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
     });
     if (result.status !== 0) {
       cachedHasLibFdkAac = false;
@@ -369,7 +370,7 @@ export async function encodePcmToAudio(
   let encodeResult: { encoded: Buffer; stderr: string };
   try {
     encodeResult = await new Promise<{ encoded: Buffer; stderr: string }>((resolve, reject) => {
-      const child = spawn('ffmpeg', args, { stdio: ['pipe', 'pipe', 'pipe'] });
+      const child = spawn('ffmpeg', args, { stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true });
 
       const stdoutChunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];
@@ -514,7 +515,7 @@ export async function decodeAudioToPcm(input: Buffer, sampleRate: number): Promi
     'pipe:1',
   ];
   return new Promise<Buffer>((resolve, reject) => {
-    const child = spawn('ffmpeg', args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    const child = spawn('ffmpeg', args, { stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true });
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];
     child.stdout.on('data', (c) => stdoutChunks.push(c));

--- a/server/src/upgrade/apply.ts
+++ b/server/src/upgrade/apply.ts
@@ -150,7 +150,7 @@ export function extractRelease(zipPath: string, releaseDir: string, topDir: stri
 
 function run(cmd: string, args: string[], cwd: string): Promise<void> {
   return new Promise((res, rej) => {
-    const child = spawn(cmd, args, { cwd, stdio: 'inherit', shell: isWin() });
+    const child = spawn(cmd, args, { cwd, stdio: 'inherit', shell: isWin(), windowsHide: true });
     child.on('error', rej);
     child.on('exit', (code) => (code === 0 ? res() : rej(new Error(`${cmd} ${args.join(' ')} exited ${code}`))));
   });
@@ -211,6 +211,7 @@ export function createApplySteps(opts: { venvDir: string; log?: (m: string) => v
         },
         detached: true,
         stdio: 'ignore',
+        windowsHide: true,
       });
       child.unref();
     },


### PR DESCRIPTION
## Summary

In a prod launch the server runs without an attached console (the fs-1 versioned-dir launcher is detached), so every spawned console program — `ffmpeg.exe`, `ffprobe.exe`, `git.exe`, the Python sidecar — gets its **own** new console window that flashes open and vanishes. Because `ffmpeg` is spawned per sentence and per chapter during generation/export, the windows flash **constantly**. In dev (`npm start` from a terminal) the children inherit the existing console, so the bug is invisible there — which is how it slipped in.

Fix: `windowsHide: true` on every `child_process` call. The hot ffmpeg/ffprobe sites were already covered (uncommitted in the tree); this completes the stragglers (`mp3.ts` libfdk_aac codec probe, `worktrees.ts` git listing) and adds a static-scan invariant test so a future spawn can't silently reintroduce a flashing window.

## Test plan

- `server/src/spawn-windows-hide.test.ts` — single-pass-lexer scan asserting `windowsHide: true` on every `child_process` call across `server/src` (blanks comments + string literals to avoid false positives). Verified it fails (correct file:line) when a flag is removed and passes when present. The scan caught a site missed by manual eyeballing.
- Full pre-push `npm run verify` green (typecheck + all tests + e2e + build); server suite 2112 passed.