### PR TITLE
feat(server,frontend,sidecar): fs-21 wave 1 — in-app Kokoro installer

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,6 +42,8 @@ python -m venv .venv
 .\.venv\Scripts\python.exe -m pip install -r requirements.txt
 
 # 3. Fetch the Kokoro TTS weights (~1.1 GB, one-time download).
+#    Option A — in-app: start the app first, then Admin → Model Manager → Kokoro → Install (no terminal needed).
+#    Option B — terminal:
 powershell -ExecutionPolicy Bypass -File scripts\install-kokoro.ps1
 cd ..\..
 
@@ -75,6 +77,8 @@ python3.11 -m venv .venv
 ./.venv/bin/python -m pip install -r requirements.txt
 
 # 3. Fetch the Kokoro TTS weights (~1.1 GB).
+#    Option A — in-app: start the app first, then Admin → Model Manager → Kokoro → Install (no terminal needed).
+#    Option B — terminal:
 bash scripts/install-kokoro.sh
 cd ../..
 
@@ -113,6 +117,8 @@ python3.11 -m venv .venv
 ./.venv/bin/python -m pip install -r requirements.txt
 
 # 3. Fetch the Kokoro TTS weights (~1.1 GB).
+#    Option A — in-app: start the app first, then Admin → Model Manager → Kokoro → Install (no terminal needed).
+#    Option B — terminal:
 bash scripts/install-kokoro.sh
 cd ../..
 

