### PR TITLE
feat(server,frontend): fs-19 completion — unified analysis-failure taxonomy

### DIFF
--- a/docs/features/173-failure-taxonomy.md
+++ b/docs/features/173-failure-taxonomy.md
@@ -31,6 +31,9 @@ owner: null
 2. `describeSynthesisError` keeps returning `{ errorReason, fatal }`; `errorReason === classifyFailure(...).userMessage`.
 3. Unknown errors never throw and never mark `fatal:true`.
 4. Engine-gating: a local-engine failure is never blamed on Gemini.
+5. Analysis-side signatures are `source: 'analysis'` — the generation scan never
+   sees them and its match ORDER is byte-identical to the pre-split table.
+6. `failure-remediations.ts` imports nothing (the frontend bundles it directly).
 
 ## Test plan
 
@@ -39,4 +42,10 @@ owner: null
 
 ## Ship notes
 
-Shipped on `feat/server-generation-quality` (integration round 2026-06-03), commit `affa489`. Closes #469. Automated server + frontend coverage green via `npm run verify`. **Owed:** live acceptance across ≥2 distinct real failure modes. Analysis-path classification was deferred (analysis failures use a separate `analysis.failedChapterIds` mechanism with no `generationError` writer) — see PR notes.
+Shipped on `feat/server-generation-quality` (integration round 2026-06-03), commit `affa489`. Closes #469. Automated server + frontend coverage green via `npm run verify`. **Owed:** live acceptance across ≥2 distinct real failure modes. Analysis-path classification shipped in the fe-29/fs-19 completion round
+(spec `docs/superpowers/specs/2026-06-12-help-troubleshooting-fs19-completion-design.md`):
+the run-level describeError() unified into `classifyAnalysisFailure` (old codes
+truncated/daily_quota/rate_limit/unavailable/internal/invalid_key/bad_request →
+FailureCode), per-chapter cast failures + the stage-2 coverage-suspect path now
+persist `failedChapterErrors` records, and the analysing view renders
+message + remediation live and after reload.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4911,3 +4911,16 @@ components:
             failedChapterIds:
               type: array
               items: { type: integer }
+            failedChapterErrors:
+              type: object
+              description: |
+                fs-19 (analysis half) — per-chapter classified failure, keyed by
+                chapterId as a string. Lets the analysing view show the real
+                message + remediation after a reload instead of a generic line.
+              additionalProperties:
+                type: object
+                required: [code, message, remediation]
+                properties:
+                  code: { $ref: '#/components/schemas/FailureCode' }
+                  message: { type: string }
+                  remediation: { type: string }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4345,6 +4345,11 @@ components:
         - cuda-poisoned
         - auth
         - unknown
+        - recycle-storm
+        - analyzer-daily-quota
+        - analyzer-truncated
+        - analyzer-unreachable
+        - attribution-incomplete
 
     ChapterQaVerdict:
       type: object

--- a/server/src/routes/analysis.test.ts
+++ b/server/src/routes/analysis.test.ts
@@ -8,6 +8,7 @@ import {
   projectRemainingMs,
   buildInterimCast,
   clearFailedChapterId,
+  recordFailedChapter,
   dropEvidencelessCast,
   isPhase0aCoverageComplete,
   reconcileSentenceCharacterIds,
@@ -784,6 +785,35 @@ describe('clearFailedChapterId — recovery detection helper', () => {
     expect(clearFailedChapterId(cache, 44)).toBe(true);
     expect(clearFailedChapterId(cache, 44)).toBe(false);
     expect(cache.failedChapterIds).toEqual([]);
+  });
+});
+
+describe('failedChapterErrors records (spec A4)', () => {
+  it('recordFailedChapter writes id + error record', () => {
+    const cache: {
+      failedChapterIds?: number[];
+      failedChapterErrors?: Record<string, { code: string; message: string; remediation: string }>;
+    } = {};
+    recordFailedChapter(cache, 7, {
+      code: 'analyzer-unreachable',
+      userMessage: 'msg',
+      remediation: 'fix',
+    });
+    expect(cache.failedChapterIds).toEqual([7]);
+    expect(cache.failedChapterErrors?.['7']).toEqual({
+      code: 'analyzer-unreachable',
+      message: 'msg',
+      remediation: 'fix',
+    });
+  });
+  it('clearFailedChapterId clears the record alongside the id', () => {
+    const cache = {
+      failedChapterIds: [7],
+      failedChapterErrors: { '7': { code: 'unknown', message: 'm', remediation: 'r' } },
+    };
+    expect(clearFailedChapterId(cache, 7)).toBe(true);
+    expect(cache.failedChapterIds).toEqual([]);
+    expect(cache.failedChapterErrors['7']).toBeUndefined();
   });
 });
 

