### PR TITLE
feat(server): localize minor-cast fold buckets for non-English (plan 221 Wave D)

### DIFF
--- a/server/src/analyzer/fold-minor-cast.test.ts
+++ b/server/src/analyzer/fold-minor-cast.test.ts
@@ -6,7 +6,10 @@ import { describe, it, expect } from 'vitest';
 import {
   foldMinorCast,
   isDescriptorName,
+  makeBucket,
   matchesProtectedRole,
+  MALE_BUCKET_ID,
+  FEMALE_BUCKET_ID,
   PROTECTED_ROLES_DEFAULT,
 } from './fold-minor-cast.js';
 import type { CharacterOutput, SentenceOutput } from '../handoff/schemas.js';
@@ -804,5 +807,86 @@ describe('matchesProtectedRole', () => {
 
   it('returns false on empty protected list', () => {
     expect(matchesProtectedRole('Bodyguard', [])).toBe(false);
+  });
+});
+
+describe('Wave D — localized minor-cast fold buckets', () => {
+  it('makeBucket mints localized Russian names for ru', () => {
+    expect(makeBucket(MALE_BUCKET_ID, 'male', 'ru').name).toBe('Незнакомый Парень');
+    expect(makeBucket(FEMALE_BUCKET_ID, 'female', 'ru').name).toBe('Незнакомая Девушка');
+    /* BCP-47 region subtag normalised. */
+    expect(makeBucket(MALE_BUCKET_ID, 'male', 'ru-RU').name).toBe('Незнакомый Парень');
+  });
+
+  it('makeBucket keeps English names for en / undefined', () => {
+    expect(makeBucket(MALE_BUCKET_ID, 'male', 'en').name).toBe('Unknown male');
+    expect(makeBucket(FEMALE_BUCKET_ID, 'female', 'en').name).toBe('Unknown female');
+    expect(makeBucket(MALE_BUCKET_ID, 'male').name).toBe('Unknown male');
+    expect(makeBucket(FEMALE_BUCKET_ID, 'female').name).toBe('Unknown female');
+  });
+
+  it('folds a low-line Russian character into a Russian-named bucket', () => {
+    const chars = [
+      makeChar('narrator'),
+      makeChar('anton', { name: 'Антон', gender: 'male' }),
+      makeChar('passerby', { name: 'Прохожий', gender: 'male' }),
+    ];
+    const sentences = makeSentences([
+      [1, 'narrator'],
+      [1, 'narrator'],
+      [1, 'narrator'],
+      [1, 'anton'],
+      [1, 'anton'],
+      [2, 'anton'],
+      [1, 'passerby'], // 1 line → folds
+    ]);
+
+    const result = foldMinorCast(chars, sentences, { minLines: 3, language: 'ru' });
+
+    const male = result.characters.find((c) => c.id === MALE_BUCKET_ID);
+    expect(male?.name).toBe('Незнакомый Парень');
+  });
+
+  it('is idempotent: re-folding a cast that already has a Russian bucket name keeps it Russian', () => {
+    /* Seed a cast that already contains a Russian-named bucket plus a fresh
+       low-line character to force the fold path (so the canonicalizer runs). */
+    const chars = [
+      makeChar('narrator'),
+      { ...makeBucket(MALE_BUCKET_ID, 'male', 'ru') },
+      makeChar('drifter', { name: 'Прохожий', gender: 'male' }),
+    ];
+    const sentences = makeSentences([
+      [1, 'narrator'],
+      [1, MALE_BUCKET_ID],
+      [1, 'drifter'], // 1 line → folds into the male bucket
+    ]);
+
+    const result = foldMinorCast(chars, sentences, { minLines: 3, language: 'ru' });
+
+    const male = result.characters.find((c) => c.id === MALE_BUCKET_ID);
+    /* The canonicalizer must NOT revert the Russian name to "Unknown male". */
+    expect(male?.name).toBe('Незнакомый Парень');
+  });
+
+  it('isDescriptorName treats Russian generic nouns as descriptors only when language is Russian', () => {
+    expect(isDescriptorName('девушка', 'ru')).toBe(true);
+    expect(isDescriptorName('Парень', 'ru')).toBe(true);
+    expect(isDescriptorName('Незнакомец', 'ru')).toBe(true);
+    expect(isDescriptorName('Старик', 'ru')).toBe(true);
+    /* Without the language flag, a Russian noun is NOT recognised. */
+    expect(isDescriptorName('девушка')).toBe(false);
+    expect(isDescriptorName('Парень')).toBe(false);
+    /* A real Russian proper name must not fold. */
+    expect(isDescriptorName('Антон', 'ru')).toBe(false);
+    expect(isDescriptorName('Борис Игнатьевич', 'ru')).toBe(false);
+  });
+
+  it('English descriptor matrix is unchanged when a language is passed', () => {
+    expect(isDescriptorName('Unknown Jogger', 'en')).toBe(true);
+    expect(isDescriptorName('The Jogger', 'en')).toBe(true);
+    expect(isDescriptorName('Old Man', 'en')).toBe(true);
+    expect(isDescriptorName('Wren', 'en')).toBe(false);
+    /* English descriptors still work under ru too (we only ADD, never remove). */
+    expect(isDescriptorName('Unknown Jogger', 'ru')).toBe(true);
   });
 });

