### PR TITLE
ci(ci,docs): gate release publish on full + cross-OS + mobile verification

### DIFF
--- a/.github/workflows/cross-os.yml
+++ b/.github/workflows/cross-os.yml
@@ -8,10 +8,15 @@ name: Cross-OS Verify
 # the per-PR E2E Mobile workflow billed ~2 min on EVERY PR push while being
 # non-blocking (continue-on-error). Both are now folded here and fired on a
 # WEEKLY cron + on-demand via workflow_dispatch instead of per-release /
-# per-PR. The deployer spread is still Windows + macOS + Linux, so fire this
-# MANUALLY (Actions tab → Cross-OS Verify → Run workflow) before announcing
-# any release that ships a zip to alpha testers.
-# See docs/features/103-ci-cost-reduction.md.
+# per-PR.
+#
+# Plan 215 — release tags now run their OWN complete cross-OS + mobile battery
+# in release.yml (publish is gated on macOS + Windows + Ubuntu-full + mobile
+# e2e), so cross-OS coverage for a release is automatic. This workflow is no
+# longer the pre-release manual step; it's the between-releases pulse — a weekly
+# cron catches cross-OS / mobile regressions on `main`, and the manual dispatch
+# stays for ad-hoc / high-risk checks off a release boundary.
+# See docs/features/103-ci-cost-reduction.md and 215-ci-label-gated-verify.md.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,23 +14,26 @@ permissions:
   contents: write
 
 jobs:
-  # Sanity-net: confirm the tagged commit builds + tests on Ubuntu before
-  # publish. If verify fails, the publish job is skipped and the release does
-  # NOT land.
+  # Sanity-net: a release tag must pass COMPLETE verification on every deployer
+  # OS before it publishes. `publish` is gated on all of the verification legs
+  # below (`needs: [verify, cross-os-verify, mobile-e2e, companion-apk-build]`);
+  # if any fails, the publish job is skipped and the release does NOT land.
   #
-  # Plan 103 — the per-release cross-OS matrix (macOS + Windows) was retired
-  # from this workflow: macOS bills at a 10× multiplier on a <4-min job, so
-  # each release tag was paying ~46 billed minutes for cross-OS smoke that
-  # scales with release cadence. The macOS + Windows verify smoke now lives
-  # in cross-os.yml (workflow_dispatch + weekly cron on main). Fire that
-  # workflow MANUALLY before announcing any release that ships a zip to
-  # alpha testers — the deployer spread is still Windows + macOS + Linux.
-  # See docs/features/103-ci-cost-reduction.md.
+  # Plan 215 — CI is opt-in on PRs (no per-PR cloud run), so the full + cross-OS
+  # battery is concentrated HERE, at the infrequent release boundary. Releases
+  # are public-beta, so paying the cost per tag (macOS bills at 10×) is the
+  # point. Plan 103 had moved cross-OS OFF the per-release path to cross-os.yml;
+  # 215 brings it back ON the tag — cross-os.yml stays for the weekly `main`
+  # pulse + ad-hoc dispatch. See docs/features/215-ci-label-gated-verify.md.
+
+  # Leg 1/4 — full `npm run verify` on Ubuntu (typecheck + lint + all tests +
+  # e2e + a11y + build): the complete single-OS battery.
   verify:
-    name: Verify (ubuntu-latest)
+    name: Verify (ubuntu-latest, full)
     runs-on: ubuntu-latest
-    # Explicit cap (default is 360 min). (CI cost round 2.)
-    timeout-minutes: 20
+    # 30 (not 20): the full battery + e2e runs ~15-20 min on a cold runner, past
+    # the 20-min PR cap. Releases are rare, so the headroom costs nothing.
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -53,11 +56,13 @@ jobs:
 
       # The server pretest hook (`scripts/preflight-ffmpeg.cjs`) refuses to
       # run when ffmpeg isn't on PATH — the MP3 encoder in
