### PR TITLE
fix(server): scope confirm-screen narrator matching to same series

### DIFF
--- a/scripts/repair-cross-series-narrator.mjs
+++ b/scripts/repair-cross-series-narrator.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/* Maintenance tool — clear cross-series generic-role (narrator) reuse links
+ * (one-time / dev-only).
+ *
+ * Before the confirm-screen matcher was series-scoped
+ * (server/src/routes/voice-match.ts), a narrator matched against EVERY book's
+ * narrator library-wide — every book carries a "narrator" under the same
+ * deterministic id, so the exact-name match fired across unrelated series and
+ * the tie was broken by arbitrary scan order. `applyVoiceMatches` then
+ * persisted that bad link to cast.json. The forward-fix stops NEW bad matches
+ * but can't retroactively clear what's already on disk (pruneStaleReuseLinks
+ * only runs at analysis time), so this backfill clears the stale data.
+ *
+ * For each book, every generic-role character (id 'narrator', or a name that
+ * normalises to 'narrator') whose `matchedFrom` points to a DIFFERENT
+ * author+series — or to a book that no longer exists — has its link reverted
+ * to a fresh voice, mirroring the server's clearStaleLink: drop matchedFrom +
+ * matchFactors always; for a pure 'reused' row, also revert voiceId -> id,
+ * voiceState -> 'generated', and drop the denormalised override voice +
+ * voiceStyle + ttsEngine. A tuned/locked narrator keeps its user-owned voice
+ * and only loses the dead badge.
+ *
+ * Same-series narrator reuse is LEFT intact — that's legitimate continuity the
+ * analysis-time linker (series-reuse-link.ts) owns.
+ *
+ * Usage:
+ *   node scripts/repair-cross-series-narrator.mjs           # dry run (no writes)
+ *   node scripts/repair-cross-series-narrator.mjs --apply   # write cast.json via PUT
+ * Env: BASE (default http://localhost:8080). Requires the dev server running,
+ * AND already running the series-scoped voice-match fix — otherwise re-opening
+ * a book's confirm view will re-stamp the link you just cleared. Back up first
+ * (the casts are mutated): GET /api/books/:id/state per book.
+ */
+const BASE = process.env.BASE ?? 'http://localhost:8080';
+const APPLY = process.argv.includes('--apply');
+
+const norm = (s) => (s ?? '').trim().toLowerCase();
+/* Generic role-names — mirror server/src/routes/voice-match.ts isGenericRole. */
+const GENERIC_ROLE_IDS = new Set(['narrator']);
+const isGenericRole = (c) => GENERIC_ROLE_IDS.has(c.id) || norm(c.name) === 'narrator';
+
+const lib = await (await fetch(`${BASE}/api/library`)).json();
+
+/* bookId -> { author, series, title } across the WHOLE library, so a link's
+   target can be resolved to its (author, series) regardless of which series
+   we're currently walking. */
+const meta = new Map();
+for (const author of lib.authors ?? []) {
+  for (const series of author.series ?? []) {
+    for (const b of series.books ?? []) {
+      meta.set(b.bookId, { author: author.name, series: series.name, title: b.title });
+    }
+  }
+}
+
+let totalCleared = 0;
+
+for (const author of lib.authors ?? []) {
+  for (const series of author.series ?? []) {
+    for (const book of series.books ?? []) {
+      const st = await (
+        await fetch(`${BASE}/api/books/${encodeURIComponent(book.bookId)}/state`)
+      ).json();
+      const characters = st.cast?.characters ?? [];
+
+      const clears = [];
+      const next = characters.map((c) => {
+        if (!isGenericRole(c) || !c.matchedFrom?.bookId) return c;
+        const target = meta.get(c.matchedFrom.bookId);
+        const sameSeries =
+          !!target && target.author === author.name && target.series === series.name;
+        if (sameSeries) return c; // legitimate same-series narrator reuse — keep
+        clears.push({
+          charId: c.id,
+          charName: c.name,
+          target: target ? `${target.series} / ${c.matchedFrom.characterId}` : '(missing book)',
+        });
+        /* Mirror clearStaleLink (series-reuse-link.ts). */
+        const out = { ...c };
+        delete out.matchedFrom;
+        delete out.matchFactors;
+        if (c.voiceState === 'reused') {
+          out.voiceId = c.id;
+          out.voiceState = 'generated';
+          delete out.overrideTtsVoices;
+          delete out.voiceStyle;
+          delete out.ttsEngine;
+        }
+        return out;
+      });
+
+      if (clears.length === 0) continue;
+      console.log(`\n=== ${author.name} / ${series.name} / ${book.title} ===`);
+      for (const cl of clears) {
+        console.log(`  CLEAR ${cl.charName} (${cl.charId}) → was linked to ${cl.target}`);
+      }
+      totalCleared += clears.length;
+
+      if (APPLY) {
+        const res = await fetch(`${BASE}/api/books/${encodeURIComponent(book.bookId)}/state`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ slice: 'cast', patch: { characters: next } }),
+        });
+        console.log(`  [apply] PUT ${res.status}`);
+      }
+    }
+  }
+}
+
+console.log(`\nTOTAL cross-series narrator links ${APPLY ? 'cleared' : 'to clear'}: ${totalCleared}`);
+console.log(APPLY ? 'APPLIED.' : 'DRY RUN (no writes). Re-run with --apply to write.');

