### PR TITLE
fix(frontend): surface pulled & uncurated Ollama models in analyzer pickers + Model Manager

### DIFF
--- a/docs/features/221-dynamic-analyzer-models.md
+++ b/docs/features/221-dynamic-analyzer-models.md
@@ -7,7 +7,7 @@ owner: null
 # 221 — Dynamic analyzer model picker (curated ∪ live Ollama tags)
 
 > Status: active
-> Key files: `src/lib/models.ts`, `src/store/account-slice.ts`, `src/components/model-settings-form.tsx`, `src/components/analysis-model-picker.tsx`, `src/views/analysing.tsx`, `src/hooks/use-local-analyzer-guard.tsx`, `server/src/routes/ollama-health.ts`, `server/src/ollama/pull-bootstrap.ts`, `server/src/analyzer/ollama.ts`, `server/src/config/registry.ts`
+> Key files: `src/lib/models.ts`, `src/store/account-slice.ts`, `src/components/model-settings-form.tsx`, `src/components/model-pull-status.tsx`, `src/components/analysis-model-picker.tsx`, `src/components/analysing/phase-model-swap.tsx`, `src/views/analysing.tsx`, `src/views/model-manager.tsx`, `src/hooks/use-local-analyzer-guard.tsx`, `server/src/routes/ollama-health.ts`, `server/src/ollama/pull-bootstrap.ts`, `server/src/analyzer/ollama.ts`, `server/src/config/registry.ts`
 > URL surface: analyzer-model pickers (upload, re-parse modal, Account → Defaults, analysing retry, setup wizard); Model Manager pull rows
 > OpenAPI: none — the `/api/ollama/*` routes are deliberately out of `openapi.yaml` (like the sidecar/qwen routes)
 
@@ -31,7 +31,7 @@ This is **Part A** of the original "dynamic analyzer models" work. The measured-
 
 - **Invariants preserved:**
   - `keepAliveFor(model, accelerator)` keeps main's `RESIDENT_MODELS` + accelerator logic (9B unloads on CPU). The knob only parameterises the `'5m'` literal; cross-engine eviction stays owned by `withGpuLoad` (plan 222).
-  - Cloud-no-probe: the analysing-view retry picker fetches the local tag list only after a failure (`error`-gated), so a healthy cloud run never probes Ollama.
+  - Cloud-no-probe: the analysing-view retry picker fetches the local tag list only after a failure (`error`-gated), so a healthy cloud run never *auto*-probes Ollama. The per-phase `PhaseModelSwap` picker additionally refreshes the live list **on `onFocus`** (explicit user interaction) — the invariant holds because the probe fires only when the user opens the dropdown, never on the passive healthy-run render.
   - Gemini fallback (`selectAnalyzer`) unchanged: `ANALYZER=local` + Ollama down + key set → silent Gemini fallback.
 
 - **Deleted:** the frontend `PULLABLE_MODELS` mirror (now `account.pullableModels` from the server).
@@ -44,6 +44,10 @@ This is **Part A** of the original "dynamic analyzer models" work. The measured-
 2. **Engine classification by tag shape.** Use `engineForModelId(id)` (`:` ⇒ local) for the GPU-contention guard and readiness gating — never `MODEL_OPTIONS.find(...).engine` (which mis-classifies an uncurated pulled tag as Gemini and silently skips the guard).
 3. **Single canonical install list.** `DEFAULT_ALLOWED_MODELS` (server) is the only source of pull suggestions; it is both the Model Manager's Pull rows (via `pullable`) and the pull-proxy allowlist (`isAllowed`). It is suggestions + a pull guard, NOT an execution boundary (anything actually pulled is runnable).
 4. **`/health` and `/refresh` stay identical.** `/refresh` delegates to `probeOllamaHealth()`; both carry `pullable`.
+5. **Analysing-view picker refreshes on open.** `PhaseModelSwap` dispatches `fetchAnalyzerModels` on `onFocus`, so a just-pulled local tag becomes selectable on a healthy run without a reload — without auto-probing on the passive render (preserves invariant in §"Cloud-no-probe").
+6. **`ModelPullStatus` rows = `health.pullable` ∪ installed tags.** The "Analyzer models" pull list derives its curated rows from the live health envelope's `pullable` (falling back to the redux `pullableModels` prop), so **"Refresh available models" is self-healing** — a refresh response repopulates an empty list (the redux prop alone could get stuck empty after a transient fetch failure). Installed-but-uncurated tags (e.g. a custom local `gemma4-e4b-8gb:latest`) are unioned in as read-only "Installed" on-disk rows, so the list is a complete picture of what the analyzer can run.
+7. **Model Manager groups by kind.** Inventory rows render under explicit subheadings — TTS under *Standard* / *Optional add-ons*, analyzer (Ollama) under *Analyzer models (Ollama)*, ASR under *Speech recognition (ASR)* — so local analyzer models are never visually lumped under the TTS "Optional add-ons".
+8. **Curated Gemma entry.** `gemma-4-E4B-it-GGUF:UD-Q4_K_XL` is a curated `MODEL_OPTIONS` local entry (friendly label "Gemma 4 E4B (local)"), matching its long-standing membership in the server pull allowlist.
 
 ## Test plan
 
@@ -55,7 +59,8 @@ This is **Part A** of the original "dynamic analyzer models" work. The measured-
 - `src/lib/models.test.ts` — `engineForModelId`; `buildLocalModelOptions` union (curated kept, uncurated appended, dedup, offline=curated); `buildModelOptionGroups`; back-compat `MODEL_OPTION_GROUPS`.
 - `src/store/account-slice.test.ts` — `fetchAnalyzerModels` populates `localAnalyzerModels` + `pullableModels`; unreachable → empty local, pullable still set.
 - `src/hooks/use-local-analyzer-guard.test.tsx` — the guard fires for an uncurated local tag.
-- `src/views/model-manager.test.tsx`, `src/components/analysing/phase-model-swap.test.tsx` — pull rows + picker render the dynamic union (incl. an uncurated tag in the Local optgroup).
+- `src/views/model-manager.test.tsx`, `src/components/analysing/phase-model-swap.test.tsx` — pull rows + picker render the dynamic union (incl. an uncurated tag in the Local optgroup); `phase-model-swap` also asserts the on-`focus` `fetchAnalyzerModels` refresh; `model-manager` asserts analyzer/ASR rows render under their own subheadings (not under Optional add-ons).
+- `src/components/model-pull-status.test.tsx` — curated ∪ installed union (uncurated tag → read-only "Installed" row); curated rows drive off `health.pullable` even when the redux prop is empty (self-healing); "Refresh available models" recovers an empty list from the refresh response's `pullable`.
 - `e2e/model-manager-models.spec.ts` — the e4b tag is offered in the pull list.
 
 ### Manual acceptance walkthrough

--- a/docs/superpowers/plans/2026-06-17-vram-telemetry-substrate-v1.md
+++ b/docs/superpowers/plans/2026-06-17-vram-telemetry-substrate-v1.md
@@ -18,7 +18,7 @@
 - **Best-effort telemetry:** every record/sample path is fire-and-forget; it MUST NOT throw into or block the analysis/synthesis path.
 - **OOM-safety (TTS):** record the **absolute** `vram_reserved_mb` at an op's peak, never a before/after delta (absolute over-estimates — the safe direction). For `qwen:synth`/`coqui`, the **clean-process gate** prevents a prior design's sticky reserved pool from poisoning the synth pool.
 - **Persisted file:** `telemetryDir()/model-vram-stats.jsonl` = `<WORKSPACE_ROOT>/.telemetry/model-vram-stats.jsonl`.
