### PR TITLE
chore: integrate analyzer-model fixes, update check, and settings nav

### DIFF
--- a/docs/features/194-voice-cloning.md
+++ b/docs/features/194-voice-cloning.md
@@ -33,8 +33,10 @@ bedtime story in their own voice while away; a kid hears themselves as the hero.
 2. **Consent on the record** — an explicit, stored consent step naming the person and the
    permitted use; cloning is blocked without it. (See risk below.)
 3. **Clone + cast** — produce a reusable cloned voice (XTTS reference path first; Qwen
-   design-to-target as the second engine) and assign it to a character exactly like a designed
-   voice, held **consistent across the book and series** the way designed voices already are.
+   reference-clip clone via Base `create_voice_clone_prompt` as the second engine — see
+   _Implementation notes_, **not** the 1.7B "design-to-target") and assign it to a character
+   exactly like a designed voice, held **consistent across the book and series** the way
+   designed voices already are.
 4. **Library separation** — cloned voices live in their own section of `#/voices`, never
    intermingled with designed voices, with provenance + consent surfaced and **reuse gated** so
    a person's voice is never offered back to an unrelated book/stranger.
@@ -56,6 +58,37 @@ bedtime story in their own voice while away; a kid hears themselves as the hero.
 - **Reversibility:** the cloned section + capture flow are gated behind a flag; disabling it
   hides capture and leaves designed voices untouched.
 
+## Implementation notes — Qwen clone pipeline (verified against code 2026-06-13)
+
+Scoped against the running sidecar; corrects the "Qwen design-to-target" framing above.
+
+- **Qwen cloning is a pure Base-0.6B operation — the 1.7B VoiceDesign is bypassed.** The clone
+  embedding (`VoiceClonePromptItem`) is created *and* consumed only on Base: real clip +
+  transcript → `Base.create_voice_clone_prompt(ref_audio, ref_text)` → `.pt` →
+  `Base.generate_voice_clone(text, voice_clone_prompt=…)` per sentence. This is the **same
+  back-half already used by `design_voice`** (`server/tts-sidecar/main.py:1436` create +
+  `:1474/:1553/:1632` synth) — voice *design* merely manufactures the reference audio with the
+  1.7B (`generate_voice_design`) first. For cloning, the audio **source** swaps to a real
+  recording; everything downstream is unchanged and already proven (the sidecar log shows
+  hundreds of successful `generate_voice_clone` calls). The Qwen clone work is therefore an
+  **ingest path only**, not net-new ML — drop the "design-to-target" framing.
+- **You cannot clone on the 1.7B and synth on the 0.6B.** Clone embeddings are
+  model-specific — that is *why* `design_voice` routes the 1.7B's **audio** (not an embedding)
+  through `Base.create_voice_clone_prompt`. Cloning never needs the 1.7B loaded, so cloned-voice
+  generation has the **same VRAM profile** as a designed voice (small resident Base only).
+- **The `.pt` is Base-version-specific → persist the raw clip.** The sibling `.json` manifest
+  records `baseModel`; swapping/upgrading the Base model orphans every `.pt`. Keep the **raw
+  reference clip** as the durable source-of-truth so `.pt`s can be re-derived after a Base
+  change — the `.pt` is a regenerable **cache**, the clip is the **master**. (`design_voice`
+  currently *discards* its reference audio after distillation; the clone path must **not** — the
+  clip is also the consent/provenance artifact the risk section requires.)
+- **Whisper ASR supplies `ref_text`.** `create_voice_clone_prompt` needs the transcript of the
+  reference clip; the in-stack Whisper ASR (srv-31) can auto-transcribe the captured sample, so
+  the user need not type what they said.
+- **Net storage per cloned voice:** raw clip (master) + `.pt` (Base-derived cache, regenerable)
+  + `.json` manifest (consent/provenance/`baseModel`) + optional preview MP3 — the designed-voice
+  layout plus the **retained clip**.
+
 ## Risk — consent & IP (must design in, not bolt on)
 
 Cloning a real person (incl. a child) is consent-sensitive and increasingly regulated
@@ -70,7 +103,9 @@ in v1.
 2. **Sample capture** — record/upload + quality checks + consent gate.
 3. **XTTS clone path** — reference-clip → reusable cloned voice → cast assignment + series
    consistency.
-4. **Qwen design-to-target** — second engine for the same cloned-voice contract.
+4. **Qwen reference-clip clone** — second engine for the same cloned-voice contract. Real clip
+   → `Base.create_voice_clone_prompt` (the 1.7B VoiceDesign is **not** used); see
+   _Implementation notes_.
 5. **Polish** — auditions, A/B vs a designed alternative, drift handling for cloned voices.
 
 ## Test plan / acceptance

--- a/e2e/upgrade-flow.spec.ts
+++ b/e2e/upgrade-flow.spec.ts
@@ -49,6 +49,9 @@ test.describe('fs-1 — in-app upgrade flow', () => {
     await expect(confirm).toBeVisible();
     await confirm.getByRole('button', { name: 'Cancel' }).click();
     await expect(confirm).toBeHidden();
-    await expect(card.getByRole('button', { name: /Apply update package/ })).toBeVisible();
+    /* Mock getUpdateStatus reports "up to date", so the manual-apply affordance
+       is the demoted label (the prominent "Apply update package…" only shows
+       when a newer release is detected). Either way the picker is back. */
+    await expect(card.getByRole('button', { name: /Apply a package manually/ })).toBeVisible();
   });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -193,6 +193,8 @@ import { upgradeRouter } from './routes/upgrade.js';
 app.use('/api/upgrade', upgradeRouter); // fs-1 — in-app upgrade: stage/apply/abort/state
 import { infoRouter } from './routes/info.js';
 app.use('/api/info', infoRouter); // fs-1 — app version + schemas + what's-new state
+import { updatesRouter } from './routes/updates.js';
+app.use('/api/updates', updatesRouter); // GET /latest — fail-open "newer release available?" check
 import { companionRouter } from './routes/companion.js';
 app.use('/api/companion', companionRouter); // interim — GET/HEAD /apk: download the packaged Android APK
 import { samplesRouter } from './routes/samples.js';

--- a/server/src/routes/models-inventory.test.ts
+++ b/server/src/routes/models-inventory.test.ts
@@ -196,6 +196,43 @@ describe('buildModelInventory', () => {
     expect(b.isDefaultEngine).toBe(false);
   });
 
