### PR TITLE
docs(docs): document the Android companion app + LAN/pairing setup

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -235,6 +235,26 @@ The app drives on phone + tablet via LAN HTTPS using `mkcert` so iOS / Android t
 
 ---
 
+## Android companion app
+
+The native Flutter **Audiobook Companion** (a separate sideload app — **not** part of this release zip) pairs to the server over the LAN and delta-syncs only the chapters that changed, for offline playback with background / lock-screen / Bluetooth controls. To use it:
+
+1. Do the LAN-HTTPS setup above (mkcert + `npm run install:cert-mobile`).
+2. Set **both** in `server/.env`, then restart in LAN mode:
+
+   ```
+   LAN_HTTPS=1
+   LAN_AUTH_TOKEN=<a-strong-secret>
+   ```
+
+   `LAN_AUTH_TOKEN` is the **pairing token**. With `LAN_HTTPS=1` set, the server **won't start if the LAN cert is missing** — run step 1 first.
+3. The pairing values are served at `GET /api/export/lan` (`{ urls, protocol: "https", token, caFingerprint }`).
+4. In the app: **Pair a device** → scan the pairing QR or enter the server URL (`https://<lan-ip>:8443`), access token, and CA fingerprint. The app pins the CA itself, so — unlike the mobile *web* UI — **you do not install the root CA on the phone**.
+
+Build/sideload instructions for the app live in [`apps/android/README.md`](apps/android/README.md); the full design is [`docs/features/188-android-companion-app.md`](docs/features/188-android-companion-app.md).
+
+---
+
 ## Updating
 
 From **v1.6.0 onward, upgrading is one click in the Account tab** — open **Account → Application updates**, pick the new `audiobook-generator-vX.Y.Z.zip`, confirm the version delta, and the app stages, validates, swaps, reinstalls deps, migrates your book data (with an automatic backup first), and restarts itself. No terminal commands.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ e2e/build), `npm run test:e2e` (Playwright only).
 - **Themes (stable in v1.3.0)** — Light / Dark / System toggle with an account-managed first-visit default. Full dark-mode coverage across white / amber / red / rose ladders + bespoke `floating-pill-inverse` utility for the cast-view selection bar.
 - **Mobile + tablet (v1.4.0)** — every view re-laid out across three Tailwind viewport tiers (`<640px` phone, `640–1024px` tablet, `≥1024px` desktop); LAN HTTPS via `mkcert` (`npm run install:cert-mobile` prints LAN URL + QR + per-OS root-cert install steps; `npm run dev:lan` / `start:lan` brings Vite + Node up on `https://0.0.0.0:5173`/`:8443`); touch-equivalence for every drag/hover affordance (tap-to-assign voice pill, PointerEvents on manuscript paragraph boundaries, `coarse-pointer:` Tailwind variant for hover-reveal labels); 44×44 px touch targets enforced.
 - **Frontend performance (v1.4.0)** — `useWindowVirtualizer` from `@tanstack/react-virtual` wraps the manuscript segment list above 60 segments, and the confirm-cast picker + listen chapter list above 40 rows (short books stay on the flat-render path). Broadcast-middleware shallow-diffs snapshots, `useAppSelectorShallow` applied at five large-slice sites, route-level `React.lazy` code-split. Main bundle 410 kB → 345 kB (gzip 108 kB → 91 kB).
