### PR TITLE
build(app,ci): add Google Play AAB distribution channel

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -60,6 +60,11 @@ jobs:
           name: castwright-release-apk
           path: apps/android/build/app/outputs/flutter-apk/app-release.apk
           if-no-files-found: error
+      # Build-health for the Google Play channel: keep `bundleRelease` green so
+      # the AAB target can't rot. Debug-signed here (no keystore secret in CI) —
+      # NOT a Play upload artifact; the real Play AAB is built locally with the
+      # upload keystore (`android/key.properties`). See apps/android/README.md.
+      - run: flutter build appbundle --release
 
   ios-compile:
     runs-on: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,20 +75,29 @@ jobs:
       - name: Build
         run: npm run build
 
-  # Build the installable companion APK ONCE (versioned in lockstep via
-  # bump-version.mjs → pubspec) and hand it to `publish` as a workflow artifact.
-  # `publish` both bundles it INTO the server zip (so the in-app "Download .apk"
-  # button works straight from the install) and attaches it as a standalone
-  # release asset. Building here (not inside publish) keeps the Flutter toolchain
-  # off the zip job and lets the APK build run in parallel with verify.
+  # Build the companion artifacts ONCE (versioned in lockstep via
+  # bump-version.mjs → pubspec) and hand them to `publish` as a workflow
+  # artifact. Two parallel channels from one signed build:
+  #   - the sideload APK, which `publish` bundles INTO the server zip (so the
+  #     in-app "Download .apk" button works straight from the install) AND
+  #     attaches as a standalone release asset;
+  #   - the Google Play AAB, attached as a standalone release asset for the
+  #     Play internal/closed testing track.
+  # Building here (not inside publish) keeps the Flutter toolchain off the zip
+  # job and lets the build run in parallel with verify.
   companion-apk-build:
-    name: Build companion APK
+    name: Build companion APK + AAB
     needs: verify
     runs-on: ubuntu-latest
     timeout-minutes: 20
     defaults:
       run:
         working-directory: apps/android
+    # Expose whether the build was signed with the real upload key so `publish`
+    # only attaches the AAB when it's an actual Play-uploadable artifact (a
+    # debug-signed AAB is useless — Play rejects it).
+    outputs:
+      signed: ${{ steps.signing.outputs.signed }}
     steps:
       - uses: actions/checkout@v6
       - uses: subosito/flutter-action@v2
@@ -96,22 +105,60 @@ jobs:
           channel: stable
           flutter-version: 3.44.1
           cache: true
+      # app-11 release signing in CI: materialise the git-ignored upload keystore
+      # + key.properties from repo secrets so the released APK + AAB are signed
+      # with the STABLE upload key (Play App Signing). Without the secret (forks,
+      # or before the maintainer adds it) the release build falls back to debug
+      # signing exactly as before — the AAB is then NOT attached (see `signed`).
+      # Required secrets: ANDROID_UPLOAD_KEYSTORE_BASE64 (base64 of
+      # upload-keystore.jks), ANDROID_UPLOAD_KEYSTORE_PASSWORD,
+      # ANDROID_UPLOAD_KEY_PASSWORD, ANDROID_UPLOAD_KEY_ALIAS.
+      - name: Wire upload keystore (release signing)
+        id: signing
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_UPLOAD_KEY_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_UPLOAD_KEY_ALIAS }}
+        run: |
+          if [ -z "$KEYSTORE_BASE64" ]; then
+            echo "::warning::No ANDROID_UPLOAD_KEYSTORE_BASE64 secret — release APK/AAB will be DEBUG-signed and the AAB will NOT be attached (Play rejects debug-signed bundles). Add the upload-keystore secrets to ship a Play artifact."
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "$KEYSTORE_BASE64" | base64 -d > android/app/upload-keystore.jks
+          {
+            echo "storePassword=$KEYSTORE_PASSWORD"
+            echo "keyPassword=$KEY_PASSWORD"
+            echo "keyAlias=$KEY_ALIAS"
+            echo "storeFile=upload-keystore.jks"
+          } > android/key.properties
+          echo "Wired upload keystore — release APK + AAB are upload-key-signed."
+          echo "signed=true" >> "$GITHUB_OUTPUT"
       - run: flutter pub get
       - run: flutter build apk --release
