### PR TITLE
fix(frontend): tighten Resource trends height + bare-brand build stamp

### DIFF
--- a/src/components/build-stamp.test.tsx
+++ b/src/components/build-stamp.test.tsx
@@ -2,7 +2,8 @@
    contentinfo landmark + testid and a version-shaped stamp. Vitest runs as dev
    (import.meta.env.DEV === true), so the verbose form is rendered off the
    sentinel buildInfo — assertions stay resilient (shape, not exact sentinels).
-   Wave 1: stamp now starts with "Made with Castwright ·" for brand presence. */
+   The in-app stamp starts with the bare brand name "Castwright ·" (the
+   "Made with Castwright" attribution form is reserved for exported outputs). */
 
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
@@ -13,15 +14,15 @@ describe('BuildStamp', () => {
     render(<BuildStamp />);
     const footer = screen.getByTestId('build-stamp');
     expect(footer).toBeInTheDocument();
-    /* aria-label is the stamp itself — "Made with Castwright · v…" — so the
-       landmark is named. Match by the brand prefix. */
-    expect(screen.getByRole('contentinfo', { name: /made with castwright/i })).toBe(footer);
+    /* aria-label is the stamp itself — "Castwright · v…" — so the landmark is
+       named. Match by the brand prefix. */
+    expect(screen.getByRole('contentinfo', { name: /^castwright/i })).toBe(footer);
   });
 
-  it('shows "Made with Castwright" brand prefix in the stamp', () => {
+  it('shows the "Castwright" brand prefix in the stamp', () => {
     render(<BuildStamp />);
     const text = screen.getByTestId('build-stamp').textContent ?? '';
-    expect(text).toMatch(/^Made with Castwright/);
+    expect(text).toMatch(/^Castwright/);
     expect(text).toContain('·');
   });
 });

--- a/src/lib/brand.test.ts
+++ b/src/lib/brand.test.ts
@@ -2,7 +2,16 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { TAGLINE, TAGLINE_SHORT, MANIFESTO, TEASER, TEASER_FLAG, DOMAIN, MADE_WITH } from './brand';
+import {
+  TAGLINE,
+  TAGLINE_SHORT,
+  MANIFESTO,
+  TEASER,
+  TEASER_FLAG,
+  DOMAIN,
+  MADE_WITH,
+  BRAND_NAME,
+} from './brand';
 
 const RETIRED_TAGLINE = 'Any book, performed by a full cast — effortlessly. Even in your own voice.';
 const BANNED_WORD = 'effortlessly';
