### PR TITLE
fix(app): theme the Continue-rail cover placeholder for dark mode

### DIFF
--- a/apps/android/lib/src/ui/library_home_screen.dart
+++ b/apps/android/lib/src/ui/library_home_screen.dart
@@ -224,9 +224,9 @@ class _LibraryHomeScreenState extends State<LibraryHomeScreen> {
                       ? Image.file(File(path),
                           fit: BoxFit.cover,
                           errorBuilder: (_, _, _) => const Icon(Icons.menu_book))
-                      : const ColoredBox(
-                          color: Color(0x22000000),
-                          child: Icon(Icons.menu_book)),
+                      : ColoredBox(
+                          color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                          child: const Icon(Icons.menu_book)),
                 ),
               ),
               const SizedBox(height: 4),


### PR DESCRIPTION
﻿## Summary

Dark-theme audit follow-up for the companion app. Swept every UI file for hardcoded colors; the app is otherwise theme-clean (everything routes through colorScheme.*, which Material 3 fromSeed adapts). The one exception: the Continue-rail cover placeholder used a translucent-black literal (Color(0x22000000)) that is nearly invisible on a dark surface. Now uses colorScheme.surfaceContainerHighest (matching the existing qr_scan_screen placeholder idiom), so it stays visible in both themes.

## Test plan

- flutter analyze lib clean.
- flutter test: 231 passing.