+      - run: flutter build appbundle --release
       - name: Stage + checksum
         run: |
           cp build/app/outputs/flutter-apk/app-release.apk \
             "castwright-${{ github.ref_name }}.apk"
+          cp build/app/outputs/bundle/release/app-release.aab \
+            "castwright-${{ github.ref_name }}.aab"
           shasum -a 256 "castwright-${{ github.ref_name }}.apk" \
             > "castwright-${{ github.ref_name }}.apk.sha256"
-          cat "castwright-${{ github.ref_name }}.apk.sha256"
-      - name: Upload APK artifact
+          shasum -a 256 "castwright-${{ github.ref_name }}.aab" \
+            > "castwright-${{ github.ref_name }}.aab.sha256"
+          cat "castwright-${{ github.ref_name }}.apk.sha256" \
+            "castwright-${{ github.ref_name }}.aab.sha256"
+      - name: Upload companion artifacts
         uses: actions/upload-artifact@v4
         with:
           name: companion-apk
           path: |
             apps/android/castwright-${{ github.ref_name }}.apk
             apps/android/castwright-${{ github.ref_name }}.apk.sha256
+            apps/android/castwright-${{ github.ref_name }}.aab
+            apps/android/castwright-${{ github.ref_name }}.aab.sha256
           retention-days: 1
 
   # Publish: builds the zip + SHA-256 on Ubuntu (the zip is platform-
@@ -224,6 +271,19 @@ jobs:
           gh release upload "${{ github.ref_name }}" \
             "companion-apk/castwright-${{ github.ref_name }}.apk" \
             "companion-apk/castwright-${{ github.ref_name }}.apk.sha256" --clobber
+
+      - name: Attach companion AAB to release (Google Play)
+        # The Play App Bundle for the internal/closed testing track. Attached only
+        # when the build was signed with the real upload key (see the build job's
+        # `signed` output) — a debug-signed AAB is not Play-uploadable. NOT bundled
+        # into the server zip: the zip serves the APK; the AAB is a Play artifact.
+        if: needs.companion-apk-build.outputs.signed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            "companion-apk/castwright-${{ github.ref_name }}.aab" \
+            "companion-apk/castwright-${{ github.ref_name }}.aab.sha256" --clobber
 
   # plan 188 / app-12 prep — build the companion for iOS UNSIGNED so the release
   # pathway exists + the iOS build is gated each release. An installable .ipa

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -80,10 +80,22 @@ flutter build appbundle --release   # build/app/outputs/bundle/release/app-relea
 **Play signing model (Play App Signing):** the `android/key.properties`
 keystore is your **upload key** — you sign every AAB upload with it; Google
 holds the app *signing* key and re-signs what users download. The AAB **must**
