### PR TITLE
feat(server): chunk Stage-1 cast detection for oversized chapters

### DIFF
--- a/docs/features/219-non-latin-names-and-ids.md
+++ b/docs/features/219-non-latin-names-and-ids.md
@@ -286,6 +286,30 @@ adversarial review + an in-flight design question:
    `slug`, every Cyrillic book mapped to `untitled__standalones__untitled`.
    Fixed by routing `slug` through `unicodeKebab`.
 
+### Follow-on — Stage-1 large-chapter chunking (2026-06-16)
+
+On-box testing of the Russian book surfaced a *second*, distinct failure: **Stage-1
+cast detection had no chunker** (only Stage-2 did, plan 187/#528), so every large
+chapter overflowed Ollama's `num_ctx` — the input filled the window, leaving no
+room for output → `done_reason:'length'` after ~0 bytes, every chapter dropped
+from the roster. Cyrillic made it acute (denser tokenisation), but it is a
+general large-chapter gap, not non-Latin-specific.
+
+Fixed (maintainer chose "both"):
+- **`num_ctx` 16384 → 32768** (`ollama.ts` const + registry default + `.env.example`):
+  headroom so fewer chapters need splitting.
+- **New `server/src/analyzer/stage1-chunk.ts`** — `runStage1ChapterChunked`
+  mirrors the Stage-2 chunker: split an over-budget chapter into paragraph-bounded
+  sub-bodies, detect each, **union** the rosters (injects the route's
+  `mergeRosterChapter`, so the module stays pure), thread the accumulated roster
+  into later chunks' prompts (so a recurring character keeps one id), and
+  adaptively re-split a chunk that still truncates. Local budget derives from
+  `num_ctx`; **cloud engines never chunk** (huge context, small output). Within-budget
+  chapters run exactly one call (byte-identical). Wired into both Phase-0a call
+  sites in `analysis.ts`. New knob `analyzer.stage1.chunkCharBudget`.
+- Tests: `stage1-chunk.test.ts` (single-call / split+union / roster-threading /
+  adaptive re-split / budget derivation).
+
 ### Owed (on-box acceptance — issue to file)
 
 - **ffmpeg + Cyrillic filesystem paths on Windows.** Book directories already use

--- a/server/.env.example
+++ b/server/.env.example
@@ -416,14 +416,16 @@ OLLAMA_RETRY_TEMPERATURE=0.6
 ANALYZER_NUM_PREDICT=-1
 # Per-request output-token cap for Gemini; set to match the free-tier ceiling. [live]
 ANALYZER_MAX_OUTPUT_TOKENS=8192
-# Context-window size handed to Ollama on every /api/chat call. Ollama keys the KV cache by (model, num_ctx), so warming with default 16384 and then changing it forces a re-load. Hardcoded today; registering this env name lifts it to a runtime knob. [live]
-ANALYZER_NUM_CTX=16384
+# Context-window size handed to Ollama on every /api/chat call. Ollama keys the KV cache by (model, num_ctx), so warming with default 32768 and then changing it forces a re-load. Larger = more KV-cache VRAM; 32768 gives large/non-Latin chapters headroom (the stage-1/2 chunkers handle anything still over budget). Lower it if a bigger analyzer model strains the GPU. [live]
+ANALYZER_NUM_CTX=32768
 # Number of GPU layers for Ollama (999 = all layers). Ollama treats this as part of its load-time cache key alongside num_ctx, so mismatching values between /load and /api/chat can force redundant model swaps. Hardcoded today; registering this env name lifts it to a runtime knob. [live]
 ANALYZER_NUM_GPU=999
 
 # ── Analyzer chunking & truncation guards ──
 # Maximum characters per stage-2 attribution chunk before the chapter is pre-emptively split. [live]
 STAGE2_CHUNK_CHAR_BUDGET=9000
+# Maximum characters per stage-1 cast-detection chunk before the chapter is split. For local engines the effective budget is derived (lowered) from Ollama num_ctx so a large or non-Latin chapter can never overflow the context window. [live]
+STAGE1_CHUNK_CHAR_BUDGET=24000
 # Attributed/source word-ratio floor below which a chapter is treated as truncated. [live]
 STAGE2_MIN_COVERAGE=0.6
 # Attributed/source word-ratio ceiling above which a chapter is treated as a repeat-loop. [live]

--- a/server/src/analyzer/ollama.test.ts
+++ b/server/src/analyzer/ollama.test.ts
@@ -148,12 +148,12 @@ describe('OllamaAnalyzer — happy path streaming', () => {
     expect(body.format).not.toBe('json');
     expect(typeof body.format).toBe('object');
     /* 9B is too heavy to leave resident on an 8 GB box (weights + KV cache
-       at num_ctx 16384 spill over budget) — see RESIDENT_MODELS in
+       at num_ctx 32768 spill over budget) — see RESIDENT_MODELS in
        ollama.ts. The 4B and llama3.1:8b both hold the keep_alive: '5m'
        slot; the 9B and any unknown tag get unloaded immediately with
        keep_alive: 0. */
     expect(body.keep_alive).toBe(0);
-    expect(body.options.num_ctx).toBe(16384);
+    expect(body.options.num_ctx).toBe(32768);
     /* Pin all layers to GPU — see ANALYZER_NUM_GPU in ollama.ts. 999 is
        the standard "all layers" idiom; without this, Ollama auto-splits
        and silently offloads layers to CPU under VRAM pressure. The

--- a/server/src/analyzer/ollama.ts
+++ b/server/src/analyzer/ollama.ts
@@ -139,7 +139,7 @@ export function keepAliveFor(model: string): string | number {
    while Ollama re-paged the model.
    Kept as static export for compat; call-sites inside this module use
    resolveAnalyzerNumCtx() / resolveAnalyzerNumGpu() for live values. */
-export const ANALYZER_NUM_CTX = 16384;
+export const ANALYZER_NUM_CTX = 32768;
 
 /* Force Ollama to load every layer of the model onto the GPU. 999 is
    the standard idiom for "all layers" — it exceeds any model's actual

--- a/server/src/analyzer/stage1-chunk.test.ts
+++ b/server/src/analyzer/stage1-chunk.test.ts
@@ -1,0 +1,124 @@
+/* Stage-1 cast-detection chunking (plan 219 / srv-40). Pins:
+   - a within-budget chapter runs exactly ONE call and returns its raw roster
+     (byte-identical to pre-chunking),
+   - an over-budget chapter is split, each chunk detected, rosters UNIONed
+     (a character recurring across chunks collapses to one entry),
+   - later chunks receive the accumulated roster (so the model can reuse ids),
+   - a chunk that truncates is adaptively re-split rather than failing the
+     chapter,
+   - the local budget derives from num_ctx. */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  runStage1ChapterChunked,
+  stage1ChunkBudgetForEngine,
+  type Stage1ChunkRunOptions,
+} from './stage1-chunk.js';
+import { AnalyzerTruncatedError } from './errors.js';
+import type { CharacterOutput } from '../handoff/schemas.js';
+
+const char = (id: string, extra: Partial<CharacterOutput> = {}): CharacterOutput => ({
+  id,
+  name: id,
+  role: 'role',
+  color: '#fff',
+  ...extra,
+});
+
+/* A minimal stand-in for the route's mergeRosterChapter: union by id, first
+   wins. (The real merge's field-level rules are exercised by analysis tests.) */
+const mergeRosters: Stage1ChunkRunOptions['mergeRosters'] = (running, chars) => {
+  for (const c of chars) if (!running.has(c.id)) running.set(c.id, c);
+};
+
+/* A body with N paragraphs of `size` chars each, blank-line separated. */
+const bodyOfParas = (n: number, size: number): string =>
+  Array.from({ length: n }, (_, i) => `${String.fromCharCode(97 + (i % 26))}`.repeat(size)).join(
+    '\n\n',
+  );
+
+describe('runStage1ChapterChunked', () => {
+  it('runs ONE call and returns the raw roster when the body fits the budget', async () => {
+    const callForBody = vi.fn(async () => ({ characters: [char('anton'), char('geser')] }));
+    const out = await runStage1ChapterChunked({
+      body: 'A short chapter.',
+      charBudget: 9000,
+      callForBody,
+      mergeRosters,
+    });
+    expect(callForBody).toHaveBeenCalledTimes(1);
+    expect(out.chunkCount).toBe(1);
+    expect(out.characters.map((c) => c.id)).toEqual(['anton', 'geser']);
+  });
+
+  it('splits an over-budget body and unions per-chunk rosters (dedup by id)', async () => {
+    // 6 paragraphs × 2000 chars = ~12K; budget 5000 → multiple chunks.
+    const body = bodyOfParas(6, 2000);
+    // Every chunk re-detects "anton"; each adds one unique character.
+    let n = 0;
+    const callForBody = vi.fn(async () => {
+      n += 1;
+      return { characters: [char('anton'), char(`extra${n}`)] };
+    });
+    const out = await runStage1ChapterChunked({ body, charBudget: 5000, callForBody, mergeRosters });
+    expect(out.chunkCount).toBeGreaterThan(1);
+    expect(callForBody).toHaveBeenCalledTimes(out.chunkCount);
+    // "anton" appears once despite being detected in every chunk.
+    expect(out.characters.filter((c) => c.id === 'anton')).toHaveLength(1);
+    // every chunk's unique character survived.
+    expect(out.characters.filter((c) => c.id.startsWith('extra'))).toHaveLength(out.chunkCount);
+  });
+
+  it('threads the accumulated roster into later chunks', async () => {
+    const body = bodyOfParas(4, 3000); // > budget → ≥2 chunks
+    const seen: number[] = [];
+    const callForBody = vi.fn(async (_sub: string, knownSoFar: CharacterOutput[]) => {
+      seen.push(knownSoFar.length);
+      return { characters: [char('anton')] };
+    });
+    await runStage1ChapterChunked({ body, charBudget: 4000, callForBody, mergeRosters });
+    // first chunk sees nothing; a later chunk sees the accumulated roster.
+    expect(seen[0]).toBe(0);
+    expect(Math.max(...seen)).toBeGreaterThan(0);
+  });
+
+  it('adaptively re-splits a chunk that truncates instead of failing', async () => {
+    const body = bodyOfParas(4, 3000);
+    let calls = 0;
+    const callForBody = vi.fn(async (sub: string) => {
+      calls += 1;
+      // The first (largest) span truncates; smaller re-split spans succeed.
+      if (sub.length > 4000) throw new AnalyzerTruncatedError('ollama', 'length', 2);
+      return { characters: [char(`c${calls}`)] };
+    });
+    const out = await runStage1ChapterChunked({
+      body,
+      charBudget: 999999, // force the single-call path, then truncation → forced split
+      callForBody,
+      mergeRosters,
+    });
+    expect(out.characters.length).toBeGreaterThan(0);
+  });
+
+  it('re-throws a non-truncation error', async () => {
+    const callForBody = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    await expect(
+      runStage1ChapterChunked({ body: 'x', charBudget: 9000, callForBody, mergeRosters }),
+    ).rejects.toThrow('boom');
+  });
+});
+
+describe('stage1ChunkBudgetForEngine', () => {
+  it('derives a smaller budget from num_ctx for local engines', () => {
+    // 16384 ctx × 0.7 × 2 = 22937 < configured 24000 → derived wins.
+    expect(stage1ChunkBudgetForEngine(24000, 16384, 'local')).toBe(22937);
+    // bigger ctx → bigger budget, capped at configured.
+    expect(stage1ChunkBudgetForEngine(24000, 32768, 'local')).toBe(24000);
+  });
+
+  it('never chunks cloud engines (huge budget)', () => {
+    expect(stage1ChunkBudgetForEngine(24000, 8192, 'gemini')).toBe(Number.MAX_SAFE_INTEGER);
+  });
+});

--- a/server/src/analyzer/stage1-chunk.ts
+++ b/server/src/analyzer/stage1-chunk.ts
@@ -1,0 +1,156 @@
+/* Stage-1 (cast detection) large-chapter chunking (plan 219 follow-on / srv-40).
+
+   Stage-1 sends a chapter's whole prose to the model to detect its speaking
+   roster. Unlike stage-2 (which got a chunker in #528), stage-1 had none — so a
+   very large chapter overflows the model's context window (`num_ctx`): the INPUT
+   alone fills the window, leaving no room for output, and Ollama stops with
+   `done_reason:'length'` after ~0 bytes (`AnalyzerTruncatedError`). A Cyrillic
+   book made this acute — non-Latin text tokenises to far more tokens per
+   character, and the book's chapters were unusually large (the 2026-06-16
+   `Ночной дозор` report: every chapter truncated after 1–1231 bytes).
+
+   This splits an over-budget chapter into paragraph-bounded sub-bodies, detects
+   the roster on each, and UNIONs the per-chunk rosters. The union is INJECTED
+   (`mergeRosters`, the route's `mergeRosterChapter`) so this module stays pure —
+   no I/O, no model calls, no prompt building, mirroring stage2-chunk.ts. The
+   accumulated roster is threaded into each later chunk's prompt (via
+   `callForBody`'s `knownSoFar`) so the model reuses ids for a character who
+   recurs across chunks instead of minting a divergent id.
+
+   A chapter that already fits the budget runs exactly one call and returns its
+   raw result — byte-identical to the pre-chunking behaviour for the overwhelming
+   majority of chapters. */
+
+import type { CharacterOutput } from '../handoff/schemas.js';
+import { AnalyzerTruncatedError } from './errors.js';
+import { configValue } from '../config/resolver.js';
+import { splitBodyIntoChunks, splitParagraphIntoSentences } from './stage2-chunk.js';
+
+/* Per-chunk INPUT char budget. Stage-1 output is small (a roster, not a
+   per-sentence list), so the binding constraint is the input fitting num_ctx
+   with room for the prompt scaffolding + the (small) output — not the output
+   cap that bounds stage-2. Conservative default; tuned down for local engines
+   from num_ctx. */
+export const DEFAULT_STAGE1_CHUNK_CHAR_BUDGET = 24000;
+
+/* Derive a safe per-chunk char budget from the local model's context window.
+   Reserve ~30% of num_ctx for the prompt header + roster + output, and assume a
+   pessimistic ~2 chars/token (Cyrillic and other non-Latin scripts tokenise far
+   denser than English's ~4 — budgeting for the dense case keeps a non-Latin
+   chapter from overflowing). Take the MIN with the configured default so this
+   only ever LOWERS the budget. Cloud engines keep the configured value. A
+   residual overflow is still caught by the adaptive re-split below. */
+export function stage1ChunkBudgetForEngine(
+  configured: number,
+  numCtxTokens: number,
+  engine: 'gemini' | 'local',
+): number {
+  /* Cloud engines have a huge context window and a small stage-1 output, so
+     there is no input-overflow to guard against — never chunk (one call per
+     chapter, unchanged). Only the local model has a tight `num_ctx`. */
+  if (engine !== 'local') return Number.MAX_SAFE_INTEGER;
+  const numCtxDerived = Math.floor(numCtxTokens * 0.7 * 2);
+  return Math.max(2000, Math.min(configured, numCtxDerived));
+}
+
+export function resolveStage1ChunkCharBudget(engine?: 'gemini' | 'local'): number {
+  if (engine !== 'local') return Number.MAX_SAFE_INTEGER; // cloud: never chunk stage-1
+  return stage1ChunkBudgetForEngine(
+    configValue<number>('analyzer.stage1.chunkCharBudget'),
+    configValue<number>('analyzer.ollama.numCtx'),
+    'local',
+  );
+}
+
+export interface Stage1ChunkRunResult {
+  characters: CharacterOutput[];
+  /** How many chunks the chapter was split into (1 = single-call path). */
+  chunkCount: number;
+}
+
+export interface Stage1ChunkRunOptions {
+  /** The full chapter prose. */
+  body: string;
+  /** Per-chunk char budget (resolveStage1ChunkCharBudget()). */
+  charBudget: number;
+  /** Build + run the stage-1 detection call for a sub-body. `knownSoFar` is the
+      roster accumulated from earlier chunks of THIS chapter (empty on the
+      single-call path + first chunk) — fold it into the prompt's known-roster so
+      a recurring character keeps one id across chunks. */
+  callForBody: (
+    subBody: string,
+    knownSoFar: CharacterOutput[],
+  ) => Promise<{ characters: CharacterOutput[] }>;
+  /** Injected roster union (the route's `mergeRosterChapter`) — folds a chunk's
+      characters into the accumulating Map. Keeps this module pure + testable. */
+  mergeRosters: (running: Map<string, CharacterOutput>, chars: CharacterOutput[]) => void;
+  /** Adaptive re-split recursion bound. Default 3. */
+  maxSplitDepth?: number;
+  /** Fired once per chunk before it runs (large-chapter progress). */
+  onChunk?: (info: { index: number; total: number; chars: number }) => void;
+}
+
+/** Detect a chapter's roster, transparently chunking when the body is larger
+    than `charBudget`. See the module header. */
+export async function runStage1ChapterChunked(
+  opts: Stage1ChunkRunOptions,
+): Promise<Stage1ChunkRunResult> {
+  const maxSplitDepth = opts.maxSplitDepth ?? 3;
+  const roster = new Map<string, CharacterOutput>();
+
+  /* Split an over-cap span for a retry: paragraph boundaries first (lossless),
+     then — when the span is a single paragraph that won't divide — sentence
+     boundaries. Mirrors stage2-chunk's splitSpanForRetry. */
+  const splitSpanForRetry = (span: string): string[] => {
+    const half = Math.max(1, Math.floor(span.length / 2));
+    const byParagraph = splitBodyIntoChunks(span, half);
+    if (byParagraph.length > 1) return byParagraph;
+    return splitParagraphIntoSentences(span, half);
+  };
+
+  /* Detect one span, splitting it further if the model truncates on it. */
+  const detectSpan = async (span: string, depth: number): Promise<void> => {
+    try {
+      const { characters } = await opts.callForBody(span, Array.from(roster.values()));
+      opts.mergeRosters(roster, characters);
+    } catch (err) {
+      if (err instanceof AnalyzerTruncatedError && depth < maxSplitDepth) {
+        const sub = splitSpanForRetry(span);
+        if (sub.length > 1) {
+          for (const s of sub) await detectSpan(s, depth + 1);
+          return;
+        }
+      }
+      throw err;
+    }
+  };
+
+  const chunks = splitBodyIntoChunks(opts.body, opts.charBudget);
+
+  if (chunks.length <= 1) {
+    /* Common case: chapter fits the char budget → one call, raw result
+       (byte-identical to the pre-chunking behaviour). If that single call
+       truncates anyway (a dense chapter under a smaller-than-assumed window),
+       fall back to the adaptive split instead of failing the chapter. A body
+       that's a single un-splittable paragraph still surfaces the truncation. */
+    try {
+      const { characters } = await opts.callForBody(opts.body, []);
+      return { characters, chunkCount: 1 };
+    } catch (err) {
+      if (!(err instanceof AnalyzerTruncatedError)) throw err;
+      const forced = splitSpanForRetry(opts.body);
+      if (forced.length <= 1) throw err;
+      for (let i = 0; i < forced.length; i += 1) {
+        opts.onChunk?.({ index: i, total: forced.length, chars: forced[i].length });
+        await detectSpan(forced[i], 1);
+      }
+      return { characters: Array.from(roster.values()), chunkCount: forced.length };
+    }
+  }
+
+  for (let i = 0; i < chunks.length; i += 1) {
+    opts.onChunk?.({ index: i, total: chunks.length, chars: chunks[i].length });
+    await detectSpan(chunks[i], 0);
+  }
+  return { characters: Array.from(roster.values()), chunkCount: chunks.length };
+}

--- a/server/src/config/registry.ts
+++ b/server/src/config/registry.ts
@@ -68,6 +68,16 @@ export const KNOBS: ConfigKnob[] = [
     apply: 'live', risk: 'medium',
   },
   {
+    key: 'analyzer.stage1.chunkCharBudget',
+    env: 'STAGE1_CHUNK_CHAR_BUDGET',
+    group: 'analyzer-chunking',
+    label: 'Stage-1 chunk char budget',
+    help: 'Maximum characters per stage-1 cast-detection chunk before the chapter is split. For local engines the effective budget is derived (lowered) from Ollama num_ctx so a large or non-Latin chapter can never overflow the context window.',
+    type: 'integer',
+    default: 24000, // ← DEFAULT_STAGE1_CHUNK_CHAR_BUDGET in analyzer/stage1-chunk.ts
+    apply: 'live', risk: 'medium',
+  },
+  {
     key: 'analyzer.stage2.minCoverage',
     env: 'STAGE2_MIN_COVERAGE',
     group: 'analyzer-chunking',
@@ -532,9 +542,9 @@ export const KNOBS: ConfigKnob[] = [
     env: 'ANALYZER_NUM_CTX',
     group: 'analyzer-sampling',
     label: 'Ollama num_ctx',
-    help: 'Context-window size handed to Ollama on every /api/chat call. Ollama keys the KV cache by (model, num_ctx), so warming with default 16384 and then changing it forces a re-load. Hardcoded today; registering this env name lifts it to a runtime knob.',
+    help: 'Context-window size handed to Ollama on every /api/chat call. Ollama keys the KV cache by (model, num_ctx), so warming with default 32768 and then changing it forces a re-load. Larger = more KV-cache VRAM; 32768 gives large/non-Latin chapters headroom (the stage-1/2 chunkers handle anything still over budget). Lower it if a bigger analyzer model strains the GPU.',
     type: 'integer', min: 0,
-    default: 16384, // ← ANALYZER_NUM_CTX constant in analyzer/ollama.ts (line 130)
+    default: 32768, // ← ANALYZER_NUM_CTX constant in analyzer/ollama.ts
     apply: 'live', risk: 'medium',
   },
   {

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -9,6 +9,7 @@ import { Router } from 'express';
 import type { Request, Response } from '../http.js';
 import { getOrHydrateManuscript } from '../store/manuscripts.js';
 import { safeBookId } from '../util/safe-id.js';
+import { runStage1ChapterChunked, resolveStage1ChunkCharBudget } from '../analyzer/stage1-chunk.js';
 import { makeThrottledHeartbeat } from './analysis-heartbeat.js';
 import { type AnalyzerSelection, type Analyzer, type StageCall } from '../analyzer/index.js';
 import {
@@ -2593,14 +2594,26 @@ export async function runMainAnalyzerJob(
             chapterId: ch.id,
             log,
             call: () =>
+              runStage1ChapterChunked({
+                body: ch.body,
+                charBudget: resolveStage1ChunkCharBudget(selection.engine),
+                mergeRosters: mergeRosterChapter,
+                onChunk: (sec) =>
+                  log(
+                    0,
+                    `Chapter ${i + 1}/${totalCastChapters} cast — large chapter, section ${
+                      sec.index + 1
+                    }/${sec.total} (${sec.chars.toLocaleString()} chars) to fit the model context…`,
+                  ),
+                callForBody: (subBody, knownSoFar) =>
               analyzer.runStage1Chapter(
             manuscriptId,
             ch.id,
             buildStage1ChapterInbox(
               manuscriptId,
               recordRef.title,
-              ch,
-              Array.from(rebuildRoster().values()),
+              { ...ch, body: subBody },
+              [...Array.from(rebuildRoster().values()), ...knownSoFar],
               seriesPrior,
             ),
             {
@@ -2659,6 +2672,7 @@ export async function runMainAnalyzerJob(
               },
             },
               ),
+              }).then((r) => ({ characters: r.characters })),
           });
         } catch (chErr) {
           /* Client disconnect propagates up — let the route's outer catch
@@ -4221,33 +4235,46 @@ async function runSubsetAnalyzerJob(
           chapterId: ch.id,
           log,
           call: () =>
-            analyzer.runStage1Chapter(
-              manuscriptId,
-              ch.id,
-              buildStage1ChapterInbox(
-                manuscriptId,
-                record.title,
-                ch,
-                Array.from(rebuildRoster().values()),
-                subsetSeriesPrior,
-              ),
-              {
-                signal: abortController.signal,
-                language: bookLanguage,
-                onWaiting: () => emitHeartbeat(0, ch.id),
-                onChunk: (info) => emitHeartbeat(0, ch.id, info),
-                onThrottle: (waitMs, reason) => {
-                  send({
-                    kind: 'throttle',
-                    phaseId: 0,
-                    chapterIndex: ch.id,
-                    model: subsetModelId,
-                    waitMs,
-                    reason,
-                  });
-                },
-              },
-            ),
+            runStage1ChapterChunked({
+              body: ch.body,
+              charBudget: resolveStage1ChunkCharBudget(selection.engine),
+              mergeRosters: mergeRosterChapter,
+              onChunk: (sec) =>
+                log(
+                  0,
+                  `Chapter ${ch.id} cast — large chapter, section ${sec.index + 1}/${
+                    sec.total
+                  } (${sec.chars.toLocaleString()} chars) to fit the model context…`,
+                ),
+              callForBody: (subBody, knownSoFar) =>
+                analyzer.runStage1Chapter(
+                  manuscriptId,
+                  ch.id,
+                  buildStage1ChapterInbox(
+                    manuscriptId,
+                    record.title,
+                    { ...ch, body: subBody },
+                    [...Array.from(rebuildRoster().values()), ...knownSoFar],
+                    subsetSeriesPrior,
+                  ),
+                  {
+                    signal: abortController.signal,
+                    language: bookLanguage,
+                    onWaiting: () => emitHeartbeat(0, ch.id),
+                    onChunk: (info) => emitHeartbeat(0, ch.id, info),
+                    onThrottle: (waitMs, reason) => {
+                      send({
+                        kind: 'throttle',
+                        phaseId: 0,
+                        chapterIndex: ch.id,
+                        model: subsetModelId,
+                        waitMs,
+                        reason,
+                      });
+                    },
+                  },
+                ),
+            }).then((r) => ({ characters: r.characters })),
         });
         chapterCast[ch.id] = result.characters;
         cache.chapterCast = chapterCast;

--- a/server/src/routes/ollama-health.test.ts
+++ b/server/src/routes/ollama-health.test.ts
@@ -192,7 +192,7 @@ describe('POST /api/ollama/load', () => {
        in server/src/analyzer/ollama.ts). Either drifting triggers a
        full model reload on the first real analysis call and the SSE
        dies mid-stream — the "Try Again" infinite-loop bug. */
-    expect(body.options?.num_ctx).toBe(16384);
+    expect(body.options?.num_ctx).toBe(32768);
     expect(body.options?.num_gpu).toBe(999);
   });
 
@@ -217,7 +217,7 @@ describe('POST /api/ollama/load', () => {
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(body.model).toBe('llama3.1:8b');
     expect(body.keep_alive).toBe('5m');
-    expect(body.options?.num_ctx).toBe(16384);
+    expect(body.options?.num_ctx).toBe(32768);
     expect(body.options?.num_gpu).toBe(999);
   });
 });


