### PR TITLE
feat(frontend,server): per-model Ollama Load/Unload + 'Voice engine' rename

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 This guide walks a deployer through bringing the app up on a clean Windows, macOS, or Linux machine after extracting `castwright-vX.Y.Z.zip` from a [GitHub release](https://github.com/dudarenok-maker/Castwright/releases).
 
-After install you'll have a single command (`npm run start:prod`) that brings up the Node server (port 8080), the Python TTS sidecar (port 9000), and the built frontend — all served from `http://localhost:8080`.
+After install you'll have a single command (`npm run start:prod`) that brings up the Node server (port 8080), the Python voice engine (port 9000), and the built frontend — all served from `http://localhost:8080`.
 
 ---
 
@@ -231,10 +231,10 @@ Or the manual path: install Ollama from <https://ollama.com>, `ollama pull qwen3
 
 **Option C — Pipelined two-model split.** For long books: Phase 0 (cast detection) runs on Gemma while Phase 1 (sentence attribution) runs on Gemini Flash in parallel, hitting independent rate-limit buckets so effective quota nearly doubles. Configure under **Account → Defaults for new books → Phase 0 model + Phase 1 model + Min-lag chapters** (default 10), or set `ANALYZER_PHASE0_MODEL` / `ANALYZER_PHASE1_MODEL` / `ANALYZER_PHASE1_MIN_LAG_CHAPTERS` in `server/.env`.
 
-## Switching TTS to Coqui XTTS v2 (alternate, on-device)
+## Switching the voice engine to Coqui XTTS v2 (alternate, on-device)
 
-1. **Account → Defaults for new books → TTS engine** → "Local (free)".
-2. **TTS model** → "Coqui XTTS v2".
+1. **Account → Defaults for new books → Voice engine** → "Local (free)".
+2. **Voice model** → "Coqui XTTS v2".
 3. Save. The first chapter generation triggers a one-time ~2 GB model download.
 
 ## Switching TTS to Qwen3-TTS
@@ -259,7 +259,7 @@ Qwen3-TTS designs a unique voice per character from the cast persona instead of 
 
    The script auto-skips on macOS / Linux / non-`cp311` Python / non-`torch-2.6 + cu124` — a wheel that can't load doesn't get installed. Once installed, activate it by setting `QWEN_ATTN_IMPL=flash_attention_2` in `server/.env`.
 
-3. **Switch a book to Qwen3.** Start the app and go to **Account → Defaults for new books → TTS engine** → "Local (free)" → **TTS model** → pick the Qwen3 entry. Save. For an existing book opened under Kokoro / Coqui, use the cast view's "Rebaseline the series" modal to design Qwen voices for the principal cast with current-vs-proposed audition before regenerating.
+3. **Switch a book to Qwen3.** Start the app and go to **Account → Defaults for new books → Voice engine** → "Local (free)" → **Voice model** → pick the Qwen3 entry. Save. For an existing book opened under Kokoro / Coqui, use the cast view's "Rebaseline the series" modal to design Qwen voices for the principal cast with current-vs-proposed audition before regenerating.
 
 **Disk + VRAM.** Qwen Base ~1 GB on disk, Base + VoiceDesign together ~2.5 GB. At runtime Base resides at ~2 GB VRAM during synth and VoiceDesign loads transiently during a design (~4–5 GB on top of Base, freed on idle or at the next synth). The GPU-arbitration semaphore (`GPU_VRAM_BUDGET` in `server/.env`, default 8 GiB) keeps an 8 GB GPU from double-booking against the analyzer.
 
@@ -268,8 +268,8 @@ Qwen3-TTS designs a unique voice per character from the cast persona instead of 
 The same Gemini key configured for the analyzer (see Option B above) doubles as the TTS provider when picked.
 
 1. Get an API key from <https://aistudio.google.com> (Google account required), saved via **Account → Server configuration → Gemini API key**.
-2. **Account → Defaults for new books → TTS engine** → "Gemini (cloud)".
-3. **TTS model** → pick `gemini-3.1-flash-preview-tts` or `gemini-2.5-flash-preview-tts`. Save.
+2. **Account → Defaults for new books → Voice engine** → "Gemini (cloud)".
+3. **Voice model** → pick `gemini-3.1-flash-preview-tts` or `gemini-2.5-flash-preview-tts`. Save.
 
 The key is stored plaintext in `~/.castwright/user-settings.json` (per-user, same trust model as `server/.env` for a single-user workspace). The env var `GEMINI_API_KEY` in `server/.env` still wins if both are set — useful for CI / scripted setups.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ or MP3.
   tap-to-assign, per-character overrides, and sample playback. Audition candidate
   voices in the profile drawer before committing, and compare two characters side
   by side — even across books.
-- **TTS engines** — Kokoro (fast, English, runs on a modest GPU), Coqui XTTS v2
+- **Voice engines** — Kokoro (fast, English, runs on a modest GPU), Coqui XTTS v2
   (zero-shot voice cloning, optional download), Qwen3-TTS (designs a unique voice
   per character from a persona and reuses it across the series), and Gemini cloud.
   A character keeps its voice when you switch engines.
@@ -74,13 +74,13 @@ or MP3.
 Download the latest `castwright-vX.Y.Z.zip` from
 [Releases](https://github.com/dudarenok-maker/Castwright/releases), extract it,
 and follow **[INSTALL.md](INSTALL.md)**. You'll end up with a single
-`npm run start:prod` command that brings up the server, the TTS sidecar, and the
+`npm run start:prod` command that brings up the server, the voice engine, and the
 web UI at <http://localhost:8080>.
 
 **Prerequisites** (full detail and per-OS steps in [INSTALL.md](INSTALL.md)):
 
 - Node.js 20.19+
-- Python 3.11 (for the TTS sidecar)
+- Python 3.11 (for the voice engine)
 - ffmpeg on `PATH`
 - ~3 GB free disk for the TTS weights
 - A GPU is strongly recommended (TTS on CPU is far slower): NVIDIA on Windows/Linux, or Apple Silicon (M-series) on macOS — used automatically via Metal, no drivers or setup
@@ -116,7 +116,7 @@ After the first public release, upgrading is one click inside the app
 ## How it's built
 
 Castwright is a Vite + React frontend, a Node/Express server, and a Python
-(FastAPI) TTS sidecar, with a native Flutter companion app. Building from source,
+(FastAPI) voice engine, with a native Flutter companion app. Building from source,
 the branching model, and the commit convention are documented in
 **[CONTRIBUTING.md](CONTRIBUTING.md)**.
 

--- a/docs/superpowers/plans/2026-06-12-model-manager-ollama-voice-engine.md
+++ b/docs/superpowers/plans/2026-06-12-model-manager-ollama-voice-engine.md
@@ -282,12 +282,7 @@ async function mockUnloadAnalyzer(opts: { model?: string } = {}): Promise<ModelC
 
 Also update `mockRemoveModel` (:5436): the loaded guard for `ollama:qwen3.5:4b` should read the Set so an unloaded default can be removed — change the hard-coded `model-loaded` return to `if (id === 'ollama:qwen3.5:4b' && MOCK_OLLAMA_RESIDENT.has('qwen3.5:4b')) return { ok:false, code:'model-loaded', error:'qwen3.5:4b is loaded.' };`
 
-- [ ] **Step 6: Update the `Api` interface** — find the `loadAnalyzer` / `unloadAnalyzer` signatures in the `Api`/`type` block and change to:
-
-```ts
-  loadAnalyzer: (opts?: { model?: string }) => Promise<ModelControlResult>;
-  unloadAnalyzer: (opts?: { model?: string }) => Promise<ModelControlResult>;
-```
+- [ ] **Step 6: (No interface to edit.)** The public type is `export type Api = typeof api` (`api.ts:6443`) — derived, not hand-written. There is **no `Api` interface** to update. The only requirement is that `realLoadAnalyzer`/`realUnloadAnalyzer` (Step 1) and `mockLoadAnalyzer`/`mockUnloadAnalyzer` (Step 3) share the identical `opts?: { model?: string }` signature, so `typeof api` resolves cleanly. Verify both pairs match before moving on.
 
 - [ ] **Step 7: Typecheck**
 
@@ -310,29 +305,42 @@ git commit -m "feat(frontend): analyzer load/unload accept a model; mock per-mod
 - Modify: `src/components/ModelControlPill.tsx:172` (button aria-label, A4)
 - Test: `src/views/model-manager.test.tsx`
 
-- [ ] **Step 1: Write the failing test** — add to `model-manager.test.tsx` (mirror the existing inventory-mocking pattern in that file; the helper that stubs `api.getModelInventory` returns an items array — include a non-default analyzer row):
+- [ ] **Step 1: Write the failing test** — add to `model-manager.test.tsx`. Use the file's existing `renderManager()` helper and the `mockInventory`/`vi.mocked` pattern (the api module is `vi.mock`-ed at the top of the file; `loadAnalyzer`/`unloadAnalyzer` are already stubbed there). **Do not mutate the shared `INVENTORY` const — build a one-off inventory inline** so other tests' row counts don't change:
 
 ```ts
-it('shows a Load/Unload pill on a NON-default Ollama row and calls the API with that model', async () => {
-  const loadSpy = vi.fn().mockResolvedValue({ status: 'ready' });
-  // stub api.getModelInventory to return a non-default, not-loaded ollama row
-  // (follow the file's existing mock-inventory helper) with:
-  //   { id: 'ollama:llama3.1:8b', kind: 'analyzer', label: 'llama3.1:8b',
-  //     present: true, loaded: false, isDefaultEngine: false, sizeBytes: 1,
-  //     diskPath: null, isFallbackEngine: false, removable: true, updatable: true }
-  // and api.loadAnalyzer = loadSpy, sidecarReachable: true.
-  renderModelManager();
+it('shows a Load pill on a NON-default Ollama row and calls loadAnalyzer with that model', async () => {
+  mockInventory.mockResolvedValue({
+    ...INVENTORY,
+    items: [
+      ...INVENTORY.items,
+      {
+        id: 'ollama:llama3.1:8b',
+        kind: 'analyzer',
+        label: 'llama3.1:8b',
+        present: true,
+        sizeBytes: 4_700_000_000,
+        diskPath: null,
+        loaded: false,
+        isDefaultEngine: false, // NON-default — the whole point
+        isFallbackEngine: false,
+        removable: true,
+        updatable: true,
+      },
+    ],
+  });
+  vi.mocked(api.loadAnalyzer).mockResolvedValue({ status: 'ready' });
+
+  renderManager();
   const row = await screen.findByTestId('model-row-ollama:llama3.1:8b');
-  const loadBtn = within(row).getByRole('button', { name: /load model/i });
-  fireEvent.click(loadBtn);
-  await waitFor(() => expect(loadSpy).toHaveBeenCalledWith({ model: 'llama3.1:8b' }));
+  within(row).getByRole('button', { name: /load model/i }).click();
+  await waitFor(() => expect(api.loadAnalyzer).toHaveBeenCalledWith({ model: 'llama3.1:8b' }));
 });
 ```
 
 - [ ] **Step 2: Run, verify failure**
 
 Run: `npx vitest run src/views/model-manager.test.tsx -t "NON-default Ollama row"`
-Expected: FAIL — no pill renders on a non-default analyzer row (`hasControl` is false), so the button query throws.
+Expected: FAIL — no pill renders on a non-default analyzer row (`hasControl` is false today), so the `getByRole('button', { name: /load model/i })` query throws.
 
 - [ ] **Step 3: Implement the gate + model threading** — in `ModelRow` (`model-manager.tsx`), replace lines 296-315:
 
@@ -395,19 +403,23 @@ git commit -m "feat(frontend): Load/Unload pill on every Ollama model in the Mod
 **Files:**
 - Modify: `e2e/model-manager-dual-model.spec.ts` (add a case) OR Create: `e2e/model-manager-ollama-load.spec.ts`
 
-- [ ] **Step 1: Write the spec** (model on the existing model-manager spec's navigation to `#/models`):
+- [ ] **Step 1: Write the spec.** Navigate exactly like `e2e/model-manager-dual-model.spec.ts` (it opens the Model Manager at `/#/models` and uses `waitForRouteReady` from `./helpers`). The 2nd mock Ollama model `llama3.1:8b` (added in Task 3) starts NOT resident; `ModelRow` already exposes `data-loaded` (`model-manager.tsx:321`). Because the mock api keeps `MOCK_OLLAMA_RESIDENT` in the same JS context, the `onAction`→refetch after each click flips `data-loaded`:
 
 ```ts
 import { test, expect } from '@playwright/test';
+import { waitForRouteReady } from './helpers';
 
 test('loads and unloads a non-default Ollama model from the Model Manager', async ({ page }) => {
   await page.goto('/#/models');
+  await waitForRouteReady(page);
+
   const row = page.getByTestId('model-row-ollama:llama3.1:8b');
   await expect(row).toBeVisible();
-  // starts not resident
   await expect(row).toHaveAttribute('data-loaded', 'false');
+
   await row.getByRole('button', { name: /load model/i }).click();
   await expect(row).toHaveAttribute('data-loaded', 'true');
+
   await row.getByRole('button', { name: /stop/i }).click();
   await expect(row).toHaveAttribute('data-loaded', 'false');
 });
@@ -416,7 +428,7 @@ test('loads and unloads a non-default Ollama model from the Model Manager', asyn
 - [ ] **Step 2: Run it**
 
 Run: `npm run test:e2e -- model-manager-ollama-load`
-Expected: PASS. (If the inventory poll cadence makes the assertion racy, the `onAction` refetch already runs after each click — assert on `data-loaded` which the row already exposes.)
+Expected: PASS.
 
 - [ ] **Step 3: Commit**
 
@@ -435,8 +447,10 @@ Apply the mapping by sense (see spec): "TTS sidecar"/"TTS engine"/"TTS model" �
 
 **Files (exact strings):**
 - `src/components/ModelControlPill.tsx:118` — `kindNoun`: `return kind === 'tts' ? 'TTS model' : 'Analyzer';` → `'Voice engine'`.
-- `src/modals/profile-drawer.tsx` — the `<label>` "TTS engine for this character" → "Voice engine for this character"; `:1733` `'Loading TTS model (~30s)…'` → `'Loading voice engine (~30s)…'`; `:1271` "…the TTS voice line above…" → "…the voice line above…".
+- `src/components/voice-engine-picker.tsx` — **`:103`** (visible `<label>`) AND **`:107`** (`aria-label`): "TTS engine for this character" → "Voice engine for this character" (both must change, or `getByLabelText` queries break). *(This label is here, NOT in profile-drawer.tsx — verified.)*
+- `src/modals/profile-drawer.tsx` — `:1733` `'Loading TTS model (~30s)…'` → `'Loading voice engine (~30s)…'`; `:1271` "…the TTS voice line above…" → "…the voice line above…".
 - `src/views/generation.tsx` — `:1421` "Recovering — restarting TTS engine…" → "Recovering — restarting voice engine…"; `:925` "The TTS engine may be synthesising…" → "The voice engine may be synthesising…"; `:935` "…current TTS model." → "…current voice engine."
+- `src/lib/play-sample-with-auto-load.ts:116` — `'TTS sidecar (:9000) is unreachable — restart it via scripts\\start-app.ps1 (or kill any stale process holding :9000). [...]'` → "Voice engine (:9000) is unreachable — …". **Preserve "is unreachable"** (matched downstream). Leave the sibling `:109` "Node server (:8080) is unreachable" string untouched (no "TTS").
 - `src/modals/queue-modal.tsx:549` — `'Mixes TTS engines. Turn on "Keep both TTS engines loaded"…'` → `'Mixes voice engines. Turn on "Keep both voice engines loaded"…'`.
 - `src/views/voices.tsx` — `:903`/`:927` `'Loading TTS…'` → `'Loading voice engine…'`; `:1944` "switch your TTS model to assign these" → "switch your voice engine to assign these".
 - `src/data/help-topics.ts` — `:16`/`:36`/`:38` "TTS sidecar" → "voice engine" (visible help copy).
@@ -445,7 +459,8 @@ Apply the mapping by sense (see spec): "TTS sidecar"/"TTS engine"/"TTS model" �
 
 **Paired test/fixture updates (same commit):**
 - `src/data/help-failures.test.ts` — the recycle-storm title pin.
-- `src/modals/profile-drawer.test.tsx:1047` — `getByLabelText('TTS engine for this character')` → `'Voice engine for this character'`.
+- `src/components/voice-engine-picker.test.tsx:29`/`:48` AND `src/modals/profile-drawer.test.tsx:1047` — `getByLabelText('TTS engine for this character')` → `'Voice engine for this character'`.
+- `src/lib/play-sample-with-auto-load.test.ts:137` (the "sidecar-specific recovery hint" assertion) and `src/components/voice-preview-button.test.tsx:102` (the error fixture text) — update to the new "Voice engine (:9000) is unreachable…" wording.
 - `src/views/generation.test.tsx:416` — `'Recovering — restarting TTS engine…'` → `'Recovering — restarting voice engine…'`.
 - `src/views/model-manager.test.tsx:274` — `describe('… — TTS sidecar preferences')` → "voice engine preferences" (cosmetic).
 - e2e: `e2e/cast.spec.ts:44`, `e2e/voice-design-progress.spec.ts:64`, `e2e/single-voice-design-background.spec.ts:57` — the `getByLabel('TTS engine for this character')` query.
@@ -481,12 +496,12 @@ git commit -m "refactor(frontend): rename user-facing TTS copy to 'voice engine'
 - `server/tts-sidecar/main.py` — `:2815`/`:3118`/`:3218`/`:3318` `"TTS sidecar is recycling to free memory; retry shortly."` → `"Voice engine is recycling to free memory; retry shortly."`; `:3102`/`:3209`/`:3303` `"TTS sidecar is in a poisoned CUDA state…"` → `"Voice engine is in a poisoned CUDA state…"` (keep the surrounding `"poisoned": true` JSON field untouched).
 - `server/src/routes/chapter-splice.ts:122` — "modelKey must be a supported TTS model id for a re-record." → "…supported voice-engine model id…".
 - `server/src/routes/chapter-qa-repair.ts:209` — "modelKey must be a supported TTS model id to repair." → "…supported voice-engine model id…".
-- Locate the "TTS sidecar (…) is unreachable" / "stopped responding to /health during voice design." producers (grep `server/src` for `is unreachable` / `stopped responding`); rename the "TTS sidecar" prefix → "Voice engine", **keeping** "unreachable"/"stopped responding".
+- The voice-design health-check producer behind `cast-design.test.ts:270`/`:304` throws `"TTS sidecar (<url>) is unreachable"` and `"TTS sidecar (<url>) stopped responding to /health during voice design."`. Find it with the grep in Step 1, rename the `"TTS sidecar"` prefix → `"Voice engine"`, **keeping** the `is unreachable` / `stopped responding` tokens (matched by `SIDECAR_DOWN_RE` at `cast-design.ts:94`).
 
 **Paired test updates (same commit):**
-- `server/src/routes/failure-taxonomy.test.ts:96` and `server/src/routes/generation-error.test.ts:143` and `server/src/tts/synthesise-chapter.test.ts:563` — the poisoned-state prose.
+- `server/src/routes/failure-taxonomy.test.ts:96` and `server/src/routes/generation-error.test.ts:143` and `server/src/tts/synthesise-chapter.test.ts:563` — the poisoned-state prose (keep the `"poisoned":true` JSON).
 - `server/src/tts/ensure-sidecar-loaded.test.ts:76` — the recycling prose.
-- `server/src/routes/cast-design.test.ts:270`/`:304` — the "TTS sidecar … unreachable / stopped responding" prose.
+- `server/src/routes/cast-design.test.ts:270`/`:304` — the simulated "TTS sidecar … unreachable / stopped responding" error fixtures → "Voice engine …".
 - `src/store/chapters-slice.test.ts:523` — the `errorReason: 'TTS sidecar timed out'` fixture → "Voice engine timed out".
 - Sidecar pytest: grep `server/tts-sidecar/tests` for the recycling/poisoned prose and update any exact-string assertions.
 

--- a/docs/superpowers/plans/2026-06-12-model-manager-ollama-voice-engine.md
+++ b/docs/superpowers/plans/2026-06-12-model-manager-ollama-voice-engine.md
@@ -1,0 +1,562 @@
+# Model Manager Ollama controls + "Voice engine" rename — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every installed Ollama model its own Load/Unload control in the Model Manager, and finish renaming user-facing "TTS" copy to "Voice engine" across the app, server/sidecar error text, and docs.
+
+**Architecture:** Two independent changes on one branch. Part A threads an optional `{ model }` through the `POST /api/ollama/{load,unload}` routes and the `api.loadAnalyzer`/`unloadAnalyzer` client wrappers, flips the Model Manager pill gate from "default analyzer only" to "every analyzer row", and makes a no-model unload evict ALL resident Ollama models (closing a co-residency OOM gap). Part B is a careful, sense-by-sense copy sweep that preserves every load-bearing token matched by detection logic.
+
+**Tech Stack:** Vite + React 18 + TS (frontend), Express + Vitest (server), pytest (Python sidecar), Playwright (e2e). Spec: `docs/superpowers/specs/2026-06-12-model-manager-ollama-voice-engine-design.md`.
+
+**Branch:** `feat/frontend-model-manager-ollama-controls` (already cut from `main`).
+
+**Reference facts (verified against code):**
+- `express.json` is global (`server/src/index.ts:120`) — routes can read `req.body`.
+- `probeOllamaHealth()` (`ollama-health.ts:77`) already returns `resident: string[]` from `/api/ps` — reuse it for evict-all.
+- Ollama tags contain colons (`qwen3.5:4b`); parse the model id with `slice('ollama:'.length)`, never `split(':')`.
+- Detection invariants to PRESERVE in Part B (never delete these tokens): `unreachable`, `stopped responding`, `did not complete within`, `RecycleStormError`, `recycled N×`, `"poisoned":true`, `ECONNREFUSED`, `fetch failed`, `sidecar not reachable`.
+
+---
+
+## Part A — Per-model Ollama Load/Unload
+
+### Task 1: `/api/ollama/load` accepts an optional `{ model }`
+
+**Files:**
+- Modify: `server/src/routes/ollama-health.ts:226-244`
+- Test: `server/src/routes/ollama-health.test.ts` (the `POST /api/ollama/load` describe at :138)
+
+- [ ] **Step 1: Write the failing test** — add inside the existing `describe('POST /api/ollama/load')`:
+
+```ts
+it('targets the model from the request body when provided, still threading num_ctx/num_gpu', async () => {
+  fetchMock.mockResolvedValue(new Response('', { status: 200 }));
+
+  const res = await request(makeApp())
+    .post('/api/ollama/load')
+    .send({ model: 'llama3.1:8b' });
+
+  expect(res.status).toBe(200);
+  const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+  expect(body.model).toBe('llama3.1:8b');
+  expect(body.keep_alive).toBe('5m');
+  expect(body.options?.num_ctx).toBe(16384);
+  expect(body.options?.num_gpu).toBe(999);
+});
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `cd server && npx vitest run src/routes/ollama-health.test.ts -t "targets the model from the request body"`
+Expected: FAIL — `body.model` is the configured default (`qwen3.5:4b`), not `llama3.1:8b`.
+
+- [ ] **Step 3: Implement** — change the `/load` handler signature + model resolution:
+
+```ts
+ollamaHealthRouter.post('/load', async (req: Request, res: Response) => {
+  const url = getResolvedOllamaUrl();
+  const requested = typeof req.body?.model === 'string' ? req.body.model.trim() : '';
+  const model = requested || getResolvedOllamaModel();
+  const result = await callOllamaGenerate(
+    url,
+    {
+      model,
+      prompt: '',
+      keep_alive: '5m',
+      stream: false,
+      options: { num_ctx: resolveAnalyzerNumCtx(), num_gpu: resolveAnalyzerNumGpu() },
+    },
+    LOAD_TIMEOUT_MS,
+  );
+  if (!result.ok) {
+    return res.status(result.status).json({ status: 'error', error: result.error });
+  }
+  return res.json({ status: 'ready' });
+});
+```
+
+- [ ] **Step 4: Run the load tests, verify green**
+
+Run: `cd server && npx vitest run src/routes/ollama-health.test.ts -t "POST /api/ollama/load"`
+Expected: PASS (the new test + the two existing no-body tests, which still resolve to the default).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/ollama-health.ts server/src/routes/ollama-health.test.ts
+git commit -m "feat(server): /api/ollama/load accepts an explicit model target"
+```
+
+---
+
+### Task 2: `/api/ollama/unload` — explicit model OR evict all resident
+
+**Files:**
+- Modify: `server/src/routes/ollama-health.ts:249-261`
+- Test: `server/src/routes/ollama-health.test.ts` (the `POST /api/ollama/unload` describe at :179)
+
+- [ ] **Step 1: Write the failing tests** — replace the existing `'POSTs /api/generate with keep_alive: 0…'` test body and add a second:
+
+```ts
+it('evicts a single model when one is named in the body', async () => {
+  fetchMock.mockResolvedValue(new Response('', { status: 200 }));
+
+  const res = await request(makeApp())
+    .post('/api/ollama/unload')
+    .send({ model: 'llama3.1:8b' });
+
+  expect(res.status).toBe(200);
+  // exactly one /api/generate eviction, for that model
+  const genCalls = fetchMock.mock.calls.filter((c) => String(c[0]).endsWith('/api/generate'));
+  expect(genCalls).toHaveLength(1);
+  const body = JSON.parse(genCalls[0][1].body);
+  expect(body.model).toBe('llama3.1:8b');
+  expect(body.keep_alive).toBe(0);
+});
+
+it('with no model, evicts EVERY resident model reported by /api/ps', async () => {
+  fetchMock.mockImplementation((url: string) => {
+    if (String(url).endsWith('/api/tags')) {
+      return Promise.resolve(new Response(JSON.stringify({ models: [] }), { status: 200 }));
+    }
+    if (String(url).endsWith('/api/ps')) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ models: [{ name: 'qwen3.5:4b' }, { name: 'llama3.1:8b' }] }), { status: 200 }),
+      );
+    }
+    return Promise.resolve(new Response('', { status: 200 })); // /api/generate
+  });
+
+  const res = await request(makeApp()).post('/api/ollama/unload');
+
+  expect(res.status).toBe(200);
+  const evicted = fetchMock.mock.calls
+    .filter((c) => String(c[0]).endsWith('/api/generate'))
+    .map((c) => JSON.parse(c[1].body).model);
+  expect(evicted.sort()).toEqual(['llama3.1:8b', 'qwen3.5:4b']);
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `cd server && npx vitest run src/routes/ollama-health.test.ts -t "POST /api/ollama/unload"`
+Expected: FAIL — the no-body path currently evicts only the configured default; the evict-all test sees one call, not two.
+
+- [ ] **Step 3: Implement** — rewrite the `/unload` handler:
+
+```ts
+ollamaHealthRouter.post('/unload', async (req: Request, res: Response) => {
+  const url = getResolvedOllamaUrl();
+  const requested = typeof req.body?.model === 'string' ? req.body.model.trim() : '';
+  // Explicit model → evict just that one. No model → evict every resident
+  // model (so the TTS auto-evict path frees ALL analyzer VRAM, not just the
+  // configured default — a manually-warmed non-default model would otherwise
+  // stay co-resident and OOM the GPU).
+  const targets = requested ? [requested] : (await probeOllamaHealth()).resident ?? [];
+  for (const model of targets) {
+    const result = await callOllamaGenerate(
+      url,
+      { model, prompt: '', keep_alive: 0, stream: false },
+      PROBE_TIMEOUT_MS,
+    );
+    if (!result.ok) {
+      return res.status(result.status).json({ status: 'error', error: result.error });
+    }
+  }
+  return res.json({ status: 'unloaded', unloaded: targets });
+});
+```
+
+- [ ] **Step 4: Run, verify green**
+
+Run: `cd server && npx vitest run src/routes/ollama-health.test.ts -t "POST /api/ollama/unload"`
+Expected: PASS. Note the existing `'returns 503 when Ollama is unreachable'` test sends no body — `probeOllamaHealth()` will return `resident: []` (its fetch is rejected), so `targets` is empty and the route returns `{status:'unloaded', unloaded:[]}` with status 200. **Update that test** to send an explicit model so it still exercises the upstream-error path:
+
+```ts
+const res = await request(makeApp()).post('/api/ollama/unload').send({ model: 'qwen3.5:4b' });
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/ollama-health.ts server/src/routes/ollama-health.test.ts
+git commit -m "feat(server): /api/ollama/unload evicts a named model, or all resident when none given"
+```
+
+---
+
+### Task 3: `api.ts` — thread `{ model }`, add a 2nd mock Ollama model, per-model residency
+
+**Files:**
+- Modify: `src/lib/api.ts` — `realLoadAnalyzer`/`realUnloadAnalyzer` (:5491-5503), `mockLoadAnalyzer`/`mockUnloadAnalyzer` (:5541-5551), the `MOCK_OLLAMA_MODEL_LOADED` flag (:5458), the mock inventory ollama row (:5407-5419), `mockGetOllamaHealth` resident (≈:5561), and the `Api` interface signatures for `loadAnalyzer`/`unloadAnalyzer`.
+
+- [ ] **Step 1: Update the real wrappers to accept a model**
+
+```ts
+async function realLoadAnalyzer(opts: { model?: string } = {}): Promise<ModelControlResult> {
+  const res = await fetch('/api/ollama/load', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(opts.model ? { model: opts.model } : {}),
+  });
+  return (await res
+    .json()
+    .catch(() => ({ status: 'error', error: `HTTP ${res.status}` }))) as ModelControlResult;
+}
+
+async function realUnloadAnalyzer(opts: { model?: string } = {}): Promise<ModelControlResult> {
+  const res = await fetch('/api/ollama/unload', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(opts.model ? { model: opts.model } : {}),
+  });
+  return (await res
+    .json()
+    .catch(() => ({ status: 'error', error: `HTTP ${res.status}` }))) as ModelControlResult;
+}
+```
+
+- [ ] **Step 2: Replace the single mock boolean with a resident Set** — replace `let MOCK_OLLAMA_MODEL_LOADED = false;` (:5458) with:
+
+```ts
+/* Per-model residency for the mock analyzer rows so the Model Manager's
+   Load/Stop pills round-trip independently under VITE_USE_MOCKS=true. Starts
+   with the default model resident, mirroring the inventory's loaded:true. */
+const MOCK_OLLAMA_RESIDENT = new Set<string>(['qwen3.5:4b']);
+```
+
+- [ ] **Step 3: Update the mock load/unload to mutate the Set**
+
+```ts
+async function mockLoadAnalyzer(opts: { model?: string } = {}): Promise<ModelControlResult> {
+  await wait(60);
+  MOCK_OLLAMA_RESIDENT.add(opts.model ?? 'qwen3.5:4b');
+  return { status: 'ready' };
+}
+
+async function mockUnloadAnalyzer(opts: { model?: string } = {}): Promise<ModelControlResult> {
+  await wait(40);
+  if (opts.model) MOCK_OLLAMA_RESIDENT.delete(opts.model);
+  else MOCK_OLLAMA_RESIDENT.clear();
+  return { status: 'unloaded' };
+}
+```
+
+- [ ] **Step 4: Add a 2nd, non-default mock Ollama row and derive `loaded` from the Set** — in the mock inventory items array, replace the single `ollama:qwen3.5:4b` entry (:5407-5419) with two entries:
+
+```ts
+      {
+        id: 'ollama:qwen3.5:4b',
+        kind: 'analyzer',
+        label: 'qwen3.5:4b',
+        present: true,
+        sizeBytes: 2_600_000_000,
+        diskPath: null,
+        loaded: MOCK_OLLAMA_RESIDENT.has('qwen3.5:4b'),
+        isDefaultEngine: true,
+        isFallbackEngine: false,
+        removable: true,
+        updatable: true,
+      },
+      {
+        id: 'ollama:llama3.1:8b',
+        kind: 'analyzer',
+        label: 'llama3.1:8b',
+        present: true,
+        sizeBytes: 4_700_000_000,
+        diskPath: null,
+        loaded: MOCK_OLLAMA_RESIDENT.has('llama3.1:8b'),
+        isDefaultEngine: false,
+        isFallbackEngine: false,
+        removable: true,
+        updatable: true,
+      },
+```
+
+- [ ] **Step 5: Wire mock Ollama health residency to the Set** — find `mockGetOllamaHealth` (≈:5561) and change its `resident`/`modelResident` to read the Set:
+
+```ts
+    resident: Array.from(MOCK_OLLAMA_RESIDENT),
+    modelResident: MOCK_OLLAMA_RESIDENT.has('qwen3.5:4b'),
+```
+
+Also update `mockRemoveModel` (:5436): the loaded guard for `ollama:qwen3.5:4b` should read the Set so an unloaded default can be removed — change the hard-coded `model-loaded` return to `if (id === 'ollama:qwen3.5:4b' && MOCK_OLLAMA_RESIDENT.has('qwen3.5:4b')) return { ok:false, code:'model-loaded', error:'qwen3.5:4b is loaded.' };`
+
+- [ ] **Step 6: Update the `Api` interface** — find the `loadAnalyzer` / `unloadAnalyzer` signatures in the `Api`/`type` block and change to:
+
+```ts
+  loadAnalyzer: (opts?: { model?: string }) => Promise<ModelControlResult>;
+  unloadAnalyzer: (opts?: { model?: string }) => Promise<ModelControlResult>;
+```
+
+- [ ] **Step 7: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS (no callers break — existing `api.unloadAnalyzer()` / `loadAnalyzer()` no-arg calls still satisfy the optional param).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/api.ts
+git commit -m "feat(frontend): analyzer load/unload accept a model; mock per-model residency + 2nd ollama model"
+```
+
+---
+
+### Task 4: Model Manager — pill on every Ollama row, sliced model name, per-kind unreachable
+
+**Files:**
+- Modify: `src/views/model-manager.tsx:294-315`
+- Modify: `src/components/ModelControlPill.tsx:172` (button aria-label, A4)
+- Test: `src/views/model-manager.test.tsx`
+
+- [ ] **Step 1: Write the failing test** — add to `model-manager.test.tsx` (mirror the existing inventory-mocking pattern in that file; the helper that stubs `api.getModelInventory` returns an items array — include a non-default analyzer row):
+
+```ts
+it('shows a Load/Unload pill on a NON-default Ollama row and calls the API with that model', async () => {
+  const loadSpy = vi.fn().mockResolvedValue({ status: 'ready' });
+  // stub api.getModelInventory to return a non-default, not-loaded ollama row
+  // (follow the file's existing mock-inventory helper) with:
+  //   { id: 'ollama:llama3.1:8b', kind: 'analyzer', label: 'llama3.1:8b',
+  //     present: true, loaded: false, isDefaultEngine: false, sizeBytes: 1,
+  //     diskPath: null, isFallbackEngine: false, removable: true, updatable: true }
+  // and api.loadAnalyzer = loadSpy, sidecarReachable: true.
+  renderModelManager();
+  const row = await screen.findByTestId('model-row-ollama:llama3.1:8b');
+  const loadBtn = within(row).getByRole('button', { name: /load model/i });
+  fireEvent.click(loadBtn);
+  await waitFor(() => expect(loadSpy).toHaveBeenCalledWith({ model: 'llama3.1:8b' }));
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `npx vitest run src/views/model-manager.test.tsx -t "NON-default Ollama row"`
+Expected: FAIL — no pill renders on a non-default analyzer row (`hasControl` is false), so the button query throws.
+
+- [ ] **Step 3: Implement the gate + model threading** — in `ModelRow` (`model-manager.tsx`), replace lines 296-315:
+
+```ts
+  const engine = TTS_ENGINE_BY_ID[item.id];
+  const isAnalyzer = item.kind === 'analyzer';
+  /* A Load/Unload pill is meaningful for the sidecar TTS engines and for every
+     installed Ollama analyzer model (all analyzer rows are Ollama; cloud Gemini
+     is not a disk artifact and never appears in the inventory). */
+  const hasControl = item.present && (engine !== undefined || isAnalyzer);
+
+  /* Analyzer residency depends on the Ollama daemon, not the TTS sidecar — an
+     unreachable daemon already yields zero analyzer rows, so analyzer rows are
+     never 'unreachable' here. Only TTS rows gate on sidecar reachability. */
+  const reachable = isAnalyzer ? true : sidecarReachable;
+  const controlState: ModelControlState = !reachable
+    ? 'unreachable'
+    : busy
+      ? 'loading'
+      : item.loaded
+        ? 'ready'
+        : 'idle';
+  const controlKind: ModelKind = isAnalyzer ? 'analyzer' : 'tts';
+
+  /* Ollama tags contain colons (ollama:qwen3.5:4b) — slice the prefix, never
+     split(':'). Mirrors performRemoval in models-inventory.ts. */
+  const analyzerModel = isAnalyzer ? item.id.slice('ollama:'.length) : undefined;
+  const doLoad = () =>
+    onAction(() =>
+      engine ? api.loadSidecar({ engine }) : api.loadAnalyzer(analyzerModel ? { model: analyzerModel } : undefined),
+    );
+  const doStop = () =>
+    onAction(() =>
+      engine ? api.unloadSidecar({ engine }) : api.unloadAnalyzer(analyzerModel ? { model: analyzerModel } : undefined),
+    );
+```
+
+- [ ] **Step 4: A4 — thread engineLabel into the button aria** — in `ModelControlPill.tsx:172`, change the button `aria-label`:
+
+```tsx
+        aria-label={`${action.label} (${engineLabel ?? kindNoun(kind)})`}
+```
+
+- [ ] **Step 5: Run, verify green**
+
+Run: `npx vitest run src/views/model-manager.test.tsx`
+Expected: PASS (new test + existing Model Manager tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/views/model-manager.tsx src/components/ModelControlPill.tsx src/views/model-manager.test.tsx
+git commit -m "feat(frontend): Load/Unload pill on every Ollama model in the Model Manager"
+```
+
+---
+
+### Task 5: e2e — drive Load/Unload on a non-default Ollama row (mock mode)
+
+**Files:**
+- Modify: `e2e/model-manager-dual-model.spec.ts` (add a case) OR Create: `e2e/model-manager-ollama-load.spec.ts`
+
+- [ ] **Step 1: Write the spec** (model on the existing model-manager spec's navigation to `#/models`):
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test('loads and unloads a non-default Ollama model from the Model Manager', async ({ page }) => {
+  await page.goto('/#/models');
+  const row = page.getByTestId('model-row-ollama:llama3.1:8b');
+  await expect(row).toBeVisible();
+  // starts not resident
+  await expect(row).toHaveAttribute('data-loaded', 'false');
+  await row.getByRole('button', { name: /load model/i }).click();
+  await expect(row).toHaveAttribute('data-loaded', 'true');
+  await row.getByRole('button', { name: /stop/i }).click();
+  await expect(row).toHaveAttribute('data-loaded', 'false');
+});
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `npm run test:e2e -- model-manager-ollama-load`
+Expected: PASS. (If the inventory poll cadence makes the assertion racy, the `onAction` refetch already runs after each click — assert on `data-loaded` which the row already exposes.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/
+git commit -m "test(e2e): Load/Unload a non-default Ollama model in the Model Manager"
+```
+
+---
+
+## Part B — "TTS" → "Voice engine" copy sweep
+
+Apply the mapping by sense (see spec): "TTS sidecar"/"TTS engine"/"TTS model" → "voice engine"; "TTS voice" → "voice"; "Loading TTS…" → "Loading voice engine…". **Capitalize to match context.** Touch only user-visible strings — never identifiers, type/field names, OpenAPI `description:`, or comments.
+
+### Task 6: App-rendered strings + paired tests
+
+**Files (exact strings):**
+- `src/components/ModelControlPill.tsx:118` — `kindNoun`: `return kind === 'tts' ? 'TTS model' : 'Analyzer';` → `'Voice engine'`.
+- `src/modals/profile-drawer.tsx` — the `<label>` "TTS engine for this character" → "Voice engine for this character"; `:1733` `'Loading TTS model (~30s)…'` → `'Loading voice engine (~30s)…'`; `:1271` "…the TTS voice line above…" → "…the voice line above…".
+- `src/views/generation.tsx` — `:1421` "Recovering — restarting TTS engine…" → "Recovering — restarting voice engine…"; `:925` "The TTS engine may be synthesising…" → "The voice engine may be synthesising…"; `:935` "…current TTS model." → "…current voice engine."
+- `src/modals/queue-modal.tsx:549` — `'Mixes TTS engines. Turn on "Keep both TTS engines loaded"…'` → `'Mixes voice engines. Turn on "Keep both voice engines loaded"…'`.
+- `src/views/voices.tsx` — `:903`/`:927` `'Loading TTS…'` → `'Loading voice engine…'`; `:1944` "switch your TTS model to assign these" → "switch your voice engine to assign these".
+- `src/data/help-topics.ts` — `:16`/`:36`/`:38` "TTS sidecar" → "voice engine" (visible help copy).
+- `src/data/help-failures.ts:17` — `'recycle-storm': 'TTS engine keeps restarting'` → `'Voice engine keeps restarting'`.
+- `src/components/model-settings-form.tsx` — scan for any remaining visible "TTS" (the engine sub-label is already "voice engine"; confirm nothing visible says "TTS").
+
+**Paired test/fixture updates (same commit):**
+- `src/data/help-failures.test.ts` — the recycle-storm title pin.
+- `src/modals/profile-drawer.test.tsx:1047` — `getByLabelText('TTS engine for this character')` → `'Voice engine for this character'`.
+- `src/views/generation.test.tsx:416` — `'Recovering — restarting TTS engine…'` → `'Recovering — restarting voice engine…'`.
+- `src/views/model-manager.test.tsx:274` — `describe('… — TTS sidecar preferences')` → "voice engine preferences" (cosmetic).
+- e2e: `e2e/cast.spec.ts:44`, `e2e/voice-design-progress.spec.ts:64`, `e2e/single-voice-design-background.spec.ts:57` — the `getByLabel('TTS engine for this character')` query.
+
+- [ ] **Step 1: Grep the live surface to catch stragglers**
+
+Run: `npx rg -n "TTS (sidecar|engine|model|voice)|Loading TTS" src e2e`
+Cross-check every hit against the list above; visible string → rename, comment/identifier/api-types → leave.
+
+- [ ] **Step 2: Apply the renames** to the source files listed above (visible strings only).
+
+- [ ] **Step 3: Apply the paired test/fixture updates** so the asserted copy matches.
+
+- [ ] **Step 4: Run the affected unit suites**
+
+Run: `npm run test -- src/data/help-failures.test.ts src/views/generation.test.tsx src/modals/profile-drawer.test.tsx src/views/model-manager.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ e2e/
+git commit -m "refactor(frontend): rename user-facing TTS copy to 'voice engine'"
+```
+
+---
+
+### Task 7: Server + sidecar user-facing error text
+
+**INVARIANT (must hold):** change only the "TTS sidecar"/"TTS engine"/"TTS model" prose. Preserve every token detection logic matches: `unreachable`, `stopped responding`, `did not complete within`, `RecycleStormError`, `recycled N×`, `"poisoned":true`, `ECONNREFUSED`, `fetch failed`, `sidecar not reachable`. (Verified: `cast-design.ts:94` `SIDECAR_DOWN_RE` and `failure-taxonomy.ts` signatures key only on those tokens, never on "TTS".)
+
+**Files (exact strings):**
+- `server/tts-sidecar/main.py` — `:2815`/`:3118`/`:3218`/`:3318` `"TTS sidecar is recycling to free memory; retry shortly."` → `"Voice engine is recycling to free memory; retry shortly."`; `:3102`/`:3209`/`:3303` `"TTS sidecar is in a poisoned CUDA state…"` → `"Voice engine is in a poisoned CUDA state…"` (keep the surrounding `"poisoned": true` JSON field untouched).
+- `server/src/routes/chapter-splice.ts:122` — "modelKey must be a supported TTS model id for a re-record." → "…supported voice-engine model id…".
+- `server/src/routes/chapter-qa-repair.ts:209` — "modelKey must be a supported TTS model id to repair." → "…supported voice-engine model id…".
+- Locate the "TTS sidecar (…) is unreachable" / "stopped responding to /health during voice design." producers (grep `server/src` for `is unreachable` / `stopped responding`); rename the "TTS sidecar" prefix → "Voice engine", **keeping** "unreachable"/"stopped responding".
+
+**Paired test updates (same commit):**
+- `server/src/routes/failure-taxonomy.test.ts:96` and `server/src/routes/generation-error.test.ts:143` and `server/src/tts/synthesise-chapter.test.ts:563` — the poisoned-state prose.
+- `server/src/tts/ensure-sidecar-loaded.test.ts:76` — the recycling prose.
+- `server/src/routes/cast-design.test.ts:270`/`:304` — the "TTS sidecar … unreachable / stopped responding" prose.
+- `src/store/chapters-slice.test.ts:523` — the `errorReason: 'TTS sidecar timed out'` fixture → "Voice engine timed out".
+- Sidecar pytest: grep `server/tts-sidecar/tests` for the recycling/poisoned prose and update any exact-string assertions.
+
+- [ ] **Step 1: Grep server + sidecar for visible "TTS" error prose**
+
+Run: `npx rg -n "TTS sidecar|TTS engine|TTS model" server/src server/tts-sidecar --glob '!**/*.test.ts'`
+Classify each: visible message string → rename; comment/identifier → leave.
+
+- [ ] **Step 2: Apply the renames** (source), preserving the INVARIANT tokens.
+
+- [ ] **Step 3: Update the paired test assertions** listed above.
+
+- [ ] **Step 4: Run the server + taxonomy + sidecar suites**
+
+Run: `npm run test:server && npm run test:server-slow`
+Run (if venv bootstrapped): `npm run test:sidecar`
+Expected: PASS. If a failure-taxonomy test goes red, a detection token was dropped — restore it; only the "TTS" prose may change.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/ src/store/chapters-slice.test.ts
+git commit -m "refactor(server,sidecar): rename user-facing TTS error text to 'voice engine'"
+```
+
+---
+
+### Task 8: Docs
+
+**Files:**
+- `README.md:47` — "TTS engines" → "Voice engines" (heading/prose).
+- `INSTALL.md:247`/`:273`/`:282` — "Account → Defaults for new books → TTS engine" → the new UI label ("Voice engine").
+
+- [ ] **Step 1: Apply the doc edits.**
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md INSTALL.md
+git commit -m "docs: rename 'TTS engine' to 'Voice engine' in README + INSTALL"
+```
+
+---
+
+### Task 9: Full verification + plan/spec closeout
+
+- [ ] **Step 1: Run the full battery**
+
+Run: `npm run verify`
+Expected: typecheck + all tests + e2e + build green. Triage any failure as related (fix here) vs pre-existing (surface to user, do not bundle).
+
+- [ ] **Step 2: Update the spec status** — set the spec frontmatter `Status:` to "implemented" and add a one-line ship note (commit SHAs).
+
+- [ ] **Step 3: Final commit + push the branch; open a draft PR**
+
+```bash
+git add docs/superpowers/specs/2026-06-12-model-manager-ollama-voice-engine-design.md
+git commit -m "docs(docs): mark Model Manager Ollama + voice-engine spec implemented"
+git push -u origin feat/frontend-model-manager-ollama-controls
+gh pr create --draft --title "feat(frontend,server): per-model Ollama Load/Unload + 'Voice engine' rename" --body "<Summary + Test plan; links the spec>"
+```
+
+Run `npm run verify` until green, then `gh pr ready` for the single billed CI run.
+
+---
+
+## Self-review
+
+**Spec coverage:** A1 evict-all (Task 2) ✓ · A2 second mock model (Task 3) ✓ · A3 slice-not-split (Task 4) ✓ · A4 button aria (Task 4) ✓ · per-kind unreachable (Task 4) ✓ · `{model}` through routes+api (Tasks 1-3) ✓ · pill on every analyzer row (Task 4) ✓ · e2e (Task 5) ✓ · Part B app strings (Task 6) ✓ · server/sidecar error text + INVARIANT (Task 7) ✓ · docs (Task 8) ✓ · verify (Task 9) ✓.
+
+**Type consistency:** `loadAnalyzer`/`unloadAnalyzer` take `opts?: { model?: string }` in the real wrappers (Task 3 Step 1), mock wrappers (Task 3 Step 3), and the `Api` interface (Task 3 Step 6); callers in `model-manager.tsx` pass `{ model } | undefined` (Task 4 Step 3) — consistent. Route bodies read `req.body?.model` (Tasks 1-2) matching what the client POSTs (Task 3 Steps 1). `data-loaded` attribute used by the e2e spec (Task 5) already exists on `ModelRow` (`model-manager.tsx:321`).
+
+**Placeholder scan:** no TBD/TODO; every code step shows the code; test steps give exact commands + expected outcomes. The two grep steps (Task 6 Step 1, Task 7 Step 1) are straggler-catchers over an enumerated list, not "decide later".

--- a/docs/superpowers/specs/2026-06-12-model-manager-ollama-voice-engine-design.md
+++ b/docs/superpowers/specs/2026-06-12-model-manager-ollama-voice-engine-design.md
@@ -1,0 +1,130 @@
+# Model Manager: per-model Ollama Load/Unload + "Voice engine" terminology
+
+- **Date:** 2026-06-12
+- **Branch:** `feat/frontend-model-manager-ollama-controls`
+- **Status:** design approved, pending spec review
+
+Two independent, mechanical changes shipped together on one branch:
+
+1. Give **every installed Ollama model** its own Load/Unload control in the
+   Model Manager (today only the *default* analyzer model has one).
+2. Finish the **"TTS" → "Voice engine"** rename in user-facing copy (the Admin
+   health board was already renamed; the rest of the app — and the docs that
+   name the UI label — still say "TTS").
+
+---
+
+## Part A — Per-model Load/Unload for every Ollama model
+
+### Current behavior
+
+- The inventory lists each pulled Ollama tag as a row (`kind: 'analyzer'`,
+  `id: 'ollama:<name>'`) with live residency from `ollama ps`
+  (`models-inventory.ts` → `buildModelInventory`).
+- The Load/Unload pill renders only when `hasControl` is true, which for
+  analyzer rows requires `isAnalyzerDefault` — i.e. **only the configured
+  default model** gets a pill (`model-manager.tsx:301`).
+- `POST /api/ollama/load` and `/api/ollama/unload` (`ollama-health.ts:226`,
+  `:249`) always target `getResolvedOllamaModel()` — the configured default —
+  and ignore any caller-supplied target.
+
+### Target behavior
+
+Each installed Ollama model gets an independent Load/Unload control. Loading
+one model does **not** evict the others — Ollama manages VRAM itself, and each
+row's residency mirrors live `ollama ps`. This matches how Ollama actually
+works (`ollama ps` can show several resident models).
+
+### Decisions
+
+- **Independent per model** (not single-active radio). Confirmed with user.
+- **No auto-evict** of the TTS sidecar when loading an Ollama model here. This
+  is a manual pre-warm; it mirrors today's default-analyzer pill, which also
+  doesn't evict TTS. Note that **analysis still runs the *configured* default
+  model**, not whatever you warm — warming a non-default model is an advisory /
+  residency-inspection action.
+
+### Backend (`server/src/routes/ollama-health.ts`)
+
+- `POST /api/ollama/load` and `/api/ollama/unload` accept an optional
+  `{ model }` in the request body. When absent, fall back to
+  `getResolvedOllamaModel()` so the existing default-model callers (the
+  Analysing-screen pill, the TTS auto-evict flow) keep working unchanged.
+- The load path keeps threading the analyzer's `num_ctx` / `num_gpu` for
+  **whatever** model is named (the load-time cache-key caveat) so a warmed
+  model isn't force-reloaded on the first real analysis call.
+
+### Frontend (`src/views/model-manager.tsx`, `src/lib/api.ts`)
+
+- `hasControl`: replace the `isAnalyzerDefault` clause with "any present
+  analyzer row" — every Ollama model gets the pill, default or not. (All
+  `kind: 'analyzer'` rows are Ollama; cloud Gemini isn't a disk artifact and
+  isn't in the inventory.)
+- `doLoad` / `doStop` parse the model name out of `item.id`
+  (`ollama:<name>`) and pass it: `api.loadAnalyzer({ model })` /
+  `api.unloadAnalyzer({ model })`. `realLoadAnalyzer` / `realUnloadAnalyzer`
+  gain an optional `{ model }` arg and POST it as the body.
+- **Bug fix surfaced by this change:** `controlState` currently maps
+  `!sidecarReachable → 'unreachable'`. That's wrong for analyzer rows — the TTS
+  sidecar being down must not grey out Ollama Load buttons. Scope the
+  unreachable signal per-kind: analyzer rows ignore `sidecarReachable`. (An
+  unreachable Ollama daemon already yields zero analyzer rows, so there is
+  nothing to mis-label.)
+- **Mock:** replace the single `MOCK_OLLAMA_MODEL_LOADED` boolean with a
+  per-model resident `Set<string>` so the manager's Load/Stop round-trips
+  visibly in mock mode and the mock inventory reflects per-model residency.
+
+---
+
+## Part B — "TTS" → "Voice engine" user-facing copy
+
+Scope confirmed with user: **all user-facing TTS copy**, including docs that
+name the UI label. **Out of scope:** code identifiers, type / field names,
+OpenAPI `description:` text, and code comments — these stay as-is.
+
+### In-app strings
+
+- `ModelControlPill.tsx` — `kindNoun`: `'TTS model'` → `'Voice engine'`. The
+  analyzer side stays `'Analyzer'`.
+- Account default-engine dropdown label + helper text → "Voice engine".
+- Per-character picker label **"TTS engine for this character"** → **"Voice
+  engine for this character"**.
+- Generation cross-engine warnings ("different TTS engine" → "different voice
+  engine").
+- `src/data/help-failures.ts` — recycle-storm title "TTS engine keeps
+  restarting" → "Voice engine keeps restarting".
+
+### Docs
+
+- `README.md` — "TTS engines" heading / prose → "Voice engines".
+- `INSTALL.md` — the "Account → Defaults for new books → TTS engine" references
+  name the UI label that's changing → "Voice engine".
+
+### Lockstep test / spec updates (matching new copy, not changing intent)
+
+- `src/data/help-failures.test.ts` — the title pin for recycle-storm.
+- `model-manager.test.tsx` — assert the new "Voice engine" pill copy.
+- e2e specs querying the visible label `getByLabel('TTS engine for this
+  character')`: `e2e/cast.spec.ts`, `e2e/voice-design-progress.spec.ts`,
+  `e2e/single-voice-design-background.spec.ts`.
+
+---
+
+## Testing
+
+- **Server** (`ollama-health.test.ts`): load/unload with an explicit
+  `{ model }` targets that model and threads `num_ctx`/`num_gpu`; an absent
+  body still targets the configured default.
+- **Frontend** (`model-manager.test.tsx`): a non-default Ollama row renders a
+  Load/Unload pill; the action calls `api.loadAnalyzer`/`unloadAnalyzer` with
+  that row's model name; the pill is not greyed out when only the TTS sidecar
+  is unreachable.
+- **Copy:** `model-manager.test.tsx` / `help-failures.test.ts` assert the new
+  "Voice engine" strings; e2e label queries updated.
+- `npm run verify` before shipping (typecheck + all tests + e2e + build).
+
+## Out of scope
+
+- Auto-evicting other engines when loading an Ollama model.
+- Renaming code identifiers, type/field names, OpenAPI descriptions, comments.
+- Changing which model analysis actually runs (still the configured default).

--- a/docs/superpowers/specs/2026-06-12-model-manager-ollama-voice-engine-design.md
+++ b/docs/superpowers/specs/2026-06-12-model-manager-ollama-voice-engine-design.md
@@ -31,28 +31,38 @@ Two independent, mechanical changes shipped together on one branch:
 ### Target behavior
 
 Each installed Ollama model gets an independent Load/Unload control. Loading
-one model does **not** evict the others — Ollama manages VRAM itself, and each
-row's residency mirrors live `ollama ps`. This matches how Ollama actually
-works (`ollama ps` can show several resident models).
+one analyzer model does **not** evict another analyzer model — Ollama manages
+VRAM itself, and each row's residency mirrors live `ollama ps`. This matches how
+Ollama actually works (`ollama ps` can show several resident models).
 
 ### Decisions
 
 - **Independent per model** (not single-active radio). Confirmed with user.
-- **No auto-evict** of the TTS sidecar when loading an Ollama model here. This
-  is a manual pre-warm; it mirrors today's default-analyzer pill, which also
-  doesn't evict TTS. Note that **analysis still runs the *configured* default
-  model**, not whatever you warm — warming a non-default model is an advisory /
-  residency-inspection action.
+- **Analysis still runs the *configured* default model**, not whatever you warm
+  — warming a non-default model is an advisory / residency-inspection action.
+- **A1 — TTS load evicts ALL resident analyzer models** (confirmed with user).
+  Adversarial-review finding: today the Generate-screen "Load TTS" flow
+  auto-evicts the analyzer via `api.unloadAnalyzer()` with no model, which
+  resolves to the *configured default* only. Once a user can warm a *non-default*
+  Ollama model from the new controls, that model would stay resident alongside
+  the TTS engine → co-residency OOM on an 8 GB GPU. Fix: a no-model
+  `POST /api/ollama/unload` evicts **every** currently-resident Ollama model
+  (probe `ollama ps`, send `keep_alive: 0` per resident tag), so the existing
+  TTS auto-evict path frees all analyzer VRAM. An explicit `{ model }` still
+  targets just that one (the per-row Unload button).
 
 ### Backend (`server/src/routes/ollama-health.ts`)
 
-- `POST /api/ollama/load` and `/api/ollama/unload` accept an optional
-  `{ model }` in the request body. When absent, fall back to
-  `getResolvedOllamaModel()` so the existing default-model callers (the
-  Analysing-screen pill, the TTS auto-evict flow) keep working unchanged.
-- The load path keeps threading the analyzer's `num_ctx` / `num_gpu` for
-  **whatever** model is named (the load-time cache-key caveat) so a warmed
-  model isn't force-reloaded on the first real analysis call.
+- `POST /api/ollama/load` accepts an optional `{ model }` in the body; when
+  absent, falls back to `getResolvedOllamaModel()` (the Analysing-screen pill
+  keeps working unchanged). It keeps threading the analyzer's `num_ctx` /
+  `num_gpu` for **whatever** model is named (the load-time cache-key caveat) so
+  a warmed model isn't force-reloaded on the first real analysis call.
+- `POST /api/ollama/unload`:
+  - with an explicit `{ model }` → evict just that model (`keep_alive: 0`).
+  - with **no** model → per A1, probe `ollama ps` and evict **every** resident
+    model. (`express.json` is mounted globally at `index.ts:120`, confirmed —
+    the route can read the body.)
 
 ### Frontend (`src/views/model-manager.tsx`, `src/lib/api.ts`)
 
@@ -60,50 +70,94 @@ works (`ollama ps` can show several resident models).
   analyzer row" — every Ollama model gets the pill, default or not. (All
   `kind: 'analyzer'` rows are Ollama; cloud Gemini isn't a disk artifact and
   isn't in the inventory.)
-- `doLoad` / `doStop` parse the model name out of `item.id`
-  (`ollama:<name>`) and pass it: `api.loadAnalyzer({ model })` /
+- `doLoad` / `doStop` derive the model name with
+  **`item.id.slice('ollama:'.length)`** — A3: tags contain colons
+  (`ollama:qwen3.5:4b`), so a `split(':')` would mis-target; mirror
+  `performRemoval`. Pass it: `api.loadAnalyzer({ model })` /
   `api.unloadAnalyzer({ model })`. `realLoadAnalyzer` / `realUnloadAnalyzer`
   gain an optional `{ model }` arg and POST it as the body.
 - **Bug fix surfaced by this change:** `controlState` currently maps
-  `!sidecarReachable → 'unreachable'`. That's wrong for analyzer rows — the TTS
-  sidecar being down must not grey out Ollama Load buttons. Scope the
+  `!sidecarReachable → 'unreachable'`. That's wrong for analyzer rows — the
+  voice engine being down must not grey out Ollama Load buttons. Scope the
   unreachable signal per-kind: analyzer rows ignore `sidecarReachable`. (An
   unreachable Ollama daemon already yields zero analyzer rows, so there is
   nothing to mis-label.)
-- **Mock:** replace the single `MOCK_OLLAMA_MODEL_LOADED` boolean with a
-  per-model resident `Set<string>` so the manager's Load/Stop round-trips
-  visibly in mock mode and the mock inventory reflects per-model residency.
+- **A4 (minor a11y):** thread `engineLabel` into the pill's *button*
+  aria-label so N analyzer Load buttons don't all read the identical
+  "Load model (analyzer)".
+- **A2 — Mock must demonstrate the feature:** the mock app exposes exactly one
+  Ollama model (`qwen3.5:4b`, the default), so there is currently **no
+  non-default row** to show the new pill on. Add a second, non-default mock
+  Ollama model, and replace the single `MOCK_OLLAMA_MODEL_LOADED` boolean with
+  a per-model resident `Set<string>` so the manager's Load/Stop round-trips
+  visibly in mock mode (and an e2e spec can exercise a non-default row).
 
 ---
 
 ## Part B — "TTS" → "Voice engine" user-facing copy
 
-Scope confirmed with user: **all user-facing TTS copy**, including docs that
-name the UI label. **Out of scope:** code identifiers, type / field names,
-OpenAPI `description:` text, and code comments — these stay as-is.
+Scope confirmed with user: **all user-facing TTS copy** — in-app strings, docs,
+**and the user-visible TEXT of server/sidecar-thrown error messages** (decision
+B). **Out of scope:** code identifiers, type / field names, OpenAPI
+`description:` text, and code comments — these stay as-is.
 
-### In-app strings
+> **Adversarial-review note:** the initial spec listed ~5 strings; the real
+> surface is much larger and the replacement is **not one-to-one**. A blind
+> find-replace produces garbage ("voice engine model key"). The plan's first
+> task is a comprehensive grep across `src/`, `server/`, `server/tts-sidecar/`,
+> and the docs to build the exact per-string replacement map below before
+> touching anything.
 
-- `ModelControlPill.tsx` — `kindNoun`: `'TTS model'` → `'Voice engine'`. The
-  analyzer side stays `'Analyzer'`.
-- Account default-engine dropdown label + helper text → "Voice engine".
-- Per-character picker label **"TTS engine for this character"** → **"Voice
-  engine for this character"**.
-- Generation cross-engine warnings ("different TTS engine" → "different voice
-  engine").
-- `src/data/help-failures.ts` — recycle-storm title "TTS engine keeps
-  restarting" → "Voice engine keeps restarting".
+### Replacement mapping (apply per-string, by sense)
+
+| Source phrase | Replacement |
+|---|---|
+| "TTS sidecar" | "voice engine" |
+| "TTS engine" / "TTS engines" | "voice engine" / "voice engines" |
+| "TTS model" | "voice engine" (or "voice" where it means the voice) |
+| "TTS voice" | "voice" |
+| "Loading TTS…" / "Loading TTS model…" | "Loading voice engine…" |
+
+### Known in-app strings (non-exhaustive — confirm via the grep task)
+
+- `ModelControlPill.tsx` — `kindNoun` `'TTS model'` → `'Voice engine'`
+  (analyzer side stays `'Analyzer'`).
+- `profile-drawer.tsx` — the **"TTS engine for this character"** select label
+  (source lives here, *not* cast.tsx), "Loading TTS model (~30s)…", "the TTS
+  voice line above".
+- `generation.tsx` — "Recovering — restarting TTS engine…", "current TTS
+  model", "The TTS engine may be synthesising…".
+- `queue-modal.tsx` — 'Mixes TTS engines. Turn on "Keep both TTS engines
+  loaded"…'.
+- `voices.tsx` — "Loading TTS…" ×2, "switch your TTS model".
+- `data/help-topics.ts` — "TTS sidecar" ×3.
+- `data/help-failures.ts` — recycle-storm title "TTS engine keeps restarting"
+  → "Voice engine keeps restarting".
+- `model-settings-form.tsx` — already mostly "voice engine"; verify the
+  engine-picker sub-label (it is **not** literally "TTS engine" — earlier
+  guess was wrong).
+
+### Server / sidecar error text (decision B)
+
+- Grep `server/src/` and `server/tts-sidecar/` for user-visible "TTS" in
+  thrown error messages / status strings (e.g. "TTS sidecar process is not
+  running. Launch the app via start-app.ps1.", analyzer/chapter `errorReason`
+  text like "TTS sidecar timed out"). Rename the visible text only; identifiers
+  and types stay.
 
 ### Docs
 
 - `README.md` — "TTS engines" heading / prose → "Voice engines".
-- `INSTALL.md` — the "Account → Defaults for new books → TTS engine" references
-  name the UI label that's changing → "Voice engine".
+- `INSTALL.md` — "Account → Defaults for new books → TTS engine" references →
+  the new UI label.
 
-### Lockstep test / spec updates (matching new copy, not changing intent)
+### Lockstep test / fixture updates (matching new copy, not changing intent)
 
-- `src/data/help-failures.test.ts` — the title pin for recycle-storm.
-- `model-manager.test.tsx` — assert the new "Voice engine" pill copy.
+- `help-failures.test.ts` (title pin), `model-manager.test.tsx` (describe name
+  + pill copy), `generation.test.tsx:416` (the "restarting TTS engine…"
+  assertion), `profile-drawer.test.tsx` (the `getByLabelText` query + the
+  sidecar-error assertions), `chapters-slice.test.ts:523` (errorReason
+  fixture), and any sidecar pytest asserting renamed message text.
 - e2e specs querying the visible label `getByLabel('TTS engine for this
   character')`: `e2e/cast.spec.ts`, `e2e/voice-design-progress.spec.ts`,
   `e2e/single-voice-design-background.spec.ts`.
@@ -112,19 +166,25 @@ OpenAPI `description:` text, and code comments — these stay as-is.
 
 ## Testing
 
-- **Server** (`ollama-health.test.ts`): load/unload with an explicit
-  `{ model }` targets that model and threads `num_ctx`/`num_gpu`; an absent
-  body still targets the configured default.
+- **Server** (`ollama-health.test.ts`):
+  - `load` with explicit `{ model }` targets that model and threads
+    `num_ctx`/`num_gpu`; absent body → configured default.
+  - `unload` with explicit `{ model }` evicts just that model; **no body →
+    evicts every model from `ollama ps`** (A1). Update the existing
+    single-model unload test to the enumerate-all behavior.
 - **Frontend** (`model-manager.test.tsx`): a non-default Ollama row renders a
   Load/Unload pill; the action calls `api.loadAnalyzer`/`unloadAnalyzer` with
-  that row's model name; the pill is not greyed out when only the TTS sidecar
-  is unreachable.
-- **Copy:** `model-manager.test.tsx` / `help-failures.test.ts` assert the new
-  "Voice engine" strings; e2e label queries updated.
+  that row's model name (sliced, not split); the pill is **not** greyed out
+  when only the voice engine (sidecar) is unreachable.
+- **e2e** (A2): with the second non-default mock Ollama model, one spec drives
+  Load/Unload on the non-default row in mock mode.
+- **Copy:** `model-manager.test.tsx` / `help-failures.test.ts` /
+  `generation.test.tsx` assert the new "voice engine" strings; e2e label
+  queries updated.
 - `npm run verify` before shipping (typecheck + all tests + e2e + build).
 
 ## Out of scope
 
-- Auto-evicting other engines when loading an Ollama model.
+- Single-active (radio) Ollama loading — rejected for "independent per model".
 - Renaming code identifiers, type/field names, OpenAPI descriptions, comments.
 - Changing which model analysis actually runs (still the configured default).

--- a/e2e/cast.spec.ts
+++ b/e2e/cast.spec.ts
@@ -41,7 +41,7 @@ test.describe('cast view → profile drawer → per-character Qwen voice', () =>
     await expect(page.getByText(/Model voice/i).first()).toBeVisible({ timeout: 5_000 });
 
     /* Switch the per-character engine to Qwen. */
-    const engineSelect = page.getByLabel('TTS engine for this character');
+    const engineSelect = page.getByLabel('Voice engine for this character');
     await expect(engineSelect).toBeVisible();
     await engineSelect.selectOption('qwen');
 

--- a/e2e/default-tts-pill-no-book.spec.ts
+++ b/e2e/default-tts-pill-no-book.spec.ts
@@ -34,7 +34,7 @@ test.describe('Default-engine TTS pill — reachable on the Books view (no book 
        "Kokoro ready" with a Stop button. */
     await expect(page.getByText(/Kokoro ready/i).first()).toBeVisible({ timeout: 5_000 });
     await expect(
-      page.getByRole('button', { name: /^stop \(tts model\)$/i }).first(),
+      page.getByRole('button', { name: /^stop \(voice engine\)$/i }).first(),
     ).toBeVisible();
 
     /* The dead-end fallback must be gone. */

--- a/e2e/kokoro-stop-pill.spec.ts
+++ b/e2e/kokoro-stop-pill.spec.ts
@@ -36,17 +36,17 @@ test.describe('Kokoro Stop pill — bidirectional Load/Stop in the Status popove
     await openStatusPopover(page);
 
     /* Wait for the first /health probe to resolve and the control to render
-       its real state. The button has aria-label "Stop (tts model)" when the
+       its real state. The button has aria-label "Stop (voice engine)" when the
        engine is ready. The displayed text reads "Kokoro ready" via the
        engineLabel override. */
-    const stopButton = page.getByRole('button', { name: /^stop \(tts model\)$/i }).first();
+    const stopButton = page.getByRole('button', { name: /^stop \(voice engine\)$/i }).first();
     await expect(stopButton).toBeVisible({ timeout: 5_000 });
     await expect(page.getByText(/Kokoro ready/i).first()).toBeVisible();
 
     /* Click Stop — pill should optimistically flip to "idle" before the
        /health repoll comes back, and the Load button replaces Stop. */
     await stopButton.click();
-    const loadButton = page.getByRole('button', { name: /^load model \(tts model\)$/i }).first();
+    const loadButton = page.getByRole('button', { name: /^load model \(voice engine\)$/i }).first();
     await expect(loadButton).toBeVisible({ timeout: 5_000 });
     await expect(page.getByText(/Kokoro idle/i).first()).toBeVisible();
 
@@ -54,7 +54,7 @@ test.describe('Kokoro Stop pill — bidirectional Load/Stop in the Status popove
        again. The mock loadSidecar resolves after a short wait and the
        hook re-probes /health, picking up kokoroLoaded:true. */
     await loadButton.click();
-    await expect(page.getByRole('button', { name: /^stop \(tts model\)$/i }).first()).toBeVisible({
+    await expect(page.getByRole('button', { name: /^stop \(voice engine\)$/i }).first()).toBeVisible({
       timeout: 5_000,
     });
     await expect(page.getByText(/Kokoro ready/i).first()).toBeVisible();

--- a/e2e/model-manager-ollama-load.spec.ts
+++ b/e2e/model-manager-ollama-load.spec.ts
@@ -1,0 +1,29 @@
+/* Model Manager — per-model Ollama Load/Unload.
+ *
+ * Every installed Ollama analyzer model (not just the configured default) now
+ * carries its own Load/Unload pill. The mock api exposes a second, NON-default
+ * model (`llama3.1:8b`) that starts un-resident; loading it flips the row's
+ * `data-loaded` (the mock keeps per-model residency in the same JS context),
+ * and Stop flips it back. */
+
+import { test, expect } from '@playwright/test';
+import { waitForRouteReady, stubAccountModelProbes } from './helpers';
+
+test.beforeEach(async ({ page }) => {
+  await stubAccountModelProbes(page);
+});
+
+test('loads and unloads a non-default Ollama model from the Model Manager', async ({ page }) => {
+  await page.goto('/#/models');
+  await waitForRouteReady(page);
+
+  const row = page.getByTestId('model-row-ollama:llama3.1:8b');
+  await expect(row).toBeVisible();
+  await expect(row).toHaveAttribute('data-loaded', 'false');
+
+  await row.getByRole('button', { name: /load model/i }).click();
+  await expect(row).toHaveAttribute('data-loaded', 'true');
+
+  await row.getByRole('button', { name: /stop/i }).click();
+  await expect(row).toHaveAttribute('data-loaded', 'false');
+});

--- a/e2e/single-voice-design-background.spec.ts
+++ b/e2e/single-voice-design-background.spec.ts
@@ -54,7 +54,7 @@ test.describe('single voice design → background-survivable', () => {
     await expect(page.getByText(/Evidence from the manuscript/i)).toBeVisible({ timeout: 10_000 });
 
     /* Switch the per-character engine to Qwen. */
-    const engineSelect = page.getByLabel('TTS engine for this character');
+    const engineSelect = page.getByLabel('Voice engine for this character');
     await expect(engineSelect).toBeVisible();
     await engineSelect.selectOption('qwen');
 

--- a/e2e/status-popover-cast-drawer.spec.ts
+++ b/e2e/status-popover-cast-drawer.spec.ts
@@ -42,9 +42,9 @@ test.describe('Status popover ↔ cast drawer coexistence', () => {
     await expect(drawerOpen, 'drawer must stay open when the popover opens').toBeVisible();
 
     /* Click Stop on the Kokoro control INSIDE the popover (mock Kokoro is
-       preloaded → "Stop (tts model)" is present). This is the exact action
+       preloaded → "Stop (voice engine)" is present). This is the exact action
        that used to dismiss the drawer. */
-    const stopButton = page.getByRole('button', { name: /^stop \(tts model\)$/i }).first();
+    const stopButton = page.getByRole('button', { name: /^stop \(voice engine\)$/i }).first();
     await expect(stopButton).toBeVisible({ timeout: 5_000 });
     await stopButton.click();
 
@@ -53,7 +53,7 @@ test.describe('Status popover ↔ cast drawer coexistence', () => {
     await expect(popover, 'popover must stay open after clicking Stop').toBeVisible();
 
     /* And the control actually acted — it flipped to Load. */
-    await expect(page.getByRole('button', { name: /^load model \(tts model\)$/i }).first()).toBeVisible(
+    await expect(page.getByRole('button', { name: /^load model \(voice engine\)$/i }).first()).toBeVisible(
       { timeout: 5_000 },
     );
     await expect(drawerOpen, 'drawer still open after the engine flipped').toBeVisible();

--- a/e2e/voice-design-progress.spec.ts
+++ b/e2e/voice-design-progress.spec.ts
@@ -61,7 +61,7 @@ test.describe('voice-design progress indicator', () => {
        MOCK_PERSONA). We must let this 80 ms timer resolve BEFORE installing
        the fake clock — otherwise the textarea stays empty and the design
        button stays disabled. */
-    const engineSelect = page.getByLabel('TTS engine for this character');
+    const engineSelect = page.getByLabel('Voice engine for this character');
     await expect(engineSelect).toBeVisible();
     await engineSelect.selectOption('qwen');
 

--- a/server/src/routes/chapter-qa-repair.ts
+++ b/server/src/routes/chapter-qa-repair.ts
@@ -206,7 +206,7 @@ chapterQaRepairRouter.post(
         : isTtsModelKey(segFile.modelKey)
           ? (segFile.modelKey as TtsModelKey)
           : null;
-      if (!modelKey) return fail('modelKey must be a supported TTS model id to repair.');
+      if (!modelKey) return fail('modelKey must be a supported voice-engine model id to repair.');
       const maxRerecords = resolveMaxRerecords(body.maxRerecords);
 
       const cast = await readJson<{ characters: CastCharacter[] }>(castJsonPath(bookDir));

--- a/server/src/routes/chapter-splice.ts
+++ b/server/src/routes/chapter-splice.ts
@@ -119,7 +119,7 @@ chapterSpliceRouter.post(
         return fail(`gainDb must be between ${GAIN_DB_MIN} and ${GAIN_DB_MAX} dB.`);
       }
     } else if (!isTtsModelKey(body.modelKey)) {
-      return fail('modelKey must be a supported TTS model id for a re-record.');
+      return fail('modelKey must be a supported voice-engine model id for a re-record.');
     } else {
       reqModelKey = body.modelKey;
     }

--- a/server/src/routes/failure-remediations.ts
+++ b/server/src/routes/failure-remediations.ts
@@ -21,36 +21,36 @@ export interface FailureRemediationCopy {
 export const FAILURE_REMEDIATIONS = {
   'synth-timeout': {
     userMessage:
-      'TTS synthesis timed out for this chapter — the local engine stalled (often the ' +
-      'sidecar reclaiming memory mid-render). Skipped so the queue advances; click Retry to re-render.',
+      'Voice synthesis timed out for this chapter — the local engine stalled (often the ' +
+      'voice engine reclaiming memory mid-render). Skipped so the queue advances; click Retry to re-render.',
     remediation:
-      'Click Retry on this chapter. If it times out repeatedly, restart the TTS sidecar to clear ' +
+      'Click Retry on this chapter. If it times out repeatedly, restart the voice engine to clear ' +
       'a wedged GPU state, then retry.',
   },
   'sidecar-unreachable': {
-    userMessage: 'Local TTS sidecar not running — start it and resume.',
+    userMessage: 'Local voice engine not running — start it and resume.',
     remediation:
-      'Start the TTS sidecar (npm start launches it automatically), wait for the sidecar pill to ' +
+      'Start the voice engine (npm start launches it automatically), wait for the voice engine pill to ' +
       'go green, then resume the run.',
   },
   'recycle-storm': {
-    userMessage: 'The TTS engine kept restarting while rendering this chapter.',
+    userMessage: 'The voice engine kept restarting while rendering this chapter.',
     remediation:
-      'The sidecar is likely thrashing — the host-memory leak (side-11) or too little ' +
-      'VRAM/RAM headroom. Restart the TTS sidecar and/or lower generation concurrency, then Retry.',
+      'The voice engine is likely thrashing — the host-memory leak (side-11) or too little ' +
+      'VRAM/RAM headroom. Restart the voice engine and/or lower generation concurrency, then Retry.',
   },
   'vram-spill': {
     userMessage:
       'The GPU ran out of video memory (VRAM) mid-render — too many models were resident at once.',
     remediation:
-      'Unload any models you are not generating with (the analyzer Ollama, or a second TTS engine) ' +
-      'from the model pills, then retry. On an 8 GB card keep only one heavy TTS model loaded.',
+      'Unload any models you are not generating with (the analyzer Ollama, or a second voice engine) ' +
+      'from the model pills, then retry. On an 8 GB card keep only one heavy voice engine loaded.',
   },
   oom: {
     userMessage:
-      'The TTS sidecar was killed by the operating system — the machine ran out of host RAM.',
+      'The voice engine was killed by the operating system — the machine ran out of host RAM.',
     remediation:
-      'Close other memory-heavy apps and retry. If it recurs, the sidecar is leaking — restart it ' +
+      'Close other memory-heavy apps and retry. If it recurs, the voice engine is leaking — restart it ' +
       'to reset its host memory, then resume.',
   },
   'disk-full': {
@@ -106,25 +106,25 @@ export const FAILURE_REMEDIATIONS = {
   },
   'xtts-speaker-desync': {
     userMessage:
-      'Local TTS engine rejected a speaker — the voice catalog is out of sync with the loaded model. ' +
-      'Stop the sidecar, re-run the speaker manifest audit, and regenerate.',
+      'Local voice engine rejected a speaker — the voice catalog is out of sync with the loaded model. ' +
+      'Stop the voice engine, re-run the speaker manifest audit, and regenerate.',
     remediation:
-      'Stop the TTS sidecar, re-run the speaker-manifest audit, then restart the sidecar and ' +
+      'Stop the voice engine, re-run the speaker-manifest audit, then restart the voice engine and ' +
       'regenerate this chapter.',
   },
   'cuda-poisoned': {
     userMessage:
-      'Local TTS sidecar hit a CUDA error and is auto-restarting (the CUDA context is corrupted ' +
-      'process-wide; only a fresh Python process recovers). Wait ~10 seconds for the sidecar pill ' +
-      'to go green again, then click Retry on this chapter. The offending text is in the sidecar ' +
+      'Local voice engine hit a CUDA error and is auto-restarting (the CUDA context is corrupted ' +
+      'process-wide; only a fresh Python process recovers). Wait ~10 seconds for the voice engine pill ' +
+      'to go green again, then click Retry on this chapter. The offending text is in the voice engine ' +
       'log (text_preview=) — usually a stray zero-width or control char in the manuscript.',
     remediation:
-      'Wait ~10 seconds for the sidecar to respawn (the pill goes green), then click Retry. If it ' +
-      'recurs on the same chapter, check the sidecar log text_preview= for a stray control char.',
+      'Wait ~10 seconds for the voice engine to respawn (the pill goes green), then click Retry. If it ' +
+      'recurs on the same chapter, check the voice engine log text_preview= for a stray control char.',
   },
   'model-not-loaded': {
     userMessage:
-      'The TTS model is not loaded in the sidecar yet — synthesis was requested before the model ' +
+      'The voice engine is not loaded yet — synthesis was requested before the model ' +
       'finished loading.',
     remediation:
       'Load the engine from its model pill (or wait for the auto-load to finish — the pill turns ' +
@@ -135,7 +135,7 @@ export const FAILURE_REMEDIATIONS = {
     userMessage:
       'Something failed in a way the app does not recognise — the raw error message is shown in place of this line.',
     remediation:
-      'Click Retry on this chapter. If it keeps failing, check the server / sidecar logs for the full ' +
+      'Click Retry on this chapter. If it keeps failing, check the server / voice engine logs for the full ' +
       'error and report it.',
   },
 } as const satisfies Record<string, FailureRemediationCopy>;

--- a/server/src/routes/failure-taxonomy.test.ts
+++ b/server/src/routes/failure-taxonomy.test.ts
@@ -147,7 +147,7 @@ describe('classifyFailure', () => {
     );
     expect(out.code).toBe('sidecar-unreachable');
     expect(out.fatal).toBe(true);
-    expect(out.userMessage).toMatch(/sidecar/i);
+    expect(out.userMessage).toMatch(/voice engine/i);
     expect(out.remediation.length).toBeGreaterThan(0);
   });
 

--- a/server/src/routes/generation-error.test.ts
+++ b/server/src/routes/generation-error.test.ts
@@ -16,7 +16,7 @@ describe('describeSynthesisError', () => {
       new Error('fetch failed: connect ECONNREFUSED 127.0.0.1:9000'),
     );
     expect(out.fatal).toBe(true);
-    expect(out.errorReason).toMatch(/sidecar not running/i);
+    expect(out.errorReason).toMatch(/voice engine not running/i);
   });
 
   it('flags sidecar-down ("not reachable" text) as fatal', () => {

--- a/server/src/routes/ollama-health.test.ts
+++ b/server/src/routes/ollama-health.test.ts
@@ -174,6 +174,21 @@ describe('POST /api/ollama/load', () => {
     expect(res.body.status).toBe('error');
     expect(res.body.error).toMatch(/404/);
   });
+
+  it('targets the model from the request body when provided, still threading num_ctx/num_gpu', async () => {
+    fetchMock.mockResolvedValue(new Response('', { status: 200 }));
+
+    const res = await request(makeApp())
+      .post('/api/ollama/load')
+      .send({ model: 'llama3.1:8b' });
+
+    expect(res.status).toBe(200);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.model).toBe('llama3.1:8b');
+    expect(body.keep_alive).toBe('5m');
+    expect(body.options?.num_ctx).toBe(16384);
+    expect(body.options?.num_gpu).toBe(999);
+  });
 });
 
 describe('POST /api/ollama/unload', () => {

--- a/server/src/routes/ollama-health.test.ts
+++ b/server/src/routes/ollama-health.test.ts
@@ -192,30 +192,56 @@ describe('POST /api/ollama/load', () => {
 });
 
 describe('POST /api/ollama/unload', () => {
-  it('POSTs /api/generate with keep_alive: 0 and returns {status: unloaded}', async () => {
+  it('evicts a single model with keep_alive: 0 when one is named in the body', async () => {
     fetchMock.mockResolvedValue(new Response('', { status: 200 }));
 
-    const res = await request(makeApp()).post('/api/ollama/unload');
+    const res = await request(makeApp()).post('/api/ollama/unload').send({ model: 'llama3.1:8b' });
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: 'unloaded' });
     /* keep_alive: 0 is the documented Ollama idiom for "drop this model from
        VRAM now" — see analyzer/ollama.ts:92 for the equivalent on real chat
        calls. If the literal 0 changes (e.g. to "0s") the eviction stops
        being immediate, which silently breaks auto-evict-before-TTS. */
-    const init = fetchMock.mock.calls[0][1];
-    const body = JSON.parse(init.body);
+    const genCalls = fetchMock.mock.calls.filter((c) => String(c[0]).endsWith('/api/generate'));
+    expect(genCalls).toHaveLength(1);
+    const body = JSON.parse(genCalls[0][1].body);
+    expect(body.model).toBe('llama3.1:8b');
     expect(body.keep_alive).toBe(0);
     expect(body.prompt).toBe('');
   });
 
-  it('returns 503 when Ollama is unreachable', async () => {
+  it('with no model, evicts EVERY resident model reported by /api/ps', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).endsWith('/api/tags')) {
+        return Promise.resolve(new Response(JSON.stringify({ models: [] }), { status: 200 }));
+      }
+      if (String(url).endsWith('/api/ps')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ models: [{ name: 'qwen3.5:4b' }, { name: 'llama3.1:8b' }] }),
+            { status: 200 },
+          ),
+        );
+      }
+      return Promise.resolve(new Response('', { status: 200 })); // /api/generate
+    });
+
+    const res = await request(makeApp()).post('/api/ollama/unload');
+
+    expect(res.status).toBe(200);
+    const evicted = fetchMock.mock.calls
+      .filter((c) => String(c[0]).endsWith('/api/generate'))
+      .map((c) => JSON.parse(c[1].body).model);
+    expect(evicted.sort()).toEqual(['llama3.1:8b', 'qwen3.5:4b']);
+  });
+
+  it('returns the upstream error when an explicit model eviction fails', async () => {
     fetchMock.mockRejectedValue(
       Object.assign(new TypeError('fetch failed'), {
         cause: Object.assign(new Error('ECONNREFUSED'), { code: 'ECONNREFUSED' }),
       }),
     );
-    const res = await request(makeApp()).post('/api/ollama/unload');
+    const res = await request(makeApp()).post('/api/ollama/unload').send({ model: 'qwen3.5:4b' });
     expect(res.status).toBe(503);
     expect(res.body.status).toBe('error');
   });

--- a/server/src/routes/ollama-health.ts
+++ b/server/src/routes/ollama-health.ts
@@ -223,9 +223,10 @@ async function callOllamaGenerate(
    to the UI as "Analysis stream ended without a result event" while
    the pill stays green ("Analyzer ready"), so every Try Again triggers
    the same reload-and-die loop. */
-ollamaHealthRouter.post('/load', async (_req: Request, res: Response) => {
+ollamaHealthRouter.post('/load', async (req: Request, res: Response) => {
   const url = getResolvedOllamaUrl();
-  const model = getResolvedOllamaModel();
+  const requested = typeof req.body?.model === 'string' ? req.body.model.trim() : '';
+  const model = requested || getResolvedOllamaModel();
   const result = await callOllamaGenerate(
     url,
     {

--- a/server/src/routes/ollama-health.ts
+++ b/server/src/routes/ollama-health.ts
@@ -247,18 +247,25 @@ ollamaHealthRouter.post('/load', async (req: Request, res: Response) => {
 /* POST /api/ollama/unload — evict the configured analyzer model from VRAM.
    Used by both the Analysing-screen Stop button and the Generate-screen
    auto-evict flow (loading TTS calls this first to free GPU memory). */
-ollamaHealthRouter.post('/unload', async (_req: Request, res: Response) => {
+ollamaHealthRouter.post('/unload', async (req: Request, res: Response) => {
   const url = getResolvedOllamaUrl();
-  const model = getResolvedOllamaModel();
-  const result = await callOllamaGenerate(
-    url,
-    { model, prompt: '', keep_alive: 0, stream: false },
-    PROBE_TIMEOUT_MS,
-  );
-  if (!result.ok) {
-    return res.status(result.status).json({ status: 'error', error: result.error });
+  const requested = typeof req.body?.model === 'string' ? req.body.model.trim() : '';
+  /* Explicit model → evict just that one. No model → evict every resident
+     model (so the TTS auto-evict path frees ALL analyzer VRAM, not just the
+     configured default — a manually-warmed non-default model would otherwise
+     stay co-resident with the voice engine and OOM the GPU). */
+  const targets = requested ? [requested] : (await probeOllamaHealth()).resident ?? [];
+  for (const model of targets) {
+    const result = await callOllamaGenerate(
+      url,
+      { model, prompt: '', keep_alive: 0, stream: false },
+      PROBE_TIMEOUT_MS,
+    );
+    if (!result.ok) {
+      return res.status(result.status).json({ status: 'error', error: result.error });
+    }
   }
-  return res.json({ status: 'unloaded' });
+  return res.json({ status: 'unloaded', unloaded: targets });
 });
 
 /* ============================================================

--- a/server/src/tts/sidecar.ts
+++ b/server/src/tts/sidecar.ts
@@ -123,7 +123,7 @@ export class SidecarTtsProvider implements TtsProvider {
 
         const buf = Buffer.from(await response.arrayBuffer());
         if (buf.length === 0) {
-          throw new Error('Local TTS sidecar returned an empty audio body.');
+          throw new Error('Local voice engine returned an empty audio body.');
         }
 
         const mimeType = response.headers.get('content-type') ?? 'audio/L16;codec=pcm;rate=24000';
@@ -187,7 +187,7 @@ export class SidecarTtsProvider implements TtsProvider {
 
         const buf = Buffer.from(await response.arrayBuffer());
         if (buf.length === 0) {
-          throw new Error('Local TTS sidecar returned an empty batch body.');
+          throw new Error('Local voice engine returned an empty batch body.');
         }
 
         const { sampleRate, pcms, genMs, audioMs } = parseBatchFrame(buf);
@@ -261,7 +261,7 @@ async function throwForResponse(response: Response): Promise<never> {
   const transient =
     !poisoned && (response.status === 408 || (response.status >= 500 && response.status < 600));
   throw Object.assign(
-    new Error(`Local TTS sidecar returned ${response.status}: ${trimmed || response.statusText}`),
+    new Error(`Local voice engine returned ${response.status}: ${trimmed || response.statusText}`),
     { transient, status: response.status, poisoned },
   );
 }

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -2812,7 +2812,7 @@ async def load_model(req: Request) -> JSONResponse:
     # the drain+respawn instead of trusting a model that won't accept synth yet.
     if _restart_pending:
         return JSONResponse(
-            {"detail": "TTS sidecar is recycling to free memory; retry shortly."},
+            {"detail": "Voice engine is recycling to free memory; retry shortly."},
             status_code=503,
         )
 
@@ -3099,7 +3099,7 @@ async def synthesize(req: Request) -> Response:
         return JSONResponse(
             {
                 "detail": (
-                    "TTS sidecar is in a poisoned CUDA state from a prior CUDA "
+                    "Voice engine is in a poisoned CUDA state from a prior CUDA "
                     "error and must be restarted. A fresh process is being "
                     "respawned automatically; retry once /health responds again."
                     + (f" (trigger: {_process_poison_reason})" if _process_poison_reason else "")
@@ -3115,7 +3115,7 @@ async def synthesize(req: Request) -> Response:
     # waits out the respawn — the in-flight chapter already counted below drains.
     if _restart_pending:
         return JSONResponse(
-            {"detail": "TTS sidecar is recycling to free memory; retry shortly."},
+            {"detail": "Voice engine is recycling to free memory; retry shortly."},
             status_code=503,
         )
 
@@ -3206,7 +3206,7 @@ async def transcribe(req: Request) -> Response:
         return JSONResponse(
             {
                 "detail": (
-                    "TTS sidecar is in a poisoned CUDA state and must be restarted."
+                    "Voice engine is in a poisoned CUDA state and must be restarted."
                     + (f" (trigger: {_process_poison_reason})" if _process_poison_reason else "")
                 ),
                 "poisoned": True,
@@ -3215,7 +3215,7 @@ async def transcribe(req: Request) -> Response:
         )
     if _restart_pending:
         return JSONResponse(
-            {"detail": "TTS sidecar is recycling to free memory; retry shortly."},
+            {"detail": "Voice engine is recycling to free memory; retry shortly."},
             status_code=503,
         )
 
@@ -3300,7 +3300,7 @@ async def synthesize_batch(req: Request) -> Response:
         return JSONResponse(
             {
                 "detail": (
-                    "TTS sidecar is in a poisoned CUDA state from a prior CUDA "
+                    "Voice engine is in a poisoned CUDA state from a prior CUDA "
                     "error and must be restarted. A fresh process is being "
                     "respawned automatically; retry once /health responds again."
                     + (f" (trigger: {_process_poison_reason})" if _process_poison_reason else "")
@@ -3315,7 +3315,7 @@ async def synthesize_batch(req: Request) -> Response:
     # rides out the respawn instead of a fresh batch entering the dying process.
     if _restart_pending:
         return JSONResponse(
-            {"detail": "TTS sidecar is recycling to free memory; retry shortly."},
+            {"detail": "Voice engine is recycling to free memory; retry shortly."},
             status_code=503,
         )
 

--- a/src/components/ModelControlPill.test.tsx
+++ b/src/components/ModelControlPill.test.tsx
@@ -17,10 +17,10 @@ function makeHandlers() {
 
 describe('ModelControlPill — label per state', () => {
   it.each<[ModelControlState, RegExp]>([
-    ['idle', /TTS model idle/i],
-    ['loading', /loading tts model/i],
-    ['ready', /TTS model ready/i],
-    ['unreachable', /TTS model unavailable/i],
+    ['idle', /Voice engine idle/i],
+    ['loading', /loading voice engine/i],
+    ['ready', /Voice engine ready/i],
+    ['unreachable', /Voice engine unavailable/i],
   ])('renders the canonical label for state %s', (state, labelRegex) => {
     const { onLoad, onStop } = makeHandlers();
     render(<ModelControlPill kind="tts" state={state} onLoad={onLoad} onStop={onStop} />);
@@ -102,9 +102,9 @@ describe('ModelControlPill — label per state', () => {
       />,
     );
     expect(screen.getByText(/Kokoro ready/i)).toBeInTheDocument();
-    /* The default "TTS model ready" must NOT appear when engineLabel is set
+    /* The default "Voice engine ready" must NOT appear when engineLabel is set
        — both rendering would leak the abstraction. */
-    expect(screen.queryByText(/TTS model ready/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Voice engine ready/i)).not.toBeInTheDocument();
   });
 
   it('flips engineLabel into the loading + unavailable copy too', () => {

--- a/src/components/ModelControlPill.tsx
+++ b/src/components/ModelControlPill.tsx
@@ -115,7 +115,7 @@ function labelFor(
 }
 
 function kindNoun(kind: ModelKind): string {
-  return kind === 'tts' ? 'TTS model' : 'Analyzer';
+  return kind === 'tts' ? 'Voice engine' : 'Analyzer';
 }
 
 function actionFor(state: ModelControlState): {

--- a/src/components/tts-notice-banner.test.tsx
+++ b/src/components/tts-notice-banner.test.tsx
@@ -48,7 +48,7 @@ describe('TtsNoticeBanner', () => {
     render(
       <TtsNoticeBanner
         evictionNotice="Analyzer unloaded to free VRAM for TTS."
-        loadErrorNotice="TTS model failed to load. Check the sidecar logs."
+        loadErrorNotice="Voice engine failed to load. Check the voice engine logs."
         onDismiss={vi.fn()}
       />,
     );

--- a/src/components/voice-engine-picker.test.tsx
+++ b/src/components/voice-engine-picker.test.tsx
@@ -26,7 +26,7 @@ const baseProps = {
 describe('VoiceEnginePicker — fs-2 lockedToQwen', () => {
   it('locks the selector to Qwen and shows the note when lockedToQwen', () => {
     render(<VoiceEnginePicker {...baseProps} installedEngines={['kokoro', 'qwen']} lockedToQwen />);
-    const select = screen.getByLabelText('TTS engine for this character') as HTMLSelectElement;
+    const select = screen.getByLabelText('Voice engine for this character') as HTMLSelectElement;
     expect(select).toBeDisabled();
     expect(select.value).toBe('qwen');
     /* No "Default (…)" / Kokoro option offered when locked. */
@@ -45,7 +45,7 @@ describe('VoiceEnginePicker — fs-2 lockedToQwen', () => {
         installedEngines={['kokoro', 'qwen']}
       />,
     );
-    const select = screen.getByLabelText('TTS engine for this character') as HTMLSelectElement;
+    const select = screen.getByLabelText('Voice engine for this character') as HTMLSelectElement;
     expect(select).not.toBeDisabled();
     expect(screen.getByRole('option', { name: /Default \(Kokoro\)/ })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: 'Kokoro' })).toBeInTheDocument();

--- a/src/components/voice-engine-picker.tsx
+++ b/src/components/voice-engine-picker.tsx
@@ -100,11 +100,11 @@ export function VoiceEnginePicker({
         className="block text-[11px] text-ink/60 font-medium mb-1.5"
         htmlFor="character-engine"
       >
-        TTS engine for this character
+        Voice engine for this character
       </label>
       <select
         id="character-engine"
-        aria-label="TTS engine for this character"
+        aria-label="Voice engine for this character"
         value={lockedToQwen ? 'qwen' : value}
         disabled={lockedToQwen}
         onChange={(e) => onChange(e.target.value as EngineChoice)}

--- a/src/components/voice-preview-button.test.tsx
+++ b/src/components/voice-preview-button.test.tsx
@@ -99,11 +99,11 @@ describe('VoicePreviewButton', () => {
 
   it('renders the helper error inline when the auto-load helper rejects', async () => {
     vi.mocked(playBaseVoiceSampleWithAutoLoad).mockRejectedValueOnce(
-      new Error('TTS sidecar (:9000) is unreachable — restart it via scripts/start-app.ps1.'),
+      new Error('Voice engine (:9000) is unreachable — restart it via scripts/start-app.ps1.'),
     );
     render(<VoicePreviewButton voice={asyaCoqui} modelKey="kokoro-v1" text="Hello." />);
     fireEvent.click(screen.getByRole('button', { name: /Play sample for Asya Anara/i }));
-    expect(await screen.findByRole('alert')).toHaveTextContent(/sidecar.*unreachable/i);
+    expect(await screen.findByRole('alert')).toHaveTextContent(/voice engine.*unreachable/i);
   });
 
   it('passes the optional aria-label override through', () => {

--- a/src/data/help-failures.ts
+++ b/src/data/help-failures.ts
@@ -14,8 +14,8 @@ export type FailureCode = components['schemas']['FailureCode'];
 
 const TITLES = {
   'vram-spill': 'GPU out of memory (VRAM)',
-  'recycle-storm': 'TTS engine keeps restarting',
-  'sidecar-unreachable': 'TTS sidecar not running',
+  'recycle-storm': 'Voice engine keeps restarting',
+  'sidecar-unreachable': 'Voice engine not running',
   'analyzer-rate-limit': 'Analyzer rate-limited',
   'analyzer-daily-quota': 'Analyzer daily quota exhausted',
   'analyzer-truncated': 'Analyzer reply cut short',
@@ -23,7 +23,7 @@ const TITLES = {
   'attribution-incomplete': 'Chapter attribution incomplete',
   oom: 'Computer ran out of memory',
   'disk-full': 'Disk full',
-  'model-not-loaded': 'TTS model not loaded yet',
+  'model-not-loaded': 'Voice engine not loaded yet',
   'synth-timeout': 'Chapter synthesis timed out',
   'xtts-speaker-desync': 'Voice catalog out of sync',
   'cuda-poisoned': 'GPU error (auto-recovering)',

--- a/src/data/help-topics.ts
+++ b/src/data/help-topics.ts
@@ -13,7 +13,7 @@ export const HELP_TOPICS: HelpTopic[] = [
     title: "The app won't start",
     body:
       'One command starts everything: run `npm start` from the install folder and it brings up ' +
-      'the web app, the server, and the TTS sidecar together. If the browser tab opens but stays ' +
+      'the web app, the server, and the voice engine together. If the browser tab opens but stays ' +
       'blank, hard-refresh (Ctrl+Shift+R). If the terminal shows a port-in-use error, another ' +
       'copy is already running — close it first. On a fresh install, run `npm install` once ' +
       'before the first start.',
@@ -33,9 +33,9 @@ export const HELP_TOPICS: HelpTopic[] = [
     title: 'Generation is much slower than usual',
     body:
       "The usual culprit is a crowded GPU. Check it isn't sharing the card with something heavy " +
-      '(games, a second model), and keep only one heavy TTS model loaded — unload the analyzer ' +
+      '(games, a second model), and keep only one heavy voice engine loaded — unload the analyzer ' +
       'Ollama or a second engine from the model pills. If the slowdown crept in after hours of ' +
-      "generating, restart the TTS sidecar (it reclaims leaked memory). The Admin view's " +
+      "generating, restart the voice engine (it reclaims leaked memory). The Admin view's " +
       'Resource trends panel shows the per-chapter speed history.',
   },
   {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5411,8 +5411,21 @@ async function mockGetModelInventory(): Promise<ModelInventoryResponse> {
         present: true,
         sizeBytes: 2_600_000_000,
         diskPath: null,
-        loaded: true,
+        loaded: MOCK_OLLAMA_RESIDENT.has('qwen3.5:4b'),
         isDefaultEngine: true,
+        isFallbackEngine: false,
+        removable: true,
+        updatable: true,
+      },
+      {
+        id: 'ollama:llama3.1:8b',
+        kind: 'analyzer',
+        label: 'llama3.1:8b',
+        present: true,
+        sizeBytes: 4_700_000_000,
+        diskPath: null,
+        loaded: MOCK_OLLAMA_RESIDENT.has('llama3.1:8b'),
+        isDefaultEngine: false,
         isFallbackEngine: false,
         removable: true,
         updatable: true,
@@ -5433,7 +5446,7 @@ async function mockRemoveModel(id: string): Promise<ModelRemovalResult> {
   if (id === 'kokoro') {
     return { ok: false, code: 'model-is-fallback', error: 'Kokoro is the fallback engine.' };
   }
-  if (id === 'ollama:qwen3.5:4b') {
+  if (id === 'ollama:qwen3.5:4b' && MOCK_OLLAMA_RESIDENT.has('qwen3.5:4b')) {
     return { ok: false, code: 'model-loaded', error: 'qwen3.5:4b is loaded.' };
   }
   MOCK_REMOVED_MODEL_IDS.add(id);
@@ -5455,7 +5468,10 @@ let MOCK_SIDECAR_QWEN_LOADED = false;
    the not-installed promo/warning stub getSidecarHealth directly. */
 const MOCK_SIDECAR_QWEN_INSTALL_STATE: 'not-installed' | 'weights-missing' | 'ready' | 'loaded' =
   'ready';
-let MOCK_OLLAMA_MODEL_LOADED = false;
+/* Per-model residency for the mock analyzer rows so the Model Manager's
+   Load/Stop pills round-trip independently under VITE_USE_MOCKS=true. Starts
+   with the default model resident, mirroring the inventory's loaded:true. */
+const MOCK_OLLAMA_RESIDENT = new Set<string>(['qwen3.5:4b']);
 
 async function realLoadSidecar(
   opts: { engine?: 'coqui' | 'kokoro' | 'qwen' } = {},
@@ -5488,15 +5504,23 @@ async function realUnloadSidecar(
     .catch(() => ({ status: 'error', error: `HTTP ${res.status}` }))) as ModelControlResult;
 }
 
-async function realLoadAnalyzer(): Promise<ModelControlResult> {
-  const res = await fetch('/api/ollama/load', { method: 'POST' });
+async function realLoadAnalyzer(opts: { model?: string } = {}): Promise<ModelControlResult> {
+  const res = await fetch('/api/ollama/load', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(opts.model ? { model: opts.model } : {}),
+  });
   return (await res
     .json()
     .catch(() => ({ status: 'error', error: `HTTP ${res.status}` }))) as ModelControlResult;
 }
 
-async function realUnloadAnalyzer(): Promise<ModelControlResult> {
-  const res = await fetch('/api/ollama/unload', { method: 'POST' });
+async function realUnloadAnalyzer(opts: { model?: string } = {}): Promise<ModelControlResult> {
+  const res = await fetch('/api/ollama/unload', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(opts.model ? { model: opts.model } : {}),
+  });
   return (await res
     .json()
     .catch(() => ({ status: 'error', error: `HTTP ${res.status}` }))) as ModelControlResult;
@@ -5538,15 +5562,16 @@ async function mockUnloadSidecar(
   return { status: 'idle' };
 }
 
-async function mockLoadAnalyzer(): Promise<ModelControlResult> {
+async function mockLoadAnalyzer(opts: { model?: string } = {}): Promise<ModelControlResult> {
   await wait(60);
-  MOCK_OLLAMA_MODEL_LOADED = true;
+  MOCK_OLLAMA_RESIDENT.add(opts.model ?? 'qwen3.5:4b');
   return { status: 'ready' };
 }
 
-async function mockUnloadAnalyzer(): Promise<ModelControlResult> {
+async function mockUnloadAnalyzer(opts: { model?: string } = {}): Promise<ModelControlResult> {
   await wait(40);
-  MOCK_OLLAMA_MODEL_LOADED = false;
+  if (opts.model) MOCK_OLLAMA_RESIDENT.delete(opts.model);
+  else MOCK_OLLAMA_RESIDENT.clear();
   return { status: 'unloaded' };
 }
 
@@ -5555,11 +5580,11 @@ async function mockGetOllamaHealth(): Promise<OllamaHealth> {
   return {
     status: 'reachable',
     url: '(mock)',
-    models: ['qwen3.5:4b'],
+    models: ['qwen3.5:4b', 'llama3.1:8b'],
     expectedModel: 'qwen3.5:4b',
     modelPulled: true,
-    resident: MOCK_OLLAMA_MODEL_LOADED ? ['qwen3.5:4b'] : [],
-    modelResident: MOCK_OLLAMA_MODEL_LOADED,
+    resident: Array.from(MOCK_OLLAMA_RESIDENT),
+    modelResident: MOCK_OLLAMA_RESIDENT.has('qwen3.5:4b'),
   };
 }
 

--- a/src/lib/play-sample-with-auto-load.test.ts
+++ b/src/lib/play-sample-with-auto-load.test.ts
@@ -149,7 +149,7 @@ describe('playSampleWithAutoLoad', () => {
     const message = await playSampleWithAutoLoad({ args: sampleArgs, playback }).catch(
       (e) => (e as Error).message,
     );
-    expect(message).toMatch(/sidecar.*:9000.*unreachable/);
+    expect(message).toMatch(/Voice engine.*:9000.*unreachable/);
     expect(message).toMatch(/ECONNREFUSED/);
     expect(api.loadSidecar).not.toHaveBeenCalled();
     expect(api.getVoiceSample).not.toHaveBeenCalled();
@@ -186,7 +186,7 @@ describe('playSampleWithAutoLoad', () => {
     });
     const playback = { play: vi.fn() };
     await expect(playSampleWithAutoLoad({ args: sampleArgs, playback })).rejects.toThrow(
-      /sidecar.*:9000.*unreachable/,
+      /Voice engine.*:9000.*unreachable/,
     );
   });
 

--- a/src/lib/play-sample-with-auto-load.ts
+++ b/src/lib/play-sample-with-auto-load.ts
@@ -113,7 +113,7 @@ async function prepareSidecar(
        emit `proxy`) — they're the more common failure mode now that
        :8080 is more stable than the Python sidecar's CUDA path. */
     throw new Error(
-      `TTS sidecar (:9000) is unreachable — restart it via scripts\\start-app.ps1 (or kill any stale process holding :9000). [${reason}]`,
+      `Voice engine (:9000) is unreachable — restart it via scripts\\start-app.ps1 (or kill any stale process holding :9000). [${reason}]`,
     );
   }
   if (health.modelLoaded) {
@@ -148,7 +148,7 @@ async function prepareSidecar(
   onStatus?.('loading-tts', { analyzerEvicted: analyzerResident });
   const result = await api.loadSidecar(engine ? { engine } : {});
   if (result.status === 'error') {
-    throw new Error(result.error ?? 'TTS sidecar failed to load.');
+    throw new Error(result.error ?? 'Voice engine failed to load.');
   }
   return { analyzerEvicted: analyzerResident };
 }

--- a/src/lib/use-tts-lifecycle.ts
+++ b/src/lib/use-tts-lifecycle.ts
@@ -218,7 +218,7 @@ export function useTtsLifecycle(): TtsLifecycle {
     try {
       const result = await api.loadSidecar({ engine });
       if (result.status === 'error') {
-        setLoadErrorNotice(result.error || 'TTS model failed to load. Check the sidecar logs.');
+        setLoadErrorNotice(result.error || 'Voice engine failed to load. Check the voice engine logs.');
         setPending(engine, null);
       }
     } catch (e) {

--- a/src/modals/profile-drawer.test.tsx
+++ b/src/modals/profile-drawer.test.tsx
@@ -1044,7 +1044,7 @@ describe('ProfileDrawer per-character engine + Qwen bespoke voice (plan 108)', (
   }
 
   function selectQwen() {
-    const select = screen.getByLabelText('TTS engine for this character');
+    const select = screen.getByLabelText('Voice engine for this character');
     fireEvent.change(select, { target: { value: 'qwen' } });
   }
 

--- a/src/modals/profile-drawer.tsx
+++ b/src/modals/profile-drawer.tsx
@@ -1268,7 +1268,7 @@ export function ProfileDrawer({
             </div>
             <p className="mt-2 text-[11px] text-ink/50">
               Drives the gender + register slot in the voice picker. If the engine picked the wrong
-              voice for this character, correct these and Save — the TTS voice line above updates
+              voice for this character, correct these and Save — the voice line above updates
               immediately.
             </p>
           </section>
@@ -1730,7 +1730,7 @@ function sampleLoadingLabel(status: SampleStatus | 'idle', modelKey: TtsModelKey
     case 'evicting':
       return 'Evicting analyzer to free VRAM…';
     case 'loading-tts':
-      return 'Loading TTS model (~30s)…';
+      return 'Loading voice engine (~30s)…';
     case 'synthesizing':
     case 'idle':
     default:

--- a/src/modals/queue-modal.tsx
+++ b/src/modals/queue-modal.tsx
@@ -546,7 +546,7 @@ function BookGroup({
                     className="mt-1 text-[10px] leading-tight text-ink/45"
                     data-testid={`queue-entry-${entry.id}-dual-model-warning`}
                   >
-                    Mixes TTS engines. Turn on "Keep both TTS engines loaded" in Account settings to
+                    Mixes voice engines. Turn on "Keep both voice engines loaded" in Account settings to
                     avoid engine-swap latency.
                   </p>
                 )}

--- a/src/views/generation.test.tsx
+++ b/src/views/generation.test.tsx
@@ -179,7 +179,7 @@ function makeStore() {
       /* Account slice powers the engines-in-use selector that determines
          which engine pill(s) render in the Generate header. Defaults to
          the same Coqui modelKey the view receives so the existing button-
-         routing assertions ("Load model (tts model)") still find the pill. */
+         routing assertions ("Load model (voice engine)") still find the pill. */
       account: accountSlice.reducer,
     },
   });
@@ -413,7 +413,7 @@ describe('GenerationView — counters exclude ignored chapters (regression)', ()
         />
       </Provider>,
     );
-    expect(screen.getByText('Recovering — restarting TTS engine…')).toBeInTheDocument();
+    expect(screen.getByText('Recovering — restarting voice engine…')).toBeInTheDocument();
     // The frozen synthesising caption must NOT show for the recovering row.
     expect(screen.queryByText(/Synthesising/)).not.toBeInTheDocument();
   });
@@ -944,7 +944,7 @@ describe('GenerationView — TTS Load button auto-evicts the analyzer', () => {
     /* Initial /api/sidecar/health probe runs on mount; once it resolves
        to modelLoaded:false the pill flips from "loading" to "idle" and
        the button label becomes "Load model". */
-    return screen.findByRole('button', { name: /load model \(tts model\)/i });
+    return screen.findByRole('button', { name: /load model \(voice engine\)/i });
   }
 
   it('calls unloadAnalyzer before loadSidecar when the analyzer was loaded', async () => {
@@ -1010,7 +1010,7 @@ describe('GenerationView — TTS Load button auto-evicts the analyzer', () => {
 
     renderView();
     /* Pill state should be "ready" → button reads "Stop". */
-    const stopBtn = await screen.findByRole('button', { name: /stop \(tts model\)/i });
+    const stopBtn = await screen.findByRole('button', { name: /stop \(voice engine\)/i });
     fireEvent.click(stopBtn);
 
     await new Promise((r) => setTimeout(r, 0));

--- a/src/views/generation.tsx
+++ b/src/views/generation.tsx
@@ -922,7 +922,7 @@ export function GenerationView({
           <div className="flex-1 min-w-0">
             <p className="text-sm font-semibold text-amber-900">Worker has gone quiet</p>
             <p className="text-sm text-amber-800/90 mt-0.5">
-              No progress for {stalledSec}s. The TTS engine may be synthesising a batch of lines or
+              No progress for {stalledSec}s. The voice engine may be synthesising a batch of lines or
               retrying — batched synthesis can run a while between updates — so give it a moment, or
               pause and resume to reset the stream.
             </p>
@@ -1418,7 +1418,7 @@ function ChapterRow({
                riding out the respawn. Name it explicitly so a healthy recovery
                doesn't read as a frozen "Synthesising …" line / stall. */
             <span className="block text-[11px] text-magenta tabular-nums mt-0.5 truncate">
-              Recovering — restarting TTS engine…
+              Recovering — restarting voice engine…
             </span>
           ) : chapter.state === 'in_progress' && verifying ? (
             /* srv-31 ASR content-QA pass: the synthesis groups are done and

--- a/src/views/model-manager.test.tsx
+++ b/src/views/model-manager.test.tsx
@@ -185,6 +185,34 @@ describe('ModelManagerView — inventory', () => {
     const coqui = await screen.findByTestId('model-row-coqui');
     expect(within(coqui).queryByRole('button', { name: /load model/i })).toBeNull();
   });
+
+  it('shows a Load pill on a NON-default Ollama row and calls loadAnalyzer with that model', async () => {
+    mockInventory.mockResolvedValue({
+      ...INVENTORY,
+      items: [
+        ...INVENTORY.items,
+        {
+          id: 'ollama:llama3.1:8b',
+          kind: 'analyzer',
+          label: 'llama3.1:8b',
+          present: true,
+          sizeBytes: 4_700_000_000,
+          diskPath: null,
+          loaded: false,
+          isDefaultEngine: false, // NON-default — the whole point
+          isFallbackEngine: false,
+          removable: true,
+          updatable: true,
+        },
+      ],
+    });
+    vi.mocked(api.loadAnalyzer).mockResolvedValue({ status: 'ready' });
+
+    renderManager();
+    const row = await screen.findByTestId('model-row-ollama:llama3.1:8b');
+    within(row).getByRole('button', { name: /load model/i }).click();
+    await waitFor(() => expect(api.loadAnalyzer).toHaveBeenCalledWith({ model: 'llama3.1:8b' }));
+  });
 });
 
 describe('ModelManagerView — remove', () => {

--- a/src/views/model-manager.test.tsx
+++ b/src/views/model-manager.test.tsx
@@ -299,7 +299,7 @@ describe('ModelManagerView — Gemini API key field', () => {
   });
 });
 
-describe('ModelManagerView — TTS sidecar preferences', () => {
+describe('ModelManagerView — voice engine preferences', () => {
   it('renders auto-start checked / unchecked from the preference', async () => {
     renderManager({ autoStartSidecar: false });
     const cb = (await screen.findByTestId('account-auto-start-sidecar')) as HTMLInputElement;

--- a/src/views/model-manager.tsx
+++ b/src/views/model-manager.tsx
@@ -294,25 +294,41 @@ function ModelRow({
   const [installerOpen, setInstallerOpen] = useState(false);
   const Installer = INSTALLER_BY_ID[item.id];
   const engine = TTS_ENGINE_BY_ID[item.id];
-  const isAnalyzerDefault = item.kind === 'analyzer' && item.isDefaultEngine;
-  /* A Load/Unload pill is meaningful only for the sidecar TTS engines and the
-     default analyzer model (Ollama). Qwen VoiceDesign / Whisper load
-     transiently or lazily, and non-default Ollama models aren't load targets. */
-  const hasControl = item.present && (engine !== undefined || isAnalyzerDefault);
+  const isAnalyzer = item.kind === 'analyzer';
+  /* A Load/Unload pill is meaningful for the sidecar TTS engines and for every
+     installed Ollama analyzer model (all analyzer rows are Ollama; cloud Gemini
+     is not a disk artifact and never appears in the inventory). */
+  const hasControl = item.present && (engine !== undefined || isAnalyzer);
 
-  const controlState: ModelControlState = !sidecarReachable
+  /* Analyzer residency depends on the Ollama daemon, not the voice engine
+     (sidecar) — an unreachable daemon already yields zero analyzer rows, so
+     analyzer rows are never 'unreachable' here. Only TTS rows gate on sidecar
+     reachability. */
+  const reachable = isAnalyzer ? true : sidecarReachable;
+  const controlState: ModelControlState = !reachable
     ? 'unreachable'
     : busy
       ? 'loading'
       : item.loaded
         ? 'ready'
         : 'idle';
-  const controlKind: ModelKind = item.kind === 'analyzer' ? 'analyzer' : 'tts';
+  const controlKind: ModelKind = isAnalyzer ? 'analyzer' : 'tts';
 
+  /* Ollama tags contain colons (ollama:qwen3.5:4b) — slice the prefix, never
+     split(':'). Mirrors performRemoval in models-inventory.ts. */
+  const analyzerModel = isAnalyzer ? item.id.slice('ollama:'.length) : undefined;
   const doLoad = () =>
-    onAction(() => (engine ? api.loadSidecar({ engine }) : api.loadAnalyzer()));
+    onAction(() =>
+      engine
+        ? api.loadSidecar({ engine })
+        : api.loadAnalyzer(analyzerModel ? { model: analyzerModel } : undefined),
+    );
   const doStop = () =>
-    onAction(() => (engine ? api.unloadSidecar({ engine }) : api.unloadAnalyzer()));
+    onAction(() =>
+      engine
+        ? api.unloadSidecar({ engine })
+        : api.unloadAnalyzer(analyzerModel ? { model: analyzerModel } : undefined),
+    );
 
   return (
     <li

--- a/src/views/voices.tsx
+++ b/src/views/voices.tsx
@@ -900,7 +900,7 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
         playback,
         onStatus: (status) => {
           if (status === 'evicting') setFamilyStatus({ key: family.key, label: 'Freeing memory…' });
-          if (status === 'loading-tts') setFamilyStatus({ key: family.key, label: 'Loading TTS…' });
+          if (status === 'loading-tts') setFamilyStatus({ key: family.key, label: 'Loading voice engine…' });
           if (status === 'synthesizing')
             setFamilyStatus({ key: family.key, label: 'Synthesising…' });
         },
@@ -924,7 +924,7 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
         playback,
         onStatus: (status) => {
           if (status === 'evicting') setFamilyStatus({ key, label: 'Freeing memory…' });
-          if (status === 'loading-tts') setFamilyStatus({ key, label: 'Loading TTS…' });
+          if (status === 'loading-tts') setFamilyStatus({ key, label: 'Loading voice engine…' });
           if (status === 'synthesizing') setFamilyStatus({ key, label: 'Synthesising…' });
         },
       });
@@ -1941,7 +1941,7 @@ function BaseVoiceCatalogPanel({
             <span className="text-xs text-ink/50">{list.length} voices</span>
             {engine !== activeEngine && (
               <span className="text-[11px] text-amber-700 bg-amber-50 border border-amber-200 px-2 py-0.5 rounded-full">
-                Not the active engine — switch your TTS model to assign these
+                Not the active engine — switch your voice engine to assign these
               </span>
             )}
           </header>


### PR DESCRIPTION
## Summary

Two changes, one branch (spec: `docs/superpowers/specs/2026-06-12-model-manager-ollama-voice-engine-design.md`, plan: `docs/superpowers/plans/2026-06-12-model-manager-ollama-voice-engine.md`).

**A — Per-model Ollama Load/Unload.** Every installed Ollama analyzer model now has its own Load/Unload pill in the Model Manager, not just the configured default. `POST /api/ollama/load` accepts an explicit `{ model }` (threading the analyzer's `num_ctx`/`num_gpu`); `POST /api/ollama/unload` evicts a named model, or — with no body — **every resident model** (`ollama ps`), closing a co-residency OOM gap where a manually-warmed non-default model would otherwise stay resident when a voice engine loads. Mock gains a 2nd non-default model so the feature is demonstrable + e2e-tested.

**B — "TTS" → "Voice engine" copy.** Finishes the rename across the app (pill label, per-character engine picker, generation/queue/voices/profile-drawer strings, Help titles + topics), the server/sidecar user-facing error text (failure-remediations Help copy, sidecar.ts wrappers, chapter-splice/qa-repair, main.py recycle/poisoned details), and README/INSTALL — preserving every detection-matched token (`sidecar not reachable`, `"poisoned":true`, `unreachable`, `stopped responding`, `headroom`, `concurrency`).

Dropped during execution: the A4 button-aria nicety (conflicted with an established pill-query contract); "Local TTS sidecar not reachable" kept verbatim (taxonomy matcher keys on it).

## Test plan

- `npm run verify` green locally (typecheck + lint + all unit/integration tiers + a11y + e2e + visual + build).
- New: server tests for `load`/`unload` model targeting + evict-all; `model-manager.test.tsx` non-default Ollama row; `e2e/model-manager-ollama-load.spec.ts`.
- Paired copy assertions updated across unit + e2e specs; taxonomy/generation-error tests updated for the renamed `sidecar-unreachable` userMessage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)