### PR TITLE
fix(frontend): repaint analysing model pill on dark mode

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -348,6 +348,18 @@
 [data-theme='dark'] .bg-emerald-100 {
   background-color: rgba(16, 185, 129, 0.18);
 }
+/* Translucent /70 variant — the analysing-view PhaseModelChip done/streaming
+   pill (`src/components/analysing/phase-model-chip.tsx`), the green capsule
+   carrying the active model name (e.g. "Gemini 3.1 Flash Lite"). Same `/N`
+   selector caveat as the variants below — Tailwind compiles `.bg-emerald-100\/70`
+   separately, so the bare `.bg-emerald-100` redirect above doesn't reach it.
+   Without this the pill painted 70% of the near-white `#d1fae5` over the dark
+   canvas, washing the lightened `text-emerald-700` model text out to
+   low contrast. Alpha sits one step below the un-multiplied base (0.18),
+   mirroring the `/70`-below-base step in the emerald-50 ladder. */
+[data-theme='dark'] .bg-emerald-100\/70 {
+  background-color: rgba(16, 185, 129, 0.16);
+}
 /* Translucent /50 variant used by the generation-view "Done" chapter card
    tint (`src/views/generation.tsx` stateConfig.done.tint). Same selector
    caveat as the `.bg-rose-50\/N` overrides above — Tailwind compiles

--- a/src/test/dark-mode-css.test.ts
+++ b/src/test/dark-mode-css.test.ts
@@ -104,6 +104,14 @@ describe('dark-mode CSS overrides (styles.css)', () => {
        painted a cream wash with light-on-light body text and a dark-green
        dismiss control. */
     { selector: '.bg-emerald-50\\/70', label: 'emerald-50 /70 (eviction banner base)' },
+    /* Analysing-view PhaseModelChip done/streaming pill
+       (`src/components/analysing/phase-model-chip.tsx`): `bg-emerald-100/70`
+       fill under `text-emerald-700` model-name text (e.g. "Gemini 3.1 Flash
+       Lite"). The bare `.bg-emerald-100` has a dark override but the `/70`
+       alpha variant compiles to its own selector that rule can't reach —
+       without this the pill painted near-white emerald-100 at 70% alpha over
+       the dark canvas, washing the light-green text out to low contrast. */
+    { selector: '.bg-emerald-100\\/70', label: 'emerald-100 /70 (phase-model-chip pill)' },
     { selector: '.text-emerald-700\\/60', label: 'emerald-700 /60 (dismiss button)' },
     { selector: '.hover\\:text-emerald-700:hover', label: 'emerald-700 hover (dismiss)' },
     /* Floating reassign picker (CharacterSearchPicker) — `bg-white` alone


### PR DESCRIPTION
## Summary

The `PhaseModelChip` done/streaming pill on the analysing view — the green capsule carrying the active analyzer model name (e.g. **"Gemini 3.1 Flash Lite"**) — washed out to low contrast in dark mode (user-reported screenshot).

Root cause: dark mode repaints Tailwind utilities via `[data-theme='dark'] .<class>` overrides in `src/styles.css`. The bare `.bg-emerald-100` had an override, but the chip uses `bg-emerald-100/70`, and the `/70` alpha variant compiles to its **own** selector (`.bg-emerald-100\/70`) that the bare rule can't reach. So on the dark canvas the pill painted near-white emerald-100 at 70% alpha, and the lightened `text-emerald-700` model text on top read light-on-light.

Fix: add the missing `[data-theme='dark'] .bg-emerald-100\/70` override at `rgba(16,185,129,0.16)` — one step below the `.bg-emerald-100` base (0.18), matching the existing emerald `/70` ladder (`bg-emerald-50/50` → 0.08, `/70` → 0.09). Same fix shape as the already-shipped `bg-emerald-50/70` and `bg-amber-50/60` overrides.

## Test plan

- `src/test/dark-mode-css.test.ts` — added a `.bg-emerald-100\/70` selector assertion (the contract test for "every dark surface utility has an override"). Red without the CSS rule, green with it.
- `npm run verify` — full battery (typecheck + all tests + e2e + build) passed locally via the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)