### PR TITLE
feat(server,openapi): srv-20 (D2) — token + CA fingerprint in /api/export/lan

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4280,6 +4280,12 @@ components:
         urls:
           type: array
           items: { type: string, description: "Reachable URL, e.g. 'http://192.168.1.42:8080' or 'https://192.168.1.42:8443'" }
+        token:
+          type: string
+          description: "srv-20 — the shared-secret LAN token, present only when LAN_AUTH_TOKEN is configured. The companion pairing QR carries it so a device can authenticate to the otherwise-guarded /api surface."
+        caFingerprint:
+          type: string
+          description: "srv-20 — the LAN CA's SHA-256 (X.509 fingerprint256), present only when the mkcert root CA is resolvable. A pairing client fetches /cert/root.crt, computes the same fingerprint, and pins only if it matches."
 
     GpuQueueState:
       type: object

--- a/server/src/routes/export-lan.test.ts
+++ b/server/src/routes/export-lan.test.ts
@@ -118,3 +118,41 @@ describe('GET /api/export/lan — CORS-from-LAN-origin acceptance', () => {
     expect(res.status).toBe(200);
   });
 });
+
+describe('GET /api/export/lan — srv-20 pairing payload (token + caFingerprint)', () => {
+  const origToken = process.env.LAN_AUTH_TOKEN;
+  afterEach(() => {
+    if (origToken === undefined) delete process.env.LAN_AUTH_TOKEN;
+    else process.env.LAN_AUTH_TOKEN = origToken;
+  });
+
+  it('omits token when LAN_AUTH_TOKEN is unset', async () => {
+    delete process.env.LAN_AUTH_TOKEN;
+    const res = await request(makeApp()).get('/api/export/lan');
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeUndefined();
+  });
+
+  it('surfaces the token when LAN_AUTH_TOKEN is set', async () => {
+    process.env.LAN_AUTH_TOKEN = 'pair-secret-123';
+    const res = await request(makeApp()).get('/api/export/lan');
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBe('pair-secret-123');
+  });
+
+  it('omits token for an empty LAN_AUTH_TOKEN', async () => {
+    process.env.LAN_AUTH_TOKEN = '';
+    const res = await request(makeApp()).get('/api/export/lan');
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeUndefined();
+  });
+
+  it('caFingerprint, when present, is a non-empty fingerprint string (best-effort)', async () => {
+    const res = await request(makeApp()).get('/api/export/lan');
+    expect(res.status).toBe(200);
+    if (res.body.caFingerprint !== undefined) {
+      expect(typeof res.body.caFingerprint).toBe('string');
+      expect(res.body.caFingerprint.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/server/src/routes/export-lan.ts
+++ b/server/src/routes/export-lan.ts
@@ -24,8 +24,11 @@
    / mic / camera APIs become available on phone Safari/Chrome). */
 
 import { networkInterfaces } from 'node:os';
+import { readFileSync } from 'node:fs';
+import { X509Certificate } from 'node:crypto';
 import { Router } from 'express';
 import type { Request, Response } from '../http.js';
+import { resolveRootCaPath } from './cert-root.js';
 
 export const exportLanRouter = Router();
 
@@ -33,6 +36,15 @@ export interface ExportLanInfo {
   urls: string[];
   port: number;
   protocol: 'http' | 'https';
+  /* srv-20 — the shared-secret LAN token, present only when LAN_AUTH_TOKEN is
+     configured. The companion pairing QR carries it so a device can
+     authenticate to the (otherwise guarded) /api surface. */
+  token?: string;
+  /* srv-20 — the LAN CA's SHA-256 (X.509 fingerprint256), present only when the
+     mkcert root CA is resolvable. A pairing client fetches /cert/root.crt,
+     computes the same fingerprint, and pins ONLY if it matches (no manual
+     hex compare, no OS cert install). */
+  caFingerprint?: string;
 }
 
 export function isLanHttpsEnabled(): boolean {
@@ -54,11 +66,37 @@ export function enumerateLanUrls(port: number, protocol: 'http' | 'https' = 'htt
   return { urls, port, protocol };
 }
 
+/* srv-20 — the configured shared-secret token (or undefined). Read directly
+   from env (not via lan-auth) to avoid a circular import (lan-auth already
+   imports isLanHttpsEnabled from here). */
+function lanAuthToken(): string | undefined {
+  const t = process.env.LAN_AUTH_TOKEN;
+  return typeof t === 'string' && t.length > 0 ? t : undefined;
+}
+
+/* srv-20 — the LAN CA's SHA-256 fingerprint (standard X.509 fingerprint256).
+   Best-effort: undefined when the mkcert CA can't be located / read / parsed. */
+export function lanCaFingerprint(): string | undefined {
+  try {
+    const ca = resolveRootCaPath();
+    if (!ca) return undefined;
+    return new X509Certificate(readFileSync(ca.path)).fingerprint256;
+  } catch {
+    return undefined;
+  }
+}
+
 exportLanRouter.get('/lan', (_req: Request, res: Response) => {
   const httpsMode = isLanHttpsEnabled();
   const port = httpsMode
     ? Number(process.env.LAN_HTTPS_PORT ?? 8443)
     : Number(process.env.PORT ?? 8080);
   const protocol: 'http' | 'https' = httpsMode ? 'https' : 'http';
-  res.json(enumerateLanUrls(port, protocol));
+  const token = lanAuthToken();
+  const caFingerprint = lanCaFingerprint();
+  res.json({
+    ...enumerateLanUrls(port, protocol),
+    ...(token !== undefined ? { token } : {}),
+    ...(caFingerprint !== undefined ? { caFingerprint } : {}),
+  });
 });

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -3203,6 +3203,10 @@ export interface components {
              */
             protocol: "http" | "https";
             urls: string[];
+            /** @description srv-20 — the shared-secret LAN token, present only when LAN_AUTH_TOKEN is configured. The companion pairing QR carries it so a device can authenticate to the otherwise-guarded /api surface. */
+            token?: string;
+            /** @description srv-20 — the LAN CA's SHA-256 (X.509 fingerprint256), present only when the mkcert root CA is resolvable. A pairing client fetches /cert/root.crt, computes the same fingerprint, and pins only if it matches. */
+            caFingerprint?: string;
         };
         GpuQueueState: {
             /** @description Number of acquires waiting in the FIFO queue behind the in-flight ops. The frontend pill renders 'GPU busy · N waiting ·' when this is > 0. */


### PR DESCRIPTION
## Summary

Completes **`srv-20`** (the middleware landed in #561). `GET /api/export/lan` now surfaces, when available, the two extra fields the companion pairing QR needs:

- **`token`** — the shared-secret LAN token (from `LAN_AUTH_TOKEN`), so a scanned QR can authenticate to the otherwise-guarded `/api` surface.
- **`caFingerprint`** — the LAN CA's SHA-256 (X.509 `fingerprint256` of the resolved mkcert root CA), so the app fetches `/cert/root.crt`, computes the same fingerprint, and **pins only if it matches** — no manual hex compare, no OS cert install.

Both are best-effort/optional (omitted when unset / unresolvable). Reads the token from env directly to avoid a circular import with `lan-auth`.

This is the last server piece `app-2`'s pairing needs (D2).

## Test plan

- `export-lan.test.ts` (13 total, 4 new): token surfaced when set, omitted when unset/empty; `caFingerprint` is a non-empty string when present (best-effort).
- OpenAPI `ExportLanInfo` + regenerated `api-types` updated; server typecheck clean.
- `npm run verify` (pre-push) green.

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
