### PR TITLE
fix(scripts): flatten wrapped console output before venv-path assertions

### DIFF
--- a/scripts/tests/sidecar-start.Tests.ps1
+++ b/scripts/tests/sidecar-start.Tests.ps1
@@ -42,6 +42,11 @@ BeforeAll {
                 -RedirectStandardOutput $outFile -RedirectStandardError $errFile
             $text = (Get-Content $outFile -Raw -ErrorAction SilentlyContinue) +
                     (Get-Content $errFile -Raw -ErrorAction SilentlyContinue)
+            # Windows PowerShell wraps Write-Error text at the inherited console
+            # width, which can split an asserted venv path mid-GUID (narrow
+            # consoles ~104 cols flake both Its). The assertions only ever match
+            # path substrings, so flatten the line breaks before they see it.
+            $text = $text -replace '\r?\n', ''
             return [pscustomobject]@{ ExitCode = $p.ExitCode; Output = $text }
         } finally {
             if ($null -eq $prev) { Remove-Item Env:\SIDECAR_VENV_DIR -ErrorAction SilentlyContinue }


### PR DESCRIPTION
## Summary

Fixes the pre-existing Pester flake in `scripts/tests/sidecar-start.Tests.ps1`: Windows PowerShell wraps the child process's `Write-Error` text at the inherited console width, which can split the asserted venv path mid-GUID on narrow consoles (~104 cols), so `Should -Match ([regex]::Escape($path))` misses. Both `It`s were vulnerable (the SIDECAR_VENV_DIR path and the script-local `.venv` fallback path).

One-line fix in the `Invoke-StartScript` helper: flatten `\r?\n` out of the captured output before the assertions see it — the tests only ever match path substrings, so de-wrapping is safe and makes console width irrelevant.

**Fail-before evidence:** hit independently by two agents on 2026-06-10 during pre-push `verify` runs at ~104-col consoles (worked around then via `mode con cols=400` / short `TMP` — no gates bypassed). A conventional fails-before regression test isn't practical here (the bug is in the test harness itself and reproduces only under a narrow inherited console); the inline comment documents the hazard.

Closes #719

## Test plan

- `npm run test:scripts` — 24/24 Pester tests green with the fix.
- Full pre-push `npm run verify` green on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
