### PR TITLE
fix(scripts): retry test:server once on a vitest fork-pool crash (not a red test)

### DIFF
--- a/scripts/tests/verify-cache.test.mjs
+++ b/scripts/tests/verify-cache.test.mjs
@@ -21,11 +21,25 @@ import {
   stepTouchedByDiff,
   computeShared,
   parseNvidiaSmiUtil,
+  isVitestPoolCrash,
   STEPS,
   _internals,
 } from '../verify-cache.mjs';
 
 const { SCHEMA_VERSION } = _internals;
+
+test('isVitestPoolCrash: true for fork-pool worker crashes, false for red tests', () => {
+  // Transient fork-pool process crashes — warrant ONE auto-retry.
+  assert.equal(isVitestPoolCrash('Error: [vitest-pool]: Worker forks emitted error.'), true);
+  assert.equal(isVitestPoolCrash('Caused by: Error: Worker exited unexpectedly'), true);
+  // Real test failures — must NOT retry (that would mask a flaky test).
+  assert.equal(isVitestPoolCrash('FAIL  src/foo.test.ts > does a thing'), false);
+  assert.equal(isVitestPoolCrash('AssertionError: expected 1 to be 2'), false);
+  assert.equal(isVitestPoolCrash('Tests  1 failed | 200 passed'), false);
+  // Benign / empty.
+  assert.equal(isVitestPoolCrash(''), false);
+  assert.equal(isVitestPoolCrash(undefined), false);
+});
 
 function mkTmp() {
   return mkdtempSync(join(tmpdir(), 'verify-cache-test-'));

--- a/scripts/verify-cache.mjs
+++ b/scripts/verify-cache.mjs
@@ -512,6 +512,48 @@ function formatSecs(ms) {
 }
 
 // Top-level orchestrator. Returns process exit code.
+/* Vitest fork-pool steps that can suffer a transient WORKER crash (the process
+   dies) under resource contention (busy GPU / a parallel session) — distinct
+   from a red test. These warrant ONE automatic retry. See issue #848 +
+   docs/features/archive/45-vitest-pool-tuning.md. */
+const RETRIABLE_POOL_STEPS = new Set(['test:server', 'test:server-slow']);
+
+/** True iff `stderr` carries a vitest fork-pool PROCESS crash signature (a worker
+    died), as opposed to a normal test failure. A real test failure must NOT match
+    — retrying that would mask a flaky test. */
+export function isVitestPoolCrash(stderr) {
+  return /Worker exited unexpectedly|Worker forks emitted error|\[vitest-pool\]/i.test(stderr || '');
+}
+
+/** Run one pipeline step (`npm run <name>`) and return its exit code. Retriable
+    pool steps stream stdout LIVE but CAPTURE stderr so a fork-pool crash can be
+    detected and the step retried exactly once; every other step inherits both
+    streams unchanged. */
+function runStepProcess(stepName, { cwd, env }) {
+  const runOnce = (capture) => {
+    const r = spawnSync('npm', ['run', stepName], {
+      cwd,
+      shell: true,
+      env,
+      ...(capture
+        ? { encoding: 'utf8', stdio: ['inherit', 'inherit', 'pipe'], maxBuffer: 64 * 1024 * 1024 }
+        : { stdio: 'inherit' }),
+    });
+    const stderr = capture ? r.stderr || '' : '';
+    if (stderr) process.stderr.write(stderr); // captured stderr isn't echoed live — surface it
+    return { code: r.status ?? 1, stderr };
+  };
+  if (!RETRIABLE_POOL_STEPS.has(stepName)) return runOnce(false).code;
+  let res = runOnce(true);
+  if (res.code !== 0 && isVitestPoolCrash(res.stderr)) {
+    console.log(
+      `[retry] ${stepName} — vitest fork-pool crash ("Worker exited unexpectedly"), not a test failure; re-running once`,
+    );
+    res = runOnce(true);
+  }
+  return res.code;
+}
+
 export function runPipeline({ argv = [], cwd = process.cwd(), env = process.env } = {}) {
   const flags = parseFlags(argv);
   const validNames = STEPS.map((s) => s.name);
@@ -631,14 +673,8 @@ export function runPipeline({ argv = [], cwd = process.cwd(), env = process.env 
 
     console.log(`[run] ${step.name}`);
     const t0 = Date.now();
-    const r = spawnSync('npm', ['run', step.name], {
-      cwd,
-      stdio: 'inherit',
-      shell: true,
-      env,
-    });
+    const code = runStepProcess(step.name, { cwd, env });
     const dt = Date.now() - t0;
-    const code = r.status ?? 1;
     if (code === 0) {
       console.log(`[pass] ${step.name} (took ${formatSecs(dt)})`);
       if (fileList !== null) {


### PR DESCRIPTION
Closes #848. The verify/pre-commit runner now captures stderr for the test:server / test:server-slow legs and re-runs the leg ONCE when stderr matches a fork-pool crash signature (`Worker exited unexpectedly` / `[vitest-pool]`). A real test failure does not match, so flaky tests are never masked. New pure `isVitestPoolCrash` helper with paired node:test coverage. Removes the contention-driven push friction documented on #848.