### PR TITLE
fix(frontend,server): analyzer readiness follows effective model + friendly voice-engine error

### DIFF
--- a/server/src/routes/sidecar-health.test.ts
+++ b/server/src/routes/sidecar-health.test.ts
@@ -465,6 +465,26 @@ describe('POST /api/sidecar/load', () => {
       }),
     );
   });
+
+  it('maps a downed-process fetch failure to friendly copy, not the raw "fetch failed"', async () => {
+    /* The pill's Load click before the sidecar finishes launching → undici
+       rejects with the opaque `TypeError: fetch failed` (real reason in
+       `.cause.code`). The proxy must surface something actionable instead of
+       leaking that string into the error banner. */
+    fetchMock.mockRejectedValue(
+      Object.assign(new TypeError('fetch failed'), {
+        cause: Object.assign(new Error('ECONNREFUSED'), { code: 'ECONNREFUSED' }),
+      }),
+    );
+    const res = await request(makeApp()).post('/api/sidecar/load').send({ engine: 'kokoro' });
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe('error');
+    expect(res.body.error).toMatch(/voice engine/i);
+    expect(res.body.error).toMatch(/starting up|running/i);
+    /* The bare undici string must NOT be the whole message (the ECONNREFUSED
+       code may still appear in the diagnostic parens). */
+    expect(res.body.error).not.toBe('fetch failed');
+  });
 });
 
 describe('POST /api/sidecar/unload', () => {
@@ -517,6 +537,8 @@ describe('POST /api/sidecar/unload', () => {
     const res = await request(makeApp()).post('/api/sidecar/unload');
     expect(res.status).toBe(503);
     expect(res.body.status).toBe('error');
+    expect(res.body.error).toMatch(/voice engine/i);
+    expect(res.body.error).not.toBe('fetch failed');
   });
 });
 

--- a/server/src/routes/sidecar-health.ts
+++ b/server/src/routes/sidecar-health.ts
@@ -30,6 +30,20 @@ const PROBE_TIMEOUT_MS = 2_000;
    leaving the UI with a phantom error and a model that's about to be ready. */
 const LOAD_TIMEOUT_MS = 90_000;
 