-- **TEST ISOLATION (MANDATORY for every new/edited test that touches the telemetry file):** the telemetry modules resolve `WORKSPACE_ROOT` once at module-eval from `process.env.WORKSPACE_DIR`. Vitest runs files in parallel forks, so every such test MUST set a unique workspace BEFORE importing the module, following the repo's existing pattern (`server/src/routes/cover/store.test.ts`):
+- **TEST ISOLATION (MANDATORY for every new/edited test that touches the telemetry file):** the telemetry modules resolve `WORKSPACE_ROOT` once at module-eval from `process.env.WORKSPACE_DIR` (confirmed: `server/src/workspace/paths.ts:28` reads `process.env.WORKSPACE_DIR`; `WORKSPACE_ROOT` is the derived const, not the env var). Vitest runs files in parallel forks, so every such test MUST set a unique workspace BEFORE importing the module. This is the plan's mandated shape (several server tests set `WORKSPACE_DIR` similarly, e.g. `server/src/cover/store.test.ts`, `server/src/routes/book-state.test.ts` — though they use a `resetModules`+`doMock` variant; use the `beforeAll`-import variant below verbatim):
 
   ```typescript
   import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
@@ -34,6 +34,8 @@
   ```
 
   Reference all module functions through the dynamically-imported binding (`stats.recordVramSample(...)`), not a static top-of-file import. `beforeEach` still `rm`s the file for within-file isolation.
+
+- **SAMPLING ENV GATE (the seam that keeps existing fetch-count tests green):** both wired sample sites (analyzer `chat()` and the TTS `maybeSampleSidecarEngine`) issue an extra `fetch` (`/api/ps` resp. `/health`) through `global.fetch`. Existing suites stub `global.fetch` and assert EXACT call counts/indices, so the extra call would break them. The fix is a single **call-time** env gate, read on every invocation (NOT at module-eval — so it survives `vi.resetModules()`): sampling is ON unless `process.env.CASTWRIGHT_VRAM_SAMPLE === '0'`. Production never sets it (default ON). Every existing fetch-count suite we touch adds `beforeAll(() => { process.env.CASTWRIGHT_VRAM_SAMPLE = '0'; }); afterAll(() => { delete process.env.CASTWRIGHT_VRAM_SAMPLE; });`. The new wiring tests set it to `'1'` so sampling fires. This replaces any per-mock surgery.
 
 - **Commit convention:** `<type>(<scope>): <subject>` — scopes `server` / `sidecar`.
 
@@ -88,9 +90,9 @@ git show feat/server-dynamic-analyzer-models:server/src/analyzer/model-vram-stat
 git show feat/server-dynamic-analyzer-models:server/src/analyzer/model-vram-stats.test.ts > server/src/analyzer/model-vram-stats.test.ts
 ```
 
-- [ ] **Step 2: Make the PORTED test isolated, then run — expect PASS**
+- [ ] **Step 2: Make the file-writing tests isolated, then run — expect PASS**
 
-The ported `sampleAndRecordVram` suite writes the real telemetry file. Convert it to the isolation pattern (Global Constraints): add the `beforeAll` tmpdir + dynamic import, reference `stats.*`, and add `beforeEach(async () => { await rm(stats.vramStatsFilePath(), { force: true }); })`.
+Only the `sampleAndRecordVram` describe block writes the real telemetry file (via `recordVramSample`); the `model-vram-stats helpers` describe (`canonicalVramKey`, `foldEma`, `_emaFromRecords`) is pure in-memory — leave it alone. Convert just the `sampleAndRecordVram` describe (and the new per-key-trim describe in Step 3) to the isolation pattern (Global Constraints): add the `beforeAll` tmpdir + dynamic import, reference `stats.*`, and add `beforeEach(async () => { await rm(stats.vramStatsFilePath(), { force: true }); })`. The ported test imports `sampleAndRecordVram`/`emaForModelSync`/`_resetVramCacheForTests` through the `stats` binding now.
 
 Run: `npm run test:server -- model-vram-stats`
 Expected: PASS.
@@ -305,7 +307,7 @@ import { rotateStatsIfDeviceChanged } from './gpu/telemetry-fingerprint.js';
 import { initVramStats } from './analyzer/model-vram-stats.js';
 ```
 