--- a/server/src/routes/analysis.test.ts
+++ b/server/src/routes/analysis.test.ts
@@ -16,6 +16,7 @@ import {
   stage1ShrinkRefused,
   buildStage1ChapterInbox,
   readPriorCastForMerge,
+  trackForReplay,
 } from './analysis.js';
 import type { CharacterOutput, SentenceOutput } from '../handoff/schemas.js';
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
@@ -814,6 +815,37 @@ describe('failedChapterErrors records (spec A4)', () => {
     expect(clearFailedChapterId(cache, 7)).toBe(true);
     expect(cache.failedChapterIds).toEqual([]);
     expect(cache.failedChapterErrors['7']).toBeUndefined();
+  });
+});
+
+describe('chapter-failed replay map (spec A4 — reconnect carries code/remediation)', () => {
+  function makeJob() {
+    return {
+      replay: { failedByChapterId: new Map(), logs: [] },
+    } as unknown as Parameters<typeof trackForReplay>[0];
+  }
+  it('stores code + remediation off a chapter-failed event', () => {
+    const job = makeJob();
+    trackForReplay(job, {
+      kind: 'chapter-failed',
+      chapterId: 3,
+      message: 'analyzer down',
+      code: 'analyzer-unreachable',
+      remediation: 'start ollama',
+    });
+    expect((job as { replay: { failedByChapterId: Map<number, unknown> } }).replay.failedByChapterId.get(3)).toEqual({
+      kind: 'chapter-failed',
+      chapterId: 3,
+      message: 'analyzer down',
+      code: 'analyzer-unreachable',
+      remediation: 'start ollama',
+    });
+  });
+  it('chapter-resolved drops the entry', () => {
+    const job = makeJob();
+    trackForReplay(job, { kind: 'chapter-failed', chapterId: 3, message: 'm' });
+    trackForReplay(job, { kind: 'chapter-resolved', chapterId: 3 });
+    expect((job as { replay: { failedByChapterId: Map<number, unknown> } }).replay.failedByChapterId.size).toBe(0);
   });
 });
 

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -44,6 +44,7 @@ import {
   loadAnalysisCache,
   saveAnalysisCache,
   type AnalysisCache,
+  type ChapterErrorRecord,
 } from '../store/analysis-cache.js';
 import {
   deleteAnalysisState,
@@ -781,7 +782,7 @@ function clampEst(ms: number): number {
 export function clearFailedChapterId(
   cache: {
     failedChapterIds?: number[];
-    failedChapterErrors?: Record<string, { code: string; message: string; remediation: string }>;
+    failedChapterErrors?: Record<string, ChapterErrorRecord>;
   },
   chapterId: number,
 ): boolean {
@@ -799,7 +800,7 @@ export function clearFailedChapterId(
 export function recordFailedChapter(
   cache: {
     failedChapterIds?: number[];
-    failedChapterErrors?: Record<string, { code: string; message: string; remediation: string }>;
+    failedChapterErrors?: Record<string, ChapterErrorRecord>;
   },
   chapterId: number,
   classified: { code: string; userMessage: string; remediation: string },
@@ -807,13 +808,11 @@ export function recordFailedChapter(
   const failedSet = new Set(cache.failedChapterIds ?? []);
   failedSet.add(chapterId);
   cache.failedChapterIds = Array.from(failedSet);
-  cache.failedChapterErrors = {
-    ...cache.failedChapterErrors,
-    [String(chapterId)]: {
-      code: classified.code,
-      message: classified.userMessage,
-      remediation: classified.remediation,
-    },
+  if (!cache.failedChapterErrors) cache.failedChapterErrors = {};
+  cache.failedChapterErrors[String(chapterId)] = {
+    code: classified.code,
+    message: classified.userMessage,
+    remediation: classified.remediation,
   };
 }
 

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -4487,4 +4487,5 @@ async function runSubsetAnalyzerJob(
 
 /* describeError, formatErrorDetail, trimQuotaMessage, tryParseApiError, and
    classifyStatus have been moved to failure-taxonomy.ts (classifyAnalysisFailure
-   / tryParseApiError exported). Call sites above now use classifyAnalysisFailure. */
+   / tryParseApiError exported). Call sites above now use classifyAnalysisFailure.
+   Note: classifyStatus was renamed statusToFailureCode (private) in its new home. */

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -1572,7 +1572,8 @@ function broadcastToJob(job: AnalysisJob, payload: unknown): void {
   }
 }
 
-function trackForReplay(job: AnalysisJob, payload: unknown): void {
+/* Exported for unit testing (the chapter-failed replay contract). */
+export function trackForReplay(job: AnalysisJob, payload: unknown): void {
   if (!payload || typeof payload !== 'object') return;
   const ev = payload as { kind?: string };
   switch (ev.kind) {

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -21,7 +21,6 @@ import {
   type PhaseWatermark,
 } from '../analyzer/phase-watermark.js';
 import { AnalysisAbortedError } from '../analyzer/ollama.js';
-import { DailyQuotaExhaustedError } from '../analyzer/rate-limit.js';
 import { foldMinorCast } from '../analyzer/fold-minor-cast.js';
 import { recoverTaggedNarratorLines } from '../analyzer/recover-tagged-lines.js';
 import {
@@ -29,7 +28,6 @@ import {
   resolveStage2ChunkCharBudget,
   type Stage2ChunkRunResult,
 } from '../analyzer/stage2-chunk.js';
-import { AnalyzerTruncatedError } from '../analyzer/errors.js';
 import {
   runStage1WithRosterGuard,
   validateRosterCoverage,
@@ -97,6 +95,7 @@ import {
   type DroppedQuotesBatch,
 } from '../store/dropped-quotes.js';
 import { configValue } from '../config/resolver.js';
+import { classifyAnalysisFailure, tryParseApiError } from './failure-taxonomy.js';
 
 /* srv-13 — the existing cast's voice/reuse fields to overlay onto a fresh
    analysis roster. Prefer cast.json; when it's absent (a reparse just deleted
@@ -3601,8 +3600,8 @@ export async function runMainAnalyzerJob(
       message: (e as Error)?.message,
       details: parsedLog?.details,
     });
-    const { code, message, detail } = describeError(e, analyzerLabel);
-    endJob(job, { kind: 'error', code, message, detail });
+    const { code, userMessage: message, remediation, detail } = classifyAnalysisFailure(e, analyzerLabel);
+    endJob(job, { kind: 'error', code, message, remediation, detail });
   }
 }
 
@@ -4474,7 +4473,7 @@ async function runSubsetAnalyzerJob(
       });
       return;
     }
-    const { code, message, detail } = describeError(e, analyzerLabel);
+    const { code, userMessage: message, remediation, detail } = classifyAnalysisFailure(e, analyzerLabel);
     console.error('[analysis-subset] failed', {
       manuscriptId,
       code,
@@ -4482,146 +4481,10 @@ async function runSubsetAnalyzerJob(
       lastStep,
       stack: (e as Error)?.stack,
     });
-    endJob(job, { kind: 'error', code, message, detail });
+    endJob(job, { kind: 'error', code, message, remediation, detail });
   }
 }
 
-/* The Gemini SDK throws `ApiError` instances whose `.message` is the raw
-   JSON envelope (e.g. `{"error":{"code":503,"message":"...","status":"...","details":[...]}}`).
-   Surface a friendly, copy-pasteable line for the UI plus a short `code` the
-   client can switch on (rate_limit | unavailable | internal | invalid_key |
-   network | unknown), and a structured `detail` string the UI can show in a
-   collapsible block — preserves the upstream details[] array which usually
-   names the field/quota that triggered the failure. */
-function describeError(
-  err: unknown,
-  modelLabel: string,
-): { code: string; message: string; detail?: string } {
-  /* Output truncation (#528) — the chapter's per-sentence JSON exceeded the
-     model's output cap. The stage-2 chunker splits over-budget chapters
-     automatically, so reaching here means even an adaptively-split section
-     (or a single un-splittable paragraph) still truncated. Classify it
-     distinctly so the UI says "too large" rather than a generic failure. */
-  if (err instanceof AnalyzerTruncatedError) {
-    return {
-      code: 'truncated',
-      message: `${modelLabel} truncated the response (${err.reason}) — a chapter section is too large for one attribution call. Lower STAGE2_CHUNK_CHAR_BUDGET and retry.`,
-      detail: `engine=${err.engine} reason=${err.reason} bytes=${err.receivedBytes}${
-        err.outputTokens ? ` tokens=${err.outputTokens}` : ''
-      }`,
-    };
-  }
-
-  /* The limiter throws DailyQuotaExhaustedError when our own RPD counter
-     OR a Google daily-quota 429 trips. Route layer must classify these
-     uniformly so the UI shows a single "switch model or wait until N"
-     message regardless of which path detected it. */
-  if (err instanceof DailyQuotaExhaustedError) {
-    return {
-      code: 'daily_quota',
-      message: `${modelLabel} daily quota exhausted — resets at ${err.resetAt.toISOString()}.`,
-      detail: `resetAt: ${err.resetAt.toISOString()}`,
-    };
-  }
-  const raw = (err as Error)?.message ?? String(err);
-  const status = (err as { status?: number })?.status;
-
-  const parsed = tryParseApiError(raw);
-  if (parsed) {
-    const code = classifyStatus(parsed.code ?? status, parsed.message);
-    /* Only trim quota messages — 4xx/5xx bodies are usually short and
-       informative (an INVALID_ARGUMENT body names the failed field), so
-       trimming them throws away the only useful diagnostic. */
-    const trimmed =
-      code === 'rate_limit' || code === 'daily_quota'
-        ? trimQuotaMessage(parsed.message)
-        : parsed.message;
-    const statusSuffix = parsed.status ? ` (${parsed.status})` : '';
-    const detail = formatErrorDetail(parsed, raw);
-    return {
-      code,
-      message: `${modelLabel} returned ${parsed.code ?? status ?? '???'}${statusSuffix}: ${trimmed}`,
-      detail,
-    };
-  }
-
-  if (status) {
-    return {
-      code: classifyStatus(status, raw),
-      message: `${modelLabel} returned ${status}: ${raw}`,
-    };
-  }
-  return { code: 'unknown', message: raw || 'Analysis failed.' };
-}
-
-/* Build the detail blob shown in the UI's collapsible. Prefer the
-   structured details[] from the upstream envelope; fall back to the raw
-   error body so debugging never has to round-trip to the server log. */
-function formatErrorDetail(
-  parsed: { status?: string; details?: unknown[] },
-  raw: string,
-): string | undefined {
-  const lines: string[] = [];
-  if (parsed.status) lines.push(`status: ${parsed.status}`);
-  if (parsed.details && parsed.details.length > 0) {
-    lines.push('details:');
-    lines.push(JSON.stringify(parsed.details, null, 2));
-  }
-  if (lines.length === 0) {
-    /* No structured details — fall back to the raw SDK message, trimmed.
-       Useful when the error wasn't a Google API envelope (e.g. network). */
-    const trimmed = raw.length > 1500 ? `${raw.slice(0, 1500)}…` : raw;
-    return trimmed.trim() || undefined;
-  }
-  return lines.join('\n');
-}
-
-/* Google's 429 body is wall-of-text — strip everything after the first
-   sentence so the UI alert stays tractable. The full text still lives in
-   the server console (and the `detail` blob) for debugging. */
-function trimQuotaMessage(message: string): string {
-  const firstStop = message.search(/[.\n]/);
-  if (firstStop > 0 && firstStop < 240) return message.slice(0, firstStop + 1).trim();
-  return message.slice(0, 240) + (message.length > 240 ? '…' : '');
-}
-
-function tryParseApiError(
-  raw: string,
-): { code?: number; message: string; status?: string; details?: unknown[] } | null {
-  /* SDK messages often look like 'got status: 503 UNAVAILABLE. {"error":{...}}'.
-     Find the first '{' and try to parse from there. */
-  const start = raw.indexOf('{');
-  if (start < 0) return null;
-  try {
-    const obj = JSON.parse(raw.slice(start)) as {
-      error?: { code?: number; message?: string; status?: string; details?: unknown[] };
-    };
-    if (obj?.error?.message) {
-      return {
-        code: obj.error.code,
-        message: obj.error.message,
-        status: obj.error.status,
-        details: obj.error.details,
-      };
-    }
-  } catch {
-    return null;
-  }
-  return null;
-}
-
-function classifyStatus(status: number | undefined, message?: string): string {
-  if (!status) return 'unknown';
-  if (status === 429) {
-    /* Distinguish per-day "free tier exhausted" from short-term per-minute
-       throttling — the user-facing remedies differ (switch model / wait
-       until quota reset vs. just retry). */
-    if (message && /free[_-]?tier|quotaValue":"\d{1,3}"/i.test(message)) return 'daily_quota';
-    return 'rate_limit';
-  }
-  if (status === 503) return 'unavailable';
-  if (status === 500) return 'internal';
-  if (status === 401 || status === 403) return 'invalid_key';
-  if (status === 400) return 'bad_request';
-  return 'unknown';
-}
+/* describeError, formatErrorDetail, trimQuotaMessage, tryParseApiError, and
+   classifyStatus have been moved to failure-taxonomy.ts (classifyAnalysisFailure
+   / tryParseApiError exported). Call sites above now use classifyAnalysisFailure. */

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -95,7 +95,7 @@ import {
   type DroppedQuotesBatch,
 } from '../store/dropped-quotes.js';
 import { configValue } from '../config/resolver.js';
-import { classifyAnalysisFailure, tryParseApiError } from './failure-taxonomy.js';
+import { classifyAnalysisFailure, tryParseApiError, FAILURE_REMEDIATIONS } from './failure-taxonomy.js';
 
 /* srv-13 — the existing cast's voice/reuse fields to overlay onto a fresh
    analysis roster. Prefer cast.json; when it's absent (a reparse just deleted
@@ -779,14 +779,42 @@ function clampEst(ms: number): number {
    for the same id is a no-op and returns false. Exported for unit
    testing. */
 export function clearFailedChapterId(
-  cache: { failedChapterIds?: number[] },
+  cache: {
+    failedChapterIds?: number[];
+    failedChapterErrors?: Record<string, { code: string; message: string; remediation: string }>;
+  },
   chapterId: number,
 ): boolean {
   const wasFailed = cache.failedChapterIds?.includes(chapterId) === true;
   if (wasFailed) {
     cache.failedChapterIds = cache.failedChapterIds!.filter((id) => id !== chapterId);
+    if (cache.failedChapterErrors) delete cache.failedChapterErrors[String(chapterId)];
   }
   return wasFailed;
+}
+
+/* fs-19 (analysis half) — promote a classified per-chapter failure to durable
+   cache state: the id keeps driving the Retry list; the record carries the
+   structured code/message/remediation for the post-reload display. */
+export function recordFailedChapter(
+  cache: {
+    failedChapterIds?: number[];
+    failedChapterErrors?: Record<string, { code: string; message: string; remediation: string }>;
+  },
+  chapterId: number,
+  classified: { code: string; userMessage: string; remediation: string },
+): void {
+  const failedSet = new Set(cache.failedChapterIds ?? []);
+  failedSet.add(chapterId);
+  cache.failedChapterIds = Array.from(failedSet);
+  cache.failedChapterErrors = {
+    ...cache.failedChapterErrors,
+    [String(chapterId)]: {
+      code: classified.code,
+      message: classified.userMessage,
+      remediation: classified.remediation,
+    },
+  };
 }
 
 /* Phase 0a coverage check — every non-excluded chapter must have a
@@ -1353,7 +1381,7 @@ export interface AnalysisJobReplayState {
   /** Active failed-chapter records, keyed by chapterId. chapter-failed
       adds entries; chapter-resolved removes them. Replayed so a
       reconnecting client sees the right set of Retry rows. */
-  failedByChapterId: Map<number, { kind: 'chapter-failed'; chapterId: number; message: string }>;
+  failedByChapterId: Map<number, { kind: 'chapter-failed'; chapterId: number; message: string; code?: string; remediation?: string }>;
   /** One-shot series-cast prior event emitted at Phase 0 entry. Cached
       here so a subscriber that attaches AFTER Phase 0 entry receives
       the carry-over surface in its catch-up replay (otherwise the
@@ -1565,12 +1593,14 @@ function trackForReplay(job: AnalysisJob, payload: unknown): void {
       job.replay.lastCastUpdate = ev as AnalysisJobReplayState['lastCastUpdate'];
       break;
     case 'chapter-failed': {
-      const e = ev as { chapterId?: number; message?: string };
+      const e = ev as { chapterId?: number; message?: string; code?: string; remediation?: string };
       if (typeof e.chapterId === 'number' && typeof e.message === 'string') {
         job.replay.failedByChapterId.set(e.chapterId, {
           kind: 'chapter-failed',
           chapterId: e.chapterId,
           message: e.message,
+          code: e.code,
+          remediation: e.remediation,
         });
       }
       break;
@@ -2550,16 +2580,16 @@ export async function runMainAnalyzerJob(
              skips it and the cache key is taken. */
           chapterCast[ch.id] = [];
           cache.chapterCast = chapterCast;
-          /* Promote the failure to durable cache state so the analysing
-             view can surface a per-chapter Retry button after reload.
-             The set is in-memory only; without this, the failed-id list
-             disappears the moment the SSE ends. Dedup via Set so a
-             second-chance retry inside the same run doesn't double up. */
-          const failedSet = new Set(cache.failedChapterIds ?? []);
-          failedSet.add(ch.id);
-          cache.failedChapterIds = Array.from(failedSet);
+          const classified = classifyAnalysisFailure(chErr, analyzerLabel);
+          recordFailedChapter(cache, ch.id, classified);
           await saveAnalysisCache(manuscriptId, cache);
-          send({ kind: 'chapter-failed', chapterId: ch.id, message: (chErr as Error).message });
+          send({
+            kind: 'chapter-failed',
+            chapterId: ch.id,
+            message: classified.userMessage,
+            code: classified.code,
+            remediation: classified.remediation,
+          });
           sendCastLiveTick();
           send({ kind: 'phase', phaseId: 0, progress: phase0Progress(), label: PHASES[0].label });
           return;
@@ -3205,9 +3235,19 @@ export async function runMainAnalyzerJob(
             coverageVerdict.issues[0] ?? 'low coverage'
           }); kept the best take and flagged the chapter for retry.`,
         );
-        const failedSet = new Set(cache.failedChapterIds ?? []);
-        failedSet.add(ch.id);
-        cache.failedChapterIds = Array.from(failedSet);
+        const copy = FAILURE_REMEDIATIONS['attribution-incomplete'];
+        recordFailedChapter(cache, ch.id, {
+          code: 'attribution-incomplete',
+          userMessage: copy.userMessage,
+          remediation: copy.remediation,
+        });
+        send({
+          kind: 'chapter-failed',
+          chapterId: ch.id,
+          message: copy.userMessage,
+          code: 'attribution-incomplete',
+          remediation: copy.remediation,
+        });
       }
       for (const s of stage2Sentences) s.chapterId = ch.id;
       sentencesByChapter.set(ch.id, stage2Sentences);
@@ -4063,12 +4103,17 @@ async function runSubsetAnalyzerJob(
         if (chErr instanceof AnalysisAbortedError) throw chErr;
         chapterCast[ch.id] = [];
         cache.chapterCast = chapterCast;
-        const failedSet = new Set(cache.failedChapterIds ?? []);
-        failedSet.add(ch.id);
-        cache.failedChapterIds = Array.from(failedSet);
+        const classified = classifyAnalysisFailure(chErr, analyzerLabel);
+        recordFailedChapter(cache, ch.id, classified);
         await saveAnalysisCache(manuscriptId, cache);
         log(0, `❌ Chapter ${ch.id} cast FAILED — ${ch.title}: ${(chErr as Error).message}`);
-        send({ kind: 'chapter-failed', chapterId: ch.id, message: (chErr as Error).message });
+        send({
+          kind: 'chapter-failed',
+          chapterId: ch.id,
+          message: classified.userMessage,
+          code: classified.code,
+          remediation: classified.remediation,
+        });
         emitCastUpdate();
       }
       send({

--- a/server/src/routes/book-state.ts
+++ b/server/src/routes/book-state.ts
@@ -265,9 +265,11 @@ bookStateRouter.get('/:bookId/state', async (req: Request, res: Response) => {
        moment the user navigates away. Sourced from the analysis cache,
        populated in analysis.ts:913 (full route) and the subset route. */
     let failedChapterIds: number[] = [];
+    let failedChapterErrors: Record<string, { code: string; message: string; remediation: string }> = {};
     if (state.manuscriptId) {
       const cache = await loadAnalysisCache(state.manuscriptId);
       failedChapterIds = cache.failedChapterIds ?? [];
+      failedChapterErrors = cache.failedChapterErrors ?? {};
       const cachedSentences = Object.values(cache.chapters ?? {}).flat();
       if (edits && Array.isArray(edits.sentences) && edits.sentences.length > 0) {
         if (cachedSentences.length > 0) {
@@ -459,7 +461,7 @@ bookStateRouter.get('/:bookId/state', async (req: Request, res: Response) => {
       renderedFallbackByCharacter,
       renderedSpeakersByChapter,
       changeLog: changeLog?.events ?? null,
-      analysis: { failedChapterIds },
+      analysis: { failedChapterIds, failedChapterErrors },
     });
   } catch (e) {
     console.error('[book-state] GET failed', e);

--- a/server/src/routes/book-state.ts
+++ b/server/src/routes/book-state.ts
@@ -42,7 +42,7 @@ import {
   getOrHydrateManuscript,
   type ManuscriptRecord,
 } from '../store/manuscripts.js';
-import { clearAnalysisCache, loadAnalysisCache } from '../store/analysis-cache.js';
+import { clearAnalysisCache, loadAnalysisCache, type ChapterErrorRecord } from '../store/analysis-cache.js';
 import { readAnalysisState, type AnalysisStateFile } from '../store/analysis-state.js';
 import { loadDroppedQuotes } from '../store/dropped-quotes.js';
 import { parseManuscript } from '../parsers/index.js';
@@ -265,7 +265,7 @@ bookStateRouter.get('/:bookId/state', async (req: Request, res: Response) => {
        moment the user navigates away. Sourced from the analysis cache,
        populated in analysis.ts:913 (full route) and the subset route. */
     let failedChapterIds: number[] = [];
-    let failedChapterErrors: Record<string, { code: string; message: string; remediation: string }> = {};
+    let failedChapterErrors: Record<string, ChapterErrorRecord> = {};
     if (state.manuscriptId) {
       const cache = await loadAnalysisCache(state.manuscriptId);
       failedChapterIds = cache.failedChapterIds ?? [];

--- a/server/src/routes/failure-remediations.ts
+++ b/server/src/routes/failure-remediations.ts
@@ -65,6 +65,40 @@ export const FAILURE_REMEDIATIONS = {
       'Wait for the quota window to reset (Gemini free-tier resets daily), or switch to a local ' +
       'engine (Kokoro / Qwen) in the engine picker, then resume.',
   },
+  'analyzer-unreachable': {
+    userMessage:
+      'The analyzer could not be reached or stopped responding — the local Ollama daemon is down, ' +
+      'or the analyzer service returned a server error.',
+    remediation:
+      'Check that Ollama is running (ollama serve), or switch the analyzer in server/.env ' +
+      '(ANALYZER=gemini with a GEMINI_API_KEY). Then retry the chapter or resume the run.',
+    helpDetail:
+      'When GEMINI_API_KEY is set, an unreachable Ollama silently retries against Gemini, so this ' +
+      'error usually means no fallback was configured — or both engines failed.',
+  },
+  'analyzer-truncated': {
+    userMessage:
+      'The analyzer model cut its reply short — a chapter section was too large for one ' +
+      'attribution call, even after automatic re-splitting.',
+    remediation:
+      'Retry the chapter. If it recurs, lower STAGE2_CHUNK_CHAR_BUDGET in server/.env (or Advanced ' +
+      'Settings) or switch to a stronger analyzer model.',
+  },
+  'analyzer-daily-quota': {
+    userMessage: "The analyzer's free-tier daily quota is exhausted.",
+    remediation:
+      'Switch to a different analyzer model (GEMINI_MODEL in server/.env or Advanced Settings — ' +
+      'each model has its own daily bucket), use the local Ollama analyzer, or wait for the quota ' +
+      'reset shown in the error.',
+  },
+  'attribution-incomplete': {
+    userMessage:
+      "Some lines in this chapter may be unattributed — the analyzer's answer did not cover every " +
+      'sentence, so the best take was kept and the chapter was flagged.',
+    remediation:
+      'Click Retry on this chapter to re-run attribution. Already-attributed lines are kept; a ' +
+      'retry usually fills the gaps.',
+  },
   auth: {
     userMessage: 'Gemini TTS authentication failed — check GEMINI_API_KEY.',
     remediation:
@@ -97,6 +131,7 @@ export const FAILURE_REMEDIATIONS = {
       'green), then retry the chapter.',
   },
   unknown: {
+    /* Rendered by the Help view only — the live unknown path shows trimRaw(raw) instead. */
     userMessage:
       'Something failed in a way the app does not recognise — the raw error message is shown in place of this line.',
     remediation:

--- a/server/src/routes/failure-remediations.ts
+++ b/server/src/routes/failure-remediations.ts
@@ -1,0 +1,106 @@
+/* fs-19 / fe-29 — canonical failure copy, shared by the server taxonomy
+   (failure-taxonomy.ts pulls each signature's strings from here) and the
+   frontend Help view (src/views/help.tsx imports this file across the package
+   boundary; Vite bundles it statically so Help works offline).
+
+   RULES:
+   - Import NOTHING. This file must type-check identically under both the
+     server (NodeNext) and frontend (bundler) tsconfigs and must never pull
+     server-only code into the frontend bundle.
+   - Keys must exactly equal the FailureCode union in failure-taxonomy.ts and
+     the OpenAPI FailureCode enum — pinned by a test on the server side and a
+     `satisfies` check on the frontend side.
+   - `helpDetail` is OPTIONAL longer prose rendered only by the Help view. */
+
+export interface FailureRemediationCopy {
+  userMessage: string;
+  remediation: string;
+  helpDetail?: string;
+}
+
+export const FAILURE_REMEDIATIONS = {
+  'synth-timeout': {
+    userMessage:
+      'TTS synthesis timed out for this chapter — the local engine stalled (often the ' +
+      'sidecar reclaiming memory mid-render). Skipped so the queue advances; click Retry to re-render.',
+    remediation:
+      'Click Retry on this chapter. If it times out repeatedly, restart the TTS sidecar to clear ' +
+      'a wedged GPU state, then retry.',
+  },
+  'sidecar-unreachable': {
+    userMessage: 'Local TTS sidecar not running — start it and resume.',
+    remediation:
+      'Start the TTS sidecar (npm start launches it automatically), wait for the sidecar pill to ' +
+      'go green, then resume the run.',
+  },
+  'recycle-storm': {
+    userMessage: 'The TTS engine kept restarting while rendering this chapter.',
+    remediation:
+      'The sidecar is likely thrashing — the host-memory leak (side-11) or too little ' +
+      'VRAM/RAM headroom. Restart the TTS sidecar and/or lower generation concurrency, then Retry.',
+  },
+  'vram-spill': {
+    userMessage:
+      'The GPU ran out of video memory (VRAM) mid-render — too many models were resident at once.',
+    remediation:
+      'Unload any models you are not generating with (the analyzer Ollama, or a second TTS engine) ' +
+      'from the model pills, then retry. On an 8 GB card keep only one heavy TTS model loaded.',
+  },
+  oom: {
+    userMessage:
+      'The TTS sidecar was killed by the operating system — the machine ran out of host RAM.',
+    remediation:
+      'Close other memory-heavy apps and retry. If it recurs, the sidecar is leaking — restart it ' +
+      'to reset its host memory, then resume.',
+  },
+  'disk-full': {
+    userMessage: 'The workspace volume is out of disk space — the chapter audio could not be written.',
+    remediation:
+      'Free up disk space on the workspace volume (delete old exports, or move the workspace to a ' +
+      'larger drive), then retry the chapter.',
+  },
+  'analyzer-rate-limit': {
+    userMessage: 'Gemini TTS rate-limited — stopped run; resume later or switch to a local engine.',
+    remediation:
+      'Wait for the quota window to reset (Gemini free-tier resets daily), or switch to a local ' +
+      'engine (Kokoro / Qwen) in the engine picker, then resume.',
+  },
+  auth: {
+    userMessage: 'Gemini TTS authentication failed — check GEMINI_API_KEY.',
+    remediation:
+      'Verify GEMINI_API_KEY in server/.env is set and valid, restart the server, then retry.',
+  },
+  'xtts-speaker-desync': {
+    userMessage:
+      'Local TTS engine rejected a speaker — the voice catalog is out of sync with the loaded model. ' +
+      'Stop the sidecar, re-run the speaker manifest audit, and regenerate.',
+    remediation:
+      'Stop the TTS sidecar, re-run the speaker-manifest audit, then restart the sidecar and ' +
+      'regenerate this chapter.',
+  },
+  'cuda-poisoned': {
+    userMessage:
+      'Local TTS sidecar hit a CUDA error and is auto-restarting (the CUDA context is corrupted ' +
+      'process-wide; only a fresh Python process recovers). Wait ~10 seconds for the sidecar pill ' +
+      'to go green again, then click Retry on this chapter. The offending text is in the sidecar ' +
+      'log (text_preview=) — usually a stray zero-width or control char in the manuscript.',
+    remediation:
+      'Wait ~10 seconds for the sidecar to respawn (the pill goes green), then click Retry. If it ' +
+      'recurs on the same chapter, check the sidecar log text_preview= for a stray control char.',
+  },
+  'model-not-loaded': {
+    userMessage:
+      'The TTS model is not loaded in the sidecar yet — synthesis was requested before the model ' +
+      'finished loading.',
+    remediation:
+      'Load the engine from its model pill (or wait for the auto-load to finish — the pill turns ' +
+      'green), then retry the chapter.',
+  },
+  unknown: {
+    userMessage:
+      'Something failed in a way the app does not recognise — the raw error message is shown in place of this line.',
+    remediation:
+      'Click Retry on this chapter. If it keeps failing, check the server / sidecar logs for the full ' +
+      'error and report it.',
+  },
+} as const satisfies Record<string, FailureRemediationCopy>;

--- a/server/src/routes/failure-taxonomy.test.ts
+++ b/server/src/routes/failure-taxonomy.test.ts
@@ -4,7 +4,8 @@
    unmapped string) and asserts the stable `code`, a jargon-free `userMessage`,
    a non-empty `remediation`, and the legacy `fatal`. These pin the incident-
    tuned regexes the classifier ports from the old ad-hoc describeSynthesisError
-   so a refactor can't silently regress them. */
+   so a refactor can't silently regress them. The file also covers the
+   analysis-side classifiers (classifyAnalysisError + classifyAnalysisFailure). */
 
 import { describe, it, expect } from 'vitest';
 import { classifyFailure, classifyAnalysisError, classifyAnalysisFailure } from './failure-taxonomy.js';

--- a/server/src/routes/failure-taxonomy.test.ts
+++ b/server/src/routes/failure-taxonomy.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { classifyFailure } from './failure-taxonomy.js';
+import { FAILURE_REMEDIATIONS } from './failure-remediations.js';
 
 /* No copy should leak raw stack/jargon at the user — assert the message reads
    like a sentence (starts uppercase, ends with punctuation, no "Traceback"
@@ -207,5 +208,32 @@ describe('classifyFailure', () => {
     expect(out.code).toBe('unknown');
     expect(out.userMessage.length).toBeLessThanOrEqual(241);
     expect(out.userMessage.endsWith('…')).toBe(true);
+  });
+});
+
+describe('failure-remediations copy module (fe-29/fs-19 shared copy)', () => {
+  it('has exactly one entry per FailureCode', () => {
+    expect(Object.keys(FAILURE_REMEDIATIONS).sort()).toEqual(
+      [
+        'analyzer-rate-limit',
+        'auth',
+        'cuda-poisoned',
+        'disk-full',
+        'model-not-loaded',
+        'oom',
+        'recycle-storm',
+        'sidecar-unreachable',
+        'synth-timeout',
+        'unknown',
+        'vram-spill',
+        'xtts-speaker-desync',
+      ].sort(),
+    );
+  });
+  it('every entry has non-empty userMessage and remediation', () => {
+    for (const [code, copy] of Object.entries(FAILURE_REMEDIATIONS)) {
+      expect(copy.userMessage.length, code).toBeGreaterThan(0);
+      expect(copy.remediation.length, code).toBeGreaterThan(0);
+    }
   });
 });

--- a/server/src/routes/failure-taxonomy.test.ts
+++ b/server/src/routes/failure-taxonomy.test.ts
@@ -229,11 +229,46 @@ describe('source gating (spec A2)', () => {
   });
 });
 
+describe('analysis-side codes (spec A2)', () => {
+  it('classifies AnalyzerTruncatedError by name', () => {
+    const err = Object.assign(new Error('gemini truncated the response'), {
+      name: 'AnalyzerTruncatedError',
+    });
+    expect(classifyAnalysisError(err).code).toBe('analyzer-truncated');
+  });
+  it('classifies DailyQuotaExhaustedError by name, before the rate-limit signature', () => {
+    const err = Object.assign(new Error('daily quota exhausted — resets later'), {
+      name: 'DailyQuotaExhaustedError',
+    });
+    expect(classifyAnalysisError(err).code).toBe('analyzer-daily-quota');
+  });
+  it('classifies an unreachable analyzer (connection refused) as analyzer-unreachable', () => {
+    expect(
+      classifyAnalysisError(new Error('connect ECONNREFUSED 127.0.0.1:11434')).code,
+    ).toBe('analyzer-unreachable');
+  });
+  it('classifies GeminiStreamIdleError (retry-exhausted) as analyzer-unreachable', () => {
+    const err = Object.assign(new Error('stream idle'), { name: 'GeminiStreamIdleError' });
+    expect(classifyAnalysisError(err).code).toBe('analyzer-unreachable');
+  });
+  it('generation path never sees the analysis-only entries', () => {
+    const err = Object.assign(new Error('whatever'), { name: 'AnalyzerTruncatedError' });
+    expect(classifyFailure(err).code).toBe('unknown');
+  });
+  it('attribution-incomplete has copy (synthetic code, no signature)', () => {
+    expect(FAILURE_REMEDIATIONS['attribution-incomplete'].remediation.length).toBeGreaterThan(0);
+  });
+});
+
 describe('failure-remediations copy module (fe-29/fs-19 shared copy)', () => {
   it('has exactly one entry per FailureCode', () => {
     expect(Object.keys(FAILURE_REMEDIATIONS).sort()).toEqual(
       [
+        'analyzer-daily-quota',
         'analyzer-rate-limit',
+        'analyzer-truncated',
+        'analyzer-unreachable',
+        'attribution-incomplete',
         'auth',
         'cuda-poisoned',
         'disk-full',

--- a/server/src/routes/failure-taxonomy.test.ts
+++ b/server/src/routes/failure-taxonomy.test.ts
@@ -312,7 +312,7 @@ describe('classifyAnalysisFailure (run-level, ports describeError verbatim — s
   });
   it('Google envelope 429 free-tier → analyzer-daily-quota with trimmed message', () => {
     const raw =
-      'got status: 429. {"error":{"code":429,"message":"You exceeded your current quota. Free tier limit, please check. More text that should be trimmed away entirely.","status":"RESOURCE_EXHAUSTED","details":[{"quotaValue":"250"}]}}';
+      'got status: 429. {"error":{"code":429,"message":"You exceeded your current quota: generate_requests_per_model_per_day_free_tier. Please check your plan and billing details. More text that should be trimmed away entirely.","status":"RESOURCE_EXHAUSTED","details":[{"quotaValue":"250"}]}}';
     const r = classifyAnalysisFailure(new Error(raw), 'Gemini (gemma-4-31b-it)');
     expect(r.code).toBe('analyzer-daily-quota');
     expect(r.userMessage).toContain('429');

--- a/server/src/routes/failure-taxonomy.test.ts
+++ b/server/src/routes/failure-taxonomy.test.ts
@@ -7,7 +7,7 @@
    so a refactor can't silently regress them. */
 
 import { describe, it, expect } from 'vitest';
-import { classifyFailure } from './failure-taxonomy.js';
+import { classifyFailure, classifyAnalysisError } from './failure-taxonomy.js';
 import { FAILURE_REMEDIATIONS } from './failure-remediations.js';
 
 /* No copy should leak raw stack/jargon at the user — assert the message reads
@@ -208,6 +208,24 @@ describe('classifyFailure', () => {
     expect(out.code).toBe('unknown');
     expect(out.userMessage.length).toBeLessThanOrEqual(241);
     expect(out.userMessage.endsWith('…')).toBe(true);
+  });
+});
+
+describe('source gating (spec A2)', () => {
+  it('classifyFailure (generation) still matches sidecar-unreachable on ECONNREFUSED', () => {
+    const r = classifyFailure(new Error('connect ECONNREFUSED 127.0.0.1:8001'));
+    expect(r.code).toBe('sidecar-unreachable');
+  });
+  it('classifyAnalysisError never blames the sidecar for an analysis failure', () => {
+    const r = classifyAnalysisError(new Error('connect ECONNREFUSED 127.0.0.1:11434'));
+    expect(r.code).not.toBe('sidecar-unreachable');
+  });
+  it('analysis path still sees the both-gated quota signature', () => {
+    const err = Object.assign(new Error('429 Too Many Requests: quota exceeded'), { status: 429 });
+    expect(classifyAnalysisError(err).code).toBe('analyzer-rate-limit');
+  });
+  it('analysis path still sees the both-gated disk-full signature', () => {
+    expect(classifyAnalysisError(new Error('ENOSPC: no space left on device')).code).toBe('disk-full');
   });
 });
 

--- a/server/src/routes/failure-taxonomy.test.ts
+++ b/server/src/routes/failure-taxonomy.test.ts
@@ -7,8 +7,10 @@
    so a refactor can't silently regress them. */
 
 import { describe, it, expect } from 'vitest';
-import { classifyFailure, classifyAnalysisError } from './failure-taxonomy.js';
+import { classifyFailure, classifyAnalysisError, classifyAnalysisFailure } from './failure-taxonomy.js';
 import { FAILURE_REMEDIATIONS } from './failure-remediations.js';
+import { DailyQuotaExhaustedError } from '../analyzer/rate-limit.js';
+import { AnalyzerTruncatedError } from '../analyzer/errors.js';
 
 /* No copy should leak raw stack/jargon at the user — assert the message reads
    like a sentence (starts uppercase, ends with punctuation, no "Traceback"
@@ -288,5 +290,52 @@ describe('failure-remediations copy module (fe-29/fs-19 shared copy)', () => {
       expect(copy.userMessage.length, code).toBeGreaterThan(0);
       expect(copy.remediation.length, code).toBeGreaterThan(0);
     }
+  });
+});
+
+describe('classifyAnalysisFailure (run-level, ports describeError verbatim — spec A3)', () => {
+  it('AnalyzerTruncatedError → analyzer-truncated with dynamic message + structured detail', () => {
+    const err = new AnalyzerTruncatedError('gemini', 'MAX_TOKENS', 8192, 4096);
+    const r = classifyAnalysisFailure(err, 'Gemini (gemma-4-31b-it)');
+    expect(r.code).toBe('analyzer-truncated');
+    expect(r.userMessage).toContain('Gemini (gemma-4-31b-it)');
+    expect(r.userMessage).toContain('MAX_TOKENS');
+    expect(r.detail).toContain('engine=gemini');
+    expect(r.remediation.length).toBeGreaterThan(0);
+  });
+  it('DailyQuotaExhaustedError → analyzer-daily-quota preserving the reset time', () => {
+    const resetAt = new Date('2026-06-13T07:00:00Z');
+    const err = new DailyQuotaExhaustedError('gemma-4-31b-it', resetAt);
+    const r = classifyAnalysisFailure(err, 'Gemini (gemma-4-31b-it)');
+    expect(r.code).toBe('analyzer-daily-quota');
+    expect(r.userMessage).toContain('2026-06-13T07:00:00.000Z');
+  });
+  it('Google envelope 429 free-tier → analyzer-daily-quota with trimmed message', () => {
+    const raw =
+      'got status: 429. {"error":{"code":429,"message":"You exceeded your current quota. Free tier limit, please check. More text that should be trimmed away entirely.","status":"RESOURCE_EXHAUSTED","details":[{"quotaValue":"250"}]}}';
+    const r = classifyAnalysisFailure(new Error(raw), 'Gemini (gemma-4-31b-it)');
+    expect(r.code).toBe('analyzer-daily-quota');
+    expect(r.userMessage).toContain('429');
+    expect(r.detail).toContain('RESOURCE_EXHAUSTED');
+  });
+  it('envelope 503 → analyzer-unreachable; 401 → auth; 400 → unknown', () => {
+    const env = (code: number, status: string) =>
+      new Error(`got status: ${code}. {"error":{"code":${code},"message":"boom","status":"${status}"}}`);
+    expect(classifyAnalysisFailure(env(503, 'UNAVAILABLE'), 'm').code).toBe('analyzer-unreachable');
+    expect(classifyAnalysisFailure(env(401, 'UNAUTHENTICATED'), 'm').code).toBe('auth');
+    expect(classifyAnalysisFailure(env(400, 'INVALID_ARGUMENT'), 'm').code).toBe('unknown');
+  });
+  it('bare status (no envelope) classifies too', () => {
+    const err = Object.assign(new Error('Service Unavailable'), { status: 503 });
+    expect(classifyAnalysisFailure(err, 'm').code).toBe('analyzer-unreachable');
+  });
+  it('non-envelope plain error falls through to the analysis table scan', () => {
+    const r = classifyAnalysisFailure(new Error('connect ECONNREFUSED 127.0.0.1:11434'), 'Ollama');
+    expect(r.code).toBe('analyzer-unreachable');
+  });
+  it('unmapped error → unknown with raw message preserved', () => {
+    const r = classifyAnalysisFailure(new Error('some novel failure'), 'm');
+    expect(r.code).toBe('unknown');
+    expect(r.userMessage).toContain('some novel failure');
   });
 });

--- a/server/src/routes/failure-taxonomy.ts
+++ b/server/src/routes/failure-taxonomy.ts
@@ -15,6 +15,9 @@
    `describeSynthesisError` now delegates here and maps back to its legacy
    `{ errorReason, fatal }` shape so existing callers keep working. */
 
+import { FAILURE_REMEDIATIONS } from './failure-remediations.js';
+export { FAILURE_REMEDIATIONS, type FailureRemediationCopy } from './failure-remediations.js';
+
 export type FailureCode =
   | 'vram-spill'
   | 'recycle-storm'
@@ -29,6 +32,12 @@ export type FailureCode =
   | 'auth'
   | 'unknown';
 
+/* Compile-time pin: every FailureCode has copy. (The reverse — no extra keys —
+   is asserted by the key-parity test in failure-taxonomy.test.ts.) */
+const _copyComplete: Record<FailureCode, { userMessage: string; remediation: string }> =
+  FAILURE_REMEDIATIONS;
+void _copyComplete;
+
 export interface FailureContext {
   status?: number;
   name?: string;
@@ -40,8 +49,6 @@ export interface FailureSignature {
   fatal: boolean;
   /** First match wins — order in FAILURE_SIGNATURES is significant. */
   match: (raw: string, ctx: FailureContext) => boolean;
-  userMessage: string;
-  remediation: string;
 }
 
 export interface ClassifiedFailure {
@@ -66,21 +73,11 @@ export const FAILURE_SIGNATURES: FailureSignature[] = [
     code: 'synth-timeout',
     fatal: false,
     match: (_raw, ctx) => ctx.name === 'ChapterSynthTimeoutError',
-    userMessage:
-      'TTS synthesis timed out for this chapter — the local engine stalled (often the ' +
-      'sidecar reclaiming memory mid-render). Skipped so the queue advances; click Retry to re-render.',
-    remediation:
-      'Click Retry on this chapter. If it times out repeatedly, restart the TTS sidecar to clear ' +
-      'a wedged GPU state, then retry.',
   },
   {
     code: 'sidecar-unreachable',
     fatal: true,
     match: (raw) => /sidecar not reachable|ECONNREFUSED|fetch failed/i.test(raw),
-    userMessage: 'Local TTS sidecar not running — start it and resume.',
-    remediation:
-      'Start the TTS sidecar (npm start launches it automatically), wait for the sidecar pill to ' +
-      'go green, then resume the run.',
   },
   /* C3 (Wave 3) — the named recycle-storm signal from synthesise-chapter.ts
      (`RecycleStormError`): the sidecar recycled/respawned more times than the
@@ -99,10 +96,6 @@ export const FAILURE_SIGNATURES: FailureSignature[] = [
     fatal: false,
     match: (raw, ctx) =>
       ctx.name === 'RecycleStormError' || /recycled \d+× while rendering/.test(raw),
-    userMessage: 'The TTS engine kept restarting while rendering this chapter.',
-    remediation:
-      'The sidecar is likely thrashing — the host-memory leak (side-11) or too little ' +
-      'VRAM/RAM headroom. Restart the TTS sidecar and/or lower generation concurrency, then Retry.',
   },
   /* CUDA out-of-memory — the GPU allocator itself refused. Distinct from the
      host-RAM OOM kill below. Comes BEFORE the cuda-poisoned check because an
@@ -112,11 +105,6 @@ export const FAILURE_SIGNATURES: FailureSignature[] = [
     code: 'vram-spill',
     fatal: true,
     match: (raw) => /CUDA out of memory|VRAM/i.test(raw),
-    userMessage:
-      'The GPU ran out of video memory (VRAM) mid-render — too many models were resident at once.',
-    remediation:
-      'Unload any models you are not generating with (the analyzer Ollama, or a second TTS engine) ' +
-      'from the model pills, then retry. On an 8 GB card keep only one heavy TTS model loaded.',
   },
   /* Host-process OOM kill — the OS killed the sidecar (exit 137 / SIGKILL).
      Matched on the kill signal, NOT on the word "memory" (which would collide
@@ -125,20 +113,11 @@ export const FAILURE_SIGNATURES: FailureSignature[] = [
     code: 'oom',
     fatal: true,
     match: (raw) => /\bkilled\b|exit code 137|SIGKILL|out of memory: killed/i.test(raw),
-    userMessage:
-      'The TTS sidecar was killed by the operating system — the machine ran out of host RAM.',
-    remediation:
-      'Close other memory-heavy apps and retry. If it recurs, the sidecar is leaking — restart it ' +
-      'to reset its host memory, then resume.',
   },
   {
     code: 'disk-full',
     fatal: true,
     match: (raw) => /ENOSPC|no space left/i.test(raw),
-    userMessage: 'The workspace volume is out of disk space — the chapter audio could not be written.',
-    remediation:
-      'Free up disk space on the workspace volume (delete old exports, or move the workspace to a ' +
-      'larger drive), then retry the chapter.',
   },
   /* Upstream rate-limit / quota. STRICT match — a real HTTP 429 or an
      unambiguous quota phrase. The bare token "rate" is NOT enough (it matches
@@ -166,45 +145,24 @@ export const FAILURE_SIGNATURES: FailureSignature[] = [
       const localEngine = ctx.engine != null && ctx.engine !== 'gemini';
       return isHttp429 || !localEngine;
     },
-    userMessage: 'Gemini TTS rate-limited — stopped run; resume later or switch to a local engine.',
-    remediation:
-      'Wait for the quota window to reset (Gemini free-tier resets daily), or switch to a local ' +
-      'engine (Kokoro / Qwen) in the engine picker, then resume.',
   },
   {
     code: 'auth',
     fatal: true,
     match: (raw, ctx) =>
       ctx.status === 401 || ctx.status === 403 || /invalid[_ ]?key|API key/i.test(raw),
-    userMessage: 'Gemini TTS authentication failed — check GEMINI_API_KEY.',
-    remediation:
-      'Verify GEMINI_API_KEY in server/.env is set and valid, restart the server, then retry.',
   },
   {
     code: 'xtts-speaker-desync',
     fatal: true,
     match: (raw) =>
       /index out of range in self|IndexError|out of range \(expected to be in range/i.test(raw),
-    userMessage:
-      'Local TTS engine rejected a speaker — the voice catalog is out of sync with the loaded model. ' +
-      'Stop the sidecar, re-run the speaker manifest audit, and regenerate.',
-    remediation:
-      'Stop the TTS sidecar, re-run the speaker-manifest audit, then restart the sidecar and ' +
-      'regenerate this chapter.',
   },
   {
     code: 'cuda-poisoned',
     fatal: true,
     match: (raw) =>
       /device-side assert|CUDA error|CUDA kernel errors|"poisoned":\s*true/i.test(raw),
-    userMessage:
-      'Local TTS sidecar hit a CUDA error and is auto-restarting (the CUDA context is corrupted ' +
-      'process-wide; only a fresh Python process recovers). Wait ~10 seconds for the sidecar pill ' +
-      'to go green again, then click Retry on this chapter. The offending text is in the sidecar ' +
-      'log (text_preview=) — usually a stray zero-width or control char in the manuscript.',
-    remediation:
-      'Wait ~10 seconds for the sidecar to respawn (the pill goes green), then click Retry. If it ' +
-      'recurs on the same chapter, check the sidecar log text_preview= for a stray control char.',
   },
   /* Placed LAST among the specific signatures: "model not loaded" / a 503 while
      loading. After the sidecar-unreachable check (a down sidecar is the more
@@ -213,18 +171,8 @@ export const FAILURE_SIGNATURES: FailureSignature[] = [
     code: 'model-not-loaded',
     fatal: true,
     match: (raw) => /model not loaded|503.*loading|loading.*model/i.test(raw),
-    userMessage:
-      'The TTS model is not loaded in the sidecar yet — synthesis was requested before the model ' +
-      'finished loading.',
-    remediation:
-      'Load the engine from its model pill (or wait for the auto-load to finish — the pill turns ' +
-      'green), then retry the chapter.',
   },
 ];
-
-const UNKNOWN_REMEDIATION =
-  'Click Retry on this chapter. If it keeps failing, check the server / sidecar logs for the full ' +
-  'error and report it.';
 
 function rawOf(err: unknown): string {
   return (err as Error)?.message ?? String(err);
@@ -249,10 +197,11 @@ export function classifyFailure(err: unknown, engine?: string): ClassifiedFailur
   };
   for (const sig of FAILURE_SIGNATURES) {
     if (sig.match(raw, ctx)) {
+      const copy = FAILURE_REMEDIATIONS[sig.code];
       return {
         code: sig.code,
-        userMessage: sig.userMessage,
-        remediation: sig.remediation,
+        userMessage: copy.userMessage,
+        remediation: copy.remediation,
         fatal: sig.fatal,
         raw,
       };
@@ -261,7 +210,7 @@ export function classifyFailure(err: unknown, engine?: string): ClassifiedFailur
   return {
     code: 'unknown',
     userMessage: trimRaw(raw),
-    remediation: UNKNOWN_REMEDIATION,
+    remediation: FAILURE_REMEDIATIONS.unknown.remediation,
     fatal: false,
     raw,
   };

--- a/server/src/routes/failure-taxonomy.ts
+++ b/server/src/routes/failure-taxonomy.ts
@@ -17,6 +17,8 @@
 
 import { FAILURE_REMEDIATIONS } from './failure-remediations.js';
 export { FAILURE_REMEDIATIONS, type FailureRemediationCopy } from './failure-remediations.js';
+import { DailyQuotaExhaustedError } from '../analyzer/rate-limit.js';
+import { AnalyzerTruncatedError } from '../analyzer/errors.js';
 
 export type FailureCode =
   | 'vram-spill'
@@ -298,4 +300,146 @@ export function classifyAnalysisError(err: unknown): ClassifiedFailure {
     fatal: false,
     raw,
   };
+}
+
+/* ── Run-level analysis classifier — ported from analysis.ts describeError ── */
+
+export interface AnalysisFailure {
+  code: FailureCode;
+  userMessage: string;
+  remediation: string;
+  detail?: string;
+}
+
+/* Build the detail blob shown in the UI's collapsible. Prefer the
+   structured details[] from the upstream envelope; fall back to the raw
+   error body so debugging never has to round-trip to the server log. */
+function formatErrorDetail(
+  parsed: { status?: string; details?: unknown[] },
+  raw: string,
+): string | undefined {
+  const lines: string[] = [];
+  if (parsed.status) lines.push(`status: ${parsed.status}`);
+  if (parsed.details && parsed.details.length > 0) {
+    lines.push('details:');
+    lines.push(JSON.stringify(parsed.details, null, 2));
+  }
+  if (lines.length === 0) {
+    /* No structured details — fall back to the raw SDK message, trimmed.
+       Useful when the error wasn't a Google API envelope (e.g. network). */
+    const trimmed = raw.length > 1500 ? `${raw.slice(0, 1500)}…` : raw;
+    return trimmed.trim() || undefined;
+  }
+  return lines.join('\n');
+}
+
+/* Google's 429 body is wall-of-text — strip everything after the first
+   sentence so the UI alert stays tractable. The full text still lives in
+   the server console (and the `detail` blob) for debugging. */
+function trimQuotaMessage(message: string): string {
+  const firstStop = message.search(/[.\n]/);
+  if (firstStop > 0 && firstStop < 240) return message.slice(0, firstStop + 1).trim();
+  return message.slice(0, 240) + (message.length > 240 ? '…' : '');
+}
+
+export function tryParseApiError(
+  raw: string,
+): { code?: number; message: string; status?: string; details?: unknown[] } | null {
+  /* SDK messages often look like 'got status: 503 UNAVAILABLE. {"error":{...}}'.
+     Find the first '{' and try to parse from there. */
+  const start = raw.indexOf('{');
+  if (start < 0) return null;
+  try {
+    const obj = JSON.parse(raw.slice(start)) as {
+      error?: { code?: number; message?: string; status?: string; details?: unknown[] };
+    };
+    if (obj?.error?.message) {
+      return {
+        code: obj.error.code,
+        message: obj.error.message,
+        status: obj.error.status,
+        details: obj.error.details,
+      };
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+/* classifyStatus, ported from analysis.ts — now emits FailureCode per the
+   spec-A2 mapping (rate_limit→analyzer-rate-limit, daily_quota→analyzer-daily-quota,
+   unavailable/internal→analyzer-unreachable, invalid_key→auth, bad_request→unknown). */
+function statusToFailureCode(status: number | undefined, message?: string): FailureCode {
+  if (!status) return 'unknown';
+  if (status === 429) {
+    if (message && /free[_-]?tier|quotaValue":"\d{1,3}"/i.test(message)) return 'analyzer-daily-quota';
+    return 'analyzer-rate-limit';
+  }
+  if (status === 503 || status === 500) return 'analyzer-unreachable';
+  if (status === 401 || status === 403) return 'auth';
+  return 'unknown';
+}
+
+function withCopy(code: FailureCode, userMessage: string, detail?: string): AnalysisFailure {
+  return { code, userMessage, remediation: FAILURE_REMEDIATIONS[code].remediation, detail };
+}
+
+/** Run-level analysis classifier — the unified replacement for analysis.ts's
+    describeError(). Typed-error checks and the Google-envelope/status parsing
+    are PORTED VERBATIM (same precedence, same message construction: model
+    label, status suffix, quota trimming, detail blob); only the code
+    vocabulary changes to FailureCode and a remediation is attached. Plain
+    unmatched errors additionally fall through to the analysis signature scan
+    (so ECONNREFUSED etc. classify here too). */
+export function classifyAnalysisFailure(err: unknown, modelLabel: string): AnalysisFailure {
+  if (err instanceof AnalyzerTruncatedError) {
+    return withCopy(
+      'analyzer-truncated',
+      `${modelLabel} truncated the response (${err.reason}) — a chapter section is too large for one attribution call. Lower STAGE2_CHUNK_CHAR_BUDGET and retry.`,
+      `engine=${err.engine} reason=${err.reason} bytes=${err.receivedBytes}${
+        err.outputTokens ? ` tokens=${err.outputTokens}` : ''
+      }`,
+    );
+  }
+  if (err instanceof DailyQuotaExhaustedError) {
+    return withCopy(
+      'analyzer-daily-quota',
+      `${modelLabel} daily quota exhausted — resets at ${err.resetAt.toISOString()}.`,
+      `resetAt: ${err.resetAt.toISOString()}`,
+    );
+  }
+  const raw = (err as Error)?.message ?? String(err);
+  const status = (err as { status?: number })?.status;
+
+  const parsed = tryParseApiError(raw);
+  if (parsed) {
+    /* Pass the full raw string to the quota check so `quotaValue` in the
+       details[] array (not just the extracted message) triggers daily-quota
+       detection. The parsed.message is used for display trimming only. */
+    const code = statusToFailureCode(parsed.code ?? status, raw);
+    /* Only trim quota messages — 4xx/5xx bodies are usually short and
+       informative (an INVALID_ARGUMENT body names the failed field), so
+       trimming them throws away the only useful diagnostic. */
+    const trimmed =
+      code === 'analyzer-rate-limit' || code === 'analyzer-daily-quota'
+        ? trimQuotaMessage(parsed.message)
+        : parsed.message;
+    const statusSuffix = parsed.status ? ` (${parsed.status})` : '';
+    return withCopy(
+      code,
+      `${modelLabel} returned ${parsed.code ?? status ?? '???'}${statusSuffix}: ${trimmed}`,
+      formatErrorDetail(parsed, raw),
+    );
+  }
+  if (status) {
+    return withCopy(statusToFailureCode(status, raw), `${modelLabel} returned ${status}: ${raw}`);
+  }
+  /* Not an API envelope — give the signature table a chance (catches the
+     connection-refused / fetch-failed family) before the unknown fallback. */
+  const scanned = classifyAnalysisError(err);
+  if (scanned.code !== 'unknown') {
+    return { code: scanned.code, userMessage: scanned.userMessage, remediation: scanned.remediation };
+  }
+  return withCopy('unknown', raw || 'Analysis failed.');
 }

--- a/server/src/routes/failure-taxonomy.ts
+++ b/server/src/routes/failure-taxonomy.ts
@@ -23,6 +23,10 @@ export type FailureCode =
   | 'recycle-storm'
   | 'sidecar-unreachable'
   | 'analyzer-rate-limit'
+  | 'analyzer-daily-quota'
+  | 'analyzer-truncated'
+  | 'analyzer-unreachable'
+  | 'attribution-incomplete'
   | 'oom'
   | 'disk-full'
   | 'model-not-loaded'
@@ -77,6 +81,35 @@ export interface ClassifiedFailure {
    contains "dege·nerate", whose "rate" substring used to match the quota regex
    and stop the whole run (2026-05-31). Pinning it first keeps that locked. */
 export const FAILURE_SIGNATURES: FailureSignature[] = [
+  /* ---- analysis-only entries (source-gated; invisible to classifyFailure).
+     Name-driven first: typed analyzer errors survive message rewording.
+     analyzer-daily-quota MUST precede the 'both' analyzer-rate-limit entry —
+     a daily-quota 429 would otherwise classify as a plain rate-limit. ---- */
+  {
+    code: 'analyzer-truncated',
+    fatal: false,
+    source: 'analysis',
+    matchName: 'AnalyzerTruncatedError',
+    match: () => false,
+  },
+  {
+    code: 'analyzer-daily-quota',
+    fatal: true,
+    source: 'analysis',
+    matchName: 'DailyQuotaExhaustedError',
+    match: (raw, ctx) =>
+      ctx.status === 429 && /free[_-]?tier|quotaValue":"\d{1,3}"/i.test(raw),
+  },
+  {
+    code: 'analyzer-unreachable',
+    fatal: true,
+    source: 'analysis',
+    matchName: 'GeminiStreamIdleError',
+    match: (raw, ctx) =>
+      ctx.status === 503 ||
+      ctx.status === 500 ||
+      /ECONNREFUSED|fetch failed|EAI_AGAIN|socket hang up/i.test(raw),
+  },
   {
     code: 'synth-timeout',
     fatal: false,

--- a/server/src/routes/failure-taxonomy.ts
+++ b/server/src/routes/failure-taxonomy.ts
@@ -44,10 +44,18 @@ export interface FailureContext {
   engine?: string;
 }
 
+export type FailureSource = 'generation' | 'analysis' | 'both';
+
 export interface FailureSignature {
   code: FailureCode;
   fatal: boolean;
-  /** First match wins — order in FAILURE_SIGNATURES is significant. */
+  /** Which classification path may match this signature. Generation keeps its
+      exact historical order/sequence (plan 154); analysis-only entries are
+      invisible to classifyFailure and vice versa. */
+  source: FailureSource;
+  /** Optional typed-error matcher, tested against err.name BEFORE the regex —
+      survives message rewording. */
+  matchName?: string;
   match: (raw: string, ctx: FailureContext) => boolean;
 }
 
@@ -72,11 +80,13 @@ export const FAILURE_SIGNATURES: FailureSignature[] = [
   {
     code: 'synth-timeout',
     fatal: false,
+    source: 'generation',
     match: (_raw, ctx) => ctx.name === 'ChapterSynthTimeoutError',
   },
   {
     code: 'sidecar-unreachable',
     fatal: true,
+    source: 'generation',
     match: (raw) => /sidecar not reachable|ECONNREFUSED|fetch failed/i.test(raw),
   },
   /* C3 (Wave 3) — the named recycle-storm signal from synthesise-chapter.ts
@@ -94,6 +104,7 @@ export const FAILURE_SIGNATURES: FailureSignature[] = [
   {
     code: 'recycle-storm',
     fatal: false,
+    source: 'generation',
     match: (raw, ctx) =>
       ctx.name === 'RecycleStormError' || /recycled \d+× while rendering/.test(raw),
   },
@@ -104,6 +115,7 @@ export const FAILURE_SIGNATURES: FailureSignature[] = [
   {
     code: 'vram-spill',
     fatal: true,
+    source: 'generation',
     match: (raw) => /CUDA out of memory|VRAM/i.test(raw),
   },
   /* Host-process OOM kill — the OS killed the sidecar (exit 137 / SIGKILL).
@@ -112,11 +124,13 @@ export const FAILURE_SIGNATURES: FailureSignature[] = [
   {
     code: 'oom',
     fatal: true,
+    source: 'generation',
     match: (raw) => /\bkilled\b|exit code 137|SIGKILL|out of memory: killed/i.test(raw),
   },
   {
     code: 'disk-full',
     fatal: true,
+    source: 'both',
     match: (raw) => /ENOSPC|no space left/i.test(raw),
   },
   /* Upstream rate-limit / quota. STRICT match — a real HTTP 429 or an
@@ -131,6 +145,7 @@ export const FAILURE_SIGNATURES: FailureSignature[] = [
   {
     code: 'analyzer-rate-limit',
     fatal: true,
+    source: 'both',
     match: (raw, ctx) => {
       const isHttp429 = ctx.status === 429;
       const looksRateLimited =
@@ -149,18 +164,21 @@ export const FAILURE_SIGNATURES: FailureSignature[] = [
   {
     code: 'auth',
     fatal: true,
+    source: 'both',
     match: (raw, ctx) =>
       ctx.status === 401 || ctx.status === 403 || /invalid[_ ]?key|API key/i.test(raw),
   },
   {
     code: 'xtts-speaker-desync',
     fatal: true,
+    source: 'generation',
     match: (raw) =>
       /index out of range in self|IndexError|out of range \(expected to be in range/i.test(raw),
   },
   {
     code: 'cuda-poisoned',
     fatal: true,
+    source: 'generation',
     match: (raw) =>
       /device-side assert|CUDA error|CUDA kernel errors|"poisoned":\s*true/i.test(raw),
   },
@@ -170,6 +188,7 @@ export const FAILURE_SIGNATURES: FailureSignature[] = [
   {
     code: 'model-not-loaded',
     fatal: true,
+    source: 'generation',
     match: (raw) => /model not loaded|503.*loading|loading.*model/i.test(raw),
   },
 ];
@@ -184,11 +203,11 @@ function trimRaw(raw: string): string {
   return raw.length > 240 ? `${raw.slice(0, 240)}…` : raw;
 }
 
-/** Classify a synthesis/analysis error into the structured taxonomy. First
-    matching signature wins; an unmapped error returns `code: 'unknown'` with
-    the (trimmed) raw message as `userMessage` and a generic remediation,
-    `fatal: false`. */
-export function classifyFailure(err: unknown, engine?: string): ClassifiedFailure {
+function scanSignatures(
+  err: unknown,
+  sources: ReadonlySet<FailureSource>,
+  engine?: string,
+): ClassifiedFailure | null {
   const raw = rawOf(err);
   const ctx: FailureContext = {
     status: (err as { status?: number })?.status,
@@ -196,7 +215,8 @@ export function classifyFailure(err: unknown, engine?: string): ClassifiedFailur
     engine,
   };
   for (const sig of FAILURE_SIGNATURES) {
-    if (sig.match(raw, ctx)) {
+    if (!sources.has(sig.source)) continue;
+    if ((sig.matchName != null && sig.matchName === ctx.name) || sig.match(raw, ctx)) {
       const copy = FAILURE_REMEDIATIONS[sig.code];
       return {
         code: sig.code,
@@ -207,6 +227,37 @@ export function classifyFailure(err: unknown, engine?: string): ClassifiedFailur
       };
     }
   }
+  return null;
+}
+
+const GENERATION_SOURCES: ReadonlySet<FailureSource> = new Set(['generation', 'both']);
+const ANALYSIS_SOURCES: ReadonlySet<FailureSource> = new Set(['analysis', 'both']);
+
+/** Classify a synthesis/analysis error into the structured taxonomy. First
+    matching signature wins; an unmapped error returns `code: 'unknown'` with
+    the (trimmed) raw message as `userMessage` and a generic remediation,
+    `fatal: false`. */
+export function classifyFailure(err: unknown, engine?: string): ClassifiedFailure {
+  const hit = scanSignatures(err, GENERATION_SOURCES, engine);
+  if (hit) return hit;
+  const raw = rawOf(err);
+  return {
+    code: 'unknown',
+    userMessage: trimRaw(raw),
+    remediation: FAILURE_REMEDIATIONS.unknown.remediation,
+    fatal: false,
+    raw,
+  };
+}
+
+/** Bare signature-table scan for the analysis path. Production callers use
+    classifyAnalysisFailure (added by a later task) — which layers the ported
+    describeError envelope parsing on top and falls back to this scan; exported
+    for that fallback and for direct unit tests. */
+export function classifyAnalysisError(err: unknown): ClassifiedFailure {
+  const hit = scanSignatures(err, ANALYSIS_SOURCES);
+  if (hit) return hit;
+  const raw = rawOf(err);
   return {
     code: 'unknown',
     userMessage: trimRaw(raw),

--- a/server/src/routes/failure-taxonomy.ts
+++ b/server/src/routes/failure-taxonomy.ts
@@ -414,10 +414,7 @@ export function classifyAnalysisFailure(err: unknown, modelLabel: string): Analy
 
   const parsed = tryParseApiError(raw);
   if (parsed) {
-    /* Pass the full raw string to the quota check so `quotaValue` in the
-       details[] array (not just the extracted message) triggers daily-quota
-       detection. The parsed.message is used for display trimming only. */
-    const code = statusToFailureCode(parsed.code ?? status, raw);
+    const code = statusToFailureCode(parsed.code ?? status, parsed.message);
     /* Only trim quota messages — 4xx/5xx bodies are usually short and
        informative (an INVALID_ARGUMENT body names the failed field), so
        trimming them throws away the only useful diagnostic. */

--- a/server/src/routes/failure-taxonomy.ts
+++ b/server/src/routes/failure-taxonomy.ts
@@ -13,7 +13,12 @@
    2026-05-31 KOTLC CH24, the CUDA poison-fence). Do not loosen them.
 
    `describeSynthesisError` now delegates here and maps back to its legacy
-   `{ errorReason, fatal }` shape so existing callers keep working. */
+   `{ errorReason, fatal }` shape so existing callers keep working.
+
+   The run-level analysis half (classifyAnalysisFailure + tryParseApiError,
+   statusToFailureCode, formatErrorDetail, trimQuotaMessage) is ported
+   VERBATIM from analysis.ts's describeError family — same envelope parsing,
+   same precedence, now unified into this module with FailureCode vocabulary. */
 
 import { FAILURE_REMEDIATIONS } from './failure-remediations.js';
 export { FAILURE_REMEDIATIONS, type FailureRemediationCopy } from './failure-remediations.js';
@@ -99,6 +104,8 @@ export const FAILURE_SIGNATURES: FailureSignature[] = [
     fatal: true,
     source: 'analysis',
     matchName: 'DailyQuotaExhaustedError',
+    /* Same free-tier regex as statusToFailureCode, but applied to the RAW string —
+       the two paths see different inputs; do not unify. */
     match: (raw, ctx) =>
       ctx.status === 429 && /free[_-]?tier|quotaValue":"\d{1,3}"/i.test(raw),
   },
@@ -373,6 +380,8 @@ export function tryParseApiError(
 function statusToFailureCode(status: number | undefined, message?: string): FailureCode {
   if (!status) return 'unknown';
   if (status === 429) {
+    /* Same regex as the analyzer-daily-quota signature, but applied to the parsed envelope MESSAGE
+       only (raw would false-positive on per-minute quotaValue details). Do not unify. */
     if (message && /free[_-]?tier|quotaValue":"\d{1,3}"/i.test(message)) return 'analyzer-daily-quota';
     return 'analyzer-rate-limit';
   }

--- a/server/src/store/analysis-cache.ts
+++ b/server/src/store/analysis-cache.ts
@@ -82,6 +82,12 @@ export interface AnalysisCache {
       genuinely had no cast" and surface a per-chapter retry affordance
       that survives reload. Subset re-runs remove the id on success. */
   failedChapterIds?: number[];
+  /** fs-19 (analysis half) — per-chapter structured failure record, keyed by
+      chapterId-as-string (JSON object keys). Additive sibling of
+      failedChapterIds: ids stay the durable retry list; this carries the
+      classified code + copy so the analysing view shows a real message +
+      remediation after reload instead of the generic fallback. */
+  failedChapterErrors?: Record<string, { code: string; message: string; remediation: string }>;
   updatedAt?: string;
 }
 
@@ -106,6 +112,7 @@ export async function loadAnalysisCache(manuscriptId: string): Promise<AnalysisC
     castDurations: cache.castDurations ?? undefined,
     stage2Durations: cache.stage2Durations ?? undefined,
     failedChapterIds: cache.failedChapterIds ?? undefined,
+    failedChapterErrors: cache.failedChapterErrors ?? undefined,
     updatedAt: cache.updatedAt,
   };
 }

--- a/server/src/store/analysis-cache.ts
+++ b/server/src/store/analysis-cache.ts
@@ -57,6 +57,14 @@ function seedEmotionsFromTags(chapters: Record<number, SentenceOutput[]>): Recor
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CACHE_DIR = resolve(__dirname, '..', '..', 'handoff', 'cache');
 
+/** fs-19 — one classified per-chapter analysis failure (message = the
+    jargon-free userMessage at classification time). */
+export interface ChapterErrorRecord {
+  code: string;
+  message: string;
+  remediation: string;
+}
+
 export interface AnalysisCache {
   /** Phase 0a — raw per-chapter character output keyed by chapterId. The
       route replays these in chapter-id order through the merge to rebuild
@@ -87,7 +95,7 @@ export interface AnalysisCache {
       failedChapterIds: ids stay the durable retry list; this carries the
       classified code + copy so the analysing view shows a real message +
       remediation after reload instead of the generic fallback. */
-  failedChapterErrors?: Record<string, { code: string; message: string; remediation: string }>;
+  failedChapterErrors?: Record<string, ChapterErrorRecord>;
   updatedAt?: string;
 }
 

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -3672,6 +3672,18 @@ export interface components {
             /** @description Persistent analysis state for the analysing view's per-chapter Retry buttons. */
             analysis?: {
                 failedChapterIds?: number[];
+                /**
+                 * @description fs-19 (analysis half) — per-chapter classified failure, keyed by
+                 *     chapterId as a string. Lets the analysing view show the real
+                 *     message + remediation after a reload instead of a generic line.
+                 */
+                failedChapterErrors?: {
+                    [key: string]: {
+                        code: components["schemas"]["FailureCode"];
+                        message: string;
+                        remediation: string;
+                    };
+                };
             };
         };
     };

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -3245,7 +3245,7 @@ export interface components {
          *     catch-all for an unmapped error (the raw message is surfaced verbatim).
          * @enum {string}
          */
-        FailureCode: "vram-spill" | "sidecar-unreachable" | "analyzer-rate-limit" | "oom" | "disk-full" | "model-not-loaded" | "synth-timeout" | "xtts-speaker-desync" | "cuda-poisoned" | "auth" | "unknown";
+        FailureCode: "vram-spill" | "sidecar-unreachable" | "analyzer-rate-limit" | "oom" | "disk-full" | "model-not-loaded" | "synth-timeout" | "xtts-speaker-desync" | "cuda-poisoned" | "auth" | "unknown" | "recycle-storm" | "analyzer-daily-quota" | "analyzer-truncated" | "analyzer-unreachable" | "attribution-incomplete";
         /**
          * @description srv-27 — advisory post-synthesis audio QA verdict for a rendered
          *     chapter. ADVISORY only: a `suspect` status drives a badge but never

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -168,7 +168,7 @@ export interface AnalyseOpts {
       persisted to the analysis cache so the analysing view can render a
       per-chapter Retry button. Emitted by both the full and subset
       analysis routes. */
-  onChapterFailed?: (e: { chapterId: number; message: string }) => void;
+  onChapterFailed?: (e: { chapterId: number; message: string; code?: string; remediation?: string }) => void;
   /** A previously-failed chapter just had its Phase 0a re-run succeed
       (either via the main route re-queueing failedChapterIds on resume,
       or via the subset retry route). The chapter id has been cleared
@@ -2025,6 +2025,7 @@ interface AnalysisStreamEvent {
   response?: AnalyseResponse;
   message?: string;
   code?: string;
+  remediation?: string;
   chapterId?: number;
   /** Structured upstream detail (Google's `status` + `details[]` for ApiError
       envelopes; falls back to the raw SDK message). Rendered in a collapsible
@@ -2070,12 +2071,17 @@ export class AnalysisError extends Error {
       "Accept smaller roster" button without parsing the message. */
   prevCharCount?: number;
   nextCharCount?: number;
+  /** Human-readable remediation hint from the server's FailureCode
+      classification — mirrors the `remediation` field on `kind:'error'`
+      SSE events and surfaces in the run-error panel. */
+  remediation?: string;
   constructor(
     message: string,
     code: string,
     detail?: string,
     prevCharCount?: number,
     nextCharCount?: number,
+    remediation?: string,
   ) {
     super(message);
     this.name = 'AnalysisError';
@@ -2083,6 +2089,7 @@ export class AnalysisError extends Error {
     this.detail = detail;
     this.prevCharCount = prevCharCount;
     this.nextCharCount = nextCharCount;
+    this.remediation = remediation;
   }
 }
 
@@ -2154,7 +2161,12 @@ async function realAnalyseManuscript(
       }
     } else if (payload.kind === 'chapter-failed') {
       if (typeof payload.chapterId === 'number' && typeof payload.message === 'string') {
-        onChapterFailed?.({ chapterId: payload.chapterId, message: payload.message });
+        onChapterFailed?.({
+          chapterId: payload.chapterId,
+          message: payload.message,
+          code: payload.code,
+          remediation: payload.remediation,
+        });
       }
     } else if (payload.kind === 'chapter-resolved') {
       if (typeof payload.chapterId === 'number') {
@@ -2195,6 +2207,7 @@ async function realAnalyseManuscript(
         payload.detail,
         payload.prevCharCount,
         payload.nextCharCount,
+        payload.remediation,
       );
     }
   };
@@ -3468,7 +3481,12 @@ async function realRunAnalysisForChapters(
       }
     } else if (payload.kind === 'chapter-failed') {
       if (typeof payload.chapterId === 'number' && typeof payload.message === 'string') {
-        onChapterFailed?.({ chapterId: payload.chapterId, message: payload.message });
+        onChapterFailed?.({
+          chapterId: payload.chapterId,
+          message: payload.message,
+          code: payload.code,
+          remediation: payload.remediation,
+        });
       }
     } else if (payload.kind === 'chapter-resolved') {
       if (typeof payload.chapterId === 'number') {
@@ -3509,6 +3527,7 @@ async function realRunAnalysisForChapters(
         payload.detail,
         payload.prevCharCount,
         payload.nextCharCount,
+        payload.remediation,
       );
     }
   };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -402,7 +402,7 @@ export interface BookStateResponse {
       the set of chapters whose Phase 0a cast detection threw across the
       analyzer's built-in retry — server-side they live in the analysis
       cache. */
-  analysis?: { failedChapterIds: number[] };
+  analysis?: { failedChapterIds: number[]; failedChapterErrors?: Record<string, { code: string; message: string; remediation: string }> };
 }
 
 /** Drop-reason enum mirrored from server/src/store/dropped-quotes.ts.

--- a/src/views/analysing.test.tsx
+++ b/src/views/analysing.test.tsx
@@ -1658,4 +1658,54 @@ describe('AnalysingView — fs-19 classified failure remediation', () => {
     ).toBeInTheDocument();
     expect(screen.queryByText(/What to do:/)).not.toBeInTheDocument();
   });
+
+  it('keeps failure classification (code + remediation) when a retried chapter re-fails', async () => {
+    /* Regression: handleRetryChapter's onChapterFailed only forwarded
+       `message`, dropping `code` and `remediation`, so the "What to do:"
+       line vanished after a retry that re-failed. */
+    getBookStateImpl = () =>
+      Promise.resolve(makeBookStateWithErrors([2], {}));
+
+    const store = configureStore({
+      reducer: {
+        ui: uiSlice.reducer,
+        cast: castSlice.reducer,
+        analysis: analysisSlice.reducer,
+        account: accountSlice.reducer,
+      },
+    });
+    render(
+      <Provider store={store}>
+        <AnalysingView
+          manuscriptId="m1"
+          bookId="b1"
+          title="Bonus Keefe Story"
+          wordCount={2440}
+          onComplete={() => {}}
+        />
+      </Provider>,
+    );
+
+    /* Click Retry on the hydrated row — this fires runAnalysisForChapters
+       and captures its opts in capturedSubsetCall. */
+    const retryBtn = await screen.findByRole('button', { name: /retry chapter/i });
+    await act(async () => {
+      fireEvent.click(retryBtn);
+    });
+    expect(capturedSubsetCall).toBeDefined();
+
+    /* The server re-emits chapter-failed with classification fields. */
+    await act(async () => {
+      capturedSubsetCall!.opts!.onChapterFailed!({
+        chapterId: 2,
+        message: 'The analyzer could not be reached…',
+        code: 'analyzer-unreachable',
+        remediation: 'Check that Ollama is running…',
+      });
+    });
+
+    /* The "What to do:" label and remediation text must still be visible. */
+    expect(await screen.findByText(/What to do:/)).toBeInTheDocument();
+    expect(screen.getByText(/Check that Ollama is running…/)).toBeInTheDocument();
+  });
 });

--- a/src/views/analysing.test.tsx
+++ b/src/views/analysing.test.tsx
@@ -1523,3 +1523,139 @@ describe('AnalysingView — Wave 2 brand manifesto', () => {
     expect(screen.getByText('Many voices, one machine.')).toBeInTheDocument();
   });
 });
+
+describe('AnalysingView — fs-19 classified failure remediation', () => {
+  function makeBookStateWithErrors(
+    failedIds: number[],
+    failedChapterErrors: Record<string, { code: string; message: string; remediation: string }>,
+  ): BookStateResponse {
+    return {
+      state: {
+        bookId: 'b1',
+        manuscriptId: 'm1',
+        title: 'Bonus Keefe Story',
+        author: '',
+        series: '',
+        seriesPosition: null,
+        isStandalone: true,
+        manuscriptFile: 'bonus-keefe.txt',
+        castConfirmed: false,
+        chapters: [
+          { id: 2, title: 'Chapter Two', slug: '2-chapter-two', duration: '0:00' },
+          { id: 3, title: 'Chapter Three', slug: '3-chapter-three', duration: '0:00' },
+          { id: 4, title: 'Chapter Four', slug: '4-chapter-four', duration: '0:00' },
+        ],
+        coverGradient: ['#000', '#fff'],
+        createdAt: '2026-05-15T00:00:00.000Z',
+        updatedAt: '2026-05-15T00:00:00.000Z',
+      },
+      cast: null,
+      manuscript: null,
+      manuscriptEdits: null,
+      revisions: null,
+      completedSlugs: [],
+      changeLog: null,
+      analysis: { failedChapterIds: failedIds, failedChapterErrors },
+    };
+  }
+
+  it('renders remediation from a live chapter-failed event (fs-19 analysis half)', async () => {
+    getBookStateImpl = () =>
+      Promise.resolve(makeBookStateWithErrors([], {}));
+
+    const store = configureStore({
+      reducer: {
+        ui: uiSlice.reducer,
+        cast: castSlice.reducer,
+        analysis: analysisSlice.reducer,
+        account: accountSlice.reducer,
+      },
+    });
+    render(
+      <Provider store={store}>
+        <AnalysingView
+          manuscriptId="m1"
+          bookId="b1"
+          title="Bonus Keefe Story"
+          wordCount={2440}
+          onComplete={() => {}}
+        />
+      </Provider>,
+    );
+
+    const startBtn = await screen.findByRole('button', { name: /start analysis/i });
+    await act(async () => {
+      fireEvent.click(startBtn);
+    });
+    await waitFor(() => expect(capturedOpts).toBeDefined());
+
+    await act(async () => {
+      capturedOpts!.onChapterFailed!({
+        chapterId: 2,
+        message: 'The analyzer could not be reached…',
+        code: 'analyzer-unreachable',
+        remediation: 'Check that Ollama is running…',
+      });
+    });
+
+    expect(await screen.findByText(/What to do:/)).toBeInTheDocument();
+    expect(screen.getByText(/Check that Ollama is running…/)).toBeInTheDocument();
+  });
+
+  it('hydrates remediation from book-state failedChapterErrors after reload', async () => {
+    getBookStateImpl = () =>
+      Promise.resolve(
+        makeBookStateWithErrors([3], {
+          '3': {
+            code: 'attribution-incomplete',
+            message: 'Some lines may be unattributed…',
+            remediation: 'Click Retry…',
+          },
+        }),
+      );
+
+    const store = configureStore({
+      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer },
+    });
+    render(
+      <Provider store={store}>
+        <AnalysingView
+          manuscriptId="m1"
+          bookId="b1"
+          title="Bonus Keefe Story"
+          wordCount={2440}
+          onComplete={() => {}}
+        />
+      </Provider>,
+    );
+
+    expect(await screen.findByText(/Some lines may be unattributed…/)).toBeInTheDocument();
+    expect(screen.getByText(/What to do:/)).toBeInTheDocument();
+    expect(screen.getByText(/Click Retry…/)).toBeInTheDocument();
+  });
+
+  it('keeps the legacy generic line when no record exists', async () => {
+    getBookStateImpl = () =>
+      Promise.resolve(makeBookStateWithErrors([4], {}));
+
+    const store = configureStore({
+      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer },
+    });
+    render(
+      <Provider store={store}>
+        <AnalysingView
+          manuscriptId="m1"
+          bookId="b1"
+          title="Bonus Keefe Story"
+          wordCount={2440}
+          onComplete={() => {}}
+        />
+      </Provider>,
+    );
+
+    expect(
+      await screen.findByText(/failed on a previous attempt/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/What to do:/)).not.toBeInTheDocument();
+  });
+});

--- a/src/views/analysing.tsx
+++ b/src/views/analysing.tsx
@@ -114,7 +114,7 @@ export function AnalysingView({
   const [phase, setPhase] = useState(0);
   const [phaseProgress, setPhaseProgress] = useState(0);
   const [logs, setLogs] = useState<Record<number, string[]>>({});
-  const [error, setError] = useState<{ message: string; code: string; detail?: string } | null>(
+  const [error, setError] = useState<{ message: string; code: string; detail?: string; remediation?: string } | null>(
     null,
   );
   const [retry, setRetry] = useState<{
@@ -163,7 +163,7 @@ export function AnalysingView({
      from /api/books/:bookId/state on mount; appended to from the SSE's
      chapter-failed event; cleared per id when a Retry succeeds. */
   const [failedChapters, setFailedChapters] = useState<
-    Array<{ chapterId: number; message: string }>
+    Array<{ chapterId: number; message: string; code?: string; remediation?: string }>
   >([]);
   const [retryingChapterId, setRetryingChapterId] = useState<number | null>(null);
   /* Bump to refetch the dropped-quotes ledger. Goes up when the server
@@ -424,7 +424,7 @@ export function AnalysingView({
                by id, preserving locked voices on existing entries. */
             dispatch(castActions.mergeCharacters(characters));
           },
-          onChapterFailed: ({ chapterId, message }) => {
+          onChapterFailed: ({ chapterId, message, code, remediation }) => {
             if (cancelled) return;
             markEvent();
             /* Upsert by chapterId so a retry of the same chapter (which
@@ -432,7 +432,7 @@ export function AnalysingView({
                the row. */
             setFailedChapters((prev) => {
               const filtered = prev.filter((f) => f.chapterId !== chapterId);
-              return [...filtered, { chapterId, message }];
+              return [...filtered, { chapterId, message, code, remediation }];
             });
           },
           onChapterResolved: ({ chapterId }) => {
@@ -516,6 +516,7 @@ export function AnalysingView({
         setConn('error');
         const code = e instanceof AnalysisError ? e.code : 'unknown';
         const detail = e instanceof AnalysisError ? e.detail : undefined;
+        const remediation = e instanceof AnalysisError ? e.remediation : undefined;
         dispatch(
           analysisActions.setHalted({
             manuscriptId,
@@ -523,7 +524,7 @@ export function AnalysingView({
             message: (e as Error)?.message ?? 'Analysis failed.',
           }),
         );
-        setError({ message: (e as Error).message || 'Analysis failed.', code, detail });
+        setError({ message: (e as Error).message || 'Analysis failed.', code, detail, remediation });
       }
     })();
     return () => {
@@ -564,16 +565,21 @@ export function AnalysingView({
         setChapterTitleById(titles);
         const failedIds = res.analysis?.failedChapterIds ?? [];
         if (failedIds.length === 0) return;
+        const errorById = res.analysis?.failedChapterErrors ?? {};
         setFailedChapters((prev) => {
           /* Merge with whatever the SSE already pushed during this session
              so we don't clobber a fresh chapter-failed event whose
              message is more useful than the hydration placeholder. */
-          const messageById = new Map(prev.map((f) => [f.chapterId, f.message]));
-          return failedIds.map((id) => ({
-            chapterId: id,
-            message:
-              messageById.get(id) ?? 'Analysis failed on a previous attempt. Retry to try again.',
-          }));
+          const liveById = new Map(prev.map((f) => [f.chapterId, f]));
+          return failedIds.map((id) => {
+            const live = liveById.get(id);
+            if (live) return live;
+            const record = errorById[String(id)];
+            if (record) {
+              return { chapterId: id, message: record.message, code: record.code, remediation: record.remediation };
+            }
+            return { chapterId: id, message: 'Analysis failed on a previous attempt. Retry to try again.' };
+          });
         });
       })
       .catch((err) => {
@@ -1126,11 +1132,16 @@ export function AnalysingView({
           {error && (
             <div className="mt-6 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-left">
               <p className="text-sm font-semibold text-red-900">
-                {error.code === 'daily_quota'
+                {(error.code === 'daily_quota' || error.code === 'analyzer-daily-quota')
                   ? 'Daily free-tier quota exhausted'
                   : 'Analysis failed'}
               </p>
               <p className="mt-1 text-sm text-red-800 wrap-break-word">{error.message}</p>
+              {error.remediation && (
+                <p className="mt-1 text-sm text-red-800/90 wrap-break-word">
+                  <span className="font-semibold">What to do:</span> {error.remediation}
+                </p>
+              )}
               {error.detail && (
                 <details className="mt-2 text-xs text-red-800/90">
                   <summary className="cursor-pointer font-medium hover:text-red-900">
@@ -1141,7 +1152,7 @@ export function AnalysingView({
                   </pre>
                 </details>
               )}
-              {error.code === 'daily_quota' && (
+              {(error.code === 'daily_quota' || error.code === 'analyzer-daily-quota') && (
                 <p className="mt-2 text-xs text-red-800/90">
                   Each Gemini model has its own 20-requests-per-day free-tier bucket. Try switching
                   to <span className="font-semibold">Gemini 3.1 Flash Lite</span> below, or wait for
@@ -1315,6 +1326,11 @@ export function AnalysingView({
                         {title}
                       </p>
                       <p className="mt-0.5 text-xs text-ink/60 wrap-break-word">{f.message}</p>
+                      {f.remediation && (
+                        <p className="mt-1 text-xs text-amber-900/90 wrap-break-word">
+                          <span className="font-semibold">What to do:</span> {f.remediation}
+                        </p>
+                      )}
                     </div>
                     <button
                       type="button"

--- a/src/views/analysing.tsx
+++ b/src/views/analysing.tsx
@@ -718,12 +718,12 @@ export function AnalysingView({
           markEvent();
           dispatch(castActions.mergeCharacters(characters));
         },
-        onChapterFailed: ({ chapterId: failedId, message }) => {
+        onChapterFailed: ({ chapterId: failedId, message, code, remediation }) => {
           markEvent();
           if (failedId === chapterId) retryReFailed = true;
           setFailedChapters((prev) => {
             const filtered = prev.filter((f) => f.chapterId !== failedId);
-            return [...filtered, { chapterId: failedId, message }];
+            return [...filtered, { chapterId: failedId, message, code, remediation }];
           });
         },
         onChapterResolved: ({ chapterId: resolvedId }) => {


### PR DESCRIPTION
## Summary
- Extracts fs-19 remediation copy into a shared, dependency-free `failure-remediations.ts` (consumed by the upcoming fe-29 Help view).
- Source-gates the signature table (`generation | analysis | both`) — generation match order untouched (plan 154).
- New codes: `analyzer-unreachable`, `analyzer-truncated`, `analyzer-daily-quota`, `attribution-incomplete`; also fixes the pre-existing `recycle-storm` OpenAPI enum drift.
- Unifies the run-level `describeError()` into `classifyAnalysisFailure` (FailureCode vocabulary + remediation on the run-error SSE; quota detection kept scoped to the parsed envelope message — verbatim port).
- Persists per-chapter `failedChapterErrors` (cast catches + the previously-silent stage-2 coverage-suspect path, which now also emits its `chapter-failed` tick); analysing view shows message + 'What to do:' live, after reload, and across subset retries.

Spec: docs/superpowers/specs/2026-06-12-help-troubleshooting-fs19-completion-design.md (PR 1 of 2). Refs #469.

## Test plan
- `failure-taxonomy.test.ts` (36): existing cases green VERBATIM + source-gating + new codes + ported describeError behaviours.
- `analysis.test.ts` (96): record/clear helpers + chapter-failed replay map carries code/remediation.
- `analysing.test.tsx` (50): live remediation, hydrated remediation, legacy fallback, retry re-failure keeps classification.
- `npm run verify` green locally (all 12 steps incl. e2e + visual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)