### PR TITLE
fix(server,frontend): confirm-screen voice hydration + same-series match scope

### DIFF
--- a/server/src/routes/voice-match.test.ts
+++ b/server/src/routes/voice-match.test.ts
@@ -15,6 +15,11 @@ import request from 'supertest';
 let workspaceRoot: string;
 let app: Express;
 let makeBookIdFn: (a: string, s: string, t: string) => string;
+/* The "current book" we're analysing. It must be a REAL on-disk book in the
+   Keeper series so the (author, series)-scoped matcher resolves its
+   series-mates (Book One / Book Two) as eligible candidates. Assigned in
+   beforeAll once makeBookId is imported. */
+let CURRENT_BOOK_ID: string;
 
 const AUTHOR = 'Shannon Messenger';
 const SERIES = 'Keeper of the Lost Cities';
@@ -162,6 +167,12 @@ beforeAll(async () => {
     true,
   );
 
+  /* The current book being analysed — a real Keeper-series book on disk so the
+     (author, series) matcher resolves Book One / Book Two as its series-mates.
+     Its own cast is empty (and it's excluded as a self-candidate anyway). */
+  CURRENT_BOOK_ID = makeBookId(AUTHOR, SERIES, 'Current Book');
+  writeBookOnDisk(workspaceRoot, AUTHOR, SERIES, 'Current Book', CURRENT_BOOK_ID, [], false);
+
   app = express();
   app.use(express.json());
   app.use('/api/books', voiceMatchRouter);
@@ -180,10 +191,6 @@ function callMatch(bookId: string, body: object) {
 }
 
 describe('voice-match router', () => {
-  /* The "current book" we're analysing — distinct from the two prior books
-     on disk, so all library voices are eligible. */
-  const CURRENT_BOOK_ID = 'currently-analysing__std__new-book';
-
   it('returns empty matches when the library has nothing useful', async () => {
     const res = await callMatch(CURRENT_BOOK_ID, {
       characters: [
@@ -392,18 +399,34 @@ describe('voice-match router', () => {
     expect(voiceIds).not.toContain('v_narr_skul'); // cross-series narrator excluded
   });
 
-  it('a real named character still matches library-wide across series', async () => {
-    /* The series scope applies ONLY to generic role-names. A genuinely
-       recurring character keeps matching against the whole library — here
-       Keefe still matches the Keeper-series Keefe from a Skulduggery-series
-       book, because reusing a designed voice across the library is the
-       intended feature. */
+  it('a real named character does NOT match across a different author/series', async () => {
+    /* Auto-match is scoped to the current book's same-author + same-series
+       mates — for EVERY character, not just generic role-names. A
+       Skulduggery-series "Keefe" must NOT grab the Keeper-series Keefe's
+       designed voice: an unrelated author's same-named character is a
+       coincidence, not a recurring character. (Cross-series reuse stays
+       possible as an explicit Voice-library assignment, just never as a
+       silent auto-match.) Mirrors the real-world "Tam Hollis" (a Castwright
+       standalone) wrongly grabbing "Tam" from Shannon Messenger's Neverseen. */
     const scepterId = makeBookIdFn('Derek Landy', 'Skulduggery Pleasant', 'Scepter of the Ancients');
     const res = await callMatch(scepterId, {
       characters: [{ id: 'keefe', name: 'Keefe', attributes: [], gender: 'male', ageRange: 'teen' }],
     });
     expect(res.status).toBe(200);
     const voiceIds = res.body.matches[0].candidates.map((c: { voiceId: string }) => c.voiceId);
-    expect(voiceIds).toContain('v_keefe'); // cross-series named char still matches
+    expect(voiceIds).not.toContain('v_keefe'); // cross-author/series named char excluded
+  });
+
+  it('a real named character STILL matches a same-series sibling book', async () => {
+    /* The scope tightening must not break legitimate within-series reuse:
+       calling as Book Three (Keeper of the Lost Cities), "Keefe" still
+       matches the Keeper-series Keefe designed in Book One / Book Two. */
+    const bookThreeId = makeBookIdFn(AUTHOR, SERIES, 'Book Three Unconfirmed');
+    const res = await callMatch(bookThreeId, {
+      characters: [{ id: 'keefe', name: 'Keefe', attributes: [], gender: 'male', ageRange: 'teen' }],
+    });
+    expect(res.status).toBe(200);
+    const voiceIds = res.body.matches[0].candidates.map((c: { voiceId: string }) => c.voiceId);
+    expect(voiceIds.some((v: string) => v === 'v_keefe' || v === 'v_keefe_alt')).toBe(true);
   });
 });

--- a/server/src/routes/voice-match.ts
+++ b/server/src/routes/voice-match.ts
@@ -37,20 +37,6 @@ import { jaccard, nameTokens, normaliseForMatch } from '../util/text-match.js';
 
 export const voiceMatchRouter = Router();
 
-/* Generic role-names exist in every book under the same deterministic id
-   (the narrator keeps voiceId/id 'narrator' across the whole library), so a
-   library-wide exact-name match fires against EVERY book's narrator — a
-   Skulduggery narrator claiming a Keeper narrator, with the tie broken by
-   arbitrary scan order. Unlike a real recurring character, a narrator is only
-   legitimately reused WITHIN its series, where the analysis-time linker
-   (series-reuse-link.ts) already handles continuity. So generic-role
-   candidates are scoped to the current book's series; everything else keeps
-   matching library-wide (designed-voice reuse across books is intentional). */
-const GENERIC_ROLE_IDS = new Set(['narrator']);
-function isGenericRole(c: CharacterMatchInput): boolean {
-  return GENERIC_ROLE_IDS.has(c.id) || normaliseForMatch(c.name) === 'narrator';
-}
-
 export interface CharacterMatchInput {
   id: string;
   name: string;
@@ -306,12 +292,16 @@ voiceMatchRouter.post('/:bookId/voice-match', async (req: Request, res: Response
     );
 
     const matches = characters.map((c) => {
-      const generic = isGenericRole(c);
       const scored: Candidate[] = [];
       for (const v of voices) {
-        /* A narrator only reuses within its own series; a real character
-           keeps matching library-wide. */
-        if (generic && !seriesMateBookIds.has(v.bookId)) continue;
+        /* Auto-match is scoped to the current book's same-author + same-series
+           mates — for EVERY character, not just generic role-names. Matching a
+           real character library-wide let an unrelated author/series's same-
+           named character grab a designed voice (a Castwright standalone's
+           "Tam Hollis" claiming Shannon Messenger's "Tam"). Cross-series reuse
+           stays available as an explicit Voice-library assignment; it is never
+           a silent auto-match. */
+        if (!seriesMateBookIds.has(v.bookId)) continue;
         const cand = scoreOne(c, v);
         if (cand) scored.push(cand);
       }

--- a/src/routes/analysing-rehydrate.test.tsx
+++ b/src/routes/analysing-rehydrate.test.tsx
@@ -1,0 +1,142 @@
+/* Regression: after analysis completes, the /confirm cast must reflect the
+   server-merged cast.json — including designed voices the reparse/replace
+   carryover (srv-13) restored. The analysis payload carries only the detected
+   roster (voiceless for an in-this-book designed voice), and the reparse/replace
+   handler cleared the cast slice, so hydrateFromAnalysis's overlay has nothing
+   to draw from. AnalysingRoute.onComplete therefore re-reads getBookState and
+   setCharacters from the authoritative merged cast.json.
+
+   Without the fix the cast slice keeps the voiceless payload roster and the
+   confirm screen renders "No voice designed yet" for a character whose designed
+   voice is safe on disk. */
+
+import { Suspense } from 'react';
+import { useEffect } from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { uiSlice } from '../store/ui-slice';
+import { castSlice } from '../store/cast-slice';
+import { chaptersSlice } from '../store/chapters-slice';
+import { manuscriptSlice } from '../store/manuscript-slice';
+import { librarySlice } from '../store/library-slice';
+import { queueSlice } from '../store/queue-slice';
+import { revisionsSlice } from '../store/revisions-slice';
+import { voicesSlice } from '../store/voices-slice';
+import { changeLogSlice } from '../store/change-log-slice';
+import { accountSlice } from '../store/account-slice';
+import { bookMetaSlice } from '../store/book-meta-slice';
+import type { AnalyseResponse } from '../lib/types';
+
+const BOOK_ID = 'castwright__standalones__the-coalfall-commission';
+
+/* The analysis payload AnalysingView hands to onComplete: a freshly-detected
+   roster whose Coalfall is VOICELESS (no overrideTtsVoices) — exactly what the
+   stream produces when the designed voice was restored server-side into
+   cast.json but never streamed back to the client. */
+const VOICELESS_PAYLOAD = {
+  bookId: BOOK_ID,
+  manuscriptId: 'mns_coalfall',
+  title: 'The Coalfall Commission',
+  characters: [{ id: 'coalfall', name: 'Coalfall', voiceState: 'generated' }],
+  chapters: [],
+  sentences: [],
+} as unknown as AnalyseResponse;
+
+/* What the merged cast.json on disk holds — Coalfall WITH its restored Qwen
+   designed voice. getBookState returns this; the fix must surface it. */
+const getBookStateMock = vi.fn();
+
+vi.mock('../lib/api', () => ({
+  api: {
+    getBookState: (bookId: string) => getBookStateMock(bookId),
+    /* AnalysingRoute / layout-free render touches none of these here, but the
+       module references `api.*` at call sites — provide inert stubs. */
+    getDroppedQuotes: () => Promise.resolve({ manuscriptId: 'mns_coalfall', batches: [] }),
+    getChapterAudio: () => new Promise(() => {}),
+  },
+  AnalysisError: class extends Error {
+    code = 'unknown';
+  },
+}));
+
+/* Stub AnalysingView so it fires onComplete once on mount with the voiceless
+   payload — standing in for a completed analysis stream. */
+vi.mock('../views/analysing', () => ({
+  AnalysingView: (props: { onComplete: (p: AnalyseResponse) => void }) => {
+    useEffect(() => {
+      props.onComplete(VOICELESS_PAYLOAD);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return null;
+  },
+}));
+
+// Import AFTER the mocks so the route module picks them up.
+import { AnalysingRoute } from './index';
+
+function makeStore() {
+  return configureStore({
+    reducer: {
+      ui: uiSlice.reducer,
+      cast: castSlice.reducer,
+      chapters: chaptersSlice.reducer,
+      revisions: revisionsSlice.reducer,
+      manuscript: manuscriptSlice.reducer,
+      library: librarySlice.reducer,
+      voices: voicesSlice.reducer,
+      changeLog: changeLogSlice.reducer,
+      account: accountSlice.reducer,
+      bookMeta: bookMetaSlice.reducer,
+      queue: queueSlice.reducer,
+    },
+  });
+}
+
+beforeEach(() => {
+  getBookStateMock.mockReset();
+});
+
+describe('AnalysingRoute.onComplete — re-reads merged cast.json', () => {
+  it('surfaces a carryover-restored designed voice the analysis payload omitted', async () => {
+    getBookStateMock.mockResolvedValue({
+      state: { bookId: BOOK_ID, chapters: [] },
+      cast: {
+        characters: [
+          {
+            id: 'coalfall',
+            name: 'Coalfall',
+            voiceState: 'generated',
+            ttsEngine: 'qwen',
+            overrideTtsVoices: { qwen: { name: 'qwen-coalfall' } },
+          },
+        ],
+      },
+    });
+
+    const store = makeStore();
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[`/books/${BOOK_ID}/analysing`]}>
+          <Suspense fallback={<div data-testid="suspense-loading" />}>
+            <Routes>
+              <Route path="/books/:bookId/analysing" element={<AnalysingRoute />} />
+            </Routes>
+          </Suspense>
+        </MemoryRouter>
+      </Provider>,
+    );
+
+    /* getBookState is called with the completed book's id … */
+    await waitFor(() => expect(getBookStateMock).toHaveBeenCalledWith(BOOK_ID));
+
+    /* … and its merged cast (with the designed voice) replaces the voiceless
+       payload roster in the slice. */
+    await waitFor(() => {
+      const coalfall = store.getState().cast.characters.find((c) => c.id === 'coalfall');
+      expect(coalfall?.overrideTtsVoices?.qwen?.name).toBe('qwen-coalfall');
+    });
+  });
+});

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -491,6 +491,31 @@ export function AnalysingRoute() {
         dispatch(chaptersActions.hydrateFromAnalysis(payload));
         dispatch(manuscriptActions.hydrateFromAnalysis(payload));
         dispatch(uiActions.analysisComplete({ bookId: payload.bookId }));
+        /* Re-read the authoritative merged cast.json after analysis. The
+           analysis payload carries the freshly-detected roster, but a voice
+           DESIGNED IN THIS BOOK that the server restored via the
+           reparse/replace carryover (srv-13) is NOT in the payload — and
+           hydrateFromAnalysis's overlay can't resurrect it because the
+           reparse/replace handler cleared the cast slice, so there's nothing
+           to overlay FROM. Without this the /confirm screen renders "No voice
+           designed yet" for characters whose designed voice is safe on disk
+           (the layout's confirm-stage hydration is skipped once the SSE stream
+           has populated the slice). Fire-and-forget; failure leaves the
+           payload roster, which a manual reload then reconciles. */
+        if (payload.bookId) {
+          const targetBookId = payload.bookId;
+          void api
+            .getBookState(targetBookId)
+            .then((res) => {
+              const merged = res?.cast?.characters;
+              if (merged && merged.length > 0) {
+                dispatch(castActions.setCharacters(merged));
+              }
+            })
+            .catch(() => {
+              /* non-fatal — confirm falls back to the analysis payload roster */
+            });
+        }
       }}
     />
   );


### PR DESCRIPTION
## Summary
Two pre-existing bugs surfaced while running Wave 2 of fs-22 (replace the demo manuscript → analyse → confirm). Neither is a regression in the Replace-manuscript feature — that workflow just exercises the reparse→analyse→confirm path that exposes them.

**Bug A — designed voices showed as "No voice designed yet" on /confirm (display only).** After a reparse/replace + fresh analysis, the carryover (srv-13) restores designed voices into `cast.json` on disk, but the confirm screen rendered them voiceless: the analysis payload omits them, `hydrateFromAnalysis`'s overlay had a cleared slice to draw from, and the layout's confirm-stage hydration is skipped once the SSE stream filled the slice. Fix: `AnalysingRoute.onComplete` re-reads the authoritative merged `cast.json` (`getBookState` → `setCharacters`).

**Bug B — a character matched across an unrelated author/series.** The library-wide `POST /voice-match` matcher matched a real character name across ALL books (a Castwright standalone's "Tam Hollis" grabbing Shannon Messenger's "Tam" at 0.475). Fix: scope ALL candidates to the current book's same-author + same-series mates (matching the analysis-time linker), not just generic role-names. Cross-series reuse stays available as an explicit Voice-library assignment.

## Test plan
- `server/src/routes/voice-match.test.ts` — cross-author/series named char no longer matches; same-series sibling still matches; requester wired as a real same-series book.
- `src/routes/analysing-rehydrate.test.tsx` — onComplete re-reads merged cast.json (fails before the fix, passes after).
- `npm run verify` fully green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
