### PR TITLE
fix(server): derive missing cast.lines from attribution on book-state read

### DIFF
--- a/server/src/routes/book-state.test.ts
+++ b/server/src/routes/book-state.test.ts
@@ -812,6 +812,123 @@ describe('book-state router — chapterCharacters reflects the post-fold roster'
   });
 });
 
+describe('book-state router — backfills missing cast.lines from attribution', () => {
+  /* Regression: a roster-added / cross-book-linked cast row (cast-add-from-
+     roster.ts mints `<id>_from_<book>` without a `lines` field, and nothing
+     rewrites it after analysis attributes sentences to it) rendered a blank
+     line count in the cast view even though the manuscript attributes lines to
+     it (the Unlocked "Councilor Alina" case). The GET handler now derives the
+     count from manuscript-edits.json and fills it in when the row lacks one,
+     without clobbering counts the analyzer already stamped. */
+  const LINES_TITLE = 'Lines Backfill Test';
+  const LINES_MANUSCRIPT_ID = 'm_lines_backfill_test';
+  let linesBookId: string;
+  let linesBookDir: string;
+
+  beforeAll(async () => {
+    const { makeBookId } = await import('../workspace/paths.js');
+    linesBookId = makeBookId(AUTHOR, SERIES, LINES_TITLE);
+    linesBookDir = join(workspaceRoot, 'books', AUTHOR, SERIES, LINES_TITLE);
+    mkdirSync(join(linesBookDir, '.audiobook'), { recursive: true });
+
+    writeFileSync(join(linesBookDir, 'manuscript.txt'), 'placeholder');
+    writeFileSync(
+      join(linesBookDir, '.audiobook', 'state.json'),
+      JSON.stringify({
+        bookId: linesBookId,
+        manuscriptId: LINES_MANUSCRIPT_ID,
+        title: LINES_TITLE,
+        author: AUTHOR,
+        series: SERIES,
+        seriesPosition: null,
+        isStandalone: true,
+        manuscriptFile: 'manuscript.txt',
+        castConfirmed: true,
+        chapters: [{ id: 63, title: 'Chapter 63', slug: '63-chapter' }],
+        coverGradient: ['#000', '#fff'],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+
+    /* Cast: a linked row with NO `lines` field (the roster-add shape), a
+       linked row with no attributed lines, and a normal row whose analyzer-
+       stamped `lines` must survive untouched. */
+    writeFileSync(
+      join(linesBookDir, '.audiobook', 'cast.json'),
+      JSON.stringify({
+        characters: [
+          { id: 'narrator', name: 'Narrator' },
+          { id: 'sophie', name: 'Sophie', lines: 99 },
+          { id: 'alina_from_shannon-', name: 'Councilor Alina' },
+          { id: 'ghost_from_shannon-', name: 'Ghost Link' },
+        ],
+      }),
+    );
+
+    writeFileSync(
+      join(linesBookDir, '.audiobook', 'manuscript-edits.json'),
+      JSON.stringify({
+        sentences: [
+          { id: 1, chapterId: 63, characterId: 'narrator', text: 'She spun toward the sound.' },
+          { id: 2, chapterId: 63, characterId: 'alina_from_shannon-', text: 'Of course she told us.' },
+          { id: 3, chapterId: 63, characterId: 'alina_from_shannon-', text: 'Oh, really?' },
+          { id: 4, chapterId: 63, characterId: 'alina_from_shannon-', text: 'Then why?' },
+          { id: 5, chapterId: 63, characterId: 'sophie', text: 'I never said that.' },
+        ],
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    const { clearAnalysisCache } = await import('../store/analysis-cache.js');
+    await clearAnalysisCache(LINES_MANUSCRIPT_ID);
+  });
+
+  it('fills cast.lines for a linked row that lacks one, from manuscript-edits attribution', async () => {
+    const res = await request(app).get(`/api/books/${linesBookId}/state`);
+    expect(res.status).toBe(200);
+    const chars = res.body.cast.characters as Array<{ id: string; lines?: number }>;
+    const byId = Object.fromEntries(chars.map((c) => [c.id, c.lines]));
+    /* The linked row had 3 sentences attributed in chapter 63 → count is
+       now surfaced instead of blank. */
+    expect(byId['alina_from_shannon-']).toBe(3);
+    /* A linked row with zero attributed lines becomes a truthful 0, not
+       undefined/blank. */
+    expect(byId['ghost_from_shannon-']).toBe(0);
+  });
+
+  it('overrides a stale stored lines count with the current attribution (derive-always)', async () => {
+    const res = await request(app).get(`/api/books/${linesBookId}/state`);
+    expect(res.status).toBe(200);
+    const chars = res.body.cast.characters as Array<{ id: string; lines?: number }>;
+    const sophie = chars.find((c) => c.id === 'sophie');
+    /* Sophie's stored count (99) is replaced by her CURRENT attribution count
+       (1 sentence in manuscript-edits) — the cast view always reflects the
+       live attribution, not a value that may have drifted since analysis. */
+    expect(sophie?.lines).toBe(1);
+  });
+
+  it('preserves stored counts when no attribution source is loaded (analysis in flight)', async () => {
+    /* No manuscript-edits AND no analysis cache → nothing to derive from.
+       Deriving-always must NOT wipe every row to 0 in this state; the stored
+       counts are the only signal the cast view has. */
+    const { clearAnalysisCache } = await import('../store/analysis-cache.js');
+    await clearAnalysisCache(LINES_MANUSCRIPT_ID);
+    rmSync(join(linesBookDir, '.audiobook', 'manuscript-edits.json'), { force: true });
+
+    const res = await request(app).get(`/api/books/${linesBookId}/state`);
+    expect(res.status).toBe(200);
+    const chars = res.body.cast.characters as Array<{ id: string; lines?: number }>;
+    const sophie = chars.find((c) => c.id === 'sophie');
+    /* Stored count survives; the linked row that never had one stays
+       absent rather than being forced to a misleading 0. */
+    expect(sophie?.lines).toBe(99);
+    const alina = chars.find((c) => c.id === 'alina_from_shannon-');
+    expect(alina?.lines).toBeUndefined();
+  });
+});
+
 describe('book-state router — state slice series-membership + on-disk rename', () => {
   /* Each case in this block creates its own book on disk so the test
      observing the post-rename layout doesn't tread on the shared bookId

--- a/server/src/routes/book-state.ts
+++ b/server/src/routes/book-state.ts
@@ -229,6 +229,14 @@ bookStateRouter.get('/:bookId/state', async (req: Request, res: Response) => {
        — without this the reducer falls back to all-cast and the pill list
        flickers from "filtered" to "everyone" on hydrate. */
     const chapterCharacters: Record<number, string[]> = {};
+    /* Total attributed-sentence count per character id, derived from the same
+       post-fold sentence list used for chapterCharacters. Used below to
+       backfill the denormalised `lines` field on cast rows that were created
+       WITHOUT one — a roster-added / cross-book-linked row (cast-add-from-
+       roster.ts mints `<id>_from_<book>` with no `lines`, and nothing rewrites
+       it after attribution), which otherwise renders a blank line count in the
+       cast view even though the manuscript attributes lines to it. */
+    const lineCountById = new Map<string, number>();
     /* Chapters whose Phase 0a cast detection failed across the analyzer's
        built-in retry. Surfaced so the analysing view can render a
        per-chapter Retry button that survives reload — without this, the
@@ -282,6 +290,7 @@ bookStateRouter.get('/:bookId/state', async (req: Request, res: Response) => {
             bucketByChapter.set(sent.chapterId, bucket);
           }
           bucket.add(sent.characterId);
+          lineCountById.set(sent.characterId, (lineCountById.get(sent.characterId) ?? 0) + 1);
         }
         for (const [id, ids] of bucketByChapter) chapterCharacters[id] = [...ids];
       } else {
@@ -289,9 +298,34 @@ bookStateRouter.get('/:bookId/state', async (req: Request, res: Response) => {
           const id = Number(chapterId);
           if (Number.isNaN(id)) continue;
           const ids = new Set<string>();
-          for (const sent of sentences) ids.add(sent.characterId);
+          for (const sent of sentences) {
+            ids.add(sent.characterId);
+            lineCountById.set(sent.characterId, (lineCountById.get(sent.characterId) ?? 0) + 1);
+          }
           chapterCharacters[id] = [...ids];
         }
+      }
+    }
+
+    /* Derive the denormalised `lines` count on every cast row from the
+       attribution above, so the cast view always reflects the CURRENT
+       manuscript-edits attribution rather than a stale value stamped at
+       analysis time. This fixes two classes of wrong count at once:
+         - roster-added / cross-book-linked rows (`<id>_from_<book>`, minted by
+           cast-add-from-roster.ts with no `lines` field) that read as blank;
+         - any row whose stored count drifted after a manual reattribution /
+           boundary move that never rewrote the cast.
+
+       Gated on having an attribution source: `lineCountById` is only populated
+       when a non-empty sentence list (manuscript-edits.json, or the cache
+       fallback) was loaded above. When analysis hasn't produced sentences yet
+       the map is empty — leave the stored counts alone rather than wiping every
+       row to 0. A row with an attribution source but no sentences of its own
+       becomes a truthful 0. */
+    if (lineCountById.size > 0 && cast?.characters && Array.isArray(cast.characters)) {
+      for (const c of cast.characters as Array<{ id?: unknown; lines?: unknown }>) {
+        if (typeof c?.id !== 'string') continue;
+        c.lines = lineCountById.get(c.id) ?? 0;
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes the **Unlocked "Councilor Alina" shows no lines** report.

`Councilor Alina` is a cross-book–**linked** cast row (`dame-alina_from_shannon-`, `matchedFrom` → Neverseen). Such rows are minted by `cast-add-from-roster.ts` **without a `lines` field**, and nothing rewrites it after analysis attributes sentences to the row. `book-state` GET serves the stored cast as-is (it denormalises *voices*, never `lines`), so the cast view rendered a **blank** line count even though the manuscript attributes 4 lines to her (ch63).

Root-cause notes:
- The user's recent **rename + alias** (Dame Alina → Councilor Alina) did **not** cause this — `renameCharacter` only touches `name`/`aliases`, and the row had `lines: undefined` in every backup going back weeks.
- Her rich 29-quote profile is **carried over from Neverseen** (the merged plan-192 link fix), which is why `repair-linked-character-attributes.mjs` is now a no-op for her — the only remaining gap was the denormalised `lines` count.

### Fix — derive-always
`book-state` GET already loads the post-fold sentence list (manuscript-edits.json) to build `chapterCharacters`. Derive a per-character total in the same pass and set `lines` on **every** cast row from it, so the displayed count always reflects the **current** attribution rather than a value stamped at analysis time. This fixes two classes of wrong count:
- roster-added / cross-book-linked rows that read as **blank**;
- any row whose stored count **drifted** after a manual reattribution / boundary move that never rewrote the cast.

**Guard:** gated on a non-empty attribution source (`lineCountById.size > 0`). When analysis hasn't produced sentences yet, the stored counts are left alone rather than wiping every row to 0. No migration / disk write — derive-on-read, self-healing once the user is on this code (Alina then shows **4**).

## Test plan
- New regression block in `server/src/routes/book-state.test.ts` (3 cases): a linked row derives its attribution count (3); a stale stored count (99) is **overridden** by current attribution (1); a no-attribution-source state **preserves** stored counts (no wipe-to-0).
- `book-state` slow suite **79/79** pass. `npm run typecheck` clean, `eslint` clean on changed files.