### PR TITLE
feat(frontend): adopt brand v2 --ink-soft value (#4A4440)

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -85,18 +85,16 @@
   --canvas: #fffdfb;
   --canvas-warm: #fcded7;
   --ink: #0f0e0d;
-  --ink-soft: #1a1a1a;
+  --ink-soft: #4a4440;
   --peach: #f79a83; /* peach = action accent */
   --peach-soft: #fcded7;
   --magenta: #a43c6c; /* magenta = secondary / brand */
   --purple-deep: #3c194f; /* deep purple = series context */
 
   /* Brand v2 neutral ramp (BRAND_CHANGELOG decision 10 / guidelines §5) — one
-     shared neutral vocabulary for app + brand. NOTE: the brand ramp also defines
-     --ink-soft #4A4440, but the app already binds --ink-soft to #1a1a1a
-     (near-black, in use across the UI). Left as-is to avoid a visual change;
-     adopting the brand #4A4440 app-wide is a separate visual decision, not part
-     of this copy/assets wave. */
+     shared neutral vocabulary for app + brand. --ink-soft (above) adopted the
+     brand ramp's #4A4440 (was #1a1a1a near-black) as a deliberate, user-approved
+     visual change after the copy/assets wave flagged the collision. */
   --ink-mute: #5a534e;
   --line: #d9cfc7;
   --line-soft: #eee2da;


### PR DESCRIPTION
## Summary

Adopts the brand v2 neutral-ramp value for the `--ink-soft` design token: `#1a1a1a` (near-black) → `#4A4440` (warm mid-dark grey), per brand guidelines §5 / BRAND_CHANGELOG decision 10. The plan-203 brand wave added the other five brand neutrals but deliberately left `--ink-soft` at the pre-existing app value and flagged the collision (`docs/features/203-brand-in-app-rollout.md`); the user has now decided to adopt the brand value. Deliberate, user-approved visual change — light theme only.

**Definition sites** (the only ones; no hex literals in component code):
- `src/styles.css:88` — `:root` value changed to `#4a4440` (+ stale deferral comment updated).
- `src/styles.css:8` — Tailwind v4 `@theme` mapping `--color-ink-soft: var(--ink-soft)` — unchanged.
- Dark theme (`[data-theme='dark']`, styles.css:164) overrides to `#dcd4cf` (a LIGHT soft-ink, correct since `--ink` flips to near-white) — intentionally untouched. Both high-contrast blocks pin `#000`/`#fff` — untouched.

**Usage survey** — every `ink-soft` usage in `src/` (all are `bg-ink-soft`; there is no `text-ink-soft` anywhere):

| File:line | Class | What it styles |
|---|---|---|
| `src/components/primitives.tsx:26` | `hover:bg-ink-soft` | shared `Button` primitive, `dark` variant hover fill |
| `src/components/model-pull-status.tsx:189` | `hover:bg-ink-soft` | "Pull" pill on the Ollama model row (hover) |
| `src/components/mini-player.tsx:619` | `bg-ink-soft` | playback-speed popover surface (resting) |
| `src/components/mini-player.tsx:676` | `bg-ink-soft` | sleep-timer popover surface (resting) |
| `src/components/mini-player.tsx:763` | `bg-ink-soft` | volume-slider popover surface (resting) |
| `src/components/manuscript-diff.tsx:205` | `hover:bg-ink-soft` | "Apply changes" CTA (hover) |
| `src/modals/voice-compare-modal.tsx:281` | `hover:bg-ink-soft` | "Use proposed voice" CTA (hover) |
| `src/modals/share-clip.tsx:353` | `hover:bg-ink-soft` | "Download clip" CTA (hover) |
| `src/modals/rebaseline-modal.tsx:590` | `hover:bg-ink-soft` | "Propose voices" CTA (hover) |
| `src/modals/rebaseline-modal.tsx:649` | `hover:bg-ink-soft` | apply/series-overrides CTA (hover) |
| `src/modals/export-audiobook.tsx:506` | `hover:bg-ink-soft` | export-start CTA (hover) |
| `src/modals/export-audiobook.tsx:515` | `hover:bg-ink-soft` | "Build download" / "Build and save" CTA (hover) |
| `src/modals/drift-report.tsx:424` | `hover:bg-ink-soft` | "Regenerate all" pill (hover) |
| `src/modals/drift-report.tsx:513` | `hover:bg-ink-soft` | per-row "Regenerate" pill (hover) |
| `src/modals/character-regenerate.tsx:200` | `hover:bg-ink-soft` | "Preview CH NN first" CTA (hover) |
| `src/views/advanced.tsx:153` | `hover:bg-ink-soft` | Advanced-config "Save" button (hover) |
| `src/views/admin.tsx:148` | `hover:bg-ink-soft` | "Open Model Manager" button (hover) |
| `src/views/admin.tsx:171` | `hover:bg-ink-soft` | "About Castwright" button (hover) |
| `src/views/admin.tsx:194` | `hover:bg-ink-soft` | "Advanced configuration" button (hover) |
| `src/views/account.tsx:449` | `hover:bg-ink-soft` | Account "Advanced configuration" button (hover) |
| `src/views/account.tsx:466` | `hover:bg-ink-soft` | Account "Save changes" button (hover) |
| `src/views/revision-diff.tsx:474` | `hover:bg-ink-soft` | new-take play/pause circle button (hover) |
| `src/components/listen/listen-header.tsx:276` | `hover:bg-ink-soft` | "Play from the start" CTA (hover) |
| `src/components/listen/listen-download-section.tsx:290` | `hover:bg-ink-soft` | listener-app send/export tile CTA (hover) |
| `src/components/listen/companion-app-banner.tsx:127` | `hover:bg-ink-soft` | "Download .apk" CTA (hover) |

**Contrast**: every usage pairs ink-soft with `text-canvas` (or `text-canvas/70`–`/80` in the popovers). On `#4A4440`: canvas `#fffdfb` ≈ 9.5:1, canvas/80 ≈ 6.8:1, canvas/70 ≈ 5.7:1 — all clear WCAG AA 4.5:1. No usage sits on a problematic background. Side effect worth eyeballing: dark CTA hover (ink `#0f0e0d` → `#4A4440`) is now a clearly visible warm lighten instead of a near-invisible `#1a1a1a` shift.

The remaining `#1A1A1A` hits in `src/` are book-cover gradient fixture data (`coverGradient`), unrelated to the token — untouched.

## Test plan

- [x] `npm run verify` (pre-push hook) — green: lint, typecheck, frontend (2591), server (2458+206), scripts (24), e2e (171 passed / 2 skipped), a11y, visual, build
- [x] `npm run test:e2e:visual` — **14/14 baselines pass with NO regeneration needed**: ink-soft only ever paints hover states and the (closed-in-snapshots) mini-player popovers, so no committed PNG drifts
- [x] `npm run test:a11y` (axe-core, 4 core views) — green
- [ ] Reviewer: eyeball one dark-CTA hover (e.g. Listen "Play from the start") in light + dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