-- [ ] **Step 2: Add the boot block** (after `resetOrphanedQueueEntries()`, before `app.listen`)
+- [ ] **Step 2: Add the boot block** (immediately after the `await resetOrphanedQueueEntries()…` statement and its trailing `.catch(...)` ~line 431 — a genuine ESM top-level `await`. Do NOT chase `app.listen`; there's an unrelated upgrade-coordinator block between them.)
 
 ```typescript
 // VRAM telemetry substrate (fs-45 v1, record-only — nothing consumes this yet).
@@ -328,17 +330,19 @@ git commit -m "feat(server): wire VRAM telemetry boot init (probe, rotate, prime
 
 ---
 
-### Task 5: Wire the analyzer sampler (record-only) — Unit A, with the existing-suite fix
+### Task 5: Wire the analyzer sampler (record-only) — Unit A, env-gated
 
-The sample call adds a `/api/ps` fetch on the chat path. `ollama.test.ts` mocks `global.fetch` and asserts exact fetch counts/indices — so the naive insertion BREAKS it. Fix: pass a dedicated `fetchFn` so the probe is distinguishable, and update the existing assertions to count only `/api/chat` calls.
+The sample call adds a `/api/ps` fetch on the chat path. `ollama.test.ts` stubs `global.fetch` and asserts EXACT call counts/indices (and uses `mockResolvedValueOnce` *queues* for the retry tests — an extra `/api/ps` GET would consume a queued chat response and crash). So instead of rewriting ~10 mocks, gate the sample behind the `CASTWRIGHT_VRAM_SAMPLE` env (Global Constraints): `ollama.test.ts` turns it OFF in one `beforeAll`, leaving every existing mock untouched. The new wiring test turns it ON.
 
-**Files:** Modify `server/src/analyzer/ollama.ts` (insert at the success `return buf`, ~line 643, **inside** the GPU-lock `try`); Modify `server/src/analyzer/ollama.test.ts` (fetch-count assertions); Create `server/src/analyzer/ollama-vram-sample.test.ts`.
+**Files:** Modify `server/src/analyzer/ollama.ts` (insert at the success `return buf`, ~line 643, **inside** the GPU-lock `try`); Modify `server/src/analyzer/ollama.test.ts` (one `beforeAll`/`afterAll` only); Create `server/src/analyzer/ollama-vram-sample.test.ts`.
 
-- [ ] **Step 1: Write the real wiring test** (isolation pattern; drives a mocked Ollama serving BOTH `/api/chat` and `/api/ps`)
+- [ ] **Step 1: Write the real wiring test** (drives the actual `OllamaAnalyzer.runStage1Chapter`, sampling ON)
+
+`chat()` is private, reached via `OllamaAnalyzer.runStage1Chapter(...)` (the entrypoint `ollama.test.ts` itself drives). Reuse that file's NDJSON helpers + valid-response constant so the stage call succeeds and reaches chat()'s `return buf`.
 
 ```typescript
-// ollama-vram-sample.test.ts — proves a successful chat records an analyzer sample.
-import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+// ollama-vram-sample.test.ts
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -348,36 +352,40 @@ let stats: typeof import('./model-vram-stats.js');
 let mod: typeof import('./ollama.js');
 beforeAll(async () => {
   process.env.WORKSPACE_DIR = mkdtempSync(join(tmpdir(), 'vram-ollama-'));
+  process.env.CASTWRIGHT_VRAM_SAMPLE = '1'; // sampling ON for this file
   stats = await import('./model-vram-stats.js');
   mod = await import('./ollama.js');
 });
-
 beforeEach(async () => { await rm(stats.vramStatsFilePath(), { force: true }); });
+afterEach(() => { vi.restoreAllMocks(); });
+
+// Build an Ollama-style NDJSON /api/chat response. COPY `VALID_RESPONSE`
+// (a schema-valid stage1 JSON string) + the `ndjsonStream`/`okResponse` helpers
+// from ollama.test.ts:41-126 — do not invent the schema.
+function chatResponse() {
+  return okResponse(ndjsonStream(chunksOf(VALID_RESPONSE, 32)));
+}
 
 it('records an analyzer VRAM sample after a successful chat', async () => {
   const fetchMock = vi.fn(async (url: string) => {
     if (url.endsWith('/api/ps')) {
-      return { ok: true, json: async () => ({ models: [{ name: 'm:latest', size: 4e9, size_vram: 4e9 }] }) } as any;
+      return { ok: true, json: async () => ({ models: [{ name: 'qwen3.5:9b', size: 6e9, size_vram: 6e9 }] }) } as any;
     }
-    // /api/chat — minimal NDJSON success the analyzer accepts
-    return { ok: true, body: ndjson([{ message: { content: '{}' }, done: true }]) } as any;
+    return chatResponse(); // /api/chat
   });
   vi.stubGlobal('fetch', fetchMock);
-  // Drive the smallest real entrypoint that runs chat() — adapt to the actual export
-  // (e.g. an OllamaAnalyzer instance's stage call). Assert a row landed:
-  await runOneChatViaPublicApi(mod); // see note below
+  const analyzer = new mod.OllamaAnalyzer({ url: 'http://localhost:11434', model: 'qwen3.5:9b' });
+  await analyzer.runStage1Chapter('m_id', 1, '# stage1 prompt', {});
   const recs = await stats.readAllVramRecords();
-  expect(recs.some((r) => r.key === 'm:latest@32768')).toBe(true);
+  expect(recs.some((r) => r.key === 'qwen3.5:9b@32768')).toBe(true);
 });
 ```
-
-NOTE: `runOneChatViaPublicApi` is a stand-in — wire it to whatever public method on the analyzer reaches `chat()` once (the same one `ollama.test.ts` already drives). `ndjson` is a tiny helper returning a `ReadableStream` of newline JSON (copy the shape `ollama.test.ts` already uses for `/api/chat`). If a full chat drive is too heavy, assert instead that `chat()` resolves AND a `/api/ps` call was made (`fetchMock.mock.calls.some(c => String(c[0]).endsWith('/api/ps'))`) — the row-landing assertion is preferred.
 
 - [ ] **Step 2: Run — expect FAIL** (no sample recorded yet)
 
 Run: `npm run test:server -- ollama-vram-sample`
 
-- [ ] **Step 3: Insert the record-only call in `chat()`**
+- [ ] **Step 3: Insert the gated record-only call in `chat()`**
 
 Add the import at the top of `ollama.ts`:
 
@@ -385,31 +393,32 @@ Add the import at the top of `ollama.ts`:
 import { sampleAndRecordVram } from './model-vram-stats.js';
 ```
 
-At the success `return buf` (~line 643, inside the `try` that still holds the GPU lock — so the model is provably resident), record first:
+At the success `return buf` (~line 643 — grep the unique `return buf;` inside `chat()`; it is inside the `try` that still holds the GPU lock, so the model is provably resident), record first, gated:
 
 ```typescript
     // fs-45 v1: record this model's real GPU footprint while provably resident.
-    // Best-effort (sampleAndRecordVram swallows all errors) — cannot throw here.
-    await sampleAndRecordVram(this.url, this.model, resolveAnalyzerNumCtx());
+    // Env-gated (Global Constraints) so fetch-count tests can opt out; best-effort.
+    if (process.env.CASTWRIGHT_VRAM_SAMPLE !== '0') {
+      await sampleAndRecordVram(this.url, this.model, resolveAnalyzerNumCtx());
+    }
     return buf;
 ```
 
-- [ ] **Step 4: Fix the existing `ollama.test.ts` fetch-count assertions**
+- [ ] **Step 4: Turn sampling OFF in the existing `ollama.test.ts`**
 
-The new `/api/ps` call inflates `global.fetch` counts. In `ollama.test.ts`, replace each `expect(fetchMock).toHaveBeenCalledTimes(N)` that counted chats with a chat-only count, and make index-based body reads select chat calls:
+Add (top of the outer `describe`, or file scope), so every existing mock/count assertion is untouched:
 
 ```typescript
-const chatCalls = fetchMock.mock.calls.filter((c) => String(c[0]).endsWith('/api/chat'));
-expect(chatCalls).toHaveLength(1); // was toHaveBeenCalledTimes(1)
-// body reads: use chatCalls[i][1] instead of fetchMock.mock.calls[i][1]
+beforeAll(() => { process.env.CASTWRIGHT_VRAM_SAMPLE = '0'; });
+afterAll(() => { delete process.env.CASTWRIGHT_VRAM_SAMPLE; });
 ```
 
-Apply to every count/index assertion the audit flagged (the single-chat `toHaveBeenCalledTimes(1)` and the retry-path `toHaveBeenCalledTimes(2)` cases, plus the `mock.calls[1]` body reads). Also stub `/api/ps` in those tests' `fetchMock` so it returns `{ ok: false }` (the sampler then no-ops) — keeps them focused on chat behavior.
+(No other edit to `ollama.test.ts` — the env gate makes the `/api/ps` call never fire there.)
 
 - [ ] **Step 5: Run the analyzer suites — expect PASS, keep-alive unchanged**
 
 Run: `npm run test:server -- ollama`
-Expected: PASS — `ollama-vram-sample`, the fixed `ollama.test.ts`, and any `keepAliveFor` test all green. If `keepAliveFor` behavior changed, revert — v1 must not touch it.
+Expected: PASS — `ollama-vram-sample` (sampling on, records), the untouched `ollama.test.ts` (sampling off), and any `keepAliveFor` test all green. If `keepAliveFor` behavior changed, revert — v1 must not touch it.
 
 - [ ] **Step 6: Commit**
 
@@ -424,27 +433,30 @@ git commit -m "feat(server): record analyzer VRAM footprint on each chat (record
 
 The OOM-safe gate for `qwen:synth`/`coqui`: a process that has loaded VoiceDesign carries a sticky-high reserved pool forever, so its reserved reading is design-contaminated. Expose a one-way "design ever loaded this process" flag so the server only samples synth/coqui from clean processes.
 
-**Files:** Modify `server/tts-sidecar/main.py` (`QwenEngine._ensure_design_loaded` ~line 1288 + the `/health` dict ~line 2862); Modify `server/tts-sidecar/tests/test_memory.py`.
+**Files:** Modify `server/tts-sidecar/main.py` (module-level flag near the other Qwen design state ~line 1931; set inside `QwenEngine._ensure_design_loaded` ~line 1288; `/health` dict — insert after the `"qwen_loaded": qwen_loaded,` line ~2870); Modify `server/tts-sidecar/tests/test_memory.py`.
 
-- [ ] **Step 1: Write the failing pytest**
+> **Venv precondition:** these TDD steps need the sidecar venv at `server/tts-sidecar/.venv`. On a box without it, the test SKIPs (exit 0) and you cannot fail-first/pass locally — implement per this task and rely on Task 9's `verify` on a bootstrapped box (note it in the task's commit/PR). The commands below call the venv pytest directly because `npm run test:sidecar` does NOT forward a `-k` filter (`run-tests.ps1` ignores extra args).
 
-In `test_memory.py`, mirror the existing `vram_*` /health test:
+- [ ] **Step 1: Write the failing pytest** — mirror the existing `/health` VRAM test (`test_memory.py:759`, which constructs the client inline with `TestClient`; there is NO `client` fixture)
 
 ```python
-def test_health_exposes_qwen_design_ever_loaded(client):
-    body = client.get("/health").json()
-    assert "qwen_design_ever_loaded" in body
+def test_health_exposes_qwen_design_ever_loaded(monkeypatch):
+    monkeypatch.setitem(main.ENGINES, "qwen", main.QwenEngine())
+    with TestClient(main.app) as client:
+        body = client.get("/health").json()
     assert body["qwen_design_ever_loaded"] is False  # fresh process, no design yet
 ```
 
