### PR TITLE
feat(server,frontend): precise per-sentence diff for reassign-staleness (#650)

### DIFF
--- a/docs/features/198-stale-chapter-reassign-indicator.md
+++ b/docs/features/198-stale-chapter-reassign-indicator.md
@@ -82,13 +82,34 @@ inherent redux behavior. Follow-up: add the e2e once a done+manuscript fixture e
    render stamp).
 5. Regenerate the chapter → a fresh `audioRenderedAt` clears the caption.
 
+## Precise per-sentence diff (#650 — supersedes the time-based v1)
+
+The time-based heuristic above has one false positive: a reassign-then-undo still
+reads stale until regenerated. The precise follow-up (#650) removes it without losing
+immediacy:
+
+- **Server** (`segments-io.ts` `collectRenderedSpeakerMaps` → book-state GET
+  `renderedSpeakersByChapter`): recovers the render-time `sentenceId → characterId`
+  map per rendered chapter from each chapter's `segments.json` (`segments[].sentenceIds`
+  + `characterId` — already persisted, no new render-time snapshot needed).
+- **Frontend** (`isChapterReassignedSinceRender`): the Generate view diffs that map
+  against the **live** manuscript. The diff is asymmetric (iterate the rendered ids):
+  a rendered sentence whose current speaker differs (reassign) or that's now gone
+  (split/merge/delete) ⇒ stale; a current sentence never in the render map can't trip
+  a false positive. **Immediate** (recomputed from the live manuscript slice, no
+  refetch — important because navigating manuscript→generate does NOT re-GET, see
+  `layout.tsx:671`) AND **precise** (reassign-then-undo ⇒ maps match ⇒ not stale).
+- **Fallback:** the row uses the precise diff when the server shipped a render map for
+  the chapter, else the time-based heuristic — so older servers / mocks still flag
+  staleness with no regression.
+
 ## Out of scope
 
-- **Precise per-sentence net-diff.** This v1 is time-based/optimistic: reassign-then-
-  undo still reads stale until regenerated. The precise version (snapshot the
-  per-sentence speaker map at render time, compare net mapping) is a filed follow-up.
+- n/a — the precise diff (#650) closed the only remaining gap.
 
 ## Ship notes
 
-(Filled when merged to main.) Lands on `fix/frontend-stale-chapter-reassign-indicator`.
-Frontend-only; no live-GPU acceptance required.
+Bug-2 time-based indicator shipped on `fix/frontend-stale-chapter-reassign-indicator`
+(PR #651, merged 2026-06-08). The precise per-sentence diff (#650) shipped on
+`feat/server-precise-reassign-stale` (2026-06-08). Frontend + a GET-only server field;
+no live-GPU acceptance required.

--- a/server/src/audio/segments-io.test.ts
+++ b/server/src/audio/segments-io.test.ts
@@ -9,6 +9,7 @@ import { join } from 'node:path';
 import {
   collectRenderedFallbackEngines,
   collectRenderedQwenVoiceNames,
+  collectRenderedSpeakerMaps,
 } from './segments-io.js';
 
 let bookDir: string;
@@ -77,5 +78,47 @@ describe('collectRenderedFallbackEngines (fe-16)', () => {
     await expect(collectRenderedQwenVoiceNames(bookDir, chapters)).resolves.toEqual(
       new Set(['qwen-keefe']),
     );
+  });
+});
+
+describe('collectRenderedSpeakerMaps (#650)', () => {
+  function writeSegmentsWithBody(
+    slug: string,
+    segments: Array<{ characterId?: string; sentenceIds?: number[]; kind?: string }>,
+  ) {
+    writeFileSync(
+      join(bookDir, 'audio', `${slug}.segments.json`),
+      JSON.stringify({ chapterId: Number(slug.slice(0, 2)), segments }),
+    );
+  }
+
+  it('inverts per-character segments into a sentenceId→characterId map per chapter', async () => {
+    writeSegmentsWithBody('01-one', [
+      { characterId: 'narrator', sentenceIds: [1, 3] },
+      { characterId: 'keefe', sentenceIds: [2] },
+    ]);
+    writeSegmentsWithBody('02-two', [{ characterId: 'sophie', sentenceIds: [4, 5] }]);
+    await expect(collectRenderedSpeakerMaps(bookDir, chapters)).resolves.toEqual({
+      1: { 1: 'narrator', 2: 'keefe', 3: 'narrator' },
+      2: { 4: 'sophie', 5: 'sophie' },
+    });
+  });
+
+  it('skips title/empty segments and omits a chapter with no per-sentence data', async () => {
+    writeSegmentsWithBody('01-one', [
+      { characterId: 'narrator', sentenceIds: [], kind: 'title' },
+      { characterId: 'narrator', sentenceIds: [1] },
+    ]);
+    /* Legacy file with no `segments` array at all → omitted entirely (so the
+       client doesn't read it as "every sentence reassigned"). */
+    writeSegments('02-two', { sophie: { voiceEngine: 'kokoro' } });
+    await expect(collectRenderedSpeakerMaps(bookDir, chapters)).resolves.toEqual({
+      1: { 1: 'narrator' },
+    });
+  });
+
+  it('returns an empty map when no audio dir exists', async () => {
+    rmSync(join(bookDir, 'audio'), { recursive: true, force: true });
+    await expect(collectRenderedSpeakerMaps(bookDir, chapters)).resolves.toEqual({});
   });
 });

