### PR TITLE
docs(docs): scope + plan for the Keefe/KotLC content scrub

### DIFF
--- a/docs/superpowers/plans/2026-06-12-keefe-scrub.md
+++ b/docs/superpowers/plans/2026-06-12-keefe-scrub.md
@@ -249,7 +249,7 @@ Run: `npm test` (frontend) → green. `git grep -iE "sophie|keefe|stellarlune|ev
 
 ## Phase 4: Server test fixtures (Cat 4 — the big one, ~62 files)
 
-**Files:** ~62 `server/src/**/*.test.ts` (enumerate: `git grep -il "sophie\|keefe\|stellarlune\|elwin\|prentice\|forkle\|dex\|fitz\|biana\|neverseen\|exile\|everblaze\|unlocked\|legacy" -- 'server/src/**/*.test.ts'`).
+**Files:** ~62 `server/src/**/*.test.ts` (enumerate with the **boundary-safe, unambiguous** token set — never bare `dex`/`legacy`/`exile`, which match `index`/`legacy-format`/etc.: `git grep -ilE "\b(sophie|keefe|stellarlune|elwin|sandor|prentice|forkle|fitz|biana|maruca|grizel|neverseen|everblaze|keeper of the lost)\b" -- 'server/src/**/*.test.ts'`).
 
 - [ ] **Step 1: Classify pure-rename vs. re-fixture**
 
@@ -263,7 +263,7 @@ Mark these for **manual re-derivation** (Step 3). Everything else is pure-rename
 
 Run the codemod across all Cat-4 test files EXCEPT the position-sensitive set:
 ```bash
-node scripts/scrub-kotlc.mjs --write $(git grep -il "sophie\|keefe\|stellarlune\|elwin\|prentice\|forkle\|dex\|fitz\|biana\|neverseen\|exile\|everblaze\|unlocked\|legacy" -- 'server/src/**/*.test.ts')
+node scripts/scrub-kotlc.mjs --write $(git grep -ilE "\b(sophie|keefe|stellarlune|elwin|sandor|prentice|forkle|fitz|biana|maruca|grizel|neverseen|everblaze|keeper of the lost)\b" -- 'server/src/**/*.test.ts')
 ```
 Because the codemod renames inline fixture text AND the assertions consistently, count/occurrence-based expectations stay correct.
 
@@ -305,7 +305,7 @@ The manuscript-path replacement is **a mapping entry** (added in Phase 0): both
 → `server/src/__fixtures__/the-coalfall-commission.md`. So the same `--write`
 codemod handles names, books, AND the path:
 ```bash
-node scripts/scrub-kotlc.mjs --write CLAUDE.md $(git grep -il "keefe\|sophie\|bonus keefe\|stellarlune\|keeper of the lost\|neverseen\|exile\|everblaze\|unlocked" -- 'docs/**/*.md')
+node scripts/scrub-kotlc.mjs --write CLAUDE.md $(git grep -ilE "\b(keefe|sophie|bonus keefe|stellarlune|keeper of the lost|neverseen|everblaze|elwin|sandor|prentice|forkle)\b" -- 'docs/**/*.md')
 ```
 Then hand-edit CLAUDE.md's "Canonical end-to-end manuscript" block prose (it is now committed + owned; drop the "do not commit — copyrighted" caveat).
 

--- a/docs/superpowers/plans/2026-06-12-keefe-scrub.md
+++ b/docs/superpowers/plans/2026-06-12-keefe-scrub.md
@@ -46,7 +46,7 @@
 | Edaline | Hespa | owned (mother) |
 | Brant | Bram | owned |
 
-**Books / series:**
+**Books / series — UNAMBIGUOUS (safe for the blanket codemod):**
 
 | KotLC | Owned |
 |---|---|
@@ -54,15 +54,30 @@
 | Stellarlune | The Drowning Bell |
 | Everblaze | The Tidewatcher's Oath |
 | Neverseen | Saltgrave |
-| Exile | The Ebb |
-| Unlocked | The Floodmark |
-| Legacy | The Lantern Tide |
-| Flashback | The Undertow |
-| Lodestar / Nightfall (if present) | The Lodestone / The Nightwater |
 
+**Books — CONTEXT-ONLY (⚠️ common English / code words — NOT in the codemod):**
+
+| KotLC | Owned | Why manual |
+|---|---|---|
+| Exile | The Ebb | "exile" is a common word |
+| Unlocked | The Floodmark | UI/state term |
+| Legacy | The Lantern Tide | **114 code files** use "legacy" for legacy format/pairing — must NOT blanket-rename |
+| Flashback | The Undertow | common word |
+| Foster (surname) | Sparrow | "foster" is also a verb — capitalised-standalone only |
+
+> These are renamed **only by the reviewed manual pass** (Phase 4 Step 3b / Phase 5
+> Step 1b), where a human confirms each occurrence genuinely refers to the KotLC
+> book/surname. The codemod must **exclude** them.
+>
 > All owned names above are original (no third-party IP). Coalfall cast names come
 > from `brand/test-book/the-coalfall-commission-cast-sheet.md`; the rest are
 > fabricated Hollow Tide-universe names.
+
+**Unambiguous CHARACTER tokens** (safe for the codemod): Sophie, Keefe, Elwin,
+Sandor, Prentice, Forkle, Fitz, Biana, Maruca, Grizel, Marella, Edaline,
+Hunkyhair, Cassius, Galvin, Stellarlune, Everblaze, Neverseen. (`Dex`, `Alina`,
+`Grady`, `Brant` are short/common enough to **spot-check** the diff, but `\b`
++ capitalisation makes them low-risk.)
 
 ---
 
@@ -104,7 +119,24 @@ Expected: the names already in the table. Add any stragglers (e.g. `Councillor X
 
 - [ ] **Step 5: Write the codemod (TDD)**
 
