### PR TITLE
fix(server): link cross-book reuse by stable voiceId when name drifts

### DIFF
--- a/server/src/workspace/series-reuse-link.test.ts
+++ b/server/src/workspace/series-reuse-link.test.ts
@@ -158,6 +158,91 @@ describe('linkSeriesReuseAtAnalysis (plan 126 Facet A)', () => {
     expect(linked).toBe(0);
   });
 
+  /* Stable-key continuity — the narrator (and any character that keeps its
+     deterministic voiceId/id across books) must link even when the analyzer
+     renames it to something with ZERO name-token overlap with the prior. This
+     is the Unraveled narrator regression: prior books call it "Narrator", this
+     book's analysis named it "Author" → the name scorer's 0.34 floor drops it,
+     so the bespoke qwen voice silently fails to carry over. */
+  it('links by stable voiceId even when the name has no token overlap (narrator rename)', async () => {
+    const NARRATOR_LIBRARY: LibraryCharacterRecord[] = [
+      {
+        bookId: BOOK1,
+        bookTitle: 'Book One',
+        character: { id: 'narrator', name: 'Narrator', voiceId: 'narrator' },
+      },
+    ];
+    const options: LinkSeriesReuseOptions = {
+      scanLibrary: async () => NARRATOR_LIBRARY,
+      resolveAuthorSeries: async () => ({ author: AUTHOR, series: SERIES }),
+      positions: async () =>
+        new Map<string, number | null>([
+          [BOOK1, 1],
+          [BOOK2, 2],
+        ]),
+      castLoader: async (bookId: string) =>
+        bookId === BOOK1
+          ? [
+              {
+                id: 'narrator',
+                ttsEngine: 'qwen',
+                overrideTtsVoices: { qwen: { name: 'qwen-narrator' } },
+                voiceStyle: 'a warm, articulate British narrator',
+              },
+            ]
+          : null,
+    };
+
+    /* Analyzer renamed the narrator to "Author" but kept the stable id/voiceId. */
+    const characters: LinkableCharacter[] = [
+      { id: 'narrator', name: 'Author', voiceId: 'narrator', voiceState: 'tuned' },
+    ];
+    const linked = await linkSeriesReuseAtAnalysis(BOOK2, characters, options);
+
+    expect(linked).toBe(1);
+    const narrator = characters[0];
+    expect(narrator.matchedFrom?.bookId).toBe(BOOK1);
+    expect(narrator.matchedFrom?.characterId).toBe('narrator');
+    expect(narrator.ttsEngine).toBe('qwen');
+    expect(narrator.overrideTtsVoices?.qwen?.name).toBe('qwen-narrator');
+    expect(narrator.voiceStyle).toBe('a warm, articulate British narrator');
+    /* A user-tuned voiceState is not demoted, but the link still stamps. */
+    expect(narrator.voiceState).toBe('tuned');
+  });
+
+  /* A stable-key match must still respect an explicit notLinkedTo decision —
+     the user's "not the same person" marker overrides even an id match. */
+  it('does not stable-key link a notLinkedTo pair', async () => {
+    const NARRATOR_LIBRARY: LibraryCharacterRecord[] = [
+      {
+        bookId: BOOK1,
+        bookTitle: 'Book One',
+        character: { id: 'narrator', name: 'Narrator', voiceId: 'narrator' },
+      },
+    ];
+    const options: LinkSeriesReuseOptions = {
+      scanLibrary: async () => NARRATOR_LIBRARY,
+      resolveAuthorSeries: async () => ({ author: AUTHOR, series: SERIES }),
+      positions: async () =>
+        new Map<string, number | null>([
+          [BOOK1, 1],
+          [BOOK2, 2],
+        ]),
+      castLoader: async () => null,
+    };
+    const characters: LinkableCharacter[] = [
+      {
+        id: 'narrator',
+        name: 'Author',
+        voiceId: 'narrator',
+        notLinkedTo: [{ bookId: BOOK1, characterId: 'narrator' }],
+      },
+    ];
+    const linked = await linkSeriesReuseAtAnalysis(BOOK2, characters, options);
+    expect(linked).toBe(0);
+    expect(characters[0].matchedFrom).toBeUndefined();
+  });
+
   /* srv-13 — the fresh analyzer roster carries NO notLinkedTo, so without the
      pre-seed the link pass re-links a pair the user separated on a prior run.
      Seeding the guard fields from the prior cast first must prevent that. */