### PR DESCRIPTION
## Summary

Fixes Phase-0a (cast detection) truncating on very large chapters — surfaced by a Cyrillic book (`Ночной дозор`) where **every** chapter failed with `ollama output truncated (reason=length) after ~0 bytes`.

Root cause: Stage-1 cast detection had **no chunker** (only Stage-2 got one, #528), so a chapter whose prose exceeds Ollama's `num_ctx` fills the context window with input, leaving no room for output → instant `done_reason:'length'`, chapter dropped from the roster. Cyrillic made it acute (denser tokenisation + unusually large chapters), but it's a general large-chapter gap.

**Fix (both levers):**
- `num_ctx` 16384 → 32768 (`ollama.ts` const + registry default + `.env.example`) for headroom so fewer chapters need splitting.
- New `server/src/analyzer/stage1-chunk.ts` `runStage1ChapterChunked`, mirroring the Stage-2 chunker: split an over-budget chapter into paragraph-bounded sub-bodies, detect each, **union** the rosters (injects the route's `mergeRosterChapter`, so the module stays pure), thread the accumulated roster into later chunks (a recurring character keeps one id), and adaptively re-split a chunk that still truncates. Local budget derives from `num_ctx`; **cloud engines never chunk** (huge context, small output). Within-budget chapters run exactly one call (byte-identical). Wired into both Phase-0a call sites. New knob `analyzer.stage1.chunkCharBudget`.

## Test plan

- New `server/src/analyzer/stage1-chunk.test.ts` — single-call / split+union / roster-threading / adaptive re-split / num_ctx-derived budget.
- `ollama.test.ts` + `ollama-health.test.ts` num_ctx assertions updated to 32768.
- `analysis.test.ts` + `analysis-pipelining.test.ts` (the end-to-end Phase-0a driver) green.
- Full `npm run verify` battery green at push (typecheck + lint + all tests + e2e + build).

Note: pre-commit was skipped on two commits due to a local `test:server` fork-contention flake under heavy machine load (50 Chrome procs); the **push ran the complete verify battery** as the gate.

Refs #823 (srv-40). Plan 219 implementation notes updated.