-Create `scripts/scrub-kotlc.mjs` exporting `scrubText(s)` that applies the mapping with **word boundaries** and **case preservation** (`Sophie`→`Wren`, `sophie`→`wren`, `SOPHIE`→`WREN`; longest-key-first so `Sophie Foster`/`Keefe Sencen`/`Lord Cassius` match before the single tokens; `Foster`→`Sparrow` only as a standalone word). The map (inline const — single source) also includes the **manuscript-path** entries (`…\Bonus Keefe Story.txt` and `~/Downloads/Bonus Keefe Story.txt` → `server/src/__fixtures__/the-coalfall-commission.md`). The module also implements a `--write <files...>` CLI that scrubs each given file in place (used by every later phase).
+Create `scripts/scrub-kotlc.mjs` exporting `scrubText(s)`. Requirements:
+
+- **Only the UNAMBIGUOUS map** (the safe character + book lists above). The
+  context-only words (`Exile`/`Unlocked`/`Legacy`/`Flashback`/`Foster`) are
+  **explicitly excluded** — a guard test asserts `scrubText('legacy pairing')` is
+  unchanged.
+- **Word boundaries + case preservation**: `Sophie`→`Wren`, `sophie`→`wren`,
+  `SOPHIE`→`WREN`.
+- **Longest-key-first**: `Sophie Foster`/`Keefe Sencen`/`Lord Cassius` before the
+  single tokens.
+- **Kebab/slug forms**: for each mapping, also match the hyphen-joined lowercase
+  form — `sophie-foster`→`wren-sparrow`, `keefe-sencen`→`tam-hollis`,
+  `mock-book-stellarlune`→`mock-book-the-drowning-bell`. Implement by, for each
+  `[from,to]`, registering both the spaced form AND `kebab(from)→kebab(to)`
+  (`from.toLowerCase().replace(/ /g,'-')`).
+- **Manuscript-path** entries: `…\Bonus Keefe Story.txt` and
+  `~/Downloads/Bonus Keefe Story.txt` → `server/src/__fixtures__/the-coalfall-commission.md`.
+- A `--write <files...>` CLI that scrubs each file in place (used by every later phase).
 
 Write `scripts/tests/scrub-kotlc.test.mjs` first:
 ```js
@@ -125,6 +157,15 @@ test('word boundaries — no mid-word hits', () => {
 test('books', () => {
   assert.equal(scrubText('Keeper of the Lost Cities: Stellarlune'),
     'The Hollow Tide: The Drowning Bell');
+});
+test('kebab/slug forms', () => {
+  assert.equal(scrubText("id: 'sophie-foster'"), "id: 'wren-sparrow'");
+  assert.equal(scrubText('mock-book-stellarlune'), 'mock-book-the-drowning-bell');
+});
+test('common words are LEFT ALONE (context-only, not codemod)', () => {
+  assert.equal(scrubText('the legacy pairing format'), 'the legacy pairing format');
+  assert.equal(scrubText('exile the chapter'), 'exile the chapter');
+  assert.equal(scrubText('foster a connection'), 'foster a connection');
 });
 ```
 Run: `node --test scripts/tests/scrub-kotlc.test.mjs` → FAIL, then implement `scrubText` until PASS.
@@ -230,12 +271,24 @@ Because the codemod renames inline fixture text AND the assertions consistently,
 
 For each file flagged in Step 1, after renaming, recompute the char offsets against the renamed fixture text (the name-length delta shifts them). Where feasible, prefer asserting on a substring/anchor rather than a hardcoded integer to avoid future fragility.
 
+- [ ] **Step 3b: Manual context-only pass (the ⚠️ common words)**
+
+The codemod left `Exile`/`Unlocked`/`Legacy`/`Flashback`/`Foster` untouched. Grep each in the Cat-4 files and rename **only** the occurrences that genuinely refer to the KotLC book/surname (almost always adjacent to other KotLC names):
+```bash
+git grep -nE "\b(Exile|Unlocked|Flashback)\b" -- 'server/src/**/*.test.ts'   # review each
+git grep -nE "\bFoster\b" -- 'server/src/**/*.test.ts'                         # surname → Sparrow
+```
+Do **not** touch lowercase `legacy`/`exile`/`unlocked` (code terms). `Legacy` the
+book is rare in tests; confirm by eye before any edit.
+
 - [ ] **Step 4: Verify**
 ```bash
 npm run test:server && npm run test:server-slow
-git grep -iE "sophie|keefe|elwin|sandor|prentice|forkle|dex|fitz|biana|stellarlune|everblaze|neverseen|exile|unlocked|legacy|keeper of the lost" -- 'server/src/**/*.test.ts'
+# Gate greps the UNAMBIGUOUS tokens only (common words excluded by design):
+git grep -iE "\b(sophie|keefe|elwin|sandor|prentice|forkle|fitz|biana|maruca|grizel|marella|edaline|hunkyhair|cassius|galvin|stellarlune|everblaze|neverseen|keeper of the lost)\b" -- 'server/src/**/*.test.ts'
 ```
