### PR TITLE
feat(server,frontend): generation stall protection Wave 3 — better recovery (C1/C2/C3)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-generation-stall-protection-wave3.md
+++ b/docs/superpowers/plans/2026-06-08-generation-stall-protection-wave3.md
@@ -44,12 +44,18 @@ to the spec; only the internal task order differs.
 groups/workers of a chapter and equals the current `MAX_RECYCLE_RECOVERIES` (2),
 so total recovery attempts per chapter are unchanged from today — what changes is
 that each attempt re-renders ONE group, not the whole chapter. **C3 disposition
-(decided):** a single chapter's recycle-storm is recorded as a **non-fatal**
-named failure (`fatal: false`); the existing cross-chapter cascade
-(`recordNonFatal`) escalates to a run-stop when storms repeat — identical to how
-`ChapterStallError` is handled. This avoids a bespoke queue-pause path; if the
-user later wants a single storm to immediately pause the queue, that is a
-one-line follow-up (flip the branch to `fatal: true`).
+(REVISED after the C3 code-quality review — see below):** a single chapter's
+recycle-storm is recorded as a **non-fatal** named failure (`fatal: false`) AND
+**pauses the queue server-side on the queue path** so the run genuinely stops
+(the spec's "pause the run"). The original plan relied solely on the
+`recordNonFatal` cross-chapter cascade — but the review proved that cascade state
+is **per-POST**, and the production queue dispatches **one chapter per POST**, so
+the cascade can never escalate on the queue path (a thrashing sidecar would grind
+for hours). The fix: on a recycle-storm with `job.queueEntryId != null`, set the
+queue file's `paused` flag (`setPaused` + `readQueueFile`/`writeQueueFile`, the
+same flag the frontend dispatcher honors), best-effort, after the failure
+surfaces. The back-compat `*` job (many chapters per POST) keeps relying on the
+cascade — there it genuinely accumulates. Shipped as commit `253beec5`.
 
 ---
 
