### PR TITLE
fix(sidecar,server,frontend): voice-design contention robustness (VRAM exclusion + liveness timeout + honest progress)

### DIFF
--- a/docs/superpowers/plans/2026-06-09-voice-design-contention-robustness.md
+++ b/docs/superpowers/plans/2026-06-09-voice-design-contention-robustness.md
@@ -1,0 +1,859 @@
+# Voice-Design Contention Robustness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop a voice design from spilling VRAM / falsely showing "Halted" / freezing its progress bar when it coincides with chapter generation on the 8 GB GPU.
+
+**Architecture:** Three independent parts, each on its own test harness, all on branch `fix/voice-design-contention-robustness`. **C (root, sidecar/Python):** a VoiceDesign forward and a Kokoro synth become mutually exclusive, and a design evicts a resident Kokoro before loading the 1.7 B model — so the three-way (generation + VoiceDesign + Kokoro) >8 GB spill can't happen. **B (server/TypeScript):** the design's 180 s wall-clock abort becomes liveness-aware — it only gives up when the sidecar's `/health` is unreachable, bounded by a 10 min ceiling. **A (frontend/React):** the design progress indicator shows a ticking elapsed clock, flips to an indeterminate shimmer past the fast window, and swaps "about 15s" for an honest "GPU may be busy" message — so it never looks frozen.
+
+**Tech Stack:** Python (FastAPI sidecar, pytest), Node/Express + TypeScript (Vitest), React 18 + TypeScript (Vitest + RTL, Playwright).
+
+**Spec:** `docs/superpowers/specs/2026-06-09-voice-design-contention-robustness-design.md`
+
+**Note on independence:** C, B, and A do not depend on each other and can be implemented/committed in any order (or in parallel by separate agents). C is the highest-value (root cause). Each part is independently shippable and testable.
+
+---
+
+## Part C — VoiceDesign ↔ Kokoro mutual exclusion (sidecar)
+
+**Why:** A model stays resident in VRAM after releasing its GPU-semaphore token. Qwen Base + active generation ≈ 3.5 GB; + VoiceDesign ≈ 6 GB (fits); + **Kokoro resident during generation** → >8 GB → spill → recycle. Kokoro runs on onnxruntime-gpu (a separate allocator from torch), so its ~1 GB is invisible to torch metrics but real on the card. Fix: never let a VoiceDesign forward and a Kokoro synth overlap, and evict a resident Kokoro for the duration of a design.
+
+### Task C1: Add the VoiceDesign↔Kokoro arbiter primitive
+
+**Files:**
+- Modify: `server/tts-sidecar/main.py` (add a module-level arbiter class + singleton, near the other module-level engine globals)
+- Test: `server/tts-sidecar/tests/test_design_kokoro_exclusion.py` (create)
+
+- [ ] **Step 1: Write the failing test for the arbiter's exclusion contract**
+
+Create `server/tts-sidecar/tests/test_design_kokoro_exclusion.py`:
+
+```python
+"""Unit tests for the VoiceDesign<->Kokoro arbiter (resident-VRAM exclusion).
+
+The arbiter guarantees a VoiceDesign forward and Kokoro synths never overlap,
+while letting Kokoro synths run concurrently with each other when no design is
+active. See docs/.../2026-06-09-voice-design-contention-robustness-design.md.
+"""
+import threading
+import time
+
+from main import _VdKokoroArbiter
+
+
+def test_design_waits_for_in_flight_kokoro_to_drain():
+    arb = _VdKokoroArbiter()
+    order = []
+    started = threading.Event()
+
+    def kokoro():
+        with arb.kokoro_synth():
+            started.set()
+            time.sleep(0.05)
+            order.append("kokoro-done")
+
+    def design():
+        started.wait()
+        with arb.design():
+            order.append("design-start")
+
+    t1 = threading.Thread(target=kokoro)
+    t2 = threading.Thread(target=design)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    # The design must not start until the in-flight Kokoro synth finished.
+    assert order == ["kokoro-done", "design-start"]
+
+
+def test_kokoro_blocks_while_design_active():
+    arb = _VdKokoroArbiter()
+    order = []
+    design_holding = threading.Event()
+    release_design = threading.Event()
+
+    def design():
+        with arb.design():
+            design_holding.set()
+            release_design.wait(timeout=1)
+            order.append("design-done")
+
+    def kokoro():
+        design_holding.wait()
+        with arb.kokoro_synth():
+            order.append("kokoro-start")
+
+    t1 = threading.Thread(target=design)
+    t2 = threading.Thread(target=kokoro)
+    t1.start()
+    t2.start()
+    time.sleep(0.05)  # give kokoro a chance to (wrongly) proceed if unguarded
+    release_design.set()
+    t1.join()
+    t2.join()
+
+    # Kokoro must not start until the design released.
+    assert order == ["design-done", "kokoro-start"]
+
+
+def test_two_kokoro_synths_run_concurrently_when_no_design():
+    arb = _VdKokoroArbiter()
+    both_in = threading.Barrier(2, timeout=1)
+
+    def kokoro():
+        with arb.kokoro_synth():
+            both_in.wait()  # raises BrokenBarrierError if they can't co-exist
+
+    t1 = threading.Thread(target=kokoro)
+    t2 = threading.Thread(target=kokoro)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+    # No assertion needed — the barrier proves concurrency (no timeout/raise).
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `server\tts-sidecar\.venv\Scripts\python.exe -m pytest server/tts-sidecar/tests/test_design_kokoro_exclusion.py -v`
+Expected: FAIL — `ImportError: cannot import name '_VdKokoroArbiter' from 'main'`.
+
+- [ ] **Step 3: Implement the arbiter**
+
+In `server/tts-sidecar/main.py`, add near the top-level imports if missing:
+
+```python
+from contextlib import contextmanager
+```
+
+Add the arbiter class + singleton at module scope, BEFORE the `kokoro = KokoroEngine()` / `qwen = QwenEngine()` singletons are constructed (so both engines can reference `_VD_KOKORO`):
+
+```python
+class _VdKokoroArbiter:
+    """Mutual exclusion between a VoiceDesign forward and Kokoro synths.
+
+    Kokoro runs on onnxruntime-gpu (a separate allocator from torch), so a
+    resident Kokoro + Qwen Base + the 1.7B VoiceDesign model oversubscribe an
+    8 GB card and spill. This arbiter guarantees the two heaviest-combined ops
+    never co-reside: a design waits for in-flight Kokoro synths to drain, then
+    blocks new ones until it finishes. Kokoro synths still run concurrently with
+    EACH OTHER (writer-priority readers/writer), so normal generation is
+    unaffected when no design is running. Qwen Base generation never touches this
+    arbiter, so a Qwen-voiced chapter generates at full speed alongside a design.
+    """
+
+    def __init__(self) -> None:
+        self._cv = threading.Condition()
+        self._kokoro_in_flight = 0
+        self._design_active = False
+
+    @contextmanager
+    def kokoro_synth(self):
+        with self._cv:
+            while self._design_active:
+                self._cv.wait()
+            self._kokoro_in_flight += 1
+        try:
+            yield
+        finally:
+            with self._cv:
+                self._kokoro_in_flight -= 1
+                self._cv.notify_all()
+
+    @contextmanager
+    def design(self):
+        with self._cv:
+            while self._kokoro_in_flight > 0:
+                self._cv.wait()
+            self._design_active = True
+        try:
+            yield
+        finally:
+            with self._cv:
+                self._design_active = False
+                self._cv.notify_all()
+
+
+_VD_KOKORO = _VdKokoroArbiter()
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `server\tts-sidecar\.venv\Scripts\python.exe -m pytest server/tts-sidecar/tests/test_design_kokoro_exclusion.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_design_kokoro_exclusion.py
+git commit -m "feat(sidecar): add VoiceDesign<->Kokoro VRAM exclusion arbiter"
+```
+
+### Task C2: Guard the Kokoro synth path with the arbiter
+
+**Files:**
+- Modify: `server/tts-sidecar/main.py` — `KokoroEngine.synthesize` (currently ~line 782)
+- Test: `server/tts-sidecar/tests/test_design_kokoro_exclusion.py` (extend)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `server/tts-sidecar/tests/test_design_kokoro_exclusion.py`:
+
+```python
+def test_kokoro_synthesize_acquires_the_arbiter(monkeypatch):
+    """KokoroEngine.synthesize must run its load+create under the arbiter so a
+    concurrent design can't start mid-synth."""
+    import main
+
+    eng = main.KokoroEngine()
+    seen = {"in_flight_during_create": None}
+
+    # Stub the heavy model so the test never loads real weights.
+    class _FakeModel:
+        def create(self, text, voice, speed, lang):
+            # Snapshot the arbiter's in-flight counter DURING create().
+            seen["in_flight_during_create"] = main._VD_KOKORO._kokoro_in_flight
+            import numpy as np
+            return np.zeros(10, dtype="float32"), 24000
+
+    eng._kokoro = _FakeModel()
+    eng._voices = ["af_heart"]
+    monkeypatch.setattr(eng, "_ensure_loaded", lambda model: None)
+
+    eng.synthesize("kokoro", "af_heart", "hello")
+    # If synthesize wrapped create() in arb.kokoro_synth(), the counter was 1.
+    assert seen["in_flight_during_create"] == 1
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `server\tts-sidecar\.venv\Scripts\python.exe -m pytest server/tts-sidecar/tests/test_design_kokoro_exclusion.py::test_kokoro_synthesize_acquires_the_arbiter -v`
+Expected: FAIL — `assert None == 1` (create ran outside the arbiter).
+
+- [ ] **Step 3: Wrap the Kokoro synth body in the arbiter**
+
+In `KokoroEngine.synthesize`, wrap the load + create in `with _VD_KOKORO.kokoro_synth():`. The method currently starts:
+
+```python
+    def synthesize(self, model: str, voice: str, text: str) -> SynthResult:
+        self._ensure_loaded(model)
+        assert self._kokoro is not None
+```
+
+Change it so everything from `_ensure_loaded` through the `self._kokoro.create(...)` call runs inside the arbiter. Minimal-diff approach — wrap the existing body:
+
+```python
+    def synthesize(self, model: str, voice: str, text: str) -> SynthResult:
+        # Resident-VRAM exclusion: never let this Kokoro forward overlap a
+        # VoiceDesign forward (the three-way spill). Acquired around load+create
+        # so a design can't evict Kokoro out from under an in-flight synth.
+        with _VD_KOKORO.kokoro_synth():
+            self._ensure_loaded(model)
+            assert self._kokoro is not None
+            # ... existing body unchanged (voice validation, create(), wrap) ...
+```
+
+Re-indent the remainder of the existing method body one level deeper under the `with`. Do NOT change any logic inside.
+
+- [ ] **Step 4: Run the focused + full exclusion test file**
+
+Run: `server\tts-sidecar\.venv\Scripts\python.exe -m pytest server/tts-sidecar/tests/test_design_kokoro_exclusion.py -v`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Run the existing Kokoro test to confirm no regression**
+
+Run: `server\tts-sidecar\.venv\Scripts\python.exe -m pytest server/tts-sidecar/tests/test_kokoro.py -v`
+Expected: PASS (unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_design_kokoro_exclusion.py
+git commit -m "feat(sidecar): run Kokoro synth under the VoiceDesign exclusion arbiter"
+```
+
+### Task C3: Hold the arbiter + evict Kokoro during a VoiceDesign forward
+
+**Files:**
+- Modify: `server/tts-sidecar/main.py` — `QwenEngine.design_voice` (currently ~line 1276)
+- Test: `server/tts-sidecar/tests/test_design_kokoro_exclusion.py` (extend)
+
+- [ ] **Step 1: Write the failing test for design-time eviction + exclusion**
+
+Append to `server/tts-sidecar/tests/test_design_kokoro_exclusion.py`:
+
+```python
+def test_design_voice_holds_arbiter_and_evicts_resident_kokoro(monkeypatch):
+    """design_voice must take arb.design() around its VoiceDesign forward and,
+    if Kokoro is resident, unload it first so the 1.7B load has headroom."""
+    import main
+
+    qeng = main.QwenEngine()
+
+    # Pretend Kokoro is resident (e.g. a mixed-cast generation loaded it).
+    main.kokoro._kokoro = object()
+    unloaded = {"called": False}
+    monkeypatch.setattr(main.kokoro, "unload",
+                        lambda: unloaded.__setitem__("called", True))
+
+    # Capture arbiter state at the moment the VoiceDesign forward runs.
+    captured = {"design_active": None, "kokoro_resident": None}
+
+    class _FakeDesign:
+        def generate_voice_design(self, text, language, instruct):
+            captured["design_active"] = main._VD_KOKORO._design_active
+            captured["kokoro_resident"] = main.kokoro._kokoro is not None
+            import numpy as np
+            return [np.zeros(10, dtype="float32")], 24000
+
+    class _FakeBase:
+        def create_voice_clone_prompt(self, ref_audio, ref_text):
+            return {"prompt": True}
+
+        def generate_voice_clone(self, text, language, voice_clone_prompt):
+            import numpy as np
+            return [np.zeros(10, dtype="float32")], 24000
+
+    qeng._design = _FakeDesign()
+    qeng._base = _FakeBase()
+    monkeypatch.setattr(qeng, "_ensure_design_loaded", lambda: None)
+    monkeypatch.setattr(qeng, "_ensure_base_loaded", lambda: None)
+    monkeypatch.setattr(main.torch, "save", lambda *a, **k: None, raising=False)
+
+    import tempfile
+    qeng._voices_dir = tempfile.mkdtemp()
+
+    qeng.design_voice("qwen-narrator-preview", "A warm voice.", "english", "Hello there.")
+
+    assert unloaded["called"] is True, "resident Kokoro must be evicted before the design"
+    assert captured["design_active"] is True, "design forward must run under arb.design()"
+    assert captured["kokoro_resident"] is False, "Kokoro must be unloaded during the design forward"
+```
+
+NOTE: if `import main.torch` indirection differs (torch is imported lazily inside `design_voice`), adjust the `torch.save` monkeypatch to patch `torch.save` on the module torch object the function imports. The function does `import torch` then `torch.save(...)`; patch via `monkeypatch.setattr("torch.save", lambda *a, **k: None)`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `server\tts-sidecar\.venv\Scripts\python.exe -m pytest server/tts-sidecar/tests/test_design_kokoro_exclusion.py::test_design_voice_holds_arbiter_and_evicts_resident_kokoro -v`
+Expected: FAIL — `unloaded["called"] is False` / `design_active is None`.
+
+- [ ] **Step 3: Wrap the VoiceDesign forward in `arb.design()` + evict Kokoro**
+
+In `QwenEngine.design_voice`, the in-flight guard + ensure + `_synth_lock` forward currently looks like (around line 1306):
+
+```python
+        self._design_last_used = time.monotonic()
+        self._design_in_flight += 1
+        try:
+            self._ensure_design_loaded()
+            self._ensure_base_loaded()
+            with self._synth_lock:
+                self._ensure_design_loaded()
+                self._ensure_base_loaded()
+                ref_wavs, ref_sr = self._design.generate_voice_design(
+                    text=ref_text, language=lang, instruct=instruct
+                )
+                ref_audio = ref_wavs[0]
+                prompt = self._base.create_voice_clone_prompt(
+                    ref_audio=(ref_audio, ref_sr), ref_text=ref_text
+                )
+```
+
+Wrap the `_ensure_design_loaded()` + the `_synth_lock` reference forward in `with _VD_KOKORO.design():`, and evict a resident Kokoro at the top of that block. Replace the block above with:
+
+```python
+        self._design_last_used = time.monotonic()
+        self._design_in_flight += 1
+        try:
+            # Resident-VRAM exclusion (root fix): a VoiceDesign forward and a
+            # Kokoro synth must not co-reside on the 8 GB card. Take the arbiter
+            # (waits for any in-flight Kokoro synth to drain, blocks new ones),
+            # then evict a resident Kokoro so the 1.7B load has headroom. Kokoro
+            # reloads on the next synth (~1s); when no generation ran it isn't
+            # resident, so this is a no-op.
+            with _VD_KOKORO.design():
+                if kokoro._kokoro is not None:
+                    log.info("Evicting resident Kokoro to free VRAM for VoiceDesign load.")
+                    kokoro.unload()
+                self._ensure_design_loaded()
+                self._ensure_base_loaded()
+                with self._synth_lock:
+                    self._ensure_design_loaded()
+                    self._ensure_base_loaded()
+                    ref_wavs, ref_sr = self._design.generate_voice_design(
+                        text=ref_text, language=lang, instruct=instruct
+                    )
+                    ref_audio = ref_wavs[0]
+                    prompt = self._base.create_voice_clone_prompt(
+                        ref_audio=(ref_audio, ref_sr), ref_text=ref_text
+                    )
+```
+
+The rest of `design_voice` (disk cache write, audition synth, `finally: self._design_in_flight -= 1`) stays exactly as-is, OUTSIDE the `with _VD_KOKORO.design():` block — the audition runs on Base only and needs no Kokoro exclusion. `kokoro` is the module-level singleton; reference it directly (no `global` needed for read).
+
+- [ ] **Step 4: Run the full exclusion test file**
+
+Run: `server\tts-sidecar\.venv\Scripts\python.exe -m pytest server/tts-sidecar/tests/test_design_kokoro_exclusion.py -v`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Run the broader sidecar suite to confirm no regression**
+
+Run: `npm run test:sidecar`
+Expected: PASS (or SKIP banner if venv unbootstrapped — but here the venv exists, so PASS).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_design_kokoro_exclusion.py
+git commit -m "fix(sidecar): evict Kokoro + exclude Kokoro synth during VoiceDesign forward
+
+Prevents the three-way (generation + VoiceDesign + Kokoro) >8GB VRAM
+oversubscription that spilled to system RAM and tripped the crash-recycle."
+```
+
+---
+
+## Part B — Liveness-aware design timeout (server)
+
+**Why:** `DESIGN_TIMEOUT_MS = 180_000` is a blind wall-clock abort. Under the (now-fixed-by-C, but still defensible) slow case it killed a design that the sidecar was still actively running, surfacing a false "Halted." Make it abort only when `/health` is genuinely unreachable, bounded by a 10 min ceiling.
+
+### Task B1: Replace the fixed abort with a liveness watchdog
+
+**Files:**
+- Modify: `server/src/routes/qwen-voice.ts` (constant ~line 70; the design fetch block ~lines 203–282)
+- Test: `server/src/routes/qwen-voice.test.ts` (add cases)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `server/src/routes/qwen-voice.test.ts` (follow the file's existing import/mocking style; these assert the new exported helper's behaviour). First, the implementation will export a pure helper `evaluateDesignLiveness` so it's unit-testable without a real sidecar:
+
+```typescript
+import { evaluateDesignLiveness } from './qwen-voice.js';
+
+describe('evaluateDesignLiveness', () => {
+  const T0 = 1_000_000;
+  it('continues while the sidecar is reachable and under the ceiling', () => {
+    const r = evaluateDesignLiveness({
+      startedAt: T0,
+      now: T0 + 200_000, // past the 180s first-check
+      health: 'reachable',
+      absoluteMaxMs: 600_000,
+    });
+    expect(r).toEqual({ action: 'continue' });
+  });
+
+  it('aborts as unreachable when the sidecar /health is down', () => {
+    const r = evaluateDesignLiveness({
+      startedAt: T0,
+      now: T0 + 200_000,
+      health: 'unreachable',
+      absoluteMaxMs: 600_000,
+    });
+    expect(r).toEqual({ action: 'abort', reason: 'unreachable' });
+  });
+
+  it('aborts on the absolute ceiling even if the sidecar still pings', () => {
+    const r = evaluateDesignLiveness({
+      startedAt: T0,
+      now: T0 + 600_001,
+      health: 'reachable',
+      absoluteMaxMs: 600_000,
+    });
+    expect(r).toEqual({ action: 'abort', reason: 'absolute' });
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd server && npx vitest run src/routes/qwen-voice.test.ts -t evaluateDesignLiveness`
+Expected: FAIL — `evaluateDesignLiveness` is not exported.
+
+- [ ] **Step 3: Implement the helper + wire the watchdog**
+
+In `server/src/routes/qwen-voice.ts`, replace the single constant and add the ceiling + helper near line 70:
+
+```typescript
+/* The base liveness-check interval. A design that exceeds this AND whose sidecar
+   /health is still reachable is slow-but-alive — keep waiting (it's almost
+   always a contended GPU). Only an unreachable sidecar or the absolute ceiling
+   aborts. (Was a blind wall-clock abort that surfaced a false "Halted" while the
+   sidecar was happily still designing.) */
+const DESIGN_LIVENESS_INTERVAL_MS = 180_000;
+/* Hard ceiling so a genuinely hung-but-pingable sidecar still fails eventually. */
+const DESIGN_ABSOLUTE_MAX_MS = 600_000;
+
+export type DesignLivenessResult =
+  | { action: 'continue' }
+  | { action: 'abort'; reason: 'unreachable' | 'absolute' };
+
+/** Pure decision for the design liveness watchdog — easy to unit-test. */
+export function evaluateDesignLiveness(p: {
+  startedAt: number;
+  now: number;
+  health: 'reachable' | 'unreachable';
+  absoluteMaxMs: number;
+}): DesignLivenessResult {
+  if (p.now - p.startedAt >= p.absoluteMaxMs) return { action: 'abort', reason: 'absolute' };
+  if (p.health === 'unreachable') return { action: 'abort', reason: 'unreachable' };
+  return { action: 'continue' };
+}
+```
+
+Add the import for the health probe at the top of the file (alongside the other imports):
+
+```typescript
+import { probeSidecarHealth } from './sidecar-health.js';
+```
+
+In `designQwenVoiceForCharacter`, replace the fixed timer (line 208) and the AbortError branch (lines 230–234). Replace:
+
+```typescript
+    const timer = setTimeout(() => controller.abort(), DESIGN_TIMEOUT_MS);
+```
+
+with the watchdog:
+
+```typescript
+    const startedAt = Date.now();
+    let abortReason: 'unreachable' | 'absolute' | null = null;
+    const livenessTimer = setInterval(() => {
+      void (async () => {
+        const health = (await probeSidecarHealth()).status; // 'reachable' | 'unreachable'
+        const decision = evaluateDesignLiveness({
+          startedAt,
+          now: Date.now(),
+          health,
+          absoluteMaxMs: DESIGN_ABSOLUTE_MAX_MS,
+        });
+        if (decision.action === 'abort') {
+          abortReason = decision.reason;
+          controller.abort();
+        } else {
+          console.warn(
+            `[qwen-voice] design slow (${Math.round((Date.now() - startedAt) / 1000)}s) ` +
+              `— sidecar /health reachable, extending (ceiling ${DESIGN_ABSOLUTE_MAX_MS / 1000}s).`,
+          );
+        }
+      })();
+    }, DESIGN_LIVENESS_INTERVAL_MS);
+```
+
+Replace the AbortError branch (currently lines 228–238) to distinguish the cause:
+
+```typescript
+      } catch (e) {
+        const err = e as { name?: string; message?: string };
+        if (err.name === 'AbortError') {
+          if (p.signal?.aborted) {
+            throw new Error('Voice design was cancelled.');
+          }
+          if (abortReason === 'unreachable') {
+            throw new Error(
+              `TTS sidecar (${sidecarUrl}) stopped responding to /health during voice design — the process may have crashed or been recycled.`,
+            );
+          }
+          throw new Error(
+            `Sidecar /qwen/design-voice did not complete within ${DESIGN_ABSOLUTE_MAX_MS}ms — voice design is unusually slow or the process is stuck.`,
+          );
+        }
+        throw new Error(
+          `TTS sidecar (${sidecarUrl}) is unreachable — ${err.message || 'request failed'}.`,
+        );
+      }
+```
+
+Update the `finally` block (line 277–281) to clear the interval instead of the old timer:
+
+```typescript
+    } finally {
+      clearInterval(livenessTimer);
+      if (p.signal) p.signal.removeEventListener('abort', onExternalAbort);
+      releaseGpu();
+    }
+```
+
+Remove the now-unused `DESIGN_TIMEOUT_MS` constant (line 70) if nothing else references it — grep first:
+
+Run: `cd server && grep -rn DESIGN_TIMEOUT_MS src/`
+If only its own declaration remains, delete that line. If other references exist, leave it and reconcile.
+
+- [ ] **Step 4: Run the unit tests to verify they pass**
+
+Run: `cd server && npx vitest run src/routes/qwen-voice.test.ts -t evaluateDesignLiveness`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Run the full qwen-voice test file + typecheck**
+
+Run: `cd server && npx vitest run src/routes/qwen-voice.test.ts` then `npm run typecheck`
+Expected: PASS for both (no type errors from the new import / signature).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/routes/qwen-voice.ts server/src/routes/qwen-voice.test.ts
+git commit -m "fix(server): make voice-design timeout liveness-aware (no false Halted)
+
+A slow-but-alive design (sidecar /health reachable) now extends instead of
+aborting at 180s; only an unreachable sidecar or a 10min ceiling aborts."
+```
+
+---
+
+## Part A — Honest design progress indicator (frontend)
+
+**Why:** `design-progress.tsx` eases the fill to ~92 % in ~15 s, holds, and hard-codes "about 15s" — so a multi-minute design looks frozen at 92 %. Add a ticking elapsed clock, flip to an indeterminate shimmer past the fast window, and swap the copy for an honest "GPU may be busy" message.
+
+### Task A1: Rework DesignProgress with elapsed clock + indeterminate + honest copy
+
+**Files:**
+- Modify: `src/components/design-progress.tsx`
+- Modify: `src/components/design-progress.test.tsx`
+- Modify (styles): `src/styles.css` (add an `.design-fill--indeterminate` shimmer rule)
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace `src/components/design-progress.test.tsx` with:
+
+```tsx
+import { render, screen, act } from '@testing-library/react';
+import { DesignProgress } from './design-progress';
+
+describe('DesignProgress', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('shows the designing phase label', () => {
+    render(<DesignProgress phase="designing" />);
+    expect(screen.getByText(/designing the voice/i)).toBeInTheDocument();
+  });
+
+  it('shows a ticking elapsed clock so it never looks frozen', () => {
+    render(<DesignProgress phase="designing" />);
+    expect(screen.getByTestId('design-elapsed')).toHaveTextContent('0:00');
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(screen.getByTestId('design-elapsed')).toHaveTextContent('0:03');
+  });
+
+  it('shows the optimistic ETA inside the fast window', () => {
+    render(<DesignProgress phase="designing" />);
+    expect(screen.getByTestId('design-eta')).toHaveTextContent(/about 15s/i);
+  });
+
+  it('switches to the honest "GPU busy" copy past the fast window', () => {
+    render(<DesignProgress phase="designing" />);
+    act(() => {
+      vi.advanceTimersByTime(21000); // past the 20s fast window
+    });
+    expect(screen.getByTestId('design-eta')).toHaveTextContent(/taking longer than usual/i);
+  });
+
+  it('flips the fill to indeterminate past the fast window', () => {
+    const { container } = render(<DesignProgress phase="designing" />);
+    expect(container.querySelector('.design-fill--indeterminate')).toBeNull();
+    act(() => {
+      vi.advanceTimersByTime(21000);
+    });
+    expect(container.querySelector('.design-fill--indeterminate')).toBeTruthy();
+  });
+
+  it('renders the waveform + fill scaffold', () => {
+    const { container } = render(<DesignProgress phase="designing" />);
+    expect(container.querySelector('[data-testid="design-waveform"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="design-fill"]')).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/components/design-progress.test.tsx`
+Expected: FAIL — no `design-elapsed` / `design-eta` testids; no indeterminate class.
+
+- [ ] **Step 3: Implement the reworked component**
+
+Replace `src/components/design-progress.tsx` with:
+
+```tsx
+import { useEffect, useState, type CSSProperties } from 'react';
+
+const PHASE_LABELS: Record<'designing' | 'rendering', string> = {
+  designing: 'Designing the voice…',
+  rendering: 'Rendering the 12s audition…',
+};
+
+/** Number of waveform bars. Static count; staggered animation delays come from
+    the nth-child rules in styles.css (.design-wave i). */
+const BARS = 12;
+
+/** Past this many ms the design is "slow" — the optimistic eased fill + "about
+    15s" ETA would start lying, so we flip to an honest indeterminate shimmer and
+    a "GPU may be busy" message. Designs normally land in ~15s; a slow one is
+    almost always a contended GPU. */
+const SLOW_AFTER_MS = 20_000;
+
+interface Props {
+  phase: 'designing' | 'rendering';
+  /** When the design is done, pass true so the fill snaps to 100%. */
+  complete?: boolean;
+}
+
+function formatElapsed(ms: number): string {
+  const total = Math.floor(ms / 1000);
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+export function DesignProgress({ phase, complete = false }: Props) {
+  /* Tick once a second so the elapsed clock advances — proof of life even when
+     the eased fill is near-full. Mount time ≈ design start (the component
+     mounts when the design begins). */
+  const [elapsedMs, setElapsedMs] = useState(0);
+  useEffect(() => {
+    if (complete) return;
+    const startedAt = Date.now();
+    const id = setInterval(() => setElapsedMs(Date.now() - startedAt), 1000);
+    return () => clearInterval(id);
+  }, [complete]);
+
+  const slow = !complete && elapsedMs >= SLOW_AFTER_MS;
+
+  /* Soft ETA: CSS eases the fill to ~92% over ~15s and holds (styles.css
+     .design-fill i). On completion we override to a full, transition-backed
+     width so it snaps shut honestly. Past the slow threshold we ADD the
+     indeterminate modifier so the bar reads "still working, no ETA" rather than
+     "stuck at 92%". */
+  const fillStyle: CSSProperties | undefined = complete
+    ? { width: '100%', animation: 'none', transition: 'width 300ms ease-out' }
+    : undefined;
+  const fillClass = `design-fill mt-2${slow ? ' design-fill--indeterminate' : ''}`;
+
+  return (
+    <div className="mt-3 rounded-2xl bg-canvas border border-ink/10 p-4">
+      <div className="design-wave" data-testid="design-waveform" aria-hidden="true">
+        {Array.from({ length: BARS }, (_, i) => (
+          <i key={i} />
+        ))}
+      </div>
+      <div className={fillClass} data-testid="design-fill">
+        <i style={fillStyle} />
+      </div>
+      <div className="mt-2 flex items-center justify-between">
+        <span className="text-[11px] font-semibold text-purple-deep/70">{PHASE_LABELS[phase]}</span>
+        <span className="text-[11px] text-ink/40 tabular-nums" data-testid="design-elapsed">
+          {formatElapsed(elapsedMs)}
+        </span>
+      </div>
+      <div className="mt-1 text-[11px] text-ink/40" data-testid="design-eta">
+        {slow ? 'Taking longer than usual — the GPU may be busy with another job.' : 'about 15s'}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Add the indeterminate shimmer style**
+
+In `src/styles.css`, find the existing `.design-fill` block and add below it:
+
+```css
+/* Slow-design state: once a design passes the fast window the eased fill would
+   sit frozen near 92% and read as "stuck". Overlay a continuously-moving
+   indeterminate shimmer so it reads "still working, no ETA". */
+.design-fill--indeterminate i {
+  animation: design-indeterminate 1.2s ease-in-out infinite;
+  width: 40%;
+}
+@keyframes design-indeterminate {
+  0% { margin-left: -42%; }
+  100% { margin-left: 100%; }
+}
+```
+
+(If `.design-fill i` uses `transform`/`width` transitions that fight this, scope the override with `.design-fill--indeterminate i { transition: none; }` as the first line of the rule.)
+
+- [ ] **Step 5: Run the component tests to verify they pass**
+
+Run: `npx vitest run src/components/design-progress.test.tsx`
+Expected: PASS (6 passed).
+
+- [ ] **Step 6: Run the consumer's tests to confirm no regression**
+
+Run: `npx vitest run src/components/voice-engine-picker.test.tsx src/modals/profile-drawer.test.tsx`
+Expected: PASS (DesignProgress still renders its phase label as before).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/design-progress.tsx src/components/design-progress.test.tsx src/styles.css
+git commit -m "fix(frontend): honest design progress (elapsed clock + indeterminate + GPU-busy copy)"
+```
+
+### Task A2: E2E — the design indicator never looks frozen on a slow design
+
+**Files:**
+- Create: `e2e/voice-design-progress.spec.ts`
+
+- [ ] **Step 1: Write the e2e spec**
+
+Create `e2e/voice-design-progress.spec.ts`. Follow the existing e2e harness conventions (mock-mode app on port 5174; see a sibling spec under `e2e/` for the `test.beforeEach` navigation + how a single design is triggered in mock mode). The spec must:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+// Drives the profile drawer's single-voice design in mock mode and asserts the
+// progress indicator stays honest on a slow design: the elapsed clock advances
+// and the copy switches to the "GPU busy" message past the fast window.
+test('design progress shows a ticking clock and honest slow-state copy', async ({ page }) => {
+  // 1. Navigate to a book → open a character's profile drawer → trigger design.
+  //    (Reuse the helper/selectors the existing drawer e2e specs use.)
+  // 2. Assert the elapsed clock is present and advances.
+  await expect(page.getByTestId('design-elapsed')).toBeVisible();
+  const first = await page.getByTestId('design-elapsed').textContent();
+  await page.waitForTimeout(2500);
+  const second = await page.getByTestId('design-elapsed').textContent();
+  expect(first).not.toBe(second);
+  // 3. The ETA line is present (exact copy depends on timing; assert it exists).
+  await expect(page.getByTestId('design-eta')).toBeVisible();
+});
+```
+
+IMPLEMENTER NOTE: wire the navigation/trigger using the existing mock-mode design path. If mock mode does not expose a slow design, assert only the always-true honesty invariants (clock present + advances; eta line present). Do NOT add app code purely to make a slow path reachable — keep the e2e to observable behaviour.
+
+- [ ] **Step 2: Run the e2e spec**
+
+Run: `npm run test:e2e -- voice-design-progress`
+Expected: PASS (chromium).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/voice-design-progress.spec.ts
+git commit -m "test(frontend): e2e — design progress indicator stays honest while running"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full battery**
+
+Run: `npm run verify`
+Expected: typecheck + all unit tests + e2e + build all green (sidecar tests run via `test:sidecar` inside `test:all`).
+
+- [ ] **Live GPU acceptance (owed, manual)**
+
+With the real sidecar + GPU: start a mixed-cast chapter generation, then design a Qwen voice mid-generation. Confirm via `nvidia-smi` that total VRAM stays under 8 GB (Kokoro evicts for the design, reloads after), the design completes without a recycle, the pill never shows "Halted," and the drawer's progress shows a ticking clock. Record the SHA + result in the spec's Ship notes.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** C → Tasks C1–C3 (arbiter + Kokoro guard + design evict/exclusion); B → Task B1 (liveness watchdog + ceiling); A → Tasks A1–A2 (honest component + e2e). Out-of-scope memory leak explicitly excluded.
+- **Type consistency:** `_VdKokoroArbiter` / `_VD_KOKORO` (sidecar), `evaluateDesignLiveness` / `DesignLivenessResult` (server), `design-elapsed` / `design-eta` / `design-fill--indeterminate` (frontend) are used consistently across their tasks.
+- **Pill "GPU busy" / "never Halted":** the false-Halted is fixed at the source by B (server no longer aborts an alive design), so the pill stops receiving a `halt` for a slow design with no frontend slice change required. The "· GPU busy" pill subtitle from the spec is optional polish and intentionally NOT a hard task here (it would need a snapshot `startedAt`); add it only if desired after the core lands.

--- a/docs/superpowers/specs/2026-06-09-voice-design-contention-robustness-design.md
+++ b/docs/superpowers/specs/2026-06-09-voice-design-contention-robustness-design.md
@@ -1,0 +1,171 @@
+---
+status: draft
+date: 2026-06-09
+branch: fix/voice-design-contention-robustness
+---
+
+# Voice-design robustness under GPU contention
+
+## Problem
+
+A user designing a narrator voice while a chapter generation was running (both
+from the UI and from a separate code-driven generation) saw the design "freeze
+on the last part of the progress bar," then the design pill flip to **"Halted."**
+Investigation showed the design actually **succeeded** — but the experience was
+broken end-to-end, and a heavy VoiceDesign model was effectively loaded on top of
+a concurrent generation, oversubscribing the 8 GB GPU until the VRAM-crash
+protection recycled the sidecar.
+
+This is one fragility story with three layers, confirmed from logs
+(`logs/tts.err.log`, `logs/tts.log`) on 2026-06-09:
+
+1. **Root cause (C) — resident-VRAM oversubscription, NOT token concurrency.**
+   A model stays resident in VRAM after it releases its GPU-semaphore token, so
+   the semaphore (which arbitrates *active* ops, `server/src/gpu/semaphore.ts`)
+   never reflects how many models are *sitting* in VRAM at once. Measured
+   footprints on the 8 GB box:
+   - Qwen Base + active generation ≈ **3.5 GB**
+   - \+ VoiceDesign (the heavy 1.7 B design model) ≈ **6 GB** → **fits, no spill**
+     (design co-residing with Qwen generation is fine and worth keeping).
+   - \+ **Kokoro resident *while generation is active*** (a mixed-cast generation
+     voices some characters on Kokoro) → **over 8 GB → spill** (RTF observed
+     **3.22**, `gen_ms=222611`) → the VRAM-crash protection recycled the sidecar
+     (fresh boot at 19:23:58). The spill is the **three-way** combination —
+     active-generation working set **+** VoiceDesign **+** Kokoro. VoiceDesign +
+     Kokoro with **no** active generation fits, so Kokoro may stay resident when
+     nothing is generating.
+
+   Kokoro runs on **onnxruntime-gpu**, a separate allocator from torch, so its
+   ~1 GB is invisible to the torch `vram_reserved` metric but real on
+   `nvidia-smi` — which is why the over-subscription was easy to miss. The
+   sidecar's plan-161/PR-490 defense-in-depth (the `_synth_lock` on
+   `unload`/`unload_design` + `_design_in_flight` re-ensure) is **intact** and
+   still prevents two VoiceDesign copies *within one design*; the emotion-variant
+   feature (fs-25/fs-34) did not break it. The gap it surfaced is different:
+   **nothing prevents VoiceDesign and Kokoro from being co-resident.**
+
+2. **Server symptom (B):** `DESIGN_TIMEOUT_MS = 180_000`
+   (`server/src/routes/qwen-voice.ts:70`) is a blind wall-clock abort. Under the
+   spill the design ran 222 s; at 180 s the `AbortController` fired and threw
+   *"did not complete within 180000ms,"* which the design slice surfaces as a
+   scary **"Halted"** — even though the sidecar answered `/health` 200 OK the
+   whole time and finished the design 42 s later.
+
+3. **Frontend symptom (A):** `src/components/design-progress.tsx` eases the fill
+   to ~92 % over ~15 s and **holds**, with a hard-coded "about 15s" label. A
+   multi-minute design therefore sits frozen at 92 % saying "about 15s" — exactly
+   the "stuck on the last part of the progress bar" report.
+
+## Scope
+
+In scope: the three fixes below. **Out of scope** (explicit user decision): the
+underlying variable-shape memory leak that inflates committed RAM to ~30 GB —
+that is a separate, harder problem guarded today by the restart ceiling. This
+spec fixes the *contention/over-subscription* fragility and the *honesty* of the
+indicator, not the leak.
+
+## Design
+
+### C — VoiceDesign and Kokoro must not co-reside (root fix, sidecar-side)
+
+This is a **resident-VRAM** rule, not a semaphore-cost change — the Node
+semaphore can't see residency, so the fix lives in the sidecar where the engines
+and VRAM are. Rule: **a VoiceDesign design forward and a Kokoro synth are mutually
+exclusive.** Because Kokoro synths only occur *during generation*, this exclusion
+is self-limiting — it bites exactly in the dangerous three-way case (design +
+active generation + Kokoro) and is a no-op when nothing is generating (so Kokoro
+may stay resident then). A design continues to co-reside happily with Qwen Base
+generation (~6 GB, fits).
+
+- Add a module-level cross-engine exclusion primitive in
+  `server/tts-sidecar/main.py` (a `threading.Lock`, e.g. `_vd_kokoro_excl`)
+  shared between the two engines. Mirrors the existing Coqui/XTTS-load ↔ analyzer
+  auto-evict precedent.
+- `KokoroEngine.synthesize` acquires `_vd_kokoro_excl` around its
+  `self._kokoro.create(...)` forward. Uncontended (the common case) this is
+  near-free; while a design holds it, Kokoro synths **wait** until the design
+  finishes (they belong to a concurrent generation — its Qwen sentences keep
+  flowing; only its Kokoro sentences pause briefly).
+- `design_voice` (`QwenEngine`), on entering the exclusive VoiceDesign forward,
+  acquires `_vd_kokoro_excl` and, **if Kokoro is currently resident**
+  (`kokoro._kokoro is not None`), calls `kokoro.unload()` to reclaim its ~1 GB so
+  the 1.7 B VoiceDesign load has headroom. Kokoro reloads on the next Kokoro
+  synth (~1 s cold). When no generation ran, Kokoro typically isn't resident
+  (`PRELOAD_KOKORO=0`), so this is a no-op — honouring "Kokoro can stay if there
+  is no generation."
+- Hold the exclusion only around the VoiceDesign *reference-clip* forward (the
+  heavy step). The Base audition + Qwen generation are unaffected.
+
+*Why mutual-exclude over evict-only:* a bare evict would let a concurrent Kokoro
+synth reload Kokoro mid-design and re-spill. Serialising the two heaviest-combined
+ops removes the evict/reload thrash window.
+
+*Interaction with A/B:* under this fix a design no longer spills, so it runs at
+normal RTF and finishes in seconds — B's 180 s timeout stops being pressured and
+A rarely reaches its "slow" state. A/B remain the honest-degradation safety net
+for any residual slow case (e.g. a long Kokoro sentence the design waits behind).
+
+### B — Liveness-aware design timeout (no false "Halted")
+
+Replace the blind 180 s abort with a `condition-based-waiting` check that only
+gives up when the sidecar is genuinely unresponsive:
+
+- On the design deadline, probe the sidecar `/health` (reuse the probe the
+  generation supervisor already uses).
+  - **alive →** re-arm for another window and keep waiting, bounded by an absolute
+    ceiling (`DESIGN_ABSOLUTE_MAX_MS`, default 10 min) so a truly hung call still
+    fails eventually. Log a single "design slow, sidecar alive — extending" warn.
+  - **unreachable →** abort with the existing user-facing error.
+- The design slice's `halt` should only be reached on a real unreachable/abort,
+  never on a slow-but-alive design.
+
+### A — Honest progress indicator
+
+Rework `src/components/design-progress.tsx` (and its pill subtitle) so it can
+never look frozen or lie about ETA:
+
+- **Elapsed clock that always ticks** ("Designing… 1:23") — proof of life even
+  when the bar is near-full. Driven off the snapshot `lastTickAt` / a start time.
+- **Determinate-then-indeterminate fill:** keep the eased determinate fill for the
+  expected fast window (~15–20 s), then flip to a continuous **indeterminate
+  shimmer** so it reads "still working, no ETA" instead of "stuck at 92 %."
+- **Honest copy:** under ~20 s show "about 15s"; past that, swap to **"Taking
+  longer than usual — the GPU may be busy with another job."** When the design is
+  queued behind generation, the pill prefix already shows "Queued (N ahead)"
+  (existing `gpu-queue` plumbing); reuse it.
+- Same honesty on the pill: "Designing X · GPU busy", and never "Halted" while the
+  sidecar is alive.
+
+## Testing
+
+- **C (sidecar, pytest):** a design forward and a Kokoro synth **never overlap**
+  (instrument the lock or assert one blocks while the other holds); a design with
+  Kokoro resident **evicts** it before the VoiceDesign load (`kokoro._kokoro is
+  None` during the design) and Kokoro reloads on the next synth; a design with no
+  Kokoro resident is a **no-op** (no spurious unload); Qwen Base generation is
+  **not** blocked by an in-flight design. New cases under
+  `server/tts-sidecar/tests/` (e.g. `test_design_kokoro_exclusion.py`).
+- **B (server):** test that a slow-but-`/health`-alive design **extends** instead
+  of aborting, that an unreachable sidecar aborts with the existing message, and
+  that the absolute ceiling still bounds a hung-but-pingable call.
+- **A (frontend):** Vitest/RTL tests that the elapsed clock advances, that past
+  the slow threshold the copy switches to the "GPU busy" message and the fill
+  flips to indeterminate, and that an alive design never renders "Halted." One
+  Playwright spec exercising the design pill through a simulated slow design
+  (UI-visible behaviour crossing redux/layout seams).
+
+## Risks / notes
+
+- The exclusion serialises **only** Kokoro synths against an in-flight design —
+  Qwen Base generation is untouched, so a Qwen-voiced chapter generates at full
+  speed alongside a design. Only a mixed-cast generation's *Kokoro* sentences
+  pause for the few seconds a design holds the lock.
+- Evicting Kokoro forces a ~1 s cold reload on the next Kokoro synth. Acceptable
+  and rare (only when a design coincides with a mixed-cast generation). It is NOT
+  evicted when idle/no-generation, per the resident-VRAM analysis above.
+- Kokoro runs on onnxruntime-gpu; its VRAM won't show in torch `vram_reserved`.
+  The exclusion is the guard — do not rely on the torch metric to detect the
+  three-way spill.
+- This fix is sidecar-only; the Node GPU semaphore and per-engine costs are left
+  unchanged (they correctly arbitrate *active* ops; residency is a separate axis
+  handled here).

--- a/e2e/voice-design-progress.spec.ts
+++ b/e2e/voice-design-progress.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from '@playwright/test';
+import { goToConfirm, waitForRouteReady } from './helpers';
+
+/**
+ * Voice-design progress indicator — honest clock + ETA line while running.
+ *
+ * Drives a fresh book to the confirm-cast view, opens Captain Halloran's
+ * Profile Drawer, switches the engine to Qwen, then FREEZES the Playwright
+ * fake clock so the mock's internal `wait()` calls (which use `setTimeout`)
+ * never resolve — leaving `DesignProgress` mounted indefinitely. The test
+ * then asserts the two load-bearing invariants from plan 196 / A1:
+ *
+ *   1. The elapsed clock element (`data-testid="design-elapsed"`) is visible
+ *      while the design is in flight.
+ *   2. The honest ETA line (`data-testid="design-eta"`) is visible.
+ *
+ * Why fake clock? The mock `mockStartSingleDesign` resolves in ~200 ms
+ * (120 ms + 80 ms via `setTimeout`). That window is too narrow for reliable
+ * Playwright assertions (acknowledged in `single-voice-design-background.spec.ts`
+ * which already dropped the waveform check for the same reason). By calling
+ * `page.clock.install()` AFTER the persona auto-populates (so the 80 ms
+ * persona-generation `wait` runs normally) but BEFORE clicking "Design &
+ * preview", all subsequent `setTimeout` calls use the frozen fake clock —
+ * the mock never advances past its first `await wait(120)`, and
+ * `DesignProgress` stays mounted long enough for deterministic assertions.
+ *
+ * The clock-advance assertion ("elapsed text changes after 2.5 s") is
+ * intentionally dropped: the fake clock also freezes DesignProgress's
+ * `setInterval`, so the counter stays at "0:00". The component's tick
+ * behaviour is already proven in unit tests (`design-progress.test.tsx`).
+ * This spec guards the RENDER PATH — that the component actually mounts
+ * through the real drawer / Redux / layout seams when a design is in flight.
+ *
+ * Why browser-level: `designBusy` crosses the profile-drawer component
+ * lifecycle, the Redux `castDesign` slice, the stream middleware's
+ * `beginSingle` dispatch, and the VoiceEnginePicker presentation layer —
+ * seams that Vitest+jsdom covers only in isolation.
+ */
+
+test.describe('voice-design progress indicator', () => {
+  test('shows elapsed clock and honest ETA line while a design is in flight', async ({ page }) => {
+    /* goToConfirm takes ~7.6 s (analysis mock). Add budget for drawer
+       interaction + clock setup. */
+    test.setTimeout(60_000);
+
+    await goToConfirm(page);
+    await waitForRouteReady(page);
+
+    /* Open Captain Halloran's drawer — the most fixture-rich character;
+       has evidence + voiceStyle so the Qwen panel auto-fills a persona.
+       Matches the selector used in single-voice-design-background.spec.ts. */
+    const card = page.getByRole('button', { name: /Open profile for Captain Halloran/i });
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await card.click();
+
+    /* Drawer mounted — evidence section proves hydration. */
+    await expect(page.getByText(/Evidence from the manuscript/i)).toBeVisible({ timeout: 10_000 });
+
+    /* Switch the per-character engine to Qwen. This triggers auto-persona
+       generation via `api.generateVoiceStyle` (mock: `wait(80)` then returns
+       MOCK_PERSONA). We must let this 80 ms timer resolve BEFORE installing
+       the fake clock — otherwise the textarea stays empty and the design
+       button stays disabled. */
+    const engineSelect = page.getByLabel('TTS engine for this character');
+    await expect(engineSelect).toBeVisible();
+    await engineSelect.selectOption('qwen');
+
+    /* Wait for the Qwen panel to mount and the persona to auto-populate.
+       The mock generateVoiceStyle resolves in ~80 ms; the timeout absorbs
+       any local contention. */
+    await expect(page.getByTestId('qwen-design-panel')).toBeVisible();
+    const personaField = page.getByTestId('qwen-persona-text');
+    await expect(personaField).not.toHaveValue('', { timeout: 5_000 });
+
+    /* FREEZE THE CLOCK. Now that the persona is ready, install Playwright's
+       fake clock. From this point on, every new `setTimeout` / `setInterval`
+       in the browser context (including the mock's `wait()` calls) uses the
+       frozen fake clock — they will not fire until we explicitly call
+       `page.clock.runFor()` or `page.clock.resume()`. This keeps
+       `DesignProgress` mounted indefinitely so we can assert on it. */
+    await page.clock.install();
+
+    /* Ensure the design button is enabled (persona non-empty). */
+    const designBtn = page.getByTestId('qwen-design-voice');
+    await expect(designBtn).toBeEnabled({ timeout: 5_000 });
+
+    /* Click the design button. This dispatches `designSingleRequested`
+       synchronously. The middleware intercepts it and dispatches `beginSingle`
+       synchronously — setting `castDesign.active` to `{ kind:'single',
+       state:'running' }` before the async `mockStartSingleDesign` even starts.
+       React re-renders with `designBusy=true`, mounting `<DesignProgress>`.
+       The mock's first `await wait(120)` then schedules a frozen timer —
+       it never fires, so `settle()` is never called, and `DesignProgress`
+       stays mounted. */
+    await designBtn.click();
+
+    /* THE LOAD-BEARING ASSERTIONS: both data-testid elements from
+       DesignProgress must be visible while the design is in flight. */
+    await expect(page.getByTestId('design-elapsed')).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByTestId('design-eta')).toBeVisible({ timeout: 3_000 });
+
+    /* Restore real timers so the browser can clean up without hanging.
+       The test is already passing at this point. */
+    await page.clock.resume();
+  });
+});

--- a/server/src/routes/cast-design.test.ts
+++ b/server/src/routes/cast-design.test.ts
@@ -140,6 +140,7 @@ function parseSse(text: string): Array<Record<string, any>> {
 }
 
 let designLock: typeof import('../tts/design-lock.js');
+let qwenVoiceMod: typeof import('./qwen-voice.js');
 
 beforeAll(async () => {
   workspaceRoot = mkdtempSync(join(tmpdir(), 'audiobook-cast-design-test-'));
@@ -148,12 +149,13 @@ beforeAll(async () => {
   process.env.VOICE_SAMPLE_AUDIO_DIR = audioDir;
   vi.stubGlobal('fetch', fetchMock);
 
-  const [{ castDesignRouter }, { qwenVoiceRouter }, { makeBookId }, lock] = await Promise.all([
+  const [{ castDesignRouter }, qwenVoice, { makeBookId }, lock] = await Promise.all([
     import('./cast-design.js'),
     import('./qwen-voice.js'),
     import('../workspace/paths.js'),
     import('../tts/design-lock.js'),
   ]);
+  qwenVoiceMod = qwenVoice;
   designLock = lock;
   bookId = makeBookId(AUTHOR, SERIES, BOOK);
   bookDir = join(workspaceRoot, 'books', AUTHOR, SERIES, BOOK);
@@ -161,7 +163,7 @@ beforeAll(async () => {
   app = express();
   app.use(express.json());
   app.use('/api/books', castDesignRouter);
-  app.use('/api/books', qwenVoiceRouter);
+  app.use('/api/books', qwenVoice.qwenVoiceRouter);
 });
 
 beforeEach(() => {
@@ -246,6 +248,34 @@ describe('POST /api/books/:bookId/cast/design', () => {
     expect(idle).toMatchObject({ done: 1, total: 2 });
     expect(idle?.failures).toHaveLength(1);
     expect(charById('fitz')?.overrideTtsVoices?.qwen?.name).toBe('qwen-v_fitz');
+  });
+
+  it('sidecar liveness watchdog "stopped responding to /health" triggers fast-fail (sidecar_unavailable)', async () => {
+    /* Regression: the bulk-design fast-fail regex previously matched
+       "unreachable|did not complete within" but NOT the new liveness-watchdog
+       message "stopped responding to /health during voice design". Without the
+       fix, the job would grind through every remaining character to the 600s
+       ceiling instead of stopping early. */
+    const stoppedMsg =
+      `TTS sidecar (http://localhost:9000) stopped responding to /health during voice design — the process may have crashed or been recycled.`;
+    const spy = vi.spyOn(qwenVoiceMod, 'designQwenVoiceForCharacter').mockRejectedValue(
+      new Error(stoppedMsg),
+    );
+
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/design`)
+      .send({ characterIds: ['aria', 'fitz'], modelKey: QWEN_KEY });
+
+    expect(res.status).toBe(200);
+    const events = parseSse(res.text);
+    const errorEvent = events.find((e) => e.type === 'error');
+    expect(errorEvent).toBeDefined();
+    expect(errorEvent?.code).toBe('sidecar_unavailable');
+    expect(errorEvent?.message).toMatch(/stopped responding/i);
+    /* The loop stopped after the first character — aria is NOT in character_designed */
+    expect(events.some((e) => e.type === 'character_designed')).toBe(false);
+
+    spy.mockRestore();
   });
 
   it('mutual exclusion: refuses to start while analysis is busy (409)', async () => {

--- a/server/src/routes/cast-design.ts
+++ b/server/src/routes/cast-design.ts
@@ -187,7 +187,7 @@ async function runDesignJob(
       /* A sidecar-wide failure (down / stuck) would fail every remaining
          character identically — stop early with a catastrophic error instead
          of grinding through N timeouts. */
-      if (/unreachable|did not complete within/i.test(message)) {
+      if (/unreachable|did not complete within|stopped responding/i.test(message)) {
         clearInterval(heartbeat);
         endJob(job, { type: 'error', code: 'sidecar_unavailable', message });
         return;

--- a/server/src/routes/qwen-voice.test.ts
+++ b/server/src/routes/qwen-voice.test.ts
@@ -676,4 +676,11 @@ describe('evaluateDesignLiveness', () => {
       evaluateDesignLiveness({ startedAt: T0, now: T0 + 600_001, health: 'reachable', absoluteMaxMs: 600_000 }),
     ).toEqual({ action: 'abort', reason: 'absolute' });
   });
+  it('prefers unreachable over absolute when both conditions are true', () => {
+    /* A sidecar that disappears exactly at the ceiling should report the more
+       informative 'unreachable' reason, not the generic 'absolute' ceiling. */
+    expect(
+      evaluateDesignLiveness({ startedAt: T0, now: T0 + 600_001, health: 'unreachable', absoluteMaxMs: 600_000 }),
+    ).toEqual({ action: 'abort', reason: 'unreachable' });
+  });
 });

--- a/server/src/routes/qwen-voice.test.ts
+++ b/server/src/routes/qwen-voice.test.ts
@@ -650,3 +650,30 @@ describe('DELETE /api/books/:bookId/cast/:characterId/emotion-variant/:emotion (
     expect(res.body).toEqual({ ok: true, removed: 'excited' });
   });
 });
+
+describe('evaluateDesignLiveness', () => {
+  /* Import dynamically to avoid loading qwen-voice.ts (and its workspace/paths
+     transitive dep) at test-module parse time — paths.ts captures WORKSPACE_DIR
+     once at load, so a static top-level import here would race beforeAll's env setup. */
+  let evaluateDesignLiveness: typeof import('./qwen-voice.js').evaluateDesignLiveness;
+  beforeAll(async () => {
+    ({ evaluateDesignLiveness } = await import('./qwen-voice.js'));
+  });
+
+  const T0 = 1_000_000;
+  it('continues while the sidecar is reachable and under the ceiling', () => {
+    expect(
+      evaluateDesignLiveness({ startedAt: T0, now: T0 + 200_000, health: 'reachable', absoluteMaxMs: 600_000 }),
+    ).toEqual({ action: 'continue' });
+  });
+  it('aborts as unreachable when the sidecar /health is down', () => {
+    expect(
+      evaluateDesignLiveness({ startedAt: T0, now: T0 + 200_000, health: 'unreachable', absoluteMaxMs: 600_000 }),
+    ).toEqual({ action: 'abort', reason: 'unreachable' });
+  });
+  it('aborts on the absolute ceiling even if the sidecar still pings', () => {
+    expect(
+      evaluateDesignLiveness({ startedAt: T0, now: T0 + 600_001, health: 'reachable', absoluteMaxMs: 600_000 }),
+    ).toEqual({ action: 'abort', reason: 'absolute' });
+  });
+});

--- a/server/src/routes/qwen-voice.ts
+++ b/server/src/routes/qwen-voice.ts
@@ -79,8 +79,8 @@ export function evaluateDesignLiveness(p: {
   health: 'reachable' | 'unreachable';
   absoluteMaxMs: number;
 }): DesignLivenessResult {
-  if (p.now - p.startedAt >= p.absoluteMaxMs) return { action: 'abort', reason: 'absolute' };
   if (p.health === 'unreachable') return { action: 'abort', reason: 'unreachable' };
+  if (p.now - p.startedAt >= p.absoluteMaxMs) return { action: 'abort', reason: 'absolute' };
   return { action: 'continue' };
 }
 

--- a/server/src/routes/qwen-voice.ts
+++ b/server/src/routes/qwen-voice.ts
@@ -59,15 +59,30 @@ interface CastFile {
   characters: CastCharacter[];
 }
 
-/* Cold voice-design (load VoiceDesign model transiently + generate a
-   reference clip + distil the clone prompt) can take noticeably longer
-   than a warm synth on first call, so budget generously like the load
-   proxy rather than the 2s health probe. The sidecar now voices only the
-   short CALIBRATION_TEXT on the heavy 1.7B reference model (the audition
-   on the 0.6B Base still speaks the full quote), so a warm design lands in
-   ~60-90s — but a cold first-design (1.7B load + CUDA kernel JIT) plus a
-   max-length audition can still approach two minutes, so keep headroom. */
-const DESIGN_TIMEOUT_MS = 180_000;
+/* The base liveness-check interval. A design that exceeds this AND whose sidecar
+   /health is still reachable is slow-but-alive — keep waiting (almost always a
+   contended GPU). Only an unreachable sidecar or the absolute ceiling aborts.
+   (Was a blind wall-clock abort that surfaced a false "Halted" while the sidecar
+   was happily still designing.) */
+const DESIGN_LIVENESS_INTERVAL_MS = 180_000;
+/* Hard ceiling so a genuinely hung-but-pingable sidecar still fails eventually. */
+const DESIGN_ABSOLUTE_MAX_MS = 600_000;
+
+export type DesignLivenessResult =
+  | { action: 'continue' }
+  | { action: 'abort'; reason: 'unreachable' | 'absolute' };
+
+/** Pure decision for the design liveness watchdog — easy to unit-test. */
+export function evaluateDesignLiveness(p: {
+  startedAt: number;
+  now: number;
+  health: 'reachable' | 'unreachable';
+  absoluteMaxMs: number;
+}): DesignLivenessResult {
+  if (p.now - p.startedAt >= p.absoluteMaxMs) return { action: 'abort', reason: 'absolute' };
+  if (p.health === 'unreachable') return { action: 'abort', reason: 'unreachable' };
+  return { action: 'continue' };
+}
 
 /* Stable cache key for the designed voice — keyed on the character's
    voiceId when present (so a series-shared identity reuses one embedding)
@@ -205,7 +220,29 @@ export async function designQwenVoiceForCharacter(
     const sidecarUrl = getResolvedSidecarUrl();
     const target = `${sidecarUrl}/qwen/design-voice`;
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), DESIGN_TIMEOUT_MS);
+    const startedAt = Date.now();
+    let abortReason: 'unreachable' | 'absolute' | null = null;
+    const livenessTimer = setInterval(() => {
+      void (async () => {
+        const { probeSidecarHealth } = await import('./sidecar-health.js');
+        const health = (await probeSidecarHealth()).status; // 'reachable' | 'unreachable'
+        const decision = evaluateDesignLiveness({
+          startedAt,
+          now: Date.now(),
+          health,
+          absoluteMaxMs: DESIGN_ABSOLUTE_MAX_MS,
+        });
+        if (decision.action === 'abort') {
+          abortReason = decision.reason;
+          controller.abort();
+        } else {
+          console.warn(
+            `[qwen-voice] design slow (${Math.round((Date.now() - startedAt) / 1000)}s) ` +
+              `— sidecar /health reachable, extending (ceiling ${DESIGN_ABSOLUTE_MAX_MS / 1000}s).`,
+          );
+        }
+      })();
+    }, DESIGN_LIVENESS_INTERVAL_MS);
     const onExternalAbort = () => controller.abort();
     if (p.signal) {
       if (p.signal.aborted) controller.abort();
@@ -228,8 +265,16 @@ export async function designQwenVoiceForCharacter(
       } catch (e) {
         const err = e as { name?: string; message?: string };
         if (err.name === 'AbortError') {
+          if (p.signal?.aborted) {
+            throw new Error('Voice design was cancelled.');
+          }
+          if (abortReason === 'unreachable') {
+            throw new Error(
+              `TTS sidecar (${sidecarUrl}) stopped responding to /health during voice design — the process may have crashed or been recycled.`,
+            );
+          }
           throw new Error(
-            `Sidecar /qwen/design-voice did not complete within ${DESIGN_TIMEOUT_MS}ms — voice design is unusually slow or the process is stuck.`,
+            `Sidecar /qwen/design-voice did not complete within ${DESIGN_ABSOLUTE_MAX_MS}ms — voice design is unusually slow or the process is stuck.`,
           );
         }
         throw new Error(
@@ -275,7 +320,7 @@ export async function designQwenVoiceForCharacter(
       );
       return { voiceId, url };
     } finally {
-      clearTimeout(timer);
+      clearInterval(livenessTimer);
       if (p.signal) p.signal.removeEventListener('abort', onExternalAbort);
       releaseGpu();
     }

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -1362,31 +1362,42 @@ class QwenEngine(Engine):
         self._design_last_used = time.monotonic()
         self._design_in_flight += 1
         try:
-            self._ensure_design_loaded()
-            self._ensure_base_loaded()
-            # Serialise the GPU forwards against any concurrent synth/design — see
-            # `_synth_lock` in __init__ (the Base model isn't thread-safe).
-            with self._synth_lock:
-                # Re-ensure the models UNDER the lock. Every in-place nuller of
-                # `_design`/`_base` (the idle watchdog, a concurrent
-                # /synthesize's unload_design, a full /unload) holds `_synth_lock`,
-                # so a model ensured before we took the lock may have been freed
-                # in the gap. Re-ensuring here is the airtight backstop against
-                # "'NoneType' object has no attribute 'generate_voice_design'".
-                # Idempotent / a no-op on the warm path; `_ensure_*` don't take
-                # `_synth_lock`, so this can't deadlock.
+            # Resident-VRAM exclusion (root fix): a VoiceDesign forward and a
+            # Kokoro synth must not co-reside on the 8 GB card. Take the arbiter
+            # (waits for any in-flight Kokoro synth to drain, blocks new ones),
+            # then evict a resident Kokoro so the 1.7B load has headroom. Kokoro
+            # reloads on the next synth (~1s); when no generation ran it isn't
+            # resident, so this is a no-op.
+            with _VD_KOKORO.design():
+                _kokoro_eng = ENGINES.get("kokoro")
+                if isinstance(_kokoro_eng, KokoroEngine) and _kokoro_eng._kokoro is not None:
+                    log.info("Evicting resident Kokoro to free VRAM for VoiceDesign load.")
+                    _kokoro_eng.unload()
                 self._ensure_design_loaded()
                 self._ensure_base_loaded()
-                # 1. design a reference clip from the persona instruction.
-                ref_wavs, ref_sr = self._design.generate_voice_design(
-                    text=ref_text, language=lang, instruct=instruct
-                )
-                ref_audio = ref_wavs[0]
+                # Serialise the GPU forwards against any concurrent synth/design — see
+                # `_synth_lock` in __init__ (the Base model isn't thread-safe).
+                with self._synth_lock:
+                    # Re-ensure the models UNDER the lock. Every in-place nuller of
+                    # `_design`/`_base` (the idle watchdog, a concurrent
+                    # /synthesize's unload_design, a full /unload) holds `_synth_lock`,
+                    # so a model ensured before we took the lock may have been freed
+                    # in the gap. Re-ensuring here is the airtight backstop against
+                    # "'NoneType' object has no attribute 'generate_voice_design'".
+                    # Idempotent / a no-op on the warm path; `_ensure_*` don't take
+                    # `_synth_lock`, so this can't deadlock.
+                    self._ensure_design_loaded()
+                    self._ensure_base_loaded()
+                    # 1. design a reference clip from the persona instruction.
+                    ref_wavs, ref_sr = self._design.generate_voice_design(
+                        text=ref_text, language=lang, instruct=instruct
+                    )
+                    ref_audio = ref_wavs[0]
 
-                # 2. distil into a reusable clone prompt on the Base model.
-                prompt = self._base.create_voice_clone_prompt(
-                    ref_audio=(ref_audio, ref_sr), ref_text=ref_text
-                )
+                    # 2. distil into a reusable clone prompt on the Base model.
+                    prompt = self._base.create_voice_clone_prompt(
+                        ref_audio=(ref_audio, ref_sr), ref_text=ref_text
+                    )
 
             # 3. cache prompt + manifest to disk (workspace-shared, keyed by voiceId).
             os.makedirs(self._voices_dir, exist_ok=True)

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -373,6 +373,54 @@ class SynthBatchResult:
         self.audio_ms = audio_ms
 
 
+class _VdKokoroArbiter:
+    """Mutual exclusion between a VoiceDesign forward and Kokoro synths.
+
+    Kokoro runs on onnxruntime-gpu (a separate allocator from torch), so a
+    resident Kokoro + Qwen Base + the 1.7B VoiceDesign model oversubscribe an
+    8 GB card and spill. This arbiter guarantees the two heaviest-combined ops
+    never co-reside: a design waits for in-flight Kokoro synths to drain, then
+    blocks new ones until it finishes. Kokoro synths still run concurrently with
+    EACH OTHER (writer-priority readers/writer), so normal generation is
+    unaffected when no design is running. Qwen Base generation never touches this
+    arbiter, so a Qwen-voiced chapter generates at full speed alongside a design.
+    """
+
+    def __init__(self) -> None:
+        self._cv = threading.Condition()
+        self._kokoro_in_flight = 0
+        self._design_active = False
+
+    @contextmanager
+    def kokoro_synth(self):
+        with self._cv:
+            while self._design_active:
+                self._cv.wait()
+            self._kokoro_in_flight += 1
+        try:
+            yield
+        finally:
+            with self._cv:
+                self._kokoro_in_flight -= 1
+                self._cv.notify_all()
+
+    @contextmanager
+    def design(self):
+        with self._cv:
+            while self._kokoro_in_flight > 0:
+                self._cv.wait()
+            self._design_active = True
+        try:
+            yield
+        finally:
+            with self._cv:
+                self._design_active = False
+                self._cv.notify_all()
+
+
+_VD_KOKORO = _VdKokoroArbiter()
+
+
 class Engine:
     """Each engine returns mono PCM as int16 little-endian + a sample rate.
     We never persist audio here — the Node side encodes PCM to MP3 and

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -381,8 +381,12 @@ class _VdKokoroArbiter:
     8 GB card and spill. This arbiter guarantees the two heaviest-combined ops
     never co-reside: a design waits for in-flight Kokoro synths to drain, then
     blocks new ones until it finishes. Kokoro synths still run concurrently with
-    EACH OTHER (writer-priority readers/writer), so normal generation is
-    unaffected when no design is running. Qwen Base generation never touches this
+    EACH OTHER (a drain-and-lock policy, not writer-priority: a waiting design
+    does NOT block new Kokoro synths until it has drained the in-flight ones
+    and set `_design_active`), so normal generation is unaffected when no
+    design is running. Under a continuous Kokoro stream a design may therefore
+    wait up to ~one sentence's duration beyond the last drain point —
+    acceptable because designs are rare and brief. Qwen Base generation never touches this
     arbiter, so a Qwen-voiced chapter generates at full speed alongside a design.
     """
 

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -832,57 +832,61 @@ class KokoroEngine(Engine):
         log.info("Kokoro model unloaded.")
 
     def synthesize(self, model: str, voice: str, text: str) -> SynthResult:
-        self._ensure_loaded(model)
-        assert self._kokoro is not None
+        # Resident-VRAM exclusion: never let this Kokoro forward overlap a
+        # VoiceDesign forward (the three-way 8 GB spill). Held around load+create
+        # so a design can't evict Kokoro out from under an in-flight synth.
+        with _VD_KOKORO.kokoro_synth():
+            self._ensure_loaded(model)
+            assert self._kokoro is not None
 
-        # Pre-flight voice validation. Non-English voice IDs (ef_*, ff_*,
-        # etc.) or unknown names fall back to FALLBACK_VOICE. The Node
-        # side reads X-Voice-Substituted-From and surfaces a warning so
-        # the upstream catalog can be fixed.
-        actual_voice = voice
-        substituted_from: Optional[str] = None
-        if self._voices and voice not in self._voices:
-            substituted_from = voice
-            actual_voice = (
-                self.FALLBACK_VOICE
-                if self.FALLBACK_VOICE in self._voices
-                else self._voices[0]
-            )
-            log.warning(
-                "Voice '%s' not in Kokoro English subset — substituting '%s'. "
-                "Valid sample: %s",
-                voice, actual_voice, ", ".join(self._voices[:8]),
-            )
+            # Pre-flight voice validation. Non-English voice IDs (ef_*, ff_*,
+            # etc.) or unknown names fall back to FALLBACK_VOICE. The Node
+            # side reads X-Voice-Substituted-From and surfaces a warning so
+            # the upstream catalog can be fixed.
+            actual_voice = voice
+            substituted_from: Optional[str] = None
+            if self._voices and voice not in self._voices:
+                substituted_from = voice
+                actual_voice = (
+                    self.FALLBACK_VOICE
+                    if self.FALLBACK_VOICE in self._voices
+                    else self._voices[0]
+                )
+                log.warning(
+                    "Voice '%s' not in Kokoro English subset — substituting '%s'. "
+                    "Valid sample: %s",
+                    voice, actual_voice, ", ".join(self._voices[:8]),
+                )
 
-        # kokoro-onnx's create() returns (samples, sample_rate). samples is
-        # a numpy float32 array in [-1, 1]; sample_rate is the model's
-        # native rate (24 kHz for v1). Wrap defensively in case a future
-        # release changes the return shape.
-        gen_start = time.perf_counter()
-        result = self._kokoro.create(
-            text,
-            voice=actual_voice,
-            speed=1.0,
-            lang=self._language,
-        )
-        gen_ms = (time.perf_counter() - gen_start) * 1000.0
-        if isinstance(result, tuple) and len(result) == 2:
-            audio, sample_rate = result
-        else:
-            audio = result
-            sample_rate = self.NATIVE_SAMPLE_RATE
-        audio_ms = _audio_duration_ms(audio, int(sample_rate))
-        log.info(
-            "kokoro synth: voice=%s text_len=%d gen_ms=%.0f audio_ms=%.0f rtf=%.2f",
-            actual_voice, len(text), gen_ms, audio_ms,
-            (gen_ms / audio_ms if audio_ms > 0 else 0.0),
-        )
-        pcm = _float_audio_to_int16_le(audio)
-        return SynthResult(
-            pcm=pcm,
-            sample_rate=int(sample_rate),
-            substituted_from=substituted_from,
-        )
+            # kokoro-onnx's create() returns (samples, sample_rate). samples is
+            # a numpy float32 array in [-1, 1]; sample_rate is the model's
+            # native rate (24 kHz for v1). Wrap defensively in case a future
+            # release changes the return shape.
+            gen_start = time.perf_counter()
+            result = self._kokoro.create(
+                text,
+                voice=actual_voice,
+                speed=1.0,
+                lang=self._language,
+            )
+            gen_ms = (time.perf_counter() - gen_start) * 1000.0
+            if isinstance(result, tuple) and len(result) == 2:
+                audio, sample_rate = result
+            else:
+                audio = result
+                sample_rate = self.NATIVE_SAMPLE_RATE
+            audio_ms = _audio_duration_ms(audio, int(sample_rate))
+            log.info(
+                "kokoro synth: voice=%s text_len=%d gen_ms=%.0f audio_ms=%.0f rtf=%.2f",
+                actual_voice, len(text), gen_ms, audio_ms,
+                (gen_ms / audio_ms if audio_ms > 0 else 0.0),
+            )
+            pcm = _float_audio_to_int16_le(audio)
+            return SynthResult(
+                pcm=pcm,
+                sample_rate=int(sample_rate),
+                substituted_from=substituted_from,
+            )
 
 
 def _float_audio_to_int16_le(audio: Any) -> bytes:

--- a/server/tts-sidecar/tests/test_design_kokoro_exclusion.py
+++ b/server/tts-sidecar/tests/test_design_kokoro_exclusion.py
@@ -74,10 +74,14 @@ def test_kokoro_blocks_while_design_active():
 def test_two_kokoro_synths_run_concurrently_when_no_design():
     arb = _VdKokoroArbiter()
     both_in = threading.Barrier(2, timeout=1)
+    errors = []
 
     def kokoro():
-        with arb.kokoro_synth():
-            both_in.wait()
+        try:
+            with arb.kokoro_synth():
+                both_in.wait()  # BrokenBarrierError if they can't co-exist
+        except Exception as e:  # noqa: BLE001 - surface to the assertion below
+            errors.append(e)
 
     t1 = threading.Thread(target=kokoro)
     t2 = threading.Thread(target=kokoro)
@@ -85,3 +89,4 @@ def test_two_kokoro_synths_run_concurrently_when_no_design():
     t2.start()
     t1.join()
     t2.join()
+    assert not errors, f"Kokoro synths could not run concurrently: {errors}"

--- a/server/tts-sidecar/tests/test_design_kokoro_exclusion.py
+++ b/server/tts-sidecar/tests/test_design_kokoro_exclusion.py
@@ -114,6 +114,56 @@ def test_kokoro_synthesize_acquires_the_arbiter(monkeypatch):
     assert seen["in_flight_during_create"] == 1
 
 
+def test_qwen_base_synth_not_gated_by_vd_kokoro_arbiter(monkeypatch):
+    """QwenEngine.synthesize (Base) must complete while _VD_KOKORO.design() is
+    held in another thread — i.e. Qwen Base generation is NOT blocked by an
+    in-flight VoiceDesign operation. Only KokoroEngine.synthesize gates on the
+    arbiter; QwenEngine.synthesize uses only _synth_lock."""
+    import main
+    import numpy as np
+
+    qeng = main.QwenEngine()
+
+    class _FakeBase:
+        def generate_voice_clone(self, text, language, voice_clone_prompt):
+            return [np.zeros(10, dtype="float32")], 24000
+
+    qeng._base = _FakeBase()
+    # Patch _ensure_base_loaded so the real model isn't required.
+    monkeypatch.setattr(qeng, "_ensure_base_loaded", lambda: None)
+    # Patch _load_voice_prompt so no .pt file is needed on disk.
+    monkeypatch.setattr(
+        qeng,
+        "_load_voice_prompt",
+        lambda voice: ({"prompt": True}, "english", True),
+    )
+
+    design_holding = threading.Event()
+    release_design = threading.Event()
+    synth_completed = threading.Event()
+
+    def hold_design():
+        with main._VD_KOKORO.design():
+            design_holding.set()
+            release_design.wait(timeout=2)
+
+    design_thread = threading.Thread(target=hold_design)
+    design_thread.start()
+    design_holding.wait(timeout=1)
+
+    # Qwen Base synthesize must NOT block on _VD_KOKORO — run it from the
+    # main thread while design_thread holds arb.design().
+    result = qeng.synthesize("qwen3-tts-0.6b", "qwen-narrator", "Hello there.")
+
+    synth_completed.set()
+    release_design.set()
+    design_thread.join(timeout=2)
+
+    # If we got here, synthesize did not block on _VD_KOKORO.
+    assert result is not None, "QwenEngine.synthesize must return a SynthResult"
+    assert result.sample_rate == 24000
+
+
 def test_design_voice_holds_arbiter_and_evicts_resident_kokoro(monkeypatch):
     """design_voice must take arb.design() around its VoiceDesign forward and,
     if Kokoro is resident, unload it first so the 1.7B load has headroom."""

--- a/server/tts-sidecar/tests/test_design_kokoro_exclusion.py
+++ b/server/tts-sidecar/tests/test_design_kokoro_exclusion.py
@@ -90,3 +90,25 @@ def test_two_kokoro_synths_run_concurrently_when_no_design():
     t1.join()
     t2.join()
     assert not errors, f"Kokoro synths could not run concurrently: {errors}"
+
+
+def test_kokoro_synthesize_acquires_the_arbiter(monkeypatch):
+    """KokoroEngine.synthesize must run its load+create under the arbiter so a
+    concurrent design can't start mid-synth."""
+    import main
+
+    eng = main.KokoroEngine()
+    seen = {"in_flight_during_create": None}
+
+    class _FakeModel:
+        def create(self, text, voice, speed, lang):
+            seen["in_flight_during_create"] = main._VD_KOKORO._kokoro_in_flight
+            import numpy as np
+            return np.zeros(10, dtype="float32"), 24000
+
+    eng._kokoro = _FakeModel()
+    eng._voices = ["af_heart"]
+    monkeypatch.setattr(eng, "_ensure_loaded", lambda model: None)
+
+    eng.synthesize("kokoro", "af_heart", "hello")
+    assert seen["in_flight_during_create"] == 1

--- a/server/tts-sidecar/tests/test_design_kokoro_exclusion.py
+++ b/server/tts-sidecar/tests/test_design_kokoro_exclusion.py
@@ -1,0 +1,87 @@
+"""Unit tests for the VoiceDesign<->Kokoro arbiter (resident-VRAM exclusion).
+
+The arbiter guarantees a VoiceDesign forward and Kokoro synths never overlap,
+while letting Kokoro synths run concurrently with each other when no design is
+active. See docs/.../2026-06-09-voice-design-contention-robustness-design.md.
+"""
+import sys
+import threading
+import time
+from pathlib import Path
+
+SIDECAR_ROOT = Path(__file__).resolve().parent.parent
+if str(SIDECAR_ROOT) not in sys.path:
+    sys.path.insert(0, str(SIDECAR_ROOT))
+
+from main import _VdKokoroArbiter
+
+
+def test_design_waits_for_in_flight_kokoro_to_drain():
+    arb = _VdKokoroArbiter()
+    order = []
+    started = threading.Event()
+
+    def kokoro():
+        with arb.kokoro_synth():
+            started.set()
+            time.sleep(0.05)
+            order.append("kokoro-done")
+
+    def design():
+        started.wait()
+        with arb.design():
+            order.append("design-start")
+
+    t1 = threading.Thread(target=kokoro)
+    t2 = threading.Thread(target=design)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert order == ["kokoro-done", "design-start"]
+
+
+def test_kokoro_blocks_while_design_active():
+    arb = _VdKokoroArbiter()
+    order = []
+    design_holding = threading.Event()
+    release_design = threading.Event()
+
+    def design():
+        with arb.design():
+            design_holding.set()
+            release_design.wait(timeout=1)
+            order.append("design-done")
+
+    def kokoro():
+        design_holding.wait()
+        with arb.kokoro_synth():
+            order.append("kokoro-start")
+
+    t1 = threading.Thread(target=design)
+    t2 = threading.Thread(target=kokoro)
+    t1.start()
+    t2.start()
+    time.sleep(0.05)
+    release_design.set()
+    t1.join()
+    t2.join()
+
+    assert order == ["design-done", "kokoro-start"]
+
+
+def test_two_kokoro_synths_run_concurrently_when_no_design():
+    arb = _VdKokoroArbiter()
+    both_in = threading.Barrier(2, timeout=1)
+
+    def kokoro():
+        with arb.kokoro_synth():
+            both_in.wait()
+
+    t1 = threading.Thread(target=kokoro)
+    t2 = threading.Thread(target=kokoro)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()

--- a/server/tts-sidecar/tests/test_design_kokoro_exclusion.py
+++ b/server/tts-sidecar/tests/test_design_kokoro_exclusion.py
@@ -112,3 +112,55 @@ def test_kokoro_synthesize_acquires_the_arbiter(monkeypatch):
 
     eng.synthesize("kokoro", "af_heart", "hello")
     assert seen["in_flight_during_create"] == 1
+
+
+def test_design_voice_holds_arbiter_and_evicts_resident_kokoro(monkeypatch):
+    """design_voice must take arb.design() around its VoiceDesign forward and,
+    if Kokoro is resident, unload it first so the 1.7B load has headroom."""
+    import main
+
+    qeng = main.QwenEngine()
+
+    # The KokoroEngine singleton lives in ENGINES["kokoro"], not a bare `kokoro`
+    # module-level name — reference it through ENGINES.
+    kokoro_eng = main.ENGINES["kokoro"]
+    kokoro_eng._kokoro = object()  # pretend Kokoro is resident
+    unloaded = {"called": False}
+
+    def _fake_unload():
+        unloaded["called"] = True
+        kokoro_eng._kokoro = None  # simulate the real unload clearing the model
+
+    monkeypatch.setattr(kokoro_eng, "unload", _fake_unload)
+
+    captured = {"design_active": None, "kokoro_resident": None}
+
+    class _FakeDesign:
+        def generate_voice_design(self, text, language, instruct):
+            captured["design_active"] = main._VD_KOKORO._design_active
+            captured["kokoro_resident"] = kokoro_eng._kokoro is not None
+            import numpy as np
+            return [np.zeros(10, dtype="float32")], 24000
+
+    class _FakeBase:
+        def create_voice_clone_prompt(self, ref_audio, ref_text):
+            return {"prompt": True}
+
+        def generate_voice_clone(self, text, language, voice_clone_prompt):
+            import numpy as np
+            return [np.zeros(10, dtype="float32")], 24000
+
+    qeng._design = _FakeDesign()
+    qeng._base = _FakeBase()
+    monkeypatch.setattr(qeng, "_ensure_design_loaded", lambda: None)
+    monkeypatch.setattr(qeng, "_ensure_base_loaded", lambda: None)
+
+    import tempfile
+    qeng._voices_dir = tempfile.mkdtemp()
+    monkeypatch.setattr("torch.save", lambda *a, **k: None)
+
+    qeng.design_voice("qwen-narrator-preview", "A warm voice.", "english", "Hello there.")
+
+    assert unloaded["called"] is True, "resident Kokoro must be evicted before the design"
+    assert captured["design_active"] is True, "design forward must run under arb.design()"
+    assert captured["kokoro_resident"] is False, "Kokoro must be unloaded during the design forward"

--- a/src/components/design-progress.test.tsx
+++ b/src/components/design-progress.test.tsx
@@ -1,15 +1,46 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { DesignProgress } from './design-progress';
 
 describe('DesignProgress', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
   it('shows the designing phase label', () => {
     render(<DesignProgress phase="designing" />);
     expect(screen.getByText(/designing the voice/i)).toBeInTheDocument();
   });
-  it('shows the rendering phase label', () => {
-    render(<DesignProgress phase="rendering" />);
-    expect(screen.getByText(/rendering the 12s audition/i)).toBeInTheDocument();
+
+  it('shows a ticking elapsed clock so it never looks frozen', () => {
+    render(<DesignProgress phase="designing" />);
+    expect(screen.getByTestId('design-elapsed')).toHaveTextContent('0:00');
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(screen.getByTestId('design-elapsed')).toHaveTextContent('0:03');
   });
+
+  it('shows the optimistic ETA inside the fast window', () => {
+    render(<DesignProgress phase="designing" />);
+    expect(screen.getByTestId('design-eta')).toHaveTextContent(/about 15s/i);
+  });
+
+  it('switches to the honest "GPU busy" copy past the fast window', () => {
+    render(<DesignProgress phase="designing" />);
+    act(() => {
+      vi.advanceTimersByTime(21000);
+    });
+    expect(screen.getByTestId('design-eta')).toHaveTextContent(/taking longer than usual/i);
+  });
+
+  it('flips the fill to indeterminate past the fast window', () => {
+    const { container } = render(<DesignProgress phase="designing" />);
+    expect(container.querySelector('.design-fill--indeterminate')).toBeNull();
+    act(() => {
+      vi.advanceTimersByTime(21000);
+    });
+    expect(container.querySelector('.design-fill--indeterminate')).toBeTruthy();
+  });
+
   it('renders the waveform + fill scaffold', () => {
     const { container } = render(<DesignProgress phase="designing" />);
     expect(container.querySelector('[data-testid="design-waveform"]')).toBeTruthy();

--- a/src/components/design-progress.test.tsx
+++ b/src/components/design-progress.test.tsx
@@ -46,4 +46,9 @@ describe('DesignProgress', () => {
     expect(container.querySelector('[data-testid="design-waveform"]')).toBeTruthy();
     expect(container.querySelector('[data-testid="design-fill"]')).toBeTruthy();
   });
+
+  it('shows the rendering phase label', () => {
+    render(<DesignProgress phase="rendering" />);
+    expect(screen.getByText(/rendering the 12s audition/i)).toBeInTheDocument();
+  });
 });

--- a/src/components/design-progress.tsx
+++ b/src/components/design-progress.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from 'react';
+import { useEffect, useState, type CSSProperties } from 'react';
 
 const PHASE_LABELS: Record<'designing' | 'rendering', string> = {
   designing: 'Designing the voice…',
@@ -9,19 +9,48 @@ const PHASE_LABELS: Record<'designing' | 'rendering', string> = {
     the nth-child rules in styles.css (.design-wave i). */
 const BARS = 12;
 
+/** Past this many ms the design is "slow" — the optimistic eased fill + "about
+    15s" ETA would start lying, so we flip to an honest indeterminate shimmer and
+    a "GPU may be busy" message. Designs normally land in ~15s; a slow one is
+    almost always a contended GPU. */
+const SLOW_AFTER_MS = 20_000;
+
 interface Props {
   phase: 'designing' | 'rendering';
   /** When the design is done, pass true so the fill snaps to 100%. */
   complete?: boolean;
 }
 
+function formatElapsed(ms: number): string {
+  const total = Math.floor(ms / 1000);
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
 export function DesignProgress({ phase, complete = false }: Props) {
-  /* Soft ETA: CSS animation eases the fill to ~92% over ~15s and holds (see
-     styles.css .design-fill i). On completion we override to a full,
-     transition-backed width so it snaps shut honestly. */
+  /* Tick once a second so the elapsed clock advances — proof of life even when
+     the eased fill is near-full. Mount time ≈ design start (the component
+     mounts when the design begins). */
+  const [elapsedMs, setElapsedMs] = useState(0);
+  useEffect(() => {
+    if (complete) return;
+    const startedAt = Date.now();
+    const id = setInterval(() => setElapsedMs(Date.now() - startedAt), 1000);
+    return () => clearInterval(id);
+  }, [complete]);
+
+  const slow = !complete && elapsedMs >= SLOW_AFTER_MS;
+
+  /* Soft ETA: CSS eases the fill to ~92% over ~15s and holds (styles.css
+     .design-fill i). On completion we override to a full, transition-backed
+     width so it snaps shut honestly. Past the slow threshold we ADD the
+     indeterminate modifier so the bar reads "still working, no ETA" rather than
+     "stuck at 92%". */
   const fillStyle: CSSProperties | undefined = complete
     ? { width: '100%', animation: 'none', transition: 'width 300ms ease-out' }
     : undefined;
+  const fillClass = `design-fill mt-2${slow ? ' design-fill--indeterminate' : ''}`;
 
   return (
     <div className="mt-3 rounded-2xl bg-canvas border border-ink/10 p-4">
@@ -30,12 +59,17 @@ export function DesignProgress({ phase, complete = false }: Props) {
           <i key={i} />
         ))}
       </div>
-      <div className="design-fill mt-2" data-testid="design-fill">
+      <div className={fillClass} data-testid="design-fill">
         <i style={fillStyle} />
       </div>
       <div className="mt-2 flex items-center justify-between">
         <span className="text-[11px] font-semibold text-purple-deep/70">{PHASE_LABELS[phase]}</span>
-        <span className="text-[11px] text-ink/40">about 15s</span>
+        <span className="text-[11px] text-ink/40 tabular-nums" data-testid="design-elapsed">
+          {formatElapsed(elapsedMs)}
+        </span>
+      </div>
+      <div className="mt-1 text-[11px] text-ink/40" data-testid="design-eta">
+        {slow ? 'Taking longer than usual — the GPU may be busy with another job.' : 'about 15s'}
       </div>
     </div>
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -813,5 +813,5 @@ samp {
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .design-wave i, .design-fill i { animation-duration: .01ms !important; animation-iteration-count: 1 !important; }
+  .design-wave i, .design-fill i, .design-fill--indeterminate i { animation-duration: .01ms !important; animation-iteration-count: 1 !important; }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -795,6 +795,23 @@ samp {
 .design-fill { height: 6px; border-radius: 4px; overflow: hidden; background: color-mix(in srgb, var(--magenta) 18%, transparent); }
 .design-fill i { display: block; height: 100%; width: 0; border-radius: 4px; background: var(--magenta); animation: design-fill 15s cubic-bezier(.15,.75,.2,1) forwards; }
 @keyframes design-fill { 0% { width: 4% } 65% { width: 78% } 100% { width: 92% } }
+/* Slow-design state: once a design passes the fast window the eased fill would
+   sit frozen near 92% and read as "stuck". Overlay a continuously-moving
+   indeterminate shimmer so it reads "still working, no ETA" rather than
+   "stuck at 92%". */
+.design-fill--indeterminate i {
+  transition: none;
+  animation: design-indeterminate 1.2s ease-in-out infinite;
+  width: 40%;
+}
+@keyframes design-indeterminate {
+  0% {
+    margin-left: -42%;
+  }
+  100% {
+    margin-left: 100%;
+  }
+}
 @media (prefers-reduced-motion: reduce) {
   .design-wave i, .design-fill i { animation-duration: .01ms !important; animation-iteration-count: 1 !important; }
 }


### PR DESCRIPTION
## Summary

Fixes the voice-design fragility that surfaced under GPU contention: a design that coincided with a chapter generation (plus a resident Kokoro) spilled VRAM past the 8 GB card, got recycled by the crash protection, showed a frozen progress bar, and flipped to a false **"Halted"** — even though the design had actually succeeded.

Three layers, one cohesive fix:

- **C — root cause (sidecar):** the spill is a **resident-VRAM** problem the GPU semaphore can't see (a model stays resident after releasing its token; Kokoro runs on onnxruntime-gpu, invisible to torch metrics). The dangerous combo is the **three-way** active-generation working set + VoiceDesign 1.7B + Kokoro. A new `_VdKokoroArbiter` makes a VoiceDesign forward and a Kokoro synth **mutually exclusive**, and `design_voice` **evicts a resident Kokoro** before the heavy load. Qwen Base generation is **not** gated — it runs at full speed alongside a design; only a mixed-cast generation's Kokoro sentences pause for the few seconds a design holds the lock.
- **B — false "Halted" (server):** the blind 180 s wall-clock abort of `/qwen/design-voice` is now **liveness-aware** — it probes the sidecar `/health` and only aborts when genuinely unreachable, bounded by a 10 min ceiling. A slow-but-alive design extends instead of dying.
- **A — honest indicator (frontend):** the progress bar no longer eases to 92 % and freezes with a hard-coded "about 15s". It shows a **ticking elapsed clock**, flips to an **indeterminate shimmer** past 20 s (reduced-motion–safe), and swaps the copy to **"Taking longer than usual — the GPU may be busy with another job."**

Spec: `docs/superpowers/specs/2026-06-09-voice-design-contention-robustness-design.md`
Plan: `docs/superpowers/plans/2026-06-09-voice-design-contention-robustness.md`

**Out of scope (deliberate):** the underlying variable-shape memory leak — separate, harder, guarded today by the restart ceiling.

## Test plan

- **Sidecar (pytest):** `test_design_kokoro_exclusion.py` — arbiter drain/block/concurrency; Kokoro synth holds the arbiter; design evicts a resident Kokoro + runs under `design()`; Qwen Base synth is **not** gated.
- **Server (vitest):** `evaluateDesignLiveness` continue/unreachable/ceiling (+ both-true→unreachable); bulk-design fast-fail regex matches the new liveness "stopped responding" error (regression test for a cross-layer gap caught in final review).
- **Frontend (vitest + RTL):** ticking clock, ETA copy switch, indeterminate flip, reduced-motion coverage, rendering-phase label.
- **E2E (Playwright):** `voice-design-progress.spec.ts` — the indicator renders honestly through the real drawer/redux/layout seams (fake-clock holds the design in-flight).
- **Full `npm run verify` green locally** (typecheck + all tests + e2e + build).

**Live-GPU acceptance owed (manual):** start a mixed-cast generation, design a Qwen voice mid-generation, confirm via `nvidia-smi` that total VRAM stays under 8 GB (Kokoro evicts, reloads after), no recycle, no "Halted", ticking clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
