### PR TITLE
fix(server,frontend): scope cast Voice library "Series" tab to the open book's series

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3708,6 +3708,15 @@ components:
           type: string
           enum: [current, library]
           description: "'current' when the voice belongs to the currently-open book; 'library' otherwise."
+        inCurrentSeries:
+          type: boolean
+          description: >-
+            True when this voice belongs to a book in the currently-open book's
+            (author, series) — including the open book itself. Absent/false when
+            no book is open or the open book is a standalone (a standalone has no
+            series continuity). The cast view's "Series" tab scopes to
+            `source === 'library' && inCurrentSeries`, so it shows only this
+            series' siblings rather than every other book in the workspace.
         reusable:
           {
             type: boolean,

--- a/server/src/routes/voices.test.ts
+++ b/server/src/routes/voices.test.ts
@@ -36,6 +36,7 @@ function writeBookOnDisk(
   title: string,
   bookId: string,
   characters: object[],
+  isStandalone = false,
 ) {
   const bookDir = join(workspace, 'books', author, series, title);
   mkdirSync(join(bookDir, '.audiobook'), { recursive: true });
@@ -48,7 +49,7 @@ function writeBookOnDisk(
       author,
       series,
       seriesPosition: null,
-      isStandalone: false,
+      isStandalone,
       manuscriptFile: 'manuscript.txt',
       castConfirmed: true,
       chapters: [],
@@ -479,6 +480,103 @@ describe('GET /api/voices?engine=qwen — generated flag', () => {
     const res = await request(app).get('/api/voices?engine=coqui');
     const keefe = res.body.voices.find((v: { id: string }) => v.id === 'v_keefe');
     expect(keefe.sampled).toBeUndefined();
+  });
+});
+
+describe('GET /api/voices?currentBookId — inCurrentSeries scoping', () => {
+  /* A self-contained author with: a two-book series (Trilogy), a same-author
+     spinoff in a DIFFERENT series, and a standalone. Distinct voiceIds per
+     book so each voice's source/inCurrentSeries can be asserted cleanly,
+     independent of the v_fitz aggregation above. The "Series" tab in the
+     cast view filters on `inCurrentSeries`, so a standalone's tab must come
+     up empty and a series book's tab must show only its own series' siblings
+     — not every other book in the workspace. */
+  const C_AUTHOR = 'Coast Author';
+  const C_SERIES = 'Trilogy';
+  const C_SPINOFF_SERIES = 'Spinoff Series';
+  let bookAId: string;
+  let bookBId: string;
+  let spinoffId: string;
+  let standaloneId: string;
+
+  beforeAll(async () => {
+    const paths = await import('../workspace/paths.js');
+    bookAId = paths.makeBookId(C_AUTHOR, C_SERIES, 'Book A');
+    bookBId = paths.makeBookId(C_AUTHOR, C_SERIES, 'Book B');
+    spinoffId = paths.makeBookId(C_AUTHOR, C_SPINOFF_SERIES, 'Spinoff');
+    standaloneId = paths.makeBookId(C_AUTHOR, 'Standalones', 'Lone Tale');
+    const mkChar = (id: string, name: string, voiceId: string) => ({
+      id,
+      name,
+      role: 'role',
+      color: 'magenta',
+      voiceId,
+      gender: 'female',
+      ageRange: 'adult',
+      attributes: ['Female'],
+      lines: 10,
+      scenes: 1,
+    });
+    writeBookOnDisk(workspaceRoot, C_AUTHOR, C_SERIES, 'Book A', bookAId, [
+      mkChar('char-alpha', 'Alpha', 'v_alpha'),
+    ]);
+    writeBookOnDisk(workspaceRoot, C_AUTHOR, C_SERIES, 'Book B', bookBId, [
+      mkChar('char-beta', 'Beta', 'v_beta'),
+    ]);
+    writeBookOnDisk(workspaceRoot, C_AUTHOR, C_SPINOFF_SERIES, 'Spinoff', spinoffId, [
+      mkChar('char-gamma', 'Gamma', 'v_gamma'),
+    ]);
+    writeBookOnDisk(
+      workspaceRoot,
+      C_AUTHOR,
+      'Standalones',
+      'Lone Tale',
+      standaloneId,
+      [mkChar('char-lone', 'Lone', 'v_lone')],
+      true /* isStandalone */,
+    );
+  });
+
+  const find = (voices: Array<{ id: string }>, id: string) =>
+    voices.find((v) => v.id === id) as
+      | { id: string; source: string; inCurrentSeries?: boolean }
+      | undefined;
+
+  it('flags a sibling-series voice inCurrentSeries when a series book is open', async () => {
+    const res = await request(app).get(`/api/voices?currentBookId=${bookAId}`);
+    expect(res.status).toBe(200);
+    const beta = find(res.body.voices, 'v_beta');
+    expect(beta).toBeDefined();
+    /* Beta lives only in the sibling Book B — not the open book — so it's a
+       library voice, but it IS in the open book's series. */
+    expect(beta!.source).toBe('library');
+    expect(beta!.inCurrentSeries).toBe(true);
+    /* The open book's own voice is 'current'. */
+    expect(find(res.body.voices, 'v_alpha')!.source).toBe('current');
+  });
+
+  it('does NOT flag a same-author different-series voice as inCurrentSeries', async () => {
+    const res = await request(app).get(`/api/voices?currentBookId=${bookAId}`);
+    const gamma = find(res.body.voices, 'v_gamma');
+    expect(gamma!.source).toBe('library');
+    /* Same author, different series → must stay out of the Series tab. */
+    expect(gamma!.inCurrentSeries).toBeFalsy();
+  });
+
+  it('flags no voice inCurrentSeries when the open book is a standalone', async () => {
+    const res = await request(app).get(`/api/voices?currentBookId=${standaloneId}`);
+    expect(res.status).toBe(200);
+    /* Sibling-series voices exist in the workspace, but the open standalone
+       has no series, so the cast view's Series tab must come up empty. */
+    expect(find(res.body.voices, 'v_beta')!.inCurrentSeries).toBeFalsy();
+    expect(find(res.body.voices, 'v_alpha')!.inCurrentSeries).toBeFalsy();
+    /* The standalone's own voice is still 'current'. */
+    expect(find(res.body.voices, 'v_lone')!.source).toBe('current');
+  });
+
+  it('flags no voice inCurrentSeries when no book is open', async () => {
+    const res = await request(app).get('/api/voices');
+    expect(find(res.body.voices, 'v_beta')!.inCurrentSeries).toBeFalsy();
   });
 });
 

--- a/server/src/routes/voices.ts
+++ b/server/src/routes/voices.ts
@@ -84,6 +84,13 @@ interface DerivedVoice {
   gradient: [string, string];
   usedIn: number;
   source: 'current' | 'library';
+  /** True when this voice belongs to a book in the currently-open book's
+      (author, series) — including the open book itself. Always falsy when no
+      book is open or the open book is a standalone (a standalone has no
+      series continuity). Drives the cast view's "Series" tab, which scopes to
+      `source === 'library' && inCurrentSeries` so it shows only this series'
+      siblings rather than every other book in the workspace. */
+  inCurrentSeries?: boolean;
   reusable?: boolean;
   pinned?: boolean;
   /** True when this voice has rendered chapter audio at least once.
@@ -200,6 +207,11 @@ async function aggregateVoices(
      usedIn aggregates across every book that contains the same voiceId). */
   const acc = new Map<string, DerivedVoice & { books: Set<string> }>();
 
+  /* bookId → its (author, series, isStandalone), recorded for every book that
+     contributes voices. Used after the scan to resolve which voices belong to
+     the open book's series (the `inCurrentSeries` flag). */
+  const bookMeta = new Map<string, { author: string; series: string; isStandalone: boolean }>();
+
   /* One memoised cast loader for reused-voice hydration, shared across every
      book scanned below so each source book's cast.json is read at most once
      (many reused characters across the series resolve to the same source). */
@@ -224,6 +236,12 @@ async function aggregateVoices(
         if (!state || !state.castConfirmed) continue;
         const cast = await readJson<CastJson>(castJsonPath(bookDir));
         if (!cast?.characters?.length) continue;
+
+        bookMeta.set(state.bookId, {
+          author: state.author,
+          series: state.series,
+          isStandalone: state.isStandalone === true,
+        });
 
         /* Hydrate reused characters' bespoke voice from their source book so the
            ttsVoice assignment below reflects the DESIGNED voice, not the empty
@@ -343,6 +361,28 @@ async function aggregateVoices(
           });
         }
       }
+    }
+  }
+
+  /* Resolve the open book's series (null when no book is open, the book has
+     no derived voices, or it's a standalone), then flag every voice that
+     shares that (author, series). The cast view's Series tab reads this so a
+     standalone never surfaces an unrelated series' cast. */
+  const cur = currentBookId ? bookMeta.get(currentBookId) : undefined;
+  const currentSeries =
+    cur && !cur.isStandalone ? { author: cur.author, series: cur.series } : null;
+  if (currentSeries) {
+    for (const voice of acc.values()) {
+      const inSeries = Array.from(voice.books).some((bid) => {
+        const m = bookMeta.get(bid);
+        return (
+          !!m &&
+          !m.isStandalone &&
+          m.author === currentSeries.author &&
+          m.series === currentSeries.series
+        );
+      });
+      if (inSeries) voice.inCurrentSeries = true;
     }
   }
 

--- a/src/components/voice-library-panel.test.tsx
+++ b/src/components/voice-library-panel.test.tsx
@@ -81,13 +81,14 @@ describe('VoiceLibraryPanel — Cast-view interactions', () => {
     const onPlaySample = vi.fn();
     /* A voice from another book in the series — no character in the
        current book uses it, so the panel should not synthesise a drawer
-       or sample target. The library tab is "library" because that's what
-       series voices use; switch to All so the test sees it. */
+       or sample target. It's `inCurrentSeries` so the panel defaults to the
+       "Series" tab and the card is visible without switching tabs. */
     render(
       <VoiceLibraryPanel
         library={[
           makeVoice('v_series', 'Other-book speaker', {
             source: 'library',
+            inCurrentSeries: true,
             bookTitle: 'Earlier Book',
             bookId: 'eb',
           }),
@@ -337,7 +338,12 @@ describe('VoiceLibraryPanel — search', () => {
        the name matches — the tab filter runs before the query. */
     const mixed: Voice[] = [
       makeVoice('v_keefe', 'Keefe Sencen', { source: 'current' }),
-      makeVoice('v_ro', 'Ro', { source: 'library', bookTitle: 'Flashback', bookId: 'fb' }),
+      makeVoice('v_ro', 'Ro', {
+        source: 'library',
+        inCurrentSeries: true,
+        bookTitle: 'Flashback',
+        bookId: 'fb',
+      }),
     ];
     render(
       <VoiceLibraryPanel library={mixed} draggingVoiceId={null} setDraggingVoiceId={vi.fn()} />,
@@ -374,5 +380,90 @@ describe('VoiceLibraryPanel — search', () => {
     });
     expect(screen.getByText(/No voices match/)).toBeInTheDocument();
     expect(screen.queryByText('Keefe Sencen')).toBeNull();
+  });
+});
+
+describe('VoiceLibraryPanel — Series tab scoping & default tab', () => {
+  /* The cast view's "Series" tab must scope to the open book's series
+     (`source === 'library' && inCurrentSeries`), not every other book in the
+     workspace. The default tab is context-aware: a series book opens on
+     "Series", a standalone opens on "This book". */
+  const thisBook = makeVoice('v_self', 'Captain Halloran', { source: 'current' });
+  const sibling = makeVoice('v_sib', 'Series Sibling', {
+    source: 'library',
+    inCurrentSeries: true,
+    bookTitle: 'Solway Bay',
+    bookId: 'sb',
+  });
+  const otherSeries = makeVoice('v_other', 'Unrelated Voice', {
+    source: 'library',
+    bookTitle: 'Some Other Book',
+    bookId: 'xx',
+  });
+
+  it('hides the Series tab and defaults to "This book" for a standalone (no series voices)', () => {
+    render(
+      <VoiceLibraryPanel
+        library={[thisBook, otherSeries]}
+        draggingVoiceId={null}
+        setDraggingVoiceId={vi.fn()}
+      />,
+    );
+    /* No series voices → no Series tab. */
+    expect(screen.queryByRole('button', { name: 'Series' })).toBeNull();
+    /* Defaults to "This book": shows the current-book voice, hides the
+       unrelated workspace voice (which only lives under "All"). */
+    expect(screen.getByText('Captain Halloran')).toBeInTheDocument();
+    expect(screen.queryByText('Unrelated Voice')).toBeNull();
+    /* The "All" tab still surfaces every workspace voice. */
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    expect(screen.getByText('Unrelated Voice')).toBeInTheDocument();
+  });
+
+  it('shows the Series tab and defaults to it for a series book', () => {
+    render(
+      <VoiceLibraryPanel
+        library={[thisBook, sibling, otherSeries]}
+        draggingVoiceId={null}
+        setDraggingVoiceId={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Series' })).toBeInTheDocument();
+    /* Defaults to "Series": shows only the in-series sibling, not the
+       current-book voice nor the unrelated-series voice. */
+    expect(screen.getByText('Series Sibling')).toBeInTheDocument();
+    expect(screen.queryByText('Captain Halloran')).toBeNull();
+    expect(screen.queryByText('Unrelated Voice')).toBeNull();
+  });
+
+  it('keeps an out-of-series library voice off the Series tab', () => {
+    render(
+      <VoiceLibraryPanel
+        library={[thisBook, sibling, otherSeries]}
+        draggingVoiceId={null}
+        setDraggingVoiceId={vi.fn()}
+      />,
+    );
+    /* Already on Series by default — the unrelated workspace voice must not
+       appear even though it's a `source: 'library'` voice. */
+    expect(screen.queryByText('Unrelated Voice')).toBeNull();
+    /* It IS reachable from the "All" tab. */
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    expect(screen.getByText('Unrelated Voice')).toBeInTheDocument();
+  });
+
+  it('respects a manual tab pick even after the auto-default would change', () => {
+    /* User clicks "This book" on a series book; the panel must not yank them
+       back to "Series". */
+    render(
+      <VoiceLibraryPanel
+        library={[thisBook, sibling]}
+        draggingVoiceId={null}
+        setDraggingVoiceId={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'This book' }));
+    expect(screen.getByText('Captain Halloran')).toBeInTheDocument();
+    expect(screen.queryByText('Series Sibling')).toBeNull();
   });
 });

--- a/src/components/voice-library-panel.tsx
+++ b/src/components/voice-library-panel.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { IconStar, IconDrag, IconCheck, IconSearch } from '../lib/icons';
 import { VoiceSwatch, Pill } from './primitives';
 import type { Character, Voice } from '../lib/types';
@@ -46,15 +46,48 @@ export function VoiceLibraryPanel({
   onTapAssign,
   assigningVoiceId,
 }: VoiceLibraryPanelProps) {
-  const [tab, setTab] = useState<Tab>('all');
   const [query, setQuery] = useState('');
+  /* Whether any voice belongs to the open book's series (a sibling book — the
+     `source === 'library'` half — that shares its author + series). The server
+     tags these `inCurrentSeries`. A standalone (or a one-book series) has none,
+     so the "Series" tab is meaningless and we hide it rather than surface an
+     empty / wrong-series tab. */
+  const hasSeriesVoices = useMemo(
+    () => library.some((v) => v.source === 'library' && v.inCurrentSeries),
+    [library],
+  );
+  /* Context-aware default: a series book opens on its "Series" tab (the
+     siblings available to reuse); a standalone opens on "This book". The tab
+     stays auto-driven until the user picks one — and `library` often arrives
+     async, so re-derive when the series signal flips (the ref keeps a manual
+     pick from being overwritten when voices load in). */
+  const [tab, setTab] = useState<Tab>('current');
+  const userPickedRef = useRef(false);
+  useEffect(() => {
+    if (userPickedRef.current) return;
+    setTab(hasSeriesVoices ? 'library' : 'current');
+  }, [hasSeriesVoices]);
+  const pickTab = (t: Tab) => {
+    userPickedRef.current = true;
+    setTab(t);
+  };
+  /* Guard against a selected 'library' tab that no longer exists (voices
+     changed out from under it) — fall back to "This book" for filtering and
+     the active-state highlight. */
+  const activeTab: Tab = tab === 'library' && !hasSeriesVoices ? 'current' : tab;
   /* Tab filter first, then a case-insensitive substring match on the two
      fields a card actually shows (character name + book title). With 75+
      voices the tabs alone don't make a single character findable, so the
      search box is the primary on-ramp on a long series. */
   const q = query.trim().toLowerCase();
   const filtered = library
-    .filter((v) => tab === 'all' || v.source === tab)
+    .filter((v) => {
+      if (activeTab === 'all') return true;
+      if (activeTab === 'current') return v.source === 'current';
+      /* 'library' tab is labelled "Series": only this book's series siblings,
+         not every other book in the workspace. */
+      return v.source === 'library' && !!v.inCurrentSeries;
+    })
     .filter(
       (v) =>
         !q ||
@@ -65,7 +98,7 @@ export function VoiceLibraryPanel({
   const tabs: Array<{ id: Tab; label: string }> = [
     { id: 'all', label: 'All' },
     { id: 'current', label: 'This book' },
-    { id: 'library', label: 'Series' },
+    ...(hasSeriesVoices ? [{ id: 'library' as Tab, label: 'Series' }] : []),
   ];
   const findCharacter = (v: Voice) =>
     characters ? findCharacterForVoice(v, characters) : undefined;
@@ -95,8 +128,8 @@ export function VoiceLibraryPanel({
           {tabs.map((t) => (
             <button
               key={t.id}
-              onClick={() => setTab(t.id)}
-              className={`flex-1 px-2 py-1 rounded-full font-medium transition-colors ${tab === t.id ? 'bg-white text-ink shadow-card' : 'text-ink/60'}`}
+              onClick={() => pickTab(t.id)}
+              className={`flex-1 px-2 py-1 rounded-full font-medium transition-colors ${activeTab === t.id ? 'bg-white text-ink shadow-card' : 'text-ink/60'}`}
             >
               {t.label}
             </button>

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -2809,6 +2809,8 @@ export interface components {
              * @enum {string}
              */
             source: "current" | "library";
+            /** @description True when this voice belongs to a book in the currently-open book's (author, series) — including the open book itself. Absent/false when no book is open or the open book is a standalone (a standalone has no series continuity). The cast view's "Series" tab scopes to `source === 'library' && inCurrentSeries`, so it shows only this series' siblings rather than every other book in the workspace. */
+            inCurrentSeries?: boolean;
             /** @description Marker for narrator-like voices that span an entire book. */
             reusable?: boolean;
             /** @description Workspace-level pin flag from audiobook-workspace/voices.json. */

--- a/src/mocks/voices.ts
+++ b/src/mocks/voices.ts
@@ -76,6 +76,7 @@ export const MOCK_VOICE_LIBRARY: VoiceLibraryResponse = {
       attributes: ['Neutral', 'Mid-tempo', 'Mid-Atlantic', 'Warm'],
       usedIn: 11,
       source: 'library',
+      inCurrentSeries: true,
       reusable: true,
       ttsVoice: tts('Sulafat', 'Warm'),
     }),
@@ -120,6 +121,7 @@ export const MOCK_VOICE_LIBRARY: VoiceLibraryResponse = {
       attributes: ['Male', 'Bass', 'Scottish', '70s', 'Weathered'],
       usedIn: 1,
       source: 'library',
+      inCurrentSeries: true,
       ttsVoice: tts('Algieba', 'Smooth'),
     }),
     withGradient({
@@ -131,6 +133,7 @@ export const MOCK_VOICE_LIBRARY: VoiceLibraryResponse = {
       attributes: ['Female', 'Soprano', 'RP English', '60s', 'Crisp'],
       usedIn: 1,
       source: 'library',
+      inCurrentSeries: true,
       ttsVoice: tts('Aoede', 'Breezy'),
     }),
     withGradient({
@@ -142,6 +145,7 @@ export const MOCK_VOICE_LIBRARY: VoiceLibraryResponse = {
       attributes: ['Male', 'Treble', 'Scottish', '12', 'Curious'],
       usedIn: 1,
       source: 'library',
+      inCurrentSeries: true,
       ttsVoice: tts('Sadachbia', 'Lively'),
     }),
     withGradient({
@@ -208,6 +212,7 @@ export const MOCK_VOICE_LIBRARY: VoiceLibraryResponse = {
       attributes: ['Male', 'Bright', 'Young'],
       usedIn: 1,
       source: 'library',
+      inCurrentSeries: true,
       overrideTtsVoices: { qwen: { name: 'qwen-finch' } },
       generated: true,
       // designed AND rendered → "Designed voices" with a Generated badge

--- a/src/views/cast.test.tsx
+++ b/src/views/cast.test.tsx
@@ -86,6 +86,9 @@ const library: Voice[] = [
     gradient: ['#E5B69C', '#C77B5C'],
     usedIn: 2,
     source: 'library',
+    /* A sibling-series voice available to reuse — so the panel surfaces it on
+       its default "Series" tab (the cast view's whole reuse affordance). */
+    inCurrentSeries: true,
     ttsVoice: {
       provider: 'coqui',
       name: 'Aaron Dreschner',


### PR DESCRIPTION
## Summary

The cast-view Voice library tabbed **All / This book / Series**, but the data had no concept of "series". `aggregateVoices` tagged every voice with a binary `source` (`current` = open book, `library` = literally every other book in the workspace), and the panel relabelled `source: 'library'` as **Series**. So a **standalone** book surfaced an entire unrelated series under its Series tab, and the default tab was hardcoded to `all` regardless of standalone-vs-series.

- **Server** — `aggregateVoices` resolves the open book's `(author, series, isStandalone)` and stamps `inCurrentSeries` on every voice belonging to a book in that same series (standalones never match; no open book / open standalone = nothing flagged).
- **OpenAPI** — added `inCurrentSeries` to the `Voice` schema; regenerated `api-types.ts`.
- **Panel** — the Series tab filters `source === 'library' && inCurrentSeries`, is **hidden** when the book has no series voices, and the default tab is **context-aware** (Series for a series book, This book for a standalone) — reactive to async voice load with a user-pick guard.

Single consumer of the tabbed panel is the cast view; the global `#/voices` page uses `VoiceCard` directly and is untouched. `source` stays binary so `cast.tsx`'s reused/tuned logic is unchanged.

## Test plan

- `server/src/routes/voices.test.ts` — new `inCurrentSeries scoping` describe: sibling-series ✔, same-author-other-series ✗, standalone open book ✗, no open book ✗.
- `src/components/voice-library-panel.test.tsx` — new `Series tab scoping & default tab` describe (hidden + This-book default for standalone; Series default + sibling-only for a series book; out-of-series library voice stays off Series; manual pick respected). Updated existing fixtures to tag `inCurrentSeries`.
- `src/mocks/voices.ts` + `src/views/cast.test.tsx` fixtures tagged `inCurrentSeries`.
- `npm run verify` green locally (typecheck + all test tiers + e2e + lint + a11y + build).

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)
