### PR TITLE
fix(server): re-split under-budget stage-2 chapters that still truncate

### DIFF
--- a/docs/features/archive/06-analyzer-gemini.md
+++ b/docs/features/archive/06-analyzer-gemini.md
@@ -31,6 +31,7 @@ Opt-in analyzer mode that hits the Gemini free-tier API directly instead of the 
   | Model                    | RPM | TPM       | RPD   |
   | ------------------------ | --- | --------- | ----- |
   | `gemini-3.1-flash-lite`  | 15  | 250,000   | 500   |
+  | `gemini-3.5-flash`       | 5   | 250,000   | 20    |
   | `gemini-3-flash-preview` | 5   | 250,000   | 20    |
   | `gemini-2.5-flash`       | 5   | 250,000   | 20    |
   | `gemma-4-31b-it`         | 15  | Unlimited | 1,500 |

--- a/docs/features/archive/187-large-chapter-stage2-and-attribution-coverage.md
+++ b/docs/features/archive/187-large-chapter-stage2-and-attribution-coverage.md
@@ -64,7 +64,9 @@ workaround. On ch19: Prentice was in cast.json with 0 lines, narrator had 221.
    ids 1..N** so the result is the exact shape a single call produces. If a
    section *still* truncates (`AnalyzerTruncatedError`), it is **adaptively
    re-split** — self-tuning to the real cap, engine-agnostic. A chapter within
-   budget runs exactly one guarded call (byte-identical to before).
+   budget runs exactly one guarded call (byte-identical to before) — and if that
+   single call *itself* truncates (see the post-ship addendum), it falls back to
+   the same adaptive split.
 
 3. **One shared resilient runner across both routes** (`routes/analysis.ts`).
    `attributeChapterStage2` (built on `buildStage2ChunkInbox` +
@@ -128,6 +130,26 @@ manual escape hatch).
   chapters on Ollama's 16K window.
 - Cross-chunk overlap beyond the small preceding-context preamble — only if seam
   mis-attribution shows up in live runs.
+
+## Post-ship addendum (2026-06-07) — single-call truncation fallback
+
+The original `runStage2ChapterChunked` only gave the **multi-chunk** path the
+adaptive re-split safety net. The **single-call** path (a body *under*
+`STAGE2_CHUNK_CHAR_BUDGET`) re-threw `AnalyzerTruncatedError` straight to the UI,
+on the assumption that a sub-budget chapter "can't" truncate. That assumption is
+false: the char budget is only a proxy for the model's **output-token** cap, and
+stage-2 output scales with **sentence count**, not chars — so a dense,
+dialogue-heavy chapter can sit under the char budget yet overflow the 8192-token
+output cap. Live hit: a 8,348-char chapter on `gemini-3.1-flash-lite` failed the
+whole run with "Analysis failed — … Lower STAGE2_CHUNK_CHAR_BUDGET and retry."
+
+Fix: when the single guarded call truncates, force-split the body in half (at
+paragraph boundaries) and run it through the same `attributeSpan` adaptive path
+the multi-chunk route already uses. A body that's a single un-splittable
+paragraph still surfaces the truncation loudly (nothing to split). New tests in
+`stage2-chunk.test.ts`: "re-splits an UNDER-budget body that still truncates on
+the single call" and "propagates an under-budget truncation that is a single
+un-splittable paragraph".
 
 ## Ship notes
 

--- a/server/src/analyzer/rate-limit.test.ts
+++ b/server/src/analyzer/rate-limit.test.ts
@@ -70,6 +70,16 @@ describe('GeminiRateLimiter', () => {
     await pending;
   });
 
