### PR TITLE
fix(frontend): count distinct chapters in drift banner + report headers

### DIFF
--- a/src/modals/drift-report.test.tsx
+++ b/src/modals/drift-report.test.tsx
@@ -624,6 +624,39 @@ describe('DriftReportModal — consolidated (book × character × snapshot) grou
     expect(screen.getAllByTestId(/^drift-group-/).length).toBeGreaterThanOrEqual(2);
   });
 
+  it('counts a chapter once when two different cast members drift in it', () => {
+    /* The Everblaze bug: chapter 5 drifts for BOTH Eliza and Sten — two
+       separate per-character groups. Pre-fix the header summed each group's
+       chapter list → "2 chapters flagged" for what is a single regeneration
+       (regenerating chapter 5 clears drift for all cast in it). Must read 1. */
+    render(
+      <DriftReportModal
+        groupsByBook={[
+          group([
+            makeEvent({
+              id: 'drift:book-A:5:eliza:voice',
+              characterId: 'eliza',
+              chapterId: 5,
+              snapshot: { voiceId: 'eliza-old', tone: { warmth: 40, pace: 50 }, attributes: [] },
+            }),
+            makeEvent({
+              id: 'drift:book-A:5:sten:voice',
+              characterId: 'sten',
+              chapterId: 5,
+              snapshot: { voiceId: 'sten-old', tone: { warmth: 60, pace: 50 }, attributes: [] },
+            }),
+          ]),
+        ]}
+        onClose={vi.fn()}
+        onRegenerateChapter={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    /* Header dedupes across characters → 1, even though there are 2 cards. */
+    expect(screen.getByText(/1 chapter flagged/)).toBeInTheDocument();
+    expect(screen.getAllByTestId(/^drift-group-/).length).toBeGreaterThanOrEqual(2);
+  });
+
   /* Regression for the Voice Drift Detector "duplicated chapter rows"
      bug — multi-factor events on the same chapter must collapse to one
      row in the chapter strip, and the header count must reflect unique

--- a/src/modals/drift-report.tsx
+++ b/src/modals/drift-report.tsx
@@ -5,7 +5,11 @@ import { CHAR_COLORS } from '../lib/colors';
 import { stripChapterPrefix } from '../lib/format-chapter-title';
 import { api } from '../lib/api';
 import { useAppSelector } from '../store';
-import type { DriftGroup, DriftChapterEntry } from '../store/revisions-slice';
+import {
+  distinctDriftChapterCount,
+  type DriftGroup,
+  type DriftChapterEntry,
+} from '../store/revisions-slice';
 import type { DriftEvent, Character, CharColor, Voice } from '../lib/types';
 
 /* The modal renders one card per `(book × character × snapshot)` group
@@ -107,14 +111,14 @@ export function DriftReportModal({
   const filterCharacterName = filterCharacterId
     ? findFilterCharacterName(groupsByBook, filterCharacterId)
     : null;
-  /* Total = unique flagged chapters across every visible group. Pre-
-     correction (plan 91 archive) this counted per-factor events, which
-     inflated the "{N} chapters flagged" label whenever the server
-     emitted multiple drift factors for the same chapter (voice + tone
-     + attributes on the same Marlow chapter → 3× count). */
-  const totalCount = visibleGroupsByBook.reduce(
-    (acc, g) => acc + g.groups.reduce((sub, gr) => sub + gr.chapters.length, 0),
-    0,
+  /* Total = unique flagged chapters across every visible group. Dedupe by
+     (book, chapter): a chapter can drift for several cast members AND several
+     factors, but regenerating it clears all of them, so it counts once.
+     Summing per-character `chapters.length` (the prior shape) double-counted a
+     chapter shared by two characters; counting raw events also multiplied by
+     factor. distinctDriftChapterCount collapses both dimensions. */
+  const totalCount = distinctDriftChapterCount(
+    visibleGroupsByBook.flatMap((g) => g.groups.flatMap((gr) => gr.events)),
   );
   /* Edge case: filter is set but the matching character has zero
      chapters (race between dispatch + drift slice update). Render
@@ -219,7 +223,7 @@ function DriftBookSection({
     return acc;
   }, [view.groups]);
   const totalChapters = useMemo(
-    () => view.groups.reduce((acc, g) => acc + g.chapters.length, 0),
+    () => distinctDriftChapterCount(view.groups.flatMap((g) => g.events)),
     [view.groups],
   );
   const findChar = (id: string) => view.characters.find((c) => c.id === id);

--- a/src/store/revisions-slice.test.ts
+++ b/src/store/revisions-slice.test.ts
@@ -6,6 +6,7 @@ import {
   revisionsActions,
   selectDriftByBook,
   selectDriftGroupsByBook,
+  distinctDriftChapterCount,
 } from './revisions-slice';
 import type { Revision, DriftEvent, RevisionsResponse } from '../lib/types';
 
@@ -38,6 +39,38 @@ describe('revisionsSlice — initial state', () => {
       timeline: {},
       loaded: false,
     });
+  });
+});
+
+describe('distinctDriftChapterCount — headline count dedupes to chapters', () => {
+  it('counts a chapter once even when multiple cast members drift in it', () => {
+    /* The real-world bug: chapter 5 has Halloran AND Marcus drifting. Raw
+       event count = 2, but regenerating chapter 5 clears both → 1 chapter. */
+    const events = [
+      drift('d1', { chapterId: 5, characterId: 'halloran' }),
+      drift('d2', { chapterId: 5, characterId: 'marcus' }),
+    ];
+    expect(distinctDriftChapterCount(events)).toBe(1);
+  });
+
+  it('counts a chapter once even when one character drifts on multiple factors', () => {
+    const events = [
+      drift('d1', { chapterId: 7, characterId: 'eliza', factor: 'register' }),
+      drift('d2', { chapterId: 7, characterId: 'eliza', factor: 'pace' }),
+    ];
+    expect(distinctDriftChapterCount(events)).toBe(1);
+  });
+
+  it('keeps the same chapter number distinct across books', () => {
+    const events = [
+      drift('d1', { bookId: 'book-A', chapterId: 3 }),
+      drift('d2', { bookId: 'book-B', chapterId: 3 }),
+    ];
+    expect(distinctDriftChapterCount(events)).toBe(2);
+  });
+
+  it('returns 0 for no events', () => {
+    expect(distinctDriftChapterCount([])).toBe(0);
   });
 });
 