-be signed with the real upload key (`key.properties` present), so build it
-**locally** — CI falls back to debug signing, which Play rejects. Verify a
-build with `keytool -printcert -jarfile app-release.aab` (AABs are JAR-signed,
-so `keytool` reads them; APKs are v2-signed — use
+be signed with the real upload key, which Play accepts but a debug-signed bundle
+is rejected.
+
+**Two ways to get a signed AAB:**
+
+- **Release pipeline (preferred for tagged releases).** With the four
+  `ANDROID_UPLOAD_*` repo secrets set (see `android/key.properties.example`),
+  `.github/workflows/release.yml` materialises the keystore, builds the
+  **upload-key-signed** APK *and* AAB, and attaches
+  `castwright-vX.Y.Z.aab` (+ `.sha256`) to the GitHub Release. Without the
+  secrets it falls back to debug signing and skips the AAB attach.
+- **Locally (for ad-hoc Play uploads).** With `android/key.properties` present:
+  `flutter build appbundle --release`.
+
+Verify a build with `keytool -printcert -jarfile app-release.aab` (AABs are
+JAR-signed, so `keytool` reads them; APKs are v2-signed — use
 `apksigner verify --print-certs` for those).
 
 **versionCode** is derived monotonically from the semver by

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -98,6 +98,25 @@ Verify a build with `keytool -printcert -jarfile app-release.aab` (AABs are
 JAR-signed, so `keytool` reads them; APKs are v2-signed — use
 `apksigner verify --print-certs` for those).
 
+### Iterating internal-test builds (no marketing bump)
+
+Play forbids reusing a **versionCode**, so a second upload of the *same*
+marketing version needs a higher code. `bump-version.mjs` derives the
+versionCode as `(M*10000 + m*100 + p) * 1000` — the `×1000` reserves a 3-digit
+**iteration band** (999 slots) below the next patch's base. So for `1.6.0` the
+base is `10600000`; iterate internal-test uploads by overriding the build
+number:
+
+```sh
+flutter build appbundle --release --build-number=10600001   # 2nd 1.6.0 upload
+flutter build appbundle --release --build-number=10600002   # 3rd, etc.
+```
+
+The tagged **release** uses the base (iteration 0). To ship a tested build to
+production, **promote** the chosen internal build in Play Console (same
+versionCode — no re-upload) rather than re-cutting iteration 0, or bump the
+patch. The iteration band never overlaps the next patch (`1.6.1 → 10601000`).
+
 **versionCode** is derived monotonically from the semver by
 `scripts/bump-version.mjs` (`M*10000 + m*100 + p`, e.g. `1.6.0 → 10600`), so
 each released version uploads cleanly. Play forbids reusing a versionCode —

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -60,6 +60,46 @@ A signed release APK for sideloading: see **`app-11`** in the plan
 (`flutter build apk --release` — falls back to debug signing unless
 `android/key.properties` is present; copy `android/key.properties.example`).
 
+## Two distribution channels: sideload APK + Play AAB
+
+The companion ships through **two parallel channels** — both built from the same
+signed release config, neither replaces the other:
+
+1. **Sideload APK** (`flutter build apk --release`) — the load-bearing channel.
+   The release pipeline bundles it into the server zip at
+   `companion/castwright-companion.apk`, where `GET /api/companion/apk` serves
+   the in-app **Download .apk** button. This stays the default install path.
+2. **Google Play App Bundle** (`flutter build appbundle --release`) →
+   `build/app/outputs/bundle/release/app-release.aab` — for the Play
+   **internal/closed testing** track. Play requires an **AAB**, not an APK.
+
+```sh
+flutter build appbundle --release   # build/app/outputs/bundle/release/app-release.aab
+```
+
+**Play signing model (Play App Signing):** the `android/key.properties`
+keystore is your **upload key** — you sign every AAB upload with it; Google
+holds the app *signing* key and re-signs what users download. The AAB **must**
+be signed with the real upload key (`key.properties` present), so build it
+**locally** — CI falls back to debug signing, which Play rejects. Verify a
+build with `keytool -printcert -jarfile app-release.aab` (AABs are JAR-signed,
+so `keytool` reads them; APKs are v2-signed — use
+`apksigner verify --print-certs` for those).
+
+**versionCode** is derived monotonically from the semver by
+`scripts/bump-version.mjs` (`M*10000 + m*100 + p`, e.g. `1.6.0 → 10600`), so
+each released version uploads cleanly. Play forbids reusing a versionCode —
+**bump the version before re-uploading the same train to a Play track.**
+
+**Two Play caveats** (neither blocks internal testing):
+- **Android Auto** (`app-9`, the `com.google.android.gms.car.application`
+  descriptor) triggers a separate Play "Cars" review before Auto works on a
+  head unit. The app still installs to internal testing without it.
+- **App Links** (`castwright.ai/pair`, `app-17`) need
+  `/.well-known/assetlinks.json` to pin the **Play app-signing key** SHA-256
+  (read it from Play Console *after* enrollment — not the upload-key
+  fingerprint).
+
 ## Pairing to your server
 
 The companion needs the server running in **LAN HTTPS mode with an access

--- a/apps/android/android/app/build.gradle.kts
+++ b/apps/android/android/app/build.gradle.kts
@@ -28,10 +28,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId = "ai.castwright"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode

--- a/apps/android/android/key.properties.example
+++ b/apps/android/android/key.properties.example
@@ -8,8 +8,15 @@
 #     -validity 10000 -alias upload
 # Then point storeFile at it (path relative to android/app, or absolute).
 #
-# In CI, write this file from repository secrets before `flutter build apk --release`
-# and base64-decode the keystore — never commit either.
+# In CI (.github/workflows/release.yml) this file + the keystore are materialised
+# from repository secrets before the release build, so the released APK + AAB are
+# signed with the upload key. Set these four repo secrets (Settings → Secrets and
+# variables → Actions), or via `gh secret set`:
+#   ANDROID_UPLOAD_KEYSTORE_BASE64    # base64 of upload-keystore.jks
+#   ANDROID_UPLOAD_KEYSTORE_PASSWORD
+#   ANDROID_UPLOAD_KEY_PASSWORD
+#   ANDROID_UPLOAD_KEY_ALIAS          # = upload
+# Never commit the keystore or this file.
 
 storePassword=changeit
 keyPassword=changeit

--- a/apps/android/lib/src/data/drift_local_library.dart
+++ b/apps/android/lib/src/data/drift_local_library.dart
@@ -37,12 +37,19 @@ class DownloadedChapter {
     required this.title,
     required this.durationSec,
     required this.urlSuffix,
+    this.bytes = 0,
   });
   final String uuid;
   final int chapterId;
   final String title;
   final double? durationSec;
   final String? urlSuffix;
