### PR TITLE
chore: add legal-page pointers to README and tie LICENSE copyright to the registered business name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -6,7 +6,7 @@ FSL-1.1-ALv2
 
 ## Notice
 
-Copyright 2026 Mikhail Dudarenok
+Copyright 2026 Mikhail Dudarenok (trading as Castwright)
 
 ## Terms and Conditions
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ while keeping the source fully readable.
 - **Model weights** carry their own upstream licences ([NOTICE](NOTICE)). Coqui
   XTTS v2 is non-commercial (CPML) and is therefore download-on-demand, never
   bundled.
+- **Privacy & terms** — the apps collect nothing and send nothing to us; the full
+  policies live at [castwright.ai/legal/privacy](https://castwright.ai/legal/privacy)
+  and [castwright.ai/legal/terms](https://castwright.ai/legal/terms). Castwright is a
+  registered business name (ABN 52 641 247 931) in Australia.
 
 **Contributing:** issues welcome; PRs by invitation for now (a DCO sign-off and a
 lightweight CLA apply — see [CONTRIBUTING.md](CONTRIBUTING.md)).


### PR DESCRIPTION
## Summary
Repo-front-door legal polish ahead of the public-beta repo going public.

- **README** License section now links to the privacy + terms policies on `castwright.ai` and notes the registered business name (ABN 52 641 247 931) in Australia.
- **LICENSE** copyright line: `Mikhail Dudarenok` → `Mikhail Dudarenok (trading as Castwright)`, tying the registered business name to the rights holder.

Docs-only; no code touched. The ABN/governing-law clauses themselves stay in the site's privacy/terms pages (not the README) — this just points there.

## Test plan
Docs-only. Pre-commit scope-skipped the test legs; pre-push `verify` passed (code steps cached, nothing code-side changed).