-- [ ] **Step 2: Run — expect FAIL**
+(Use the same `main` / `TestClient` imports the file already has at the top.)
 
-Run: `npm run test:sidecar -- -k qwen_design_ever_loaded`
-Expected: FAIL — key absent.
+- [ ] **Step 2: Run — expect FAIL** (`KeyError`/missing key)
+
+Run: `server/tts-sidecar/.venv/Scripts/python.exe -m pytest server/tts-sidecar/tests/test_memory.py -k qwen_design_ever_loaded -q`
+Expected: FAIL — `qwen_design_ever_loaded` absent. (If it instead prints a SKIP/venv banner, see the precondition above.)
 
 - [ ] **Step 3: Implement the module flag + /health field**
 
-Near the other module-level state in `main.py`, add:
+Add the module-level flag near the other Qwen design state (~line 1931, by `_design_idle_task`):
 
 ```python
 # fs-45 v1 — one-way, process-lifetime flag. Set the first time VoiceDesign is
@@ -453,14 +465,14 @@ Near the other module-level state in `main.py`, add:
 _QWEN_DESIGN_EVER_LOADED = False
 ```
 
-In `QwenEngine._ensure_design_loaded`, after the VoiceDesign model is actually loaded (inside the `if self._design is None:` branch), set it:
+In `QwenEngine._ensure_design_loaded` (~line 1288), **inside** the `if self._design is None:` branch, right after the load (`self._design = self._load_qwen_model(...)` ~1295), set it:
 
 ```python
         global _QWEN_DESIGN_EVER_LOADED
         _QWEN_DESIGN_EVER_LOADED = True
 ```
 
-In the `/health` return dict, add:
+In the `/health` return dict, add the field right after `"qwen_loaded": qwen_loaded,`:
 
 ```python
         "qwen_design_ever_loaded": _QWEN_DESIGN_EVER_LOADED,
@@ -468,7 +480,7 @@ In the `/health` return dict, add:
 
 - [ ] **Step 4: Run — expect PASS**
 
-Run: `npm run test:sidecar -- -k qwen_design_ever_loaded`
+Run: `server/tts-sidecar/.venv/Scripts/python.exe -m pytest server/tts-sidecar/tests/test_memory.py -k qwen_design_ever_loaded -q`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
@@ -574,7 +586,20 @@ export async function sampleSidecarEngineVram(
   }
   await recordSidecarEngineVram(key, health.vramReservedMb);
 }
+
+/** One-liner for the wired call sites: env-gated (so fetch-count tests opt out
+    via CASTWRIGHT_VRAM_SAMPLE=0) + probes /health + applies the gate. The env
+    check is FIRST so a disabled sample issues no /health fetch at all. Best-effort. */
+export async function maybeSampleSidecarEngine(key: SidecarVramKey): Promise<void> {
+  if (process.env.CASTWRIGHT_VRAM_SAMPLE === '0') return;
+  try {
+    const { probeSidecarHealth } = await import('../routes/sidecar-health.js');
+    await sampleSidecarEngineVram(key, await probeSidecarHealth());
+  } catch { /* best-effort */ }
+}
 ```
