### PR TITLE
docs(docs): record the Castwright brand in CLAUDE.md + README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,14 @@ Frontend for an audiobook-generation tool. Vite + React 18 + TypeScript +
 Redux Toolkit. Mocked API surface today; designed to swap to a real backend
 without changing component code.
 
+**Brand:** the product is **Castwright** (`castwright.ai`) — _any book, performed by a full
+cast — effortlessly. Even in your own voice._ Brand assets + guidelines live in `brand/`; the
+design spec is `docs/superpowers/specs/2026-06-07-castwright-brand-design.md`; the brand story
+is `docs/project-narrative.md`. The **internal package name and repo dir stay
+`audiobook-generator`** (it's the release-zip / upgrade-flow artifact) — only user-facing
+surfaces say "Castwright". App fonts: **General Sans** (sans) + **Lora** (serif). Next big
+release = voice cloning (`fs-38`, plan `docs/features/194-voice-cloning.md`).
+
 ## Working principles
 
 General working style layered on top of the project-specific rules below.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Audiobook Generator
+# Castwright
 
-Turn a manuscript into a finished audiobook on your own machine.
+> _Any book, performed by a full cast — effortlessly. Even in your own voice._
+> (The internal package / repo name stays `audiobook-generator`.)
+
+Turn a manuscript into a finished, **full-cast** audiobook on your own machine — every
+character in their own voice, consistent across a whole series.
 
 Upload `.md` / `.txt` / `.epub` / `.pdf` → an analyzer extracts characters,
 chapters, and per-sentence speaker tags → assign a TTS voice to each


### PR DESCRIPTION
Make the brand discoverable for future sessions/contributors: CLAUDE.md gains a Brand note (name, domain, tagline, asset/spec/story pointers, the internal-name-stays-`audiobook-generator` rule, app fonts General Sans + Lora, next-big-release voice cloning), and README is retitled to Castwright. Docs-only.