--- a/server/src/routes/voice-match.test.ts
+++ b/server/src/routes/voice-match.test.ts
@@ -101,6 +101,9 @@ beforeAll(async () => {
         gender: 'female',
         ageRange: 'teen',
       },
+      /* Same-series narrator — the legitimate reuse target for a later
+         Keeper book's narrator. */
+      { id: 'narrator', name: 'Narrator', voiceId: 'v_narr_kotlc', gender: 'neutral' },
     ],
     true,
   );
@@ -143,6 +146,20 @@ beforeAll(async () => {
     makeBookId(AUTHOR, SERIES, 'Book Three Unconfirmed'),
     [{ id: 'fitz', name: 'Fitz', voiceId: 'v_fitz_wip', gender: 'male', ageRange: 'teen' }],
     false,
+  );
+
+  /* A DIFFERENT author + series, confirmed, with its own narrator. Every
+     book's narrator shares the deterministic id/name "narrator", so a
+     library-wide exact-name match would let this unrelated-series narrator
+     surface as a candidate for a Keeper book's narrator. It must not. */
+  writeBookOnDisk(
+    workspaceRoot,
+    'Derek Landy',
+    'Skulduggery Pleasant',
+    'Scepter of the Ancients',
+    makeBookId('Derek Landy', 'Skulduggery Pleasant', 'Scepter of the Ancients'),
+    [{ id: 'narrator', name: 'Narrator', voiceId: 'v_narr_skul', gender: 'neutral' }],
+    true,
   );
 
   app = express();
@@ -357,5 +374,36 @@ describe('voice-match router', () => {
     expect(res.body.matches[0].candidates.length).toBeGreaterThan(0); // keefe matched
     expect(res.body.matches[1].candidates).toEqual([]); // nobody empty
     expect(res.body.matches[2].candidates.length).toBeGreaterThan(0); // sophie matched
+  });
+
+  it('generic role (narrator) only matches within the same series', async () => {
+    /* Call as Book Two (Keeper of the Lost Cities). The library holds two
+       narrators: Book One's (same series, v_narr_kotlc) and Scepter of the
+       Ancients' (Skulduggery Pleasant, v_narr_skul). Both are an exact
+       name match, but a narrator is only legitimately reused within its
+       own series — the cross-series one must be excluded. */
+    const bookTwoId = makeBookIdFn(AUTHOR, SERIES, 'Book Two');
+    const res = await callMatch(bookTwoId, {
+      characters: [{ id: 'narrator', name: 'Narrator', attributes: [], gender: 'neutral' }],
+    });
+    expect(res.status).toBe(200);
+    const voiceIds = res.body.matches[0].candidates.map((c: { voiceId: string }) => c.voiceId);
+    expect(voiceIds).toContain('v_narr_kotlc'); // same-series narrator surfaces
+    expect(voiceIds).not.toContain('v_narr_skul'); // cross-series narrator excluded
+  });
+
+  it('a real named character still matches library-wide across series', async () => {
+    /* The series scope applies ONLY to generic role-names. A genuinely
+       recurring character keeps matching against the whole library — here
+       Keefe still matches the Keeper-series Keefe from a Skulduggery-series
+       book, because reusing a designed voice across the library is the
+       intended feature. */
+    const scepterId = makeBookIdFn('Derek Landy', 'Skulduggery Pleasant', 'Scepter of the Ancients');
+    const res = await callMatch(scepterId, {
+      characters: [{ id: 'keefe', name: 'Keefe', attributes: [], gender: 'male', ageRange: 'teen' }],
+    });
+    expect(res.status).toBe(200);
+    const voiceIds = res.body.matches[0].candidates.map((c: { voiceId: string }) => c.voiceId);
+    expect(voiceIds).toContain('v_keefe'); // cross-series named char still matches
   });
 });

