### PR TITLE
fix(frontend,server): group Resource trends by book + cap rows with a scroll

### DIFF
--- a/docs/features/175-resource-telemetry.md
+++ b/docs/features/175-resource-telemetry.md
@@ -19,6 +19,7 @@ owner: null
 
 ## Architectural impact
 
+- **`bookTitle` on the record (2026-06-07):** the JSONL record carries the human-readable `state.title` alongside the `bookId` slug, stamped at append time in `generation.ts`. Nullable for legacy records written before the field. The admin panel groups newest-first rows into contiguous per-book runs (`groupTelemetryByBook`) under a sticky header (label = `bookTitle ?? bookId ?? '(unknown book)'`), and caps the rows at `max-h-[60vh]` with `overflow-y-auto` so a long run scrolls inside the card instead of running off the page. Filed as a `bug` (no scroll + no book name in the table).
 - **New module** `resource-telemetry.ts`: `ResourceTelemetryRecord`, `TELEMETRY_MAX_LINES = 2000`, `telemetryFilePath()` = `<WORKSPACE_ROOT>/.telemetry/resource-telemetry.jsonl` (new `telemetryDir()` in `paths.ts`, mirroring `.backups`), `appendTelemetry(rec)` (append one JSONL line, dir auto-create, trim oldest over cap, best-effort — swallows IO errors), `readTelemetry(limit?)` (newest-first, skips a corrupt trailing line).
 - `generation.ts` completion block: **fire-and-forget** `void appendTelemetry({...})` right after `recordChapterThroughput` — never awaited, never blocks the hot path. `wallSec = synthSec`; VRAM/host-RAM via a best-effort `probeSidecarHealth()` (short timeout, gated on a sidecar engine), nulls on timeout.
 - **New endpoint** `GET /api/generation/telemetry?limit=` mounted on the existing `generationStatsRouter` → `{ records: ResourceTelemetryRecord[] }` newest-first. `api.getResourceTelemetry()` (real + mock).
@@ -29,10 +30,11 @@ owner: null
 1. The telemetry append is **fire-and-forget** and best-effort — a telemetry failure must never affect chapter generation or RTF.
 2. The JSONL is capped at `TELEMETRY_MAX_LINES`; rotation drops the oldest; a corrupt trailing line is skipped, not thrown.
 3. The panel lives in the **admin console** (`src/views/admin.tsx`), not the DEV-only worktrees view (the fs-20 issue predated the worktrees→admin fold).
+4. Rows group into **contiguous** per-book runs (split on every `bookId` change), preserving the newest-first chronological order — never collapse all of a book's rows together, which would reorder interleaved multi-book runs.
 
 ## Test plan
 
-- **Automated:** `server/src/tts/resource-telemetry.test.ts` — append N to a temp dir; JSONL round-trips; cap rotation drops oldest; `readTelemetry(limit)` newest-first + honors limit; partial trailing line skipped. `server/src/routes/generation-stats.test.ts` — `GET /telemetry` returns records. `src/views/admin.test.tsx` — mock `api.getResourceTelemetry`; panel renders rows incl. VRAM + wall columns + sparkline; empty → "No telemetry recorded yet."
+- **Automated:** `server/src/tts/resource-telemetry.test.ts` — append N to a temp dir; JSONL round-trips; cap rotation drops oldest; `readTelemetry(limit)` newest-first + honors limit; partial trailing line skipped. `server/src/routes/generation-stats.test.ts` — `GET /telemetry` returns records. `src/views/admin.test.tsx` — mock `api.getResourceTelemetry`; panel renders rows incl. VRAM + wall columns + sparkline; empty → "No telemetry recorded yet."; rows group under a per-book header splitting on `bookId` change; header falls back `bookTitle → bookId → '(unknown book)'`.
 - **Manual:** generate a few chapters, open `#/admin`, confirm the Resource trends panel shows RTF + VRAM + wall-time rows and the sparkline tracks RTF.
 
 ## Ship notes

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4627,7 +4627,7 @@ components:
     ResourceTelemetryRecord:
       type: object
       required:
-        [at, bookId, chapterId, title, modelKey, rtf, audioSec, wallSec, vramReservedMb, vramTotalMb, committedHostMb]
+        [at, bookId, bookTitle, chapterId, title, modelKey, rtf, audioSec, wallSec, vramReservedMb, vramTotalMb, committedHostMb]
       description: |
         One per-chapter telemetry sample captured right after a chapter
         rendered: throughput (RTF, audio/wall seconds) + GPU and host-RAM
@@ -4636,6 +4636,7 @@ components:
       properties:
         at: { type: string, format: date-time }
         bookId: { type: string, nullable: true }