--- a/server/src/audio/segments-io.ts
+++ b/server/src/audio/segments-io.ts
@@ -41,6 +41,13 @@ export interface SegmentsFile {
   chapterTitle?: string;
   synthesizedAt?: string;
   characterSnapshots?: Record<string, CharacterSnapshot>;
+  /** Per-character speaking segments captured at render time. Each segment
+      records which sentence ids that character spoke, so the render-time
+      sentence→speaker mapping is recoverable. Used to detect a chapter whose
+      sentences were reassigned AFTER it rendered (precise, net-diff staleness).
+      Absent on pre-108 / title-only files; a `kind: 'title'` segment carries an
+      empty `sentenceIds`. */
+  segments?: Array<{ characterId?: string; sentenceIds?: number[] }>;
 }
 
 /* Load every rendered chapter's segments file for a book, in chapter order.
@@ -89,6 +96,38 @@ export async function collectRenderedQwenVoiceNames(
     }
   }
   return names;
+}
+
+/* The render-time sentence→speaker map per rendered chapter, recovered from each
+   `<slug>.segments.json`'s per-character `segments[]`. Shape:
+   `{ [chapterId]: { [sentenceId]: characterId } }`. Only chapters with a segments
+   file on disk appear (i.e. rendered ones). Title/silence segments (empty
+   `sentenceIds`) and malformed entries are skipped.
+
+   The frontend diffs this against the LIVE manuscript sentence→speaker mapping to
+   flag a `done` chapter whose sentences were reassigned after it rendered — a
+   precise, net-diff signal (reassign-then-undo reads not-stale) that supersedes the
+   time-based change-log heuristic. */
+export async function collectRenderedSpeakerMaps(
+  bookDir: string,
+  chapters: Array<{ id: number; slug: string }>,
+): Promise<Record<number, Record<number, string>>> {
+  const out: Record<number, Record<number, string>> = {};
+  const segs = await loadSegmentsFiles(bookDir, chapters);
+  for (const seg of segs) {
+    const map: Record<number, string> = {};
+    for (const s of seg.segments ?? []) {
+      if (!s.characterId || !Array.isArray(s.sentenceIds)) continue;
+      for (const sid of s.sentenceIds) {
+        if (typeof sid === 'number') map[sid] = s.characterId;
+      }
+    }
+    /* Only surface chapters that actually carried per-sentence segments — an
+       empty map (legacy file without `segments`) would otherwise read as "every
+       sentence reassigned" on the client. */
+    if (Object.keys(map).length > 0) out[seg.chapterId] = map;
+  }
+  return out;
 }
 
 /* fe-16 — per-character fallback engine aggregated across a book's rendered

--- a/server/src/routes/book-state.ts
+++ b/server/src/routes/book-state.ts
@@ -51,7 +51,10 @@ import { hydrateCastReusedVoices } from '../tts/hydrate-reused-voice-workspace.j
 import type { ReuseHydratable } from '../tts/hydrate-reused-voice.js';
 import { PRESERVED_VOICE_FIELDS } from '../store/merge-analysis-cast.js';
 import { preserveDesignedVoicesOnCastWrite } from '../workspace/preserve-cast-voices.js';
-import { collectRenderedFallbackEngines } from '../audio/segments-io.js';
+import {
+  collectRenderedFallbackEngines,
+  collectRenderedSpeakerMaps,
+} from '../audio/segments-io.js';
 import type { LoudnormSidecarJson } from '../tts/loudnorm.js';
 
 export const bookStateRouter = Router();
@@ -404,6 +407,16 @@ bookStateRouter.get('/:bookId/state', async (req: Request, res: Response) => {
       state.chapters,
     ).catch(() => ({}));
 
+    /* Render-time sentence→speaker map per rendered chapter (#650). The frontend
+       diffs it against the live manuscript to flag a `done` chapter whose
+       sentences were reassigned after it rendered — precise (no false positives)
+       and immediate (recomputed from the live manuscript), superseding the
+       time-based change-log heuristic. Tolerant of a missing audio dir. */
+    const renderedSpeakersByChapter = await collectRenderedSpeakerMaps(
+      bookDir,
+      state.chapters,
+    ).catch(() => ({}));
+
     res.json({
       state,
       cast,
@@ -414,6 +427,7 @@ bookStateRouter.get('/:bookId/state', async (req: Request, res: Response) => {
       chapterCharacters,
       chapterLufs,
       renderedFallbackByCharacter,
+      renderedSpeakersByChapter,
       changeLog: changeLog?.events ?? null,
       analysis: { failedChapterIds },
     });

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -710,6 +710,11 @@ export function Layout() {
                `lufs` field undefined (no-data state in the report
                card). */
             chapterLufs: res.chapterLufs,
+            /* #650 — render-time sentence→speaker map per chapter so the
+               Generate view can flag chapters reassigned since they rendered.
+               Older servers omit it; the slice leaves the map empty and the
+               view falls back to the time-based heuristic. */
+            renderedSpeakersByChapter: res.renderedSpeakersByChapter,
           }),
         );
         dispatch(

--- a/src/lib/stale-chapters.test.ts
+++ b/src/lib/stale-chapters.test.ts
@@ -3,6 +3,7 @@ import {
   renderedChaptersForCharacter,
   latestReassignAt,
   isChapterStaleFromReassign,
+  isChapterReassignedSinceRender,
 } from './stale-chapters';
 import type { Chapter, ChangeLogEvent } from './types';
 
@@ -82,5 +83,63 @@ describe('isChapterStaleFromReassign (Bug 2)', () => {
 
   it('is NOT stale when the chapter has no reassignment at all', () => {
     expect(isChapterStaleFromReassign(doneCh(1, '2026-06-08T10:00:00Z'), [])).toBe(false);
+  });
+});
+
+describe('isChapterReassignedSinceRender (#650 precise diff)', () => {
+  const rendered = { 1: 'narrator', 2: 'sophie', 3: 'keefe' };
+
+  it('not reassigned when the live mapping matches the render-time mapping', () => {
+    const current = [
+      { id: 1, characterId: 'narrator' },
+      { id: 2, characterId: 'sophie' },
+      { id: 3, characterId: 'keefe' },
+    ];
+    expect(isChapterReassignedSinceRender(rendered, current)).toBe(false);
+  });
+
+  it('reassigned when a rendered sentence now has a different speaker', () => {
+    const current = [
+      { id: 1, characterId: 'narrator' },
+      { id: 2, characterId: 'keefe' }, // was sophie
+      { id: 3, characterId: 'keefe' },
+    ];
+    expect(isChapterReassignedSinceRender(rendered, current)).toBe(true);
+  });
+
+  it('reassigned when a rendered sentence is gone (split/merge/delete)', () => {
+    const current = [
+      { id: 1, characterId: 'narrator' },
+      { id: 3, characterId: 'keefe' }, // id 2 removed
+    ];
+    expect(isChapterReassignedSinceRender(rendered, current)).toBe(true);
+  });
+
+  it('NO false positive on reassign-then-undo (the whole point vs the time-based heuristic)', () => {
+    /* Same mapping as render after an undo → not stale, even though the
+       time-based heuristic would still read stale from the logged edits. */
+    const current = [
+      { id: 1, characterId: 'narrator' },
+      { id: 2, characterId: 'sophie' },
+      { id: 3, characterId: 'keefe' },
+    ];
+    expect(isChapterReassignedSinceRender(rendered, current)).toBe(false);
+  });
+
+  it('does not false-positive on a current sentence that was never in the render map', () => {
+    /* A structural/empty line absent from segments isn't a rendered key, so an
+       extra current sentence can't trip staleness on its own. */
+    const current = [
+      { id: 1, characterId: 'narrator' },
+      { id: 2, characterId: 'sophie' },
+      { id: 3, characterId: 'keefe' },
+      { id: 99, characterId: 'narrator' }, // never rendered
+    ];
+    expect(isChapterReassignedSinceRender(rendered, current)).toBe(false);
+  });
+
+  it('returns false when there is no render map for the chapter (fall back to heuristic)', () => {
+    expect(isChapterReassignedSinceRender(undefined, [{ id: 1, characterId: 'x' }])).toBe(false);
+    expect(isChapterReassignedSinceRender({}, [{ id: 1, characterId: 'x' }])).toBe(false);
   });
 });

--- a/src/lib/stale-chapters.ts
+++ b/src/lib/stale-chapters.ts
@@ -43,6 +43,32 @@ export function isChapterStaleFromReassign(chapter: Chapter, events: ChangeLogEv
   return reassignedAt != null && reassignedAt > chapter.audioRenderedAt;
 }
 
+/* #650 — PRECISE staleness: diff the render-time sentence→speaker map (from the
+   chapter's segments.json, shipped on the book-state GET as
+   `renderedSpeakersByChapter`) against the LIVE manuscript. Supersedes the
+   time-based heuristic above: it's precise (a reassign-then-undo reads
+   not-stale) AND immediate (recomputed from the live manuscript slice, no
+   refetch needed). The Generate view uses this when the render map is present
+   for a chapter and falls back to `isChapterStaleFromReassign` otherwise.
+
+   Asymmetric on purpose — iterate the RENDERED ids only. A rendered sentence
+   whose current speaker differs (reassign) or that's now gone (split/merge/
+   delete) ⇒ stale; a sentence that never made it into the segments map (e.g. a
+   structural/empty line) can't trip a false positive because it isn't a key. */
+export function isChapterReassignedSinceRender(
+  rendered: Record<number, string> | undefined,
+  currentSentences: Array<{ id: number; characterId: string }>,
+): boolean {
+  if (!rendered || Object.keys(rendered).length === 0) return false;
+  const current = new Map<number, string>();
+  for (const s of currentSentences) current.set(s.id, s.characterId);
+  for (const sidStr of Object.keys(rendered)) {
+    const sid = Number(sidStr);
+    if (current.get(sid) !== rendered[sid]) return true;
+  }
+  return false;
+}
+
 /** Returns a callback that marks a character's rendered audio stale (no-op when
     the character speaks in no `done` chapter). Reads chapters from the store. */
 export function useMarkCharacterStaleIfRendered(): (character: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -353,6 +353,14 @@ export interface BookStateResponse {
       the cast Status pill reads "Fallback (Kokoro)". Empty / undefined when no
       audio has rendered or nothing fell back. */
   renderedFallbackByCharacter?: Record<string, string>;
+  /** #650 — render-time sentence→speaker map per rendered chapter
+      (`{ [chapterId]: { [sentenceId]: characterId } }`), recovered from each
+      chapter's `<slug>.segments.json`. The Generate view diffs it against the
+      live manuscript to flag a `done` chapter whose sentences were reassigned
+      after it rendered — precise (no reassign-then-undo false positive) and
+      immediate. Absent for legacy/unrendered chapters; the view falls back to
+      the time-based change-log heuristic when a chapter has no entry. */
+  renderedSpeakersByChapter?: Record<number, Record<number, string>>;
   /** Editorial activity trail (regenerate confirms, etc.). Null when no
       change-log.json has been written yet — the layout falls back to an
       empty list so the Activity view doesn't replay a stale demo seed for

--- a/src/modals/edit-chapter-title.test.tsx
+++ b/src/modals/edit-chapter-title.test.tsx
@@ -57,6 +57,7 @@ function renderModal(
         lastTickAt: null,
         currentBookId: null,
         activeStreams: {},
+        renderedSpeakersByChapter: {},
       },
     },
   });

--- a/src/store/chapters-slice.test.ts
+++ b/src/store/chapters-slice.test.ts
@@ -30,6 +30,7 @@ const baseState = (chapters: Chapter[]): ChaptersState => ({
   lastTickAt: null,
   currentBookId: null,
   activeStreams: {},
+  renderedSpeakersByChapter: {},
 });
 
 const tick = (t: Partial<GenerationTick> & { type: GenerationTick['type'] }): GenerationTick =>

--- a/src/store/chapters-slice.ts
+++ b/src/store/chapters-slice.ts
@@ -89,6 +89,13 @@ export interface ChaptersState {
       same book coexist as separate entries; the layout pill selectors
       aggregate across `Object.values`. */
   activeStreams: Record<string, ActiveStreamSnapshot>;
+  /** #650 — render-time sentence→speaker map per rendered chapter
+      (`{ [chapterId]: { [sentenceId]: characterId } }`), hydrated from the
+      book-state GET. The Generate view diffs it against the live manuscript to
+      flag a `done` chapter whose sentences were reassigned after it rendered.
+      Empty for older servers / before the first hydrate; the view then falls
+      back to the time-based change-log heuristic. */
+  renderedSpeakersByChapter: Record<number, Record<number, string>>;
 }
 
 const initialState: ChaptersState = {
@@ -98,6 +105,7 @@ const initialState: ChaptersState = {
   lastTickAt: null,
   currentBookId: null,
   activeStreams: {},
+  renderedSpeakersByChapter: {},
 };
 
 export const chaptersSlice = createSlice({
@@ -238,11 +246,22 @@ export const chaptersSlice = createSlice({
           present with a `null` entry → fetched-but-no-data, render
           neutral. */
         chapterLufs?: Record<number, ChapterLoudness | null>;
+        /** #650 — render-time sentence→speaker map per chapter. Absent on older
+          servers → left empty, view falls back to the change-log heuristic. */
+        renderedSpeakersByChapter?: Record<number, Record<number, string>>;
       }>,
     ) => {
-      const { bookId, chapters, completedSlugs, characters, chapterCharacters, chapterLufs } =
-        a.payload;
+      const {
+        bookId,
+        chapters,
+        completedSlugs,
+        characters,
+        chapterCharacters,
+        chapterLufs,
+        renderedSpeakersByChapter,
+      } = a.payload;
       if (bookId) s.currentBookId = bookId;
+      s.renderedSpeakersByChapter = renderedSpeakersByChapter ?? {};
       const done = new Set(completedSlugs);
       const allCastQueued: Record<string, 'queued'> = {};
       for (const c of characters) allCastQueued[c.id] = 'queued';

--- a/src/views/generation.test.tsx
+++ b/src/views/generation.test.tsx
@@ -1214,6 +1214,80 @@ describe('GenerationView — reassignment staleness caption (Bug 2)', () => {
   });
 });
 
+describe('GenerationView — precise reassignment staleness via render map (#650)', () => {
+  /* When the server ships a per-chapter render-time sentence→speaker map, the
+     Generate view diffs it against the LIVE manuscript instead of using the
+     time-based change-log heuristic — precise (a reassign-then-undo reads
+     not-stale) and immediate. Chapter 1's fixture sentences are
+     {1:narrator, 2:keefe, 3:keefe}. */
+  function renderWithRenderMap(
+    renderedSpeakersByChapter: Record<number, Record<number, string>>,
+  ): void {
+    const store = configureStore({
+      reducer: {
+        ui: uiSlice.reducer,
+        chapters: chaptersSlice.reducer,
+        manuscript: manuscriptSlice.reducer,
+        changeLog: changeLogSlice.reducer,
+        cast: castSlice.reducer,
+        library: librarySlice.reducer,
+        queue: queueSlice.reducer,
+      },
+    });
+    /* hydrateFromBookState is the only setter for renderedSpeakersByChapter. */
+    store.dispatch(
+      chaptersSlice.actions.hydrateFromBookState({
+        bookId: 'b1',
+        chapters: [
+          { id: 1, title: 'Chapter 1', slug: '01-a' },
+          { id: 2, title: 'Chapter 2', slug: '02-b' },
+        ],
+        completedSlugs: ['01-a'],
+        characters,
+        renderedSpeakersByChapter,
+      } as any),
+    );
+    store.dispatch(chaptersSlice.actions.setChapters([chapter1, chapter2]));
+    store.dispatch(
+      manuscriptSlice.actions.hydrateFromAnalysis({
+        bookId: 'b1',
+        characters,
+        chapters: [chapter1, chapter2],
+        sentences,
+      } as any),
+    );
+    render(
+      <Provider store={store}>
+        <HostedGenerationView
+          chapters={[chapter1, chapter2]}
+          characters={characters}
+          paused
+          title="Render Map Fixture"
+          bookId="b1"
+          modelKey="kokoro-v1"
+          onRegenerate={() => {}}
+          onRegenerateBook={() => {}}
+          onRegenerateCharacterInChapter={() => {}}
+          onPreview={() => {}}
+        />
+      </Provider>,
+    );
+  }
+
+  it('shows the caption when the live mapping differs from the render map', () => {
+    /* Render had sentence 2 on narrator; the manuscript now has it on keefe. */
+    renderWithRenderMap({ 1: { 1: 'narrator', 2: 'narrator', 3: 'keefe' } });
+    expect(screen.getByText(/Sentences reassigned · regenerate to refresh/i)).toBeInTheDocument();
+  });
+
+  it('does NOT show the caption when the live mapping matches the render map (no false positive)', () => {
+    /* Identical to the fixture sentences → not stale, even if the time-based
+       heuristic would have flagged it. */
+    renderWithRenderMap({ 1: { 1: 'narrator', 2: 'keefe', 3: 'keefe' } });
+    expect(screen.queryByText(/Sentences reassigned/i)).toBeNull();
+  });
+});
+
 describe('GenerationView — bulk Regenerate all drifted (plan 35 follow-up)', () => {
   /* The banner now carries a "Regenerate all" affordance that confirms
      once and dispatches regenerateChapterIds for every drifted chapter

--- a/src/views/generation.tsx
+++ b/src/views/generation.tsx
@@ -58,7 +58,10 @@ import { ttsModelLabel, formatEngineBreakdown } from '../lib/tts-models';
 import { parseDuration, formatTime } from '../lib/time';
 import { CHAR_COLORS } from '../lib/colors';
 import { stripChapterPrefix } from '../lib/format-chapter-title';
-import { isChapterStaleFromReassign } from '../lib/stale-chapters';
+import {
+  isChapterStaleFromReassign,
+  isChapterReassignedSinceRender,
+} from '../lib/stale-chapters';
 import {
   characterLinePositionsByChapter,
   characterRowProgress,
@@ -153,6 +156,11 @@ export function GenerationView({
   const sentences = useAppSelector((s) => s.manuscript.sentences);
   const manuscriptId = useAppSelector((s) => s.manuscript.manuscriptId);
   const activityEvents = useAppSelector((s) => s.changeLog.events);
+  /* #650 — render-time sentence→speaker map per chapter, for the PRECISE
+     reassignment-staleness diff (vs the time-based change-log fallback). */
+  const renderedSpeakersByChapter = useAppSelector(
+    (s) => s.chapters.renderedSpeakersByChapter,
+  );
   /* Drives the "View queue · N" pill in the header. Reflects real workspace
      queue entries when present, else the live generation run (the primary,
      reconcile-driven path never writes a queue entry) so the pill doesn't read
@@ -608,6 +616,29 @@ export function GenerationView({
      under out-of-order completion (the positions+currentLine map above is the
      fallback when the set is absent). */
   const characterSentenceIds = useMemo(() => characterSentenceIdsByChapter(sentences), [sentences]);
+  /* #650 — the set of chapters whose live sentence→speaker mapping differs from
+     what was rendered (precise reassignment staleness). Recomputed from the live
+     manuscript, so it reflects an edit immediately without a refetch; only
+     chapters the server shipped a render map for are considered here (others
+     fall back to the time-based heuristic at the row). */
+  const reassignedSinceRenderSet = useMemo(() => {
+    const renderedIds = Object.keys(renderedSpeakersByChapter);
+    if (renderedIds.length === 0) return new Set<number>();
+    const byChapter = new Map<number, Array<{ id: number; characterId: string }>>();
+    for (const s of sentences) {
+      let arr = byChapter.get(s.chapterId);
+      if (!arr) byChapter.set(s.chapterId, (arr = []));
+      arr.push({ id: s.id, characterId: s.characterId });
+    }
+    const set = new Set<number>();
+    for (const cidStr of renderedIds) {
+      const cid = Number(cidStr);
+      if (isChapterReassignedSinceRender(renderedSpeakersByChapter[cid], byChapter.get(cid) ?? [])) {
+        set.add(cid);
+      }
+    }
+    return set;
+  }, [renderedSpeakersByChapter, sentences]);
 
   /* SSE ownership lives in src/store/generation-stream-middleware.ts so the
      stream survives navigating away from this view. The view is a pure
@@ -1067,7 +1098,14 @@ export function GenerationView({
               onIncludeClick={handleIncludeClick}
               onCancelSubset={handleCancelSubset}
               onRetrySubset={handleRetrySubset}
-              stale={isChapterStaleFromReassign(ch, activityEvents)}
+              stale={
+                /* Precise diff when the server shipped this chapter's render
+                   map (#650); otherwise the time-based change-log heuristic
+                   (Bug 2) so older servers / mocks still flag staleness. */
+                renderedSpeakersByChapter[ch.id]
+                  ? reassignedSinceRenderSet.has(ch.id)
+                  : isChapterStaleFromReassign(ch, activityEvents)
+              }
               subsetProgress={subsetByChapter[ch.id] ?? null}
               activeModelKey={modelKey}
             />


### PR DESCRIPTION
## Summary

Supersedes the time-based "needs regeneration" indicator (Bug 2 / plan 198) with a **precise per-sentence diff**, removing its one false positive (a reassign-then-undo still read stale until regenerated).

The render-time `sentenceId → characterId` mapping is **already persisted** in each chapter's `segments.json` (`segments[].sentenceIds` + `characterId`). The book-state GET now recovers it (`collectRenderedSpeakerMaps` → `renderedSpeakersByChapter`), and the Generate view diffs it against the **live manuscript** (`isChapterReassignedSinceRender`). The diff is **asymmetric** over the rendered ids: a rendered sentence whose current speaker differs (reassign) or that's now gone (split/merge/delete) ⇒ stale; a current sentence that was never in the render map can't trip a false positive.

Why client-side diff (not a server boolean): navigating manuscript→generate does **not** re-GET (the hydration effect short-circuits when the manuscript is already loaded — `layout.tsx:671`), so a server-only verdict would lag an edit. Diffing the shipped map against the live manuscript slice is both **immediate** and **precise**. The row **falls back** to the time-based heuristic when the server shipped no render map for a chapter (older servers / mocks) — no regression.

Updates plan `docs/features/198-stale-chapter-reassign-indicator.md` (precise-diff section + ship notes).

## Test plan

- Vitest server `server/src/audio/segments-io.test.ts` — `collectRenderedSpeakerMaps` inverts per-character segments, skips title/empty + legacy-no-`segments` files, tolerates missing audio dir.
- Vitest `src/lib/stale-chapters.test.ts` — `isChapterReassignedSinceRender`: match / reassign / split-removed / **reassign-then-undo = not stale** / never-rendered sentence / no-map.
- Vitest `src/views/generation.test.tsx` — precise caption shows when the live map differs from the render map; hidden when they match (no false positive).
- `npm run verify` green locally (off latest `main`, incl. Bug 1 + Bug 2).

**Note:** committed from an isolated git worktree (a concurrent session owns the shared checkout); the husky gate ran via a worktree-scoped shebang copy of `verify:fast:scoped`, not bypassed.

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)