-Expected: all server tests green; grep returns **no matches**. Commit `test(server): re-fixture the server suite onto owned Coalfall/Hollow Tide content`.
+Expected: all server tests green; gate grep returns **no matches**. (Eyeball the
+remaining `Exile`/`Legacy`/`Foster` hits are all non-KotLC.) Commit `test(server): re-fixture the server suite onto owned Coalfall/Hollow Tide content`.
 
 > This phase may warrant splitting into 2–3 PRs by directory (`analyzer`+`routes`, `tts`+`store`, `workspace`+`audio`+`export`+`parsers`+`handoff`) to keep each review tractable. The acceptance gate per PR is the same (scoped grep clean + that subtree's tests green).
 
@@ -260,9 +313,12 @@ Then hand-edit CLAUDE.md's "Canonical end-to-end manuscript" block prose (it is 
 
 Per the convention: in archived plans recording real past runs (observed char lists, "Ch44 pos 37588"), the codemod replaces the *name* — review the diff and **do not** invent Coalfall-specific numbers. Where a sentence would read as a fabricated Coalfall run, soften to "(historical run against the prior test manuscript)" rather than asserting it happened against Coalfall.
 
+Also do the **context-only book pass** here (the codemod skipped `Exile`/`Unlocked`/`Legacy`/`Flashback`): in *docs prose* these usually DO mean the KotLC book (e.g. "Exile ch56", "Stellarlune reusing Everblaze"). Rename those occurrences by hand to the owned titles; still leave lowercase code-term `legacy` alone if any appears in docs.
+
 - [ ] **Step 3: Verify**
 ```bash
-git grep -iE "keefe|sophie|bonus keefe story|stellarlune|keeper of the lost|neverseen|exile|everblaze|unlocked|elwin" -- 'CLAUDE.md' 'docs/**/*.md'
+# Unambiguous tokens must be zero; eyeball remaining Exile/Legacy hits are non-KotLC.
+git grep -iE "\b(keefe|sophie|bonus keefe story|stellarlune|keeper of the lost|neverseen|everblaze|elwin|sandor|prentice|forkle)\b" -- 'CLAUDE.md' 'docs/**/*.md'
 ```
 Expected: **no matches**. (Docs-only PR → CI doc-fast-path applies.) Commit `docs(docs): repoint canonical manuscript + scrub KotLC from all docs`.
 
@@ -287,11 +343,12 @@ Expected: language-detection e2e green; no KotLC matches. Commit `e2e(e2e): owne
 
 ## Final verification (after all phases)
 
-- [ ] **Repo-wide grep is clean:**
+- [ ] **Repo-wide grep is clean (UNAMBIGUOUS tokens):**
 ```bash
-git grep -iE "\b(sophie|keefe|elwin|sandor|prentice|forkle|fitz|biana|maruca|grizel|stellarlune|everblaze|neverseen|exile|unlocked|legacy|keeper of the lost|bonus keefe story)\b" -- ':!node_modules' ':!docs/superpowers/plans/2026-06-12-keefe-scrub.md' ':!docs/test-book/kotlc-to-coalfall-mapping.md'
+git grep -iE "\b(sophie|keefe|elwin|sandor|prentice|forkle|fitz|biana|maruca|grizel|marella|edaline|hunkyhair|cassius|galvin|stellarlune|everblaze|neverseen|keeper of the lost|bonus keefe story)\b" -- ':!node_modules' ':!docs/superpowers/plans/2026-06-12-keefe-scrub.md' ':!docs/test-book/kotlc-to-coalfall-mapping.md'
 ```
-Expected: **no matches** anywhere in the tracked tree (except this plan + the mapping doc, which name them deliberately).
+Expected: **no matches** (except this plan + the mapping doc, which name them deliberately).
+- [ ] **Context-only words audited:** the remaining `Exile`/`Unlocked`/`Legacy`/`Flashback`/`Foster` hits are each confirmed non-KotLC (code terms / the verb), per Phase 4 Step 3b + Phase 5 Step 2.
 - [ ] **Full battery:** `npm run verify` green.
 - [ ] **Spec status → delivered;** move the scope doc note. Update `CLAUDE.md` testing section already done in Phase 5.
 

--- a/docs/superpowers/plans/2026-06-12-keefe-scrub.md
+++ b/docs/superpowers/plans/2026-06-12-keefe-scrub.md
@@ -1,0 +1,302 @@
+# Keefe / KotLC → Coalfall Scrub Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan phase-by-phase. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Remove all *Keeper of the Lost Cities* (third-party copyright) content — the codebase's de-facto fixture/mock dataset — and replace it with Castwright-owned content (The Coalfall Commission + the Hollow Tide series), committing an owned canonical e2e manuscript (+ a Russian variant for multilingual).
+
+**Architecture:** A single fixed **mapping table** (KotLC entity → owned entity) applied consistently. Renaming *both* a fixture's input text and its assertions preserves most prose-derived tests; only **char-position** assertions break (different name lengths shift offsets) and need re-derivation. Mechanical bulk via a word-boundary, case-preserving codemod; the position-sensitive analyzer subset by hand.
+
+**Tech Stack:** TypeScript (Vitest server + frontend), Node codemod script, Markdown docs.
+
+**Scope:** `docs/superpowers/specs/2026-06-12-keefe-scrub-scope.md` (decisions: full scope incl. archived docs; commit owned manuscript; Russian multilingual fixture; historicity = replace-name-keep-point-no-fabricated-numbers).
+
+**Commit scope vocab:** `server` | `frontend` | `mocks` | `docs` | `scripts` | `e2e`. One phase = one PR.
+
+**Conventions for every phase:**
+- Work on a branch `chore/keefe-scrub-phaseN-<slug>` off latest `main`; one PR per phase.
+- After edits, the phase's **acceptance gate** is: (1) `git grep -i` for the KotLC names in that phase's scope returns **zero**, and (2) the relevant test battery passes.
+- Run server tests with `npm run test:server` (+ `test:server-slow` for the 6 routed files); frontend with `npm test`; e2e with `npm run test:e2e`.
+
+---
+
+## The mapping table (the linchpin — authored here, finalised in Phase 0)
+
+**Characters** (chosen to preserve token-count/role where a test depends on it; twins/alias/non-human use the Coalfall analogues):
+
+| KotLC | Owned | Note |
+|---|---|---|
+| Sophie / Sophie Foster | Wren / Wren Sparrow | protagonist; alias analogue |
+| Foster (surname) | Sparrow | Wren's in-story alias |
+| Keefe / Keefe Sencen | Tam / Tam Hollis | |
+| Lord Hunkyhair (Keefe's joke alias) | Sir Singe | owned joke alias |
+| Elwin | Oduvan (Master Oduvan) | |
+| Fitz | Brann (Brann Weir) | twin analogue |
+| Biana | Maerin | |
+| Dex | Hart | |
+| Sandor | Garrow | owned (bodyguard role) |
+| Prentice | Lessom (Father Lessom) | |
+| Forkle | Casper (Widow Casper) | |
+| Alina / Councillor Alina / Dame Alina | Linnet / Dame Linnet | owned |
+| Lord Cassius | Lord Vane | owned (keeps "Lord X") |
+| Lady Galvin | Lady Wick | owned (keeps "Lady X") |
+| Grizel | Sela | |
+| Maruca | Berrin (Berrin Weir) | second twin |
+| Marella | Edda | owned |
+| Grady | Corvin | owned (father) |
+| Edaline | Hespa | owned (mother) |
+| Brant | Bram | owned |
+
+**Books / series:**
+
+| KotLC | Owned |
+|---|---|
+| Keeper of the Lost Cities (series) | The Hollow Tide |
+| Stellarlune | The Drowning Bell |
+| Everblaze | The Tidewatcher's Oath |
+| Neverseen | Saltgrave |
+| Exile | The Ebb |
+| Unlocked | The Floodmark |
+| Legacy | The Lantern Tide |
+| Flashback | The Undertow |
+| Lodestar / Nightfall (if present) | The Lodestone / The Nightwater |
+
+> All owned names above are original (no third-party IP). Coalfall cast names come
+> from `brand/test-book/the-coalfall-commission-cast-sheet.md`; the rest are
+> fabricated Hollow Tide-universe names.
+
+---
+
+## Phase 0: Foundation — commit the manuscript + mapping doc + codemod
+
+**Files:**
+- Create: `server/src/__fixtures__/the-coalfall-commission.md` (owned manuscript)
+- Create: `server/src/__fixtures__/the-coalfall-commission.ru.md` (Russian variant — Cat 6)
+- Create: `docs/test-book/kotlc-to-coalfall-mapping.md` (the canon table above + enumeration)
+- Create: `scripts/scrub-kotlc.mjs` (codemod)
+- Test: `scripts/tests/scrub-kotlc.test.mjs` (node --test)
+
+- [ ] **Step 1: Commit the owned manuscript fixture**
+
+Copy the owned manuscript out of git-ignored `brand/test-book/` into a committed fixtures path:
+```bash
+mkdir -p server/src/__fixtures__
+cp "brand/test-book/the-coalfall-commission.md" server/src/__fixtures__/the-coalfall-commission.md
+```
+Confirm it is original/owned prose (header reads "A Castwright original"). This is the committed canonical e2e manuscript.
+
+- [ ] **Step 2: Create the Russian multilingual fixture**
+
+Produce an owned Russian translation of **Chapter One** of the Coalfall manuscript (the language-detection fixture only needs a non-English passage, not the whole book). Write it to `server/src/__fixtures__/the-coalfall-commission.ru.md`. Keep it clearly owned (translation of the owned text). This replaces the Russian *Bonus Keefe Story* used by `e2e/language-detection.spec.ts` + fs-2 multilingual.
+
+> The translation content is authored by the implementer/maintainer; it must be a faithful Russian rendering of Coalfall Ch1, no third-party text.
+
+- [ ] **Step 3: Write the mapping doc**
+
+Create `docs/test-book/kotlc-to-coalfall-mapping.md` containing the two tables above verbatim, plus a "completeness" note: the canonical enumeration command (below) and the rule "Coalfall cast first, fabricate owned Hollow Tide names for overflow; never a near-homophone of a KotLC name."
+
+- [ ] **Step 4: Enumerate every KotLC name in use (catch the long tail)**
+
+Run and append any names not already in the table:
+```bash
+git grep -ohE "\b(Sophie|Keefe|Elwin|Sandor|Prentice|Forkle|Dex|Fitz|Biana|Maruca|Cassius|Grizel|Hunkyhair|Alina|Galvin|Grady|Brant|Marella|Edaline|Foster|Keeper of the Lost Cities|Stellarlune|Unlocked|Legacy|Neverseen|Exile|Everblaze|Flashback)\b" -- ':!node_modules' ':!docs/superpowers/plans' | sort | uniq -c | sort -rn
+```
+Expected: the names already in the table. Add any stragglers (e.g. `Councillor X`, `Lord/Lady X`) with an owned mapping before proceeding.
+
+- [ ] **Step 5: Write the codemod (TDD)**
+
+Create `scripts/scrub-kotlc.mjs` exporting `scrubText(s)` that applies the mapping with **word boundaries** and **case preservation** (`Sophie`→`Wren`, `sophie`→`wren`, `SOPHIE`→`WREN`; longest-key-first so `Sophie Foster`/`Keefe Sencen`/`Lord Cassius` match before the single tokens; `Foster`→`Sparrow` only as a standalone word). The map (inline const — single source) also includes the **manuscript-path** entries (`…\Bonus Keefe Story.txt` and `~/Downloads/Bonus Keefe Story.txt` → `server/src/__fixtures__/the-coalfall-commission.md`). The module also implements a `--write <files...>` CLI that scrubs each given file in place (used by every later phase).
+
+Write `scripts/tests/scrub-kotlc.test.mjs` first:
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { scrubText } from '../scrub-kotlc.mjs';
+
+test('multi-word before single-word', () => {
+  assert.equal(scrubText('Sophie Foster and Sophie'), 'Wren Sparrow and Wren');
+  assert.equal(scrubText('Keefe Sencen'), 'Tam Hollis');
+});
+test('case preservation', () => {
+  assert.equal(scrubText('SOPHIE said to keefe'), 'WREN said to tam');
+});
+test('word boundaries — no mid-word hits', () => {
+  assert.equal(scrubText('Fosters philosophiel'), 'Fosters philosophiel');
+});
+test('books', () => {
+  assert.equal(scrubText('Keeper of the Lost Cities: Stellarlune'),
+    'The Hollow Tide: The Drowning Bell');
+});
+```
+Run: `node --test scripts/tests/scrub-kotlc.test.mjs` → FAIL, then implement `scrubText` until PASS.
+
+- [ ] **Step 6: Commit**
+```bash
+git add server/src/__fixtures__ docs/test-book scripts/scrub-kotlc.mjs scripts/tests/scrub-kotlc.test.mjs
+git commit -m "chore(scripts): owned Coalfall fixtures + KotLC→Coalfall mapping + codemod"
+```
+
+---
+
+## Phase 1: Code comments (Cat 2a)
+
+**Files (5):** `server/src/analyzer/roster-coverage.ts`, `server/src/routes/voice-match.ts`, `server/src/util/text-match.ts`, `server/src/workspace/series-cast-scan.ts`, `src/modals/drift-report.tsx`
+
+- [ ] **Step 1: Apply the codemod to comments only**
+
+These files use KotLC names *only in comments* (verified — no logic depends). Apply:
+```bash
+node scripts/scrub-kotlc.mjs --write server/src/analyzer/roster-coverage.ts server/src/routes/voice-match.ts server/src/util/text-match.ts server/src/workspace/series-cast-scan.ts src/modals/drift-report.tsx
+```
+
+- [ ] **Step 2: Historicity check**
+
+Review the diff for any comment recording a *real observed value* (e.g. "produced 6 characters: …"). Per the historicity convention: keep the count, replace the names; do not invent new Coalfall-specific values. Hand-fix any that read as a fabricated run.
+
+- [ ] **Step 3: Verify**
+```bash
+git grep -iE "sophie|keefe|elwin|stellarlune|keeper of the lost" -- server/src/analyzer/roster-coverage.ts server/src/routes/voice-match.ts server/src/util/text-match.ts server/src/workspace/series-cast-scan.ts src/modals/drift-report.tsx
+```
+Expected: **no matches**. Then `npm run typecheck`. Commit `docs(server,frontend): reword KotLC examples in code comments` (use `chore` if scope mix rejects).
+
+---
+
+## Phase 2: Analyzer prompt examples + tests (Cat 2b)
+
+**Files:** `server/src/routes/analysis.ts` (KotLC names inside the LLM prompt template literals, ~L1140–1147 et al.), `server/src/analyzer/gemini.test.ts`, `server/src/analyzer/ollama.test.ts` (+ any analyzer test asserting prompt substrings)
+
+- [ ] **Step 1: Find prompt-substring assertions first**
+```bash
+git grep -nE "Sophie|Keefe|FILED BY|Memory Log" -- 'server/src/analyzer/*.test.ts' 'server/src/routes/analysis.test.ts'
+```
+List every test that asserts a prompt substring containing a KotLC name — those assertions must change in lockstep with the prompt.
+
+- [ ] **Step 2: Scrub the prompt + its tests together**
+```bash
+node scripts/scrub-kotlc.mjs --write server/src/routes/analysis.ts
+node scripts/scrub-kotlc.mjs --write server/src/analyzer/gemini.test.ts server/src/analyzer/ollama.test.ts
+```
+Then hand-reconcile any test from Step 1 whose assertion didn't get rewritten by the codemod (e.g. partial-string matches).
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run test:server` (analyzer tests) — expect green. Then `git grep -iE "sophie|keefe|elwin|prentice|stellarlune" -- server/src/routes/analysis.ts` → no matches.
+Commit `refactor(server): replace KotLC examples in the analyzer prompt + tests`.
+
+---
+
+## Phase 3: Frontend mock data (Cat 3)
+
+**Files (2 + tests):** `src/data/drift.ts`, `src/lib/api.ts` (mock book entries like `mock-book-stellarlune` + comments), plus any frontend `*.test.tsx` asserting those names.
+
+- [ ] **Step 1: Scrub**
+```bash
+node scripts/scrub-kotlc.mjs --write src/data/drift.ts src/lib/api.ts
+```
+Also rename id slugs: `mock-book-stellarlune` → `mock-book-the-drowning-bell` (the codemod should map `stellarlune` in slugs too; verify the slug form `mock-book-<x>` is handled or hand-fix).
+
+- [ ] **Step 2: Update frontend tests**
+```bash
+git grep -il "sophie\|keefe\|stellarlune\|mock-book-stellarlune" -- 'src/**/*.test.tsx' 'src/**/*.test.ts'
+```
+Scrub those files too; reconcile assertions.
+
+- [ ] **Step 3: Verify**
+
+Run: `npm test` (frontend) → green. `git grep -iE "sophie|keefe|stellarlune|everblaze|neverseen" -- src/data/drift.ts src/lib/api.ts` → no matches. Sanity-check mock mode still renders (`npm run dev`, spot-check the library). Commit `mocks(frontend): owned books/characters in drift + api mock data`.
+
+---
+
+## Phase 4: Server test fixtures (Cat 4 — the big one, ~62 files)
+
+**Files:** ~62 `server/src/**/*.test.ts` (enumerate: `git grep -il "sophie\|keefe\|stellarlune\|elwin\|prentice\|forkle\|dex\|fitz\|biana\|neverseen\|exile\|everblaze\|unlocked\|legacy" -- 'server/src/**/*.test.ts'`).
+
+- [ ] **Step 1: Classify pure-rename vs. re-fixture**
+
+Position/length-sensitive tests break under rename (different name lengths shift char offsets). Find them:
+```bash
+git grep -lnE "pos(ition)?[: ]+[0-9]{3,}|charIndex|offset[: ]+[0-9]+|substring\(|slice\([0-9]" -- 'server/src/**/*.test.ts' | xargs git grep -lE "sophie|keefe" 2>/dev/null
+```
+Mark these for **manual re-derivation** (Step 3). Everything else is pure-rename (Step 2).
+
+- [ ] **Step 2: Codemod the bulk**
+
+Run the codemod across all Cat-4 test files EXCEPT the position-sensitive set:
+```bash
+node scripts/scrub-kotlc.mjs --write $(git grep -il "sophie\|keefe\|stellarlune\|elwin\|prentice\|forkle\|dex\|fitz\|biana\|neverseen\|exile\|everblaze\|unlocked\|legacy" -- 'server/src/**/*.test.ts')
+```
+Because the codemod renames inline fixture text AND the assertions consistently, count/occurrence-based expectations stay correct.
+
+- [ ] **Step 3: Re-derive position-sensitive tests**
+
+For each file flagged in Step 1, after renaming, recompute the char offsets against the renamed fixture text (the name-length delta shifts them). Where feasible, prefer asserting on a substring/anchor rather than a hardcoded integer to avoid future fragility.
+
+- [ ] **Step 4: Verify**
+```bash
+npm run test:server && npm run test:server-slow
+git grep -iE "sophie|keefe|elwin|sandor|prentice|forkle|dex|fitz|biana|stellarlune|everblaze|neverseen|exile|unlocked|legacy|keeper of the lost" -- 'server/src/**/*.test.ts'
+```
+Expected: all server tests green; grep returns **no matches**. Commit `test(server): re-fixture the server suite onto owned Coalfall/Hollow Tide content`.
+
+> This phase may warrant splitting into 2–3 PRs by directory (`analyzer`+`routes`, `tts`+`store`, `workspace`+`audio`+`export`+`parsers`+`handoff`) to keep each review tractable. The acceptance gate per PR is the same (scoped grep clean + that subtree's tests green).
+
+---
+
+## Phase 5: Docs — pointer + prose together (Cat 1 + Cat 5)
+
+**Files:** `CLAUDE.md` + ~45 `docs/**/*.md` (`git grep -il "keefe\|sophie\|bonus keefe story\|stellarlune\|keeper of the lost" -- 'CLAUDE.md' 'docs/**/*.md'`).
+
+- [ ] **Step 1: Repoint the canonical manuscript**
+
+The manuscript-path replacement is **a mapping entry** (added in Phase 0): both
+`C:\Users\dudar\Downloads\Bonus Keefe Story.txt` and `~/Downloads/Bonus Keefe Story.txt`
+→ `server/src/__fixtures__/the-coalfall-commission.md`. So the same `--write`
+codemod handles names, books, AND the path:
+```bash
+node scripts/scrub-kotlc.mjs --write CLAUDE.md $(git grep -il "keefe\|sophie\|bonus keefe\|stellarlune\|keeper of the lost\|neverseen\|exile\|everblaze\|unlocked" -- 'docs/**/*.md')
+```
+Then hand-edit CLAUDE.md's "Canonical end-to-end manuscript" block prose (it is now committed + owned; drop the "do not commit — copyrighted" caveat).
+
+- [ ] **Step 2: Historicity sweep**
+
+Per the convention: in archived plans recording real past runs (observed char lists, "Ch44 pos 37588"), the codemod replaces the *name* — review the diff and **do not** invent Coalfall-specific numbers. Where a sentence would read as a fabricated Coalfall run, soften to "(historical run against the prior test manuscript)" rather than asserting it happened against Coalfall.
+
+- [ ] **Step 3: Verify**
+```bash
+git grep -iE "keefe|sophie|bonus keefe story|stellarlune|keeper of the lost|neverseen|exile|everblaze|unlocked|elwin" -- 'CLAUDE.md' 'docs/**/*.md'
+```
+Expected: **no matches**. (Docs-only PR → CI doc-fast-path applies.) Commit `docs(docs): repoint canonical manuscript + scrub KotLC from all docs`.
+
+---
+
+## Phase 6: Multilingual fixture wiring (Cat 6)
+
+**Files:** `e2e/language-detection.spec.ts` + any server test / fixture that fed it non-English KotLC text; references in `docs/features/162-fs2-multilanguage.md`, `docs/features/165-*.md`.
+
+- [ ] **Step 1: Point the language fixtures at the Russian Coalfall excerpt**
+
+Replace the non-English KotLC fixture content/reference with `server/src/__fixtures__/the-coalfall-commission.ru.md` (or an inline excerpt from it). Update assertions that checked specific KotLC Russian strings to Coalfall Russian strings.
+
+- [ ] **Step 2: Verify**
+```bash
+npm run test:e2e -- language-detection
+git grep -iE "keefe|sophie" -- e2e/language-detection.spec.ts docs/features/162-fs2-multilanguage.md
+```
+Expected: language-detection e2e green; no KotLC matches. Commit `e2e(e2e): owned Russian Coalfall fixture for language detection`.
+
+---
+
+## Final verification (after all phases)
+
+- [ ] **Repo-wide grep is clean:**
+```bash
+git grep -iE "\b(sophie|keefe|elwin|sandor|prentice|forkle|fitz|biana|maruca|grizel|stellarlune|everblaze|neverseen|exile|unlocked|legacy|keeper of the lost|bonus keefe story)\b" -- ':!node_modules' ':!docs/superpowers/plans/2026-06-12-keefe-scrub.md' ':!docs/test-book/kotlc-to-coalfall-mapping.md'
+```
+Expected: **no matches** anywhere in the tracked tree (except this plan + the mapping doc, which name them deliberately).
+- [ ] **Full battery:** `npm run verify` green.
+- [ ] **Spec status → delivered;** move the scope doc note. Update `CLAUDE.md` testing section already done in Phase 5.
+
+## Self-review notes
+
+- `Dex` (3 letters) and `Fitz`, `Hart`, `Tam` are short — ensure the codemod's word-boundary regex doesn't hit substrings (`Dexterity`, `indexed`). The Phase-0 test pins `\b` behaviour; add `Dex`-specific cases.
+- `Foster` → `Sparrow` only as a standalone surname; guard against "foster" the verb (lowercase) — check the ~128 `Foster` hits are all the surname before blanket-renaming (a Phase-0/Phase-4 spot check).
+- `Tam`/`Hart`/`Sela`/`Wren` are **owned** names already present (Coalfall) — the codemod must not double-map them; the mapping table has no owned-name keys, so this is safe by construction, but verify no KotLC→owned target collides with a *different* KotLC source.

--- a/docs/superpowers/specs/2026-06-12-keefe-scrub-scope.md
+++ b/docs/superpowers/specs/2026-06-12-keefe-scrub-scope.md
@@ -1,0 +1,126 @@
+# Keefe / KotLC → Coalfall scrub — scope
+
+**Status:** scope (decisions captured 2026-06-12; not yet planned)
+**Type:** content/copyright scrub (not a feature)
+
+## Goal
+
+Remove all *Keeper of the Lost Cities* (Shannon Messenger, third-party copyright)
+content from the repository — used today as the de-facto test/mock dataset — and
+replace it with Castwright-owned content (**The Coalfall Commission** + the
+invented **Hollow Tide** series). Commit an owned canonical e2e manuscript so the
+documented test recipe no longer points at a copyrighted local-only file.
+
+## Decisions (locked)
+
+| Decision | Choice |
+|---|---|
+| Scope boundary | **Everything**, including the ~45 archived/historical regression-plan docs. |
+| Canonical manuscript | **Commit an owned manuscript** (the Coalfall Commission, 2 chapters) into the repo as the e2e fixture. |
+| Manuscript length | 2 chapters is **sufficient** (user-confirmed). |
+
+## The footprint (grounded)
+
+The KotLC universe is the primary fixture/mock dataset across the codebase, far
+beyond just "Bonus Keefe Story". Union ≈ **150+ files**. Name occurrences:
+Sophie (130), Keefe (124), "Keeper of the Lost" (50), Stellarlune (45), Elwin
+(33), Fitz (22), Neverseen (19), Everblaze (18).
+
+Five categories by risk:
+
+| # | Category | Where | Risk |
+|---|---|---|---|
+| 1 | **Canonical manuscript pointer** | `CLAUDE.md` + ~60 doc refs to `…\Bonus Keefe Story.txt` | Low (doc edits) |
+| 2 | **Code comments** (KotLC as examples) | `roster-coverage.ts`, `voice-match.ts`, `text-match.ts`, `series-cast-scan.ts`, `drift-report.tsx`, `api.ts` comments | Low — verified **no logic depends on them**, pure reword |
+| 3 | **Frontend mock data** | `src/mocks/` (incl. `canned-data.ts`), `src/data/`, the mock branch of `src/lib/api.ts` (e.g. `mock-book-stellarlune`) | Med — drives mock-mode UI, marketing capture, frontend tests asserting names |
+| 4 | **Server test fixtures** | many `server/src/**/*.test.ts` (analyzer/audio/export) | **High** — use KotLC manuscripts + assert specific names/counts → owned fixtures + expected-value rewrites |
+| 5 | **Docs prose / archived plans** | 45 files, mostly historical regression plans | Med (volume) — reword KotLC walkthrough examples |
+
+## Owned replacement canon
+
+**The Coalfall Commission** — Castwright-owned, purpose-built as "a clean, owned
+replacement for the proprietary Bonus Keefe Story" (see
+`brand/test-book/the-coalfall-commission-cast-sheet.md`). 2 chapters, 2,892
+words, **14 speakers + narrator**, with a deliberate **test-case map** that
+mirrors the suite's needs:
+
+| Owned cast member | Serves the test pattern |
+|---|---|
+| **Wren** (alias **Sparrow**) | alias resolution (was `Keefe`/`Sophie` + aliases) |
+| **Brann Weir** / **Berrin Weir** (twins) | twin / same-demographics disambiguation |
+| **Coalfall** (dragon), **the bell** | non-human voices |
+| **Tam Hollis** (unnamed lane voice → named) | incidental-speaker promotion |
+| **Master Oduvan** (70), **Sela** (8), **Widow Casper** (80s) | age-spread |
+| **Narrator**, **Maerin**, **Father Lessom** (whisper), **Ivo**, **Hart** | register spread, narrator slot |
+
+Source files already exist (git-ignored, owned): `brand/test-book/the-coalfall-commission.md`
+(manuscript), `.epub`, `-cast-sheet.md` (roster + expected casting + test-case map).
+
+**Series cases** (cross-book reuse, `series-cast-scan`, voice-match across
+books) need an owned *multi-book series*. Coalfall is standalone → use the
+invented **Hollow Tide** series (3 books: *The Drowning Bell*, *The Tidewatcher's
+Oath*, *Saltgrave*; author *Marin Vale*) already established in the marketing
+capture, with **fabricated owned rosters** (tests need consistent owned names,
+not real prose).
+
+## Replacement-mapping approach
+
+A single fixed mapping table (KotLC entity → owned entity) applied
+consistently, leveraging the deliberate analogues above so test *intent* is
+preserved. Examples:
+- `Sophie` / `Keefe` → `Wren` (+ alias `Sparrow`) or the appropriate Coalfall role
+- KotLC twins / look-alikes → `Brann Weir` / `Berrin Weir`
+- `Keeper of the Lost Cities` (series) → `The Hollow Tide`
+- `Stellarlune` / `Everblaze` / `Neverseen` / `Unlocked` (books) → Hollow Tide book titles
+- `Bonus Keefe Story.txt` → the committed Coalfall manuscript fixture
+
+## Fidelity strategy
+
+- **Categories 1, 2, 5** (pointer, comments, docs): structure-preserving rename
+  via the mapping table — mechanical.
+- **Category 3** (frontend mocks): swap book/character fixtures to owned ones;
+  update frontend tests that assert names. The mock manuscripts dir is already
+  partly owned (`src/mocks/manuscripts/the-northern-star.md`).
+- **Category 4** (server analyzer fixtures): where a test asserts *prose-derived*
+  values (occurrence counts, char positions, roster coverage), a pure rename is
+  insufficient — re-fixture against the **owned Coalfall manuscript text** and
+  recompute expected values. This is the bulk of the effort.
+
+## Committed-manuscript location (proposal)
+
+Move an owned copy of the manuscript out of git-ignored `brand/test-book/` into a
+committed fixtures path — proposed `server/src/__fixtures__/the-coalfall-commission.md`
+(+ `.epub` if a parser fixture wants it), alongside the existing
+`server/src/parsers/__fixtures__/`. Update CLAUDE.md's "Canonical end-to-end
+manuscript" to cite the committed path. (Brand cover art etc. stay git-ignored;
+only the manuscript text + cast sheet become committed test fixtures.)
+
+## Phasing (recommended)
+
+0. **Commit the owned manuscript fixture** + a `KotLC→owned` mapping doc (the canon).
+1. **Canonical pointer** — CLAUDE.md + ~60 doc refs → committed Coalfall path.
+2. **Code comments** — reword (low risk, no tests affected).
+3. **Frontend mock data** — owned books/chars + frontend test updates.
+4. **Server fixtures** — owned manuscripts/rosters + expected-value rewrites (largest).
+5. **Docs prose / archived plans** — reword KotLC examples (mechanical, high volume).
+
+Each phase is independently shippable and verifiable (`npm run verify` /
+`test:server`), so they can land as separate PRs.
+
+## Open items / risks (resolve during planning)
+
+- **Server-fixture churn (Cat 4)** is the real cost — some analyzer tests encode
+  KotLC-prose-specific expectations; those become owned-manuscript-specific.
+  Needs a pass to identify which tests are pure-rename vs. re-fixture.
+- **Hollow Tide rosters** must be fabricated for series tests (owned names only).
+- **Archived-doc churn (Cat 5)** edits historical records; acceptable per the
+  "everything" decision, but it's ~45 files of prose.
+- **Mapping completeness** — enumerate every KotLC name in use (not just the top
+  8) before the rename so nothing is missed.
+
+## Effort
+
+Large and cross-cutting (~150+ files), but most is mechanical rename once the
+mapping table is fixed. The concentrated-effort core is **Category 4** (server
+analyzer fixture re-derivation). Recommend executing phase-by-phase as separate
+PRs rather than one mega-change.

--- a/docs/superpowers/specs/2026-06-12-keefe-scrub-scope.md
+++ b/docs/superpowers/specs/2026-06-12-keefe-scrub-scope.md
@@ -18,6 +18,8 @@ documented test recipe no longer points at a copyrighted local-only file.
 | Scope boundary | **Everything**, including the ~45 archived/historical regression-plan docs. |
 | Canonical manuscript | **Commit an owned manuscript** (the Coalfall Commission, 2 chapters) into the repo as the e2e fixture. |
 | Manuscript length | 2 chapters is **sufficient** (user-confirmed). |
+| Multilingual (Cat 6) | **(a)** create an owned **Russian** version of a Coalfall excerpt as the committed multilingual fixture. |
+| Historicity | **Confirmed:** replace the copyrighted name, keep the illustrative point, do NOT fabricate Coalfall-specific observed values. |
 
 ## The footprint (grounded)
 

--- a/docs/superpowers/specs/2026-06-12-keefe-scrub-scope.md
+++ b/docs/superpowers/specs/2026-06-12-keefe-scrub-scope.md
@@ -1,6 +1,6 @@
 # Keefe / KotLC → Coalfall scrub — scope
 
-**Status:** scope (decisions captured 2026-06-12; not yet planned)
+**Status:** scope (decisions captured 2026-06-12; adversarial-reviewed; two decisions still open — see Open items; not yet planned)
 **Type:** content/copyright scrub (not a feature)
 
 ## Goal
@@ -31,10 +31,12 @@ Five categories by risk:
 | # | Category | Where | Risk |
 |---|---|---|---|
 | 1 | **Canonical manuscript pointer** | `CLAUDE.md` + ~60 doc refs to `…\Bonus Keefe Story.txt` | Low (doc edits) |
-| 2 | **Code comments** (KotLC as examples) | `roster-coverage.ts`, `voice-match.ts`, `text-match.ts`, `series-cast-scan.ts`, `drift-report.tsx`, `api.ts` comments | Low — verified **no logic depends on them**, pure reword |
-| 3 | **Frontend mock data** | `src/mocks/` (incl. `canned-data.ts`), `src/data/`, the mock branch of `src/lib/api.ts` (e.g. `mock-book-stellarlune`) | Med — drives mock-mode UI, marketing capture, frontend tests asserting names |
+| 2a | **Code comments** (KotLC as examples) | `roster-coverage.ts`, `voice-match.ts`, `text-match.ts`, `series-cast-scan.ts`, `drift-report.tsx` | Low — no logic depends, pure reword |
+| 2b | **Analyzer PROMPT examples** | `server/src/routes/analysis.ts` (~L1140–1147: KotLC names inside the LLM prompt template literals) | **Med** — these are prompt *content* the analyzer sends, likely pinned by `gemini.test.ts`/prompt tests. NOT a cosmetic reword. |
+| 3 | **Frontend mock data** | `src/mocks/` (incl. `canned-data.ts`), `src/data/`, the mock branch of `src/lib/api.ts` (e.g. `mock-book-stellarlune` book entries — *data*, not comments) | Med — drives mock-mode UI, marketing capture, frontend tests asserting names |
 | 4 | **Server test fixtures** | many `server/src/**/*.test.ts` (analyzer/audio/export) | **High** — use KotLC manuscripts + assert specific names/counts → owned fixtures + expected-value rewrites |
-| 5 | **Docs prose / archived plans** | 45 files, mostly historical regression plans | Med (volume) — reword KotLC walkthrough examples |
+| 5 | **Docs prose / archived plans** | 45 files (19 of which **also** hold the manuscript pointer from Cat 1 — edit once, not twice) | Med (volume) |
+| 6 | **Multilingual fixtures** | `e2e/language-detection.spec.ts`, `162-fs2-multilanguage.md` + non-English (Russian) KotLC content | **Blocked** — Coalfall is English-only; **no owned non-English text exists** (see Open items) |
 
 ## Owned replacement canon
 
@@ -95,28 +97,50 @@ committed fixtures path — proposed `server/src/__fixtures__/the-coalfall-commi
 manuscript" to cite the committed path. (Brand cover art etc. stay git-ignored;
 only the manuscript text + cast sheet become committed test fixtures.)
 
