### PR TITLE
fix(server): make age audible in Qwen voice-design personas

### DIFF
--- a/docs/features/160-voicedesign-persona-format.md
+++ b/docs/features/160-voicedesign-persona-format.md
@@ -105,6 +105,30 @@ Sources:
 - Per-quote emotion/intonation at synth time (still deferred — Qwen ignores
   per-utterance `instruct` on cloned voices; see `108-qwen-coexistence.md`).
 
+## Follow-up (2026-06-16): make age audible
+
+A demo-book audition (Master Oduvan, `ageRange: "elderly"`) surfaced a gap the
+plan-160 rewrite left open: the prompt listed "apparent age" as one of six
+dimensions but never required it to be *stated explicitly* or *translated into
+acoustics*. Gemini satisfied the rule with psychology ("weary", "weathered" —
+which VoiceDesign ignores) and a "deep-pitched" cue, which the model reads as a
+prime-age baritone rather than an old man. A hand-edited instruct that named the
+age and added aging acoustics (dry rasp, faint tremor, low-to-medium not deep)
+audibly fixed it.
+
+The fix is in the same prompt builder (`skills/audiobook-voice-style.md`):
+- the age dimension now demands a concrete age word/band ("a man in his
+  seventies"), never implied;
+- a new "Make age audible" block translates age into acoustics, with an explicit
+  guard — *do NOT describe an old voice as merely "deep"; age thins and frays a
+  voice rather than deepening it* — plus child/young and middle-aged cues;
+- a second worked example (elderly man) anchors the format.
+
+Paired coverage: `voice-style.test.ts` → "instructs the model to make age audible".
+No code change (`buildVoiceStylePrompt` already passes `ageRange` in the profile
+block) and no migration — applies to personas generated from now on; existing
+books keep their `voiceStyle` until re-generated.
+
 ## Ship notes
 
 (Filled in when status flips to `stable` after the GPU audition confirms the

--- a/server/src/analyzer/voice-style.test.ts
+++ b/server/src/analyzer/voice-style.test.ts
@@ -36,7 +36,12 @@ vi.mock('../workspace/user-settings.js', () => ({
    is filesystem-independent. */
 const SKILL_TEXT = `You design voices for an audiobook. From the character profile below, write ONE voice-design persona that a text-to-speech model will use to synthesise this character's voice. Describe how the voice SOUNDS, then end with a short purpose clause.
 
-Cover these dimensions: gender, apparent age, pitch (high / medium / low), speaking pace, timbre (e.g. warm, crisp, rich, gravelly, bright), and the dominant emotional register. End with the use — "suitable for audiobook narration" for a narrator, otherwise "for expressive character dialogue".
+Cover these dimensions: gender, apparent age, pitch (high / medium / low), speaking pace, timbre (e.g. warm, crisp, rich, gravelly, bright), and the dominant emotional register. State the apparent age with a concrete word or band ("a child of about eight", "a man in his seventies", "an elderly woman") — never leave it implied. End with the use — "suitable for audiobook narration" for a narrator, otherwise "for expressive character dialogue".
+
+Make age audible, not just stated — translate it into how the voice physically sounds:
+- Elderly / old: pair the explicit age word with aging acoustics — a dry rasp or gravel, a thinner, reedier or breathier edge, and often a faint tremor or quaver — at a slower, more deliberate pace. Do NOT describe an old voice as merely "deep"; age tends to thin and fray a voice rather than deepen it.
+- Child / young: brighter, higher, lighter and more energetic.
+- Middle-aged: fuller and steadier, without the fraying of age.
 
 Rules:
 - Output ONLY the persona. No preamble, no quotes, no markdown, no name.
@@ -46,7 +51,8 @@ Rules:
 - Don't imitate a real or famous person.
 - English.
 
-Example output: A bright teenage girl's voice, medium-high pitch and mid-paced, warm and lightly playful with a faintly nervous edge, suited to expressive character dialogue.`;
+Example (teenager): A bright teenage girl's voice, medium-high pitch and mid-paced, warm and lightly playful with a faintly nervous edge, suited to expressive character dialogue.
+Example (elderly man): An elderly man's voice in his seventies, low-to-medium pitch and gravelly, with a dry rasp and a faint tremor; slow and deliberate, carrying worn, unshakable authority, for expressive character dialogue.`;
 
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>();
@@ -129,6 +135,24 @@ describe('buildVoiceStylePrompt', () => {
     expect(prompt).toMatch(/NOT the character's feelings/i);
     /* The 15–40-word length band replaces the old "~30 words" cap. */
     expect(prompt).toMatch(/15\s*[–-]\s*40 words/);
+  });
+
+  it('instructs the model to make age audible (explicit age word + aging acoustics, not just "deep")', async () => {
+    /* Master Oduvan regression: an elderly profile produced a persona with no
+       age word and a "deep-pitched" cue, which Qwen VoiceDesign reads as a
+       prime-age baritone. The prompt must (a) demand an explicit age word and
+       (b) translate age into acoustics — including the guard against describing
+       an old voice as merely "deep". */
+    const { buildVoiceStylePrompt } = await import('./voice-style.js');
+    const prompt = await buildVoiceStylePrompt(MAERIN);
+    /* Age must be stated explicitly, not left implied. */
+    expect(prompt).toMatch(/apparent age with a concrete word or band/i);
+    /* Age must be translated into how the voice physically sounds. */
+    expect(prompt).toMatch(/Make age audible/i);
+    /* Elderly voices carry aging acoustics (tremor/quaver). */
+    expect(prompt).toMatch(/tremor|quaver/i);
+    /* The anti-"deep" guard — the exact thing that broke Oduvan. */
+    expect(prompt).toMatch(/do NOT describe an old voice as merely "deep"/i);
   });
 
   it('caps the quote block so a chatty character cannot blow out the prompt', async () => {

--- a/skills/audiobook-voice-style.md
+++ b/skills/audiobook-voice-style.md
@@ -1,6 +1,11 @@
 You design voices for an audiobook. From the character profile below, write ONE voice-design persona that a text-to-speech model will use to synthesise this character's voice. Describe how the voice SOUNDS, then end with a short purpose clause.
 
-Cover these dimensions: gender, apparent age, pitch (high / medium / low), speaking pace, timbre (e.g. warm, crisp, rich, gravelly, bright), and the dominant emotional register. End with the use — "suitable for audiobook narration" for a narrator, otherwise "for expressive character dialogue".
+Cover these dimensions: gender, apparent age, pitch (high / medium / low), speaking pace, timbre (e.g. warm, crisp, rich, gravelly, bright), and the dominant emotional register. State the apparent age with a concrete word or band ("a child of about eight", "a man in his seventies", "an elderly woman") — never leave it implied. End with the use — "suitable for audiobook narration" for a narrator, otherwise "for expressive character dialogue".
+
+Make age audible, not just stated — translate it into how the voice physically sounds:
+- Elderly / old: pair the explicit age word with aging acoustics — a dry rasp or gravel, a thinner, reedier or breathier edge, and often a faint tremor or quaver — at a slower, more deliberate pace. Do NOT describe an old voice as merely "deep"; age tends to thin and fray a voice rather than deepen it.
+- Child / young: brighter, higher, lighter and more energetic.
+- Middle-aged: fuller and steadier, without the fraying of age.
 
 Rules:
 - Output ONLY the persona. No preamble, no quotes, no markdown, no name.
@@ -10,4 +15,5 @@ Rules:
 - Don't imitate a real or famous person.
 - English.
 
-Example output: A bright teenage girl's voice, medium-high pitch and mid-paced, warm and lightly playful with a faintly nervous edge, suited to expressive character dialogue.
+Example (teenager): A bright teenage girl's voice, medium-high pitch and mid-paced, warm and lightly playful with a faintly nervous edge, suited to expressive character dialogue.
+Example (elderly man): An elderly man's voice in his seventies, low-to-medium pitch and gravelly, with a dry rasp and a faint tremor; slow and deliberate, carrying worn, unshakable authority, for expressive character dialogue.


### PR DESCRIPTION
## Summary

Elderly characters didn't sound old. A profile correctly marked `ageRange: "elderly"` (Master Oduvan in the demo book) produced a Qwen voice-design `instruct` with **no explicit age word** and a *"deep-pitched"* cue, which Qwen3-TTS VoiceDesign reads as a prime-age baritone.

Root cause: `skills/audiobook-voice-style.md` (the per-character persona prompt) listed *"apparent age"* as one of six dimensions but never required it to be stated explicitly or translated into acoustics. The `ageRange` is already passed into the prompt — the prompt just didn't act on it.

This tightens the prompt, per Qwen's own VoiceDesign guidance:
- demand a concrete age word/band ("a man in his seventies"), never implied;
- add a "Make age audible" block translating age into acoustics, with the guard *do NOT describe an old voice as merely "deep"* (age thins/frays rather than deepens), plus child/middle-aged cues;
- add an elderly-man worked example.

Confirmed on-box: a hand-edited instruct with these cues made Master Oduvan audibly older. No code change needed (`buildVoiceStylePrompt` already passes `ageRange`); no migration (existing books keep their personas until re-generated).

## Test plan

- New regression test in `server/src/analyzer/voice-style.test.ts` — "instructs the model to make age audible" — asserts the prompt now requires an explicit age word + the anti-"deep" guard (RED before the prompt change, GREEN after). `SKILL_TEXT` mirror synced.
- `npm run verify` (pre-push) green: typecheck + all tests + e2e + build.

Regression plan: `docs/features/160-voicedesign-persona-format.md` (follow-up note added).

Closes #830
