### PR TITLE
fix(server): tolerate stray model keys in analyzer schema validation

### DIFF
--- a/server/src/analyzer/gemini.ts
+++ b/server/src/analyzer/gemini.ts
@@ -847,9 +847,50 @@ export function parseAndValidate<T>(raw: string, schema: z.ZodType<T>): ParseRes
 
   const result = schema.safeParse(parsed);
   if (!result.success) {
-    return { ok: false, kind: 'schema-validation', detail: result.error.issues };
+    /* Constrained-decoding stray-key tolerance. Ollama's `format:<schema>`
+       (and Gemini's responseSchema) enforce JSON *shape* but NOT
+       additionalProperties:false, so a local model routinely stamps an extra
+       key the strict schema doesn't want onto an otherwise-valid object — the
+       real qwen3.5:9b per-chapter cast failure stamped a top-level `chapterId`
+       and the whole chapter's roster was discarded. When EVERY issue is an
+       unrecognized key, strip the offending keys at their reported paths and
+       re-validate once. Genuine shape problems (missing required fields, wrong
+       types) surface different issue codes and still hard-fail here. */
+    const issues = result.error.issues;
+    if (issues.length > 0 && issues.every((i) => i.code === 'unrecognized_keys')) {
+      const cleaned = stripUnrecognizedKeys(parsed, issues);
+      const reparse = schema.safeParse(cleaned);
+      if (reparse.success) {
+        return { ok: true, value: reparse.data, repaired: true };
+      }
+    }
+    return { ok: false, kind: 'schema-validation', detail: issues };
   }
   return { ok: true, value: result.data, repaired };
+}
+
+/* Remove the keys Zod flagged as `unrecognized_keys` from a deep clone of the
+   parsed object. Each `unrecognized_keys` issue carries the `path` to the
+   object that owns the extra keys and the `keys` list itself; walk to that
+   object and delete them. The clone keeps the caller's parsed value intact.
+   Used only by parseAndValidate to salvage a payload whose sole fault is stray
+   keys that constrained decoding failed to suppress. */
+function stripUnrecognizedKeys(root: unknown, issues: z.ZodIssue[]): unknown {
+  const clone = structuredClone(root);
+  for (const issue of issues) {
+    if (issue.code !== 'unrecognized_keys') continue;
+    let target: unknown = clone;
+    for (const seg of issue.path) {
+      if (target == null || typeof target !== 'object') break;
+      target = (target as Record<PropertyKey, unknown>)[seg];
+    }
+    if (target != null && typeof target === 'object') {
+      for (const key of issue.keys) {
+        delete (target as Record<string, unknown>)[key];
+      }
+    }
+  }
+  return clone;
 }
 
 /* Strips a wrapping ```json ... ``` (or bare ``` ... ```) markdown fence

--- a/server/src/analyzer/ollama.test.ts
+++ b/server/src/analyzer/ollama.test.ts
@@ -402,8 +402,12 @@ describe('OllamaAnalyzer — validation-retry', () => {
     const invalid = JSON.stringify({
       characters: [] /* missing required field on shape — empty arr is fine actually */,
     });
-    /* Use a stronger violation: extra field that .strict() forbids. */
-    const strictlyInvalid = JSON.stringify({ characters: [], stowaways: ['nope'] });
+    /* Use a genuine SHAPE violation to force the retry: `characters` must be
+       an array, so a string fails with an `invalid_type` issue. (An extra
+       strict-forbidden key would NOT work here — parseAndValidate now strips
+       stray keys and accepts the cleaned object on the first attempt, so it
+       would never reach the retry path this test exercises.) */
+    const strictlyInvalid = JSON.stringify({ characters: 'nope' });
 
     /* First call → strictlyInvalid, second call → valid. */
     fetchMock
