### PR TITLE
fix(app): companion loads the downloaded library first + fast-fail offline

### DIFF
--- a/apps/android/lib/src/data/api_client.dart
+++ b/apps/android/lib/src/data/api_client.dart
@@ -32,7 +32,7 @@ class ApiException implements Exception {
 /// carries the Bearer token. The transport is injectable for tests.
 class ApiClient {
   ApiClient(this.connection,
-      {HttpSend? send, this.requestTimeout = const Duration(seconds: 10)})
+      {HttpSend? send, this.requestTimeout = const Duration(seconds: 4)})
       : _send = send ?? _pinnedSend(connection);
 
   final Connection connection;
@@ -216,7 +216,7 @@ class _ApiListenProgressApi implements ListenProgressApi {
 /// otherwise hang until the OS-default timeout — tens of seconds — leaving the
 /// library/player UIs spinning before their offline fallback can run. Bounding
 /// it makes "server is gone" surface fast so the local-library path takes over.
-const Duration _connectTimeout = Duration(seconds: 5);
+const Duration _connectTimeout = Duration(seconds: 2);
 
 /// Build the CA-pinned HttpClient shared by every real transport, with the
 /// fast-fail [_connectTimeout] applied so offline connects don't hang.

--- a/apps/android/lib/src/data/api_client.dart
+++ b/apps/android/lib/src/data/api_client.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -30,18 +31,24 @@ class ApiException implements Exception {
 /// request validates the server cert against the pinned CA (from pairing) and
 /// carries the Bearer token. The transport is injectable for tests.
 class ApiClient {
-  ApiClient(this.connection, {HttpSend? send})
+  ApiClient(this.connection,
+      {HttpSend? send, this.requestTimeout = const Duration(seconds: 10)})
       : _send = send ?? _pinnedSend(connection);
 
   final Connection connection;
   final HttpSend _send;
+
+  /// Upper bound on a single JSON request. Offline, the connect fails fast via
+  /// [_connectTimeout]; this is the backstop for a connection that opens but
+  /// then stalls, so callers never spin indefinitely on a wedged server.
+  final Duration requestTimeout;
 
   Uri _u(String path) => Uri.parse('${connection.server.url}$path');
 
   Future<Map<String, dynamic>> getJson(String path) async {
     final res = await _send('GET', _u(path), {
       HttpHeaders.authorizationHeader: 'Bearer ${connection.server.token}',
-    });
+    }).timeout(requestTimeout);
     if (res.statusCode == 401 || res.statusCode == 403) {
       throw ApiException(res.statusCode, 'Not authorised — re-pair the device.');
     }
@@ -134,9 +141,7 @@ class ApiClient {
     required double currentSec,
     required String listenedAt,
   }) async {
-    final ctx = SecurityContext(withTrustedRoots: false)
-      ..setTrustedCertificatesBytes(utf8.encode(connection.caPem));
-    final client = HttpClient(context: ctx);
+    final client = _pinnedHttpClient(connection);
     try {
       final req = await client.putUrl(_u('/api/books/$bookId/listen-progress'));
       req.headers.set(HttpHeaders.authorizationHeader,
@@ -162,9 +167,7 @@ class ApiClient {
   /// large chapters never buffer fully in memory; the `Range` header (set by the
   /// downloader on a resume) is forwarded verbatim.
   RangeFetch pinnedRangeFetch() {
-    final ctx = SecurityContext(withTrustedRoots: false)
-      ..setTrustedCertificatesBytes(utf8.encode(connection.caPem));
-    final client = HttpClient(context: ctx);
+    final client = _pinnedHttpClient(connection);
     final token = connection.server.token;
     return (Uri url, Map<String, String> headers) async {
       final req = await client.getUrl(url);
@@ -208,12 +211,25 @@ class _ApiListenProgressApi implements ListenProgressApi {
           chapterId: chapterId, currentSec: currentSec, listenedAt: listenedAt);
 }
 
+/// How long to wait for the TCP/TLS connection to the paired server before
+/// giving up. Offline (server unreachable on the LAN) the connect would
+/// otherwise hang until the OS-default timeout — tens of seconds — leaving the
+/// library/player UIs spinning before their offline fallback can run. Bounding
+/// it makes "server is gone" surface fast so the local-library path takes over.
+const Duration _connectTimeout = Duration(seconds: 5);
+
+/// Build the CA-pinned HttpClient shared by every real transport, with the
+/// fast-fail [_connectTimeout] applied so offline connects don't hang.
+HttpClient _pinnedHttpClient(Connection connection) {
+  final ctx = SecurityContext(withTrustedRoots: false)
+    ..setTrustedCertificatesBytes(utf8.encode(connection.caPem));
+  return HttpClient(context: ctx)..connectionTimeout = _connectTimeout;
+}
+
 /// Real transport: a `dart:io` HttpClient that trusts ONLY the pinned CA and
 /// reuses one connection pool for the paired server's lifetime.
 HttpSend _pinnedSend(Connection connection) {
-  final ctx = SecurityContext(withTrustedRoots: false)
-    ..setTrustedCertificatesBytes(utf8.encode(connection.caPem));
-  final client = HttpClient(context: ctx);
+  final client = _pinnedHttpClient(connection);
   return (method, url, headers) async {
     final req = await client.openUrl(method, url);
     headers.forEach(req.headers.set);

--- a/apps/android/lib/src/domain/library_load.dart
+++ b/apps/android/lib/src/domain/library_load.dart
@@ -1,0 +1,81 @@
+import 'library_tree.dart';
+
+/// One render state for the library home screen, emitted by
+/// [loadLibraryLocalFirst]. The screen maps each emission straight onto its
+/// widget state — covers/durations are layered on top by the screen.
+class LibraryLoad {
+  const LibraryLoad({
+    required this.books,
+    required this.offline,
+    required this.connecting,
+    required this.loading,
+    this.error,
+  });
+
+  /// The books to show right now (local first, then server-reconciled).
+  final List<LibraryBook> books;
+
+  /// True once we've confirmed the server is unreachable but have a local
+  /// (downloaded) library to keep showing — drives the "Offline" retry chip.
+  final bool offline;
+
+  /// True while the background server probe is still in flight.
+  final bool connecting;
+
+  /// True only when there is nothing to show yet (no local library AND the
+  /// server hasn't answered) — the sole case that warrants a full-screen spinner.
+  final bool loading;
+
+  /// Set only when we have NOTHING to show and the server is unreachable.
+  final String? error;
+}
+
+/// Local-first library load: show the downloaded library immediately, then
+/// reconcile with the server in the background if it's reachable. A connection
+/// failure never blocks or errors the user out as long as something is on disk
+/// — it just leaves them on the local library with an "Offline" affordance.
+///
+/// Emits the local state first (so the UI paints instantly), then a second
+/// state once the server answers (or fails). Extracted from the widget so this
+/// ordering contract is unit-tested without the device-only [CompanionRuntime].
+Stream<LibraryLoad> loadLibraryLocalFirst({
+  required Future<List<LibraryBook>> Function() loadLocal,
+  required Future<List<LibraryBook>> Function() loadServer,
+}) async* {
+  List<LibraryBook> local;
+  try {
+    local = await loadLocal();
+  } catch (_) {
+    local = const []; // nothing downloaded yet
+  }
+
+  // 1. Paint whatever is on disk straight away; probe the server in the back-
+  //    ground. Spinner only when there's genuinely nothing to show yet.
+  yield LibraryLoad(
+    books: local,
+    offline: false,
+    connecting: true,
+    loading: local.isEmpty,
+  );
+
+  // 2. Reconcile with the server. Success upgrades to the live catalogue;
+  //    failure keeps the local library (offline) and only surfaces an error
+  //    when there was nothing local to fall back to.
+  try {
+    final server = await loadServer();
+    yield LibraryLoad(
+        books: server, offline: false, connecting: false, loading: false);
+  } catch (e) {
+    if (local.isNotEmpty) {
+      yield LibraryLoad(
+          books: local, offline: true, connecting: false, loading: false);
+    } else {
+      yield LibraryLoad(
+          books: const [],
+          offline: false,
+          connecting: false,
+          loading: false,
+          error: '$e');
+    }
+  }
+}

--- a/apps/android/lib/src/ui/library_home_screen.dart
+++ b/apps/android/lib/src/ui/library_home_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../data/companion_runtime.dart';
 import '../domain/home_shelf.dart';
+import '../domain/library_load.dart';
 import '../domain/library_tree.dart';
 import '../domain/listen_progress.dart';
 import '../domain/paired_server.dart';
@@ -40,6 +41,7 @@ class _LibraryHomeScreenState extends State<LibraryHomeScreen> {
   String _query = '';
   bool _loading = true;
   bool _offline = false;
+  bool _connecting = false; // background server probe in flight
   String? _error;
 
   @override
@@ -48,31 +50,13 @@ class _LibraryHomeScreenState extends State<LibraryHomeScreen> {
     _refresh();
   }
 
+  /// Local-first: paint the downloaded library immediately, then reconcile with
+  /// the server in the background. A connection failure never blocks the user —
+  /// they stay on the local library with an "Offline" retry chip. The state
+  /// machine lives in [loadLibraryLocalFirst] so its ordering is unit-tested.
   Future<void> _refresh() async {
-    setState(() {
-      _loading = true;
-      _error = null;
-    });
-    List<LibraryBook> books;
-    var offline = false;
-    try {
-      books = await widget.runtime.sync.loadLibrary(); // server index
-    } catch (_) {
-      // Server unreachable → fall back to the downloaded library on disk.
-      try {
-        books = await widget.runtime.sync.loadLocalLibrary();
-        offline = true;
-      } catch (e) {
-        if (mounted) {
-          setState(() {
-            _error = '$e';
-            _loading = false;
-          });
-        }
-        return;
-      }
-    }
-    // app-14: continue-listening rail from local lastPlayedAt.
+    setState(() => _error = null);
+    // app-14: continue-listening rail from local lastPlayedAt (always local).
     final shelf = buildContinueListening([
       for (final s in await widget.runtime.library.listBooks())
         ShelfBook(
@@ -83,15 +67,22 @@ class _LibraryHomeScreenState extends State<LibraryHomeScreen> {
           updatedAt: '',
         ),
     ]);
-    if (!mounted) return;
-    setState(() {
-      _books = books;
-      _continue = shelf;
-      _offline = offline;
-      _loading = false;
-    });
-    _loadCovers(books);
-    _loadDurations(books);
+    await for (final s in loadLibraryLocalFirst(
+      loadLocal: widget.runtime.sync.loadLocalLibrary,
+      loadServer: widget.runtime.sync.loadLibrary,
+    )) {
+      if (!mounted) return;
+      setState(() {
+        _books = s.books;
+        _continue = shelf;
+        _offline = s.offline;
+        _connecting = s.connecting;
+        _loading = s.loading;
+        _error = s.error;
+      });
+      _loadCovers(s.books);
+      _loadDurations(s.books);
+    }
   }
 
   Future<void> _loadCovers(List<LibraryBook> books) async {
@@ -264,19 +255,19 @@ class _LibraryHomeScreenState extends State<LibraryHomeScreen> {
                 key: const Key('offline-chip'),
                 avatar: Icon(Icons.cloud_off,
                     size: 18, color: Theme.of(context).colorScheme.onErrorContainer),
-                label: Text(_loading ? 'Connecting…' : 'Offline'),
+                label: const Text('Offline'),
                 backgroundColor: Theme.of(context).colorScheme.errorContainer,
                 labelStyle: TextStyle(
                     color: Theme.of(context).colorScheme.onErrorContainer),
-                onPressed: _loading ? null : _refresh, // tap to retry
+                onPressed: _refresh, // tap to retry
               ),
             )
           else
             IconButton(
               key: const Key('library-sync'),
-              tooltip: 'Sync',
+              tooltip: _connecting ? 'Connecting…' : 'Sync',
               icon: const Icon(Icons.sync),
-              onPressed: _loading ? null : _refresh,
+              onPressed: (_loading || _connecting) ? null : _refresh,
             ),
           IconButton(
             key: const Key('open-settings'),

--- a/apps/android/test/data/api_client_test.dart
+++ b/apps/android/test/data/api_client_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:castwright/src/data/api_client.dart';
 import 'package:castwright/src/data/pairing_service.dart';
@@ -38,6 +40,21 @@ void main() {
         api.info(),
         throwsA(isA<ApiException>().having((e) => e.statusCode, 'status', 503)),
       );
+    });
+
+    // Regression (offline spinner): when the device is offline the real
+    // transport's connect hangs until the OS TCP timeout instead of failing
+    // fast, so every request — and the library/player UIs that await them —
+    // spins for tens of seconds before the offline fallback can run. A hanging
+    // send must abort with a TimeoutException so callers' catch-and-fall-back
+    // path fires promptly.
+    test('getJson aborts a hanging transport with TimeoutException', () async {
+      final api = ApiClient(
+        conn(),
+        requestTimeout: const Duration(milliseconds: 50),
+        send: (_, _, _) => Completer<HttpResult>().future, // never completes
+      );
+      await expectLater(api.info(), throwsA(isA<TimeoutException>()));
     });
   });
 }

--- a/apps/android/test/domain/library_load_test.dart
+++ b/apps/android/test/domain/library_load_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:castwright/src/domain/library_load.dart';
+import 'package:castwright/src/domain/library_tree.dart';
+
+LibraryBook bk(String id) => LibraryBook(
+      bookId: id,
+      title: id,
+      author: 'a',
+      series: '',
+      seriesPosition: null,
+      downloadState: BookDownloadState.downloaded,
+    );
+
+Future<List<LibraryBook>> Function() ok(List<LibraryBook> v) => () async => v;
+Future<List<LibraryBook>> Function() fails() =>
+    () async => throw Exception('unreachable');
+
+void main() {
+  group('loadLibraryLocalFirst', () {
+    test('local content paints first, then the server upgrades it', () async {
+      final local = [bk('downloaded')];
+      final server = [bk('downloaded'), bk('streamable')];
+      final states = await loadLibraryLocalFirst(
+        loadLocal: ok(local),
+        loadServer: ok(server),
+      ).toList();
+
+      expect(states, hasLength(2));
+      // 1st paint: the local library, no spinner, server probe in flight.
+      expect(states[0].books, local);
+      expect(states[0].loading, isFalse);
+      expect(states[0].connecting, isTrue);
+      expect(states[0].offline, isFalse);
+      // 2nd paint: the full server catalogue, done probing.
+      expect(states[1].books, server);
+      expect(states[1].connecting, isFalse);
+      expect(states[1].offline, isFalse);
+      expect(states[1].error, isNull);
+    });
+
+    test('a failed connection does NOT block or error when local exists',
+        () async {
+      final local = [bk('downloaded')];
+      final states = await loadLibraryLocalFirst(
+        loadLocal: ok(local),
+        loadServer: fails(),
+      ).toList();
+
+      expect(states, hasLength(2));
+      expect(states[0].books, local); // shown immediately
+      expect(states[0].loading, isFalse);
+      // Stays on the local library, marked offline, no error screen.
+      expect(states.last.books, local);
+      expect(states.last.offline, isTrue);
+      expect(states.last.connecting, isFalse);
+      expect(states.last.error, isNull);
+    });
+
+    test('empty local + reachable server: spinner first, then the catalogue',
+        () async {
+      final server = [bk('streamable')];
+      final states = await loadLibraryLocalFirst(
+        loadLocal: ok(const []),
+        loadServer: ok(server),
+      ).toList();
+
+      expect(states.first.loading, isTrue); // nothing to show yet
+      expect(states.first.books, isEmpty);
+      expect(states.last.books, server);
+      expect(states.last.loading, isFalse);
+      expect(states.last.offline, isFalse);
+    });
+
+    test('empty local + unreachable server surfaces the error', () async {
+      final states = await loadLibraryLocalFirst(
+        loadLocal: ok(const []),
+        loadServer: fails(),
+      ).toList();
+
+      expect(states.last.books, isEmpty);
+      expect(states.last.error, isNotNull);
+      expect(states.last.loading, isFalse);
+      expect(states.last.connecting, isFalse);
+    });
+
+    test('a throwing local load is treated as empty, not fatal', () async {
+      final server = [bk('streamable')];
+      final states = await loadLibraryLocalFirst(
+        loadLocal: () async => throw Exception('disk error'),
+        loadServer: ok(server),
+      ).toList();
+
+      expect(states.first.books, isEmpty);
+      expect(states.first.loading, isTrue);
+      expect(states.last.books, server);
+      expect(states.last.error, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes the companion app "spinning forever / very slow to load" behaviour when the paired server is unreachable (device offline / off the LAN).

**Root cause:** the CA-pinned `dart:io` HTTP transports in `apps/android/lib/src/data/api_client.dart` had **no `connectionTimeout` and no request timeout**. Offline, a connect to the LAN server hung until the OS-default TCP timeout (tens of seconds) before throwing, so the library/player UIs spun before their offline fallback could run — and every subsequent tap re-attempted a connect and hung again.

Two changes:

1. **Fast-fail timeouts.** A shared `_pinnedHttpClient()` with a **2 s `connectionTimeout`** (used by all three real transports) + a **4 s request `.timeout()`** on the JSON path. A gone server now surfaces in ~2 s instead of tens of seconds.

2. **Local-first library load.** The library home no longer gates its first paint on the server. It paints the **downloaded library immediately** and reconciles with the server in the **background**: reachable → upgrades to the live catalogue; unreachable → stays on the local library with an **"Offline"** retry chip. A failed connection never blocks the user and never shows an error screen when something is downloaded. The ordering/state machine is extracted to `loadLibraryLocalFirst()` so it is unit-tested without the device-only `CompanionRuntime`.

## Test plan

- `flutter analyze` (changed files): clean.
- `flutter test`: **217/217 pass**, including:
  - `test/data/api_client_test.dart` — a hanging transport now aborts `getJson` with `TimeoutException` (regression).
  - `test/domain/library_load_test.dart` (new, 5 cases) — local paints first then server upgrades; a failed connection does NOT block/error when local exists; empty-local spinner; empty-local error; throwing local load treated as empty.

On-device acceptance still owed: with WiFi off the downloaded library should appear instantly with an "Offline" chip and no re-hang on tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)