### PR TITLE
docs(docs): brand-language pass over CONTRIBUTING + reconcile fe-3/fs-8 backlog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,15 @@
 # Contributing
 
-How to land changes on this repo without stepping on yourself (or on a parallel
-agent run). Two rules — the **branching model** keeps work isolated until it's
-ready to merge, and the **commit convention** makes the history greppable by
-area. The commit convention is enforced by a git hook; the branching model is
-soft convention.
+Castwright turns a manuscript into a full-cast audiobook — every character in
+their own voice, performed on a machine you already own. This guide is how to
+work on it without stepping on yourself (or on a parallel agent run).
+
+Two habits carry most of that weight. The **branching model** keeps work
+isolated until it's ready to merge, and the **commit convention** keeps the
+history greppable by area. The commit convention is enforced by a git hook; the
+branching model is soft convention — held up by agreement, not tooling. The
+honest version: `main` is the only branch anyone trusts, so everything else is
+in service of keeping it shippable.
 
 ## TL;DR
 
@@ -37,6 +42,8 @@ place, please open an issue to discuss a change before sending a PR.
 ## Branching model
 
 Trunk-based with short-lived feature branches, isolated per agent via worktrees.
+One branch is one cohesive change — small enough to hold in your head, isolated
+enough that a parallel run can't trip over it.
 
 ### Branch naming
 
@@ -200,6 +207,9 @@ manually):
 
 ## Commit convention
 
+The history is a tool, not a log. Tag every commit by area so
+`git log --grep="(scope)"` can walk a single surface years later.
+
 Format:
 
 ```
@@ -347,8 +357,9 @@ label-lint or required-field enforcement beyond the forms themselves; the
 
 ## Pull requests
 
-Every change that lands on `main` goes through a GitHub PR. The template, the
-title gate, and the merge-button policy together codify what PRs #1-#4 already
+Every change that lands on `main` goes through a GitHub PR — that's the one door,
+and the review at it is what lets the next person trust the branch. The template,
+the title gate, and the merge-button policy together codify what PRs #1-#4 already
 do by hand. See [docs/features/archive/44-pr-hygiene.md](docs/features/archive/44-pr-hygiene.md)
 for the regression plan and rationale.
 
@@ -477,6 +488,7 @@ The compact version:
 
 ## Releasing
 
+A release is a performance going out the door, so it gets the same care as one.
 Cutting a public release is one command (after the notes file is ready):
 
 ```sh

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -369,20 +369,6 @@ _Full detail + acceptance:_ [#401](https://github.com/dudarenok-maker/AudioBook-
 - _Benefit (technical):_ stays on a supported eslint line; clears the last row of the round-3 `npm outdated`.
 _Full detail + acceptance:_ [#711](https://github.com/dudarenok-maker/AudioBook-Generator/issues/711).
 
-### Listener-app handoffs
-
-#### `fe-3` — Apple Books (iOS / macOS) handoff modal ([#434](https://github.com/dudarenok-maker/AudioBook-Generator/issues/434))
-
-- _What:_ Wire Apple Books tile with the appropriate handoff: macOS supports drag-into-Books; iOS supports AirDrop or sync via Files. Modal shows the platform-specific flow (detect Mac vs other UA, default to "iOS via AirDrop"). Copy-and-instructions only — no direct integration with Apple Books library API (which is restricted).
-- _Benefit (user):_ closes one more "Coming soon" tile.
-_Full detail + acceptance:_ [#434](https://github.com/dudarenok-maker/AudioBook-Generator/issues/434).
-
-#### `fs-8` — PocketBook Cloud direct upload OR `@pbsync.com` email gateway ([#436](https://github.com/dudarenok-maker/AudioBook-Generator/issues/436))
-
-- _What:_ Research and prototype either (a) PocketBook Cloud upload (protocol is closed — needs reverse-engineering or vendor contact) or (b) sending the exported file as an attachment to `<user>@pbsync.com` (officially marketed for ebooks; audiobook size limits undocumented).
-- _Benefit (user):_ true sideload-free path. Low priority because LAN download + sync folder already work.
-_Full detail + acceptance:_ [#436](https://github.com/dudarenok-maker/AudioBook-Generator/issues/436).
-
 ---
 
 ## Won't (this round) — explicitly parked
@@ -408,6 +394,8 @@ Specific items someone might reasonably re-propose. Each carries a _Why parked_ 
 - `srv-10` — Conflict resolution for two simultaneous `state.json` writers ([#445](https://github.com/dudarenok-maker/AudioBook-Generator/issues/445)). _Why parked:_ single-user-per-workspace assumption; file locking is advisory at best on Windows network shares. _Wake when:_ multi-user collab on a shared workspace becomes a real use case. Pairs with `fe-11` — both wake under the same trigger.
 
 - `srv-5` — Tune per-engine VRAM cost map against real hardware ([#447](https://github.com/dudarenok-maker/AudioBook-Generator/issues/447)). _Why parked:_ most of the original scope dissolved under the Qwen tuning work. The plan-113 fix serialises the Qwen forward per-engine (it isn't thread-safe), so `GPU_VRAM_BUDGET>1` gives **no same-engine Qwen parallelism** — the cost … _Wake when:_ cross-engine packing actually thrashes (spill-to-RAM slowdown, `nvidia-smi` near the card ceiling) on real hardware, or a different/smaller GPU changes the headroom math. …
+
+- `fs-8` — PocketBook Cloud direct upload OR `@pbsync.com` email gateway ([#436](https://github.com/dudarenok-maker/Castwright/issues/436)). _Why parked:_ the sideload-*free* transport isn't worth building — LAN download + the sync-folder path already get a finished book onto a PocketBook, and both candidate routes are unattractive: PocketBook Cloud's protocol is closed (needs reverse-engineering or vendor contact), and `@pbsync.com` is documented for ebooks with undocumented audiobook size limits. The PocketBook *sideload* tile (M4B) stays live and covers the need. _Wake when:_ PocketBook ships a documented upload API, OR enough users ask for a no-sideload PocketBook path to justify the reverse-engineering cost.
 
 ---
 


### PR DESCRIPTION
## Summary

Cleanup round, docs-only (CI doc-only fast-path applies).

- **GitHub About** (repo metadata, applied out-of-band): set the empty description to the Castwright tagline + one-liner, `castwright.ai` homepage, and 9 topics.
- **fe-3 — Apple Books handoff (#434):** the intent shipped via the unified M4B export tile, not the original UA-detection handoff modal the issue spec'd. Closed #434 as delivered and dropped its Could row (the now-empty "Listener-app handoffs" subsection with it).
- **fs-8 — PocketBook Cloud / pbsync gateway (#436):** parked as won't-do — closed #436, relabelled `moscow:wont`, moved to the Won't bucket with a Why-parked / Wake-when.
- **CONTRIBUTING.md:** holistic brand-language pass in the Castwright voice (calm, candid craftsperson — no AI-hype filler). Prose-only diff — every command, table, rule, and link is byte-for-byte unchanged.

Closes #434
Closes #436

## Test plan

- [x] `git diff` confirms CONTRIBUTING change is prose-only (tables/commands/links intact).
- [x] BACKLOG: fe-3 row removed, fs-8 relocated to Won't bucket.
- [x] Markdown is not in the `verify` lint gate (eslint-only) and these files are in the CI doc-only fast-path, so no full battery applies. Existing manual ~78-char wrap preserved (file was never Prettier-formatted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)