+        bookTitle: { type: string, nullable: true, description: 'Human-readable book title at render time (state.json title); null for legacy records written before this field or when the book title was unknown.' }
         chapterId:
           oneOf:
             - type: integer

--- a/server/src/routes/generation-stats.test.ts
+++ b/server/src/routes/generation-stats.test.ts
@@ -103,6 +103,7 @@ describe('GET /api/generation/telemetry (fs-20)', () => {
     await appendTelemetry({
       at: new Date().toISOString(),
       bookId: 'book-a',
+      bookTitle: 'Book A',
       chapterId: 1,
       title: 'Chapter 1',
       modelKey: 'qwen3-tts-0.6b',
@@ -116,6 +117,7 @@ describe('GET /api/generation/telemetry (fs-20)', () => {
     await appendTelemetry({
       at: new Date().toISOString(),
       bookId: 'book-a',
+      bookTitle: 'Book A',
       chapterId: 2,
       title: 'Chapter 2',
       modelKey: 'qwen3-tts-0.6b',
@@ -137,6 +139,7 @@ describe('GET /api/generation/telemetry (fs-20)', () => {
       await appendTelemetry({
         at: new Date().toISOString(),
         bookId: 'book-a',
+        bookTitle: 'Book A',
         chapterId: i,
         title: `Chapter ${i}`,
         modelKey: 'qwen3-tts-0.6b',

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -1425,6 +1425,7 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
         await appendTelemetry({
           at: new Date().toISOString(),
           bookId: job.bookId,
+          bookTitle: state.title ?? null,
           chapterId: chapter.id,
           title: chapter.title ?? null,
           modelKey,

--- a/server/src/tts/resource-telemetry.test.ts
+++ b/server/src/tts/resource-telemetry.test.ts
@@ -16,6 +16,7 @@ let telemetryFilePath: () => string;
 const rec = (over: Partial<Parameters<typeof mod.appendTelemetry>[0]> = {}) => ({
   at: new Date().toISOString(),
   bookId: 'book-a',
+  bookTitle: 'Book A',
   chapterId: 1,
   title: 'Chapter 1',
   modelKey: 'qwen3-tts-0.6b',
@@ -58,6 +59,7 @@ describe('resource-telemetry', () => {
     expect(out[0].chapterId).toBe(7);
     expect(out[0].rtf).toBe(0.9);
     expect(out[0].vramTotalMb).toBe(8192);
+    expect(out[0].bookTitle).toBe('Book A');
   });
 
   it('returns records newest-first and honours the limit', async () => {

--- a/server/src/tts/resource-telemetry.ts
+++ b/server/src/tts/resource-telemetry.ts
@@ -17,6 +17,9 @@ import { join } from 'node:path';
 export interface ResourceTelemetryRecord {
   at: string;
   bookId: string | null;
+  /** Human-readable book title at render time (state.json `title`). Null for
+      legacy records written before this field, or when the title was unknown. */
+  bookTitle: string | null;
   chapterId: number | string;
   title: string | null;
   modelKey: string | null;

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -3480,6 +3480,8 @@ export interface components {
             /** Format: date-time */
             at: string;
             bookId: string | null;
+            /** @description Human-readable book title at render time (state.json title); null for legacy records written before this field or when the book title was unknown. */
+            bookTitle: string | null;
             chapterId: number | string;
             title: string | null;
             modelKey: string | null;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5313,10 +5313,22 @@ const mock = {
   getResourceTelemetry: async (
     limit?: number,
   ): Promise<{ records: ResourceTelemetryRecord[] }> => {
+    /* Newest-first; the first three rows come from a second book so the Admin
+       panel's per-book grouping has more than one group to render in mock mode. */
+    const books = [
+      { bookId: 'mock-book-stellarlune', bookTitle: 'Stellarlune' },
+      { bookId: 'mock-book-stellarlune', bookTitle: 'Stellarlune' },
+      { bookId: 'mock-book-stellarlune', bookTitle: 'Stellarlune' },
+      { bookId: 'mock-book-unlocked', bookTitle: 'Unlocked' },
+      { bookId: 'mock-book-unlocked', bookTitle: 'Unlocked' },
+      { bookId: 'mock-book-unlocked', bookTitle: 'Unlocked' },
+      { bookId: 'mock-book-unlocked', bookTitle: 'Unlocked' },
+    ];
     const records: ResourceTelemetryRecord[] = [2.41, 2.12, 1.78, 1.5, 1.31, 1.12, 0.94].map(
       (rtf, i) => ({
         at: new Date(Date.parse('2026-06-01T09:00:00Z') + (6 - i) * 9 * 60_000).toISOString(),
-        bookId: 'mock-book',
+        bookId: books[i].bookId,
+        bookTitle: books[i].bookTitle,
         chapterId: 7 - i,
         title: `Chapter ${7 - i}`,
         modelKey: 'qwen3-tts-0.6b',

--- a/src/views/admin.test.tsx
+++ b/src/views/admin.test.tsx
@@ -70,6 +70,7 @@ const chapter = (over: Partial<RecentChapter>): RecentChapter => ({
 const telemetry = (over: Partial<ResourceTelemetryRecord>): ResourceTelemetryRecord => ({
   at: '2026-06-01T09:00:00Z',
   bookId: 'book-a',
+  bookTitle: 'Book A',
   chapterId: 1,
   title: 'Chapter 1',
   modelKey: 'qwen3-tts-0.6b',
@@ -284,6 +285,44 @@ describe('AdminView — fs-20 resource trends panel', () => {
     expect(within(rows[0]).getByText('21:00')).toBeInTheDocument();
     /* Hand-rolled sparkline present (>= 2 points). */
     expect(within(panel).getByTestId('resource-rtf-sparkline')).toBeInTheDocument();
+  });
+
+  it('groups rows under a sticky per-book header, splitting on book change', async () => {
+    mockTelemetry.mockResolvedValue({
+      records: [
+        telemetry({ chapterId: 26, bookId: 'stellarlune', bookTitle: 'Stellarlune' }),
+        telemetry({ chapterId: 25, bookId: 'stellarlune', bookTitle: 'Stellarlune' }),
+        telemetry({ chapterId: 4, bookId: 'unlocked', bookTitle: 'Unlocked' }),
+      ],
+    });
+    renderAdmin();
+
+    const panel = await screen.findByTestId('resource-trends');
+    const headers = within(panel)
+      .getAllByTestId('resource-book-header')
+      .map((h) => h.textContent);
+    expect(headers).toEqual(['Stellarlune', 'Unlocked']);
+
+    /* The Stellarlune group owns the first two chapter rows; Unlocked owns one. */
+    const groups = within(panel).getAllByTestId('resource-book-group');
+    expect(within(groups[0]).getAllByTestId(/^resource-row-/)).toHaveLength(2);
+    expect(within(groups[1]).getAllByTestId(/^resource-row-/)).toHaveLength(1);
+  });
+
+  it('falls back to the bookId, then a placeholder, when the title is absent', async () => {
+    mockTelemetry.mockResolvedValue({
+      records: [
+        telemetry({ chapterId: 2, bookId: 'legacy-slug', bookTitle: null }),
+        telemetry({ chapterId: 1, bookId: null, bookTitle: null }),
+      ],
+    });
+    renderAdmin();
+
+    const panel = await screen.findByTestId('resource-trends');
+    const headers = within(panel)
+      .getAllByTestId('resource-book-header')
+      .map((h) => h.textContent);
+    expect(headers).toEqual(['legacy-slug', '(unknown book)']);
   });
 
   it('shows the empty-state copy when no telemetry has been recorded', async () => {

--- a/src/views/admin.tsx
+++ b/src/views/admin.tsx
@@ -373,6 +373,28 @@ function GenerationThroughput({ stats }: { stats: GenerationStatsResponse | null
    compact per-chapter table plus a hand-rolled inline SVG sparkline of RTF
    across the records (no charting dep). VRAM (reserved/total) + wall-time
    columns surface the resource pressure that climbs across a long run. */
+/* Group newest-first telemetry into contiguous runs by book, so a long
+   workspace run reads as "Stellarlune (chapters…), Unlocked (chapters…)"
+   rather than an undifferentiated wall of chapter numbers. We split on every
+   bookId change rather than collapsing all of a book's rows together, so the
+   chronological newest-first ordering is preserved even when two books'
+   generations interleave. Label falls back bookTitle → bookId → unknown. */
+function groupTelemetryByBook(
+  records: ResourceTelemetryRecord[],
+): Array<{ key: string; label: string; rows: ResourceTelemetryRecord[] }> {
+  const groups: Array<{ key: string; label: string; rows: ResourceTelemetryRecord[] }> = [];
+  for (const r of records) {
+    const key = r.bookId ?? r.bookTitle ?? '';
+    const last = groups[groups.length - 1];
+    if (last && last.key === key) {
+      last.rows.push(r);
+    } else {
+      groups.push({ key, label: r.bookTitle ?? r.bookId ?? '(unknown book)', rows: [r] });
+    }
+  }
+  return groups;
+}
+
 function ResourceTrends() {
   const [records, setRecords] = useState<ResourceTelemetryRecord[]>([]);
   const [loaded, setLoaded] = useState(false);
@@ -426,28 +448,47 @@ function ResourceTrends() {
             <span className="text-right hidden sm:block">Wall</span>
             <span className="text-right">VRAM</span>
           </div>
-          <div className="divide-y divide-ink/5">
-            {records.map((r) => (
-              <div
-                key={`${r.bookId ?? ''}:${r.chapterId}:${r.at}`}
-                className="grid grid-cols-[1fr_auto_auto_auto] gap-x-3 sm:gap-x-6 items-center px-4 py-2.5 text-sm"
-                data-testid={`resource-row-${r.chapterId}`}
-              >
-                <span className="min-w-0 truncate text-ink">
-                  <span className="text-ink/40 font-mono mr-2">#{r.chapterId}</span>
-                  {r.title ?? <span className="text-ink/40">(untitled)</span>}
-                </span>
-                <span className="text-right font-mono tabular-nums text-ink/80">{fmtRtf(r.rtf)}</span>
-                <span className="text-right font-mono tabular-nums text-ink/50 hidden sm:block">
-                  {formatDuration(r.wallSec)}
-                </span>
-                <span className="text-right font-mono tabular-nums text-ink/50">
-                  {r.vramReservedMb == null
-                    ? '–'
-                    : `${(r.vramReservedMb / 1024).toFixed(1)}${
-                        r.vramTotalMb != null ? ` / ${(r.vramTotalMb / 1024).toFixed(1)}` : ''
-                      } GB`}
-                </span>
+          {/* Cap the rows at ~60% of the viewport and scroll inside — a long run
+              records hundreds of chapters that would otherwise run off the page.
+              Each book's chapters sit under a sticky header so you can tell which
+              book a row belongs to once you've scrolled past the top group. */}
+          <div className="max-h-[60vh] overflow-y-auto" data-testid="resource-trends-scroll">
+            {groupTelemetryByBook(records).map((group, gi) => (
+              <div key={`${group.key}:${gi}`} data-testid="resource-book-group">
+                <div
+                  className="sticky top-0 z-10 bg-white px-4 py-1.5 text-xs font-medium text-ink/70 border-b border-ink/5 truncate"
+                  data-testid="resource-book-header"
+                  title={group.label}
+                >
+                  {group.label}
+                </div>
+                <div className="divide-y divide-ink/5">
+                  {group.rows.map((r) => (
+                    <div
+                      key={`${r.bookId ?? ''}:${r.chapterId}:${r.at}`}
+                      className="grid grid-cols-[1fr_auto_auto_auto] gap-x-3 sm:gap-x-6 items-center px-4 py-2.5 text-sm"
+                      data-testid={`resource-row-${r.chapterId}`}
+                    >
+                      <span className="min-w-0 truncate text-ink">
+                        <span className="text-ink/40 font-mono mr-2">#{r.chapterId}</span>
+                        {r.title ?? <span className="text-ink/40">(untitled)</span>}
+                      </span>
+                      <span className="text-right font-mono tabular-nums text-ink/80">
+                        {fmtRtf(r.rtf)}
+                      </span>
+                      <span className="text-right font-mono tabular-nums text-ink/50 hidden sm:block">
+                        {formatDuration(r.wallSec)}
+                      </span>
+                      <span className="text-right font-mono tabular-nums text-ink/50">
+                        {r.vramReservedMb == null
+                          ? '–'
+                          : `${(r.vramReservedMb / 1024).toFixed(1)}${
+                              r.vramTotalMb != null ? ` / ${(r.vramTotalMb / 1024).toFixed(1)}` : ''
+                            } GB`}
+                      </span>
+                    </div>
+                  ))}
+                </div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary

The Admin → **Resource trends** panel listed every chapter across a run with no scroll (rows ran off the page) and no indication of which book a chapter belonged to.

- Add a human-readable `bookTitle` to the telemetry record (stamped from `state.json` at append time; nullable for legacy records).
- Group the newest-first rows into **contiguous per-book runs** under a sticky header (label falls back `bookTitle → bookId → '(unknown book)'`), preserving chronological order even when books interleave.
- Cap the rows at `max-h-[60vh]` with `overflow-y-auto` so a long run scrolls inside the card.

Verified in the real browser (mock mode): Stellarlune / Unlocked group headers render; rows sit in a `max-height: 540px` `overflow-y: auto` container; 0 console errors.

## Test plan

- `server/src/tts/resource-telemetry.test.ts` — `bookTitle` round-trips.
- `src/views/admin.test.tsx` — rows group under a per-book header splitting on `bookId` change; header falls back `bookTitle → bookId → '(unknown book)'`.
- `server/src/routes/generation-stats.test.ts` — updated `appendTelemetry` literals for the new required field.
- Typecheck + affected suites green locally; visual verify in browser.

Regression plan: `docs/features/175-resource-telemetry.md`.

Closes #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)