### PR TITLE
ci(scripts,docs): pre-push commit-subject guard (backstop bypassed commit-msg)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,12 @@
-# Refuse force-push / deletion of protected branches (main) before the
-# ~15-min verify even starts. Bypass intentionally with `git push --no-verify`.
-# See docs/features/163-protected-push-guard.md.
-node scripts/guard-protected-push.mjs "$@" || exit 1
+# Pre-push guards run before the ~15-min verify. git pipes the pushed-ref list
+# on stdin; capture it ONCE and feed both guards (stdin can only be read once).
+# Bypass intentionally with `git push --no-verify`.
+#   1. guard-protected-push  — refuse force-push / deletion of main (#163).
+#   2. guard-commit-subjects — reject any pushed commit whose subject violates
+#      the Conventional-Commits rule, even if commit-msg was bypassed
+#      (--no-verify / worktree hook couldn't spawn). Backstops the @-leak that
+#      shipped on #856.
+PUSH_REFS=$(cat)
+printf '%s\n' "$PUSH_REFS" | node scripts/guard-protected-push.mjs "$@" || exit 1
+printf '%s\n' "$PUSH_REFS" | node scripts/guard-commit-subjects.mjs "$@" || exit 1
 npm run verify

--- a/docs/features/163-protected-push-guard.md
+++ b/docs/features/163-protected-push-guard.md
@@ -121,6 +121,23 @@ Run from the repo root (no real remote needed — pipe a fake ref line):
   `npm run verify` check would deadlock doc-only PRs (`verify.yml` skips them
   via `paths-ignore: docs/**`, so the required check would never report).
 
+## Sibling guard — pre-push commit-subject lint (2026-06-17)
+
+`.husky/pre-push` now runs a second guard, `scripts/guard-commit-subjects.mjs`,
+alongside the force-push/deletion guard. It validates **every commit being
+pushed** against the Conventional-Commits subject rule (reusing
+`validateCommitSubject` from `scripts/validate-commit-msg.mjs`), so a malformed
+subject is caught at push time **even when `commit-msg` was skipped** — e.g. a
+`git commit --no-verify`, or a worktree whose husky hook couldn't spawn. The
+motivating bug: a PowerShell here-string `@'…'@` used to build `git commit -m`
+leaked a stray `@` into three subjects (`@ feat(server): …`) that reached `main`
+via #856 because that worktree committed with `--no-verify`; once merged, the
+only fix is a history rewrite + force-push (blocked). The hook captures git's
+pushed-ref stdin once (`PUSH_REFS=$(cat)`) and feeds both guards. Pure core
+(`evaluatePush`) is unit-tested in `scripts/tests/guard-commit-subjects.test.mjs`
+(auto-discovered by `npm run test:hooks`); intentional bypass is still
+`git push --no-verify`.
+
 ## Ship notes
 
 (Filled in when status flips to `stable`: shipped date + commit SHA.)

