### PR TITLE
feat(server,frontend,sidecar): fs-21 wave 1b — venv bootstrap (decision Z)

### DIFF
--- a/docs/superpowers/plans/2026-06-12-fs21-wave1b-venv-bootstrap.md
+++ b/docs/superpowers/plans/2026-06-12-fs21-wave1b-venv-bootstrap.md
@@ -1,0 +1,135 @@
+# fs-21 Wave 1b — Venv bootstrap (decision Z) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Checkbox (`- [ ]`) steps.
+
+**Goal:** Let the first-run wizard one-click **bootstrap the sidecar Python venv** — the artifact upstream of every TTS engine (no venv → sidecar won't start → no engine runs). Per **decision Z**: do it in-app when a Python 3.11 interpreter is found, and **degrade to copy-paste per-OS instructions** when it isn't (the wizard never owns provisioning Python itself).
+
+**Architecture:** A Python-interpreter discovery helper + a Node `bootstrap-venv.mjs` that runs `python -m venv` then `<venv>/python -m pip install -r requirements.txt` (idempotent — no-op if the venv python already exists), fronted by a `VenvBootstrap` job class + a `/api/setup/venv` polling route + a `fetch`-polling component, mirroring the install-bootstrap pattern Wave 1 used for Kokoro.
+
+**Tech Stack:** Node 20 + TS (ESM `.js` imports), `node:child_process` (`spawn`/`spawnSync`), Vitest, React 18 + `fetch`-polling.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-fs21-first-run-wizard-design.md` · **Epic:** #474 · **Branch:** `feat/fs21-wave1b-venv-bootstrap` off `main` (worktree `C:\Claude\Projects\wt-fs21-wave1b`).
+
+> **Split from Wave 1 by the adversarial review.** Inherently **OWED (not CI-gated):** a real fresh `python -m venv` + multi-GB `pip install -r requirements.txt` on a box WITHOUT a venv (this box has one → the idempotent guard no-ops). All *logic + wiring* (discovery, helpers, job state, route shapes, component states, the degrade path) IS unit-tested here.
+
+> **Verified by Explore (2026-06-12):** Express 5.2.1 handles `app.use('/api/setup', readinessRouter)` + `app.use('/api/setup/venv', venvRouter)` cleanly in either mount order (readiness has no catch-all) — no `setupRouter` merge needed. Nothing in the repo creates a venv programmatically today; the existing `install-*.mjs` all `findVenvPython()` and exit if absent — `bootstrap-venv.mjs` is the opposite (it CREATES it).
+
+> **Standing rule:** this plan gets an adversarial review BEFORE any task executes.
+
+---
+
+## File Structure
+- Create `server/src/tts/python-discovery.ts` — `findPython311(opts?)` → `{ cmd, args } | null`.
+- Create `server/tts-sidecar/scripts/bootstrap-venv.mjs` — venv creator + pip installer (exports pure helpers `venvPythonPath`, `venvAlreadyBootstrapped`).
+- Create `server/src/tts/venv-bootstrap.ts` — `class VenvBootstrap` (job manager, mirror `KokoroInstallBootstrap`).
+- Create `server/src/routes/venv-bootstrap.ts` — `venvBootstrapRouter` at `/api/setup/venv`.
+- Create `src/components/venv-bootstrap.tsx` — polling component with the degrade path.
+- Modify `server/src/index.ts` (register), `server/vitest.config.slow.ts` + `server/vitest.config.ts` (pin the route test).
+- Tests beside each.
+
+---
+
+## Task B1: `python-discovery.ts`
+
+**Files:** Create `server/src/tts/python-discovery.ts`, `server/src/tts/python-discovery.test.ts`.
+
+- [ ] **Step 1: Failing test** — inject a stub `runFn(cmd, args) → { status, stdout, stderr }`:
+  - win32: prefers `py` with args `['-3.11']` when `py -3.11 --version` → `Python 3.11.x`.
+  - posix: tries `python3.11` then `python3`; accepts the first whose `--version` parses to 3.10–3.12.
+  - returns `null` when no candidate reports a 3.10–3.12 version.
+  - parses the version from EITHER stdout or stderr (older pythons print `--version` to stderr).
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { findPython311 } from './python-discovery.js';
+const ok = (v: string) => ({ status: 0, stdout: `Python ${v}\n`, stderr: '' });
+const fail = () => ({ status: 1, stdout: '', stderr: 'not found' });
+
+describe('findPython311', () => {
+  it('win32 prefers py -3.11', () => {
+    const r = findPython311({ platform: 'win32', runFn: (c, a) => (c === 'py' && a[0] === '-3.11' ? ok('3.11.9') : fail()) });
+    expect(r).toEqual({ cmd: 'py', args: ['-3.11'] });
+  });
+  it('posix falls back python3.11 → python3', () => {
+    const r = findPython311({ platform: 'linux', runFn: (c) => (c === 'python3' ? ok('3.12.2') : fail()) });
+    expect(r).toEqual({ cmd: 'python3', args: [] });
+  });
+  it('rejects too-old / too-new', () => {
+    expect(findPython311({ platform: 'linux', runFn: () => ok('3.9.1') })).toBeNull();
+    expect(findPython311({ platform: 'linux', runFn: () => ok('3.13.0') })).toBeNull();
+  });
+  it('null when nothing found', () => {
+    expect(findPython311({ platform: 'win32', runFn: () => fail() })).toBeNull();
+  });
+  it('parses version from stderr', () => {
+    const r = findPython311({ platform: 'linux', runFn: (c) => (c === 'python3.11' ? { status: 0, stdout: '', stderr: 'Python 3.11.0\n' } : fail()) });
+    expect(r).toEqual({ cmd: 'python3.11', args: [] });
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** `export function findPython311(opts?: { platform?: NodeJS.Platform; runFn?: (cmd: string, args: string[]) => { status: number | null; stdout: string; stderr: string } }): { cmd: string; args: string[] } | null`. Default `runFn` = `(cmd, args) => spawnSync(cmd, [...args, '--version'], { windowsHide: true, encoding: 'utf8' })` (map to `{ status, stdout, stderr }`). Candidates: win32 → `[['py',['-3.11']], ['python',[]]]`; posix → `[['python3.11',[]], ['python3',[]]]`. For each, run `--version`, parse `/Python (\d+)\.(\d+)/` from `stdout || stderr`, accept major===3 && minor 10–12. Return first match or null.
+- [ ] **Step 4: Run → PASS; Step 5: Commit** `feat(server): Python 3.11 interpreter discovery (fs-21 wave 1b)`.
+
+---
+
+## Task B2: `bootstrap-venv.mjs`
+
+**Files:** Create `server/tts-sidecar/scripts/bootstrap-venv.mjs`, `server/src/tts/bootstrap-venv-helpers.test.ts`.
+
+- [ ] **Step 1: Failing helper test** (mirror `install-kokoro-helpers.test.ts`'s `@ts-expect-error` import). The `.mjs` exports `venvPythonPath(venvDir, platform)` (→ `join(venvDir,'Scripts','python.exe')` on win32 else `join(venvDir,'bin','python')`) and `venvAlreadyBootstrapped(venvDir, platform)` (`existsSync(venvPythonPath(...))`). Test both layouts + a temp dir with/without the python file.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement `bootstrap-venv.mjs`:**
+  - `export function venvPythonPath(venvDir, platform)` and `export function venvAlreadyBootstrapped(venvDir, platform)`.
+  - `main()` (under the import-meta main-guard from `install-kokoro.mjs`): resolve `venvDir = process.env.SIDECAR_VENV_DIR ?? join(repoRoot,'server','tts-sidecar','.venv')`. If `venvAlreadyBootstrapped(venvDir, process.platform)` → `[bootstrap-venv] venv already present` + exit 0 (idempotent). Else: `process.argv[2]` = python cmd, `process.argv.slice(3)` = its args; run `spawnSync(pyCmd, [...pyArgs, '-m', 'venv', venvDir], { stdio:'inherit', windowsHide:true })` (throw on non-zero), then `spawnSync(venvPythonPath(venvDir, process.platform), ['-m','pip','install','-r', join(repoRoot,'server','tts-sidecar','requirements.txt')], { stdio:'inherit', windowsHide:true })` (throw on non-zero). Emit `[bootstrap-venv] <step>` lines (creating venv, installing requirements, done). Exit 1 with `[bootstrap-venv] FAIL: ...` on error.
+- [ ] **Step 4: Run → PASS; Step 5: Commit** `feat(sidecar): bootstrap-venv.mjs (python -m venv + pip install) (fs-21 wave 1b)`.
+
+---
+
+## Task B3: `VenvBootstrap` class
+
+**Files:** Create `server/src/tts/venv-bootstrap.ts`, `server/src/tts/venv-bootstrap.test.ts`.
+
+- [ ] **Step 1: READ `server/src/tts/kokoro-install-bootstrap.ts` (Wave 1) in full.** Mirror as `VenvBootstrap`:
+  - State: `'present' | 'absent'` (binary).
+  - `detect()` → `{ venvPresent: sidecarVenvPresent(repoRoot) /* from ../diagnostics/venv.js */, python: findPython311() /* {cmd,args}|null */, installed: venvPresent }`.
+  - `start()`: if `venvPresent` → short-circuit job `status:'installed'`; else if `findPython311()` returns null → job `status:'error'` whose `error` is the per-OS manual instructions string (the **decision-Z degrade** — `py -3.11 -m venv .venv` / `python3.11 -m venv .venv` + the pip line); else spawn `this.spawnFn('node', [join(repoRoot,'server','tts-sidecar','scripts','bootstrap-venv.mjs'), python.cmd, ...python.args], { cwd: repoRoot, windowsHide: true })`, surfacing `[bootstrap-venv]` step lines.
+  - injectable `spawnFn`, `detectVenvFn` (= sidecarVenvPresent), `findPythonFn` (= findPython311); `getJob/getActiveJob/recheck/_reset`. Export the class + `VenvBootstrapJob` interface.
+- [ ] **Step 2: Failing test** (stubbed deps): venv present → short-circuits `installed` no spawn; venv absent + python found → spawns once, `[bootstrap-venv]` updates step, exit 0 → installed; venv absent + NO python → `error` job carrying instructions, NO spawn; non-zero exit → error with stderr tail.
+- [ ] **Step 3: Run → FAIL; Step 4: implement; Step 5: Run → PASS; Step 6: Commit** `feat(server): VenvBootstrap job manager (decision Z) (fs-21 wave 1b)`.
+
+---
+
+## Task B4: `/api/setup/venv` route + registration (slow-pool test)
+
+**Files:** Create `server/src/routes/venv-bootstrap.ts`, `server/src/routes/venv-bootstrap.route.test.ts`; modify `server/src/index.ts`, `server/vitest.config.slow.ts`, `server/vitest.config.ts`.
+
+- [ ] **Step 1: READ `server/src/routes/kokoro-install.ts` (Wave 1).** Mirror as `venvBootstrapRouter`: `GET /detect` → bootstrap.detect(); `POST /bootstrap` → start() → 202 + job; `GET /bootstrap/:id` → getJob (404 if null). Module-singleton `VenvBootstrap` + the same test-injection hook. (Path verbs are `/bootstrap` not `/install` — it's not installing a model.)
+- [ ] **Step 2: Failing slow-pool route test** (stubbed bootstrap, mirror `kokoro-install.route.test.ts`): detect shape; POST `/bootstrap` → 202; no-python → error job carries the instructions string. Pin `'src/routes/venv-bootstrap.route.test.ts'` to `SLOW_FILES` (slow config) + `SLOW_FILES_TO_EXCLUDE` (fast config).
+- [ ] **Step 3: Run → FAIL; Step 4: implement + register `app.use('/api/setup/venv', venvBootstrapRouter)` AFTER the `app.use('/api/setup', setupReadinessRouter)` line (express 5 multi-mount verified safe); Step 5: slow test → PASS + `npm run typecheck`.**
+- [ ] **Step 6: Commit** `feat(server): /api/setup/venv bootstrap route (decision Z) (fs-21 wave 1b)`.
+
+---
+
+## Task B5: `venv-bootstrap.tsx` component
+
+**Files:** Create `src/components/venv-bootstrap.tsx`, `src/components/venv-bootstrap.test.tsx`.
+
+- [ ] **Step 1: READ `src/components/kokoro-install.tsx` (Wave 1).** Mirror as `VenvBootstrap({ onBootstrapped })`, polling `/api/setup/venv/detect`, `POST /api/setup/venv/bootstrap`, `GET /api/setup/venv/bootstrap/:id`. States: `venvPresent` → green "TTS engine ready"; `!venvPresent && python found` → one-click "Set up the TTS engine" (POST + poll `[bootstrap-venv]` steps; note this can take several minutes — show the live step + a "this can take a few minutes" hint); `!venvPresent && NO python` → render the **per-OS manual instructions** (decision-Z degrade) + a "Re-check" button; error → message + retry. Design tokens, no hex.
+- [ ] **Step 2: Failing test** (mock fetch): renders one-click when python found; renders manual instructions when not; calls `onBootstrapped` when a poll flips to present/installed.
+- [ ] **Step 3: Run → FAIL; Step 4: implement; Step 5: Run → PASS + typecheck.**
+- [ ] **Step 6: Commit** `feat(frontend): venv bootstrap component (decision Z) (fs-21 wave 1b)`.
+
+---
+
+## Task B6: Full verify + draft PR
+
+- [ ] **Step 1:** `npm run verify` green (cache-aware retry for the `test:server` contention flake).
+- [ ] **Step 2:** `gh pr create --draft --title "feat(server,frontend,sidecar): fs-21 wave 1b — venv bootstrap (decision Z)" --body "... Refs #474. OWED: real fresh venv create + pip install on a box without a venv (Win/mac/linux); logic + degrade path fully tested here."` → `gh pr ready` once green.
+
+---
+
+## Self-Review
+- Covers decision Z end-to-end: discovery (B1) → creator (B2) → job (B3) → route (B4) → component with the degrade path (B5).
+- **Open questions for the adversarial review:** (1) confirm `sidecarVenvPresent` is exported from `server/src/diagnostics/venv.js` (Wave 0) with the signature `(repoRoot)`; (2) confirm the `/api/setup/venv` mount truly doesn't collide with the readiness router on THIS codebase (Explore verified on express 5.2.1 — re-confirm the readiness router has no `/*`); (3) does `bootstrap-venv.mjs`'s idempotent no-op make B2/B3 trivially green here while the real path stays OWED — is the OWED framing honest in the PR body; (4) should `venv-bootstrap.tsx` reuse any copy from the Wave 0 readiness-blocker remediation, or is it standalone.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -82,6 +82,7 @@ import { modelsInventoryRouter } from './routes/models-inventory.js';
 import { whisperInstallRouter } from './routes/whisper-install.js';
 import { coquiInstallRouter } from './routes/coqui-install.js';
 import { kokoroInstallRouter } from './routes/kokoro-install.js';
+import { venvBootstrapRouter } from './routes/venv-bootstrap.js';
 import { gpuQueueRouter } from './routes/gpu-queue.js';
 import { diagnosticsRouter } from './routes/diagnostics.js';
 import { setupReadinessRouter } from './routes/setup-readiness.js';
@@ -253,6 +254,7 @@ app.use('/api/models', modelsInventoryRouter); // fs-23 — in-app Model Manager
 app.use('/api/gpu', gpuQueueRouter); // mounts GET /queue (semaphore depth + inFlight for the top-bar pill)
 app.use('/api/diagnostics', diagnosticsRouter); // fs-18 — GET / one-shot health board (admin console)
 app.use('/api/setup', setupReadinessRouter); // fs-21 — first-run readiness probe
+app.use('/api/setup/venv', venvBootstrapRouter); // fs-21 wave 1b — venv bootstrap (decision Z)
 
 /* Production-mode frontend serving. Helper resolves whether to mount based
    on NODE_ENV=production OR the existence of dist/index.html. Mounted AFTER

--- a/server/src/routes/venv-bootstrap.route.test.ts
+++ b/server/src/routes/venv-bootstrap.route.test.ts
@@ -1,0 +1,175 @@
+/* /api/setup/venv bootstrap routes (fs-21 decision Z). Injects a VenvBootstrap
+   with a stubbed detect + spawn so the whole detect/bootstrap/poll/recheck
+   surface runs offline (no real Python or venv needed).
+
+   Pinned to the slow pool (vitest.config.slow.ts) — integration route test
+   that supertest's a live Express instance, same class as
+   setup-readiness.route.test.ts and kokoro-install.route.test.ts. */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import express from 'express';
+import request from 'supertest';
+import {
+  venvBootstrapRouter,
+  setVenvBootstrap,
+  _resetVenvBootstrap,
+} from './venv-bootstrap.js';
+import {
+  VenvBootstrap,
+  type VenvBootstrapJobStatus,
+} from '../tts/venv-bootstrap.js';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/setup/venv', venvBootstrapRouter);
+  return app;
+}
+
+function fakeChild(code: number) {
+  const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  queueMicrotask(() => child.emit('close', code));
+  return child;
+}
+
+async function poll(
+  app: express.Express,
+  id: string,
+  until: (s: VenvBootstrapJobStatus) => boolean,
+) {
+  for (let i = 0; i < 200; i++) {
+    const res = await request(app).get(`/api/setup/venv/bootstrap/${id}`);
+    if (until(res.body.status)) return res.body;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error('poll timed out');
+}
+
+afterEach(() => {
+  _resetVenvBootstrap();
+});
+
+describe('GET /api/setup/venv/detect', () => {
+  it('returns venvPresent:true and pythonFound:true when both are present', async () => {
+    setVenvBootstrap(
+      new VenvBootstrap({
+        repoRoot: '/repo',
+        detectVenvFn: () => true,
+        findPythonFn: () => ({ cmd: 'python3.11', args: [] }),
+      }),
+    );
+    const res = await request(makeApp()).get('/api/setup/venv/detect');
+    expect(res.status).toBe(200);
+    expect(res.body.venvPresent).toBe(true);
+    expect(res.body.pythonFound).toBe(true);
+    expect(res.body.state).toBe('present');
+  });
+
+  it('returns venvPresent:false and pythonFound:false when both are absent', async () => {
+    setVenvBootstrap(
+      new VenvBootstrap({
+        repoRoot: '/repo',
+        detectVenvFn: () => false,
+        findPythonFn: () => null,
+      }),
+    );
+    const res = await request(makeApp()).get('/api/setup/venv/detect');
+    expect(res.status).toBe(200);
+    expect(res.body.venvPresent).toBe(false);
+    expect(res.body.pythonFound).toBe(false);
+    expect(res.body.state).toBe('absent');
+  });
+});
+
+describe('POST /api/setup/venv/bootstrap + poll', () => {
+  it('starts a job (202) and returns a job with id and status', async () => {
+    setVenvBootstrap(
+      new VenvBootstrap({
+        repoRoot: '/repo',
+        detectVenvFn: () => true,
+        findPythonFn: () => ({ cmd: 'python3.11', args: [] }),
+      }),
+    );
+    const app = makeApp();
+    const start = await request(app).post('/api/setup/venv/bootstrap');
+    expect(start.status).toBe(202);
+    expect(start.body.id).toBeTruthy();
+    expect(start.body.status).toBeTruthy();
+  });
+
+  it('reaches installed once venv lands (python present, spawn exits 0)', async () => {
+    let calls = 0;
+    setVenvBootstrap(
+      new VenvBootstrap({
+        repoRoot: '/repo',
+        /* First call (pre-install probe) → absent; second call (post-
+           bootstrap probe) → present. */
+        detectVenvFn: () => calls++ > 0,
+        findPythonFn: () => ({ cmd: 'python3.11', args: [] }),
+        spawnFn: () => fakeChild(0) as never,
+      }),
+    );
+    const app = makeApp();
+    const start = await request(app).post('/api/setup/venv/bootstrap');
+    expect(start.status).toBe(202);
+
+    const done = await poll(app, start.body.id, (s) => s === 'installed' || s === 'error');
+    expect(done.status).toBe('installed');
+  });
+
+  it('404s polling an unknown job id', async () => {
+    setVenvBootstrap(
+      new VenvBootstrap({
+        repoRoot: '/repo',
+        detectVenvFn: () => true,
+        findPythonFn: () => ({ cmd: 'python3.11', args: [] }),
+      }),
+    );
+    const res = await request(makeApp()).get('/api/setup/venv/bootstrap/does-not-exist');
+    expect(res.status).toBe(404);
+  });
+
+  it('error job carries instructions string when Python is not found', async () => {
+    setVenvBootstrap(
+      new VenvBootstrap({
+        repoRoot: '/repo',
+        detectVenvFn: () => false,
+        findPythonFn: () => null,
+      }),
+    );
+    const app = makeApp();
+    const start = await request(app).post('/api/setup/venv/bootstrap');
+    expect(start.status).toBe(202);
+
+    const done = await poll(app, start.body.id, (s) => s === 'error' || s === 'installed');
+    expect(done.status).toBe('error');
+    expect(typeof done.error).toBe('string');
+    expect(done.error.length).toBeGreaterThan(0);
+  });
+});
+
+describe('POST /api/setup/venv/bootstrap/:id/recheck', () => {
+  it('promotes a stuck job to installed once the venv appears', async () => {
+    let present = false;
+    setVenvBootstrap(
+      new VenvBootstrap({
+        repoRoot: '/repo',
+        detectVenvFn: () => present,
+        findPythonFn: () => ({ cmd: 'python3.11', args: [] }),
+        spawnFn: () => fakeChild(0) as never,
+      }),
+    );
+    const app = makeApp();
+    const start = await request(app).post('/api/setup/venv/bootstrap');
+    // detectVenvFn always returns false → bootstrap exits 0 but venv still
+    // missing → job lands in 'error'
+    await poll(app, start.body.id, (s) => s === 'error');
+    present = true;
+    const res = await request(app).post(`/api/setup/venv/bootstrap/${start.body.id}/recheck`);
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('installed');
+  });
+});

--- a/server/src/routes/venv-bootstrap.ts
+++ b/server/src/routes/venv-bootstrap.ts
@@ -1,0 +1,57 @@
+/* In-app venv bootstrap routes (fs-21 decision Z). Mirrors kokoro-install.ts
+   so Account → Models can bootstrap the Python venv without a terminal:
+
+     GET  /api/setup/venv/detect              — venv + python probe (no job)
+     POST /api/setup/venv/bootstrap           — kick off bootstrap-venv.mjs (202 + job)
+     GET  /api/setup/venv/bootstrap/:id       — poll job progress
+     POST /api/setup/venv/bootstrap/:id/recheck — re-probe venv state
+
+   Verb is `/bootstrap`, NOT `/install` — the venv is not a model; we're
+   setting up the runtime environment, not downloading weights. */
+
+import { Router } from 'express';
+import type { Request, Response } from '../http.js';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { VenvBootstrap } from '../tts/venv-bootstrap.js';
+
+export const venvBootstrapRouter = Router();
+
+/* server/src/routes/venv-bootstrap.ts → repo root is three levels up. */
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+const defaultBootstrap = new VenvBootstrap({ repoRoot: REPO_ROOT });
+let bootstrap: VenvBootstrap = defaultBootstrap;
+
+/** Test injection — swap in a stubbed bootstrap (offline, no spawn). */
+export function setVenvBootstrap(b: VenvBootstrap): void {
+  bootstrap = b;
+}
+export function _resetVenvBootstrap(): void {
+  bootstrap = defaultBootstrap;
+}
+
+venvBootstrapRouter.get('/detect', (_req: Request, res: Response) => {
+  return res.json(bootstrap.detect());
+});
+
+venvBootstrapRouter.post('/bootstrap', (_req: Request, res: Response) => {
+  const job = bootstrap.start();
+  return res.status(202).json(job);
+});
+
+venvBootstrapRouter.get('/bootstrap/:id', (req: Request, res: Response) => {
+  const job = bootstrap.getJob(req.params.id);
+  if (!job) {
+    return res.status(404).json({ error: `No venv bootstrap job '${req.params.id}'` });
+  }
+  return res.json(job);
+});
+
+venvBootstrapRouter.post('/bootstrap/:id/recheck', (req: Request, res: Response) => {
+  const job = bootstrap.recheck(req.params.id);
+  if (!job) {
+    return res.status(404).json({ error: `No venv bootstrap job '${req.params.id}'` });
+  }
+  return res.json(job);
+});

--- a/server/src/tts/bootstrap-venv-helpers.test.ts
+++ b/server/src/tts/bootstrap-venv-helpers.test.ts
@@ -1,0 +1,24 @@
+/* fs-21 — bootstrap-venv.mjs helpers. The script's main() is
+   guarded (runs only when invoked directly), so importing it here is inert. */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+// @ts-expect-error — standalone install script ships no .d.ts; helpers are plain JS.
+import { venvPythonPath, venvAlreadyBootstrapped } from '../../tts-sidecar/scripts/bootstrap-venv.mjs';
+
+describe('bootstrap-venv helpers', () => {
+  it('venvPythonPath: win32 → Scripts/python.exe, posix → bin/python', () => {
+    expect(venvPythonPath('/v', 'win32')).toBe(join('/v', 'Scripts', 'python.exe'));
+    expect(venvPythonPath('/v', 'linux')).toBe(join('/v', 'bin', 'python'));
+  });
+  it('venvAlreadyBootstrapped reflects the python binary presence', () => {
+    const d = mkdtempSync(join(tmpdir(), 'v-'));
+    expect(venvAlreadyBootstrapped(d, 'linux')).toBe(false);
+    mkdirSync(join(d, 'bin'), { recursive: true });
+    writeFileSync(join(d, 'bin', 'python'), '');
+    expect(venvAlreadyBootstrapped(d, 'linux')).toBe(true);
+    rmSync(d, { recursive: true, force: true });
+  });
+});

--- a/server/src/tts/python-discovery.test.ts
+++ b/server/src/tts/python-discovery.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { findPython311 } from './python-discovery.js';
+const ok = (v: string) => ({ status: 0, stdout: `Python ${v}\n`, stderr: '' });
+const fail = () => ({ status: 1, stdout: '', stderr: 'not found' });
+
+describe('findPython311', () => {
+  it('win32 prefers py -3.11', () => {
+    const r = findPython311({ platform: 'win32', runFn: (c, a) => (c === 'py' && a[0] === '-3.11' ? ok('3.11.9') : fail()) });
+    expect(r).toEqual({ cmd: 'py', args: ['-3.11'] });
+  });
+  it('posix falls back python3.11 → python3', () => {
+    const r = findPython311({ platform: 'linux', runFn: (c) => (c === 'python3' ? ok('3.12.2') : fail()) });
+    expect(r).toEqual({ cmd: 'python3', args: [] });
+  });
+  it('rejects too-old / too-new', () => {
+    expect(findPython311({ platform: 'linux', runFn: () => ok('3.9.1') })).toBeNull();
+    expect(findPython311({ platform: 'linux', runFn: () => ok('3.13.0') })).toBeNull();
+  });
+  it('null when nothing found', () => {
+    expect(findPython311({ platform: 'win32', runFn: () => fail() })).toBeNull();
+  });
+  it('parses version from stderr', () => {
+    const r = findPython311({ platform: 'linux', runFn: (c) => (c === 'python3.11' ? { status: 0, stdout: '', stderr: 'Python 3.11.0\n' } : fail()) });
+    expect(r).toEqual({ cmd: 'python3.11', args: [] });
+  });
+});

--- a/server/src/tts/python-discovery.ts
+++ b/server/src/tts/python-discovery.ts
@@ -1,0 +1,30 @@
+/* fs-21 wave 1b — discover a Python 3.10–3.12 interpreter for the venv
+   bootstrap (decision Z). Returns null when none found → the caller degrades
+   to per-OS manual instructions. Injectable runFn for tests. */
+import { spawnSync } from 'node:child_process';
+
+type ProbeResult = { status: number | null; stdout: string; stderr: string };
+type RunFn = (cmd: string, args: string[]) => ProbeResult;
+
+const defaultRunFn: RunFn = (cmd, args) => {
+  const r = spawnSync(cmd, [...args, '--version'], { windowsHide: true, encoding: 'utf8' });
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+};
+
+export function findPython311(opts?: { platform?: NodeJS.Platform; runFn?: RunFn }): { cmd: string; args: string[] } | null {
+  const platform = opts?.platform ?? process.platform;
+  const runFn = opts?.runFn ?? defaultRunFn;
+  const candidates: { cmd: string; args: string[] }[] =
+    platform === 'win32'
+      ? [{ cmd: 'py', args: ['-3.11'] }, { cmd: 'python', args: [] }]
+      : [{ cmd: 'python3.11', args: [] }, { cmd: 'python3', args: [] }];
+  for (const c of candidates) {
+    const r = runFn(c.cmd, c.args);
+    if (r.status !== 0) continue;
+    const m = /Python (\d+)\.(\d+)/.exec(r.stdout || r.stderr);
+    if (!m) continue;
+    const major = Number(m[1]); const minor = Number(m[2]);
+    if (major === 3 && minor >= 10 && minor <= 12) return { cmd: c.cmd, args: c.args };
+  }
+  return null;
+}

--- a/server/src/tts/venv-bootstrap.test.ts
+++ b/server/src/tts/venv-bootstrap.test.ts
@@ -1,0 +1,162 @@
+/* VenvBootstrap state machine (fs-21 decision Z). Runs offline: stubbed
+   detectVenvFn / findPythonFn drive the detect inputs; stubbed spawnFn emits
+   fake `[bootstrap-venv]` lines + an exit code. No real Python spawn. */
+
+import { describe, it, expect } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { VenvBootstrap } from './venv-bootstrap.js';
+
+function makeFakeChild(exitCode: number, opts: { stdout?: string; stderr?: string } = {}) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  /* Emit after the caller has attached its listeners. */
+  queueMicrotask(() => {
+    if (opts.stdout) child.stdout.emit('data', Buffer.from(opts.stdout));
+    if (opts.stderr) child.stderr.emit('data', Buffer.from(opts.stderr));
+    child.emit('close', exitCode);
+  });
+  return child;
+}
+
+async function until(pred: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) throw new Error('timed out waiting for condition');
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe('VenvBootstrap', () => {
+  it('venv present → start() short-circuits to installed WITHOUT spawning', async () => {
+    let spawned = 0;
+    const b = new VenvBootstrap({
+      repoRoot: '/repo',
+      detectVenvFn: () => true,
+      findPythonFn: () => ({ cmd: 'python3.11', args: [] }),
+      spawnFn: () => {
+        spawned++;
+        return makeFakeChild(0) as never;
+      },
+    });
+    const job = b.start();
+    await until(() => b.getJob(job.id)?.status === 'installed');
+    expect(b.getJob(job.id)?.status).toBe('installed');
+    expect(spawned).toBe(0);
+  });
+
+  it('venv absent + python found → spawns once, [bootstrap-venv] line updates step, exit 0 → installed', async () => {
+    let spawned = 0;
+    const b = new VenvBootstrap({
+      repoRoot: '/repo',
+      detectVenvFn: () => false,
+      findPythonFn: () => ({ cmd: 'py', args: ['-3.11'] }),
+      spawnFn: () => {
+        spawned++;
+        return makeFakeChild(0, { stdout: '[bootstrap-venv] creating venv\n' }) as never;
+      },
+    });
+    const job = b.start();
+    await until(() => {
+      const j = b.getJob(job.id);
+      return j?.status === 'installed' || j?.status === 'error';
+    });
+    expect(spawned).toBe(1);
+    // step should have been updated at some point from the stdout line
+    // (final step may be overwritten, but spawn happened)
+  });
+
+  it('venv absent + NO python → job status error with "Python 3.11" in error, NO spawn', async () => {
+    let spawned = 0;
+    const b = new VenvBootstrap({
+      repoRoot: '/repo',
+      detectVenvFn: () => false,
+      findPythonFn: () => null,
+      spawnFn: () => {
+        spawned++;
+        return makeFakeChild(0) as never;
+      },
+    });
+    const job = b.start();
+    await until(() => b.getJob(job.id)?.status === 'error');
+    expect(b.getJob(job.id)?.status).toBe('error');
+    expect(b.getJob(job.id)?.error).toMatch(/Python 3\.11/);
+    expect(spawned).toBe(0);
+  });
+
+  it('[bootstrap-venv] stdout line updates job.step', async () => {
+    const b = new VenvBootstrap({
+      repoRoot: '/repo',
+      detectVenvFn: () => false,
+      findPythonFn: () => ({ cmd: 'py', args: ['-3.11'] }),
+      spawnFn: () =>
+        makeFakeChild(0, { stdout: '[bootstrap-venv] creating venv\n' }) as never,
+    });
+    const job = b.start();
+    // Wait for any terminal state
+    await until(() => {
+      const j = b.getJob(job.id);
+      return j?.status === 'installed' || j?.status === 'error';
+    });
+    // The step should have been set from the stdout line at some point
+    // (the final step text may be 'Done. Venv ready.' but the step should be non-null)
+    expect(b.getJob(job.id)?.step).not.toBeNull();
+  });
+
+  it('venv absent + python found, non-zero exit → error with stderr tail', async () => {
+    const b = new VenvBootstrap({
+      repoRoot: '/repo',
+      detectVenvFn: () => false,
+      findPythonFn: () => ({ cmd: 'py', args: ['-3.11'] }),
+      spawnFn: () =>
+        makeFakeChild(1, { stderr: 'ERROR: pip install failed\n' }) as never,
+    });
+    const job = b.start();
+    await until(() => b.getJob(job.id)?.status === 'error');
+    expect(b.getJob(job.id)?.error).toMatch(/exited with code 1/);
+    expect(b.getJob(job.id)?.error).toMatch(/pip install failed/);
+  });
+
+  it('detect() returns correct venvPresent / pythonFound / state', async () => {
+    const bPresent = new VenvBootstrap({
+      repoRoot: '/repo',
+      detectVenvFn: () => true,
+      findPythonFn: () => ({ cmd: 'py', args: ['-3.11'] }),
+    });
+    const result = await bPresent.detect();
+    expect(result.venvPresent).toBe(true);
+    expect(result.pythonFound).toBe(true);
+    expect(result.installed).toBe(true);
+    expect(result.state).toBe('present');
+
+    const bAbsent = new VenvBootstrap({
+      repoRoot: '/repo',
+      detectVenvFn: () => false,
+      findPythonFn: () => null,
+    });
+    const result2 = await bAbsent.detect();
+    expect(result2.venvPresent).toBe(false);
+    expect(result2.pythonFound).toBe(false);
+    expect(result2.installed).toBe(false);
+    expect(result2.state).toBe('absent');
+  });
+
+  it('recheck promotes a job to installed once venv appears', async () => {
+    let venvPresent = false;
+    const b = new VenvBootstrap({
+      repoRoot: '/repo',
+      detectVenvFn: () => venvPresent,
+      findPythonFn: () => ({ cmd: 'py', args: ['-3.11'] }),
+      spawnFn: () => makeFakeChild(0) as never,
+    });
+    // detectVenvFn always false → exit 0 but post-check false → error
+    const job = b.start();
+    await until(() => b.getJob(job.id)?.status === 'error');
+    venvPresent = true;
+    const rechecked = await b.recheck(job.id);
+    expect(rechecked?.status).toBe('installed');
+  });
+});