+
+(Add a unit test asserting `maybeSampleSidecarEngine` is a no-op when `process.env.CASTWRIGHT_VRAM_SAMPLE === '0'` — set it in the test, assert no row + that `probeSidecarHealth` isn't reached by mocking it to throw.)
 
 - [ ] **Step 5: Run — expect PASS** (all cases). - [ ] **Step 6: Commit**
 
@@ -587,67 +612,107 @@ git commit -m "feat(server): TTS reserved-at-peak recorder with clean-process ga
 
 ### Task 8: Wire TTS sampling at design + engine-ready call sites
 
-**Files:** Modify `server/src/routes/qwen-voice.ts` (after the design fetch succeeds, before `return { voiceId, url }` ~line 373 — **inside** the `withGpuLoad` callback, where VoiceDesign is still resident); Modify `server/src/tts/ensure-sidecar-loaded.ts` (after `await withGpuLoad(...)` resolves ~line 130 — **outside** the lock; `engine` in scope); extend `server/src/tts/ensure-sidecar-loaded.test.ts` (already mocks `withGpuLoad`).
+**Files:** Modify `server/src/routes/qwen-voice.ts` (before `return { voiceId, url }` ~line 373 — **inside** the `withGpuLoad` callback, VoiceDesign still resident; `probeSidecarHealth` already imported via `./sidecar-health.js` at ~line 279); Modify `server/src/tts/ensure-sidecar-loaded.ts` (after `await withGpuLoad(...)` resolves ~line 130 — **outside** the lock; `engine` in scope); Modify `server/src/tts/ensure-sidecar-loaded.test.ts` + `server/src/routes/qwen-voice.test.ts` (turn sampling OFF) and add the wiring test.
 
-- [ ] **Step 1: Write the failing wiring test** (extend `ensure-sidecar-loaded.test.ts`, isolation pattern; the file already mocks `withGpuLoad`)
+- [ ] **Step 1: Wire both call sites with the one-liner**
+
+In `ensure-sidecar-loaded.ts`, after the `await withGpuLoad(...)` block resolves (engine loaded, lock released). Kokoro excluded — onnxruntime VRAM is torch-invisible (deferred to v2):
 
 ```typescript
-it('records a qwen:synth sample from a clean process after engine-ready', async () => {
-  vi.doMock('../routes/sidecar-health.js', () => ({
-    probeSidecarHealth: async () => ({ status: 'reachable', vramReservedMb: 1800, qwenLoaded: true, qwenDesignEverLoaded: false }),
-  }));
-  // drive ensureSidecarEngineReady('qwen', ...) with the existing fast-ready mock path,
+  // fs-45 v1: sample this engine's reserved footprint (env-gated + clean-process
+  // gate inside maybeSampleSidecarEngine). Best-effort, record-only.
+  if (engine === 'qwen' || engine === 'coqui') {
+    const { maybeSampleSidecarEngine } = await import('../gpu/sidecar-vram-sample.js');
+    await maybeSampleSidecarEngine(engine === 'qwen' ? 'qwen:synth' : 'coqui');
+  }
+```
+
+In `qwen-voice.ts`, inside the `withGpuLoad` callback, just before it returns `{ voiceId, url }`:
+
+```typescript
+        // fs-45 v1: record the design peak (Base + VoiceDesign resident here).
+        const { maybeSampleSidecarEngine } = await import('../gpu/sidecar-vram-sample.js');
+        await maybeSampleSidecarEngine('qwen:design');
+```
+
+- [ ] **Step 2: Turn sampling OFF in the existing fetch-count suites**
+
+Both `ensure-sidecar-loaded.test.ts` and `qwen-voice.test.ts` stub `global.fetch` and assert call counts — the new `/health` probe would inflate them. Add to each (file/outer-describe scope):
+
+```typescript
+beforeAll(() => { process.env.CASTWRIGHT_VRAM_SAMPLE = '0'; });
+afterAll(() => { delete process.env.CASTWRIGHT_VRAM_SAMPLE; });
+```
+
+(With `'0'`, `maybeSampleSidecarEngine` returns before any fetch — existing assertions are untouched.)
+
+- [ ] **Step 3: Run the touched suites — expect PASS** (sampling off, no behavior change)
+
+Run: `npm run test:server -- qwen-voice ensure-sidecar-loaded`
+Expected: PASS — existing assertions unaffected.
+
+- [ ] **Step 4: Write the failing wiring test** (new file `server/src/tts/ensure-sidecar-vram.test.ts` — own isolation + sampling ON; stub `global.fetch` to branch `/load` vs `/health`, so `probeSidecarHealth` runs for real, no `vi.doMock` fragility)
+
+```typescript
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+vi.mock('../workspace/user-settings.js', () => ({
+  getResolvedSidecarUrl: () => 'http://localhost:9000',
+  readConfigOverrides: () => ({}),
+}));
+vi.mock('../gpu/gpu-load.js', () => ({
+  withGpuLoad: async (fn: () => Promise<unknown>) => fn(),
+  GpuBusyError: class extends Error {},
+}));
+
+let stats: typeof import('../analyzer/model-vram-stats.js');
+let mod: typeof import('./ensure-sidecar-loaded.js');
+beforeAll(async () => {
+  process.env.WORKSPACE_DIR = mkdtempSync(join(tmpdir(), 'vram-ensure-'));
+  process.env.CASTWRIGHT_VRAM_SAMPLE = '1';
+  stats = await import('../analyzer/model-vram-stats.js');
+  mod = await import('./ensure-sidecar-loaded.js');
+});
+beforeEach(async () => { await rm(stats.vramStatsFilePath(), { force: true }); });
+const realFetch = global.fetch;
+afterEach(() => { global.fetch = realFetch; vi.restoreAllMocks(); });
+
+it('records qwen:synth from a clean process after engine-ready', async () => {
+  global.fetch = vi.fn(async (url: string) => {
+    if (url.endsWith('/health')) {
+      return { ok: true, json: async () => ({ vram_reserved_mb: 1800, qwen_loaded: true, qwen_design_ever_loaded: false, engines: ['qwen'] }) } as any;
+    }
+    return { ok: true, json: async () => ({ status: 'ready' }) } as any; // /load
+  }) as unknown as typeof fetch;
+  await mod.ensureSidecarEngineReady('qwen', undefined, { timeoutMs: 40, pollIntervalMs: 5 });
   const recs = await stats.readAllVramRecords();
   expect(recs.some((r) => r.key === 'qwen:synth' && r.vramMb === 1800)).toBe(true);
 });
 ```
 
-(Adapt to the file's existing mock harness for `tryLoadOnce`/`withGpuLoad` so the load resolves "ready" fast.)
+(`probeSidecarHealth` reads `body.vram_reserved_mb` / `qwen_loaded` / `qwen_design_ever_loaded` — the snake_case keys this `/health` mock returns.)
 
-- [ ] **Step 2: Run — expect FAIL**
+- [ ] **Step 5: Run — expect FAIL** then, after Step 1's wiring is in place, PASS
 
-Run: `npm run test:server -- ensure-sidecar-loaded`
+Run: `npm run test:server -- ensure-sidecar-vram`
+Expected: with Step 1 wired, PASS — a `qwen:synth` row at 1800. (Write this test, watch it FAIL if you stub the wiring out, then confirm PASS with the real wiring.)
 
-- [ ] **Step 3: Wire the engine-ready site (`qwen:synth` / `coqui`)**
-
-In `ensure-sidecar-loaded.ts`, after the `await withGpuLoad(...)` block resolves (engine loaded, lock released):
-
-```typescript
-  // fs-45 v1: sample this engine's reserved footprint (clean-process gate inside
-  // sampleSidecarEngineVram). Kokoro excluded — onnxruntime VRAM is torch-invisible
-  // (deferred to v2). Best-effort, record-only.
-  if (engine === 'qwen' || engine === 'coqui') {
-    try {
-      const { probeSidecarHealth } = await import('../routes/sidecar-health.js');
-      const { sampleSidecarEngineVram } = await import('../gpu/sidecar-vram-sample.js');
-      await sampleSidecarEngineVram(engine === 'qwen' ? 'qwen:synth' : 'coqui', await probeSidecarHealth());
-    } catch { /* best-effort */ }
-  }
-```
-
-- [ ] **Step 4: Wire the design site (`qwen:design`)**
-
-In `qwen-voice.ts`, inside the `withGpuLoad` callback, just before it returns `{ voiceId, url }` (VoiceDesign still resident → reserved reflects the Base+VoiceDesign peak):
-
-```typescript
-        // fs-45 v1: record the design peak (Base + VoiceDesign resident here).
-        try {
-          const { probeSidecarHealth } = await import('./sidecar-health.js');
-          const { sampleSidecarEngineVram } = await import('../gpu/sidecar-vram-sample.js');
-          await sampleSidecarEngineVram('qwen:design', await probeSidecarHealth());
-        } catch { /* best-effort */ }
-```
-
-- [ ] **Step 5: Typecheck + the touched suites**
+- [ ] **Step 6: Typecheck + all touched suites**
 
 Run: `npm run typecheck` → PASS.
-Run: `npm run test:server -- qwen-voice ensure-sidecar-loaded sidecar-vram-sample`
-Expected: PASS — existing tests stay green (additions are guarded; `probeSidecarHealth` is mocked where present), new wiring test passes.
+Run: `npm run test:server -- qwen-voice ensure-sidecar sidecar-vram-sample`
+Expected: PASS — existing suites (sampling off) + the new wiring test (sampling on).
 
 - [ ] **Step 6: Commit**
 
 ```bash
-git add server/src/routes/qwen-voice.ts server/src/tts/ensure-sidecar-loaded.ts server/src/tts/ensure-sidecar-loaded.test.ts
+git add server/src/routes/qwen-voice.ts server/src/routes/qwen-voice.test.ts \
+        server/src/tts/ensure-sidecar-loaded.ts server/src/tts/ensure-sidecar-loaded.test.ts \
+        server/src/tts/ensure-sidecar-vram.test.ts
 git commit -m "feat(server): sample TTS engine VRAM at design + engine-ready (gated)"
 ```
 
@@ -664,12 +729,12 @@ git commit -m "feat(server): sample TTS engine VRAM at design + engine-ready (ga
   - **v2 trigger:** start the MB engine only once telemetry from a real 12/16 GB card shows the MB decision flips ≥1 real eviction vs the `gpu.safeCoexistMb` threshold.
   - **Manual acceptance:** GPU box — run analysis + a voice design + a generation; confirm `<WORKSPACE_ROOT>/.telemetry/model-vram-stats.jsonl` gains `…@<numCtx>`, `qwen:design`, and (on a fresh/recycled process) `qwen:synth`/`coqui` rows; design-then-generate in the SAME process records NO `qwen:synth` (gate). Spoof the device total → `.stale` rotation. Links #845.
 
-- [ ] **Step 2: Add the INDEX entry** under the appropriate area in `docs/features/INDEX.md`.
+- [ ] **Step 2: Add the INDEX entry** under the `## Plans by area` heading in `docs/features/INDEX.md`, near the 221/222 entries (same area). Re-confirm 223 is unused first.
 
 - [ ] **Step 3: Full battery**
 
 Run: `LOW_CONCURRENCY=1 npm run verify`
-Expected: PASS — typecheck + all tests (incl. `test:sidecar`) + e2e + build.
+Expected: PASS — typecheck + all tests + e2e + build. NOTE: on a box without the sidecar venv, `test:sidecar` SKIPs (exit 0) — so Task 6's `qwen_design_ever_loaded` test is NOT actually exercised here. If you're on such a box, say so explicitly in the PR ("sidecar leg skipped — venv absent; pytest verified on a bootstrapped box / CI") rather than claiming sidecar coverage.
 
 - [ ] **Step 4: Commit, push, PR**
 
@@ -699,4 +764,5 @@ BODY
 - **Review fixes folded:** synth-pool poisoning (B-BLOCKER-1) → clean-process gate (Tasks 6–8); test isolation race (A-BLOCKER-2) → mandatory `WORKSPACE_DIR` tmpdir + dynamic-import pattern in Global Constraints, applied to every telemetry test; `ollama.test.ts` fetch-count breakage (A-BLOCKER-1) → Task 5 Step 4; dead-wiring gap (MAJOR 3) → real wiring tests in Tasks 5 & 8; insertion lines pinned (`:643` inside lock; `:373` design inside lock; `:130` engine-ready outside lock).
 - **BLOCKER-2 (load-time vs peak) accepted with rationale:** in a clean process, reserved is sticky, so chapters 2+ sample the true synth peak; the rare chapter-1 load-time-floor sample sits below v2's p95 and is discarded. Documented in the regression plan.
 - **Type consistency:** `'qwen:synth'|'qwen:design'|'coqui'` union shared across Tasks 7/8; `readAllVramRecords`/`VramSampleRecord`/`vramStatsFilePath` shared Tasks 2/3/5/7; health fields `vramReservedMb`/`qwenLoaded`/`qwenDesignEverLoaded` (camelCase) verified against `sidecar-health.ts`.
-- **No new placeholders** except the deliberately-flagged `runOneChatViaPublicApi`/`ndjson` test stand-ins (Task 5 Step 1), which point at the existing `ollama.test.ts` harness to copy.
+- **Delivery-review fixes folded:** the fetch-count breakage in BOTH `ollama.test.ts` (Task 5) and `ensure-sidecar-loaded.test.ts`/`qwen-voice.test.ts` (Task 8) is solved by the single call-time `CASTWRIGHT_VRAM_SAMPLE` env gate — existing suites set `'0'` (no extra fetch, no mock surgery), wiring tests set `'1'`. Task 5's driver is the real `OllamaAnalyzer.runStage1Chapter` reusing `ollama.test.ts`'s `ndjsonStream`/`okResponse`/`VALID_RESPONSE`; Task 6's pytest uses inline `TestClient(main.app)` (no nonexistent `client` fixture) and a direct venv-pytest `-k` command (since `npm run test:sidecar` drops `-k`), with the no-venv SKIP caveat; Task 8's wiring test stubs `global.fetch` to branch `/load` vs `/health` (real `probeSidecarHealth`, no `vi.doMock`-on-dynamic-import fragility). Anchors pinned: `/health` insert after `"qwen_loaded"`; flag set inside `_ensure_design_loaded`'s `if self._design is None:`; boot block after `resetOrphanedQueueEntries().catch(...)`.
+- **No unresolved placeholders.** Task 5's wiring test names the exact helpers to copy from `ollama.test.ts:41-126`.

--- a/src/components/analysing/phase-model-swap.test.tsx
+++ b/src/components/analysing/phase-model-swap.test.tsx
@@ -9,6 +9,7 @@ import { uiSlice } from '../../store/ui-slice';
 import { PhaseModelSwap } from './phase-model-swap';
 
 const putUserSettingsMock = vi.fn();
+const getOllamaHealthMock = vi.fn();
 
 vi.mock('../../lib/api', async () => {
   const actual = await vi.importActual<typeof import('../../lib/api')>('../../lib/api');
@@ -25,12 +26,15 @@ vi.mock('../../lib/api', async () => {
           ...(patch as Record<string, unknown>),
         });
       },
+      getOllamaHealth: () => getOllamaHealthMock(),
     },
   };
 });
 
 beforeEach(() => {
   putUserSettingsMock.mockReset();
+  getOllamaHealthMock.mockReset();
+  getOllamaHealthMock.mockResolvedValue({ status: 'reachable', url: '', models: [], pullable: [] });
 });
 
 function mountStore(
@@ -159,11 +163,29 @@ describe('PhaseModelSwap', () => {
     });
   });
 