--- a/server/src/analyzer/fold-minor-cast.ts
+++ b/server/src/analyzer/fold-minor-cast.ts
@@ -34,6 +34,7 @@
 
 import type { CharacterOutput, SentenceOutput } from '../handoff/schemas.js';
 import { taggedSpeakerIds } from './recover-tagged-lines.js';
+import { normaliseBookLanguage } from '../tts/language.js';
 
 export interface FoldOptions {
   /** A character whose attributed line count is strictly below this
@@ -66,6 +67,11 @@ export interface FoldOptions {
       otherwise be silently dropped or bucketed into
       unknown-male/female. */
   protectedRoles?: string[];
+  /** BCP-47 book language (e.g. `'ru'`, `'en'`, `'ru-RU'`). Drives the
+      localized bucket name (`bucketName`) AND the language-keyed Russian
+      descriptor detection in `isDescriptorName`. Missing / English → the
+      existing English behaviour. Normalised via `normaliseBookLanguage`. */
+  language?: string;
 }
 
 export interface FoldResult {
@@ -96,6 +102,26 @@ export const PROTECTED_ROLES_DEFAULT = ['Bodyguard', 'Mentor', 'Family Member'];
 export const MALE_BUCKET_ID = 'unknown-male';
 export const FEMALE_BUCKET_ID = 'unknown-female';
 const NARRATOR_ID = 'narrator';
+
+/* Localized minor-cast bucket display names (Wave D, plan 221). Keyed by the
+   normalised primary subtag. English is the default for every unmapped
+   language. The single source of truth used by BOTH `makeBucket` (mint) AND
+   the `withCounts` canonicalizer (re-fold), so a Russian-named bucket is never
+   reverted to English on a subsequent fold. Russian strings are user-specified
+   and must stay exact. */
+const BUCKET_NAMES: Record<string, { male: string; female: string }> = {
+  ru: { male: 'Незнакомый Парень', female: 'Незнакомая Девушка' },
+};
+const BUCKET_NAMES_DEFAULT = { male: 'Unknown male', female: 'Unknown female' };
+
+/* The localized display name for a bucket given the book language. Used by
+   both the minting path (`makeBucket`) and the canonicalizer so re-folds are
+   stable/idempotent. */
+export function bucketName(gender: 'male' | 'female', language?: string): string {
+  const primary = normaliseBookLanguage(language);
+  const names = BUCKET_NAMES[primary] ?? BUCKET_NAMES_DEFAULT;
+  return names[gender];
+}
 
 /* Returns true if `role` matches any entry in `protectedRoles` via
    case-insensitive substring. `'Goblin Bodyguard'` matches `'Bodyguard'`;
@@ -129,6 +155,30 @@ const GENERIC_ROLE_TAIL = new Set([
   'voice',
 ]);
 
+/* Russian generic-role nouns that read as descriptors rather than proper
+   names ("девушка" = girl, "парень" = guy, "незнакомец" = stranger). Only
+   consulted when the book language is Russian. Unlike the English tail-word
+   rule these match a BARE single-word name (Russian background speakers are
+   typically emitted as a lone noun, not "<adj> <noun>"). Russian inflection
+   means this is PARTIAL coverage for v1 — case-declined forms ("девушку",
+   "парня") and adjective-prefixed phrases are not stemmed; we match the
+   nominative singular only. Extending to a stemmer is deliberately out of
+   scope (don't over-engineer). */
+const GENERIC_ROLE_RU = new Set([
+  'девушка',
+  'парень',
+  'юноша',
+  'мужчина',
+  'женщина',
+  'незнакомец',
+  'незнакомка',
+  'человек',
+  'голос',
+  'старик',
+  'старуха',
+  'парнишка',
+]);
+
 /* Decides whether a character's `name` reads as a descriptor rather
    than a proper name. The three patterns we catch in order:
      1. `^Unknown\b...` — the Stage-1 contract ("Unknown <descriptor>"
@@ -145,8 +195,14 @@ const GENERIC_ROLE_TAIL = new Set([
         role tail so a bare proper name that happens to be a role
         ("Boy" used as a nickname) doesn't get folded.
    Trim + lowercase normalisation up front so the model's casing
-   choices don't matter. */
-export function isDescriptorName(name: string): boolean {
+   choices don't matter.
+
+   When `language` is Russian the English patterns above still apply (the
+   model occasionally emits "Unknown …" even on a Russian book) AND a bare
+   Russian generic noun ("девушка", "парень") is additionally treated as a
+   descriptor. Russian inflection means partial coverage for v1 — see
+   `GENERIC_ROLE_RU`. */
+export function isDescriptorName(name: string, language?: string): boolean {
   const trimmed = name.trim();
   if (!trimmed) return false;
   if (/^unknown\b/i.test(trimmed)) return true;
@@ -155,6 +211,10 @@ export function isDescriptorName(name: string): boolean {
   if (parts.length >= 2) {
     const tail = parts[parts.length - 1].toLowerCase();
     if (GENERIC_ROLE_TAIL.has(tail)) return true;
+  }
+  if (normaliseBookLanguage(language) === 'ru') {
+    /* Match a lone Russian generic noun (the typical background-speaker form). */
+    if (parts.length === 1 && GENERIC_ROLE_RU.has(parts[0].toLowerCase())) return true;
   }
   return false;
 }
@@ -167,9 +227,13 @@ function pickBucket(c: CharacterOutput): string {
   return c.gender === 'female' ? FEMALE_BUCKET_ID : MALE_BUCKET_ID;
 }
 
-export function makeBucket(id: string, gender: 'male' | 'female'): CharacterOutput {
+export function makeBucket(
+  id: string,
+  gender: 'male' | 'female',
+  language?: string,
+): CharacterOutput {
   const label = gender === 'male' ? 'male' : 'female';
-  const title = gender === 'male' ? 'Unknown male' : 'Unknown female';
+  const title = bucketName(gender, language);
   return {
     id,
     name: title,
@@ -193,6 +257,9 @@ export function foldMinorCast(
   const minLines = opts.minLines ?? MIN_LINES_DEFAULT;
   const nameOnly = opts.nameOnly === true;
   const protectedRoles = opts.protectedRoles ?? PROTECTED_ROLES_DEFAULT;
+  const language = opts.language;
+  const maleName = bucketName('male', language);
+  const femaleName = bucketName('female', language);
 
   /* Count attributed lines per character id. In nameOnly mode the count
      is unused (line-count rules are off) — keep the map empty rather
@@ -239,7 +306,7 @@ export function foldMinorCast(
   for (const c of characters) {
     if (c.id === NARRATOR_ID) continue;
     if (c.id === MALE_BUCKET_ID || c.id === FEMALE_BUCKET_ID) continue;
-    const isDescriptor = isDescriptorName(c.name);
+    const isDescriptor = isDescriptorName(c.name, language);
     const lines = lineCount.get(c.id) ?? 0;
     const isProtected =
       (c.detectionSource === 'narrator-mention' &&
@@ -272,8 +339,8 @@ export function foldMinorCast(
      (plan 122). */
   const hasDriftedBucket = characters.some(
     (c) =>
-      (c.id === MALE_BUCKET_ID && c.name !== 'Unknown male') ||
-      (c.id === FEMALE_BUCKET_ID && c.name !== 'Unknown female'),
+      (c.id === MALE_BUCKET_ID && c.name !== maleName) ||
+      (c.id === FEMALE_BUCKET_ID && c.name !== femaleName),
   );
 
   /* No folds and no drops (and no drifted bucket) → no-op, preserve
@@ -305,12 +372,12 @@ export function foldMinorCast(
   /* Synthesise missing buckets (or re-use if already present in the input). */
   const survivorById = new Map(survivors.map((c) => [c.id, c]));
   if (needMale && !survivorById.has(MALE_BUCKET_ID)) {
-    const bucket = makeBucket(MALE_BUCKET_ID, 'male');
+    const bucket = makeBucket(MALE_BUCKET_ID, 'male', language);
     survivors.push(bucket);
     survivorById.set(bucket.id, bucket);
   }
   if (needFemale && !survivorById.has(FEMALE_BUCKET_ID)) {
-    const bucket = makeBucket(FEMALE_BUCKET_ID, 'female');
+    const bucket = makeBucket(FEMALE_BUCKET_ID, 'female', language);
     survivors.push(bucket);
     survivorById.set(bucket.id, bucket);
   }
@@ -366,10 +433,10 @@ export function foldMinorCast(
        drifted NAME is deliberately NOT kept as an alias, so the matcher won't
        re-bind that character to the bucket). */
     if (base.id === MALE_BUCKET_ID) {
-      return { ...base, name: 'Unknown male', gender: 'male' as const, role: base.role || 'background' };
+      return { ...base, name: maleName, gender: 'male' as const, role: base.role || 'background' };
     }
     if (base.id === FEMALE_BUCKET_ID) {
-      return { ...base, name: 'Unknown female', gender: 'female' as const, role: base.role || 'background' };
+      return { ...base, name: femaleName, gender: 'female' as const, role: base.role || 'background' };
     }
     return base;
   });

--- a/server/src/routes/analysis.test.ts
+++ b/server/src/routes/analysis.test.ts
@@ -1539,6 +1539,29 @@ describe('buildInterimCast — mid-run cast snapshot', () => {
     expect(male.aliases).toEqual(['The Jogger', 'Drooly Boy', 'Unknown Intruder']);
     expect(female.aliases).toEqual(['Tall Lady']);
   });
+
+  it('mints localized Russian bucket names end-to-end when language is ru (Wave D, plan 221)', () => {
+    /* A Russian book folds bare generic-noun descriptors and the bucket
+       carries the user-specified Russian display name, matching what the
+       post-Phase-1 fold will produce. */
+    const chapterCast: Record<number, CharacterOutput[]> = {
+      1: [
+        makeChar('narrator', 'Рассказчик'),
+        makeChar('anton', 'Антон', { gender: 'male' }),
+        makeChar('parnishka', 'парень', { gender: 'male' }),
+        makeChar('devushka', 'девушка', { gender: 'female' }),
+      ],
+    };
+
+    const interim = buildInterimCast(chapterCast, [1], 'ru');
+
+    const male = interim.find((c) => c.id === 'unknown-male')!;
+    const female = interim.find((c) => c.id === 'unknown-female')!;
+    expect(male?.name).toBe('Незнакомый Парень');
+    expect(female?.name).toBe('Незнакомая Девушка');
+    /* A real proper name ("Антон") is NOT folded. */
+    expect(interim.some((c) => c.id === 'anton')).toBe(true);
+  });
 });
 
 /* Phase 0b finalise drops non-narrator characters whose verifier

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -623,6 +623,7 @@ export function mergeRosterChapter(
 export function buildInterimCast(
   chapterCast: Record<number, CharacterOutput[]>,
   chapterOrder: number[],
+  language?: string,
 ): CharacterOutput[] {
   const roster = new Map<string, CharacterOutput>();
   for (const chapterId of chapterOrder) {
@@ -630,7 +631,7 @@ export function buildInterimCast(
     if (cast?.length) mergeRosterChapter(roster, cast);
   }
   if (roster.size === 0) return [];
-  const folded = previewFoldForLiveView(Array.from(roster.values()));
+  const folded = previewFoldForLiveView(Array.from(roster.values()), language);
   return attachLinesAndScenes(assignPaletteColors(folded), []);
 }
 
@@ -667,8 +668,11 @@ async function writeFoldJournal(
   );
 }
 
-function previewFoldForLiveView(characters: CharacterOutput[]): CharacterOutput[] {
-  return foldMinorCast(characters, [], { nameOnly: true }).characters;
+function previewFoldForLiveView(
+  characters: CharacterOutput[],
+  language?: string,
+): CharacterOutput[] {
+  return foldMinorCast(characters, [], { nameOnly: true, language }).characters;
 }
 
 /* Stage 1 doesn't know per-sentence counts. Compute lines (sentences spoken)
@@ -2498,7 +2502,7 @@ export async function runMainAnalyzerJob(
         await saveAnalysisCache(manuscriptId, cache);
       }
       await persistDroppedQuotesBatch(recordRef.bookDir, manuscriptId, 'analysis-stream', verified);
-      send({ kind: 'cast-update', characters: previewFoldForLiveView(stage1.characters) });
+      send({ kind: 'cast-update', characters: previewFoldForLiveView(stage1.characters, bookLanguage) });
       /* Plan 88 follow-up — cache hit: Phase 0 is already complete, so
          the finalised stage1 is the canonical roster for any Phase 1
          worker that asks for a snapshot. Flip the flag so
@@ -2552,7 +2556,7 @@ export async function runMainAnalyzerJob(
            Unknown female buckets in the live view — same contract the
            on-disk interim cast.json uses, kept in lockstep so the user
            sees one consistent roster across SSE + .audiobook/. */
-        const folded = previewFoldForLiveView(Array.from(roster.values()));
+        const folded = previewFoldForLiveView(Array.from(roster.values()), bookLanguage);
         send({ kind: 'cast-update', characters: folded });
       };
 
@@ -2898,6 +2902,7 @@ export async function runMainAnalyzerJob(
           const interim = buildInterimCast(
             chapterCast,
             recordRef.chapterHints.map((h) => h.id),
+            bookLanguage,
           );
           if (interim.length > 0) {
             try {
@@ -3084,7 +3089,7 @@ export async function runMainAnalyzerJob(
           verified,
         );
         stage1ActualMs = Date.now() - stage0Start;
-        send({ kind: 'cast-update', characters: previewFoldForLiveView(stage1.characters) });
+        send({ kind: 'cast-update', characters: previewFoldForLiveView(stage1.characters, bookLanguage) });
         /* Cast.json reflects the verified Phase 0b state before Phase 1's
            attribution pass starts (which can be the longest phase by far
            on a long book). We apply the name-only fold here too — the
@@ -3101,7 +3106,7 @@ export async function runMainAnalyzerJob(
         if (recordRef.bookDir) {
           try {
             const stage1Cast = attachLinesAndScenes(
-              assignPaletteColors(previewFoldForLiveView(stage1.characters)),
+              assignPaletteColors(previewFoldForLiveView(stage1.characters, bookLanguage)),
               [],
             );
             await writeJsonAtomic(castJsonPath(recordRef.bookDir), {
@@ -3794,6 +3799,7 @@ export async function runMainAnalyzerJob(
     }
     const folded = foldMinorCast(stage1.characters, recovered.sentences, {
       minLines: userSettings.minorCastMinLines,
+      language: bookLanguage,
     });
     if (folded.summary.foldedCount > 0) {
       const parts: string[] = [];
@@ -4403,7 +4409,7 @@ async function runSubsetAnalyzerJob(
     };
     const emitCastUpdate = (): void => {
       const roster = rebuildRoster();
-      const folded = previewFoldForLiveView(Array.from(roster.values()));
+      const folded = previewFoldForLiveView(Array.from(roster.values()), bookLanguage);
       send({ kind: 'cast-update', characters: folded });
     };
 
@@ -4481,6 +4487,7 @@ async function runSubsetAnalyzerJob(
           const interim = buildInterimCast(
             chapterCast,
             record.chapterHints.map((h) => h.id),
+            bookLanguage,
           );
           if (interim.length > 0) {
             try {
@@ -4595,7 +4602,7 @@ async function runSubsetAnalyzerJob(
     }
     await saveAnalysisCache(manuscriptId, cache);
     await persistDroppedQuotesBatch(record.bookDir, manuscriptId, 'analysis-chapters', verified);
-    send({ kind: 'cast-update', characters: previewFoldForLiveView(stage1.characters) });
+    send({ kind: 'cast-update', characters: previewFoldForLiveView(stage1.characters, bookLanguage) });
     send({ kind: 'phase', phaseId: 0, progress: 1, label: PHASES[0].label, model: subsetModelId });
 
     /* ── Phase 1 (subset). Sentence attribution for the new chapters only.
@@ -4744,7 +4751,9 @@ async function runSubsetAnalyzerJob(
     }
     /* Re-fold the cast against the merged sentence set so the bucket
        attributions stay coherent with the new chapters' attributions. */
-    const folded = foldMinorCast(stage1.characters, recovered.sentences);
+    const folded = foldMinorCast(stage1.characters, recovered.sentences, {
+      language: bookLanguage,
+    });
     if (folded.summary.droppedSilent > 0) {
       const sample = folded.dropped.slice(0, 4).join(', ');
       const more = folded.dropped.length > 4 ? `, +${folded.dropped.length - 4} more` : '';

--- a/server/src/routes/cast-merge.test.ts
+++ b/server/src/routes/cast-merge.test.ts
@@ -477,3 +477,113 @@ describe('cast-merge downgrade to bucket', () => {
     }
   });
 });
+
+describe('cast-merge downgrade to bucket — Russian book (Wave D, plan 221)', () => {
+  const R_AUTHOR = 'Russian Downgrade Author';
+  const R_SERIES = 'Standalones';
+  const R_TITLE = 'Russian Downgrade Book';
+  const R_MANUSCRIPT_ID = 'm_ru_downgrade_test';
+
+  let rBookDir: string;
+  let rBookId: string;
+  let rCachePath: string;
+
+  beforeAll(async () => {
+    const { makeBookId } = await import('../workspace/paths.js');
+    rBookId = makeBookId(R_AUTHOR, R_SERIES, R_TITLE);
+    rBookDir = join(workspaceRoot, 'books', R_AUTHOR, R_SERIES, R_TITLE);
+    mkdirSync(join(rBookDir, '.audiobook'), { recursive: true });
+
+    writeFileSync(
+      join(rBookDir, '.audiobook', 'state.json'),
+      JSON.stringify({
+        bookId: rBookId,
+        manuscriptId: R_MANUSCRIPT_ID,
+        title: R_TITLE,
+        author: R_AUTHOR,
+        series: R_SERIES,
+        seriesPosition: null,
+        isStandalone: true,
+        manuscriptFile: 'manuscript.txt',
+        castConfirmed: true,
+        language: 'ru',
+        chapters: [{ id: 1, title: 'Один', slug: '01-odin' }],
+        coverGradient: ['#000', '#fff'],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+    writeFileSync(join(rBookDir, 'manuscript.txt'), 'placeholder');
+
+    writeFileSync(
+      join(rBookDir, '.audiobook', 'cast.json'),
+      JSON.stringify({
+        characters: [
+          {
+            id: 'prohozhiy',
+            name: 'Прохожий',
+            role: 'background',
+            color: 'halloran',
+            lines: 2,
+            scenes: 1,
+            gender: 'male',
+          },
+          {
+            id: 'anton',
+            name: 'Антон',
+            role: 'protagonist',
+            color: 'eliza',
+            lines: 9,
+            scenes: 1,
+            gender: 'male',
+          },
+        ],
+      }),
+    );
+
+    const sents = [
+      { id: 1, chapterId: 1, characterId: 'prohozhiy', text: 'Привет.' },
+      { id: 2, chapterId: 1, characterId: 'anton', text: 'Здравствуйте.' },
+    ];
+    writeFileSync(
+      join(rBookDir, '.audiobook', 'manuscript-edits.json'),
+      JSON.stringify({ sentences: sents }),
+    );
+
+    const testFileDir = dirname(fileURLToPath(import.meta.url));
+    rCachePath = resolve(testFileDir, '..', '..', 'handoff', 'cache', `${R_MANUSCRIPT_ID}.json`);
+    mkdirSync(dirname(rCachePath), { recursive: true });
+    writeFileSync(
+      rCachePath,
+      JSON.stringify({
+        stage1: {
+          characters: [
+            { id: 'prohozhiy', name: 'Прохожий', role: 'background', gender: 'male' },
+            { id: 'anton', name: 'Антон', role: 'protagonist', gender: 'male' },
+          ],
+          chapters: [{ id: 1, title: 'Один' }],
+        },
+        chapters: { 1: [sents[0], sents[1]] },
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+  });
+
+  afterAll(() => {
+    if (rCachePath) rmSync(rCachePath, { force: true });
+  });
+
+  it('mints the Russian-named unknown-male bucket on a manual downgrade', async () => {
+    const res = await request(app)
+      .post(`/api/books/${rBookId}/cast/merge`)
+      .set('Content-Type', 'application/json')
+      .send({ sourceId: 'prohozhiy', targetId: 'unknown-male' });
+
+    expect(res.status).toBe(200);
+    const body = res.body as { characters: Array<Record<string, unknown>> };
+    const bucket = body.characters.find((c) => c.id === 'unknown-male')!;
+    /* Book language ru → bucket carries the localized name, matching the fold. */
+    expect(bucket.name).toBe('Незнакомый Парень');
+    expect(bucket.gender).toBe('male');
+  });
+});

--- a/server/src/routes/cast-merge.ts
+++ b/server/src/routes/cast-merge.ts
@@ -24,6 +24,7 @@ import { readJson, writeJsonAtomic } from '../workspace/state-io.js';
 import { loadAnalysisCache, saveAnalysisCache } from '../store/analysis-cache.js';
 import { loadCastMerges, saveCastMerges, appendManualEntry } from '../store/cast-merges.js';
 import { normaliseForMatch } from './analysis.js';
+import { bookStateLanguage } from '../workspace/scan.js';
 import { makeBucket, MALE_BUCKET_ID, FEMALE_BUCKET_ID } from '../analyzer/fold-minor-cast.js';
 import type { CharacterOutput, SentenceOutput } from '../handoff/schemas.js';
 
@@ -81,7 +82,12 @@ castMergeRouter.post('/:bookId/cast/merge', async (req: Request, res: Response) 
      special-case "book has never had a background voice before". */
   let createdBucket: CharacterOutput | null = null;
   if (!target && (targetId === MALE_BUCKET_ID || targetId === FEMALE_BUCKET_ID)) {
-    createdBucket = makeBucket(targetId, targetId === MALE_BUCKET_ID ? 'male' : 'female');
+    /* Localize the minted bucket's display name to the book's language so a
+       manual downgrade on a non-English book produces the SAME name the
+       analyser's fold would (e.g. Russian "Незнакомый Парень"). Resolved via
+       the canonical seam; defaults to English when state has no language. */
+    const language = bookStateLanguage(state);
+    createdBucket = makeBucket(targetId, targetId === MALE_BUCKET_ID ? 'male' : 'female', language);
     cast.characters.push(createdBucket);
     target = createdBucket;
   }


### PR DESCRIPTION
## Summary

Wave D of plan 221. Localizes the minor-cast fold buckets for non-English books and makes Russian descriptor-names fold.

- **Single source of truth** `bucketName(gender, language)` used by BOTH `makeBucket` and the `withCounts` canonicalizer in `fold-minor-cast.ts` — so a re-fold can't revert a localized bucket to English. Russian: `unknown-male` → **Незнакомый Парень**, `unknown-female` → **Незнакомая Девушка**; English unchanged.
- `language?` threaded through `FoldOptions` → both finalisation folds (main + subset), `previewFoldForLiveView`, the exported `buildInterimCast` (+ all callers), and `cast-merge.ts` manual downgrade (resolves via `bookStateLanguage`) — so live/interim/manual buckets all agree, no English-then-flip.
- `isDescriptorName(name, language?)` language-keyed: Russian generic nouns (девушка/парень/юноша/…) fold only under `ru`; English behavior unchanged. Russian inflection → documented partial coverage for v1.

Addresses the adversarial-review corrections (canonicalizer single-source; `buildInterimCast`/`previewFoldForLiveView` signature ripple; `cast-merge` language source).

## Test plan

- `fold-minor-cast.test.ts` (39): ru/en/undefined bucket names; **idempotence** (re-fold keeps the Russian name — pins the canonicalizer regression surface); `isDescriptorName` ru positives/negatives; English matrix unchanged.
- `cast-merge.test.ts` (8): Russian-book manual downgrade mints the Russian bucket name.
- `analysis.test.ts` (121): `buildInterimCast` ru end-to-end; English path unchanged.
- Full `npm run verify` green (the one e2e failure was the known stale-Vite-on-5174 port flake — specs pass clean in isolation; Wave D is server-only and mock-mode e2e never touches the fold path).

Plan: `docs/features/221-multilingual-attribution-gemma-and-cast-merge.md` (Wave D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)