### PR TITLE
feat(app): app-2 (part 3) — QR pairing scanner + authenticated API client

### DIFF
--- a/apps/android/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- app-2: network calls to the paired server + QR pairing-code scanning. -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.CAMERA"/>
     <application
         android:label="audiobook_companion"
         android:name="${applicationName}"

--- a/apps/android/lib/src/data/api_client.dart
+++ b/apps/android/lib/src/data/api_client.dart
@@ -1,0 +1,72 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'pairing_service.dart' show Connection;
+
+/// Result of a raw HTTP send (status + body) — the injection seam that lets the
+/// API client be unit-tested without real TLS.
+class HttpResult {
+  const HttpResult(this.statusCode, this.body);
+  final int statusCode;
+  final String body;
+}
+
+typedef HttpSend = Future<HttpResult> Function(
+    String method, Uri url, Map<String, String> headers);
+
+class ApiException implements Exception {
+  const ApiException(this.statusCode, this.message);
+  final int statusCode;
+  final String message;
+  @override
+  String toString() => 'ApiException($statusCode): $message';
+}
+
+/// Authenticated, CA-pinned HTTP client for the paired server (app-2). Every
+/// request validates the server cert against the pinned CA (from pairing) and
+/// carries the Bearer token. The transport is injectable for tests.
+class ApiClient {
+  ApiClient(this.connection, {HttpSend? send})
+      : _send = send ?? _pinnedSend(connection);
+
+  final Connection connection;
+  final HttpSend _send;
+
+  Uri _u(String path) => Uri.parse('${connection.server.url}$path');
+
+  Future<Map<String, dynamic>> getJson(String path) async {
+    final res = await _send('GET', _u(path), {
+      HttpHeaders.authorizationHeader: 'Bearer ${connection.server.token}',
+    });
+    if (res.statusCode == 401 || res.statusCode == 403) {
+      throw ApiException(res.statusCode, 'Not authorised — re-pair the device.');
+    }
+    if (res.statusCode >= 400) {
+      throw ApiException(res.statusCode, 'Request to $path failed (${res.statusCode}).');
+    }
+    final decoded = jsonDecode(res.body);
+    if (decoded is! Map<String, dynamic>) {
+      throw ApiException(res.statusCode, 'Expected a JSON object from $path.');
+    }
+    return decoded;
+  }
+
+  /// GET /api/info — the server version / capabilities handshake (used to
+  /// gate features + confirm the server is new enough for the sync manifest).
+  Future<Map<String, dynamic>> info() => getJson('/api/info');
+}
+
+/// Real transport: a `dart:io` HttpClient that trusts ONLY the pinned CA and
+/// reuses one connection pool for the paired server's lifetime.
+HttpSend _pinnedSend(Connection connection) {
+  final ctx = SecurityContext(withTrustedRoots: false)
+    ..setTrustedCertificatesBytes(utf8.encode(connection.caPem));
+  final client = HttpClient(context: ctx);
+  return (method, url, headers) async {
+    final req = await client.openUrl(method, url);
+    headers.forEach(req.headers.set);
+    final res = await req.close();
+    final body = await res.transform(utf8.decoder).join();
+    return HttpResult(res.statusCode, body);
+  };
+}

--- a/apps/android/lib/src/domain/paired_server.dart
+++ b/apps/android/lib/src/domain/paired_server.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 /// Connection details the app pairs to, parsed from the pairing QR payload
 /// `{ url, token, caFingerprint }` (plan 188, app-2 / srv-20). Pure data with
 /// no platform dependencies, so it lives in the domain layer and is fully