+
+  /// On-disk byte size of the downloaded audio (0 when the file is absent —
+  /// e.g. a finished chapter whose file was evicted but whose row remains).
+  /// The Android Auto browse tree filters to `bytes > 0` so only playable
+  /// chapters appear in the car.
+  final int bytes;
 }
 
 /// The production on-device store (`app-4`): a drift/SQLite-backed
@@ -181,6 +188,7 @@ class DriftLocalLibrary implements LocalLibrary, PlaybackStore, ThumbnailStore {
           title: r.title,
           durationSec: r.durationSec,
           urlSuffix: r.urlSuffix,
+          bytes: r.bytes,
         ),
     ];
   }
@@ -340,6 +348,18 @@ class DriftLocalLibrary implements LocalLibrary, PlaybackStore, ThumbnailStore {
       positionMs: row.positionMs,
       listenedAt: row.updatedAt,
     );
+  }
+
+  /// The `bookId` with the most recent resume activity (max `playback.updatedAt`),
+  /// or null if nothing has ever been played. Drives the Android Auto "current
+  /// book" tab on cold connect, when no book is loaded in the player yet.
+  Future<String?> mostRecentlyPlayedBookId() async {
+    final row = await (_db.select(_db.playback)
+          ..orderBy(
+              [(p) => OrderingTerm(expression: p.updatedAt, mode: OrderingMode.desc)])
+          ..limit(1))
+        .getSingleOrNull();
+    return row?.bookId;
   }
 
   /// One-time migration: if the `app-3` JSON snapshot exists under [_rootPath],

--- a/apps/android/lib/src/domain/media_browse_tree.dart
+++ b/apps/android/lib/src/domain/media_browse_tree.dart
@@ -6,10 +6,36 @@ library;
 
 const String rootMediaId = 'root';
 
+/// Tab-1 sentinel — resolves to the current book's chapter list (app-9).
+const String currentMediaId = 'current';
+
+/// Tab-2 sentinel — resolves to the downloaded-book library.
+const String libraryMediaId = 'library';
+
+/// audio_service's "recent" root (`AudioService.recentRootId`) — Android Auto /
+/// Assistant query this for one-tap resume. We answer it with the current chapter.
+const String recentMediaId = 'recent';
+
 String bookMediaId(String bookId) => 'book/$bookId';
 String chapterMediaId(String bookId, String uuid) => 'chapter/$bookId/$uuid';
 
