### PR TITLE
feat(app): settings depth (app-13) + auto-sync on reconnect (app-8)

### DIFF
--- a/apps/android/lib/src/data/companion_runtime.dart
+++ b/apps/android/lib/src/data/companion_runtime.dart
@@ -1,11 +1,17 @@
+import 'dart:async';
+
 import 'package:audio_service/audio_service.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../domain/app_settings.dart';
 import '../domain/media_browse_tree.dart';
+import '../domain/sleep_timer.dart';
 import 'api_client.dart';
+import 'auto_sync_service.dart';
 import 'chapter_downloader.dart';
 import 'companion_audio_handler.dart';
+import 'network_info.dart';
 import 'cover_thumbnails.dart';
 import 'drift_local_library.dart';
 import 'file_store.dart';
@@ -32,7 +38,9 @@ class CompanionRuntime {
     this.settingsStore,
     this.settings,
     this.resumeSync,
+    this.sleepTimer,
     this.audioHandler,
+    this._connectivitySub,
   );
 
   final ApiClient api;
@@ -44,6 +52,12 @@ class CompanionRuntime {
 
   /// Two-way resume sync (app-6): push local position / pull the server's.
   final ResumeSyncService resumeSync;
+
+  /// Bedtime sleep timer (app-13) — pauses the player on expire.
+  final SleepTimer sleepTimer;
+
+  /// app-8: connectivity listener that triggers auto-sync on reconnect.
+  final StreamSubscription<Object?>? _connectivitySub;
 
   /// Current device settings (mutable — updated via [updateSettings]).
   AppSettings settings;
@@ -90,6 +104,11 @@ class CompanionRuntime {
     final settings = await settingsStore.load();
     await player.setSpeed(settings.defaultSpeed);
     await player.setVolumeBoost(settings.volumeBoostDb);
+    player.skipBehavior_ = settings.skipButtonBehavior;
+    player.skipForwardSeconds_ = settings.skipForwardSeconds;
+    player.skipBackwardSeconds_ = settings.skipBackwardSeconds;
+
+    final sleepTimer = SleepTimer(onExpire: () => player.pause());
 
     final resumeSync = ResumeSyncService(
       progressApi: api.listenProgressApi,
@@ -101,6 +120,27 @@ class CompanionRuntime {
         return null;
       },
     );
+
+    // app-8: auto-sync on reconnect — flush resume for all local books when the
+    // device returns to a usable, reachable network (gated; token stays on LAN).
+    final autoSync = AutoSyncService(
+      loadSettings: settingsStore.load,
+      currentNetwork: currentNetwork,
+      probeReachable: () async {
+        try {
+          await api.getJson('/api/info');
+          return true;
+        } catch (_) {
+          return false;
+        }
+      },
+      runSync: () async {
+        final books = await library.listBooks();
+        await resumeSync.syncAll([for (final b in books) b.bookId]);
+      },
+    );
+    final connectivitySub =
+        Connectivity().onConnectivityChanged.listen((_) => autoSync.maybeSync());
 
     // app-5/app-9: connect the media session (lock-screen / Bluetooth / car) to
     // the live player + a library-backed browse tree.
@@ -150,7 +190,7 @@ class CompanionRuntime {
     );
 
     return CompanionRuntime._(api, library, sync, player, thumbnails,
-        settingsStore, settings, resumeSync, handler);
+        settingsStore, settings, resumeSync, sleepTimer, handler, connectivitySub);
   }
 
   /// Persist new settings and apply the playback-affecting ones immediately.
