### PR TITLE
fix(frontend): scope-picker variant count spans the whole Qwen cast

### DIFF
--- a/docs/features/201-cast-bulk-emotion-variants.md
+++ b/docs/features/201-cast-bulk-emotion-variants.md
@@ -65,26 +65,38 @@ The existing "Design full cast" button **no longer fires immediately** — it op
 `DesignScopePicker` (`src/components/design-scope-picker.tsx`), a popover with
 three rows:
 
-| Scope | Work count | Action |
+| Scope | Work count badge | Action |
 |---|---|---|
-| **Base voices** | characters with lifecycle `Needs voice` | bases only (today's behaviour) |
-| **Emotion variants** | Σ demanded-but-missing variants across Qwen cast | variants only |
-| **Both** | bases + their needed variants | bases first, then variants |
+| **Base voices** | characters with lifecycle `Needs voice` | bases only |
+| **Emotion variants** | Σ demanded-but-missing variants across the **whole** Qwen cast (total), with a `✓ N ready now · ⚠ M need a base` split underneath | variants only — ships the *ready* tasks; disabled until ≥1 is ready, with a loud "needs a base first — use Both" warning |
+| **Both** | bases + every needed variant | bases first, then variants |
 
 A scope with zero work is disabled with a green "all done" chip. Selecting a scope
 dispatches `castDesignActions.designAllRequested({ scope, characterIds, variantTasks })`.
 
-**Work-list computation.** `buildVariantTasks` (`src/lib/variant-tasks.ts`) iterates
-the cast: for each Qwen character that HAS a base voice, emits the in-use emotions
-that lack a designed variant. `variantWorkCounts` gives the picker its count. The
-list is computed at dispatch time and passed to the server as `variantTasks` in the
-POST body — the server re-validates freshness (already-designed = skip, missing-base
-= skip) to avoid clobbering concurrent work.
+**Count = the whole Qwen cast (matches the rows).** `buildVariantTasks`
+(`src/lib/variant-tasks.ts`) takes an `isQwen` predicate from the caller; the cast
+view passes the SAME predicate its "Needs variants" chip and glyph strips use
+(effective project engine OR a matched Qwen library voice), so the picker total can
+never disagree with the rows. For each matching character it emits the in-use
+emotions lacking a designed variant, tagging each task `hasBase` (= the character
+already has a designed `qwen.name`, mirroring the server's design gate).
+`variantWorkCounts` splits the list into `{ totalTasks, readyTasks, blockedTasks,
+blockedChars }` for the "40 total · 5 ready · 35 need a base" display.
 
-**Dependency rule.** Under `variants` scope, a character still missing its base
-voice is silently skipped (the base must exist before a variant can be designed).
-Under `both`, the character's base is designed first and its variant tasks follow.
-`buildTaskList` in `cast-design.ts` enforces the base-before-variant ordering.
+> **Fix (2026-06-10):** the shipped build gated `buildVariantTasks` on
+> `isQwenWithBase`, so the picker counted only already-voiced characters (e.g. 5)
+> while the cast rows' "Needs variants" chip counted the whole emotion cast (e.g.
+> 16) — the two surfaces disagreed and "Both" undercounted. The count now spans the
+> whole Qwen cast, as the table above always intended.
+
+**Dependency rule.** Under `variants` scope the picker ships ONLY the `hasBase`
+(ready) tasks: a baseless character is still **counted** in the total (so the badge
+matches the cast rows) but **excluded** from the dispatch, with a loud warning that
+it needs a base first; the row is disabled until ≥1 task is ready. Under `both`,
+every task is shipped and `buildTaskList` (`cast-design.ts`) designs each
+character's base before its variants. The server still defensively skips a variant
+whose base is missing (belt-and-braces against a stale client).
 
 **Server execution.** `cast-design.ts` receives the unified task list. Each task
 routes through `withDesignLock` + `gpuSemaphore` (unchanged). For a variant task
@@ -144,11 +156,12 @@ loaded sentences). This means:
 - `VariantGlyphStrip` renders **nothing** (or the quiet "no emotion tags" hint)
   for non-Qwen characters — variants are Qwen-only. Guard at `ttsEngine === 'qwen'`
   in `cast.tsx` before passing props.
-- `buildVariantTasks` (and therefore the `variantTasks` sent to the server) includes
-  ONLY Qwen characters that **have a base voice** (`overrideTtsVoices?.qwen?.name`
-  truthy). A character without a base is excluded from the `variants` task list; it
-  only appears under `both` as a base task (and only gets variant tasks once the base
-  is in place).
+- `buildVariantTasks` **counts** every Qwen-effective character with demanded-but-
+  missing variants (the picker total must match the cast rows' "Needs variants" chip),
+  tagging each task `hasBase`. The `variantTasks` **dispatched** are scope-dependent:
+  `variants` ships only `hasBase` tasks (a baseless character is counted but excluded,
+  with a loud warning); `both` ships every task and designs the base first. A baseless
+  character only gets its variants once its base is in place (via `both`).
 - The server's `runDesignJob` checks freshness per task at execution time — a variant
   whose base was concurrently removed between picker-open and task execution is
   skipped (not failed). Skipped tasks increment `job.skipped`.
@@ -162,7 +175,7 @@ loaded sentences). This means:
   book and fall back to base in a sibling.
 - The existing `character_designed` SSE event and `setQwenOverrideName` reducer path
   are unchanged (base voice designs still use them).