@@ -13,6 +15,20 @@ class PairedServer {
   final String url;
   final String token;
   final String caFingerprint;
+
+  /// Parse the raw text of a scanned pairing QR (a JSON object).
+  factory PairedServer.fromQrPayload(String raw) {
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } catch (_) {
+      throw const FormatException('pairing QR is not valid JSON');
+    }
+    if (decoded is! Map<String, dynamic>) {
+      throw const FormatException('pairing QR is not a JSON object');
+    }
+    return PairedServer.fromJson(decoded);
+  }
 
   factory PairedServer.fromJson(Map<String, dynamic> json) {
     final url = _requireNonEmptyString(json, 'url');

--- a/apps/android/lib/src/ui/pairing_screen.dart
+++ b/apps/android/lib/src/ui/pairing_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../data/pairing_service.dart';
 import '../data/pairing_store.dart';
 import '../domain/paired_server.dart';
+import 'qr_scan_screen.dart';
 
 /// Manual pairing form (app-2). Enter the server URL + token + CA fingerprint
 /// from the desktop pairing screen; on success the verified connection is
@@ -58,6 +59,22 @@ class _PairingScreenState extends State<PairingScreen> {
     }
   }
 
+  /// Open the camera scanner; on a valid pairing QR, fill the form fields so
+  /// the user can review before pairing.
+  Future<void> _scan() async {
+    final server = await Navigator.of(context).push<PairedServer>(
+      MaterialPageRoute(builder: (_) => const QrScanScreen()),
+    );
+    if (server != null && mounted) {
+      setState(() {
+        _url.text = server.url;
+        _token.text = server.token;
+        _fingerprint.text = server.caFingerprint;
+        _error = null;
+      });
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -67,8 +84,15 @@ class _PairingScreenState extends State<PairingScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            const Text('Enter the server details shown on the desktop pairing '
-                'screen. (QR scanning comes next.)'),
+            const Text('Scan the pairing QR shown on the desktop, or enter the '
+                'details manually.'),
+            const SizedBox(height: 12),
+            OutlinedButton.icon(
+              key: const Key('scan-qr'),
+              onPressed: _busy ? null : _scan,
+              icon: const Icon(Icons.qr_code_scanner),
+              label: const Text('Scan QR'),
+            ),
             const SizedBox(height: 12),
             TextField(
               key: const Key('field-url'),

--- a/apps/android/lib/src/ui/qr_scan_screen.dart
+++ b/apps/android/lib/src/ui/qr_scan_screen.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+import '../domain/paired_server.dart';
+
+/// Scans the server pairing QR and pops with the parsed [PairedServer]
+/// (app-2). Non-matching codes are ignored so the camera keeps scanning.
+class QrScanScreen extends StatefulWidget {
+  const QrScanScreen({super.key});
+
+  @override
+  State<QrScanScreen> createState() => _QrScanScreenState();
+}
+
+class _QrScanScreenState extends State<QrScanScreen> {
+  bool _handled = false;
+
+  void _onDetect(BarcodeCapture capture) {
+    if (_handled || capture.barcodes.isEmpty) return;
+    final raw = capture.barcodes.first.rawValue;
+    if (raw == null || raw.isEmpty) return;
+    try {
+      final server = PairedServer.fromQrPayload(raw);
+      _handled = true;
+      Navigator.of(context).pop(server);
+    } on FormatException {
+      // Not a pairing QR — keep scanning.
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Scan pairing code')),
+      body: MobileScanner(onDetect: _onDetect),
+    );
+  }
+}

--- a/apps/android/pubspec.lock
+++ b/apps/android/pubspec.lock
@@ -256,6 +256,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.18.0"
+  mobile_scanner:
+    dependency: "direct main"
+    description:
+      name: mobile_scanner
+      sha256: d234581c090526676fd8fab4ada92f35c6746e3fb4f05a399665d75a399fb760
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.3"
   objective_c:
     dependency: transitive
     description:
@@ -437,6 +445,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.2.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   win32:
     dependency: transitive
     description:

--- a/apps/android/pubspec.yaml
+++ b/apps/android/pubspec.yaml
@@ -41,6 +41,9 @@ dependencies:
   # app-2 — persist the paired-server connection (url/token/fingerprint).
   flutter_secure_storage: ^9.2.4
 
+  # app-2 — scan the server pairing QR.
+  mobile_scanner: ^5.2.3
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/apps/android/test/data/api_client_test.dart
+++ b/apps/android/test/data/api_client_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:audiobook_companion/src/data/api_client.dart';
+import 'package:audiobook_companion/src/data/pairing_service.dart';
+import 'package:audiobook_companion/src/domain/paired_server.dart';
+
+Connection conn() => const Connection(
+      server: PairedServer(url: 'https://10.0.0.5:8443', token: 'tok', caFingerprint: 'f'),
+      caPem: 'PEM',
+    );
+
+void main() {
+  group('ApiClient', () {
+    test('getJson returns the parsed body and sends the Bearer token', () async {
+      String? sentAuth;
+      Uri? sentUrl;
+      final api = ApiClient(conn(), send: (method, url, headers) async {
+        sentAuth = headers['authorization'];
+        sentUrl = url;
+        return const HttpResult(200, '{"appVersion":"1.6.0"}');
+      });
+      final body = await api.info();
+      expect(body['appVersion'], '1.6.0');
+      expect(sentAuth, 'Bearer tok');
+      expect(sentUrl.toString(), 'https://10.0.0.5:8443/api/info');
+    });
+
+    test('throws ApiException on 401', () async {
+      final api = ApiClient(conn(), send: (_, _, _) async => const HttpResult(401, ''));
+      await expectLater(
+        api.info(),
+        throwsA(isA<ApiException>().having((e) => e.statusCode, 'status', 401)),
+      );
+    });
+
+    test('throws ApiException on 5xx', () async {
+      final api = ApiClient(conn(), send: (_, _, _) async => const HttpResult(503, ''));
+      await expectLater(
+        api.info(),
+        throwsA(isA<ApiException>().having((e) => e.statusCode, 'status', 503)),
+      );
+    });
+  });
+}

--- a/apps/android/test/domain/paired_server_test.dart
+++ b/apps/android/test/domain/paired_server_test.dart
@@ -33,5 +33,22 @@ void main() {
         throwsA(isA<FormatException>()),
       );
     });
+
+    group('fromQrPayload', () {
+      test('parses a scanned JSON payload', () {
+        final s = PairedServer.fromQrPayload(
+          '{"url":"https://10.0.0.5:8443","token":"t","caFingerprint":"AB:CD"}',
+        );
+        expect(s.url, 'https://10.0.0.5:8443');
+        expect(s.token, 't');
+        expect(s.caFingerprint, 'AB:CD');
+      });
+
+      test('rejects non-JSON and non-object payloads', () {
+        expect(() => PairedServer.fromQrPayload('not json'), throwsA(isA<FormatException>()));
+        expect(() => PairedServer.fromQrPayload('"a string"'), throwsA(isA<FormatException>()));
+        expect(() => PairedServer.fromQrPayload('[1,2,3]'), throwsA(isA<FormatException>()));
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary

**Finishes `app-2`** (pairing + app-managed TLS trust + API client). Builds on the cert-pinning core (#565) and the pairing service/store/form (#566):

- **`ApiClient`** — an authenticated, **CA-pinned** HTTP client for the paired server. Every request validates the server cert against the pinned CA (from pairing) and carries the Bearer token; `getJson()` + `info()` (the `/api/info` handshake). Injectable transport, unit-tested without TLS. **This is the connection layer `app-3`+ builds on.** *(A thin hand-written client; full OpenAPI Dart codegen is deferred until the consumed surface stabilises.)*
- **QR pairing** — `PairedServer.fromQrPayload` parses the scanned JSON; `QrScanScreen` (`mobile_scanner`) + a **"Scan QR"** button on the pairing form that fills the fields from a scanned code (review-before-pair). `CAMERA` + `INTERNET` permissions added.

## Test plan

- `flutter analyze` clean; `flutter test` green (**21** tests — added API-client error matrix + QR-payload parsing).
- **Debug APK builds** with the `mobile_scanner` native plugin (`√ Built app-debug.apk`).
- The QR camera is exercised on a **physical device** (an emulator has no real camera); the parse + form/transport logic is unit-tested.
- `npm run verify` (pre-push) green.

Closes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)
