### PR TITLE
fix(server,frontend): stamp the engine the audio actually rendered in for drift

### DIFF
--- a/docs/features/archive/35-engine-drift-detection.md
+++ b/docs/features/archive/35-engine-drift-detection.md
@@ -30,9 +30,12 @@ read, and surface the mismatch in the Generation view.
 ## Invariants
 
 1. **Each chapter audio render writes `audioModelKey` and
-   `audioRenderedAt` into `state.json`** (`server/src/routes/generation.ts`
-   post-render block). The stamp matches the `modelKey` passed to the
-   generation route for that run.
+   `audioRenderedAt` into `state.json`** (`finalize-chapter-write.ts`). The
+   stamp is the engine the audio ACTUALLY rendered in — derived from the
+   per-character render snapshots, NOT blindly the request `modelKey`. See
+   the per-character reconciliation section below; before that fix this field
+   was the request default, which produced a false drift badge on any chapter
+   whose speakers all rendered on a non-default engine.
 
 2. **Legacy chapters are lazy-backfilled from
    `audio/<slug>.segments.json`** by
@@ -188,6 +191,50 @@ read, and surface the mismatch in the Generation view.
     chapter finishes on its original engine and stamps that engine.
     The drift detector then correctly flags it the next time the user
     looks at the chapter list.
+
+## Per-character engine reconciliation (false-drift fix, 2026-06-07)
+
+This plan (chapter-wide drift) predated plan 108 (per-character engine
+routing). The chapter stamp was the generation request's DEFAULT engine, so a
+chapter whose speakers all rendered on a different engine than the project
+default got a wrong stamp — classically a narration-only chapter whose narrator
+carries `ttsEngine: 'qwen'`, regenerated while the project default was Kokoro:
+it renders 100% on Qwen but stamped `kokoro-v1`, firing a false "Generated with
+Kokoro · current engine is Qwen" badge once the project engine was set to Qwen.
+The audio was correct; only the stamp lied.
+
+Reconciliation invariants:
+
+A. **The stamp reflects the rendered engine, not the request default.**
+   `finalize-chapter-write.ts` computes a per-engine breakdown from the render
+   `characterSnapshots` (each character's `renderedFallbackEngine ?? voiceEngine`)
+   via `engineBreakdownFromSnapshots`, then stamps `audioModelKey` with
+   `effectiveAudioModelKey`: the single engine's canonical key when the chapter
+   is UNIFORM, else the request key (a single key can't represent a mixed
+   chapter). Both helpers live in `server/src/audio/engine-breakdown.ts`; the
+   engine→key map is the shared `canonicalModelKeyForEngine` (`model-keys.ts`),
+   which also replaced generation.ts's local copy.
+
+B. **A new per-chapter `audioEngines` map carries the breakdown** — distinct
+   speaking characters per engine, e.g. `{ kokoro: 1, qwen: 6 }`. Stamped on
+   render, returned on the `chapter_complete` SSE tick, persisted in
+   `state.json`, and lazy-backfilled from `characterSnapshots` by
+   `backfillAudioModelKeysFromSegments` (scan.ts) for legacy chapters.
+
+C. **Mixed-engine chapters show a breakdown, not a drift warning.** A chapter
+   with >1 engine in `audioEngines` is intentional (narrator on Kokoro +
+   dialogue on Qwen). The Generation view (`generation.tsx`,
+   `isMixedEngineChapter`) renders a neutral "Voices: Kokoro (1), Qwen (6)"
+   caption (`formatEngineBreakdown`, `tts-models.ts`) and excludes the chapter
+   from the drift banner / bulk-regen set. Uniform chapters keep the existing
+   amber drift caption, now driven by the corrected stamp.
+
+D. **Existing wrong stamps are repaired by
+   `scripts/repair-audio-engine-stamp.mjs`** (dry-run default, `--apply`): it
+   recomputes the effective engine from `characterSnapshots` and corrects
+   `audioModelKey` only where it disagrees, plus backfills `audioEngines`.
+   First run (2026-06-07) corrected 2 stamps (Unlocked CH12/13, narrator-only
+   Qwen chapters mis-stamped Kokoro) and set 355 breakdowns library-wide.
 
 ## Modal fidelity contract (drift-report-fidelity, 2026-05-19)
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3298,8 +3298,18 @@ components:
             this chapter's audio. Carries the engine forward so the
             frontend can update `chapter.audioModelKey` without waiting
             for a state.json reload (which would otherwise let an
-            engine-drift badge appear only after page navigation). See
-            `docs/features/archive/35-engine-drift-detection.md`.
+            engine-drift badge appear only after page navigation). With
+            per-character engine routing (plan 108) this is the engine the
+            audio ACTUALLY rendered in, not necessarily the request default.
+            See `docs/features/archive/35-engine-drift-detection.md`.
+        audioEngines:
+          type: object
+          additionalProperties: { type: integer }
+          description: |
+            Only on `chapter_complete` — distinct speaking characters per TTS
+            engine they actually rendered in (e.g. `{ "kokoro": 1, "qwen": 6 }`).
+            Carries the mixed-engine breakdown forward so the frontend can show
+            the per-engine voice-count caption without a state.json reload.
         audioQa:
           allOf:
             - $ref: '#/components/schemas/ChapterQaVerdict'
@@ -4342,7 +4352,21 @@ components:
             segments file for legacy chapters. Absent on never-rendered
             chapters. The frontend compares against the project's
             current `ui.ttsModelKey` to surface engine-drift badges (see
-            `docs/features/archive/35-engine-drift-detection.md`).
+            `docs/features/archive/35-engine-drift-detection.md`). With
+            per-character engine routing (plan 108) this reflects the engine
+            the audio actually rendered in (a uniform chapter), not the
+            request default.
+        audioEngines:
+          type: object
+          additionalProperties: { type: integer }
+          description: |
+            Distinct speaking characters per TTS engine they actually rendered
+            in, e.g. `{ "kokoro": 1, "qwen": 6 }`. For a uniform chapter it has
+            one key matching `audioModelKey`'s engine; a chapter that mixes
+            engines (narrator on Kokoro + dialogue on Qwen) carries the full
+            breakdown, which the Generation view shows as a per-engine
+            voice-count caption instead of a drift badge. Stamped at render
+            time, backfilled from the segments file for legacy chapters.
         audioRenderedAt:
           type: string
           format: date-time