--- a/docs/superpowers/plans/2026-06-12-fs21-wave1-install-parity.md
+++ b/docs/superpowers/plans/2026-06-12-fs21-wave1-install-parity.md
@@ -1,0 +1,163 @@
+# fs-21 Wave 1 — In-app Kokoro installer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Give the first-run wizard (and the Model Manager) a **one-click, in-app** way to install the **Kokoro TTS weights** — the default engine, excluded from the release zip, and the only TTS hard-blocker with no in-app installer today. Qwen/Coqui/Whisper already install in-app via Node `.mjs`; Kokoro only had terminal scripts.
+
+**Architecture:** Mirror the existing install machinery exactly — a Node `install-*.mjs` spawned by an in-memory-job bootstrap class, fronted by a `POST /install` + `GET /install/:id` **polling** route (no SSE), and a self-contained `fetch`-polling React component wired into the Model Manager's `INSTALLER_BY_ID`. Kokoro is a pure file-download installer (no venv, no Python).
+
+**Tech Stack:** Node 20 + TypeScript (server, ESM `.js` import extensions), `node:child_process` spawn, `node:crypto` SHA256, Vitest (server + frontend), React 18 + `fetch`-polling component, Playwright e2e.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-fs21-first-run-wizard-design.md` · **Epic:** #474 · **Branch:** `feat/fs21-wave1-install-parity` off `main` (worktree `C:\Claude\Projects\wt-fs21-wave1`).
+
+> **Framing (corrected by the pre-execution adversarial review):** Kokoro terminal installers `install-kokoro.ps1` (Windows, SHA-verifying) and `install-kokoro.sh` (POSIX) **already exist and already work cross-platform**. The gap this wave closes is **in-app one-click** install: the install-bootstrap classes spawn `node <script>.mjs` uniformly, and can't portably spawn a `.ps1` on Linux or a `.sh` on Windows — so the button-driven path needs a **Node `install-kokoro.mjs`** (which also ports the `.ps1`'s SHA256 verify, which the `.sh` lacks). The new `.mjs` **coexists** with the terminal `.ps1`/`.sh` (INSTALL.md still references those) — it does not retire them.
+
+> **Spec corrections to fold into the Wave 4 doc pass:** install progress is **polling, not SSE**; no `runInstallScript` platform-dispatch helper (the `.mjs` pattern needs none).
+
+> **Scope split (adversarial review):** the **venv bootstrap (decision Z) moved to Wave 1b** — it's unverifiable on this box (the idempotent guard no-ops because a venv already exists) and its real `pip install` is inherently OWED, whereas this Kokoro wave is fully verifiable + independently valuable. The two share no code.
+
+> **Per the standing rule, this plan already passed an adversarial review; the fixes below are folded in.**
+
+---
+
+## File Structure
+
+- Create `server/tts-sidecar/scripts/install-kokoro.mjs` — Node downloader: fetch the two ONNX files to the kokoro weight dir, SHA256-verify against `model-hashes.json` (ports `install-kokoro.ps1` logic the `.sh` lacks), emit `[install-kokoro] <step>` stdout lines, delete + exit(1) on hash mismatch. Respects `KOKORO_MODEL_PATH`/`KOKORO_VOICES_PATH` env overrides (versioned-install layout). Coexists with the `.ps1`/`.sh`.
+- Create `server/src/tts/kokoro-install-detect.ts` — `detectKokoroInstalledOnDisk(repoRoot): boolean`.
+- Create `server/src/tts/kokoro-install-bootstrap.ts` — `class KokoroInstallBootstrap` (mirror `CoquiInstallBootstrap`, **binary** state — no `weights-missing`).
+- Create `server/src/routes/kokoro-install.ts` — `kokoroInstallRouter` (mirror `coqui-install.ts`).
+- Create `src/components/kokoro-install.tsx` — mirror `coqui-install.tsx` (fetch-polling).
+- Modify `server/src/index.ts` (register `/api/kokoro`), `src/views/model-manager.tsx` (`INSTALLER_BY_ID` + comment), `src/views/model-manager.test.tsx` (invert the "no installer for kokoro" assertion), `server/src/tts/engine-presence.ts` (DRY via the new detect helper), `scripts/release-manifest.test.mjs` (pin the new `.mjs`), `INSTALL.md` (note the in-app option).
+- Tests: `install-kokoro-helpers.test.ts`, `kokoro-install-detect.test.ts`, `kokoro-install-bootstrap.test.ts`, `kokoro-install.route.test.ts` (slow pool), `kokoro-install.test.tsx`.
+
+---
+
+## Task A1: `install-kokoro.mjs` (Node downloader + SHA256 verify)
+
+**Files:** Create `server/tts-sidecar/scripts/install-kokoro.mjs`; Test `server/src/tts/install-kokoro-helpers.test.ts`.
+
+- [ ] **Step 1: Write the failing helper test.** Mirror `server/src/tts/install-qwen3-helpers.test.ts` — note it imports the `.mjs` with a `// @ts-expect-error` (the `.mjs` ships no `.d.ts`). The new `.mjs` exports `sha256File(path)` and `kokoroHashes()`.
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+// @ts-expect-error — .mjs script ships no type declarations (matches install-qwen3-helpers.test.ts)
+import { sha256File, kokoroHashes } from '../../tts-sidecar/scripts/install-kokoro.mjs';
+
+describe('install-kokoro helpers', () => {
+  it('sha256File matches node:crypto', () => {
+    const d = mkdtempSync(join(tmpdir(), 'k-')); const f = join(d, 'x');
+    writeFileSync(f, 'hello kokoro');
+    const want = createHash('sha256').update('hello kokoro').digest('hex');
+    expect(sha256File(f)).toBe(want);
+    rmSync(d, { recursive: true, force: true });
+  });
+  it('kokoroHashes exposes the two pinned weight files', () => {
+    const h = kokoroHashes();
+    expect(h['kokoro-v1.0.onnx'].sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(h['voices-v1.0.bin'].sizeBytes).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL** (`cd server && npx vitest run src/tts/install-kokoro-helpers.test.ts`).
+
+- [ ] **Step 3: Implement `install-kokoro.mjs`.** Port `install-kokoro.ps1` (the SHA-verifying reference, ~lines 53-117) to Node, copying the structure of `install-qwen3.mjs` (repoRoot resolution, `sha256File` at qwen :54, `JSON.parse(readFileSync(model-hashes.json))` at qwen :45-46, main-guard at qwen :265 `process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href`):
+  - Target dir: dirname of `process.env.KOKORO_MODEL_PATH`/`KOKORO_VOICES_PATH` if set, else `<repoRoot>/server/tts-sidecar/voices/kokoro`.
+  - URLs: `https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/{kokoro-v1.0.onnx,voices-v1.0.bin}`.
+  - `export function sha256File(p)`; `export function kokoroHashes()` → returns `JSON.parse(readFileSync(<scripts>/model-hashes.json)).kokoro` (object keyed by filename).
+  - For each file: if present AND `sha256File === pin.sha256` → `[install-kokoro] <name> already present, verified`; else download (Node `https`/`fetch`), then verify sha256 vs pin; on mismatch `[install-kokoro] ERROR sha256 mismatch for <name>`, delete the file, `process.exit(1)`.
+  - Emit `[install-kokoro] <step>` lines. `main()` runs only under the import-meta main-guard.
+
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** `feat(sidecar): in-app install-kokoro.mjs with SHA256 verify (fs-21 wave 1)` (`git add server/tts-sidecar/scripts/install-kokoro.mjs server/src/tts/install-kokoro-helpers.test.ts`).
+
+---
+
+## Task A2: `kokoro-install-detect.ts` (+ DRY engine-presence)
+
+**Files:** Create `server/src/tts/kokoro-install-detect.ts`, `server/src/tts/kokoro-install-detect.test.ts`; modify `server/src/tts/engine-presence.ts`.
+
+- [ ] **Step 1: Failing test** — `detectKokoroInstalledOnDisk(repoRoot)` false on an empty temp root, true when both weight files exist under `server/tts-sidecar/voices/kokoro/` (mirror `engine-presence.test.ts`'s temp-tree / mock approach).
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** `export function detectKokoroInstalledOnDisk(repoRoot: string): boolean { return totalSizeBytes(kokoroWeightPaths(repoRoot)).fileCount > 0; }` (import both from `./model-paths.js`). Then refactor `server/src/tts/engine-presence.ts` to call `detectKokoroInstalledOnDisk(repoRoot)` for its kokoro check instead of the inline `totalSizeBytes(kokoroWeightPaths(repoRoot)).fileCount > 0`. The existing `engine-presence.test.ts` mocks `./model-paths.js`, and the new helper calls the same mocked functions transitively, so it stays green — verify by running it.
+- [ ] **Step 4: Run → PASS** (`kokoro-install-detect.test.ts` + `engine-presence.test.ts` both green).
+- [ ] **Step 5: Commit** `refactor(server): extract detectKokoroInstalledOnDisk + DRY engine-presence (fs-21 wave 1)`.
+
+---
+
+## Task A3: `KokoroInstallBootstrap`
+
+**Files:** Create `server/src/tts/kokoro-install-bootstrap.ts`, `server/src/tts/kokoro-install-bootstrap.test.ts`.
+
+- [ ] **Step 1: Read `server/src/tts/coqui-install-bootstrap.ts` + `coqui-install-bootstrap.test.ts` in full.** Mirror for Kokoro, with these deliberate divergences:
+  - **Binary state only** — `detect()` maps `detectKokoroInstalledOnDisk` to `'not-installed' | 'installed'`. **DO NOT copy Coqui's `weights-missing` middle state or its post-spawn `weights-missing` error branch** (that's Coqui's venv-package-vs-weights split, which Kokoro doesn't have).
+  - Spawn `this.spawnFn('node', [join(repoRoot,'server','tts-sidecar','scripts','install-kokoro.mjs'), ...installArgs], { cwd: repoRoot, windowsHide: true })`.
+  - `[install-kokoro]` stdout step regex; stderr-tail on non-zero exit; in-memory `Map<string, KokoroInstallJob>`; `detect/start/getJob/getActiveJob/recheck/_reset`.
+- [ ] **Step 2: Write the failing test** mirroring `coqui-install-bootstrap.test.ts` (stubbed `spawnFn` + `detectFn`): start() spawns exactly once; short-circuits to `installed` without spawning when already present; non-zero exit → `error` with stderr tail; `[install-kokoro]` lines update `job.step`.
+- [ ] **Step 3: Run → FAIL; Step 4: implement; Step 5: Run → PASS.**
+- [ ] **Step 6: Commit** `feat(server): KokoroInstallBootstrap (fs-21 wave 1)`.
+
+---
+
+## Task A4: `kokoro-install.ts` route + registration (slow-pool route test)
+
+**Files:** Create `server/src/routes/kokoro-install.ts`, `server/src/routes/kokoro-install.route.test.ts`; modify `server/src/index.ts`, `server/vitest.config.slow.ts`, `server/vitest.config.ts`.
+
+- [ ] **Step 1: Read `server/src/routes/coqui-install.ts` + its registration (`index.ts:248`).** Mirror: `kokoroInstallRouter` with GET `/detect`, POST `/install`, GET `/install/:id`, POST `/install/:id/recheck`, backed by a module-singleton `KokoroInstallBootstrap`, exposing the same test-injection hook coqui's route has.
+- [ ] **Step 2: Write the slow-pool route test** (mirror coqui route test + Wave 0's `setup-readiness.route.test.ts`): stubbed bootstrap; assert detect/poll shapes + 202 on install. Add `'src/routes/kokoro-install.route.test.ts'` to `SLOW_FILES` (`server/vitest.config.slow.ts`) AND `SLOW_FILES_TO_EXCLUDE` (`server/vitest.config.ts`).
+- [ ] **Step 3: Run → FAIL; Step 4: implement route + register `app.use('/api/kokoro', kokoroInstallRouter)` after the coqui line (index.ts:248); Step 5: run slow test → PASS + `npm run typecheck`.**
+- [ ] **Step 6: Commit** `feat(server): /api/kokoro in-app install route (fs-21 wave 1)`.
+
+---
+
+## Task A5: `kokoro-install.tsx` component
+
+**Files:** Create `src/components/kokoro-install.tsx`, `src/components/kokoro-install.test.tsx`.
+
+- [ ] **Step 1: Read `src/components/coqui-install.tsx` in full.** Mirror: `KokoroInstall({ onInstalled })`, `POLL_INTERVAL_MS = 1_500`, `fetch('/api/kokoro/detect')` / `POST /api/kokoro/install` / `GET /api/kokoro/install/:id`, four render states (installed / installing+step / error+retry / not-installed+button). Design tokens only, no hex.
+- [ ] **Step 2: Write the failing test** mirroring `coqui-install.test.tsx` (mock `fetch`): renders install button when not installed; shows step while installing; calls `onInstalled` when status flips to `installed`.
+- [ ] **Step 3: Run → FAIL; Step 4: implement; Step 5: Run → PASS.**
+- [ ] **Step 6: Commit** `feat(frontend): KokoroInstall polling component (fs-21 wave 1)`.
+
+---
+
+## Task A6: wire Kokoro into the Model Manager (INVERT the existing assertion)
+
+**Files:** Modify `src/views/model-manager.tsx`, `src/views/model-manager.test.tsx`.
+
+- [ ] **Step 1: Read `src/views/model-manager.test.tsx` around line 377.** There is an EXISTING passing test "**offers no install toggle for a release-bundled model (kokoro)**" asserting `queryByTestId('model-install-toggle-kokoro')` is **null**. Adding the kokoro installer will make that toggle render → that test goes red. **Invert it**: rename/rewrite it to assert the kokoro install toggle now RENDERS (mirror how the test asserts the coqui/qwen-base/whisper toggles render). This is the blocking step the adversarial review flagged.
+- [ ] **Step 2: Run → the inverted assertion FAILS** (toggle not yet rendered) `npx vitest run src/views/model-manager.test.tsx`.
+- [ ] **Step 3: Implement** — import `KokoroInstall`, add `kokoro: KokoroInstall` to `INSTALLER_BY_ID` (`model-manager.tsx:40-44`), and **update the stale comment at `model-manager.tsx:39`** ("kokoro ships in the release bundle… none get a row installer") to note kokoro now has an in-app installer (fs-21 wave 1; weights are fetched at install time, not bundled).
+- [ ] **Step 4: Run → PASS + `npm run typecheck`.**
+- [ ] **Step 5: Commit** `feat(frontend): wire Kokoro installer into Model Manager (fs-21 wave 1)`.
+
+---
+
+## Task A7: docs + release-manifest hygiene
+
+**Files:** Modify `scripts/release-manifest.test.mjs`, `INSTALL.md`.
+
+- [ ] **Step 1:** In `scripts/release-manifest.test.mjs`, add an `INCLUDED`-assertion line for `server/tts-sidecar/scripts/install-kokoro.mjs` next to where `install-kokoro.ps1`/`.sh` are pinned (~lines 47-48). Run the manifest test → PASS (it already passes via the `server/tts-sidecar/**` wildcard; this just pins it explicitly).
+- [ ] **Step 2:** In `INSTALL.md`, where `install-kokoro.ps1`/`install-kokoro.sh` are referenced (~lines 44-45, 77-78, 115-116), add a one-line note that Kokoro can now also be installed **in-app via the Model Manager** (no terminal needed). Keep the terminal commands.
+- [ ] **Step 3: Commit** `docs(scripts,docs): pin install-kokoro.mjs + note in-app install (fs-21 wave 1)`.
+
+---
+
+## Task A8: Full verify + draft PR
+
+- [ ] **Step 1:** `npm run verify` green (retry the `test:server` worker-flake under contention as in Wave 0 — cache-aware verify heals incrementally).
+- [ ] **Step 2:** `gh pr create --draft --title "feat(server,frontend,sidecar): fs-21 wave 1 — in-app Kokoro installer" --body "... Refs #474. OWED: real Kokoro install on a Mac + a Linux box (the .mjs is Node-cross-platform; logic + offline flow are tested here)."` Then `gh pr ready` once green.
+
+---
+
+## Self-Review
+
+**Spec coverage (Wave 1 = Kokoro in-app installer):** install-kokoro.mjs (A1) → detect helper + DRY (A2) → bootstrap (A3) → route (A4) → component (A5) → Model Manager wiring + inverted test (A6) → docs/manifest (A7) → verify/PR (A8). The venv bootstrap is **Wave 1b** (separate plan).
+
+**Adversarial-review fixes folded in:** (1) A6 inverts the existing `model-manager.test.tsx:377` "no kokoro installer" assertion + updates the comment [was the blocking defect]; (2) A1 test carries `// @ts-expect-error` on the `.mjs` import; (3) A3 explicitly drops Coqui's `weights-missing` branch (Kokoro is binary); (4) framing fixed — `.sh`/`.ps1` already exist, the value is in-app one-click, the `.mjs` coexists; (5) INSTALL.md + release-manifest ripples named (A7). The `/api/setup/venv` mount question is moot (moved to 1b). Express-5 multi-mount + engine-presence DRY were verified safe.
+
+**OWED (not CI-gated):** real Kokoro install on Mac + Linux boxes (the `.mjs` is Node-cross-platform; offline + stubbed-spawn flow is fully tested here).

--- a/scripts/tests/release-manifest.test.mjs
+++ b/scripts/tests/release-manifest.test.mjs
@@ -46,6 +46,7 @@ const INCLUDED = [
   'server/tts-sidecar/start.ps1',
   'server/tts-sidecar/scripts/install-kokoro.ps1',
   'server/tts-sidecar/scripts/install-kokoro.sh',
+  'server/tts-sidecar/scripts/install-kokoro.mjs',
 
   // Runtime scripts the deployer invokes
   'scripts/start-app-prod.mjs',

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -81,6 +81,7 @@ import { qwenInstallRouter } from './routes/qwen-install.js';
 import { modelsInventoryRouter } from './routes/models-inventory.js';
 import { whisperInstallRouter } from './routes/whisper-install.js';
 import { coquiInstallRouter } from './routes/coqui-install.js';
+import { kokoroInstallRouter } from './routes/kokoro-install.js';
 import { gpuQueueRouter } from './routes/gpu-queue.js';
 import { diagnosticsRouter } from './routes/diagnostics.js';
 import { setupReadinessRouter } from './routes/setup-readiness.js';
@@ -246,6 +247,7 @@ app.use('/api/sidecar', sidecarHealthRouter); // mounts GET /health
 app.use('/api/ollama', ollamaHealthRouter); // mounts GET /health (local LLM analyzer)
 app.use('/api/qwen', qwenInstallRouter); // in-app Qwen3-TTS installer (detect/install/poll/recheck)
 app.use('/api/coqui', coquiInstallRouter); // in-app Coqui XTTS v2 installer (detect/install/poll/recheck)
+app.use('/api/kokoro', kokoroInstallRouter); // in-app Kokoro ONNX installer (fs-21: detect/install/poll/recheck)
 app.use('/api/whisper', whisperInstallRouter); // in-app Whisper ASR installer (srv-31: detect/install/poll/recheck)
 app.use('/api/models', modelsInventoryRouter); // fs-23 — in-app Model Manager: inventory + remove
 app.use('/api/gpu', gpuQueueRouter); // mounts GET /queue (semaphore depth + inFlight for the top-bar pill)

--- a/server/src/routes/kokoro-install.route.test.ts
+++ b/server/src/routes/kokoro-install.route.test.ts
@@ -1,0 +1,125 @@
+/* /api/kokoro install routes (fs-21). Injects a KokoroInstallBootstrap with a
+   stubbed detect + spawn so the whole detect/install/poll/recheck surface runs
+   offline (no real download or weight files needed).
+
+   Pinned to the slow pool (vitest.config.slow.ts) — integration route test
+   that supertest's a live Express instance, same class as
+   setup-readiness.route.test.ts and the coqui/whisper install tests. */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import express from 'express';
+import request from 'supertest';
+import {
+  kokoroInstallRouter,
+  setKokoroInstallBootstrap,
+  _resetKokoroInstallBootstrap,
+} from './kokoro-install.js';
+import {
+  KokoroInstallBootstrap,
+  type KokoroInstallJobStatus,
+} from '../tts/kokoro-install-bootstrap.js';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/kokoro', kokoroInstallRouter);
+  return app;
+}
+
+function fakeChild(code: number) {
+  const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  queueMicrotask(() => child.emit('close', code));
+  return child;
+}
+
+async function poll(
+  app: express.Express,
+  id: string,
+  until: (s: KokoroInstallJobStatus) => boolean,
+) {
+  for (let i = 0; i < 200; i++) {
+    const res = await request(app).get(`/api/kokoro/install/${id}`);
+    if (until(res.body.status)) return res.body;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error('poll timed out');
+}
+
+afterEach(() => {
+  _resetKokoroInstallBootstrap();
+});
+
+describe('GET /api/kokoro/detect', () => {
+  it('returns installed:true when weights are present', async () => {
+    setKokoroInstallBootstrap(
+      new KokoroInstallBootstrap({ repoRoot: '/repo', detectFn: () => true }),
+    );
+    const res = await request(makeApp()).get('/api/kokoro/detect');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ state: 'installed', installed: true });
+  });
+
+  it('returns installed:false when weights are absent', async () => {
+    setKokoroInstallBootstrap(
+      new KokoroInstallBootstrap({ repoRoot: '/repo', detectFn: () => false }),
+    );
+    const res = await request(makeApp()).get('/api/kokoro/detect');
+    expect(res.body).toEqual({ state: 'not-installed', installed: false });
+  });
+});
+
+describe('POST /api/kokoro/install + poll', () => {
+  it('starts a job (202) and reaches installed once weights land', async () => {
+    let calls = 0;
+    setKokoroInstallBootstrap(
+      new KokoroInstallBootstrap({
+        repoRoot: '/repo',
+        /* First call (pre-install probe) → not installed; second call (post-
+           install probe) → installed. */
+        detectFn: () => calls++ > 0,
+        spawnFn: () => fakeChild(0) as never,
+      }),
+    );
+    const app = makeApp();
+    const start = await request(app).post('/api/kokoro/install');
+    expect(start.status).toBe(202);
+    expect(start.body.id).toBeTruthy();
+    expect(start.body.status).toBeTruthy();
+
+    const done = await poll(app, start.body.id, (s) => s === 'installed' || s === 'error');
+    expect(done.status).toBe('installed');
+  });
+
+  it('404s polling an unknown job id', async () => {
+    setKokoroInstallBootstrap(
+      new KokoroInstallBootstrap({ repoRoot: '/repo', detectFn: () => true }),
+    );
+    const res = await request(makeApp()).get('/api/kokoro/install/does-not-exist');
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/kokoro/install/:id/recheck', () => {
+  it('promotes a stuck job to installed once the weights appear', async () => {
+    let installed = false;
+    setKokoroInstallBootstrap(
+      new KokoroInstallBootstrap({
+        repoRoot: '/repo',
+        detectFn: () => installed,
+        spawnFn: () => fakeChild(0) as never,
+      }),
+    );
+    const app = makeApp();
+    const start = await request(app).post('/api/kokoro/install');
+    // detectFn always returns false → installer exits 0 but weights still
+    // missing → job lands in 'error'
+    await poll(app, start.body.id, (s) => s === 'error');
+    installed = true;
+    const res = await request(app).post(`/api/kokoro/install/${start.body.id}/recheck`);
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('installed');
+  });
+});

--- a/server/src/routes/kokoro-install.ts
+++ b/server/src/routes/kokoro-install.ts
@@ -1,0 +1,59 @@
+/* In-app Kokoro install routes (fs-21). Mirrors the Coqui/Whisper install
+   routes so Account → Models can install the Kokoro ONNX weights without a
+   terminal:
+
+     GET  /api/kokoro/detect              — install-state probe (no job)
+     POST /api/kokoro/install             — kick off install-kokoro.mjs (202 + job)
+     GET  /api/kokoro/install/:id         — poll job progress
+     POST /api/kokoro/install/:id/recheck — re-probe install-state
+
+   No resolver-cache sync (unlike Qwen) — Kokoro's presence is detected at
+   sidecar startup, not via a lazy resolver; install-state never feeds
+   getResolvedTtsModelKey on the server side. */
+
+import { Router } from 'express';
+import type { Request, Response } from '../http.js';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { KokoroInstallBootstrap } from '../tts/kokoro-install-bootstrap.js';
+
+export const kokoroInstallRouter = Router();
+
+/* server/src/routes/kokoro-install.ts → repo root is three levels up. */
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+const defaultBootstrap = new KokoroInstallBootstrap({ repoRoot: REPO_ROOT });
+let bootstrap: KokoroInstallBootstrap = defaultBootstrap;
+
+/** Test injection — swap in a stubbed bootstrap (offline, no spawn). */
+export function setKokoroInstallBootstrap(b: KokoroInstallBootstrap): void {
+  bootstrap = b;
+}
+export function _resetKokoroInstallBootstrap(): void {
+  bootstrap = defaultBootstrap;
+}
+
+kokoroInstallRouter.get('/detect', async (_req: Request, res: Response) => {
+  return res.json(await bootstrap.detect());
+});
+
+kokoroInstallRouter.post('/install', (_req: Request, res: Response) => {
+  const job = bootstrap.start();
+  return res.status(202).json(job);
+});
+
+kokoroInstallRouter.get('/install/:id', (req: Request, res: Response) => {
+  const job = bootstrap.getJob(req.params.id);
+  if (!job) {
+    return res.status(404).json({ error: `No Kokoro install job '${req.params.id}'` });
+  }
+  return res.json(job);
+});
+
+kokoroInstallRouter.post('/install/:id/recheck', async (req: Request, res: Response) => {
+  const job = await bootstrap.recheck(req.params.id);
+  if (!job) {
+    return res.status(404).json({ error: `No Kokoro install job '${req.params.id}'` });
+  }
+  return res.json(job);
+});

--- a/server/src/tts/engine-presence.ts
+++ b/server/src/tts/engine-presence.ts
@@ -1,12 +1,12 @@
 /* fs-21 — is at least one TTS engine's weights present on disk? Reuses the
    exact detectors the Model Manager inventory uses, so "present" means the
    same thing in both places. */
-import { kokoroWeightPaths, totalSizeBytes } from './model-paths.js';
+import { detectKokoroInstalledOnDisk } from './kokoro-install-detect.js';
 import { coquiWeightsPresent } from './coqui-install-detect.js';
 import { detectQwenInstallStateOnDisk } from './qwen-install-detect.js';
 
 export function anyTtsEnginePresent(repoRoot: string): boolean {
-  const kokoro = totalSizeBytes(kokoroWeightPaths(repoRoot)).fileCount > 0;
+  const kokoro = detectKokoroInstalledOnDisk(repoRoot);
   const coqui = coquiWeightsPresent();
   const qwen = detectQwenInstallStateOnDisk(repoRoot) === 'ready';
   return kokoro || coqui || qwen;

--- a/server/src/tts/install-kokoro-helpers.test.ts
+++ b/server/src/tts/install-kokoro-helpers.test.ts
@@ -1,0 +1,25 @@
+/* fs-21 — install-kokoro.mjs SHA256-verify helpers. The script's main() is
+   guarded (runs only when invoked directly), so importing it here is inert. */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+// @ts-expect-error — standalone install script ships no .d.ts; helpers are plain JS.
+import { sha256File, kokoroHashes } from '../../tts-sidecar/scripts/install-kokoro.mjs';
+
+describe('install-kokoro helpers', () => {
+  it('sha256File matches node:crypto', () => {
+    const d = mkdtempSync(join(tmpdir(), 'k-')); const f = join(d, 'x');
+    writeFileSync(f, 'hello kokoro');
+    const want = createHash('sha256').update('hello kokoro').digest('hex');
+    expect(sha256File(f)).toBe(want);
+    rmSync(d, { recursive: true, force: true });
+  });
+  it('kokoroHashes exposes the two pinned weight files', () => {
+    const h = kokoroHashes();
+    expect(h['kokoro-v1.0.onnx'].sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(h['voices-v1.0.bin'].sizeBytes).toBeGreaterThan(0);
+  });
+});

--- a/server/src/tts/kokoro-install-bootstrap.test.ts
+++ b/server/src/tts/kokoro-install-bootstrap.test.ts
@@ -1,0 +1,139 @@
+/* KokoroInstallBootstrap state machine. Runs the whole install offline: stubbed
+   detectFn drives the install-state (boolean), stubbed spawnFn emits fake
+   `[install-kokoro]` progress + an exit code. No real download. */
+
+import { describe, it, expect } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { KokoroInstallBootstrap } from './kokoro-install-bootstrap.js';
+
+function makeFakeChild(exitCode: number, opts: { stdout?: string; stderr?: string } = {}) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  /* Emit after the caller has attached its listeners (run() awaits the close). */
+  queueMicrotask(() => {
+    if (opts.stdout) child.stdout.emit('data', Buffer.from(opts.stdout));
+    if (opts.stderr) child.stderr.emit('data', Buffer.from(opts.stderr));
+    child.emit('close', exitCode);
+  });
+  return child;
+}
+
+async function until(pred: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) throw new Error('timed out waiting for condition');
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe('KokoroInstallBootstrap', () => {
+  it('detect() reports installed=true only when detectFn returns true', async () => {
+    const bInstalled = new KokoroInstallBootstrap({ repoRoot: '/repo', detectFn: () => true });
+    const bMissing = new KokoroInstallBootstrap({ repoRoot: '/repo', detectFn: () => false });
+    expect((await bInstalled.detect()).installed).toBe(true);
+    expect((await bInstalled.detect()).state).toBe('installed');
+    expect((await bMissing.detect()).installed).toBe(false);
+    expect((await bMissing.detect()).state).toBe('not-installed');
+  });
+
+  it('start() spawns exactly once and transitions to installing', async () => {
+    let spawned = 0;
+    const b = new KokoroInstallBootstrap({
+      repoRoot: '/repo',
+      detectFn: () => false,
+      spawnFn: () => {
+        spawned++;
+        return makeFakeChild(0, { stdout: '[install-kokoro] downloading\n' }) as never;
+      },
+    });
+    // detectFn always returns false so it won't short-circuit
+    // but spawnFn exit 0 triggers the post-check detectFn which also returns false
+    // so job will go to error — that's fine, we just check spawned count
+    const job = b.start();
+    await until(() => {
+      const j = b.getJob(job.id);
+      return j?.status === 'installed' || j?.status === 'error';
+    });
+    expect(spawned).toBe(1);
+  });
+
+  it('short-circuits to installed WITHOUT spawning when detectFn already returns true', async () => {
+    let spawned = 0;
+    const b = new KokoroInstallBootstrap({
+      repoRoot: '/repo',
+      detectFn: () => true,
+      spawnFn: () => {
+        spawned++;
+        return makeFakeChild(0) as never;
+      },
+    });
+    const job = b.start();
+    await until(() => b.getJob(job.id)?.status === 'installed');
+    expect(spawned).toBe(0);
+  });
+
+  it('errors with the stderr tail when the installer exits non-zero', async () => {
+    const b = new KokoroInstallBootstrap({
+      repoRoot: '/repo',
+      detectFn: () => false,
+      spawnFn: () =>
+        makeFakeChild(1, { stderr: 'ERROR: Kokoro download failed\n' }) as never,
+    });
+    const job = b.start();
+    await until(() => b.getJob(job.id)?.status === 'error');
+    expect(b.getJob(job.id)?.error).toMatch(/exited with code 1/);
+    expect(b.getJob(job.id)?.error).toMatch(/download failed/);
+  });
+
+  it('[install-kokoro] stdout line updates job.step', async () => {
+    /* detectFn sequence: first call (before-check) returns false → spawns;
+       second call (after-check) returns true → installed. */
+    let callCount = 0;
+    const b = new KokoroInstallBootstrap({
+      repoRoot: '/repo',
+      detectFn: () => {
+        callCount++;
+        return callCount > 1; // false on first (before), true on second (after)
+      },
+      spawnFn: () =>
+        makeFakeChild(0, { stdout: '[install-kokoro] downloading\n' }) as never,
+    });
+    const job = b.start();
+    await until(() => b.getJob(job.id)?.status === 'installed');
+    expect(b.getJob(job.id)?.step).toContain('installed');
+  });
+
+  it('successful run (exit 0, detect=true after) transitions to installed', async () => {
+    let callCount = 0;
+    const b = new KokoroInstallBootstrap({
+      repoRoot: '/repo',
+      detectFn: () => {
+        callCount++;
+        return callCount > 1; // not installed before, installed after
+      },
+      spawnFn: () => makeFakeChild(0) as never,
+    });
+    const job = b.start();
+    await until(() => b.getJob(job.id)?.status === 'installed');
+    expect(b.getJob(job.id)?.status).toBe('installed');
+  });
+
+  it('recheck promotes a job to installed once detect returns true', async () => {
+    let installed = false;
+    const b = new KokoroInstallBootstrap({
+      repoRoot: '/repo',
+      detectFn: () => installed,
+      spawnFn: () => makeFakeChild(0) as never,
+    });
+    // detectFn always false → exit 0 but post-check still false → error
+    const job = b.start();
+    await until(() => b.getJob(job.id)?.status === 'error');
+    installed = true;
+    const rechecked = await b.recheck(job.id);
+    expect(rechecked?.status).toBe('installed');
+  });
+});

--- a/server/src/tts/kokoro-install-bootstrap.ts
+++ b/server/src/tts/kokoro-install-bootstrap.ts
@@ -1,0 +1,226 @@
+/* In-app Kokoro install bootstrap (fs-21). Spawns
+ * server/tts-sidecar/scripts/install-kokoro.mjs and surfaces its
+ * `[install-kokoro]` step lines so a deployer can install the Kokoro weights
+ * from Account → Models without a terminal. Progress is STEP-based (no single
+ * byte total for the ONNX download).
+ *
+ * State machine:
+ *   idle → detecting → installing → installed
+ *                          └─ error ↗
+ *
+ * Unlike Coqui/Whisper, Kokoro state is BINARY: either the weight files are
+ * present on disk (`installed`) or they are not (`not-installed`). There is no
+ * intermediate `weights-missing` / `model-missing` state because Kokoro has no
+ * venv-package prerequisite separate from its weights — the check is purely
+ * file presence.
+ *
+ * Dependency-injectable (`spawnFn`, `detectFn`) so the route's vitest harness
+ * runs the whole machine offline with no real download.
+ */
+
+import { spawn as realSpawn, type ChildProcess } from 'node:child_process';
+import { join } from 'node:path';
+import { detectKokoroInstalledOnDisk } from './kokoro-install-detect.js';
+
+export type KokoroInstallState = 'installed' | 'not-installed';
+
+export type KokoroInstallJobStatus = 'detecting' | 'installing' | 'installed' | 'error';
+
+export interface KokoroInstallJob {
+  id: string;
+  status: KokoroInstallJobStatus;
+  /** Latest `[install-kokoro]` step line, surfaced to the UI as status text
+      (there's no byte total to drive a percentage bar). */
+  step: string | null;
+  error: string | null;
+  startedAt: number;
+  updatedAt: number;
+}
+
+export type KokoroSpawnFn = (
+  cmd: string,
+  args: readonly string[],
+  opts?: { cwd?: string; windowsHide?: boolean },
+) => ChildProcess;
+
+export interface KokoroInstallOptions {
+  /** Repo root — used to locate install-kokoro.mjs and to probe the weight files. */
+  repoRoot: string;
+  spawnFn?: KokoroSpawnFn;
+  /** Stubbable install-state probe (offline tests). Defaults to the on-disk
+      detector against repoRoot. Returns true if installed, false otherwise. */
+  detectFn?: () => boolean | Promise<boolean>;
+  /** Install flags forwarded to install-kokoro.mjs. */
+  installArgs?: readonly string[];
+}
+
+export class KokoroInstallBootstrap {
+  private jobs = new Map<string, KokoroInstallJob>();
+  private active: string | null = null;
+  private nextId = 1;
+
+  private readonly repoRoot: string;
+  private readonly spawnFn: KokoroSpawnFn;
+  private readonly detectFn: () => boolean | Promise<boolean>;
+  private readonly installArgs: readonly string[];
+
+  constructor(opts: KokoroInstallOptions) {
+    this.repoRoot = opts.repoRoot;
+    this.spawnFn = opts.spawnFn ?? (realSpawn as unknown as KokoroSpawnFn);
+    this.detectFn = opts.detectFn ?? (() => detectKokoroInstalledOnDisk(this.repoRoot));
+    this.installArgs = opts.installArgs ?? [];
+  }
+
+  /** Probe install-state without kicking off a job. Used by GET /detect. */
+  async detect(): Promise<{ state: KokoroInstallState; installed: boolean }> {
+    const installed = await this.detectFn();
+    const state: KokoroInstallState = installed ? 'installed' : 'not-installed';
+    return { state, installed };
+  }
+
+  getJob(id: string): KokoroInstallJob | null {
+    return this.jobs.get(id) ?? null;
+  }
+
+  getActiveJob(): KokoroInstallJob | null {
+    return this.active ? this.jobs.get(this.active) ?? null : null;
+  }
+
+  /** Kick off (or return the in-flight) install job. Returns synchronously;
+      the spawn runs in the background and the caller polls GET /install/:id. */
+  start(): KokoroInstallJob {
+    const existing = this.getActiveJob();
+    if (existing && existing.status !== 'installed' && existing.status !== 'error') {
+      return existing;
+    }
+    const id = String(this.nextId++);
+    const job: KokoroInstallJob = {
+      id,
+      status: 'detecting',
+      step: null,
+      error: null,
+      startedAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    this.jobs.set(id, job);
+    this.active = id;
+    void this.run(job).catch((err) => {
+      this.transition(job, 'error', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+    return job;
+  }
+
+  private async run(job: KokoroInstallJob): Promise<void> {
+    /* Already installed? short-circuit (idempotent — the install script is also
+       idempotent, but skipping the multi-minute spawn is the common path on a
+       box where Kokoro weights were already pre-fetched). */
+    const before = await this.detectFn();
+    if (before) {
+      this.transition(job, 'installed', { step: 'Already installed.' });
+      return;
+    }
+
+    this.transition(job, 'installing', { step: 'Starting installer…' });
+    await this.spawnInstaller(job);
+
+    /* Re-probe: the script exited 0, confirm the weight files actually landed. A
+       0-exit with weights still missing is surfaced as an error so the UI
+       doesn't claim success on a partial download. */
+    const after = await this.detectFn();
+    if (after) {
+      this.transition(job, 'installed', { step: 'Done. Kokoro installed.' });
+    } else {
+      this.transition(job, 'error', {
+        error:
+          'Installer finished but the Kokoro weight files are still missing — the download may have been interrupted. Retry (downloads resume).',
+      });
+    }
+  }
+
+  /** Re-probe install-state; promote a stuck installing/error job to installed
+      if the weight files are now present. */
+  async recheck(id: string): Promise<KokoroInstallJob | null> {
+    const job = this.jobs.get(id);
+    if (!job) return null;
+    const installed = await this.detectFn();
+    if (installed && job.status !== 'installed') {
+      this.transition(job, 'installed', { step: 'Done. Kokoro installed.' });
+    }
+    return this.jobs.get(id) ?? null;
+  }
+
+  private spawnInstaller(job: KokoroInstallJob): Promise<void> {
+    const script = join(
+      this.repoRoot,
+      'server',
+      'tts-sidecar',
+      'scripts',
+      'install-kokoro.mjs',
+    );
+    return new Promise((resolve, reject) => {
+      let proc: ChildProcess;
+      try {
+        /* Piped stdio (NOT inherit) so we can read the script's
+           `[install-kokoro]` step lines and surface the latest to the UI. */
+        proc = this.spawnFn('node', [script, ...this.installArgs], {
+          cwd: this.repoRoot,
+          windowsHide: true,
+        });
+      } catch (err) {
+        reject(err instanceof Error ? err : new Error(String(err)));
+        return;
+      }
+      let stderrTail = '';
+      const onStdout = (b: Buffer): void => {
+        for (const line of b.toString('utf8').split('\n')) {
+          const m = line.match(/\[install-kokoro\]\s*(.+)/);
+          if (m) this.update(job, { step: m[1].trim() });
+        }
+      };
+      const onStderr = (b: Buffer): void => {
+        /* Keep only the tail — a download failure dump can be huge; the last
+           few lines carry the actionable error. */
+        stderrTail = (stderrTail + b.toString('utf8')).slice(-2000);
+      };
+      proc.stdout?.on('data', onStdout);
+      proc.stderr?.on('data', onStderr);
+      proc.on('error', (err) => reject(err));
+      proc.on('close', (code) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(
+            new Error(
+              `install-kokoro.mjs exited with code ${code}.` +
+                (stderrTail.trim() ? ` ${stderrTail.trim().split('\n').slice(-3).join(' ')}` : ''),
+            ),
+          );
+        }
+      });
+    });
+  }
+
+  private transition(
+    job: KokoroInstallJob,
+    status: KokoroInstallJobStatus,
+    extra: Partial<KokoroInstallJob> = {},
+  ): void {
+    job.status = status;
+    Object.assign(job, extra);
+    job.updatedAt = Date.now();
+  }
+
+  private update(job: KokoroInstallJob, patch: Partial<KokoroInstallJob>): void {
+    Object.assign(job, patch);
+    job.updatedAt = Date.now();
+  }
+
+  /** Reset for tests — drops all jobs. */
+  _reset(): void {
+    this.jobs.clear();
+    this.active = null;
+    this.nextId = 1;
+  }
+}

--- a/server/src/tts/kokoro-install-detect.test.ts
+++ b/server/src/tts/kokoro-install-detect.test.ts
@@ -1,0 +1,47 @@
+/* Unit tests for detectKokoroInstalledOnDisk — mocks model-paths.js
+   (kokoroWeightPaths + totalSizeBytes) and asserts the fileCount > 0 predicate. */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./model-paths.js', () => ({
+  kokoroWeightPaths: vi.fn(() => [] as string[]),
+  totalSizeBytes: vi.fn(() => ({ bytes: 0, fileCount: 0 })),
+}));
+
+import { detectKokoroInstalledOnDisk } from './kokoro-install-detect.js';
+import { kokoroWeightPaths, totalSizeBytes } from './model-paths.js';
+
+const mockKokoroWeightPaths = vi.mocked(kokoroWeightPaths);
+const mockTotalSizeBytes = vi.mocked(totalSizeBytes);
+
+beforeEach(() => {
+  mockKokoroWeightPaths.mockReturnValue([]);
+  mockTotalSizeBytes.mockReturnValue({ bytes: 0, fileCount: 0 });
+});
+
+describe('detectKokoroInstalledOnDisk', () => {
+  it('returns false when fileCount is 0 (no weight files found)', () => {
+    mockTotalSizeBytes.mockReturnValue({ bytes: 0, fileCount: 0 });
+    expect(detectKokoroInstalledOnDisk('/repo')).toBe(false);
+  });
+
+  it('returns true when fileCount is 2 (both weight files present)', () => {
+    mockKokoroWeightPaths.mockReturnValue(['/repo/kokoro-v1.0.onnx', '/repo/voices-v1.0.bin']);
+    mockTotalSizeBytes.mockReturnValue({ bytes: 500_000_000, fileCount: 2 });
+    expect(detectKokoroInstalledOnDisk('/repo')).toBe(true);
+  });
+
+  it('returns true when fileCount is 1 (partial install still counts as present)', () => {
+    mockKokoroWeightPaths.mockReturnValue(['/repo/kokoro-v1.0.onnx']);
+    mockTotalSizeBytes.mockReturnValue({ bytes: 300_000_000, fileCount: 1 });
+    expect(detectKokoroInstalledOnDisk('/repo')).toBe(true);
+  });
+
+  it('passes the weight paths from kokoroWeightPaths into totalSizeBytes', () => {
+    const paths = ['/repo/kokoro-v1.0.onnx', '/repo/voices-v1.0.bin'];
+    mockKokoroWeightPaths.mockReturnValue(paths);
+    mockTotalSizeBytes.mockReturnValue({ bytes: 500_000_000, fileCount: 2 });
+    detectKokoroInstalledOnDisk('/repo');
+    expect(mockTotalSizeBytes).toHaveBeenCalledWith(paths);
+  });
+});

--- a/server/src/tts/kokoro-install-detect.ts
+++ b/server/src/tts/kokoro-install-detect.ts
@@ -1,0 +1,8 @@
+/* fs-21 — is Kokoro installed on disk? Single source of truth for the
+   binary "both weight files present" check, reused by the install bootstrap
+   and engine-presence. */
+import { kokoroWeightPaths, totalSizeBytes } from './model-paths.js';
+
+export function detectKokoroInstalledOnDisk(repoRoot: string): boolean {
+  return totalSizeBytes(kokoroWeightPaths(repoRoot)).fileCount > 0;
+}

--- a/server/tts-sidecar/scripts/install-kokoro.mjs
+++ b/server/tts-sidecar/scripts/install-kokoro.mjs
@@ -21,7 +21,7 @@
 // Idempotent: already-verified files are skipped without re-downloading.
 
 import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, readFileSync, unlinkSync, createWriteStream } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, unlinkSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';

--- a/server/tts-sidecar/scripts/install-kokoro.mjs
+++ b/server/tts-sidecar/scripts/install-kokoro.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// install-kokoro.mjs -- download the Kokoro v1 ONNX model + voices manifest
+// into the sidecar voices/kokoro/ directory so the sidecar can preload them
+// on boot. (fs-21 wave 1 -- in-app install parity with install-kokoro.ps1.)
+//
+// Cross-platform Node ESM (Windows + macOS + Linux). The .ps1/.sh siblings
+// continue to exist for terminal use; this .mjs is the portable entry the
+// in-app install-bootstrap can spawn without shell constraints.
+//
+// What it does:
+//   1. Resolve the target directory (env overrides or <repoRoot>/server/
+//      tts-sidecar/voices/kokoro/).
+//   2. For each of the two weight files (kokoro-v1.0.onnx + voices-v1.0.bin):
+//      - If the file exists AND its SHA256 matches the pin -> skip.
+//      - Otherwise download via Node global fetch (follows 302 redirects),
+//        verify SHA256, refuse + delete on mismatch.
+//
+// Usage:
+//   node server/tts-sidecar/scripts/install-kokoro.mjs
+//
+// Idempotent: already-verified files are skipped without re-downloading.
+
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, unlinkSync, createWriteStream } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// scripts/ -> tts-sidecar/ -> server/ -> repo root
+const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
+
+const KOKORO_URL_BASE =
+  'https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/';
+
+const FILES = [
+  { name: 'kokoro-v1.0.onnx', url: `${KOKORO_URL_BASE}kokoro-v1.0.onnx` },
+  { name: 'voices-v1.0.bin', url: `${KOKORO_URL_BASE}voices-v1.0.bin` },
+];
+
+/** SHA256 a file synchronously, returning a lowercased hex string. */
+export function sha256File(path) {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+/**
+ * Read the kokoro section from model-hashes.json (next to this script).
+ * Returns an object keyed by filename, each { sha256, sizeBytes }.
+ */
+export function kokoroHashes() {
+  const manifest = JSON.parse(readFileSync(join(__dirname, 'model-hashes.json'), 'utf8'));
+  return manifest.kokoro;
+}
+
+function step(msg) {
+  process.stdout.write(`[install-kokoro] ${msg}\n`);
+}
+
+function resolveTargetDir() {
+  // Prefer explicit env overrides (KOKORO_MODEL_PATH points at the .onnx file).
+  if (process.env.KOKORO_MODEL_PATH) return dirname(process.env.KOKORO_MODEL_PATH);
+  if (process.env.KOKORO_VOICES_PATH) return dirname(process.env.KOKORO_VOICES_PATH);
+  return join(REPO_ROOT, 'server', 'tts-sidecar', 'voices', 'kokoro');
+}
+
+async function downloadFile(url, destPath) {
+  step(`Downloading ${url}`);
+  // Node 20 global fetch follows 302 redirects automatically (GitHub releases
+  // 302 -> cdn.githubusercontent.com). No manual redirect handling needed.
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} ${res.statusText} fetching ${url}`);
+  }
+  const buf = Buffer.from(await res.arrayBuffer());
+  if (buf.length < 1024) {
+    throw new Error(
+      `Downloaded file is only ${buf.length} bytes -- looks like an error page, not weights.`,
+    );
+  }
+  await writeFile(destPath, buf);
+}
+
+async function installFile(name, url, targetDir, hashes) {
+  const dest = join(targetDir, name);
+  const pin = hashes[name];
+
+  if (existsSync(dest)) {
+    const actual = sha256File(dest);
+    if (pin && actual === pin.sha256) {
+      step(`${name} already present, verified — skipping.`);
+      return;
+    }
+    step(`${name} exists but failed integrity check — re-downloading.`);
+    unlinkSync(dest);
+  }
+
+  await downloadFile(url, dest);
+
+  step(`Verifying ${name}...`);
+  const actual = sha256File(dest);
+  if (pin && actual !== pin.sha256) {
+    unlinkSync(dest);
+    step(`ERROR sha256 mismatch for ${name}`);
+    step(`  expected ${pin.sha256}`);
+    step(`  got      ${actual}`);
+    step(
+      `  Deleted the file. Re-run to retry, or re-bless model-hashes.json if the upstream asset legitimately changed.`,
+    );
+    process.exit(1);
+  }
+
+  const sizeMB = ((await import('node:fs')).statSync(dest).size / 1024 / 1024).toFixed(1);
+  step(`Downloaded and verified ${name} (${sizeMB} MB).`);
+}
+
+async function main() {
+  const targetDir = resolveTargetDir();
+
+  if (!existsSync(targetDir)) {
+    step(`Creating ${targetDir}`);
+    mkdirSync(targetDir, { recursive: true });
+  }
+
+  const hashes = kokoroHashes();
+
+  for (const { name, url } of FILES) {
+    await installFile(name, url, targetDir, hashes);
+  }
+
+  step('Done. Restart the sidecar to pick up the new weights.');
+}
+
+// Run only when invoked directly (node install-kokoro.mjs); stay inert on import
+// so unit tests can exercise sha256File / kokoroHashes without triggering a download.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    process.stderr.write(`[install-kokoro] FAIL: ${err.message}\n`);
+    process.exit(1);
+  });
+}

--- a/server/vitest.config.slow.ts
+++ b/server/vitest.config.slow.ts
@@ -42,6 +42,7 @@ export const SLOW_FILES = [
   'src/routes/generation-boundary-recycle.test.ts',
   'src/parsers/pdf-real.test.ts',
   'src/routes/setup-readiness.route.test.ts',
+  'src/routes/kokoro-install.route.test.ts',
 ];
 
 export default defineConfig({

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -43,6 +43,9 @@ const SLOW_FILES_TO_EXCLUDE = [
   /* Integration test: makes a real 2s-timeout network probe to the sidecar.
      Slow/flaky under the parallel fast pool — serialised here (fs-21). */
   'src/routes/setup-readiness.route.test.ts',
+  /* Integration route test: supertest against a live Express instance
+     (kokoro install bootstrap, offline-stubbed). Serialised (fs-21). */
+  'src/routes/kokoro-install.route.test.ts',
 ];
 
 /* Contention throttle (plan 156). LOW_CONCURRENCY (set manually, or

--- a/src/components/kokoro-install.test.tsx
+++ b/src/components/kokoro-install.test.tsx
@@ -1,0 +1,119 @@
+/* KokoroInstall component state-machine spec. Mirrors coqui-install.test.tsx —
+   stubbed fetch drives detect/install/poll. */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { KokoroInstall } from './kokoro-install';
+
+const fetchMock = vi.fn();
+
+function jsonResponse(body: unknown, init: { status?: number } = {}) {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('KokoroInstall', () => {
+  it('renders the "installed" pill when /detect reports installed', async () => {
+    fetchMock.mockImplementation((url: string) =>
+      url.includes('/detect')
+        ? Promise.resolve(jsonResponse({ state: 'ready', installed: true }))
+        : Promise.resolve(jsonResponse({})),
+    );
+    render(<KokoroInstall />);
+    await waitFor(() => expect(screen.getByTestId('kokoro-install-ready')).toBeInTheDocument());
+    expect(screen.getByText(/Kokoro is installed/i)).toBeInTheDocument();
+  });
+
+  it('renders the install card when not installed', async () => {
+    fetchMock.mockImplementation((url: string) =>
+      url.includes('/detect')
+        ? Promise.resolve(jsonResponse({ state: 'weights-missing', installed: false }))
+        : Promise.resolve(jsonResponse({})),
+    );
+    render(<KokoroInstall />);
+    await waitFor(() =>
+      expect(screen.getByTestId('kokoro-install-not-detected')).toBeInTheDocument(),
+    );
+    expect(screen.getByRole('button', { name: /install kokoro/i })).toBeInTheDocument();
+  });
+
+  it('clicking Install POSTs /install and renders the job card with the step text', async () => {
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.endsWith('/detect')) {
+        return Promise.resolve(jsonResponse({ state: 'weights-missing', installed: false }));
+      }
+      if (url.endsWith('/install') && init?.method === 'POST') {
+        return Promise.resolve(
+          jsonResponse({ id: '1', status: 'installing', step: 'Downloading Kokoro weights', error: null }),
+        );
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    render(<KokoroInstall />);
+    await waitFor(() =>
+      expect(screen.getByTestId('kokoro-install-not-detected')).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /install kokoro/i }));
+    await waitFor(() => expect(screen.getByTestId('kokoro-install-job')).toBeInTheDocument());
+    expect(screen.getByText(/Downloading Kokoro weights/i)).toBeInTheDocument();
+  });
+
+  it('calls onInstalled when a poll flips to installed', async () => {
+    const onInstalled = vi.fn();
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/detect')) {
+        return Promise.resolve(jsonResponse({ state: 'weights-missing', installed: false }));
+      }
+      if (url.endsWith('/install') && init?.method === 'POST') {
+        return Promise.resolve(
+          jsonResponse({ id: '42', status: 'installing', step: 'Downloading…', error: null }),
+        );
+      }
+      if (url.includes('/install/42')) {
+        return Promise.resolve(
+          jsonResponse({ id: '42', status: 'installed', step: null, error: null }),
+        );
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    render(<KokoroInstall onInstalled={onInstalled} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('kokoro-install-not-detected')).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /install kokoro/i }));
+    await waitFor(() => expect(onInstalled).toHaveBeenCalledTimes(1), { timeout: 5000 });
+  });
+
+  it('renders the error card with a retry button on a failed job', async () => {
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.endsWith('/detect')) {
+        return Promise.resolve(jsonResponse({ state: 'weights-missing', installed: false }));
+      }
+      if (url.endsWith('/install') && init?.method === 'POST') {
+        return Promise.resolve(
+          jsonResponse({ id: '1', status: 'error', step: null, error: 'download failed' }),
+        );
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    render(<KokoroInstall />);
+    await waitFor(() =>
+      expect(screen.getByTestId('kokoro-install-not-detected')).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /install kokoro/i }));
+    await waitFor(() => expect(screen.getByTestId('kokoro-install-error')).toBeInTheDocument());
+    expect(screen.getByText(/download failed/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/kokoro-install.tsx
+++ b/src/components/kokoro-install.tsx
@@ -1,0 +1,173 @@
+/* In-app Kokoro install affordance. Mirrors coqui-install.tsx but for the
+   default Kokoro engine:
+
+     GET  /api/kokoro/detect          → { state, installed }
+     POST /api/kokoro/install         → { id, status, step, ... } (202)
+     GET  /api/kokoro/install/:id     → poll
+     POST /api/kokoro/install/:id/recheck → re-probe
+
+   Progress is STEP-based (install-kokoro.mjs streams step lines; the ~330 MB
+   download has no single byte total). Self-contained — owns its polling loop,
+   no redux. Kokoro is the DEFAULT engine — copy frames it as such. */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { PrimaryButton } from './primitives';
+
+export type KokoroInstallState = 'not-installed' | 'weights-missing' | 'ready' | 'loaded';
+
+export interface KokoroInstallJob {
+  id: string;
+  status: 'detecting' | 'installing' | 'installed' | 'error';
+  step: string | null;
+  error: string | null;
+  startedAt: number;
+  updatedAt: number;
+}
+
+interface DetectResp {
+  state: KokoroInstallState;
+  installed: boolean;
+}
+
+const POLL_INTERVAL_MS = 1_500;
+
+export function KokoroInstall({ onInstalled }: { onInstalled?: () => void } = {}) {
+  const [detect, setDetect] = useState<DetectResp | null>(null);
+  const [job, setJob] = useState<KokoroInstallJob | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const doDetect = useCallback(async () => {
+    try {
+      const res = await fetch('/api/kokoro/detect');
+      if (!res.ok) throw new Error(`detect failed: HTTP ${res.status}`);
+      setDetect((await res.json()) as DetectResp);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    void doDetect();
+  }, [doDetect]);
+
+  useEffect(() => {
+    if (!job) return;
+    if (job.status === 'installed' || job.status === 'error') return;
+    if (pollRef.current) clearTimeout(pollRef.current);
+    pollRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/kokoro/install/${job.id}`);
+        if (!res.ok) throw new Error(`poll failed: HTTP ${res.status}`);
+        const body = (await res.json()) as KokoroInstallJob;
+        setJob(body);
+        if (body.status === 'installed') {
+          void doDetect();
+          onInstalled?.();
+        }
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    }, POLL_INTERVAL_MS);
+    return () => {
+      if (pollRef.current) clearTimeout(pollRef.current);
+    };
+  }, [job, doDetect, onInstalled]);
+
+  const startInstall = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      const res = await fetch('/api/kokoro/install', { method: 'POST' });
+      if (!res.ok) throw new Error(`start failed: HTTP ${res.status}`);
+      setJob((await res.json()) as KokoroInstallJob);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (detect?.installed) {
+    return (
+      <div
+        data-testid="kokoro-install-ready"
+        className="rounded-2xl border border-emerald-200 bg-emerald-50 p-4"
+      >
+        <div className="flex items-center gap-3">
+          <span className="w-2 h-2 rounded-full bg-emerald-600" />
+          <div className="flex-1">
+            <p className="text-sm font-semibold text-emerald-900">Kokoro is installed</p>
+            <p className="text-xs text-emerald-900/70">
+              The default voice engine is ready — English voices are available in the per-character voice picker.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={doDetect}
+            disabled={busy}
+            className="px-3 py-1.5 rounded-full border border-emerald-300 bg-white text-xs text-emerald-900 hover:bg-emerald-100 disabled:opacity-50"
+          >
+            Re-check
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (job && (job.status === 'detecting' || job.status === 'installing')) {
+    return (
+      <div
+        data-testid="kokoro-install-job"
+        data-job-status={job.status}
+        className="rounded-2xl border border-ink/10 bg-canvas p-4 space-y-2"
+      >
+        <div className="flex items-center gap-3">
+          <span className="w-3 h-3 rounded-full border-2 border-magenta border-t-transparent animate-spin" />
+          <p className="text-sm font-semibold text-ink">
+            {job.status === 'detecting' ? 'Checking your system…' : 'Installing Kokoro…'}
+          </p>
+        </div>
+        <p className="text-xs text-ink/60">
+          {job.step ?? 'Downloading Kokoro weights (~330 MB) — this should only take a minute.'}
+        </p>
+      </div>
+    );
+  }
+
+  if (job && job.status === 'error') {
+    return (
+      <div
+        data-testid="kokoro-install-error"
+        className="rounded-2xl border border-rose-200 bg-rose-50 p-4 space-y-2"
+      >
+        <p className="text-sm font-semibold text-rose-900">Kokoro install failed</p>
+        <p className="text-xs text-rose-900/80">{job.error ?? 'Install failed.'}</p>
+        <PrimaryButton variant="dark" onClick={startInstall} icon={false}>
+          {busy ? 'Retrying…' : 'Try again'}
+        </PrimaryButton>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="kokoro-install-not-detected"
+      className="rounded-2xl border border-ink/10 bg-canvas p-4 space-y-3"
+    >
+      <div>
+        <p className="text-sm font-semibold text-ink">Kokoro is not installed</p>
+        <p className="mt-1 text-xs text-ink/55">
+          Kokoro is the default voice engine — 28 expressive English voices, fast CPU inference,
+          and a compact ~330 MB footprint. Install it once and every book benefits immediately.
+          Qwen (voice design) and Coqui (zero-shot cloning) are separate optional engines.
+        </p>
+      </div>
+      <PrimaryButton variant="dark" onClick={startInstall} disabled={busy} icon={false}>
+        {busy ? 'Starting…' : 'Install Kokoro'}
+      </PrimaryButton>
+      {error && <p className="text-xs text-rose-700">{error}</p>}
+    </div>
+  );
+}

--- a/src/views/model-manager.test.tsx
+++ b/src/views/model-manager.test.tsx
@@ -374,10 +374,10 @@ describe('ModelManagerView — per-row install (fs-23 follow-up)', () => {
     expect(within(qwen).getByTestId('model-install-toggle-qwen-base')).toHaveTextContent(/Update/);
   });
 
-  it('offers no install toggle for a release-bundled model (kokoro)', async () => {
+  it('shows an Install toggle for kokoro (fs-21: weights fetched at install time, not bundled)', async () => {
     renderManager();
     const kokoro = await screen.findByTestId('model-row-kokoro');
-    expect(within(kokoro).queryByTestId('model-install-toggle-kokoro')).toBeNull();
+    expect(within(kokoro).getByTestId('model-install-toggle-kokoro')).toBeInTheDocument();
   });
 
   it('reduces the bottom card to the Ollama analyzer only — no TTS/ASR installer headings', async () => {

--- a/src/views/model-manager.tsx
+++ b/src/views/model-manager.tsx
@@ -21,6 +21,7 @@ import { api, type ModelInventoryItem, type ModelInventoryResponse } from '../li
 import { formatBytes } from '../lib/bytes';
 import { ModelSettingsForm } from '../components/model-settings-form';
 import { CoquiInstall } from '../components/coqui-install';
+import { KokoroInstall } from '../components/kokoro-install';
 import { QwenInstall } from '../components/qwen-install';
 import { WhisperInstall } from '../components/whisper-install';
 
@@ -35,9 +36,12 @@ const TTS_ENGINE_BY_ID: Partial<Record<string, 'coqui' | 'kokoro' | 'qwen'>> = {
 
 /* Inventory ids with an in-app installer, rendered inline under the row (fs-23
    follow-up — install lives with the model, not in a separate bottom section).
-   kokoro ships in the release bundle, qwen-design is fetched at design time, and
-   ollama models live in the analyzer section below — none get a row installer. */
+   As of fs-21 wave 1, kokoro has an in-app installer too — its ~330 MB weights
+   are fetched at install time rather than bundled in the release zip.
+   qwen-design is fetched at design time, and ollama models live in the analyzer
+   section below — neither gets a row installer here. */
 const INSTALLER_BY_ID: Partial<Record<string, ComponentType<{ onInstalled?: () => void }>>> = {
+  kokoro: KokoroInstall,
   coqui: CoquiInstall,
   'qwen-base': QwenInstall,
   whisper: WhisperInstall,


### PR DESCRIPTION
## Summary

Wave 1 of **fs-21** (#474): a one-click **in-app Kokoro installer** — Kokoro is the default TTS engine but its weights are excluded from the release zip, and it was the only TTS hard-blocker with no in-app installer. Mirrors the existing Coqui/Qwen/Whisper install machinery (polling, not SSE).

- **`install-kokoro.mjs`** — Node downloader for the two ONNX weight files with SHA256 verify against `model-hashes.json` (ports the `.ps1` verify the `.sh` lacks); coexists with the existing terminal `.ps1`/`.sh`.
- **`KokoroInstallBootstrap`** — in-memory job manager (binary `installed`/`not-installed` state — no Coqui-style `weights-missing` branch).
- **`/api/kokoro`** route (detect / install / poll / recheck) + **`KokoroInstall`** polling component, wired into the Model Manager's `INSTALLER_BY_ID`.
- DRY: extracted `detectKokoroInstalledOnDisk` (reused by `engine-presence`).
- Docs/manifest: pinned the new `.mjs` in the release-manifest test; INSTALL.md notes the in-app option.

**Scope:** the venv bootstrap (decision Z) was split to **Wave 1b** by the pre-execution adversarial review (unverifiable on a box that already has a venv; real `pip install` is OWED).

## Test plan
- Unit: install-kokoro helpers (SHA256 + hash manifest), detect helper, bootstrap (7 cases incl. short-circuit/error/step), KokoroInstall component (5 states), Model-Manager wiring (existing 'no kokoro installer' assertion **inverted**).
- Server integration: `/api/kokoro` route test pinned to the slow pool.
- `npm run verify` green locally (full battery).

Built via plan → **adversarial plan review** (caught the test-inversion + a false cross-platform premise) → subagent-driven execution per task. Refs #474.

**OWED (not CI-gated):** real Kokoro install on a Mac + a Linux box (the `.mjs` is Node-cross-platform; offline + stubbed-spawn flow fully tested here).