+  it('applies the baked-in limits for gemini-3.5-flash (250K TPM, not the 100K fallback)', async () => {
+    /* Registered in BUILTIN_LIMITS as 5 RPM / 250K TPM / 20 RPD. A single
+       120K-token acquire fits the baked 250K cap without waiting; under the
+       unknown-model fallback (100K TPM) that same call would block — so a
+       non-blocking acquire proves the entry is wired up, not falling back. */
+    const onWait = vi.fn();
+    await limiter.acquire('gemini-3.5-flash', 120_000, { onWait });
+    expect(onWait).not.toHaveBeenCalled();
+  });
+
   it('reconciles an over-estimated entry via recordActualTokens', async () => {
     /* Reserve 50K; reconcile down to 10K — a follow-up 200K request
        must now fit (10K + 200K = 210K, under 250K). */

--- a/server/src/analyzer/rate-limit.ts
+++ b/server/src/analyzer/rate-limit.ts
@@ -35,6 +35,7 @@ const FALLBACK_LIMITS: ModelLimits = { rpm: 5, tpm: 100_000, rpd: 50 };
    change. */
 const BUILTIN_LIMITS: Record<string, ModelLimits> = {
   'gemini-3.1-flash-lite': { rpm: 15, tpm: 250_000, rpd: 500 },
+  'gemini-3.5-flash': { rpm: 5, tpm: 250_000, rpd: 20 },
   'gemini-3-flash-preview': { rpm: 5, tpm: 250_000, rpd: 20 },
   'gemini-2.5-flash': { rpm: 5, tpm: 250_000, rpd: 20 },
   'gemma-4-31b-it': { rpm: 15, tpm: Infinity, rpd: 1500 },

--- a/server/src/analyzer/stage2-chunk.test.ts
+++ b/server/src/analyzer/stage2-chunk.test.ts
@@ -134,6 +134,44 @@ describe('runStage2ChapterChunked', () => {
     expect(out.coverage.ok).toBe(true);
   });
 
+  it('re-splits an UNDER-budget body that still truncates on the single call', async () => {
+    /* A dense chapter whose char count fits the budget but whose per-sentence
+       JSON output overflows the model cap (output scales with sentence count,
+       not chars). The single-call path must fall back to the adaptive split
+       instead of propagating the truncation. */
+    const body = makeBody(6);
+    let fullBodyTruncations = 0;
+    const call = vi.fn(async (subBody: string, _preceding: string | null) => {
+      // The whole body truncates; any strictly-smaller span succeeds.
+      if (subBody.length >= body.length) {
+        fullBodyTruncations += 1;
+        throw new AnalyzerTruncatedError('gemini', 'MAX_TOKENS', subBody.length);
+      }
+      return fakeAttribute(subBody);
+    });
+    const out = await runStage2ChapterChunked({
+      body,
+      charBudget: 10_000, // > body.length → single-call path is selected first
+      coverageRetries: 1,
+      callForBody: call,
+    });
+    expect(fullBodyTruncations).toBe(1); // tried the single call once, then split
+    expect(out.chunkCount).toBeGreaterThan(1); // reported as a chunked run
+    expect(out.sentences.map((s) => s.id)).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(out.coverage.ok).toBe(true);
+  });
+
+  it('propagates an under-budget truncation that is a single un-splittable paragraph', async () => {
+    // One paragraph, under budget, but the model truncates on it: nothing to split.
+    const body = 'word '.repeat(40).trim();
+    const call = vi.fn(async (_subBody: string, _preceding: string | null) => {
+      throw new AnalyzerTruncatedError('gemini', 'MAX_TOKENS', body.length);
+    });
+    await expect(
+      runStage2ChapterChunked({ body, charBudget: 10_000, coverageRetries: 1, callForBody: call }),
+    ).rejects.toBeInstanceOf(AnalyzerTruncatedError);
+  });
+
   it('retries a chunk whose first attempt has low coverage', async () => {
     const body = makeBody(8);
     const onRetry = vi.fn();

--- a/server/src/analyzer/stage2-chunk.ts
+++ b/server/src/analyzer/stage2-chunk.ts
@@ -126,23 +126,6 @@ export async function runStage2ChapterChunked(
 ): Promise<Stage2ChunkRunResult> {
   const contextParagraphs = opts.contextParagraphs ?? 2;
   const maxSplitDepth = opts.maxSplitDepth ?? 3;
-  const chunks = splitBodyIntoChunks(opts.body, opts.charBudget);
-
-  if (chunks.length <= 1) {
-    /* Common case: chapter fits in one call. Preserve the exact current
-       behaviour — one guarded call against the full body, model ids untouched,
-       the guard's own verdict returned. (A sub-budget chapter that still
-       truncates is effectively impossible at sane budgets; if it ever did, the
-       AnalyzerTruncatedError now surfaces loudly instead of a silent reset.) */
-    const { result, coverage } = await runStage2WithCoverageGuard({
-      body: opts.body,
-      maxRetries: opts.coverageRetries,
-      call: () => opts.callForBody(opts.body, null),
-      thresholds: opts.coverageThresholds,
-      onRetry: opts.onRetry,
-    });
-    return { sentences: result.sentences, coverage, chunkCount: 1 };
-  }
 
   /* Attribute one span, splitting it further if the model truncates on it. */
   const attributeSpan = async (
@@ -176,19 +159,53 @@ export async function runStage2ChapterChunked(
     }
   };
 
-  const all: SentenceOutput[] = [];
-  let preceding: string | null = null;
-  for (let i = 0; i < chunks.length; i += 1) {
-    opts.onChunk?.({ index: i, total: chunks.length, chars: chunks[i].length });
-    all.push(...(await attributeSpan(chunks[i], 0, preceding)));
-    preceding = tailParagraphs(chunks[i], contextParagraphs);
+  /* Run a pre-split chunk list and stitch the result back into the single-call
+     shape (ids renumbered 1..N — each chunk numbered its own 1..M, which would
+     collide on concat; a single call would have produced one contiguous 1..N).
+     chapterId is the caller's to stamp (it already does
+     `for (s of result.sentences) s.chapterId = ch.id`). */
+  const runChunks = async (chunks: string[]): Promise<Stage2ChunkRunResult> => {
+    const all: SentenceOutput[] = [];
+    let preceding: string | null = null;
+    for (let i = 0; i < chunks.length; i += 1) {
+      opts.onChunk?.({ index: i, total: chunks.length, chars: chunks[i].length });
+      all.push(...(await attributeSpan(chunks[i], 0, preceding)));
+      preceding = tailParagraphs(chunks[i], contextParagraphs);
+    }
+    const sentences = all.map((s, i) => ({ ...s, id: i + 1 }));
+    const coverage = validateStage2Coverage(opts.body, sentences, opts.coverageThresholds);
+    return { sentences, coverage, chunkCount: chunks.length };
+  };
+
+  const chunks = splitBodyIntoChunks(opts.body, opts.charBudget);
+
+  if (chunks.length <= 1) {
+    /* Common case: chapter fits the char budget → one guarded call against the
+       full body, model ids untouched, the guard's own verdict returned
+       (byte-identical to the pre-chunking behaviour for the vast majority of
+       chapters). The char budget is only a PROXY for the model's output-token
+       cap, though: stage-2 output scales with sentence count, so a dense
+       (dialogue-heavy) chapter can fit the char budget yet still overflow the
+       cap. When that single call truncates, fall back to the adaptive split
+       instead of failing the whole run — the same self-tuning the multi-chunk
+       path already has. A body that's a single un-splittable paragraph has
+       nowhere to split, so the truncation still surfaces loudly. */
+    try {
+      const { result, coverage } = await runStage2WithCoverageGuard({
+        body: opts.body,
+        maxRetries: opts.coverageRetries,
+        call: () => opts.callForBody(opts.body, null),
+        thresholds: opts.coverageThresholds,
+        onRetry: opts.onRetry,
+      });
+      return { sentences: result.sentences, coverage, chunkCount: 1 };
+    } catch (err) {
+      if (!(err instanceof AnalyzerTruncatedError)) throw err;
+      const forced = splitBodyIntoChunks(opts.body, Math.max(1, Math.floor(opts.body.length / 2)));
+      if (forced.length <= 1) throw err; // single paragraph: nothing to split
+      return runChunks(forced);
+    }
   }
 
-  /* Renumber ids 1..N within the chapter — each chunk numbered its own 1..M,
-     which would collide on concat; a single call would have produced one
-     contiguous 1..N, so this restores that contract. chapterId is the caller's
-     to stamp (it already does `for (s of result.sentences) s.chapterId = ch.id`). */
-  const sentences = all.map((s, i) => ({ ...s, id: i + 1 }));
-  const coverage = validateStage2Coverage(opts.body, sentences, opts.coverageThresholds);
-  return { sentences, coverage, chunkCount: chunks.length };
+  return runChunks(chunks);
 }

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -63,6 +63,12 @@ export const MODEL_OPTIONS: ModelOption[] = [
     engine: 'gemini',
   },
   {
+    id: 'gemini-3.5-flash',
+    label: 'Gemini 3.5 Flash',
+    hint: '5 RPM, 250K TPM, 20/day — strongest Flash, but only enough for a short book',
+    engine: 'gemini',
+  },
+  {
     id: 'gemini-3-flash-preview',
     label: 'Gemini 3 Flash',
     hint: '5 RPM, 250K TPM, 20/day — only enough for a short book',


### PR DESCRIPTION
## Summary

Two fixes from one live "Analysis failed" incident on a Gemini run:

1. **Stage-2 single-call truncation → adaptive re-split fallback** (`server/src/analyzer/stage2-chunk.ts`). The single-call attribution path (a chapter body *under* `STAGE2_CHUNK_CHAR_BUDGET`) re-threw `AnalyzerTruncatedError` straight to the UI, assuming a sub-budget chapter can't truncate. It can: the char budget is only a proxy for the model's **output-token** cap, and stage-2 emits one JSON object per sentence, so a dense dialogue-heavy chapter fits the char budget yet overflows the 8192-token cap. Live hit: an **8,348-char** chapter on `gemini-3.1-flash-lite` failed the whole run. Now, when the single guarded call truncates, the body is force-split in half at paragraph boundaries and run through the same adaptive `attributeSpan` path the multi-chunk route already uses. A single un-splittable paragraph still surfaces the error loudly.

2. **Add Gemini 3.5 Flash as an analysis-model option** (`src/lib/models.ts`, `server/src/analyzer/rate-limit.ts`). Adds `gemini-3.5-flash` to the picker (upload / re-parse / analysing / account) and registers its free-tier limits (**5 RPM / 250K TPM / 20 RPD**) in the server rate-limiter so it isn't throttled by the conservative unknown-model fallback. Default analysis model is unchanged.

Plan addendum: `docs/features/archive/187-large-chapter-stage2-and-attribution-coverage.md`. Limits table: `docs/features/archive/06-analyzer-gemini.md`.

## Test plan

- `stage2-chunk.test.ts` — new: "re-splits an UNDER-budget body that still truncates on the single call" (fails before the fix, passes after) + "propagates an under-budget truncation that is a single un-splittable paragraph".
- `rate-limit.test.ts` — new: `gemini-3.5-flash` uses its baked-in 250K TPM, not the 100K fallback.
- Verified locally: typecheck ✓, frontend (2316) ✓, server-fast (2232) ✓, server-slow (191, isolated) ✓. Full `npm run verify` left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)