### PR TITLE
docs(docs): defer Wave 4 to Could (#845) + document two-model-split gotcha

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -153,12 +153,6 @@ _Full detail + acceptance:_ [#790](https://github.com/dudarenok-maker/Castwright
 - _Benefit (user):_ non-English (Cyrillic, and other non-Latin) books work end-to-end instead of silently colliding ids / dead cross-book reuse / a stalled analysis.
 _Full detail + acceptance:_ [#823](https://github.com/dudarenok-maker/Castwright/issues/823).
 
-#### `fs-45` — VRAM MB-accounting policy + two-model-split UI (Wave 4, beta 12/16 GB cards) ([#845](https://github.com/dudarenok-maker/Castwright/issues/845))
-
-- _What:_ Wave 1 (plan [222](features/222-gpu-residency-and-analysing-honesty.md)) already gives 12/16 GB cards coexistence via the `gpu.safeCoexistMb` threshold (a roomy card simply doesn't evict). Wave 4 refines it for beta testers running better cards than the 8 GB dev box: (a) a per-(engine, mode) MB cost table vs detected VRAM (non-additive Qwen synth/design modes) so a 12 GB card with a heavy combo that passes the coarse threshold but would overcommit is caught; (b) a two-model analysis-split warn + confirm UI when phase0/phase1 use two different local models that won't co-fit.
-- _Benefit (user):_ beta testers on 12/16 GB cards get precise coexistence (no needless eviction) without edge-case OOMs, and a split run can't silently overcommit.
-_Full detail + acceptance:_ plan [222](features/222-gpu-residency-and-analysing-honesty.md) "Out of scope" + spec `docs/superpowers/specs/2026-06-16-vram-budget-aware-gpu-policy-design.md` §7 · [#845](https://github.com/dudarenok-maker/Castwright/issues/845).
-
 ### Companion app
 
 _The three items below are the companion-app follow-ups left after the Android v1 shipped
@@ -181,6 +175,12 @@ security & hardening, ops & distribution, listener-app handoffs).
 Sub-groups and the items within them are ranked top = highest priority.
 
 ### Reliability & observability
+
+#### `fs-45` — VRAM MB-accounting policy (Wave 4, beta 12/16 GB cards) ([#845](https://github.com/dudarenok-maker/Castwright/issues/845))
+
+- _What:_ A per-(engine, mode) MB cost table vs detected VRAM, replacing Wave 1's coarse `gpu.safeCoexistMb` threshold so a 12 GB card with a heavy combo that passes the threshold but would overcommit is caught. **Deferred (Could) until a real 12/16 GB box yields measured cost numbers:** an adversarial review found that with guessed values the engine makes the same evict/coexist decisions as the threshold (and even mis-evicts on a 12 GB card during voice design), so it adds OOM risk for ~no decision-quality gain. The related two-model-split gotcha is now documented in `docs/local-llm.md` (no UI built). Revisit with telemetry from a beta tester's card.
+- _Benefit (user):_ precise coexistence on bigger cards without edge-case OOMs — once the cost table is measured rather than guessed.
+_Full detail + acceptance:_ plan [222](features/222-gpu-residency-and-analysing-honesty.md) "Out of scope" + spec `docs/superpowers/specs/2026-06-16-vram-budget-aware-gpu-policy-design.md` §7 · drafted plan `docs/superpowers/plans/2026-06-16-wave4-vram-mb-accounting.md` · [#845](https://github.com/dudarenok-maker/Castwright/issues/845).
 
 #### `srv-30` — CPU-only analyzer device (large RAM-resident model, concurrent with GPU TTS) ([#507](https://github.com/dudarenok-maker/AudioBook-Generator/issues/507))
 

--- a/docs/local-llm.md
+++ b/docs/local-llm.md
@@ -84,6 +84,27 @@ then running analysis at 16384 triggers a silent full reload mid-stream,
 which used to surface as "Analysis stream ended without a result event" with
 no other signal. The reasoning is at `server/src/routes/ollama-health.ts:161`.
 
+### Keeping the analyzer warm + the analyzer↔TTS / two-model-split gotcha (plan 222)
+
+The analyzer model is kept **resident** across the chapter loop (`keep_alive: '5m'`)
+so it isn't unloaded+reloaded between sections — reloading a multi-GB model every
+section is the "VRAM sawtooth" / mid-stream stall that hurts large (especially
+Cyrillic) books. A resident analyzer can't co-reside with a TTS/voice-design load
+on a small GPU, so the server **evicts the resident analyzer before any sidecar
+TTS/voice-design load** (or returns a 409 if an analysis is mid-flight), then loads.
+On a roomy card (detected VRAM ≥ `GPU_SAFE_COEXIST_MB`, default 11000 MB) nothing
+is evicted — analyzer + TTS coexist. See `server/src/gpu/` + plan 222.
+
+**Two-model analysis split — troubleshooting.** If you set TWO *different local*
+models for the two analysis phases (`ANALYZER_PHASE0_MODEL` + `ANALYZER_PHASE1_MODEL`),
+they can't both stay resident on a small GPU — they'll **reload between phases**,
+slowing the run (each phase pays a cold model load). On an 8 GB card this is
+unavoidable. To avoid it: use the **same** local model for both phases, pair **one
+local + one cloud** model (Gemini uses no VRAM), or run on a **larger card** (12/16 GB)
+where both co-reside. A VRAM-aware in-app warning + per-model MB budgeting is tracked
+but deferred (issue #845 / `fs-45`) until there's measured telemetry from real
+12/16 GB hardware.
+
 ## Pinning the analyzer to 100% GPU
 
 By default Ollama makes its own GPU-vs-CPU layer-split decision on every model

--- a/docs/superpowers/plans/2026-06-16-wave4-vram-mb-accounting.md
+++ b/docs/superpowers/plans/2026-06-16-wave4-vram-mb-accounting.md
@@ -1,0 +1,70 @@
+# Wave 4 — VRAM MB-accounting policy + two-model-split warning — Implementation Plan
+
+> ⏸️ **STATUS: DEFERRED — `moscow:could`, issue #845 / `fs-45`.** This plan is drafted
+> and adversarial-review-hardened but **NOT executed**. An adversarial review (2026-06-16)
+> concluded the MB engine is premature: with *guessed* cost numbers it makes the same
+> evict/coexist decisions as Wave 1's `gpu.safeCoexistMb` threshold across 8/12/16 GB (and
+> mis-evicts on a 12 GB card during voice design), so it adds OOM risk for ~no gain. **Revisit
+> only when a real 12/16 GB box provides MEASURED VRAM telemetry** to populate
+> `gpu.modelCostMb.*`. The two-model-split gotcha was instead documented in `docs/local-llm.md`
+> (no UI). When reviving: re-check the review's BLOCKER 1 (make `incomingMb` a *trailing
+> optional* arg so the ~5 passthrough mocks survive) and BLOCKER 2 (use measured, not guessed,
+> design cost) — both captured in the #845 comment thread.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** Replace the coarse single-threshold eviction decision (`gpu.safeCoexistMb`) with a per-(engine, mode) **MB-accounting** policy, so 12/16 GB beta cards coexist *precisely* (a heavy combo that would overcommit is still caught), and warn at the settings surface when a two-model analysis split won't co-fit.
+
+**Architecture:** A pure cost model (`costMb(key, mode?)`) + a pure `planLoad(state, residentMbs[], incomingMb)`. `withGpuLoad` gains the incoming engine's cost so it can call `planLoad` instead of the threshold; the eviction *action* (evict-all → verify → load under the mutex) is unchanged — only the *decision* gets MB-precise. A small read-only server route exposes `splitFits` so `model-settings-form.tsx` can render a warning without replicating the cost math.
+
+**Tech Stack:** TS (Node ESM), Vitest, Express, the config registry, Playwright e2e.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-vram-budget-aware-gpu-policy-design.md` §7. **Issue:** #845 (fs-45). Builds on plan 222 (Wave 1).
+
+**Branch:** `feat/server-vram-mb-accounting` (off `main`, already checked out).
+
+**Anchors (verified):** `withGpuLoad(loadFn)` (`server/src/gpu/gpu-load.ts:23`, currently uses `shouldEvictBeforeSidecarLoad`); call sites — `ensureSidecarEngineReady` (`server/src/tts/ensure-sidecar-loaded.ts`, wraps the `/load` loop) and `designQwenVoiceForCharacter` (`server/src/routes/qwen-voice.ts`, wraps the design fetch). Residents from `probeOllamaHealth().resident` (`ollama-health.ts`), tag-canonicalized at `ollama-health.ts:143`. VRAM from `getLastKnownVram()` (`gpu/vram-state.ts`). Sidecar engine costs precedent: `gpu.weight.*` (`server/src/tts/engine-vram-cost.ts`). Settings UI: `src/components/model-settings-form.tsx` (`analyzerPhase0Model`/`analyzerPhase1Model`); model labels `src/lib/models.ts`.
+
+**Cost table (initial, registry `gpu.modelCostMb.*`, MB; biased UP on the OOM-critical design path):** ollama `qwen3.5:4b`=3500, `llama3.1:8b`=5000, `qwen3.5:9b`=6400; qwen `synth`=3700, qwen `design`=5000 (Base+VoiceDesign, non-additive — one value, never summed); coqui=3500; kokoro=1000; gemini/cloud=0; unknown→ a high fallback (`gpu.modelCostMb.unknown`, default 7000 — prefer evicting). Headroom reuses `gpu.vramHeadroomMb` (NEW knob, default 1024).
+
+---
+
+### Task 1: Cost model — `costMb(key, mode?)`
+**Files:** Create `server/src/gpu/model-cost.ts` + `model-cost.test.ts`. Register knobs in `server/src/config/registry.ts`.
+- [ ] Failing tests: `costMb('qwen3.5:9b')`=6400; `costMb('qwen','synth')`=3700 vs `costMb('qwen','design')`=5000 (NOT summed); tag-canonical `costMb('qwen3.5:9b-instruct-q4_K_M')`=6400 (prefix match, reuse the `ollama-health.ts:143` matcher or its helper); unknown id → the high fallback; `costMb('gemini')`=0.
+- [ ] Implement `costMb` reading `gpu.modelCostMb.<key>` (live via `configValue`) with the table defaults; canonicalize Ollama tags before lookup. Register the `gpu.modelCostMb.*` + `gpu.vramHeadroomMb` knobs (ConfigKnob shape: `key`/`env`/`type:'integer'`/`min`/`default`/`apply`/`risk`/`label`/`help` — mirror `gpu.safeCoexistMb`). Run `npm run config:sync` and commit the regenerated `.env.example` (do NOT hand-edit it).
+- [ ] Green; commit `feat(server): per-(engine,mode) VRAM MB cost model`.
+
+### Task 2: `planLoad` + `splitFits` (pure)
+**Files:** add to `server/src/gpu/residency.ts` (or `model-cost.ts`) + tests.
+- [ ] Failing tests: `planLoad({cuda,8188},[6400],3700)` → `{fits:false}` (10100 > 8188−1024); `planLoad({cuda,12288},[6400],3700)` → `{fits:true}`; CPU → always fits; unknown total → `{fits:false}` (conservative); `splitFits('qwen3.5:9b','qwen3.5:4b',{cuda,8188})` → false, `(…,{cuda,16384})` → true. Pure — residents' MB injected (no live probe inside).
+- [ ] Implement: `planLoad(state, residentMbs, incomingMb)` → CPU/unknown handling then `sum(residentMbs)+incomingMb ≤ totalMb − headroom`. `splitFits(a,b,state) = planLoad(state, [costMb(a)], costMb(b)).fits`. Keep `shouldEvictBeforeSidecarLoad` for now (Task 3 migrates callers off it; remove only once unused).
+- [ ] Green; commit `feat(server): planLoad + splitFits MB-fit checks`.
+
+### Task 3: Rewire `withGpuLoad` to MB precision
+**Files:** `server/src/gpu/gpu-load.ts` + its call sites + `gpu-load.test.ts`.
+- [ ] Failing tests: extend `gpu-load.test.ts` — `withGpuLoad(3700, loadFn)` on `{cuda,8188}` with a resident `[6400]` → evicts (10100 over budget); on `{cuda,12288}` → no evict, coexist; CPU → no evict; analysis-busy on a constrained card → `GpuBusyError`; eviction-verify fail-closed (unchanged). (Mock `costMb`/`probeOllamaHealth`/`planLoad` deps.)
+- [ ] Implement: change signature to `withGpuLoad(incomingMb: number, loadFn)`. Decision becomes: read residents via `probeOllamaHealth().resident` → map through `costMb` → `planLoad(getLastKnownVram(), residentMbs, incomingMb).fits` ? `loadFn()` : (mutex → refuse-if-busy → evict-all → verify → load). The evict/verify/refuse machinery is unchanged. Update call sites to pass the incoming cost: `ensureSidecarEngineReady` → `costMb(engine, engine==='qwen'?'synth':undefined)`; `designQwenVoiceForCharacter` → `costMb('qwen','design')`. (Probing residents needs an async read; keep it inside the function. For determinism, planLoad stays pure — the probe + mapping happen in `withGpuLoad`, injected into planLoad.)
+- [ ] Green (incl. the existing eviction-regression + the two hook tests still pass with the new signature); commit `feat(server): MB-precise eviction decision in withGpuLoad`.
+
+### Task 4: `GET /api/gpu/split-fits` route
+**Files:** a route (e.g. extend `server/src/routes/gpu-queue.ts` or new `gpu-policy.ts`) + test.
+- [ ] Failing test: `GET /api/gpu/split-fits?a=qwen3.5:9b&b=qwen3.5:4b` → `{ fits: <bool>, totalMb, budgetMb }` using `splitFits` + `getLastKnownVram`. CPU/unknown → `fits:true`/conservative per `planLoad`.
+- [ ] Implement the route; mount it. Add the client method in `src/lib/api.ts` (`getSplitFits(a,b)`), behind the mock too.
+- [ ] Green; commit `feat(server): GET /api/gpu/split-fits for the settings split warning`.
+
+### Task 5: Two-model-split warning in settings
+**Files:** `src/components/model-settings-form.tsx` + test + e2e.
+- [ ] Failing unit test: when `analyzerPhase0Model` ≠ `analyzerPhase1Model` and both are local (Ollama-shaped ids), and the (mocked) `getSplitFits` returns `{fits:false, totalMb:8188}`, the form renders a budget-worded warning ("won't both fit in your ~8 GB GPU — they'll reload between phases"). When `fits:true` (or either model is cloud/gemini, or phase0==phase1), NO warning.
+- [ ] Implement: on the relevant model-pick change, call `api.getSplitFits(phase0, phase1)` (debounced/once) and render the inline warning (design tokens only, no hex). Gate on both-local.
+- [ ] e2e (mandatory — crosses the settings/redux seam): in an analysing/account e2e, set two different local models, stub `getSplitFits`→false, assert the warning; set equal/cloud → none.
+- [ ] Green; commit `feat(frontend): warn when a two-model local split won't co-fit VRAM`.
+
+### Finalize
+- [ ] `npm run config:check`; full `LOW_CONCURRENCY=1 npm run verify`; push (pre-push verify) → PR (`Closes #845`); flip plan 222 / spec §7 status note; consider removing now-unused `shouldEvictBeforeSidecarLoad` if Task 3 fully replaced it (else keep + note).
+
+## Self-review notes
+- Spec §7 coverage: cost table (T1), planLoad/splitFits (T2), MB-precise withGpuLoad (T3), split-fits route (T4), settings warning (T5).
+- **Back-compat:** on 8 GB the MB decision yields the SAME evict-always behavior as the threshold (10100 > 7168), so Wave 1 boxes are unchanged. The win is 12/16 GB precision.
+- **Risk:** `withGpuLoad` signature change touches 2 call sites — update both; the eviction-regression test must stay green. `costMb` unknown→high keeps the fail-safe (evict when unsure).
+- Out of scope: per-model live-MB calibration; mid-run split confirm (pre-flight warning only).


### PR DESCRIPTION
Per review, Wave 4's MB-accounting engine is premature (guessed numbers → same decisions as the Wave 1 threshold; mis-evicts on 12 GB during design). Moves `fs-45`/#845 to `moscow:could` (revisit with measured 12/16 GB telemetry), documents the two-model-split gotcha in `docs/local-llm.md` (no UI), and preserves the drafted+review-hardened plan with a DEFERRED banner. Refs #845.