--- a/scripts/repair-audio-engine-stamp.mjs
+++ b/scripts/repair-audio-engine-stamp.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/*
+ * repair-audio-engine-stamp.mjs
+ *
+ * One-time data repair for the false engine-drift badge (2026-06-07).
+ *
+ * Symptom: a chapter shows "⚠ Generated with Kokoro v1 · current engine is
+ * Qwen" even though its audio actually rendered on Qwen. Plan 35 (chapter-wide
+ * engine-drift detection) predated plan 108 (per-character engine routing):
+ * finalize-chapter-write stamped `state.json.audioModelKey` with the generation
+ * request's DEFAULT engine, not the engine the audio actually rendered in. A
+ * narration-only chapter whose narrator carries `ttsEngine: 'qwen'`, regenerated
+ * while the project default was Kokoro, rendered 100% on Qwen but stamped
+ * `kokoro-v1` → a false drift badge once the project engine was set to Qwen.
+ *
+ * The truth lives in `audio/<slug>.segments.json` -> `characterSnapshots`, where
+ * each speaking character's ACTUAL engine is recorded (`renderedFallbackEngine`
+ * ?? `voiceEngine`). This script recomputes the per-engine voice-count breakdown
+ * from those snapshots and, when the chapter is UNIFORM on a single engine whose
+ * canonical key disagrees with the stamped `audioModelKey`, corrects the stamp.
+ * It also backfills the new `audioEngines` field on every rendered chapter (so
+ * mixed-engine chapters gain the "Kokoro (1), Qwen (6)" caption data).
+ *
+ * It NEVER rewrites the audio — only the metadata stamp that already disagrees
+ * with the rendered audio. Mixed-engine chapters keep their `audioModelKey`
+ * (a single key can't represent them); only `audioEngines` is added.
+ *
+ * DRY RUN BY DEFAULT — prints the planned writes and exits without touching
+ * disk. Pass --apply to write each changed state.json (a .bak is written first).
+ *
+ * Env:
+ *   BASE                 workspace root (overrides everything)
+ *   AUDIOBOOK_WORKSPACE  workspace root (same default the server uses)
+ *   default              <home>/AudiobookWorkspace
+ *
+ * Usage:
+ *   node scripts/repair-audio-engine-stamp.mjs            # dry run
+ *   node scripts/repair-audio-engine-stamp.mjs --apply    # write
+ *   BASE="C:/AudiobookWorkspace" node scripts/repair-audio-engine-stamp.mjs --apply
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const APPLY = process.argv.includes('--apply');
+
+const BASE =
+  (process.env.BASE && path.resolve(process.env.BASE)) ||
+  (process.env.AUDIOBOOK_WORKSPACE && path.resolve(process.env.AUDIOBOOK_WORKSPACE)) ||
+  path.join(os.homedir(), 'AudiobookWorkspace');
+
+const BOOKS_ROOT = path.join(BASE, 'books');
+
+/* Canonical engine -> model key. Mirrors server canonicalModelKeyForEngine.
+   Gemini variants can't be recovered from a snapshot, so a uniform-Gemini
+   chapter keeps its existing stamp (left untouched below). */
+const CANONICAL = {
+  kokoro: 'kokoro-v1',
+  qwen: 'qwen3-tts-0.6b',
+  coqui: 'coqui-xtts-v2',
+  piper: 'piper-en-us-medium',
+};
+
+const readJson = (p) => {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return null;
+  }
+};
+
+/* Recursively collect every `<dir>/.audiobook/` that holds a state.json. */
+function findAudiobookDirs(root) {
+  const found = [];
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (!e.isDirectory()) continue;
+      const child = path.join(dir, e.name);
+      if (e.name === '.audiobook') {
+        if (fs.existsSync(path.join(child, 'state.json'))) found.push(child);
+        continue; // never descend into .audiobook
+      }
+      walk(child);
+    }
+  };
+  walk(root);
+  return found;
+}
+
+/* Distinct speaking characters per engine they ACTUALLY rendered in. Mirrors
+   server engineBreakdownFromSnapshots. */
+function engineBreakdownFromSnapshots(snapshots) {
+  const breakdown = {};
+  for (const snap of Object.values(snapshots ?? {})) {
+    const engine = snap?.renderedFallbackEngine ?? snap?.voiceEngine;
+    if (!engine) continue;
+    breakdown[engine] = (breakdown[engine] ?? 0) + 1;
+  }
+  return breakdown;
+}
+
+const sameBreakdown = (a, b) => JSON.stringify(a ?? {}) === JSON.stringify(b ?? {});
+
+function main() {
+  if (!fs.existsSync(BOOKS_ROOT)) {
+    console.error(`No books root at ${BOOKS_ROOT}. Set BASE to your workspace.`);
+    process.exit(1);
+  }
+  console.log(`${APPLY ? 'APPLY' : 'DRY RUN'} — workspace: ${BASE}\n`);
+
+  let booksChanged = 0;
+  let stampsFixed = 0;
+  let breakdownsAdded = 0;
+
+  for (const ab of findAudiobookDirs(BOOKS_ROOT)) {
+    const statePath = path.join(ab, 'state.json');
+    const state = readJson(statePath);
+    if (!state || !Array.isArray(state.chapters)) continue;
+    const audioDir = path.join(path.dirname(ab), 'audio');
+    const bookLabel = path.relative(BOOKS_ROOT, path.dirname(ab));
+
+    let bookChanged = false;
+    for (const ch of state.chapters) {
+      if (!ch?.slug) continue;
+      const segPath = path.join(audioDir, `${ch.slug}.segments.json`);
+      const seg = readJson(segPath);
+      if (!seg?.characterSnapshots) continue;
+      const breakdown = engineBreakdownFromSnapshots(seg.characterSnapshots);
+      const engines = Object.keys(breakdown);
+      if (engines.length === 0) continue;
+
+      const changes = [];
+
+      // 1) Correct a wrong uniform-engine stamp.
+      if (engines.length === 1) {
+        const canonical = CANONICAL[engines[0]];
+        if (canonical && ch.audioModelKey && ch.audioModelKey !== canonical) {
+          changes.push(`audioModelKey ${ch.audioModelKey} → ${canonical}`);
+          if (APPLY) ch.audioModelKey = canonical;
+          stampsFixed += 1;
+        }
+      }
+
+      // 2) Add / refresh the per-engine breakdown.
+      if (!sameBreakdown(ch.audioEngines, breakdown)) {
+        changes.push(`audioEngines ${JSON.stringify(ch.audioEngines ?? {})} → ${JSON.stringify(breakdown)}`);
+        if (APPLY) ch.audioEngines = breakdown;
+        breakdownsAdded += 1;
+      }
+
+      if (changes.length) {
+        console.log(`  [${bookLabel}] ch${ch.id} ${ch.slug}: ${changes.join('; ')}`);
+        bookChanged = true;
+      }
+    }
+
+    if (bookChanged) {
+      booksChanged += 1;
+      if (APPLY) {
+        fs.copyFileSync(statePath, `${statePath}.bak-engine-stamp-${Date.now()}`);
+        fs.writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`);
+      }
+    }
+  }
+
+  console.log(
+    `\n${APPLY ? 'Wrote' : 'Would write'} ${booksChanged} book(s): ` +
+      `${stampsFixed} stamp(s) corrected, ${breakdownsAdded} breakdown(s) set.`,
+  );
+  if (!APPLY && booksChanged > 0) console.log('Re-run with --apply to write.');
+}
+
+main();

--- a/server/src/audio/engine-breakdown.test.ts
+++ b/server/src/audio/engine-breakdown.test.ts
@@ -1,0 +1,63 @@
+/* Drift-stamp correctness (false "Generated with Kokoro" badge, 2026-06-07).
+   Plan 35 (chapter-wide engine drift) predated plan 108 (per-character engine
+   routing): finalize-chapter-write stamped `audioModelKey` with the request's
+   DEFAULT engine, not the engine the audio actually rendered in. A narration-
+   only chapter whose narrator carries `ttsEngine: 'qwen'`, regenerated while the
+   project default was Kokoro, rendered 100% on Qwen but stamped `kokoro-v1` —
+   a false drift badge once the project engine was set to Qwen.
+
+   These pin the two pure helpers that fix it: the per-engine voice-count
+   breakdown (drives the mixed-engine "Kokoro (1), Qwen (6)" display) and the
+   effective chapter-wide model key (the corrected drift stamp). */
+
+import { describe, it, expect } from 'vitest';
+import { engineBreakdownFromSnapshots, effectiveAudioModelKey } from './engine-breakdown.js';
+
+describe('engineBreakdownFromSnapshots', () => {
+  it('counts a single speaker under the engine it rendered in', () => {
+    const breakdown = engineBreakdownFromSnapshots({
+      narrator: { voiceEngine: 'qwen' },
+    });
+    expect(breakdown).toEqual({ qwen: 1 });
+  });
+
+  it('counts distinct speakers per engine for a mixed-engine chapter', () => {
+    const breakdown = engineBreakdownFromSnapshots({
+      narrator: { voiceEngine: 'kokoro' },
+      sophie: { voiceEngine: 'qwen' },
+      keefe: { voiceEngine: 'qwen' },
+    });
+    expect(breakdown).toEqual({ kokoro: 1, qwen: 2 });
+  });
+
+  it('attributes a fallen-back character to the engine it ACTUALLY rendered in', () => {
+    const breakdown = engineBreakdownFromSnapshots({
+      // Configured Qwen, but rendered Kokoro (no designed voice / Qwen down).
+      sophie: { voiceEngine: 'qwen', renderedFallbackEngine: 'kokoro' },
+    });
+    expect(breakdown).toEqual({ kokoro: 1 });
+  });
+
+  it('returns an empty breakdown for no snapshots', () => {
+    expect(engineBreakdownFromSnapshots({})).toEqual({});
+  });
+});
+
+describe('effectiveAudioModelKey', () => {
+  it('returns the single engine canonical key when the chapter is uniform (the bug case)', () => {
+    // Narrator-only Qwen chapter regenerated while the project default was Kokoro.
+    expect(effectiveAudioModelKey({ qwen: 1 }, 'kokoro-v1')).toBe('qwen3-tts-0.6b');
+  });
+
+  it('keeps the request model key when the chapter mixes engines', () => {
+    expect(effectiveAudioModelKey({ kokoro: 1, qwen: 2 }, 'kokoro-v1')).toBe('kokoro-v1');
+  });
+
+  it('keeps the request model key when there are no speakers', () => {
+    expect(effectiveAudioModelKey({}, 'qwen3-tts-0.6b')).toBe('qwen3-tts-0.6b');
+  });
+
+  it('preserves the specific Gemini variant when uniform on Gemini', () => {
+    expect(effectiveAudioModelKey({ gemini: 1 }, 'gemini-3.1-flash')).toBe('gemini-3.1-flash');
+  });
+});

--- a/server/src/audio/engine-breakdown.ts
+++ b/server/src/audio/engine-breakdown.ts
@@ -1,0 +1,62 @@
+/* Per-chapter engine breakdown for the drift signal (false-drift fix, 2026-06-07).
+
+   Plan 35 detects engine drift by comparing a chapter's `audioModelKey` against
+   the project's current engine. That stamp used to be the generation request's
+   DEFAULT engine, which is wrong once per-character engine routing (plan 108)
+   sends a chapter's audio to a different engine than the project default — e.g.
+   a narration-only chapter whose narrator has `ttsEngine: 'qwen'`, regenerated
+   while the project default is Kokoro: it renders 100% on Qwen but stamped
+   `kokoro-v1`, producing a false "Generated with Kokoro" badge.
+
+   These pure helpers derive the truth from the per-character render snapshots:
+   - `engineBreakdownFromSnapshots` — distinct speaking characters per engine
+     they ACTUALLY rendered in (fallback engine wins). Drives the mixed-engine
+     "Kokoro (1), Qwen (6)" display and the corrected stamp below.
+   - `effectiveAudioModelKey` — the chapter-wide drift stamp: the single engine's
+     canonical key when uniform; the request key when mixed (a single key can't
+     represent a genuinely multi-engine chapter, so drift falls back to today's
+     behaviour and the breakdown carries the detail). */
+
+import {
+  canonicalModelKeyForEngine,
+  type TtsEngine,
+  type TtsModelKey,
+} from '../tts/model-keys.js';
+
+/** Minimal structural view of a render snapshot — the engine fields only. */
+interface SnapshotEngineView {
+  voiceEngine?: string;
+  /** Engine it actually rendered in when it differs from `voiceEngine`
+      (Qwen→Kokoro fallback). When set, it — not `voiceEngine` — is the truth. */
+  renderedFallbackEngine?: string;
+}
+
+export type AudioEngineBreakdown = Partial<Record<TtsEngine, number>>;
+
+/** Count distinct speaking characters per engine they actually rendered in.
+    Snapshots without a resolvable engine are skipped. */
+export function engineBreakdownFromSnapshots(
+  snapshots: Record<string, SnapshotEngineView>,
+): AudioEngineBreakdown {
+  const breakdown: AudioEngineBreakdown = {};
+  for (const snap of Object.values(snapshots)) {
+    const engine = (snap.renderedFallbackEngine ?? snap.voiceEngine) as TtsEngine | undefined;
+    if (!engine) continue;
+    breakdown[engine] = (breakdown[engine] ?? 0) + 1;
+  }
+  return breakdown;
+}
+
+/** The chapter-wide model key to stamp for drift detection. When every speaking
+    character rendered in ONE engine, return that engine's canonical key (the
+    fix). When the chapter mixes engines (or has no speakers), keep the request
+    key — the breakdown map carries the per-engine detail for display. */
+export function effectiveAudioModelKey(
+  breakdown: AudioEngineBreakdown,
+  requestModelKey: TtsModelKey,
+): TtsModelKey {
+  const engines = Object.keys(breakdown) as TtsEngine[];
+  return engines.length === 1
+    ? canonicalModelKeyForEngine(engines[0], requestModelKey)
+    : requestModelKey;
+}

--- a/server/src/audio/finalize-chapter-write.test.ts
+++ b/server/src/audio/finalize-chapter-write.test.ts
@@ -122,3 +122,57 @@ describe('finalizeChapterAudioWrite onEncoded', () => {
     expect(existsSync(join(audioRoot, `${SLUG}.mp3`))).toBe(true);
   });
 });
+
+describe('finalizeChapterAudioWrite engine stamp (false-drift fix)', () => {
+  const readChapter = async () => {
+    const { readJson } = await import('../workspace/state-io.js');
+    const state = await readJson<{ chapters: Array<Record<string, unknown>> }>(
+      join(bookDir, '.audiobook', 'state.json'),
+    );
+    return state!.chapters.find((c) => c.id === 1)!;
+  };
+
+  it('stamps the ACTUAL rendered engine, not the request default, for a uniform chapter', async () => {
+    // Narrator-only chapter whose narrator renders on Qwen (per-character
+    // engine), regenerated while the project default + request is Kokoro.
+    const pcm = tone(1.0, 12000);
+    const { audioModelKey } = await finalizeChapterAudioWrite({
+      ...baseInput(),
+      pcm,
+      segments: [
+        { groupIndex: 0, characterId: 'narrator', sentenceIds: [1], startSec: 0, endSec: 1.0 },
+      ],
+      cast: [{ id: 'narrator', name: 'Narrator', gender: 'neutral', attributes: [], ttsEngine: 'qwen' }],
+      defaultEngine: 'kokoro',
+      modelKey: 'kokoro-v1',
+    });
+
+    expect(audioModelKey).toBe('qwen3-tts-0.6b');
+    const ch = await readChapter();
+    expect(ch.audioModelKey).toBe('qwen3-tts-0.6b');
+    expect(ch.audioEngines).toEqual({ qwen: 1 });
+  });
+
+  it('records the per-engine breakdown and keeps the request key for a mixed chapter', async () => {
+    const pcm = tone(1.0, 12000);
+    const { audioModelKey } = await finalizeChapterAudioWrite({
+      ...baseInput(),
+      pcm,
+      segments: [
+        { groupIndex: 0, characterId: 'narrator', sentenceIds: [1], startSec: 0, endSec: 0.5 },
+        { groupIndex: 1, characterId: 'sophie', sentenceIds: [2], startSec: 0.5, endSec: 1.0 },
+      ],
+      cast: [
+        { id: 'narrator', name: 'Narrator', gender: 'neutral', attributes: [] },
+        { id: 'sophie', name: 'Sophie', gender: 'female', attributes: [], ttsEngine: 'qwen' },
+      ],
+      defaultEngine: 'kokoro',
+      modelKey: 'kokoro-v1',
+    });
+
+    expect(audioModelKey).toBe('kokoro-v1');
+    const ch = await readChapter();
+    expect(ch.audioModelKey).toBe('kokoro-v1');
+    expect(ch.audioEngines).toEqual({ kokoro: 1, qwen: 1 });
+  });
+});

--- a/server/src/audio/finalize-chapter-write.ts
+++ b/server/src/audio/finalize-chapter-write.ts
@@ -31,6 +31,11 @@ import { evaluateChapterQa, type ChapterQaVerdict } from '../tts/audio-qa.js';
 import type { ChapterSegment, CastCharacter } from '../tts/synthesise-chapter.js';
 import type { TtsEngine, TtsModelKey } from '../tts/index.js';
 import { buildCharacterSnapshots } from './character-snapshots.js';
+import {
+  engineBreakdownFromSnapshots,
+  effectiveAudioModelKey,
+  type AudioEngineBreakdown,
+} from './engine-breakdown.js';
 import type { CharacterSnapshot } from './segments-io.js';
 
 /** Strict on-disk shape of `<slug>.segments.json` (the write view; the loose
@@ -77,6 +82,13 @@ export interface FinalizeChapterAudioResult {
   durationSec: number;
   audioQa: ChapterQaVerdict;
   segmentCount: number;
+  /** Chapter-wide drift stamp: the engine the audio ACTUALLY rendered in
+      (per-character routing aware), not necessarily the request `modelKey`.
+      The generation route puts this on the `chapter_complete` SSE tick. */
+  audioModelKey: TtsModelKey;
+  /** Distinct speaking characters per engine they rendered in. Drives the
+      mixed-engine "Kokoro (1), Qwen (6)" caption. */
+  audioEngines: AudioEngineBreakdown;
 }
 
 export async function finalizeChapterAudioWrite(
@@ -155,6 +167,15 @@ export async function finalizeChapterAudioWrite(
   }
   const characterSnapshots = buildCharacterSnapshots(cast, speakingIds, defaultEngine, fallbackByChar);
 
+  /* Drift stamp from the ACTUAL render, not the request default (false-drift
+     fix, 2026-06-07). The breakdown counts the speaking characters per engine
+     they rendered in; the stamp collapses to the single engine's canonical key
+     when uniform (so a narrator-on-Qwen chapter regenerated under a Kokoro
+     default stamps Qwen, clearing the false badge), else keeps the request key
+     and lets the breakdown carry the mixed-engine detail. */
+  const audioEngines = engineBreakdownFromSnapshots(characterSnapshots);
+  const effectiveModelKey = effectiveAudioModelKey(audioEngines, modelKey);
+
   const segmentsFile: ChapterSegmentsFile = {
     bookId,
     chapterId: chapter.id,
@@ -195,7 +216,8 @@ export async function finalizeChapterAudioWrite(
           ? {
               ...c,
               duration: formatted,
-              audioModelKey: modelKey,
+              audioModelKey: effectiveModelKey,
+              audioEngines,
               audioRenderedAt: segmentsFile.synthesizedAt,
               audioQa,
               generationState: undefined,
@@ -210,5 +232,11 @@ export async function finalizeChapterAudioWrite(
     await writeJsonAtomic(statePath, stampStateSchema(next));
   }
 
-  return { durationSec, audioQa, segmentCount: segments.length };
+  return {
+    durationSec,
+    audioQa,
+    segmentCount: segments.length,
+    audioModelKey: effectiveModelKey,
+    audioEngines,
+  };
 }

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -45,6 +45,7 @@ import { chapterAudioExists } from '../workspace/chapter-audio-file.js';
 import { loadAnalysisCache } from '../store/analysis-cache.js';
 import { rebuildCacheFromEdits } from '../store/analysis-cache-rebuild.js';
 import {
+  canonicalModelKeyForEngine,
   engineForModelKey,
   isTtsModelKey,
   selectTtsProvider,
@@ -548,27 +549,14 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
      bespoke character on Qwen, …). Build a per-engine provider cache — the
      default engine reuses the request's provider/modelKey — so
      `synthesiseChapter` routes each character to its own engine's provider
-     without reconstructing it per group. */
-  const canonicalModelKeyForEngine = (e: TtsEngine): TtsModelKey => {
-    switch (e) {
-      case 'kokoro':
-        return 'kokoro-v1';
-      case 'qwen':
-        return 'qwen3-tts-0.6b';
-      case 'coqui':
-        return 'coqui-xtts-v2';
-      case 'piper':
-        return 'piper-en-us-medium';
-      case 'gemini':
-        return modelKey.startsWith('gemini-') ? modelKey : 'gemini-2.5-flash';
-    }
-  };
+     without reconstructing it per group. Canonical engine→key mapping is the
+     shared `canonicalModelKeyForEngine` (also drives the drift stamp). */
   const providerCache = new Map<TtsEngine, { provider: TtsProvider; modelKey: TtsModelKey }>();
   providerCache.set(engine, { provider, modelKey });
   const resolveForEngine = (e: TtsEngine): { provider: TtsProvider; modelKey: TtsModelKey } => {
     const cached = providerCache.get(e);
     if (cached) return cached;
-    const mk = canonicalModelKeyForEngine(e);
+    const mk = canonicalModelKeyForEngine(e, modelKey);
     const built = { provider: selectTtsProvider(mk), modelKey: mk };
     providerCache.set(e, built);
     return built;
@@ -1340,7 +1328,11 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
          no-progress watchdog bump right after the long encode step, exactly
          where the inlined `bumpProgress()` used to sit. expectedSec carries the
          same char-derived QA estimate as before (srv-27). */
-      const { audioQa } = await finalizeChapterAudioWrite({
+      const {
+        audioQa,
+        audioModelKey: renderedModelKey,
+        audioEngines,
+      } = await finalizeChapterAudioWrite({
         bookId,
         bookDir,
         chapter: { id: chapter.id, slug: chapter.slug, title: chapter.title },
@@ -1452,7 +1444,12 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
         progress: 1,
         currentLine: totalLines,
         totalLines,
-        audioModelKey: modelKey,
+        /* The engine the audio ACTUALLY rendered in (per-character routing,
+           plan 108), not the request default — so a narrator-on-Qwen chapter
+           regenerated under a Kokoro default doesn't flash a false Kokoro
+           drift badge (false-drift fix, 2026-06-07). */
+        audioModelKey: renderedModelKey,
+        audioEngines,
         /* Belt-and-suspenders with the assembling tick (see line 616).
            The assembling tick is the primary carrier, but it can be missed
            when the page is hidden / the cross-book guard drops it / a

--- a/server/src/tts/model-keys.ts
+++ b/server/src/tts/model-keys.ts
@@ -69,6 +69,30 @@ export function engineForModelKey(key: TtsModelKey): TtsEngine {
   return 'gemini';
 }
 
+/* The canonical model key for an engine — the inverse of `engineForModelKey`.
+   Gemini has two UI-stable variants, so its canonical key is whichever Gemini
+   key the run requested (falling back to 2.5 when the request wasn't Gemini).
+   Used to stamp a chapter's `audioModelKey` with the engine the audio ACTUALLY
+   rendered in (per-character routing, plan 108) rather than the request default
+   (the false-drift fix, 2026-06-07). */
+export function canonicalModelKeyForEngine(
+  engine: TtsEngine,
+  requestModelKey: TtsModelKey,
+): TtsModelKey {
+  switch (engine) {
+    case 'kokoro':
+      return 'kokoro-v1';
+    case 'qwen':
+      return 'qwen3-tts-0.6b';
+    case 'coqui':
+      return 'coqui-xtts-v2';
+    case 'piper':
+      return 'piper-en-us-medium';
+    case 'gemini':
+      return requestModelKey.startsWith('gemini-') ? requestModelKey : 'gemini-2.5-flash';
+  }
+}
+
 /* For sidecar requests, derive the engine-side model id from the namespaced
    key. `coqui-xtts-v2` → `xtts_v2`, `piper-en-us-medium` → `en-us-medium`. */
 export function sidecarModelId(key: TtsModelKey): string {

--- a/server/src/workspace/scan.ts
+++ b/server/src/workspace/scan.ts
@@ -21,6 +21,7 @@ import { readStateJsonWithRecovery, writeStateJsonAtomic } from './state-migrate
 import { ensureChapterUuids } from './chapter-uuid.js';
 import { loadAnalysisCache } from '../store/analysis-cache.js';
 import { formatDuration } from '../audio/format-duration.js';
+import { engineBreakdownFromSnapshots } from '../audio/engine-breakdown.js';
 import { normaliseBookLanguage } from '../tts/language.js';
 
 export type LibraryBookStatus =
@@ -71,6 +72,12 @@ export interface BookStateJson {
         engine than the project's current `ui.ttsModelKey`. Optional so
         unrendered chapters and very old state.json files load cleanly. */
     audioModelKey?: string;
+    /** Distinct speaking characters per TTS engine they ACTUALLY rendered in
+        (per-character routing, plan 108). Stamped on render and backfilled
+        from segments `characterSnapshots` on scan. Drives the mixed-engine
+        "Kokoro (1), Qwen (6)" caption; for a uniform chapter it has one key
+        matching `audioModelKey`'s engine. Optional for legacy/unrendered. */
+    audioEngines?: Record<string, number>;
     /** ISO timestamp when the audio was rendered. Mirrors segments file's
         `synthesizedAt`. Used as a tie-breaker for cast-drift detection
         (was the cast confirmed before or after the audio was made?). */
@@ -286,6 +293,9 @@ interface SegmentsJsonForScan {
   durationSec?: number;
   modelKey?: string;
   synthesizedAt?: string;
+  /** Per-character render snapshots — source for the `audioEngines` breakdown
+      backfill on chapters that pre-date that field (false-drift fix). */
+  characterSnapshots?: Record<string, { voiceEngine?: string; renderedFallbackEngine?: string }>;
 }
 
 function formatRuntime(totalSec: number): string {
@@ -762,12 +772,20 @@ export async function backfillAudioModelKeysFromSegments(
         typeof meta.durationSec === 'number' &&
         Number.isFinite(meta.durationSec) &&
         meta.durationSec > 0;
-      if (needsModelKey || needsRenderedAt || needsDuration) {
+      /* Engine breakdown backfill (false-drift fix). Recompute from the render
+         snapshots so a legacy chapter gains the mixed-engine detail. New field,
+         so a simple presence gate — never overwrites an existing breakdown. */
+      const breakdown = meta.characterSnapshots
+        ? engineBreakdownFromSnapshots(meta.characterSnapshots)
+        : {};
+      const needsEngines = !ch.audioEngines && Object.keys(breakdown).length > 0;
+      if (needsModelKey || needsRenderedAt || needsDuration || needsEngines) {
         next[i] = {
           ...ch,
           ...(needsModelKey ? { audioModelKey: meta.modelKey } : {}),
           ...(needsRenderedAt ? { audioRenderedAt: meta.synthesizedAt } : {}),
           ...(needsDuration ? { duration: formatDuration(meta.durationSec as number) } : {}),
+          ...(needsEngines ? { audioEngines: breakdown } : {}),
         };
         backfillNeeded = true;
       }

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -2495,11 +2495,22 @@ export interface components {
              *     this chapter's audio. Carries the engine forward so the
              *     frontend can update `chapter.audioModelKey` without waiting
              *     for a state.json reload (which would otherwise let an
-             *     engine-drift badge appear only after page navigation). See
-             *     `docs/features/archive/35-engine-drift-detection.md`.
+             *     engine-drift badge appear only after page navigation). With
+             *     per-character engine routing (plan 108) this is the engine the
+             *     audio ACTUALLY rendered in, not necessarily the request default.
+             *     See `docs/features/archive/35-engine-drift-detection.md`.
              * @enum {string}
              */
             audioModelKey?: "kokoro-v1" | "qwen3-tts-0.6b" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
+            /**
+             * @description Only on `chapter_complete` — distinct speaking characters per TTS
+             *     engine they actually rendered in (e.g. `{ "kokoro": 1, "qwen": 6 }`).
+             *     Carries the mixed-engine breakdown forward so the frontend can show
+             *     the per-engine voice-count caption without a state.json reload.
+             */
+            audioEngines?: {
+                [key: string]: number;
+            };
             /**
              * @description srv-27 — Only on `chapter_complete` — the advisory post-synthesis
              *     QA verdict, so the frontend can stamp a "Suspect" badge the moment
@@ -3238,10 +3249,25 @@ export interface components {
              *     segments file for legacy chapters. Absent on never-rendered
              *     chapters. The frontend compares against the project's
              *     current `ui.ttsModelKey` to surface engine-drift badges (see
-             *     `docs/features/archive/35-engine-drift-detection.md`).
+             *     `docs/features/archive/35-engine-drift-detection.md`). With
+             *     per-character engine routing (plan 108) this reflects the engine
+             *     the audio actually rendered in (a uniform chapter), not the
+             *     request default.
              * @enum {string}
              */
             audioModelKey?: "kokoro-v1" | "qwen3-tts-0.6b" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
+            /**
+             * @description Distinct speaking characters per TTS engine they actually rendered
+             *     in, e.g. `{ "kokoro": 1, "qwen": 6 }`. For a uniform chapter it has
+             *     one key matching `audioModelKey`'s engine; a chapter that mixes
+             *     engines (narrator on Kokoro + dialogue on Qwen) carries the full
+             *     breakdown, which the Generation view shows as a per-engine
+             *     voice-count caption instead of a drift badge. Stamped at render
+             *     time, backfilled from the segments file for legacy chapters.
+             */
+            audioEngines?: {
+                [key: string]: number;
+            };
             /**
              * Format: date-time
              * @description ISO timestamp from when the audio was synthesised. Mirrors

--- a/src/lib/tts-models.test.ts
+++ b/src/lib/tts-models.test.ts
@@ -5,7 +5,23 @@ import {
   ttsModelLabel,
   engineForModelKey,
   engineGroupForModelKey,
+  formatEngineBreakdown,
 } from './tts-models';
+
+describe('formatEngineBreakdown (mixed-engine chapter caption)', () => {
+  it('renders one engine with its voice count', () => {
+    expect(formatEngineBreakdown({ qwen: 1 })).toBe('Qwen (1)');
+  });
+
+  it('renders a mixed breakdown alphabetically by engine label', () => {
+    expect(formatEngineBreakdown({ qwen: 6, kokoro: 1 })).toBe('Kokoro (1), Qwen (6)');
+  });
+
+  it('returns an empty string for an empty or missing breakdown', () => {
+    expect(formatEngineBreakdown({})).toBe('');
+    expect(formatEngineBreakdown(undefined)).toBe('');
+  });
+});
 
 describe('tts-models catalog includes Qwen3-TTS (plan 108)', () => {
   it('lists qwen3-tts-0.6b under the Local engine group (so it shows in the model dropdowns)', () => {

--- a/src/lib/tts-models.ts
+++ b/src/lib/tts-models.ts
@@ -66,6 +66,27 @@ export function ttsModelLabel(key: TtsModelKey): string {
   return TTS_MODEL_OPTIONS.find((m) => m.id === key)?.label ?? key;
 }
 
+/* Short, engine-level labels (not model-level) for the mixed-engine chapter
+   caption — "Kokoro (1), Qwen (6)". The model labels ("Kokoro v1") are too long
+   to repeat per engine in a compact row caption. */
+const TTS_ENGINE_LABELS: Record<string, string> = {
+  kokoro: 'Kokoro',
+  qwen: 'Qwen',
+  coqui: 'Coqui',
+  gemini: 'Gemini',
+  piper: 'Piper',
+};
+
+/** Format a per-engine voice-count breakdown as "Kokoro (1), Qwen (6)", sorted
+    alphabetically by engine label for stable display. Empty/missing → ''. */
+export function formatEngineBreakdown(breakdown?: Record<string, number>): string {
+  if (!breakdown) return '';
+  return Object.entries(breakdown)
+    .map(([engine, count]) => `${TTS_ENGINE_LABELS[engine] ?? engine} (${count})`)
+    .sort((a, b) => a.localeCompare(b))
+    .join(', ');
+}
+
 import { FRONTEND_ACCOUNT_DEFAULTS } from './account-defaults';
 
 /* Single source of truth for the frontend's TTS default — mirrors server's

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -252,6 +252,12 @@ export interface BookStateJson {
         type (`server/src/workspace/scan.ts`). Drives the engine-drift
         badge per plan 35. */
     audioModelKey?: TtsModelKey;
+    /** Distinct speaking characters per TTS engine they rendered in
+        (per-character routing, plan 108). One key on a uniform chapter;
+        the full breakdown on a mixed-engine chapter, which the Generation
+        view shows as a "Kokoro (1), Qwen (6)" caption. Mirror of the
+        server's BookStateJson type. */
+    audioEngines?: Partial<Record<TtsEngine, number>>;
     /** ISO timestamp when the audio was synthesised; mirrors the
         segments file's `synthesizedAt`. */
     audioRenderedAt?: string;

--- a/src/store/chapters-slice.ts
+++ b/src/store/chapters-slice.ts
@@ -304,6 +304,10 @@ export const chaptersSlice = createSlice({
            current ui.ttsModelKey. Absent on unrendered chapters; the
            server backfills it from segments.json for legacy chapters. */
             audioModelKey: c.audioModelKey,
+            /* Per-engine voice-count breakdown (false-drift fix). One key on a
+               uniform chapter, the full map on a mixed-engine chapter — drives
+               the "Kokoro (1), Qwen (6)" caption. */
+            audioEngines: c.audioEngines,
             audioRenderedAt: c.audioRenderedAt,
             /* Plan 77 — per-chapter EBU R128 loudness sidecar (plan 71)
            hydrated from the book-state response. `null` entry = sidecar
@@ -433,6 +437,9 @@ export const chaptersSlice = createSlice({
            is tolerated (older server before this field landed) — the
            chapter stays at its previously-hydrated value. */
         if (ev.audioModelKey) ch.audioModelKey = ev.audioModelKey;
+        /* Carry the per-engine breakdown so a mixed-engine chapter's caption
+           (or a corrected uniform stamp) is right the instant Done flips. */
+        if (ev.audioEngines) ch.audioEngines = ev.audioEngines;
         /* srv-27 — stamp the advisory QA verdict so the "Suspect" badge can
            appear the moment the Done pill flips, without a state.json reload.
            Absent on an older server → leave the hydrated value. */

--- a/src/views/generation.test.tsx
+++ b/src/views/generation.test.tsx
@@ -995,6 +995,31 @@ describe('GenerationView — engine drift detection (plan 35)', () => {
     expect(screen.getByText(/1 chapter generated with a different engine/i)).toBeTruthy();
   });
 
+  it('shows a per-engine voice-count caption (not a drift warning) for a mixed-engine chapter', () => {
+    /* False-drift fix: a chapter whose voices span engines (narrator on
+       Kokoro + dialogue on Qwen) is intentional, not drift. Show the
+       breakdown instead of the amber "Generated with X" warning, even when
+       its stamped audioModelKey differs from the active engine. */
+    const mixed: Chapter = {
+      ...chapter1,
+      audioModelKey: 'kokoro-v1',
+      audioEngines: { kokoro: 1, qwen: 6 },
+    };
+    renderWithChapters([mixed, chapter2], 'coqui-xtts-v2');
+    expect(screen.getByText(/Kokoro \(1\), Qwen \(6\)/)).toBeTruthy();
+    expect(screen.queryByText(/Generated with .* · current engine is/i)).toBeNull();
+  });
+
+  it('a mixed-engine chapter does not contribute to the top-of-view drift banner', () => {
+    const mixed: Chapter = {
+      ...chapter1,
+      audioModelKey: 'kokoro-v1',
+      audioEngines: { kokoro: 1, qwen: 6 },
+    };
+    renderWithChapters([mixed, chapter2], 'coqui-xtts-v2');
+    expect(screen.queryByText(/generated with a different engine/i)).toBeNull();
+  });
+
   it('chapters with no audioModelKey stamp (legacy / never-rendered) do not contribute drift signal', () => {
     /* Unstamped done chapter: silent. The opportunistic backfill runs
        on the server; until it lands we don't nag the user. */

--- a/src/views/generation.tsx
+++ b/src/views/generation.tsx
@@ -54,7 +54,7 @@ import { useLocalAnalyzerGuard } from '../hooks/use-local-analyzer-guard';
 import { useReverseLocalAnalyzerGuard } from '../hooks/use-reverse-local-analyzer-guard';
 import { ANALYSIS_PHASES } from '../data/analysis-phases';
 import { MODEL_OPTIONS } from '../lib/models';
-import { ttsModelLabel } from '../lib/tts-models';
+import { ttsModelLabel, formatEngineBreakdown } from '../lib/tts-models';
 import { parseDuration, formatTime } from '../lib/time';
 import { CHAR_COLORS } from '../lib/colors';
 import { stripChapterPrefix } from '../lib/format-chapter-title';
@@ -84,6 +84,14 @@ const ACTIVITY_FEED_TYPES: ChangeLogEvent['type'][] = [
   'chapter_failed',
   'generation_started',
 ];
+
+/* A chapter whose voices span more than one TTS engine (e.g. narrator on
+   Kokoro + dialogue on Qwen, per-character routing plan 108). Such a chapter
+   can't be reduced to a single drift comparison, so the row shows a per-engine
+   voice-count breakdown instead of a drift warning (false-drift fix). */
+function isMixedEngineChapter(chapter: Chapter): boolean {
+  return Object.keys(chapter.audioEngines ?? {}).length > 1;
+}
 
 /* Transient per-chapter state for an in-flight "Include in book" subset
    analysis. Lives only while the SSE is streaming — drops on success,
@@ -610,7 +618,15 @@ export function GenerationView({
   const driftedChapters = useMemo(
     () =>
       activeChapters.filter(
-        (c) => c.state === 'done' && c.audioModelKey != null && c.audioModelKey !== modelKey,
+        (c) =>
+          c.state === 'done' &&
+          c.audioModelKey != null &&
+          c.audioModelKey !== modelKey &&
+          /* A genuinely mixed-engine chapter (narrator on Kokoro + dialogue on
+             Qwen) is intentional, not drift — it shows a per-engine breakdown
+             caption instead, and must not inflate the drift banner/bulk-regen
+             (false-drift fix, 2026-06-07). */
+          !isMixedEngineChapter(c),
       ),
     [activeChapters, modelKey],
   );
@@ -1319,6 +1335,17 @@ function ChapterRow({
             <span className="block text-[11px] text-magenta tabular-nums mt-0.5 truncate">
               {liveSpeaker ? `Synthesising ${liveSpeaker.name} · ` : ''}
               line {liveCurrent.toLocaleString()} of {liveTotal.toLocaleString()}
+            </span>
+          ) : chapter.state === 'done' && isMixedEngineChapter(chapter) ? (
+            /* Mixed-engine breakdown caption (false-drift fix, 2026-06-07).
+               A chapter whose voices span engines (narrator on Kokoro +
+               dialogue on Qwen) is intentional, not drift — show the per-engine
+               voice count instead of an amber warning. */
+            <span
+              className="block text-[11px] text-ink/50 tabular-nums mt-0.5 truncate"
+              title={`Voices rendered across ${formatEngineBreakdown(chapter.audioEngines)}.`}
+            >
+              Voices: {formatEngineBreakdown(chapter.audioEngines)}
             </span>
           ) : chapter.state === 'done' &&
             chapter.audioModelKey &&


### PR DESCRIPTION
Closes #605

## Summary

Fixes a **false engine-drift badge**: two narration-only chapters (Unlocked CH12/13) showed "⚠ Generated with Kokoro v1 · current engine is Qwen" even though their audio rendered on **Qwen**. The user's ear was right — only the metadata stamp lied.

**Root cause:** Plan 35 (chapter-wide engine-drift detection) predated plan 108 (per-character engine routing). `finalize-chapter-write.ts` stamped `state.json.audioModelKey` with the generation request's **default** engine, not the engine the audio actually rendered in. A chapter whose narrator carries `ttsEngine: 'qwen'`, regenerated while the project default was Kokoro, rendered 100% on Qwen (per-character override) but stamped `kokoro-v1`. The render-time `characterSnapshots` (`voiceEngine: 'qwen'`, no fallback) proved the contradiction.

**Fix:**
- `server/src/audio/engine-breakdown.ts` (pure): `engineBreakdownFromSnapshots` + `effectiveAudioModelKey`. Shared `canonicalModelKeyForEngine` added to `model-keys.ts` (replaces generation.ts's local copy).
- `finalize-chapter-write` stamps the **effective** engine + a new per-chapter `audioEngines` breakdown; returns both; `generation.ts` carries them on the `chapter_complete` SSE tick. Plumbed through openapi → api-types → types → chapters-slice, and lazy-backfilled from `characterSnapshots` in `scan.ts`.
- **Mixed-engine chapters** (narrator on Kokoro + dialogue on Qwen) now show a neutral **"Voices: Kokoro (1), Qwen (6)"** caption instead of a drift warning, and are excluded from the drift banner / bulk-regen. Uniform chapters keep the amber caption, now driven by the corrected stamp.
- `scripts/repair-audio-engine-stamp.mjs` (dry-run default, `--apply`) corrects existing wrong stamps + backfills `audioEngines`. **Already run `--apply` on the live workspace**: corrected 2 stamps (CH12/13 → `qwen3-tts-0.6b`), set 355 breakdowns library-wide (`.bak` written).
- Plan 35 archive doc updated (invariant 1 + per-character reconciliation section A–D).

## Test plan

- TDD'd unit + integration tests, each watched fail before implementing:
  - `engine-breakdown.test.ts` — breakdown (uniform / mixed / fallback / empty) + effective-key.
  - `finalize-chapter-write.test.ts` — uniform chapter stamps actual engine; mixed chapter records breakdown + keeps request key.
  - `tts-models.test.ts` — `formatEngineBreakdown` rendering/ordering.
  - `generation.test.tsx` — mixed-engine chapter shows the "Voices:" caption, no drift caption, not in the drift banner.
- `npm run verify` — **green** (typecheck + all tests + e2e + visual + build, exit 0).

**Owed:** live-GPU acceptance — regenerate a chapter on the real sidecar and confirm a narrator-on-Qwen chapter stamps `qwen3-tts-0.6b` with no false badge, and a genuinely mixed chapter shows the breakdown caption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)