### PR TITLE
fix(server,scripts): windowsHide round 2 — launcher, installers, spawnFn spawns

### DIFF
--- a/launch.mjs
+++ b/launch.mjs
@@ -112,7 +112,12 @@ function main() {
   }
 
   const cwd = plan.mode === 'release' ? plan.releaseDir : installRoot;
-  const child = spawn(process.execPath, [plan.startScript], { cwd, env: childEnv, stdio: 'inherit' });
+  const child = spawn(process.execPath, [plan.startScript], {
+    cwd,
+    env: childEnv,
+    stdio: 'inherit',
+    windowsHide: true,
+  });
   child.on('exit', (code) => process.exit(code ?? 0));
   child.on('error', (err) => {
     process.stderr.write(`[launch] failed to start ${plan.startScript}: ${err.message}\n`);

--- a/scripts/restart-after-upgrade.mjs
+++ b/scripts/restart-after-upgrade.mjs
@@ -68,6 +68,7 @@ async function main() {
     env: process.env,
     detached: true,
     stdio: 'ignore',
+    windowsHide: true,
   });
   child.unref();
   process.exit(0);

--- a/scripts/stop-app.mjs
+++ b/scripts/stop-app.mjs
@@ -22,7 +22,10 @@ function info(msg) {
 function killTree(pid) {
   try {
     if (isWindows) {
-      execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore' });
+      execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'], {
+        stdio: 'ignore',
+        windowsHide: true,
+      });
     } else {
       // Negative pid = process group on POSIX. start-app-prod.mjs runs the
       // child detached so it gets its own group.

--- a/server/src/ollama/install-bootstrap.test.ts
+++ b/server/src/ollama/install-bootstrap.test.ts
@@ -172,7 +172,7 @@ describe('InstallBootstrap.start — state machine', () => {
     expect(finalJob?.status).toBe('installed');
     expect(finalJob?.error).toBeNull();
     expect(detect).toHaveBeenCalledTimes(2);
-    expect(spawnFn).toHaveBeenCalledWith('bash', expect.any(Array));
+    expect(spawnFn).toHaveBeenCalledWith('bash', expect.any(Array), { windowsHide: true });
   });
 
   it('windows path stays in "installing" with manualInstallerPath set after download', async () => {

--- a/server/src/ollama/install-bootstrap.ts
+++ b/server/src/ollama/install-bootstrap.ts
@@ -77,7 +77,7 @@ export type HttpFn = (url: string) => Promise<HttpResponse>;
 export type SpawnFn = (
   cmd: string,
   args: readonly string[],
-  opts?: { env?: NodeJS.ProcessEnv },
+  opts?: { env?: NodeJS.ProcessEnv; windowsHide?: boolean },
 ) => ChildProcess;
 
 export interface InstallBootstrapOptions {
@@ -122,7 +122,7 @@ async function defaultDetectOllama(spawnFn: SpawnFn): Promise<string | null> {
   return new Promise((resolve) => {
     let proc: ChildProcess;
     try {
-      proc = spawnFn('ollama', ['-v']);
+      proc = spawnFn('ollama', ['-v'], { windowsHide: true });
     } catch {
       resolve(null);
       return;
@@ -367,7 +367,7 @@ export class InstallBootstrap {
 
   private spawnAndWait(cmd: string, args: readonly string[]): Promise<void> {
     return new Promise((resolve, reject) => {
-      const proc = this.spawnFn(cmd, args);
+      const proc = this.spawnFn(cmd, args, { windowsHide: true });
       proc.on('error', reject);
       proc.on('close', (code) => {
         if (code === 0) resolve();

--- a/server/src/spawn-windows-hide.test.ts
+++ b/server/src/spawn-windows-hide.test.ts
@@ -3,20 +3,25 @@
  * Symptom this locks down: on Windows, a prod app launched without an
  * attached console (the fs-1 versioned-dir launcher runs detached) gives
  * every spawned console program — ffmpeg.exe, ffprobe.exe, git.exe, the
- * Python sidecar — its OWN new console window, which flashes open and
+ * Python sidecar, pip — its OWN new console window, which flashes open and
  * vanishes. During audio generation/export the server spawns ffmpeg per
  * sentence and per chapter, so the windows flash "constantly". In dev
  * (`npm start` from a terminal) the children inherit the existing console,
  * so the bug is invisible there — which is exactly how it slipped in.
  *
  * The fix is `windowsHide: true` on EVERY child_process call. Rather than
- * unit-test each call site, this scans the whole server source tree and
- * asserts the invariant globally: any new spawn that forgets the flag
- * fails here, before it can ever ship a flashing window to a user.
+ * unit-test each call site, this scans the source globally and asserts the
+ * invariant: any new spawn that forgets the flag fails here, before it can
+ * ever ship a flashing window to a user.
  *
- * Scope: production server source only (`server/src/**`, excluding tests).
- * Launcher scripts under `scripts/*.mjs` already carry the flag and are
- * out of this suite's reach. */
+ * Three scans (round 2 widened the net after launchers + injectable-spawnFn
+ * installers slipped through the server/src-only round-1 scan):
+ *   1. direct child_process calls in `server/src/**`,
+ *   2. indirect `spawnFn(...)` calls in `server/src/**` (the install
+ *      bootstraps spawn through a function pointer the bare scan can't see),
+ *   3. the prod launcher + start/stop + model-installer scripts that live
+ *      OUTSIDE server/src (a hidden parent does not stop a grandchild pip /
+ *      python from popping its own console). */
 
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -33,6 +38,28 @@ const SPAWN_NAMES = ['spawnSync', 'spawn', 'execFileSync', 'execFile', 'execSync
    match `someRegex.exec(...)`, `child.spawn(...)`, or a local `respawn(...)`
    helper — only top-level `spawn(`, `spawnSync(`, `execFile(`, etc. */
 const CALL_RE = new RegExp(String.raw`(?<![.\w])(${SPAWN_NAMES.join('|')})\s*\(`, 'g');
+
+/* Indirect spawners. The install bootstraps (whisper/coqui/qwen/ollama) launch
+   their child through an injectable `spawnFn` function pointer, so the
+   bare-call scan above can't see them — exactly the round-1 blind spot. Match
+   any `spawnFn(` (bare OR member, e.g. `this.spawnFn(`) and demand the flag. */
+const INDIRECT_RE = /\bspawnFn\s*\(/g;
+
+/* Prod-reachable spawn sites OUTSIDE server/src that the tree scan can't reach:
+   the versioned-dir launcher (launch.mjs), the prod start/stop scripts, the
+   upgrade restarter, and the model installer scripts — which spawn python/pip,
+   and a hidden parent does NOT stop a grandchild from popping its own console
+   on Windows, so each grandchild needs the flag too. */
+const REPO_ROOT = join(SRC_ROOT, '..', '..');
+const EXTERNAL_FILES = [
+  'launch.mjs',
+  'scripts/start-app-prod.mjs',
+  'scripts/restart-after-upgrade.mjs',
+  'scripts/stop-app.mjs',
+  'server/tts-sidecar/scripts/install-whisper.mjs',
+  'server/tts-sidecar/scripts/install-qwen3.mjs',
+  'server/tts-sidecar/scripts/install-coqui.mjs',
+].map((rel) => join(REPO_ROOT, rel));
 
 function listSourceFiles(dir: string): string[] {
   const out: string[] = [];
@@ -119,38 +146,65 @@ function extractCallArgs(src: string, openParenIdx: number): string {
   return src.slice(openParenIdx); // unbalanced — treat the rest as the call
 }
 
+/* Scan one file for spawn calls matching `re` whose call args omit
+   `windowsHide: true`. Returns repo-relative `path:line — name(...)` offenders. */
+function scanFile(file: string, re: RegExp): string[] {
+  const offenders: string[] = [];
+  const src = blankCommentsAndStrings(readFileSync(file, 'utf8'));
+  for (const match of src.matchAll(re)) {
+    const name = match[0].replace(/\s*\($/, '').trim();
+    const openParenIdx = match.index + match[0].length - 1;
+    const callText = extractCallArgs(src, openParenIdx);
+    if (!/windowsHide\s*:\s*true/.test(callText)) {
+      const rel = file.slice(REPO_ROOT.length + 1).replace(/\\/g, '/');
+      const line = src.slice(0, match.index).split('\n').length;
+      offenders.push(`${rel}:${line} — ${name}(...) missing windowsHide: true`);
+    }
+  }
+  return offenders;
+}
+
 describe('windowsHide invariant (no flashing console windows in prod)', () => {
-  const files = listSourceFiles(SRC_ROOT).filter((f) =>
+  const serverFiles = listSourceFiles(SRC_ROOT).filter((f) =>
     readFileSync(f, 'utf8').includes('child_process'),
   );
 
   it('finds at least the known ffmpeg/sidecar spawners (scan is wired up)', () => {
     /* Guard against the scan silently matching nothing (e.g. a refactor that
        moves all spawns) and giving a false green. */
-    expect(files.length).toBeGreaterThanOrEqual(5);
+    expect(serverFiles.length).toBeGreaterThanOrEqual(5);
   });
 
-  it('every child_process spawn passes windowsHide: true', () => {
-    const offenders: string[] = [];
-
-    for (const file of files) {
-      const src = blankCommentsAndStrings(readFileSync(file, 'utf8'));
-      for (const match of src.matchAll(CALL_RE)) {
-        const name = match[1];
-        const openParenIdx = match.index + match[0].length - 1;
-        const callText = extractCallArgs(src, openParenIdx);
-        if (!/windowsHide\s*:\s*true/.test(callText)) {
-          const rel = file.slice(SRC_ROOT.length + 1).replace(/\\/g, '/');
-          const upToMatch = src.slice(0, match.index);
-          const line = upToMatch.split('\n').length;
-          offenders.push(`${rel}:${line} — ${name}(...) missing windowsHide: true`);
-        }
-      }
-    }
-
+  it('every direct child_process spawn in server/src passes windowsHide: true', () => {
+    const offenders = serverFiles.flatMap((f) => scanFile(f, CALL_RE));
     expect(
       offenders,
       `child_process calls missing windowsHide (would flash a console window in prod):\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('every indirect spawnFn(...) call in server/src passes windowsHide: true', () => {
+    /* Only files whose `spawnFn` defaults to a RAW child_process spawn — the
+       reliable static tell is that they import `realSpawn`. A `spawnFn` that
+       delegates to an already-hiding wrapper (e.g. sidecar-supervisor → the
+       windowsHide'd `spawnSidecar`) is exempt: the flag lives in the wrapper,
+       and forcing it onto the high-level call would be meaningless. */
+    const indirectFiles = listSourceFiles(SRC_ROOT).filter((f) => {
+      const src = readFileSync(f, 'utf8');
+      return src.includes('spawnFn') && src.includes('realSpawn');
+    });
+    const offenders = indirectFiles.flatMap((f) => scanFile(f, INDIRECT_RE));
+    expect(
+      offenders,
+      `spawnFn() calls missing windowsHide (installer bootstraps would flash):\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('prod launcher + start/stop + installer scripts pass windowsHide: true', () => {
+    const offenders = EXTERNAL_FILES.flatMap((f) => scanFile(f, CALL_RE));
+    expect(
+      offenders,
+      `spawns outside server/src missing windowsHide (launcher/installer flash):\n${offenders.join('\n')}`,
     ).toEqual([]);
   });
 });

--- a/server/src/tts/coqui-install-bootstrap.ts
+++ b/server/src/tts/coqui-install-bootstrap.ts
@@ -40,7 +40,7 @@ export interface CoquiInstallJob {
 export type CoquiSpawnFn = (
   cmd: string,
   args: readonly string[],
-  opts?: { cwd?: string },
+  opts?: { cwd?: string; windowsHide?: boolean },
 ) => ChildProcess;
 
 export interface CoquiInstallOptions {
@@ -159,7 +159,10 @@ export class CoquiInstallBootstrap {
       try {
         /* Piped stdio (NOT inherit) so we can read the script's
            `[install-coqui]` step lines and surface the latest to the UI. */
-        proc = this.spawnFn('node', [script, ...this.installArgs], { cwd: this.repoRoot });
+        proc = this.spawnFn('node', [script, ...this.installArgs], {
+          cwd: this.repoRoot,
+          windowsHide: true,
+        });
       } catch (err) {
         reject(err instanceof Error ? err : new Error(String(err)));
         return;

--- a/server/src/tts/qwen-install-bootstrap.ts
+++ b/server/src/tts/qwen-install-bootstrap.ts
@@ -43,7 +43,7 @@ export interface QwenInstallJob {
 export type QwenSpawnFn = (
   cmd: string,
   args: readonly string[],
-  opts?: { cwd?: string },
+  opts?: { cwd?: string; windowsHide?: boolean },
 ) => ChildProcess;
 
 export interface QwenInstallOptions {
@@ -165,7 +165,10 @@ export class QwenInstallBootstrap {
         /* Piped stdio (NOT inherit) so we can read the script's
            `[install-qwen3]` step lines and surface the latest to the UI. The
            script writes via process.stdout.write, so piping captures it. */
-        proc = this.spawnFn('node', [script, ...this.installArgs], { cwd: this.repoRoot });
+        proc = this.spawnFn('node', [script, ...this.installArgs], {
+          cwd: this.repoRoot,
+          windowsHide: true,
+        });
       } catch (err) {
         reject(err instanceof Error ? err : new Error(String(err)));
         return;

--- a/server/src/tts/whisper-install-bootstrap.ts
+++ b/server/src/tts/whisper-install-bootstrap.ts
@@ -34,7 +34,7 @@ export interface WhisperInstallJob {
 export type WhisperSpawnFn = (
   cmd: string,
   args: readonly string[],
-  opts?: { cwd?: string },
+  opts?: { cwd?: string; windowsHide?: boolean },
 ) => ChildProcess;
 
 export interface WhisperInstallOptions {
@@ -142,7 +142,10 @@ export class WhisperInstallBootstrap {
     return new Promise((resolve, reject) => {
       let proc: ChildProcess;
       try {
-        proc = this.spawnFn('node', [script, ...this.installArgs], { cwd: this.repoRoot });
+        proc = this.spawnFn('node', [script, ...this.installArgs], {
+          cwd: this.repoRoot,
+          windowsHide: true,
+        });
       } catch (err) {
         reject(err instanceof Error ? err : new Error(String(err)));
         return;

--- a/server/tts-sidecar/scripts/install-coqui.mjs
+++ b/server/tts-sidecar/scripts/install-coqui.mjs
@@ -60,6 +60,7 @@ function run(python, pyArgs, env) {
     cwd: SIDECAR_DIR,
     stdio: 'inherit',
     env: { ...process.env, ...env },
+    windowsHide: true,
   });
   if (res.error) throw new Error(`spawn failed: ${res.error.message}`);
   return res.status ?? 1;

--- a/server/tts-sidecar/scripts/install-qwen3.mjs
+++ b/server/tts-sidecar/scripts/install-qwen3.mjs
@@ -89,6 +89,7 @@ function run(python, pyArgs, env) {
     cwd: SIDECAR_DIR,
     stdio: 'inherit',
     env: { ...process.env, ...env },
+    windowsHide: true,
   });
   if (res.error) throw new Error(`spawn failed: ${res.error.message}`);
   return res.status ?? 1;
@@ -100,7 +101,7 @@ function venvPyTag(python) {
   const res = spawnSync(
     python,
     ['-c', 'import sys;print(f"cp{sys.version_info.major}{sys.version_info.minor}")'],
-    { cwd: SIDECAR_DIR },
+    { cwd: SIDECAR_DIR, windowsHide: true },
   );
   if (res.status !== 0 || !res.stdout) return null;
   return res.stdout.toString().trim();

--- a/server/tts-sidecar/scripts/install-whisper.mjs
+++ b/server/tts-sidecar/scripts/install-whisper.mjs
@@ -59,6 +59,7 @@ function run(python, pyArgs, env) {
     cwd: SIDECAR_DIR,
     stdio: 'inherit',
     env: { ...process.env, ...env },
+    windowsHide: true,
   });
   if (res.error) throw new Error(`spawn failed: ${res.error.message}`);
   return res.status ?? 1;


### PR DESCRIPTION
## Summary

Closes the remaining Windows console-flash sources that PR #563 missed. The
round-1 invariant guard scanned only `server/src/**` for **bare** `spawn(` calls,
so three prod-reachable spawn classes still pop a console window:

1. **Outside `server/src`** — `launch.mjs` (versioned-dir launcher),
   `scripts/restart-after-upgrade.mjs`, `scripts/stop-app.mjs`.
2. **Injectable `spawnFn` function pointers** — the whisper/coqui/qwen/ollama
   install bootstraps spawn through `this.spawnFn(...)`, invisible to the
   bare-call scan.
3. **Installer grandchildren** — `install-{whisper,qwen3,coqui}.mjs` spawn
   python/pip; a hidden parent does NOT stop a grandchild popping its own console.

Fix: add `windowsHide: true` to every one (widening the four `SpawnFn` option
types), and extend `server/src/spawn-windows-hide.test.ts` with two new scans so
this class can't regress:
- **indirect `spawnFn()` scan** over `server/src` (scoped to files that import
  `realSpawn`, so wrapper-delegating `spawnFn`s like `sidecar-supervisor`'s —
  which already routes through the hidden `spawnSidecar` — stay exempt).
- **external-file scan** of the launcher + start/stop + installer scripts.

`sidecar-supervisor.ts` is intentionally not flagged (its `spawnFn` defaults to
the already-`windowsHide`'d `spawnSidecar`).

Note: there is no dedicated `whisper-install-bootstrap.test.ts` (pre-existing);
its `windowsHide` is locked by the invariant scan.

## Test plan

- `npx vitest run src/spawn-windows-hide.test.ts` — 4/4 green (the two new scans
  fail before the fix, pass after — verified test-first).
- ollama/coqui/qwen bootstrap suites green (ollama assertion updated for the new
  `{ windowsHide: true }` arg).
- `npm run typecheck` (frontend + server) clean.
- Full `npm run verify` pending before merge.

**Action for deploy:** rebuild + relaunch prod to pick this up (server runs tsx
over source; a restart suffices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)