--- a/server/src/routes/voice-match.ts
+++ b/server/src/routes/voice-match.ts
@@ -32,9 +32,24 @@ import {
   scanLibraryCharacters,
   type LibraryCharacterRecord,
 } from '../workspace/library-cast-scan.js';
+import { scanSeriesCharactersForBookId } from '../workspace/series-cast-scan.js';
 import { jaccard, nameTokens, normaliseForMatch } from '../util/text-match.js';
 
 export const voiceMatchRouter = Router();
+
+/* Generic role-names exist in every book under the same deterministic id
+   (the narrator keeps voiceId/id 'narrator' across the whole library), so a
+   library-wide exact-name match fires against EVERY book's narrator — a
+   Skulduggery narrator claiming a Keeper narrator, with the tie broken by
+   arbitrary scan order. Unlike a real recurring character, a narrator is only
+   legitimately reused WITHIN its series, where the analysis-time linker
+   (series-reuse-link.ts) already handles continuity. So generic-role
+   candidates are scoped to the current book's series; everything else keeps
+   matching library-wide (designed-voice reuse across books is intentional). */
+const GENERIC_ROLE_IDS = new Set(['narrator']);
+function isGenericRole(c: CharacterMatchInput): boolean {
+  return GENERIC_ROLE_IDS.has(c.id) || normaliseForMatch(c.name) === 'narrator';
+}
 
 export interface CharacterMatchInput {
   id: string;
@@ -282,9 +297,21 @@ voiceMatchRouter.post('/:bookId/voice-match', async (req: Request, res: Response
       voices.push(v);
     }
 
+    /* Same-series bookIds for generic-role scoping. Resolves the current
+       book's (author, series) and lists its confirmed series-mates; empty
+       when the book is standalone, earliest, or not yet on disk — in which
+       case a narrator legitimately matches nothing. */
+    const seriesMateBookIds = new Set(
+      (await scanSeriesCharactersForBookId(bookId)).map((r) => r.bookId),
+    );
+
     const matches = characters.map((c) => {
+      const generic = isGenericRole(c);
       const scored: Candidate[] = [];
       for (const v of voices) {
+        /* A narrator only reuses within its own series; a real character
+           keeps matching library-wide. */
+        if (generic && !seriesMateBookIds.has(v.bookId)) continue;
         const cand = scoreOne(c, v);
         if (cand) scored.push(cand);
       }


### PR DESCRIPTION
## Summary

The confirm-screen matcher (`POST /voice-match`) scanned the **whole library** with no series scoping, so a generic role-name like the narrator — named "Narrator" with id `narrator` in every book — exact-matched (score 1.0) against every other book's narrator, the tie broken by arbitrary scan order. A Skulduggery narrator could claim a Keeper narrator. Distinct from the analysis-time linker (`series-reuse-link.ts`), which is already same-author+series scoped — that earlier fix (PR #634) never touched this path.

Generic-role incoming characters (id `narrator`, or a name that normalises to `narrator`) now match only candidates from the current book's series, via `scanSeriesCharactersForBookId`. Real named characters still match library-wide — designed-voice reuse across books is intentional.

Includes `scripts/repair-cross-series-narrator.mjs` to clear links already persisted by `applyVoiceMatches` (the forward-fix can't retroactively clear on-disk data; `pruneStaleReuseLinks` only runs at analysis time). Run after deploy: dry-run, then `--apply`.

## Test plan

- New regression tests in `voice-match.test.ts`: a narrator matches only its same-series counterpart (failing-first → green), and a real character still matches across series.
- Local (server-only diff): typecheck clean, `test:server` 2407 pass, `test:server-slow` 203 pass, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)