### PR TITLE
fix(app): replace ML Kit scanner with zxing to fix Android 16 QR crash

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -84,7 +84,7 @@ and pins the CA itself — **no OS root-cert install is needed on the phone**
 
 The discipline throughout: a **pure, unit-tested brain over injectable IO**, with
 native plugins (just_audio / audio_service / drift / connectivity / secure
-storage / mobile_scanner) at the thin, device-tested edge.
+storage / flutter_zxing) at the thin, device-tested edge.
 
 ## CI
 

--- a/apps/android/android/gradle.properties
+++ b/apps/android/android/gradle.properties
@@ -4,15 +4,3 @@ android.useAndroidX=true
 android.newDsl=false
 # This builtInKotlin flag was added by the Flutter template
 android.builtInKotlin=false
-# mobile_scanner: use the UNBUNDLED (Google Play Services) ML Kit barcode model
-# rather than the bundled one. The bundled model (com.google.mlkit:barcode-scanning
-# 17.3.0) deterministically NPEs inside ML Kit's own process() pipeline on start
-# ("Attempt to invoke virtual method '…' on a null object reference") on Android
-# 16 / API 36 — reproduced on a Pixel 10 Pro emulator AND on a real device. The
-# unbundled variant pulls a newer ML Kit (18.3.1) via Play Services, which avoids
-# that path on real devices with provisioned Play Services. (The emulator can't
-# fairly validate it — its GMS ML Kit module reports "no usable artifacts" — so
-# the scan path is verified on a real phone; qr_scan_screen.dart degrades to a
-# "enter details manually" fallback if start() still fails.) Costs ~600 KB + a
-# one-time model download on first scan.
-dev.steenbakker.mobile_scanner.useUnbundled=true

--- a/apps/android/lib/src/ui/qr_scan_screen.dart
+++ b/apps/android/lib/src/ui/qr_scan_screen.dart
@@ -1,18 +1,17 @@
 import 'package:flutter/material.dart';
-import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:flutter_zxing/flutter_zxing.dart';
 
 import '../domain/paired_server.dart';
 
 /// Scans the server pairing QR and pops with the parsed [PairedServer]
 /// (app-2). Non-matching codes are ignored so the camera keeps scanning.
 ///