@@ -484,9 +490,17 @@ git commit -m "feat(server,frontend): show a visible 'recovering' phase while a 
 outer catch's generic `describeSynthesisError` path → an `unknown`/`sidecar-
 unreachable` failure with no specific remediation. C3 maps it to a clear, named
 failure (`code: 'recycle-storm'`) with concrete remediation, recorded
-**non-fatal** so the existing cross-chapter cascade (`recordNonFatal`) escalates
-to a run-stop when storms repeat — identical to how `ChapterStallError` is
-handled (`isStall` branch, generation.ts ≈1527).
+**non-fatal** (`isStall`-style branch, generation.ts ≈1527).
+
+> **REVISED (C3 code-quality review):** the named failure ALONE does not satisfy
+> the spec's "pause the run." The `recordNonFatal` cascade is **per-POST** and the
+> queue dispatches **one chapter per POST**, so it never escalates on the queue
+> path. So C3 also **pauses the queue** on a recycle-storm when `job.queueEntryId
+> != null`: `readQueueFile(queueJsonPath())` → `writeQueueFile(…, setPaused(file,
+> true))` (best-effort try/catch, after the `chapter_failed` broadcast + state
+> persist). The dispatcher honors `paused` and halts. The `*` back-compat job
+> (many chapters per POST) is left on the cascade. Shipped as `253beec5`; tested
+> by asserting the queue file's `paused` flips `true` after a `RecycleStormError`.
 
 **Files:**
 - Modify: `server/src/routes/failure-taxonomy.ts` (+ `'recycle-storm'` code + signature)

--- a/docs/superpowers/plans/2026-06-08-generation-stall-protection-wave3.md
+++ b/docs/superpowers/plans/2026-06-08-generation-stall-protection-wave3.md
@@ -502,8 +502,19 @@ handled (`isStall` branch, generation.ts ≈1527).
 - [ ] **Step 3: Run, confirm FAIL:**
 `cd server && npx vitest run src/routes/failure-taxonomy.test.ts -t "recycle-storm"`
 
+> **⚠️ Ordering hazard (found in the C1 code-quality review).** `RecycleStormError`'s
+> message contains the literal `"VRAM/RAM headroom"`, which matches the existing
+> `vram-spill` signature's `/CUDA out of memory|VRAM/i` regex. Since the table is
+> first-match-wins, the new `recycle-storm` signature MUST be placed **before** the
+> `vram-spill` entry, and SHOULD match on `ctx.name === 'RecycleStormError'` (type-driven,
+> not substring) so a future message reword can't silently mis-classify it. Independently,
+> the `generation.ts` `isRecycleStorm` outer-catch branch (below) short-circuits BEFORE
+> `describeSynthesisError` is ever called for this error — so the taxonomy entry is the
+> defense-in-depth path for any other caller that classifies a `RecycleStormError`, and
+> the outer-catch branch is the primary path generation uses. Implement BOTH.
+
 - [ ] **Step 4: Implement.**
-  - `failure-taxonomy.ts`: add `| 'recycle-storm'` to `FailureCode`; add a signature (place it beside the `synth-timeout` entry, matching on `ctx.name === 'RecycleStormError'` OR `/recycled \d+× while rendering/` on the raw message):
+  - `failure-taxonomy.ts`: add `| 'recycle-storm'` to `FailureCode`; add a signature **placed BEFORE the `vram-spill` entry** (see the ordering hazard above), matching on `ctx.name === 'RecycleStormError'` first (type-driven) — the raw-message regex is only a fallback:
 ```ts
   {
     code: 'recycle-storm',

--- a/docs/superpowers/plans/2026-06-08-generation-stall-protection-wave3.md
+++ b/docs/superpowers/plans/2026-06-08-generation-stall-protection-wave3.md
@@ -1,0 +1,568 @@
+# Generation Stall Protection — Wave 3 (better recovery) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a sidecar recycles mid-render, recover WITHOUT discarding completed groups (C1), show a visible "recovering" state instead of a silent stall (C2), and turn an unrecoverable recycle storm into a clearly-named alert instead of a generic failure / hours of grind (C3).
+
+**Architecture:** Three server-led changes plus a small frontend phase add.
+**C1** moves the transient-recovery boundary from *around the whole chapter*
+(`routes/generation.ts`'s `for (recovery…)` loop re-invoking `synthesiseChapter`
+from the top) to *inside* `synthesiseChapter`'s per-group worker loop, via an
+injected `onRecoverRecycle` hook. Because the function never restarts, every
+already-completed `results[group.index]` slot is preserved; only the failed
+group/batch re-attempts after the readiness wait. **C2** emits a
+`chapter_recovering` SSE tick + `phase: 'recovering'` from that hook with a
+heartbeat, mirroring srv-31's `chapter_verifying` phase (plan 197). **C3** makes
+`synthesiseChapter` throw a dedicated `RecycleStormError` when the in-loop
+recovery budget is exhausted; `generation.ts` maps it to a named, jargon-free
+failure (`code: 'recycle-storm'`) whose stable reason the existing cross-chapter
+cascade escalates to a run-stop — same pattern as `ChapterStallError`.
+
+**Tech Stack:** TypeScript (Express server + Redux frontend + Vitest). No sidecar
+Python change. Reuses the existing `ensureSidecarEngineReady` readiness gate
+(`tts/ensure-sidecar-loaded.ts`), `isTransient` (`tts/retry.ts`), the failure
+taxonomy (`routes/failure-taxonomy.ts`), and the chapter-phase machinery
+(`src/store/chapters-slice.ts` + `src/views/generation.tsx`).
+
+**Spec:** `docs/superpowers/specs/2026-06-08-generation-stall-protection-design.md` · **Bug:** #672 · **PR:** #673 · **Wave 1:** `…-wave1.md` · **Wave 2:** `…-wave2.md`
+
+---
+
+## Priority / ordering note
+
+Implement in order **C1 → C2 → C3** (the design spec lists "C2 → C1 → C3" on a
+value/risk basis, but C2 and C3 both hang off the recovery seam C1 introduces —
+emitting the recovering tick against today's `for (recovery…)` loop would be
+throwaway work that C1 immediately deletes). The delivered behaviour is identical
+to the spec; only the internal task order differs.
+
+- **C1** is the core fix and the only structural change (relocates one existing test).
+- **C2** is a thin add on C1's `onRecoverRecycle` callback + a frontend phase (mirror plan 197).
+- **C3** is a small named-error + taxonomy add on the same callback's exhaustion path.
+
+**Recovery budget semantics (decided):** the in-loop budget is SHARED across all
+groups/workers of a chapter and equals the current `MAX_RECYCLE_RECOVERIES` (2),
+so total recovery attempts per chapter are unchanged from today — what changes is
+that each attempt re-renders ONE group, not the whole chapter. **C3 disposition
+(decided):** a single chapter's recycle-storm is recorded as a **non-fatal**
+named failure (`fatal: false`); the existing cross-chapter cascade
+(`recordNonFatal`) escalates to a run-stop when storms repeat — identical to how
+`ChapterStallError` is handled. This avoids a bespoke queue-pause path; if the
+user later wants a single storm to immediately pause the queue, that is a
+one-line follow-up (flip the branch to `fatal: true`).
+
+---
+
+## File Structure
+
+- `server/src/tts/synthesise-chapter.ts` — `onRecoverRecycle` + `maxRecycleRecoveries` opts, the `withRecycleRecovery` helper wrapping every synth site, and the new `RecycleStormError` (C1 + C3).
+- `server/src/tts/synthesise-chapter.test.ts` — **extend**: resume-preservation + budget-exhaustion + passthrough unit tests (C1/C3).
+- `server/src/routes/generation.ts` — collapse the `for (recovery…)` loop into a single `synthesiseChapter` call wired with `onRecoverRecycle` (which performs the readiness wait + emits the C2 recovering tick/heartbeat); map `RecycleStormError` in the outer catch (C1 + C2 + C3).
+- `server/src/routes/generation-recycle-recovery.test.ts` — **rewrite** to the new architecture: assert the wiring (hook drives `ensureSidecarEngineReady` + recovering ticks; `RecycleStormError` → named `chapter_failed`).
+- `server/src/routes/failure-taxonomy.ts` — add the `'recycle-storm'` `FailureCode` + signature (C3).
+- `server/src/routes/failure-taxonomy.test.ts` — extend with the recycle-storm classification (C3).
+- `src/lib/types.ts` — add `'recovering'` to the chapter `phase` union + `chapter_recovering` to the generation-event union (C2).
+- `src/store/chapters-slice.ts` — reduce `chapter_recovering` → `phase: 'recovering'` (mirror `chapter_verifying`) (C2).
+- `src/store/chapters-slice.test.ts` — extend with the recovering-phase case (C2).
+- `src/views/generation.tsx` — render the "Recovering…" caption for `phase === 'recovering'` (C2).
+- `src/views/generation.test.tsx` — extend with the recovering caption case (C2).
+- `e2e/` — one spec asserting the recovering phase surfaces (C2, UI-visible across the SSE→redux→view seam per CLAUDE.md).
+
+---
+
+## Task 1: C1 — in-loop recycle recovery (resume from completed groups)
+
+**Context:** `synthesiseChapter` (`tts/synthesise-chapter.ts`) synthesises the
+title beat, an anchor group, then a worker pool over `workItems` (single +
+Qwen-batch), writing each result into `results[group.index]`; a final
+index-order pass concatenates. Today a transient sidecar-down (recycle/respawn
+drop, or a non-poisoned drain-503 — both surface as `transient` once
+`withTtsRetry`'s short budget exhausts) OR a `ChapterSynthTimeoutError` (a synth
+that hung because the respawned sidecar was still loading the model in-band)
+unwinds the whole `Promise.all` and bubbles out; `generation.ts`'s
+`for (recovery = 0; ; recovery++)` loop (≈ lines 1144–1311) then catches it,
+waits on `ensureSidecarEngineReady`, and **re-invokes `synthesiseChapter` from
+the top — discarding every completed group**. C1 moves recovery inside: a synth
+site that throws a recoverable error calls an injected `onRecoverRecycle` hook
+(wired to the readiness gate) and re-attempts the SAME work item; completed
+`results[]` slots are preserved because the function never restarts.
+
+**Recoverable-error classification (ported verbatim from `generation.ts`
+≈1290–1297):** recover iff `isTransient(err) || err.name ===
+'ChapterSynthTimeoutError'`, AND NOT (`err.name === 'AbortError'` ||
+`signal?.aborted`), AND the shared budget is not yet exhausted. Anything else
+(poison, non-transient classifier errors, abort) re-throws unchanged.
+
+**Files:**
+- Modify: `server/src/tts/synthesise-chapter.ts`
+- Modify: `server/src/routes/generation.ts`
+- Test: `server/src/tts/synthesise-chapter.test.ts`
+- Rewrite: `server/src/routes/generation-recycle-recovery.test.ts`
+
+- [ ] **Step 1: Read the seams.** In `synthesise-chapter.ts`: the `SynthesiseChapterOpts` interface, the opts destructure (≈614–646), the title-beat synth (≈748–757), the anchor synth (≈1043–1048), the worker pool (≈1137–1169), and the segment-QA + ASR re-record `synthGroup` calls (≈1204, ≈1274). Note `withTtsRetry` is already imported from `./retry.js`; you will ALSO import `isTransient` from there. In `generation.ts`: the `for (recovery…)` loop (≈1144–1311), `ensureSidecarEngineReady` usage, `MAX_RECYCLE_RECOVERIES` (≈103), and `isTransient` import (≈82). In `generation-recycle-recovery.test.ts`: the whole file (it mocks `synthesiseChapter` wholesale + a swappable `ensureReadyImpl` — that harness is reused for the rewrite).
+
+- [ ] **Step 2: Write the failing unit tests** in `server/src/tts/synthesise-chapter.test.ts`. Use the file's existing fake-provider pattern (a `provider` object with a `synthesize` returning `{ pcm, sampleRate }`; copy a neighbouring test's cast/sentence fixtures). Add a per-group call counter so resume can be asserted.
+
+```ts
+import { isTransient } from './retry.js'; // (only if a test constructs a transient; otherwise omit)
+
+function transientErr(): Error {
+  return Object.assign(new Error('sidecar not reachable (fetch failed)'), {
+    transient: true as const,
+    cause: 'network' as const,
+  });
+}
+
+it('C1: recovers a transient mid-pool failure WITHOUT re-rendering completed groups', async () => {
+  // 3 single-sentence groups, poolWidth 1 (serial). Provider throws transient
+  // on the FIRST call for group index 1, succeeds on retry; groups 0 + 2 each
+  // synth exactly once.
+  const calls = new Map<string, number>(); // key by text
+  let thrownForG1 = false;
+  const provider = {
+    synthesize: vi.fn(async ({ text }: { text: string }) => {
+      calls.set(text, (calls.get(text) ?? 0) + 1);
+      if (text.includes('SENT1') && !thrownForG1) { thrownForG1 = true; throw transientErr(); }
+      return { pcm: Buffer.alloc(2), sampleRate: 24000 };
+    }),
+  };
+  const onRecoverRecycle = vi.fn(async () => {});
+  const result = await synthesiseChapter({
+    sentences: [mkSent(0, 'SENT0'), mkSent(1, 'SENT1'), mkSent(2, 'SENT2')],
+    cast, provider: provider as any, modelKey, engine: 'kokoro',
+    sentenceConcurrency: 1, groupHeartbeatMs: 0,
+    onRecoverRecycle, maxRecycleRecoveries: 2,
+  });
+  expect(onRecoverRecycle).toHaveBeenCalledTimes(1);       // one recovery
+  expect(calls.get(normalisedOf('SENT0'))).toBe(1);         // completed group NOT re-rendered
+  expect(calls.get(normalisedOf('SENT2'))).toBe(1);         // completed group NOT re-rendered
+  expect(result.segments.length).toBe(3);                   // chapter completed
+});
+
+it('C1: throws RecycleStormError after the shared budget is exhausted', async () => {
+  const provider = { synthesize: vi.fn(async () => { throw transientErr(); }) };
+  await expect(synthesiseChapter({
+    sentences: [mkSent(0, 'A')], cast, provider: provider as any, modelKey, engine: 'kokoro',
+    sentenceConcurrency: 1, groupHeartbeatMs: 0,
+    onRecoverRecycle: async () => {}, maxRecycleRecoveries: 2,
+  })).rejects.toMatchObject({ name: 'RecycleStormError' });
+  // 1 primary + 2 recoveries = 3 attempts.
+  expect(provider.synthesize).toHaveBeenCalledTimes(3);
+});
+
+it('C1: a non-transient error does NOT recover (re-throws immediately)', async () => {
+  const provider = { synthesize: vi.fn(async () => { throw new Error('index out of range in self'); }) };
+  await expect(synthesiseChapter({
+    sentences: [mkSent(0, 'A')], cast, provider: provider as any, modelKey, engine: 'kokoro',
+    sentenceConcurrency: 1, groupHeartbeatMs: 0,
+    onRecoverRecycle: async () => {}, maxRecycleRecoveries: 2,
+  })).rejects.toThrow('index out of range');
+  expect(provider.synthesize).toHaveBeenCalledTimes(1);
+});
+
+it('C1: passthrough — with no onRecoverRecycle a transient bubbles out unchanged (pre-C1)', async () => {
+  const provider = { synthesize: vi.fn(async () => { throw transientErr(); }) };
+  await expect(synthesiseChapter({
+    sentences: [mkSent(0, 'A')], cast, provider: provider as any, modelKey, engine: 'kokoro',
+    sentenceConcurrency: 1, groupHeartbeatMs: 0,
+    // NO onRecoverRecycle
+  })).rejects.toMatchObject({ transient: true });
+  expect(provider.synthesize).toHaveBeenCalledTimes(1);
+});
+```
+> `mkSent`/`normalisedOf`/`cast`/`modelKey` mirror the existing helpers in `synthesise-chapter.test.ts` — copy them from a neighbouring test rather than inventing. `normalisedOf` accounts for `normaliseForTts` (the key the provider sees). If the existing tests key the fake provider differently (e.g. by `voiceName`), follow that idiom.
+
+- [ ] **Step 3: Run, confirm the C1 tests FAIL** (the opts don't exist / recovery isn't wired):
+`cd server && npx vitest run src/tts/synthesise-chapter.test.ts -t "C1"`
+
+- [ ] **Step 4: Implement in `synthesise-chapter.ts`.**
+  1. Import `isTransient`: change `import { withTtsRetry } from './retry.js';` → `import { withTtsRetry, isTransient } from './retry.js';`.
+  2. Add the error class near `ChapterStallError` (≈118):
+```ts
+/** Thrown by synthesiseChapter when the in-loop recycle-recovery budget
+    (`maxRecycleRecoveries`) is exhausted on a single chapter — i.e. the sidecar
+    recycled/respawned more times than allowed while this one chapter rendered.
+    A NAMED signal (C3) so generation.ts can surface "the sidecar is thrashing —
+    likely the host-memory leak (side-11) or insufficient headroom" instead of a
+    generic mid-synth failure. Carries the recovery count + the last underlying
+    error for the log. */
+export class RecycleStormError extends Error {
+  readonly recoveries: number;
+  readonly lastError: unknown;
+  constructor(recoveries: number, lastError: unknown) {
+    super(
+      `The TTS sidecar recycled ${recoveries}× while rendering this single chapter ` +
+        `— it is likely thrashing (host-memory leak or insufficient VRAM/RAM headroom). ` +
+        `Stopping so the run doesn't grind. Restart the sidecar / lower concurrency, then Retry.`,
+    );
+    this.name = 'RecycleStormError';
+    this.recoveries = recoveries;
+    this.lastError = lastError;
+  }
+}
+```
+  3. Add to `SynthesiseChapterOpts` (near the other recovery-relevant opts):
+```ts
+  /** C1 (Wave 3) — recover from a transient sidecar-down WITHOUT discarding
+      completed groups. When a synth site throws a recoverable error
+      (`isTransient` OR a `ChapterSynthTimeoutError`), the site calls this hook
+      to wait out the respawn, then re-attempts the SAME work item; every
+      already-completed `results[]` slot is preserved. Wired by generation.ts to
+      `ensureSidecarEngineReady(engine, signal)` (+ the C2 recovering tick).
+      `engine` is the failed item's resolved engine (a chapter can be mixed-
+      engine); `attempt` is the 1-indexed shared recovery count. ABSENT → no
+      in-loop recovery: a transient bubbles out unchanged (pre-C1 behaviour, the
+      passthrough every existing caller/test relies on). */
+  onRecoverRecycle?: (e: { engine: TtsEngine; attempt: number }) => Promise<void>;
+  /** Max in-loop recycle recoveries SHARED across all groups/workers of this
+      chapter. Mirrors generation.ts `MAX_RECYCLE_RECOVERIES` (2). Exceeding it
+      throws `RecycleStormError` so the chapter fails fast (no infinite grind).
+      Only consulted when `onRecoverRecycle` is provided. Default 2. */
+  maxRecycleRecoveries?: number;
+```
+  4. Destructure them (with `onRecoverRecycle` undefined-by-default and `maxRecycleRecoveries = 2`).
+  5. Add a shared counter + the helper, INSIDE `synthesiseChapter` (so it closes over `signal`, `onRecoverRecycle`, `maxRecycleRecoveries`), placed before the title beat:
+```ts
+  let recycleRecoveries = 0;
+  /* C1 in-loop recovery. Re-attempt `fn` after waiting out a sidecar respawn,
+     WITHOUT discarding completed groups (the function never restarts, so every
+     filled `results[]` slot survives). The shared `recycleRecoveries` counter
+     bounds total recoveries per chapter; exhaustion throws RecycleStormError
+     (C3). Recoverable = isTransient OR ChapterSynthTimeoutError; an abort or a
+     non-recoverable error re-throws. No-op passthrough when `onRecoverRecycle`
+     is absent (pre-C1). Wraps EVERY synth site (title, anchor, pool item,
+     QA/ASR re-record) so recovery coverage matches the old whole-chapter loop. */
+  async function withRecycleRecovery<T>(
+    engineForItem: TtsEngine,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    for (;;) {
+      try {
+        return await fn();
+      } catch (err) {
+        if (!onRecoverRecycle) throw err;
+        const name = (err as { name?: string })?.name;
+        if (name === 'AbortError' || signal?.aborted) throw err;
+        const isRecycleTimeout = name === 'ChapterSynthTimeoutError';
+        if (!isTransient(err) && !isRecycleTimeout) throw err;
+        if (recycleRecoveries >= maxRecycleRecoveries) {
+          throw new RecycleStormError(recycleRecoveries, err);
+        }
+        recycleRecoveries += 1;
+        /* May throw AbortError (run paused mid-wait) → propagates out as a clean
+           stop, exactly like the old generation.ts recovery loop. */
+        await onRecoverRecycle({ engine: engineForItem, attempt: recycleRecoveries });
+      }
+    }
+  }
+```
+  6. Wrap each synth site with `withRecycleRecovery(<engine>, () => <existing call>)`:
+     - **Title beat** (≈748): `const titleResult = await withRecycleRecovery(titleRoute.engine, () => withTtsRetry(() => titleRoute.provider.synthesize({…}), { signal }));`
+     - **Anchor group** (≈1044): `const result = await withRecycleRecovery(resolveGroup(anchorGroup).route.engine, () => synthGroup(anchorGroup));`
+     - **Pool single item** (≈1153): `results[item.group.index] = await withRecycleRecovery(resolveGroup(item.group).route.engine, () => synthGroup(item.group));`
+     - **Pool batch item** (≈1156): `const out = await withRecycleRecovery(resolveGroup(item.groups[0]).route.engine, () => synthBatch(item.groups));`
+     - **Segment-QA re-record** (≈1204): `const fresh = await withRecycleRecovery(resolveGroup(group).route.engine, () => synthGroup(group));`
+     - **ASR re-record** (≈1274): same wrap as segment-QA.
+     > `resolveGroup(...)` is memoised by group index, so calling it for the engine is cheap and side-effect-free. `withRecycleRecovery` is a no-op passthrough when `onRecoverRecycle` is absent, so these wraps are byte-identical for every existing caller/test that doesn't pass the hook.
+
+- [ ] **Step 5: Run, confirm the C1 unit tests PASS + the WHOLE synthesise-chapter suite stays green** (the passthrough wrap must not perturb the 30+ determinism/batching/QA tests):
+`cd server && npx vitest run src/tts/synthesise-chapter.test.ts`
+
+- [ ] **Step 6: Implement in `generation.ts` — collapse the loop.** Replace the `for (recovery = 0; ; recovery += 1) { try { result = await synthesiseChapter({…}); break; } catch (synthErr) { … ensureSidecarEngineReady … } }` block (≈1143–1311) with a SINGLE call that injects the hook:
+```ts
+      let result: Awaited<ReturnType<typeof synthesiseChapter>>;
+      result = await synthesiseChapter({
+        sentences,
+        cast: cast.characters,
+        provider,
+        modelKey,
+        engine,
+        resolveForEngine,
+        qwenUnavailable,
+        forbidKokoroFallback: nonEnglishBook,
+        bookLanguage,
+        signal: chapterSignal,
+        chapterTitleNarration,
+        narratorCharacterId: 'narrator',
+        onTitleStart: () => { /* …unchanged… */ },
+        onGroupStart: ({ group, totalGroups, completed }) => { /* …unchanged… */ },
+        onGroupComplete: ({ group, totalGroups, completed }) => { /* …unchanged… */ },
+        onBatchComplete: ({ genMs, audioMs }) => { /* …unchanged… */ },
+        maxSegmentRerecords: resolveSegmentQaRerecords(),
+        onSegmentRerecord: () => { /* …unchanged… */ },
+        ...(asrEnabled() ? { asr: { /* …unchanged… */ } } : {}),
+        /* C1 — recover in-loop (preserves completed groups) instead of the old
+           outer for-loop that re-rendered the whole chapter. The hook waits out
+           the respawn on the readiness gate and emits the C2 recovering state
+           (added in Task 2). MAX_RECYCLE_RECOVERIES is the shared per-chapter
+           budget; on exhaustion synthesiseChapter throws RecycleStormError,
+           mapped by the outer catch (Task 3). */
+        maxRecycleRecoveries: MAX_RECYCLE_RECOVERIES,
+        onRecoverRecycle: async ({ engine: recEngine, attempt }) => {
+          console.warn(
+            `[generation] chapter ${chapter.id} (${chapter.slug}): sidecar unavailable ` +
+              `mid-synth (recycle/respawn) — riding out the respawn, re-attempt ` +
+              `${attempt}/${MAX_RECYCLE_RECOVERIES} (preserving completed groups).`,
+          );
+          /* Task 2 (C2) inserts the recovering tick + heartbeat here, around the
+             wait. For Task 1, just wait on the readiness gate (current behaviour,
+             relocated into the hook). Honours the run abort. */
+          await ensureSidecarEngineReady(recEngine, chapterSignal);
+        },
+      });
+```
+  Keep `synthStartMs` (≈1122) where it is. Delete the now-unused `for`/`recovery` scaffolding and the inner classification block (its logic moved into `withRecycleRecovery`). Leave the outer `try/catch` (≈1513) untouched for now — Task 3 adds the `RecycleStormError` branch.
+
+- [ ] **Step 7: Rewrite `generation-recycle-recovery.test.ts`** to the new architecture. The file mocks `synthesiseChapter`, so it can no longer drive the inner recovery — instead it asserts the WIRING. Keep the harness (express app, queue seed, swappable `synthesiseImpl` + `ensureReadyImpl` + `ensureReadyCalls`). Replace the four `it(...)` bodies:
+```ts
+it('drives ensureSidecarEngineReady from onRecoverRecycle, then completes (no chapter_failed)', async () => {
+  let calls = 0;
+  synthesiseImpl = async (args: any) => {
+    calls += 1;
+    if (calls === 1) {
+      // First call: exercise the injected hook once (simulating an in-loop
+      // recovery), then succeed — proving generation wires the hook to the gate.
+      await args.onRecoverRecycle({ engine: 'kokoro', attempt: 1 });
+      return okResult();
+    }
+    return okResult();
+  };
+  const body = await runChapter();
+  expect(calls).toBe(1);                       // synthesiseChapter called ONCE (recovery is internal now)
+  expect(ensureReadyCalls).toBeGreaterThanOrEqual(2); // preload gate + the hook's wait
+  expect(body).toContain('"type":"chapter_complete"');
+  expect(body).not.toContain('"type":"chapter_failed"');
+});
+
+it('surfaces chapter_failed when synthesiseChapter throws RecycleStormError', async () => {
+  const { RecycleStormError } = await import('../tts/synthesise-chapter.js');
+  synthesiseImpl = async () => { throw new RecycleStormError(2, new Error('sidecar down')); };
+  const body = await runChapter();
+  expect(body).toContain('"type":"chapter_failed"');
+  expect(body).not.toContain('"type":"chapter_complete"');
+  // Task 3 asserts the recycle-storm code/remediation here too.
+});
+
+it('does NOT recover a non-transient error — surfaces immediately', async () => {
+  synthesiseImpl = async () => { throw new Error('index out of range in self'); };
+  const body = await runChapter();
+  expect(body).toContain('"type":"chapter_failed"');
+});
+
+it('stops cleanly when the hook wait aborts (pause/displacement mid-recovery)', async () => {
+  synthesiseImpl = async (args: any) => {
+    await args.onRecoverRecycle({ engine: 'kokoro', attempt: 1 }); // throws AbortError (ensureReadyImpl below)
+    return okResult();
+  };
+  ensureReadyImpl = async () => {
+    if (ensureReadyCalls >= 2) throw new DOMException('preload aborted', 'AbortError');
+  };
+  const body = await runChapter();
+  expect(body).not.toContain('"type":"chapter_failed"'); // abort = clean stop
+  expect(body).not.toContain('"type":"chapter_complete"');
+});
+```
+  > Update the file's top-of-file comment block to describe the new contract (recovery is internal to `synthesiseChapter`; this suite pins the generation-side wiring). Keep `transientSidecarDown()`/`okResult()` helpers — `okResult()` is still used.
+
+- [ ] **Step 8: Run the rewritten generation suite + a broad server pass:**
+`cd server && npx vitest run src/routes/generation-recycle-recovery.test.ts src/routes/generation.test.ts src/routes/generation-stall-watchdog.test.ts`
+
+- [ ] **Step 9: Commit**
+```bash
+git add server/src/tts/synthesise-chapter.ts server/src/tts/synthesise-chapter.test.ts server/src/routes/generation.ts server/src/routes/generation-recycle-recovery.test.ts
+git commit -m "feat(server): recover sidecar recycles in-loop without re-rendering completed groups (Refs #672)"
+```
+
+---
+
+## Task 2: C2 — visible "recovering" phase
+
+**Context:** During the readiness wait inside `onRecoverRecycle` (up to
+`READINESS_TIMEOUT_MS` = 210 s), the SSE stream is silent — the client's 30 s
+"Worker has gone quiet" stall detector (`STALL_THRESHOLD_MS`,
+`src/store/chapters-slice.ts`) fires for what is actually a healthy respawn
+ride-out. C2 emits a `chapter_recovering` tick + a heartbeat from the hook, and
+adds a `phase: 'recovering'` the Generate view renders as "Recovering…". This is
+the exact shape srv-31 added for `chapter_verifying` (plan 197,
+`docs/features/archive/197-asr-verifying-phase.md`) — mirror it.
+
+**Files:**
+- Modify: `server/src/routes/generation.ts` (emit the tick + heartbeat in the hook; add `chapter_recovering` to the broadcast event union wherever `chapter_verifying` is declared)
+- Modify: `src/lib/types.ts` (phase union + event union)
+- Modify: `src/store/chapters-slice.ts` (reducer)
+- Modify: `src/views/generation.tsx` (caption)
+- Test: `src/store/chapters-slice.test.ts`, `src/views/generation.test.tsx`, `server/src/routes/generation-recycle-recovery.test.ts` (assert the tick fires)
+- Test (e2e): `e2e/` (new spec)
+
+- [ ] **Step 1: Read the precedent.** Read how `chapter_verifying` is declared on the server broadcast event type (grep `chapter_verifying` in `server/src/routes/` — find the union; it sits beside `chapter_assembling`), emitted (`emitVerifying`, generation.ts ≈1132), typed on the frontend (`src/lib/types.ts` event union + the `phase` union ≈ line 12), reduced (`src/store/chapters-slice.ts` ≈448–456), and rendered (`src/views/generation.tsx:1303,1310,1414`). Replicate each touch-point for `recovering`.
+
+- [ ] **Step 2: Write the failing frontend tests.**
+  - `src/store/chapters-slice.test.ts` — mirror the `chapter_verifying` reducer test (≈372): a `chapter_recovering` event holds the row `in_progress` with `phase === 'recovering'`.
+  - `src/views/generation.test.tsx` — mirror the "Verifying speech…" test (≈322): a chapter with `phase: 'recovering'` shows the recovering caption.
+```ts
+// chapters-slice.test.ts
+it('chapter_recovering holds the row in_progress with phase=recovering', () => {
+  const start = baseState([makeChapter(3, { state: 'in_progress' })]);
+  const next = reducer(start, applyGenerationEvent({ type: 'chapter_recovering', chapterId: 3, progress: 0.9 }));
+  expect(next.chapters[0].phase).toBe('recovering');
+  expect(next.chapters[0].state).toBe('in_progress');
+});
+// generation.test.tsx
+it('shows the recovering caption on a chapter in the recovering phase', () => {
+  // render with a chapter { phase: 'recovering', state: 'in_progress' }
+  expect(screen.getByText('Recovering — restarting TTS engine…')).toBeInTheDocument();
+});
+```
+  > Match the exact action creator / render harness the neighbouring `verifying` tests use (`applyGenerationEvent` vs a thunk; the view's render helper). Copy them verbatim as skeletons.
+
+- [ ] **Step 3: Run, confirm FAIL:**
+`npx vitest run src/store/chapters-slice.test.ts src/views/generation.test.tsx -t "recovering"`
+
+- [ ] **Step 4: Implement.**
+  - **`src/lib/types.ts`:** add `'recovering'` to the `phase` union (the comment ≈ line 12 documents `phase`; extend it to note `chapter_recovering`); add `chapter_recovering` to the generation-event union with the same fields as `chapter_verifying` (`chapterId`, `progress?`, `currentLine?`, `totalLines?`).
+  - **`src/store/chapters-slice.ts`:** add a handler beside the `chapter_verifying` block (≈448):
+```ts
+      if (ev.type === 'chapter_recovering') {
+        /* C2 (Wave 3) — sidecar recycled mid-render; the worker is riding out
+           the respawn (up to ~210 s). Mirror chapter_verifying: hold the row
+           in_progress with a distinct phase so the view shows "Recovering…"
+           instead of a frozen caption + the 30 s stall banner. */
+        ch.phase = 'recovering';
+        ch.state = 'in_progress';
+        ch.progress = ev.progress ?? ch.progress;
+        if (ev.currentLine != null) ch.currentLine = ev.currentLine;
+        if (ev.totalLines != null) ch.totalLines = ev.totalLines;
+        return;
+      }
+```
+  - **`src/views/generation.tsx`:** beside `const verifying = chapter.phase === 'verifying';` (≈1303) add `const recovering = chapter.phase === 'recovering';` and extend the caption ternary (≈1310 + the JSX ≈1414) so `recovering` → `'Recovering — restarting TTS engine…'`. Keep it ordered so `recovering` wins over the default synthesising caption.
+  - **`server/src/routes/generation.ts`:** (a) add `chapter_recovering` to the server broadcast event union (beside `chapter_verifying`); (b) in the `onRecoverRecycle` hook (Task 1), emit the tick + a heartbeat around the wait:
+```ts
+        onRecoverRecycle: async ({ engine: recEngine, attempt }) => {
+          console.warn(/* …unchanged… */);
+          const emitRecovering = () => {
+            bumpProgress(); // feed the server no-progress watchdog during the wait
+            broadcast(job, {
+              type: 'chapter_recovering',
+              chapterId: chapter.id,
+              characterId: null,
+              progress: 0.9,
+              currentLine: job.lastProgressTick?.currentLine ?? 0,
+              totalLines,
+            });
+          };
+          emitRecovering();
+          const beat = setInterval(emitRecovering, 10_000); // < client 30 s stall threshold
+          beat.unref?.();
+          try {
+            await ensureSidecarEngineReady(recEngine, chapterSignal);
+          } finally {
+            clearInterval(beat);
+          }
+        },
+```
+  > `bumpProgress` + the 10 s heartbeat together keep BOTH watchdogs fed: the server no-progress guard (`chapterNoProgressMs`, 720 s) and the client stall detector (30 s). The `0.9` progress + last `currentLine` keep the bar where synthesis left it.
+
+- [ ] **Step 5: Add the server-side tick assertion** to the rewritten `generation-recycle-recovery.test.ts` (Task 1's first test): `expect(body).toContain('"type":"chapter_recovering"');`.
+
+- [ ] **Step 6: Run frontend + server suites:**
+`npx vitest run src/store/chapters-slice.test.ts src/views/generation.test.tsx` and `cd server && npx vitest run src/routes/generation-recycle-recovery.test.ts`
+
+- [ ] **Step 7: Add one e2e spec** under `e2e/` asserting the recovering phase surfaces (UI-visible across SSE→redux→view per CLAUDE.md). Mirror the closest existing generation-phase e2e (search `e2e/` for `verifying`/`assembling`/`chapter_` mock-stream specs); if the e2e harness drives generation via the mock API, add a `chapter_recovering` frame to the mock stream and assert the "Recovering…" caption renders. If no comparable generation-SSE e2e exists, note that in the commit message and rely on the Vitest view test (do not invent a new harness).
+
+- [ ] **Step 8: Commit**
+```bash
+git add server/src/routes/generation.ts server/src/routes/generation-recycle-recovery.test.ts src/lib/types.ts src/store/chapters-slice.ts src/store/chapters-slice.test.ts src/views/generation.tsx src/views/generation.test.tsx e2e/
+git commit -m "feat(server,frontend): show a visible 'recovering' phase while a chapter rides out a sidecar respawn (Refs #672)"
+```
+
+---
+
+## Task 3: C3 — named recycle-storm alert
+
+**Context:** `RecycleStormError` (added in Task 1) currently surfaces through the
+outer catch's generic `describeSynthesisError` path → an `unknown`/`sidecar-
+unreachable` failure with no specific remediation. C3 maps it to a clear, named
+failure (`code: 'recycle-storm'`) with concrete remediation, recorded
+**non-fatal** so the existing cross-chapter cascade (`recordNonFatal`) escalates
+to a run-stop when storms repeat — identical to how `ChapterStallError` is
+handled (`isStall` branch, generation.ts ≈1527).
+
+**Files:**
+- Modify: `server/src/routes/failure-taxonomy.ts` (+ `'recycle-storm'` code + signature)
+- Modify: `server/src/routes/generation.ts` (outer-catch branch)
+- Test: `server/src/routes/failure-taxonomy.test.ts`, `server/src/routes/generation-recycle-recovery.test.ts`
+
+- [ ] **Step 1: Read** `failure-taxonomy.ts` — the `FailureCode` union (≈18), the `FailureSignature` shape (≈37), the ORDERED `FAILURE_SIGNATURES` table (the timeout/`ChapterSynthTimeoutError` entry must stay first), and how `name` reaches a signature via `FailureContext`. Read `generation.ts`'s `isStall` branch (≈1527–1547) — C3's branch mirrors it.
+
+- [ ] **Step 2: Write the failing tests.**
+  - `failure-taxonomy.test.ts`: a `RecycleStormError` (raw message or `ctx.name === 'RecycleStormError'`) classifies to `{ code: 'recycle-storm', fatal: false }` with a remediation mentioning the sidecar/headroom.
+  - `generation-recycle-recovery.test.ts` (the Task-1 RecycleStormError test): extend to assert `"errorCode":"recycle-storm"` and a remediation substring in the `chapter_failed` frame.
+
+- [ ] **Step 3: Run, confirm FAIL:**
+`cd server && npx vitest run src/routes/failure-taxonomy.test.ts -t "recycle-storm"`
+
+- [ ] **Step 4: Implement.**
+  - `failure-taxonomy.ts`: add `| 'recycle-storm'` to `FailureCode`; add a signature (place it beside the `synth-timeout` entry, matching on `ctx.name === 'RecycleStormError'` OR `/recycled \d+× while rendering/` on the raw message):
+```ts
+  {
+    code: 'recycle-storm',
+    fatal: false, // non-fatal per chapter; the cross-chapter cascade escalates repeats
+    match: (raw, ctx) => ctx.name === 'RecycleStormError' || /recycled \d+× while rendering/.test(raw),
+    userMessage: 'The TTS engine kept restarting while rendering this chapter.',
+    remediation:
+      'The sidecar is likely thrashing — the host-memory leak (side-11) or too little ' +
+      'VRAM/RAM headroom. Restart the TTS sidecar and/or lower generation concurrency, then Retry.',
+  },
+```
+  - `generation.ts` outer catch: add an `isRecycleStorm` branch beside `isStall` so the named code/remediation/`fatal:false` ride through (let it flow into `recordNonFatal(cascade, errorReason)` exactly like a stall). Pass `name` into the classifier via `FailureContext` if the existing `describeSynthesisError(e, engine)` call doesn't already forward `e.name` (it forwards `ctx.name` per failure-taxonomy — confirm and, if needed, ensure `(e as Error).name` is threaded). Simplest: mirror the `isStall` literal-object branch:
+```ts
+      const isRecycleStorm = (e as { name?: string })?.name === 'RecycleStormError';
+      const initial = isStall
+        ? { /* …unchanged stall object… */ }
+        : isRecycleStorm
+          ? {
+              errorReason: (e as Error).message,
+              fatal: false,
+              code: 'recycle-storm' as FailureCode,
+              remediation:
+                'Restart the TTS sidecar (clears a thrashing/leaking process) and/or lower ' +
+                'generation concurrency, then Retry. If it persists, the host-memory leak ' +
+                '(side-11) needs headroom.',
+            }
+          : describeSynthesisError(e, engine);
+```
+  > Keep the log line specific: `console.error('[generation] chapter … RECYCLE STORM: sidecar recycled N× on one chapter — recorded non-fatal; cascade will stop the run if it repeats.')`.
+
+- [ ] **Step 5: Run the taxonomy + generation suites:**
+`cd server && npx vitest run src/routes/failure-taxonomy.test.ts src/routes/generation-recycle-recovery.test.ts`
+
+- [ ] **Step 6: Commit**
+```bash
+git add server/src/routes/failure-taxonomy.ts server/src/routes/failure-taxonomy.test.ts server/src/routes/generation.ts server/src/routes/generation-recycle-recovery.test.ts
+git commit -m "feat(server): name the recycle-storm failure class with concrete remediation (Refs #672)"
+```
+
+---
+
+## Task 4: Wave 3 wrap-up
+
+- [ ] **Step 1: Typecheck** — `npm run typecheck` → PASS (frontend + server; the new opts, event type, phase, and FailureCode must all line up).
+- [ ] **Step 2: Server suite** — `npm run test:server` → PASS. (Worker-fork flake is known; re-run the single failing file in isolation if it appears — see the project memory.)
+- [ ] **Step 3: Frontend suite** — `npm run test` → PASS.
+- [ ] **Step 4: Fast battery** — `npm run verify:fast` → PASS (matches pre-commit).
+- [ ] **Step 5: e2e (if a spec was added)** — `npm run test:e2e` → PASS.
+- [ ] **Step 6: Mark the spec** — add `**Wave 3 landed:** <date>, <shas>` under Delivery in `…-generation-stall-protection-design.md`; note the C1→C2→C3 internal ordering. Commit `docs(docs): mark Wave 3 of generation stall protection landed (Closes #672)`.
+- [ ] **Step 7: Spec status + bug** — Wave 3 completes the spec; flip bug #672 from `Refs` to a delivery that can `Closes #672` (the spec's defect-E recovery item is now shipped). Consider moving the design spec's status to `shipped` and whether the three plan files + spec should move under `docs/features/archive/` (follow the archive convention; if a stall-protection regression plan exists under `docs/features/`, fill its Ship notes).
+- [ ] **Step 8: Push + PR** — push the branch and update PR #673 (or open the Wave 3 PR per the draft-first CI flow). Body: `Closes #672`. Run `npm run verify` once locally before `gh pr ready` (no CI minutes — local verify is authoritative).
+
+---
+
+## Self-review notes
+
+- **Spec coverage (Wave 3):** C1 ✓ (Task 1 — boundary moved into the per-group loop, completed groups preserved, `out of scope`: disk-checkpoint across a full server restart stays out per the spec), C2 ✓ (Task 2 — `chapter_recovering` tick + phase + heartbeat), C3 ✓ (Task 3 — `RecycleStormError` + named taxonomy entry, escalates via the existing cascade).
+- **Passthrough safety:** `withRecycleRecovery` is a no-op when `onRecoverRecycle` is absent, so every existing `synthesiseChapter` caller and its 30+ tests are byte-identical; only `generation.ts` opts in.
+- **Test relocation (not deletion):** `generation-recycle-recovery.test.ts` is rewritten to the new architecture (wiring-level) and the resume-preservation proof moves to `synthesise-chapter.test.ts` — a complete replacement, satisfying the testing-discipline rule.
+- **Preserved invariants:** the recoverable-error classification is ported verbatim (`isTransient || ChapterSynthTimeoutError`, abort excluded); `MAX_RECYCLE_RECOVERIES` is unchanged as the shared budget; poison/non-transient errors still surface immediately; the no-progress watchdog + abort plumbing are untouched (the hook runs under `chapterSignal`).
+- **Cross-task types:** `onRecoverRecycle`/`maxRecycleRecoveries`/`RecycleStormError` (Task 1) are consumed by Tasks 2–3; `chapter_recovering` + `phase: 'recovering'` (Task 2) are defined once in `types.ts`; `'recycle-storm'` `FailureCode` (Task 3) is added in one place.
+- **Ordering:** C1 → C2 → C3, each commits independently and is revertible; C2/C3 build on C1's hook (rationale in the priority note).

--- a/docs/superpowers/specs/2026-06-08-generation-stall-protection-design.md
+++ b/docs/superpowers/specs/2026-06-08-generation-stall-protection-design.md
@@ -126,6 +126,14 @@ adoption-policy decision:
   recycles on the same chapter — stop grinding: pause the run and surface a
   clear alert naming the cause (likely the leak / undersized headroom) instead
   of burning hours. Builds on the existing `MAX_RECYCLE_RECOVERIES` fall-through.
+  *As shipped:* `synthesiseChapter` throws a named `RecycleStormError` on budget
+  exhaustion → `generation.ts` maps it to a `recycle-storm` failure code +
+  remediation AND **pauses the queue** (`setPaused` on the queue file) on the
+  queue path so the dispatcher halts. (The original "rely on the `recordNonFatal`
+  cascade" idea was dropped: the cascade is per-POST and the queue dispatches one
+  chapter per POST, so it never escalates on the queue path — the explicit
+  queue-pause is what delivers "pause the run." The back-compat `*` job, many
+  chapters per POST, still uses the cascade.)
 
 ## Delivery (3 waves, each independently valuable)
 
@@ -141,6 +149,22 @@ adoption-policy decision:
 > supervisor respawn-state — NOT handle-ownership, which would have wedged the
 > dispatcher for adopted sidecars). Typecheck + server (2376 tests) green. Plan:
 > `docs/superpowers/plans/2026-06-08-generation-stall-protection-wave2.md`.
