### PR TITLE
fix(frontend,server,openapi,e2e): Admin/Account UI polish + voice-engine rename

### DIFF
--- a/e2e/admin-ui-polish.spec.ts
+++ b/e2e/admin-ui-polish.spec.ts
@@ -1,0 +1,92 @@
+/* Admin / Account UI polish — crosses the router/redux/layout seam, so it earns
+   a Playwright spec per CLAUDE.md's e2e bar. Runs against Vite in mock mode,
+   where GET /api/diagnostics returns a board that now carries the ASR row + the
+   "Voice engine" rename, and the throughput/telemetry mocks ship 7 rows so both
+   Admin tables actually render their scroll regions.
+
+   Covers:
+     - the "TTS sidecar" → "Voice engine" rename in the health board,
+     - the new ASR (Whisper) row sitting directly below the Voice engine row,
+     - both Admin tables scrolling inside the inset thin-scrollbar utility with a
+       sticky column header pinned INSIDE the scroller (the header-alignment fix),
+     - the Account "Open Model Manager" button staying readable in dark mode
+       (dark text on the inverted-ink pill, not white-on-near-white). */
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Admin watch console — voice-engine rename + ASR row', () => {
+  test('labels the sidecar row "Voice engine" and drops the "TTS sidecar" jargon', async ({
+    page,
+  }) => {
+    await page.goto('/#/admin');
+    const sidecarRow = page.getByTestId('health-row-sidecar');
+    await expect(sidecarRow).toBeVisible({ timeout: 10_000 });
+    await expect(sidecarRow).toContainText('Voice engine');
+    await expect(page.getByTestId('health-board')).not.toContainText('TTS sidecar');
+  });
+
+  test('renders the ASR (Whisper) row directly below the Voice engine row', async ({ page }) => {
+    await page.goto('/#/admin');
+    await expect(page.getByTestId('health-row-asr')).toBeVisible({ timeout: 10_000 });
+    const ids = await page
+      .getByTestId('health-board')
+      .locator('[data-testid^="health-row-"]')
+      .evaluateAll((els) => els.map((e) => e.getAttribute('data-testid')));
+    expect(ids.indexOf('health-row-asr')).toBe(ids.indexOf('health-row-sidecar') + 1);
+  });
+});
+
+test.describe('Admin tables — scroll region + sticky header alignment', () => {
+  test('generation throughput scrolls in the inset thin-scrollbar with a sticky header inside', async ({
+    page,
+  }) => {
+    await page.goto('/#/admin');
+    const scroll = page.getByTestId('generation-throughput-scroll');
+    await expect(scroll).toBeVisible({ timeout: 10_000 });
+    await expect(scroll).toHaveClass(/scrollbar-thin/);
+    await expect(scroll).toHaveClass(/overflow-y-auto/);
+    // The column header is the first child of the scroller and is sticky, so it
+    // shares the reserved gutter with the rows it sits above.
+    const headerPosition = await scroll
+      .locator(':scope > div')
+      .first()
+      .evaluate((el) => getComputedStyle(el).position);
+    expect(headerPosition).toBe('sticky');
+    // Rows live in the same scroller.
+    await expect(scroll.locator('[data-testid^="throughput-row-"]').first()).toBeVisible();
+  });
+
+  test('resource trends scrolls in the inset thin-scrollbar with a sticky header inside', async ({
+    page,
+  }) => {
+    await page.goto('/#/admin');
+    const scroll = page.getByTestId('resource-trends-scroll');
+    await expect(scroll).toBeVisible({ timeout: 10_000 });
+    await expect(scroll).toHaveClass(/scrollbar-thin/);
+    const headerPosition = await scroll
+      .locator(':scope > div')
+      .first()
+      .evaluate((el) => getComputedStyle(el).position);
+    expect(headerPosition).toBe('sticky');
+    await expect(scroll.locator('[data-testid^="resource-row-"]').first()).toBeVisible();
+  });
+});
+
+test.describe('Account — Open Model Manager button in dark mode', () => {
+  test('paints dark text on the inverted-ink pill so it stays readable', async ({ page }) => {
+    await page.goto('/#/account');
+    // Force the dark theme the same way main.tsx does (data-theme on <html>).
+    await page.evaluate(() => document.documentElement.setAttribute('data-theme', 'dark'));
+    const button = page.getByTestId('account-model-manager-pointer');
+    await expect(button).toBeVisible({ timeout: 10_000 });
+    // In dark mode --canvas is near-black, so text-canvas must resolve to a DARK
+    // colour. The shipped bug used text-white (near-white) → invisible pill.
+    const luminance = await button.evaluate((el) => {
+      const rgb = getComputedStyle(el)
+        .color.match(/\d+/g)!
+        .map(Number);
+      return 0.299 * rgb[0] + 0.587 * rgb[1] + 0.114 * rgb[2];
+    });
+    expect(luminance).toBeLessThan(80);
+  });
+});

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4665,8 +4665,8 @@ components:
       properties:
         id:
           type: string
-          enum: [gpu, sidecar, analyzer, gemini, ffmpeg, disk]
-          description: Stable identifier for the check (drives the UI row key).
+          enum: [gpu, sidecar, asr, analyzer, gemini, ffmpeg, disk]
+          description: Stable identifier for the check (drives the UI row key). `sidecar` is the Voice engine; `asr` is the Whisper content-QA engine.
         label:
           type: string
           description: Friendly display label, e.g. "GPU / VRAM".

