### PR TITLE
feat(scripts): ship the fs-22 demo book in the release zip + document it

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -130,6 +130,21 @@ To stop: `npm run stop:prod`.
 
 ---
 
+## Try the demo book
+
+The app ships with a generate-able demo — **The Coalfall Commission** (an original
+Castwright work). On the books-library empty state or the upload screen, click
+**"try a sample book"** to load it into your workspace with its full 13-character
+cast already designed, then **Generate** to hear it.
+
+The designed voices are **Qwen** (the flagship per-character engine), so generating
+the demo as designed needs the Qwen model installed (Model Manager → install Qwen)
+on a GPU. Every character also carries a **Kokoro** fallback preset, so the demo
+still generates with a full cast on a box without Qwen — just less bespoke. No audio
+ships in the bundle; the demo runs the real pipeline locally.
+
+---
+
 ## Troubleshooting
 
 ### "ffmpeg not found on PATH"

--- a/scripts/build-release-zip.mjs
+++ b/scripts/build-release-zip.mjs
@@ -88,6 +88,11 @@ export const MANIFEST = {
     // fs-1 upgrade machinery the deployer/runtime needs.
     'scripts/restart-after-upgrade.mjs',
     'scripts/setup-versioned-install.mjs',
+
+    // fs-22 — the bundled, generate-able demo book (manuscript + designed cast
+    // + voice files, no audio). Loaded into the workspace via the "Try the
+    // sample" affordance (POST /api/samples/:slug/load).
+    'samples/**',
   ],
   exclude: [
     // Installed deps + venv (deployer runs npm ci / pip install).

--- a/scripts/tests/release-manifest.test.mjs
+++ b/scripts/tests/release-manifest.test.mjs
@@ -187,3 +187,8 @@ test('ships the analyzer skill prompts (read at runtime from <root>/skills)', ()
   assert.equal(matchesManifest('skills/audiobook-character-detection-per-chapter.md'), true);
   assert.equal(matchesManifest('skills/audiobook-voice-style.md'), true);
 });
+
+test('ships the fs-22 bundled demo book (manuscript + cast + voice files)', () => {
+  assert.equal(matchesManifest('samples/the-coalfall-commission/.audiobook/cast.json'), true);
+  assert.equal(matchesManifest('samples/the-coalfall-commission/voices/qwen/qwen-coalfall.pt'), true);
+});


### PR DESCRIPTION
## Summary
Wave 4 of fs-22. Adds samples/** to the release manifest so the bundled demo book ships in the release zip; manifest test asserts it. INSTALL.md documents the 'try a sample book' flow + Qwen-designed / Kokoro-fallback engines.

Refs #475.