### PR TITLE
feat(frontend,server): analysing-view model honesty + per-chapter section progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,10 @@ audiobook-workspace/
 # are checked in and the MOBI/AZW3 e2e cases skip cleanly when these are absent.
 server/src/parsers/__fixtures__/sample.mobi
 server/src/parsers/__fixtures__/sample.azw3
+
+# Ad-hoc local repro / bisect scripts (and their scratch output) for one-off
+# debugging — e.g. the Russian stage-2 under-production probes. Local only,
+# never committed; also excluded from lint (see eslint.config.js).
+server/repro-*.mts
+server/repro-*.txt
+server/roster.json

--- a/docs/superpowers/plans/2026-06-16-wave2-3-analysing-honesty-progress.md
+++ b/docs/superpowers/plans/2026-06-16-wave2-3-analysing-honesty-progress.md
@@ -1,0 +1,89 @@
+# Wave 2+3 — analysing-view model honesty + section progress — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]` checkboxes.
+
+**Goal:** (W2) the analysing model chip mirrors the model the server *actually resolved/ran*, not the local Redux selection; (W3) per-chapter progress shows "section M/N" with a sub-bar instead of only elapsed/est.
+
+**Architecture:** Both are additive SSE enrichments. The server already computes `activeModelId`/`phase1ModelId` and tracks `sectionsDone/sectionsTotal` in `castInFlight`; it just doesn't *emit* them to the client. Add the fields to the existing phase/live payloads, thread through `src/lib/api.ts` types + handlers, and render in `phase-model-chip.tsx` / `phase-card.tsx`'s `LiveChapterRow`.
+
+**Tech Stack:** TS, Vitest + RTL (frontend), Vitest node (server), Playwright e2e.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-vram-budget-aware-gpu-policy-design.md` §5 (label) + §6 (progress).
+
+**Branch:** `feat/frontend-analysing-honesty-progress` (off `main`, already checked out).
+
+**Seam anchors (verified):**
+- Chip: `src/components/analysing/phase-model-chip.tsx` (reads Redux `account.analyzerPhase0Model`/`phase1Model`, `ui.selectedModel*`; label via `MODEL_OPTIONS` in `src/lib/models.ts`).
+- View: `src/views/analysing.tsx` (`onPhase` handler; per-phase state buckets like `heartbeatByPhase`).
+- Server phase emit: `server/src/routes/analysis.ts` — `activeModelId` (`:2075`), `phase1ModelId` (`:3127`); phase events `send({ kind:'phase', phaseId, progress, label })` at `:2413/:2538/:2801/:2950/:3082/:3115`; throttle events already carry `model` (`:2747/:3451`).
+- Live ticker: `sendCastLiveTick()` (`:2586-2619`), maps `castInFlight` (`sectionsDone/sectionsTotal` at `:2581-2584/:2673-2674`) → `chapters[]` (currently WITHOUT section fields).
+- Client types: `AnalysisStreamEvent` (`src/lib/api.ts:~2245`), `AnalysisLiveChapter`/`AnalysisLiveInfo` (`src/lib/api.ts:~126-135`); phase handler (`:~2365`).
+- Render: `LiveChapterRow` (`src/components/analysing/phase-card.tsx:42-76`), `LiveChapterTicker` mounted at `:457`.
+- Tests: `phase-model-chip.test.tsx`, `phase-card.test.tsx`; e2e `e2e/analysing-multi-model.spec.ts` (mock stream `ANALYSIS_NORTHERN_STAR` in `src/mocks/canned-data.ts`).
+
+---
+
+## W2 — model-label honesty
+
+### Task 1: Server emits the resolved `model` on phase events
+
+**Files:** Modify `server/src/routes/analysis.ts`; Test `server/src/routes/analysis.test.ts`.
+
+- [ ] **Step 1 — failing test:** add a test asserting that a `phase` SSE event for phase 0 carries `model` equal to the resolved analyzer id (mirror the existing analysis.test.ts harness that captures emitted events). Assert `phase` events include `model: <resolved>` for phase 0 (and phase1ModelId for phase 1 where applicable).
+- [ ] **Step 2 — run red:** `cd server && npx vitest run src/routes/analysis.test.ts -t "phase event carries model"` → FAIL.
+- [ ] **Step 3 — implement:** at each phase `send({ kind: 'phase', phaseId, progress, label })` site (`:2413/:2538/:2801/:2950/:3082/:3115`), add `model:` — use `activeModelId` for the phase-0/cast sites and `phase1ModelId` for the phase-1/attribution sites (match the variable in scope at each site; read the surrounding code to pick the right one). Keep it a string id (the client maps id→label).
+- [ ] **Step 4 — run green** + full `cd server && npx vitest run src/routes/analysis.test.ts`.
+- [ ] **Step 5 — commit** `LOW_CONCURRENCY=1 git commit -m "feat(server): emit resolved analyzer model on analysis phase events"`.
+
+### Task 2: Frontend chip mirrors the server model
+
+**Files:** `src/lib/api.ts` (type + handler), `src/views/analysing.tsx` (capture), `src/components/analysing/phase-card.tsx` (pass-through), `src/components/analysing/phase-model-chip.tsx` (prefer serverModel); Tests: `phase-model-chip.test.tsx` + e2e `e2e/analysing-multi-model.spec.ts`.
+
+- [ ] **Step 1 — failing unit test** in `phase-model-chip.test.tsx`: when a `serverModel` prop is provided, the chip renders THAT model's label (via MODEL_OPTIONS) regardless of the Redux selection. (Render with Redux set to 4B + `serverModel='qwen3.5:9b'` → expect "Qwen3.5 9B (local)".)
+- [ ] **Step 2 — run red.**
+- [ ] **Step 3 — implement (client wiring):**
+  - `src/lib/api.ts`: add `model?: string` to the `phase` variant of `AnalysisStreamEvent` (~:2245) and extract it in the phase handler (~:2365) into the `onPhase` payload (extend `onPhase`'s arg type with `model?: string`).
+  - `src/views/analysing.tsx`: add a `serverModelByPhase` state bucket (mirror `heartbeatByPhase`); in `onPhase`, `setServerModelByPhase(prev => payload.model ? { ...prev, [phaseId]: payload.model } : prev)`. Pass `serverModelByPhase` to the PhaseCard(s).
+  - `phase-card.tsx`: accept `serverModelByPhase?: Record<number,string>`; pass `serverModel={serverModelByPhase?.[p.id]}` to `<PhaseModelChip>`.
+  - `phase-model-chip.tsx`: accept `serverModel?: string`; in the label derivation, prefer `serverModel` over the Redux-derived id when present (`const modelId = serverModel ?? <existing redux-derived id>`). Pre-stream (no serverModel yet) keeps the existing Redux behavior.
+- [ ] **Step 4 — run green:** `npm test -- phase-model-chip` and the view test if present.
+- [ ] **Step 5 — e2e:** extend `e2e/analysing-multi-model.spec.ts` (or add a case) so the mock stream emits a phase `model` that DIFFERS from the default selection, and assert the chip shows the server-reported label. (Check `ANALYSIS_NORTHERN_STAR` in `src/mocks/canned-data.ts` for how phase events are shaped; add `model` there if the mock drives the chip.)
+- [ ] **Step 6 — commit** `feat(frontend): analysing chip mirrors the server-resolved analyzer model`.
+
+---
+
+## W3 — per-chapter section progress
+
+### Task 3: Server includes section counts in the live tick
+
+**Files:** Modify `server/src/routes/analysis.ts` (`sendCastLiveTick`, `:2586-2619`); Test `server/src/routes/analysis.test.ts`.
+
+- [ ] **Step 1 — failing test:** assert a `phase`/live tick's `chapters[]` entries include `sectionsDone`/`sectionsTotal` from the `castInFlight` slot (drive a chunked-chapter scenario in the existing harness, or unit-test the mapping if extractable).
+- [ ] **Step 2 — run red.**
+- [ ] **Step 3 — implement:** in the `castInFlight` → `chapters[]` map (`:2600-2615`), add `sectionsDone: r.sectionsDone` and `sectionsTotal: r.sectionsTotal` to each entry. (They already live on the slot at `:2581-2584/:2673-2674`.)
+- [ ] **Step 4 — run green** (`analysis.test.ts`).
+- [ ] **Step 5 — commit** `feat(server): surface per-chapter section counts in the analysis live tick`.
+
+### Task 4: Frontend renders the section sub-bar
+
+**Files:** `src/lib/api.ts` (`AnalysisLiveChapter` type), `src/components/analysing/phase-card.tsx` (`LiveChapterRow`); Tests: `phase-card.test.tsx` + e2e.
+
+- [ ] **Step 1 — failing unit test** in `phase-card.test.tsx`: a `LiveChapterRow`/ticker given a chapter with `sectionsTotal: 4, sectionsDone: 3` renders "section 3/4" (and a sub-bar element); a chapter with `sectionsTotal` ≤ 1 renders NO section line.
+- [ ] **Step 2 — run red.**
+- [ ] **Step 3 — implement:**
+  - `src/lib/api.ts`: add `sectionsDone?: number; sectionsTotal?: number;` to `AnalysisLiveChapter` (~:126-131).
+  - `phase-card.tsx` `LiveChapterRow` (`:42-76`): when `chapter.sectionsTotal && chapter.sectionsTotal > 1`, render a `· section {sectionsDone}/{sectionsTotal}` line + a thin sub-bar (`width: (sectionsDone/sectionsTotal)*100%`), using existing token classes (no hex literals; match the file's `text-ink/50`, `bg-ink/10` patterns).
+- [ ] **Step 4 — run green:** `npm test -- phase-card`.
+- [ ] **Step 5 — e2e:** add/extend an `e2e/analysing-*.spec.ts` case so the mock live tick includes `sectionsTotal>1` and assert the section text/sub-bar renders. (Add section fields to the mock live payload in `canned-data.ts` if needed.)
+- [ ] **Step 6 — commit** `feat(frontend): per-chapter section sub-bar in the analysing live ticker`.
+
+---
+
+## Finalize
+- [ ] `npm run config:check` (no registry change here, but confirm clean), then full `LOW_CONCURRENCY=1 npm run verify` (GPU idle).
+- [ ] Push branch (pre-push verify) → open PR (Refs the spec §5/§6).
+
+## Self-review notes
+- Spec coverage: §5 label (T1+T2), §6 progress (T3+T4). Both cross the streaming/redux seam → e2e is MANDATORY (T2 Step 5, T4 Step 5), per CLAUDE.md.
+- Out of scope: Wave 4 (MB-accounting policy + split UI), deferred.
+- No hex literals in render code (design-token CSS vars only). Additive SSE fields are optional (back-compat: an older client ignores them; a newer client tolerates their absence).

--- a/e2e/analysing-multi-model.spec.ts
+++ b/e2e/analysing-multi-model.spec.ts
@@ -196,4 +196,19 @@ test.describe('plan 95 — analysing multi-model UI + sticky bar', () => {
       .poll(async () => (await readAccountSlice(page)).analyzerPhase0Model, { timeout: 5_000 })
       .toBe('gemini-3.1-flash-lite');
   });
+
+  test('live ticker shows "section M/N" sub-bar when mock emits sectionsDone/sectionsTotal', async ({
+    page,
+  }) => {
+    /* The mock analysis stream (mockAnalyseManuscript in src/lib/api.ts)
+       emits a live payload with sectionsDone:2 / sectionsTotal:5 on Phase 0
+       between 40–70% progress. Assert the section text renders in the ticker
+       before the phase completes. */
+    await bootFreshBookIntoAnalysing(page);
+    await page.getByRole('button', { name: /Start analysis/i }).click();
+    /* Wait for the live ticker to appear with section info. The mock emits
+       the live payload during Phase 0 progress 40–70%, so it will appear
+       while Phase 0 is streaming. */
+    await expect(page.getByText(/section 2\/5/i)).toBeVisible({ timeout: 8_000 });
+  });
 });

--- a/e2e/analysing-multi-model.spec.ts
+++ b/e2e/analysing-multi-model.spec.ts
@@ -80,21 +80,22 @@ test.describe('plan 95 — analysing multi-model UI + sticky bar', () => {
     await expect(page.getByTestId('phase-model-chip-2')).toHaveCount(0);
   });
 
-  test('single-model (no split): both chips name the same model and Phase 1 shows no warm-up hint', async ({
+  test('single-model (no split): both chips name the server-reported model and Phase 1 shows no warm-up hint', async ({
     page,
   }) => {
     await bootFreshBookIntoAnalysing(page);
     await page.getByRole('button', { name: /Start analysis/i }).click();
     const phase1 = page.getByTestId('phase-model-chip-1');
     await expect(phase1).toBeVisible({ timeout: 5_000 });
-    /* No per-phase split is configured (fresh account), so both phases run
-       the single effective model — the mock default is Gemini 3.1 Flash Lite
-       (FRONTEND_ACCOUNT_DEFAULTS.defaultAnalysisModel). The old chip
-       fabricated "Gemma 4 31B" for Phase 0; plan 118 makes it honest. */
+    /* The mock analysis stream emits `model: 'qwen3.5:9b'` on every phase
+       event (Task 2 — the mock exercises the "server ran a different model
+       than the UI default" path). With Task 2 wired, the chip now prefers
+       the server-reported id over the Redux selection (Gemini 3.1 Flash Lite),
+       so both chips must show the 9B label once the SSE arrives. */
     await expect(page.getByTestId('phase-model-chip-0').first()).toContainText(
-      'Gemini 3.1 Flash Lite',
+      'Qwen3.5 9B (local)',
     );
-    await expect(phase1).toContainText('Gemini 3.1 Flash Lite');
+    await expect(phase1.first()).toContainText('Qwen3.5 9B (local)');
     /* And no false promise of a handoff that won't happen with the split off. */
     await expect(phase1).not.toContainText(/warms up/i);
   });
@@ -149,6 +150,22 @@ test.describe('plan 95 — analysing multi-model UI + sticky bar', () => {
        Resume button takes over. */
     await expect(page.getByTestId('sticky-pause-button')).toHaveCount(0);
     await expect(page.getByRole('button', { name: /Resume analysis/i })).toBeVisible();
+  });
+
+  test('chip shows the server-reported model label, not the Redux default', async ({ page }) => {
+    /* The mock analysis stream (mockAnalyseManuscript in src/lib/api.ts)
+       emits `model: 'qwen3.5:9b'` on every phase event.  The Redux default
+       for a fresh account is Gemini 3.1 Flash Lite.  Task 2 wires the chip
+       to prefer the server-reported model id over the Redux selection, so
+       once the first phase event arrives the chip must flip to the 9B label
+       rather than the UI's default. */
+    await bootFreshBookIntoAnalysing(page);
+    await page.getByRole('button', { name: /Start analysis/i }).click();
+    const chip0 = page.getByTestId('phase-model-chip-0').first();
+    await expect(chip0).toBeVisible({ timeout: 5_000 });
+    /* Server emitted qwen3.5:9b — chip must reflect that, not the Redux default. */
+    await expect(chip0).toContainText('Qwen3.5 9B (local)');
+    await expect(chip0).not.toContainText('Gemini');
   });
 
   test('Phase 0 model swap writes the saveAccountSettings patch + surfaces the toast', async ({

--- a/e2e/analysing-multi-model.spec.ts
+++ b/e2e/analysing-multi-model.spec.ts
@@ -48,9 +48,7 @@ async function bootFreshBookIntoAnalysing(page: Page) {
   await page.getByRole('button', { name: /Paste text/i }).click();
   await page
     .locator('textarea')
-    .fill(
-      '# The Plan 95 Book\n\n# Chapter 1\n\nA tiny chapter.\n\n# Chapter 2\n\nAnother.\n',
-    );
+    .fill('# The Plan 95 Book\n\n# Chapter 1\n\nA tiny chapter.\n\n# Chapter 2\n\nAnother.\n');
   await page.getByRole('button', { name: /Upload pasted text/i }).click();
   await expect(page.getByRole('button', { name: /Save book and start analysis/i })).toBeVisible({
     timeout: 5_000,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -44,6 +44,9 @@ export default tseslint.config(
       'e2e/**/__snapshots__/',
       'audiobook-workspace/',
       'src/lib/api-types.ts',
+      // Ad-hoc, local-only repro/bisect scripts (e.g. server/repro-attribution.mts).
+      // Throwaway debugging probes — git-ignored and not held to the lint bar.
+      'server/repro-*.mts',
     ],
   },
 

--- a/server/src/routes/analysis.phase-model.test.ts
+++ b/server/src/routes/analysis.phase-model.test.ts
@@ -1,0 +1,272 @@
+/* Phase-event model propagation — regression for "phase events carry the
+   resolved analyzer model id."
+
+   The route already emits `model` on throttle events (plan-88 precedent).
+   This suite pins the matching contract for plain `phase` events: every
+   phase-0 event must carry `model === phase0ModelId` and every phase-1
+   event must carry `model === phase1ModelId`.
+
+   Uses the same spy-analyzer + stub-manuscript harness as
+   analysis-pipelining.test.ts so no network / Ollama calls are made. */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { runMainAnalyzerJob, type AnalysisJob } from './analysis.js';
+import { clearAnalysisCache } from '../store/analysis-cache.js';
+import type { Analyzer, AnalyzerSelection, StageCall } from '../analyzer/index.js';
+import type {
+  Stage1ChapterOutput,
+  Stage1Output,
+  Stage2ChapterOutput,
+} from '../handoff/schemas.js';
+import type { ChapterHint } from '../store/manuscripts.js';
+import { putManuscript, removeManuscript } from '../store/manuscripts.js';
+
+/* ── spy analyzer / selection helpers (mirrors analysis-pipelining.test.ts) */
+
+function buildSpyPhase0Analyzer(): Analyzer {
+  return {
+    async runStage1(): Promise<Stage1Output> {
+      throw new Error('runStage1 not used in this suite');
+    },
+    async runStage1Chapter(
+      _manuscriptId: string,
+      chapterId: number,
+    ): Promise<Stage1ChapterOutput> {
+      return {
+        characters: [
+          {
+            id: 'narrator',
+            name: 'Narrator',
+            role: 'narrator',
+            color: 'narrator',
+            evidence: [
+              { quote: 'lorem ipsum dolor sit amet' },
+              { quote: 'lorem ipsum dolor sit amet' },
+              { quote: 'lorem ipsum dolor sit amet' },
+            ],
+          },
+          {
+            id: `ch${chapterId}-char`,
+            name: `Character_ch${chapterId}`,
+            role: 'character',
+            color: 'unset',
+            evidence: [
+              { quote: 'lorem ipsum dolor sit amet' },
+              { quote: 'lorem ipsum dolor sit amet' },
+              { quote: 'lorem ipsum dolor sit amet' },
+            ],
+          },
+        ],
+      };
+    },
+    async runStage2Chapter(): Promise<Stage2ChapterOutput> {
+      throw new Error('Phase-0 analyzer does not run Phase-1 calls');
+    },
+    async runEmotionChapter() {
+      throw new Error('Phase-0 analyzer does not run emotion calls');
+    },
+  };
+}
+
+function buildSpyPhase1Analyzer(): Analyzer {
+  return {
+    async runStage1(): Promise<Stage1Output> {
+      throw new Error('runStage1 not used in this suite');
+    },
+    async runStage1Chapter(): Promise<Stage1ChapterOutput> {
+      throw new Error('Phase-1 analyzer does not run Phase-0 calls');
+    },
+    async runStage2Chapter(
+      _manuscriptId: string,
+      chapterId: number,
+      _prompt: string,
+      _call: StageCall,
+    ): Promise<Stage2ChapterOutput> {
+      return {
+        sentences: [
+          {
+            id: chapterId * 100 + 1,
+            chapterId,
+            characterId: 'narrator',
+            text: 'lorem ipsum dolor sit amet.',
+          },
+        ],
+      };
+    },
+    async runEmotionChapter() {
+      throw new Error('Phase-1 analyzer does not run emotion calls');
+    },
+  };
+}
+
+function buildSelection(analyzer: Analyzer, model: string): AnalyzerSelection {
+  return { analyzer, engine: 'gemini', model, fallbackModel: null };
+}
+
+function buildStubJob(manuscriptId: string): AnalysisJob {
+  return {
+    controller: new AbortController(),
+    subscribers: new Set(),
+    manuscriptId,
+    kind: 'main',
+    bookDir: null,
+    engine: 'gemini',
+    replay: {
+      logs: [],
+      lastPhase: null,
+      lastEta: null,
+      lastCastUpdate: null,
+      failedByChapterId: new Map(),
+      lastSeriesPrior: null,
+    },
+    lastDiskWriteAt: 0,
+  };
+}
+
+function buildStubChapters(count: number): ChapterHint[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    title: `Chapter ${i + 1}`,
+    body: `Chapter ${i + 1} body. ` + 'lorem ipsum dolor sit amet '.repeat(50),
+  }));
+}
+
+function registerStubManuscript(id: string, count: number): void {
+  const chapterHints = buildStubChapters(count);
+  putManuscript({
+    manuscriptId: id,
+    format: 'plaintext',
+    title: `Stub ${id}`,
+    wordCount: chapterHints.length * 100,
+    byteSize: 100_000,
+    uploadedAt: new Date().toISOString(),
+    sourceText: chapterHints.map((c) => c.body).join('\n\n'),
+    chapterHints,
+  });
+}
+
+/* ── vi.mock for select-analyzer so the route picks our spy analyzers. ── */
+
+vi.mock('../analyzer/select-analyzer.js', async () => {
+  const actual = await vi.importActual<typeof import('../analyzer/select-analyzer.js')>(
+    '../analyzer/select-analyzer.js',
+  );
+  return {
+    ...actual,
+    selectAnalyzerForPhase: (opts: { phase: 'phase0' | 'phase1' }) => {
+      const g = globalThis as Record<string, unknown>;
+      if (opts.phase === 'phase1' && g.__phase_model_test_phase1_selection) {
+        return g.__phase_model_test_phase1_selection;
+      }
+      return actual.selectAnalyzerForPhase(opts as Parameters<typeof actual.selectAnalyzerForPhase>[0]);
+    },
+    isPerPhaseModelSelectionActive: () => {
+      /* Always return false (sequential mode) — keeps Phase 1 simple and
+         deterministic without needing to fiddle with lag semaphores. */
+      return false;
+    },
+  };
+});
+
+function setPhase1Selection(sel: AnalyzerSelection): void {
+  (globalThis as Record<string, unknown>).__phase_model_test_phase1_selection = sel;
+}
+
+function clearPhase1Selection(): void {
+  delete (globalThis as Record<string, unknown>).__phase_model_test_phase1_selection;
+}
+
+afterEach(() => {
+  clearPhase1Selection();
+});
+
+/* ── captured-events helper ── */
+
+interface CapturedEvent {
+  kind: string;
+  [k: string]: unknown;
+}
+
+function attachEventCapture(job: AnalysisJob): CapturedEvent[] {
+  const events: CapturedEvent[] = [];
+  const sub = {
+    send: (payload: unknown) => {
+      if (payload && typeof payload === 'object') {
+        events.push(payload as CapturedEvent);
+      }
+    },
+    res: { end: () => {} } as unknown as import('express').Response,
+    keepAlive: setInterval(() => {}, 100_000) as NodeJS.Timeout,
+  };
+  /* Clear the keepAlive so the test process doesn't hang. */
+  clearInterval(sub.keepAlive);
+  job.subscribers.add(sub);
+  return events;
+}
+
+/* ── Suite: phase events carry the resolved model id ─────────────────── */
+
+describe('phase events carry the resolved model id', () => {
+  it(
+    'phase-0 events have model===phase0ModelId; phase-1 events have model===phase1ModelId',
+    async () => {
+      const PHASE0_MODEL = 'gemma-phase0-test-model';
+      const PHASE1_MODEL = 'gemini-phase1-test-model';
+
+      const manuscriptId = `test-phase-model-${Date.now()}`;
+      registerStubManuscript(manuscriptId, 2);
+
+      /* Disable the stage-2 coverage guard (plan 181): stub responses are
+         intentionally minimal and would fail coverage, tripling call counts.
+         This is the same pattern as analysis-pipelining.test.ts. */
+      const origCovRetries = process.env.STAGE2_COVERAGE_RETRIES;
+      process.env.STAGE2_COVERAGE_RETRIES = '0';
+
+      const phase0Analyzer = buildSpyPhase0Analyzer();
+      const phase1Analyzer = buildSpyPhase1Analyzer();
+      const phase0Selection = buildSelection(phase0Analyzer, PHASE0_MODEL);
+      const phase1Selection = buildSelection(phase1Analyzer, PHASE1_MODEL);
+      setPhase1Selection(phase1Selection);
+
+      const job = buildStubJob(manuscriptId);
+      const events = attachEventCapture(job);
+
+      try {
+        const { getManuscript } = await import('../store/manuscripts.js');
+        const recordRef = getManuscript(manuscriptId);
+        if (!recordRef) throw new Error('stub manuscript not found');
+
+        await runMainAnalyzerJob(job, recordRef as never, phase0Selection, {
+          requestedFresh: true,
+          allowStage1Shrink: true,
+          requestedModel: undefined,
+        });
+
+        const phaseEvents = events.filter((e) => e.kind === 'phase') as Array<
+          CapturedEvent & { phaseId: number; model?: string }
+        >;
+
+        /* Must have emitted at least one phase-0 and one phase-1 event. */
+        const phase0Events = phaseEvents.filter((e) => e.phaseId === 0);
+        const phase1Events = phaseEvents.filter((e) => e.phaseId === 1);
+        expect(phase0Events.length).toBeGreaterThan(0);
+        expect(phase1Events.length).toBeGreaterThan(0);
+
+        /* Every phase-0 event must carry the resolved phase-0 model id. */
+        for (const ev of phase0Events) {
+          expect(ev.model, `phase-0 event missing model: ${JSON.stringify(ev)}`).toBe(PHASE0_MODEL);
+        }
+
+        /* Every phase-1 event must carry the resolved phase-1 model id. */
+        for (const ev of phase1Events) {
+          expect(ev.model, `phase-1 event missing model: ${JSON.stringify(ev)}`).toBe(PHASE1_MODEL);
+        }
+      } finally {
+        removeManuscript(manuscriptId);
+        await clearAnalysisCache(manuscriptId);
+        process.env.STAGE2_COVERAGE_RETRIES = origCovRetries;
+      }
+    },
+    60_000,
+  );
+});

--- a/server/src/routes/analysis.phase-model.test.ts
+++ b/server/src/routes/analysis.phase-model.test.ts
@@ -13,11 +13,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { runMainAnalyzerJob, type AnalysisJob } from './analysis.js';
 import { clearAnalysisCache } from '../store/analysis-cache.js';
 import type { Analyzer, AnalyzerSelection, StageCall } from '../analyzer/index.js';
-import type {
-  Stage1ChapterOutput,
-  Stage1Output,
-  Stage2ChapterOutput,
-} from '../handoff/schemas.js';
+import type { Stage1ChapterOutput, Stage1Output, Stage2ChapterOutput } from '../handoff/schemas.js';
 import type { ChapterHint } from '../store/manuscripts.js';
 import { putManuscript, removeManuscript } from '../store/manuscripts.js';
 
@@ -28,10 +24,7 @@ function buildSpyPhase0Analyzer(): Analyzer {
     async runStage1(): Promise<Stage1Output> {
       throw new Error('runStage1 not used in this suite');
     },
-    async runStage1Chapter(
-      _manuscriptId: string,
-      chapterId: number,
-    ): Promise<Stage1ChapterOutput> {
+    async runStage1Chapter(_manuscriptId: string, chapterId: number): Promise<Stage1ChapterOutput> {
       return {
         characters: [
           {
@@ -158,7 +151,9 @@ vi.mock('../analyzer/select-analyzer.js', async () => {
       if (opts.phase === 'phase1' && g.__phase_model_test_phase1_selection) {
         return g.__phase_model_test_phase1_selection;
       }
-      return actual.selectAnalyzerForPhase(opts as Parameters<typeof actual.selectAnalyzerForPhase>[0]);
+      return actual.selectAnalyzerForPhase(
+        opts as Parameters<typeof actual.selectAnalyzerForPhase>[0],
+      );
     },
     isPerPhaseModelSelectionActive: () => {
       /* Always return false (sequential mode) — keeps Phase 1 simple and
@@ -207,66 +202,62 @@ function attachEventCapture(job: AnalysisJob): CapturedEvent[] {
 /* ── Suite: phase events carry the resolved model id ─────────────────── */
 
 describe('phase events carry the resolved model id', () => {
-  it(
-    'phase-0 events have model===phase0ModelId; phase-1 events have model===phase1ModelId',
-    async () => {
-      const PHASE0_MODEL = 'gemma-phase0-test-model';
-      const PHASE1_MODEL = 'gemini-phase1-test-model';
+  it('phase-0 events have model===phase0ModelId; phase-1 events have model===phase1ModelId', async () => {
+    const PHASE0_MODEL = 'gemma-phase0-test-model';
+    const PHASE1_MODEL = 'gemini-phase1-test-model';
 
-      const manuscriptId = `test-phase-model-${Date.now()}`;
-      registerStubManuscript(manuscriptId, 2);
+    const manuscriptId = `test-phase-model-${Date.now()}`;
+    registerStubManuscript(manuscriptId, 2);
 
-      /* Disable the stage-2 coverage guard (plan 181): stub responses are
+    /* Disable the stage-2 coverage guard (plan 181): stub responses are
          intentionally minimal and would fail coverage, tripling call counts.
          This is the same pattern as analysis-pipelining.test.ts. */
-      const origCovRetries = process.env.STAGE2_COVERAGE_RETRIES;
-      process.env.STAGE2_COVERAGE_RETRIES = '0';
+    const origCovRetries = process.env.STAGE2_COVERAGE_RETRIES;
+    process.env.STAGE2_COVERAGE_RETRIES = '0';
 
-      const phase0Analyzer = buildSpyPhase0Analyzer();
-      const phase1Analyzer = buildSpyPhase1Analyzer();
-      const phase0Selection = buildSelection(phase0Analyzer, PHASE0_MODEL);
-      const phase1Selection = buildSelection(phase1Analyzer, PHASE1_MODEL);
-      setPhase1Selection(phase1Selection);
+    const phase0Analyzer = buildSpyPhase0Analyzer();
+    const phase1Analyzer = buildSpyPhase1Analyzer();
+    const phase0Selection = buildSelection(phase0Analyzer, PHASE0_MODEL);
+    const phase1Selection = buildSelection(phase1Analyzer, PHASE1_MODEL);
+    setPhase1Selection(phase1Selection);
 
-      const job = buildStubJob(manuscriptId);
-      const events = attachEventCapture(job);
+    const job = buildStubJob(manuscriptId);
+    const events = attachEventCapture(job);
 
-      try {
-        const { getManuscript } = await import('../store/manuscripts.js');
-        const recordRef = getManuscript(manuscriptId);
-        if (!recordRef) throw new Error('stub manuscript not found');
+    try {
+      const { getManuscript } = await import('../store/manuscripts.js');
+      const recordRef = getManuscript(manuscriptId);
+      if (!recordRef) throw new Error('stub manuscript not found');
 
-        await runMainAnalyzerJob(job, recordRef as never, phase0Selection, {
-          requestedFresh: true,
-          allowStage1Shrink: true,
-          requestedModel: undefined,
-        });
+      await runMainAnalyzerJob(job, recordRef as never, phase0Selection, {
+        requestedFresh: true,
+        allowStage1Shrink: true,
+        requestedModel: undefined,
+      });
 
-        const phaseEvents = events.filter((e) => e.kind === 'phase') as Array<
-          CapturedEvent & { phaseId: number; model?: string }
-        >;
+      const phaseEvents = events.filter((e) => e.kind === 'phase') as Array<
+        CapturedEvent & { phaseId: number; model?: string }
+      >;
 
-        /* Must have emitted at least one phase-0 and one phase-1 event. */
-        const phase0Events = phaseEvents.filter((e) => e.phaseId === 0);
-        const phase1Events = phaseEvents.filter((e) => e.phaseId === 1);
-        expect(phase0Events.length).toBeGreaterThan(0);
-        expect(phase1Events.length).toBeGreaterThan(0);
+      /* Must have emitted at least one phase-0 and one phase-1 event. */
+      const phase0Events = phaseEvents.filter((e) => e.phaseId === 0);
+      const phase1Events = phaseEvents.filter((e) => e.phaseId === 1);
+      expect(phase0Events.length).toBeGreaterThan(0);
+      expect(phase1Events.length).toBeGreaterThan(0);
 
-        /* Every phase-0 event must carry the resolved phase-0 model id. */
-        for (const ev of phase0Events) {
-          expect(ev.model, `phase-0 event missing model: ${JSON.stringify(ev)}`).toBe(PHASE0_MODEL);
-        }
-
-        /* Every phase-1 event must carry the resolved phase-1 model id. */
-        for (const ev of phase1Events) {
-          expect(ev.model, `phase-1 event missing model: ${JSON.stringify(ev)}`).toBe(PHASE1_MODEL);
-        }
-      } finally {
-        removeManuscript(manuscriptId);
-        await clearAnalysisCache(manuscriptId);
-        process.env.STAGE2_COVERAGE_RETRIES = origCovRetries;
+      /* Every phase-0 event must carry the resolved phase-0 model id. */
+      for (const ev of phase0Events) {
+        expect(ev.model, `phase-0 event missing model: ${JSON.stringify(ev)}`).toBe(PHASE0_MODEL);
       }
-    },
-    60_000,
-  );
+
+      /* Every phase-1 event must carry the resolved phase-1 model id. */
+      for (const ev of phase1Events) {
+        expect(ev.model, `phase-1 event missing model: ${JSON.stringify(ev)}`).toBe(PHASE1_MODEL);
+      }
+    } finally {
+      removeManuscript(manuscriptId);
+      await clearAnalysisCache(manuscriptId);
+      process.env.STAGE2_COVERAGE_RETRIES = origCovRetries;
+    }
+  }, 60_000);
 });

--- a/server/src/routes/analysis.test.ts
+++ b/server/src/routes/analysis.test.ts
@@ -23,6 +23,7 @@ import {
   buildStage1ChapterInbox,
   readPriorCastForMerge,
   trackForReplay,
+  castInFlightEntryToLiveChapter,
 } from './analysis.js';
 import type { CharacterOutput, SentenceOutput } from '../handoff/schemas.js';
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
@@ -1779,5 +1780,41 @@ describe('readPriorCastForMerge (srv-13 carryover fallback)', () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('castInFlightEntryToLiveChapter — live tick chapter map (Phase-0a cast)', () => {
+  it('live tick chapters carry section counts', () => {
+    /* A chapter chunked into 4 sections with 2 done — the live tick entry
+       must expose sectionsDone and sectionsTotal so the frontend can render
+       section-level progress. */
+    const entry = {
+      chapterIndex: 0,
+      chapterTitle: 'Chapter One',
+      baseEstMs: 60_000,
+      startedAt: Date.now() - 30_000,
+      sectionsDone: 2,
+      sectionsTotal: 4,
+    };
+    const result = castInFlightEntryToLiveChapter(entry, Date.now());
+    expect(result.sectionsDone).toBe(2);
+    expect(result.sectionsTotal).toBe(4);
+  });
+
+  it('preserves existing chapterIndex / chapterTitle / elapsedMs / estMs fields', () => {
+    const now = Date.now();
+    const entry = {
+      chapterIndex: 2,
+      chapterTitle: 'Chapter Three',
+      baseEstMs: 30_000,
+      startedAt: now - 10_000,
+      sectionsDone: 0,
+      sectionsTotal: 1,
+    };
+    const result = castInFlightEntryToLiveChapter(entry, now);
+    expect(result.chapterIndex).toBe(3); // 0-based → 1-based
+    expect(result.chapterTitle).toBe('Chapter Three');
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(0);
+    expect(typeof result.estMs).toBe('number');
   });
 });

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -2446,7 +2446,13 @@ export async function runMainAnalyzerJob(
         0,
         `Resuming — Phase 0 already complete (${charCount} character${charCount === 1 ? '' : 's'} cached).`,
       );
-      send({ kind: 'phase', phaseId: 0, progress: 1, label: PHASES[0].label, model: activeModelId });
+      send({
+        kind: 'phase',
+        phaseId: 0,
+        progress: 1,
+        label: PHASES[0].label,
+        model: activeModelId,
+      });
       stage1 = cache.stage1;
       sortEvidence(stage1.characters);
       const verified = verifyEvidenceAgainstSource(stage1.characters, record.sourceText, (msg) =>
@@ -2571,7 +2577,13 @@ export async function runMainAnalyzerJob(
       };
 
       /* Initial cast-update + progress reflecting any cached cast. */
-      send({ kind: 'phase', phaseId: 0, progress: phase0Progress(), label: PHASES[0].label, model: activeModelId });
+      send({
+        kind: 'phase',
+        phaseId: 0,
+        progress: phase0Progress(),
+        label: PHASES[0].label,
+        model: activeModelId,
+      });
       if (cachedCastCount > 0) emitCastUpdate();
 
       /* Tasks that need to run. Excluded chapters (front/back-matter the
@@ -2824,7 +2836,13 @@ export async function runMainAnalyzerJob(
             remediation: classified.remediation,
           });
           sendCastLiveTick();
-          send({ kind: 'phase', phaseId: 0, progress: phase0Progress(), label: PHASES[0].label, model: activeModelId });
+          send({
+            kind: 'phase',
+            phaseId: 0,
+            progress: phase0Progress(),
+            label: PHASES[0].label,
+            model: activeModelId,
+          });
           return;
         }
 
@@ -2973,7 +2991,13 @@ export async function runMainAnalyzerJob(
             0,
             `Phase 0 paused — ${failedCount} chapter${failedCount === 1 ? '' : 's'} still needs cast detection (see ❌ lines above). Phase 1 won't start until every chapter has a roster — retry below or re-run analysis.`,
           );
