### PR TITLE
fix(mocks): give MOCK_LIBRARY books voiceIds so dev VOICES total isn't 0

### DIFF
--- a/src/mocks/library.test.ts
+++ b/src/mocks/library.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { MOCK_LIBRARY } from './library';
+
+const allBooks = MOCK_LIBRARY.authors.flatMap((a) => a.series.flatMap((s) => s.books));
+
+describe('MOCK_LIBRARY voice totals', () => {
+  it('every book carries voiceIds (else the library VOICES total renders 0)', () => {
+    for (const b of allBooks) expect(Array.isArray(b.voiceIds)).toBe(true);
+  });
+
+  it('per-book voiceIds length matches voiceCount', () => {
+    for (const b of allBooks) expect(b.voiceIds!.length).toBe(b.voiceCount);
+  });
+
+  it('distinct voices is non-zero and counts series-reused voices once', () => {
+    // Mirrors book-library.tsx: new Set(flatMap(voiceIds)).size.
+    const distinct = new Set(allBooks.flatMap((b) => b.voiceIds ?? [])).size;
+    // 5 in Solway Bay + 1 new in The Northern Star (narrator/Carrick/Mara reused;
+    // Carrick's Compass reuses only existing ids) = 6.
+    expect(distinct).toBe(6);
+    // Strictly fewer than the naive sum, proving reuse is collapsed.
+    const summed = allBooks.reduce((s, b) => s + b.voiceCount, 0);
+    expect(distinct).toBeLessThan(summed);
+  });
+});

--- a/src/mocks/library.ts
+++ b/src/mocks/library.ts
@@ -27,6 +27,7 @@ export const MOCK_LIBRARY: LibraryResponse = {
               completedChapters: 18,
               characterCount: 5,
               voiceCount: 5,
+              voiceIds: ['narrator', 'v-carrick', 'v-mara', 'v-doran', 'v-elsie'],
               progress: 1.0,
               runtime: '11h 24m',
               lastWorkedOn: '3 days ago',
@@ -45,6 +46,9 @@ export const MOCK_LIBRARY: LibraryResponse = {
               completedChapters: 2,
               characterCount: 4,
               voiceCount: 4,
+              /* Book 2 reuses narrator/Carrick/Mara from Solway Bay + one new
+                 voice — the series-consistency headline. */
+              voiceIds: ['narrator', 'v-carrick', 'v-mara', 'v-tane'],
               progress: 0.42,
               runtime: '4h 38m',
               lastWorkedOn: '2 min ago',
@@ -64,6 +68,9 @@ export const MOCK_LIBRARY: LibraryResponse = {
               completedChapters: 0,
               characterCount: 6,
               voiceCount: 3,
+              /* All 3 ready voices were matched from the series library (hence
+                 matchedFromLibrary: 3) — every id reused from Solway Bay. */
+              voiceIds: ['narrator', 'v-carrick', 'v-doran'],
               matchedFromLibrary: 3,
               lastWorkedOn: 'Yesterday',
               coverGradient: ['#D4A04E', '#7B5A26'],
@@ -86,6 +93,7 @@ export const MOCK_LIBRARY: LibraryResponse = {
               completedChapters: 0,
               characterCount: 0,
               voiceCount: 0,
+              voiceIds: [],
               progress: 0.34,
               lastWorkedOn: 'Just now',
               coverGradient: ['#A43C6C', '#3C194F'],


### PR DESCRIPTION
## Summary

Normal mock mode (`VITE_USE_MOCKS`, no `DEMO_CAPTURE`) had the same gap the marketing fixtures did: the library stats strip unions per-book `voiceIds` (`book-library.tsx:264`) but `MOCK_LIBRARY` only set `voiceCount`, so the **VOICES** tile rendered **0** in dev.

- Add `voiceIds` per book, sharing ids across the Northern Coast Trilogy (narrator / Carrick / Mara / Doran reused).
- Distinct total is now **6** (5 in Solway Bay + 1 new in The Northern Star; Carrick's Compass reuses only existing ids) — demonstrating series reuse rather than the naive sum of 12.

Completes the voice-total fix across both mock library sources (marketing fixtures were PR #808).

## Test plan

- New `src/mocks/library.test.ts`: every book has `voiceIds`, per-book `voiceIds.length === voiceCount`, distinct union `=== 6` and `< summed voiceCount`.
- Full frontend suite green (2851); typecheck + ESLint clean; pre-push `verify` battery green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)