-- `showDesignFullCast` now also fires when `variantCount > 0` (not only on
+- `showDesignFullCast` now also fires when `variantWork.totalTasks > 0` (not only on
   `needsVoiceIds.length > 0`), so the button appears for a fully-voiced cast that
   still has outstanding variant work.
 
@@ -199,15 +212,20 @@ loaded sentences). This means:
   cast slice and bumps done; variants-only start (empty `characterIds`) proceeds.
 
 **Frontend — work-list + scope picker (Vitest + RTL):**
-- `src/lib/variant-tasks.test.ts` — `buildVariantTasks` emits only in-use emotions
-  lacking a designed variant for chars with a base voice; excludes chars with no base;
-  excludes chars with no in-use emotions. `variantWorkCounts` returns the total.
-- `src/components/design-scope-picker.test.tsx` — shows live counts and a combined
-  "both" total; disables an empty scope with "all done"; calls `onPick` with the chosen
-  scope; all three rows disabled when total is zero.
-- `src/views/cast.test.tsx` — clicking the button opens the picker; clicking a scope row
-  dispatches `designAllRequested` with the correct payload (`scope`, `variantTasks`);
-  existing base-only dispatch updated to go through the picker.
+- `src/lib/variant-tasks.test.ts` — `buildVariantTasks` emits in-use emotions lacking a
+  designed variant for every character the `isQwen` predicate accepts, flagging `hasBase`
+  (base present) vs not; **includes** a baseless character (hasBase=false); excludes chars
+  the predicate rejects or with no in-use emotions. `variantWorkCounts` splits a list into
+  `{ totalTasks, readyTasks, blockedTasks, blockedChars }`.
+- `src/components/design-scope-picker.test.tsx` — shows the variant total badge, the
+  `N ready · M need a base` split, and the combined "both" total; surfaces the loud
+  base-voice warning when some variants are blocked (hidden when all ready); disables
+  "Emotion variants" when nothing is ready but keeps the warning; "all done" for an
+  empty scope; calls `onPick`; all rows disabled when there's no work.
+- `src/views/cast.test.tsx` — clicking the button opens the picker; picking a scope
+  dispatches `designAllRequested` with the correct payload; a baseless emotion character
+  is **counted** in the picker total but **excluded** from the `variants` dispatch (base-
+  then-variant deferred to `both`); existing base-only dispatch goes through the picker.
 
 **Frontend — glyph strip (Vitest + RTL):**
 - `src/components/variant-glyph-strip.test.tsx` — renders one glyph per in-use emotion

--- a/docs/features/201-cast-bulk-emotion-variants.md
+++ b/docs/features/201-cast-bulk-emotion-variants.md
@@ -84,11 +84,13 @@ already has a designed `qwen.name`, mirroring the server's design gate).
 `variantWorkCounts` splits the list into `{ totalTasks, readyTasks, blockedTasks,
 blockedChars }` for the "40 total · 5 ready · 35 need a base" display.
 
