### PR TITLE
fix(e2e): fully decode lazy covers before marketing capture

### DIFF
--- a/e2e/marketing/capture.spec.ts
+++ b/e2e/marketing/capture.spec.ts
@@ -27,12 +27,29 @@ const onlyScene = process.env.CAPTURE_SCENE; // optional single-scene filter
    PNGs and won't be painted within a fixed settle. Non-fatal (a broken image
    shouldn't abort the run). */
 async function waitForImages(page: import('@playwright/test').Page) {
+  /* Force lazy images (e.g. the continue-listening rail covers) to fetch even
+     below the fold. A full-page capture resizes the viewport AFTER this, which
+     would otherwise trigger a deferred lazy fetch and paint the cover mid-decode
+     (the Coalfall rail cover did exactly this). */
+  await page
+    .evaluate(() => {
+      for (const img of Array.from(document.images)) if (img.loading === 'lazy') img.loading = 'eager';
+    })
+    .catch(() => {});
+
+  /* Every <img> has finished loading... */
   await page
     .waitForFunction(
       () => Array.from(document.images).every((img) => img.complete && img.naturalWidth > 0),
       undefined,
       { timeout: 20_000 },
     )
+    .catch(() => {});
+
+  /* ...AND finished decoding. `complete` can be true before the bitmap is
+     decoded/painted, so await decode() on each to guarantee a clean frame. */
+  await page
+    .evaluate(() => Promise.all(Array.from(document.images).map((img) => img.decode().catch(() => {}))))
     .catch(() => {});
 }
 

--- a/playwright.marketing.config.ts
+++ b/playwright.marketing.config.ts
@@ -13,9 +13,10 @@ export default defineConfig({
   fullyParallel: false,
   workers: 1,
   retries: 0,
-  /* Cold Vite compile of the SPA + posed render can exceed Playwright's stock
-     30s per-test default, especially under GPU/CPU contention. */
-  timeout: 90_000,
+  /* Cold Vite compile of the SPA + posed render + full image decode can exceed
+     Playwright's stock 30s default, especially on the first (cold) test under
+     GPU/CPU contention. */
+  timeout: 120_000,
   reporter: 'list',
   use: { baseURL, navigationTimeout: 60_000 },
   expect: { toHaveScreenshot: { animations: 'disabled' } },


### PR DESCRIPTION
## Summary

The Continue Listening rail covers use `loading="lazy"`. On a `fullPage` marketing capture the viewport resize fired the deferred lazy fetch **after** `waitForImages` passed, so the screenshot grabbed the Coalfall rail cover mid-decode — its top sliver over the pink gradient placeholder (visible in `continue-listening.desktop.*` and `library-shelf-full.desktop.*`).

- `waitForImages` now forces lazy imgs eager, waits for `complete`, then `await img.decode()` on every image so the captured frame is fully painted.
- Bump the marketing per-test timeout 90s → 120s to cover the extra decode wait on the cold first test.

Fix is in the capture harness only — `loading="lazy"` stays correct for real users.

## Test plan

- Recut both affected scenes; re-inspected the rail region at full resolution — all three covers (Drowning Bell, Coalfall, Saltgrave) now render fully in desktop hero + full-page shots, light and dark. File sizes grew accordingly (e.g. library-shelf-full 797→995 KB).
- ESLint + typecheck clean; pre-push `verify` battery green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)