--- a/scripts/guard-commit-subjects.mjs
+++ b/scripts/guard-commit-subjects.mjs
@@ -1,0 +1,105 @@
+// Pre-push commit-subject guard for .husky/pre-push.
+//
+// Validates every commit being pushed against the Conventional-Commits subject
+// rule (reusing validateCommitSubject from validate-commit-msg.mjs). This is the
+// backstop for the `commit-msg` hook: a commit made with `git commit --no-verify`
+// (or in a worktree whose husky hook couldn't spawn) skips `commit-msg` entirely,
+// so a malformed subject — e.g. a stray "@ " leaked from a PowerShell here-string
+// `@'...'@` used to build `git commit -m` — can otherwise reach `main`. Once
+// merged, fixing the subject needs a history rewrite + force-push (blocked).
+// Catching it at push time is the last cheap line of defense.
+//
+// git pipes one line per ref being pushed to the hook's stdin:
+//   "<localRef> <localSha> <remoteRef> <remoteSha>"
+// A zero sha (all '0') means create (remoteSha) or delete (localSha).
+//
+// Intentionally bypassable with `git push --no-verify` for the rare deliberate
+// case. See docs/features/163-protected-push-guard.md (sibling guard).
+
+import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { validateCommitSubject, helpMessage as subjectHelp } from './validate-commit-msg.mjs';
+
+const isZeroSha = (sha) => /^0+$/.test(sha);
+const UNIT = '\x1f'; // git log field separator
+
+// Pure, unit-testable core. `listSubjects(remoteSha, localSha)` returns the
+// new commits in the push as [{ sha, subject }] — injected in tests so this
+// runs without a real repo. Each subject is validated; a deletion (zero
+// localSha) contributes nothing. Returns { blocked, failures }.
+export function evaluatePush(stdinText, { listSubjects }) {
+  const failures = [];
+  const seen = new Set();
+  for (const line of String(stdinText).split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    const [, localSha, , remoteSha] = trimmed.split(/\s+/);
+    if (!localSha || isZeroSha(localSha)) continue; // deletion — nothing to check
+    for (const { sha, subject } of listSubjects(remoteSha, localSha)) {
+      if (seen.has(sha)) continue; // a commit pushed on two refs is checked once
+      seen.add(sha);
+      const verdict = validateCommitSubject(subject);
+      if (!verdict.ok) failures.push({ sha, subject, reason: verdict.reason });
+    }
+  }
+  return { blocked: failures.length > 0, failures };
+}
+
+export function helpMessage(failures) {
+  const lines = [
+    `pre-push blocked: ${failures.length} commit subject(s) violate the Conventional Commits convention:`,
+    ``,
+  ];
+  for (const f of failures) {
+    lines.push(`  ${String(f.sha).slice(0, 9)}  ${JSON.stringify(f.subject)}  — ${f.reason}`);
+  }
+  lines.push(
+    ``,
+    subjectHelp(failures[0]?.subject ?? ''),
+    ``,
+    `Reword the offending commit(s) before pushing (git rebase -i / git commit --amend),`,
+    `or — only if genuinely intended — bypass with: git push --no-verify`,
+  );
+  return lines.join('\n');
+}
+
+// Real git-backed lister for CLI mode. Best-effort: a git error returns [] so
+// the guard never blocks a push because git itself hiccupped.
+function gitListSubjects(remoteSha, localSha) {
+  const revs =
+    remoteSha && !isZeroSha(remoteSha)
+      ? [`${remoteSha}..${localSha}`] // re-push: only commits since the last push
+      : [localSha, '--not', '--remotes']; // new branch: commits not yet on any remote
+  const res = spawnSync('git', ['log', `--format=%H${UNIT}%s`, ...revs], {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (res.status !== 0 || typeof res.stdout !== 'string') return [];
+  return res.stdout
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => {
+      const idx = l.indexOf(UNIT);
+      return { sha: l.slice(0, idx), subject: l.slice(idx + 1) };
+    });
+}
+
+const invokedAsCli =
+  typeof process !== 'undefined' &&
+  Array.isArray(process.argv) &&
+  /guard-commit-subjects\.mjs$/.test(process.argv[1] ?? '');
+
+if (invokedAsCli) {
+  let stdinText = '';
+  try {
+    stdinText = readFileSync(0, 'utf8');
+  } catch {
+    stdinText = ''; // no stdin (e.g. invoked manually) — nothing to check
+  }
+  const { blocked, failures } = evaluatePush(stdinText, { listSubjects: gitListSubjects });
+  if (blocked) {
+    process.stderr.write(helpMessage(failures) + '\n');
+    process.exit(1);
+  }
+  process.exit(0);
+}

--- a/scripts/tests/guard-commit-subjects.test.mjs
+++ b/scripts/tests/guard-commit-subjects.test.mjs
@@ -1,0 +1,91 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluatePush, helpMessage } from '../guard-commit-subjects.mjs';
+
+const ZERO = '0'.repeat(40);
+const line = (localSha, remoteSha = ZERO, remoteRef = 'refs/heads/feature') =>
+  `refs/heads/feature ${localSha} ${remoteRef} ${remoteSha}`;
+
+// listSubjects stub: maps a localSha to a fixed commit list.
+const lister = (commits) => () => commits;
+
+test('clean Conventional-Commits subjects pass', () => {
+  const r = evaluatePush(line('aaa'), {
+    listSubjects: lister([
+      { sha: 'aaa', subject: 'feat(server): add narrator-default heuristic' },
+      { sha: 'bbb', subject: 'docs(docs): update plan 221' },
+      { sha: 'ccc', subject: 'chore: bump deps' },
+    ]),
+  });
+  assert.equal(r.blocked, false);
+  assert.equal(r.failures.length, 0);
+});
+
+test('the real bug: a leaked "@ " prefix (PS here-string) is blocked', () => {
+  const r = evaluatePush(line('aaa'), {
+    listSubjects: lister([
+      { sha: 'aaa', subject: '@ feat(server): language-aware minor-cast fold buckets' },
+    ]),
+  });
+  assert.equal(r.blocked, true);
+  assert.equal(r.failures.length, 1);
+  assert.equal(r.failures[0].sha, 'aaa');
+  assert.match(r.failures[0].reason, /Conventional Commits/);
+});
+
+test('empty and bad-type subjects are blocked', () => {
+  const r = evaluatePush(line('aaa'), {
+    listSubjects: lister([
+      { sha: 'aaa', subject: '' },
+      { sha: 'bbb', subject: 'wip: random change' },
+      { sha: 'ccc', subject: 'feat(unknown-scope): nope' },
+    ]),
+  });
+  assert.equal(r.blocked, true);
+  assert.equal(r.failures.length, 3);
+});
+
+test('merge / revert / fixup commits are exempt (git auto-generated)', () => {
+  const r = evaluatePush(line('aaa'), {
+    listSubjects: lister([
+      { sha: 'aaa', subject: 'Merge pull request #856 from foo/bar' },
+      { sha: 'bbb', subject: 'Revert "feat(server): x"' },
+      { sha: 'ccc', subject: 'fixup! feat(server): x' },
+    ]),
+  });
+  assert.equal(r.blocked, false);
+});
+
+test('a deletion (zero local sha) checks nothing', () => {
+  let called = false;
+  const r = evaluatePush(line(ZERO), {
+    listSubjects: () => {
+      called = true;
+      return [];
+    },
+  });
+  assert.equal(r.blocked, false);
+  assert.equal(called, false);
+});
+
+test('a commit pushed on two refs is validated once', () => {
+  const stdin = `${line('aaa')}\n${line('aaa')}`;
+  let calls = 0;
+  const r = evaluatePush(stdin, {
+    listSubjects: () => {
+      calls += 1;
+      return [{ sha: 'dup', subject: '@ feat(server): x' }];
+    },
+  });
+  // listSubjects runs per ref line, but the duplicate sha is only reported once
+  assert.equal(calls, 2);
+  assert.equal(r.failures.length, 1);
+});
+
+test('helpMessage names the offending sha + subject and shows the convention', () => {
+  const msg = helpMessage([{ sha: 'abc123def456', subject: '@ feat(server): x', reason: 'r' }]);
+  assert.match(msg, /abc123def/);
+  assert.match(msg, /@ feat\(server\): x/);
+  assert.match(msg, /Allowed types/);
+  assert.match(msg, /--no-verify/);
+});