--- a/server/src/routes/diagnostics.test.ts
+++ b/server/src/routes/diagnostics.test.ts
@@ -75,12 +75,18 @@ describe('GET /api/diagnostics', () => {
     expect(res.body.checks.map((c: Check) => c.id)).toEqual([
       'gpu',
       'sidecar',
+      'asr',
       'analyzer',
       'gemini',
       'ffmpeg',
       'disk',
     ]);
     expect(byId(res.body.checks, 'sidecar').detail).toContain('qwen');
+    /* The sidecar row is labelled "Voice engine" for users (not "TTS sidecar"). */
+    expect(
+      (res.body.checks as Array<{ id: string; label: string }>).find((c) => c.id === 'sidecar')!
+        .label,
+    ).toBe('Voice engine');
   });
 
   it('fails the gpu + sidecar rows when the sidecar is unreachable', async () => {
@@ -203,5 +209,58 @@ describe('GET /api/diagnostics', () => {
     expect(byId(res.body.checks, 'disk').detail).toContain('statfs blew up');
     // The other checks are unaffected.
     expect(byId(res.body.checks, 'sidecar').status).toBe('ok');
+  });
+
+  describe('ASR (Whisper) row (srv-31)', () => {
+    it('reports off when content-QA ASR is disabled (the default)', async () => {
+      /* Default mock omits asrEnabled → ASR is off; never a failure. */
+      const res = await request(makeApp()).get('/api/diagnostics');
+      const asr = byId(res.body.checks, 'asr');
+      expect(asr.status).toBe('ok');
+      expect(asr.detail).toMatch(/off/i);
+    });
+
+    it('reports enabled · idle · device when ASR is on but not yet resident', async () => {
+      probeSidecarHealth.mockResolvedValue({
+        status: 'reachable',
+        url: '',
+        proxy: 'sidecar',
+        qwenLoaded: true,
+        asrEnabled: true,
+        asrLoaded: false,
+        asrDevice: 'cpu',
+      });
+      const res = await request(makeApp()).get('/api/diagnostics');
+      const asr = byId(res.body.checks, 'asr');
+      expect(asr.status).toBe('ok');
+      expect(asr.detail).toBe('enabled · idle · cpu');
+    });
+
+    it('reports enabled · resident · device when the Whisper model is loaded', async () => {
+      probeSidecarHealth.mockResolvedValue({
+        status: 'reachable',
+        url: '',
+        proxy: 'sidecar',
+        qwenLoaded: true,
+        asrEnabled: true,
+        asrLoaded: true,
+        asrDevice: 'cuda',
+      });
+      const res = await request(makeApp()).get('/api/diagnostics');
+      const asr = byId(res.body.checks, 'asr');
+      expect(asr.status).toBe('ok');
+      expect(asr.detail).toBe('enabled · resident · cuda');
+    });
+
+    it('fails the ASR row when the voice engine is unreachable', async () => {
+      probeSidecarHealth.mockResolvedValue({
+        status: 'unreachable',
+        url: '',
+        proxy: 'sidecar',
+        error: 'connection refused',
+      });
+      const res = await request(makeApp()).get('/api/diagnostics');
+      expect(byId(res.body.checks, 'asr').status).toBe('fail');
+    });
   });
 });

