### PR TITLE
feat(app): finished-tracking + automatic storage eviction (app-4)

### DIFF
--- a/apps/android/lib/src/data/companion_runtime.dart
+++ b/apps/android/lib/src/data/companion_runtime.dart
@@ -7,6 +7,7 @@ import 'package:path_provider/path_provider.dart';
 import '../domain/app_settings.dart';
 import '../domain/media_browse_tree.dart';
 import '../domain/sleep_timer.dart';
+import '../domain/storage_policy.dart';
 import 'api_client.dart';
 import 'auto_sync_service.dart';
 import 'chapter_downloader.dart';
@@ -40,7 +41,7 @@ class CompanionRuntime {
     this.resumeSync,
     this.sleepTimer,
     this.audioHandler,
-    this._connectivitySub,
+    this._subs,
   );
 
   final ApiClient api;
@@ -56,8 +57,8 @@ class CompanionRuntime {
   /// Bedtime sleep timer (app-13) — pauses the player on expire.
   final SleepTimer sleepTimer;
 
-  /// app-8: connectivity listener that triggers auto-sync on reconnect.
-  final StreamSubscription<Object?>? _connectivitySub;
+  /// Background stream subscriptions (app-8 connectivity, app-4 finished-track).
+  final List<StreamSubscription<Object?>> _subs;
 
   /// Current device settings (mutable — updated via [updateSettings]).
   AppSettings settings;
@@ -142,6 +143,10 @@ class CompanionRuntime {
     final connectivitySub =
         Connectivity().onConnectivityChanged.listen((_) => autoSync.maybeSync());
 
+    // app-4: mark a chapter finished when it plays to its end.
+    final completedSub = player.chapterCompletedStream
+        .listen((uuid) => library.setChapterFinished(uuid, true));
+
     // app-5/app-9: connect the media session (lock-screen / Bluetooth / car) to
     // the live player + a library-backed browse tree.
     handler?.attach(
@@ -190,7 +195,20 @@ class CompanionRuntime {
     );
 
     return CompanionRuntime._(api, library, sync, player, thumbnails,
-        settingsStore, settings, resumeSync, sleepTimer, handler, connectivitySub);
+        settingsStore, settings, resumeSync, sleepTimer, handler,
+        [connectivitySub, completedSub]);
+  }
+
+  /// app-4: enforce the storage cap (auto-delete finished + LRU book eviction).
+  /// Call after a download lands.
+  Future<void> enforceStorageCap() async {
+    final plan = planStorageEviction(
+      books: await library.bookUsages(),
+      capBytes: settings.storageCapBytes,
+      autoDeleteFinished: settings.autoDeleteFinished,
+      keepRecentBooks: settings.keepRecentBooks,
+    );
+    await library.applyEviction(plan);
   }
 
   /// Persist new settings and apply the playback-affecting ones immediately.
@@ -205,7 +223,9 @@ class CompanionRuntime {
   }
 
   Future<void> dispose() async {
-    await _connectivitySub?.cancel();
+    for (final s in _subs) {
+      await s.cancel();
+    }
     audioHandler?.detach();
     await player.dispose();
     await library.close();

--- a/apps/android/lib/src/data/player_controller.dart
+++ b/apps/android/lib/src/data/player_controller.dart
@@ -62,7 +62,11 @@ class PlayerController {
         _autosaveInterval = saveInterval {
     skipBehavior_ = skipBehavior;
     _sub = _engine.positionStream.listen(_onTick);
-    _completionSub = _engine.completionStream.listen((_) => _advance());
+    _completionSub = _engine.completionStream.listen((_) {
+      final finished = currentChapterUuid;
+      if (finished != null) _chapterCompleted.add(finished);
+      _advance();
+    });
   }
 
   final AudioEngine _engine;
@@ -81,6 +85,11 @@ class PlayerController {
   StreamSubscription<void>? _completionSub;
   final StreamController<NowPlaying?> _nowPlaying =
       StreamController<NowPlaying?>.broadcast();
+
+  /// Emits a chapter's `uuid` when it plays to its end (app-4 finished-tracking).
+  final StreamController<String> _chapterCompleted =
+      StreamController<String>.broadcast();
+  Stream<String> get chapterCompletedStream => _chapterCompleted.stream;
   List<PlayableChapter> _playlist = const [];
   String? _bookId;
   String _bookTitle = '';
@@ -247,6 +256,7 @@ class PlayerController {
     await _sub?.cancel();
     await _completionSub?.cancel();
     await _nowPlaying.close();
+    await _chapterCompleted.close();
     await _engine.dispose();
   }
 }

--- a/apps/android/lib/src/ui/library_home_screen.dart
+++ b/apps/android/lib/src/ui/library_home_screen.dart
@@ -137,6 +137,7 @@ class _LibraryHomeScreenState extends State<LibraryHomeScreen> {
             setState(() => _progress[book.bookId] = t > 0 ? '$d/$t' : '…'),
       );
       if (mounted) setState(() => _progress.remove(book.bookId));
+      await widget.runtime.enforceStorageCap(); // app-4: keep under the cap
       await _refresh();
     } catch (e) {
       if (mounted) {

--- a/apps/android/lib/src/ui/player_screen.dart
+++ b/apps/android/lib/src/ui/player_screen.dart
@@ -60,6 +60,9 @@ class _PlayerScreenState extends State<PlayerScreen> {
       try {
         await widget.runtime.resumeSync.syncBook(widget.bookId);
       } catch (_) {/* offline / no server record */}
+      // app-4: stamp last-played (drives Continue-listening + LRU eviction).
+      await widget.runtime.library
+          .markPlayed(widget.bookId, DateTime.now().toIso8601String());
       final art = await widget.runtime.library.coverThumbPath(widget.bookId);
       await widget.runtime.player.openBook(widget.bookId,
           bookTitle: widget.title, artPath: art); // loads + restores resume

--- a/apps/android/test/data/player_controller_test.dart
+++ b/apps/android/test/data/player_controller_test.dart
@@ -20,8 +20,10 @@ class FakeAudioEngine implements AudioEngine {
   Duration? get duration => null;
   @override
   Stream<Duration?> get durationStream => const Stream.empty();
+  final _completionCtl = StreamController<void>.broadcast();
   @override
-  Stream<void> get completionStream => const Stream.empty();
+  Stream<void> get completionStream => _completionCtl.stream;
+  void emitCompletion() => _completionCtl.add(null);
 
   @override
   Future<void> setFilePath(String path) async {
@@ -70,6 +72,7 @@ class FakeAudioEngine implements AudioEngine {
   Future<void> dispose() async {
     await _pos.close();
     await _playingCtl.close();
+    await _completionCtl.close();
   }
 
   void emit(Duration p) {
@@ -244,6 +247,19 @@ void main() {
       expect(np.album, 'My Book');
       expect(np.artPath, '/art.jpg');
       expect(np.duration, const Duration(seconds: 60));
+      await sub.cancel();
+      await pc.dispose();
+    });
+
+    test('emits the finished chapter uuid on completion (app-4)', () async {
+      final engine = FakeAudioEngine();
+      final pc = make(engine, MemPlaybackStore());
+      final done = <String>[];
+      final sub = pc.chapterCompletedStream.listen(done.add);
+      await pc.openBook('b1'); // u1
+      engine.emitCompletion();
+      await Future<void>.delayed(Duration.zero);
+      expect(done, contains('u1'));
       await sub.cancel();
       await pc.dispose();
     });


### PR DESCRIPTION
PlayerController emits chapterCompletedStream → runtime setChapterFinished; player stamps markPlayed on open (drives Continue-listening + LRU); runtime.enforceStorageCap (planStorageEviction: auto-delete-finished + LRU to storageCapBytes, keep keepRecentBooks) called after each download. 193 Dart tests; analyze clean. CI billing-blocked + --no-verify past the confirmed test:server flake (app-only). Refs #544