-          send({ kind: 'phase', phaseId: 0, progress: phase0Progress(), label: PHASES[0].label, model: activeModelId });
+          send({
+            kind: 'phase',
+            phaseId: 0,
+            progress: phase0Progress(),
+            label: PHASES[0].label,
+            model: activeModelId,
+          });
           /* Release any parked Phase 1 waiters so they can observe
              `phase0FailedCount > 0` and short-circuit out of dispatch.
              Without this they'd hang forever waiting on the watermark. */
@@ -3105,7 +3129,13 @@ export async function runMainAnalyzerJob(
             `${parserChapterCount} chapter${parserChapterCount === 1 ? '' : 's'} identified in ${humanSeconds(stage1ActualMs)}`,
           );
         }
-        send({ kind: 'phase', phaseId: 0, progress: 1, label: PHASES[0].label, model: activeModelId });
+        send({
+          kind: 'phase',
+          phaseId: 0,
+          progress: 1,
+          label: PHASES[0].label,
+          model: activeModelId,
+        });
         /* Plan 88 — Phase 0b consolidation has produced the final roster
            (`stage1.characters` above). Release any remaining Phase 1
            waiters parked on the back-pressure semaphore — they'll dispatch
@@ -3138,7 +3168,13 @@ export async function runMainAnalyzerJob(
        pipelined mode parks until Phase 0 chapter `i + LAG` completes
        (the new back-pressure semaphore). */
     markPhase(1);
