### PR TITLE
fix(server): keep tagged speakers the verifier emptied (hex-entity decode + tag-aware prune)

### DIFF
--- a/server/src/parsers/html-utils.test.ts
+++ b/server/src/parsers/html-utils.test.ts
@@ -1,0 +1,50 @@
+/* Unit tests for the shared HTML helpers. The numeric-entity cases pin the
+   root cause of the Coalfall attribution bug (2026-06-09): an EPUB that
+   encodes apostrophes as the HEX numeric reference `&#x27;` left literal
+   `&#x27;` in the parsed source text, so every apostrophe-bearing evidence
+   quote failed the verifier's substring match → the speaker (Master Oduvan)
+   lost all evidence and was pruned from the cast, his lines folding to the
+   narrator. stripHtml decoded only the DECIMAL `&#39;`, never the hex form. */
+
+import { describe, it, expect } from 'vitest';
+import { stripHtml, extractFirstHeading } from './html-utils.js';
+
+describe('stripHtml — numeric character references', () => {
+  it('decodes the hex apostrophe &#x27; (the Coalfall regression)', () => {
+    expect(stripHtml('<p>You&#x27;ll have to make do with the second.</p>')).toBe(
+      "You'll have to make do with the second.",
+    );
+  });
+
+  it('still decodes the decimal apostrophe &#39;', () => {
+    expect(stripHtml('<p>I&#39;m not crying.</p>')).toBe("I'm not crying.");
+  });
+
+  it('decodes hex curly punctuation (&#x2019; &#x201C; &#x201D;)', () => {
+    expect(stripHtml('<p>&#x201C;I&#x2019;ve been nursing it,&#x201D; he said.</p>')).toBe(
+      '“I’ve been nursing it,” he said.',
+    );
+  });
+
+  it('decodes the hex double-quote &#x22; and uppercase hex digits', () => {
+    expect(stripHtml('<p>&#x22;Begin,&#x22; said the dragon &#x2014; tired.</p>')).toBe(
+      '"Begin," said the dragon — tired.',
+    );
+  });
+
+  it('decodes a decimal reference above the named set (&#8217; right quote)', () => {
+    expect(stripHtml('<p>don&#8217;t</p>')).toBe('don’t');
+  });
+
+  it('leaves real text and the existing named entities intact', () => {
+    expect(stripHtml('<p>Smith &amp; Sons &lt;forge&gt; &quot;open&quot;</p>')).toBe(
+      'Smith & Sons <forge> "open"',
+    );
+  });
+});
+
+describe('extractFirstHeading — numeric character references', () => {
+  it('decodes a hex apostrophe in the heading text', () => {
+    expect(extractFirstHeading('<h1>Oduvan&#x27;s Forge</h1>')).toBe("Oduvan's Forge");
+  });
+});

--- a/server/src/parsers/html-utils.ts
+++ b/server/src/parsers/html-utils.ts
@@ -4,21 +4,46 @@
 
 import { tagHtmlEmphasis } from './audio-tags.js';
 
