### PR TITLE
docs(docs): fs-21 first-run wizard spec + Wave 0 implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-06-12-fs21-wave0-readiness-spine.md
+++ b/docs/superpowers/plans/2026-06-12-fs21-wave0-readiness-spine.md
@@ -1,0 +1,926 @@
+# fs-21 Wave 0 — Readiness Spine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the foundational, independently-testable spine of the fs-21 first-run wizard: a derived `GET /api/setup/readiness` (a thin mapper over the existing `diagnostics.ts` aggregator), a new `{ kind: 'setup' }` gated stage at `#/setup`, a `setupCompletedAt` persisted flag, and a boot-time gate that redirects to `#/setup` when a hard-blocker fails.
+
+**Architecture:** The hard gate is *derived* — on boot, `Layout` fetches readiness; if any hard-blocker (sidecar+venv, ffmpeg, ≥1 TTS engine, analyzer) fails, the user is redirected to the setup stage. Readiness reuses the diagnostics probes (extracted into a reusable `buildDiagnostics()`), adding only the probes diagnostics lacks: venv-on-disk and per-engine TTS weights. The setup view itself is a stub here (Wave 2 fleshes the five-step UI); Wave 0 proves the gate + readiness contract end to end.
+
+**Tech Stack:** Express + TypeScript (server), Vitest (server + frontend unit), React 18 + Redux Toolkit + react-router v6 hash router (frontend), Playwright (e2e). Mocks behind `VITE_USE_MOCKS`.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-fs21-first-run-wizard-design.md` · **Issue:** #474 · **Branch:** `feat/fs21-wave0-readiness-spine` off `main`.
+
+> **Per the review-first convention, do NOT file the per-wave sub-issue until this plan is reviewed.** When approved: cut `feat/fs21-wave0-readiness-spine`, open it as a **draft** PR, run `npm run verify` locally to green, then `gh pr ready`.
+
+---
+
+## File Structure
+
+**Server (new):**
+- `server/src/diagnostics/venv.ts` — `sidecarVenvPresent()`: stats the sidecar venv python and reports presence. One responsibility: "is the Python env bootstrapped?"
+- `server/src/routes/setup-readiness.ts` — `GET /api/setup/readiness` route + `buildSetupReadiness()` + the `SetupReadiness` types. The thin mapper.
+- `server/src/routes/setup-readiness.test.ts` — route + mapper tests.
+- `server/src/diagnostics/venv.test.ts` — venv probe test.
+
+**Server (modify):**
+- `server/src/routes/diagnostics.ts` — extract the inline handler body into an exported `buildDiagnostics(): Promise<DiagnosticsResponse>` so both the diagnostics route AND readiness reuse it (no HTTP self-call).
+- `server/src/workspace/user-settings.ts` — add `setupCompletedAt?: string | null` to `UserSettings` + `getResolvedSetupCompletedAt()` + `writeSetupCompletedAt()`.
+- `server/src/index.ts` — register the new router.
+
+**Frontend (new):**
+- `src/views/setup.tsx` — `SetupView` STUB (Wave 2 replaces the body). Renders the readiness summary so the route is real and testable now.
+- `src/views/setup.test.tsx` — stub render test.
+
+**Frontend (modify):**
+- `src/lib/types.ts` — add `{ kind: 'setup' }` to the `Stage` union.
+- `src/lib/router.ts` — `stageToHash` case for `setup`.
+- `src/store/ui-slice.ts` — `openSetup` reducer.
+- `src/routes/index.tsx` — `SetupRoute` + route table entry.
+- `src/lib/api.ts` — `SetupReadiness` interface + `realGetSetupReadiness` / `mockGetSetupReadiness` (dual-state) + wire into the `api` object (both real + mock maps).
+- `src/components/layout.tsx` — boot-time readiness fetch + splash gate + redirect.
+- `src/store/ui-slice.test.ts` — `openSetup` test.
+- `src/lib/router.test.ts` — `stageToHash('setup')` test.
+
+**E2E (new):**
+- `e2e/setup-gate.spec.ts` — gate fires when readiness is not-ready (mock forced to not-ready), and does NOT fire when ready.
+
+---
+
+## Task 1: `setupCompletedAt` persisted flag (server)
+
+**Files:**
+- Modify: `server/src/workspace/user-settings.ts`
+- Test: `server/src/workspace/user-settings.test.ts` (add cases; create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/src/workspace/user-settings.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('setupCompletedAt', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'us-'));
+    process.env.USER_SETTINGS_PATH = join(dir, 'settings.json');
+  });
+
+  it('reads null when unset', async () => {
+    const { getResolvedSetupCompletedAt } = await import('./user-settings.js');
+    expect(getResolvedSetupCompletedAt()).toBeNull();
+  });
+
+  it('round-trips a stamped ISO string', async () => {
+    const { writeSetupCompletedAt, getResolvedSetupCompletedAt } = await import(
+      './user-settings.js'
+    );
+    await writeSetupCompletedAt('2026-06-12T00:00:00.000Z');
+    expect(getResolvedSetupCompletedAt()).toBe('2026-06-12T00:00:00.000Z');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/workspace/user-settings.test.ts -t setupCompletedAt`
+Expected: FAIL — `getResolvedSetupCompletedAt is not a function`.
+
+- [ ] **Step 3: Implement the field + getter + writer**
+
+In `server/src/workspace/user-settings.ts`, add `setupCompletedAt?: string | null;` to the `UserSettings` interface (near `lastSeenAppVersion`), then add (mirroring the existing `getResolvedGeminiApiKey` / `writeGeminiApiKey` read/write pattern in this file):
+
+```ts
+/** fs-21 — ISO timestamp stamped when the user finishes (or exits) the
+    guided first-run flow. Suppresses the guided re-intro; the hard gate
+    itself stays derived from live readiness, so this never grants access. */
+export function getResolvedSetupCompletedAt(): string | null {
+  return readUserSettings().setupCompletedAt ?? null;
+}
+
+export async function writeSetupCompletedAt(ts: string | null): Promise<UserSettings> {
+  const next = { ...readUserSettings(), setupCompletedAt: ts };
+  await writeUserSettings(next);
+  return next;
+}
+```
+
+> Use the same internal read/write helpers the neighbouring `writeGeminiApiKey` uses (`readUserSettings()` / `writeUserSettings()`). If their names differ in the file, match the local convention exactly.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/workspace/user-settings.test.ts -t setupCompletedAt`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/workspace/user-settings.ts server/src/workspace/user-settings.test.ts
+git commit -m "feat(server): add setupCompletedAt user-setting (fs-21 wave 0)"
+```
+
+---
+
+## Task 2: Extract `buildDiagnostics()` from the diagnostics route
+
+**Files:**
+- Modify: `server/src/routes/diagnostics.ts`
+- Test: `server/src/routes/diagnostics.test.ts` (existing — must stay green)
+
+- [ ] **Step 1: Run the existing diagnostics test to capture green baseline**
+
+Run: `cd server && npx vitest run src/routes/diagnostics.test.ts`
+Expected: PASS (baseline before refactor).
+
+- [ ] **Step 2: Extract the handler body into an exported function**
+
+In `server/src/routes/diagnostics.ts`, move the entire async body of `diagnosticsRouter.get('/', ...)` into a new exported function, and have the route delegate. The function returns the same `DiagnosticsResponse` already defined in the file:
+
+```ts
+export async function buildDiagnostics(): Promise<DiagnosticsResponse> {
+  // ↓ the exact body that was inside the route handler (sidecar probe,
+  //   the Promise.all([...]) of runCheck(...) calls, worst(), response).
+  const sidecar = await probeSidecarHealth().catch(
+    (e: Error) => ({ status: 'unreachable' as const, url: '', proxy: 'sidecar' as const, error: e.message }),
+  );
+  const engine = getResolvedAnalysisEngine();
+  const checks = await Promise.all([ /* …unchanged runCheck(...) calls… */ ]);
+  return { ts: new Date().toISOString(), overall: worst(checks), checks };
+}
+
+diagnosticsRouter.get('/', async (_req: Request, res: Response) => {
+  res.json(await buildDiagnostics());
+});
+```
+
+This is a pure move — no logic changes. The route now just JSON-returns `buildDiagnostics()`.
+
+- [ ] **Step 3: Run the existing diagnostics test to verify still green**
+
+Run: `cd server && npx vitest run src/routes/diagnostics.test.ts`
+Expected: PASS (refactor preserved behaviour).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/src/routes/diagnostics.ts
+git commit -m "refactor(server): extract buildDiagnostics() for reuse (fs-21 wave 0)"
+```
+
+---
+
+## Task 3: Sidecar venv presence probe (server)
+
+**Files:**
+- Create: `server/src/diagnostics/venv.ts`
+- Test: `server/src/diagnostics/venv.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { sidecarVenvPresent } from './venv.js';
+
+describe('sidecarVenvPresent', () => {
+  it('false when the venv python is absent', () => {
+    const root = mkdtempSync(join(tmpdir(), 'venv-'));
+    expect(sidecarVenvPresent(root)).toBe(false);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('true when a venv python exists under either layout', () => {
+    const root = mkdtempSync(join(tmpdir(), 'venv-'));
+    // POSIX layout: .venv/bin/python
+    mkdirSync(join(root, 'server', 'tts-sidecar', '.venv', 'bin'), { recursive: true });
+    writeFileSync(join(root, 'server', 'tts-sidecar', '.venv', 'bin', 'python'), '');
+    expect(sidecarVenvPresent(root)).toBe(true);
+    rmSync(root, { recursive: true, force: true });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/diagnostics/venv.test.ts`
+Expected: FAIL — cannot find module `./venv.js`.
+
+- [ ] **Step 3: Implement the probe**
+
+```ts
+/* fs-21 — is the TTS sidecar's Python venv bootstrapped? The venv is
+   upstream of every TTS engine (start.{sh,ps1} error out without it).
+   Checks both the Windows (Scripts\python.exe) and POSIX (bin/python)
+   layouts, honouring SIDECAR_VENV_DIR (versioned-install override). */
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export function sidecarVenvPresent(repoRoot: string): boolean {
+  const base =
+    process.env.SIDECAR_VENV_DIR ?? join(repoRoot, 'server', 'tts-sidecar', '.venv');
+  return (
+    existsSync(join(base, 'bin', 'python')) ||
+    existsSync(join(base, 'Scripts', 'python.exe'))
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/diagnostics/venv.test.ts`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/diagnostics/venv.ts server/src/diagnostics/venv.test.ts
+git commit -m "feat(server): sidecar venv presence probe (fs-21 wave 0)"
+```
+
+---
+
+## Task 4: `GET /api/setup/readiness` mapper + route (server)
+
+**Files:**
+- Create: `server/src/routes/setup-readiness.ts`
+- Test: `server/src/routes/setup-readiness.test.ts`
+
+The readiness shape maps the diagnostics checks (by `id`) plus the venv + TTS-weights probes into four hard-blockers. Mapping rules:
+- `sidecar` blocker = diagnostics `sidecar` check is `ok` **AND** `sidecarVenvPresent`.
+- `ffmpeg` blocker = diagnostics `ffmpeg` check is `ok`.
+- `analyzer` blocker = (engine `local`: diagnostics `analyzer` is `ok`) **OR** (engine `gemini`: diagnostics `gemini` is `ok`) — i.e. the in-use analyzer check is `ok`.
+- `tts` blocker = `ttsEnginePresentFn()` (≥1 engine weights on disk) — injected so the test can drive it without real weight dirs.
+- `info.gpu` = the diagnostics `gpu` check `detail` (never blocks).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { buildSetupReadiness } from './setup-readiness.js';
+import type { DiagnosticsResponse } from './diagnostics.js';
+
+function diag(over: Partial<Record<string, 'ok' | 'warn' | 'fail'>>): DiagnosticsResponse {
+  const def: Record<string, 'ok' | 'warn' | 'fail'> = {
+    gpu: 'ok', sidecar: 'ok', asr: 'ok', analyzer: 'ok', gemini: 'ok', ffmpeg: 'ok', disk: 'ok',
+  };
+  const merged = { ...def, ...over };
+  return {
+    ts: 'T',
+    overall: 'ok',
+    checks: Object.entries(merged).map(([id, status]) => ({
+      id: id as never, label: id, status, detail: `${id}:${status}`,
+    })),
+  };
+}
+
+describe('buildSetupReadiness', () => {
+  it('is ready when all hard-blockers pass', () => {
+    const r = buildSetupReadiness({
+      diagnostics: diag({}), engine: 'local', venvPresent: true, ttsEnginePresent: true,
+    });
+    expect(r.ready).toBe(true);
+    expect(r.blockers).toEqual({ sidecar: 'pass', ffmpeg: 'pass', tts: 'pass', analyzer: 'pass' });
+  });
+
+  it('fails sidecar when venv is missing even if the sidecar pings', () => {
+    const r = buildSetupReadiness({
+      diagnostics: diag({}), engine: 'local', venvPresent: false, ttsEnginePresent: true,
+    });
+    expect(r.blockers.sidecar).toBe('fail');
+    expect(r.ready).toBe(false);
+  });
+
+  it('fails tts when no engine weights are present', () => {
+    const r = buildSetupReadiness({
+      diagnostics: diag({}), engine: 'local', venvPresent: true, ttsEnginePresent: false,
+    });
+    expect(r.blockers.tts).toBe('fail');
+    expect(r.ready).toBe(false);
+  });
+
+  it('uses the gemini check when engine is gemini', () => {
+    const r = buildSetupReadiness({
+      diagnostics: diag({ analyzer: 'fail', gemini: 'ok' }),
+      engine: 'gemini', venvPresent: true, ttsEnginePresent: true,
+    });
+    expect(r.blockers.analyzer).toBe('pass');
+  });
+
+  it('surfaces gpu detail as info, never a blocker', () => {
+    const r = buildSetupReadiness({
+      diagnostics: diag({ gpu: 'fail' }), engine: 'local', venvPresent: true, ttsEnginePresent: true,
+    });
+    expect(r.ready).toBe(true);
+    expect(r.info.gpu).toBe('gpu:fail');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/routes/setup-readiness.test.ts`
+Expected: FAIL — cannot find module `./setup-readiness.js`.
+
+- [ ] **Step 3: Implement the mapper + route**
+
+```ts
+/* fs-21 — GET /api/setup/readiness. A THIN MAPPER over diagnostics.ts (it
+   must not re-implement the aggregator), adding the two probes diagnostics
+   lacks: venv-on-disk and per-engine TTS weights. Drives the adaptive gate. */
+import { Router } from 'express';
+import type { Request, Response } from '../http.js';
+import { buildDiagnostics, type DiagnosticsResponse } from './diagnostics.js';
+import { getResolvedAnalysisEngine, getResolvedSetupCompletedAt } from '../workspace/user-settings.js';
+import { sidecarVenvPresent } from '../diagnostics/venv.js';
+import { anyTtsEnginePresent } from '../tts/engine-presence.js';
+import { REPO_ROOT } from '../workspace/paths.js';
+
+export type BlockerStatus = 'pass' | 'fail';
+
+export interface SetupReadiness {
+  ready: boolean;
+  completedAt: string | null;
+  blockers: { sidecar: BlockerStatus; ffmpeg: BlockerStatus; tts: BlockerStatus; analyzer: BlockerStatus };
+  info: { gpu: string };
+}
+
+function checkOk(d: DiagnosticsResponse, id: string): boolean {
+  return d.checks.find((c) => c.id === id)?.status === 'ok';
+}
+function detail(d: DiagnosticsResponse, id: string): string {
+  return d.checks.find((c) => c.id === id)?.detail ?? '';
+}
+
+export function buildSetupReadiness(input: {
+  diagnostics: DiagnosticsResponse;
+  engine: 'local' | 'gemini';
+  venvPresent: boolean;
+  ttsEnginePresent: boolean;
+  completedAt?: string | null;
+}): SetupReadiness {
+  const { diagnostics: d, engine, venvPresent, ttsEnginePresent } = input;
+  const blockers = {
+    sidecar: (checkOk(d, 'sidecar') && venvPresent ? 'pass' : 'fail') as BlockerStatus,
+    ffmpeg: (checkOk(d, 'ffmpeg') ? 'pass' : 'fail') as BlockerStatus,
+    tts: (ttsEnginePresent ? 'pass' : 'fail') as BlockerStatus,
+    analyzer: (checkOk(d, engine === 'gemini' ? 'gemini' : 'analyzer') ? 'pass' : 'fail') as BlockerStatus,
+  };
+  return {
+    ready: Object.values(blockers).every((b) => b === 'pass'),
+    completedAt: input.completedAt ?? null,
+    blockers,
+    info: { gpu: detail(d, 'gpu') },
+  };
+}
+
+export const setupReadinessRouter = Router();
+
+setupReadinessRouter.get('/readiness', async (_req: Request, res: Response) => {
+  const diagnostics = await buildDiagnostics();
+  res.json(
+    buildSetupReadiness({
+      diagnostics,
+      engine: getResolvedAnalysisEngine(),
+      venvPresent: sidecarVenvPresent(REPO_ROOT),
+      ttsEnginePresent: anyTtsEnginePresent(REPO_ROOT),
+      completedAt: getResolvedSetupCompletedAt(),
+    }),
+  );
+});
+```
+
+> `REPO_ROOT` import: if `server/src/workspace/paths.js` exports the repo root under a different name (e.g. `WORKSPACE_ROOT` is the workspace, not the repo), use the existing constant that `models-inventory.ts` passes to `kokoroWeightPaths(repoRoot)` — match that exact import so paths resolve identically to the inventory route.
+
+- [ ] **Step 4: Create the `anyTtsEnginePresent` helper it depends on**
+
+Create `server/src/tts/engine-presence.ts`, reusing the **same** detectors `models-inventory.ts` already imports (do not write new disk logic):
+
+```ts
+/* fs-21 — is at least one TTS engine's weights present on disk? Reuses the
+   exact detectors the Model Manager inventory uses, so "present" means the
+   same thing in both places. */
+import { kokoroWeightPaths, totalSizeBytes } from './model-paths.js';
+import { coquiWeightsPresent } from './coqui-install-detect.js';
+import { detectQwenInstallStateOnDisk } from './qwen-install-detect.js';
+
+export function anyTtsEnginePresent(repoRoot: string): boolean {
+  const kokoro = totalSizeBytes(kokoroWeightPaths(repoRoot)).fileCount > 0;
+  const coqui = coquiWeightsPresent();
+  const qwen = detectQwenInstallStateOnDisk().basePresent;
+  return kokoro || coqui || qwen;
+}
+```
+
+> Verify the imported symbol names against `server/src/routes/models-inventory.ts` (it imports `kokoroWeightPaths`, `coquiWeightsPresent`, `detectQwenInstallStateOnDisk`). If the Qwen detector's "base present" property is named differently than `basePresent`, match the field models-inventory reads for the `qwen-base` row.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/routes/setup-readiness.test.ts`
+Expected: PASS (all five cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/routes/setup-readiness.ts server/src/routes/setup-readiness.test.ts server/src/tts/engine-presence.ts
+git commit -m "feat(server): GET /api/setup/readiness mapper over diagnostics (fs-21 wave 0)"
+```
+
+---
+
+## Task 5: Register the readiness router
+
+**Files:**
+- Modify: `server/src/index.ts`
+- Test: `server/src/routes/setup-readiness.test.ts` (add a supertest route case)
+
+- [ ] **Step 1: Write the failing route test**
+
+Append to `server/src/routes/setup-readiness.test.ts`:
+
+```ts
+import request from 'supertest';
+import express from 'express';
+import { setupReadinessRouter } from './setup-readiness.js';
+
+describe('GET /api/setup/readiness route', () => {
+  it('returns 200 with the readiness shape', async () => {
+    const app = express();
+    app.use('/api/setup', setupReadinessRouter);
+    const res = await request(app).get('/api/setup/readiness');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('ready');
+    expect(res.body).toHaveProperty('blockers.sidecar');
+    expect(res.body).toHaveProperty('info.gpu');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails or errors**
+
+Run: `cd server && npx vitest run src/routes/setup-readiness.test.ts -t "route"`
+Expected: FAIL or error (route may throw if probes need wiring — that's fine; we assert 200 after registration is sound). If it already passes because the router is self-contained, proceed — the registration step below is still required for the live app.
+
+- [ ] **Step 3: Register the router in `server/src/index.ts`**
+
+Mirror the diagnostics registration (`import { diagnosticsRouter } from './routes/diagnostics.js';` + `app.use('/api/diagnostics', diagnosticsRouter);`). Add:
+
+```ts
+import { setupReadinessRouter } from './routes/setup-readiness.js';
+```
+
+and alongside the other `app.use('/api/...')` lines:
+
+```ts
+app.use('/api/setup', setupReadinessRouter); // fs-21 — first-run readiness probe
+```
+
+- [ ] **Step 4: Run the server test + typecheck**
+
+Run: `cd server && npx vitest run src/routes/setup-readiness.test.ts && npm run typecheck`
+Expected: PASS + clean typecheck.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/index.ts server/src/routes/setup-readiness.test.ts
+git commit -m "feat(server): register /api/setup readiness router (fs-21 wave 0)"
+```
+
+---
+
+## Task 6: `setup` stage variant + router + reducer (frontend)
+
+**Files:**
+- Modify: `src/lib/types.ts`, `src/lib/router.ts`, `src/store/ui-slice.ts`
+- Test: `src/lib/router.test.ts`, `src/store/ui-slice.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/lib/router.test.ts`:
+
+```ts
+it('maps the setup stage to #/setup', () => {
+  expect(stageToHash({ kind: 'setup' })).toBe('#/setup');
+});
+```
+
+In `src/store/ui-slice.test.ts`:
+
+```ts
+it('openSetup sets the setup stage', () => {
+  const s = uiSlice.reducer(undefined, uiActions.openSetup());
+  expect(s.stage).toEqual({ kind: 'setup' });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/lib/router.test.ts src/store/ui-slice.test.ts -t setup`
+Expected: FAIL — `'setup'` not assignable to `Stage`; `openSetup` undefined.
+
+- [ ] **Step 3: Add the variant, hash case, and reducer**
+
+In `src/lib/types.ts`, add to the `Stage` union (next to `model-manager`):
+
+```ts
+  | { kind: 'setup' }
+```
+
+In `src/lib/router.ts` `stageToHash`, add before `analysing`:
+
+```ts
+    case 'setup':
+      return '#/setup';
+```
+
+In `src/store/ui-slice.ts`, add a reducer next to `openModelManager`:
+
+```ts
+    /* fs-21 — first-run setup wizard, reached on the boot gate or from Account. */
+    openSetup: (s) => {
+      s.stage = { kind: 'setup' };
+    },
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/lib/router.test.ts src/store/ui-slice.test.ts -t setup`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/types.ts src/lib/router.ts src/store/ui-slice.ts src/lib/router.test.ts src/store/ui-slice.test.ts
+git commit -m "feat(frontend): add setup stage variant + #/setup + openSetup (fs-21 wave 0)"
+```
+
+---
+
+## Task 7: API client — `getSetupReadiness` with dual-state mock
+
+**Files:**
+- Modify: `src/lib/api.ts`
+- Test: `src/lib/api.test.ts` (add cases; create if absent)
+
+The mock must drive BOTH ready and not-ready so dev + e2e can exercise the gate. Drive it off a URL query param so e2e can force a state: `?setup=notready` → not-ready, anything else → ready.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+describe('mockGetSetupReadiness', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    // @ts-expect-error test shim
+    import.meta.env.VITE_USE_MOCKS = 'true';
+  });
+
+  it('returns ready by default', async () => {
+    window.location.hash = '#/';
+    const { api } = await import('./api.js');
+    const r = await api.getSetupReadiness();
+    expect(r.ready).toBe(true);
+  });
+
+  it('returns not-ready when the setup=notready param is present', async () => {
+    window.location.hash = '#/?setup=notready';
+    const { api } = await import('./api.js');
+    const r = await api.getSetupReadiness();
+    expect(r.ready).toBe(false);
+    expect(r.blockers.tts).toBe('fail');
+  });
+});
+```
+
+> If `src/lib/api.test.ts` does not exist or `import.meta.env` can't be mutated in this project's jsdom setup, instead export `mockGetSetupReadiness` and test it directly with a stubbed `window.location.hash`. Match whatever pattern an existing `*mock*` test in the repo uses.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/api.test.ts -t SetupReadiness`
+Expected: FAIL — `api.getSetupReadiness is not a function`.
+
+- [ ] **Step 3: Implement the interface + real + mock + wire-up**
+
+In `src/lib/api.ts`, near the `DiagnosticsResponse` block (~line 5127), add:
+
+```ts
+/* fs-21 — first-run readiness. Mirrors SetupReadiness in
+   server/src/routes/setup-readiness.ts. */
+export type BlockerStatus = 'pass' | 'fail';
+export interface SetupReadiness {
+  ready: boolean;
+  completedAt: string | null;
+  blockers: { sidecar: BlockerStatus; ffmpeg: BlockerStatus; tts: BlockerStatus; analyzer: BlockerStatus };
+  info: { gpu: string };
+}
+
+async function realGetSetupReadiness(): Promise<SetupReadiness> {
+  const res = await fetch('/api/setup/readiness');
+  if (!res.ok) throw new Error(`readiness ${res.status}`);
+  return (await res.json()) as SetupReadiness;
+}
+
+async function mockGetSetupReadiness(): Promise<SetupReadiness> {
+  const notReady = window.location.hash.includes('setup=notready');
+  return notReady
+    ? {
+        ready: false,
+        completedAt: null,
+        blockers: { sidecar: 'pass', ffmpeg: 'pass', tts: 'fail', analyzer: 'fail' },
+        info: { gpu: 'CPU — no GPU detected' },
+      }
+    : {
+        ready: true,
+        completedAt: '2026-06-12T00:00:00.000Z',
+        blockers: { sidecar: 'pass', ffmpeg: 'pass', tts: 'pass', analyzer: 'pass' },
+        info: { gpu: 'cuda · 1.2 / 8.0 GB reserved' },
+      };
+}
+```
+
+Then wire into BOTH maps in the `api` object — next to `getDiagnostics: realGetDiagnostics,` (~line 5874) add `getSetupReadiness: realGetSetupReadiness,`; next to `getDiagnostics: mockGetDiagnostics,` (~line 6121) add `getSetupReadiness: mockGetSetupReadiness,`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/api.test.ts -t SetupReadiness`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/api.ts src/lib/api.test.ts
+git commit -m "feat(frontend): api.getSetupReadiness with dual-state mock (fs-21 wave 0)"
+```
+
+---
+
+## Task 8: `SetupView` stub + `SetupRoute` (frontend)
+
+**Files:**
+- Create: `src/views/setup.tsx`, `src/views/setup.test.tsx`
+- Modify: `src/routes/index.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+`src/views/setup.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SetupView } from './setup';
+
+describe('SetupView (wave 0 stub)', () => {
+  it('renders the setup heading and the blocker rows from props', () => {
+    render(
+      <SetupView
+        readiness={{
+          ready: false,
+          completedAt: null,
+          blockers: { sidecar: 'pass', ffmpeg: 'pass', tts: 'fail', analyzer: 'fail' },
+          info: { gpu: 'CPU — no GPU detected' },
+        }}
+      />,
+    );
+    expect(screen.getByRole('heading', { name: /set up castwright/i })).toBeInTheDocument();
+    expect(screen.getByText(/tts/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/views/setup.test.tsx`
+Expected: FAIL — cannot find module `./setup`.
+
+- [ ] **Step 3: Implement the stub view**
+
+```tsx
+/* fs-21 Wave 0 — SetupView STUB. Renders the readiness summary so the gated
+   #/setup route is real and testable. Wave 2 replaces this body with the
+   five-step guided/checklist wizard; the props contract (readiness) stays. */
+import type { SetupReadiness } from '../lib/api';
+
+export function SetupView({ readiness }: { readiness: SetupReadiness | null }) {
+  return (
+    <main className="mx-auto max-w-2xl p-6">
+      <h1 className="text-2xl font-semibold text-ink">Set up Castwright</h1>
+      <p className="mt-2 text-ink/60 text-sm">
+        We’re checking that everything needed to produce an audiobook is in place.
+      </p>
+      <ul className="mt-6 space-y-2">
+        {readiness &&
+          Object.entries(readiness.blockers).map(([id, status]) => (
+            <li
+              key={id}
+              className="flex items-center justify-between rounded-2xl border border-ink/10 bg-canvas px-4 py-3"
+            >
+              <span className="text-sm font-medium text-ink uppercase">{id}</span>
+              <span className={status === 'pass' ? 'text-emerald-600' : 'text-amber-600'}>
+                {status === 'pass' ? 'Ready' : 'Needs attention'}
+              </span>
+            </li>
+          ))}
+      </ul>
+    </main>
+  );
+}
+```
+
+> No design-token hex literals: `text-ink`, `bg-canvas` are existing tokens. `emerald/amber` are placeholder status colours for the stub — Wave 2 swaps them for the brand status tokens.
+
+- [ ] **Step 4: Add `SetupRoute` + route entry in `src/routes/index.tsx`**
+
+Add a lazy import next to `ModelManagerView`:
+
+```tsx
+const SetupView = lazy(() => import('../views/setup').then((m) => ({ default: m.SetupView })));
+```
+
+Add the route component next to `ModelManagerRoute`:
+
+```tsx
+/* fs-21 — first-run setup wizard. Fetches readiness on mount; Wave 2 fleshes
+   the steps. */
+function SetupRoute() {
+  useHydrateStage({ kind: 'setup' }, []);
+  const [readiness, setReadiness] = useState<Awaited<ReturnType<typeof api.getSetupReadiness>> | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    api.getSetupReadiness().then((r) => { if (!cancelled) setReadiness(r); }).catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+  return <SetupView readiness={readiness} />;
+}
+```
+
+Add to the `children` array (next to the `models` entry):
+
+```tsx
+      { path: 'setup', element: <SetupRoute /> },
+```
+
+- [ ] **Step 5: Run the view test to verify it passes**
+
+Run: `npx vitest run src/views/setup.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/views/setup.tsx src/views/setup.test.tsx src/routes/index.tsx
+git commit -m "feat(frontend): setup stub view + #/setup route (fs-21 wave 0)"
+```
+
+---
+
+## Task 9: Boot-splash gate in Layout
+
+**Files:**
+- Modify: `src/components/layout.tsx`
+- Test: `e2e/setup-gate.spec.ts` (Task 10 covers the e2e; this task's verification is the typecheck + a manual mock check)
+
+The gate: on mount, fetch readiness once. While the fetch is pending show a splash (block content). When it resolves, if `!ready` AND the current stage isn't already `setup`, navigate to `#/setup`. If `ready`, render normally. Never re-fetch on every navigation — one boot check (plus Wave 2's focus re-check, out of scope here).
+
+- [ ] **Step 1: Add the gate state + effect**
+
+In `src/components/layout.tsx`, near the existing boot effects (the `fetchAccountSettings` effect ~line 453), add:
+
+```tsx
+const [setupReady, setSetupReady] = useState<boolean | null>(null); // null = checking
+useEffect(() => {
+  let cancelled = false;
+  api
+    .getSetupReadiness()
+    .then((r) => {
+      if (cancelled) return;
+      setSetupReady(r.ready);
+      if (!r.ready && store.getState().ui.stage.kind !== 'setup') {
+        navigate('/setup');
+      }
+    })
+    .catch(() => { if (!cancelled) setSetupReady(true); }); // probe failure must not lock the app out
+  return () => { cancelled = true; };
+}, []); // eslint-disable-line react-hooks/exhaustive-deps
+```
+
+> Use the `navigate` from `useNavigate()` and the imported `store` + `api` already available in this module (Layout already imports `store` and dispatches; add `useNavigate`/`api` imports if not present, matching `src/routes/index.tsx`). On probe failure we fail OPEN (`setSetupReady(true)`) so a transient readiness error never bricks the app.
+
+- [ ] **Step 2: Render the splash while checking**
+
+Where Layout returns its tree, gate the first paint:
+
+```tsx
+if (setupReady === null) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-canvas">
+      <p className="text-ink/60 text-sm">Checking your setup…</p>
+    </div>
+  );
+}
+```
+
+> Place this BEFORE the main `return (<Outlet … />)`. It only blocks the very first paint until the one-shot readiness fetch resolves; subsequent navigations don't re-trigger it (the effect has `[]` deps).
+
+- [ ] **Step 3: Typecheck + frontend unit suite**
+
+Run: `npm run typecheck && npm run test`
+Expected: PASS (no type errors; existing Layout tests still green — if a Layout test now needs the readiness mock, add `getSetupReadiness` to that test's api stub returning `{ ready: true, … }`).
+
+- [ ] **Step 4: Manual mock check**
+
+Run: `npm run dev`, open `http://localhost:5173/#/?setup=notready` → expect redirect to `#/setup` showing the stub with TTS/analyzer "Needs attention". Open `http://localhost:5173/#/` → expect the normal library (gate open).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/layout.tsx
+git commit -m "feat(frontend): boot-splash readiness gate -> #/setup (fs-21 wave 0)"
+```
+
+---
+
+## Task 10: E2E — the gate fires when not-ready
+
+**Files:**
+- Create: `e2e/setup-gate.spec.ts`
+
+- [ ] **Step 1: Write the spec**
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test('boot gate redirects to #/setup when not ready', async ({ page }) => {
+  await page.goto('/#/?setup=notready');
+  await expect(page).toHaveURL(/#\/setup/);
+  await expect(page.getByRole('heading', { name: /set up castwright/i })).toBeVisible();
+});
+
+test('boot gate stays out of the way when ready', async ({ page }) => {
+  await page.goto('/#/');
+  await expect(page).not.toHaveURL(/#\/setup/);
+});
+```
+
+> Mock mode is the e2e default (port 5174). `?setup=notready` drives `mockGetSetupReadiness` to the not-ready branch (Task 7). No server needed.
+
+- [ ] **Step 2: Run the spec to verify it passes**
+
+Run: `npm run test:e2e -- setup-gate`
+Expected: PASS (both tests). If chromium isn't installed: `npx playwright install chromium` first.
+
+- [ ] **Step 3: Add the view to responsive coverage**
+
+Append a case for the `setup` stage to `e2e/responsive/coverage.spec.ts` following the existing per-view pattern in that file (navigate to `/#/?setup=notready`, assert the heading is visible at each project viewport).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/setup-gate.spec.ts e2e/responsive/coverage.spec.ts
+git commit -m "test(e2e): setup boot-gate happy + not-ready paths (fs-21 wave 0)"
+```
+
+---
+
+## Task 11: Full verify + draft PR
+
+- [ ] **Step 1: Run the full pre-push battery**
+
+Run: `npm run verify`
+Expected: typecheck + all unit + e2e + build all green. Fix any red before proceeding (triage related-vs-pre-existing per CONTRIBUTING).
+
+- [ ] **Step 2: Open as a draft PR**
+
+```bash
+git push -u origin feat/fs21-wave0-readiness-spine
+gh pr create --draft --title "feat(server,frontend): fs-21 wave 0 — readiness spine + setup gate" --body "Wave 0 of fs-21 (first-run wizard). Derived adaptive gate: GET /api/setup/readiness (thin mapper over diagnostics.ts) + { kind: 'setup' } stage at #/setup + boot splash redirect + setupCompletedAt. SetupView is a stub (Wave 2 fleshes the 5-step UI). Refs #474. Plan: docs/superpowers/plans/2026-06-12-fs21-wave0-readiness-spine.md"
+```
+
+- [ ] **Step 3: Promote to ready once green (bills exactly one CI run)**
+
+```bash
+gh pr ready
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage (Wave 0 scope only):**
+- `{ kind: 'setup' }` stage + `#/setup` route → Task 6, 8 ✓
+- Derived gate / boot splash / redirect on not-ready → Task 9 ✓
+- `GET /api/setup/readiness` as a thin mapper over `diagnostics.ts` (not a re-impl) → Task 2 (extract) + Task 4 (map) ✓
+- Hard-blocker definitions (sidecar+venv, ffmpeg, ≥1 TTS engine, analyzer-per-engine; GPU info-only) → Task 4 mapping + tests ✓
+- `setupCompletedAt` persisted, hard gate stays derived → Task 1 + Task 4 (completedAt is surfaced, NOT used to open the gate) ✓
+- Mockable to BOTH ready and not-ready for dev + e2e → Task 7 (`?setup=notready`) ✓
+- Headless/Docker "works for free" → same derived gate fires on first UI open; no Wave-0-specific code needed (covered by Task 9's boot fetch) ✓
+- **Deferred to later waves (correctly out of Wave 0):** the 5-step UI bodies + install rows (Wave 2), Kokoro install route + venv bootstrap + parity audit (Wave 1), two-tier smoke test (Wave 3), Account "Re-run setup" entry (Wave 2), docs/closure (Wave 4).
+
+**Placeholder scan:** No TBD/TODO; every code step shows the code; every run step shows the command + expected result. The two `>` notes that say "verify symbol name against file X" are explicit guards against type-drift, not missing content — the canonical code is present and the guard names the exact reference file.
+
+**Type consistency:** `SetupReadiness` / `BlockerStatus` are defined identically server-side (Task 4) and client-side (Task 7). `buildSetupReadiness` input keys (`diagnostics`, `engine`, `venvPresent`, `ttsEnginePresent`, `completedAt`) match between its definition (Task 4 Step 3) and its callers (Task 4 route + Task 4 tests). `getSetupReadiness` is the api method name in Tasks 7, 8, 9. `openSetup` / `{ kind: 'setup' }` consistent across Tasks 6, 8, 9.

--- a/docs/superpowers/plans/2026-06-12-fs21-wave0-readiness-spine.md
+++ b/docs/superpowers/plans/2026-06-12-fs21-wave0-readiness-spine.md
@@ -11,6 +11,8 @@
 **Spec:** `docs/superpowers/specs/2026-06-12-fs21-first-run-wizard-design.md` · **Issue:** #474 · **Branch:** `feat/fs21-wave0-readiness-spine` off `main`.
 
 > **Per the review-first convention, do NOT file the per-wave sub-issue until this plan is reviewed.** When approved: cut `feat/fs21-wave0-readiness-spine`, open it as a **draft** PR, run `npm run verify` locally to green, then `gh pr ready`.
+>
+> **Prerequisite:** the spec + this plan currently live on `docs/docs-fs21-wizard-spec`, not `main`. **Merge that docs branch first** (or have the executor read the plan from it) so the code branch — cut off `main` — has the plan available during execution.
 
 ---
 
@@ -91,24 +93,36 @@ Expected: FAIL — `getResolvedSetupCompletedAt is not a function`.
 
 - [ ] **Step 3: Implement the field + getter + writer**
 
-In `server/src/workspace/user-settings.ts`, add `setupCompletedAt?: string | null;` to the `UserSettings` interface (near `lastSeenAppVersion`), then add (mirroring the existing `getResolvedGeminiApiKey` / `writeGeminiApiKey` read/write pattern in this file):
+In `server/src/workspace/user-settings.ts`, add `setupCompletedAt?: string | null;` to the `UserSettings` interface (near `lastSeenAppVersion`), then add the getter + writer.
+
+**Important:** the getter must read the module-level sync `cached` (NOT the async `readUserSettings()` — that returns a `Promise`), exactly like `getResolvedGeminiApiKey` does. And the writer must mirror `writeUpgradeMeta` (a *dedicated* writer that goes straight through `writeChain` + `writeJsonAtomic` + sets `cached`) — NOT `writeUserSettings()`, because that path runs `patchSchema.parse()` + `stripForbiddenKeys()` and would drop a brand-new field.
 
 ```ts
 /** fs-21 — ISO timestamp stamped when the user finishes (or exits) the
     guided first-run flow. Suppresses the guided re-intro; the hard gate
-    itself stays derived from live readiness, so this never grants access. */
+    itself stays derived from live readiness, so this never grants access.
+    Sync read off the in-process cache, like getResolvedGeminiApiKey. */
 export function getResolvedSetupCompletedAt(): string | null {
-  return readUserSettings().setupCompletedAt ?? null;
+  return cached?.setupCompletedAt ?? null;
 }
 
+/** Dedicated writer (mirrors writeUpgradeMeta): bypasses the general
+    writeUserSettings schema/strip path so the new field persists, and
+    refreshes the sync `cached` the getter reads. */
 export async function writeSetupCompletedAt(ts: string | null): Promise<UserSettings> {
-  const next = { ...readUserSettings(), setupCompletedAt: ts };
-  await writeUserSettings(next);
+  const next = writeChain.then(async () => {
+    const current = await readUserSettings();
+    const merged: UserSettings = { ...current, setupCompletedAt: ts };
+    await writeJsonAtomic(USER_SETTINGS_PATH, merged);
+    cached = merged;
+    return merged;
+  });
+  writeChain = next.catch(() => undefined);
   return next;
 }
 ```
 
-> Use the same internal read/write helpers the neighbouring `writeGeminiApiKey` uses (`readUserSettings()` / `writeUserSettings()`). If their names differ in the file, match the local convention exactly.
+> `cached`, `writeChain`, `readUserSettings`, `writeJsonAtomic`, and `USER_SETTINGS_PATH` are all module-private symbols already declared in this file (see `writeUpgradeMeta` at ~line 605). This code lives in the same module, so it reads/writes them directly.
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -338,7 +352,13 @@ import { buildDiagnostics, type DiagnosticsResponse } from './diagnostics.js';
 import { getResolvedAnalysisEngine, getResolvedSetupCompletedAt } from '../workspace/user-settings.js';
 import { sidecarVenvPresent } from '../diagnostics/venv.js';
 import { anyTtsEnginePresent } from '../tts/engine-presence.js';
-import { REPO_ROOT } from '../workspace/paths.js';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+/* Repo root computed locally, exactly as models-inventory.ts does (this file
+   is also under server/src/routes/, so '..','..','..' lands on the repo root).
+   workspace/paths.ts exports WORKSPACE_ROOT, NOT a repo root — don't import. */
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 
 export type BlockerStatus = 'pass' | 'fail';
 
@@ -394,11 +414,9 @@ setupReadinessRouter.get('/readiness', async (_req: Request, res: Response) => {
 });
 ```
 
-> `REPO_ROOT` import: if `server/src/workspace/paths.js` exports the repo root under a different name (e.g. `WORKSPACE_ROOT` is the workspace, not the repo), use the existing constant that `models-inventory.ts` passes to `kokoroWeightPaths(repoRoot)` — match that exact import so paths resolve identically to the inventory route.
-
 - [ ] **Step 4: Create the `anyTtsEnginePresent` helper it depends on**
 
-Create `server/src/tts/engine-presence.ts`, reusing the **same** detectors `models-inventory.ts` already imports (do not write new disk logic):
+Create `server/src/tts/engine-presence.ts`, reusing the **same** detectors `models-inventory.ts` imports (do not write new disk logic). Note the exact signatures (verified): `coquiWeightsPresent()` takes no args; `detectQwenInstallStateOnDisk(repoRoot)` **requires `repoRoot`** and returns a **string union** `'not-installed' | 'weights-missing' | 'ready'` (so compare `=== 'ready'`, there is no `.basePresent`); `totalSizeBytes(paths)` returns a `DirSize` with `.fileCount`.
 
 ```ts
 /* fs-21 — is at least one TTS engine's weights present on disk? Reuses the
@@ -411,12 +429,10 @@ import { detectQwenInstallStateOnDisk } from './qwen-install-detect.js';
 export function anyTtsEnginePresent(repoRoot: string): boolean {
   const kokoro = totalSizeBytes(kokoroWeightPaths(repoRoot)).fileCount > 0;
   const coqui = coquiWeightsPresent();
-  const qwen = detectQwenInstallStateOnDisk().basePresent;
+  const qwen = detectQwenInstallStateOnDisk(repoRoot) === 'ready';
   return kokoro || coqui || qwen;
 }
 ```
-
-> Verify the imported symbol names against `server/src/routes/models-inventory.ts` (it imports `kokoroWeightPaths`, `coquiWeightsPresent`, `detectQwenInstallStateOnDisk`). If the Qwen detector's "base present" property is named differently than `basePresent`, match the field models-inventory reads for the `qwen-base` row.
 
 - [ ] **Step 5: Run test to verify it passes**
 
@@ -432,23 +448,26 @@ git commit -m "feat(server): GET /api/setup/readiness mapper over diagnostics (f
 
 ---
 
-## Task 5: Register the readiness router
+## Task 5: Register the readiness router (+ integration route test in the slow pool)
 
 **Files:**
-- Modify: `server/src/index.ts`
-- Test: `server/src/routes/setup-readiness.test.ts` (add a supertest route case)
+- Modify: `server/src/index.ts`, `server/vitest.config.slow.ts`
+- Create: `server/src/routes/setup-readiness.route.test.ts` (integration, slow pool)
 
-- [ ] **Step 1: Write the failing route test**
+- [ ] **Step 1: Write the failing route test in its OWN file (it triggers a live sidecar probe)**
 
-Append to `server/src/routes/setup-readiness.test.ts`:
+The route handler calls `buildDiagnostics()`, which runs `probeSidecarHealth()` — a real network probe with a timeout. That makes this an integration test that can be slow/flaky in the parallel fast pool, so it lives in a **separate file routed to `test:server-slow`** (the same treatment the analyzer/diagnostics route tests get). The pure mapper logic is already covered by `setup-readiness.test.ts` (Task 4) in the fast pool.
+
+Create `server/src/routes/setup-readiness.route.test.ts`:
 
 ```ts
+import { describe, it, expect } from 'vitest';
 import request from 'supertest';
 import express from 'express';
 import { setupReadinessRouter } from './setup-readiness.js';
 
-describe('GET /api/setup/readiness route', () => {
-  it('returns 200 with the readiness shape', async () => {
+describe('GET /api/setup/readiness route (integration — live probe)', () => {
+  it('returns 200 with the readiness shape even when the sidecar is down', async () => {
     const app = express();
     app.use('/api/setup', setupReadinessRouter);
     const res = await request(app).get('/api/setup/readiness');
@@ -460,12 +479,16 @@ describe('GET /api/setup/readiness route', () => {
 });
 ```
 
-- [ ] **Step 2: Run test to verify it fails or errors**
+- [ ] **Step 2: Pin the new file to the slow pool**
 
-Run: `cd server && npx vitest run src/routes/setup-readiness.test.ts -t "route"`
-Expected: FAIL or error (route may throw if probes need wiring — that's fine; we assert 200 after registration is sound). If it already passes because the router is self-contained, proceed — the registration step below is still required for the live app.
+In `server/vitest.config.slow.ts`, add `'src/routes/setup-readiness.route.test.ts'` to the `include` list (the same array that already pins the analyzer/gemini + routes tests). Confirm the fast `server/vitest.config.ts` **excludes** it (the slow files are excluded from the fast run via the existing exclude/route mechanism — match how `diagnostics`-class tests are kept out of the fast pool).
 
-- [ ] **Step 3: Register the router in `server/src/index.ts`**
+- [ ] **Step 3: Run the slow test to verify it passes after registration**
+
+Run: `cd server && npx vitest run --config vitest.config.slow.ts src/routes/setup-readiness.route.test.ts`
+Expected: PASS (200 + shape; the sidecar being unreachable just yields `fail` blockers, never a 500).
+
+- [ ] **Step 4: Register the router in `server/src/index.ts`**
 
 Mirror the diagnostics registration (`import { diagnosticsRouter } from './routes/diagnostics.js';` + `app.use('/api/diagnostics', diagnosticsRouter);`). Add:
 
@@ -479,15 +502,15 @@ and alongside the other `app.use('/api/...')` lines:
 app.use('/api/setup', setupReadinessRouter); // fs-21 — first-run readiness probe
 ```
 
-- [ ] **Step 4: Run the server test + typecheck**
+- [ ] **Step 5: Run the slow route test + typecheck**
 
-Run: `cd server && npx vitest run src/routes/setup-readiness.test.ts && npm run typecheck`
+Run: `cd server && npx vitest run --config vitest.config.slow.ts src/routes/setup-readiness.route.test.ts && npm run typecheck`
 Expected: PASS + clean typecheck.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-git add server/src/index.ts server/src/routes/setup-readiness.test.ts
+git add server/src/index.ts server/src/routes/setup-readiness.route.test.ts server/vitest.config.slow.ts
 git commit -m "feat(server): register /api/setup readiness router (fs-21 wave 0)"
 ```
 
@@ -567,38 +590,37 @@ git commit -m "feat(frontend): add setup stage variant + #/setup + openSetup (fs
 - Modify: `src/lib/api.ts`
 - Test: `src/lib/api.test.ts` (add cases; create if absent)
 
-The mock must drive BOTH ready and not-ready so dev + e2e can exercise the gate. Drive it off a URL query param so e2e can force a state: `?setup=notready` → not-ready, anything else → ready.
+The mock must drive BOTH ready and not-ready so dev + e2e can exercise the gate. It latches the state into `sessionStorage` from a `?setup=notready` URL param, so the state **survives the redirect to `#/setup`** (where the param is gone). Test the **exported `mockGetSetupReadiness` directly** — do NOT go through `api.*`, because the api module locks `USE_MOCKS` at import time (`import.meta.env` can't be re-toggled after import).
 
 - [ ] **Step 1: Write the failing test**
 
 ```ts
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mockGetSetupReadiness } from './api';
 
 describe('mockGetSetupReadiness', () => {
   beforeEach(() => {
-    vi.resetModules();
-    // @ts-expect-error test shim
-    import.meta.env.VITE_USE_MOCKS = 'true';
+    sessionStorage.clear();
+    window.location.hash = '#/';
   });
 
   it('returns ready by default', async () => {
-    window.location.hash = '#/';
-    const { api } = await import('./api.js');
-    const r = await api.getSetupReadiness();
+    const r = await mockGetSetupReadiness();
     expect(r.ready).toBe(true);
   });
 
-  it('returns not-ready when the setup=notready param is present', async () => {
+  it('latches not-ready from the setup=notready param and persists it across nav', async () => {
     window.location.hash = '#/?setup=notready';
-    const { api } = await import('./api.js');
-    const r = await api.getSetupReadiness();
-    expect(r.ready).toBe(false);
-    expect(r.blockers.tts).toBe('fail');
+    const first = await mockGetSetupReadiness();
+    expect(first.ready).toBe(false);
+    expect(first.blockers.tts).toBe('fail');
+    // param gone after a redirect — the latch keeps it not-ready
+    window.location.hash = '#/setup';
+    const second = await mockGetSetupReadiness();
+    expect(second.ready).toBe(false);
   });
 });
 ```
-
-> If `src/lib/api.test.ts` does not exist or `import.meta.env` can't be mutated in this project's jsdom setup, instead export `mockGetSetupReadiness` and test it directly with a stubbed `window.location.hash`. Match whatever pattern an existing `*mock*` test in the repo uses.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -626,8 +648,15 @@ async function realGetSetupReadiness(): Promise<SetupReadiness> {
   return (await res.json()) as SetupReadiness;
 }
 
-async function mockGetSetupReadiness(): Promise<SetupReadiness> {
-  const notReady = window.location.hash.includes('setup=notready');
+/* Exported so unit tests can drive it directly (the `api.*` indirection locks
+   USE_MOCKS at import). Latches not-ready into sessionStorage from the
+   ?setup=notready param so the state survives the redirect to #/setup, where
+   the query param is gone. */
+export async function mockGetSetupReadiness(): Promise<SetupReadiness> {
+  if (window.location.hash.includes('setup=notready')) {
+    sessionStorage.setItem('mock-setup-readiness', 'notready');
+  }
+  const notReady = sessionStorage.getItem('mock-setup-readiness') === 'notready';
   return notReady
     ? {
         ready: false,
@@ -785,11 +814,11 @@ git commit -m "feat(frontend): setup stub view + #/setup route (fs-21 wave 0)"
 - Modify: `src/components/layout.tsx`
 - Test: `e2e/setup-gate.spec.ts` (Task 10 covers the e2e; this task's verification is the typecheck + a manual mock check)
 
-The gate: on mount, fetch readiness once. While the fetch is pending show a splash (block content). When it resolves, if `!ready` AND the current stage isn't already `setup`, navigate to `#/setup`. If `ready`, render normally. Never re-fetch on every navigation — one boot check (plus Wave 2's focus re-check, out of scope here).
+The gate: on mount, fetch readiness once. While the fetch is pending show a splash (block content). When it resolves, if `!ready` navigate to `#/setup` (a no-op if already there); if `ready`, render normally. Never re-fetch on every navigation — one boot check (plus Wave 2's focus re-check, out of scope here).
 
 - [ ] **Step 1: Add the gate state + effect**
 
-In `src/components/layout.tsx`, near the existing boot effects (the `fetchAccountSettings` effect ~line 453), add:
+In `src/components/layout.tsx`, add this state + effect **with the other top-level hooks** (the component already calls `useNavigate()` — reuse that `navigate`; place this next to the `fetchAccountSettings` boot effect ~line 453, NOT after any early return):
 
 ```tsx
 const [setupReady, setSetupReady] = useState<boolean | null>(null); // null = checking
@@ -800,16 +829,16 @@ useEffect(() => {
     .then((r) => {
       if (cancelled) return;
       setSetupReady(r.ready);
-      if (!r.ready && store.getState().ui.stage.kind !== 'setup') {
-        navigate('/setup');
-      }
+      // Redirecting to /setup when already there is a harmless no-op, so we
+      // don't need to read the current stage (Layout does NOT import `store`).
+      if (!r.ready) navigate('/setup');
     })
     .catch(() => { if (!cancelled) setSetupReady(true); }); // probe failure must not lock the app out
   return () => { cancelled = true; };
 }, []); // eslint-disable-line react-hooks/exhaustive-deps
 ```
 
-> Use the `navigate` from `useNavigate()` and the imported `store` + `api` already available in this module (Layout already imports `store` and dispatches; add `useNavigate`/`api` imports if not present, matching `src/routes/index.tsx`). On probe failure we fail OPEN (`setSetupReady(true)`) so a transient readiness error never bricks the app.
+> Layout already imports `api` (line 33) and `useNavigate` (line 2) and `useState`/`useEffect` (line 1) — no new imports needed, and **do NOT import `store`** (Layout doesn't, and we no longer need it). On probe failure we fail OPEN (`setSetupReady(true)`) so a transient readiness error never bricks the app.
 
 - [ ] **Step 2: Render the splash while checking**
 
@@ -825,12 +854,12 @@ if (setupReady === null) {
 }
 ```
 
-> Place this BEFORE the main `return (<Outlet … />)`. It only blocks the very first paint until the one-shot readiness fetch resolves; subsequent navigations don't re-trigger it (the effect has `[]` deps).
+> **Rules-of-hooks:** place this early return **immediately before the component's final top-level `return (`**, after EVERY hook call in the component (Layout has ~20 hooks — `useTheme`, `useTtsLifecycle`, the many `useEffect`/`useState`, etc.). An early return placed above any hook will throw "rendered fewer hooks than expected." It only blocks the very first paint until the one-shot readiness fetch resolves; subsequent navigations don't re-trigger it (the effect has `[]` deps).
 
 - [ ] **Step 3: Typecheck + frontend unit suite**
 
 Run: `npm run typecheck && npm run test`
-Expected: PASS (no type errors; existing Layout tests still green — if a Layout test now needs the readiness mock, add `getSetupReadiness` to that test's api stub returning `{ ready: true, … }`).
+Expected: PASS (no type errors). Existing Layout tests now mount the readiness fetch on render: in unit tests `api` resolves to the mock (which returns `ready: true`) or, if it hits the real `fetch` and rejects in jsdom, the `.catch` fails OPEN (`setSetupReady(true)`) — either way the splash resolves. If a Layout test emits an `act(...)` warning from the post-mount state update, wrap its render/assertions in `await waitFor(...)` (or assert the resolved tree) rather than disabling the gate.
 
 - [ ] **Step 4: Manual mock check**
 
@@ -867,7 +896,7 @@ test('boot gate stays out of the way when ready', async ({ page }) => {
 });
 ```
 
-> Mock mode is the e2e default (port 5174). `?setup=notready` drives `mockGetSetupReadiness` to the not-ready branch (Task 7). No server needed.
+> Mock mode is the e2e default (port 5174). `?setup=notready` drives `mockGetSetupReadiness` to the not-ready branch (Task 7). No server needed. Each Playwright test runs in a fresh browser context, so the `sessionStorage` latch from the not-ready test does not leak into the ready test.
 
 - [ ] **Step 2: Run the spec to verify it passes**
 
@@ -921,6 +950,6 @@ gh pr ready
 - Headless/Docker "works for free" → same derived gate fires on first UI open; no Wave-0-specific code needed (covered by Task 9's boot fetch) ✓
 - **Deferred to later waves (correctly out of Wave 0):** the 5-step UI bodies + install rows (Wave 2), Kokoro install route + venv bootstrap + parity audit (Wave 1), two-tier smoke test (Wave 3), Account "Re-run setup" entry (Wave 2), docs/closure (Wave 4).
 
-**Placeholder scan:** No TBD/TODO; every code step shows the code; every run step shows the command + expected result. The two `>` notes that say "verify symbol name against file X" are explicit guards against type-drift, not missing content — the canonical code is present and the guard names the exact reference file.
+**Placeholder scan:** No TBD/TODO; every code step shows the code; every run step shows the command + expected result. All previously-hedged symbols are now pinned against the real source (subagent-execution review, 2026-06-12): the settings getter reads the module-level `cached` + a `writeUpgradeMeta`-style dedicated writer (Task 1); `REPO_ROOT` is computed locally, not imported (Task 4); `detectQwenInstallStateOnDisk(repoRoot) === 'ready'` and `coquiWeightsPresent()` no-arg (Task 4); the Layout gate uses `navigate` only (no `store` import) with an explicit rules-of-hooks placement (Task 9); the mock latches not-ready into `sessionStorage` to survive the redirect and is tested via the exported `mockGetSetupReadiness` (Task 7); the live-probe route test is isolated to the slow pool (Task 5).
 
 **Type consistency:** `SetupReadiness` / `BlockerStatus` are defined identically server-side (Task 4) and client-side (Task 7). `buildSetupReadiness` input keys (`diagnostics`, `engine`, `venvPresent`, `ttsEnginePresent`, `completedAt`) match between its definition (Task 4 Step 3) and its callers (Task 4 route + Task 4 tests). `getSetupReadiness` is the api method name in Tasks 7, 8, 9. `openSetup` / `{ kind: 'setup' }` consistent across Tasks 6, 8, 9.

--- a/docs/superpowers/specs/2026-06-12-fs21-first-run-wizard-design.md
+++ b/docs/superpowers/specs/2026-06-12-fs21-first-run-wizard-design.md
@@ -125,7 +125,7 @@ Wave-structured, each independently reviewable with its own gate. Default dispos
 - Owning Python/CUDA provisioning on every OS (Z bootstraps the venv only when Python 3.11 is already present).
 - Tier-2 "re-analyze" is opt-in, not default.
 - Whisper ASR never blocks.
-- Installer packaging (`ops-1` / `ops-15` / `ops-2`) — separate work that *hands off* to this wizard.
+- Installer packaging (`ops-1` / `ops-15` / `ops-2`) — separate work that *hands off* to this wizard. **Updated 2026-06-12 with the Z venv-ownership note:** native installers (`ops-1` #432 / `ops-15` #735) pre-build the sidecar venv (Python 3.11 stays the only hard prereq; the wizard's one-click bootstrap is the fallback); Docker (`ops-2` #433) bakes the venv into the image (wizard venv step = no-op there; venv is an image layer, not a mounted volume).
 - Wizard-copy i18n (defers to `fs-14`).
 - Intended-destination restore after gating.
 

--- a/docs/superpowers/specs/2026-06-12-fs21-first-run-wizard-design.md
+++ b/docs/superpowers/specs/2026-06-12-fs21-first-run-wizard-design.md
@@ -1,13 +1,13 @@
 # fs-21 — First-run setup wizard (cross-platform setup owner)
 
 > **Status:** design (awaiting review) · **Date:** 2026-06-12 · **Issue:** [#474](https://github.com/dudarenok-maker/Castwright/issues/474)
-> **Owes:** a `docs/features/NN-*.md` regression plan at implementation (plans currently reach 207 → next free is 208).
+> **Owes:** a `docs/features/NN-*.md` regression plan at implementation (plans currently reach 208 → next free is 209).
 
 ## Summary
 
 A guided, cross-platform (Windows / macOS / Linux) first-run flow that becomes the **single owner of post-install setup for every platform**. Both installers (`ops-1` Windows `.exe`, `ops-15` macOS `.dmg`) and the Docker deploy (`ops-2`) ship only the app + runtime prerequisites and hand off here, so model install + verification is identical across OSes rather than reimplemented per installer.
 
-The wizard is an **orchestrator** over seams that already exist — the Model Manager install/inventory backends, the Ollama analyzer install/pull bootstraps, the fs-43 server-sourced device panel, the fs-22 bundled demo book, and the real generation pipeline — plus a small amount of new backend (a readiness probe, a Kokoro install route, a light smoke endpoint, and — per the venv decision below — a sidecar-bootstrap path).
+The wizard is an **orchestrator** over seams that already exist — the Model Manager install/inventory backends, the Ollama analyzer install/pull bootstraps, the existing `diagnostics.ts` health aggregator, the fs-43 device panel (`device-panel.tsx` over `/api/info`), the fs-22 bundled demo book, and the real generation pipeline — plus a small amount of new backend (a readiness shape *derived from* `diagnostics.ts`, a Kokoro install route, a light smoke endpoint, and — per the venv decision below — a sidecar-bootstrap path).
 
 ## Decisions locked in brainstorming
 
@@ -24,13 +24,13 @@ The wizard is an **orchestrator** over seams that already exist — the Model Ma
 ## Architecture & app surface
 
 - **New stage variant, not a modal.** Add `{ kind: 'setup' }` to the discriminated-union `ui.stage` (mirroring how `model-manager` was added in plan 193), routed at `#/setup` via pure `parseHash`/`stageToHash`. A real stage survives reload, deep-links, and slots into the e2e coverage spec.
-- **The adaptive gate is derived, not flag-driven.** On boot a selector computes `setupReadiness` from one new endpoint, `GET /api/setup/readiness`, which folds together: ffmpeg-on-PATH, the `/api/models/inventory` snapshot (TTS engines + Ollama tags), sidecar reachability + venv presence, the resolved analyzer config (Ollama daemon/model state **or** Gemini key), and the fs-43 device facts. It degrades gracefully with the sidecar down.
+- **The adaptive gate is derived, not flag-driven — and it reuses `diagnostics.ts`.** The existing `server/src/routes/diagnostics.ts` already aggregates the checks we need (`CheckId = 'gpu' | 'sidecar' | 'asr' | 'analyzer' | 'gemini' | 'ffmpeg' | 'disk'`), each returning a pass/fail + a human-readable detail line, and is built to "probe the sidecar once and reuse it." So `GET /api/setup/readiness` is a **thin mapper over diagnostics → the hard-blocker readiness shape**, adding only the probes diagnostics lacks: venv-present-on-disk, per-engine *weights* presence (from `/api/models/inventory`), and Ollama *model-pulled* state. It must NOT reinvent the aggregator. It degrades gracefully with the sidecar down (the diagnostics `sidecar`/`gpu` rows already model that).
 - **Boot splash gates first paint.** Because the router is a pure URL↔stage map (it doesn't gate today), a short *"Checking your setup…"* splash blocks first render until readiness resolves, then redirects into `#/setup` if any hard-blocker fails. This avoids a flash-then-yank and is what makes **headless/Docker work for free** — a fresh container with no models serves the UI, the probe reports not-ready, and the same gate fires without any launcher event.
 - **One persisted bit:** `setupCompletedAt` (user-settings, server-side) suppresses the *guided* intro on later launches and satisfies "doesn't re-run once completed." The hard gate stays purely derived, so removing a model later legitimately re-fires the gate in **checklist** mode (the Model Manager's "can't remove the in-use default → 409" guard already prevents a nasty mid-session yank).
 - **Hybrid presentation, one component, two modes:**
   - *Guided* (first run, `setupCompletedAt == null`): linear paged flow, one step per screen, Back/Next, progress dots.
   - *Checklist* (re-entry from **Account → "Re-run setup"** / Admin, or a later launch where a blocker regressed): all steps visible, status per row, jump to any item. Resume is automatic because state is derived from live checks.
-- **Reuse, don't rebuild:** install rows reuse `CoquiInstall` / `QwenInstall` / `WhisperInstall` and the Ollama analyzer section from the Model Manager; GPU facts come from the fs-43 device panel; the full smoke run reuses fs-22 sample-load + the generation pipeline.
+- **Reuse, don't rebuild:** install rows reuse `CoquiInstall` / `QwenInstall` / `WhisperInstall` and the Ollama analyzer section from the Model Manager; the readiness probe reuses `diagnostics.ts`; GPU facts are **sidecar-derived** (the diagnostics `gpu` row reads the sidecar's torch CUDA figures, so GPU info is simply absent until the venv/sidecar exist — consistent with GPU being info-only); the device-panel UI (`device-panel.tsx`) is reused for display; the full smoke run reuses fs-22 sample-load + the generation pipeline.
 
 ## Hard-blockers — precise definitions
 
@@ -45,10 +45,12 @@ The gate releases only when **all** of these pass; each is also a wizard step th
 
 GPU presence is surfaced (Step 1) but **never blocks** — CPU fallback is allowed.
 
+**What opens the gate (and what the smoke test is *not*).** The hard gate — app access — opens the moment the hard-blockers above (Steps 1–3) pass, *derived live*, independent of the smoke test. The **smoke test (Step 5) is confidence, not a gate condition**: a user who has satisfied Steps 1–3 already has app access and could skip it. `setupCompletedAt` is stamped when the user finishes (or exits) the *guided* flow, only to suppress the guided re-intro. Consequence of choosing the adaptive gate, stated honestly: the issue's "prove the whole stack end-to-end *before* the user uploads" becomes **"offer proof," not "force it."** Guided mode walks the user into the smoke test by default, but it is not a wall.
+
 ## The steps
 
 **Step 1 — Environment & sidecar** *(blocks only on sidecar-unreachable; GPU is info)*
-OS/arch, GPU (CUDA / MPS / none + VRAM) from the fs-43 panel, Python + sidecar reachability, venv presence, Node version. GPU is informational and *seeds the defaults* in Step 4 (CPU box → default to Kokoro, warn Qwen is slow). A missing venv / down sidecar surfaces the **Z** bootstrap affordance (below) or instruction.
+OS/arch, GPU (CUDA / MPS / none + VRAM) — **sidecar-derived** (the diagnostics `gpu` row reads torch CUDA figures), so absent until the venv/sidecar exist — Python + sidecar reachability, venv presence, Node version. GPU is informational and *seeds the defaults* in Step 4 (CPU box → default to Kokoro, warn Qwen is slow). A missing venv / down sidecar surfaces the **Z** bootstrap affordance (below) or instruction.
 
 **Step 2 — ffmpeg** *(hard blocker; verify + instruct)*
 Pass shows the version; fail shows per-OS remediation (`winget install ffmpeg` / `brew install ffmpeg` / `apt install ffmpeg`) + Re-check.
@@ -64,9 +66,9 @@ Default engine, analysis model, theme — pre-filled from Step 1, written throug
 
 **Step 5 — Two-tier smoke test** *(locked until Steps 1–3 pass)*
 - **Tier 1 — light check (automatic, on completion).** `POST /api/setup/smoke`: synth one fixed *committed* snippet with the default engine → ffmpeg assemble → audible inline clip, plus a cheap **analyzer liveness ping**. No book scaffold, no full analysis run. Pass = non-empty audio produced + assembled + plays (length/exit-code check, **not** a golden byte match — engines are stochastic). Fail names the broken stage with matching remediation.
-- **Tier 2 — full run on the demo book (opt-in).** A "Hear a real audiobook now?" card loads **The Coalfall Commission** (fs-22, `POST /api/samples/the-coalfall-commission/load`, idempotent) and runs the **real generation pipeline** (all 13 voices synthesized + assembled) → drops into the Listen view with playable audio. The demo ships with a pre-designed cast and **no audio**, so generation *is* the end-to-end proof. An optional **"re-analyze first"** toggle exercises the analyzer end-to-end for the thorough deployer. Refuses/queues if a generation is already active (no GPU contention); CPU-aware, progress-streaming budget (no false timeouts).
+- **Tier 2 — full run on the demo book (opt-in).** A "Hear a real audiobook now?" card loads **The Coalfall Commission** (fs-22, `POST /api/samples/the-coalfall-commission/load`, idempotent) and runs the **real generation pipeline** (all 13 voices synthesized + assembled) → ends in the Listen view with playable audio. The demo ships with a pre-designed cast and **no audio**, so generation *is* the end-to-end proof. **Flow caveat (verify at implementation):** a freshly-loaded sample may land in the **cast-confirm** state, not generate-ready (plan 207 routes to "cast-confirm or cast view depending on `book.status`"). So Tier 2 must either auto-advance past confirm for the demo, or the card walks the user through it — *not* assumed to be a single load→audio click. An optional **"re-analyze first"** toggle exercises the analyzer end-to-end for the thorough deployer. Refuses/queues if a generation is already active (no GPU contention); CPU-aware, progress-streaming budget (no false timeouts).
 
-Completion stamps `setupCompletedAt`; the gate opens and guided mode won't re-trigger. The checklist stays reachable from Account.
+Finishing (or exiting) the guided flow stamps `setupCompletedAt`, so guided mode won't re-trigger — note the *app-access* gate already opened when Steps 1–3 passed (see "What opens the gate" above). The checklist stays reachable from Account.
 
 ## Cross-platform install work (the full-parity scope)
 
@@ -86,7 +88,7 @@ New backend work:
 
 1. **Kokoro install route** — `POST /api/kokoro/install` + a `KokoroInstall` SSE component + a `runInstallScript()` **platform-dispatch helper** (`.ps1` on Windows, `.sh` elsewhere). Targets the **versioned** `<install>/models/kokoro` path (per `setup-versioned-install.mjs`, which shares weights across releases — *not* the legacy `voices/kokoro`). ops-7 hash-verified; `windowsHide: true` on the spawn (commit-gate invariant).
 2. **Sidecar bootstrap (per Z)** — detect Python 3.11 + venv; offer one-click `python -m venv + pip install -r requirements.txt` with streamed progress, degrading to instruction when Python 3.11 is absent. Reuses the platform-dispatch helper.
-3. **Readiness probe** — `GET /api/setup/readiness` folding the components above into one `setupReadiness` shape; works with the sidecar down. **Mockable to both ready and not-ready states** (query param / mock toggle) so dev and e2e can exercise both the gate firing and the happy path.
+3. **Readiness probe** — `GET /api/setup/readiness` as a **thin mapper over the existing `diagnostics.ts` aggregator** → the hard-blocker `setupReadiness` shape, adding only the probes diagnostics lacks (venv-on-disk, per-engine weights from inventory, Ollama model-pulled). Explicitly *not* a parallel re-implementation. Works with the sidecar down. **Mockable to both ready and not-ready states** (query param / mock toggle) so dev and e2e can exercise both the gate firing and the happy path.
 4. **Light smoke endpoint** — `POST /api/setup/smoke` (snippet → synth → assemble + analyzer ping); reuses real synth/assembly code, returns a per-stage breakdown.
 5. **Install-backend parity audit** — run Qwen / Coqui / Ollama install on real macOS + Linux boxes and fix what breaks. **Time-boxed with a pressure-release valve:** if a backend can't be made cross-platform cheaply, degrade *that one engine* to instruct-only and file a follow-up rather than sinking v1.
 
@@ -102,11 +104,11 @@ New backend work:
 
 Wave-structured, each independently reviewable with its own gate. Default disposition: one integration PR per parallel round, verified once (`integration/<date>`).
 
-- **Wave 0 — Readiness spine** *(foundational, sequential)*: `GET /api/setup/readiness` + `{ kind: 'setup' }` stage + `#/setup` route + boot splash + `setupCompletedAt` + mock dual-state stub. *Gate:* typecheck + unit tests (selector + router redirect) + e2e stub that the gate fires when not-ready.
+- **Wave 0 — Readiness spine** *(foundational, sequential)*: `GET /api/setup/readiness` as a **thin mapper over `diagnostics.ts`** (+ the 2-3 missing probes) + `{ kind: 'setup' }` stage + `#/setup` route + boot splash + `setupCompletedAt` + mock dual-state stub. *Gate:* typecheck + unit tests (mapper + selector + router redirect) + e2e stub that the gate fires when not-ready. (Reusing diagnostics keeps this wave small.)
 - **Wave 1 — Cross-platform install parity** *(riskiest; owes on-box acceptance)*: Kokoro install route + `KokoroInstall` + `runInstallScript()` helper + sidecar bootstrap (Z) + the parity audit. *Gate:* server/sidecar unit tests for the route + dispatch helper. **On-box install acceptance (Mac + Linux) is documented-OWED**, not a CI gate.
 - **Wave 2 — The wizard UI** *(hybrid; can run ∥ Wave 1 in a worktree, frontend scope)*: the `setup` view (two modes), 5 steps, reusing the existing installers + fs-43 panel; Account "Re-run setup" entry. *Gate:* vitest per step (pass/fail/remediation) + `e2e/responsive/coverage.spec.ts` entry.
 - **Wave 3 — Two-tier smoke test**: Tier 1 endpoint + committed snippet fixture + inline player + mock stub; Tier 2 card wiring sample-load → generation → Listen + optional re-analyze. Completion stamps `setupCompletedAt`. *Gate:* server test (per-stage breakdown) + **the issue's required mock-mode e2e happy-path progression**.
-- **Wave 4 — Docs & closure**: new `docs/features/208-fs21-first-run-wizard.md` regression plan + INDEX entry + BACKLOG row removal + `Closes #474`. Run `cross-os.yml` before any release announce.
+- **Wave 4 — Docs & closure**: new `docs/features/209-fs21-first-run-wizard.md` regression plan + INDEX entry + BACKLOG row removal + `Closes #474`. Run `cross-os.yml` before any release announce.
 
 **Parallelism:** Wave 0 lands first (spine). Then Wave 1 (server) ∥ Wave 2 (frontend, mocking the not-yet-real route via the existing install-component pattern) in worktrees → `integration/<date>`, verify between merges → Wave 3 → Wave 4.
 

--- a/docs/superpowers/specs/2026-06-12-fs21-first-run-wizard-design.md
+++ b/docs/superpowers/specs/2026-06-12-fs21-first-run-wizard-design.md
@@ -1,0 +1,143 @@
+# fs-21 — First-run setup wizard (cross-platform setup owner)
+
+> **Status:** design (awaiting review) · **Date:** 2026-06-12 · **Issue:** [#474](https://github.com/dudarenok-maker/Castwright/issues/474)
+> **Owes:** a `docs/features/NN-*.md` regression plan at implementation (plans currently reach 207 → next free is 208).
+
+## Summary
+
+A guided, cross-platform (Windows / macOS / Linux) first-run flow that becomes the **single owner of post-install setup for every platform**. Both installers (`ops-1` Windows `.exe`, `ops-15` macOS `.dmg`) and the Docker deploy (`ops-2`) ship only the app + runtime prerequisites and hand off here, so model install + verification is identical across OSes rather than reimplemented per installer.
+
+The wizard is an **orchestrator** over seams that already exist — the Model Manager install/inventory backends, the Ollama analyzer install/pull bootstraps, the fs-43 server-sourced device panel, the fs-22 bundled demo book, and the real generation pipeline — plus a small amount of new backend (a readiness probe, a Kokoro install route, a light smoke endpoint, and — per the venv decision below — a sidecar-bootstrap path).
+
+## Decisions locked in brainstorming
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Gate model | **Adaptive gate** | Block only when synthesis is genuinely impossible; guide everything else. |
+| Hard blockers | **ffmpeg + ≥1 TTS engine (+ its runtime) + an analyzer** | The minimum to produce an audiobook end to end. GPU is *not* a blocker (CPU fallback survives). |
+| Cross-platform install ambition | **Full parity** | v1 owns one-click *model* install on all three OSes, including a new Kokoro install route. (ffmpeg is verify+instruct — see below.) |
+| Smoke test | **Two-tier**: a light always-on check + an opt-in full run on the bundled demo book | Light proof gates completion cheaply; the full run is faithful end-to-end *and* a first-listen delight moment. |
+| Wizard shape | **Hybrid (one component, two modes)** | Guided/linear on first run; checklist on re-entry from Account. |
+| Persisted state | **`setupCompletedAt` only** | A hard gate is purely *derived*; a separate "dismissed" flag would be meaningless (it could never grant app access). |
+| Sidecar venv ownership | **Z — hybrid** (recommended; confirm on review) | Installer owns the venv; the wizard *detects* a missing/broken venv and offers a one-click bootstrap **when Python 3.11 is present**, degrading to instruct otherwise. |
+
+## Architecture & app surface
+
+- **New stage variant, not a modal.** Add `{ kind: 'setup' }` to the discriminated-union `ui.stage` (mirroring how `model-manager` was added in plan 193), routed at `#/setup` via pure `parseHash`/`stageToHash`. A real stage survives reload, deep-links, and slots into the e2e coverage spec.
+- **The adaptive gate is derived, not flag-driven.** On boot a selector computes `setupReadiness` from one new endpoint, `GET /api/setup/readiness`, which folds together: ffmpeg-on-PATH, the `/api/models/inventory` snapshot (TTS engines + Ollama tags), sidecar reachability + venv presence, the resolved analyzer config (Ollama daemon/model state **or** Gemini key), and the fs-43 device facts. It degrades gracefully with the sidecar down.
+- **Boot splash gates first paint.** Because the router is a pure URL↔stage map (it doesn't gate today), a short *"Checking your setup…"* splash blocks first render until readiness resolves, then redirects into `#/setup` if any hard-blocker fails. This avoids a flash-then-yank and is what makes **headless/Docker work for free** — a fresh container with no models serves the UI, the probe reports not-ready, and the same gate fires without any launcher event.
+- **One persisted bit:** `setupCompletedAt` (user-settings, server-side) suppresses the *guided* intro on later launches and satisfies "doesn't re-run once completed." The hard gate stays purely derived, so removing a model later legitimately re-fires the gate in **checklist** mode (the Model Manager's "can't remove the in-use default → 409" guard already prevents a nasty mid-session yank).
+- **Hybrid presentation, one component, two modes:**
+  - *Guided* (first run, `setupCompletedAt == null`): linear paged flow, one step per screen, Back/Next, progress dots.
+  - *Checklist* (re-entry from **Account → "Re-run setup"** / Admin, or a later launch where a blocker regressed): all steps visible, status per row, jump to any item. Resume is automatic because state is derived from live checks.
+- **Reuse, don't rebuild:** install rows reuse `CoquiInstall` / `QwenInstall` / `WhisperInstall` and the Ollama analyzer section from the Model Manager; GPU facts come from the fs-43 device panel; the full smoke run reuses fs-22 sample-load + the generation pipeline.
+
+## Hard-blockers — precise definitions
+
+The gate releases only when **all** of these pass; each is also a wizard step that reports `pass | fail` with remediation.
+
+1. **Sidecar runtime reachable.** The Python sidecar responds *and* its venv exists. A missing venv means no engine can run, so this sits upstream of the TTS check. Ownership = **Z** (see below).
+2. **ffmpeg present.** `ffmpeg -version` on PATH. **Verify + instruct only** on every platform (no bundled ffmpeg installer; it's the OS/installer's job). Per-OS copy-paste remediation + "Re-check".
+3. **≥1 TTS engine with weights.** Kokoro is the default; **its weights are *not* in the release zip** (`build-release-zip.mjs` excludes `voices/kokoro/**`, "1.1 GB, fetched at install time"), so this blocker fires on *every* fresh install and is satisfied by the new one-click Kokoro install route (or Qwen/Coqui as alternates).
+4. **An analyzer available**, matched to the resolved analyzer config:
+   - `ANALYZER=gemini` → a Gemini API key is set (validated). **Recommended path — true zero local install.**
+   - `ANALYZER=local` → the Ollama daemon is reachable **and** the configured model is pulled; falls back to a Gemini key if one is set.
+
+GPU presence is surfaced (Step 1) but **never blocks** — CPU fallback is allowed.
+
+## The steps
+
+**Step 1 — Environment & sidecar** *(blocks only on sidecar-unreachable; GPU is info)*
+OS/arch, GPU (CUDA / MPS / none + VRAM) from the fs-43 panel, Python + sidecar reachability, venv presence, Node version. GPU is informational and *seeds the defaults* in Step 4 (CPU box → default to Kokoro, warn Qwen is slow). A missing venv / down sidecar surfaces the **Z** bootstrap affordance (below) or instruction.
+
+**Step 2 — ffmpeg** *(hard blocker; verify + instruct)*
+Pass shows the version; fail shows per-OS remediation (`winget install ffmpeg` / `brew install ffmpeg` / `apt install ffmpeg`) + Re-check.
+
+**Step 3 — Models** *(hard blocker: ≥1 TTS engine AND an analyzer)*
+- *TTS engine* — Kokoro present → green; absent → one-click **Install Kokoro** (new cross-platform route); Qwen/Coqui offered as alternates. At least one must end green.
+- *Analyzer* — **Gemini key (recommended, zero local install)** validated with a cheap ping; **or** Ollama: install the daemon if absent (on **Windows this is a manual GUI `.exe` double-click** — surfaced honestly), then one-click pull the configured model.
+- Whisper ASR is offered but **never blocks** (opt-in content-QA engine).
+Install progress reuses the existing SSE-backed components, so long downloads survive reload exactly like the Model Manager.
+
+**Step 4 — Defaults** *(skippable; sensible auto-picks)*
+Default engine, analysis model, theme — pre-filled from Step 1, written through the existing `UserSettingsPatch` Save harness.
+
+**Step 5 — Two-tier smoke test** *(locked until Steps 1–3 pass)*
+- **Tier 1 — light check (automatic, on completion).** `POST /api/setup/smoke`: synth one fixed *committed* snippet with the default engine → ffmpeg assemble → audible inline clip, plus a cheap **analyzer liveness ping**. No book scaffold, no full analysis run. Pass = non-empty audio produced + assembled + plays (length/exit-code check, **not** a golden byte match — engines are stochastic). Fail names the broken stage with matching remediation.
+- **Tier 2 — full run on the demo book (opt-in).** A "Hear a real audiobook now?" card loads **The Coalfall Commission** (fs-22, `POST /api/samples/the-coalfall-commission/load`, idempotent) and runs the **real generation pipeline** (all 13 voices synthesized + assembled) → drops into the Listen view with playable audio. The demo ships with a pre-designed cast and **no audio**, so generation *is* the end-to-end proof. An optional **"re-analyze first"** toggle exercises the analyzer end-to-end for the thorough deployer. Refuses/queues if a generation is already active (no GPU contention); CPU-aware, progress-streaming budget (no false timeouts).
+
+Completion stamps `setupCompletedAt`; the gate opens and guided mode won't re-trigger. The checklist stays reachable from Account.
+
+## Cross-platform install work (the full-parity scope)
+
+Audit of where the install backends stand today:
+
+| Component | x-plat backend | In-app route | Gap to close |
+|---|---|---|---|
+| **Sidecar venv** | `start.{sh,ps1}` error if absent; manual `venv + pip install` | ✗ | Per **Z**: detect + optional one-click bootstrap when Python 3.11 present |
+| **Kokoro** (default TTS) | `.ps1` + `.sh`, no `.mjs` | ✗ **none** | New `POST /api/kokoro/install` + `KokoroInstall` component |
+| **Qwen-base** | `.mjs` + `.ps1` | ✓ | Verify mac/linux |
+| **Coqui** | `.mjs` + `.ps1` + `.sh` | ✓ | Verify mac/linux |
+| **Whisper** | `.mjs` | ✓ | Not a blocker — leave as-is |
+| **Ollama daemon** | `install-bootstrap.ts` (per-platform) | ✓ (manual `.exe` on Win) | Verify; surface the Windows manual step |
+| **Ollama model** | `pull-bootstrap.ts` (daemon must be up) | ✓ | Verify cross-OS |
+
+New backend work:
+
+1. **Kokoro install route** — `POST /api/kokoro/install` + a `KokoroInstall` SSE component + a `runInstallScript()` **platform-dispatch helper** (`.ps1` on Windows, `.sh` elsewhere). Targets the **versioned** `<install>/models/kokoro` path (per `setup-versioned-install.mjs`, which shares weights across releases — *not* the legacy `voices/kokoro`). ops-7 hash-verified; `windowsHide: true` on the spawn (commit-gate invariant).
+2. **Sidecar bootstrap (per Z)** — detect Python 3.11 + venv; offer one-click `python -m venv + pip install -r requirements.txt` with streamed progress, degrading to instruction when Python 3.11 is absent. Reuses the platform-dispatch helper.
+3. **Readiness probe** — `GET /api/setup/readiness` folding the components above into one `setupReadiness` shape; works with the sidecar down. **Mockable to both ready and not-ready states** (query param / mock toggle) so dev and e2e can exercise both the gate firing and the happy path.
+4. **Light smoke endpoint** — `POST /api/setup/smoke` (snippet → synth → assemble + analyzer ping); reuses real synth/assembly code, returns a per-stage breakdown.
+5. **Install-backend parity audit** — run Qwen / Coqui / Ollama install on real macOS + Linux boxes and fix what breaks. **Time-boxed with a pressure-release valve:** if a backend can't be made cross-platform cheaply, degrade *that one engine* to instruct-only and file a follow-up rather than sinking v1.
+
+## Edge cases & concurrency
+
+- **Cross-tab:** readiness stays server-derived and is re-checked on focus, so a Tab-A completion releases Tab-B's gate via the existing BroadcastChannel sync — no stale local cache.
+- **Reload mid-Tier-2 generation:** generation is the reload-resilient job; on reload the blockers now pass, the gate is open, and the running job resubscribes in the generation/Listen view. No special handling.
+- **Model removed after completion:** gate re-derives and re-fires in checklist mode; the in-use-default removal guard prevents a mid-session yank.
+- **Deep-link after gating:** a not-ready user hitting `#/listen` lands on `#/` after setup; no intended-destination restore in v1 (deliberate non-goal).
+- **Offline + Gemini analyzer:** the Tier-1 analyzer ping needs network for the Gemini path; local/Ollama is fully offline. Acceptable.
+
+## Delivery roadmap
+
+Wave-structured, each independently reviewable with its own gate. Default disposition: one integration PR per parallel round, verified once (`integration/<date>`).
+
+- **Wave 0 — Readiness spine** *(foundational, sequential)*: `GET /api/setup/readiness` + `{ kind: 'setup' }` stage + `#/setup` route + boot splash + `setupCompletedAt` + mock dual-state stub. *Gate:* typecheck + unit tests (selector + router redirect) + e2e stub that the gate fires when not-ready.
+- **Wave 1 — Cross-platform install parity** *(riskiest; owes on-box acceptance)*: Kokoro install route + `KokoroInstall` + `runInstallScript()` helper + sidecar bootstrap (Z) + the parity audit. *Gate:* server/sidecar unit tests for the route + dispatch helper. **On-box install acceptance (Mac + Linux) is documented-OWED**, not a CI gate.
+- **Wave 2 — The wizard UI** *(hybrid; can run ∥ Wave 1 in a worktree, frontend scope)*: the `setup` view (two modes), 5 steps, reusing the existing installers + fs-43 panel; Account "Re-run setup" entry. *Gate:* vitest per step (pass/fail/remediation) + `e2e/responsive/coverage.spec.ts` entry.
+- **Wave 3 — Two-tier smoke test**: Tier 1 endpoint + committed snippet fixture + inline player + mock stub; Tier 2 card wiring sample-load → generation → Listen + optional re-analyze. Completion stamps `setupCompletedAt`. *Gate:* server test (per-stage breakdown) + **the issue's required mock-mode e2e happy-path progression**.
+- **Wave 4 — Docs & closure**: new `docs/features/208-fs21-first-run-wizard.md` regression plan + INDEX entry + BACKLOG row removal + `Closes #474`. Run `cross-os.yml` before any release announce.
+
+**Parallelism:** Wave 0 lands first (spine). Then Wave 1 (server) ∥ Wave 2 (frontend, mocking the not-yet-real route via the existing install-component pattern) in worktrees → `integration/<date>`, verify between merges → Wave 3 → Wave 4.
+
+## v1 Definition of Done
+
+1. Fresh install on **Windows / macOS / Linux**: open app → gate fires → (Z: bootstrap sidecar if Python present) → one-click Kokoro + analyzer (ffmpeg + the Windows-Ollama `.exe` instructed) → defaults → Tier-1 smoke passes → optional demo-book full run plays audio → gate opens and never re-gates.
+2. **Headless/Docker**: the same gate fires on first UI open, no launcher event needed.
+3. Mock-mode e2e covers the happy-path progression (and the gate-fires-when-not-ready case).
+4. On-box install acceptance (Mac + Linux) recorded as OWED in the plan.
+
+## Out of scope / secondary gaps (explicitly not v1)
+
+- ffmpeg **auto-install** (instruct-only by design).
+- Owning Python/CUDA provisioning on every OS (Z bootstraps the venv only when Python 3.11 is already present).
+- Tier-2 "re-analyze" is opt-in, not default.
+- Whisper ASR never blocks.
+- Installer packaging (`ops-1` / `ops-15` / `ops-2`) — separate work that *hands off* to this wizard.
+- Wizard-copy i18n (defers to `fs-14`).
+- Intended-destination restore after gating.
+
+## Testing strategy
+
+- **Unit (frontend):** readiness selector, router redirect + boot-splash gating, each wizard step's pass/fail/remediation rendering, two-mode (guided/checklist) switch.
+- **Unit (server/sidecar):** `runInstallScript()` platform dispatch, Kokoro install route (stubbed spawn), readiness shape (incl. sidecar-down degradation), smoke endpoint per-stage breakdown, sidecar-bootstrap detection.
+- **e2e (mock mode):** happy-path progression through all five steps; gate-fires-when-not-ready; `coverage.spec.ts` entry for the new view.
+- **Manual / on-box (OWED):** real one-click installs on a Mac + a Linux box; the Tier-2 demo-book full run producing audible output; the Z venv bootstrap on a box with Python 3.11.
+
+## Issue handling
+
+Per the review-first convention: land this spec branch first and **hold** filing the per-wave sub-issues until the spec is reviewed.
+
+## Open question for review
+
+- **Confirm the venv decision (Z).** The spec assumes Z (installer owns the venv; wizard offers one-click bootstrap when Python 3.11 is present). If you prefer **X** (pure installer responsibility, wizard instructs only) or **Y** (wizard fully owns Python/CUDA provisioning), the hard-blocker list, Wave 1 sizing, and the DoD shift accordingly.


### PR DESCRIPTION
## Summary

Design spec + Wave 0 implementation plan for **fs-21** (first-run setup wizard / cross-platform setup owner), the single owner of post-install setup across Windows/macOS/Linux. Adaptive gate; hard-blockers = sidecar runtime+venv, ffmpeg, ≥1 TTS engine, an analyzer; full cross-platform install parity; two-tier smoke test (light check + opt-in full run on the fs-22 demo book); hybrid guided/checklist UI. Venv decision **Z** locked and propagated to ops-1/ops-15/ops-2.

Wave 0 plan = the readiness spine: `GET /api/setup/readiness` (thin mapper over `diagnostics.ts`), `{ kind: 'setup' }` stage at `#/setup`, `setupCompletedAt`, boot-splash gate. Later waves get their own plans once Wave 0 pins the shared types.

Carries three rounds of adversarial review (spec design, subagent-execution readiness, pre-merge consistency).

## Test plan

Doc-only (`docs/superpowers/**`) — CI verify fast-path applies. No code changes; no automated tests. Wave 0's tests land when the plan is executed.

Refs #474.

🤖 Generated with [Claude Code](https://claude.com/claude-code)