-enum MediaIdKind { root, book, chapter, unknown }
+// --- Android Auto content-style extras -----------------------------------
+// AA reads these keys from a browsable parent's extras to decide how to render
+// its children (1 = list, 2 = grid). `MediaItem.extras` are propagated to AA.
+const String _contentStyleBrowsableHint =
+    'android.media.browse.CONTENT_STYLE_BROWSABLE_HINT';
+const String _contentStylePlayableHint =
+    'android.media.browse.CONTENT_STYLE_PLAYABLE_HINT';
+const int _contentStyleListItem = 1;
+
+/// Extras to attach to a browsable parent so AA renders its children as a list
+/// (not a grid / not the awkward one-tab-per-item strip).
+const Map<String, dynamic> listContentStyleExtras = {
+  _contentStyleBrowsableHint: _contentStyleListItem,
+  _contentStylePlayableHint: _contentStyleListItem,
+};
+
+enum MediaIdKind { root, current, library, recent, book, chapter, unknown }
 
 class MediaId {
   const MediaId(this.kind, {this.bookId, this.uuid});
@@ -20,6 +46,9 @@ class MediaId {
 
 MediaId parseMediaId(String id) {
   if (id == rootMediaId) return const MediaId(MediaIdKind.root);
+  if (id == currentMediaId) return const MediaId(MediaIdKind.current);
+  if (id == libraryMediaId) return const MediaId(MediaIdKind.library);
+  if (id == recentMediaId) return const MediaId(MediaIdKind.recent);
   final parts = id.split('/');
   if (parts.length == 2 && parts[0] == 'book') {
     return MediaId(MediaIdKind.book, bookId: parts[1]);
@@ -28,6 +57,18 @@ MediaId parseMediaId(String id) {
     return MediaId(MediaIdKind.chapter, bookId: parts[1], uuid: parts[2]);
   }
   return const MediaId(MediaIdKind.unknown);
+}
+
+/// The root's children for Android Auto: the current-book tab first (labelled
+/// with the live book title), then "Library". When there is no current book
+/// (nothing played / nothing downloaded), Tab 1 is hidden and the root is just
+/// "Library". Both are browsable (`playable: false`).
+List<MediaNode> rootBrowseChildren({String? currentBookTitle}) {
+  return [
+    if (currentBookTitle != null)
+      MediaNode(id: currentMediaId, title: currentBookTitle, playable: false),
+    const MediaNode(id: libraryMediaId, title: 'Library', playable: false),
+  ];
 }
 
 class BrowseChapter {

--- a/apps/android/pubspec.yaml
+++ b/apps/android/pubspec.yaml
@@ -17,8 +17,11 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
 # Kept in lockstep with the root/server version by scripts/bump-version.mjs
-# (build number = M*10000 + m*100 + p, monotonic). Plan 188.
-version: 1.6.0+10600
+# (versionCode = (M*10000 + m*100 + p) * 1000, monotonic; the ×1000 reserves a
+# 3-digit build-iteration band so successive Play uploads of the same marketing
+# version take base+1, base+2, … via `flutter build … --build-number=<N>`).
+# Plan 188.
+version: 1.6.0+10600000
 
 environment:
   sdk: ^3.12.1

--- a/apps/android/test/data/drift_local_library_test.dart
+++ b/apps/android/test/data/drift_local_library_test.dart
@@ -199,6 +199,45 @@ void main() {
     });
   });
 
+  group('DriftLocalLibrary (Android Auto browse support)', () {
+    test('mostRecentlyPlayedBookId returns the book with the latest playback updatedAt',
+        () async {
+      final lib = makeLib(InMemoryFileStore());
+      await lib.savePlayback('b1', 'u1', 1000, '2026-06-10T10:00:00Z');
+      await lib.savePlayback('b2', 'u2', 2000, '2026-06-12T09:00:00Z');
+      await lib.savePlayback('b3', 'u3', 500, '2026-06-11T08:00:00Z');
+
+      expect(await lib.mostRecentlyPlayedBookId(), 'b2');
+      await lib.close();
+    });
+
+    test('mostRecentlyPlayedBookId is null when nothing has been played', () async {
+      final lib = makeLib(InMemoryFileStore());
+      expect(await lib.mostRecentlyPlayedBookId(), isNull);
+      await lib.close();
+    });
+
+    test('chaptersForBook exposes downloaded bytes — 0 after a file is evicted',
+        () async {
+      final fs = InMemoryFileStore();
+      final lib = makeLib(fs);
+      await fs.writeBytes('/data/books/b1/u1/audio.mp3', List.filled(300, 1));
+      await lib.recordChapterMeta(
+          bookId: 'b1', uuid: 'u1', chapterId: 1, title: 'One',
+          fingerprint: 'fp', urlSuffix: 'audio.mp3');
+
+      expect((await lib.chaptersForBook('b1')).single.bytes, 300);
+
+      // Eviction drops the file but keeps the row at bytes=0 — must read as 0.
+      await lib.applyEviction(const EvictionPlan(
+        chapterFilesToDrop: [ChapterRef('b1', 'u1')],
+        booksToEvict: [],
+      ));
+      expect((await lib.chaptersForBook('b1')).single.bytes, 0);
+      await lib.close();
+    });
+  });
+
   group('DriftLocalLibrary legacy JSON import', () {
     test('imports an app-3 sync-state.json then deletes it', () async {
       final fs = InMemoryFileStore();

--- a/apps/android/test/domain/media_browse_tree_test.dart
+++ b/apps/android/test/domain/media_browse_tree_test.dart
@@ -30,6 +30,38 @@ void main() {
     });
   });
 
+  group('mediaId codec (Android Auto tabs)', () {
+    test('round-trips the current / library / recent sentinels', () {
+      expect(parseMediaId(currentMediaId).kind, MediaIdKind.current);
+      expect(parseMediaId(libraryMediaId).kind, MediaIdKind.library);
+      expect(parseMediaId(recentMediaId).kind, MediaIdKind.recent);
+    });
+  });
+
+  group('rootBrowseChildren', () {
+    test('shows the current-book tab first, then Library, when a book is current', () {
+      final nodes = rootBrowseChildren(currentBookTitle: 'Unraveled');
+      expect(nodes.map((n) => n.id), [currentMediaId, libraryMediaId]);
+      expect(nodes.first.title, 'Unraveled');
+      expect(nodes.last.title, 'Library');
+      expect(nodes.every((n) => !n.playable), isTrue);
+    });
+
+    test('hides the current-book tab when there is no current book', () {
+      final nodes = rootBrowseChildren(currentBookTitle: null);
+      expect(nodes.map((n) => n.id), [libraryMediaId]);
+    });
+  });
+
+  group('content-style extras', () {
+    test('list extras request the LIST hint for browsable + playable children', () {
+      expect(listContentStyleExtras['android.media.browse.CONTENT_STYLE_BROWSABLE_HINT'],
+          1);
+      expect(listContentStyleExtras['android.media.browse.CONTENT_STYLE_PLAYABLE_HINT'],
+          1);
+    });
+  });
+
   group('buildMediaBrowseTree', () {
     test('root lists books as browsable nodes', () {
       final root = buildMediaBrowseTree(lib);

--- a/docs/features/188-android-companion-app.md
+++ b/docs/features/188-android-companion-app.md
@@ -811,6 +811,22 @@ top for the running status):
   **To ship a properly-signed alpha:** `keytool -genkey -v -keystore upload-keystore.jks
   -keyalg RSA -keysize 2048 -validity 10000 -alias upload`, drop `android/key.properties`
   (see the example), then `flutter build apk --release`; sideload `app-release.apk`.
+  - **Google Play channel (2026-06-13):** the real upload keystore now exists
+    (`apps/android/android/app/upload-keystore.jks`, alias `upload`, RSA-2048,
+    valid → 2053; upload-cert SHA-256 `ba7b147d…`). `flutter build appbundle
+    --release` produces a Play-ready **AAB** signed by that upload key (verified:
+    `keytool -printcert -jarfile app-release.aab` → `CN=Mikhail Dudarenok,
+    O=Castwright`). The AAB is a **second, parallel channel** for Play
+    internal/closed testing — it does **not** replace the sideload APK, which the
+    release zip still bundles at `companion/castwright-companion.apk` for
+    `GET /api/companion/apk`. CI (`app.yml`) gained a `bundleRelease`
+    build-health step (debug-signed; not a Play artifact). Play caveats:
+    Android Auto (`app-9`) needs a separate Cars review; App Links (`app-17`)
+    must pin the **Play app-signing** key fingerprint in `assetlinks.json`, read
+    from Console post-enrollment. Full build/sign/upload doc lives in
+    `apps/android/README.md` ("Two distribution channels"). Console-side steps
+    (account, create-app + Play App Signing opt-in, App content declarations)
+    are maintainer-only.
 - `app-9` — in-car (closed #552): pure `media_browse_tree` (root→books→chapters `MediaNode` +
   mediaId codec + `childrenOf`) wired into `CompanionAudioHandler.getChildren`/`playFromMediaId`
   (audio_service `MediaBrowser`, Android Auto + CarPlay) + Android Auto descriptor

--- a/docs/features/188-android-companion-app.md
+++ b/docs/features/188-android-companion-app.md
@@ -827,7 +827,13 @@ top for the running status):
     Release (skipped, debug-fallback, when the secret is absent). Wiring the
     upload key into release CI also fixes a latent sideload bug: hosted-runner
     debug keystores drift per run, so debug-signed sideload APKs couldn't update
-    in place across releases — upload-key signing gives a stable identity. Play caveats:
+    in place across releases — upload-key signing gives a stable identity.
+    **versionCode iteration band:** `bump-version.mjs` now derives the
+    versionCode as `(M*10000+m*100+p)*1000` (1.6.0 → 10600000); the ×1000
+    reserves 999 iteration slots so successive Play uploads of the *same*
+    marketing version take `base+1, base+2, …`
+    (`flutter build … --build-number=<N>`) without colliding with the next
+    patch's base — Play forbids reusing a versionCode. Play caveats:
     Android Auto (`app-9`) needs a separate Cars review; App Links (`app-17`)
     must pin the **Play app-signing** key fingerprint in `assetlinks.json`, read
     from Console post-enrollment. Full build/sign/upload doc lives in

--- a/docs/features/188-android-companion-app.md
+++ b/docs/features/188-android-companion-app.md
@@ -820,7 +820,14 @@ top for the running status):
     internal/closed testing — it does **not** replace the sideload APK, which the
     release zip still bundles at `companion/castwright-companion.apk` for
     `GET /api/companion/apk`. CI (`app.yml`) gained a `bundleRelease`
-    build-health step (debug-signed; not a Play artifact). Play caveats:
+    build-health step (debug-signed; not a Play artifact). The **release
+    pipeline** (`release.yml`) now materialises the upload keystore from four
+    `ANDROID_UPLOAD_*` repo secrets, signs the release APK **and** AAB with the
+    upload key, and attaches `castwright-vX.Y.Z.aab` (+`.sha256`) to the GitHub
+    Release (skipped, debug-fallback, when the secret is absent). Wiring the
+    upload key into release CI also fixes a latent sideload bug: hosted-runner
+    debug keystores drift per run, so debug-signed sideload APKs couldn't update
+    in place across releases — upload-key signing gives a stable identity. Play caveats:
     Android Auto (`app-9`) needs a separate Cars review; App Links (`app-17`)
     must pin the **Play app-signing** key fingerprint in `assetlinks.json`, read
     from Console post-enrollment. Full build/sign/upload doc lives in

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -128,10 +128,17 @@ export function readPubspecVersion(repoRootDir) {
   return m ? m[2].split('+')[0] : null;
 }
 
-/** Deterministic, monotonic build number from a semver: M*10000 + m*100 + p. */
+/** Deterministic, monotonic versionCode base from a semver. The semver maps to
+ *  `M*10000 + m*100 + p`, then `×1000` to reserve the low three digits as a
+ *  build-ITERATION band. The tagged release takes the base (iteration 0); a
+ *  successive Play upload of the *same* marketing version (e.g. an internal-test
+ *  build) takes `base + 1`, `base + 2`, … — distinct, strictly-increasing
+ *  versionCodes that never collide with the next patch's base. Play forbids
+ *  reusing a versionCode, so this is what lets you iterate test builds without a
+ *  marketing bump. 1.6.0 → 10600000; 1.6.1 → 10601000 (999 iteration slots). */
 export function pubspecBuildNumber(version) {
   const [maj, min, pat] = version.split('.').map((n) => parseInt(n, 10) || 0);
-  return maj * 10000 + min * 100 + pat;
+  return (maj * 10000 + min * 100 + pat) * 1000;
 }
 
 export function writePubspecVersion(repoRootDir, version) {

--- a/scripts/tests/bump-version.test.mjs
+++ b/scripts/tests/bump-version.test.mjs
@@ -479,12 +479,17 @@ test('pubspec version helpers round-trip with a monotonic build number', () => {
     mkdirSync(dirname(p), { recursive: true });
     writeFileSync(p, 'name: x\nversion: 1.0.0+1\nenvironment:\n  sdk: ^3.0.0\n');
     assert.equal(readPubspecVersion(dir), '1.0.0'); // drops the +build
-    assert.equal(pubspecBuildNumber('1.6.0'), 10600);
-    assert.equal(pubspecBuildNumber('2.13.4'), 21304);
+    // ×1000 reserves a 3-digit build-iteration band (base+1, base+2, … for
+    // successive Play uploads of the same marketing version) without colliding
+    // with the next patch's base.
+    assert.equal(pubspecBuildNumber('1.6.0'), 10600000);
+    assert.equal(pubspecBuildNumber('2.13.4'), 21304000);
+    // Iteration band stays below the next patch's base — no overlap.
+    assert.ok(pubspecBuildNumber('1.6.0') + 999 < pubspecBuildNumber('1.6.1'));
 
     writePubspecVersion(dir, '1.6.0');
     assert.equal(readPubspecVersion(dir), '1.6.0');
-    assert.match(readFileSync(p, 'utf8'), /^version: 1\.6\.0\+10600$/m);
+    assert.match(readFileSync(p, 'utf8'), /^version: 1\.6\.0\+10600000$/m);
     assert.match(readFileSync(p, 'utf8'), /sdk: \^3\.0\.0/); // other lines survive
   } finally {
     rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Adds a **Google Play App Bundle (AAB)** distribution channel for the Flutter
companion, alongside the existing sideload APK — the APK stays load-bearing
(the release zip still bundles it at `companion/castwright-companion.apk` for
`GET /api/companion/apk`). Three additive commits:

1. **AAB build path + docs** — `flutter build appbundle --release`, README
   "Two distribution channels", `app.yml` `bundleRelease` build-health step,
   dropped the stale `applicationId` TODO.
2. **Signed AAB in the release pipeline** — `release.yml` materialises the
   upload keystore from four `ANDROID_UPLOAD_*` repo secrets, signs the release
   APK **and** AAB with the upload key, and attaches `castwright-vX.Y.Z.aab`
   (+`.sha256`) to the GitHub Release. Debug-fallback + AAB-attach-skip when the
   secret is absent. Also fixes a latent sideload bug (hosted-runner debug
   keystores drift per run → in-place updates broke).
3. **versionCode iteration band** — widen the `bump-version.mjs` derivation to
   `(M*10000+m*100+p)*1000` (1.6.0 → 10600000), reserving 999 iteration slots so
   successive Play uploads of the same marketing version take `base+N` without
   colliding with the next patch's base (Play forbids reusing a versionCode).

The sideload APK + server-zip flow is unchanged; the AAB is never zipped.

## Test plan

- `bump-version.test.mjs` updated — 24 green (new no-overlap assertion on the
  iteration band).
- Rebuilt the release bundle; merged-manifest `versionCode=10600000` confirmed.
- Signed APK + AAB built locally and verified to the upload key
  (`apksigner verify --print-certs` / `keytool -printcert -jarfile`).
- `npm run verify` green (pre-push hook, full battery).

Refs the companion umbrella plan
[188](docs/features/188-android-companion-app.md) (`app-11` distribution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
