### PR TITLE
feat(app): app-11 signed release APK + alpha channel

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -33,6 +33,14 @@ jobs:
       - run: flutter analyze
       - run: flutter test
       - run: flutter build apk --debug
+      # app-11: also build the release APK (debug-signed fallback unless signing
+      # secrets are wired) and publish it as an installable alpha sideload artifact.
+      - run: flutter build apk --release
+      - uses: actions/upload-artifact@v4
+        with:
+          name: companion-release-apk
+          path: apps/android/build/app/outputs/flutter-apk/app-release.apk
+          if-no-files-found: error
 
   ios-compile:
     runs-on: macos-latest

--- a/apps/android/android/.gitignore
+++ b/apps/android/android/.gitignore
@@ -12,3 +12,8 @@ GeneratedPluginRegistrant.java
 key.properties
 **/*.keystore
 **/*.jks
+
+# app-11: release signing secrets — never commit
+key.properties
+*.jks
+*.keystore

--- a/apps/android/android/app/build.gradle.kts
+++ b/apps/android/android/app/build.gradle.kts
@@ -1,8 +1,21 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     id("com.android.application")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }
+
+// app-11: release signing. `android/key.properties` (git-ignored) supplies the
+// real upload keystore for distribution; absent (CI / fresh clone) we fall back
+// to debug signing so `flutter build apk --release` still produces an
+// installable sideload APK for alpha.
+val keystorePropertiesFile = rootProject.file("key.properties")
+val keystoreProperties = Properties().apply {
+    if (keystorePropertiesFile.exists()) load(FileInputStream(keystorePropertiesFile))
+}
+val hasReleaseKeystore = keystorePropertiesFile.exists()
 
 android {
     namespace = "com.audiobookgenerator.audiobook_companion"
@@ -25,11 +38,26 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        if (hasReleaseKeystore) {
+            create("release") {
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+                storeFile = (keystoreProperties["storeFile"] as String?)?.let { file(it) }
+                storePassword = keystoreProperties["storePassword"] as String
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            // Real upload key when key.properties is present; debug fallback
+            // otherwise so the release APK still builds + sideloads for alpha.
+            signingConfig = if (hasReleaseKeystore) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
         }
     }
 }

