### PR TITLE
feat(app): app-2 (part 1) — cert-fingerprint pinning verification

### DIFF
--- a/apps/android/lib/src/data/cert_pinning.dart
+++ b/apps/android/lib/src/data/cert_pinning.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+import 'package:crypto/crypto.dart';
+
+/// Cert-fingerprint pinning for the pairing flow (plan 188, app-2 / srv-20).
+///
+/// The server's pairing QR carries `caFingerprint` — the SHA-256 (X.509
+/// fingerprint256) of its mkcert root CA. At pair time the app fetches
+/// `/cert/root.crt` over a one-shot, validation-bypassing client, computes the
+/// same fingerprint here, and pins the CA **only if it matches** — automated
+/// MitM protection with no manual hex compare and no OS-level cert install.
+///
+/// These are pure functions (no `dart:io`, no platform deps) so the security
+/// logic is fully unit-testable without a device.
+
+/// Decodes the DER bytes from a PEM `CERTIFICATE` block (strips the
+/// `-----BEGIN/END-----` armor and base64-decodes the body).
+List<int> pemToDer(String pem) {
+  final body = pem
+      .split(RegExp(r'\r?\n'))
+      .where((l) => l.isNotEmpty && !l.startsWith('-----'))
+      .join();
+  return base64.decode(body);
+}
+
+/// Formats a digest as Node's `X509Certificate.fingerprint256` does:
+/// uppercase hex, colon-separated (e.g. `AB:CD:01`).
+String formatFingerprint(List<int> digest) =>
+    digest.map((b) => b.toRadixString(16).padLeft(2, '0').toUpperCase()).join(':');
+
+/// SHA-256 fingerprint of the certificate in [pem], matching the server's
+/// `caFingerprint`.
+String caFingerprintFromPem(String pem) =>
+    formatFingerprint(sha256.convert(pemToDer(pem)).bytes);
+
+/// Compares two fingerprints, ignoring case and any non-hex separators
+/// (`:`, whitespace) so formatting differences never cause a false mismatch.
+bool fingerprintsMatch(String a, String b) {
+  String norm(String s) => s.replaceAll(RegExp('[^0-9a-fA-F]'), '').toUpperCase();
+  final na = norm(a);
+  return na.isNotEmpty && na == norm(b);
+}
+
+/// True when the fetched CA [pem] matches the [expected] pinned fingerprint.
+bool verifyCaFingerprint(String pem, String expected) =>
+    fingerprintsMatch(caFingerprintFromPem(pem), expected);

--- a/apps/android/pubspec.lock
+++ b/apps/android/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  crypto:
+    dependency: "direct main"
+    description:
+      name: crypto
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.7"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -192,6 +200,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:

--- a/apps/android/pubspec.yaml
+++ b/apps/android/pubspec.yaml
@@ -35,6 +35,9 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
 
+  # srv-20 pairing (app-2) — SHA-256 of the server CA for cert-fingerprint pinning.
+  crypto: ^3.0.6
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/apps/android/test/data/cert_pinning_test.dart
+++ b/apps/android/test/data/cert_pinning_test.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:audiobook_companion/src/data/cert_pinning.dart';
+
+String pemOf(List<int> der) =>
+    '-----BEGIN CERTIFICATE-----\n${base64.encode(der)}\n-----END CERTIFICATE-----\n';
+
+void main() {
+  group('cert pinning', () {
+    test('pemToDer strips armor and decodes the base64 body', () {
+      final der = List<int>.generate(40, (i) => i);
+      expect(pemToDer(pemOf(der)), der);
+    });
+
+    test('formatFingerprint emits uppercase colon-separated hex', () {
+      expect(formatFingerprint([0xab, 0x01, 0xff]), 'AB:01:FF');
+    });
+
+    test('fingerprintsMatch ignores case and separators', () {
+      expect(fingerprintsMatch('ab:cd:ef', 'ABCDEF'), isTrue);
+      expect(fingerprintsMatch('AB CD EF', 'ab:cd:ef'), isTrue);
+      expect(fingerprintsMatch('ab:cd', 'ab:ce'), isFalse);
+      expect(fingerprintsMatch('', 'abcd'), isFalse);
+    });
+
+    test('verifyCaFingerprint round-trips: matches its own fingerprint, rejects others', () {
+      final pem = pemOf(List<int>.generate(64, (i) => (i * 7) % 256));
+      final fp = caFingerprintFromPem(pem);
+      // A real SHA-256 is 32 bytes -> 32 colon-separated hex groups.
+      expect(fp.split(':').length, 32);
+      expect(verifyCaFingerprint(pem, fp), isTrue);
+      // Same fingerprint, server-style lowercase without colons, still matches.
+      expect(verifyCaFingerprint(pem, fp.replaceAll(':', '').toLowerCase()), isTrue);
+      expect(verifyCaFingerprint(pem, 'AB:CD:EF'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Part 1 of **`app-2`** (pairing + app-managed TLS trust) — the **pure-Dart security core**, buildable + testable with no device.

`lib/src/data/cert_pinning.dart` verifies the CA the app fetches from `/cert/root.crt` against the `caFingerprint` carried in the pairing QR (surfaced by `srv-20` D2). It computes Node's X.509 `fingerprint256` (PEM → DER → SHA-256 → uppercase colon-hex) and compares case/separator-insensitively. The app pins **only on a match** — automated MitM protection, no manual hex compare, no OS-level cert install (the key iOS-readiness move).

Pairs with the `PairedServer` model from `app-1` (the `{ url, token, caFingerprint }` payload).

## Test plan

- `flutter analyze` clean; `flutter test` green (8 tests — 4 cert-pinning + 3 `PairedServer` + 1 widget).
- Adds the `crypto` dependency.
- `npm run verify` (pre-push) green — the existing battery is unaffected.

`Refs #542` — remaining for `app-2` (the device/native-plugin parts): the connection service (one-shot bad-cert bootstrap fetch → verify → pin in a `dart:io` `SecurityContext`), secure token storage (`flutter_secure_storage`), the QR-scan pairing screen, and the generated API client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
