### PR TITLE
feat(app): wire the companion shell — library + player over live sync

### DIFF
--- a/apps/android/lib/main.dart
+++ b/apps/android/lib/main.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 
+import 'src/data/companion_runtime.dart';
 import 'src/data/pairing_service.dart';
 import 'src/data/pairing_store.dart';
 import 'src/domain/paired_server.dart';
+import 'src/ui/library_home_screen.dart';
 import 'src/ui/pairing_screen.dart';
 
 /// Audiobook Companion — the native listening client (plan 188). app-1 shell +
-/// app-2 pairing; the library and the player land on top.
+/// app-2 pairing + the app-3..14 library / sync / player wired on top.
 void main() {
   runApp(AudiobookCompanionApp(store: SecurePairingStore()));
 }
@@ -45,19 +47,48 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   PairedServer? _paired;
+  CompanionRuntime? _runtime;
   bool _loading = true;
+  String? _connError;
 
   @override
   void initState() {
     super.initState();
-    widget.store.load().then((p) {
+    widget.store.load().then((p) async {
+      if (!mounted) return;
+      if (p == null) {
+        setState(() => _loading = false);
+        return;
+      }
+      _paired = p;
+      await _establish();
+    });
+  }
+
+  /// Re-establish the cert-pinned connection from stored credentials (re-fetch
+  /// + verify the CA, re-probe the token), then build the wired runtime.
+  Future<void> _establish() async {
+    setState(() {
+      _loading = true;
+      _connError = null;
+    });
+    try {
+      final conn = await widget.service.pair(_paired!);
+      final runtime = await CompanionRuntime.forConnection(conn);
       if (mounted) {
         setState(() {
-          _paired = p;
+          _runtime = runtime;
           _loading = false;
         });
       }
-    });
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _connError = '$e';
+          _loading = false;
+        });
+      }
+    }
   }
 
   Future<void> _openPairing() async {
@@ -66,41 +97,73 @@ class _HomePageState extends State<HomePage> {
         builder: (_) => PairingScreen(service: widget.service, store: widget.store),
       ),
     );
-    if (result != null && mounted) setState(() => _paired = result);
+    if (result != null && mounted) {
+      _paired = result;
+      await _establish();
+    }
   }
 
   Future<void> _unpair() async {
+    await _runtime?.dispose();
     await widget.store.clear();
-    if (mounted) setState(() => _paired = null);
+    if (mounted) {
+      setState(() {
+        _runtime = null;
+        _paired = null;
+        _connError = null;
+      });
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Audiobook Companion')),
-      body: Center(child: _body()),
-    );
-  }
-
-  Widget _body() {
-    if (_loading) return const CircularProgressIndicator();
+    if (_loading) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
     if (_paired == null) {
-      return Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const Text('Not paired yet', key: Key('home-status')),
-          const SizedBox(height: 16),
-          FilledButton(onPressed: _openPairing, child: const Text('Pair a device')),
-        ],
+      return Scaffold(
+        appBar: AppBar(title: const Text('Audiobook Companion')),
+        body: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text('Not paired yet', key: Key('home-status')),
+              const SizedBox(height: 16),
+              FilledButton(
+                  onPressed: _openPairing, child: const Text('Pair a device')),
+            ],
+          ),
+        ),
       );
     }
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Text('Paired with ${_paired!.url}', key: const Key('home-status')),
-        const SizedBox(height: 16),
-        OutlinedButton(onPressed: _unpair, child: const Text('Unpair')),
-      ],
+    if (_runtime == null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Audiobook Companion')),
+        body: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text('Paired with ${_paired!.url}', key: const Key('home-status')),
+              const SizedBox(height: 8),
+              if (_connError != null)
+                Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Text("Couldn't reach the server:\n$_connError",
+                      textAlign: TextAlign.center),
+                ),
+              Wrap(spacing: 12, children: [
+                FilledButton(onPressed: _establish, child: const Text('Retry')),
+                OutlinedButton(onPressed: _unpair, child: const Text('Unpair')),
+              ]),
+            ],
+          ),
+        ),
+      );
+    }
+    return LibraryHomeScreen(
+      runtime: _runtime!,
+      serverLabel: _paired!.url,
+      onUnpair: _unpair,
     );
   }
 }

