### PR TITLE
feat(app): offline mode — open + play the downloaded library when offline

### DIFF
--- a/apps/android/lib/main.dart
+++ b/apps/android/lib/main.dart
@@ -8,7 +8,9 @@ import 'src/ui/library_home_screen.dart';
 import 'src/ui/pairing_screen.dart';
 
 /// Audiobook Companion — the native listening client (plan 188). app-1 shell +
-/// app-2 pairing + the app-3..14 library / sync / player wired on top.
+/// app-2 pairing + the app-3..14 library / sync / player wired on top, with
+/// OFFLINE launch (the runtime is rebuilt from the stored cert — no network
+/// needed to open the downloaded library).
 void main() {
   runApp(AudiobookCompanionApp(store: SecurePairingStore()));
 }
@@ -49,31 +51,61 @@ class _HomePageState extends State<HomePage> {
   PairedServer? _paired;
   CompanionRuntime? _runtime;
   bool _loading = true;
-  String? _connError;
+
+  /// Legacy pairing with no stored cert — needs one online reconnect to
+  /// capture it before offline mode works.
+  String? _bootstrapError;
 
   @override
   void initState() {
     super.initState();
-    widget.store.load().then((p) async {
-      if (!mounted) return;
-      if (p == null) {
-        setState(() => _loading = false);
-        return;
-      }
-      _paired = p;
-      await _establish();
-    });
+    _boot();
   }
 
-  /// Re-establish the cert-pinned connection from stored credentials (re-fetch
-  /// + verify the CA, re-probe the token), then build the wired runtime.
-  Future<void> _establish() async {
+  Future<void> _boot() async {
+    final server = await widget.store.load();
+    if (!mounted) return;
+    if (server == null) {
+      setState(() => _loading = false);
+      return;
+    }
+    _paired = server;
+    final caPem = await widget.store.loadCaPem();
+    if (caPem == null || caPem.isEmpty) {
+      // Pre-offline pairing: must reconnect once to capture the cert.
+      await _bootstrapFromServer();
+      return;
+    }
+    // Offline-capable: rebuild the pinned runtime from stored creds, no network.
+    try {
+      final runtime = await CompanionRuntime.forConnection(
+          Connection(server: server, caPem: caPem));
+      if (mounted) {
+        setState(() {
+          _runtime = runtime;
+          _loading = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _bootstrapError = '$e';
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  /// One online round-trip to fetch + verify + persist the cert for a legacy
+  /// pairing, then build the runtime.
+  Future<void> _bootstrapFromServer() async {
     setState(() {
       _loading = true;
-      _connError = null;
+      _bootstrapError = null;
     });
     try {
       final conn = await widget.service.pair(_paired!);
+      await widget.store.saveCaPem(conn.caPem);
       final runtime = await CompanionRuntime.forConnection(conn);
       if (mounted) {
         setState(() {
@@ -84,7 +116,7 @@ class _HomePageState extends State<HomePage> {
     } catch (e) {
       if (mounted) {
         setState(() {
-          _connError = '$e';
+          _bootstrapError = '$e';
           _loading = false;
         });
       }
@@ -99,7 +131,7 @@ class _HomePageState extends State<HomePage> {
     );
     if (result != null && mounted) {
       _paired = result;
-      await _establish();
+      await _boot();
     }
   }
 
@@ -110,7 +142,7 @@ class _HomePageState extends State<HomePage> {
       setState(() {
         _runtime = null;
         _paired = null;
-        _connError = null;
+        _bootstrapError = null;
       });
     }
   }
@@ -137,6 +169,7 @@ class _HomePageState extends State<HomePage> {
       );
     }
     if (_runtime == null) {
+      // Legacy pairing, currently offline → can't open until we capture the cert.
       return Scaffold(
         appBar: AppBar(title: const Text('Audiobook Companion')),
         body: Center(
@@ -144,15 +177,25 @@ class _HomePageState extends State<HomePage> {
             mainAxisSize: MainAxisSize.min,
             children: [
               Text('Paired with ${_paired!.url}', key: const Key('home-status')),
-              const SizedBox(height: 8),
-              if (_connError != null)
-                Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Text("Couldn't reach the server:\n$_connError",
-                      textAlign: TextAlign.center),
+              const Padding(
+                padding: EdgeInsets.all(16),
+                child: Text(
+                  'Connect to the server once to enable offline playback.',
+                  textAlign: TextAlign.center,
                 ),
+              ),
+              if (_bootstrapError != null)
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: Text(_bootstrapError!,
+                      textAlign: TextAlign.center,
+                      style:
+                          TextStyle(color: Theme.of(context).colorScheme.error)),
+                ),
+              const SizedBox(height: 12),
               Wrap(spacing: 12, children: [
-                FilledButton(onPressed: _establish, child: const Text('Retry')),
+                FilledButton(
+                    onPressed: _bootstrapFromServer, child: const Text('Connect')),
                 OutlinedButton(onPressed: _unpair, child: const Text('Unpair')),
               ]),
             ],

--- a/apps/android/lib/src/data/drift_local_library.dart
+++ b/apps/android/lib/src/data/drift_local_library.dart
@@ -29,6 +29,22 @@ class BookSummary {
   final String? coverThumbPath;
 }
 
+/// A locally-stored chapter (the offline source for the player + durations).
+class DownloadedChapter {
+  const DownloadedChapter({
+    required this.uuid,
+    required this.chapterId,
+    required this.title,
+    required this.durationSec,
+    required this.urlSuffix,
+  });
+  final String uuid;
+  final int chapterId;
+  final String title;
+  final double? durationSec;
+  final String? urlSuffix;
+}
+
 /// The production on-device store (`app-4`): a drift/SQLite-backed
 /// [LocalLibrary] (so the `app-3` sync engine runs against it unchanged) plus
 /// storage accounting, the eviction-plan applier, play/finished tracking, cover
@@ -104,6 +120,69 @@ class DriftLocalLibrary implements LocalLibrary, PlaybackStore, ThumbnailStore {
         ),
       );
     }
+  }
+
+  /// Like [recordChapter] but also persists chapter id/title/duration from the
+  /// manifest detail, so the player + library work OFFLINE. Preserves the
+  /// `finished` flag on re-download.
+  Future<void> recordChapterMeta({
+    required String bookId,
+    required String uuid,
+    required int chapterId,
+    required String title,
+    required String fingerprint,
+    required String urlSuffix,
+    double? durationSec,
+  }) async {
+    await _ensureBook(bookId);
+    final size = await _fs.size(audioPath(bookId, uuid, urlSuffix));
+    final bytes = size < 0 ? 0 : size;
+    final existing = await (_db.select(_db.chapters)
+          ..where((c) => c.uuid.equals(uuid)))
+        .getSingleOrNull();
+    if (existing == null) {
+      await _db.into(_db.chapters).insert(ChaptersCompanion.insert(
+            uuid: uuid,
+            bookId: bookId,
+            chapterId: chapterId,
+            title: Value(title),
+            fingerprint: Value(fingerprint),
+            urlSuffix: Value(urlSuffix),
+            bytes: Value(bytes),
+            durationSec: Value(durationSec),
+          ));
+    } else {
+      await (_db.update(_db.chapters)..where((c) => c.uuid.equals(uuid))).write(
+        ChaptersCompanion(
+          bookId: Value(bookId),
+          chapterId: Value(chapterId),
+          title: Value(title),
+          fingerprint: Value(fingerprint),
+          urlSuffix: Value(urlSuffix),
+          bytes: Value(bytes),
+          durationSec: Value(durationSec),
+        ),
+      );
+    }
+  }
+
+  /// Locally-stored chapters for a book, ordered by positional id — the
+  /// offline source for the player playlist + chapter list + durations.
+  Future<List<DownloadedChapter>> chaptersForBook(String bookId) async {
+    final rows = await (_db.select(_db.chapters)
+          ..where((c) => c.bookId.equals(bookId))
+          ..orderBy([(c) => OrderingTerm(expression: c.chapterId)]))
+        .get();
+    return [
+      for (final r in rows)
+        DownloadedChapter(
+          uuid: r.uuid,
+          chapterId: r.chapterId,
+          title: r.title,
+          durationSec: r.durationSec,
+          urlSuffix: r.urlSuffix,
+        ),
+    ];
   }
 
   @override

--- a/apps/android/lib/src/data/library_database.dart
+++ b/apps/android/lib/src/data/library_database.dart
@@ -40,6 +40,10 @@ class Chapters extends Table {
   /// storage accounting.
   IntColumn get bytes => integer().withDefault(const Constant(0))();
 
+  /// PCM-measured chapter length (seconds) from the manifest — stored so the
+  /// player + library show durations + listener progress OFFLINE.
+  RealColumn get durationSec => real().nullable()();
+
   /// Whether the user has finished this chapter — drives auto-delete-finished
   /// eviction (the row stays; only the audio file is dropped).
   BoolColumn get finished => boolean().withDefault(const Constant(false))();
@@ -70,13 +74,14 @@ class LibraryDatabase extends _$LibraryDatabase {
   LibraryDatabase.open() : this(driftDatabase(name: 'library'));
 
   @override
-  int get schemaVersion => 2;
+  int get schemaVersion => 3;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
         onCreate: (m) => m.createAll(),
         onUpgrade: (m, from, to) async {
           if (from < 2) await m.createTable(playback);
+          if (from < 3) await m.addColumn(chapters, chapters.durationSec);
         },
       );
 }

--- a/apps/android/lib/src/data/library_database.g.dart
+++ b/apps/android/lib/src/data/library_database.g.dart
@@ -606,6 +606,17 @@ class $ChaptersTable extends Chapters with TableInfo<$ChaptersTable, Chapter> {
     requiredDuringInsert: false,
     defaultValue: const Constant(0),
   );
+  static const VerificationMeta _durationSecMeta = const VerificationMeta(
+    'durationSec',
+  );
+  @override
+  late final GeneratedColumn<double> durationSec = GeneratedColumn<double>(
+    'duration_sec',
+    aliasedName,
+    true,
+    type: DriftSqlType.double,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _finishedMeta = const VerificationMeta(
     'finished',
   );
@@ -630,6 +641,7 @@ class $ChaptersTable extends Chapters with TableInfo<$ChaptersTable, Chapter> {
     fingerprint,
     urlSuffix,
     bytes,
+    durationSec,
     finished,
   ];
   @override
@@ -695,6 +707,15 @@ class $ChaptersTable extends Chapters with TableInfo<$ChaptersTable, Chapter> {
         bytes.isAcceptableOrUnknown(data['bytes']!, _bytesMeta),
       );
     }
+    if (data.containsKey('duration_sec')) {
+      context.handle(
+        _durationSecMeta,
+        durationSec.isAcceptableOrUnknown(
+          data['duration_sec']!,
+          _durationSecMeta,
+        ),
+      );
+    }
     if (data.containsKey('finished')) {
       context.handle(
         _finishedMeta,
@@ -738,6 +759,10 @@ class $ChaptersTable extends Chapters with TableInfo<$ChaptersTable, Chapter> {
         DriftSqlType.int,
         data['${effectivePrefix}bytes'],
       )!,
+      durationSec: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}duration_sec'],
+      ),
       finished: attachedDatabase.typeMapping.read(
         DriftSqlType.bool,
         data['${effectivePrefix}finished'],
@@ -767,6 +792,10 @@ class Chapter extends DataClass implements Insertable<Chapter> {
   /// storage accounting.
   final int bytes;
 
+  /// PCM-measured chapter length (seconds) from the manifest — stored so the
+  /// player + library show durations + listener progress OFFLINE.
+  final double? durationSec;
+
   /// Whether the user has finished this chapter — drives auto-delete-finished
   /// eviction (the row stays; only the audio file is dropped).
   final bool finished;
@@ -778,6 +807,7 @@ class Chapter extends DataClass implements Insertable<Chapter> {
     this.fingerprint,
     this.urlSuffix,
     required this.bytes,
+    this.durationSec,
     required this.finished,
   });
   @override
@@ -794,6 +824,9 @@ class Chapter extends DataClass implements Insertable<Chapter> {
       map['url_suffix'] = Variable<String>(urlSuffix);
     }
     map['bytes'] = Variable<int>(bytes);
+    if (!nullToAbsent || durationSec != null) {
+      map['duration_sec'] = Variable<double>(durationSec);
+    }
     map['finished'] = Variable<bool>(finished);
     return map;
   }
@@ -811,6 +844,9 @@ class Chapter extends DataClass implements Insertable<Chapter> {
           ? const Value.absent()
           : Value(urlSuffix),
       bytes: Value(bytes),
+      durationSec: durationSec == null && nullToAbsent
+          ? const Value.absent()
+          : Value(durationSec),
       finished: Value(finished),
     );
   }
@@ -828,6 +864,7 @@ class Chapter extends DataClass implements Insertable<Chapter> {
       fingerprint: serializer.fromJson<String?>(json['fingerprint']),
       urlSuffix: serializer.fromJson<String?>(json['urlSuffix']),
       bytes: serializer.fromJson<int>(json['bytes']),
+      durationSec: serializer.fromJson<double?>(json['durationSec']),
       finished: serializer.fromJson<bool>(json['finished']),
     );
   }
@@ -842,6 +879,7 @@ class Chapter extends DataClass implements Insertable<Chapter> {
       'fingerprint': serializer.toJson<String?>(fingerprint),
       'urlSuffix': serializer.toJson<String?>(urlSuffix),
       'bytes': serializer.toJson<int>(bytes),
+      'durationSec': serializer.toJson<double?>(durationSec),
       'finished': serializer.toJson<bool>(finished),
     };
   }
@@ -854,6 +892,7 @@ class Chapter extends DataClass implements Insertable<Chapter> {
     Value<String?> fingerprint = const Value.absent(),
     Value<String?> urlSuffix = const Value.absent(),
     int? bytes,
+    Value<double?> durationSec = const Value.absent(),
     bool? finished,
   }) => Chapter(
     uuid: uuid ?? this.uuid,
@@ -863,6 +902,7 @@ class Chapter extends DataClass implements Insertable<Chapter> {
     fingerprint: fingerprint.present ? fingerprint.value : this.fingerprint,
     urlSuffix: urlSuffix.present ? urlSuffix.value : this.urlSuffix,
     bytes: bytes ?? this.bytes,
+    durationSec: durationSec.present ? durationSec.value : this.durationSec,
     finished: finished ?? this.finished,
   );
   Chapter copyWithCompanion(ChaptersCompanion data) {
@@ -876,6 +916,9 @@ class Chapter extends DataClass implements Insertable<Chapter> {
           : this.fingerprint,
       urlSuffix: data.urlSuffix.present ? data.urlSuffix.value : this.urlSuffix,
       bytes: data.bytes.present ? data.bytes.value : this.bytes,
+      durationSec: data.durationSec.present
+          ? data.durationSec.value
+          : this.durationSec,
       finished: data.finished.present ? data.finished.value : this.finished,
     );
   }
@@ -890,6 +933,7 @@ class Chapter extends DataClass implements Insertable<Chapter> {
           ..write('fingerprint: $fingerprint, ')
           ..write('urlSuffix: $urlSuffix, ')
           ..write('bytes: $bytes, ')
+          ..write('durationSec: $durationSec, ')
           ..write('finished: $finished')
           ..write(')'))
         .toString();
@@ -904,6 +948,7 @@ class Chapter extends DataClass implements Insertable<Chapter> {
     fingerprint,
     urlSuffix,
     bytes,
+    durationSec,
     finished,
   );
   @override
@@ -917,6 +962,7 @@ class Chapter extends DataClass implements Insertable<Chapter> {
           other.fingerprint == this.fingerprint &&
           other.urlSuffix == this.urlSuffix &&
           other.bytes == this.bytes &&
+          other.durationSec == this.durationSec &&
           other.finished == this.finished);
 }
 
@@ -928,6 +974,7 @@ class ChaptersCompanion extends UpdateCompanion<Chapter> {
   final Value<String?> fingerprint;
   final Value<String?> urlSuffix;
   final Value<int> bytes;
+  final Value<double?> durationSec;
   final Value<bool> finished;
   final Value<int> rowid;
   const ChaptersCompanion({
@@ -938,6 +985,7 @@ class ChaptersCompanion extends UpdateCompanion<Chapter> {
     this.fingerprint = const Value.absent(),
     this.urlSuffix = const Value.absent(),
     this.bytes = const Value.absent(),
+    this.durationSec = const Value.absent(),
     this.finished = const Value.absent(),
     this.rowid = const Value.absent(),
   });
@@ -949,6 +997,7 @@ class ChaptersCompanion extends UpdateCompanion<Chapter> {
     this.fingerprint = const Value.absent(),
     this.urlSuffix = const Value.absent(),
     this.bytes = const Value.absent(),
+    this.durationSec = const Value.absent(),
     this.finished = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : uuid = Value(uuid),
@@ -962,6 +1011,7 @@ class ChaptersCompanion extends UpdateCompanion<Chapter> {
     Expression<String>? fingerprint,
     Expression<String>? urlSuffix,
     Expression<int>? bytes,
+    Expression<double>? durationSec,
     Expression<bool>? finished,
     Expression<int>? rowid,
   }) {
@@ -973,6 +1023,7 @@ class ChaptersCompanion extends UpdateCompanion<Chapter> {
       if (fingerprint != null) 'fingerprint': fingerprint,
       if (urlSuffix != null) 'url_suffix': urlSuffix,
       if (bytes != null) 'bytes': bytes,
+      if (durationSec != null) 'duration_sec': durationSec,
       if (finished != null) 'finished': finished,
       if (rowid != null) 'rowid': rowid,
     });
@@ -986,6 +1037,7 @@ class ChaptersCompanion extends UpdateCompanion<Chapter> {
     Value<String?>? fingerprint,
     Value<String?>? urlSuffix,
     Value<int>? bytes,
+    Value<double?>? durationSec,
     Value<bool>? finished,
     Value<int>? rowid,
   }) {
@@ -997,6 +1049,7 @@ class ChaptersCompanion extends UpdateCompanion<Chapter> {
       fingerprint: fingerprint ?? this.fingerprint,
       urlSuffix: urlSuffix ?? this.urlSuffix,
       bytes: bytes ?? this.bytes,
+      durationSec: durationSec ?? this.durationSec,
       finished: finished ?? this.finished,
       rowid: rowid ?? this.rowid,
     );
@@ -1026,6 +1079,9 @@ class ChaptersCompanion extends UpdateCompanion<Chapter> {
     if (bytes.present) {
       map['bytes'] = Variable<int>(bytes.value);
     }
+    if (durationSec.present) {
+      map['duration_sec'] = Variable<double>(durationSec.value);
+    }
     if (finished.present) {
       map['finished'] = Variable<bool>(finished.value);
     }
@@ -1045,6 +1101,7 @@ class ChaptersCompanion extends UpdateCompanion<Chapter> {
           ..write('fingerprint: $fingerprint, ')
           ..write('urlSuffix: $urlSuffix, ')
           ..write('bytes: $bytes, ')
+          ..write('durationSec: $durationSec, ')
           ..write('finished: $finished, ')
           ..write('rowid: $rowid')
           ..write(')'))
@@ -1656,6 +1713,7 @@ typedef $$ChaptersTableCreateCompanionBuilder =
       Value<String?> fingerprint,
       Value<String?> urlSuffix,
       Value<int> bytes,
+      Value<double?> durationSec,
       Value<bool> finished,
       Value<int> rowid,
     });
@@ -1668,6 +1726,7 @@ typedef $$ChaptersTableUpdateCompanionBuilder =
       Value<String?> fingerprint,
       Value<String?> urlSuffix,
       Value<int> bytes,
+      Value<double?> durationSec,
       Value<bool> finished,
       Value<int> rowid,
     });
@@ -1713,6 +1772,11 @@ class $$ChaptersTableFilterComposer
 
   ColumnFilters<int> get bytes => $composableBuilder(
     column: $table.bytes,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get durationSec => $composableBuilder(
+    column: $table.durationSec,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -1766,6 +1830,11 @@ class $$ChaptersTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<double> get durationSec => $composableBuilder(
+    column: $table.durationSec,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<bool> get finished => $composableBuilder(
     column: $table.finished,
     builder: (column) => ColumnOrderings(column),
@@ -1803,6 +1872,11 @@ class $$ChaptersTableAnnotationComposer
 
   GeneratedColumn<int> get bytes =>
       $composableBuilder(column: $table.bytes, builder: (column) => column);
+
+  GeneratedColumn<double> get durationSec => $composableBuilder(
+    column: $table.durationSec,
+    builder: (column) => column,
+  );
 
   GeneratedColumn<bool> get finished =>
       $composableBuilder(column: $table.finished, builder: (column) => column);
@@ -1843,6 +1917,7 @@ class $$ChaptersTableTableManager
                 Value<String?> fingerprint = const Value.absent(),
                 Value<String?> urlSuffix = const Value.absent(),
                 Value<int> bytes = const Value.absent(),
+                Value<double?> durationSec = const Value.absent(),
                 Value<bool> finished = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => ChaptersCompanion(
@@ -1853,6 +1928,7 @@ class $$ChaptersTableTableManager
                 fingerprint: fingerprint,
                 urlSuffix: urlSuffix,
                 bytes: bytes,
+                durationSec: durationSec,
                 finished: finished,
                 rowid: rowid,
               ),
@@ -1865,6 +1941,7 @@ class $$ChaptersTableTableManager
                 Value<String?> fingerprint = const Value.absent(),
                 Value<String?> urlSuffix = const Value.absent(),
                 Value<int> bytes = const Value.absent(),
+                Value<double?> durationSec = const Value.absent(),
                 Value<bool> finished = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => ChaptersCompanion.insert(
@@ -1875,6 +1952,7 @@ class $$ChaptersTableTableManager
                 fingerprint: fingerprint,
                 urlSuffix: urlSuffix,
                 bytes: bytes,
+                durationSec: durationSec,
                 finished: finished,
                 rowid: rowid,
               ),

--- a/apps/android/lib/src/data/pairing_store.dart
+++ b/apps/android/lib/src/data/pairing_store.dart
@@ -10,6 +10,12 @@ abstract class PairingStore {
   Future<PairedServer?> load();
   Future<void> save(PairedServer server);
   Future<void> clear();
+
+  /// The pinned CA cert (PEM) captured at pairing — persisted so the app can
+  /// rebuild the cert-pinned connection (and play downloaded books) OFFLINE,
+  /// without re-fetching `/cert/root.crt`. Null for legacy pairings.
+  Future<void> saveCaPem(String pem);
+  Future<String?> loadCaPem();
 }
 
 /// Real implementation backed by the OS keystore/keychain via
@@ -20,6 +26,7 @@ class SecurePairingStore implements PairingStore {
       : _storage = storage ?? const FlutterSecureStorage();
 
   static const _key = 'paired_server';
+  static const _caKey = 'paired_server_ca_pem';
   final FlutterSecureStorage _storage;
 
   @override
@@ -38,5 +45,14 @@ class SecurePairingStore implements PairingStore {
       _storage.write(key: _key, value: jsonEncode(server.toJson()));
 
   @override
-  Future<void> clear() => _storage.delete(key: _key);
+  Future<void> clear() async {
+    await _storage.delete(key: _key);
+    await _storage.delete(key: _caKey);
+  }
+
+  @override
+  Future<void> saveCaPem(String pem) => _storage.write(key: _caKey, value: pem);
+
+  @override
+  Future<String?> loadCaPem() => _storage.read(key: _caKey);
 }

--- a/apps/android/lib/src/data/sync_controller.dart
+++ b/apps/android/lib/src/data/sync_controller.dart
@@ -95,7 +95,15 @@ class SyncController {
         finalPath: _library.audioPath(bookId, c.uuid, c.urlSuffix!),
         expectedSize: c.expectedSize,
       );
-      await _library.recordChapter(bookId, c.uuid, c.fingerprint!, c.urlSuffix!);
+      await _library.recordChapterMeta(
+        bookId: bookId,
+        uuid: c.uuid,
+        chapterId: c.id,
+        title: c.title,
+        fingerprint: c.fingerprint!,
+        urlSuffix: c.urlSuffix!,
+        durationSec: c.durationSec,
+      );
       done++;
       onProgress?.call(done, total);
     }
@@ -103,10 +111,53 @@ class SyncController {
   }
 
   /// Ensure the book's detail (chapter order/paths) is loaded in-session so
-  /// [playlistFor] works even when we didn't just download it.
+  /// [playlistFor]/[chaptersOf] work. Falls back to a detail SYNTHESIZED from
+  /// the local drift store when the server is unreachable (OFFLINE playback).
   Future<void> ensureDetail(String bookId) async {
     if (_details.containsKey(bookId)) return;
-    _details[bookId] = await _api.bookDetail(bookId);
+    try {
+      _details[bookId] = await _api.bookDetail(bookId);
+    } catch (_) {
+      final local = await _library.chaptersForBook(bookId);
+      if (local.isEmpty) rethrow; // nothing local AND offline → real failure
+      _details[bookId] = SyncManifestBookDetail(
+        schemaVersion: 1,
+        bookId: bookId,
+        updatedAt: '',
+        chapters: [
+          for (final c in local)
+            SyncManifestChapter(
+              uuid: c.uuid,
+              id: c.chapterId,
+              title: c.title,
+              fingerprint: 'local', // non-null → hasAudio true
+              urlSuffix: c.urlSuffix,
+              durationSec: c.durationSec,
+              audioUrl: c.urlSuffix != null
+                  ? '/api/books/$bookId/chapters/${c.chapterId}/${c.urlSuffix}'
+                  : null,
+            ),
+        ],
+        activeChapterUuids: [for (final c in local) c.uuid],
+      );
+    }
+  }
+
+  /// Build the library from the LOCAL drift store only (offline) — all books
+  /// present on disk, marked downloaded.
+  Future<List<LibraryBook>> loadLocalLibrary() async {
+    final books = await _library.listBooks();
+    return [
+      for (final b in books)
+        LibraryBook(
+          bookId: b.bookId,
+          title: b.title,
+          author: b.author,
+          series: b.series,
+          seriesPosition: b.seriesPosition?.toDouble(),
+          downloadState: BookDownloadState.downloaded,
+        ),
+    ];
   }
 
   /// True once the book has at least one downloaded chapter on disk.

--- a/apps/android/lib/src/ui/library_home_screen.dart
+++ b/apps/android/lib/src/ui/library_home_screen.dart
@@ -35,6 +35,7 @@ class _LibraryHomeScreenState extends State<LibraryHomeScreen> {
   final Set<String> _collapsed = {}; // collapsed author/series section keys
   String _query = '';
   bool _loading = true;
+  bool _offline = false;
   String? _error;
 
   @override
@@ -48,23 +49,33 @@ class _LibraryHomeScreenState extends State<LibraryHomeScreen> {
       _loading = true;
       _error = null;
     });
+    List<LibraryBook> books;
+    var offline = false;
     try {
-      final books = await widget.runtime.sync.loadLibrary();
-      if (!mounted) return;
-      setState(() {
-        _books = books;
-        _loading = false;
-      });
-      _loadCovers(books);
-      _loadDurations(books);
-    } catch (e) {
-      if (mounted) {
-        setState(() {
-          _error = '$e';
-          _loading = false;
-        });
+      books = await widget.runtime.sync.loadLibrary(); // server index
+    } catch (_) {
+      // Server unreachable → fall back to the downloaded library on disk.
+      try {
+        books = await widget.runtime.sync.loadLocalLibrary();
+        offline = true;
+      } catch (e) {
+        if (mounted) {
+          setState(() {
+            _error = '$e';
+            _loading = false;
+          });
+        }
+        return;
       }
     }
+    if (!mounted) return;
+    setState(() {
+      _books = books;
+      _offline = offline;
+      _loading = false;
+    });
+    _loadCovers(books);
+    _loadDurations(books);
   }
 
   Future<void> _loadCovers(List<LibraryBook> books) async {
@@ -148,12 +159,27 @@ class _LibraryHomeScreenState extends State<LibraryHomeScreen> {
       appBar: AppBar(
         title: const Text('Library'),
         actions: [
-          IconButton(
-            key: const Key('library-sync'),
-            tooltip: 'Sync',
-            icon: const Icon(Icons.sync),
-            onPressed: _loading ? null : _refresh,
-          ),
+          if (_offline)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+              child: ActionChip(
+                key: const Key('offline-chip'),
+                avatar: Icon(Icons.cloud_off,
+                    size: 18, color: Theme.of(context).colorScheme.onErrorContainer),
+                label: Text(_loading ? 'Connecting…' : 'Offline'),
+                backgroundColor: Theme.of(context).colorScheme.errorContainer,
+                labelStyle: TextStyle(
+                    color: Theme.of(context).colorScheme.onErrorContainer),
+                onPressed: _loading ? null : _refresh, // tap to retry
+              ),
+            )
+          else
+            IconButton(
+              key: const Key('library-sync'),
+              tooltip: 'Sync',
+              icon: const Icon(Icons.sync),
+              onPressed: _loading ? null : _refresh,
+            ),
           IconButton(
             tooltip: 'Unpair',
             icon: const Icon(Icons.link_off),

--- a/apps/android/lib/src/ui/pairing_screen.dart
+++ b/apps/android/lib/src/ui/pairing_screen.dart
@@ -47,6 +47,7 @@ class _PairingScreenState extends State<PairingScreen> {
       );
       final conn = await widget.service.pair(server);
       await widget.store.save(conn.server);
+      await widget.store.saveCaPem(conn.caPem);
       if (mounted) Navigator.of(context).pop(conn.server);
     } on PairingException catch (e) {
       setState(() => _error = e.message);

--- a/apps/android/test/data/drift_local_library_test.dart
+++ b/apps/android/test/data/drift_local_library_test.dart
@@ -25,6 +25,42 @@ void main() {
       await lib.close();
     });
 
+    test('recordChapterMeta persists id/title/duration for offline + orders by id', () async {
+      final fs = InMemoryFileStore();
+      final lib = makeLib(fs);
+      await fs.writeBytes('/data/books/b1/u2/audio.mp3', [1, 2]);
+      await fs.writeBytes('/data/books/b1/u1/audio.mp3', [3, 4]);
+      await lib.recordChapterMeta(
+          bookId: 'b1', uuid: 'u2', chapterId: 2, title: 'Two',
+          fingerprint: 'fp2', urlSuffix: 'audio.mp3', durationSec: 120.5);
+      await lib.recordChapterMeta(
+          bookId: 'b1', uuid: 'u1', chapterId: 1, title: 'One',
+          fingerprint: 'fp1', urlSuffix: 'audio.mp3', durationSec: 60.0);
+
+      final chs = await lib.chaptersForBook('b1');
+      expect(chs.map((c) => c.uuid), ['u1', 'u2']); // ordered by chapterId
+      expect(chs.first.title, 'One');
+      expect(chs.last.durationSec, 120.5);
+      await lib.close();
+    });
+
+    test('recordChapterMeta preserves the finished flag on re-download', () async {
+      final fs = InMemoryFileStore();
+      final lib = makeLib(fs);
+      await fs.writeBytes('/data/books/b1/u1/audio.mp3', [1]);
+      await lib.recordChapterMeta(
+          bookId: 'b1', uuid: 'u1', chapterId: 1, title: 'One',
+          fingerprint: 'fp1', urlSuffix: 'audio.mp3', durationSec: 10);
+      await lib.setChapterFinished('u1', true);
+      await lib.recordChapterMeta(
+          bookId: 'b1', uuid: 'u1', chapterId: 1, title: 'One',
+          fingerprint: 'fp1b', urlSuffix: 'audio.mp3', durationSec: 11);
+
+      final usage = await lib.bookUsages();
+      expect(usage.single.chapters.single.finished, isTrue);
+      await lib.close();
+    });
+
     test('recordChapter stats the on-disk file for byte accounting', () async {
       final fs = InMemoryFileStore();
       final lib = makeLib(fs);

--- a/apps/android/test/data/sync_controller_test.dart
+++ b/apps/android/test/data/sync_controller_test.dart
@@ -19,20 +19,31 @@ class _FakeApi implements ManifestApi {
       details[bookId]!;
 }
 
+/// Simulates an unreachable server (offline).
+class _ThrowingApi implements ManifestApi {
+  @override
+  Future<SyncManifestIndex> index({String? since}) async =>
+      throw Exception('offline');
+  @override
+  Future<SyncManifestBookDetail> bookDetail(String bookId) async =>
+      throw Exception('offline');
+}
+
 SyncManifestIndexBook idx(String id, String title) => SyncManifestIndexBook(
     bookId: id, updatedAt: 't', title: title, author: 'A', series: 'S',
     seriesPosition: 1, chapterCount: 1);
 
-SyncManifestChapter ch(String book, String uuid, int id, String fp) =>
+SyncManifestChapter ch(String book, String uuid, int id, String fp,
+        {double? dur}) =>
     SyncManifestChapter(
-      uuid: uuid, id: id, title: 'ch$id', fingerprint: fp,
+      uuid: uuid, id: id, title: 'ch$id', fingerprint: fp, durationSec: dur,
       urlSuffix: 'audio.mp3', audioUrl: '/api/books/$book/chapters/$id/audio.mp3');
 
 void main() {
   late InMemoryFileStore fs;
   late DriftLocalLibrary lib;
 
-  SyncController make(_FakeApi api, Map<String, List<int>> serverBytes) {
+  SyncController make(ManifestApi api, Map<String, List<int>> serverBytes) {
     final downloader = ChapterDownloader(
       (url, headers) async =>
           RangeResponse(statusCode: 200, body: Stream.value(serverBytes[url.path]!)),
@@ -120,5 +131,51 @@ void main() {
         .downloadBook('b1', onProgress: (d, t) => downloaded = t);
     expect(downloaded, 1); // only the changed chapter
     expect(await fs.read('/d/books/b1/u1/audio.mp3'), [9, 9, 9, 9]);
+  });
+
+  test('OFFLINE: ensureDetail synthesizes from the drift store + playlist works',
+      () async {
+    // Download online (records chapter id/title/duration in drift).
+    final online = _FakeApi(
+      SyncManifestIndex(schemaVersion: 1, books: [idx('b1', 'B')], activeBookIds: ['b1']),
+      {
+        'b1': SyncManifestBookDetail(
+          schemaVersion: 1, bookId: 'b1', updatedAt: 't',
+          chapters: [ch('b1', 'u1', 1, 'fp1|3', dur: 30)],
+          activeChapterUuids: ['u1']),
+      },
+    );
+    await make(online, {'/api/books/b1/chapters/1/audio.mp3': [1, 2, 3]})
+        .downloadBook('b1');
+
+    // New controller, server unreachable.
+    final offline = make(_ThrowingApi(), {});
+    await offline.ensureDetail('b1');
+    final chs = offline.chaptersOf('b1');
+    expect(chs.single.uuid, 'u1');
+    expect(chs.single.title, 'ch1');
+    expect(chs.single.durationSec, 30.0);
+    expect(chs.single.hasAudio, isTrue);
+    expect(offline.playlistFor('b1').single.path, '/d/books/b1/u1/audio.mp3');
+  });
+
+  test('OFFLINE: loadLocalLibrary lists downloaded books, all marked downloaded',
+      () async {
+    final online = _FakeApi(
+      SyncManifestIndex(schemaVersion: 1, books: [idx('b1', 'B')], activeBookIds: ['b1']),
+      {
+        'b1': SyncManifestBookDetail(
+          schemaVersion: 1, bookId: 'b1', updatedAt: 't',
+          chapters: [ch('b1', 'u1', 1, 'fp1|3', dur: 30)],
+          activeChapterUuids: ['u1']),
+      },
+    );
+    final c = make(online, {'/api/books/b1/chapters/1/audio.mp3': [1, 2, 3]});
+    await c.loadIndex(); // records book meta
+    await c.downloadBook('b1');
+
+    final local = await make(_ThrowingApi(), {}).loadLocalLibrary();
+    expect(local.single.bookId, 'b1');
+    expect(local.single.title, 'B');
   });
 }

--- a/apps/android/test/ui/pairing_screen_test.dart
+++ b/apps/android/test/ui/pairing_screen_test.dart
@@ -11,12 +11,17 @@ import 'package:audiobook_companion/src/ui/pairing_screen.dart';
 
 class FakeStore implements PairingStore {
   PairedServer? saved;
+  String? savedCaPem;
   @override
   Future<PairedServer?> load() async => saved;
   @override
   Future<void> save(PairedServer server) async => saved = server;
   @override
   Future<void> clear() async => saved = null;
+  @override
+  Future<void> saveCaPem(String pem) async => savedCaPem = pem;
+  @override
+  Future<String?> loadCaPem() async => savedCaPem;
 }
 
 String pemOf(List<int> der) =>

--- a/apps/android/test/widget_test.dart
+++ b/apps/android/test/widget_test.dart
@@ -9,12 +9,17 @@ import 'package:audiobook_companion/src/domain/paired_server.dart';
 class FakeStore implements PairingStore {
   FakeStore([this._value]);
   PairedServer? _value;
+  String? _caPem;
   @override
   Future<PairedServer?> load() async => _value;
   @override
   Future<void> save(PairedServer server) async => _value = server;
   @override
   Future<void> clear() async => _value = null;
+  @override
+  Future<void> saveCaPem(String pem) async => _caPem = pem;
+  @override
+  Future<String?> loadCaPem() async => _caPem;
 }
 
 void main() {


### PR DESCRIPTION
## Summary

A paired app that couldn't reach the server previously showed a blocking "couldn't connect" screen — the downloaded books were unreachable. Now the app is fully usable offline:

- **Persist the pinned CA cert** at pairing (`PairingStore.saveCaPem/loadCaPem`) → the runtime is rebuilt from stored creds on launch with **no network**.
- **Persist chapter id/title/durationSec in drift** on download (new `durationSec` column, schema **v2→v3** migration + `recordChapterMeta`) → player playlist, chapter list, and durations work offline.
- **`SyncController.ensureDetail`** falls back to a detail **synthesized from the drift store** when the server is unreachable; `loadLocalLibrary` lists the on-disk library → the player plays fully offline.
- **`LibraryHomeScreen`**: a failed server index falls back to the local library + shows a tappable **"Offline" chip** (retries on tap) instead of an error; online shows the normal Sync action.
- **`main.dart`** launches offline-capable; a legacy pairing with no stored cert shows a one-time "Connect to enable offline playback" prompt.

## Test plan

`recordChapterMeta` persistence/ordering/finished-preserved; `ensureDetail` offline synthesis + offline playlist; `loadLocalLibrary`. **186 Dart tests green**, `flutter analyze` clean. Local `npm run verify` green (pre-push).

Refs #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)