+  it('fetches live analyzer models when the picker is focused (lazy refresh on open)', async () => {
+    /* A healthy run never auto-probes Ollama (cloud-no-probe invariant), so the
+       slice can be stale. Opening the dropdown is an explicit user interaction —
+       it MUST refresh the live tag list so a just-pulled model is selectable. */
+    const store = mountStore({ analyzerPhase0Model: null, localAnalyzerModels: [] });
+    render(
+      <Provider store={store}>
+        <PhaseModelSwap phaseId={0} isActive={false} />
+      </Provider>,
+    );
+    const select = screen.getByTestId('phase-model-swap-0') as HTMLSelectElement;
+    expect(getOllamaHealthMock).not.toHaveBeenCalled();
+    fireEvent.focus(select);
+    await waitFor(() => {
+      expect(getOllamaHealthMock).toHaveBeenCalled();
+    });
+  });
+
   it('renders a pulled-but-uncurated live tag as an option in the Local optgroup (dynamic union, not the static const)', () => {
     /* Seed a live tag the curated catalog does NOT carry. The picker must
        build its groups from buildModelOptionGroups(buildLocalModelOptions(...))
        off the slice — proving the dynamic union, not the static const. */
-    const uncurated = 'gemma-4-E4B-it-GGUF:UD-Q4_K_XL';
+    const uncurated = 'gemma4-e4b-8gb:latest';
     const store = mountStore({
       analyzerPhase0Model: null,
       localAnalyzerModels: [{ name: uncurated }],

--- a/src/components/analysing/phase-model-swap.tsx
+++ b/src/components/analysing/phase-model-swap.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { MODEL_OPTIONS, buildLocalModelOptions, buildModelOptionGroups } from '../../lib/models';
 import { useAppDispatch, useAppSelector } from '../../store';
 import {
+  fetchAnalyzerModels,
   saveAccountSettings,
   selectAnalyzerPhase0Model,
   selectAnalyzerPhase1Model,
@@ -45,10 +46,12 @@ export function PhaseModelSwap({ phaseId, isActive }: PhaseModelSwapProps) {
   const [toast, setToast] = useState<string | null>(null);
 
   /* Dynamic curated ∪ live-Ollama-tag union so a pulled-but-uncurated tag is
-     selectable here. localAnalyzerModels is populated by fetchAnalyzerModels
-     dispatched from the analysing-view failure card / Model Manager — this
-     picker renders inside every phase card (cloud runs included), so it must
-     NOT itself probe Ollama (that would break the cloud-run no-probe invariant).
+     selectable here. localAnalyzerModels is seeded by fetchAnalyzerModels
+     (analysing-view failure card / Model Manager / upload) and refreshed lazily
+     when THIS picker is opened (onFocus below). The lazy refresh keeps a healthy
+     run from auto-probing Ollama — the probe fires only on an explicit user
+     interaction (opening the dropdown), so the cloud-run no-probe invariant
+     holds while a just-pulled model still becomes selectable without a reload.
      Empty (not yet fetched / offline) falls back to the curated catalog. */
   const localAnalyzerModels = useAppSelector((s) => s.account.localAnalyzerModels);
   const modelGroups = buildModelOptionGroups(buildLocalModelOptions(localAnalyzerModels));
@@ -99,6 +102,7 @@ export function PhaseModelSwap({ phaseId, isActive }: PhaseModelSwapProps) {
       <select
         value={rawValue ?? ''}
         onChange={(e) => onChange(e.target.value)}
+        onFocus={() => void dispatch(fetchAnalyzerModels())}
         data-testid={`phase-model-swap-${phaseId}`}
         title={`Swap the Phase ${phaseId} model. Applies from the next chapter; the in-flight chapter completes on the current model.`}
         className="px-2.5 py-1 rounded-full border border-ink/15 bg-white text-[11px] font-medium text-ink focus:outline-hidden focus:ring-2 focus:ring-magenta/30"

--- a/src/components/model-pull-status.test.tsx
+++ b/src/components/model-pull-status.test.tsx
@@ -144,7 +144,82 @@ describe('ModelPullStatus — pull flow', () => {
   });
 });
 
+describe('ModelPullStatus — curated ∪ installed union', () => {
+  it('renders installed-but-uncurated tags as read-only on-disk rows', () => {
+    render(
+      <ModelPullStatus
+        pullableModels={['qwen3.5:4b']}
+        health={{
+          status: 'reachable',
+          url: 'http://localhost:11434',
+          models: ['qwen3.5:4b', 'gemma4-e4b-8gb:latest'],
+          pullable: ['qwen3.5:4b', 'llama3.1:8b'],
+          expectedModel: 'qwen3.5:4b',
+        }}
+      />,
+    );
+    /* The uncurated installed tag shows as an on-disk "Installed" row with NO
+       Pull button (it's not pullable, it's already there). */
+    const extraRow = screen.getByTestId('model-row-gemma4-e4b-8gb:latest');
+    expect(extraRow).toHaveTextContent(/installed/i);
+    expect(screen.getByTestId('model-installed-gemma4-e4b-8gb:latest')).toBeInTheDocument();
+    expect(screen.queryByTestId('model-pull-gemma4-e4b-8gb:latest')).not.toBeInTheDocument();
+    /* Curated rows still come from the health envelope's pullable list. */
+    expect(screen.getByTestId('model-row-llama3.1:8b')).toHaveTextContent(/not pulled yet/i);
+  });
+
+  it('drives curated rows off health.pullable even when the redux prop is empty (self-healing)', () => {
+    render(
+      <ModelPullStatus
+        pullableModels={[]}
+        health={{
+          status: 'reachable',
+          url: 'http://localhost:11434',
+          models: ['qwen3.5:4b'],
+          pullable: ['qwen3.5:4b', 'llama3.1:8b'],
+          expectedModel: 'qwen3.5:4b',
+        }}
+      />,
+    );
+    /* An empty redux pullableModels must NOT blank the list — health.pullable
+       carries the curated set. */
+    expect(screen.getByTestId('model-row-qwen3.5:4b')).toHaveTextContent(/on disk/i);
+    expect(screen.getByTestId('model-row-llama3.1:8b')).toBeInTheDocument();
+  });
+});
+
 describe('ModelPullStatus — refresh', () => {
+  it('recovers an empty list when the refresh response carries pullable', async () => {
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === '/api/ollama/refresh' && init?.method === 'POST') {
+        return Promise.resolve(
+          jsonResponse({
+            status: 'reachable',
+            url: 'http://localhost:11434',
+            models: ['qwen3.5:4b'],
+            pullable: ['qwen3.5:4b', 'llama3.1:8b'],
+            expectedModel: 'qwen3.5:4b',
+          }),
+        );
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    /* Start fully empty: no redux prop, no pullable in the initial envelope. */
+    render(
+      <ModelPullStatus
+        pullableModels={[]}
+        health={{ status: 'reachable', url: 'http://localhost:11434', models: [], pullable: [] }}
+      />,
+    );
+    expect(screen.queryByTestId('model-row-qwen3.5:4b')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('model-pull-refresh'));
+    await waitFor(() => {
+      expect(screen.getByTestId('model-row-qwen3.5:4b')).toBeInTheDocument();
+      expect(screen.getByTestId('model-row-llama3.1:8b')).toBeInTheDocument();
+    });
+  });
+
+
   it('clicking "Refresh available models" POSTs /api/ollama/refresh and updates the rows', async () => {
     fetchMock.mockImplementation((url: string, init?: RequestInit) => {
       if (url === '/api/ollama/refresh' && init?.method === 'POST') {

--- a/src/components/model-pull-status.tsx
+++ b/src/components/model-pull-status.tsx
@@ -36,6 +36,10 @@ export interface OllamaHealthEnvelope {
   models?: string[];
   expectedModel?: string;
   modelPulled?: boolean;
+  /** Curated pull-allowlist, echoed by /api/ollama/health and /refresh. Driving
+      the rows off this (not just the redux prop) makes "Refresh available
+      models" self-healing — a refresh response repopulates an empty list. */
+  pullable?: string[];
   error?: string;
 }
 
@@ -135,9 +139,20 @@ export function ModelPullStatus({ health, pullableModels, onPulled }: ModelPullS
     }
   };
 
-  const presentTags = new Set<string>(localHealth?.models ?? []);
+  /* Curated pull-allowlist comes from the live health envelope when present (so
+     "Refresh available models" repopulates it without a reload), falling back to
+     the redux prop for callers that don't thread pullable through health. */
+  const curated = localHealth?.pullable ?? [...pullableModels];
+  const installedTags = localHealth?.models ?? [];
+  const presentTags = new Set<string>(installedTags);
   const expectedModel = localHealth?.expectedModel;
   const isReachable = localHealth?.status === 'reachable';
+  /* Installed-but-uncurated tags (e.g. a custom local Ollama model not in the
+     allowlist) are unioned in as read-only on-disk rows, so this list is a
+     complete picture of what the analyzer can run — mirroring the inventory. */
+  const coveredByCurated = (tag: string) =>
+    curated.some((m) => m === tag || isPrefixMatch(m, new Set([tag])));
+  const extraInstalled = installedTags.filter((t) => !coveredByCurated(t));
 
   return (
     <div data-testid="model-pull-status" className="space-y-4">
@@ -164,7 +179,7 @@ export function ModelPullStatus({ health, pullableModels, onPulled }: ModelPullS
       )}
 
       <ul className="divide-y divide-ink/5 rounded-xl border border-ink/10 overflow-hidden">
-        {pullableModels.map((model) => {
+        {curated.map((model) => {
           const present = presentTags.has(model) || isPrefixMatch(model, presentTags);
           const isDefault = model === expectedModel;
           const isActivePull =
@@ -201,6 +216,32 @@ export function ModelPullStatus({ health, pullableModels, onPulled }: ModelPullS
                   {present ? 'Pulled' : 'Pull'}
                 </button>
               )}
+            </li>
+          );
+        })}
+        {/* Installed tags outside the curated allowlist — read-only on-disk rows
+            so a custom local model (e.g. a renamed Gemma) still shows here. */}
+        {extraInstalled.map((model) => {
+          const isDefault = model === expectedModel;
+          return (
+            <li
+              key={model}
+              data-testid={`model-row-${model}`}
+              className="flex items-center gap-3 px-3 py-2 bg-white"
+            >
+              <span className="w-2 h-2 rounded-full bg-emerald-600" aria-hidden />
+              <div className="flex-1">
+                <p className="text-sm font-mono text-ink">{model}</p>
+                <p className="text-xs text-ink/55">
+                  On disk · installed{isDefault ? ' · configured default' : ''}
+                </p>
+              </div>
+              <span
+                data-testid={`model-installed-${model}`}
+                className="px-3 py-1.5 rounded-full border border-ink/10 bg-ink/5 text-xs text-ink/50"
+              >
+                Installed
+              </span>
             </li>
           );
         })}

--- a/src/lib/models.test.ts
+++ b/src/lib/models.test.ts
@@ -25,11 +25,12 @@ describe('buildLocalModelOptions', () => {
     expect(q?.label).toBe('Qwen3.5 4B (local)');
   });
   it('appends an uncurated live tag as a bare option', () => {
-    const opts = buildLocalModelOptions([{ name: 'gemma-4-E4B-it-GGUF:UD-Q4_K_XL' }], curated);
-    const g = opts.find((o) => o.id === 'gemma-4-E4B-it-GGUF:UD-Q4_K_XL');
+    /* A genuinely-uncurated tag (a custom local model not in MODEL_OPTIONS). */
+    const opts = buildLocalModelOptions([{ name: 'gemma4-e4b-8gb:latest' }], curated);
+    const g = opts.find((o) => o.id === 'gemma4-e4b-8gb:latest');
     expect(g).toEqual({
-      id: 'gemma-4-E4B-it-GGUF:UD-Q4_K_XL',
-      label: 'gemma-4-E4B-it-GGUF:UD-Q4_K_XL',
+      id: 'gemma4-e4b-8gb:latest',
+      label: 'gemma4-e4b-8gb:latest',
       engine: 'local',
     });
   });

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -36,6 +36,12 @@ export const MODEL_OPTIONS: ModelOption[] = [
     hint: '~5 GB VRAM, stays resident across the analysis loop; stronger than the 4B on dialogue-dense edge cases',
     engine: 'local',
   },
+  {
+    id: 'gemma-4-E4B-it-GGUF:UD-Q4_K_XL',
+    label: 'Gemma 4 E4B (local)',
+    hint: '~6 GB VRAM (UD-Q4 quant), strong on multilingual (incl. Russian) dialogue attribution',
+    engine: 'local',
+  },
   /* --- Gemini API (direct or fallback) — sorted by free-tier headroom,
         most-comfortable first. Hints carry the live RPM/TPM/RPD limits
         pulled from aistudio.google.com/app/rate-limit on 2026-05-16 so

--- a/src/views/model-manager.test.tsx
+++ b/src/views/model-manager.test.tsx
@@ -690,6 +690,69 @@ describe('ModelManagerView — health honesty + repair + tier grouping', () => {
     expect(within(board).getByText(/^Standard$/i)).toBeInTheDocument();
     expect(within(board).getByText(/optional add-ons/i)).toBeInTheDocument();
   });
+
+  it('gives analyzer (Ollama) and ASR rows their own subheadings, not lumped under Optional add-ons', async () => {
+    mockInventory.mockResolvedValue({
+      ...INVENTORY,
+      items: [
+        {
+          id: 'coqui',
+          kind: 'tts',
+          label: 'Coqui XTTS v2',
+          present: true,
+          sizeBytes: 1_800_000_000,
+          diskPath: 'voices/coqui',
+          loaded: false,
+          installState: 'ready',
+          tier: 'secondary',
+          isDefaultEngine: false,
+          isFallbackEngine: false,
+          removable: true,
+          updatable: true,
+        },
+        {
+          id: 'whisper',
+          kind: 'asr',
+          label: 'Whisper ASR (faster-whisper)',
+          present: true,
+          sizeBytes: 141_000_000,
+          diskPath: 'models/whisper',
+          loaded: false,
+          installState: 'ready',
+          isDefaultEngine: false,
+          isFallbackEngine: false,
+          removable: true,
+          updatable: true,
+        },
+        {
+          id: 'ollama:gemma4-e4b-8gb:latest',
+          kind: 'analyzer',
+          label: 'gemma4-e4b-8gb:latest',
+          present: true,
+          sizeBytes: 5_700_000_000,
+          diskPath: null,
+          loaded: false,
+          isDefaultEngine: false,
+          isFallbackEngine: false,
+          removable: true,
+          updatable: true,
+        },
+      ],
+    });
+    renderManager();
+    const board = await screen.findByTestId('model-inventory');
+    /* Analyzer (Ollama) rows live under their OWN heading. */
+    const analyzerHeading = within(board).getByText(/analyzer models/i);
+    expect(analyzerHeading).toBeInTheDocument();
+    /* ASR rows get their own heading too. */
+    expect(within(board).getByText(/speech recognition/i)).toBeInTheDocument();
+    /* The Ollama row sits under the Analyzer heading, NOT the Optional add-ons
+       (Coqui) group — assert it's the analyzer group that contains the row. */
+    const analyzerGroup = analyzerHeading.closest('div');
+    expect(
+      within(analyzerGroup as HTMLElement).getByTestId('model-row-ollama:gemma4-e4b-8gb:latest'),
+    ).toBeInTheDocument();
+  });
 });
 
 describe('ModelManagerView — settings form accordion shell', () => {

--- a/src/views/model-manager.tsx
+++ b/src/views/model-manager.tsx
@@ -150,14 +150,16 @@ function ModelInventory() {
         </p>
       )}
 
-      {/* TTS rows grouped under Standard / Optional add-ons subheadings.
-          ASR (Whisper) and analyzer (Ollama) rows keep their own flat list below. */}
+      {/* TTS rows grouped under Standard / Optional add-ons subheadings. ASR
+          (Whisper) and analyzer (Ollama) rows each get their OWN subheading so
+          local analyzer models aren't visually lumped under "Optional add-ons". */}
       {(() => {
         const ttsStandard = inv.items.filter((i) => i.kind === 'tts' && i.tier !== 'secondary');
         const ttsSecondary = inv.items.filter((i) => i.kind === 'tts' && i.tier === 'secondary');
         /* ttsStandard already includes tier===undefined items (undefined !== 'secondary'). */
         const standardRows = ttsStandard;
-        const otherRows = inv.items.filter((i) => i.kind !== 'tts');
+        const asrRows = inv.items.filter((i) => i.kind === 'asr');
+        const analyzerRows = inv.items.filter((i) => i.kind === 'analyzer');
 
         const rowProps = (item: ModelInventoryItem) => ({
           item,
@@ -215,12 +217,29 @@ function ModelInventory() {
                 </ul>
               </div>
             )}
-            {otherRows.length > 0 && (
-              <ul className="space-y-3">
-                {otherRows.map((item) => (
-                  <ModelRow key={item.id} {...rowProps(item)} />
-                ))}
-              </ul>
+            {analyzerRows.length > 0 && (
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-wide text-ink/45 mb-2">
+                  Analyzer models (Ollama)
+                </p>
+                <ul className="space-y-3">
+                  {analyzerRows.map((item) => (
+                    <ModelRow key={item.id} {...rowProps(item)} />
+                  ))}
+                </ul>
+              </div>
+            )}
+            {asrRows.length > 0 && (
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-wide text-ink/45 mb-2">
+                  Speech recognition (ASR)
+                </p>
+                <ul className="space-y-3">
+                  {asrRows.map((item) => (
+                    <ModelRow key={item.id} {...rowProps(item)} />
+                  ))}
+                </ul>
+              </div>
             )}
           </div>
         );


### PR DESCRIPTION
## Summary

Three related analyzer-model display fixes (plan 221 follow-up), plus curating the Gemma E4B tag.

- **A — analysing-view picker didn't show a just-pulled model.** `PhaseModelSwap` read `account.localAnalyzerModels`, which the analysing view only refreshes on a *failed* run (deliberate cloud-no-probe invariant). It now refreshes the live tag list **on dropdown focus** — an explicit user interaction, so the invariant holds while a freshly-pulled model becomes selectable without a reload.
- **B — Ollama rows lumped under "Optional add-ons".** Inventory rows now group by kind under explicit subheadings: **Analyzer models (Ollama)** and **Speech recognition (ASR)**, instead of trailing the TTS "Optional add-ons" list.
- **C — "Analyzer models" pull list rendered empty.** Rows now derive from the live `/api/ollama/health` `pullable` (falling back to the redux prop), so **"Refresh available models" is self-healing** — an empty `pullableModels` can't get stuck. Installed-but-uncurated tags (e.g. a custom local `gemma4-e4b-8gb:latest`) are unioned in as read-only "Installed" on-disk rows, so the list is a complete picture of what the analyzer can run.
- **+** `gemma-4-E4B-it-GGUF:UD-Q4_K_XL` is now a curated `MODEL_OPTIONS` local entry ("Gemma 4 E4B (local)"), matching its server pull-allowlist membership.

Root cause for C was confirmed against the live server: `/api/ollama/health` returns HTTP 200 with `pullable` fully populated, so the server is correct — the empty list was a transient fetch race with no UI recovery path. This fixes the recoverability gap.

## Test plan

- `src/lib/models.test.ts` — curated Gemma entry; uncurated-tag union example flipped to `gemma4-e4b-8gb:latest`.
- `src/components/analysing/phase-model-swap.test.tsx` — on-`focus` `fetchAnalyzerModels` refresh; dynamic union still renders an uncurated tag in the Local optgroup.
- `src/views/model-manager.test.tsx` — analyzer/ASR rows render under their own subheadings, not under Optional add-ons.
- `src/components/model-pull-status.test.tsx` — curated ∪ installed union (read-only "Installed" row); curated rows drive off `health.pullable` even when the redux prop is empty; "Refresh" recovers an empty list from the refresh response.
- `npm run verify` green (typecheck + all tests + e2e + build).

Regression plan: `docs/features/221-dynamic-analyzer-models.md` (invariants 5–8 added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