+>
+> **Wave 3 landed 2026-06-09** on `feat/server-generation-stall-protection-wave3`
+> (internal order C1 → C2 → C3, since C2/C3 build on C1's `onRecoverRecycle`
+> seam): **C1** `3da94091` (in-loop recovery — completed groups preserved; the
+> recovery boundary moved from a whole-chapter re-invoke into `synthesiseChapter`'s
+> per-group loop via an injected `onRecoverRecycle` hook + `withRecycleRecovery`
+> passthrough helper + `RecycleStormError`; the old whole-chapter recovery test
+> was relocated to a unit-level resume-preservation proof). **C2** `35abcea9` +
+> `0aa8e4f1` (`chapter_recovering` SSE tick + 10s heartbeat from the hook +
+> `phase: 'recovering'` mirroring `chapter_verifying`; the fix holds the progress
+> bar rather than regressing it). **C3** `f122b0cd` + `253beec5` (named
+> `recycle-storm` taxonomy entry ordered before `vram-spill` to beat its "VRAM"
+> substring match, + **queue-pause** on a storm so the run actually stops — the
+> per-POST cascade can't escalate on the queue path). Typecheck + server (2384
+> tests) + frontend green. Plan:
+> `docs/superpowers/plans/2026-06-08-generation-stall-protection-wave3.md`.
 
 1. **Wave 1 — config safety (ships first; prevents *this* incident):** A1, A2,
    A4 + prod-fresh-sidecar policy.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3257,7 +3257,7 @@ components:
       properties:
         type:
           type: string