### PR DESCRIPTION
## Summary

Prevention lock-down after the Wave D (#856) commits shipped with a stray `@` in their subjects (`@ feat(server): …`) — a PowerShell here-string `@'…'@` leaked the delimiter into `git commit -m`, and it reached `main` because that worktree committed with `--no-verify` (so `commit-msg` never ran). Once merged, the only fix is a history rewrite + force-push (blocked) — so the fix is to catch it at push time.

- **`scripts/guard-commit-subjects.mjs`** — new `.husky/pre-push` guard that validates **every commit being pushed** against the Conventional-Commits subject rule (reuses `validateCommitSubject` from `validate-commit-msg.mjs`). Catches a malformed subject even when `commit-msg` was skipped (`--no-verify` / worktree hook couldn't spawn). Proven end-to-end: it blocks the real `3d0c4fae` (`@ feat…`) and passes clean ranges.
- **`.husky/pre-push`** — captures git's pushed-ref stdin once (`PUSH_REFS=$(cat)`) and feeds both the force-push guard and the new subject guard.
- Pure core `evaluatePush` is unit-tested (`scripts/tests/guard-commit-subjects.test.mjs`, auto-discovered by `test:hooks`): clean subjects pass; the `@ `-leak case, empty, and bad-scope subjects block; merge/revert/fixup exempt; deletions check nothing; per-sha dedup.
- Doc note in `docs/features/163-protected-push-guard.md`.

Intentional bypass remains `git push --no-verify`.

## Test plan
- `node --test scripts/tests/guard-commit-subjects.test.mjs` → 7/7; full `test:hooks` 376 green.
- End-to-end CLI: guard blocks the real merged `@` commit (exit 1), passes clean (exit 0).
- Pushed through the new pre-push guard itself (dogfood) — full `npm run verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)