### PR TITLE
feat(frontend): Castwright brand presence — on-ramp + listener touchpoints

### DIFF
--- a/docs/superpowers/plans/2026-06-08-castwright-wave2-touchpoints.md
+++ b/docs/superpowers/plans/2026-06-08-castwright-wave2-touchpoints.md
@@ -1,0 +1,60 @@
+# Castwright Wave 2 — On-ramp + listener touchpoints (plan)
+
+> REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** Tasteful brand presence at the moments that matter — empty library, upload, Listen header, share modals, and the analysing/generation screens. Reuse the existing `<CastwaveMark/>` (`src/lib/icons.tsx`). Brand rules: the **primary tagline is fixed wording** ("Any book, performed by a full cast — effortlessly. Even in your own voice."); short form "Any book, fully cast."; manifesto "Many voices, one machine."; **Magenta = brand, Peach = action only**.
+
+**Source of truth:** `docs/superpowers/specs/2026-06-08-castwright-brand-full-pass-design.md` (Wave 2).
+
+Shared strings (use verbatim):
+- Short form tagline: `Any book, fully cast.`
+- Manifesto: `Many voices, one machine.`
+- Listen line: `Full-cast audiobook · made with Castwright`
+- Share attribution: `Made with Castwright · castwright.ai`
+
+---
+
+## Task 1 — On-ramp (empty library + upload)
+
+**Files:** `src/components/library/library-empty-states.tsx`, `src/views/upload.tsx`. Tests: `src/views/book-library.test.tsx` (covers EmptyLibrary) or a new `library-empty-states.test.tsx`; `src/views/upload.test.tsx`.
+
+- [ ] **Empty library** (`library-empty-states.tsx`, `EmptyLibrary`):
+  - Replace the `<IconPlus/>` inside the round badge with `<CastwaveMark className="w-8 h-8" aria-hidden="true" />` and change the badge color from peach to brand: `bg-magenta/10 text-magenta` (Castwave is brand, not action). Import `CastwaveMark` from `../../lib/icons`.
+  - Add a tagline sub-headline directly under the `<h3>Your library is empty</h3>`: `<p className="mt-2 text-sm text-ink/60">Any book, fully cast.</p>`.
+  - **Fix the stale path:** in the `<code>` block change `audiobook-workspace/books/…` → `castwright-workspace/books/…` (Wave 0 renamed the default workspace dir).
+  - Keep the "Import your first book" CTA button exactly as-is (peach/dark action is correct).
+- [ ] **Upload** (`upload.tsx` ~line 215, the non-reupload branch): add a quiet subtitle between the `<MixedHeading … bold="meet the cast" />` block and the existing `<p className="mt-4 text-lg text-ink/70">`: `<p className="mt-3 text-sm text-ink/60">Any book, fully cast.</p>`. Do NOT add it to the reupload branch (keep that focused on "see what changed").
+- [ ] **Tests (TDD):** add to `book-library.test.tsx` (or new `library-empty-states.test.tsx`) an assertion that the empty state renders "Any book, fully cast." and that the example path reads `castwright-workspace`. Add to `upload.test.tsx` an assertion the new-project headline area shows "Any book, fully cast." (and NOT on reupload). Watch fail → implement → pass.
+- [ ] `npm run typecheck`; commit `feat(frontend): brand the empty-library + upload on-ramp (Castwave mark + tagline)`.
+
+## Task 2 — Listener + share surfaces
+
+**Files:** `src/components/listen/listen-header.tsx`, `src/modals/share-clip.tsx`, `src/modals/share-link.tsx`. Tests: `listen-header.test.tsx`, `share-clip.test.tsx`, `share-link.test.tsx`.
+
+- [ ] **Listen header** (`listen-header.tsx`): after the credit `<p className="mt-3 text-ink/70">…</p>` block (closes ~line 238), add a quiet brand line:
+  ```tsx
+  <p className="mt-2 text-xs text-ink/50">Full-cast audiobook · made with Castwright</p>
+  ```
+- [ ] **Share-clip** (`share-clip.tsx`): in the footer row (`px-6 py-4 border-t …`, ~line 339), add a left-aligned attribution so the buttons stay right: change the footer to `justify-between` and prepend `<span className="text-[11px] text-ink/40">Made with Castwright · castwright.ai</span>` before the Cancel/Download buttons (wrap the two buttons in a `<div className="flex items-center gap-3">`). Keep `data-testid="share-clip-confirm"` intact.
+- [ ] **Share-link** (`share-link.tsx`): in the footer (`px-6 py-4 border-t …`, ~line 171) do the same — `justify-between`, prepend the `Made with Castwright · castwright.ai` span (text-[11px] text-ink/40), keep the `Done` button right.
+- [ ] **Tests (TDD):** `listen-header.test.tsx` asserts "made with Castwright" renders. `share-clip.test.tsx` + `share-link.test.tsx` assert the attribution line renders without breaking existing button/testid assertions. Watch fail → implement → pass.
+- [ ] `npm run typecheck`; commit `feat(frontend): brand the Listen header + share modals (made with Castwright)`.
+
+## Task 3 — Processing screens (analysing + generation)
+
+**Files:** `src/views/analysing.tsx` (~line 974), `src/views/generation.tsx` (~line 791). Tests: `analysing.test.tsx`, `generation.test.tsx`.
+
+- [ ] **Analysing** (`analysing.tsx`): after the description `<p className="mt-4 text-ink/70">…</p>` add a brand-voice manifesto line: `<p className="mt-2 text-sm text-ink/50">Many voices, one machine.</p>`.
+- [ ] **Generation** (`generation.tsx`): after the `{completed} of … chapters complete` `<p className="mt-3 text-ink/60">` add `<p className="mt-1 text-sm text-ink/50">Many voices, one machine.</p>`.
+- [ ] **Tests (TDD):** add an assertion in each view's test that "Many voices, one machine." renders during the analysing / generation stage. Watch fail → implement → pass. (These test files are large — add focused new `it(...)` cases; do not restructure existing tests.)
+- [ ] `npm run typecheck`; commit `feat(frontend): brand-voice subtitle on analysing + generation screens`.
+
+## Task 4 — Verify + PR
+
+- [ ] `npm run verify` green.
+- [ ] Push `feat/castwright-onramp-touchpoints`; `gh pr create` with `Refs #631` (Wave 2); body links spec + this plan.
+
+## Notes
+- Reuse `<CastwaveMark/>` — do NOT inline new SVGs. Color it `text-magenta` (brand), never peach.
+- Keep additions minimal and quiet (small, muted text) — the look stays pixel-stable elsewhere.
+- Primary tagline is fixed wording; only use the approved short form / manifesto strings above.

