### PR TITLE
feat(server): cast name-fidelity + no-spurious-merge guardrails

### DIFF
--- a/docs/features/219-non-latin-names-and-ids.md
+++ b/docs/features/219-non-latin-names-and-ids.md
@@ -310,6 +310,26 @@ Fixed (maintainer chose "both"):
 - Tests: `stage1-chunk.test.ts` (single-call / split+union / roster-threading /
   adaptive re-split / budget derivation).
 
+### Follow-on — cast name fidelity (2026-06-16)
+
+On-box Russian testing showed the local 4B model **copying surnames** across
+characters (`Сергеевич Городецкий` / `Назарова` smeared from Anton / Svetlana
+onto unrelated cast) and **folding distinct names** together (`Игорь`↔`Илья`,
+`Гарик`↔`Игорь`). The Phase-0a prompt had strong id-reuse guidance but no
+anti-invention / anti-merge guardrail. Fixes:
+- Prompt: a **name-fidelity** rule (use the name exactly as the text uses it;
+  never add/copy a surname/patronymic/title; aliases only for forms the text
+  itself equates) + a **no-spurious-merge** rule (distinct names are separate
+  people unless the text explicitly equates them).
+- Dropped the Stage-1 chunker's **intra-chapter roster-threading** (it fed those
+  full names into every section, amplifying the smear); cross-chapter id
+  stability still comes from the book-level running roster.
+- Live ETA: also shipped section-progress refinement for the Phase-0a ticker so
+  the first chapter no longer reads "over budget" (`refineCastChapterEstMs`).
+
+Caveat: these reduce but don't eliminate the errors on a 4B local model over
+Russian — the reliable fix for name/alias fidelity is the **Gemini analyzer**.
+
 ### Owed (on-box acceptance — issue to file)
 
 - **ffmpeg + Cyrillic filesystem paths on Windows.** Book directories already use

--- a/server/src/analyzer/stage1-chunk.test.ts
+++ b/server/src/analyzer/stage1-chunk.test.ts
@@ -3,7 +3,8 @@
      (byte-identical to pre-chunking),
    - an over-budget chapter is split, each chunk detected, rosters UNIONed
      (a character recurring across chunks collapses to one entry),
-   - later chunks receive the accumulated roster (so the model can reuse ids),
+   - each section is detected independently (the intra-chapter roster is NOT
+     threaded — it amplified a small-model surname-smear on Russian),
    - a chunk that truncates is adaptively re-split rather than failing the
      chapter,
    - the local budget derives from num_ctx. */
@@ -60,7 +61,12 @@ describe('runStage1ChapterChunked', () => {
       n += 1;
       return { characters: [char('anton'), char(`extra${n}`)] };
     });
-    const out = await runStage1ChapterChunked({ body, charBudget: 5000, callForBody, mergeRosters });
+    const out = await runStage1ChapterChunked({
+      body,
+      charBudget: 5000,
+      callForBody,
+      mergeRosters,
+    });
     expect(out.chunkCount).toBeGreaterThan(1);
     expect(callForBody).toHaveBeenCalledTimes(out.chunkCount);
     // "anton" appears once despite being detected in every chunk.
@@ -69,17 +75,17 @@ describe('runStage1ChapterChunked', () => {
     expect(out.characters.filter((c) => c.id.startsWith('extra'))).toHaveLength(out.chunkCount);
   });
 
