### PR TITLE
fix(mocks): give marketing library books voiceIds so VOICES total isn't 0

### DIFF
--- a/src/mocks/marketing/hollow-tide.test.ts
+++ b/src/mocks/marketing/hollow-tide.test.ts
@@ -59,6 +59,33 @@ describe('Hollow Tide marketing fixtures', () => {
           expect(HOLLOW_TIDE_BOOK_STATES.has(book.bookId)).toBe(true);
   });
 
+  describe('voice totals (library "VOICES" stat)', () => {
+    const allBooks = HOLLOW_TIDE_LIBRARY.authors.flatMap((a) =>
+      a.series.flatMap((s) => s.books),
+    );
+
+    it('every book carries voiceIds (else the library VOICES total is 0)', () => {
+      for (const b of allBooks) expect(Array.isArray(b.voiceIds)).toBe(true);
+    });
+
+    it('per-book voiceIds length matches voiceCount', () => {
+      for (const b of allBooks) expect(b.voiceIds!.length).toBe(b.voiceCount);
+    });
+
+    it('distinct voices across the library is non-zero and reflects series reuse', () => {
+      // Mirrors book-library.tsx: new Set(flatMap(voiceIds)).size.
+      const distinct = new Set(allBooks.flatMap((b) => b.voiceIds ?? [])).size;
+      // 10 across the Hollow Tide trilogy (narrator/Cray/Wren reused) + 13 Coalfall.
+      expect(distinct).toBe(23);
+    });
+
+    it('Coalfall counts agree with its 13-character cast', () => {
+      const coalfall = allBooks.find((b) => b.bookId === 'coalfall-commission')!;
+      expect(coalfall.characterCount).toBe(13);
+      expect(coalfall.voiceCount).toBe(13);
+    });
+  });
+
   describe('HOLLOW_TIDE_CONTINUE', () => {
     it('poses exactly three resume cards', () => {
       expect(HOLLOW_TIDE_CONTINUE).toHaveLength(3);

--- a/src/mocks/marketing/hollow-tide.ts
+++ b/src/mocks/marketing/hollow-tide.ts
@@ -315,6 +315,14 @@ export const HOLLOW_TIDE_BOOK_STATES = new Map<string, BookStateResponse>([
   ['coalfall-commission', coalfallCommission],
 ]);
 
+/* Distinct voice ids behind a book's voiceCount (voiceId ?? id), mirroring the
+   server's per-book `voiceIds`. The library view unions these across books for
+   its DISTINCT-voices total — summing voiceCount would count a series-reused
+   voice once per book. Without this the marketing library showed "VOICES 0". */
+const voiceIdsOf = (b: BookStateResponse): string[] => [
+  ...new Set((b.cast?.characters ?? []).map((c) => c.voiceId ?? c.id)),
+];
+
 export const HOLLOW_TIDE_LIBRARY: LibraryResponse = {
   authors: [
     {
@@ -335,6 +343,7 @@ export const HOLLOW_TIDE_LIBRARY: LibraryResponse = {
               completedChapters: 12,
               characterCount: 7,
               voiceCount: 7,
+              voiceIds: voiceIdsOf(drowningBell),
               progress: 1,
               runtime: '7h 02m',
               lastWorkedOn: '2 days ago',
@@ -355,6 +364,7 @@ export const HOLLOW_TIDE_LIBRARY: LibraryResponse = {
               completedChapters: 7,
               characterCount: 6,
               voiceCount: 6,
+              voiceIds: voiceIdsOf(saltgrave),
               progress: 0.62,
               runtime: '6h 18m',
               lastWorkedOn: '4 min ago',
@@ -376,6 +386,7 @@ export const HOLLOW_TIDE_LIBRARY: LibraryResponse = {
               completedChapters: 0,
               characterCount: 0,
               voiceCount: 0,
+              voiceIds: [],
               progress: 0.4,
               lastWorkedOn: 'Just now',
               coverGradient: ['#22343F', '#0A1014'],
@@ -403,8 +414,9 @@ export const HOLLOW_TIDE_LIBRARY: LibraryResponse = {
               status: 'complete',
               chapterCount: 4,
               completedChapters: 4,
-              characterCount: 12,
-              voiceCount: 12,
+              characterCount: 13,
+              voiceCount: 13,
+              voiceIds: voiceIdsOf(coalfallCommission),
               progress: 1,
               runtime: '2h 41m',
               lastWorkedOn: 'Last week',


### PR DESCRIPTION
## Summary

The library stats strip computes its DISTINCT-voices total by unioning each book's `voiceIds` (`book-library.tsx:264`), but the marketing fixtures only set `voiceCount` — so the union was empty and the **VOICES** tile rendered **0** (visible on `library-shelf`, `library-shelf-full`, and the library top behind `continue-listening`).

- Derive `voiceIds` per book from its cast (`voiceId ?? id`), mirroring what the server emits.
- VOICES total is now **23**: 10 distinct across the Hollow Tide trilogy (narrator / Cray / Wren reused across books) + 13 Coalfall.
- Correct Coalfall's stale `characterCount`/`voiceCount` `12 → 13` to match its 13-character, all-`generated` cast.

## Test plan

- 4 new assertions in `hollow-tide.test.ts`: every book has `voiceIds`, per-book `voiceIds.length === voiceCount`, distinct union `=== 23`, Coalfall counts `=== 13`.
- Full frontend suite green (2848); typecheck + ESLint clean; pre-push `verify` battery green.
- Recut the stats-bearing scenes and confirmed at full resolution the VOICES tile reads **23** (desktop, light + dark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)