-          enum: [progress, chapter_assembling, chapter_verifying, chapter_complete, chapter_failed, idle, resume_from, warning, chapter_awaiting_fallback_confirm]
+          enum: [progress, chapter_assembling, chapter_verifying, chapter_recovering, chapter_complete, chapter_failed, idle, resume_from, warning, chapter_awaiting_fallback_confirm]
           description: |
             `chapter_assembling` is emitted between the last per-group synthesis
             tick and `chapter_complete`, while the server concatenates the PCM,
@@ -3268,6 +3268,12 @@ components:
             assembly; it carries the same counters as `chapter_assembling` and
             surfaces a "Verifying speech…" phase so the row doesn't look frozen
             on "Synthesising …".
+            `chapter_recovering` is emitted (Wave 3, C2) while a worker rides out
+            a mid-render sidecar recycle/respawn on the readiness gate (up to
+            ~210 s). It carries the same counters as `chapter_assembling`, fires
+            on a 10 s heartbeat so the client's 30 s stall detector stays fed, and
+            surfaces a "Recovering …" phase so the row reads as healthy recovery
+            rather than a silent stall.
             `resume_from` is emitted as the FIRST event on every new subscriber
             (cold connect AND reconnect after `tsx watch` restart or server
             bounce) and carries a snapshot of completed chapter ids for the

--- a/server/src/routes/failure-taxonomy.test.ts
+++ b/server/src/routes/failure-taxonomy.test.ts
@@ -155,6 +155,43 @@ describe('classifyFailure', () => {
     expect(out.userMessage).toMatch(/authentication/i);
   });
 
