### PR TITLE
docs(docs): mention the bundled demo book in README + 1.7.0 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ or MP3.
   speaker tags are surfaced for a quick review pass. DRM-protected files are
   rejected up front. Re-uploading a book shows a sentence-level diff before
   anything changes.
+- **Try a sample** — a ready-made demo book (an original full-cast story) loads
+  in one click with its whole cast already designed, so you can generate and hear
+  a full performance before importing anything of your own.
 - **Analyzer choice** — run a fully local model via Ollama (no API key, nothing
   leaves your machine) or use the Gemini free tier. For long books, an optional
   two-model pipeline runs cast detection and sentence attribution in parallel to

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Castwright 1.7.0
 
+- **Try it in one click.** A ready-made sample — an original story performed by a full cast — loads with every voice already designed, so you can generate and hear what Castwright does before importing a thing of your own.
 - **It runs on a Mac now.** Apple Silicon is a first-class home for Castwright — it finds your Mac's graphics on its own, no setup and no drivers. (Intel Macs work too, just slower.)
 - **Your whole cast can act.** Design expressive, emotion-aware voices for every character in one pass — not just your leads — and each performance stays true from the first chapter to the last.
 - **Long books you can walk away from.** Big manuscripts ride out the rough patches on their own and keep going, so a full performance finishes while you're elsewhere.


### PR DESCRIPTION
Doc-only. Surfaces the fs-22 bundled demo book in the README feature list + 1.7.0 release notes. INSTALL.md + the release-zip manifest already cover it. Refs #475.