### PR TITLE
docs(docs): v1.7.0 public-readiness docs + licensing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -454,9 +454,8 @@ title check.
 
 A PR whose changed-file set lives entirely under `docs/**`, root-level
 `*.md` (`README.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `CHANGELOG.md`), or
-`.github/*.md` (e.g. `.github/pull_request_template.md`) skips both
-[`verify.yml`](.github/workflows/verify.yml) and
-[`e2e-mobile.yml`](.github/workflows/e2e-mobile.yml) via `paths-ignore`.
+`.github/*.md` (e.g. `.github/pull_request_template.md`) skips
+[`verify.yml`](.github/workflows/verify.yml) via `paths-ignore`.
 The PR still requires a valid title (`pr-title-lint.yml` runs on every
 PR) and GitHub's native `mergeable` status still surfaces conflicts —
 the gate stays "PR required + title valid + no conflicts", just without

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,26 @@ soft convention.
 - Long-running parallel work goes in a `git worktree`, not a second clone. Reconcile multiple agent branches via an `integration/<date>` branch with `npm run verify` between merges.
 - `main` is always shippable. `npm run verify` is the pre-push gate.
 
+## Contributing & licensing
+
+Castwright is **source-available under the Functional Source License**
+(FSL-1.1-ALv2, a.k.a. FSL-1.1-Apache-2.0) — not OSI open source. See
+[`LICENSE`](LICENSE); the [README license section](README.md#license) explains
+the model in one paragraph. The `brand/` assets are **not** covered by the code
+licence — all rights reserved ([`brand/LICENSE`](brand/LICENSE)).
+
+**Posture today: issues welcome, PRs by invitation.** Until the CLA tooling is in
+place, please open an issue to discuss a change before sending a PR.
+
+**When external PRs open up,** two things will be required on every contribution:
+
+- **DCO sign-off** — add `Signed-off-by: Your Name <you@example.com>` to each
+  commit (`git commit -s`), certifying you wrote the change and may submit it
+  under the project licence.
+- **A lightweight CLA** — so the maintainer retains the right to relicense (the
+  FSL future-grant and any relicensing depend on owning the copyright). This will
+  be collected by a CLA bot; see [`docs/licensing.md`](docs/licensing.md).
+
 ## Branching model
 
 Trunk-based with short-lived feature branches, isolated per agent via worktrees.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -148,6 +148,45 @@ Sidecar will fall back to CPU and log it. Verify `nvidia-smi` works at the OS le
 
 ---
 
+## Configuration
+
+The server reads `server/.env` (copied from `server/.env.example` in the install
+steps above). All knobs have safe defaults — set only what you need.
+
+**Analyzer**
+
+- `ANALYZER` — `local` (default, Ollama) or `gemini`.
+- `GEMINI_API_KEY` — required when `ANALYZER=gemini` (or as the automatic
+  fallback when Ollama is unreachable).
+- `GEMINI_MODEL` — the Gemini model id; plus per-model `GEMINI_RPM_*` /
+  `GEMINI_TPM_*` / `GEMINI_RPD_*` rate caps (see `server/.env.example`).
+- `ANALYZER_PHASE0_MODEL` / `ANALYZER_PHASE1_MODEL` /
+  `ANALYZER_PHASE1_MIN_LAG_CHAPTERS` — optional two-model analyzer (cast
+  detection + sentence attribution in parallel). Set both phase vars to enable.
+
+**Generation & TTS**
+
+- `WORKSPACE_DIR` — where your per-book library lives (set this to a writable
+  folder).
+- `GEN_WORKERS` — how many chapters synthesise at once (default `2`).
+- `GPU_VRAM_BUDGET` — VRAM-weighted GPU budget in GiB (default `8`). Drop to `6`
+  on a 6 GB card.
+- `PRELOAD_COQUI` — `0` (default; Coqui loads on demand) or `1`.
+- `QWEN_BATCH_SIZE` (default `8`) and `QWEN_ATTN_IMPL` (default `sdpa`) — Qwen
+  tuning knobs.
+- `AUDIO_LOUDNORM_ENABLED` — `true` (default; two-pass EBU R128 at
+  -16 LUFS / 11 LU / -1.5 dBTP) or `false` to opt out.
+
+**LAN / companion access**
+
+- `LAN_HTTPS` — `1` serves over mkcert-backed HTTPS on `:8443`, bound on all
+  interfaces (phone/tablet web + the Android companion). Off by default;
+  `npm run start:lan` sets it. Requires the LAN cert
+  (`npm run install:cert-mobile`); with `LAN_HTTPS=1` the server refuses to start
+  if the cert is missing.
+- `LAN_AUTH_TOKEN` — the shared pairing secret for the companion (and the LAN
+  access guard on `/api` + `/workspace`). Required for the companion app.
+
 ## Setting up the analyzer
 
 The install bundle ships Kokoro weights for TTS only — the analyzer needs either a local Ollama daemon or a Gemini API key. The server-side default is `ANALYZER=local` (Ollama); if no Ollama daemon is reachable, the analyzer auto-falls back to the Gemini free tier when a key is configured.
@@ -163,7 +202,7 @@ Or the manual path: install Ollama from <https://ollama.com>, `ollama pull qwen3
 
 **Option B — Gemini (cloud, free tier).** Get a key from <https://aistudio.google.com>, paste it into **Account → Server configuration → Gemini API key**. Engine selection follows from the model picker — pick any Gemini model in **Defaults for new books → Analysis model**. Save. The key persists to your per-user settings file `~/.castwright/user-settings.json` (plaintext, same trust model as `server/.env`).
 
-**Option C — Pipelined two-model split (v1.4.0).** For long books: Phase 0 (cast detection) runs on Gemma while Phase 1 (sentence attribution) runs on Gemini Flash in parallel, hitting independent rate-limit buckets so effective quota nearly doubles. Configure under **Account → Defaults for new books → Phase 0 model + Phase 1 model + Min-lag chapters** (default 10), or set `ANALYZER_PHASE0_MODEL` / `ANALYZER_PHASE1_MODEL` / `ANALYZER_PHASE1_MIN_LAG_CHAPTERS` in `server/.env`.
+**Option C — Pipelined two-model split.** For long books: Phase 0 (cast detection) runs on Gemma while Phase 1 (sentence attribution) runs on Gemini Flash in parallel, hitting independent rate-limit buckets so effective quota nearly doubles. Configure under **Account → Defaults for new books → Phase 0 model + Phase 1 model + Min-lag chapters** (default 10), or set `ANALYZER_PHASE0_MODEL` / `ANALYZER_PHASE1_MODEL` / `ANALYZER_PHASE1_MIN_LAG_CHAPTERS` in `server/.env`.
 
 ## Switching TTS to Coqui XTTS v2 (alternate, on-device)
 
@@ -171,7 +210,7 @@ Or the manual path: install Ollama from <https://ollama.com>, `ollama pull qwen3
 2. **TTS model** → "Coqui XTTS v2".
 3. Save. The first chapter generation triggers a one-time ~2 GB model download.
 
-## Switching TTS to Qwen3-TTS (v1.5.0, bespoke per-character voices)
+## Switching TTS to Qwen3-TTS
 
 Qwen3-TTS designs a unique voice per character from the cast persona instead of picking from a preset catalogue — only two English Qwen speakers exist upstream, so the app caches each designed voice's embedding and reuses it across the book and series for vocal consistency. This is the v1.5.0 headline TTS engine and **becomes the default for new books once it's installed** (until then, and on any box without it, books render in Kokoro). It is **NOT** auto-downloaded with the Kokoro / Coqui paths — it needs a one-time install of the Python package + model weights (~5 GB).
 
@@ -209,7 +248,7 @@ The key is stored plaintext in `~/.castwright/user-settings.json` (per-user, sam
 
 ---
 
-## Picking a chapter audio format (v1.4.0)
+## Picking a chapter audio format
 
 Chapter audio defaults to MP3 VBR V2. Two newer codecs are available per-book under **Listen view → metadata editor → Audio format** or in the export modal:
 
@@ -223,7 +262,7 @@ Loudness normalization (EBU R128, two-pass, targeting -16 LUFS / 11 LU / -1.5 dB
 
 ---
 
-## Mobile + tablet access over LAN HTTPS (v1.4.0)
+## Mobile + tablet access over LAN HTTPS
 
 The app drives on phone + tablet via LAN HTTPS using `mkcert` so iOS / Android trust the cert without browser warnings. One-time setup per dev box:
 
@@ -257,56 +296,34 @@ Build/sideload instructions for the app live in [`apps/android/README.md`](apps/
 
 ## Updating
 
-From **v1.6.0 onward, upgrading is one click in the Account tab** — open **Account → Application updates**, pick the new `castwright-vX.Y.Z.zip`, confirm the version delta, and the app stages, validates, swaps, reinstalls deps, migrates your book data (with an automatic backup first), and restarts itself. No terminal commands.
+Upgrading is one click in the app: open **Account → Application updates**, pick
+the new `castwright-vX.Y.Z.zip`, confirm the version delta, and the app stages,
+validates, swaps, reinstalls dependencies, migrates your book data (with an
+automatic backup first), and restarts itself. No terminal commands.
 
-This works because 1.6.0 introduces a **versioned-directory layout**: each release lives in its own `releases/vX.Y.Z/` folder, a stable `launch.mjs` at the install root always runs the current one, and your data lives in shared siblings outside the release folders. An upgrade extracts the new release into a *fresh* folder and only flips a pointer once it's ready — the running version is never touched, so a failed upgrade just keeps running the old one.
+This works because Castwright uses a **versioned-directory layout**: each release
+lives in its own `releases/vX.Y.Z/` folder, a stable `launch.mjs` at the install
+root always runs the current one, and your data lives in shared siblings outside
+the release folders. An upgrade extracts the new release into a *fresh* folder and
+only flips a pointer once it's ready — the running version is never touched, so a
+failed upgrade just keeps running the previous one. A fresh install already ships
+this machinery, so there is nothing to convert.
 
 ```
 <install>/
   launch.mjs            <- start the app from here (shortcut / start-app.bat points at it)
-  .current-version      <- "1.6.0"
-  releases/v1.6.0/      <- the code (one extracted zip)
+  .current-version      <- e.g. "1.7.0"
+  releases/v1.7.0/      <- the code (one extracted zip)
   workspace/            <- your library (books, voices)
-  venv/  models/kokoro/ <- shared python venv + ~330 MB Kokoro weights
+  venv/  models/kokoro/ <- shared Python venv + Kokoro weights
   logs/  .run/
 ```
 
-### One-time conversion when you adopt v1.6.0 (from v1.5.x)
-
-A v1.5.x install is a single flat checkout with none of this machinery, so the **jump into 1.6.0 is still manual** — run the bundled converter once:
-
-1. `npm run stop:prod` in your existing v1.5.x folder.
-2. Download and extract `castwright-v1.6.0.zip` to a temporary folder.
-3. From the extracted folder, dry-run the converter (prints exactly what it will move):
-   ```
-   node scripts/setup-versioned-install.mjs --install <new-install-dir> --from <old-v1.5.x-dir>
-   ```
-4. Re-run with `--apply` to execute. It creates `<new-install-dir>/releases/v1.6.0/`, writes the pointer, places `launch.mjs` at the root, and **moves** (not re-downloads) your `audiobook-workspace`, the sidecar `.venv`, and the Kokoro weights into the shared siblings.
-5. Start the app: `node <new-install-dir>/launch.mjs`.
-
-Your account settings live in `~/.castwright/user-settings.json` (outside any install folder) and carry over automatically; copy your old `server/.env` into `releases/v1.6.0/server/.env` if you had custom keys.
-
-**After this one-time step, every later upgrade is the one-click Account flow above** — the first self-upgrade you'll experience is 1.6.0 → 1.7.0. (1.6.0 ships the mechanism; it can't upgrade *into* itself.)
+Your account settings live in `~/.castwright/user-settings.json` (outside any
+install folder) and carry over automatically; copy your old `server/.env` into
+`releases/vX.Y.Z/server/.env` if you set custom keys.
 
 ### Manual fallback (any version)
 
 The in-app flow is just orchestration — you can always swap by hand: `npm run stop:prod`, extract the new release into a new `releases/vX.Y.Z/`, set `.current-version`, `npm ci && npm --prefix server ci`, then `node launch.mjs`. Your `workspace/`, `venv/`, and `models/` are untouched.
 
-### v1.4.0 → v1.5.0 notes
-
-- **Qwen3-TTS is the new headline TTS engine and becomes the DEFAULT for new books once it's installed** (resolved live — a box without Qwen keeps defaulting to Kokoro, and an explicit engine pick in Account is always honoured). It is NOT auto-installed by the per-OS steps above; install it in one click from **Account → Models** (or via `node server/tts-sidecar/scripts/install-qwen3.mjs`). Existing books continue to render through their current engine unchanged. **Graceful fallback:** a Qwen book whose character has no designed voice — or any Qwen render when the engine isn't installed/loaded — renders that character in Kokoro instead of failing, shown as a "Fallback (Kokoro)" status.
-- **Per-character TTS engine.** Cast members now carry a per-engine `overrideTtsVoices: { coqui?, kokoro?, gemini?, qwen? }` map; legacy single-field `overrideTtsVoice` rows migrate lazily on read, so books from v1.4.0 keep their voice assignments when you flip a project's engine — no re-cast required.
-- **Persisted generation queue** at `<workspace>/.queue.json`. No migration: the file is created on first enqueue post-upgrade; in-progress generations pre-1.5.0 just finish.
-- **New optional env knobs** in `server/.env` (all have safe defaults — leave unset to keep the v1.4.0 behaviour):
-  - `GPU_VRAM_BUDGET` — VRAM-weighted GPU semaphore budget in GiB (default `8`). Drop to `6` on a 6 GB card to keep analyzer + Qwen Base co-resident.
-  - `QWEN_BATCH_SIZE` — Qwen sentences-per-batched-forward cap (default `8`). Set `=1` as a per-call kill-switch to fall back to one-sentence-per-call.
-  - `QWEN_ATTN_IMPL` — attention impl for Qwen (default `sdpa`). Flip to `flash_attention_2` after running `install-qwen3.mjs --flash-attn`.
-- **Build-version footer.** Every view now stamps the running build at the bottom (`v1.5.0 (a1b2c3d)` in production). If you upgraded but the footer still reads `v1.4.0`, the new bundle didn't extract over — re-run the unpack.
-- **No `BookStateJson` schema change.** Books from v1.4.0 hydrate as-is.
-
-### v1.3.x → v1.4.0 notes
-
-- `BookStateJson` gained an optional `audioFormat` field (`'mp3' | 'aac-m4a' | 'opus'`). Existing books default to `'mp3'`; no migration required.
-- Finished exports moved from the hidden `.audiobook/exports/<id>/` jail to a visible `<bookDir>/exports/<slug>.<ext>` sibling to `audio/`. Old exports stay where they were — only new exports land in the new location.
-- Audio loudness normalization is on by default in v1.4.0. Set `AUDIO_LOUDNORM_ENABLED=false` in `server/.env` if you need bit-exact match with previously-rendered chapters; otherwise regenerate to bring older chapters into the loudness target.
-- New optional env knobs: `ANALYZER_PHASE0_MODEL` / `ANALYZER_PHASE1_MODEL` / `ANALYZER_PHASE1_MIN_LAG_CHAPTERS` (pipelined two-model analyzer), `GEN_WORKERS` (renamed from `GEN_CHAPTER_CONCURRENCY`; how many chapters the generation queue synthesises at once, default 2). All have safe defaults — leave unset to keep the v1.3.1 behaviour.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,7 +18,7 @@ After install you'll have a single command (`npm run start:prod`) that brings up
   - Windows: `winget install Gyan.FFmpeg`
   - macOS: `brew install ffmpeg`
   - Linux: `sudo apt install ffmpeg` (or `sudo dnf install ffmpeg`)
-- **~3 GB free disk** for the Kokoro TTS weights
+- **~3 GB free disk** (Kokoro TTS weights ~1.1 GB, plus the Node modules and Python virtual environment)
 - **NVIDIA GPU + recent drivers** (optional but strongly recommended — Kokoro on CPU is ~10× slower than on a modest GPU)
 
 > **Note for Linux deployers**: validated on Ubuntu 22.04+. The same scripts should work on any glibc Linux with `bash`, `curl`, and the prereqs above. Snap-installed ffmpeg sometimes ends up at `/snap/bin/ffmpeg` instead of `/usr/bin/ffmpeg`; if `which ffmpeg` returns empty after `apt install`, prepend `/snap/bin` to your PATH.
@@ -88,7 +88,7 @@ Browser opens `http://localhost:8080`.
 
 To stop: `npm run stop:prod`.
 
-> **Gatekeeper note**: macOS may prompt that downloaded binaries (`python`, `ffmpeg`, sidecar `.dylib`s) are from an "unidentified developer." Allowing them once via System Settings → Privacy & Security is expected; the v1 release zip is not codesigned.
+> **Gatekeeper note**: macOS may prompt that downloaded binaries (`python`, `ffmpeg`, sidecar `.dylib`s) are from an "unidentified developer." Allowing them once via System Settings → Privacy & Security is expected; this release zip is not codesigned.
 
 ---
 
@@ -191,7 +191,7 @@ steps above). All knobs have safe defaults — set only what you need.
 
 The install bundle ships Kokoro weights for TTS only — the analyzer needs either a local Ollama daemon or a Gemini API key. The server-side default is `ANALYZER=local` (Ollama); if no Ollama daemon is reachable, the analyzer auto-falls back to the Gemini free tier when a key is configured.
 
-**Option A — Ollama (private, fully on-device).** Since v1.3.0 the Account → Models card in the running app installs Ollama and pulls models without leaving the UI:
+**Option A — Ollama (private, fully on-device).** The Account → Models card in the running app installs Ollama and pulls models without leaving the UI:
 
 1. Start the app (`npm run start:prod`), open **Account → Models**.
 2. Click **Install Ollama** (platform-aware bootstrap; Windows / macOS / Linux all covered).
@@ -212,7 +212,7 @@ Or the manual path: install Ollama from <https://ollama.com>, `ollama pull qwen3
 
 ## Switching TTS to Qwen3-TTS
 
-Qwen3-TTS designs a unique voice per character from the cast persona instead of picking from a preset catalogue — only two English Qwen speakers exist upstream, so the app caches each designed voice's embedding and reuses it across the book and series for vocal consistency. This is the v1.5.0 headline TTS engine and **becomes the default for new books once it's installed** (until then, and on any box without it, books render in Kokoro). It is **NOT** auto-downloaded with the Kokoro / Coqui paths — it needs a one-time install of the Python package + model weights (~5 GB).
+Qwen3-TTS designs a unique voice per character from the cast persona instead of picking from a preset catalogue — only two English Qwen speakers exist upstream, so the app caches each designed voice's embedding and reuses it across the book and series for vocal consistency. It **becomes the default for new books once it's installed** (until then, and on any box without it, books render in Kokoro). It is **NOT** auto-downloaded with the Kokoro / Coqui paths — it needs a one-time install of the Python package + model weights (~2.5 GB).
 
 **Recommended — install in-app (no terminal).** Start the app, open **Account → Models**, and click **Install Qwen3-TTS** on the Qwen card. It downloads the Base + VoiceDesign models in the background with live progress; when it finishes, new books default to Qwen. The CLI below stays available for scripted / offline / CI setups and is equivalent.
 
@@ -313,7 +313,7 @@ this machinery, so there is nothing to convert.
 <install>/
   launch.mjs            <- start the app from here (shortcut / start-app.bat points at it)
   .current-version      <- e.g. "1.7.0"
-  releases/v1.7.0/      <- the code (one extracted zip)
+  releases/vX.Y.Z/      <- the code (one extracted zip per release)
   workspace/            <- your library (books, voices)
   venv/  models/kokoro/ <- shared Python venv + Kokoro weights
   logs/  .run/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, ALv2 Future License
+
+## Abbreviation
+
+FSL-1.1-ALv2
+
+## Notice
+
+Copyright 2026 Mikhail Dudarenok
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -47,6 +47,7 @@ Coqui XTTS v2 (text-to-speech; zero-shot voice cloning)
 Whisper / faster-whisper (optional speech-to-text quality check)
   Licence:  MIT (OpenAI Whisper models) — downloaded on demand under their
             upstream licence.
+  Status:   Download-on-demand; not bundled.
   Source:   https://github.com/SYSTRAN/faster-whisper
 
 ============================================================

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,58 @@
+Castwright
+Copyright © 2026 Mikhail Dudarenok
+
+This product is licensed under the Functional Source License, Version 1.1,
+ALv2 Future License (FSL-1.1-ALv2). See the LICENSE file at the repository root.
+
+Castwright incorporates and/or works with third-party components, each governed
+by its own licence. Model weights are bundled in the release only when their
+upstream licence permits commercial redistribution; non-commercial weights are
+downloaded on demand from their official source and are never bundled.
+
+Rule of thumb: the installer may fetch weights from their official home; the
+release archive bundles nothing whose licence is unverified.
+
+============================================================
+Bundled model weights
+============================================================
+
+Kokoro v1 (text-to-speech)
+  Upstream: hexgrad/Kokoro-82M; ONNX build via thewh1teagle/kokoro-onnx
+  Licence:  Apache License 2.0
+  Source:   https://huggingface.co/hexgrad/Kokoro-82M
+            https://github.com/thewh1teagle/kokoro-onnx
+  Verified: 8 June 2026
+
+============================================================
+Optional model weights (downloaded on demand, NOT bundled)
+============================================================
+
+Qwen3-TTS (text-to-speech; per-character designed voices)
+  Models:   Qwen/Qwen3-TTS-12Hz-0.6B-Base
+            Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign
+  Licence:  Apache License 2.0
+  Source:   https://huggingface.co/Qwen/Qwen3-TTS-12Hz-0.6B-Base
+            https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign
+  Verified: 8 June 2026
+
+Coqui XTTS v2 (text-to-speech; zero-shot voice cloning)
+  Model:    coqui/XTTS-v2
+  Licence:  Coqui Public Model License 1.0.0 (CPML) — NON-COMMERCIAL
+  Status:   NOT bundled. Fetched on demand from the original source; its licence
+            is shown at install time and it is offered as a user-supplied,
+            optional engine.
+  Source:   https://huggingface.co/coqui/XTTS-v2
+  Verified: 8 June 2026
+
+Whisper / faster-whisper (optional speech-to-text quality check)
+  Licence:  MIT (OpenAI Whisper models) — downloaded on demand under their
+            upstream licence.
+  Source:   https://github.com/SYSTRAN/faster-whisper
+
+============================================================
+Application dependencies
+============================================================
+
+The frontend, server, and TTS sidecar depend on third-party npm and PyPI
+packages, each retaining its own open-source licence. See each package's
+distribution (node_modules, the Python environment) for the full texts.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ or MP3.
   flat narrator.
 - **Series memory** — a character keeps the same voice across every book in a
   series.
-- **Your own voice** — clone a voice from a short sample (optional, on-device).
-- **Private by default** — analysis and speech run on your machine; cloud is
+- **Designed voices** — every character gets a unique voice designed from its persona, kept consistent across the series. (Cloning a voice from your own sample is the next major release.)
+- **On-device by default** — analysis and speech run on your machine; cloud is
   opt-in.
 - **You own the files** — export standard M4B / MP3 / AAC / Opus and keep them.
   No lock-in.

--- a/README.md
+++ b/README.md
@@ -1,338 +1,142 @@
 # Castwright
 
 > _Any book, performed by a full cast — effortlessly. Even in your own voice._
-> npm packages: `castwright` / `castwright-server`. Repo: `Castwright`. Release artifact: `castwright-vX.Y.Z.zip`. Note: v1.6.0 cannot self-upgrade across the rename — alpha installs reinstall fresh.
 
-Turn a manuscript into a finished, **full-cast** audiobook on your own machine — every
-character in their own voice, consistent across a whole series.
+Turn a manuscript into a finished, **full-cast** audiobook on your own machine —
+every character in their own voice, consistent across a whole series. Castwright
+runs locally end-to-end; nothing leaves your computer unless you opt into a cloud
+analyzer.
 
-Upload `.md` / `.txt` / `.epub` / `.pdf` → an analyzer extracts characters,
-chapters, and per-sentence speaker tags → assign a TTS voice to each
-character → generate per-chapter audio → listen, revise, export to M4B
+Upload `.md` / `.txt` / `.epub` / `.pdf` / `.mobi` / `.azw3` → an analyzer
+extracts characters, chapters, and per-sentence speaker tags → assign a voice to
+each character → generate per-chapter audio → listen, revise, and export to M4B
 or MP3.
 
-The pipeline runs locally end-to-end. Analysis can use a local Ollama
-model (default) or the Gemini free-tier API. TTS uses Kokoro v1 (eager-loaded, ~1 GB
-VRAM) by default, with Coqui XTTS v2 available on demand for zero-shot
-voice cloning.
+## What you get
 
-## Quickstart
-
-**Prerequisites**
-
-- Node 20.19 or newer (Vite 8 requires ≥20.19 / ≥22.12; the repo targets Node 24 via `.nvmrc`)
-- Python 3.11 (for the TTS sidecar)
-- ffmpeg on `PATH` (checked by `npm run dev` via `scripts/preflight-ffmpeg.cjs`)
-- Windows 11 with PowerShell 5.1+ — the harness ships Windows-native start
-  scripts; macOS / Linux work for development but the orchestration scripts
-  under `scripts/` are PowerShell
-
-**Install**
-
-```powershell
-git clone https://github.com/dudarenok-maker/Castwright.git
-cd Castwright
-npm install
-cd server && npm install && cd ..
-```
-
-The `prepare` hook installs husky and wires `.husky/` for commit gating.
-
-Optional, one-time per workstation:
-
-```powershell
-# Pester 5+ for the PowerShell-scripts test harness
-Install-Module -Name Pester -Scope CurrentUser -Force -SkipPublisherCheck
-
-# Chromium for Playwright e2e
-npx playwright install chromium
-
-# Kokoro v1 weights for the default TTS engine (~1 GB)
-powershell -ExecutionPolicy Bypass -File server/tts-sidecar/scripts/install-kokoro.ps1
-```
-
-**Run**
-
-```powershell
-npm start                  # frontend + server + TTS sidecar in one shot
-# or, three terminals if you want them split:
-npm run dev:frontend       # Vite on http://localhost:5173
-npm run dev:server         # Node API on http://localhost:8080
-npm run tts:sidecar        # FastAPI TTS on http://localhost:9000
-```
-
-Since v1.3.0 the server owns the TTS sidecar child-process lifecycle (per-user `autoStartSidecar` preference, default on) — `npm start` brings up frontend + server + sidecar from one terminal, and Ctrl+C tears the sidecar down cleanly.
-
-The frontend opens to the book library at <http://localhost:5173>. Configure analyzer and TTS preferences from the Account page once the app is up. The Account → Models card (also new in v1.3.0) installs Ollama, pulls model weights, and pre-fetches Coqui XTTS without dropping to a terminal.
-
-**Verify your install**
-
-```powershell
-npm run verify             # typecheck + all tests + e2e + build
-```
-
-This is the same battery the pre-push hook runs. Sub-batteries:
-`npm run test:fast` (pre-commit), `npm run verify:quick` (all tests, no
-e2e/build), `npm run test:e2e` (Playwright only).
+- **Full-cast narration** — every character speaks in their own voice, not one
+  flat narrator.
+- **Series memory** — a character keeps the same voice across every book in a
+  series.
+- **Your own voice** — clone a voice from a short sample (optional, on-device).
+- **Private by default** — analysis and speech run on your machine; cloud is
+  opt-in.
+- **You own the files** — export standard M4B / MP3 / AAC / Opus and keep them.
+  No lock-in.
 
 ## Features
 
-- **Manuscript ingestion** — paste or upload `.md`, `.txt`, `.epub`, `.pdf`, `.mobi`, or `.azw3`; chapter names extracted, low-confidence speaker assignments surfaced for review. DRM-protected MOBI files are rejected up-front with a clear error. **Diff-on-reupload (v1.4.0)** — side-by-side sentence-level diff (LCS + char-level inner highlight) gates any re-upload of an existing book before slice mutation; an amber banner flags renamed chapters whose sticky title overrides won't match the new parse.
-- **Manuscript editing** — per-sentence speaker reassign, chapter merge/split/reorder, manual chapter rename with a sticky `titleOverridden` flag (v1.4.0) preserved across heuristic refresh passes. **Low-confidence triage polish (v1.4.0)** — J/K shortcuts jump to the next misattribution and auto-open the inspector; a typeahead `<CharacterSearchPicker>` lists local cast + recurring series-mates so a missing series character can be materialised from the prior roster in one click.
-- **Analyzer choice** — local Ollama (default, no API key required) or Gemini free-tier (cloud, 1500 RPD). Sticky across navigation and process restarts. **In-app multi-model management (v1.3.0)** — Install Ollama, pull a model, and pre-fetch Coqui XTTS from the Account → Models card without dropping to a terminal. **Pipelined two-model analyzer (v1.4.0)** — opt-in Phase 0 (cast detection, e.g. `gemma-4-31b-it`) and Phase 1 (sentence attribution, e.g. `gemini-3.1-flash-lite`) run in parallel with a configurable 10-chapter minimum lag, hitting independent rate-limit buckets so effective quota nearly doubles. Phase model picker + min-lag knob live on the Account tab.
-- **Voice library** — per-engine catalogs, family grouping, drag-to-assign, per-character overrides, sample playback, side-by-side cast comparison. **Same-book cast compare from the global Voices tab (v1.3.0)** — on-demand fetches the foreign book's cast so you can audition two characters from a different book side-by-side.
-- **TTS engines** — Kokoro v1 (eager-loaded English-only, 28 voices), Coqui XTTS v2 (button-driven, zero-shot cloning), Gemini cloud. Per-character voice profiles persist across engine switches. **Voice preview while editing (v1.3.0)** — audition multiple voice candidates inside the profile drawer with a user-editable sample line, without committing the assignment. **Kokoro stop pill (v1.4.0)** — top-bar pill evicts Kokoro to free ~1 GB VRAM for an XTTS warm or a heavier analyzer model without restarting the sidecar.
-- **Generation** — per-chapter SSE stream, sticky across navigation, cold-boot resumable. Auto-retry on transient sidecar failures. **Cross-tab state sync (v1.3.0)** — open the same book in two tabs and the analysis / generation pills update in lockstep via `BroadcastChannel`, no round-trip needed. **Parallel chapter synthesis (v1.4.0)** — bounded worker pool over chapters via `GEN_CHAPTER_CONCURRENCY` (default 2); per-chapter SSE tracks isolated through the chapters slice so interleaved events never cross. **Voiced chapter titles + inter-chapter silence (v1.4.0)** — each chapter audio now opens with the title rendered as a period-separated clause (`Chapter 2. Moolark.`) in the project's narrator voice, followed by a baked-in silence; reads cleanly across Coqui / Kokoro / Gemini.
-- **Revisions & drift** — pending-revisions pill, A/B audio audition with rollback preservation, full diff view, engine-drift detection per chapter. **Revision history timeline (v1.3.0)** — read-only chronological log of accept/reject events per chapter, surfaced from the existing A/B player modal. **Cast Drift consolidation (v1.4.0)** — drift report modal collapses by `(book × character × snapshot)` — ~300 events surface as ~6–18 cards with bulk Regen-all / Dismiss-all / Auto-regen-all on multi-chapter groups. **Background drift polling (v1.4.0)** — `GET /api/revisions?bookIds=...` bulk endpoint + two-tier poller (30 s active, 120 s background) surfaces drift on non-active books within ~2 min without a navigate.
-- **Listening surface (overhauled in v1.3.0)** — playback speed picker (0.75×–2×, persisted per book), user-placed markers (note / rerecord) with a listen-view sidebar, sleep timer with countdown presets + end-of-chapter mode, true RMS waveform peaks computed at encode time, listening-progress resume bookmarks, per-book editorial notes (collapsible card), share a 30-second clip of any chapter as MP3, mint a slugged share URL for the whole book M4B. **Loudness report card (v1.4.0)** — colour-coded per-row drift pill (≤2 / 2–4 / >4 LU buckets) + expandable card with summary line, sparkline, and per-chapter table.
-- **Library** — auto-fetched OpenLibrary covers on import; manual cover picker with three tabs (search, upload, frame), drag-pan + zoom framing without re-encoding the source JPEG. **Library polish (v1.4.0)** — debounced title/author search + tag-chip filter; card↔table view toggle with series grouping; portable book bundle (`.zip` of state + manuscript + audio + cover + change-log + MANIFEST) for export and import.
-- **Export** — M4B (with cover, chapter atoms, optional descriptions), AAC/M4A zip, Opus zip, MP3 zip, per-chapter MP3 folder, portable book bundle (v1.4.0), sync-folder save, LAN download with QR. **Per-book audio format (v1.4.0)** — `BookStateJson.audioFormat` (default `'mp3'`, also `'aac-m4a'` or `'opus'`) drives the chapter encode + matching export shapes; libfdk_aac auto-detects with native AAC fallback. **EBU R128 loudness normalization (v1.4.0)** — two-pass `loudnorm` at -16 LUFS / 11 LU / -1.5 dBTP on by default (`AUDIO_LOUDNORM_ENABLED=false` opts out); voice samples deliberately skip the pass.
-- **Exports + sync folder (v1.4.0)** — finished artifacts now land at `<bookDir>/exports/<slug>.<ext>` (visible) rather than the hidden `.audiobook/exports/<id>/` jail; export modal auto-saves the sync folder on blur with an inline error banner and a "Test" probe button; widened `renameWithRetry` covers Google Drive for Desktop and OneDrive virtual-FS EACCES/EIO hiccups with destination-specific hints.
-- **Persistence** — per-book `state.json` + `cast.json` + `manuscript-edits.json` with rotating backups, torn-read recovery, and schema versioning for forward-compatible migrations.
-- **Themes (stable in v1.3.0)** — Light / Dark / System toggle with an account-managed first-visit default. Full dark-mode coverage across white / amber / red / rose ladders + bespoke `floating-pill-inverse` utility for the cast-view selection bar.
-- **Mobile + tablet (v1.4.0)** — every view re-laid out across three Tailwind viewport tiers (`<640px` phone, `640–1024px` tablet, `≥1024px` desktop); LAN HTTPS via `mkcert` (`npm run install:cert-mobile` prints LAN URL + QR + per-OS root-cert install steps; `npm run dev:lan` / `start:lan` brings Vite + Node up on `https://0.0.0.0:5173`/`:8443`); touch-equivalence for every drag/hover affordance (tap-to-assign voice pill, PointerEvents on manuscript paragraph boundaries, `coarse-pointer:` Tailwind variant for hover-reveal labels); 44×44 px touch targets enforced.
-- **Frontend performance (v1.4.0)** — `useWindowVirtualizer` from `@tanstack/react-virtual` wraps the manuscript segment list above 60 segments, and the confirm-cast picker + listen chapter list above 40 rows (short books stay on the flat-render path). Broadcast-middleware shallow-diffs snapshots, `useAppSelectorShallow` applied at five large-slice sites, route-level `React.lazy` code-split. Main bundle 410 kB → 345 kB (gzip 108 kB → 91 kB).
-- **Android companion app** — a native **Flutter** listening companion (`apps/android/`) that pairs to the server over LAN HTTPS, **delta-syncs only the chapters that changed** (per-chapter `…/audio` files, not whole-book re-exports), and plays offline with background / lock-screen / Bluetooth / Android-Auto controls + two-way resume sync. Pairing is cryptographically auto-verified — the app fetches `/cert/root.crt` and pins the CA itself, so **no OS root-cert install is needed on the phone**. See [Companion app (Android)](#companion-app-android) below and [`apps/android/README.md`](apps/android/README.md). The full architecture + delivery log is [`docs/features/188-android-companion-app.md`](docs/features/188-android-companion-app.md).
+- **Ingest** — paste or upload `.md`, `.txt`, `.epub`, `.pdf`, `.mobi`, or
+  `.azw3`. Chapters and character names are extracted automatically; low-confidence
+  speaker tags are surfaced for a quick review pass. DRM-protected files are
+  rejected up front. Re-uploading a book shows a sentence-level diff before
+  anything changes.
+- **Analyzer choice** — run a fully local model via Ollama (no API key, nothing
+  leaves your machine) or use the Gemini free tier. For long books, an optional
+  two-model pipeline runs cast detection and sentence attribution in parallel to
+  roughly double throughput.
+- **Voice & cast** — per-engine voice catalogues with family grouping, drag- or
+  tap-to-assign, per-character overrides, and sample playback. Audition candidate
+  voices in the profile drawer before committing, and compare two characters side
+  by side — even across books.
+- **TTS engines** — Kokoro (fast, English, runs on a modest GPU), Coqui XTTS v2
+  (zero-shot voice cloning, optional download), Qwen3-TTS (designs a unique voice
+  per character from a persona and reuses it across the series), and Gemini cloud.
+  A character keeps its voice when you switch engines.
+- **Generation** — per-chapter, resumable, and sticky across navigation; chapters
+  synthesise in a bounded parallel pool. Each chapter opens with its title spoken
+  in the narrator's voice. Open the same book in two tabs and progress stays in
+  sync.
+- **Revisions & drift** — pending-revision review, A/B audition with rollback, a
+  per-chapter revision timeline, and automatic detection (with one-click
+  regeneration) when a chapter's voices drift from the current cast.
+- **Listening** — a built-in player with speed control, markers, a sleep timer,
+  true waveform peaks, resume bookmarks, per-book notes, and one-tap sharing of a
+  30-second clip or the whole book.
+- **Library** — auto-fetched cover art with a manual cover picker (search /
+  upload / frame), title & author search, tag filters, series grouping, and a
+  portable book bundle for backup or transfer.
+- **Export** — M4B (with cover and chapter markers), AAC/M4A, Opus, MP3 (zip or
+  per-chapter folder), plus LAN download with a QR code. EBU R128 loudness
+  normalisation is on by default.
+- **Mobile, tablet & companion app** — every view is responsive across phone /
+  tablet / desktop and reachable over your home network via HTTPS, with a native
+  Android companion that syncs only what changed and plays offline (background,
+  lock-screen, Bluetooth, Android Auto).
 
-## Layout
+## Quickstart
 
-```
-src/                  Vite 8 (Rolldown) + React 19 + Redux Toolkit frontend
-  store/              RTK slices (ui, cast, chapters, revisions, manuscript,
-                      book-meta, notifications, broadcast-middleware,
-                      engines-in-use-selector)
-  views/              Stage views (books, upload, analysing, confirm, ready, listen,
-                      account, worktrees); listen.tsx is an orchestrator over the
-                      sub-components below (decomposed in v1.3.0); book-library.tsx
-                      is a thin orchestrator over src/components/library/* (v1.4.0)
-  components/         Shared UI primitives — including character-search-picker (v1.4.0),
-                      manuscript-diff, loudness-report, delayed-spinner, stat-tiles
-    listen/           Listen-view region sub-components — listen-header,
-                      listen-player-region, listen-download-section (v1.3.0)
-    library/          Library-view sub-components — library-chrome (search + tags +
-                      view toggle), library-grid, library-table, library-status-ui,
-                      library-empty-states (v1.4.0)
-  modals/             Profile drawer, cover picker, compare-cast, share-clip,
-                      share-link, edit-book-meta, edit-chapter-title (v1.4.0), etc.
-  lib/                api, router, types, generated api-types, manuscript-diff,
-                      chapter-override-conflict, use-debounced-value
-  mocks/              VITE_USE_MOCKS=1 fixtures
-server/               Node + Express API (TypeScript)
-  src/
-    routes/           HTTP routes including /api/books/:bookId/share +
-                      /share/:slug + /api/books/:bookId/chapters/:chapterId/clip
-                      (v1.3.0); /api/books/:id/export/portable + /api/import/portable
-                      + /api/books/:bookId/cast/add-from-roster +
-                      /api/books/:bookId/chapters/:chapterId/rename +
-                      /api/revisions?bookIds=... + /api/worktrees +
-                      /api/user/settings/sync-folder/test +
-                      /api/sidecar/{load,unload} + /cert-root (v1.4.0)
-    analyzer/         phase-watermark + select-analyzer for the pipelined
-                      two-model Phase 0/1 split (v1.4.0)
-    tts/              loudnorm.ts (EBU R128 two-pass), aac.ts, opus.ts,
-                      synthesise-chapter.ts (parallel-friendly extracted entry),
-                      chapter-title-narration.ts (v1.4.0)
-    export/           build-portable-book.ts, build-codec-zip.ts (v1.4.0)
-    import/           scan-import-folder.ts (v1.4.0)
-    ollama/           Vendor-installer bootstrap (v1.3.0)
-  tts-sidecar/        Python FastAPI TTS sidecar (Coqui + Kokoro)
-    scripts/          install-kokoro.{sh,ps1} + install-coqui.{sh,ps1} (v1.3.0)
-  handoff/            Gemini analyzer prompt/response traceability
-apps/android/         Flutter companion app (pkg castwright) — domain
-                      (pure logic) / data (cert-pinned client, drift store, sync
-                      engine, player) / ui; iOS target lives here too. See
-                      apps/android/README.md + docs/features/188-…md
-e2e/                  Playwright specs against Vite in mock mode (chromium-only
-                      pre-push); responsive/* runs against mobile-chrome (Pixel 7)
-                      and tablet-chrome (iPad Pro 11) via npm run test:e2e:mobile
-                      (v1.4.0)
-scripts/              Orchestration (start/stop/install/preflight) — primarily
-                      Node ESM since v1.2.2; wt-new.mjs spawns parallel Claude
-                      worktrees, wt-list.mjs shows their port assignments,
-                      wt-merge.mjs (v1.3.1) drives the integration-branch
-                      reconciliation pattern, setup-lan-certs.mjs +
-                      print-cert-install-instructions.mjs bootstrap mkcert
-                      HTTPS for mobile testing (v1.4.0)
-.github/workflows/    CI — release.yml on tag push, verify.yml on every PR (v1.3.0);
-                      Node 24 since v1.4.0
-docs/
-  features/           Living per-feature regression plans (INDEX.md)
-  features/archive/   Plans that shipped and are no longer load-bearing
-  BACKLOG.md          MoSCoW-bucketed outstanding work
-  project-narrative.md  Project story for design / engineering conversations
-openapi.yaml          API contract — single source of truth for shapes
-```
+Download the latest `castwright-vX.Y.Z.zip` from
+[Releases](https://github.com/dudarenok-maker/Castwright/releases), extract it,
+and follow **[INSTALL.md](INSTALL.md)**. You'll end up with a single
+`npm run start:prod` command that brings up the server, the TTS sidecar, and the
+web UI at <http://localhost:8080>.
 
-## Configuration
+**Prerequisites** (full detail and per-OS steps in [INSTALL.md](INSTALL.md)):
 
-Server reads `server/.env` (Node 20.6+ native `process.loadEnvFile`).
-Copy `server/.env.example` as a starting point. Notable knobs:
-
-- `ANALYZER` — `local` (default, Ollama) or `gemini`.
-- `GEMINI_API_KEY`, `GEMINI_MODEL`, and the per-model RPM / TPM / RPD
-  caps when `ANALYZER=gemini`.
-- `ANALYZER_PHASE0_MODEL` / `ANALYZER_PHASE1_MODEL` /
-  `ANALYZER_PHASE1_MIN_LAG_CHAPTERS` (v1.4.0) — opt-in pipelined
-  two-model analyzer (Gemma cast + Gemini attribution by default,
-  10-chapter min lag). Set both phase vars to enable; legacy
-  single-model `ANALYZER=…` path preserved verbatim when unset. The
-  Account tab UI mirrors the same knobs per-book.
-- `PRELOAD_COQUI` — `0` (default; Coqui loads on demand) or `1`.
-- `GEN_WORKERS` (v1.4.0; renamed from `GEN_CHAPTER_CONCURRENCY`, which is no
-  longer read) — how many chapters the generation queue synthesises
-  concurrently. Default `2`. Queue concurrency only; the GPU semaphore
-  (`GPU_VRAM_BUDGET` / `GPU_CONCURRENCY`) is the separate VRAM guard.
-- `AUDIO_LOUDNORM_ENABLED` (v1.4.0) — `true` (default; two-pass EBU R128
-  at -16 LUFS / 11 LU / -1.5 dBTP on every newly-rendered chapter) or
-  `false` to opt out per server install. Voice samples deliberately
-  skip the pass.
-- `WORKSPACE_DIR` — where per-book `.audiobook/` folders live.
-- `LAN_HTTPS` — `1` flips the listener from HTTP `:8080` (loopback) to
-  mkcert-backed HTTPS `:8443` bound on all interfaces (mobile/tablet web access
-  and the Android companion). Off by default; `npm run start:lan` sets it.
-  Requires the LAN cert (`npm run install:cert-mobile`).
-- `LAN_AUTH_TOKEN` — a shared secret that, together with `LAN_HTTPS=1`, turns on
-  the LAN access guard on `/api` + `/workspace` (loopback always bypasses;
-  `/cert/root.crt` + `/audio` stay open). **Required for the companion** — it's
-  the pairing token, surfaced in the `GET /api/export/lan` pairing payload. Per-
-  device, individually-revocable tokens layer on top via `GET/POST/DELETE
-  /api/devices` (`srv-33`).
-
-Frontend reads `VITE_USE_MOCKS` from `.env.development`. Mock mode
-round-trips against an in-memory store and is what the Playwright e2e
-suite runs against.
-
-### Mobile + tablet over LAN HTTPS (v1.4.0)
-
-1. One-time per dev box: `scoop install mkcert` (Windows), `brew install mkcert` (macOS), or `apt install mkcert` (Linux), then `mkcert -install`.
-2. `npm run install:cert-mobile` — prints LAN URL + QR code + per-OS root-cert install steps.
-3. Install the root CA on each mobile device once (iOS: Settings → Profile downloaded → Install → trust; Android: Settings → Security → Install certificate).
-4. `npm run dev:lan` (HMR-capable Vite + Node at `https://0.0.0.0:5173`/`:8443`) or `npm run build && npm run start:lan` (production bundle at `https://0.0.0.0:8443`).
-5. Open the printed LAN URL on the device — lock icon, no warning.
-
-E2E across phone (Pixel 7) and tablet (iPad Pro 11) viewports is opt-in via `npm run test:e2e:mobile` (~10–15 min); the pre-push gate (`npm run test:e2e`) is chromium-only.
+- Node.js 20.19+
+- Python 3.11 (for the TTS sidecar)
+- ffmpeg on `PATH`
+- ~3 GB free disk for the TTS weights
+- An NVIDIA GPU is strongly recommended (TTS on CPU is far slower)
 
 ## Companion app (Android)
 
-The native Flutter companion lives in [`apps/android/`](apps/android/README.md).
-It pairs to a server running in **LAN HTTPS mode with an access token** and then
-delta-syncs + plays offline. The web UI's LAN setup above is shared; the
-companion adds an **access token** (the pairing secret) on top.
+A native Flutter companion pairs to your running server over the home network
+(HTTPS, cert-pinned), delta-syncs only the chapters that changed, and plays them
+offline with background, lock-screen, Bluetooth, and Android Auto controls.
+Pairing is cryptographically self-verified, so **no certificate install is needed
+on the phone**.
 
-**Server side — bring it up for pairing:**
-
-1. One-time LAN cert (same as mobile web): install `mkcert` (e.g. `winget install
-   FiloSottile.mkcert` on Windows), then `npm run install:cert-mobile` (runs
-   `mkcert -install` and writes `.run/certs/`).
-2. In `server/.env` set both:
-
-   ```
-   LAN_HTTPS=1
-   LAN_AUTH_TOKEN=<a-strong-secret>
-   ```
-
-3. Start in LAN mode: `npm run start:lan` (binds `https://0.0.0.0:8443`). With
-   `LAN_HTTPS=1` set, the server **hard-exits if the LAN cert is missing** — run
-   step 1 first.
-4. The pairing values come from `GET /api/export/lan` →
-   `{ urls, port, protocol: "https", token, caFingerprint }`.
-
-**Phone/emulator side — pair:** open the app → **Pair a device** → scan the
-pairing QR, or enter **Server URL** (`https://<lan-ip>:8443`), **access token**,
-and **CA fingerprint (SHA-256)** manually. The app fetches `/cert/root.crt`,
-verifies its SHA-256 against the fingerprint, and pins the CA in its own TLS
-context — **no OS root-cert install on the phone** (unlike the web UI, which
-needs the root CA trusted in the device browser).
-
-**Per-device tokens (optional, `srv-33`):** `POST /api/devices` mints an
-individually-revocable token; `GET /api/devices` lists them; `DELETE
-/api/devices/:id` revokes one. Layered on the shared secret — the shared token
-keeps working.
-
-Build/run/test the app itself per [`apps/android/README.md`](apps/android/README.md).
-_Distribution: each tagged [GitHub Release](#releases) attaches a built
-`castwright-vX.Y.Z.apk` (sideload it) plus an unsigned iOS build —
-it's a separate Flutter build from the server zip, but shipped alongside it on
-the same release._
-
-## Parallel sessions (developer-only)
-
-Multiple Claude Code (or any) sessions can run in parallel against this
-repo via git worktrees with non-colliding ports:
-
-- `node scripts/wt-new.mjs feat/foo-slug` — creates a worktree under
-  `.claude/worktrees/agent-…`, cuts the branch, and writes a `.env.local`
-  with VITE_PORT / PORT / LOCAL_TTS_PORT / PLAYWRIGHT_PORT offset by
-  `slot * 10` so dev servers don't fight over `:5173` / `:8080` / `:9000`
-  / `:5174`. The parent worktree keeps stock defaults.
-- `node scripts/wt-list.mjs` — terminal-friendly table of every active
-  worktree with its slot, branch, and port assignments.
-- **`#/worktrees` view (dev mode only)** — once a dev server is running
-  (`npm run dev`), open `http://localhost:5173/#/worktrees` or click
-  the small `wt` chip in the top-bar (left of the theme toggle, dev-only).
-  The view lists every worktree with a live TCP probe against each
-  VITE_PORT (green dot = dev server alive). Click a green row → opens
-  that worktree's dev URL in a new tab. Auto-refresh every 10 s. The
-  backing `GET /api/worktrees` route 404s in production builds.
-- `node scripts/wt-merge.mjs <branch> [<branch>...]` — drives the
-  CONTRIBUTING.md "Reconciliation pattern" for parallel-agent branches:
-  cuts `integration/<YYYY-MM-DD>` off `main`, merges each branch via
-  `--no-ff`, runs `npm run verify` between merges, aborts on conflict
-  (exit 2) or verify failure (exit 3) with a copy-pasteable follow-up.
-  Idempotent; `--dry-run` previews without mutating.
-
-See [`docs/features/archive/86-worktree-dashboard.md`](docs/features/archive/86-worktree-dashboard.md),
-[`docs/features/archive/85-wt-merge-helper.md`](docs/features/archive/85-wt-merge-helper.md),
-and [`CONTRIBUTING.md` "Parallel agents"](CONTRIBUTING.md#parallel-agents)
-for the full workflow.
-
-## Documentation
-
-- [`docs/features/INDEX.md`](docs/features/INDEX.md) — every shipped
-  feature has a living regression plan with invariants, acceptance
-  walkthrough, and test pointers.
-- [`docs/BACKLOG.md`](docs/BACKLOG.md) — MoSCoW-bucketed outstanding
-  work; future rounds pull from here.
-- [`CLAUDE.md`](CLAUDE.md) — project context for AI assistants:
-  conventions, commands, branching, testing discipline.
-- [`CONTRIBUTING.md`](CONTRIBUTING.md) — commit convention, scope
-  vocabulary, branching workflow, release-notes rules.
+Each [GitHub Release](https://github.com/dudarenok-maker/Castwright/releases)
+attaches a ready-to-sideload `castwright-vX.Y.Z.apk`. Server-side pairing setup
+(LAN HTTPS + an access token) is in [INSTALL.md](INSTALL.md); the app's own build
+and usage notes are in [`apps/android/README.md`](apps/android/README.md).
 
 ## Releases
 
-Packaged downloads of tagged releases are published to
-[GitHub Releases](https://github.com/dudarenok-maker/Castwright/releases).
-Each release attaches (all with `.sha256` checksums):
+Tagged releases are published to
+[GitHub Releases](https://github.com/dudarenok-maker/Castwright/releases). Each
+attaches (all with `.sha256` checksums):
 
 - `castwright-vX.Y.Z.zip` — the platform-independent **server** bundle
-  (Windows / macOS / Linux); follow [`INSTALL.md`](INSTALL.md).
-- `castwright-vX.Y.Z.apk` — the installable **Android companion** app
-  (plan 188), versioned in lockstep via `scripts/bump-version.mjs` (which now
-  also bumps `apps/android/pubspec.yaml`). Sideload it onto the phone.
-- `castwright-vX.Y.Z-ios-unsigned.*` — the **unsigned iOS** build
-  (app-12 prep): the release pipeline compiles the iOS app every release so the
-  pathway stays green; it needs Apple signing certs to become an installable
-  `.ipa` (tracked as `app-12`).
+  (Windows / macOS / Linux); install via [INSTALL.md](INSTALL.md).
+- `castwright-vX.Y.Z.apk` — the sideloadable **Android companion** app.
+- `castwright-vX.Y.Z-ios-unsigned.*` — an **unsigned iOS** build (needs Apple
+  signing to become an installable `.ipa`).
 
-The release pipeline is documented in
-[`docs/features/archive/49-release-package.md`](docs/features/archive/49-release-package.md).
+After the first public release, upgrading is one click inside the app
+(**Account → Application updates**); see [INSTALL.md](INSTALL.md#updating).
 
-## Testing
+## How it's built
 
-Five harnesses, all wired into `npm run verify`:
+Castwright is a Vite + React frontend, a Node/Express server, and a Python
+(FastAPI) TTS sidecar, with a native Flutter companion app. Building from source,
+the branching model, and the commit convention are documented in
+**[CONTRIBUTING.md](CONTRIBUTING.md)**.
 
-| Harness            | Command                | What it covers                          |
-| ------------------ | ---------------------- | --------------------------------------- |
-| Frontend           | `npm test`             | Vitest + jsdom, React Testing Library   |
-| Server             | `npm run test:server`  | Vitest + node, ffmpeg integration       |
-| Sidecar            | `npm run test:sidecar` | pytest against the Python venv          |
-| PowerShell scripts | `npm run test:scripts` | Pester 5 against `scripts/lib/`         |
-| End-to-end         | `npm run test:e2e`     | Playwright + Chromium against mock mode |
+## Documentation
 
-Commit gating runs `verify:fast` on pre-commit and the full `verify` on
-pre-push. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the commit
-convention enforced by `.husky/commit-msg`.
+- **[INSTALL.md](INSTALL.md)** — install, configure, and update the app.
+- **[`apps/android/README.md`](apps/android/README.md)** — the Android companion.
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** — building from source, branching, and
+  the commit convention.
 
 ## License
 
-Private — not currently licensed for redistribution.
+Castwright is **source-available — not OSI open source**. The code is licensed
+under the **Functional Source License v1.1 with an Apache-2.0 future grant**
+(FSL-1.1-ALv2, a.k.a. FSL-1.1-Apache-2.0) — see **[LICENSE](LICENSE)**. In short:
+use, modify, and share it for any purpose **except** building a competing product
+or service; two years after each release, that release's code becomes Apache-2.0.
+Leading with this plainly is deliberate — it bars a competing fork from day one
+while keeping the source fully readable.
+
+- **Brand assets** in [`brand/`](brand/) are **not** covered by the code licence —
+  all rights reserved ([`brand/LICENSE`](brand/LICENSE)).
+- **Model weights** carry their own upstream licences ([NOTICE](NOTICE)). Coqui
+  XTTS v2 is non-commercial (CPML) and is therefore download-on-demand, never
+  bundled.
+
+**Contributing:** issues welcome; PRs by invitation for now (a DCO sign-off and a
+lightweight CLA apply — see [CONTRIBUTING.md](CONTRIBUTING.md)).

--- a/brand/LICENSE
+++ b/brand/LICENSE
@@ -1,0 +1,26 @@
+Castwright brand assets — Copyright © 2026 Mikhail Dudarenok. All rights reserved.
+
+This directory ("brand/") contains the Castwright name, wordmarks, logos, the
+"Castwave" mark, icons, colour system, and related identity assets.
+
+These brand assets are NOT covered by the Functional Source License that governs
+the Castwright source code (see the LICENSE file at the repository root). A
+licence to the code is not a licence to the identity.
+
+You MAY, without prior permission, reproduce the unmodified marks at reasonable
+size for the purpose of identifying or referring to Castwright in news articles,
+reviews, academic work, and similar editorial or informational contexts (nominative
+fair use).
+
+You MAY NOT, without prior written permission from the copyright holder:
+
+- use the marks (or anything confusingly similar) to name, brand, or promote
+  another product, service, fork, or distribution;
+- imply sponsorship, affiliation, or endorsement by Castwright;
+- modify, recolour, or redraw the marks; or
+- incorporate the marks into your own logos or trademarks.
+
+"Castwright" is an unregistered trade mark of the copyright holder; trade-mark
+registration is in progress. All rights not expressly granted above are reserved.
+
+Questions / permission requests: open an issue on the repository.

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -1,0 +1,87 @@
+# Licensing & repo-opening compliance
+
+Maintainer-facing record of Castwright's licensing model, the bundled-model
+audit, and the checklist that must clear before the GitHub repository is made
+public. Companion to
+[`brand/monetisation-free-vs-gated-2026-06-08.md`](../brand/monetisation-free-vs-gated-2026-06-08.md)
+§5 and §7.
+
+## The model
+
+- **Code** — Functional Source License v1.1 with an Apache-2.0 future grant
+  (**FSL-1.1-ALv2**, a.k.a. FSL-1.1-Apache-2.0). Source-available, *not* OSI
+  open source: any use is permitted except a Competing Use, and each release's
+  code converts to plain Apache-2.0 two years after it is made available. File:
+  [`/LICENSE`](../LICENSE).
+- **Brand** — the `brand/` assets are all rights reserved
+  ([`brand/LICENSE`](../brand/LICENSE)). A code licence is not a licence to the
+  identity.
+- **Engine weights** — bundled only if the upstream licence permits commercial
+  redistribution; non-commercial weights are download-on-demand from their
+  official home and never bundled ([`/NOTICE`](../NOTICE)).
+- **Paid gate (future)** — an Ed25519-signed offline licence key for the "Cast
+  Pass", no phone-home (monetisation §7.2). Not built; needs an `fs-` plan.
+
+## Engine-licence audit
+
+Verified 8 June 2026 from the Hugging Face model cards. **Re-verify at the
+pinned release version before every public release** — a model card licence can
+change between snapshots.
+
+| Engine | Model(s) | Upstream licence | Bundled? | Verified |
+|---|---|---|---|---|
+| Kokoro v1 | hexgrad/Kokoro-82M (ONNX via thewh1teagle/kokoro-onnx) | Apache-2.0 | **Yes** — weights ship / install with the app | 8 Jun 2026 |
+| Qwen3-TTS Base | Qwen/Qwen3-TTS-12Hz-0.6B-Base | Apache-2.0 | No — download-on-demand | 8 Jun 2026 |
+| Qwen3-TTS VoiceDesign | Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign | Apache-2.0 | No — download-on-demand | 8 Jun 2026 |
+| Coqui XTTS v2 | coqui/XTTS-v2 | **CPML — non-commercial** | No — download-on-demand, licence shown at install | 8 Jun 2026 |
+| Whisper (QA, optional) | faster-whisper models | MIT | No — download-on-demand | known; re-confirm |
+
+Rule of thumb: the installer may fetch weights from their official home; the
+release archive bundles nothing whose licence is unverified.
+
+## Repo-opening checklist
+
+**Done in the docs/licensing pass:**
+
+- [x] `LICENSE` (FSL-1.1-ALv2)
+- [x] `brand/LICENSE` (all rights reserved + nominative fair use)
+- [x] `NOTICE` (bundled-model attributions + audit summary)
+- [x] README license statement (source-available, brand carve-out, model notice)
+- [x] CONTRIBUTING contribution-licensing terms (DCO / CLA / PRs-by-invitation)
+
+**Pending before flipping the repo public:**
+
+- [ ] **Companion website (`castwright.ai`) live** — the stated gate for going
+      public; the public-flip and any "Cast Pass" messaging wait for it.
+- [ ] **Git history scrub — DESTRUCTIVE, force-push.** Audit history for
+      committed secrets and copyrighted fixtures, then rewrite if found:
+  - Audit: `git log --all --full-history -- '**/.env' 'server/.env'` and a
+    secret scan (e.g. `gitleaks detect`, `trufflehog`). Also check the canonical
+    copyrighted manuscript fixture never entered history:
+    `git log --all --full-history --oneline -- '**/*Keefe*'`.
+  - If anything is found: back up the repo, rewrite with
+    `git filter-repo --invert-paths --path <file>` (or BFG), force-push, and
+    have every clone re-clone. Do **not** run casually.
+- [ ] **cla-assistant bot** wired (GitHub App) so external PRs collect the CLA.
+- [ ] **Branch protection on `main`** (available once the repo is public / Pro):
+      require the PR-title check and a review.
+- [ ] **`gh repo edit --visibility public`** and confirm the repo name is
+      `Castwright`.
+- [ ] **Licence-key seam (Cast Pass)** — needs an `fs-` plan (server settings +
+      companion pairing + series matcher). Not a blocker for a free-tier-only
+      public release.
+
+## Trade mark
+
+Register "Castwright" as a trade mark (AU via IP Australia first, ~AU$250/class
+self-filed; US later) — tracked as **ops-12**. Strengthens the `brand/`
+all-rights-reserved carve-out against a confusing fork. Not executed here.
+
+## Sources
+
+- FSL template: <https://github.com/getsentry/fsl.software> (`FSL-1.1-ALv2.template.md`).
+- Engine licences: the Hugging Face model cards linked in the audit table,
+  verified 8 June 2026.
+- Decisions & rationale:
+  [`brand/monetisation-free-vs-gated-2026-06-08.md`](../brand/monetisation-free-vs-gated-2026-06-08.md)
+  §5 (action items) and §7 (distribution & licensing).

--- a/docs/superpowers/plans/2026-06-08-v17-public-readiness-docs-licensing.md
+++ b/docs/superpowers/plans/2026-06-08-v17-public-readiness-docs-licensing.md
@@ -1,0 +1,778 @@
+# v1.7.0 Public-Readiness: Docs + Licensing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the developer-oriented README into an app/user-facing document, tidy INSTALL for a first-time public reader, and create every licensing artifact for the first public GitHub release of Castwright — without flipping the repo public yet.
+
+**Architecture:** Pure docs/licensing change in the `docs` scope. Four new files (`LICENSE`, `brand/LICENSE`, `NOTICE`, `docs/licensing.md`) carry exact, verified content; three existing files (`README.md`, `INSTALL.md`, `CONTRIBUTING.md`) are edited surgically. No code, no tests, no version bump.
+
+**Tech Stack:** Markdown + plain-text licence files. Verification via `grep`/manual link check. Worktree at `C:\Claude\Projects\wt-docs-v17`, branch `docs/docs-v17-public-readiness`, worktree-scoped husky hooks already configured.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-v17-public-readiness-docs-licensing-design.md`
+
+**Working rules for the executor:**
+- All paths below are relative to the worktree root `C:\Claude\Projects\wt-docs-v17`.
+- Commit subjects MUST be `docs(docs): <subject>` (the worktree-scoped commit-msg hook enforces it). `docs` scope skips the test legs in pre-commit.
+- Stage files **explicitly by path** in each commit — never `git add -A` (the untracked `.husky-wt/` dir must not be committed).
+- Licence files are reproduced **verbatim** where this plan marks them verbatim. Do not reword legal text.
+- Release-framing rule: v1.7.0 is the **first public release**. No comparative/changelog framing, no per-version upgrade history, no inline `(vX.Y.Z)` feature tags. Use `vX.Y.Z` placeholders for artifact names.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `LICENSE` *(new)* | The code licence — FSL-1.1-ALv2 verbatim, filled placeholders |
+| `brand/LICENSE` *(new)* | Brand-asset carve-out — all rights reserved + fair use |
+| `NOTICE` *(new)* | Third-party / bundled-model attributions + engine-audit summary |
+| `docs/licensing.md` *(new)* | Maintainer-facing licence model, engine audit, repo-opening checklist |
+| `README.md` *(rewrite)* | App/user-facing project front page incl. License section |
+| `INSTALL.md` *(edit)* | Add Configuration; remove migration history; forward-looking Updating |
+| `CONTRIBUTING.md` *(edit)* | Add "Contributing & licensing" section |
+
+---
+
+## Task 1: `LICENSE` (FSL-1.1-ALv2, verbatim)
+
+**Files:**
+- Create: `LICENSE`
+
+- [ ] **Step 1: Create the file with this exact content**
+
+(Verbatim FSL-1.1-ALv2 template with `${year}`→`2026`, `${licensor name}`→`Mikhail Dudarenok`. Do not alter wording.)
+
+```
+# Functional Source License, Version 1.1, ALv2 Future License
+
+## Abbreviation
+
+FSL-1.1-ALv2
+
+## Notice
+
+Copyright 2026 Mikhail Dudarenok
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+```
+
+- [ ] **Step 2: Verify the placeholders are filled and no template tokens remain**
+
+Run: `grep -nE '\$\{|licensor name|\{year\}' LICENSE`
+Expected: no output (exit 1).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add LICENSE
+git commit -m "docs(docs): add FSL-1.1-ALv2 LICENSE"
+```
+
+---
+
+## Task 2: `brand/LICENSE` (all rights reserved)
+
+**Files:**
+- Create: `brand/LICENSE`
+
+- [ ] **Step 1: Create the file with this exact content**
+
+```
+Castwright brand assets — Copyright © 2026 Mikhail Dudarenok. All rights reserved.
+
+This directory ("brand/") contains the Castwright name, wordmarks, logos, the
+"Castwave" mark, icons, colour system, and related identity assets.
+
+These brand assets are NOT covered by the Functional Source License that governs
+the Castwright source code (see the LICENSE file at the repository root). A
+licence to the code is not a licence to the identity.
+
+You MAY, without prior permission, reproduce the unmodified marks at reasonable
+size for the purpose of identifying or referring to Castwright in news articles,
+reviews, academic work, and similar editorial or informational contexts (nominative
+fair use).
+
+You MAY NOT, without prior written permission from the copyright holder:
+
+- use the marks (or anything confusingly similar) to name, brand, or promote
+  another product, service, fork, or distribution;
+- imply sponsorship, affiliation, or endorsement by Castwright;
+- modify, recolour, or redraw the marks; or
+- incorporate the marks into your own logos or trademarks.
+
+"Castwright" is an unregistered trade mark of the copyright holder; trade-mark
+registration is in progress. All rights not expressly granted above are reserved.
+
+Questions / permission requests: open an issue on the repository.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add brand/LICENSE
+git commit -m "docs(docs): add brand asset licence (all rights reserved)"
+```
+
+---
+
+## Task 3: `NOTICE` (third-party + bundled-model attributions)
+
+**Files:**
+- Create: `NOTICE`
+
+Engine licences below were verified 8 June 2026 from the Hugging Face model cards.
+
+- [ ] **Step 1: Create the file with this exact content**
+
+```
+Castwright
+Copyright © 2026 Mikhail Dudarenok
+
+This product is licensed under the Functional Source License, Version 1.1,
+ALv2 Future License (FSL-1.1-ALv2). See the LICENSE file at the repository root.
+
+Castwright incorporates and/or works with third-party components, each governed
+by its own licence. Model weights are bundled in the release only when their
+upstream licence permits commercial redistribution; non-commercial weights are
+downloaded on demand from their official source and are never bundled.
+
+Rule of thumb: the installer may fetch weights from their official home; the
+release archive bundles nothing whose licence is unverified.
+
+============================================================
+Bundled model weights
+============================================================
+
+Kokoro v1 (text-to-speech)
+  Upstream: hexgrad/Kokoro-82M; ONNX build via thewh1teagle/kokoro-onnx
+  Licence:  Apache License 2.0
+  Source:   https://huggingface.co/hexgrad/Kokoro-82M
+            https://github.com/thewh1teagle/kokoro-onnx
+  Verified: 8 June 2026
+
+============================================================
+Optional model weights (downloaded on demand, NOT bundled)
+============================================================
+
+Qwen3-TTS (text-to-speech; per-character designed voices)
+  Models:   Qwen/Qwen3-TTS-12Hz-0.6B-Base
+            Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign
+  Licence:  Apache License 2.0
+  Source:   https://huggingface.co/Qwen/Qwen3-TTS-12Hz-0.6B-Base
+            https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign
+  Verified: 8 June 2026
+
+Coqui XTTS v2 (text-to-speech; zero-shot voice cloning)
+  Model:    coqui/XTTS-v2
+  Licence:  Coqui Public Model License 1.0.0 (CPML) — NON-COMMERCIAL
+  Status:   NOT bundled. Fetched on demand from the original source; its licence
+            is shown at install time and it is offered as a user-supplied,
+            optional engine.
+  Source:   https://huggingface.co/coqui/XTTS-v2
+  Verified: 8 June 2026
+
+Whisper / faster-whisper (optional speech-to-text quality check)
+  Licence:  MIT (OpenAI Whisper models) — downloaded on demand under their
+            upstream licence.
+  Source:   https://github.com/SYSTRAN/faster-whisper
+
+============================================================
+Application dependencies
+============================================================
+
+The frontend, server, and TTS sidecar depend on third-party npm and PyPI
+packages, each retaining its own open-source licence. See each package's
+distribution (node_modules, the Python environment) for the full texts.
+```
+
+- [ ] **Step 2: Verify no unresolved verification placeholders**
+
+Run: `grep -niE 'TODO|TBD|verify before|unverified-claim' NOTICE`
+Expected: no output (the "unverified" appears only in the rule-of-thumb sentence; if `grep` matches only that line, that is fine — confirm visually).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add NOTICE
+git commit -m "docs(docs): add NOTICE with bundled-model licence attributions"
+```
+
+---
+
+## Task 4: `docs/licensing.md` (maintainer compliance home)
+
+**Files:**
+- Create: `docs/licensing.md`
+
+- [ ] **Step 1: Create the file with this exact content**
+
+````markdown
+# Licensing & repo-opening compliance
+
+Maintainer-facing record of Castwright's licensing model, the bundled-model
+audit, and the checklist that must clear before the GitHub repository is made
+public. Companion to
+[`brand/monetisation-free-vs-gated-2026-06-08.md`](../brand/monetisation-free-vs-gated-2026-06-08.md)
+§5 and §7.
+
+## The model
+
+- **Code** — Functional Source License v1.1 with an Apache-2.0 future grant
+  (**FSL-1.1-ALv2**, a.k.a. FSL-1.1-Apache-2.0). Source-available, *not* OSI
+  open source: any use is permitted except a Competing Use, and each release's
+  code converts to plain Apache-2.0 two years after it is made available. File:
+  [`/LICENSE`](../LICENSE).
+- **Brand** — the `brand/` assets are all rights reserved
+  ([`brand/LICENSE`](../brand/LICENSE)). A code licence is not a licence to the
+  identity.
+- **Engine weights** — bundled only if the upstream licence permits commercial
+  redistribution; non-commercial weights are download-on-demand from their
+  official home and never bundled ([`/NOTICE`](../NOTICE)).
+- **Paid gate (future)** — an Ed25519-signed offline licence key for the "Cast
+  Pass", no phone-home (monetisation §7.2). Not built; needs an `fs-` plan.
+
+## Engine-licence audit
+
+Verified 8 June 2026 from the Hugging Face model cards. **Re-verify at the
+pinned release version before every public release** — a model card licence can
+change between snapshots.
+
+| Engine | Model(s) | Upstream licence | Bundled? | Verified |
+|---|---|---|---|---|
+| Kokoro v1 | hexgrad/Kokoro-82M (ONNX via thewh1teagle/kokoro-onnx) | Apache-2.0 | **Yes** — weights ship / install with the app | 8 Jun 2026 |
+| Qwen3-TTS Base | Qwen/Qwen3-TTS-12Hz-0.6B-Base | Apache-2.0 | No — download-on-demand | 8 Jun 2026 |
+| Qwen3-TTS VoiceDesign | Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign | Apache-2.0 | No — download-on-demand | 8 Jun 2026 |
+| Coqui XTTS v2 | coqui/XTTS-v2 | **CPML — non-commercial** | No — download-on-demand, licence shown at install | 8 Jun 2026 |
+| Whisper (QA, optional) | faster-whisper models | MIT | No — download-on-demand | known; re-confirm |
+
+Rule of thumb: the installer may fetch weights from their official home; the
+release archive bundles nothing whose licence is unverified.
+
+## Repo-opening checklist
+
+**Done in the docs/licensing pass:**
+
+- [x] `LICENSE` (FSL-1.1-ALv2)
+- [x] `brand/LICENSE` (all rights reserved + nominative fair use)
+- [x] `NOTICE` (bundled-model attributions + audit summary)
+- [x] README license statement (source-available, brand carve-out, model notice)
+- [x] CONTRIBUTING contribution-licensing terms (DCO / CLA / PRs-by-invitation)
+
+**Pending before flipping the repo public:**
+
+- [ ] **Companion website (`castwright.ai`) live** — the stated gate for going
+      public; the public-flip and any "Cast Pass" messaging wait for it.
+- [ ] **Git history scrub — DESTRUCTIVE, force-push.** Audit history for
+      committed secrets and copyrighted fixtures, then rewrite if found:
+  - Audit: `git log --all --full-history -- '**/.env' 'server/.env'` and a
+    secret scan (e.g. `gitleaks detect`, `trufflehog`). Also check the canonical
+    copyrighted manuscript fixture never entered history:
+    `git log --all --full-history --oneline -- '**/*Keefe*'`.
+  - If anything is found: back up the repo, rewrite with
+    `git filter-repo --invert-paths --path <file>` (or BFG), force-push, and
+    have every clone re-clone. Do **not** run casually.
+- [ ] **cla-assistant bot** wired (GitHub App) so external PRs collect the CLA.
+- [ ] **Branch protection on `main`** (available once the repo is public / Pro):
+      require the PR-title check and a review.
+- [ ] **`gh repo edit --visibility public`** and confirm the repo name is
+      `Castwright`.
+- [ ] **Licence-key seam (Cast Pass)** — needs an `fs-` plan (server settings +
+      companion pairing + series matcher). Not a blocker for a free-tier-only
+      public release.
+
+## Trade mark
+
+Register "Castwright" as a trade mark (AU via IP Australia first, ~AU$250/class
+self-filed; US later) — tracked as **ops-12**. Strengthens the `brand/`
+all-rights-reserved carve-out against a confusing fork. Not executed here.
+
+## Sources
+
+- FSL template: <https://github.com/getsentry/fsl.software> (`FSL-1.1-ALv2.template.md`).
+- Engine licences: the Hugging Face model cards linked in the audit table,
+  verified 8 June 2026.
+- Decisions & rationale:
+  [`brand/monetisation-free-vs-gated-2026-06-08.md`](../brand/monetisation-free-vs-gated-2026-06-08.md)
+  §5 (action items) and §7 (distribution & licensing).
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/licensing.md
+git commit -m "docs(docs): add licensing compliance + repo-opening checklist"
+```
+
+---
+
+## Task 5: `README.md` — rewrite to app/user-facing
+
+**Files:**
+- Modify (full replace): `README.md`
+
+- [ ] **Step 1: Replace the ENTIRE file content with the following**
+
+````markdown
+# Castwright
+
+> _Any book, performed by a full cast — effortlessly. Even in your own voice._
+
+Turn a manuscript into a finished, **full-cast** audiobook on your own machine —
+every character in their own voice, consistent across a whole series. Castwright
+runs locally end-to-end; nothing leaves your computer unless you opt into a cloud
+analyzer.
+
+Upload `.md` / `.txt` / `.epub` / `.pdf` / `.mobi` / `.azw3` → an analyzer
+extracts characters, chapters, and per-sentence speaker tags → assign a voice to
+each character → generate per-chapter audio → listen, revise, and export to M4B
+or MP3.
+
+## What you get
+
+- **Full-cast narration** — every character speaks in their own voice, not one
+  flat narrator.
+- **Series memory** — a character keeps the same voice across every book in a
+  series.
+- **Your own voice** — clone a voice from a short sample (optional, on-device).
+- **Private by default** — analysis and speech run on your machine; cloud is
+  opt-in.
+- **You own the files** — export standard M4B / MP3 / AAC / Opus and keep them.
+  No lock-in.
+
+## Features
+
+- **Ingest** — paste or upload `.md`, `.txt`, `.epub`, `.pdf`, `.mobi`, or
+  `.azw3`. Chapters and character names are extracted automatically; low-confidence
+  speaker tags are surfaced for a quick review pass. DRM-protected files are
+  rejected up front. Re-uploading a book shows a sentence-level diff before
+  anything changes.
+- **Analyzer choice** — run a fully local model via Ollama (no API key, nothing
+  leaves your machine) or use the Gemini free tier. For long books, an optional
+  two-model pipeline runs cast detection and sentence attribution in parallel to
+  roughly double throughput.
+- **Voice & cast** — per-engine voice catalogues with family grouping, drag- or
+  tap-to-assign, per-character overrides, and sample playback. Audition candidate
+  voices in the profile drawer before committing, and compare two characters side
+  by side — even across books.
+- **TTS engines** — Kokoro (fast, English, runs on a modest GPU), Coqui XTTS v2
+  (zero-shot voice cloning, optional download), Qwen3-TTS (designs a unique voice
+  per character from a persona and reuses it across the series), and Gemini cloud.
+  A character keeps its voice when you switch engines.
+- **Generation** — per-chapter, resumable, and sticky across navigation; chapters
+  synthesise in a bounded parallel pool. Each chapter opens with its title spoken
+  in the narrator's voice. Open the same book in two tabs and progress stays in
+  sync.
+- **Revisions & drift** — pending-revision review, A/B audition with rollback, a
+  per-chapter revision timeline, and automatic detection (with one-click
+  regeneration) when a chapter's voices drift from the current cast.
+- **Listening** — a built-in player with speed control, markers, a sleep timer,
+  true waveform peaks, resume bookmarks, per-book notes, and one-tap sharing of a
+  30-second clip or the whole book.
+- **Library** — auto-fetched cover art with a manual cover picker (search /
+  upload / frame), title & author search, tag filters, series grouping, and a
+  portable book bundle for backup or transfer.
+- **Export** — M4B (with cover and chapter markers), AAC/M4A, Opus, MP3 (zip or
+  per-chapter folder), plus LAN download with a QR code. EBU R128 loudness
+  normalisation is on by default.
+- **Mobile, tablet & companion app** — every view is responsive across phone /
+  tablet / desktop and reachable over your home network via HTTPS, with a native
+  Android companion that syncs only what changed and plays offline (background,
+  lock-screen, Bluetooth, Android Auto).
+
+## Quickstart
+
+Download the latest `castwright-vX.Y.Z.zip` from
+[Releases](https://github.com/dudarenok-maker/Castwright/releases), extract it,
+and follow **[INSTALL.md](INSTALL.md)**. You'll end up with a single
+`npm run start:prod` command that brings up the server, the TTS sidecar, and the
+web UI at <http://localhost:8080>.
+
+**Prerequisites** (full detail and per-OS steps in [INSTALL.md](INSTALL.md)):
+
+- Node.js 20.19+
+- Python 3.11 (for the TTS sidecar)
+- ffmpeg on `PATH`
+- ~3 GB free disk for the TTS weights
+- An NVIDIA GPU is strongly recommended (TTS on CPU is far slower)
+
+## Companion app (Android)
+
+A native Flutter companion pairs to your running server over the home network
+(HTTPS, cert-pinned), delta-syncs only the chapters that changed, and plays them
+offline with background, lock-screen, Bluetooth, and Android Auto controls.
+Pairing is cryptographically self-verified, so **no certificate install is needed
+on the phone**.
+
+Each [GitHub Release](https://github.com/dudarenok-maker/Castwright/releases)
+attaches a ready-to-sideload `castwright-vX.Y.Z.apk`. Server-side pairing setup
+(LAN HTTPS + an access token) is in [INSTALL.md](INSTALL.md); the app's own build
+and usage notes are in [`apps/android/README.md`](apps/android/README.md).
+
+## Releases
+
+Tagged releases are published to
+[GitHub Releases](https://github.com/dudarenok-maker/Castwright/releases). Each
+attaches (all with `.sha256` checksums):
+
+- `castwright-vX.Y.Z.zip` — the platform-independent **server** bundle
+  (Windows / macOS / Linux); install via [INSTALL.md](INSTALL.md).
+- `castwright-vX.Y.Z.apk` — the sideloadable **Android companion** app.
+- `castwright-vX.Y.Z-ios-unsigned.*` — an **unsigned iOS** build (needs Apple
+  signing to become an installable `.ipa`).
+
+After the first public release, upgrading is one click inside the app
+(**Account → Application updates**); see [INSTALL.md](INSTALL.md#updating).
+
+## How it's built
+
+Castwright is a Vite + React frontend, a Node/Express server, and a Python
+(FastAPI) TTS sidecar, with a native Flutter companion app. Building from source,
+the branching model, and the commit convention are documented in
+**[CONTRIBUTING.md](CONTRIBUTING.md)**.
+
+## Documentation
+
+- **[INSTALL.md](INSTALL.md)** — install, configure, and update the app.
+- **[`apps/android/README.md`](apps/android/README.md)** — the Android companion.
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** — building from source, branching, and
+  the commit convention.
+
+## License
+
+Castwright is **source-available — not OSI open source**. The code is licensed
+under the **Functional Source License v1.1 with an Apache-2.0 future grant**
+(FSL-1.1-ALv2, a.k.a. FSL-1.1-Apache-2.0) — see **[LICENSE](LICENSE)**. In short:
+use, modify, and share it for any purpose **except** building a competing product
+or service; two years after each release, that release's code becomes Apache-2.0.
+Leading with this plainly is deliberate — it bars a competing fork from day one
+while keeping the source fully readable.
+
+- **Brand assets** in [`brand/`](brand/) are **not** covered by the code licence —
+  all rights reserved ([`brand/LICENSE`](brand/LICENSE)).
+- **Model weights** carry their own upstream licences ([NOTICE](NOTICE)). Coqui
+  XTTS v2 is non-commercial (CPML) and is therefore download-on-demand, never
+  bundled.
+
+**Contributing:** issues welcome; PRs by invitation for now (a DCO sign-off and a
+lightweight CLA apply — see [CONTRIBUTING.md](CONTRIBUTING.md)).
+````
+
+- [ ] **Step 2: Verify the dev sections and changelog framing are gone**
+
+Run: `grep -nE 'worktree|Parallel sessions|verify:fast|Testing harness|\(v1\.[0-9]|cannot self-upgrade|Private — not' README.md`
+Expected: no output (exit 1). (A single match on `npm run start:prod` context is acceptable only if it is the Quickstart line — there should be none of the listed patterns.)
+
+- [ ] **Step 3: Verify every relative link target exists**
+
+Run: `grep -oE '\]\(([A-Za-z][^)]*)\)' README.md`
+Then eyeball that each path (`INSTALL.md`, `LICENSE`, `NOTICE`, `brand/`, `brand/LICENSE`, `CONTRIBUTING.md`, `apps/android/README.md`) exists in the tree.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(docs): rewrite README as app-focused for first public release"
+```
+
+---
+
+## Task 6: `INSTALL.md` — add Configuration, drop migration history, forward-looking Updating
+
+**Files:**
+- Modify: `INSTALL.md`
+
+- [ ] **Step 1: Add a Configuration section.** Insert the following block immediately BEFORE the line `## Setting up the analyzer` (i.e. after the Troubleshooting section, before analyzer setup):
+
+````markdown
+## Configuration
+
+The server reads `server/.env` (copied from `server/.env.example` in the install
+steps above). All knobs have safe defaults — set only what you need.
+
+**Analyzer**
+
+- `ANALYZER` — `local` (default, Ollama) or `gemini`.
+- `GEMINI_API_KEY` — required when `ANALYZER=gemini` (or as the automatic
+  fallback when Ollama is unreachable).
+- `GEMINI_MODEL` — the Gemini model id; plus per-model `GEMINI_RPM_*` /
+  `GEMINI_TPM_*` / `GEMINI_RPD_*` rate caps (see `server/.env.example`).
+- `ANALYZER_PHASE0_MODEL` / `ANALYZER_PHASE1_MODEL` /
+  `ANALYZER_PHASE1_MIN_LAG_CHAPTERS` — optional two-model analyzer (cast
+  detection + sentence attribution in parallel). Set both phase vars to enable.
+
+**Generation & TTS**
+
+- `WORKSPACE_DIR` — where your per-book library lives (set this to a writable
+  folder).
+- `GEN_WORKERS` — how many chapters synthesise at once (default `2`).
+- `GPU_VRAM_BUDGET` — VRAM-weighted GPU budget in GiB (default `8`). Drop to `6`
+  on a 6 GB card.
+- `PRELOAD_COQUI` — `0` (default; Coqui loads on demand) or `1`.
+- `QWEN_BATCH_SIZE` (default `8`) and `QWEN_ATTN_IMPL` (default `sdpa`) — Qwen
+  tuning knobs.
+- `AUDIO_LOUDNORM_ENABLED` — `true` (default; two-pass EBU R128 at
+  -16 LUFS / 11 LU / -1.5 dBTP) or `false` to opt out.
+
+**LAN / companion access**
+
+- `LAN_HTTPS` — `1` serves over mkcert-backed HTTPS on `:8443`, bound on all
+  interfaces (phone/tablet web + the Android companion). Off by default;
+  `npm run start:lan` sets it. Requires the LAN cert
+  (`npm run install:cert-mobile`); with `LAN_HTTPS=1` the server refuses to start
+  if the cert is missing.
+- `LAN_AUTH_TOKEN` — the shared pairing secret for the companion (and the LAN
+  access guard on `/api` + `/workspace`). Required for the companion app.
+````
+
+- [ ] **Step 2: Delete the migration-history sections.** Remove these three subsections in their entirety from the `## Updating` area:
+  - `### One-time conversion when you adopt v1.6.0 (from v1.5.x)` (and its numbered steps + the trailing paragraph ending "...the first self-upgrade you'll experience is 1.6.0 → 1.7.0. (1.6.0 ships the mechanism; it can't upgrade *into* itself.)")
+  - `### v1.4.0 → v1.5.0 notes` (entire bullet list)
+  - `### v1.3.x → v1.4.0 notes` (entire bullet list)
+
+Keep `### Manual fallback (any version)`.
+
+- [ ] **Step 3: Rewrite the `## Updating` opening.** Replace everything from the `## Updating` heading down to (but not including) `### Manual fallback (any version)` with:
+
+````markdown
+## Updating
+
+Upgrading is one click in the app: open **Account → Application updates**, pick
+the new `castwright-vX.Y.Z.zip`, confirm the version delta, and the app stages,
+validates, swaps, reinstalls dependencies, migrates your book data (with an
+automatic backup first), and restarts itself. No terminal commands.
+
+This works because Castwright uses a **versioned-directory layout**: each release
+lives in its own `releases/vX.Y.Z/` folder, a stable `launch.mjs` at the install
+root always runs the current one, and your data lives in shared siblings outside
+the release folders. An upgrade extracts the new release into a *fresh* folder and
+only flips a pointer once it's ready — the running version is never touched, so a
+failed upgrade just keeps running the previous one. A fresh install already ships
+this machinery, so there is nothing to convert.
+
+```
+<install>/
+  launch.mjs            <- start the app from here (shortcut / start-app.bat points at it)
+  .current-version      <- e.g. "1.7.0"
+  releases/v1.7.0/      <- the code (one extracted zip)
+  workspace/            <- your library (books, voices)
+  venv/  models/kokoro/ <- shared Python venv + Kokoro weights
+  logs/  .run/
+```
+
+Your account settings live in `~/.castwright/user-settings.json` (outside any
+install folder) and carry over automatically; copy your old `server/.env` into
+`releases/vX.Y.Z/server/.env` if you set custom keys.
+````
+
+- [ ] **Step 4: Sweep remaining inline version tags in INSTALL.** Open the file and remove parenthetical `(v1.4.0)` / `(v1.5.0)` / `(v1.3.0)` style tags from section headings and prose where they read as changelog noise (e.g. `## Picking a chapter audio format (v1.4.0)` → `## Picking a chapter audio format`; `## Mobile + tablet access over LAN HTTPS (v1.4.0)` → drop the tag). Leave the `## Switching TTS to Qwen3-TTS` section's substance intact but drop its `(v1.5.0, ...)` tag from the heading. Do NOT change install commands or technical content.
+
+- [ ] **Step 5: Verify the migration history is gone and no stale version tags remain in headings**
+
+Run: `grep -nE 'One-time conversion|v1\.4\.0 → v1\.5\.0|v1\.3\.x → v1\.4\.0|adopt v1\.6\.0' INSTALL.md`
+Expected: no output (exit 1).
+
+Run: `grep -nE '^#+ .*\(v1\.[0-9]' INSTALL.md`
+Expected: no output (exit 1) — no heading carries an inline version tag.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add INSTALL.md
+git commit -m "docs(docs): add Configuration, drop pre-public upgrade history from INSTALL"
+```
+
+---
+
+## Task 7: `CONTRIBUTING.md` — add "Contributing & licensing"
+
+**Files:**
+- Modify: `CONTRIBUTING.md`
+
+- [ ] **Step 1: Insert a new section** immediately after the `## TL;DR` list (before `## Branching model`):
+
+````markdown
+## Contributing & licensing
+
+Castwright is **source-available under the Functional Source License**
+(FSL-1.1-ALv2, a.k.a. FSL-1.1-Apache-2.0) — not OSI open source. See
+[`LICENSE`](LICENSE); the [README license section](README.md#license) explains
+the model in one paragraph. The `brand/` assets are **not** covered by the code
+licence — all rights reserved ([`brand/LICENSE`](brand/LICENSE)).
+
+**Posture today: issues welcome, PRs by invitation.** Until the CLA tooling is in
+place, please open an issue to discuss a change before sending a PR.
+
+**When external PRs open up,** two things will be required on every contribution:
+
+- **DCO sign-off** — add `Signed-off-by: Your Name <you@example.com>` to each
+  commit (`git commit -s`), certifying you wrote the change and may submit it
+  under the project licence.
+- **A lightweight CLA** — so the maintainer retains the right to relicense (the
+  FSL future-grant and any relicensing depend on owning the copyright). This will
+  be collected by a CLA bot; see [`docs/licensing.md`](docs/licensing.md).
+````
+
+- [ ] **Step 2: Verify the section landed and links are intact**
+
+Run: `grep -nE 'Contributing & licensing|Signed-off-by|FSL-1.1-ALv2' CONTRIBUTING.md`
+Expected: the new section's lines appear.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CONTRIBUTING.md
+git commit -m "docs(docs): add contributing & licensing terms (DCO / CLA / FSL)"
+```
+
+---
+
+## Task 8: Final verification sweep
+
+**Files:** none (read-only checks)
+
+- [ ] **Step 1: No "Private — not licensed" residue anywhere in user docs**
+
+Run: `grep -rnE 'Private — not currently licensed|not currently licensed for redistribution' README.md INSTALL.md CONTRIBUTING.md`
+Expected: no output (exit 1).
+
+- [ ] **Step 2: All new licensing files exist and are non-empty**
+
+Run: `for f in LICENSE NOTICE brand/LICENSE docs/licensing.md; do test -s "$f" && echo "OK $f" || echo "MISSING $f"; done`
+Expected: four `OK` lines.
+
+- [ ] **Step 3: No template placeholders survived in licence files**
+
+Run: `grep -rnE '\$\{|\{year\}|licensor name|TODO|TBD' LICENSE NOTICE brand/LICENSE docs/licensing.md`
+Expected: no output (exit 1).
+
+- [ ] **Step 4: Confirm `.husky-wt/` was never staged**
+
+Run: `git log --name-only --pretty=format: docs/docs-v17-public-readiness | grep -c '.husky-wt'`
+Expected: `0`.
+
+- [ ] **Step 5: Review the full diff against `main`**
+
+Run: `git diff main --stat`
+Expected: only `README.md`, `INSTALL.md`, `CONTRIBUTING.md`, `LICENSE`, `NOTICE`, `brand/LICENSE`, `docs/licensing.md`, and the two `docs/superpowers/{specs,plans}/...` files.
+
+- [ ] **Step 6: Open the PR (draft) per CONTRIBUTING**
+
+```bash
+git push -u origin docs/docs-v17-public-readiness
+gh pr create --draft --title "docs(docs): v1.7.0 public-readiness docs + licensing" --body "<summary + test plan>"
+```
+
+PR body must include `## Summary` (the docs/licensing wrap-up; note the repo is NOT
+yet flipped public — that waits on the companion website) and `## Test plan`
+(`- [ ] npm run verify — green`; manual link check; grep sweeps from Task 8).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Spec §1 README app-focus → Task 5. ✓
+- Spec §2 INSTALL cleanup (Configuration, drop history, forward Updating) → Task 6. ✓
+- Spec §3 licensing files (LICENSE, brand/LICENSE, NOTICE, README license) → Tasks 1, 2, 3, 5. ✓
+- Spec §4 CONTRIBUTING CLA/DCO → Task 7. ✓
+- Spec §5 docs/licensing.md + flagged follow-ups (history scrub, CLA bot, visibility flip) → Task 4. ✓
+- Release-framing constraint (first public release, no version tags) → enforced in Tasks 5 & 6 with grep gates. ✓
+- Engine audit web-verification → done during planning; results baked into Tasks 3 & 4. ✓
+
+**Placeholder scan:** Licence/NOTICE/licensing.md bodies are complete verbatim text. The only `<...>` placeholder is the PR body in Task 8 Step 6, which is intentional (author writes it at PR time). No "TBD/TODO/implement later" in deliverable content.
+
+**Type/naming consistency:** Licence named consistently as "FSL-1.1-ALv2 (a.k.a. FSL-1.1-Apache-2.0)" across LICENSE, NOTICE, README, CONTRIBUTING, docs/licensing.md. Licensor "Mikhail Dudarenok" consistent. Model ids match the installers (`Qwen/Qwen3-TTS-12Hz-0.6B-Base`, `Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign`, `hexgrad/Kokoro-82M`, `coqui/XTTS-v2`).

--- a/docs/superpowers/specs/2026-06-08-v17-public-readiness-docs-licensing-design.md
+++ b/docs/superpowers/specs/2026-06-08-v17-public-readiness-docs-licensing-design.md
@@ -1,0 +1,221 @@
+# v1.7.0 public-readiness: docs cleanup + licensing wrap-up
+
+**Date:** 8 June 2026
+**Status:** design (approved in brainstorming; pending spec review)
+**Scope:** `docs` — `README.md`, `INSTALL.md`, `CONTRIBUTING.md`, new `LICENSE`,
+new `brand/LICENSE`, new `NOTICE`, new `docs/licensing.md`.
+**Companion to:** `brand/monetisation-free-vs-gated-2026-06-08.md` (§5 action
+items, §7 distribution & licensing), `brand/brand-guidelines.md`,
+`docs/project-narrative.md`.
+
+---
+
+## Goal
+
+Prepare the user-facing documentation and the licensing artifacts for the first
+**public** GitHub release of Castwright, cut as v1.7.0 (possibly v1.8.0 — see
+"Release framing"). Two threads:
+
+1. **Docs cleanup** — turn the developer-oriented `README.md` into an
+   app/user/deployer-facing document; tidy `INSTALL.md` for a first-time public
+   reader; keep `CONTRIBUTING.md` / `CLAUDE.md` as the developer home.
+2. **Licensing wrap-up** — create all the licensing files the monetisation doc's
+   repo-opening checklist calls for (`LICENSE`, `brand/LICENSE`, `NOTICE`,
+   contribution terms), and record the engine-licence audit and the remaining
+   repo-opening steps in one place (`docs/licensing.md`).
+
+## Non-goals (this pass)
+
+- **Do not flip the repo to public.** The user is building the companion website
+  (`castwright.ai`) first; the visibility flip + any "we're now open / buy the
+  Cast Pass" messaging waits for that. The LICENSE governs the code regardless of
+  repo visibility, so the files and the README license statement are written in
+  their final public form now; only the `gh repo edit --visibility public` step
+  is deferred.
+- **Do not rewrite git history** (the secret/fixture scrub). It is destructive
+  and force-push-bound; this pass writes the exact checklist into
+  `docs/licensing.md` but executes nothing.
+- **Do not bump `package.json` versions.** That is `scripts/bump-version.mjs` at
+  release time.
+- **Do not touch** `apps/android/README.md` or `server/tts-sidecar/README.md` —
+  both are correctly-scoped component *developer* readmes.
+- No CLA-assistant bot wiring, no branch-protection enable, no licence-key
+  (`fs-`) seam — all recorded as follow-ups in `docs/licensing.md`.
+
+## Release framing (load-bearing constraint)
+
+v1.7.0 is the **first real public release**. Every earlier version
+(v1.0–v1.6.0) was limited to a single user (the author) and the alpha circle.
+Consequences for the docs:
+
+- There is **no public upgrade history**. The first upgrade any public user will
+  ever perform is *this release → the next one*.
+- `INSTALL.md` drops all the per-version migration notes (v1.5.x→1.6.0
+  converter, "v1.4.0 → v1.5.0 notes", "v1.3.x → v1.4.0 notes"). They documented
+  one person's private migrations.
+- `README.md` drops comparative / changelog framing: the inline `(v1.4.0)` /
+  `(v1.3.0)` feature tags and the "v1.6.0 cannot self-upgrade across the rename /
+  alpha installs reinstall fresh" note. Capabilities are presented as features of
+  v1, full stop. (This matches `CONTRIBUTING.md` → "Release notes" → "What stays
+  out": no comparative phrasing on an initial release.)
+- The exact number may be 1.7.0 or 1.8.0 depending on when the website + other
+  prerequisites land. Prose uses the `vX.Y.Z` placeholder for artifact names (the
+  repo's existing convention) and the phrase "the first public release" for
+  release-history semantics, so the docs survive either number.
+
+---
+
+## 1. `README.md` — strip to an app/user-facing document
+
+The current README (~338 lines) mixes user content with developer content that
+is **already fully documented** in `CONTRIBUTING.md` (branching, commit
+convention, worktrees, parallel sessions, releasing) and `CLAUDE.md` (testing
+discipline, commands). So "strip to app-focused" is mostly deletion + a pointer,
+not migration.
+
+**Keep & sharpen:**
+
+- Title, tagline, one-paragraph "what is this".
+- "What it does" — the ingest → analyse → cast → generate → listen/export
+  pipeline in plain language.
+- **Features** — condensed to clean capability bullets. Remove every inline
+  version tag. Group by surface (Ingest, Voice & cast, Generation, Listening,
+  Library, Export, Companion app) so a prospective user reads capabilities, not a
+  changelog.
+- **Quickstart (for users)** — lead with "download the release zip → follow
+  `INSTALL.md`", not git-clone. One short "Building from source" line pointing to
+  `CONTRIBUTING.md` for the contributor path.
+- **Companion app (Android)** — keep; it's user-facing. Trim the duplicated
+  server-side LAN setup detail down to a pointer into `INSTALL.md`.
+- **Releases** — keep (zip + apk + unsigned iOS, with `.sha256`).
+- **License** — rewrite (see §3).
+
+**Remove (replace with a single "Building from source / contributing →
+CONTRIBUTING.md" line):**
+
+- Testing harness table + verify batteries.
+- Parallel sessions / worktrees section.
+- Commit-gate / husky detail.
+- The exhaustive internal `src/` layout tree (a contributor reads the code; a
+  user does not need it). A short, high-level "How it's built" paragraph
+  (Vite + React frontend, Node/Express server, Python TTS sidecar, Flutter
+  companion) is enough.
+- The deployer env-knob list → **moves into `INSTALL.md` Configuration** (that's
+  where a deployer looks).
+
+## 2. `INSTALL.md` — cleanup pass
+
+Already user-facing and solid; no structural rewrite. Changes:
+
+- **Absorb the Configuration env-knob reference** from README into a single
+  "Configuration" section (ANALYZER / GEMINI_* / LAN_HTTPS / LAN_AUTH_TOKEN /
+  WORKSPACE_DIR / AUDIO_LOUDNORM_ENABLED / GEN_WORKERS / GPU_VRAM_BUDGET, etc.).
+- **Remove the historical migration sections** ("One-time conversion when you
+  adopt v1.6.0", "v1.4.0 → v1.5.0 notes", "v1.3.x → v1.4.0 notes") per the
+  release-framing constraint.
+- **Rewrite "Updating"** as forward-looking only: from this first public release
+  onward, upgrading is one click in **Account → Application updates** (the
+  versioned-directory mechanism that has existed since 1.6.0 ships in the box, so
+  a fresh install already has it — no one-time conversion, because there is no
+  prior *public* install to convert). Keep the manual-fallback subsection.
+- Make version references consistent with "first public release" framing.
+
+## 3. Licensing files (created now; repo stays private until the flip)
+
+Copyright/licensor identity: legal holder **Mikhail Dudarenok**, product/brand
+**Castwright** referenced alongside — e.g. *"Castwright — Copyright © 2026
+Mikhail Dudarenok"*.
+
+- **`LICENSE`** (root) — **FSL-1.1-Apache-2.0**, the official Functional Source
+  License template (Apache-2.0 future licence variant). Fields: Licensor =
+  *Mikhail Dudarenok*; the "Software" line names Castwright. FSL permits any use
+  **except** a competing product/service; each release's code converts to plain
+  Apache-2.0 two years after its publication date.
+- **`brand/LICENSE`** — **all rights reserved** for the `brand/` assets (logos,
+  wordmarks, the Castwave mark), with an explicit fair-use permission for
+  articles / reviews. States plainly that a code licence is not a licence to the
+  identity. Header: *"Castwright brand assets — Copyright © 2026 Mikhail
+  Dudarenok. All rights reserved."*
+- **`NOTICE`** (root) — public third-party / bundled-component attributions plus
+  the **engine-licence audit summary**:
+  - **Kokoro** — bundled weights; licence stated and **verified at the pinned
+    release version** (expected Apache-2.0).
+  - **Coqui XTTS v2** — **CPML, non-commercial → NOT bundled**; download-on-demand
+    from the original source only, licence shown at install, positioned as a
+    user-supplied optional engine.
+  - **Qwen3-TTS** — weight licence **verified** (Qwen releases vary between
+    Apache-2.0 and the Qwen licence); download-on-demand if restricted.
+  - Rule of thumb recorded: *the installer may fetch weights from their official
+    home; the release zip bundles nothing whose licence is unverified.*
+  - Implementation note: the Kokoro and Qwen3 licence claims are **web-verified
+    at their pinned versions while writing `NOTICE`** (the audit is a pre-launch
+    blocker per monetisation §5/§7.1). If a version cannot be verified
+    confidently, `NOTICE` records "verify before bundling" rather than asserting.
+- **README License section** — replaces *"Private — not currently licensed for
+  redistribution"* with: a one-line **source-available (FSL-1.1-Apache-2.0, not
+  OSI open source)** statement and why; the `brand/` carve-out; the bundled-model
+  notice (pointer to `NOTICE`); and the **"issues welcome, PRs by invitation"**
+  contribution stance.
+
+## 4. `CONTRIBUTING.md` — contribution-licensing terms
+
+Add a short **"Contributing & licensing"** section near the top:
+
+- The repo is **source-available under FSL-1.1-Apache-2.0**, not OSI open source.
+- **DCO sign-off required** on any external contribution (`Signed-off-by:` via
+  `git commit -s`); a lightweight **CLA** is required before a non-trivial
+  external PR is merged (cla-assistant wiring is a flagged follow-up).
+- Current posture: **"issues welcome, PRs by invitation"** until the CLA bot is
+  in place (per monetisation §7.1 — retrofitting a CLA after contributors
+  accumulate is painful).
+- `brand/` assets are not covered by the code licence (pointer to
+  `brand/LICENSE`).
+
+## 5. `docs/licensing.md` — the licensing-compliance home (new)
+
+Single place that records, for the maintainer:
+
+- The licence model (FSL code, all-rights-reserved brand, download-on-demand for
+  non-commercial engine weights) and *why* (links to monetisation §7).
+- **Engine-licence audit table** with verification status + date per engine.
+- **Repo-opening checklist** (from monetisation §5 action item 6), with each item
+  marked done / pending:
+  - `LICENSE`, `brand/LICENSE`, `NOTICE`, README statement, CONTRIBUTING terms —
+    *done in this pass*.
+  - **Git history secret/fixture scrub** — *pending*; exact targets (`.env`,
+    keys, the copyrighted *Bonus Keefe Story* fixture) and the recommended
+    `git filter-repo` command sketch, flagged destructive.
+  - cla-assistant bot; `gh repo edit --visibility public`; branch protection on
+    `main`; the licence-key (`fs-`) seam.
+- Trade-mark action (AU registration via IP Australia) referenced as a tracked
+  follow-up (ops-12), not executed here.
+
+---
+
+## File-by-file change list
+
+| File | Action |
+|---|---|
+| `README.md` | Restructure → app-focused; rewrite License section; remove dev sections + version tags + self-upgrade note |
+| `INSTALL.md` | Add Configuration section; remove historical migration sections; rewrite Updating as forward-looking |
+| `CONTRIBUTING.md` | Add "Contributing & licensing" section (FSL / DCO / CLA / PRs-by-invitation) |
+| `LICENSE` | **New** — FSL-1.1-Apache-2.0 |
+| `brand/LICENSE` | **New** — all rights reserved + fair-use note |
+| `NOTICE` | **New** — third-party + bundled-engine attributions + audit summary |
+| `docs/licensing.md` | **New** — licence model, engine audit, repo-opening checklist, flagged follow-ups |
+
+## Testing / verification
+
+Docs-and-licensing change — no automated tests apply. Verification:
+
+- `npm run verify:fast:scoped` on commit (docs scope skips the test legs; the
+  commit-msg hook validates the subject).
+- Manual: every internal link in the rewritten README/INSTALL resolves; no
+  remaining "Private — not licensed" string; no remaining inline `(vX.Y.Z)`
+  feature tags in README; no broken pointer to removed sections.
+- The engine-licence claims in `NOTICE` are each tied to a verification source +
+  date.
+
+## Ship notes
+
+_(filled at merge)_


### PR DESCRIPTION
## Summary

Prepares the user-facing docs and licensing artifacts for the first **public** release of Castwright. Does **not** flip the repo public — that stays gated on the companion website and is tracked as a pending item in `docs/licensing.md`. No `package.json` version bump.

- **README** rewritten app/user-facing: capability-grouped Features (no inline version tags), user Quickstart (download zip → INSTALL), and a source-available License section. Developer content removed (it already lives in CONTRIBUTING/CLAUDE) and replaced with a pointer.
- **INSTALL** gains a consolidated **Configuration** section (env knobs); drops all pre-public per-version upgrade history; **Updating** rewritten forward-looking (first public release = no migration-from-prior-public).
- **LICENSE** (new) — FSL-1.1-ALv2 (a.k.a. FSL-1.1-Apache-2.0), verbatim, © 2026 Mikhail Dudarenok.
- **brand/LICENSE** (new) — brand assets all rights reserved + nominative fair use.
- **NOTICE** (new) — bundled/optional model attributions, licences web-verified 8 Jun 2026 (Kokoro / Qwen3 Base + VoiceDesign = Apache-2.0; Coqui XTTS v2 = CPML non-commercial, download-on-demand only).
- **docs/licensing.md** (new) — licence model, engine-licence audit table, and the repo-opening checklist (history scrub flagged as a destructive pending step, not run here).
- **CONTRIBUTING** — adds a "Contributing & licensing" section (FSL / DCO sign-off / lightweight CLA / issues-welcome-PRs-by-invitation).

Spec: `docs/superpowers/specs/2026-06-08-v17-public-readiness-docs-licensing-design.md`
Plan: `docs/superpowers/plans/2026-06-08-v17-public-readiness-docs-licensing.md`

## Test plan

Docs/licensing-only change — `docs`-scope skips all automated test legs (pre-commit + CI path-filter). Verified via deterministic checks instead:

- [x] No version-tags / upgrade-history / "Private — not licensed" residue (grep gates).
- [x] No template placeholders in LICENSE / NOTICE / brand/LICENSE / docs/licensing.md.
- [x] Every internal markdown link resolves.
- [x] Engine licences verified against Hugging Face model cards (8 Jun 2026).
- [x] Branch touches only the 9 intended files; main untouched on those paths (clean merge).