-  it('threads the accumulated roster into later chunks', async () => {
-    const body = bodyOfParas(4, 3000); // > budget → ≥2 chunks
-    const seen: number[] = [];
-    const callForBody = vi.fn(async (_sub: string, knownSoFar: CharacterOutput[]) => {
-      seen.push(knownSoFar.length);
+  it('detects each section independently — does NOT thread the intra-chapter roster', async () => {
+    // Threading the accumulated roster into later sections amplified a small-model
+    // surname-smear on Russian (2026-06-16), so callForBody now takes ONLY the
+    // sub-body — section context comes solely from the caller's book-level roster.
+    const body = bodyOfParas(4, 3000);
+    const callForBody = vi.fn(async (...args: unknown[]) => {
+      expect(args).toHaveLength(1); // sub-body only, no roster argument
       return { characters: [char('anton')] };
     });
     await runStage1ChapterChunked({ body, charBudget: 4000, callForBody, mergeRosters });
-    // first chunk sees nothing; a later chunk sees the accumulated roster.
-    expect(seen[0]).toBe(0);
-    expect(Math.max(...seen)).toBeGreaterThan(0);
+    expect(callForBody.mock.calls.every((c) => c.length === 1)).toBe(true);
   });
 
   it('adaptively re-splits a chunk that truncates instead of failing', async () => {

--- a/server/src/analyzer/stage1-chunk.ts
+++ b/server/src/analyzer/stage1-chunk.ts
@@ -12,10 +12,15 @@
    This splits an over-budget chapter into paragraph-bounded sub-bodies, detects
    the roster on each, and UNIONs the per-chunk rosters. The union is INJECTED
    (`mergeRosters`, the route's `mergeRosterChapter`) so this module stays pure —
-   no I/O, no model calls, no prompt building, mirroring stage2-chunk.ts. The
-   accumulated roster is threaded into each later chunk's prompt (via
-   `callForBody`'s `knownSoFar`) so the model reuses ids for a character who
-   recurs across chunks instead of minting a divergent id.
+   no I/O, no model calls, no prompt building, mirroring stage2-chunk.ts.
+
+   Each section is detected INDEPENDENTLY against the book-level running roster
+   the caller supplies — the accumulated intra-chapter roster is deliberately NOT
+   threaded into later sections. Threading it amplified a small-model failure on
+   non-Latin text (2026-06-16): seeing a full name like "Антон Сергеевич
+   Городецкий" in the section-N prompt, qwen3.5:4b copied the surname onto
+   unrelated characters in section N+1 and folded distinct names together.
+   Cross-CHAPTER id stability still comes from the caller's running roster.
 
    A chapter that already fits the budget runs exactly one call and returns its
    raw result — byte-identical to the pre-chunking behaviour for the overwhelming
@@ -73,14 +78,10 @@ export interface Stage1ChunkRunOptions {
   body: string;
   /** Per-chunk char budget (resolveStage1ChunkCharBudget()). */
   charBudget: number;
-  /** Build + run the stage-1 detection call for a sub-body. `knownSoFar` is the
-      roster accumulated from earlier chunks of THIS chapter (empty on the
-      single-call path + first chunk) — fold it into the prompt's known-roster so
-      a recurring character keeps one id across chunks. */
-  callForBody: (
-    subBody: string,
-    knownSoFar: CharacterOutput[],
-  ) => Promise<{ characters: CharacterOutput[] }>;
+  /** Build + run the stage-1 detection call for a sub-body. Each section is
+      detected independently against the caller's book-level running roster (the
+      intra-chapter accumulation is intentionally NOT passed — see header). */
+  callForBody: (subBody: string) => Promise<{ characters: CharacterOutput[] }>;
   /** Injected roster union (the route's `mergeRosterChapter`) — folds a chunk's
       characters into the accumulating Map. Keeps this module pure + testable. */
   mergeRosters: (running: Map<string, CharacterOutput>, chars: CharacterOutput[]) => void;
@@ -111,7 +112,7 @@ export async function runStage1ChapterChunked(
   /* Detect one span, splitting it further if the model truncates on it. */
   const detectSpan = async (span: string, depth: number): Promise<void> => {
     try {
-      const { characters } = await opts.callForBody(span, Array.from(roster.values()));
+      const { characters } = await opts.callForBody(span);
       opts.mergeRosters(roster, characters);
     } catch (err) {
       if (err instanceof AnalyzerTruncatedError && depth < maxSplitDepth) {
@@ -134,7 +135,7 @@ export async function runStage1ChapterChunked(
        fall back to the adaptive split instead of failing the chapter. A body
        that's a single un-splittable paragraph still surfaces the truncation. */
     try {
-      const { characters } = await opts.callForBody(opts.body, []);
+      const { characters } = await opts.callForBody(opts.body);
       return { characters, chunkCount: 1 };
     } catch (err) {
       if (!(err instanceof AnalyzerTruncatedError)) throw err;

--- a/server/src/routes/analysis.test.ts
+++ b/server/src/routes/analysis.test.ts
@@ -1273,6 +1273,21 @@ describe('buildStage1ChapterInbox — Phase 0a per-chapter prompt', () => {
     expect(inbox).toContain("I'd just settled into bed when Wren hailed me.");
   });
 
+  it('carries the name-fidelity + no-spurious-merge guardrails (2026-06-16 Russian surname-smear / Игорь↔Илья)', () => {
+    const inbox = buildStage1ChapterInbox(
+      'mns_test',
+      'Night Watch',
+      { id: 1, title: 'Chapter 1', body: 'Body.' },
+      [],
+    );
+    // #1 name fidelity — no invented/copied surnames.
+    expect(inbox).toMatch(/Name fidelity/i);
+    expect(inbox).toMatch(/never copy another character'?s surname/i);
+    // #3 no spurious merge of distinct names.
+    expect(inbox).toMatch(/Do not merge distinct characters/i);
+    expect(inbox).toMatch(/explicitly equates them/i);
+  });
+
   it('renders the broadened first-person guidance so journal/registry chapters detect their author (regression for The Floodmark)', () => {
     const inbox = buildStage1ChapterInbox(
       'mns_test',

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -1275,6 +1275,23 @@ appears only by being mentioned or described in this chapter (no spoken
 line and not the author of the chapter's prose), omit them from this
 chapter's output.
 
+**Name fidelity — do not invent or copy names.** Set each character's
+\`name\` to exactly how THIS text refers to them. Never add a surname,
+patronymic, honorific, or title that the text does not use for that
+specific character, and never copy another character's surname onto them
+— even if other characters or the running roster have one. If the text
+only ever calls someone "Игорь" / "Olga", their name is "Игорь" / "Olga",
+not "Игорь Smith" / "Olga Petrova". \`aliases\` are ONLY for alternate
+forms the text itself uses for the SAME person (a nickname the narration
+explicitly attaches, a first-name/full-name pair the text equates).
+
+**Do not merge distinct characters.** Two characters with different names
+are SEPARATE people unless this text explicitly equates them (e.g.
+"Игорь, whom everyone called Гарик"). Do NOT fold one into the other via
+\`aliases\` just because the names are similar, or because one is a common
+nickname of the other in general — only the text of THIS book decides.
+When unsure, keep them separate.
+
 Return ONLY a JSON object matching the schema. No prose, no code fences.
 
 ## Manuscript metadata
@@ -2664,7 +2681,7 @@ export async function runMainAnalyzerJob(
                   );
                   sendCastLiveTick();
                 },
-                callForBody: (subBody, knownSoFar) =>
+                callForBody: (subBody) =>
                   analyzer.runStage1Chapter(
                     manuscriptId,
                     ch.id,
@@ -2672,7 +2689,7 @@ export async function runMainAnalyzerJob(
                       manuscriptId,
                       recordRef.title,
                       { ...ch, body: subBody },
-                      [...Array.from(rebuildRoster().values()), ...knownSoFar],
+                      Array.from(rebuildRoster().values()),
                       seriesPrior,
                     ),
                     {
@@ -4338,7 +4355,7 @@ async function runSubsetAnalyzerJob(
                     sec.total
                   } (${sec.chars.toLocaleString()} chars) to fit the model context…`,
                 ),
-              callForBody: (subBody, knownSoFar) =>
+              callForBody: (subBody) =>
                 analyzer.runStage1Chapter(
                   manuscriptId,
                   ch.id,
@@ -4346,7 +4363,7 @@ async function runSubsetAnalyzerJob(
                     manuscriptId,
                     record.title,
                     { ...ch, body: subBody },
-                    [...Array.from(rebuildRoster().values()), ...knownSoFar],
+                    Array.from(rebuildRoster().values()),
                     subsetSeriesPrior,
                   ),
                   {


### PR DESCRIPTION
## Summary

On-box Russian testing showed `qwen3.5:4b` **copying surnames** across characters (`Сергеевич Городецкий` / `Назарова` smeared from Anton/Svetlana onto unrelated cast) and **folding distinct names** together (`Игорь`↔`Илья`, `Гарик`↔`Игорь`). The Phase-0a prompt had strong id-reuse guidance but no anti-invention/anti-merge guardrail.

Three fixes:
1. **Prompt — name fidelity:** set `name` exactly as the text uses it; never add/copy a surname/patronymic/title; aliases only for forms the text equates.
2. **Prompt — no spurious merge:** differently-named characters are separate unless the text explicitly equates them (e.g. "Игорь, called Гарик"); don't fold on nickname-similarity alone.
3. **Dropped the Stage-1 chunker's intra-chapter roster-threading** — it fed full names into every section, amplifying the smear. `callForBody` now takes only the sub-body; cross-chapter id stability still comes from the book-level running roster.

## Test plan
- `buildStage1ChapterInbox` asserts both guardrails; `stage1-chunk` asserts no roster threading (callForBody arity 1); `analysis` + `stage1-chunk` suites green (125).
- Full `npm run verify` battery passed every assertion (2744+ server tests, 0 failures); the push hit only the known `test:server` fork-contention flake (worker crash, no real failure) because a live analysis run was competing for the box — pushed `--no-verify` with maintainer sign-off. CI is opt-in.

Caveat: reduces but doesn't eliminate the errors on a 4B local model over Russian — Gemini analyzer is the reliable ceiling.

Refs #823 (srv-40). Plan 219 follow-on.