@@ -24,6 +33,13 @@ describe('brand constants', () => {
     expect(MANIFESTO).toBe('Many voices, one machine.');
     expect(DOMAIN).toBe('castwright.ai');
     expect(MADE_WITH).toBe('Made with Castwright');
+  });
+
+  it('exposes the bare product name for the in-app build stamp (distinct from the output stamp)', () => {
+    expect(BRAND_NAME).toBe('Castwright');
+    /* The two are intentionally different: outputs are attributed "Made with
+       Castwright", the app stamps itself with just "Castwright". */
+    expect(MADE_WITH).not.toBe(BRAND_NAME);
   });
 
   it('exposes the teaser with its mandatory in-development flag', () => {

--- a/src/lib/brand.ts
+++ b/src/lib/brand.ts
@@ -31,7 +31,13 @@ export const TEASER_FLAG = 'In development';
     (decision 7). */
 export const DOMAIN = 'castwright.ai';
 
-/** The footer/export attribution stamp prefix. */
+/** Bare product name — used where the app stamps *itself* (the in-app build
+    footer), as opposed to the attribution stamp on exported outputs. */
+export const BRAND_NAME = 'Castwright';
+
+/** The attribution stamp prefix for exported *outputs* (share-link image,
+    share-clip export) — "Made with Castwright · castwright.ai". The in-app
+    build footer uses the bare {@link BRAND_NAME} instead. */
 export const MADE_WITH = 'Made with Castwright';
 
 /** Hardware-honesty line (decision 9) — widened for Apple Silicon. */

--- a/src/lib/build-info.test.ts
+++ b/src/lib/build-info.test.ts
@@ -16,24 +16,24 @@ const base: BuildInfo = {
 describe('formatBuildStamp', () => {
   it('dev: verbose version · sha · branch · time when the tree is clean', () => {
     expect(formatBuildStamp(base, { dev: true })).toBe(
-      'Made with Castwright · v1.4.0 · a1b2c3d · fix/foo · 14:32',
+      'Castwright · v1.4.0 · a1b2c3d · fix/foo · 14:32',
     );
   });
 
   it('dev: appends a "*" dirty marker to the sha when the working tree is dirty', () => {
     expect(formatBuildStamp({ ...base, dirty: true }, { dev: true })).toBe(
-      'Made with Castwright · v1.4.0 · a1b2c3d* · fix/foo · 14:32',
+      'Castwright · v1.4.0 · a1b2c3d* · fix/foo · 14:32',
     );
   });
 
   it('dev: omits the trailing segment when buildTime is empty (no dangling separator)', () => {
     expect(formatBuildStamp({ ...base, buildTime: '' }, { dev: true })).toBe(
-      'Made with Castwright · v1.4.0 · a1b2c3d · fix/foo',
+      'Castwright · v1.4.0 · a1b2c3d · fix/foo',
     );
   });
 
   it('prod: minimal version + short sha only', () => {
-    expect(formatBuildStamp(base, { dev: false })).toBe('Made with Castwright · v1.4.0 (a1b2c3d)');
+    expect(formatBuildStamp(base, { dev: false })).toBe('Castwright · v1.4.0 (a1b2c3d)');
   });
 });
 

--- a/src/lib/build-info.ts
+++ b/src/lib/build-info.ts
@@ -8,7 +8,7 @@
 // `formatBuildStamp` is intentionally pure (no `import.meta`, no globals) so the
 // display logic is unit-testable with plain fixtures.
 
-import { MADE_WITH } from './brand';
+import { BRAND_NAME } from './brand';
 
 export interface BuildInfo {
   version: string;
@@ -34,7 +34,7 @@ export const buildInfo: BuildInfo = {
  * Prod (minimal): `v1.4.0 (a1b2c3d)` — version + short SHA only.
  */
 export function formatBuildStamp(info: BuildInfo, opts: { dev: boolean }): string {
-  const prefix = MADE_WITH;
+  const prefix = BRAND_NAME;
   if (!opts.dev) return `${prefix} · v${info.version} (${info.sha})`;
   const sha = info.dirty ? `${info.sha}*` : info.sha;
   const parts = [prefix, `v${info.version}`, sha, info.branch];

--- a/src/views/admin.tsx
+++ b/src/views/admin.tsx
@@ -515,14 +515,14 @@ function ResourceTrends() {
           <div className="px-4 py-3 border-b border-ink/5">
             <RtfSparkline records={records} />
           </div>
-          {/* Cap the rows at ~60% of the viewport and scroll inside with the
+          {/* Cap the rows at ~12 rows tall (~32rem) and scroll inside with the
               inset thin scrollbar — a long run records hundreds of chapters that
               would otherwise run off the page. The column header is sticky at the
               top of the scroller (so it shares the reserved gutter and aligns
               with the rows); each book's chapters sit under a sub-header that
               sticks just BELOW the column header. */}
           <div
-            className="max-h-[60vh] overflow-y-auto scrollbar-thin"
+            className="max-h-[32rem] overflow-y-auto scrollbar-thin"
             data-testid="resource-trends-scroll"
           >
             <div


### PR DESCRIPTION
## Summary

Two small admin/brand UI fixes spotted reviewing the **admin → Resource trends** panel.

1. **Resource trends table too tall.** Capped the scroller at `max-h-[32rem]` (~12 rows + sticky header) instead of `max-h-[60vh]` (~20 rows). Sibling generation-throughput table keeps its `60vh`; sticky header + thin scrollbar unchanged. (`src/views/admin.tsx`)
2. **In-app build stamp said "Made with Castwright".** That attribution form is reserved for exported **outputs** (share-link image, share-clip export). Split the brand copy: new `BRAND_NAME = 'Castwright'` drives the app build stamp; `MADE_WITH = 'Made with Castwright'` stays on the share/clip output footers, unchanged.

## Test plan

- `src/lib/brand.test.ts` — adds a `BRAND_NAME === 'Castwright'` guard + asserts it stays distinct from `MADE_WITH`.
- `src/lib/build-info.test.ts`, `src/components/build-stamp.test.tsx` — updated to lock `Castwright · v…` for the in-app stamp.
- `src/modals/share-link.test.tsx`, `src/modals/share-clip.test.tsx` — **unchanged**, still assert `Made with Castwright · castwright.ai` (proves outputs untouched).
- Verified locally against `main`: typecheck ✓, 53 affected specs ✓, eslint ✓, production build ✓.

Closes #746