### PR TITLE
fix(sidecar): force onnxruntime-gpu via ORT swap, not kokoro-onnx[gpu]

### DIFF
--- a/docs/features/archive/217-amd-gpu-support.md
+++ b/docs/features/archive/217-amd-gpu-support.md
@@ -237,3 +237,26 @@ Phase-2 section above + spec "Spike findings"):
 on **ROCm** on a supported AMD card + pin the wheel sha256s into `model-hashes.json`
 (the author's 780M iGPU is not ROCm-supported); Phase-1 CPU-only + macOS fresh-install
 synth (B/C). These reopen this plan from archive only if beta surfaces a real failure.
+
+### Post-ship hardening — NVIDIA Kokoro forced to `onnxruntime-gpu` (2026-06-16)
+
+**Supersedes the "NVIDIA regression fence: `onnxruntime-gpu` via `kokoro-onnx[gpu]`"
+claims above (lines ~32, 42, 47).** On-box, a stamped-`nvidia` venv was found running
+Kokoro on the **CPU**: `kokoro-onnx[gpu]` declares plain `onnxruntime` as a *core* dep
+and only *adds* `onnxruntime-gpu` via the extra; both land in the same `onnxruntime/`
+import namespace and pip's resolution order can leave the CPU build winning →
+`CUDAExecutionProvider` absent → silent CPU-only Kokoro on a GPU box.
+
+Fix (branch `fix/sidecar-nvidia-ort-gpu-enforce`): the `install-ort.mjs` ORT swap —
+previously AMD/DirectML-only — is now the **single GPU-runtime enforcement point for
+every profile**. The overlay carries **plain `kokoro-onnx`** (deterministic core
+`onnxruntime`); `planOrtSwap` swaps to the profile's `ortPackage` whenever it isn't
+plain `onnxruntime` (nvidia → `onnxruntime-gpu`), and `installForProfile` runs the swap
+in the generic branch too — a swap failure is now **fatal** (no silent CPU fallback on
+a GPU box). macOS stays on plain `onnxruntime` (the swap is nvidia-only, so no broken
+bare-`onnxruntime-gpu` line in the shared overlay). Paired tests:
+`install-ort-helpers.test.ts` (nvidia → swap), `bootstrap-venv-helpers.test.ts` (nvidia
+overlay + swap, swap-failure fatal), `requirements-layout.test.ts` +
+`test_requirements.py` (overlay is plain `kokoro-onnx`, never `[gpu]` / bare
+`onnxruntime-gpu`). This changes `nvidia-cuda.txt`'s reqHash, so existing nvidia venvs
+self-heal via a `pip-in-place` on next bootstrap.

--- a/server/src/tts/bootstrap-venv-helpers.test.ts
+++ b/server/src/tts/bootstrap-venv-helpers.test.ts
@@ -39,11 +39,23 @@ describe('bootstrap-venv helpers', () => {
 });
 
 describe('installForProfile — Auto + CPU fallback (AMD phase 2)', () => {
-  it('nvidia installs its overlay directly and returns nvidia', () => {
+  it('nvidia installs its overlay then swaps onnxruntime → onnxruntime-gpu', () => {
     const pip = fakePip();
     expect(installForProfile('/py', 'nvidia', pip.run, 'win32', null)).toBe('nvidia');
-    expect(pip.calls).toHaveLength(1);
-    expect(pip.calls[0].join(' ')).toMatch(/install -r .*nvidia-cuda\.txt/);
+    const joined = pip.calls.map((c) => c.join(' '));
+    // overlay first (pulls plain onnxruntime via kokoro-onnx), then the GPU swap —
+    // so onnxruntime-gpu unambiguously owns the shared onnxruntime/ namespace.
+    expect(joined[0]).toMatch(/install -r .*nvidia-cuda\.txt/);
+    expect(joined[1]).toBe('uninstall -y onnxruntime');
+    expect(joined[2]).toBe('install onnxruntime-gpu');
+    expect(pip.calls).toHaveLength(3);
+  });
+
+  it('nvidia: a failed ORT swap is fatal (no silent CPU-only Kokoro)', () => {
+    const pip = fakePip(['onnxruntime-gpu']); // the GPU install step fails
+    expect(() => installForProfile('/py', 'nvidia', pip.run, 'win32', null)).toThrow(
+      /ONNX runtime swap failed/,
+    );
   });
 
   it('amd success: pre-installs ROCm wheels + amd overlay, returns amd', () => {

--- a/server/src/tts/install-ort-helpers.test.ts
+++ b/server/src/tts/install-ort-helpers.test.ts
@@ -3,17 +3,25 @@ import { describe, it, expect } from 'vitest';
 import { planOrtSwap } from '../../tts-sidecar/scripts/install-ort.mjs';
 
 describe('planOrtSwap', () => {
+  // The overlay ALWAYS installs plain `onnxruntime` (kokoro-onnx's core dep). The
+  // swap then replaces it with whatever GPU runtime the profile actually needs —
+  // keyed on installRecipe.ortPackage. Any package other than plain 'onnxruntime'
+  // (today: nvidia → onnxruntime-gpu; a future DirectML re-enable → -directml) is a
+  // swap; 'onnxruntime' itself is a no-op.
+  it('nvidia → swap plain onnxruntime → onnxruntime-gpu', () => {
+    const plan = planOrtSwap('nvidia', 'win32');
+    expect(plan.action).toBe('swap');
+    expect(plan.steps).toEqual([
+      ['uninstall', '-y', 'onnxruntime'],
+      ['install', 'onnxruntime-gpu'],
+    ]);
+  });
+
   // S0.1 RESOLVED (2026-06-15): DirectML can't run the Kokoro model, so the AMD
-  // profile installs plain onnxruntime (CPU EP) — no onnxruntime-directml swap on
-  // any OS. The swap logic stays (keyed on installRecipe.ortPackage ===
-  // 'onnxruntime-directml') so re-enabling DirectML later is a one-line revert.
+  // profile installs plain onnxruntime (CPU EP) — no swap on any OS.
   it('amd → skip on every OS (DirectML disabled; plain onnxruntime, no swap)', () => {
     expect(planOrtSwap('amd', 'win32').action).toBe('skip');
     expect(planOrtSwap('amd', 'linux').action).toBe('skip');
-  });
-
-  it('nvidia → skip (onnxruntime-gpu arrives via kokoro-onnx[gpu], no swap)', () => {
-    expect(planOrtSwap('nvidia', 'win32').action).toBe('skip');
   });
 
   it('cpu → skip (plain onnxruntime installed by the overlay)', () => {

--- a/server/src/tts/requirements-layout.test.ts
+++ b/server/src/tts/requirements-layout.test.ts
@@ -26,14 +26,19 @@ describe('layered requirements (base + nvidia/cpu/amd overlays)', () => {
   // extra was dropped (commit b2a1ac19) — torchcodec only ships cores for FFmpeg
   // 4–7 and is only needed on torch >=2.9; we pin torch 2.8, so torchaudio keeps
   // in-core audio I/O and [codec] is unnecessary. torch/torchaudio are EXPLICIT
-  // (coqui-tts 0.27.5 dropped the transitive torch dep).
-  it('nvidia overlay == TODAY: explicit pinned torch 2.8 + kokoro-onnx[gpu], NO [codec]', () => {
+  // (coqui-tts 0.27.5 dropped the transitive torch dep). Kokoro is PLAIN (no [gpu]
+  // extra): onnxruntime-gpu is installed by the nvidia ORT swap (install-ort.mjs),
+  // not the overlay — so the [gpu] extra can't leave the CPU build owning the
+  // shared onnxruntime/ namespace (the 2026-06-16 silent-CPU-Kokoro regression).
+  it('nvidia overlay == TODAY: explicit pinned torch 2.8 + plain kokoro-onnx, NO [gpu]/[codec]', () => {
     const n = read('nvidia-cuda.txt');
     expect(n).toMatch(/^coqui-tts/m);
     expect(n).not.toMatch(/coqui-tts\[codec\]/);
     expect(n).toMatch(/^torch==2\.8\.0/m);
     expect(n).toMatch(/^torchaudio==2\.8\.0/m);
-    expect(n).toMatch(/kokoro-onnx\[gpu\]/);
+    expect(n).toMatch(/^kokoro-onnx\b/m);
+    expect(n).not.toMatch(/^kokoro-onnx\[gpu\]/m); // anchored: a requirement line, not the explanatory comment
+    expect(n).not.toMatch(/^onnxruntime-gpu/m); // swap-only; never in the shared overlay
   });
 
   it('requirements.txt shim points at the nvidia-cuda overlay (sole legacy default)', () => {

--- a/server/tts-sidecar/README.md
+++ b/server/tts-sidecar/README.md
@@ -14,7 +14,7 @@ torch dependency tree doesn't leak into Node tooling.
 | → CPU / macOS | PyPI default = CPU / MPS build | |
 | coqui-tts | `>=0.24.0` (resolves ~0.27.x), **no `[codec]` extra** | 0.27.5 dropped its transitive torch (torch now explicit); `[codec]` dropped → no torchcodec |
 | **torchcodec** | **not installed** | only needed on torch ≥2.9; its cores support FFmpeg 4–7 only (fails vs FFmpeg 8) — sidestepped by pinning torch <2.9 |
-| kokoro-onnx | `[gpu]>=0.4.0,<0.5.0` | onnxruntime-gpu via the platform-gated extra; no torch |
+| kokoro-onnx | `>=0.4.0,<0.5.0` (plain, **no `[gpu]`**) | overlay lands core `onnxruntime` (CPU); `install-ort.mjs` swaps in `onnxruntime-gpu` on the nvidia profile. `[gpu]` is avoided — it coexists with the core dep and can silently leave CPU onnxruntime winning. No torch |
 | transformers | `>=4.45,<5.0` | coqui-tts compat cap |
 
 ## Accelerator profiles (NVIDIA / AMD / CPU / Apple)

--- a/server/tts-sidecar/requirements/nvidia-cuda.txt
+++ b/server/tts-sidecar/requirements/nvidia-cuda.txt
@@ -41,12 +41,16 @@ torchaudio==2.8.0
 # DeepSpeed isn't available.
 
 # Kokoro v1 — quality-tuned local TTS engine, eagerly loaded at sidecar startup.
-# The [gpu] extra pulls onnxruntime-gpu ONLY on x86_64 non-macOS (kokoro-onnx's
-# own platform marker); plain onnxruntime always comes from the core dep, so a
-# macOS / Apple Silicon install gets the CPU/CoreML runtime and `pip install`
-# succeeds. Run scripts/install-kokoro.{ps1,sh} once to fetch the model + voices
-# manifest into voices/kokoro/ (gitignored, ~330 MB).
-kokoro-onnx[gpu]>=0.4.0,<0.5.0
+# Installed PLAIN (no [gpu] extra) so it deterministically lands the core
+# `onnxruntime` (CPU) module; install-ort.mjs then swaps in the GPU runtime the
+# profile needs (nvidia → onnxruntime-gpu) as the single enforcement point. We do
+# NOT use kokoro-onnx[gpu]: that extra coexists with the core onnxruntime dep, and
+# pip's resolution order can leave the CPU build owning the shared `onnxruntime/`
+# namespace → a silent CPU-only Kokoro on a GPU box (the 2026-06-16 regression).
+# macOS/Apple-Silicon keeps the plain CPU/CoreML runtime (no swap for non-nvidia).
+# Run scripts/install-kokoro.{ps1,sh} once to fetch the model + voices manifest
+# into voices/kokoro/ (gitignored, ~330 MB).
+kokoro-onnx>=0.4.0,<0.5.0
 
 # Qwen3-TTS — per-character bespoke voices via design -> clone -> cache ->
 # reuse (plan 108). NOT a fixed-voice catalog like Kokoro; voices are designed

--- a/server/tts-sidecar/scripts/accelerator-profile.mjs
+++ b/server/tts-sidecar/scripts/accelerator-profile.mjs
@@ -134,7 +134,9 @@ export function ortProviders(profile, platform) {
  * USED to arrive transitively via coqui-tts, but coqui-tts 0.27.5 dropped that
  * declaration, so it is now pinned explicitly in the overlay; null here means
  * "nothing extra beyond the requirements," not "torch is transitive." NVIDIA ORT
- * is `onnxruntime-gpu` via kokoro-onnx[gpu]. AMD pre-installs the ROCm torch
+ * is `onnxruntime-gpu`, swapped in by install-ort.mjs after the overlay (which
+ * carries plain kokoro-onnx → core onnxruntime) — NOT via kokoro-onnx[gpu], whose
+ * extra can leave the CPU build owning the namespace. AMD pre-installs the ROCm torch
  * wheels (a {wheels:[…]} list) BEFORE the engine packages — install-torch.mjs
  * runs them; their alpha local-version tags can't be pinned in amd-rocm.txt.
  * The CPU recipe (cpu-index torch) is a Phase-2 improvement.

--- a/server/tts-sidecar/scripts/bootstrap-venv.mjs
+++ b/server/tts-sidecar/scripts/bootstrap-venv.mjs
@@ -178,6 +178,20 @@ export function installForProfile(
   if (!runPip(['install', '-r', overlayPath(profile)])) {
     throw new Error(`pip install failed for the ${profile} overlay`);
   }
+  // Put the right Kokoro ONNX runtime in place. The overlay lands plain
+  // `onnxruntime` (kokoro-onnx's core dep); nvidia swaps it for onnxruntime-gpu so
+  // CUDAExecutionProvider is actually available (a missing swap = silent CPU-only
+  // Kokoro on a GPU box). A swap failure is fatal here — better to fail the install
+  // loudly than ship a GPU box that quietly synthesises on the CPU.
+  const ort = planOrtSwap(profile, platform);
+  if (ort.action === 'swap') {
+    log(`swapping ONNX runtime → the ${profile} GPU build`);
+    for (const step of ort.steps) {
+      if (!runPip(step)) {
+        throw new Error(`ONNX runtime swap failed (pip ${step.join(' ')}) for the ${profile} overlay`);
+      }
+    }
+  }
   return profile;
 }
 

--- a/server/tts-sidecar/scripts/install-ort.mjs
+++ b/server/tts-sidecar/scripts/install-ort.mjs
@@ -1,15 +1,22 @@
 #!/usr/bin/env node
-// install-ort.mjs — the AMD-Windows ONNX-runtime swap (S0.3). Kokoro is installed
-// plain (`kokoro-onnx`, no [gpu] extra), which pulls the base `onnxruntime` CPU
-// module. To run Kokoro on DirectML we must REPLACE that module with
-// `onnxruntime-directml` — the two can't co-exist (same import name). This runs
-// AFTER the requirements overlay install (Wave B wires it into the bootstrap
-// flow). No-op for every non-amd-win profile, where the overlay's onnxruntime
-// (or onnxruntime-gpu via kokoro-onnx[gpu]) is already correct.
+// install-ort.mjs — the ONNX-runtime swap that puts the RIGHT Kokoro runtime in
+// place after the requirements overlay. The overlay always installs plain
+// `onnxruntime` (kokoro-onnx's core dependency — see requirements/nvidia-cuda.txt),
+// so any profile whose Kokoro must run on a GPU runtime has to REPLACE that module
+// with the accelerator-specific one (they all share the `onnxruntime` import name
+// and can't co-exist reliably):
+//   - nvidia  → onnxruntime-gpu      (CUDAExecutionProvider)
+//   - amd-win → onnxruntime-directml (disabled after S0.1 — Kokoro stays CPU)
+//   - cpu/apple → no swap (plain onnxruntime is correct)
+// This is the SINGLE enforcement point for GPU Kokoro: we deliberately do NOT lean
+// on `kokoro-onnx[gpu]`, because that extra coexists with the core `onnxruntime`
+// dep and pip's resolution order can leave the CPU build owning the namespace — a
+// silent CPU-only Kokoro on a GPU box (the 2026-06-16 regression). Runs AFTER the
+// overlay install (bootstrap-venv.mjs wires it into every profile's flow).
 // Pure planner (planOrtSwap) + guarded CLI, mirroring install-torch.mjs.
 //
-// Usage (Phase 2 bootstrap wires this; manual form for testing):
-//   CASTWRIGHT_ACCELERATOR_PROFILE=amd node install-ort.mjs <venv-python>
+// Usage (the bootstrap wires this; manual form for testing):
+//   CASTWRIGHT_ACCELERATOR_PROFILE=nvidia node install-ort.mjs <venv-python>
 //
 // NOTE: the minimum working onnxruntime-directml version (the release carrying
 // the Kokoro ConvTranspose fix) is OWED on real AMD hardware (Wave H1). Until
@@ -20,17 +27,19 @@ import { pathToFileURL } from 'node:url';
 import { installRecipe } from './accelerator-profile.mjs';
 
 /**
- * Decide the ordered pip steps to put the correct ONNX runtime in place after
- * the overlay install. Only amd+win needs a swap (base onnxruntime →
- * onnxruntime-directml); every other profile already has the right runtime from
- * its overlay. Pure — no I/O. `steps` are pip sub-command arg arrays, run in
- * order with the venv python.
+ * Decide the ordered pip steps to put the correct ONNX runtime in place after the
+ * overlay install. The overlay always lands plain `onnxruntime` (kokoro-onnx's
+ * core dep), so any profile whose recipe needs a different ortPackage (nvidia →
+ * onnxruntime-gpu; a future DirectML re-enable → onnxruntime-directml) is a swap;
+ * a recipe that already wants plain `onnxruntime` (cpu/amd/apple) is a no-op. Pure
+ * — no I/O. `steps` are pip sub-command arg arrays, run in order with the venv
+ * python.
  * @returns {{action:'skip', reason:string} | {action:'swap', steps:string[][]}}
  */
 export function planOrtSwap(profile, platform) {
   const { ortPackage } = installRecipe(profile, platform);
-  if (ortPackage !== 'onnxruntime-directml') {
-    return { action: 'skip', reason: `${ortPackage} is installed by the overlay; no swap` };
+  if (ortPackage === 'onnxruntime') {
+    return { action: 'skip', reason: 'plain onnxruntime from the overlay is correct; no swap' };
   }
   return {
     action: 'swap',

--- a/server/tts-sidecar/scripts/venv-migration.mjs
+++ b/server/tts-sidecar/scripts/venv-migration.mjs
@@ -88,9 +88,9 @@ export function classifyVenvState({ venvExists, stamp, required }) {
 /**
  * The requirements overlay file for an install profile. amd/cpu get their own
  * overlay; nvidia, apple, and anything unrecognised fall back to the nvidia-cuda
- * overlay — which is also the mac-safe set (kokoro-onnx[gpu] degrades to plain
- * onnxruntime on darwin, torch from PyPI gives the mps build), preserving today's
- * NVIDIA + macOS behaviour. Pure.
+ * overlay — which is also the mac-safe set (plain kokoro-onnx gives the CPU/CoreML
+ * onnxruntime, the GPU swap is nvidia-only, torch from PyPI gives the mps build),
+ * preserving today's NVIDIA + macOS behaviour. Pure.
  * @param {string} profile
  * @returns {string} a filename under requirements/
  */

--- a/server/tts-sidecar/tests/test_requirements.py
+++ b/server/tts-sidecar/tests/test_requirements.py
@@ -1,6 +1,12 @@
-"""Lock the onnxruntime dependency strategy: the GPU runtime must be pulled via
-kokoro-onnx's platform-gated [gpu] extra, NOT a bare unmarked onnxruntime-gpu
-line (which has no macOS wheel and aborts `pip install` on Apple Silicon).
+"""Lock the onnxruntime dependency strategy: the shared overlay installs PLAIN
+`kokoro-onnx` (→ the core `onnxruntime` CPU module). The GPU runtime is swapped in
+separately by the nvidia-only ORT swap (scripts/install-ort.mjs), NOT by a line in
+the overlay. Two things the overlay must therefore NEVER carry:
+  - a bare unmarked `onnxruntime-gpu` line (no macOS wheel → aborts `pip install`
+    on Apple Silicon, which reads this same overlay), and
+  - `kokoro-onnx[gpu]` (the extra coexists with the core onnxruntime dep, and pip's
+    resolution order can leave the CPU build owning the shared `onnxruntime/`
+    namespace → a silent CPU-only Kokoro on a GPU box; the 2026-06-16 regression).
 
 requirements.txt is a layered structure (a shim that `-r`-includes
 requirements/nvidia-cuda.txt, which `-r`-includes requirements/base.txt), so the
@@ -36,12 +42,19 @@ def _lines():
     return _resolve(REQ)
 
 
-def test_kokoro_uses_gpu_extra():
-    assert any(l.startswith("kokoro-onnx[gpu]") for l in _lines()), \
-        "expected kokoro-onnx[gpu] so onnxruntime-gpu is platform-gated by the extra"
+def test_kokoro_is_plain_no_gpu_extra():
+    lines = _lines()
+    assert any(_pkg(l) == "kokoro-onnx" for l in lines), \
+        "expected a plain kokoro-onnx requirement"
+    assert not any(l.startswith("kokoro-onnx[gpu]") for l in lines), \
+        ("kokoro-onnx[gpu] must NOT be used — the [gpu] extra coexists with the core "
+         "onnxruntime dep and can leave the CPU build owning the namespace (silent "
+         "CPU-only Kokoro). onnxruntime-gpu is installed by the nvidia ORT swap instead.")
 
 
 def test_no_bare_unmarked_onnxruntime_gpu():
+    """onnxruntime-gpu must never appear in the shared overlay (mac reads it too) —
+    it's installed only by the nvidia-only swap in scripts/install-ort.mjs."""
     for l in _lines():
         if l.startswith("onnxruntime-gpu") and ";" not in l:
             raise AssertionError(


### PR DESCRIPTION
## Summary

A stamped-`nvidia` venv was found running **Kokoro on the CPU** on a GPU box. Root cause: `kokoro-onnx[gpu]` declares plain `onnxruntime` (CPU) as a *core* dependency and only *adds* `onnxruntime-gpu` via the extra. Both occupy the same `onnxruntime/` import namespace, and pip's resolution order can leave the CPU build winning → `CUDAExecutionProvider` absent → silent CPU-only Kokoro despite the server correctly injecting `KOKORO_ORT_PROVIDERS=["CUDA","CPU"]`.

This makes the `install-ort.mjs` ORT swap — previously AMD/DirectML-only — the **single GPU-runtime enforcement point for every profile**:

- `requirements/nvidia-cuda.txt` carries **plain `kokoro-onnx`** (deterministic core `onnxruntime`); `onnxruntime-gpu` is swapped in afterward, never in the shared overlay (keeps macOS `pip install` safe — the swap is nvidia-only).
- `planOrtSwap` swaps whenever the recipe's `ortPackage` isn't plain `onnxruntime` (nvidia → `onnxruntime-gpu`); skips for cpu/amd/apple.
- `installForProfile` runs the swap in the generic branch too, and a **swap failure is now fatal** — no silent CPU fallback on a GPU box.

Existing nvidia venvs self-heal via a `pip-in-place` on next bootstrap (the overlay reqHash changed). Supersedes the "NVIDIA regression fence: `onnxruntime-gpu` via `kokoro-onnx[gpu]`" claims in plan 217 (post-ship note added).

## Test plan

- `install-ort-helpers.test.ts` — nvidia → swap `[uninstall onnxruntime, install onnxruntime-gpu]`; amd/cpu → skip.
- `bootstrap-venv-helpers.test.ts` — nvidia installs overlay **then** swaps; a failed swap is fatal.
- `requirements-layout.test.ts` + `test_requirements.py` — overlay is plain `kokoro-onnx`, never `[gpu]` or a bare `onnxruntime-gpu` line.
- Full `npm run verify` green on pre-push (typecheck + all tests + e2e + build). `test:server-slow` flaked once under parallel-battery CPU contention; passes 237/237 in isolation (known flake, unrelated tier).
- On-box: `onnxruntime-gpu` installed, ORT `InferenceSession` on the real Kokoro weights reports `['CUDAExecutionProvider', 'CPUExecutionProvider']`.