--- a/server/src/routes/diagnostics.ts
+++ b/server/src/routes/diagnostics.ts
@@ -24,7 +24,7 @@ import {
 import { WORKSPACE_ROOT } from '../workspace/paths.js';
 
 export type CheckStatus = 'ok' | 'warn' | 'fail';
-export type CheckId = 'gpu' | 'sidecar' | 'analyzer' | 'gemini' | 'ffmpeg' | 'disk';
+export type CheckId = 'gpu' | 'sidecar' | 'asr' | 'analyzer' | 'gemini' | 'ffmpeg' | 'disk';
 
 export interface DiagnosticsCheck {
   id: CheckId;
@@ -122,12 +122,12 @@ diagnosticsRouter.get('/', async (_req: Request, res: Response) => {
       };
     }),
 
-    // TTS sidecar reachability + resident models.
-    runCheck('sidecar', 'TTS sidecar', () => {
+    // Voice engine (TTS sidecar) reachability + resident models.
+    runCheck('sidecar', 'Voice engine', () => {
       if (sidecar.status !== 'reachable') {
         return {
           id: 'sidecar',
-          label: 'TTS sidecar',
+          label: 'Voice engine',
           status: 'fail',
           detail: sidecar.error || 'unreachable',
         };
@@ -138,10 +138,43 @@ diagnosticsRouter.get('/', async (_req: Request, res: Response) => {
       if (sidecar.qwenLoaded) resident.push('qwen');
       return {
         id: 'sidecar',
-        label: 'TTS sidecar',
+        label: 'Voice engine',
         status: 'ok',
         detail: resident.length ? `reachable · ${resident.join(', ')}` : 'reachable · no model resident',
         value: resident.join(', ') || null,
+      };
+    }),
+
+    // ASR (Whisper) content-QA engine (srv-31). Display-only — it loads lazily
+    // on /transcribe and idle-evicts, so there's no Load/Stop here. OFF unless
+    // SEG_ASR_ENABLED, in which case we surface whether it's resident + device.
+    // Never a `fail` row: an idle (not-yet-loaded) ASR is the normal state.
+    runCheck('asr', 'ASR (Whisper)', () => {
+      if (sidecar.status !== 'reachable') {
+        return {
+          id: 'asr',
+          label: 'ASR (Whisper)',
+          status: 'fail',
+          detail: 'voice engine unreachable — cannot read ASR state',
+        };
+      }
+      if (!sidecar.asrEnabled) {
+        return {
+          id: 'asr',
+          label: 'ASR (Whisper)',
+          status: 'ok',
+          detail: 'off — content-QA disabled',
+        };
+      }
+      const device = sidecar.asrDevice ?? 'cpu';
+      return {
+        id: 'asr',
+        label: 'ASR (Whisper)',
+        status: 'ok',
+        detail: sidecar.asrLoaded
+          ? `enabled · resident · ${device}`
+          : `enabled · idle · ${device}`,
+        value: sidecar.asrLoaded ? device : null,
       };
     }),
 

--- a/src/components/AsrStatusBadge.test.tsx
+++ b/src/components/AsrStatusBadge.test.tsx
@@ -22,9 +22,9 @@ describe('AsrStatusBadge', () => {
     expect(screen.getByText('Whisper ASR idle')).toBeInTheDocument();
   });
 
-  it('shows the sidecar-down label when unreachable', () => {
+  it('shows the voice-engine-down label when unreachable', () => {
     render(<AsrStatusBadge state="unreachable" device={null} />);
-    expect(screen.getByText('Sidecar process not running')).toBeInTheDocument();
+    expect(screen.getByText('Voice engine not running')).toBeInTheDocument();
   });
 
   it('collapses an unexpected state to idle (no Load/Stop button ever renders)', () => {

--- a/src/components/AsrStatusBadge.tsx
+++ b/src/components/AsrStatusBadge.tsx
@@ -29,7 +29,7 @@ export function AsrStatusBadge({
         ? `Whisper ASR ready · ${device}`
         : 'Whisper ASR ready'
       : key === 'unreachable'
-        ? 'Sidecar process not running'
+        ? 'Voice engine not running'
         : 'Whisper ASR idle';
   return (
     <span

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1029,7 +1029,7 @@ export function Layout() {
           kind="tts"
           engineLabel="Kokoro"
           state={ttsLifecycle.kokoro.state}
-          unreachableLabel="Sidecar process not running"
+          unreachableLabel="Voice engine not running"
           onLoad={() => {
             void ttsLifecycle.kokoro.onLoad();
           }}
@@ -1043,7 +1043,7 @@ export function Layout() {
           kind="tts"
           engineLabel="Coqui XTTS"
           state={ttsLifecycle.coqui.state}
-          unreachableLabel="Sidecar process not running"
+          unreachableLabel="Voice engine not running"
           onLoad={() => {
             void ttsLifecycle.coqui.onLoad();
           }}
@@ -1057,7 +1057,7 @@ export function Layout() {
           kind="tts"
           engineLabel="Qwen"
           state={ttsLifecycle.qwen.state}
-          unreachableLabel="Sidecar process not running"
+          unreachableLabel="Voice engine not running"
           onLoad={() => {
             void ttsLifecycle.qwen.onLoad();
           }}

--- a/src/components/model-settings-form.tsx
+++ b/src/components/model-settings-form.tsx
@@ -333,12 +333,12 @@ export function ModelSettingsForm() {
       </FormCard>
 
       <FormCard
-        title="TTS sidecar"
-        hint="The Python sidecar process that runs Qwen3-TTS / Kokoro / Coqui XTTS locally. The Node server can launch it for you automatically."
+        title="Voice engine"
+        hint="The local voice engine (a Python process) that runs Qwen3-TTS / Kokoro / Coqui XTTS. The Node server can launch it for you automatically."
       >
         <FieldRow
           label="Auto-start with server"
-          sublabel="When the analysis server starts (start-app.bat or `cd server && npm run dev`), automatically spawn the Python TTS sidecar as a child process. Disable to run `npm run tts:sidecar` yourself, e.g. for debugging or to swap engines per-session. Takes effect on the next server restart."
+          sublabel="When the analysis server starts (start-app.bat or `cd server && npm run dev`), automatically spawn the Python voice engine as a child process. Disable to run `npm run tts:sidecar` yourself, e.g. for debugging or to swap engines per-session. Takes effect on the next server restart."
         >
           <label className="inline-flex items-center gap-3 cursor-pointer select-none">
             <input
@@ -382,7 +382,7 @@ export function ModelSettingsForm() {
         {eagerEngineIsQwen ? (
           <FieldRow
             label="Eager-load Qwen at startup"
-            sublabel="On by default while Qwen is your default engine — the sidecar preloads Qwen's synth model at boot so the first chapter doesn't wait on a cold load. Turn off to warm it lazily on first synth and keep that VRAM free until generation starts. Kokoro stays the on-demand fallback either way. Takes effect on the next sidecar restart."
+            sublabel="On by default while Qwen is your default engine — the voice engine preloads Qwen's synth model at boot so the first chapter doesn't wait on a cold load. Turn off to warm it lazily on first synth and keep that VRAM free until generation starts. Kokoro stays the on-demand fallback either way. Takes effect on the next voice-engine restart."
           >
             <label className="inline-flex items-center gap-3 cursor-pointer select-none">
               <input
@@ -394,20 +394,20 @@ export function ModelSettingsForm() {
               />
               <span className="text-sm text-ink">
                 {eagerLoadQwen
-                  ? 'Enabled — the sidecar preloads Qwen at startup.'
+                  ? 'Enabled — the voice engine preloads Qwen at startup.'
                   : 'Disabled — Qwen warms on demand on first synth.'}
               </span>
             </label>
             {eagerLoadQwenDirty && (
               <p className="mt-2 text-xs text-amber-800 bg-amber-100 rounded-full px-3 py-1 inline-block">
-                Restart the sidecar to apply this change.
+                Restart the voice engine to apply this change.
               </p>
             )}
           </FieldRow>
         ) : (
           <FieldRow
             label="Eager-load Kokoro at startup"
-            sublabel="On by default. Turn off if Qwen is your main engine — Kokoro then loads only when a Kokoro voice (e.g. the narrator) is synthesized, freeing ~1 GB VRAM. Takes effect on the next sidecar restart."
+            sublabel="On by default. Turn off if Qwen is your main engine — Kokoro then loads only when a Kokoro voice (e.g. the narrator) is synthesized, freeing ~1 GB VRAM. Takes effect on the next voice-engine restart."
           >
             <label className="inline-flex items-center gap-3 cursor-pointer select-none">
               <input
@@ -419,13 +419,13 @@ export function ModelSettingsForm() {
               />
               <span className="text-sm text-ink">
                 {eagerLoadKokoro
-                  ? 'Enabled — the sidecar preloads Kokoro at startup.'
+                  ? 'Enabled — the voice engine preloads Kokoro at startup.'
                   : 'Disabled — Kokoro warms on demand on first synth.'}
               </span>
             </label>
             {eagerLoadKokoroDirty && (
               <p className="mt-2 text-xs text-amber-800 bg-amber-100 rounded-full px-3 py-1 inline-block">
-                Restart the sidecar to apply this change.
+                Restart the voice engine to apply this change.
               </p>
             )}
           </FieldRow>
@@ -454,9 +454,9 @@ export function ModelSettingsForm() {
 
       <FormCard
         title="Server configuration"
-        hint="Non-secret overrides for what's in server/.env. Sidecar URL and Ollama settings take effect on the next request."
+        hint="Non-secret overrides for what's in server/.env. Voice engine URL and Ollama settings take effect on the next request."
       >
-        <FieldRow label="Sidecar URL" sublabel="Local TTS sidecar endpoint. Default: http://localhost:9000">
+        <FieldRow label="Voice engine URL" sublabel="Local voice engine endpoint. Default: http://localhost:9000">
           <input
             type="text"
             value={sidecarUrl}

--- a/src/hooks/use-local-analyzer-guard.tsx
+++ b/src/hooks/use-local-analyzer-guard.tsx
@@ -102,7 +102,7 @@ export function useLocalAnalyzerGuard({ generatingBookTitle }: GuardOptions = {}
       body={
         <>
           <p>
-            Local analysis needs the same GPU as the TTS sidecar, so audio generation for{' '}
+            Local analysis needs the same GPU as the Voice engine, so audio generation for{' '}
             <b>{resolvedTitle}</b> will pause while this manuscript is analysed.
           </p>
           <p className="mt-3 text-ink/60">

--- a/src/hooks/use-reverse-local-analyzer-guard.tsx
+++ b/src/hooks/use-reverse-local-analyzer-guard.tsx
@@ -104,7 +104,7 @@ export function useReverseLocalAnalyzerGuard({
       body={
         <>
           <p>
-            Local analysis needs the same GPU as the TTS sidecar, so analysis for{' '}
+            Local analysis needs the same GPU as the Voice engine, so analysis for{' '}
             <b>{resolvedTitle}</b> will pause while audio is generated.
           </p>
           <p className="mt-3 text-ink/60">

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -3498,10 +3498,10 @@ export interface components {
         };
         DiagnosticsCheck: {
             /**
-             * @description Stable identifier for the check (drives the UI row key).
+             * @description Stable identifier for the check (drives the UI row key). `sidecar` is the Voice engine; `asr` is the Whisper content-QA engine.
              * @enum {string}
              */
-            id: "gpu" | "sidecar" | "analyzer" | "gemini" | "ffmpeg" | "disk";
+            id: "gpu" | "sidecar" | "asr" | "analyzer" | "gemini" | "ffmpeg" | "disk";
             /** @description Friendly display label, e.g. "GPU / VRAM". */
             label: string;
             /**

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4878,7 +4878,14 @@ async function mockGetGpuQueueState(): Promise<GpuQueueState> {
    DiagnosticsResponse schema in openapi.yaml; see server/src/routes/diagnostics.ts.
    Polled by the Admin view + the top-bar status dot (~30 s cadence). */
 export type DiagnosticsStatus = 'ok' | 'warn' | 'fail';
-export type DiagnosticsCheckId = 'gpu' | 'sidecar' | 'analyzer' | 'gemini' | 'ffmpeg' | 'disk';
+export type DiagnosticsCheckId =
+  | 'gpu'
+  | 'sidecar'
+  | 'asr'
+  | 'analyzer'
+  | 'gemini'
+  | 'ffmpeg'
+  | 'disk';
 
 export interface DiagnosticsCheck {
   id: DiagnosticsCheckId;
@@ -4912,7 +4919,8 @@ async function mockGetDiagnostics(): Promise<DiagnosticsResponse> {
     overall: 'ok',
     checks: [
       { id: 'gpu', label: 'GPU / VRAM', status: 'ok', detail: 'cuda · 1.2 / 8.0 GB reserved', value: '1.2/8.0 GB' },
-      { id: 'sidecar', label: 'TTS sidecar', status: 'ok', detail: 'reachable · kokoro, qwen', value: 'kokoro, qwen' },
+      { id: 'sidecar', label: 'Voice engine', status: 'ok', detail: 'reachable · kokoro, qwen', value: 'kokoro, qwen' },
+      { id: 'asr', label: 'ASR (Whisper)', status: 'ok', detail: 'off — content-QA disabled' },
       { id: 'analyzer', label: 'Analyzer (Ollama)', status: 'ok', detail: 'reachable · model resident' },
       { id: 'gemini', label: 'Analyzer (Gemini)', status: 'ok', detail: 'not in use' },
       { id: 'ffmpeg', label: 'ffmpeg / ffprobe', status: 'ok', detail: 'both present' },

--- a/src/views/account.test.tsx
+++ b/src/views/account.test.tsx
@@ -84,6 +84,17 @@ describe('AccountView â€” rendering', () => {
     expect(screen.getByText('/foo/bar')).toBeInTheDocument();
     expect(screen.getByText(/source: override/i)).toBeInTheDocument();
   });
+
+  it('paints the Open Model Manager button with the theme-safe ink/canvas token', () => {
+    /* Regression: the button shipped `bg-ink text-white`, which renders
+       white-on-near-white once --ink inverts in dark mode (the fs-23 dark-CTA
+       fix idiom is `bg-ink text-canvas`, as on the Admin sibling button). */
+    renderView();
+    const button = screen.getByTestId('account-model-manager-pointer');
+    expect(button.className).toContain('bg-ink');
+    expect(button.className).toContain('text-canvas');
+    expect(button.className).not.toContain('text-white');
+  });
 });
 
 describe('AccountView â€” save flow', () => {

--- a/src/views/account.tsx
+++ b/src/views/account.tsx
@@ -389,15 +389,15 @@ export function AccountView() {
           <div>
             <h2 className="text-base font-semibold text-ink">Models &amp; engines</h2>
             <p className="mt-1 text-xs text-ink/55 max-w-prose">
-              Installing models, picking the default TTS / analyzer engine, the sidecar / Ollama
-              URLs, and the Gemini key now live in the Model Manager.
+              Installing models, picking the default TTS / analyzer engine, the Voice engine /
+              Ollama URLs, and the Gemini key now live in the Model Manager.
             </p>
           </div>
           <button
             type="button"
             onClick={() => dispatch(uiActions.openModelManager())}
             data-testid="account-model-manager-pointer"
-            className="shrink-0 min-h-[44px] sm:min-h-0 px-4 py-2 rounded-xl bg-ink text-white text-sm font-medium hover:bg-ink/90"
+            className="shrink-0 min-h-[44px] sm:min-h-0 px-4 py-2 rounded-xl bg-ink text-canvas text-sm font-medium hover:bg-ink-soft"
           >
             Open Model Manager →
           </button>

--- a/src/views/admin.test.tsx
+++ b/src/views/admin.test.tsx
@@ -47,7 +47,8 @@ const healthyBoard: DiagnosticsResponse = {
   overall: 'ok',
   checks: [
     { id: 'gpu', label: 'GPU / VRAM', status: 'ok', detail: 'cuda · 1.2 / 8.0 GB reserved' },
-    { id: 'sidecar', label: 'TTS sidecar', status: 'ok', detail: 'reachable · qwen' },
+    { id: 'sidecar', label: 'Voice engine', status: 'ok', detail: 'reachable · qwen' },
+    { id: 'asr', label: 'ASR (Whisper)', status: 'ok', detail: 'off — content-QA disabled' },
     { id: 'analyzer', label: 'Analyzer (Ollama)', status: 'warn', detail: 'reachable · model not pulled' },
     { id: 'gemini', label: 'Analyzer (Gemini)', status: 'ok', detail: 'not in use' },
     { id: 'ffmpeg', label: 'ffmpeg / ffprobe', status: 'fail', detail: 'ffprobe not found on PATH' },
@@ -120,11 +121,14 @@ describe('AdminView — health board', () => {
     expect(ids).toEqual([
       'health-row-gpu',
       'health-row-sidecar',
+      'health-row-asr',
       'health-row-analyzer',
       'health-row-gemini',
       'health-row-ffmpeg',
       'health-row-disk',
     ]);
+    /* The ASR row sits directly below the Voice engine row (srv-31 watch). */
+    expect(ids[ids.indexOf('health-row-sidecar') + 1]).toBe('health-row-asr');
     expect(screen.getByTestId('health-row-ffmpeg')).toHaveAttribute('data-status', 'fail');
     expect(screen.getByTestId('health-row-analyzer')).toHaveAttribute('data-status', 'warn');
     expect(within(screen.getByTestId('health-row-gpu')).getByText(/8\.0 GB/)).toBeInTheDocument();
@@ -331,5 +335,59 @@ describe('AdminView — fs-20 resource trends panel', () => {
     await waitFor(() => expect(mockTelemetry).toHaveBeenCalled());
     expect(screen.queryByTestId('resource-trends')).toBeNull();
     expect(screen.getByText(/No telemetry recorded yet/i)).toBeInTheDocument();
+  });
+});
+
+describe('AdminView — table scroll regions + header alignment', () => {
+  /* Both Admin tables scroll inside the inset thin-scrollbar utility (matching
+     every other in-card scroll region), and pin their column header INSIDE the
+     scroller with ONE shared column template so the header tracks line up with
+     the data rows instead of drifting on the scrollbar gutter + independent
+     `auto` columns. */
+  const THROUGHPUT_COLS = 'md:grid-cols-[1fr_7rem_3.5rem_3.5rem_auto]';
+  const TRENDS_COLS = 'sm:grid-cols-[1fr_3rem_3.5rem_auto]';
+
+  it('scrolls the generation-throughput rows in the inset thin-scrollbar region', async () => {
+    mockStats.mockResolvedValue({
+      ...idleStats,
+      recentChapters: [chapter({ chapterId: 1, rtf: 1.0 })],
+    });
+    renderAdmin();
+    const scroll = await screen.findByTestId('generation-throughput-scroll');
+    expect(scroll.className).toMatch(/overflow-y-auto/);
+    expect(scroll.className).toMatch(/scrollbar-thin/);
+  });
+
+  it('scrolls the resource-trends rows in the inset thin-scrollbar region', async () => {
+    mockTelemetry.mockResolvedValue({ records: [telemetry({ chapterId: 1 })] });
+    renderAdmin();
+    const scroll = await screen.findByTestId('resource-trends-scroll');
+    expect(scroll.className).toMatch(/overflow-y-auto/);
+    expect(scroll.className).toMatch(/scrollbar-thin/);
+  });
+
+  it('throughput header is sticky inside the scroller and shares the row column template', async () => {
+    mockStats.mockResolvedValue({
+      ...idleStats,
+      recentChapters: [chapter({ chapterId: 1, rtf: 1.0 })],
+    });
+    renderAdmin();
+    const scroll = await screen.findByTestId('generation-throughput-scroll');
+    const header = scroll.firstElementChild as HTMLElement;
+    expect(header.className).toMatch(/sticky/);
+    expect(header.className).toContain(THROUGHPUT_COLS);
+    const row = within(scroll).getByTestId('throughput-row-1');
+    expect(row.className).toContain(THROUGHPUT_COLS);
+  });
+
+  it('resource-trends header is sticky inside the scroller and shares the row column template', async () => {
+    mockTelemetry.mockResolvedValue({ records: [telemetry({ chapterId: 1 })] });
+    renderAdmin();
+    const scroll = await screen.findByTestId('resource-trends-scroll');
+    const header = scroll.firstElementChild as HTMLElement;
+    expect(header.className).toMatch(/sticky/);
+    expect(header.className).toContain(TRENDS_COLS);
+    const row = within(scroll).getByTestId('resource-row-1');
+    expect(row.className).toContain(TRENDS_COLS);
   });
 });

--- a/src/views/admin.tsx
+++ b/src/views/admin.tsx
@@ -68,6 +68,20 @@ const TREND_STYLE: Record<Trend, { cls: string; glyph: string; label: string }> 
   none: { cls: 'text-ink/70', glyph: '', label: '' },
 };
 
+/* Shared column templates so each table's sticky header and its body rows are
+   ONE grid definition, not two independent grids whose `auto` tracks size to
+   different content (header text vs. data) and drift out of alignment. Explicit
+   rem widths on the fixed columns guarantee the tracks line up; the responsive
+   variants drop tracks in lockstep with the cells' `hidden sm:/md:block` so the
+   collapse stays aligned at every breakpoint. The header lives INSIDE the
+   scroll container (sticky) so it shares the scrollbar gutter the rows reserve
+   (scrollbar-gutter: stable from .scrollbar-thin) — otherwise the header would
+   run a gutter-width past the rows. */
+const THROUGHPUT_COLS =
+  'grid grid-cols-[1fr_auto] sm:grid-cols-[1fr_7rem_auto] md:grid-cols-[1fr_7rem_3.5rem_3.5rem_auto] gap-x-3 sm:gap-x-6';
+const TRENDS_COLS =
+  'grid grid-cols-[1fr_3rem_auto] sm:grid-cols-[1fr_3rem_3.5rem_auto] gap-x-3 sm:gap-x-6';
+
 export function AdminView() {
   const [stats, setStats] = useState<GenerationStatsResponse | null>(null);
 
@@ -186,7 +200,7 @@ function HealthBoard() {
     <section className="mb-10">
       <h3 className="text-lg font-medium tracking-tight text-ink mb-1">Health</h3>
       <p className="text-sm text-ink/60 mb-4">
-        GPU &amp; VRAM, TTS sidecar, analyzer, ffmpeg and free disk. Re-checked every 30 s.
+        GPU &amp; VRAM, Voice engine, analyzer, ASR, ffmpeg and free disk. Re-checked every 30 s.
       </p>
 
       {!loaded && <p className="text-sm text-ink/50">Running diagnostics…</p>}
@@ -350,17 +364,28 @@ function GenerationThroughput({ stats }: { stats: GenerationStatsResponse | null
           className="bg-white rounded-3xl border border-ink/10 shadow-card overflow-hidden"
           data-testid="generation-throughput-table"
         >
-          <div className="grid grid-cols-[1fr_auto_auto_auto_auto] gap-x-3 sm:gap-x-6 px-4 py-2 text-[11px] uppercase tracking-wide text-ink/40 border-b border-ink/5">
-            <span>Chapter</span>
-            <span className="text-right hidden sm:block">Engine</span>
-            <span className="text-right hidden md:block">Audio</span>
-            <span className="text-right hidden md:block">Synth</span>
-            <span className="text-right">RTF</span>
-          </div>
-          <div className="divide-y divide-ink/5">
-            {recent.map((c, i) => (
-              <ThroughputRow key={`${c.bookId ?? ''}:${c.chapterId}:${c.at}`} chapter={c} olderRtf={recent[i + 1]?.rtf} />
-            ))}
+          {/* Cap the rows and scroll inside with the inset thin scrollbar — a
+              long run records far more chapters than fit on the page. The
+              column header is sticky INSIDE the scroller so it shares the
+              reserved gutter and stays put while rows scroll. */}
+          <div
+            className="max-h-[60vh] overflow-y-auto scrollbar-thin"
+            data-testid="generation-throughput-scroll"
+          >
+            <div
+              className={`sticky top-0 z-10 bg-white ${THROUGHPUT_COLS} px-4 py-2 text-[11px] uppercase tracking-wide text-ink/40 border-b border-ink/5`}
+            >
+              <span>Chapter</span>
+              <span className="text-right hidden sm:block">Engine</span>
+              <span className="text-right hidden md:block">Audio</span>
+              <span className="text-right hidden md:block">Synth</span>
+              <span className="text-right">RTF</span>
+            </div>
+            <div className="divide-y divide-ink/5">
+              {recent.map((c, i) => (
+                <ThroughputRow key={`${c.bookId ?? ''}:${c.chapterId}:${c.at}`} chapter={c} olderRtf={recent[i + 1]?.rtf} />
+              ))}
+            </div>
           </div>
         </div>
       )}
@@ -442,21 +467,28 @@ function ResourceTrends() {
           <div className="px-4 py-3 border-b border-ink/5">
             <RtfSparkline records={records} />
           </div>
-          <div className="grid grid-cols-[1fr_auto_auto_auto] gap-x-3 sm:gap-x-6 px-4 py-2 text-[11px] uppercase tracking-wide text-ink/40 border-b border-ink/5">
-            <span>Chapter</span>
-            <span className="text-right">RTF</span>
-            <span className="text-right hidden sm:block">Wall</span>
-            <span className="text-right">VRAM</span>
-          </div>
-          {/* Cap the rows at ~60% of the viewport and scroll inside — a long run
-              records hundreds of chapters that would otherwise run off the page.
-              Each book's chapters sit under a sticky header so you can tell which
-              book a row belongs to once you've scrolled past the top group. */}
-          <div className="max-h-[60vh] overflow-y-auto" data-testid="resource-trends-scroll">
+          {/* Cap the rows at ~60% of the viewport and scroll inside with the
+              inset thin scrollbar — a long run records hundreds of chapters that
+              would otherwise run off the page. The column header is sticky at the
+              top of the scroller (so it shares the reserved gutter and aligns
+              with the rows); each book's chapters sit under a sub-header that
+              sticks just BELOW the column header. */}
+          <div
+            className="max-h-[60vh] overflow-y-auto scrollbar-thin"
+            data-testid="resource-trends-scroll"
+          >
+            <div
+              className={`sticky top-0 z-20 bg-white ${TRENDS_COLS} px-4 py-2 text-[11px] uppercase tracking-wide text-ink/40 border-b border-ink/5`}
+            >
+              <span>Chapter</span>
+              <span className="text-right">RTF</span>
+              <span className="text-right hidden sm:block">Wall</span>
+              <span className="text-right">VRAM</span>
+            </div>
             {groupTelemetryByBook(records).map((group, gi) => (
               <div key={`${group.key}:${gi}`} data-testid="resource-book-group">
                 <div
-                  className="sticky top-0 z-10 bg-white px-4 py-1.5 text-xs font-medium text-ink/70 border-b border-ink/5 truncate"
+                  className="sticky top-8 z-10 bg-white px-4 py-1.5 text-xs font-medium text-ink/70 border-b border-ink/5 truncate"
                   data-testid="resource-book-header"
                   title={group.label}
                 >
@@ -466,7 +498,7 @@ function ResourceTrends() {
                   {group.rows.map((r) => (
                     <div
                       key={`${r.bookId ?? ''}:${r.chapterId}:${r.at}`}
-                      className="grid grid-cols-[1fr_auto_auto_auto] gap-x-3 sm:gap-x-6 items-center px-4 py-2.5 text-sm"
+                      className={`${TRENDS_COLS} items-center px-4 py-2.5 text-sm`}
                       data-testid={`resource-row-${r.chapterId}`}
                     >
                       <span className="min-w-0 truncate text-ink">
@@ -558,7 +590,7 @@ function ThroughputRow({ chapter, olderRtf }: { chapter: RecentChapter; olderRtf
   const style = TREND_STYLE[trend];
   return (
     <div
-      className="grid grid-cols-[1fr_auto_auto_auto_auto] gap-x-3 sm:gap-x-6 items-center px-4 py-2.5 text-sm"
+      className={`${THROUGHPUT_COLS} items-center px-4 py-2.5 text-sm`}
       data-testid={`throughput-row-${chapter.chapterId}`}
     >
       <span className="min-w-0 truncate text-ink">

--- a/src/views/generation.tsx
+++ b/src/views/generation.tsx
@@ -768,7 +768,7 @@ export function GenerationView({
                 kind="tts"
                 engineLabel="Kokoro"
                 state={ttsLifecycle.kokoro.state}
-                unreachableLabel="Sidecar process not running"
+                unreachableLabel="Voice engine not running"
                 onLoad={() => {
                   void ttsLifecycle.kokoro.onLoad();
                 }}
@@ -782,7 +782,7 @@ export function GenerationView({
                 kind="tts"
                 engineLabel="Coqui XTTS"
                 state={ttsLifecycle.coqui.state}
-                unreachableLabel="Sidecar process not running"
+                unreachableLabel="Voice engine not running"
                 onLoad={() => {
                   void ttsLifecycle.coqui.onLoad();
                 }}

--- a/src/views/model-manager.tsx
+++ b/src/views/model-manager.tsx
@@ -104,7 +104,7 @@ function ModelInventory() {
         <h2 className="text-base font-semibold text-ink">Installed models</h2>
         {!inv.sidecarReachable && (
           <span className="text-[11px] font-semibold text-amber-700 bg-amber-50 border border-amber-200 rounded-full px-2.5 py-1">
-            Sidecar unreachable — residency unknown
+            Voice engine unreachable — residency unknown
           </span>
         )}
       </div>

--- a/src/views/voices.tsx
+++ b/src/views/voices.tsx
@@ -1803,7 +1803,7 @@ function BaseVoiceCatalogPanel({
       <div className="bg-white rounded-3xl border border-ink/10 shadow-card p-10 text-center">
         <p className="text-sm font-bold text-ink">Loading base voices…</p>
         <p className="mt-2 text-xs text-ink/60 max-w-md mx-auto">
-          If this stays empty, load the TTS sidecar from the model pill — the Coqui catalog is
+          If this stays empty, load the Voice engine from the model pill — the Coqui catalog is
           fetched live from the loaded model.
         </p>
       </div>
@@ -1814,7 +1814,7 @@ function BaseVoiceCatalogPanel({
       <div className="bg-white rounded-3xl border border-ink/10 shadow-card p-10 text-center">
         <p className="text-sm font-bold text-ink">No base voices available</p>
         <p className="mt-2 text-xs text-ink/60 max-w-md mx-auto">
-          The TTS sidecar isn't reachable, or the loaded model has no published speakers. Load a
+          The Voice engine isn't reachable, or the loaded model has no published speakers. Load a
           model to populate this list.
         </p>
       </div>


### PR DESCRIPTION
## Summary

Fixes five reported Admin/Account UI items (reported with screenshots):

- **Account "Open Model Manager" button** was illegible in dark mode (`bg-ink text-white` → white-on-near-white once `--ink` inverts). Now uses `text-canvas` + `hover:bg-ink-soft` (the fs-23 dark-CTA idiom, matching the Admin sibling button).
- **Admin tables** now scroll inside the inset `.scrollbar-thin` utility used everywhere else — Resource trends had the default browser scrollbar; Generation throughput had no scroller at all.
- **Admin table header alignment** fixed: the column header is pinned **inside** the scroller (sticky, sharing the reserved scrollbar gutter) and shares one responsive column template with the rows; per-book sub-headers stick just below it.
- **ASR (Whisper) row** added to the Health board, directly below the Voice engine row, fed by the existing `asrEnabled / asrLoaded / asrDevice` probe fields.
- **Renamed user-facing "TTS sidecar" → "Voice engine"** across the health board, Account / Model-Manager / settings copy, analyzer-guard banners, voices empty-states, and the unreachable pill labels. Internal identifiers, comments, and server error-reason plumbing keep "sidecar".

## Test plan

- `npm run typecheck` — green (frontend + server)
- Frontend unit: admin / account / AsrStatusBadge specs (scroller classes, shared column template, sticky header, ASR row order, dark-safe button, label rename); full suite **2376 passing**
- Server unit: `diagnostics.test` — ASR row states + Voice engine label (**16 passing**)
- New Playwright e2e `e2e/admin-ui-polish.spec.ts` — both tables' scrollers + sticky header, ASR row position, rename, and dark-mode button luminance (**5 passing**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