--- a/server/src/workspace/series-reuse-link.ts
+++ b/server/src/workspace/series-reuse-link.ts
@@ -175,7 +175,9 @@ export async function linkSeriesReuseAtAnalysis(
      the origin: nothing to link against. */
   const scanLibrary = options.scanLibrary ?? scanLibraryCharacters;
   const all = await scanLibrary();
-  const priorVoices: LibraryVoice[] = [];
+  /* Carry each prior's seriesPosition so a stable-key match can prefer the
+     most-recent earlier book (the freshest design of that same voice). */
+  const priorVoices: Array<{ voice: LibraryVoice; pos: number }> = [];
   for (const record of all) {
     if (record.bookId === bookId) continue;
     const recMeta = await resolveAuthorSeries(record.bookId);
@@ -187,7 +189,7 @@ export async function linkSeriesReuseAtAnalysis(
     if (myPosition === null || pos === null || pos >= myPosition) continue;
     if (SKIP_IDS.has(record.character.id)) continue;
     const v = projectVoice(record);
-    if (v) priorVoices.push(v);
+    if (v) priorVoices.push({ voice: v, pos });
   }
   if (priorVoices.length === 0) return 0;
 
@@ -207,17 +209,35 @@ export async function linkSeriesReuseAtAnalysis(
       attributes: c.attributes,
     };
 
-    let best: { voice: LibraryVoice; score: number } | null = null;
-    for (const v of priorVoices) {
+    const notLinkedToPrior = (v: LibraryVoice): boolean =>
       /* notLinkedTo guard — the user explicitly declared this pair is NOT the
          same person (e.g. teenage vs adult Sophie); never auto-link it. */
-      const blocked = (c.notLinkedTo ?? []).some(
+      (c.notLinkedTo ?? []).some(
         (p) => p.bookId === v.bookId && p.characterId === v.characterId,
       );
-      if (blocked) continue;
-      const cand = scoreOne(input, v);
-      if (!cand) continue;
-      if (!best || cand.score > best.score) best = { voice: v, score: cand.score };
+
+    /* Stable-key pass FIRST: a character that kept its deterministic write key
+       (`voiceId ?? id`) across books IS the same voice, even when the analyzer
+       renamed it to something with no name-token overlap — the Unraveled
+       narrator ("Narrator" → "Author"). The name scorer's 0.34 floor can't see
+       this, so match on the key directly and prefer the most-recent earlier
+       book. Confidence is 1: an identical write key is definitive, not fuzzy. */
+    const myKey = c.voiceId ?? c.id;
+    let best: { voice: LibraryVoice; score: number } | null = null;
+    let stableBest: { voice: LibraryVoice; pos: number } | null = null;
+    for (const { voice: v, pos } of priorVoices) {
+      if (v.voiceId !== myKey || notLinkedToPrior(v)) continue;
+      if (!stableBest || pos > stableBest.pos) stableBest = { voice: v, pos };
+    }
+    if (stableBest) {
+      best = { voice: stableBest.voice, score: 1 };
+    } else {
+      for (const { voice: v } of priorVoices) {
+        if (notLinkedToPrior(v)) continue;
+        const cand = scoreOne(input, v);
+        if (!cand) continue;
+        if (!best || cand.score > best.score) best = { voice: v, score: cand.score };
+      }
     }
     if (!best) continue;
 


### PR DESCRIPTION
## Summary

The analysis-time cross-book reuse linker (`linkSeriesReuseAtAnalysis`) scored prior-book candidates **only** through `scoreOne`'s name/alias floor (`nameScore < 0.34` drops the candidate). A recurring character that keeps its deterministic write key (`voiceId ?? id`) across books but is renamed by the analyzer to a label with **zero name-token overlap** falls through and never inherits its prior bespoke Qwen voice.

Concretely: the KOTLC narrator is `"Narrator"` in every prior book, but the analyzer named it `"Author"` in **Unraveled**. `author` vs `narrator` share no token → `nameScore = 0` → no `matchedFrom` → the `qwen-narrator` override never hydrated, so the cast view correctly reported *"No Qwen voice designed yet"*. Every other recurring character shares ≥1 name token with a prior, so a whole-series audit found **exactly 1** silent miss (only the narrator).

**Fix:** add a stable-key pass that runs *before* the name scorer — when an incoming character's `voiceId/id` exactly matches a prior's write key, treat it as the same voice (confidence 1) and prefer the most-recent earlier book. Still honors `notLinkedTo` and the `unknown-*` buckets.

Affected workspace data (Unraveled's narrator) was repaired out-of-band to mirror the fix's output; this PR is the durable code fix that prevents recurrence on future analyses.

## Test plan

- New regression tests in `series-reuse-link.test.ts`:
  - links by stable `voiceId` when the name has zero token overlap (narrator rename) — failed before the fix, passes after;
  - a `notLinkedTo` pair is still never stable-key linked.
- `npm run test:server` — full server suite green (2247 passed) via the pre-commit hook.
- Server typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)