### PR TITLE
docs(docs): add competitive + monetisation briefs and sharpen positioning

### DIFF
--- a/brand/brand-guidelines.md
+++ b/brand/brand-guidelines.md
@@ -23,6 +23,12 @@ observer. Castwright gives the story back its voices — on hardware you already
 **Personality:** a thoughtful craftsperson, not a hype machine. Literary, candid, quietly
 confident. Loves the *listener's* experience and says the honest version of everything.
 
+**Positioning statement** *(the anchor every surface paraphrases; see
+`competitive-brief-2026-06-08.md` for the landscape it answers):*
+> For readers who love stories — especially series — Castwright is the only tool that turns
+> any book into a full-cast performance on a machine they already own: every character in
+> their own voice, consistent from book one to the last, with nothing leaving home.
+
 ---
 
 ## 2. Tagline & messaging hierarchy
@@ -72,6 +78,13 @@ unhurried, dry-witted, never breathless.
   consumer copy; "render" is fine in technical/dev contexts.
 - The people in a book: the **cast**; the lead reader is the **narrator**.
 - The personal-voice feature: **your voice** / **family voices** (with consent) — never "deepfake."
+- The output is a **performance**, never "AI narration" — catalogue-flooding (Audible Virtual
+  Voice et al.) has made "AI narration" mean *robotic and flat* to readers.
+- Where it runs: **your machine** / **at home** — never "on-prem," "edge," or "local-first"
+  in consumer copy; those are infrastructure words, not reader words.
+- Cloning, in one breath: **your voice, with consent, kept at home.**
+- Don't claim "open-source-powered" as a value in itself — **credit the engines by name**
+  (Kokoro, XTTS, Qwen) and let the specificity do the work.
 
 ### Sample copy (use as the reference register)
 
@@ -81,16 +94,48 @@ unhurried, dry-witted, never breathless.
 - **Primary CTA:** *Cast your first book* · **Secondary:** *Hear a sample*
 - **Pillar 1 (full cast):** *No more one bored narrator. The apprentice sounds thirteen; the
   swordsmith sounds seventy and a forge.*
-- **Pillar 2 (series-consistent):** *Book two should sound like book one. Castwright remembers
-  your cast — even when an author renames someone mid-series.*
+- **Pillar 2 (series-consistent — the spearhead claim):** *Book two should sound like book one.
+  Castwright remembers your cast — even when an author renames someone mid-series.* **No one
+  else does this for readers** — full-cast generation is no longer unique (see the competitive
+  brief), series memory is. Lead with it everywhere right after the full cast.
 - **Pillar 3 (your voice):** *Read a bedtime story in your own voice, even when you're away —
   or let your kid be the hero. Your voices, with your permission, stay on your machine.*
+- **Pillar 4 (ownership):** *Rendered once, on hardware you own. No meter, no monthly fee, no
+  server that can take your library away. The frontier never sees a chapter.*
 - **Empty state (library):** *No books yet. Drop in an EPUB, PDF, or paste a chapter — we'll
   find the cast.*
 - **Error (analysis hiccup):** *That chapter didn't parse cleanly. We kept the rest; retry just
   this one.* (Honest, scoped, no blame, no jargon.)
 - **App Store short:** *Turn any novel into a full-cast audiobook. Every character gets their
   own voice, consistent across a whole series — rendered on your own device, even in your voice.*
+
+### Proof, not promises
+
+"Say the honest version" needs receipts. When copy makes a claim, reach for these — stated
+plainly, never gloating:
+
+- **Quality:** every line is acoustically checked and transcript-verified before a chapter is
+  assembled; the plainly broken lines never reach your ears.
+- **Economics:** a heavy reader pays the electricity, once per book — against $11/month clouds
+  that won't let you export the audio, and cloud creation that runs to ~$200 per book by the
+  vendors' own tables.
+- **Permanence:** when a cloud voice product was acquired in 2025, its users' libraries and
+  voice clones were deleted at sunset (Play.ht). Your renders are files on your disk; nobody
+  can take them away. Reference this factually, never gleefully.
+
+### Competitive register — how we speak about others
+
+Three rules, all downstream of the craftsperson persona:
+
+- **Clouds: name tradeoffs factually, never mock.** Both clauses true, no sneer: *"ElevenLabs
+  makes stunning voices. It also meters them by the hour and keeps your audio."* If a
+  comparison needs adjectives to land, it isn't ready.
+- **Open source is kin, not competition.** The local-audiobook community is our earliest
+  audience and our engine suppliers. Credit Kokoro, XTTS, and Qwen visibly; never punch down
+  at a hobby project's rough edges.
+- **Never punch at human narrators.** The villain is the *economics that force one bored
+  narrator to play everyone* — not the person. Audible's human full-cast productions are the
+  benchmark we honour, not deride.
 
 ---
 
@@ -154,3 +199,8 @@ to ~16px; outline wordmark type for production.
 - Reframe `../docs/project-narrative.md` into the Castwright brand once this is signed off
   (retitle, weave the name + pillars in — keep the candid first-person voice intact).
 - Optional later: sonic identity / audio logo + a "house narrator" voice persona.
+- **Quarterly competitive refresh** against the `competitive-brief-2026-06-08.md` baseline —
+  watch Spoken releases (series continuity, author→reader pivot), ElevenLabs Reader features
+  (auto-casting risk), and the OSS wave (Alexandria, abogen, ebook2audiobook/E2A-SML). The
+  series-consistency claim and the QA-gate claim must be re-verified as *still unique* before
+  each external use.

