### PR TITLE
fix(frontend): deterministic listen-resume e2e via pre-boot bookmark seed

### DIFF
--- a/e2e/listen-resume.spec.ts
+++ b/e2e/listen-resume.spec.ts
@@ -14,64 +14,57 @@ import { waitForListenViewReady } from './helpers';
  *
  * Pairs with docs/features/archive/47-listen-progress.md.
  */
+
+/* Prime the mock listen-progress RECORD via an init script that runs BEFORE
+   the app boots, so the layout mount-effect's `getListenProgress('sb')`
+   reads this bookmark on its very first call and hydrates the slice. This is
+   deterministic: dispatching the slice AFTER navigation is fragile because the
+   same async fetch returns empty for an un-seeded book and can clobber the
+   dispatched value (it did once the tour-status boot fetch shifted effect
+   timing). The mock honours `window.__SEED_LISTEN_PROGRESS__` (see
+   `mockGetListenProgress`). */
+async function gotoListenWithBookmark(
+  page: import('@playwright/test').Page,
+  bookmark: { chapterId: number; currentSec: number },
+) {
+  await page.addInitScript((bm) => {
+    (
+      window as unknown as { __SEED_LISTEN_PROGRESS__: Record<string, unknown> }
+    ).__SEED_LISTEN_PROGRESS__ = {
+      sb: { chapterId: bm.chapterId, currentSec: bm.currentSec, updatedAt: new Date().toISOString() },
+    };
+  }, bookmark);
+  await page.goto('/#/books/sb/listen');
+  /* Generous: the first spec to reach the listen view pays a cold Vite
+     transform when the warmup project is skipped (CI / single-spec runs). */
+  await expect(page.getByRole('heading', { name: /Solway Bay/i, level: 1 })).toBeVisible({
+    timeout: 25_000,
+  });
+}
+
+/* Absorb a cold first-transform of the listen view (the warmup project is
+   skipped on CI / when running this spec in isolation). */
+test.describe.configure({ timeout: 90_000 });
+
 test.describe('listen-progress resume', () => {
-  test('shows the Resume pill when a bookmark exists and seeks playback to it', async ({
-    page,
-  }) => {
-    await page.goto('/#/books/sb/listen');
-    await expect(page.getByRole('heading', { name: /Solway Bay/i, level: 1 })).toBeVisible({
-      timeout: 10_000,
-    });
 
-    /* Seed the mock listen-progress slice + on-disk record for the
-       Solway Bay book by dispatching the slice action AND priming
-       the mock API. The on-disk path (mockPutListenProgress) is what
-       the MiniPlayer's mount-effect fetch reads, so both routes need
-       the same record. */
-    await page.evaluate(async () => {
-      const store = (
-        window as unknown as {
-          __store__: { dispatch: (a: unknown) => void };
-        }
-      ).__store__;
-      store.dispatch({
-        type: 'listenProgress/hydrate',
-        payload: {
-          bookId: 'sb',
-          progress: { chapterId: 1, currentSec: 67, updatedAt: new Date().toISOString() },
-        },
-      });
-    });
+  test('shows the Resume pill when a bookmark exists and seeks playback to it', async ({ page }) => {
+    await gotoListenWithBookmark(page, { chapterId: 1, currentSec: 67 });
 
-    /* Pill renders inside chapter 1's row. */
+    /* Pill renders inside chapter 1's row. formatTime(67) → "1:07". */
     const chapter1 = page.getByTestId('chapter-row-1');
-    await expect(chapter1.getByText(/Resume at/i)).toBeVisible({ timeout: 3_000 });
-    /* formatTime(67) → "1:07" */
+    await expect(chapter1.getByText(/Resume at/i)).toBeVisible({ timeout: 5_000 });
     await expect(chapter1.getByText(/Resume at 1:07/)).toBeVisible();
   });
 
   test('does NOT show the pill for chapters other than the bookmarked one', async ({ page }) => {
-    await page.goto('/#/books/sb/listen');
-    await expect(page.getByRole('heading', { name: /Solway Bay/i, level: 1 })).toBeVisible({
-      timeout: 10_000,
-    });
-
     /* Bookmark on chapter 1 should not surface a pill on chapter 2's row. */
-    await page.evaluate(async () => {
-      const store = (
-        window as unknown as {
-          __store__: { dispatch: (a: unknown) => void };
-        }
-      ).__store__;
-      store.dispatch({
-        type: 'listenProgress/hydrate',
-        payload: {
-          bookId: 'sb',
-          progress: { chapterId: 1, currentSec: 67, updatedAt: new Date().toISOString() },
-        },
-      });
-    });
+    await gotoListenWithBookmark(page, { chapterId: 1, currentSec: 67 });
 
+    /* Confirm the bookmark hydrated (pill on ch1) before asserting absence. */
+    await expect(page.getByTestId('chapter-row-1').getByText(/Resume at/i)).toBeVisible({
+      timeout: 5_000,
+    });
     const chapter2 = page.getByTestId('chapter-row-2');
     await expect(chapter2).toBeVisible();
     await expect(chapter2.getByText(/Resume at/i)).not.toBeVisible();
@@ -80,26 +73,8 @@ test.describe('listen-progress resume', () => {
   test('does NOT show the pill when the bookmarked position is under the 5 s noise floor', async ({
     page,
   }) => {
-    await page.goto('/#/books/sb/listen');
-    await expect(page.getByRole('heading', { name: /Solway Bay/i, level: 1 })).toBeVisible({
-      timeout: 10_000,
-    });
-
     /* currentSec = 3 (below the 5 s gate the ChapterListenRow uses). */
-    await page.evaluate(async () => {
-      const store = (
-        window as unknown as {
-          __store__: { dispatch: (a: unknown) => void };
-        }
-      ).__store__;
-      store.dispatch({
-        type: 'listenProgress/hydrate',
-        payload: {
-          bookId: 'sb',
-          progress: { chapterId: 1, currentSec: 3, updatedAt: new Date().toISOString() },
-        },
-      });
-    });
+    await gotoListenWithBookmark(page, { chapterId: 1, currentSec: 3 });
 
     const chapter1 = page.getByTestId('chapter-row-1');
     await expect(chapter1).toBeVisible();
@@ -112,29 +87,14 @@ test.describe('listen-progress resume', () => {
      `!isPlaying` gate at the browser level; deterministic because the
      gate keys on currentTrack, not on the audio playhead. */
   test('hides the Resume pill once the bookmarked chapter starts playing', async ({ page }) => {
-    await page.goto('/#/books/sb/listen');
+    await gotoListenWithBookmark(page, { chapterId: 1, currentSec: 67 });
     /* Wait for the chapters slice to hydrate (Play-from-start enabled) so
        the row's play handler is wired before we click — otherwise the
        click can land pre-hydration and currentTrack never updates. */
     await waitForListenViewReady(page, /Solway Bay/i);
 
-    await page.evaluate(async () => {
-      const store = (
-        window as unknown as {
-          __store__: { dispatch: (a: unknown) => void };
-        }
-      ).__store__;
-      store.dispatch({
-        type: 'listenProgress/hydrate',
-        payload: {
-          bookId: 'sb',
-          progress: { chapterId: 1, currentSec: 67, updatedAt: new Date().toISOString() },
-        },
-      });
-    });
-
     const chapter1 = page.getByTestId('chapter-row-1');
-    await expect(chapter1.getByText(/Resume at/i)).toBeVisible({ timeout: 3_000 });
+    await expect(chapter1.getByText(/Resume at/i)).toBeVisible({ timeout: 5_000 });
 
     /* Start playback from this chapter's row. Assert the button flips to
        "Pause chapter 1" first — that proves currentTrack propagated and

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1122,7 +1122,15 @@ const MOCK_LISTEN_PROGRESS = new Map<string, ListenProgress>();
 
 export async function mockGetListenProgress(bookId: string): Promise<ListenProgress | null> {
   await wait(15);
-  return MOCK_LISTEN_PROGRESS.get(bookId) ?? null;
+  const fromMap = MOCK_LISTEN_PROGRESS.get(bookId);
+  if (fromMap) return fromMap;
+  /* e2e seam: a spec can prime a bookmark via `page.addInitScript` BEFORE
+     the app boots, so the very first layout hydrate reads it — deterministic,
+     no post-navigation dispatch race. Undefined in normal dev/prod. */
+  const seeded = (
+    globalThis as unknown as { __SEED_LISTEN_PROGRESS__?: Record<string, ListenProgress> }
+  ).__SEED_LISTEN_PROGRESS__?.[bookId];
+  return seeded ?? null;
 }
 
 export async function mockPutListenProgress(


### PR DESCRIPTION
## Summary

Fixes the `e2e/listen-resume.spec.ts` failure on `main`. The spec seeded the listen-progress bookmark by dispatching the Redux slice **after** navigation, which raced `layout.tsx`'s async `getListenProgress('sb')`. For the un-seeded mock book that fetch returns empty, and once the guided-tour boot fetch (`30c59439`) shifted effect timing it resolved last — clearing the seeded bookmark, so the "Resume at" pill never rendered.

The fix seeds the mock bookmark via `page.addInitScript` **before the app boots**: `mockGetListenProgress` now falls back to `window.__SEED_LISTEN_PROGRESS__`, so the very first layout hydrate reads the bookmark. No post-nav dispatch, no race. A single direct `goto` plus generous heading/describe-level timeouts absorb a cold listen-view transform when the warmup project is skipped (CI / single-spec).

## Test plan

`e2e/listen-resume.spec.ts` — **20/20 across `--repeat-each=5`**, zero flakes (was a hard fail on `main`). Typecheck clean; `src/lib/api` unit tests (53) green. The mock seam is mock-only and inert unless `window.__SEED_LISTEN_PROGRESS__` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)