### PR TITLE
feat(app): report wall-clock listening stats from the companion (fs-16, Wave H)

### DIFF
--- a/apps/android/lib/src/data/api_client.dart
+++ b/apps/android/lib/src/data/api_client.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import '../domain/sync_manifest.dart';
 import 'chapter_downloader.dart' show RangeFetch, RangeResponse;
+import 'listen_stats_service.dart' show ListenStatsApi, StatDay;
 import 'pairing_service.dart' show Connection;
 import 'resume_sync_service.dart' show ListenProgressApi, RemoteProgress;
 import 'sync_engine.dart' show ManifestApi;
@@ -87,6 +88,9 @@ class ApiClient {
   /// Adapter so this client satisfies the resume sync's [ListenProgressApi].
   ListenProgressApi get listenProgressApi => _ApiListenProgressApi(this);
 
+  /// Adapter so this client satisfies the stats flush's [ListenStatsApi].
+  ListenStatsApi get listenStatsApi => _ApiListenStatsApi(this);
+
   /// CA-pinned, authenticated GET returning the full response bytes (e.g. a
   /// book cover). Throws [ApiException] on >= 400 (404 = no cover).
   Future<List<int>> getBytes(String path) async {
@@ -162,6 +166,33 @@ class ApiClient {
     }
   }
 
+  /// PUT absolute listening-time accruals (fs-16). Body: `{ sessionId, days }`.
+  /// CA-pinned, same transport as [putListenProgress].
+  Future<void> putListenStats(
+    String bookId, {
+    required String sessionId,
+    required List<StatDay> days,
+  }) async {
+    final client = _pinnedHttpClient(connection);
+    try {
+      final req = await client.putUrl(_u('/api/books/$bookId/listen-stats'));
+      req.headers.set(
+          HttpHeaders.authorizationHeader, 'Bearer ${connection.server.token}');
+      req.headers.contentType = ContentType.json;
+      req.write(jsonEncode({
+        'sessionId': sessionId,
+        'days': [for (final d in days) {'date': d.date, 'seconds': d.seconds}],
+      }));
+      final res = await req.close();
+      await res.drain<void>();
+      if (res.statusCode >= 400) {
+        throw ApiException(res.statusCode, 'listen-stats PUT failed');
+      }
+    } finally {
+      client.close(force: true);
+    }
+  }
+
   /// A range-capable, CA-pinned, authenticated byte fetcher for chapter audio
   /// downloads — the engine's [RangeFetch] seam. Streams the response body so
   /// large chapters never buffer fully in memory; the `Range` header (set by the
@@ -191,6 +222,20 @@ class _ApiManifestApi implements ManifestApi {
   @override
   Future<SyncManifestBookDetail> bookDetail(String bookId) =>
       _client.syncManifestBookDetail(bookId);
+}
+
+/// Wraps [ApiClient] as the stats flush's [ListenStatsApi].
+class _ApiListenStatsApi implements ListenStatsApi {
+  _ApiListenStatsApi(this._client);
+  final ApiClient _client;
+
+  @override
+  Future<void> putListenStats(
+    String bookId, {
+    required String sessionId,
+    required List<StatDay> days,
+  }) =>
+      _client.putListenStats(bookId, sessionId: sessionId, days: days);
 }
 
 /// Wraps [ApiClient] as the resume sync's [ListenProgressApi].

--- a/apps/android/lib/src/data/auto_sync_service.dart
+++ b/apps/android/lib/src/data/auto_sync_service.dart
@@ -15,6 +15,8 @@ class AutoSyncService {
     required Future<NetworkType> Function() currentNetwork,
     required Future<bool> Function() probeReachable,
     required Future<void> Function() runSync,
+    // fs-16: flush buffered listen-stats on reconnect; null = no-op.
+    this._flushStats,
   })  : _settingsLoader = loadSettings,
         _networkProbe = currentNetwork,
         _reachabilityProbe = probeReachable,
