### PR TITLE
feat(frontend): /about brand page + error-boundary brand polish

### DIFF
--- a/docs/superpowers/plans/2026-06-08-castwright-wave3-about.md
+++ b/docs/superpowers/plans/2026-06-08-castwright-wave3-about.md
@@ -1,0 +1,67 @@
+# Castwright Wave 3 — /about brand page + error-copy polish (plan)
+
+> REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** A dedicated `#/about` brand page (Castwave mark, primary tagline, manifesto, castwright.ai link, app version), linked from Admin; plus a light brand-voice polish of the top-level error boundary. **Descoped:** a broad toast-copy rewrite — existing toast/error strings already follow the brand voice (functional, no AI hype); rewriting them all is low-value churn (CLAUDE.md "surgical changes"). Noted in the PR.
+
+**Source of truth:** `docs/superpowers/specs/2026-06-08-castwright-brand-full-pass-design.md` (Wave 3). Precedent for a standalone route: the Model Manager (`#/models`).
+
+Brand strings (verbatim):
+- Primary tagline (FIXED): `Any book, performed by a full cast — effortlessly. Even in your own voice.`
+- Manifesto: `Many voices, one machine.`
+- Story line: `Castwright turns a book into a full-cast performance — and keeps each voice true from book one to the last. Even in your own voice.`
+- Domain link: `https://castwright.ai` (label `castwright.ai`)
+
+---
+
+## Task 1 — `#/about` route plumbing + view + Admin link
+
+Mirror the Model Manager wiring EXACTLY (it's the working precedent).
+
+**Files:**
+- `src/lib/types.ts` (the `Stage` discriminated union) — add `{ kind: 'about' }`.
+- `src/lib/router.ts` — `stageToHash`: add `case 'about': return '#/about';`; `parseHash`: map `#/about` → `{ kind: 'about' }` (mirror the `models`→`model-manager` mapping).
+- `src/store/ui-slice.ts` — add reducer `openAbout: (s) => { s.stage = { kind: 'about' }; }` (mirror `openModelManager`, ~line 160).
+- `src/routes/index.tsx` — lazy import `AboutView` (mirror `ModelManagerView` ~line 69); add `function AboutRoute() { useHydrateStage({ kind: 'about' }, []); return <AboutView />; }` (mirror `ModelManagerRoute` ~line 326); register `{ path: 'about', element: <AboutRoute /> }` (mirror ~line 922).
+- Create `src/views/about.tsx` — `export function AboutView()`. Mirror `model-manager.tsx` structure: `<div className="max-w-[960px] mx-auto px-4 sm:px-6 py-10">`, a `SectionLabel` ("About"), a `MixedHeading regular="About" bold="Castwright" level="h1"`. Then content (`space-y-6`):
+  - Big `<CastwaveMark className="w-16 h-16 text-magenta" aria-hidden="true" />` (import from `../lib/icons`).
+  - Primary tagline in serif, prominent: `<p className="font-serif text-xl text-ink">Any book, performed by a full cast — effortlessly. Even in your own voice.</p>`.
+  - Manifesto: `<p className="text-ink/60">Many voices, one machine.</p>`.
+  - Story paragraph (the story line above) in `text-ink/70 max-w-prose`.
+  - External link: `<a href="https://castwright.ai" target="_blank" rel="noreferrer" className="text-magenta font-medium hover:underline">castwright.ai</a>`.
+  - App version: `import { buildInfo } from '../lib/build-info'` → show `Castwright v{buildInfo.version} ({buildInfo.sha})` in `text-xs text-ink/50`.
+  - A back link to the library (mirror however model-manager returns; if it relies on the top-bar back, add a simple `<button onClick={() => dispatch(uiActions...)}>← Back</button>` only if model-manager has one — otherwise omit and rely on the top bar).
+- `src/views/admin.tsx` — add an `AboutLink` section mirroring `ModelManagerLink` (~line 119-149): heading "About Castwright", a one-line description, a button `onClick={() => dispatch(uiActions.openAbout())}` with `data-testid="admin-open-about"` and label "About Castwright →".
+
+**Tests (TDD):**
+- `src/views/about.test.tsx`: renders the primary tagline, the manifesto, the `castwright.ai` link (href), and the version (`buildInfo.version`).
+- Router: if `src/lib/router.test.ts` exists, add `stageToHash({kind:'about'}) === '#/about'` and `parseHash('#/about')` round-trip; else add a `ui-slice` test that `openAbout` sets `stage.kind === 'about'`.
+- `src/views/admin.test.tsx`: the `admin-open-about` button dispatches `openAbout` (stage becomes about). Mirror the existing `admin-open-model-manager` test.
+
+**Verify:** `npm test -- about admin router ui-slice` green; `npm run typecheck` clean (Stage union exhaustiveness — make sure any `switch` over `stage.kind` that must handle all variants still compiles; if a switch needs an `about` case, add it minimally).
+
+**Commit:** `feat(frontend): /about brand page (Castwave mark, tagline, version) linked from Admin`.
+
+## Task 2 — Error-boundary brand-voice polish (light)
+
+**File:** `src/components/error-boundary.tsx` + `error-boundary.test.tsx`.
+
+- The current heading "The Generate screen hit a render error." is oddly specific (it's the app-wide boundary). Make it general + on-brand-calm:
+  - Eyebrow: keep `Something broke` (fine) OR `Something went sideways` (dry, on-brand). Use `Something went sideways`.
+  - Heading: `Castwright hit a snag rendering this screen.`
+  - Body: keep the existing reassurance ("Your work is still safe on disk. …") — it's already on-voice; leave it.
+  - Button: keep `Try again`.
+- TDD: update `error-boundary.test.tsx`'s copy assertion to the new heading/eyebrow; keep the reset-button test green.
+
+**Commit:** `feat(frontend): brand-voice polish on the error boundary`.
+
+## Task 3 — Verify + PR
+
+- [ ] `npm run verify` green.
+- [ ] Add one Playwright assertion: navigating to `#/about` shows the tagline (small new spec or extend an existing one). Keep e2e green.
+- [ ] Push `feat/castwright-about-voice`; `gh pr create` with `Refs #631` (Wave 3, final wave); body links spec + plan and notes the descoped toast rewrite.
+
+## Notes
+- Reuse `<CastwaveMark/>` (magenta); do not inline SVGs.
+- Mirror the model-manager route wiring precisely — don't invent a new routing mechanism.
+- Keep the look consistent with model-manager (same container/heading pattern).

--- a/e2e/about-page.spec.ts
+++ b/e2e/about-page.spec.ts
@@ -1,0 +1,16 @@
+/* Wave 3 — /about brand page renders the primary tagline.
+
+   AboutView renders the Castwright tagline in a <p> scoped to the
+   /about route. The locator targets the tagline text directly so it
+   survives layout changes; it does NOT match the top-bar wordmark
+   (which contains only "Castwright", not the full tagline sentence). */
+
+import { test, expect } from '@playwright/test';
+
+test('/about renders the brand tagline', async ({ page }) => {
+  await page.goto('/#/about');
+
+  await expect(
+    page.getByText('Any book, performed by a full cast', { exact: false }),
+  ).toBeVisible({ timeout: 10_000 });
+});

--- a/src/components/error-boundary.test.tsx
+++ b/src/components/error-boundary.test.tsx
@@ -46,6 +46,8 @@ describe('ErrorBoundary', () => {
         </ErrorBoundary>,
       );
       expect(screen.getByRole('alert')).toBeTruthy();
+      expect(screen.getByText(/Something went sideways/)).toBeTruthy();
+      expect(screen.getByText(/Castwright hit a snag rendering this screen\./)).toBeTruthy();
       expect(screen.getByText(/reducer crashed on a tick/)).toBeTruthy();
       expect(screen.getByRole('button', { name: /try again/i })).toBeTruthy();
     } finally {

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -38,9 +38,9 @@ export class ErrorBoundary extends Component<Props, State> {
         <div className="max-w-lg w-full bg-white rounded-3xl border border-ink/10 p-8 space-y-5">
           <div className="space-y-1.5">
             <p className="text-xs uppercase tracking-wider text-ink/50 font-semibold">
-              Something broke
+              Something went sideways
             </p>
-            <h1 className="text-2xl font-bold text-ink">The Generate screen hit a render error.</h1>
+            <h1 className="text-2xl font-bold text-ink">Castwright hit a snag rendering this screen.</h1>
             <p className="text-sm text-ink/70">
               Your work is still safe on disk. Click below to re-render the page without losing your
               session. If the error keeps coming back, copy the message and check the dev console

--- a/src/lib/router.test.ts
+++ b/src/lib/router.test.ts
@@ -30,6 +30,10 @@ describe('stageToHash', () => {
     expect(stageToHash({ kind: 'model-manager' })).toBe('#/models');
   });
 
+  it('about → #/about', () => {
+    expect(stageToHash({ kind: 'about' })).toBe('#/about');
+  });
+
   it('analysing with bookId → #/books/:id/analysing', () => {
     expect(stageToHash({ kind: 'analysing', bookId: 'ns', manuscriptId: null })).toBe(
       '#/books/ns/analysing',

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -34,6 +34,8 @@ export function stageToHash(stage: Stage | null | undefined): string {
       return '#/admin';
     case 'model-manager':
       return '#/models';
+    case 'about':
+      return '#/about';
     case 'analysing':
       return stage.bookId ? `#/books/${stage.bookId}/analysing` : '#/new';
     case 'confirm': {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -721,4 +721,6 @@ export type Stage =
   /* fs-23 — In-app Model Manager. Top-level view (like account/admin), reached
      from the Admin view. Consolidates all model install/inventory/residency
      controls that used to live in the Account view. */
-  | { kind: 'model-manager' };
+  | { kind: 'model-manager' }
+  /* Wave 3 — /about brand page, reached from the Admin view. */
+  | { kind: 'about' };

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -69,6 +69,9 @@ const AdminView = lazy(() =>
 const ModelManagerView = lazy(() =>
   import('../views/model-manager').then((m) => ({ default: m.ModelManagerView })),
 );
+const AboutView = lazy(() =>
+  import('../views/about').then((m) => ({ default: m.AboutView })),
+);
 import { ChapterExclusionList } from '../components/chapter-exclusion-list';
 import { isLikelyFrontMatter, chapterSlug } from '../lib/chapter-heuristics';
 import type { Character, Stage, View } from '../lib/types';
@@ -326,6 +329,12 @@ function AdminRoute() {
 function ModelManagerRoute() {
   useHydrateStage({ kind: 'model-manager' }, []);
   return <ModelManagerView />;
+}
+
+/* Wave 3 — /about brand page, reached from the Admin view. */
+function AboutRoute() {
+  useHydrateStage({ kind: 'about' }, []);
+  return <AboutView />;
 }
 
 export function ChangelogRoute() {
@@ -920,6 +929,7 @@ export const router = createHashRouter([
       /* Inbound alias for old dev bookmarks; stageToHash canonicalises to #/admin. */
       { path: 'worktrees', element: <AdminRoute /> },
       { path: 'models', element: <ModelManagerRoute /> },
+      { path: 'about', element: <AboutRoute /> },
       { path: 'books/:bookId/analysing', element: <AnalysingRoute /> },
       { path: 'books/:bookId/confirm', element: <ConfirmRoute /> },
       { path: 'books/:bookId/:view', element: <ReadyRoute /> },

--- a/src/store/ui-slice.test.ts
+++ b/src/store/ui-slice.test.ts
@@ -306,3 +306,11 @@ describe('uiSlice — regenerate-modal scope override', () => {
     expect(s.regenInitialScope).toBeNull();
   });
 });
+
+
+describe('uiSlice — openAbout', () => {
+  it('openAbout sets stage.kind to about', () => {
+    const s = uiSlice.reducer(baseState({ kind: 'books' }), uiActions.openAbout());
+    expect(s.stage.kind).toBe('about');
+  });
+});

--- a/src/store/ui-slice.ts
+++ b/src/store/ui-slice.ts
@@ -160,6 +160,10 @@ export const uiSlice = createSlice({
     openModelManager: (s) => {
       s.stage = { kind: 'model-manager' };
     },
+    /* Wave 3 — /about brand page, reached from the Admin view. */
+    openAbout: (s) => {
+      s.stage = { kind: 'about' };
+    },
     startNewBook: (s) => {
       s.stage = { kind: 'upload' };
     },

--- a/src/views/about.test.tsx
+++ b/src/views/about.test.tsx
@@ -1,0 +1,50 @@
+/* Task 1 — /about brand page. TDD tests run before the view exists.
+   Regression: the About page must show the primary tagline, manifesto,
+   the castwright.ai link, and the app version so the brand identity
+   is always reachable from Admin. */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { uiSlice } from '../store/ui-slice';
+import { AboutView } from './about';
+import { buildInfo } from '../lib/build-info';
+
+function renderAbout() {
+  const store = configureStore({ reducer: { ui: uiSlice.reducer } });
+  return render(
+    <Provider store={store}>
+      <AboutView />
+    </Provider>,
+  );
+}
+
+describe('AboutView', () => {
+  it('renders the primary tagline', () => {
+    renderAbout();
+    expect(
+      screen.getByText(
+        /Any book, performed by a full cast — effortlessly\. Even in your own voice\./,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the manifesto', () => {
+    renderAbout();
+    expect(screen.getByText(/Many voices, one machine\./)).toBeInTheDocument();
+  });
+
+  it('renders the castwright.ai external link with the correct href', () => {
+    renderAbout();
+    const link = screen.getByRole('link', { name: /castwright\.ai/i });
+    expect(link).toHaveAttribute('href', 'https://castwright.ai');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer');
+  });
+
+  it('renders the app version string', () => {
+    renderAbout();
+    expect(screen.getByText(new RegExp(`Castwright v${buildInfo.version}`))).toBeInTheDocument();
+  });
+});

--- a/src/views/about.tsx
+++ b/src/views/about.tsx
@@ -1,0 +1,48 @@
+/* Wave 3 — /about brand page.
+   Reached from the Admin view (#/about). Mirrors the Model Manager layout
+   (same container / heading pattern). */
+
+import { SectionLabel, MixedHeading } from '../components/primitives';
+import { CastwaveMark } from '../lib/icons';
+import { buildInfo } from '../lib/build-info';
+
+export function AboutView() {
+  return (
+    <div className="max-w-[960px] mx-auto px-4 sm:px-6 py-10">
+      <div className="mb-8">
+        <SectionLabel>About</SectionLabel>
+        <div className="mt-4">
+          <MixedHeading regular="About" bold="Castwright" level="h1" />
+        </div>
+      </div>
+
+      <div className="space-y-6">
+        <CastwaveMark className="w-16 h-16 text-magenta" aria-hidden="true" />
+
+        <p className="font-serif text-xl text-ink">
+          Any book, performed by a full cast — effortlessly. Even in your own voice.
+        </p>
+
+        <p className="text-ink/60">Many voices, one machine.</p>
+
+        <p className="text-ink/70 max-w-prose">
+          Castwright turns a book into a full-cast performance — and keeps each voice true from book
+          one to the last. Even in your own voice.
+        </p>
+
+        <a
+          href="https://castwright.ai"
+          target="_blank"
+          rel="noreferrer"
+          className="inline-block text-magenta font-medium hover:underline"
+        >
+          castwright.ai
+        </a>
+
+        <p className="text-xs text-ink/50">
+          Castwright v{buildInfo.version} ({buildInfo.sha})
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/views/admin.test.tsx
+++ b/src/views/admin.test.tsx
@@ -154,6 +154,15 @@ describe('AdminView — model manager link (fs-23)', () => {
   });
 });
 
+describe('AdminView — about link', () => {
+  it('opens the About page when the link is clicked', async () => {
+    const { store } = renderAdmin();
+    const link = await screen.findByTestId('admin-open-about');
+    link.click();
+    expect(store.getState().ui.stage.kind).toBe('about');
+  });
+});
+
 describe('AdminView — dev-only worktrees gating', () => {
   it('renders the worktrees section in dev (import.meta.env.DEV true)', async () => {
     // vitest runs with DEV === true by default.

--- a/src/views/admin.tsx
+++ b/src/views/admin.tsx
@@ -116,6 +116,7 @@ export function AdminView() {
         no logs required.
       </p>
 
+      <AboutLink />
       <ModelManagerLink />
       <HealthBoard />
       <GenerationThroughput stats={stats} />
@@ -146,6 +147,29 @@ function ModelManagerLink() {
         className="shrink-0 min-h-[44px] sm:min-h-0 px-4 py-2 rounded-xl bg-ink text-canvas text-sm font-medium hover:bg-ink-soft"
       >
         Open Model Manager →
+      </button>
+    </section>
+  );
+}
+
+/* Wave 3 — entry point to the /about brand page. */
+function AboutLink() {
+  const dispatch = useAppDispatch();
+  return (
+    <section className="mb-6 rounded-2xl border border-ink/10 bg-white p-5 shadow-card flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <h3 className="text-base font-semibold text-ink">About Castwright</h3>
+        <p className="mt-1 text-xs text-ink/55 max-w-prose">
+          Brand story, tagline, and app version.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={() => dispatch(uiActions.openAbout())}
+        data-testid="admin-open-about"
+        className="shrink-0 min-h-[44px] sm:min-h-0 px-4 py-2 rounded-xl bg-ink text-canvas text-sm font-medium hover:bg-ink-soft"
+      >
+        About Castwright →
       </button>
     </section>
   );


### PR DESCRIPTION
## Summary

Wave 3 (final) of the Castwright brand pass:
- **`#/about` brand page** — Castwave mark, primary tagline, "Many voices, one machine." manifesto, castwright.ai link, app version. Wired like the Model Manager route; linked from Admin.
- **Error-boundary brand-voice polish** — calmer general copy, keeps the "your work is safe on disk" reassurance + Try again.

Descoped: a broad toast-copy rewrite (existing copy already on-voice — CLAUDE.md surgical changes).

Spec: docs/superpowers/specs/2026-06-08-castwright-brand-full-pass-design.md (Wave 3)
Plan: docs/superpowers/plans/2026-06-08-castwright-wave3-about.md

Refs #631

## Test plan
All verify legs green (lint, typecheck, unit/integration, e2e 157/157, e2e:visual, build). New about/router/ui-slice/admin/error-boundary tests + a Playwright assertion for #/about. (One e2e run hit a webServer-startup flake — ERR_CONNECTION_REFUSED on all specs — confirmed green on a clean re-run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)