### PR TITLE
fix(frontend): resolve Qwen voice + show descriptor on compare Side A

### DIFF
--- a/src/lib/use-ab-audition.test.ts
+++ b/src/lib/use-ab-audition.test.ts
@@ -95,6 +95,18 @@ describe('useAbAudition', () => {
     expect(order).toEqual(['a']); // B never reached
   });
 
+  it('playSide surfaces a failing side on the row AND the footer (regression: Side A errors were swallowed)', async () => {
+    const playback = makePlayback();
+    const s = sides([], { aThrows: true });
+    const { result } = renderHook(() => useAbAudition({ sides: s, playback }));
+
+    await act(async () => {
+      await result.current.playSide('a');
+    });
+    expect(result.current.rowState.a.error).toBe('boom');
+    expect(result.current.footerError).toBe('boom');
+  });
+
   it('stopAndCancel stops playback', () => {
     const playback = makePlayback();
     playback.isPlaying = true;

--- a/src/lib/use-ab-audition.ts
+++ b/src/lib/use-ab-audition.ts
@@ -89,7 +89,12 @@ export function useAbAudition({
       await sides[side].play();
       setRow(side, { loading: false });
     } catch (err) {
+      /* Surface on BOTH the side row AND the footer — a single-side play
+         failure was previously only written to the row, which some consumers
+         (VoiceCompareModal's Side A) don't render, so it looked like nothing
+         happened. The footer is always shown by AbCompareShell. */
       setRow(side, { loading: false, error: (err as Error).message });
+      setFooterError((err as Error).message);
     }
   }
 

--- a/src/modals/voice-compare-modal.test.tsx
+++ b/src/modals/voice-compare-modal.test.tsx
@@ -11,6 +11,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { VoiceCompareModal } from './voice-compare-modal';
+import { playSampleWithAutoLoad } from '../lib/play-sample-with-auto-load';
 import type { Character, Voice } from '../lib/types';
 
 vi.mock('../lib/use-sample-playback', () => {
@@ -43,16 +44,22 @@ const currentSubject = {
   ttsVoice: { provider: 'kokoro', name: 'af_heart', description: 'warm' },
 } as unknown as Voice;
 
-function renderModal(overrides?: { onApprove?: () => void; onClose?: () => void }) {
+function renderModal(overrides?: {
+  onApprove?: () => void;
+  onClose?: () => void;
+  character?: Character;
+  currentSubject?: Voice;
+  currentModelKey?: string;
+}) {
   const onApprove = vi.fn(overrides?.onApprove);
   const onClose = vi.fn(overrides?.onClose);
   render(
     <VoiceCompareModal
       bookId="b1"
-      character={character}
-      currentSubject={currentSubject}
+      character={overrides?.character ?? character}
+      currentSubject={overrides?.currentSubject ?? currentSubject}
       currentSampleVoiceId="v_x"
-      currentModelKey="kokoro-v1"
+      currentModelKey={(overrides?.currentModelKey ?? 'kokoro-v1') as never}
       designModelKey="qwen3-tts-0.6b"
       sampleVoiceId="v_x"
       initial={{ voiceId: 'qwen-x-preview', previewUrl: '/audio/initial.mp3', persona: 'initial persona' }}
@@ -63,8 +70,25 @@ function renderModal(overrides?: { onApprove?: () => void; onClose?: () => void 
   return { onApprove, onClose };
 }
 
+/* A Qwen current voice whose id lives in `ttsVoice.name` only (the reused /
+   designed shape) — NOT in `overrideTtsVoices.qwen`, which is what tripped the
+   server pick. */
+const qwenCurrentSubject = {
+  id: 'v_q',
+  character: 'Master Oduvan',
+  ttsVoice: { provider: 'qwen', name: 'qwen-master-oduvan', description: 'Designed voice' },
+} as unknown as Voice;
+const qwenCharacter = {
+  id: 'x',
+  name: 'Master Oduvan',
+  color: 'lilac',
+  role: 'elder',
+  voiceStyle: 'An elderly gravelly voice with a dry rasp.',
+} as unknown as Character;
+
 beforeEach(() => {
   Object.values(api).forEach((fn) => fn.mockClear());
+  (playSampleWithAutoLoad as unknown as ReturnType<typeof vi.fn>).mockClear();
 });
 
 describe('VoiceCompareModal', () => {
@@ -125,5 +149,49 @@ describe('VoiceCompareModal', () => {
       ),
     );
     expect(api.generateVoiceStyle).toHaveBeenCalledWith('b1', 'x');
+  });
+
+  it('Play current injects the Qwen voiceId into overrideTtsVoices so the server can resolve it (regression: Play current did nothing)', async () => {
+    renderModal({
+      character: qwenCharacter,
+      currentSubject: qwenCurrentSubject,
+      currentModelKey: 'qwen3-tts-0.6b',
+    });
+    fireEvent.click(screen.getByTestId('voice-compare-current-play'));
+    await waitFor(() => expect(playSampleWithAutoLoad).toHaveBeenCalledTimes(1));
+    const arg = (playSampleWithAutoLoad as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(arg.args.voice.overrideTtsVoices.qwen.name).toBe('qwen-master-oduvan');
+    expect(arg.args.modelKey).toBe('qwen3-tts-0.6b');
+  });
+
+  it('Side A shows the current voice descriptor line AND its persona', () => {
+    renderModal({
+      character: qwenCharacter,
+      currentSubject: qwenCurrentSubject,
+      currentModelKey: 'qwen3-tts-0.6b',
+    });
+    const descriptor = screen.getByTestId('voice-compare-current-name');
+    expect(descriptor.textContent).toMatch(/Qwen/);
+    expect(descriptor.textContent).toMatch(/Designed voice/);
+    expect(screen.getByTestId('voice-compare-current-persona').textContent).toBe(
+      'An elderly gravelly voice with a dry rasp.',
+    );
+  });
+
+  it('a failing Play current surfaces an error instead of silently doing nothing', async () => {
+    (playSampleWithAutoLoad as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('Voice engine (:9000) is unreachable'),
+    );
+    renderModal({
+      character: qwenCharacter,
+      currentSubject: qwenCurrentSubject,
+      currentModelKey: 'qwen3-tts-0.6b',
+    });
+    fireEvent.click(screen.getByTestId('voice-compare-current-play'));
+    await waitFor(() =>
+      expect(screen.getByTestId('voice-compare-current-error').textContent).toMatch(
+        /unreachable/,
+      ),
+    );
   });
 });

--- a/src/modals/voice-compare-modal.tsx
+++ b/src/modals/voice-compare-modal.tsx
@@ -70,15 +70,35 @@ export function VoiceCompareModal({
 
   const currentPrefix = sampleUrlPrefix(currentSampleVoiceId, currentModelKey);
 
+  /* The current voice's Qwen voiceId. A designed/reused Qwen voice carries its
+     id in `ttsVoice.name` but often NOT in `overrideTtsVoices.qwen` — and the
+     server's `pickVoiceForEngine('qwen', …)` reads ONLY the override slot and
+     returns '' otherwise (sidecar then 400s). So resolve it the same 3-way way
+     the drawer does and inject it below, mirroring the drawer's own Play 12s. */
+  const currentQwenName =
+    currentSubject.overrideTtsVoices?.qwen?.name ??
+    (currentSubject.ttsVoice?.provider === 'qwen' ? currentSubject.ttsVoice.name : undefined);
+
   const sides: Record<'a' | 'b', AbSide> = {
     a: {
       matchUrl: currentPrefix,
       matchMode: 'prefix',
       play: async () => {
+        /* Inject the resolved Qwen voiceId into the override slot the server
+           reads; non-Qwen current voices pass through unchanged. */
+        const requestVoice: Voice = currentQwenName
+          ? {
+              ...currentSubject,
+              overrideTtsVoices: {
+                ...(currentSubject.overrideTtsVoices ?? {}),
+                qwen: { name: currentQwenName },
+              },
+            }
+          : currentSubject;
         await playSampleWithAutoLoad({
           args: {
             voiceId: currentSampleVoiceId,
-            voice: currentSubject,
+            voice: requestVoice,
             modelKey: currentModelKey,
             characterHint: buildCharacterHint(character),
           },
@@ -186,9 +206,37 @@ export function VoiceCompareModal({
       onClose={handleClose}
       sideA={
         <SideCard side="a" title="Current voice" character={character}>
-          <p className="text-sm text-ink/70" data-testid="voice-compare-current-name">
-            {currentSubject.ttsVoice?.name ?? 'Current voice'}
+          {/* Descriptor line for the CURRENT voice — provider · name · description,
+              mirroring the drawer card — so Side A isn't a bare voiceId. */}
+          <p
+            className="text-[11px] truncate"
+            data-testid="voice-compare-current-name"
+            title={`${capitalise(currentSubject.ttsVoice?.provider)} voice — ${currentSubject.ttsVoice?.description ?? ''}`}
+          >
+            <span className="text-ink/40">
+              {capitalise(currentSubject.ttsVoice?.provider) || 'Voice'} ·{' '}
+            </span>
+            {currentSubject.ttsVoice?.name && (
+              <span className="font-semibold text-ink/70">{currentSubject.ttsVoice.name}</span>
+            )}
+            <span className="text-ink/40">
+              {currentSubject.ttsVoice?.name ? ' · ' : ''}
+              {currentSubject.ttsVoice?.description ?? 'Current voice'}
+            </span>
           </p>
+          {/* The persona the current voice was designed with (read-only) so the
+              user can A/B the old description against the proposed one on Side B. */}
+          {character.voiceStyle?.trim() && (
+            <div>
+              <p className="text-[11px] text-ink/60 font-medium mb-1">Voice persona</p>
+              <p
+                data-testid="voice-compare-current-persona"
+                className="w-full px-3 py-2 rounded-xl border border-ink/15 bg-white/60 text-sm text-ink/80 max-h-28 overflow-y-auto whitespace-pre-wrap"
+              >
+                {character.voiceStyle}
+              </p>
+            </div>
+          )}
           <PlayButton
             testId="voice-compare-current-play"
             label="Play current"
@@ -197,6 +245,14 @@ export function VoiceCompareModal({
             disabled={autoRunning && (rowState.b?.loading ?? false)}
             onClick={() => playSide('a')}
           />
+          {rowState.a?.error && (
+            <p
+              className="text-[11px] text-red-600/90 font-medium"
+              data-testid="voice-compare-current-error"
+            >
+              ⚠ {rowState.a.error}
+            </p>
+          )}
         </SideCard>
       }
       sideB={
@@ -287,6 +343,11 @@ export function VoiceCompareModal({
       }
     />
   );
+}
+
+/** Title-case a provider tag for the Side-A descriptor line (e.g. qwen → Qwen). */
+function capitalise(s: string | undefined): string {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : '';
 }
 
 function SideCard({


### PR DESCRIPTION
## Summary

Follow-up to #832. Three defects in the voice re-design A/B compare's **"Current voice" (Side A)**, surfaced during live testing:

1. **"Play current" did nothing.** Side A sent `currentSubject` raw, but a designed/reused Qwen voice carries its id in `ttsVoice.name`, *not* in `overrideTtsVoices.qwen`. The server's `pickVoiceForEngine('qwen', …)` (`voice-mapping.ts:248,263`) reads only the override slot and returns `''` → the sidecar 400s. Fix: resolve the id the same 3-way way the drawer does and **inject it into the request**, mirroring the drawer's own "Play 12s sample" (`profile-drawer.tsx:616`).
2. **Side A play errors were swallowed.** `playSide` wrote the error only to the side row, which Side A didn't render — so a failure looked like "nothing happened." Now also sets `footerError` (always rendered by `AbCompareShell`) plus an inline Side A error. Benefits `CompareCastModal` equally.
3. **Side A was missing the voice descriptor** — it showed only the bare voiceId. Now shows the `provider · name · description` line (like the drawer card) plus the current voice's persona (read-only) for a true old-vs-new comparison.

## Test plan

- `voice-compare-modal.test.tsx`: Side A injects `overrideTtsVoices.qwen.name`; descriptor + persona render; a failing play surfaces an error (no more silent nothing).
- `use-ab-audition.test.ts`: regression — `playSide` failure surfaces on the footer, not just the row.
- Full frontend Vitest: 220 files / 2867 tests passed. `tsc`: clean. `npm run build`: green. `npm run test:e2e`: 203 passed (1 known pre-existing `queue-modal` flake, passed on retry).
- OWED: live in-browser confirm on the GPU box that "Play current" now plays and Side A shows the descriptor + persona.

🤖 Generated with [Claude Code](https://claude.com/claude-code)