### PR TITLE
fix(frontend): tidy marketing-capture render nits

### DIFF
--- a/src/components/top-bar.test.tsx
+++ b/src/components/top-bar.test.tsx
@@ -195,6 +195,18 @@ describe('TopBar — StatusPill (hover popover)', () => {
     renderWithStore(<TopBar {...makeProps({ stage: 'books', statusSummary: null })} />);
     expect(screen.queryByTestId('status-pill')).not.toBeInTheDocument();
   });
+
+  it('keeps the pill outside the horizontally-scrolling nav strip so a wide breadcrumb cannot clip it', () => {
+    /* Regression: on the listen view the long book-title breadcrumb starved
+       the `overflow-x-auto` middle strip and scrolled the right-anchored pill
+       off-screen, clipping it to "Revis". The pill must live in an
+       always-visible shrink-0 slot, never inside an overflow-x-auto ancestor. */
+    renderWithStore(
+      <TopBar {...makeProps({ stage: 'ready', view: 'listen', projectTitle: 'The Drowning Bell' })} />,
+    );
+    const pill = screen.getByTestId('status-pill');
+    expect(pill.closest('.overflow-x-auto')).toBeNull();
+  });
 });
 
 describe('summarizeStatus — dominant-state priority ladder (plan 120)', () => {

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -312,17 +312,19 @@ export function TopBar({
               ))}
             </nav>
           )}
-          {/* One compact Status pill (pushed right via ml-auto) replaces the
-              former TTS / analysis / generation / revisions cluster. Hovering
-              (or tapping / focusing) it reveals an anchored popover with the
-              full detail — no modal, no backdrop, so it never dismisses an open
-              cast drawer. Hidden on idle global views (statusSummary === null). */}
-          {statusSummary && (
-            <div className="ml-auto shrink-0">
-              <StatusPill summary={statusSummary} detail={statusDetail} />
-            </div>
-          )}
         </div>
