### PR TITLE
feat(frontend,server): narrator credit defaults to Castwright + persistent brand stamps

### DIFF
--- a/docs/superpowers/plans/2026-06-08-castwright-wave1-narrator-stamps.md
+++ b/docs/superpowers/plans/2026-06-08-castwright-wave1-narrator-stamps.md
@@ -1,0 +1,74 @@
+# Castwright Wave 1 — Narrator credit + persistent stamps (plan)
+
+> REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** Listen-tab narrator credit defaults to "Castwright" (over the cast-narrator name; explicit wins) and persists; the exported-file artist tag keeps the author when the credit is the brand default; add a "Made with Castwright" footer stamp + a "Rendered with Castwright · castwright.ai" comment in exported MP3/M4B.
+
+**Source of truth:** `docs/superpowers/specs/2026-06-08-castwright-brand-full-pass-design.md` (Wave 1).
+
+---
+
+## Task 1 — Frontend narrator credit default (display + hydrate + remove orphaned helper)
+
+**Files:** `src/store/book-meta-slice.ts`, `src/views/listen.tsx`, `src/components/layout.tsx`, tests `book-meta-slice.test.ts` / `listen.test.tsx` / `src/test/a11y.test.tsx`.
+
+- [ ] **Add the constant.** In `src/store/book-meta-slice.ts`, export `export const DEFAULT_NARRATOR_CREDIT = 'Castwright';`.
+- [ ] **Hydrate default (TDD).** Change line ~79 `narratorCredit: state.narratorCredit ?? narratorFallback ?? null` → `narratorCredit: state.narratorCredit ?? DEFAULT_NARRATOR_CREDIT`. Remove the `narratorFallback` field from `HydratePayload` (line ~64) and its destructure (line ~74). Update `book-meta-slice.test.ts`: the "falls back to narratorFallback" case → "defaults to DEFAULT_NARRATOR_CREDIT when state.narratorCredit missing" (expect `'Castwright'`); the "uses null when both missing" case → expect `'Castwright'`.
+- [ ] **Remove orphaned helper.** Delete `narratorNameFromCast` (line ~150) and its `describe` block in `book-meta-slice.test.ts`.
+- [ ] **Update call sites.** In `src/components/layout.tsx`: drop the `narratorNameFromCast` import (line 23) and remove the `narratorFallback:` arg from BOTH `hydrateFromBookState` dispatches (lines ~742, ~828).
+- [ ] **Display precedence (TDD).** In `src/views/listen.tsx` lines ~147-150, change to:
+  ```ts
+  const narratorName =
+    (bookMeta?.narratorCredit && bookMeta.narratorCredit.trim()) || DEFAULT_NARRATOR_CREDIT;
+  ```
+  (import `DEFAULT_NARRATOR_CREDIT` from the slice; drop the `characters.find(c => c.id === 'narrator')` fallback; update the precedence comment). Update `listen.test.tsx`: rename "falls back to the cast narrator when narratorCredit is blank" → "defaults to Castwright when no explicit credit" (expect `'Castwright'`, not 'Anders Vale'); keep the explicit-credit-wins case green. Update `src/test/a11y.test.tsx` fixture if it asserts a specific narrator name.
+- [ ] Run `npm test -- book-meta-slice listen` and `npm run typecheck`; commit `feat(frontend): narrator credit defaults to Castwright (over cast narrator), persisted via hydrate`.
+
+## Task 2 — Server narrator default (book-state GET) + persistence
+
+**Files:** server book-state GET handler (`server/src/routes/book-state.ts`; find the GET that returns `state` to the client — near the PATCH at line ~637), `server/src/workspace/scan.ts` if it assembles the returned state. Test: `server/src/routes/book-state.test.ts`.
+
+- [ ] **Add a server constant** `export const DEFAULT_NARRATOR_CREDIT = 'Castwright';` in a shared server module (e.g. top of `book-state.ts` or a small `server/src/export/narrator-credit.ts` reused by the export builders in Task 3). Document the FE/server duplication.
+- [ ] **TDD:** add a `book-state.test.ts` case: GET for a book whose stored `narratorCredit` is null/empty returns `narratorCredit: 'Castwright'`; a book with an explicit credit returns it unchanged.
+- [ ] In the GET handler, when the resolved `narratorCredit` is null/empty, return `DEFAULT_NARRATOR_CREDIT`. (The existing meta-PUT path then writes it through on the next save — no change needed there.)
+- [ ] Run `cd server && npx vitest run src/routes/book-state.test.ts`; commit `feat(server): book-state GET defaults empty narratorCredit to Castwright`.
+
+## Task 3 — Export artist sentinel + "Rendered with Castwright" comment
+
+**Files:** new `server/src/export/narrator-credit.ts` (shared `DEFAULT_NARRATOR_CREDIT` + `artistForExport`), `build-mp3-folder.ts:71`, `build-mp3-zip.ts:89`, `build-m4b.ts:154`, `server/src/export/id3-tags.ts`. Tests: the three builders' tests + `id3-tags.test.ts`.
+
+- [ ] **TDD `artistForExport`.** Create `server/src/export/narrator-credit.ts`:
+  ```ts
+  export const DEFAULT_NARRATOR_CREDIT = 'Castwright';
+  /** TPE1 artist: a real human narrator credit, else the author. The brand
+      default "Castwright" is treated as "no human narrator" so the artist tag
+      stays the author. */
+  export function artistForExport(state: { narratorCredit?: string | null; author: string }): string {
+    const c = state.narratorCredit?.trim();
+    return c && c !== DEFAULT_NARRATOR_CREDIT ? c : state.author;
+  }
+  ```
+  Add `narrator-credit.test.ts`: empty → author; `'Castwright'` → author; `'Jane Narrator'` → 'Jane Narrator'. (If Task 2 created the server const elsewhere, consolidate it here and re-import to avoid duplication.)
+- [ ] Replace the duplicated `const artist = (state.narratorCredit && state.narratorCredit.trim()) || state.author;` in all three builders with `const artist = artistForExport(state);` (import the helper). Keep the three builders' existing tests green (they pass `narratorCredit: 'Jane Narrator'` → still 'Jane Narrator').
+- [ ] **ID3 comment (TDD).** In `server/src/export/id3-tags.ts`: add optional `comment?: string | null` to `Id3Tags`; when present, push `'-metadata', \`comment=${tags.comment}\`` into the ffmpeg args (after the `date` arg). Add an `id3-tags.test.ts` case asserting the `comment=` metadata arg is emitted when `comment` is set and omitted when not. Wire the three MP3 builders to pass `comment: 'Rendered with Castwright · castwright.ai'`.
+- [ ] **M4B comment.** In `build-m4b.ts`, add the same `Rendered with Castwright · castwright.ai` to the M4B metadata atoms (follow the existing `-metadata` pattern there; M4B uses `comment`/`©cmt`). Keep `build-m4b.test.ts` green; add an assertion for the comment if the test inspects metadata args.
+- [ ] Run `cd server && npx vitest run src/export/`; commit `feat(server): export artist keeps author for default credit + "Rendered with Castwright" comment stamp`.
+
+## Task 4 — Footer stamp + back-catalogue backfill
+
+**Files:** `src/components/build-stamp.tsx` (+ the `formatBuildStamp` helper it calls — find it), new `scripts/repair-narrator-credit.mjs` + test.
+
+- [ ] **Footer stamp.** Prepend `"Made with Castwright · "` to the rendered build stamp. Locate `formatBuildStamp` (the pure formatter) and prepend there so it's covered by its existing unit test; update that test. If the stamp is assembled inline in `build-stamp.tsx`, prepend in the JSX and add/adjust a render test. Keep a11y (the footer's aria-label) sensible.
+- [ ] **Backfill script (TDD).** Create `scripts/repair-narrator-credit.mjs` mirroring the repo's `repair-*.mjs` pattern: an exported pure `planBackfill(books)` that returns the bookIds whose `book-state.json` `narratorCredit` is empty/null (to be set to `'Castwright'`), and a `main()` with `--apply` (dry-run default) that walks `BOOKS_ROOT`/each book's `.audiobook/state.json` (or book-state.json — match how other repair scripts read book state) and writes `"Castwright"` only where empty. Add `scripts/tests/repair-narrator-credit.test.mjs` (use `node:test`+`assert`, the repo's scripts-test convention) covering `planBackfill`: empty→included, explicit→skipped.
+- [ ] Run the frontend stamp test + `node --test scripts/tests/repair-narrator-credit.test.mjs`; commit `feat(repo): Made-with-Castwright footer + repair-narrator-credit backfill`.
+
+## Task 5 — Verify + PR
+
+- [ ] `npm run verify` green.
+- [ ] Add one Playwright assertion (in an existing listen e2e spec or a small new one) that the Listen header shows "Castwright" for a book with no explicit narrator credit. Keep e2e green.
+- [ ] Push `feat/castwright-narrator-stamps`; `gh pr create --draft` with `Refs #631` (Wave 1 of the brand pass); body links the spec + this plan.
+
+## Notes
+- Per-book `.audiobook/` folder name is unrelated — do not touch.
+- DEFAULT_NARRATOR_CREDIT is duplicated FE (book-meta-slice) + server (narrator-credit.ts) by necessity (no shared module) — document it in both.
+- Explicit user credits are never overwritten anywhere.

--- a/e2e/listen-narrator-credit.spec.ts
+++ b/e2e/listen-narrator-credit.spec.ts
@@ -1,0 +1,34 @@
+/* Wave 1 — narrator credit defaults to "Castwright" when the book has
+   no explicit narratorCredit field.
+
+   listen.tsx computes:
+     narratorName = (bookMeta?.narratorCredit && trim) || DEFAULT_NARRATOR_CREDIT
+   where DEFAULT_NARRATOR_CREDIT = 'Castwright' (book-meta-slice.ts).
+   listen-header.tsx renders: "· narrated by <span>{narratorName}</span>"
+   inside the <p> below the book title.
+
+   The Solway Bay mock (id 'sb') returns narratorCredit: null from the
+   mock API, so the default branch fires and the header should show
+   "narrated by Castwright".
+
+   The locator scopes to the header's <p> credit line so the top-bar
+   "Castwright" wordmark does NOT match (it has no "narrated by" prefix). */
+
+import { test, expect } from '@playwright/test';
+import { waitForListenViewReady } from './helpers';
+
+test('listen header shows "narrated by Castwright" when no explicit narrator credit is set', async ({
+  page,
+}) => {
+  await page.goto('/#/books/sb/listen');
+  await waitForListenViewReady(page, /Solway Bay/i);
+
+  /* The credit line is the <p> immediately below the <h1> title; it
+     contains "By <author> · narrated by <narratorName>". We assert on
+     the "narrated by Castwright" substring so the test survives author-
+     text changes while pinning the narrator-credit branch. Scoping to
+     an <p> ancestor avoids any wordmark hit. */
+  const creditLine = page.locator('p', { hasText: /narrated by/i }).first();
+  await expect(creditLine).toBeVisible({ timeout: 10_000 });
+  await expect(creditLine).toContainText('narrated by Castwright');
+});

--- a/scripts/repair-narrator-credit.mjs
+++ b/scripts/repair-narrator-credit.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/*
+ * repair-narrator-credit.mjs
+ *
+ * Back-catalogue backfill for the Castwright Wave 1 narrator credit (plan 204).
+ *
+ * Symptom: books created before the Wave 1 release have a null/empty
+ * `narratorCredit` in their `.audiobook/state.json`. The server's book-state
+ * GET already defaults it to "Castwright" for display, but the on-disk value
+ * stays null — so export artist tags and any direct reader see no credit.
+ * This script writes `narratorCredit: 'Castwright'` onto every book that has
+ * no explicit narrator credit, making the data durable and self-consistent.
+ *
+ * Rules:
+ *   - null / empty / whitespace-only → write 'Castwright'.
+ *   - Any non-empty, non-whitespace value (including 'Castwright' already set)
+ *     → skip. Explicit credits are NEVER overwritten.
+ *   - Idempotent: running twice is safe.
+ *
+ * DRY RUN BY DEFAULT — prints the planned writes and exits without touching
+ * disk. Pass --apply to write each changed state.json (a .bak is written first).
+ *
+ * Env:
+ *   BASE                 workspace root (overrides everything)
+ *   AUDIOBOOK_WORKSPACE  workspace root (same default the server uses)
+ *   default              <home>/AudiobookWorkspace
+ *
+ * Usage:
+ *   node scripts/repair-narrator-credit.mjs            # dry run
+ *   node scripts/repair-narrator-credit.mjs --apply    # write
+ *   BASE="C:/AudiobookWorkspace" node scripts/repair-narrator-credit.mjs --apply
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+// ---------------------------------------------------------------------------
+// Pure helper — exported for unit tests
+// ---------------------------------------------------------------------------
+
+/**
+ * Given an array of `{ bookId, narratorCredit }` entries, return the bookIds
+ * whose narratorCredit is null, undefined, empty, or whitespace-only.
+ * Explicit credits (including 'Castwright' already written) are excluded.
+ *
+ * @param {Array<{ bookId: string, narratorCredit?: string | null }>} books
+ * @returns {string[]}
+ */
+export function planBackfill(books) {
+  return books
+    .filter(({ narratorCredit }) => !narratorCredit || !narratorCredit.trim())
+    .map(({ bookId }) => bookId);
+}
+
+// ---------------------------------------------------------------------------
+// I/O helpers
+// ---------------------------------------------------------------------------
+
+const readJson = (p) => {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return null;
+  }
+};
+
+/** Recursively collect every `<dir>/.audiobook/` that holds a state.json. */
+function findAudiobookDirs(root) {
+  const found = [];
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (!e.isDirectory()) continue;
+      const child = path.join(dir, e.name);
+      if (e.name === '.audiobook') {
+        if (fs.existsSync(path.join(child, 'state.json'))) found.push(child);
+        continue; // never descend into .audiobook
+      }
+      walk(child);
+    }
+  };
+  walk(root);
+  return found;
+}
+
+// ---------------------------------------------------------------------------
+// main — exported for unit tests; also called when run as a script
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string[]} argv    — process.argv slice (flags only; pass [] for defaults)
+ * @param {string}   [booksRootOverride] — override BOOKS_ROOT (used in tests)
+ */
+export async function main(argv = process.argv.slice(2), booksRootOverride) {
+  const APPLY = argv.includes('--apply');
+
+  const BASE =
+    (process.env.BASE && path.resolve(process.env.BASE)) ||
+    (process.env.AUDIOBOOK_WORKSPACE && path.resolve(process.env.AUDIOBOOK_WORKSPACE)) ||
+    path.join(os.homedir(), 'AudiobookWorkspace');
+
+  const BOOKS_ROOT = booksRootOverride ?? path.join(BASE, 'books');
+
+  if (!fs.existsSync(BOOKS_ROOT)) {
+    console.error(`No books root at ${BOOKS_ROOT}. Set BASE to your workspace.`);
+    return;
+  }
+
+  console.log(`${APPLY ? 'APPLY' : 'DRY RUN'} — workspace books: ${BOOKS_ROOT}\n`);
+
+  // Collect all books with their current narratorCredit.
+  const bookEntries = [];
+  for (const ab of findAudiobookDirs(BOOKS_ROOT)) {
+    const statePath = path.join(ab, 'state.json');
+    const state = readJson(statePath);
+    if (!state) continue;
+    const bookId = path.relative(BOOKS_ROOT, path.dirname(ab));
+    bookEntries.push({ bookId, narratorCredit: state.narratorCredit ?? null, statePath, state });
+  }
+
+  // Determine which books need the credit written.
+  const toFill = planBackfill(bookEntries);
+
+  if (toFill.length === 0) {
+    console.log('All books already have an explicit narratorCredit — nothing to do.');
+    return;
+  }
+
+  // Build a lookup from bookId to the full entry.
+  const byId = new Map(bookEntries.map((e) => [e.bookId, e]));
+
+  let written = 0;
+  for (const bookId of toFill) {
+    const entry = byId.get(bookId);
+    if (!entry) continue;
+    console.log(`  ${APPLY ? 'Writing' : 'Would write'} narratorCredit → 'Castwright'  [${bookId}]`);
+    if (APPLY) {
+      const bak = `${entry.statePath}.bak-narrator-credit-${Date.now()}`;
+      fs.copyFileSync(entry.statePath, bak);
+      const updated = { ...entry.state, narratorCredit: 'Castwright' };
+      fs.writeFileSync(entry.statePath, `${JSON.stringify(updated, null, 2)}\n`);
+      written += 1;
+    }
+  }
+
+  console.log(
+    `\n${APPLY ? 'Wrote' : 'Would write'} ${APPLY ? written : toFill.length} book(s).`,
+  );
+  if (!APPLY && toFill.length > 0) console.log('Re-run with --apply to write.');
+}
+
+// Run when executed directly (not imported in tests).
+if (process.argv[1] && process.argv[1].replace(/\\/g, '/').endsWith('repair-narrator-credit.mjs')) {
+  main();
+}