--- a/src/store/revisions-slice.ts
+++ b/src/store/revisions-slice.ts
@@ -476,6 +476,19 @@ export function groupDriftEvents(events: DriftEvent[]): DriftGroup[] {
   });
 }
 
+/* Count of DISTINCT flagged chapters across a set of drift events.
+
+   Drift's unit of action is the chapter: regenerating a chapter clears
+   drift for EVERY cast member in it. So every "{N} chapters" headline must
+   dedupe to unique `(book, chapter)` pairs — counting raw events (which are
+   chapter × character × factor) over-reports whenever a chapter has more than
+   one drifting character, or one character drifts on multiple factors. Keyed
+   by `bookId|chapterId` so the same chapter number in two books stays
+   distinct. */
+export function distinctDriftChapterCount(events: DriftEvent[]): number {
+  return new Set(events.map((e) => `${e.bookId ?? ''}|${e.chapterId}`)).size;
+}
+
 /* Selector: collapse the flat drift list into `(book × character ×
    snapshot)` groups. Replaces the per-event card render in the Drift
    Report modal — 300 events typically collapse to ~6–18 groups because

--- a/src/views/cast.test.tsx
+++ b/src/views/cast.test.tsx
@@ -18,7 +18,7 @@ import { voicesSlice } from '../store/voices-slice';
 import { CastView, compareCastRows } from './cast';
 import { playSampleWithAutoLoad } from '../lib/play-sample-with-auto-load';
 import { api } from '../lib/api';
-import type { Character, Voice, TtsModelKey, Sentence } from '../lib/types';
+import type { Character, Voice, TtsModelKey, Sentence, DriftEvent } from '../lib/types';
 
 vi.mock('../lib/api', () => ({
   api: {
@@ -914,6 +914,52 @@ describe('CastView drift pill — per-character entry to the Voice Drift Detecto
     fireEvent.click(pills[0]);
     expect(onShowDrift).toHaveBeenCalledTimes(1);
     expect(onShowDrift).toHaveBeenCalledWith('narrator');
+  });
+
+  it('banner counts DISTINCT chapters, not raw drift events', () => {
+    /* The Everblaze bug: two characters drift in the SAME chapter. Raw event
+       count = 2, but regenerating the chapter clears both, so the banner —
+       and each character's row pill — must report 1 chapter, not 2. */
+    const store = configureStore({
+      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, castDesign: castDesignSlice.reducer },
+    });
+    const mkDrift = (characterId: string, factor: string): DriftEvent =>
+      ({
+        id: `d:${characterId}:${factor}`,
+        bookId: 'b1',
+        characterId,
+        chapterId: 2,
+        chapterTitle: 'Chapter 2',
+        severity: 'severe',
+        factor,
+        factorLabel: factor,
+        description: 'drift',
+        autoQueueable: true,
+        detected: '2026-01-01T00:00:00Z',
+        suggestedAction: 'regenerate_chapter',
+      }) as unknown as DriftEvent;
+    render(
+      <Provider store={store}>
+        <CastView
+          characters={[{ ...narrator, id: 'narrator' }, marrow]}
+          setCharacters={() => {}}
+          library={library}
+          title="The Northern Star"
+          onOpenProfile={() => {}}
+          onShowMatchDetail={() => {}}
+          driftEvents={[
+            mkDrift('narrator', 'voice'),
+            mkDrift('narrator', 'pace'),
+            mkDrift('marrow', 'voice'),
+          ]}
+          onShowDrift={() => {}}
+        />
+      </Provider>,
+    );
+    /* Banner: 3 events across 2 characters + 2 factors, all in chapter 2 → 1. */
+    expect(screen.getByText(/Voice drift detected in 1 chapter\b/)).toBeInTheDocument();
+    /* narrator's row pill: 2 factor-events, 1 chapter. */
+    expect(screen.getAllByTitle(/1 chapter with voice drift/).length).toBeGreaterThan(0);
   });
 });
 