+/* Decode numeric character references — both hex (`&#x27;`) and decimal
+   (`&#39;`). EPUB serializers very commonly emit the HEX apostrophe
+   `&#x27;`; decoding only the named set plus the decimal `&#39;` left the
+   hex form literal in the parsed source text, which silently broke
+   evidence-quote matching: every apostrophe-bearing quote failed the
+   verifier's substring check, so a speaker whose evidence all carried
+   apostrophes lost the cast entirely and his lines folded to the narrator
+   (the Coalfall / Master Oduvan regression, 2026-06-09). Invalid or out-of-
+   range references are left untouched rather than dropped. */
+export function decodeNumericEntities(s: string): string {
+  return s
+    .replace(/&#x([0-9a-fA-F]+);/g, (m, hex) => codePointOr(m, parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (m, dec) => codePointOr(m, parseInt(dec, 10)));
+}
+
+function codePointOr(original: string, codePoint: number): string {
+  if (!Number.isFinite(codePoint) || codePoint < 0 || codePoint > 0x10ffff) return original;
+  try {
+    return String.fromCodePoint(codePoint);
+  } catch {
+    return original;
+  }
+}
+
 /* Strip HTML tags from a chapter body, decode common entities, and convert
    block-level breaks to plain-text newlines. Folds `<em>/<i>/<strong>` into
    `[emphasis]…[/emphasis]` tags via tagHtmlEmphasis before stripping so the
    audio-tag information survives the strip. */
 export function stripHtml(html: string): string {
-  return tagHtmlEmphasis(html)
-    .replace(/<\s*br\s*\/?>/gi, '\n')
-    .replace(/<\/p>/gi, '\n\n')
-    .replace(/<[^>]+>/g, '')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
+  return decodeNumericEntities(
+    tagHtmlEmphasis(html)
+      .replace(/<\s*br\s*\/?>/gi, '\n')
+      .replace(/<\/p>/gi, '\n\n')
+      .replace(/<[^>]+>/g, '')
+      .replace(/&nbsp;/g, ' ')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&amp;/g, '&'),
+  )
     .replace(/[ \t]+\n/g, '\n')
     .replace(/\n{3,}/g, '\n\n')
     .trim();
@@ -33,14 +58,15 @@ const FIRST_HEADING_RE = /<h[1-3][^>]*>([\s\S]{0,400}?)<\/h[1-3]>/i;
 export function extractFirstHeading(html: string): string | null {
   const m = FIRST_HEADING_RE.exec(html);
   if (!m) return null;
-  const raw = m[1]
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
+  const raw = decodeNumericEntities(
+    m[1]
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&nbsp;/g, ' ')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&amp;/g, '&'),
+  )
     .replace(/\s+/g, ' ')
     .trim();
   if (raw.length === 0 || raw.length > 200) return null;

--- a/server/src/routes/analysis.test.ts
+++ b/server/src/routes/analysis.test.ts
@@ -1418,6 +1418,42 @@ describe('dropEvidencelessCast — Phase 0b drop of characters with no verifiabl
     expect(logs[0]).toContain('Dropped 1 character ');
     expect(logs[0]).not.toContain('Dropped 1 characters');
   });
+
+  /* Defense-in-depth (Coalfall / Master Oduvan, 2026-06-09): the verifier can
+     kill every quote of a REAL speaker when the source-vs-quote match is
+     fragile (an encoding quirk, an LLM paraphrase). The roster-coverage guard
+     that exists to never lose a tagged speaker runs during detection — BEFORE
+     this prune — so it can't protect against the prune. Cross-check the prose:
+     an evidenceless character the source still tags as a speaker is kept. */
+  it('keeps an evidenceless character the source tags as a speaker, drops one with no tags', () => {
+    const logs: string[] = [];
+    const source =
+      '"Leave it," said Master Oduvan, without looking up. "Whoever it is can knock." ' +
+      '"If I douse the fire," Oduvan said, "I lose the weld I have been nursing." ' +
+      'The cat watched from the rafters and did not speak.';
+    const chars: CharacterOutput[] = [
+      makeChar('narrator', 'Narrator', []),
+      makeChar('sophie', 'Sophie', [{ quote: 'Real line' }]),
+      makeChar('master-oduvan', 'Master Oduvan', []), // verifier killed all his quotes — but he's tagged
+      makeChar('iggy', 'Iggy', []), // pet — never tagged as a speaker in the prose
+    ];
+
+    const kept = dropEvidencelessCast(chars, (msg) => logs.push(msg), source);
+
+    expect(kept.map((c) => c.id)).toEqual(['narrator', 'sophie', 'master-oduvan']);
+    expect(logs.some((l) => /[Kk]ept 1 .*tag/.test(l))).toBe(true); // rescue logged
+    expect(logs.some((l) => l.includes('Dropped 1 character') && l.includes('Iggy'))).toBe(true);
+  });
+
+  it('drops a tagged-name character when no source text is supplied (back-compat)', () => {
+    /* Without source text there's no tag signal — the prune behaves exactly
+       as before, so the two-arg call sites and tests are unaffected. */
+    const kept = dropEvidencelessCast(
+      [makeChar('narrator', 'Narrator', []), makeChar('oduvan', 'Oduvan', [])],
+      () => {},
+    );
+    expect(kept.map((c) => c.id)).toEqual(['narrator']);
+  });
 });
 
 /* B1 — sticky analysis: in-flight job map + /pause endpoint.

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -32,6 +32,7 @@ import {
 import { AnalyzerTruncatedError } from '../analyzer/errors.js';
 import {
   runStage1WithRosterGuard,
+  validateRosterCoverage,
   chapterDriftExceeded,
   type MissingSpeaker,
 } from '../analyzer/roster-coverage.js';
@@ -350,22 +351,73 @@ export function verifyEvidenceAgainstSource(
    only ever surface speakers with at least one verifiable line. The
    narrator is exempt — the narrator's "lines" are prose, not dialogue,
    and the Stage-1 prompt doesn't ask for verbatim quotes from prose. */