+- **Android companion app** — a native **Flutter** listening companion (`apps/android/`) that pairs to the server over LAN HTTPS, **delta-syncs only the chapters that changed** (per-chapter `…/audio` files, not whole-book re-exports), and plays offline with background / lock-screen / Bluetooth / Android-Auto controls + two-way resume sync. Pairing is cryptographically auto-verified — the app fetches `/cert/root.crt` and pins the CA itself, so **no OS root-cert install is needed on the phone**. See [Companion app (Android)](#companion-app-android) below and [`apps/android/README.md`](apps/android/README.md). The full architecture + delivery log is [`docs/features/188-android-companion-app.md`](docs/features/188-android-companion-app.md).
 
 ## Layout
 
@@ -134,6 +135,10 @@ server/               Node + Express API (TypeScript)
   tts-sidecar/        Python FastAPI TTS sidecar (Coqui + Kokoro)
     scripts/          install-kokoro.{sh,ps1} + install-coqui.{sh,ps1} (v1.3.0)
   handoff/            Manual-analyzer inbox/outbox (when ANALYZER=manual)
+apps/android/         Flutter companion app (pkg audiobook_companion) — domain
+                      (pure logic) / data (cert-pinned client, drift store, sync
+                      engine, player) / ui; iOS target lives here too. See
+                      apps/android/README.md + docs/features/188-…md
 e2e/                  Playwright specs against Vite in mock mode (chromium-only
                       pre-push); responsive/* runs against mobile-chrome (Pixel 7)
                       and tablet-chrome (iPad Pro 11) via npm run test:e2e:mobile
@@ -179,6 +184,16 @@ Copy `server/.env.example` as a starting point. Notable knobs:
   `false` to opt out per server install. Voice samples deliberately
   skip the pass.
 - `WORKSPACE_DIR` — where per-book `.audiobook/` folders live.
+- `LAN_HTTPS` — `1` flips the listener from HTTP `:8080` (loopback) to
+  mkcert-backed HTTPS `:8443` bound on all interfaces (mobile/tablet web access
+  and the Android companion). Off by default; `npm run start:lan` sets it.
+  Requires the LAN cert (`npm run install:cert-mobile`).
+- `LAN_AUTH_TOKEN` — a shared secret that, together with `LAN_HTTPS=1`, turns on
+  the LAN access guard on `/api` + `/workspace` (loopback always bypasses;
+  `/cert/root.crt` + `/audio` stay open). **Required for the companion** — it's
+  the pairing token, surfaced in the `GET /api/export/lan` pairing payload. Per-
+  device, individually-revocable tokens layer on top via `GET/POST/DELETE
+  /api/devices` (`srv-33`).
 
 Frontend reads `VITE_USE_MOCKS` from `.env.development`. Mock mode
 round-trips against an in-memory store and is what the Playwright e2e
@@ -193,6 +208,48 @@ suite runs against.
 5. Open the printed LAN URL on the device — lock icon, no warning.
 
 E2E across phone (Pixel 7) and tablet (iPad Pro 11) viewports is opt-in via `npm run test:e2e:mobile` (~10–15 min); the pre-push gate (`npm run test:e2e`) is chromium-only.
+
+## Companion app (Android)
+
+The native Flutter companion lives in [`apps/android/`](apps/android/README.md).
+It pairs to a server running in **LAN HTTPS mode with an access token** and then
+delta-syncs + plays offline. The web UI's LAN setup above is shared; the
+companion adds an **access token** (the pairing secret) on top.
+
+**Server side — bring it up for pairing:**
+
+1. One-time LAN cert (same as mobile web): install `mkcert` (e.g. `winget install
+   FiloSottile.mkcert` on Windows), then `npm run install:cert-mobile` (runs
+   `mkcert -install` and writes `.run/certs/`).
+2. In `server/.env` set both:
+
+   ```
+   LAN_HTTPS=1
+   LAN_AUTH_TOKEN=<a-strong-secret>
+   ```
+
+3. Start in LAN mode: `npm run start:lan` (binds `https://0.0.0.0:8443`). With
+   `LAN_HTTPS=1` set, the server **hard-exits if the LAN cert is missing** — run
+   step 1 first.
+4. The pairing values come from `GET /api/export/lan` →
+   `{ urls, port, protocol: "https", token, caFingerprint }`.
+
+**Phone/emulator side — pair:** open the app → **Pair a device** → scan the
+pairing QR, or enter **Server URL** (`https://<lan-ip>:8443`), **access token**,
+and **CA fingerprint (SHA-256)** manually. The app fetches `/cert/root.crt`,
+verifies its SHA-256 against the fingerprint, and pins the CA in its own TLS
+context — **no OS root-cert install on the phone** (unlike the web UI, which
+needs the root CA trusted in the device browser).
+
+**Per-device tokens (optional, `srv-33`):** `POST /api/devices` mints an
+individually-revocable token; `GET /api/devices` lists them; `DELETE
+/api/devices/:id` revokes one. Layered on the shared secret — the shared token
+keeps working.
+
+Build/run/test the app itself per [`apps/android/README.md`](apps/android/README.md).
+The MVP installs via the debug APK; a signed release APK (`app-11`) is the proper
+sideload channel. _Distribution note: the companion is **not** part of the
+server release zip — it's a separate Flutter build._
 
 ## Parallel sessions (developer-only)
 

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -1,17 +1,93 @@
-# audiobook_companion
+# Audiobook Companion (Android)
 
-A new Flutter project.
+`audiobook_companion` — a native **Flutter** listening companion for the
+Audiobook Generator. It pairs to your server over the home LAN (HTTPS,
+cert-pinned), **delta-syncs only the chapters that changed**, and plays them
+offline with background / lock-screen / Bluetooth controls. Android-first; the
+codebase is iOS-ready (one Flutter project, the iOS target lives here too).
 
-## Getting Started
+Full architecture, the item-by-item delivery log, and the v1 definition-of-done
+live in the umbrella plan: [`docs/features/188-android-companion-app.md`](../../docs/features/188-android-companion-app.md).
 
-This project is a starting point for a Flutter application.
+## What it does
 
-A few resources to get you started if this is your first Flutter project:
+- **Delta sync** — consumes the server's two-level sync-manifest
+  (`GET /api/library/sync-manifest`) and re-pulls only chapters whose audio
+  changed (keyed by a stable per-chapter `uuid`, not the positional id), with
+  resumable range downloads, integrity checks, and atomic swap.
+- **Offline store** — drift/SQLite per-chapter audio + metadata + cover
+  thumbnails, with storage accounting and auto-eviction (delete-finished /
+  least-recently-listened).
+- **Native player** — `just_audio` + `audio_service`: background playback,
+  lock-screen + Bluetooth controls, per-book resume, ~10 s autosave, sleep
+  timer; media-key skip defaults to ±30/±15 s seek (toggle to chapter-skip).
+- **Two-way resume** — pushes your listening position back to the server,
+  last-write-wins by listen time (never clobbers a newer position).
+- **Browse / home** — author → series → book browse + a "Continue listening"
+  shelf with seamless multi-book switching.
+- **In-car** — Android Auto + CarPlay media-browser tree.
+- **LAN streaming (opt-in)** — start an undownloaded chapter instantly at home.
 
-- [Learn Flutter](https://docs.flutter.dev/get-started/learn-flutter)
-- [Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Flutter learning resources](https://docs.flutter.dev/reference/learning-resources)
+## Prerequisites
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+- **Flutter** 3.44.1+ (stable) and the **Android SDK** (cmdline-tools +
+  platform-tools; `adb` on PATH). Confirm with `flutter doctor`.
+- An Android device or emulator (the project's AVD is `Pixel_10_Pro`).
+
+## Build / test / run (from `apps/android/`)
+
+```sh
+flutter pub get
+flutter analyze        # zero-tolerance — even info lints fail CI
+flutter test           # pure Dart VM unit + widget tests (no device needed)
+flutter build apk --debug          # build/app/outputs/flutter-apk/app-debug.apk
+```
+
+Run on a device/emulator:
+
+```sh
+flutter emulators --launch Pixel_10_Pro   # or plug in a phone
+flutter run                                # or: adb install -r build/app/outputs/flutter-apk/app-debug.apk
+```
+
+> On a 16 KB-page-size emulator image (e.g. recent Pixel images) Android shows a
+> one-time "not 16 KB compatible" notice for the **debug** build's native libs
+> and runs them in page-size compatibility mode — it's not a crash. It doesn't
+> appear on typical 4 KB-page phones; proper 16 KB alignment is a release/Play
+> concern.
+
+A signed release APK for sideloading: see **`app-11`** in the plan
+(`flutter build apk --release` — falls back to debug signing unless
+`android/key.properties` is present; copy `android/key.properties.example`).
+
+## Pairing to your server
+
+The companion needs the server running in **LAN HTTPS mode with an access
+token** (see the root [`README.md`](../../README.md#companion-app-android) and
+[`INSTALL.md`](../../INSTALL.md)). Then in the app: **Pair a device** → scan the
+pairing QR, or enter the **Server URL** (`https://<lan-ip>:8443`), **access
+token**, and **CA fingerprint (SHA-256)** by hand. The app fetches
+`/cert/root.crt`, verifies its SHA-256 against the scanned/entered fingerprint,
+and pins the CA itself — **no OS root-cert install is needed on the phone**
+(that's the app-managed-TLS-trust design).
+
+## Architecture (where things live)
+
+- `lib/src/domain/` — pure models + logic (sync manifest/plan, storage policy,
+  resume reconcile, skip behaviour, library tree, home shelf, media-browse tree,
+  app settings, sleep timer) — fully unit-tested, no IO.
+- `lib/src/data/` — adapters over injectable IO seams: `api_client` (cert-pinned
+  HTTP), `sync_engine` + `chapter_downloader` + `file_store` + `local_library`
+  (drift), `player_controller` + `just_audio_engine` + `companion_audio_handler`,
+  `resume_sync_service`, `settings_store`, `network_info`, `cover_thumbnails`.
+- `lib/src/ui/` — screens (pairing, QR scan, library, settings, home).
+
+The discipline throughout: a **pure, unit-tested brain over injectable IO**, with
+native plugins (just_audio / audio_service / drift / connectivity / secure
+storage / mobile_scanner) at the thin, device-tested edge.
+
+## CI
+
+`.github/workflows/app.yml` (path-filtered to `apps/android/**`) runs
+`flutter analyze` + `flutter test` + a debug **and** release APK build on Ubuntu,
+plus an unsigned iOS compile on macOS to keep the codebase iOS-ready.


### PR DESCRIPTION
## Summary

Documents the Android companion app and the LAN-HTTPS + pairing setup we now rely on (mkcert, `LAN_HTTPS`, `LAN_AUTH_TOKEN`, and `srv-33` per-device tokens) so a deployer can bring the companion up.

- **`apps/android/README.md`** — replaces the Flutter stub with a real companion README: what it does, build/test/run, the 16 KB-emulator note, pairing, architecture, CI.
- **`README.md`** — adds an Android-companion feature bullet, a **Companion app (Android)** section (server-side `LAN_HTTPS` + `LAN_AUTH_TOKEN` pairing steps + the phone-side flow), the `LAN_HTTPS`/`LAN_AUTH_TOKEN` config knobs, and an `apps/android/` layout entry.
- **`INSTALL.md`** — adds an **Android companion app** section (separate sideload, not in the release zip) with the pairing steps.

## Test plan

Docs only — no code changed. Local pre-push `npm run verify` green (cache-aware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)