### PR TITLE
fix(app): decode pairing QR full-frame at 1080p with tryHarder

### DIFF
--- a/apps/android/lib/src/ui/qr_scan_screen.dart
+++ b/apps/android/lib/src/ui/qr_scan_screen.dart
@@ -42,7 +42,19 @@ class _QrScanScreenState extends State<QrScanScreen> {
       body: ReaderWidget(
         onScan: _onScan,
         codeFormat: Format.qrCode,
+        // Decode robustness for real-world capture (a phone pointed at the QR on
+        // a desktop screen). The ReaderWidget defaults are tuned for big, clean
+        // codes filling the frame: tryHarder is OFF, only the centre 50% is
+        // decoded (cropPercent 0.5), and the camera caps at 720p. The pairing QR
+        // is dense ({url, token, caFingerprint}), so those defaults left it
+        // unreadable while the native camera app decoded the same code off the
+        // same screen. Match that: search the WHOLE frame at 1080p with the
+        // thorough binarizer/locator. tryRotate stays on (its default).
+        tryHarder: true,
         tryInverted: true,
+        resolution: ResolutionPreset.veryHigh,
+        cropPercent: 1.0,
+        showScannerOverlay: false,
         showToggleCamera: false,
         // Lets the user decode a saved screenshot of the QR as a fallback.
         showGallery: true,

--- a/apps/android/test/ui/qr_scan_screen_test.dart
+++ b/apps/android/test/ui/qr_scan_screen_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_zxing/flutter_zxing.dart';
+
+import 'package:castwright/src/ui/qr_scan_screen.dart';
+
+/// Regression guard for the pairing-QR scanner decode config.
+///
+/// The scanner shipped with flutter_zxing's `ReaderWidget` defaults (tryHarder
+/// OFF, centre-50% crop, 720p), which left the dense pairing QR unreadable on a
+/// real phone even though the native camera app decoded the same code off the
+/// same screen. These assertions pin the robustness knobs so a refactor can't
+/// silently fall back to the weak defaults.
+void main() {
+  testWidgets('configures ReaderWidget for robust real-world QR decode', (tester) async {
+    // ReaderWidget's camera init runs through platform channels that no-op in a
+    // widget test; it swallows the failure and stays in the tree, so a single
+    // pump is enough to read its configuration without settling camera futures.
+    await tester.pumpWidget(const MaterialApp(home: QrScanScreen()));
+    await tester.pump();
+
+    final reader = tester.widget<ReaderWidget>(find.byType(ReaderWidget));
+
+    expect(reader.codeFormat, Format.qrCode);
+    expect(reader.tryHarder, isTrue,
+        reason: 'tryHarder is the single biggest decode lever for camera capture');
+    expect(reader.cropPercent, 1.0,
+        reason: 'decode the whole frame, not a centre crop, so the QR resolves anywhere in view');
+    expect(reader.resolution, ResolutionPreset.veryHigh,
+        reason: 'the dense pairing QR needs more than 720p to resolve its modules');
+    expect(reader.tryInverted, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

The companion app's pairing-QR scanner loaded the camera but never decoded — on a real phone the live camera and gallery-imported photos both failed, even though the **native camera app read the same QR off the same screen**. So the QR is fine; our decoder config was the weak link.

The zxing `ReaderWidget` (added in `0c113c5e`) ran on its stock defaults, which assume a large, clean code filling the frame:
- `tryHarder` **off** — the single biggest decode lever for real-world capture
- only the **centre 50%** of the frame decoded (`cropPercent: 0.5`)
- camera capped at **720p** (`ResolutionPreset.high`)

The pairing QR is dense (`{url, token, caFingerprint}` JSON), so those defaults left it unresolvable. The previous commit only verified gallery-import of a *clean* PNG, which masked this.

**Fix** (`qr_scan_screen.dart`): match what a competent decoder does — search the **whole frame** (`cropPercent: 1.0`) at **1080p** (`ResolutionPreset.veryHigh`) with the thorough binarizer/locator (`tryHarder: true`). `tryRotate`/`tryInverted` kept on; scanner overlay disabled since there's no crop box to aim at any more. The gallery-import path inherits `tryHarder` too, so photo decode improves as well.

QR generation (`pair-device.tsx`) is deliberately untouched — the native-camera test proves the QR itself is fine.

## Test plan

- New regression test `apps/android/test/ui/qr_scan_screen_test.dart` pins the four robustness knobs (`tryHarder`, `cropPercent`, `resolution`, `tryInverted`) so a refactor can't silently fall back to the weak defaults.
- `flutter test` — **194 app tests green**.
- `npm run verify` — full battery (lint, typecheck, all tests, e2e, build) green in an isolated worktree.
- On-device decode confirmation pending (only a real phone can exercise the camera path); release APK built with the fix.

Refs #188 (companion app); follow-up to `0c113c5e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)