--- a/scripts/tests/repair-narrator-credit.test.mjs
+++ b/scripts/tests/repair-narrator-credit.test.mjs
@@ -1,0 +1,129 @@
+/* Tests for scripts/repair-narrator-credit.mjs
+   Run via: node --test scripts/tests/repair-narrator-credit.test.mjs
+
+   Covers planBackfill: the pure function that decides which books need
+   'Castwright' written as their narratorCredit.  An explicit (non-empty,
+   non-whitespace) credit is left untouched; null / empty / whitespace → included. */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { planBackfill, main } from '../repair-narrator-credit.mjs';
+
+// ---------------------------------------------------------------------------
+// planBackfill — pure function tests
+// ---------------------------------------------------------------------------
+
+test('planBackfill: null narratorCredit → included', () => {
+  const result = planBackfill([{ bookId: 'book-a', narratorCredit: null }]);
+  assert.deepEqual(result, ['book-a']);
+});
+
+test('planBackfill: undefined narratorCredit → included', () => {
+  const result = planBackfill([{ bookId: 'book-b', narratorCredit: undefined }]);
+  assert.deepEqual(result, ['book-b']);
+});
+
+test('planBackfill: empty string narratorCredit → included', () => {
+  const result = planBackfill([{ bookId: 'book-c', narratorCredit: '' }]);
+  assert.deepEqual(result, ['book-c']);
+});
+
+test('planBackfill: whitespace-only narratorCredit → included', () => {
+  const result = planBackfill([{ bookId: 'book-d', narratorCredit: '   ' }]);
+  assert.deepEqual(result, ['book-d']);
+});
+
+test('planBackfill: explicit credit → excluded', () => {
+  const result = planBackfill([{ bookId: 'book-e', narratorCredit: 'Jane Narrator' }]);
+  assert.deepEqual(result, []);
+});
+
+test('planBackfill: "Castwright" already set → excluded (not re-written)', () => {
+  /* The brand default itself counts as explicit once written — idempotent. */
+  const result = planBackfill([{ bookId: 'book-f', narratorCredit: 'Castwright' }]);
+  assert.deepEqual(result, []);
+});
+
+test('planBackfill: mixed — only the empty/null entries are returned', () => {
+  const books = [
+    { bookId: 'a', narratorCredit: null },
+    { bookId: 'b', narratorCredit: 'Jane' },
+    { bookId: 'c', narratorCredit: '' },
+    { bookId: 'd', narratorCredit: 'Castwright' },
+    { bookId: 'e', narratorCredit: '  ' },
+  ];
+  const result = planBackfill(books);
+  assert.deepEqual(result, ['a', 'c', 'e']);
+});
+
+test('planBackfill: empty array → empty result', () => {
+  assert.deepEqual(planBackfill([]), []);
+});
+
+// ---------------------------------------------------------------------------
+// main --apply — integration: writes narratorCredit only where empty
+// ---------------------------------------------------------------------------
+
+test('main --apply writes Castwright where narratorCredit is missing', async () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'repair-narrator-credit-test-'));
+  try {
+    const booksRoot = join(tmp, 'books');
+    const bookDir = join(booksRoot, 'My Book');
+    const audiobookDir = join(bookDir, '.audiobook');
+    mkdirSync(audiobookDir, { recursive: true });
+    writeFileSync(
+      join(audiobookDir, 'state.json'),
+      JSON.stringify({ title: 'My Book', author: 'Author A', narratorCredit: null }),
+    );
+
+    await main(['--apply'], booksRoot);
+
+    const written = JSON.parse(readFileSync(join(audiobookDir, 'state.json'), 'utf8'));
+    assert.equal(written.narratorCredit, 'Castwright');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('main --apply skips books with an explicit credit', async () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'repair-narrator-credit-skip-'));
+  try {
+    const booksRoot = join(tmp, 'books');
+    const bookDir = join(booksRoot, 'Another Book');
+    const audiobookDir = join(bookDir, '.audiobook');
+    mkdirSync(audiobookDir, { recursive: true });
+    const initial = { title: 'Another Book', author: 'Author B', narratorCredit: 'Jane Narrator' };
+    writeFileSync(join(audiobookDir, 'state.json'), JSON.stringify(initial));
+
+    await main(['--apply'], booksRoot);
+
+    const written = JSON.parse(readFileSync(join(audiobookDir, 'state.json'), 'utf8'));
+    assert.equal(written.narratorCredit, 'Jane Narrator', 'explicit credit must NOT be overwritten');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('main dry-run does NOT modify state.json', async () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'repair-narrator-credit-dry-'));
+  try {
+    const booksRoot = join(tmp, 'books');
+    const bookDir = join(booksRoot, 'Dry Book');
+    const audiobookDir = join(bookDir, '.audiobook');
+    mkdirSync(audiobookDir, { recursive: true });
+    const initial = { title: 'Dry Book', author: 'Author C', narratorCredit: null };
+    writeFileSync(join(audiobookDir, 'state.json'), JSON.stringify(initial));
+
+    /* No --apply → dry-run default */
+    await main([], booksRoot);
+
+    const written = JSON.parse(readFileSync(join(audiobookDir, 'state.json'), 'utf8'));
+    assert.equal(written.narratorCredit, null, 'dry-run must not touch state.json');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/server/src/export/build-m4b.test.ts
+++ b/server/src/export/build-m4b.test.ts
@@ -338,6 +338,22 @@ describeIfTools('buildM4b', () => {
     expect(descValue).toBe(longDesc);
   }, 30_000);
 
+  it('embeds the "Rendered with Castwright · castwright.ai" comment atom', async () => {
+    /* The FFMETADATA `comment` key maps to the M4B `©cmt` atom.
+       ffprobe surfaces it as `comment` in format_tags. This stamp is
+       unconditional — it does not depend on the narratorCredit value. */
+    const commentPath = join(tmpRoot, 'with-castwright-comment.m4b');
+    await buildM4b({ bookDir, state: makeState(), outPath: commentPath });
+    const probe = ffprobeJson(commentPath);
+    const tags = probe.format.tags ?? {};
+    const commentKey = Object.keys(tags).find((k) => k.toLowerCase() === 'comment');
+    expect(
+      commentKey,
+      `expected a comment tag; got keys: ${Object.keys(tags).join(', ')}`,
+    ).toBeDefined();
+    expect(tags[commentKey as string]).toBe('Rendered with Castwright · castwright.ai');
+  }, 30_000);
+
   it('omits desc / ldes atoms when state.description is null or blank (plan 33)', async () => {
     const blankPath = join(tmpRoot, 'no-desc.m4b');
     await buildM4b({

--- a/server/src/export/build-m4b.ts
+++ b/server/src/export/build-m4b.ts
@@ -24,6 +24,7 @@ import { join } from 'node:path';
 import { audioDir, coverImagePath } from '../workspace/paths.js';
 import { findChapterAudio } from '../workspace/chapter-audio-file.js';
 import { ExportIncompleteError } from './build-mp3-zip.js';
+import { artistForExport } from './narrator-credit.js';
 import type { BookStateJson } from '../workspace/scan.js';
 
 export { ExportIncompleteError } from './build-mp3-zip.js';
@@ -151,7 +152,7 @@ function buildFfmetadata(
 ): string {
   const lines: string[] = [';FFMETADATA1'];
 
-  const artist = (state.narratorCredit && state.narratorCredit.trim()) || state.author;
+  const artist = artistForExport(state);
   lines.push(`title=${escapeFfmetadata(state.title)}`);
   lines.push(`artist=${escapeFfmetadata(artist)}`);
   lines.push(`album=${escapeFfmetadata(state.title)}`);
@@ -169,6 +170,10 @@ function buildFfmetadata(
     lines.push(`description=${escapeFfmetadata(desc)}`);
     lines.push(`synopsis=${escapeFfmetadata(desc)}`);
   }
+  /* Castwright brand stamp — the `comment` / `©cmt` atom surfaces in
+     Apple Books / Plex / Voice-Android "info" panels. The comment stamp
+     always carries the brand regardless of the artist/narrator setting. */
+  lines.push(`comment=${escapeFfmetadata('Rendered with Castwright · castwright.ai')}`);
   /* iTunes audiobook media kind — flips Apple/QuickTime players from
      'Music' to 'Audiobook'. Harmless on players that ignore it. */
   lines.push(`media_type=2`);

--- a/server/src/export/build-mp3-folder.ts
+++ b/server/src/export/build-mp3-folder.ts
@@ -22,6 +22,7 @@ import { audioDir, coverImagePath } from '../workspace/paths.js';
 import { findChapterAudio } from '../workspace/chapter-audio-file.js';
 import { applyId3v24Tags, type Id3Tags } from './id3-tags.js';
 import { ExportIncompleteError, pad2, sanitiseForZip } from './build-mp3-zip.js';
+import { artistForExport } from './narrator-credit.js';
 import type { BookStateJson } from '../workspace/scan.js';
 
 export interface BuildMp3FolderOptions {
@@ -68,7 +69,7 @@ export async function buildMp3Folder(opts: BuildMp3FolderOptions): Promise<Build
 
   const total = resolved.length;
   const albumArtist = state.author;
-  const artist = (state.narratorCredit && state.narratorCredit.trim()) || state.author;
+  const artist = artistForExport(state);
   const album = state.title;
 
   /* Plan 36 A3: thread the cached cover into every chapter's APIC
@@ -101,6 +102,7 @@ export async function buildMp3Folder(opts: BuildMp3FolderOptions): Promise<Build
       trackTotal: total,
       genre: state.genre ?? null,
       date: state.publicationDate ?? null,
+      comment: 'Rendered with Castwright · castwright.ai',
     };
     await applyId3v24Tags(mp3Path, taggedPath, tags, { coverJpegPath });
     const taggedStat = await stat(taggedPath);

--- a/server/src/export/build-mp3-zip.ts
+++ b/server/src/export/build-mp3-zip.ts
@@ -23,6 +23,7 @@ import { ZipFile } from 'yazl';
 import { audioDir, coverImagePath } from '../workspace/paths.js';
 import { findChapterAudio } from '../workspace/chapter-audio-file.js';
 import { applyId3v24Tags, type Id3Tags } from './id3-tags.js';
+import { artistForExport } from './narrator-credit.js';
 import type { BookStateJson } from '../workspace/scan.js';
 
 export interface BuildMp3ZipOptions {
@@ -86,7 +87,7 @@ export async function buildMp3Zip(opts: BuildMp3ZipOptions): Promise<BuildMp3Zip
 
   const total = resolved.length;
   const albumArtist = state.author;
-  const artist = (state.narratorCredit && state.narratorCredit.trim()) || state.author;
+  const artist = artistForExport(state);
   const album = state.title;
 
   /* Plan 36 A3: embed the cached OpenLibrary cover into each chapter's
@@ -134,6 +135,7 @@ export async function buildMp3Zip(opts: BuildMp3ZipOptions): Promise<BuildMp3Zip
         trackTotal: total,
         genre: state.genre ?? null,
         date: state.publicationDate ?? null,
+        comment: 'Rendered with Castwright · castwright.ai',
       };
       await applyId3v24Tags(mp3Path, taggedPath, tags, { coverJpegPath });
       const taggedStat = await stat(taggedPath);

--- a/server/src/export/id3-tags.test.ts
+++ b/server/src/export/id3-tags.test.ts
@@ -183,6 +183,51 @@ describeIf('applyId3v24Tags', () => {
     expect(true).toBe(true);
   });
 
+  it('writes the comment tag when tags.comment is set', async () => {
+    const destPath = join(tmpDir, 'with-comment.mp3');
+    await applyId3v24Tags(srcPath, destPath, {
+      title: 'Chapter 1',
+      album: 'The Northern Star',
+      artist: 'Jane Narrator',
+      albumArtist: 'Some Author',
+      track: 1,
+      trackTotal: 3,
+      comment: 'Rendered with Castwright · castwright.ai',
+    });
+    const { tags } = await probe(destPath);
+    /* ffprobe surfaces the ID3 COMM frame as 'comment' in format_tags. */
+    expect(tags.comment).toBe('Rendered with Castwright · castwright.ai');
+  });
+
+  it('omits the comment tag when tags.comment is absent', async () => {
+    const destPath = join(tmpDir, 'no-comment.mp3');
+    await applyId3v24Tags(srcPath, destPath, {
+      title: 'Chapter 1',
+      album: 'The Northern Star',
+      artist: 'Jane Narrator',
+      albumArtist: 'Some Author',
+      track: 1,
+      trackTotal: 3,
+    });
+    const { tags } = await probe(destPath);
+    expect(tags.comment).toBeUndefined();
+  });
+
+  it('omits the comment tag when tags.comment is null', async () => {
+    const destPath = join(tmpDir, 'null-comment.mp3');
+    await applyId3v24Tags(srcPath, destPath, {
+      title: 'Chapter 1',
+      album: 'The Northern Star',
+      artist: 'Jane Narrator',
+      albumArtist: 'Some Author',
+      track: 1,
+      trackTotal: 3,
+      comment: null,
+    });
+    const { tags } = await probe(destPath);
+    expect(tags.comment).toBeUndefined();
+  });
+
   /* Plan 36 A3: APIC embedding for MP3.ZIP exports. The cover-art
      pipeline writes <bookDir>/.audiobook/cover.jpg; build-mp3-zip.ts
      probes that file once per export and threads it as the optional

--- a/server/src/export/id3-tags.ts
+++ b/server/src/export/id3-tags.ts
@@ -29,6 +29,10 @@ export interface Id3Tags {
   trackTotal: number;
   genre?: string | null;
   date?: string | null;
+  /** Optional free-form comment written to the ID3v2 COMM frame.
+      When set, ffmpeg emits `-metadata comment=<value>`.
+      Intended for the "Rendered with Castwright · castwright.ai" stamp. */
+  comment?: string | null;
 }
 
 export interface ApplyId3Options {
@@ -74,6 +78,7 @@ export async function applyId3v24Tags(
   ];
   if (tags.genre) args.push('-metadata', `genre=${tags.genre}`);
   if (tags.date) args.push('-metadata', `date=${tags.date}`);
+  if (tags.comment) args.push('-metadata', `comment=${tags.comment}`);
   args.push('-f', 'mp3', destPath);
 
   await new Promise<void>((resolve, reject) => {

--- a/server/src/export/narrator-credit.test.ts
+++ b/server/src/export/narrator-credit.test.ts
@@ -1,0 +1,45 @@
+/* Unit tests for narrator-credit.ts (Task 3).
+   Pure logic — no filesystem or ffmpeg needed. */
+
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_NARRATOR_CREDIT, artistForExport } from './narrator-credit.js';
+
+describe('DEFAULT_NARRATOR_CREDIT', () => {
+  it('is the string "Castwright"', () => {
+    expect(DEFAULT_NARRATOR_CREDIT).toBe('Castwright');
+  });
+});
+
+describe('artistForExport', () => {
+  const author = 'Shannon Messenger';
+
+  it('returns the author when narratorCredit is absent', () => {
+    expect(artistForExport({ author })).toBe(author);
+  });
+
+  it('returns the author when narratorCredit is null', () => {
+    expect(artistForExport({ narratorCredit: null, author })).toBe(author);
+  });
+
+  it('returns the author when narratorCredit is empty string', () => {
+    expect(artistForExport({ narratorCredit: '', author })).toBe(author);
+  });
+
+  it('returns the author when narratorCredit is whitespace-only', () => {
+    expect(artistForExport({ narratorCredit: '   ', author })).toBe(author);
+  });
+
+  it('returns the author when narratorCredit is the brand default "Castwright"', () => {
+    expect(artistForExport({ narratorCredit: 'Castwright', author })).toBe(author);
+  });
+
+  it('returns the explicit human credit unchanged when it is a real name', () => {
+    expect(artistForExport({ narratorCredit: 'Jane Narrator', author })).toBe('Jane Narrator');
+  });
+
+  it('returns a real credit even when it differs only by trimming (no sentinel match)', () => {
+    /* A credit of ' Castwright ' has a real value — trim only governs the
+       sentinel check, not the return value (we return the trimmed value). */
+    expect(artistForExport({ narratorCredit: ' Jane Vale ', author })).toBe('Jane Vale');
+  });
+});

--- a/server/src/export/narrator-credit.ts
+++ b/server/src/export/narrator-credit.ts
@@ -1,0 +1,19 @@
+/* Shared narrator-credit constants and helpers used by the book-state GET
+   handler (Task 2) and the export builders (Task 3).
+
+   NOTE: DEFAULT_NARRATOR_CREDIT is intentionally duplicated on the frontend
+   in `src/store/book-meta-slice.ts` — there is no shared module between the
+   server and the React app, so each side owns its own copy. Keep them in sync
+   when the brand default changes. */
+
+export const DEFAULT_NARRATOR_CREDIT = 'Castwright';
+
+/** TPE1 artist for MP3/M4B export: a real human narrator credit, else the
+    author. The brand default "Castwright" is treated as "no human narrator"
+    so the artist tag stays the author (TPE1 = who performed/narrated, not
+    the brand that rendered it). The visible Listen credit + the comment stamp
+    DO say Castwright — this sentinel only governs the TPE1 artist tag. */
+export function artistForExport(state: { narratorCredit?: string | null; author: string }): string {
+  const c = state.narratorCredit?.trim();
+  return c && c !== DEFAULT_NARRATOR_CREDIT ? c : state.author;
+}

--- a/server/src/routes/book-state.test.ts
+++ b/server/src/routes/book-state.test.ts
@@ -1825,3 +1825,76 @@ describe('book-state router — srv-35 stable chapter uuid (plan 190)', () => {
     expect(get.body.chapterUuid).toBeUndefined();
   });
 });
+
+describe('book-state router — GET defaults narratorCredit to Castwright', () => {
+  /* TDD for Task 2: the GET handler must return DEFAULT_NARRATOR_CREDIT
+     ('Castwright') when the stored narratorCredit is null/empty/absent,
+     and must return the explicit value unchanged when set.
+
+     Uses the shared `bookId` + `app` from `beforeAll` at the top of this
+     file. The state-slice PUT tests above may have renamed the bookDir;
+     we re-seed it here so each case starts from a known state. */
+
+  function resetState(extra: Record<string, unknown> = {}) {
+    /* Ensure the directory exists (may have been renamed by prior tests). */
+    mkdirSync(join(bookDir, '.audiobook'), { recursive: true });
+    writeFileSync(
+      join(bookDir, '.audiobook', 'state.json'),
+      JSON.stringify({
+        bookId,
+        manuscriptId: 'm_test',
+        title: 'Renamed Title',
+        author: 'Different Author',
+        series: 'Renamed Series',
+        seriesPosition: null,
+        isStandalone: true,
+        manuscriptFile: 'manuscript.txt',
+        castConfirmed: true,
+        chapters: [{ id: 1, title: 'Chapter 1', slug: 'chapter-one' }],
+        coverGradient: ['#000', '#fff'],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        ...extra,
+      }),
+    );
+  }
+
+  beforeEach(() => {
+    /* Reset state.json to a baseline without narratorCredit for each case. */
+    resetState(/* narratorCredit absent */);
+  });
+
+  it('returns narratorCredit: "Castwright" when stored value is absent', async () => {
+    const res = await request(app).get(`/api/books/${bookId}/state`);
+    expect(res.status).toBe(200);
+    expect(res.body.state.narratorCredit).toBe('Castwright');
+  });
+
+  it('returns narratorCredit: "Castwright" when stored value is null', async () => {
+    resetState({ narratorCredit: null });
+    const res = await request(app).get(`/api/books/${bookId}/state`);
+    expect(res.status).toBe(200);
+    expect(res.body.state.narratorCredit).toBe('Castwright');
+  });
+
+  it('returns narratorCredit: "Castwright" when stored value is empty string', async () => {
+    resetState({ narratorCredit: '' });
+    const res = await request(app).get(`/api/books/${bookId}/state`);
+    expect(res.status).toBe(200);
+    expect(res.body.state.narratorCredit).toBe('Castwright');
+  });
+
+  it('returns narratorCredit: "Castwright" when stored value is whitespace-only', async () => {
+    resetState({ narratorCredit: '   ' });
+    const res = await request(app).get(`/api/books/${bookId}/state`);
+    expect(res.status).toBe(200);
+    expect(res.body.state.narratorCredit).toBe('Castwright');
+  });
+
+  it('returns the explicit credit unchanged when stored value is a real name', async () => {
+    resetState({ narratorCredit: 'Jane Narrator' });
+    const res = await request(app).get(`/api/books/${bookId}/state`);
+    expect(res.status).toBe(200);
+    expect(res.body.state.narratorCredit).toBe('Jane Narrator');
+  });
+});

--- a/server/src/routes/book-state.ts
+++ b/server/src/routes/book-state.ts
@@ -48,6 +48,7 @@ import { parseManuscript } from '../parsers/index.js';
 import { CHAPTER_TITLE_PARSER_VERSION } from '../parsers/version.js';
 import { snapshotInFlightAnalysis } from './analysis.js';
 import { hydrateCastReusedVoices } from '../tts/hydrate-reused-voice-workspace.js';
+import { DEFAULT_NARRATOR_CREDIT } from '../export/narrator-credit.js';
 import type { ReuseHydratable } from '../tts/hydrate-reused-voice.js';
 import { PRESERVED_VOICE_FIELDS } from '../store/merge-analysis-cast.js';
 import { preserveDesignedVoicesOnCastWrite } from '../workspace/preserve-cast-voices.js';
@@ -417,8 +418,20 @@ bookStateRouter.get('/:bookId/state', async (req: Request, res: Response) => {
       state.chapters,
     ).catch(() => ({}));
 
+    /* Apply the brand default for narratorCredit in the GET response so the
+       frontend always sees 'Castwright' when no explicit credit has been set.
+       The on-disk value is left untouched — the PATCH/write path persists the
+       explicit value on the next save. */
+    const stateView = {
+      ...state,
+      narratorCredit:
+        state.narratorCredit && state.narratorCredit.trim()
+          ? state.narratorCredit
+          : DEFAULT_NARRATOR_CREDIT,
+    };
+
     res.json({
-      state,
+      state: stateView,
       cast,
       manuscript,
       manuscriptEdits: edits,

--- a/src/components/build-stamp.test.tsx
+++ b/src/components/build-stamp.test.tsx
@@ -1,7 +1,8 @@
 /* Plan 124 — build-version footer. Verifies the shell footer renders with the
    contentinfo landmark + testid and a version-shaped stamp. Vitest runs as dev
    (import.meta.env.DEV === true), so the verbose form is rendered off the
-   sentinel buildInfo — assertions stay resilient (shape, not exact sentinels). */
+   sentinel buildInfo — assertions stay resilient (shape, not exact sentinels).
+   Wave 1: stamp now starts with "Made with Castwright ·" for brand presence. */
 
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
@@ -12,14 +13,15 @@ describe('BuildStamp', () => {
     render(<BuildStamp />);
     const footer = screen.getByTestId('build-stamp');
     expect(footer).toBeInTheDocument();
-    /* Single named contentinfo landmark for screen readers. */
-    expect(screen.getByRole('contentinfo', { name: /build version/i })).toBe(footer);
+    /* aria-label is the stamp itself — "Made with Castwright · v…" — so the
+       landmark is named. Match by the brand prefix. */
+    expect(screen.getByRole('contentinfo', { name: /made with castwright/i })).toBe(footer);
   });
 
-  it('shows a version-shaped, separator-joined stamp in dev', () => {
+  it('shows "Made with Castwright" brand prefix in the stamp', () => {
     render(<BuildStamp />);
     const text = screen.getByTestId('build-stamp').textContent ?? '';
-    expect(text).toMatch(/^v\d/);
+    expect(text).toMatch(/^Made with Castwright/);
     expect(text).toContain('·');
   });
 });

--- a/src/components/build-stamp.tsx
+++ b/src/components/build-stamp.tsx
@@ -10,7 +10,7 @@ export function BuildStamp() {
   const stamp = formatBuildStamp(buildInfo, { dev: import.meta.env.DEV });
   return (
     <footer
-      aria-label="Build version"
+      aria-label={stamp}
       data-testid="build-stamp"
       className="px-4 py-3 text-center text-xs text-ink/55 select-text"
     >

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -20,7 +20,7 @@ import { revisionsActions, selectDriftGroupsByBook } from '../store/revisions-sl
 import { libraryActions } from '../store/library-slice';
 import { voicesActions } from '../store/voices-slice';
 import { changeLogActions } from '../store/change-log-slice';
-import { bookMetaActions, narratorNameFromCast } from '../store/book-meta-slice';
+import { bookMetaActions } from '../store/book-meta-slice';
 import { notificationsActions } from '../store/notifications-slice';
 import { listenProgressActions } from '../store/listen-progress-slice';
 import {
@@ -724,8 +724,7 @@ export function Layout() {
         );
         dispatch(changeLogActions.hydrateFromBookState(res.changeLog ?? null));
         /* Editable Listen-view metadata: seed from state.json's editorial
-           fields, falling back to the cast narrator's name when the book
-           predates the narratorCredit field. */
+           fields; when narratorCredit is absent the slice defaults to 'Castwright'. */
         dispatch(
           bookMetaActions.hydrateFromBookState({
             bookId,
@@ -739,7 +738,6 @@ export function Layout() {
               description: res.state.description ?? null,
               notes: res.state.notes ?? null,
             },
-            narratorFallback: narratorNameFromCast(res.cast?.characters ?? []),
           }),
         );
 
@@ -825,7 +823,6 @@ export function Layout() {
       bookMetaActions.hydrateFromBookState({
         bookId,
         state: { title: entry.title, author: entry.author, series: entry.series },
-        narratorFallback: narratorNameFromCast(characters),
       }),
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/lib/build-info.test.ts
+++ b/src/lib/build-info.test.ts
@@ -15,23 +15,25 @@ const base: BuildInfo = {
 
 describe('formatBuildStamp', () => {
   it('dev: verbose version · sha · branch · time when the tree is clean', () => {
-    expect(formatBuildStamp(base, { dev: true })).toBe('v1.4.0 · a1b2c3d · fix/foo · 14:32');
+    expect(formatBuildStamp(base, { dev: true })).toBe(
+      'Made with Castwright · v1.4.0 · a1b2c3d · fix/foo · 14:32',
+    );
   });
 
   it('dev: appends a "*" dirty marker to the sha when the working tree is dirty', () => {
     expect(formatBuildStamp({ ...base, dirty: true }, { dev: true })).toBe(
-      'v1.4.0 · a1b2c3d* · fix/foo · 14:32',
+      'Made with Castwright · v1.4.0 · a1b2c3d* · fix/foo · 14:32',
     );
   });
 
   it('dev: omits the trailing segment when buildTime is empty (no dangling separator)', () => {
     expect(formatBuildStamp({ ...base, buildTime: '' }, { dev: true })).toBe(
-      'v1.4.0 · a1b2c3d · fix/foo',
+      'Made with Castwright · v1.4.0 · a1b2c3d · fix/foo',
     );
   });
 
   it('prod: minimal version + short sha only', () => {
-    expect(formatBuildStamp(base, { dev: false })).toBe('v1.4.0 (a1b2c3d)');
+    expect(formatBuildStamp(base, { dev: false })).toBe('Made with Castwright · v1.4.0 (a1b2c3d)');
   });
 });
 

--- a/src/lib/build-info.ts
+++ b/src/lib/build-info.ts
@@ -32,9 +32,10 @@ export const buildInfo: BuildInfo = {
  * Prod (minimal): `v1.4.0 (a1b2c3d)` — version + short SHA only.
  */
 export function formatBuildStamp(info: BuildInfo, opts: { dev: boolean }): string {
-  if (!opts.dev) return `v${info.version} (${info.sha})`;
+  const prefix = 'Made with Castwright';
+  if (!opts.dev) return `${prefix} · v${info.version} (${info.sha})`;
   const sha = info.dirty ? `${info.sha}*` : info.sha;
-  const parts = [`v${info.version}`, sha, info.branch];
+  const parts = [prefix, `v${info.version}`, sha, info.branch];
   if (info.buildTime) parts.push(info.buildTime);
   return parts.join(' · ');
 }

--- a/src/store/book-meta-slice.test.ts
+++ b/src/store/book-meta-slice.test.ts
@@ -6,11 +6,10 @@ import {
   bookMetaActions,
   selectEffectiveMeta,
   selectIsDirty,
-  narratorNameFromCast,
+  DEFAULT_NARRATOR_CREDIT,
   type BookMetaState,
   type EditableBookMeta,
 } from './book-meta-slice';
-import type { Character } from '../lib/types';
 import type { RootState } from './index';
 
 const initial = (): BookMetaState => ({ draft: null, saved: {} });
@@ -59,21 +58,21 @@ describe('bookMetaSlice — hydrateFromBookState', () => {
     });
   });
 
-  it('falls back to narratorFallback when state.narratorCredit is missing', () => {
+  it('defaults to DEFAULT_NARRATOR_CREDIT when state.narratorCredit is missing', () => {
     const next = reducer(
       initial(),
       bookMetaActions.hydrateFromBookState({
         bookId: 'ns',
         state: { title: 'X', author: 'A', series: 'S' },
-        narratorFallback: 'Narrator',
       }),
     );
-    expect(next.saved.ns.narratorCredit).toBe('Narrator');
+    expect(next.saved.ns.narratorCredit).toBe('Castwright');
+    expect(next.saved.ns.narratorCredit).toBe(DEFAULT_NARRATOR_CREDIT);
     expect(next.saved.ns.genre).toBeNull();
     expect(next.saved.ns.publicationDate).toBeNull();
   });
 
-  it('uses null when both state.narratorCredit and fallback are missing', () => {
+  it('defaults to Castwright when both state.narratorCredit and any fallback are missing', () => {
     const next = reducer(
       initial(),
       bookMetaActions.hydrateFromBookState({
@@ -81,7 +80,7 @@ describe('bookMetaSlice — hydrateFromBookState', () => {
         state: { title: 'X', author: 'A', series: 'S' },
       }),
     );
-    expect(next.saved.ns.narratorCredit).toBeNull();
+    expect(next.saved.ns.narratorCredit).toBe('Castwright');
   });
 });
 
@@ -188,27 +187,3 @@ describe('selectors', () => {
   });
 });
 
-describe('narratorNameFromCast', () => {
-  const ch = (id: string, name: string): Character =>
-    ({ id, name, role: '', color: 'narrator' }) as Character;
-
-  it('returns null when the cast is empty', () => {
-    expect(narratorNameFromCast([])).toBeNull();
-  });
-
-  it("returns the explicit narrator character's name when present", () => {
-    expect(
-      narratorNameFromCast([
-        ch('halloran', 'Halloran'),
-        ch('narrator', 'Narrator'),
-        ch('eliza', 'Eliza'),
-      ]),
-    ).toBe('Narrator');
-  });
-
-  it('falls back to the first character when there is no narrator id', () => {
-    expect(
-      narratorNameFromCast([ch('halloran', 'Captain Halloran'), ch('eliza', 'Eliza Gray')]),
-    ).toBe('Captain Halloran');
-  });
-});

--- a/src/store/book-meta-slice.ts
+++ b/src/store/book-meta-slice.ts
@@ -16,8 +16,12 @@
    `state` slice patch containing all six fields. */
 
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
-import type { BookStateJson, Character } from '../lib/types';
+import type { BookStateJson } from '../lib/types';
 import type { RootState } from './index';
+
+/** Default narrator credit shown when no explicit credit has been saved.
+    Duplicated on the server in server/src/export/narrator-credit.ts (no shared module). */
+export const DEFAULT_NARRATOR_CREDIT = 'Castwright';
 
 export interface EditableBookMeta {
   title: string;
@@ -60,8 +64,6 @@ interface HydratePayload {
     description?: string | null;
     notes?: string | null;
   };
-  /** Used as the narratorCredit fallback when state.narratorCredit is missing. */
-  narratorFallback?: string | null;
 }
 
 export const bookMetaSlice = createSlice({
@@ -71,12 +73,12 @@ export const bookMetaSlice = createSlice({
     /* Seed `saved[bookId]` from the BookStateJson the server returned on book
        open. Wipes any stale draft from a previous book. */
     hydrateFromBookState: (s, a: PayloadAction<HydratePayload>) => {
-      const { bookId, state, narratorFallback } = a.payload;
+      const { bookId, state } = a.payload;
       s.saved[bookId] = {
         title: state.title,
         author: state.author,
         series: state.series,
-        narratorCredit: state.narratorCredit ?? narratorFallback ?? null,
+        narratorCredit: state.narratorCredit ?? DEFAULT_NARRATOR_CREDIT,
         genre: state.genre ?? null,
         publicationDate: state.publicationDate ?? null,
         description: state.description ?? null,
@@ -142,13 +144,3 @@ export const selectEffectiveMeta =
 export const selectIsDirty = (s: RootState): boolean =>
   s.bookMeta.draft != null && Object.keys(s.bookMeta.draft).length > 0;
 
-/* ── Helpers ────────────────────────────────────────────────────────────── */
-
-/** Pick the narrator's display name from the cast for use as a default
-    `narratorCredit`. Convention: the character with id === 'narrator' is the
-    designated narrator; fall back to the first character otherwise. */
-export function narratorNameFromCast(characters: Character[]): string | null {
-  if (characters.length === 0) return null;
-  const explicit = characters.find((c) => c.id === 'narrator');
-  return (explicit ?? characters[0]).name;
-}

--- a/src/views/listen.test.tsx
+++ b/src/views/listen.test.tsx
@@ -133,10 +133,12 @@ describe('ListenView — top section reads from bookMeta', () => {
     expect(screen.getByText('Sam Voice')).toBeInTheDocument();
   });
 
-  it('falls back to the cast narrator when narratorCredit is blank', () => {
+  it('defaults to Castwright when no explicit credit', () => {
     renderView({ meta: baseMeta({ narratorCredit: null }) });
-    /* Anders Vale comes from the cast (id === "narrator"). */
-    expect(screen.getByText('Anders Vale')).toBeInTheDocument();
+    /* When no explicit narratorCredit, the brand default "Castwright" is shown
+       rather than the cast narrator character's name. */
+    expect(screen.getByText('Castwright')).toBeInTheDocument();
+    expect(screen.queryByText('Anders Vale')).not.toBeInTheDocument();
   });
 
   it('paints the cover with the book gradient passed in props', () => {

--- a/src/views/listen.tsx
+++ b/src/views/listen.tsx
@@ -17,7 +17,11 @@ import { ListenHeader, ListenMetadataEditor } from '../components/listen/listen-
 import { ListenPlayerRegion } from '../components/listen/listen-player-region';
 import { ListenDownloadSection } from '../components/listen/listen-download-section';
 import type { Chapter, Character, Voice, ListenerApp, ExportQueueItem } from '../lib/types';
-import type { EditableBookMeta, EditableBookMetaField } from '../store/book-meta-slice';
+import {
+  DEFAULT_NARRATOR_CREDIT,
+  type EditableBookMeta,
+  type EditableBookMetaField,
+} from '../store/book-meta-slice';
 
 interface Props {
   /** Required so the Export modal can target the right book on POST.
@@ -141,13 +145,10 @@ export function ListenView({
   const listenable = chapters.filter((c) => !c.excluded);
   const completed = listenable.filter((c) => c.state === 'done').length;
   const totalSec = listenable.reduce((s, c) => s + parseDuration(c.duration), 0);
-  /* Narrator credit precedence: explicit override from bookMeta (or '' if the
-     user cleared it) → the cast's narrator character → null. The header
-     suppresses the "narrated by …" phrase when none of those resolve. */
+  /* Narrator credit precedence: explicit override from bookMeta → DEFAULT_NARRATOR_CREDIT.
+     Explicit user credits always win; when none is set the brand default is shown. */
   const narratorName =
-    (bookMeta?.narratorCredit && bookMeta.narratorCredit.trim()) ||
-    characters.find((c) => c.id === 'narrator')?.name ||
-    null;
+    (bookMeta?.narratorCredit && bookMeta.narratorCredit.trim()) || DEFAULT_NARRATOR_CREDIT;
   /* `voiceCount` counts only the speaking cast (not the narrator) — matches the
      library card's "cast of N voices" copy and degrades gracefully when only
      the narrator is present. */


### PR DESCRIPTION
## Summary

Wave 1 of the Castwright brand pass:
- **Narrator credit defaults to "Castwright"** (over the cast-narrator name; explicit user credits still win), persisted via book-state GET default + the existing meta-PUT write-through + a `repair-narrator-credit.mjs` backfill.
- **Exported-file artist tag keeps the author** when the credit is the brand default — `artistForExport()` treats the literal "Castwright" as the "no human narrator" sentinel across the 3 export builders.
- **Persistent stamps:** "Made with Castwright ·" footer build-stamp + a "Rendered with Castwright · castwright.ai" comment in exported MP3 (ID3 COMM) and M4B (©cmt).
- Removed the now-orphaned `narratorNameFromCast` helper.

Spec: `docs/superpowers/specs/2026-06-08-castwright-brand-full-pass-design.md` (Wave 1)
Plan: `docs/superpowers/plans/2026-06-08-castwright-wave1-narrator-stamps.md`

Refs #631

## Test plan
- `npm run verify` green (lint, typecheck, all unit/integration, e2e, e2e:visual, build).
- New tests: book-meta-slice default, listen default, book-state GET default, `artistForExport`, ID3 comment frame, M4B ©cmt, `planBackfill`, build-stamp prefix, + a Playwright assertion that the Listen header shows "narrated by Castwright" with no explicit credit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)