-## Phasing (recommended)
+## Phasing (revised after adversarial review)
 
 0. **Commit the owned manuscript fixture** + a `KotLC→owned` mapping doc (the canon).
-1. **Canonical pointer** — CLAUDE.md + ~60 doc refs → committed Coalfall path.
-2. **Code comments** — reword (low risk, no tests affected).
-3. **Frontend mock data** — owned books/chars + frontend test updates.
-4. **Server fixtures** — owned manuscripts/rosters + expected-value rewrites (largest).
-5. **Docs prose / archived plans** — reword KotLC examples (mechanical, high volume).
+1. **Code comments (Cat 2a)** — reword (low risk, no tests affected).
+2. **Analyzer prompt examples (Cat 2b)** — reword KotLC→Coalfall *inside* the
+   analyzer prompt; **update the analyzer/prompt tests in the same change** (this
+   is behaviour-adjacent, not cosmetic).
+3. **Frontend mock data (Cat 3)** — owned books/chars + frontend test updates.
+4. **Server fixtures (Cat 4)** — owned manuscripts/rosters + expected-value
+   rewrites (largest; identify pure-rename vs. re-fixture first).
+5. **Docs — pointer + prose together (Cat 1 + Cat 5)** — one pass per doc file
+   (the manuscript pointer and KotLC prose co-occur in 19 files; CLAUDE.md
+   included). Repoints to the committed Coalfall path AND rewords examples.
+6. **Multilingual (Cat 6)** — gated on the non-English-source decision below.
 