-    send({ kind: 'phase', phaseId: 1, progress: 0.02, label: PHASES[1].label, model: phase1ModelId });
+    send({
+      kind: 'phase',
+      phaseId: 1,
+      progress: 0.02,
+      label: PHASES[1].label,
+      model: phase1ModelId,
+    });
     const totalChapters = record.chapterHints.length;
     log(
       1,
@@ -4321,7 +4357,13 @@ async function runSubsetAnalyzerJob(
       0,
       `Re-analyzing ${toRun.length} chapter${toRun.length === 1 ? '' : 's'} via ${analyzerLabel}.`,
     );
-    send({ kind: 'phase', phaseId: 0, progress: 0.02, label: PHASES[0].label, model: subsetModelId });
+    send({
+      kind: 'phase',
+      phaseId: 0,
+      progress: 0.02,
+      label: PHASES[0].label,
+      model: subsetModelId,
+    });
 
     /* Same series-cast prior the main route uses (C2). Resolved once
        per subset retry so the prompt still recognises series-regulars
@@ -4588,7 +4630,13 @@ async function runSubsetAnalyzerJob(
       endJob(job);
       return;
     }
-    send({ kind: 'phase', phaseId: 1, progress: 0.02, label: PHASES[1].label, model: phase1ModelId });
+    send({
+      kind: 'phase',
+      phaseId: 1,
+      progress: 0.02,
+      label: PHASES[1].label,
+      model: phase1ModelId,
+    });
     for (let idx = 0; idx < toRun.length; idx++) {
       const ch = toRun[idx];
       log(1, `Chapter ${ch.id} — ${ch.title}: attributing sentences via ${phase1AnalyzerLabel}…`);

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -872,6 +872,42 @@ export function clampStageEstMs(ms: number): number {
   return Math.max(MIN_EST_MS, Math.round(ms));
 }
 
+/** Shape of a single entry in the Phase-0a cast live-tick `chapters[]` array.
+    Exported so callers (frontend type consumers, tests) can reference it. */
+export interface CastLiveChapter {
+  chapterIndex: number;
+  chapterTitle: string;
+  elapsedMs: number;
+  estMs: number;
+  /** Section progress for chunked chapters (1/1 for single-section chapters). */
+  sectionsDone: number;
+  sectionsTotal: number;
+}
+
+/** Pure mapping helper: converts one `CastInFlight`-shaped slot and a `now`
+    timestamp into the live-tick chapter entry.  Exported for unit tests. */
+export function castInFlightEntryToLiveChapter(
+  r: {
+    chapterIndex: number;
+    chapterTitle: string;
+    baseEstMs: number;
+    startedAt: number;
+    sectionsDone: number;
+    sectionsTotal: number;
+  },
+  now: number,
+): CastLiveChapter {
+  const elapsedMs = now - r.startedAt;
+  return {
+    chapterIndex: r.chapterIndex + 1,
+    chapterTitle: r.chapterTitle,
+    elapsedMs,
+    estMs: refineCastChapterEstMs(elapsedMs, r.baseEstMs, r.sectionsDone, r.sectionsTotal),
+    sectionsDone: r.sectionsDone,
+    sectionsTotal: r.sectionsTotal,
+  };
+}
+
 /* Decide whether cached per-chapter durations may seed this run's observed-
    rate tracker. The samples are only valid when the resumed run uses the SAME
    analyzer engine that produced them — a Gemini-paced duration would mis-seed
@@ -2598,22 +2634,11 @@ export async function runMainAnalyzerJob(
             running.length > 0
               ? {
                   totalChapters: totalCastChapters,
-                  chapters: running.map((r) => {
-                    /* Chapter-total elapsed (NOT the per-section call elapsed —
-                       the chunker calls the model once per section). */
-                    const elapsedMs = now - r.startedAt;
-                    return {
-                      chapterIndex: r.chapterIndex + 1,
-                      chapterTitle: r.chapterTitle,
-                      elapsedMs,
-                      estMs: refineCastChapterEstMs(
-                        elapsedMs,
-                        r.baseEstMs,
-                        r.sectionsDone,
-                        r.sectionsTotal,
-                      ),
-                    };
-                  }),
+                  /* Chapter-total elapsed (NOT the per-section call elapsed —
+                     the chunker calls the model once per section).
+                     sectionsDone/sectionsTotal are forwarded so the frontend
+                     can render section-level progress within a chapter. */
+                  chapters: running.map((r) => castInFlightEntryToLiveChapter(r, now)),
                 }
               : undefined,
         });

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -2410,7 +2410,7 @@ export async function runMainAnalyzerJob(
         0,
         `Resuming — Phase 0 already complete (${charCount} character${charCount === 1 ? '' : 's'} cached).`,
       );
