### PR TITLE
feat(app): library total duration + listener progress; per-chapter durations

### DIFF
--- a/apps/android/lib/src/domain/listen_progress.dart
+++ b/apps/android/lib/src/domain/listen_progress.dart
@@ -1,0 +1,34 @@
+/// Pure helpers for showing how far through a book the listener is, and for
+/// formatting durations. No IO — fed by the manifest chapter durations + the
+/// stored resume point.
+library;
+
+/// Fraction (0..1) of a book listened: the durations of all chapters before
+/// the resume point, plus the current position, over the book total. Returns 0
+/// when the total is unknown (no durations). Null chapter durations count as 0.
+double listenedFraction({
+  required List<double?> durations,
+  required int resumeIndex,
+  required double resumePositionSec,
+}) {
+  final total = durations.fold<double>(0, (s, d) => s + (d ?? 0));
+  if (total <= 0) return 0;
+  var listened = resumePositionSec;
+  for (var i = 0; i < resumeIndex && i < durations.length; i++) {
+    listened += durations[i] ?? 0;
+  }
+  final f = listened / total;
+  return f < 0 ? 0 : (f > 1 ? 1 : f);
+}
+
+/// `H:MM:SS` when there are hours, else `M:SS`; null → empty string.
+String formatDuration(double? seconds) {
+  if (seconds == null) return '';
+  final total = seconds.round();
+  final h = total ~/ 3600;
+  final m = (total % 3600) ~/ 60;
+  final s = total % 60;
+  final ss = s.toString().padLeft(2, '0');
+  if (h > 0) return '$h:${m.toString().padLeft(2, '0')}:$ss';
+  return '$m:$ss';
+}

--- a/apps/android/lib/src/ui/library_home_screen.dart
+++ b/apps/android/lib/src/ui/library_home_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../data/companion_runtime.dart';
 import '../domain/library_tree.dart';
+import '../domain/listen_progress.dart';
 import 'player_screen.dart';
 
 /// Post-pairing home: a cover-art library grouped into author → series
@@ -29,6 +30,8 @@ class _LibraryHomeScreenState extends State<LibraryHomeScreen> {
   List<LibraryBook> _books = [];
   final Map<String, String> _covers = {}; // bookId -> thumb path
   final Map<String, String> _progress = {}; // bookId -> "done/total"
+  final Map<String, double> _totalSec = {}; // bookId -> total duration (s)
+  final Map<String, double> _listened = {}; // bookId -> listened fraction (0..1)
   final Set<String> _collapsed = {}; // collapsed author/series section keys
   String _query = '';
   bool _loading = true;
@@ -53,6 +56,7 @@ class _LibraryHomeScreenState extends State<LibraryHomeScreen> {
         _loading = false;
       });
       _loadCovers(books);