--- a/apps/android/android/key.properties.example
+++ b/apps/android/android/key.properties.example
@@ -1,0 +1,17 @@
+# app-11: release signing template. Copy to `android/key.properties` (git-ignored)
+# and fill in your upload keystore. When this file is ABSENT the release build
+# falls back to debug signing, so `flutter build apk --release` still produces an
+# installable sideload APK for alpha testing.
+#
+# Generate an upload keystore once:
+#   keytool -genkey -v -keystore upload-keystore.jks -keyalg RSA -keysize 2048 \
+#     -validity 10000 -alias upload
+# Then point storeFile at it (path relative to android/app, or absolute).
+#
+# In CI, write this file from repository secrets before `flutter build apk --release`
+# and base64-decode the keystore — never commit either.
+
+storePassword=changeit
+keyPassword=changeit
+keyAlias=upload
+storeFile=upload-keystore.jks

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -437,7 +437,7 @@ hash matches — no OS cert install, no manual hex compare).
 11. `srv-33` ([#551](https://github.com/dudarenok-maker/AudioBook-Generator/issues/551)) — Device pairing + multi-device token management (on top of `srv-20`). _Benefit:_ revocable per-device access.
 12. `app-9` ([#552](https://github.com/dudarenok-maker/AudioBook-Generator/issues/552)) — In-car (**Android Auto + CarPlay**) head-unit UI. _Benefit:_ first-class in-car beyond the Bluetooth path.
 13. `app-10` ([#553](https://github.com/dudarenok-maker/AudioBook-Generator/issues/553)) — Stream-over-LAN instant play. _Benefit:_ zero-wait preview before a download.
-14. `app-11` ([#554](https://github.com/dudarenok-maker/AudioBook-Generator/issues/554)) — Distribution: signed release APK + alpha channel. _Benefit:_ testers can install it. _Depends:_ `app-1`.
+14. ✅ **SHIPPED** `app-11` ([#554](https://github.com/dudarenok-maker/AudioBook-Generator/issues/554)) — Distribution: Gradle release signing via git-ignored `key.properties` (real upload keystore) with a debug-signed fallback so `flutter build apk --release` always sideloads; `key.properties.example` + CI `companion-release-apk` artifact. Release APK verified (65.6 MB). _Benefit:_ testers can install it.
 
 ---
 

--- a/docs/features/188-android-companion-app.md
+++ b/docs/features/188-android-companion-app.md
@@ -22,9 +22,10 @@ per CLAUDE.md; this doc is what they hang off.
 > `app-2` (pairing + TLS pinning + API client), `app-3` (delta sync engine),
 > `app-4` (offline store — drift/SQLite), `app-5` (native player —
 > just_audio/audio_service), `app-6` (two-way resume sync), `app-7` (library browse),
-> `app-13` (settings), `app-8` (auto-sync on reconnect), and now **`app-14` (home shelf +
-> multi-book switching)** — the full MVP app block is built. The next item is **`app-11`**
-> (signed APK), then follow-ups `app-9`/`app-10`. See **Build progress & dev
+> `app-13` (settings), `app-8` (auto-sync on reconnect), `app-14` (home shelf + multi-book
+> switching) — the full MVP app block — and now **`app-11` (signed release APK + alpha
+> channel)**. Remaining: the ranked follow-ups **`app-9`** (Android Auto/CarPlay) and
+> **`app-10`** (LAN streaming). See **Build progress & dev
 > setup** immediately below.
 
 ---
@@ -48,13 +49,13 @@ per CLAUDE.md; this doc is what they hang off.
 | `app-7` | #577 (merge `9cc7061`, closed #547) | library browse: pure `library_tree` (author→series→book grouping + sort by `seriesPosition`/title + case-insensitive `filterBooks`) + `BookDownloadState`; presentational `LibraryScreen` (collapsible groups, search, per-book state pill + download/remove, prop-driven so it widget-tests). 9 paired Dart tests (6 tree + 3 widget). **Live device acceptance owed.** |
 | `app-13` | #579 (merge `e54c2af`, closed #549) | settings: pure `AppSettings` (sleep timer, default speed, skip-silence, skip-button behaviour, unmetered-Wi-Fi-only, storage cap + auto-delete-finished + keep-recent-books, auto-sync/auto-download — drives app-5/app-4/app-8) with json round-trip + tolerant `fromJson`; `SettingsStore` (FileStore JSON, defaults on corrupt); testable `SleepTimer` (injectable scheduler); presentational `SettingsScreen`. 14 paired Dart tests. **Live device acceptance owed.** |
 | `app-8` | #580 (merge `b064b0d`, closed #548) | auto-sync on reconnect: pure `shouldAutoSync` gate (never on mobile/offline, only unmetered Wi-Fi unless opted in, only when the paired server is reachable — token never leaves the home LAN) + `AutoSyncService` (pre-gates before probing so it never probes off-LAN; runs delta sync + resume flush when allowed) + pure `networkTypeFromConnectivity` + real `connectivity_plus` resolver (pinned 6.x — 7.x iOS uses an iOS-26 `NWPath` API that fails the CI iOS compile). 17 paired Dart tests. **Live device acceptance owed.** |
-| `app-14` | _this PR_ (closed #550) | home shelf + multi-book switching: pure `home_shelf` (`buildContinueListening` = in-progress books most-recently-played first; `buildRecentlyUpdated` newest-first capped) + presentational `HomeScreen` (Continue-listening rail + recently-updated rail; tap → `onOpenBook`, host wires to the player's `switchBook` for seamless per-book resume). 6 paired Dart tests. **Live device acceptance owed.** **MVP app block (app-1..8,13,14) complete.** |
+| `app-14` | #582 (merge `e5b5da9`, closed #550) | home shelf + multi-book switching: pure `home_shelf` (`buildContinueListening` = in-progress books most-recently-played first; `buildRecentlyUpdated` newest-first capped) + presentational `HomeScreen` (Continue-listening rail + recently-updated rail; tap → `onOpenBook`, host wires to the player's `switchBook` for seamless per-book resume). 6 paired Dart tests. **Live device acceptance owed.** **MVP app block (app-1..8,13,14) complete.** |
+| `app-11` | _this PR_ (closed #554) | distribution: Gradle release signing via git-ignored `android/key.properties` (real upload keystore) with a **debug-signed fallback** so `flutter build apk --release` always produces an installable sideload APK; `key.properties.example` + `.gitignore` for the secrets; CI publishes a `companion-release-apk` artifact per build. Build-config (no Dart tests); release APK verified locally (65.6 MB). |
 
-### Next up — `app-11` (signed APK), then follow-ups
+### Next up — `app-9` / `app-10` (follow-ups)
 
-The **MVP app block is built**. Remaining: **`app-11`** (signed release APK + alpha channel),
-then the ranked follow-ups **`app-9`** (Android Auto/CarPlay) and **`app-10`** (LAN streaming).
-See the item specs below.
+The **MVP app block + signed APK are built**. Remaining are the ranked follow-ups:
+**`app-9`** (Android Auto/CarPlay) and **`app-10`** (LAN streaming). See the item specs below.
 
 ### Remaining app track
 
@@ -773,8 +774,16 @@ top for the running status):
   `HomeScreen` (Continue-listening + recently-updated rails; tap → `onOpenBook` → player
   `switchBook`). 6 paired Dart tests; clean + APK builds. **Live device acceptance owed.**
   **MVP app block (app-1..8,13,14) complete.**
+- `app-11` — distribution (closed #554): Gradle release signing reads git-ignored
+  `android/key.properties` (real upload keystore) with a **debug-signed fallback**, so
+  `flutter build apk --release` always builds an installable sideload APK; `key.properties.example`
+  documents keystore generation + CI-secret wiring; CI publishes a `companion-release-apk`
+  artifact each build. Build-config only (no Dart tests); release APK verified locally (65.6 MB).
+  **To ship a properly-signed alpha:** `keytool -genkey -v -keystore upload-keystore.jks
+  -keyalg RSA -keysize 2048 -validity 10000 -alias upload`, drop `android/key.properties`
+  (see the example), then `flutter build apk --release`; sideload `app-release.apk`.
 
 All MVP server prerequisites are merged. Toolchain installed + the app validated on a
 `Pixel_10_Pro` emulator. Per the user's directive, the app track is being built through
 `app-10` with **all live-device acceptance batched at the end** for the whole feature set.
-Next up: `app-11` (signed APK), then `app-9`/`app-10`.
+Next up: `app-9` / `app-10` (follow-ups).


### PR DESCRIPTION
## Summary

`app-11` — distribution (plan [188](docs/features/188-android-companion-app.md), `app-11` / #554). A proper signed-release channel for alpha sideloading.

- **`android/app/build.gradle.kts`** — release signing reads the git-ignored `android/key.properties` (real upload keystore); **falls back to debug signing when absent**, so `flutter build apk --release` always produces an installable sideload APK (CI + fresh clones included — no secret required to build).
- **`android/key.properties.example`** — keystore generation + CI-secret wiring instructions.
- **`android/.gitignore`** — never commit `key.properties` / `*.jks` / `*.keystore`.
- **`.github/workflows/app.yml`** — also builds the release APK and publishes it as a `companion-release-apk` artifact each run.

## Test plan

- Build-config only — no Dart logic to unit-test (the gate is a successful release build + the CI artifact).
- `flutter build apk --release` — **builds locally** (65.6 MB, debug-fallback signed).
- `flutter analyze` — clean.
- CI publishes the installable `companion-release-apk` artifact.

To ship a properly-signed alpha: generate an upload keystore (`keytool -genkey … -alias upload`), drop `android/key.properties` (see the example), then `flutter build apk --release`.

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)