### PR TITLE
fix(frontend,server): model-manager dark-mode CTA, Coqui inventory path, per-row install

### DIFF
--- a/e2e/model-manager-dual-model.spec.ts
+++ b/e2e/model-manager-dual-model.spec.ts
@@ -72,28 +72,32 @@ test.describe('Account — dual-model TTS flag', () => {
   });
 });
 
-test.describe('Account — Qwen install card', () => {
-  test('renders the in-app Qwen3-TTS installer card', async ({ page }) => {
+test.describe('Model Manager — Qwen install (per-row)', () => {
+  test('opens the in-app Qwen3-TTS installer from its inventory row', async ({ page }) => {
     await page.goto('/#/models');
     await waitForRouteReady(page);
 
-    /* The display-only snippet was replaced by the one-click QwenInstall
-       component. The /api/qwen/detect probe is stubbed not-installed (see
-       stubAccountModelProbes), so the "Install Qwen3-TTS" card renders. */
+    /* fs-23 follow-up: the installer is no longer a passive bottom card — it
+       expands from the Qwen Base inventory row's Install/Update toggle. The
+       /api/qwen/detect probe is stubbed not-installed (stubAccountModelProbes),
+       so the "Install Qwen3-TTS" card renders once expanded. */
+    const row = page.getByTestId('model-row-qwen-base');
+    await row.getByTestId('model-install-toggle-qwen-base').click();
     await expect(page.getByTestId('qwen-install-not-detected')).toBeVisible();
     await expect(page.getByRole('button', { name: /Install Qwen3-TTS/i })).toBeVisible();
   });
 });
 
-test.describe('Account — Coqui install card', () => {
-  test('renders the in-app Coqui XTTS v2 installer card', async ({ page }) => {
+test.describe('Model Manager — Coqui install (per-row)', () => {
+  test('opens the in-app Coqui XTTS v2 installer from its inventory row', async ({ page }) => {
     await page.goto('/#/models');
     await waitForRouteReady(page);
 
-    /* The display-only install snippet was replaced by the one-click
-       CoquiInstall component. The /api/coqui/detect probe is stubbed
-       weights-missing (see stubAccountModelProbes), so the "Install Coqui
-       XTTS v2" card renders with its value/difference copy. */
+    /* fs-23 follow-up: expand the Coqui row's Install toggle. The
+       /api/coqui/detect probe is stubbed weights-missing
+       (stubAccountModelProbes), so the "Install Coqui XTTS v2" card renders. */
+    const row = page.getByTestId('model-row-coqui');
+    await row.getByTestId('model-install-toggle-coqui').click();
     await expect(page.getByTestId('coqui-install-not-detected')).toBeVisible();
     await expect(page.getByRole('button', { name: /Install Coqui XTTS v2/i })).toBeVisible();
   });

--- a/server/src/routes/models-inventory.test.ts
+++ b/server/src/routes/models-inventory.test.ts
@@ -21,8 +21,13 @@ import type { SidecarHealthResult } from './sidecar-health.js';
 
 let repoRoot: string;
 let hfCache: string;
+let ttsHome: string;
 const savedHfHubCache = process.env.HF_HUB_CACHE;
 const savedHfHome = process.env.HF_HOME;
+const savedTtsHome = process.env.TTS_HOME;
+
+/* Coqui's XTTS v2 dir under a TTS_HOME, mirroring get_user_data_dir("tts"). */
+const XTTS_DIR = 'tts_models--multilingual--multi-dataset--xtts_v2';
 
 function writeFile(path: string, bytes: number) {
   mkdirSync(join(path, '..'), { recursive: true });
@@ -32,19 +37,27 @@ function writeFile(path: string, bytes: number) {
 beforeEach(() => {
   repoRoot = mkdtempSync(join(tmpdir(), 'mm-repo-'));
   hfCache = mkdtempSync(join(tmpdir(), 'mm-hf-'));
+  ttsHome = mkdtempSync(join(tmpdir(), 'mm-tts-'));
   /* Route the HF-cache resolver at our temp dir so qwen/whisper sizing is
      deterministic, and clear HF_HOME so it can't shadow HF_HUB_CACHE. */
   process.env.HF_HUB_CACHE = hfCache;
   delete process.env.HF_HOME;
+  /* Pin TTS_HOME at a temp dir so the Coqui present-probe (coquiWeightsPresent)
+     can't read the real %LOCALAPPDATA%\tts on the dev box and flake the
+     "coqui absent" assertion. */
+  process.env.TTS_HOME = ttsHome;
 });
 
 afterEach(() => {
   rmSync(repoRoot, { recursive: true, force: true });
   rmSync(hfCache, { recursive: true, force: true });
+  rmSync(ttsHome, { recursive: true, force: true });
   if (savedHfHubCache === undefined) delete process.env.HF_HUB_CACHE;
   else process.env.HF_HUB_CACHE = savedHfHubCache;
   if (savedHfHome === undefined) delete process.env.HF_HOME;
   else process.env.HF_HOME = savedHfHome;
+  if (savedTtsHome === undefined) delete process.env.TTS_HOME;
+  else process.env.TTS_HOME = savedTtsHome;
   vi.restoreAllMocks();
 });
 
@@ -136,6 +149,18 @@ describe('buildModelInventory', () => {
     expect(coqui.present).toBe(false);
     expect(coqui.sizeBytes).toBeNull();
     expect(coqui.removable).toBe(false);
+  });
+
+  it('reports Coqui present when model.pth lives in the TTS user-data dir', () => {
+    /* Regression for the inventory↔installer-card disagreement: present is keyed
+       off the same model.pth probe /api/coqui/detect uses, resolved under
+       TTS_HOME — NOT the old voices/coqui guess the runtime never populates. */
+    writeFile(join(ttsHome, 'tts', XTTS_DIR, 'model.pth'), 4096);
+    const inv = buildModelInventory(baseDeps());
+    const coqui = inv.items.find((i) => i.id === 'coqui')!;
+    expect(coqui.present).toBe(true);
+    expect(coqui.sizeBytes).toBe(4096);
+    expect(coqui.removable).toBe(true);
   });
 
   it('sizes a Qwen Base HF snapshot and surfaces its install state', () => {

--- a/server/src/routes/models-inventory.ts
+++ b/server/src/routes/models-inventory.ts
@@ -29,6 +29,7 @@ import {
 } from '../workspace/user-settings.js';
 import { engineForModelKey, type TtsEngine } from '../tts/index.js';
 import { detectQwenInstallStateOnDisk } from '../tts/qwen-install-detect.js';
+import { coquiWeightsPresent } from '../tts/coqui-install-detect.js';
 import {
   kokoroWeightPaths,
   kokoroWeightDir,
@@ -172,9 +173,12 @@ export function buildModelInventory(deps: InventoryDeps): ModelInventoryResponse
   });
 
   /* ── Coqui XTTS v2 (alternate TTS) ─────────────────────────────────── */
-  const coquiPath = coquiWeightDir(repoRoot);
+  const coquiPath = coquiWeightDir();
   const coquiSize = dirSizeBytes(coquiPath);
-  const coquiPresent = coquiSize.bytes > 0;
+  /* Authoritative present check — the same model.pth probe /api/coqui/detect
+     uses, so the inventory row and the installer card never disagree. A
+     half-finished download (config.json only) reads as not-present. */
+  const coquiPresent = coquiWeightsPresent();
   items.push({
     id: 'coqui',
     kind: 'tts',
@@ -321,7 +325,7 @@ function removalPaths(id: string, repoRoot: string): string[] {
     case 'qwen-design':
       return [qwenDesignRepoDir()];
     case 'coqui':
-      return [coquiWeightDir(repoRoot)];
+      return [coquiWeightDir()];
     case 'whisper':
       return [whisperRepoDir()];
     default:

--- a/server/src/tts/coqui-install-detect.ts
+++ b/server/src/tts/coqui-install-detect.ts
@@ -41,10 +41,18 @@ function ttsDataDir(): string {
   return join(base, 'tts');
 }
 
+/** The XTTS v2 model directory under the resolved TTS user-data dir. Single
+    source of truth shared with the Model Manager inventory (model-paths.ts) so
+    the inventory row and the /api/coqui/detect card can't disagree on where the
+    weights live. */
+export function coquiModelDir(): string {
+  return join(ttsDataDir(), XTTS_DIR_NAME);
+}
+
 /** True if the XTTS v2 model blob (`model.pth`) is present — a half-finished
     download (config.json only) reads as missing, mirroring Qwen's caution. */
 export function coquiWeightsPresent(): boolean {
-  return existsSync(join(ttsDataDir(), XTTS_DIR_NAME, 'model.pth'));
+  return existsSync(join(coquiModelDir(), 'model.pth'));
 }
 
 /** True if the `TTS` package (pip `coqui-tts`) is present in the sidecar venv's

--- a/server/src/tts/model-paths.ts
+++ b/server/src/tts/model-paths.ts
@@ -13,6 +13,7 @@
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { coquiModelDir } from './coqui-install-detect.js';
 
 /* Same repo ids the sidecar engines resolve (main.py), env-overridable in
    lockstep so a relocated model is sized/removed where it actually lives. */
@@ -60,10 +61,13 @@ export function kokoroWeightDir(repoRoot: string): string {
   return join(sidecarDir(repoRoot), 'voices', 'kokoro');
 }
 
-/** The XTTS v2 model directory under TTS_HOME (install-coqui.ps1 layout). */
-export function coquiWeightDir(repoRoot: string): string {
-  const home = process.env.TTS_HOME || join(sidecarDir(repoRoot), 'voices', 'coqui');
-  return join(home, 'tts', 'tts_models--multilingual--multi-dataset--xtts_v2');
+/** The XTTS v2 model directory. Delegates to the authoritative resolver in
+    coqui-install-detect.ts (the TTS lib's user-data dir — what the runtime and
+    /api/coqui/detect actually use), NOT the old voices/coqui guess: the sidecar
+    runtime never sets TTS_HOME, so the guess diverged from reality and made the
+    inventory disagree with the installer card. */
+export function coquiWeightDir(): string {
+  return coquiModelDir();
 }
 
 /** Qwen Base / VoiceDesign HF snapshot repo dirs. */

--- a/src/components/coqui-install.tsx
+++ b/src/components/coqui-install.tsx
@@ -33,7 +33,7 @@ interface DetectResp {
 
 const POLL_INTERVAL_MS = 1_500;
 
-export function CoquiInstall() {
+export function CoquiInstall({ onInstalled }: { onInstalled?: () => void } = {}) {
   const [detect, setDetect] = useState<DetectResp | null>(null);
   const [job, setJob] = useState<CoquiInstallJob | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -64,7 +64,10 @@ export function CoquiInstall() {
         if (!res.ok) throw new Error(`poll failed: HTTP ${res.status}`);
         const body = (await res.json()) as CoquiInstallJob;
         setJob(body);
-        if (body.status === 'installed') void doDetect();
+        if (body.status === 'installed') {
+          void doDetect();
+          onInstalled?.();
+        }
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e));
       }
@@ -72,7 +75,7 @@ export function CoquiInstall() {
     return () => {
       if (pollRef.current) clearTimeout(pollRef.current);
     };
-  }, [job, doDetect]);
+  }, [job, doDetect, onInstalled]);
 
   const startInstall = async () => {
     setError(null);

--- a/src/components/model-settings-form.tsx
+++ b/src/components/model-settings-form.tsx
@@ -17,9 +17,6 @@ import { useAppDispatch, useAppSelector } from '../store';
 import { saveAccountSettings, saveGeminiApiKey } from '../store/account-slice';
 import { isPrivateHostUrl } from '../lib/sidecar-url';
 import { OllamaInstall } from './ollama-install';
-import { QwenInstall } from './qwen-install';
-import { WhisperInstall } from './whisper-install';
-import { CoquiInstall } from './coqui-install';
 import { ModelPullStatus } from './model-pull-status';
 
 /* Plan 61 — mirror server/src/ollama/pull-bootstrap.ts DEFAULT_ALLOWED_MODELS
@@ -561,10 +558,11 @@ function ModelsCard() {
       data-testid="account-models-card"
       className="rounded-2xl border border-ink/10 bg-white p-6 shadow-card"
     >
-      <h2 className="text-base font-semibold text-ink">Install / update models</h2>
+      <h2 className="text-base font-semibold text-ink">Install / update analyzer (Ollama)</h2>
       <p className="mt-1 text-xs text-ink/55">
-        Install Ollama, pull analyzer model weights, and pre-fetch Coqui XTTS / Qwen / Whisper — all
-        without dropping to a terminal. Kokoro v1 ships pre-installed via the release bundle.
+        Install the Ollama daemon and pull analyzer model weights without dropping to a terminal.
+        The TTS / ASR models (Kokoro, Qwen, Coqui, Whisper) install from their rows in the inventory
+        above.
       </p>
 
       <div className="mt-4 space-y-6">
@@ -583,40 +581,6 @@ function ModelsCard() {
             highlighted.
           </p>
           <ModelPullStatus health={health} pullableModels={PULLABLE_MODELS} />
-        </div>
-
-        <div className="space-y-2">
-          <h3 className="text-sm font-medium text-ink">Coqui XTTS v2 (alternate cloning engine)</h3>
-          <p className="text-xs text-ink/55">
-            The alternate engine — zero-shot voice cloning from a reference clip, plus ~30 baked
-            multilingual voices. Optional: Kokoro and Qwen cover the defaults. Install it here to
-            pre-fetch the model; the CLI (<code className="font-mono">install-coqui.ps1</code> /{' '}
-            <code className="font-mono">.sh</code>) stays available for scripted / offline setups,
-            and the sidecar still auto-downloads on first synth if you skip this.
-          </p>
-          <CoquiInstall />
-        </div>
-
-        <div className="space-y-2">
-          <h3 className="text-sm font-medium text-ink">Qwen3-TTS (bespoke per-character voices)</h3>
-          <p className="text-xs text-ink/55">
-            Qwen3-TTS designs a unique voice per character — the headline TTS engine. Install it
-            here to make it the default for new books; the CLI
-            (`node server/tts-sidecar/scripts/install-qwen3.mjs`) stays available for scripted /
-            offline setups.
-          </p>
-          <QwenInstall />
-        </div>
-
-        <div className="space-y-2">
-          <h3 className="text-sm font-medium text-ink">Whisper ASR (per-sentence content QA)</h3>
-          <p className="text-xs text-ink/55">
-            Transcribes each generated sentence and re-records "fluent but wrong words" takes the
-            signal checks can't catch (srv-31). Install it here, then enable the gate with
-            `SEG_ASR_ENABLED=1` (`ASR_DEVICE=cpu|cuda`); the CLI
-            (`node server/tts-sidecar/scripts/install-whisper.mjs`) stays available.
-          </p>
-          <WhisperInstall />
         </div>
       </div>
     </section>

--- a/src/components/qwen-install.tsx
+++ b/src/components/qwen-install.tsx
@@ -31,7 +31,7 @@ interface DetectResp {
 
 const POLL_INTERVAL_MS = 1_500;
 
-export function QwenInstall() {
+export function QwenInstall({ onInstalled }: { onInstalled?: () => void } = {}) {
   const [detect, setDetect] = useState<DetectResp | null>(null);
   const [job, setJob] = useState<QwenInstallJob | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -62,7 +62,10 @@ export function QwenInstall() {
         if (!res.ok) throw new Error(`poll failed: HTTP ${res.status}`);
         const body = (await res.json()) as QwenInstallJob;
         setJob(body);
-        if (body.status === 'installed') void doDetect();
+        if (body.status === 'installed') {
+          void doDetect();
+          onInstalled?.();
+        }
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e));
       }
@@ -70,7 +73,7 @@ export function QwenInstall() {
     return () => {
       if (pollRef.current) clearTimeout(pollRef.current);
     };
-  }, [job, doDetect]);
+  }, [job, doDetect, onInstalled]);
 
   const startInstall = async () => {
     setError(null);

--- a/src/components/whisper-install.tsx
+++ b/src/components/whisper-install.tsx
@@ -30,7 +30,7 @@ interface DetectResp {
 
 const POLL_INTERVAL_MS = 1_500;
 
-export function WhisperInstall() {
+export function WhisperInstall({ onInstalled }: { onInstalled?: () => void } = {}) {
   const [detect, setDetect] = useState<DetectResp | null>(null);
   const [job, setJob] = useState<WhisperInstallJob | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -61,7 +61,10 @@ export function WhisperInstall() {
         if (!res.ok) throw new Error(`poll failed: HTTP ${res.status}`);
         const body = (await res.json()) as WhisperInstallJob;
         setJob(body);
-        if (body.status === 'installed') void doDetect();
+        if (body.status === 'installed') {
+          void doDetect();
+          onInstalled?.();
+        }
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e));
       }
@@ -69,7 +72,7 @@ export function WhisperInstall() {
     return () => {
       if (pollRef.current) clearTimeout(pollRef.current);
     };
-  }, [job, doDetect]);
+  }, [job, doDetect, onInstalled]);
 
   const startInstall = async () => {
     setError(null);

--- a/src/views/admin.test.tsx
+++ b/src/views/admin.test.tsx
@@ -137,6 +137,16 @@ describe('AdminView — model manager link (fs-23)', () => {
     link.click();
     expect(store.getState().ui.stage.kind).toBe('model-manager');
   });
+
+  it('uses the theme-safe ink/canvas token so it stays readable in dark mode', async () => {
+    /* Regression: the button shipped with `bg-ink text-white`, which paints
+       white-on-near-white once --ink inverts in dark mode. The codebase idiom
+       (PrimaryButton `dark`) is `bg-ink text-canvas`. */
+    renderAdmin();
+    const link = await screen.findByTestId('admin-open-model-manager');
+    expect(link.className).toContain('text-canvas');
+    expect(link.className).not.toContain('text-white');
+  });
 });
 
 describe('AdminView — dev-only worktrees gating', () => {

--- a/src/views/admin.tsx
+++ b/src/views/admin.tsx
@@ -129,7 +129,7 @@ function ModelManagerLink() {
         type="button"
         onClick={() => dispatch(uiActions.openModelManager())}
         data-testid="admin-open-model-manager"
-        className="shrink-0 min-h-[44px] sm:min-h-0 px-4 py-2 rounded-xl bg-ink text-white text-sm font-medium hover:bg-ink/90"
+        className="shrink-0 min-h-[44px] sm:min-h-0 px-4 py-2 rounded-xl bg-ink text-canvas text-sm font-medium hover:bg-ink-soft"
       >
         Open Model Manager →
       </button>

--- a/src/views/model-manager.test.tsx
+++ b/src/views/model-manager.test.tsx
@@ -357,14 +357,37 @@ describe('ModelManagerView — analyzer split', () => {
   });
 });
 
-describe('ModelManagerView — installers', () => {
-  it('renders the in-app installer cards for Coqui / Qwen / Whisper', async () => {
+describe('ModelManagerView — per-row install (fs-23 follow-up)', () => {
+  it('shows an Install toggle on a not-installed row and reveals the installer inline', async () => {
+    renderManager();
+    const coqui = await screen.findByTestId('model-row-coqui');
+    const toggle = within(coqui).getByTestId('model-install-toggle-coqui');
+    expect(toggle).toHaveTextContent(/Install/);
+    expect(within(coqui).queryByTestId('model-installer-coqui')).toBeNull();
+    fireEvent.click(toggle);
+    expect(within(coqui).getByTestId('model-installer-coqui')).toBeInTheDocument();
+  });
+
+  it('labels the toggle Update on an installed row', async () => {
+    renderManager();
+    const qwen = await screen.findByTestId('model-row-qwen-base');
+    expect(within(qwen).getByTestId('model-install-toggle-qwen-base')).toHaveTextContent(/Update/);
+  });
+
+  it('offers no install toggle for a release-bundled model (kokoro)', async () => {
+    renderManager();
+    const kokoro = await screen.findByTestId('model-row-kokoro');
+    expect(within(kokoro).queryByTestId('model-install-toggle-kokoro')).toBeNull();
+  });
+
+  it('reduces the bottom card to the Ollama analyzer only — no TTS/ASR installer headings', async () => {
     renderManager();
     const card = await screen.findByTestId('account-models-card');
-    expect(within(card).getByRole('heading', { name: /Coqui XTTS v2/i, level: 3 })).toBeInTheDocument();
     expect(
-      within(card).getByRole('heading', { name: /Qwen3-TTS \(bespoke/i, level: 3 }),
+      within(card).getByRole('heading', { name: /Local analyzer \(Ollama\)/i, level: 3 }),
     ).toBeInTheDocument();
-    expect(within(card).getByRole('heading', { name: /Whisper ASR/i, level: 3 })).toBeInTheDocument();
+    expect(within(card).queryByRole('heading', { name: /Coqui XTTS v2/i, level: 3 })).toBeNull();
+    expect(within(card).queryByRole('heading', { name: /Qwen3-TTS \(bespoke/i, level: 3 })).toBeNull();
+    expect(within(card).queryByRole('heading', { name: /Whisper ASR/i, level: 3 })).toBeNull();
   });
 });

--- a/src/views/model-manager.tsx
+++ b/src/views/model-manager.tsx
@@ -7,7 +7,7 @@
 
    The moved form sections land in step A7 (alongside the Account surgery). */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type ComponentType } from 'react';
 import { SectionLabel, MixedHeading } from '../components/primitives';
 import {
   ModelControlPill,
@@ -17,6 +17,9 @@ import {
 import { api, type ModelInventoryItem, type ModelInventoryResponse } from '../lib/api';
 import { formatBytes } from '../lib/bytes';
 import { ModelSettingsForm } from '../components/model-settings-form';
+import { CoquiInstall } from '../components/coqui-install';
+import { QwenInstall } from '../components/qwen-install';
+import { WhisperInstall } from '../components/whisper-install';
 
 const INVENTORY_POLL_MS = 30_000;
 
@@ -25,6 +28,16 @@ const TTS_ENGINE_BY_ID: Partial<Record<string, 'coqui' | 'kokoro' | 'qwen'>> = {
   kokoro: 'kokoro',
   'qwen-base': 'qwen',
   coqui: 'coqui',
+};
+
+/* Inventory ids with an in-app installer, rendered inline under the row (fs-23
+   follow-up — install lives with the model, not in a separate bottom section).
+   kokoro ships in the release bundle, qwen-design is fetched at design time, and
+   ollama models live in the analyzer section below — none get a row installer. */
+const INSTALLER_BY_ID: Partial<Record<string, ComponentType<{ onInstalled?: () => void }>>> = {
+  coqui: CoquiInstall,
+  'qwen-base': QwenInstall,
+  whisper: WhisperInstall,
 };
 
 export function ModelManagerView() {
@@ -119,6 +132,7 @@ function ModelInventory() {
                 setBusyId(null);
               }
             }}
+            onChanged={refetch}
             onRemove={() => setConfirmItem(item)}
           />
         ))}
@@ -251,14 +265,18 @@ function ModelRow({
   sidecarReachable,
   busy,
   onAction,
+  onChanged,
   onRemove,
 }: {
   item: ModelInventoryItem;
   sidecarReachable: boolean;
   busy: boolean;
   onAction: (action: () => Promise<unknown>) => Promise<void>;
+  onChanged: () => void;
   onRemove: () => void;
 }) {
+  const [installerOpen, setInstallerOpen] = useState(false);
+  const Installer = INSTALLER_BY_ID[item.id];
   const engine = TTS_ENGINE_BY_ID[item.id];
   const isAnalyzerDefault = item.kind === 'analyzer' && item.isDefaultEngine;
   /* A Load/Unload pill is meaningful only for the sidecar TTS engines and the
@@ -285,8 +303,9 @@ function ModelRow({
       data-testid={`model-row-${item.id}`}
       data-present={item.present}
       data-loaded={item.loaded}
-      className="rounded-xl border border-ink/10 bg-ink/2 p-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+      className="rounded-xl border border-ink/10 bg-ink/2 p-3 flex flex-col gap-3"
     >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div className="min-w-0">
         <div className="flex items-center gap-2 flex-wrap">
           <span className="text-sm font-semibold text-ink">{item.label}</span>
@@ -339,6 +358,17 @@ function ModelRow({
             onStop={doStop}
           />
         )}
+        {Installer && (
+          <button
+            type="button"
+            onClick={() => setInstallerOpen((o) => !o)}
+            data-testid={`model-install-toggle-${item.id}`}
+            aria-expanded={installerOpen}
+            className="min-h-[44px] sm:min-h-0 px-3 py-1 rounded-full border border-ink/15 bg-white text-[11px] font-semibold text-ink/70 hover:bg-ink/5"
+          >
+            {item.present ? 'Update' : 'Install'} {installerOpen ? '▴' : '▾'}
+          </button>
+        )}
         {item.present && item.removable && (
           <button
             type="button"
@@ -350,6 +380,16 @@ function ModelRow({
           </button>
         )}
       </div>
+      </div>
+
+      {Installer && installerOpen && (
+        <div
+          data-testid={`model-installer-${item.id}`}
+          className="border-t border-ink/10 pt-3"
+        >
+          <Installer onInstalled={onChanged} />
+        </div>
+      )}
     </li>
   );
 }


### PR DESCRIPTION
## Summary

Three post-ship fixes for the In-app Model Manager (fs-23, #476) surfaced while exercising it on the real box:

- **(a) Dark-mode launch button.** The Admin "Open Model Manager" button shipped with `bg-ink text-white`, which paints white-on-near-white once `--ink` inverts in dark mode. Switched to the theme-safe `bg-ink text-canvas hover:bg-ink-soft` idiom (the `PrimaryButton` `dark` variant).
- **(b) Coqui inventory ↔ installer-card disagreement.** The inventory sized Coqui under a `voices/coqui` guess the sidecar runtime never populates (it never sets `TTS_HOME`), while `/api/coqui/detect` reads the TTS lib's user-data dir — so the top row read "not installed" while the bottom card read "installed". Exported `coquiModelDir()` from `coqui-install-detect.ts`, delegated `coquiWeightDir()` to it, and keyed the inventory `present` off the same `coquiWeightsPresent()` `model.pth` probe so the two surfaces can't diverge (also fixes Remove targeting the right dir).
- **(c) Merged non-Ollama install into the inventory rows.** Each Coqui / Qwen Base / Whisper row now has an **Install** (absent) / **Update** (present) toggle that expands the existing installer inline (additive `onInstalled` prop wired to the inventory refetch). The bottom card shrank to the **Ollama analyzer only** — removing the duplicate status display and replacing the per-card "Re-check" with the inventory poll.

## Test plan

- `npm run verify` — full battery green locally (typecheck + all tests + e2e + lint + a11y + build; `model-manager` chunk builds at 45.44 kB).
- Frontend: `admin.test.tsx` gains a theme-safe-token assertion; `model-manager.test.tsx` covers the per-row Install/Update toggle + inline installer reveal and the Ollama-only bottom card.
- Server: `models-inventory.test.ts` gains `TTS_HOME` isolation + a present-Coqui case.
- e2e: `model-manager-dual-model.spec.ts` Qwen/Coqui install tests repointed to the per-row toggle (pass).
- **Owed (GPU box):** confirm the Coqui row reads *Installed* with real weights in `%LOCALAPPDATA%\tts`, and a real per-row Install/Update of Whisper/Coqui.

Refs #476