--- a/src/components/library/library-empty-states.tsx
+++ b/src/components/library/library-empty-states.tsx
@@ -3,20 +3,21 @@
    pre-refactor JSX so existing `book-library.test.tsx` assertions
    keep resolving. */
 
-import { IconPlus } from '../../lib/icons';
+import { CastwaveMark, IconPlus } from '../../lib/icons';
 import { PrimaryButton } from '../primitives';
 
 export function EmptyLibrary({ onStartNew }: { onStartNew: () => void }) {
   return (
     <div className="bg-white rounded-3xl border border-ink/10 shadow-card p-12 text-center">
-      <span className="w-16 h-16 mx-auto rounded-full bg-peach/10 grid place-items-center text-peach">
-        <IconPlus className="w-7 h-7" />
+      <span className="w-16 h-16 mx-auto rounded-full bg-magenta/10 grid place-items-center text-magenta">
+        <CastwaveMark className="w-8 h-8" aria-hidden="true" />
       </span>
       <h3 className="mt-5 font-serif text-2xl font-bold text-ink">Your library is empty</h3>
+      <p className="mt-2 text-sm text-ink/60">Any book, fully cast.</p>
       <p className="mt-2 text-sm text-ink/60 max-w-md mx-auto leading-relaxed">
         Books live on disk under{' '}
         <code className="px-1.5 py-0.5 rounded bg-ink/5 text-[12px]">
-          audiobook-workspace/books/&lt;Author&gt;/&lt;Series&gt;/&lt;Title&gt;/
+          castwright-workspace/books/&lt;Author&gt;/&lt;Series&gt;/&lt;Title&gt;/
         </code>
         . Import a manuscript and we'll lay it out for you.
       </p>

--- a/src/components/listen/listen-header.test.tsx
+++ b/src/components/listen/listen-header.test.tsx
@@ -27,6 +27,13 @@ const baseProps = {
   notes: null,
 };
 
+describe('ListenHeader — Wave 2 brand attribution', () => {
+  it('renders "Full-cast audiobook · made with Castwright" below the credit line', () => {
+    render(<ListenHeader {...baseProps} />);
+    expect(screen.getByText('Full-cast audiobook · made with Castwright')).toBeInTheDocument();
+  });
+});
+
 describe('ListenHeader — fs-2 language badge', () => {
   it('renders a Russian badge for a ru book', () => {
     render(<ListenHeader {...baseProps} language="ru" />);

--- a/src/components/listen/listen-header.tsx
+++ b/src/components/listen/listen-header.tsx
@@ -237,6 +237,7 @@ export function ListenHeader({
             </>
           ) : null}
         </p>
+        <p className="mt-2 text-xs text-ink/50">Full-cast audiobook · made with Castwright</p>
         <div className="mt-5 flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-ink/60">
           <span>
             <span className="font-semibold text-ink tabular-nums">{formatTime(totalSec)}</span>{' '}

--- a/src/modals/share-clip.test.tsx
+++ b/src/modals/share-clip.test.tsx
@@ -145,4 +145,14 @@ describe('ShareClipModal', () => {
     const url: string = (props.onDownload as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(url).toContain('Author%20With%20Spaces__series__title');
   });
+
+  it('renders "Made with Castwright · castwright.ai" attribution in the footer (Wave 2 brand)', () => {
+    renderModal();
+    expect(screen.getByText('Made with Castwright · castwright.ai')).toBeInTheDocument();
+  });
+
+  it('keeps the share-clip-confirm testid intact after footer restructure', () => {
+    renderModal();
+    expect(screen.getByTestId('share-clip-confirm')).toBeInTheDocument();
+  });
 });

--- a/src/modals/share-clip.tsx
+++ b/src/modals/share-clip.tsx
@@ -336,23 +336,26 @@ export function ShareClipModal({
             )}
           </div>
 
-          <div className="px-6 py-4 border-t border-ink/10 flex items-center justify-end gap-3">
-            <button
-              onClick={onClose}
-              className="text-sm font-medium text-ink/60 hover:text-ink"
-            >
-              Cancel
-            </button>
-            <button
-              onClick={handleConfirm}
-              data-testid="share-clip-confirm"
-              disabled={invalid}
-              className={`inline-flex items-center gap-2 px-4 py-2 rounded-full bg-ink text-canvas text-sm font-semibold hover:bg-ink-soft ${
-                invalid ? 'opacity-50 cursor-not-allowed' : ''
-              }`}
-            >
-              Download clip
-            </button>
+          <div className="px-6 py-4 border-t border-ink/10 flex items-center justify-between gap-3">
+            <span className="text-[11px] text-ink/40">Made with Castwright · castwright.ai</span>
+            <div className="flex items-center gap-3">
+              <button
+                onClick={onClose}
+                className="text-sm font-medium text-ink/60 hover:text-ink"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirm}
+                data-testid="share-clip-confirm"
+                disabled={invalid}
+                className={`inline-flex items-center gap-2 px-4 py-2 rounded-full bg-ink text-canvas text-sm font-semibold hover:bg-ink-soft ${
+                  invalid ? 'opacity-50 cursor-not-allowed' : ''
+                }`}
+              >
+                Download clip
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/modals/share-link.test.tsx
+++ b/src/modals/share-link.test.tsx
@@ -103,6 +103,17 @@ describe('share-link modal', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it('renders "Made with Castwright · castwright.ai" attribution in the footer (Wave 2 brand)', () => {
+    render(
+      <ShareLinkModal
+        open={true}
+        url="https://example.test/share/ABCDEFGHJKMN"
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByText('Made with Castwright · castwright.ai')).toBeInTheDocument();
+  });
+
   it('clicking the backdrop closes the modal', () => {
     const onClose = vi.fn();
     const { container } = render(

--- a/src/modals/share-link.tsx
+++ b/src/modals/share-link.tsx
@@ -168,10 +168,13 @@ export function ShareLinkModal({ open, url, onClose, onCopyFailed }: ShareLinkMo
             </p>
           </div>
 
-          <div className="px-6 py-4 border-t border-ink/10 flex items-center justify-end gap-3">
-            <PrimaryButton variant="dark" onClick={onClose}>
-              Done
-            </PrimaryButton>
+          <div className="px-6 py-4 border-t border-ink/10 flex items-center justify-between gap-3">
+            <span className="text-[11px] text-ink/40">Made with Castwright · castwright.ai</span>
+            <div className="flex items-center gap-3">
+              <PrimaryButton variant="dark" onClick={onClose}>
+                Done
+              </PrimaryButton>
+            </div>
           </div>
         </div>
       </div>

--- a/src/views/analysing.test.tsx
+++ b/src/views/analysing.test.tsx
@@ -1516,3 +1516,10 @@ describe('AnalysingView — request-model gating (plan 118)', () => {
     expect(capturedOpts?.model).toBe('gemini-2.5-flash');
   });
 });
+
+describe('AnalysingView — Wave 2 brand manifesto', () => {
+  it('renders "Many voices, one machine." on the analysing screen', () => {
+    renderView();
+    expect(screen.getByText('Many voices, one machine.')).toBeInTheDocument();
+  });
+});

--- a/src/views/analysing.tsx
+++ b/src/views/analysing.tsx
@@ -982,6 +982,7 @@ export function AnalysingView({
               ? describeRemaining(remainingMs, wordCount)
               : describeSize(wordCount)}
           </p>
+          <p className="mt-2 text-sm text-ink/50">Many voices, one machine.</p>
           {/* Analyzer Load/Stop control. Rendered even without a manuscript
               so the user can pre-warm Ollama from the Analysing screen (the
               page-refresh / deep-link case where manuscriptId is null lands

--- a/src/views/book-library.test.tsx
+++ b/src/views/book-library.test.tsx
@@ -92,6 +92,17 @@ describe('BookLibraryView — loading affordance', () => {
     expect(screen.queryByTestId('library-skeleton')).not.toBeInTheDocument();
   });
 
+  it('empty state shows "Any book, fully cast." tagline (Wave 2 brand)', () => {
+    renderView({ loaded: true, authors: [] });
+    expect(screen.getByText('Any book, fully cast.')).toBeInTheDocument();
+  });
+
+  it('empty state workspace path reads castwright-workspace (not audiobook-workspace)', () => {
+    renderView({ loaded: true, authors: [] });
+    expect(screen.getByText(/castwright-workspace/)).toBeInTheDocument();
+    expect(screen.queryByText(/audiobook-workspace/)).not.toBeInTheDocument();
+  });
+
   it('renders the populated grid once loaded with authors', () => {
     renderView({ loaded: true, authors: [oneAuthor] });
     /* Author name only appears as the h2 above the series row — unique

--- a/src/views/generation.test.tsx
+++ b/src/views/generation.test.tsx
@@ -2202,3 +2202,10 @@ describe('GenerationView — srv-27 advisory QA badge', () => {
     expect(screen.queryByText('Suspect')).toBeNull();
   });
 });
+
+describe('GenerationView — Wave 2 brand manifesto', () => {
+  it('renders "Many voices, one machine." on the generation screen', () => {
+    renderView();
+    expect(screen.getByText('Many voices, one machine.')).toBeInTheDocument();
+  });
+});

--- a/src/views/generation.tsx
+++ b/src/views/generation.tsx
@@ -799,6 +799,7 @@ export function GenerationView({
             {completed} of {activeChapters.length} chapters complete
             {etaSec != null && <> · approx. {formatTime(etaSec)} remaining</>}
           </p>
+          <p className="mt-1 text-sm text-ink/50">Many voices, one machine.</p>
           {linesCounter.total > 0 && (
             <p className="mt-1 text-xs text-ink/55 tabular-nums">
               <span className="font-semibold text-ink/75">

--- a/src/views/upload.test.tsx
+++ b/src/views/upload.test.tsx
@@ -191,6 +191,14 @@ describe('UploadView — first-time upload (existing path unchanged)', () => {
   });
 });
 
+describe('UploadView — Wave 2 brand (on-ramp tagline)', () => {
+  it('shows "Any book, fully cast." on the new-project branch', () => {
+    const store = makeStore();
+    renderUpload(store);
+    expect(screen.getByText('Any book, fully cast.')).toBeInTheDocument();
+  });
+});
+
 describe('UploadView — re-upload mode (plan 74)', () => {
   it('renders the re-upload banner and the book title when reuploadingBookId is set', () => {
     const store = makeStore({
@@ -304,6 +312,15 @@ describe('UploadView — re-upload mode (plan 74)', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('listen-stub')).toBeInTheDocument();
     });
+  });
+
+  it('"Any book, fully cast." tagline absent on re-upload branch (Wave 2 brand)', () => {
+    const store = makeStore({
+      reuploadingBookId: 'bk_a',
+      libraryBooks: [reuploadBook],
+    });
+    renderUpload(store);
+    expect(screen.queryByText('Any book, fully cast.')).not.toBeInTheDocument();
   });
 
   it('Cancel re-upload returns to the book without showing the diff modal', async () => {

--- a/src/views/upload.tsx
+++ b/src/views/upload.tsx
@@ -217,6 +217,9 @@ export function UploadView() {
               <MixedHeading level="h1" regular="Drop your manuscript to" bold="meet the cast" />
             )}
           </div>
+          {!isReuploading && (
+            <p className="mt-3 text-sm text-ink/60">Any book, fully cast.</p>
+          )}
           <p className="mt-4 text-lg text-ink/70">
             {isReuploading ? (
               <>


### PR DESCRIPTION
## Summary

Wave 2 of the Castwright brand pass — tasteful brand presence at the moments that matter (reuses the existing `<CastwaveMark/>`, Magenta = brand):
- **Empty library:** Castwave mark badge + "Any book, fully cast." sub-headline (also fixes a Wave-0 leftover: the example path now reads `castwright-workspace`).
- **Upload:** "Any book, fully cast." subtitle on the new-project screen.
- **Listen header:** quiet "Full-cast audiobook · made with Castwright" line.
- **Share-clip + share-link modals:** "Made with Castwright · castwright.ai" footer attribution.
- **Analysing + Generation:** "Many voices, one machine." brand-voice subtitle.

Spec: `docs/superpowers/specs/2026-06-08-castwright-brand-full-pass-design.md` (Wave 2)
Plan: `docs/superpowers/plans/2026-06-08-castwright-wave2-touchpoints.md`

Refs #631

## Test plan
- `npm run verify` green (lint, typecheck, all unit/integration, e2e, e2e:visual, build — 2425 tests).
- New assertions across empty-library/upload/listen-header/share-clip/share-link/analysing/generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)