--- a/server/src/tts/venv-bootstrap.ts
+++ b/server/src/tts/venv-bootstrap.ts
@@ -1,0 +1,229 @@
+/* In-app venv bootstrap (fs-21 decision Z). Spawns
+ * server/tts-sidecar/scripts/bootstrap-venv.mjs and surfaces its
+ * `[bootstrap-venv]` step lines so a deployer can bootstrap the Python venv
+ * from Account → Models without a terminal. When Python 3.11 is not found,
+ * the job immediately fails with per-OS manual instructions (no spawn).
+ *
+ * State machine:
+ *   idle → bootstrapping → installed
+ *               └─ error ↗
+ *
+ * Venv state is BINARY: either present (`present`) or absent (`absent`).
+ * Detection is two-pronged: venv presence on disk + Python 3.11 reachability.
+ * No Python → immediate `error` with manual instructions; no spawn attempted.
+ *
+ * Dependency-injectable (`spawnFn`, `detectVenvFn`, `findPythonFn`) so the
+ * vitest harness runs the whole machine offline with no real Python spawn.
+ */
+
+import { spawn as realSpawn, type ChildProcess } from 'node:child_process';
+import { join } from 'node:path';
+import { sidecarVenvPresent } from '../diagnostics/venv.js';
+import { findPython311 } from './python-discovery.js';
+
+export type VenvBootstrapState = 'present' | 'absent';
+
+export type VenvBootstrapJobStatus = 'detecting' | 'bootstrapping' | 'installed' | 'error';
+
+export interface VenvBootstrapJob {
+  id: string;
+  status: VenvBootstrapJobStatus;
+  /** Latest `[bootstrap-venv]` step line, surfaced to the UI as status text. */
+  step: string | null;
+  error: string | null;
+  startedAt: number;
+  updatedAt: number;
+}
+
+export type VenvSpawnFn = (
+  cmd: string,
+  args: readonly string[],
+  opts?: { cwd?: string; windowsHide?: boolean },
+) => ChildProcess;
+
+export interface VenvBootstrapOptions {
+  /** Repo root — used to locate bootstrap-venv.mjs and probe the venv. */
+  repoRoot: string;
+  spawnFn?: VenvSpawnFn;
+  /** Stubbable venv-presence probe (offline tests). Defaults to sidecarVenvPresent. */
+  detectVenvFn?: (repoRoot: string) => boolean;
+  /** Stubbable Python 3.11 finder (offline tests). Defaults to findPython311. */
+  findPythonFn?: () => { cmd: string; args: string[] } | null;
+}
+
+/** Canonical degrade instructions for missing Python (decision Z). */
+const NO_PYTHON_INSTRUCTIONS =
+  'No Python 3.11 found. Install Python 3.11, then run:\n' +
+  '  cd server/tts-sidecar\n' +
+  '  py -3.11 -m venv .venv   (Windows)  /  python3.11 -m venv .venv   (macOS/Linux)\n' +
+  '  .venv/Scripts/python -m pip install -r requirements.txt   (Windows)  /  ' +
+  '.venv/bin/python -m pip install -r requirements.txt   (macOS/Linux)';
+
+export class VenvBootstrap {
+  private jobs = new Map<string, VenvBootstrapJob>();
+  private active: string | null = null;
+  private nextId = 1;
+
+  private readonly repoRoot: string;
+  private readonly spawnFn: VenvSpawnFn;
+  private readonly detectVenvFn: (repoRoot: string) => boolean;
+  private readonly findPythonFn: () => { cmd: string; args: string[] } | null;
+
+  constructor(opts: VenvBootstrapOptions) {
+    this.repoRoot = opts.repoRoot;
+    this.spawnFn = opts.spawnFn ?? (realSpawn as unknown as VenvSpawnFn);
+    this.detectVenvFn = opts.detectVenvFn ?? sidecarVenvPresent;
+    this.findPythonFn = opts.findPythonFn ?? (() => findPython311());
+  }
+
+  /** Probe state without kicking off a job. Used by GET /detect. */
+  detect(): { state: VenvBootstrapState; venvPresent: boolean; pythonFound: boolean; installed: boolean } {
+    const venvPresent = this.detectVenvFn(this.repoRoot);
+    const pythonFound = this.findPythonFn() !== null;
+    const installed = venvPresent;
+    const state: VenvBootstrapState = installed ? 'present' : 'absent';
+    return { state, venvPresent, pythonFound, installed };
+  }
+
+  getJob(id: string): VenvBootstrapJob | null {
+    return this.jobs.get(id) ?? null;
+  }
+
+  getActiveJob(): VenvBootstrapJob | null {
+    return this.active ? this.jobs.get(this.active) ?? null : null;
+  }
+
+  /** Kick off (or return the in-flight) bootstrap job. Returns synchronously;
+      the spawn runs in the background and the caller polls GET /bootstrap/:id. */
+  start(): VenvBootstrapJob {
+    const existing = this.getActiveJob();
+    if (existing && existing.status !== 'installed' && existing.status !== 'error') {
+      return existing;
+    }
+    const id = String(this.nextId++);
+    const job: VenvBootstrapJob = {
+      id,
+      status: 'detecting',
+      step: null,
+      error: null,
+      startedAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    this.jobs.set(id, job);
+    this.active = id;
+    void this.run(job).catch((err) => {
+      this.transition(job, 'error', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+    return job;
+  }
+
+  private async run(job: VenvBootstrapJob): Promise<void> {
+    /* Venv already present? Short-circuit (idempotent). */
+    if (this.detectVenvFn(this.repoRoot)) {
+      this.transition(job, 'installed', { step: 'Already installed.' });
+      return;
+    }
+
+    /* Python not found? Immediate degrade — no spawn. */
+    const python = this.findPythonFn();
+    if (python === null) {
+      this.transition(job, 'error', { error: NO_PYTHON_INSTRUCTIONS });
+      return;
+    }
+
+    this.transition(job, 'bootstrapping', { step: 'Starting venv bootstrap…' });
+    await this.spawnBootstrap(job, python);
+
+    /* Re-probe: confirm venv landed. */
+    if (this.detectVenvFn(this.repoRoot)) {
+      this.transition(job, 'installed', { step: 'Done. Venv ready.' });
+    } else {
+      this.transition(job, 'error', {
+        error:
+          'bootstrap-venv.mjs exited successfully but the venv is still missing — the install may have been interrupted. Retry.',
+      });
+    }
+  }
+
+  /** Re-probe venv state; promote a stuck bootstrapping/error job to installed
+      if the venv is now present. */
+  recheck(id: string): VenvBootstrapJob | null {
+    const job = this.jobs.get(id);
+    if (!job) return null;
+    if (this.detectVenvFn(this.repoRoot) && job.status !== 'installed') {
+      this.transition(job, 'installed', { step: 'Done. Venv ready.' });
+    }
+    return this.jobs.get(id) ?? null;
+  }
+
+  private spawnBootstrap(job: VenvBootstrapJob, python: { cmd: string; args: string[] }): Promise<void> {
+    const script = join(
+      this.repoRoot,
+      'server',
+      'tts-sidecar',
+      'scripts',
+      'bootstrap-venv.mjs',
+    );
+    return new Promise((resolve, reject) => {
+      let proc: ChildProcess;
+      try {
+        proc = this.spawnFn('node', [script, python.cmd, ...python.args], {
+          cwd: this.repoRoot,
+          windowsHide: true,
+        });
+      } catch (err) {
+        reject(err instanceof Error ? err : new Error(String(err)));
+        return;
+      }
+      let stderrTail = '';
+      const onStdout = (b: Buffer): void => {
+        for (const line of b.toString('utf8').split('\n')) {
+          const m = line.match(/\[bootstrap-venv\]\s*(.+)/);
+          if (m) this.update(job, { step: m[1].trim() });
+        }
+      };
+      const onStderr = (b: Buffer): void => {
+        stderrTail = (stderrTail + b.toString('utf8')).slice(-2000);
+      };
+      proc.stdout?.on('data', onStdout);
+      proc.stderr?.on('data', onStderr);
+      proc.on('error', (err) => reject(err));
+      proc.on('close', (code) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(
+            new Error(
+              `bootstrap-venv.mjs exited with code ${code}.` +
+                (stderrTail.trim() ? ` ${stderrTail.trim().split('\n').slice(-3).join(' ')}` : ''),
+            ),
+          );
+        }
+      });
+    });
+  }
+
+  private transition(
+    job: VenvBootstrapJob,
+    status: VenvBootstrapJobStatus,
+    extra: Partial<VenvBootstrapJob> = {},
+  ): void {
+    job.status = status;
+    Object.assign(job, extra);
+    job.updatedAt = Date.now();
+  }
+
+  private update(job: VenvBootstrapJob, patch: Partial<VenvBootstrapJob>): void {
+    Object.assign(job, patch);
+    job.updatedAt = Date.now();
+  }
+
+  /** Reset for tests — drops all jobs. */
+  _reset(): void {
+    this.jobs.clear();
+    this.active = null;
+    this.nextId = 1;
+  }
+}

--- a/server/tts-sidecar/scripts/bootstrap-venv.mjs
+++ b/server/tts-sidecar/scripts/bootstrap-venv.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// bootstrap-venv.mjs -- create a Python venv and pip-install requirements.txt
+// into it. Spawned by the VenvBootstrap job class (fs-21 wave 1b) as:
+//   node bootstrap-venv.mjs <pythonCmd> [pythonArgs...]
+//
+// Cross-platform Node ESM (Windows + macOS + Linux).
+//
+// What it does:
+//   1. Resolve the venv directory (SIDECAR_VENV_DIR env or the canonical
+//      <repoRoot>/server/tts-sidecar/.venv).
+//   2. If the venv python binary already exists -> no-op (idempotent).
+//   3. Otherwise: python -m venv <venvDir>, then <venvPython> -m pip install
+//      -r requirements.txt.
+//
+// Usage:
+//   node server/tts-sidecar/scripts/bootstrap-venv.mjs python3
+//   node server/tts-sidecar/scripts/bootstrap-venv.mjs py -3.11
+//
+// Idempotent: if the venv python binary already exists, exits 0 immediately.
+
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// scripts/ -> tts-sidecar/ -> server/ -> repo root  (3 levels up)
+const REPO_ROOT = resolve(__dirname, '..', '..', '..');
+
+/**
+ * Return the path of the python binary inside a venv directory.
+ * @param {string} venvDir  Absolute path to the venv root.
+ * @param {string} platform process.platform value ('win32' | 'linux' | 'darwin' | …)
+ * @returns {string}
+ */
+export function venvPythonPath(venvDir, platform) {
+  return platform === 'win32'
+    ? join(venvDir, 'Scripts', 'python.exe')
+    : join(venvDir, 'bin', 'python');
+}
+
+/**
+ * Return true iff the venv python binary already exists (venv was already
+ * created and should have pip-installed deps).
+ * @param {string} venvDir
+ * @param {string} platform
+ * @returns {boolean}
+ */
+export function venvAlreadyBootstrapped(venvDir, platform) {
+  return existsSync(venvPythonPath(venvDir, platform));
+}
+
+function log(m) {
+  process.stdout.write(`[bootstrap-venv] ${m}\n`);
+}
+
+function main() {
+  const venvDir =
+    process.env.SIDECAR_VENV_DIR ?? join(REPO_ROOT, 'server', 'tts-sidecar', '.venv');
+  const platform = process.platform;
+
+  if (venvAlreadyBootstrapped(venvDir, platform)) {
+    log('venv already present — nothing to do');
+    return;
+  }
+
+  const pyCmd = process.argv[2];
+  const pyArgs = process.argv.slice(3);
+
+  if (!pyCmd) {
+    process.stderr.write('[bootstrap-venv] FAIL: no python command given\n');
+    process.exit(1);
+  }
+
+  log(`creating venv at ${venvDir}`);
+  const v = spawnSync(pyCmd, [...pyArgs, '-m', 'venv', venvDir], {
+    stdio: 'inherit',
+    windowsHide: true,
+  });
+  if (v.status !== 0) {
+    process.stderr.write('[bootstrap-venv] FAIL: venv creation failed\n');
+    process.exit(1);
+  }
+
+  const venvPy = venvPythonPath(venvDir, platform);
+  const reqs = join(REPO_ROOT, 'server', 'tts-sidecar', 'requirements.txt');
+
+  log('installing requirements (this can take several minutes)');
+  const p = spawnSync(venvPy, ['-m', 'pip', 'install', '-r', reqs], {
+    stdio: 'inherit',
+    windowsHide: true,
+  });
+  if (p.status !== 0) {
+    process.stderr.write('[bootstrap-venv] FAIL: pip install failed\n');
+    process.exit(1);
+  }
+
+  log('done');
+}
+
+// Run only when invoked directly (node bootstrap-venv.mjs); stay inert on import
+// so unit tests can exercise venvPythonPath / venvAlreadyBootstrapped without
+// triggering a real venv creation.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/server/tts-sidecar/scripts/install-kokoro.mjs
+++ b/server/tts-sidecar/scripts/install-kokoro.mjs
@@ -28,7 +28,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // scripts/ -> tts-sidecar/ -> server/ -> repo root
-const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
+const REPO_ROOT = resolve(__dirname, '..', '..', '..');
 
 const KOKORO_URL_BASE =
   'https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/';

--- a/server/vitest.config.slow.ts
+++ b/server/vitest.config.slow.ts
@@ -43,6 +43,7 @@ export const SLOW_FILES = [
   'src/parsers/pdf-real.test.ts',
   'src/routes/setup-readiness.route.test.ts',
   'src/routes/kokoro-install.route.test.ts',
+  'src/routes/venv-bootstrap.route.test.ts',
 ];
 
 export default defineConfig({

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -46,6 +46,9 @@ const SLOW_FILES_TO_EXCLUDE = [
   /* Integration route test: supertest against a live Express instance
      (kokoro install bootstrap, offline-stubbed). Serialised (fs-21). */
   'src/routes/kokoro-install.route.test.ts',
+  /* Integration route test: supertest against a live Express instance
+     (venv bootstrap, offline-stubbed). Serialised (fs-21). */
+  'src/routes/venv-bootstrap.route.test.ts',
 ];
 
 /* Contention throttle (plan 156). LOW_CONCURRENCY (set manually, or

--- a/src/components/venv-bootstrap.test.tsx
+++ b/src/components/venv-bootstrap.test.tsx
@@ -1,0 +1,153 @@
+/* VenvBootstrap component state-machine spec. Mirrors kokoro-install.test.tsx —
+   stubbed fetch drives detect/bootstrap/poll. */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { VenvBootstrap } from './venv-bootstrap';
+
+const fetchMock = vi.fn();
+
+function jsonResponse(body: unknown, init: { status?: number } = {}) {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('VenvBootstrap', () => {
+  it('renders the "Set up" button when pythonFound true and venv absent', async () => {
+    fetchMock.mockImplementation((url: string) =>
+      url.includes('/detect')
+        ? Promise.resolve(
+            jsonResponse({ state: 'no-venv', venvPresent: false, pythonFound: true, installed: false }),
+          )
+        : Promise.resolve(jsonResponse({})),
+    );
+    render(<VenvBootstrap />);
+    await waitFor(() =>
+      expect(screen.getByTestId('venv-bootstrap-setup')).toBeInTheDocument(),
+    );
+    expect(screen.getByRole('button', { name: /set up the tts engine/i })).toBeInTheDocument();
+  });
+
+  it('renders manual instructions when pythonFound false and venv absent', async () => {
+    fetchMock.mockImplementation((url: string) =>
+      url.includes('/detect')
+        ? Promise.resolve(
+            jsonResponse({ state: 'no-python', venvPresent: false, pythonFound: false, installed: false }),
+          )
+        : Promise.resolve(jsonResponse({})),
+    );
+    render(<VenvBootstrap />);
+    await waitFor(() =>
+      expect(screen.getByTestId('venv-bootstrap-manual')).toBeInTheDocument(),
+    );
+    // decision-Z: both Windows and macOS/Linux instructions must be visible
+    expect(screen.getByText(/py -3\.11/i)).toBeInTheDocument();
+    expect(screen.getByText(/python3\.11 -m venv/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /re-check/i })).toBeInTheDocument();
+  });
+
+  it('renders the ready card when venvPresent', async () => {
+    fetchMock.mockImplementation((url: string) =>
+      url.includes('/detect')
+        ? Promise.resolve(
+            jsonResponse({ state: 'ready', venvPresent: true, pythonFound: true, installed: true }),
+          )
+        : Promise.resolve(jsonResponse({})),
+    );
+    render(<VenvBootstrap />);
+    await waitFor(() =>
+      expect(screen.getByTestId('venv-bootstrap-ready')).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/TTS engine ready/i)).toBeInTheDocument();
+  });
+
+  it('clicking "Set up" POSTs bootstrap and renders the job progress card', async () => {
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/detect')) {
+        return Promise.resolve(
+          jsonResponse({ state: 'no-venv', venvPresent: false, pythonFound: true, installed: false }),
+        );
+      }
+      if (url.includes('/bootstrap') && init?.method === 'POST') {
+        return Promise.resolve(
+          jsonResponse({ id: '1', status: 'installing', step: 'Creating virtual environment', error: null }),
+        );
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    render(<VenvBootstrap />);
+    await waitFor(() =>
+      expect(screen.getByTestId('venv-bootstrap-setup')).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /set up the tts engine/i }));
+    await waitFor(() =>
+      expect(screen.getByTestId('venv-bootstrap-job')).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/Creating virtual environment/i)).toBeInTheDocument();
+  });
+
+  it('calls onBootstrapped when a poll flips to installed', async () => {
+    const onBootstrapped = vi.fn();
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/detect')) {
+        return Promise.resolve(
+          jsonResponse({ state: 'no-venv', venvPresent: false, pythonFound: true, installed: false }),
+        );
+      }
+      if (url.includes('/bootstrap') && init?.method === 'POST') {
+        return Promise.resolve(
+          jsonResponse({ id: '42', status: 'installing', step: 'Installing packages…', error: null }),
+        );
+      }
+      if (url.includes('/bootstrap/42')) {
+        return Promise.resolve(
+          jsonResponse({ id: '42', status: 'installed', step: null, error: null }),
+        );
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    render(<VenvBootstrap onBootstrapped={onBootstrapped} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('venv-bootstrap-setup')).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /set up the tts engine/i }));
+    await waitFor(() => expect(onBootstrapped).toHaveBeenCalledTimes(1), { timeout: 5000 });
+  });
+
+  it('renders the error card with a retry button on a failed job', async () => {
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/detect')) {
+        return Promise.resolve(
+          jsonResponse({ state: 'no-venv', venvPresent: false, pythonFound: true, installed: false }),
+        );
+      }
+      if (url.includes('/bootstrap') && init?.method === 'POST') {
+        return Promise.resolve(
+          jsonResponse({ id: '1', status: 'error', step: null, error: 'pip install failed' }),
+        );
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    render(<VenvBootstrap />);
+    await waitFor(() =>
+      expect(screen.getByTestId('venv-bootstrap-setup')).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /set up the tts engine/i }));
+    await waitFor(() =>
+      expect(screen.getByTestId('venv-bootstrap-error')).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/pip install failed/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/venv-bootstrap.tsx
+++ b/src/components/venv-bootstrap.tsx
@@ -1,0 +1,229 @@
+/* In-app TTS venv bootstrap affordance (fs-21 wave 1b).
+   Three states driven by GET /api/setup/venv/detect:
+
+     1. venvPresent (or job installed)  → green "TTS engine ready" card
+     2. !venvPresent && pythonFound     → one-click "Set up the TTS engine" button
+                                          that POSTs bootstrap and polls the job
+     3. !venvPresent && !pythonFound    → decision-Z degrade: per-OS manual
+                                          instructions + Re-check button
+
+   Routes:
+     GET  /api/setup/venv/detect          → { state, venvPresent, pythonFound, installed }
+     POST /api/setup/venv/bootstrap       → { id, status, step, error, ... } (202)
+     GET  /api/setup/venv/bootstrap/:id   → poll
+
+   Self-contained — owns its polling loop, no redux. */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { PrimaryButton } from './primitives';
+
+export interface VenvBootstrapJob {
+  id: string;
+  status: 'installing' | 'installed' | 'error';
+  step: string | null;
+  error: string | null;
+}
+
+interface DetectResp {
+  state: string;
+  venvPresent: boolean;
+  pythonFound: boolean;
+  installed: boolean;
+}
+
+const POLL_INTERVAL_MS = 1_500;
+
+export function VenvBootstrap({ onBootstrapped }: { onBootstrapped?: () => void } = {}) {
+  const [detect, setDetect] = useState<DetectResp | null>(null);
+  const [job, setJob] = useState<VenvBootstrapJob | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const doDetect = useCallback(async () => {
+    try {
+      const res = await fetch('/api/setup/venv/detect');
+      if (!res.ok) throw new Error(`detect failed: HTTP ${res.status}`);
+      const body = (await res.json()) as DetectResp;
+      setDetect(body);
+      if (body.venvPresent || body.installed) {
+        onBootstrapped?.();
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, [onBootstrapped]);
+
+  useEffect(() => {
+    void doDetect();
+  }, [doDetect]);
+
+  useEffect(() => {
+    if (!job) return;
+    if (job.status === 'installed' || job.status === 'error') return;
+    if (pollRef.current) clearTimeout(pollRef.current);
+    pollRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/setup/venv/bootstrap/${job.id}`);
+        if (!res.ok) throw new Error(`poll failed: HTTP ${res.status}`);
+        const body = (await res.json()) as VenvBootstrapJob;
+        setJob(body);
+        if (body.status === 'installed') {
+          void doDetect();
+          onBootstrapped?.();
+        }
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    }, POLL_INTERVAL_MS);
+    return () => {
+      if (pollRef.current) clearTimeout(pollRef.current);
+    };
+  }, [job, doDetect, onBootstrapped]);
+
+  const startBootstrap = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      const res = await fetch('/api/setup/venv/bootstrap', { method: 'POST' });
+      if (!res.ok) throw new Error(`start failed: HTTP ${res.status}`);
+      setJob((await res.json()) as VenvBootstrapJob);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // State 1: venv already present (or just installed)
+  if (detect?.venvPresent || detect?.installed || job?.status === 'installed') {
+    return (
+      <div
+        data-testid="venv-bootstrap-ready"
+        className="rounded-2xl border border-emerald-200 bg-emerald-50 p-4"
+      >
+        <div className="flex items-center gap-3">
+          <span className="w-2 h-2 rounded-full bg-emerald-600" />
+          <div className="flex-1">
+            <p className="text-sm font-semibold text-emerald-900">TTS engine ready</p>
+            <p className="text-xs text-emerald-900/70">
+              The Python virtual environment is set up — all TTS engines can be loaded.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={doDetect}
+            disabled={busy}
+            className="px-3 py-1.5 rounded-full border border-emerald-300 bg-white text-xs text-emerald-900 hover:bg-emerald-100 disabled:opacity-50"
+          >
+            Re-check
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Job in progress
+  if (job && job.status === 'installing') {
+    return (
+      <div
+        data-testid="venv-bootstrap-job"
+        data-job-status={job.status}
+        className="rounded-2xl border border-ink/10 bg-canvas p-4 space-y-2"
+      >
+        <div className="flex items-center gap-3">
+          <span className="w-3 h-3 rounded-full border-2 border-magenta border-t-transparent animate-spin" />
+          <p className="text-sm font-semibold text-ink">Setting up TTS engine…</p>
+        </div>
+        <p className="text-xs text-ink/60">
+          {job.step ??
+            'This downloads ~2 GB of Python packages and can take several minutes.'}
+        </p>
+        <p className="text-xs text-ink/40">
+          This downloads ~2 GB of Python packages and can take several minutes.
+        </p>
+      </div>
+    );
+  }
+
+  // Job error
+  if (job && job.status === 'error') {
+    return (
+      <div
+        data-testid="venv-bootstrap-error"
+        className="rounded-2xl border border-rose-200 bg-rose-50 p-4 space-y-2"
+      >
+        <p className="text-sm font-semibold text-rose-900">Setup failed</p>
+        <p className="text-xs text-rose-900/80">{job.error ?? 'Bootstrap failed.'}</p>
+        <PrimaryButton variant="dark" onClick={startBootstrap} icon={false}>
+          {busy ? 'Retrying…' : 'Try again'}
+        </PrimaryButton>
+      </div>
+    );
+  }
+
+  // State 3: decision-Z — no Python found → manual instructions
+  if (detect && !detect.pythonFound) {
+    return (
+      <div
+        data-testid="venv-bootstrap-manual"
+        className="rounded-2xl border border-ink/10 bg-canvas p-4 space-y-3"
+      >
+        <div>
+          <p className="text-sm font-semibold text-ink">Python 3.11 not found</p>
+          <p className="mt-1 text-xs text-ink/55">
+            The TTS engine requires Python 3.11. Install it from{' '}
+            <span className="font-medium text-ink">python.org</span>, then run these
+            commands from the <code className="text-xs bg-ink/5 px-1 rounded">server/tts-sidecar</code>{' '}
+            directory:
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs font-semibold text-ink/70 uppercase tracking-wide">Windows</p>
+          <pre className="text-xs bg-ink/5 text-ink rounded-lg p-3 overflow-x-auto leading-relaxed">
+            {`py -3.11 -m venv .venv\n.venv\\Scripts\\python -m pip install -r requirements.txt`}
+          </pre>
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs font-semibold text-ink/70 uppercase tracking-wide">
+            macOS / Linux
+          </p>
+          <pre className="text-xs bg-ink/5 text-ink rounded-lg p-3 overflow-x-auto leading-relaxed">
+            {`python3.11 -m venv .venv\n.venv/bin/python -m pip install -r requirements.txt`}
+          </pre>
+        </div>
+
+        <button
+          type="button"
+          onClick={doDetect}
+          className="px-3 py-1.5 rounded-full border border-ink/20 bg-white text-xs text-ink hover:bg-ink/5"
+        >
+          Re-check
+        </button>
+        {error && <p className="text-xs text-rose-700">{error}</p>}
+      </div>
+    );
+  }
+
+  // State 2: Python found but no venv → one-click setup
+  return (
+    <div
+      data-testid="venv-bootstrap-setup"
+      className="rounded-2xl border border-ink/10 bg-canvas p-4 space-y-3"
+    >
+      <div>
+        <p className="text-sm font-semibold text-ink">TTS engine not set up</p>
+        <p className="mt-1 text-xs text-ink/55">
+          The TTS engine needs a Python virtual environment with its dependencies installed.
+          This is a one-time setup (~2 GB download).
+        </p>
+      </div>
+      <PrimaryButton variant="dark" onClick={startBootstrap} disabled={busy} icon={false}>
+        {busy ? 'Starting…' : 'Set up the TTS engine'}
+      </PrimaryButton>
+      {error && <p className="text-xs text-rose-700">{error}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Wave 1b of **fs-21** (#474): one-click in-app **sidecar venv bootstrap** (decision Z), split from Wave 1 by adversarial review. The venv is upstream of every TTS engine; this lets the wizard create it when a Python 3.11 interpreter is found, and **degrade to per-OS manual instructions** when not.
- `python-discovery.findPython311` (py -3.11 / python3.11 / python3, 3.10–3.12).
- `bootstrap-venv.mjs` — `python -m venv` + `pip install -r requirements.txt`, idempotent.
- `VenvBootstrap` job class + `/api/setup/venv` polling route (mounts cleanly alongside Wave 0's /api/setup readiness).
- `venv-bootstrap.tsx` component: one-click when Python found; manual-instructions degrade when not.
- **Drive-by fix:** corrected `install-kokoro.mjs` REPO_ROOT (4 → 3 `..`) — a real path bug shipped in Wave 1, masked by the OWED on-box path; caught via cross-task comparison.

## Test plan
Unit: discovery (5 cases), bootstrap-venv helpers, VenvBootstrap job (7 cases incl. no-Python degrade), component (6 states). Server integration: /api/setup/venv route test in the slow pool. `npm run verify` green.
Plan → **adversarial plan review** (no blocking issues; confirmed the stdio:'inherit' / stdout-capture concern is a non-issue) → subagent-driven execution. Refs #474.
**OWED (not CI-gated):** real fresh `venv` create + multi-GB `pip install` on a box without a venv (Win/mac/linux); logic + degrade path fully tested here.