### PR TITLE
feat(app): per-chapter waveform in the player

### DIFF
--- a/apps/android/lib/src/data/api_client.dart
+++ b/apps/android/lib/src/data/api_client.dart
@@ -95,6 +95,21 @@ class ApiClient {
     return out;
   }
 
+  /// Per-chapter waveform peaks (240 normalized RMS bins) from the existing
+  /// chapter-audio meta endpoint. Empty list when absent/unreachable.
+  Future<List<double>> getChapterPeaks(String bookId, int chapterId) async {
+    try {
+      final j = await getJson('/api/books/$bookId/chapters/$chapterId/audio');
+      final raw = j['peaks'];
+      if (raw is List) {
+        return [for (final e in raw) (e as num).toDouble()];
+      }
+    } on ApiException {
+      /* no audio meta / offline → no waveform */
+    }
+    return const [];
+  }
+
   /// GET the server resume bookmark; null when the server has none (404).
   Future<RemoteProgress?> getListenProgress(String bookId) async {
     try {

--- a/apps/android/lib/src/domain/waveform.dart
+++ b/apps/android/lib/src/domain/waveform.dart
@@ -1,0 +1,32 @@
+/// Pure waveform reduction for the player's chapter waveform. The server
+/// serves 240 normalized RMS bins per chapter (`GET …/chapters/:id/audio`
+/// `peaks`); the UI resamples them to however many bars fit the width.
+library;
+
+/// Downsample [peaks] to [bars] bars by windowed max, then normalize so the
+/// loudest bar is 1.0 (a quiet chapter still shows a readable shape). Returns
+/// all-zero bars for empty input, and an empty list for a non-positive count.
+List<double> resamplePeaks(List<double> peaks, int bars) {
+  if (bars <= 0) return const [];
+  final out = List<double>.filled(bars, 0.0);
+  if (peaks.isEmpty) return out;
+  for (var i = 0; i < bars; i++) {
+    final start = (i * peaks.length / bars).floor();
+    var end = ((i + 1) * peaks.length / bars).floor();
+    if (end <= start) end = start + 1;
+    if (end > peaks.length) end = peaks.length;
+    var maxV = 0.0;
+    for (var j = start; j < end; j++) {
+      final v = peaks[j].abs();
+      if (v > maxV) maxV = v;
+    }
+    out[i] = maxV;
+  }
+  final peak = out.fold<double>(0, (m, v) => v > m ? v : m);
+  if (peak > 0) {
+    for (var i = 0; i < bars; i++) {
+      out[i] = out[i] / peak;
+    }
+  }
+  return out;
+}

--- a/apps/android/lib/src/ui/player_screen.dart
+++ b/apps/android/lib/src/ui/player_screen.dart
@@ -4,6 +4,7 @@ import '../data/companion_runtime.dart';
 import '../data/player_controller.dart';
 import '../domain/listen_progress.dart';
 import '../domain/sync_manifest.dart';
+import 'waveform_bar.dart';
 
 /// Player surface: a chapter picker + transport controls over the
 /// [PlayerController]. Pick a chapter to start listening; the position ticks
@@ -29,6 +30,21 @@ class _PlayerScreenState extends State<PlayerScreen> {
   bool _playing = false;
   String? _error;
   List<SyncManifestChapter> _chapters = const [];
+  final Map<String, List<double>> _peaks = {}; // chapter uuid -> RMS peaks
+
+  /// Fetch + cache a chapter's waveform peaks (best-effort; needs the server).
+  Future<void> _ensurePeaks(String uuid, int chapterId) async {
+    if (_peaks.containsKey(uuid)) return;
+    final peaks = await widget.runtime.api.getChapterPeaks(widget.bookId, chapterId);
+    if (peaks.isNotEmpty && mounted) setState(() => _peaks[uuid] = peaks);
+  }
+
+  void _ensureCurrentPeaks() {
+    final uuid = widget.runtime.player.currentChapterUuid;
+    if (uuid == null) return;
+    final ch = _chapters.where((c) => c.uuid == uuid);
+    if (ch.isNotEmpty) _ensurePeaks(uuid, ch.first.id);
+  }
 
   @override
   void initState() {
@@ -45,6 +61,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
           _chapters = widget.runtime.sync.chaptersOf(widget.bookId);
           _ready = true;
         });
+        _ensureCurrentPeaks();
       }
     } catch (e) {
       if (mounted) setState(() => _error = '$e');
@@ -60,6 +77,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
   Future<void> _playChapter(String uuid) async {
     await widget.runtime.player.playChapter(uuid);
     if (mounted) setState(() => _playing = true);
+    _ensureCurrentPeaks();
   }
 
   Future<void> _togglePlay() async {
@@ -154,15 +172,35 @@ class _PlayerScreenState extends State<PlayerScreen> {
                 return Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    Slider(
-                      key: const Key('player-progress'),
-                      value: v,
-                      max: maxMs > 0 ? maxMs.toDouble() : 1.0,
-                      onChanged: maxMs > 0
-                          ? (x) => player
-                              .seekTo(Duration(milliseconds: x.round()))
-                          : null,
-                    ),
+                    Builder(builder: (context) {
+                      final uuid = player.currentChapterUuid;
+                      final peaks = uuid != null ? _peaks[uuid] : null;
+                      final progress = maxMs > 0
+                          ? pos.inMilliseconds / maxMs
+                          : 0.0;
+                      if (peaks != null && peaks.isNotEmpty) {
+                        return Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 12),
+                          child: WaveformBar(
+                            peaks: peaks,
+                            progress: progress,
+                            onSeek: maxMs > 0
+                                ? (f) => player.seekTo(
+                                    Duration(milliseconds: (f * maxMs).round()))
+                                : null,
+                          ),
+                        );
+                      }
+                      return Slider(
+                        key: const Key('player-progress'),
+                        value: v,
+                        max: maxMs > 0 ? maxMs.toDouble() : 1.0,
+                        onChanged: maxMs > 0
+                            ? (x) => player
+                                .seekTo(Duration(milliseconds: x.round()))
+                            : null,
+                      );
+                    }),
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 16),
                       child: Row(

--- a/apps/android/lib/src/ui/waveform_bar.dart
+++ b/apps/android/lib/src/ui/waveform_bar.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+import '../domain/waveform.dart';
+
+/// A chapter waveform: resamples the server's RMS peaks to fit the width,
+/// tints the played portion, and seeks on tap/drag. Falls back to nothing
+/// when there are no peaks (caller decides what to show instead).
+class WaveformBar extends StatelessWidget {
+  const WaveformBar({
+    super.key,
+    required this.peaks,
+    required this.progress,
+    this.onSeek,
+    this.height = 48,
+  });
+
+  final List<double> peaks;
+  final double progress; // 0..1
+  final ValueChanged<double>? onSeek; // fraction 0..1
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        final bars = (width / 3).floor().clamp(1, 512);
+        final resampled = resamplePeaks(peaks, bars);
+        void seek(double dx) =>
+            onSeek?.call((dx / width).clamp(0.0, 1.0));
+        return GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTapDown: (d) => seek(d.localPosition.dx),
+          onHorizontalDragUpdate: (d) => seek(d.localPosition.dx),
+          child: CustomPaint(
+            size: Size(width, height),
+            painter: _WaveformPainter(
+              bars: resampled,
+              progress: progress.clamp(0.0, 1.0),
+              played: scheme.primary,
+              unplayed: scheme.outlineVariant,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _WaveformPainter extends CustomPainter {
+  _WaveformPainter({
+    required this.bars,
+    required this.progress,
+    required this.played,
+    required this.unplayed,
+  });
+
+  final List<double> bars;
+  final double progress;
+  final Color played;
+  final Color unplayed;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (bars.isEmpty) return;
+    final slot = size.width / bars.length;
+    final barW = (slot * 0.66).clamp(1.0, 4.0);
+    final mid = size.height / 2;
+    final playedPaint = Paint()..color = played..strokeCap = StrokeCap.round;
+    final unplayedPaint = Paint()..color = unplayed..strokeCap = StrokeCap.round;
+    final progressX = progress * size.width;
+    for (var i = 0; i < bars.length; i++) {
+      final x = i * slot + slot / 2;
+      final h = (bars[i] * (size.height - 2)).clamp(2.0, size.height);
+      final paint = (x <= progressX ? playedPaint : unplayedPaint)
+        ..strokeWidth = barW;
+      canvas.drawLine(Offset(x, mid - h / 2), Offset(x, mid + h / 2), paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_WaveformPainter old) =>
+      old.progress != progress ||
+      old.bars.length != bars.length ||
+      old.played != played;
+}

--- a/apps/android/test/domain/waveform_test.dart
+++ b/apps/android/test/domain/waveform_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:audiobook_companion/src/domain/waveform.dart';
+
+void main() {
+  group('resamplePeaks', () {
+    test('downsamples by windowed max and normalizes to [0,1]', () {
+      // 4 peaks → 2 bars: bar0=max(0,1)=1, bar1=max(0,0.5)=0.5, peak=1.
+      expect(resamplePeaks([0, 1, 0, 0.5], 2), [1.0, 0.5]);
+    });
+
+    test('normalizes a quiet chapter so the loudest bar fills', () {
+      // all small, max 0.2 → normalized so the peak becomes 1.
+      final r = resamplePeaks([0.1, 0.2, 0.05], 3);
+      expect(r.reduce((a, b) => a > b ? a : b), 1.0);
+    });
+
+    test('empty peaks → all-zero bars', () {
+      expect(resamplePeaks([], 4), [0.0, 0.0, 0.0, 0.0]);
+    });
+
+    test('more bars than samples does not crash and covers every bar', () {
+      final r = resamplePeaks([1, 0], 5);
+      expect(r.length, 5);
+      expect(r.every((v) => v >= 0 && v <= 1), isTrue);
+    });
+
+    test('non-positive bar count → empty', () {
+      expect(resamplePeaks([1, 2, 3], 0), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The server already serves 240-bin RMS peaks per chapter (plan 56: `GET /api/books/:id/chapters/:cid/audio` → `{ peaks }`), so **no server change** — just the renderer:

- `ApiClient.getChapterPeaks` fetches + parses peaks (graceful empty when offline).
- `domain/waveform.dart` `resamplePeaks` (pure, unit-tested): windowed-max downsample to fit width + normalize so the loudest bar fills.
- `ui/waveform_bar.dart`: a `CustomPainter` waveform that tints the played portion and seeks on tap/drag.
- `PlayerScreen` renders the current chapter's waveform (peaks cached per uuid) in place of the slider; falls back to the plain slider when peaks are unavailable.

## Test plan

`waveform` unit tests (resample math); 182 Dart tests green; `flutter analyze` clean.

Refs #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)