### PR TITLE
feat(frontend): fe-33 real per-chapter waveform bars in Listen view

### DIFF
--- a/src/components/listen/listen-player-region.tsx
+++ b/src/components/listen/listen-player-region.tsx
@@ -10,7 +10,7 @@
    shell (not on the listen view), so this region only exposes the
    chapter-row triggers + the markers sidebar. */
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import {
   IconPlay,
@@ -21,6 +21,7 @@ import {
 } from '../../lib/icons';
 import { SectionLabel, Pill } from '../primitives';
 import { Waveform } from '../waveform';
+import { api } from '../../lib/api';
 import { parseDuration, formatTime } from '../../lib/time';
 import { stripChapterPrefix } from '../../lib/format-chapter-title';
 import { useAppSelector } from '../../store';
@@ -224,6 +225,62 @@ interface ChapterListenRowProps {
   onRename: () => void;
 }
 
+/* Module-level cache of fetched per-chapter loudness envelopes, keyed by
+   book + chapter + render stamp. A re-record (new audioRenderedAt) busts the
+   entry — mirroring the mini-player's render-stamp cache-bust — while ordinary
+   re-renders and virtualiser re-mounts reuse the cached array instead of
+   refetching. Shared across every row in the list. */
+const peaksCache = new Map<string, number[]>();
+
+function peaksCacheKey(bookId: string, chapter: Chapter): string {
+  return `${bookId}:${chapter.id}:${chapter.audioRenderedAt ?? ''}`;
+}
+
+/* Lazily fetch the real loudness envelope for a `done` chapter so its row's
+   waveform reflects the actual audio rather than the seeded decorative shape.
+   Reuses the same getChapterAudio endpoint the mini-player already calls.
+   Returns null while loading, on error, or for chapters with no rendered audio
+   — in which case <Waveform> falls back to its seeded bars. */
+function useChapterPeaks(bookId: string, chapter: Chapter): number[] | null {
+  const hasAudio = chapter.state === 'done';
+  const key = peaksCacheKey(bookId, chapter);
+  const [peaks, setPeaks] = useState<number[] | null>(() =>
+    hasAudio ? peaksCache.get(key) ?? null : null,
+  );
+  useEffect(() => {
+    if (!hasAudio) {
+      setPeaks(null);
+      return;
+    }
+    const cached = peaksCache.get(key);
+    if (cached) {
+      setPeaks(cached);
+      return;
+    }
+    let cancelled = false;
+    api
+      .getChapterAudio({ bookId, chapterId: chapter.id, duration: chapter.duration })
+      .then((meta) => {
+        if (cancelled) return;
+        const next = meta.peaks ?? [];
+        if (next.length > 0) {
+          peaksCache.set(key, next);
+          setPeaks(next);
+        } else {
+          setPeaks(null);
+        }
+      })
+      .catch(() => {
+        /* Non-fatal — the row keeps the seeded waveform shape. */
+        if (!cancelled) setPeaks(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [bookId, chapter.id, chapter.duration, hasAudio, key]);
+  return peaks;
+}
+
 function ChapterListenRow({
   bookId,
   chapter,
@@ -249,6 +306,10 @@ function ChapterListenRow({
   const totalSec = live?.durationSec || parseDuration(chapter.duration);
   const elapsedSec = live ? Math.min(live.currentSec, totalSec) : 0;
   const progress = totalSec ? elapsedSec / totalSec : 0;
+  /* Real per-chapter loudness envelope for the waveform bars; null until the
+     fetch lands (or for not-yet-generated rows), where <Waveform> falls back
+     to its seeded shape. */
+  const peaks = useChapterPeaks(bookId, chapter);
   /* A chapter only has audio to play or share once it's `done` — the
      other states (queued / in_progress / failed) carry a placeholder
      "0:00" duration and no file. Gate the Play + Share affordances on
@@ -337,7 +398,11 @@ function ChapterListenRow({
             on phone keeps the row scannable in a single tap-friendly
             column. */}
         <div className="hidden md:block">
-          <Waveform progress={isPlaying ? progress : 0} active={isPlaying} />
+          <Waveform
+            progress={isPlaying ? progress : 0}
+            active={isPlaying}
+            peaks={peaks ?? undefined}
+          />
         </div>
         {/* Mobile bottom strip: duration on the left, action pills on
             the right. md+ promotes the spans into their original grid

--- a/src/components/waveform.test.tsx
+++ b/src/components/waveform.test.tsx
@@ -4,10 +4,14 @@
 
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/react';
-import { Waveform } from './waveform';
+import { Waveform, peaksToBars } from './waveform';
 
 function barHeights(container: HTMLElement): string[] {
   return Array.from(container.querySelectorAll('span')).map((s) => s.style.height);
+}
+
+function barHeightNumbers(container: HTMLElement): number[] {
+  return Array.from(container.querySelectorAll('span')).map((s) => parseFloat(s.style.height));
 }
 
 describe('Waveform', () => {
@@ -31,5 +35,62 @@ describe('Waveform', () => {
     const a = render(<Waveform progress={0} active={false} />);
     const b = render(<Waveform progress={1} active />);
     expect(barHeights(b.container)).toEqual(barHeights(a.container));
+  });
+
+  it('falls back to the seeded shape when peaks is empty', () => {
+    const seeded = render(<Waveform progress={0} active={false} />);
+    const withEmpty = render(<Waveform progress={0} active={false} peaks={[]} />);
+    expect(barHeights(withEmpty.container)).toEqual(barHeights(seeded.container));
+  });
+
+  it('still renders 48 bars when driven by real peaks', () => {
+    const peaks = Array.from({ length: 240 }, (_, i) => (i % 12) / 12);
+    const { container } = render(<Waveform progress={0} active peaks={peaks} />);
+    expect(barHeights(container)).toHaveLength(48);
+  });
+
+  it('derives heights from peaks — loudest bin maps to the tallest bar', () => {
+    // Flat-low envelope with one loud window at the end.
+    const peaks = Array.from({ length: 240 }, (_, i) => (i >= 235 ? 1 : 0.1));
+    const { container } = render(<Waveform progress={0} active peaks={peaks} />);
+    const heights = barHeightNumbers(container);
+    const max = Math.max(...heights);
+    // The tallest bar is the last one (where the loud window lives).
+    expect(heights.indexOf(max)).toBe(heights.length - 1);
+    // Loudest bar fills the track; quiet bars sit near the floor but visible.
+    expect(max).toBeCloseTo(100, 5);
+    expect(Math.min(...heights)).toBeGreaterThan(0);
+  });
+
+  it('a flat envelope yields uniform bars at the floor', () => {
+    const { container } = render(
+      <Waveform progress={0} active peaks={Array(240).fill(0.5)} />,
+    );
+    const heights = barHeightNumbers(container);
+    expect(new Set(heights.map((h) => h.toFixed(4))).size).toBe(1);
+  });
+});
+
+describe('peaksToBars', () => {
+  it('returns null for undefined or empty input', () => {
+    expect(peaksToBars(undefined)).toBeNull();
+    expect(peaksToBars([])).toBeNull();
+  });
+
+  it('reduces a 240-bin envelope to the requested bar count', () => {
+    const bars = peaksToBars(Array(240).fill(0.4), 48);
+    expect(bars).toHaveLength(48);
+  });
+
+  it('normalises so the loudest bar is 1 and applies a floor', () => {
+    const peaks = Array.from({ length: 240 }, (_, i) => (i < 5 ? 1 : 0.1));
+    const bars = peaksToBars(peaks, 48)!;
+    expect(Math.max(...bars)).toBeCloseTo(1, 5);
+    expect(Math.min(...bars)).toBeGreaterThanOrEqual(0.12);
+  });
+
+  it('maps an all-silent envelope to the uniform floor (no NaN)', () => {
+    const bars = peaksToBars(Array(240).fill(0), 48)!;
+    expect(bars.every((b) => b === 0.12)).toBe(true);
   });
 });

--- a/src/components/waveform.tsx
+++ b/src/components/waveform.tsx
@@ -1,22 +1,52 @@
 interface WaveformProps {
   progress: number;
   active: boolean;
+  /** Real per-chapter loudness envelope (server's 240-bin RMS peaks, plan 56).
+      When present and non-empty the bars are derived from it; otherwise the
+      seeded `BARS` fallback below keeps the decorative shape for loading /
+      not-yet-generated rows. */
+  peaks?: number[];
 }
 
+const BAR_COUNT = 48;
+
 // Deterministic seeded bar heights, computed once at module load so every
-// Waveform mount renders the identical 48-bar profile (fe-6, #413).
+// Waveform mount renders the identical 48-bar profile when no real peaks are
+// available (fe-6, #413).
 const BARS: number[] = (() => {
   let s = 42;
   const out: number[] = [];
-  for (let i = 0; i < 48; i++) {
+  for (let i = 0; i < BAR_COUNT; i++) {
     s = (s * 9301 + 49297) % 233280;
     out.push(0.25 + (s / 233280) * 0.75);
   }
   return out;
 })();
 
-export function Waveform({ progress, active }: WaveformProps) {
-  const bars = BARS;
+/* Reduce the server's variable-length RMS envelope (240 bins in practice) to
+   `count` bar heights in [floor, 1]. Chunked mean, then re-normalised so the
+   loudest bar fills the track, with a small floor so quiet/silent bins still
+   render a visible sliver — matching the seeded bars' visual weight. Returns
+   null for an empty/undefined input so the caller can fall back to BARS. */
+export function peaksToBars(peaks: number[] | undefined, count = BAR_COUNT): number[] | null {
+  if (!peaks || peaks.length === 0) return null;
+  const floor = 0.12;
+  const means: number[] = [];
+  for (let i = 0; i < count; i++) {
+    const lo = Math.floor((i * peaks.length) / count);
+    const hi = Math.max(lo + 1, Math.floor(((i + 1) * peaks.length) / count));
+    let sum = 0;
+    for (let j = lo; j < hi; j++) sum += peaks[j];
+    means.push(sum / (hi - lo));
+  }
+  const max = Math.max(...means);
+  // All-silent envelope → uniform floor (avoids divide-by-zero / NaN).
+  if (max <= 0) return means.map(() => floor);
+  return means.map((m) => floor + (1 - floor) * (m / max));
+}
+
+export function Waveform({ progress, active, peaks }: WaveformProps) {
+  const bars = peaksToBars(peaks) ?? BARS;
   return (
     <div className="flex items-end gap-[2px] h-7">
       {bars.map((h, i) => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1344,13 +1344,22 @@ async function mockStreamSplice({ chapterId, mode, characterId, onTick }: Splice
   });
 }
 
-async function mockGetChapterAudio({ duration }: AudioArgs): Promise<ChapterAudio> {
+async function mockGetChapterAudio({ chapterId, duration }: AudioArgs): Promise<ChapterAudio> {
   await wait(120);
   const totalSec = parseDuration(duration || '10:00');
   const peakCount = 240;
+  /* Deterministic per-chapter envelope: seed a tiny LCG from chapterId so each
+     chapter has a stable-but-distinct waveform. (Was Math.random() — fine when
+     peaks went unrendered, but the Listen-view rows now draw them, so the
+     listen.png / listen-dark.png visual snapshots need a deterministic shape.) */
+  let seed = ((Number(chapterId) || 1) * 1009) % 233280;
+  const rand = () => {
+    seed = (seed * 9301 + 49297) % 233280;
+    return seed / 233280;
+  };
   const peaks = Array.from({ length: peakCount }, (_, i) => {
     const base = 0.35 + 0.45 * Math.sin((i / peakCount) * Math.PI);
-    return Math.max(0.05, Math.min(1, base + (Math.random() - 0.5) * 0.35));
+    return Math.max(0.05, Math.min(1, base + (rand() - 0.5) * 0.35));
   });
   /* Deterministic per-character segment layout so the Listen-view per-line
      re-record resolver (fs-26) has something to bite on in mock mode: split

--- a/src/test/a11y.test.tsx
+++ b/src/test/a11y.test.tsx
@@ -33,12 +33,14 @@ import type { EditableBookMeta } from '../store/book-meta-slice';
 
 /* The Upload view fires api.importManuscript on user action only,
    but the workspace-path row mounts on render and calls
-   getWorkspaceInfo. Never-resolving promises keep the render shape
-   stable for axe to scan. */
+   getWorkspaceInfo. The Listen view's chapter rows fetch real waveform
+   peaks via getChapterAudio for every `done` chapter on mount.
+   Never-resolving promises keep the render shape stable for axe to scan. */
 vi.mock('../lib/api', () => ({
   api: {
     getWorkspaceInfo: () => new Promise(() => {}),
     importManuscript: () => new Promise(() => {}),
+    getChapterAudio: () => new Promise(() => {}),
   },
 }));
 


### PR DESCRIPTION
## Summary

The Listen-view chapter rows drew a single hardcoded **seeded** 48-bar "waveform" — identical for every chapter, unrelated to the audio. The real loudness envelope has existed end-to-end since plan 56 (`compute-peaks` → `<slug>.peaks.json` → `ChapterAudio.peaks`), but the rows never consumed it. This wires the real data in — **frontend only, zero server changes**.

- **`Waveform`** gains an optional `peaks?` prop + a pure `peaksToBars` helper (240→48 chunked mean, re-normalised so the loudest bar fills the track, with a 0.12 floor so quiet bins stay visible). Falls back to the seeded shape when peaks are absent, so loading / not-yet-generated rows still render.
- **`ChapterListenRow`** uses a new `useChapterPeaks` hook that lazily fetches the envelope for `done` chapters via the existing `getChapterAudio` endpoint, memoised in a module-level `Map` keyed by `book:chapter:audioRenderedAt` (a re-record busts it). Request volume is bounded by the list's existing virtualisation.
- **Mock** `mockGetChapterAudio` peaks are now seeded by `chapterId` (was `Math.random()`) so the now-rendered bars keep the `listen.png` / `listen-dark.png` visual snapshots deterministic.

## Test plan

- `waveform.test.tsx`: existing seeded-fallback specs unchanged; added peaks-path coverage (48 bars from real peaks, loudest bin → tallest bar, flat → uniform, empty → fallback) + direct `peaksToBars` unit tests (normalisation, floor, all-silent → no NaN).
- `a11y.test.tsx`: mock gains `getChapterAudio` (Listen rows now call it on mount).
- `npm run verify` green locally (typecheck + all unit/integration tests + e2e + visual + build). Listen visual snapshots stayed within tolerance — no re-bless needed.

Closes #584
