### PR TITLE
feat(server): narrator-default heuristic for non-English attribution

### DIFF
--- a/docs/features/162-fs2-multilanguage.md
+++ b/docs/features/162-fs2-multilanguage.md
@@ -110,6 +110,41 @@ audio language. So `generateVoiceStyle` / `designQwenVoice` / the voice-sample
 APIs stay language-free (CLAUDE.md simplicity-first). Do not re-add a persona
 language param.
 
+### Non-English narrator-default heuristic (plan 221 Wave A)
+
+The per-sentence attribution model — especially on non-Latin scripts —
+mislabels third-person NARRATION as the named character (e.g. "Егор засунул
+руки в карманы" → `egor`), which would read narration in that character's
+voice. Because the spoken-vs-narration distinction is mechanical, non-English
+stage-2 attribution decides it in code instead of trusting the model: after
+`runStage2ChapterChunked` returns, `applyNonEnglishNarratorDefault`
+(`server/src/analyzer/narrator-default.ts`) forces every NON-spoken sentence's
+`characterId` to `narrator`. A "spoken line" begins with a dialogue dash
+(—/–/-, including the named HTML entities `&mdash;`/`&ndash;`) or an opening
+quote («/"/“), or contains a quoted span; everything else is narration. The
+helper is wired inside the shared `attributeChapterStage2`
+(`server/src/routes/analysis.ts`) gated on `isNonEnglish(language)`, so both the
+main and subset analysis routes get it and the English path is byte-identical
+(same-array no-op). It runs AFTER coverage, which keys on sentence text not
+`characterId`, so the coverage verdict is unchanged.
+
+The one class the heuristic deliberately leaves to the model is the dashed
+narrative TAG ("— сказал юноша."), which looks spoken — the Russian branch of
+`languagePreamble` (`server/src/analyzer/gemini.ts`) appends a guard telling the
+model that a dashed line describing who spoke or what they did is the narrator,
+not the speaker.
+
+**Evidence (`server/repro-heuristic.mts`, against a local non-committed Russian
+EPUB):** the model's narration-block correctness was 0–1/6 per run; the
+heuristic deterministically produced 6/6 every run while leaving every dialogue
+line untouched (`spoken-lines-kept-named` unchanged across 3 runs).
+
+**Known limitation:** a genuine spoken line that lacks BOTH a leading
+dash/quote AND any quoted span would be wrongly forced to `narrator`. This
+depends on the model preserving the dialogue marker; empirically gemma-e4b
+preserved the dash on every dialogue line, but it is a model-preservation
+dependency, not a guarantee.
+
 ## Test plan
 
 ### Automated coverage

--- a/docs/features/221-multilingual-attribution-gemma-and-cast-merge.md
+++ b/docs/features/221-multilingual-attribution-gemma-and-cast-merge.md
@@ -1,0 +1,255 @@
+---
+status: active
+shipped: null
+owner: null
+---
+
+# 221 — Multilingual attribution: Russian prompt guards + local model + cast de-duplication
+
+> Status: active — **Wave A shipped** (deterministic narrator-default heuristic +
+> Russian dash-tag preamble guard); Waves B/C/D are follow-ups. Investigation
+> complete and reproduced cold against the real book; the **prompt-guard fix is
+> empirically validated**, model choice settled. Extends [162 (fs-2 multilanguage)](162-fs2-multilanguage.md)
+> and [187 (large-chapter stage-2 + attribution coverage)](archive/187-large-chapter-stage2-and-attribution-coverage.md).
+> Trigger: full analysis of a Russian book (Ночной дозор / Night Watch, 9 ch,
+> 43-char cast, run on the **local** engine with `qwen3.5:9b`) never completes —
+> stage-2 attribution fails the coverage guard, and the cast is full of
+> un-merged duplicates.
+
+## Benefit / Rationale
+
+- **User:** a non-English manuscript (Russian first) completes a full local
+  analysis, with sentences attributed *correctly* (dialogue to speakers,
+  narration to the narrator), the cast collapsed to the real people, and one-off
+  background speakers folded into localized generic voices.
+- **Technical:** the stage-2 attribution prompt becomes script-aware (Russian
+  dash-dialogue + third-person-narration rules); the recommended local model for
+  non-English is one proven robust on Cyrillic dialogue; cross-chapter roster
+  merging stops minting duplicates.
+- **Architectural:** no contract change — `language` stays an open BCP-47 string
+  (162); model id stays a free string routed by `selectAnalyzer`.
+
+---
+
+## Root cause (reproduced, with correctness measured — not just coverage)
+
+Driven through the **real** pipeline (real EPUB parse → real chunker → real
+skill prompt → exact Ollama `/api/chat` body). Probe scripts:
+`server/repro-*.mts` (untracked scratch — delete before any commit).
+
+**Critical methodology note:** the stage-2 coverage guard (`stage2-coverage.ts`)
+**never inspects `characterId`** — `ok` is computed purely from word-overlap of
+sentence *text*. So "coverage PASS (ratio 0.9)" means *"~90% of words were
+transcribed back"*, NOT *"speakers are correct."* All model judgements below
+were therefore re-measured on **attribution correctness** (per-sentence speaker
+labels), not coverage.
+
+### Defect 3 — stage-2 under-production + mis-attribution on Russian dialogue (blocker)
+
+`qwen3.5:9b`, under constrained JSON decoding, attributes the opening narration
+then **collapses at the first em-dash («—») dialogue line**, emits a tiny valid
+JSON, and stops (`done_reason: stop`, not `length` — the truncation guard never
+fires; only coverage catches it). **Stochastic — ~⅔ of attempts fail** at temp
+0.2 (small-N estimate), which is why all 3 coverage retries failed. The current
+coverage-guard retry re-runs the **identical call at the same temperature**;
+bumping temperature made it *worse* in testing — grammar-off ~doubled Qwen's
+completion rate but didn't fix it.
+
+Independently, **both** Qwen and Gemma mis-handle two Russian-specific things
+even when they complete:
+1. **Third-person narration labelled as the character** (`Егор засунул руки в
+   карманы` → `egor`) instead of `narrator` — would read narration in the
+   character's voice.
+2. **Dash-dialogue narrative *tags*** (`— коротко сказал юноша`, `— Девушка
+   улыбнулась`) attributed to a speaker instead of `narrator`. Root cause: the
+   attribution skill's "split dialogue from tags" rules + examples are
+   English-quote-centric (`"…," he said`); Russian `— speech — tag` gets
+   segmented into tag-fragments that look like speech.
+
+### Defect 1 — cross-chapter cast merge is exact-id only
+
+`mergeRosterChapter` (`server/src/routes/analysis.ts:545`, key line `:550`
+`roster.get(incoming.id)`) merges by **exact id**, with no name/alias fallback.
+The analyzer emits divergent ids for the same Russian person across chapters
+(transliteration + name-form drift) → 43 unmerged duplicates, every
+`aliases: []`: `boris-ignatyevich`/`boris-ignatievich`/`shef`,
+`anton`/`anton-gorodetsky`, `egor`/`yegor`, `tigrenok`/`tigerlet`,
+`olga`/`olya`, `svet`/`svetlana`/`svetlana-nazarova`. This is *also* the source
+of the residual attribution slips — e.g. the young vampire "юноша" has **no
+roster character**, so his lines (`— Сильнее`) land on `egor`/`yegor`. No
+prompt or model fixes a missing roster entry.
+
+### Defect 2 — `unknown-male/female` fold never ran + is English-only
+
+`foldMinorCast` (`server/src/analyzer/fold-minor-cast.ts`) runs **post-stage-2**
+(needs line counts; main call `analysis.ts:~3787`). Stage-2 failed (Defect 3) →
+the fold never ran → **buckets never created** (as observed). And it's
+English-only: `GENERIC_ROLE_TAIL` can't catch девушка/парень/Депутат/Следователь;
+`makeBucket` hardcodes English names; and the **canonicalizer invariant**
+(`fold-minor-cast.ts:368-373`) *re-stamps* `name:'Unknown male'/'Unknown female'`
+on every fold pass — so localizing `makeBucket` alone is a no-op unless the
+canonicalizer is localized too (it has no `language` in scope today).
+
+---
+
+## Empirical findings (this is the new core — measured on the failing section)
+
+Same section (7576 chars / 1095 words), production-shaped inbox, real 43-char
+roster, `think:false`, `num_ctx 32768`, RTX 4070 (8 GB).
+
+**Prompt guards are the biggest quality lever** (Russian narration rule +
+dash-tag splitting, injected into the system instruction):
+
+| | Gemma e4b, **no guards** | Gemma e4b, **+ guards** |
+|---|---|---|
+| narrator ratio | 67% | **88%** |
+| Narration-about-Egor correct | ❌ many → `egor` | ✅ **9/10** (one `[11]` straggler) |
+| Dialogue tags → narrator | ❌ → speaker | ✅ mostly |
+| Completes / deterministic | ✅ | ✅ |
+
+Guards are **model-specific**: they sharply help Gemma; they *regressed* Qwen
+(53% narrator — Qwen keys on the many mid-sentence dashes in Russian prose).
+
+**Model comparison (with guards, correctness + speed):**
+
+| Model | gen tok/s | prefill | quality | verdict |
+|---|---|---|---|---|
+| **gemma e4b UD-Q4** (`gemma4-e4b-8gb`) | **~56** | <2 s | 88% narr, `[11]` stray | ✅ **production pick** |
+| gemma e4b UD-Q5 (`gemma4-e4b-q5`) | ~52 | low | 83–86% narr, `[11]` stray | ≈ Q4, no gain — skip |
+| gemma 12B (`gemma4-12b-8gb`) | **~7** | **~50 s** | 91% narr, `[11]` fixed | ❌ ~24 h/book, 16k didn't help |
+| qwen3.5:9b | ~22–26 | — | 85% narr *when it completes* (~⅓) | ❌ unreliable; guards hurt it |
+| qwen3.5:4b | — | — | unparseable JSON | ❌ |
+
+**Conclusions:** (1) `gemma4-e4b` **UD-Q4** + guards is the sweet spot — fast,
+fits, reliable, good quality. (2) Climbing quant (Q5) or size (12B) yields no
+usable gain — Q5 ≈ Q4, the 12B is fatally slow on an 8 GB card (compute/bandwidth
+bound; KV reduction to 16k did not help). (3) Residual errors (`[11]`
+action-narration, the missing "юноша") are **prompt + roster**, not model
+fidelity. (4) **Wall-clock is a real constraint**: even the fast e4b is ~158 s
+per ~9k-char section → **~3 h for this ~72-section book.** The 12B would be
+~24 h. This bounds any model choice.
+
+---
+
+## The plan
+
+TDD throughout (CLAUDE.md): each behaviour ships a paired test; each fix a
+regression test that fails before. Implementation branches off `main` (the
+current `fix/server-gpu-eviction-…` branch holds unrelated work).
+
+### Wave A — Russian attribution prompt guards (the validated quality fix) — IMPLEMENTED
+
+**Status: shipped.** Implemented as a deterministic post-model heuristic plus a
+preamble guard, rather than guard-text-only:
+
+1. **Narrator-default heuristic** (`server/src/analyzer/narrator-default.ts`,
+   wired into `attributeChapterStage2` in `server/src/routes/analysis.ts`, gated
+   on `isNonEnglish(language)`): after stage-2 returns, every NON-spoken sentence
+   is forced to `narrator`. Mechanically catches third-person narration labelled
+   as a character (`Егор засунул руки в карманы` → `narrator`) without trusting
+   the model. Runs after coverage (which keys on text, not `characterId`), so the
+   verdict is unchanged; English is a byte-identical no-op. Empirically (the
+   model's narration correctness 0–1/6 → a deterministic 6/6 every run, dialogue
+   untouched). See [162](162-fs2-multilanguage.md) for the full write-up.
+2. **Russian dash-dialogue tag guard** in `languagePreamble`
+   (`server/src/analyzer/gemini.ts`): the one class the heuristic deliberately
+   leaves to the model is the dashed narrative TAG (`— сказал юноша`,
+   `— Девушка улыбнулась`), which looks spoken — the Russian preamble now tells
+   the model that such a line is the narrator, only the spoken words → the
+   speaker.
+
+- **Tests:** `server/src/analyzer/narrator-default.test.ts` (pure unit:
+  `isSpokenLine`, `forceNarratorOnNonSpokenLines`, `applyNonEnglishNarratorDefault`,
+  + the `foldMinorCast` interaction); `server/src/analyzer/gemini.test.ts`
+  (dash-tag guard present for `ru`, absent for `en`/absent).
+- **Known limitation:** a genuine spoken line with no leading dash/quote and no
+  quoted span would be wrongly forced to `narrator` (model-marker-preservation
+  dependency). The deterministic narration rule from the original guard-text plan
+  (heavy stage-2-only guard block threading the stage through `languagePreamble`)
+  was superseded by the code-side heuristic, which is more reliable; untagged
+  dashed-line speaker-continuation remains a model-only concern (Wave C roster).
+
+### Wave B — recommended local model for non-English
+
+The **shipped default is cloud Gemini** (`analysisEngine:'gemini'`,
+`gemini-3.1-flash-lite`; `user-settings.ts:236,253`). This bug hits **local**
+users (offline) whose Ollama default is `qwen3.5:4b` (`DEFAULT_OLLAMA_MODEL`).
+So this is NOT a global default flip — it's about the **local** model:
+
+1. Add `gemma4-e4b` (UD-Q4) to the model list (`src/lib/models.ts`, engine
+   `'local'`) with a "best for non-English / multilingual" hint.
+2. Make the **local** model selection language-aware: non-English →
+   `gemma4-e4b`; keep `qwen3.5:4b/9b` for English and selectable for any
+   language (CJK untested — no claim). User override always wins.
+3. Make `gemma4-e4b` resident (`RESIDENT_MODELS`, ollama.ts) so it stays warm
+   across the loop. (NOTE: the earlier "9b comment is stale" claim was WRONG —
+   `RESIDENT_MODELS = {qwen3.5:4b, llama3.1:8b}`, 9b is correctly non-resident,
+   `ollama.test.ts:199` pins it. Leave that comment alone.)
+4. **Model availability:** making a new local model the non-English default
+   means it must be present — wire into the Model Manager (193/fs-23) /
+   installer, with a graceful "model not installed → fall back to qwen +
+   actionable diagnostic." This is a hard dependency, not a "until then."
+- **Tests:** unit on language-aware local model resolution (`ru`→gemma,
+  `en`→qwen, override wins); model-missing fallback path.
+
+### Wave C — name/alias-aware cross-chapter merge (Defect 1)
+
+Add a name/alias fallback to `mergeRosterChapter` when exact-id misses. Tiered:
+(1) exact normalized-name/alias match → merge (safe; kills the
+`boris-ignatyevich`≡`boris-ignatievich`, `egor`≡`yegor`, `tigrenok`≡`tigerlet`
+duplicates); (2) high token-overlap → merge with a single-dominant-candidate +
+high-floor guard (`Антон`/`Антон Городецкий`); (3) diminutives/epithets
+(`Оля`/`Ольга`, `шеф`) → manual UI for v1. Reuse `text-match.ts`
+(`normaliseForMatch`/`nameTokens`/`jaccard`) and export/reimplement
+`exactNameOverlap` (currently private in `voice-match.ts`).
+
+- **Scope caveat:** `mergeRosterChapter` returns `void`, has no sentence access,
+  and is called from 5+ sites incl. intra-chapter chunk union (first-wins) —
+  so a sentence-`characterId` rewrite must be threaded out as a rewrite-table
+  (parallel to `foldMinorCast.rewrites`), and the fuzzy match must be
+  order-deterministic. This is a structural change, not a one-line fallback.
+- **Tests:** unit fixtures — identical-name/drifted-id merge; token-overlap
+  merge; **non-merge** of two distinct same-token names; gender-disagreement
+  (`tigrenok`/`tigerlet`) without corrupting gender; chunk-union determinism.
+
+### Wave D — localized minor-cast fold (Defect 2)
+
+Thread `language` into `foldMinorCast` → `makeBucket` **and** the canonicalizer
+(`:368-373`); Russian → **Незнакомый Парень** / **Незнакомая Девушка**. Make
+`isDescriptorName`/`GENERIC_ROLE_TAIL` language-keyed (add девушка/парень/
+мужчина/женщина/незнакомец/незнакомка/человек/голос). Localize `cast-merge.ts`
+manual-downgrade `makeBucket` call too.
+
+- **Tests:** `makeBucket('ru')` names survive the canonicalizer; Russian
+  `isDescriptorName` positives/negatives; fold threads language.
+
+### Cross-cutting — reliable completion + wall-clock
+
+- **Perturbed retry (required, not optional):** on a coverage failure, retry
+  with a perturbation chosen *empirically* — grammar-off is the lever that
+  helped (temperature-up made it worse). Bounds the all-fail probability for any
+  model. Extend `runStage2WithCoverageGuard`.
+- **Wall-clock:** measure full-chapter (all 13 sections of ch1) end-to-end with
+  the chosen model; confirm full-book time against an acceptable target before
+  declaring done.
+
+---
+
+## Open questions
+
+1. **Local non-English default = `gemma4-e4b` UD-Q4** — confirm the canonical
+   Ollama tag to ship (the tuned `gemma4-e4b-8gb` vs an upstream tag).
+2. **Wave C aggressiveness** — Tier 1 (exact-name, safe) only, or +Tier 2
+   (token-overlap)?
+3. **How does gemma reach installs** — Model Manager auto-fetch, installer
+   bundle, or documented manual pull (with qwen fallback) for now?
+4. **Cloud-gemini on Russian untested** — the shipped default (cloud
+   `gemini-3.1-flash-lite`) was never run on this book; if cloud handles Russian
+   well, the local fix is the only gap. Worth one confirmation run.
+
+## Out of scope (v1)
+
+- Automatic diminutive/epithet merging (Оля/Ольга, шеф) — manual UI.
+- CJK / non-Russian tuning (no data; no claims).
+- Chunker / coverage thresholds (187) — unchanged.
+- Quant above UD-Q4 / models larger than e4b — measured, no usable gain on 8 GB.

--- a/docs/superpowers/plans/2026-06-16-russian-attribution-narrator-heuristic.md
+++ b/docs/superpowers/plans/2026-06-16-russian-attribution-narrator-heuristic.md
@@ -1,0 +1,480 @@
+# Russian Attribution — Narrator-Default Heuristic + Dash-Tag Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make non-English (Russian-first) stage-2 attribution correct by deterministically forcing non-spoken sentences to `narrator` after the model returns, plus a Russian dash-dialogue tag guard in the language preamble.
+
+**Architecture:** A new pure module (`narrator-default.ts`) classifies each attributed sentence as spoken vs. narration and rewrites non-spoken sentences' `characterId` to `narrator`. It is applied inside the shared `attributeChapterStage2` runner, gated on `isNonEnglish(language)`, so both the main and subset analysis routes get it with zero English-path change. Coverage is unaffected (the coverage guard keys on sentence *text*, never `characterId`). A short Russian guard string is appended to the existing `languagePreamble` to nudge the model on dash-dialogue *tags* (the one class the heuristic deliberately leaves to the model).
+
+**Tech Stack:** TypeScript (NodeNext ESM, `.js` import specifiers), Vitest (server, node env), Zod schema types (`SentenceOutput`).
+
+**Why this scope:** This is Wave A of plan [221](../../features/221-multilingual-attribution-gemma-and-cast-merge.md). It is self-contained and deterministically unit-testable (no model calls). The model-selection (gemma-e4b), roster de-duplication, and localized buckets are separate later waves and are NOT in this plan.
+
+**Empirical basis (server/repro-heuristic.mts, 3/3 runs on the real failing section):** the model's narration-block correctness was 0–1/6; the heuristic deterministically produced **6/6 every run** while leaving every dialogue line untouched (`spoken-lines-kept-named` unchanged 15→15, 14→14, 13→13).
+
+---
+
+## File Structure
+
+- **Create** `server/src/analyzer/narrator-default.ts` — pure classification + rewrite helpers. One responsibility: deciding spoken-vs-narration and applying the narrator default.
+- **Create** `server/src/analyzer/narrator-default.test.ts` — unit tests (pure, no model/network).
+- **Modify** `server/src/routes/analysis.ts` — call the helper inside `attributeChapterStage2` (one gated line + two imports).
+- **Modify** `server/src/analyzer/gemini.ts` — extend the Russian branch of `languagePreamble`.
+- **Modify** `server/src/analyzer/gemini.test.ts` (or the file that tests `languagePreamble`) — assert the new guard text appears for `ru` and not for `en`.
+- **Modify** `docs/features/162-fs2-multilanguage.md` — note the narrator-default heuristic under multilanguage attribution.
+- **Modify** `docs/features/INDEX.md` — only if a new plan entry is needed (221 already tracked).
+
+---
+
+### Task 1: Pure narrator-default module
+
+**Files:**
+- Create: `server/src/analyzer/narrator-default.ts`
+- Test: `server/src/analyzer/narrator-default.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// server/src/analyzer/narrator-default.test.ts
+import { describe, it, expect } from 'vitest';
+import type { SentenceOutput } from '../handoff/schemas.js';
+import {
+  isSpokenLine,
+  forceNarratorOnNonSpokenLines,
+  applyNonEnglishNarratorDefault,
+} from './narrator-default.js';
+
+const s = (id: number, characterId: string, text: string): SentenceOutput =>
+  ({ id, chapterId: 1, characterId, text, confidence: 0.9 }) as SentenceOutput;
+
+describe('isSpokenLine', () => {
+  it('treats leading em-dash / en-dash / hyphen as spoken', () => {
+    expect(isSpokenLine('— Иди сюда')).toBe(true);
+    expect(isSpokenLine('– Иди сюда')).toBe(true);
+    expect(isSpokenLine('- Иди сюда')).toBe(true);
+    expect(isSpokenLine('   — с ведущими пробелами')).toBe(true);
+  });
+  it('treats leading or embedded quote spans as spoken', () => {
+    expect(isSpokenLine('«Привет»')).toBe(true);
+    expect(isSpokenLine('Он сказал «привет» громко')).toBe(true);
+    expect(isSpokenLine('"Hard to starboard"')).toBe(true);
+    expect(isSpokenLine('“smart quotes”')).toBe(true);
+  });
+  it('treats plain third-person narration as NOT spoken', () => {
+    expect(isSpokenLine('Егор засунул руки в карманы, покосился назад.')).toBe(false);
+    expect(isSpokenLine('Мальчик шёл по переходу.')).toBe(false);
+    expect(isSpokenLine('')).toBe(false);
+    // mid-sentence dash is punctuation, not a dialogue marker (anchored ^)
+    expect(isSpokenLine('Ветер толкнул Егора последний раз и стих - будто смирился.')).toBe(false);
+  });
+  it('matches named HTML dash entities at the start (stripHtml may leave them)', () => {
+    expect(isSpokenLine('&mdash; Иди сюда')).toBe(true);
+    expect(isSpokenLine('&ndash; Стой')).toBe(true);
+  });
+  it('a bare dash line is spoken (no text after the marker)', () => {
+    expect(isSpokenLine('—')).toBe(true);
+    expect(isSpokenLine('- ')).toBe(true);
+  });
+  it('KNOWN false-positive: narration quoting a sign/title reads as spoken (documented limitation)', () => {
+    // The embedded-quoted-span branch can't tell a spoken line from narration
+    // that quotes an inscription. Acceptable: it only means such a line is LEFT
+    // to the model rather than forced to narrator — never the reverse.
+    expect(isSpokenLine('На двери висела табличка «Закрыто».')).toBe(true);
+  });
+});
+
+describe('forceNarratorOnNonSpokenLines', () => {
+  it('rewrites non-spoken sentences to narrator, leaves spoken lines untouched', () => {
+    const input = [
+      s(1, 'egor', 'Егор засунул руки в карманы, покосился назад.'),
+      s(2, 'woman', '— Иди сюда.., иди ко мне...'),
+      s(3, 'egor', 'Мальчик шёл по переходу.'),
+    ];
+    const out = forceNarratorOnNonSpokenLines(input);
+    expect(out.map((x) => x.characterId)).toEqual(['narrator', 'woman', 'narrator']);
+  });
+  it('does not mutate the input array or its elements', () => {
+    const input = [s(1, 'egor', 'Егор побежал.')];
+    const out = forceNarratorOnNonSpokenLines(input);
+    expect(input[0].characterId).toBe('egor');
+    expect(out[0]).not.toBe(input[0]);
+  });
+  it('preserves all other fields', () => {
+    const input = [{ id: 7, chapterId: 2, characterId: 'egor', text: 'Он обернулся.', confidence: 0.55, emotion: 'sad' } as SentenceOutput];
+    const out = forceNarratorOnNonSpokenLines(input);
+    expect(out[0]).toMatchObject({ id: 7, chapterId: 2, characterId: 'narrator', text: 'Он обернулся.', confidence: 0.55, emotion: 'sad' });
+  });
+});
+
+describe('applyNonEnglishNarratorDefault', () => {
+  const input = [s(1, 'egor', 'Егор побежал.'), s(2, 'woman', '— Стой!')];
+  it('applies the heuristic for non-English languages', () => {
+    expect(applyNonEnglishNarratorDefault(input, 'ru').map((x) => x.characterId)).toEqual(['narrator', 'woman']);
+    expect(applyNonEnglishNarratorDefault(input, 'ru-RU').map((x) => x.characterId)).toEqual(['narrator', 'woman']);
+  });
+  it('is a no-op for English and for missing language (returns the same array reference)', () => {
+    expect(applyNonEnglishNarratorDefault(input, 'en')).toBe(input);
+    expect(applyNonEnglishNarratorDefault(input, undefined)).toBe(input);
+  });
+  it('leaves English characterIds unchanged in VALUE, not just reference (guards a gate regression)', () => {
+    const en = [s(1, 'halloran', 'The wind had turned.'), s(2, 'halloran', '"Hard to starboard,"')];
+    const out = applyNonEnglishNarratorDefault(en, 'en');
+    expect(out.map((x) => x.characterId)).toEqual(['halloran', 'halloran']);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/analyzer/narrator-default.test.ts`
+Expected: FAIL — `Cannot find module './narrator-default.js'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// server/src/analyzer/narrator-default.ts
+/* Deterministic narrator-default heuristic (plan 221, Wave A).
+
+   The per-sentence attribution model — especially on non-Latin scripts —
+   mislabels third-person NARRATION as the named character (e.g. "Егор засунул
+   руки в карманы" → `egor`), which would read narration in that character's
+   voice. The spoken-vs-narration distinction is mechanical, so we decide it in
+   code instead of trusting the model: any sentence that is NOT a spoken line is
+   forced to `narrator`.
+
+   A "spoken line" = begins with a dialogue dash (—/–/-) or an opening quote
+   («/"/“), OR contains a quoted span. Everything else is narration. This
+   deliberately LEAVES dashed narrative tags ("— сказал юноша") to the model +
+   language preamble (they look spoken), and never touches dialogue lines, so it
+   cannot break speaker attribution — it only ever changes a non-spoken line to
+   `narrator`. Coverage is unaffected (the coverage guard keys on sentence text,
+   not characterId). Empirically (server/repro-heuristic.mts) this took the
+   model's narration-block correctness from 0–1/6 to 6/6 on every run with zero
+   dialogue damage. Pure: no I/O, no model calls. */
+
+import type { SentenceOutput } from '../handoff/schemas.js';
+import { isNonEnglish } from '../tts/language.js';
+
+const NARRATOR_ID = 'narrator';
+
+/** True when the sentence text reads as spoken dialogue: a leading dialogue
+    dash / opening quote, or an embedded quoted span. Also matches the named
+    HTML dash entities `&mdash;`/`&ndash;` — some EPUB toolchains emit these and
+    `stripHtml` (parsers/html-utils.ts) only decodes a small named-entity set, so
+    the dash can survive literally in the body the model echoes. Without this,
+    real dialogue prefixed by `&mdash;` would be wrongly forced to narrator. */
+export function isSpokenLine(text: string): boolean {
+  const t = (text ?? '').trimStart();
+  if (!t) return false;
+  if (/^(&mdash;|&ndash;|[-–—])/i.test(t)) return true; // dash entities + literal dashes
+  if (/^[«"“]/.test(t)) return true; // opening guillemet / straight / smart quote
+  if (/«[^»]+»/.test(t) || /"[^"]+"/.test(t) || /“[^”]+”/.test(t)) return true; // embedded quoted span
+  return false;
+}
+
+/** Return a new sentence list where every non-spoken sentence's characterId is
+    `narrator`. Spoken lines are returned unchanged. Pure — never mutates input. */
+export function forceNarratorOnNonSpokenLines(sentences: SentenceOutput[]): SentenceOutput[] {
+  return sentences.map((s) =>
+    isSpokenLine(s.text) ? s : { ...s, characterId: NARRATOR_ID },
+  );
+}
+
+/** Apply the narrator-default heuristic only for non-English books. For English
+    (and missing language) returns the SAME array reference (no-op) so the
+    English path is byte-identical. */
+export function applyNonEnglishNarratorDefault(
+  sentences: SentenceOutput[],
+  language: string | undefined,
+): SentenceOutput[] {
+  if (!isNonEnglish(language ?? '')) return sentences;
+  return forceNarratorOnNonSpokenLines(sentences);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/analyzer/narrator-default.test.ts`
+Expected: PASS (all describe blocks green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/analyzer/narrator-default.ts server/src/analyzer/narrator-default.test.ts
+git commit -m "feat(server): narrator-default heuristic for non-English attribution"
+```
+
+---
+
+### Task 2: Wire the heuristic into the shared stage-2 runner
+
+**Files:**
+- Modify: `server/src/routes/analysis.ts` (imports near the other analyzer imports; body of `attributeChapterStage2` ~`1473-1514`)
+
+- [ ] **Step 1: Add the import**
+
+Add to the analyzer-side imports in `server/src/routes/analysis.ts` (near `import { runStage1ChapterChunked, ... } from '../analyzer/stage1-chunk.js';`):
+
+```typescript
+import { applyNonEnglishNarratorDefault } from '../analyzer/narrator-default.js';
+```
+
+- [ ] **Step 2: Make the function `async` and apply the heuristic on the stitched result**
+
+FIRST: the function is declared `function attributeChapterStage2(opts: {` (analysis.ts:1473) — it is NOT async and currently returns the promise directly. Adding `await` requires changing the declaration to:
+
+```typescript
+async function attributeChapterStage2(opts: {
+```
+
+(The return type annotation `Promise<Stage2ChunkRunResult>` is unchanged and still correct.)
+
+THEN, in the body, replace the trailing `return runStage2ChapterChunked({ ... });` with an awaited capture + gated rewrite. The function body's final statement currently is:
+
+```typescript
+  return runStage2ChapterChunked({
+    body: opts.chapter.body,
+    charBudget: resolveStage2ChunkCharBudget(opts.engine),
+    coverageRetries: resolveStage2CoverageRetries(),
+    callForBody,
+    onRetry: opts.onCoverageRetry,
+    onChunk: opts.onChunk,
+  });
+```
+
+Change it to:
+
+```typescript
+  const result = await runStage2ChapterChunked({
+    body: opts.chapter.body,
+    charBudget: resolveStage2ChunkCharBudget(opts.engine),
+    coverageRetries: resolveStage2CoverageRetries(),
+    callForBody,
+    onRetry: opts.onCoverageRetry,
+    onChunk: opts.onChunk,
+  });
+  /* plan 221 Wave A — non-English narrator-default heuristic. The model
+     mislabels third-person narration as a character on non-Latin scripts;
+     force non-spoken sentences to `narrator`. No-op for English. Runs AFTER
+     coverage (coverage keys on text, not characterId), so the verdict is
+     unchanged. */
+  result.sentences = applyNonEnglishNarratorDefault(result.sentences, opts.stageCall.language);
+  return result;
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: no errors. (`attributeChapterStage2` already returns `Promise<Stage2ChunkRunResult>`; `result.sentences` is `SentenceOutput[]`, matching the helper.)
+
+- [ ] **Step 4: Run the server attribution tests to confirm no regression**
+
+Run: `cd server && npx vitest run src/routes/analysis.test.ts`
+Expected: PASS (English-path attribution unchanged — the helper is a no-op for `en`/absent language).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/analysis.ts
+git commit -m "feat(server): apply narrator-default in attributeChapterStage2 (non-English)"
+```
+
+---
+
+### Task 3: Fold-interaction safety test (narration-default vs minor-cast fold)
+
+**Why:** the heuristic moves model-mislabeled narration off characters onto `narrator`, which lowers those characters' line counts. `foldMinorCast` (`server/src/analyzer/fold-minor-cast.ts`) folds/drops characters with `< minLines` (default 3) attributed lines. We must prove a real speaker (≥3 genuine dialogue lines) is NOT folded after the heuristic, and consciously accept that a genuinely-minor speaker (<3 dialogue lines) folding is the *intended* behavior (the heuristic makes the count accurate — narration was never their dialogue). KNOWN GAP (Wave C): the protection that rescues low-line speakers via prose tags (`taggedSpeakerIds` → `DIALOGUE_VERBS` in `recover-tagged-lines.ts`/`dialogue-verbs.ts`) is **English-verb-only**, so a Russian speaker whose quotes were stranded on narrator isn't protected — extending those verbs to Russian is Wave C, not this plan.
+
+**Files:**
+- Test: `server/src/analyzer/narrator-default.test.ts` (add a describe block; import `foldMinorCast`)
+
+- [ ] **Step 1: Write the test**
+
+```typescript
+import { foldMinorCast } from './fold-minor-cast.js';
+
+describe('narrator-default + foldMinorCast interaction', () => {
+  it('a speaker with >= minLines real (dashed) dialogue lines survives the fold', () => {
+    // egor: 4 narration lines (model mislabeled as egor) + 3 real dashed lines
+    const sentences = [
+      s(1, 'egor', 'Егор засунул руки в карманы.'),
+      s(2, 'egor', 'Мальчик посмотрел вверх.'),
+      s(3, 'egor', 'Егор побежал.'),
+      s(4, 'egor', 'Он обернулся.'),
+      s(5, 'egor', '— Хорошо.'),
+      s(6, 'egor', '— Иду.'),
+      s(7, 'egor', '— Сейчас.'),
+    ];
+    const chars = [
+      { id: 'narrator', name: 'Narrator', role: 'narrator', gender: 'neutral' },
+      { id: 'egor', name: 'Егор', role: 'Boy', gender: 'male' },
+    ] as any;
+    const fixed = forceNarratorOnNonSpokenLines(sentences); // 4 narration -> narrator, 3 dashed stay egor
+    const folded = foldMinorCast(chars, fixed, { minLines: 3 });
+    expect(folded.characters.some((c) => c.id === 'egor')).toBe(true); // survived (3 dialogue lines)
+    expect(folded.rewrites['egor']).toBeUndefined(); // not folded into a bucket
+  });
+
+  it('a speaker with < minLines real dialogue lines folds — intended (count is now accurate)', () => {
+    const sentences = [
+      s(1, 'extra', 'Прохожий шёл мимо.'),
+      s(2, 'extra', 'Он остановился.'),
+      s(3, 'extra', '— Что?'),
+    ];
+    const chars = [
+      { id: 'narrator', name: 'Narrator', role: 'narrator', gender: 'neutral' },
+      { id: 'extra', name: 'Прохожий', role: 'Passerby', gender: 'male' },
+    ] as any;
+    const fixed = forceNarratorOnNonSpokenLines(sentences); // 2 narration -> narrator, 1 dashed stays
+    const folded = foldMinorCast(chars, fixed, { minLines: 3 });
+    expect(folded.rewrites['extra']).toBe('unknown-male'); // 1 dialogue line < 3 -> folded (correct)
+  });
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cd server && npx vitest run src/analyzer/narrator-default.test.ts`
+Expected: PASS. (If the first test FAILS — a real speaker gets folded — STOP and escalate: the heuristic is removing protection that Russian needs, and Wave C's Russian `DIALOGUE_VERBS` extension must move into this plan.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/src/analyzer/narrator-default.test.ts
+git commit -m "test(server): narrator-default x foldMinorCast interaction (Russian speaker survival)"
+```
+
+---
+
+### Task 4: Russian dash-dialogue tag guard in languagePreamble
+
+**Files:**
+- Modify: `server/src/analyzer/gemini.ts` (`languagePreamble`, ~`161-169`)
+- Test: `server/src/analyzer/gemini.test.ts` (or wherever `languagePreamble` is unit-tested — search for `languagePreamble`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the language-preamble test file (search: `grep -rn "languagePreamble" server/src --include=*.test.ts`). If none exists, add to `server/src/analyzer/gemini.test.ts`:
+
+```typescript
+import { languagePreamble } from './gemini.js';
+
+describe('languagePreamble — Russian dash-dialogue tag guard', () => {
+  it('tells the model that dashed narrative tags are narrator, for ru', () => {
+    const p = languagePreamble('ru');
+    expect(p).toMatch(/тег|narrative tag|сказал/i);
+    expect(p).toMatch(/narrator/);
+  });
+  it('adds nothing for English', () => {
+    expect(languagePreamble('en')).toBe('');
+    expect(languagePreamble(undefined)).toBe('');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+NOTE: `gemini.test.ts` is in the SLOW vitest tier (`server/vitest.config.ts` `SLOW_FILES_TO_EXCLUDE` excludes it from the default config). It runs ONLY via the slow config — the plain `npx vitest run src/analyzer/gemini.test.ts` reports "No test files found". Always pass `--config vitest.config.slow.ts` for this file.
+
+Run: `cd server && npx vitest run --config vitest.config.slow.ts src/analyzer/gemini.test.ts -t "dash-dialogue tag guard"`
+Expected: FAIL — current Russian preamble has no tag guidance.
+
+- [ ] **Step 3: Extend the Russian conventions string**
+
+In `server/src/analyzer/gemini.ts`, the Russian branch of `languagePreamble` currently is:
+
+```typescript
+  const conventions = ru
+    ? ' Dialogue is often marked with guillemets «…» or an em-dash —, not English "quotes". Characters may be named by first name, patronymic, surname, or diminutive (e.g. "Соня" for "Софья") — treat these as the same person.'
+    : '';
+```
+
+Replace the `ru` string with (append the tag-splitting guidance):
+
+```typescript
+  const conventions = ru
+    ? ' Dialogue is often marked with guillemets «…» or an em-dash —, not English "quotes". Characters may be named by first name, patronymic, surname, or diminutive (e.g. "Соня" for "Софья") — treat these as the same person. IMPORTANT: a dashed line that is a narrative TAG describing who spoke or what they did — e.g. «— сказал юноша.», «— тихо произнесла девушка.», «— Девушка улыбнулась.» (verbs like сказал/произнёс(ла)/воскликнул(а)/спросил(а)/засмеялся/улыбнулась/нахмурился) — is the narrator, NOT the speaker. Only the actually-spoken words belong to the speaker.'
+    : '';
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run --config vitest.config.slow.ts src/analyzer/gemini.test.ts -t "dash-dialogue tag guard"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/analyzer/gemini.ts server/src/analyzer/gemini.test.ts
+git commit -m "feat(server): Russian dash-dialogue tag guard in languagePreamble"
+```
+
+---
+
+### Task 5: Regression plan + docs
+
+**Files:**
+- Modify: `docs/features/162-fs2-multilanguage.md`
+- Modify: `docs/features/221-multilingual-attribution-gemma-and-cast-merge.md` (mark Wave A status)
+
+- [ ] **Step 1: Note the heuristic in the multilanguage plan**
+
+Add a short subsection to `docs/features/162-fs2-multilanguage.md` under attribution, documenting: non-English stage-2 applies a deterministic narrator-default (`server/src/analyzer/narrator-default.ts`) + the dash-tag preamble guard; cite `server/repro-heuristic.mts` evidence (0–1/6 → 6/6, dialogue untouched); note the known limitation (a genuine spoken line lacking a leading dash/quote would be forced to narrator — rare in Russian dash-dialogue).
+
+- [ ] **Step 2: Update plan 221 Wave A status**
+
+In `docs/features/221-multilingual-attribution-gemma-and-cast-merge.md`, mark Wave A (heuristic + dash-tag guard) as implemented/shipping, leaving Waves B/C/D as follow-ups.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/features/162-fs2-multilanguage.md docs/features/221-multilingual-attribution-gemma-and-cast-merge.md
+git commit -m "docs(server): record narrator-default heuristic under multilanguage (plan 221 Wave A)"
+```
+
+---
+
+### Task 6: Full verification
+
+- [ ] **Step 1: Run the server test battery**
+
+Run: `cd server && npm run test` (or from root: `npm run test:server`)
+Expected: PASS, including the new `narrator-default.test.ts` and unchanged `analysis.test.ts`. NOTE: `gemini.test.ts` is in the SLOW tier — it runs via `npm run test:server-slow` (root), NOT the default `npm run test`. Run that too: `npm run test:server-slow` → PASS (incl. the new dash-tag guard test).
+
+- [ ] **Step 2: Typecheck the whole project**
+
+Run (root): `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Run the full pre-push battery**
+
+Run (root): `npm run verify`
+Expected: PASS (lint + all tests + e2e + build). This is the gate before opening the PR.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Narration mislabeled as character → Task 1 (`forceNarratorOnNonSpokenLines`) + Task 2 (wired, non-English). ✓
+- Dash-dialogue tags → Task 3 (preamble guard — the class the heuristic leaves to the model). ✓
+- English path unchanged → `applyNonEnglishNarratorDefault` no-ops for `en`/absent (Task 1 test asserts same-reference return; Task 2 only changes non-English). ✓
+- Coverage unaffected → heuristic runs after `runStage2ChapterChunked` returns; coverage verdict already computed on text. ✓
+- Both main + subset routes covered → applied inside shared `attributeChapterStage2`. ✓
+
+**Placeholder scan:** none — all steps have concrete code, exact paths, and commands.
+
+**Type consistency:** `SentenceOutput` used throughout; `isNonEnglish(language: string)` is the real signature in `server/src/tts/language.ts` (call with `language ?? ''`); `attributeChapterStage2` returns `Promise<Stage2ChunkRunResult>` whose `.sentences` is `SentenceOutput[]`; helper names (`isSpokenLine`, `forceNarratorOnNonSpokenLines`, `applyNonEnglishNarratorDefault`) are consistent across Tasks 1–2.
+
+**Known limitation (documented in Task 4):** a genuine spoken line that lacks a leading dialogue marker AND has no quoted span would be wrongly forced to `narrator`. Rare in Russian dash-dialogue (the failing section showed zero such damage across 3 runs); acceptable for v1, revisit if a counter-example appears.
+
+**Evidence provenance:** the "6/6 every run" numbers come from `server/repro-heuristic.mts` against a LOCAL, non-committed EPUB (Ночной дозор, em-dash dialogue). They are not reproducible from a clean checkout. The committed Russian fixture `server/src/__fixtures__/the-coalfall-commission.ru.md` uses guillemet «…» dialogue (no leading dashes) — `isSpokenLine` handles both marker styles (the embedded-quoted-span branch covers guillemets), and the Task 1 unit tests exercise both. The `isSpokenLine` logic in the plan is byte-identical to the validated probe.
+
+**Scope (cached analyses):** this corrects NEW or re-run analyses only. A Russian book analysed/cached before this ships keeps the model's bad narration labels until re-analysed — `attributeChapterStage2` is the single stage-2 chokepoint (both main route analysis.ts:3535 and subset route :4649 go through it, and BOTH set `stageCall.language` — verified analysis.ts:3472 and :4658; the emotion pass only reads `characterId`, never re-attributes), so a re-run applies the fix everywhere.
+
+**Round-2 review notes folded in:**
+- **Fold interaction (was flagged BLOCKER):** Task 3 pins it with tests — a ≥3-dialogue-line speaker survives; a <3-line speaker folds (intended, the count is now accurate). The model-trust risk is real only if `isSpokenLine` MISSES genuine dialogue (see next), which would under-count a real speaker.
+- **Dialogue-detection robustness (model-dependent):** the heuristic only force-narrators a line with no leading dash/quote and no quoted span. If the analyzer emits dialogue WITHOUT a leading marker (drops the dash when echoing, or a quote continues across a segmentation boundary), that line is wrongly narrator-ized. Empirically gemma-e4b preserved the dash on every dialogue line (`repro-heuristic.mts`, `spoken-lines-kept-named` unchanged 3/3 runs), and `&mdash;`/`&ndash;` are now handled — but this is a **model-preservation dependency**, not a guarantee. Honest claim: "depends on the model preserving the dialogue marker," not "rare."
+- **Shared preamble:** `languagePreamble` feeds `buildSystemInstruction` for ALL stages (stage-1 detection, stage-2, emotion), not just stage-2. The dashed-tag guard reaching stage-1 is harmless (stage-1 builds the roster, doesn't attribute lines) — considered, accepted.
+- **No deterministic backstop for dashed TAGS:** `— сказал юноша` looks spoken to `isSpokenLine`, so the heuristic leaves it to the model+guard. If the model disobeys the guard, that tag stays mis-attributed. Known gap, not a solved case.
+- **Follow-ups (NOT this plan):** decode `&mdash;`/`&ndash;` in `stripHtml` (parsers/html-utils.ts) at the source so the literal entity never reaches synthesis (broader parser change); extend `DIALOGUE_VERBS` (dialogue-verbs.ts) to Russian so `recover-tagged-lines`/`taggedSpeakerIds` protects Russian low-line speakers — **Wave C** (roster).

--- a/server/src/analyzer/gemini.test.ts
+++ b/server/src/analyzer/gemini.test.ts
@@ -263,6 +263,20 @@ describe('fs-2 — languagePreamble + estimateInputTokens', () => {
     expect(languagePreamble('')).toBe('');
   });
 
+  describe('languagePreamble — Russian dash-dialogue tag guard', () => {
+    it('tells the model that dashed narrative tags are narrator, for ru', async () => {
+      const { languagePreamble } = await import('./gemini.js');
+      const p = languagePreamble('ru');
+      expect(p).toMatch(/тег|narrative tag|сказал/i);
+      expect(p).toMatch(/narrator/);
+    });
+    it('adds nothing for English', async () => {
+      const { languagePreamble } = await import('./gemini.js');
+      expect(languagePreamble('en')).toBe('');
+      expect(languagePreamble(undefined)).toBe('');
+    });
+  });
+
   it('buildSystemInstruction appends the preamble only for non-English', async () => {
     const { buildSystemInstruction } = await import('./gemini.js');
     expect(buildSystemInstruction('SKILL', 'ru')).toMatch(/manuscript text is in Russian/i);

--- a/server/src/analyzer/gemini.ts
+++ b/server/src/analyzer/gemini.ts
@@ -163,7 +163,7 @@ export function languagePreamble(language?: string): string {
   const ru = normaliseBookLanguage(language) === 'ru';
   const where = ru ? 'Russian (Cyrillic script)' : `${language} (a non-English language)`;
   const conventions = ru
-    ? ' Dialogue is often marked with guillemets «…» or an em-dash —, not English "quotes". Characters may be named by first name, patronymic, surname, or diminutive (e.g. "Соня" for "Софья") — treat these as the same person.'
+    ? ' Dialogue is often marked with guillemets «…» or an em-dash —, not English "quotes". Characters may be named by first name, patronymic, surname, or diminutive (e.g. "Соня" for "Софья") — treat these as the same person. IMPORTANT: a dashed line that is a narrative TAG describing who spoke or what they did — e.g. «— сказал юноша.», «— тихо произнесла девушка.», «— Девушка улыбнулась.» (verbs like сказал/произнёс(ла)/воскликнул(а)/спросил(а)/засмеялся/улыбнулась/нахмурился) — is the narrator, NOT the speaker. Only the actually-spoken words belong to the speaker.'
     : '';
   return `\n\nIMPORTANT: the manuscript text is in ${where}. Quote evidence VERBATIM from the manuscript (do not translate or transliterate it). Keep all JSON field names and enum values in English exactly as the schema shows.${conventions}`;
 }

--- a/server/src/analyzer/narrator-default.test.ts
+++ b/server/src/analyzer/narrator-default.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import type { SentenceOutput } from '../handoff/schemas.js';
+import {
+  isSpokenLine,
+  forceNarratorOnNonSpokenLines,
+  applyNonEnglishNarratorDefault,
+} from './narrator-default.js';
+
+const s = (id: number, characterId: string, text: string): SentenceOutput =>
+  ({ id, chapterId: 1, characterId, text, confidence: 0.9 }) as SentenceOutput;
+
+describe('isSpokenLine', () => {
+  it('treats leading em-dash / en-dash / hyphen as spoken', () => {
+    expect(isSpokenLine('— Иди сюда')).toBe(true);
+    expect(isSpokenLine('– Иди сюда')).toBe(true);
+    expect(isSpokenLine('- Иди сюда')).toBe(true);
+    expect(isSpokenLine('   — с ведущими пробелами')).toBe(true);
+  });
+  it('treats leading or embedded quote spans as spoken', () => {
+    expect(isSpokenLine('«Привет»')).toBe(true);
+    expect(isSpokenLine('Он сказал «привет» громко')).toBe(true);
+    expect(isSpokenLine('"Hard to starboard"')).toBe(true);
+    expect(isSpokenLine('“smart quotes”')).toBe(true);
+  });
+  it('treats plain third-person narration as NOT spoken', () => {
+    expect(isSpokenLine('Егор засунул руки в карманы, покосился назад.')).toBe(false);
+    expect(isSpokenLine('Мальчик шёл по переходу.')).toBe(false);
+    expect(isSpokenLine('')).toBe(false);
+    // mid-sentence dash is punctuation, not a dialogue marker (anchored ^)
+    expect(isSpokenLine('Ветер толкнул Егора последний раз и стих - будто смирился.')).toBe(false);
+  });
+  it('matches named HTML dash entities at the start (stripHtml may leave them)', () => {
+    expect(isSpokenLine('&mdash; Иди сюда')).toBe(true);
+    expect(isSpokenLine('&ndash; Стой')).toBe(true);
+  });
+  it('a bare dash line is spoken (no text after the marker)', () => {
+    expect(isSpokenLine('—')).toBe(true);
+    expect(isSpokenLine('- ')).toBe(true);
+  });
+  it('KNOWN false-positive: narration quoting a sign/title reads as spoken (documented limitation)', () => {
+    // The embedded-quoted-span branch can't tell a spoken line from narration
+    // that quotes an inscription. Acceptable: it only means such a line is LEFT
+    // to the model rather than forced to narrator — never the reverse.
+    expect(isSpokenLine('На двери висела табличка «Закрыто».')).toBe(true);
+  });
+});
+
+describe('forceNarratorOnNonSpokenLines', () => {
+  it('rewrites non-spoken sentences to narrator, leaves spoken lines untouched', () => {
+    const input = [
+      s(1, 'egor', 'Егор засунул руки в карманы, покосился назад.'),
+      s(2, 'woman', '— Иди сюда.., иди ко мне...'),
+      s(3, 'egor', 'Мальчик шёл по переходу.'),
+    ];
+    const out = forceNarratorOnNonSpokenLines(input);
+    expect(out.map((x) => x.characterId)).toEqual(['narrator', 'woman', 'narrator']);
+  });
+  it('does not mutate the input array or its elements', () => {
+    const input = [s(1, 'egor', 'Егор побежал.')];
+    const out = forceNarratorOnNonSpokenLines(input);
+    expect(input[0].characterId).toBe('egor');
+    expect(out[0]).not.toBe(input[0]);
+  });
+  it('preserves all other fields', () => {
+    const input = [{ id: 7, chapterId: 2, characterId: 'egor', text: 'Он обернулся.', confidence: 0.55, emotion: 'sad' } as SentenceOutput];
+    const out = forceNarratorOnNonSpokenLines(input);
+    expect(out[0]).toMatchObject({ id: 7, chapterId: 2, characterId: 'narrator', text: 'Он обернулся.', confidence: 0.55, emotion: 'sad' });
+  });
+});
+
+describe('applyNonEnglishNarratorDefault', () => {
+  const input = [s(1, 'egor', 'Егор побежал.'), s(2, 'woman', '— Стой!')];
+  it('applies the heuristic for non-English languages', () => {
+    expect(applyNonEnglishNarratorDefault(input, 'ru').map((x) => x.characterId)).toEqual(['narrator', 'woman']);
+    expect(applyNonEnglishNarratorDefault(input, 'ru-RU').map((x) => x.characterId)).toEqual(['narrator', 'woman']);
+  });
+  it('is a no-op for English and for missing language (returns the same array reference)', () => {
+    expect(applyNonEnglishNarratorDefault(input, 'en')).toBe(input);
+    expect(applyNonEnglishNarratorDefault(input, undefined)).toBe(input);
+  });
+  it('leaves English characterIds unchanged in VALUE, not just reference (guards a gate regression)', () => {
+    const en = [s(1, 'halloran', 'The wind had turned.'), s(2, 'halloran', '"Hard to starboard,"')];
+    const out = applyNonEnglishNarratorDefault(en, 'en');
+    expect(out.map((x) => x.characterId)).toEqual(['halloran', 'halloran']);
+  });
+});

--- a/server/src/analyzer/narrator-default.test.ts
+++ b/server/src/analyzer/narrator-default.test.ts
@@ -5,6 +5,7 @@ import {
   forceNarratorOnNonSpokenLines,
   applyNonEnglishNarratorDefault,
 } from './narrator-default.js';
+import { foldMinorCast } from './fold-minor-cast.js';
 
 const s = (id: number, characterId: string, text: string): SentenceOutput =>
   ({ id, chapterId: 1, characterId, text, confidence: 0.9 }) as SentenceOutput;
@@ -82,5 +83,43 @@ describe('applyNonEnglishNarratorDefault', () => {
     const en = [s(1, 'halloran', 'The wind had turned.'), s(2, 'halloran', '"Hard to starboard,"')];
     const out = applyNonEnglishNarratorDefault(en, 'en');
     expect(out.map((x) => x.characterId)).toEqual(['halloran', 'halloran']);
+  });
+});
+
+describe('narrator-default + foldMinorCast interaction', () => {
+  it('a speaker with >= minLines real (dashed) dialogue lines survives the fold', () => {
+    // egor: 4 narration lines (model mislabeled as egor) + 3 real dashed lines
+    const sentences = [
+      s(1, 'egor', 'Егор засунул руки в карманы.'),
+      s(2, 'egor', 'Мальчик посмотрел вверх.'),
+      s(3, 'egor', 'Егор побежал.'),
+      s(4, 'egor', 'Он обернулся.'),
+      s(5, 'egor', '— Хорошо.'),
+      s(6, 'egor', '— Иду.'),
+      s(7, 'egor', '— Сейчас.'),
+    ];
+    const chars = [
+      { id: 'narrator', name: 'Narrator', role: 'narrator', gender: 'neutral' },
+      { id: 'egor', name: 'Егор', role: 'Boy', gender: 'male' },
+    ] as any;
+    const fixed = forceNarratorOnNonSpokenLines(sentences); // 4 narration -> narrator, 3 dashed stay egor
+    const folded = foldMinorCast(chars, fixed, { minLines: 3 });
+    expect(folded.characters.some((c) => c.id === 'egor')).toBe(true); // survived (3 dialogue lines)
+    expect(folded.rewrites['egor']).toBeUndefined(); // not folded into a bucket
+  });
+
+  it('a speaker with < minLines real dialogue lines folds — intended (count is now accurate)', () => {
+    const sentences = [
+      s(1, 'extra', 'Прохожий шёл мимо.'),
+      s(2, 'extra', 'Он остановился.'),
+      s(3, 'extra', '— Что?'),
+    ];
+    const chars = [
+      { id: 'narrator', name: 'Narrator', role: 'narrator', gender: 'neutral' },
+      { id: 'extra', name: 'Прохожий', role: 'Passerby', gender: 'male' },
+    ] as any;
+    const fixed = forceNarratorOnNonSpokenLines(sentences); // 2 narration -> narrator, 1 dashed stays
+    const folded = foldMinorCast(chars, fixed, { minLines: 3 });
+    expect(folded.rewrites['extra']).toBe('unknown-male'); // 1 dialogue line < 3 -> folded (correct)
   });
 });

--- a/server/src/analyzer/narrator-default.ts
+++ b/server/src/analyzer/narrator-default.ts
@@ -1,0 +1,57 @@
+/* Deterministic narrator-default heuristic (plan 221, Wave A).
+
+   The per-sentence attribution model — especially on non-Latin scripts —
+   mislabels third-person NARRATION as the named character (e.g. "Егор засунул
+   руки в карманы" → `egor`), which would read narration in that character's
+   voice. The spoken-vs-narration distinction is mechanical, so we decide it in
+   code instead of trusting the model: any sentence that is NOT a spoken line is
+   forced to `narrator`.
+
+   A "spoken line" = begins with a dialogue dash (—/–/-) or an opening quote
+   («/"/“), OR contains a quoted span. Everything else is narration. This
+   deliberately LEAVES dashed narrative tags ("— сказал юноша") to the model +
+   language preamble (they look spoken), and never touches dialogue lines, so it
+   cannot break speaker attribution — it only ever changes a non-spoken line to
+   `narrator`. Coverage is unaffected (the coverage guard keys on sentence text,
+   not characterId). Empirically (server/repro-heuristic.mts) this took the
+   model's narration-block correctness from 0–1/6 to 6/6 on every run with zero
+   dialogue damage. Pure: no I/O, no model calls. */
+
+import type { SentenceOutput } from '../handoff/schemas.js';
+import { isNonEnglish } from '../tts/language.js';
+
+const NARRATOR_ID = 'narrator';
+
+/** True when the sentence text reads as spoken dialogue: a leading dialogue
+    dash / opening quote, or an embedded quoted span. Also matches the named
+    HTML dash entities `&mdash;`/`&ndash;` — some EPUB toolchains emit these and
+    `stripHtml` (parsers/html-utils.ts) only decodes a small named-entity set, so
+    the dash can survive literally in the body the model echoes. Without this,
+    real dialogue prefixed by `&mdash;` would be wrongly forced to narrator. */
+export function isSpokenLine(text: string): boolean {
+  const t = (text ?? '').trimStart();
+  if (!t) return false;
+  if (/^(&mdash;|&ndash;|[-–—])/i.test(t)) return true; // dash entities + literal dashes
+  if (/^[«"“]/.test(t)) return true; // opening guillemet / straight / smart quote
+  if (/«[^»]+»/.test(t) || /"[^"]+"/.test(t) || /“[^”]+”/.test(t)) return true; // embedded quoted span
+  return false;
+}
+
+/** Return a new sentence list where every non-spoken sentence's characterId is
+    `narrator`. Spoken lines are returned unchanged. Pure — never mutates input. */
+export function forceNarratorOnNonSpokenLines(sentences: SentenceOutput[]): SentenceOutput[] {
+  return sentences.map((s) =>
+    isSpokenLine(s.text) ? s : { ...s, characterId: NARRATOR_ID },
+  );
+}
+
+/** Apply the narrator-default heuristic only for non-English books. For English
+    (and missing language) returns the SAME array reference (no-op) so the
+    English path is byte-identical. */
+export function applyNonEnglishNarratorDefault(
+  sentences: SentenceOutput[],
+  language: string | undefined,
+): SentenceOutput[] {
+  if (!isNonEnglish(language ?? '')) return sentences;
+  return forceNarratorOnNonSpokenLines(sentences);
+}

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -10,6 +10,7 @@ import type { Request, Response } from '../http.js';
 import { getOrHydrateManuscript } from '../store/manuscripts.js';
 import { safeBookId } from '../util/safe-id.js';
 import { runStage1ChapterChunked, resolveStage1ChunkCharBudget } from '../analyzer/stage1-chunk.js';
+import { applyNonEnglishNarratorDefault } from '../analyzer/narrator-default.js';
 import { makeThrottledHeartbeat } from './analysis-heartbeat.js';
 import { type AnalyzerSelection, type Analyzer, type StageCall } from '../analyzer/index.js';
 import {
@@ -1470,7 +1471,7 @@ ${subBody}
    adaptively re-split. For a chapter within budget this is exactly one guarded
    call against the full body (byte-identical to the prior behaviour). Returns
    the stitched sentences + combined coverage verdict. */
-function attributeChapterStage2(opts: {
+async function attributeChapterStage2(opts: {
   analyzer: Analyzer;
   manuscriptId: string;
   title: string;
@@ -1504,7 +1505,7 @@ function attributeChapterStage2(opts: {
       opts.stageCall,
     );
   };
-  return runStage2ChapterChunked({
+  const result = await runStage2ChapterChunked({
     body: opts.chapter.body,
     charBudget: resolveStage2ChunkCharBudget(opts.engine),
     coverageRetries: resolveStage2CoverageRetries(),
@@ -1512,6 +1513,13 @@ function attributeChapterStage2(opts: {
     onRetry: opts.onCoverageRetry,
     onChunk: opts.onChunk,
   });
+  /* plan 221 Wave A — non-English narrator-default heuristic. The model
+     mislabels third-person narration as a character on non-Latin scripts;
+     force non-spoken sentences to `narrator`. No-op for English. Runs AFTER
+     coverage (coverage keys on text, not characterId), so the verdict is
+     unchanged. */
+  result.sentences = applyNonEnglishNarratorDefault(result.sentences, opts.stageCall.language);
+  return result;
 }
 
 /* ── Sticky analysis: in-flight job map + multi-subscriber broadcast ────


### PR DESCRIPTION
## Summary

Wave A of plan 221 (multilingual attribution). On non-English (Russian) books, the stage-2 attribution model mislabels third-person **narration** as a character (e.g. «Егор засунул руки в карманы» → `egor`), which would read narration in that character's voice. The narration-vs-dialogue split is mechanical, so we decide it in code instead of trusting the model:

- **`server/src/analyzer/narrator-default.ts`** — `isSpokenLine` (leading dash `—/–/-`, `&mdash;`/`&ndash;` entities, opening guillemet/quote, or embedded quoted span) + `forceNarratorOnNonSpokenLines` + `applyNonEnglishNarratorDefault`. Any **non-spoken** sentence is forced to `narrator`; spoken lines are never touched.
- Applied inside the shared **`attributeChapterStage2`** runner (covers both the main and subset routes), gated on `isNonEnglish(language)` → English path is a byte-identical no-op. Runs **after** coverage (which keys on text, not `characterId`), so the coverage verdict is unchanged.
- **`languagePreamble`** Russian branch gains a dash-dialogue **tag** guard (`— сказал юноша.` → narrator) — the one class the heuristic deliberately leaves to the model.

Empirically (local repro on a real Russian book): the model's narration-block correctness was 0–1/6 per run; the heuristic produced **6/6 every run** with **zero dialogue lines changed**.

Waves B (local model selection), C (cross-chapter cast de-duplication), D (localized `unknown-*` buckets) remain follow-ups in plan 221.

## Test plan

- New `narrator-default.test.ts` (14 tests): dash/quote/entity classification, anchored-`^` mid-sentence-dash negative, non-mutation, value-level English no-op, and **fold-interaction** (a ≥3-dialogue-line speaker survives `foldMinorCast`; a <3-line extra correctly folds).
- New `languagePreamble` dash-tag guard test (slow tier).
- `attributeChapterStage2` made `async`; `analysis.test.ts` 120/120 (English path unchanged).
- Full `npm run verify` green (lint + typecheck + all tests + e2e + build).

Plan: `docs/features/221-multilingual-attribution-gemma-and-cast-merge.md` (Wave A) + `docs/superpowers/plans/2026-06-16-russian-attribution-narrator-heuristic.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)