--- a/brand/competitive-brief-2026-06-08.md
+++ b/brand/competitive-brief-2026-06-08.md
@@ -1,0 +1,200 @@
+# Castwright — competitive brief & brand recommendations
+
+**Research date:** 8 June 2026 · **Estimated read time:** 14 minutes
+**Companion to:** `brand-guidelines.md` (current state) and `../docs/project-narrative.md` (the story)
+
+---
+
+## Executive summary
+
+**The category Castwright invented is no longer empty — but the position Castwright holds is still unclaimed.** In the last 12 months, automated per-character "full-cast" audiobook generation went from white space to a contested feature: **Spoken** shipped it for authors (Magic Mode, May 2026), **Audibloom** and **MyNarratorAI** ship it in the cloud, and at least **four open-source projects** (led by **Alexandria Audiobook**, on the same Qwen3-TTS stack) ship it locally. **ElevenLabs + Spotify** just made single-voice AI audiobooks free for authors (June 2026 beta).
+
+**Key findings**
+
+- **Nobody combines Castwright's four pillars.** Consumer-facing + full cast + series-consistent + local/private exists nowhere else as one product. Each competitor holds at most two.
+- **Two claims remain genuinely unique:** **series-level cast consistency for readers** (Spoken approached it author-side on 5 June 2026 — this window is closing) and **automated per-sentence quality gating** ("the line actually says the right words") — no one, commercial or OSS, markets either.
+- **The local/ownership story is unclaimed marketing whitespace.** Every commercial rival meters cloud credits (ElevenLabs hours, Speechify word caps, Spoken per-word, Audibloom hours/month); ElevenReader even **forbids audio export**. Play.ht's shutdown (Meta acquihire; user libraries and voice clones deleted 31 Dec 2025) is a ready-made proof point: *a cloud library can be deleted by someone else's acquisition.*
+- **The OSS tier is the most direct threat to the "local" pillar,** not the giants: ebook2audiobook (~19k stars) owns the home-conversion default, and Alexandria (580★, surging) does LLM casting + emotion + cloning on an 8 GB GPU. Their gap is product polish, series memory, and QA — exactly where the brand should plant its flag.
+
+**Decisions sought**
+
+1. **Promote the local/ownership story from supporting detail to a named brand pillar** (currently buried under "your voice").
+2. **Claim series consistency loudly and now** — it is the moat with a closing window.
+3. **Add a competitive register to the brand guidelines** (how we talk about clouds, giants, and OSS) so future copy stays candid without turning combative.
+
+**Actions proposed:** seven specific edits to `brand-guidelines.md` (Section 8 below) plus a short content plan exploiting the gaps (Section 9).
+
+---
+
+## 1. Landscape overview
+
+Four tiers compete for the same listener-hours, with different business models:
+
+| Tier | Players | Model | Full-cast? | Local? | Threat to Castwright |
+|---|---|---|---|---|---|
+| **Consumer reader apps** | ElevenLabs Reader, Speechify, MyNarratorAI, CastReader | Subscription, cloud-metered | MyNarratorAI/CastReader yes (cloud); others no | No | **High** — same audience |
+| **Author/publisher platforms** | Spoken, Audibloom, ElevenLabs Studio, Wondercraft, Murf, Respeecher | Per-word / per-hour / credits | Spoken & Audibloom yes, automated | No | **Medium** — different buyer, overlapping claims |
+| **Platform-native catalogue tools** | Audible Virtual Voice, Spotify×ElevenLabs, Apple Books, Google Play | Free creation, store lock-in | No (single narrator) | No | **Low-medium** — shapes expectations, floods catalogues |
+| **Open-source / local** | ebook2audiobook (+E2A-SML), Alexandria, audiobook-creator, abogen, Audiblez | Free, own GPU | Alexandria & E2A-SML yes | **Yes** | **High** — same pillar, same hardware, zero price |
+
+**Consolidation signal:** Play.ht is dead (Meta acquihire, product sunset 31 Dec 2025), DeepZen's site is in maintenance mode, Speechki is flagged out of business. The mid-tier cloud "AI narration bureau" is being squeezed between ElevenLabs and free platform-native tools. The two ends that survive: platform giants and local/free. Castwright sits at the local end with a consumer product — defensible ground.
+
+---
+
+## 2. Competitor profiles (the five that matter most)
+
+### 2.1 ElevenLabs (Reader + Audiobooks/Studio) — the gravity well
+
+- **Positioning:** *"Turn your manuscript into a studio-quality audiobook in minutes"* / Reader: *"Listen to anything with stunningly natural voices."* End-to-end create→publish→earn loop.
+- **Pricing:** Reader Ultra **$11/mo**; creation Free→$5→$22→$99→~$330/mo, credit-metered (~"Free–$200 per book" by their own table).
+- **Full-cast:** v3 Dialogue mode + Studio multi-speaker exist, but casting is **manual hand-tagging by the rights-holder**. No consumer feature auto-casts a novel you own; the Reader is single-narrator and **blocks audio export**.
+- **Recent moves:** Spotify for Authors integration (21 May 2026), 200K human-narrated titles licensed into Reader (May 2026), Iconic Voices marketplace.
+- **Weaknesses:** credit metering confuses and compounds on book-length work; cloud-only; everything locked in their ecosystem.
+- **Tone:** polished, superlative-heavy ("stunningly natural," "studio-quality") — the exact register Castwright's guidelines already ban.
+
+### 2.2 Spoken (spoken.press) — closest claim overlap
+
+- **Positioning:** *"The AI Audiobook Company™"*, *"Free to use. Pay when Perfect."* — full-cast AI audiobooks for **authors**, ethics-forward.
+- **Pricing:** **$20 per 5,000 finished words** (≈$200 for a 46k-word novel); $50/mo halves it.
+- **Full-cast:** yes — Magic Mode (20 May 2026) auto-orchestrates the whole performance. **v2.1 (5 June 2026) added cross-project continuity for series** — the direct overlap with Castwright's "book two sounds like book one."
+- **Weaknesses:** author-side only (readers can't convert books they don't hold rights to), cloud, per-word costs scale steeply across a series, small bootstrapped team.
+- **Tone:** warm, writerly, anti-big-tech — the most Castwright-like voice in the field. Differentiate by audience (readers vs authors) and by locality, not by tone.
+
+### 2.3 Audibloom — closest pipeline analogue
+
+- **Positioning:** *"Novel to Audiobook AI — a full cast for your characters."* LLM auto-casting for indie authors; claims 80–90% first-pass attribution accuracy.
+- **Pricing:** $15–$99/mo tiers; full multi-character from **$39/mo**; **$29 per-book** pack.
+- **Weaknesses:** cloud-only, no M4B yet, no distribution, unproven at book length, no independent reviews.
+- **Note:** its marketing ("the first audiobook tool that actually understands your characters") is a direct collision with Castwright's essence statement. Expect copy conflict.
+
+### 2.4 MyNarratorAI — the consumer cloud twin
+
+- **Positioning:** *"Transform Your E-books into Full Cast Audiobooks with AI"* — the only other **reader-facing** full-cast product found.
+- **Pricing:** Free (watermarked) / $5 / $10 / $25 per month.
+- **Weaknesses:** ePub-only, web-only, cloud, watermark-gated free tier, unknown voice quality, small/bootstrapped, and it inherits the unanswered legal question of uploading purchased books to a third-party server — which **local rendering structurally avoids**.
+
+### 2.5 Alexandria Audiobook (OSS) — the direct local threat
+
+- **What:** open-source, same **Qwen3-TTS** family as Castwright; LLM script annotation with a second review pass, voice design from text, cloning, LoRA voice persistence, emotion/instruct control, browser editor, M4B export. **8 GB VRAM minimum.** 580★ and surging; single maintainer.
+- **Gaps vs Castwright:** no series memory (within-book roster continuity only), no ASR/acoustic QA gate, no manuscript/cast/listen product UX, no companion app, no installer-grade onboarding, hobbyist support model.
+- **Flanking it:** ebook2audiobook (~19k★) is single-voice but owns the community default and could absorb multi-voice via E2A-SML; abogen (~4.7k★) is adding "theatrical" multi-voice and ships Audiobookshelf integration.
+
+**Honourable mentions:** Speechify ($29/mo headline, $139/yr effective; billing-complaint magnet; no per-character casting), Audible Virtual Voice (single-narrator catalogue flooding; its **human** full-cast Harry Potter productions define the premium benchmark), CastReader and Narratemi (young cloud full-cast entrants — watch list), NotebookLM (taught consumers that "AI can do two voices").
+
+---
+
+## 3. Messaging comparison matrix
+
+| Dimension | **Castwright** | ElevenLabs | Spoken | Audibloom | MyNarratorAI | Alexandria (OSS) |
+|---|---|---|---|---|---|---|
+| Tagline | *Any book, performed by a full cast — effortlessly. Even in your own voice.* | "Turn your manuscript into a studio-quality audiobook in minutes" | "Free to use. Pay when Perfect." | "A full cast for your characters" | "Transform Your E-books into Full Cast Audiobooks" | (README, no brand) |
+| Buyer | **Readers/listeners** | Authors + listeners (two-sided) | Authors | Indie authors | Readers | Hobbyist self-hosters |
+| Hero claim | Full cast, series-true, on your machine | Most expressive voices | Ethical full-cast at scale | "Understands your characters" | Full cast + customisation | Free + local |
+| Series consistency | **Yes — reader-side, automated** | No | Author-side (v2.1, new) | No | No | Within-book only |
+| Local/private | **Yes — synthesis never leaves the machine** | No (no export from Reader) | No | No | No | Yes |
+| Cost model | **Per book, once — electricity** | Credits/subscription | Per-word | Subscription/hours | Subscription | Free |
+| Voice | Literary craftsperson, candid | Superlative tech | Warm writerly | Pragmatic indie | Enthusiast/feature-listy | None |
+| Villain in their story | The one bored narrator; the metered cloud | Slow expensive studios | Big-tech exploitation | Manual copy-paste TTS | Boring narration | ElevenLabs pricing |
+
+**Read of the matrix:** the tone lane Castwright occupies (literary, candid, anti-hype) is shared only with Spoken — but Spoken sells to authors. In the **reader** market, no one talks the way Castwright talks, and no one makes the ownership argument at all.
+
+---
+
+## 4. Pricing landscape
+
+| Product | Model | Cost for a heavy reader (10 novels/yr) |
+|---|---|---|
+| ElevenLabs Reader Ultra | $11/mo sub, no export | $132/yr, **own nothing** |
+| ElevenLabs creation | credits | "Free–$200 **per book**" (their words) |
+| Speechify Premium | $139/yr effective | $139/yr, single narrator, word caps |
+| Spoken | $20/5,000 words | ≈ **$1,600–2,000/yr** for 10 novels (author-side) |
+| Audibloom | $39/mo or $29/book | $290–468/yr |
+| MyNarratorAI | $5–25/mo | $60–300/yr |
+| Audible Premium Plus | $14.95/mo | $179/yr, 12 credits |
+| OSS (Alexandria etc.) | free + GPU | electricity |
+| **Castwright** | **per book, on your GPU** | **electricity — and you own the files forever** |
+
+**Implication:** Castwright's economics are an order of magnitude better for exactly its target buyer (the heavy series reader) — but the brand currently states this once, mid-narrative. It should be a front-line message with the arithmetic shown, in the candid register the guidelines already mandate.
+
+---
+
+## 5. Positioning map
+
+Axes that split this market most cleanly: **who it's for** (rights-holders vs readers) × **where it runs** (cloud-metered vs your machine).
+
+- **Rights-holders × cloud:** ElevenLabs Studio, Spoken, Audibloom, Wondercraft, platform-native tools — crowded.
+- **Readers × cloud:** ElevenLabs Reader, Speechify, MyNarratorAI, CastReader — crowded, single-narrator or quality-unproven.
+- **Rights-holders × local:** empty (no demand — authors want distribution).
+- **Readers × local:** **Audiblez/ebook2audiobook (single-voice, hobbyist UX) … and Castwright.** The only occupant with a full-cast product and consumer polish.
+
+The quadrant is real, growing (OSS star counts prove demand), and the only credible co-occupants are open-source projects whose gaps — series memory, QA gating, finished UX, a companion app — are precisely Castwright's strengths. **Category strategy: niche-to-own, not category-war.** Don't out-shout ElevenLabs; own "the reader's machine."
+
+---
+
+## 6. Gap analysis — unclaimed messaging whitespace
+
+1. **Series consistency, reader-side.** "Book two sounds like book one" — no consumer product claims it. Spoken claims it for authors as of 5 June 2026. **Closing window; claim it first and loudest.**
+2. **Ownership/permanence.** "Rendered once on your machine; no meter, no monthly fee, no server that can delete your library." Play.ht users lost every clone and render on 31 Dec 2025. ElevenReader forbids export. Unclaimed by anyone.
+3. **The quality gate.** Every sentence acoustically checked and ASR-verified before assembly. No competitor — including Pozotron, which sells QA for *human* narration — markets automated content QA on AI renders. "The plainly broken lines never reach your ears" is honest, specific, and unique.
+4. **The clean legal story.** Cloud consumer rivals quietly dodge "can I upload a book I bought?" Local rendering for personal use is structurally the cleanest position in the category. State it plainly, in the honest register.
+5. **Family voices done right.** Voice cloning is table stakes everywhere — but *consent-tracked, on-device, never-leaves-home* family voices are claimed by no one. fs-38's differentiation is the privacy architecture, not the cloning.
+
+---
+
+## 7. Threats
+
+| Threat | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| **ElevenLabs adds auto-casting to Reader** (they have v3 Dialogue + 200K-title library + $11/mo) | Medium-high, 6–18 mo | High | Own the lanes they can't follow: local, export-free ownership, series memory across *your* library. Speed on fs-38. |
+| **Spoken extends series continuity and pivots reader-side** | Medium | Medium-high | Claim reader-side series consistency in all brand surfaces now; it's shipped product, not roadmap. |
+| **Alexandria/ebook2audiobook reach feature parity locally, free** | High (capability), medium (polish) | Medium | Never compete on price with free. Compete on finished product: onboarding, cast UX, QA gate, companion app, series memory. Treat OSS with respect in all copy — its users are Castwright's earliest adopters. |
+| **Platform catalogue flooding cheapens "AI audiobook"** (Virtual Voice complaints: robotic, flat) | Already happening | Medium | Don't market as "AI audiobook." Market as a **performance**. The brand lexicon already does this — enforce it harder. |
+| **Big-tech multi-speaker models restricted or withdrawn** (Microsoft pulled VibeVoice weights) | Ongoing | Low-medium (opportunity) | Curated-engine approach + local weights = stability story. |
+
+---
+
+## 8. Recommended brand iterations (edits to `brand-guidelines.md`)
+
+These preserve the tagline, voice, and visual system — the research validates all three. The changes sharpen *what we claim* and *against whom*, not *how we sound*.
+
+1. **Add a fourth message pillar — Ownership.** Current pillars: full cast, series-consistent, your voice. Add: **"Yours, on your machine."** Draft copy in the house register: *"Rendered once, on hardware you own. No meter, no monthly fee, no server that can take your library away. The frontier never sees a chapter."* The narrative already says this beautifully; the guidelines never made it a pillar — and it is the least copyable claim in the field.
+2. **Sharpen the series pillar into the spearhead claim.** Reorder pillars: series consistency second only to full cast, with the explicit line *"No one else does this for readers."* Window is closing (Spoken v2.1); first-claim advantage is real.
+3. **Add a "proof, not promises" section.** The guidelines mandate honesty; give copywriters the receipts to be honest *with*: every line acoustically checked and transcript-verified; per-book cost arithmetic vs $11/mo–$200/book clouds; the Play.ht shutdown as the ownership cautionary tale (referenced factually, never gleefully).
+4. **Add a competitive register ("how we speak about others").** Three rules consistent with the craftsperson persona: **(a)** name clouds' tradeoffs factually, never mock ("ElevenLabs makes stunning voices. It also meters them by the hour and keeps your audio." — both clauses true); **(b)** treat open source as kin, not competition — credit engines (Kokoro, XTTS, Qwen) visibly; the OSS community is the early-adopter base; **(c)** never punch at human narrators — the villain is the *one bored narrator forced to play everyone*, i.e. the economics, not the person. (The Audible full-cast Potter productions are the benchmark to honour, not deride.)
+5. **Extend the lexicon.** Add: the conversion is a **performance**, never "AI narration" (catalogue-flooding has poisoned that term); the machine is **"your machine"/"at home"**, never "on-prem"/"edge"/"local-first" in consumer copy; cloning is **"your voice, with consent, kept at home"** — "deepfake" stays banned; avoid "open-source-powered" as a value claim (credit specifically instead).
+6. **Add a positioning statement to anchor Section 1:** *For readers who love stories — especially series — Castwright is the only tool that turns any book into a full-cast performance on a machine they already own: every character in their own voice, consistent from book one to the last, with nothing leaving home.*
+7. **Add a watch-list note to "Open items":** quarterly competitive refresh (Spoken releases, ElevenLabs Reader features, Alexandria/abogen capability) — this brief as the baseline.
+
+**Risk of inaction:** the story ("nobody builds the cast") drifts out of date as Spoken/Audibloom market exactly that — the narrative's "why nobody's built it" framing should evolve to *"why nobody builds it for readers, at home"* at the next refresh.
+
+---
+
+## 9. Action items & next steps
+
+**Quick wins (this week)**
+
+1. Apply edits 1–7 above to `brand-guidelines.md` — I can draft the diff on approval.
+2. Update `project-narrative.md`'s "Why this is broken" to acknowledge the 2025–26 full-cast wave and re-anchor the gap on *readers + home hardware* (keeps the candid contract intact).
+3. Reserve the comparison claims while true: "the only full-cast audiobook tool that runs on your machine" — verify quarterly.
+
+**Strategic (next quarter)**
+
+4. Ship fs-38 (your voice) with the consent/privacy story front-and-centre — it converts the tagline's open promise before a cloud rival claims "family voices."
+5. Content plan against the whitespace: a "why your audiobooks should live at home" essay (Play.ht case), a listen-first demo page (apprentice/swordsmith/dragon A-B against single-narrator), and an honest benchmark post (RTF, VRAM, cost arithmetic) — the register the OSS community respects and shares.
+6. Decide the OSS relationship posture (acknowledge kinship in About page vs stay quiet) — recommend acknowledgment; it pre-empts "closed app built on open models" criticism.
+
+**Key people worth consulting:** none internal (solo project); externally, alpha testers are the proxy panel for testing the new pillar copy.
+
+---
+
+## Sources
+
+**Internal:** `brand/brand-guidelines.md` · `docs/project-narrative.md`
+
+**Consumer tier:** [elevenreader.io/pricing](https://elevenreader.io/pricing) · [elevenlabs.io/audiobooks](https://elevenlabs.io/audiobooks) · [elevenlabs.io/v3](https://elevenlabs.io/v3) · [TechCrunch — Spotify×ElevenLabs (21 May 2026)](https://techcrunch.com/2026/05/21/spotify-launches-an-elevenlabs-powered-audiobook-creation-tool/) · [TechTimes — 200K titles on ElevenReader](https://www.techtimes.com/articles/317030/20260522/elevenreader-lands-200000-human-narrated-titles-11-subscription-takes-aim-audible.htm) · [speechify.com/pricing](https://speechify.com/pricing/) · [9to5Mac — Speechify celebrity voices](https://9to5mac.com/2026/02/02/speechify-adds-celebrity-voices-to-its-ai-voice-assistant/) · [KDP Virtual Voice](https://kdp.amazon.com/en_US/help/topic/GMPQGZAZJH6FF456) · [ACX Voice Replicas](https://www.acx.com/mp/blog/now-in-beta-narrator-voice-replicas-on-acx) · [Audible newsroom — AI narration & translation](https://www.audible.com/about/newsroom/audible-expands-catalog-with-ai-narration-and-translation-for-publishers) · [authors.apple.com — digital narration](https://authors.apple.com/support/4519-digital-narration-audiobooks) · [Google Play auto-narrated](https://play.google.com/books/publish/autonarrated/) · [mynarratorai.com](https://mynarratorai.com/)
+
+**Author/publisher tier:** [spoken.press](https://www.spoken.press/) · [Spoken pricing](https://www.spoken.press/pricing) · [Spoken Studio V2 / Magic Mode](https://www.spoken.press/the-spoken-chronicle/spoken-studio-v2-magic-mode-amp-turnkey-full-cast-audiobook-creation) · [Spoken v2.1 release notes](https://www.spoken.press/the-spoken-chronicle/spoken-v21-release-notes-continuity-amp-creative-control) · [audibloom.io](https://audibloom.io/novel-to-audiobook/) · [audibloom.io/pricing](https://audibloom.io/pricing) · [murf.ai/pricing](https://murf.ai/pricing) · [wondercraft.ai/audiobook](https://www.wondercraft.ai/audiobook) · [TechCrunch — Meta acquires Play AI](https://techcrunch.com/2025/07/13/meta-acquires-voice-startup-play-ai/) · [Play.ht shutdown notice (kore.ai community)](https://community.kore.ai/t/important-update-playht-tts-support-discontinued-heres-what-to-do/5001) · [deepzen.io (maintenance)](https://deepzen.io/) · [pozotron.com](https://www.pozotron.com/) · [narakeet.com pricing](https://www.narakeet.com/docs/pricing/) · [respeecher.com — audiobooks](https://www.respeecher.com/podcasts-audiobooks) · [camb.ai](https://www.camb.ai/) · [Speechki — PitchBook](https://pitchbook.com/profiles/company/490990-60)
+
+**Local/OSS tier:** [Alexandria Audiobook](https://github.com/Finrandojin/alexandria-audiobook) · [prakharsr/audiobook-creator](https://github.com/prakharsr/audiobook-creator) · [ebook2audiobook](https://github.com/DrewThomasson/ebook2audiobook) · [E2A-SML](https://github.com/DrewThomasson/E2A-SML) · [abogen](https://github.com/denizsafak/abogen) · [Audiblez](https://github.com/santinic/audiblez) · [epub2tts](https://github.com/aedocw/epub2tts) · [Pandrator](https://github.com/lukaszliniewicz/Pandrator) · [Microsoft VibeVoice](https://github.com/microsoft/VibeVoice) · [NotebookLM updates](https://blog.google/innovation-and-ai/models-and-research/google-labs/notebooklm-video-overviews-studio-upgrades/) · [HN — converter frustrations](https://news.ycombinator.com/item?id=44386097)
+
+**Freshness caveats:** Speechify Premium+ cloning price and word caps are from third-party reviews; Play.ht sunset timeline is from migration guides, not first-party; DeepZen/Speechki statuses inferred (maintenance page / PitchBook flag); OSS star counts are point-in-time. Audible's third-party AI-narration policy shifts frequently — re-verify before citing publicly.

--- a/brand/monetisation-free-vs-gated-2026-06-08.md
+++ b/brand/monetisation-free-vs-gated-2026-06-08.md
@@ -1,0 +1,215 @@
+# Castwright — free vs gated: community comparison & one-off pricing model
+
+**Date:** 8 June 2026 · **Estimated read time:** 12 minutes
+**Companion to:** `competitive-brief-2026-06-08.md` (competitor detail and sources) and `brand-guidelines.md` (Pillar 4 — ownership)
+
+---
+
+## Executive summary
+
+**The free community products define the floor: anything they do free, Castwright must do free.** Gating a capability that Alexandria or ebook2audiobook gives away simply routes users to GitHub. What they *cannot* do — series memory, the quality gate's auto-repair loop, family voices with a consent trail, the companion app, the multi-book studio — is where a gate is both fair and defensible, because the value accumulates with sustained use.
+
+**Recommended model: free core, one-off "Cast Pass" at US$7.**
+
+- **Free, forever, no caps or watermarks:** the complete single-book magic — ingest, full-cast analysis, designed voices, emotion, basic cloning, QA *detection*, manuscript editing, M4B export. The free tier must be the best local audiobook tool available, full stop.
+- **Cast Pass (one-off US$7, covers all v1.x):** the library that remembers — series continuity, cross-book voice library, family voices (fs-38), companion-app pairing, multi-book queue, A/B diff player, QA auto-repair.
+- **Never gated, on principle:** export (no lock-in is a brand non-negotiable), consent controls, QA detection (trust is not a paid feature).
+
+**Decisions sought:** confirm the free/gated split (Section 3), the US$7 price point, and the sell-on-web-not-in-app distribution (avoids Apple's 30% and IAP rules).
+
+**Sustainability check:** fixed costs ≈ US$300–650/yr (Apple developer program, code signing, domain, store fees — itemised with verified 2026 pricing in Section 4; GitHub CI drops to $0 once the repo is public). **~50–105 passes a year covers it** at ~$6.15 net per sale after Paddle's cut. A 5% conversion on 2,000 free users clears the bar comfortably.
+
+---
+
+## 1. The free community floor (what must stay free)
+
+| Capability | Best free community offering | Maturity | Implication for Castwright |
+|---|---|---|---|
+| EPUB/PDF/MOBI ingest → chaptered M4B | ebook2audiobook (~19k★), Audiblez (~6k★) | Mature, mainstream | **Free** — commodity |
+| Single-voice conversion (Kokoro-class) | Audiblez, abogen (~4.7k★) — CPU-friendly | Mature | **Free** — commodity |
+| **LLM character detection + auto full-cast** | Alexandria (580★, surging), audiobook-creator (465★), E2A-SML | Working, rough edges | **Free** — this is the demo of the magic; gate it and users pick Alexandria |
+| Designed voices from a persona | Alexandria (same Qwen3-TTS stack, incl. voice design + LoRA) | Working | **Free** — parity exists |
+| Emotion/tone direction | Alexandria (instruct-based), audiobook-creator (Orpheus tags) | Partial | **Free** — capability parity exists; Castwright wins on automation quality, not existence |
+| Basic voice cloning from a sample | ebook2audiobook, Pandrator, Alexandria | Mature (table stakes) | **Free** (single personal voice) |
+| Runs on an 8 GB consumer GPU | Alexandria (8 GB min), abogen/Audiblez (CPU-class) | Yes | **Free** — it's the shared pillar |
+
+**What none of them have** (verified in the 8 June competitive research): series-level cast memory, automated per-sentence QA with re-record, voice-drift detection, a consent-tracked family-voice library, a paired companion app, a finished non-technical UX, multi-book parallel workflow.
+
+---
+
+## 2. Where Castwright is alone (the gateable surface)
+
+| Capability | Community state | Value pattern | Gate? |
+|---|---|---|---|
+| **Series continuity** — cast memory across books, alias-aware matching, merge, provenance, rebaseline | Nobody (Alexandria is within-book only) | Accumulates with every book; heavy series readers | **Gate** — flagship of the Pass |
+| **Cross-book voice library** — reuse, duplicate review, compare | Nobody | Accumulates | **Gate** |
+| **Family voices (fs-38)** — cloning with consent trail, provenance, reuse rules, on-device guarantee | Raw cloning is free everywhere; the consent/family *experience* is nowhere | Most personal value in the product | **Gate** (the *experience*; raw single-voice cloning stays free) |
+| **Companion app pairing** — sync, offline, resume, CarPlay/Android Auto | None paired to generation (Audiobookshelf is player-only) | Daily-use comfort; real app-store costs | **Gate** — M4B export to any player stays free, so no lock-in |
+| **Multi-book studio** — workspace queue, parallel books, drag reorder | None | Power-user comfort | **Gate** |
+| **A/B revision diff player** | None | Power-user comfort | **Gate** |
+| **QA auto-repair loop** — failed lines re-recorded automatically; one-click drift regeneration | Nobody detects, nobody repairs | Comfort on top of trust | **Gate the automation** — detection and flags stay free |
+| QA *detection* + drift *flags* | Nobody | Trust | **Free** — a broken line a free user can't see hurts the brand more than US$7 |
+| Export (M4B/MP3, anywhere) | Free everywhere | Principle | **Never gated** — "no lock-in" is a non-negotiable |
+
+**The pattern:** free buys you a perfect *book*; the Pass buys you a *library*. One render is the magic trick; the accumulated cast across a series is the relationship — and the only part no one can copy from GitHub this year.
+
+---
+
+## 3. The recommended split, as the user sees it
+
+| | **Free** | **Cast Pass — one-off US$7** |
+|---|---|---|
+| Books | Any book, full cast, no caps, no watermark | Everything in Free |
+| Voices | Catalogue + designed + one personal cloned voice | **Family voices** with consent trail & reuse rules |
+| Series | Each book casts fresh | **Castwright remembers your cast across the series** |
+| Library | Per-book | **Cross-book voice library, merge, provenance, rebaseline** |
+| Quality | Every line checked & flagged; manual re-record | **Auto-repair + one-click drift regeneration** |
+| Listening | Export M4B/MP3 to any player | **Companion app pairing** (sync, offline, resume) |
+| Workflow | One book at a time | **Multi-book queue, A/B diff player** |
+| Updates | All v1.x | All v1.x; future major versions may carry an upgrade pass |
+
+**Brand framing (in the house register):** *"Castwright is free — every book, the full cast, yours to keep. The Cast Pass is seven dollars, once. It keeps the lights on, and it gives your library a memory."* Honest about why the gate exists (sustainability, not rent-seeking) — consistent with Pillar 4: it is the anti-subscription.
+
+---
+
+## 4. Pricing & mechanics
+
+| Question | Recommendation | Rationale |
+|---|---|---|
+| Price | **US$7** (within your 5–10 band) | Below impulse threshold; ~half an Audible month; trivially fair against $132/yr clouds. $5 leaves margin on the table; $9.99 reads like a SaaS trick |
+| Model | One-off, all v1.x updates | Anti-subscription IS the positioning; a recurring fee would contradict Pillar 4 |
+| Sales channel | **Web (Stripe/Paddle), key emailed; never in-app on iOS** | Selling the unlock inside the companion app triggers Apple's 30% + IAP rules; the desktop product unlock sold on castwright.ai avoids it entirely (Paddle handles AU GST/EU VAT as merchant of record) |
+| Enforcement | Light, honour-system licence key; no phone-home DRM | A privacy-first local product cannot phone home to validate licences without breaking its own story. Price below piracy effort; goodwill converts |
+| Series trial | First *returning* cast match in book two works free, then prompts | The user must *hear* the moat before paying for it |
+
+### Sustainability arithmetic (verified 8 June 2026)
+
+| Cost line | US$/yr | Notes |
+|---|---|---|
+| Apple Developer | **99** | Required for the iOS app AND macOS notarisation (Gatekeeper blocks unnotarised apps even off-store). Deferred until a Mac/iOS ship |
+| Windows code signing | **115–139** | **Decided (§4.2): Certum Cloud Code Signing Individual via SSLmentor** — $139/yr, or $115/yr on a 3-yr purchase. Open-source cert ruled out (revocation on commercial use), Azure excludes AU, no Australian CA exists, EV is pointless post-2024. Microsoft Store (Phase 3) sidesteps SmartScreen entirely |
+| Domain (castwright.ai) | **~78** | Actual: A$240 / 2 yr = A$120/yr — normal for `.ai` |
+| Hosting | **~0** | Cloudflare Pages (site) + Workers free tier (licence issuance; 100k req/day) + Paddle-hosted checkout. Workers Paid US$5/mo only if the issuance log outgrows free KV |
+| Google Play | **25 once** | Personal accounts need a ~12-tester closed test before production — the alpha channel already satisfies it |
+| GitHub CI | **~0 once public** | Standard runners on public repos are free and unlimited, incl. macOS — opening the repo zeroes the current private-repo minutes burn (Windows ×2, macOS ×10 multipliers). Interim: self-hosted runner on the dev box for heavy legs (free; per-minute billing for self-hosted postponed indefinitely) or Pro US$4/mo |
+| **Fixed total** | **≈ 300–650/yr** | Signing path decides the band |
+
+**Per-sale cut (variable):** Paddle 5% + US$0.50 → on a US$7 Pass: **$0.85 (~12%), netting ~$6.15**. The $0.50 floor stings at low price points but buys merchant-of-record status (GST/VAT is Paddle's problem). Chargebacks $20 each — noise at this price.
+
+**Break-even ≈ 50–105 passes/yr** at $6.15 net. Anything beyond funds the GPU fund and the languages roadmap. Strategic note: the open-repo decision is also the cost decision — public CI minutes are free, so distribution strategy and cost floor are the same lever.
+
+### 4.1 Why the signing costs exist at all (plain language)
+
+Both Microsoft and Apple treat downloaded software from an unidentified publisher as malware-until-proven-otherwise; the "proof" is a cryptographic signature traceable to a verified real-world identity. That identity verification — not the cryptography — is what the money buys.
+
+- **Windows (SmartScreen).** An unsigned `castwright-setup.exe` triggers the full-screen blue *"Windows protected your PC"* wall, with the proceed button hidden behind "More info." Technical users click through; the non-technical reader Castwright targets — the one who chose it over Alexandria precisely because they can't drive a Python install — reads "protected," assumes virus, deletes. Plausibly a 50%+ funnel kill at the worst possible moment. A signed installer shows a verified publisher name instead, and **reputation accrues to the certificate** with download volume until the prompt disappears entirely. The annual fee exists because the certificate is an expiring identity document, and since 2023 the key must live in tamper-proof hardware or a cloud HSM (hence the price gap between bare and token/cloud options). Note: **EV certificates no longer buy instant SmartScreen reputation** (Microsoft dropped EV special treatment in Aug 2024) — OV is sufficient; EV matters only for kernel drivers.
+- **macOS (Gatekeeper).** Since Catalina, any internet-downloaded app must be **notarised** — uploaded to Apple, scanned, stamped — or macOS refuses to open it (a hard block, not a click-through: *"damaged or can't be checked for malware"*). Notarisation itself is free **but only works from a paid Apple Developer account** — that's gate one of the $99/yr. Gate two: the iOS companion app has no distribution path at all except the App Store, which requires the same membership. One fee, both gates.
+- **Why $0 today:** alpha testers are inside the personal trust radius and have been told to click through. The moment a stranger downloads from a public repo, the OS warning *is* the first impression — and a product whose pillar is "trust me with your books on your machine" cannot open with a malware warning. Windows signing is therefore due at public launch; Apple's fee only when a Mac/iOS build ships.
+
+### 4.2 Windows signing: cheapest viable paths (investigated 8 June 2026)
+
+Constraint: Australian individual (no company), FSL-licensed (source-available, not OSI open source).
+
+| Path | Cost | Eligibility vs constraints | Verdict |
+|---|---|---|---|
+| ~~Certum Open Source Code Signing~~ | ~~€69/€29 renewal~~ | **Ruled out (8 June 2026, per Certum's own terms):** issued only to individuals, CN/Organisation forced to "Open Source Developer" (not Castwright), and — decisive — *"if Certum determines that the certificate is being used to sign software distributed commercially, the certificate will be revoked."* Revocation mid-flight would void SmartScreen trust on every installer already shipped. The Cast Pass makes Castwright commercial distribution; not a grey area | Closed — do not revisit |
+| **Certum Cloud Code Signing INDIVIDUAL (SimplySign) — via SSLmentor** | **US$139/yr · $127/yr on 2-yr ($254) · $115/yr on 3-yr ($345)** (verified 8 June 2026) | The variant purchasable **without a registered entity** (invoice to personal name; SSLmentor claims exclusivity on it). No licence test, key in Certum's cloud HSM, `signtool`-compatible so signing automates inside `release.yml`. Validation: ID + face scan + utility bill, ~3+ business days. Publisher shown to users = personal name, not "Castwright" (needs an entity to change) | **THE pick — [sslmentor.com/certum/certumcodecloudindividual](https://www.sslmentor.com/certum/certumcodecloudindividual)** |
+| Certum Cloud Code Signing (business) via reseller | from ~US$116/yr multi-year ([SSLmentor](https://www.sslmentor.com/certum/certumcodecloud)) | Requires a registered organisation — relevant later if an ABN/entity is set up so the publisher reads "Castwright" | Future upgrade path |
+| Certum direct (shop.certum.eu / certum.store) | €209/yr cloud; €169 set / €139 code (card-based) | Same products, worst prices; card variants mean manual, physically-present signing each release | Reference only — don't |
+| **Australian options** | Sectigo/Comodo OV via AU storefronts ([CodeSignCert AU](https://codesigncert.com/au) ~AU$226+/yr, [SSL2Buy AU](https://www.ssl2buy.com/au/code-signing-certificate) AU$317+, [CheapSSLShop AU](https://www.cheapsslshop.com/au/code-signing-certificates) AU$320–367, [TheSSLStore AU](https://www.thesslstores.com.au/products/code-signing-certificates.aspx) teaser "from $89.54" but code-signing lines actually $135–929/yr) | **No Australian CA issues Windows code-signing certificates** — these are AUD-billing storefronts for the same global CAs, mostly business-validated, with USB tokens shipped. All verified options cost more than the Certum Individual cloud route; Azure (the other cloud option) excludes AU | Closed — AUD invoicing is the only benefit, at a premium |
+| Sectigo/Comodo OV (individual validation) via resellers | ~$200–250/yr + token | Individuals ✔, no licence test | Only if Certum paths both fail |
+| Azure Artifact Signing | ~$120/yr | **Australia not eligible** (orgs US/CA/EU/UK; individuals US/CA) | Re-check at each release; best price-for-product if eligibility expands |
+| SignPath Foundation (free OSS signing service) | $0 | Vets projects for genuine OSS status — FSL likely ineligible *(unverified)* | Low-cost lottery ticket; one email |
+| DigiCert | ~$400+/yr | — | No reason at this scale |
+
+Two regulatory notes that affect all paths: from **March 2026 certificate validity is capped at ~15 months** (460 days) — budget for renewal admin annually regardless of vendor; and multi-year purchases now mean re-issuance under the same order, not a longer-lived certificate.
+
+**Bottom line (decided 8 June 2026):** **Certum Cloud Code Signing Individual via SSLmentor — US$139/yr (or $345/3-yr ≈ $115/yr)**. The open-source route is closed by the commercial Cast Pass (revocation risk), EV buys nothing since Microsoft dropped its SmartScreen advantage (kernel drivers only), card-based variants trade small savings for manual signing every release, and no Australian option exists — local storefronts resell the same global CAs at a premium with shipped tokens. Beats the $200–400 originally budgeted; the Microsoft Store path (Phase 3, $19 once) removes SmartScreen for store-installed users permanently. One adjacent driver: Windows 11's **Smart App Control hard-blocks unsigned apps** (no click-through), strengthening the sign-at-public-launch requirement. Publisher-name note: an individual cert shows "Mikhail Dudarenok" in UAC/SmartScreen prompts — showing "Castwright" requires a registered entity and the business-variant cert; park alongside the §7.1 trade-mark action.
+
+---
+
+## 5. Core risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Gating the spearhead claim** — series consistency is the brand's headline, now behind a gate | The *claim* stays front-and-centre; the gate is one coffee, once. The book-two free taste (above) lets the moat sell itself. Watch alpha-tester reaction before locking |
+| OSS reaches series-memory parity (Alexandria adds a library) | Likely eventually. The Pass bundle never rests on one feature — companion app, family voices, auto-repair, and polish travel together |
+| Honour-system piracy | Accepted by design; the buyer is buying sustainability and the story, not the bits |
+| iOS companion app + paid unlock entanglement | Keep the app free; the Pass unlocks *pairing* server-side (the licence lives in the desktop product, not the app) — re-verify against App Review guidelines before iOS submission |
+| "Free tier is too good" (nobody converts) | That's the strategy: the free tier defeats Alexandria, the Pass converts the readers who finish a series — exactly the users with the most accumulated value |
+
+---
+
+## 6. Action items
+
+1. **Decide** the split, price (US$7), and web-only sales channel — this document is the proposal.
+2. Add the licence/unlock seam to the backlog as a proper item (touches server settings, companion-app pairing, and the series matcher) — needs a `fs-` plan before any implementation.
+3. Test the framing copy on alpha testers alongside the Pillar 4 messaging.
+4. Re-verify the "nobody has series memory" claim at each quarterly competitive refresh (now in `brand-guidelines.md` open items) — the Pass bundle composition should evolve as OSS catches up.
+5. **Engine licence audit before the repo opens or anything is sold** (Section 7.1) — Coqui XTTS v2's CPML is non-commercial: confirm download-on-demand handling; verify Kokoro and Qwen3-TTS weight licences at release versions.
+6. **Repo-opening checklist:** `LICENSE` (FSL-1.1-Apache-2.0) + `brand/LICENSE` carve-out, README source-available statement, secret/history scrub (`.env`, keys, copyrighted fixtures — the canonical Keefe manuscript must not be in git history), DCO/CLA bot, then the licence-key seam as a `fs-` plan.
+
+---
+
+## 7. Distribution & licensing
+
+**The model in one line:** castwright.ai is the front door, GitHub is the warehouse, the licence is source-available (not OSI open source), and the gate is an offline signed key. The public repo is the growth engine — stars are the zero-budget marketing channel this community actually uses (ebook2audiobook ~19k★, Alexandria 580★ and surging), and freemium users arrive through it.
+
+| Layer | Choice | Why |
+|---|---|---|
+| Front door | **castwright.ai** — demo audio, docs, narrative, Cast Pass checkout | Owned channel; the listen-first demo is the conversion moment |
+| Payments | **Paddle** (merchant of record) | Handles AU GST / EU VAT / US sales tax as the seller of record — no tax registrations for a sole operator |
+| Artifact hosting | **GitHub Releases** | Free bandwidth, the community's native discovery surface, Issues as the support channel |
+| Licence | **FSL-1.1-Apache-2.0** (Functional Source License) | Code fully public; competing redistribution barred; each release auto-converts to Apache-2.0 after two years — credible "we mean it" signal |
+| Gate | **Ed25519-signed offline licence key** | No phone-home — the privacy story survives its own business model |
+| Companion app | Free on Google Play (now) / App Store (later); the Pass unlocks *pairing* on the desktop side | Keeps Apple IAP rules and the 30% cut entirely out of scope |
+
+**Brand note:** the README must say plainly that this is source-available, not OSI open source, and why — leading with that honesty is the competitive-register rule applied to ourselves. The repo opening also hands rivals the series-matcher source; accepted, per Section 5 — the moat is the finished product, and from day one the licence (not obscurity) is what bars a competing fork.
+
+### 7.1 Technical: licensing
+
+- **Licence file and scope.** `LICENSE` = FSL-1.1-Apache-2.0 (the Apache future-licence variant). FSL permits any use *except* a competing product/service; after two years each release's code becomes plain Apache-2.0. No per-file headers needed beyond a short banner in `README`.
+- **Carve-outs that must NOT be FSL'd:**
+  - `brand/` (logos, wordmarks, the Castwave mark) — *all rights reserved*, with a `brand/LICENSE` note permitting fair use in articles/reviews. A licence to the code is not a licence to the identity; this is what actually stops a confusing fork, alongside an eventual **trade mark registration for "Castwright"** (AU first via IP Australia, ~AU$250/class self-filed; US later).
+  - Test fixtures derived from copyrighted manuscripts — never commit (already the convention).
+- **Contributions.** Relicensing rights require owning the copyright. Use **DCO sign-offs plus a lightweight CLA** (cla-assistant bot) from the first external PR — retrofitting a CLA after contributors accumulate is painful. Until then, "issues welcome, PRs by invitation" is a legitimate stance.
+- **Engine licence audit (pre-launch blocker).** The product's licence is irrelevant if a bundled model's licence forbids commercial distribution:
+  - **Kokoro** — Apache-2.0 (model + code): safe to bundle. *(Verify at release.)*
+  - **Coqui XTTS v2** — the model weights are under Coqui's **CPML, a non-commercial licence**, and Coqui-the-company wound down: **do not bundle**. Keep XTTS strictly download-on-demand from the original source, with its licence shown at install, positioned as a user-supplied optional engine. *(Risk: a paid Pass adjacent to a CPML model needs a considered position — flag for legal reading.)*
+  - **Qwen3-TTS** — verify the exact model-weight licence (Qwen releases vary between Apache-2.0 and the Qwen licence with use restrictions) before bundling; same download-on-demand fallback if restricted.
+  - Rule of thumb: **the installer may fetch weights from their official home; the release zip bundles nothing whose licence is unverified.**
+
+### 7.2 Technical: key management
+
+- **Key format.** An Ed25519-signed token, human-pasteable: `CW1-<base32(payload)>-<base32(signature)>`. Payload (CBOR/JSON, ~100 bytes): `edition: "cast-pass"`, `major: 1` (entitles all v1.x), `issued: <date>`, `licensee: <name or email hash>`, `order: <Paddle order id>`.
+- **Issuance pipeline (the only cloud component in the entire product):** Paddle checkout → webhook → a single **Cloudflare Worker** holding the private signing key as a secret → derives the key **deterministically from the order id** (reissue = identical key, support becomes a lookup, no licence database needed) → delivered on the receipt page + email. Keep an append-only issuance log (Workers KV) for support audits.
+- **Verification (in-app):** the public key ships embedded in the binary; verify signature + `major` entitlement **offline at startup — no activation, no seat counting, no expiry, no network call ever**. Locked features stay visible with an honest one-line explanation and the price — the locked state *is* the upsell surface.
+- **Key security and rotation:** private key lives only in the Worker secret + an offline backup (password manager / hardware token). The app embeds an **array** of valid public keys so a rotation (or a v2 key) is just an append in a patch release.
+- **Revocation:** at US$7, don't build it. A refunded order's key keeps working until the next release optionally ships a tiny embedded blocklist; chargeback abuse at this price is noise.
+- **Companion-app unlock:** the desktop server validates the local licence and enables pairing endpoints; the mobile app stays free and licence-unaware — nothing for App Review to object to.
+- **Failure honesty (on-brand):** if the key file is missing or corrupt, the app says exactly that and keeps every free feature working. A licence problem must never break a render.
+
+### 7.3 Technical: distribution channel roadmap
+
+| Phase | Channel | Effort | Notes |
+|---|---|---|---|
+| **1 — Launch** | castwright.ai + GitHub Releases | Done by definition | Signed installers; the v1.6.0 rename already forces fresh installs, so launch is the clean break |
+| 1 | **Pinokio** listing | Low (one JSON script) | Where Alexandria's users one-click install — meet the kin where they live |
+| **2 — Stabilised releases** | **winget** (manifest PR), **Scoop** bucket | Low | Windows dev-adjacent reach; free |
+| 2 | **Homebrew cask** | Low | macOS reach once the cross-OS verify is routine |
+| 2 | **GHCR Docker image** (headless server) | Medium | The r/selfhosted + Audiobookshelf crowd; pairs with the companion app story |
+| **3 — Trust surfaces** | **Microsoft Store** (MSIX) | Medium (US$19 once) | Auto-update + SmartScreen trust for non-technical Windows users — the audience the OSS tools can't reach |
+| 3 | **Flathub / AUR** | Medium | Linux credibility; AUR will likely appear community-made once the repo is public — adopt rather than fight it |
+| 3 | **Umbrel / CasaOS app stores** | Low-medium | Self-hosted appliance audience (OpenReader precedent) |
+| Companion | Google Play (now) → Apple App Store (with iOS release) → **F-Droid** (open repo makes it possible) | Per store | F-Droid listing is a privacy-community trust signal money can't buy |
+| **Skip** | Steam, itch.io, Gumroad, Setapp | — | Wrong audiences or duplicate of Paddle |
+
+**Sequencing rule:** a channel earns its slot only when its update path is automated in the release flow (`release.yml`) — every manual-upload channel is a future stale-version complaint.
+
+---
+
+## Sources
+
+Internal: `brand/competitive-brief-2026-06-08.md` (all competitor capability and pricing claims, researched 8 June 2026) · `brand/brand-guidelines.md` (Pillar 4, competitive register) · `docs/project-narrative.md` (non-negotiables: no lock-in, privacy by default, mid-market hardware).
+External pricing reference points: ElevenLabs Reader Ultra $11/mo · Speechify ~$139/yr · MyNarratorAI $5–25/mo · Audibloom $39/mo or $29/book · Spoken ~$200/novel · OSS free — see the competitive brief's source list for URLs.
+Signing & infrastructure (verified 8 June 2026): [Certum Open Source Code Signing](https://certum.store/open-source-code-signing-code.html) · [Certum required documents](https://support.certum.eu/en/code-signing-required-documents/) · [first-hand Certum OSS write-up (Oct 2025)](https://piers.rocks/2025/10/30/certum-open-source-code-sign.html) · [Certum SimplySign via SSLmentor](https://www.sslmentor.com/certum/certumcodecloud) · [Azure Artifact Signing pricing](https://azure.microsoft.com/en-us/pricing/details/artifact-signing/) · [Azure eligibility FAQ](https://learn.microsoft.com/en-us/azure/artifact-signing/faq) · [SSL Insights provider comparison 2026](https://sslinsights.com/best-code-signing-certificate-providers/) · [GitHub Actions 2026 pricing](https://github.com/resources/insights/2026-pricing-changes-for-github-actions) · [Paddle pricing](https://www.paddle.com/pricing)

--- a/docs/project-narrative.md
+++ b/docs/project-narrative.md
@@ -2,7 +2,7 @@
 
 **Many voices, one machine.**
 
-_A project narrative — named & updated 7 June 2026_
+_A project narrative — named 7 June, updated 8 June 2026_
 
 **Estimated read time:** 6 minutes for the narrative; 7 more for the functional and technical sections below.
 **What this is:** The story behind **Castwright** — _any book, performed by a full cast; effortlessly, even in your own voice._ Why fiction listening is broken, what fixes it, and where the product stands today. A functional section and a technical section sit below the narrative for design and engineering conversations. I refresh this every couple of days, so the dates and the state are honest at the top.
@@ -29,7 +29,9 @@ Nothing on that list does what fiction actually demands.
 
 Fiction has a cast. Fiction has tone — a character is angry in this paragraph, broken in the next, deadpan three pages later. Fiction has narration that should _recede_ when dialogue is happening and step forward when describing a sunset. Reading aloud is a performance, and what we have is dictation.
 
-The reason nobody's built it isn't that the technology is missing. It's that the conventional path costs too much. Render every audiobook in the cloud, with frontier-model orchestration on every chapter, and you've priced out anyone who isn't a streaming service. The interesting question isn't _can it be done_ — it's _can it be done on a machine someone already owns_.
+This past year the gap started to close — from the other side, and it's worth being honest about. Full-cast AI narration exists now: author-side studios sell it by the word in the cloud, and a handful of open-source projects do it locally for anyone comfortable with a Python install. The wave proves the appetite. But every one of them either sells to the rights-holder rather than the reader, meters the render through someone else's server, or forgets the cast the moment the book ends. Nobody builds the performance for the _reader_ — for the book you already own, on the machine already under your desk, with a cast that's still the same people in book five.
+
+The reason it hasn't reached readers isn't that the technology is missing. It's that the conventional path costs too much. Render every audiobook in the cloud, with frontier-model orchestration on every chapter, and you've priced out anyone who isn't a streaming service. The interesting question isn't _can it be done_ — it's _can it be done on a machine someone already owns_.
 
 That's the bet I'm taking.
 


### PR DESCRIPTION
## Summary

Doc-only branding update. Adds two new strategy briefs and threads their conclusions back into the brand voice docs:

- **`brand/competitive-brief-2026-06-08.md`** (new) — the 2026-06 landscape (cloud author-side studios, ElevenLabs Reader, the local OSS wave) and what it means for our claims.
- **`brand/monetisation-free-vs-gated-2026-06-08.md`** (new) — free-vs-gated analysis, including the Windows code-signing decision (Certum Cloud Code Signing Individual via SSLmentor).
- **`brand/brand-guidelines.md`** — positioning anchor, series-consistency as the spearhead claim, proof points, and the competitive register for how we speak about clouds / OSS / human narrators.
- **`docs/project-narrative.md`** — honest framing of the full-cast AI wave; date refresh.

## Test plan

Doc-only change (`brand/**`, `docs/**`) — no code paths touched, no automated tests apply. CI skips `verify.yml` for doc-only PRs via `paths-ignore`.