-/// We drive an explicit [MobileScannerController] (rather than letting the
-/// widget create an implicit one) so we can (a) restrict ML Kit to QR codes —
-/// smaller init surface — and (b) own its lifecycle for disposal. The custom
-/// [MobileScanner.errorBuilder] replaces the plugin's raw default ("An
-/// unexpected error occurred." + a native exception string) with a friendly
-/// message that points the user back to manual entry — so a camera / ML Kit
-/// failure never strands them on a black screen with an obfuscated stack trace.
+/// Uses `flutter_zxing` (zxing-cpp via FFI) rather than ML Kit: mobile_scanner
+/// 7.2.0's ML Kit barcode scanner NPEs inside `process()` on start on Android
+/// 16 / API 36 (reproduced on a Pixel 10 Pro emulator + a real device). zxing
+/// has no ML Kit / Play Services dependency. `ReaderWidget` is a self-contained
+/// camera scanner with a built-in gallery import — so the user can also pick a
+/// screenshot of the QR if the live camera is awkward.
 class QrScanScreen extends StatefulWidget {
   const QrScanScreen({super.key});
 
@@ -21,27 +20,18 @@ class QrScanScreen extends StatefulWidget {
 }
 
 class _QrScanScreenState extends State<QrScanScreen> {
-  final MobileScannerController _controller = MobileScannerController(
-    formats: const [BarcodeFormat.qrCode],
-  );
   bool _handled = false;
 
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  void _onDetect(BarcodeCapture capture) {
-    if (_handled || capture.barcodes.isEmpty) return;
-    final raw = capture.barcodes.first.rawValue;
+  void _onScan(Code code) {
+    if (_handled || !mounted) return;
+    final raw = code.text;
     if (raw == null || raw.isEmpty) return;
     try {
       final server = PairedServer.fromQrPayload(raw);
       _handled = true;
       Navigator.of(context).pop(server);
     } on FormatException {
-      // Not a pairing QR — keep scanning.
+      // A QR, but not a pairing payload — keep scanning.
     }
   }
 
@@ -49,51 +39,16 @@ class _QrScanScreenState extends State<QrScanScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Scan pairing code')),
-      body: MobileScanner(
-        controller: _controller,
-        onDetect: _onDetect,
-        errorBuilder: (context, error) => _ScannerError(error: error),
-      ),
-    );
-  }
-}
-
-/// Friendly replacement for mobile_scanner's default error widget. Tells the
-/// user the camera couldn't start and to use manual entry instead, with a
-/// button that returns to the pairing form.
-class _ScannerError extends StatelessWidget {
-  const _ScannerError({required this.error});
-
-  final MobileScannerException error;
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Icon(Icons.no_photography_outlined, size: 48),
-            const SizedBox(height: 16),
-            const Text(
-              "Couldn't start the camera",
-              textAlign: TextAlign.center,
-              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 8),
-            const Text(
-              'Go back and enter the server URL, access token and CA '
-              'fingerprint from the desktop pairing screen manually.',
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 20),
-            FilledButton(
-              key: const Key('scan-error-back'),
-              onPressed: () => Navigator.of(context).maybePop(),
-              child: const Text('Enter details manually'),
-            ),
-          ],
+      body: ReaderWidget(
+        onScan: _onScan,
+        codeFormat: Format.qrCode,
+        tryInverted: true,
+        showToggleCamera: false,
+        // Lets the user decode a saved screenshot of the QR as a fallback.
+        showGallery: true,
+        loading: const DecoratedBox(
+          decoration: BoxDecoration(color: Colors.black),
+          child: Center(child: CircularProgressIndicator()),
         ),
       ),
     );

--- a/apps/android/pubspec.lock
+++ b/apps/android/pubspec.lock
@@ -129,6 +129,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.12.6"
+  camera:
+    dependency: transitive
+    description:
+      name: camera
+      sha256: "034c38cb8014d29698dcae6d20276688a1bf74e6487dfeb274d70ea05d5f7777"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.12.0+1"
+  camera_android_camerax:
+    dependency: transitive
+    description:
+      name: camera_android_camerax
+      sha256: e20c1e92ce6797d9ae9b1db1e09a4c1039a04827d0b24985f5da3840b96948ac
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2+1"
+  camera_avfoundation:
+    dependency: transitive
+    description:
+      name: camera_avfoundation
+      sha256: "90e4cc3fde331581a3b2d35d83be41dbb7393af0ab857eb27b732174289cb96d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.1"
+  camera_platform_interface:
+    dependency: transitive
+    description:
+      name: camera_platform_interface
+      sha256: "7ac852d77699acee79f0d438b793feee26721841e50973576419ff5c6d95e9b7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.13.0"
+  camera_web:
+    dependency: transitive
+    description:
+      name: camera_web
+      sha256: "57f49a635c8bf249d07fb95eb693d7e4dda6796dedb3777f9127fb54847beba7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+3"
   characters:
     dependency: transitive
     description:
@@ -209,6 +249,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+2"
   crypto:
     dependency: "direct main"
     description:
@@ -297,6 +345,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "2567f398e06ac72dcf2e98a0c95df2a9edd03c2c2e0cacd4780f20cdf56263a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.5"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: "35e0bd61ebcdb91a3505813b055b09b79dfdc7d0aee9c09a7ba59ae4bb13dc85"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "62197474ae75893a62df75939c777763d39c2bc5f73ce5b88497208bc269abfd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+5"
   fixnum:
     dependency: transitive
     description:
