### PR TITLE
feat(app): wire media session (app-5/9) + two-way resume sync (app-6)

### DIFF
--- a/apps/android/lib/main.dart
+++ b/apps/android/lib/main.dart
@@ -1,5 +1,7 @@
+import 'package:audio_service/audio_service.dart';
 import 'package:flutter/material.dart';
 
+import 'src/data/companion_audio_handler.dart';
 import 'src/data/companion_runtime.dart';
 import 'src/data/pairing_service.dart';
 import 'src/data/pairing_store.dart';
@@ -11,17 +13,28 @@ import 'src/ui/pairing_screen.dart';
 /// app-2 pairing + the app-3..14 library / sync / player wired on top, with
 /// OFFLINE launch (the runtime is rebuilt from the stored cert — no network
 /// needed to open the downloaded library).
-void main() {
-  runApp(AudiobookCompanionApp(store: SecurePairingStore()));
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  // app-5/app-9: the media session must exist before the UI (lock-screen /
+  // Bluetooth / Android Auto). The runtime attaches the live player once paired.
+  final handler = await AudioService.init(
+    builder: () => CompanionAudioHandler(),
+    config: companionAudioServiceConfig,
+  );
+  runApp(AudiobookCompanionApp(store: SecurePairingStore(), audioHandler: handler));
 }
 
 class AudiobookCompanionApp extends StatelessWidget {
-  const AudiobookCompanionApp({super.key, required this.store, this.service});
+  const AudiobookCompanionApp(
+      {super.key, required this.store, this.service, this.audioHandler});
 
   final PairingStore store;
 
   /// Injectable so widget tests can drive pairing without real network/TLS.
   final PairingService? service;
+
+  /// The media-session handler (null in widget tests).
+  final CompanionAudioHandler? audioHandler;
 
   @override
   Widget build(BuildContext context) {
@@ -32,16 +45,24 @@ class AudiobookCompanionApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF8A2BE2)),
         useMaterial3: true,
       ),