--- a/apps/android/lib/src/data/api_client.dart
+++ b/apps/android/lib/src/data/api_client.dart
@@ -80,6 +80,21 @@ class ApiClient {
   /// Adapter so this client satisfies the resume sync's [ListenProgressApi].
   ListenProgressApi get listenProgressApi => _ApiListenProgressApi(this);
 
+  /// CA-pinned, authenticated GET returning the full response bytes (e.g. a
+  /// book cover). Throws [ApiException] on >= 400 (404 = no cover).
+  Future<List<int>> getBytes(String path) async {
+    final fetch = pinnedRangeFetch();
+    final res = await fetch(_u(path), const {});
+    if (res.statusCode >= 400) {
+      throw ApiException(res.statusCode, 'GET $path failed (${res.statusCode}).');
+    }
+    final out = <int>[];
+    await for (final chunk in res.body) {
+      out.addAll(chunk);
+    }
+    return out;
+  }
+
   /// GET the server resume bookmark; null when the server has none (404).
   Future<RemoteProgress?> getListenProgress(String bookId) async {
     try {

--- a/apps/android/lib/src/data/audio_engine.dart
+++ b/apps/android/lib/src/data/audio_engine.dart
@@ -17,5 +17,13 @@ abstract class AudioEngine {
   /// Position ticks (drive the autosave throttle).
   Stream<Duration> get positionStream;
 
+  /// Loaded media duration (null until known).
+  Duration? get duration;
+  Stream<Duration?> get durationStream;
+
+  /// Fires once each time the loaded track plays to its end (drives
+  /// auto-advance to the next chapter).
+  Stream<void> get completionStream;
+
   Future<void> dispose();
 }

--- a/apps/android/lib/src/data/companion_runtime.dart
+++ b/apps/android/lib/src/data/companion_runtime.dart
@@ -1,0 +1,68 @@
+import 'package:path_provider/path_provider.dart';
+
+import 'api_client.dart';
+import 'chapter_downloader.dart';
+import 'cover_thumbnails.dart';
+import 'drift_local_library.dart';
+import 'file_store.dart';
+import 'just_audio_engine.dart';
+import 'library_database.dart';
+import 'pairing_service.dart' show Connection;
+import 'player_controller.dart';
+import 'sync_controller.dart';
+
+/// The wired runtime for a paired server (app-shell integration): builds the
+/// cert-pinned [ApiClient], the on-device drift store, the [SyncController]
+/// (index + per-book download), and the [PlayerController] over `just_audio`.
+/// Device glue — exercised on a device, not in unit tests (each piece it wires
+/// is unit-tested on its own).
+class CompanionRuntime {
+  CompanionRuntime._(this.api, this.library, this.sync, this.player, this.thumbnails);
+
+  final ApiClient api;
+  final DriftLocalLibrary library;
+  final SyncController sync;
+  final PlayerController player;
+  final ThumbnailCache thumbnails;
+
+  static Future<CompanionRuntime> forConnection(Connection connection) async {
+    final docs = await getApplicationDocumentsDirectory();
+    final root = '${docs.path}/companion';
+
+    final api = ApiClient(connection);
+    final fs = const DiskFileStore();
+    final library =
+        DriftLocalLibrary(LibraryDatabase.open(), fs, root: root);
+    final downloader = ChapterDownloader(api.pinnedRangeFetch(), fs);
+
+    Uri resolve(String path) => Uri.parse('${connection.server.url}$path');
+
+    final sync = SyncController(
+      manifestApi: api.manifestApi,
+      localLibrary: library,
+      chapterDownloader: downloader,
+      urlResolver: resolve,
+    );
+
+    final player = PlayerController(
+      audioEngine: JustAudioEngine(),
+      playbackStore: library,
+      playlistLoader: (bookId) async => sync.playlistFor(bookId),
+      clock: DateTime.now,
+    );
+
+    final thumbnails = ThumbnailCache(
+      fs: fs,
+      store: library,
+      fetch: (bookId) => api.getBytes('/api/books/$bookId/cover'),
+      root: root,
+    );
+
+    return CompanionRuntime._(api, library, sync, player, thumbnails);
+  }
+
+  Future<void> dispose() async {
+    await player.dispose();
+    await library.close();
+  }
+}

--- a/apps/android/lib/src/data/drift_local_library.dart
+++ b/apps/android/lib/src/data/drift_local_library.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:drift/drift.dart';
 
 import '../domain/storage_policy.dart';
+import 'cover_thumbnails.dart' show ThumbnailStore;
 import 'file_store.dart';
 import 'library_database.dart';
 import 'local_library.dart';
@@ -35,7 +36,7 @@ class BookSummary {
 ///
 /// Per-chapter audio lives at `<root>/books/<bookId>/<uuid>/<urlSuffix>` — the
 /// same scheme as the `app-3` [FileLocalLibrary] it supersedes.
-class DriftLocalLibrary implements LocalLibrary, PlaybackStore {
+class DriftLocalLibrary implements LocalLibrary, PlaybackStore, ThumbnailStore {
   DriftLocalLibrary(this._db, this._fs, {required String root}) : _rootPath = root;
 
   final LibraryDatabase _db;
@@ -213,6 +214,7 @@ class DriftLocalLibrary implements LocalLibrary, PlaybackStore {
     ];
   }
 
+  @override
   Future<String?> coverThumbPath(String bookId) async {
     final row = await (_db.select(_db.books)
           ..where((b) => b.bookId.equals(bookId)))
@@ -220,6 +222,7 @@ class DriftLocalLibrary implements LocalLibrary, PlaybackStore {
     return row?.coverThumbPath;
   }
 
+  @override
   Future<void> setCoverThumbPath(String bookId, String path) async {
     await _ensureBook(bookId);
     await (_db.update(_db.books)..where((b) => b.bookId.equals(bookId)))

--- a/apps/android/lib/src/data/just_audio_engine.dart
+++ b/apps/android/lib/src/data/just_audio_engine.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:just_audio/just_audio.dart';
 
 import 'audio_engine.dart';
@@ -14,6 +16,16 @@ class JustAudioEngine implements AudioEngine {
   Stream<Duration> get positionStream => _player.positionStream;
 
   @override
+  Duration? get duration => _player.duration;
+
+  @override
+  Stream<Duration?> get durationStream => _player.durationStream;
+
+  @override
+  Stream<void> get completionStream => _player.processingStateStream
+      .where((s) => s == ProcessingState.completed);
+
+  @override
   Future<void> setFilePath(String path) async {
     await _player.setFilePath(path);
   }
@@ -26,7 +38,11 @@ class JustAudioEngine implements AudioEngine {
   }
 
   @override
-  Future<void> play() => _player.play();
+  Future<void> play() async {
+    // just_audio's play() Future resolves only when playback ENDS; we only want
+    // to START playback and return, so fire-and-forget it.
+    unawaited(_player.play());
+  }
 
   @override
   Future<void> pause() => _player.pause();

--- a/apps/android/lib/src/data/player_controller.dart
+++ b/apps/android/lib/src/data/player_controller.dart
@@ -34,6 +34,7 @@ class PlayerController {
         _autosaveInterval = saveInterval {
     skipBehavior_ = skipBehavior;
     _sub = _engine.positionStream.listen(_onTick);
+    _completionSub = _engine.completionStream.listen((_) => _advance());
   }
 
   final AudioEngine _engine;
@@ -46,10 +47,30 @@ class PlayerController {
   late SkipButtonBehavior skipBehavior_;
 
   StreamSubscription<Duration>? _sub;
+  StreamSubscription<void>? _completionSub;
   List<PlayableChapter> _playlist = const [];
   String? _bookId;
   int _index = -1;
+  double _speed = 1.0;
   DateTime? _lastSave;
+
+  /// Live playback duration of the loaded chapter (null until known).
+  Stream<Duration?> get durationStream => _engine.durationStream;
+  Duration? get duration => _engine.duration;
+
+  double get speed => _speed;
+  Future<void> setSpeed(double speed) {
+    _speed = speed;
+    return _engine.setSpeed(speed);
+  }
+
+  /// Auto-advance to the next chapter when the current one ends.
+  Future<void> _advance() async {
+    if (_index >= 0 && _index + 1 < _playlist.length) {
+      await _loadIndex(_index + 1);
+      await play();
+    }
+  }
 
   String? get currentBookId => _bookId;
   String? get currentChapterUuid =>
@@ -58,6 +79,17 @@ class PlayerController {
   /// True only for the chapter currently loaded in the engine — the `app-3`
   /// sync engine uses this as its deferred-swap `isInUse` predicate.
   bool isInUse(String uuid) => uuid == currentChapterUuid;
+
+  /// The loaded playlist (for a chapter-list UI).
+  List<PlayableChapter> get chapters => List.unmodifiable(_playlist);
+
+  /// Load + play a specific chapter by its stable `uuid`.
+  Future<void> playChapter(String uuid) async {
+    final i = _playlist.indexWhere((c) => c.uuid == uuid);
+    if (i < 0) return;
+    await _loadIndex(i);
+    await play();
+  }
 
   /// Prepare a book for playback: load its playlist, restore the saved resume
   /// point (or start at the first chapter), and seek there.
@@ -77,6 +109,7 @@ class PlayerController {
     if (index < 0 || index >= _playlist.length) return;
     _index = index;
     await _engine.setFilePath(_playlist[index].path);
+    if (_speed != 1.0) await _engine.setSpeed(_speed); // persist speed across chapters
     if (seekMs > 0) await _engine.seek(Duration(milliseconds: seekMs));
     // Measure the autosave interval from load time, so we don't persist on the
     // very first position tick.
@@ -85,6 +118,10 @@ class PlayerController {
 
   Future<void> seekTo(Duration position) =>
       _engine.seek(position < Duration.zero ? Duration.zero : position);
+
+  /// Live playback position (for the player UI).
+  Stream<Duration> get positionStream => _engine.positionStream;
+  Duration get position => _engine.position;
 
   Future<void> play() => _engine.play();
   Future<void> pause() async {
@@ -139,6 +176,7 @@ class PlayerController {
 
   Future<void> dispose() async {
     await _sub?.cancel();
+    await _completionSub?.cancel();
     await _engine.dispose();
   }
 }

--- a/apps/android/lib/src/data/sync_controller.dart
+++ b/apps/android/lib/src/data/sync_controller.dart
@@ -1,0 +1,134 @@
+import '../domain/library_tree.dart';
+import '../domain/sync_manifest.dart';
+import '../domain/sync_plan.dart';
+import 'chapter_downloader.dart';
+import 'drift_local_library.dart';
+import 'player_controller.dart';
+import 'sync_engine.dart' show ManifestApi;
+
+/// App-shell sync orchestration (the integration glue over the app-3 engine
+/// pieces): load the cheap manifest **index** to populate the library, then
+/// **download one book on demand** (so we don't pull a whole multi-book library
+/// at once). Per-book download reuses the `planBookSync` delta — a re-download
+/// after a server regen pulls only the changed chapters.
+class SyncController {
+  SyncController({
+    required ManifestApi manifestApi,
+    required DriftLocalLibrary localLibrary,
+    required ChapterDownloader chapterDownloader,
+    required Uri Function(String path) urlResolver,
+  })  : _api = manifestApi,
+        _library = localLibrary,
+        _downloader = chapterDownloader,
+        _resolveUrl = urlResolver;
+
+  final ManifestApi _api;
+  final DriftLocalLibrary _library;
+  final ChapterDownloader _downloader;
+  final Uri Function(String path) _resolveUrl;
+
+  /// Last fetched detail per book — drives the player playlist in-session.
+  final Map<String, SyncManifestBookDetail> _details = {};
+
+  /// Fetch the index, record each book's display metadata locally, and return
+  /// the book rows for the library UI. No audio is downloaded.
+  Future<List<SyncManifestIndexBook>> loadIndex() async {
+    final index = await _api.index();
+    for (final b in index.books) {
+      await _library.upsertBookMeta(
+        bookId: b.bookId,
+        title: b.title,
+        author: b.author,
+        series: b.series,
+        seriesPosition: b.seriesPosition?.toInt(), // drift col is int; display uses the index double
+      );
+    }
+    return index.books;
+  }
+
+  /// Load the index AND compute each book's download state for the library UI:
+  /// not-downloaded, downloaded, or **update-available** (downloaded but the
+  /// server's `updatedAt` moved past what we last synced — something changed
+  /// since the last connect).
+  Future<List<LibraryBook>> loadLibrary() async {
+    final books = await loadIndex();
+    final localUpdated = await _library.syncedBookUpdatedAt();
+    final result = <LibraryBook>[];
+    for (final b in books) {
+      final downloaded = (await _library.chapterFingerprints(b.bookId)).isNotEmpty;
+      final BookDownloadState state;
+      if (!downloaded) {
+        state = BookDownloadState.notDownloaded;
+      } else if ((localUpdated[b.bookId] ?? '').compareTo(b.updatedAt) < 0) {
+        state = BookDownloadState.updateAvailable;
+      } else {
+        state = BookDownloadState.downloaded;
+      }
+      result.add(LibraryBook(
+        bookId: b.bookId,
+        title: b.title,
+        author: b.author,
+        series: b.series,
+        seriesPosition: b.seriesPosition,
+        downloadState: state,
+      ));
+    }
+    return result;
+  }
+
+  /// Download (or delta-update) one book's chapters. Pulls only chapters that
+  /// are new or whose fingerprint changed.
+  Future<void> downloadBook(
+    String bookId, {
+    void Function(int done, int total)? onProgress,
+  }) async {
+    final detail = await _api.bookDetail(bookId);
+    _details[bookId] = detail;
+    final localFp = await _library.chapterFingerprints(bookId);
+    final plan = planBookSync(detail, localFp);
+    final total = plan.chaptersToDownload.length;
+    var done = 0;
+    onProgress?.call(done, total);
+    for (final c in plan.chaptersToDownload) {
+      await _downloader.download(
+        url: _resolveUrl(c.audioUrl!),
+        finalPath: _library.audioPath(bookId, c.uuid, c.urlSuffix!),
+        expectedSize: c.expectedSize,
+      );
+      await _library.recordChapter(bookId, c.uuid, c.fingerprint!, c.urlSuffix!);
+      done++;
+      onProgress?.call(done, total);
+    }
+    await _library.setBookUpdatedAt(bookId, detail.updatedAt);
+  }
+
+  /// Ensure the book's detail (chapter order/paths) is loaded in-session so
+  /// [playlistFor] works even when we didn't just download it.
+  Future<void> ensureDetail(String bookId) async {
+    if (_details.containsKey(bookId)) return;
+    _details[bookId] = await _api.bookDetail(bookId);
+  }
+
+  /// True once the book has at least one downloaded chapter on disk.
+  Future<bool> isBookDownloaded(String bookId) async =>
+      (await _library.chapterFingerprints(bookId)).isNotEmpty;
+
+  /// The book's chapters (uuid + title) from the in-session detail, for a
+  /// chapter-picker UI. Empty until the detail has been loaded.
+  List<SyncManifestChapter> chaptersOf(String bookId) =>
+      _details[bookId]?.chapters ?? const [];
+
+  /// Ordered, locally-playable chapters for a book (from the in-session detail).
+  List<PlayableChapter> playlistFor(String bookId) {
+    final detail = _details[bookId];
+    if (detail == null) return const [];
+    return [
+      for (final c in detail.chapters)
+        if (c.hasAudio)
+          PlayableChapter(
+            uuid: c.uuid,
+            path: _library.audioPath(bookId, c.uuid, c.urlSuffix!),
+          ),
+    ];
+  }
+}

--- a/apps/android/lib/src/domain/library_tree.dart
+++ b/apps/android/lib/src/domain/library_tree.dart
@@ -19,8 +19,17 @@ class LibraryBook {
   final String title;
   final String author;
   final String series;
-  final int? seriesPosition;
+
+  /// Decimal so novellas (e.g. 8.5) sort between whole-numbered entries.
+  final double? seriesPosition;
   final BookDownloadState downloadState;
+}
+
+/// Render a series position for display: whole numbers without a decimal
+/// (`1`, `9`), fractional ones with it (`8.5`); null → empty string.
+String formatSeriesPosition(double? pos) {
+  if (pos == null) return '';
+  return pos == pos.roundToDouble() ? pos.toInt().toString() : '$pos';
 }
 
 class SeriesGroup {
@@ -71,13 +80,16 @@ int _byPositionThenTitle(LibraryBook a, LibraryBook b) {
   return a.title.toLowerCase().compareTo(b.title.toLowerCase());
 }
 
-/// Case-insensitive filter on title or author; empty query returns all.
+/// Case-insensitive filter on title, author, OR series; empty query returns
+/// all. (Series matters: filtering "Keeper" should keep every book in the
+/// "Keeper of the Lost Cities" series, not just the one titled that.)
 List<LibraryBook> filterBooks(List<LibraryBook> books, String query) {
   final q = query.trim().toLowerCase();
   if (q.isEmpty) return books;
   return books
       .where((b) =>
           b.title.toLowerCase().contains(q) ||
-          b.author.toLowerCase().contains(q))
+          b.author.toLowerCase().contains(q) ||
+          b.series.toLowerCase().contains(q))
       .toList();
 }

--- a/apps/android/lib/src/domain/sync_manifest.dart
+++ b/apps/android/lib/src/domain/sync_manifest.dart
@@ -27,7 +27,7 @@ class SyncManifestIndexBook {
   final String title;
   final String author;
   final String series;
-  final int? seriesPosition;
+  final double? seriesPosition;
 
   /// Active (non-excluded) chapter count.
   final int chapterCount;
@@ -40,7 +40,7 @@ class SyncManifestIndexBook {
       title: json['title'] as String? ?? '',
       author: json['author'] as String? ?? '',
       series: json['series'] as String? ?? '',
-      seriesPosition: (json['seriesPosition'] as num?)?.toInt(),
+      seriesPosition: (json['seriesPosition'] as num?)?.toDouble(),
       chapterCount: (json['chapterCount'] as num?)?.toInt() ?? 0,
       coverUrl: json['coverUrl'] as String?,
     );

--- a/apps/android/lib/src/ui/library_home_screen.dart
+++ b/apps/android/lib/src/ui/library_home_screen.dart
@@ -1,0 +1,325 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+import '../data/companion_runtime.dart';
+import '../domain/library_tree.dart';
+import 'player_screen.dart';
+
+/// Post-pairing home: a cover-art library grouped into author → series
+/// sections, with a search/filter, per-book download (with progress) +
+/// update-available badge, and tap-to-open the player.
+class LibraryHomeScreen extends StatefulWidget {
+  const LibraryHomeScreen({
+    super.key,
+    required this.runtime,
+    required this.serverLabel,
+    required this.onUnpair,
+  });
+
+  final CompanionRuntime runtime;
+  final String serverLabel;
+  final Future<void> Function() onUnpair;
+
+  @override
+  State<LibraryHomeScreen> createState() => _LibraryHomeScreenState();
+}
+
+class _LibraryHomeScreenState extends State<LibraryHomeScreen> {
+  List<LibraryBook> _books = [];
+  final Map<String, String> _covers = {}; // bookId -> thumb path
+  final Map<String, String> _progress = {}; // bookId -> "done/total"
+  final Set<String> _collapsed = {}; // collapsed author/series section keys
+  String _query = '';
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _refresh();
+  }
+
+  Future<void> _refresh() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final books = await widget.runtime.sync.loadLibrary();
+      if (!mounted) return;
+      setState(() {
+        _books = books;
+        _loading = false;
+      });
+      _loadCovers(books);
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = '$e';
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _loadCovers(List<LibraryBook> books) async {
+    for (final b in books) {
+      if (_covers.containsKey(b.bookId)) continue;
+      try {
+        final path = await widget.runtime.thumbnails.ensureThumbnail(b.bookId);
+        if (mounted) setState(() => _covers[b.bookId] = path);
+      } catch (_) {
+        /* no cover — show a placeholder */
+      }
+    }
+  }
+
+  Future<void> _download(LibraryBook book) async {
+    setState(() => _progress[book.bookId] = '…');
+    try {
+      await widget.runtime.sync.downloadBook(
+        book.bookId,
+        onProgress: (d, t) =>
+            setState(() => _progress[book.bookId] = t > 0 ? '$d/$t' : '…'),
+      );
+      if (mounted) setState(() => _progress.remove(book.bookId));
+      await _refresh();
+    } catch (e) {
+      if (mounted) {
+        setState(() => _progress.remove(book.bookId));
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Download failed: $e')));
+      }
+    }
+  }
+
+  void _open(LibraryBook book) {
+    Navigator.of(context).push(MaterialPageRoute(
+      builder: (_) => PlayerScreen(
+          runtime: widget.runtime, bookId: book.bookId, title: book.title),
+    ));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tree = buildLibraryTree(filterBooks(_books, _query));
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Library'),
+        actions: [
+          IconButton(
+            key: const Key('library-sync'),
+            tooltip: 'Sync',
+            icon: const Icon(Icons.sync),
+            onPressed: _loading ? null : _refresh,
+          ),
+          IconButton(
+            tooltip: 'Unpair',
+            icon: const Icon(Icons.link_off),
+            onPressed: () async => widget.onUnpair(),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+            child: TextField(
+              key: const Key('library-search'),
+              decoration: const InputDecoration(
+                prefixIcon: Icon(Icons.search),
+                hintText: 'Filter by author, series or title',
+                isDense: true,
+                border: OutlineInputBorder(),
+              ),
+              onChanged: (v) => setState(() => _query = v),
+            ),
+          ),
+          if (_loading)
+            const Expanded(child: Center(child: CircularProgressIndicator()))
+          else if (_error != null)
+            Expanded(
+              child: Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: Text('Sync failed: $_error', key: const Key('library-error')),
+                ),
+              ),
+            )
+          else
+            Expanded(
+              child: ListView(
+                children: [
+                  for (final author in tree) ..._authorSection(author),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  void _toggle(String key) => setState(
+      () => _collapsed.contains(key) ? _collapsed.remove(key) : _collapsed.add(key));
+
+  Widget _sectionHeader({
+    required String label,
+    required bool collapsed,
+    required VoidCallback onTap,
+    required double indent,
+    TextStyle? style,
+    String? trailing,
+  }) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: EdgeInsets.fromLTRB(indent, 10, 12, 6),
+        child: Row(
+          children: [
+            Icon(collapsed ? Icons.add_box_outlined : Icons.indeterminate_check_box_outlined,
+                size: 22),
+            const SizedBox(width: 8),
+            Expanded(child: Text(label, style: style)),
+            if (trailing != null)
+              Text(trailing, style: Theme.of(context).textTheme.bodySmall),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _authorSection(AuthorGroup author) {
+    final aKey = 'author:${author.author}';
+    final aCollapsed = _collapsed.contains(aKey);
+    final bold = Theme.of(context)
+        .textTheme
+        .titleMedium
+        ?.copyWith(fontWeight: FontWeight.bold);
+    final bookCount =
+        author.series.fold<int>(0, (n, s) => n + s.books.length);
+    return [
+      _sectionHeader(
+        label: author.author,
+        collapsed: aCollapsed,
+        onTap: () => _toggle(aKey),
+        indent: 12,
+        style: bold,
+        trailing: '$bookCount',
+      ),
+      const Divider(height: 1),
+      if (!aCollapsed)
+        for (final series in author.series)
+          ..._seriesSection(author.author, series),
+    ];
+  }
+
+  List<Widget> _seriesSection(String author, SeriesGroup series) {
+    if (series.series.isEmpty) {
+      return [for (final book in series.books) _bookTile(book)];
+    }
+    final sKey = 'series:$author/${series.series}';
+    final sCollapsed = _collapsed.contains(sKey);
+    return [
+      _sectionHeader(
+        label: series.series,
+        collapsed: sCollapsed,
+        onTap: () => _toggle(sKey),
+        indent: 28,
+        style: Theme.of(context).textTheme.labelLarge,
+        trailing: '${series.books.length}',
+      ),
+      if (!sCollapsed) for (final book in series.books) _bookTile(book),
+    ];
+  }
+
+  Widget _bookTile(LibraryBook book) {
+    final downloading = _progress.containsKey(book.bookId);
+    return ListTile(
+      key: Key('book-${book.bookId}'),
+      leading: _cover(book.bookId),
+      title: Text(book.title),
+      subtitle: Text(_subtitle(book)),
+      isThreeLine: book.series.isNotEmpty,
+      onTap: (book.downloadState == BookDownloadState.downloaded ||
+              book.downloadState == BookDownloadState.updateAvailable)
+          ? () => _open(book)
+          : null,
+      trailing: downloading
+          ? _progressWidget(book.bookId)
+          : _action(book),
+    );
+  }
+
+  Widget _cover(String bookId) {
+    final path = _covers[bookId];
+    final child = path != null
+        ? Image.file(File(path), fit: BoxFit.cover,
+            errorBuilder: (_, _, _) => const Icon(Icons.menu_book))
+        : const Icon(Icons.menu_book);
+    return SizedBox(
+      width: 44,
+      height: 60,
+      child: ClipRRect(borderRadius: BorderRadius.circular(4), child: child),
+    );
+  }
+
+  Widget _action(LibraryBook book) {
+    switch (book.downloadState) {
+      case BookDownloadState.notDownloaded:
+        return IconButton(
+          key: Key('download-${book.bookId}'),
+          icon: const Icon(Icons.download),
+          tooltip: 'Download',
+          onPressed: () => _download(book),
+        );
+      case BookDownloadState.updateAvailable:
+        return IconButton(
+          key: Key('update-${book.bookId}'),
+          icon: const Icon(Icons.sync_problem),
+          color: Theme.of(context).colorScheme.tertiary,
+          tooltip: 'Update available — re-sync',
+          onPressed: () => _download(book),
+        );
+      case BookDownloadState.downloaded:
+        return IconButton(
+          icon: const Icon(Icons.play_circle_outline),
+          tooltip: 'Play',
+          onPressed: () => _open(book),
+        );
+      case BookDownloadState.downloading:
+        return _progressWidget(book.bookId);
+    }
+  }
+
+  Widget _progressWidget(String bookId) {
+    final p = _progress[bookId] ?? '…';
+    return Row(mainAxisSize: MainAxisSize.min, children: [
+      Text(p),
+      const SizedBox(width: 8),
+      const SizedBox(
+          width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2)),
+    ]);
+  }
+
+  String _subtitle(LibraryBook book) {
+    final pos = formatSeriesPosition(book.seriesPosition);
+    final series = book.series.isEmpty
+        ? ''
+        : '${book.series}${pos.isNotEmpty ? ' #$pos' : ''}\n';
+    return '$series${_statusLabel(book.downloadState)}';
+  }
+
+  String _statusLabel(BookDownloadState s) {
+    switch (s) {
+      case BookDownloadState.notDownloaded:
+        return 'Not downloaded';
+      case BookDownloadState.downloading:
+        return 'Downloading…';
+      case BookDownloadState.downloaded:
+        return 'Downloaded · tap to listen';
+      case BookDownloadState.updateAvailable:
+        return 'Update available since last sync';
+    }
+  }
+}

--- a/apps/android/lib/src/ui/player_screen.dart
+++ b/apps/android/lib/src/ui/player_screen.dart
@@ -1,0 +1,217 @@
+import 'package:flutter/material.dart';
+
+import '../data/companion_runtime.dart';
+import '../data/player_controller.dart';
+import '../domain/sync_manifest.dart';
+
+/// Player surface: a chapter picker + transport controls over the
+/// [PlayerController]. Pick a chapter to start listening; the position ticks
+/// live and play/pause/seek work.
+class PlayerScreen extends StatefulWidget {
+  const PlayerScreen({
+    super.key,
+    required this.runtime,
+    required this.bookId,
+    required this.title,
+  });
+
+  final CompanionRuntime runtime;
+  final String bookId;
+  final String title;
+
+  @override
+  State<PlayerScreen> createState() => _PlayerScreenState();
+}
+
+class _PlayerScreenState extends State<PlayerScreen> {
+  bool _ready = false;
+  bool _playing = false;
+  String? _error;
+  List<SyncManifestChapter> _chapters = const [];
+
+  @override
+  void initState() {
+    super.initState();
+    _prepare();
+  }
+
+  Future<void> _prepare() async {
+    try {
+      await widget.runtime.sync.ensureDetail(widget.bookId);
+      await widget.runtime.player.openBook(widget.bookId); // loads + restores resume
+      if (mounted) {
+        setState(() {
+          _chapters = widget.runtime.sync.chaptersOf(widget.bookId);
+          _ready = true;
+        });
+      }
+    } catch (e) {
+      if (mounted) setState(() => _error = '$e');
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.runtime.player.pause();
+    super.dispose();
+  }
+
+  Future<void> _playChapter(String uuid) async {
+    await widget.runtime.player.playChapter(uuid);
+    if (mounted) setState(() => _playing = true);
+  }
+
+  Future<void> _togglePlay() async {
+    final p = widget.runtime.player;
+    if (_playing) {
+      await p.pause();
+    } else {
+      await p.play();
+    }
+    if (mounted) setState(() => _playing = !_playing);
+  }
+
+  String _fmt(Duration d) {
+    final h = d.inHours;
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return h > 0 ? '$h:$m:$s' : '$m:$s';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final player = widget.runtime.player;
+    if (_error != null) {
+      return Scaffold(
+        appBar: AppBar(title: Text(widget.title)),
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text('Playback error: $_error', key: const Key('player-error')),
+          ),
+        ),
+      );
+    }
+    if (!_ready) {
+      return Scaffold(
+        appBar: AppBar(title: Text(widget.title)),
+        body: const Center(child: CircularProgressIndicator()),
+      );
+    }
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.title)),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView.builder(
+              itemCount: _chapters.length,
+              itemBuilder: (_, i) {
+                final c = _chapters[i];
+                final current = c.uuid == player.currentChapterUuid;
+                return ListTile(
+                  key: Key('chapter-${c.uuid}'),
+                  leading: CircleAvatar(child: Text('${c.id}')),
+                  title: Text(c.title.isEmpty ? 'Chapter ${c.id}' : c.title),
+                  trailing: current
+                      ? Icon(_playing ? Icons.volume_up : Icons.pause,
+                          color: Theme.of(context).colorScheme.primary)
+                      : null,
+                  selected: current,
+                  onTap: c.hasAudio ? () => _playChapter(c.uuid) : null,
+                  enabled: c.hasAudio,
+                );
+              },
+            ),
+          ),
+          const Divider(height: 1),
+          _transport(player),
+        ],
+      ),
+    );
+  }
+
+  Widget _transport(PlayerController player) {
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
+        child: StreamBuilder<Duration?>(
+          stream: player.durationStream,
+          builder: (_, durSnap) {
+            final dur = durSnap.data ?? player.duration ?? Duration.zero;
+            return StreamBuilder<Duration>(
+              stream: player.positionStream,
+              builder: (_, posSnap) {
+                final pos = posSnap.data ?? Duration.zero;
+                final maxMs = dur.inMilliseconds;
+                final v = maxMs > 0
+                    ? pos.inMilliseconds.clamp(0, maxMs).toDouble()
+                    : 0.0;
+                return Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Slider(
+                      key: const Key('player-progress'),
+                      value: v,
+                      max: maxMs > 0 ? maxMs.toDouble() : 1.0,
+                      onChanged: maxMs > 0
+                          ? (x) => player
+                              .seekTo(Duration(milliseconds: x.round()))
+                          : null,
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(_fmt(pos), key: const Key('player-position')),
+                          Text(dur > Duration.zero ? _fmt(dur) : '--:--'),
+                        ],
+                      ),
+                    ),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        IconButton(
+                          iconSize: 34,
+                          icon: const Icon(Icons.replay_30),
+                          onPressed: () => player.skip(forward: false),
+                        ),
+                        IconButton(
+                          key: const Key('player-playpause'),
+                          iconSize: 52,
+                          icon: Icon(
+                              _playing ? Icons.pause_circle : Icons.play_circle),
+                          onPressed: _togglePlay,
+                        ),
+                        IconButton(
+                          iconSize: 34,
+                          icon: const Icon(Icons.forward_30),
+                          onPressed: () => player.skip(forward: true),
+                        ),
+                        TextButton(
+                          key: const Key('player-speed'),
+                          onPressed: _cycleSpeed,
+                          child: Text('${_speed}x'),
+                        ),
+                      ],
+                    ),
+                  ],
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  static const _speeds = [1.0, 1.25, 1.5, 2.0, 0.75];
+  double _speed = 1.0;
+
+  Future<void> _cycleSpeed() async {
+    final next = _speeds[(_speeds.indexOf(_speed) + 1) % _speeds.length];
+    await widget.runtime.player.setSpeed(next);
+    if (mounted) setState(() => _speed = next);
+  }
+}

--- a/apps/android/test/data/player_controller_test.dart
+++ b/apps/android/test/data/player_controller_test.dart
@@ -16,6 +16,12 @@ class FakeAudioEngine implements AudioEngine {
   Duration get position => _position;
   @override
   Stream<Duration> get positionStream => _pos.stream;
+  @override
+  Duration? get duration => null;
+  @override
+  Stream<Duration?> get durationStream => const Stream.empty();
+  @override
+  Stream<void> get completionStream => const Stream.empty();
 
   @override
   Future<void> setFilePath(String path) async {

--- a/apps/android/test/data/sync_controller_test.dart
+++ b/apps/android/test/data/sync_controller_test.dart
@@ -1,0 +1,124 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:audiobook_companion/src/data/chapter_downloader.dart';
+import 'package:audiobook_companion/src/data/drift_local_library.dart';
+import 'package:audiobook_companion/src/data/file_store.dart';
+import 'package:audiobook_companion/src/data/library_database.dart';
+import 'package:audiobook_companion/src/data/sync_controller.dart';
+import 'package:audiobook_companion/src/data/sync_engine.dart';
+import 'package:audiobook_companion/src/domain/sync_manifest.dart';
+
+class _FakeApi implements ManifestApi {
+  _FakeApi(this.indexValue, this.details);
+  final SyncManifestIndex indexValue;
+  final Map<String, SyncManifestBookDetail> details;
+  @override
+  Future<SyncManifestIndex> index({String? since}) async => indexValue;
+  @override
+  Future<SyncManifestBookDetail> bookDetail(String bookId) async =>
+      details[bookId]!;
+}
+
+SyncManifestIndexBook idx(String id, String title) => SyncManifestIndexBook(
+    bookId: id, updatedAt: 't', title: title, author: 'A', series: 'S',
+    seriesPosition: 1, chapterCount: 1);
+
+SyncManifestChapter ch(String book, String uuid, int id, String fp) =>
+    SyncManifestChapter(
+      uuid: uuid, id: id, title: 'ch$id', fingerprint: fp,
+      urlSuffix: 'audio.mp3', audioUrl: '/api/books/$book/chapters/$id/audio.mp3');
+
+void main() {
+  late InMemoryFileStore fs;
+  late DriftLocalLibrary lib;
+
+  SyncController make(_FakeApi api, Map<String, List<int>> serverBytes) {
+    final downloader = ChapterDownloader(
+      (url, headers) async =>
+          RangeResponse(statusCode: 200, body: Stream.value(serverBytes[url.path]!)),
+      fs,
+      delay: (_) async {},
+    );
+    return SyncController(
+      manifestApi: api,
+      localLibrary: lib,
+      chapterDownloader: downloader,
+      urlResolver: (p) => Uri.parse('https://s$p'),
+    );
+  }
+
+  setUp(() {
+    fs = InMemoryFileStore();
+    lib = DriftLocalLibrary(LibraryDatabase(NativeDatabase.memory()), fs, root: '/d');
+  });
+
+  test('loadIndex records book metadata for the library (no downloads)', () async {
+    final api = _FakeApi(
+      SyncManifestIndex(schemaVersion: 1, books: [idx('b1', 'Book One')], activeBookIds: ['b1']),
+      const {},
+    );
+    final books = await make(api, {}).loadIndex();
+    expect(books.single.title, 'Book One');
+    final listed = await lib.listBooks();
+    expect(listed.single.title, 'Book One');
+    // no chapters downloaded
+    expect(await lib.chapterFingerprints('b1'), isEmpty);
+  });
+
+  test('downloadBook pulls the book\'s chapters and records them', () async {
+    final api = _FakeApi(
+      SyncManifestIndex(schemaVersion: 1, books: [idx('b1', 'B')], activeBookIds: ['b1']),
+      {
+        'b1': SyncManifestBookDetail(
+          schemaVersion: 1, bookId: 'b1', updatedAt: 't',
+          chapters: [ch('b1', 'u1', 1, 'fp1|3'), ch('b1', 'u2', 2, 'fp2|2')],
+          activeChapterUuids: ['u1', 'u2'],
+        ),
+      },
+    );
+    final c = make(api, {
+      '/api/books/b1/chapters/1/audio.mp3': [1, 2, 3],
+      '/api/books/b1/chapters/2/audio.mp3': [4, 5],
+    });
+    final progress = <String>[];
+    await c.downloadBook('b1', onProgress: (d, t) => progress.add('$d/$t'));
+
+    expect(await fs.read('/d/books/b1/u1/audio.mp3'), [1, 2, 3]);
+    expect(await lib.chapterFingerprints('b1'), {'u1': 'fp1|3', 'u2': 'fp2|2'});
+    expect(progress.last, '2/2');
+    expect(await c.isBookDownloaded('b1'), isTrue);
+  });
+
+  test('re-downloading after a regen pulls only the changed chapter', () async {
+    // First sync.
+    final api1 = _FakeApi(
+      SyncManifestIndex(schemaVersion: 1, books: [idx('b1', 'B')], activeBookIds: ['b1']),
+      {
+        'b1': SyncManifestBookDetail(
+          schemaVersion: 1, bookId: 'b1', updatedAt: 't1',
+          chapters: [ch('b1', 'u1', 1, 'fp1|3'), ch('b1', 'u2', 2, 'fp2|2')],
+          activeChapterUuids: ['u1', 'u2']),
+      },
+    );
+    await make(api1, {
+      '/api/books/b1/chapters/1/audio.mp3': [1, 2, 3],
+      '/api/books/b1/chapters/2/audio.mp3': [4, 5],
+    }).downloadBook('b1');
+
+    // ch1 regenerated (fp changed); ch2 unchanged.
+    final api2 = _FakeApi(
+      api1.indexValue,
+      {
+        'b1': SyncManifestBookDetail(
+          schemaVersion: 1, bookId: 'b1', updatedAt: 't2',
+          chapters: [ch('b1', 'u1', 1, 'fp1b|4'), ch('b1', 'u2', 2, 'fp2|2')],
+          activeChapterUuids: ['u1', 'u2']),
+      },
+    );
+    var downloaded = 0;
+    await make(api2, {'/api/books/b1/chapters/1/audio.mp3': [9, 9, 9, 9]})
+        .downloadBook('b1', onProgress: (d, t) => downloaded = t);
+    expect(downloaded, 1); // only the changed chapter
+    expect(await fs.read('/d/books/b1/u1/audio.mp3'), [9, 9, 9, 9]);
+  });
+}

--- a/apps/android/test/domain/library_tree_test.dart
+++ b/apps/android/test/domain/library_tree_test.dart
@@ -5,7 +5,7 @@ LibraryBook bk(
   String id, {
   String author = 'A',
   String series = '',
-  int? pos,
+  double? pos,
   String? title,
   BookDownloadState state = BookDownloadState.downloaded,
 }) =>
@@ -44,6 +44,22 @@ void main() {
       expect(tree.single.series.single.books.single.title, 'Solo');
     });
 
+    test('orders by decimal series position (novella 8.5 between 8 and 9)', () {
+      final tree = buildLibraryTree([
+        bk('b1', author: 'SM', series: 'KOTLC', pos: 9, title: 'Stellarlune'),
+        bk('b2', author: 'SM', series: 'KOTLC', pos: 8, title: 'Legacy'),
+        bk('b3', author: 'SM', series: 'KOTLC', pos: 8.5, title: 'Unlocked'),
+      ]);
+      expect(tree.single.series.single.books.map((b) => b.title),
+          ['Legacy', 'Unlocked', 'Stellarlune']);
+    });
+
+    test('formatSeriesPosition shows decimals only when needed', () {
+      expect(formatSeriesPosition(8.5), '8.5');
+      expect(formatSeriesPosition(1), '1');
+      expect(formatSeriesPosition(null), '');
+    });
+
     test('a series with null positions falls back to title order', () {
       final tree = buildLibraryTree([
         bk('b1', author: 'A', series: 'S', title: 'Beta'),
@@ -70,6 +86,16 @@ void main() {
 
     test('matches author', () {
       expect(filterBooks(books, 'sanderson').single.bookId, 'b1');
+    });
+
+    test('matches series — keeps every book in a matched series', () {
+      final series = [
+        bk('b1', author: 'Shannon Messenger', series: 'Keeper of the Lost Cities', title: 'Exile'),
+        bk('b2', author: 'Shannon Messenger', series: 'Keeper of the Lost Cities', title: 'Neverseen'),
+        bk('b3', author: 'Other', series: 'Different', title: 'Standalone'),
+      ];
+      final hit = filterBooks(series, 'keeper');
+      expect(hit.map((b) => b.bookId), ['b1', 'b2']);
     });
   });
 }


### PR DESCRIPTION
## Summary

Integrates the merged app-3..app-14 pieces into a **working app** behind pairing, validated live on the Pixel 10 Pro emulator against the real LAN server (paired → cert-pinned re-connect → srv-32 index sync → cover library → per-book download → offline playback).

- **`CompanionRuntime.forConnection`** — builds the cert-pinned `ApiClient`, drift store, `ChapterDownloader`, `SyncController`, `PlayerController`, cover `ThumbnailCache` from a paired `Connection`.
- **`SyncController`** — loads the cheap manifest **index** for the library; **downloads one book on demand** (per-book `planBookSync` delta — re-download after a server regen pulls only changed chapters). `loadLibrary` computes per-book state incl. **update-available**.
- **`main.dart`** — re-establishes the pinned connection from stored creds on launch → **`LibraryHomeScreen`** (cover art, author→series sections, collapsible **+/-** groups, filter by author/series/title, per-book download with progress) → **`PlayerScreen`** (chapter picker, resume, seekable progress + elapsed/total, speed, **auto-advance**).
- **Engine**: `AudioEngine` gains `duration`/`durationStream`/`completionStream`; `JustAudioEngine.play()` is fire-and-forget (just_audio's `play()` resolves at end-of-track → hung the player on "loading").
- **Fixes**: `filterBooks` matches **series**; `seriesPosition` is **decimal** (novellas like 8.5).

## Test plan

Paired unit tests: `sync_controller`, `library_tree` (series filter + decimal + `formatSeriesPosition`), `player_controller`. **173 Dart tests green**, `flutter analyze` clean. Device-validated on the emulator. Local `npm run verify` green (one prior flake in `test:server` under generation contention; passed clean in isolation + on re-run).

Refs #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)