--- a/src/views/cast.tsx
+++ b/src/views/cast.tsx
@@ -39,6 +39,7 @@ import type {
 import { useAppSelector, useAppDispatch } from '../store';
 import { voicesActions } from '../store/voices-slice';
 import { castDesignActions } from '../store/cast-design-slice';
+import { distinctDriftChapterCount } from '../store/revisions-slice';
 import { useSamplePlayback } from '../lib/use-sample-playback';
 import { playSampleWithAutoLoad } from '../lib/play-sample-with-auto-load';
 import { sampleScopeFor } from '../lib/sample-scope';
@@ -231,7 +232,11 @@ export function CastView({
       prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
     );
   const driftByChar = (id: string) => driftEvents.filter((d) => d.characterId === id);
-  const totalDriftEvents = driftEvents.length;
+  /* Headline + per-row counts are DISTINCT chapters, not raw events: a chapter
+     can drift for several cast members (or several factors), but regenerating
+     it clears all of them, so the actionable unit is the chapter. */
+  const driftChapterCountFor = (id: string) => distinctDriftChapterCount(driftByChar(id));
+  const totalDriftChapters = distinctDriftChapterCount(driftEvents);
   const findVoice = (id?: string) => library.find((v) => v.id === id);
   /* A character's effective engine = its per-character override, else the
      project default. Qwen is the only override that diverges from the project
@@ -661,7 +666,7 @@ export function CastView({
           </div>
         )}
 
-        {totalDriftEvents > 0 && (
+        {totalDriftChapters > 0 && (
           <button
             onClick={() => onShowDrift()}
             className="w-full mb-4 p-4 rounded-3xl border border-amber-200 bg-amber-50/60 hover:bg-amber-50 transition-colors flex items-center gap-4 text-left"
@@ -671,8 +676,8 @@ export function CastView({
             </span>
             <div className="flex-1 min-w-0">
               <p className="text-sm font-bold text-ink">
-                Voice drift detected in {totalDriftEvents} chapter
-                {totalDriftEvents === 1 ? '' : 's'}
+                Voice drift detected in {totalDriftChapters} chapter
+                {totalDriftChapters === 1 ? '' : 's'}
               </p>
               <p className="text-xs text-ink/65 mt-0.5">
                 Some chapters have voices that don't match their established profiles. Click to
@@ -828,9 +833,9 @@ export function CastView({
                   <span className="min-w-0">
                     <span className="flex items-center gap-1.5">
                       <span className="font-semibold text-ink truncate">{c.name}</span>
-                      {driftByChar(c.id).length > 0 && (
+                      {driftChapterCountFor(c.id) > 0 && (
                         <span
-                          title={`${driftByChar(c.id).length} chapter${driftByChar(c.id).length === 1 ? '' : 's'} with voice drift`}
+                          title={`${driftChapterCountFor(c.id)} chapter${driftChapterCountFor(c.id) === 1 ? '' : 's'} with voice drift`}
                           onClick={(e) => {
                             e.stopPropagation();
                             onShowDrift(c.id);
@@ -838,7 +843,7 @@ export function CastView({
                           className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 text-[10px] font-bold"
                         >
                           <IconAlertTri className="w-2.5 h-2.5" />
-                          {driftByChar(c.id).length}
+                          {driftChapterCountFor(c.id)}
                         </span>
                       )}
                     </span>
@@ -1026,9 +1031,9 @@ export function CastView({
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-1.5 flex-wrap">
                       <span className="font-semibold text-ink truncate">{c.name}</span>
-                      {driftByChar(c.id).length > 0 && (
+                      {driftChapterCountFor(c.id) > 0 && (
                         <span
-                          title={`${driftByChar(c.id).length} chapter${driftByChar(c.id).length === 1 ? '' : 's'} with voice drift`}
+                          title={`${driftChapterCountFor(c.id)} chapter${driftChapterCountFor(c.id) === 1 ? '' : 's'} with voice drift`}
                           onClick={(e) => {
                             e.stopPropagation();
                             onShowDrift(c.id);
@@ -1036,7 +1041,7 @@ export function CastView({
                           className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 text-[10px] font-bold"
                         >
                           <IconAlertTri className="w-2.5 h-2.5" />
-                          {driftByChar(c.id).length}
+                          {driftChapterCountFor(c.id)}
                         </span>
                       )}
                     </div>


### PR DESCRIPTION
## Summary
The Cast drift banner ("Voice drift detected in N chapters"), the per-row drift pill, and the Drift Report modal headers all counted drift **events** (chapter × character × factor) while labelling them "chapters." On Everblaze this inflated the headline to **547**. Drift's unit of action is the chapter — regenerating it clears drift for every cast member in it — so the count must dedupe to distinct `(book, chapter)` pairs.

New pure helper `distinctDriftChapterCount(events)` (keyed by `bookId|chapterId`) wired into all four counters: banner, per-row pill, modal aggregate header, per-book header. The modal had already collapsed the per-factor dimension (plan 91) but still summed per-character, double-counting a chapter shared by 2+ cast. The mock fixture never caught this because each of its chapters has exactly one drifting character.

## Test plan
- `distinctDriftChapterCount` unit tests: cross-character, multi-factor, multi-book, empty
- Drift modal regression: a chapter drifting for two characters reads "1 chapter flagged" (was 2)
- Cast banner regression: 3 events across 2 characters + 2 factors in one chapter reads "1 chapter"
- Full frontend suite green (2836 tests); typecheck + ESLint + `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)