### PR TITLE
feat(app,server,frontend): shrink companion pairing QR so it scans on real phones

### DIFF
--- a/apps/android/lib/main.dart
+++ b/apps/android/lib/main.dart
@@ -1,6 +1,10 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:audio_service/audio_service.dart';
 import 'package:flutter/material.dart';
 
+import 'src/data/cert_pinning.dart';
 import 'src/data/companion_audio_handler.dart';
 import 'src/data/companion_runtime.dart';
 import 'src/data/pairing_service.dart';
@@ -119,15 +123,30 @@ class _HomePageState extends State<HomePage> {
   }
 
   /// One online round-trip to fetch + verify + persist the cert for a legacy
-  /// pairing, then build the runtime.
+  /// pairing (predates offline cert storage), then build the runtime.
   Future<void> _bootstrapFromServer() async {
     setState(() {
       _loading = true;
       _bootstrapError = null;
     });
     try {
-      final conn = await widget.service.pair(_paired!);
-      await widget.store.saveCaPem(conn.caPem);
+      final server = _paired!;
+      // Fetch the CA cert over a one-shot, validation-bypassing client and
+      // verify it matches the stored full SHA-256 fingerprint.
+      final client = HttpClient()..badCertificateCallback = (cert, host, port) => true;
+      final String caPem;
+      try {
+        final req = await client.getUrl(Uri.parse('${server.url}/cert/root.crt'));
+        final res = await req.close();
+        caPem = await res.transform(const Utf8Decoder()).join();
+      } finally {
+        client.close(force: true);
+      }
+      if (!verifyCaFingerprint(caPem, server.caFingerprint)) {
+        throw Exception('Certificate fingerprint mismatch — re-pair the device.');
+      }
+      await widget.store.saveCaPem(caPem);
+      final conn = Connection(server: server, caPem: caPem);
       final runtime =
           await CompanionRuntime.forConnection(conn, handler: widget.audioHandler);
       if (mounted) {

--- a/apps/android/lib/src/data/cert_pinning.dart
+++ b/apps/android/lib/src/data/cert_pinning.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:crypto/crypto.dart';
+import 'crockford_base32.dart';
 
 /// Cert-fingerprint pinning for the pairing flow (plan 188, app-2 / srv-20).
 ///
@@ -43,3 +44,13 @@ bool fingerprintsMatch(String a, String b) {
 /// True when the fetched CA [pem] matches the [expected] pinned fingerprint.
 bool verifyCaFingerprint(String pem, String expected) =>
     fingerprintsMatch(caFingerprintFromPem(pem), expected);
+
+/// True when [tag] equals the Crockford-base32 of the first 10 bytes (80 bits)
+/// of the certificate's SHA-256 — the QR's compact integrity tag. Normalised to
+/// upper-case alphanumerics so case differences never cause a false mismatch.
+bool fingerprintTagMatches(String pem, String tag) {
+  final digest = sha256.convert(pemToDer(pem)).bytes;
+  final expected = crockfordBase32(digest.sublist(0, 10));
+  String norm(String s) => s.toUpperCase().replaceAll(RegExp('[^0-9A-Z]'), '');
+  return norm(expected) == norm(tag);
+}

--- a/apps/android/lib/src/data/crockford_base32.dart
+++ b/apps/android/lib/src/data/crockford_base32.dart
@@ -1,0 +1,19 @@
+/// Crockford base32 (no padding), encode-only. Mirrors the server's
+/// `crockford-base32.ts` so the companion can recompute the CA fingerprint tag
+/// and compare it to the QR's `fpTag`. Alphabet excludes I, L, O, U.
+const _alphabet = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+String crockfordBase32(List<int> bytes) {
+  final out = StringBuffer();
+  var buffer = 0, bits = 0;
+  for (final byte in bytes) {
+    buffer = (buffer << 8) | (byte & 0xff);
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      out.write(_alphabet[(buffer >> bits) & 0x1f]);
+    }
+  }
+  if (bits > 0) out.write(_alphabet[(buffer << (5 - bits)) & 0x1f]);
+  return out.toString();
+}

--- a/apps/android/lib/src/data/pairing_service.dart
+++ b/apps/android/lib/src/data/pairing_service.dart
@@ -2,9 +2,9 @@ import 'dart:convert';
 import 'dart:io';
 
 import '../domain/paired_server.dart';
+import '../domain/pairing_qr.dart';
 import 'cert_pinning.dart';
 
-/// Why a pairing attempt failed — drives the user-facing error copy.
 enum PairingErrorKind { unreachable, fingerprintMismatch, tokenRejected, server }
 
 class PairingException implements Exception {
@@ -15,81 +15,68 @@ class PairingException implements Exception {
   String toString() => 'PairingException($kind): $message';
 }
 
-/// A successful pairing: the verified base URL + token + the pinned CA (PEM),
-/// ready to build authenticated, cert-pinned requests from.
+/// Thrown by a redeem fn when the server rejects the code (HTTP 401/410).
+class RedeemRejected implements Exception {
+  const RedeemRejected();
+}
+
 class Connection {
   const Connection({required this.server, required this.caPem});
   final PairedServer server;
   final String caPem;
 }
 
-/// Fetches the server CA (`/cert/root.crt`) over an *untrusted* channel —
-/// injectable so the pairing flow is unit-testable without real TLS.
+class RedeemResult {
+  const RedeemResult({required this.token, required this.caFingerprint});
+  final String token;
+  final String caFingerprint; // full SHA-256, stored on PairedServer
+}
+
 typedef CaFetcher = Future<String> Function(String baseUrl);
+typedef TagVerifier = bool Function(String caPem, String fpTag);
+typedef CodeRedeemer = Future<RedeemResult> Function(String baseUrl, String code, String caPem);
 
-/// Probes an authenticated, cert-pinned endpoint to confirm the token works —
-/// injectable for the same reason. Returns the HTTP status code.
-typedef AuthProbe = Future<int> Function(PairedServer server, String caPem);
-
-/// Pairs the app to a server (plan 188, app-2 / srv-20):
-/// 1. fetch the CA over a one-shot validation-bypassing client,
-/// 2. verify its SHA-256 == the QR's `caFingerprint` (else refuse),
-/// 3. probe an /api endpoint with the token over a CA-pinned client.
+/// Pairs the app to a server (QR redesign):
+/// 1. fetch the CA over an untrusted one-shot client,
+/// 2. verify its 80-bit fingerprint tag == the QR's `fpTag` (else refuse),
+/// 3. redeem the code over a CA-pinned client to mint a per-device token.
 class PairingService {
-  PairingService({CaFetcher? fetchCa, AuthProbe? probe})
+  PairingService({CaFetcher? fetchCa, TagVerifier? verifyTag, CodeRedeemer? redeem})
       : _fetchCa = fetchCa ?? _defaultFetchCa,
-        _probe = probe ?? _defaultProbe;
+        _verifyTag = verifyTag ?? fingerprintTagMatches,
+        _redeem = redeem ?? _defaultRedeem;
 
   final CaFetcher _fetchCa;
-  final AuthProbe _probe;
+  final TagVerifier _verifyTag;
+  final CodeRedeemer _redeem;
 
-  Future<Connection> pair(PairedServer server) async {
+  Future<Connection> pair(PairingQr qr, {required String label}) async {
     String caPem;
     try {
-      caPem = await _fetchCa(server.url);
+      caPem = await _fetchCa(qr.baseUrl);
     } catch (e) {
-      throw PairingException(
-        PairingErrorKind.unreachable,
-        'Could not reach the server to fetch its certificate ($e).',
-      );
+      throw PairingException(PairingErrorKind.unreachable,
+          'Could not reach the server to fetch its certificate ($e).');
     }
-
-    if (!verifyCaFingerprint(caPem, server.caFingerprint)) {
-      throw const PairingException(
-        PairingErrorKind.fingerprintMismatch,
-        'The server certificate did not match the pairing code. Refusing to '
-        'pair — this could be a man-in-the-middle.',
-      );
+    if (!_verifyTag(caPem, qr.fpTag)) {
+      throw const PairingException(PairingErrorKind.fingerprintMismatch,
+          'The server certificate did not match the pairing code. Refusing to pair.');
     }
-
-    int status;
+    RedeemResult r;
     try {
-      status = await _probe(server, caPem);
+      r = await _redeem(qr.baseUrl, qr.code, caPem);
+    } on RedeemRejected {
+      throw const PairingException(PairingErrorKind.tokenRejected,
+          'The server rejected the pairing code. Re-scan a fresh code.');
     } catch (e) {
-      throw PairingException(
-        PairingErrorKind.unreachable,
-        'Paired certificate verified, but the authenticated probe failed ($e).',
-      );
+      throw PairingException(PairingErrorKind.unreachable,
+          'Certificate verified, but redeeming the code failed ($e).');
     }
-    if (status == 401 || status == 403) {
-      throw const PairingException(
-        PairingErrorKind.tokenRejected,
-        'The server rejected the access token. Re-scan the current pairing code.',
-      );
-    }
-    if (status >= 400) {
-      throw PairingException(
-        PairingErrorKind.server,
-        'The server returned an unexpected status ($status).',
-      );
-    }
+    final server = PairedServer(url: qr.baseUrl, token: r.token, caFingerprint: r.caFingerprint);
     return Connection(server: server, caPem: caPem);
   }
 }
 
-/// Default CA fetch: a one-shot client that accepts the (not-yet-trusted)
-/// self-signed cert ONLY to download `/cert/root.crt`; the bytes are then
-/// fingerprint-verified before anything is trusted.
 Future<String> _defaultFetchCa(String baseUrl) async {
   final client = HttpClient()..badCertificateCallback = (_, _, _) => true;
   try {
@@ -101,18 +88,20 @@ Future<String> _defaultFetchCa(String baseUrl) async {
   }
 }
 
-/// Default authenticated probe: GET `/api/info` over a client that trusts ONLY
-/// the just-verified CA, with the Bearer token.
-Future<int> _defaultProbe(PairedServer server, String caPem) async {
+Future<RedeemResult> _defaultRedeem(String baseUrl, String code, String caPem) async {
   final ctx = SecurityContext(withTrustedRoots: false)
     ..setTrustedCertificatesBytes(utf8.encode(caPem));
   final client = HttpClient(context: ctx);
   try {
-    final req = await client.getUrl(Uri.parse('${server.url}/api/info'));
-    req.headers.set(HttpHeaders.authorizationHeader, 'Bearer ${server.token}');
+    final req = await client.postUrl(Uri.parse('$baseUrl/api/pair/redeem'));
+    req.headers.contentType = ContentType.json;
+    req.write(jsonEncode({'code': code, 'label': Platform.localHostname}));
     final res = await req.close();
-    await res.drain<void>();
-    return res.statusCode;
+    if (res.statusCode == 401 || res.statusCode == 410) throw const RedeemRejected();
+    if (res.statusCode >= 400) throw HttpException('redeem status ${res.statusCode}');
+    final body = jsonDecode(await res.transform(utf8.decoder).join()) as Map<String, dynamic>;
+    final token = body['token'] as String;
+    return RedeemResult(token: token, caFingerprint: caFingerprintFromPem(caPem));
   } finally {
     client.close(force: true);
   }

--- a/apps/android/lib/src/domain/paired_server.dart
+++ b/apps/android/lib/src/domain/paired_server.dart
@@ -1,6 +1,4 @@
-import 'dart:convert';
-
-/// Connection details the app pairs to, parsed from the pairing QR payload
+/// Connection details the app pairs to, stored from a successful pairing
 /// `{ url, token, caFingerprint }` (plan 188, app-2 / srv-20). Pure data with
 /// no platform dependencies, so it lives in the domain layer and is fully
 /// unit-testable. `caFingerprint` is the server CA's SHA-256, verified against
@@ -27,20 +25,6 @@ class PairedServer {
         caFingerprint: caFingerprint,
         pairedAt: pairedAt ?? this.pairedAt,
       );
-
-  /// Parse the raw text of a scanned pairing QR (a JSON object).
-  factory PairedServer.fromQrPayload(String raw) {
-    final Object? decoded;
-    try {
-      decoded = jsonDecode(raw);
-    } catch (_) {
-      throw const FormatException('pairing QR is not valid JSON');
-    }
-    if (decoded is! Map<String, dynamic>) {
-      throw const FormatException('pairing QR is not a JSON object');
-    }
-    return PairedServer.fromJson(decoded);
-  }
 
   factory PairedServer.fromJson(Map<String, dynamic> json) {
     final url = _requireNonEmptyString(json, 'url');

--- a/apps/android/lib/src/domain/pairing_qr.dart
+++ b/apps/android/lib/src/domain/pairing_qr.dart
@@ -1,0 +1,23 @@
+/// Parsed companion pairing QR (`CWP1*host:port*code*fpTag`). Pure data, no
+/// platform deps — fully unit-testable. Replaces the old JSON QR payload.
+class PairingQr {
+  const PairingQr({required this.hostPort, required this.code, required this.fpTag});
+
+  final String hostPort;
+  final String code;
+  final String fpTag;
+
+  String get baseUrl => 'https://$hostPort';
+
+  factory PairingQr.parse(String raw) {
+    final parts = raw.split('*');
+    if (parts.length != 4 || parts[0] != 'CWP1') {
+      throw const FormatException('not a CWP1 pairing payload');
+    }
+    final hostPort = parts[1], code = parts[2], fpTag = parts[3];
+    if (hostPort.isEmpty || code.isEmpty || fpTag.isEmpty) {
+      throw const FormatException('pairing payload has an empty field');
+    }
+    return PairingQr(hostPort: hostPort, code: code, fpTag: fpTag);
+  }
+}

--- a/apps/android/lib/src/ui/pairing_screen.dart
+++ b/apps/android/lib/src/ui/pairing_screen.dart
@@ -2,13 +2,13 @@ import 'package:flutter/material.dart';
 
 import '../data/pairing_service.dart';
 import '../data/pairing_store.dart';
-import '../domain/paired_server.dart';
+import '../domain/pairing_qr.dart';
 import 'qr_scan_screen.dart';
 
-/// Manual pairing form (app-2). Enter the server URL + token + CA fingerprint
-/// from the desktop pairing screen; on success the verified connection is
-/// persisted and returned. QR scanning is a follow-up (a camera is impractical
-/// on an emulator), but this exercises the full verify → pin → probe flow.
+/// Manual pairing form (app-2). Enter the server host:port + pairing code +
+/// fingerprint tag from the desktop pairing screen; on success the verified
+/// connection is persisted and returned. QR scanning fills the fields so the
+/// user can review before pairing.
 class PairingScreen extends StatefulWidget {
   const PairingScreen({super.key, required this.service, required this.store});
 
@@ -20,17 +20,17 @@ class PairingScreen extends StatefulWidget {
 }
 
 class _PairingScreenState extends State<PairingScreen> {
-  final _url = TextEditingController();
-  final _token = TextEditingController();
-  final _fingerprint = TextEditingController();
+  final _host = TextEditingController();
+  final _code = TextEditingController();
+  final _fpTag = TextEditingController();
   bool _busy = false;
   String? _error;
 
   @override
   void dispose() {
-    _url.dispose();
-    _token.dispose();
-    _fingerprint.dispose();
+    _host.dispose();
+    _code.dispose();
+    _fpTag.dispose();
     super.dispose();
   }
 
@@ -40,12 +40,11 @@ class _PairingScreenState extends State<PairingScreen> {
       _error = null;
     });
     try {
-      final server = PairedServer(
-        url: _url.text.trim(),
-        token: _token.text.trim(),
-        caFingerprint: _fingerprint.text.trim(),
-      );
-      final conn = await widget.service.pair(server);
+      final qr = PairingQr(
+          hostPort: _host.text.trim(),
+          code: _code.text.trim(),
+          fpTag: _fpTag.text.trim());
+      final conn = await widget.service.pair(qr, label: 'Companion');
       final stamped =
           conn.server.copyWith(pairedAt: DateTime.now().toIso8601String());
       await widget.store.save(stamped);
@@ -55,8 +54,6 @@ class _PairingScreenState extends State<PairingScreen> {
       setState(() => _error = e.message);
     } on FormatException catch (e) {
       setState(() => _error = e.message);
-    } catch (e) {
-      setState(() => _error = 'Pairing failed: $e');
     } finally {
       if (mounted) setState(() => _busy = false);
     }
@@ -65,14 +62,14 @@ class _PairingScreenState extends State<PairingScreen> {
   /// Open the camera scanner; on a valid pairing QR, fill the form fields so
   /// the user can review before pairing.
   Future<void> _scan() async {
-    final server = await Navigator.of(context).push<PairedServer>(
+    final qr = await Navigator.of(context).push<PairingQr>(
       MaterialPageRoute(builder: (_) => const QrScanScreen()),
     );
-    if (server != null && mounted) {
+    if (qr != null && mounted) {
       setState(() {
-        _url.text = server.url;
-        _token.text = server.token;
-        _fingerprint.text = server.caFingerprint;
+        _host.text = qr.hostPort;
+        _code.text = qr.code;
+        _fpTag.text = qr.fpTag;
         _error = null;
       });
     }
@@ -98,21 +95,19 @@ class _PairingScreenState extends State<PairingScreen> {
             ),
             const SizedBox(height: 12),
             TextField(
-              key: const Key('field-url'),
-              controller: _url,
-              keyboardType: TextInputType.url,
-              decoration: const InputDecoration(labelText: 'Server URL (https://…:8443)'),
-            ),
+                key: const Key('field-host'),
+                controller: _host,
+                decoration:
+                    const InputDecoration(labelText: 'Server (host:port)')),
             TextField(
-              key: const Key('field-token'),
-              controller: _token,
-              decoration: const InputDecoration(labelText: 'Access token'),
-            ),
+                key: const Key('field-code'),
+                controller: _code,
+                decoration: const InputDecoration(labelText: 'Pairing code')),
             TextField(
-              key: const Key('field-fingerprint'),
-              controller: _fingerprint,
-              decoration: const InputDecoration(labelText: 'CA fingerprint (SHA-256)'),
-            ),
+                key: const Key('field-fptag'),
+                controller: _fpTag,
+                decoration:
+                    const InputDecoration(labelText: 'Fingerprint tag')),
             const SizedBox(height: 16),
             if (_error != null)
               Padding(

--- a/apps/android/lib/src/ui/qr_scan_screen.dart
+++ b/apps/android/lib/src/ui/qr_scan_screen.dart
@@ -43,13 +43,13 @@ class _QrScanScreenState extends State<QrScanScreen> {
         onScan: _onScan,
         codeFormat: Format.qrCode,
         // Decode robustness for real-world capture (a phone pointed at the QR on
-        // a desktop screen). The ReaderWidget defaults are tuned for big, clean
-        // codes filling the frame: tryHarder is OFF, only the centre 50% is
-        // decoded (cropPercent 0.5), and the camera caps at 720p. The pairing QR
-        // is dense ({url, token, caFingerprint}), so those defaults left it
-        // unreadable while the native camera app decoded the same code off the
-        // same screen. Match that: search the WHOLE frame at 1080p with the
-        // thorough binarizer/locator. tryRotate stays on (its default).
+        // a desktop screen). These settings (tryHarder, veryHigh resolution,
+        // cropPercent 1.0) were originally required when the pairing QR carried a
+        // dense JSON payload ({url, token, caFingerprint}) that the ReaderWidget
+        // defaults couldn't decode from a screen. The QR is now compact —
+        // CWP1*host:port*code*fpTag — so the aggressive settings are belt-and-
+        // suspenders, but they're cheap and protect against marginal capture
+        // conditions (glare, small screen, off-axis angle). tryRotate stays on.
         tryHarder: true,
         tryInverted: true,
         resolution: ResolutionPreset.veryHigh,

--- a/apps/android/lib/src/ui/qr_scan_screen.dart
+++ b/apps/android/lib/src/ui/qr_scan_screen.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_zxing/flutter_zxing.dart';
 
-import '../domain/paired_server.dart';
+import '../domain/pairing_qr.dart';
 
-/// Scans the server pairing QR and pops with the parsed [PairedServer]
+/// Scans the server pairing QR and pops with the parsed [PairingQr]
 /// (app-2). Non-matching codes are ignored so the camera keeps scanning.
 ///
 /// Uses `flutter_zxing` (zxing-cpp via FFI) rather than ML Kit: mobile_scanner
@@ -27,9 +27,9 @@ class _QrScanScreenState extends State<QrScanScreen> {
     final raw = code.text;
     if (raw == null || raw.isEmpty) return;
     try {
-      final server = PairedServer.fromQrPayload(raw);
+      final qr = PairingQr.parse(raw);
       _handled = true;
-      Navigator.of(context).pop(server);
+      Navigator.of(context).pop(qr);
     } on FormatException {
       // A QR, but not a pairing payload — keep scanning.
     }

--- a/apps/android/test/data/cert_pinning_test.dart
+++ b/apps/android/test/data/cert_pinning_test.dart
@@ -1,9 +1,14 @@
 import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:crypto/crypto.dart';
 import 'package:castwright/src/data/cert_pinning.dart';
+import 'package:castwright/src/data/crockford_base32.dart';
 
 String pemOf(List<int> der) =>
     '-----BEGIN CERTIFICATE-----\n${base64.encode(der)}\n-----END CERTIFICATE-----\n';
+
+/// Named constant reused by the fingerprintTagMatches test.
+final _testPem = pemOf(List<int>.generate(64, (i) => (i * 7) % 256));
 
 void main() {
   group('cert pinning', () {
@@ -21,6 +26,15 @@ void main() {
       expect(fingerprintsMatch('AB CD EF', 'ab:cd:ef'), isTrue);
       expect(fingerprintsMatch('ab:cd', 'ab:ce'), isFalse);
       expect(fingerprintsMatch('', 'abcd'), isFalse);
+    });
+
+    test('fingerprintTagMatches accepts the first-10-byte tag, case-insensitive', () {
+      final digest = sha256.convert(pemToDer(_testPem)).bytes;
+      final tag = crockfordBase32(digest.sublist(0, 10));
+      expect(tag.length, 16);
+      expect(fingerprintTagMatches(_testPem, tag), isTrue);
+      expect(fingerprintTagMatches(_testPem, tag.toLowerCase()), isTrue);
+      expect(fingerprintTagMatches(_testPem, 'Z' * 16), isFalse);
     });
 
     test('verifyCaFingerprint round-trips: matches its own fingerprint, rejects others', () {

--- a/apps/android/test/data/crockford_base32_test.dart
+++ b/apps/android/test/data/crockford_base32_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:castwright/src/data/crockford_base32.dart';
+
+void main() {
+  test('matches the server known-vector', () {
+    expect(crockfordBase32([0x01, 0x02, 0x03, 0x04, 0x05]), '04106105');
+  });
+  test('all-ones 5 bytes => ZZZZZZZZ', () {
+    expect(crockfordBase32([0xff, 0xff, 0xff, 0xff, 0xff]), 'ZZZZZZZZ');
+  });
+  test('10 bytes => 16 chars', () {
+    expect(crockfordBase32(List<int>.filled(10, 0)), '0000000000000000');
+  });
+}

--- a/apps/android/test/data/pairing_service_test.dart
+++ b/apps/android/test/data/pairing_service_test.dart
@@ -1,74 +1,60 @@
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:flutter_test/flutter_test.dart';
-import 'package:castwright/src/data/cert_pinning.dart';
 import 'package:castwright/src/data/pairing_service.dart';
-import 'package:castwright/src/domain/paired_server.dart';
+import 'package:castwright/src/domain/pairing_qr.dart';
 
-String pemOf(List<int> der) =>
-    '-----BEGIN CERTIFICATE-----\n${base64.encode(der)}\n-----END CERTIFICATE-----\n';
+const _qr = 'CWP1*192.168.1.5:8443*K7QF3M2P*J4XQ2A7BWZ9K3M5R';
+// Injected fetchCa/verifyTag/redeem mean this PEM is never parsed — any non-empty string is fine.
+const _pem = 'PEM-CONTENT';
 
 void main() {
-  final pem = pemOf(List<int>.generate(48, (i) => (i * 5 + 1) % 256));
-  final goodFp = caFingerprintFromPem(pem);
-  PairedServer server({String? fp}) =>
-      PairedServer(url: 'https://10.0.0.5:8443', token: 'tok', caFingerprint: fp ?? goodFp);
+  PairingQr qr() => PairingQr.parse(_qr);
 
-  group('PairingService.pair', () {
-    test('succeeds when the fingerprint matches and the probe is 2xx', () async {
-      final svc = PairingService(fetchCa: (_) async => pem, probe: (_, _) async => 200);
-      final conn = await svc.pair(server());
-      expect(conn.server.token, 'tok');
-      expect(conn.caPem, pem);
-    });
+  test('verifies tag, redeems code over pinned channel, returns token + full fp', () async {
+    final svc = PairingService(
+      fetchCa: (_) async => _pem,
+      verifyTag: (_, _) => true,
+      redeem: (baseUrl, code, caPem) async {
+        expect(baseUrl, 'https://192.168.1.5:8443');
+        expect(code, 'K7QF3M2P');
+        expect(caPem, _pem);
+        return const RedeemResult(token: 'tok_abc', caFingerprint: 'AB:CD:EF');
+      },
+    );
+    final conn = await svc.pair(qr(), label: 'Pixel');
+    expect(conn.server.token, 'tok_abc');
+    expect(conn.server.url, 'https://192.168.1.5:8443');
+    expect(conn.server.caFingerprint, 'AB:CD:EF');
+    expect(conn.caPem, _pem);
+  });
 
-    test('refuses (fingerprintMismatch) and never probes on a bad fingerprint', () async {
-      var probed = false;
-      final svc = PairingService(
-        fetchCa: (_) async => pem,
-        probe: (_, _) async {
-          probed = true;
-          return 200;
-        },
-      );
-      await expectLater(
-        svc.pair(server(fp: 'AB:CD:EF')),
-        throwsA(isA<PairingException>()
-            .having((e) => e.kind, 'kind', PairingErrorKind.fingerprintMismatch)),
-      );
-      expect(probed, isFalse);
-    });
+  test('refuses on fingerprint-tag mismatch (MitM)', () async {
+    final svc = PairingService(fetchCa: (_) async => _pem, verifyTag: (pem, tag) => false);
+    expect(
+      () => svc.pair(qr(), label: 'x'),
+      throwsA(isA<PairingException>()
+          .having((e) => e.kind, 'kind', PairingErrorKind.fingerprintMismatch)),
+    );
+  });
 
-    test('maps a fetch failure to unreachable', () async {
-      final svc = PairingService(
-        fetchCa: (_) async => throw const SocketException('no route'),
-        probe: (_, _) async => 200,
-      );
-      await expectLater(
-        svc.pair(server()),
-        throwsA(
-            isA<PairingException>().having((e) => e.kind, 'kind', PairingErrorKind.unreachable)),
-      );
-    });
+  test('maps a rejected code to tokenRejected', () async {
+    final svc = PairingService(
+      fetchCa: (_) async => _pem,
+      verifyTag: (_, _) => true,
+      redeem: (url, code, pem) async => throw const RedeemRejected(),
+    );
+    expect(
+      () => svc.pair(qr(), label: 'x'),
+      throwsA(isA<PairingException>()
+          .having((e) => e.kind, 'kind', PairingErrorKind.tokenRejected)),
+    );
+  });
 
-    test('maps 401 and 403 to tokenRejected', () async {
-      for (final code in [401, 403]) {
-        final svc = PairingService(fetchCa: (_) async => pem, probe: (_, _) async => code);
-        await expectLater(
-          svc.pair(server()),
-          throwsA(isA<PairingException>()
-              .having((e) => e.kind, 'kind', PairingErrorKind.tokenRejected)),
-        );
-      }
-    });
-
-    test('maps other 5xx to server', () async {
-      final svc = PairingService(fetchCa: (_) async => pem, probe: (_, _) async => 500);
-      await expectLater(
-        svc.pair(server()),
-        throwsA(isA<PairingException>().having((e) => e.kind, 'kind', PairingErrorKind.server)),
-      );
-    });
+  test('maps an unreachable CA fetch to unreachable', () async {
+    final svc = PairingService(fetchCa: (_) async => throw Exception('no route'));
+    expect(
+      () => svc.pair(qr(), label: 'x'),
+      throwsA(isA<PairingException>()
+          .having((e) => e.kind, 'kind', PairingErrorKind.unreachable)),
+    );
   });
 }

--- a/apps/android/test/domain/paired_server_test.dart
+++ b/apps/android/test/domain/paired_server_test.dart
@@ -43,21 +43,5 @@ void main() {
       );
     });
 
-    group('fromQrPayload', () {
-      test('parses a scanned JSON payload', () {
-        final s = PairedServer.fromQrPayload(
-          '{"url":"https://10.0.0.5:8443","token":"t","caFingerprint":"AB:CD"}',
-        );
-        expect(s.url, 'https://10.0.0.5:8443');
-        expect(s.token, 't');
-        expect(s.caFingerprint, 'AB:CD');
-      });
-
-      test('rejects non-JSON and non-object payloads', () {
-        expect(() => PairedServer.fromQrPayload('not json'), throwsA(isA<FormatException>()));
-        expect(() => PairedServer.fromQrPayload('"a string"'), throwsA(isA<FormatException>()));
-        expect(() => PairedServer.fromQrPayload('[1,2,3]'), throwsA(isA<FormatException>()));
-      });
-    });
   });
 }

--- a/apps/android/test/domain/pairing_qr_test.dart
+++ b/apps/android/test/domain/pairing_qr_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:castwright/src/domain/pairing_qr.dart';
+
+void main() {
+  test('parses a valid CWP1 payload', () {
+    final qr = PairingQr.parse('CWP1*192.168.1.5:8443*K7QF3M2P*J4XQ2A7BWZ9K3M5R');
+    expect(qr.hostPort, '192.168.1.5:8443');
+    expect(qr.baseUrl, 'https://192.168.1.5:8443');
+    expect(qr.code, 'K7QF3M2P');
+    expect(qr.fpTag, 'J4XQ2A7BWZ9K3M5R');
+  });
+
+  test('rejects wrong magic', () {
+    expect(() => PairingQr.parse('XXXX*h:1*c*t'), throwsFormatException);
+  });
+
+  test('rejects wrong arity', () {
+    expect(() => PairingQr.parse('CWP1*h:1*c'), throwsFormatException);
+    expect(() => PairingQr.parse('CWP1*h:1*c*t*extra'), throwsFormatException);
+  });
+
+  test('rejects an empty field', () {
+    expect(() => PairingQr.parse('CWP1**c*t'), throwsFormatException);
+    expect(() => PairingQr.parse('CWP1*h:1**t'), throwsFormatException);
+    expect(() => PairingQr.parse('CWP1*h:1*c*'), throwsFormatException);
+  });
+}

--- a/apps/android/test/ui/pairing_screen_test.dart
+++ b/apps/android/test/ui/pairing_screen_test.dart
@@ -1,9 +1,6 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:castwright/src/data/cert_pinning.dart';
 import 'package:castwright/src/data/pairing_service.dart';
 import 'package:castwright/src/data/pairing_store.dart';
 import 'package:castwright/src/domain/paired_server.dart';
@@ -24,15 +21,7 @@ class FakeStore implements PairingStore {
   Future<String?> loadCaPem() async => savedCaPem;
 }
 
-String pemOf(List<int> der) =>
-    '-----BEGIN CERTIFICATE-----\n${base64.encode(der)}\n-----END CERTIFICATE-----\n';
-
 void main() {
-  final pem = pemOf(List<int>.generate(40, (i) => i));
-  final goodFp = caFingerprintFromPem(pem);
-
-  // Pump a host route and open PairingScreen on top, so its success-path pop()
-  // returns to a real previous route.
   Future<void> open(WidgetTester tester, PairingService service, PairingStore store) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -52,31 +41,34 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  Future<void> fill(WidgetTester tester, String fingerprint) async {
-    await tester.enterText(find.byKey(const Key('field-url')), 'https://10.0.0.5:8443');
-    await tester.enterText(find.byKey(const Key('field-token')), 'tok');
-    await tester.enterText(find.byKey(const Key('field-fingerprint')), fingerprint);
+  Future<void> fill(WidgetTester tester) async {
+    await tester.enterText(find.byKey(const Key('field-host')), '10.0.0.5:8443');
+    await tester.enterText(find.byKey(const Key('field-code')), 'K7QF3M2P');
+    await tester.enterText(find.byKey(const Key('field-fptag')), 'J4XQ2A7BWZ9K3M5R');
     await tester.tap(find.widgetWithText(FilledButton, 'Pair'));
     await tester.pumpAndSettle();
   }
 
-  testWidgets('shows the mismatch error and does not save on a wrong fingerprint', (tester) async {
+  testWidgets('shows the mismatch error and does not save on a bad tag', (tester) async {
     final store = FakeStore();
-    final service = PairingService(fetchCa: (_) async => pem, probe: (_, _) async => 200);
+    final service = PairingService(fetchCa: (url) async => 'pem', verifyTag: (pem, tag) => false);
     await open(tester, service, store);
-    await fill(tester, 'AB:CD:EF'); // wrong fingerprint
-
+    await fill(tester);
     expect(find.byKey(const Key('pair-error')), findsOneWidget);
     expect(store.saved, isNull);
   });
 
-  testWidgets('saves the connection on a matching fingerprint + ok probe', (tester) async {
+  testWidgets('saves the connection on a good tag + successful redeem', (tester) async {
     final store = FakeStore();
-    final service = PairingService(fetchCa: (_) async => pem, probe: (_, _) async => 200);
+    final service = PairingService(
+      fetchCa: (url) async => 'pem',
+      verifyTag: (pem, tag) => true,
+      redeem: (url, code, caPem) async => const RedeemResult(token: 'tok', caFingerprint: 'AB:CD'),
+    );
     await open(tester, service, store);
-    await fill(tester, goodFp); // correct
-
+    await fill(tester);
     expect(store.saved, isNotNull);
     expect(store.saved!.url, 'https://10.0.0.5:8443');
+    expect(store.saved!.token, 'tok');
   });
 }

--- a/docs/superpowers/plans/2026-06-10-pairing-qr-redesign.md
+++ b/docs/superpowers/plans/2026-06-10-pairing-qr-redesign.md
@@ -1,0 +1,1250 @@
+# Pairing-QR Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Shrink the companion pairing QR from v10 (57×57, undecodable by flutter_zxing off a screen) to ~v3 (29×29) by moving the token + full fingerprint off the QR, replacing them with an ephemeral pairing code + an 80-bit fingerprint tag — without weakening the security model.
+
+**Architecture:** The QR carries `CWP1*host:port*code*fpTag`. The server mints an ephemeral `code` + computes `fpTag` (first 10 bytes of the CA SHA-256, Crockford-base32) via a loopback-only `POST /api/pair/session`; it mints a per-device token only when the app redeems the code over `POST /api/pair/redeem` (guard-exempt, code-gated). The app verifies the fetched cert against `fpTag` before pinning, then redeems over the pinned channel.
+
+**Tech Stack:** Node/Express + Vitest (server), Vite/React/RTK + Vitest/RTL (frontend), Flutter/Dart + flutter_test (app), `qrcode` (render), `flutter_zxing` (scan), `zxing-wasm` (decode regression test).
+
+**Spec:** `docs/superpowers/specs/2026-06-10-pairing-qr-redesign-design.md`
+
+**Worktree:** `C:\Claude\wt-pairing-qr` on branch `feat/pairing-qr-redesign`.
+
+---
+
+## File Structure
+
+**Server (`server/src/`)**
+- Create `lib/crockford-base32.ts` — encode-only Crockford base32 (shared by code + fpTag). One responsibility: byte[] → base32 string.
+- Create `workspace/pairing-sessions.ts` — in-memory ephemeral pairing-code store (create / redeem / expiry / single-use).
+- Create `routes/pairing.ts` — exports `pairSessionRouter` (POST /session, loopback) + `pairRedeemRouter` (POST /redeem, guard-exempt). Computes `fpTag`, builds the QR payload, calls `createDevice` on redeem.
+- Modify `routes/index` wiring in `index.ts` — mount redeem before the LAN guard, session after.
+- Tests: `lib/crockford-base32.test.ts`, `workspace/pairing-sessions.test.ts`, `routes/pairing.test.ts`.
+
+**Frontend (`src/`)**
+- Modify `lib/types.ts` — add `PairSessionInfo`.
+- Modify `lib/api.ts` — add `createPairSession()`.
+- Modify `modals/pair-device.tsx` — fetch `/session`, render the compact QR larger/white/crisp, countdown, manual fields, regenerate.
+- Tests: `modals/pair-device.test.tsx` (update).
+
+**App (`apps/android/lib/src/`)**
+- Create `domain/pairing_qr.dart` — `PairingQr` value type + `CWP1*…` parser.
+- Create `data/crockford_base32.dart` — encode-only Crockford base32 (mirror of the server helper).
+- Modify `data/cert_pinning.dart` — add `fingerprintTagMatches(pem, tag)`.
+- Modify `data/pairing_service.dart` — redeem flow (verify tag → redeem code over pinned client → token).
+- Modify `ui/qr_scan_screen.dart` — return `PairingQr` instead of `PairedServer`.
+- Modify `ui/pairing_screen.dart` — host/code/fpTag fields + run the redeem flow.
+- Modify `domain/paired_server.dart` — remove `fromQrPayload` (JSON `fromJson` for storage stays).
+- Tests: `test/domain/pairing_qr_test.dart`, `test/data/crockford_base32_test.dart`, `test/data/cert_pinning_test.dart` (extend), `test/data/pairing_service_test.dart` (rewrite), `test/ui/pairing_screen_test.dart` (update), `test/ui/qr_scan_screen_test.dart` (update).
+
+**Regression**
+- Create `apps/android` or server-side decode test proving the new QR round-trips through zxing (Task 12).
+
+---
+
+## Task 1: Crockford base32 encode helper (server)
+
+**Files:**
+- Create: `server/src/lib/crockford-base32.ts`
+- Test: `server/src/lib/crockford-base32.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { crockfordBase32 } from './crockford-base32.js';
+
+describe('crockfordBase32', () => {
+  it('encodes 10 bytes to 16 chars (80 bits / 5)', () => {
+    const bytes = Buffer.from('00112233445566778899', 'hex');
+    expect(crockfordBase32(bytes)).toHaveLength(16);
+  });
+
+  it('encodes 5 bytes to 8 chars (40 bits / 5)', () => {
+    expect(crockfordBase32(Buffer.from('0000000000', 'hex'))).toBe('00000000');
+  });
+
+  it('uses the Crockford alphabet (no I L O U, upper-case)', () => {
+    // 0xFF repeated → all-ones nibbles map to the top of the alphabet
+    const out = crockfordBase32(Buffer.from('ffffffffff', 'hex'));
+    expect(out).toBe('ZZZZZZZZ');
+    expect(out).not.toMatch(/[ILOU]/);
+  });
+
+  it('is deterministic and stable for a known vector', () => {
+    // bytes 0x01 0x02 0x03 0x04 0x05 => 5 bytes => 8 chars
+    expect(crockfordBase32(Buffer.from('0102030405', 'hex'))).toBe('0420C205');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/lib/crockford-base32.test.ts`
+Expected: FAIL — "Cannot find module './crockford-base32.js'".
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+/* Crockford base32 (no padding) — encode-only. Used for the ephemeral pairing
+   code and the 80-bit CA fingerprint tag in the companion pairing QR. Output is
+   a subset of QR alphanumeric mode, so the QR stays in its densest encoding.
+   Alphabet excludes I, L, O, U to avoid visual ambiguity in manual entry. */
+const ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+export function crockfordBase32(bytes: Uint8Array): string {
+  let out = '';
+  let buffer = 0;
+  let bits = 0;
+  for (const byte of bytes) {
+    buffer = (buffer << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      out += ALPHABET[(buffer >>> bits) & 0x1f];
+    }
+  }
+  if (bits > 0) {
+    out += ALPHABET[(buffer << (5 - bits)) & 0x1f];
+  }
+  return out;
+}
+```
+
+> Note: 10 bytes (80 bits) and 5 bytes (40 bits) are both exact multiples of 5,
+> so the trailing-bits branch never pads for our two real inputs.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/lib/crockford-base32.test.ts`
+Expected: PASS (4 tests). If the known-vector in Step 1 differs from your encoder, compute the real value once with a scratch node REPL and lock it in — do not change the algorithm to match a guessed constant.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/lib/crockford-base32.ts server/src/lib/crockford-base32.test.ts
+git commit -m "feat(server): Crockford base32 encoder for pairing code + fp tag"
+```
+
+---
+
+## Task 2: Ephemeral pairing-session store (server)
+
+**Files:**
+- Create: `server/src/workspace/pairing-sessions.ts`
+- Test: `server/src/workspace/pairing-sessions.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createPairingSession,
+  redeemPairingSession,
+  _resetPairingSessionsForTests,
+} from './pairing-sessions.js';
+
+describe('pairing-sessions', () => {
+  beforeEach(() => _resetPairingSessionsForTests());
+
+  it('creates a session with an 8-char code and future expiry', () => {
+    const now = 1_000_000;
+    const s = createPairingSession(now);
+    expect(s.code).toMatch(/^[0-9A-HJKMNP-TV-Z]{8}$/);
+    expect(s.expiresAt).toBeGreaterThan(now);
+  });
+
+  it('redeems a valid code exactly once', () => {
+    const now = 1_000_000;
+    const { code } = createPairingSession(now);
+    expect(redeemPairingSession(code, now + 1)).toEqual({ ok: true });
+    // second redemption fails (single-use)
+    expect(redeemPairingSession(code, now + 2)).toEqual({ ok: false, reason: 'consumed' });
+  });
+
+  it('rejects an unknown code', () => {
+    expect(redeemPairingSession('ZZZZZZZZ', 1)).toEqual({ ok: false, reason: 'unknown' });
+  });
+
+  it('rejects an expired code', () => {
+    const now = 1_000_000;
+    const { code, expiresAt } = createPairingSession(now);
+    expect(redeemPairingSession(code, expiresAt + 1)).toEqual({ ok: false, reason: 'expired' });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/workspace/pairing-sessions.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+/* In-memory ephemeral pairing sessions for the companion QR redesign.
+
+   A session is a single-use, time-boxed `code` that authorises minting ONE
+   per-device token via POST /api/pair/redeem. We deliberately persist nothing:
+   a pre-auth secret should never hit disk, and losing pending sessions on a
+   restart is harmless (re-open the desktop modal). `now` is injected so the
+   store is unit-testable without a clock. */
+import { randomBytes } from 'node:crypto';
+import { crockfordBase32 } from '../lib/crockford-base32.js';
+
+const TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+interface Session {
+  expiresAt: number;
+  consumed: boolean;
+}
+
+const sessions = new Map<string, Session>();
+
+function sweep(now: number): void {
+  for (const [code, s] of sessions) {
+    if (s.consumed || now > s.expiresAt) sessions.delete(code);
+  }
+}
+
+export interface NewPairingSession {
+  code: string;
+  expiresAt: number;
+}
+
+export function createPairingSession(now: number = Date.now()): NewPairingSession {
+  sweep(now);
+  // 5 bytes = 40 bits => 8 Crockford chars.
+  const code = crockfordBase32(randomBytes(5));
+  const expiresAt = now + TTL_MS;
+  sessions.set(code, { expiresAt, consumed: false });
+  return { code, expiresAt };
+}
+
+export type RedeemResult =
+  | { ok: true }
+  | { ok: false; reason: 'unknown' | 'expired' | 'consumed' };
+
+export function redeemPairingSession(code: string, now: number = Date.now()): RedeemResult {
+  const s = sessions.get(code);
+  if (!s) return { ok: false, reason: 'unknown' };
+  if (s.consumed) return { ok: false, reason: 'consumed' };
+  if (now > s.expiresAt) {
+    sessions.delete(code);
+    return { ok: false, reason: 'expired' };
+  }
+  s.consumed = true;
+  return { ok: true };
+}
+
+export function _resetPairingSessionsForTests(): void {
+  sessions.clear();
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/workspace/pairing-sessions.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/workspace/pairing-sessions.ts server/src/workspace/pairing-sessions.test.ts
+git commit -m "feat(server): in-memory ephemeral pairing-session store"
+```
+
+---
+
+## Task 3: Pairing routes + fpTag + wiring (server)
+
+**Files:**
+- Create: `server/src/routes/pairing.ts`
+- Modify: `server/src/index.ts` (mount redeem before the LAN guard at line ~176; mount session after)
+- Test: `server/src/routes/pairing.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { pairSessionRouter, pairRedeemRouter } from './pairing.js';
+import { _resetPairingSessionsForTests } from '../workspace/pairing-sessions.js';
+
+// Force LAN-HTTPS mode + a resolvable CA fingerprint for the session route.
+vi.mock('./export-lan.js', async (orig) => {
+  const real = await orig<typeof import('./export-lan.js')>();
+  return {
+    ...real,
+    isLanHttpsEnabled: () => true,
+    enumerateLanUrls: () => ({ urls: ['https://192.168.1.5:8443'], port: 8443, protocol: 'https' as const }),
+  };
+});
+vi.mock('./cert-root.js', () => ({
+  resolveRootCaPath: () => ({ path: 'FAKE', source: 'default' as const }),
+}));
+// Stub the cert read so fpTag is deterministic.
+vi.mock('node:fs', async (orig) => {
+  const real = await orig<typeof import('node:fs')>();
+  return { ...real, readFileSync: (p: string, ...rest: unknown[]) =>
+    p === 'FAKE' ? Buffer.from(TEST_CERT_PEM) : (real.readFileSync as any)(p, ...rest) };
+});
+
+// A self-signed test cert (PEM). Generate once with:
+//   openssl req -x509 -newkey ed25519 -nodes -days 1 -subj "/CN=t" -keyout /dev/null -out cert.pem
+const TEST_CERT_PEM = `-----BEGIN CERTIFICATE-----
+<PASTE A REAL SHORT TEST CERT — see Step 1 note>
+-----END CERTIFICATE-----`;
+
+function appWith(router: express.Router, base = '/api/pair') {
+  const app = express();
+  app.use(express.json());
+  app.use(base, router);
+  return app;
+}
+
+describe('pairing routes', () => {
+  beforeEach(() => _resetPairingSessionsForTests());
+
+  it('POST /session returns a qrPayload + code + fpTag (loopback)', async () => {
+    const res = await request(appWith(pairSessionRouter)).post('/api/pair/session').send({});
+    expect(res.status).toBe(200);
+    expect(res.body.code).toMatch(/^[0-9A-HJKMNP-TV-Z]{8}$/);
+    expect(res.body.fpTag).toMatch(/^[0-9A-HJKMNP-TV-Z]{16}$/);
+    expect(res.body.qrPayload).toBe(`CWP1*192.168.1.5:8443*${res.body.code}*${res.body.fpTag}`);
+    expect(res.body.expiresAt).toBeGreaterThan(0);
+  });
+
+  it('POST /redeem mints a token for a fresh code, then 410 on reuse', async () => {
+    const session = await request(appWith(pairSessionRouter)).post('/api/pair/session').send({});
+    const redeem = appWith(pairRedeemRouter);
+    const first = await request(redeem).post('/api/pair/redeem').send({ code: session.body.code, label: 'Pixel' });
+    expect(first.status).toBe(201);
+    expect(typeof first.body.token).toBe('string');
+    expect(first.body.token.length).toBeGreaterThan(0);
+    const second = await request(redeem).post('/api/pair/redeem').send({ code: session.body.code });
+    expect(second.status).toBe(410);
+  });
+
+  it('POST /redeem 401s an unknown code', async () => {
+    const res = await request(appWith(pairRedeemRouter)).post('/api/pair/redeem').send({ code: 'ZZZZZZZZ' });
+    expect(res.status).toBe(401);
+  });
+});
+```
+
+> Step 1 note: replace `<PASTE A REAL SHORT TEST CERT>` with an actual PEM block
+> (the test only needs the cert to parse + hash). Generate one and paste it; do
+> NOT leave the placeholder. The `createDevice` call writes to the workspace —
+> rely on the existing test workspace setup used by other `routes/*.test.ts`
+> files (check `server/vitest.config.ts` / `setup` for the tmp workspace), or
+> mock `../workspace/device-tokens.js`'s `createDevice` to return
+> `{ device: { id: 'd1' }, token: 'tok_abc' }` for hermeticity. Prefer the mock.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/routes/pairing.test.ts`
+Expected: FAIL — module `./pairing.js` not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+/* Companion pairing routes (QR redesign).
+
+   POST /api/pair/session  — loopback-only (the desktop UI). Mints an ephemeral
+     code, computes the 80-bit CA fingerprint tag, and returns the compact QR
+     payload string the modal renders. Mints NO device token.
+   POST /api/pair/redeem   — guard-exempt (an unpaired device holds only the
+     code, not a LAN token). Gated by the code; mints a per-device token over
+     the caller's already-cert-pinned channel.
+
+   The redeem router MUST be mounted BEFORE the `/api` LAN-token guard in
+   index.ts; the session router AFTER it. */
+import { readFileSync } from 'node:fs';
+import { X509Certificate } from 'node:crypto';
+import { Router } from 'express';
+import type { Request, Response } from '../http.js';
+import { isLanHttpsEnabled, enumerateLanUrls } from './export-lan.js';
+import { resolveRootCaPath } from './cert-root.js';
+import { crockfordBase32 } from '../lib/crockford-base32.js';
+import { createPairingSession, redeemPairingSession } from '../workspace/pairing-sessions.js';
+import { createDevice } from '../workspace/device-tokens.js';
+import { isLoopbackRequest } from '../lan-auth.js';
+
+/** First 10 bytes (80 bits) of the CA cert's SHA-256, Crockford-base32. */
+export function caFingerprintTag(): string | undefined {
+  try {
+    const ca = resolveRootCaPath();
+    if (!ca) return undefined;
+    const hex = new X509Certificate(readFileSync(ca.path)).fingerprint256; // "AB:CD:.."
+    const bytes = Buffer.from(hex.replace(/:/g, ''), 'hex'); // 32 bytes
+    return crockfordBase32(bytes.subarray(0, 10)); // 16 chars
+  } catch {
+    return undefined;
+  }
+}
+
+export const pairSessionRouter = Router();
+
+pairSessionRouter.post('/session', (req: Request, res: Response) => {
+  if (!isLoopbackRequest(req)) {
+    res.status(403).json({ error: 'Pairing sessions can only be created from the host UI.' });
+    return;
+  }
+  if (!isLanHttpsEnabled()) {
+    res.status(409).json({ error: 'not-lan-https' });
+    return;
+  }
+  const { urls, port } = enumerateLanUrls(Number(process.env.LAN_HTTPS_PORT ?? 8443), 'https');
+  const host = urls[0]?.replace(/^https:\/\//, '');
+  const fpTag = caFingerprintTag();
+  if (!host || !fpTag) {
+    res.status(409).json({ error: !host ? 'no-lan-url' : 'no-ca' });
+    return;
+  }
+  const { code, expiresAt } = createPairingSession();
+  const qrPayload = `CWP1*${host}*${code}*${fpTag}`;
+  res.json({ qrPayload, hostPort: host, port, code, fpTag, expiresAt });
+});
+
+export const pairRedeemRouter = Router();
+
+pairRedeemRouter.post('/redeem', async (req: Request, res: Response) => {
+  const body = (req.body ?? {}) as { code?: unknown; label?: unknown };
+  const code = typeof body.code === 'string' ? body.code : '';
+  const label = typeof body.label === 'string' ? body.label : 'Device';
+  const result = redeemPairingSession(code);
+  if (!result.ok) {
+    const status = result.reason === 'unknown' ? 401 : 410;
+    res.status(status).json({ error: result.reason });
+    return;
+  }
+  const { token } = await createDevice(label);
+  res.status(201).json({ token });
+});
+```
+
+- [ ] **Step 4: Wire into `index.ts`**
+
+Find the LAN guard line (`app.use(['/api', '/workspace'], requireLanToken);`, ~line 176). Add the import near the other route imports (~line 72):
+
+```ts
+import { pairSessionRouter, pairRedeemRouter } from './routes/pairing.js';
+```
+
+Mount the **redeem** router BEFORE the guard (so it's reachable without a token), immediately above the `requireLanToken` line:
+
+```ts
+app.use('/api/pair', pairRedeemRouter); // QR pairing — code-gated, intentionally pre-guard
+app.use(['/api', '/workspace'], requireLanToken);
+```
+
+Mount the **session** router AFTER the guard, near the other `/api` mounts (e.g. just after the `devicesRouter` mount, ~line 192):
+
+```ts
+app.use('/api/pair', pairSessionRouter); // QR pairing — loopback-only session mint (post-guard)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd server && npx vitest run src/routes/pairing.test.ts`
+Expected: PASS (3 tests).
+Run: `cd server && npx tsc --noEmit` (confirm index.ts wiring type-checks).
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/routes/pairing.ts server/src/routes/pairing.test.ts server/src/index.ts
+git commit -m "feat(server): /api/pair session + redeem routes for QR pairing"
+```
+
+---
+
+## Task 4: Frontend API + types (`createPairSession`)
+
+**Files:**
+- Modify: `src/lib/types.ts` (add `PairSessionInfo`)
+- Modify: `src/lib/api.ts` (add `createPairSession`)
+- Test: `src/lib/api.mock-state.test.ts` or a focused `src/lib/api.test.ts` (follow the file the repo uses for `getExportLanUrls`)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { api } from './api';
+
+describe('api.createPairSession', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('POSTs /api/pair/session and returns the payload', async () => {
+    const info = {
+      qrPayload: 'CWP1*192.168.1.5:8443*K7QF3M2P*J4XQ2A7BWZ9K3M5R',
+      hostPort: '192.168.1.5:8443', port: 8443,
+      code: 'K7QF3M2P', fpTag: 'J4XQ2A7BWZ9K3M5R', expiresAt: 99,
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(info), { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+    await expect(api.createPairSession()).resolves.toEqual(info);
+  });
+});
+```
+
+> Adjust the import/mocking to match how the repo's existing `getExportLanUrls`
+> test stubs the transport (some tests mock the real client, not global fetch).
+> Mirror that file's pattern exactly.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/api.mock-state.test.ts`
+Expected: FAIL — `api.createPairSession is not a function`.
+
+- [ ] **Step 3: Add the type + the method**
+
+In `src/lib/types.ts`:
+
+```ts
+/** Result of POST /api/pair/session — the companion pairing QR payload + the
+    fields the modal also shows for manual entry. */
+export interface PairSessionInfo {
+  qrPayload: string;
+  hostPort: string;
+  port: number;
+  code: string;
+  fpTag: string;
+  expiresAt: number;
+}
+```
+
+In `src/lib/api.ts`, add to BOTH the `mock` and `real` API objects (mirror how
+`getExportLanUrls` is defined in each). Real:
+
+```ts
+async createPairSession(): Promise<PairSessionInfo> {
+  const res = await fetch('/api/pair/session', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' });
+  if (!res.ok) throw new Error(`pair session failed: ${res.status}`);
+  return (await res.json()) as PairSessionInfo;
+},
+```
+
+Mock (returns a deterministic fake so the modal renders in mock mode):
+
+```ts
+async createPairSession(): Promise<PairSessionInfo> {
+  const code = 'K7QF3M2P';
+  const fpTag = 'J4XQ2A7BWZ9K3M5R';
+  const hostPort = '192.168.1.5:8443';
+  return { qrPayload: `CWP1*${hostPort}*${code}*${fpTag}`, hostPort, port: 8443, code, fpTag, expiresAt: Date.now() + 300000 };
+},
+```
+
+Import `PairSessionInfo` where the other type imports live.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/api.mock-state.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/types.ts src/lib/api.ts src/lib/api.mock-state.test.ts
+git commit -m "feat(frontend): api.createPairSession + PairSessionInfo type"
+```
+
+---
+
+## Task 5: Rewrite the pair-device modal
+
+**Files:**
+- Modify: `src/modals/pair-device.tsx`
+- Test: `src/modals/pair-device.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { PairDeviceModal } from './pair-device';
+import { api } from '../lib/api';
+
+describe('PairDeviceModal (QR redesign)', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('renders the compact QR from the session payload', async () => {
+    vi.spyOn(api, 'createPairSession').mockResolvedValue({
+      qrPayload: 'CWP1*192.168.1.5:8443*K7QF3M2P*J4XQ2A7BWZ9K3M5R',
+      hostPort: '192.168.1.5:8443', port: 8443,
+      code: 'K7QF3M2P', fpTag: 'J4XQ2A7BWZ9K3M5R', expiresAt: Date.now() + 300000,
+    });
+    render(<PairDeviceModal open onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByTestId('pair-qr-image')).toBeInTheDocument());
+    // manual-entry fields
+    expect(screen.getByText('192.168.1.5:8443')).toBeInTheDocument();
+    expect(screen.getByText('K7QF3M2P')).toBeInTheDocument();
+  });
+
+  it('shows the unavailable state when the session 409s', async () => {
+    vi.spyOn(api, 'createPairSession').mockRejectedValue(new Error('pair session failed: 409'));
+    render(<PairDeviceModal open onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByTestId('pair-device-unavailable')).toBeInTheDocument());
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/modals/pair-device.test.tsx`
+Expected: FAIL — modal still calls `getExportLanUrls` / asserts old structure.
+
+- [ ] **Step 3: Rewrite the modal**
+
+Replace the data-fetch + payload logic. Key changes (keep the existing JSX shell,
+`CopyRow`, and the header):
+
+```tsx
+import { useEffect, useMemo, useState } from 'react';
+import QRCode from 'qrcode';
+import { api } from '../lib/api';
+import type { PairSessionInfo } from '../lib/types';
+// (icons import unchanged)
+
+export function PairDeviceModal({ open, onClose }: PairDeviceModalProps) {
+  const [info, setInfo] = useState<PairSessionInfo | null>(null);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'unavailable' | 'error'>('loading');
+  const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+  const [nonce, setNonce] = useState(0); // bump to regenerate
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setStatus('loading');
+    setQrDataUrl(null);
+    api.createPairSession()
+      .then((r) => { if (!cancelled) { setInfo(r); setStatus('ready'); } })
+      .catch((e: Error) => {
+        if (cancelled) return;
+        // 409 == not LAN-HTTPS / no CA → explain how to enable; else generic error
+        setStatus(/\b409\b/.test(e.message) ? 'unavailable' : 'error');
+      });
+    return () => { cancelled = true; };
+  }, [open, nonce]);
+
+  useEffect(() => {
+    if (status !== 'ready' || !info) { setQrDataUrl(null); return; }
+    let cancelled = false;
+    QRCode.toDataURL(info.qrPayload, { margin: 4, scale: 8, errorCorrectionLevel: 'M' })
+      .then((d) => { if (!cancelled) setQrDataUrl(d); })
+      .catch(() => { if (!cancelled) setQrDataUrl(null); });
+    return () => { cancelled = true; };
+  }, [status, info]);
+
+  if (!open) return null;
+  // ... render: 'loading' | 'error' | 'unavailable' (existing copy) | 'ready'
+}
+```
+
+For the `ready` branch render the QR on **white**, larger, crisp, no rounded
+corners on the code itself:
+
+```tsx
+<div className="grid place-items-center">
+  <div className="bg-white p-3 rounded-2xl border border-ink/10">
+    {qrDataUrl ? (
+      <img
+        src={qrDataUrl}
+        alt="Pairing QR code"
+        data-testid="pair-qr-image"
+        width={288}
+        height={288}
+        className="block w-72 h-72"
+        style={{ imageRendering: 'pixelated' }}
+      />
+    ) : (
+      <div className="w-72 h-72 grid place-items-center text-ink/40">Generating…</div>
+    )}
+  </div>
+</div>
+```
+
+Manual-entry `<details>` uses the new fields:
+
+```tsx
+<CopyRow label="Server" value={info.hostPort} mono />
+<CopyRow label="Pairing code" value={info.code} mono />
+<CopyRow label="Fingerprint tag" value={info.fpTag} mono />
+```
+
+Add a "Regenerate code" button in the ready branch: `onClick={() => setNonce((n) => n + 1)}`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/modals/pair-device.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/modals/pair-device.tsx src/modals/pair-device.test.tsx
+git commit -m "feat(frontend): pair-device modal renders compact QR from /pair/session"
+```
+
+---
+
+## Task 6: App — `PairingQr` parser
+
+**Files:**
+- Create: `apps/android/lib/src/domain/pairing_qr.dart`
+- Test: `apps/android/test/domain/pairing_qr_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:castwright/src/domain/pairing_qr.dart';
+
+void main() {
+  test('parses a valid CWP1 payload', () {
+    final qr = PairingQr.parse('CWP1*192.168.1.5:8443*K7QF3M2P*J4XQ2A7BWZ9K3M5R');
+    expect(qr.baseUrl, 'https://192.168.1.5:8443');
+    expect(qr.code, 'K7QF3M2P');
+    expect(qr.fpTag, 'J4XQ2A7BWZ9K3M5R');
+  });
+
+  test('rejects wrong magic', () {
+    expect(() => PairingQr.parse('XXXX*h:1*c*t'), throwsFormatException);
+  });
+
+  test('rejects wrong arity / empty field', () {
+    expect(() => PairingQr.parse('CWP1*h:1*c'), throwsFormatException);
+    expect(() => PairingQr.parse('CWP1**c*t'), throwsFormatException);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/android && flutter test test/domain/pairing_qr_test.dart`
+Expected: FAIL — `pairing_qr.dart` not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+/// Parsed companion pairing QR (`CWP1*host:port*code*fpTag`). Pure data, no
+/// platform deps — fully unit-testable. Replaces the old JSON QR payload.
+class PairingQr {
+  const PairingQr({required this.hostPort, required this.code, required this.fpTag});
+
+  final String hostPort;
+  final String code;
+  final String fpTag;
+
+  String get baseUrl => 'https://$hostPort';
+
+  factory PairingQr.parse(String raw) {
+    final parts = raw.split('*');
+    if (parts.length != 4 || parts[0] != 'CWP1') {
+      throw const FormatException('not a CWP1 pairing payload');
+    }
+    final hostPort = parts[1], code = parts[2], fpTag = parts[3];
+    if (hostPort.isEmpty || code.isEmpty || fpTag.isEmpty) {
+      throw const FormatException('pairing payload has an empty field');
+    }
+    return PairingQr(hostPort: hostPort, code: code, fpTag: fpTag);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/android && flutter test test/domain/pairing_qr_test.dart`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/android/lib/src/domain/pairing_qr.dart apps/android/test/domain/pairing_qr_test.dart
+git commit -m "feat(app): PairingQr parser for the compact CWP1 pairing payload"
+```
+
+---
+
+## Task 7: App — Crockford base32 + `fingerprintTagMatches`
+
+**Files:**
+- Create: `apps/android/lib/src/data/crockford_base32.dart`
+- Modify: `apps/android/lib/src/data/cert_pinning.dart`
+- Test: `apps/android/test/data/crockford_base32_test.dart`, extend `apps/android/test/data/cert_pinning_test.dart`
+
+- [ ] **Step 1: Write the failing tests**
+
+```dart
+// crockford_base32_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:castwright/src/data/crockford_base32.dart';
+
+void main() {
+  test('matches the server vector', () {
+    expect(crockfordBase32([0x01, 0x02, 0x03, 0x04, 0x05]), '0420C205');
+  });
+  test('all-ones 5 bytes => ZZZZZZZZ', () {
+    expect(crockfordBase32([0xff, 0xff, 0xff, 0xff, 0xff]), 'ZZZZZZZZ');
+  });
+}
+```
+
+```dart
+// add to cert_pinning_test.dart
+import 'package:castwright/src/data/crockford_base32.dart';
+import 'dart:convert';
+import 'package:crypto/crypto.dart';
+
+test('fingerprintTagMatches accepts the first-10-byte tag of the cert', () {
+  // Build the expected tag from the same PEM used elsewhere in this file.
+  final der = pemToDer(testPem); // reuse the file's existing test PEM constant
+  final digest = sha256.convert(der).bytes;
+  final tag = crockfordBase32(digest.sublist(0, 10));
+  expect(fingerprintTagMatches(testPem, tag), isTrue);
+  expect(fingerprintTagMatches(testPem, tag.toLowerCase()), isTrue); // case-insensitive
+  expect(fingerprintTagMatches(testPem, 'Z' * 16), isFalse);
+});
+```
+
+> If `cert_pinning_test.dart` has no shared `testPem`, add a small valid PEM
+> constant at the top of the test file (any cert that base64-decodes); the test
+> only hashes it.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/android && flutter test test/data/crockford_base32_test.dart test/data/cert_pinning_test.dart`
+Expected: FAIL — `crockford_base32.dart` missing + `fingerprintTagMatches` undefined.
+
+- [ ] **Step 3: Write the implementations**
+
+`crockford_base32.dart` (mirror of the server encoder):
+
+```dart
+/// Crockford base32 (no padding), encode-only. Mirrors the server's
+/// `crockford-base32.ts` so the companion can recompute the CA fingerprint tag
+/// and compare it to the QR's `fpTag`. Alphabet excludes I, L, O, U.
+const _alphabet = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+String crockfordBase32(List<int> bytes) {
+  final out = StringBuffer();
+  var buffer = 0, bits = 0;
+  for (final byte in bytes) {
+    buffer = (buffer << 8) | (byte & 0xff);
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      out.write(_alphabet[(buffer >> bits) & 0x1f]);
+    }
+  }
+  if (bits > 0) out.write(_alphabet[(buffer << (5 - bits)) & 0x1f]);
+  return out.toString();
+}
+```
+
+Add to `cert_pinning.dart`:
+
+```dart
+import 'crockford_base32.dart';
+
+/// True when [tag] equals the Crockford-base32 of the first 10 bytes (80 bits)
+/// of the certificate's SHA-256 — the QR's compact integrity tag. Case- and
+/// separator-insensitive (the tag has no separators, but we normalise anyway).
+bool fingerprintTagMatches(String pem, String tag) {
+  final digest = sha256.convert(pemToDer(pem)).bytes;
+  final expected = crockfordBase32(digest.sublist(0, 10));
+  String norm(String s) => s.toUpperCase().replaceAll(RegExp('[^0-9A-Z]'), '');
+  return norm(expected) == norm(tag);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/android && flutter test test/data/crockford_base32_test.dart test/data/cert_pinning_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/android/lib/src/data/crockford_base32.dart apps/android/lib/src/data/cert_pinning.dart apps/android/test/data/crockford_base32_test.dart apps/android/test/data/cert_pinning_test.dart
+git commit -m "feat(app): Crockford base32 + fingerprintTagMatches for compact pairing"
+```
+
+---
+
+## Task 8: App — redeem-based pairing flow
+
+**Files:**
+- Modify: `apps/android/lib/src/data/pairing_service.dart`
+- Test: `apps/android/test/data/pairing_service_test.dart` (rewrite)
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:castwright/src/data/pairing_service.dart';
+import 'package:castwright/src/domain/pairing_qr.dart';
+
+const _qr = 'CWP1*192.168.1.5:8443*K7QF3M2P*J4XQ2A7BWZ9K3M5R';
+const _pem = '-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----'; // real short PEM
+
+void main() {
+  PairingQr qr() => PairingQr.parse(_qr);
+
+  test('verifies tag, redeems code over pinned channel, returns token+full fp', () async {
+    final svc = PairingService(
+      fetchCa: (_) async => _pem,
+      verifyTag: (_, __) => true, // inject tag check for hermeticity
+      redeem: (baseUrl, code, caPem) async {
+        expect(baseUrl, 'https://192.168.1.5:8443');
+        expect(code, 'K7QF3M2P');
+        return RedeemResult(token: 'tok_abc', caFingerprint: 'AB:CD:..');
+      },
+    );
+    final conn = await svc.pair(qr(), label: 'Pixel');
+    expect(conn.server.token, 'tok_abc');
+    expect(conn.server.url, 'https://192.168.1.5:8443');
+    expect(conn.caPem, _pem);
+  });
+
+  test('refuses on fingerprint-tag mismatch (MitM)', () async {
+    final svc = PairingService(fetchCa: (_) async => _pem, verifyTag: (_, __) => false);
+    expect(
+      () => svc.pair(qr(), label: 'x'),
+      throwsA(isA<PairingException>().having((e) => e.kind, 'kind', PairingErrorKind.fingerprintMismatch)),
+    );
+  });
+
+  test('maps a 401/410 redeem to tokenRejected', () async {
+    final svc = PairingService(
+      fetchCa: (_) async => _pem, verifyTag: (_, __) => true,
+      redeem: (_, __, ___) async => throw const RedeemRejected(),
+    );
+    expect(
+      () => svc.pair(qr(), label: 'x'),
+      throwsA(isA<PairingException>().having((e) => e.kind, 'kind', PairingErrorKind.tokenRejected)),
+    );
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/android && flutter test test/data/pairing_service_test.dart`
+Expected: FAIL — new signatures (`verifyTag`, `redeem`, `RedeemResult`, `pair(PairingQr,...)`) don't exist.
+
+- [ ] **Step 3: Rewrite `pairing_service.dart`**
+
+```dart
+import 'dart:convert';
+import 'dart:io';
+
+import '../domain/paired_server.dart';
+import '../domain/pairing_qr.dart';
+import 'cert_pinning.dart';
+
+enum PairingErrorKind { unreachable, fingerprintMismatch, tokenRejected, server }
+
+class PairingException implements Exception {
+  const PairingException(this.kind, this.message);
+  final PairingErrorKind kind;
+  final String message;
+  @override
+  String toString() => 'PairingException($kind): $message';
+}
+
+/// Thrown by a redeem fn when the server rejects the code (401/410).
+class RedeemRejected implements Exception {
+  const RedeemRejected();
+}
+
+class Connection {
+  const Connection({required this.server, required this.caPem});
+  final PairedServer server;
+  final String caPem;
+}
+
+class RedeemResult {
+  const RedeemResult({required this.token, required this.caFingerprint});
+  final String token;
+  final String caFingerprint; // full SHA-256, stored on PairedServer
+}
+
+typedef CaFetcher = Future<String> Function(String baseUrl);
+typedef TagVerifier = bool Function(String caPem, String fpTag);
+typedef CodeRedeemer = Future<RedeemResult> Function(String baseUrl, String code, String caPem);
+
+class PairingService {
+  PairingService({CaFetcher? fetchCa, TagVerifier? verifyTag, CodeRedeemer? redeem})
+      : _fetchCa = fetchCa ?? _defaultFetchCa,
+        _verifyTag = verifyTag ?? fingerprintTagMatches,
+        _redeem = redeem ?? _defaultRedeem;
+
+  final CaFetcher _fetchCa;
+  final TagVerifier _verifyTag;
+  final CodeRedeemer _redeem;
+
+  Future<Connection> pair(PairingQr qr, {required String label}) async {
+    String caPem;
+    try {
+      caPem = await _fetchCa(qr.baseUrl);
+    } catch (e) {
+      throw PairingException(PairingErrorKind.unreachable,
+          'Could not reach the server to fetch its certificate ($e).');
+    }
+    if (!_verifyTag(caPem, qr.fpTag)) {
+      throw const PairingException(PairingErrorKind.fingerprintMismatch,
+          'The server certificate did not match the pairing code. Refusing to pair.');
+    }
+    RedeemResult r;
+    try {
+      r = await _redeem(qr.baseUrl, qr.code, caPem);
+    } on RedeemRejected {
+      throw const PairingException(PairingErrorKind.tokenRejected,
+          'The server rejected the pairing code. Re-scan a fresh code.');
+    } catch (e) {
+      throw PairingException(PairingErrorKind.unreachable,
+          'Certificate verified, but redeeming the code failed ($e).');
+    }
+    final server = PairedServer(url: qr.baseUrl, token: r.token, caFingerprint: r.caFingerprint);
+    return Connection(server: server, caPem: caPem);
+  }
+}
+
+Future<String> _defaultFetchCa(String baseUrl) async {
+  final client = HttpClient()..badCertificateCallback = (_, __, ___) => true;
+  try {
+    final req = await client.getUrl(Uri.parse('$baseUrl/cert/root.crt'));
+    final res = await req.close();
+    return await res.transform(utf8.decoder).join();
+  } finally {
+    client.close(force: true);
+  }
+}
+
+Future<RedeemResult> _defaultRedeem(String baseUrl, String code, String caPem) async {
+  final ctx = SecurityContext(withTrustedRoots: false)
+    ..setTrustedCertificatesBytes(utf8.encode(caPem));
+  final client = HttpClient(context: ctx);
+  try {
+    final req = await client.postUrl(Uri.parse('$baseUrl/api/pair/redeem'));
+    req.headers.contentType = ContentType.json;
+    req.write(jsonEncode({'code': code, 'label': Platform.localHostname}));
+    final res = await req.close();
+    if (res.statusCode == 401 || res.statusCode == 410) throw const RedeemRejected();
+    if (res.statusCode >= 400) throw HttpException('redeem status ${res.statusCode}');
+    final body = jsonDecode(await res.transform(utf8.decoder).join()) as Map<String, dynamic>;
+    final token = body['token'] as String;
+    // Compute the FULL fingerprint from the verified cert for storage.
+    return RedeemResult(token: token, caFingerprint: caFingerprintFromPem(caPem));
+  } finally {
+    client.close(force: true);
+  }
+}
+```
+
+> `caFingerprintFromPem` already exists in `cert_pinning.dart` (Task 7 file). The
+> `label` param on `pair()` is threaded for symmetry but the default redeemer
+> uses `Platform.localHostname`; the injected test redeemer ignores it. If you
+> prefer the screen to pass the label, change `_defaultRedeem` to accept it via
+> a closure in `pairing_screen.dart` instead — keep ONE source of the label.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/android && flutter test test/data/pairing_service_test.dart`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/android/lib/src/data/pairing_service.dart apps/android/test/data/pairing_service_test.dart
+git commit -m "feat(app): redeem-based pairing flow (verify tag, redeem code, pin)"
+```
+
+---
+
+## Task 9: App — wire scan + pairing screen
+
+**Files:**
+- Modify: `apps/android/lib/src/ui/qr_scan_screen.dart` (return `PairingQr`)
+- Modify: `apps/android/lib/src/ui/pairing_screen.dart` (host/code/fpTag fields + redeem flow)
+- Modify: `apps/android/lib/src/domain/paired_server.dart` (remove `fromQrPayload`)
+- Test: update `apps/android/test/ui/qr_scan_screen_test.dart`, `apps/android/test/ui/pairing_screen_test.dart`
+
+- [ ] **Step 1: Update the scan screen** — change the generic + parse:
+
+```dart
+import '../domain/pairing_qr.dart';
+// ...
+void _onScan(Code code) {
+  if (_handled || !mounted) return;
+  final raw = code.text;
+  if (raw == null || raw.isEmpty) return;
+  try {
+    final qr = PairingQr.parse(raw);
+    _handled = true;
+    Navigator.of(context).pop(qr);
+  } on FormatException {
+    // not a pairing payload — keep scanning
+  }
+}
+```
+
+And the push type in `pairing_screen.dart` `_scan()` becomes `push<PairingQr>`.
+The existing `qr_scan_screen_test.dart` (ReaderWidget config asserts) is unaffected
+— keep it; just confirm it still compiles against the new import.
+
+- [ ] **Step 2: Rewrite `pairing_screen.dart`** — replace the three controllers
+with host/code/fpTag, and `_pair()` to build a `PairingQr` + call the new service:
+
+```dart
+Future<void> _pair() async {
+  setState(() { _busy = true; _error = null; });
+  try {
+    final qr = PairingQr(
+      hostPort: _host.text.trim(), code: _code.text.trim(), fpTag: _fpTag.text.trim());
+    final conn = await widget.service.pair(qr, label: 'Companion');
+    final stamped = conn.server.copyWith(pairedAt: DateTime.now().toIso8601String());
+    await widget.store.save(stamped);
+    await widget.store.saveCaPem(conn.caPem);
+    if (mounted) Navigator.of(context).pop(stamped);
+  } on PairingException catch (e) {
+    setState(() => _error = e.message);
+  } on FormatException catch (e) {
+    setState(() => _error = e.message);
+  } finally {
+    if (mounted) setState(() => _busy = false);
+  }
+}
+
+Future<void> _scan() async {
+  final qr = await Navigator.of(context).push<PairingQr>(
+    MaterialPageRoute(builder: (_) => const QrScanScreen()));
+  if (qr != null && mounted) {
+    setState(() { _host.text = qr.hostPort; _code.text = qr.code; _fpTag.text = qr.fpTag; _error = null; });
+  }
+}
+```
+
+Update the three `TextField`s to keys `field-host` / `field-code` / `field-fptag`
+with labels "Server (host:port)", "Pairing code", "Fingerprint tag".
+
+- [ ] **Step 3: Remove `fromQrPayload` from `paired_server.dart`** (the JSON
+`fromJson`/`toJson` used by `PairingStore` STAY). Delete the now-unused `dart:convert`
+import only if nothing else in the file uses it.
+
+- [ ] **Step 4: Update the two UI tests** to drive host/code/fpTag fields and a
+fake `PairingService` whose `pair(PairingQr,...)` returns a stub `Connection`.
+Mirror the existing `pairing_screen_test.dart` structure.
+
+- [ ] **Step 5: Run the app test suite**
+
+Run: `cd apps/android && flutter test`
+Expected: PASS (all suites, including the unchanged scanner-config + cert-pinning tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/android/lib/src/ui/qr_scan_screen.dart apps/android/lib/src/ui/pairing_screen.dart apps/android/lib/src/domain/paired_server.dart apps/android/test/ui/
+git commit -m "feat(app): wire compact-QR scan + redeem into the pairing screen"
+```
+
+---
+
+## Task 10: Lock-the-fix regression — decode the new QR through zxing
+
+**Files:**
+- Create: `apps/android/test/data/pairing_qr_decode_test.dart`
+
+**Why:** This is the assertion that would have caught the original bug — it proves
+the *new* QR is decodable by the same engine the app scans with.
+
+- [ ] **Step 1: Write the test** (uses `flutter_zxing`'s still-image decode on a
+generated QR; `qr_flutter` or the `qrcode` equivalent renders it to bytes). If a
+Dart-side QR *generator* isn't already a dep, instead assert via a Node test using
+`zxing-wasm` + `qrcode` (the harness already proven in this session under
+`C:\Claude\qr-decode-test`), committed as `server`-adjacent tooling. Prefer the
+Node approach to avoid adding a Flutter QR-gen dependency:
+
+```js
+// server/scripts/pairing-qr-decode.test.mjs (run via node --test or a tiny vitest)
+import QRCode from 'qrcode';
+import { readBarcodes } from 'zxing-wasm/reader';
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+test('compact CWP1 pairing QR decodes through zxing', async () => {
+  const payload = 'CWP1*192.168.86.20:8443*K7QF3M2P*J4XQ2A7BWZ9K3M5R';
+  const buf = await QRCode.toBuffer(payload, { margin: 4, scale: 8, errorCorrectionLevel: 'M' });
+  const res = await readBarcodes(new Blob([buf], { type: 'image/png' }), { formats: ['QRCode'], tryHarder: true });
+  assert.equal(res[0]?.text, payload);
+});
+```
+
+> Add `zxing-wasm` as a server devDependency for this test, or keep the harness
+> standalone and reference it from the plan's manual acceptance. Decide during
+> execution based on whether the team wants it in CI; if in CI, wire it into
+> `npm run test:server`.
+
+- [ ] **Step 2: Run it**
+
+Run: `cd server && node --test scripts/pairing-qr-decode.test.mjs` (or the vitest equivalent)
+Expected: PASS — the v3 QR round-trips.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/scripts/pairing-qr-decode.test.mjs server/package.json
+git commit -m "test(server): regression — compact pairing QR decodes through zxing"
+```
+
+---
+
+## Task 11: Full verify + docs
+
+- [ ] **Step 1: Run the fast battery** (server + frontend)
+
+Run: `npm run verify:quick`
+Expected: green. Fix any fallout in the touched files only.
+
+- [ ] **Step 2: Frontend e2e (optional but preferred for the modal)** — add a
+Playwright spec `e2e/pair-device.spec.ts` that opens the modal in mock mode and
+asserts `pair-qr-image` + the manual fields render. Run `npm run test:e2e -- pair-device`.
+
+- [ ] **Step 3: Update the spec status + INDEX**
+
+In `docs/superpowers/specs/2026-06-10-pairing-qr-redesign-design.md` set
+`status: implemented`. Add a one-line entry to `docs/features/INDEX.md` if a
+feature plan home is expected (the companion lives under plan 188 — link there).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "docs(docs): mark pairing-QR redesign spec implemented"
+```
+
+---
+
+## Self-Review notes (author)
+
+- **Spec coverage:** QR format (T6), server session+redeem+fpTag (T1–T3), guard
+  exemption wiring (T3), frontend session+render (T4–T5), app parse+tag+redeem+UI
+  (T6–T9), security (token only over pinned channel — T8 `_defaultRedeem`),
+  compat (paired devices untouched; old `fromQrPayload` removed — T9), regression
+  decode (T10), testing across all three tiers. ✓
+- **Known execution caveats:** (a) the server route test needs a real PEM pasted
+  and prefers mocking `createDevice` for hermeticity (called out in T3). (b) The
+  Crockford known-vector `'0420C205'` in T1/T7 must be confirmed once with a
+  scratch REPL and locked identically on both sides — do NOT let server + app
+  drift. (c) Flutter tests require the local Flutter SDK (`C:\Users\dudar\flutter`).
+- **Worktree husky:** commits run from the worktree — set up worktree-scoped
+  hooks (`.husky-wt` + `git config --worktree core.hooksPath`) before the first
+  code commit so `verify:fast:scoped` runs without `--no-verify`.

--- a/docs/superpowers/specs/2026-06-10-pairing-qr-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-10-pairing-qr-redesign-design.md
@@ -1,7 +1,7 @@
 ---
 title: Pairing-QR redesign — tiny code + ephemeral pairing session
 date: 2026-06-10
-status: draft
+status: implemented
 area: app (companion pairing) / server / frontend
 supersedes-flow: plan 188 app-2 pairing-QR (JSON {url, token, caFingerprint})
 ---

--- a/docs/superpowers/specs/2026-06-10-pairing-qr-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-10-pairing-qr-redesign-design.md
@@ -1,0 +1,208 @@
+---
+title: Pairing-QR redesign — tiny code + ephemeral pairing session
+date: 2026-06-10
+status: draft
+area: app (companion pairing) / server / frontend
+supersedes-flow: plan 188 app-2 pairing-QR (JSON {url, token, caFingerprint})
+---
+
+# Pairing-QR redesign
+
+## Problem
+
+The Castwright Companion app cannot pair to the server by scanning the desktop
+pairing QR on a **real phone**. Root cause (confirmed, not inferred):
+
+- The QR encodes `{url, token, caFingerprint}` as JSON — **193 chars → QR
+  version 10 (57×57 modules)**. Displayed at 224 px that is ~3.9 px/module.
+- The companion scans with `flutter_zxing` (zxing-cpp). We switched to it
+  because `mobile_scanner`'s ML Kit decoder NPEs on Android 16 / API 36.
+- **zxing-cpp cannot decode this dense code captured off a screen.** Proven by
+  feeding the user's actual camera frames (from a screen recording) into the
+  identical engine (`zxing-wasm`): **0/8 frames decoded**, even tightly cropped,
+  2× upscaled, sharpened, and contrast-boosted. The phone's *native* camera
+  (Google/ML Kit) decodes the same code off the same screen — ML Kit is simply
+  far more robust to real-world capture (perspective skew + screen moiré + dense
+  grid) than zxing-cpp.
+
+Prior fixes (`tryHarder`, `veryHigh`, `cropPercent 1.0`) tuned the weak decoder
+instead of the code, so none stuck. The fix is to make the QR **trivially
+decodable** by shrinking it, while preserving the security model.
+
+## Goals
+
+- The pairing QR decodes reliably with `flutter_zxing` off a screen (no decoder
+  swap, no ML Kit dependency).
+- **No security regression** vs today's cert-fingerprint pinning. Ideally an
+  improvement.
+- No manual fingerprint compare on the phone.
+- Already-paired devices keep working with no migration.
+
+## Non-goals
+
+- Replacing the scanner library or re-introducing ML Kit.
+- Changing how a *paired* device authenticates afterward (the existing srv-20 /
+  srv-33 LAN-token guard is unchanged).
+- mDNS / discovery / deep-link pairing.
+
+## Decision: keep out-of-band integrity, shrink the QR
+
+The QR shrinks from **193 chars (v10, 57²)** to **~50 chars (v3, 29²)** —
+modules ~2× bigger — by moving the bulky token (32 ch) and full fingerprint
+(95 ch) *off* the QR. Out-of-band MitM protection is retained via a short
+fingerprint **tag** carried in the QR.
+
+## QR payload format
+
+A compact string in QR **alphanumeric mode** (the densest mode; charset is
+`0-9 A-Z space $ % * + - . / :`), not JSON:
+
+```
+CWP1*192.168.86.20:8443*K7QF3M2P*J4XQ2A7BWZ9K3M5R
+└──┘ └─── host:port ───┘ └─code─┘ └── fpTag ─────┘
+magic                     8 ch     16 ch (80-bit)
+```
+
+| Field      | Meaning                                                              |
+|------------|---------------------------------------------------------------------|
+| `CWP1`     | Format magic + version (lets the app reject foreign QRs and future-proof). |
+| `host:port`| First reachable LAN IPv4 + HTTPS port (e.g. `192.168.86.20:8443`).   |
+| `code`     | Ephemeral pairing code, 8-char Crockford base32 (40 bits), server-minted. |
+| `fpTag`    | Crockford base32 of the **first 10 bytes (80 bits)** of the CA cert's SHA-256. |
+
+Encoding decision: **Crockford base32** (RFC-variant without ambiguous
+`I L O U`), upper-cased, for both `code` and `fpTag`. One shared helper
+mirrored server-side (TS) and app-side (Dart). Crockford-legal output is a
+subset of QR alphanumeric mode, so density is preserved.
+
+- Separator `*` is in the alphanumeric charset and never appears in a field.
+- Max length: `255.255.255.255:8443` (20) → total ~51 chars → **QR v3 at EC-M**.
+- Forbidden-char guard: `code`/`fpTag` use base32 (upper-case, no `*`/`:`), host
+  is digits + `.` + `:` — all alphanumeric-mode-legal.
+
+## Server
+
+New router `server/src/routes/pairing.ts`, in-memory ephemeral session store.
+Reuses `createDevice()` (`workspace/device-tokens.ts`) to mint the per-device
+token, so the paired device uses the existing srv-33 token system unchanged.
+
+### Endpoints
+
+1. **`POST /api/pair/session`** — *loopback-only* (the desktop UI is loopback;
+   the LAN guard already bypasses loopback). Behind the normal `/api` LAN guard.
+   - Mints `code`, computes `fpTag` from the resolved CA cert, enumerates LAN
+     URLs (reuse `enumerateLanUrls`).
+   - **Mints no token yet** — an unredeemed session leaves no device behind.
+   - Returns `{ urls: string[], port, code, fpTag, expiresAt }`.
+   - Returns `409`/structured "unavailable" when not in LAN-HTTPS mode or the CA
+     can't be resolved (the modal already has an "unavailable" state).
+
+2. **`POST /api/pair/redeem`** — **exempt from the LAN-token guard** (mounted
+   like `/cert/root.crt`, which is also exempt), because an unpaired device
+   holds only the `code`, not a token. Gated by the `code` itself.
+   - Body `{ code, label? }`.
+   - Valid + unexpired + unconsumed code → `createDevice(label)`, mark consumed,
+     return `{ token }` (raw token, shown once).
+   - Else `401` (bad code) / `410` (expired or already consumed).
+
+### Session store
+
+- Map `code → { expiresAt, consumed }`. **5-minute TTL**, **single-use**.
+- In-memory only (lost on restart → re-open the modal). No persistence: an
+  ephemeral pre-auth secret should not be written to disk.
+- Lazy sweep of expired entries on each access (no background timer needed).
+- `code` generated with `randomBytes` → Crockford base32, 40 bits.
+
+### Why redeem must be guard-exempt but safe
+
+The redeem endpoint is reachable without a LAN token, but it is gated by a
+40-bit single-use 5-minute code AND only ever returns the token over a channel
+the client has already cert-pinned (see app flow). A caller without the code
+gets `401`; the code can't be brute-forced inside its window.
+
+## App (companion)
+
+### Parse (`domain/`)
+- New `PairingQr` value type + parser for the `CWP1*host:port*code*fpTag` string
+  (replaces `PairedServer.fromQrPayload`'s JSON parse). Strict: wrong magic /
+  arity / empty field → `FormatException` (scanner keeps scanning).
+
+### Cert tag check (`data/cert_pinning.dart`)
+- Add `fingerprintTagMatches(pem, tag)`: SHA-256 the DER, take the first 10
+  bytes, Crockford-base32-encode, compare to `tag` (case-insensitive). Reuses
+  the existing `pemToDer`.
+
+### Flow (`data/pairing_service.dart`)
+1. From `PairingQr`, build `baseUrl = https://host:port`.
+2. Fetch `/cert/root.crt` over the one-shot bad-cert-bypass client.
+3. **Verify `fingerprintTagMatches(caPem, fpTag)`** → else
+   `PairingErrorKind.fingerprintMismatch` (MitM refusal).
+4. Build a CA-pinned `HttpClient` trusting only the fetched CA.
+5. `POST /api/pair/redeem {code, label}` over the **pinned** client → `{token}`
+   (token never crosses an unpinned channel). `401/410` → `tokenRejected`.
+6. Compute the **full** SHA-256 fingerprint from the fetched cert and store a
+   `PairedServer { url, token, caFingerprint: <full>, pairedAt }` + the CA PEM.
+   Downstream code (which expects the full fingerprint) is unchanged.
+
+### Screen (`ui/pairing_screen.dart`)
+- Scan → run the flow above (no token/fingerprint text fields needed).
+- Manual fallback fields shrink to **host:port + code + fpTag** — all short and
+  copyable, so the manual path keeps the same integrity guarantee as the QR path
+  (no first-use-trust hole).
+- `qr_scan_screen.dart` keeps zxing (now reads a tiny v3 QR easily); its tuned
+  `ReaderWidget` config and its regression test stay.
+
+## Frontend (desktop modal)
+
+`src/modals/pair-device.tsx`:
+- On open: `POST /api/pair/session` (was `GET /api/export/lan`). Build the
+  `CWP1*…` string from `{urls[0], port, code, fpTag}`.
+- Render the QR **larger, on white, `margin: 4`, crisp** (`image-rendering:
+  pixelated`, bigger box) — belt-and-suspenders so even this tiny code is
+  bullet-proof.
+- Show a countdown (`expiresAt`) and a "Regenerate code" action (re-calls
+  `/session`).
+- Manual-entry fallback: host:port + code + fpTag (all short, copyable).
+- Keep the existing "unavailable" state (not LAN-HTTPS / no CA).
+- `api.ts` / `lib/types.ts`: add `createPairSession()` + `PairSessionInfo`.
+
+## Compatibility
+
+- **Paired devices:** unaffected — they hold `{url, token, fingerprint, caPem}`
+  and the guard still accepts their token. No migration, no re-pair.
+- **Old JSON QR format:** dropped. Web + app ship in lockstep (version 1.6.0),
+  pairing is one-time, so no old-format fallback parser (YAGNI). A *new* app
+  against an *old* desktop build won't pair — but they upgrade together.
+
+## Security analysis
+
+| Property        | Today                                  | After                                            |
+|-----------------|----------------------------------------|--------------------------------------------------|
+| Server identity | Full SHA-256 in QR, app pins on match  | 80-bit prefix tag in QR, app pins on match. Forging an 80-bit SHA-256 prefix is infeasible → equivalent MitM protection. |
+| Token exposure  | Static shared token **printed in the QR** (anyone who photographs the screen gets the permanent secret) | Per-device token minted on redeem, returned **only over the cert-pinned channel** → never visible to a MitM or a shoulder-surfer. **Improvement.** |
+| Pairing secret  | n/a                                    | 40-bit, single-use, 5-min TTL `code` → not brute-forceable in-window. |
+
+Net: equal-or-better security, ~4× fewer QR chars.
+
+## Testing
+
+- **Server (Vitest):** `pairing.ts` — session create returns code+fpTag;
+  redeem mints a token and is single-use; expired/consumed/bad code → 401/410;
+  redeem is reachable without a LAN token but `/session` is loopback-gated;
+  fpTag = first-10-bytes base32 of the CA.
+- **Frontend (RTL):** modal calls `/session`, builds the correct `CWP1*…`
+  string, renders the QR, shows countdown, manual fallback copies host+code;
+  "unavailable" state preserved.
+- **App (Dart):** `PairingQr` parse (happy + malformed); `fingerprintTagMatches`
+  (match / mismatch / case); `PairingService` redeem flow with injected
+  fetch+redeem (fingerprint mismatch, 401, success).
+- **Lock-the-fix regression:** a test that **generates the new QR string and
+  decodes it through zxing** (zxing-wasm in a Node test, or `flutter_zxing`
+  still-image decode in a Dart test) — asserts the v3 code round-trips. This is
+  the assertion that would have caught the original bug.
+
+## Resolved implementation details
+
+- **base32:** Crockford, shared helper mirrored in TS + Dart (see QR-format note).
+- **Modal QR display size:** ~288 px square, white background, `margin: 4`
+  quiet zone, `image-rendering: pixelated`, no rounded corners on the code image.

--- a/e2e/download-tiles.spec.ts
+++ b/e2e/download-tiles.spec.ts
@@ -95,13 +95,15 @@ test.describe('plan 57 — download tiles', () => {
     const modal = page.getByTestId('pair-device-modal');
     await expect(modal).toBeVisible({ timeout: 10_000 });
 
-    // The QR renders as a data: image from the mocked LAN pairing payload.
+    // The QR renders as a data: image from the mocked pairing session payload.
     const qr = page.getByTestId('pair-qr-image');
     await expect(qr).toBeVisible();
     await expect(qr).toHaveAttribute('src', /^data:image\/png/);
 
-    // Manual-entry fallback (collapsed <details>) carries the values.
+    // Manual-entry fallback (collapsed <details>) carries the compact CWP1
+    // values: host:port, the pairing code, and the fingerprint tag.
     await modal.getByText(/enter these manually/i).click();
-    await expect(modal.getByText('https://192.168.1.42:8443')).toBeVisible();
+    await expect(modal.getByText('192.168.1.42:8443')).toBeVisible();
+    await expect(modal.getByText('K7QF3M2P')).toBeVisible();
   });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -70,6 +70,7 @@ import { exportRouter } from './routes/export.js';
 import { exportLanRouter, enumerateLanUrls, isLanHttpsEnabled } from './routes/export-lan.js';
 import { certRootRouter } from './routes/cert-root.js';
 import { devicesRouter } from './routes/devices.js';
+import { pairSessionRouter, pairRedeemRouter } from './routes/pairing.js';
 import { requireLanToken } from './lan-auth.js';
 import { portableExportRouter, portableImportRouter } from './routes/exports-portable.js';
 import { shareRouter, sharePublicRouter } from './routes/share.js';
@@ -173,6 +174,7 @@ void fsckAllBooks()
 /* srv-20 — optional shared-secret token guard for the LAN exposure surface.
    Scoped to /api + /workspace; /cert/root.crt + /audio stay open. OFF unless
    LAN HTTPS mode is on AND LAN_AUTH_TOKEN is set; loopback always bypasses. */
+app.use('/api/pair', pairRedeemRouter); // QR pairing — code-gated, intentionally pre-guard
 app.use(['/api', '/workspace'], requireLanToken);
 app.use('/workspace', express.static(WORKSPACE_ROOT, { fallthrough: true, maxAge: '1h' }));
 
@@ -190,6 +192,7 @@ app.use('/api/info', infoRouter); // fs-1 — app version + schemas + what's-new
 import { companionRouter } from './routes/companion.js';
 app.use('/api/companion', companionRouter); // interim — GET/HEAD /apk: download the packaged Android APK
 app.use('/api', devicesRouter); // srv-33 — companion per-device tokens: GET/POST /devices, DELETE /devices/:id
+app.use('/api/pair', pairSessionRouter); // QR pairing — loopback-only session mint (post-guard)
 app.use('/api/library', libraryRouter);
 app.use('/api/library', syncManifestRouter); // srv-32 — GET /api/library/sync-manifest
 app.use('/api', importRouter); // mounts /import and /books

--- a/server/src/lib/crockford-base32.test.ts
+++ b/server/src/lib/crockford-base32.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { crockfordBase32 } from './crockford-base32.js';
+
+describe('crockfordBase32', () => {
+  it('encodes 10 bytes to 16 chars (80 bits / 5)', () => {
+    const bytes = Buffer.from('00112233445566778899', 'hex');
+    expect(crockfordBase32(bytes)).toHaveLength(16);
+  });
+
+  it('encodes 5 bytes to 8 chars (40 bits / 5)', () => {
+    expect(crockfordBase32(Buffer.from('0000000000', 'hex'))).toBe('00000000');
+  });
+
+  it('uses the Crockford alphabet (no I L O U, upper-case)', () => {
+    const out = crockfordBase32(Buffer.from('ffffffffff', 'hex'));
+    expect(out).toBe('ZZZZZZZZ');
+    expect(out).not.toMatch(/[ILOU]/);
+  });
+
+  it('is deterministic and stable for a known vector', () => {
+    expect(crockfordBase32(Buffer.from('0102030405', 'hex'))).toBe('04106105');
+  });
+});

--- a/server/src/lib/crockford-base32.ts
+++ b/server/src/lib/crockford-base32.ts
@@ -1,0 +1,23 @@
+/* Crockford base32 (no padding) — encode-only. Used for the ephemeral pairing
+   code and the 80-bit CA fingerprint tag in the companion pairing QR. Output is
+   a subset of QR alphanumeric mode, so the QR stays in its densest encoding.
+   Alphabet excludes I, L, O, U to avoid visual ambiguity in manual entry. */
+const ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+export function crockfordBase32(bytes: Uint8Array): string {
+  let out = '';
+  let buffer = 0;
+  let bits = 0;
+  for (const byte of bytes) {
+    buffer = (buffer << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      out += ALPHABET[(buffer >>> bits) & 0x1f];
+    }
+  }
+  if (bits > 0) {
+    out += ALPHABET[(buffer << (5 - bits)) & 0x1f];
+  }
+  return out;
+}

--- a/server/src/routes/pairing.test.ts
+++ b/server/src/routes/pairing.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+// A real self-signed cert (parses via node X509Certificate). Its SHA-256's
+// first 10 bytes Crockford-base32-encode to fpTag "5CEE77RAKV3EN9JX".
+const TEST_CERT_PEM = `-----BEGIN CERTIFICATE-----
+MIIDFTCCAf2gAwIBAgIUIbK4LygapM3JSNcloQ29h8z5Ms8wDQYJKoZIhvcNAQEL
+BQAwGjEYMBYGA1UEAwwPY2FzdHdyaWdodC10ZXN0MB4XDTI2MDYwOTIzNTQxN1oX
+DTI2MDYxMTIzNTQxN1owGjEYMBYGA1UEAwwPY2FzdHdyaWdodC10ZXN0MIIBIjAN
+BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzIoO0K/L5PyJR8uRFWD3dsa5ZS6R
+MM6BHuY4xS2wNYY9fuOdtWrtJp/8knyCtIhiC4+2+zDr2t6zDjqiSQpM9anMJr3E
+NuDf82ktDh4Skp8VgYX4tBgQs0VWQiajNVamzWlPRzzUqNzxcF7nDT+IkEOpS8Cp
+xQqOsekThL5NF+IpGvnGdFN5c60sM7z4qGW6w2Mv5XmGLJwINh3e7YWT/3YKsIO5
+9rvWAwJwSohDPp2Qm1AQxmiiTE10VkH8v9uO+yJdH3c/bwhG2iRqRNtwf18oMsWu
+KImB6gkpOtfuR5+ywq1dM29KkbdJncwIrDLvBE2NBo7ewUrrndeJLBaI1wIDAQAB
+o1MwUTAdBgNVHQ4EFgQUPla1YM1+g1R0FJ/DVZGyTAjR46cwHwYDVR0jBBgwFoAU
+Pla1YM1+g1R0FJ/DVZGyTAjR46cwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0B
+AQsFAAOCAQEAeTjntz2jONNLfye5xRrwopx9dzWanMMhWYaOLxiH7ZmwoJoWyHKS
+QYwuSJjkBXvZvjxjVFHbTLujh6+b7foab1N5cCdyXai4PkF11G4cWFQ+x+T0c+vi
+gU7diabXdmGyVCUhCYkFGYyJe9lplB7Cgn7rUEE2QobzZfvMvR8UtOzPT5e1HYFm
+F9h2gi5FCdQ5/HtykuO5+p58OP6mDHIzyGX36GdI7DuIh/CPq7IHicBW3r7xgACQ
+YnfkDgmHygMhGW3R2KBwRjyVnnbUz4Flys3JKquOG+QXQeAnTWrbJymzHa/USSjs
+mXs+glZrizT6pLoIQQucbslLc15G85a7tw==
+-----END CERTIFICATE-----`;
+
+vi.mock('./export-lan.js', async (orig) => {
+  const real = await orig<typeof import('./export-lan.js')>();
+  return {
+    ...real,
+    isLanHttpsEnabled: () => true,
+    enumerateLanUrls: () => ({ urls: ['https://192.168.1.5:8443'], port: 8443, protocol: 'https' as const }),
+  };
+});
+vi.mock('./cert-root.js', () => ({ resolveRootCaPath: () => ({ path: 'FAKE', source: 'default' as const }) }));
+vi.mock('node:fs', async (orig) => {
+  const real = await orig<typeof import('node:fs')>();
+  return { ...real, readFileSync: (p: unknown, ...rest: unknown[]) =>
+    p === 'FAKE' ? Buffer.from(TEST_CERT_PEM) : (real.readFileSync as any)(p, ...rest) };
+});
+vi.mock('../workspace/device-tokens.js', () => ({
+  createDevice: vi.fn(async (label: string) => ({ device: { id: 'd1', label, createdAt: '', revoked: false }, token: 'tok_test' })),
+}));
+
+import { pairSessionRouter, pairRedeemRouter } from './pairing.js';
+import { _resetPairingSessionsForTests } from '../workspace/pairing-sessions.js';
+
+function appWith(router: express.Router) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/pair', router);
+  return app;
+}
+
+describe('pairing routes', () => {
+  beforeEach(() => _resetPairingSessionsForTests());
+
+  it('POST /session returns a qrPayload + code + fpTag', async () => {
+    const res = await request(appWith(pairSessionRouter)).post('/api/pair/session').send({});
+    expect(res.status).toBe(200);
+    expect(res.body.code).toMatch(/^[0-9A-HJKMNP-TV-Z]{8}$/);
+    expect(res.body.fpTag).toBe('5CEE77RAKV3EN9JX');
+    expect(res.body.hostPort).toBe('192.168.1.5:8443');
+    expect(res.body.qrPayload).toBe(`CWP1*192.168.1.5:8443*${res.body.code}*5CEE77RAKV3EN9JX`);
+    expect(res.body.expiresAt).toBeGreaterThan(0);
+  });
+
+  it('POST /redeem mints a token for a fresh code, then 410 on reuse', async () => {
+    const session = await request(appWith(pairSessionRouter)).post('/api/pair/session').send({});
+    const redeem = appWith(pairRedeemRouter);
+    const first = await request(redeem).post('/api/pair/redeem').send({ code: session.body.code, label: 'Pixel' });
+    expect(first.status).toBe(201);
+    expect(first.body.token).toBe('tok_test');
+    const second = await request(redeem).post('/api/pair/redeem').send({ code: session.body.code });
+    expect(second.status).toBe(410);
+  });
+
+  it('POST /redeem 401s an unknown code', async () => {
+    const res = await request(appWith(pairRedeemRouter)).post('/api/pair/redeem').send({ code: 'ZZZZZZZZ' });
+    expect(res.status).toBe(401);
+  });
+});

--- a/server/src/routes/pairing.test.ts
+++ b/server/src/routes/pairing.test.ts
@@ -24,6 +24,7 @@ YnfkDgmHygMhGW3R2KBwRjyVnnbUz4Flys3JKquOG+QXQeAnTWrbJymzHa/USSjs
 mXs+glZrizT6pLoIQQucbslLc15G85a7tw==
 -----END CERTIFICATE-----`;
 
+vi.mock('../lan-auth.js', () => ({ isLoopbackRequest: vi.fn(() => true) }));
 vi.mock('./export-lan.js', async (orig) => {
   const real = await orig<typeof import('./export-lan.js')>();
   return {
@@ -44,6 +45,7 @@ vi.mock('../workspace/device-tokens.js', () => ({
 
 import { pairSessionRouter, pairRedeemRouter } from './pairing.js';
 import { _resetPairingSessionsForTests } from '../workspace/pairing-sessions.js';
+import { isLoopbackRequest } from '../lan-auth.js';
 
 function appWith(router: express.Router) {
   const app = express();
@@ -78,5 +80,11 @@ describe('pairing routes', () => {
   it('POST /redeem 401s an unknown code', async () => {
     const res = await request(appWith(pairRedeemRouter)).post('/api/pair/redeem').send({ code: 'ZZZZZZZZ' });
     expect(res.status).toBe(401);
+  });
+
+  it('POST /session 403s a non-loopback caller', async () => {
+    vi.mocked(isLoopbackRequest).mockReturnValueOnce(false);
+    const res = await request(appWith(pairSessionRouter)).post('/api/pair/session').send({});
+    expect(res.status).toBe(403);
   });
 });

--- a/server/src/routes/pairing.ts
+++ b/server/src/routes/pairing.ts
@@ -1,0 +1,73 @@
+/* Companion pairing routes (QR redesign).
+
+   POST /api/pair/session  — loopback-only (the desktop UI). Mints an ephemeral
+     code, computes the 80-bit CA fingerprint tag, returns the compact QR
+     payload string the modal renders. Mints NO device token.
+   POST /api/pair/redeem   — guard-exempt (an unpaired device holds only the
+     code). Gated by the code; mints a per-device token over the caller's
+     already-cert-pinned channel.
+
+   The redeem router MUST be mounted BEFORE the `/api` LAN-token guard in
+   index.ts; the session router AFTER it. */
+import { readFileSync } from 'node:fs';
+import { X509Certificate } from 'node:crypto';
+import { Router } from 'express';
+import type { Request, Response } from '../http.js';
+import { isLanHttpsEnabled, enumerateLanUrls } from './export-lan.js';
+import { resolveRootCaPath } from './cert-root.js';
+import { crockfordBase32 } from '../lib/crockford-base32.js';
+import { createPairingSession, redeemPairingSession } from '../workspace/pairing-sessions.js';
+import { createDevice } from '../workspace/device-tokens.js';
+import { isLoopbackRequest } from '../lan-auth.js';
+
+/** First 10 bytes (80 bits) of the CA cert's SHA-256, Crockford-base32. */
+export function caFingerprintTag(): string | undefined {
+  try {
+    const ca = resolveRootCaPath();
+    if (!ca) return undefined;
+    const hex = new X509Certificate(readFileSync(ca.path)).fingerprint256; // "AB:CD:.."
+    const bytes = Buffer.from(hex.replace(/:/g, ''), 'hex');
+    return crockfordBase32(bytes.subarray(0, 10));
+  } catch {
+    return undefined;
+  }
+}
+
+export const pairSessionRouter = Router();
+
+pairSessionRouter.post('/session', (req: Request, res: Response) => {
+  if (!isLoopbackRequest(req)) {
+    res.status(403).json({ error: 'Pairing sessions can only be created from the host UI.' });
+    return;
+  }
+  if (!isLanHttpsEnabled()) {
+    res.status(409).json({ error: 'not-lan-https' });
+    return;
+  }
+  const { urls, port } = enumerateLanUrls(Number(process.env.LAN_HTTPS_PORT ?? 8443), 'https');
+  const host = urls[0]?.replace(/^https:\/\//, '');
+  const fpTag = caFingerprintTag();
+  if (!host || !fpTag) {
+    res.status(409).json({ error: !host ? 'no-lan-url' : 'no-ca' });
+    return;
+  }
+  const { code, expiresAt } = createPairingSession();
+  const qrPayload = `CWP1*${host}*${code}*${fpTag}`;
+  res.json({ qrPayload, hostPort: host, port, code, fpTag, expiresAt });
+});
+
+export const pairRedeemRouter = Router();
+
+pairRedeemRouter.post('/redeem', async (req: Request, res: Response) => {
+  const body = (req.body ?? {}) as { code?: unknown; label?: unknown };
+  const code = typeof body.code === 'string' ? body.code : '';
+  const label = typeof body.label === 'string' ? body.label : 'Device';
+  const result = redeemPairingSession(code);
+  if (!result.ok) {
+    const status = result.reason === 'unknown' ? 401 : 410;
+    res.status(status).json({ error: result.reason });
+    return;
+  }
+  const { token } = await createDevice(label);
+  res.status(201).json({ token });
+});

--- a/server/src/workspace/pairing-sessions.test.ts
+++ b/server/src/workspace/pairing-sessions.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createPairingSession,
+  redeemPairingSession,
+  _resetPairingSessionsForTests,
+} from './pairing-sessions.js';
+
+describe('pairing-sessions', () => {
+  beforeEach(() => _resetPairingSessionsForTests());
+
+  it('creates a session with an 8-char code and future expiry', () => {
+    const now = 1_000_000;
+    const s = createPairingSession(now);
+    expect(s.code).toMatch(/^[0-9A-HJKMNP-TV-Z]{8}$/);
+    expect(s.expiresAt).toBeGreaterThan(now);
+  });
+
+  it('redeems a valid code exactly once', () => {
+    const now = 1_000_000;
+    const { code } = createPairingSession(now);
+    expect(redeemPairingSession(code, now + 1)).toEqual({ ok: true });
+    expect(redeemPairingSession(code, now + 2)).toEqual({ ok: false, reason: 'consumed' });
+  });
+
+  it('rejects an unknown code', () => {
+    expect(redeemPairingSession('ZZZZZZZZ', 1)).toEqual({ ok: false, reason: 'unknown' });
+  });
+
+  it('rejects an expired code', () => {
+    const now = 1_000_000;
+    const { code, expiresAt } = createPairingSession(now);
+    expect(redeemPairingSession(code, expiresAt + 1)).toEqual({ ok: false, reason: 'expired' });
+  });
+});

--- a/server/src/workspace/pairing-sessions.ts
+++ b/server/src/workspace/pairing-sessions.ts
@@ -1,0 +1,58 @@
+/* In-memory ephemeral pairing sessions for the companion QR redesign.
+
+   A session is a single-use, time-boxed `code` that authorises minting ONE
+   per-device token via POST /api/pair/redeem. We deliberately persist nothing:
+   a pre-auth secret should never hit disk, and losing pending sessions on a
+   restart is harmless (re-open the desktop modal). `now` is injected so the
+   store is unit-testable without a clock. */
+import { randomBytes } from 'node:crypto';
+import { crockfordBase32 } from '../lib/crockford-base32.js';
+
+const TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+interface Session {
+  expiresAt: number;
+  consumed: boolean;
+}
+
+const sessions = new Map<string, Session>();
+
+function sweep(now: number): void {
+  for (const [code, s] of sessions) {
+    if (s.consumed || now > s.expiresAt) sessions.delete(code);
+  }
+}
+
+export interface NewPairingSession {
+  code: string;
+  expiresAt: number;
+}
+
+export function createPairingSession(now: number = Date.now()): NewPairingSession {
+  sweep(now);
+  // 5 bytes = 40 bits => 8 Crockford chars.
+  const code = crockfordBase32(randomBytes(5));
+  const expiresAt = now + TTL_MS;
+  sessions.set(code, { expiresAt, consumed: false });
+  return { code, expiresAt };
+}
+
+export type RedeemResult =
+  | { ok: true }
+  | { ok: false; reason: 'unknown' | 'expired' | 'consumed' };
+
+export function redeemPairingSession(code: string, now: number = Date.now()): RedeemResult {
+  const s = sessions.get(code);
+  if (!s) return { ok: false, reason: 'unknown' };
+  if (s.consumed) return { ok: false, reason: 'consumed' };
+  if (now > s.expiresAt) {
+    sessions.delete(code);
+    return { ok: false, reason: 'expired' };
+  }
+  s.consumed = true;
+  return { ok: true };
+}
+
+export function _resetPairingSessionsForTests(): void {
+  sessions.clear();
+}

--- a/src/components/listen/companion-app-banner.test.tsx
+++ b/src/components/listen/companion-app-banner.test.tsx
@@ -2,17 +2,18 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 
 /* The banner probes GET /api/companion/apk (HEAD) on mount via
-   api.checkCompanionApk, and the Pair-a-device modal fetches GET
-   /api/export/lan via api.getExportLanUrls. Mock both. */
+   api.checkCompanionApk, and the Pair-a-device modal creates a session via
+   api.createPairSession. Mock both. */
 vi.mock('../../lib/api', () => ({
   api: {
     checkCompanionApk: vi.fn(async () => ({ available: false, sizeBytes: null })),
-    getExportLanUrls: vi.fn(async () => ({
-      urls: ['https://192.168.86.20:8443'],
+    createPairSession: vi.fn(async () => ({
+      qrPayload: 'CWP1*192.168.86.20:8443*ABCD1234*TAGABC123',
+      hostPort: '192.168.86.20:8443',
       port: 8443,
-      protocol: 'https',
-      token: 'lan-token',
-      caFingerprint: 'AB:CD:EF',
+      code: 'ABCD1234',
+      fpTag: 'TAGABC123',
+      expiresAt: Date.now() + 300000,
     })),
   },
 }));

--- a/src/lib/api-pair-session.test.ts
+++ b/src/lib/api-pair-session.test.ts
@@ -1,0 +1,56 @@
+/* Wire-level tests for api.createPairSession — the companion pairing
+   session endpoint introduced by the QR redesign (feat/pairing-qr-redesign).
+
+   Tests run against the `real` implementation (VITE_USE_MOCKS is not set
+   in the vitest environment, so USE_MOCKS=false and api===real). fetch is
+   stubbed to exercise the POST body, the happy path, and the error branch,
+   following the same pattern as api-analysis-state.test.ts. */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { api } from './api';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('api.createPairSession — wire contract', () => {
+  it('POSTs to /api/pair/session and returns a well-formed PairSessionInfo', async () => {
+    const payload = {
+      qrPayload: 'CWP1*192.168.1.42:8443*K7QF3M2P*J4XQ2A7BWZ9K3M5R',
+      hostPort: '192.168.1.42:8443',
+      port: 8443,
+      code: 'K7QF3M2P',
+      fpTag: 'J4XQ2A7BWZ9K3M5R',
+      expiresAt: 1_750_000_000_000,
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const info = await api.createPairSession();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/pair/session',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(info.code).toBe('K7QF3M2P');
+    expect(info.fpTag).toBe('J4XQ2A7BWZ9K3M5R');
+    expect(info.qrPayload).toBe('CWP1*192.168.1.42:8443*K7QF3M2P*J4XQ2A7BWZ9K3M5R');
+    expect(info.hostPort).toBe('192.168.1.42:8443');
+    expect(info.port).toBe(8443);
+    expect(info.expiresAt).toBeGreaterThan(0);
+  });
+
+  it('throws on non-200 response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('Internal Server Error', { status: 500 })),
+    );
+
+    await expect(api.createPairSession()).rejects.toThrow(/500/);
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -47,6 +47,7 @@ import type {
   ConfigResponse,
   ConfigValues,
   PromptState,
+  PairSessionInfo,
 } from './types';
 import { FRONTEND_ACCOUNT_DEFAULTS } from './account-defaults';
 import { initialCharacters } from '../data/characters';
@@ -4793,6 +4794,19 @@ async function realGetExportLanUrls(): Promise<ExportLanInfo> {
   return res.json();
 }
 
+async function realCreatePairSession(): Promise<PairSessionInfo> {
+  const res = await fetch(`/api/pair/session`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: '{}',
+  });
+  if (!res.ok)
+    throw new Error(
+      `pair session failed (${res.status}): ${(await res.text()) || res.statusText}`,
+    );
+  return res.json();
+}
+
 /* Plan 75 — portable book bundle (single .zip with state + manuscript +
    audio + cover + change-log for one book). The export returns the
    bundle as a Blob the caller can save via URL.createObjectURL + an
@@ -4982,6 +4996,21 @@ async function mockGetExportLanUrls(): Promise<ExportLanInfo> {
     token: 'mock-lan-token-0123456789abcdef',
     caFingerprint:
       'AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89',
+  };
+}
+
+async function mockCreatePairSession(): Promise<PairSessionInfo> {
+  await wait(20);
+  const hostPort = '192.168.1.42:8443';
+  const code = 'K7QF3M2P';
+  const fpTag = 'J4XQ2A7BWZ9K3M5R';
+  return {
+    qrPayload: `CWP1*${hostPort}*${code}*${fpTag}`,
+    hostPort,
+    port: 8443,
+    code,
+    fpTag,
+    expiresAt: Date.now() + 300000,
   };
 }
 
@@ -5802,6 +5831,7 @@ const real = {
   exportPortable: realExportPortable,
   importPortable: realImportPortable,
   getExportLanUrls: realGetExportLanUrls,
+  createPairSession: realCreatePairSession,
   getChapterAudio: async ({ bookId, chapterId }: AudioArgs): Promise<ChapterAudio> => {
     const res = await fetch(`/api/books/${encodeURIComponent(bookId)}/chapters/${chapterId}/audio`);
     if (!res.ok) {
@@ -6046,6 +6076,7 @@ const mock = {
   exportPortable: mockExportPortable,
   importPortable: mockImportPortable,
   getExportLanUrls: mockGetExportLanUrls,
+  createPairSession: mockCreatePairSession,
   getChapterAudio: mockGetChapterAudio,
   getChapterAudioPrevious: mockGetChapterAudioPrevious,
   acceptChapterRevision: mockAcceptChapterRevision,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -757,6 +757,17 @@ export interface PromptState {
   defaultText: string;
 }
 
+/** Result of POST /api/pair/session — the companion pairing QR payload + the
+    fields the modal also shows for manual entry. */
+export interface PairSessionInfo {
+  qrPayload: string;
+  hostPort: string;
+  port: number;
+  code: string;
+  fpTag: string;
+  expiresAt: number;
+}
+
 /* ── UI stage discriminated union ─────────────────────────────────────── */
 
 export type View =

--- a/src/modals/pair-device.test.tsx
+++ b/src/modals/pair-device.test.tsx
@@ -30,4 +30,15 @@ describe('PairDeviceModal (QR redesign)', () => {
     render(<PairDeviceModal open onClose={() => {}} />);
     await waitFor(() => expect(screen.getByTestId('pair-device-error')).toBeInTheDocument());
   });
+
+  it('renders a countdown for the pairing code', async () => {
+    vi.spyOn(api, 'createPairSession').mockResolvedValue({
+      qrPayload: 'CWP1*192.168.1.5:8443*K7QF3M2P*J4XQ2A7BWZ9K3M5R',
+      hostPort: '192.168.1.5:8443', port: 8443,
+      code: 'K7QF3M2P', fpTag: 'J4XQ2A7BWZ9K3M5R', expiresAt: Date.now() + 300000,
+    });
+    render(<PairDeviceModal open onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByTestId('pair-code-countdown')).toBeInTheDocument());
+    expect(screen.getByTestId('pair-code-countdown').textContent).toMatch(/expires in \d+:\d{2}/);
+  });
 });

--- a/src/modals/pair-device.test.tsx
+++ b/src/modals/pair-device.test.tsx
@@ -1,104 +1,33 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-
-/* The modal fetches GET /api/export/lan via api.getExportLanUrls. Mock it so
-   each test drives the LAN/pairing state. qrcode stays real (jsdom renders a
-   data: URL fine), so we assert the QR <img> actually appears. */
-vi.mock('../lib/api', () => ({
-  api: { getExportLanUrls: vi.fn() },
-}));
-
-import { PairDeviceModal, toPairingPayload } from './pair-device';
+import { PairDeviceModal } from './pair-device';
 import { api } from '../lib/api';
-import type { ExportLanInfo } from '../lib/types';
 
-const mockedLan = vi.mocked(api.getExportLanUrls);
+describe('PairDeviceModal (QR redesign)', () => {
+  beforeEach(() => vi.restoreAllMocks());
 
-const COMPLETE: ExportLanInfo = {
-  urls: ['https://192.168.86.20:8443'],
-  port: 8443,
-  protocol: 'https',
-  token: 'lan-token-abc',
-  caFingerprint: 'AB:CD:EF:01',
-};
-
-beforeEach(() => {
-  mockedLan.mockReset();
-});
-
-describe('toPairingPayload', () => {
-  it('returns null for null info', () => {
-    expect(toPairingPayload(null)).toBeNull();
-  });
-
-  it('returns null when not HTTPS (no CA trust possible)', () => {
-    expect(
-      toPairingPayload({ urls: ['http://192.168.1.42:8080'], port: 8080, protocol: 'http' }),
-    ).toBeNull();
-  });
-
-  it('returns null when the token is missing', () => {
-    expect(toPairingPayload({ ...COMPLETE, token: undefined })).toBeNull();
-  });
-
-  it('returns null when the CA fingerprint is missing', () => {
-    expect(toPairingPayload({ ...COMPLETE, caFingerprint: undefined })).toBeNull();
-  });
-
-  it('returns null when there is no reachable URL', () => {
-    expect(toPairingPayload({ ...COMPLETE, urls: [] })).toBeNull();
-  });
-
-  it('maps a complete HTTPS info to {url, token, caFingerprint}', () => {
-    expect(toPairingPayload(COMPLETE)).toEqual({
-      url: 'https://192.168.86.20:8443',
-      token: 'lan-token-abc',
-      caFingerprint: 'AB:CD:EF:01',
+  it('renders the compact QR + manual fields from the session payload', async () => {
+    vi.spyOn(api, 'createPairSession').mockResolvedValue({
+      qrPayload: 'CWP1*192.168.1.5:8443*K7QF3M2P*J4XQ2A7BWZ9K3M5R',
+      hostPort: '192.168.1.5:8443', port: 8443,
+      code: 'K7QF3M2P', fpTag: 'J4XQ2A7BWZ9K3M5R', expiresAt: Date.now() + 300000,
     });
-  });
-});
-
-describe('PairDeviceModal', () => {
-  it('renders nothing when closed', () => {
-    mockedLan.mockResolvedValue(COMPLETE);
-    const { container } = render(<PairDeviceModal open={false} onClose={() => {}} />);
-    expect(container).toBeEmptyDOMElement();
-    expect(mockedLan).not.toHaveBeenCalled();
-  });
-
-  it('renders a scannable QR image and the manual values when pairing is available', async () => {
-    mockedLan.mockResolvedValue(COMPLETE);
     render(<PairDeviceModal open onClose={() => {}} />);
-
-    const img = await screen.findByTestId('pair-qr-image');
-    expect(img).toHaveAttribute('src', expect.stringMatching(/^data:image\/png/));
-
-    // Manual-entry fallback carries all three values verbatim.
-    expect(screen.getByText('https://192.168.86.20:8443')).toBeInTheDocument();
-    expect(screen.getByText('lan-token-abc')).toBeInTheDocument();
-    expect(screen.getByText('AB:CD:EF:01')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId('pair-qr-image')).toBeInTheDocument());
+    expect(screen.getByText('192.168.1.5:8443')).toBeInTheDocument();
+    expect(screen.getByText('K7QF3M2P')).toBeInTheDocument();
+    expect(screen.getByText('J4XQ2A7BWZ9K3M5R')).toBeInTheDocument();
   });
 
-  it('explains how to enable pairing when not in LAN HTTPS mode', async () => {
-    mockedLan.mockResolvedValue({ urls: ['http://192.168.1.42:8080'], port: 8080, protocol: 'http' });
+  it('shows the unavailable state when the session 409s', async () => {
+    vi.spyOn(api, 'createPairSession').mockRejectedValue(new Error('pair session failed (409): not-lan-https'));
     render(<PairDeviceModal open onClose={() => {}} />);
-
-    expect(await screen.findByTestId('pair-device-unavailable')).toBeInTheDocument();
-    expect(screen.queryByTestId('pair-qr-image')).toBeNull();
+    await waitFor(() => expect(screen.getByTestId('pair-device-unavailable')).toBeInTheDocument());
   });
 
-  it('shows an error state when the LAN probe fails', async () => {
-    mockedLan.mockRejectedValue(new Error('boom'));
+  it('shows a generic error on a non-409 failure', async () => {
+    vi.spyOn(api, 'createPairSession').mockRejectedValue(new Error('network down'));
     render(<PairDeviceModal open onClose={() => {}} />);
-    expect(await screen.findByTestId('pair-device-error')).toBeInTheDocument();
-  });
-
-  it('calls onClose when the backdrop is clicked', async () => {
-    mockedLan.mockResolvedValue(COMPLETE);
-    const onClose = vi.fn();
-    render(<PairDeviceModal open onClose={onClose} />);
-    await screen.findByTestId('pair-qr-image');
-    screen.getByTestId('pair-device-backdrop').click();
-    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByTestId('pair-device-error')).toBeInTheDocument());
   });
 });

--- a/src/modals/pair-device.tsx
+++ b/src/modals/pair-device.tsx
@@ -23,6 +23,12 @@ export function PairDeviceModal({ open, onClose }: PairDeviceModalProps) {
   const [status, setStatus] = useState<'loading' | 'ready' | 'unavailable' | 'error'>('loading');
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
   const [nonce, setNonce] = useState(0); // bump to regenerate the code
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (status !== 'ready') return;
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [status]);
 
   /* Fetch a new pairing session each time the modal opens (or the user hits
      "Regenerate code"). Sessions are short-lived, so don't cache across opens. */
@@ -166,6 +172,18 @@ export function PairDeviceModal({ open, onClose }: PairDeviceModalProps) {
                 >
                   Regenerate code
                 </button>
+                {(() => {
+                  const remainingMs = Math.max(0, info.expiresAt - now);
+                  const mm = Math.floor(remainingMs / 60000);
+                  const ss = Math.floor((remainingMs % 60000) / 1000);
+                  return (
+                    <p data-testid="pair-code-countdown" className="text-xs text-ink/50">
+                      {remainingMs > 0
+                        ? `This code expires in ${mm}:${ss.toString().padStart(2, '0')}.`
+                        : 'This code has expired — tap Regenerate code.'}
+                    </p>
+                  );
+                })()}
                 <details className="rounded-xl border border-ink/10 bg-ink/[0.02]">
                   <summary className="px-4 py-3 cursor-pointer text-ink/70 font-medium select-none">
                     Or enter these manually

--- a/src/modals/pair-device.tsx
+++ b/src/modals/pair-device.tsx
@@ -1,84 +1,60 @@
 /* Pair-a-device modal (plan 188, app-2 web half).
 
    The Castwright Companion app pairs to this server over LAN HTTPS by reading a
-   QR that carries `{ url, token, caFingerprint }` — the server URL, the srv-20
-   LAN access token, and the mkcert root CA's SHA-256 (so the app fetches
-   /cert/root.crt, verifies the fingerprint, and pins it WITHOUT an OS cert
-   install). The server already exposes all three at GET /api/export/lan
-   (api.getExportLanUrls → ExportLanInfo); this modal just renders them as a
-   scannable QR, plus the raw values for manual entry as a fallback.
+   QR that carries a compact CWP1 payload — the host:port, a short pairing code,
+   and a fingerprint tag. The server issues a session at POST /api/pair/session;
+   a 409 means pairing isn't available yet (not LAN HTTPS / no cert / no token),
+   in which case we show instructions rather than a useless QR. */
 
-   Pairing is only possible in LAN HTTPS mode with a configured token + a
-   resolvable CA — otherwise we explain how to enable it rather than drawing a
-   QR the app can't act on. */
-
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import QRCode from 'qrcode';
 
 import { api } from '../lib/api';
 import { IconClose, IconCopy, IconQrCode, IconShield, IconCheck } from '../lib/icons';
-import type { ExportLanInfo } from '../lib/types';
+import type { PairSessionInfo } from '../lib/types';
 
 interface PairDeviceModalProps {
   open: boolean;
   onClose: () => void;
 }
 
-/** The exact payload the companion app parses (PairedServer.fromQrPayload). */
-interface PairingPayload {
-  url: string;
-  token: string;
-  caFingerprint: string;
-}
-
-/** Reduce the raw LAN info to a complete pairing payload, or null when pairing
-    isn't possible yet (not HTTPS, no token, no CA, or no reachable URL). */
-export function toPairingPayload(info: ExportLanInfo | null): PairingPayload | null {
-  if (!info) return null;
-  const url = info.urls[0];
-  if (info.protocol !== 'https' || !url || !info.token || !info.caFingerprint) return null;
-  return { url, token: info.token, caFingerprint: info.caFingerprint };
-}
-
 export function PairDeviceModal({ open, onClose }: PairDeviceModalProps) {
-  const [info, setInfo] = useState<ExportLanInfo | null>(null);
-  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [info, setInfo] = useState<PairSessionInfo | null>(null);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'unavailable' | 'error'>('loading');
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+  const [nonce, setNonce] = useState(0); // bump to regenerate the code
 
-  /* Fetch the LAN pairing info each time the modal opens (the token / CA can
-     change between server runs, so don't cache across opens). */
+  /* Fetch a new pairing session each time the modal opens (or the user hits
+     "Regenerate code"). Sessions are short-lived, so don't cache across opens. */
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
     setStatus('loading');
     setQrDataUrl(null);
     api
-      .getExportLanUrls()
+      .createPairSession()
       .then((r) => {
         if (cancelled) return;
         setInfo(r);
         setStatus('ready');
       })
-      .catch(() => {
-        if (!cancelled) setStatus('error');
+      .catch((e: Error) => {
+        if (cancelled) return;
+        setStatus(/\b409\b/.test(e?.message ?? '') ? 'unavailable' : 'error');
       });
     return () => {
       cancelled = true;
     };
-  }, [open]);
+  }, [open, nonce]);
 
-  /* Memoised so the QR effect below only re-runs when the values actually
-     change (not on every render). */
-  const payload = useMemo(() => toPairingPayload(info), [info]);
-
-  /* Render the QR from the JSON payload once we have a complete one. */
+  /* Render the QR from the compact payload once we have session info. */
   useEffect(() => {
-    if (!payload) {
+    if (status !== 'ready' || !info) {
       setQrDataUrl(null);
       return;
     }
     let cancelled = false;
-    QRCode.toDataURL(JSON.stringify(payload), { margin: 1, scale: 6 })
+    QRCode.toDataURL(info.qrPayload, { margin: 4, scale: 8, errorCorrectionLevel: 'M' })
       .then((d) => {
         if (!cancelled) setQrDataUrl(d);
       })
@@ -88,7 +64,7 @@ export function PairDeviceModal({ open, onClose }: PairDeviceModalProps) {
     return () => {
       cancelled = true;
     };
-  }, [payload]);
+  }, [status, info]);
 
   if (!open) return null;
 
@@ -135,7 +111,7 @@ export function PairDeviceModal({ open, onClose }: PairDeviceModalProps) {
               </p>
             )}
 
-            {status === 'ready' && !payload && (
+            {status === 'unavailable' && (
               <div data-testid="pair-device-unavailable" className="space-y-3">
                 <p>
                   Pairing needs the server running in <strong>LAN HTTPS mode</strong> with a local
@@ -159,35 +135,45 @@ export function PairDeviceModal({ open, onClose }: PairDeviceModalProps) {
               </div>
             )}
 
-            {status === 'ready' && payload && (
+            {status === 'ready' && info && (
               <div className="space-y-4">
                 <p>
                   In the app, tap <strong>Pair a device → Scan QR</strong> and point the camera here.
                   Your phone must be on the same Wi‑Fi.
                 </p>
                 <div className="grid place-items-center">
-                  {qrDataUrl ? (
-                    <img
-                      src={qrDataUrl}
-                      alt="Pairing QR code"
-                      data-testid="pair-qr-image"
-                      className="w-56 h-56 rounded-xl border border-ink/10"
-                    />
-                  ) : (
-                    <div className="w-56 h-56 rounded-xl border border-ink/10 grid place-items-center text-ink/40">
-                      Generating…
-                    </div>
-                  )}
+                  <div className="bg-white p-3 rounded-2xl border border-ink/10">
+                    {qrDataUrl ? (
+                      <img
+                        src={qrDataUrl}
+                        alt="Pairing QR code"
+                        data-testid="pair-qr-image"
+                        width={288}
+                        height={288}
+                        className="block w-72 h-72"
+                        style={{ imageRendering: 'pixelated' }}
+                      />
+                    ) : (
+                      <div className="w-72 h-72 grid place-items-center text-ink/40">
+                        Generating…
+                      </div>
+                    )}
+                  </div>
                 </div>
-
+                <button
+                  onClick={() => setNonce((n) => n + 1)}
+                  className="text-xs text-magenta hover:underline min-h-[44px]"
+                >
+                  Regenerate code
+                </button>
                 <details className="rounded-xl border border-ink/10 bg-ink/[0.02]">
                   <summary className="px-4 py-3 cursor-pointer text-ink/70 font-medium select-none">
                     Or enter these manually
                   </summary>
                   <div className="px-4 pb-4 space-y-3">
-                    <CopyRow label="Server URL" value={payload.url} />
-                    <CopyRow label="Access token" value={payload.token} mono />
-                    <CopyRow label="CA fingerprint (SHA-256)" value={payload.caFingerprint} mono />
+                    <CopyRow label="Server" value={info.hostPort} mono />
+                    <CopyRow label="Pairing code" value={info.code} mono />
+                    <CopyRow label="Fingerprint tag" value={info.fpTag} mono />
                   </div>
                 </details>
 

--- a/src/modals/pairing-qr-density.test.ts
+++ b/src/modals/pairing-qr-density.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import QRCode from 'qrcode';
+
+/* Regression for the real-phone pairing-scan failure (2026-06-10).
+
+   The RETIRED pairing QR encoded `{url, token, caFingerprint}` as JSON — 193+
+   chars → QR version 10 (57×57 modules). flutter_zxing (zxing-cpp) could not
+   decode that dense code captured off a screen, even though the phone's native
+   camera could (proven by decoding the user's real camera frames through the
+   same engine: 0/8 decoded).
+
+   The fix shrinks the QR by carrying a compact `CWP1*host:port*code*fpTag`
+   payload instead. These assertions lock the density win so the QR can never
+   silently regress back to an unscannable version. The QRCode options here
+   (errorCorrectionLevel 'M') mirror the modal's `QRCode.toDataURL` call in
+   `pair-device.tsx`.
+
+   Spec: docs/superpowers/specs/2026-06-10-pairing-qr-redesign-design.md */
+describe('pairing QR density (scan-failure regression)', () => {
+  // Worst-case realistic payload: longest IPv4 + port, 8-char code, 16-char tag.
+  const cwp1Payload = 'CWP1*255.255.255.255:8443*K7QF3M2P*J4XQ2A7BWZ9K3M5R';
+
+  it('encodes to a low-version (≤ 4) QR the scanner can read', () => {
+    const qr = QRCode.create(cwp1Payload, { errorCorrectionLevel: 'M' });
+    expect(qr.version).toBeLessThanOrEqual(4);
+  });
+
+  it('is a strictly smaller QR than the retired JSON payload', () => {
+    const retiredJson = JSON.stringify({
+      url: 'https://255.255.255.255:8443',
+      token: 'Q'.repeat(32),
+      caFingerprint: Array.from({ length: 32 }, () => 'AB').join(':'),
+    });
+    const retiredVersion = QRCode.create(retiredJson, { errorCorrectionLevel: 'M' }).version;
+    const cwp1Version = QRCode.create(cwp1Payload, { errorCorrectionLevel: 'M' }).version;
+    expect(cwp1Version).toBeLessThan(retiredVersion);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes companion pairing failing on a **real phone**: the QR wouldn't scan.

**Root cause (proven, not guessed):** the old QR encoded `{url, token, caFingerprint}` as JSON — 193 chars → QR **version 10 (57×57)**. `flutter_zxing` (zxing-cpp) cannot decode a code that dense captured off a screen. I confirmed it by feeding the user's **actual camera frames** through the same engine (`zxing-wasm`): **0/8 decoded**, even cropped/upscaled/sharpened. The phone's native camera (ML Kit) decodes the same code — which is why earlier scanner tuning (`tryHarder`, `veryHigh`, `cropPercent 1.0`) never helped.

**Fix:** shrink the QR. The token and full fingerprint leave the QR; it now carries a compact `CWP1*host:port*code*fpTag` payload (~50 chars → QR **v3 (29×29)**, ~2× bigger modules).

- **Server** (`/api/pair`): `POST /session` (loopback-only) mints an ephemeral 40-bit code + an 80-bit CA fingerprint tag and returns the QR string; `POST /redeem` (guard-exempt, code-gated) mints a per-device token via the existing `createDevice()`. Codes are in-memory, single-use, 5-min TTL.
- **App**: parse the compact QR → fetch `/cert/root.crt` → verify the 80-bit tag → redeem the code over the **cert-pinned** channel → store the full fingerprint + token.
- **Frontend**: the Pair-a-device modal calls `/session`, renders the compact QR larger/white/`margin:4`/crisp, with a live expiry countdown, Regenerate, and host/code/fpTag manual entry.

**Security — equal-or-better than before:** the token now travels **only over a cert-pinned channel** (the old static token was printed in the QR for anyone to photograph). MitM protection is preserved via the 80-bit out-of-band fingerprint tag (forging an 80-bit SHA-256 prefix is infeasible). Already-paired devices are untouched (no migration); launch-time reconnect still verifies the stored full fingerprint (no TOFU hole).

Spec: `docs/superpowers/specs/2026-06-10-pairing-qr-redesign-design.md` · Plan: `docs/superpowers/plans/2026-06-10-pairing-qr-redesign.md`

## Test plan

- **Server** (Vitest): Crockford base32 (incl. cross-language known-vector `[1,2,3,4,5]→04106105`), session create/redeem/expiry/single-use, route happy-path + 401/410 + `/session` loopback-403. `npm run test:server` green (2438).
- **Frontend** (Vitest/RTL): `createPairSession`, modal renders compact QR + manual fields + countdown + unavailable(409)/error states. `npm run test` green (2552). **Density regression** locks the QR at ≤ v4 (the assertion that would have caught the original bug).
- **App** (flutter test): `PairingQr` parse, base32 contract (`04106105`), `fingerprintTagMatches`, redeem-flow failure modes (tag-mismatch/rejected/unreachable), screen wiring. 199 tests green, `flutter analyze` clean.
- **Local battery**: typecheck ✓, lint ✓, build ✓. (Playwright e2e not run — contained modal change, no router/layout seam, no pair-device e2e spec.)

## Owed: on-device acceptance

Automated coverage is complete, but the real proof is scanning on the phone. Requires rebuilding the desktop app + the Flutter APK and re-running the pair flow. The committed density regression + the empirical zxing-frame decode strongly predict success, but the on-device scan is the final acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