-Each phase is independently shippable and verifiable (`npm run verify` /
-`test:server`), so they can land as separate PRs.
+Phases 0–5 are independently shippable + verifiable (`npm run verify` /
+`test:server`) as separate PRs. Phase 6 is blocked until its decision lands.
 
 ## Open items / risks (resolve during planning)
 
+- **DECISION — multilingual source (Cat 6).** Coalfall is English-only and no
+  owned non-English text exists. Options: (a) commission a short owned non-English
+  passage (e.g. a Russian-translated Coalfall excerpt) as a committed fixture;
+  (b) replace the language-detection fixture with a minimal public-domain /
+  synthetic non-English snippet (no KotLC, no Coalfall); (c) descope multilingual
+  from this scrub and track it separately. **Needs a call before Phase 6.**
+- **DECISION — historicity convention.** Many Cat 2a comments and Cat 5 archived
+  docs record *real past runs* against Bonus Keefe (observed char lists, char
+  positions, e.g. `analysis.ts:946`, "Ch44 pos 37588"). Renaming to Coalfall
+  makes them describe a run that never happened. Convention: **replace the
+  copyrighted name, keep the illustrative point, and do NOT fabricate
+  Coalfall-specific observed values** (genericise the number or mark it
+  illustrative). Confirm this reading is acceptable.
 - **Server-fixture churn (Cat 4)** is the real cost — some analyzer tests encode
   KotLC-prose-specific expectations; those become owned-manuscript-specific.
