### PR TITLE
build(mocks,e2e): pose Continue Listening rail in marketing capture set

### DIFF
--- a/docs/superpowers/specs/2026-06-14-marketing-continue-listening-capture-design.md
+++ b/docs/superpowers/specs/2026-06-14-marketing-continue-listening-capture-design.md
@@ -1,0 +1,162 @@
+# Marketing capture: Continue Listening rail
+
+- **Status:** draft
+- **Date:** 2026-06-14
+- **Area:** frontend / marketing capture harness
+- **Branch:** `feat/frontend-marketing-continue-listening`
+
+## Problem
+
+The cross-book **Continue Listening** rail (fs-15, `src/components/library/continue-listening-rail.tsx`)
+ships on the front (library) screen but has never appeared in a marketing
+screenshot. Cause: the rail renders `null` when it has no items
+(`continue-listening-rail.tsx:29`), and its data comes from
+`api.getContinueListening()`, whose mock (`api.ts:1230`) only returns whatever is
+in `globalThis.__SEED_CONTINUE__`. The demo-capture path
+(`VITE_DEMO_CAPTURE=1`) never seeds it, so under `npm run capture:marketing` the
+call returns `[]` and the rail silently disappears — even though the posed stats
+say "In Progress 2". The committed `library-shelf.*.png` jumps straight from the
+stats/filters to the book grid.
+
+## Goal
+
+Make the Continue Listening rail appear in the marketing set, populated with our
+own manuscripts, with real covers and varied progress — so the captured images
+honestly represent the product.
+
+## Non-goals
+
+- No change to the rail component, the real backend, or normal mock mode.
+- No change to the `formatDuration` output format (see Decision D1).
+- No companion (Android) marketing capture work — that path is separate.
+
+## Design
+
+### 1. Posed fixture
+
+Add a `HOLLOW_TIDE_CONTINUE: ContinueListeningItem[]` export to
+`src/mocks/marketing/hollow-tide.ts` (type imported from `../../lib/types`).
+Three items, array order = on-screen order (the slice's `hydrate` does **not**
+sort — `continue-listening-slice.ts:29`), `updatedAt` descending to also match
+the OpenAPI ordering contract:
+
+| # | bookId | title | chapterId | completionPct | remainingSec | renders as |
+|---|---|---|---|---|---|---|
+| 1 | `hollow-tide-1` | The Drowning Bell | 11 | 0.92 | 2040 | `Ch 11 · 34:00 left` |
+| 2 | `coalfall-commission` | The Coalfall Commission | 3 | 0.28 | 6960 | `Ch 3 · 01:56:00 left` |
+| 3 | `hollow-tide-2` | Saltgrave | 2 | 0.15 | 19260 | `Ch 2 · 05:21:00 left` |
+
+`currentSec` set to plausible in-chapter offsets (display-irrelevant but
+required by the schema). The set excludes `hollow-tide-3` (The Tidewatcher's
+Oath) because it is only *analysing* — no generated audio, so a listen-resume
+entry would misrepresent the feature. The 92% first card tells the
+"started the next book before finishing the first" story.
+
+Covers come free: the rail's `covers` prop is `coversByBookId`
+(`book-library.tsx:253`), built from `allBooks` → `coverImageUrl`, and all three
+books set `coverImageUrl` in `HOLLOW_TIDE_LIBRARY`.
+
+### 2. Mock wiring
+
+Add a `DEMO_CAPTURE` branch at the top of `mockGetContinueListening`
+(`api.ts:1230`), returning a **fresh copy** so Immer's freeze of the `hydrate`
+payload can't poison a re-fetch:
+
+```ts
+export async function mockGetContinueListening() {
+  await wait(15);
+  if (DEMO_CAPTURE) return HOLLOW_TIDE_CONTINUE.map((x) => ({ ...x }));
+  const seeded = (globalThis as ...).__SEED_CONTINUE__;
+  return seeded ?? [];
+}
+```
+
+`HOLLOW_TIDE_CONTINUE` joins the existing marketing-fixture import block
+(`api.ts:60`). The `__SEED_CONTINUE__` path is untouched, so the existing
+`api.test.ts` seed tests stay green (the branch only fires under capture).
+
+### 3. Scene registry + harness
+
+Extend `Scene` (`e2e/marketing/scenes.ts`) with two optional fields:
+
+- `scrollTo?: string` — selector to `scrollIntoView({ block: 'center' })` before
+  the shot (viewport stays the frame, but the target is centred).
+- `fullPage?: boolean` — per-scene full-page capture.
+
+In `capture.spec.ts`: after the `waitFor` block and before the theme loop, if
+`scene.scrollTo` is set, `await page.locator(scene.scrollTo).evaluate(el =>
+el.scrollIntoView({ block: 'center' }))`. Change the screenshot's `fullPage` to
+`scene.fullPage ?? process.env.CAPTURE_FULLPAGE === '1'`. Both fields are
+optional, so every existing scene captures byte-identically.
+
+### 4. New scenes
+
+Two new rows in `SCENES`; the existing `library-shelf` brand hero is left
+untouched.
+
+```ts
+{
+  id: 'continue-listening',
+  hash: '#/',
+  viewports: ['desktop', 'phone', 'tablet'],
+  waitFor: 'section[aria-label="Continue listening"]',
+  scrollTo: 'section[aria-label="Continue listening"]',
+},
+{
+  id: 'library-shelf-full',
+  hash: '#/',
+  viewports: ['desktop'],
+  waitFor: 'section[aria-label="Continue listening"]',
+  fullPage: true,
+},
+```
+
+- `continue-listening` — the rail as a real product screen with app chrome
+  above/below, across all three widths (phone/tablet prove the snap-scroll
+  shelf). 6 PNGs (3 viewports × light/dark).
+- `library-shelf-full` — the honest full front screen, desktop only (full-page
+  phone/tablet would be absurdly tall). 2 PNGs. This is what literally closes
+  the original "front screen has no rail" complaint.
+
+Output (all to git-ignored `mockups/marketing-screens/`):
+`continue-listening.{desktop,phone,tablet}.{light,dark}.png`,
+`library-shelf-full.desktop.{light,dark}.png`.
+
+Run: `CAPTURE_SCENE=continue-listening npm run capture:marketing` (add
+`--project=phone --project=tablet` for the small widths) and
+`CAPTURE_SCENE=library-shelf-full npm run capture:marketing`.
+
+## Testing
+
+Add a case to `src/mocks/marketing/hollow-tide.test.ts` asserting on the
+exported `HOLLOW_TIDE_CONTINUE` constant directly (the `api.ts` `DEMO_CAPTURE`
+branch can't be exercised through the api function under vitest, since the
+module const reads `import.meta.env.VITE_DEMO_CAPTURE`, which isn't `'1'` in the
+test env):
+
+- exactly 3 items;
+- each is shape-valid against `ContinueListeningItem` (required keys present);
+- every `bookId` exists in `HOLLOW_TIDE_BOOK_STATES`;
+- none is `hollow-tide-3` (no audio);
+- `updatedAt` is strictly descending;
+- the first item's `completionPct` is `0.92`.
+
+The capture spec's inline registry guard already covers the two new scenes'
+`#/`-prefixed, unique-id rows. The marketing capture is not a regression gate,
+so no e2e baseline is added.
+
+## Decisions / risks
+
+- **D1 — remaining-time format accepted as-is.** `formatDuration` renders
+  `MM:SS` / `HH:MM:SS`. The 92% first card is under an hour so it shows `34:00`
+  while the others show `HH:MM:SS` — mildly inconsistent for the hero card, and
+  "34:00" is slightly ambiguous in isolation, but the 92% progress bar carries
+  the meaning. Changing the format would mean editing the rail component
+  (out of scope), so we accept it.
+- **D2 — Saltgrave `completionPct` is of the full book.** 0.15 of 6h18m while
+  only 7/11 chapters have audio; "05:21:00 left" implies the whole book. Fine
+  for a posed shot (you're in Ch 2, inside the generated range).
+- **D3 — existing `library-shelf.png` left stale.** Not re-captured, so it keeps
+  its rail-less top-of-page frame. A future full `capture:marketing` run would
+  re-render it with the rail near the fold; harmless, since these are
+  git-ignored working artifacts, not regression baselines.

--- a/e2e/marketing/capture.spec.ts
+++ b/e2e/marketing/capture.spec.ts
@@ -66,6 +66,15 @@ for (const scene of SCENES) {
     }
     await waitForImages(page);
 
+    /* Frame a below-the-fold region (e.g. the continue-listening rail). Non-fatal
+       — a missing target shouldn't abort the run. */
+    if (scene.scrollTo) {
+      await page
+        .locator(scene.scrollTo)
+        .evaluate((el) => el.scrollIntoView({ block: 'center' }))
+        .catch(() => {});
+    }
+
     /* Capture each requested theme. The app's default theme preference is
        "system", so emulating `prefers-color-scheme` re-themes it without any
        app change. Default: both light + dark; `CAPTURE_THEME=light|dark` limits
@@ -78,7 +87,7 @@ for (const scene of SCENES) {
       await page.waitForTimeout(400); // settle the theme re-render
       await page.screenshot({
         path: resolve(OUT, `${scene.id}.${vp}.${theme}.png`),
-        fullPage: process.env.CAPTURE_FULLPAGE === '1',
+        fullPage: scene.fullPage ?? process.env.CAPTURE_FULLPAGE === '1',
       });
     }
   });

--- a/e2e/marketing/scenes.ts
+++ b/e2e/marketing/scenes.ts
@@ -14,6 +14,11 @@ export interface Scene {
   viewports?: Viewport[];
   /** Optional selector to await before the shot (ensures the view painted). */
   waitFor?: string;
+  /** Optional selector to scrollIntoView({block:'center'}) before the shot, so a
+      below-the-fold region (e.g. the continue-listening rail) is framed. */
+  scrollTo?: string;
+  /** Capture the full scrollable page instead of just the viewport. */
+  fullPage?: boolean;
 }
 
 export const SCENES: Scene[] = [
@@ -50,6 +55,24 @@ export const SCENES: Scene[] = [
     hash: '#/books/hollow-tide-1/listen',
     viewports: ['desktop', 'phone', 'tablet'],
     waitFor: '[data-testid="listen-cover-art"]',
+  },
+  {
+    /* Cross-book "Continue listening" rail (fs-15), posed from our manuscripts.
+       Scrolled to centre so the rail is the hero with app chrome around it. */
+    id: 'continue-listening',
+    hash: '#/',
+    viewports: ['desktop', 'phone', 'tablet'],
+    waitFor: 'section[aria-label="Continue listening"]',
+    scrollTo: 'section[aria-label="Continue listening"]',
+  },
+  {
+    /* The honest full front screen — the rail in context below the stats/grid.
+       Full-page (desktop only; phone/tablet full-page would be absurdly tall). */
+    id: 'library-shelf-full',
+    hash: '#/',
+    viewports: ['desktop'],
+    waitFor: 'section[aria-label="Continue listening"]',
+    fullPage: true,
   },
   {
     id: 'account',

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -62,6 +62,7 @@ import {
   HOLLOW_TIDE_BOOK_STATES,
   HOLLOW_TIDE_POSED,
   HOLLOW_TIDE_VOICES,
+  HOLLOW_TIDE_CONTINUE,
   COALFALL_VOICES,
 } from '../mocks/marketing/hollow-tide';
 import { MOCK_BASE_VOICES, MOCK_VOICE_LIBRARY } from '../mocks/voices';
@@ -1229,6 +1230,9 @@ export async function mockGetLibraryStats() {
 
 export async function mockGetContinueListening() {
   await wait(15);
+  // Marketing capture: pose the rail from our manuscripts. Fresh copies, since
+  // the slice's hydrate freezes its payload via Immer.
+  if (DEMO_CAPTURE) return HOLLOW_TIDE_CONTINUE.map((x) => ({ ...x }));
   const seeded = (globalThis as unknown as { __SEED_CONTINUE__?: ContinueListeningItem[] }).__SEED_CONTINUE__;
   return seeded ?? [];
 }

--- a/src/mocks/marketing/hollow-tide.test.ts
+++ b/src/mocks/marketing/hollow-tide.test.ts
@@ -4,6 +4,7 @@ import {
   HOLLOW_TIDE_BOOK_STATES,
   HOLLOW_TIDE_POSED,
   HOLLOW_TIDE_VOICES,
+  HOLLOW_TIDE_CONTINUE,
 } from './hollow-tide';
 
 describe('Hollow Tide marketing fixtures', () => {
@@ -56,6 +57,42 @@ describe('Hollow Tide marketing fixtures', () => {
       for (const series of author.series)
         for (const book of series.books)
           expect(HOLLOW_TIDE_BOOK_STATES.has(book.bookId)).toBe(true);
+  });
+
+  describe('HOLLOW_TIDE_CONTINUE', () => {
+    it('poses exactly three resume cards', () => {
+      expect(HOLLOW_TIDE_CONTINUE).toHaveLength(3);
+    });
+
+    it('every item is shape-valid against ContinueListeningItem', () => {
+      for (const item of HOLLOW_TIDE_CONTINUE) {
+        expect(typeof item.bookId).toBe('string');
+        expect(typeof item.title).toBe('string');
+        expect(typeof item.chapterId).toBe('number');
+        expect(typeof item.currentSec).toBe('number');
+        expect(typeof item.remainingSec).toBe('number');
+        expect(item.completionPct).toBeGreaterThanOrEqual(0);
+        expect(item.completionPct).toBeLessThanOrEqual(1);
+        expect(() => new Date(item.updatedAt).toISOString()).not.toThrow();
+      }
+    });
+
+    it('only features books that exist and have generated audio', () => {
+      for (const item of HOLLOW_TIDE_CONTINUE) {
+        expect(HOLLOW_TIDE_BOOK_STATES.has(item.bookId)).toBe(true);
+        // hollow-tide-3 is still analysing — a resume card would misrepresent it.
+        expect(item.bookId).not.toBe('hollow-tide-3');
+      }
+    });
+
+    it('is ordered most-recently-updated first', () => {
+      const times = HOLLOW_TIDE_CONTINUE.map((i) => new Date(i.updatedAt).getTime());
+      for (let i = 1; i < times.length; i++) expect(times[i]).toBeLessThan(times[i - 1]);
+    });
+
+    it('leads with the nearly-finished book (92%)', () => {
+      expect(HOLLOW_TIDE_CONTINUE[0].completionPct).toBe(0.92);
+    });
   });
 
   describe('HOLLOW_TIDE_VOICES', () => {

--- a/src/mocks/marketing/hollow-tide.ts
+++ b/src/mocks/marketing/hollow-tide.ts
@@ -1,6 +1,12 @@
 /* Capture-only marketing fixtures (VITE_DEMO_CAPTURE=1). Additive — never
    served in normal mock mode, so this touches no existing spec. */
-import type { LibraryResponse, BookStateResponse, Character, Sentence } from '../../lib/types';
+import type {
+  LibraryResponse,
+  BookStateResponse,
+  Character,
+  Sentence,
+  ContinueListeningItem,
+} from '../../lib/types';
 import type { CoverFraming } from '../../lib/cover-framing';
 import coalfallCastJson from './coalfall-cast.json';
 import coalfallManuscriptJson from './coalfall-manuscript.json';
@@ -413,6 +419,47 @@ export const HOLLOW_TIDE_LIBRARY: LibraryResponse = {
     },
   ],
 };
+
+/* ── Continue-listening shelf fixture (served under VITE_DEMO_CAPTURE=1) ──
+   Posed so the front-screen rail finally shows in marketing shots. Array order
+   IS the on-screen order (the slice doesn't re-sort); updatedAt is also kept
+   descending to match the OpenAPI "most-recently-updated first" contract.
+
+   Only books with generated audio belong here — hollow-tide-3 is still
+   analysing, so it's excluded. The 92%-through Drowning Bell as the first card
+   tells the "dipped into the next book before finishing the first" story.
+
+   remainingSec renders via formatDuration (MM:SS / HH:MM:SS):
+     2040 → "34:00", 6960 → "01:56:00", 19260 → "05:21:00". */
+export const HOLLOW_TIDE_CONTINUE: ContinueListeningItem[] = [
+  {
+    bookId: 'hollow-tide-1',
+    title: 'The Drowning Bell',
+    chapterId: 11,
+    currentSec: 540,
+    remainingSec: 2040,
+    completionPct: 0.92,
+    updatedAt: '2026-06-12T18:30:00.000Z',
+  },
+  {
+    bookId: 'coalfall-commission',
+    title: 'The Coalfall Commission',
+    chapterId: 3,
+    currentSec: 300,
+    remainingSec: 6960,
+    completionPct: 0.28,
+    updatedAt: '2026-06-12T15:10:00.000Z',
+  },
+  {
+    bookId: 'hollow-tide-2',
+    title: 'Saltgrave',
+    chapterId: 2,
+    currentSec: 120,
+    remainingSec: 19260,
+    completionPct: 0.15,
+    updatedAt: '2026-06-11T20:00:00.000Z',
+  },
+];
 
 /* ── Voice-library fixture (served under VITE_DEMO_CAPTURE=1) ──────────── */
 import type { VoiceLibraryResponse, Voice } from '../../lib/types';


### PR DESCRIPTION
## Summary

The cross-book **Continue Listening** rail (fs-15) never appeared in marketing screenshots: it renders `null` when empty, and the demo-capture path never seeded `getContinueListening()`, so `--mode marketing` returned `[]` and the rail silently vanished from the front screen.

- Add a posed `HOLLOW_TIDE_CONTINUE` fixture (Drowning Bell 92% · Coalfall 28% · Saltgrave 15% — audio-bearing books only; `hollow-tide-3` excluded since it's still analysing), returned from `mockGetContinueListening` under `DEMO_CAPTURE` as fresh copies (Immer-freeze-safe).
- Two new optional `Scene` fields (`scrollTo`, `fullPage`); existing scenes capture byte-identically.
- Two new scenes: **`continue-listening`** (rail as hero, scrolled to centre — desktop/phone/tablet) and **`library-shelf-full`** (full-page front screen — desktop) so the front screen finally shows the rail in context.

Design spec: `docs/superpowers/specs/2026-06-14-marketing-continue-listening-capture-design.md`.

## Test plan

- 5 new fixture assertions in `src/mocks/marketing/hollow-tide.test.ts` (count, shape, audio-bearing books only, `updatedAt` descending, first card 0.92). Existing `__SEED_CONTINUE__` seed tests unchanged.
- Full frontend suite green (2844 passed); typecheck + ESLint clean; pre-push `verify` battery green.
- 8 capture PNGs produced and visually confirmed (hero / phone snap-scroll / full-page front screen, light + dark) — real covers, distinct progress bars, rendered `Ch 11 · 34:00 left` etc. PNGs live under git-ignored `mockups/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)