-      send({ kind: 'phase', phaseId: 0, progress: 1, label: PHASES[0].label });
+      send({ kind: 'phase', phaseId: 0, progress: 1, label: PHASES[0].label, model: activeModelId });
       stage1 = cache.stage1;
       sortEvidence(stage1.characters);
       const verified = verifyEvidenceAgainstSource(stage1.characters, record.sourceText, (msg) =>
@@ -2535,7 +2535,7 @@ export async function runMainAnalyzerJob(
       };
 
       /* Initial cast-update + progress reflecting any cached cast. */
-      send({ kind: 'phase', phaseId: 0, progress: phase0Progress(), label: PHASES[0].label });
+      send({ kind: 'phase', phaseId: 0, progress: phase0Progress(), label: PHASES[0].label, model: activeModelId });
       if (cachedCastCount > 0) emitCastUpdate();
 
       /* Tasks that need to run. Excluded chapters (front/back-matter the
@@ -2593,6 +2593,7 @@ export async function runMainAnalyzerJob(
           phaseId: 0,
           progress: phase0Progress(),
           label: PHASES[0].label,
+          model: activeModelId,
           live:
             running.length > 0
               ? {
@@ -2798,7 +2799,7 @@ export async function runMainAnalyzerJob(
             remediation: classified.remediation,
           });
           sendCastLiveTick();
-          send({ kind: 'phase', phaseId: 0, progress: phase0Progress(), label: PHASES[0].label });
+          send({ kind: 'phase', phaseId: 0, progress: phase0Progress(), label: PHASES[0].label, model: activeModelId });
           return;
         }
 
@@ -2947,7 +2948,7 @@ export async function runMainAnalyzerJob(
             0,
             `Phase 0 paused — ${failedCount} chapter${failedCount === 1 ? '' : 's'} still needs cast detection (see ❌ lines above). Phase 1 won't start until every chapter has a roster — retry below or re-run analysis.`,
           );
-          send({ kind: 'phase', phaseId: 0, progress: phase0Progress(), label: PHASES[0].label });
+          send({ kind: 'phase', phaseId: 0, progress: phase0Progress(), label: PHASES[0].label, model: activeModelId });
           /* Release any parked Phase 1 waiters so they can observe
              `phase0FailedCount > 0` and short-circuit out of dispatch.
              Without this they'd hang forever waiting on the watermark. */
@@ -3079,7 +3080,7 @@ export async function runMainAnalyzerJob(
             `${parserChapterCount} chapter${parserChapterCount === 1 ? '' : 's'} identified in ${humanSeconds(stage1ActualMs)}`,
           );
         }
-        send({ kind: 'phase', phaseId: 0, progress: 1, label: PHASES[0].label });
+        send({ kind: 'phase', phaseId: 0, progress: 1, label: PHASES[0].label, model: activeModelId });
         /* Plan 88 — Phase 0b consolidation has produced the final roster
            (`stage1.characters` above). Release any remaining Phase 1
            waiters parked on the back-pressure semaphore — they'll dispatch
@@ -3112,7 +3113,7 @@ export async function runMainAnalyzerJob(
        pipelined mode parks until Phase 0 chapter `i + LAG` completes
        (the new back-pressure semaphore). */
     markPhase(1);
-    send({ kind: 'phase', phaseId: 1, progress: 0.02, label: PHASES[1].label });
+    send({ kind: 'phase', phaseId: 1, progress: 0.02, label: PHASES[1].label, model: phase1ModelId });
     const totalChapters = record.chapterHints.length;
     log(
       1,
@@ -3230,6 +3231,7 @@ export async function runMainAnalyzerJob(
         phaseId: 1,
         progress: Math.min(0.02 + 0.93 * cachedFrac, 0.95),
         label: PHASES[1].label,
+        model: phase1ModelId,
       });
     }
 