+  it('classifies a RecycleStormError (by ctx.name) as recycle-storm, non-fatal', () => {
+    /* C3 — the named recycle-storm error from synthesise-chapter.ts. Its real
+       message contains "VRAM/RAM headroom", which would match the vram-spill
+       regex; the type-driven ctx.name signature MUST win because it is ordered
+       before vram-spill (first-match-wins). */
+    const err = Object.assign(
+      new Error(
+        'The TTS sidecar recycled 2× while rendering this single chapter — it is likely ' +
+          'thrashing (host-memory leak or insufficient VRAM/RAM headroom). Stopping so the ' +
+          "run doesn't grind. Restart the sidecar / lower concurrency, then Retry.",
+      ),
+      { name: 'RecycleStormError' },
+    );
+    const out = classifyFailure(err, 'kokoro');
+    expect(out.code).toBe('recycle-storm');
+    expect(out.code).not.toBe('vram-spill'); // ORDERING: must not be swallowed by the VRAM regex
+    expect(out.fatal).toBe(false);
+    expect(out.userMessage).toMatch(/kept restarting|restarting/i);
+    expect(out.remediation).toMatch(/sidecar|headroom|concurrency/i);
+    assertJargonFree(out.userMessage);
+  });
+
+  it('classifies a recycle-storm by raw message fallback (no ctx.name) as recycle-storm', () => {
+    /* Defense-in-depth: even with the type-driven ctx.name absent (e.g. a
+       message-only error from another path), the raw-message fallback regex
+       classifies it as recycle-storm, NOT vram-spill. */
+    const out = classifyFailure(
+      new Error(
+        'The TTS sidecar recycled 3× while rendering this single chapter — insufficient VRAM headroom.',
+      ),
+      'kokoro',
+    );
+    expect(out.code).toBe('recycle-storm');
+    expect(out.code).not.toBe('vram-spill');
+    expect(out.fatal).toBe(false);
+  });
+
   it('passes an unknown error through as code "unknown", non-fatal, raw userMessage', () => {
     const out = classifyFailure(new Error('Something unexpected and unmapped happened'));
     expect(out.code).toBe('unknown');

--- a/server/src/routes/failure-taxonomy.ts
+++ b/server/src/routes/failure-taxonomy.ts
@@ -89,9 +89,11 @@ export const FAILURE_SIGNATURES: FailureSignature[] = [
      headroom", which matches vram-spill's /VRAM/i regex, and the table is
      first-match-wins. Matched TYPE-DRIVEN (ctx.name) first so a future message
      reword can't silently mis-classify it; the raw-message regex is a fallback
-     only. Non-fatal per chapter — the cross-chapter cascade (recordNonFatal in
-     generation.ts) escalates to a run-stop when storms repeat, just like a
-     stall. */
+     only. `fatal: false` because the chapter itself isn't poison. The RUN is
+     stopped a different way per dispatch path: on the queue path (one POST per
+     chapter) generation.ts PAUSES the queue on a storm; the cross-chapter
+     cascade (recordNonFatal in generation.ts) only escalates to a run-stop on
+     the back-compat `*` job, which loops many chapters in one POST. */
   {
     code: 'recycle-storm',
     fatal: false,

--- a/server/src/routes/failure-taxonomy.ts
+++ b/server/src/routes/failure-taxonomy.ts
@@ -17,6 +17,7 @@
 
 export type FailureCode =
   | 'vram-spill'
+  | 'recycle-storm'
   | 'sidecar-unreachable'
   | 'analyzer-rate-limit'
   | 'oom'
@@ -80,6 +81,26 @@ export const FAILURE_SIGNATURES: FailureSignature[] = [
     remediation:
       'Start the TTS sidecar (npm start launches it automatically), wait for the sidecar pill to ' +
       'go green, then resume the run.',
+  },
+  /* C3 (Wave 3) — the named recycle-storm signal from synthesise-chapter.ts
+     (`RecycleStormError`): the sidecar recycled/respawned more times than the
+     in-loop budget allows while rendering ONE chapter. MUST be placed BEFORE
+     the vram-spill entry: RecycleStormError's message contains "VRAM/RAM
+     headroom", which matches vram-spill's /VRAM/i regex, and the table is
+     first-match-wins. Matched TYPE-DRIVEN (ctx.name) first so a future message
+     reword can't silently mis-classify it; the raw-message regex is a fallback
+     only. Non-fatal per chapter — the cross-chapter cascade (recordNonFatal in
+     generation.ts) escalates to a run-stop when storms repeat, just like a
+     stall. */
+  {
+    code: 'recycle-storm',
+    fatal: false,
+    match: (raw, ctx) =>
+      ctx.name === 'RecycleStormError' || /recycled \d+× while rendering/.test(raw),
+    userMessage: 'The TTS engine kept restarting while rendering this chapter.',
+    remediation:
+      'The sidecar is likely thrashing — the host-memory leak (side-11) or too little ' +
+      'VRAM/RAM headroom. Restart the TTS sidecar and/or lower generation concurrency, then Retry.',
   },
   /* CUDA out-of-memory — the GPU allocator itself refused. Distinct from the
      host-RAM OOM kill below. Comes BEFORE the cuda-poisoned check because an

--- a/server/src/routes/generation-recycle-recovery.test.ts
+++ b/server/src/routes/generation-recycle-recovery.test.ts
@@ -244,7 +244,11 @@ describe('srv-17c in-worker recovery after a mid-synth sidecar death', () => {
 
     expect(body).toContain('"type":"chapter_failed"');
     expect(body).not.toContain('"type":"chapter_complete"');
-    // Task 3 asserts the recycle-storm code/remediation in the chapter_failed frame.
+    // C3 — the chapter_failed frame carries the named recycle-storm code + a
+    // concrete remediation (restart sidecar / lower concurrency / side-11),
+    // NOT a generic vram-spill / unknown classification.
+    expect(body).toContain('"errorCode":"recycle-storm"');
+    expect(body).toMatch(/"remediation":"[^"]*(?:sidecar|concurrency|headroom)/i);
   }, 10_000);
 
   it('does NOT recover a non-transient error — surfaces immediately', async () => {

--- a/server/src/routes/generation-recycle-recovery.test.ts
+++ b/server/src/routes/generation-recycle-recovery.test.ts
@@ -249,6 +249,15 @@ describe('srv-17c in-worker recovery after a mid-synth sidecar death', () => {
     // NOT a generic vram-spill / unknown classification.
     expect(body).toContain('"errorCode":"recycle-storm"');
     expect(body).toMatch(/"remediation":"[^"]*(?:sidecar|concurrency|headroom)/i);
+    /* C3 — on the QUEUE path one POST = one chapter, so the cross-chapter
+       cascade can never escalate. A recycle-storm instead PAUSES the queue
+       server-side, stopping a thrashing sidecar from grinding chapter after
+       chapter. The harness seeds paused:false, so a true flag proves the
+       storm set it. */
+    await vi.waitFor(async () => {
+      const file = await readQueueFile(queuePath);
+      expect(file.paused).toBe(true);
+    });
   }, 10_000);
 
   it('does NOT recover a non-transient error — surfaces immediately', async () => {

--- a/server/src/routes/generation-recycle-recovery.test.ts
+++ b/server/src/routes/generation-recycle-recovery.test.ts
@@ -224,6 +224,8 @@ describe('srv-17c in-worker recovery after a mid-synth sidecar death', () => {
 
     expect(calls).toBe(1); // synthesiseChapter called ONCE (recovery is internal now)
     expect(ensureReadyCalls).toBeGreaterThanOrEqual(2); // preload gate + the hook's wait
+    // C2 — the hook emits a visible "recovering" tick while it rides out the respawn.
+    expect(body).toContain('"type":"chapter_recovering"');
     expect(body).toContain('"type":"chapter_complete"');
     expect(body).not.toContain('"type":"chapter_failed"');
     // srv-16 done-prune fired → the entry is gone (never left failed/in_progress).

--- a/server/src/routes/generation-recycle-recovery.test.ts
+++ b/server/src/routes/generation-recycle-recovery.test.ts
@@ -1,22 +1,24 @@
 /* srv-17c — in-worker recovery when the sidecar dies mid-synth.
  *
- * A host-RAM recycle (plan 143), a crash, or an OOM drops the in-flight
- * `/synthesize` connection (or, while a recycle drains, returns a non-poisoned
- * 503). Both surface as a `transient` error once `withTtsRetry`'s short budget
- * exhausts. The srv-17b readiness gate only protects the NEXT chapter; the one
- * already mid-synth would otherwise be classified fatal ("sidecar not
- * reachable") → `chapter_failed` + run abort, recovered only by a later manual
- * Retry / boot sweep (the ch36/ch46 drops).
+ * As of C1 (Wave 3) the recovery loop lives INSIDE `synthesiseChapter`: a
+ * mid-render recycle is recovered from the failed synth site via an injected
+ * `onRecoverRecycle` hook (riding out the respawn on the readiness gate),
+ * WITHOUT re-rendering the already-completed groups. `generation.ts` no longer
+ * wraps the whole chapter in a `for (recovery…)` loop — it injects the hook
+ * (wired to `ensureSidecarEngineReady`) and maps a thrown `RecycleStormError`
+ * (budget exhausted) to `chapter_failed` via the outer catch.
  *
- * These pin the recovery loop in `processOneChapter`:
- *   1. transient-then-success → chapter COMPLETES (srv-16 done-prune), NO
- *      `chapter_failed`, and the readiness gate was polled between attempts;
- *   2. transient on every attempt → after MAX_RECYCLE_RECOVERIES it falls
- *      through to the unchanged `chapter_failed` path (a truly-dead sidecar
- *      still surfaces, never an infinite loop);
- *   3. a non-transient error → NO recovery loop (straight to failure), proving
- *      poison / fatal-classifier errors still surface immediately;
- *   4. an abort mid-wait (pause / displacement) → clean stop, no failure tick.
+ * Because this suite mocks `synthesiseChapter` wholesale, it can no longer drive
+ * the inner recovery — it pins the generation-side WIRING instead:
+ *   1. the injected `onRecoverRecycle` drives `ensureSidecarEngineReady`, then
+ *      the chapter COMPLETES (no `chapter_failed`);
+ *   2. a thrown `RecycleStormError` → `chapter_failed` (budget exhausted);
+ *   3. a non-transient error → `chapter_failed` (surfaces immediately);
+ *   4. an abort thrown from the hook's wait (pause / displacement mid-recovery)
+ *      → clean stop, no failure tick.
+ * The resume-preservation proof (completed groups survive a recovery) now lives
+ * in `synthesise-chapter.test.ts` (the C1 unit tests), where the real per-group
+ * loop is exercised.
  *
  * Same fetch+SSE socket harness as generation-orphan-recovery.test.ts; we drive
  * a real http.Server and read the SSE body text to assert which ticks fired. */
@@ -78,17 +80,6 @@ let writeQueueFile: (
   path: string,
   file: import('../workspace/queue-io.js').QueueFile,
 ) => Promise<void>;
-
-/* A transient sidecar-down error — exactly what `sidecar.ts:post()` annotates on
-   a connection drop (and what `throwForResponse` annotates on a non-poisoned
-   5xx). `withTtsRetry` has already exhausted its short budget by the time this
-   reaches `processOneChapter`. */
-function transientSidecarDown(): Error {
-  return Object.assign(new Error('Local TTS sidecar not reachable at http://x. (fetch failed)'), {
-    transient: true as const,
-    cause: 'network' as const,
-  });
-}
 
 function okResult() {
   return {
@@ -216,60 +207,60 @@ async function readEntryStatus(): Promise<string | undefined> {
 }
 
 describe('srv-17c in-worker recovery after a mid-synth sidecar death', () => {
-  it('re-renders the chapter after a transient sidecar-down — completes, no chapter_failed', async () => {
+  it('drives ensureSidecarEngineReady from onRecoverRecycle, then completes (no chapter_failed)', async () => {
     let calls = 0;
-    synthesiseImpl = async () => {
+    synthesiseImpl = async (args: any) => {
       calls += 1;
-      if (calls === 1) throw transientSidecarDown(); // recycle kills the first attempt
-      return okResult(); // sidecar respawned → second attempt succeeds
+      if (calls === 1) {
+        // First call: exercise the injected hook once (simulating an in-loop
+        // recovery), then succeed — proving generation wires the hook to the gate.
+        await args.onRecoverRecycle({ engine: 'kokoro', attempt: 1 });
+        return okResult();
+      }
+      return okResult();
     };
 
     const body = await runChapter();
 
-    expect(calls).toBe(2); // failed once, recovered once
+    expect(calls).toBe(1); // synthesiseChapter called ONCE (recovery is internal now)
+    expect(ensureReadyCalls).toBeGreaterThanOrEqual(2); // preload gate + the hook's wait
     expect(body).toContain('"type":"chapter_complete"');
     expect(body).not.toContain('"type":"chapter_failed"');
-    // Preload gate (1) + one recovery wait (1) = the gate was polled between attempts.
-    expect(ensureReadyCalls).toBeGreaterThanOrEqual(2);
     // srv-16 done-prune fired → the entry is gone (never left failed/in_progress).
     await vi.waitFor(async () => {
       expect(await readEntryStatus()).toBeUndefined();
     });
   }, 10_000);
 
-  it('falls through to chapter_failed once the recovery budget is exhausted', async () => {
-    let calls = 0;
+  it('surfaces chapter_failed when synthesiseChapter throws RecycleStormError', async () => {
+    const { RecycleStormError } = await import('../tts/synthesise-chapter.js');
     synthesiseImpl = async () => {
-      calls += 1;
-      throw transientSidecarDown(); // sidecar never comes back
+      throw new RecycleStormError(2, new Error('sidecar down'));
     };
 
     const body = await runChapter();
 
-    // 1 primary + MAX_RECYCLE_RECOVERIES (2) re-attempts = 3 synth calls, then fail.
-    expect(calls).toBe(3);
     expect(body).toContain('"type":"chapter_failed"');
     expect(body).not.toContain('"type":"chapter_complete"');
+    // Task 3 asserts the recycle-storm code/remediation in the chapter_failed frame.
   }, 10_000);
 
   it('does NOT recover a non-transient error — surfaces immediately', async () => {
-    let calls = 0;
     synthesiseImpl = async () => {
-      calls += 1;
       throw new Error('index out of range in self'); // XTTS tensor — fatal, not transient
     };
 
     const body = await runChapter();
 
-    expect(calls).toBe(1); // no recovery loop for a non-transient error
     expect(body).toContain('"type":"chapter_failed"');
   }, 10_000);
 
-  it('stops cleanly (no chapter_failed) when the run is aborted during the recovery wait', async () => {
-    let calls = 0;
-    synthesiseImpl = async () => {
-      calls += 1;
-      throw transientSidecarDown();
+  it('stops cleanly when the hook wait aborts (pause/displacement mid-recovery)', async () => {
+    synthesiseImpl = async (args: any) => {
+      // The hook's readiness wait throws AbortError (ensureReadyImpl below); that
+      // must propagate out of synthesiseChapter as a clean stop, not a failure.
+      await args.onRecoverRecycle({ engine: 'kokoro', attempt: 1 });
+      return okResult();
     };
     /* First gate call (preload) resolves; the recovery wait throws AbortError —
        as if /pause fired while we were riding out the respawn. */
@@ -279,8 +270,7 @@ describe('srv-17c in-worker recovery after a mid-synth sidecar death', () => {
 
     const body = await runChapter();
 
-    expect(calls).toBe(1); // failed once, then the recovery wait aborted
-    expect(body).not.toContain('"type":"chapter_failed"'); // abort is a clean stop
+    expect(body).not.toContain('"type":"chapter_failed"'); // abort = clean stop
     expect(body).not.toContain('"type":"chapter_complete"');
   }, 10_000);
 });

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -30,7 +30,12 @@ import {
   stateJsonPath,
 } from '../workspace/paths.js';
 import { readQueueFile, writeQueueFile } from '../workspace/queue-migrate.js';
-import { completeEntry, markAwaitingConfirm, resetEntryToQueued } from '../workspace/queue-io.js';
+import {
+  completeEntry,
+  markAwaitingConfirm,
+  resetEntryToQueued,
+  setPaused,
+} from '../workspace/queue-io.js';
 import { computeQwenKokoroFallbackSet, type QwenFallbackChar } from '../tts/qwen-fallback-set.js';
 import { readJson, writeJsonAtomic } from '../workspace/state-io.js';
 import { stampStateSchema } from '../workspace/state-migrate.js';
@@ -1548,8 +1553,10 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
          rendering it). Short-circuit BEFORE describeSynthesisError so the named
          code/remediation ride through (the taxonomy entry would also classify it
          correctly, but the literal object keeps the wording owned here and avoids
-         re-deriving it). Non-fatal, like a stall — recordNonFatal below escalates
-         to a run-stop if storms repeat across chapters. */
+         re-deriving it). Non-fatal per chapter. The run-stop is the queue PAUSE
+         set below (on the queue path: one POST = one chapter, so the
+         cross-chapter cascade can never escalate). The cascade still escalates
+         only on the back-compat `*` job, which loops many chapters in one POST. */
       const isRecycleStorm = (e as { name?: string })?.name === 'RecycleStormError';
       const initial = isStall
         ? {
@@ -1585,7 +1592,8 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
         const recoveries = (e as { recoveries?: number })?.recoveries ?? MAX_RECYCLE_RECOVERIES;
         console.error(
           `[generation] chapter ${chapter.id} (${chapter.slug}) RECYCLE STORM: sidecar recycled ` +
-            `${recoveries}× on one chapter — recorded non-fatal; cascade will stop the run if it repeats.`,
+            `${recoveries}× on one chapter — recorded non-fatal. On the queue path the run is ` +
+            `stopped by pausing the queue (below); the back-compat \`*\` job relies on the cascade.`,
         );
       } else {
         console.error(`[generation] chapter ${chapter.id} (${chapter.slug}) failed:`, e);
@@ -1645,6 +1653,32 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
           `[generation] failed to persist error state for chapter ${chapter.id}:`,
           persistErr,
         );
+      }
+      /* C3 (Wave 3) — recycle storm on the QUEUE path: pause the queue so a
+         thrashing sidecar stops the run instead of grinding chapter after
+         chapter. The dispatcher fires ONE POST per chapter, so the cross-chapter
+         cascade above (recordNonFatal) can never escalate on this path — this
+         server-side pause is the faithful "stop the run". Runs AFTER the
+         chapter_failed broadcast + state persist, so the failure surfaces
+         regardless. fatal stays false (the queue-pause is the run-stop; flipping
+         fatal would needlessly take the `*`-job controller.abort() path).
+         BEST-EFFORT: a queue-write hiccup must never mask the real chapter
+         failure, so this is wrapped + warns on error only. The back-compat `*`
+         job (no queueEntryId) is untouched — it keeps relying on the cascade. */
+      if (isRecycleStorm && job.queueEntryId != null) {
+        try {
+          const before = await readQueueFile(queueJsonPath());
+          await writeQueueFile(queueJsonPath(), setPaused(before, true));
+          console.error(
+            '[generation] RECYCLE STORM: paused the queue — restart the TTS sidecar / ' +
+              'restore headroom, then resume.',
+          );
+        } catch (pauseErr) {
+          console.warn(
+            `[generation] failed to pause the queue after a recycle storm on chapter ${chapter.id}:`,
+            pauseErr,
+          );
+        }
       }
       if (fatal) {
         /* Back-compat `*` job only: set the flag AND abort the signal so the

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -1288,11 +1288,37 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
               `mid-synth (recycle/respawn) — riding out the respawn, re-attempt ` +
               `${attempt}/${MAX_RECYCLE_RECOVERIES} (preserving completed groups).`,
           );
+          /* C2 (Wave 3) — the readiness wait below can take up to ~210 s
+             (READINESS_TIMEOUT_MS); without a tick the SSE goes silent and the
+             client's 30 s "Worker has gone quiet" stall banner fires for what is
+             actually a healthy respawn ride-out. Emit a chapter_recovering tick
+             immediately + on a 10 s heartbeat so BOTH watchdogs stay fed: the
+             server no-progress guard (bumpProgress) and the client stall detector
+             (< 30 s). 0.9 progress + the last currentLine keep the bar where
+             synthesis left it. Mirrors emitVerifying (srv-31). */
+          const emitRecovering = () => {
+            bumpProgress();
+            broadcast(job, {
+              type: 'chapter_recovering',
+              chapterId: chapter.id,
+              characterId: null,
+              progress: 0.9,
+              currentLine: job.lastProgressTick?.currentLine ?? 0,
+              totalLines,
+            });
+          };
+          emitRecovering();
+          const beat = setInterval(emitRecovering, 10_000);
+          beat.unref?.();
           /* Polls through the supervisor respawn (srv-17b, 120 s budget); throws
              AbortError if the run is paused/displaced mid-wait → propagates out
              of synthesiseChapter as a clean stop (the outer catch returns on
-             AbortError). Task 2 (C2) wraps this in a recovering tick + heartbeat. */
-          await ensureSidecarEngineReady(recEngine, chapterSignal);
+             AbortError). */
+          try {
+            await ensureSidecarEngineReady(recEngine, chapterSignal);
+          } finally {
+            clearInterval(beat);
+          }
         },
       });
 

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -1543,6 +1543,14 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
          queue advances; the cascade counter below still escalates if stalls
          repeat across chapters, which signals a systemic wedge). */
       const isStall = (e as { name?: string })?.name === 'ChapterStallError';
+      /* C3 (Wave 3) — RecycleStormError: synthesiseChapter exhausted the in-loop
+         recycle-recovery budget on a single chapter (the sidecar thrashed while
+         rendering it). Short-circuit BEFORE describeSynthesisError so the named
+         code/remediation ride through (the taxonomy entry would also classify it
+         correctly, but the literal object keeps the wording owned here and avoids
+         re-deriving it). Non-fatal, like a stall — recordNonFatal below escalates
+         to a run-stop if storms repeat across chapters. */
+      const isRecycleStorm = (e as { name?: string })?.name === 'RecycleStormError';
       const initial = isStall
         ? {
             errorReason: (e as Error).message,
@@ -1552,7 +1560,17 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
               'Click Retry on this chapter. If it stalls repeatedly, restart the TTS sidecar to ' +
               'clear a wedged GPU state, then retry.',
           }
-        : describeSynthesisError(e, engine);
+        : isRecycleStorm
+          ? {
+              errorReason: (e as Error).message,
+              fatal: false,
+              code: 'recycle-storm' as FailureCode,
+              remediation:
+                'Restart the TTS sidecar (clears a thrashing/leaking process) and/or lower ' +
+                'generation concurrency, then Retry. If it persists, the host-memory leak ' +
+                '(side-11) needs headroom.',
+            }
+          : describeSynthesisError(e, engine);
       let { errorReason, fatal } = initial;
       /* fs-19 — the structured code + remediation ride alongside the legacy
          reason on both the broadcast and the persisted state. Const (not part of
@@ -1562,6 +1580,12 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
         console.error(
           `[generation] chapter ${chapter.id} (${chapter.slug}) STALLED during ${stallPhase}: ` +
             `no progress for ${Math.round(noProgressMs / 1000)}s — recorded as failed so the queue advances.`,
+        );
+      } else if (isRecycleStorm) {
+        const recoveries = (e as { recoveries?: number })?.recoveries ?? MAX_RECYCLE_RECOVERIES;
+        console.error(
+          `[generation] chapter ${chapter.id} (${chapter.slug}) RECYCLE STORM: sidecar recycled ` +
+            `${recoveries}× on one chapter — recorded non-fatal; cascade will stop the run if it repeats.`,
         );
       } else {
         console.error(`[generation] chapter ${chapter.id} (${chapter.slug}) failed:`, e);

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -1302,7 +1302,13 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
               type: 'chapter_recovering',
               chapterId: chapter.id,
               characterId: null,
-              progress: 0.9,
+              /* Hold the bar where synthesis left it rather than snapping to a
+                 fixed 0.9 — a recycle can fire at any group position, so a hard
+                 0.9 would visibly REGRESS the bar (e.g. 0.95 → 0.9) for the
+                 ride-out, then jump forward. Reuse the last real tick's progress
+                 (same idiom as currentLine below); 0.9 is only the pre-first-tick
+                 seed. */
+              progress: job.lastProgressTick?.progress ?? 0.9,
               currentLine: job.lastProgressTick?.currentLine ?? 0,
               totalLines,
             });

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -79,7 +79,6 @@ import {
   resolveAsrSampleEvery,
   buildCastNameAllowlist,
 } from '../tts/segment-asr-qa.js';
-import { isTransient } from '../tts/retry.js';
 import { describeSynthesisError, newCascadeState, recordNonFatal } from './generation-error.js';
 import type { FailureCode } from './failure-taxonomy.js';
 import { AVG_CHAPTER_BYTES, diskGuardMode, evaluateDiskGuard } from '../workspace/disk-guard.js';
@@ -1120,10 +1119,10 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
          encode/disk happens after and is excluded) — drives the RTF rollup +
          the dev top-bar throughput pill. */
       const synthStartMs = Date.now();
-      /* srv-17c recovery loop (see MAX_RECYCLE_RECOVERIES). Wraps ONLY the synth
-         call: on a transient sidecar-down (recycle/respawn/crash, or a drain-503)
-         we wait out the respawn on the readiness gate and re-render. AbortError
-         and non-transient / poison errors re-throw to the outer catch unchanged. */
+      /* srv-17c recovery is now IN-LOOP (C1, Wave 3): synthesiseChapter recovers
+         a mid-render recycle from the failed synth site via the `onRecoverRecycle`
+         hook below (riding out the respawn on the readiness gate) WITHOUT
+         re-rendering completed groups. See the hook + MAX_RECYCLE_RECOVERIES. */
       /* srv-31 — surface the ASR content-QA pass as a "verifying" phase. Fired
          per sampled group (onProgress) AND per drift re-record (onRerecord);
          both bump the no-progress watchdog and broadcast a chapter_verifying
@@ -1140,10 +1139,7 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
           totalLines,
         });
       };
-      let result: Awaited<ReturnType<typeof synthesiseChapter>>;
-      for (let recovery = 0; ; recovery += 1) {
-        try {
-          result = await synthesiseChapter({
+      const result = await synthesiseChapter({
         sentences,
         cast: cast.characters,
         provider,
@@ -1270,45 +1266,35 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
               },
             }
           : {}),
-          });
-          break;
-        } catch (synthErr) {
-          /* Recoverable only while the run is live and the budget remains. Two
-             recoverable shapes:
-               1. a transient sidecar-down (connection drop on recycle/crash, or
-                  a drain-503), and
-               2. a ChapterSynthTimeoutError — a synth that HUNG past the per-call
-                  ceiling. Under a host-RAM recycle the respawned sidecar can be
-                  HTTP-up but still loading the model in-band, so the in-flight
-                  call stalls to the timeout instead of failing fast. That timeout
-                  is non-transient by construction, so without this it bubbles to
-                  the outer catch and stops the run (2026-05-31 KOTLC CH24). Ride
-                  it out the same way: wait on the readiness gate, then re-render
-                  against a sidecar that is actually ready.
-             AbortError, poison, and every other fatal classifier error re-throw
-             to the outer catch unchanged. */
-          const isRecycleTimeout =
-            (synthErr as { name?: string })?.name === 'ChapterSynthTimeoutError';
-          if (
-            (synthErr as { name?: string })?.name === 'AbortError' ||
-            (!isTransient(synthErr) && !isRecycleTimeout) ||
-            chapterSignal.aborted ||
-            recovery >= MAX_RECYCLE_RECOVERIES
-          ) {
-            throw synthErr;
-          }
+        /* C1 (srv-17c, Wave 3) — recover in-loop (preserves completed groups)
+           instead of the old outer for-loop that re-rendered the WHOLE chapter
+           on a mid-render recycle (the RTF collapse). synthesiseChapter now calls
+           this hook from the failed synth site, waits out the respawn on the
+           readiness gate, and re-attempts ONLY that work item; every already-
+           filled `results[]` slot survives because the function never restarts.
+           Recoverable = a transient sidecar-down (recycle/respawn/crash drop, or
+           a drain-503 — both `transient` once withTtsRetry's short budget
+           exhausts) OR a ChapterSynthTimeoutError (a synth that HUNG because the
+           respawned sidecar was still loading the model in-band — non-transient
+           by construction, classified recoverable inside withRecycleRecovery).
+           MAX_RECYCLE_RECOVERIES is the shared per-chapter budget; on exhaustion
+           synthesiseChapter throws RecycleStormError, which the outer catch maps
+           to chapter_failed (Task 3 names it). AbortError, poison, and every
+           other fatal classifier error still re-throw unchanged. */
+        maxRecycleRecoveries: MAX_RECYCLE_RECOVERIES,
+        onRecoverRecycle: async ({ engine: recEngine, attempt }) => {
           console.warn(
-            `[generation] chapter ${chapter.id} (${chapter.slug}): ${
-              isRecycleTimeout
-                ? 'synth stalled (likely a mid-render recycle)'
-                : 'sidecar unavailable mid-synth (recycle/respawn)'
-            } — riding out the respawn, re-attempt ${recovery + 1}/${MAX_RECYCLE_RECOVERIES}.`,
+            `[generation] chapter ${chapter.id} (${chapter.slug}): sidecar unavailable ` +
+              `mid-synth (recycle/respawn) — riding out the respawn, re-attempt ` +
+              `${attempt}/${MAX_RECYCLE_RECOVERIES} (preserving completed groups).`,
           );
           /* Polls through the supervisor respawn (srv-17b, 120 s budget); throws
-             AbortError if the run is paused/displaced mid-wait. */
-          await ensureSidecarEngineReady(engine, chapterSignal);
-        }
-      }
+             AbortError if the run is paused/displaced mid-wait → propagates out
+             of synthesiseChapter as a clean stop (the outer catch returns on
+             AbortError). Task 2 (C2) wraps this in a recovering tick + heartbeat. */
+          await ensureSidecarEngineReady(recEngine, chapterSignal);
+        },
+      });
 
       /* All per-group synthesis is done; the next stretch is disk-write
          work (encode MP3 → temp file → segments JSON → atomic rename →

--- a/server/src/tts/synthesise-chapter.test.ts
+++ b/server/src/tts/synthesise-chapter.test.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_QWEN_BATCH_TOKEN_BUDGET,
   ChapterSynthTimeoutError,
   MissingDesignedVoiceError,
+  RecycleStormError,
   type CastCharacter,
 } from './synthesise-chapter.js';
 import type { SentenceOutput } from '../handoff/schemas.js';
@@ -2432,4 +2433,149 @@ describe('synthesiseChapter pre-assembly QA gate', () => {
     const body = result.segments.find((s) => s.sentenceIds.includes(1));
     expect(body?.voiceSubstitutedFrom).toBeUndefined();
   });
+});
+
+/* ── C1 (Wave 3): in-loop recycle recovery ───────────────────────────
+   A transient sidecar-down mid-pool must recover WITHOUT discarding the
+   already-completed groups: synthesiseChapter calls the injected
+   `onRecoverRecycle` hook (the readiness wait, in production) and re-attempts
+   ONLY the failed work item; every filled `results[]` slot survives because the
+   function never restarts. On budget exhaustion it throws the named
+   `RecycleStormError`; an abort or a non-transient error never recovers; and
+   with no hook a transient bubbles out unchanged (the pre-C1 passthrough every
+   other caller relies on).
+
+   NOTE ON CALL COUNTS: each synth site wraps `withTtsRetry` (1 primary + 2
+   retries on a persistent transient), so a single recovery attempt makes up to
+   3 provider calls. These tests therefore assert on the RECOVERY count
+   (`onRecoverRecycle` invocations / `RecycleStormError.recoveries`), which is
+   the contract C1 introduces — independent of the inner retry budget. */
+describe('synthesiseChapter C1 in-loop recycle recovery', () => {
+  const c1Cast: CastCharacter[] = [
+    { id: 'narrator', name: 'Narrator', attributes: ['observational'] },
+  ];
+
+  function transientErr(): Error {
+    return Object.assign(new Error('sidecar not reachable (fetch failed)'), {
+      transient: true as const,
+      cause: 'network' as const,
+    });
+  }
+
+  it('recovers a transient mid-pool failure WITHOUT re-rendering completed groups', async () => {
+    /* 3 single-sentence groups, serial (sentenceConcurrency 1). The middle
+       group's first synthGroup throws a persistent transient (drains its whole
+       withTtsRetry budget → 3 provider calls), which trips ONE in-loop recovery;
+       on the re-attempt the provider succeeds. Groups 0 + 2 synth exactly once
+       (never re-rendered). */
+    const calls = new Map<string, number>();
+    let g1Budget = 3; // throw for the first synthGroup's full retry budget, then succeed
+    const provider: TtsProvider = {
+      synthesize: vi.fn(async (input: SynthesizeInput): Promise<SynthesizeOutput> => {
+        calls.set(input.text, (calls.get(input.text) ?? 0) + 1);
+        if (input.text.includes('middle') && g1Budget > 0) {
+          g1Budget -= 1;
+          throw transientErr();
+        }
+        return { pcm: Buffer.alloc(2), sampleRate: 24000, mimeType: 'audio/pcm' };
+      }),
+    };
+    const onRecoverRecycle = vi.fn(async () => {});
+
+    const result = await synthesiseChapter({
+      sentences: [
+        sentence(1, 'narrator', 'first line.'),
+        sentence(2, 'narrator', 'middle line.'),
+        sentence(3, 'narrator', 'last line.'),
+      ],
+      cast: c1Cast,
+      provider,
+      modelKey: 'gemini-2.5-flash',
+      engine: 'kokoro',
+      sentenceConcurrency: 1,
+      groupHeartbeatMs: 0,
+      onRecoverRecycle,
+      maxRecycleRecoveries: 2,
+    });
+
+    expect(onRecoverRecycle).toHaveBeenCalledTimes(1); // exactly one recovery
+    expect(onRecoverRecycle).toHaveBeenCalledWith({ engine: 'kokoro', attempt: 1 });
+    expect(calls.get('first line.')).toBe(1); // completed group NOT re-rendered
+    expect(calls.get('last line.')).toBe(1); // completed group NOT re-rendered
+    expect(result.segments.length).toBe(3); // chapter completed
+  }, 15_000);
+
+  it('throws RecycleStormError after the shared budget is exhausted', async () => {
+    const onRecoverRecycle = vi.fn(async () => {});
+    const provider: TtsProvider = {
+      synthesize: vi.fn(async (): Promise<SynthesizeOutput> => {
+        throw transientErr();
+      }),
+    };
+
+    const err = await synthesiseChapter({
+      sentences: [sentence(1, 'narrator', 'a line.')],
+      cast: c1Cast,
+      provider,
+      modelKey: 'gemini-2.5-flash',
+      engine: 'kokoro',
+      sentenceConcurrency: 1,
+      groupHeartbeatMs: 0,
+      onRecoverRecycle,
+      maxRecycleRecoveries: 2,
+    }).then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(RecycleStormError);
+    expect((err as RecycleStormError).recoveries).toBe(2);
+    // 1 primary attempt + 2 recoveries = 3 synth attempts → hook fired twice.
+    expect(onRecoverRecycle).toHaveBeenCalledTimes(2);
+  }, 30_000);
+
+  it('a non-transient error does NOT recover (re-throws immediately)', async () => {
+    const onRecoverRecycle = vi.fn(async () => {});
+    const provider: TtsProvider = {
+      synthesize: vi.fn(async (): Promise<SynthesizeOutput> => {
+        throw new Error('index out of range in self');
+      }),
+    };
+
+    await expect(
+      synthesiseChapter({
+        sentences: [sentence(1, 'narrator', 'a line.')],
+        cast: c1Cast,
+        provider,
+        modelKey: 'gemini-2.5-flash',
+        engine: 'kokoro',
+        sentenceConcurrency: 1,
+        groupHeartbeatMs: 0,
+        onRecoverRecycle,
+        maxRecycleRecoveries: 2,
+      }),
+    ).rejects.toThrow('index out of range');
+    expect(onRecoverRecycle).not.toHaveBeenCalled(); // non-transient → no recovery
+    expect(provider.synthesize).toHaveBeenCalledTimes(1); // withTtsRetry bails on non-transient
+  });
+
+  it('passthrough — with no onRecoverRecycle a transient bubbles out unchanged (pre-C1)', async () => {
+    const provider: TtsProvider = {
+      synthesize: vi.fn(async (): Promise<SynthesizeOutput> => {
+        throw transientErr();
+      }),
+    };
+
+    await expect(
+      synthesiseChapter({
+        sentences: [sentence(1, 'narrator', 'a line.')],
+        cast: c1Cast,
+        provider,
+        modelKey: 'gemini-2.5-flash',
+        engine: 'kokoro',
+        sentenceConcurrency: 1,
+        groupHeartbeatMs: 0,
+        // NO onRecoverRecycle → no in-loop recovery; transient bubbles out.
+      }),
+    ).rejects.toMatchObject({ transient: true });
+  }, 15_000);
 });

--- a/server/src/tts/synthesise-chapter.ts
+++ b/server/src/tts/synthesise-chapter.ts
@@ -26,7 +26,7 @@ import {
 } from './segment-asr-qa.js';
 import type { TranscribeResult } from './transcribe-client.js';
 import { resamplePcm16 } from './resample-pcm16.js';
-import { withTtsRetry } from './retry.js';
+import { withTtsRetry, isTransient } from './retry.js';
 import { gpuSemaphore } from '../gpu/semaphore.js';
 
 /* How many Qwen sentences to pack into one batched `generate_voice_clone`
@@ -123,6 +123,28 @@ export class ChapterStallError extends Error {
         `Check the TTS sidecar (it may be wedged or memory-saturated).`,
     );
     this.name = 'ChapterStallError';
+  }
+}
+
+/** Thrown by synthesiseChapter when the in-loop recycle-recovery budget
+    (`maxRecycleRecoveries`) is exhausted on a single chapter — i.e. the sidecar
+    recycled/respawned more times than allowed while this one chapter rendered.
+    A NAMED signal (C3) so generation.ts can surface "the sidecar is thrashing —
+    likely the host-memory leak (side-11) or insufficient headroom" instead of a
+    generic mid-synth failure. Carries the recovery count + the last underlying
+    error for the log. */
+export class RecycleStormError extends Error {
+  readonly recoveries: number;
+  readonly lastError: unknown;
+  constructor(recoveries: number, lastError: unknown) {
+    super(
+      `The TTS sidecar recycled ${recoveries}× while rendering this single chapter ` +
+        `— it is likely thrashing (host-memory leak or insufficient VRAM/RAM headroom). ` +
+        `Stopping so the run doesn't grind. Restart the sidecar / lower concurrency, then Retry.`,
+    );
+    this.name = 'RecycleStormError';
+    this.recoveries = recoveries;
+    this.lastError = lastError;
   }
 }
 
@@ -499,6 +521,22 @@ export interface SynthesiseChapterOpts {
       inline here, but the multi-worker queue overlaps chapter N's (CPU) ASR with
       chapter N+1's (GPU) synth, so it doesn't serialise the run. */
   asr?: AsrPassOptions;
+  /** C1 (Wave 3) — recover from a transient sidecar-down WITHOUT discarding
+      completed groups. When a synth site throws a recoverable error
+      (`isTransient` OR a `ChapterSynthTimeoutError`), the site calls this hook
+      to wait out the respawn, then re-attempts the SAME work item; every
+      already-completed `results[]` slot is preserved. Wired by generation.ts to
+      `ensureSidecarEngineReady(engine, signal)` (+ the C2 recovering tick).
+      `engine` is the failed item's resolved engine (a chapter can be mixed-
+      engine); `attempt` is the 1-indexed shared recovery count. ABSENT → no
+      in-loop recovery: a transient bubbles out unchanged (pre-C1 behaviour, the
+      passthrough every existing caller/test relies on). */
+  onRecoverRecycle?: (e: { engine: TtsEngine; attempt: number }) => Promise<void>;
+  /** Max in-loop recycle recoveries SHARED across all groups/workers of this
+      chapter. Mirrors generation.ts `MAX_RECYCLE_RECOVERIES` (2). Exceeding it
+      throws `RecycleStormError` so the chapter fails fast (no infinite grind).
+      Only consulted when `onRecoverRecycle` is provided. Default 2. */
+  maxRecycleRecoveries?: number;
 }
 
 /** Options for the per-sentence ASR content-QA pass (srv-31). */
@@ -643,6 +681,8 @@ export async function synthesiseChapter(
     segmentQaThresholds,
     onSegmentRerecord,
     asr,
+    onRecoverRecycle,
+    maxRecycleRecoveries = 2,
   } = opts;
 
   /* Per-character engine resolver (plan 108). Returns the engine + its
@@ -717,6 +757,39 @@ export async function synthesiseChapter(
      padding is deliberately NOT recorded as segments (it's not narration,
      it's structural padding, and the listen view's timeline shouldn't show
      dead-air rows). */
+  let recycleRecoveries = 0;
+  /* C1 in-loop recovery. Re-attempt `fn` after waiting out a sidecar respawn,
+     WITHOUT discarding completed groups (the function never restarts, so every
+     filled `results[]` slot survives). The shared `recycleRecoveries` counter
+     bounds total recoveries per chapter; exhaustion throws RecycleStormError
+     (C3). Recoverable = isTransient OR ChapterSynthTimeoutError; an abort or a
+     non-recoverable error re-throws. No-op passthrough when `onRecoverRecycle`
+     is absent (pre-C1). Wraps EVERY synth site (title, anchor, pool item,
+     QA/ASR re-record) so recovery coverage matches the old whole-chapter loop. */
+  async function withRecycleRecovery<T>(
+    engineForItem: TtsEngine,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    for (;;) {
+      try {
+        return await fn();
+      } catch (err) {
+        if (!onRecoverRecycle) throw err;
+        const name = (err as { name?: string })?.name;
+        if (name === 'AbortError' || signal?.aborted) throw err;
+        const isRecycleTimeout = name === 'ChapterSynthTimeoutError';
+        if (!isTransient(err) && !isRecycleTimeout) throw err;
+        if (recycleRecoveries >= maxRecycleRecoveries) {
+          throw new RecycleStormError(recycleRecoveries, err);
+        }
+        recycleRecoveries += 1;
+        /* May throw AbortError (run paused mid-wait) → propagates out as a clean
+           stop, exactly like the old generation.ts recovery loop. */
+        await onRecoverRecycle({ engine: engineForItem, attempt: recycleRecoveries });
+      }
+    }
+  }
+
   const titleText = chapterTitleNarration?.trim();
   if (titleText) {
     if (signal?.aborted) {
@@ -745,15 +818,17 @@ export async function synthesiseChapter(
 
     onTitleStart?.();
 
-    const titleResult = await withTtsRetry(
-      () =>
-        titleRoute.provider.synthesize({
-          text: normaliseForTts(titleText),
-          voiceName: narratorVoice,
-          modelKey: titleRoute.modelKey,
-          signal,
-        }),
-      { signal },
+    const titleResult = await withRecycleRecovery(titleRoute.engine, () =>
+      withTtsRetry(
+        () =>
+          titleRoute.provider.synthesize({
+            text: normaliseForTts(titleText),
+            voiceName: narratorVoice,
+            modelKey: titleRoute.modelKey,
+            signal,
+          }),
+        { signal },
+      ),
     );
 
     sampleRate = titleResult.sampleRate;
@@ -1041,7 +1116,9 @@ export async function synthesiseChapter(
       throw new DOMException('synthesiseChapter aborted', 'AbortError');
     }
     const anchorGroup = groups[0];
-    const result = await synthGroup(anchorGroup);
+    const result = await withRecycleRecovery(resolveGroup(anchorGroup).route.engine, () =>
+      synthGroup(anchorGroup),
+    );
     results[anchorGroup.index] = result;
     sampleRate = result.sampleRate;
     fireComplete(anchorGroup);
@@ -1150,10 +1227,16 @@ export async function synthesiseChapter(
           if (i >= workItems.length) return;
           const item = workItems[i];
           if (item.kind === 'single') {
-            results[item.group.index] = await synthGroup(item.group);
+            results[item.group.index] = await withRecycleRecovery(
+              resolveGroup(item.group).route.engine,
+              () => synthGroup(item.group),
+            );
             fireComplete(item.group);
           } else {
-            const out = await synthBatch(item.groups);
+            const out = await withRecycleRecovery(
+              resolveGroup(item.groups[0]).route.engine,
+              () => synthBatch(item.groups),
+            );
             /* Scatter each batched chunk back to ITS OWN group index — this is
                what keeps the index-order concat below identical to the per-call
                path. */
@@ -1201,7 +1284,9 @@ export async function synthesiseChapter(
           maxRerecords: maxSegmentRerecords,
           reasons: bestVerdict.reasons,
         });
-        const fresh = await synthGroup(group);
+        const fresh = await withRecycleRecovery(resolveGroup(group).route.engine, () =>
+          synthGroup(group),
+        );
         const freshVerdict = evaluateSegmentPcm(
           fresh.pcm,
           fresh.sampleRate,
@@ -1271,7 +1356,9 @@ export async function synthesiseChapter(
           wer: bestClass.wer,
           reasons: bestClass.reasons,
         });
-        const fresh = await synthGroup(group);
+        const fresh = await withRecycleRecovery(resolveGroup(group).route.engine, () =>
+          synthGroup(group),
+        );
         const freshClass = await verify(fresh.pcm, fresh.sampleRate, group.text);
         if (asrBetter(freshClass, bestClass)) {
           best = fresh;

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -2463,6 +2463,12 @@ export interface components {
              *     assembly; it carries the same counters as `chapter_assembling` and
              *     surfaces a "Verifying speech…" phase so the row doesn't look frozen
              *     on "Synthesising …".
+             *     `chapter_recovering` is emitted (Wave 3, C2) while a worker rides out
+             *     a mid-render sidecar recycle/respawn on the readiness gate (up to
+             *     ~210 s). It carries the same counters as `chapter_assembling`, fires
+             *     on a 10 s heartbeat so the client's 30 s stall detector stays fed, and
+             *     surfaces a "Recovering …" phase so the row reads as healthy recovery
+             *     rather than a silent stall.
              *     `resume_from` is emitted as the FIRST event on every new subscriber
              *     (cold connect AND reconnect after `tsx watch` restart or server
              *     bounce) and carries a snapshot of completed chapter ids for the
@@ -2478,7 +2484,7 @@ export interface components {
              *     chapters keep flowing. See plan `docs/features/archive/102-global-queue-modal.md`.
              * @enum {string}
              */
-            type: "progress" | "chapter_assembling" | "chapter_verifying" | "chapter_complete" | "chapter_failed" | "idle" | "resume_from" | "warning" | "chapter_awaiting_fallback_confirm";
+            type: "progress" | "chapter_assembling" | "chapter_verifying" | "chapter_recovering" | "chapter_complete" | "chapter_failed" | "idle" | "resume_from" | "warning" | "chapter_awaiting_fallback_confirm";
             chapterId?: number;
             /** @description null = chapter-wide tick (not character-specific). */
             characterId?: string | null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,10 +9,14 @@ export type Character = components['schemas']['Character'] & {
   sourceBookId?: string;
   sourceBookTitle?: string;
 };
-/* `phase` is a UI-only sub-state set from the `chapter_assembling` SSE tick.
-   It lets the Generate view distinguish "synthesising sentences" from the
-   short disk-write phase between the last group and chapter_complete, so
-   the bar doesn't appear stuck at 99 %. Not part of the wire schema.
+/* `phase` is a UI-only sub-state set from the `chapter_assembling`,
+   `chapter_verifying`, and `chapter_recovering` SSE ticks. It lets the Generate
+   view distinguish "synthesising sentences" from the short disk-write phase
+   (`assembling`) between the last group and chapter_complete, the post-synthesis
+   ASR content-QA pass (`verifying`, srv-31), and a mid-render sidecar
+   recycle/respawn ride-out (`recovering`, Wave 3 C2) — so the bar doesn't appear
+   stuck at 99 % and a healthy respawn doesn't read as a silent stall. Not part
+   of the wire schema.
 
    `lufs` is a UI-only mirror of the chapter's EBU R128 sidecar payload
    (plan 71). Hydrated lazily from the book-state endpoint's per-chapter
@@ -21,7 +25,7 @@ export type Character = components['schemas']['Character'] & {
    / disabled / silent-source). `null` distinguishes "fetched but no data"
    from "not fetched yet". See plan 77 for the report-card consumer. */
 export type Chapter = components['schemas']['Chapter'] & {
-  phase?: 'assembling' | 'verifying' | null;
+  phase?: 'assembling' | 'verifying' | 'recovering' | null;
   lufs?: components['schemas']['ChapterLoudness'] | null;
   /* fs-13 — accumulated SET (as a Redux-serialisable array) of manuscript
      sentence ids whose same-speaker group has COMPLETED during the live run.

--- a/src/store/chapters-slice.test.ts
+++ b/src/store/chapters-slice.test.ts
@@ -396,6 +396,43 @@ describe('chaptersSlice — applyGenerationTick', () => {
     });
   });
 
+  describe('chapter_recovering', () => {
+    it('holds the row in_progress with phase=recovering and carries progress', () => {
+      const start = baseState([makeChapter(3, { state: 'in_progress', progress: 0.6 })]);
+      const next = chaptersSlice.reducer(
+        start,
+        chaptersActions.applyGenerationTick(
+          tick({ type: 'chapter_recovering', chapterId: 3, progress: 0.9 }),
+        ),
+      );
+      expect(next.chapters[0].phase).toBe('recovering');
+      expect(next.chapters[0].state).toBe('in_progress');
+      expect(next.chapters[0].progress).toBeCloseTo(0.9);
+    });
+
+    it('keeps the existing progress when the tick omits it', () => {
+      const start = baseState([makeChapter(3, { state: 'in_progress', progress: 0.42 })]);
+      const next = chaptersSlice.reducer(
+        start,
+        chaptersActions.applyGenerationTick(tick({ type: 'chapter_recovering', chapterId: 3 })),
+      );
+      expect(next.chapters[0].phase).toBe('recovering');
+      expect(next.chapters[0].progress).toBeCloseTo(0.42);
+    });
+
+    it('is cleared by a subsequent chapter_complete', () => {
+      const start = baseState([makeChapter(3, { state: 'in_progress', phase: 'recovering' })]);
+      const next = chaptersSlice.reducer(
+        start,
+        chaptersActions.applyGenerationTick(
+          tick({ type: 'chapter_complete', chapterId: 3, totalLines: 10 }),
+        ),
+      );
+      expect(next.chapters[0].phase).toBe(null);
+      expect(next.chapters[0].state).toBe('done');
+    });
+  });
+
   describe('chapter_complete', () => {
     it('flips state to done, progress to 1, and all non-skipped characters to done', () => {
       const start = baseState([

--- a/src/store/chapters-slice.ts
+++ b/src/store/chapters-slice.ts
@@ -458,6 +458,21 @@ export const chaptersSlice = createSlice({
         return;
       }
 
+      if (ev.type === 'chapter_recovering') {
+        /* C2 (Wave 3) — sidecar recycled mid-render; the worker is riding out
+           the respawn on the readiness gate (up to ~210 s). Mirror
+           chapter_verifying: hold the row in_progress with a distinct phase so
+           the view shows "Recovering…" instead of a frozen caption + the 30 s
+           stall banner. Keep the existing progress when the tick omits it so the
+           bar stays where synthesis left it. */
+        ch.phase = 'recovering';
+        ch.state = 'in_progress';
+        ch.progress = ev.progress ?? ch.progress;
+        if (ev.currentLine != null) ch.currentLine = ev.currentLine;
+        if (ev.totalLines != null) ch.totalLines = ev.totalLines;
+        return;
+      }
+
       if (ev.type === 'chapter_complete') {
         ch.state = 'done';
         ch.progress = 1;

--- a/src/views/generation.test.tsx
+++ b/src/views/generation.test.tsx
@@ -369,6 +369,55 @@ describe('GenerationView — counters exclude ignored chapters (regression)', ()
     expect(screen.queryByText(/Synthesising/)).not.toBeInTheDocument();
   });
 
+  it('shows the recovering caption on a chapter in the recovering phase', () => {
+    const recovering: Chapter = {
+      ...chapter1,
+      state: 'in_progress',
+      phase: 'recovering',
+      progress: 0.9,
+    };
+    const ch2Queued: Chapter = { ...chapter2 };
+    const store = configureStore({
+      reducer: {
+        ui: uiSlice.reducer,
+        chapters: chaptersSlice.reducer,
+        manuscript: manuscriptSlice.reducer,
+        changeLog: changeLogSlice.reducer,
+        cast: castSlice.reducer,
+        library: librarySlice.reducer,
+        queue: queueSlice.reducer,
+      },
+    });
+    store.dispatch(chaptersSlice.actions.setChapters([recovering, ch2Queued]));
+    store.dispatch(
+      manuscriptSlice.actions.hydrateFromAnalysis({
+        bookId: 'b1',
+        characters,
+        chapters: [recovering, ch2Queued],
+        sentences,
+      } as any),
+    );
+    render(
+      <Provider store={store}>
+        <HostedGenerationView
+          chapters={[recovering, ch2Queued]}
+          characters={characters}
+          paused
+          title="Bonus Keefe Story"
+          bookId="b1"
+          modelKey="coqui-xtts-v2"
+          onRegenerate={() => {}}
+          onRegenerateBook={() => {}}
+          onRegenerateCharacterInChapter={() => {}}
+          onPreview={() => {}}
+        />
+      </Provider>,
+    );
+    expect(screen.getByText('Recovering — restarting TTS engine…')).toBeInTheDocument();
+    // The frozen synthesising caption must NOT show for the recovering row.
+    expect(screen.queryByText(/Synthesising/)).not.toBeInTheDocument();
+  });
+
   it('suppresses the stale "Active:" line when a chapter is in the verifying phase', () => {
     const verifying: Chapter = {
       ...chapter1,

--- a/src/views/generation.tsx
+++ b/src/views/generation.tsx
@@ -1301,16 +1301,21 @@ function ChapterRow({
 
   const assembling = chapter.phase === 'assembling';
   const verifying = chapter.phase === 'verifying';
-  const rowStalled = stalled && chapter.state === 'in_progress';
+  /* C2 (Wave 3) — the worker is riding out a mid-render sidecar respawn. Takes
+     precedence over the stall styling: this IS a healthy recovery, not a stall. */
+  const recovering = chapter.phase === 'recovering';
+  const rowStalled = stalled && chapter.state === 'in_progress' && !recovering;
   const inProgressLabel = rowStalled
     ? 'Stalled'
-    : assembling
-      ? 'Assembling…'
-      : verifying
-        ? 'Verifying speech…'
-        : paused
-          ? 'Paused'
-          : 'Generating';
+    : recovering
+      ? 'Recovering…'
+      : assembling
+        ? 'Assembling…'
+        : verifying
+          ? 'Verifying speech…'
+          : paused
+            ? 'Paused'
+            : 'Generating';
   const inProgressPill = rowStalled ? (
     <Pill color="warning">Stalled</Pill>
   ) : (
@@ -1406,7 +1411,14 @@ function ChapterRow({
           <span className="block font-semibold text-ink truncate">
             {stripChapterPrefix(chapter.title)}
           </span>
-          {chapter.state === 'in_progress' && verifying ? (
+          {chapter.state === 'in_progress' && recovering ? (
+            /* C2 (Wave 3) — the sidecar recycled mid-render and the worker is
+               riding out the respawn. Name it explicitly so a healthy recovery
+               doesn't read as a frozen "Synthesising …" line / stall. */
+            <span className="block text-[11px] text-magenta tabular-nums mt-0.5 truncate">
+              Recovering — restarting TTS engine…
+            </span>
+          ) : chapter.state === 'in_progress' && verifying ? (
             /* srv-31 ASR content-QA pass: the synthesis groups are done and
                counters are frozen near 99 %, so show the QA step explicitly
                instead of a stuck "Synthesising …" line. */
@@ -1486,6 +1498,7 @@ function ChapterRow({
             paused={paused}
             assembling={assembling}
             verifying={verifying}
+            recovering={recovering}
           />
         </span>
         <span className="hidden sm:block text-sm tabular-nums text-ink/60 text-right">
@@ -1784,6 +1797,7 @@ function ChapterRow({
           {chapter.state === 'in_progress' &&
             !assembling &&
             !verifying &&
+            !recovering &&
             chapter.currentLine != null &&
             chapter.currentLine > 0 && (
               <div className="mt-4 ml-[60px] flex items-center gap-3 text-xs text-ink/60">
@@ -1933,12 +1947,14 @@ function ChapterProgressBar({
   paused,
   assembling,
   verifying,
+  recovering,
 }: {
   progress: number;
   state: Chapter['state'];
   paused: boolean;
   assembling: boolean;
   verifying: boolean;
+  recovering: boolean;
 }) {
   if (state === 'queued') return <div className="h-1.5 rounded-full bg-ink/6" />;
   if (state === 'done')
@@ -1953,11 +1969,12 @@ function ChapterProgressBar({
         <div className="h-full rounded-full bg-rose-500" style={{ width: `${progress * 100}%` }} />
       </div>
     );
-  if (assembling || verifying)
+  if (assembling || verifying || recovering)
     return (
-      /* Disk-write phase (assembling) or the srv-31 ASR content-QA pass
-         (verifying) — neutral ink-tone bar with stripe motion to read as
-         "near done, busy" rather than the magenta synthesis gradient. */
+      /* Disk-write phase (assembling), the srv-31 ASR content-QA pass
+         (verifying), or a mid-render sidecar respawn ride-out (recovering, C2)
+         — neutral ink-tone bar with stripe motion to read as "near done, busy"
+         rather than the magenta synthesis gradient. */
       <div className="relative h-1.5 rounded-full bg-ink/6 overflow-hidden">
         <div
           className="absolute inset-y-0 left-0 rounded-full bg-ink/40"


### PR DESCRIPTION
## Summary

Wave 3 (the final wave) of generation stall protection — the **recovery** layer from `docs/superpowers/specs/2026-06-08-generation-stall-protection-design.md`. Waves 1 (config safety) + 2 (safe recycles) already merged via #673. This wave makes a mid-render sidecar recycle **recoverable, visible, and bounded**:

- **C1 — resume from completed groups** (`3da94091`): moved the transient-recovery boundary from a whole-chapter re-invoke in `generation.ts` *into* `synthesiseChapter`'s per-group worker loop, via an injected `onRecoverRecycle` hook + a `withRecycleRecovery` passthrough helper + a named `RecycleStormError`. A recycle mid-render now re-attempts only the failed group/batch — every already-rendered group's PCM is preserved (kills the RTF collapse from the incident). No-op passthrough when the hook is absent, so all existing `synthesiseChapter` callers/tests are byte-identical. The old whole-chapter recovery test was relocated to a unit-level resume-preservation proof.
- **C2 — visible "recovering" phase** (`35abcea9`, `0aa8e4f1`): the hook emits a `chapter_recovering` SSE tick + 10s heartbeat during the respawn wait (≤210s), and the Generate view renders a `phase: 'recovering'` ("Recovering — restarting TTS engine…") — so a healthy ride-out never trips the 30s "Worker has gone quiet" banner. Mirrors srv-31's `chapter_verifying` phase (plan 197). The bar holds its position instead of regressing.
- **C3 — bounded recycle storm** (`f122b0cd`, `253beec5`): on recovery-budget exhaustion, `synthesiseChapter` throws `RecycleStormError` → mapped to a named `recycle-storm` failure code + concrete remediation (ordered before `vram-spill` in the taxonomy to beat its "VRAM" substring match) **and pauses the queue** so a thrashing sidecar stops the run instead of grinding for hours. (The per-POST `recordNonFatal` cascade can't escalate on the queue path — one chapter per POST — so the explicit queue-pause is what delivers the spec's "pause the run"; the back-compat `*` job keeps the cascade.)

Built subagent-driven (implementer + spec-compliance review + code-quality review per task). The code-quality review of C3 caught the cascade-never-escalates defect; the queue-pause fix (`253beec5`) is the result.

## Test plan

- `npm run verify` — **full battery green locally** (lint, typecheck, config:check, test:hooks, frontend test, test:server, test:server-slow, test:scripts, test:sidecar, e2e, e2e:visual, build). No CI minutes → local verify is authoritative.
- New/changed tests: 4 C1 unit tests in `synthesise-chapter.test.ts` (resume-preservation, budget→RecycleStormError, non-transient-no-recover, passthrough); rewritten `generation-recycle-recovery.test.ts` (wiring + `chapter_recovering` tick + `errorCode:recycle-storm` + queue `paused` flips true); `failure-taxonomy.test.ts` recycle-storm-beats-vram-spill (both type-driven + raw-message paths); `chapters-slice.test.ts` + `generation.test.tsx` recovering-phase.
- **Live-GPU acceptance still owed** (a real long-book Qwen run that recycles mid-render).

Plan: `docs/superpowers/plans/2026-06-08-generation-stall-protection-wave3.md`. Spec Delivery section updated with the Wave 3 SHAs.

Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)