+        {/* One compact Status pill replacing the former TTS / analysis /
+            generation / revisions cluster. Kept OUTSIDE the scrolling middle
+            strip (shrink-0) so a wide breadcrumb — e.g. the listen view's long
+            book title — can never scroll it off-screen / clip it to "Revis".
+            Hovering (or tapping / focusing) reveals an anchored popover with the
+            full detail — no modal, no backdrop, so it never dismisses an open
+            cast drawer. Hidden on idle global views (statusSummary === null). */}
+        {statusSummary && (
+          <div className="shrink-0">
+            <StatusPill summary={statusSummary} detail={statusDetail} />
+          </div>
+        )}
         <div className="flex items-center gap-3 shrink-0">
           <AdminPill onClick={onOpenAdmin} active={stage === 'admin'} />
           {(queueCount ?? 0) > 0 && onOpenQueue && (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4444,6 +4444,15 @@ async function realGetWorkspaceInfo(): Promise<WorkspaceInfo> {
 
 async function mockGetWorkspaceInfo(): Promise<WorkspaceInfo> {
   await wait(40);
+  /* Marketing capture: show a realistic, configured-looking workspace path
+     instead of the `(mock)` placeholder — which also renders amber as an
+     unconfigured "default", wrong for a hero shot. Capture-only. */
+  if (DEMO_CAPTURE)
+    return {
+      root: '~/Audiobooks/Castwright',
+      booksRoot: '~/Audiobooks/Castwright/books',
+      source: 'env',
+    };
   return { root: '(mock)', booksRoot: '(mock)/books', source: 'default' };
 }
 

--- a/src/mocks/marketing/hollow-tide.ts
+++ b/src/mocks/marketing/hollow-tide.ts
@@ -35,7 +35,7 @@ const inspCray = (): Character => ({
   tone: { warmth: 0.4, pace: 0.45, authority: 0.85, emotion: 0.5 },
   description: 'Dogged harbour-town inspector.',
   ttsEngine: 'qwen',
-  overrideTtsVoices: { qwen: { name: 'qwen-cray-v1' } },
+  overrideTtsVoices: { qwen: { name: 'Cray v1' } },
 });
 
 const drWren = (): Character => ({
@@ -48,7 +48,7 @@ const drWren = (): Character => ({
   tone: { warmth: 0.55, pace: 0.4, authority: 0.6, emotion: 0.45 },
   description: 'Precise, dryly humane coroner.',
   ttsEngine: 'qwen',
-  overrideTtsVoices: { qwen: { name: 'qwen-wren-v1' } },
+  overrideTtsVoices: { qwen: { name: 'Wren v1' } },
 });
 
 const reusedFromBook1 = (c: Character): Character => ({
@@ -534,7 +534,7 @@ export const HOLLOW_TIDE_VOICES: VoiceLibraryResponse = {
       usedIn: 1,
       source: 'library',
       inCurrentSeries: true,
-      ttsVoice: qwenTts('qwen-remy', 'Designed voice'),
+      ttsVoice: qwenTts('Remy v1', 'Designed voice'),
     }),
     withGradient({
       id: 'v_marin_cross',
@@ -558,7 +558,7 @@ export const HOLLOW_TIDE_VOICES: VoiceLibraryResponse = {
       usedIn: 1,
       source: 'library',
       inCurrentSeries: true,
-      ttsVoice: qwenTts('qwen-sable', 'Designed voice'),
+      ttsVoice: qwenTts('Sable v1', 'Designed voice'),
     }),
   ],
 };

--- a/src/views/cast.tsx
+++ b/src/views/cast.tsx
@@ -745,7 +745,7 @@ export function CastView({
 
         {/* Plan 81 wave 3 — md:+ table layout (legacy, unchanged contract). */}
         <div className="hidden md:block bg-white rounded-3xl border border-ink/10 shadow-card overflow-hidden">
-          <div className="grid grid-cols-[40px_1.5fr_1.2fr_1.6fr_0.6fr_1.2fr_1fr_140px] px-6 py-3 text-[11px] uppercase tracking-wider font-semibold text-ink/50 border-b border-ink/10">
+          <div className="grid grid-cols-[40px_1.5fr_1.2fr_1.6fr_0.6fr_1.2fr_1fr_140px] gap-x-3 px-6 py-3 text-[11px] uppercase tracking-wider font-semibold text-ink/50 border-b border-ink/10">
             <span></span>
             <span>Character</span>
             <span>Role</span>
@@ -789,7 +789,7 @@ export function CastView({
                   }
                   onOpenProfile(c.id);
                 }}
-                className={`w-full grid grid-cols-[40px_1.5fr_1.2fr_1.6fr_0.6fr_1.2fr_1fr_140px] px-6 py-4 items-center text-left text-sm hover:bg-ink/2 transition-colors cursor-pointer ${i < filtered.length - 1 ? 'border-b border-ink/5' : ''} ${isDropTarget ? 'drop-active' : ''} ${selectedCharIds.includes(c.id) ? 'bg-peach/4' : ''}`}
+                className={`w-full grid grid-cols-[40px_1.5fr_1.2fr_1.6fr_0.6fr_1.2fr_1fr_140px] gap-x-3 px-6 py-4 items-center text-left text-sm hover:bg-ink/2 transition-colors cursor-pointer ${i < filtered.length - 1 ? 'border-b border-ink/5' : ''} ${isDropTarget ? 'drop-active' : ''} ${selectedCharIds.includes(c.id) ? 'bg-peach/4' : ''}`}
               >
                 <span
                   onClick={(e) => {


### PR DESCRIPTION
## Summary

Five render defects spotted in the marketing screenshots; four real fixes, one was a stale shot already cleared by a re-capture.

- **`(mock)` shelf chip** — `mockGetWorkspaceInfo` showed the literal `(mock)` workspace path, rendered amber as an unconfigured "default". Capture-only: returns a realistic configured path under `VITE_DEMO_CAPTURE`.
- **Raw `qwen-*` voice slugs** — Hollow Tide fixtures surfaced `qwen-remy` / `qwen-wren-v1` etc. in the cast + voice library; renamed the capture fixtures to clean labels (`Remy v1`, `Wren v1`, `Cray v1`, `Sable v1`).
- **"LINESTONE" header** *(shipped UI)* — the cast table's `Lines` (narrow, right-aligned) and `Tone` headers abutted into one word when the voice-library panel narrows the grid; added `gap-x-3`.
- **`Revisions` pill clipped to "Revis"** *(shipped UI)* — on the listen view the long book-title breadcrumb starved the `overflow-x-auto` middle strip and scrolled the right-anchored StatusPill off-screen. Lifted the pill out of the scrolling strip into an always-visible `shrink-0` slot.
- The "Generato" caption on the light listen shot was a **stale screenshot** — current copy reads "made with Castwright"; the re-capture cleared it (no code change).

Two of the fixes (`(mock)`, voice slugs) are capture-only (touch only `VITE_DEMO_CAPTURE` fixtures); two are genuine shipped-UI legibility fixes that also help real users at narrow widths.

## Test plan

- Added a top-bar regression test: the StatusPill must have no `overflow-x-auto` ancestor (locks the pill out of the clipping strip).
- `npm run verify` green locally — full battery (lint, typecheck, frontend + server + scripts + sidecar tests, e2e, e2e:visual, build).
- Regenerated `mockups/marketing-screens/` (desktop + phone + tablet) and visually confirmed all four scenes are clean.