@@ -3276,6 +3278,7 @@ export async function runMainAnalyzerJob(
         phaseId: 1,
         progress: p,
         label: PHASES[1].label,
+        model: phase1ModelId,
         live:
           running.length > 0
             ? {
@@ -3674,7 +3677,7 @@ export async function runMainAnalyzerJob(
         .slice(0, 4);
       for (const t of top) log(1, `${t.name}: ${t.lines.toLocaleString()} lines`);
     }
-    send({ kind: 'phase', phaseId: 1, progress: 1, label: PHASES[1].label });
+    send({ kind: 'phase', phaseId: 1, progress: 1, label: PHASES[1].label, model: phase1ModelId });
 
     /* ── Phase 2: matching library — empty for first slice. */
     markPhase(2);
@@ -4293,7 +4296,7 @@ async function runSubsetAnalyzerJob(
       0,
       `Re-analyzing ${toRun.length} chapter${toRun.length === 1 ? '' : 's'} via ${analyzerLabel}.`,
     );
-    send({ kind: 'phase', phaseId: 0, progress: 0.02, label: PHASES[0].label });
+    send({ kind: 'phase', phaseId: 0, progress: 0.02, label: PHASES[0].label, model: subsetModelId });
 
     /* Same series-cast prior the main route uses (C2). Resolved once
        per subset retry so the prompt still recognises series-regulars
@@ -4441,6 +4444,7 @@ async function runSubsetAnalyzerJob(
         phaseId: 0,
         progress: 0.02 + 0.93 * ((idx + 1) / toRun.length),
         label: PHASES[0].label,
+        model: subsetModelId,
       });
     }
 
@@ -4517,7 +4521,7 @@ async function runSubsetAnalyzerJob(
     await saveAnalysisCache(manuscriptId, cache);
     await persistDroppedQuotesBatch(record.bookDir, manuscriptId, 'analysis-chapters', verified);
     send({ kind: 'cast-update', characters: previewFoldForLiveView(stage1.characters) });
-    send({ kind: 'phase', phaseId: 0, progress: 1, label: PHASES[0].label });
+    send({ kind: 'phase', phaseId: 0, progress: 1, label: PHASES[0].label, model: subsetModelId });
 
     /* ── Phase 1 (subset). Sentence attribution for the new chapters only.
        Cached chapters are left alone — their sentences stay in
@@ -4559,7 +4563,7 @@ async function runSubsetAnalyzerJob(
       endJob(job);
       return;
     }
-    send({ kind: 'phase', phaseId: 1, progress: 0.02, label: PHASES[1].label });
+    send({ kind: 'phase', phaseId: 1, progress: 0.02, label: PHASES[1].label, model: phase1ModelId });
     for (let idx = 0; idx < toRun.length; idx++) {
       const ch = toRun[idx];
       log(1, `Chapter ${ch.id} — ${ch.title}: attributing sentences via ${phase1AnalyzerLabel}…`);
@@ -4633,6 +4637,7 @@ async function runSubsetAnalyzerJob(
         phaseId: 1,
         progress: 0.02 + 0.93 * ((idx + 1) / toRun.length),
         label: PHASES[1].label,
+        model: phase1ModelId,
       });
     }
 

--- a/src/components/analysing/phase-card.test.tsx
+++ b/src/components/analysing/phase-card.test.tsx
@@ -35,6 +35,114 @@ function renderPhase(phase: AnalysisPhase) {
   );
 }
 
+const activePhase: AnalysisPhase = {
+  id: 0,
+  label: 'Detecting characters',
+  detail: 'Named-entity extraction, dialogue attribution, speaker resolution.',
+  duration: 1000,
+};
+
+describe('LiveChapterRow — section sub-bar', () => {
+  /* When a chapter has sectionsTotal > 1 the row must show "section M/N"
+     and a thin sub-bar; single-section (or absent) chapters must stay clean. */
+  it('shows "section M/N" text when sectionsTotal > 1', () => {
+    const store = mountStore();
+    render(
+      <Provider store={store}>
+        <PhaseCard
+          phase={activePhase}
+          activePhaseId={activePhase.id}
+          phaseProgress={0.5}
+          phaseLogs={[]}
+          live={{
+            totalChapters: 10,
+            chapters: [
+              {
+                chapterIndex: 2,
+                chapterTitle: 'Chapter 2',
+                elapsedMs: 3000,
+                estMs: 8000,
+                sectionsDone: 3,
+                sectionsTotal: 4,
+              },
+            ],
+          }}
+          isLocalAnalyzer={false}
+          analysisStarted={true}
+          conn="streaming"
+          bookId={null}
+          droppedQuotesRefreshKey={0}
+        />
+      </Provider>,
+    );
+    expect(screen.getByText(/section 3\/4/i)).toBeInTheDocument();
+  });
+
+  it('renders no "section" text when sectionsTotal is 1', () => {
+    const store = mountStore();
+    render(
+      <Provider store={store}>
+        <PhaseCard
+          phase={activePhase}
+          activePhaseId={activePhase.id}
+          phaseProgress={0.5}
+          phaseLogs={[]}
+          live={{
+            totalChapters: 10,
+            chapters: [
+              {
+                chapterIndex: 2,
+                chapterTitle: 'Chapter 2',
+                elapsedMs: 3000,
+                estMs: 8000,
+                sectionsDone: 1,
+                sectionsTotal: 1,
+              },
+            ],
+          }}
+          isLocalAnalyzer={false}
+          analysisStarted={true}
+          conn="streaming"
+          bookId={null}
+          droppedQuotesRefreshKey={0}
+        />
+      </Provider>,
+    );
+    expect(screen.queryByText(/section/i)).toBeNull();
+  });
+
+  it('renders no "section" text when sectionsTotal is absent', () => {
+    const store = mountStore();
+    render(
+      <Provider store={store}>
+        <PhaseCard
+          phase={activePhase}
+          activePhaseId={activePhase.id}
+          phaseProgress={0.5}
+          phaseLogs={[]}
+          live={{
+            totalChapters: 10,
+            chapters: [
+              {
+                chapterIndex: 2,
+                chapterTitle: 'Chapter 2',
+                elapsedMs: 3000,
+                estMs: 8000,
+              },
+            ],
+          }}
+          isLocalAnalyzer={false}
+          analysisStarted={true}
+          conn="streaming"
+          bookId={null}
+          droppedQuotesRefreshKey={0}
+        />
+      </Provider>,
+    );
+    expect(screen.queryByText(/section/i)).toBeNull();
+  });
+});
+
 describe('PhaseCard layout', () => {
   /* The detail copy must span the full card width rather than the narrow
      column beneath the label. The model chip + swap dropdown share the

--- a/src/components/analysing/phase-card.tsx
+++ b/src/components/analysing/phase-card.tsx
@@ -55,22 +55,45 @@ function LiveChapterRow({
   }, [chapter.elapsedMs, chapter.chapterIndex]);
 
   const overBudget = displayMs > chapter.estMs * 1.25;
+  const showSections =
+    chapter.sectionsTotal !== undefined && chapter.sectionsTotal > 1;
+  const sectionPct = showSections
+    ? ((chapter.sectionsDone ?? 0) / chapter.sectionsTotal!) * 100
+    : 0;
   return (
-    <div
-      className={`inline-flex items-center gap-2 text-[11px] font-mono tabular-nums ${overBudget ? 'text-amber-700' : 'text-ink/60'}`}
-    >
-      <span className="font-semibold">
-        Chapter {chapter.chapterIndex}/{totalChapters}
-      </span>
-      <span className="text-ink/30">·</span>
-      <span className="truncate max-w-[220px]" title={chapter.chapterTitle}>
-        {chapter.chapterTitle}
-      </span>
-      <span className="text-ink/30">·</span>
-      <span>
-        {humanSecondsCompact(displayMs)} of ~{humanSecondsCompact(chapter.estMs)}
-      </span>
-      {overBudget && <span className="ml-1 font-semibold">over budget</span>}
+    <div className="flex flex-col gap-0.5">
+      <div
+        className={`inline-flex items-center gap-2 text-[11px] font-mono tabular-nums ${overBudget ? 'text-amber-700' : 'text-ink/60'}`}
+      >
+        <span className="font-semibold">
+          Chapter {chapter.chapterIndex}/{totalChapters}
+        </span>
+        <span className="text-ink/30">·</span>
+        <span className="truncate max-w-[220px]" title={chapter.chapterTitle}>
+          {chapter.chapterTitle}
+        </span>
+        <span className="text-ink/30">·</span>
+        <span>
+          {humanSecondsCompact(displayMs)} of ~{humanSecondsCompact(chapter.estMs)}
+        </span>
+        {showSections && (
+          <>
+            <span className="text-ink/30">·</span>
+            <span className="text-ink/50">
+              section {chapter.sectionsDone}/{chapter.sectionsTotal}
+            </span>
+          </>
+        )}
+        {overBudget && <span className="ml-1 font-semibold">over budget</span>}
+      </div>
+      {showSections && (
+        <div className="h-0.5 w-48 rounded-full bg-ink/10 overflow-hidden">
+          <div
+            className="h-full rounded-full bg-ink/20"
+            style={{ width: `${sectionPct}%` }}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/analysing/phase-card.tsx
+++ b/src/components/analysing/phase-card.tsx
@@ -55,8 +55,7 @@ function LiveChapterRow({
   }, [chapter.elapsedMs, chapter.chapterIndex]);
 
   const overBudget = displayMs > chapter.estMs * 1.25;
-  const showSections =
-    chapter.sectionsTotal !== undefined && chapter.sectionsTotal > 1;
+  const showSections = chapter.sectionsTotal !== undefined && chapter.sectionsTotal > 1;
   const sectionPct = showSections
     ? ((chapter.sectionsDone ?? 0) / chapter.sectionsTotal!) * 100
     : 0;
@@ -88,10 +87,7 @@ function LiveChapterRow({
       </div>
       {showSections && (
         <div className="h-0.5 w-48 rounded-full bg-ink/10 overflow-hidden">
-          <div
-            className="h-full rounded-full bg-ink/20"
-            style={{ width: `${sectionPct}%` }}
-          />
+          <div className="h-full rounded-full bg-ink/20" style={{ width: `${sectionPct}%` }} />
         </div>
       )}
     </div>
@@ -426,9 +422,7 @@ export function PhaseCard({
             <IconSpinner className="w-4 h-4 text-magenta" />
           </span>
         )}
-        {!isDone && !isActive && (
-          <span className="w-7 h-7 rounded-full border border-ink/15" />
-        )}
+        {!isDone && !isActive && <span className="w-7 h-7 rounded-full border border-ink/15" />}
       </div>
       <div className="flex-1 min-w-0">
         <div className="flex items-start justify-between gap-3 flex-wrap">
@@ -439,7 +433,11 @@ export function PhaseCard({
           </p>
           {hasModelControls && (
             <div className="flex items-center gap-2 flex-wrap shrink-0">
-              <PhaseModelChip phaseId={p.id as 0 | 1} state={chipState} serverModel={serverModelByPhase?.[p.id]} />
+              <PhaseModelChip
+                phaseId={p.id as 0 | 1}
+                state={chipState}
+                serverModel={serverModelByPhase?.[p.id]}
+              />
               <PhaseModelSwap phaseId={p.id as 0 | 1} isActive={isActive} />
             </div>
           )}

--- a/src/components/analysing/phase-card.tsx
+++ b/src/components/analysing/phase-card.tsx
@@ -343,6 +343,8 @@ interface PhaseCardProps {
   live: AnalysisLiveInfo | null;
   heartbeat?: { hb: AnalysisHeartbeat; receivedAt: number };
   throttle?: { until: number; model: string; reason: 'rpm' | 'tpm' | 'rpd' | 'retry-after' };
+  /** Server-resolved model id per phase, populated from SSE phase events. */
+  serverModelByPhase?: Record<number, string>;
   isLocalAnalyzer: boolean;
   analysisStarted: boolean;
   conn: ConnState;
@@ -362,6 +364,7 @@ export function PhaseCard({
   live,
   heartbeat,
   throttle,
+  serverModelByPhase,
   isLocalAnalyzer,
   analysisStarted,
   conn,
@@ -413,7 +416,7 @@ export function PhaseCard({
           </p>
           {hasModelControls && (
             <div className="flex items-center gap-2 flex-wrap shrink-0">
-              <PhaseModelChip phaseId={p.id as 0 | 1} state={chipState} />
+              <PhaseModelChip phaseId={p.id as 0 | 1} state={chipState} serverModel={serverModelByPhase?.[p.id]} />
               <PhaseModelSwap phaseId={p.id as 0 | 1} isActive={isActive} />
             </div>
           )}

--- a/src/components/analysing/phase-model-chip.test.tsx
+++ b/src/components/analysing/phase-model-chip.test.tsx
@@ -71,9 +71,15 @@ describe('PhaseModelChip', () => {
     });
 
     it('falls back to account.defaultAnalysisModel when ui has no selected model', () => {
-      renderChip({ analyzerPhase0Model: null }, { phaseId: 0, state: 'pending' }, { selectedModel: '' });
+      renderChip(
+        { analyzerPhase0Model: null },
+        { phaseId: 0, state: 'pending' },
+        { selectedModel: '' },
+      );
       /* account initial defaultAnalysisModel is gemini-3.1-flash-lite. */
-      expect(screen.getByTestId('phase-model-chip-0').textContent).toContain('Gemini 3.1 Flash Lite');
+      expect(screen.getByTestId('phase-model-chip-0').textContent).toContain(
+        'Gemini 3.1 Flash Lite',
+      );
     });
 
     it('does NOT show the warm-up hint for phase 1 even in the warming state', () => {
@@ -118,7 +124,9 @@ describe('PhaseModelChip', () => {
         },
         { phaseId: 1, state: 'warming' },
       );
-      expect(screen.getByTestId('phase-model-chip-1').textContent).toContain('warms up after ch. 15');
+      expect(screen.getByTestId('phase-model-chip-1').textContent).toContain(
+        'warms up after ch. 15',
+      );
     });
 
     it('shows an honest "Server default" when a phase is left blank but the split is active', () => {

--- a/src/components/analysing/phase-model-chip.test.tsx
+++ b/src/components/analysing/phase-model-chip.test.tsx
@@ -187,4 +187,44 @@ describe('PhaseModelChip', () => {
     const { container } = renderChip({}, { phaseId: 2, state: 'pending' });
     expect(container.querySelector('[data-testid^="phase-model-chip"]')).toBeNull();
   });
+
+  describe('serverModel prop — mirrors the server-resolved model id', () => {
+    it('PREFERS serverModel over the Redux selection when present', () => {
+      /* Regression for Task 2: chip must show the server-reported model id
+         ("qwen3.5:9b") even when Redux has a different selection ("qwen3.5:4b").
+         This is the core truthfulness requirement: if the server actually ran
+         on a different model than the UI's default, the chip must say so. */
+      renderChip(
+        { analyzerPhase0Model: null, analyzerPhase1Model: null },
+        { phaseId: 0, state: 'streaming', serverModel: 'qwen3.5:9b' },
+        { selectedModel: 'qwen3.5:4b' },
+      );
+      const chip = screen.getByTestId('phase-model-chip-0');
+      expect(chip.textContent).toContain('Qwen3.5 9B (local)');
+      expect(chip.textContent).not.toContain('Qwen3.5 4B');
+    });
+
+    it('falls back to Redux selection when serverModel is absent (pre-stream)', () => {
+      /* Pre-stream: no server events have arrived yet, so serverModel is
+         undefined. The existing Redux-derived behaviour must be preserved. */
+      renderChip(
+        { analyzerPhase0Model: null, analyzerPhase1Model: null },
+        { phaseId: 0, state: 'pending' },
+        { selectedModel: 'qwen3.5:4b' },
+      );
+      const chip = screen.getByTestId('phase-model-chip-0');
+      expect(chip.textContent).toContain('Qwen3.5 4B (local)');
+    });
+
+    it('resolves an unknown serverModel id to the raw id (graceful fallback)', () => {
+      /* A future model the frontend doesn't know about yet should still
+         render its id rather than crashing or hiding it. */
+      renderChip(
+        { analyzerPhase0Model: null },
+        { phaseId: 0, state: 'streaming', serverModel: 'unknown-future-model:70b' },
+      );
+      const chip = screen.getByTestId('phase-model-chip-0');
+      expect(chip.textContent).toContain('unknown-future-model:70b');
+    });
+  });
 });

--- a/src/components/analysing/phase-model-chip.tsx
+++ b/src/components/analysing/phase-model-chip.tsx
@@ -13,6 +13,11 @@ interface PhaseModelChipProps {
   /** Override the chip label (used by sticky bar to render "Phase N · model").
       Default is just the model name. */
   prefix?: string;
+  /** Server-resolved model id, carried from the `model` field on SSE phase
+      events. When present, PREFERRED over the Redux-derived selection so the
+      chip shows what the server actually ran on rather than the UI default.
+      Absent pre-stream (no SSE events yet) → existing Redux fallback applies. */
+  serverModel?: string;
 }
 
 /* Pill displaying the model that ACTUALLY owns a phase, with a state-coloured
@@ -27,7 +32,7 @@ interface PhaseModelChipProps {
        see (it depends on server env) — show an honest "Server default" rather
        than guessing.
    Phase 2 (library match) has no model and is intentionally not surfaced. */
-export function PhaseModelChip({ phaseId, state, prefix }: PhaseModelChipProps) {
+export function PhaseModelChip({ phaseId, state, prefix, serverModel }: PhaseModelChipProps) {
   const splitActive = useAppSelector((s) => selectAnalyzerSplitIsActive(s.account));
   const minLag = useAppSelector((s) => selectAnalyzerPhase1MinLag(s.account));
   const phaseModel = useAppSelector((s) =>
@@ -56,9 +61,15 @@ export function PhaseModelChip({ phaseId, state, prefix }: PhaseModelChipProps) 
   const useSingle = overrideActive || !splitActive;
   const serverDefault = !useSingle && !phaseModel;
   const modelId = useSingle ? effectiveSingleModel : phaseModel;
-  const label = serverDefault
-    ? 'Server default'
-    : (MODEL_OPTIONS.find((m) => m.id === modelId)?.label ?? modelId ?? 'Server default');
+  /* Prefer the server-reported model id when one has arrived over SSE —
+     it reflects what the server ACTUALLY ran on, overriding the client's
+     Redux selection. Falls back to the existing Redux derivation pre-stream
+     (when serverModel is undefined). */
+  const label = serverModel !== undefined
+    ? (MODEL_OPTIONS.find((m) => m.id === serverModel)?.label ?? serverModel)
+    : serverDefault
+      ? 'Server default'
+      : (MODEL_OPTIONS.find((m) => m.id === modelId)?.label ?? modelId ?? 'Server default');
 
   const meta = (() => {
     if (state === 'streaming') {

--- a/src/components/analysing/phase-model-chip.tsx
+++ b/src/components/analysing/phase-model-chip.tsx
@@ -1,9 +1,6 @@
 import { MODEL_OPTIONS } from '../../lib/models';
 import { useAppSelector } from '../../store';
-import {
-  selectAnalyzerSplitIsActive,
-  selectAnalyzerPhase1MinLag,
-} from '../../store/account-slice';
+import { selectAnalyzerSplitIsActive, selectAnalyzerPhase1MinLag } from '../../store/account-slice';
 
 export type PhaseChipState = 'pending' | 'warming' | 'streaming' | 'done';
 
@@ -36,7 +33,11 @@ export function PhaseModelChip({ phaseId, state, prefix, serverModel }: PhaseMod
   const splitActive = useAppSelector((s) => selectAnalyzerSplitIsActive(s.account));
   const minLag = useAppSelector((s) => selectAnalyzerPhase1MinLag(s.account));
   const phaseModel = useAppSelector((s) =>
-    phaseId === 0 ? s.account.analyzerPhase0Model : phaseId === 1 ? s.account.analyzerPhase1Model : null,
+    phaseId === 0
+      ? s.account.analyzerPhase0Model
+      : phaseId === 1
+        ? s.account.analyzerPhase1Model
+        : null,
   );
   /* The model that a single-model run uses for BOTH phases: the per-run pick
      (ui.selectedModel) which is seeded from, and falls back to, the account
@@ -44,7 +45,8 @@ export function PhaseModelChip({ phaseId, state, prefix, serverModel }: PhaseMod
      mount the chip without the ui slice; production always has it. */
   const effectiveSingleModel = useAppSelector(
     (s) =>
-      (s as { ui?: { selectedModel?: string } }).ui?.selectedModel || s.account.defaultAnalysisModel,
+      (s as { ui?: { selectedModel?: string } }).ui?.selectedModel ||
+      s.account.defaultAnalysisModel,
   );
   /* A per-run override (an explicit pick on the analysis-failed card, e.g.
      qwen3.5:4b chosen to dodge a Gemini block) wins over the saved per-phase
@@ -65,11 +67,12 @@ export function PhaseModelChip({ phaseId, state, prefix, serverModel }: PhaseMod
      it reflects what the server ACTUALLY ran on, overriding the client's
      Redux selection. Falls back to the existing Redux derivation pre-stream
      (when serverModel is undefined). */
-  const label = serverModel !== undefined
-    ? (MODEL_OPTIONS.find((m) => m.id === serverModel)?.label ?? serverModel)
-    : serverDefault
-      ? 'Server default'
-      : (MODEL_OPTIONS.find((m) => m.id === modelId)?.label ?? modelId ?? 'Server default');
+  const label =
+    serverModel !== undefined
+      ? (MODEL_OPTIONS.find((m) => m.id === serverModel)?.label ?? serverModel)
+      : serverDefault
+        ? 'Server default'
+        : (MODEL_OPTIONS.find((m) => m.id === modelId)?.label ?? modelId ?? 'Server default');
 
   const meta = (() => {
     if (state === 'streaming') {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -128,6 +128,12 @@ export interface AnalysisLiveChapter {
   chapterTitle: string;
   elapsedMs: number;
   estMs: number;
+  /** How many sections of this chapter the analyzer has finished so far.
+      Only present when sectionsTotal > 1 (multi-section chapters). */
+  sectionsDone?: number;
+  /** Total sections this chapter was split into.
+      Absent or ≤ 1 means the chapter is a single section — no sub-bar. */
+  sectionsTotal?: number;
 }
 export interface AnalysisLiveInfo {
   totalChapters: number;
@@ -1319,8 +1325,26 @@ async function mockAnalyseManuscript(
         /* Emit the server-resolved model on every phase tick so the chip
            can mirror it. The mock uses qwen3.5:9b to exercise the
            "server ran a different model than the UI default" path that
-           the e2e spec asserts in analysing-multi-model.spec.ts. */
-        onPhase?.({ phaseId: ph.id, progress, model: 'qwen3.5:9b' });
+           the e2e spec asserts in analysing-multi-model.spec.ts.
+           Phase 0 also emits a live payload at ~50% progress to exercise
+           the per-chapter section sub-bar (sectionsDone/sectionsTotal). */
+        const live =
+          ph.id === 0 && progress >= 0.4 && progress < 0.7
+            ? {
+                totalChapters: 2,
+                chapters: [
+                  {
+                    chapterIndex: 1,
+                    chapterTitle: 'Chapter 1',
+                    elapsedMs: Math.round(progress * ph.durationMs),
+                    estMs: ph.durationMs,
+                    sectionsDone: 2,
+                    sectionsTotal: 5,
+                  },
+                ],
+              }
+            : undefined;
+        onPhase?.({ phaseId: ph.id, progress, model: 'qwen3.5:9b', live });
         if (progress >= 1) {
           clearInterval(t);
           resolve();

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -156,7 +156,7 @@ export interface AnalyseOpts {
       working on the old request while the new one queues, manifesting
       to the user as cascading aborts in the server log. */
   signal?: AbortSignal;
-  onPhase?: (e: { phaseId: number; progress: number; live?: AnalysisLiveInfo }) => void;
+  onPhase?: (e: { phaseId: number; progress: number; live?: AnalysisLiveInfo; model?: string }) => void;
   /** Narrative log lines streamed from the server. Surface them in the
       active phase so the user sees real progress (e.g. detected characters,
       sentence counts) instead of canned snippets. */
@@ -1316,7 +1316,11 @@ async function mockAnalyseManuscript(
     await new Promise<void>((resolve) => {
       const t = setInterval(() => {
         const progress = Math.min(1, (Date.now() - start) / ph.durationMs);
-        onPhase?.({ phaseId: ph.id, progress });
+        /* Emit the server-resolved model on every phase tick so the chip
+           can mirror it. The mock uses qwen3.5:9b to exercise the
+           "server ran a different model than the UI default" path that
+           the e2e spec asserts in analysing-multi-model.spec.ts. */
+        onPhase?.({ phaseId: ph.id, progress, model: 'qwen3.5:9b' });
         if (progress >= 1) {
           clearInterval(t);
           resolve();
@@ -2364,7 +2368,12 @@ async function realAnalyseManuscript(
   const handle = (payload: AnalysisStreamEvent) => {
     if (payload.kind === 'phase') {
       if (typeof payload.phaseId === 'number' && typeof payload.progress === 'number') {
-        onPhase?.({ phaseId: payload.phaseId, progress: payload.progress, live: payload.live });
+        onPhase?.({
+          phaseId: payload.phaseId,
+          progress: payload.progress,
+          live: payload.live,
+          model: typeof payload.model === 'string' ? payload.model : undefined,
+        });
       }
     } else if (payload.kind === 'log') {
       if (typeof payload.phaseId === 'number' && typeof payload.message === 'string') {
@@ -3762,7 +3771,12 @@ async function realRunAnalysisForChapters(
   const handle = (payload: AnalysisStreamEvent) => {
     if (payload.kind === 'phase') {
       if (typeof payload.phaseId === 'number' && typeof payload.progress === 'number') {
-        onPhase?.({ phaseId: payload.phaseId, progress: payload.progress, live: payload.live });
+        onPhase?.({
+          phaseId: payload.phaseId,
+          progress: payload.progress,
+          live: payload.live,
+          model: typeof payload.model === 'string' ? payload.model : undefined,
+        });
       }
     } else if (payload.kind === 'log') {
       if (typeof payload.phaseId === 'number' && typeof payload.message === 'string') {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -162,7 +162,12 @@ export interface AnalyseOpts {
       working on the old request while the new one queues, manifesting
       to the user as cascading aborts in the server log. */
   signal?: AbortSignal;
-  onPhase?: (e: { phaseId: number; progress: number; live?: AnalysisLiveInfo; model?: string }) => void;
+  onPhase?: (e: {
+    phaseId: number;
+    progress: number;
+    live?: AnalysisLiveInfo;
+    model?: string;
+  }) => void;
   /** Narrative log lines streamed from the server. Surface them in the
       active phase so the user sees real progress (e.g. detected characters,
       sentence counts) instead of canned snippets. */
@@ -190,7 +195,12 @@ export interface AnalyseOpts {
       persisted to the analysis cache so the analysing view can render a
       per-chapter Retry button. Emitted by both the full and subset
       analysis routes. */
-  onChapterFailed?: (e: { chapterId: number; message: string; code?: string; remediation?: string }) => void;
+  onChapterFailed?: (e: {
+    chapterId: number;
+    message: string;
+    code?: string;
+    remediation?: string;
+  }) => void;
   /** A previously-failed chapter just had its Phase 0a re-run succeed
       (either via the main route re-queueing failedChapterIds on resume,
       or via the subset retry route). The chapter id has been cleared
@@ -987,7 +997,12 @@ function buildCarricksCompassMockState(): BookStateResponse {
     manuscriptEdits: null,
     revisions: null,
     completedSlugs: [],
-    chapterCharacters: { 1: ['eliza_cc'], 2: ['eliza_cc', 'greene'], 3: ['eliza_cc', 'greene'], 4: ['greene'] },
+    chapterCharacters: {
+      1: ['eliza_cc'],
+      2: ['eliza_cc', 'greene'],
+      3: ['eliza_cc', 'greene'],
+      4: ['greene'],
+    },
     changeLog: null,
     analysis: undefined,
   };
@@ -1211,7 +1226,8 @@ export async function mockPutListenStats(
 
 export async function mockGetLibraryStats() {
   await wait(15);
-  const seeded = (globalThis as unknown as { __SEED_LIBRARY_STATS__?: LibraryStats }).__SEED_LIBRARY_STATS__;
+  const seeded = (globalThis as unknown as { __SEED_LIBRARY_STATS__?: LibraryStats })
+    .__SEED_LIBRARY_STATS__;
   if (seeded) return seeded;
   let totalListenedSec = 0;
   const byDayMap = new Map<string, number>();
@@ -1239,7 +1255,8 @@ export async function mockGetContinueListening() {
   // Marketing capture: pose the rail from our manuscripts. Fresh copies, since
   // the slice's hydrate freezes its payload via Immer.
   if (DEMO_CAPTURE) return HOLLOW_TIDE_CONTINUE.map((x) => ({ ...x }));
-  const seeded = (globalThis as unknown as { __SEED_CONTINUE__?: ContinueListeningItem[] }).__SEED_CONTINUE__;
+  const seeded = (globalThis as unknown as { __SEED_CONTINUE__?: ContinueListeningItem[] })
+    .__SEED_CONTINUE__;
   return seeded ?? [];
 }
 
@@ -1539,7 +1556,12 @@ function mockStreamGeneration({
 
 /* fs-26 mock — emits the start → assembling → complete arc synchronously so
    mock-mode (e2e / unit) drives the splice flow without a backend. */
-async function mockStreamSplice({ chapterId, mode, characterId, onTick }: SpliceArgs): Promise<void> {
+async function mockStreamSplice({
+  chapterId,
+  mode,
+  characterId,
+  onTick,
+}: SpliceArgs): Promise<void> {
   onTick({ type: 'splice_start', chapterId, mode, characterId });
   await wait(80);
   onTick({ type: 'chapter_assembling', chapterId, progress: 0.99 });
@@ -3247,10 +3269,7 @@ async function realReparseBook(bookId: string): Promise<ReparseBookResponse> {
   return res.json();
 }
 
-async function realReplaceManuscript(
-  bookId: string,
-  file: File,
-): Promise<ReparseBookResponse> {
+async function realReplaceManuscript(bookId: string, file: File): Promise<ReparseBookResponse> {
   const form = new FormData();
   form.append('file', file);
   const res = await fetch(`/api/books/${encodeURIComponent(bookId)}/replace-manuscript`, {
@@ -3290,7 +3309,11 @@ async function realLoadSample(slug: string): Promise<{ bookId: string }> {
   const res = await fetch(`/api/samples/${encodeURIComponent(slug)}/load`, { method: 'POST' });
   if (!res.ok) {
     let detail = '';
-    try { detail = ((await res.json()) as { error?: string }).error ?? ''; } catch { /* not json */ }
+    try {
+      detail = ((await res.json()) as { error?: string }).error ?? '';
+    } catch {
+      /* not json */
+    }
     throw new Error(detail || `Couldn't load the sample (${res.status}).`);
   }
   return res.json();
@@ -3383,10 +3406,7 @@ async function mockReparseBook(_bookId: string): Promise<ReparseBookResponse> {
   return { state: { chapters: [] }, chapterCount: 0, chapterTitles: [], chapters: [] };
 }
 
-async function mockReplaceManuscript(
-  _bookId: string,
-  _file: File,
-): Promise<ReparseBookResponse> {
+async function mockReplaceManuscript(_bookId: string, _file: File): Promise<ReparseBookResponse> {
   await wait(120);
   return { state: { chapters: [] }, chapterCount: 0, chapterTitles: [], chapters: [] };
 }
@@ -4167,7 +4187,11 @@ async function realStreamSplice({
     }
   } catch (e) {
     if ((e as { name?: string })?.name === 'AbortError') return;
-    onTick({ type: 'chapter_failed', chapterId, errorReason: (e as Error).message ?? 'Splice failed.' });
+    onTick({
+      type: 'chapter_failed',
+      chapterId,
+      errorReason: (e as Error).message ?? 'Splice failed.',
+    });
   }
 }
 
@@ -4306,10 +4330,7 @@ export interface CastDesignStatus {
   failures?: Array<{ characterId: string; name: string; error: string }>;
 }
 
-export async function readCastDesignStream(
-  res: Response,
-  cb: CastDesignCallbacks,
-): Promise<void> {
+export async function readCastDesignStream(res: Response, cb: CastDesignCallbacks): Promise<void> {
   if (!res.ok || !res.body) {
     let detail = '';
     try {
@@ -4335,11 +4356,18 @@ export async function readCastDesignStream(
             phase: e.phase === 'rendering' ? 'rendering' : 'designing',
           });
         } else {
-          cb.onResumeFrom?.({ total: e.total ?? 0, done: e.done ?? 0, currentName: e.currentName ?? null });
+          cb.onResumeFrom?.({
+            total: e.total ?? 0,
+            done: e.done ?? 0,
+            currentName: e.currentName ?? null,
+          });
         }
         break;
       case 'phase':
-        if (typeof e.characterId === 'string' && (e.phase === 'designing' || e.phase === 'rendering'))
+        if (
+          typeof e.characterId === 'string' &&
+          (e.phase === 'designing' || e.phase === 'rendering')
+        )
           cb.onPhase?.({ characterId: e.characterId, phase: e.phase });
         break;
       case 'designed':
@@ -4382,7 +4410,11 @@ export async function readCastDesignStream(
           typeof e.emotion === 'string' &&
           typeof e.voiceId === 'string'
         )
-          cb.onVariantDesigned?.({ characterId: e.characterId, emotion: e.emotion as Emotion, voiceId: e.voiceId });
+          cb.onVariantDesigned?.({
+            characterId: e.characterId,
+            emotion: e.emotion as Emotion,
+            voiceId: e.voiceId,
+          });
         break;
       case 'character_skipped':
         if (typeof e.characterId === 'string')
@@ -4503,10 +4535,12 @@ async function realStartSingleDesign(
 }
 
 async function realSubscribeSingleDesign(bookId: string, cb: CastDesignCallbacks): Promise<void> {
-  const res = await fetch(
-    `/api/books/${encodeURIComponent(bookId)}/cast/design-single/subscribe`,
-    { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}', signal: cb.signal },
-  );
+  const res = await fetch(`/api/books/${encodeURIComponent(bookId)}/cast/design-single/subscribe`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: '{}',
+    signal: cb.signal,
+  });
   await readCastDesignStream(res, cb);
 }
 
@@ -4542,7 +4576,10 @@ async function mockStartSingleDesign(
       persona: args.persona,
     });
   } else {
-    cb.onCharacterDesigned?.({ characterId: args.characterId, voiceId: `qwen-${args.characterId}` });
+    cb.onCharacterDesigned?.({
+      characterId: args.characterId,
+      voiceId: `qwen-${args.characterId}`,
+    });
   }
   cb.onIdle?.({ done: args.preview ? 0 : 1, total: 1, skipped: 0, failures: [] });
 }
@@ -4602,7 +4639,11 @@ async function mockStartCastDesign(
       cb.onProgress?.({ characterId: t.characterId, name: t.characterId, done, total });
       await wait(120);
       if (cb.signal?.aborted) return;
-      cb.onVariantDesigned?.({ characterId: t.characterId, emotion, voiceId: `qwen-${t.characterId}__${emotion}` });
+      cb.onVariantDesigned?.({
+        characterId: t.characterId,
+        emotion,
+        voiceId: `qwen-${t.characterId}__${emotion}`,
+      });
       done += 1;
     }
   }
@@ -4947,7 +4988,9 @@ async function realPutGeminiKey(key: string | null): Promise<UserSettings> {
 async function realGetAppInfo(): Promise<AppInfo> {
   const res = await fetch('/api/info');
   if (!res.ok)
-    throw new Error(`App info fetch failed (${res.status}): ${(await res.text()) || res.statusText}`);
+    throw new Error(
+      `App info fetch failed (${res.status}): ${(await res.text()) || res.statusText}`,
+    );
   return res.json();
 }
 /* "Is a newer release available?" check for the Application updates card.
@@ -4957,10 +5000,23 @@ async function realGetAppInfo(): Promise<AppInfo> {
 async function realGetUpdateStatus(): Promise<UpdateStatus> {
   try {
     const res = await fetch('/api/updates/latest');
-    if (!res.ok) return { reachable: false, currentVersion: '', latestVersion: null, updateAvailable: false, url: null };
+    if (!res.ok)
+      return {
+        reachable: false,
+        currentVersion: '',
+        latestVersion: null,
+        updateAvailable: false,
+        url: null,
+      };
     return res.json();
   } catch {
-    return { reachable: false, currentVersion: '', latestVersion: null, updateAvailable: false, url: null };
+    return {
+      reachable: false,
+      currentVersion: '',
+      latestVersion: null,
+      updateAvailable: false,
+      url: null,
+    };
   }
 }
 /* Interim — HEAD-probe GET /api/companion/apk to learn whether a packaged
@@ -4980,30 +5036,40 @@ async function realCheckCompanionApk(): Promise<CompanionApkAvailability> {
 async function realDismissWhatsNew(): Promise<void> {
   const res = await fetch('/api/info/dismiss-whats-new', { method: 'POST' });
   if (!res.ok)
-    throw new Error(`Dismiss what's-new failed (${res.status}): ${(await res.text()) || res.statusText}`);
+    throw new Error(
+      `Dismiss what's-new failed (${res.status}): ${(await res.text()) || res.statusText}`,
+    );
 }
 async function realUpgradeStage(file: File): Promise<UpgradeStageResult> {
   const form = new FormData();
   form.append('zip', file, file.name);
   const res = await fetch('/api/upgrade/stage', { method: 'POST', body: form });
   if (!res.ok)
-    throw new Error(`Upgrade staging failed (${res.status}): ${(await res.text()) || res.statusText}`);
+    throw new Error(
+      `Upgrade staging failed (${res.status}): ${(await res.text()) || res.statusText}`,
+    );
   return res.json();
 }
 async function realUpgradeApply(): Promise<void> {
   const res = await fetch('/api/upgrade/apply', { method: 'POST' });
   if (!res.ok)
-    throw new Error(`Upgrade apply failed (${res.status}): ${(await res.text()) || res.statusText}`);
+    throw new Error(
+      `Upgrade apply failed (${res.status}): ${(await res.text()) || res.statusText}`,
+    );
 }
 async function realUpgradeAbort(): Promise<void> {
   const res = await fetch('/api/upgrade/abort', { method: 'POST' });
   if (!res.ok)
-    throw new Error(`Upgrade abort failed (${res.status}): ${(await res.text()) || res.statusText}`);
+    throw new Error(
+      `Upgrade abort failed (${res.status}): ${(await res.text()) || res.statusText}`,
+    );
 }
 async function realUpgradeState(): Promise<UpgradeStatePayload> {
   const res = await fetch('/api/upgrade/state');
   if (!res.ok)
-    throw new Error(`Upgrade state failed (${res.status}): ${(await res.text()) || res.statusText}`);
+    throw new Error(
+      `Upgrade state failed (${res.status}): ${(await res.text()) || res.statusText}`,
+    );
   return res.json();
 }
 
@@ -5050,7 +5116,13 @@ async function mockDismissWhatsNew(): Promise<void> {
 }
 async function mockUpgradeStage(_file: File): Promise<UpgradeStageResult> {
   await wait(50);
-  return { candidateVersion: '1.7.0', runningVersion: '1.6.0', reqHash: 'mock', requiresPipInstall: false, isDowngrade: false };
+  return {
+    candidateVersion: '1.7.0',
+    runningVersion: '1.6.0',
+    reqHash: 'mock',
+    requiresPipInstall: false,
+    isDowngrade: false,
+  };
 }
 async function mockUpgradeApply(): Promise<void> {
   await wait(30);
@@ -5261,9 +5333,7 @@ async function realCreatePairSession(): Promise<PairSessionInfo> {
     body: '{}',
   });
   if (!res.ok)
-    throw new Error(
-      `pair session failed (${res.status}): ${(await res.text()) || res.statusText}`,
-    );
+    throw new Error(`pair session failed (${res.status}): ${(await res.text()) || res.statusText}`);
   return res.json();
 }
 
@@ -5553,10 +5623,27 @@ async function mockGetDiagnostics(): Promise<DiagnosticsResponse> {
     ts: '2026-01-01T00:00:00.000Z',
     overall: 'ok',
     checks: [
-      { id: 'gpu', label: 'GPU / VRAM', status: 'ok', detail: 'cuda · 1.2 / 8.0 GB reserved', value: '1.2/8.0 GB' },
-      { id: 'sidecar', label: 'Voice engine', status: 'ok', detail: 'reachable · kokoro, qwen', value: 'kokoro, qwen' },
+      {
+        id: 'gpu',
+        label: 'GPU / VRAM',
+        status: 'ok',
+        detail: 'cuda · 1.2 / 8.0 GB reserved',
+        value: '1.2/8.0 GB',
+      },
+      {
+        id: 'sidecar',
+        label: 'Voice engine',
+        status: 'ok',
+        detail: 'reachable · kokoro, qwen',
+        value: 'kokoro, qwen',
+      },
       { id: 'asr', label: 'ASR (Whisper)', status: 'ok', detail: 'off — content-QA disabled' },
-      { id: 'analyzer', label: 'Analyzer (Ollama)', status: 'ok', detail: 'reachable · model resident' },
+      {
+        id: 'analyzer',
+        label: 'Analyzer (Ollama)',
+        status: 'ok',
+        detail: 'reachable · model resident',
+      },
       { id: 'gemini', label: 'Analyzer (Gemini)', status: 'ok', detail: 'not in use' },
       { id: 'ffmpeg', label: 'ffmpeg / ffprobe', status: 'ok', detail: 'both present' },
       { id: 'disk', label: 'Free disk', status: 'ok', detail: '142 GB free', value: 142 },
@@ -5570,7 +5657,12 @@ export type BlockerStatus = 'pass' | 'fail';
 export interface SetupReadiness {
   ready: boolean;
   completedAt: string | null;
-  blockers: { sidecar: BlockerStatus; ffmpeg: BlockerStatus; tts: BlockerStatus; analyzer: BlockerStatus };
+  blockers: {
+    sidecar: BlockerStatus;
+    ffmpeg: BlockerStatus;
+    tts: BlockerStatus;
+    analyzer: BlockerStatus;
+  };
   info: { gpu: string };
 }
 
@@ -5658,7 +5750,13 @@ async function realRunSmokeTest(): Promise<SmokeTestResult> {
 
 export async function mockRunSmokeTest(): Promise<SmokeTestResult> {
   await wait(800);
-  return { ok: true, url: stubAudioA, durationSec: 3.2, analyzerOk: true, analyzerDetail: '(mock)' };
+  return {
+    ok: true,
+    url: stubAudioA,
+    durationSec: 3.2,
+    analyzerOk: true,
+    analyzerDetail: '(mock)',
+  };
 }
 
 async function mockGetSidecarHealth(): Promise<SidecarHealth> {
@@ -5703,109 +5801,110 @@ async function mockGetModelInventory(): Promise<ModelInventoryResponse> {
       ? { ...item, present: false, loaded: false, sizeBytes: null, removable: false }
       : item;
   const items: ModelInventoryItem[] = [
-      {
-        id: 'kokoro',
-        kind: 'tts',
-        label: 'Kokoro v1',
-        present: true,
-        sizeBytes: 346_030_080,
-        diskPath: 'server/tts-sidecar/voices/kokoro',
-        loaded: MOCK_SIDECAR_KOKORO_LOADED,
-        installState: MOCK_SIDECAR_KOKORO_LOADED ? 'loaded' : 'ready',
-        tier: 'standard',
-        isDefaultEngine: !MOCK_SIDECAR_QWEN_LOADED,
-        isFallbackEngine: true,
-        removable: true,
-        updatable: true,
-        integrity: 'verified',
-      },
-      {
-        id: 'qwen-base',
-        kind: 'tts',
-        label: 'Qwen3-TTS Base (0.6B)',
-        present: true,
-        sizeBytes: 1_283_457_024,
-        diskPath: '~/.cache/huggingface/hub/models--Qwen--Qwen3-TTS-12Hz-0.6B-Base',
-        loaded: MOCK_SIDECAR_QWEN_LOADED,
-        /* package-missing exercises the Needs-repair / Repair / no-Load-pill
+    {
+      id: 'kokoro',
+      kind: 'tts',
+      label: 'Kokoro v1',
+      present: true,
+      sizeBytes: 346_030_080,
+      diskPath: 'server/tts-sidecar/voices/kokoro',
+      loaded: MOCK_SIDECAR_KOKORO_LOADED,
+      installState: MOCK_SIDECAR_KOKORO_LOADED ? 'loaded' : 'ready',
+      tier: 'standard',
+      isDefaultEngine: !MOCK_SIDECAR_QWEN_LOADED,
+      isFallbackEngine: true,
+      removable: true,
+      updatable: true,
+      integrity: 'verified',
+    },
+    {
+      id: 'qwen-base',
+      kind: 'tts',
+      label: 'Qwen3-TTS Base (0.6B)',
+      present: true,
+      sizeBytes: 1_283_457_024,
+      diskPath: '~/.cache/huggingface/hub/models--Qwen--Qwen3-TTS-12Hz-0.6B-Base',
+      loaded: MOCK_SIDECAR_QWEN_LOADED,
+      /* package-missing exercises the Needs-repair / Repair / no-Load-pill
            health states that model-manager-health.spec.ts pins (Task 12).
            installState resolves back to 'loaded' when the user loads it. */
-        installState: MOCK_SIDECAR_QWEN_LOADED ? 'loaded' : 'package-missing',
-        tier: 'standard',
-        isDefaultEngine: MOCK_SIDECAR_QWEN_LOADED,
-        isFallbackEngine: false,
-        removable: true,
-        updatable: true,
-        integrity: 'unpinned',
-      },
-      {
-        id: 'qwen-design',
-        kind: 'tts',
-        label: 'Qwen3-TTS VoiceDesign (1.7B)',
-        present: true,
-        sizeBytes: 3_623_878_656,
-        diskPath: '~/.cache/huggingface/hub/models--Qwen--Qwen3-TTS-12Hz-1.7B-VoiceDesign',
-        loaded: false,
-        tier: 'standard',
-        isDefaultEngine: false,
-        isFallbackEngine: false,
-        removable: true,
-        updatable: true,
-      },
-      {
-        id: 'coqui',
-        kind: 'tts',
-        label: 'Coqui XTTS v2',
-        present: false,
-        sizeBytes: null,
-        diskPath: 'server/tts-sidecar/voices/coqui/tts/tts_models--multilingual--multi-dataset--xtts_v2',
-        loaded: false,
-        installState: 'not-installed',
-        tier: 'secondary',
-        isDefaultEngine: false,
-        isFallbackEngine: false,
-        removable: false,
-        updatable: true,
-      },
-      {
-        id: 'whisper',
-        kind: 'asr',
-        label: 'Whisper ASR (faster-whisper)',
-        present: false,
-        sizeBytes: null,
-        diskPath: '~/.cache/huggingface/hub/models--Systran--faster-whisper-base',
-        loaded: false,
-        isDefaultEngine: false,
-        isFallbackEngine: false,
-        removable: false,
-        updatable: true,
-      },
-      {
-        id: 'ollama:qwen3.5:4b',
-        kind: 'analyzer',
-        label: 'qwen3.5:4b',
-        present: true,
-        sizeBytes: 2_600_000_000,
-        diskPath: null,
-        loaded: MOCK_OLLAMA_RESIDENT.has('qwen3.5:4b'),
-        isDefaultEngine: true,
-        isFallbackEngine: false,
-        removable: true,
-        updatable: true,
-      },
-      {
-        id: 'ollama:llama3.1:8b',
-        kind: 'analyzer',
-        label: 'llama3.1:8b',
-        present: true,
-        sizeBytes: 4_700_000_000,
-        diskPath: null,
-        loaded: MOCK_OLLAMA_RESIDENT.has('llama3.1:8b'),
-        isDefaultEngine: false,
-        isFallbackEngine: false,
-        removable: true,
-        updatable: true,
-      },
+      installState: MOCK_SIDECAR_QWEN_LOADED ? 'loaded' : 'package-missing',
+      tier: 'standard',
+      isDefaultEngine: MOCK_SIDECAR_QWEN_LOADED,
+      isFallbackEngine: false,
+      removable: true,
+      updatable: true,
+      integrity: 'unpinned',
+    },
+    {
+      id: 'qwen-design',
+      kind: 'tts',
+      label: 'Qwen3-TTS VoiceDesign (1.7B)',
+      present: true,
+      sizeBytes: 3_623_878_656,
+      diskPath: '~/.cache/huggingface/hub/models--Qwen--Qwen3-TTS-12Hz-1.7B-VoiceDesign',
+      loaded: false,
+      tier: 'standard',
+      isDefaultEngine: false,
+      isFallbackEngine: false,
+      removable: true,
+      updatable: true,
+    },
+    {
+      id: 'coqui',
+      kind: 'tts',
+      label: 'Coqui XTTS v2',
+      present: false,
+      sizeBytes: null,
+      diskPath:
+        'server/tts-sidecar/voices/coqui/tts/tts_models--multilingual--multi-dataset--xtts_v2',
+      loaded: false,
+      installState: 'not-installed',
+      tier: 'secondary',
+      isDefaultEngine: false,
+      isFallbackEngine: false,
+      removable: false,
+      updatable: true,
+    },
+    {
+      id: 'whisper',
+      kind: 'asr',
+      label: 'Whisper ASR (faster-whisper)',
+      present: false,
+      sizeBytes: null,
+      diskPath: '~/.cache/huggingface/hub/models--Systran--faster-whisper-base',
+      loaded: false,
+      isDefaultEngine: false,
+      isFallbackEngine: false,
+      removable: false,
+      updatable: true,
+    },
+    {
+      id: 'ollama:qwen3.5:4b',
+      kind: 'analyzer',
+      label: 'qwen3.5:4b',
+      present: true,
+      sizeBytes: 2_600_000_000,
+      diskPath: null,
+      loaded: MOCK_OLLAMA_RESIDENT.has('qwen3.5:4b'),
+      isDefaultEngine: true,
+      isFallbackEngine: false,
+      removable: true,
+      updatable: true,
+    },
+    {
+      id: 'ollama:llama3.1:8b',
+      kind: 'analyzer',
+      label: 'llama3.1:8b',
+      present: true,
+      sizeBytes: 4_700_000_000,
+      diskPath: null,
+      loaded: MOCK_OLLAMA_RESIDENT.has('llama3.1:8b'),
+      isDefaultEngine: false,
+      isFallbackEngine: false,
+      removable: true,
+      updatable: true,
+    },
   ];
   return {
     ts: new Date().toISOString(),
@@ -6130,10 +6229,34 @@ const MOCK_CONFIG_GROUPS: import('./types').ConfigGroup[] = [
 
 /* In-memory mock config store. Starts with default values; PUT/reset mutate it. */
 const MOCK_CONFIG_VALUES: import('./types').ConfigValues = {
-  KOKORO_SAMPLE_RATE: { key: 'KOKORO_SAMPLE_RATE', effective: 24000, source: 'default', locked: false, overridden: false },
-  SEG_QA_MAX_RERECORDS: { key: 'SEG_QA_MAX_RERECORDS', effective: 2, source: 'default', locked: false, overridden: false },
-  SEG_ASR_ENABLED: { key: 'SEG_ASR_ENABLED', effective: false, source: 'default', locked: false, overridden: false },
-  ANALYZER_STAGE1_PROMPT: { key: 'ANALYZER_STAGE1_PROMPT', effective: 'Attribute each sentence to its speaker.', source: 'default', locked: false, overridden: false },
+  KOKORO_SAMPLE_RATE: {
+    key: 'KOKORO_SAMPLE_RATE',
+    effective: 24000,
+    source: 'default',
+    locked: false,
+    overridden: false,
+  },
+  SEG_QA_MAX_RERECORDS: {
+    key: 'SEG_QA_MAX_RERECORDS',
+    effective: 2,
+    source: 'default',
+    locked: false,
+    overridden: false,
+  },
+  SEG_ASR_ENABLED: {
+    key: 'SEG_ASR_ENABLED',
+    effective: false,
+    source: 'default',
+    locked: false,
+    overridden: false,
+  },
+  ANALYZER_STAGE1_PROMPT: {
+    key: 'ANALYZER_STAGE1_PROMPT',
+    effective: 'Attribute each sentence to its speaker.',
+    source: 'default',
+    locked: false,
+    overridden: false,
+  },
 };
 
 /* In-memory prompt store keyed by id. */
@@ -6166,16 +6289,23 @@ export async function mockPutConfig(
   const applied: string[] = [];
   for (const [key, value] of Object.entries(patch)) {
     if (key in MOCK_CONFIG_VALUES) {
-      MOCK_CONFIG_VALUES[key] = { ...MOCK_CONFIG_VALUES[key], effective: value, source: 'override', overridden: true };
+      MOCK_CONFIG_VALUES[key] = {
+        ...MOCK_CONFIG_VALUES[key],
+        effective: value,
+        source: 'override',
+        overridden: true,
+      };
       applied.push(key);
     }
   }
   return { ok: true, applied, values: { ...MOCK_CONFIG_VALUES } };
 }
 
-export async function mockResetConfig(
-  body: { keys?: string[]; group?: string; all?: boolean },
-): Promise<{ ok: boolean; values: ConfigValues }> {
+export async function mockResetConfig(body: {
+  keys?: string[];
+  group?: string;
+  all?: boolean;
+}): Promise<{ ok: boolean; values: ConfigValues }> {
   await wait(30);
   const keysToReset: string[] = body.all
     ? Object.keys(MOCK_CONFIG_VALUES)
@@ -6187,7 +6317,13 @@ export async function mockResetConfig(
   for (const key of keysToReset) {
     const descriptor = MOCK_CONFIG_DESCRIPTORS.find((d) => d.key === key);
     if (descriptor && key in MOCK_CONFIG_VALUES) {
-      MOCK_CONFIG_VALUES[key] = { key, effective: descriptor.default, source: 'default', locked: false, overridden: false };
+      MOCK_CONFIG_VALUES[key] = {
+        key,
+        effective: descriptor.default,
+        source: 'default',
+        locked: false,
+        overridden: false,
+      };
     }
   }
   return { ok: true, values: { ...MOCK_CONFIG_VALUES } };
@@ -6227,10 +6363,34 @@ export async function mockRestartSidecar(): Promise<{ ok: boolean; error?: strin
 /* Test helper — reset the mock config store to its initial defaults. */
 export function _resetMockConfig(): void {
   Object.assign(MOCK_CONFIG_VALUES, {
-    KOKORO_SAMPLE_RATE: { key: 'KOKORO_SAMPLE_RATE', effective: 24000, source: 'default', locked: false, overridden: false },
-    SEG_QA_MAX_RERECORDS: { key: 'SEG_QA_MAX_RERECORDS', effective: 2, source: 'default', locked: false, overridden: false },
-    SEG_ASR_ENABLED: { key: 'SEG_ASR_ENABLED', effective: false, source: 'default', locked: false, overridden: false },
-    ANALYZER_STAGE1_PROMPT: { key: 'ANALYZER_STAGE1_PROMPT', effective: 'Attribute each sentence to its speaker.', source: 'default', locked: false, overridden: false },
+    KOKORO_SAMPLE_RATE: {
+      key: 'KOKORO_SAMPLE_RATE',
+      effective: 24000,
+      source: 'default',
+      locked: false,
+      overridden: false,
+    },
+    SEG_QA_MAX_RERECORDS: {
+      key: 'SEG_QA_MAX_RERECORDS',
+      effective: 2,
+      source: 'default',
+      locked: false,
+      overridden: false,
+    },
+    SEG_ASR_ENABLED: {
+      key: 'SEG_ASR_ENABLED',
+      effective: false,
+      source: 'default',
+      locked: false,
+      overridden: false,
+    },
+    ANALYZER_STAGE1_PROMPT: {
+      key: 'ANALYZER_STAGE1_PROMPT',
+      effective: 'Attribute each sentence to its speaker.',
+      source: 'default',
+      locked: false,
+      overridden: false,
+    },
   });
   MOCK_PROMPTS.set('ANALYZER_STAGE1_PROMPT', {
     id: 'ANALYZER_STAGE1_PROMPT',
@@ -6263,27 +6423,25 @@ async function realPutConfig(
   return res.json();
 }
 
-async function realResetConfig(
-  body: { keys?: string[]; group?: string; all?: boolean },
-): Promise<{ ok: boolean; values: ConfigValues }> {
+async function realResetConfig(body: {
+  keys?: string[];
+  group?: string;
+  all?: boolean;
+}): Promise<{ ok: boolean; values: ConfigValues }> {
   const res = await fetch('/api/config/reset', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
   if (!res.ok)
-    throw new Error(
-      `Config reset failed (${res.status}): ${(await res.text()) || res.statusText}`,
-    );
+    throw new Error(`Config reset failed (${res.status}): ${(await res.text()) || res.statusText}`);
   return res.json();
 }
 
 async function realGetPrompt(id: string): Promise<PromptState> {
   const res = await fetch(`/api/config/prompts/${encodeURIComponent(id)}`);
   if (!res.ok)
-    throw new Error(
-      `Prompt fetch failed (${res.status}): ${(await res.text()) || res.statusText}`,
-    );
+    throw new Error(`Prompt fetch failed (${res.status}): ${(await res.text()) || res.statusText}`);
   return res.json();
 }
 
@@ -6305,9 +6463,7 @@ async function realResetPrompt(id: string): Promise<PromptState> {
     method: 'POST',
   });
   if (!res.ok)
-    throw new Error(
-      `Prompt reset failed (${res.status}): ${(await res.text()) || res.statusText}`,
-    );
+    throw new Error(`Prompt reset failed (${res.status}): ${(await res.text()) || res.statusText}`);
   return res.json();
 }
 
@@ -6549,17 +6705,13 @@ const real = {
     const res = await fetch('/api/generation/stats');
     if (!res.ok) {
       const detail = await res.text().catch(() => '');
-      throw new Error(
-        `Generation stats fetch failed (${res.status}): ${detail || res.statusText}`,
-      );
+      throw new Error(`Generation stats fetch failed (${res.status}): ${detail || res.statusText}`);
     }
     return res.json();
   },
   /* fs-20 — per-run resource telemetry for the Admin trend panel (GET
      /api/generation/telemetry). Newest-first; empty when nothing recorded. */
-  getResourceTelemetry: async (
-    limit?: number,
-  ): Promise<{ records: ResourceTelemetryRecord[] }> => {
+  getResourceTelemetry: async (limit?: number): Promise<{ records: ResourceTelemetryRecord[] }> => {
     const qs = limit != null ? `?limit=${encodeURIComponent(limit)}` : '';
     const res = await fetch(`/api/generation/telemetry${qs}`);
     if (!res.ok) {
@@ -6762,9 +6914,7 @@ const mock = {
   /* fs-20 — mock per-run resource telemetry. Mirrors the throughput mock's
      newest-first shape; VRAM climbs slightly across the run so the trend
      panel's sparkline has a visible slope in mock mode. */
-  getResourceTelemetry: async (
-    limit?: number,
-  ): Promise<{ records: ResourceTelemetryRecord[] }> => {
+  getResourceTelemetry: async (limit?: number): Promise<{ records: ResourceTelemetryRecord[] }> => {
     /* Newest-first; the first three rows come from a second book so the Admin
        panel's per-book grouping has more than one group to render in mock mode. */
     const books = [
@@ -6807,7 +6957,13 @@ const mock = {
    record type from the same `../lib/api` surface as the other admin types. */
 export type { ResourceTelemetryRecord } from './types';
 /* Re-export config types so the config slice + view import from a single source. */
-export type { ConfigResponse, ConfigValues, KnobDescriptor, ConfigGroup, PromptState } from './types';
+export type {
+  ConfigResponse,
+  ConfigValues,
+  KnobDescriptor,
+  ConfigGroup,
+  PromptState,
+} from './types';
 
 /** One finished chapter's own throughput, for the dev Worktrees throughput
     table. `rtf` is synth-wall ÷ audio (< 1 = faster than realtime) or null when

--- a/src/views/analysing.tsx
+++ b/src/views/analysing.tsx
@@ -124,9 +124,12 @@ export function AnalysingView({
   const [phase, setPhase] = useState(0);
   const [phaseProgress, setPhaseProgress] = useState(0);
   const [logs, setLogs] = useState<Record<number, string[]>>({});
-  const [error, setError] = useState<{ message: string; code: string; detail?: string; remediation?: string } | null>(
-    null,
-  );
+  const [error, setError] = useState<{
+    message: string;
+    code: string;
+    detail?: string;
+    remediation?: string;
+  } | null>(null);
   const [retry, setRetry] = useState<{
     nonce: number;
     fresh: boolean;
@@ -571,7 +574,12 @@ export function AnalysingView({
             message: (e as Error)?.message ?? 'Analysis failed.',
           }),
         );
-        setError({ message: (e as Error).message || 'Analysis failed.', code, detail, remediation });
+        setError({
+          message: (e as Error).message || 'Analysis failed.',
+          code,
+          detail,
+          remediation,
+        });
       }
     })();
     return () => {
@@ -623,9 +631,17 @@ export function AnalysingView({
             if (live) return live;
             const record = errorById[String(id)];
             if (record) {
-              return { chapterId: id, message: record.message, code: record.code, remediation: record.remediation };
+              return {
+                chapterId: id,
+                message: record.message,
+                code: record.code,
+                remediation: record.remediation,
+              };
             }
-            return { chapterId: id, message: 'Analysis failed on a previous attempt. Retry to try again.' };
+            return {
+              chapterId: id,
+              message: 'Analysis failed on a previous attempt. Retry to try again.',
+            };
           });
         });
       })
@@ -1179,7 +1195,7 @@ export function AnalysingView({
           {error && (
             <div className="mt-6 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-left">
               <p className="text-sm font-semibold text-red-900">
-                {(error.code === 'daily_quota' || error.code === 'analyzer-daily-quota')
+                {error.code === 'daily_quota' || error.code === 'analyzer-daily-quota'
                   ? 'Daily free-tier quota exhausted'
                   : 'Analysis failed'}
               </p>

--- a/src/views/analysing.tsx
+++ b/src/views/analysing.tsx
@@ -151,6 +151,10 @@ export function AnalysingView({
   const [throttleByPhase, setThrottleByPhase] = useState<
     Record<number, { until: number; model: string; reason: 'rpm' | 'tpm' | 'rpd' | 'retry-after' }>
   >({});
+  /* Server-resolved model id per phase — populated from the `model` field
+     on `kind: 'phase'` SSE events. Lets PhaseModelChip display what the
+     server ACTUALLY ran on rather than the client's Redux selection. */
+  const [serverModelByPhase, setServerModelByPhase] = useState<Record<number, string>>({});
   /* Server-refined total-remaining-ms. Null until the first chapter
      completes — then the heading swaps from the static describeSize
      string (Gemini-calibrated 22ms/word) to a value that reflects the
@@ -348,6 +352,7 @@ export function AnalysingView({
     setLastEventAt(null);
     setLive(null);
     setHeartbeatByPhase({});
+    setServerModelByPhase({});
     setRemainingMs(null);
     /* Clear castIncomplete on every re-entry so an old "paused" state
        doesn't linger when the user clicks Try again / Start fresh /
@@ -388,10 +393,13 @@ export function AnalysingView({
           model: requestModel,
           fresh: retry.fresh || undefined,
           allowStage1Shrink: retry.allowStage1Shrink || undefined,
-          onPhase: ({ phaseId, progress, live }) => {
+          onPhase: ({ phaseId, progress, live, model: serverModel }) => {
             if (cancelled) return;
             setConn('streaming');
             markEvent();
+            if (serverModel) {
+              setServerModelByPhase((prev) => ({ ...prev, [phaseId]: serverModel }));
+            }
             dispatch(
               analysisActions.applyAnalysisSnapshotTick({
                 manuscriptId,
@@ -1284,6 +1292,7 @@ export function AnalysingView({
               live={live}
               heartbeat={heartbeatByPhase[p.id]}
               throttle={throttleByPhase[p.id]}
+              serverModelByPhase={serverModelByPhase}
               isLocalAnalyzer={isLocalAnalyzer}
               analysisStarted={analysisStarted}
               conn={conn}


### PR DESCRIPTION
Two analysing-view honesty/legibility improvements (spec §5+§6, additive SSE).

**W2 — model honesty:** server emits the resolved analyzer id on every phase SSE event; the chip prefers it over the Redux default (so it stops lying '4B' when 9B ran).

**W3 — section progress:** the live tick now carries sectionsDone/Total; LiveChapterRow renders 'section M/N' + sub-bar when sectionsTotal>1.

Tests: server (phase model emit, live-tick section counts), frontend unit (chip prefers serverModel; section line gating), e2e (chip label + section text). `npm run verify` green. Independent of #840; off main (Wave 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)