@@ -334,6 +414,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.35"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -392,6 +480,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_zxing:
+    dependency: "direct main"
+    description:
+      name: flutter_zxing
+      sha256: "6bf0cb0fde122455e73ae78214457c106fbde3c633af4624ce29567ac590ef21"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   glob:
     dependency: transitive
     description:
@@ -448,6 +544,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.9.1"
+  image_picker:
+    dependency: transitive
+    description:
+      name: image_picker
+      sha256: "91c025426c2881c551100bce834e201c835a170151545f58d17da5180ca7d9ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: "6f3a1995eafb000333174fae92202622033b0ee7fd917a6cd3730295264df84a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+19"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "66257a3191ab360d23a55c8241c91a6e329d31e94efa7be9cf7a212e65850214"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: b9c4a438a9ff4f60808c9cf0039b93a42bb6c2211ef6ebb647394b2b3fa84588
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+6"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "1f81c5f2046b9ab724f85523e4af65be1d47b038160a8c8deed909762c308ed4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "86f0f15a309de7e1a552c12df9ce5b59fe927e71385329355aec4776c6a8ec91"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2+1"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "567e056716333a1647c64bb6bd873cff7622233a5c3f694be28a583d4715690c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: d248c86554a72b5495a31c56f060cf73a41c7ff541689327b1a7dbccc33adfae
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   io:
     dependency: transitive
     description:
@@ -584,14 +744,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  mobile_scanner:
-    dependency: "direct main"
-    description:
-      name: mobile_scanner
-      sha256: c92c26bf2231695b6d3477c8dcf435f51e28f87b1745966b1fe4c47a286171ce
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.2.0"
   native_toolchain_c:
     dependency: transitive
     description:

--- a/apps/android/pubspec.yaml
+++ b/apps/android/pubspec.yaml
@@ -44,8 +44,12 @@ dependencies:
   # 10.x ships 16 KB-page-aligned native libs (datastore_shared_counter).
   flutter_secure_storage: ^10.3.1
 
-  # app-2 — scan the server pairing QR. 7.x bundles 16 KB-aligned ML Kit.
-  mobile_scanner: ^7.2.0
+  # app-2 — scan the server pairing QR via flutter_zxing (zxing-cpp through FFI),
+  # NOT ML Kit. mobile_scanner 7.2.0's ML Kit barcode scanner NPEs inside
+  # process() on start on Android 16 / API 36 — reproduced on a Pixel 10 Pro
+  # emulator AND a real device, both bundled & unbundled ML Kit variants, with
+  # camera permission granted. zxing has no ML Kit / Play Services dependency.
+  flutter_zxing: ^2.3.0
   path_provider: ^2.1.5
   flutter_foreground_task: ^9.2.2
   drift: ^2.33.0

--- a/docs/features/188-android-companion-app.md
+++ b/docs/features/188-android-companion-app.md
@@ -74,21 +74,23 @@ a copyable manual-entry list, and explains how to enable LAN HTTPS when the payl
 incomplete (not https / no token / no CA). Tests: `pair-device.test.tsx` (11) +
 `companion-app-banner.test.tsx` (pair-button→modal) + an e2e in `download-tiles.spec.ts`.
 
