### PR TITLE
docs(docs): correct in-app release notes before the 1.7.0 cut

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 - **Set up once, and we'll walk you through it.** First launch guides you step by step through everything Castwright needs and checks it's all in place — and if something's missing, it tells you plainly how to put it right. A quick tour shows you around, and a help screen is a click away whenever you want it.
 - **It runs on a Mac now.** Apple Silicon is a first-class home for Castwright — it finds your Mac's graphics on its own, no setup and no drivers. (Intel Macs work too, just slower.)
 - **Your whole cast can act.** Design expressive, emotion-aware voices for every character in one pass — not just your leads — and each performance stays true from the first chapter to the last.
+- **It catches a bad line before you do.** Before a chapter comes together, every line is checked — how it sounds *and* whether it spoke the right words — the off ones are re-recorded on their own, and anything still not right is a single, scoped tap to fix.
 - **Long books you can walk away from.** Big manuscripts ride out the rough patches on their own and keep going, so a full performance finishes while you're elsewhere.
 - **Pick up where you left off.** Your shelf remembers what you were in the middle of and puts it back within reach, and a reading dashboard keeps your streak and your hours.
 - **Take your library with you.** Pair your phone in one scan and listen offline, with chapters, progress and speed that follow you.
@@ -12,14 +13,19 @@
 # Castwright 1.6.0
 
 - **Update from inside the app.** Castwright can update itself, and tells you what's new when a fresh version lands.
-- **It checks its own work.** Every line is acoustically checked and transcript-verified before a chapter is assembled — the plainly broken ones never reach your ears, and when something does go wrong you get a clear, scoped way to fix just that part.
+- **It flags a suspect take.** Every finished chapter is checked for the obvious faults — near-silence, clipping, an abrupt cut-off — and anything off gets a clear badge, so you catch it before you settle in.
+- **Not only in English.** Castwright now performs Russian-language books — it spots the language on its own and gives every character a voice that speaks it.
 - **Your library, kept safe.** Automatic backups, so a growing shelf is protected without you thinking about it.
 - **Smoother listening.** Chapters advance on their own, and you can skip forward and back from the mini-player.
-- **Better on a phone.** The web player fits small screens cleanly.
 
 # Castwright 1.5.0 — the first full Castwright
 
 - **Any book, performed by a full cast.** Turn a manuscript into a full-cast performance — every character its own voice, start to finish.
 - **Voices designed for the character.** Bespoke voices crafted to each role, not picked off a shelf, so the apprentice sounds thirteen and the swordsmith sounds seventy and a forge.
-- **Your book never leaves the house.** Everything renders on your own machine — no meter, no monthly fee.
-- **About the time it takes to listen.** A chapter renders in roughly the time it takes to play it, so a full book is an evening, not a week.
+- **The same voice, book after book.** A returning character keeps the voice you designed across a whole series, so a long saga stays consistent.
+- **Listen the way you like.** Adjustable speed, a sleep timer, your own markers, resume-where-you-stopped, and a 30-second clip you can share — a player built for long books.
+- **Read it on your phone, too.** Open your library from a phone or tablet browser over your home network — the same app, sized to the screen.
+- **Bring any book; take any format.** EPUB, PDF, Kindle and plain text go in; a chaptered M4B, MP3, AAC or Opus comes out — or drops straight into your sync folder.
+- **Even, broadcast-level volume.** Every chapter is loudness-matched, so you're not riding the volume knob between a whisper and a battle.
+- **Reshape it without starting over.** Merge, split, rename or reorder chapters and fix who-said-what — no re-import, no re-analysis.
+- **Your book never leaves the house.** Everything renders on your own machine — no meter, no monthly fee — in about the time it takes to play it.


### PR DESCRIPTION
## Summary

Corrects the in-app `#/release-notes` history before cutting 1.7.0.

- **1.6.0 misattribution (QA).** The block claimed per-line transcript verification + a pre-assembly gate that re-records bad takes — that work (`srv-31` ASR, plan 179) shipped in the **1.7.0** cycle, not 1.6.0 (verified: neither is in `v1.6.0` history). Softened 1.6.0 to the advisory post-synthesis badge it actually shipped (`srv-27`), and moved the real gate into the **1.7.0** block.
- **1.6.0 "Better on a phone".** That was the 1.4.0 mobile/tablet-web round (plan 81), which is inside the **1.5.0 bundle**; 1.6.0 only had two overflow fixes. Replaced with **Russian-language support** (`fs-2`), which genuinely shipped in 1.6.0.
- **1.5.0 bundle.** Expanded 4 → 9 bullets so the initial-alpha block represents the full 1.0.0–1.5.0 feature set (series-consistent voices, listening player, phone-browser-over-LAN, formats in/out, loudness matching, chapter editing).

## Test plan

Docs-only — CI doc-only fast-path skips `verify.yml`. Verified each claim against git history (tag membership of `srv-27` / `srv-31` / plan 179 / plan 81).

🤖 Generated with [Claude Code](https://claude.com/claude-code)