-> **Fix (2026-06-10):** the shipped build gated `buildVariantTasks` on
-> `isQwenWithBase`, so the picker counted only already-voiced characters (e.g. 5)
-> while the cast rows' "Needs variants" chip counted the whole emotion cast (e.g.
-> 16) — the two surfaces disagreed and "Both" undercounted. The count now spans the
-> whole Qwen cast, as the table above always intended.
+> **Fix (2026-06-10 — [bug #695](https://github.com/dudarenok-maker/Castwright/issues/695), PR #694):**
+> the shipped build gated `buildVariantTasks` on `isQwenWithBase`, so the picker
+> counted only already-voiced characters (e.g. 5) while the cast rows' "Needs
+> variants" chip counted the whole emotion cast (e.g. 16) — the two surfaces
+> disagreed and "Both" undercounted. The count now spans the whole Qwen cast, as
+> the table above always intended, with the variants-only scope shipping only the
+> ready (has-base) tasks behind a loud warning.
 
 **Dependency rule.** Under `variants` scope the picker ships ONLY the `hasBase`
 (ready) tasks: a baseless character is still **counted** in the total (so the badge
@@ -289,6 +291,7 @@ Requires a Qwen project with weights installed + a book with emotion-tagged sent
 - Plan 177 (archived) — fs-25 per-quote emotion: `docs/features/archive/177-fs25-per-quote-emotion.md`
 - Plan 180 — fe-31 emotion chip preview (variant audition in the drawer): `docs/features/180-fe31-emotion-chip-preview.md`
 - Backlog: `fe-32` ([#512](https://github.com/dudarenok-maker/AudioBook-Generator/issues/512))
+- Bug: scope-picker variant undercount ([#695](https://github.com/dudarenok-maker/Castwright/issues/695), PR #694) — count now spans the whole Qwen cast
 
 ## Follow-ups
 

--- a/src/components/design-scope-picker.test.tsx
+++ b/src/components/design-scope-picker.test.tsx
@@ -3,28 +3,77 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DesignScopePicker } from './design-scope-picker';
 
-const props = (over = {}) => ({ baseCount: 2, variantCount: 5, onPick: vi.fn(), onClose: vi.fn(), ...over });
+const props = (over = {}) => ({
+  baseCount: 21,
+  variantTotal: 40,
+  variantReady: 5,
+  variantBlocked: 35,
+  variantBlockedChars: 14,
+  onPick: vi.fn(),
+  onClose: vi.fn(),
+  ...over,
+});
 
 describe('DesignScopePicker', () => {
-  it('shows live counts and a combined "both" total', () => {
+  it('shows total variant demand, the ready/blocked split, and a combined "both" total', () => {
     render(<DesignScopePicker {...props()} />);
-    expect(screen.getByTestId('scope-bases')).toHaveTextContent('2 needed');
-    expect(screen.getByTestId('scope-variants')).toHaveTextContent('5 needed');
-    expect(screen.getByTestId('scope-both')).toHaveTextContent('7 tasks');
+    expect(screen.getByTestId('scope-bases')).toHaveTextContent('21 needed');
+    expect(screen.getByTestId('scope-variants')).toHaveTextContent('40');
+    expect(screen.getByTestId('scope-both')).toHaveTextContent('61 tasks');
+    const split = screen.getByTestId('variants-split');
+    expect(split).toHaveTextContent('5 ready');
+    expect(split).toHaveTextContent('35 need a base');
   });
-  it('disables an empty scope with "all done"', () => {
+
+  it('shows a loud base-voice warning when some variants are blocked', () => {
+    render(<DesignScopePicker {...props()} />);
+    expect(screen.getByTestId('variants-base-warning')).toHaveTextContent('14');
+    expect(screen.getByTestId('variants-base-warning')).toHaveTextContent(/base voice/i);
+  });
+
+  it('disables "Emotion variants" when nothing is ready, but keeps the warning visible', () => {
+    render(
+      <DesignScopePicker
+        {...props({ variantReady: 0, variantBlocked: 40, variantBlockedChars: 16 })}
+      />,
+    );
+    expect(screen.getByTestId('scope-variants')).toBeDisabled();
+    expect(screen.getByTestId('variants-base-warning')).toBeInTheDocument();
+  });
+
+  it('enables "Emotion variants" when at least one is ready', () => {
+    render(<DesignScopePicker {...props()} />);
+    expect(screen.getByTestId('scope-variants')).not.toBeDisabled();
+  });
+
+  it('hides the base warning when every variant is ready', () => {
+    render(
+      <DesignScopePicker
+        {...props({ variantTotal: 5, variantReady: 5, variantBlocked: 0, variantBlockedChars: 0 })}
+      />,
+    );
+    expect(screen.queryByTestId('variants-base-warning')).not.toBeInTheDocument();
+  });
+
+  it('shows "all done" for a scope with no work', () => {
     render(<DesignScopePicker {...props({ baseCount: 0 })} />);
     expect(screen.getByTestId('scope-bases')).toBeDisabled();
     expect(screen.getByTestId('scope-bases')).toHaveTextContent('all done');
   });
+
   it('calls onPick with the chosen scope', async () => {
     const onPick = vi.fn();
     render(<DesignScopePicker {...props({ onPick })} />);
     await userEvent.click(screen.getByTestId('scope-variants'));
     expect(onPick).toHaveBeenCalledWith('variants');
   });
+
   it('disables both when there is no work at all', () => {
-    render(<DesignScopePicker {...props({ baseCount: 0, variantCount: 0 })} />);
+    render(
+      <DesignScopePicker
+        {...props({ baseCount: 0, variantTotal: 0, variantReady: 0, variantBlocked: 0, variantBlockedChars: 0 })}
+      />,
+    );
     expect(screen.getByTestId('scope-both')).toBeDisabled();
   });
 });

--- a/src/components/design-scope-picker.tsx
+++ b/src/components/design-scope-picker.tsx
@@ -1,19 +1,36 @@
 /* fe-32 — scope picker for the single "Design full cast" button. One entry,
    three scopes, each annotated with its live work count so GPU cost is visible
-   before starting. A scope with zero work is disabled ("all done"). Closes on
-   Escape; the parent handles outside-click. */
+   before starting. A scope with zero ACTIONABLE work is disabled ("all done").
+   Closes on Escape; the parent handles outside-click.
+
+   "Emotion variants" reports the WHOLE cast's variant demand (matching the
+   cast rows' "Needs variants" chip), split into "ready now" (characters that
+   already have a base voice) vs "need a base". The variants-only scope can only
+   synthesise on top of an existing base, so it's disabled until ≥1 is ready and
+   carries a loud warning; the "Both" scope designs the bases first, so its task
+   count includes every variant. */
 import { useEffect, type JSX } from 'react';
-import { IconSparkle, IconClose } from '../lib/icons';
+import { IconSparkle, IconClose, IconCheck, IconAlertTri } from '../lib/icons';
 import type { CastDesignScope } from '../store/cast-design-slice';
 
 export function DesignScopePicker({
   baseCount,
-  variantCount,
+  variantTotal,
+  variantReady,
+  variantBlocked,
+  variantBlockedChars,
   onPick,
   onClose,
 }: {
   baseCount: number;
-  variantCount: number;
+  /** Total (character × emotion) variant tasks across the whole cast. */
+  variantTotal: number;
+  /** Variant tasks for characters that already have a base voice. */
+  variantReady: number;
+  /** Variant tasks blocked behind a missing base voice. */
+  variantBlocked: number;
+  /** Distinct characters whose variants are blocked behind a missing base. */
+  variantBlockedChars: number;
   onPick: (scope: CastDesignScope) => void;
   onClose: () => void;
 }): JSX.Element {
@@ -25,7 +42,12 @@ export function DesignScopePicker({
     return () => window.removeEventListener('keydown', onKey);
   }, [onClose]);
 
-  const bothCount = baseCount + variantCount;
+  const bothCount = baseCount + variantTotal;
+
+  const badgeClass = (active: boolean) =>
+    `text-xs font-bold px-2.5 py-1 rounded-full shrink-0 ${
+      active ? 'bg-amber-500/10 text-amber-700' : 'bg-emerald-500/10 text-emerald-700'
+    }`;
 
   function Row({
     scope,
@@ -53,15 +75,7 @@ export function DesignScopePicker({
           <span className="block text-sm font-bold text-ink">{title}</span>
           <span className="block text-xs text-ink/55">{desc}</span>
         </span>
-        <span
-          className={`text-xs font-bold px-2.5 py-1 rounded-full shrink-0 ${
-            count === 0
-              ? 'bg-emerald-500/10 text-emerald-700'
-              : 'bg-amber-500/10 text-amber-700'
-          }`}
-        >
-          {count === 0 ? 'all done' : `${count} ${unit}`}
-        </span>
+        <span className={badgeClass(count > 0)}>{count === 0 ? 'all done' : `${count} ${unit}`}</span>
       </button>
     );
   }
@@ -81,6 +95,7 @@ export function DesignScopePicker({
           <IconClose className="w-3.5 h-3.5" />
         </button>
       </div>
+
       <Row
         scope="bases"
         title="Base voices"
@@ -88,13 +103,59 @@ export function DesignScopePicker({
         count={baseCount}
         unit="needed"
       />
-      <Row
-        scope="variants"
-        title="Emotion variants"
-        desc="Tagged emotions missing a variant"
-        count={variantCount}
-        unit="needed"
-      />
+
+      {/* Emotion variants — bespoke row: total-demand badge + ready/blocked
+          split, disabled until ≥1 is designable, with a loud base-voice
+          warning when some are blocked. */}
+      <button
+        type="button"
+        role="menuitem"
+        data-testid="scope-variants"
+        disabled={variantReady === 0}
+        onClick={() => onPick('variants')}
+        className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-ink/4 disabled:cursor-not-allowed border-t border-ink/8 min-h-[44px]"
+      >
+        <span className="flex-1 min-w-0">
+          <span className={`block text-sm font-bold ${variantReady === 0 ? 'text-ink/40' : 'text-ink'}`}>
+            Emotion variants
+          </span>
+          <span className={`block text-xs ${variantReady === 0 ? 'text-ink/35' : 'text-ink/55'}`}>
+            Tagged emotions missing a variant
+          </span>
+          {variantTotal > 0 && (
+            <span
+              data-testid="variants-split"
+              className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] font-semibold"
+            >
+              <span className="inline-flex items-center gap-1 text-emerald-700">
+                <IconCheck className="w-3 h-3" />
+                {variantReady} ready now
+              </span>
+              {variantBlocked > 0 && (
+                <span className="inline-flex items-center gap-1 text-amber-700">
+                  <IconAlertTri className="w-3 h-3" />
+                  {variantBlocked} need a base
+                </span>
+              )}
+            </span>
+          )}
+        </span>
+        <span className={badgeClass(variantTotal > 0)}>{variantTotal === 0 ? 'all done' : variantTotal}</span>
+      </button>
+      {variantBlockedChars > 0 && (
+        <p
+          data-testid="variants-base-warning"
+          className="px-4 pb-3 -mt-0.5 text-[11px] text-amber-700 flex items-start gap-1.5"
+        >
+          <IconAlertTri className="w-3 h-3 mt-0.5 shrink-0" />
+          <span>
+            Variants only run for voices that already exist —{' '}
+            {variantBlockedChars} {variantBlockedChars === 1 ? 'character needs' : 'characters need'} a
+            base voice first. Choose “Both” to design everything.
+          </span>
+        </p>
+      )}
+
       <Row
         scope="both"
         title="Both"

--- a/src/components/emotion-variant-designer.tsx
+++ b/src/components/emotion-variant-designer.tsx
@@ -106,7 +106,7 @@ export function EmotionVariantDesigner({
   if (!baseDesigned) {
     return (
       <p data-testid="variant-gate-hint" className="text-xs text-ink/50 mt-2">
-        Design the main voice first to add emotion variants.
+        Emotion variants become available once this character has a designed base voice.
       </p>
     );
   }

--- a/src/lib/variant-tasks.test.ts
+++ b/src/lib/variant-tasks.test.ts
@@ -2,33 +2,76 @@ import { describe, it, expect } from 'vitest';
 import { buildVariantTasks, variantWorkCounts } from './variant-tasks';
 import type { Character } from './types';
 
-const qwen = (id: string, variants: Record<string, { name: string }> = {}, name = 'qwen-' + id) =>
-  ({ id, name: id, ttsEngine: 'qwen', overrideTtsVoices: { qwen: { name, variants } } }) as unknown as Character;
+/* A Qwen character with a designed base voice (and optional designed variants). */
+const based = (id: string, variants: Record<string, { name: string }> = {}) =>
+  ({ id, name: id, ttsEngine: 'qwen', overrideTtsVoices: { qwen: { name: 'qwen-' + id, variants } } }) as unknown as Character;
+
+/* A Qwen-effective character with NO designed base voice yet. */
+const baseless = (id: string) => ({ id, name: id, ttsEngine: 'qwen' }) as unknown as Character;
+
+const isQwen = (c: Character) => c.ttsEngine === 'qwen';
 
 describe('buildVariantTasks', () => {
-  it('emits only in-use emotions that lack a designed variant, base present', () => {
-    const chars = [qwen('sophie', { angry: { name: 'x' } })];
+  it('emits only in-use emotions that lack a designed variant, flagging an existing base', () => {
+    const chars = [based('sophie', { angry: { name: 'x' } })];
     const used = new Map([['sophie', new Set(['angry', 'excited'])]]);
-    expect(buildVariantTasks(chars, used)).toEqual([{ characterId: 'sophie', emotions: ['excited'] }]);
+    expect(buildVariantTasks(chars, used, isQwen)).toEqual([
+      { characterId: 'sophie', emotions: ['excited'], hasBase: true },
+    ]);
   });
-  it('excludes a character with no base voice (needs base first)', () => {
-    const fitz = { id: 'fitz', name: 'fitz', ttsEngine: 'qwen' } as unknown as Character;
+
+  it('INCLUDES a character with no base voice yet, flagged hasBase=false', () => {
+    // The bulk "Both" run designs the base first, so the variant is still
+    // counted as demand — hasBase records that it is not actionable alone.
     const used = new Map([['fitz', new Set(['angry'])]]);
-    expect(buildVariantTasks([fitz], used)).toEqual([]);
+    expect(buildVariantTasks([baseless('fitz')], used, isQwen)).toEqual([
+      { characterId: 'fitz', emotions: ['angry'], hasBase: false },
+    ]);
   });
+
+  it('excludes characters the isQwen predicate rejects (non-Qwen-effective)', () => {
+    const kokoro = { id: 'gandalf', name: 'gandalf', ttsEngine: 'kokoro' } as unknown as Character;
+    const used = new Map([['gandalf', new Set(['angry'])]]);
+    expect(buildVariantTasks([kokoro], used, isQwen)).toEqual([]);
+  });
+
   it('excludes characters with no in-use emotions', () => {
-    const used = new Map<string, Set<string>>();
-    expect(buildVariantTasks([qwen('ed')], used)).toEqual([]);
+    expect(buildVariantTasks([based('ed')], new Map(), isQwen)).toEqual([]);
   });
 });
 
 describe('variantWorkCounts', () => {
-  it('counts total missing variants across the cast', () => {
-    const chars = [qwen('sophie', { angry: { name: 'x' } }), qwen('keefe')];
-    const used = new Map([
-      ['sophie', new Set(['angry', 'excited'])],
-      ['keefe', new Set(['whisper', 'sad'])],
-    ]);
-    expect(variantWorkCounts(chars, used)).toBe(3);
+  it('splits total demand into ready (has base) vs blocked (needs a base first)', () => {
+    const tasks = buildVariantTasks(
+      [based('sophie', { angry: { name: 'x' } }), baseless('keefe')],
+      new Map([
+        ['sophie', new Set(['angry', 'excited'])], // 1 ready (excited; angry designed)
+        ['keefe', new Set(['whisper', 'sad'])], // 2 blocked (no base)
+      ]),
+      isQwen,
+    );
+    expect(variantWorkCounts(tasks)).toEqual({
+      totalTasks: 3,
+      readyTasks: 1,
+      blockedTasks: 2,
+      blockedChars: 1,
+    });
+  });
+
+  it('is all-ready when every emotion character already has a base', () => {
+    const tasks = buildVariantTasks(
+      [based('a'), based('b')],
+      new Map([
+        ['a', new Set(['angry'])],
+        ['b', new Set(['sad', 'excited'])],
+      ]),
+      isQwen,
+    );
+    expect(variantWorkCounts(tasks)).toEqual({
+      totalTasks: 3,
+      readyTasks: 3,
+      blockedTasks: 0,
+      blockedChars: 0,
+    });
   });
 });

--- a/src/lib/variant-tasks.ts
+++ b/src/lib/variant-tasks.ts
@@ -1,37 +1,71 @@
-/* fe-32 — demand-driven variant work-list. Mirrors `countMissingVariants`
-   (src/lib/voice-status.ts): for each Qwen character that HAS a base voice, the
-   in-use emotions (from `usedEmotionsByCharacter`) that don't yet have a designed
-   variant. A character missing its base is excluded — a variant needs a base. */
+/* fe-32 — demand-driven variant work-list. For each Qwen-effective character,
+   the in-use emotions (from `usedEmotionsByCharacter`) that don't yet have a
+   designed variant. A base voice is NOT required to be COUNTED: the bulk "Both"
+   run designs the base first, then its variants, so a not-yet-voiced character
+   still represents real variant demand. `hasBase` records whether the task is
+   actionable on its own (the "Emotion variants" scope can only synthesise a
+   variant on top of an existing base — mirroring the server's design gate in
+   cast-design.ts, which skips a variant when the character has no qwen name). */
 import type { Character, Emotion } from './types';
-
-function isQwenWithBase(c: Character): boolean {
-  return c.ttsEngine === 'qwen' && !!c.overrideTtsVoices?.qwen?.name;
-}
 
 export interface VariantTask {
   characterId: string;
   emotions: Emotion[];
+  /** True when the character already has a designed Qwen base voice, so its
+      variants are designable right now. False = blocked behind a missing base
+      (needs the "Both" scope, which designs the base first). */
+  hasBase: boolean;
 }
 
+/** Build the variant work-list. `isQwen` is supplied by the caller so this
+    matches the cast view's "Needs variants" chip exactly (effective project
+    engine OR a matched Qwen library voice) — the picker count can't disagree
+    with the rows. */
 export function buildVariantTasks(
   characters: Character[],
   usedEmotions: Map<string, Set<string>>,
+  isQwen: (c: Character) => boolean,
 ): VariantTask[] {
   const tasks: VariantTask[] = [];
   for (const c of characters) {
-    if (!isQwenWithBase(c)) continue;
+    if (!isQwen(c)) continue;
     const used = usedEmotions.get(c.id);
     if (!used || used.size === 0) continue;
     const designed = new Set(Object.keys(c.overrideTtsVoices?.qwen?.variants ?? {}));
     const emotions = [...used].filter((e) => !designed.has(e)) as Emotion[];
-    if (emotions.length > 0) tasks.push({ characterId: c.id, emotions });
+    if (emotions.length > 0) {
+      tasks.push({ characterId: c.id, emotions, hasBase: !!c.overrideTtsVoices?.qwen?.name });
+    }
   }
   return tasks;
 }
 
-export function variantWorkCounts(
-  characters: Character[],
-  usedEmotions: Map<string, Set<string>>,
-): number {
-  return buildVariantTasks(characters, usedEmotions).reduce((n, t) => n + t.emotions.length, 0);
+export interface VariantWorkCounts {
+  /** Total (character × emotion) variant tasks across the whole cast. */
+  totalTasks: number;
+  /** Tasks for characters that already have a base voice — designable now. */
+  readyTasks: number;
+  /** Tasks blocked behind a missing base voice. */
+  blockedTasks: number;
+  /** Distinct characters whose variant tasks are blocked behind a missing base. */
+  blockedChars: number;
+}
+
+/** Split a variant work-list into ready (has base) vs blocked (needs a base
+    designed first) tallies, for the scope picker's "N ready · M need a base". */
+export function variantWorkCounts(tasks: VariantTask[]): VariantWorkCounts {
+  let totalTasks = 0;
+  let readyTasks = 0;
+  let blockedTasks = 0;
+  let blockedChars = 0;
+  for (const t of tasks) {
+    totalTasks += t.emotions.length;
+    if (t.hasBase) {
+      readyTasks += t.emotions.length;
+    } else {
+      blockedTasks += t.emotions.length;
+      blockedChars += 1;
+    }
+  }
+  return { totalTasks, readyTasks, blockedTasks, blockedChars };
 }

--- a/src/views/cast.test.tsx
+++ b/src/views/cast.test.tsx
@@ -1520,6 +1520,71 @@ describe('CastView — Design full cast button', () => {
     /* Picker closes after picking */
     expect(screen.queryByTestId('design-scope-picker')).toBeNull();
   });
+
+  it('counts a baseless emotion character in the picker total but EXCLUDES it from the variants-only dispatch', () => {
+    /* withBase: qwen + base + 1 missing variant → "ready now".
+       baseless: qwen + NO base + 2 in-use emotions → counted as demand (the
+       picker total reflects the cast rows), but the variants-only scope can't
+       act on it (no base) so it must be dropped from the dispatch and a loud
+       warning shown — the user designs its base via "Both" first. */
+    const withBase: Character = {
+      id: 'with-base', name: 'With Base', role: 'Hero', color: 'mentor',
+      lines: 10, scenes: 3, attributes: [], ttsEngine: 'qwen',
+      overrideTtsVoices: { qwen: { name: 'qwen-with-base', variants: {} } },
+    };
+    const baseless: Character = {
+      id: 'baseless', name: 'Baseless', role: 'Extra', color: 'mentor',
+      lines: 4, scenes: 1, attributes: [], ttsEngine: 'qwen',
+      overrideTtsVoices: undefined,
+    };
+    const sents: Sentence[] = [
+      { id: 30, chapterId: 1, text: 'Rage!', characterId: 'with-base', emotion: 'angry' },
+      { id: 31, chapterId: 1, text: 'Hush', characterId: 'baseless', emotion: 'whisper' },
+      { id: 32, chapterId: 1, text: 'Yay!', characterId: 'baseless', emotion: 'excited' },
+    ];
+    const actions: Array<{ type: string; payload?: unknown }> = [];
+    const recorder =
+      () => (next: (a: unknown) => unknown) => (action: unknown) => {
+        actions.push(action as { type: string; payload?: unknown });
+        return next(action);
+      };
+    const store = configureStore({
+      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, castDesign: castDesignSlice.reducer },
+      middleware: (g) => g().concat(recorder),
+    });
+    store.dispatch(uiSlice.actions.setTtsModelKey('qwen3-tts-0.6b'));
+    store.dispatch(uiSlice.actions.openBook({ id: 'b4', status: 'complete' }));
+    render(
+      <Provider store={store}>
+        <CastView
+          characters={[withBase, baseless]}
+          setCharacters={() => {}}
+          library={library}
+          sentences={sents}
+          title="X"
+          onOpenProfile={() => {}}
+          onShowMatchDetail={() => {}}
+          driftEvents={[]}
+          onShowDrift={() => {}}
+        />
+      </Provider>,
+    );
+    fireEvent.click(screen.getByTestId('design-full-cast'));
+    /* Picker total = 3 (1 ready + 2 blocked); Both = 1 base + 3 variants = 4. */
+    expect(screen.getByTestId('scope-variants')).toHaveTextContent('3');
+    expect(screen.getByTestId('variants-split')).toHaveTextContent('1 ready');
+    expect(screen.getByTestId('variants-split')).toHaveTextContent('2 need a base');
+    expect(screen.getByTestId('variants-base-warning')).toBeInTheDocument();
+    expect(screen.getByTestId('scope-both')).toHaveTextContent('4 tasks');
+    /* Variants-only dispatch carries ONLY the ready (has-base) task. */
+    fireEvent.click(screen.getByTestId('scope-variants'));
+    const a = actions.find((x) => x.type === castDesignActions.designAllRequested.type) as
+      | { payload: { scope: string; characterIds: string[]; variantTasks: Array<{ characterId: string; emotions: string[] }> } }
+      | undefined;
+    expect(a?.payload.scope).toBe('variants');
+    expect(a?.payload.characterIds).toEqual([]);
+    expect(a?.payload.variantTasks).toEqual([{ characterId: 'with-base', emotions: ['angry'] }]);
+  });
 });
 
 describe('CastView — variant glyph strip in the Status column', () => {

--- a/src/views/cast.tsx
+++ b/src/views/cast.tsx
@@ -57,7 +57,7 @@ import { QwenStatusNotice } from '../components/qwen-status-notice';
 import { DesignScopePicker } from '../components/design-scope-picker';
 import { api } from '../lib/api';
 import type { CastDesignScope } from '../store/cast-design-slice';
-import { buildVariantTasks } from '../lib/variant-tasks';
+import { buildVariantTasks, variantWorkCounts } from '../lib/variant-tasks';
 
 interface Props {
   characters: Character[];
@@ -142,9 +142,6 @@ export function CastView({
   /* fs-34 — index used emotions per character ONCE (not per row) for the
      "N tags need a variant" cast-row count. */
   const usedEmotions = useMemo(() => usedEmotionsByCharacter(sentences ?? []), [sentences]);
-  /* fe-32 — demand-driven variant work-list for the scope picker. */
-  const variantTasks = useMemo(() => buildVariantTasks(characters, usedEmotions), [characters, usedEmotions]);
-  const variantCount = useMemo(() => variantTasks.reduce((n, t) => n + t.emotions.length, 0), [variantTasks]);
   const [scopeOpen, setScopeOpen] = useState(false);
   const [query, setQuery] = useState('');
   /* fe-16 — non-English books are Qwen-locked. On entry, eagerly load Qwen so
@@ -242,6 +239,21 @@ export function CastView({
      a Qwen-pinned character. */
   const effectiveEngineFor = (c: Character): TtsEngine => c.ttsEngine ?? ttsEngine;
 
+  /* fe-32 — demand-driven variant work-list for the scope picker, scoped the
+     SAME way the cast rows' "Needs variants" chip is (effective project engine
+     OR a matched Qwen library voice) so the picker count can't disagree with
+     the rows. Counts every emotion character's missing variants; `hasBase`
+     splits the actionable-now total (`readyTasks`) from the work blocked behind
+     a missing base voice (`blockedTasks`/`blockedChars`). */
+  const isQwenForVariants = (c: Character): boolean =>
+    effectiveEngineFor(c) === 'qwen' || findVoiceForCharacter(c, library)?.ttsVoice?.provider === 'qwen';
+  const variantTasks = useMemo(
+    () => buildVariantTasks(characters, usedEmotions, isQwenForVariants),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [characters, usedEmotions, library, ttsEngine],
+  );
+  const variantWork = useMemo(() => variantWorkCounts(variantTasks), [variantTasks]);
+
   /* Status-filter keys for a character, resolved the SAME way the row's
      StatusPill resolves its labels (matched library voice + effective engine)
      so the chips and the rows can't disagree. */
@@ -273,7 +285,8 @@ export function CastView({
      to design, OR while a run for this book is active (so the Cancel control stays
      reachable even after the last row flips and the counts hit 0). */
   const showDesignFullCast =
-    (ttsEngine === 'qwen' && (needsVoiceIds.length > 0 || variantCount > 0)) || designRunningHere;
+    (ttsEngine === 'qwen' && (needsVoiceIds.length > 0 || variantWork.totalTasks > 0)) ||
+    designRunningHere;
   useEffect(() => {
     if (designRunningHere || designRunningElsewhere) setScopeOpen(false);
   }, [designRunningHere, designRunningElsewhere]);
@@ -291,13 +304,23 @@ export function CastView({
     setScopeOpen(false);
     if (!bookId) return;
     const modelKey = sampleModelKeyForEngine('qwen', ttsModelKey);
+    /* 'variants' alone can only synthesise on top of an existing base, so it
+       ships ONLY the ready (has-base) tasks — the server would silently skip
+       the rest. 'both' designs the bases first, so it ships every task. Strip
+       the UI-only `hasBase` flag before it crosses the API boundary. */
+    const scopedVariantTasks =
+      scope === 'bases'
+        ? []
+        : (scope === 'variants' ? variantTasks.filter((t) => t.hasBase) : variantTasks).map(
+            ({ characterId, emotions }) => ({ characterId, emotions }),
+          );
     dispatch(
       castDesignActions.designAllRequested({
         bookId,
         characterIds: scope === 'variants' ? [] : needsVoiceIds,
         modelKey,
         scope,
-        variantTasks: scope === 'bases' ? [] : variantTasks,
+        variantTasks: scopedVariantTasks,
       }),
     );
   };
@@ -578,7 +601,10 @@ export function CastView({
                     <div className="fixed inset-0 z-40" onClick={() => setScopeOpen(false)} aria-hidden />
                     <DesignScopePicker
                       baseCount={needsVoiceIds.length}
-                      variantCount={variantCount}
+                      variantTotal={variantWork.totalTasks}
+                      variantReady={variantWork.readyTasks}
+                      variantBlocked={variantWork.blockedTasks}
+                      variantBlockedChars={variantWork.blockedChars}
                       onPick={startDesign}
                       onClose={() => setScopeOpen(false)}
                     />


### PR DESCRIPTION
## Summary

The "Design full cast" scope picker **undercounted emotion variants**, so the count "didn't sound right." `buildVariantTasks` gated on `isQwenWithBase`, so **"Emotion variants"** counted only already-voiced characters (e.g. 5) while the cast rows' **"Needs variants"** chip + glyph strips counted the whole Qwen emotion cast (e.g. 16). The two surfaces disagreed and **"Both" undercounted**. (Not a duplication bug — the cast has 23 unique characters, verified.)

- `buildVariantTasks` now takes an `isQwen` predicate (the cast view passes the **same** one its chip uses) and counts every Qwen-effective emotion character, tagging each task `hasBase`. `variantWorkCounts` splits the list into `{ totalTasks, readyTasks, blockedTasks, blockedChars }`.
- The **"Emotion variants"** row shows the full demand as the badge with a `✓ N ready now · ⚠ M need a base` split and a **loud warning**; it's **disabled until ≥1 is ready** and dispatches **only the ready (has-base) tasks** (the server would skip the rest). **"Both"** ships every task and designs bases first. This aligns the code with plan 201's documented intent.
- Profile-drawer gate hint reworded to match ("available once a base exists").

## Test plan

- `npm run verify` equivalent run locally, all green: typecheck (fe+srv), lint, frontend **2563**, server fast **2427** (incl. `cast-design.test.ts`), server slow **203**, the 2 affected e2e specs, build.
- New/updated: `variant-tasks.test.ts` (ready/blocked split + baseless inclusion), `design-scope-picker.test.tsx` (split + warning + disable), `cast.test.tsx` (baseless counted-but-excluded-from-`variants` dispatch). Server base-then-variant / skip-baseless already pinned in `cast-design.test.ts:431/455`.

Refs plan `docs/features/201-cast-bulk-emotion-variants.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #695