### PR TITLE
chore(repo): point issue-template backlog link at renamed Castwright repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Backlog & priorities
-    url: https://github.com/dudarenok-maker/AudioBook-Generator/blob/main/docs/BACKLOG.md
+    url: https://github.com/dudarenok-maker/Castwright/blob/main/docs/BACKLOG.md
     about: The prioritized MoSCoW planning view. File a "Backlog item" above to add a tracked piece of work.


### PR DESCRIPTION
One-line follow-up to the Castwright rename (#653): the issue-template backlog link still pointed at the old `AudioBook-Generator` repo path (worked via GitHub redirect). Now canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)