+      _loadDurations(books);
     } catch (e) {
       if (mounted) {
         setState(() {
@@ -71,6 +75,42 @@ class _LibraryHomeScreenState extends State<LibraryHomeScreen> {
         if (mounted) setState(() => _covers[b.bookId] = path);
       } catch (_) {
         /* no cover — show a placeholder */
+      }
+    }
+  }
+
+  /// Fetch each book's detail (cheap JSON, like covers) to show total
+  /// duration; for downloaded books, compute the listener-progress fraction
+  /// from the stored resume point.
+  Future<void> _loadDurations(List<LibraryBook> books) async {
+    for (final b in books) {
+      try {
+        await widget.runtime.sync.ensureDetail(b.bookId);
+        final chs = widget.runtime.sync.chaptersOf(b.bookId);
+        final durations = [for (final c in chs) c.durationSec];
+        final total = durations.fold<double>(0, (s, d) => s + (d ?? 0));
+        if (total <= 0) continue;
+        double? fraction;
+        if (b.downloadState == BookDownloadState.downloaded ||
+            b.downloadState == BookDownloadState.updateAvailable) {
+          final pb = await widget.runtime.library.loadPlayback(b.bookId);
+          if (pb != null) {
+            final idx = chs.indexWhere((c) => c.uuid == pb.chapterUuid);
+            fraction = listenedFraction(
+              durations: durations,
+              resumeIndex: idx < 0 ? 0 : idx,
+              resumePositionSec: pb.positionMs / 1000.0,
+            );
+          }
+        }
+        if (mounted) {
+          setState(() {
+            _totalSec[b.bookId] = total;
+            if (fraction != null) _listened[b.bookId] = fraction;
+          });
+        }
+      } catch (_) {
+        /* detail unavailable (older server without durationSec, or offline) */
       }
     }
   }
@@ -239,8 +279,8 @@ class _LibraryHomeScreenState extends State<LibraryHomeScreen> {
       key: Key('book-${book.bookId}'),
       leading: _cover(book.bookId),
       title: Text(book.title),
-      subtitle: Text(_subtitle(book)),
-      isThreeLine: book.series.isNotEmpty,
+      subtitle: _subtitleWidget(book),
+      isThreeLine: true,
       onTap: (book.downloadState == BookDownloadState.downloaded ||
               book.downloadState == BookDownloadState.updateAvailable)
           ? () => _open(book)
@@ -302,12 +342,31 @@ class _LibraryHomeScreenState extends State<LibraryHomeScreen> {
     ]);
   }
 
-  String _subtitle(LibraryBook book) {
+  Widget _subtitleWidget(LibraryBook book) {
     final pos = formatSeriesPosition(book.seriesPosition);
-    final series = book.series.isEmpty
-        ? ''
-        : '${book.series}${pos.isNotEmpty ? ' #$pos' : ''}\n';
-    return '$series${_statusLabel(book.downloadState)}';
+    final seriesLine = book.series.isEmpty
+        ? null
+        : '${book.series}${pos.isNotEmpty ? ' #$pos' : ''}';
+    final total = _totalSec[book.bookId];
+    final status = _statusLabel(book.downloadState) +
+        (total != null ? ' · ${formatDuration(total)}' : '');
+    final listened = _listened[book.bookId];
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (seriesLine != null) Text(seriesLine),
+        Text(status),
+        if (listened != null && listened > 0)
+          Padding(
+            padding: const EdgeInsets.only(top: 4, right: 12),
+            child: LinearProgressIndicator(
+              value: listened,
+              minHeight: 4,
+              backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+            ),
+          ),
+      ],
+    );
   }
 
   String _statusLabel(BookDownloadState s) {

--- a/apps/android/lib/src/ui/player_screen.dart
+++ b/apps/android/lib/src/ui/player_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../data/companion_runtime.dart';
 import '../data/player_controller.dart';
+import '../domain/listen_progress.dart';
 import '../domain/sync_manifest.dart';
 
 /// Player surface: a chapter picker + transport controls over the
@@ -112,6 +113,9 @@ class _PlayerScreenState extends State<PlayerScreen> {
                   key: Key('chapter-${c.uuid}'),
                   leading: CircleAvatar(child: Text('${c.id}')),
                   title: Text(c.title.isEmpty ? 'Chapter ${c.id}' : c.title),
+                  subtitle: c.durationSec != null
+                      ? Text(formatDuration(c.durationSec))
+                      : null,
                   trailing: current
                       ? Icon(_playing ? Icons.volume_up : Icons.pause,
                           color: Theme.of(context).colorScheme.primary)

--- a/apps/android/test/domain/listen_progress_test.dart
+++ b/apps/android/test/domain/listen_progress_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:audiobook_companion/src/domain/listen_progress.dart';
+
+void main() {
+  group('listenedFraction', () {
+    test('sums prior chapter durations + current position over the total', () {
+      final f = listenedFraction(
+        durations: [60, 120, 60],
+        resumeIndex: 1,
+        resumePositionSec: 30,
+      );
+      expect(f, closeTo((60 + 30) / 240, 1e-9));
+    });
+
+    test('is 0 when total duration is unknown (all null)', () {
+      expect(
+        listenedFraction(durations: [null, null], resumeIndex: 1, resumePositionSec: 5),
+        0,
+      );
+    });
+
+    test('clamps to 1 and tolerates null chapter durations', () {
+      final f = listenedFraction(
+        durations: [60, null, 60],
+        resumeIndex: 3,
+        resumePositionSec: 999,
+      );
+      expect(f, 1.0);
+    });
+  });
+
+  group('formatDuration', () {
+    test('formats seconds as H:MM:SS / M:SS', () {
+      expect(formatDuration(0), '0:00');
+      expect(formatDuration(65), '1:05');
+      expect(formatDuration(3725), '1:02:05');
+      expect(formatDuration(null), '');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Now that srv-32 (#601) ships per-chapter `durationSec`, surface durations in the companion:

- **Library**: fetch each book's detail (cheap JSON, like covers) to show **total book duration** in the tile; for downloaded titles, a **listener-progress bar** computed from the stored resume point (durations of prior chapters + current position over the book total).
- **Player**: each chapter row shows its **duration**.
- Pure `listenedFraction` + `formatDuration` helpers (`domain/listen_progress.dart`), unit-tested. **Degrades gracefully** when durations are absent (older server): no total, no progress bar — the rest of the UI is unaffected.

## Test plan

`listen_progress` unit tests (fraction math + formatting); 177 Dart tests green; `flutter analyze` clean. Requires a server running srv-32 to display durations (graceful no-op otherwise).

Refs #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)