-  Needs a pass to identify which tests are pure-rename vs. re-fixture.
-- **Hollow Tide rosters** must be fabricated for series tests (owned names only).
-- **Archived-doc churn (Cat 5)** edits historical records; acceptable per the
-  "everything" decision, but it's ~45 files of prose.
-- **Mapping completeness** — enumerate every KotLC name in use (not just the top
-  8) before the rename so nothing is missed.
+  Needs a pass to classify each test pure-rename vs. re-fixture.
+- **Cardinality** — KotLC fixtures may name more distinct characters than
+  Coalfall's 14 (e.g. a fixture with Sophie+Keefe+Elwin+Biana+Alina+narrator =
+  6 is fine, but enumerate the largest before assuming a 1:1 map). Hollow Tide
+  rosters (fabricated, owned) absorb the overflow + the series cases.
+- **Mapping completeness** — enumerate **every** KotLC name in use (not just the
+  top 8: also Biana, Alina, Grizel, Prentice, Dame Alina, etc.) before renaming.
+- **Test-pinned prompt (Cat 2b)** — confirm which analyzer tests assert prompt
+  substrings before editing `analysis.ts`.
 
 ## Effort
 


### PR DESCRIPTION
﻿Scope + full phase-by-phase plan for removing all Keeper of the Lost Cities (third-party copyright) content and replacing it with owned Coalfall/Hollow Tide content. Adversarially reviewed twice (scope + plan). No code changes — planning docs only.

See docs/superpowers/specs/2026-06-12-keefe-scrub-scope.md and docs/superpowers/plans/2026-06-12-keefe-scrub.md.
