### PR TITLE
docs(docs): remove shipped fe-37/fs-43 backlog rows

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -37,12 +37,6 @@ to monitoring). Prior full pass 2026-06-02 folded in the 29 brainstorm items #45
 - _Benefit (business):_ protects the brand a real business is being built on; avoids a forced rename after launch.
 _Full detail + acceptance:_ [#626](https://github.com/dudarenok-maker/AudioBook-Generator/issues/626).
 
-### `fe-37` — Brand-in-app v1.7.0 rollout (tagline / about / brand.ts / neutrals / multi-version release notes + gate) ([#704](https://github.com/dudarenok-maker/Castwright/issues/704))
-
-- _What:_ Land the 10 June v2 brand decisions inside the app for the v1.7.0 ship + close the audit gaps. Single PR on `feat/frontend-brand-v2-rollout`: new tagline single-sourced in `src/lib/brand.ts` (+ 3 missed static sites — `index.html` meta, `manifest.webmanifest`); rebuilt `/about` (7 blocks, teaser flagged); hand-designed favicons + refreshed `og.png` (+ render-script reconcile so re-runs don't clobber them); six neutral tokens; **multi-version** brand-voice release notes (1.5.0 / 1.6.0 / 1.7.0) at a new `#/release-notes` history view linked from Account + `/about`, decoupled from the tag-annotation bundler; technical notes in `release-notes-next.md`; two-point release gate (`bump-version.mjs` + `release.yml` reject placeholder/wrong-version notes).
-- _Benefit (user / brand):_ the app stops broadcasting retired brand in previews, tabs, SEO and the PWA; v1.7.0 presents a coherent, honest Castwright with real, multi-version in-app notes. Splits out `fs-43` + `app-16`.
-_Full detail + acceptance:_ [#704](https://github.com/dudarenok-maker/Castwright/issues/704) · spec `docs/superpowers/specs/2026-06-10-brand-in-app-rollout-design.md`.
-
 ### `srv-1` — Merge journal for deterministic alias un-link ([#397](https://github.com/dudarenok-maker/AudioBook-Generator/issues/397))
 
 - _What:_ At every cast-merge call site (manual merge route, fold-minor-cast post-stage-2 pass), append a record to a per-book journal file `<bookDir>/.audiobook/cast-merges.json` of shape `{ ts, kind: 'manual' | 'fold', sourceId, sourceName, targetId, affectedSentenceIds: number[] }`. The unlink-alias route then reads this journal to compute `impactedChapters.candidateSentenceIds` as the exact sentences originally rewritten by the merge — no `chapterCast` heuristic, no per-chapter listing of sentences that may belong to a third party.
@@ -133,12 +127,6 @@ _Full detail + acceptance:_ [#416](https://github.com/dudarenok-maker/AudioBook-
 - _What:_ Add a per-chapter "Detect emotions" option (the emotion-only backfill pass scoped to the current chapter) alongside the whole-book trigger. The fs-33 v1 shipped whole-book only.
 - _Benefit (user):_ cheap targeted re-detect for one edited/late-added chapter without re-running the whole book's quota.
 _Full detail + acceptance:_ [#592](https://github.com/dudarenok-maker/AudioBook-Generator/issues/592).
-
-### `fs-43` — "Will it run on my machine?" device panel (sensible, server-sourced) ([#705](https://github.com/dudarenok-maker/Castwright/issues/705))
-
-- _What:_ A first-run / Account → Models panel showing the per-platform hardware-honesty line + the detected **host** device, **server-sourced** via `GET /api/info` (`os.platform()`/`os.arch()` → Apple Silicon / Windows / Linux). The server runs the models; a LAN browser is the phone, so client-side detection would be wrong. Surfaces existing `health.device` (cuda/cpu) when a model is loaded; honest "load a voice to confirm" otherwise. Audits + fixes frontend GPU-not-detected strings for NVIDIA-only phrasing. **Ships in the brand wave (`fe-37` #704)**; the deep ground-truth half is split to `side-14`.
-- _Benefit (user):_ answers "will it run on my Mac/PC?" honestly today — especially the new Apple Silicon path, which `os.arch()` detects reliably.
-_Full detail + acceptance:_ [#705](https://github.com/dudarenok-maker/Castwright/issues/705).
 
 ### `side-14` — Device ground-truth: sidecar reports active-engine torch device incl. mps (deep half of fs-43) ([#707](https://github.com/dudarenok-maker/Castwright/issues/707))
 


### PR DESCRIPTION
## Summary
Post-ship hygiene for the brand-in-app wave (PR #713, merged): removes the two thin BACKLOG rows whose issues auto-closed on that merge — **fe-37** (#704) and **fs-43** (#705). The follow-up rows stay: **side-14** (#707) and **app-16** (#706, delegated to the app-work agent).

Docs-only — skips `verify.yml` via `paths-ignore`.

## Test plan
N/A (BACKLOG.md only).

Refs #704