-      # `server/src/tts/mp3.ts` shells out to it. `SKIP_FFMPEG_PREFLIGHT=1`
-      # exists as an escape hatch but it makes `mp3.test.ts` silently skip —
-      # we want the gate.
+      # `server/src/tts/mp3.ts` shells out to it; the e2e audio paths need it too.
       - name: Install ffmpeg
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      # `npm run verify` runs the e2e suite, which needs the chromium engine.
+      - name: Install Playwright chromium
+        run: npx playwright install --with-deps chromium
 
       # fe-37 — a hand-cut tag must not publish empty/placeholder user-facing
       # notes. The committed RELEASE_NOTES.md top section must lead with the tag
@@ -65,15 +70,87 @@ jobs:
       - name: Guard — committed release notes are real
         run: node scripts/release-notes-gate.mjs "${{ github.ref_name }}"
 
+      # Full battery (incl. build). Sidecar pytest + Pester skip with a banner on
+      # a fresh runner (no venv / no Pester 5), as the old verify:quick leg did.
+      - name: Verify
+        run: npm run verify
+
+  # Leg 2/4 — cross-OS smoke (macOS + Windows): verify:quick + build. Ubuntu is
+  # covered by `verify` above. Mirrors cross-os.yml's cross-os-verify job; no
+  # cross-OS e2e (Playwright font-hinting drift is unreliable off-Linux).
+  cross-os-verify:
+    name: Verify (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # Node 24 + npm/node_modules caches + `npm ci` (root + server) — shared
+      # composite with verify.yml / cross-os.yml.
+      - name: Setup Node + deps
+        uses: ./.github/actions/setup
+
+      - name: Install ffmpeg (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install ffmpeg
+
+      - name: Install ffmpeg (Windows)
+        if: matrix.os == 'windows-latest'
+        run: choco install ffmpeg -y --no-progress
+
       # `verify:quick` is `test:all` (hooks + frontend + server + scripts +
-      # sidecar). Sidecar tests skip with a banner if the venv isn't
-      # bootstrapped (which it won't be on a fresh runner — that's fine,
-      # we don't ship a sidecar test gate for the release pipeline).
+      # sidecar; sidecar/Pester skip with a banner on a fresh runner).
       - name: Verify
         run: npm run verify:quick
 
       - name: Build
         run: npm run build
+
+  # Leg 3/4 — mobile + tablet viewport e2e (Pixel 7 / iPad Pro 11), Ubuntu /
+  # chromium. Mirrors cross-os.yml's mobile-e2e job but runs UNCONDITIONALLY on a
+  # release tag (no change-window gate — every public-beta tag gets it).
+  mobile-e2e:
+    name: npm run test:e2e:mobile
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node + deps
+        uses: ./.github/actions/setup
+
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: E2E Mobile
+        run: npm run test:e2e:mobile
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-mobile-release
+          path: playwright-report/
+          retention-days: 7
 
   # Build the companion artifacts ONCE (versioned in lockstep via
   # bump-version.mjs → pubspec) and hand them to `publish` as a workflow
@@ -172,10 +249,12 @@ jobs:
 
   # Publish: builds the zip + SHA-256 on Ubuntu (the zip is platform-
   # independent, no need to build it three times) and uploads them to the
-  # GitHub Release. Gated on verify AND the APK build so the zip can bundle it.
+  # GitHub Release. Gated on the COMPLETE verification spread (Ubuntu full +
+  # mobile e2e + macOS/Windows smoke) AND the APK build so the zip can bundle it
+  # — a red leg on any deployer OS blocks the public-beta release.
   publish:
     name: Publish release zip
-    needs: [verify, companion-apk-build]
+    needs: [verify, cross-os-verify, mobile-e2e, companion-apk-build]
     runs-on: ubuntu-latest
     # Explicit cap (default is 360 min). (CI cost round 2.)
     timeout-minutes: 15

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,13 +385,15 @@ tests, a server-only PR skips Playwright e2e + the frontend unit suite, a root
 What still runs automatically: `pr-title-lint.yml` on every PR, `app.yml` on
 `apps/android/**` changes (the only automated coverage for the Flutter
 companion — no local hook runs `flutter analyze`/`test`), `release.yml` on a
-`vX.Y.Z` tag, and `cross-os.yml` on its weekly Sunday cron. Cross-OS verify
-(macOS + Windows) + mobile/tablet e2e live on `cross-os.yml` (`workflow_dispatch`
-+ weekly cron on `main`) — **fire it manually before announcing any release
-that ships a zip to alpha testers** (deployer spread is still Windows + macOS +
-Linux). `release.yml` verifies Ubuntu-only before publish. The doc-only
-`paths-ignore` fast-path (plan 101) is a second layer — a `run-ci`-labeled PR
-whose files are all docs still won't spin up the battery.
+`vX.Y.Z` tag, and `cross-os.yml` on its weekly Sunday cron. **Every release tag
+now runs COMPLETE cross-platform verification before it publishes** (plan 215):
+`release.yml` gates publish on full `npm run verify` (Ubuntu) + `test:e2e:mobile`
+(Ubuntu) + `verify:quick`+build on macOS **and** Windows — a red leg on any
+deployer OS blocks the public-beta release, so you no longer fire cross-OS by
+hand before a release. `cross-os.yml` (`workflow_dispatch` + weekly cron on
+`main`) stays as the between-releases pulse + ad-hoc cross-OS/mobile run. The
+doc-only `paths-ignore` fast-path (plan 101) is a second layer — a `run-ci`-labeled
+PR whose files are all docs still won't spin up the battery.
 See [docs/features/215-ci-label-gated-verify.md](docs/features/215-ci-label-gated-verify.md),
 [103](docs/features/103-ci-cost-reduction.md), and
 [archive/101](docs/features/archive/101-docs-only-ci-skip.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -422,8 +422,10 @@ A labeled PR run is scope-filtered to the legs the diff touched (plan 103); a
 manual dispatch runs the full battery. What still runs automatically on its own:
 `pr-title-lint.yml` on every PR, `app.yml` on `apps/android/**` changes,
 `release.yml` on a `vX.Y.Z` tag, and `cross-os.yml` (macOS + Windows + mobile
-e2e) on its weekly cron + manual dispatch — fire that one before any release
-announce, since high-risk / cross-platform changes are exactly what it covers.
+e2e) on its weekly cron + manual dispatch. **Every release tag runs the complete
+cross-platform battery before publishing** (full `npm run verify` + mobile e2e on
+Ubuntu, plus `verify:quick`+build on macOS and Windows — see `release.yml`), so
+cross-OS coverage for a release is automatic, not a manual pre-announce step.
 Rationale + measurements:
 [docs/features/215-ci-label-gated-verify.md](docs/features/215-ci-label-gated-verify.md),
 [docs/features/118-ci-cost-round-2.md](docs/features/118-ci-cost-round-2.md).

--- a/docs/features/215-ci-label-gated-verify.md
+++ b/docs/features/215-ci-label-gated-verify.md
@@ -47,14 +47,29 @@ asked**.
 - **Unlabeled PRs** still *evaluate* the workflow but the job is skipped by the
   `if:` → zero runner minutes. No required status check on `main` gates merge,
   so a skipped job never blocks.
-- **Untouched** (still automatic): `pr-title-lint.yml` (every PR — cheap title
-  gate), `app.yml` (Flutter companion CI on `apps/android/**` — the only
+- **`release.yml` is now the complete-verification boundary.** Because PRs no
+  longer run cloud CI, the full + cross-OS battery is concentrated on the tag.
+  `publish` gates on `needs: [verify, cross-os-verify, mobile-e2e,
+  companion-apk-build]`:
+  - `verify` — full `npm run verify` on Ubuntu (typecheck + lint + all tests +
+    e2e + a11y + build); upgraded from the old `verify:quick` and given a 30-min
+    cap + a Playwright-chromium install for the e2e leg.
+  - `cross-os-verify` — `verify:quick` + build on **macOS** and **Windows**
+    (matrix; mirrors `cross-os.yml`). Restores the cross-OS gate plan 103 had
+    moved off the release path — releases are public-beta, so the macOS 10×
+    minutes are worth it per (infrequent) tag.
+  - `mobile-e2e` — `npm run test:e2e:mobile` (Pixel 7 / iPad Pro 11), Ubuntu,
+    run unconditionally per tag.
+  A red leg on any deployer OS blocks the release. `cross-os.yml` stays as the
+  between-releases weekly pulse + ad-hoc dispatch.
+- **Still automatic, otherwise untouched:** `pr-title-lint.yml` (every PR — cheap
+  title gate), `app.yml` (Flutter companion CI on `apps/android/**` — the only
   automated coverage for the app; no local hook runs `flutter analyze`/`test`),
-  `release.yml` (on `vX.Y.Z` tag), `cross-os.yml` (weekly Sunday cron + manual
-  dispatch — the "high-risk / needs cross-OS" lane).
+  `cross-os.yml` (weekly Sunday cron + manual dispatch).
 - **Reversibility:** revert the `verify.yml` trigger/`if:` edits to restore
-  auto-on-PR. The `run-ci` label is a repo label; deleting it just removes the
-  opt-in handle (dispatch still works).
+  auto-on-PR; revert the `release.yml` job additions to drop back to the
+  Ubuntu-only `verify:quick` release gate. The `run-ci` label is a repo label;
+  deleting it just removes the opt-in handle (dispatch still works).
 
 ## Invariants to preserve
 
@@ -88,7 +103,11 @@ config + docs only.
 4. **Actions tab → Verify → Run workflow on a branch** (or `gh workflow run
    verify.yml --ref <branch>`) → runs the **full** battery (all scopes), no PR
    needed.
-5. **Push a `vX.Y.Z` tag** → `release.yml` still runs end-to-end (unchanged).
+5. **Push a `vX.Y.Z` tag** → `release.yml` runs the complete battery and only
+   publishes if ALL legs pass: `verify` (Ubuntu full), `cross-os-verify`
+   (macOS + Windows), `mobile-e2e` (Ubuntu), and `companion-apk-build`. Force a
+   red on any one (e.g. a Windows-only failure) → `publish` is skipped and no
+   GitHub Release lands.
 6. **Push to `apps/android/**`** → `app.yml` still runs (unchanged).
 
 ## Out of scope


### PR DESCRIPTION
## Summary

Concentrates **complete cross-platform verification on each release tag**, now that CI is opt-in on PRs (plan 215). Releases are public-beta, so paying the cross-OS cost per (infrequent) tag is the point.

`release.yml` — `publish` is now gated on `needs: [verify, cross-os-verify, mobile-e2e, companion-apk-build]`:
- **`verify`** — full `npm run verify` on Ubuntu (typecheck + lint + all tests + e2e + a11y + build), upgraded from the old `verify:quick`; adds a Playwright-chromium install for the e2e leg and a 30-min cap.
- **`cross-os-verify`** — `verify:quick` + build on **macOS** and **Windows** (matrix; mirrors `cross-os.yml`). Restores the cross-OS gate plan 103 had moved off the release path.
- **`mobile-e2e`** — `npm run test:e2e:mobile` (Pixel 7 / iPad Pro 11), Ubuntu, run unconditionally per tag.

A red leg on any deployer OS blocks the release. `cross-os.yml` stays as the weekly `main` pulse + ad-hoc dispatch (header comment updated). Docs (`CLAUDE.md`, `CONTRIBUTING.md`) + plan `215` updated.

## Test plan

CI workflow YAML isn't unit-testable here (no `act` harness). Verified statically:
- `release.yml` parses as valid YAML; job graph is `verify` / `cross-os-verify` (macos+windows) / `mobile-e2e` / `companion-apk-build` → `publish` (needs all four) → `companion-ios`.
- New jobs mirror the proven `cross-os.yml` definitions; `./.github/actions/setup` composite + `verify` / `verify:quick` / `test:e2e:mobile` npm scripts all confirmed present.
- **Full end-to-end exercise only happens on the next real `vX.Y.Z` tag** — tag-triggered + publishing, so it can't be dry-run without cutting a real release.

Regression plan: `docs/features/215-ci-label-gated-verify.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