+/* When the sidecar PROCESS is down, Node's fetch rejects with the opaque
+   `TypeError: fetch failed` (the real reason — ECONNREFUSED — hides in
+   `.cause.code`). That bare "fetch failed" was leaking straight into the
+   voice-engine pill's error banner when a user clicked Load before the
+   sidecar had finished launching. Map any non-timeout proxy failure to copy
+   the user can act on, with the technical code kept in parens for support. */
+function friendlyUnreachableError(err: { message?: string; cause?: unknown }): string {
+  const code = (err.cause as { code?: string } | undefined)?.code;
+  const detail = code ?? err.message;
+  return `Couldn't reach the voice engine — it may still be starting up, or it isn't running yet. Try again in a moment.${
+    detail ? ` (${detail})` : ''
+  }`;
+}
+
 interface SidecarHealthBody {
   engines?: string[];
   /* fs-1 — sidecar app version (server/tts-sidecar/version.py), surfaced by
@@ -307,13 +321,13 @@ sidecarHealthRouter.post('/load', async (req: Request, res: Response) => {
     return res.json(body);
   } catch (e) {
     clearTimeout(timer);
-    const err = e as { name?: string; message?: string };
+    const err = e as { name?: string; message?: string; cause?: unknown };
     const isTimeout = err.name === 'AbortError';
     return res.status(503).json({
       status: 'error',
       error: isTimeout
         ? `Sidecar /load did not complete within ${LOAD_TIMEOUT_MS}ms — model load is unusually slow or the process is stuck.`
-        : err.message || 'Sidecar /load request failed.',
+        : friendlyUnreachableError(err),
     });
   }
 });
@@ -349,13 +363,13 @@ sidecarHealthRouter.post('/unload', async (req: Request, res: Response) => {
     return res.json(body);
   } catch (e) {
     clearTimeout(timer);
-    const err = e as { name?: string; message?: string };
+    const err = e as { name?: string; message?: string; cause?: unknown };
     const isTimeout = err.name === 'AbortError';
     return res.status(503).json({
       status: 'error',
       error: isTimeout
         ? `Sidecar /unload did not respond within ${PROBE_TIMEOUT_MS}ms.`
-        : err.message || 'Sidecar /unload request failed.',
+        : friendlyUnreachableError(err),
     });
   }
 });

--- a/src/views/analysing.test.tsx
+++ b/src/views/analysing.test.tsx
@@ -1517,6 +1517,84 @@ describe('AnalysingView — request-model gating (plan 118)', () => {
   });
 });
 
+/* Regression: the readiness gate must follow the model the run ACTUALLY uses
+   (the per-phase split), NOT ui.selectedModel. Field report: the account
+   default seeds ui.selectedModel to a local Ollama model on every boot, but the
+   per-phase dropdowns route the run to Gemini — and the view stayed "stuck on
+   Ollama" (Ollama-not-reachable pill, "Waiting for analyzer…", needs-VRAM hint)
+   even though the cloud run never touches Ollama. */
+describe('AnalysingView — readiness gate follows the effective per-phase model', () => {
+  function makeStore(opts: {
+    selectedModel: string;
+    phase0?: string | null;
+    phase1?: string | null;
+  }) {
+    return configureStore({
+      reducer: {
+        ui: uiSlice.reducer,
+        cast: castSlice.reducer,
+        analysis: analysisSlice.reducer,
+        account: accountSlice.reducer,
+      },
+      preloadedState: {
+        ui: {
+          ...uiSlice.getInitialState(),
+          selectedModel: opts.selectedModel,
+          selectedModelExplicit: false,
+        } as ReturnType<typeof uiSlice.getInitialState>,
+        account: {
+          ...accountSlice.getInitialState(),
+          analyzerPhase0Model: opts.phase0 ?? null,
+          analyzerPhase1Model: opts.phase1 ?? null,
+        } as ReturnType<typeof accountSlice.getInitialState>,
+      },
+    });
+  }
+
+  it('does not gate on (or even probe) Ollama when the split routes both phases to cloud, despite a local ui.selectedModel', async () => {
+    /* Even with Ollama down, a cloud run must not be blocked by it. */
+    getOllamaHealthSpy.mockResolvedValue({
+      status: 'unreachable',
+      url: '(test)',
+      error: 'connect ECONNREFUSED',
+    });
+    const store = makeStore({
+      selectedModel: 'qwen3.5:4b', // stale local default seeded from account
+      phase0: 'gemma-4-31b-it', // per-phase split → both cloud
+      phase1: 'gemini-3.1-flash-lite',
+    });
+    render(
+      <Provider store={store}>
+        <AnalysingView manuscriptId="m1" title="Bonus Keefe Story" model="qwen3.5:4b" onComplete={() => {}} />
+      </Provider>,
+    );
+    const startBtn = await screen.findByRole('button', { name: /start analysis/i });
+    expect(startBtn).toBeEnabled();
+    expect(screen.queryByText(/Ollama not reachable/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Waiting for analyzer/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/resident in VRAM/i)).not.toBeInTheDocument();
+    /* The probe effect is gated on isLocalAnalyzer — a cloud-effective run must
+       never reach out to Ollama at all. */
+    expect(getOllamaHealthSpy).not.toHaveBeenCalled();
+  });
+
+  it('still gates on Ollama when the effective run IS local (split off, local default)', async () => {
+    getOllamaHealthSpy.mockResolvedValue({
+      status: 'unreachable',
+      url: '(test)',
+      error: 'connect ECONNREFUSED',
+    });
+    const store = makeStore({ selectedModel: 'qwen3.5:4b' }); // no per-phase split
+    render(
+      <Provider store={store}>
+        <AnalysingView manuscriptId="m1" title="Bonus Keefe Story" model="qwen3.5:4b" onComplete={() => {}} />
+      </Provider>,
+    );
+    expect(await screen.findByText(/Ollama not reachable/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /waiting for analyzer/i })).toBeDisabled();
+  });
+});
+
 describe('AnalysingView — Wave 2 brand manifesto', () => {
   it('renders "Many voices, one machine." on the analysing screen', () => {
     renderView();

--- a/src/views/analysing.tsx
+++ b/src/views/analysing.tsx
@@ -260,22 +260,42 @@ export function AnalysingView({
      analyzer Load/Stop machinery lives further down; this slice pulls
      just the bits the analysis effect needs to decide whether it's
      safe to fire the SSE. */
-  const selectedModel = useMemo(() => {
-    const id = model ?? MODEL_OPTIONS[0].id;
-    return MODEL_OPTIONS.find((m) => m.id === id);
-  }, [model]);
-  const isLocalAnalyzer = selectedModel?.engine === 'local';
-  /* Plan 118 — the model id to SEND on the request (distinct from the
-     readiness/engine derivation above, which keeps reading the always-
-     populated `model` prop = ui.selectedModel). When the user has a per-phase
-     split configured AND hasn't made an explicit per-run pick, send nothing
-     so the server's saved per-phase models apply (precedence priority 3).
-     Otherwise send the selected model — preserving the single-model path
+  /* Plan 118 — the model id to SEND on the request. When the user has a
+     per-phase split configured AND hasn't made an explicit per-run pick, send
+     nothing so the server's saved per-phase models apply (precedence priority
+     3). Otherwise send the selected model — preserving the single-model path
      (split off → both phases use defaultAnalysisModel) and the explicit
      per-run override (priority 2). */
   const splitActive = useAppSelector((s) => selectAnalyzerSplitIsActive(s.account));
   const selectedModelExplicit = useAppSelector((s) => s.ui.selectedModelExplicit);
+  const phase0Model = useAppSelector((s) => s.account.analyzerPhase0Model);
+  const phase1Model = useAppSelector((s) => s.account.analyzerPhase1Model);
   const requestModel = splitActive && !selectedModelExplicit ? undefined : model;
+  /* The model id(s) the run will ACTUALLY execute on. The readiness/engine
+     gate MUST derive from these, not from ui.selectedModel: ui.selectedModel is
+     re-seeded from the account default on every boot (ui-slice.ts), so a user
+     who once used Ollama keeps a stale LOCAL default there even after switching
+     the per-phase dropdowns to a cloud model. Reading it directly left the view
+     "stuck on Ollama" — probing the daemon, blocking Start on VRAM residency —
+     for a Gemini run that never calls Ollama. Mirror requestModel exactly:
+       - split engaged, no explicit pick → the saved per-phase models (a blank
+         phase falls through to the server's own default, which the client
+         can't see; treat as not-local so a cloud deployment isn't gated on an
+         Ollama it never calls);
+       - otherwise → the single per-run model (or the built-in default). */
+  const effectiveModelIds = useMemo<string[]>(() => {
+    if (splitActive && !selectedModelExplicit) {
+      return [phase0Model, phase1Model].filter((id): id is string => Boolean(id));
+    }
+    return [model ?? MODEL_OPTIONS[0].id];
+  }, [splitActive, selectedModelExplicit, phase0Model, phase1Model, model]);
+  const isLocalAnalyzer = effectiveModelIds.some(
+    (id) => MODEL_OPTIONS.find((m) => m.id === id)?.engine === 'local',
+  );
+  /* Engine tag captured into the cross-navigation snapshot (read by the
+     reverse-local-analyzer guard). Mirror the effective-local derivation so a
+     cloud run is never mis-tagged 'local' and made to nag the TTS-start path. */
+  const effectiveEngine: 'local' | 'gemini' = isLocalAnalyzer ? 'local' : 'gemini';
   const [ollamaHealth, setOllamaHealth] = useState<OllamaHealth | null>(null);
   const [pendingAnalyzerPill, setPendingAnalyzerPill] = useState<ModelControlState | null>(null);
   const [analyzerProbeKey, setAnalyzerProbeKey] = useState(0);
@@ -351,7 +371,7 @@ export function AnalysingView({
          later. A user model-switch mid-stream must not mis-classify a
          running analysis from the reverse-direction guard's
          perspective (see use-reverse-local-analyzer-guard.tsx). */
-        engine: selectedModel?.engine,
+        engine: effectiveEngine,
         phaseId: 0,
         phaseLabel: ANALYSIS_PHASES[0]?.label ?? 'Detecting characters',
         phaseProgress: 0,
@@ -677,7 +697,7 @@ export function AnalysingView({
         bookId: bookId ?? null,
         manuscriptId,
         bookTitle: title ?? undefined,
-        engine: selectedModel?.engine,
+        engine: effectiveEngine,
         phaseId: 0,
         phaseLabel: ANALYSIS_PHASES[0]?.label ?? 'Detecting characters',
         phaseProgress: 0,
@@ -796,7 +816,7 @@ export function AnalysingView({
               bookId: bookId ?? null,
               manuscriptId,
               bookTitle: title ?? undefined,
-              engine: selectedModel?.engine,
+              engine: effectiveEngine,
               phaseId: 0,
               phaseLabel: ANALYSIS_PHASES[0]?.label ?? 'Detecting characters',
               phaseProgress: 0,


### PR DESCRIPTION
## Summary

Two alpha-tester papercuts in the model-readiness UX, traced to root cause via systematic debugging and fixed at the source.

### 1. Analysing view stays "stuck on Ollama" with a cloud model — Closes #769
The readiness gate derived `isLocalAnalyzer` from `ui.selectedModel`, but the run actually uses the **per-phase** models (`requestModel`). `ui.selectedModel` is re-seeded from the account default every boot, so a user who'd used Ollama kept a stale **local** default there even after switching the per-phase dropdowns to Gemini — leaving the view showing "Ollama not reachable", "Waiting for analyzer…", and the needs-VRAM hint for a cloud run that never calls Ollama.

**Fix:** derive the gate (and the snapshot `engine` tag the reverse-analyzer guard reads) from the **effective** model ids the run will execute on — per-phase models when the split is engaged, else the single per-run model. A blank phase = server default (unknown) → treated as not-local.

### 2. Raw "fetch failed" from the voice-engine Load pill — Closes #770
`POST /api/sidecar/{load,unload}` forwarded undici's opaque `"fetch failed"` (ECONNREFUSED hides in `.cause.code`) verbatim. Clicking **Load** before the sidecar finished launching leaked that string into the pill's error banner.

**Fix:** map any non-timeout proxy failure to actionable copy — *"Couldn't reach the voice engine — it may still be starting up, or it isn't running yet. Try again in a moment."* — keeping the technical code in parens. Timeouts + real upstream error envelopes keep their existing specific messages.

## Test plan
- `src/views/analysing.test.tsx` — new regression block: cloud-effective run → no Ollama pill/copy, Start enabled, Ollama never probed; genuine-local run → gate preserved. **54/54 pass.**
- `server/src/routes/sidecar-health.test.ts` — `/load` + `/unload` ECONNREFUSED → friendly message, never the bare "fetch failed". **32/32 pass.**
- Typecheck (frontend + server): clean.
- Full `test:server` (2549/2549) + `test:server-slow` (224/224) verified green in isolation. Pre-push hook flaked 3× under local box contention (heavy Chrome + verify parallelism); pushed with `--no-verify` per maintainer authorization — **draft, so CI runs the full battery once on promotion to ready.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)