### PR TITLE
feat(server): srv-32 manifest — per-chapter durationSec from the segments file

### DIFF
--- a/server/src/routes/library-sync-manifest.test.ts
+++ b/server/src/routes/library-sync-manifest.test.ts
@@ -39,6 +39,7 @@ function seedBook(
       audioQa?: unknown;
     }>;
     audioFiles?: Array<{ slug: string; ext: string; bytes: number }>;
+    segmentFiles?: Array<{ slug: string; durationSec: number }>;
   },
 ): { bookId: string; bookDir: string } {
   const bookDir = join(workspaceRoot, 'books', author, SERIES, title);
@@ -65,6 +66,12 @@ function seedBook(
   );
   for (const f of opts.audioFiles ?? []) {
     writeFileSync(join(bookDir, 'audio', `${f.slug}.${f.ext}`), 'x'.repeat(f.bytes));
+  }
+  for (const s of opts.segmentFiles ?? []) {
+    writeFileSync(
+      join(bookDir, 'audio', `${s.slug}.segments.json`),
+      JSON.stringify({ durationSec: s.durationSec }),
+    );
   }
   return { bookId, bookDir };
 }
@@ -104,6 +111,9 @@ beforeAll(async () => {
       { id: 3, uuid: 'uuid-a3', slug: '03-three', title: 'Three', excluded: true },
     ],
     audioFiles: [{ slug: '01-one', ext: 'mp3', bytes: 4096 }],
+    // Segments file carries the authoritative PCM duration (250) — must win
+    // over the audioQa verdict's 100.
+    segmentFiles: [{ slug: '01-one', durationSec: 250 }],
   });
   b1Dir = seededB1.bookDir;
 
