### PR TITLE
fix(server): heal stale cross-series reuse links on re-analysis

### DIFF
--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -82,7 +82,7 @@ import {
 } from '../tts/design-lock.js';
 import { scanSeriesCharactersForBookId } from '../workspace/series-cast-scan.js';
 import { dedupSeriesPrior } from '../workspace/series-prior-dedup.js';
-import { linkSeriesReuseAtAnalysis } from '../workspace/series-reuse-link.js';
+import { linkSeriesReuseAtAnalysis, pruneStaleReuseLinks } from '../workspace/series-reuse-link.js';
 import {
   normaliseForMatch as normaliseForMatchShared,
   matchQuoteInSource,
@@ -2736,6 +2736,10 @@ export async function runMainAnalyzerJob(
                without this it would re-link a pair the user separated and
                re-stamp links already established (srv-13). */
             seedReuseGuardsFromPriorCast(priorCastForMerge, characters);
+            const staleDropped = await pruneStaleReuseLinks(recordRef.bookId, characters);
+            if (staleDropped > 0) {
+              log(0, `Cleared ${staleDropped} stale reuse link${staleDropped === 1 ? '' : 's'} pointing at a book no longer in this series.`);
+            }
             const linked = await linkSeriesReuseAtAnalysis(recordRef.bookId, characters);
             if (linked > 0) {
               log(0, `Linked ${linked} recurring character${linked === 1 ? '' : 's'} to prior books in this series (Reused).`);
@@ -4283,6 +4287,13 @@ async function runSubsetAnalyzerJob(
     if (record.bookId) {
       try {
         seedReuseGuardsFromPriorCast(priorCastForMerge, enriched);
+        const staleDropped = await pruneStaleReuseLinks(record.bookId, enriched);
+        if (staleDropped > 0) {
+          log(
+            0,
+            `Cleared ${staleDropped} stale reuse link${staleDropped === 1 ? '' : 's'} pointing at a book no longer in this series.`,
+          );
+        }
         const linked = await linkSeriesReuseAtAnalysis(record.bookId, enriched);
         if (linked > 0) {
           log(

--- a/server/src/workspace/series-reuse-link.test.ts
+++ b/server/src/workspace/series-reuse-link.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   linkSeriesReuseAtAnalysis,
+  pruneStaleReuseLinks,
   type LinkableCharacter,
   type LinkSeriesReuseOptions,
 } from './series-reuse-link.js';
@@ -269,5 +270,113 @@ describe('linkSeriesReuseAtAnalysis (plan 126 Facet A)', () => {
     const linked = await linkSeriesReuseAtAnalysis(BOOK2, fresh, baseOptions());
     expect(linked).toBe(0);
     expect(fresh[0].matchedFrom).toBeUndefined();
+  });
+});
+
+/* pruneStaleReuseLinks — a preserved matchedFrom (carried across re-analysis by
+   seedReuseGuardsFromPriorCast) whose target is no longer a same-author /
+   same-series EARLIER book is stale. It happens when a book is re-homed to
+   another series or made standalone after the link was stamped (the Coalfall /
+   narrator regression, 2026-06-09): the narrator stayed linked to a
+   Shannon-Messenger book after the book moved to Castwright/Standalones, and
+   neither re-analysis (preserves links by design) nor the UI unmatch (rejects
+   non-series-mates) could clear it. */
+describe('pruneStaleReuseLinks', () => {
+  const COALFALL = 'castwright__standalones__coalfall';
+  const BONUS = 'shannon__keeper__bonus';
+  const KEEPER1 = 'shannon__keeper__book1';
+  const KEEPER2 = 'shannon__keeper__book2';
+  const META: Record<string, { author: string; series: string } | null> = {
+    [COALFALL]: { author: 'Castwright', series: 'Standalones' },
+    [BONUS]: { author: 'Shannon Messenger', series: 'Keeper' },
+    [KEEPER1]: { author: 'Shannon Messenger', series: 'Keeper' },
+    [KEEPER2]: { author: 'Shannon Messenger', series: 'Keeper' },
+  };
+  const opts = (): LinkSeriesReuseOptions => ({
+    resolveAuthorSeries: async (id) => META[id] ?? null,
+    positions: async () =>
+      new Map<string, number | null>([
+        [BONUS, 1],
+        [KEEPER1, 1],
+        [KEEPER2, 2],
+        [COALFALL, null],
+      ]),
+  });
+
+  it('drops a cross-series stale link and reverts a pure-reuse voice to fresh', async () => {
+    const chars: LinkableCharacter[] = [
+      {
+        id: 'narrator',
+        name: 'Narrator',
+        voiceId: 'narrator',
+        voiceState: 'reused',
+        ttsEngine: 'qwen',
+        overrideTtsVoices: { qwen: { name: 'qwen-narrator' } },
+        voiceStyle: 'British female',
+        matchedFrom: { bookId: BONUS, characterId: 'narrator', bookTitle: 'Bonus', confidence: 0.92 },
+      },
+    ];
+    const dropped = await pruneStaleReuseLinks(COALFALL, chars, opts());
+    expect(dropped).toBe(1);
+    const n = chars[0];
+    expect(n.matchedFrom).toBeFalsy();
+    expect(n.voiceState).toBe('generated');
+    expect(n.voiceId).toBe('narrator');
+    expect(n.overrideTtsVoices).toBeFalsy();
+    expect(n.voiceStyle).toBeFalsy();
+  });
+
+  it('keeps a valid same-series earlier-book link', async () => {
+    const chars: LinkableCharacter[] = [
+      {
+        id: 'sophie',
+        name: 'Sophie',
+        voiceState: 'reused',
+        matchedFrom: { bookId: KEEPER1, characterId: 'sophie', bookTitle: 'Book One', confidence: 1 },
+      },
+    ];
+    const dropped = await pruneStaleReuseLinks(KEEPER2, chars, opts());
+    expect(dropped).toBe(0);
+    expect(chars[0].matchedFrom?.bookId).toBe(KEEPER1);
+    expect(chars[0].voiceState).toBe('reused');
+  });
+
+  it('drops a forward/sideways same-series link (target not strictly earlier)', async () => {
+    /* book-1 wrongly linked to book-2 (later) — the linker only makes
+       earlier-only links, so a preserved forward link is stale. */
+    const chars: LinkableCharacter[] = [
+      {
+        id: 'sophie',
+        name: 'Sophie',
+        voiceState: 'reused',
+        matchedFrom: { bookId: KEEPER2, characterId: 'sophie', bookTitle: 'Book Two', confidence: 1 },
+      },
+    ];
+    const dropped = await pruneStaleReuseLinks(KEEPER1, chars, opts());
+    expect(dropped).toBe(1);
+    expect(chars[0].matchedFrom).toBeFalsy();
+  });
+
+  it('drops the stale badge but preserves a user-tuned voice', async () => {
+    const chars: LinkableCharacter[] = [
+      {
+        id: 'narrator',
+        name: 'Narrator',
+        voiceState: 'tuned',
+        overrideTtsVoices: { qwen: { name: 'my-custom-voice' } },
+        matchedFrom: { bookId: BONUS, characterId: 'narrator', bookTitle: 'Bonus', confidence: 0.9 },
+      },
+    ];
+    const dropped = await pruneStaleReuseLinks(COALFALL, chars, opts());
+    expect(dropped).toBe(1);
+    expect(chars[0].matchedFrom).toBeFalsy();
+    /* User's own voice is untouched — only the stale link badge is removed. */
+    expect(chars[0].voiceState).toBe('tuned');
+    expect(chars[0].overrideTtsVoices?.qwen?.name).toBe('my-custom-voice');
+  });
+
+  it('is a no-op when there are no links to check', async () => {
+    const chars: LinkableCharacter[] = [{ id: 'oduvan', name: 'Oduvan', voiceState: 'generated' }];
+    expect(await pruneStaleReuseLinks(COALFALL, chars, opts())).toBe(0);
   });
 });

--- a/server/src/workspace/series-reuse-link.ts
+++ b/server/src/workspace/series-reuse-link.ts
@@ -62,6 +62,7 @@ export interface LinkableCharacter {
     bookTitle?: string;
     confidence?: number;
   } | null;
+  matchFactors?: unknown[];
   notLinkedTo?: { bookId: string; characterId: string }[];
 }
 
@@ -147,6 +148,67 @@ export interface LinkSeriesReuseOptions {
   ) => Promise<{ author: string; series: string } | null>;
   positions?: () => Promise<Map<string, number | null>>;
   castLoader?: CastLoader;
+}
+
+/* Revert a stale-linked character. A pure reuse row's voice was denormalised
+   FROM the now-stale link, so it reverts to a fresh, unlinked voice; a user-
+   owned voice (tuned/locked) keeps its voice and only loses the dead badge. */
+function clearStaleLink(c: LinkableCharacter): void {
+  delete c.matchedFrom;
+  delete c.matchFactors;
+  if (c.voiceState === 'reused') {
+    c.voiceId = c.id;
+    c.voiceState = 'generated';
+    delete c.overrideTtsVoices;
+    delete c.voiceStyle;
+    delete c.ttsEngine;
+  }
+}
+
+/* Drop a `matchedFrom` whose target is no longer a valid reuse source — i.e.
+   not a same-author + same-series, strictly-EARLIER book (exactly what
+   linkSeriesReuseAtAnalysis links against). This heals links that go stale when
+   a book is re-homed to another series or made standalone after the link was
+   stamped: seedReuseGuardsFromPriorCast preserves the old link across re-
+   analysis, and the UI unmatch refuses non-series-mates, so without this the
+   dead link is unclearable. Conservative: a same-series link with an unknown
+   position on either side is LEFT intact (a flaky scan must not nuke a
+   legitimate link), and the whole pass no-ops when the current book can't be
+   resolved. Mutates in place; returns the count dropped. Run BEFORE the link
+   pass so a series book can then re-link to its correct earlier sibling. */
+export async function pruneStaleReuseLinks(
+  bookId: string,
+  characters: LinkableCharacter[],
+  options: LinkSeriesReuseOptions = {},
+): Promise<number> {
+  if (!bookId || characters.length === 0) return 0;
+  const linked = characters.filter((c) => c.matchedFrom?.bookId);
+  if (linked.length === 0) return 0;
+
+  const resolveAuthorSeries = options.resolveAuthorSeries ?? findAuthorSeriesForBookId;
+  const meta = await resolveAuthorSeries(bookId);
+  if (!meta) return 0; // can't resolve the current book — don't guess
+
+  const positions = await (options.positions ?? seriesPositionByBookId)();
+  const myPos = positions.get(bookId) ?? null;
+
+  let dropped = 0;
+  for (const c of linked) {
+    const targetBookId = c.matchedFrom!.bookId!;
+    const targetMeta = await resolveAuthorSeries(targetBookId);
+    const sameSeries =
+      !!targetMeta && targetMeta.author === meta.author && targetMeta.series === meta.series;
+    /* Earlier-only guard mirrors the linker: a same-series link is valid only
+       when the target is a strictly-lower position. Unknown positions can't
+       prove "earlier", so they're treated as acceptable (conservative keep). */
+    const targetPos = positions.get(targetBookId) ?? null;
+    const earlierOk = myPos === null || targetPos === null || targetPos < myPos;
+    if (sameSeries && earlierOk) continue;
+
+    clearStaleLink(c);
+    dropped++;
+  }
+  return dropped;
 }
 
 /* Mutate `characters` in place, stamping reuse links against prior same-series


### PR DESCRIPTION
## Summary

Follow-up to the Coalfall attribution fixes. After Oduvan was restored, the **narrator** showed up matched/reused to an unrelated *Bonus Keefe Story* (Shannon Messenger) narrator — dragging in its British `qwen-narrator` voice — even though this is a standalone Castwright book.

**Root cause:** the link was legitimate when stamped (the book's folder originated as a copy of a Keeper book, so it resolved as a Keeper series-mate), then went **stale** when the book was re-homed to `Castwright/Standalones`. `seedReuseGuardsFromPriorCast` preserves reuse links across re-analysis (srv-13), and the UI "not the same person" unmatch **refuses non-series-mate / standalone pairs** (cast-not-linked-to.ts:71-80) — so the dead link was unclearable by any normal flow.

**Fix:** add `pruneStaleReuseLinks`, run before the link pass at both analysis call sites. It drops any `matchedFrom` whose target is not a same-author + same-series, **strictly-earlier** book (exactly what `linkSeriesReuseAtAnalysis` links against). A pure-reuse row reverts to a fresh `generated` voice; a user-tuned/locked voice is preserved (only the dead badge is removed). Conservative: no-ops when the current book can't be resolved, and keeps a same-series link whose position is unknown.

## Test plan

- TDD (RED→GREEN): 5 new cases in `series-reuse-link.test.ts` — cross-series drop + voice revert, valid same-series keep, forward/sideways drop, tuned-voice preserved, no-op when nothing linked.
- `npm run typecheck` clean; full server suite green (2,400 passed) on the pre-commit gate.
- The affected standalone book's narrator was also repaired on disk (link cleared, voice reset to generated).

Note: pushed with `--no-verify` (owner-authorized) — the pre-push e2e gate fails on a **pre-existing zero-flaky policy** tripping on unrelated frontend admin/advanced-settings/analysing-multi-model specs (8 flaky / 0 hard failures); this change is server-only and can't affect them.