### PR TITLE
fix(frontend): keep emotion glyphs green-tick on completed variant rows

### DIFF
--- a/docs/features/201-cast-bulk-emotion-variants.md
+++ b/docs/features/201-cast-bulk-emotion-variants.md
@@ -53,7 +53,11 @@ second line of the cast row's Status column for every Qwen character. It receive
 Quiet states (no glyph strip):
 - Non-Qwen or Qwen-with-no-base — nothing
 - Qwen with no in-use emotion tags → "no emotion tags" hint
-- All demanded variants designed → "✓ variants complete" (with SVG check)
+
+When all demanded variants are designed the strip does **not** collapse — every
+in-use emotion glyph stays visible, all turned green with a check, so a finished
+row reads the same as an in-progress one. The wrapper carries a `variants-complete`
+test marker once every in-use emotion is designed.
 
 This supersedes and **removes** the old `VariantsBadge` count badge and the "N tags
 need a variant" text hint from the cast row — the glyphs convey the same information
@@ -259,8 +263,8 @@ Requires a Qwen project with weights installed + a book with emotion-tagged sent
 4. **Close the tab and re-open** — the pill resumes (reload-resilient job). Verify the pill
    count continues ticking from where it was.
 5. **Watch a row** — as each variant completes, the corresponding amber `!` glyph flips to a
-   green `✓` live. If all of a character's demanded variants are designed, the strip shows
-   "✓ variants complete".
+   green `✓` live. When all of a character's demanded variants are designed, the glyphs stay
+   put — the row just shows every emotion glyph green with a check (no collapse to a summary).
 6. **After all variants complete** — pill clears; "Design full cast" button no longer
    appears (variantCount + needsVoiceIds both = 0).
 7. **Audition a variant** — open a character's profile drawer → click the ▶ preview button

--- a/e2e/cast-variant-design.spec.ts
+++ b/e2e/cast-variant-design.spec.ts
@@ -72,12 +72,17 @@ test.describe('cast view → Design full cast → Emotion variants scope', () =>
        qwen.variants.angry → VariantGlyphStrip re-renders with data-state='designed'. */
     await variantsBtn.click();
 
-    /* The glyph must flip once the mock variant_designed event lands. With
-       only one in-use emotion ('angry'), VariantGlyphStrip replaces the
-       individual glyph with the "variants complete" badge once it is designed
-       (all in-use emotions have a variant). */
+    /* The glyph must flip to green once the mock variant_designed event lands.
+       The emotion glyph STAYS visible (it doesn't collapse into a summary badge)
+       — the strip just adds the 'variants-complete' marker on its wrapper once
+       every in-use emotion is designed, so a finished row reads like an
+       in-progress one with all-green ticks. */
     await expect(page.getByTestId('variants-complete').first()).toBeVisible({
       timeout: 5_000,
     });
+    await expect(page.getByTestId('variant-glyph-angry').first()).toHaveAttribute(
+      'data-state',
+      'designed',
+    );
   });
 });

--- a/src/components/variant-glyph-strip.test.tsx
+++ b/src/components/variant-glyph-strip.test.tsx
@@ -8,9 +8,11 @@ describe('VariantGlyphStrip', () => {
     expect(screen.getByTestId('variant-glyph-angry')).toHaveAttribute('data-state', 'designed');
     expect(screen.getByTestId('variant-glyph-excited')).toHaveAttribute('data-state', 'needed');
   });
-  it('shows a complete state when every in-use emotion is designed', () => {
+  it('marks the complete state but keeps each emotion glyph visible (green/designed)', () => {
     render(<VariantGlyphStrip usedEmotions={new Set(['angry'])} designedEmotions={new Set(['angry'])} />);
     expect(screen.getByTestId('variants-complete')).toBeInTheDocument();
+    // The glyph stays — a finished row reads the same as in-progress, all green.
+    expect(screen.getByTestId('variant-glyph-angry')).toHaveAttribute('data-state', 'designed');
   });
   it('renders the no-tags hint when there are no in-use emotions', () => {
     render(<VariantGlyphStrip usedEmotions={new Set()} designedEmotions={new Set()} />);

--- a/src/components/variant-glyph-strip.tsx
+++ b/src/components/variant-glyph-strip.tsx
@@ -1,9 +1,11 @@
 /* fe-32 — demand-driven per-emotion variant status for a cast row. One glyph per
    emotion the character's quotes USE; a green check badge = designed, an amber
    alert badge = needed (renders in the base voice until designed). Quiet when
-   the character uses no emotion tags; "complete" when every in-use emotion is
-   designed. Status badges are crisp SVG icons (IconCheck / IconAlertTri), not
-   emoji-text, per the spec's icon-quality requirement. */
+   the character uses no emotion tags. Designed emotions keep their glyph with a
+   green check (rather than collapsing to a summary badge) so a finished row reads
+   the same as an in-progress one — each emotion stays visible as a "done" marker.
+   Status badges are crisp SVG icons (IconCheck / IconAlertTri), not emoji-text,
+   per the spec's icon-quality requirement. */
 import type { JSX } from 'react';
 import { IconCheck, IconAlertTri } from '../lib/icons';
 
@@ -24,15 +26,12 @@ export function VariantGlyphStrip({
       <span data-testid="variants-no-tags" className="text-[10px] text-ink/35 italic">no emotion tags</span>
     );
   }
-  if (inUse.every((e) => designedEmotions.has(e))) {
-    return (
-      <span data-testid="variants-complete" className="inline-flex items-center gap-1 text-[10px] font-semibold text-emerald-700">
-        <IconCheck className="w-3 h-3" /> variants complete
-      </span>
-    );
-  }
+  const allDesigned = inUse.every((e) => designedEmotions.has(e));
   return (
-    <span className="inline-flex items-center gap-1.5">
+    <span
+      data-testid={allDesigned ? 'variants-complete' : undefined}
+      className="inline-flex items-center gap-1.5"
+    >
       {inUse.map((e) => {
         const designed = designedEmotions.has(e);
         return (


### PR DESCRIPTION
## Summary

`VariantGlyphStrip` collapsed a fully-designed cast row into a single "✓ variants complete" text badge, hiding the per-emotion glyphs. Now every in-use emotion glyph stays visible and turns green with a check, so a finished row reads the same as an in-progress one — the green ticks persist as "done" markers.

The wrapper `<span>` keeps a `variants-complete` test marker when every in-use emotion is designed, so the marker now means "strip is in the complete state" while the glyphs remain rendered.

## Test plan

- `src/components/variant-glyph-strip.test.tsx` — the complete-state test now also asserts the glyph stays visible with `data-state="designed"`.
- `e2e/cast-variant-design.spec.ts` — asserts the glyph stays `designed` (green) alongside the `variants-complete` marker after the mock `variant_designed` event; updated the stale comment.
- `docs/features/201-cast-bulk-emotion-variants.md` — reflects the no-collapse behaviour.
- `npm run verify` — full battery green locally (typecheck + all tests + e2e + build). Single e2e spec confirmed green (`cast-variant-design`, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)