### PR TITLE
feat(app): volume boost + settings/management screen + per-book removal

### DIFF
--- a/apps/android/lib/main.dart
+++ b/apps/android/lib/main.dart
@@ -205,7 +205,7 @@ class _HomePageState extends State<HomePage> {
     }
     return LibraryHomeScreen(
       runtime: _runtime!,
-      serverLabel: _paired!.url,
+      server: _paired!,
       onUnpair: _unpair,
     );
   }

--- a/apps/android/lib/src/data/audio_engine.dart
+++ b/apps/android/lib/src/data/audio_engine.dart
@@ -11,6 +11,11 @@ abstract class AudioEngine {
   Future<void> seek(Duration position);
   Future<void> setSpeed(double speed);
 
+  /// Boost loudness above the source's unity (decibels, 0 = off). `setVolume`
+  /// can only attenuate; this adds gain (Android LoudnessEnhancer) so a quiet
+  /// −16 LUFS master can be lifted on-device.
+  Future<void> setVolumeBoost(double db);
+
   /// Current playback position.
   Duration get position;
 

--- a/apps/android/lib/src/data/companion_runtime.dart
+++ b/apps/android/lib/src/data/companion_runtime.dart
@@ -1,5 +1,6 @@
 import 'package:path_provider/path_provider.dart';
 
+import '../domain/app_settings.dart';
 import 'api_client.dart';
 import 'chapter_downloader.dart';
 import 'cover_thumbnails.dart';
@@ -9,21 +10,34 @@ import 'just_audio_engine.dart';
 import 'library_database.dart';
 import 'pairing_service.dart' show Connection;
 import 'player_controller.dart';
+import 'settings_store.dart';
 import 'sync_controller.dart';
 
 /// The wired runtime for a paired server (app-shell integration): builds the
 /// cert-pinned [ApiClient], the on-device drift store, the [SyncController]
-/// (index + per-book download), and the [PlayerController] over `just_audio`.
-/// Device glue — exercised on a device, not in unit tests (each piece it wires
-/// is unit-tested on its own).
+/// (index + per-book download), the [PlayerController] over `just_audio`, and
+/// loads/applies device [AppSettings]. Device glue — exercised on a device, not
+/// in unit tests (each piece it wires is unit-tested on its own).
 class CompanionRuntime {
-  CompanionRuntime._(this.api, this.library, this.sync, this.player, this.thumbnails);
+  CompanionRuntime._(
+    this.api,
+    this.library,
+    this.sync,
+    this.player,
+    this.thumbnails,
+    this.settingsStore,
+    this.settings,
+  );
 
   final ApiClient api;
   final DriftLocalLibrary library;
   final SyncController sync;
   final PlayerController player;
   final ThumbnailCache thumbnails;
+  final SettingsStore settingsStore;
+
+  /// Current device settings (mutable — updated via [updateSettings]).
+  AppSettings settings;
 
   static Future<CompanionRuntime> forConnection(Connection connection) async {
     final docs = await getApplicationDocumentsDirectory();
@@ -31,8 +45,7 @@ class CompanionRuntime {
 
     final api = ApiClient(connection);
     final fs = const DiskFileStore();
-    final library =
-        DriftLocalLibrary(LibraryDatabase.open(), fs, root: root);
+    final library = DriftLocalLibrary(LibraryDatabase.open(), fs, root: root);
     final downloader = ChapterDownloader(api.pinnedRangeFetch(), fs);
 
     Uri resolve(String path) => Uri.parse('${connection.server.url}$path');
@@ -58,7 +71,21 @@ class CompanionRuntime {
       root: root,
     );
 
-    return CompanionRuntime._(api, library, sync, player, thumbnails);
+    final settingsStore = SettingsStore(fs, path: '$root/settings.json');
+    final settings = await settingsStore.load();
+    await player.setSpeed(settings.defaultSpeed);
+    await player.setVolumeBoost(settings.volumeBoostDb);
+
+    return CompanionRuntime._(
+        api, library, sync, player, thumbnails, settingsStore, settings);
+  }
+
+  /// Persist new settings and apply the playback-affecting ones immediately.
+  Future<void> updateSettings(AppSettings next) async {
+    settings = next;
+    await settingsStore.save(next);
+    await player.setVolumeBoost(next.volumeBoostDb);
+    await player.setSpeed(next.defaultSpeed);
   }
 
   Future<void> dispose() async {

--- a/apps/android/lib/src/data/drift_local_library.dart
+++ b/apps/android/lib/src/data/drift_local_library.dart
@@ -205,6 +205,14 @@ class DriftLocalLibrary implements LocalLibrary, PlaybackStore, ThumbnailStore {
     await _fs.deleteDir(_bookDir(bookId));
   }
 
+  /// Remove ALL downloaded books + their audio files (reclaims all storage).
+  /// Pairing + settings are untouched.
+  Future<void> clearAllBooks() async {
+    for (final b in await listBooks()) {
+      await evictBook(b.bookId);
+    }
+  }
+
   // --- app-4 store extensions ---------------------------------------------
 
   /// Per-book usage for the storage-eviction policy.

--- a/apps/android/lib/src/data/just_audio_engine.dart
+++ b/apps/android/lib/src/data/just_audio_engine.dart
@@ -7,7 +7,14 @@ import 'audio_engine.dart';
 /// Real [AudioEngine] backed by `just_audio`. Thin wrapper — behaviour is
 /// validated on a device (no unit tests for the native player).
 class JustAudioEngine implements AudioEngine {
-  final AudioPlayer _player = AudioPlayer();
+  JustAudioEngine() : this._(AndroidLoudnessEnhancer());
+  JustAudioEngine._(this._loudness)
+      : _player = AudioPlayer(
+          audioPipeline: AudioPipeline(androidAudioEffects: [_loudness]),
+        );
+
+  final AndroidLoudnessEnhancer _loudness;
+  final AudioPlayer _player;
 
   @override
   Duration get position => _player.position;
@@ -52,6 +59,12 @@ class JustAudioEngine implements AudioEngine {
 
   @override
   Future<void> setSpeed(double speed) => _player.setSpeed(speed);
+
+  @override
+  Future<void> setVolumeBoost(double db) async {
+    await _loudness.setEnabled(db > 0);
+    await _loudness.setTargetGain(db); // decibels above unity
+  }
 
   @override
   Future<void> dispose() => _player.dispose();

--- a/apps/android/lib/src/data/player_controller.dart
+++ b/apps/android/lib/src/data/player_controller.dart
@@ -52,6 +52,7 @@ class PlayerController {
   String? _bookId;
   int _index = -1;
   double _speed = 1.0;
+  double _boostDb = 0;
   DateTime? _lastSave;
 
   /// Live playback duration of the loaded chapter (null until known).
@@ -62,6 +63,13 @@ class PlayerController {
   Future<void> setSpeed(double speed) {
     _speed = speed;
     return _engine.setSpeed(speed);
+  }
+
+  /// Loudness boost in dB above unity (0 = off), re-applied per chapter.
+  double get volumeBoostDb => _boostDb;
+  Future<void> setVolumeBoost(double db) {
+    _boostDb = db;
+    return _engine.setVolumeBoost(db);
   }
 
   /// Auto-advance to the next chapter when the current one ends.
@@ -110,6 +118,7 @@ class PlayerController {
     _index = index;
     await _engine.setFilePath(_playlist[index].path);
     if (_speed != 1.0) await _engine.setSpeed(_speed); // persist speed across chapters
+    if (_boostDb > 0) await _engine.setVolumeBoost(_boostDb); // persist boost too
     if (seekMs > 0) await _engine.seek(Duration(milliseconds: seekMs));
     // Measure the autosave interval from load time, so we don't persist on the
     // very first position tick.

--- a/apps/android/lib/src/domain/app_settings.dart
+++ b/apps/android/lib/src/domain/app_settings.dart
@@ -20,6 +20,7 @@ class AppSettings {
     this.autoSyncOnReconnect = true,
     this.autoDownloadInProgress = true,
     this.streamOverLan = false,
+    this.volumeBoostDb = 0,
   });
 
   /// 0 = off.
@@ -48,6 +49,10 @@ class AppSettings {
   /// play (drives `app-10`). Off by default — the app is offline-first.
   final bool streamOverLan;
 
+  /// Loudness boost in dB above unity (0 = off, max 12) — lifts the moderate
+  /// −16 LUFS masters on-device. Drives `app-5` via the player.
+  final double volumeBoostDb;
+
   static const AppSettings defaults = AppSettings();
 
   AppSettings copyWith({
@@ -64,6 +69,7 @@ class AppSettings {
     bool? autoSyncOnReconnect,
     bool? autoDownloadInProgress,
     bool? streamOverLan,
+    double? volumeBoostDb,
   }) {
     return AppSettings(
       sleepTimerMinutes: sleepTimerMinutes ?? this.sleepTimerMinutes,
@@ -80,6 +86,7 @@ class AppSettings {
       autoDownloadInProgress:
           autoDownloadInProgress ?? this.autoDownloadInProgress,
       streamOverLan: streamOverLan ?? this.streamOverLan,
+      volumeBoostDb: volumeBoostDb ?? this.volumeBoostDb,
     );
   }
 
@@ -97,6 +104,7 @@ class AppSettings {
         'autoSyncOnReconnect': autoSyncOnReconnect,
         'autoDownloadInProgress': autoDownloadInProgress,
         'streamOverLan': streamOverLan,
+        'volumeBoostDb': volumeBoostDb,
       };
 
   factory AppSettings.fromJson(Map<String, dynamic> json) {
@@ -123,6 +131,8 @@ class AppSettings {
       autoDownloadInProgress:
           json['autoDownloadInProgress'] as bool? ?? d.autoDownloadInProgress,
       streamOverLan: json['streamOverLan'] as bool? ?? d.streamOverLan,
+      volumeBoostDb:
+          (json['volumeBoostDb'] as num?)?.toDouble() ?? d.volumeBoostDb,
     );
   }
 

--- a/apps/android/lib/src/domain/paired_server.dart
+++ b/apps/android/lib/src/domain/paired_server.dart
@@ -10,11 +10,23 @@ class PairedServer {
     required this.url,
     required this.token,
     required this.caFingerprint,
+    this.pairedAt,
   });
 
   final String url;
   final String token;
   final String caFingerprint;
+
+  /// ISO-8601 timestamp this server was paired (set at save; null for legacy
+  /// pairings predating this field). Surfaced as "paired since" in settings.
+  final String? pairedAt;
+
+  PairedServer copyWith({String? pairedAt}) => PairedServer(
+        url: url,
+        token: token,
+        caFingerprint: caFingerprint,
+        pairedAt: pairedAt ?? this.pairedAt,
+      );
 
   /// Parse the raw text of a scanned pairing QR (a JSON object).
   factory PairedServer.fromQrPayload(String raw) {
@@ -34,13 +46,19 @@ class PairedServer {
     final url = _requireNonEmptyString(json, 'url');
     final token = _requireNonEmptyString(json, 'token');
     final caFingerprint = _requireNonEmptyString(json, 'caFingerprint');
-    return PairedServer(url: url, token: token, caFingerprint: caFingerprint);
+    return PairedServer(
+      url: url,
+      token: token,
+      caFingerprint: caFingerprint,
+      pairedAt: json['pairedAt'] as String?,
+    );
   }
 
   Map<String, dynamic> toJson() => {
         'url': url,
         'token': token,
         'caFingerprint': caFingerprint,
+        if (pairedAt != null) 'pairedAt': pairedAt,
       };
 
   static String _requireNonEmptyString(Map<String, dynamic> json, String key) {

--- a/apps/android/lib/src/ui/app_settings_screen.dart
+++ b/apps/android/lib/src/ui/app_settings_screen.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+
+import '../data/companion_runtime.dart';
+import '../domain/paired_server.dart';
+
+/// App settings + device management: the volume-boost control, the paired-server
+/// info (URL, certificate fingerprint, paired-since — never the token), and the
+/// unpair / delete-library actions.
+class AppSettingsScreen extends StatefulWidget {
+  const AppSettingsScreen({
+    super.key,
+    required this.runtime,
+    required this.server,
+    required this.onUnpair,
+    required this.onLibraryCleared,
+  });
+
+  final CompanionRuntime runtime;
+  final PairedServer server;
+  final Future<void> Function() onUnpair;
+  final VoidCallback onLibraryCleared;
+
+  @override
+  State<AppSettingsScreen> createState() => _AppSettingsScreenState();
+}
+
+class _AppSettingsScreenState extends State<AppSettingsScreen> {
+  late double _boost = widget.runtime.settings.volumeBoostDb;
+
+  Future<void> _commitBoost(double db) => widget.runtime.updateSettings(
+      widget.runtime.settings.copyWith(volumeBoostDb: db));
+
+  Future<bool> _confirm(String title, String message, String action) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(title),
+        content: Text(message),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel')),
+          FilledButton(
+              onPressed: () => Navigator.pop(ctx, true), child: Text(action)),
+        ],
+      ),
+    );
+    return ok ?? false;
+  }
+
+  Future<void> _deleteLibrary() async {
+    if (!await _confirm('Delete library?',
+        'Removes all downloaded audio from this device. You can re-download later.',
+        'Delete')) {
+      return;
+    }
+    await widget.runtime.library.clearAllBooks();
+    widget.onLibraryCleared();
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Downloaded library deleted.')));
+    }
+  }
+
+  Future<void> _unpair() async {
+    if (!await _confirm('Unpair this device?',
+        'Disconnects from the server and removes the saved certificate + downloaded library.',
+        'Unpair')) {
+      return;
+    }
+    await widget.onUnpair();
+    if (mounted) Navigator.of(context).pop();
+  }
+
+  String _pairedSince() {
+    final raw = widget.server.pairedAt;
+    if (raw == null) return 'unknown';
+    final dt = DateTime.tryParse(raw);
+    if (dt == null) return raw;
+    final l = dt.toLocal();
+    final d = '${l.year}-${l.month.toString().padLeft(2, '0')}-${l.day.toString().padLeft(2, '0')}';
+    final t = '${l.hour.toString().padLeft(2, '0')}:${l.minute.toString().padLeft(2, '0')}';
+    return '$d $t';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: ListView(
+        children: [
+          _sectionLabel('Playback'),
+          ListTile(
+            title: const Text('Volume boost'),
+            subtitle: Text(_boost <= 0
+                ? 'Off — plays the master at full strength'
+                : 'Boosted +${_boost.toStringAsFixed(0)} dB'),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Slider(
+              key: const Key('boost-slider'),
+              value: _boost,
+              min: 0,
+              max: 12,
+              divisions: 12,
+              label: '+${_boost.toStringAsFixed(0)} dB',
+              onChanged: (v) => setState(() => _boost = v),
+              onChangeEnd: _commitBoost,
+            ),
+          ),
+          const Divider(),
+          _sectionLabel('Server'),
+          ListTile(
+            leading: const Icon(Icons.dns_outlined),
+            title: const Text('Server'),
+            subtitle: Text(widget.server.url),
+          ),
+          ListTile(
+            leading: const Icon(Icons.verified_user_outlined),
+            title: const Text('Certificate (SHA-256)'),
+            subtitle: Text(widget.server.caFingerprint,
+                style: const TextStyle(fontFamily: 'monospace', fontSize: 11)),
+          ),
+          ListTile(
+            leading: const Icon(Icons.schedule),
+            title: const Text('Paired since'),
+            subtitle: Text(_pairedSince()),
+          ),
+          const Divider(),
+          _sectionLabel('Manage'),
+          ListTile(
+            key: const Key('delete-library'),
+            leading: Icon(Icons.delete_sweep_outlined, color: scheme.error),
+            title: Text('Delete downloaded library',
+                style: TextStyle(color: scheme.error)),
+            subtitle: const Text('Free up space; keep the pairing'),
+            onTap: _deleteLibrary,
+          ),
+          ListTile(
+            key: const Key('unpair'),
+            leading: Icon(Icons.link_off, color: scheme.error),
+            title: Text('Unpair device', style: TextStyle(color: scheme.error)),
+            subtitle: const Text('Disconnect + forget this server'),
+            onTap: _unpair,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _sectionLabel(String text) => Padding(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+        child: Text(text,
+            style: Theme.of(context)
+                .textTheme
+                .labelLarge
+                ?.copyWith(color: Theme.of(context).colorScheme.primary)),
+      );
+}

--- a/apps/android/lib/src/ui/library_home_screen.dart
+++ b/apps/android/lib/src/ui/library_home_screen.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import '../data/companion_runtime.dart';
 import '../domain/library_tree.dart';
 import '../domain/listen_progress.dart';
+import '../domain/paired_server.dart';
+import 'app_settings_screen.dart';
 import 'player_screen.dart';
 
 /// Post-pairing home: a cover-art library grouped into author → series
@@ -14,12 +16,12 @@ class LibraryHomeScreen extends StatefulWidget {
   const LibraryHomeScreen({
     super.key,
     required this.runtime,
-    required this.serverLabel,
+    required this.server,
     required this.onUnpair,
   });
 
   final CompanionRuntime runtime;
-  final String serverLabel;
+  final PairedServer server;
   final Future<void> Function() onUnpair;
 
   @override
@@ -181,9 +183,17 @@ class _LibraryHomeScreenState extends State<LibraryHomeScreen> {
               onPressed: _loading ? null : _refresh,
             ),
           IconButton(
-            tooltip: 'Unpair',
-            icon: const Icon(Icons.link_off),
-            onPressed: () async => widget.onUnpair(),
+            key: const Key('open-settings'),
+            tooltip: 'Settings',
+            icon: const Icon(Icons.settings_outlined),
+            onPressed: () => Navigator.of(context).push(MaterialPageRoute(
+              builder: (_) => AppSettingsScreen(
+                runtime: widget.runtime,
+                server: widget.server,
+                onUnpair: widget.onUnpair,
+                onLibraryCleared: _refresh,
+              ),
+            )),
           ),
         ],
       ),
@@ -340,21 +350,57 @@ class _LibraryHomeScreenState extends State<LibraryHomeScreen> {
           onPressed: () => _download(book),
         );
       case BookDownloadState.updateAvailable:
-        return IconButton(
-          key: Key('update-${book.bookId}'),
-          icon: const Icon(Icons.sync_problem),
-          color: Theme.of(context).colorScheme.tertiary,
-          tooltip: 'Update available — re-sync',
-          onPressed: () => _download(book),
-        );
       case BookDownloadState.downloaded:
-        return IconButton(
-          icon: const Icon(Icons.play_circle_outline),
-          tooltip: 'Play',
-          onPressed: () => _open(book),
+        // Downloaded (tap row to play) — menu offers update/remove.
+        return PopupMenuButton<String>(
+          key: Key('book-menu-${book.bookId}'),
+          onSelected: (v) {
+            if (v == 'play') _open(book);
+            if (v == 'update') _download(book);
+            if (v == 'remove') _removeDownload(book);
+          },
+          itemBuilder: (_) => [
+            const PopupMenuItem(value: 'play', child: Text('Play')),
+            if (book.downloadState == BookDownloadState.updateAvailable)
+              const PopupMenuItem(
+                  value: 'update', child: Text('Update (re-sync)')),
+            const PopupMenuItem(
+                value: 'remove', child: Text('Remove download')),
+          ],
         );
       case BookDownloadState.downloading:
         return _progressWidget(book.bookId);
+    }
+  }
+
+  Future<void> _removeDownload(LibraryBook book) async {
+    if (widget.runtime.player.currentBookId == book.bookId) {
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+          content: Text('Stop playback before removing this book.')));
+      return;
+    }
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Remove download?'),
+        content: Text(
+            'Deletes the downloaded audio for "${book.title}". You can re-download it later.'),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel')),
+          FilledButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Remove')),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    await widget.runtime.library.evictBook(book.bookId);
+    await _refresh();
+    if (mounted) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Removed "${book.title}".')));
     }
   }
 

--- a/apps/android/lib/src/ui/pairing_screen.dart
+++ b/apps/android/lib/src/ui/pairing_screen.dart
@@ -46,9 +46,11 @@ class _PairingScreenState extends State<PairingScreen> {
         caFingerprint: _fingerprint.text.trim(),
       );
       final conn = await widget.service.pair(server);
-      await widget.store.save(conn.server);
+      final stamped =
+          conn.server.copyWith(pairedAt: DateTime.now().toIso8601String());
+      await widget.store.save(stamped);
       await widget.store.saveCaPem(conn.caPem);
-      if (mounted) Navigator.of(context).pop(conn.server);
+      if (mounted) Navigator.of(context).pop(stamped);
     } on PairingException catch (e) {
       setState(() => _error = e.message);
     } on FormatException catch (e) {

--- a/apps/android/lib/src/ui/player_screen.dart
+++ b/apps/android/lib/src/ui/player_screen.dart
@@ -236,6 +236,14 @@ class _PlayerScreenState extends State<PlayerScreen> {
                           onPressed: _cycleSpeed,
                           child: Text('${_speed}x'),
                         ),
+                        IconButton(
+                          key: const Key('player-boost'),
+                          tooltip: 'Volume boost',
+                          icon: Icon(widget.runtime.settings.volumeBoostDb > 0
+                              ? Icons.volume_up
+                              : Icons.volume_up_outlined),
+                          onPressed: _openBoostSheet,
+                        ),
                       ],
                     ),
                   ],
@@ -250,6 +258,39 @@ class _PlayerScreenState extends State<PlayerScreen> {
 
   static const _speeds = [1.0, 1.25, 1.5, 2.0, 0.75];
   double _speed = 1.0;
+
+  /// Quick volume-boost slider; writes through the runtime so it persists and
+  /// stays in sync with the settings screen.
+  void _openBoostSheet() {
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (_) {
+        var boost = widget.runtime.settings.volumeBoostDb;
+        return StatefulBuilder(
+          builder: (ctx, setSheet) => Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text('Volume boost  +${boost.toStringAsFixed(0)} dB',
+                    style: Theme.of(ctx).textTheme.titleMedium),
+                Slider(
+                  value: boost,
+                  min: 0,
+                  max: 12,
+                  divisions: 12,
+                  label: '+${boost.toStringAsFixed(0)} dB',
+                  onChanged: (v) => setSheet(() => boost = v),
+                  onChangeEnd: (v) => widget.runtime.updateSettings(
+                      widget.runtime.settings.copyWith(volumeBoostDb: v)),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    ).then((_) => mounted ? setState(() {}) : null); // refresh the boost icon
+  }
 
   Future<void> _cycleSpeed() async {
     final next = _speeds[(_speeds.indexOf(_speed) + 1) % _speeds.length];

--- a/apps/android/test/data/drift_local_library_test.dart
+++ b/apps/android/test/data/drift_local_library_test.dart
@@ -61,6 +61,21 @@ void main() {
       await lib.close();
     });
 
+    test('clearAllBooks evicts every book + its files', () async {
+      final fs = InMemoryFileStore();
+      final lib = makeLib(fs);
+      await fs.writeBytes('/data/books/b1/u1/audio.mp3', [1]);
+      await fs.writeBytes('/data/books/b2/u1/audio.mp3', [2]);
+      await lib.recordChapter('b1', 'u1', 'fp1', 'audio.mp3');
+      await lib.recordChapter('b2', 'u1', 'fp2', 'audio.mp3');
+      expect((await lib.listBooks()).length, 2);
+
+      await lib.clearAllBooks();
+      expect(await lib.listBooks(), isEmpty);
+      expect(await fs.read('/data/books/b1/u1/audio.mp3'), isNull);
+      await lib.close();
+    });
+
     test('recordChapter stats the on-disk file for byte accounting', () async {
       final fs = InMemoryFileStore();
       final lib = makeLib(fs);

--- a/apps/android/test/data/player_controller_test.dart
+++ b/apps/android/test/data/player_controller_test.dart
@@ -50,6 +50,8 @@ class FakeAudioEngine implements AudioEngine {
   @override
   Future<void> setSpeed(double s) async => calls.add('speed:$s');
   @override
+  Future<void> setVolumeBoost(double db) async => calls.add('boost:$db');
+  @override
   Future<void> dispose() async => _pos.close();
 
   void emit(Duration p) {
@@ -179,6 +181,20 @@ void main() {
       await pc.skip(forward: true);
       expect(pc.currentChapterUuid, 'u2');
       expect(engine.loadedPath, '/b1/u2/audio.mp3');
+      await pc.dispose();
+    });
+
+    test('volume boost is applied and re-applied on each chapter load', () async {
+      final engine = FakeAudioEngine();
+      final pc = make(engine, MemPlaybackStore(),
+          behavior: SkipButtonBehavior.chapter);
+      await pc.openBook('b1');
+      await pc.setVolumeBoost(8);
+      expect(engine.calls, contains('boost:8.0'));
+      expect(pc.volumeBoostDb, 8.0);
+      engine.calls.clear();
+      await pc.skip(forward: true); // next chapter
+      expect(engine.calls, contains('boost:8.0')); // persisted across chapters
       await pc.dispose();
     });
 

--- a/apps/android/test/domain/app_settings_test.dart
+++ b/apps/android/test/domain/app_settings_test.dart
@@ -36,6 +36,7 @@ void main() {
         storageCapBytes: 1234,
         autoDeleteFinished: true,
         streamOverLan: true,
+        volumeBoostDb: 8,
       );
       final back = AppSettings.fromJson(s.toJson());
       expect(back.sleepTimerMinutes, 30);
@@ -44,6 +45,12 @@ void main() {
       expect(back.storageCapBytes, 1234);
       expect(back.autoDeleteFinished, isTrue);
       expect(back.streamOverLan, isTrue);
+      expect(back.volumeBoostDb, 8.0);
+    });
+
+    test('volumeBoostDb defaults to 0 (off)', () {
+      expect(AppSettings.defaults.volumeBoostDb, 0);
+      expect(AppSettings.fromJson(const {}).volumeBoostDb, 0);
     });
 
     test('fromJson tolerates missing keys (falls back to defaults)', () {

--- a/apps/android/test/domain/paired_server_test.dart
+++ b/apps/android/test/domain/paired_server_test.dart
@@ -19,6 +19,15 @@ void main() {
       expect(PairedServer.fromJson(s.toJson()).toJson(), s.toJson());
     });
 
+    test('copyWith stamps pairedAt and it round-trips; legacy json has none', () {
+      const base = PairedServer(url: 'u', token: 't', caFingerprint: 'f');
+      expect(base.pairedAt, isNull);
+      expect(base.toJson().containsKey('pairedAt'), isFalse); // legacy-clean
+      final stamped = base.copyWith(pairedAt: '2026-06-07T10:00:00.000Z');
+      expect(PairedServer.fromJson(stamped.toJson()).pairedAt,
+          '2026-06-07T10:00:00.000Z');
+    });
+
     test('rejects a payload with a missing or empty required field', () {
       expect(
         () => PairedServer.fromJson({'url': 'u', 'token': 't'}),


### PR DESCRIPTION
## Summary

Three companion features over existing seams (one cohesive round):

1. **Volume boost** — the −16 LUFS masters sound quiet (esp. on the emulator), and `setVolume` can only attenuate. `AudioEngine.setVolumeBoost(db)` → `JustAudioEngine` wires an `AndroidLoudnessEnhancer` in an `AudioPipeline` (gain in dB). `AppSettings.volumeBoostDb` (0, max 12); `PlayerController` re-applies it per chapter (mirrors speed). **`CompanionRuntime` now loads `SettingsStore` and applies boost+speed to the player** (settings were built in app-13 but never wired). Controls: a slider in the settings screen + a quick boost sheet on the player.
2. **Settings / device-management screen** (gear in the library app bar): boost slider; server info — URL, CA fingerprint, **paired-since** (new `PairedServer.pairedAt`, JSON-tolerant for legacy); the **token is never shown**. **Unpair** (clears store) + **Delete downloaded library** (`clearAllBooks`), both confirm-gated. Unpair moved here from the app bar.
3. **Per-book local removal**: a "Remove download" menu on downloaded books → `evictBook`, guarded against removing the currently-playing book; re-downloadable later.

## Test plan

`PlayerController` boost apply+persist; `AppSettings` + `PairedServer` JSON round-trips (incl. defaults/legacy); `clearAllBooks`. **190 Dart tests green**, `flutter analyze` clean, debug + release APK build. Watching CI `android` + `ios-compile`.

Refs #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)