-      home: HomePage(store: store, service: service ?? PairingService()),
+      home: HomePage(
+          store: store,
+          service: service ?? PairingService(),
+          audioHandler: audioHandler),
     );
   }
 }
 
 class HomePage extends StatefulWidget {
-  const HomePage({super.key, required this.store, required this.service});
+  const HomePage(
+      {super.key,
+      required this.store,
+      required this.service,
+      this.audioHandler});
 
   final PairingStore store;
   final PairingService service;
+  final CompanionAudioHandler? audioHandler;
 
   @override
   State<HomePage> createState() => _HomePageState();
@@ -79,7 +100,8 @@ class _HomePageState extends State<HomePage> {
     // Offline-capable: rebuild the pinned runtime from stored creds, no network.
     try {
       final runtime = await CompanionRuntime.forConnection(
-          Connection(server: server, caPem: caPem));
+          Connection(server: server, caPem: caPem),
+          handler: widget.audioHandler);
       if (mounted) {
         setState(() {
           _runtime = runtime;
@@ -106,7 +128,8 @@ class _HomePageState extends State<HomePage> {
     try {
       final conn = await widget.service.pair(_paired!);
       await widget.store.saveCaPem(conn.caPem);
-      final runtime = await CompanionRuntime.forConnection(conn);
+      final runtime =
+          await CompanionRuntime.forConnection(conn, handler: widget.audioHandler);
       if (mounted) {
         setState(() {
           _runtime = runtime;

--- a/apps/android/lib/src/data/audio_engine.dart
+++ b/apps/android/lib/src/data/audio_engine.dart
@@ -22,6 +22,10 @@ abstract class AudioEngine {
   /// Position ticks (drive the autosave throttle).
   Stream<Duration> get positionStream;
 
+  /// Whether playback is currently active (drives the media-session state).
+  bool get playing;
+  Stream<bool> get playingStream;
+
   /// Loaded media duration (null until known).
   Duration? get duration;
   Stream<Duration?> get durationStream;

--- a/apps/android/lib/src/data/companion_audio_handler.dart
+++ b/apps/android/lib/src/data/companion_audio_handler.dart
@@ -1,51 +1,103 @@
+import 'dart:async';
+
 import 'package:audio_service/audio_service.dart';
 
-import '../domain/media_browse_tree.dart';
 import 'player_controller.dart';
 
-/// Bridges the OS media session (lock screen, Bluetooth, notification) to the
-/// [PlayerController]. Bluetooth/notification skip buttons honour the `app-13`
-/// skip-button behaviour (default ±seek, not chapter) via [PlayerController.skip].
+/// Bridges the OS media session (lock screen, notification, Bluetooth/headset,
+/// Android Auto / CarPlay) to the [PlayerController].
 ///
-/// `app-9` adds the in-car browse tree (Android Auto + CarPlay) via the
-/// `MediaBrowser` callbacks ([getChildren] / [playFromMediaId]) over the pure
-/// [buildMediaBrowseTree]/[childrenOf] domain — the host supplies [browseRoot]
-/// (built from the library) and [onPlayMediaId] (open + play).
+/// Created detached in `main()` via `AudioService.init` (before pairing builds
+/// the runtime), then [attach]ed to the live player. It **observes** the
+/// player's streams to broadcast `playbackState` + `mediaItem` outward (so the
+/// lock-screen shows title/art/progress) and routes OS controls inward.
+/// Bluetooth next/prev honour the app-13 skip behaviour via [PlayerController.skip].
 ///
-/// Device-tuned glue — not unit-tested (the [PlayerController] + browse-tree
-/// brains are).
+/// app-9: in-car browse comes from the injected [childrenProvider] /
+/// [onPlayMediaId] (the runtime builds these from the live library).
 class CompanionAudioHandler extends BaseAudioHandler with SeekHandler {
-  CompanionAudioHandler(
-    this._controller, {
-    MediaNode Function()? browseRoot,
-    void Function(MediaId mediaId)? onPlayMediaId,
-  })  : _browseRootProvider = browseRoot,
-        _playMediaIdCallback = onPlayMediaId;
+  PlayerController? _controller;
+  Future<List<MediaItem>> Function(String parentMediaId)? _childrenProvider;
+  Future<void> Function(String mediaId)? _onPlayMediaId;
+  final List<StreamSubscription<Object?>> _subs = [];
 
-  final PlayerController _controller;
-  final MediaNode Function()? _browseRootProvider;
-  final void Function(MediaId mediaId)? _playMediaIdCallback;
+  /// Wire the live player (+ optional car browse). Idempotent: re-attaching
+  /// detaches the previous player first.
+  void attach(
+    PlayerController controller, {
+    Future<List<MediaItem>> Function(String parentMediaId)? childrenProvider,
+    Future<void> Function(String mediaId)? onPlayMediaId,
+  }) {
+    detach();
+    _controller = controller;
+    _childrenProvider = childrenProvider;
+    _onPlayMediaId = onPlayMediaId;
+    _subs.add(controller.playingStream.listen((_) => _broadcastState()));
+    _subs.add(controller.positionStream.listen((_) => _broadcastState()));
+    _subs.add(controller.nowPlayingStream.listen(_onNowPlaying));
+    _broadcastState();
+  }
+
+  void detach() {
+    for (final s in _subs) {
+      s.cancel();
+    }
+    _subs.clear();
+    _controller = null;
+  }
+
+  void _onNowPlaying(NowPlaying? np) {
+    if (np == null) return;
+    mediaItem.add(MediaItem(
+      id: np.id,
+      title: np.title,
+      album: np.album.isEmpty ? 'Audiobook' : np.album,
+      duration: np.duration,
+      artUri: (np.artPath != null && np.artPath!.isNotEmpty)
+          ? Uri.file(np.artPath!)
+          : null,
+    ));
+    _broadcastState();
+  }
+
+  void _broadcastState() {
+    final c = _controller;
+    final isPlaying = c?.playing ?? false;
+    playbackState.add(playbackState.value.copyWith(
+      controls: [
+        MediaControl.skipToPrevious,
+        if (isPlaying) MediaControl.pause else MediaControl.play,
+        MediaControl.skipToNext,
+      ],
+      systemActions: const {MediaAction.seek},
+      processingState: AudioProcessingState.ready,
+      playing: isPlaying,
+      updatePosition: c?.position ?? Duration.zero,
+    ));
+  }
 
   @override
-  Future<void> play() => _controller.play();
+  Future<void> play() => _controller?.play() ?? Future.value();
 
   @override
-  Future<void> pause() => _controller.pause();
+  Future<void> pause() => _controller?.pause() ?? Future.value();
 
   @override
-  Future<void> seek(Duration position) => _controller.seekTo(position);
+  Future<void> seek(Duration position) =>
+      _controller?.seekTo(position) ?? Future.value();
 
   // Bluetooth/headset/steering-wheel next/prev — defaults to a short seek so an
   // accidental press doesn't skip a whole chapter (toggle in app-13).
   @override
-  Future<void> skipToNext() => _controller.skip(forward: true);
+  Future<void> skipToNext() => _controller?.skip(forward: true) ?? Future.value();
 
   @override
-  Future<void> skipToPrevious() => _controller.skip(forward: false);
+  Future<void> skipToPrevious() =>
+      _controller?.skip(forward: false) ?? Future.value();
 
   @override
   Future<void> stop() async {
-    await _controller.pause();
+    await _controller?.pause();
     await super.stop();
   }
 
@@ -54,24 +106,16 @@ class CompanionAudioHandler extends BaseAudioHandler with SeekHandler {
   @override
   Future<List<MediaItem>> getChildren(String parentMediaId,
       [Map<String, dynamic>? options]) async {
-    final root = _browseRootProvider?.call();
-    if (root == null) return const [];
-    return childrenOf(root, parentMediaId).map(_toMediaItem).toList();
+    final provider = _childrenProvider;
+    return provider != null ? await provider(parentMediaId) : const [];
   }
 
   @override
   Future<void> playFromMediaId(String mediaId,
       [Map<String, dynamic>? extras]) async {
-    final parsed = parseMediaId(mediaId);
-    if (parsed.kind == MediaIdKind.chapter) _playMediaIdCallback?.call(parsed);
+    final cb = _onPlayMediaId;
+    if (cb != null) await cb(mediaId);
   }
-
-  MediaItem _toMediaItem(MediaNode n) => MediaItem(
-        id: n.id,
-        title: n.title,
-        album: n.subtitle,
-        playable: n.playable,
-      );
 }
 
 /// Standard audio_service config for the companion's media session.

--- a/apps/android/lib/src/data/companion_runtime.dart
+++ b/apps/android/lib/src/data/companion_runtime.dart
@@ -13,6 +13,7 @@ import 'just_audio_engine.dart';
 import 'library_database.dart';
 import 'pairing_service.dart' show Connection;
 import 'player_controller.dart';
+import 'resume_sync_service.dart';
 import 'settings_store.dart';
 import 'sync_controller.dart';
 
@@ -30,6 +31,7 @@ class CompanionRuntime {
     this.thumbnails,
     this.settingsStore,
     this.settings,
+    this.resumeSync,
     this.audioHandler,
   );
 
@@ -39,6 +41,9 @@ class CompanionRuntime {
   final PlayerController player;
   final ThumbnailCache thumbnails;
   final SettingsStore settingsStore;
+
+  /// Two-way resume sync (app-6): push local position / pull the server's.
+  final ResumeSyncService resumeSync;
 
   /// Current device settings (mutable — updated via [updateSettings]).
   AppSettings settings;
@@ -85,6 +90,17 @@ class CompanionRuntime {
     final settings = await settingsStore.load();
     await player.setSpeed(settings.defaultSpeed);
     await player.setVolumeBoost(settings.volumeBoostDb);
+
+    final resumeSync = ResumeSyncService(
+      progressApi: api.listenProgressApi,
+      playbackStore: library,
+      chapterIdResolver: (bookId, uuid) async {
+        for (final c in await library.chaptersForBook(bookId)) {
+          if (c.uuid == uuid) return c.chapterId;
+        }
+        return null;
+      },
+    );
 
     // app-5/app-9: connect the media session (lock-screen / Bluetooth / car) to
     // the live player + a library-backed browse tree.
@@ -134,7 +150,7 @@ class CompanionRuntime {
     );
 
     return CompanionRuntime._(api, library, sync, player, thumbnails,
-        settingsStore, settings, handler);
+        settingsStore, settings, resumeSync, handler);
   }
 
   /// Persist new settings and apply the playback-affecting ones immediately.

--- a/apps/android/lib/src/data/companion_runtime.dart
+++ b/apps/android/lib/src/data/companion_runtime.dart
@@ -1,8 +1,11 @@
+import 'package:audio_service/audio_service.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../domain/app_settings.dart';
+import '../domain/media_browse_tree.dart';
 import 'api_client.dart';
 import 'chapter_downloader.dart';
+import 'companion_audio_handler.dart';
 import 'cover_thumbnails.dart';
 import 'drift_local_library.dart';
 import 'file_store.dart';
@@ -27,6 +30,7 @@ class CompanionRuntime {
     this.thumbnails,
     this.settingsStore,
     this.settings,
+    this.audioHandler,
   );
 
   final ApiClient api;
@@ -39,7 +43,13 @@ class CompanionRuntime {
   /// Current device settings (mutable — updated via [updateSettings]).
   AppSettings settings;
 
-  static Future<CompanionRuntime> forConnection(Connection connection) async {
+  /// The media-session handler (lock-screen/Bluetooth/car), null in tests.
+  final CompanionAudioHandler? audioHandler;
+
+  static Future<CompanionRuntime> forConnection(
+    Connection connection, {
+    CompanionAudioHandler? handler,
+  }) async {
     final docs = await getApplicationDocumentsDirectory();
     final root = '${docs.path}/companion';
 
@@ -76,8 +86,55 @@ class CompanionRuntime {
     await player.setSpeed(settings.defaultSpeed);
     await player.setVolumeBoost(settings.volumeBoostDb);
 
-    return CompanionRuntime._(
-        api, library, sync, player, thumbnails, settingsStore, settings);
+    // app-5/app-9: connect the media session (lock-screen / Bluetooth / car) to
+    // the live player + a library-backed browse tree.
+    handler?.attach(
+      player,
+      childrenProvider: (parentId) async {
+        final parsed = parseMediaId(parentId);
+        if (parsed.kind == MediaIdKind.book && parsed.bookId != null) {
+          try {
+            await sync.ensureDetail(parsed.bookId!);
+          } catch (_) {/* offline — fall back to local rows */}
+          final chs = await library.chaptersForBook(parsed.bookId!);
+          return [
+            for (final c in chs)
+              MediaItem(
+                id: chapterMediaId(parsed.bookId!, c.uuid),
+                title: c.title.isEmpty ? 'Chapter ${c.chapterId}' : c.title,
+                playable: true,
+              ),
+          ];
+        }
+        final books = await library.listBooks();
+        return [
+          for (final b in books)
+            MediaItem(
+                id: bookMediaId(b.bookId),
+                title: b.title,
+                album: b.author,
+                playable: false),
+        ];
+      },
+      onPlayMediaId: (mediaId) async {
+        final parsed = parseMediaId(mediaId);
+        if (parsed.kind != MediaIdKind.chapter) return;
+        final bid = parsed.bookId!;
+        try {
+          await sync.ensureDetail(bid);
+        } catch (_) {/* offline */}
+        BookSummary? meta;
+        for (final b in await library.listBooks()) {
+          if (b.bookId == bid) meta = b;
+        }
+        await player.openBook(bid,
+            bookTitle: meta?.title ?? '', artPath: meta?.coverThumbPath);
+        await player.playChapter(parsed.uuid!);
+      },
+    );
+
+    return CompanionRuntime._(api, library, sync, player, thumbnails,
+        settingsStore, settings, handler);
   }
 
   /// Persist new settings and apply the playback-affecting ones immediately.
@@ -89,6 +146,7 @@ class CompanionRuntime {
   }
 
   Future<void> dispose() async {
+    audioHandler?.detach();
     await player.dispose();
     await library.close();
   }

--- a/apps/android/lib/src/data/just_audio_engine.dart
+++ b/apps/android/lib/src/data/just_audio_engine.dart
@@ -23,6 +23,12 @@ class JustAudioEngine implements AudioEngine {
   Stream<Duration> get positionStream => _player.positionStream;
 
   @override
+  bool get playing => _player.playing;
+
+  @override
+  Stream<bool> get playingStream => _player.playingStream;
+
+  @override
   Duration? get duration => _player.duration;
 
   @override

--- a/apps/android/lib/src/data/player_controller.dart
+++ b/apps/android/lib/src/data/player_controller.dart
@@ -4,11 +4,39 @@ import '../domain/skip_behavior.dart';
 import 'audio_engine.dart';
 import 'playback_store.dart';
 
-/// One chapter the player can load: its stable `uuid` and local file path.
+/// One chapter the player can load: its stable `uuid` and local file path,
+/// plus display metadata (title/duration) for the media-session notification.
 class PlayableChapter {
-  const PlayableChapter({required this.uuid, required this.path});
+  const PlayableChapter({
+    required this.uuid,
+    required this.path,
+    this.title = '',
+    this.durationSec,
+  });
   final String uuid;
   final String path;
+  final String title;
+  final double? durationSec;
+}
+
+/// Pure now-playing snapshot; the audio-service handler maps it to a MediaItem
+/// for the lock-screen / notification / car display. No audio_service import
+/// here keeps [PlayerController] unit-testable.
+class NowPlaying {
+  const NowPlaying({
+    required this.id,
+    required this.bookId,
+    required this.title,
+    required this.album,
+    this.artPath,
+    this.duration,
+  });
+  final String id; // chapter uuid
+  final String bookId;
+  final String title; // chapter title
+  final String album; // book title
+  final String? artPath; // cover thumbnail file path
+  final Duration? duration;
 }
 
 /// Resolves a book's ordered, locally-available chapters (built from the
@@ -48,8 +76,12 @@ class PlayerController {
 
   StreamSubscription<Duration>? _sub;
   StreamSubscription<void>? _completionSub;
+  final StreamController<NowPlaying?> _nowPlaying =
+      StreamController<NowPlaying?>.broadcast();
   List<PlayableChapter> _playlist = const [];
   String? _bookId;
+  String _bookTitle = '';
+  String? _artPath;
   int _index = -1;
   double _speed = 1.0;
   double _boostDb = 0;
@@ -58,6 +90,14 @@ class PlayerController {
   /// Live playback duration of the loaded chapter (null until known).
   Stream<Duration?> get durationStream => _engine.durationStream;
   Duration? get duration => _engine.duration;
+
+  /// Playing/paused for the media session.
+  Stream<bool> get playingStream => _engine.playingStream;
+  bool get playing => _engine.playing;
+
+  /// Emits on every chapter load (incl. auto-advance) so the media session
+  /// updates the lock-screen / car title + artwork.
+  Stream<NowPlaying?> get nowPlayingStream => _nowPlaying.stream;
 
   double get speed => _speed;
   Future<void> setSpeed(double speed) {
@@ -101,8 +141,11 @@ class PlayerController {
 
   /// Prepare a book for playback: load its playlist, restore the saved resume
   /// point (or start at the first chapter), and seek there.
-  Future<void> openBook(String bookId) async {
+  Future<void> openBook(String bookId,
+      {String bookTitle = '', String? artPath}) async {
     _bookId = bookId;
+    _bookTitle = bookTitle;
+    _artPath = artPath;
     _playlist = await _loadPlaylist(bookId);
     final saved = await _store.loadPlayback(bookId);
     var index = 0;
@@ -116,7 +159,18 @@ class PlayerController {
   Future<void> _loadIndex(int index, {int seekMs = 0}) async {
     if (index < 0 || index >= _playlist.length) return;
     _index = index;
-    await _engine.setFilePath(_playlist[index].path);
+    final c = _playlist[index];
+    _nowPlaying.add(NowPlaying(
+      id: c.uuid,
+      bookId: _bookId ?? '',
+      title: c.title.isEmpty ? 'Chapter ${index + 1}' : c.title,
+      album: _bookTitle,
+      artPath: _artPath,
+      duration: c.durationSec != null
+          ? Duration(milliseconds: (c.durationSec! * 1000).round())
+          : null,
+    ));
+    await _engine.setFilePath(c.path);
     if (_speed != 1.0) await _engine.setSpeed(_speed); // persist speed across chapters
     if (_boostDb > 0) await _engine.setVolumeBoost(_boostDb); // persist boost too
     if (seekMs > 0) await _engine.seek(Duration(milliseconds: seekMs));
@@ -186,6 +240,7 @@ class PlayerController {
   Future<void> dispose() async {
     await _sub?.cancel();
     await _completionSub?.cancel();
+    await _nowPlaying.close();
     await _engine.dispose();
   }
 }

--- a/apps/android/lib/src/data/sync_controller.dart
+++ b/apps/android/lib/src/data/sync_controller.dart
@@ -179,6 +179,8 @@ class SyncController {
           PlayableChapter(
             uuid: c.uuid,
             path: _library.audioPath(bookId, c.uuid, c.urlSuffix!),
+            title: c.title,
+            durationSec: c.durationSec,
           ),
     ];
   }

--- a/apps/android/lib/src/ui/player_screen.dart
+++ b/apps/android/lib/src/ui/player_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../data/companion_runtime.dart';
 import '../data/player_controller.dart';
 import '../domain/listen_progress.dart';
+import '../domain/resume_reconcile.dart';
 import '../domain/sync_manifest.dart';
 import 'waveform_bar.dart';
 
@@ -55,6 +56,10 @@ class _PlayerScreenState extends State<PlayerScreen> {
   Future<void> _prepare() async {
     try {
       await widget.runtime.sync.ensureDetail(widget.bookId);
+      // app-6: pull a newer server position before restoring (offline-safe).
+      try {
+        await widget.runtime.resumeSync.syncBook(widget.bookId);
+      } catch (_) {/* offline / no server record */}
       final art = await widget.runtime.library.coverThumbPath(widget.bookId);
       await widget.runtime.player.openBook(widget.bookId,
           bookTitle: widget.title, artPath: art); // loads + restores resume
@@ -73,7 +78,12 @@ class _PlayerScreenState extends State<PlayerScreen> {
 
   @override
   void dispose() {
-    widget.runtime.player.pause();
+    // Save locally, then push the latest position to the server (app-6),
+    // best-effort + offline-safe.
+    widget.runtime.player
+        .pause()
+        .then((_) => widget.runtime.resumeSync.syncBook(widget.bookId))
+        .catchError((_) => ResumeAction.noop);
     super.dispose();
   }
 

--- a/apps/android/lib/src/ui/player_screen.dart
+++ b/apps/android/lib/src/ui/player_screen.dart
@@ -55,7 +55,10 @@ class _PlayerScreenState extends State<PlayerScreen> {
   Future<void> _prepare() async {
     try {
       await widget.runtime.sync.ensureDetail(widget.bookId);
-      await widget.runtime.player.openBook(widget.bookId); // loads + restores resume
+      final art = await widget.runtime.library.coverThumbPath(widget.bookId);
+      await widget.runtime.player.openBook(widget.bookId,
+          bookTitle: widget.title, artPath: art); // loads + restores resume
+      // feeds the lock-screen/notification metadata via nowPlayingStream
       if (mounted) {
         setState(() {
           _chapters = widget.runtime.sync.chaptersOf(widget.bookId);

--- a/apps/android/test/data/player_controller_test.dart
+++ b/apps/android/test/data/player_controller_test.dart
@@ -37,10 +37,25 @@ class FakeAudioEngine implements AudioEngine {
     calls.add('stream:$url');
   }
 
+  bool _playing = false;
+  final _playingCtl = StreamController<bool>.broadcast();
   @override
-  Future<void> play() async => calls.add('play');
+  bool get playing => _playing;
   @override
-  Future<void> pause() async => calls.add('pause');
+  Stream<bool> get playingStream => _playingCtl.stream;
+  @override
+  Future<void> play() async {
+    _playing = true;
+    _playingCtl.add(true);
+    calls.add('play');
+  }
+
+  @override
+  Future<void> pause() async {
+    _playing = false;
+    _playingCtl.add(false);
+    calls.add('pause');
+  }
   @override
   Future<void> seek(Duration p) async {
     _position = p;
@@ -52,7 +67,10 @@ class FakeAudioEngine implements AudioEngine {
   @override
   Future<void> setVolumeBoost(double db) async => calls.add('boost:$db');
   @override
-  Future<void> dispose() async => _pos.close();
+  Future<void> dispose() async {
+    await _pos.close();
+    await _playingCtl.close();
+  }
 
   void emit(Duration p) {
     _position = p;
@@ -195,6 +213,27 @@ void main() {
       engine.calls.clear();
       await pc.skip(forward: true); // next chapter
       expect(engine.calls, contains('boost:8.0')); // persisted across chapters
+      await pc.dispose();
+    });
+
+    test('nowPlayingStream emits chapter + book metadata on load', () async {
+      final engine = FakeAudioEngine();
+      final pc = make(engine, MemPlaybackStore(), playlists: {
+        'b1': const [
+          PlayableChapter(
+              uuid: 'u1', path: '/b1/u1/a.mp3', title: 'Intro', durationSec: 60),
+        ],
+      });
+      final events = <NowPlaying?>[];
+      final sub = pc.nowPlayingStream.listen(events.add);
+      await pc.openBook('b1', bookTitle: 'My Book', artPath: '/art.jpg');
+      await Future<void>.delayed(Duration.zero);
+      final np = events.whereType<NowPlaying>().last;
+      expect(np.title, 'Intro');
+      expect(np.album, 'My Book');
+      expect(np.artPath, '/art.jpg');
+      expect(np.duration, const Duration(seconds: 60));
+      await sub.cancel();
       await pc.dispose();
     });
 


### PR DESCRIPTION
## Summary

Two wiring-round items (bundled — branch-name collision forced them onto one branch; merging on local verification since GitHub Actions is billing-blocked).

### app-5 + app-9 — media session
The `CompanionAudioHandler` was never instantiated/`init`'d and the player ran `just_audio` directly → no background playback, lock-screen, Bluetooth, or Android Auto. Now: `AudioService.init` in `main()`, runtime `attach`es the live player, the handler **broadcasts** `playbackState` + `mediaItem` (title/album/duration/cover art) and routes controls inward; `PlayerController` emits a `NowPlaying` snapshot per chapter; Android Auto/CarPlay browse fed by a live library tree.

### app-6 — two-way resume sync
`ResumeSyncService` wired into the runtime (api + drift store + uuid→chapterId resolver). The player pulls a newer server position on open and pushes the local position on close (reconcile by `listenedAt`, srv-34; offline-safe). Listening position now flows back to the server.

## Test plan

`flutter analyze` clean; **191 Dart tests** (incl. new `nowPlayingStream`); debug APK builds; OS media session verified live via `dumpsys media_session`. **CI not run — GitHub Actions blocked by an account billing/spending-limit issue; iOS-compile last passed on #608 with the same plugin set.** On-device lock-screen/background + resume-sync to be confirmed on a physical phone.

Refs #545, #552, #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)