### PR TITLE
feat(frontend): per-card Needs-variant badge on Voices designed cards

### DIFF
--- a/src/components/primitives.tsx
+++ b/src/components/primitives.tsx
@@ -251,6 +251,23 @@ export function VariantsBadge({ count }: { count: number }) {
   );
 }
 
+/* fe-34 — warning sibling of VariantsBadge: shown on a designed Qwen voice card
+   when the character speaks in-use emotions that have no designed variant yet
+   (count from `missingVariantCountByVoiceId`). Mirrors the cast view's amber
+   "N tags need a variant" row badge so both surfaces signal the same gap. */
+export function NeedsVariantsBadge({ count }: { count: number }) {
+  return (
+    <span
+      data-testid="needs-variants-badge"
+      title={`${count} in-use ${count === 1 ? 'emotion' : 'emotions'} still ${count === 1 ? 'needs' : 'need'} a designed variant`}
+      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium text-amber-700 bg-amber-500/10"
+    >
+      <IconSparkle className="w-2.5 h-2.5" />
+      Needs · {count}
+    </span>
+  );
+}
+
 /* Coming-soon affordance for still-mocked sections (listener-app cards,
    download tiles, export-queue rows). Sits in the title row of each card
    and pairs with disabled action buttons so smoke passes can't mistake demo

--- a/src/views/voices.test.tsx
+++ b/src/views/voices.test.tsx
@@ -1982,4 +1982,16 @@ describe('fe-34 — variant filter toggle', () => {
     const variantGroup = screen.getByRole('group', { name: 'Filter by emotion variants' });
     expect(within(variantGroup).getByRole('button', { name: 'All' })).toBeInTheDocument();
   });
+
+  it('shows a per-card "Needs" badge on a designed voice missing a variant', async () => {
+    renderToggleView();
+    await act(async () => {}); // flush the getBaseVoices mount effect
+    // Default 'all' filter shows both designed cards. Only Fury (no variants,
+    // speaks an "angry" quote) is missing one → exactly one Needs badge.
+    const needs = screen.getAllByTestId('needs-variants-badge');
+    expect(needs).toHaveLength(1);
+    expect(needs[0]).toHaveTextContent('Needs · 1');
+    // Calm is fully covered → carries the Variants badge, never a Needs badge.
+    expect(screen.getByTestId('variants-badge')).toHaveTextContent('Variants');
+  });
 });

--- a/src/views/voices.tsx
+++ b/src/views/voices.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
-import { SectionLabel, MixedHeading, VoiceSwatch, Pill, VariantsBadge } from '../components/primitives';
+import {
+  SectionLabel,
+  MixedHeading,
+  VoiceSwatch,
+  Pill,
+  VariantsBadge,
+  NeedsVariantsBadge,
+} from '../components/primitives';
 import { StatTile } from '../components/stat-tiles';
 import { VoiceCard } from '../components/voice-library-panel';
 import { IconPlay, IconSparkle } from '../lib/icons';
@@ -1191,6 +1198,7 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
               selectedVoiceIds={selectedVoiceIds}
               onToggleSelect={toggleSelect}
               variantCountByVoiceId={variantCountByVoiceId}
+              missingVariantCountByVoiceId={missingVariantCountByVoiceId}
               representativeBookIdBySeries={representativeBookIdBySeries}
               onRebaselineSeries={(bookId) =>
                 dispatch(uiActions.openRebaselineModal({ bookId }))
@@ -1756,6 +1764,9 @@ interface QwenSectionProps {
   /* fs-34 — designed emotion-variant count per Qwen voiceId (0/absent → no
      badge). Resolved in the parent where the cross-book cast cache lives. */
   variantCountByVoiceId: Map<string, number>;
+  /* fe-34 — in-use emotions still lacking a designed variant, per Qwen voiceId
+     (0/absent → no badge). Resolved in the parent alongside variantCountByVoiceId. */
+  missingVariantCountByVoiceId: Map<string, number>;
   /* Per-series Rebaseline (plan 108 follow-up) — reused verbatim from
      VoiceFamilySection. Rebaseline *creates* designed Qwen voices, so it
      sits naturally on the Qwen sections' series-group headers. */
@@ -1777,6 +1788,7 @@ function QwenStatusSection({
   selectedVoiceIds,
   onToggleSelect,
   variantCountByVoiceId,
+  missingVariantCountByVoiceId,
   representativeBookIdBySeries,
   onRebaselineSeries,
 }: QwenSectionProps) {
@@ -1851,6 +1863,11 @@ function QwenStatusSection({
                                 )}
                                 {(variantCountByVoiceId.get(v.id) ?? 0) > 0 && (
                                   <VariantsBadge count={variantCountByVoiceId.get(v.id)!} />
+                                )}
+                                {(missingVariantCountByVoiceId.get(v.id) ?? 0) > 0 && (
+                                  <NeedsVariantsBadge
+                                    count={missingVariantCountByVoiceId.get(v.id)!}
+                                  />
                                 )}
                               </span>
                             ) : undefined


### PR DESCRIPTION
## Summary
Follow-up polish to fe-34. Each designed Qwen voice card in the Voices view now shows an amber **"Needs · N"** badge when the character speaks in-use emotions with no designed variant yet — the same signal the cast view's "N tags need a variant" row badge gives, so you can see *how many* variants a voice is missing without opening its profile. Reuses the `missingVariantCountByVoiceId` map already computed for the Needs-variants filter.

- New `NeedsVariantsBadge` primitive (warning sibling of `VariantsBadge`).
- Threaded `missingVariantCountByVoiceId` into `QwenStatusSection`.

## Test plan
- `src/views/voices.test.tsx` — designed card missing a variant shows exactly one `Needs · N` badge; a fully-covered card shows `Variants`, never `Needs` (56 tests).
- typecheck, lint, prod build all green.