### PR TITLE
fix(frontend): portal voice-compare modal out of clip-path drawer

### DIFF
--- a/src/modals/profile-drawer.test.tsx
+++ b/src/modals/profile-drawer.test.tsx
@@ -1279,6 +1279,47 @@ describe('ProfileDrawer per-character engine + Qwen bespoke voice (plan 108)', (
     expect(await screen.findByRole('dialog', { name: /compare/i })).toBeInTheDocument();
   });
 
+  it('portals the compare modal OUTSIDE the clip-path drawer aside (regression: compare rendered clipped underneath the drawer)', async () => {
+    /* The drawer aside carries `scrollbar-thin`, whose `clip-path: inset(...)`
+       clips ALL descendants — including `position: fixed` ones. If the
+       full-screen A/B compare overlay renders as a DOM child of the aside it is
+       clipped to the ~520px drawer column ("rendered underneath the drawer"),
+       so it MUST be portaled out to document.body. jsdom can't see clip-path,
+       but it CAN assert the overlay is not nested in the clipped aside. */
+    const { store } = renderWithBook({
+      ...baseChar,
+      ttsEngine: 'qwen',
+      voiceId: 'v_hal',
+      overrideTtsVoices: { qwen: { name: 'qwen-halloran' } },
+      voiceStyle: 'a steady adult voice',
+    });
+    act(() => {
+      store.dispatch(
+        castDesignActions.beginSingle({
+          bookId: 'book-1',
+          characterId: 'halloran',
+          name: 'Captain Halloran',
+          mode: 'redesign',
+          lastTickAt: 1,
+        }),
+      );
+      store.dispatch(
+        castDesignActions.previewReady({
+          bookId: 'book-1',
+          characterId: 'halloran',
+          previewVoiceId: 'qwen-halloran-preview',
+          previewUrl: '/audio/voices/char-halloran-preview.mp3',
+          persona: 'a steady adult voice',
+          lastTickAt: 2,
+        }),
+      );
+    });
+    const overlay = await screen.findByTestId('voice-compare-overlay');
+    const drawerAside = document.querySelector('[data-tour-id="profile-drawer"]');
+    expect(drawerAside).toBeTruthy();
+    expect(drawerAside!.contains(overlay)).toBe(false);
+  });
+
   it('on Save writes ttsEngine=qwen + the qwen override series-scoped', async () => {
     setVoiceOverride.mockClear();
     const onSave = vi.fn();

--- a/src/modals/profile-drawer.tsx
+++ b/src/modals/profile-drawer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import {
   IconClose,
   IconWaveform,
@@ -1042,40 +1043,50 @@ export function ProfileDrawer({
               />
             )}
 
-            {voiceCompareInitial && bookId && (
-              <VoiceCompareModal
-                bookId={bookId}
-                character={character}
-                currentSubject={currentSubject}
-                currentSampleVoiceId={sampleVoiceId}
-                currentModelKey={currentModelKey}
-                designModelKey={effectiveSampleModelKey}
-                sampleVoiceId={sampleVoiceId}
-                initial={voiceCompareInitial}
-                onApprove={({ voiceId, persona: approvedPersona, previewUrl }) => {
-                  /* Stage the PROMOTED (stable) voice into the drawer; Save
-                     persists it series-scoped exactly as before. */
-                  setPersona(approvedPersona);
-                  setDesignedVoiceId(voiceId);
-                  designPreviewUrlRef.current = previewUrl;
-                  dispatch(
-                    castActions.setVoiceStyle({
-                      characterId: character.id,
-                      voiceStyle: approvedPersona,
-                    }),
-                  );
-                  setVoiceCompareInitial(null);
-                  /* Resolving the compare ends the single-design lifecycle —
-                     clear the slice so the Design pill / ready-to-compare state
-                     reset (otherwise the effect would re-open the modal). */
-                  dispatch(castDesignActions.clear());
-                }}
-                onClose={() => {
-                  setVoiceCompareInitial(null);
-                  dispatch(castDesignActions.clear());
-                }}
-              />
-            )}
+            {/* Portaled to document.body: the drawer aside carries
+                `scrollbar-thin`, whose `clip-path` clips ALL descendants —
+                including `position: fixed` ones — so a nested full-screen A/B
+                compare overlay renders clipped to the ~520px drawer column.
+                Portaling out (the app's convention for top-bar/tour/picker
+                overlays) lets it cover the viewport. */}
+            {voiceCompareInitial &&
+              bookId &&
+              typeof document !== 'undefined' &&
+              createPortal(
+                <VoiceCompareModal
+                  bookId={bookId}
+                  character={character}
+                  currentSubject={currentSubject}
+                  currentSampleVoiceId={sampleVoiceId}
+                  currentModelKey={currentModelKey}
+                  designModelKey={effectiveSampleModelKey}
+                  sampleVoiceId={sampleVoiceId}
+                  initial={voiceCompareInitial}
+                  onApprove={({ voiceId, persona: approvedPersona, previewUrl }) => {
+                    /* Stage the PROMOTED (stable) voice into the drawer; Save
+                       persists it series-scoped exactly as before. */
+                    setPersona(approvedPersona);
+                    setDesignedVoiceId(voiceId);
+                    designPreviewUrlRef.current = previewUrl;
+                    dispatch(
+                      castActions.setVoiceStyle({
+                        characterId: character.id,
+                        voiceStyle: approvedPersona,
+                      }),
+                    );
+                    setVoiceCompareInitial(null);
+                    /* Resolving the compare ends the single-design lifecycle —
+                       clear the slice so the Design pill / ready-to-compare state
+                       reset (otherwise the effect would re-open the modal). */
+                    dispatch(castDesignActions.clear());
+                  }}
+                  onClose={() => {
+                    setVoiceCompareInitial(null);
+                    dispatch(castDesignActions.clear());
+                  }}
+                />,
+                document.body,
+              )}
 
             {/* Preset (Coqui/Kokoro/Gemini) speaker picker — shown only when
                 this character will actually synthesise with a PRESET engine.


### PR DESCRIPTION
## Summary

The per-character voice **re-design** A/B compare modal ("Design & compare") opened correctly — the slice flipped to `ready-to-compare`, the "…'s new voice is ready to compare" toast fired, and `VoiceCompareModal` rendered — but it appeared **clipped to the ~520px Profile Drawer column** ("rendered underneath the drawer"), with no usable way to compare.

**Root cause:** the modal was a DOM child of the drawer `<aside>`, which carries the `scrollbar-thin` class. `.scrollbar-thin` applies `clip-path: inset(0 round …)` (`src/styles.css`), and `clip-path` clips the paint of its **entire subtree — including `position: fixed` descendants** (unlike `overflow`, which leaves fixed children alone unless a transform ancestor makes it the containing block). So the full-screen `fixed inset-0` overlay was painted only where it intersected the clipped aside box.

**Fix:** portal `VoiceCompareModal` to `document.body` (the app's existing convention for top-bar / tour / searchable-picker / rebaseline / status-popover overlays). `CompareCastModal` — the other `AbCompareShell` consumer — was already mounted at view level (`cast.tsx`, `voices.tsx`), never clipped, which is why only this drawer-nested consumer was affected.

The backend + SSE single-redesign preview path (`server/src/routes/single-design.ts`) was correct and is untouched.

## Test plan

- New regression test in `profile-drawer.test.tsx`: asserts the compare overlay is **not** a descendant of the clipped `[data-tour-id="profile-drawer"]` aside (jsdom can't see `clip-path`, but it can see DOM nesting — the actionable invariant). Red before the fix, green after.
- Full `profile-drawer.test.tsx`: 75 passed.
- `tsc --noEmit`: clean. `npm run build`: green. `npm run test:e2e`: 204 passed / 0 failed.
- Frontend-scoped verify legs (lint, typecheck, frontend Vitest, build, e2e) all green. The unrelated `test:server-slow` `analysis-pipelining` timeout is pre-existing/environmental (concurrent-session CPU starvation) and untouched by this frontend-only change.
- OWED: live in-browser confirm on the GPU box that the compare now fills the viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)