### PR TITLE
feat(server,frontend): fs-21 wave 2 — first-run wizard UI

### DIFF
--- a/docs/superpowers/plans/2026-06-12-fs21-wave2-wizard-ui.md
+++ b/docs/superpowers/plans/2026-06-12-fs21-wave2-wizard-ui.md
@@ -30,7 +30,7 @@
 
 ## Task C1: `POST /api/setup/complete` route
 
-**Files:** Modify `server/src/routes/setup-readiness.ts` (add the POST handler to the same `setupReadinessRouter` — it's already mounted at `/api/setup`, so `POST /complete` → `/api/setup/complete`); Test: extend `server/src/routes/setup-readiness.test.ts` (the pure/unit one — this handler is trivial, no live probe) OR a small new unit test.
+**Files:** Modify `server/src/routes/setup-readiness.ts` (add the POST handler to the same `setupReadinessRouter` — already mounted at `/api/setup`, so `POST /complete` → `/api/setup/complete`); Test: extend the EXISTING slow-pool route test `server/src/routes/setup-readiness.route.test.ts` (created in Wave 0, already pinned in both vitest configs) — NOT the pure `setup-readiness.test.ts`. A supertest mount belongs in the slow pool per the documented mirror invariant.
 
 - [ ] **Step 1: Failing test** — POST `/api/setup/complete` returns 200 `{ completedAt: <ISO string> }` and calls the settings writer. Inject/stub `writeSetupCompletedAt` if the route imports it directly (mirror how setup-readiness injects deps), else use a temp settings file + assert `getResolvedSetupCompletedAt()` is non-null after.
 
@@ -88,15 +88,15 @@ setupReadinessRouter.post('/complete', async (_req, res) => {
 
 **Files:** Create `src/components/setup/step-environment.tsx`, `step-ffmpeg.tsx`, `step-models.tsx`, `step-defaults.tsx`, `step-finish.tsx` + a test per non-trivial one.
 
-Each step component takes `{ readiness: SetupReadiness; onRefetch: () => void }` (and `step-finish` also `{ onFinish: () => void }`). They are presentational + reuse existing components.
+Each step component takes `{ readiness: SetupReadiness; onRefetch: () => void }` (and `step-finish` also `{ onFinish: () => void }`). They are presentational + reuse existing components. **Dispatch as THREE separate subagent tasks** (per the per-group commits): C4a = Step E + Step F; C4b = Step M; C4c = Step D + Step Finish. (One task for all five is too large.)
 
 - [ ] **Step E (environment):** `StepEnvironment` renders `<DevicePanel />` + a line showing `readiness.info.gpu`. Non-blocking; always "ok". Test: renders DevicePanel + the gpu string.
 - [ ] **Step F (ffmpeg):** `StepFfmpeg` — if `readiness.blockers.ffmpeg === 'pass'` → green "ffmpeg found"; else → an instruct card with per-OS commands (`winget install ffmpeg` / `brew install ffmpeg` / `sudo apt install ffmpeg`) + a "Re-check" button calling `onRefetch`. (Mirror `venv-bootstrap.tsx`'s degrade/instruction block style.) Test: pass → green; fail → instructions + Re-check calls onRefetch.
 - [ ] **Step M (models):** `StepModels` — two required sub-sections:
   - *TTS runtime + engine:* `<VenvBootstrap onBootstrapped={onRefetch} />` then `<KokoroInstall onInstalled={onRefetch} />` (with Qwen/Coqui offered as collapsible alternates). Show `readiness.blockers.tts`/`sidecar` status.
-  - *Analyzer:* recommended `<GeminiKeyField status={account.apiKeyStatus} onSave={(k)=>dispatch(saveGeminiApiKey(k)).then(onRefetch)} />`; OR (collapsible "use a local analyzer") `<OllamaInstall onInstalled={onRefetch} />` + `<ModelPullStatus .../>`. Show `readiness.blockers.analyzer` status.
+  - *Analyzer:* recommended `<GeminiKeyField status={account.apiKeyStatus} onSave={(k)=>dispatch(saveGeminiApiKey(k)).then(onRefetch)} />`; OR (collapsible "use a local analyzer") `<OllamaInstall onInstalled={onRefetch} />`. **DROP `ModelPullStatus`** (the review found its props need the inline-only `PULLABLE_MODELS` const + a parallel ollama-health probe; the `analyzer` blocker passes on a Gemini key OR Ollama-daemon-reachable, so pulling a specific tag isn't needed to clear the gate — leave model-pull to the Model Manager). Show `readiness.blockers.analyzer` status.
   Test: renders the venv + kokoro + analyzer sub-sections; install callbacks call onRefetch (mock the children or assert presence).
-- [ ] **Step D (defaults):** `StepDefaults` — a 4-field inline form: default engine (`defaultTtsEngine`), default TTS model key (`defaultTtsModelKey`), default analysis model (`defaultAnalysisModel`), theme (`defaultThemePreference`). Pre-fill from the account slice; on change `dispatch(saveAccountSettings({...}))`. Skippable (auto-picks valid). READ `src/components/model-settings-form.tsx` for the exact field option lists + the `saveAccountSettings` patch shape; inline only these 4 fields (do not embed the whole form). Test: renders 4 selects, changing one dispatches saveAccountSettings with that field.
+- [ ] **Step D (defaults):** `StepDefaults` — a 4-field inline form: default engine (`defaultTtsEngine`), default TTS model key (`defaultTtsModelKey`), default analysis model (`defaultAnalysisModel`), theme (`defaultThemePreference`). Pre-fill from the account slice; on change build a `UserSettingsPatch` and `dispatch(saveAccountSettings(patch))`. Skippable (auto-picks valid). **Field provenance (review):** engine/model option lists + the engine→model reset idiom come from `src/lib/tts-models.ts` (`TTS_ENGINES`) and are used in `src/components/model-settings-form.tsx`; analysis-model options from `MODEL_OPTION_GROUPS` in `src/lib/models.ts`; **`defaultThemePreference` is managed in `src/views/account.tsx` (a `'light'|'dark'|'system'` `ThemePreference`), NOT in model-settings-form** — read account.tsx for that one. When the user actively changes the TTS model, also send `defaultTtsModelKeyExplicit: true` (mirrors model-settings-form so a Qwen-installed box isn't silently pinned). Inline only these 4 fields (do not embed the whole form). Test: renders 4 selects, changing one dispatches saveAccountSettings with that field.
 - [ ] **Step Fin (finish):** `StepFinish` — a placeholder card: "Smoke test (coming soon)" disabled affordance + copy that the full audible end-to-end test arrives next release; a **"Finish setup"** PrimaryButton calling `onFinish`. Test: renders the placeholder + Finish calls onFinish.
 - [ ] **Commit per logical group** (e.g. one commit for steps E+F, one for M, one for D+Fin) with `feat(frontend): setup wizard step components (fs-21 wave 2)`. Run `npx vitest run src/components/setup/` green + typecheck before each commit.
 
@@ -104,12 +104,12 @@ Each step component takes `{ readiness: SetupReadiness; onRefetch: () => void }`
 
 ## Task C5: `SetupWizard` orchestrator + `SetupView` rewrite
 
-**Files:** Create `src/components/setup/setup-wizard.tsx` + test; modify `src/views/setup.tsx`.
+**Files:** Create `src/components/setup/setup-wizard.tsx` + test; modify `src/views/setup.tsx` AND `src/views/setup.test.tsx` (the Wave 0 stub test — widening `SetupView`'s props breaks it; update it to the wizard-era assertion, OR make the new props optional with defaults so it still compiles, then update its body assertion off the removed stub list).
 
 - [ ] **Step 1: Failing test** for `SetupWizard` — props `{ readiness: SetupReadiness; mode: 'guided' | 'checklist'; onRefetch: () => void; onFinish: () => void }`:
-  - guided mode: shows ONE step at a time with Back/Next + progress dots; Next disabled on a *blocking* step whose blocker is still `fail` (ffmpeg, tts, analyzer); Step 5 reachable only when blockers pass.
+  - guided mode: shows ONE step at a time with Back/Next + progress dots. **Next is ALWAYS enabled (simpler model, per review)** — the wizard does NOT gate Next on blocker status; the derived Wave 0 boot gate (`layout.tsx`) already keeps the app locked behind `#/setup` until all blockers pass, so in-wizard gating is redundant and bug-prone (stale-readiness traps). Each blocking step still SHOWS its `readiness.blockers` status so the user knows what's left.
   - checklist mode: all 5 steps rendered stacked, each with its status; no Back/Next.
-  - both: hard-blocker statuses come from `readiness.blockers`; `info`/defaults steps never block.
+  - both: blocker statuses come from `readiness.blockers`; `info`/defaults steps are informational.
 - [ ] **Step 2: Run → FAIL.**
 - [ ] **Step 3: Implement** the orchestrator: a `STEPS` array (id, title, component, `blocking: boolean`), step index state (guided), render the matching step(s), wire `onRefetch`/`onFinish` down. Use `MixedHeading`/`PrimaryButton`/`SectionLabel` primitives + the `max-w-[960px] mx-auto px-4 sm:px-6 py-10` shell (match ModelManagerView). Then rewrite `src/views/setup.tsx` `SetupView` to render `<SetupWizard readiness={readiness} mode={mode} onRefetch={onRefetch} onFinish={onFinish} />` (props threaded from SetupRoute in C6). Keep `SetupView`'s `readiness: SetupReadiness | null` prop; render a light "checking…" state when null.
 - [ ] **Step 4: Run → PASS + typecheck.**
@@ -132,7 +132,7 @@ Each step component takes `{ readiness: SetupReadiness; onRefetch: () => void }`
 
 **Files:** Create `e2e/setup-wizard.spec.ts`; extend `e2e/responsive/coverage.spec.ts`.
 
-- [ ] **Step 1:** `setup-wizard.spec.ts` (mock mode): navigate `/#/?setup=notready` → the wizard renders with step UI (heading "Set up Castwright", a blocking step visible); assert the ffmpeg/models steps show status from the mock readiness; the "Finish setup" affordance exists. (The mock readiness's blockers drive the UI; in not-ready mock, tts/analyzer are `fail` so guided Next is gated — assert that.) Then a ready-mock path: navigate `/#/` (ready) → no redirect (gate stays out). Keep assertions resilient (role/text), not pixel.
+- [ ] **Step 1:** `setup-wizard.spec.ts` (mock mode): navigate `/#/?setup=notready` → the wizard renders with step UI (heading "Set up Castwright", step navigation visible); assert the ffmpeg/models steps show status from the mock readiness (tts/analyzer `fail` → "needs attention"-style status text). Do NOT assert Next-gating (the simpler model always allows Next). Then a ready-mock path: navigate `/#/` (ready) → no redirect (gate stays out). Keep assertions resilient (role/text), not pixel.
 - [ ] **Step 2:** Update the `e2e/responsive/coverage.spec.ts` setup case if the heading/layout changed (it shouldn't — heading stays "Set up Castwright").
 - [ ] **Step 3:** `npm run test:e2e -- setup` → PASS.
 - [ ] **Step 4: Commit** `test(e2e): setup wizard step flow (fs-21 wave 2)`.

--- a/docs/superpowers/plans/2026-06-12-fs21-wave2-wizard-ui.md
+++ b/docs/superpowers/plans/2026-06-12-fs21-wave2-wizard-ui.md
@@ -1,0 +1,151 @@
+# fs-21 Wave 2 — First-run wizard UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Checkbox (`- [ ]`) steps.
+
+**Goal:** Replace the Wave 0 `SetupView` stub with the real **hybrid guided/checklist first-run wizard** (5 steps: Environment/GPU → ffmpeg → Models → Defaults → Finish), composing the install components from Waves 1/1b, and add the `POST /api/setup/complete` route + the Account "Re-run setup" entry. The Step-5 audible smoke test is Wave 3 — here it's a clearly-labeled placeholder; "Finish" marks setup complete and returns home.
+
+**Architecture:** A `setup-wizard.tsx` orchestrator holds step state and renders **guided mode** (linear, one step + Back/Next, when `completedAt == null`) or **checklist mode** (all steps visible, on re-entry). Each step is a small sub-component under `src/components/setup/`. Steps reuse the existing self-contained install components (`VenvBootstrap`, `KokoroInstall`, `Coqui/Qwen/Whisper/OllamaInstall`, `GeminiKeyField`, `DevicePanel`). After any install completes, the wizard re-fetches `api.getSetupReadiness()` so blocker status updates live. The hard gate stays derived (Wave 0); `completedAt` only suppresses the guided re-intro.
+
+**Tech Stack:** React 18 + Redux Toolkit + react-router (frontend), Express/TS (the one new route), Vitest + Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-fs21-first-run-wizard-design.md` · **Epic:** #474 · **Branch:** `feat/fs21-wave2-wizard-ui` off `main` (worktree `C:\Claude\Projects\wt-fs21-wave2`).
+
+> **Gap resolutions (from the Wave 2 Explore):** ffmpeg = instruct-card (no installer, per spec); Step 5 = placeholder + a new `POST /api/setup/complete` (the smoke synth is Wave 3); `OllamaInstall` gains an `onInstalled` prop; "Re-run setup" Account button is new; `SetupRoute` re-fetches between steps. **Deferred (noted, not built):** the layout `completedAt`-aware splash-skip optimization (the Wave 0 gate works as-is).
+
+> **Standing rule:** adversarial plan review BEFORE any task executes.
+
+---
+
+## File Structure
+- Create `server/src/routes/setup-complete.ts` (or extend the setup-readiness router) — `POST /api/setup/complete` → `writeSetupCompletedAt(new Date().toISOString())` → `{ completedAt }`. Test beside it.
+- Modify `src/lib/api.ts` — `completeSetup()` real + mock + wire into both maps.
+- Modify `src/components/ollama-install.tsx` — add optional `onInstalled?: () => void` (fires when detect/poll reports installed), matching the sibling components.
+- Create `src/components/setup/setup-wizard.tsx` (orchestrator) + per-step components: `step-environment.tsx`, `step-ffmpeg.tsx`, `step-models.tsx`, `step-defaults.tsx`, `step-finish.tsx`. + tests.
+- Modify `src/views/setup.tsx` — `SetupView` renders `<SetupWizard readiness={...} onRefetch={...} />` instead of the stub list.
+- Modify `src/routes/index.tsx` — `SetupRoute` exposes a `refetch` (re-calls `api.getSetupReadiness`) passed to `SetupView`, and reads `completedAt` to pick guided vs checklist mode.
+- Modify `src/views/account.tsx` — add a "Re-run setup" pointer card → `dispatch(uiActions.openSetup())`.
+- Create `e2e/setup-wizard.spec.ts` + extend `e2e/responsive/coverage.spec.ts`.
+
+---
+
+## Task C1: `POST /api/setup/complete` route
+
+**Files:** Modify `server/src/routes/setup-readiness.ts` (add the POST handler to the same `setupReadinessRouter` — it's already mounted at `/api/setup`, so `POST /complete` → `/api/setup/complete`); Test: extend `server/src/routes/setup-readiness.test.ts` (the pure/unit one — this handler is trivial, no live probe) OR a small new unit test.
+
+- [ ] **Step 1: Failing test** — POST `/api/setup/complete` returns 200 `{ completedAt: <ISO string> }` and calls the settings writer. Inject/stub `writeSetupCompletedAt` if the route imports it directly (mirror how setup-readiness injects deps), else use a temp settings file + assert `getResolvedSetupCompletedAt()` is non-null after.
+
+```ts
+// in a describe that mounts setupReadinessRouter on express + supertest
+it('POST /complete stamps setupCompletedAt and returns it', async () => {
+  const res = await request(app).post('/api/setup/complete');
+  expect(res.status).toBe(200);
+  expect(typeof res.body.completedAt).toBe('string');
+  expect(new Date(res.body.completedAt).toISOString()).toBe(res.body.completedAt);
+});
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** in `setup-readiness.ts`: add
+```ts
+import { writeSetupCompletedAt } from '../workspace/user-settings.js';
+setupReadinessRouter.post('/complete', async (_req, res) => {
+  const ts = new Date().toISOString();
+  await writeSetupCompletedAt(ts);
+  res.json({ completedAt: ts });
+});
+```
+(Confirm `writeSetupCompletedAt` is exported from `user-settings.ts` — it is, from Wave 0.)
+- [ ] **Step 4: Run → PASS + typecheck.** (If the test triggers the live-probe-heavy file, keep this POST test in the fast pool — it doesn't call buildDiagnostics.)
+- [ ] **Step 5: Commit** `feat(server): POST /api/setup/complete stamps setupCompletedAt (fs-21 wave 2)`.
+
+---
+
+## Task C2: `api.completeSetup` client + mock
+
+**Files:** Modify `src/lib/api.ts`; extend `src/lib/api.test.ts`.
+
+- [ ] **Step 1: Failing test** — `mockCompleteSetup()` resolves `{ completedAt: <string> }` (test the exported mock directly, like `mockGetSetupReadiness`).
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** near `realGetSetupReadiness`: `realCompleteSetup()` → `POST /api/setup/complete`; `export async function mockCompleteSetup(): Promise<{ completedAt: string }> { return { completedAt: '2026-06-12T00:00:00.000Z' }; }`. Wire `completeSetup` into BOTH the real and mock `api` maps (next to `getSetupReadiness`).
+- [ ] **Step 4: Run → PASS + typecheck.**
+- [ ] **Step 5: Commit** `feat(frontend): api.completeSetup (fs-21 wave 2)`.
+
+---
+
+## Task C3: `OllamaInstall` gains `onInstalled`
+
+**Files:** Modify `src/components/ollama-install.tsx`; extend its test (create `src/components/ollama-install.test.tsx` if absent).
+
+- [ ] **Step 1: READ `src/components/ollama-install.tsx`** + a sibling (`kokoro-install.tsx`) for the `onInstalled` pattern. **Failing test:** `OllamaInstall` calls `onInstalled` when its detect/poll reports installed (mock fetch).
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** — add `{ onInstalled }: { onInstalled?: () => void } = {}` to the signature; call `onInstalled?.()` at the same point the sibling components do (when status flips to installed / detect reports installed). Keep all existing behavior — purely additive. Existing call sites (Model Manager / ModelSettingsForm) pass no prop → unaffected.
+- [ ] **Step 4: Run → PASS + typecheck** (incl. the existing Model Manager tests still green).
+- [ ] **Step 5: Commit** `feat(frontend): OllamaInstall onInstalled callback (fs-21 wave 2)`.
+
+---
+
+## Task C4: Step sub-components
+
+**Files:** Create `src/components/setup/step-environment.tsx`, `step-ffmpeg.tsx`, `step-models.tsx`, `step-defaults.tsx`, `step-finish.tsx` + a test per non-trivial one.
+
+Each step component takes `{ readiness: SetupReadiness; onRefetch: () => void }` (and `step-finish` also `{ onFinish: () => void }`). They are presentational + reuse existing components.
+
+- [ ] **Step E (environment):** `StepEnvironment` renders `<DevicePanel />` + a line showing `readiness.info.gpu`. Non-blocking; always "ok". Test: renders DevicePanel + the gpu string.
+- [ ] **Step F (ffmpeg):** `StepFfmpeg` — if `readiness.blockers.ffmpeg === 'pass'` → green "ffmpeg found"; else → an instruct card with per-OS commands (`winget install ffmpeg` / `brew install ffmpeg` / `sudo apt install ffmpeg`) + a "Re-check" button calling `onRefetch`. (Mirror `venv-bootstrap.tsx`'s degrade/instruction block style.) Test: pass → green; fail → instructions + Re-check calls onRefetch.
+- [ ] **Step M (models):** `StepModels` — two required sub-sections:
+  - *TTS runtime + engine:* `<VenvBootstrap onBootstrapped={onRefetch} />` then `<KokoroInstall onInstalled={onRefetch} />` (with Qwen/Coqui offered as collapsible alternates). Show `readiness.blockers.tts`/`sidecar` status.
+  - *Analyzer:* recommended `<GeminiKeyField status={account.apiKeyStatus} onSave={(k)=>dispatch(saveGeminiApiKey(k)).then(onRefetch)} />`; OR (collapsible "use a local analyzer") `<OllamaInstall onInstalled={onRefetch} />` + `<ModelPullStatus .../>`. Show `readiness.blockers.analyzer` status.
+  Test: renders the venv + kokoro + analyzer sub-sections; install callbacks call onRefetch (mock the children or assert presence).
+- [ ] **Step D (defaults):** `StepDefaults` — a 4-field inline form: default engine (`defaultTtsEngine`), default TTS model key (`defaultTtsModelKey`), default analysis model (`defaultAnalysisModel`), theme (`defaultThemePreference`). Pre-fill from the account slice; on change `dispatch(saveAccountSettings({...}))`. Skippable (auto-picks valid). READ `src/components/model-settings-form.tsx` for the exact field option lists + the `saveAccountSettings` patch shape; inline only these 4 fields (do not embed the whole form). Test: renders 4 selects, changing one dispatches saveAccountSettings with that field.
+- [ ] **Step Fin (finish):** `StepFinish` — a placeholder card: "Smoke test (coming soon)" disabled affordance + copy that the full audible end-to-end test arrives next release; a **"Finish setup"** PrimaryButton calling `onFinish`. Test: renders the placeholder + Finish calls onFinish.
+- [ ] **Commit per logical group** (e.g. one commit for steps E+F, one for M, one for D+Fin) with `feat(frontend): setup wizard step components (fs-21 wave 2)`. Run `npx vitest run src/components/setup/` green + typecheck before each commit.
+
+---
+
+## Task C5: `SetupWizard` orchestrator + `SetupView` rewrite
+
+**Files:** Create `src/components/setup/setup-wizard.tsx` + test; modify `src/views/setup.tsx`.
+
+- [ ] **Step 1: Failing test** for `SetupWizard` — props `{ readiness: SetupReadiness; mode: 'guided' | 'checklist'; onRefetch: () => void; onFinish: () => void }`:
+  - guided mode: shows ONE step at a time with Back/Next + progress dots; Next disabled on a *blocking* step whose blocker is still `fail` (ffmpeg, tts, analyzer); Step 5 reachable only when blockers pass.
+  - checklist mode: all 5 steps rendered stacked, each with its status; no Back/Next.
+  - both: hard-blocker statuses come from `readiness.blockers`; `info`/defaults steps never block.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** the orchestrator: a `STEPS` array (id, title, component, `blocking: boolean`), step index state (guided), render the matching step(s), wire `onRefetch`/`onFinish` down. Use `MixedHeading`/`PrimaryButton`/`SectionLabel` primitives + the `max-w-[960px] mx-auto px-4 sm:px-6 py-10` shell (match ModelManagerView). Then rewrite `src/views/setup.tsx` `SetupView` to render `<SetupWizard readiness={readiness} mode={mode} onRefetch={onRefetch} onFinish={onFinish} />` (props threaded from SetupRoute in C6). Keep `SetupView`'s `readiness: SetupReadiness | null` prop; render a light "checking…" state when null.
+- [ ] **Step 4: Run → PASS + typecheck.**
+- [ ] **Step 5: Commit** `feat(frontend): SetupWizard orchestrator + SetupView rewrite (fs-21 wave 2)`.
+
+---
+
+## Task C6: `SetupRoute` re-fetch + mode + Account entry
+
+**Files:** Modify `src/routes/index.tsx`, `src/views/account.tsx`.
+
+- [ ] **Step 1:** In `SetupRoute`: keep the initial `getSetupReadiness` fetch; add a `refetch()` (re-calls it + setReadiness) passed as `onRefetch`; derive `mode = readiness?.completedAt ? 'checklist' : 'guided'`; `onFinish = async () => { await api.completeSetup(); navigate('/'); }`. Pass `mode`/`onRefetch`/`onFinish` to `SetupView` (widen `SetupView` props accordingly — coordinate with C5's prop list).
+- [ ] **Step 2:** In `src/views/account.tsx`, add a "Re-run setup" pointer card mirroring the "Open Model Manager →" button (lines ~445-452): `onClick={() => dispatch(uiActions.openSetup())}`, `data-testid="account-rerun-setup"`. Extend `src/views/account.test.tsx` to assert the button dispatches `openSetup` (mirror the model-manager-pointer test).
+- [ ] **Step 3:** `npm run typecheck` + `npx vitest run src/views/account.test.tsx src/routes` green.
+- [ ] **Step 4: Commit** `feat(frontend): setup re-fetch + guided/checklist mode + Account re-run entry (fs-21 wave 2)`.
+
+---
+
+## Task C7: e2e
+
+**Files:** Create `e2e/setup-wizard.spec.ts`; extend `e2e/responsive/coverage.spec.ts`.
+
+- [ ] **Step 1:** `setup-wizard.spec.ts` (mock mode): navigate `/#/?setup=notready` → the wizard renders with step UI (heading "Set up Castwright", a blocking step visible); assert the ffmpeg/models steps show status from the mock readiness; the "Finish setup" affordance exists. (The mock readiness's blockers drive the UI; in not-ready mock, tts/analyzer are `fail` so guided Next is gated — assert that.) Then a ready-mock path: navigate `/#/` (ready) → no redirect (gate stays out). Keep assertions resilient (role/text), not pixel.
+- [ ] **Step 2:** Update the `e2e/responsive/coverage.spec.ts` setup case if the heading/layout changed (it shouldn't — heading stays "Set up Castwright").
+- [ ] **Step 3:** `npm run test:e2e -- setup` → PASS.
+- [ ] **Step 4: Commit** `test(e2e): setup wizard step flow (fs-21 wave 2)`.
+
+---
+
+## Task C8: Full verify + draft PR
+
+- [ ] **Step 1:** `npm run verify` green (cache-aware retry for the `test:server` contention flake).
+- [ ] **Step 2:** `gh pr create --draft --title "feat(server,frontend): fs-21 wave 2 — first-run wizard UI" --body "... Refs #474. Step 5 audible smoke test lands in Wave 3 (here it's a placeholder + the /api/setup/complete route)."` → `gh pr ready` once green.
+
+---
+
+## Self-Review
+- 5-step coverage: env (DevicePanel) / ffmpeg (instruct) / models (compose installers) / defaults (4-field) / finish (placeholder + complete route). Guided vs checklist via `completedAt`. Hard gate stays derived (Wave 0 untouched).
+- **Open questions for the adversarial review:** (1) confirm `OllamaInstall`'s current internal state machine has a clean point to fire `onInstalled` (or whether polling readiness is safer); (2) confirm `ModelPullStatus`'s exact props (the Explore gave `health` + `pullableModels` — verify before Step M wires it, or drop the model-pull sub-step to keep Step M to engine+key); (3) confirm the `saveAccountSettings` patch field names + option lists in `model-settings-form.tsx` for the 4 defaults; (4) does widening `SetupView`'s props break the Wave 0 `setup.test.tsx`? (update it); (5) is the guided-mode "Next gated on blocking step" logic worth the complexity, or should guided mode simply always allow Next and rely on the derived gate to keep the app locked until blockers pass? (simpler); (6) Step M is large — should it split into Step-TTS + Step-Analyzer for clarity?

--- a/e2e/setup-wizard.spec.ts
+++ b/e2e/setup-wizard.spec.ts
@@ -1,0 +1,65 @@
+/* fs-21 wave 2 — C7: first-run setup wizard step-flow e2e.
+ *
+ * ?setup=notready drives the mock (mockGetSetupReadiness) to return
+ * not-ready, which causes the boot gate to redirect to #/setup and
+ * render the wizard in guided mode.
+ *
+ * Assertions are role/text based, not pixel/screenshot, so they stay
+ * resilient across layout tweaks. Key wizard labels (from setup-wizard.tsx):
+ *   - Back button:  "Back"  (disabled on step 1, enabled on step 2+)
+ *   - Next button:  "Next"  (hidden on the last step — StepFinish owns
+ *                            its own "Finish setup" button instead)
+ *   - Progress:     "Step N of 5"
+ */
+
+import { test, expect } from '@playwright/test';
+
+test('first-run wizard renders with step UI when not ready', async ({ page }) => {
+  await page.goto('/#/?setup=notready');
+  await expect(page).toHaveURL(/#\/setup/);
+  await expect(page.getByRole('heading', { name: /set up castwright/i })).toBeVisible();
+  // Step 1 shows "Step 1 of 5" progress indicator
+  await expect(page.getByText(/step 1 of 5/i)).toBeVisible();
+  // Next is always enabled in guided mode
+  await expect(page.getByRole('button', { name: /^next$/i })).toBeVisible();
+  // Back is present but disabled on the first step
+  await expect(page.getByRole('button', { name: /^back$/i })).toBeDisabled();
+});
+
+test('wizard can advance through steps (Next is always enabled)', async ({ page }) => {
+  await page.goto('/#/?setup=notready');
+  await expect(page.getByRole('heading', { name: /set up castwright/i })).toBeVisible();
+
+  const next = page.getByRole('button', { name: /^next$/i });
+  await next.click(); // step 1 → step 2
+
+  // After advancing, Back becomes enabled
+  await expect(page.getByRole('button', { name: /^back$/i })).toBeEnabled();
+  // Progress indicator advances
+  await expect(page.getByText(/step 2 of 5/i)).toBeVisible();
+  // Next is still available (not on the last step yet)
+  await expect(next).toBeVisible();
+});
+
+test('wizard reaches the last step and shows Finish setup', async ({ page }) => {
+  await page.goto('/#/?setup=notready');
+  await expect(page.getByRole('heading', { name: /set up castwright/i })).toBeVisible();
+
+  const next = page.getByRole('button', { name: /^next$/i });
+
+  // Advance through steps 1 → 2 → 3 → 4 (Next disappears on step 5)
+  for (let i = 0; i < 4; i++) {
+    await expect(next).toBeVisible();
+    await next.click();
+  }
+
+  // On step 5 the wizard's Next is gone; StepFinish owns "Finish setup"
+  await expect(page.getByText(/step 5 of 5/i)).toBeVisible();
+  await expect(next).not.toBeVisible();
+  await expect(page.getByRole('button', { name: /finish setup/i })).toBeVisible();
+});
+
+test('boot gate stays out of the way when ready', async ({ page }) => {
+  await page.goto('/#/');
+  await expect(page).not.toHaveURL(/#\/setup/);
+});

--- a/server/src/routes/setup-readiness.route.test.ts
+++ b/server/src/routes/setup-readiness.route.test.ts
@@ -14,3 +14,14 @@ describe('GET /api/setup/readiness route (integration — live probe)', () => {
     expect(res.body).toHaveProperty('info.gpu');
   });
 });
+
+describe('POST /api/setup/complete route', () => {
+  it('POST /complete stamps setupCompletedAt and returns it', async () => {
+    const app = express();
+    app.use('/api/setup', setupReadinessRouter);
+    const res = await request(app).post('/api/setup/complete');
+    expect(res.status).toBe(200);
+    expect(typeof res.body.completedAt).toBe('string');
+    expect(new Date(res.body.completedAt).toISOString()).toBe(res.body.completedAt);
+  });
+});

--- a/server/src/routes/setup-readiness.ts
+++ b/server/src/routes/setup-readiness.ts
@@ -4,7 +4,7 @@
 import { Router } from 'express';
 import type { Request, Response } from '../http.js';
 import { buildDiagnostics, type CheckId, type DiagnosticsResponse } from './diagnostics.js';
-import { getResolvedAnalysisEngine, getResolvedSetupCompletedAt } from '../workspace/user-settings.js';
+import { getResolvedAnalysisEngine, getResolvedSetupCompletedAt, writeSetupCompletedAt } from '../workspace/user-settings.js';
 import { sidecarVenvPresent } from '../diagnostics/venv.js';
 import { anyTtsEnginePresent } from '../tts/engine-presence.js';
 import { fileURLToPath } from 'node:url';
@@ -54,6 +54,12 @@ export function buildSetupReadiness(input: {
 }
 
 export const setupReadinessRouter = Router();
+
+setupReadinessRouter.post('/complete', async (_req: Request, res: Response) => {
+  const ts = new Date().toISOString();
+  await writeSetupCompletedAt(ts);
+  res.json({ completedAt: ts });
+});
 
 setupReadinessRouter.get('/readiness', async (_req: Request, res: Response) => {
   const diagnostics = await buildDiagnostics();

--- a/src/components/ollama-install.test.tsx
+++ b/src/components/ollama-install.test.tsx
@@ -167,4 +167,55 @@ describe('OllamaInstall — not detected', () => {
     expect(screen.getByText(/HTTP 502/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
   });
+
+  it('calls onInstalled when a poll flips status to installed', async () => {
+    const onInstalled = vi.fn();
+    fetchMock.mockImplementation((url: string, init: RequestInit | undefined) => {
+      if (url.includes('/detect')) {
+        return Promise.resolve(jsonResponse({ installed: false, version: null }));
+      }
+      if (url.endsWith('/install') && init?.method === 'POST') {
+        return Promise.resolve(
+          jsonResponse(
+            {
+              id: '42',
+              status: 'downloading',
+              platform: 'linux',
+              arch: 'x64',
+              bytesReceived: 0,
+              bytesTotal: 50_000_000,
+              manualInstallerPath: null,
+              error: null,
+              startedAt: 0,
+              updatedAt: 0,
+            },
+            { status: 202 },
+          ),
+        );
+      }
+      if (url.includes('/install/42')) {
+        return Promise.resolve(
+          jsonResponse({
+            id: '42',
+            status: 'installed',
+            platform: 'linux',
+            arch: 'x64',
+            bytesReceived: 50_000_000,
+            bytesTotal: 50_000_000,
+            manualInstallerPath: null,
+            error: null,
+            startedAt: 0,
+            updatedAt: 0,
+          }),
+        );
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    render(<OllamaInstall onInstalled={onInstalled} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('ollama-install-not-detected')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /install ollama/i }));
+    await waitFor(() => expect(onInstalled).toHaveBeenCalledTimes(1), { timeout: 5000 });
+  });
 });

--- a/src/components/ollama-install.tsx
+++ b/src/components/ollama-install.tsx
@@ -48,7 +48,7 @@ function formatMB(bytes: number): string {
   return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 }
 
-export function OllamaInstall() {
+export function OllamaInstall({ onInstalled }: { onInstalled?: () => void } = {}) {
   const [detect, setDetect] = useState<DetectResp | null>(null);
   const [job, setJob] = useState<InstallJob | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -87,6 +87,7 @@ export function OllamaInstall() {
            the new version string. */
         if (body.status === 'installed') {
           void doDetect();
+          onInstalled?.();
         }
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e));
@@ -95,7 +96,7 @@ export function OllamaInstall() {
     return () => {
       if (pollRef.current) clearTimeout(pollRef.current);
     };
-  }, [job, doDetect]);
+  }, [job, doDetect, onInstalled]);
 
   const startInstall = async () => {
     setError(null);

--- a/src/components/setup/setup-wizard.test.tsx
+++ b/src/components/setup/setup-wizard.test.tsx
@@ -1,0 +1,205 @@
+/* fs-21 wave 2 — C5: SetupWizard orchestrator tests.
+   The 5 step components are stubbed (lightweight divs with testids) so this
+   suite tests ORCHESTRATION — step paging, Back/Next, progress, mode split —
+   not the steps themselves. */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { SetupReadiness } from '../../lib/api';
+
+// ── stub the 5 step components ────────────────────────────────────────────────
+
+vi.mock('./step-environment', () => ({
+  StepEnvironment: () => <div data-testid="step-environment-stub">env</div>,
+}));
+vi.mock('./step-ffmpeg', () => ({
+  StepFfmpeg: () => <div data-testid="step-ffmpeg-stub">ffmpeg</div>,
+}));
+vi.mock('./step-models', () => ({
+  StepModels: () => <div data-testid="step-models-stub">models</div>,
+}));
+vi.mock('./step-defaults', () => ({
+  StepDefaults: () => <div data-testid="step-defaults-stub">defaults</div>,
+}));
+vi.mock('./step-finish', () => ({
+  StepFinish: ({ onFinish }: { onFinish: () => void }) => (
+    <div data-testid="step-finish-stub">
+      <button type="button" onClick={onFinish}>
+        Finish setup
+      </button>
+    </div>
+  ),
+}));
+
+import { SetupWizard } from './setup-wizard';
+
+const READINESS: SetupReadiness = {
+  ready: false,
+  completedAt: null,
+  blockers: { sidecar: 'pass', ffmpeg: 'pass', tts: 'fail', analyzer: 'fail' },
+  info: { gpu: 'CPU — no GPU detected' },
+};
+
+const STEP_TESTIDS = [
+  'step-environment-stub',
+  'step-ffmpeg-stub',
+  'step-models-stub',
+  'step-defaults-stub',
+  'step-finish-stub',
+];
+
+describe('SetupWizard', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows the "Set up Castwright" heading in guided mode', () => {
+    render(
+      <SetupWizard
+        readiness={READINESS}
+        mode="guided"
+        onRefetch={() => {}}
+        onFinish={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole('heading', { name: /set up castwright/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the "Set up Castwright" heading in checklist mode', () => {
+    render(
+      <SetupWizard
+        readiness={READINESS}
+        mode="checklist"
+        onRefetch={() => {}}
+        onFinish={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole('heading', { name: /set up castwright/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('guided mode renders ONE step at a time, starting on the first', () => {
+    render(
+      <SetupWizard
+        readiness={READINESS}
+        mode="guided"
+        onRefetch={() => {}}
+        onFinish={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('step-environment-stub')).toBeInTheDocument();
+    expect(screen.queryByTestId('step-ffmpeg-stub')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('step-finish-stub')).not.toBeInTheDocument();
+  });
+
+  it('guided mode shows a "Step N of 5" progress indicator', () => {
+    render(
+      <SetupWizard
+        readiness={READINESS}
+        mode="guided"
+        onRefetch={() => {}}
+        onFinish={() => {}}
+      />,
+    );
+    expect(screen.getByText(/step 1 of 5/i)).toBeInTheDocument();
+  });
+
+  it('guided mode: Next is always enabled (no blocker gating) and advances', () => {
+    render(
+      <SetupWizard
+        readiness={READINESS}
+        mode="guided"
+        onRefetch={() => {}}
+        onFinish={() => {}}
+      />,
+    );
+    const next = screen.getByRole('button', { name: /next/i });
+    // even with failing blockers, Next is NOT disabled
+    expect(next).not.toBeDisabled();
+    fireEvent.click(next);
+    expect(screen.getByTestId('step-ffmpeg-stub')).toBeInTheDocument();
+    expect(screen.queryByTestId('step-environment-stub')).not.toBeInTheDocument();
+    expect(screen.getByText(/step 2 of 5/i)).toBeInTheDocument();
+  });
+
+  it('guided mode: Back returns to the previous step', () => {
+    render(
+      <SetupWizard
+        readiness={READINESS}
+        mode="guided"
+        onRefetch={() => {}}
+        onFinish={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    expect(screen.getByTestId('step-ffmpeg-stub')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /back/i }));
+    expect(screen.getByTestId('step-environment-stub')).toBeInTheDocument();
+    expect(screen.getByText(/step 1 of 5/i)).toBeInTheDocument();
+  });
+
+  it('guided mode: Back is disabled on the first step', () => {
+    render(
+      <SetupWizard
+        readiness={READINESS}
+        mode="guided"
+        onRefetch={() => {}}
+        onFinish={() => {}}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /back/i })).toBeDisabled();
+  });
+
+  it('guided mode: the Finish step renders on the last step (no Next there)', () => {
+    render(
+      <SetupWizard
+        readiness={READINESS}
+        mode="guided"
+        onRefetch={() => {}}
+        onFinish={() => {}}
+      />,
+    );
+    // advance through all 4 transitions to the last (finish) step
+    for (let i = 0; i < 4; i++) {
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    }
+    expect(screen.getByTestId('step-finish-stub')).toBeInTheDocument();
+    expect(screen.getByText(/step 5 of 5/i)).toBeInTheDocument();
+    // Finish lives inside StepFinish; the wizard's own Next is gone
+    expect(screen.queryByRole('button', { name: /next/i })).not.toBeInTheDocument();
+  });
+
+  it('guided mode: the finish step button calls onFinish', () => {
+    const onFinish = vi.fn();
+    render(
+      <SetupWizard
+        readiness={READINESS}
+        mode="guided"
+        onRefetch={() => {}}
+        onFinish={onFinish}
+      />,
+    );
+    for (let i = 0; i < 4; i++) {
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    }
+    fireEvent.click(screen.getByRole('button', { name: /finish setup/i }));
+    expect(onFinish).toHaveBeenCalledTimes(1);
+  });
+
+  it('checklist mode renders all 5 steps stacked, with no Back/Next', () => {
+    render(
+      <SetupWizard
+        readiness={READINESS}
+        mode="checklist"
+        onRefetch={() => {}}
+        onFinish={() => {}}
+      />,
+    );
+    for (const id of STEP_TESTIDS) {
+      expect(screen.getByTestId(id)).toBeInTheDocument();
+    }
+    expect(screen.queryByRole('button', { name: /next/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^back$/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/setup/setup-wizard.tsx
+++ b/src/components/setup/setup-wizard.tsx
@@ -1,0 +1,183 @@
+/* fs-21 wave 2 — C5: SetupWizard orchestrator.
+   Composes the five step components into two modes:
+
+   - guided   — linear, one step at a time, Back/Next paging + a "Step N of 5"
+                progress indicator. Next is ALWAYS enabled: the derived Wave 0
+                boot gate is the real lock, so the wizard never blocks
+                progression on a failing blocker. The final step (Finish) owns
+                its own "Finish setup" button (via onFinish), so the wizard's
+                Next is dropped there.
+   - checklist — all five steps rendered stacked for re-entry (used once setup
+                is already complete); no Back/Next.
+
+   Per-step prop types differ (StepDefaults has no onRefetch; StepFinish takes
+   onFinish, not onRefetch), so each step is wired explicitly rather than via a
+   uniform spread. */
+
+import { useState } from 'react';
+import { MixedHeading } from '../primitives';
+import type { SetupReadiness } from '../../lib/api';
+import { StepEnvironment } from './step-environment';
+import { StepFfmpeg } from './step-ffmpeg';
+import { StepModels } from './step-models';
+import { StepDefaults } from './step-defaults';
+import { StepFinish } from './step-finish';
+
+type StepId = 'environment' | 'ffmpeg' | 'models' | 'defaults' | 'finish';
+
+const STEPS: { id: StepId; title: string }[] = [
+  { id: 'environment', title: 'Environment' },
+  { id: 'ffmpeg', title: 'ffmpeg' },
+  { id: 'models', title: 'Models' },
+  { id: 'defaults', title: 'Defaults' },
+  { id: 'finish', title: 'Finish' },
+];
+
+interface Props {
+  readiness: SetupReadiness;
+  mode: 'guided' | 'checklist';
+  onRefetch: () => void;
+  onFinish: () => void;
+}
+
+/* Render a single step by id, passing ONLY the props its type declares. */
+function renderStep(
+  id: StepId,
+  readiness: SetupReadiness,
+  onRefetch: () => void,
+  onFinish: () => void,
+) {
+  switch (id) {
+    case 'environment':
+      return <StepEnvironment readiness={readiness} onRefetch={onRefetch} />;
+    case 'ffmpeg':
+      return <StepFfmpeg readiness={readiness} onRefetch={onRefetch} />;
+    case 'models':
+      return <StepModels readiness={readiness} onRefetch={onRefetch} />;
+    case 'defaults':
+      return <StepDefaults readiness={readiness} />;
+    case 'finish':
+      return <StepFinish readiness={readiness} onFinish={onFinish} />;
+  }
+}
+
+export function SetupWizard({ readiness, mode, onRefetch, onFinish }: Props) {
+  const [stepIndex, setStepIndex] = useState(0);
+
+  return (
+    <div className="max-w-[960px] mx-auto px-4 sm:px-6 py-10">
+      <header className="mb-8">
+        <MixedHeading regular="Set up" bold="Castwright" level="h1" />
+        <p className="mt-3 text-ink/60 max-w-xl">
+          A quick check that everything needed to produce an audiobook is in place.
+        </p>
+      </header>
+
+      {mode === 'guided' ? (
+        <GuidedWizard
+          readiness={readiness}
+          stepIndex={stepIndex}
+          onStepChange={setStepIndex}
+          onRefetch={onRefetch}
+          onFinish={onFinish}
+        />
+      ) : (
+        <ChecklistWizard readiness={readiness} onRefetch={onRefetch} onFinish={onFinish} />
+      )}
+    </div>
+  );
+}
+
+// ── guided mode ───────────────────────────────────────────────────────────────
+
+function GuidedWizard({
+  readiness,
+  stepIndex,
+  onStepChange,
+  onRefetch,
+  onFinish,
+}: {
+  readiness: SetupReadiness;
+  stepIndex: number;
+  onStepChange: (next: number) => void;
+  onRefetch: () => void;
+  onFinish: () => void;
+}) {
+  const step = STEPS[stepIndex];
+  const isFirst = stepIndex === 0;
+  const isLast = stepIndex === STEPS.length - 1;
+
+  return (
+    <div className="space-y-6">
+      {/* Progress indicator: dots + "Step N of 5" */}
+      <div className="flex items-center gap-3">
+        <div className="flex items-center gap-1.5" aria-hidden>
+          {STEPS.map((s, i) => (
+            <span
+              key={s.id}
+              className={[
+                'h-2 rounded-full transition-all',
+                i === stepIndex ? 'w-6 bg-magenta' : 'w-2 bg-ink/15',
+              ].join(' ')}
+            />
+          ))}
+        </div>
+        <span className="text-xs font-medium text-ink/55">
+          Step {stepIndex + 1} of {STEPS.length}
+        </span>
+      </div>
+
+      <div className="rounded-2xl border border-ink/10 bg-white p-5 sm:p-6 shadow-card">
+        {renderStep(step.id, readiness, onRefetch, onFinish)}
+      </div>
+
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          onClick={() => onStepChange(stepIndex - 1)}
+          disabled={isFirst}
+          className="min-h-[44px] sm:min-h-0 px-4 py-2 rounded-full border border-ink/15 bg-white text-sm font-medium text-ink/70 hover:bg-ink/5 disabled:opacity-40 disabled:hover:bg-white disabled:cursor-not-allowed"
+        >
+          Back
+        </button>
+
+        {/* Next is ALWAYS enabled — no blocker gating. On the last step the
+            Finish button lives inside StepFinish, so the wizard's Next is gone. */}
+        {!isLast && (
+          <button
+            type="button"
+            onClick={() => onStepChange(stepIndex + 1)}
+            className="min-h-[44px] sm:min-h-0 px-5 py-2 rounded-full bg-ink text-canvas text-sm font-medium hover:bg-ink-soft"
+          >
+            Next
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── checklist mode ──────────────────────────────────────────────────────────
+
+function ChecklistWizard({
+  readiness,
+  onRefetch,
+  onFinish,
+}: {
+  readiness: SetupReadiness;
+  onRefetch: () => void;
+  onFinish: () => void;
+}) {
+  return (
+    <div className="space-y-6">
+      {STEPS.map((s) => (
+        <section
+          key={s.id}
+          className="rounded-2xl border border-ink/10 bg-white p-5 sm:p-6 shadow-card"
+        >
+          {renderStep(s.id, readiness, onRefetch, onFinish)}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/components/setup/step-defaults.test.tsx
+++ b/src/components/setup/step-defaults.test.tsx
@@ -1,0 +1,143 @@
+/* StepDefaults spec — fs-21 wave 2.
+   Verifies that the component renders 4 selects (engine, TTS model, analysis
+   model, theme) pre-filled from the account slice, and that changing the theme
+   select dispatches saveAccountSettings with the new defaultThemePreference. */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import { accountSlice } from '../../store/account-slice';
+import type { SetupReadiness } from '../../lib/api';
+
+// ── mock the API so saveAccountSettings thunk stays in-memory ─────────────
+
+const putUserSettingsMock = vi.fn();
+
+vi.mock('../../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/api')>('../../lib/api');
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      putUserSettings: (patch: unknown) => {
+        putUserSettingsMock(patch);
+        return Promise.resolve({
+          ...accountSlice.getInitialState(),
+          ...(patch as Record<string, unknown>),
+        });
+      },
+    },
+  };
+});
+
+import { StepDefaults } from './step-defaults';
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function makeReadiness(overrides: Partial<SetupReadiness> = {}): SetupReadiness {
+  return {
+    ready: true,
+    completedAt: null,
+    blockers: { sidecar: 'pass', ffmpeg: 'pass', tts: 'pass', analyzer: 'pass' },
+    info: { gpu: 'cuda · 1.2 / 8.0 GB' },
+    ...overrides,
+  };
+}
+
+function makeStore(
+  preloaded: Partial<ReturnType<typeof accountSlice.getInitialState>> = {},
+) {
+  return configureStore({
+    reducer: { account: accountSlice.reducer },
+    preloadedState: {
+      account: {
+        ...accountSlice.getInitialState(),
+        ...preloaded,
+      } as ReturnType<typeof accountSlice.getInitialState>,
+    },
+  });
+}
+
+function renderStep(overrides: Partial<ReturnType<typeof accountSlice.getInitialState>> = {}) {
+  const store = makeStore(overrides);
+  render(
+    <Provider store={store}>
+      <StepDefaults readiness={makeReadiness()} />
+    </Provider>,
+  );
+  return { store };
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  putUserSettingsMock.mockReset();
+});
+
+describe('StepDefaults', () => {
+  it('renders a "Defaults" heading', () => {
+    renderStep();
+    expect(screen.getByRole('heading', { name: /defaults/i })).toBeInTheDocument();
+  });
+
+  it('renders 4 select controls (engine, TTS model, analysis model, theme)', () => {
+    renderStep();
+    const selects = screen.getAllByRole('combobox');
+    expect(selects.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('pre-selects the engine from the account slice defaultTtsEngine', () => {
+    renderStep({ defaultTtsEngine: 'gemini' });
+    const select = screen.getByLabelText(/voice engine/i) as HTMLSelectElement;
+    expect(select.value).toBe('gemini');
+  });
+
+  it('pre-selects the analysis model from the account slice', () => {
+    renderStep({ defaultAnalysisModel: 'gemma-4-31b-it' });
+    const select = screen.getByLabelText(/analysis model/i) as HTMLSelectElement;
+    expect(select.value).toBe('gemma-4-31b-it');
+  });
+
+  it('pre-selects the theme from the account slice defaultThemePreference', () => {
+    renderStep({ defaultThemePreference: 'dark' });
+    const select = screen.getByLabelText(/theme/i) as HTMLSelectElement;
+    expect(select.value).toBe('dark');
+  });
+
+  it('dispatches saveAccountSettings with defaultThemePreference when theme changes', async () => {
+    renderStep({ defaultThemePreference: 'system' });
+    const select = screen.getByLabelText(/theme/i) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'light' } });
+    await waitFor(() => {
+      expect(putUserSettingsMock).toHaveBeenCalledWith(
+        expect.objectContaining({ defaultThemePreference: 'light' }),
+      );
+    });
+  });
+
+  it('dispatches saveAccountSettings with defaultTtsEngine when engine changes', async () => {
+    renderStep({ defaultTtsEngine: 'local' });
+    const select = screen.getByLabelText(/voice engine/i) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'gemini' } });
+    await waitFor(() => {
+      expect(putUserSettingsMock).toHaveBeenCalledWith(
+        expect.objectContaining({ defaultTtsEngine: 'gemini' }),
+      );
+    });
+  });
+
+  it('dispatches saveAccountSettings with defaultTtsModelKeyExplicit:true when TTS model changes', async () => {
+    renderStep({ defaultTtsModelKey: 'kokoro-v1', defaultTtsEngine: 'local' });
+    const select = screen.getByLabelText(/voice model/i) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'qwen3-tts-0.6b' } });
+    await waitFor(() => {
+      expect(putUserSettingsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          defaultTtsModelKey: 'qwen3-tts-0.6b',
+          defaultTtsModelKeyExplicit: true,
+        }),
+      );
+    });
+  });
+});

--- a/src/components/setup/step-defaults.tsx
+++ b/src/components/setup/step-defaults.tsx
@@ -1,0 +1,185 @@
+/* fs-21 wave 2 — Step: Defaults.
+   Informational step: pre-fills the four key defaults (voice engine, TTS
+   model, analysis model, theme) from the account slice and dispatches
+   saveAccountSettings on every change. Never blocks wizard progression. */
+
+import { useEffect, useState } from 'react';
+import { TTS_ENGINES, type TtsEngineId } from '../../lib/tts-models';
+import { MODEL_OPTION_GROUPS } from '../../lib/models';
+import type { TtsModelKey } from '../../lib/types';
+import type { ThemePreference } from '../../lib/use-theme';
+import { useAppDispatch, useAppSelector } from '../../store';
+import { saveAccountSettings } from '../../store/account-slice';
+import type { SetupReadiness } from '../../lib/api';
+
+// ── prop types ──────────────────────────────────────────────────────────────
+
+interface Props {
+  /** Passed by the wizard orchestrator for contract uniformity. */
+  readiness: SetupReadiness;
+}
+
+// ── shared select class ─────────────────────────────────────────────────────
+
+const SELECT_CLS =
+  'w-full px-3 py-2 rounded-xl border border-ink/15 bg-white text-sm text-ink focus:outline-hidden focus:ring-2 focus:ring-magenta/30';
+
+// ── component ───────────────────────────────────────────────────────────────
+
+export function StepDefaults({ readiness: _readiness }: Props) {
+  const dispatch = useAppDispatch();
+  const account = useAppSelector((s) => s.account);
+
+  /* Local mirror of the four persisted defaults. Re-syncs whenever the
+     account slice rehydrates (e.g. after a successful save). */
+  const effectiveTtsModelKey = account.resolvedTtsModelKey ?? account.defaultTtsModelKey;
+  const [engine, setEngine] = useState<TtsEngineId>(account.defaultTtsEngine);
+  const [ttsModel, setTtsModel] = useState<TtsModelKey>(effectiveTtsModelKey);
+  const [analysisModel, setAnalysisModel] = useState<string>(account.defaultAnalysisModel);
+  const [theme, setTheme] = useState<ThemePreference>(account.defaultThemePreference ?? 'system');
+
+  useEffect(() => {
+    setEngine(account.defaultTtsEngine);
+    setTtsModel(account.resolvedTtsModelKey ?? account.defaultTtsModelKey);
+    setAnalysisModel(account.defaultAnalysisModel);
+    setTheme(account.defaultThemePreference ?? 'system');
+  }, [
+    account.hydrated,
+    account.defaultTtsEngine,
+    account.defaultTtsModelKey,
+    account.resolvedTtsModelKey,
+    account.defaultAnalysisModel,
+    account.defaultThemePreference,
+  ]);
+
+  /* When the engine switches, default to the new group's first model if the
+     current model doesn't belong to it (mirrors model-settings-form). */
+  const engineGroup = TTS_ENGINES.find((g) => g.id === engine) ?? TTS_ENGINES[0];
+  useEffect(() => {
+    if (!engineGroup.models.some((m) => m.id === ttsModel)) {
+      setTtsModel(engineGroup.models[0].id);
+    }
+  }, [engine, engineGroup, ttsModel]);
+
+  // ── change handlers ───────────────────────────────────────────────────────
+
+  const handleEngineChange = (next: TtsEngineId) => {
+    setEngine(next);
+    void dispatch(saveAccountSettings({ defaultTtsEngine: next }));
+  };
+
+  const handleTtsModelChange = (next: TtsModelKey) => {
+    setTtsModel(next);
+    void dispatch(
+      saveAccountSettings({
+        defaultTtsModelKey: next,
+        /* Pin the explicit flag so the saved choice isn't silently
+           overridden by a future resolved default. Mirrors model-settings-form. */
+        defaultTtsModelKeyExplicit: true,
+      }),
+    );
+  };
+
+  const handleAnalysisModelChange = (next: string) => {
+    setAnalysisModel(next);
+    void dispatch(saveAccountSettings({ defaultAnalysisModel: next }));
+  };
+
+  const handleThemeChange = (next: ThemePreference) => {
+    setTheme(next);
+    void dispatch(saveAccountSettings({ defaultThemePreference: next }));
+  };
+
+  // ── render ────────────────────────────────────────────────────────────────
+
+  return (
+    <section className="space-y-6">
+      <h2 className="text-lg font-semibold text-ink">Defaults</h2>
+
+      <p className="text-sm text-ink/60">
+        These defaults are used the first time you open a new book. You can change
+        them per-book later — this is just your starting point.
+      </p>
+
+      <div className="space-y-4">
+        {/* Voice engine */}
+        <div>
+          <label htmlFor="setup-defaults-engine" className="block text-sm font-medium text-ink mb-1">
+            Voice engine
+          </label>
+          <select
+            id="setup-defaults-engine"
+            value={engine}
+            onChange={(e) => handleEngineChange(e.target.value as TtsEngineId)}
+            className={SELECT_CLS}
+          >
+            {TTS_ENGINES.map((g) => (
+              <option key={g.id} value={g.id} title={g.hint}>
+                {g.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* TTS model (filtered to selected engine) */}
+        <div>
+          <label htmlFor="setup-defaults-tts-model" className="block text-sm font-medium text-ink mb-1">
+            Voice model
+          </label>
+          <select
+            id="setup-defaults-tts-model"
+            value={ttsModel}
+            onChange={(e) => handleTtsModelChange(e.target.value as TtsModelKey)}
+            className={SELECT_CLS}
+          >
+            {engineGroup.models.map((m) => (
+              <option key={m.id} value={m.id} title={m.hint}>
+                {m.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Analysis model */}
+        <div>
+          <label htmlFor="setup-defaults-analysis-model" className="block text-sm font-medium text-ink mb-1">
+            Analysis model
+          </label>
+          <select
+            id="setup-defaults-analysis-model"
+            value={analysisModel}
+            onChange={(e) => handleAnalysisModelChange(e.target.value)}
+            className={SELECT_CLS}
+          >
+            {MODEL_OPTION_GROUPS.map((g) => (
+              <optgroup key={g.engine} label={g.label}>
+                {g.models.map((m) => (
+                  <option key={m.id} value={m.id} title={m.hint}>
+                    {m.label}
+                  </option>
+                ))}
+              </optgroup>
+            ))}
+          </select>
+        </div>
+
+        {/* Theme */}
+        <div>
+          <label htmlFor="setup-defaults-theme" className="block text-sm font-medium text-ink mb-1">
+            Theme
+          </label>
+          <select
+            id="setup-defaults-theme"
+            value={theme}
+            onChange={(e) => handleThemeChange(e.target.value as ThemePreference)}
+            className={SELECT_CLS}
+          >
+            <option value="system">System (follow OS setting)</option>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/setup/step-environment.test.tsx
+++ b/src/components/setup/step-environment.test.tsx
@@ -1,0 +1,51 @@
+/* StepEnvironment spec — fs-21 wave 2.
+   Asserts the step renders the DevicePanel region and surfaces the
+   readiness.info.gpu string passed in via props. */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+/* Stub useAppInfo so DevicePanel renders without a Redux store. */
+vi.mock('../../lib/use-app-info', () => ({
+  useAppInfo: () => ({ info: null, error: null, refresh: vi.fn() }),
+}));
+
+import { StepEnvironment } from './step-environment';
+import type { SetupReadiness } from '../../lib/api';
+
+function makeReadiness(overrides: Partial<SetupReadiness> = {}): SetupReadiness {
+  return {
+    ready: true,
+    completedAt: null,
+    blockers: { sidecar: 'pass', ffmpeg: 'pass', tts: 'pass', analyzer: 'pass' },
+    info: { gpu: 'cuda · 1.2 / 8.0 GB reserved' },
+    ...overrides,
+  };
+}
+
+describe('StepEnvironment', () => {
+  it('renders an Environment heading', () => {
+    render(<StepEnvironment readiness={makeReadiness()} onRefetch={vi.fn()} />);
+    expect(screen.getByRole('heading', { name: /environment/i })).toBeInTheDocument();
+  });
+
+  it('renders the gpu string from readiness.info.gpu', () => {
+    const readiness = makeReadiness({ info: { gpu: 'Apple GPU (Metal)' } });
+    render(<StepEnvironment readiness={readiness} onRefetch={vi.fn()} />);
+    expect(screen.getByText(/Apple GPU \(Metal\)/)).toBeInTheDocument();
+  });
+
+  it('renders a Re-check button that calls onRefetch', () => {
+    const onRefetch = vi.fn();
+    render(<StepEnvironment readiness={makeReadiness()} onRefetch={onRefetch} />);
+    const btn = screen.getByRole('button', { name: /re-check/i });
+    btn.click();
+    expect(onRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the DevicePanel sentinel text', () => {
+    render(<StepEnvironment readiness={makeReadiness()} onRefetch={vi.fn()} />);
+    /* DevicePanel always renders its "Will it run on my machine?" heading. */
+    expect(screen.getByText(/will it run on my machine/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/setup/step-environment.tsx
+++ b/src/components/setup/step-environment.tsx
@@ -1,0 +1,35 @@
+/* fs-21 wave 2 — Step 1: Environment.
+   Informational step: shows detected hardware via DevicePanel plus the
+   readiness.info.gpu summary. Never blocks wizard progression. */
+
+import type { SetupReadiness } from '../../lib/api';
+import { DevicePanel } from '../device-panel';
+
+interface Props {
+  readiness: SetupReadiness;
+  onRefetch: () => void;
+}
+
+export function StepEnvironment({ readiness, onRefetch }: Props) {
+  return (
+    <section className="space-y-4">
+      <h2 className="text-lg font-semibold text-ink">Environment</h2>
+
+      <DevicePanel />
+
+      <div className="rounded-2xl border border-ink/10 bg-canvas px-4 py-3 flex items-center justify-between gap-4">
+        <p className="text-sm text-ink/70">
+          <span className="text-ink/50">Detected:</span>{' '}
+          <span className="font-medium text-ink">{readiness.info.gpu}</span>
+        </p>
+        <button
+          type="button"
+          onClick={onRefetch}
+          className="shrink-0 px-3 py-1.5 rounded-full border border-ink/20 bg-white text-xs text-ink hover:bg-ink/5"
+        >
+          Re-check
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/setup/step-ffmpeg.test.tsx
+++ b/src/components/setup/step-ffmpeg.test.tsx
@@ -1,0 +1,57 @@
+/* StepFfmpeg spec — fs-21 wave 2.
+   Asserts the green "found" card on pass and per-OS install instructions
+   + Re-check button on fail. */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { StepFfmpeg } from './step-ffmpeg';
+import type { SetupReadiness } from '../../lib/api';
+
+function makeReadiness(ffmpeg: 'pass' | 'fail'): SetupReadiness {
+  return {
+    ready: ffmpeg === 'pass',
+    completedAt: null,
+    blockers: { sidecar: 'pass', ffmpeg, tts: 'pass', analyzer: 'pass' },
+    info: { gpu: 'cpu' },
+  };
+}
+
+describe('StepFfmpeg', () => {
+  describe('when ffmpeg blocker is pass', () => {
+    it('renders a ready / found indication', () => {
+      render(<StepFfmpeg readiness={makeReadiness('pass')} onRefetch={vi.fn()} />);
+      expect(screen.getByText(/ffmpeg found/i)).toBeInTheDocument();
+    });
+
+    it('does NOT render install instructions', () => {
+      render(<StepFfmpeg readiness={makeReadiness('pass')} onRefetch={vi.fn()} />);
+      expect(screen.queryByText(/winget install ffmpeg/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/brew install ffmpeg/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when ffmpeg blocker is fail', () => {
+    it('renders Windows install instructions', () => {
+      render(<StepFfmpeg readiness={makeReadiness('fail')} onRefetch={vi.fn()} />);
+      expect(screen.getByText(/winget install ffmpeg/i)).toBeInTheDocument();
+    });
+
+    it('renders macOS install instructions', () => {
+      render(<StepFfmpeg readiness={makeReadiness('fail')} onRefetch={vi.fn()} />);
+      expect(screen.getByText(/brew install ffmpeg/i)).toBeInTheDocument();
+    });
+
+    it('renders Linux install instructions', () => {
+      render(<StepFfmpeg readiness={makeReadiness('fail')} onRefetch={vi.fn()} />);
+      expect(screen.getByText(/sudo apt install ffmpeg/i)).toBeInTheDocument();
+    });
+
+    it('renders a Re-check button that calls onRefetch', () => {
+      const onRefetch = vi.fn();
+      render(<StepFfmpeg readiness={makeReadiness('fail')} onRefetch={onRefetch} />);
+      const btn = screen.getByRole('button', { name: /re-check/i });
+      fireEvent.click(btn);
+      expect(onRefetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/setup/step-ffmpeg.tsx
+++ b/src/components/setup/step-ffmpeg.tsx
@@ -1,0 +1,86 @@
+/* fs-21 wave 2 — Step 2: ffmpeg.
+   Hard-blocker step. ffmpeg is an OS-level dependency — no in-app installer.
+   Shows a green "found" card on pass; shows per-OS install instructions + a
+   Re-check button on fail (mirrors the venv-bootstrap decision-Z pattern). */
+
+import type { SetupReadiness } from '../../lib/api';
+
+interface Props {
+  readiness: SetupReadiness;
+  onRefetch: () => void;
+}
+
+export function StepFfmpeg({ readiness, onRefetch }: Props) {
+  const passed = readiness.blockers.ffmpeg === 'pass';
+
+  if (passed) {
+    return (
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold text-ink">ffmpeg</h2>
+        <div
+          data-testid="step-ffmpeg-ready"
+          className="rounded-2xl border border-emerald-200 bg-emerald-50 p-4"
+        >
+          <div className="flex items-center gap-3">
+            <span className="w-2 h-2 rounded-full bg-emerald-600 shrink-0" />
+            <div className="flex-1">
+              <p className="text-sm font-semibold text-emerald-900">ffmpeg found</p>
+              <p className="text-xs text-emerald-900/70">
+                Audio assembly is ready — ffmpeg is available on this machine.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-lg font-semibold text-ink">ffmpeg</h2>
+      <div
+        data-testid="step-ffmpeg-missing"
+        className="rounded-2xl border border-amber-200 bg-amber-50 p-4 space-y-4"
+      >
+        <div>
+          <p className="text-sm font-semibold text-amber-900">ffmpeg not found</p>
+          <p className="mt-1 text-xs text-amber-900/70">
+            Castwright uses ffmpeg to assemble and normalise audio. Install it with your
+            OS package manager, then click Re-check.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <p className="text-xs font-semibold text-ink/60 uppercase tracking-wide">Windows</p>
+            <pre className="text-xs bg-ink/5 text-ink rounded-lg p-3 overflow-x-auto leading-relaxed">
+              {'winget install ffmpeg'}
+            </pre>
+          </div>
+
+          <div className="space-y-1">
+            <p className="text-xs font-semibold text-ink/60 uppercase tracking-wide">macOS</p>
+            <pre className="text-xs bg-ink/5 text-ink rounded-lg p-3 overflow-x-auto leading-relaxed">
+              {'brew install ffmpeg'}
+            </pre>
+          </div>
+
+          <div className="space-y-1">
+            <p className="text-xs font-semibold text-ink/60 uppercase tracking-wide">Linux</p>
+            <pre className="text-xs bg-ink/5 text-ink rounded-lg p-3 overflow-x-auto leading-relaxed">
+              {'sudo apt install ffmpeg'}
+            </pre>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={onRefetch}
+          className="px-3 py-1.5 rounded-full border border-amber-300 bg-white text-xs text-amber-900 hover:bg-amber-100"
+        >
+          Re-check
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/setup/step-finish.test.tsx
+++ b/src/components/setup/step-finish.test.tsx
@@ -1,0 +1,50 @@
+/* StepFinish spec — fs-21 wave 2.
+   Verifies the placeholder smoke-test card and the "Finish setup" button. */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { SetupReadiness } from '../../lib/api';
+import { StepFinish } from './step-finish';
+
+function makeReadiness(overrides: Partial<SetupReadiness> = {}): SetupReadiness {
+  return {
+    ready: true,
+    completedAt: null,
+    blockers: { sidecar: 'pass', ffmpeg: 'pass', tts: 'pass', analyzer: 'pass' },
+    info: { gpu: 'cuda · 1.2 / 8.0 GB' },
+    ...overrides,
+  };
+}
+
+describe('StepFinish', () => {
+  it('renders a "Finish" heading', () => {
+    render(<StepFinish readiness={makeReadiness()} onFinish={vi.fn()} />);
+    expect(screen.getByRole('heading', { name: /finish/i })).toBeInTheDocument();
+  });
+
+  it('renders the smoke-test placeholder text', () => {
+    render(<StepFinish readiness={makeReadiness()} onFinish={vi.fn()} />);
+    expect(
+      screen.getByText(/full audible end-to-end smoke test arrives in the next release/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a disabled smoke-test affordance', () => {
+    render(<StepFinish readiness={makeReadiness()} onFinish={vi.fn()} />);
+    const smokeBtn = screen.getByTestId('smoke-test-placeholder');
+    expect(smokeBtn).toBeDisabled();
+  });
+
+  it('renders a "Finish setup" button', () => {
+    render(<StepFinish readiness={makeReadiness()} onFinish={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /finish setup/i })).toBeInTheDocument();
+  });
+
+  it('calls onFinish when "Finish setup" is clicked', () => {
+    const onFinish = vi.fn();
+    render(<StepFinish readiness={makeReadiness()} onFinish={onFinish} />);
+    const btn = screen.getByRole('button', { name: /finish setup/i });
+    btn.click();
+    expect(onFinish).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/setup/step-finish.tsx
+++ b/src/components/setup/step-finish.tsx
@@ -1,0 +1,60 @@
+/* fs-21 wave 2 — Step: Finish.
+   Final wizard step. Shows a placeholder for the Wave-3 audible smoke test
+   (arriving in the next release) and a "Finish setup" button that calls
+   onFinish, which the orchestrator wires to completeSetup + navigate home. */
+
+import { PrimaryButton } from '../primitives';
+import type { SetupReadiness } from '../../lib/api';
+
+// ── prop types ──────────────────────────────────────────────────────────────
+
+interface Props {
+  /** Passed by the wizard orchestrator for contract uniformity. */
+  readiness: SetupReadiness;
+  /** Called when the user clicks "Finish setup". */
+  onFinish: () => void;
+}
+
+// ── component ───────────────────────────────────────────────────────────────
+
+export function StepFinish({ readiness: _readiness, onFinish }: Props) {
+  return (
+    <section className="space-y-6">
+      <h2 className="text-lg font-semibold text-ink">Finish</h2>
+
+      <p className="text-sm text-ink/60">
+        Everything looks good. When you're ready, finish setup to go to your library.
+      </p>
+
+      {/* Smoke-test placeholder — Wave 3 */}
+      <div className="rounded-2xl border border-ink/10 bg-canvas px-4 py-4 space-y-3">
+        <div className="flex items-center gap-3">
+          <span className="text-sm font-medium text-ink">End-to-end smoke test</span>
+          <span className="inline-block px-2.5 py-0.5 rounded-full border border-ink/10 text-xs text-ink/50">
+            Coming soon
+          </span>
+        </div>
+        <p className="text-xs text-ink/55">
+          The full audible end-to-end smoke test arrives in the next release. It will generate
+          a short sample sentence through your configured voice engine and confirm audio
+          comes back correctly before you start on your first book.
+        </p>
+        <button
+          type="button"
+          data-testid="smoke-test-placeholder"
+          disabled
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-ink/15 text-sm text-ink/40 cursor-not-allowed"
+          aria-disabled
+        >
+          Run smoke test
+        </button>
+      </div>
+
+      <div className="flex justify-end">
+        <PrimaryButton onClick={onFinish} icon={false}>
+          Finish setup
+        </PrimaryButton>
+      </div>
+    </section>
+  );
+}

--- a/src/components/setup/step-models.test.tsx
+++ b/src/components/setup/step-models.test.tsx
@@ -1,0 +1,193 @@
+/* StepModels composition spec.
+   Uses vi.mock to stub the heavy child components so assertions focus on
+   composition (correct sections rendered, callbacks wired), not on each
+   child's internal state machine. */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { accountSlice } from '../../store/account-slice';
+import type { SetupReadiness } from '../../lib/api';
+import { StepModels } from './step-models';
+
+// ── stub child components ──────────────────────────────────────────────────
+
+vi.mock('../venv-bootstrap', () => ({
+  VenvBootstrap: ({ onBootstrapped }: { onBootstrapped?: () => void }) => (
+    <div data-testid="stub-venv-bootstrap" data-has-cb={typeof onBootstrapped}>
+      VenvBootstrap stub
+    </div>
+  ),
+}));
+
+vi.mock('../kokoro-install', () => ({
+  KokoroInstall: ({ onInstalled }: { onInstalled?: () => void }) => (
+    <div data-testid="stub-kokoro-install" data-has-cb={typeof onInstalled}>
+      KokoroInstall stub
+    </div>
+  ),
+}));
+
+vi.mock('../qwen-install', () => ({
+  QwenInstall: ({ onInstalled }: { onInstalled?: () => void }) => (
+    <div data-testid="stub-qwen-install" data-has-cb={typeof onInstalled}>
+      QwenInstall stub
+    </div>
+  ),
+}));
+
+vi.mock('../coqui-install', () => ({
+  CoquiInstall: ({ onInstalled }: { onInstalled?: () => void }) => (
+    <div data-testid="stub-coqui-install" data-has-cb={typeof onInstalled}>
+      CoquiInstall stub
+    </div>
+  ),
+}));
+
+vi.mock('../ollama-install', () => ({
+  OllamaInstall: ({ onInstalled }: { onInstalled?: () => void }) => (
+    <div data-testid="stub-ollama-install" data-has-cb={typeof onInstalled}>
+      OllamaInstall stub
+    </div>
+  ),
+}));
+
+vi.mock('../account-forms', () => ({
+  GeminiKeyField: ({
+    status,
+    onSave,
+  }: {
+    status: 'set' | 'unset';
+    onSave: (k: string | null) => unknown;
+  }) => (
+    <div data-testid="stub-gemini-key-field" data-status={status} data-has-cb={typeof onSave}>
+      GeminiKeyField stub
+    </div>
+  ),
+}));
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function makeStore() {
+  return configureStore({
+    reducer: { account: accountSlice.reducer },
+  });
+}
+
+const notReadyReadiness: SetupReadiness = {
+  ready: false,
+  completedAt: null,
+  blockers: { sidecar: 'fail', ffmpeg: 'pass', tts: 'fail', analyzer: 'fail' },
+  info: { gpu: 'none' },
+};
+
+const readyReadiness: SetupReadiness = {
+  ready: true,
+  completedAt: '2026-01-01T00:00:00Z',
+  blockers: { sidecar: 'pass', ffmpeg: 'pass', tts: 'pass', analyzer: 'pass' },
+  info: { gpu: 'NVIDIA A100' },
+};
+
+function renderStep(readiness: SetupReadiness = notReadyReadiness) {
+  const store = makeStore();
+  const onRefetch = vi.fn();
+  render(
+    <Provider store={store}>
+      <StepModels readiness={readiness} onRefetch={onRefetch} />
+    </Provider>,
+  );
+  return { store, onRefetch };
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+describe('StepModels', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the "Models" heading', () => {
+    renderStep();
+    expect(screen.getByRole('heading', { name: /models/i })).toBeInTheDocument();
+  });
+
+  it('renders the TTS section with VenvBootstrap and KokoroInstall stubs', () => {
+    renderStep();
+    expect(screen.getByTestId('stub-venv-bootstrap')).toBeInTheDocument();
+    expect(screen.getByTestId('stub-kokoro-install')).toBeInTheDocument();
+  });
+
+  it('passes a function callback to VenvBootstrap (onBootstrapped)', () => {
+    renderStep();
+    expect(screen.getByTestId('stub-venv-bootstrap').dataset.hasCb).toBe('function');
+  });
+
+  it('passes a function callback to KokoroInstall (onInstalled)', () => {
+    renderStep();
+    expect(screen.getByTestId('stub-kokoro-install').dataset.hasCb).toBe('function');
+  });
+
+  it('renders the Analyzer section with GeminiKeyField stub', () => {
+    renderStep();
+    expect(screen.getByTestId('stub-gemini-key-field')).toBeInTheDocument();
+  });
+
+  it('passes a function callback to GeminiKeyField (onSave)', () => {
+    renderStep();
+    expect(screen.getByTestId('stub-gemini-key-field').dataset.hasCb).toBe('function');
+  });
+
+  it('renders the alternative engines toggle/details element', () => {
+    renderStep();
+    // Details/summary for alternative engines should be in the document
+    const details = document.querySelector('details');
+    expect(details).toBeInTheDocument();
+  });
+
+  it('Qwen and Coqui stubs are present inside alternatives (hidden by default)', () => {
+    renderStep();
+    // They are rendered (in the DOM) even if not visible — their container is collapsed
+    expect(screen.getByTestId('stub-qwen-install')).toBeInTheDocument();
+    expect(screen.getByTestId('stub-coqui-install')).toBeInTheDocument();
+  });
+
+  it('OllamaInstall stub is present inside the local analyzer toggle', () => {
+    renderStep();
+    expect(screen.getByTestId('stub-ollama-install')).toBeInTheDocument();
+  });
+
+  it('passes a function callback to QwenInstall (onInstalled)', () => {
+    renderStep();
+    expect(screen.getByTestId('stub-qwen-install').dataset.hasCb).toBe('function');
+  });
+
+  it('passes a function callback to CoquiInstall (onInstalled)', () => {
+    renderStep();
+    expect(screen.getByTestId('stub-coqui-install').dataset.hasCb).toBe('function');
+  });
+
+  it('passes a function callback to OllamaInstall (onInstalled)', () => {
+    renderStep();
+    expect(screen.getByTestId('stub-ollama-install').dataset.hasCb).toBe('function');
+  });
+
+  it('shows sidecar + tts blocker status badges', () => {
+    renderStep(notReadyReadiness);
+    // Both sidecar and tts are 'fail' in notReadyReadiness
+    const failBadges = document.querySelectorAll('[data-blocker-status="fail"]');
+    expect(failBadges.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('shows pass badges when all blockers pass', () => {
+    renderStep(readyReadiness);
+    const passBadges = document.querySelectorAll('[data-blocker-status="pass"]');
+    expect(passBadges.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('reflects the account apiKeyStatus in GeminiKeyField status prop', () => {
+    renderStep();
+    // Initial store has apiKeyStatus:'unset'
+    expect(screen.getByTestId('stub-gemini-key-field').dataset.status).toBe('unset');
+  });
+});

--- a/src/components/setup/step-models.tsx
+++ b/src/components/setup/step-models.tsx
@@ -1,0 +1,169 @@
+/* Setup wizard — Step: Models.
+   Composes the in-app installers for the TTS runtime (venv + Kokoro default,
+   Qwen/Coqui as collapsible alternatives) and the analyzer setup (Gemini key
+   recommended, local Ollama as collapsible alternative).
+
+   Each install callback (`onInstalled` / `onBootstrapped`) is wired to
+   `onRefetch` so the wizard re-probes readiness after every completed install. */
+
+import { VenvBootstrap } from '../venv-bootstrap';
+import { KokoroInstall } from '../kokoro-install';
+import { QwenInstall } from '../qwen-install';
+import { CoquiInstall } from '../coqui-install';
+import { OllamaInstall } from '../ollama-install';
+import { GeminiKeyField } from '../account-forms';
+import { useAppDispatch, useAppSelector } from '../../store';
+import { saveGeminiApiKey } from '../../store/account-slice';
+import type { SetupReadiness } from '../../lib/api';
+
+// ── small status badge ──────────────────────────────────────────────────────
+
+function BlockerBadge({
+  status,
+  label,
+}: {
+  status: 'pass' | 'fail';
+  label: string;
+}) {
+  const isPass = status === 'pass';
+  return (
+    <span
+      data-blocker-status={status}
+      className={[
+        'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold',
+        isPass
+          ? 'bg-emerald-100 text-emerald-800'
+          : 'bg-amber-100 text-amber-800',
+      ].join(' ')}
+    >
+      <span
+        className={[
+          'w-1.5 h-1.5 rounded-full',
+          isPass ? 'bg-emerald-600' : 'bg-amber-600',
+        ].join(' ')}
+      />
+      {label}
+    </span>
+  );
+}
+
+// ── section heading ─────────────────────────────────────────────────────────
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="text-base font-semibold text-ink">{children}</h2>
+  );
+}
+
+// ── StepModels ──────────────────────────────────────────────────────────────
+
+export function StepModels({
+  readiness,
+  onRefetch,
+}: {
+  readiness: SetupReadiness;
+  onRefetch: () => void;
+}) {
+  const dispatch = useAppDispatch();
+  const account = useAppSelector((s) => s.account);
+
+  const handleGeminiSave = async (key: string | null) => {
+    await dispatch(saveGeminiApiKey(key));
+    onRefetch();
+  };
+
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-semibold text-ink">Models</h1>
+
+      {/* ── TTS runtime section ─────────────────────────────────────── */}
+      <section className="space-y-4">
+        <div className="flex items-center gap-3">
+          <SectionHeading>TTS runtime</SectionHeading>
+          <BlockerBadge
+            status={readiness.blockers.sidecar}
+            label={readiness.blockers.sidecar === 'pass' ? 'Runtime ready' : 'Runtime needed'}
+          />
+          <BlockerBadge
+            status={readiness.blockers.tts}
+            label={readiness.blockers.tts === 'pass' ? 'Engine ready' : 'Engine needed'}
+          />
+        </div>
+
+        <p className="text-sm text-ink/60">
+          The TTS runtime is a Python environment that runs the voice engines.
+          Set it up once — all engines share it.
+        </p>
+
+        <VenvBootstrap onBootstrapped={onRefetch} />
+        <KokoroInstall onInstalled={onRefetch} />
+
+        {/* Alternative engines — collapsible */}
+        <details className="group rounded-2xl border border-ink/10">
+          <summary className="flex cursor-pointer items-center justify-between px-4 py-3 text-sm font-medium text-ink select-none">
+            <span>Alternative voice engines</span>
+            <span className="text-xs text-ink/50 group-open:hidden">
+              Qwen3-TTS · Coqui XTTS v2
+            </span>
+            <span className="text-xs text-ink/50 hidden group-open:inline">
+              Hide
+            </span>
+          </summary>
+          <div className="px-4 pb-4 space-y-4">
+            <p className="text-xs text-ink/55">
+              Kokoro is the default engine and covers most use cases.
+              Install Qwen3-TTS for bespoke per-character voice design, or
+              Coqui XTTS v2 for zero-shot cloning.
+            </p>
+            <QwenInstall onInstalled={onRefetch} />
+            <CoquiInstall onInstalled={onRefetch} />
+          </div>
+        </details>
+      </section>
+
+      {/* ── Analyzer section ────────────────────────────────────────── */}
+      <section className="space-y-4">
+        <div className="flex items-center gap-3">
+          <SectionHeading>Analyzer</SectionHeading>
+          <BlockerBadge
+            status={readiness.blockers.analyzer}
+            label={readiness.blockers.analyzer === 'pass' ? 'Analyzer ready' : 'Analyzer needed'}
+          />
+        </div>
+
+        <p className="text-sm text-ink/60">
+          The analyzer reads your manuscript and detects characters, scenes, and
+          dialogue attribution. A Gemini API key is the recommended option — it
+          uses the free tier and needs no local GPU.
+        </p>
+
+        <div className="rounded-2xl border border-ink/10 bg-white p-4">
+          <GeminiKeyField
+            status={account.apiKeyStatus}
+            onSave={handleGeminiSave}
+          />
+        </div>
+
+        {/* Local analyzer — collapsible */}
+        <details className="group rounded-2xl border border-ink/10">
+          <summary className="flex cursor-pointer items-center justify-between px-4 py-3 text-sm font-medium text-ink select-none">
+            <span>Use a local analyzer instead</span>
+            <span className="text-xs text-ink/50 group-open:hidden">
+              Ollama · runs on-device
+            </span>
+            <span className="text-xs text-ink/50 hidden group-open:inline">
+              Hide
+            </span>
+          </summary>
+          <div className="px-4 pb-4 space-y-4">
+            <p className="text-xs text-ink/55">
+              Ollama runs the analyzer model on your machine — no API key needed,
+              but requires a capable GPU and a one-time model download.
+            </p>
+            <OllamaInstall onInstalled={onRefetch} />
+          </div>
+        </details>
+      </section>
+    </div>
+  );
+}

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { mockGetSetupReadiness } from './api';
+import { mockGetSetupReadiness, mockCompleteSetup } from './api';
 
 describe('mockGetSetupReadiness', () => {
   beforeEach(() => {
@@ -20,5 +20,13 @@ describe('mockGetSetupReadiness', () => {
     window.location.hash = '#/setup';
     const second = await mockGetSetupReadiness();
     expect(second.ready).toBe(false);
+  });
+});
+
+describe('mockCompleteSetup', () => {
+  it('resolves an ISO completedAt', async () => {
+    const r = await mockCompleteSetup();
+    expect(typeof r.completedAt).toBe('string');
+    expect(new Date(r.completedAt).toISOString()).toBe(r.completedAt);
   });
 });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5217,6 +5217,16 @@ export async function mockGetSetupReadiness(): Promise<SetupReadiness> {
       };
 }
 
+async function realCompleteSetup(): Promise<{ completedAt: string }> {
+  const res = await fetch('/api/setup/complete', { method: 'POST' });
+  if (!res.ok) throw new Error(`complete ${res.status}`);
+  return (await res.json()) as { completedAt: string };
+}
+
+export async function mockCompleteSetup(): Promise<{ completedAt: string }> {
+  return { completedAt: '2026-06-12T00:00:00.000Z' };
+}
+
 async function mockGetSidecarHealth(): Promise<SidecarHealth> {
   /* Mocks pretend everything's healthy — generation is local and synchronous
      under VITE_USE_MOCKS=true, so there's no real sidecar to probe. */
@@ -5932,6 +5942,7 @@ const real = {
   getGpuQueueState: realGetGpuQueueState,
   getDiagnostics: realGetDiagnostics,
   getSetupReadiness: realGetSetupReadiness,
+  completeSetup: realCompleteSetup,
   getOllamaHealth: realGetOllamaHealth,
   loadSidecar: realLoadSidecar,
   unloadSidecar: realUnloadSidecar,
@@ -6180,6 +6191,7 @@ const mock = {
   getGpuQueueState: mockGetGpuQueueState,
   getDiagnostics: mockGetDiagnostics,
   getSetupReadiness: mockGetSetupReadiness,
+  completeSetup: mockCompleteSetup,
   getOllamaHealth: mockGetOllamaHealth,
   loadSidecar: mockLoadSidecar,
   unloadSidecar: mockUnloadSidecar,

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -407,17 +407,37 @@ function ModelManagerRoute() {
   return <ModelManagerView />;
 }
 
-/* fs-21 — first-run setup wizard. Fetches readiness on mount; Wave 2 fleshes
-   the steps. */
+/* fs-21 — first-run setup wizard. Fetches readiness on mount; Wave 2 adds
+   re-fetch, guided/checklist mode, and onFinish navigation. */
 function SetupRoute() {
   useHydrateStage({ kind: 'setup' }, []);
+  const navigate = useNavigate();
   const [readiness, setReadiness] = useState<Awaited<ReturnType<typeof api.getSetupReadiness>> | null>(null);
+
   useEffect(() => {
     let cancelled = false;
     api.getSetupReadiness().then((r) => { if (!cancelled) setReadiness(r); }).catch(() => {});
     return () => { cancelled = true; };
   }, []);
-  return <SetupView readiness={readiness} />;
+
+  const refetch = () => {
+    let cancelled = false;
+    api.getSetupReadiness().then((r) => { if (!cancelled) setReadiness(r); }).catch(() => {});
+    return () => { cancelled = true; };
+  };
+
+  const mode: 'guided' | 'checklist' = readiness?.completedAt ? 'checklist' : 'guided';
+
+  const onFinish = async () => {
+    try {
+      await api.completeSetup();
+    } catch {
+      /* non-fatal */
+    }
+    navigate('/');
+  };
+
+  return <SetupView readiness={readiness} mode={mode} onRefetch={refetch} onFinish={onFinish} />;
 }
 
 /* Wave 3 — /about brand page, reached from the Admin view. */

--- a/src/views/account.test.tsx
+++ b/src/views/account.test.tsx
@@ -431,6 +431,24 @@ describe('AccountView â€” Advanced (power-user) card (fe-2)', () => {
   });
 });
 
+describe('AccountView — Re-run setup pointer (fs-21)', () => {
+  it('renders the Re-run setup button with the theme-safe ink/canvas token', () => {
+    renderView();
+    const button = screen.getByTestId('account-rerun-setup');
+    expect(button.className).toContain('bg-ink');
+    expect(button.className).toContain('text-canvas');
+    expect(button.className).not.toContain('text-white');
+  });
+
+  it('clicking Re-run setup dispatches openSetup and transitions ui.stage to setup', async () => {
+    const user = userEvent.setup();
+    const { store } = renderView();
+    const button = screen.getByTestId('account-rerun-setup');
+    await user.click(button);
+    expect(store.getState().ui.stage.kind).toBe('setup');
+  });
+});
+
 describe('AccountView — settings-accordion shell', () => {
   it('renders server-persisted sections as collapsible accordion sections and Save still dispatches', async () => {
     (api.putUserSettings as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(SERVER_FIXTURE);

--- a/src/views/account.tsx
+++ b/src/views/account.tsx
@@ -485,6 +485,23 @@ export function AccountView() {
           </a>
         </section>
 
+        <section className="rounded-2xl border border-ink/10 bg-white p-6 shadow-card flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-base font-semibold text-ink">First-run setup</h2>
+            <p className="mt-1 text-xs text-ink/55 max-w-prose">
+              Re-open the setup wizard to check model installation, workspace, and engine readiness.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => dispatch(uiActions.openSetup())}
+            data-testid="account-rerun-setup"
+            className="shrink-0 min-h-[44px] sm:min-h-0 px-4 py-2 rounded-xl bg-ink text-canvas text-sm font-medium hover:bg-ink-soft"
+          >
+            Re-run setup →
+          </button>
+        </section>
+
         <div className="flex items-center gap-4">
           <PrimaryButton variant={dirty ? 'dark' : 'ghost'} onClick={onSave} icon={false}>
             {saving ? 'Saving…' : 'Save changes'}

--- a/src/views/setup.test.tsx
+++ b/src/views/setup.test.tsx
@@ -1,20 +1,42 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { SetupView } from './setup';
 
-describe('SetupView (wave 0 stub)', () => {
-  it('renders the setup heading and the blocker rows from props', () => {
-    render(
-      <SetupView
-        readiness={{
-          ready: false,
-          completedAt: null,
-          blockers: { sidecar: 'pass', ffmpeg: 'pass', tts: 'fail', analyzer: 'fail' },
-          info: { gpu: 'CPU — no GPU detected' },
-        }}
-      />,
-    );
+/* The step components pull in the store / sidecar-install surfaces; stub them
+   so this thin-wrapper test only asserts SetupView routes to the wizard. */
+vi.mock('../components/setup/step-environment', () => ({
+  StepEnvironment: () => <div data-testid="step-environment-stub">env</div>,
+}));
+vi.mock('../components/setup/step-ffmpeg', () => ({
+  StepFfmpeg: () => <div data-testid="step-ffmpeg-stub">ffmpeg</div>,
+}));
+vi.mock('../components/setup/step-models', () => ({
+  StepModels: () => <div data-testid="step-models-stub">models</div>,
+}));
+vi.mock('../components/setup/step-defaults', () => ({
+  StepDefaults: () => <div data-testid="step-defaults-stub">defaults</div>,
+}));
+vi.mock('../components/setup/step-finish', () => ({
+  StepFinish: () => <div data-testid="step-finish-stub">finish</div>,
+}));
+
+const READINESS = {
+  ready: false,
+  completedAt: null,
+  blockers: { sidecar: 'pass', ffmpeg: 'pass', tts: 'fail', analyzer: 'fail' },
+  info: { gpu: 'CPU — no GPU detected' },
+} as const;
+
+describe('SetupView', () => {
+  it('renders the wizard heading and (default guided) first step from props', () => {
+    render(<SetupView readiness={READINESS} />);
     expect(screen.getByRole('heading', { name: /set up castwright/i })).toBeInTheDocument();
-    expect(screen.getByText(/tts/i)).toBeInTheDocument();
+    // default mode is guided → the first step is shown
+    expect(screen.getByTestId('step-environment-stub')).toBeInTheDocument();
+  });
+
+  it('renders a Checking… state while readiness is null', () => {
+    render(<SetupView readiness={null} />);
+    expect(screen.getByTestId('setup-checking')).toBeInTheDocument();
   });
 });

--- a/src/views/setup.tsx
+++ b/src/views/setup.tsx
@@ -1,29 +1,41 @@
-/* fs-21 Wave 0 — SetupView STUB. Renders the readiness summary so the gated
-   #/setup route is real and testable. Wave 2 replaces this body with the
-   five-step guided/checklist wizard; the props contract (readiness) stays. */
-import type { SetupReadiness } from '../lib/api';
+/* fs-21 — SetupView. Thin wrapper that renders the five-step first-run wizard
+   (SetupWizard) once readiness has loaded. The route owner (SetupRoute, C6)
+   supplies mode (guided for a fresh setup, checklist for re-entry), onRefetch
+   (re-probe readiness), and onFinish (completeSetup + navigate home).
 
-export function SetupView({ readiness }: { readiness: SetupReadiness | null }) {
+   mode/onRefetch/onFinish carry safe defaults so the Wave 0 callers that pass
+   only `readiness` keep compiling. */
+import type { SetupReadiness } from '../lib/api';
+import { SetupWizard } from '../components/setup/setup-wizard';
+
+export function SetupView({
+  readiness,
+  mode = 'guided',
+  onRefetch = () => {},
+  onFinish = () => {},
+}: {
+  readiness: SetupReadiness | null;
+  mode?: 'guided' | 'checklist';
+  onRefetch?: () => void;
+  onFinish?: () => void;
+}) {
+  if (readiness == null) {
+    return (
+      <main className="mx-auto max-w-2xl p-6">
+        <h1 className="text-2xl font-semibold text-ink">Set up Castwright</h1>
+        <p className="mt-2 text-ink/60 text-sm" data-testid="setup-checking">
+          Checking…
+        </p>
+      </main>
+    );
+  }
+
   return (
-    <main className="mx-auto max-w-2xl p-6">
-      <h1 className="text-2xl font-semibold text-ink">Set up Castwright</h1>
-      <p className="mt-2 text-ink/60 text-sm">
-        We're checking that everything needed to produce an audiobook is in place.
-      </p>
-      <ul className="mt-6 space-y-2">
-        {readiness &&
-          Object.entries(readiness.blockers).map(([id, status]) => (
-            <li
-              key={id}
-              className="flex items-center justify-between rounded-2xl border border-ink/10 bg-canvas px-4 py-3"
-            >
-              <span className="text-sm font-medium text-ink uppercase">{id}</span>
-              <span className={status === 'pass' ? 'text-emerald-600' : 'text-amber-600'}>
-                {status === 'pass' ? 'Ready' : 'Needs attention'}
-              </span>
-            </li>
-          ))}
-      </ul>
-    </main>
+    <SetupWizard
+      readiness={readiness}
+      mode={mode}
+      onRefetch={onRefetch}
+      onFinish={onFinish}
+    />
   );
 }


### PR DESCRIPTION
## Summary
Wave 2 of **fs-21** (#474): the hybrid guided/checklist **first-run setup wizard** UI replacing the Wave 0 stub. 5 steps (Environment/GPU → ffmpeg → Models → Defaults → Finish) composing the Wave 1/1b installers.
- `POST /api/setup/complete` (stamps setupCompletedAt) + `api.completeSetup`.
- `OllamaInstall` gains an `onInstalled` callback.
- 5 step components under `src/components/setup/` + a `SetupWizard` orchestrator (guided linear / checklist on re-entry; Next always-enabled — the derived Wave 0 boot gate is the real lock).
- ffmpeg = verify+instruct card; analyzer = Gemini-key (recommended) / Ollama (local); Models = venv + Kokoro (+ collapsible Qwen/Coqui).
- `SetupRoute` re-fetches readiness between steps; mode = completedAt ? checklist : guided; Finish → completeSetup → home.
- Account 'Re-run setup' entry.

**Deferred to Wave 3:** the audible Step-5 smoke test (here a labeled placeholder).

## Test plan
Unit: complete route (slow pool), api.completeSetup, OllamaInstall callback, 5 step components, SetupWizard orchestrator, SetupRoute, Account button. e2e: setup-wizard.spec.ts (4 tests). `npm run verify` green.
Plan → **adversarial review** (caught a mis-pooled test, wrong theme-field provenance, over-complex Next-gating, dropped ModelPullStatus) → subagent-driven execution. Refs #474.