### PR TITLE
feat(frontend,server): continue-listening shelf controls — covers, scrollbar, finish/hide (fs-15)

### DIFF
--- a/docs/features/213-continue-listening-shelf-controls.md
+++ b/docs/features/213-continue-listening-shelf-controls.md
@@ -1,0 +1,89 @@
+---
+status: active
+shipped: null
+owner: null
+---
+
+# Continue-listening shelf controls (covers · auto-hide · finish/hide)
+
+> Status: active
+> Key files: `src/components/library/continue-listening-rail.tsx`, `src/views/book-library.tsx`, `src/store/continue-listening-slice.ts`, `src/lib/api.ts`, `server/src/workspace/listen-stats-aggregate.ts`, `server/src/routes/book-state.ts`, `server/src/routes/library.ts`, `openapi.yaml`
+> URL surface: `#/` (Books view rail) — indirect
+> OpenAPI ops: `POST /api/books/{bookId}/shelf-status`; extends `ListenProgress` schema
+
+Follow-up polish on the fs-15 Continue-listening rail (plan
+[212](archive/212-fs15-fs16-listening-stats.md)). Four user-reported issues,
+observed in dark mode on the live workspace.
+
+## Benefit / Rationale
+
+- **User:** the rail shows real cover art (not just a gradient); the scrollbar
+  matches the app theme in dark mode; books you've effectively finished drop off
+  automatically; and a per-card ⋯ menu lets you **Mark as finished** (e.g. when
+  progress sync failed) or **Hide from shelf** without re-listening.
+- **Technical:** auto-hide is a server-side aggregation tweak (no client state);
+  finish/hide persist on the existing `listen-progress.json` via one new endpoint.
+- **Architectural:** introduces explicit shelf flags as the durable signal the
+  derived "finished" heuristic could never fully infer, while keeping the rail a
+  pure render driven by `GET /api/library/continue-listening`.
+
+## What changed
+
+1. **Covers (#1)** — the rail renders the book's `coverImageUrl` (threaded from
+   the library slice as a `bookId → url` map in `book-library.tsx`), with the
+   gradient placeholder as fallback on a missing URL **and** on `<img>` error.
+   No server/openapi change — the URL already exists on `LibraryBook`.
+2. **Scrollbar (#2)** — the scroll strip uses the theme-aware `.scrollbar-thin`
+   utility, with `--scrollbar-thin-radius: 0` and `clip-path: none` so the
+   utility's rounded in-card clip can't clip the cards' hover shadow / focus ring.
+3. **Auto-hide completed (#3)** — `listen-stats-aggregate.ts` gains
+   `isEffectivelyComplete` (listenable total > 0 and ≤ `FINISH_TAIL_SEC` of the
+   book's end remaining); `isFinished` now also accepts an explicit flag and the
+   effectively-complete branch. `buildContinueListening` excludes finished,
+   `hidden`, and zero-listenable-audio books. This catches the "0:00 left" cards
+   whose resume bookmark sat in a non-listenable trailing chapter.
+4. **Finish / Hide (#4/#5)** — `POST /api/books/:bookId/shelf-status`
+   `{ finished?, hidden? }` read-modify-writes shelf flags on
+   `listen-progress.json`. **`finished` is sticky** (preserved across later
+   progress saves) and counts toward the fs-16 "books finished" stat; **`hidden`
+   is cleared on the next progress save** (resuming un-hides). The existing
+   `PUT /listen-progress` was changed to **merge** rather than overwrite so a
+   position save can't erase the flags. The rail's ⋯ menu is a portal-anchored
+   popover (the rail's `overflow-x-auto` strip + the card's `overflow-hidden`
+   would clip an in-flow dropdown — same reason `status-popover.tsx` portals).
+
+## Invariants to preserve
+
+- `ListenProgress` shape stays backward-compatible — all four new fields
+  (`finished`, `finishedAt`, `hidden`, `dismissedAt`) are optional; legacy
+  records and the mini-player (which reads only `chapterId`/`currentSec`/
+  `playbackRate`/`markers`) are unaffected.
+- `PUT /listen-progress` must keep returning a record equal to what it writes
+  (`book-state.test.ts` asserts on-disk === response === GET).
+- The rail stays presentational; all persistence + toasts live in the
+  orchestrator (`book-library.tsx`).
+
+## Known risks (accepted)
+
+- `POST /shelf-status` and `PUT /listen-progress` both read-modify-write
+  `listen-progress.json` without a shared per-book lock — a concurrent finish +
+  position-save on the *same* book could clobber. Near-impossible via the UI (a
+  finished/hidden card is not the active player). Documented, not locked.
+- A genuinely in-progress book missing all chapter durations won't appear on the
+  rail (no listenable total) — reachable via the library grid.
+
+## Tests
+
+- `server/src/workspace/listen-stats-aggregate.test.ts` — auto-hide / finished /
+  hidden cases incl. the "0:00 left" leak repro.
+- `server/src/routes/book-state.test.ts` — `shelf-status` write/clear/idempotent/
+  404 + the PUT-merge regression (finished sticky, hidden cleared on resume).
+- `src/store/continue-listening-slice.test.ts` — `dismiss`.
+- `src/lib/api.test.ts` — mock `setShelfStatus` prunes the seeded shelf.
+- `src/components/library/continue-listening-rail.test.tsx` — cover + fallback,
+  scrollbar class, ⋯ menu finish/hide/Escape.
+- `e2e/listening-stats.spec.ts` — finish-via-menu removes the card.
+
+## Ship notes
+
+_To be filled at merge._

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -104,6 +104,7 @@ This section lists only the **in-flight working set** — plans whose `status:` 
 
 ### H. Listen & playback
 
+- [213 — Continue-listening shelf controls (covers · auto-hide · finish/hide)](213-continue-listening-shelf-controls.md) — `active`. Polish on the fs-15 rail (plan 212): real cover art with gradient fallback; theme-aware thin scrollbar (dark-mode compliant); server-side auto-hide of effectively-complete books (`isEffectivelyComplete` + extended `isFinished`) so "0:00 left" cards drop off; and per-card ⋯ menu **Mark as finished** (sticky, counts in fs-16 stats) / **Hide from shelf** (cleared on next resume), persisted via `POST /api/books/{id}/shelf-status` on `listen-progress.json` with a merge-not-clobber `PUT /listen-progress`. Portal-anchored menu (rail's `overflow-x-auto` would clip an in-flow dropdown). Closes the four shelf nits.
 - [159 — Listen-row affordances gated on generated audio](159-listen-ungenerated-chapter-affordances.md) — `active`. Listen-view chapter rows for chapters that haven't generated audio yet (`state` of `queued`/`in_progress`/`failed`) no longer masquerade as playable: the Play + Share-clip buttons are `disabled`, and a state-aware label (`Queued`/`Generating…`/`Failed`) replaces the misleading "0:00" duration. Reuses the existing `state === 'done'` "has audio" predicate; Regenerate stays active (it can start/retry generation). Single-component change in `listen-player-region.tsx` with paired unit coverage.
 
 ### K. Cross-cutting invariants

--- a/e2e/listening-stats.spec.ts
+++ b/e2e/listening-stats.spec.ts
@@ -95,6 +95,25 @@ test.describe('fs-15 continue-listening rail', () => {
     await expect(page).toHaveURL(/#\/books\/sb\/listen/, { timeout: 10_000 });
   });
 
+  test('marking a card finished from the ⋯ menu removes it from the rail', async ({ page }) => {
+    await page.addInitScript((seed) => {
+      (window as unknown as { __SEED_CONTINUE__: unknown }).__SEED_CONTINUE__ = seed;
+    }, CONTINUE_SEED);
+    await page.goto('/');
+
+    const card = page.getByRole('button', { name: /Continue listening to Solway Bay/i });
+    await card.waitFor({ state: 'visible', timeout: 25_000 });
+
+    /* Hover reveals the ⋯ control on pointer devices; open it and finish. */
+    await card.hover();
+    await page.getByRole('button', { name: /Continue-listening options/i }).click();
+    await page.getByRole('menuitem', { name: /Mark as finished/i }).click();
+
+    /* Optimistic dismiss drops the only card → the whole rail unmounts. */
+    await expect(card).toHaveCount(0, { timeout: 5_000 });
+    await expect(page.getByRole('heading', { name: /Continue listening/i })).not.toBeVisible();
+  });
+
   test('does NOT render the rail when __SEED_CONTINUE__ is empty', async ({ page }) => {
     /* No seed script — the mock returns [] by default. */
     await page.goto('/');

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1039,6 +1039,39 @@ paths:
         '400': { description: Body missing chapterId or currentSec, or contains non-numeric values, or contains a marker with an unrecognised kind }
         '404': { description: Book not found }
 
+  /api/books/{bookId}/shelf-status:
+    post:
+      summary: Set the Continue-listening shelf flags for a book
+      operationId: setShelfStatus
+      description: |
+        fs-15 shelf controls — read-modify-write the `finished` / `hidden`
+        flags on the book's `listen-progress.json`. Body must include at least
+        one boolean; setting a flag to `false` clears it. `finished` ("Mark as
+        finished") is sticky and counts toward library stats; `hidden` ("Hide
+        from shelf") only removes the book from the rail and is cleared on the
+        next progress save. The resume position is carried forward untouched;
+        a book with no prior bookmark can still be flagged (cold record).
+      parameters:
+        - { in: path, name: bookId, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              minProperties: 1
+              properties:
+                finished: { type: boolean }
+                hidden: { type: boolean }
+      responses:
+        '200':
+          description: The updated listen-progress record with the new shelf flags
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ListenProgress' }
+        '400': { description: Body includes neither a boolean `finished` nor a boolean `hidden` }
+        '404': { description: Book not found }
+
   /api/books/{bookId}/listen-stats:
     put:
       summary: Append per-day listening seconds for a book
@@ -2947,6 +2980,28 @@ components:
             Plan 53 — user-placed bookmarks. Optional / absent on
             pre-plan-53 records.
           items: { $ref: '#/components/schemas/ListenMarker' }
+        finished:
+          type: boolean
+          description: |
+            fs-15 shelf controls — set by POST /shelf-status when the user picks
+            "Mark as finished". Sticky (preserved across later progress saves);
+            drops the book off the Continue-listening rail AND counts it toward
+            the library "books finished" stat.
+        finishedAt:
+          type: string
+          format: date-time
+          description: 'fs-15 — server-stamped ISO time the book was marked finished.'
+        hidden:
+          type: boolean
+          description: |
+            fs-15 shelf controls — set by POST /shelf-status when the user picks
+            "Hide from shelf". Drops the book off the Continue-listening rail
+            WITHOUT counting it as finished, and is cleared on the next progress
+            save (resuming un-hides the book).
+        dismissedAt:
+          type: string
+          format: date-time
+          description: 'fs-15 — server-stamped ISO time the book was hidden from the shelf.'
 
     ListenMarker:
       type: object

--- a/server/src/routes/book-state.test.ts
+++ b/server/src/routes/book-state.test.ts
@@ -1925,3 +1925,129 @@ describe('PUT /:bookId/listen-stats', () => {
     expect(res.status).toBe(404);
   });
 });
+
+describe('book-state router — shelf-status (fs-15 shelf controls)', () => {
+  const SS_AUTHOR = 'Shelf Status Author';
+  const SS_SERIES = 'Standalones';
+  const SS_TITLE = 'Shelf Status Book';
+  let ssBookId: string;
+  let ssBookDir: string;
+  const lpFile = () => join(ssBookDir, '.audiobook', 'listen-progress.json');
+  const readLp = () => JSON.parse(readFileSync(lpFile(), 'utf8'));
+
+  beforeAll(async () => {
+    const { makeBookId } = await import('../workspace/paths.js');
+    ssBookId = makeBookId(SS_AUTHOR, SS_SERIES, SS_TITLE);
+    ssBookDir = join(workspaceRoot, 'books', SS_AUTHOR, SS_SERIES, SS_TITLE);
+    mkdirSync(join(ssBookDir, '.audiobook'), { recursive: true });
+    writeFileSync(
+      join(ssBookDir, '.audiobook', 'state.json'),
+      JSON.stringify({
+        bookId: ssBookId,
+        manuscriptId: 'm_shelf_status',
+        title: SS_TITLE,
+        author: SS_AUTHOR,
+        series: SS_SERIES,
+        seriesPosition: null,
+        isStandalone: true,
+        manuscriptFile: 'manuscript.txt',
+        castConfirmed: true,
+        chapters: [
+          { id: 1, title: 'Chapter 1', slug: 'chapter-one' },
+          { id: 2, title: 'Chapter 2', slug: 'chapter-two' },
+        ],
+        coverGradient: ['#000', '#fff'],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+    writeFileSync(join(ssBookDir, 'manuscript.txt'), 'placeholder');
+  });
+
+  beforeEach(() => {
+    // Reset to a known mid-listen bookmark before each case.
+    writeFileSync(
+      lpFile(),
+      JSON.stringify({ chapterId: 1, currentSec: 120, updatedAt: '2026-06-14T00:00:00.000Z' }),
+    );
+  });
+
+  it('POST finished:true stamps finished + finishedAt on disk', async () => {
+    const res = await request(app)
+      .post(`/api/books/${ssBookId}/shelf-status`)
+      .set('Content-Type', 'application/json')
+      .send({ finished: true });
+    expect(res.status).toBe(200);
+    expect(res.body.finished).toBe(true);
+    expect(typeof res.body.finishedAt).toBe('string');
+    const onDisk = readLp();
+    expect(onDisk.finished).toBe(true);
+    expect(onDisk.chapterId).toBe(1); // position preserved
+  });
+
+  it('POST hidden:true stamps hidden + dismissedAt on disk', async () => {
+    const res = await request(app)
+      .post(`/api/books/${ssBookId}/shelf-status`)
+      .send({ hidden: true });
+    expect(res.status).toBe(200);
+    expect(res.body.hidden).toBe(true);
+    expect(typeof res.body.dismissedAt).toBe('string');
+    expect(readLp().hidden).toBe(true);
+  });
+
+  it('POST finished:false clears the flag', async () => {
+    await request(app).post(`/api/books/${ssBookId}/shelf-status`).send({ finished: true });
+    const res = await request(app).post(`/api/books/${ssBookId}/shelf-status`).send({ finished: false });
+    expect(res.status).toBe(200);
+    expect(res.body.finished).toBeFalsy();
+    expect(readLp().finished).toBeFalsy();
+  });
+
+  it('is idempotent (POST finished:true twice stays finished)', async () => {
+    await request(app).post(`/api/books/${ssBookId}/shelf-status`).send({ finished: true });
+    const res = await request(app).post(`/api/books/${ssBookId}/shelf-status`).send({ finished: true });
+    expect(res.status).toBe(200);
+    expect(res.body.finished).toBe(true);
+  });
+
+  it('400s when neither finished nor hidden is a boolean', async () => {
+    const res = await request(app).post(`/api/books/${ssBookId}/shelf-status`).send({ foo: 'bar' });
+    expect(res.status).toBe(400);
+  });
+
+  it('404s on an unknown book', async () => {
+    const res = await request(app).post(`/api/books/does-not-exist/shelf-status`).send({ finished: true });
+    expect(res.status).toBe(404);
+  });
+
+  it('works when no listen-progress.json exists yet (marks finished from cold)', async () => {
+    rmSync(lpFile(), { force: true });
+    const res = await request(app).post(`/api/books/${ssBookId}/shelf-status`).send({ finished: true });
+    expect(res.status).toBe(200);
+    expect(res.body.finished).toBe(true);
+    expect(readLp().finished).toBe(true);
+  });
+
+  describe('PUT /listen-progress merge', () => {
+    it('preserves finished across a subsequent progress save', async () => {
+      await request(app).post(`/api/books/${ssBookId}/shelf-status`).send({ finished: true });
+      const put = await request(app)
+        .put(`/api/books/${ssBookId}/listen-progress`)
+        .send({ chapterId: 2, currentSec: 45 });
+      expect(put.status).toBe(200);
+      expect(put.body.chapterId).toBe(2);
+      expect(put.body.finished).toBe(true); // sticky
+      expect(readLp().finished).toBe(true);
+    });
+
+    it('clears hidden on a subsequent progress save (resuming un-hides)', async () => {
+      await request(app).post(`/api/books/${ssBookId}/shelf-status`).send({ hidden: true });
+      const put = await request(app)
+        .put(`/api/books/${ssBookId}/listen-progress`)
+        .send({ chapterId: 1, currentSec: 200 });
+      expect(put.status).toBe(200);
+      expect(put.body.hidden).toBeFalsy();
+      expect(readLp().hidden).toBeFalsy();
+    });
+  });
+});

--- a/server/src/routes/book-state.ts
+++ b/server/src/routes/book-state.ts
@@ -1249,6 +1249,15 @@ interface ListenProgressFile {
   /* Plan 53 — user-placed bookmarks. Optional; absent on pre-plan-53
      records. */
   markers?: ListenMarker[];
+  /* fs-15 shelf controls — explicit Continue-listening flags, set via
+     POST /:bookId/shelf-status. `finished` (sticky: preserved across a
+     subsequent progress PUT) counts toward booksFinished and drops the book
+     off the rail; `hidden` (cleared on the next progress PUT — resuming
+     un-hides) only drops it off the rail. */
+  finished?: boolean;
+  finishedAt?: string;
+  hidden?: boolean;
+  dismissedAt?: string;
 }
 
 /* Plan 53 — bounds on playback rate. Mirrors the openapi.yaml
@@ -1395,6 +1404,11 @@ bookStateRouter.put('/:bookId/listen-progress', async (req: Request, res: Respon
        a legacy book without uuids) — GET then keeps the stored chapterId. */
     const stateForUuid = await readJson<BookStateJson>(stateJsonPath(located.bookDir));
     const chapterUuid = stateForUuid?.chapters.find((c) => c.id === body.chapterId)?.uuid;
+    /* fs-15 shelf controls — merge the prior record's shelf flags rather than
+       clobbering them: `finished` is sticky (a user "Mark as finished" survives
+       later progress saves), while `hidden` is intentionally NOT carried over —
+       a fresh resume position un-hides the book from the Continue-listening rail. */
+    const prior = await readJson<ListenProgressFile>(listenProgressJsonPath(located.bookDir));
     const record: ListenProgressFile = {
       chapterId: body.chapterId,
       ...(chapterUuid ? { chapterUuid } : {}),
@@ -1402,12 +1416,60 @@ bookStateRouter.put('/:bookId/listen-progress', async (req: Request, res: Respon
       updatedAt: effectiveUpdatedAt,
       ...(playbackRate !== undefined ? { playbackRate } : {}),
       ...(markers !== undefined ? { markers } : {}),
+      ...(prior?.finished
+        ? { finished: true, ...(prior.finishedAt ? { finishedAt: prior.finishedAt } : {}) }
+        : {}),
     };
     await writeJsonAtomic(listenProgressJsonPath(located.bookDir), record);
     res.json(record);
   } catch (e) {
     console.error('[book-state] PUT listen-progress failed', e);
     res.status(500).json({ error: (e as Error).message || 'Failed to write listen-progress.' });
+  }
+});
+
+/* fs-15 shelf controls — POST /:bookId/shelf-status { finished?, hidden? }.
+   Read-modify-write the Continue-listening shelf flags on the listen-progress
+   record. Body must carry at least one boolean; setting a flag to false clears
+   it (cheap reversibility). The resume position is carried forward untouched. */
+bookStateRouter.post('/:bookId/shelf-status', async (req: Request, res: Response) => {
+  try {
+    const located = await findBookByBookId(req.params.bookId);
+    if (!located) return res.status(404).json({ error: 'Book not found.' });
+    const body = req.body as Partial<{ finished: unknown; hidden: unknown }> | undefined;
+    const hasFinished = !!body && typeof body.finished === 'boolean';
+    const hasHidden = !!body && typeof body.hidden === 'boolean';
+    if (!hasFinished && !hasHidden) {
+      return res.status(400).json({ error: 'Body must include a boolean `finished` and/or `hidden`.' });
+    }
+    const now = new Date().toISOString();
+    const prior = await readJson<ListenProgressFile>(listenProgressJsonPath(located.bookDir));
+    /* Fall back to a cold record so a book with no prior bookmark can still be
+       flagged (e.g. marking finished after a failed sync). */
+    const record: ListenProgressFile = { ...(prior ?? { chapterId: 0, currentSec: 0, updatedAt: now }) };
+    if (hasFinished) {
+      if (body!.finished) {
+        record.finished = true;
+        record.finishedAt = now;
+      } else {
+        delete record.finished;
+        delete record.finishedAt;
+      }
+    }
+    if (hasHidden) {
+      if (body!.hidden) {
+        record.hidden = true;
+        record.dismissedAt = now;
+      } else {
+        delete record.hidden;
+        delete record.dismissedAt;
+      }
+    }
+    await writeJsonAtomic(listenProgressJsonPath(located.bookDir), record);
+    res.json(record);
+  } catch (e) {
+    console.error('[book-state] POST shelf-status failed', e);
+    res.status(500).json({ error: (e as Error).message || 'Failed to write shelf-status.' });
   }
 });
 

--- a/server/src/routes/library.ts
+++ b/server/src/routes/library.ts
@@ -26,7 +26,15 @@ import {
 
 export const libraryRouter = Router();
 
-type ResumeBookmark = { chapterId: number; currentSec: number; updatedAt: string; chapterUuid?: string };
+type ResumeBookmark = {
+  chapterId: number;
+  currentSec: number;
+  updatedAt: string;
+  chapterUuid?: string;
+  /* fs-15 shelf controls — explicit Continue-listening flags. */
+  finished?: boolean;
+  hidden?: boolean;
+};
 type MappedChapter = { id: number; uuid?: string; duration?: string; excluded?: boolean; held?: boolean };
 
 async function assembleBookInputs(): Promise<BookStatsInput[]> {
@@ -67,6 +75,9 @@ async function assembleBookInputs(): Promise<BookStatsInput[]> {
         })),
         resume: resumeObject,
         statsFile: statsFile ?? null,
+        /* fs-15 shelf controls — explicit flags drive auto-hide + finished stats. */
+        finished: resume?.finished,
+        hidden: resume?.hidden,
       };
     }),
   );

--- a/server/src/workspace/listen-stats-aggregate.test.ts
+++ b/server/src/workspace/listen-stats-aggregate.test.ts
@@ -1,7 +1,35 @@
 import { describe, it, expect } from 'vitest';
-import { completionPct, isFinished, buildLibraryStats, buildContinueListening } from './listen-stats-aggregate.js';
+import {
+  completionPct,
+  isFinished,
+  buildLibraryStats,
+  buildContinueListening,
+  type BookStatsInput,
+} from './listen-stats-aggregate.js';
 
 const ch = [{ id: 1, duration: '10:00' }, { id: 2, duration: '10:00' }];
+
+type Ch = BookStatsInput['chapters'][number];
+
+/* fs-15 shelf controls — helper for the auto-hide / finished / hidden cases. */
+function book(over: Partial<BookStatsInput> = {}): BookStatsInput {
+  return {
+    bookId: 'b1',
+    title: 'Test Book',
+    series: null,
+    isStandalone: true,
+    chapters: [
+      { id: 1, duration: '00:30:00' },
+      { id: 2, duration: '00:30:00' },
+    ],
+    resume: null,
+    statsFile: null,
+    ...over,
+  };
+}
+
+const at = '2026-06-14T00:00:00.000Z';
+const railIds = (items: { bookId: string }[]) => items.map((i) => i.bookId);
 
 describe('completionPct', () => {
   it('is consumed / total listenable', () => {
@@ -44,5 +72,74 @@ describe('buildContinueListening', () => {
     ];
     const out = buildContinueListening(books);
     expect(out.map((x) => x.bookId)).toEqual(['b', 'a']);
+  });
+});
+
+describe('buildContinueListening — auto-hide completed (fs-15 shelf controls)', () => {
+  it('keeps a genuinely in-progress book on the rail', () => {
+    const b = book({ resume: { chapterId: 1, currentSec: 60, updatedAt: at } });
+    expect(railIds(buildContinueListening([b]))).toContain('b1');
+  });
+
+  it('drops a book consumed to the end whose resume bookmark is in a non-listenable final chapter (the "0:00 left" leak)', () => {
+    // ch2 has no duration (credits / audio not generated) → not listenable.
+    // The bookmark points at it; everything listenable (ch1) is consumed.
+    const chapters: Ch[] = [{ id: 1, duration: '00:30:00' }, { id: 2 }];
+    const b = book({ chapters, resume: { chapterId: 2, currentSec: 10, updatedAt: at } });
+    expect(railIds(buildContinueListening([b]))).not.toContain('b1');
+  });
+
+  it('drops a book with no listenable audio at all (no durations)', () => {
+    const chapters: Ch[] = [{ id: 1 }, { id: 2 }];
+    const b = book({ chapters, resume: { chapterId: 1, currentSec: 10, updatedAt: at } });
+    expect(buildContinueListening([b])).toHaveLength(0);
+  });
+
+  it('excludes an explicitly-finished book even with plenty of time remaining', () => {
+    const b = book({ resume: { chapterId: 1, currentSec: 60, updatedAt: at }, finished: true });
+    expect(buildContinueListening([b])).toHaveLength(0);
+  });
+
+  it('excludes a hidden book', () => {
+    const b = book({ resume: { chapterId: 1, currentSec: 60, updatedAt: at }, hidden: true });
+    expect(buildContinueListening([b])).toHaveLength(0);
+  });
+});
+
+describe('buildLibraryStats — finished accounting (fs-15 shelf controls)', () => {
+  it('counts an explicitly-finished book as finished', () => {
+    const b = book({ resume: { chapterId: 1, currentSec: 60, updatedAt: at }, finished: true });
+    const stats = buildLibraryStats([b]);
+    expect(stats.booksFinished).toBe(1);
+    expect(stats.perBook.find((p) => p.bookId === 'b1')?.finished).toBe(true);
+  });
+
+  it('does NOT count a merely-hidden book as finished', () => {
+    const b = book({ resume: { chapterId: 1, currentSec: 60, updatedAt: at }, hidden: true });
+    const stats = buildLibraryStats([b]);
+    expect(stats.booksFinished).toBe(0);
+    expect(stats.perBook.find((p) => p.bookId === 'b1')?.finished).toBe(false);
+  });
+
+  it('counts an effectively-complete book as finished without an explicit flag', () => {
+    const chapters: Ch[] = [{ id: 1, duration: '00:30:00' }, { id: 2 }];
+    const b = book({ chapters, resume: { chapterId: 2, currentSec: 10, updatedAt: at } });
+    expect(buildLibraryStats([b]).booksFinished).toBe(1);
+  });
+
+  it('does NOT count a no-audio book as finished', () => {
+    const chapters: Ch[] = [{ id: 1 }, { id: 2 }];
+    const b = book({ chapters, resume: { chapterId: 1, currentSec: 10, updatedAt: at } });
+    expect(buildLibraryStats([b]).booksFinished).toBe(0);
+  });
+});
+
+describe('isFinished — explicit flag (fs-15 shelf controls)', () => {
+  it('short-circuits true for an explicitly-finished book regardless of position', () => {
+    expect(isFinished([{ id: 1, duration: '00:30:00' }], { chapterId: 1, currentSec: 5, updatedAt: at }, true)).toBe(true);
+  });
+
+  it('stays false for a no-audio book that is not explicitly finished', () => {
+    expect(isFinished([{ id: 1 }], { chapterId: 1, currentSec: 10, updatedAt: at })).toBe(false);
   });
 });

--- a/server/src/workspace/listen-stats-aggregate.ts
+++ b/server/src/workspace/listen-stats-aggregate.ts
@@ -16,6 +16,12 @@ export interface ResumeInput { chapterId: number; currentSec: number; updatedAt:
 export interface BookStatsInput {
   bookId: string; title: string; series: string | null; isStandalone: boolean;
   chapters: DurChapter[]; resume: ResumeInput | null; statsFile: ListenStatsFile | null;
+  /* fs-15 shelf controls — explicit per-book flags read from listen-progress.json.
+     `finished` (sticky, user "Mark as finished") counts toward booksFinished and
+     drops the book off the rail; `hidden` (user "Hide from shelf", cleared on the
+     next resume) only drops it off the rail. */
+  finished?: boolean;
+  hidden?: boolean;
 }
 
 /** Completion as consumed / total listenable. Guards divide-by-zero. */
@@ -27,15 +33,39 @@ export function completionPct(chapters: DurChapter[], resume: ResumeInput | null
   return Math.min(1, consumed / total);
 }
 
-/** True when in the final listenable chapter and within finish tail threshold. */
-export function isFinished(chapters: DurChapter[], resume: ResumeInput | null): boolean {
+/** True when the user has consumed within FINISH_TAIL_SEC of the whole book's
+    listenable end. Catches the "0:00 left" case where the resume bookmark sits
+    in a non-listenable trailing chapter (excluded/held/no-duration) but every
+    listenable second is already behind the bookmark, so the narrow
+    final-chapter-tail check below would miss it. Requires real listenable
+    audio (total > 0) — a book with no durations is "no audio", not "finished". */
+export function isEffectivelyComplete(chapters: DurChapter[], resume: ResumeInput | null): boolean {
+  if (!resume) return false;
+  const total = bookListenableSeconds(chapters);
+  if (total <= 0) return false;
+  const consumed = secondsBeforeChapter(chapters, resume.chapterId) + Math.max(0, resume.currentSec);
+  return total - consumed <= FINISH_TAIL_SEC;
+}
+
+/** True when the book is finished: an explicit user "Mark as finished" flag,
+    OR the resume bookmark sits in the final listenable chapter within its tail,
+    OR the listenable audio is effectively all consumed. */
+export function isFinished(
+  chapters: DurChapter[],
+  resume: ResumeInput | null,
+  explicitFinished = false,
+): boolean {
+  if (explicitFinished) return true;
   if (!resume) return false;
   const final = finalListenableChapter(chapters);
-  if (!final || final.id !== resume.chapterId) return false;
-  const finalSec = parseDurationToSec(final.duration);
-  if (finalSec <= 0) return false;
-  const tail = Math.max(FINISH_TAIL_SEC, finalSec * FINISH_TAIL_FRAC);
-  return resume.currentSec >= finalSec - tail;
+  if (final && final.id === resume.chapterId) {
+    const finalSec = parseDurationToSec(final.duration);
+    if (finalSec > 0) {
+      const tail = Math.max(FINISH_TAIL_SEC, finalSec * FINISH_TAIL_FRAC);
+      if (resume.currentSec >= finalSec - tail) return true;
+    }
+  }
+  return isEffectivelyComplete(chapters, resume);
 }
 
 export interface LibraryStats {
@@ -53,7 +83,7 @@ export function buildLibraryStats(books: BookStatsInput[]): LibraryStats {
   const perBook = books.map((b) => ({
     bookId: b.bookId, title: b.title,
     completionPct: completionPct(b.chapters, b.resume),
-    finished: isFinished(b.chapters, b.resume),
+    finished: isFinished(b.chapters, b.resume, b.finished),
   })).sort((a, b) => b.completionPct - a.completionPct);
 
   const seriesMap = new Map<string, { finishedCount: number; importedCount: number }>();
@@ -61,7 +91,7 @@ export function buildLibraryStats(books: BookStatsInput[]): LibraryStats {
     if (b.isStandalone || !b.series) continue;
     const e = seriesMap.get(b.series) ?? { finishedCount: 0, importedCount: 0 };
     e.importedCount += 1;
-    if (isFinished(b.chapters, b.resume)) e.finishedCount += 1;
+    if (isFinished(b.chapters, b.resume, b.finished)) e.finishedCount += 1;
     seriesMap.set(b.series, e);
   }
 
@@ -81,10 +111,18 @@ export interface ContinueItem {
   remainingSec: number; completionPct: number; updatedAt: string;
 }
 
-/** Continue-listening list: excludes finished + <=5s noise, sorted by updatedAt desc. */
+/** Continue-listening list: excludes finished (explicit or effectively-complete),
+    hidden, books with no listenable audio, and <=5s noise; sorted by updatedAt desc. */
 export function buildContinueListening(books: BookStatsInput[]): ContinueItem[] {
   return books
-    .filter((b) => b.resume && b.resume.currentSec > NOISE_FLOOR_SEC && !isFinished(b.chapters, b.resume))
+    .filter(
+      (b) =>
+        b.resume &&
+        b.resume.currentSec > NOISE_FLOOR_SEC &&
+        !b.hidden &&
+        !isFinished(b.chapters, b.resume, b.finished) &&
+        bookListenableSeconds(b.chapters) > 0,
+    )
     .map((b) => {
       const total = bookListenableSeconds(b.chapters);
       const consumed = secondsBeforeChapter(b.chapters, b.resume!.chapterId) + b.resume!.currentSec;

--- a/src/components/library/continue-listening-rail.test.tsx
+++ b/src/components/library/continue-listening-rail.test.tsx
@@ -14,10 +14,12 @@ const item = (over: Partial<ContinueItem> = {}): ContinueItem => ({
   ...over,
 });
 
+const noop = () => {};
+
 describe('ContinueListeningRail', () => {
   it('renders nothing when items is empty', () => {
     const { container } = render(
-      <ContinueListeningRail items={[]} onOpen={() => {}} />,
+      <ContinueListeningRail items={[]} onOpen={noop} onFinish={noop} onHide={noop} />,
     );
     expect(container.firstChild).toBeNull();
   });
@@ -27,12 +29,10 @@ describe('ContinueListeningRail', () => {
       item({ bookId: 'b1', title: 'The Coalfall Commission', chapterId: 3, remainingSec: 3600 }),
       item({ bookId: 'b2', title: 'Another Book', chapterId: 1, remainingSec: 300 }),
     ];
-    render(<ContinueListeningRail items={items} onOpen={() => {}} />);
+    render(<ContinueListeningRail items={items} onOpen={noop} onFinish={noop} onHide={noop} />);
 
     expect(screen.getByText('The Coalfall Commission')).toBeInTheDocument();
     expect(screen.getByText('Another Book')).toBeInTheDocument();
-
-    // Captions: "Ch N · HH:MM:SS left" or "Ch N · MM:SS left"
     expect(screen.getByText(/Ch 3/)).toBeInTheDocument();
     expect(screen.getByText(/Ch 1/)).toBeInTheDocument();
   });
@@ -43,19 +43,111 @@ describe('ContinueListeningRail', () => {
       item({ bookId: 'book-alpha', chapterId: 5 }),
       item({ bookId: 'book-beta', chapterId: 2, title: 'Book Beta' }),
     ];
-    render(<ContinueListeningRail items={items} onOpen={onOpen} />);
+    render(<ContinueListeningRail items={items} onOpen={onOpen} onFinish={noop} onHide={noop} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /book-alpha|The Coalfall Commission/i }));
+    // The card's accessible name is "Continue listening to {title}"; the ⋯
+    // button's title-free label keeps these queries unambiguous.
+    fireEvent.click(screen.getByRole('button', { name: /Continue listening to The Coalfall Commission/i }));
     expect(onOpen).toHaveBeenCalledWith('book-alpha', 5);
 
-    fireEvent.click(screen.getByRole('button', { name: /Book Beta/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Continue listening to Book Beta/i }));
     expect(onOpen).toHaveBeenCalledWith('book-beta', 2);
 
     expect(onOpen).toHaveBeenCalledTimes(2);
   });
 
   it('renders the section heading when items are present', () => {
-    render(<ContinueListeningRail items={[item()]} onOpen={() => {}} />);
+    render(<ContinueListeningRail items={[item()]} onOpen={noop} onFinish={noop} onHide={noop} />);
     expect(screen.getByText(/continue listening/i)).toBeInTheDocument();
+  });
+
+  it('applies the theme-aware thin scrollbar to the scroll strip', () => {
+    const { container } = render(
+      <ContinueListeningRail items={[item()]} onOpen={noop} onFinish={noop} onHide={noop} />,
+    );
+    expect(container.querySelector('.scrollbar-thin')).not.toBeNull();
+  });
+});
+
+describe('ContinueListeningRail — covers', () => {
+  it('renders the cover image when a URL is supplied', () => {
+    const { container } = render(
+      <ContinueListeningRail
+        items={[item({ bookId: 'b1' })]}
+        covers={{ b1: '/api/books/b1/cover' }}
+        onOpen={noop}
+        onFinish={noop}
+        onHide={noop}
+      />,
+    );
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toBe('/api/books/b1/cover');
+  });
+
+  it('falls back to the gradient placeholder when no cover URL is supplied', () => {
+    const { container } = render(
+      <ContinueListeningRail items={[item({ bookId: 'b1' })]} onOpen={noop} onFinish={noop} onHide={noop} />,
+    );
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('falls back to the gradient when the cover image errors', () => {
+    const { container } = render(
+      <ContinueListeningRail
+        items={[item({ bookId: 'b1' })]}
+        covers={{ b1: '/api/books/b1/cover' }}
+        onOpen={noop}
+        onFinish={noop}
+        onHide={noop}
+      />,
+    );
+    const img = container.querySelector('img')!;
+    fireEvent.error(img);
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+});
+
+describe('ContinueListeningRail — finish / hide menu', () => {
+  it('opens the ⋯ menu and fires onFinish with the bookId', () => {
+    const onFinish = vi.fn();
+    render(
+      <ContinueListeningRail
+        items={[item({ bookId: 'book-x' })]}
+        onOpen={noop}
+        onFinish={onFinish}
+        onHide={noop}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Continue-listening options/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Mark as finished/i }));
+    expect(onFinish).toHaveBeenCalledWith('book-x');
+  });
+
+  it('fires onHide with the bookId from the menu', () => {
+    const onHide = vi.fn();
+    render(
+      <ContinueListeningRail
+        items={[item({ bookId: 'book-y' })]}
+        onOpen={noop}
+        onFinish={noop}
+        onHide={onHide}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Continue-listening options/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Hide from shelf/i }));
+    expect(onHide).toHaveBeenCalledWith('book-y');
+  });
+
+  it('closes the menu on Escape', () => {
+    render(
+      <ContinueListeningRail items={[item({ bookId: 'b1' })]} onOpen={noop} onFinish={noop} onHide={noop} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Continue-listening options/i }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('menu')).toBeNull();
   });
 });

--- a/src/components/library/continue-listening-rail.tsx
+++ b/src/components/library/continue-listening-rail.tsx
@@ -1,31 +1,58 @@
 /* Continue-listening rail — horizontal shelf of in-progress books.
  *
- * Purely presentational: receives items and an `onOpen` callback from the
- * parent view. The parent (E2) is responsible for fetching and dispatching
- * into the continueListening slice. This component only renders.
+ * Purely presentational: receives items, a cover lookup, and callbacks from the
+ * parent view (book-library.tsx). The parent fetches + dispatches into the
+ * continueListening slice and owns the finish/hide side effects; this component
+ * only renders and signals intent.
  *
  * Renders nothing when items is empty so the parent can mount it
  * unconditionally without needing its own guard. */
 
-import { IconPlay } from '../../lib/icons';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { IconPlay, IconMore, IconCheck, IconClose } from '../../lib/icons';
 import { formatDuration } from '../../lib/time';
 import type { ContinueItem } from '../../store/continue-listening-slice';
 
 interface Props {
   items: ContinueItem[];
   onOpen: (bookId: string, chapterId: number) => void;
+  /** bookId → cover image URL (from the library slice). Missing ⇒ gradient. */
+  covers?: Record<string, string | undefined>;
+  /** fs-15 — "Mark as finished" (sticky, counts in stats). */
+  onFinish: (bookId: string) => void;
+  /** fs-15 — "Hide from shelf" (un-hides on next resume). */
+  onHide: (bookId: string) => void;
 }
 
-export function ContinueListeningRail({ items, onOpen }: Props) {
+export function ContinueListeningRail({ items, onOpen, covers, onFinish, onHide }: Props) {
   if (items.length === 0) return null;
 
   return (
     <section aria-label="Continue listening">
       <h2 className="font-serif text-xl font-bold text-ink mb-4">Continue listening</h2>
-      {/* Horizontal scrollable row; snap-x for a native feel on touch */}
-      <div className="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory">
+      {/* Horizontal scrollable row; snap-x for a native feel on touch. The
+          theme-aware .scrollbar-thin replaces the default OS scrollbar; we
+          neutralise its rounded clip-path (meant for in-card scroll regions)
+          so it can't clip the cards' hover shadow / focus ring. */}
+      <div
+        className="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory scrollbar-thin"
+        style={
+          {
+            ['--scrollbar-thin-radius']: '0px',
+            clipPath: 'none',
+          } as React.CSSProperties
+        }
+      >
         {items.map((item) => (
-          <ContinueCard key={item.bookId} item={item} onOpen={onOpen} />
+          <ContinueCard
+            key={item.bookId}
+            item={item}
+            cover={covers?.[item.bookId]}
+            onOpen={onOpen}
+            onFinish={onFinish}
+            onHide={onHide}
+          />
         ))}
       </div>
     </section>
@@ -34,53 +61,212 @@ export function ContinueListeningRail({ items, onOpen }: Props) {
 
 function ContinueCard({
   item,
+  cover,
   onOpen,
+  onFinish,
+  onHide,
 }: {
   item: ContinueItem;
+  cover?: string;
   onOpen: (bookId: string, chapterId: number) => void;
+  onFinish: (bookId: string) => void;
+  onHide: (bookId: string) => void;
 }) {
   const pct = Math.min(1, Math.max(0, item.completionPct));
   const remaining = formatDuration(item.remainingSec);
+  const [imgError, setImgError] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuBtnRef = useRef<HTMLButtonElement>(null);
+  const showCover = !!cover && !imgError;
 
   return (
-    <button
-      type="button"
-      onClick={() => onOpen(item.bookId, item.chapterId)}
-      aria-label={`Continue listening to ${item.title}`}
-      className="group flex-shrink-0 w-48 snap-start rounded-2xl border border-ink/10 bg-white shadow-card hover:shadow-float hover:border-ink/20 transition-all text-left overflow-hidden min-h-[44px] sm:min-h-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-peach"
-    >
-      {/* Cover area — gradient placeholder matching BookCard's visual language */}
-      <div className="aspect-16/10 relative bg-gradient-to-br from-peach/60 to-magenta/40 overflow-hidden">
-        {/* Decorative rings, same motif as BookCard */}
-        <svg viewBox="0 0 192 120" className="absolute inset-0 w-full h-full opacity-20">
-          <circle cx="40" cy="60" r="55" fill="none" stroke="white" strokeWidth="0.5" />
-          <circle cx="40" cy="60" r="38" fill="none" stroke="white" strokeWidth="0.5" />
-          <circle cx="40" cy="60" r="22" fill="none" stroke="white" strokeWidth="0.5" />
-        </svg>
+    <div className="group relative flex-shrink-0 w-48 snap-start">
+      <button
+        type="button"
+        onClick={() => onOpen(item.bookId, item.chapterId)}
+        aria-label={`Continue listening to ${item.title}`}
+        className="block w-full rounded-2xl border border-ink/10 bg-white shadow-card hover:shadow-float hover:border-ink/20 transition-all text-left overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-peach"
+      >
+        {/* Cover area — real cover when available, else the gradient placeholder
+            matching BookCard's visual language. */}
+        <div className="aspect-16/10 relative bg-gradient-to-br from-peach/60 to-magenta/40 overflow-hidden">
+          {showCover ? (
+            <img
+              src={cover}
+              alt=""
+              loading="lazy"
+              onError={() => setImgError(true)}
+              className="absolute inset-0 w-full h-full object-cover"
+            />
+          ) : (
+            /* Decorative rings, same motif as BookCard */
+            <svg viewBox="0 0 192 120" className="absolute inset-0 w-full h-full opacity-20">
+              <circle cx="40" cy="60" r="55" fill="none" stroke="white" strokeWidth="0.5" />
+              <circle cx="40" cy="60" r="38" fill="none" stroke="white" strokeWidth="0.5" />
+              <circle cx="40" cy="60" r="22" fill="none" stroke="white" strokeWidth="0.5" />
+            </svg>
+          )}
 
-        {/* Play badge */}
-        <span className="absolute bottom-2 right-2 w-7 h-7 rounded-full bg-white/20 group-hover:bg-white/35 transition-colors grid place-items-center">
-          <IconPlay className="w-3.5 h-3.5 text-white" />
-        </span>
-      </div>
-
-      {/* Text + progress */}
-      <div className="p-3">
-        <p className="text-[13px] font-semibold text-ink leading-snug line-clamp-2 mb-1">
-          {item.title}
-        </p>
-        <p className="text-[11px] text-ink/55 mb-2">
-          Ch {item.chapterId} · {remaining} left
-        </p>
-
-        {/* Thin progress bar */}
-        <div className="h-1 rounded-full bg-ink/10 overflow-hidden">
-          <div
-            className="h-full bg-peach rounded-full"
-            style={{ width: `${pct * 100}%` }}
-          />
+          {/* Play badge */}
+          <span className="absolute bottom-2 right-2 w-7 h-7 rounded-full bg-white/20 group-hover:bg-white/35 transition-colors grid place-items-center">
+            <IconPlay className="w-3.5 h-3.5 text-white" />
+          </span>
         </div>
-      </div>
-    </button>
+
+        {/* Text + progress */}
+        <div className="p-3">
+          <p className="text-[13px] font-semibold text-ink leading-snug line-clamp-2 mb-1">
+            {item.title}
+          </p>
+          <p className="text-[11px] text-ink/55 mb-2">
+            Ch {item.chapterId} · {remaining} left
+          </p>
+
+          {/* Thin progress bar */}
+          <div className="h-1 rounded-full bg-ink/10 overflow-hidden">
+            <div className="h-full bg-peach rounded-full" style={{ width: `${pct * 100}%` }} />
+          </div>
+        </div>
+      </button>
+
+      {/* Overflow menu — sibling of the main button (not nested) so it isn't
+          clipped by the card's overflow-hidden, and so we don't nest buttons.
+          Faintly visible on touch; revealed on hover/focus on pointer devices. */}
+      <button
+        ref={menuBtnRef}
+        type="button"
+        aria-label="Continue-listening options"
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        onClick={(e) => {
+          e.stopPropagation();
+          setMenuOpen((o) => !o);
+        }}
+        className="absolute top-1.5 right-1.5 grid place-items-center min-h-[44px] min-w-[44px] sm:min-h-[32px] sm:min-w-[32px] rounded-full bg-ink/40 hover:bg-ink/60 text-white opacity-0 group-hover:opacity-100 coarse-pointer:opacity-70 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-peach transition-opacity"
+      >
+        <IconMore className="w-4 h-4" />
+      </button>
+
+      {menuOpen && (
+        <CardMenu
+          anchorRef={menuBtnRef}
+          title={item.title}
+          onClose={() => setMenuOpen(false)}
+          onFinish={() => {
+            onFinish(item.bookId);
+            setMenuOpen(false);
+          }}
+          onHide={() => {
+            onHide(item.bookId);
+            setMenuOpen(false);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+const MENU_WIDTH = 184;
+const MENU_HEIGHT = 96;
+const VIEWPORT_MARGIN = 8;
+
+/* Portal-anchored menu. The rail lives in an `overflow-x-auto` strip and each
+   card is `overflow-hidden`, so an in-flow dropdown would be clipped twice over
+   — mirror the status-popover / searchable-picker pattern: portal to
+   document.body, position via the anchor's getBoundingClientRect, track
+   scroll/resize, dismiss on Escape / outside-click. */
+function CardMenu({
+  anchorRef,
+  title,
+  onClose,
+  onFinish,
+  onHide,
+}: {
+  anchorRef: React.RefObject<HTMLButtonElement | null>;
+  title: string;
+  onClose: () => void;
+  onFinish: () => void;
+  onHide: () => void;
+}) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+
+  useLayoutEffect(() => {
+    function compute() {
+      const el = anchorRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      const spillsBelow = rect.bottom + MENU_HEIGHT > window.innerHeight - VIEWPORT_MARGIN;
+      const top = spillsBelow
+        ? Math.max(VIEWPORT_MARGIN, rect.top - MENU_HEIGHT - 4)
+        : rect.bottom + 4;
+      let left = rect.right - MENU_WIDTH; // right-align to the ⋯ button
+      left = Math.min(Math.max(VIEWPORT_MARGIN, left), window.innerWidth - MENU_WIDTH - VIEWPORT_MARGIN);
+      setPos({ top, left });
+    }
+    compute();
+    window.addEventListener('scroll', compute, true);
+    window.addEventListener('resize', compute);
+    return () => {
+      window.removeEventListener('scroll', compute, true);
+      window.removeEventListener('resize', compute);
+    };
+  }, [anchorRef]);
+
+  useEffect(() => {
+    function onDown(e: MouseEvent) {
+      const t = e.target as Node;
+      if (panelRef.current?.contains(t)) return;
+      if (anchorRef.current?.contains(t)) return; // let the ⋯ button toggle
+      onClose();
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [anchorRef, onClose]);
+
+  if (typeof document === 'undefined') return null;
+
+  return createPortal(
+    <div
+      ref={panelRef}
+      role="menu"
+      tabIndex={-1}
+      aria-label={`Options for ${title}`}
+      className="fixed z-50 bg-white border border-ink/15 rounded-xl shadow-float py-1 fade-in"
+      style={{
+        top: pos?.top ?? 0,
+        left: pos?.left ?? 0,
+        width: MENU_WIDTH,
+        visibility: pos ? 'visible' : 'hidden',
+      }}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <button
+        type="button"
+        role="menuitem"
+        onClick={onFinish}
+        className="flex w-full items-center gap-2 px-3 py-2 min-h-[44px] sm:min-h-0 text-left text-sm text-ink hover:bg-ink/5 focus-visible:outline-none focus-visible:bg-ink/5"
+      >
+        <IconCheck className="w-4 h-4 text-ink/60" />
+        Mark as finished
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        onClick={onHide}
+        className="flex w-full items-center gap-2 px-3 py-2 min-h-[44px] sm:min-h-0 text-left text-sm text-ink hover:bg-ink/5 focus-visible:outline-none focus-visible:bg-ink/5"
+      >
+        <IconClose className="w-4 h-4 text-ink/60" />
+        Hide from shelf
+      </button>
+    </div>,
+    document.body,
   );
 }

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -706,6 +706,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/books/{bookId}/shelf-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Set the Continue-listening shelf flags for a book
+         * @description fs-15 shelf controls — read-modify-write the `finished` / `hidden`
+         *     flags on the book's `listen-progress.json`. Body must include at least
+         *     one boolean; setting a flag to `false` clears it. `finished` ("Mark as
+         *     finished") is sticky and counts toward library stats; `hidden` ("Hide
+         *     from shelf") only removes the book from the rail and is cleared on the
+         *     next progress save. The resume position is carried forward untouched;
+         *     a book with no prior bookmark can still be flagged (cold record).
+         */
+        post: operations["setShelfStatus"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/books/{bookId}/listen-stats": {
         parameters: {
             query?: never;
@@ -2271,6 +2297,30 @@ export interface components {
              *     pre-plan-53 records.
              */
             markers?: components["schemas"]["ListenMarker"][];
+            /**
+             * @description fs-15 shelf controls — set by POST /shelf-status when the user picks
+             *     "Mark as finished". Sticky (preserved across later progress saves);
+             *     drops the book off the Continue-listening rail AND counts it toward
+             *     the library "books finished" stat.
+             */
+            finished?: boolean;
+            /**
+             * Format: date-time
+             * @description fs-15 — server-stamped ISO time the book was marked finished.
+             */
+            finishedAt?: string;
+            /**
+             * @description fs-15 shelf controls — set by POST /shelf-status when the user picks
+             *     "Hide from shelf". Drops the book off the Continue-listening rail
+             *     WITHOUT counting it as finished, and is cleared on the next progress
+             *     save (resuming un-hides the book).
+             */
+            hidden?: boolean;
+            /**
+             * Format: date-time
+             * @description fs-15 — server-stamped ISO time the book was hidden from the shelf.
+             */
+            dismissedAt?: string;
         };
         /**
          * @description Plan 53 — user-placed bookmark inside a book. The listen-view
@@ -5001,6 +5051,49 @@ export interface operations {
                 };
             };
             /** @description Body missing chapterId or currentSec */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Book not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    setShelfStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                bookId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    finished?: boolean;
+                    hidden?: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description The updated listen-progress record with the new shelf flags */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListenProgress"];
+                };
+            };
+            /** @description Body includes neither a boolean `finished` nor a boolean `hidden` */
             400: {
                 headers: {
                     [name: string]: unknown;

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -6,6 +6,7 @@ import {
   mockPutListenStats,
   mockGetLibraryStats,
   mockGetContinueListening,
+  mockSetShelfStatus,
   _resetMockListenStats,
 } from './api';
 
@@ -87,5 +88,26 @@ describe('mock listen-stats client', () => {
   it('getContinueListening returns empty array when no seed', async () => {
     const out = await mockGetContinueListening();
     expect(out).toEqual([]);
+  });
+
+  it('setShelfStatus(finished) prunes the seeded shelf so a refetch drops the book', async () => {
+    (globalThis as any).__SEED_CONTINUE__ = [
+      { bookId: 'keep', title: 'Keep', chapterId: 1, currentSec: 90, remainingSec: 600, completionPct: 0.1, updatedAt: '2026-06-13T00:00:00Z' },
+      { bookId: 'gone', title: 'Gone', chapterId: 1, currentSec: 90, remainingSec: 600, completionPct: 0.1, updatedAt: '2026-06-13T00:00:00Z' },
+    ];
+    const rec = await mockSetShelfStatus('gone', { finished: true });
+    expect(rec.finished).toBe(true);
+    const out = await mockGetContinueListening();
+    expect(out.map((x: any) => x.bookId)).toEqual(['keep']);
+    delete (globalThis as any).__SEED_CONTINUE__;
+  });
+
+  it('setShelfStatus(hidden) also prunes the shelf', async () => {
+    (globalThis as any).__SEED_CONTINUE__ = [
+      { bookId: 'h', title: 'H', chapterId: 1, currentSec: 90, remainingSec: 600, completionPct: 0.1, updatedAt: '2026-06-13T00:00:00Z' },
+    ];
+    await mockSetShelfStatus('h', { hidden: true });
+    expect(await mockGetContinueListening()).toEqual([]);
+    delete (globalThis as any).__SEED_CONTINUE__;
   });
 });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1233,6 +1233,21 @@ export async function mockGetContinueListening() {
   return seeded ?? [];
 }
 
+/* fs-15 shelf controls — mock mirror. Marking a book finished or hiding it
+   prunes the seeded shelf so a refetch reflects the removal; clearing a flag
+   is a no-op on the seed. */
+export async function mockSetShelfStatus(
+  bookId: string,
+  body: ShelfStatusArgs,
+): Promise<ListenProgress> {
+  await wait(15);
+  const g = globalThis as unknown as { __SEED_CONTINUE__?: ContinueListeningItem[] };
+  if ((body.finished || body.hidden) && Array.isArray(g.__SEED_CONTINUE__)) {
+    g.__SEED_CONTINUE__ = g.__SEED_CONTINUE__.filter((x) => x.bookId !== bookId);
+  }
+  return { chapterId: 0, currentSec: 0, updatedAt: new Date().toISOString(), ...body };
+}
+
 export function _resetMockListenStats(): void {
   MOCK_LISTEN_STATS.clear();
 }
@@ -1914,6 +1929,17 @@ export interface ListenProgress {
   /* Plan 53. */
   playbackRate?: number;
   markers?: ListenProgressMarker[];
+  /* fs-15 shelf controls — Continue-listening flags set via setShelfStatus. */
+  finished?: boolean;
+  finishedAt?: string;
+  hidden?: boolean;
+  dismissedAt?: string;
+}
+
+/** fs-15 shelf controls — POST /shelf-status body. At least one boolean. */
+export interface ShelfStatusArgs {
+  finished?: boolean;
+  hidden?: boolean;
 }
 
 /* Plan 53 — PUT body extension. chapterId/currentSec stay required so
@@ -1980,6 +2006,20 @@ async function realGetContinueListening() {
   if (!res.ok)
     throw new Error(
       `continue-listening GET failed (${res.status}): ${(await res.text()) || res.statusText}`,
+    );
+  return res.json();
+}
+
+/* fs-15 shelf controls — mark a book finished / hide it from the rail. */
+async function realSetShelfStatus(bookId: string, body: ShelfStatusArgs): Promise<ListenProgress> {
+  const res = await fetch(`/api/books/${encodeURIComponent(bookId)}/shelf-status`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok)
+    throw new Error(
+      `shelf-status POST failed (${res.status}): ${(await res.text()) || res.statusText}`,
     );
   return res.json();
 }
@@ -6258,6 +6298,7 @@ const real = {
   putListenStats: realPutListenStats,
   getLibraryStats: realGetLibraryStats,
   getContinueListening: realGetContinueListening,
+  setShelfStatus: realSetShelfStatus,
   findCoverCandidates: realFindCoverCandidates,
   setCover: realSetCover,
   removeCover: realRemoveCover,
@@ -6514,6 +6555,7 @@ const mock = {
   putListenStats: mockPutListenStats,
   getLibraryStats: mockGetLibraryStats,
   getContinueListening: mockGetContinueListening,
+  setShelfStatus: mockSetShelfStatus,
   findCoverCandidates: mockFindCoverCandidates,
   setCover: mockSetCover,
   removeCover: mockRemoveCover,

--- a/src/store/continue-listening-slice.test.ts
+++ b/src/store/continue-listening-slice.test.ts
@@ -50,6 +50,26 @@ describe('continueListeningSlice — hydrate', () => {
   });
 });
 
+describe('continueListeningSlice — dismiss', () => {
+  it('removes the matching book and leaves the rest', () => {
+    const start = continueListeningSlice.reducer(
+      empty(),
+      continueListeningActions.hydrate([item({ bookId: 'b1' }), item({ bookId: 'b2' })]),
+    );
+    const next = continueListeningSlice.reducer(start, continueListeningActions.dismiss('b1'));
+    expect(next.items.map((i) => i.bookId)).toEqual(['b2']);
+  });
+
+  it('is a no-op when the bookId is not on the shelf', () => {
+    const start = continueListeningSlice.reducer(
+      empty(),
+      continueListeningActions.hydrate([item({ bookId: 'b1' })]),
+    );
+    const next = continueListeningSlice.reducer(start, continueListeningActions.dismiss('nope'));
+    expect(next.items.map((i) => i.bookId)).toEqual(['b1']);
+  });
+});
+
 describe('selectContinueListening', () => {
   it('returns items when slice is present', () => {
     const items = [item()];

--- a/src/store/continue-listening-slice.ts
+++ b/src/store/continue-listening-slice.ts
@@ -29,6 +29,13 @@ export const continueListeningSlice = createSlice({
     hydrate: (s, a: PayloadAction<ContinueItem[]>) => {
       s.items = a.payload;
     },
+    /** fs-15 shelf controls — optimistically drop one book from the shelf
+        (after the user marks it finished or hides it). The server fetch on the
+        next mount is the source of truth; this just makes the card vanish
+        immediately. */
+    dismiss: (s, a: PayloadAction<string>) => {
+      s.items = s.items.filter((i) => i.bookId !== a.payload);
+    },
   },
 });
 

--- a/src/views/book-library.tsx
+++ b/src/views/book-library.tsx
@@ -26,6 +26,7 @@ import { useAppSelector, useAppDispatch } from '../store';
 import { startLinearTour } from '../store/tour-slice';
 import { uiActions } from '../store/ui-slice';
 import { continueListeningActions, selectContinueListening } from '../store/continue-listening-slice';
+import { notificationsActions } from '../store/notifications-slice';
 import { useDebouncedValue } from '../lib/use-debounced-value';
 import {
   LibraryChrome,
@@ -141,6 +142,32 @@ export function BookLibraryView({
       }),
     );
   };
+
+  /* fs-15 shelf controls — optimistically drop the card, then persist via
+     api.setShelfStatus. On failure, re-fetch the shelf to restore truth and
+     surface an error toast. */
+  const applyShelfStatus = (
+    bookId: string,
+    body: { finished?: boolean; hidden?: boolean },
+    okMessage: string,
+    failMessage: string,
+  ) => {
+    dispatch(continueListeningActions.dismiss(bookId));
+    api
+      .setShelfStatus(bookId, body)
+      .then(() => dispatch(notificationsActions.pushToast({ kind: 'info', message: okMessage })))
+      .catch(() => {
+        dispatch(notificationsActions.pushToast({ kind: 'error', message: failMessage }));
+        api
+          .getContinueListening()
+          .then((items) => dispatch(continueListeningActions.hydrate(items)))
+          .catch(() => {});
+      });
+  };
+  const handleFinishContinue = (bookId: string) =>
+    applyShelfStatus(bookId, { finished: true }, 'Marked as finished.', "Couldn't mark as finished.");
+  const handleHideContinue = (bookId: string) =>
+    applyShelfStatus(bookId, { hidden: true }, 'Hidden from Continue listening.', "Couldn't hide this book.");
   const [filter, setFilter] = useState<Filter>('all');
   /* Plan 73 — raw input fires every keystroke, debouncedSearch lags by
      ~150ms so the filter chain doesn't re-run mid-word. activeTags is
@@ -219,6 +246,13 @@ export function BookLibraryView({
   const allBooks = useMemo(
     () => authors.flatMap((a) => a.series.flatMap((s) => s.books)),
     [authors],
+  );
+  /* fs-15 — bookId → cover URL, so the Continue-listening rail can show real
+     covers (it gets only ids from the listen-progress aggregate). Missing entry
+     ⇒ the rail falls back to its gradient placeholder. */
+  const coversByBookId = useMemo(
+    () => Object.fromEntries(allBooks.map((b) => [b.bookId, b.coverImageUrl] as const)),
+    [allBooks],
   );
   const totals = {
     books: allBooks.length,
@@ -318,7 +352,13 @@ export function BookLibraryView({
         toggleLanguage={toggleLanguage}
         clearFilters={clearFilters}
       />
-      <ContinueListeningRail items={continueListeningItems} onOpen={handleOpenContinue} />
+      <ContinueListeningRail
+        items={continueListeningItems}
+        covers={coversByBookId}
+        onOpen={handleOpenContinue}
+        onFinish={handleFinishContinue}
+        onHide={handleHideContinue}
+      />
       {showNoResults ? (
         <NoResults onClear={clearFilters} />
       ) : effectiveViewMode === 'card' ? (


### PR DESCRIPTION
## Summary

Follow-up polish on the fs-15 Continue-listening rail (plan
[213](docs/features/213-continue-listening-shelf-controls.md)), fixing four
issues reported on the Books view in dark mode:

1. **Covers** — the rail now renders each book's real cover art (threaded from
   the library slice as a `bookId → coverImageUrl` map), with the gradient
   placeholder as fallback on a missing URL **and** on `<img>` error. No
   server/openapi change.
2. **Dark-mode scrollbar** — the horizontal strip uses the theme-aware
   `.scrollbar-thin` utility (clip-path neutralised so it can't clip the cards'
   hover shadow / focus ring) instead of the default OS scrollbar.
3. **Auto-hide completed** — books consumed to the end now drop off the rail
   automatically, including the "0:00 left" cards whose resume bookmark sat in a
   non-listenable trailing chapter. New `isEffectivelyComplete` + an
   explicit-flag-aware `isFinished` in the server aggregator;
   `buildContinueListening` also excludes hidden books and books with no
   listenable audio.
4. **Finish / Hide controls** — a per-card ⋯ menu offers **Mark as finished**
   (sticky, counts toward the fs-16 "books finished" stat — e.g. when progress
   sync failed) and **Hide from shelf** (dismiss without claiming completion;
   un-hides on the next resume). Persisted via
   `POST /api/books/{id}/shelf-status` on `listen-progress.json`; the existing
   `PUT /listen-progress` now **merges** rather than clobbers the flags. The
   menu is a portal-anchored popover (an in-flow dropdown would be clipped by
   the `overflow-x-auto` strip + the card's `overflow-hidden`).

## Test plan

- `npm run verify` — green locally (lint, typecheck, all unit/integration
  tiers, e2e + visual, build).
- New / updated tests:
  - `server/.../listen-stats-aggregate.test.ts` — auto-hide / finished / hidden,
    incl. the "0:00 left" leak repro.
  - `server/.../book-state.test.ts` — `shelf-status` route + **PUT-merge
    regression** (finished sticky, hidden cleared on resume).
  - `src/store/continue-listening-slice.test.ts` — `dismiss`.
  - `src/lib/api.test.ts` — mock `setShelfStatus` prunes the seeded shelf.
  - `src/components/library/continue-listening-rail.test.tsx` — cover + fallback,
    scrollbar class, ⋯ menu finish / hide / Escape.
  - `e2e/listening-stats.spec.ts` — finish-via-menu removes the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