+/** Tokenise a display name the same way the roster-coverage guard does
+    (lowercase, split on whitespace / dots / hyphens, tokens ≥ 2 chars) so a
+    tagged-speaker name ("Oduvan") overlaps a fuller cast name ("Master
+    Oduvan") on a shared token. */
+function nameTokensForDrop(name: string): Set<string> {
+  return new Set(
+    (name || '')
+      .toLowerCase()
+      .split(/[\s.-]+/)
+      .filter((t) => t.length >= 2),
+  );
+}
+
 export function dropEvidencelessCast(
   characters: CharacterOutput[],
   log: (message: string) => void,
+  sourceText = '',
 ): CharacterOutput[] {
+  /* Defense-in-depth — the evidence verifier can kill every quote of a REAL
+     speaker when the source-vs-quote match is fragile (an encoding quirk such
+     as an undecoded `&#x27;`, an LLM paraphrase). The roster-coverage guard
+     that exists to never lose a tagged speaker runs during DETECTION, before
+     this prune, so it can't protect against the prune. Re-derive the prose
+     dialogue-tag signal here (empty roster ⇒ every bounded `<Name> <verb>`
+     speaker) and keep an evidenceless character the source still tags as a
+     speaker. The narrator-less prune purpose — killing INVENTED non-speakers
+     the model hallucinated onto the roster — is preserved: those have no
+     dialogue tags, so they still drop. Only scanned when there's actually an
+     evidenceless non-narrator character to rescue. */
+  const hasEvidenceless = characters.some(
+    (c) => c.id !== 'narrator' && (c.evidence?.length ?? 0) === 0,
+  );
+  const taggedTokens = new Set<string>();
+  if (sourceText && hasEvidenceless) {
+    for (const sp of validateRosterCoverage(sourceText, []).missingSpeakers) {
+      for (const tok of nameTokensForDrop(sp.name)) taggedTokens.add(tok);
+    }
+  }
+
   const kept: CharacterOutput[] = [];
   const droppedNames: string[] = [];
+  const rescuedNames: string[] = [];
   for (const c of characters) {
     if (c.id === 'narrator') {
       kept.push(c);
       continue;
     }
     if ((c.evidence?.length ?? 0) === 0) {
+      const tagged =
+        taggedTokens.size > 0 &&
+        [...nameTokensForDrop(c.name)].some((t) => taggedTokens.has(t));
+      if (tagged) {
+        rescuedNames.push(c.name);
+        kept.push(c);
+        continue;
+      }
       droppedNames.push(c.name);
       continue;
     }
     kept.push(c);
+  }
+  if (rescuedNames.length > 0) {
+    const sample = rescuedNames.slice(0, 4).join(', ');
+    const more = rescuedNames.length > 4 ? `, +${rescuedNames.length - 4} more` : '';
+    log(
+      `Kept ${rescuedNames.length} evidenceless character${rescuedNames.length === 1 ? '' : 's'} the prose still tags as a speaker (${sample}${more}) — verifier killed every quote but the dialogue tags prove they speak.`,
+    );
   }
   if (droppedNames.length > 0) {
     const sample = droppedNames.slice(0, 4).join(', ');
@@ -2158,7 +2210,11 @@ export async function runMainAnalyzerJob(
         log(0, msg),
       );
       const before = stage1.characters.length;
-      stage1.characters = dropEvidencelessCast(stage1.characters, (msg) => log(0, msg));
+      stage1.characters = dropEvidencelessCast(
+        stage1.characters,
+        (msg) => log(0, msg),
+        record.sourceText,
+      );
       if (verified.totalDropped > 0 || stage1.characters.length !== before) {
         /* Shrink guard — when the re-verify on the resume short-circuit
            would drop more than half of a non-trivial cached roster,
@@ -2659,7 +2715,11 @@ export async function runMainAnalyzerJob(
         const verified = verifyEvidenceAgainstSource(rawCharacters, record.sourceText, (msg) =>
           log(0, msg),
         );
-        const characters = dropEvidencelessCast(rawCharacters, (msg) => log(0, msg));
+        const characters = dropEvidencelessCast(
+          rawCharacters,
+          (msg) => log(0, msg),
+          record.sourceText,
+        );
         /* Plan 126 Facet A — establish cross-book reuse links server-side.
            Match each new character against prior same-series confirmed cast
            and stamp `matchedFrom` + a unified `voiceId` + `voiceState:'reused'`
@@ -4008,7 +4068,11 @@ async function runSubsetAnalyzerJob(
     const verified = verifyEvidenceAgainstSource(rawCharacters, record.sourceText, (msg) =>
       log(0, msg),
     );
-    const characters = dropEvidencelessCast(rawCharacters, (msg) => log(0, msg));
+    const characters = dropEvidencelessCast(
+      rawCharacters,
+      (msg) => log(0, msg),
+      record.sourceText,
+    );
     const stage1: Stage1Output = {
       characters,
       chapters: record.chapterHints.map((c) => ({ id: c.id, title: c.title })),

--- a/server/src/util/text-match.test.ts
+++ b/server/src/util/text-match.test.ts
@@ -97,6 +97,39 @@ describe('matchQuoteInSource — three-tier verifier', () => {
   it('returns null for empty normalised input', () => {
     expect(matchQuoteInSource('', source)).toBeNull();
   });
+
+  it('matches a quote stitched across an INTERRUPTING mid-sentence dialogue tag', () => {
+    /* Coalfall regression (2026-06-09): source interrupts a single
+       sentence with the tag — `"If I douse the fire," Oduvan said, "I
+       lose the weld..."`. The model returns the two halves joined by the
+       comma the tag replaced. There is only ONE sentence-final period, so
+       the sentence-split `segments` tier yields a single fragment and
+       cannot fire; the clause split (on the interrupting comma) rescues
+       it. Both halves are genuine contiguous runs in the source. */
+    const interrupted = normaliseForMatch(
+      '"If I douse the fire," Oduvan said, "I lose the weld I have been nursing since noon."',
+    );
+    expect(
+      matchQuoteInSource(
+        normaliseForMatch('If I douse the fire, I lose the weld I have been nursing since noon.'),
+        interrupted,
+      ),
+    ).toBe('segments');
+  });
+
+  it('does NOT clause-rescue when an interrupting-stitch half is fabricated', () => {
+    /* Guard the looser clause split: the first half is real, the second is
+       invented and never appears in the source, so the quote stays dropped. */
+    const interrupted = normaliseForMatch(
+      '"If I douse the fire," Oduvan said, "I lose the weld I have been nursing since noon."',
+    );
+    expect(
+      matchQuoteInSource(
+        normaliseForMatch('If I douse the fire, I will summon the town guard at once.'),
+        interrupted,
+      ),
+    ).toBeNull();
+  });
 });
 
 describe('matchQuoteInSource — KOTLC ledger regression', () => {

--- a/server/src/util/text-match.ts
+++ b/server/src/util/text-match.ts
@@ -36,6 +36,23 @@ export function splitSentenceSegments(s: string, minLen = 8): string[] {
     .filter((seg) => seg.length >= minLen);
 }
 
+/** Split on CLAUSE punctuation — comma / semicolon / colon as well as
+    sentence-final `.!?` — followed by whitespace. Used as a looser fallback
+    for the "interrupting dialogue tag" stitch: source writes
+    `"If I douse the fire," Oduvan said, "I lose the weld..."` and the model
+    returns the two halves rejoined by the comma the tag replaced, all within
+    a SINGLE sentence — so splitSentenceSegments yields one fragment and can't
+    fire. `minLen` is higher (default 12) than the sentence splitter because
+    comma-delimited clauses are shorter and more common, so the floor guards
+    against two unrelated short fragments coincidentally co-occurring. */
+export function splitClauseSegments(s: string, minLen = 12): string[] {
+  return s
+    .split(/[,;:.!?]+\s+/)
+    .map(stripTerminalSentencePunct)
+    .map((seg) => seg.trim())
+    .filter((seg) => seg.length >= minLen);
+}
+
 export type QuoteMatchTier = 'verbatim' | 'terminal_punct' | 'segments';
 
 /** Three-tier substring match for evidence quotes against an already-
@@ -66,6 +83,15 @@ export function matchQuoteInSource(norm: string, normalisedSource: string): Quot
 
   const segments = splitSentenceSegments(norm);
   if (segments.length >= 2 && segments.every((seg) => normalisedSource.includes(seg))) {
+    return 'segments';
+  }
+
+  /* Interrupting-tag fallback — split on clause punctuation so a stitch that
+     happened MID-sentence (the dialogue tag interrupted one sentence rather
+     than sitting between two) can still verify when every clause is a real
+     contiguous run in the source. */
+  const clauses = splitClauseSegments(norm);
+  if (clauses.length >= 2 && clauses.every((seg) => normalisedSource.includes(seg))) {
     return 'segments';
   }
 


### PR DESCRIPTION
## Summary

End-to-end fix for the "a detected speaker silently vanishes from the cast and his lines fold to the narrator" bug (Master Oduvan / *The Coalfall Commission*).

**Root cause:** the EPUB encodes apostrophes as the **hex** entity `&#x27;`. `stripHtml` decoded only named entities plus the **decimal** `&#39;`, so literal `&#x27;` survived into `record.sourceText`. Every apostrophe-bearing evidence quote then failed `verifyEvidenceAgainstSource`'s substring match → a speaker whose evidence all carried apostrophes (Oduvan) lost every quote, was pruned by `dropEvidencelessCast`, and Stage-2 (constrained to roster ids) dumped all 14 of his lines on the narrator. Proven by reproducing the exact `dropped-quotes.json` pattern from the clean epub, and confirmed against the full chapter-1 attribution (every roster member's split quote/tag pairs attribute correctly; only the non-rostered Oduvan folds to narrator).

Three changes, two of them independent layers of protection:

1. **Parser (root cause)** — shared `decodeNumericEntities` (hex + decimal, invalid refs left intact); `stripHtml` + `extractFirstHeading` route through it. Fixes EPUB and MOBI.
2. **Quote matcher (hardening)** — `splitClauseSegments` fallback in `matchQuoteInSource` for dialogue stitched across an *interrupting* mid-sentence tag (`"If I douse the fire," Oduvan said, "I lose the weld…"`), guarded so a fabricated half still drops.
3. **Prune (defense-in-depth)** — the roster-coverage guard runs during detection, *before* the evidence prune, so it can't protect against the prune. `dropEvidencelessCast` now re-derives the `<Name> <verb>` tag signal and keeps an evidenceless character the prose still tags as a speaker; invented non-speakers (no tags) still drop. `sourceText` is a new optional arg — two-arg callers unchanged.

## Test plan

- TDD (RED→GREEN) for all three: new `html-utils.test.ts` (numeric-entity decode), `text-match.test.ts` (interrupting-tag stitch + fabricated-half guard), `analysis.test.ts` (`dropEvidencelessCast` rescue + back-compat).
- End-to-end on the real Coalfall data: all three previously-dropped quotes now match (2 verbatim once apostrophes decode, 1 via clause fallback); and with all evidence stripped, the tag-aware prune still rescues Oduvan while an untagged invented character drops.
- Full `npm run verify` green on pre-push (typecheck + all tests `2395 server` + e2e + build).

Note: the on-disk Coalfall book still lacks Oduvan until re-analyzed — both fixes are forward-looking.