### PR TITLE
fix(app): 16 KB page alignment — mobile_scanner 7 + secure_storage 10

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -36,6 +36,25 @@ jobs:
       # app-11: also build the release APK (debug-signed fallback unless signing
       # secrets are wired) and publish it as an installable alpha sideload artifact.
       - run: flutter build apk --release
+      # Guard the 16 KB page-size fix (mobile_scanner 7 / secure_storage 10 /
+      # NDK r28): every bundled arm64 native lib must have ≥16 KB-aligned LOAD
+      # segments or it warns / runs in compat-mode on 16 KB-page devices.
+      - name: Verify 16 KB ELF alignment (arm64)
+        run: |
+          set -euo pipefail
+          apk="build/app/outputs/flutter-apk/app-release.apk"
+          work="$(mktemp -d)"
+          unzip -o -q "$apk" 'lib/arm64-v8a/*.so' -d "$work"
+          fail=0
+          for so in "$work"/lib/arm64-v8a/*.so; do
+            bad=$(readelf -lW "$so" | awk '/LOAD/{a=strtonum($NF); if(a<16384) print a}')
+            if [ -n "$bad" ]; then
+              echo "::error::$(basename "$so") is NOT 16 KB-aligned"; fail=1
+            else
+              echo "ok: $(basename "$so")"
+            fi
+          done
+          exit $fail
       - uses: actions/upload-artifact@v4
         with:
           name: companion-release-apk

--- a/apps/android/pubspec.lock
+++ b/apps/android/pubspec.lock
@@ -281,6 +281,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  ffi_leak_tracker:
+    dependency: transitive
+    description:
+      name: ffi_leak_tracker
+      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -330,50 +338,50 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.4"
+    version: "10.3.1"
+  flutter_secure_storage_darwin:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_darwin
+      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
       name: flutter_secure_storage_linux
-      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      sha256: a5f35ddab43cf5c8215d2feb4ce1957851f28c5c37e6f04335066a0602087bf5
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
-  flutter_secure_storage_macos:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_macos
-      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.3"
+    version: "3.0.1"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
       name: flutter_secure_storage_platform_interface
-      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      sha256: "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "2.0.1"
   flutter_secure_storage_web:
     dependency: transitive
     description:
       name: flutter_secure_storage_web
-      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      sha256: "073a62b3aeb866ab4ce795f960413948e51e5a42a9b0c8333b6daf5bb3208a1c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "2.1.1"
   flutter_secure_storage_windows:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      sha256: "471951813a97006d899db4948acc654a4f28c440083ea08178935ce20b173ec1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "4.2.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -580,10 +588,10 @@ packages:
     dependency: "direct main"
     description:
       name: mobile_scanner
-      sha256: d234581c090526676fd8fab4ada92f35c6746e3fb4f05a399665d75a399fb760
+      sha256: c92c26bf2231695b6d3477c8dcf435f51e28f87b1745966b1fe4c47a286171ce
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.3"
+    version: "7.2.0"
   native_toolchain_c:
     dependency: transitive
     description:
@@ -1041,10 +1049,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      sha256: ba6f4bba816c8d7e3c1580e170f3786d216951cc6b94babc3b814c08d2cb2738
       url: "https://pub.dev"
     source: hosted
-    version: "5.15.0"
+    version: "6.3.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/apps/android/pubspec.yaml
+++ b/apps/android/pubspec.yaml
@@ -39,14 +39,15 @@ dependencies:
   crypto: ^3.0.6
 
   # app-2 — persist the paired-server connection (url/token/fingerprint).
-  flutter_secure_storage: ^9.2.4
+  # 10.x ships 16 KB-page-aligned native libs (datastore_shared_counter).
+  flutter_secure_storage: ^10.3.1
 
-  # app-2 — scan the server pairing QR.
-  mobile_scanner: ^5.2.3
+  # app-2 — scan the server pairing QR. 7.x bundles 16 KB-aligned ML Kit.
+  mobile_scanner: ^7.2.0
   path_provider: ^2.1.5
   flutter_foreground_task: ^9.2.2
   drift: ^2.33.0
-  drift_flutter: ^0.3.0
+  drift_flutter: ^0.3.0 # pulls sqlite3_flutter_libs 0.6.0+eol (latest)
   image: ^4.9.1
   just_audio: ^0.10.5
   audio_service: ^0.18.18


### PR DESCRIPTION
## Summary

On 16 KB-page devices the app showed an "App Compatibility" warning and ran in compat-mode because several bundled native libs had 4 KB-aligned ELF LOAD segments — plugin prebuilts: ML Kit's `libbarhopper_v3` + `libimage_processing_util_jni` (mobile_scanner 5.x) and `libdatastore_shared_counter` (flutter_secure_storage 9.x).

- **mobile_scanner 5→7** (16 KB-aligned ML Kit) and **flutter_secure_storage 9→10** (16 KB-aligned datastore). **No code changes** — `onDetect` / read-write-delete APIs are source-compatible.
- `sqlite3_flutter_libs` already at `0.6.0+eol` (via drift_flutter) and aligned; `connectivity_plus` stays at 6.1.0 (not a native-lib offender; 7.x broke the iOS compile).
- **CI guard**: a new step fails the app lane if any arm64 lib regresses below 16 KB.

**Verified locally:** every arm64-v8a + x86_64 lib in the release APK now has ≥16 KB-aligned LOAD segments (`libapp`/`libflutter` `0x10000`, the rest `0x4000`); the compatibility dialog no longer appears on the 16 KB emulator.

The plugin bumps also refresh the iOS pods — the macOS `ios-compile` lane gates them (relevant for the app-12 iOS target).

## Test plan

186 Dart tests green; `flutter analyze` clean; release APK 16 KB-verified. **Watching CI `android` (incl. the new alignment guard) + `ios-compile` before merge.**

Refs #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)