@@ -24,6 +26,7 @@ class AutoSyncService {
   final Future<NetworkType> Function() _networkProbe;
   final Future<bool> Function() _reachabilityProbe;
   final Future<void> Function() _syncRunner;
+  final Future<void> Function()? _flushStats;
 
   /// Returns true iff a sync was actually started.
   Future<bool> maybeSync() async {
@@ -51,6 +54,8 @@ class AutoSyncService {
     if (!allowed) return false;
 
     await _syncRunner();
+    // fs-16: flush buffered listen-stats now that we know the server is reachable.
+    await _flushStats?.call();
     return true;
   }
 }

--- a/apps/android/lib/src/data/companion_runtime.dart
+++ b/apps/android/lib/src/data/companion_runtime.dart
@@ -10,6 +10,7 @@ import '../domain/storage_policy.dart';
 import 'api_client.dart';
 import 'car_browse.dart';
 import 'auto_sync_service.dart';
+import 'listen_stats_service.dart';
 import 'chapter_downloader.dart';
 import 'companion_audio_handler.dart';
 import 'download_foreground_service.dart';
@@ -96,7 +97,8 @@ class CompanionRuntime {
 
     final api = ApiClient(connection);
     final fs = const DiskFileStore();
-    final library = DriftLocalLibrary(LibraryDatabase.open(), fs, root: root);
+    final db = LibraryDatabase.open();
+    final library = DriftLocalLibrary(db, fs, root: root);
     final downloader = ChapterDownloader(api.pinnedRangeFetch(), fs);
 
     Uri resolve(String path) => Uri.parse('${connection.server.url}$path');
@@ -108,11 +110,24 @@ class CompanionRuntime {
       urlResolver: resolve,
     );
 
+    // fs-16: per-app-launch session id — a compact ms-epoch string, stable for
+    // the process lifetime. Injected into the player so tests can override it.
+    final sessionId =
+        DateTime.now().millisecondsSinceEpoch.toRadixString(36).toUpperCase();
+
     final player = PlayerController(
       audioEngine: JustAudioEngine(),
       playbackStore: library,
       playlistLoader: (bookId) async => sync.playlistFor(bookId),
       clock: DateTime.now,
+      statsDb: db,
+      sessionId: sessionId,
+      localDate: () {
+        final n = DateTime.now();
+        return '${n.year.toString().padLeft(4, '0')}-'
+            '${n.month.toString().padLeft(2, '0')}-'
+            '${n.day.toString().padLeft(2, '0')}';
+      },
     );
 
     final thumbnails = ThumbnailCache(
@@ -143,6 +158,9 @@ class CompanionRuntime {
       },
     );
 
+    // fs-16: listen-stats flush service — PUTs buffered absolutes to the server.
+    final statsFlush = ListenStatsFlushService(api: api.listenStatsApi, db: db);
+
     // app-8: auto-sync on reconnect — flush resume for all local books when the
     // device returns to a usable, reachable network (gated; token stays on LAN).
     final autoSync = AutoSyncService(
@@ -160,6 +178,7 @@ class CompanionRuntime {
         final books = await library.listBooks();
         await resumeSync.syncAll([for (final b in books) b.bookId]);
       },
+      flushStats: statsFlush.flush,
     );
     final connectivitySub =
         Connectivity().onConnectivityChanged.listen((_) => autoSync.maybeSync());

--- a/apps/android/lib/src/data/library_database.dart
+++ b/apps/android/lib/src/data/library_database.dart
@@ -3,6 +3,20 @@ import 'package:drift_flutter/drift_flutter.dart';
 
 part 'library_database.g.dart';
 
+/// One row per (sessionId, bookId, date) accrual — the offline buffer for
+/// listening-stats flushing (fs-16 H-b). Seconds are stored as absolute
+/// totals; upsert is max(existing, incoming) so re-sending is idempotent,
+/// matching the server's own max() upsert on `PUT /api/books/:id/listen-stats`.
+class ListenStatsBuffer extends Table {
+  TextColumn get sessionId => text()();
+  TextColumn get bookId => text()();
+  TextColumn get date => text()(); // 'YYYY-MM-DD'
+  IntColumn get seconds => integer()();
+
+  @override
+  Set<Column<Object>> get primaryKey => {sessionId, bookId, date};
+}
+
 /// One row per synced book (the phone's local mirror of the server library).
 class Books extends Table {
   TextColumn get bookId => text()();
@@ -65,7 +79,7 @@ class Playback extends Table {
   Set<Column<Object>> get primaryKey => {bookId};
 }
 
-@DriftDatabase(tables: [Books, Chapters, Playback])
+@DriftDatabase(tables: [Books, Chapters, Playback, ListenStatsBuffer])
 class LibraryDatabase extends _$LibraryDatabase {
   LibraryDatabase(super.e);
 
@@ -74,7 +88,7 @@ class LibraryDatabase extends _$LibraryDatabase {
   LibraryDatabase.open() : this(driftDatabase(name: 'library'));
 
   @override
-  int get schemaVersion => 3;
+  int get schemaVersion => 4;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -82,6 +96,57 @@ class LibraryDatabase extends _$LibraryDatabase {
         onUpgrade: (m, from, to) async {
           if (from < 2) await m.createTable(playback);
           if (from < 3) await m.addColumn(chapters, chapters.durationSec);
+          if (from < 4) await m.createTable(listenStatsBuffer);
         },
       );
+
+  // ── listen-stats buffer DAO ────────────────────────────────────────────
+
+  /// Upsert an absolute accrual: stores max(existing.seconds, [seconds]).
+  /// Uses a single raw SQL upsert so there is no race between read and write.
+  Future<void> upsertListenStatAccrual({
+    required String sessionId,
+    required String bookId,
+    required String date,
+    required int seconds,
+  }) =>
+      customStatement(
+        'INSERT INTO listen_stats_buffer (session_id, book_id, date, seconds) '
+        'VALUES (?, ?, ?, ?) '
+        'ON CONFLICT (session_id, book_id, date) DO UPDATE '
+        'SET seconds = MAX(excluded.seconds, listen_stats_buffer.seconds)',
+        [sessionId, bookId, date, seconds],
+      );
+
+  /// All buffered rows, grouped by (bookId, sessionId). Returns a map
+  /// `bookId → sessionId → List<(date, seconds)>`.
+  Future<Map<String, Map<String, List<({String date, int seconds})>>>>
+      pendingByBook() async {
+    final rows = await select(listenStatsBuffer).get();
+    final result =
+        <String, Map<String, List<({String date, int seconds})>>>{};
+    for (final r in rows) {
+      result
+          .putIfAbsent(r.bookId, () => {})
+          .putIfAbsent(r.sessionId, () => [])
+          .add((date: r.date, seconds: r.seconds));
+    }
+    return result;
+  }
+
+  /// Delete the rows that were successfully flushed.
+  Future<void> clearFlushedListenStats({
+    required String sessionId,
+    required String bookId,
+    required List<String> dates,
+  }) async {
+    await (delete(listenStatsBuffer)
+          ..where(
+            (t) =>
+                t.sessionId.equals(sessionId) &
+                t.bookId.equals(bookId) &
+                t.date.isIn(dates),
+          ))
+        .go();
+  }
 }

--- a/apps/android/lib/src/data/library_database.g.dart
+++ b/apps/android/lib/src/data/library_database.g.dart
@@ -1430,12 +1430,327 @@ class PlaybackCompanion extends UpdateCompanion<PlaybackData> {
   }
 }
 
+class $ListenStatsBufferTable extends ListenStatsBuffer
+    with TableInfo<$ListenStatsBufferTable, ListenStatsBufferData> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $ListenStatsBufferTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _sessionIdMeta = const VerificationMeta(
+    'sessionId',
+  );
+  @override
+  late final GeneratedColumn<String> sessionId = GeneratedColumn<String>(
+    'session_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _bookIdMeta = const VerificationMeta('bookId');
+  @override
+  late final GeneratedColumn<String> bookId = GeneratedColumn<String>(
+    'book_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _dateMeta = const VerificationMeta('date');
+  @override
+  late final GeneratedColumn<String> date = GeneratedColumn<String>(
+    'date',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _secondsMeta = const VerificationMeta(
+    'seconds',
+  );
+  @override
+  late final GeneratedColumn<int> seconds = GeneratedColumn<int>(
+    'seconds',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [sessionId, bookId, date, seconds];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'listen_stats_buffer';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<ListenStatsBufferData> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('session_id')) {
+      context.handle(
+        _sessionIdMeta,
+        sessionId.isAcceptableOrUnknown(data['session_id']!, _sessionIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_sessionIdMeta);
+    }
+    if (data.containsKey('book_id')) {
+      context.handle(
+        _bookIdMeta,
+        bookId.isAcceptableOrUnknown(data['book_id']!, _bookIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_bookIdMeta);
+    }
+    if (data.containsKey('date')) {
+      context.handle(
+        _dateMeta,
+        date.isAcceptableOrUnknown(data['date']!, _dateMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_dateMeta);
+    }
+    if (data.containsKey('seconds')) {
+      context.handle(
+        _secondsMeta,
+        seconds.isAcceptableOrUnknown(data['seconds']!, _secondsMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_secondsMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {sessionId, bookId, date};
+  @override
+  ListenStatsBufferData map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return ListenStatsBufferData(
+      sessionId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}session_id'],
+      )!,
+      bookId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}book_id'],
+      )!,
+      date: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}date'],
+      )!,
+      seconds: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}seconds'],
+      )!,
+    );
+  }
+
+  @override
+  $ListenStatsBufferTable createAlias(String alias) {
+    return $ListenStatsBufferTable(attachedDatabase, alias);
+  }
+}
+
+class ListenStatsBufferData extends DataClass
+    implements Insertable<ListenStatsBufferData> {
+  final String sessionId;
+  final String bookId;
+  final String date;
+  final int seconds;
+  const ListenStatsBufferData({
+    required this.sessionId,
+    required this.bookId,
+    required this.date,
+    required this.seconds,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['session_id'] = Variable<String>(sessionId);
+    map['book_id'] = Variable<String>(bookId);
+    map['date'] = Variable<String>(date);
+    map['seconds'] = Variable<int>(seconds);
+    return map;
+  }
+
+  ListenStatsBufferCompanion toCompanion(bool nullToAbsent) {
+    return ListenStatsBufferCompanion(
+      sessionId: Value(sessionId),
+      bookId: Value(bookId),
+      date: Value(date),
+      seconds: Value(seconds),
+    );
+  }
+
+  factory ListenStatsBufferData.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return ListenStatsBufferData(
+      sessionId: serializer.fromJson<String>(json['sessionId']),
+      bookId: serializer.fromJson<String>(json['bookId']),
+      date: serializer.fromJson<String>(json['date']),
+      seconds: serializer.fromJson<int>(json['seconds']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'sessionId': serializer.toJson<String>(sessionId),
+      'bookId': serializer.toJson<String>(bookId),
+      'date': serializer.toJson<String>(date),
+      'seconds': serializer.toJson<int>(seconds),
+    };
+  }
+
+  ListenStatsBufferData copyWith({
+    String? sessionId,
+    String? bookId,
+    String? date,
+    int? seconds,
+  }) => ListenStatsBufferData(
+    sessionId: sessionId ?? this.sessionId,
+    bookId: bookId ?? this.bookId,
+    date: date ?? this.date,
+    seconds: seconds ?? this.seconds,
+  );
+  ListenStatsBufferData copyWithCompanion(ListenStatsBufferCompanion data) {
+    return ListenStatsBufferData(
+      sessionId: data.sessionId.present ? data.sessionId.value : this.sessionId,
+      bookId: data.bookId.present ? data.bookId.value : this.bookId,
+      date: data.date.present ? data.date.value : this.date,
+      seconds: data.seconds.present ? data.seconds.value : this.seconds,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ListenStatsBufferData(')
+          ..write('sessionId: $sessionId, ')
+          ..write('bookId: $bookId, ')
+          ..write('date: $date, ')
+          ..write('seconds: $seconds')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(sessionId, bookId, date, seconds);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is ListenStatsBufferData &&
+          other.sessionId == this.sessionId &&
+          other.bookId == this.bookId &&
+          other.date == this.date &&
+          other.seconds == this.seconds);
+}
+
+class ListenStatsBufferCompanion
+    extends UpdateCompanion<ListenStatsBufferData> {
+  final Value<String> sessionId;
+  final Value<String> bookId;
+  final Value<String> date;
+  final Value<int> seconds;
+  final Value<int> rowid;
+  const ListenStatsBufferCompanion({
+    this.sessionId = const Value.absent(),
+    this.bookId = const Value.absent(),
+    this.date = const Value.absent(),
+    this.seconds = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  ListenStatsBufferCompanion.insert({
+    required String sessionId,
+    required String bookId,
+    required String date,
+    required int seconds,
+    this.rowid = const Value.absent(),
+  }) : sessionId = Value(sessionId),
+       bookId = Value(bookId),
+       date = Value(date),
+       seconds = Value(seconds);
+  static Insertable<ListenStatsBufferData> custom({
+    Expression<String>? sessionId,
+    Expression<String>? bookId,
+    Expression<String>? date,
+    Expression<int>? seconds,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (sessionId != null) 'session_id': sessionId,
+      if (bookId != null) 'book_id': bookId,
+      if (date != null) 'date': date,
+      if (seconds != null) 'seconds': seconds,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  ListenStatsBufferCompanion copyWith({
+    Value<String>? sessionId,
+    Value<String>? bookId,
+    Value<String>? date,
+    Value<int>? seconds,
+    Value<int>? rowid,
+  }) {
+    return ListenStatsBufferCompanion(
+      sessionId: sessionId ?? this.sessionId,
+      bookId: bookId ?? this.bookId,
+      date: date ?? this.date,
+      seconds: seconds ?? this.seconds,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (sessionId.present) {
+      map['session_id'] = Variable<String>(sessionId.value);
+    }
+    if (bookId.present) {
+      map['book_id'] = Variable<String>(bookId.value);
+    }
+    if (date.present) {
+      map['date'] = Variable<String>(date.value);
+    }
+    if (seconds.present) {
+      map['seconds'] = Variable<int>(seconds.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ListenStatsBufferCompanion(')
+          ..write('sessionId: $sessionId, ')
+          ..write('bookId: $bookId, ')
+          ..write('date: $date, ')
+          ..write('seconds: $seconds, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$LibraryDatabase extends GeneratedDatabase {
   _$LibraryDatabase(QueryExecutor e) : super(e);
   $LibraryDatabaseManager get managers => $LibraryDatabaseManager(this);
   late final $BooksTable books = $BooksTable(this);
   late final $ChaptersTable chapters = $ChaptersTable(this);
   late final $PlaybackTable playback = $PlaybackTable(this);
+  late final $ListenStatsBufferTable listenStatsBuffer =
+      $ListenStatsBufferTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -1444,6 +1759,7 @@ abstract class _$LibraryDatabase extends GeneratedDatabase {
     books,
     chapters,
     playback,
+    listenStatsBuffer,
   ];
 }
 
@@ -2163,6 +2479,200 @@ typedef $$PlaybackTableProcessedTableManager =
       PlaybackData,
       PrefetchHooks Function()
     >;
+typedef $$ListenStatsBufferTableCreateCompanionBuilder =
+    ListenStatsBufferCompanion Function({
+      required String sessionId,
+      required String bookId,
+      required String date,
+      required int seconds,
+      Value<int> rowid,
+    });
+typedef $$ListenStatsBufferTableUpdateCompanionBuilder =
+    ListenStatsBufferCompanion Function({
+      Value<String> sessionId,
+      Value<String> bookId,
+      Value<String> date,
+      Value<int> seconds,
+      Value<int> rowid,
+    });
+
+class $$ListenStatsBufferTableFilterComposer
+    extends Composer<_$LibraryDatabase, $ListenStatsBufferTable> {
+  $$ListenStatsBufferTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get sessionId => $composableBuilder(
+    column: $table.sessionId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get bookId => $composableBuilder(
+    column: $table.bookId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get date => $composableBuilder(
+    column: $table.date,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get seconds => $composableBuilder(
+    column: $table.seconds,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$ListenStatsBufferTableOrderingComposer
+    extends Composer<_$LibraryDatabase, $ListenStatsBufferTable> {
+  $$ListenStatsBufferTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get sessionId => $composableBuilder(
+    column: $table.sessionId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get bookId => $composableBuilder(
+    column: $table.bookId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get date => $composableBuilder(
+    column: $table.date,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get seconds => $composableBuilder(
+    column: $table.seconds,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$ListenStatsBufferTableAnnotationComposer
+    extends Composer<_$LibraryDatabase, $ListenStatsBufferTable> {
+  $$ListenStatsBufferTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get sessionId =>
+      $composableBuilder(column: $table.sessionId, builder: (column) => column);
+
+  GeneratedColumn<String> get bookId =>
+      $composableBuilder(column: $table.bookId, builder: (column) => column);
+
+  GeneratedColumn<String> get date =>
+      $composableBuilder(column: $table.date, builder: (column) => column);
+
+  GeneratedColumn<int> get seconds =>
+      $composableBuilder(column: $table.seconds, builder: (column) => column);
+}
+
+class $$ListenStatsBufferTableTableManager
+    extends
+        RootTableManager<
+          _$LibraryDatabase,
+          $ListenStatsBufferTable,
+          ListenStatsBufferData,
+          $$ListenStatsBufferTableFilterComposer,
+          $$ListenStatsBufferTableOrderingComposer,
+          $$ListenStatsBufferTableAnnotationComposer,
+          $$ListenStatsBufferTableCreateCompanionBuilder,
+          $$ListenStatsBufferTableUpdateCompanionBuilder,
+          (
+            ListenStatsBufferData,
+            BaseReferences<
+              _$LibraryDatabase,
+              $ListenStatsBufferTable,
+              ListenStatsBufferData
+            >,
+          ),
+          ListenStatsBufferData,
+          PrefetchHooks Function()
+        > {
+  $$ListenStatsBufferTableTableManager(
+    _$LibraryDatabase db,
+    $ListenStatsBufferTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$ListenStatsBufferTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$ListenStatsBufferTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$ListenStatsBufferTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<String> sessionId = const Value.absent(),
+                Value<String> bookId = const Value.absent(),
+                Value<String> date = const Value.absent(),
+                Value<int> seconds = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => ListenStatsBufferCompanion(
+                sessionId: sessionId,
+                bookId: bookId,
+                date: date,
+                seconds: seconds,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String sessionId,
+                required String bookId,
+                required String date,
+                required int seconds,
+                Value<int> rowid = const Value.absent(),
+              }) => ListenStatsBufferCompanion.insert(
+                sessionId: sessionId,
+                bookId: bookId,
+                date: date,
+                seconds: seconds,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$ListenStatsBufferTableProcessedTableManager =
+    ProcessedTableManager<
+      _$LibraryDatabase,
+      $ListenStatsBufferTable,
+      ListenStatsBufferData,
+      $$ListenStatsBufferTableFilterComposer,
+      $$ListenStatsBufferTableOrderingComposer,
+      $$ListenStatsBufferTableAnnotationComposer,
+      $$ListenStatsBufferTableCreateCompanionBuilder,
+      $$ListenStatsBufferTableUpdateCompanionBuilder,
+      (
+        ListenStatsBufferData,
+        BaseReferences<
+          _$LibraryDatabase,
+          $ListenStatsBufferTable,
+          ListenStatsBufferData
+        >,
+      ),
+      ListenStatsBufferData,
+      PrefetchHooks Function()
+    >;
 
 class $LibraryDatabaseManager {
   final _$LibraryDatabase _db;
@@ -2173,4 +2683,6 @@ class $LibraryDatabaseManager {
       $$ChaptersTableTableManager(_db, _db.chapters);
   $$PlaybackTableTableManager get playback =>
       $$PlaybackTableTableManager(_db, _db.playback);
+  $$ListenStatsBufferTableTableManager get listenStatsBuffer =>
+      $$ListenStatsBufferTableTableManager(_db, _db.listenStatsBuffer);
 }

--- a/apps/android/lib/src/data/listen_stats_service.dart
+++ b/apps/android/lib/src/data/listen_stats_service.dart
@@ -1,0 +1,63 @@
+import 'library_database.dart';
+
+/// A single (date, seconds) pair for the PUT body.
+class StatDay {
+  const StatDay({required this.date, required this.seconds});
+  final String date;
+  final int seconds;
+}
+
+/// The listen-stats PUT endpoint, injectable for tests.
+/// Real implementation is [ApiClient.listenStatsApi].
+abstract class ListenStatsApi {
+  /// PUT /api/books/[bookId]/listen-stats — absolute accrual per day.
+  /// Server performs max() upsert keyed by (date, sessionId), so re-sending
+  /// is idempotent.
+  Future<void> putListenStats(
+    String bookId, {
+    required String sessionId,
+    required List<StatDay> days,
+  });
+}
+
+/// Reads all buffered (sessionId, bookId, date, seconds) rows from the drift
+/// offline buffer, PUTs each (bookId, sessionId) group to the server, and
+/// clears the rows that were acknowledged. API failures are silently swallowed
+/// so the buffer survives for the next reconnect; because the PUT is idempotent
+/// (server uses max()), re-sending the same absolutes is always safe.
+class ListenStatsFlushService {
+  ListenStatsFlushService({
+    required this._api,
+    required this._db,
+  });
+
+  final ListenStatsApi _api;
+  final LibraryDatabase _db;
+
+  /// Flush all pending rows. Iterates each (bookId → sessionId) group in turn;
+  /// per-group failures leave ONLY that group's rows in the buffer.
+  Future<void> flush() async {
+    final pending = await _db.pendingByBook();
+    for (final bookEntry in pending.entries) {
+      final bookId = bookEntry.key;
+      for (final sessionEntry in bookEntry.value.entries) {
+        final sessionId = sessionEntry.key;
+        final dayRows = sessionEntry.value;
+        if (dayRows.isEmpty) continue;
+
+        final days = dayRows.map((r) => StatDay(date: r.date, seconds: r.seconds)).toList();
+        try {
+          await _api.putListenStats(bookId, sessionId: sessionId, days: days);
+          await _db.clearFlushedListenStats(
+            sessionId: sessionId,
+            bookId: bookId,
+            dates: dayRows.map((r) => r.date).toList(),
+          );
+        } on Exception {
+          // Leave the rows; they will be re-sent on the next flush.
+          // Re-sending absolutes is safe because the server uses max().
+        }
+      }
+    }
+  }
+}

--- a/apps/android/lib/src/data/player_controller.dart
+++ b/apps/android/lib/src/data/player_controller.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 
+import '../domain/listen_stats_accumulator.dart';
 import '../domain/skip_behavior.dart';
 import 'audio_engine.dart';
+import 'library_database.dart';
 import 'playback_store.dart';
 
 /// One chapter the player can load: its stable `uuid` and local file path,
@@ -55,6 +57,10 @@ class PlayerController {
     required DateTime Function() clock,
     SkipButtonBehavior skipBehavior = SkipButtonBehavior.seek,
     Duration saveInterval = const Duration(seconds: 10),
+    // fs-16: optional listen-stats accumulator wiring.
+    this._statsDb,
+    this._sessionId,
+    this._localDate,
   })  : _engine = audioEngine,
         _store = playbackStore,
         _loadPlaylist = playlistLoader,
@@ -67,6 +73,8 @@ class PlayerController {
       if (finished != null) _chapterCompleted.add(finished);
       _advance();
     });
+    // Subscribe to playing state to drive the accumulator.
+    _playingSub = _engine.playingStream.listen(_onPlayingChanged);
   }
 
   final AudioEngine _engine;
@@ -74,6 +82,12 @@ class PlayerController {
   final PlaylistLoader _loadPlaylist;
   final DateTime Function() _now;
   final Duration _autosaveInterval;
+
+  // fs-16: listen-stats accumulator — null when no db/sessionId injected.
+  final LibraryDatabase? _statsDb;
+  final String? _sessionId;
+  final String Function()? _localDate;
+  StatsAccumulator? _accumulator;
 
   /// Skip-button behaviour + seek amounts (driven by `app-13`); mutable so
   /// settings can change them at runtime.
@@ -83,6 +97,7 @@ class PlayerController {
 
   StreamSubscription<Duration>? _sub;
   StreamSubscription<void>? _completionSub;
+  StreamSubscription<bool>? _playingSub;
   final StreamController<NowPlaying?> _nowPlaying =
       StreamController<NowPlaying?>.broadcast();
 
@@ -155,6 +170,23 @@ class PlayerController {
   /// point (or start at the first chapter), and seek there.
   Future<void> openBook(String bookId,
       {String bookTitle = '', String? artPath}) async {
+    // fs-16: create or retarget the accumulator for this book.
+    final ld = _localDate;
+    if (_statsDb != null && _sessionId != null && ld != null) {
+      final acc = _accumulator;
+      if (acc == null) {
+        // First open — create the accumulator targeting this book.
+        _accumulator = StatsAccumulator(
+          bookId,
+          () => _now().millisecondsSinceEpoch,
+          ld,
+        );
+      } else if (acc.bookId != bookId) {
+        // Book changed via a direct openBook call (e.g. car browse): flush + retarget.
+        final handoff = acc.switchBook(bookId);
+        await _persistStatsHandoff(handoff);
+      }
+    }
     _bookId = bookId;
     _bookTitle = bookTitle;
     _artPath = artPath;
@@ -218,6 +250,12 @@ class PlayerController {
   /// resume point — per-book state is preserved across switches.
   Future<void> switchBook(String bookId) async {
     await saveNow();
+    // fs-16: flush the prior book's accumulated stats before retargeting.
+    final acc = _accumulator;
+    if (acc != null) {
+      final handoff = acc.switchBook(bookId);
+      await _persistStatsHandoff(handoff);
+    }
     await openBook(bookId);
   }
 
@@ -237,6 +275,17 @@ class PlayerController {
     }
   }
 
+  // fs-16: drive the accumulator from the engine's playing-state stream.
+  void _onPlayingChanged(bool isPlaying) {
+    final acc = _accumulator;
+    if (acc == null) return;
+    if (isPlaying) {
+      acc.onPlay();
+    } else {
+      acc.onPause();
+    }
+  }
+
   void _onTick(Duration position) {
     final last = _lastSave;
     final now = _now();
@@ -248,13 +297,49 @@ class PlayerController {
         // Fire-and-forget; ordering preserved by the single-subscription stream.
         _store.savePlayback(
             book, uuid, position.inMilliseconds, now.toIso8601String());
+        // fs-16: tick the accumulator and buffer any drained days.
+        _tickStats(book);
       }
+    }
+  }
+
+  /// Tick the stats accumulator and upsert drained days into the offline buffer.
+  void _tickStats(String bookId) {
+    final acc = _accumulator;
+    final db = _statsDb;
+    final session = _sessionId;
+    if (acc == null || db == null || session == null) return;
+    acc.tick();
+    final result = acc.drain();
+    for (final day in result.days) {
+      db.upsertListenStatAccrual(
+        sessionId: session,
+        bookId: bookId,
+        date: day.date,
+        seconds: day.seconds,
+      );
+    }
+  }
+
+  /// Persist the prior book's accumulated stats to the offline buffer.
+  Future<void> _persistStatsHandoff(BookHandoff handoff) async {
+    final db = _statsDb;
+    final session = _sessionId;
+    if (db == null || session == null || handoff.days.isEmpty) return;
+    for (final day in handoff.days) {
+      await db.upsertListenStatAccrual(
+        sessionId: session,
+        bookId: handoff.bookId,
+        date: day.date,
+        seconds: day.seconds,
+      );
     }
   }
 
   Future<void> dispose() async {
     await _sub?.cancel();
     await _completionSub?.cancel();
+    await _playingSub?.cancel();
     await _nowPlaying.close();
     await _chapterCompleted.close();
     await _engine.dispose();

--- a/apps/android/lib/src/data/player_controller.dart
+++ b/apps/android/lib/src/data/player_controller.dart
@@ -277,6 +277,10 @@ class PlayerController {
 
   // fs-16: drive the accumulator from the engine's playing-state stream.
   void _onPlayingChanged(bool isPlaying) {
+    // Accrual is gated on play/pause intent only. Safe because playback is always
+    // from local downloaded files (setFilePath), so there are no sustained buffer
+    // stalls. If streaming (setStreamUrl) is ever wired into the player flow,
+    // additionally gate accrual on processingState == ready (spec fs-16 m7).
     final acc = _accumulator;
     if (acc == null) return;
     if (isPlaying) {

--- a/apps/android/lib/src/domain/listen_stats_accumulator.dart
+++ b/apps/android/lib/src/domain/listen_stats_accumulator.dart
@@ -1,0 +1,102 @@
+/// fs-16 — wall-clock listening accumulator, Dart mirror of
+/// `src/lib/listen-stats-reporter.ts`. Rate- and seek-independent: sums real
+/// elapsed time between play/pause/tick checkpoints using an injected clock,
+/// never the media position. Buckets seconds by the injected local-date string;
+/// switching books flushes the prior book's tally. Pure domain — no Flutter/IO
+/// imports, no DateTime.now().
+library;
+
+/// One day's accumulated listening seconds for a book.
+class DrainedDay {
+  const DrainedDay({required this.date, required this.seconds});
+  final String date;
+  final int seconds;
+}
+
+/// Returned by [StatsAccumulator.drain].
+class DrainResult {
+  const DrainResult({required this.sessionPresent, required this.days});
+  final bool sessionPresent;
+  final List<DrainedDay> days;
+}
+
+/// Returned by [StatsAccumulator.switchBook].
+class BookHandoff {
+  const BookHandoff({required this.bookId, required this.days});
+  final String bookId;
+  final List<DrainedDay> days;
+}
+
+/// Accumulates wall-clock listening time for a single book, bucketed by local
+/// date. Constructed with a [bookId], a [_now] clock returning ms-epoch ints,
+/// and a [_localDate] returning the current local date as `'YYYY-MM-DD'`.
+class StatsAccumulator {
+  StatsAccumulator(this._bookId, this._now, this._localDate);
+
+  String _bookId;
+  final int Function() _now;
+  final String Function() _localDate;
+
+  final Map<String, double> _byDate = {};
+  bool _playing = false;
+  int _lastCheckpoint = 0;
+
+  void _addElapsed() {
+    if (!_playing) return;
+    final t = _now();
+    final secs = (t - _lastCheckpoint) / 1000.0;
+    final date = _localDate();
+    _byDate[date] = (_byDate[date] ?? 0.0) + (secs < 0 ? 0.0 : secs);
+    _lastCheckpoint = t;
+  }
+
+  /// Start accruing. Idempotent: a second call while already playing does nothing.
+  void onPlay() {
+    if (_playing) return;
+    _playing = true;
+    _lastCheckpoint = _now();
+  }
+
+  /// Add elapsed since last checkpoint and stop accruing.
+  void onPause() {
+    _addElapsed();
+    _playing = false;
+  }
+
+  /// Periodic checkpoint; also captures midnight rollover when [_localDate] flips.
+  void tick() {
+    _addElapsed();
+  }
+
+  /// Snapshot the accumulated days (rounded to whole seconds, zero-second days
+  /// filtered) without clearing. Updates the checkpoint so draining twice while
+  /// playing does not re-count the same interval.
+  DrainResult drain() {
+    _addElapsed();
+    return DrainResult(
+      sessionPresent: _byDate.isNotEmpty || _playing,
+      days: _byDate.entries
+          .map((e) => DrainedDay(date: e.key, seconds: e.value.round()))
+          .where((d) => d.seconds > 0)
+          .toList(),
+    );
+  }
+
+  /// Flush the current book's tally and re-target [nextBookId]. Returns the
+  /// prior book's days. If playing, the checkpoint is reset so the new book
+  /// starts accruing from this moment.
+  BookHandoff switchBook(String nextBookId) {
+    _addElapsed();
+    final prior = BookHandoff(
+      bookId: _bookId,
+      days: _byDate.entries
+          .map((e) => DrainedDay(date: e.key, seconds: e.value.round()))
+          .where((d) => d.seconds > 0)
+          .toList(),
+    );
+    _byDate.clear();
+    _bookId = nextBookId;
+    if (_playing) _lastCheckpoint = _now();
+    return prior;
+  }
+}

--- a/apps/android/lib/src/domain/listen_stats_accumulator.dart
+++ b/apps/android/lib/src/domain/listen_stats_accumulator.dart
@@ -37,6 +37,9 @@ class StatsAccumulator {
   final int Function() _now;
   final String Function() _localDate;
 
+  /// The book this accumulator is currently targeting.
+  String get bookId => _bookId;
+
   final Map<String, double> _byDate = {};
   bool _playing = false;
   int _lastCheckpoint = 0;

--- a/apps/android/test/data/api_client_test.dart
+++ b/apps/android/test/data/api_client_test.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:castwright/src/data/api_client.dart';
+import 'package:castwright/src/data/listen_stats_service.dart';
 import 'package:castwright/src/data/pairing_service.dart';
 import 'package:castwright/src/domain/paired_server.dart';
 
@@ -55,6 +57,37 @@ void main() {
         send: (_, _, _) => Completer<HttpResult>().future, // never completes
       );
       await expectLater(api.info(), throwsA(isA<TimeoutException>()));
+    });
+
+    // listenStatsApi is the [_ApiListenStatsApi] adapter wiring [ApiClient] as
+    // the [ListenStatsApi] port.  Verify the adapter delegates correctly by
+    // exercising it through a fake [ListenStatsApi] implementation — the real
+    // PUT uses a pinned HttpClient that is not injectable, so the transport is
+    // validated at the flush-service level (listen_stats_flush_service_test.dart).
+    test('listenStatsApi getter returns a ListenStatsApi', () {
+      final api = ApiClient(conn(), send: (_, _, _) async => const HttpResult(200, '{}'));
+      expect(api.listenStatsApi, isA<ListenStatsApi>());
+    });
+
+    test('putListenStats serialises the JSON body correctly', () async {
+      // We can't inject a send hook into putListenStats because it creates its
+      // own pinned client.  Instead we verify the JSON shape directly using
+      // jsonEncode (the same code path the method uses) to confirm the contract
+      // matches the server spec: { sessionId, days:[{date,seconds}] }.
+      final days = [
+        StatDay(date: '2026-06-14', seconds: 120),
+        StatDay(date: '2026-06-13', seconds: 60),
+      ];
+      final body = jsonEncode({
+        'sessionId': 'test-session',
+        'days': [for (final d in days) {'date': d.date, 'seconds': d.seconds}],
+      });
+      final decoded = jsonDecode(body) as Map<String, dynamic>;
+      expect(decoded['sessionId'], 'test-session');
+      final decodedDays = decoded['days'] as List<dynamic>;
+      expect(decodedDays.length, 2);
+      expect(decodedDays[0], {'date': '2026-06-14', 'seconds': 120});
+      expect(decodedDays[1], {'date': '2026-06-13', 'seconds': 60});
     });
   });
 }

--- a/apps/android/test/data/auto_sync_service_test.dart
+++ b/apps/android/test/data/auto_sync_service_test.dart
@@ -7,14 +7,17 @@ void main() {
   group('AutoSyncService.maybeSync', () {
     late int probes;
     late int syncs;
+    late int flushes;
 
     AutoSyncService make({
       AppSettings? settings,
       NetworkType network = NetworkType.wifiUnmetered,
       bool reachable = true,
+      bool withFlush = false,
     }) {
       probes = 0;
       syncs = 0;
+      flushes = 0;
       return AutoSyncService(
         loadSettings: () async => settings ?? AppSettings.defaults,
         currentNetwork: () async => network,
@@ -23,6 +26,7 @@ void main() {
           return reachable;
         },
         runSync: () async => syncs++,
+        flushStats: withFlush ? () async => flushes++ : null,
       );
     }
 
@@ -60,6 +64,23 @@ void main() {
       expect(await svc.maybeSync(), isFalse);
       expect(probes, 1);
       expect(syncs, 0);
+    });
+
+    // fs-16: listen-stats flush on reconnect.
+    test('flushStats is invoked on a successful sync (fs-16)', () async {
+      final svc = make(withFlush: true);
+      expect(await svc.maybeSync(), isTrue);
+      expect(syncs, 1);
+      expect(flushes, 1);
+    });
+
+    test('flushStats is not invoked when sync is skipped', () async {
+      final svc = make(
+        settings: AppSettings.defaults.copyWith(autoSyncOnReconnect: false),
+        withFlush: true,
+      );
+      expect(await svc.maybeSync(), isFalse);
+      expect(flushes, 0);
     });
   });
 }

--- a/apps/android/test/data/listen_stats_buffer_test.dart
+++ b/apps/android/test/data/listen_stats_buffer_test.dart
@@ -1,0 +1,159 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:castwright/src/data/library_database.dart';
+
+LibraryDatabase _makeDb() => LibraryDatabase(NativeDatabase.memory());
+
+void main() {
+  group('ListenStatsBuffer — upsertListenStatAccrual', () {
+    test('inserts a new row', () async {
+      final db = _makeDb();
+      await db.upsertListenStatAccrual(
+        sessionId: 's1',
+        bookId: 'b1',
+        date: '2026-06-14',
+        seconds: 120,
+      );
+      final pending = await db.pendingByBook();
+      expect(pending['b1']?['s1']?.single, (date: '2026-06-14', seconds: 120));
+      await db.close();
+    });
+
+    test('upsert is max — larger incoming replaces smaller existing', () async {
+      final db = _makeDb();
+      await db.upsertListenStatAccrual(
+          sessionId: 's1', bookId: 'b1', date: '2026-06-14', seconds: 100);
+      await db.upsertListenStatAccrual(
+          sessionId: 's1', bookId: 'b1', date: '2026-06-14', seconds: 200);
+      final pending = await db.pendingByBook();
+      expect(pending['b1']!['s1']!.single.seconds, 200);
+      await db.close();
+    });
+
+    test('upsert is max — smaller incoming does not shrink an existing row', () async {
+      final db = _makeDb();
+      await db.upsertListenStatAccrual(
+          sessionId: 's1', bookId: 'b1', date: '2026-06-14', seconds: 300);
+      await db.upsertListenStatAccrual(
+          sessionId: 's1', bookId: 'b1', date: '2026-06-14', seconds: 50);
+      final pending = await db.pendingByBook();
+      // 300 must survive; re-sending a smaller absolute must not shrink it.
+      expect(pending['b1']!['s1']!.single.seconds, 300);
+      await db.close();
+    });
+
+    test('different dates are independent rows', () async {
+      final db = _makeDb();
+      await db.upsertListenStatAccrual(
+          sessionId: 's1', bookId: 'b1', date: '2026-06-13', seconds: 60);
+      await db.upsertListenStatAccrual(
+          sessionId: 's1', bookId: 'b1', date: '2026-06-14', seconds: 90);
+      final pending = await db.pendingByBook();
+      final days = pending['b1']!['s1']!;
+      expect(days.length, 2);
+      final byDate = {for (final d in days) d.date: d.seconds};
+      expect(byDate['2026-06-13'], 60);
+      expect(byDate['2026-06-14'], 90);
+      await db.close();
+    });
+
+    test('different sessionIds are independent rows', () async {
+      final db = _makeDb();
+      await db.upsertListenStatAccrual(
+          sessionId: 'sA', bookId: 'b1', date: '2026-06-14', seconds: 100);
+      await db.upsertListenStatAccrual(
+          sessionId: 'sB', bookId: 'b1', date: '2026-06-14', seconds: 200);
+      final pending = await db.pendingByBook();
+      expect(pending['b1']!['sA']!.single.seconds, 100);
+      expect(pending['b1']!['sB']!.single.seconds, 200);
+      await db.close();
+    });
+  });
+
+  group('ListenStatsBuffer — pendingByBook', () {
+    test('returns empty map when nothing buffered', () async {
+      final db = _makeDb();
+      expect(await db.pendingByBook(), isEmpty);
+      await db.close();
+    });
+
+    test('groups rows by bookId then sessionId', () async {
+      final db = _makeDb();
+      await db.upsertListenStatAccrual(
+          sessionId: 's1', bookId: 'b1', date: '2026-06-14', seconds: 10);
+      await db.upsertListenStatAccrual(
+          sessionId: 's1', bookId: 'b2', date: '2026-06-14', seconds: 20);
+      final pending = await db.pendingByBook();
+      expect(pending.keys, containsAll(['b1', 'b2']));
+      expect(pending['b1']!['s1']!.single.seconds, 10);
+      expect(pending['b2']!['s1']!.single.seconds, 20);
+      await db.close();
+    });
+  });
+
+  group('ListenStatsBuffer — clearFlushedListenStats', () {
+    test('removes only the named rows', () async {
+      final db = _makeDb();
+      await db.upsertListenStatAccrual(
+          sessionId: 's1', bookId: 'b1', date: '2026-06-13', seconds: 60);
+      await db.upsertListenStatAccrual(
+          sessionId: 's1', bookId: 'b1', date: '2026-06-14', seconds: 90);
+
+      await db.clearFlushedListenStats(
+        sessionId: 's1',
+        bookId: 'b1',
+        dates: ['2026-06-13'],
+      );
+
+      final pending = await db.pendingByBook();
+      final days = pending['b1']?['s1'] ?? [];
+      expect(days.length, 1);
+      expect(days.single.date, '2026-06-14');
+      await db.close();
+    });
+
+    test('does not touch rows for a different session', () async {
+      final db = _makeDb();
+      await db.upsertListenStatAccrual(
+          sessionId: 'sA', bookId: 'b1', date: '2026-06-14', seconds: 100);
+      await db.upsertListenStatAccrual(
+          sessionId: 'sB', bookId: 'b1', date: '2026-06-14', seconds: 200);
+
+      await db.clearFlushedListenStats(
+        sessionId: 'sA',
+        bookId: 'b1',
+        dates: ['2026-06-14'],
+      );
+
+      final pending = await db.pendingByBook();
+      // sA is gone; sB survives
+      expect(pending['b1']!.containsKey('sA'), isFalse);
+      expect(pending['b1']!['sB']!.single.seconds, 200);
+      await db.close();
+    });
+  });
+
+  group('ListenStatsBuffer — relaunch persistence', () {
+    test('rows survive close and re-open of the in-memory DB', () async {
+      // In production the DB is file-backed; here we simulate "relaunch" by
+      // writing to one db instance and then confirming the rows exist in
+      // another instance that shares the same in-memory executor.
+      //
+      // With NativeDatabase.memory() each instance is independent, so this
+      // test instead verifies that the buffer DAO reads back after write
+      // without a close/re-open (the persistence guarantee is the drift
+      // file-backed path; the contract here is that rows are NOT cleared
+      // automatically — only clearFlushedListenStats removes them).
+      final db = _makeDb();
+      await db.upsertListenStatAccrual(
+          sessionId: 's1', bookId: 'b1', date: '2026-06-14', seconds: 120);
+
+      // Rows are still there after a second pendingByBook call (not auto-cleared).
+      final first = await db.pendingByBook();
+      final second = await db.pendingByBook();
+      expect(first, equals(second));
+      expect(second['b1']!['s1']!.single.seconds, 120);
+      await db.close();
+    });
+  });
+}

--- a/apps/android/test/data/listen_stats_flush_service_test.dart
+++ b/apps/android/test/data/listen_stats_flush_service_test.dart
@@ -125,11 +125,8 @@ void main() {
       final db = _makeDb();
 
       // We need a controllable per-call failure. Use a custom fake.
-      final callCount = <String, int>{};
-      late ListenStatsFlushService svc;
-
       final selectiveApi = _SelectiveFailApi({'b2'});
-      svc = ListenStatsFlushService(api: selectiveApi, db: db);
+      final svc = ListenStatsFlushService(api: selectiveApi, db: db);
 
       await db.upsertListenStatAccrual(
           sessionId: 's1', bookId: 'b1', date: '2026-06-14', seconds: 10);
@@ -142,7 +139,6 @@ void main() {
       // b1 succeeded → cleared; b2 failed → still buffered.
       expect(pending.containsKey('b1'), isFalse);
       expect(pending['b2']!['s1']!.single.seconds, 20);
-      expect(callCount, isEmpty); // ignore — used by _SelectiveFailApi internally
       await db.close();
     });
   });

--- a/apps/android/test/data/listen_stats_flush_service_test.dart
+++ b/apps/android/test/data/listen_stats_flush_service_test.dart
@@ -1,0 +1,164 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:castwright/src/data/library_database.dart';
+import 'package:castwright/src/data/listen_stats_service.dart';
+
+// ── Fake API ──────────────────────────────────────────────────────────────────
+
+class FakeListenStatsApi implements ListenStatsApi {
+  final List<String> calls = []; // 'bookId|sessionId|date:secs,...'
+  bool shouldThrow = false;
+
+  @override
+  Future<void> putListenStats(
+    String bookId, {
+    required String sessionId,
+    required List<StatDay> days,
+  }) async {
+    if (shouldThrow) throw Exception('network error');
+    final dayStr = days.map((d) => '${d.date}:${d.seconds}').join(',');
+    calls.add('$bookId|$sessionId|$dayStr');
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+LibraryDatabase _makeDb() => LibraryDatabase(NativeDatabase.memory());
+
+ListenStatsFlushService _makeService(
+        FakeListenStatsApi api, LibraryDatabase db) =>
+    ListenStatsFlushService(api: api, db: db);
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+void main() {
+  group('ListenStatsFlushService.flush', () {
+    test('PUTs buffered absolutes and clears rows on success', () async {
+      final db = _makeDb();
+      final api = FakeListenStatsApi();
+
+      await db.upsertListenStatAccrual(
+          sessionId: 's1', bookId: 'b1', date: '2026-06-14', seconds: 120);
+
+      await _makeService(api, db).flush();
+
+      expect(api.calls.length, 1);
+      expect(api.calls.single, 'b1|s1|2026-06-14:120');
+      // Buffer must be empty after a successful flush.
+      expect(await db.pendingByBook(), isEmpty);
+      await db.close();
+    });
+
+    test('a failing API leaves the buffer intact', () async {
+      final db = _makeDb();
+      final api = FakeListenStatsApi()..shouldThrow = true;
+
+      await db.upsertListenStatAccrual(
+          sessionId: 's1', bookId: 'b1', date: '2026-06-14', seconds: 60);
+
+      await _makeService(api, db).flush();
+
+      // No rows cleared — the buffer survived.
+      final pending = await db.pendingByBook();
+      expect(pending['b1']!['s1']!.single.seconds, 60);
+      await db.close();
+    });
+
+    test('a re-flush after a partial failure does not double-count', () async {
+      final db = _makeDb();
+      final api = FakeListenStatsApi();
+
+      await db.upsertListenStatAccrual(
+          sessionId: 's1', bookId: 'b1', date: '2026-06-14', seconds: 100);
+
+      // First flush fails.
+      api.shouldThrow = true;
+      await _makeService(api, db).flush();
+      api.shouldThrow = false;
+      api.calls.clear();
+
+      // Second flush succeeds — the absolute value is re-sent, not accumulated.
+      await _makeService(api, db).flush();
+
+      // The PUT carries the same absolute 100, not 200.
+      expect(api.calls.single, 'b1|s1|2026-06-14:100');
+      expect(await db.pendingByBook(), isEmpty);
+      await db.close();
+    });
+
+    test('multiple (bookId, sessionId) pairs each get their own PUT', () async {
+      final db = _makeDb();
+      final api = FakeListenStatsApi();
+
+      await db.upsertListenStatAccrual(
+          sessionId: 's1', bookId: 'b1', date: '2026-06-14', seconds: 10);
+      await db.upsertListenStatAccrual(
+          sessionId: 's1', bookId: 'b2', date: '2026-06-14', seconds: 20);
+      await db.upsertListenStatAccrual(
+          sessionId: 's2', bookId: 'b1', date: '2026-06-14', seconds: 30);
+
+      await _makeService(api, db).flush();
+
+      // Three distinct PUTs (b1/s1, b2/s1, b1/s2 — order may vary).
+      expect(api.calls.length, 3);
+      expect(api.calls, containsAll([
+        'b1|s1|2026-06-14:10',
+        'b2|s1|2026-06-14:20',
+        'b1|s2|2026-06-14:30',
+      ]));
+      expect(await db.pendingByBook(), isEmpty);
+      await db.close();
+    });
+
+    test('flush on empty buffer is a no-op', () async {
+      final db = _makeDb();
+      final api = FakeListenStatsApi();
+
+      await _makeService(api, db).flush();
+
+      expect(api.calls, isEmpty);
+      await db.close();
+    });
+
+    test('partial (book-level) failure: successful books are cleared, '
+        'failed book rows survive', () async {
+      final db = _makeDb();
+
+      // We need a controllable per-call failure. Use a custom fake.
+      final callCount = <String, int>{};
+      late ListenStatsFlushService svc;
+
+      final selectiveApi = _SelectiveFailApi({'b2'});
+      svc = ListenStatsFlushService(api: selectiveApi, db: db);
+
+      await db.upsertListenStatAccrual(
+          sessionId: 's1', bookId: 'b1', date: '2026-06-14', seconds: 10);
+      await db.upsertListenStatAccrual(
+          sessionId: 's1', bookId: 'b2', date: '2026-06-14', seconds: 20);
+
+      await svc.flush();
+
+      final pending = await db.pendingByBook();
+      // b1 succeeded → cleared; b2 failed → still buffered.
+      expect(pending.containsKey('b1'), isFalse);
+      expect(pending['b2']!['s1']!.single.seconds, 20);
+      expect(callCount, isEmpty); // ignore — used by _SelectiveFailApi internally
+      await db.close();
+    });
+  });
+}
+
+/// Fake that throws only for books in [_failBookIds].
+class _SelectiveFailApi implements ListenStatsApi {
+  _SelectiveFailApi(this._failBookIds);
+  final Set<String> _failBookIds;
+
+  @override
+  Future<void> putListenStats(
+    String bookId, {
+    required String sessionId,
+    required List<StatDay> days,
+  }) async {
+    if (_failBookIds.contains(bookId)) throw Exception('fail $bookId');
+  }
+}

--- a/apps/android/test/data/player_controller_test.dart
+++ b/apps/android/test/data/player_controller_test.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 
+import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:castwright/src/data/audio_engine.dart';
+import 'package:castwright/src/data/library_database.dart';
 import 'package:castwright/src/data/player_controller.dart';
 import 'package:castwright/src/data/playback_store.dart';
 import 'package:castwright/src/domain/skip_behavior.dart';
@@ -111,6 +113,30 @@ PlayerController make(
     skipBehavior: behavior,
     clock: now ?? () => DateTime.utc(2026, 6, 6, 12),
     saveInterval: const Duration(seconds: 10),
+  );
+}
+
+/// Build a player wired to the stats accumulator. [nowMs] is a mutable box —
+/// the caller changes it between steps to advance the injected clock.
+PlayerController makeWithStats(
+  FakeAudioEngine engine,
+  MemPlaybackStore store,
+  LibraryDatabase db,
+  List<int> nowMs, {
+  String sessionId = 'sess1',
+  String localDate = '2026-06-14',
+  Map<String, List<PlayableChapter>>? playlists,
+}) {
+  final lists = playlists ?? {'b1': playlistB1};
+  return PlayerController(
+    audioEngine: engine,
+    playbackStore: store,
+    playlistLoader: (bookId) async => lists[bookId] ?? const [],
+    clock: () => DateTime.fromMillisecondsSinceEpoch(nowMs[0]),
+    saveInterval: const Duration(seconds: 10),
+    statsDb: db,
+    sessionId: sessionId,
+    localDate: () => localDate,
   );
 }
 
@@ -271,6 +297,93 @@ void main() {
       expect(pc.isInUse('u1'), isTrue);
       expect(pc.isInUse('u2'), isFalse);
       await pc.dispose();
+    });
+  });
+
+  // ── fs-16: listen-stats accumulator wiring ────────────────────────────────
+
+  group('PlayerController stats accumulator (fs-16)', () {
+    test('autosave tick upserts accrual when playing', () async {
+      final engine = FakeAudioEngine();
+      final db = LibraryDatabase(NativeDatabase.memory());
+      final nowMs = [0]; // mutable clock box
+      final pc = makeWithStats(engine, MemPlaybackStore(), db, nowMs);
+
+      await pc.openBook('b1');
+      // Start playing (triggers onPlay via playingStream).
+      await engine.play();
+      await Future<void>.delayed(Duration.zero);
+
+      // Advance clock by 15 s and fire the position stream to cross the autosave
+      // interval. The stats tick should drain ~15 s into the buffer.
+      nowMs[0] = 15000;
+      engine.emit(const Duration(seconds: 15));
+      await Future<void>.delayed(Duration.zero);
+
+      final pending = await db.pendingByBook();
+      expect(pending.containsKey('b1'), isTrue);
+      final days = pending['b1']!['sess1']!;
+      expect(days.length, 1);
+      expect(days.single.date, '2026-06-14');
+      expect(days.single.seconds, greaterThan(0));
+
+      await pc.dispose();
+      await db.close();
+    });
+
+    test('buffering (not playing) does not accrue', () async {
+      final engine = FakeAudioEngine();
+      final db = LibraryDatabase(NativeDatabase.memory());
+      final nowMs = [0];
+      final pc = makeWithStats(engine, MemPlaybackStore(), db, nowMs);
+
+      await pc.openBook('b1');
+      // Do NOT call engine.play() — engine stays paused.
+      nowMs[0] = 15000;
+      engine.emit(const Duration(seconds: 15));
+      await Future<void>.delayed(Duration.zero);
+
+      // No stats should have been buffered.
+      expect(await db.pendingByBook(), isEmpty);
+
+      await pc.dispose();
+      await db.close();
+    });
+
+    test('book switch persists prior book stats before retargeting', () async {
+      final engine = FakeAudioEngine();
+      final db = LibraryDatabase(NativeDatabase.memory());
+      final nowMs = [0];
+      final pc = makeWithStats(
+        engine,
+        MemPlaybackStore(),
+        db,
+        nowMs,
+        playlists: {
+          'b1': playlistB1,
+          'b2': const [PlayableChapter(uuid: 'x1', path: '/b2/x1/audio.mp3')],
+        },
+      );
+
+      await pc.openBook('b1');
+      await engine.play();
+      await Future<void>.delayed(Duration.zero);
+
+      // Advance 20 s, fire tick to accrue b1 stats.
+      nowMs[0] = 20000;
+      engine.emit(const Duration(seconds: 20));
+      await Future<void>.delayed(Duration.zero);
+
+      // Switch to b2 — should flush b1 stats into the buffer.
+      await pc.switchBook('b2');
+
+      final pending = await db.pendingByBook();
+      expect(pending.containsKey('b1'), isTrue,
+          reason: 'b1 stats must be flushed to buffer on switch');
+      expect(pending['b1']!['sess1']!.single.seconds, greaterThan(0));
+
+      await pc.dispose();
+      await db.close();
     });
   });
 }

--- a/apps/android/test/domain/listen_stats_accumulator_test.dart
+++ b/apps/android/test/domain/listen_stats_accumulator_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:castwright/src/domain/listen_stats_accumulator.dart';
+
+void main() {
+  group('StatsAccumulator', () {
+    test('accrues wall-clock while playing, ignores paused time', () {
+      var t = 1749808800000; // 2026-06-13T10:00:00Z (ms epoch)
+      final acc = StatsAccumulator('book-1', () => t, () => '2026-06-13');
+      acc.onPlay();
+      t += 10000;
+      acc.onPause();
+      t += 60000;
+      acc.onPlay();
+      t += 5000;
+      final drained = acc.drain();
+      expect(drained.sessionPresent, isTrue);
+      expect(drained.days.length, 1);
+      expect(drained.days.first.date, '2026-06-13');
+      expect(drained.days.first.seconds, 15);
+    });
+
+    test('attributes to the active book and flushes prior book on switch', () {
+      var t = 1749808800000;
+      var dateStr = '2026-06-13';
+      final acc = StatsAccumulator('book-1', () => t, () => dateStr);
+      acc.onPlay();
+      t += 20000;
+      final handoff = acc.switchBook('book-2');
+      expect(handoff.bookId, 'book-1');
+      expect(handoff.days.length, 1);
+      expect(handoff.days.first.date, '2026-06-13');
+      expect(handoff.days.first.seconds, 20);
+      // playing continues on book-2 with refreshed checkpoint
+      t += 10000;
+      final drained = acc.drain();
+      expect(drained.days.length, 1);
+      expect(drained.days.first.date, '2026-06-13');
+      expect(drained.days.first.seconds, 10);
+    });
+
+    test('splits a play interval across local midnight', () {
+      var t = 1749858590000; // 2026-06-13T23:59:50Z
+      var dateStr = '2026-06-13';
+      final acc = StatsAccumulator('b', () => t, () => dateStr);
+      acc.onPlay();
+      t += 10000;
+      dateStr = '2026-06-13';
+      acc.tick();
+      t += 10000;
+      dateStr = '2026-06-14';
+      acc.tick();
+      final days = acc.drain().days;
+      expect(days.any((d) => d.date == '2026-06-13' && d.seconds == 10), isTrue);
+      expect(days.any((d) => d.date == '2026-06-14' && d.seconds == 10), isTrue);
+    });
+
+    test('drain reports sessionPresent false before any play', () {
+      final acc = StatsAccumulator('b', () => 0, () => '2026-06-13');
+      final drained = acc.drain();
+      expect(drained.sessionPresent, isFalse);
+      expect(drained.days, isEmpty);
+    });
+
+    test('double onPause does not double-count', () {
+      var t = 1749808800000;
+      final acc = StatsAccumulator('b', () => t, () => '2026-06-13');
+      acc.onPlay();
+      t += 10000;
+      acc.onPause();
+      t += 5000;
+      acc.onPause(); // no-op: not playing
+      final days = acc.drain().days;
+      expect(days.length, 1);
+      expect(days.first.seconds, 10);
+    });
+
+    test('draining twice while playing does not re-count the same interval', () {
+      var t = 1749808800000;
+      final acc = StatsAccumulator('b', () => t, () => '2026-06-13');
+      acc.onPlay();
+      t += 10000;
+      final first = acc.drain();
+      expect(first.days.first.seconds, 10);
+      t += 5000;
+      final second = acc.drain();
+      expect(second.days.first.seconds, 15);
+    });
+
+    test('zero-second days are filtered from drain', () {
+      var t = 1749808800000;
+      final acc = StatsAccumulator('b', () => t, () => '2026-06-13');
+      acc.onPlay();
+      acc.onPause(); // zero elapsed
+      final drained = acc.drain();
+      expect(drained.days, isEmpty);
+      // sessionPresent is true because byDate has an entry (even zero) OR playing was true.
+      // Actually after pause, playing=false, and byDate has 0s — drain filters it.
+      // sessionPresent = byDate.isNotEmpty || playing: byDate has entry with 0s → isNotEmpty
+      // so sessionPresent may be true here (matching TS: byDate.size > 0 || playing).
+      // We just assert days is empty — the critical contract.
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Wave H of fs-16 (report-only): the Android companion now reports **wall-clock listening time** to the server's `PUT /api/books/{id}/listen-stats` (shipped in #783), so the web `#/stats` dashboard reflects listening done on the phone. **No new companion UI.**

**Stacked on #783** (base = `feat/listening-stats-fs15-fs16`) — depends on that PR's server endpoint. GitHub will auto-retarget this to `main` when #783 merges.

- **Pure accumulator** (`lib/src/domain/listen_stats_accumulator.dart`) — a faithful Dart mirror of the web `StatsAccumulator`: wall-clock from an injected clock (rate/seek-independent), per-`(book, local-date)`, book-switch handoff, midnight split, zero-day filtering.
- **Offline buffer** (drift `ListenStatsBuffer` table, schema 3→4 + migration) — absolute seconds keyed `(sessionId, bookId, date)`, `MAX()` upsert (atomic SQL, idempotent). Survives app relaunch; `sessionId` persisted with the rows so a prior session flushes under its own id.
- **Flush service** — on network reconnect (`auto_sync_service`), PUTs the buffered absolutes per `(book, session)` and clears only on success; failures leave rows for safe re-send (server `max()`).
- **Player wiring** — `playingStream` → onPlay/onPause; the existing ~10s autosave tick persists drained days to the buffer; book switch persists the prior book first. A per-app-launch `sessionId` is minted once. Accrual is gated on play/pause intent — safe because the companion plays **local downloaded files** (no sustained buffer stalls); documented for the future streaming path.

## Test plan

- `flutter test` (full companion suite): **294 passing**. `flutter analyze`: clean.
- New tests: accumulator (7, mirrors the TS cases incl. idempotence + midnight); drift buffer (max-upsert, persistence, selective clear); flush service (success/clear, failure-retains, partial-failure, idempotent re-send); player wiring (accrues on tick while playing, NOT while paused, book-switch persists prior); auto-sync (flush fires on reconnect, not on skip).

## Owed (on-device acceptance)

- Buffer **relaunch survival** is proven by design (no auto-clear; sessionId is a stored column) but unit tests use in-memory drift (no cross-instance file sharing) — confirm on a real device that a killed-mid-session flush lands its accruals on reconnect.
- `finished` divergence from the dashboard's position-derived flag (companion's local `setChapterFinished` not synced) — known, documented in plan 212.

Refs #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)