### PR TITLE
chore(app): brand the empty-album media-session fallback as Castwright

### DIFF
--- a/apps/android/lib/src/data/companion_audio_handler.dart
+++ b/apps/android/lib/src/data/companion_audio_handler.dart
@@ -51,7 +51,7 @@ class CompanionAudioHandler extends BaseAudioHandler with SeekHandler {
     mediaItem.add(MediaItem(
       id: np.id,
       title: np.title,
-      album: np.album.isEmpty ? 'Audiobook' : np.album,
+      album: np.album.isEmpty ? 'Castwright' : np.album,
       duration: np.duration,
       artUri: (np.artPath != null && np.artPath!.isNotEmpty)
           ? Uri.file(np.artPath!)

--- a/apps/android/test/data/companion_audio_handler_test.dart
+++ b/apps/android/test/data/companion_audio_handler_test.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:castwright/src/data/audio_engine.dart';
+import 'package:castwright/src/data/companion_audio_handler.dart';
+import 'package:castwright/src/data/playback_store.dart';
+import 'package:castwright/src/data/player_controller.dart';
+import 'package:castwright/src/domain/skip_behavior.dart';
+
+class FakeAudioEngine implements AudioEngine {
+  Duration _position = Duration.zero;
+  @override
+  Duration get position => _position;
+  @override
+  Stream<Duration> get positionStream => const Stream.empty();
+  @override
+  Duration? get duration => null;
+  @override
+  Stream<Duration?> get durationStream => const Stream.empty();
+  @override
+  Stream<void> get completionStream => const Stream.empty();
+
+  @override
+  Future<void> setFilePath(String path) async => _position = Duration.zero;
+  @override
+  Future<void> setStreamUrl(String url, {Map<String, String>? headers}) async =>
+      _position = Duration.zero;
+
+  @override
+  bool get playing => false;
+  @override
+  Stream<bool> get playingStream => const Stream.empty();
+  @override
+  Future<void> play() async {}
+  @override
+  Future<void> pause() async {}
+  @override
+  Future<void> seek(Duration p) async => _position = p;
+  @override
+  Future<void> setSpeed(double s) async {}
+  @override
+  Future<void> setVolumeBoost(double db) async {}
+  @override
+  Future<void> dispose() async {}
+}
+
+class MemPlaybackStore implements PlaybackStore {
+  @override
+  Future<void> savePlayback(String b, String u, int ms, String iso) async {}
+  @override
+  Future<PlaybackPoint?> loadPlayback(String b) async => null;
+}
+
+PlayerController makeController() => PlayerController(
+      audioEngine: FakeAudioEngine(),
+      playbackStore: MemPlaybackStore(),
+      playlistLoader: (bookId) async =>
+          const [PlayableChapter(uuid: 'u1', path: '/b1/u1/audio.mp3')],
+      skipBehavior: SkipButtonBehavior.seek,
+      clock: () => DateTime.utc(2026, 6, 10, 12),
+      saveInterval: const Duration(seconds: 10),
+    );
+
+void main() {
+  group('CompanionAudioHandler media-session metadata', () {
+    test('empty album falls back to the Castwright brand, not "Audiobook"',
+        () async {
+      final handler = CompanionAudioHandler();
+      final controller = makeController();
+      handler.attach(controller);
+
+      await controller.openBook('b1'); // bookTitle defaults to ''
+      await Future<void>.delayed(Duration.zero); // let the broadcast deliver
+
+      expect(handler.mediaItem.value?.album, 'Castwright');
+    });
+
+    test('a real book title is passed through untouched', () async {
+      final handler = CompanionAudioHandler();
+      final controller = makeController();
+      handler.attach(controller);
+
+      await controller.openBook('b1', bookTitle: 'Keeper of the Lost Cities');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(handler.mediaItem.value?.album, 'Keeper of the Lost Cities');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Brands the companion app's media-session fallback: when a book's album metadata is missing, the Android lock screen / notification now shows **Castwright** instead of generic Audiobook (`apps/android/lib/src/data/companion_audio_handler.dart`).

This was the **single finding** of the app-16 brand audit across `apps/android`: checklist items 1-3 (tagline usage / `.ai`-in-lockup / engine credits) audited **CLEAN** across the Dart sources, the AndroidManifest label, the iOS Info.plist, and pubspec — only this fallback string carried pre-brand wording.

Closes #706

## Test plan

- [x] New `apps/android/test/data/companion_audio_handler_test.dart` pins the `Castwright` fallback for an empty album AND that a real book title passes through untouched (2 tests, green)
- [x] `flutter analyze` — No issues found
- [x] `flutter test` (full companion suite) — 201 passed
- [x] `npm run verify` (pre-push hook) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)