### PR TITLE
fix(server): evict resident Ollama before sidecar loads + safe keep_alive flip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,10 @@ audiobook-workspace/
 # are checked in and the MOBI/AZW3 e2e cases skip cleanly when these are absent.
 server/src/parsers/__fixtures__/sample.mobi
 server/src/parsers/__fixtures__/sample.azw3
+
+# Ad-hoc local repro / bisect scripts (and their scratch output) for one-off
+# debugging — e.g. the Russian stage-2 under-production probes. Local only,
+# never committed; also excluded from lint (see eslint.config.js).
+server/repro-*.mts
+server/repro-*.txt
+server/roster.json

--- a/docs/superpowers/plans/2026-06-16-wave1-gpu-eviction-residency.md
+++ b/docs/superpowers/plans/2026-06-16-wave1-gpu-eviction-residency.md
@@ -1,0 +1,715 @@
+# Wave 1 — GPU eviction before sidecar loads + safe keep_alive flip — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the already-done `qwen3.5:9b` `keep_alive: '5m'` flip safe by evicting a resident Ollama model server-side before any sidecar TTS/voice-design load, gated by a single VRAM threshold.
+
+**Architecture:** A pure `residency` policy decides "evict before load?" from a cached VRAM state (last-known-good from sidecar `/health`, resilient to respawn). A shared `unloadResidentOllama()` (extracted from the `/unload` route) performs the eviction under a dedicated load-mutex, scoped to the configured analyzer model so concurrent sessions aren't stomped. Two server-side chokepoints call it: `ensureSidecarEngineReady` (generation/bulk) and `designQwenVoiceForCharacter` (voice design). An `isAnyAnalysisBusy()` interlock guarantees an in-flight analysis is never evicted.
+
+**Tech Stack:** TypeScript (Node ESM), Vitest (node env), Express routes, the existing config registry (`configValue`).
+
+**Spec:** `docs/superpowers/specs/2026-06-16-vram-budget-aware-gpu-policy-design.md` (§4).
+
+**Branch:** `git switch feat/analysing-residency-label-progress` then rename: `git branch -m fix/server-gpu-eviction-before-sidecar-load`. The keep_alive flip + its ollama tests already live here (uncommitted) and ship with this wave.
+
+---
+
+### Task 1: Register the `gpu.safeCoexistMb` config knob
+
+**Files:**
+- Modify: `server/src/config/registry.ts` (the `gpu-lifecycle` group)
+
+- [ ] **Step 1: Add the knob to the registry**
+
+Find the `gpu-lifecycle` group entries (search `gpu.vramBudget` / `gpu.concurrency`) and add an entry alongside them:
+
+```ts
+{
+  id: 'gpu.safeCoexistMb',
+  group: 'gpu-lifecycle',
+  type: 'number',
+  default: 11000,
+  label: 'Safe analyzer+TTS coexistence VRAM (MB)',
+  help: 'If detected GPU VRAM is below this, evict the resident Ollama analyzer before loading a sidecar TTS/voice-design model. 8 GB cards evict; 12/16 GB coexist. Set 0 to always evict.',
+  apply: 'live',
+},
+```
+
+- [ ] **Step 2: Verify it resolves**
+
+Run: `cd server && npx vitest run src/config -t "registry"`
+Expected: PASS (existing registry-shape tests still green with the new entry).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/src/config/registry.ts
+git commit -m "feat(server): add gpu.safeCoexistMb eviction-threshold knob"
+```
+
+---
+
+### Task 2: VRAM-state cache on sidecar health (resilient to respawn)
+
+**Files:**
+- Modify: `server/src/routes/sidecar-health.ts` (near `setLastKnownQwenInstallState`, ~line 244)
+- Test: `server/src/routes/sidecar-health.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setLastKnownVram, getLastKnownVram } from './sidecar-health.js';
+
+describe('last-known VRAM cache', () => {
+  beforeEach(() => setLastKnownVram(null)); // reset to "never probed"
+
+  it('defaults to unknown accelerator / null total before any probe', () => {
+    expect(getLastKnownVram()).toEqual({ accelerator: 'unknown', totalMb: null });
+  });
+
+  it('records a CUDA total and exposes accelerator cuda', () => {
+    setLastKnownVram({ totalMb: 8188 });
+    expect(getLastKnownVram()).toEqual({ accelerator: 'cuda', totalMb: 8188 });
+  });
+
+  it('records a reachable-but-no-CUDA probe as cpu', () => {
+    setLastKnownVram({ totalMb: null });
+    expect(getLastKnownVram()).toEqual({ accelerator: 'cpu', totalMb: null });
+  });
+
+  it('an unreachable poll (undefined) leaves the last-known state intact', () => {
+    setLastKnownVram({ totalMb: 8188 });
+    setLastKnownVram(undefined); // unreachable — do not downgrade
+    expect(getLastKnownVram()).toEqual({ accelerator: 'cuda', totalMb: 8188 });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/routes/sidecar-health.test.ts -t "last-known VRAM"`
+Expected: FAIL — `setLastKnownVram`/`getLastKnownVram` are not exported.
+
+- [ ] **Step 3: Implement the cache**
+
+Add near `setLastKnownQwenInstallState` in `sidecar-health.ts`:
+
+```ts
+export type Accelerator = 'cuda' | 'cpu' | 'unknown';
+export interface VramState {
+  accelerator: Accelerator;
+  totalMb: number | null;
+}
+
+/* Last-known VRAM, mirroring the Qwen-install-state cache: only a REACHABLE
+   probe updates it, so a transient sidecar respawn (when eviction must still
+   make a decision) doesn't downgrade a known-good reading. `null` = reset to
+   "never probed"; `undefined` = unreachable poll (no-op). CUDA presence is
+   inferred from a non-null vram_total_mb (the sidecar reports it iff CUDA). */
+let lastKnownVram: VramState = { accelerator: 'unknown', totalMb: null };
+
+export function setLastKnownVram(
+  next: { totalMb: number | null } | null | undefined,
+): void {
+  if (next === undefined) return; // unreachable — keep last-known
+  if (next === null) {
+    lastKnownVram = { accelerator: 'unknown', totalMb: null };
+    return;
+  }
+  lastKnownVram = {
+    totalMb: next.totalMb,
+    accelerator: next.totalMb != null ? 'cuda' : 'cpu',
+  };
+}
+
+export function getLastKnownVram(): VramState {
+  return lastKnownVram;
+}
+```
+
+- [ ] **Step 4: Populate it on a reachable probe**
+
+In `probeSidecarHealth`, immediately after `setLastKnownQwenInstallState(qwenInstallState);` (line ~244):
+
+```ts
+setLastKnownVram({
+  totalMb: typeof body.vram_total_mb === 'number' ? body.vram_total_mb : null,
+});
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `cd server && npx vitest run src/routes/sidecar-health.test.ts`
+Expected: PASS (new cache tests + existing health tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/routes/sidecar-health.ts server/src/routes/sidecar-health.test.ts
+git commit -m "feat(server): cache last-known GPU VRAM state from sidecar health"
+```
+
+---
+
+### Task 3: Pure residency policy — `shouldEvictBeforeSidecarLoad`
+
+**Files:**
+- Create: `server/src/gpu/residency.ts`
+- Test: `server/src/gpu/residency.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../config/resolver.js', () => ({
+  configValue: vi.fn(() => 11000), // gpu.safeCoexistMb default
+}));
+
+import { shouldEvictBeforeSidecarLoad } from './residency.js';
+
+describe('shouldEvictBeforeSidecarLoad', () => {
+  it('CPU never evicts (no VRAM contention)', () => {
+    expect(shouldEvictBeforeSidecarLoad({ accelerator: 'cpu', totalMb: null })).toBe(false);
+  });
+
+  it('GPU with unknown total is conservative — evict', () => {
+    expect(shouldEvictBeforeSidecarLoad({ accelerator: 'cuda', totalMb: null })).toBe(true);
+  });
+
+  it('accelerator unknown (never probed) is conservative — evict', () => {
+    expect(shouldEvictBeforeSidecarLoad({ accelerator: 'unknown', totalMb: null })).toBe(true);
+  });
+
+  it('8 GB card (below threshold) evicts', () => {
+    expect(shouldEvictBeforeSidecarLoad({ accelerator: 'cuda', totalMb: 8188 })).toBe(true);
+  });
+
+  it('12 GB and 16 GB cards coexist (no evict)', () => {
+    expect(shouldEvictBeforeSidecarLoad({ accelerator: 'cuda', totalMb: 12288 })).toBe(false);
+    expect(shouldEvictBeforeSidecarLoad({ accelerator: 'cuda', totalMb: 16384 })).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/gpu/residency.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// server/src/gpu/residency.ts
+import { configValue } from '../config/resolver.js';
+import type { VramState } from '../routes/sidecar-health.js';
+
+/** Should a resident Ollama analyzer be evicted before loading a sidecar
+    TTS/voice-design model, given the detected VRAM?
+    - CPU: never (models share system RAM; no GPU to overflow).
+    - GPU, total unknown / never probed: yes (conservative — better a reload
+      than an OOM).
+    - GPU with a known total below `gpu.safeCoexistMb`: yes (8 GB can't host
+      analyzer + TTS together). At/above it: no (12/16 GB coexist). */
+export function shouldEvictBeforeSidecarLoad(v: VramState): boolean {
+  if (v.accelerator === 'cpu') return false;
+  if (v.totalMb == null) return true;
+  return v.totalMb < configValue<number>('gpu.safeCoexistMb');
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `cd server && npx vitest run src/gpu/residency.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/gpu/residency.ts server/src/gpu/residency.test.ts
+git commit -m "feat(server): VRAM-threshold residency policy (shouldEvictBeforeSidecarLoad)"
+```
+
+---
+
+### Task 4: Extract `unloadResidentOllama` and reuse it in the route
+
+**Files:**
+- Modify: `server/src/routes/ollama-health.ts` (the `POST /unload` handler, ~lines 282-301)
+- Test: `server/src/routes/ollama-health.test.ts` (existing `/unload` describe block, ~line 225)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `/unload` describe in `ollama-health.test.ts`:
+
+```ts
+it('exposes unloadResidentOllama() that evicts the named targets with keep_alive: 0', async () => {
+  const fetchMock = vi.fn().mockResolvedValue(okResponse('{}')); // reuse the file's helpers
+  vi.stubGlobal('fetch', fetchMock);
+  const { unloadResidentOllama } = await import('./ollama-health.js');
+  await unloadResidentOllama(['qwen3.5:9b']);
+  const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+  expect(body.model).toBe('qwen3.5:9b');
+  expect(body.keep_alive).toBe(0);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/routes/ollama-health.test.ts -t "unloadResidentOllama"`
+Expected: FAIL — `unloadResidentOllama` not exported.
+
+- [ ] **Step 3: Extract the helper**
+
+In `ollama-health.ts`, add an exported function and have the route call it:
+
+```ts
+/** Evict resident Ollama model(s) by issuing keep_alive:0 generate calls.
+    `targets` empty/omitted → evict EVERY model /api/ps reports (the explicit
+    Stop path). Returns the list actually evicted. Throws on the first failed
+    eviction so callers can surface it. */
+export async function unloadResidentOllama(targets?: string[]): Promise<string[]> {
+  const url = getResolvedOllamaUrl();
+  const list =
+    targets && targets.length > 0 ? targets : (await probeOllamaHealth()).resident ?? [];
+  for (const model of list) {
+    const result = await callOllamaGenerate(
+      url,
+      { model, prompt: '', keep_alive: 0, stream: false },
+      PROBE_TIMEOUT_MS,
+    );
+    if (!result.ok) throw new Error(result.error ?? `unload ${model} failed`);
+  }
+  return list;
+}
+```
+
+Replace the body of the `POST /unload` handler to delegate:
+
+```ts
+ollamaHealthRouter.post('/unload', async (req: Request, res: Response) => {
+  const requested = typeof req.body?.model === 'string' ? req.body.model.trim() : '';
+  try {
+    const unloaded = await unloadResidentOllama(requested ? [requested] : undefined);
+    return res.json({ status: 'unloaded', unloaded });
+  } catch (e) {
+    return res.status(502).json({ status: 'error', error: (e as Error).message });
+  }
+});
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd server && npx vitest run src/routes/ollama-health.test.ts`
+Expected: PASS (new test + the existing single/all/error eviction tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/ollama-health.ts server/src/routes/ollama-health.test.ts
+git commit -m "refactor(server): extract unloadResidentOllama() shared eviction helper"
+```
+
+---
+
+### Task 5: Load-mutex + the `evictOllamaForGpuLoad` orchestrator
+
+**Files:**
+- Create: `server/src/gpu/load-mutex.ts`
+- Create: `server/src/gpu/evict-for-load.ts`
+- Test: `server/src/gpu/evict-for-load.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const unloadMock = vi.fn().mockResolvedValue(['qwen3.5:9b']);
+const vramMock = vi.fn();
+const busyMock = vi.fn().mockReturnValue(false);
+
+vi.mock('../routes/ollama-health.js', () => ({ unloadResidentOllama: unloadMock }));
+vi.mock('../routes/sidecar-health.js', () => ({ getLastKnownVram: vramMock }));
+vi.mock('../tts/design-lock.js', () => ({ isAnyAnalysisBusy: busyMock }));
+vi.mock('../workspace/user-settings.js', () => ({
+  getResolvedOllamaModel: () => 'qwen3.5:9b',
+}));
+vi.mock('./residency.js', () => ({
+  shouldEvictBeforeSidecarLoad: (v: { totalMb: number | null }) =>
+    v.totalMb != null && v.totalMb < 11000,
+}));
+
+import { evictOllamaForGpuLoad } from './evict-for-load.js';
+
+describe('evictOllamaForGpuLoad', () => {
+  beforeEach(() => {
+    unloadMock.mockClear();
+    busyMock.mockReturnValue(false);
+  });
+
+  it('evicts the configured analyzer model on an 8 GB card', async () => {
+    vramMock.mockReturnValue({ accelerator: 'cuda', totalMb: 8188 });
+    await evictOllamaForGpuLoad();
+    expect(unloadMock).toHaveBeenCalledWith(['qwen3.5:9b']);
+  });
+
+  it('does NOT evict on a 12 GB card (coexist)', async () => {
+    vramMock.mockReturnValue({ accelerator: 'cuda', totalMb: 12288 });
+    await evictOllamaForGpuLoad();
+    expect(unloadMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT evict while an analysis is in flight (interlock)', async () => {
+    vramMock.mockReturnValue({ accelerator: 'cuda', totalMb: 8188 });
+    busyMock.mockReturnValue(true);
+    await evictOllamaForGpuLoad();
+    expect(unloadMock).not.toHaveBeenCalled();
+  });
+
+  it('never throws if eviction fails (best-effort — a load must still proceed)', async () => {
+    vramMock.mockReturnValue({ accelerator: 'cuda', totalMb: 8188 });
+    unloadMock.mockRejectedValueOnce(new Error('ollama down'));
+    await expect(evictOllamaForGpuLoad()).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/gpu/evict-for-load.test.ts`
+Expected: FAIL — modules not found.
+
+- [ ] **Step 3: Implement the load-mutex**
+
+```ts
+// server/src/gpu/load-mutex.ts
+/* Serialises evict-then-load sequences. The GpuSemaphore arbitrates EXECUTION
+   (token budget around /chat and /synthesize); it neither knows about nor
+   serialises model LOADS. Two concurrent generation/design starts could each
+   read "fits", then both load and overcommit. This mutex makes the
+   evict→load decision atomic. Distinct from, and orthogonal to, the token
+   semaphore. */
+let tail: Promise<unknown> = Promise.resolve();
+
+export function withGpuLoadLock<T>(fn: () => Promise<T>): Promise<T> {
+  const run = tail.then(fn, fn);
+  // Keep the chain alive regardless of fn's outcome; swallow to avoid unhandled.
+  tail = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+```
+
+- [ ] **Step 4: Implement the orchestrator**
+
+```ts
+// server/src/gpu/evict-for-load.ts
+import { getLastKnownVram } from '../routes/sidecar-health.js';
+import { unloadResidentOllama } from '../routes/ollama-health.js';
+import { isAnyAnalysisBusy } from '../tts/design-lock.js';
+import { getResolvedOllamaModel } from '../workspace/user-settings.js';
+import { shouldEvictBeforeSidecarLoad } from './residency.js';
+import { withGpuLoadLock } from './load-mutex.js';
+
+/** Best-effort: before a server-initiated sidecar TTS/voice-design load, free a
+    resident Ollama analyzer if the card can't host both. No-op on CPU / big
+    cards / when an analysis is in flight (it must not be evicted; analysis and
+    generation are sequential pipeline phases). Scoped to the configured
+    analyzer model so a concurrent session's different model isn't stomped.
+    Never throws — a failed eviction must not block the load it precedes. */
+export async function evictOllamaForGpuLoad(): Promise<void> {
+  if (isAnyAnalysisBusy()) return;
+  if (!shouldEvictBeforeSidecarLoad(getLastKnownVram())) return;
+  await withGpuLoadLock(async () => {
+    try {
+      await unloadResidentOllama([getResolvedOllamaModel()]);
+    } catch (e) {
+      console.warn(`[gpu] pre-load Ollama eviction failed (continuing): ${(e as Error).message}`);
+    }
+  });
+}
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `cd server && npx vitest run src/gpu/evict-for-load.test.ts`
+Expected: PASS (all four cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/gpu/load-mutex.ts server/src/gpu/evict-for-load.ts server/src/gpu/evict-for-load.test.ts
+git commit -m "feat(server): evictOllamaForGpuLoad orchestrator + GPU load-mutex"
+```
+
+---
+
+### Task 6: Hook the generation/bulk preload (`ensureSidecarEngineReady`)
+
+**Files:**
+- Modify: `server/src/tts/ensure-sidecar-loaded.ts` (`ensureSidecarEngineReady`, before the `for (;;)` loop, ~line 113)
+- Test: `server/src/tts/ensure-sidecar-loaded.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('evicts a resident Ollama model BEFORE the first /load poll', async () => {
+  const calls: string[] = [];
+  const evictMock = vi.fn(async () => { calls.push('evict'); });
+  vi.doMock('../gpu/evict-for-load.js', () => ({ evictOllamaForGpuLoad: evictMock }));
+  vi.stubGlobal('fetch', vi.fn(async () => { calls.push('load'); return okJson({ status: 'ready' }); }));
+  const { ensureSidecarEngineReady } = await import('./ensure-sidecar-loaded.js');
+  await ensureSidecarEngineReady('qwen', undefined, { timeoutMs: 1000, pollIntervalMs: 10 });
+  expect(evictMock).toHaveBeenCalledTimes(1);
+  expect(calls[0]).toBe('evict'); // eviction precedes the first load
+});
+
+it('does NOT evict for a cloud / non-sidecar engine', async () => {
+  const evictMock = vi.fn();
+  vi.doMock('../gpu/evict-for-load.js', () => ({ evictOllamaForGpuLoad: evictMock }));
+  const { ensureSidecarEngineReady } = await import('./ensure-sidecar-loaded.js');
+  await ensureSidecarEngineReady('gemini' as never);
+  expect(evictMock).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/tts/ensure-sidecar-loaded.test.ts -t "evicts a resident"`
+Expected: FAIL — no eviction call happens today.
+
+- [ ] **Step 3: Implement the hook**
+
+In `ensureSidecarEngineReady`, after the `if (!SIDECAR_ENGINES.has(engine)) return;` guard and before computing `target`/the loop:
+
+```ts
+const { evictOllamaForGpuLoad } = await import('../gpu/evict-for-load.js');
+await evictOllamaForGpuLoad(); // once, before polling /load (not per attempt)
+```
+
+(Place it after the early returns so cloud engines and an already-aborted signal skip it; the dynamic import keeps the gpu module out of the cloud path.)
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd server && npx vitest run src/tts/ensure-sidecar-loaded.test.ts`
+Expected: PASS (eviction-precedes-load + cloud-skips + existing readiness tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/tts/ensure-sidecar-loaded.ts server/src/tts/ensure-sidecar-loaded.test.ts
+git commit -m "feat(server): evict resident Ollama before the generation preload /load"
+```
+
+---
+
+### Task 7: Hook the voice-design path (`designQwenVoiceForCharacter`)
+
+**Files:**
+- Modify: `server/src/routes/qwen-voice.ts` (inside `withDesignLock`, before the `/qwen/design-voice` fetch, ~line 271)
+- Test: `server/src/routes/qwen-voice.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('evicts a resident Ollama model before the design fetch', async () => {
+  const order: string[] = [];
+  const evictMock = vi.fn(async () => { order.push('evict'); });
+  vi.doMock('../gpu/evict-for-load.js', () => ({ evictOllamaForGpuLoad: evictMock }));
+  vi.stubGlobal('fetch', vi.fn(async () => { order.push('design'); return okJson({ voiceId: 'v', url: 'u' }); }));
+  const { designQwenVoiceForCharacter } = await import('./qwen-voice.js');
+  await designQwenVoiceForCharacter(/* minimal valid params per the existing suite's helper */);
+  expect(evictMock).toHaveBeenCalledTimes(1);
+  expect(order[0]).toBe('evict');
+});
+```
+
+(Reuse the file's existing param/fixture helper for `DesignQwenVoiceParams`; mock `withDesignLock` to invoke its callback if the suite already does.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/routes/qwen-voice.test.ts -t "evicts a resident"`
+Expected: FAIL — no eviction before the design fetch.
+
+- [ ] **Step 3: Implement the hook**
+
+Inside the `withDesignLock(p.bookDir, async () => { ... })` callback, as the FIRST statement (before `gpuSemaphore.acquire`):
+
+```ts
+const { evictOllamaForGpuLoad } = await import('../gpu/evict-for-load.js');
+await evictOllamaForGpuLoad(); // free VRAM before the sidecar lazily loads VoiceDesign (~5 GB)
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd server && npx vitest run src/routes/qwen-voice.test.ts`
+Expected: PASS (eviction-precedes-design + existing design tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/qwen-voice.ts server/src/routes/qwen-voice.test.ts
+git commit -m "feat(server): evict resident Ollama before voice-design loads VoiceDesign"
+```
+
+---
+
+### Task 8: CPU-gate the 9B residency (keep_alive × accelerator)
+
+**Files:**
+- Modify: `server/src/analyzer/ollama.ts` (`keepAliveFor`, ~line 129; its caller at ~line 416)
+- Test: `server/src/analyzer/ollama.test.ts` (the keep_alive describe, ~line 186)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the keep_alive describe:
+
+```ts
+it('keeps the heavy 9B resident only on a GPU; CPU-only unloads it to spare RAM', async () => {
+  const { keepAliveFor } = await import('./ollama.js');
+  expect(keepAliveFor('qwen3.5:9b', 'cuda')).toBe('5m');
+  expect(keepAliveFor('qwen3.5:9b', 'cpu')).toBe(0);
+  // small models stay resident regardless — they don't threaten RAM
+  expect(keepAliveFor('qwen3.5:4b', 'cpu')).toBe('5m');
+  // unknown accelerator: treat as GPU (the common case) — keep 9B resident
+  expect(keepAliveFor('qwen3.5:9b', 'unknown')).toBe('5m');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/analyzer/ollama.test.ts -t "only on a GPU"`
+Expected: FAIL — `keepAliveFor` takes one arg.
+
+- [ ] **Step 3: Implement the gate**
+
+Update `keepAliveFor` and its caller. Add a set of "big" models that are only worth pinning where VRAM (not RAM) is the constraint:
+
+```ts
+const RAM_HEAVY_MODELS = new Set(['qwen3.5:9b']); // pin only on a GPU
+
+export function keepAliveFor(model: string, accelerator: Accelerator = 'unknown'): string | number {
+  if (!RESIDENT_MODELS.has(model)) return 0;
+  if (RAM_HEAVY_MODELS.has(model) && accelerator === 'cpu') return 0;
+  return '5m';
+}
+```
+
+Import `Accelerator` + `getLastKnownVram` and thread the accelerator at the call site (~line 416):
+
+```ts
+import type { Accelerator } from '../routes/sidecar-health.js';
+import { getLastKnownVram } from '../routes/sidecar-health.js';
+// ...
+keep_alive: keepAliveFor(this.model, getLastKnownVram().accelerator),
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd server && npx vitest run src/analyzer/ollama.test.ts`
+Expected: PASS (new gate test + the 3 updated 9B='5m' tests already on this branch).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/analyzer/ollama.ts server/src/analyzer/ollama.test.ts
+git commit -m "feat(server): pin the 9B analyzer resident only on a GPU (spare CPU RAM)"
+```
+
+---
+
+### Task 9: Regression — no sidecar `/load` while an over-budget Ollama model is resident
+
+**Files:**
+- Test: `server/src/gpu/eviction-regression.test.ts` (new, integration-style with mocks)
+
+- [ ] **Step 1: Write the failing-then-passing guard test**
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/* The load-bearing safety invariant for the keep_alive flip: on an 8 GB card,
+   a sidecar /load must be PRECEDED by an Ollama eviction. Drive the real
+   ensureSidecarEngineReady with mocked VRAM (8 GB), a resident model, and a
+   recording fetch; assert the eviction generate-call lands before the /load. */
+
+const events: string[] = [];
+vi.mock('../routes/sidecar-health.js', () => ({
+  getLastKnownVram: () => ({ accelerator: 'cuda', totalMb: 8188 }),
+}));
+vi.mock('../tts/design-lock.js', () => ({ isAnyAnalysisBusy: () => false }));
+vi.mock('../workspace/user-settings.js', () => ({
+  getResolvedOllamaModel: () => 'qwen3.5:9b',
+  getResolvedSidecarUrl: () => 'http://sidecar',
+}));
+vi.mock('../routes/ollama-health.js', () => ({
+  unloadResidentOllama: vi.fn(async () => { events.push('ollama-evict'); return ['qwen3.5:9b']; }),
+}));
+
+beforeEach(() => { events.length = 0; });
+
+it('on 8 GB, eviction precedes the sidecar /load', async () => {
+  vi.stubGlobal('fetch', vi.fn(async () => { events.push('sidecar-load'); return new Response(JSON.stringify({ status: 'ready' }), { status: 200 }); }));
+  const { ensureSidecarEngineReady } = await import('../tts/ensure-sidecar-loaded.js');
+  await ensureSidecarEngineReady('qwen', undefined, { timeoutMs: 1000, pollIntervalMs: 10 });
+  expect(events).toEqual(['ollama-evict', 'sidecar-load']);
+});
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `cd server && npx vitest run src/gpu/eviction-regression.test.ts`
+Expected: PASS (Tasks 5-6 already wired the ordering; this pins it against regressions).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/src/gpu/eviction-regression.test.ts
+git commit -m "test(server): regression — eviction precedes sidecar load on 8 GB"
+```
+
+---
+
+### Task 10: Document the .env knob + full verify
+
+**Files:**
+- Modify: `server/.env.example`
+
+- [ ] **Step 1: Document the knob**
+
+Add under the GPU section of `server/.env.example`:
+
+```
+# Below this detected GPU VRAM (MB), evict the resident Ollama analyzer before
+# loading a sidecar TTS/voice-design model. 8 GB cards evict; 12/16 GB coexist.
+# 0 = always evict. Default 11000.
+GPU_SAFE_COEXIST_MB=11000
+```
+
+- [ ] **Step 2: Run the full server battery**
+
+Run: `cd server && npm run test:server && npm run test:server-slow`
+Expected: PASS (all green; the keep_alive-flip tests, the new gpu/ tests, the eviction hooks).
+
+- [ ] **Step 3: Typecheck + verify**
+
+Run: `npm run typecheck` then `npm run verify`
+Expected: PASS. (Run `verify` only when the GPU is idle — it contends with any live analysis/generation.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/.env.example
+git commit -m "docs(server): document GPU_SAFE_COEXIST_MB eviction threshold"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** §4.1 threshold (Task 3), §4.2 VRAM cache (Task 2), §4.3 shared helper + scoped eviction (Tasks 4-5), §4.4 both hooks (Tasks 6-7), §4.5 load-mutex (Task 5), §4.6 in-flight interlock (Task 5), §4.7 CPU residency gate (Task 8), §8 W1 tests incl. the no-load-while-resident regression (Task 9). Registry knob (Task 1) + .env (Task 10).
+- **Out of scope (later waves):** label honesty (W2), progress explainer (W3), MB-accounting policy + split-guard UI (W4 deferred).
+- **Merge:** this branch carries the keep_alive flip; do not merge a build with the flip but without Tasks 5-7.

--- a/docs/superpowers/plans/2026-06-16-wave1-gpu-eviction-residency.md
+++ b/docs/superpowers/plans/2026-06-16-wave1-gpu-eviction-residency.md
@@ -2,15 +2,15 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make the already-done `qwen3.5:9b` `keep_alive: '5m'` flip safe by evicting a resident Ollama model server-side before any sidecar TTS/voice-design load, gated by a single VRAM threshold.
+**Goal:** Make the already-done `qwen3.5:9b` `keep_alive: '5m'` flip safe by evicting resident Ollama models server-side before any sidecar TTS/voice-design load — atomically (evict+load under one lock), evicting **all** residents, and **refusing** the load (409) when analysis is busy on a card that can't coexist.
 
-**Architecture:** A pure `residency` policy decides "evict before load?" from a cached VRAM state (last-known-good from sidecar `/health`, resilient to respawn). A shared `unloadResidentOllama()` (extracted from the `/unload` route) performs the eviction under a dedicated load-mutex, scoped to the configured analyzer model so concurrent sessions aren't stomped. Two server-side chokepoints call it: `ensureSidecarEngineReady` (generation/bulk) and `designQwenVoiceForCharacter` (voice design). An `isAnyAnalysisBusy()` interlock guarantees an in-flight analysis is never evicted.
+**Architecture:** A pure `residency` policy decides "evict before load?" from a cached VRAM state (last-known-good from sidecar `/health`, resilient to respawn). `withGpuLoad(loadFn)` is the single chokepoint: on a constrained card it takes a load-mutex, refuses if an analysis is in flight (`GpuBusyError` → 409), evicts **all** resident Ollama models, verifies they're gone (fail-closed), then runs the load **inside the lock**; on a roomy card / CPU it runs the load directly. Two call sites wrap their loads in it: `ensureSidecarEngineReady` (generation/bulk) and `designQwenVoiceForCharacter` (voice design).
 
-**Tech Stack:** TypeScript (Node ESM), Vitest (node env), Express routes, the existing config registry (`configValue`).
+**Tech Stack:** TypeScript (Node ESM), Vitest (node env), Express routes, the config registry (`configValue`).
 
-**Spec:** `docs/superpowers/specs/2026-06-16-vram-budget-aware-gpu-policy-design.md` (§4).
+**Spec:** `docs/superpowers/specs/2026-06-16-vram-budget-aware-gpu-policy-design.md` (§4). This plan was revised after a two-lens adversarial review of v1 — see §"Review fixes baked in" at the end.
 
-**Branch:** `git switch feat/analysing-residency-label-progress` then rename: `git branch -m fix/server-gpu-eviction-before-sidecar-load`. The keep_alive flip + its ollama tests already live here (uncommitted) and ship with this wave.
+**Branch:** `git switch feat/analysing-residency-label-progress` then `git branch -m fix/server-gpu-eviction-before-sidecar-load`. The keep_alive flip + its ollama tests already live here (uncommitted) and ship with this wave. **Keep the flip as the LAST commit** so it can be reverted independently if a post-merge OOM surfaces.
 
 ---
 
@@ -18,27 +18,31 @@
 
 **Files:**
 - Modify: `server/src/config/registry.ts` (the `gpu-lifecycle` group)
+- Reference: `server/src/config/types.ts` (the `ConfigKnob` shape — fields are `key`, `env`, `type`, `default`, `risk`, `apply`, `group`, `label`, `help`; numeric knobs may carry `min`)
 
 - [ ] **Step 1: Add the knob to the registry**
 
-Find the `gpu-lifecycle` group entries (search `gpu.vramBudget` / `gpu.concurrency`) and add an entry alongside them:
+Find the `gpu-lifecycle` entries (search `gpu.vramBudget`) and add, matching the existing `ConfigKnob` shape exactly:
 
 ```ts
 {
-  id: 'gpu.safeCoexistMb',
+  key: 'gpu.safeCoexistMb',
+  env: 'GPU_SAFE_COEXIST_MB',
   group: 'gpu-lifecycle',
   type: 'number',
   default: 11000,
-  label: 'Safe analyzer+TTS coexistence VRAM (MB)',
-  help: 'If detected GPU VRAM is below this, evict the resident Ollama analyzer before loading a sidecar TTS/voice-design model. 8 GB cards evict; 12/16 GB coexist. Set 0 to always evict.',
+  min: 0,
+  risk: 'high',
   apply: 'live',
+  label: 'Safe analyzer+TTS coexistence VRAM (MB)',
+  help: 'If detected GPU VRAM is below this, evict the resident Ollama analyzer before loading a sidecar TTS/voice-design model. 8 GB cards evict; 12/16 GB coexist. 0 = always evict.',
 },
 ```
 
 - [ ] **Step 2: Verify it resolves**
 
-Run: `cd server && npx vitest run src/config -t "registry"`
-Expected: PASS (existing registry-shape tests still green with the new entry).
+Run: `cd server && npx vitest run src/config`
+Expected: PASS — existing registry-shape tests stay green with the new entry; `configValue<number>('gpu.safeCoexistMb')` resolves to 11000 (or `GPU_SAFE_COEXIST_MB`).
 
 - [ ] **Step 3: Commit**
 
@@ -49,38 +53,36 @@ git commit -m "feat(server): add gpu.safeCoexistMb eviction-threshold knob"
 
 ---
 
-### Task 2: VRAM-state cache on sidecar health (resilient to respawn)
+### Task 2: VRAM-state module (cache + types), resilient to respawn
 
 **Files:**
-- Modify: `server/src/routes/sidecar-health.ts` (near `setLastKnownQwenInstallState`, ~line 244)
-- Test: `server/src/routes/sidecar-health.test.ts`
+- Create: `server/src/gpu/vram-state.ts` (own the `VramState`/`Accelerator` types + the cache, so neither the analyzer nor the policy has to import the heavy `routes/sidecar-health.ts` graph)
+- Modify: `server/src/routes/sidecar-health.ts` (populate the cache on a reachable probe, ~line 244)
+- Test: `server/src/gpu/vram-state.test.ts`
 
 - [ ] **Step 1: Write the failing test**
 
 ```ts
 import { describe, it, expect, beforeEach } from 'vitest';
-import { setLastKnownVram, getLastKnownVram } from './sidecar-health.js';
+import { setLastKnownVram, getLastKnownVram } from './vram-state.js';
 
 describe('last-known VRAM cache', () => {
   beforeEach(() => setLastKnownVram(null)); // reset to "never probed"
 
-  it('defaults to unknown accelerator / null total before any probe', () => {
+  it('defaults to unknown / null before any probe', () => {
     expect(getLastKnownVram()).toEqual({ accelerator: 'unknown', totalMb: null });
   });
-
-  it('records a CUDA total and exposes accelerator cuda', () => {
+  it('records a CUDA total as accelerator cuda', () => {
     setLastKnownVram({ totalMb: 8188 });
     expect(getLastKnownVram()).toEqual({ accelerator: 'cuda', totalMb: 8188 });
   });
-
   it('records a reachable-but-no-CUDA probe as cpu', () => {
     setLastKnownVram({ totalMb: null });
     expect(getLastKnownVram()).toEqual({ accelerator: 'cpu', totalMb: null });
   });
-
   it('an unreachable poll (undefined) leaves the last-known state intact', () => {
     setLastKnownVram({ totalMb: 8188 });
-    setLastKnownVram(undefined); // unreachable — do not downgrade
+    setLastKnownVram(undefined);
     expect(getLastKnownVram()).toEqual({ accelerator: 'cuda', totalMb: 8188 });
   });
 });
@@ -88,14 +90,13 @@ describe('last-known VRAM cache', () => {
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cd server && npx vitest run src/routes/sidecar-health.test.ts -t "last-known VRAM"`
-Expected: FAIL — `setLastKnownVram`/`getLastKnownVram` are not exported.
+Run: `cd server && npx vitest run src/gpu/vram-state.test.ts`
+Expected: FAIL — module not found.
 
-- [ ] **Step 3: Implement the cache**
-
-Add near `setLastKnownQwenInstallState` in `sidecar-health.ts`:
+- [ ] **Step 3: Implement the module**
 
 ```ts
+// server/src/gpu/vram-state.ts
 export type Accelerator = 'cuda' | 'cpu' | 'unknown';
 export interface VramState {
   accelerator: Accelerator;
@@ -104,15 +105,13 @@ export interface VramState {
 
 /* Last-known VRAM, mirroring the Qwen-install-state cache: only a REACHABLE
    probe updates it, so a transient sidecar respawn (when eviction must still
-   make a decision) doesn't downgrade a known-good reading. `null` = reset to
-   "never probed"; `undefined` = unreachable poll (no-op). CUDA presence is
-   inferred from a non-null vram_total_mb (the sidecar reports it iff CUDA). */
+   decide) doesn't downgrade a known-good reading. `null` resets to "never
+   probed"; `undefined` is an unreachable poll (no-op). CUDA presence is inferred
+   from a non-null vram_total_mb (the sidecar reports it iff CUDA). */
 let lastKnownVram: VramState = { accelerator: 'unknown', totalMb: null };
 
-export function setLastKnownVram(
-  next: { totalMb: number | null } | null | undefined,
-): void {
-  if (next === undefined) return; // unreachable — keep last-known
+export function setLastKnownVram(next: { totalMb: number | null } | null | undefined): void {
+  if (next === undefined) return;
   if (next === null) {
     lastKnownVram = { accelerator: 'unknown', totalMb: null };
     return;
@@ -130,8 +129,11 @@ export function getLastKnownVram(): VramState {
 
 - [ ] **Step 4: Populate it on a reachable probe**
 
-In `probeSidecarHealth`, immediately after `setLastKnownQwenInstallState(qwenInstallState);` (line ~244):
-
+In `sidecar-health.ts` add the import at the top:
+```ts
+import { setLastKnownVram } from '../gpu/vram-state.js';
+```
+and immediately after `setLastKnownQwenInstallState(qwenInstallState);` (line ~244):
 ```ts
 setLastKnownVram({
   totalMb: typeof body.vram_total_mb === 'number' ? body.vram_total_mb : null,
@@ -140,14 +142,14 @@ setLastKnownVram({
 
 - [ ] **Step 5: Run tests to verify pass**
 
-Run: `cd server && npx vitest run src/routes/sidecar-health.test.ts`
-Expected: PASS (new cache tests + existing health tests).
+Run: `cd server && npx vitest run src/gpu/vram-state.test.ts src/routes/sidecar-health.test.ts`
+Expected: PASS.
 
 - [ ] **Step 6: Commit**
 
 ```bash
-git add server/src/routes/sidecar-health.ts server/src/routes/sidecar-health.test.ts
-git commit -m "feat(server): cache last-known GPU VRAM state from sidecar health"
+git add server/src/gpu/vram-state.ts server/src/gpu/vram-state.test.ts server/src/routes/sidecar-health.ts
+git commit -m "feat(server): last-known GPU VRAM state cache (gpu/vram-state)"
 ```
 
 ---
@@ -161,32 +163,22 @@ git commit -m "feat(server): cache last-known GPU VRAM state from sidecar health
 - [ ] **Step 1: Write the failing test**
 
 ```ts
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-
-vi.mock('../config/resolver.js', () => ({
-  configValue: vi.fn(() => 11000), // gpu.safeCoexistMb default
-}));
-
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('../config/resolver.js', () => ({ configValue: vi.fn(() => 11000) }));
 import { shouldEvictBeforeSidecarLoad } from './residency.js';
 
 describe('shouldEvictBeforeSidecarLoad', () => {
-  it('CPU never evicts (no VRAM contention)', () => {
+  it('CPU never evicts', () => {
     expect(shouldEvictBeforeSidecarLoad({ accelerator: 'cpu', totalMb: null })).toBe(false);
   });
-
-  it('GPU with unknown total is conservative — evict', () => {
+  it('GPU unknown total → evict (conservative)', () => {
     expect(shouldEvictBeforeSidecarLoad({ accelerator: 'cuda', totalMb: null })).toBe(true);
   });
-
-  it('accelerator unknown (never probed) is conservative — evict', () => {
+  it('accelerator unknown (never probed) → evict (conservative)', () => {
     expect(shouldEvictBeforeSidecarLoad({ accelerator: 'unknown', totalMb: null })).toBe(true);
   });
-
-  it('8 GB card (below threshold) evicts', () => {
+  it('8 GB evicts; 12/16 GB coexist', () => {
     expect(shouldEvictBeforeSidecarLoad({ accelerator: 'cuda', totalMb: 8188 })).toBe(true);
-  });
-
-  it('12 GB and 16 GB cards coexist (no evict)', () => {
     expect(shouldEvictBeforeSidecarLoad({ accelerator: 'cuda', totalMb: 12288 })).toBe(false);
     expect(shouldEvictBeforeSidecarLoad({ accelerator: 'cuda', totalMb: 16384 })).toBe(false);
   });
@@ -203,15 +195,11 @@ Expected: FAIL — module not found.
 ```ts
 // server/src/gpu/residency.ts
 import { configValue } from '../config/resolver.js';
-import type { VramState } from '../routes/sidecar-health.js';
+import type { VramState } from './vram-state.js';
 
-/** Should a resident Ollama analyzer be evicted before loading a sidecar
-    TTS/voice-design model, given the detected VRAM?
-    - CPU: never (models share system RAM; no GPU to overflow).
-    - GPU, total unknown / never probed: yes (conservative — better a reload
-      than an OOM).
-    - GPU with a known total below `gpu.safeCoexistMb`: yes (8 GB can't host
-      analyzer + TTS together). At/above it: no (12/16 GB coexist). */
+/** Evict a resident Ollama analyzer before loading a sidecar TTS/voice-design
+    model? CPU: never. GPU with unknown/never-probed total: yes (conservative).
+    GPU below `gpu.safeCoexistMb`: yes; at/above: no (12/16 GB coexist). */
 export function shouldEvictBeforeSidecarLoad(v: VramState): boolean {
   if (v.accelerator === 'cpu') return false;
   if (v.totalMb == null) return true;
@@ -228,65 +216,82 @@ Expected: PASS.
 
 ```bash
 git add server/src/gpu/residency.ts server/src/gpu/residency.test.ts
-git commit -m "feat(server): VRAM-threshold residency policy (shouldEvictBeforeSidecarLoad)"
+git commit -m "feat(server): VRAM-threshold residency policy"
 ```
 
 ---
 
-### Task 4: Extract `unloadResidentOllama` and reuse it in the route
+### Task 4: `unloadResidentOllama` (evict ALL) + `verifyOllamaEvicted`
 
 **Files:**
-- Modify: `server/src/routes/ollama-health.ts` (the `POST /unload` handler, ~lines 282-301)
-- Test: `server/src/routes/ollama-health.test.ts` (existing `/unload` describe block, ~line 225)
+- Modify: `server/src/routes/ollama-health.ts` (extract from `POST /unload`, ~lines 282-301; reuse `probeOllamaHealth().resident`, `callOllamaGenerate`, `PROBE_TIMEOUT_MS`, `getResolvedOllamaUrl`)
+- Test: `server/src/routes/ollama-health.test.ts` (the `/unload` describe, ~line 225)
 
 - [ ] **Step 1: Write the failing test**
 
-Add to the existing `/unload` describe in `ollama-health.test.ts`:
-
 ```ts
-it('exposes unloadResidentOllama() that evicts the named targets with keep_alive: 0', async () => {
-  const fetchMock = vi.fn().mockResolvedValue(okResponse('{}')); // reuse the file's helpers
-  vi.stubGlobal('fetch', fetchMock);
+it('unloadResidentOllama() with no targets evicts EVERY resident with keep_alive: 0', async () => {
+  // probeOllamaHealth reports two residents; the helper must evict both.
+  fetchMock.mockImplementation(async (url: string) => {
+    if (String(url).endsWith('/api/ps')) {
+      return new Response(JSON.stringify({ models: [{ name: 'qwen3.5:9b' }, { name: 'llama3.1:8b' }] }), { status: 200 });
+    }
+    return new Response('', { status: 200 }); // /api/generate unload
+  });
   const { unloadResidentOllama } = await import('./ollama-health.js');
-  await unloadResidentOllama(['qwen3.5:9b']);
-  const body = JSON.parse(fetchMock.mock.calls[0][1].body);
-  expect(body.model).toBe('qwen3.5:9b');
-  expect(body.keep_alive).toBe(0);
+  const evicted = await unloadResidentOllama();
+  expect(evicted.sort()).toEqual(['llama3.1:8b', 'qwen3.5:9b']);
+});
+
+it('verifyOllamaEvicted() resolves true once /api/ps no longer lists the target', async () => {
+  let calls = 0;
+  fetchMock.mockImplementation(async () => {
+    calls += 1;
+    const models = calls === 1 ? [{ name: 'qwen3.5:9b' }] : []; // gone on the 2nd probe
+    return new Response(JSON.stringify({ models }), { status: 200 });
+  });
+  const { verifyOllamaEvicted } = await import('./ollama-health.js');
+  await expect(verifyOllamaEvicted({ retries: 3, delayMs: 1 })).resolves.toBe(true);
 });
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cd server && npx vitest run src/routes/ollama-health.test.ts -t "unloadResidentOllama"`
-Expected: FAIL — `unloadResidentOllama` not exported.
+Run: `cd server && npx vitest run src/routes/ollama-health.test.ts -t "unloadResidentOllama|verifyOllamaEvicted"`
+Expected: FAIL — neither is exported.
 
-- [ ] **Step 3: Extract the helper**
-
-In `ollama-health.ts`, add an exported function and have the route call it:
+- [ ] **Step 3: Implement**
 
 ```ts
-/** Evict resident Ollama model(s) by issuing keep_alive:0 generate calls.
-    `targets` empty/omitted → evict EVERY model /api/ps reports (the explicit
-    Stop path). Returns the list actually evicted. Throws on the first failed
-    eviction so callers can surface it. */
+/** Evict resident Ollama model(s) via keep_alive:0 generate calls. Empty/omitted
+    `targets` → evict EVERY model /api/ps reports (the safe default: a phase-env
+    or quant-tagged resident won't be missed; matches the /unload-all route).
+    Returns the list evicted. Throws on the first failed eviction. */
 export async function unloadResidentOllama(targets?: string[]): Promise<string[]> {
   const url = getResolvedOllamaUrl();
-  const list =
-    targets && targets.length > 0 ? targets : (await probeOllamaHealth()).resident ?? [];
+  const list = targets && targets.length > 0 ? targets : (await probeOllamaHealth()).resident ?? [];
   for (const model of list) {
-    const result = await callOllamaGenerate(
-      url,
-      { model, prompt: '', keep_alive: 0, stream: false },
-      PROBE_TIMEOUT_MS,
-    );
+    const result = await callOllamaGenerate(url, { model, prompt: '', keep_alive: 0, stream: false }, PROBE_TIMEOUT_MS);
     if (!result.ok) throw new Error(result.error ?? `unload ${model} failed`);
   }
   return list;
 }
+
+/** Poll /api/ps until no model remains resident (Ollama unloads asynchronously).
+    Returns true when clear; false if still resident after the retries. */
+export async function verifyOllamaEvicted(opts: { retries?: number; delayMs?: number } = {}): Promise<boolean> {
+  const retries = opts.retries ?? 5;
+  const delayMs = opts.delayMs ?? 400;
+  for (let i = 0; i < retries; i += 1) {
+    const resident = (await probeOllamaHealth()).resident ?? [];
+    if (resident.length === 0) return true;
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+  return ((await probeOllamaHealth()).resident ?? []).length === 0;
+}
 ```
 
-Replace the body of the `POST /unload` handler to delegate:
-
+Replace the `POST /unload` handler body to delegate:
 ```ts
 ollamaHealthRouter.post('/unload', async (req: Request, res: Response) => {
   const requested = typeof req.body?.model === 'string' ? req.body.model.trim() : '';
@@ -302,103 +307,100 @@ ollamaHealthRouter.post('/unload', async (req: Request, res: Response) => {
 - [ ] **Step 4: Run tests to verify pass**
 
 Run: `cd server && npx vitest run src/routes/ollama-health.test.ts`
-Expected: PASS (new test + the existing single/all/error eviction tests).
+Expected: PASS (new tests + existing single/all/error eviction tests).
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add server/src/routes/ollama-health.ts server/src/routes/ollama-health.test.ts
-git commit -m "refactor(server): extract unloadResidentOllama() shared eviction helper"
+git commit -m "refactor(server): unloadResidentOllama (evict-all) + verifyOllamaEvicted"
 ```
 
 ---
 
-### Task 5: Load-mutex + the `evictOllamaForGpuLoad` orchestrator
+### Task 5: `withGpuLoad` orchestrator + load-mutex + `GpuBusyError`
 
 **Files:**
 - Create: `server/src/gpu/load-mutex.ts`
-- Create: `server/src/gpu/evict-for-load.ts`
-- Test: `server/src/gpu/evict-for-load.test.ts`
+- Create: `server/src/gpu/gpu-load.ts`
+- Test: `server/src/gpu/gpu-load.test.ts`
 
 - [ ] **Step 1: Write the failing test**
 
 ```ts
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const unloadMock = vi.fn().mockResolvedValue(['qwen3.5:9b']);
+const unloadMock = vi.fn(async () => ['qwen3.5:9b']);
+const verifyMock = vi.fn(async () => true);
 const vramMock = vi.fn();
-const busyMock = vi.fn().mockReturnValue(false);
+const busyMock = vi.fn(() => false);
+const shouldEvictMock = vi.fn((v: { totalMb: number | null }) => v.totalMb != null && v.totalMb < 11000);
 
-vi.mock('../routes/ollama-health.js', () => ({ unloadResidentOllama: unloadMock }));
-vi.mock('../routes/sidecar-health.js', () => ({ getLastKnownVram: vramMock }));
+vi.mock('../routes/ollama-health.js', () => ({ unloadResidentOllama: unloadMock, verifyOllamaEvicted: verifyMock }));
+vi.mock('./vram-state.js', () => ({ getLastKnownVram: vramMock }));
 vi.mock('../tts/design-lock.js', () => ({ isAnyAnalysisBusy: busyMock }));
-vi.mock('../workspace/user-settings.js', () => ({
-  getResolvedOllamaModel: () => 'qwen3.5:9b',
-}));
-vi.mock('./residency.js', () => ({
-  shouldEvictBeforeSidecarLoad: (v: { totalMb: number | null }) =>
-    v.totalMb != null && v.totalMb < 11000,
-}));
+vi.mock('./residency.js', () => ({ shouldEvictBeforeSidecarLoad: shouldEvictMock }));
 
-import { evictOllamaForGpuLoad } from './evict-for-load.js';
+import { withGpuLoad, GpuBusyError } from './gpu-load.js';
 
-describe('evictOllamaForGpuLoad', () => {
-  beforeEach(() => {
-    unloadMock.mockClear();
-    busyMock.mockReturnValue(false);
-  });
+beforeEach(() => {
+  unloadMock.mockClear(); verifyMock.mockClear(); busyMock.mockReturnValue(false); verifyMock.mockResolvedValue(true);
+});
 
-  it('evicts the configured analyzer model on an 8 GB card', async () => {
+describe('withGpuLoad', () => {
+  it('on 8 GB: evicts, verifies, then runs the load (in that order)', async () => {
     vramMock.mockReturnValue({ accelerator: 'cuda', totalMb: 8188 });
-    await evictOllamaForGpuLoad();
-    expect(unloadMock).toHaveBeenCalledWith(['qwen3.5:9b']);
+    const order: string[] = [];
+    unloadMock.mockImplementationOnce(async () => { order.push('evict'); return ['qwen3.5:9b']; });
+    verifyMock.mockImplementationOnce(async () => { order.push('verify'); return true; });
+    const out = await withGpuLoad(async () => { order.push('load'); return 'ok'; });
+    expect(out).toBe('ok');
+    expect(order).toEqual(['evict', 'verify', 'load']);
   });
 
-  it('does NOT evict on a 12 GB card (coexist)', async () => {
+  it('on 12 GB: runs the load directly, no eviction', async () => {
     vramMock.mockReturnValue({ accelerator: 'cuda', totalMb: 12288 });
-    await evictOllamaForGpuLoad();
+    const out = await withGpuLoad(async () => 'ok');
+    expect(out).toBe('ok');
     expect(unloadMock).not.toHaveBeenCalled();
   });
 
-  it('does NOT evict while an analysis is in flight (interlock)', async () => {
+  it('REFUSES with GpuBusyError when analysis is busy on a constrained card (no load)', async () => {
     vramMock.mockReturnValue({ accelerator: 'cuda', totalMb: 8188 });
     busyMock.mockReturnValue(true);
-    await evictOllamaForGpuLoad();
+    const load = vi.fn();
+    await expect(withGpuLoad(load as never)).rejects.toBeInstanceOf(GpuBusyError);
+    expect(load).not.toHaveBeenCalled();
     expect(unloadMock).not.toHaveBeenCalled();
   });
 
-  it('never throws if eviction fails (best-effort — a load must still proceed)', async () => {
+  it('fail-closed: if eviction cannot be verified, throws and does NOT load', async () => {
     vramMock.mockReturnValue({ accelerator: 'cuda', totalMb: 8188 });
-    unloadMock.mockRejectedValueOnce(new Error('ollama down'));
-    await expect(evictOllamaForGpuLoad()).resolves.toBeUndefined();
+    verifyMock.mockResolvedValue(false);
+    const load = vi.fn();
+    await expect(withGpuLoad(load as never)).rejects.toBeInstanceOf(GpuBusyError);
+    expect(load).not.toHaveBeenCalled();
   });
 });
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cd server && npx vitest run src/gpu/evict-for-load.test.ts`
+Run: `cd server && npx vitest run src/gpu/gpu-load.test.ts`
 Expected: FAIL — modules not found.
 
 - [ ] **Step 3: Implement the load-mutex**
 
 ```ts
 // server/src/gpu/load-mutex.ts
-/* Serialises evict-then-load sequences. The GpuSemaphore arbitrates EXECUTION
-   (token budget around /chat and /synthesize); it neither knows about nor
-   serialises model LOADS. Two concurrent generation/design starts could each
-   read "fits", then both load and overcommit. This mutex makes the
-   evict→load decision atomic. Distinct from, and orthogonal to, the token
-   semaphore. */
+/* Serialises evict+load sequences. The GpuSemaphore arbitrates EXECUTION (token
+   budget around /chat and /synthesize); it neither knows about nor serialises
+   model LOADS. This mutex makes evict→verify→load atomic so two concurrent
+   starts can't both evict then both load and overcommit. */
 let tail: Promise<unknown> = Promise.resolve();
-
 export function withGpuLoadLock<T>(fn: () => Promise<T>): Promise<T> {
   const run = tail.then(fn, fn);
-  // Keep the chain alive regardless of fn's outcome; swallow to avoid unhandled.
-  tail = run.then(
-    () => undefined,
-    () => undefined,
-  );
+  tail = run.then(() => undefined, () => undefined);
   return run;
 }
 ```
@@ -406,153 +408,216 @@ export function withGpuLoadLock<T>(fn: () => Promise<T>): Promise<T> {
 - [ ] **Step 4: Implement the orchestrator**
 
 ```ts
-// server/src/gpu/evict-for-load.ts
-import { getLastKnownVram } from '../routes/sidecar-health.js';
-import { unloadResidentOllama } from '../routes/ollama-health.js';
-import { isAnyAnalysisBusy } from '../tts/design-lock.js';
-import { getResolvedOllamaModel } from '../workspace/user-settings.js';
+// server/src/gpu/gpu-load.ts
+import { getLastKnownVram } from './vram-state.js';
 import { shouldEvictBeforeSidecarLoad } from './residency.js';
 import { withGpuLoadLock } from './load-mutex.js';
+import { unloadResidentOllama, verifyOllamaEvicted } from '../routes/ollama-health.js';
+import { isAnyAnalysisBusy } from '../tts/design-lock.js';
 
-/** Best-effort: before a server-initiated sidecar TTS/voice-design load, free a
-    resident Ollama analyzer if the card can't host both. No-op on CPU / big
-    cards / when an analysis is in flight (it must not be evicted; analysis and
-    generation are sequential pipeline phases). Scoped to the configured
-    analyzer model so a concurrent session's different model isn't stomped.
-    Never throws — a failed eviction must not block the load it precedes. */
-export async function evictOllamaForGpuLoad(): Promise<void> {
-  if (isAnyAnalysisBusy()) return;
-  if (!shouldEvictBeforeSidecarLoad(getLastKnownVram())) return;
-  await withGpuLoadLock(async () => {
-    try {
-      await unloadResidentOllama([getResolvedOllamaModel()]);
-    } catch (e) {
-      console.warn(`[gpu] pre-load Ollama eviction failed (continuing): ${(e as Error).message}`);
+/** Thrown when a sidecar TTS/voice-design load cannot proceed on a card that
+    can't coexist — because an analysis is in flight, or eviction couldn't be
+    confirmed. Routes map it to HTTP 409. */
+export class GpuBusyError extends Error {
+  readonly code = 'GPU_BUSY';
+  constructor(message: string) {
+    super(message);
+    this.name = 'GpuBusyError';
+  }
+}
+
+/** Run a sidecar model load safely w.r.t. the resident Ollama analyzer.
+    - Roomy card / CPU: run the load directly (it fits; no serialisation needed).
+    - Constrained card: under the load-mutex — refuse if analysis is busy
+      (would have to evict an active analyzer), else evict ALL residents, verify
+      they're gone (fail-closed), then run the load INSIDE the lock. */
+export async function withGpuLoad<T>(loadFn: () => Promise<T>): Promise<T> {
+  if (!shouldEvictBeforeSidecarLoad(getLastKnownVram())) {
+    return loadFn();
+  }
+  return withGpuLoadLock(async () => {
+    if (isAnyAnalysisBusy()) {
+      throw new GpuBusyError('GPU busy with analysis — try again once it finishes.');
     }
+    await unloadResidentOllama();
+    if (!(await verifyOllamaEvicted())) {
+      throw new GpuBusyError('Could not free GPU memory (analyzer still resident) — try again shortly.');
+    }
+    return loadFn();
   });
 }
 ```
 
 - [ ] **Step 5: Run tests to verify pass**
 
-Run: `cd server && npx vitest run src/gpu/evict-for-load.test.ts`
+Run: `cd server && npx vitest run src/gpu/gpu-load.test.ts`
 Expected: PASS (all four cases).
 
 - [ ] **Step 6: Commit**
 
 ```bash
-git add server/src/gpu/load-mutex.ts server/src/gpu/evict-for-load.ts server/src/gpu/evict-for-load.test.ts
-git commit -m "feat(server): evictOllamaForGpuLoad orchestrator + GPU load-mutex"
+git add server/src/gpu/load-mutex.ts server/src/gpu/gpu-load.ts server/src/gpu/gpu-load.test.ts
+git commit -m "feat(server): withGpuLoad — atomic evict+verify+load with refuse-on-busy"
 ```
 
 ---
 
-### Task 6: Hook the generation/bulk preload (`ensureSidecarEngineReady`)
+### Task 6: Wrap the generation preload in `withGpuLoad`
 
 **Files:**
-- Modify: `server/src/tts/ensure-sidecar-loaded.ts` (`ensureSidecarEngineReady`, before the `for (;;)` loop, ~line 113)
+- Modify: `server/src/tts/ensure-sidecar-loaded.ts` (`ensureSidecarEngineReady`, wrap the poll loop, after the early returns ~line 107)
+- Modify: `server/src/routes/generation.ts` (the worker that calls `ensureSidecarEngineReady`, ~line 1103 — surface `GpuBusyError` as a clean refusal, not a breaker-tripping crash)
 - Test: `server/src/tts/ensure-sidecar-loaded.test.ts`
 
 - [ ] **Step 1: Write the failing test**
 
 ```ts
-it('evicts a resident Ollama model BEFORE the first /load poll', async () => {
-  const calls: string[] = [];
-  const evictMock = vi.fn(async () => { calls.push('evict'); });
-  vi.doMock('../gpu/evict-for-load.js', () => ({ evictOllamaForGpuLoad: evictMock }));
-  vi.stubGlobal('fetch', vi.fn(async () => { calls.push('load'); return okJson({ status: 'ready' }); }));
+it('wraps the load in withGpuLoad (eviction precedes the first /load on a constrained card)', async () => {
+  const order: string[] = [];
+  vi.doMock('../gpu/gpu-load.js', () => ({
+    withGpuLoad: async (fn: () => Promise<unknown>) => { order.push('gpu-load-gate'); return fn(); },
+    GpuBusyError: class extends Error {},
+  }));
+  vi.stubGlobal('fetch', vi.fn(async () => { order.push('load'); return { ok: true, json: async () => ({ status: 'ready' }) }; }));
   const { ensureSidecarEngineReady } = await import('./ensure-sidecar-loaded.js');
   await ensureSidecarEngineReady('qwen', undefined, { timeoutMs: 1000, pollIntervalMs: 10 });
-  expect(evictMock).toHaveBeenCalledTimes(1);
-  expect(calls[0]).toBe('evict'); // eviction precedes the first load
+  expect(order[0]).toBe('gpu-load-gate'); // gate wraps the load
+  expect(order).toContain('load');
 });
 
-it('does NOT evict for a cloud / non-sidecar engine', async () => {
-  const evictMock = vi.fn();
-  vi.doMock('../gpu/evict-for-load.js', () => ({ evictOllamaForGpuLoad: evictMock }));
+it('does NOT engage the gate for a cloud / non-sidecar engine', async () => {
+  const gate = vi.fn(async (fn: () => Promise<unknown>) => fn());
+  vi.doMock('../gpu/gpu-load.js', () => ({ withGpuLoad: gate, GpuBusyError: class extends Error {} }));
   const { ensureSidecarEngineReady } = await import('./ensure-sidecar-loaded.js');
   await ensureSidecarEngineReady('gemini' as never);
-  expect(evictMock).not.toHaveBeenCalled();
+  expect(gate).not.toHaveBeenCalled();
 });
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cd server && npx vitest run src/tts/ensure-sidecar-loaded.test.ts -t "evicts a resident"`
-Expected: FAIL — no eviction call happens today.
+Run: `cd server && npx vitest run src/tts/ensure-sidecar-loaded.test.ts -t "withGpuLoad"`
+Expected: FAIL — no gate today.
 
-- [ ] **Step 3: Implement the hook**
+- [ ] **Step 3: Wrap the loop**
 
-In `ensureSidecarEngineReady`, after the `if (!SIDECAR_ENGINES.has(engine)) return;` guard and before computing `target`/the loop:
+In `ensureSidecarEngineReady`, after `if (!SIDECAR_ENGINES.has(engine)) return;` and `if (signal?.aborted) throw …;`, wrap the existing readiness loop. Move the `for (;;) { … }` into a `withGpuLoad` callback:
 
 ```ts
-const { evictOllamaForGpuLoad } = await import('../gpu/evict-for-load.js');
-await evictOllamaForGpuLoad(); // once, before polling /load (not per attempt)
+const { withGpuLoad } = await import('../gpu/gpu-load.js');
+await withGpuLoad(async () => {
+  const target = `${getResolvedSidecarUrl()}/load`;
+  const deadline = Date.now() + (opts.timeoutMs ?? READINESS_TIMEOUT_MS);
+  const pollIntervalMs = opts.pollIntervalMs ?? POLL_INTERVAL_MS;
+  let lastReason = 'unknown';
+  for (;;) {
+    if (signal?.aborted) throw new DOMException('preload aborted', 'AbortError');
+    const outcome = await tryLoadOnce(target, engine, signal);
+    if (outcome.ready) return;
+    lastReason = outcome.reason;
+    if (Date.now() >= deadline) {
+      console.warn(`[generation] preload ${engine}: not ready after budget (last: ${lastReason}) — falling back to lazy load.`);
+      return;
+    }
+    await sleep(pollIntervalMs, signal);
+  }
+});
 ```
 
-(Place it after the early returns so cloud engines and an already-aborted signal skip it; the dynamic import keeps the gpu module out of the cloud path.)
+(The whole load is now inside the lock on a constrained card; `withGpuLoad` may throw `GpuBusyError` — let it propagate.)
 
-- [ ] **Step 4: Run tests to verify pass**
+- [ ] **Step 4: Handle GpuBusyError at the generation worker**
+
+At the `await ensureSidecarEngineReady(engine, chapterSignal);` call sites in `generation.ts` (lines ~1103/1121/1329), wrap so a `GpuBusyError` fails the chapter with a clear, non-retryable message rather than tripping the consecutive-failure breaker:
+
+```ts
+try {
+  await ensureSidecarEngineReady(engine, chapterSignal);
+} catch (e) {
+  const { GpuBusyError } = await import('../gpu/gpu-load.js');
+  if (e instanceof GpuBusyError) {
+    throw new Error(`Generation paused: ${e.message}`); // surfaced to the user; analysis must finish first
+  }
+  throw e;
+}
+```
+
+- [ ] **Step 5: Run tests to verify pass**
 
 Run: `cd server && npx vitest run src/tts/ensure-sidecar-loaded.test.ts`
-Expected: PASS (eviction-precedes-load + cloud-skips + existing readiness tests).
+Expected: PASS (gate-wraps-load + cloud-skips + existing readiness tests).
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-git add server/src/tts/ensure-sidecar-loaded.ts server/src/tts/ensure-sidecar-loaded.test.ts
-git commit -m "feat(server): evict resident Ollama before the generation preload /load"
+git add server/src/tts/ensure-sidecar-loaded.ts server/src/tts/ensure-sidecar-loaded.test.ts server/src/routes/generation.ts
+git commit -m "feat(server): gate the generation preload through withGpuLoad"
 ```
 
 ---
 
-### Task 7: Hook the voice-design path (`designQwenVoiceForCharacter`)
+### Task 7: Wrap voice design in `withGpuLoad` + map `GpuBusyError` → 409
 
 **Files:**
-- Modify: `server/src/routes/qwen-voice.ts` (inside `withDesignLock`, before the `/qwen/design-voice` fetch, ~line 271)
-- Test: `server/src/routes/qwen-voice.test.ts`
+- Modify: `server/src/routes/qwen-voice.ts` (`designQwenVoiceForCharacter`, wrap the design fetch inside `withDesignLock`, ~line 270)
+- Modify: the route that calls `designQwenVoiceForCharacter` (search `design-voice` route handler in `qwen-voice.ts`) — map `GpuBusyError` → HTTP 409
+- Test: `server/src/routes/qwen-voice.test.ts` (route-level — the suite is `request(app).post(...)`)
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Write the failing test (through the route, matching the suite's style)**
 
 ```ts
-it('evicts a resident Ollama model before the design fetch', async () => {
-  const order: string[] = [];
-  const evictMock = vi.fn(async () => { order.push('evict'); });
-  vi.doMock('../gpu/evict-for-load.js', () => ({ evictOllamaForGpuLoad: evictMock }));
-  vi.stubGlobal('fetch', vi.fn(async () => { order.push('design'); return okJson({ voiceId: 'v', url: 'u' }); }));
-  const { designQwenVoiceForCharacter } = await import('./qwen-voice.js');
-  await designQwenVoiceForCharacter(/* minimal valid params per the existing suite's helper */);
-  expect(evictMock).toHaveBeenCalledTimes(1);
-  expect(order[0]).toBe('evict');
+it('returns 409 when analysis is busy on a constrained card (GPU busy)', async () => {
+  vi.doMock('../gpu/gpu-load.js', () => ({
+    withGpuLoad: async () => { const { GpuBusyError } = await import('../gpu/gpu-load.js'); throw new GpuBusyError('GPU busy with analysis — try again once it finishes.'); },
+    GpuBusyError: class GpuBusyError extends Error { code = 'GPU_BUSY'; },
+  }));
+  const app = await freshApp(); // the suite's app factory
+  const res = await request(app).post('/api/books/demo/cast/maerin/design-voice').send({ persona: 'warm' });
+  expect(res.status).toBe(409);
+  expect(res.body.error).toMatch(/GPU busy/i);
 });
 ```
 
-(Reuse the file's existing param/fixture helper for `DesignQwenVoiceParams`; mock `withDesignLock` to invoke its callback if the suite already does.)
+(If `withGpuLoad` is hard to mock through the route, instead assert the route's error mapping directly: make `designQwenVoiceForCharacter` reject with `GpuBusyError` via the mock and assert the handler's `catch` returns 409. Use whichever the suite's existing structure supports — do NOT leave this as a placeholder; the suite already builds `app` and posts design requests.)
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cd server && npx vitest run src/routes/qwen-voice.test.ts -t "evicts a resident"`
-Expected: FAIL — no eviction before the design fetch.
+Run: `cd server && npx vitest run src/routes/qwen-voice.test.ts -t "GPU busy"`
+Expected: FAIL — no gate / no 409 mapping yet.
 
-- [ ] **Step 3: Implement the hook**
+- [ ] **Step 3: Wrap the design fetch**
 
-Inside the `withDesignLock(p.bookDir, async () => { ... })` callback, as the FIRST statement (before `gpuSemaphore.acquire`):
+Inside `withDesignLock(p.bookDir, async () => { … })`, wrap from the `gpuSemaphore.acquire` through the design fetch in `withGpuLoad`:
 
 ```ts
-const { evictOllamaForGpuLoad } = await import('../gpu/evict-for-load.js');
-await evictOllamaForGpuLoad(); // free VRAM before the sidecar lazily loads VoiceDesign (~5 GB)
+const { withGpuLoad } = await import('../gpu/gpu-load.js');
+return withGpuLoad(async () => {
+  const releaseGpu = await gpuSemaphore.acquire(costForEngine('qwen'));
+  // … existing body through the /qwen/design-voice fetch and PCM encode …
+});
 ```
 
-- [ ] **Step 4: Run tests to verify pass**
+- [ ] **Step 4: Map the error at the route**
+
+In the `design-voice` route handler's `catch`, add before the generic 500:
+
+```ts
+const { GpuBusyError } = await import('../gpu/gpu-load.js');
+if (err instanceof GpuBusyError) {
+  return res.status(409).json({ error: err.message, code: 'gpu_busy' });
+}
+```
+
+- [ ] **Step 5: Run tests to verify pass**
 
 Run: `cd server && npx vitest run src/routes/qwen-voice.test.ts`
-Expected: PASS (eviction-precedes-design + existing design tests).
+Expected: PASS (new 409 test + existing design tests).
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add server/src/routes/qwen-voice.ts server/src/routes/qwen-voice.test.ts
-git commit -m "feat(server): evict resident Ollama before voice-design loads VoiceDesign"
+git commit -m "feat(server): gate voice design through withGpuLoad (409 when GPU busy)"
 ```
 
 ---
@@ -560,22 +625,18 @@ git commit -m "feat(server): evict resident Ollama before voice-design loads Voi
 ### Task 8: CPU-gate the 9B residency (keep_alive × accelerator)
 
 **Files:**
-- Modify: `server/src/analyzer/ollama.ts` (`keepAliveFor`, ~line 129; its caller at ~line 416)
-- Test: `server/src/analyzer/ollama.test.ts` (the keep_alive describe, ~line 186)
+- Modify: `server/src/analyzer/ollama.ts` (`keepAliveFor` ~line 129; its caller ~line 416 — import `Accelerator`/`getLastKnownVram` from `../gpu/vram-state.js`, NOT from routes, to keep the import graph light)
+- Test: `server/src/analyzer/ollama.test.ts` (keep_alive describe, ~line 186)
 
 - [ ] **Step 1: Write the failing test**
 
-Add to the keep_alive describe:
-
 ```ts
-it('keeps the heavy 9B resident only on a GPU; CPU-only unloads it to spare RAM', async () => {
+it('pins the heavy 9B resident only on a GPU; CPU unloads it to spare RAM', async () => {
   const { keepAliveFor } = await import('./ollama.js');
   expect(keepAliveFor('qwen3.5:9b', 'cuda')).toBe('5m');
   expect(keepAliveFor('qwen3.5:9b', 'cpu')).toBe(0);
-  // small models stay resident regardless — they don't threaten RAM
-  expect(keepAliveFor('qwen3.5:4b', 'cpu')).toBe('5m');
-  // unknown accelerator: treat as GPU (the common case) — keep 9B resident
-  expect(keepAliveFor('qwen3.5:9b', 'unknown')).toBe('5m');
+  expect(keepAliveFor('qwen3.5:4b', 'cpu')).toBe('5m'); // small model: stays
+  expect(keepAliveFor('qwen3.5:9b', 'unknown')).toBe('5m'); // unprobed: assume GPU (the perf win)
 });
 ```
 
@@ -584,12 +645,13 @@ it('keeps the heavy 9B resident only on a GPU; CPU-only unloads it to spare RAM'
 Run: `cd server && npx vitest run src/analyzer/ollama.test.ts -t "only on a GPU"`
 Expected: FAIL — `keepAliveFor` takes one arg.
 
-- [ ] **Step 3: Implement the gate**
-
-Update `keepAliveFor` and its caller. Add a set of "big" models that are only worth pinning where VRAM (not RAM) is the constraint:
+- [ ] **Step 3: Implement**
 
 ```ts
-const RAM_HEAVY_MODELS = new Set(['qwen3.5:9b']); // pin only on a GPU
+import type { Accelerator } from '../gpu/vram-state.js';
+import { getLastKnownVram } from '../gpu/vram-state.js';
+
+const RAM_HEAVY_MODELS = new Set(['qwen3.5:9b']); // pin only where VRAM (not RAM) is the constraint
 
 export function keepAliveFor(model: string, accelerator: Accelerator = 'unknown'): string | number {
   if (!RESIDENT_MODELS.has(model)) return 0;
@@ -598,82 +660,77 @@ export function keepAliveFor(model: string, accelerator: Accelerator = 'unknown'
 }
 ```
 
-Import `Accelerator` + `getLastKnownVram` and thread the accelerator at the call site (~line 416):
-
+Caller (~line 416):
 ```ts
-import type { Accelerator } from '../routes/sidecar-health.js';
-import { getLastKnownVram } from '../routes/sidecar-health.js';
-// ...
 keep_alive: keepAliveFor(this.model, getLastKnownVram().accelerator),
 ```
 
 - [ ] **Step 4: Run tests to verify pass**
 
 Run: `cd server && npx vitest run src/analyzer/ollama.test.ts`
-Expected: PASS (new gate test + the 3 updated 9B='5m' tests already on this branch).
+Expected: PASS (new gate test + the 3 updated 9B='5m' tests already on this branch — they call `keepAliveFor('qwen3.5:9b')` with the default 'unknown' → '5m', still green).
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add server/src/analyzer/ollama.ts server/src/analyzer/ollama.test.ts
-git commit -m "feat(server): pin the 9B analyzer resident only on a GPU (spare CPU RAM)"
+git commit -m "feat(server): pin the 9B analyzer resident only on a GPU"
 ```
 
 ---
 
-### Task 9: Regression — no sidecar `/load` while an over-budget Ollama model is resident
+### Task 9: Regression — eviction/refusal invariants under real wiring
 
 **Files:**
-- Test: `server/src/gpu/eviction-regression.test.ts` (new, integration-style with mocks)
+- Test: `server/src/gpu/eviction-regression.test.ts`
 
-- [ ] **Step 1: Write the failing-then-passing guard test**
+- [ ] **Step 1: Write the guard tests**
 
 ```ts
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-/* The load-bearing safety invariant for the keep_alive flip: on an 8 GB card,
-   a sidecar /load must be PRECEDED by an Ollama eviction. Drive the real
-   ensureSidecarEngineReady with mocked VRAM (8 GB), a resident model, and a
-   recording fetch; assert the eviction generate-call lands before the /load. */
-
 const events: string[] = [];
-vi.mock('../routes/sidecar-health.js', () => ({
-  getLastKnownVram: () => ({ accelerator: 'cuda', totalMb: 8188 }),
-}));
-vi.mock('../tts/design-lock.js', () => ({ isAnyAnalysisBusy: () => false }));
-vi.mock('../workspace/user-settings.js', () => ({
-  getResolvedOllamaModel: () => 'qwen3.5:9b',
-  getResolvedSidecarUrl: () => 'http://sidecar',
-}));
+const busy = { value: false };
+
+vi.mock('./vram-state.js', () => ({ getLastKnownVram: () => ({ accelerator: 'cuda', totalMb: 8188 }) }));
+vi.mock('../tts/design-lock.js', () => ({ isAnyAnalysisBusy: () => busy.value }));
+vi.mock('./residency.js', () => ({ shouldEvictBeforeSidecarLoad: (v: { totalMb: number | null }) => v.totalMb != null && v.totalMb < 11000 }));
 vi.mock('../routes/ollama-health.js', () => ({
-  unloadResidentOllama: vi.fn(async () => { events.push('ollama-evict'); return ['qwen3.5:9b']; }),
+  unloadResidentOllama: vi.fn(async () => { events.push('evict'); return ['qwen3.5:9b']; }),
+  verifyOllamaEvicted: vi.fn(async () => { events.push('verify'); return true; }),
 }));
 
-beforeEach(() => { events.length = 0; });
+beforeEach(() => { events.length = 0; busy.value = false; });
 
-it('on 8 GB, eviction precedes the sidecar /load', async () => {
-  vi.stubGlobal('fetch', vi.fn(async () => { events.push('sidecar-load'); return new Response(JSON.stringify({ status: 'ready' }), { status: 200 }); }));
-  const { ensureSidecarEngineReady } = await import('../tts/ensure-sidecar-loaded.js');
-  await ensureSidecarEngineReady('qwen', undefined, { timeoutMs: 1000, pollIntervalMs: 10 });
-  expect(events).toEqual(['ollama-evict', 'sidecar-load']);
+it('on 8 GB idle: evict → verify → load, in order', async () => {
+  const { withGpuLoad } = await import('./gpu-load.js');
+  await withGpuLoad(async () => { events.push('load'); });
+  expect(events).toEqual(['evict', 'verify', 'load']);
+});
+
+it('on 8 GB with analysis busy: REFUSES (GpuBusyError), never evicts or loads', async () => {
+  busy.value = true;
+  const { withGpuLoad, GpuBusyError } = await import('./gpu-load.js');
+  await expect(withGpuLoad(async () => { events.push('load'); })).rejects.toBeInstanceOf(GpuBusyError);
+  expect(events).toEqual([]); // no evict, no load
 });
 ```
 
 - [ ] **Step 2: Run it**
 
 Run: `cd server && npx vitest run src/gpu/eviction-regression.test.ts`
-Expected: PASS (Tasks 5-6 already wired the ordering; this pins it against regressions).
+Expected: PASS (Tasks 4-5 wired the ordering + refusal).
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add server/src/gpu/eviction-regression.test.ts
-git commit -m "test(server): regression — eviction precedes sidecar load on 8 GB"
+git commit -m "test(server): eviction precedes load; refuses on analysis-busy (8 GB)"
 ```
 
 ---
 
-### Task 10: Document the .env knob + full verify
+### Task 10: Document the knob + full verify
 
 **Files:**
 - Modify: `server/.env.example`
@@ -681,7 +738,6 @@ git commit -m "test(server): regression — eviction precedes sidecar load on 8 
 - [ ] **Step 1: Document the knob**
 
 Add under the GPU section of `server/.env.example`:
-
 ```
 # Below this detected GPU VRAM (MB), evict the resident Ollama analyzer before
 # loading a sidecar TTS/voice-design model. 8 GB cards evict; 12/16 GB coexist.
@@ -692,9 +748,9 @@ GPU_SAFE_COEXIST_MB=11000
 - [ ] **Step 2: Run the full server battery**
 
 Run: `cd server && npm run test:server && npm run test:server-slow`
-Expected: PASS (all green; the keep_alive-flip tests, the new gpu/ tests, the eviction hooks).
+Expected: PASS (keep_alive-flip tests, the new gpu/ tests, the two hooks, the regression).
 
-- [ ] **Step 3: Typecheck + verify**
+- [ ] **Step 3: Typecheck + verify (GPU idle)**
 
 Run: `npm run typecheck` then `npm run verify`
 Expected: PASS. (Run `verify` only when the GPU is idle — it contends with any live analysis/generation.)
@@ -703,13 +759,25 @@ Expected: PASS. (Run `verify` only when the GPU is idle — it contends with any
 
 ```bash
 git add server/.env.example
-git commit -m "docs(server): document GPU_SAFE_COEXIST_MB eviction threshold"
+git commit -m "docs(server): document GPU_SAFE_COEXIST_MB threshold"
 ```
 
 ---
 
-## Self-review notes
+## Review fixes baked in (v1 → v2, from the adversarial review)
 
-- **Spec coverage:** §4.1 threshold (Task 3), §4.2 VRAM cache (Task 2), §4.3 shared helper + scoped eviction (Tasks 4-5), §4.4 both hooks (Tasks 6-7), §4.5 load-mutex (Task 5), §4.6 in-flight interlock (Task 5), §4.7 CPU residency gate (Task 8), §8 W1 tests incl. the no-load-while-resident regression (Task 9). Registry knob (Task 1) + .env (Task 10).
+- **Registry shape** (B1): `key`/`env`/`risk`/`min`, not `id` — Task 1.
+- **Test helpers** (B2/B3): `new Response(...)` and inline `{ ok, json }` — no nonexistent `okResponse`/`okJson` — Tasks 4, 6, 9.
+- **Mock completeness** (B4): regression uses module-level mocks of the gpu deps, not a partial user-settings mock — Task 9.
+- **Voice-design test** (B5): route-level (`request(app)`), asserting the 409 — Task 7, not an unfillable direct-call placeholder.
+- **Interlock hole** (safety B1): analysis-busy on a constrained card now **REFUSES** (`GpuBusyError` → 409), never skip-and-load — Tasks 5, 6, 7.
+- **Scoped-evict miss** (safety B2): evict **ALL** residents (button-path parity), not `getResolvedOllamaModel()` — Task 4/5.
+- **Mutex scope** (safety B3): `withGpuLoad` holds the lock across **evict + verify + load** — Task 5.
+- **Fail-open** (safety S1): `verifyOllamaEvicted` + fail-closed (`GpuBusyError`) on a constrained card — Tasks 4, 5.
+- **Heavy import** (code S1): `VramState`/`Accelerator` + cache live in `gpu/vram-state.ts`; analyzer imports from there — Task 2, 8.
+- **`'unknown'` accelerator**: eviction treats it as evict (conservative, Task 3); residency treats it as GPU/pin (the perf win, Task 8) — opposite-but-correct per decision; CPU-RAM in the brief unprobed window is the documented out-of-scope caveat (spec §4.8).
+- **Independent flip revert** (N1): keep_alive flip stays the last commit on the branch.
+
+## Self-review notes
+- **Spec coverage:** §4.1 threshold (T3), §4.2 cache (T2), §4.3 evict-all helper + verify (T4), §4.4 both hooks (T6/T7), §4.5 mutex-wraps-load (T5), §4.6 refuse-on-busy (T5/T6/T7), §4.7 verify/fail-closed (T4/T5), §4.8 CPU residency gate (T8), §8 tests incl. the regression (T9). Knob (T1) + .env (T10).
 - **Out of scope (later waves):** label honesty (W2), progress explainer (W3), MB-accounting policy + split-guard UI (W4 deferred).
-- **Merge:** this branch carries the keep_alive flip; do not merge a build with the flip but without Tasks 5-7.

--- a/docs/superpowers/plans/2026-06-16-wave1-gpu-eviction-residency.md
+++ b/docs/superpowers/plans/2026-06-16-wave1-gpu-eviction-residency.md
@@ -243,12 +243,18 @@ it('unloadResidentOllama() with no targets evicts EVERY resident with keep_alive
   expect(evicted.sort()).toEqual(['llama3.1:8b', 'qwen3.5:9b']);
 });
 
-it('verifyOllamaEvicted() resolves true once /api/ps no longer lists the target', async () => {
-  let calls = 0;
-  fetchMock.mockImplementation(async () => {
-    calls += 1;
-    const models = calls === 1 ? [{ name: 'qwen3.5:9b' }] : []; // gone on the 2nd probe
-    return new Response(JSON.stringify({ models }), { status: 200 });
+it('verifyOllamaEvicted() resolves true once /api/ps no longer lists a resident', async () => {
+  /* probeOllamaHealth fires /api/tags AND /api/ps in parallel (ollama-health.ts:123),
+     so discriminate by URL — only the /api/ps branch drives the "still resident?"
+     decision (`.resident`). Counting raw fetch calls would be non-deterministic. */
+  let psProbes = 0;
+  fetchMock.mockImplementation(async (url: string) => {
+    if (String(url).endsWith('/api/ps')) {
+      psProbes += 1;
+      const models = psProbes === 1 ? [{ name: 'qwen3.5:9b' }] : []; // gone on the 2nd ps probe
+      return new Response(JSON.stringify({ models }), { status: 200 });
+    }
+    return new Response(JSON.stringify({ models: [] }), { status: 200 }); // /api/tags
   });
   const { verifyOllamaEvicted } = await import('./ollama-health.js');
   await expect(verifyOllamaEvicted({ retries: 3, delayMs: 1 })).resolves.toBe(true);
@@ -472,8 +478,24 @@ git commit -m "feat(server): withGpuLoad — atomic evict+verify+load with refus
 - [ ] **Step 1: Write the failing test**
 
 ```ts
-it('wraps the load in withGpuLoad (eviction precedes the first /load on a constrained card)', async () => {
+/* CRITICAL mocking note: ensureSidecarEngineReady pulls in the gate via a
+   RUNTIME `await import('../gpu/gpu-load.js')` (Step 3). The module graph is
+   already warm from this file's top-level `import … from './ensure-sidecar-loaded.js'`,
+   and `vi.doMock` is NOT hoisted — so without `vi.resetModules()` the dynamic
+   import returns the cached REAL module and the mock never applies. Each new
+   test must: register the doMock(s), reset modules, THEN dynamically import the
+   unit — re-declaring any static dep the reset drops (here getResolvedSidecarUrl,
+   imported at ensure-sidecar-loaded.ts:26). Clean up in afterEach so the file's
+   existing readiness tests see the real module. */
+afterEach(() => { vi.doUnmock('../gpu/gpu-load.js'); vi.doUnmock('../workspace/user-settings.js'); vi.resetModules(); });
+
+it('wraps the load in withGpuLoad (the gate runs before /load on a constrained card)', async () => {
   const order: string[] = [];
+  vi.resetModules();
+  vi.doMock('../workspace/user-settings.js', () => ({
+    getResolvedSidecarUrl: () => 'http://localhost:9000',
+    readConfigOverrides: () => ({}),
+  }));
   vi.doMock('../gpu/gpu-load.js', () => ({
     withGpuLoad: async (fn: () => Promise<unknown>) => { order.push('gpu-load-gate'); return fn(); },
     GpuBusyError: class extends Error {},
@@ -487,6 +509,7 @@ it('wraps the load in withGpuLoad (eviction precedes the first /load on a constr
 
 it('does NOT engage the gate for a cloud / non-sidecar engine', async () => {
   const gate = vi.fn(async (fn: () => Promise<unknown>) => fn());
+  vi.resetModules();
   vi.doMock('../gpu/gpu-load.js', () => ({ withGpuLoad: gate, GpuBusyError: class extends Error {} }));
   const { ensureSidecarEngineReady } = await import('./ensure-sidecar-loaded.js');
   await ensureSidecarEngineReady('gemini' as never);
@@ -501,22 +524,24 @@ Expected: FAIL — no gate today.
 
 - [ ] **Step 3: Wrap the loop**
 
-In `ensureSidecarEngineReady`, after `if (!SIDECAR_ENGINES.has(engine)) return;` and `if (signal?.aborted) throw …;`, wrap the existing readiness loop. Move the `for (;;) { … }` into a `withGpuLoad` callback:
+**Replace lines 109-128 IN THEIR ENTIRETY** — from `const target = …` through the closing `}` of the `for (;;)` loop. Do NOT leave the original loop in place (a paste-on-top yields duplicate `const target`/`const deadline` → TS redeclaration error → red commit). The replacement keeps the existing `const timeoutMs` (do not inline it away) and wraps the loop in a `withGpuLoad` callback:
 
 ```ts
 const { withGpuLoad } = await import('../gpu/gpu-load.js');
+const target = `${getResolvedSidecarUrl()}/load`;
+const timeoutMs = opts.timeoutMs ?? READINESS_TIMEOUT_MS;
+const pollIntervalMs = opts.pollIntervalMs ?? POLL_INTERVAL_MS;
+const deadline = Date.now() + timeoutMs;
+let lastReason = 'unknown';
+
 await withGpuLoad(async () => {
-  const target = `${getResolvedSidecarUrl()}/load`;
-  const deadline = Date.now() + (opts.timeoutMs ?? READINESS_TIMEOUT_MS);
-  const pollIntervalMs = opts.pollIntervalMs ?? POLL_INTERVAL_MS;
-  let lastReason = 'unknown';
   for (;;) {
     if (signal?.aborted) throw new DOMException('preload aborted', 'AbortError');
     const outcome = await tryLoadOnce(target, engine, signal);
-    if (outcome.ready) return;
+    if (outcome.ready) return; // resolves the withGpuLoad callback; ensureSidecarEngineReady then returns void
     lastReason = outcome.reason;
     if (Date.now() >= deadline) {
-      console.warn(`[generation] preload ${engine}: not ready after budget (last: ${lastReason}) — falling back to lazy load.`);
+      console.warn(`[generation] preload ${engine}: not ready after ${timeoutMs}ms (last: ${lastReason}) — falling back to lazy load.`);
       return;
     }
     await sleep(pollIntervalMs, signal);
@@ -524,23 +549,31 @@ await withGpuLoad(async () => {
 });
 ```
 
-(The whole load is now inside the lock on a constrained card; `withGpuLoad` may throw `GpuBusyError` — let it propagate.)
+(The whole load is now inside the lock on a constrained card; `withGpuLoad` may throw `GpuBusyError` — let it propagate to the caller, handled in Step 4.)
 
 - [ ] **Step 4: Handle GpuBusyError at the generation worker**
 
-At the `await ensureSidecarEngineReady(engine, chapterSignal);` call sites in `generation.ts` (lines ~1103/1121/1329), wrap so a `GpuBusyError` fails the chapter with a clear, non-retryable message rather than tripping the consecutive-failure breaker:
+`generation.ts` has THREE `ensureSidecarEngineReady` call sites. Wrap **only the two primary preload sites — line ~1103 (`engine`) and line ~1121 (`'kokoro'` fallback)**. **Leave line ~1329 UNWRAPPED**: it sits inside the `onRecoverRecycle` callback with its own `try/finally { clearInterval(beat) }`, and recycle-recovery already polls through respawn — a `GpuBusyError` there should propagate unchanged, not be reworded.
+
+Add a tiny local helper near the top of the worker and call it at the two chosen sites (so the catch logic isn't duplicated):
 
 ```ts
-try {
-  await ensureSidecarEngineReady(engine, chapterSignal);
-} catch (e) {
-  const { GpuBusyError } = await import('../gpu/gpu-load.js');
-  if (e instanceof GpuBusyError) {
-    throw new Error(`Generation paused: ${e.message}`); // surfaced to the user; analysis must finish first
+// near the other generation worker helpers
+async function ensureReadyOrPause(eng: TtsEngine, sig: AbortSignal | undefined): Promise<void> {
+  try {
+    await ensureSidecarEngineReady(eng, sig);
+  } catch (e) {
+    const { GpuBusyError } = await import('../gpu/gpu-load.js');
+    if (e instanceof GpuBusyError) {
+      // Surface as a clear, user-facing pause — NOT a breaker-tripping crash.
+      throw new Error(`Generation paused: ${e.message}`);
+    }
+    throw e;
   }
-  throw e;
 }
 ```
+
+Then at line ~1103 replace `await ensureSidecarEngineReady(engine, chapterSignal);` with `await ensureReadyOrPause(engine, chapterSignal);`, and likewise at ~1121 for `'kokoro'`. (`TtsEngine` is already imported in this file via `ensure-sidecar-loaded.js` exports — reuse it.)
 
 - [ ] **Step 5: Run tests to verify pass**
 
@@ -565,20 +598,37 @@ git commit -m "feat(server): gate the generation preload through withGpuLoad"
 
 - [ ] **Step 1: Write the failing test (through the route, matching the suite's style)**
 
+The suite is route-level (`request(app).post(...)`) and builds `app` once in `beforeAll`; there is NO `freshApp()` factory (don't invent one). A runtime dynamic import of the gate can't be intercepted by in-body `vi.doMock`, so use a **file-level hoisted mock** that defaults to passthrough (keeps every existing design test green) and is overridden for one call in the 409 test.
+
+Add ONCE at the top of `qwen-voice.test.ts` (with the other top-level mocks):
 ```ts
-it('returns 409 when analysis is busy on a constrained card (GPU busy)', async () => {
-  vi.doMock('../gpu/gpu-load.js', () => ({
-    withGpuLoad: async () => { const { GpuBusyError } = await import('../gpu/gpu-load.js'); throw new GpuBusyError('GPU busy with analysis — try again once it finishes.'); },
-    GpuBusyError: class GpuBusyError extends Error { code = 'GPU_BUSY'; },
-  }));
-  const app = await freshApp(); // the suite's app factory
-  const res = await request(app).post('/api/books/demo/cast/maerin/design-voice').send({ persona: 'warm' });
+const { withGpuLoadMock } = vi.hoisted(() => ({
+  withGpuLoadMock: vi.fn(async (fn: () => Promise<unknown>) => fn()), // default: passthrough
+}));
+vi.mock('../gpu/gpu-load.js', () => ({
+  withGpuLoad: (fn: () => Promise<unknown>) => withGpuLoadMock(fn),
+  GpuBusyError: class GpuBusyError extends Error {
+    code = 'GPU_BUSY';
+    constructor(m: string) { super(m); this.name = 'GpuBusyError'; }
+  },
+}));
+```
+
+The new test (uses the suite's EXISTING `bookId` + `designBody` fixtures — `qwen-voice.test.ts:144,158` — and the same character route the suite's happy-path design test posts to; do NOT use `/books/demo/...` or a bare `{persona}` body, which 404/400 before reaching the gate):
+```ts
+it('returns 409 when the GPU is busy with analysis (constrained card)', async () => {
+  const { GpuBusyError } = await import('../gpu/gpu-load.js');
+  withGpuLoadMock.mockImplementationOnce(() => {
+    throw new GpuBusyError('GPU busy with analysis — try again once it finishes.');
+  });
+  const res = await request(app)
+    .post(`/api/books/${bookId}/cast/maerin/design-voice`) // same path the suite's design test uses
+    .send(designBody);
   expect(res.status).toBe(409);
   expect(res.body.error).toMatch(/GPU busy/i);
 });
 ```
-
-(If `withGpuLoad` is hard to mock through the route, instead assert the route's error mapping directly: make `designQwenVoiceForCharacter` reject with `GpuBusyError` via the mock and assert the handler's `catch` returns 409. Use whichever the suite's existing structure supports — do NOT leave this as a placeholder; the suite already builds `app` and posts design requests.)
+(Match the exact character segment + `designBody` shape the suite's existing successful `design-voice` test uses; the point is a request that reaches `designQwenVoiceForCharacter`, where the gate throws.)
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -587,24 +637,28 @@ Expected: FAIL — no gate / no 409 mapping yet.
 
 - [ ] **Step 3: Wrap the design fetch**
 
-Inside `withDesignLock(p.bookDir, async () => { … })`, wrap from the `gpuSemaphore.acquire` through the design fetch in `withGpuLoad`:
+Do NOT relocate any inner code — the `withDesignLock` callback (`qwen-voice.ts:270-379`) contains a `gpuSemaphore.acquire`/`releaseGpu`, a `setInterval` liveness timer, an `AbortController`, and a `try { … } finally { clearInterval; removeEventListener; releaseGpu(); }`. Splitting it mid-`try` would orphan the `finally`. Instead **wrap the entire existing callback body verbatim**:
 
-```ts
-const { withGpuLoad } = await import('../gpu/gpu-load.js');
-return withGpuLoad(async () => {
-  const releaseGpu = await gpuSemaphore.acquire(costForEngine('qwen'));
-  // … existing body through the /qwen/design-voice fetch and PCM encode …
-});
-```
+1. Immediately AFTER the opening `return withDesignLock(p.bookDir, async () => {` (line 270), insert two lines:
+   ```ts
+   const { withGpuLoad } = await import('../gpu/gpu-load.js');
+   return withGpuLoad(async () => {
+   ```
+2. Immediately BEFORE the `});` that CLOSES the `withDesignLock` callback (line ~379), insert one closing line so the new `withGpuLoad(async () => {` is balanced:
+   ```ts
+   });
+   ```
+
+Net effect: the whole existing body (acquire → timer → try/finally → return) now runs inside `withGpuLoad`, untouched. On a constrained card with analysis busy, `withGpuLoad` throws `GpuBusyError` *before* `gpuSemaphore.acquire`, so no semaphore token is taken and there's nothing to clean up; on a roomy card it's a passthrough and behaviour is identical to today.
 
 - [ ] **Step 4: Map the error at the route**
 
-In the `design-voice` route handler's `catch`, add before the generic 500:
+In the `design-voice` route handler's `catch (e)` block (`qwen-voice.ts:497-501` — the one that currently does `return res.status(502)…`; NOT the `promote-voice` handler at ~514), add the 409 mapping BEFORE the existing 502 return. Note the catch binds `e`, not `err`:
 
 ```ts
 const { GpuBusyError } = await import('../gpu/gpu-load.js');
-if (err instanceof GpuBusyError) {
-  return res.status(409).json({ error: err.message, code: 'gpu_busy' });
+if (e instanceof GpuBusyError) {
+  return res.status(409).json({ error: e.message, code: 'gpu_busy' });
 }
 ```
 

--- a/docs/superpowers/specs/2026-06-16-vram-budget-aware-gpu-policy-design.md
+++ b/docs/superpowers/specs/2026-06-16-vram-budget-aware-gpu-policy-design.md
@@ -1,0 +1,213 @@
+# GPU residency safety + analysing-view honesty — design
+
+> Status: draft (spec) — 2026-06-16. Rewritten after a two-lens adversarial
+> review that verified claims against source (see §11 for what the review
+> overturned).
+> Scope: server (analyzer residency, GPU eviction before sidecar loads) +
+> frontend (analysing chip label, per-chapter progress). Delivered as **waves**,
+> not one PR.
+
+## 1. Problem
+
+On the live 8 GB box the analyzer in use is `qwen3.5:9b`. Three problems:
+
+1. **Reload tax.** The 9B fell to `keep_alive: 0`, so Ollama unloaded+reloaded
+   ~6.35 GB on **every chapter section** — a VRAM sawtooth, mid-stream "no
+   response" stalls, degraded wall-clock. Worst on **Cyrillic** manuscripts,
+   which need the larger model.
+2. **Eviction blind spot.** The analyzer↔TTS eviction that frees VRAM before a
+   voice engine loads is driven by the **frontend** Load button only. The
+   **server-side** generation preload and **the voice-design path** load sidecar
+   models with **no** Ollama eviction. Harmless under `keep_alive: 0` (9B
+   already gone); an **OOM risk** the moment the 9B is kept resident.
+3. **Opaque / dishonest UI.** The analysing chip shows the local default
+   ("Qwen3.5 4B") even when the server resolved 9B via `ANALYZER_PHASE0_MODEL`;
+   progress reads "GPU is busy" with no legible forward signal.
+
+## 2. Decomposition (the spec's primary correction)
+
+This is **not one cohesive change.** It ships as independent waves, each its own
+branch/PR, `npm run verify` green between. Order matters only where noted.
+
+| Wave | What | Depends on |
+|---|---|---|
+| **0** | Stray-key tolerance (done, stranded on its branch) | — |
+| **1** | **Eviction-gap fix + `keep_alive` flip**, behind a simple VRAM threshold | — |
+| **2** | Model-label honesty | — |
+| **3** | Progress explainer (section-based) | — |
+| **4 (deferred)** | Full MB-accounting policy + split-guard UI | a real 12/16 GB user |
+
+The label (2) and progress (3) are independent of the VRAM work and of each
+other. The MB-accounting engine (4) is **deferred** — on 8 GB the eviction
+decision is always "evict," so a cost table buys nothing and adds OOM risk via
+coarse estimates. Build it when 12/16 GB hardware is real.
+
+## 3. Already done this session
+
+- **Stray-key tolerance** (Wave 0) — `parseAndValidate` salvages an
+  `unrecognized_keys`-only schema failure (the qwen3.5:9b `chapterId` drop).
+  Committed on `fix/server-analyzer-tolerate-unrecognized-keys`. Independent;
+  merge first.
+- **`keep_alive` flip** — `qwen3.5:9b` added to `RESIDENT_MODELS` ('5m'). Done +
+  green on `feat/analysing-residency-label-progress`. **MUST NOT ship until
+  Wave 1's eviction lands in the same build** — otherwise analysis→generate
+  within 5 min OOMs the 8 GB box. Rebase the flip onto Wave 1.
+
+## 4. Wave 1 — eviction-gap fix (the real safety fix)
+
+### 4.1 Decision: a single threshold, not a cost engine
+```
+// server/src/gpu/residency.ts
+const SAFE_COEXIST_MB = registry('gpu.safeCoexistMb', 11000); // below → evict
+
+function shouldEvictBeforeSidecarLoad(v: VramState): boolean {
+  if (v.accelerator === 'cpu') return false;            // no VRAM contention
+  if (v.totalMb == null) return true;                   // GPU, unknown → safe: evict
+  return v.totalMb < SAFE_COEXIST_MB;                   // 8 GB → evict; 12/16 → coexist
+}
+```
+One knob expresses the whole 8/12/16 GB story (`8192 < 11000` → evict; `12288`,
+`16384` ≥ 11000 → coexist) without a per-model table, mode detection, or live
+correction. The MB engine (Wave 4) refines this *only when* a coexistence box
+exists.
+
+### 4.2 VRAM state, resilient to sidecar respawn
+- `vramTotalMb` + a CUDA-presence flag come **only** from the sidecar `/health`
+  body, and the sidecar self-exits/respawns (`ensure-sidecar-loaded.ts:8-24`),
+  so a live probe is null exactly when eviction must run.
+- **Fix:** cache the last reachable `/health` VRAM figures (mirror the existing
+  `setLastKnownQwenInstallState` pattern, `sidecar-health.ts:244`). The policy
+  reads the **cache**, never a fresh probe. `accelerator` is `'cuda'` when a CUDA
+  total was ever seen, `'cpu'` when health reported no CUDA, else `'unknown'`
+  (treated as the conservative GPU branch → evict).
+
+### 4.3 Shared eviction helper
+- Extract the `/api/ollama/unload` unload-all logic into
+  `unloadResidentOllama(targets?)` (`ollama-health.ts:289` →
+  `probeOllamaHealth().resident` → `callOllamaGenerate(keep_alive:0)`), reused by
+  the route and the new server-side callers.
+- **Scope it to this run's analyzer model(s), not blanket-all-residents**, so a
+  second concurrent session's resident analyzer isn't stomped (the box is shared;
+  `semaphore.ts:1-7`). Blanket-all stays only on the explicit user Stop path.
+
+### 4.4 The two server-side hooks (this is the actual gap)
+Both points are **server-initiated**, so the eviction lives there — it does *not*
+need to hook the sidecar's lazy internal load:
+1. **Generation preload.** In `ensureSidecarEngineReady`, **once before the poll
+   loop** (not per attempt, `ensure-sidecar-loaded.ts:115`), if
+   `shouldEvictBeforeSidecarLoad(state)` → `unloadResidentOllama()` then proceed.
+2. **Voice design.** In `designQwenVoiceForCharacter`
+   (`qwen-voice.ts:270-316`), **before** the `/qwen/design-voice` fetch, run the
+   same evict. The sidecar then lazily loads VoiceDesign (~5 GB) into freed VRAM.
+   (The sidecar's own exclusion only evicts Kokoro, `main.py:1519`; Ollama is a
+   separate process only the server can evict.)
+
+### 4.5 Atomicity (load-mutex, not the GpuSemaphore)
+The `GpuSemaphore` is a token FIFO around **execution**, not loads, and cannot
+evict (`semaphore.ts:55-103`). Evict-then-load must be atomic under a **new
+dedicated async mutex** (`gpuLoadMutex`) so two concurrent design/gen starts
+can't both evict then both overcommit. The token semaphore is unchanged and
+orthogonal.
+
+### 4.6 In-flight analysis is non-evictable
+An analyzer model actively serving an analysis must not be evicted mid-run (that
+*is* the sawtooth, and would corrupt the run). In practice analysis and
+generation/design are **sequential pipeline phases**: assert "no sidecar
+TTS/design load is requested while an analysis job is active" via the existing
+`isAnyAnalysisBusy()` (`design-lock.ts:83`). That makes the evict-an-active-model
+case impossible by construction; the hooks in §4.4 only run post-analysis.
+
+### 4.7 CPU residency guard
+The flip added 9B to `RESIDENT_MODELS` unconditionally; on a CPU-only box that
+keeps ~6.4 GB warm in **RAM** for 5 min with no guard (RAM exhaustion is out of
+scope, but the flip *creates* the exposure). **Gate big-model residency on a
+GPU:** `keepAliveFor` returns '5m' for the 9B only when the cached accelerator is
+a GPU, else the prior behaviour. Unit-test `keepAliveFor` × accelerator.
+
+## 5. Wave 2 — model-label honesty
+- **Premise corrected:** the chip (`src/components/analysing/phase-model-chip.tsx`)
+  reads Redux `account.analyzerPhase0Model`, **not** a server field. So this is a
+  real (small) vertical slice, not a rewire.
+- **Server:** ensure the resolved effective per-phase model id is emitted on the
+  progress stream (today `activeModelId = selection.model` exists at
+  `analysis.ts:2075` and is sent at `:2747`; confirm it's on the first event, add
+  it if not).
+- **Frontend:** the chip mirrors the server-reported model once streaming starts;
+  falls back to the Redux selection pre-stream. When phase0≠phase1, show the
+  active phase's model (phase0 during detection, phase1 during attribution).
+- **Tests:** jsdom unit (chip reflects server `model`) **+ a mandatory e2e**
+  (crosses the streaming seam).
+
+## 6. Wave 3 — progress explainer (section-based)
+- **Data corrected:** `charsDone/charsTotal` do **not** exist in the SSE
+  protocol; `sectionsDone`/`sectionsTotal` do. Ship the honest minimum first:
+  surface the existing section counts as "Chapter 2 · section 3/4" with a thin
+  sub-bar that advances on each section completion.
+- **Optional follow-up (only if wanted):** add per-section char accumulation
+  (`charsDone` summed as sections complete; `charsTotal` known up front) for
+  "56k / 80k words." Called out as **new server bookkeeping**, not free.
+- **Tests:** server emits section progress; frontend renders + advances the
+  sub-bar; **mandatory e2e** (streaming seam).
+
+## 7. Wave 4 (deferred) — MB-accounting policy + split guard
+Build only when a 12/16 GB user exists.
+- Per-(engine, mode) MB cost table (registry `gpu.modelCostMb.*`, additive-
+  optional with defaults), **non-additive Qwen modes** (synth ~3700 vs design
+  ~5000 — design value biased **upward** since it's the OOM-critical path; tie to
+  Base-stays-resident-during-design, `main.py:1525`). Each cell carries a
+  measured-on-box provenance note. `planLoad(state, residents[], incomingMb)`
+  stays **pure** (caller injects residents' MB; no internal live probe — tests
+  stay deterministic; `vram_reserved_mb` is observability-only, aggregate and
+  cross-process-blind). `splitFits` collapses into `planLoad`.
+- **Split guard UI = pre-flight only.** Per-phase models are set in settings
+  (`ANALYZER_PHASE0_MODEL`/`PHASE1_MODEL` / account). When two different local
+  models won't co-fit, show a budget-worded warning **at the settings surface**
+  ("won't both fit in your <N> GB GPU — they'll reload between phases"). No
+  mid-run pause (the `ui.stage` union has no mid-analysis-confirm state, and
+  adding one is unjustified). The server silently evicts between phases to
+  function.
+
+## 8. Testing (per wave)
+- **W1:** `shouldEvictBeforeSidecarLoad` across cpu/null/8/12/16; VRAM-cache
+  survives a simulated respawn; `unloadResidentOllama` evicts the scoped
+  model(s); the two hooks evict before load on 8 GB and skip on 12/16 GB / CPU;
+  **regression: no sidecar `/load` fires while an over-budget Ollama model is
+  resident**; `keepAliveFor` × accelerator; the `isAnyAnalysisBusy` interlock.
+- **W2:** chip reflects server model not Redux default (unit) + e2e.
+- **W3:** section progress emit + render/advance (unit) + e2e.
+- **W4:** cost table + registry + unknown→high fallback (with tag
+  canonicalization, `ollama-health.ts:143`); `planLoad` fits/evict 8/12/16;
+  non-additive modes; split pre-flight warning render.
+
+## 9. Risks / assumptions (post-review)
+- **R1 (closed by §4.4+§4.6):** every server-initiated sidecar load now evicts;
+  in-flight analysis can't be evicted because no load is requested during it.
+- **R2 — threshold mis-set.** `SAFE_COEXIST_MB` default 11000 assumes
+  analyzer+TTS ≈ 10 GB; a 12 GB card with a heavier combo could still OOM. The
+  conservative direction (raise the threshold) just evicts more. Tune per box.
+- **R3 — cached VRAM staleness.** If the GPU/driver changes under a long-lived
+  server, the cache is stale until the next reachable `/health`. Acceptable; a
+  restart re-probes.
+- **R4 — Wave 4 estimates** remain coarse; that's precisely why it's deferred.
+
+## 10. Branch / merge plan
+- W0: merge `fix/server-analyzer-tolerate-unrecognized-keys`.
+- W1: `feat/analysing-residency-label-progress` → narrow to **eviction + flip**;
+  rename to `fix/server-gpu-eviction-before-sidecar-load`. Flip rides with it.
+- W2: `fix/frontend-analyser-model-label`.
+- W3: `feat/analysing-progress-sections`.
+- W4: deferred; own spec/plan when scheduled.
+
+## 11. What the adversarial review overturned (audit trail)
+- "Voice-design path does the same eviction" — **false** (no server load to
+  hook); rewritten as a server-side evict before the design fetch (§4.4).
+- "Run eviction inside the GpuSemaphore critical section" — **unsupported** (the
+  semaphore is an execution token FIFO); replaced with a dedicated load-mutex
+  (§4.5).
+- "`VramState.accelerator` available to the policy" — **no source**; added a
+  last-known-good cache and a defined fallback (§4.2).
+- "One delivery" — **rejected**; decomposed into waves (§2), MB engine deferred.
+- "Server already emits the model the chip can mirror" — **false** (chip reads
+  Redux); reframed as a real slice (§5).
+- "`charsDone/charsTotal` already exist" — **false**; section-based minimum (§6).
+- keep_alive flip + CPU → unguarded RAM residency — added the GPU gate (§4.7).

--- a/docs/superpowers/specs/2026-06-16-vram-budget-aware-gpu-policy-design.md
+++ b/docs/superpowers/specs/2026-06-16-vram-budget-aware-gpu-policy-design.md
@@ -93,31 +93,52 @@ exists.
 ### 4.4 The two server-side hooks (this is the actual gap)
 Both points are **server-initiated**, so the eviction lives there — it does *not*
 need to hook the sidecar's lazy internal load:
-1. **Generation preload.** In `ensureSidecarEngineReady`, **once before the poll
-   loop** (not per attempt, `ensure-sidecar-loaded.ts:115`), if
-   `shouldEvictBeforeSidecarLoad(state)` → `unloadResidentOllama()` then proceed.
-2. **Voice design.** In `designQwenVoiceForCharacter`
-   (`qwen-voice.ts:270-316`), **before** the `/qwen/design-voice` fetch, run the
-   same evict. The sidecar then lazily loads VoiceDesign (~5 GB) into freed VRAM.
-   (The sidecar's own exclusion only evicts Kokoro, `main.py:1519`; Ollama is a
-   separate process only the server can evict.)
+Both wrap their load in `withGpuLoad(loadFn)` (§4.5), which evicts **all**
+resident Ollama models (`unloadResidentOllama()` with no targets — button-path
+parity, so a phase-env-resolved or quant-tagged resident isn't missed) and runs
+the load inside the lock:
+1. **Generation preload.** `ensureSidecarEngineReady` wraps its `/load` poll loop
+   in `withGpuLoad` (`ensure-sidecar-loaded.ts:115`).
+2. **Voice design.** `designQwenVoiceForCharacter` wraps the `/qwen/design-voice`
+   fetch in `withGpuLoad` (`qwen-voice.ts:270-316`). The sidecar then lazily
+   loads VoiceDesign (~5 GB) into freed VRAM. (The sidecar's own exclusion only
+   evicts Kokoro, `main.py:1519`; Ollama is a separate process only the server
+   can evict.)
 
-### 4.5 Atomicity (load-mutex, not the GpuSemaphore)
+### 4.5 Atomicity (evict + load in ONE critical section)
 The `GpuSemaphore` is a token FIFO around **execution**, not loads, and cannot
-evict (`semaphore.ts:55-103`). Evict-then-load must be atomic under a **new
-dedicated async mutex** (`gpuLoadMutex`) so two concurrent design/gen starts
-can't both evict then both overcommit. The token semaphore is unchanged and
-orthogonal.
+evict (`semaphore.ts:55-103`). A new dedicated async mutex (`gpuLoadMutex`) must
+wrap **evict + verify + the actual load together** — not just the evict. If the
+load runs after the lock releases, two concurrent starts each evict (serialized)
+then both load (concurrent) → overcommit. So the load chokepoints pass their
+load operation *into* the locked region (`withGpuLoad(loadFn)`). The mutex is
+engaged **only on a card that needs eviction** (`shouldEvictBeforeSidecarLoad`);
+on 12/16 GB / CPU the loads fit and run unserialized. The token semaphore is
+unchanged and orthogonal.
 
-### 4.6 In-flight analysis is non-evictable
-An analyzer model actively serving an analysis must not be evicted mid-run (that
-*is* the sawtooth, and would corrupt the run). In practice analysis and
-generation/design are **sequential pipeline phases**: assert "no sidecar
-TTS/design load is requested while an analysis job is active" via the existing
-`isAnyAnalysisBusy()` (`design-lock.ts:83`). That makes the evict-an-active-model
-case impossible by construction; the hooks in §4.4 only run post-analysis.
+### 4.6 Analysis-busy → REFUSE the load (not skip-and-proceed)
+`isAnyAnalysisBusy()` is **global** (`design-lock.ts:83`), and generation has
+**no** analysis-busy gate today — so a load on Book Y can be requested while
+analysis runs on Book X (or in a second session). The analyzer is actively
+resident during that analysis and must not be evicted (it would corrupt the
+run). On a card that can't coexist, the load therefore **cannot safely proceed**.
+`withGpuLoad` **refuses** it: if `shouldEvictBeforeSidecarLoad` AND
+`isAnyAnalysisBusy()` → throw `GpuBusyError`, which the generation/design routes
+surface as a 409 ("GPU busy with analysis — try again when it finishes"),
+mirroring the existing bulk cast-design 409 (`cast-design.ts:364`). The load is
+never started during analysis; the analyzer is never evicted mid-run. (Earlier
+drafts proposed *skipping* eviction while letting the load through — that was an
+OOM hole; refusing is the fix.)
 
-### 4.7 CPU residency guard
+### 4.7 Verify-then-load, fail-closed
+Ollama's `keep_alive:0` unload is asynchronous. After evicting, re-probe
+`/api/ps` (bounded retries); proceed only once the target is gone. On a
+constrained card, if eviction can't be confirmed, **refuse the load**
+(`GpuBusyError`) rather than load on top of a still-resident model. "Best-effort,
+proceed anyway" is only acceptable where coexistence was already safe (i.e.
+where no eviction was needed).
+
+### 4.8 CPU residency guard
 The flip added 9B to `RESIDENT_MODELS` unconditionally; on a CPU-only box that
 keeps ~6.4 GB warm in **RAM** for 5 min with no guard (RAM exhaustion is out of
 scope, but the flip *creates* the exposure). **Gate big-model residency on a

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -44,6 +44,9 @@ export default tseslint.config(
       'e2e/**/__snapshots__/',
       'audiobook-workspace/',
       'src/lib/api-types.ts',
+      // Ad-hoc, local-only repro/bisect scripts (e.g. server/repro-attribution.mts).
+      // Throwaway debugging probes — git-ignored and not held to the lint bar.
+      'server/repro-*.mts',
     ],
   },
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -105,12 +105,6 @@ GPU_CONCURRENCY=99
 # is batching (QWEN_BATCH_SIZE below), not this.
 # GPU_VRAM_BUDGET=4
 
-# Below this detected GPU VRAM (MB), the server evicts the resident Ollama
-# analyzer before loading a sidecar TTS/voice-design model (analyzer + TTS can't
-# co-reside on a small card). 8 GB cards evict; 12/16 GB coexist. 0 = always
-# evict. CPU-only ignores this (no VRAM contention). Default 11000. [live]
-# GPU_SAFE_COEXIST_MB=11000
-
 # Generation queue concurrency — how many chapters the queue synthesises at once
 # (renamed from the retired GEN_CHAPTER_CONCURRENCY). GEN_WORKERS (env) is the
 # deploy knob and takes PRECEDENCE over the per-user `generationWorkers` account
@@ -544,6 +538,8 @@ GPU_WEIGHT_COQUI=3
 GPU_WEIGHT_ANALYZER=4
 # VRAM token cost for a Whisper ASR op. Only charged when ASR_DEVICE=cuda; the CPU-default path takes no token. Read live per-op via costForEngine(); changes take effect on the next transcription without a restart. [live · high risk]
 GPU_WEIGHT_ASR=1
+# If detected GPU VRAM is below this, evict the resident Ollama analyzer before loading a sidecar TTS/voice-design model. 8 GB cards evict; 12/16 GB coexist. 0 = always evict. [live · high risk]
+GPU_SAFE_COEXIST_MB=11000
 # Seconds of voice-design inactivity before the watchdog frees the transient Qwen VoiceDesign 1.7B model (reclaiming ~4–5 GB VRAM). Values below 5 fall back to the default (120) to avoid reload thrash. A real /synthesize also frees it immediately. [restart-sidecar · high risk]
 QWEN_DESIGN_IDLE_TTL=120
 # Seconds of ASR inactivity before the sidecar frees the Whisper model. Mainly reclaims VRAM on ASR_DEVICE=cuda; on cpu it frees host RAM. Values below 5 fall back to the default (120) to avoid reload thrash. [restart-sidecar · high risk]

--- a/server/.env.example
+++ b/server/.env.example
@@ -105,6 +105,12 @@ GPU_CONCURRENCY=99
 # is batching (QWEN_BATCH_SIZE below), not this.
 # GPU_VRAM_BUDGET=4
 
+# Below this detected GPU VRAM (MB), the server evicts the resident Ollama
+# analyzer before loading a sidecar TTS/voice-design model (analyzer + TTS can't
+# co-reside on a small card). 8 GB cards evict; 12/16 GB coexist. 0 = always
+# evict. CPU-only ignores this (no VRAM contention). Default 11000. [live]
+# GPU_SAFE_COEXIST_MB=11000
+
 # Generation queue concurrency — how many chapters the queue synthesises at once
 # (renamed from the retired GEN_CHAPTER_CONCURRENCY). GEN_WORKERS (env) is the
 # deploy knob and takes PRECEDENCE over the per-user `generationWorkers` account

--- a/server/src/analyzer/ollama.test.ts
+++ b/server/src/analyzer/ollama.test.ts
@@ -207,6 +207,14 @@ describe('OllamaAnalyzer — keep_alive policy (per-model VRAM residency)', () =
     expect(keepAliveFor('placeholder:test-7b')).toBe(0);
   });
 
+  it('pins the heavy 9B resident only on a GPU; CPU unloads it to spare RAM', async () => {
+    const { keepAliveFor } = await import('./ollama.js');
+    expect(keepAliveFor('qwen3.5:9b', 'cuda')).toBe('5m');
+    expect(keepAliveFor('qwen3.5:9b', 'cpu')).toBe(0);
+    expect(keepAliveFor('qwen3.5:4b', 'cpu')).toBe('5m'); // small model: stays
+    expect(keepAliveFor('qwen3.5:9b', 'unknown')).toBe('5m'); // unprobed: assume GPU (the perf win)
+  });
+
   it('threads keep_alive: "5m" into the /api/chat body when the model is qwen3.5:4b', async () => {
     fetchMock.mockResolvedValue(okResponse(ndjsonStream(chunksOf(VALID_RESPONSE, 32))));
     const { OllamaAnalyzer } = await import('./ollama.js');

--- a/server/src/analyzer/ollama.test.ts
+++ b/server/src/analyzer/ollama.test.ts
@@ -147,12 +147,14 @@ describe('OllamaAnalyzer — happy path streaming', () => {
      * the string sentinel. */
     expect(body.format).not.toBe('json');
     expect(typeof body.format).toBe('object');
-    /* 9B is too heavy to leave resident on an 8 GB box (weights + KV cache
-       at num_ctx 32768 spill over budget) — see RESIDENT_MODELS in
-       ollama.ts. The 4B and llama3.1:8b both hold the keep_alive: '5m'
-       slot; the 9B and any unknown tag get unloaded immediately with
-       keep_alive: 0. */
-    expect(body.keep_alive).toBe(0);
+    /* 9B now holds the resident keep_alive: '5m' slot alongside the 4B and
+       llama3.1:8b. The chunker caps each section so weights + KV stay within
+       the 8 GB budget; the old keep_alive: 0 unloaded+reloaded ~6.35 GB
+       between every section, which dominated wall-clock — badly so on
+       Cyrillic manuscripts that need the larger model. The generation
+       engine's auto-evict frees it before Qwen TTS / XTTS load. See
+       RESIDENT_MODELS in ollama.ts; unknown tags still get 0. */
+    expect(body.keep_alive).toBe('5m');
     expect(body.options.num_ctx).toBe(32768);
     /* Pin all layers to GPU — see ANALYZER_NUM_GPU in ollama.ts. 999 is
        the standard "all layers" idiom; without this, Ollama auto-splits
@@ -193,10 +195,12 @@ describe('OllamaAnalyzer — keep_alive policy (per-model VRAM residency)', () =
        Stage 1 → Stage 2 → next-chapter loop. */
     expect(keepAliveFor('qwen3.5:4b')).toBe('5m');
     expect(keepAliveFor('llama3.1:8b')).toBe('5m');
-    /* 9B (~6.6 GB) is over budget once the KV cache lands — unload
-       immediately so XTTS isn't squeezed when the user flips to the
-       generation phase. */
-    expect(keepAliveFor('qwen3.5:9b')).toBe(0);
+    /* 9B (~6.6 GB) is now resident too: it fits within budget with the
+       chunker-capped KV cache, and dropping ~6.35 GB between every section
+       was crippling analysis (especially Cyrillic, which needs the larger
+       model). The generation-phase auto-evict frees it before Qwen TTS /
+       XTTS load. */
+    expect(keepAliveFor('qwen3.5:9b')).toBe('5m');
     /* An unknown model id defaults to 0 — the conservative choice is
        "unload immediately" so we never accidentally pin a model the
        allowlist hasn't been tuned for. */
@@ -221,13 +225,13 @@ describe('OllamaAnalyzer — keep_alive policy (per-model VRAM residency)', () =
     expect(body.keep_alive).toBe('5m');
   });
 
-  it('threads keep_alive: 0 into the /api/chat body for qwen3.5:9b (over budget — unload immediately)', async () => {
+  it('threads keep_alive: "5m" into the /api/chat body for qwen3.5:9b (resident — reload tax removed)', async () => {
     fetchMock.mockResolvedValue(okResponse(ndjsonStream(chunksOf(VALID_RESPONSE, 32))));
     const { OllamaAnalyzer } = await import('./ollama.js');
     const analyzer = new OllamaAnalyzer({ url: 'http://localhost:11434', model: 'qwen3.5:9b' });
     await analyzer.runStage1Chapter('m_ollama_keepalive_9b', 1, '# prompt', {});
     const body = JSON.parse((fetchMock.mock.calls[0][1] as { body: string }).body);
-    expect(body.keep_alive).toBe(0);
+    expect(body.keep_alive).toBe('5m');
   });
 });
 

--- a/server/src/analyzer/ollama.ts
+++ b/server/src/analyzer/ollama.ts
@@ -15,6 +15,8 @@ import { z } from 'zod';
 import { gpuSemaphore } from '../gpu/semaphore.js';
 import { costForEngine } from '../tts/engine-vram-cost.js';
 import { configValue } from '../config/resolver.js';
+import type { Accelerator } from '../gpu/vram-state.js';
+import { getLastKnownVram } from '../gpu/vram-state.js';
 import { writeInbox, errorPath, rawAttemptPath, type HandoffKey } from '../handoff/protocol.js';
 import {
   stage1Schema,
@@ -130,14 +132,27 @@ export function resolveOllamaRetryTemperature(): number {
    Tune the allowlist in lockstep with src/lib/models.ts MODEL_OPTIONS. */
 const RESIDENT_MODELS = new Set(['qwen3.5:4b', 'qwen3.5:9b', 'llama3.1:8b']);
 
+/* Models that are only safe to keep resident where the constraint is VRAM
+   (GPU box). On a CPU-only machine the same model would pin ~6.4 GB of
+   system RAM for 5 min with no eviction guard, so we unload immediately
+   when the accelerator is 'cpu'. Small models (4B/8B) fit comfortably in
+   either context and are NOT in this set. */
+const RAM_HEAVY_MODELS = new Set(['qwen3.5:9b']);
+
 /** Picks the `keep_alive` value for an Ollama /api/chat call:
     - models in RESIDENT_MODELS → '5m' (stay loaded for the analysis loop)
+    - RAM_HEAVY_MODELS on CPU   → 0   (would pin ~6.4 GB in system RAM)
     - everything else            → 0   (unload immediately after the call,
                                         matching `keep_alive: 0` in Ollama's
                                         own unload pattern — see
-                                        https://github.com/ollama/ollama/blob/main/docs/api.md#keep-alive). */
-export function keepAliveFor(model: string): string | number {
-  return RESIDENT_MODELS.has(model) ? '5m' : 0;
+                                        https://github.com/ollama/ollama/blob/main/docs/api.md#keep-alive).
+    The `accelerator` parameter defaults to 'unknown', which is treated as
+    GPU (the common case + the perf win), so existing 1-arg callers are
+    unaffected. */
+export function keepAliveFor(model: string, accelerator: Accelerator = 'unknown'): string | number {
+  if (!RESIDENT_MODELS.has(model)) return 0;
+  if (RAM_HEAVY_MODELS.has(model) && accelerator === 'cpu') return 0;
+  return '5m';
 }
 
 /* num_ctx the analyzer hands Ollama on every /api/chat call (see the
@@ -423,7 +438,7 @@ export class OllamaAnalyzer implements Analyzer {
          The 4B and Llama-8B stay resident across the analysis loop; the
          9B unloads immediately so its 6.6 GB doesn't squat on VRAM that
          XTTS needs after analysis. */
-      keep_alive: keepAliveFor(this.model),
+      keep_alive: keepAliveFor(this.model, getLastKnownVram().accelerator),
       /* Suppress qwen3.5's thinking tokens — they'd appear as
          `<think>…</think>` ahead of the JSON and break the parser. Ollama
          silently ignores this flag on non-thinking models. */

--- a/server/src/analyzer/ollama.ts
+++ b/server/src/analyzer/ollama.ts
@@ -109,16 +109,26 @@ export function resolveOllamaRetryTemperature(): number {
 /* Models we want Ollama to hold in VRAM between back-to-back analysis
    calls. Stage 1 → Stage 2 → next chapter happens on a tight loop, and
    reloading a multi-GB weight set between each one would dominate
-   wall-clock time. The 4B (~3 GB) and Llama-8B (~5 GB) both fit
-   resident on an 8 GB box alongside the ~1–1.5 GB KV cache at
-   ANALYZER_NUM_CTX, with enough headroom to absorb a long-chapter KV
-   spike. The 9B (~6.6 GB) is too tight — KV cache pushes it over budget
-   — so we still evict that immediately after each call. XTTS is loaded
-   on a separate, mutually-exclusive pipeline phase, so neither tenant
-   has to fit alongside the other; the auto-evict pill mediates the
-   swap. Tune the allowlist in lockstep with src/lib/models.ts
-   MODEL_OPTIONS. */
-const RESIDENT_MODELS = new Set(['qwen3.5:4b', 'llama3.1:8b']);
+   wall-clock time — the 9B otherwise unloads+reloads ~6.35 GB on every
+   chapter section, which surfaces as a VRAM sawtooth and mid-stream
+   "no response" stalls. The 4B (~3 GB), Llama-8B (~5 GB), and 9B
+   (~6.6 GB) all fit resident on an 8 GB box alongside the KV cache at
+   ANALYZER_NUM_CTX: the chunker caps each section to ~24k chars so the
+   KV cache never reaches the 32k worst case (confirmed live — the 9B
+   ran ~6.25 GB / 8 GB resident).
+
+   The cross-engine handoff is the load-bearing assumption: a resident 9B
+   CANNOT co-reside with Qwen TTS / XTTS, so we rely on the generation
+   engine's auto-evict to drop a resident Ollama model before it loads.
+   With that protection in place, keeping the 9B warm across the analysis
+   loop is safe and removes the reload tax.
+
+   NOTE: this does NOT hold for a LOCAL-MODEL SPLIT (a run that uses two
+   different local models across phase0/phase1). Two large local models
+   resident at once would exceed the 8 GB budget — that path must keep
+   its non-resident eviction; do not naively add both to this set.
+   Tune the allowlist in lockstep with src/lib/models.ts MODEL_OPTIONS. */
+const RESIDENT_MODELS = new Set(['qwen3.5:4b', 'qwen3.5:9b', 'llama3.1:8b']);
 
 /** Picks the `keep_alive` value for an Ollama /api/chat call:
     - models in RESIDENT_MODELS → '5m' (stay loaded for the analysis loop)

--- a/server/src/config/registry.ts
+++ b/server/src/config/registry.ts
@@ -466,6 +466,16 @@ export const KNOBS: ConfigKnob[] = [
     apply: 'live', risk: 'high', // read per-op via costForEngine() in tts/engine-vram-cost.ts
   },
   {
+    key: 'gpu.safeCoexistMb',
+    env: 'GPU_SAFE_COEXIST_MB',
+    group: 'gpu-lifecycle',
+    label: 'Safe analyzer+TTS coexistence VRAM (MB)',
+    help: 'If detected GPU VRAM is below this, evict the resident Ollama analyzer before loading a sidecar TTS/voice-design model. 8 GB cards evict; 12/16 GB coexist. 0 = always evict.',
+    type: 'integer', min: 0,
+    default: 11000, // ← gpu/residency.ts: below this threshold Ollama is evicted before sidecar load
+    apply: 'live', risk: 'high',
+  },
+  {
     key: 'sidecar.qwenDesignIdleTtl',
     env: 'QWEN_DESIGN_IDLE_TTL',
     group: 'gpu-lifecycle',

--- a/server/src/gpu/eviction-regression.test.ts
+++ b/server/src/gpu/eviction-regression.test.ts
@@ -3,25 +3,45 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const events: string[] = [];
 const busy = { value: false };
 
-vi.mock('./vram-state.js', () => ({ getLastKnownVram: () => ({ accelerator: 'cuda', totalMb: 8188 }) }));
+vi.mock('./vram-state.js', () => ({
+  getLastKnownVram: () => ({ accelerator: 'cuda', totalMb: 8188 }),
+}));
 vi.mock('../tts/design-lock.js', () => ({ isAnyAnalysisBusy: () => busy.value }));
-vi.mock('./residency.js', () => ({ shouldEvictBeforeSidecarLoad: (v: { totalMb: number | null }) => v.totalMb != null && v.totalMb < 11000 }));
+vi.mock('./residency.js', () => ({
+  shouldEvictBeforeSidecarLoad: (v: { totalMb: number | null }) =>
+    v.totalMb != null && v.totalMb < 11000,
+}));
 vi.mock('../routes/ollama-health.js', () => ({
-  unloadResidentOllama: vi.fn(async () => { events.push('evict'); return ['qwen3.5:9b']; }),
-  verifyOllamaEvicted: vi.fn(async () => { events.push('verify'); return true; }),
+  unloadResidentOllama: vi.fn(async () => {
+    events.push('evict');
+    return ['qwen3.5:9b'];
+  }),
+  verifyOllamaEvicted: vi.fn(async () => {
+    events.push('verify');
+    return true;
+  }),
 }));
 
-beforeEach(() => { events.length = 0; busy.value = false; });
+beforeEach(() => {
+  events.length = 0;
+  busy.value = false;
+});
 
 it('on 8 GB idle: evict → verify → load, in order', async () => {
   const { withGpuLoad } = await import('./gpu-load.js');
-  await withGpuLoad(async () => { events.push('load'); });
+  await withGpuLoad(async () => {
+    events.push('load');
+  });
   expect(events).toEqual(['evict', 'verify', 'load']);
 });
 
 it('on 8 GB with analysis busy: REFUSES (GpuBusyError), never evicts or loads', async () => {
   busy.value = true;
   const { withGpuLoad, GpuBusyError } = await import('./gpu-load.js');
-  await expect(withGpuLoad(async () => { events.push('load'); })).rejects.toBeInstanceOf(GpuBusyError);
+  await expect(
+    withGpuLoad(async () => {
+      events.push('load');
+    }),
+  ).rejects.toBeInstanceOf(GpuBusyError);
   expect(events).toEqual([]); // no evict, no load
 });

--- a/server/src/gpu/eviction-regression.test.ts
+++ b/server/src/gpu/eviction-regression.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const events: string[] = [];
+const busy = { value: false };
+
+vi.mock('./vram-state.js', () => ({ getLastKnownVram: () => ({ accelerator: 'cuda', totalMb: 8188 }) }));
+vi.mock('../tts/design-lock.js', () => ({ isAnyAnalysisBusy: () => busy.value }));
+vi.mock('./residency.js', () => ({ shouldEvictBeforeSidecarLoad: (v: { totalMb: number | null }) => v.totalMb != null && v.totalMb < 11000 }));
+vi.mock('../routes/ollama-health.js', () => ({
+  unloadResidentOllama: vi.fn(async () => { events.push('evict'); return ['qwen3.5:9b']; }),
+  verifyOllamaEvicted: vi.fn(async () => { events.push('verify'); return true; }),
+}));
+
+beforeEach(() => { events.length = 0; busy.value = false; });
+
+it('on 8 GB idle: evict → verify → load, in order', async () => {
+  const { withGpuLoad } = await import('./gpu-load.js');
+  await withGpuLoad(async () => { events.push('load'); });
+  expect(events).toEqual(['evict', 'verify', 'load']);
+});
+
+it('on 8 GB with analysis busy: REFUSES (GpuBusyError), never evicts or loads', async () => {
+  busy.value = true;
+  const { withGpuLoad, GpuBusyError } = await import('./gpu-load.js');
+  await expect(withGpuLoad(async () => { events.push('load'); })).rejects.toBeInstanceOf(GpuBusyError);
+  expect(events).toEqual([]); // no evict, no load
+});

--- a/server/src/gpu/eviction-regression.test.ts
+++ b/server/src/gpu/eviction-regression.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { it, expect, vi, beforeEach } from 'vitest';
 
 const events: string[] = [];
 const busy = { value: false };

--- a/server/src/gpu/gpu-load.test.ts
+++ b/server/src/gpu/gpu-load.test.ts
@@ -5,11 +5,16 @@ const { unloadMock, verifyMock, vramMock, busyMock, shouldEvictMock } = vi.hoist
   const verifyMock = vi.fn(async () => true);
   const vramMock = vi.fn();
   const busyMock = vi.fn(() => false);
-  const shouldEvictMock = vi.fn((v: { totalMb: number | null }) => v.totalMb != null && v.totalMb < 11000);
+  const shouldEvictMock = vi.fn(
+    (v: { totalMb: number | null }) => v.totalMb != null && v.totalMb < 11000,
+  );
   return { unloadMock, verifyMock, vramMock, busyMock, shouldEvictMock };
 });
 
-vi.mock('../routes/ollama-health.js', () => ({ unloadResidentOllama: unloadMock, verifyOllamaEvicted: verifyMock }));
+vi.mock('../routes/ollama-health.js', () => ({
+  unloadResidentOllama: unloadMock,
+  verifyOllamaEvicted: verifyMock,
+}));
 vi.mock('./vram-state.js', () => ({ getLastKnownVram: vramMock }));
 vi.mock('../tts/design-lock.js', () => ({ isAnyAnalysisBusy: busyMock }));
 vi.mock('./residency.js', () => ({ shouldEvictBeforeSidecarLoad: shouldEvictMock }));
@@ -17,16 +22,28 @@ vi.mock('./residency.js', () => ({ shouldEvictBeforeSidecarLoad: shouldEvictMock
 import { withGpuLoad, GpuBusyError } from './gpu-load.js';
 
 beforeEach(() => {
-  unloadMock.mockClear(); verifyMock.mockClear(); busyMock.mockReturnValue(false); verifyMock.mockResolvedValue(true);
+  unloadMock.mockClear();
+  verifyMock.mockClear();
+  busyMock.mockReturnValue(false);
+  verifyMock.mockResolvedValue(true);
 });
 
 describe('withGpuLoad', () => {
   it('on 8 GB: evicts, verifies, then runs the load (in that order)', async () => {
     vramMock.mockReturnValue({ accelerator: 'cuda', totalMb: 8188 });
     const order: string[] = [];
-    unloadMock.mockImplementationOnce(async () => { order.push('evict'); return ['qwen3.5:9b']; });
-    verifyMock.mockImplementationOnce(async () => { order.push('verify'); return true; });
-    const out = await withGpuLoad(async () => { order.push('load'); return 'ok'; });
+    unloadMock.mockImplementationOnce(async () => {
+      order.push('evict');
+      return ['qwen3.5:9b'];
+    });
+    verifyMock.mockImplementationOnce(async () => {
+      order.push('verify');
+      return true;
+    });
+    const out = await withGpuLoad(async () => {
+      order.push('load');
+      return 'ok';
+    });
     expect(out).toBe('ok');
     expect(order).toEqual(['evict', 'verify', 'load']);
   });

--- a/server/src/gpu/gpu-load.test.ts
+++ b/server/src/gpu/gpu-load.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { unloadMock, verifyMock, vramMock, busyMock, shouldEvictMock } = vi.hoisted(() => {
+  const unloadMock = vi.fn(async () => ['qwen3.5:9b']);
+  const verifyMock = vi.fn(async () => true);
+  const vramMock = vi.fn();
+  const busyMock = vi.fn(() => false);
+  const shouldEvictMock = vi.fn((v: { totalMb: number | null }) => v.totalMb != null && v.totalMb < 11000);
+  return { unloadMock, verifyMock, vramMock, busyMock, shouldEvictMock };
+});
+
+vi.mock('../routes/ollama-health.js', () => ({ unloadResidentOllama: unloadMock, verifyOllamaEvicted: verifyMock }));
+vi.mock('./vram-state.js', () => ({ getLastKnownVram: vramMock }));
+vi.mock('../tts/design-lock.js', () => ({ isAnyAnalysisBusy: busyMock }));
+vi.mock('./residency.js', () => ({ shouldEvictBeforeSidecarLoad: shouldEvictMock }));
+
+import { withGpuLoad, GpuBusyError } from './gpu-load.js';
+
+beforeEach(() => {
+  unloadMock.mockClear(); verifyMock.mockClear(); busyMock.mockReturnValue(false); verifyMock.mockResolvedValue(true);
+});
+
+describe('withGpuLoad', () => {
+  it('on 8 GB: evicts, verifies, then runs the load (in that order)', async () => {
+    vramMock.mockReturnValue({ accelerator: 'cuda', totalMb: 8188 });
+    const order: string[] = [];
+    unloadMock.mockImplementationOnce(async () => { order.push('evict'); return ['qwen3.5:9b']; });
+    verifyMock.mockImplementationOnce(async () => { order.push('verify'); return true; });
+    const out = await withGpuLoad(async () => { order.push('load'); return 'ok'; });
+    expect(out).toBe('ok');
+    expect(order).toEqual(['evict', 'verify', 'load']);
+  });
+
+  it('on 12 GB: runs the load directly, no eviction', async () => {
+    vramMock.mockReturnValue({ accelerator: 'cuda', totalMb: 12288 });
+    const out = await withGpuLoad(async () => 'ok');
+    expect(out).toBe('ok');
+    expect(unloadMock).not.toHaveBeenCalled();
+  });
+
+  it('REFUSES with GpuBusyError when analysis is busy on a constrained card (no load)', async () => {
+    vramMock.mockReturnValue({ accelerator: 'cuda', totalMb: 8188 });
+    busyMock.mockReturnValue(true);
+    const load = vi.fn();
+    await expect(withGpuLoad(load as never)).rejects.toBeInstanceOf(GpuBusyError);
+    expect(load).not.toHaveBeenCalled();
+    expect(unloadMock).not.toHaveBeenCalled();
+  });
+
+  it('fail-closed: if eviction cannot be verified, throws and does NOT load', async () => {
+    vramMock.mockReturnValue({ accelerator: 'cuda', totalMb: 8188 });
+    verifyMock.mockResolvedValue(false);
+    const load = vi.fn();
+    await expect(withGpuLoad(load as never)).rejects.toBeInstanceOf(GpuBusyError);
+    expect(load).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/gpu/gpu-load.ts
+++ b/server/src/gpu/gpu-load.ts
@@ -30,7 +30,9 @@ export async function withGpuLoad<T>(loadFn: () => Promise<T>): Promise<T> {
     }
     await unloadResidentOllama();
     if (!(await verifyOllamaEvicted())) {
-      throw new GpuBusyError('Could not free GPU memory (analyzer still resident) — try again shortly.');
+      throw new GpuBusyError(
+        'Could not free GPU memory (analyzer still resident) — try again shortly.',
+      );
     }
     return loadFn();
   });

--- a/server/src/gpu/gpu-load.ts
+++ b/server/src/gpu/gpu-load.ts
@@ -1,0 +1,37 @@
+import { getLastKnownVram } from './vram-state.js';
+import { shouldEvictBeforeSidecarLoad } from './residency.js';
+import { withGpuLoadLock } from './load-mutex.js';
+import { unloadResidentOllama, verifyOllamaEvicted } from '../routes/ollama-health.js';
+import { isAnyAnalysisBusy } from '../tts/design-lock.js';
+
+/** Thrown when a sidecar TTS/voice-design load cannot proceed on a card that
+    can't coexist — because an analysis is in flight, or eviction couldn't be
+    confirmed. Routes map it to HTTP 409. */
+export class GpuBusyError extends Error {
+  readonly code = 'GPU_BUSY';
+  constructor(message: string) {
+    super(message);
+    this.name = 'GpuBusyError';
+  }
+}
+
+/** Run a sidecar model load safely w.r.t. the resident Ollama analyzer.
+    - Roomy card / CPU: run the load directly (it fits; no serialisation needed).
+    - Constrained card: under the load-mutex — refuse if analysis is busy
+      (would have to evict an active analyzer), else evict ALL residents, verify
+      they're gone (fail-closed), then run the load INSIDE the lock. */
+export async function withGpuLoad<T>(loadFn: () => Promise<T>): Promise<T> {
+  if (!shouldEvictBeforeSidecarLoad(getLastKnownVram())) {
+    return loadFn();
+  }
+  return withGpuLoadLock(async () => {
+    if (isAnyAnalysisBusy()) {
+      throw new GpuBusyError('GPU busy with analysis — try again once it finishes.');
+    }
+    await unloadResidentOllama();
+    if (!(await verifyOllamaEvicted())) {
+      throw new GpuBusyError('Could not free GPU memory (analyzer still resident) — try again shortly.');
+    }
+    return loadFn();
+  });
+}

--- a/server/src/gpu/load-mutex.ts
+++ b/server/src/gpu/load-mutex.ts
@@ -5,6 +5,9 @@
 let tail: Promise<unknown> = Promise.resolve();
 export function withGpuLoadLock<T>(fn: () => Promise<T>): Promise<T> {
   const run = tail.then(fn, fn);
-  tail = run.then(() => undefined, () => undefined);
+  tail = run.then(
+    () => undefined,
+    () => undefined,
+  );
   return run;
 }

--- a/server/src/gpu/load-mutex.ts
+++ b/server/src/gpu/load-mutex.ts
@@ -1,0 +1,10 @@
+/* Serialises evict+load sequences. The GpuSemaphore arbitrates EXECUTION (token
+   budget around /chat and /synthesize); it neither knows about nor serialises
+   model LOADS. This mutex makes evict→verify→load atomic so two concurrent
+   starts can't both evict then both load and overcommit. */
+let tail: Promise<unknown> = Promise.resolve();
+export function withGpuLoadLock<T>(fn: () => Promise<T>): Promise<T> {
+  const run = tail.then(fn, fn);
+  tail = run.then(() => undefined, () => undefined);
+  return run;
+}

--- a/server/src/gpu/residency.test.ts
+++ b/server/src/gpu/residency.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('../config/resolver.js', () => ({ configValue: vi.fn(() => 11000) }));
+import { shouldEvictBeforeSidecarLoad } from './residency.js';
+
+describe('shouldEvictBeforeSidecarLoad', () => {
+  it('CPU never evicts', () => {
+    expect(shouldEvictBeforeSidecarLoad({ accelerator: 'cpu', totalMb: null })).toBe(false);
+  });
+  it('GPU unknown total → evict (conservative)', () => {
+    expect(shouldEvictBeforeSidecarLoad({ accelerator: 'cuda', totalMb: null })).toBe(true);
+  });
+  it('accelerator unknown (never probed) → evict (conservative)', () => {
+    expect(shouldEvictBeforeSidecarLoad({ accelerator: 'unknown', totalMb: null })).toBe(true);
+  });
+  it('8 GB evicts; 12/16 GB coexist', () => {
+    expect(shouldEvictBeforeSidecarLoad({ accelerator: 'cuda', totalMb: 8188 })).toBe(true);
+    expect(shouldEvictBeforeSidecarLoad({ accelerator: 'cuda', totalMb: 12288 })).toBe(false);
+    expect(shouldEvictBeforeSidecarLoad({ accelerator: 'cuda', totalMb: 16384 })).toBe(false);
+  });
+});

--- a/server/src/gpu/residency.ts
+++ b/server/src/gpu/residency.ts
@@ -1,0 +1,11 @@
+import { configValue } from '../config/resolver.js';
+import type { VramState } from './vram-state.js';
+
+/** Evict a resident Ollama analyzer before loading a sidecar TTS/voice-design
+    model? CPU: never. GPU with unknown/never-probed total: yes (conservative).
+    GPU below `gpu.safeCoexistMb`: yes; at/above: no (12/16 GB coexist). */
+export function shouldEvictBeforeSidecarLoad(v: VramState): boolean {
+  if (v.accelerator === 'cpu') return false;
+  if (v.totalMb == null) return true;
+  return v.totalMb < configValue<number>('gpu.safeCoexistMb');
+}

--- a/server/src/gpu/vram-state.test.ts
+++ b/server/src/gpu/vram-state.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setLastKnownVram, getLastKnownVram } from './vram-state.js';
+
+describe('last-known VRAM cache', () => {
+  beforeEach(() => setLastKnownVram(null)); // reset to "never probed"
+
+  it('defaults to unknown / null before any probe', () => {
+    expect(getLastKnownVram()).toEqual({ accelerator: 'unknown', totalMb: null });
+  });
+  it('records a CUDA total as accelerator cuda', () => {
+    setLastKnownVram({ totalMb: 8188 });
+    expect(getLastKnownVram()).toEqual({ accelerator: 'cuda', totalMb: 8188 });
+  });
+  it('records a reachable-but-no-CUDA probe as cpu', () => {
+    setLastKnownVram({ totalMb: null });
+    expect(getLastKnownVram()).toEqual({ accelerator: 'cpu', totalMb: null });
+  });
+  it('an unreachable poll (undefined) leaves the last-known state intact', () => {
+    setLastKnownVram({ totalMb: 8188 });
+    setLastKnownVram(undefined);
+    expect(getLastKnownVram()).toEqual({ accelerator: 'cuda', totalMb: 8188 });
+  });
+});

--- a/server/src/gpu/vram-state.ts
+++ b/server/src/gpu/vram-state.ts
@@ -1,0 +1,28 @@
+export type Accelerator = 'cuda' | 'cpu' | 'unknown';
+export interface VramState {
+  accelerator: Accelerator;
+  totalMb: number | null;
+}
+
+/* Last-known VRAM, mirroring the Qwen-install-state cache: only a REACHABLE
+   probe updates it, so a transient sidecar respawn (when eviction must still
+   decide) doesn't downgrade a known-good reading. `null` resets to "never
+   probed"; `undefined` is an unreachable poll (no-op). CUDA presence is inferred
+   from a non-null vram_total_mb (the sidecar reports it iff CUDA). */
+let lastKnownVram: VramState = { accelerator: 'unknown', totalMb: null };
+
+export function setLastKnownVram(next: { totalMb: number | null } | null | undefined): void {
+  if (next === undefined) return;
+  if (next === null) {
+    lastKnownVram = { accelerator: 'unknown', totalMb: null };
+    return;
+  }
+  lastKnownVram = {
+    totalMb: next.totalMb,
+    accelerator: next.totalMb != null ? 'cuda' : 'cpu',
+  };
+}
+
+export function getLastKnownVram(): VramState {
+  return lastKnownVram;
+}

--- a/server/src/routes/cast-design.test.ts
+++ b/server/src/routes/cast-design.test.ts
@@ -39,6 +39,16 @@ vi.mock('../analyzer/voice-style.js', () => ({
   generateVoiceStylePersona: personaMock,
 }));
 
+/* Passthrough mock — keeps withGpuLoad a no-op in tests so the unit boundary
+   stays at the sidecar fetch and doesn't try to evict a real Ollama. */
+vi.mock('../gpu/gpu-load.js', () => ({
+  withGpuLoad: async (fn: () => Promise<unknown>) => fn(),
+  GpuBusyError: class GpuBusyError extends Error {
+    code = 'GPU_BUSY';
+    constructor(m: string) { super(m); this.name = 'GpuBusyError'; }
+  },
+}));
+
 const characters = [
   { id: 'narrator', name: 'Narrator', role: 'narrator', color: 'narrator' },
   {

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -1086,6 +1086,21 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
           })
         : null;
 
+    /* Wraps ensureSidecarEngineReady at the two primary preload sites so a
+       GpuBusyError (analysis in progress on a constrained card) surfaces as a
+       user-facing "Generation paused" message rather than an unhandled throw. */
+    async function ensureReadyOrPause(eng: TtsEngine, sig: AbortSignal | undefined): Promise<void> {
+      try {
+        await ensureSidecarEngineReady(eng, sig);
+      } catch (e) {
+        const { GpuBusyError } = await import('../gpu/gpu-load.js');
+        if (e instanceof GpuBusyError) {
+          throw new Error(`Generation paused: ${(e as Error).message}`); // user-facing pause, NOT a breaker-tripping crash
+        }
+        throw e;
+      }
+    }
+
     try {
       const renderBody = async (chapterSignal: AbortSignal): Promise<void> => {
       /* Build the spoken chapter-title phrase from chapter.id + chapter.title.
@@ -1100,7 +1115,7 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
          racing the lazy load. Idempotent + best-effort (the sidecar
          `_base_load_lock` is the correctness guarantee; this is the explicit
          "wait until ready" on top). Honours the run abort. */
-      await ensureSidecarEngineReady(engine, chapterSignal);
+      await ensureReadyOrPause(engine, chapterSignal);
       /* Warm Kokoro ONLY when this chapter will actually render a Qwen→Kokoro
          fallback — either the whole-cast `qwenUnavailable` case, or a confirmed
          per-character undesigned-voice fallback (an unconfirmed one parked the
@@ -1118,7 +1133,7 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
             engine,
           ).length > 0);
       if (willFallBackToKokoro) {
-        await ensureSidecarEngineReady('kokoro', chapterSignal);
+        await ensureReadyOrPause('kokoro', chapterSignal);
       }
       /* Wall around the synth phase only (all TTS — title beat + body groups;
          encode/disk happens after and is excluded) — drives the RTF rollup +

--- a/server/src/routes/ollama-health.test.ts
+++ b/server/src/routes/ollama-health.test.ts
@@ -276,6 +276,32 @@ describe('POST /api/ollama/unload', () => {
     expect(res.status).toBe(503);
     expect(res.body.status).toBe('error');
   });
+
+  it('unloadResidentOllama() with no targets evicts EVERY resident with keep_alive: 0', async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (String(url).endsWith('/api/ps')) {
+        return new Response(JSON.stringify({ models: [{ name: 'qwen3.5:9b' }, { name: 'llama3.1:8b' }] }), { status: 200 });
+      }
+      return new Response('', { status: 200 }); // /api/tags + the /api/generate unload calls
+    });
+    const { unloadResidentOllama } = await import('./ollama-health.js');
+    const evicted = await unloadResidentOllama();
+    expect(evicted.sort()).toEqual(['llama3.1:8b', 'qwen3.5:9b']);
+  });
+
+  it('verifyOllamaEvicted() resolves true once /api/ps no longer lists a resident', async () => {
+    let psProbes = 0;
+    fetchMock.mockImplementation(async (url: string) => {
+      if (String(url).endsWith('/api/ps')) {
+        psProbes += 1;
+        const models = psProbes === 1 ? [{ name: 'qwen3.5:9b' }] : []; // gone on the 2nd ps probe
+        return new Response(JSON.stringify({ models }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ models: [] }), { status: 200 }); // /api/tags
+    });
+    const { verifyOllamaEvicted } = await import('./ollama-health.js');
+    await expect(verifyOllamaEvicted({ retries: 3, delayMs: 1 })).resolves.toBe(true);
+  });
 });
 
 /* ============================================================

--- a/server/src/routes/ollama-health.ts
+++ b/server/src/routes/ollama-health.ts
@@ -276,28 +276,49 @@ ollamaHealthRouter.post('/load', async (req: Request, res: Response) => {
   return res.json({ status: 'ready' });
 });
 
+/** Evict resident Ollama model(s) via keep_alive:0 generate calls. Empty/omitted
+    `targets` → evict EVERY model /api/ps reports (the safe default: a phase-env
+    or quant-tagged resident won't be missed; matches the /unload-all route).
+    Returns the list evicted. Throws on the first failed eviction (error carries
+    `.status` for the HTTP response code). */
+export async function unloadResidentOllama(targets?: string[]): Promise<string[]> {
+  const url = getResolvedOllamaUrl();
+  const list = targets && targets.length > 0 ? targets : (await probeOllamaHealth()).resident ?? [];
+  for (const model of list) {
+    const result = await callOllamaGenerate(url, { model, prompt: '', keep_alive: 0, stream: false }, PROBE_TIMEOUT_MS);
+    if (!result.ok) {
+      const err = Object.assign(new Error(result.error ?? `unload ${model} failed`), { status: result.status });
+      throw err;
+    }
+  }
+  return list;
+}
+
+/** Poll /api/ps until no model remains resident (Ollama unloads asynchronously).
+    Returns true when clear; false if still resident after the retries. */
+export async function verifyOllamaEvicted(opts: { retries?: number; delayMs?: number } = {}): Promise<boolean> {
+  const retries = opts.retries ?? 5;
+  const delayMs = opts.delayMs ?? 400;
+  for (let i = 0; i < retries; i += 1) {
+    const resident = (await probeOllamaHealth()).resident ?? [];
+    if (resident.length === 0) return true;
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+  return ((await probeOllamaHealth()).resident ?? []).length === 0;
+}
+
 /* POST /api/ollama/unload — evict the configured analyzer model from VRAM.
    Used by both the Analysing-screen Stop button and the Generate-screen
    auto-evict flow (loading TTS calls this first to free GPU memory). */
 ollamaHealthRouter.post('/unload', async (req: Request, res: Response) => {
-  const url = getResolvedOllamaUrl();
   const requested = typeof req.body?.model === 'string' ? req.body.model.trim() : '';
-  /* Explicit model → evict just that one. No model → evict every resident
-     model (so the TTS auto-evict path frees ALL analyzer VRAM, not just the
-     configured default — a manually-warmed non-default model would otherwise
-     stay co-resident with the voice engine and OOM the GPU). */
-  const targets = requested ? [requested] : (await probeOllamaHealth()).resident ?? [];
-  for (const model of targets) {
-    const result = await callOllamaGenerate(
-      url,
-      { model, prompt: '', keep_alive: 0, stream: false },
-      PROBE_TIMEOUT_MS,
-    );
-    if (!result.ok) {
-      return res.status(result.status).json({ status: 'error', error: result.error });
-    }
+  try {
+    const unloaded = await unloadResidentOllama(requested ? [requested] : undefined);
+    return res.json({ status: 'unloaded', unloaded });
+  } catch (e) {
+    const err = e as Error & { status?: number };
+    return res.status(err.status ?? 502).json({ status: 'error', error: err.message });
   }
-  return res.json({ status: 'unloaded', unloaded: targets });
 });
 
 /* ============================================================

--- a/server/src/routes/qwen-voice.test.ts
+++ b/server/src/routes/qwen-voice.test.ts
@@ -60,6 +60,17 @@ vi.mock('../tts/index.js', async (importOriginal) => {
   return { ...actual, selectTtsProvider: vi.fn(() => ({ synthesize })) };
 });
 
+const { withGpuLoadMock } = vi.hoisted(() => ({
+  withGpuLoadMock: vi.fn(async (fn: () => Promise<unknown>) => fn()), // default: passthrough
+}));
+vi.mock('../gpu/gpu-load.js', () => ({
+  withGpuLoad: (fn: () => Promise<unknown>) => withGpuLoadMock(fn),
+  GpuBusyError: class GpuBusyError extends Error {
+    code = 'GPU_BUSY';
+    constructor(m: string) { super(m); this.name = 'GpuBusyError'; }
+  },
+}));
+
 const characters = [
   { id: 'narrator', name: 'Narrator', role: 'narrator', color: 'narrator' },
   {
@@ -395,6 +406,18 @@ describe('POST /api/books/:bookId/cast/:characterId/design-voice', () => {
     expect(res.status).toBe(200);
     const sent = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(sent.language).toBe('English');
+  });
+
+  it('returns 409 when the GPU is busy with analysis (constrained card)', async () => {
+    const { GpuBusyError } = await import('../gpu/gpu-load.js');
+    withGpuLoadMock.mockImplementationOnce(() => {
+      throw new GpuBusyError('GPU busy with analysis — try again once it finishes.');
+    });
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/maerin/design-voice`)
+      .send(designBody);
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/GPU busy/i);
   });
 });
 

--- a/server/src/routes/qwen-voice.ts
+++ b/server/src/routes/qwen-voice.ts
@@ -268,6 +268,8 @@ export async function designQwenVoiceForCharacter(
   const calibrationText = buildSampleText(toVoiceLike(p.character), buildHintFromCast(p.character));
 
   return withDesignLock(p.bookDir, async () => {
+    const { withGpuLoad } = await import('../gpu/gpu-load.js');
+    return withGpuLoad(async () => {
     const releaseGpu = await gpuSemaphore.acquire(costForEngine('qwen'));
     const sidecarUrl = getResolvedSidecarUrl();
     const target = `${sidecarUrl}/qwen/design-voice`;
@@ -376,6 +378,7 @@ export async function designQwenVoiceForCharacter(
       if (p.signal) p.signal.removeEventListener('abort', onExternalAbort);
       releaseGpu();
     }
+    });
   });
 }
 
@@ -497,6 +500,10 @@ qwenVoiceRouter.post(
     } catch (e) {
       /* The core throws a user-facing message for sidecar/encode/timeout
          failures — surface it as a 502 (the sidecar boundary). */
+      const { GpuBusyError } = await import('../gpu/gpu-load.js');
+      if (e instanceof GpuBusyError) {
+        return res.status(409).json({ error: e.message, code: 'gpu_busy' });
+      }
       return res.status(502).json({ error: (e as Error).message || 'Voice design failed.' });
     }
   },

--- a/server/src/routes/qwen-voice.ts
+++ b/server/src/routes/qwen-voice.ts
@@ -40,11 +40,7 @@ import { encodePcmToAudio } from '../tts/mp3.js';
 import { gpuSemaphore } from '../gpu/semaphore.js';
 import { costForEngine } from '../tts/engine-vram-cost.js';
 import { withDesignLock, isDesignBusy } from '../tts/design-lock.js';
-import {
-  buildHintFromCast,
-  toVoiceLike,
-  type CastCharacter,
-} from '../tts/synthesise-chapter.js';
+import { buildHintFromCast, toVoiceLike, type CastCharacter } from '../tts/synthesise-chapter.js';
 import { forEachMatchingCastCharacter } from './voices.js';
 import { findAuthorSeriesForBookId } from '../workspace/series-cast-scan.js';
 import {
@@ -112,7 +108,10 @@ const EMOTION_INSTRUCT: Record<Exclude<Emotion, 'neutral'>, string> = {
 };
 
 /** Append the emotion delivery clause to a persona for variant design. */
-export function buildVariantInstruct(persona: string, emotion: Exclude<Emotion, 'neutral'>): string {
+export function buildVariantInstruct(
+  persona: string,
+  emotion: Exclude<Emotion, 'neutral'>,
+): string {
   return `${persona.trim()} ${EMOTION_INSTRUCT[emotion]}`.trim();
 }
 
@@ -218,7 +217,8 @@ qwenVoiceRouter.get(
        override wins, else the stable `qwen-${voiceId}` key (so a REUSED
        character with an empty own override still resolves to its series-shared
        sidecar). */
-    const voiceName = character.overrideTtsVoices?.qwen?.name ?? deriveQwenVoiceId(character, characterId);
+    const voiceName =
+      character.overrideTtsVoices?.qwen?.name ?? deriveQwenVoiceId(character, characterId);
     const sidecar = await readJson<{ instruct?: string }>(qwenVoiceSidecarPath(voiceName)).catch(
       () => null,
     );
@@ -262,122 +262,120 @@ export async function designQwenVoiceForCharacter(
   const baseVoiceId = deriveQwenVoiceId(p.character, p.characterId);
   const designedId = p.emotion ? `${baseVoiceId}__${p.emotion}` : baseVoiceId;
   const voiceId = p.preview ? previewVoiceIdFor(designedId) : designedId;
-  const instructForDesign = p.emotion
-    ? buildVariantInstruct(p.persona, p.emotion)
-    : p.persona;
+  const instructForDesign = p.emotion ? buildVariantInstruct(p.persona, p.emotion) : p.persona;
   const calibrationText = buildSampleText(toVoiceLike(p.character), buildHintFromCast(p.character));
 
   return withDesignLock(p.bookDir, async () => {
     const { withGpuLoad } = await import('../gpu/gpu-load.js');
     return withGpuLoad(async () => {
-    const releaseGpu = await gpuSemaphore.acquire(costForEngine('qwen'));
-    const sidecarUrl = getResolvedSidecarUrl();
-    const target = `${sidecarUrl}/qwen/design-voice`;
-    const controller = new AbortController();
-    const startedAt = Date.now();
-    let abortReason: 'unreachable' | 'absolute' | null = null;
-    const livenessTimer = setInterval(() => {
-      void (async () => {
-        const { probeSidecarHealth } = await import('./sidecar-health.js');
-        const health = (await probeSidecarHealth()).status; // 'reachable' | 'unreachable'
-        const decision = evaluateDesignLiveness({
-          startedAt,
-          now: Date.now(),
-          health,
-          absoluteMaxMs: DESIGN_ABSOLUTE_MAX_MS,
-        });
-        if (decision.action === 'abort') {
-          abortReason = decision.reason;
-          controller.abort();
-        } else {
-          console.warn(
-            `[qwen-voice] design slow (${Math.round((Date.now() - startedAt) / 1000)}s) ` +
-              `— sidecar /health reachable, extending (ceiling ${DESIGN_ABSOLUTE_MAX_MS / 1000}s).`,
-          );
-        }
-      })();
-    }, DESIGN_LIVENESS_INTERVAL_MS);
-    const onExternalAbort = () => controller.abort();
-    if (p.signal) {
-      if (p.signal.aborted) controller.abort();
-      else p.signal.addEventListener('abort', onExternalAbort, { once: true });
-    }
-    try {
-      let upstream: Awaited<ReturnType<typeof fetch>>;
-      try {
-        upstream = await fetch(target, {
-          method: 'POST',
-          signal: controller.signal,
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            voiceId,
-            instruct: instructForDesign,
-            language: p.language,
-            calibrationText,
-          }),
-        });
-      } catch (e) {
-        const err = e as { name?: string; message?: string };
-        if (err.name === 'AbortError') {
-          if (p.signal?.aborted) {
-            throw new Error('Voice design was cancelled.');
+      const releaseGpu = await gpuSemaphore.acquire(costForEngine('qwen'));
+      const sidecarUrl = getResolvedSidecarUrl();
+      const target = `${sidecarUrl}/qwen/design-voice`;
+      const controller = new AbortController();
+      const startedAt = Date.now();
+      let abortReason: 'unreachable' | 'absolute' | null = null;
+      const livenessTimer = setInterval(() => {
+        void (async () => {
+          const { probeSidecarHealth } = await import('./sidecar-health.js');
+          const health = (await probeSidecarHealth()).status; // 'reachable' | 'unreachable'
+          const decision = evaluateDesignLiveness({
+            startedAt,
+            now: Date.now(),
+            health,
+            absoluteMaxMs: DESIGN_ABSOLUTE_MAX_MS,
+          });
+          if (decision.action === 'abort') {
+            abortReason = decision.reason;
+            controller.abort();
+          } else {
+            console.warn(
+              `[qwen-voice] design slow (${Math.round((Date.now() - startedAt) / 1000)}s) ` +
+                `— sidecar /health reachable, extending (ceiling ${DESIGN_ABSOLUTE_MAX_MS / 1000}s).`,
+            );
           }
-          if (abortReason === 'unreachable') {
+        })();
+      }, DESIGN_LIVENESS_INTERVAL_MS);
+      const onExternalAbort = () => controller.abort();
+      if (p.signal) {
+        if (p.signal.aborted) controller.abort();
+        else p.signal.addEventListener('abort', onExternalAbort, { once: true });
+      }
+      try {
+        let upstream: Awaited<ReturnType<typeof fetch>>;
+        try {
+          upstream = await fetch(target, {
+            method: 'POST',
+            signal: controller.signal,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              voiceId,
+              instruct: instructForDesign,
+              language: p.language,
+              calibrationText,
+            }),
+          });
+        } catch (e) {
+          const err = e as { name?: string; message?: string };
+          if (err.name === 'AbortError') {
+            if (p.signal?.aborted) {
+              throw new Error('Voice design was cancelled.');
+            }
+            if (abortReason === 'unreachable') {
+              throw new Error(
+                `TTS sidecar (${sidecarUrl}) stopped responding to /health during voice design — the process may have crashed or been recycled.`,
+              );
+            }
             throw new Error(
-              `TTS sidecar (${sidecarUrl}) stopped responding to /health during voice design — the process may have crashed or been recycled.`,
+              `Sidecar /qwen/design-voice did not complete within ${DESIGN_ABSOLUTE_MAX_MS}ms — voice design is unusually slow or the process is stuck.`,
             );
           }
           throw new Error(
-            `Sidecar /qwen/design-voice did not complete within ${DESIGN_ABSOLUTE_MAX_MS}ms — voice design is unusually slow or the process is stuck.`,
+            `TTS sidecar (${sidecarUrl}) is unreachable — ${err.message || 'request failed'}.`,
           );
         }
-        throw new Error(
-          `TTS sidecar (${sidecarUrl}) is unreachable — ${err.message || 'request failed'}.`,
-        );
-      }
-      if (!upstream.ok) {
-        let detail = '';
-        try {
-          const body = (await upstream.json()) as { detail?: string; error?: string };
-          detail = body.detail ?? body.error ?? '';
-        } catch {
-          /* not json */
+        if (!upstream.ok) {
+          let detail = '';
+          try {
+            const body = (await upstream.json()) as { detail?: string; error?: string };
+            detail = body.detail ?? body.error ?? '';
+          } catch {
+            /* not json */
+          }
+          throw new Error(
+            detail ||
+              `Sidecar /qwen/design-voice returned ${upstream.status} ${upstream.statusText}.`,
+          );
         }
-        throw new Error(
-          detail ||
-            `Sidecar /qwen/design-voice returned ${upstream.status} ${upstream.statusText}.`,
-        );
-      }
-      const sampleRate = Number(upstream.headers.get('X-Sample-Rate') ?? '24000') || 24000;
-      const pcm = Buffer.from(await upstream.arrayBuffer());
+        const sampleRate = Number(upstream.headers.get('X-Sample-Rate') ?? '24000') || 24000;
+        const pcm = Buffer.from(await upstream.arrayBuffer());
 
-      const fileName = voiceSampleFileName({
-        cacheScope: p.sampleVoiceId,
-        modelKey: p.modelKey,
-        text: calibrationText,
-        voiceName: voiceId,
-      });
-      const filePath = voiceSampleFilePath(fileName);
-      const url = voiceSamplePublicUrl(fileName);
-      try {
-        await mkdir(voiceSampleAudioDir(), { recursive: true });
-        const mp3 = await encodePcmToAudio(pcm, sampleRate);
-        await writeFile(filePath, mp3);
-      } catch (encErr) {
-        throw new Error(
-          `Designed the voice but failed to cache its preview: ${(encErr as Error).message}`,
+        const fileName = voiceSampleFileName({
+          cacheScope: p.sampleVoiceId,
+          modelKey: p.modelKey,
+          text: calibrationText,
+          voiceName: voiceId,
+        });
+        const filePath = voiceSampleFilePath(fileName);
+        const url = voiceSamplePublicUrl(fileName);
+        try {
+          await mkdir(voiceSampleAudioDir(), { recursive: true });
+          const mp3 = await encodePcmToAudio(pcm, sampleRate);
+          await writeFile(filePath, mp3);
+        } catch (encErr) {
+          throw new Error(
+            `Designed the voice but failed to cache its preview: ${(encErr as Error).message}`,
+          );
+        }
+        console.log(
+          `[qwen-voice] book=${p.bookDir} character=${p.characterId} voiceId=${voiceId} ` +
+            `→ cached ${fileName} (${pcm.length} bytes @ ${sampleRate}Hz)`,
         );
+        return { voiceId, url };
+      } finally {
+        clearInterval(livenessTimer);
+        if (p.signal) p.signal.removeEventListener('abort', onExternalAbort);
+        releaseGpu();
       }
-      console.log(
-        `[qwen-voice] book=${p.bookDir} character=${p.characterId} voiceId=${voiceId} ` +
-          `→ cached ${fileName} (${pcm.length} bytes @ ${sampleRate}Hz)`,
-      );
-      return { voiceId, url };
-    } finally {
-      clearInterval(livenessTimer);
-      if (p.signal) p.signal.removeEventListener('abort', onExternalAbort);
-      releaseGpu();
-    }
     });
   });
 }
@@ -456,8 +454,7 @@ qwenVoiceRouter.post(
     /* Cache identity — the same (voiceId path, modelKey) the /sample player
        uses, so the audition we render here lands on the file it later reads.
        Required: without them we can't reproduce the player's cache key. */
-    const sampleVoiceId =
-      typeof body.sampleVoiceId === 'string' ? body.sampleVoiceId.trim() : '';
+    const sampleVoiceId = typeof body.sampleVoiceId === 'string' ? body.sampleVoiceId.trim() : '';
     if (!sampleVoiceId) {
       return res.status(400).json({
         error: '`sampleVoiceId` is required so the preview can be cached as the 12s sample.',
@@ -494,7 +491,13 @@ qwenVoiceRouter.post(
            only for a standalone. Mirrors the base-voice series scope. */
         const isStandalone = located.state?.isStandalone === true;
         const seriesInfo = isStandalone ? null : await findAuthorSeriesForBookId(bookId);
-        await persistEmotionVariant(bookDir, characterId, emotion, voiceId, seriesInfo ?? undefined);
+        await persistEmotionVariant(
+          bookDir,
+          characterId,
+          emotion,
+          voiceId,
+          seriesInfo ?? undefined,
+        );
       }
       return res.status(200).json({ voiceId, url });
     } catch (e) {
@@ -573,7 +576,12 @@ qwenVoiceRouter.post(
        synthesises fresh from the promoted `.pt`. */
     const calibrationText = buildSampleText(toVoiceLike(character), buildHintFromCast(character));
     const previewMp3 = voiceSampleFilePath(
-      voiceSampleFileName({ cacheScope: sampleVoiceId, modelKey, text: calibrationText, voiceName: previewVoiceId }),
+      voiceSampleFileName({
+        cacheScope: sampleVoiceId,
+        modelKey,
+        text: calibrationText,
+        voiceName: previewVoiceId,
+      }),
     );
     const realFileName = voiceSampleFileName({
       cacheScope: sampleVoiceId,

--- a/server/src/routes/sidecar-health.ts
+++ b/server/src/routes/sidecar-health.ts
@@ -14,6 +14,7 @@ import {
 } from '../workspace/user-settings.js';
 import { asrEnabled } from '../tts/segment-asr-qa.js';
 import { getActiveSupervisor } from '../tts/sidecar-supervisor.js';
+import { setLastKnownVram } from '../gpu/vram-state.js';
 
 export const sidecarHealthRouter = Router();
 
@@ -251,6 +252,9 @@ export async function probeSidecarHealth(): Promise<SidecarHealthResult> {
        a reachable response — an unreachable poll leaves the last-known state
        intact (a transient timeout shouldn't downgrade a known-ready Qwen). */
     setLastKnownQwenInstallState(qwenInstallState);
+    setLastKnownVram({
+      totalMb: typeof body.vram_total_mb === 'number' ? body.vram_total_mb : null,
+    });
     return {
       status: 'reachable',
       url,

--- a/server/src/tts/ensure-sidecar-loaded.test.ts
+++ b/server/src/tts/ensure-sidecar-loaded.test.ts
@@ -5,6 +5,14 @@ vi.mock('../workspace/user-settings.js', () => ({
   readConfigOverrides: () => ({}),
 }));
 
+/* Passthrough mock for the existing readiness tests — they don't care about
+   the GPU gate; the withGpuLoad suite overrides this per-test via vi.doMock +
+   vi.resetModules. */
+vi.mock('../gpu/gpu-load.js', () => ({
+  withGpuLoad: async (fn: () => Promise<unknown>) => fn(),
+  GpuBusyError: class extends Error {},
+}));
+
 import { ensureSidecarEngineReady } from './ensure-sidecar-loaded.js';
 
 const realFetch = global.fetch;
@@ -123,5 +131,43 @@ describe('ensureSidecarEngineReady', () => {
     await expect(
       ensureSidecarEngineReady('qwen', ac.signal, { timeoutMs: 5_000, pollIntervalMs: 50 }),
     ).rejects.toMatchObject({ name: 'AbortError' });
+  });
+});
+
+describe('ensureSidecarEngineReady — withGpuLoad gate', () => {
+  /* Each test must: vi.resetModules() → vi.doMock() → dynamic import.
+     This ensures the dynamic `await import('../gpu/gpu-load.js')` inside
+     ensureSidecarEngineReady resolves to the test's mock, not the module cache. */
+  afterEach(() => {
+    vi.doUnmock('../gpu/gpu-load.js');
+    vi.doUnmock('../workspace/user-settings.js');
+    vi.resetModules();
+  });
+
+  it('wraps the load in withGpuLoad (the gate runs before /load on a constrained card)', async () => {
+    const order: string[] = [];
+    vi.resetModules();
+    vi.doMock('../workspace/user-settings.js', () => ({
+      getResolvedSidecarUrl: () => 'http://localhost:9000',
+      readConfigOverrides: () => ({}),
+    }));
+    vi.doMock('../gpu/gpu-load.js', () => ({
+      withGpuLoad: async (fn: () => Promise<unknown>) => { order.push('gpu-load-gate'); return fn(); },
+      GpuBusyError: class extends Error {},
+    }));
+    vi.stubGlobal('fetch', vi.fn(async () => { order.push('load'); return { ok: true, json: async () => ({ status: 'ready' }) }; }));
+    const { ensureSidecarEngineReady: ensureReady } = await import('./ensure-sidecar-loaded.js');
+    await ensureReady('qwen', undefined, { timeoutMs: 1000, pollIntervalMs: 10 });
+    expect(order[0]).toBe('gpu-load-gate');
+    expect(order).toContain('load');
+  });
+
+  it('does NOT engage the gate for a cloud / non-sidecar engine', async () => {
+    const gate = vi.fn(async (fn: () => Promise<unknown>) => fn());
+    vi.resetModules();
+    vi.doMock('../gpu/gpu-load.js', () => ({ withGpuLoad: gate, GpuBusyError: class extends Error {} }));
+    const { ensureSidecarEngineReady: ensureReady } = await import('./ensure-sidecar-loaded.js');
+    await ensureReady('gemini' as never);
+    expect(gate).not.toHaveBeenCalled();
   });
 });

--- a/server/src/tts/ensure-sidecar-loaded.ts
+++ b/server/src/tts/ensure-sidecar-loaded.ts
@@ -120,7 +120,9 @@ export async function ensureSidecarEngineReady(
       if (outcome.ready) return; // resolves the withGpuLoad callback; ensureSidecarEngineReady then returns void
       lastReason = outcome.reason;
       if (Date.now() >= deadline) {
-        console.warn(`[generation] preload ${engine}: not ready after ${timeoutMs}ms (last: ${lastReason}) — falling back to lazy load.`);
+        console.warn(
+          `[generation] preload ${engine}: not ready after ${timeoutMs}ms (last: ${lastReason}) — falling back to lazy load.`,
+        );
         return;
       }
       await sleep(pollIntervalMs, signal);

--- a/server/src/tts/ensure-sidecar-loaded.ts
+++ b/server/src/tts/ensure-sidecar-loaded.ts
@@ -106,26 +106,26 @@ export async function ensureSidecarEngineReady(
   if (!SIDECAR_ENGINES.has(engine)) return; // cloud / unknown — nothing to load
   if (signal?.aborted) throw new DOMException('preload aborted', 'AbortError');
 
+  const { withGpuLoad } = await import('../gpu/gpu-load.js');
   const target = `${getResolvedSidecarUrl()}/load`;
   const timeoutMs = opts.timeoutMs ?? READINESS_TIMEOUT_MS;
   const pollIntervalMs = opts.pollIntervalMs ?? POLL_INTERVAL_MS;
   const deadline = Date.now() + timeoutMs;
   let lastReason = 'unknown';
 
-  for (;;) {
-    if (signal?.aborted) throw new DOMException('preload aborted', 'AbortError');
-    const outcome = await tryLoadOnce(target, engine, signal);
-    if (outcome.ready) return;
-    lastReason = outcome.reason;
-    if (Date.now() >= deadline) {
-      console.warn(
-        `[generation] preload ${engine}: not ready after ${timeoutMs}ms (last: ${lastReason}) — ` +
-          `falling back to lazy load.`,
-      );
-      return;
+  await withGpuLoad(async () => {
+    for (;;) {
+      if (signal?.aborted) throw new DOMException('preload aborted', 'AbortError');
+      const outcome = await tryLoadOnce(target, engine, signal);
+      if (outcome.ready) return; // resolves the withGpuLoad callback; ensureSidecarEngineReady then returns void
+      lastReason = outcome.reason;
+      if (Date.now() >= deadline) {
+        console.warn(`[generation] preload ${engine}: not ready after ${timeoutMs}ms (last: ${lastReason}) — falling back to lazy load.`);
+        return;
+      }
+      await sleep(pollIntervalMs, signal);
     }
-    await sleep(pollIntervalMs, signal);
-  }
+  });
 }
 
 /* Abort-aware sleep — resolves after `ms`, or rejects promptly if `signal`


### PR DESCRIPTION
## Summary

Wave 1 of the GPU-residency work (spec: `docs/superpowers/specs/2026-06-16-vram-budget-aware-gpu-policy-design.md`, plan: `docs/superpowers/plans/2026-06-16-wave1-gpu-eviction-residency.md`). Makes it safe to keep `qwen3.5:9b` resident across the analysis loop — which kills the per-section ~6.35 GB unload/reload tax (the VRAM sawtooth + mid-stream "no response" stalls, worst on Cyrillic manuscripts that need the larger model).

**The flip alone is unsafe** (a resident 9B can't co-reside with a sidecar TTS/VoiceDesign load on an 8 GB card → OOM). This PR adds the eviction guard the flip depends on:

- **`gpu/vram-state.ts`** — last-known VRAM cache, populated from the sidecar `/health` probe, resilient to sidecar respawn (only a reachable probe updates it).
- **`gpu/residency.ts`** — `shouldEvictBeforeSidecarLoad`: a single VRAM threshold (`gpu.safeCoexistMb`, default 11000). 8 GB → evict; 12/16 GB → coexist; CPU → never; unknown → conservative evict.
- **`unloadResidentOllama` / `verifyOllamaEvicted`** (extracted from the `/unload` route) — evict **all** residents (so a phase-env / quant-tagged resident isn't missed), then confirm they're gone.
- **`gpu/gpu-load.ts` `withGpuLoad`** — the single chokepoint: on a constrained card it takes a dedicated load-mutex, **refuses** (`GpuBusyError` → 409) if an analysis is in flight, else evicts → verifies (fail-closed) → runs the load **inside the lock**; on a roomy card / CPU it's a passthrough.
- Wired **server-side** into the generation preload (`ensureSidecarEngineReady`) and **voice design** (`designQwenVoiceForCharacter`, 409 mapping) — the gap the frontend Load button never covered.
- **CPU residency gate** — the 9B is pinned resident only on a GPU (won't hog system RAM on a CPU-only box).

Closes the loop the frontend-only eviction left open. The design + plan were hardened across three adversarial-review passes (correctness/safety, scope, subagent-executability) — see the spec's §11 and the plan's "review fixes baked in."

## Test plan

- Unit: `vram-state` cache (respawn-resilient), `residency` threshold across cpu/null/8/12/16 GB, `unloadResidentOllama` (evict-all) + `verifyOllamaEvicted`, `withGpuLoad` (evict→verify→load order, 12 GB bypass, refuse-on-busy, fail-closed), `keepAliveFor` × accelerator.
- Integration: generation preload runs the gate before `/load`; voice design returns 409 when busy; `cast-design` unaffected.
- Regression: `gpu/eviction-regression.test.ts` pins evict-precedes-load + refuse-on-analysis-busy on 8 GB.
- `npm run verify` green (lint + typecheck + config:check + all tests + e2e + build), single-fork.

## Note

The `keep_alive` flip rides in this PR (it's only safe with the eviction). Built on top of Wave 0 (#839, already merged). Deferred to a later wave: the full MB-accounting policy + two-model-split UI (only needed once 12/16 GB hardware is in play).

🤖 Generated with [Claude Code](https://claude.com/claude-code)