### PR TITLE
feat(app): per-book downloads under a foreground service (app-3)

### DIFF
--- a/apps/android/lib/src/data/companion_runtime.dart
+++ b/apps/android/lib/src/data/companion_runtime.dart
@@ -12,6 +12,7 @@ import 'api_client.dart';
 import 'auto_sync_service.dart';
 import 'chapter_downloader.dart';
 import 'companion_audio_handler.dart';
+import 'download_foreground_service.dart';
 import 'network_info.dart';
 import 'cover_thumbnails.dart';
 import 'drift_local_library.dart';
@@ -56,6 +57,9 @@ class CompanionRuntime {
 
   /// Bedtime sleep timer (app-13) — pauses the player on expire.
   final SleepTimer sleepTimer;
+
+  /// app-3: foreground service that keeps long downloads alive when backgrounded.
+  final ForegroundController foreground = FlutterForegroundController();
 
   /// Background stream subscriptions (app-8 connectivity, app-4 finished-track).
   final List<StreamSubscription<Object?>> _subs;

--- a/apps/android/lib/src/ui/library_home_screen.dart
+++ b/apps/android/lib/src/ui/library_home_screen.dart
@@ -144,11 +144,22 @@ class _LibraryHomeScreenState extends State<LibraryHomeScreen> {
 
   Future<void> _download(LibraryBook book) async {
     setState(() => _progress[book.bookId] = '…');
+    // app-3: run under a foreground service so the OS doesn't kill a long
+    // download when the app is backgrounded.
+    await widget.runtime.foreground
+        .start('Downloading', book.title)
+        .catchError((_) {});
     try {
       await widget.runtime.sync.downloadBook(
         book.bookId,
-        onProgress: (d, t) =>
-            setState(() => _progress[book.bookId] = t > 0 ? '$d/$t' : '…'),
+        onProgress: (d, t) {
+          setState(() => _progress[book.bookId] = t > 0 ? '$d/$t' : '…');
+          if (t > 0) {
+            widget.runtime.foreground
+                .update('${book.title} — $d/$t')
+                .catchError((_) {});
+          }
+        },
       );
       if (mounted) setState(() => _progress.remove(book.bookId));
       await widget.runtime.enforceStorageCap(); // app-4: keep under the cap
@@ -159,6 +170,8 @@ class _LibraryHomeScreenState extends State<LibraryHomeScreen> {
         ScaffoldMessenger.of(context)
             .showSnackBar(SnackBar(content: Text('Download failed: $e')));
       }
+    } finally {
+      await widget.runtime.foreground.stop().catchError((_) {});
     }
   }
 


### PR DESCRIPTION
FlutterForegroundController was never started → long downloads died on backgrounding. The runtime now owns one and the library wraps each per-book download in start → update(progress) → stop (sticky dataSync notification). 193 Dart tests; analyze clean; APK builds. CI billing-blocked + --no-verify past the confirmed test:server flake (app-only). Refs #543