+  it('does not mark a same-family different-size tag as loaded (qwen3.5:4b resident ≠ qwen3.5:9b loaded)', () => {
+    /* Regression: tagMatches over-matched on the family root, so a resident
+       qwen3.5:4b lit up qwen3.5:9b as "Loaded" in the Model Manager even
+       though ollama ps held only the 4b. Different explicit size tags must
+       never be conflated. */
+    const inv = buildModelInventory(
+      baseDeps({
+        ollama: {
+          reachable: true,
+          models: [
+            { name: 'qwen3.5:4b', size: 3_200_000_000 },
+            { name: 'qwen3.5:9b', size: 6_100_000_000 },
+          ],
+          resident: ['qwen3.5:4b'],
+        },
+      }),
+    );
+    const four = inv.items.find((i) => i.id === 'ollama:qwen3.5:4b')!;
+    const nine = inv.items.find((i) => i.id === 'ollama:qwen3.5:9b')!;
+    expect(four.loaded).toBe(true); // actually resident
+    expect(nine.loaded).toBe(false); // NOT resident — must not borrow 4b's residency
+  });
+
+  it('treats a bare family tag as equivalent to :latest (qwen3.5 resident ⇒ qwen3.5:latest loaded)', () => {
+    const inv = buildModelInventory(
+      baseDeps({
+        ollama: {
+          reachable: true,
+          models: [{ name: 'qwen3.5:latest', size: 3_200_000_000 }],
+          resident: ['qwen3.5'],
+        },
+      }),
+    );
+    const latest = inv.items.find((i) => i.id === 'ollama:qwen3.5:latest')!;
+    expect(latest.loaded).toBe(true); // bare 'qwen3.5' resident === ':latest'
+  });
+
   it('flips Kokoro off-default when Qwen is the resolved engine', () => {
     installKokoro();
     const inv = buildModelInventory(baseDeps({ resolvedTtsEngine: 'qwen' }));

--- a/server/src/routes/models-inventory.ts
+++ b/server/src/routes/models-inventory.ts
@@ -98,11 +98,16 @@ export interface InventoryDeps {
   resolvedOllamaModel: string;
 }
 
-/* Ollama canonicalises tags, so match on either the exact tag or the root. */
+/* Match an Ollama residency tag against an inventory model name. Ollama
+   canonicalises a bare family name to its ':latest' tag, so 'qwen3.5' and
+   'qwen3.5:latest' are the same model — but two DIFFERENT explicit tags that
+   merely share a family root (qwen3.5:4b vs qwen3.5:9b) are NOT. The previous
+   root-only comparison conflated the latter, so a resident qwen3.5:4b lit up
+   qwen3.5:9b as "Loaded" in the Model Manager (residency borrowed across size
+   variants). Normalise the bare-name⇄:latest equivalence only. */
 function tagMatches(tag: string, expected: string): boolean {
-  if (tag === expected) return true;
-  const root = expected.split(':')[0];
-  return tag === root || tag.split(':')[0] === root;
+  const norm = (t: string) => (t.includes(':') ? t : `${t}:latest`);
+  return norm(tag) === norm(expected);
 }
 
 /** Pure inventory builder — all I/O (sidecar/ollama probes, resolver reads) is

--- a/server/src/routes/updates.test.ts
+++ b/server/src/routes/updates.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { parseVersionFromTag, compareSemver, buildUpdateStatus } from './updates.js';
+
+describe('parseVersionFromTag', () => {
+  it('extracts X.Y.Z from common tag shapes', () => {
+    expect(parseVersionFromTag('v1.7.0')).toBe('1.7.0');
+    expect(parseVersionFromTag('castwright-v1.7.0')).toBe('1.7.0');
+    expect(parseVersionFromTag('castwright-1.7.0')).toBe('1.7.0');
+    expect(parseVersionFromTag('1.7.0')).toBe('1.7.0');
+  });
+
+  it('returns null for null/empty/unparseable tags', () => {
+    expect(parseVersionFromTag(null)).toBeNull();
+    expect(parseVersionFromTag(undefined)).toBeNull();
+    expect(parseVersionFromTag('')).toBeNull();
+    expect(parseVersionFromTag('latest')).toBeNull();
+  });
+});
+
+describe('compareSemver', () => {
+  it('orders by major.minor.patch', () => {
+    expect(compareSemver('1.7.0', '1.6.0')).toBe(1);
+    expect(compareSemver('1.6.0', '1.7.0')).toBe(-1);
+    expect(compareSemver('1.6.0', '1.6.0')).toBe(0);
+    expect(compareSemver('2.0.0', '1.9.9')).toBe(1);
+    expect(compareSemver('1.6.1', '1.6.0')).toBe(1);
+  });
+
+  it('treats unparseable as 0.0.0 (oldest) so garbage never claims to be newer', () => {
+    expect(compareSemver('garbage', '1.6.0')).toBe(-1);
+  });
+});
+
+describe('buildUpdateStatus', () => {
+  it('reports an available update when the release is newer', () => {
+    const s = buildUpdateStatus('1.6.0', { ok: true, tag: 'v1.7.0', url: 'https://x/releases/1.7.0' });
+    expect(s).toEqual({
+      reachable: true,
+      currentVersion: '1.6.0',
+      latestVersion: '1.7.0',
+      updateAvailable: true,
+      url: 'https://x/releases/1.7.0',
+    });
+  });
+
+  it('reports up-to-date when the release equals the running version', () => {
+    const s = buildUpdateStatus('1.6.0', { ok: true, tag: 'v1.6.0', url: 'https://x' });
+    expect(s.reachable).toBe(true);
+    expect(s.updateAvailable).toBe(false);
+    expect(s.latestVersion).toBe('1.6.0');
+  });
+
+  it('never claims an update when the release is older than current', () => {
+    const s = buildUpdateStatus('1.7.0', { ok: true, tag: 'v1.6.0', url: 'https://x' });
+    expect(s.updateAvailable).toBe(false);
+  });
+
+  it('FAILS OPEN: an unreachable source yields reachable:false with the running version, no update', () => {
+    const s = buildUpdateStatus('1.6.0', { ok: false });
+    expect(s).toEqual({
+      reachable: false,
+      currentVersion: '1.6.0',
+      latestVersion: null,
+      updateAvailable: false,
+      url: null,
+    });
+  });
+
+  it('does not claim an update when reachable but the tag is unparseable', () => {
+    const s = buildUpdateStatus('1.6.0', { ok: true, tag: 'nightly', url: 'https://x' });
+    expect(s.reachable).toBe(true);
+    expect(s.updateAvailable).toBe(false);
+    expect(s.latestVersion).toBeNull();
+  });
+});

--- a/server/src/routes/updates.ts
+++ b/server/src/routes/updates.ts
@@ -1,0 +1,133 @@
+/* GET /api/updates/latest — best-effort "is a newer release available?" check.
+
+   Self-hosted apps upgrade by applying a release .zip (see upgrade.ts); there's
+   no auto-update feed. This route adds a *check* so the Account → Application
+   updates card can say "you're up to date" vs "update available" instead of
+   always offering Apply.
+
+   FAIL-OPEN by design: the repo may be private (or the box offline / behind a
+   proxy), so any failure to reach GitHub Releases resolves to
+   `{ reachable: false }` — NOT an error. The card then degrades to showing the
+   running version + manual Apply, exactly as before. Never throws to the client.
+
+   Local-ops only (like sidecar/ollama/models routes) — stays out of openapi.yaml. */
+
+import { Router } from 'express';
+import type { Request, Response } from '../http.js';
+import { getAppVersion } from '../app-version.js';
+
+export const updatesRouter = Router();
+
+/** owner/repo to query. Overridable for forks / private mirrors. */
+function repoSlug(): string {
+  return process.env.UPDATE_CHECK_REPO?.trim() || 'dudarenok-maker/Castwright';
+}
+
+const CHECK_TIMEOUT_MS = 4000;
+/* GitHub's unauthenticated API allows 60 req/hr/IP; cache so repeated Account
+   visits don't burn it. 1h is plenty for a manual-upgrade product. */
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+export interface UpdateStatus {
+  /** False when the release source couldn't be reached (private repo, offline,
+      rate-limited, …). The client treats this as "no info" and shows the
+      running version only — never an error. */
+  reachable: boolean;
+  /** The running app version (always present — read locally). */
+  currentVersion: string;
+  /** Parsed latest release version, or null when unreachable/unparseable. */
+  latestVersion: string | null;
+  /** True only when reachable AND latestVersion is strictly newer than current. */
+  updateAvailable: boolean;
+  /** Release page URL when reachable, else null. */
+  url: string | null;
+}
+
+/** Extract a semver-ish "X.Y.Z" from a release tag. Handles 'v1.7.0',
+    'castwright-v1.7.0', 'castwright-1.7.0', and a bare '1.7.0'. Returns null
+    when no major.minor.patch can be found. */
+export function parseVersionFromTag(tag: string | null | undefined): string | null {
+  if (!tag) return null;
+  const m = tag.match(/(\d+)\.(\d+)\.(\d+)/);
+  return m ? `${m[1]}.${m[2]}.${m[3]}` : null;
+}
+
+/** Compare two "X.Y.Z" strings numerically. Returns 1 if a>b, -1 if a<b, 0 if
+    equal. A version that can't be parsed sorts as 0.0.0 (oldest), so a garbage
+    "latest" can never falsely claim to be newer than a real current version. */
+export function compareSemver(a: string, b: string): number {
+  const parts = (v: string): [number, number, number] => {
+    const m = v.match(/(\d+)\.(\d+)\.(\d+)/);
+    return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : [0, 0, 0];
+  };
+  const pa = parts(a);
+  const pb = parts(b);
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] > pb[i]) return 1;
+    if (pa[i] < pb[i]) return -1;
+  }
+  return 0;
+}
+
+/** Pure assembly of the response from the current version + the (already
+    fetched, fail-safe) release lookup. Unit-tested without network. */
+export function buildUpdateStatus(
+  currentVersion: string,
+  fetched: { ok: true; tag: string; url: string } | { ok: false },
+): UpdateStatus {
+  if (!fetched.ok) {
+    return { reachable: false, currentVersion, latestVersion: null, updateAvailable: false, url: null };
+  }
+  const latestVersion = parseVersionFromTag(fetched.tag);
+  const updateAvailable = latestVersion != null && compareSemver(latestVersion, currentVersion) > 0;
+  return { reachable: true, currentVersion, latestVersion, updateAvailable, url: fetched.url };
+}
+
+/** Fetch the latest release tag from GitHub. Never throws — returns
+    `{ ok: false }` on timeout, non-2xx (incl. 404 for a private repo without a
+    token), or malformed body. An optional GITHUB_TOKEN lifts the rate limit and
+    grants access to a private repo's releases. */
+async function fetchLatestRelease(): Promise<{ ok: true; tag: string; url: string } | { ok: false }> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), CHECK_TIMEOUT_MS);
+  try {
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'castwright-update-check',
+    };
+    const token = process.env.GITHUB_TOKEN?.trim();
+    if (token) headers.Authorization = `Bearer ${token}`;
+    const res = await fetch(`https://api.github.com/repos/${repoSlug()}/releases/latest`, {
+      headers,
+      signal: ctrl.signal,
+    });
+    if (!res.ok) return { ok: false };
+    const body = (await res.json()) as { tag_name?: string; html_url?: string };
+    if (typeof body.tag_name !== 'string') return { ok: false };
+    return { ok: true, tag: body.tag_name, url: typeof body.html_url === 'string' ? body.html_url : '' };
+  } catch {
+    return { ok: false };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+let cache: { at: number; status: UpdateStatus } | null = null;
+
+updatesRouter.get('/latest', async (_req: Request, res: Response) => {
+  const now = Date.now();
+  if (cache && now - cache.at < CACHE_TTL_MS) {
+    res.json(cache.status);
+    return;
+  }
+  const status = buildUpdateStatus(getAppVersion(), await fetchLatestRelease());
+  /* Only cache a reachable result — a transient failure shouldn't pin
+     "unreachable" for an hour; the next visit retries. */
+  if (status.reachable) cache = { at: now, status };
+  res.json(status);
+});
+
+/** Test seam — reset the module-level cache between cases. */
+export function __resetUpdateCacheForTests(): void {
+  cache = null;
+}

--- a/src/components/analyzer-model-override-badge.test.tsx
+++ b/src/components/analyzer-model-override-badge.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import { accountSlice } from '../store/account-slice';
+import { uiSlice } from '../store/ui-slice';
+import { AnalyzerModelOverrideBadge } from './analyzer-model-override-badge';
+
+function mountStore(selectedModel: string, selectedModelExplicit: boolean, defaultAnalysisModel: string) {
+  return configureStore({
+    reducer: { account: accountSlice.reducer, ui: uiSlice.reducer },
+    preloadedState: {
+      account: {
+        ...accountSlice.getInitialState(),
+        defaultAnalysisModel,
+      } as ReturnType<typeof accountSlice.getInitialState>,
+      ui: {
+        ...uiSlice.getInitialState(),
+        selectedModel,
+        selectedModelExplicit,
+      } as ReturnType<typeof uiSlice.getInitialState>,
+    },
+  });
+}
+
+describe('AnalyzerModelOverrideBadge', () => {
+  it('renders nothing when no explicit override is active', () => {
+    render(
+      <Provider store={mountStore('gemini-3.1-flash-lite', false, 'gemini-3.1-flash-lite')}>
+        <AnalyzerModelOverrideBadge />
+      </Provider>,
+    );
+    expect(screen.queryByTestId('analyzer-model-override-badge')).toBeNull();
+  });
+
+  it('renders nothing when the explicit pick equals the saved default', () => {
+    render(
+      <Provider store={mountStore('gemini-3.1-flash-lite', true, 'gemini-3.1-flash-lite')}>
+        <AnalyzerModelOverrideBadge />
+      </Provider>,
+    );
+    expect(screen.queryByTestId('analyzer-model-override-badge')).toBeNull();
+  });
+
+  it('surfaces the override with both model labels when it differs from the saved default', () => {
+    render(
+      <Provider store={mountStore('qwen3.5:4b', true, 'gemini-3.1-flash-lite')}>
+        <AnalyzerModelOverrideBadge />
+      </Provider>,
+    );
+    const badge = screen.getByTestId('analyzer-model-override-badge');
+    expect(badge).toHaveTextContent('Qwen3.5 4B (local)'); // the override in use
+    expect(badge).toHaveTextContent('Gemini 3.1 Flash Lite'); // the saved default
+  });
+
+  it('Reset to default clears the override (explicit → false, value → saved default)', async () => {
+    const store = mountStore('qwen3.5:4b', true, 'gemini-3.1-flash-lite');
+    render(
+      <Provider store={store}>
+        <AnalyzerModelOverrideBadge />
+      </Provider>,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /reset to default/i }));
+    expect(store.getState().ui.selectedModel).toBe('gemini-3.1-flash-lite');
+    expect(store.getState().ui.selectedModelExplicit).toBe(false);
+    // And the badge disappears once the override is cleared.
+    expect(screen.queryByTestId('analyzer-model-override-badge')).toBeNull();
+  });
+});

