### PR TITLE
feat(frontend): Has/Needs emotion-variant filters (fe-34)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -269,12 +269,6 @@ _Full detail + acceptance:_ [#592](https://github.com/dudarenok-maker/AudioBook-
 - _Benefit (user):_ an intentional "no emotion here" survives a later Detect-emotions run.
 _Full detail + acceptance:_ [#593](https://github.com/dudarenok-maker/AudioBook-Generator/issues/593).
 
-#### `fe-34` — Voices view: "Has emotion variants" filter (fs-34 follow-up) ([#595](https://github.com/dudarenok-maker/AudioBook-Generator/issues/595))
-
-- _What:_ The cross-book Voices view renders the `VariantsBadge` on Qwen designed-voice cards (shipped), but has no status-filter like the cast view's chips. Add a filter toggle to narrow the view to voices whose character has ≥1 designed emotion variant.
-- _Benefit (user):_ quickly find which cross-book voices already have expressive variants.
-_Full detail + acceptance:_ [#595](https://github.com/dudarenok-maker/AudioBook-Generator/issues/595).
-
 #### `fe-4` — Single-poll TTS lifecycle for a third consumer (tracking) ([#421](https://github.com/dudarenok-maker/AudioBook-Generator/issues/421))
 
 - _What:_ Tracking item. The consolidated `useTtsLifecycle()` hook (`src/lib/use-tts-lifecycle.ts`) drives today's pill surfaces — top-bar (`src/components/layout.tsx`) and Generation view (`src/views/generation.tsx`) — from one `setInterval` via `LayoutContext`. Per the 2026-05-21 Kokoro-Stop-pill change, the hook now fans out per engine: it returns `{ coqui, kokoro, evictionNotice, loadErrorNotice, dismissNotices }` from a single /health probe. **Wake this item when a JIT-warmed surface graduates to pill-driven UI.** Concrete triggers: Profile Drawer Play, Cast row Play, or the per-character "regenerate this voice across the book" button — whichever first stops using `playSampleWithAutoLoad` and starts wanting an always-on Load/Stop affordance.

--- a/docs/superpowers/plans/2026-06-08-variant-design-filters.md
+++ b/docs/superpowers/plans/2026-06-08-variant-design-filters.md
@@ -1,0 +1,659 @@
+# Variant-design Filters Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the user filter cast members (primary) and cross-book voices (secondary) by whether they still need emotion variants designed, and resurrect the dead fs-25 "Has variants" cast chip.
+
+**Architecture:** One shared key-emitter (`statusFilterKeys` in `voice-status.ts`) gains a `Needs variants` key from the already-existing `countMissingVariants`. The cast view threads its already-computed `usedEmotions` into both the chip tally and the row predicate, and fixes the tally so `Variants` is actually counted. The Voices view caches sentences (already returned by `getBookState`) and adds an All/Has/Needs toggle over its Qwen "Designed voices" section.
+
+**Tech Stack:** React 18 + TypeScript + Redux Toolkit; Vitest + React Testing Library (jsdom); Playwright (chromium).
+
+**Spec:** `docs/superpowers/specs/2026-06-08-variant-design-filters-design.md`
+**Branch:** `feat/frontend-variant-design-filters` (already cut)
+
+> **Commit note:** husky's pre-commit can't spawn in some shells on this box (`Exec format error`). Each commit step uses `git commit --no-verify`; the task's own `npm run ...` test step is the gate. Run the full `npm run verify` once at the end (Task 6).
+
+---
+
+## File Structure
+
+- `src/lib/voice-status.ts` — add optional `usedEmotions` param + `Needs variants` key to `statusFilterKeys`. (Pure, unit-tested.)
+- `src/lib/voice-status.test.ts` — new cases for the `Needs variants` key.
+- `src/views/cast.tsx` — thread `usedEmotions` into the tally + predicate; tally `Variants` and `Needs variants`; add `Needs variants` to `CHIP_ORDER`; add `CHIP_LABELS`.
+- `src/views/cast.test.tsx` — chip render/count/filter cases (incl. the resurrected `Has variants`).
+- `src/views/voices.tsx` — sentences cache; `missingVariantCountByVoiceId`; All/Has/Needs toggle gating the Qwen designed section.
+- `src/views/voices.test.tsx` — toggle filter cases.
+- `e2e/cast-variant-filter.spec.ts` — (optional, Task 5) browser-level cast filter check.
+- `docs/BACKLOG.md`, spec frontmatter — issue hygiene (Task 6).
+
+---
+
+## Task 1: `Needs variants` filter key in `voice-status.ts`
+
+**Files:**
+- Modify: `src/lib/voice-status.ts:161-171`
+- Test: `src/lib/voice-status.test.ts` (append to the `describe('statusFilterKeys …')` block at `:216`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these cases inside the existing `describe('statusFilterKeys — cast-view filter keys', …)` block (the `char`/`voice`/`QWEN`/`KOKORO` helpers already exist in this file):
+
+```ts
+  it('keys a designed Qwen character with an unmet in-use emotion as "Needs variants"', () => {
+    const c = char({ overrideTtsVoices: { qwen: { name: 'qwen-x', variants: {} } } });
+    const used = new Set(['angry']);
+    expect(statusFilterKeys(c, voice({ generated: true }), QWEN, used)).toEqual([
+      'Generated',
+      'Needs variants',
+    ]);
+  });
+
+  it('omits "Needs variants" when every in-use emotion has a designed variant', () => {
+    const c = char({
+      overrideTtsVoices: { qwen: { name: 'qwen-x', variants: { angry: { name: 'qwen-x-angry' } } } },
+    });
+    expect(statusFilterKeys(c, voice({ generated: true }), QWEN, new Set(['angry']))).toEqual([
+      'Generated',
+    ]);
+  });
+
+  it('omits "Needs variants" when usedEmotions is undefined', () => {
+    const c = char({ overrideTtsVoices: { qwen: { name: 'qwen-x', variants: {} } } });
+    expect(statusFilterKeys(c, voice({ generated: true }), QWEN)).toEqual(['Generated']);
+  });
+
+  it('never keys "Needs variants" for a non-Qwen character', () => {
+    const c = char({ voiceState: 'generated' });
+    expect(statusFilterKeys(c, undefined, KOKORO, new Set(['angry']))).toEqual(['Matched']);
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run test -- src/lib/voice-status.test.ts`
+Expected: FAIL — the new cases get `['Generated']` etc. without the `'Needs variants'` element (the 4th param is ignored today).
+
+- [ ] **Step 3: Implement the key**
+
+Replace `statusFilterKeys` (`src/lib/voice-status.ts:161-171`) with:
+
+```ts
+export function statusFilterKeys(
+  c: Character,
+  voice: Voice | undefined,
+  effectiveEngine: TtsEngine,
+  /** fs-34 — the character's in-use non-neutral emotions
+      (`usedEmotionsByCharacter(...).get(c.id)`). When provided, a Qwen-effective
+      character with ≥1 in-use emotion lacking a designed variant also matches
+      the "Needs variants" chip. Optional so existing callers keep compiling. */
+  usedEmotions?: Set<string>,
+): string[] {
+  const { lifecycle, reused, hasEmotionVariants } = resolveVoiceStatus(c, voice, effectiveEngine);
+  const keys = [lifecycle?.label ?? 'Unset'];
+  if (reused) keys.push('Reused');
+  if (hasEmotionVariants) keys.push('Variants');
+  const isQwen = effectiveEngine === 'qwen' || voice?.ttsVoice?.provider === 'qwen';
+  if (isQwen && countMissingVariants(c, usedEmotions) > 0) keys.push('Needs variants');
+  return keys;
+}
+```
+
+`countMissingVariants` is already defined in this file (`:74`) — no new import.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm run test -- src/lib/voice-status.test.ts`
+Expected: PASS (all cases, including pre-existing ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/voice-status.ts src/lib/voice-status.test.ts
+git commit --no-verify -m "feat(frontend): emit Needs variants filter key from statusFilterKeys"
+```
+
+---
+
+## Task 2: Cast-view chips — fix tally, thread emotions, label chips
+
+**Files:**
+- Modify: `src/views/cast.tsx` — `CHIP_ORDER` (`:105-117`), `statusKeysFor` (`:233-234`), `statusBuckets` memo (`:279-302`), chip label render (`:649`)
+- Test: `src/views/cast.test.tsx` (append to the chip `describe` block near `:1011`)
+
+`usedEmotions`, `countMissingVariants`, `usedEmotionsByCharacter`, and `resolveVoiceStatus` are already imported/computed in `cast.tsx` (`:25-26`, `:133`).
+
+- [ ] **Step 1: Write the failing tests**
+
+In `cast.test.tsx`, inside the chip-filter `describe`, add a designed-Qwen-with-missing-variant fixture and tests. Add this fixture next to `ghost`/`blank` (around `:1037`):
+
+```ts
+  // Designed Qwen voice, speaks an "angry" quote, but has NO angry variant ⇒ "Needs variants".
+  const fury: Character = {
+    id: 'fury',
+    name: 'Fury',
+    role: 'Rival',
+    color: 'mentor',
+    lines: 4,
+    scenes: 1,
+    attributes: [],
+    ttsEngine: 'qwen',
+    overrideTtsVoices: { qwen: { name: 'qwen-fury', variants: {} } },
+  };
+  // Designed Qwen voice WITH the matching variant ⇒ "Has variants", not "Needs variants".
+  const calm: Character = {
+    id: 'calm',
+    name: 'Calm',
+    role: 'Sage',
+    color: 'mentor',
+    lines: 4,
+    scenes: 1,
+    attributes: [],
+    ttsEngine: 'qwen',
+    overrideTtsVoices: { qwen: { name: 'qwen-calm', variants: { angry: { name: 'qwen-calm-angry' } } } },
+  };
+  const variantSentences: Sentence[] = [
+    { id: 1, chapterId: 1, text: 'No!', characterId: 'fury', emotion: 'angry', kind: 'dialogue' },
+    { id: 2, chapterId: 1, text: 'Peace.', characterId: 'calm', emotion: 'angry', kind: 'dialogue' },
+  ];
+
+  function renderVariantView() {
+    const store = configureStore({
+      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, castDesign: castDesignSlice.reducer },
+    });
+    return render(
+      <Provider store={store}>
+        <CastView
+          characters={[fury, calm]}
+          setCharacters={() => {}}
+          library={library}
+          sentences={variantSentences}
+          title="The Northern Star"
+          onOpenProfile={() => {}}
+          onShowMatchDetail={() => {}}
+          driftEvents={[]}
+          onShowDrift={() => {}}
+        />
+      </Provider>,
+    );
+  }
+
+  it('renders the resurrected "Has variants" chip with its count', () => {
+    renderVariantView();
+    expect(chip(/^Has variants/).textContent).toContain('1'); // calm only
+  });
+
+  it('renders the "Needs variants" chip and filters to unmet-variant rows', () => {
+    renderVariantView();
+    expect(chip(/^Needs variants/).textContent).toContain('1'); // fury only
+    fireEvent.click(chip(/^Needs variants/));
+    expect(isPresent('Fury')).toBe(true);
+    expect(isPresent('Calm')).toBe(false);
+  });
+```
+
+Confirm `Sentence` is imported at the top of `cast.test.tsx`; if not, add it to the `../lib/types` import.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run test -- src/views/cast.test.tsx`
+Expected: FAIL — `chip(/^Has variants/)` and `chip(/^Needs variants/)` throw "Unable to find role button" (neither chip renders today).
+
+- [ ] **Step 3a: Add `Needs variants` to `CHIP_ORDER` + a label map**
+
+In `cast.tsx`, change the tail of `CHIP_ORDER` (`:113-117`) and add `CHIP_LABELS` right after it:
+
+```ts
+  'Unset',
+  'Reused',
+  /* fs-25 / fs-34 — variant capability chips, last. */
+  'Variants',
+  'Needs variants',
+];
+
+/* Display labels for chips whose internal key differs from what we want shown.
+   The key stays stable (it flows through statusFilters + statusFilterKeys);
+   only the chip text changes. */
+const CHIP_LABELS: Record<string, string> = {
+  Variants: 'Has variants',
+  'Needs variants': 'Needs variants',
+};
+```
+
+- [ ] **Step 3b: Thread `usedEmotions` into the row predicate**
+
+Replace `statusKeysFor` (`cast.tsx:233-234`) with:
+
+```ts
+  const statusKeysFor = (c: Character): string[] =>
+    statusFilterKeys(c, findVoiceForCharacter(c, library), effectiveEngineFor(c), usedEmotions.get(c.id));
+```
+
+- [ ] **Step 3c: Tally `Variants` and `Needs variants` in `statusBuckets`**
+
+In the `statusBuckets` memo (`cast.tsx:279-302`), pull the full status + add the two variant tallies inside the loop, and add `usedEmotions` to the deps. Replace the memo body with:
+
+```ts
+  const statusBuckets = useMemo(() => {
+    const tally = new Map<string, { color: StatusPillColor; count: number }>();
+    for (const c of characters) {
+      const effectiveEngine = c.ttsEngine ?? ttsEngine;
+      const voice = findVoiceForCharacter(c, library);
+      const { lifecycle, reused, hasEmotionVariants } = resolveVoiceStatus(c, voice, effectiveEngine);
+      const lifecycleKey = lifecycle?.label ?? 'Unset';
+      const lifecycleColor: StatusPillColor = lifecycle?.color ?? 'neutral';
+      tally.set(lifecycleKey, {
+        color: lifecycleColor,
+        count: (tally.get(lifecycleKey)?.count ?? 0) + 1,
+      });
+      if (reused) {
+        tally.set('Reused', { color: 'library', count: (tally.get('Reused')?.count ?? 0) + 1 });
+      }
+      if (hasEmotionVariants) {
+        tally.set('Variants', { color: 'library', count: (tally.get('Variants')?.count ?? 0) + 1 });
+      }
+      const isQwen = effectiveEngine === 'qwen' || voice?.ttsVoice?.provider === 'qwen';
+      if (isQwen && countMissingVariants(c, usedEmotions.get(c.id)) > 0) {
+        tally.set('Needs variants', {
+          color: 'warning',
+          count: (tally.get('Needs variants')?.count ?? 0) + 1,
+        });
+      }
+    }
+    return CHIP_ORDER.filter((key) => tally.has(key)).map((key) => ({
+      key,
+      color: tally.get(key)!.color,
+      count: tally.get(key)!.count,
+    }));
+  }, [characters, library, ttsEngine, usedEmotions]);
+```
+
+- [ ] **Step 3d: Render the chip label via the map**
+
+In the chip button (`cast.tsx:649`), change `<span>{b.key}</span>` to:
+
+```tsx
+                  <span>{CHIP_LABELS[b.key] ?? b.key}</span>
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm run test -- src/views/cast.test.tsx`
+Expected: PASS — both new cases plus all pre-existing chip cases (which assert `/^Needs voice/`, `/^Matched/`, etc., unaffected by the label map).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/views/cast.tsx src/views/cast.test.tsx
+git commit --no-verify -m "feat(frontend): cast Has/Needs variants chips (+ fix dead fs-25 tally)"
+```
+
+---
+
+## Task 3: Voices-view All/Has/Needs variants toggle
+
+**Files:**
+- Modify: `src/views/voices.tsx` — imports (`:6-28`), state, `hydrateForeignCast` (`:709-768`), a new `missingVariantCountByVoiceId` memo (beside `:232`), the section render (`:1096-1112`)
+- Test: `src/views/voices.test.tsx` (new `describe` block at end of file)
+
+- [ ] **Step 1: Write the failing test**
+
+Append a new block to `voices.test.tsx`. It mounts the open-book path (ui ready stage + redux cast + redux manuscript sentences) so no async hydrate is needed:
+
+```ts
+describe('fe-34 — variant filter toggle', () => {
+  const designedNeeds: Character = {
+    id: 'fury', name: 'Fury', role: 'Rival', color: 'mentor', lines: 4, scenes: 1, attributes: [],
+    ttsEngine: 'qwen', overrideTtsVoices: { qwen: { name: 'qwen-fury', variants: {} } },
+  };
+  const designedHas: Character = {
+    id: 'calm', name: 'Calm', role: 'Sage', color: 'mentor', lines: 4, scenes: 1, attributes: [],
+    ttsEngine: 'qwen',
+    overrideTtsVoices: { qwen: { name: 'qwen-calm', variants: { angry: { name: 'qwen-calm-angry' } } } },
+  };
+  const sentences: Sentence[] = [
+    { id: 1, chapterId: 1, text: 'No!', characterId: 'fury', emotion: 'angry', kind: 'dialogue' },
+    { id: 2, chapterId: 1, text: 'Peace.', characterId: 'calm', emotion: 'angry', kind: 'dialogue' },
+  ];
+  const qwenLib: Voice[] = [
+    { id: 'qwen-fury', character: 'Fury', bookId: 'b1', bookTitle: 'Book One', attributes: [],
+      usedIn: 1, source: 'current', gradient: ['#000', '#111'],
+      ttsVoice: { provider: 'qwen', name: 'qwen-fury', description: '' } },
+    { id: 'qwen-calm', character: 'Calm', bookId: 'b1', bookTitle: 'Book One', attributes: [],
+      usedIn: 1, source: 'current', gradient: ['#000', '#111'],
+      ttsVoice: { provider: 'qwen', name: 'qwen-calm', description: '' } },
+  ];
+
+  function renderToggleView() {
+    const store = configureStore({
+      reducer: {
+        ui: uiSlice.reducer, cast: castSlice.reducer, manuscript: manuscriptSlice.reducer,
+        notifications: notificationsSlice.reducer, voices: voicesSlice.reducer,
+        library: librarySlice.reducer, rebaseline: rebaselineSlice.reducer,
+      },
+    });
+    store.dispatch(uiActions.bookOpened({ bookId: 'b1' })); // ui.stage.kind = 'ready', bookId 'b1'
+    store.dispatch(castActions.hydrate({ characters: [designedNeeds, designedHas] }));
+    store.dispatch(manuscriptActions.setSentences(sentences));
+    return render(
+      <Provider store={store}>
+        <LibraryView library={qwenLib} />
+      </Provider>,
+    );
+  }
+
+  it('narrows the designed voices to needs-variants when "Needs variants" is selected', () => {
+    renderToggleView();
+    expect(screen.getByText('Calm')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^Needs variants/ }));
+    expect(screen.getByText('Fury')).toBeInTheDocument();
+    expect(screen.queryByText('Calm')).toBeNull();
+  });
+
+  it('narrows to has-variants when "Has variants" is selected', () => {
+    renderToggleView();
+    fireEvent.click(screen.getByRole('button', { name: /^Has variants/ }));
+    expect(screen.getByText('Calm')).toBeInTheDocument();
+    expect(screen.queryByText('Fury')).toBeNull();
+  });
+});
+```
+
+> Match the real action creators/selectors used elsewhere in `voices.test.tsx` and the slices. If `uiActions.bookOpened` / `castActions.hydrate` / `manuscriptActions.setSentences` differ in name, grep the slice files and the top of `voices.test.tsx` for the exact creators already used to seed an open book, and substitute. The store-reducer set mirrors the file's other render helpers.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test -- src/views/voices.test.tsx`
+Expected: FAIL — `getByRole('button', { name: /^Needs variants/ })` not found (no toggle yet).
+
+- [ ] **Step 3a: Imports + state + open-book sentences**
+
+In `voices.tsx`, add to the `../lib/voice-status` usage — it isn't imported yet, so add an import near `:28`:
+
+```ts
+import { usedEmotionsByCharacter, countMissingVariants } from '../lib/voice-status';
+```
+
+Add `Sentence` to the `../lib/types` import list (`:6-13`):
+
+```ts
+  Sentence,
+```
+
+Inside `LibraryView`, near the other `useState` hooks (after `:135`), add:
+
+```ts
+  /* fe-34 — variant filter for the Qwen "Designed voices" section. */
+  const [variantFilter, setVariantFilter] = useState<'all' | 'has' | 'needs'>('all');
+  /* fe-34 — sentences per foreign book, cached from the same getBookState the
+     duplicate/compare flows already fetch. The open book reads redux below. */
+  const [sentencesByBookId, setSentencesByBookId] = useState<Map<string, Sentence[]>>(
+    () => new Map(),
+  );
+```
+
+Add the open-book sentences selector next to the other selectors (after `:172`):
+
+```ts
+  const openBookSentences = useAppSelector((s) => s.manuscript.sentences);
+```
+
+- [ ] **Step 3b: Cache sentences on foreign hydrate**
+
+In `hydrateForeignCast`, in the success branch right after the cast `setGlobalCastCache(...)` block (`:738-742`), add:
+
+```ts
+      const sents = res?.manuscriptEdits?.sentences ?? [];
+      setSentencesByBookId((prev) => {
+        const next = new Map(prev);
+        next.set(bookId, sents);
+        return next;
+      });
+```
+
+- [ ] **Step 3c: `missingVariantCountByVoiceId` memo**
+
+Add immediately after the existing `variantCountByVoiceId` memo (`:232-242`):
+
+```ts
+  /* fe-34 — per-voice count of in-use emotions that LACK a designed variant.
+     Mirrors variantCountByVoiceId but needs the book's sentences (redux for
+     the open book, the cache for foreign books — 0 until a book hydrates). */
+  const missingVariantCountByVoiceId = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const v of qwenLibrary) {
+      const source =
+        v.bookId === currentBookId ? characters : (globalCastCache.get(v.bookId) ?? null);
+      const ch = source ? findCharacterForVoice(v, source) : null;
+      if (!ch) continue;
+      const sents =
+        v.bookId === currentBookId ? openBookSentences : (sentencesByBookId.get(v.bookId) ?? []);
+      const used = usedEmotionsByCharacter(sents).get(ch.id);
+      const n = countMissingVariants(ch, used);
+      if (n > 0) map.set(v.id, n);
+    }
+    return map;
+  }, [qwenLibrary, currentBookId, characters, globalCastCache, openBookSentences, sentencesByBookId]);
+```
+
+- [ ] **Step 3d: Apply the filter to the Qwen library + hide families**
+
+Replace the `qwenGroups` memo (`:228`) with a filtered variant, and add a `showFamilies` flag:
+
+```ts
+  const filteredQwenLibrary = useMemo(() => {
+    if (variantFilter === 'all') return qwenLibrary;
+    const map = variantFilter === 'has' ? variantCountByVoiceId : missingVariantCountByVoiceId;
+    return qwenLibrary.filter((v) => (map.get(v.id) ?? 0) > 0);
+  }, [qwenLibrary, variantFilter, variantCountByVoiceId, missingVariantCountByVoiceId]);
+  const qwenGroups = useMemo(
+    () => buildQwenStatusGroups(filteredQwenLibrary, tab),
+    [filteredQwenLibrary, tab],
+  );
+  /* When a variant filter is active, preset (non-Qwen) families and the
+     "Needs a voice" bucket aren't variant-relevant, so hide everything but the
+     matching Qwen designed voices. */
+  const showFamilies = variantFilter === 'all';
+```
+
+> Delete the old `const qwenGroups = useMemo(() => buildQwenStatusGroups(qwenLibrary, tab), [qwenLibrary, tab]);` line so it isn't declared twice.
+
+- [ ] **Step 3e: Render the toggle + gate families**
+
+In the render, gate the families map on `showFamilies` (`:1076`):
+
+```tsx
+          {showFamilies && families.map((f) => (
+```
+
+Add the toggle control just above the families/qwen render, right after the `<div className={…dragging…}>` opens (after `:988`). Render it only when there are Qwen voices:
+
+```tsx
+          {qwenLibrary.length > 0 && (
+            <div
+              className="flex items-center gap-2 flex-wrap"
+              role="group"
+              aria-label="Filter by emotion variants"
+            >
+              <span className="text-xs text-ink/50">Variants:</span>
+              {(['all', 'has', 'needs'] as const).map((key) => {
+                const label = key === 'all' ? 'All' : key === 'has' ? 'Has variants' : 'Needs variants';
+                const active = variantFilter === key;
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setVariantFilter(key)}
+                    aria-pressed={active}
+                    className={`min-h-[44px] sm:min-h-0 inline-flex items-center px-3 py-2 sm:py-1.5 rounded-full text-sm font-medium transition-colors ${
+                      active
+                        ? 'bg-ink text-canvas'
+                        : 'border border-ink/10 bg-white text-ink/70 hover:text-ink hover:bg-ink/4'
+                    }`}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+              {variantFilter !== 'all' && (
+                <span className="text-[11px] text-ink/45">
+                  Counts fill in as other books load.
+                </span>
+              )}
+            </div>
+          )}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm run test -- src/views/voices.test.tsx`
+Expected: PASS — toggle narrows the designed voices correctly.
+
+- [ ] **Step 5: Typecheck the two changed views**
+
+Run: `npm run typecheck`
+Expected: no errors. (Catches a wrong action-creator name from the test note, or a missing `Sentence`/import.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/views/voices.tsx src/views/voices.test.tsx
+git commit --no-verify -m "feat(frontend): Voices view Has/Needs variants toggle (fe-34)"
+```
+
+---
+
+## Task 4: Run the frontend suite + lint
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full frontend unit run**
+
+Run: `npm run test`
+Expected: PASS (all frontend specs). If a pre-existing chip test broke, it's almost certainly the label map — confirm those tests match on `/^Needs voice/` etc. (lifecycle keys, unaffected), not on `Variants`.
+
+- [ ] **Step 2: Lint + format**
+
+Run: `npm run lint`
+Expected: clean. Fix any unused-import or formatting nits introduced.
+
+- [ ] **Step 3: Commit (only if lint auto-fixed files)**
+
+```bash
+git add -A
+git commit --no-verify -m "chore(frontend): lint fixups for variant filters"
+```
+
+---
+
+## Task 5 (OPTIONAL): Playwright e2e for the cast Needs-variants filter
+
+> **Scope call:** the mock pipeline currently has **no** Qwen-designed character, per-sentence emotions, or variant maps (`src/mocks/` has none). A real e2e needs new mock fixtures — a meaningful lift for a `moscow:could` item. The jsdom RTL tests in Tasks 2–3 already cover the redux + filter behaviour. **Recommendation: defer** unless the user wants the browser-level net. If deferred, say so in the PR's Test plan. The steps below are the path if you do it.
+
+**Files:**
+- Modify: a mock manuscript/cast fixture so one book renders a designed-Qwen character that speaks a non-neutral emotion with no matching variant (grep `src/mocks/canned-data.ts` + `src/mocks/voices.ts` + `src/mocks/manuscripts/` for the cast/sentence seams; add `emotion: 'angry'` to one dialogue sentence and an `overrideTtsVoices.qwen` with `variants: {}` on its character).
+- Create: `e2e/cast-variant-filter.spec.ts`
+
+- [ ] **Step 1: Write the spec**
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test('cast view filters to characters needing emotion variants', async ({ page }) => {
+  await page.goto('/#/books');
+  // Open the seeded book and navigate to its cast view (mirror e2e/cast.spec.ts navigation).
+  // …open book, land on #/books/:id/cast…
+  const needs = page.getByRole('button', { name: /^Needs variants/ });
+  await expect(needs).toBeVisible();
+  await needs.click();
+  // The designed-but-missing-variant character remains; a fully-voiced one is hidden.
+  await expect(page.getByText('Fury')).toBeVisible();
+  await expect(page.getByText('Calm')).toHaveCount(0);
+});
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `npm run test:e2e -- cast-variant-filter`
+Expected: PASS. (Requires `npx playwright install chromium` once.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/cast-variant-filter.spec.ts src/mocks/
+git commit --no-verify -m "test(e2e): cast Needs-variants filter"
+```
+
+---
+
+## Task 6: Verify, issue hygiene, PR
+
+**Files:**
+- Modify: `docs/BACKLOG.md` (remove the fe-34 row, `:272-276`), spec frontmatter `status: draft → active`.
+
+- [ ] **Step 1: Full battery**
+
+Run: `npm run verify`
+Expected: PASS (typecheck + all tests + e2e + build). This is the real gate (the commits used `--no-verify` because the hook can't spawn).
+
+- [ ] **Step 2: File the dead-chip bug issue**
+
+```bash
+gh issue create --label bug --label area:fe \
+  --title "fe — 'Has emotion variants' cast chip never renders (fs-25 tally omission)" \
+  --body "statusBuckets in src/views/cast.tsx never tallied the 'Variants' key, so CHIP_ORDER.filter(key => tally.has(key)) always dropped it — the fs-25 'Has emotion variants' chip was unreachable. Fixed in the fe-34 PR by tallying Variants + adding Needs variants."
+```
+
+Note the returned issue number as `#BUG`.
+
+- [ ] **Step 3: Remove the fe-34 backlog row**
+
+Delete the `#### \`fe-34\` …` block in `docs/BACKLOG.md` (`:272-276`).
+
+- [ ] **Step 4: Promote the spec status**
+
+In `docs/superpowers/specs/2026-06-08-variant-design-filters-design.md`, change `**Status:** draft` to `**Status:** active`.
+
+- [ ] **Step 5: Commit hygiene**
+
+```bash
+git add docs/BACKLOG.md docs/superpowers/specs/2026-06-08-variant-design-filters-design.md
+git commit --no-verify -m "docs(frontend): close fe-34 backlog row + promote spec"
+```
+
+- [ ] **Step 6: Push + open a draft PR**
+
+```bash
+git push -u origin feat/frontend-variant-design-filters
+gh pr create --draft \
+  --title "feat(frontend): Has/Needs emotion-variant filters (fe-34)" \
+  --body "$(cat <<'EOF'
+## Summary
+Adds "Has variants" / "Needs variants" filtering so the user can find cast members (and cross-book voices) that still need emotion variants designed — the missing slice in the book → cast workflow. Also resurrects the dead fs-25 "Has emotion variants" cast chip (the tally never counted it).
+
+- Cast view: working Has variants + new Needs variants chips (Qwen-gated, live counts, filters rows).
+- Voices view: All / Has / Needs variants toggle over the Qwen "Designed voices" section (fe-34). Foreign-book counts fill in lazily as casts/sentences hydrate.
+- Shared `statusFilterKeys` gains a `Needs variants` key from the existing `countMissingVariants`.
+
+## Test plan
+- `src/lib/voice-status.test.ts` — Needs variants key across Qwen/non-Qwen/has/needs/undefined.
+- `src/views/cast.test.tsx` — resurrected Has variants chip + Needs variants chip render/count/filter.
+- `src/views/voices.test.tsx` — toggle narrows the designed section to has/needs.
+- [e2e: deferred — mock pipeline lacks Qwen+emotion fixtures; RTL covers the logic] OR `e2e/cast-variant-filter.spec.ts`.
+- `npm run verify` green locally.
+
+Closes #595
+Closes #BUG
+EOF
+)"
+```
+
+Replace `#BUG` with the issue number from Step 2. Leave the PR as a draft; run `gh pr ready` only after `npm run verify` is green (CI-cost default).
+
+---
+
+## Self-Review (completed by plan author)
+
+- **Spec coverage:** §1 voice-status → Task 1; §2 cast tally/threading/labels → Task 2; §3 voices cache+memo+toggle → Task 3; testing → Tasks 1–5; issue hygiene → Task 6. All spec sections map to a task.
+- **Placeholder scan:** `#BUG` is an explicit "fill from Step 2 output" handle, not a vague TODO; the e2e navigation comment is inside the clearly-marked OPTIONAL task with a grep pointer. No "add error handling"/"write tests for the above" style gaps.
+- **Type consistency:** `statusFilterKeys(c, voice, engine, usedEmotions?)` defined in Task 1 and called with the 4th arg in Task 2 (`usedEmotions.get(c.id)`). `variantFilter: 'all'|'has'|'needs'`, `sentencesByBookId: Map<string, Sentence[]>`, `missingVariantCountByVoiceId: Map<string,number>` used consistently in Task 3. `CHIP_LABELS` keys (`Variants`, `Needs variants`) match `CHIP_ORDER` entries.
+- **Risk flagged:** Task 3's test uses assumed action-creator names (`bookOpened`/`hydrate`/`setSentences`) with an explicit instruction to grep the slices for the real names — the only spot needing live confirmation.

--- a/docs/superpowers/specs/2026-06-08-variant-design-filters-design.md
+++ b/docs/superpowers/specs/2026-06-08-variant-design-filters-design.md
@@ -1,7 +1,7 @@
 # Variant-design filters — design spec
 
 **Date:** 2026-06-08
-**Status:** draft
+**Status:** active
 **Issue:** fe-34 ([#595](https://github.com/dudarenok-maker/AudioBook-Generator/issues/595)) + a newly-found `bug` (the dead "Has variants" cast chip — issue to be filed)
 **Scope:** `frontend` (`src/views/cast.tsx`, `src/views/voices.tsx`, `src/lib/voice-status.ts`)
 

--- a/docs/superpowers/specs/2026-06-08-variant-design-filters-design.md
+++ b/docs/superpowers/specs/2026-06-08-variant-design-filters-design.md
@@ -1,0 +1,174 @@
+# Variant-design filters — design spec
+
+**Date:** 2026-06-08
+**Status:** draft
+**Issue:** fe-34 ([#595](https://github.com/dudarenok-maker/AudioBook-Generator/issues/595)) + a newly-found `bug` (the dead "Has variants" cast chip — issue to be filed)
+**Scope:** `frontend` (`src/views/cast.tsx`, `src/views/voices.tsx`, `src/lib/voice-status.ts`)
+
+## Problem
+
+A cast member can have a designed Qwen voice yet still be missing **emotion
+variants** — the per-quote expressive renders (e.g. `angry`, `whisper`) for the
+emotions its quotes actually use. Today you can *see* this per row (the amber
+**"N tags need a variant"** badge, `cast.tsx:1289`, driven by
+`countMissingVariants` in `voice-status.ts`), but you **cannot filter the cast
+down to just those members**. In the user's primary workflow (book → cast → fix
+design → generate), finding "who still needs variants designed" means eyeballing
+every row.
+
+Two adjacent facts sharpen the scope:
+
+1. **The other lifecycle states already filter fine** (`Needs voice`,
+   `Designed`, `Generated`, …) via the cast view's status-filter chips. Variants
+   are the one missing slice.
+2. **The fs-25 "Has emotion variants" chip is dead code.** `CHIP_ORDER`
+   (`cast.tsx:105`) lists `Variants` and `statusFilterKeys` (`voice-status.ts:161`)
+   emits it, but the `statusBuckets` tally (`cast.tsx:279-302`) — which decides
+   *which* chips render via `CHIP_ORDER.filter((key) => tally.has(key))` — never
+   counts `Variants`. So the chip can never appear. This is why the user has
+   never seen it.
+
+fe-34's literal ask is a "Has emotion variants" filter on the cross-book
+**Voices view** (`#/voices`). That view is the secondary pathway; the primary
+win is the cast view. This spec does both (the user chose the "mirror into both"
+option) and fixes the dead chip along the way.
+
+## Goal / Definition of done
+
+- Cast view exposes a working **"Has variants"** chip and a new **"Needs
+  variants"** chip; both render only when ≥1 character matches, carry a live
+  count, and filter the rows (desktop table + mobile cards).
+- Voices view exposes an **All / Has variants / Needs variants** toggle over the
+  Qwen "Designed voices" section.
+- The dead fs-25 chip is resurrected (tally fix) rather than left unreachable.
+- Paired automated tests at every touched seam; one Playwright spec for the cast
+  "Needs variants" filter.
+- fe-34 (#595) closed; the dead-chip `bug` issue filed and closed in the same PR.
+
+Non-goals: changing how variants are *designed* or *rendered*; any backend
+change; eager pre-fetching of every foreign book's sentences.
+
+## Design
+
+### 1. `src/lib/voice-status.ts` — single source of truth for chip keys
+
+Extend the existing emitter so the chips and the rows can never diverge:
+
+```ts
+export function statusFilterKeys(
+  c: Character,
+  voice: Voice | undefined,
+  effectiveEngine: TtsEngine,
+  usedEmotions?: Set<string>, // NEW — the character's in-use emotions
+): string[] {
+  const { lifecycle, reused, hasEmotionVariants } =
+    resolveVoiceStatus(c, voice, effectiveEngine);
+  const keys = [lifecycle?.label ?? 'Unset'];
+  if (reused) keys.push('Reused');
+  if (hasEmotionVariants) keys.push('Variants');
+  // NEW: Qwen-effective + at least one in-use emotion lacks a designed variant.
+  const isQwen = effectiveEngine === 'qwen' || voice?.ttsVoice?.provider === 'qwen';
+  if (isQwen && countMissingVariants(c, usedEmotions) > 0) keys.push('Needs variants');
+  return keys;
+}
+```
+
+`usedEmotions` is optional so the pre-existing two-arg/three-arg callers keep
+compiling; without it `countMissingVariants` returns 0 (no `Needs variants`
+key). `countMissingVariants` already exists and is engine-agnostic — the Qwen
+gate lives here (a missing variant only changes audio under Qwen).
+
+### 2. `src/views/cast.tsx` — wire the data + fix the tally + label the chips
+
+- **Thread `usedEmotions`** (already computed once at `cast.tsx:133` via
+  `usedEmotionsByCharacter(sentences)`) into:
+  - `statusKeysFor(c)` (the `filtered` predicate, `cast.tsx:234`/`312`) →
+    `statusFilterKeys(c, voice, engine, usedEmotions.get(c.id))`.
+  - the `statusBuckets` tally memo (`cast.tsx:279-302`).
+- **Tally fix.** In `statusBuckets`, after the lifecycle + `Reused` tallies, add
+  per-character:
+  - `Variants` when `resolveVoiceStatus(...).hasEmotionVariants` (color
+    `library`).
+  - `Needs variants` when Qwen-effective and
+    `countMissingVariants(c, usedEmotions.get(c.id)) > 0` (color `warning`,
+    matching the row badge). Add `usedEmotions` to the memo deps.
+- **`CHIP_ORDER`** gains `Needs variants` after `Variants`.
+- **Chip labels.** The chip currently renders the raw key (`cast.tsx:649`,
+  `<span>{b.key}</span>`). Add a small label map so the display reads nicely
+  while the key stays stable (the key flows through `statusFilters` / filtering):
+
+  ```ts
+  const CHIP_LABELS: Record<string, string> = {
+    Variants: 'Has variants',
+    'Needs variants': 'Needs variants',
+  };
+  // render: CHIP_LABELS[b.key] ?? b.key
+  ```
+
+No change to row rendering — the per-row "N tags need a variant" badge stays.
+
+### 3. `src/views/voices.tsx` — mirror both filters (fe-34)
+
+- **Cache sentences on hydrate.** `hydrateForeignCast` already calls
+  `api.getBookState(bookId)`; its response carries `manuscriptEdits.sentences`
+  (confirmed in `BookStateResponse`, `api-types.ts:3556`). Today only
+  `res.cast.characters` is kept. Add a parallel cache (e.g.
+  `sentencesByBookId: Map<string, Sentence[]>`) populated from
+  `res.manuscriptEdits?.sentences ?? []` at the same write site. The open book
+  reads sentences from the redux manuscript slice.
+- **`missingVariantCountByVoiceId`** — a new memo beside the existing
+  `variantCountByVoiceId` (`voices.tsx:232`). For each Qwen voice resolve its
+  character (redux for the open book, `globalCastCache` otherwise), resolve its
+  book's sentences (redux / `sentencesByBookId`), then
+  `countMissingVariants(ch, usedEmotionsByCharacter(sentences).get(ch.id))`.
+- **Filter control.** A minimal segmented toggle — **All / Has variants / Needs
+  variants** — rendered above the Qwen sections (variants only matter for
+  *designed* voices, so the toggle scopes the "Designed voices" section; the
+  "Needs a voice" bucket and preset families are unaffected). Default `All`.
+  Predicate uses the two maps.
+- **Known limitation (accepted).** A foreign book whose state hasn't hydrated
+  yet contributes 0 to both maps, so its voices read as "no variants / no needs"
+  until loaded — identical to the existing lazy duplicate-detector behaviour. No
+  eager fetch. Surface a one-line hint near the toggle ("counts fill in as books
+  load") so the partial state isn't mistaken for completeness.
+
+### Data flow
+
+```
+sentences ──usedEmotionsByCharacter──▶ Set<emotion> per characterId
+                                          │
+character.overrideTtsVoices.qwen.variants │ (designed)
+                                          ▼
+                              countMissingVariants ▶ N
+        ┌───────────────────────────────┴───────────────────────────────┐
+   cast.tsx                                                          voices.tsx
+   statusFilterKeys → "Needs variants" key                          missingVariantCountByVoiceId
+   statusBuckets    → chip + count                                  toggle predicate
+```
+
+## Testing
+
+- **`src/lib/voice-status.test.ts`** — `statusFilterKeys` emits `Needs variants`
+  for a Qwen character with an in-use emotion lacking a variant; omits it when
+  all in-use emotions have variants, when `usedEmotions` is undefined, and for a
+  non-Qwen character; still emits `Variants` for has-variants.
+- **`src/views/cast.test.tsx`** — with a fixture cast + sentences: the
+  resurrected **Has variants** chip renders with the right count; the **Needs
+  variants** chip renders, counts correctly, and toggling it filters rows
+  (assert via the chip/row count parity the suite already checks,
+  `cast.test.tsx:1014`).
+- **`src/views/voices.test.tsx`** — the toggle narrows the Designed-voices
+  section to has / needs correctly off the cached sentences.
+- **`e2e/`** — one Playwright spec: load a mock book whose cast has a
+  needs-variants character, click **Needs variants**, assert only the matching
+  row(s) remain. (UI-visible, crosses redux/layout — meets the CLAUDE.md e2e
+  bar.) Add a mock fixture sentence with a non-neutral emotion if none exists.
+
+## Issue hygiene
+
+- PR body: `Closes #595` (fe-34).
+- File a `bug`-labelled issue for the unreachable "Has variants" chip
+  (fs-25 tally omission) and `Closes #<that>` in the same PR.
+- fe-34 is a small/localized item — no new `docs/features/` regression plan; this
+  spec + the paired tests are the record. Remove the fe-34 row from
+  `docs/BACKLOG.md` on merge.

--- a/src/lib/voice-status.test.ts
+++ b/src/lib/voice-status.test.ts
@@ -261,6 +261,21 @@ describe('statusFilterKeys — cast-view filter keys', () => {
     ]);
   });
 
+  it('keys both "Variants" and "Needs variants" for a partially-designed character', () => {
+    // Realistic mid-design state: angry/sad designed, surprised still in use but unmet.
+    const c = char({
+      overrideTtsVoices: {
+        qwen: {
+          name: 'qwen-x',
+          variants: { angry: { name: 'qwen-x-angry' }, sad: { name: 'qwen-x-sad' } },
+        },
+      },
+    });
+    expect(
+      statusFilterKeys(c, voice({ generated: true }), QWEN, new Set(['angry', 'sad', 'surprised'])),
+    ).toEqual(['Generated', 'Variants', 'Needs variants']);
+  });
+
   it('omits "Needs variants" when usedEmotions is undefined', () => {
     const c = char({ overrideTtsVoices: { qwen: { name: 'qwen-x', variants: {} } } });
     expect(statusFilterKeys(c, voice({ generated: true }), QWEN)).toEqual(['Generated']);

--- a/src/lib/voice-status.test.ts
+++ b/src/lib/voice-status.test.ts
@@ -239,6 +239,37 @@ describe('statusFilterKeys — cast-view filter keys', () => {
       'Reused',
     ]);
   });
+
+  it('keys a designed Qwen character with an unmet in-use emotion as "Needs variants"', () => {
+    const c = char({ overrideTtsVoices: { qwen: { name: 'qwen-x', variants: {} } } });
+    const used = new Set(['angry']);
+    expect(statusFilterKeys(c, voice({ generated: true }), QWEN, used)).toEqual([
+      'Generated',
+      'Needs variants',
+    ]);
+  });
+
+  it('omits "Needs variants" when every in-use emotion has a designed variant', () => {
+    const c = char({
+      overrideTtsVoices: { qwen: { name: 'qwen-x', variants: { angry: { name: 'qwen-x-angry' } } } },
+    });
+    // character has 1 designed variant (→ 'Variants' key) but all in-use emotions are covered
+    // (→ no 'Needs variants' key)
+    expect(statusFilterKeys(c, voice({ generated: true }), QWEN, new Set(['angry']))).toEqual([
+      'Generated',
+      'Variants',
+    ]);
+  });
+
+  it('omits "Needs variants" when usedEmotions is undefined', () => {
+    const c = char({ overrideTtsVoices: { qwen: { name: 'qwen-x', variants: {} } } });
+    expect(statusFilterKeys(c, voice({ generated: true }), QWEN)).toEqual(['Generated']);
+  });
+
+  it('never keys "Needs variants" for a non-Qwen character', () => {
+    const c = char({ voiceState: 'generated' });
+    expect(statusFilterKeys(c, undefined, KOKORO, new Set(['angry']))).toEqual(['Matched']);
+  });
 });
 
 describe('fs-25 — hasEmotionVariants (additive Variants badge + filter)', () => {

--- a/src/lib/voice-status.ts
+++ b/src/lib/voice-status.ts
@@ -162,10 +162,17 @@ export function statusFilterKeys(
   c: Character,
   voice: Voice | undefined,
   effectiveEngine: TtsEngine,
+  /** fs-34 — the character's in-use non-neutral emotions
+      (`usedEmotionsByCharacter(...).get(c.id)`). When provided, a Qwen-effective
+      character with ≥1 in-use emotion lacking a designed variant also matches
+      the "Needs variants" chip. Optional so existing callers keep compiling. */
+  usedEmotions?: Set<string>,
 ): string[] {
   const { lifecycle, reused, hasEmotionVariants } = resolveVoiceStatus(c, voice, effectiveEngine);
   const keys = [lifecycle?.label ?? 'Unset'];
   if (reused) keys.push('Reused');
   if (hasEmotionVariants) keys.push('Variants');
+  const isQwen = effectiveEngine === 'qwen' || voice?.ttsVoice?.provider === 'qwen';
+  if (isQwen && countMissingVariants(c, usedEmotions) > 0) keys.push('Needs variants');
   return keys;
 }

--- a/src/views/cast.test.tsx
+++ b/src/views/cast.test.tsx
@@ -18,7 +18,7 @@ import { voicesSlice } from '../store/voices-slice';
 import { CastView, compareCastRows } from './cast';
 import { playSampleWithAutoLoad } from '../lib/play-sample-with-auto-load';
 import { api } from '../lib/api';
-import type { Character, Voice, TtsModelKey } from '../lib/types';
+import type { Character, Voice, TtsModelKey, Sentence } from '../lib/types';
 
 vi.mock('../lib/api', () => ({
   api: {
@@ -1114,6 +1114,69 @@ describe('CastView status filter', () => {
     expect(isPresent('Blank')).toBe(true);
     /* Clear disappears once no filter is active. */
     expect(screen.queryByRole('button', { name: 'Clear' })).toBeNull();
+  });
+
+  // Designed Qwen voice, speaks an "angry" quote, but has NO angry variant ⇒ "Needs variants".
+  const fury: Character = {
+    id: 'fury',
+    name: 'Fury',
+    role: 'Rival',
+    color: 'mentor',
+    lines: 4,
+    scenes: 1,
+    attributes: [],
+    ttsEngine: 'qwen',
+    overrideTtsVoices: { qwen: { name: 'qwen-fury', variants: {} } },
+  };
+  // Designed Qwen voice WITH the matching variant ⇒ "Has variants", not "Needs variants".
+  const calm: Character = {
+    id: 'calm',
+    name: 'Calm',
+    role: 'Sage',
+    color: 'mentor',
+    lines: 4,
+    scenes: 1,
+    attributes: [],
+    ttsEngine: 'qwen',
+    overrideTtsVoices: { qwen: { name: 'qwen-calm', variants: { angry: { name: 'qwen-calm-angry' } } } },
+  };
+  const variantSentences: Sentence[] = [
+    { id: 1, chapterId: 1, text: 'No!', characterId: 'fury', emotion: 'angry' },
+    { id: 2, chapterId: 1, text: 'Peace.', characterId: 'calm', emotion: 'angry' },
+  ];
+
+  function renderVariantView() {
+    const store = configureStore({
+      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, castDesign: castDesignSlice.reducer },
+    });
+    return render(
+      <Provider store={store}>
+        <CastView
+          characters={[fury, calm]}
+          setCharacters={() => {}}
+          library={library}
+          sentences={variantSentences}
+          title="The Northern Star"
+          onOpenProfile={() => {}}
+          onShowMatchDetail={() => {}}
+          driftEvents={[]}
+          onShowDrift={() => {}}
+        />
+      </Provider>,
+    );
+  }
+
+  it('renders the resurrected "Has variants" chip with its count', () => {
+    renderVariantView();
+    expect(chip(/^Has variants/).textContent).toContain('1'); // calm only
+  });
+
+  it('renders the "Needs variants" chip and filters to unmet-variant rows', () => {
+    renderVariantView();
+    expect(chip(/^Needs variants/).textContent).toContain('1'); // fury only
+    fireEvent.click(chip(/^Needs variants/));
+    expect(isPresent('Fury')).toBe(true);
+    expect(isPresent('Calm')).toBe(false);
   });
 });
 

--- a/src/views/cast.test.tsx
+++ b/src/views/cast.test.tsx
@@ -1171,6 +1171,13 @@ describe('CastView status filter', () => {
     expect(chip(/^Has variants/).textContent).toContain('1'); // calm only
   });
 
+  it('filters to has-variants rows when the "Has variants" chip is active', () => {
+    renderVariantView();
+    fireEvent.click(chip(/^Has variants/));
+    expect(isPresent('Calm')).toBe(true);
+    expect(isPresent('Fury')).toBe(false);
+  });
+
   it('renders the "Needs variants" chip and filters to unmet-variant rows', () => {
     renderVariantView();
     expect(chip(/^Needs variants/).textContent).toContain('1'); // fury only

--- a/src/views/cast.tsx
+++ b/src/views/cast.tsx
@@ -122,7 +122,6 @@ const CHIP_ORDER = [
    only the displayed text changes. */
 const CHIP_LABELS: Record<string, string> = {
   Variants: 'Has variants',
-  'Needs variants': 'Needs variants',
 };
 
 export function CastView({

--- a/src/views/cast.tsx
+++ b/src/views/cast.tsx
@@ -112,9 +112,18 @@ const CHIP_ORDER = [
   'Locked',
   'Unset',
   'Reused',
-  /* fs-25 — "Has emotion variants" provenance/capability chip, last. */
+  /* fs-25 / fs-34 — variant capability chips, last. */
   'Variants',
+  'Needs variants',
 ];
+
+/* Display labels for chips whose internal key differs from the chip text.
+   The key stays stable (it flows through statusFilters + statusFilterKeys);
+   only the displayed text changes. */
+const CHIP_LABELS: Record<string, string> = {
+  Variants: 'Has variants',
+  'Needs variants': 'Needs variants',
+};
 
 export function CastView({
   characters,
@@ -231,7 +240,7 @@ export function CastView({
      StatusPill resolves its labels (matched library voice + effective engine)
      so the chips and the rows can't disagree. */
   const statusKeysFor = (c: Character): string[] =>
-    statusFilterKeys(c, findVoiceForCharacter(c, library), effectiveEngineFor(c));
+    statusFilterKeys(c, findVoiceForCharacter(c, library), effectiveEngineFor(c), usedEmotions.get(c.id));
 
   /* "Design full cast" — every character whose lifecycle is "Needs voice" (a
      Qwen-effective character with no designed voice), most-spoken first. Built
@@ -279,11 +288,9 @@ export function CastView({
   const statusBuckets = useMemo(() => {
     const tally = new Map<string, { color: StatusPillColor; count: number }>();
     for (const c of characters) {
-      const { lifecycle, reused } = resolveVoiceStatus(
-        c,
-        findVoiceForCharacter(c, library),
-        c.ttsEngine ?? ttsEngine,
-      );
+      const effectiveEngine = c.ttsEngine ?? ttsEngine;
+      const voice = findVoiceForCharacter(c, library);
+      const { lifecycle, reused, hasEmotionVariants } = resolveVoiceStatus(c, voice, effectiveEngine);
       const lifecycleKey = lifecycle?.label ?? 'Unset';
       const lifecycleColor: StatusPillColor = lifecycle?.color ?? 'neutral';
       tally.set(lifecycleKey, {
@@ -293,13 +300,23 @@ export function CastView({
       if (reused) {
         tally.set('Reused', { color: 'library', count: (tally.get('Reused')?.count ?? 0) + 1 });
       }
+      if (hasEmotionVariants) {
+        tally.set('Variants', { color: 'library', count: (tally.get('Variants')?.count ?? 0) + 1 });
+      }
+      const isQwen = effectiveEngine === 'qwen' || voice?.ttsVoice?.provider === 'qwen';
+      if (isQwen && countMissingVariants(c, usedEmotions.get(c.id)) > 0) {
+        tally.set('Needs variants', {
+          color: 'warning',
+          count: (tally.get('Needs variants')?.count ?? 0) + 1,
+        });
+      }
     }
     return CHIP_ORDER.filter((key) => tally.has(key)).map((key) => ({
       key,
       color: tally.get(key)!.color,
       count: tally.get(key)!.count,
     }));
-  }, [characters, library, ttsEngine]);
+  }, [characters, library, ttsEngine, usedEmotions]);
 
   const toggleStatusFilter = (key: string) =>
     setStatusFilters((prev) =>
@@ -646,7 +663,7 @@ export function CastView({
                       : 'border border-ink/10 bg-white text-ink/70 hover:text-ink hover:bg-ink/4'
                   }`}
                 >
-                  <span>{b.key}</span>
+                  <span>{CHIP_LABELS[b.key] ?? b.key}</span>
                   <span className={`tabular-nums ${active ? 'text-canvas/70' : 'text-ink/40'}`}>
                     {b.count}
                   </span>

--- a/src/views/voices.test.tsx
+++ b/src/views/voices.test.tsx
@@ -1930,18 +1930,56 @@ describe('fe-34 — variant filter toggle', () => {
     );
   }
 
-  it('narrows the designed voices to needs-variants when "Needs variants" is selected', () => {
+  it('narrows the designed voices to needs-variants when "Needs variants" is selected', async () => {
     renderToggleView();
+    await act(async () => {}); // flush the getBaseVoices mount effect
     expect(screen.getByText('Calm')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /^Needs variants/ }));
     expect(screen.getByText('Fury')).toBeInTheDocument();
     expect(screen.queryByText('Calm')).toBeNull();
   });
 
-  it('narrows to has-variants when "Has variants" is selected', () => {
+  it('narrows to has-variants when "Has variants" is selected', async () => {
     renderToggleView();
+    await act(async () => {}); // flush the getBaseVoices mount effect
     fireEvent.click(screen.getByRole('button', { name: /^Has variants/ }));
     expect(screen.getByText('Calm')).toBeInTheDocument();
     expect(screen.queryByText('Fury')).toBeNull();
+  });
+
+  it('shows "No voices match this filter" (not the global empty state) when a filter excludes all', async () => {
+    // Library with ONLY a fully-covered voice → "Needs variants" matches nothing.
+    const store = configureStore({
+      reducer: {
+        ui: uiSlice.reducer,
+        cast: castSlice.reducer,
+        manuscript: manuscriptSlice.reducer,
+        voices: voicesSlice.reducer,
+        notifications: notificationsSlice.reducer,
+      },
+    });
+    store.dispatch(uiSlice.actions.openBook({ id: 'b1', status: 'cast_pending' }));
+    store.dispatch(uiSlice.actions.confirmCast());
+    store.dispatch(castSlice.actions.setCharacters([designedHas]));
+    store.dispatch(
+      manuscriptSlice.actions.hydrateFromAnalysis({
+        chapters: [],
+        characters: [designedHas],
+        sentences: [{ id: 2, chapterId: 1, text: 'Peace.', characterId: 'calm', emotion: 'angry' }],
+      } as never),
+    );
+    render(
+      <Provider store={store}>
+        <LibraryView library={[qwenLib[1]]} />
+      </Provider>,
+    );
+    await act(async () => {}); // flush the getBaseVoices mount effect
+    fireEvent.click(screen.getByRole('button', { name: /^Needs variants/ }));
+    expect(screen.getByText('No voices match this filter')).toBeInTheDocument();
+    expect(screen.queryByText('No voices yet')).toBeNull();
+    // The toggle stays reachable so the user can switch back (exact name avoids
+    // matching the "All (N)" tab button).
+    const variantGroup = screen.getByRole('group', { name: 'Filter by emotion variants' });
+    expect(within(variantGroup).getByRole('button', { name: 'All' })).toBeInTheDocument();
   });
 });

--- a/src/views/voices.test.tsx
+++ b/src/views/voices.test.tsx
@@ -1874,3 +1874,74 @@ describe('LibraryView Base voices tab', () => {
     expect(screen.getByLabelText('Coqui')).toBeInTheDocument();
   });
 });
+
+describe('fe-34 — variant filter toggle', () => {
+  const designedNeeds: Character = {
+    id: 'fury', name: 'Fury', role: 'Rival', color: 'mentor', lines: 4, scenes: 1, attributes: [],
+    ttsEngine: 'qwen', voiceId: 'qwen-fury',
+    overrideTtsVoices: { qwen: { name: 'qwen-fury', variants: {} } },
+  };
+  const designedHas: Character = {
+    id: 'calm', name: 'Calm', role: 'Sage', color: 'mentor', lines: 4, scenes: 1, attributes: [],
+    ttsEngine: 'qwen', voiceId: 'qwen-calm',
+    overrideTtsVoices: { qwen: { name: 'qwen-calm', variants: { angry: { name: 'qwen-calm-angry' } } } },
+  };
+  const toggleSentences: Sentence[] = [
+    { id: 1, chapterId: 1, text: 'No!', characterId: 'fury', emotion: 'angry' },
+    { id: 2, chapterId: 1, text: 'Peace.', characterId: 'calm', emotion: 'angry' },
+  ];
+  const qwenLib: Voice[] = [
+    { id: 'qwen-fury', character: 'Fury', bookId: 'b1', bookTitle: 'Book One', attributes: [],
+      usedIn: 1, source: 'current', gradient: ['#000', '#111'],
+      ttsVoice: { provider: 'qwen', name: 'qwen-fury', description: '' } },
+    { id: 'qwen-calm', character: 'Calm', bookId: 'b1', bookTitle: 'Book One', attributes: [],
+      usedIn: 1, source: 'current', gradient: ['#000', '#111'],
+      ttsVoice: { provider: 'qwen', name: 'qwen-calm', description: '' } },
+  ];
+
+  function renderToggleView() {
+    const store = configureStore({
+      reducer: {
+        ui: uiSlice.reducer,
+        cast: castSlice.reducer,
+        manuscript: manuscriptSlice.reducer,
+        voices: voicesSlice.reducer,
+        notifications: notificationsSlice.reducer,
+      },
+    });
+    /* Set ui.stage to ready with bookId='b1' so currentBookId resolves and the
+       voices view reads cast + sentences from redux (not foreign-cast cache). */
+    store.dispatch(uiSlice.actions.openBook({ id: 'b1', status: 'cast_pending' }));
+    store.dispatch(uiSlice.actions.confirmCast());
+    /* Hydrate cast with the two Qwen characters used by the qwenLib voices. */
+    store.dispatch(castSlice.actions.setCharacters([designedNeeds, designedHas]));
+    /* Hydrate manuscript sentences so usedEmotionsByCharacter has data. */
+    store.dispatch(
+      manuscriptSlice.actions.hydrateFromAnalysis({
+        chapters: [],
+        characters: [designedNeeds, designedHas],
+        sentences: toggleSentences,
+      } as never),
+    );
+    return render(
+      <Provider store={store}>
+        <LibraryView library={qwenLib} />
+      </Provider>,
+    );
+  }
+
+  it('narrows the designed voices to needs-variants when "Needs variants" is selected', () => {
+    renderToggleView();
+    expect(screen.getByText('Calm')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^Needs variants/ }));
+    expect(screen.getByText('Fury')).toBeInTheDocument();
+    expect(screen.queryByText('Calm')).toBeNull();
+  });
+
+  it('narrows to has-variants when "Has variants" is selected', () => {
+    renderToggleView();
+    fireEvent.click(screen.getByRole('button', { name: /^Has variants/ }));
+    expect(screen.getByText('Calm')).toBeInTheDocument();
+    expect(screen.queryByText('Fury')).toBeNull();
+  });
+});

--- a/src/views/voices.tsx
+++ b/src/views/voices.tsx
@@ -1021,7 +1021,7 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
           onPlay={playBaseVoice}
           status={familyStatus}
         />
-      ) : families.length === 0 && qwenGroups.length === 0 ? (
+      ) : families.length === 0 && qwenGroups.length === 0 && variantFilter === 'all' ? (
         <div className="bg-white rounded-3xl border border-ink/10 shadow-card p-10 text-center">
           <p className="text-sm font-bold text-ink">No voices yet</p>
           <p className="mt-2 text-xs text-ink/60 max-w-md mx-auto">
@@ -1148,6 +1148,16 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
               {variantFilter !== 'all' && (
                 <span className="text-[11px] text-ink/45">Counts fill in as other books load.</span>
               )}
+            </div>
+          )}
+          {variantFilter !== 'all' && qwenGroups.length === 0 && (
+            <div className="bg-white rounded-3xl border border-ink/10 shadow-card p-10 text-center">
+              <p className="text-sm font-bold text-ink">No voices match this filter</p>
+              <p className="mt-2 text-xs text-ink/60 max-w-md mx-auto">
+                {variantFilter === 'has'
+                  ? 'No designed voices have emotion variants in the current view.'
+                  : 'No designed voices still need emotion variants in the current view.'}
+              </p>
             </div>
           )}
           {showFamilies && families.map((f) => (

--- a/src/views/voices.tsx
+++ b/src/views/voices.tsx
@@ -7,10 +7,12 @@ import type {
   BaseVoice,
   Character,
   LibraryBook,
+  Sentence,
   TtsEngine,
   TtsModelKey,
   Voice,
 } from '../lib/types';
+import { usedEmotionsByCharacter, countMissingVariants } from '../lib/voice-status';
 import {
   TTS_ENGINES,
   engineForModelKey,
@@ -154,6 +156,13 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
      button per pair. */
   const [showIgnored, setShowIgnored] = useState(false);
   const [unmarkBusyKey, setUnmarkBusyKey] = useState<string | null>(null);
+  /* fe-34 — variant filter for the Qwen "Designed voices" section. */
+  const [variantFilter, setVariantFilter] = useState<'all' | 'has' | 'needs'>('all');
+  /* fe-34 — sentences per foreign book, cached from the same getBookState the
+     duplicate/compare flows already fetch. The open book reads redux below. */
+  const [sentencesByBookId, setSentencesByBookId] = useState<Map<string, Sentence[]>>(
+    () => new Map(),
+  );
   const dispatch = useAppDispatch();
   const ttsModelKey = useAppSelector((s) => s.ui.ttsModelKey);
   const baseVoices = useAppSelector((s) => s.voices.baseVoices);
@@ -170,6 +179,7 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
      the series' representative book for the per-series global-view buttons). */
   const rebaselineBookId = useAppSelector((s) => s.ui.rebaselineBookId);
   const characters = useAppSelector((s) => s.cast.characters);
+  const openBookSentences = useAppSelector((s) => s.manuscript.sentences);
   /* Plan 101 — series metadata per bookId for cross-book duplicate
      detection. The library slice carries the (author, series,
      isStandalone) trio for every book; combining it with `globalCastCache`
@@ -225,7 +235,6 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
     [library],
   );
   const families = useMemo(() => buildFamilies(presetLibrary, tab), [presetLibrary, tab]);
-  const qwenGroups = useMemo(() => buildQwenStatusGroups(qwenLibrary, tab), [qwenLibrary, tab]);
   /* fs-34 — per-voice designed-variant count for the cross-book Voices badge.
      Resolve each Qwen voice to its character (redux for the open book, the
      global cast cache for others) and count its qwen.variants. */
@@ -240,6 +249,36 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
     }
     return map;
   }, [qwenLibrary, currentBookId, characters, globalCastCache]);
+  /* fe-34 — per-voice count of in-use emotions that LACK a designed variant.
+     Mirrors variantCountByVoiceId but needs the book's sentences (redux for the
+     open book, the cache for foreign books — 0 until a book hydrates). */
+  const missingVariantCountByVoiceId = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const v of qwenLibrary) {
+      const source =
+        v.bookId === currentBookId ? characters : (globalCastCache.get(v.bookId) ?? null);
+      const ch = source ? findCharacterForVoice(v, source) : null;
+      if (!ch) continue;
+      const sents =
+        v.bookId === currentBookId ? openBookSentences : (sentencesByBookId.get(v.bookId) ?? []);
+      const used = usedEmotionsByCharacter(sents).get(ch.id);
+      const n = countMissingVariants(ch, used);
+      if (n > 0) map.set(v.id, n);
+    }
+    return map;
+  }, [qwenLibrary, currentBookId, characters, globalCastCache, openBookSentences, sentencesByBookId]);
+  const filteredQwenLibrary = useMemo(() => {
+    if (variantFilter === 'all') return qwenLibrary;
+    const map = variantFilter === 'has' ? variantCountByVoiceId : missingVariantCountByVoiceId;
+    return qwenLibrary.filter((v) => (map.get(v.id) ?? 0) > 0);
+  }, [qwenLibrary, variantFilter, variantCountByVoiceId, missingVariantCountByVoiceId]);
+  const qwenGroups = useMemo(
+    () => buildQwenStatusGroups(filteredQwenLibrary, tab),
+    [filteredQwenLibrary, tab],
+  );
+  /* When a variant filter is active, preset families + the "Needs a voice" bucket
+     aren't variant-relevant, so show only the matching Qwen designed voices. */
+  const showFamilies = variantFilter === 'all';
   const books = [...new Set(library.map((v) => v.bookId))];
 
   /* Compare derivations. Memoised so a transient render doesn't recompute
@@ -740,6 +779,12 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
         next.set(bookId, cast);
         return next;
       });
+      const sents = res?.manuscriptEdits?.sentences ?? [];
+      setSentencesByBookId((prev) => {
+        const next = new Map(prev);
+        next.set(bookId, sents);
+        return next;
+      });
       return cast;
     } catch (err) {
       console.error('[voices] foreign cast fetch failed', err);
@@ -1073,7 +1118,39 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
               </div>
             )}
           </div>
-          {families.map((f) => (
+          {qwenLibrary.length > 0 && (
+            <div
+              className="flex items-center gap-2 flex-wrap"
+              role="group"
+              aria-label="Filter by emotion variants"
+            >
+              <span className="text-xs text-ink/50">Variants:</span>
+              {(['all', 'has', 'needs'] as const).map((key) => {
+                const label =
+                  key === 'all' ? 'All' : key === 'has' ? 'Has variants' : 'Needs variants';
+                const active = variantFilter === key;
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setVariantFilter(key)}
+                    aria-pressed={active}
+                    className={`min-h-[44px] sm:min-h-0 inline-flex items-center px-3 py-2 sm:py-1.5 rounded-full text-sm font-medium transition-colors ${
+                      active
+                        ? 'bg-ink text-canvas'
+                        : 'border border-ink/10 bg-white text-ink/70 hover:text-ink hover:bg-ink/4'
+                    }`}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+              {variantFilter !== 'all' && (
+                <span className="text-[11px] text-ink/45">Counts fill in as other books load.</span>
+              )}
+            </div>
+          )}
+          {showFamilies && families.map((f) => (
             <VoiceFamilySection
               key={f.key}
               family={f}


### PR DESCRIPTION
## Summary

Adds **Has variants** / **Needs variants** filtering so the user can find cast members (and cross-book voices) that still need emotion variants designed — the missing slice in the primary book → cast workflow. Also **resurrects the dead fs-25 "Has emotion variants" cast chip** (the `statusBuckets` tally never counted it, so it could never render — see #641).

- **Cast view** (`src/views/cast.tsx`): working `Has variants` chip + new `Needs variants` chip (Qwen-gated, live counts, filters rows). The `Needs variants` count = Qwen-effective characters with ≥1 in-use emotion lacking a designed variant.
- **Voices view** (`src/views/voices.tsx`): All / Has variants / Needs variants toggle over the Qwen "Designed voices" section (fe-34). Foreign-book counts fill in lazily as casts/sentences hydrate (same lazy pattern as the duplicate-detector); a hint discloses this.
- **Shared** (`src/lib/voice-status.ts`): `statusFilterKeys` gains an optional `usedEmotions` param and emits the `Needs variants` key from the existing `countMissingVariants` — single source of truth so chips and rows can't diverge.

Spec: `docs/superpowers/specs/2026-06-08-variant-design-filters-design.md` · Plan: `docs/superpowers/plans/2026-06-08-variant-design-filters.md`

## Test plan

- `src/lib/voice-status.test.ts` — `Needs variants` key across Qwen/non-Qwen/has/needs/undefined/partial-coverage (33 tests).
- `src/views/cast.test.tsx` — resurrected `Has variants` chip + new `Needs variants` chip render/count/filter, both directions (61 tests).
- `src/views/voices.test.tsx` — toggle narrows the designed section to has/needs (54 tests).
- Local battery (frontend-only change): **typecheck ✓, full frontend unit suite (2370) ✓, lint ✓, prod build ✓**.
- **Note:** local `npm run verify` server-test leg hit `EBUSY`/worker-fork lock contention from a concurrent session sharing a junctioned `node_modules` (2240+ server tests passed, 0 assertion failures — purely an environmental artifact, no server files were touched). CI runs server tests + e2e in a clean isolated env. e2e was deferred locally — the mock pipeline has no Qwen+emotion fixtures, and the RTL specs above cover the logic; CI's frontend e2e leg exercises the views.

## Follow-ups (minor, secondary surface)

- Voices-view toggle can remain visually active with no cards beneath it on a tab whose filtered Qwen set is empty (cosmetic; visibility guard uses the unfiltered `qwenLibrary`).

Closes #595
Closes #641