@@ -168,7 +178,7 @@ describe('GET /api/library/sync-manifest?bookId= — detail', () => {
     expect(c1.urlSuffix).toBe('audio.mp3');
     expect(c1.audioUrl).toBe(`/api/books/${b1}/chapters/1/audio.mp3`);
     expect(c1.fingerprint).toContain('4096');
-    expect(c1.durationSec).toBe(100);
+    expect(c1.durationSec).toBe(250); // segments-file duration wins over audioQa's 100
     expect(c1.lufs).toBe(-16);
 
     const c2 = res.body.chapters.find((c: { uuid: string }) => c.uuid === 'uuid-a2');

--- a/server/src/routes/library-sync-manifest.ts
+++ b/server/src/routes/library-sync-manifest.ts
@@ -11,7 +11,8 @@
  * wrapper (book walk, file stat, format probe) + manual gzip. See plan 191. */
 
 import { Router } from 'express';
-import { existsSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 import { gzipSync } from 'node:zlib';
 import type { Request, Response } from '../http.js';
 import { collectBooks, findBookByBookId } from '../workspace/scan.js';
@@ -72,7 +73,26 @@ syncManifestRouter.get('/sync-manifest', async (req: Request, res: Response) => 
           fileSize = undefined;
         }
         if (fileSize !== undefined) {
-          audioByChapterId.set(c.id, { fileSize, urlSuffix: found.urlSuffix });
+          /* Real PCM-measured length lives in the per-chapter segments file
+             (state.json's audioQa.durationSec is often absent on older
+             books). Read it so the companion can show total + per-chapter
+             durations + listener progress. Best-effort: omit on any miss. */
+          let durationSec: number | undefined;
+          try {
+            const seg = JSON.parse(
+              readFileSync(join(audioRoot, `${c.slug}.segments.json`), 'utf8'),
+            ) as { durationSec?: number };
+            if (typeof seg.durationSec === 'number' && Number.isFinite(seg.durationSec)) {
+              durationSec = seg.durationSec;
+            }
+          } catch {
+            /* no segments file / unreadable → omit duration */
+          }
+          audioByChapterId.set(c.id, {
+            fileSize,
+            urlSuffix: found.urlSuffix,
+            ...(durationSec !== undefined ? { durationSec } : {}),
+          });
         }
       }
       return sendMaybeGzip(req, res, buildSyncManifestBookDetail(bookId, state, audioByChapterId));

--- a/server/src/workspace/sync-manifest.test.ts
+++ b/server/src/workspace/sync-manifest.test.ts
@@ -151,6 +151,18 @@ describe('buildSyncManifestBookDetail', () => {
     expect(c1.lufs).toBe(-16.2);
   });
 
+  it('uses the audio fact durationSec (from the segments file) when audioQa has none', () => {
+    const s2 = state({
+      bookId: 'b1',
+      chapters: [ch({ id: 1, uuid: 'u1', audioRenderedAt: '2026-04-01T00:00:00.000Z' })],
+    });
+    const audio2 = new Map<number, ChapterAudioFact>([
+      [1, { fileSize: 4096, urlSuffix: 'audio.mp3', durationSec: 99.5 }],
+    ]);
+    const detail = buildSyncManifestBookDetail('b1', s2, audio2);
+    expect(detail.chapters[0].durationSec).toBe(99.5);
+  });
+
   it('lists a chapter without audio but with no fingerprint/urlSuffix', () => {
     const detail = buildSyncManifestBookDetail('b1', s, audio);
     const c2 = detail.chapters.find((c) => c.uuid === 'u2')!;

--- a/server/src/workspace/sync-manifest.ts
+++ b/server/src/workspace/sync-manifest.ts
@@ -28,6 +28,10 @@ export const SYNC_MANIFEST_SCHEMA = 1;
 export interface ChapterAudioFact {
   fileSize: number;
   urlSuffix: 'audio.mp3' | 'audio.m4a' | 'audio.ogg';
+  /** Real PCM-measured length from the chapter's `<slug>.segments.json`
+   *  (the authoritative source the library scan uses). Preferred over the
+   *  QA verdict's `durationSec`, which is often absent on older books. */
+  durationSec?: number;
 }
 
 export interface SyncManifestIndexBook {
@@ -135,6 +139,7 @@ export function buildSyncManifestBookDetail(
     if (c.excluded) continue;
     const audio = audioByChapterId.get(c.id);
     const lufs = c.audioQa?.measuredLufs;
+    const durationSec = audio?.durationSec ?? c.audioQa?.durationSec;
     chapters.push({
       // The route guarantees a uuid via ensureChapterUuids before building.
       uuid: c.uuid ?? '',
@@ -147,7 +152,7 @@ export function buildSyncManifestBookDetail(
             audioUrl: `/api/books/${bookId}/chapters/${c.id}/${audio.urlSuffix}`,
           }
         : {}),
-      ...(c.audioQa?.durationSec !== undefined ? { durationSec: c.audioQa.durationSec } : {}),
+      ...(durationSec !== undefined ? { durationSec } : {}),
       ...(lufs !== undefined && lufs !== null ? { lufs } : {}),
     });
   }


### PR DESCRIPTION
## Summary

The companion needs per-chapter durations for **total book length, per-chapter lengths, and listener progress**, but the detail manifest only read `audioQa.durationSec`, which is absent on most books. The authoritative PCM-measured duration lives in each chapter's `<slug>.segments.json` (the same value the library scan totals).

The detail route now reads that `durationSec` per chapter and passes it to the builder via `ChapterAudioFact.durationSec`; the builder prefers it over `audioQa.durationSec` (fallback preserved). Index stays cheap (no per-chapter I/O) — the companion sums the detail per book for totals. No manifest shape change (`durationSec` was already in the schema), so no `schemaVersion` bump.

## Test plan

- builder: uses the fact's `durationSec` when `audioQa` has none.
- route: reads the segments file and it wins over `audioQa` (250 over 100).

18 sync-manifest tests pass; `npm run typecheck` clean; local `npm run verify` green (pre-push).

Refs #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)