### PR TITLE
fix(server,frontend): id-drift voice rescue + distinct Replace-manuscript icon

### DIFF
--- a/server/src/store/merge-analysis-cast.test.ts
+++ b/server/src/store/merge-analysis-cast.test.ts
@@ -110,6 +110,55 @@ describe('mergeAnalysisResultWithExistingCast', () => {
     const merged = mergeAnalysisResultWithExistingCast(existing, fresh);
     expect(merged[0].aliases).toEqual(['Keefe', 'Lord Hunkyhair', 'Mr. Sencen']);
   });
+
+  it('id drift: a relabelled character carries its voice onto the same-name fresh row (no duplicate)', () => {
+    // The analyzer relabelled the dragon `coalfall` -> `coalfall-dragon` between
+    // runs. The old voiced row was dropped by id; without the name fallback the
+    // fresh `coalfall-dragon` would be voiceless AND old `coalfall` re-added as a
+    // 0-line orphan.
+    const existing: C[] = [
+      {
+        id: 'coalfall',
+        name: 'Coalfall',
+        voiceState: 'tuned',
+        voiceId: 'coalfall',
+        ttsEngine: 'qwen',
+        overrideTtsVoices: { qwen: { name: 'qwen-coalfall' } },
+      },
+    ];
+    const fresh: C[] = [{ id: 'coalfall-dragon', name: 'Coalfall', lines: 33 } as C];
+    const merged = mergeAnalysisResultWithExistingCast(existing, fresh);
+    // The descriptive, library-unique fresh id wins; no orphan.
+    expect(merged.map((c) => c.id)).toEqual(['coalfall-dragon']);
+    const dragon = merged[0];
+    expect(dragon.overrideTtsVoices).toEqual({ qwen: { name: 'qwen-coalfall' } });
+    expect(dragon.ttsEngine).toBe('qwen');
+    expect(dragon.voiceState).toBe('tuned');
+    expect((dragon as C).lines).toBe(33); // analyzer-owned fields stay from the fresh row
+  });
+
+  it('id drift: an ambiguous name (two fresh rows) falls back to id-only + re-adds the orphan', () => {
+    const existing: C[] = [
+      {
+        id: 'coalfall',
+        name: 'Coalfall',
+        voiceState: 'tuned',
+        overrideTtsVoices: { qwen: { name: 'qwen-coalfall' } },
+      },
+    ];
+    // Two fresh rows share the name → too risky to guess; don't merge by name.
+    const fresh: C[] = [
+      { id: 'coalfall-dragon', name: 'Coalfall' } as C,
+      { id: 'coalfall-other', name: 'Coalfall' } as C,
+    ];
+    const merged = mergeAnalysisResultWithExistingCast(existing, fresh);
+    expect(merged.map((c) => c.id)).toEqual(['coalfall-dragon', 'coalfall-other', 'coalfall']);
+    // The orphan keeps its voice; neither fresh row got it.
+    expect(merged.find((c) => c.id === 'coalfall')!.overrideTtsVoices).toEqual({
+      qwen: { name: 'qwen-coalfall' },
+    });
+    expect(merged.find((c) => c.id === 'coalfall-dragon')!.overrideTtsVoices).toBeUndefined();
+  });
 });
 
 describe('seedReuseGuardsFromPriorCast', () => {

--- a/server/src/store/merge-analysis-cast.ts
+++ b/server/src/store/merge-analysis-cast.ts
@@ -26,6 +26,8 @@
        lose a designed/reused voice. User deletes/merges already remove the id
        from cast.json, so only analyzer-dropped characters get rescued. */
 
+import { normaliseForMatch } from '../util/text-match.js';
+
 /** Per-character fields owned by voice design / reuse, not by the analyzer. */
 export const PRESERVED_VOICE_FIELDS = [
   'voiceId',
@@ -84,16 +86,58 @@ export function voicedSurvivorsDropped(
 }
 
 /** Overlay the existing cast's voice-design fields onto the freshly-analysed
-    roster (matched by `id`), union aliases, and re-add voiced characters the
-    fresh roster dropped. Returns a new array; inputs are not mutated. */
+    roster (matched by `id`, with a same-name fallback for analyzer id drift),
+    union aliases, and re-add voiced characters the fresh roster dropped.
+    Returns a new array; inputs are not mutated. */
 export function mergeAnalysisResultWithExistingCast<T extends { id: string }>(
   existing: ReadonlyArray<CastRecord>,
   fresh: T[],
 ): T[] {
   if (!existing.length) return fresh;
   const byId = new Map(existing.map((c) => [c.id, c]));
+  const freshIds = new Set(fresh.map((f) => f.id));
+  const nameOf = (c: { name?: unknown } & Record<string, unknown>): string =>
+    typeof c.name === 'string' ? normaliseForMatch(c.name) : '';
+
+  /* Name-fallback for analyzer id drift. The analyzer is non-deterministic about
+     a character's id across runs (it relabelled the dragon `coalfall` →
+     `coalfall-dragon` between two analyses of the same book). The id-keyed
+     overlay then misses, the fresh row comes up voiceless, AND the dropped
+     voiced row is re-added below as a 0-line orphan — a visible duplicate.
+     Match a voiced existing character whose id the fresh roster DROPPED to a
+     same-name fresh character so its designed voice rides onto the freshly-
+     detected row (which carries the lines + the more descriptive, library-
+     unique id). Guard against ambiguity: a normalised name shared by more than
+     one dropped-voiced existing OR more than one fresh row is left to the
+     id-only path (too risky to guess). */
+  const freshNameCounts = new Map<string, number>();
+  for (const f of fresh) {
+    const key = nameOf(f as T & Record<string, unknown>);
+    if (key) freshNameCounts.set(key, (freshNameCounts.get(key) ?? 0) + 1);
+  }
+  const droppedVoicedByName = new Map<string, CastRecord>();
+  const ambiguousNames = new Set<string>();
+  for (const old of existing) {
+    if (freshIds.has(old.id) || !isVoicedOrReused(old)) continue;
+    const key = nameOf(old);
+    if (!key) continue;
+    if (droppedVoicedByName.has(key)) ambiguousNames.add(key);
+    else droppedVoicedByName.set(key, old);
+  }
+  const claimedByName = new Set<string>(); // existing ids whose voice rode onto a fresh row
+
   const overlaid = fresh.map((f) => {
-    const old = byId.get(f.id);
+    let old = byId.get(f.id);
+    if (!old) {
+      const key = nameOf(f as T & Record<string, unknown>);
+      if (key && !ambiguousNames.has(key) && freshNameCounts.get(key) === 1) {
+        const cand = droppedVoicedByName.get(key);
+        if (cand) {
+          old = cand;
+          claimedByName.add(cand.id);
+        }
+      }
+    }
     if (!old) return f;
     const merged = { ...(f as Record<string, unknown>) };
     for (const key of PRESERVED_VOICE_FIELDS) {
@@ -104,10 +148,11 @@ export function mergeAnalysisResultWithExistingCast<T extends { id: string }>(
     return merged as T;
   });
 
-  /* Carry forward voiced/reused characters the fresh roster omitted. */
-  const freshIds = new Set(fresh.map((f) => f.id));
+  /* Carry forward voiced/reused characters the fresh roster omitted — UNLESS
+     their designed voice already rode onto a same-name fresh row above (id
+     drift), which would otherwise re-add them as a 0-line duplicate. */
   for (const old of existing) {
-    if (freshIds.has(old.id)) continue;
+    if (freshIds.has(old.id) || claimedByName.has(old.id)) continue;
     if (isVoicedOrReused(old)) overlaid.push(old as unknown as T);
   }
   return overlaid;

--- a/src/components/library/library-grid.tsx
+++ b/src/components/library/library-grid.tsx
@@ -20,6 +20,7 @@ import {
   IconMore,
   IconTrash,
   IconRefresh,
+  IconUpload,
   IconPencil,
   IconImage,
 } from '../../lib/icons';
@@ -283,7 +284,7 @@ function BookCard({
                 }}
                 className="w-full px-3 py-2.5 text-left text-sm font-medium text-ink hover:bg-ink/4 inline-flex items-center gap-2 border-b border-ink/5"
               >
-                <IconRefresh className="w-4 h-4" /> Replace manuscript…
+                <IconUpload className="w-4 h-4" /> Replace manuscript…
               </button>
               <button
                 onClick={() => {
@@ -471,7 +472,7 @@ function BookCard({
           open={confirmReplace}
           eyebrow="Replace"
           title={book.title}
-          icon={<IconRefresh className="w-4 h-4" />}
+          icon={<IconUpload className="w-4 h-4" />}
           body={
             <div className="space-y-2">
               <p>This replaces the manuscript file and re-detects chapters from the new file.</p>

--- a/src/components/library/library-table.tsx
+++ b/src/components/library/library-table.tsx
@@ -25,6 +25,7 @@ import {
   IconMore,
   IconPencil,
   IconRefresh,
+  IconUpload,
   IconStar,
   IconTrash,
 } from '../../lib/icons';
@@ -394,7 +395,7 @@ function BookRow({
                 }}
                 className="w-full px-3 py-2.5 text-left text-sm font-medium text-ink hover:bg-ink/4 inline-flex items-center gap-2 border-b border-ink/5"
               >
-                <IconRefresh className="w-4 h-4" /> Replace manuscript…
+                <IconUpload className="w-4 h-4" /> Replace manuscript…
               </button>
               <button
                 onClick={() => {
@@ -478,7 +479,7 @@ function BookRow({
             open={confirmReplace}
             eyebrow="Replace"
             title={book.title}
-            icon={<IconRefresh className="w-4 h-4" />}
+            icon={<IconUpload className="w-4 h-4" />}
             body={
               <div className="space-y-2">
                 <p>This replaces the manuscript file and re-detects chapters from the new file.</p>


### PR DESCRIPTION
## Summary
Two follow-up fixes.

**Analyzer id-drift duplicate** — the analyzer relabels a character's id between runs (it gave the dragon `coalfall` one run, `coalfall-dragon` the next). The id-keyed voice merge then missed and the dropped voiced row was re-added as a 0-line orphan = a visible duplicate. `mergeAnalysisResultWithExistingCast` now matches a voiced existing character whose id was dropped to a same-name fresh row, so its designed voice rides onto the freshly-detected row (keeping the more descriptive, library-unique id); ambiguous names fall back to id-only.

**Replace-manuscript icon** — gave `Replace manuscript...` the upload glyph (`IconUpload`) so it no longer shares `IconRefresh` with `Re-parse manuscript`.

## Test plan
- `merge-analysis-cast.test.ts`: id-drift carries the voice onto the same-name fresh row (no duplicate); ambiguous-name guard falls back to id-only.
- Library component tests + typecheck green; pre-push verify passed.