-**Scanner crash on Android 16 (mobile_scanner 7.2.0).** `Scan QR` showed the plugin's raw
-default error — `NullPointerException: Attempt to invoke virtual method '…' on a null object
-reference` — a black screen with an obfuscated trace. Diagnosed via `adb logcat`: the NPE is
-inside **ML Kit's own `process()` pipeline** on `controller.start()`, reproduced on a Pixel 10
-Pro **API-36** emulator *and* a real device (identical obfuscation → the emulator is a faithful
-oracle). It is **independent of the bundled vs unbundled ML Kit variant**. mobile_scanner 7.2.0
-is the latest, and downgrading is blocked by the Android-15/16 **16 KB page-alignment**
-requirement (7.x is the variant with 16 KB-aligned native libs). Mitigations landed
-(`qr_scan_screen.dart`): an explicit QR-only `MobileScannerController` + a friendly
-`errorBuilder` that degrades to **"Couldn't start the camera → Enter details manually"**
-(no more black-screen gibberish), and switched to the **unbundled** ML Kit (18.3.1 via Play
-Services) as the camera-scan fix candidate — the emulator can't fairly validate it (its GMS ML
-Kit reports "no usable artifacts"). **Owed:** real-phone validation of the actual scan path;
-manual entry is the guaranteed pairing path meanwhile. Upstream-issue / version-bump tracking
-is the next step if the unbundled variant doesn't resolve it on a real device.
+**Scanner crash on Android 16 → replaced ML Kit with zxing (`flutter_zxing`).** `Scan QR`
+crashed with `NullPointerException: Attempt to invoke virtual method '…' on a null object
+reference`. Diagnosed via `adb logcat`: the NPE is **inside Google ML Kit's own `process()`
+pipeline** (every stack frame is obfuscated Google code — mobile_scanner's own Kotlin would show
+un-obfuscated `dev.steenbakker.*` and never appears), reproduced on a Pixel 10 Pro **API-36**
+emulator *and* a real device. Ruled out: camera permission (granted; `GrantPermissionsActivity`
+fires), native-load / 16 KB alignment (no `dlopen`/`UnsatisfiedLink` — the lib loads), and the
+ML Kit variant (bundled 17.3.0 **and** unbundled 18.3.1 fail identically). Root cause: ML Kit
+barcode is incompatible with this Android-16 runtime, and it's closed/obfuscated — unfixable from
+our layer. **Fix: dropped mobile_scanner entirely and swapped to `flutter_zxing` (zxing-cpp via
+FFI — no ML Kit, no Play Services).** `qr_scan_screen.dart` now uses `ReaderWidget`
+(`Format.qrCode`) with a built-in gallery-import fallback. Built with NDK r27 (16 KB-aligned
+`.so` by default). **Verified end-to-end on the Android-16 emulator** (the same box that
+faithfully reproduced the NPE): (1) the live camera preview opens with **zero NPE / native-load
+error**, and (2) decoding the real pairing QR via gallery-import lands back on the pairing form
+with all three fields auto-populated — exercising the same `onScan → PairedServer.fromQrPayload`
+path the live camera uses. 193 app Dart tests green.
 
 ### Dev setup (this box — full toolchain installed + validated)
 


### PR DESCRIPTION
## Summary

The companion's **Scan QR** crashed with a `NullPointerException` inside Google **ML Kit's own barcode `process()`** on **Android 16 / API 36** — reproduced on a Pixel 10 Pro API-36 emulator **and** a real device. Ruled out camera permission (granted), native-load / 16 KB alignment (lib loads fine), and ML Kit variant (bundled 17.3.0 **and** unbundled 18.3.1 fail identically). ML Kit barcode is incompatible with this Android-16 runtime and is closed-source — unfixable from our layer.

**Fix:** drop `mobile_scanner`; scan via **`flutter_zxing`** (zxing-cpp via FFI — no ML Kit, no Play Services). `qr_scan_screen.dart` uses `ReaderWidget(Format.qrCode)` with a built-in **gallery-import** fallback. Built with NDK r27 (16 KB-aligned `.so`).

## Test plan (verified on the Android-16 emulator that reproduced the NPE)

1. Live camera preview opens with **zero NPE / native-load error** (logcat: `Opened CameraId`, CameraX streams active).
2. Decoding the real pairing QR via gallery-import returns to the pairing form with **all three fields auto-populated** — same `onScan → PairedServer.fromQrPayload` path the live camera uses.
3. `flutter test` — **193 app Dart tests green**.

Follows up the merged web pairing-QR work (#679). Plan: docs/features/188-android-companion-app.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)