### PR TITLE
fix(frontend): shorten Regenerate label + reorder chapter action row

### DIFF
--- a/src/views/generation.tsx
+++ b/src/views/generation.tsx
@@ -1571,6 +1571,16 @@ function ChapterRow({
           <button
             onClick={(e) => {
               e.stopPropagation();
+              onToggleExcluded(chapter.id, true);
+            }}
+            className="inline-flex items-center gap-1.5 min-h-[44px] px-2 text-xs font-medium text-ink/45 hover:text-ink/70 transition-colors"
+            title="Skip this chapter — no audio will be generated for it."
+          >
+            <IconClose className="w-3.5 h-3.5" /> Exclude
+          </button>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
               onRename(chapter);
             }}
             data-testid={`chapter-row-${chapter.id}-rename`}
@@ -1578,16 +1588,6 @@ function ChapterRow({
             className="inline-flex items-center gap-1.5 min-h-[44px] px-2 text-xs font-medium text-ink/60 hover:text-magenta transition-colors"
           >
             <IconPencil className="w-3.5 h-3.5" /> Rename
-          </button>
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onRegenerate(chapter);
-            }}
-            className="inline-flex items-center gap-1.5 min-h-[44px] px-2 text-xs font-medium text-ink/60 hover:text-magenta transition-colors"
-          >
-            <IconRefresh className="w-3.5 h-3.5" />{' '}
-            {chapter.state === 'failed' ? 'Retry chapter' : 'Regenerate this chapter'}
           </button>
           <button
             onClick={(e) => {
@@ -1604,12 +1604,13 @@ function ChapterRow({
           <button
             onClick={(e) => {
               e.stopPropagation();
-              onToggleExcluded(chapter.id, true);
+              onRegenerate(chapter);
             }}
-            className="inline-flex items-center gap-1.5 min-h-[44px] px-2 text-xs font-medium text-ink/45 hover:text-ink/70 transition-colors"
-            title="Skip this chapter — no audio will be generated for it."
+            aria-label={chapter.state === 'failed' ? 'Retry chapter' : 'Regenerate this chapter'}
+            className="inline-flex items-center gap-1.5 min-h-[44px] px-2 text-xs font-medium text-ink/60 hover:text-magenta transition-colors"
           >
-            <IconClose className="w-3.5 h-3.5" /> Exclude
+            <IconRefresh className="w-3.5 h-3.5" />{' '}
+            {chapter.state === 'failed' ? 'Retry chapter' : 'Regenerate'}
           </button>
         </div>
       )}


### PR DESCRIPTION
## Summary

The per-chapter action row on the generation view wrapped **Exclude** onto a second line at typical card widths. This:

- Shortens the visible button label **"Regenerate this chapter" → "Regenerate"** (the full text is preserved as the `aria-label`, so the accessible name is unchanged and it stays disambiguated from the book-level *Regenerate* button and the queued-row *"Generate chapter N"* escape hatch). All five actions now fit on one line.
- Reorders the actions to **Preview · Exclude · Rename · Re-analyse · Regenerate**.

Frontend-only, no behavior change.

## Test plan

- `npm test -- src/views/generation.test.tsx` — 60 passed (the `aria-label` keeps the existing role-name assertions green).
- Full frontend suite: 2508 passed.
- Verified in a real browser (mock mode): at the ~700px card width all five actions report `oneLine: true`; Exclude no longer wraps.
- `npm run verify` locally before merge.