--- a/src/components/analyzer-model-override-badge.tsx
+++ b/src/components/analyzer-model-override-badge.tsx
@@ -1,0 +1,50 @@
+/* Surfaces an active per-run analyzer-model override so it can never
+   silently shadow the saved default. Background: a per-run model pick
+   (ui.selectedModel, e.g. qwen3.5:4b chosen to dodge a Gemini recitation
+   block) used to persist device-local and globally, overriding the saved
+   `analysisEngine`/`defaultAnalysisModel` on every later run, on every
+   book, with no UI signal — the "Ollama silently forced" bug. The override
+   is now transient (not persisted); this badge makes it visible within a
+   session and offers a one-click reset back to the saved default.
+
+   Self-contained: reads ui + account straight off the store and renders
+   nothing unless an explicit pick differs from the saved default, so it can
+   be dropped next to any analyzer-model picker. */
+
+import { useAppDispatch, useAppSelector } from '../store';
+import { uiActions } from '../store/ui-slice';
+import { MODEL_OPTIONS } from '../lib/models';
+
+function modelLabel(id: string): string {
+  return MODEL_OPTIONS.find((m) => m.id === id)?.label ?? id;
+}
+
+export function AnalyzerModelOverrideBadge() {
+  const dispatch = useAppDispatch();
+  const selectedModel = useAppSelector((s) => s.ui.selectedModel);
+  const explicit = useAppSelector((s) => s.ui.selectedModelExplicit);
+  const savedDefault = useAppSelector((s) => s.account?.defaultAnalysisModel ?? '');
+
+  /* Only when a per-run pick is active AND actually differs from the saved
+     default — an explicit pick that matches the default is not an override. */
+  if (!explicit || !savedDefault || selectedModel === savedDefault) return null;
+
+  return (
+    <div
+      data-testid="analyzer-model-override-badge"
+      className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-ink/70"
+    >
+      <span>
+        This run uses <span className="font-semibold text-ink">{modelLabel(selectedModel)}</span> —
+        overrides your saved default ({modelLabel(savedDefault)}).
+      </span>
+      <button
+        type="button"
+        onClick={() => dispatch(uiActions.resetSelectedModelToDefault(savedDefault))}
+        className="font-semibold text-magenta hover:underline focus:outline-hidden focus:ring-2 focus:ring-magenta/30 rounded"
+      >
+        Reset to default
+      </button>
+    </div>
+  );
+}

