### PR TITLE
test(app): drop unused image_picker import in qr_scan_screen_test

### DIFF
--- a/apps/android/test/ui/qr_scan_screen_test.dart
+++ b/apps/android/test/ui/qr_scan_screen_test.dart
@@ -2,7 +2,6 @@ import 'package:castwright/src/domain/pairing_qr.dart';
 import 'package:castwright/src/ui/qr_scan_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:image_picker/image_picker.dart';
 
 /// Pumps QrScanScreen (live camera OFF — the mobile_scanner platform view can't
 /// run under flutter test) behind a launcher button and captures the popped


### PR DESCRIPTION
## Summary
Removes a dead `image_picker` import from `qr_scan_screen_test.dart` (left over from `b910bd0b`). It was the only `flutter analyze` issue in the companion package, so this makes `app.yml`'s analyze step green.

## Test plan
- `flutter analyze` → No issues found (was: 1 unused_import warning)
- `flutter test test/ui/qr_scan_screen_test.dart` → passes (4 tests); the import is genuinely unused (no `ImagePicker` reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)