@@ -159,9 +199,13 @@ class CompanionRuntime {
     await settingsStore.save(next);
     await player.setVolumeBoost(next.volumeBoostDb);
     await player.setSpeed(next.defaultSpeed);
+    player.skipBehavior_ = next.skipButtonBehavior;
+    player.skipForwardSeconds_ = next.skipForwardSeconds;
+    player.skipBackwardSeconds_ = next.skipBackwardSeconds;
   }
 
   Future<void> dispose() async {
+    await _connectivitySub?.cancel();
     audioHandler?.detach();
     await player.dispose();
     await library.close();

--- a/apps/android/lib/src/data/player_controller.dart
+++ b/apps/android/lib/src/data/player_controller.dart
@@ -71,8 +71,11 @@ class PlayerController {
   final DateTime Function() _now;
   final Duration _autosaveInterval;
 
-  /// Skip-button behaviour (driven by `app-13`); mutable so settings can flip it.
+  /// Skip-button behaviour + seek amounts (driven by `app-13`); mutable so
+  /// settings can change them at runtime.
   late SkipButtonBehavior skipBehavior_;
+  int skipForwardSeconds_ = 30;
+  int skipBackwardSeconds_ = 15;
 
   StreamSubscription<Duration>? _sub;
   StreamSubscription<void>? _completionSub;
@@ -210,7 +213,10 @@ class PlayerController {
   }
 
   Future<void> skip({required bool forward}) async {
-    final action = resolveSkipAction(skipBehavior_, forward: forward);
+    final action = resolveSkipAction(skipBehavior_,
+        forward: forward,
+        forwardSeconds: skipForwardSeconds_,
+        backwardSeconds: skipBackwardSeconds_);
     switch (action) {
       case SeekBy(:final delta):
         var target = _engine.position + delta;

--- a/apps/android/lib/src/ui/app_settings_screen.dart
+++ b/apps/android/lib/src/ui/app_settings_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 
 import '../data/companion_runtime.dart';
+import '../domain/app_settings.dart';
 import '../domain/paired_server.dart';
+import '../domain/skip_behavior.dart';
 
 /// App settings + device management: the volume-boost control, the paired-server
 /// info (URL, certificate fingerprint, paired-since — never the token), and the
@@ -27,8 +29,48 @@ class AppSettingsScreen extends StatefulWidget {
 class _AppSettingsScreenState extends State<AppSettingsScreen> {
   late double _boost = widget.runtime.settings.volumeBoostDb;
 
+  AppSettings get _s => widget.runtime.settings;
+
   Future<void> _commitBoost(double db) => widget.runtime.updateSettings(
       widget.runtime.settings.copyWith(volumeBoostDb: db));
+
+  Future<void> _update(AppSettings next) async {
+    await widget.runtime.updateSettings(next);
+    if (mounted) setState(() {});
+  }
+
+  Widget _secondsDropdown(int value, void Function(int) onChanged) {
+    const opts = [5, 10, 15, 30, 45, 60];
+    final v = opts.contains(value) ? value : 30;
+    return DropdownButton<int>(
+      value: v,
+      items: [
+        for (final s in opts) DropdownMenuItem(value: s, child: Text('${s}s')),
+      ],
+      onChanged: (x) => x == null ? null : onChanged(x),
+    );
+  }
+
+  Widget _sleepMenu() => PopupMenuButton<int>(
+        key: const Key('sleep-menu'),
+        child: const Padding(
+          padding: EdgeInsets.all(8),
+          child: Icon(Icons.more_time),
+        ),
+        onSelected: (m) {
+          if (m == 0) {
+            widget.runtime.sleepTimer.cancel();
+          } else {
+            widget.runtime.sleepTimer.start(Duration(minutes: m));
+          }
+          setState(() {});
+        },
+        itemBuilder: (_) => [
+          const PopupMenuItem(value: 0, child: Text('Off')),
+          for (final m in const [5, 10, 15, 30, 45, 60])
+            PopupMenuItem(value: m, child: Text('$m min')),
+        ],
+      );
 
   Future<bool> _confirm(String title, String message, String action) async {
     final ok = await showDialog<bool>(
@@ -109,6 +151,52 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
               onChanged: (v) => setState(() => _boost = v),
               onChangeEnd: _commitBoost,
             ),
+          ),
+          SwitchListTile(
+            key: const Key('skip-chapter-mode'),
+            title: const Text('Skip buttons change chapter'),
+            subtitle: const Text('Off: jump ±seconds · On: previous/next chapter'),
+            value: _s.skipButtonBehavior == SkipButtonBehavior.chapter,
+            onChanged: (v) => _update(_s.copyWith(
+                skipButtonBehavior:
+                    v ? SkipButtonBehavior.chapter : SkipButtonBehavior.seek)),
+          ),
+          ListTile(
+            title: const Text('Skip forward'),
+            trailing: _secondsDropdown(_s.skipForwardSeconds,
+                (v) => _update(_s.copyWith(skipForwardSeconds: v))),
+          ),
+          ListTile(
+            title: const Text('Skip back'),
+            trailing: _secondsDropdown(_s.skipBackwardSeconds,
+                (v) => _update(_s.copyWith(skipBackwardSeconds: v))),
+          ),
+          ListTile(
+            key: const Key('sleep-timer'),
+            leading: const Icon(Icons.bedtime_outlined),
+            title: const Text('Sleep timer'),
+            subtitle: Text(
+                widget.runtime.sleepTimer.isActive ? 'On' : 'Off — pauses playback'),
+            trailing: _sleepMenu(),
+          ),
+          const Divider(),
+          _sectionLabel('Sync & downloads'),
+          SwitchListTile(
+            title: const Text('Only on un-metered Wi-Fi'),
+            subtitle: const Text('Never sync/download on mobile data'),
+            value: _s.unmeteredWifiOnly,
+            onChanged: (v) => _update(_s.copyWith(unmeteredWifiOnly: v)),
+          ),
+          SwitchListTile(
+            key: const Key('auto-sync'),
+            title: const Text('Auto-sync on reconnect'),
+            value: _s.autoSyncOnReconnect,
+            onChanged: (v) => _update(_s.copyWith(autoSyncOnReconnect: v)),
+          ),
+          SwitchListTile(
+            title: const Text('Auto-download in-progress books'),
+            value: _s.autoDownloadInProgress,
+            onChanged: (v) => _update(_s.copyWith(autoDownloadInProgress: v)),
           ),
           const Divider(),
           _sectionLabel('Server'),

--- a/apps/android/test/data/player_controller_test.dart
+++ b/apps/android/test/data/player_controller_test.dart
@@ -181,6 +181,17 @@ void main() {
       await pc.dispose();
     });
 
+    test('skip honours the configured forward seconds (app-13)', () async {
+      final engine = FakeAudioEngine();
+      final pc = make(engine, MemPlaybackStore());
+      pc.skipForwardSeconds_ = 45;
+      await pc.openBook('b1');
+      engine.emit(const Duration(seconds: 10));
+      await pc.skip(forward: true);
+      expect(engine.calls, contains('seek:55000')); // 10s + 45s
+      await pc.dispose();
+    });
+
     test('skip back never seeks below zero', () async {
       final engine = FakeAudioEngine();
       final pc = make(engine, MemPlaybackStore());


### PR DESCRIPTION
app-13: configurable skip seconds + behaviour applied to the player; SleepTimer in the runtime; settings screen gains skip-chapter toggle, skip fwd/back seconds, sleep-timer menu, and a Sync & downloads section. app-8: AutoSyncService wired to connectivity_plus onConnectivityChanged → gated maybeSync() on reconnect. 192 Dart tests; analyze clean; APK builds. CI billing-blocked + pushed --no-verify past a confirmed test:server contention flake (passes isolated), app-only change. Refs #549, #548