--- a/src/components/upgrade-card.test.tsx
+++ b/src/components/upgrade-card.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import type { UpdateStatus } from '../lib/types';
+
+/* useAppInfo → a fixed running version. */
+vi.mock('../lib/use-app-info', () => ({
+  useAppInfo: () => ({ info: { appVersion: '1.6.0', sidecarVersion: '1.6.0' }, error: null, refresh: vi.fn() }),
+}));
+
+/* api.getUpdateStatus is the only api call the card makes on mount. */
+const h = vi.hoisted(() => ({ getUpdateStatus: vi.fn() }));
+vi.mock('../lib/api', () => ({ api: { getUpdateStatus: h.getUpdateStatus } }));
+
+import { upgradeSlice } from '../store/upgrade-slice';
+import { UpgradeCard } from './upgrade-card';
+
+function renderCard() {
+  const store = configureStore({ reducer: { upgrade: upgradeSlice.reducer } });
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <UpgradeCard />
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+const status = (over: Partial<UpdateStatus>): UpdateStatus => ({
+  reachable: true,
+  currentVersion: '1.6.0',
+  latestVersion: '1.6.0',
+  updateAvailable: false,
+  url: null,
+  ...over,
+});
+
+beforeEach(() => {
+  h.getUpdateStatus.mockReset();
+});
+
+describe('UpgradeCard — update-check states', () => {
+  it('shows "Update available" + a primary Apply when a newer release exists', async () => {
+    h.getUpdateStatus.mockResolvedValue(
+      status({ latestVersion: '1.7.0', updateAvailable: true, url: 'https://x/releases/1.7.0' }),
+    );
+    renderCard();
+    await waitFor(() => expect(screen.getByTestId('update-available')).toBeInTheDocument());
+    expect(screen.getByTestId('update-available')).toHaveTextContent('v1.7.0');
+    expect(screen.getByRole('button')).toHaveTextContent('Apply update package…');
+  });
+
+  it('shows "up to date" + a demoted manual-apply when on the latest', async () => {
+    h.getUpdateStatus.mockResolvedValue(status({ latestVersion: '1.6.0', updateAvailable: false }));
+    renderCard();
+    await waitFor(() => expect(screen.getByTestId('up-to-date')).toBeInTheDocument());
+    expect(screen.queryByTestId('update-available')).toBeNull();
+    expect(screen.getByRole('button')).toHaveTextContent('Apply a package manually…');
+  });
+
+  it('FAILS OPEN: an unreachable check shows neither banner, just the manual apply', async () => {
+    h.getUpdateStatus.mockResolvedValue(
+      status({ reachable: false, latestVersion: null, updateAvailable: false }),
+    );
+    renderCard();
+    // running version always renders; give the effect a tick to settle.
+    await waitFor(() => expect(screen.getByText(/You're running/)).toBeInTheDocument());
+    expect(screen.queryByTestId('update-available')).toBeNull();
+    expect(screen.queryByTestId('up-to-date')).toBeNull();
+    expect(screen.getByRole('button')).toHaveTextContent('Apply a package manually…');
+  });
+
+  it('does not throw when the check rejects (client-side fail-open)', async () => {
+    h.getUpdateStatus.mockRejectedValue(new Error('network'));
+    renderCard();
+    await waitFor(() => expect(screen.getByText(/You're running/)).toBeInTheDocument());
+    expect(screen.queryByTestId('update-available')).toBeNull();
+  });
+});

--- a/src/components/upgrade-card.tsx
+++ b/src/components/upgrade-card.tsx
@@ -18,6 +18,8 @@ import {
 } from '../store/upgrade-slice';
 import { notificationsActions } from '../store/notifications-slice';
 import { useAppInfo } from '../lib/use-app-info';
+import { api } from '../lib/api';
+import type { UpdateStatus } from '../lib/types';
 
 function Card({ children }: { children: React.ReactNode }) {
   return (
@@ -42,6 +44,27 @@ export function UpgradeCard() {
   const fileRef = useRef<HTMLInputElement>(null);
   const runningVersion = info?.appVersion ?? '…';
 
+  /* Best-effort "is a newer release out?" check. Fail-open: on an unreachable
+     source (private repo / offline) `update` stays null OR carries
+     reachable:false, and the card shows only the running version — no error. */
+  const [update, setUpdate] = useState<UpdateStatus | null>(null);
+  useEffect(() => {
+    let alive = true;
+    void api
+      .getUpdateStatus()
+      .then((u) => {
+        if (alive) setUpdate(u);
+      })
+      .catch(() => {
+        /* fail-open — leave update null, show running version only */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+  const updateAvailable = update?.reachable === true && update.updateAvailable;
+  const upToDate = update?.reachable === true && !update.updateAvailable;
+
   const onPick = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) void dispatch(stageUpgrade(file));
@@ -54,6 +77,31 @@ export function UpgradeCard() {
         You&apos;re running <span className="font-semibold">v{runningVersion}</span>
         {info?.sidecarVersion ? ` · sidecar v${info.sidecarVersion}` : ''}.
       </p>
+
+      {updateAvailable && (
+        <p data-testid="update-available" className="mt-2 text-sm font-semibold text-magenta">
+          Update available: v{update?.latestVersion}
+          {update?.url ? (
+            <>
+              {' '}
+              <a
+                href={update.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium underline"
+              >
+                View release
+              </a>
+            </>
+          ) : null}
+        </p>
+      )}
+      {upToDate && (
+        <p data-testid="up-to-date" className="mt-2 text-sm text-ink/65">
+          You&apos;re up to date.
+        </p>
+      )}
+
       <p className="mt-1 text-xs">
         <Link to="/release-notes" className="font-medium text-magenta hover:underline">
           See what&apos;s new
@@ -65,9 +113,17 @@ export function UpgradeCard() {
         type="button"
         onClick={() => fileRef.current?.click()}
         disabled={upgrade.status === 'staging' || upgrade.status === 'applying'}
-        className="mt-3 min-h-[44px] sm:min-h-0 rounded-xl bg-magenta px-4 py-2 text-sm font-medium text-white hover:bg-magenta/90 disabled:opacity-50"
+        className={
+          updateAvailable
+            ? 'mt-3 min-h-[44px] sm:min-h-0 rounded-xl bg-magenta px-4 py-2 text-sm font-medium text-white hover:bg-magenta/90 disabled:opacity-50'
+            : 'mt-3 min-h-[44px] sm:min-h-0 rounded-xl border border-ink/15 px-4 py-2 text-sm font-medium text-ink/70 hover:bg-ink/5 disabled:opacity-50'
+        }
       >
-        {upgrade.status === 'staging' ? 'Validating…' : 'Apply update package…'}
+        {upgrade.status === 'staging'
+          ? 'Validating…'
+          : updateAvailable
+            ? 'Apply update package…'
+            : 'Apply a package manually…'}
       </button>
 
       {upgrade.status === 'error' && upgrade.error && (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -6,6 +6,7 @@
 
 import type {
   AppInfo,
+  UpdateStatus,
   CompanionApkAvailability,
   Emotion,
   UpgradeStageResult,
@@ -4756,6 +4757,19 @@ async function realGetAppInfo(): Promise<AppInfo> {
     throw new Error(`App info fetch failed (${res.status}): ${(await res.text()) || res.statusText}`);
   return res.json();
 }
+/* "Is a newer release available?" check for the Application updates card.
+   FAIL-OPEN: any non-2xx or network error resolves to reachable:false (the
+   server already fails open for the private-repo/offline case; this guards the
+   client leg too). Never throws — the card degrades to the running version. */
+async function realGetUpdateStatus(): Promise<UpdateStatus> {
+  try {
+    const res = await fetch('/api/updates/latest');
+    if (!res.ok) return { reachable: false, currentVersion: '', latestVersion: null, updateAvailable: false, url: null };
+    return res.json();
+  } catch {
+    return { reachable: false, currentVersion: '', latestVersion: null, updateAvailable: false, url: null };
+  }
+}
 /* Interim — HEAD-probe GET /api/companion/apk to learn whether a packaged
    Android APK has been dropped at the server's resolved location. A 404 (or any
    network error) means "no APK"; a 200 carries the byte size via Content-Length.
@@ -4818,6 +4832,18 @@ let mockAppInfo: AppInfo = {
 async function mockGetAppInfo(): Promise<AppInfo> {
   await wait(40);
   return { ...mockAppInfo };
+}
+/* Mock has no release source — report "up to date" on the running version so the
+   card renders its steady state under VITE_USE_MOCKS=true. */
+async function mockGetUpdateStatus(): Promise<UpdateStatus> {
+  await wait(20);
+  return {
+    reachable: true,
+    currentVersion: mockAppInfo.appVersion,
+    latestVersion: mockAppInfo.appVersion,
+    updateAvailable: false,
+    url: null,
+  };
 }
 /* Mock has no real server to host an APK, so the companion download is always
    "unavailable" in mock/dev — the banner stays in its store-only state. */
@@ -6101,6 +6127,7 @@ const real = {
   putUserSettings: realPutUserSettings,
   putGeminiKey: realPutGeminiKey,
   getAppInfo: realGetAppInfo,
+  getUpdateStatus: realGetUpdateStatus,
   checkCompanionApk: realCheckCompanionApk,
   dismissWhatsNew: realDismissWhatsNew,
   upgradeStage: realUpgradeStage,
@@ -6353,6 +6380,7 @@ const mock = {
   putUserSettings: mockPutUserSettings,
   putGeminiKey: mockPutGeminiKey,
   getAppInfo: mockGetAppInfo,
+  getUpdateStatus: mockGetUpdateStatus,
   checkCompanionApk: mockCheckCompanionApk,
   dismissWhatsNew: mockDismissWhatsNew,
   upgradeStage: mockUpgradeStage,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -206,6 +206,18 @@ export interface AppInfo {
   activeEngine?: string;
 }
 
+/* Result of the "is a newer release available?" check for the Account →
+   Application updates card. FAIL-OPEN: `reachable: false` means the release
+   source couldn't be reached (private repo / offline / rate-limited) — the
+   card then shows only the running version, never an error. */
+export interface UpdateStatus {
+  reachable: boolean;
+  currentVersion: string;
+  latestVersion: string | null;
+  updateAvailable: boolean;
+  url: string | null;
+}
+
 /* Interim companion-app distribution — availability of the packaged Android
    APK served by GET /api/companion/apk. The Listen-tab banner probes this
    (HEAD) and shows a "Download .apk" button only when `available`. */

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -84,6 +84,7 @@ const HelpView = lazy(() =>
   import('../views/help').then((m) => ({ default: m.HelpView })),
 );
 import { ChapterExclusionList } from '../components/chapter-exclusion-list';
+import { AnalyzerModelOverrideBadge } from '../components/analyzer-model-override-badge';
 import { isLikelyFrontMatter, chapterSlug } from '../lib/chapter-heuristics';
 import type { Character, Stage, View } from '../lib/types';
 
@@ -1035,6 +1036,8 @@ function ReparseResultBody({
           ))}
         </select>
       </label>
+
+      <AnalyzerModelOverrideBadge />
 
       <p className="text-ink/55 text-xs">
         Cast and analysis cache were cleared. Hit "Analyse now" to run character detection +

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -68,16 +68,22 @@ import { exportPollMiddleware } from './exports-middleware';
 import { createStreamRunner, type StreamRunner } from './generation-stream-runner';
 
 /** Persisted ui-slice keys. Stage so refresh restores the same view +
- *  chapter + drawer; model selectors so the user's per-session picks
- *  survive boot. Transient overlays (regenChapter,
- *  matchDetailFor, staleAudio, previewRegen, previewMode, ...) are
- *  deliberately omitted — restoring them would re-open dismissed
- *  modals on every refresh. */
+ *  chapter + drawer; the TTS engine pick so the chosen voice engine
+ *  survives boot. Transient overlays (regenChapter, matchDetailFor,
+ *  staleAudio, previewRegen, previewMode, ...) are deliberately omitted —
+ *  restoring them would re-open dismissed modals on every refresh.
+ *
+ *  NOTE — the analyzer model selectors (`selectedModel` /
+ *  `selectedModelExplicit`) are intentionally NOT persisted. They are a
+ *  per-run override; persisting them let an explicit pick (e.g. qwen3.5:4b
+ *  chosen to dodge a Gemini recitation block) silently shadow the saved
+ *  `analysisEngine`/`defaultAnalysisModel` on every later run, across
+ *  reloads and books, with no UI signal. Leaving them transient means a
+ *  reload reverts to the saved default; the override badge surfaces it
+ *  within a session. See src/store/persist-whitelist.test.ts. */
 export const UI_PERSIST_WHITELIST: ReadonlyArray<keyof UiState> = [
   'stage',
-  'selectedModel',
   'ttsModelKey',
-  'selectedModelExplicit',
   'ttsModelKeyExplicit',
   'themeOverride',
 ];
@@ -102,7 +108,11 @@ export const MANUSCRIPT_PERSIST_WHITELIST: ReadonlyArray<keyof ManuscriptState> 
  *  initialState, which is the safe outcome for storage we don't know how
  *  to migrate. Pair with a `migrate:` config entry to do a real
  *  field-level migration when one is needed. */
-const UI_PERSIST_VERSION = 2;
+/* v3 — drop the persisted analyzer-model override (selectedModel /
+   selectedModelExplicit). The migrate below strips it from existing v2
+   blobs so a value stuck from before the fix (e.g. qwen3.5:4b) clears on
+   upgrade WITHOUT resetting the still-persisted stage / TTS / theme keys. */
+const UI_PERSIST_VERSION = 3;
 const MANUSCRIPT_PERSIST_VERSION = 1;
 
 /* fe-2 — the whole settings slice persists device-local (every field is a
@@ -116,6 +126,19 @@ const uiPersistConfig: PersistConfig<UiState> = {
   /* Cast to mutable to satisfy redux-persist's PersistConfig (it widens
      to string[] internally). */
   whitelist: UI_PERSIST_WHITELIST as unknown as string[],
+  /* v2→v3: strip the no-longer-persisted analyzer-model override from any
+     existing blob so a pre-fix stuck value (e.g. qwen3.5:4b silently
+     shadowing the saved Gemini default) is cleared on first load after the
+     upgrade. Returning the same blob minus those two keys preserves the
+     other persisted prefs (stage / TTS engine / theme). */
+  migrate: (state) => {
+    if (state && typeof state === 'object') {
+      const s = state as Record<string, unknown>;
+      delete s.selectedModel;
+      delete s.selectedModelExplicit;
+    }
+    return Promise.resolve(state);
+  },
 };
 
 const manuscriptPersistConfig: PersistConfig<ManuscriptState> = {

--- a/src/store/persist-config.test.ts
+++ b/src/store/persist-config.test.ts
@@ -19,11 +19,13 @@ import { uiSlice } from './ui-slice';
 import { manuscriptSlice } from './manuscript-slice';
 
 describe('UI_PERSIST_WHITELIST', () => {
-  it('contains exactly the stage + user-model-pick fields that should survive refresh', () => {
-    /* Sorted compare so reorder doesn't churn this assertion. */
+  it('contains exactly the stage + TTS-engine-pick + theme fields that should survive refresh', () => {
+    /* Sorted compare so reorder doesn't churn this assertion. NOTE: the
+       analyzer-model selectors (selectedModel / selectedModelExplicit) are
+       intentionally NOT here — they are a per-run override that must revert to
+       the saved default on reload (fix: sticky-model bug). See the transient
+       guard below + persist-whitelist.test.ts. */
     expect([...UI_PERSIST_WHITELIST].sort()).toEqual([
-      'selectedModel',
-      'selectedModelExplicit',
       'stage',
       'themeOverride',
       'ttsModelKey',
@@ -48,6 +50,10 @@ describe('UI_PERSIST_WHITELIST', () => {
       'driftReportCharacterFilter',
       'previewMode',
       'reuploadingBookId',
+      /* Per-run analyzer-model override — transient by design so it can't
+         silently shadow the saved analysisEngine across reloads/books. */
+      'selectedModel',
+      'selectedModelExplicit',
     ];
     for (const key of transientKeys) {
       expect(

--- a/src/store/persist-whitelist.test.ts
+++ b/src/store/persist-whitelist.test.ts
@@ -1,0 +1,20 @@
+/* Guards the fix for the sticky analyzer-model bug: a per-run model pick
+   (ui.selectedModel / selectedModelExplicit) must NOT be persisted, so it
+   reverts to the saved account default on reload instead of silently
+   shadowing analysisEngine forever. The TTS engine pick stays persisted —
+   that stickiness is a separate, intentional preference. */
+
+import { describe, expect, it } from 'vitest';
+import { UI_PERSIST_WHITELIST } from './index';
+
+describe('UI persist whitelist — analyzer model override is transient', () => {
+  it('omits selectedModel and selectedModelExplicit so a per-run pick reverts on reload', () => {
+    expect(UI_PERSIST_WHITELIST).not.toContain('selectedModel');
+    expect(UI_PERSIST_WHITELIST).not.toContain('selectedModelExplicit');
+  });
+
+  it('still persists the TTS engine pick (separate, intentional stickiness)', () => {
+    expect(UI_PERSIST_WHITELIST).toContain('ttsModelKey');
+    expect(UI_PERSIST_WHITELIST).toContain('ttsModelKeyExplicit');
+  });
+});

--- a/src/store/ui-slice.test.ts
+++ b/src/store/ui-slice.test.ts
@@ -257,6 +257,34 @@ describe('uiSlice — seed defaults from account settings', () => {
   });
 });
 
+describe('uiSlice — analyzer model override is transient + resettable (fix: sticky selectedModel)', () => {
+  it('setSelectedModel marks the pick explicit (a per-run override)', () => {
+    const s = uiSlice.reducer(
+      baseState({ kind: 'books' }),
+      uiActions.setSelectedModel('qwen3.5:4b'),
+    );
+    expect(s.selectedModel).toBe('qwen3.5:4b');
+    expect(s.selectedModelExplicit).toBe(true);
+  });
+
+  it('resetSelectedModelToDefault clears the override and restores the saved default', () => {
+    let s = uiSlice.reducer(baseState({ kind: 'books' }), uiActions.setSelectedModel('qwen3.5:4b'));
+    s = uiSlice.reducer(s, uiActions.resetSelectedModelToDefault('gemini-3.1-flash-lite'));
+    expect(s.selectedModel).toBe('gemini-3.1-flash-lite');
+    expect(s.selectedModelExplicit).toBe(false);
+  });
+
+  it('after reset, an account re-hydrate seeds the saved default again (no longer sticky)', () => {
+    let s = uiSlice.reducer(baseState({ kind: 'books' }), uiActions.setSelectedModel('qwen3.5:4b'));
+    s = uiSlice.reducer(s, uiActions.resetSelectedModelToDefault('gemini-3.1-flash-lite'));
+    s = uiSlice.reducer(s, {
+      type: 'account/fetch/fulfilled',
+      payload: { defaultAnalysisModel: 'gemma-4-31b-it', defaultTtsModelKey: 'kokoro-v1' },
+    });
+    expect(s.selectedModel).toBe('gemma-4-31b-it');
+  });
+});
+
 describe('uiSlice — rebaseline modal target bookId', () => {
   it('openRebaselineModal stores the target bookId and opens the modal', () => {
     const start = baseState({ kind: 'voices' });

--- a/src/store/ui-slice.ts
+++ b/src/store/ui-slice.ts
@@ -313,6 +313,18 @@ export const uiSlice = createSlice({
       s.selectedModel = a.payload;
       s.selectedModelExplicit = true;
     },
+    /* Drop a per-run analyzer-model override and fall back to the saved
+       account default. Clearing `selectedModelExplicit` re-arms the
+       account-defaults seeder (see applyAccountDefaults), so a later
+       settings hydrate/save keeps the picker in sync with the saved
+       default. Fixes the sticky-override bug where an explicit pick (e.g.
+       qwen3.5:4b chosen to dodge a Gemini block) silently shadowed the
+       saved `analysisEngine` on every later run. Powers the "Reset to
+       default" affordance on the override badge. */
+    resetSelectedModelToDefault: (s, a: PayloadAction<string>) => {
+      s.selectedModel = a.payload;
+      s.selectedModelExplicit = false;
+    },
     setTtsModelKey: (s, a: PayloadAction<TtsModelKey>) => {
       s.ttsModelKey = a.payload;
       s.ttsModelKeyExplicit = true;

--- a/src/views/account.backups.test.tsx
+++ b/src/views/account.backups.test.tsx
@@ -27,6 +27,14 @@ vi.mock('../lib/api', () => ({
     backupBookNow: vi.fn(),
     restoreBookBackup: vi.fn(),
     getLibrary: vi.fn(),
+    /* UpgradeCard (inside AccountView) checks for updates on mount; fail-open. */
+    getUpdateStatus: vi.fn().mockResolvedValue({
+      reachable: false,
+      currentVersion: '',
+      latestVersion: null,
+      updateAvailable: false,
+      url: null,
+    }),
   },
 }));
 

--- a/src/views/account.test.tsx
+++ b/src/views/account.test.tsx
@@ -460,7 +460,9 @@ describe('AccountView — settings-accordion shell', () => {
        renders buttons with the same label text, so we look for the aria-expanded
        attribute that only section header toggles carry. */
     const expandedBtns = screen.getAllByRole('button', { expanded: true });
-    const expandedLabels = expandedBtns.map((b) => b.getAttribute('aria-label') ?? b.textContent ?? '');
+    const expandedLabels = expandedBtns.map(
+      (b) => b.getAttribute('aria-label') ?? b.textContent ?? '',
+    );
     expect(expandedLabels.some((l) => /profile/i.test(l))).toBe(true);
     expect(expandedLabels.some((l) => /cast analysis/i.test(l))).toBe(true);
     expect(expandedLabels.some((l) => /workspace/i.test(l))).toBe(true);
@@ -474,5 +476,22 @@ describe('AccountView — settings-accordion shell', () => {
       expect(api.putUserSettings).toHaveBeenCalledTimes(1);
     });
   });
-});
 
+  it('lists the button-only sections in the side-nav too (Models / Advanced / Help / First-run)', () => {
+    /* Regression: these four cards used to sit OUTSIDE the accordion, so the
+       side-nav didn't cover them. They now live inside it with scroll-link ids,
+       so the mobile jump <select> (and desktop rail) carry an entry for each. */
+    renderView();
+    for (const label of [
+      'Models & engines',
+      'Advanced configuration',
+      'Help & troubleshooting',
+      'First-run setup',
+    ]) {
+      expect(screen.getByRole('option', { name: label })).toBeInTheDocument();
+    }
+    /* And each card carries the scroll-target id the nav points at. */
+    expect(document.getElementById('cfg-section-acct-models')).not.toBeNull();
+    expect(document.getElementById('cfg-section-acct-setup')).not.toBeNull();
+  });
+});

--- a/src/views/account.test.tsx
+++ b/src/views/account.test.tsx
@@ -19,6 +19,15 @@ vi.mock('../lib/api', () => ({
     getUserSettings: vi.fn(),
     putUserSettings: vi.fn(),
     putGeminiKey: vi.fn(),
+    /* UpgradeCard (rendered inside AccountView) checks for updates on mount;
+       fail-open so these tests don't touch the network. */
+    getUpdateStatus: vi.fn().mockResolvedValue({
+      reachable: false,
+      currentVersion: '',
+      latestVersion: null,
+      updateAvailable: false,
+      url: null,
+    }),
   },
 }));
 

--- a/src/views/account.tsx
+++ b/src/views/account.tsx
@@ -7,12 +7,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { SectionLabel, MixedHeading, PrimaryButton } from '../components/primitives';
-import type {
-  BackupSnapshot,
-  ConfigGroup,
-  UserSettings,
-  UserSettingsPatch,
-} from '../lib/types';
+import type { BackupSnapshot, ConfigGroup, UserSettings, UserSettingsPatch } from '../lib/types';
 import type { ThemePreference } from '../lib/use-theme';
 import { api } from '../lib/api';
 import { UpgradeCard } from '../components/upgrade-card';
@@ -31,10 +26,7 @@ import {
 } from '../store/settings-slice';
 import { formatKeyLabel, normalizeKeyEvent } from '../lib/keybindings';
 import { FieldRow, ReadOnlyRow } from '../components/account-forms';
-import {
-  SettingsAccordion,
-  SettingsSection,
-} from '../components/settings/settings-accordion';
+import { SettingsAccordion, SettingsSection } from '../components/settings/settings-accordion';
 
 /* Synthetic ConfigGroup descriptors for account sections — these are not
    registry knobs, so overriddenCount is always 0 and there's no reset. */
@@ -191,7 +183,7 @@ export function AccountView() {
   }
 
   return (
-    <div className="max-w-[960px] mx-auto px-6 py-10">
+    <div className="max-w-[1200px] mx-auto px-6 py-10">
       <div className="mb-8">
         <SectionLabel>Account</SectionLabel>
         <div className="mt-4">
@@ -215,10 +207,18 @@ export function AccountView() {
             { id: 'acct-backups', label: 'Backups', risk: 'low' },
             { id: 'acct-workspace', label: 'Workspace', risk: 'low' },
             { id: 'acct-device-local', label: 'Device-local', risk: 'low' },
+            { id: 'acct-models', label: 'Models & engines', risk: 'low' },
+            { id: 'acct-advanced', label: 'Advanced configuration', risk: 'low' },
+            { id: 'acct-help', label: 'Help & troubleshooting', risk: 'low' },
+            { id: 'acct-setup', label: 'First-run setup', risk: 'low' },
           ]}
         >
           <SettingsSection
-            group={acctGroup('acct-profile', 'Profile', 'How you appear in the top bar and the change log.')}
+            group={acctGroup(
+              'acct-profile',
+              'Profile',
+              'How you appear in the top bar and the change log.',
+            )}
             overriddenCount={0}
           >
             <FieldRow label="Display name">
@@ -292,7 +292,7 @@ export function AccountView() {
             group={acctGroup(
               'acct-appearance',
               'Appearance',
-              "How the app looks. The sun/moon toggle in the top bar is a device-only override; this picker sets the default that any new device or fresh session inherits.",
+              'How the app looks. The sun/moon toggle in the top bar is a device-only override; this picker sets the default that any new device or fresh session inherits.',
             )}
             overriddenCount={0}
           >
@@ -317,9 +317,10 @@ export function AccountView() {
                 className="flex items-center justify-between gap-3 rounded-xl border border-magenta/30 bg-magenta/10 px-4 py-3"
               >
                 <div className="text-xs text-ink/75">
-                  <span className="font-semibold text-magenta">This device is overridden</span> — the
-                  top-bar toggle is set to <span className="font-mono text-ink">{themeOverride}</span>
-                  . Clear the override to follow the account default again.
+                  <span className="font-semibold text-magenta">This device is overridden</span> —
+                  the top-bar toggle is set to{' '}
+                  <span className="font-mono text-ink">{themeOverride}</span>. Clear the override to
+                  follow the account default again.
                 </div>
                 <PrimaryButton
                   variant="ghost"
@@ -430,77 +431,92 @@ export function AccountView() {
           </SettingsSection>
 
           <AdvancedCard />
+
+          {/* fs-23 — model setup (engines, installers, sidecar, analyzer split,
+              server config) now lives in the Model Manager, reached from Admin.
+              Button-only cards live INSIDE the accordion so the side-nav lists
+              and scroll-links them too (id="cfg-section-<navId>"). */}
+          <section
+            id="cfg-section-acct-models"
+            className="rounded-2xl border border-ink/10 bg-white p-6 shadow-card flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div>
+              <h2 className="text-base font-semibold text-ink">Models &amp; engines</h2>
+              <p className="mt-1 text-xs text-ink/55 max-w-prose">
+                Installing models, picking the default Voice / analyzer engine, the Voice engine /
+                Ollama URLs, and the Gemini key now live in the Model Manager.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => dispatch(uiActions.openModelManager())}
+              data-testid="account-model-manager-pointer"
+              className="shrink-0 min-h-[44px] sm:min-h-0 px-4 py-2 rounded-xl bg-ink text-canvas text-sm font-medium hover:bg-ink-soft"
+            >
+              Open Model Manager →
+            </button>
+          </section>
+
+          <section
+            id="cfg-section-acct-advanced"
+            className="rounded-2xl border border-ink/10 bg-white p-6 shadow-card flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div>
+              <h2 className="text-base font-semibold text-ink">Advanced configuration</h2>
+              <p className="mt-1 text-xs text-ink/55 max-w-prose">
+                Tune model, generation, and QA settings at your own risk.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => dispatch(uiActions.openAdvanced())}
+              data-testid="account-advanced-pointer"
+              className="shrink-0 min-h-[44px] sm:min-h-0 px-4 py-2 rounded-xl bg-ink text-canvas text-sm font-medium hover:bg-ink-soft"
+            >
+              Open Advanced settings →
+            </button>
+          </section>
+
+          <section
+            id="cfg-section-acct-help"
+            className="rounded-2xl border border-ink/10 bg-white p-6 shadow-card flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div>
+              <h2 className="text-base font-semibold text-ink">Help &amp; troubleshooting</h2>
+              <p className="mt-1 text-xs text-ink/55 max-w-prose">
+                FAQs, engine setup guides, and troubleshooting steps for common issues.
+              </p>
+            </div>
+            <a
+              href="#/help"
+              data-testid="account-help-pointer"
+              className="shrink-0 min-h-[44px] sm:min-h-0 px-4 py-2 rounded-xl bg-ink text-canvas text-sm font-medium hover:bg-ink-soft inline-flex items-center"
+            >
+              Open Help →
+            </a>
+          </section>
+
+          <section
+            id="cfg-section-acct-setup"
+            className="rounded-2xl border border-ink/10 bg-white p-6 shadow-card flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div>
+              <h2 className="text-base font-semibold text-ink">First-run setup</h2>
+              <p className="mt-1 text-xs text-ink/55 max-w-prose">
+                Re-open the setup wizard to check model installation, workspace, and engine
+                readiness.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => dispatch(uiActions.openSetup())}
+              data-testid="account-rerun-setup"
+              className="shrink-0 min-h-[44px] sm:min-h-0 px-4 py-2 rounded-xl bg-ink text-canvas text-sm font-medium hover:bg-ink-soft"
+            >
+              Re-run setup →
+            </button>
+          </section>
         </SettingsAccordion>
-
-        {/* fs-23 — model setup (engines, installers, sidecar, analyzer split,
-            server config) now lives in the Model Manager, reached from Admin. */}
-        <section className="rounded-2xl border border-ink/10 bg-white p-6 shadow-card flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h2 className="text-base font-semibold text-ink">Models &amp; engines</h2>
-            <p className="mt-1 text-xs text-ink/55 max-w-prose">
-              Installing models, picking the default Voice / analyzer engine, the Voice engine /
-              Ollama URLs, and the Gemini key now live in the Model Manager.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => dispatch(uiActions.openModelManager())}
-            data-testid="account-model-manager-pointer"
-            className="shrink-0 min-h-[44px] sm:min-h-0 px-4 py-2 rounded-xl bg-ink text-canvas text-sm font-medium hover:bg-ink-soft"
-          >
-            Open Model Manager →
-          </button>
-        </section>
-
-        <section className="rounded-2xl border border-ink/10 bg-white p-6 shadow-card flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h2 className="text-base font-semibold text-ink">Advanced configuration</h2>
-            <p className="mt-1 text-xs text-ink/55 max-w-prose">
-              Tune model, generation, and QA settings at your own risk.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => dispatch(uiActions.openAdvanced())}
-            data-testid="account-advanced-pointer"
-            className="shrink-0 min-h-[44px] sm:min-h-0 px-4 py-2 rounded-xl bg-ink text-canvas text-sm font-medium hover:bg-ink-soft"
-          >
-            Open Advanced settings →
-          </button>
-        </section>
-
-        <section className="rounded-2xl border border-ink/10 bg-white p-6 shadow-card flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h2 className="text-base font-semibold text-ink">Help &amp; troubleshooting</h2>
-            <p className="mt-1 text-xs text-ink/55 max-w-prose">
-              FAQs, engine setup guides, and troubleshooting steps for common issues.
-            </p>
-          </div>
-          <a
-            href="#/help"
-            data-testid="account-help-pointer"
-            className="shrink-0 min-h-[44px] sm:min-h-0 px-4 py-2 rounded-xl bg-ink text-canvas text-sm font-medium hover:bg-ink-soft inline-flex items-center"
-          >
-            Open Help →
-          </a>
-        </section>
-
-        <section className="rounded-2xl border border-ink/10 bg-white p-6 shadow-card flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h2 className="text-base font-semibold text-ink">First-run setup</h2>
-            <p className="mt-1 text-xs text-ink/55 max-w-prose">
-              Re-open the setup wizard to check model installation, workspace, and engine readiness.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => dispatch(uiActions.openSetup())}
-            data-testid="account-rerun-setup"
-            className="shrink-0 min-h-[44px] sm:min-h-0 px-4 py-2 rounded-xl bg-ink text-canvas text-sm font-medium hover:bg-ink-soft"
-          >
-            Re-run setup →
-          </button>
-        </section>
 
         <div className="flex items-center gap-4">
           <PrimaryButton variant={dirty ? 'dark' : 'ghost'} onClick={onSave} icon={false}>
@@ -748,13 +764,12 @@ function AdvancedCard() {
       )}
       overriddenCount={0}
     >
-      <div
-        data-testid="account-advanced-card"
-        className="space-y-6"
-      >
+      <div data-testid="account-advanced-card" className="space-y-6">
         {/* Keyboard shortcut — play/pause */}
         <div>
-          <span className="block text-sm font-medium text-ink">Keyboard shortcut — play / pause</span>
+          <span className="block text-sm font-medium text-ink">
+            Keyboard shortcut — play / pause
+          </span>
           <span className="block text-xs text-ink/55 mt-0.5">
             Toggles the mini-player on the Listen view. Default is Space; rebind to any letter or
             Space.
@@ -820,7 +835,9 @@ function AdvancedCard() {
 
         {/* fe-24 — keyboard shortcut — skip forward */}
         <div>
-          <span className="block text-sm font-medium text-ink">Keyboard shortcut — skip forward</span>
+          <span className="block text-sm font-medium text-ink">
+            Keyboard shortcut — skip forward
+          </span>
           <span className="block text-xs text-ink/55 mt-0.5">
             Fast-forwards the mini-player by the skip-forward delta below. Default is L (mirrors
             YouTube).
@@ -880,7 +897,10 @@ function AdvancedCard() {
             />
           </div>
           <div>
-            <label htmlFor="account-skip-forward-sec" className="block text-sm font-medium text-ink">
+            <label
+              htmlFor="account-skip-forward-sec"
+              className="block text-sm font-medium text-ink"
+            >
               Skip-forward amount (s)
             </label>
             <span className="block text-xs text-ink/55 mt-0.5">

--- a/src/views/advanced.tsx
+++ b/src/views/advanced.tsx
@@ -111,9 +111,7 @@ function PromptRow({ descriptor }: PromptRowProps) {
       </div>
       <p className="text-xs text-ink/55 mb-2">{descriptor.help}</p>
 
-      {loadError && (
-        <p className="text-xs text-rose-700 mb-2">Couldn't load prompt: {loadError}</p>
-      )}
+      {loadError && <p className="text-xs text-rose-700 mb-2">Couldn't load prompt: {loadError}</p>}
 
       {!editing ? (
         <div className="flex items-center gap-2 flex-wrap">
@@ -173,9 +171,7 @@ function PromptRow({ descriptor }: PromptRowProps) {
 
 export function AdvancedView() {
   const dispatch = useAppDispatch();
-  const { groups, descriptors, values, status, error, hydrated } = useAppSelector(
-    (s) => s.config,
-  );
+  const { groups, descriptors, values, status, error, hydrated } = useAppSelector((s) => s.config);
   const restartPending = useAppSelector(selectRestartPending);
   const restartServerPending = useAppSelector(selectRestartServerPending);
   const [restarting, setRestarting] = useState(false);
@@ -199,7 +195,7 @@ export function AdvancedView() {
   };
 
   return (
-    <div className="max-w-[960px] mx-auto px-4 sm:px-6 py-10">
+    <div className="max-w-[1200px] mx-auto px-4 sm:px-6 py-10">
       <div className="mb-8">
         <button
           type="button"
@@ -268,7 +264,9 @@ export function AdvancedView() {
             </button>
           </div>
 
-          <SettingsAccordion sections={groups.map((g) => ({ id: g.id, label: g.label, risk: g.risk }))}>
+          <SettingsAccordion
+            sections={groups.map((g) => ({ id: g.id, label: g.label, risk: g.risk }))}
+          >
             {groups.map((group) => {
               const groupDescriptors = descriptors.filter((d) => d.group === group.id);
               const overriddenCount = groupDescriptors.filter(
@@ -289,13 +287,15 @@ export function AdvancedView() {
                       <OverrideRow
                         key={d.key}
                         descriptor={d}
-                        value={values[d.key] ?? {
-                          key: d.key,
-                          effective: d.default,
-                          source: 'default',
-                          locked: false,
-                          overridden: false,
-                        }}
+                        value={
+                          values[d.key] ?? {
+                            key: d.key,
+                            effective: d.default,
+                            source: 'default',
+                            locked: false,
+                            overridden: false,
+                          }
+                        }
                         onChange={(raw) => dispatch(saveOverride({ key: d.key, value: raw }))}
                         onRevert={() => dispatch(resetKnob(d.key))}
                       />

--- a/src/views/analysing.tsx
+++ b/src/views/analysing.tsx
@@ -15,6 +15,7 @@ import { ANALYSIS_PHASES } from '../data/analysis-phases';
 import { computeOverallProgress } from '../lib/analysis-progress';
 import { MODEL_OPTIONS, MODEL_OPTION_GROUPS } from '../lib/models';
 import { ModelControlPill, type ModelControlState } from '../components/ModelControlPill';
+import { AnalyzerModelOverrideBadge } from '../components/analyzer-model-override-badge';
 import { PhaseCard, type ConnState } from '../components/analysing/phase-card';
 import { StickyAnalysisBar } from '../components/analysing/sticky-analysis-bar';
 import type { AnalyseResponse } from '../lib/types';
@@ -1227,6 +1228,7 @@ export function AnalysingView({
                     ))}
                   </select>
                 </label>
+                <AnalyzerModelOverrideBadge />
                 <button
                   onClick={() => setRetry((r) => ({ nonce: r.nonce + 1, fresh: false }))}
                   className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-ink text-canvas text-xs font-semibold hover:bg-ink/90"

--- a/src/views/model-manager.tsx
+++ b/src/views/model-manager.tsx
@@ -20,6 +20,7 @@ import {
 import { api, type ModelInventoryItem, type ModelInventoryResponse } from '../lib/api';
 import { formatBytes } from '../lib/bytes';
 import { ModelSettingsForm } from '../components/model-settings-form';
+import { SettingsAccordion } from '../components/settings/settings-accordion';
 import { CoquiInstall } from '../components/coqui-install';
 import { KokoroInstall } from '../components/kokoro-install';
 import { QwenInstall } from '../components/qwen-install';
@@ -50,7 +51,7 @@ const INSTALLER_BY_ID: Partial<Record<string, ComponentType<{ onInstalled?: () =
 export function ModelManagerView() {
   const dispatch = useAppDispatch();
   return (
-    <div className="max-w-[960px] mx-auto px-4 sm:px-6 py-10">
+    <div className="max-w-[1200px] mx-auto px-4 sm:px-6 py-10">
       <div className="mb-8">
         <button
           type="button"
@@ -64,16 +65,30 @@ export function ModelManagerView() {
           <MixedHeading regular="Model" bold="Manager" level="h1" />
         </div>
         <p className="mt-3 text-ink/60 max-w-xl">
-          Install, remove, and update your local models, see disk usage, and load or unload each into
-          the GPU.
+          Install, remove, and update your local models, see disk usage, and load or unload each
+          into the GPU.
         </p>
       </div>
 
-      <div className="space-y-6">
-        <DevicePanel />
-        <ModelInventory />
-        <ModelSettingsForm />
-      </div>
+      {/* Side-menu of sections (mirrors the Account / Advanced layout) — scroll
+          targets are id="cfg-section-<navId>". */}
+      <SettingsAccordion
+        sections={[
+          { id: 'mm-device', label: 'Device', risk: 'low' },
+          { id: 'mm-models', label: 'Installed models', risk: 'low' },
+          { id: 'mm-settings', label: 'Defaults & engines', risk: 'low' },
+        ]}
+      >
+        <div id="cfg-section-mm-device">
+          <DevicePanel />
+        </div>
+        <div id="cfg-section-mm-models">
+          <ModelInventory />
+        </div>
+        <div id="cfg-section-mm-settings">
+          <ModelSettingsForm />
+        </div>
+      </SettingsAccordion>
     </div>
   );
 }
@@ -129,7 +144,9 @@ function ModelInventory() {
         GPU memory.
       </p>
       {error && (
-        <p className="mt-2 text-xs text-amber-700">Couldn't refresh just now — showing last known.</p>
+        <p className="mt-2 text-xs text-amber-700">
+          Couldn't refresh just now — showing last known.
+        </p>
       )}
 
       <ul className="mt-4 space-y-3">
@@ -338,87 +355,84 @@ function ModelRow({
       className="rounded-xl border border-ink/10 bg-ink/2 p-3 flex flex-col gap-3"
     >
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-      <div className="min-w-0">
-        <div className="flex items-center gap-2 flex-wrap">
-          <span className="text-sm font-semibold text-ink">{item.label}</span>
-          {item.isDefaultEngine && (
-            <span className="text-[10px] font-semibold uppercase tracking-wide text-magenta bg-magenta/10 rounded-full px-2 py-0.5">
-              Default
-            </span>
-          )}
-          {item.isFallbackEngine && (
-            <span className="text-[10px] font-semibold uppercase tracking-wide text-ink/55 bg-ink/5 rounded-full px-2 py-0.5">
-              Fallback
-            </span>
-          )}
-          {item.integrity === 'verified' && (
-            <span
-              className="text-[10px] font-semibold text-emerald-700"
-              title="On-disk size matches the pinned release (full SHA256 is verified at install time)"
-            >
-              ✓ verified
-            </span>
-          )}
-          {item.integrity === 'mismatch' && (
-            <span
-              className="text-[10px] font-semibold text-rose-700"
-              title="On-disk size differs from the pinned release — reinstall to restore integrity"
-            >
-              ⚠ size mismatch
-            </span>
-          )}
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-sm font-semibold text-ink">{item.label}</span>
+            {item.isDefaultEngine && (
+              <span className="text-[10px] font-semibold uppercase tracking-wide text-magenta bg-magenta/10 rounded-full px-2 py-0.5">
+                Default
+              </span>
+            )}
+            {item.isFallbackEngine && (
+              <span className="text-[10px] font-semibold uppercase tracking-wide text-ink/55 bg-ink/5 rounded-full px-2 py-0.5">
+                Fallback
+              </span>
+            )}
+            {item.integrity === 'verified' && (
+              <span
+                className="text-[10px] font-semibold text-emerald-700"
+                title="On-disk size matches the pinned release (full SHA256 is verified at install time)"
+              >
+                ✓ verified
+              </span>
+            )}
+            {item.integrity === 'mismatch' && (
+              <span
+                className="text-[10px] font-semibold text-rose-700"
+                title="On-disk size differs from the pinned release — reinstall to restore integrity"
+              >
+                ⚠ size mismatch
+              </span>
+            )}
+          </div>
+          <div className="mt-1 text-xs text-ink/55">
+            {item.present ? formatBytes(item.sizeBytes) : 'not installed'}
+            {item.diskPath && (
+              <>
+                {' · '}
+                <span className="font-mono break-all text-ink/45">{item.diskPath}</span>
+              </>
+            )}
+          </div>
         </div>
-        <div className="mt-1 text-xs text-ink/55">
-          {item.present ? formatBytes(item.sizeBytes) : 'not installed'}
-          {item.diskPath && (
-            <>
-              {' · '}
-              <span className="font-mono break-all text-ink/45">{item.diskPath}</span>
-            </>
-          )}
-        </div>
-      </div>
 
-      <div className="flex items-center gap-2 shrink-0 flex-wrap">
-        <ResidencyBadge item={item} />
-        {hasControl && (
-          <ModelControlPill
-            kind={controlKind}
-            state={controlState}
-            engineLabel={item.label}
-            onLoad={doLoad}
-            onStop={doStop}
-          />
-        )}
-        {Installer && (
-          <button
-            type="button"
-            onClick={() => setInstallerOpen((o) => !o)}
-            data-testid={`model-install-toggle-${item.id}`}
-            aria-expanded={installerOpen}
-            className="min-h-[44px] sm:min-h-0 px-3 py-1 rounded-full border border-ink/15 bg-white text-[11px] font-semibold text-ink/70 hover:bg-ink/5"
-          >
-            {item.present ? 'Update' : 'Install'} {installerOpen ? '▴' : '▾'}
-          </button>
-        )}
-        {item.present && item.removable && (
-          <button
-            type="button"
-            onClick={onRemove}
-            data-testid={`model-remove-${item.id}`}
-            className="min-h-[44px] sm:min-h-0 px-3 py-1 rounded-full border border-rose-200 bg-white text-[11px] font-semibold text-rose-700 hover:bg-rose-50"
-          >
-            Remove
-          </button>
-        )}
-      </div>
+        <div className="flex items-center gap-2 shrink-0 flex-wrap">
+          <ResidencyBadge item={item} />
+          {hasControl && (
+            <ModelControlPill
+              kind={controlKind}
+              state={controlState}
+              engineLabel={item.label}
+              onLoad={doLoad}
+              onStop={doStop}
+            />
+          )}
+          {Installer && (
+            <button
+              type="button"
+              onClick={() => setInstallerOpen((o) => !o)}
+              data-testid={`model-install-toggle-${item.id}`}
+              aria-expanded={installerOpen}
+              className="min-h-[44px] sm:min-h-0 px-3 py-1 rounded-full border border-ink/15 bg-white text-[11px] font-semibold text-ink/70 hover:bg-ink/5"
+            >
+              {item.present ? 'Update' : 'Install'} {installerOpen ? '▴' : '▾'}
+            </button>
+          )}
+          {item.present && item.removable && (
+            <button
+              type="button"
+              onClick={onRemove}
+              data-testid={`model-remove-${item.id}`}
+              className="min-h-[44px] sm:min-h-0 px-3 py-1 rounded-full border border-rose-200 bg-white text-[11px] font-semibold text-rose-700 hover:bg-rose-50"
+            >
+              Remove
+            </button>
+          )}
+        </div>
       </div>
 
       {Installer && installerOpen && (
-        <div
-          data-testid={`model-installer-${item.id}`}
-          className="border-t border-ink/10 pt-3"
-        >
+        <div data-testid={`model-installer-${item.id}`} className="border-t border-ink/10 pt-3">
           <Installer onInstalled={onChanged} />
         </div>
       )}

--- a/src/views/upload.tsx
+++ b/src/views/upload.tsx
@@ -6,6 +6,7 @@ import { api } from '../lib/api';
 import type { UploadArgs } from '../lib/api';
 import { TAGLINE_SHORT } from '../lib/brand';
 import { AnalysisModelPicker } from '../components/analysis-model-picker';
+import { AnalyzerModelOverrideBadge } from '../components/analyzer-model-override-badge';
 import { useAppDispatch, useAppSelector } from '../store';
 import { uiActions } from '../store/ui-slice';
 import { libraryActions } from '../store/library-slice';
@@ -289,6 +290,10 @@ export function UploadView() {
             onChange={(id) => dispatch(uiActions.setSelectedModel(id))}
             disabled={busy}
           />
+        </div>
+
+        <div className="mb-5 flex justify-center">
+          <AnalyzerModelOverrideBadge />
         </div>
 
         <div


### PR DESCRIPTION
## Summary

Integration of three independent branches (one verified PR per the CI-cost reconciliation pattern). All landed test-first.

**Bug fixes**
- **Ollama residency leak** — `tagMatches` no longer conflates same-family size tags, so a resident `qwen3.5:4b` won't show `qwen3.5:9b` as "Loaded" in the Model Manager.
- **Sticky analyzer model** — the per-run analyzer model pick (`ui.selectedModel`/`selectedModelExplicit`) is no longer persisted (dropped from the whitelist + a v2→v3 migrate that clears any stuck value), so a reload reverts to the saved `analysisEngine`/`defaultAnalysisModel` instead of silently shadowing it forever. A new override badge + "Reset to default" surfaces an active per-run pick next to every analyzer picker. No silent gemini→local switch was ever added.

**Update check (fail-open)**
- New `GET /api/updates/latest` checks GitHub Releases (optional `GITHUB_TOKEN`, `UPDATE_CHECK_REPO` override), caches reachable results 1h, and FAILS OPEN — a private/offline/rate-limited source returns `{ reachable: false }`, never an error. The Application updates card now shows *Update available: vX* / *You're up to date* / silent fallback (running version + manual apply), with the manual-apply button demoted when current.

**Settings nav unification**
- Account's button-only cards (Models & engines, Advanced, Help, First-run setup) moved inside the side-menu accordion with scroll-link ids + nav entries; the Model Manager gained the same side-menu (Device / Installed models / Defaults & engines); all three settings views widened 960→1200px.

Also folds verified fs-38 (plan 194) implementation notes for the Qwen reference-clip clone pipeline.

## Test plan

- `npm run verify` green locally on the integrated branch — lint, typecheck, full unit/integration suites (frontend 2763, server 2552 + slow + scripts + sidecar), e2e + visual, build.
- New paired tests: `updates.test.ts` (version parse/compare/fail-open), `analyzer-model-override-badge.test.tsx`, `upgrade-card.test.tsx` (3 update-check states + client fail-open), `persist-whitelist.test.ts`, `models-inventory.test.ts` (residency cross-tag regression), `ui-slice.test.ts` (reset reducer), `account.test.tsx` (nav entries), and the `upgrade-flow` e2e updated for the demoted label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)