@@ -478,7 +482,10 @@ describe('OllamaAnalyzer — validation-retry', () => {
   });
 
   it('hard-fails after the second attempt also fails validation', async () => {
-    const bad = JSON.stringify({ characters: [], extraField: 'nope' });
+    /* Genuine SHAPE violation (`characters` must be an array) so BOTH attempts
+       hard-fail and reach the post-retry throw. An extra strict-forbidden key
+       would be stripped and accepted by parseAndValidate, never failing. */
+    const bad = JSON.stringify({ characters: 'nope' });
     /* Fresh Response per call — a streamed body can only be consumed once,
        so a shared `mockResolvedValue(...)` would feed the second attempt
        an already-drained stream and trip the "empty response" branch. */

--- a/server/src/analyzer/ollama.ts
+++ b/server/src/analyzer/ollama.ts
@@ -265,9 +265,13 @@ export class OllamaAnalyzer implements Analyzer {
        Ollama doesn't have to resolve $ref — safer across engine versions.
        target:'draft-07' keeps the same dialect zod-to-json-schema emitted
        before the Zod 4 bump. The resulting schema preserves .strict() as
-       additionalProperties:false and .min(1) as minItems:1, which is the
-       whole point: the model can't emit malformed JSON or extra fields by
-       construction. */
+       additionalProperties:false and .min(1) as minItems:1, constraining the
+       overall JSON shape. NOTE: llama.cpp's grammar conversion does NOT honour
+       additionalProperties:false — the model can still stamp an extra key on
+       an object (the real qwen3.5:9b per-chapter cast failure stamped a stray
+       top-level `chapterId`). parseAndValidate tolerates that by stripping
+       unrecognized-keys-only failures, so a stray key no longer discards a
+       whole chapter. */
     const responseFormat = z.toJSONSchema(schema, { target: 'draft-07', reused: 'inline' });
 
     const start = Date.now();

--- a/server/src/analyzer/parse-and-repair.test.ts
+++ b/server/src/analyzer/parse-and-repair.test.ts
@@ -251,10 +251,47 @@ describe('parseAndValidate — repair integration', () => {
     }
   });
 
-  it('returns schema-validation when the JSON is valid but violates the schema', () => {
-    /* Repair path is not engaged — JSON.parse succeeds on the first try.
-       Result must NOT spuriously claim `repaired: true`. */
-    const r = parseAndValidate('{"quote":"hi","note":"n","extra":"forbidden"}', schema);
+  it('salvages a failure whose ONLY issues are unrecognized keys (constrained-decoding stray-key tolerance)', () => {
+    /* Ollama's `format:<schema>` (and Gemini's responseSchema) enforce JSON
+       *shape* but NOT additionalProperties:false, so a local model routinely
+       stamps an extra key the strict schema doesn't want onto an otherwise
+       valid object — the real qwen3.5:9b per-chapter cast failure stamped a
+       top-level `chapterId` and a whole chapter's roster was discarded. The
+       stray key is stripped, the cleaned object is accepted, and `repaired`
+       is flagged so the caller logs the cleanup. */
+    const r = parseAndValidate('{"quote":"hi","note":"n","chapterId":1}', schema);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value).toEqual({ quote: 'hi', note: 'n' });
+      expect(r.repaired).toBe(true);
+    }
+  });
+
+  it('strips an unrecognized key inside a NESTED strict object (path-walk), not just top-level', () => {
+    const nested = z.object({ inner: z.object({ a: z.string() }).strict() }).strict();
+    const r = parseAndValidate('{"inner":{"a":"x","stray":1}}', nested);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value).toEqual({ inner: { a: 'x' } });
+      expect(r.repaired).toBe(true);
+    }
+  });
+
+  it('still returns schema-validation for a REAL violation (missing required field)', () => {
+    /* The salvage path must NOT mask genuine shape errors — only failures whose
+       issues are ALL `unrecognized_keys` are recoverable. */
+    const r = parseAndValidate('{"quote":"hi"}', schema);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.kind).toBe('schema-validation');
+    }
+  });
+
+  it('still returns schema-validation when a stray key is MIXED with a real violation', () => {
+    /* `note` is the wrong type AND there's an extra key. Because not EVERY
+       issue is unrecognized_keys, we do not salvage — a genuine shape problem
+       must still surface. */
+    const r = parseAndValidate('{"quote":"hi","note":42,"chapterId":1}', schema);
     expect(r.ok).toBe(false);
     if (!r.ok) {
       expect(r.kind).toBe('schema-validation');


### PR DESCRIPTION
## Summary

Local-model constrained decoding (Ollama's `format:<schema>`) enforces JSON *shape* but not `additionalProperties:false`, so `qwen3.5:9b` stamped a stray top-level `chapterId` onto an otherwise-valid per-chapter cast result. The strict Zod schema hard-rejected it as `unrecognized_keys`, the retry (temp 0.2) deterministically repeated it, and the whole chapter's roster was discarded after ~8 min — dropping chapters from the analysis.

`parseAndValidate` now salvages a schema-validation failure whose issues are **all** `unrecognized_keys`: it strips the offending keys at their reported paths (top-level *and* nested) and re-validates once. Genuine shape errors (missing required fields, wrong types) surface different codes and still hard-fail. Engine- and stage-agnostic (Ollama + Gemini; stage1/stage1Chapter/stage2/emotion), recovers on the first attempt, so no chapter is dropped over a cosmetic key. Also corrects the stale `ollama.ts` comment that wrongly claimed extra fields were impossible "by construction."

## Test plan

- New unit tests in `parse-and-repair.test.ts`: salvage top-level stray key; salvage nested stray key; missing-required still fails; mixed violation still fails.
- Two existing ollama retry tests retargeted to a genuine type violation (extra keys are now salvaged, so they no longer trigger the retry path).
- `npm run verify` green (typecheck + all tests + e2e + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)