### PR TITLE
ci(ci,docs): drop per-release unsigned iOS build (save macOS minutes)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -373,42 +373,11 @@ jobs:
             "companion-apk/castwright-${{ github.ref_name }}.aab" \
             "companion-apk/castwright-${{ github.ref_name }}.aab.sha256" --clobber
 
-  # plan 188 / app-12 prep — build the companion for iOS UNSIGNED so the release
-  # pathway exists + the iOS build is gated each release. An installable .ipa
-  # needs Apple signing certs (app-12); until then we attach the unsigned
-  # archive so it can be signed + exported later.
-  companion-ios:
-    name: Companion iOS (unsigned, app-12 prep)
-    needs: publish
-    runs-on: macos-latest
-    timeout-minutes: 30
-    defaults:
-      run:
-        working-directory: apps/android
-    steps:
-      - uses: actions/checkout@v6
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-          flutter-version: 3.44.1
-          cache: true
-      - run: flutter pub get
-      - run: flutter build ipa --no-codesign
-      - name: Package unsigned artifact
-        run: |
-          set -e
-          out="castwright-${{ github.ref_name }}-ios-unsigned"
-          if ls build/ios/ipa/*.ipa >/dev/null 2>&1; then
-            cp build/ios/ipa/*.ipa "$out.ipa"
-            echo "ASSET=apps/android/$out.ipa" >> "$GITHUB_ENV"
-          else
-            # --no-codesign can't export a distributable .ipa; ship the archive.
-            ditto -c -k --sequesterRsrc --keepParent \
-              build/ios/archive/Runner.xcarchive "$out.xcarchive.zip"
-            echo "ASSET=apps/android/$out.xcarchive.zip" >> "$GITHUB_ENV"
-          fi
-      - name: Attach to release
-        working-directory: .
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ github.ref_name }}" "$ASSET" --clobber
+  # NOTE: the per-release iOS build (unsigned, "app-12 prep") was REMOVED to save
+  # ~80-120 macOS-billed minutes/tag (macOS is 10×). It produced an un-installable
+  # unsigned archive that nothing consumes (no iOS distribution exists yet), and
+  # iOS *compileability* is already verified by app.yml's `ios-compile` job on
+  # every `apps/android/**` change — so nothing iOS rots. When iOS actually ships
+  # (app-12 / #555), add a SIGNED `.ipa` release job here — and even then weigh the
+  # macOS minutes: a manual/occasional signed build may beat one per tag.
+  # See docs/features/188-android-companion-app.md (app-12).

--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ attaches (all with `.sha256` checksums):
 - `castwright-vX.Y.Z.zip` — the platform-independent **server** bundle
   (Windows / macOS / Linux); install via [INSTALL.md](INSTALL.md).
 - `castwright-vX.Y.Z.apk` — the sideloadable **Android companion** app.
-- `castwright-vX.Y.Z-ios-unsigned.*` — an **unsigned iOS** build (needs Apple
-  signing to become an installable `.ipa`).
+
+An iOS companion build isn't published yet — it lands with `app-12` (signed
+`.ipa`); the Flutter codebase already stays iOS-ready.
 
 After the first public release, upgrading is one click inside the app
 (**Account → Application updates**); see [INSTALL.md](INSTALL.md#updating).

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -96,6 +96,7 @@ _The Android companion shipped (plan 188); these are the launch-blocking gaps �
 
 - _What:_ Build + release the Flutter companion on iOS. The codebase stays iOS-ready by construction (app-managed TLS trust, dual-platform Flutter plugins, an unsigned iOS CI compile from `app-1`), so this is incremental, not a rewrite. _Codec caveat:_ iOS `AVPlayer` can't play `.ogg` — for iOS the server must render MP3/M4A (OGG is Android-only); the app reads the format from the manifest and surfaces it.
 - _Benefit (user):_ brings the companion to iPhone/iPad listeners — the other half of the mobile audience.
+- _CI note (2026-06-14):_ the per-release unsigned `companion-ios` build was removed from `release.yml` (saved ~80–120 macOS-billed min/tag; `app.yml`'s `ios-compile` still guards build health). This item should add a **signed** `.ipa` release job when it lands — weighing whether it's worth the macOS minutes on every tag vs. an occasional manual build.
 _Full detail + acceptance:_ [#555](https://github.com/dudarenok-maker/AudioBook-Generator/issues/555) · [plan 188](features/188-android-companion-app.md).
 
 ## Should — important, not blocking ship

--- a/docs/features/188-android-companion-app.md
+++ b/docs/features/188-android-companion-app.md
@@ -503,6 +503,12 @@ IDs are permanent. Priority = position. MVP block first, follow-ups after.
   be incremental. Filed as a parked **Won't (this round)** backlog row with a clear
   wake-trigger (Android MVP stable + listener demand).
 - **Benefit (user):** one codebase, both platforms. **Depends on:** MVP stable.
+- **CI note (2026-06-14):** the per-release *unsigned* iOS build (`companion-ios`) was
+  REMOVED from `release.yml` — it cost ~80–120 macOS-billed min/tag (10×) for an
+  un-installable artifact nothing consumes, and `app.yml`'s `ios-compile` job already
+  guards iOS *compileability* on every `apps/android/**` change. When app-12 ships, add
+  a **signed `.ipa`** release job here — **but even then weigh the macOS minutes**: a
+  manual or occasional signed build is likely the better trade than one on every tag.
 
 ### Relationships to existing items (reconcile, don't absorb)
 


### PR DESCRIPTION
## Summary

Removes the `companion-ios` job from `release.yml`. It built an **unsigned, un-installable** iOS archive on a macOS runner (~80–120 billed min/tag at the 10× multiplier) and attached it to each Release — but no iOS distribution consumes it yet (that's `app-12` / #555).

iOS **build health is unaffected**: `app.yml`'s `ios-compile` job already runs `flutter build ios --no-codesign` on every `apps/android/**` push + PR, so iOS can't silently stop compiling. The per-release build was purely redundant cost.

This roughly **halves per-release minutes** (~270 → ~150–210), leaving `cross-os-verify` (macOS+Windows smoke) as the only macOS job on a tag.

When iOS actually ships (`app-12`), a **signed** `.ipa` release job replaces this stub — noted in `plan 188`, `BACKLOG` (app-12 row), a `release.yml` breadcrumb, and `README` (dropped the now-stale `ios-unsigned` release asset). The note flags that even then, a manual/occasional signed build may beat one per tag.

## Test plan

- `release.yml` parses as valid YAML; job graph is now `verify` / `cross-os-verify` / `mobile-e2e` / `companion-apk-build` → `publish`; `companion-ios` gone; only remaining macOS runner is the intended `cross-os-verify` matrix.
- Docs-only changes otherwise; no app code touched.

Refs #555 (app-12). Regression plan: `docs/features/188-android-companion-app.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
