### PR TITLE
fix(scripts): honor LAN_HTTPS from server/.env across prod + dev launchers

### DIFF
--- a/scripts/start-app-prod.mjs
+++ b/scripts/start-app-prod.mjs
@@ -4,6 +4,13 @@
 // the server itself (plan 43, gated on autoStartSidecar). Cross-platform —
 // runs on Windows, macOS, Linux. Logs to logs/server.log + .err.log, PID at
 // .run/server.pid (forward slashes — Node's fs handles both).
+//
+// LAN mode (companion app, plan 188): when server/.env has LAN_HTTPS=1 (or
+// `npm run start:lan` injects it via cross-env), the server flips to HTTPS on
+// :8443 bound to 0.0.0.0 (see server/src/index.ts + bind-host.ts). The
+// launcher must therefore health-check the SAME port/protocol the server will
+// actually bind, or it false-FAILs waiting on :8080 while the server is up on
+// :8443. resolveLaunchTarget() mirrors the server's selection so the two agree.
 
 import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, openSync, writeFileSync } from 'node:fs';
@@ -13,6 +20,7 @@ import net from 'node:net';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
+const serverDir = resolve(repoRoot, 'server');
 /* runDir / logDir default to repoRoot but honour APP_RUN_DIR / APP_LOG_DIR so a
    versioned-dir install (fs-1) parks server.pid + logs in a shared sibling
    OUTSIDE releases/vX.Y.Z/ — the restarter waits on this server.pid across the
@@ -22,13 +30,42 @@ const repoRoot = resolve(__dirname, '..');
 const runDir = process.env.APP_RUN_DIR ? resolve(process.env.APP_RUN_DIR) : resolve(repoRoot, '.run');
 const logDir = process.env.APP_LOG_DIR ? resolve(process.env.APP_LOG_DIR) : resolve(repoRoot, 'logs');
 const distIndex = resolve(repoRoot, 'dist', 'index.html');
-const serverEntry = resolve(repoRoot, 'server', 'dist', 'index.js');
+const serverEntry = resolve(serverDir, 'dist', 'index.js');
 
-mkdirSync(runDir, { recursive: true });
-mkdirSync(logDir, { recursive: true });
-
-const SERVER_PORT = Number(process.env.PORT ?? 8080);
 const HEALTH_TIMEOUT_MS = 60_000;
+
+/* Pure: which port/protocol will the server actually bind? Mirrors
+   server/src/index.ts (PORT ?? 8080, LAN_HTTPS_PORT ?? 8443) and
+   routes/export-lan.ts isLanHttpsEnabled() (LAN_HTTPS === '1'). Exported so
+   scripts/tests/start-app-prod.test.mjs can pin the contract without spawning. */
+export function resolveLaunchTarget(env = process.env) {
+  const lanHttps = env.LAN_HTTPS === '1';
+  const httpPort = Number(env.PORT ?? 8080);
+  const lanPort = Number(env.LAN_HTTPS_PORT ?? 8443);
+  return {
+    lanHttps,
+    port: lanHttps ? lanPort : httpPort,
+    protocol: lanHttps ? 'https' : 'http',
+  };
+}
+
+/* Load server/.env into process.env so the launcher sees the SAME LAN_HTTPS /
+   PORT / LAN_HTTPS_PORT the server will read on boot. The server re-loads it
+   itself (cwd-relative process.loadEnvFile), so this is purely to keep the
+   launcher's health-check port in sync. A value injected on the CLI (start:lan
+   does `cross-env LAN_HTTPS=1`) takes precedence over the file. */
+function loadServerEnv() {
+  const cliLanHttps = process.env.LAN_HTTPS; // start:lan's cross-env injection, if any
+  const envPath = resolve(serverDir, '.env');
+  if (existsSync(envPath)) {
+    try {
+      process.loadEnvFile(envPath);
+    } catch {
+      /* unreadable/malformed .env — fall back to whatever is already in env */
+    }
+  }
+  if (cliLanHttps !== undefined) process.env.LAN_HTTPS = cliLanHttps;
+}
 
 function info(msg) {
   process.stdout.write(`${msg}\n`);
@@ -36,17 +73,6 @@ function info(msg) {
 function fail(msg) {
   process.stderr.write(`[FAIL] ${msg}\n`);
   process.exit(1);
-}
-
-if (!existsSync(distIndex)) {
-  fail(
-    `Frontend bundle missing at dist/index.html. Run "npm run build" before "npm run start:prod".`,
-  );
-}
-if (!existsSync(serverEntry)) {
-  fail(
-    `Server bundle missing at server/dist/index.js. Run "npm run build" before "npm run start:prod".`,
-  );
 }
 
 function probePort(port) {
@@ -71,51 +97,76 @@ async function waitForListen(port, timeoutMs) {
   return false;
 }
 
-const alreadyUp = await probePort(SERVER_PORT);
-if (alreadyUp) {
-  info(`[SKIP] something already listening on :${SERVER_PORT} — leaving it alone`);
-  info(`[READY] http://localhost:${SERVER_PORT}/`);
+async function main() {
+  mkdirSync(runDir, { recursive: true });
+  mkdirSync(logDir, { recursive: true });
+
+  loadServerEnv();
+  const { lanHttps, port, protocol } = resolveLaunchTarget(process.env);
+  const url = `${protocol}://localhost:${port}/`;
+
+  if (!existsSync(distIndex)) {
+    fail(
+      `Frontend bundle missing at dist/index.html. Run "npm run build" before "npm run start:prod".`,
+    );
+  }
+  if (!existsSync(serverEntry)) {
+    fail(
+      `Server bundle missing at server/dist/index.js. Run "npm run build" before "npm run start:prod".`,
+    );
+  }
+
+  const alreadyUp = await probePort(port);
+  if (alreadyUp) {
+    info(`[SKIP] something already listening on :${port} — leaving it alone`);
+    info(`[READY] ${url}`);
+    process.exit(0);
+  }
+
+  const outLog = openSync(resolve(logDir, 'server.log'), 'a');
+  const errLog = openSync(resolve(logDir, 'server.err.log'), 'a');
+
+  /* Spawn the built server directly with the current Node binary instead of going
+     through `npm.cmd` — on Node >=20.6 spawning a `.cmd` without `shell: true`
+     throws EINVAL on Windows (the CVE-2024-27980 mitigation), which broke
+     `npm run start:prod`. Running `node dist/index.js` with cwd=server is simpler
+     and ALSO guarantees `process.loadEnvFile('.env')` resolves server/.env
+     (it's cwd-relative) — so prod gets the same WORKSPACE_DIR / analyzer / GPU
+     tuning the dev server reads. detached + unref so the server outlives this
+     launcher and the console window that double-clicked the .bat. */
+  const child = spawn(process.execPath, ['dist/index.js'], {
+    cwd: serverDir,
+    env: { ...process.env, NODE_ENV: 'production' },
+    stdio: ['ignore', outLog, errLog],
+    detached: true,
+    windowsHide: true,
+  });
+
+  if (typeof child.pid !== 'number') {
+    fail('Failed to spawn server process.');
+  }
+
+  writeFileSync(resolve(runDir, 'server.pid'), String(child.pid), 'utf8');
+  info(
+    `[START] server pid=${child.pid} -> logs/server.log ` +
+      `(NODE_ENV=production${lanHttps ? ', LAN_HTTPS=1' : ''})`,
+  );
+
+  child.unref();
+
+  const ready = await waitForListen(port, HEALTH_TIMEOUT_MS);
+  if (!ready) {
+    fail(
+      `Server did not start listening on :${port} within ${HEALTH_TIMEOUT_MS / 1000}s. ` +
+        `Tail logs/server.err.log for details.`,
+    );
+  }
+
+  info(`[OK] server on :${port}${lanHttps ? ' (LAN HTTPS)' : ''}`);
+  info(`[READY] ${url}  (stop with "npm run stop:prod")`);
   process.exit(0);
 }
 
-const outLog = openSync(resolve(logDir, 'server.log'), 'a');
-const errLog = openSync(resolve(logDir, 'server.err.log'), 'a');
-
-const serverDir = resolve(repoRoot, 'server');
-
-/* Spawn the built server directly with the current Node binary instead of going
-   through `npm.cmd` — on Node >=20.6 spawning a `.cmd` without `shell: true`
-   throws EINVAL on Windows (the CVE-2024-27980 mitigation), which broke
-   `npm run start:prod`. Running `node dist/index.js` with cwd=server is simpler
-   and ALSO guarantees `process.loadEnvFile('.env')` resolves server/.env
-   (it's cwd-relative) — so prod gets the same WORKSPACE_DIR / analyzer / GPU
-   tuning the dev server reads. detached + unref so the server outlives this
-   launcher and the console window that double-clicked the .bat. */
-const child = spawn(process.execPath, ['dist/index.js'], {
-  cwd: serverDir,
-  env: { ...process.env, NODE_ENV: 'production' },
-  stdio: ['ignore', outLog, errLog],
-  detached: true,
-  windowsHide: true,
-});
-
-if (typeof child.pid !== 'number') {
-  fail('Failed to spawn server process.');
-}
-
-writeFileSync(resolve(runDir, 'server.pid'), String(child.pid), 'utf8');
-info(`[START] server pid=${child.pid} -> logs/server.log (NODE_ENV=production)`);
-
-child.unref();
-
-const ready = await waitForListen(SERVER_PORT, HEALTH_TIMEOUT_MS);
-if (!ready) {
-  fail(
-    `Server did not start listening on :${SERVER_PORT} within ${HEALTH_TIMEOUT_MS / 1000}s. ` +
-      `Tail logs/server.err.log for details.`,
-  );
-}
-
-info(`[OK] server on :${SERVER_PORT}`);
-info(`[READY] http://localhost:${SERVER_PORT}/  (stop with "npm run stop:prod")`);
-process.exit(0);
+// CLI guard — only run main() when invoked directly, not when imported by tests.
+const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (invokedDirectly) await main();

--- a/scripts/start-app.ps1
+++ b/scripts/start-app.ps1
@@ -34,18 +34,40 @@ function Fail($msg) {
     exit 1
 }
 
+# --- LAN mode (companion app, plan 188) -----------------------------------
+# server/.env LAN_HTTPS=1 makes the Node server bind HTTPS on :8443 / 0.0.0.0
+# (see server/src/index.ts + bind-host.ts). Mirror that here so `npm start`
+# brings up the matching LAN dev stack instead of false-failing the health-wait
+# on :8080: the server moves to :8443 and Vite runs HTTPS (vite-plugin-mkcert)
+# bound to all interfaces — exactly what `npm run dev:lan` does explicitly. The
+# proxy target follows in vite.config.ts (https://localhost:8443 when LAN).
+$serverEnvPath = Join-Path $repoRoot "server\.env"
+$lanHttps = $false
+if (Test-Path $serverEnvPath) {
+    if (Select-String -Path $serverEnvPath -Pattern '^\s*LAN_HTTPS\s*=\s*1\s*$' -Quiet) {
+        $lanHttps = $true
+    }
+}
+$serverPort = if ($lanHttps) { 8443 } else { 8080 }
+$frontendArgs = if ($lanHttps) { @("run", "dev:frontend", "--", "--host", "0.0.0.0") } else { @("run", "dev:frontend") }
+if ($lanHttps) {
+    # Read by vite.config.ts (useHttps) — inherited by the Start-Process children.
+    $env:VITE_HTTPS = "1"
+    Write-Status "[LAN] LAN_HTTPS=1 in server/.env — LAN dev stack: server HTTPS :8443, Vite HTTPS all-interface :5173"
+}
+
 # --- Service definitions --------------------------------------------------
 $services = @(
     @{
         Name      = "frontend"
         Port      = 5173
         FilePath  = "npm.cmd"
-        ArgList   = @("run", "dev:frontend")
+        ArgList   = $frontendArgs
         WorkDir   = $repoRoot
     },
     @{
         Name      = "server"
-        Port      = 8080
+        Port      = $serverPort
         FilePath  = "npm.cmd"
         ArgList   = @("run", "dev:server")
         WorkDir   = $repoRoot
@@ -177,7 +199,8 @@ if ($pending.Count -gt 0) {
 # at http://localhost:5173/ the moment dev:frontend is listening. We used to
 # *also* call Start-Process URL here, which surfaced as two Chrome tabs on
 # every start. The script-side launcher is gone; Vite is the single opener.
-Write-Status "[READY] http://localhost:5173/ (stop with stop-app.bat)"
+$readyProto = if ($lanHttps) { "https" } else { "http" }
+Write-Status "[READY] ${readyProto}://localhost:5173/ (stop with stop-app.bat)"
 
 # Best-effort cleanup of stale rotated logs from past locked-start cycles.
 # Canonical `<name>.log` / `<name>.err.log` are preserved; only timestamped

--- a/scripts/stop-app.mjs
+++ b/scripts/stop-app.mjs
@@ -58,7 +58,9 @@ for (const name of ['server', 'tts']) {
 }
 
 // Belt-and-braces: sweep listeners on our prod ports. (No 5173 here — prod
-// doesn't run Vite.)
+// doesn't run Vite.) :8443 is the LAN HTTPS port (start:lan / LAN_HTTPS=1 in
+// server/.env) — sweep it too so a LAN server with no surviving PID file is
+// still reaped.
 async function probeAndSweep(port) {
   return new Promise((resolveProbe) => {
     const sock = net.connect({ port, host: '127.0.0.1' });
@@ -78,7 +80,7 @@ async function probeAndSweep(port) {
 }
 
 const stillListening = [];
-for (const port of [8080, 9000]) {
+for (const port of [8080, 8443, 9000]) {
   if (await probeAndSweep(port)) stillListening.push(port);
 }
 

--- a/scripts/stop-app.ps1
+++ b/scripts/stop-app.ps1
@@ -31,8 +31,9 @@ foreach ($name in $names) {
     }
 }
 
-# Belt-and-braces: kill any orphaned listeners on our ports.
-$ports = @(5173, 8080, 9000)
+# Belt-and-braces: kill any orphaned listeners on our ports. :8443 is the LAN
+# HTTPS port (LAN_HTTPS=1 in server/.env or npm run dev:lan) — sweep it too.
+$ports = @(5173, 8080, 8443, 9000)
 $conns = Get-NetTCPConnection -LocalPort $ports -State Listen -ErrorAction SilentlyContinue
 if ($conns) {
     foreach ($c in $conns) {

--- a/scripts/tests/start-app-prod.test.mjs
+++ b/scripts/tests/start-app-prod.test.mjs
@@ -1,0 +1,63 @@
+// Pin the prod launcher's port/protocol selection so it can never again
+// false-FAIL by health-checking :8080 while the server binds LAN HTTPS on
+// :8443. resolveLaunchTarget must mirror server/src/index.ts (PORT ?? 8080,
+// LAN_HTTPS_PORT ?? 8443) + routes/export-lan.ts (LAN_HTTPS === '1').
+// Discovered by `npm run test:hooks` (node --test scripts/tests/*.test.mjs).
+//
+// Importing start-app-prod.mjs must NOT spawn the server — the module guards
+// main() behind an invoked-directly check, so importing only the pure helper
+// is side-effect-free.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveLaunchTarget } from '../start-app-prod.mjs';
+
+test('loopback prod: no LAN_HTTPS → http on :8080', () => {
+  assert.deepEqual(resolveLaunchTarget({}), {
+    lanHttps: false,
+    port: 8080,
+    protocol: 'http',
+  });
+});
+
+test('LAN_HTTPS=1 → https on :8443 (the bug: launcher must wait here, not :8080)', () => {
+  assert.deepEqual(resolveLaunchTarget({ LAN_HTTPS: '1' }), {
+    lanHttps: true,
+    port: 8443,
+    protocol: 'https',
+  });
+});
+
+test('only the exact string "1" enables LAN (matches isLanHttpsEnabled)', () => {
+  for (const v of ['0', 'true', 'yes', '', 'TRUE']) {
+    assert.equal(resolveLaunchTarget({ LAN_HTTPS: v }).lanHttps, false, `LAN_HTTPS=${v}`);
+  }
+});
+
+test('PORT overrides the loopback HTTP port', () => {
+  const t = resolveLaunchTarget({ PORT: '9999' });
+  assert.equal(t.port, 9999);
+  assert.equal(t.protocol, 'http');
+});
+
+test('LAN_HTTPS_PORT overrides the LAN HTTPS port; PORT is ignored in LAN mode', () => {
+  const t = resolveLaunchTarget({ LAN_HTTPS: '1', LAN_HTTPS_PORT: '9443', PORT: '8080' });
+  assert.equal(t.port, 9443);
+  assert.equal(t.protocol, 'https');
+});
+
+test('defaults to process.env when called with no argument', () => {
+  const saved = { LAN_HTTPS: process.env.LAN_HTTPS, PORT: process.env.PORT };
+  try {
+    delete process.env.LAN_HTTPS;
+    delete process.env.PORT;
+    assert.equal(resolveLaunchTarget().port, 8080);
+    process.env.LAN_HTTPS = '1';
+    assert.equal(resolveLaunchTarget().port, 8443);
+  } finally {
+    if (saved.LAN_HTTPS === undefined) delete process.env.LAN_HTTPS;
+    else process.env.LAN_HTTPS = saved.LAN_HTTPS;
+    if (saved.PORT === undefined) delete process.env.PORT;
+    else process.env.PORT = saved.PORT;
+  }
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -62,8 +62,19 @@ function buildInfoConstants() {
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   const vitePort = Number(env.VITE_PORT ?? 5173);
-  const apiPort = Number(env.VITE_API_PORT ?? env.PORT ?? 8080);
+  // VITE_HTTPS=1 is set by both `npm run dev:lan` and start-app.ps1's LAN path,
+  // and it always coincides with the Node server running LAN HTTPS on :8443
+  // (LAN_HTTPS=1). It is the LAN signal Vite actually receives — LAN_HTTPS lives
+  // in server/.env, which loadEnv (root-scoped) never reads — so the proxy
+  // target keys off useHttps, not LAN_HTTPS.
   const useHttps = env.VITE_HTTPS === '1' || process.env.VITE_HTTPS === '1';
+  // In LAN HTTPS dev the server binds HTTPS on :8443, so the dev proxy must
+  // target https://…:8443, not the plain-HTTP :8080 default — otherwise every
+  // /api + /audio call from the Vite frontend hits a dead port. `secure: false`
+  // accepts the local mkcert/LAN cert on the loopback hop. Loopback dev
+  // (no VITE_HTTPS) keeps http://…:8080. VITE_API_PORT/PORT still override.
+  const apiPort = Number(env.VITE_API_PORT ?? env.PORT ?? (useHttps ? 8443 : 8080));
+  const apiTarget = `${useHttps ? 'https' : 'http'}://localhost:${apiPort}`;
   const plugins: PluginOption[] = [react()];
   if (useHttps) plugins.push(mkcert());
   return {
@@ -83,8 +94,8 @@ export default defineConfig(({ mode }) => {
       port: vitePort,
       open: !useHttps, // skip auto-open in LAN mode — user is on a mobile device
       proxy: {
-        '/api': { target: `http://localhost:${apiPort}`, changeOrigin: true },
-        '/audio': { target: `http://localhost:${apiPort}`, changeOrigin: true },
+        '/api': { target: apiTarget, changeOrigin: true, secure: false },
+        '/audio': { target: apiTarget, changeOrigin: true, secure: false },
       },
     },
     build: {


### PR DESCRIPTION
## Summary

First real activation of LAN mode (companion app, plan 188) surfaced that LAN is only **half-wired** into the launchers. With `LAN_HTTPS=1` in `server/.env`, the Node server correctly binds **HTTPS on `:8443` / `0.0.0.0`** (`server/src/index.ts` + `bind-host.ts`), but:

- `scripts/start-app-prod.mjs` hard-waited on `:8080` → reported a false `[FAIL]` after 60s while the server was actually up on `:8443`.
- `stop-app.mjs` / `stop-app.ps1` only swept `:8080`/`:9000` → could not reap a LAN server.
- The dev path (`npm start`) had the same false-fail, and `vite.config.ts` proxied `/api`+`/audio` to the dead `http://localhost:8080` instead of the HTTPS server on `:8443`.

This makes `server/.env` the single source of truth for **either pass** (prod *and* dev): if `LAN_HTTPS=1` is set, both `npm run start:prod` and `npm start` come up in LAN mode and health-check the right port; `start:lan` / `dev:lan` remain the explicit opt-ins.

### Changes
- **`start-app-prod.mjs`** — loads `server/.env`, resolves `{lanHttps, port, protocol}` via a new pure `resolveLaunchTarget()` (mirrors `index.ts` `PORT ?? 8080` / `LAN_HTTPS_PORT ?? 8443` and `isLanHttpsEnabled` `LAN_HTTPS === '1'`); probes/waits/reports on the actual port. CLI `LAN_HTTPS` (from `start:lan`'s `cross-env`) takes precedence over the file. `main()` is now guarded behind an invoked-directly check so the helper imports side-effect-free.
- **`start-app.ps1`** — detects `LAN_HTTPS=1` in `server/.env` → expects the server on `:8443` and brings Vite up HTTPS + all-interface (`VITE_HTTPS=1`, `--host 0.0.0.0`).
- **`stop-app.mjs` / `stop-app.ps1`** — sweep `:8443` too.
- **`vite.config.ts`** — when `useHttps`, proxy targets `https://localhost:8443` (`secure: false`).
- **`scripts/tests/start-app-prod.test.mjs`** — pins the `resolveLaunchTarget` contract.

## Test plan
- `node --test scripts/tests/start-app-prod.test.mjs` — 6 cases green (loopback default, LAN flip, exact-`'1'` gating, `PORT`/`LAN_HTTPS_PORT` overrides, `process.env` default).
- `npm run test:hooks` — 319 green.
- `npm run typecheck` — clean (frontend + server).
- **Live (prod path):** with `LAN_HTTPS=1` in `server/.env`, `npm run start:prod` → `[OK] server on :8443 (LAN HTTPS)`, reachable on `:8443`; `npm run stop:prod` reaps it and all ports clear.
- Dev path (`start-app.ps1` + Vite proxy) is implemented + typechecked; full browser/device LAN run not exercised here (mirrors the proven prod logic + `dev:lan`'s known-good flags).

> Committed with `--no-verify` (pre-push battery bypassed at the user's request to speed up); equivalent checks (`test:hooks`, `typecheck`, live start/stop) were run manually and are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)