### PR TITLE
fix(server): sweep fs-45 v1 telemetry follow-ups

### DIFF
--- a/docs/features/223-vram-telemetry-substrate.md
+++ b/docs/features/223-vram-telemetry-substrate.md
@@ -44,6 +44,8 @@ owner: null
 
 Within a single process, switching between heavy engines (e.g. a Coqui synth then a Qwen synth) can leave a sticky-high reserved reading; the gate only excludes *design* contamination, not engine-switch contamination. Sidecar recycles reset it. v2's per-model sidecar accounting (if ever built) supersedes this. This is an acceptable over-estimate (OOM-safe direction) for a record-only substrate.
 
+A second, benign edge: a **pre-fs-45 sidecar** that omits the `qwen_design_ever_loaded` field is mapped to `false` in `probeSidecarHealth` (`qwen_design_ever_loaded === true` defaults absent → `false`), so a `qwen:synth`/`coqui` sample taken against an old sidecar that *had* loaded VoiceDesign would record a design-sized (over-estimate) row. Over-estimate is the OOM-safe direction, and old sidecars vanish after one restart — so this self-heals and never under-reports.
+
 ## v2 trigger (the deferred MB engine)
 
 Start the deferred MB-accounting engine (`costMb` p95+margin → `planLoad`/`splitFits` → MB-precise `withGpuLoad`, spec `docs/superpowers/specs/2026-06-17-vram-telemetry-mb-accounting-design.md`) **only once telemetry from a real 12/16 GB card shows the MB decision would flip ≥1 real eviction** vs the Wave-1 `gpu.safeCoexistMb` threshold (plan 222). The two-model-split warning + AMD/`rocm-smi` path were dropped from scope by adversarial review unless evidence resurfaces them.

--- a/server/src/analyzer/model-vram-stats.ts
+++ b/server/src/analyzer/model-vram-stats.ts
@@ -1,9 +1,12 @@
 /* Measured per-model VRAM store. Each analysis call samples the resident
    model's actual GPU footprint from Ollama /api/ps (size_vram) and appends a
-   JSONL line; keepAliveFor() reads back an EMA to decide whether the model is
-   small enough to stay resident. Append-only (mirrors resource-telemetry.ts)
-   because a read-modify-write JSON object loses concurrent updates. EMA is
-   computed at read time by folding the log in chronological (file) order. */
+   JSONL line. Append-only (mirrors resource-telemetry.ts) because a
+   read-modify-write JSON object loses concurrent updates.
+   fs-45 v1 is RECORD-ONLY: nothing reads this store for a decision (the
+   analyzer's keepAliveFor() uses the flat RESIDENT_MODELS logic, unchanged).
+   The EMA read below — computed at read time by folding the log in
+   chronological (file) order — is the DEFERRED v2 consumer: an adaptive
+   keepAliveFor() that would evict a model too big to stay resident. Dormant. */
 
 import { mkdir, readFile, writeFile, appendFile } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -91,15 +94,15 @@ export async function recordVramSample(rec: VramSampleRecord): Promise<void> {
   }
 }
 
-/** Async EMA read (used by tooling / tests that read the file). The hot
-    keepAliveFor() path uses a synchronous in-memory cache primed below
-    (added in Task 5). */
+/** Async EMA read (used by tooling / tests that read the file). The deferred-v2
+    keepAliveFor() path would use the synchronous in-memory cache primed below. */
 export async function emaForModelAsync(model: string, numCtx: number): Promise<number | null> {
   return _emaFromRecords(await readRecords(), canonicalVramKey(model, numCtx));
 }
 
-/* Synchronous EMA cache for keepAliveFor(). Keyed by canonicalVramKey. Updated
-   on every sample and primed from disk at boot. */
+/* Synchronous EMA cache for the deferred-v2 keepAliveFor(). Keyed by
+   canonicalVramKey. Updated on every sample and primed from disk at boot;
+   no v1 consumer reads it. */
 const emaCache = new Map<string, number>();
 
 export function emaForModelSync(model: string, numCtx: number): number | null {

--- a/server/src/gpu/device-total.ts
+++ b/server/src/gpu/device-total.ts
@@ -1,9 +1,10 @@
-/* Boot-time GPU total-VRAM probe. The analyzer keep-alive decision
-   (analyzer/ollama.ts keepAliveFor) needs the device total synchronously,
+/* Boot-time GPU total-VRAM probe. The DEFERRED v2 adaptive keep-alive decision
+   (analyzer/ollama.ts keepAliveFor) would need the device total synchronously,
    and the TTS sidecar — the other VRAM source — is typically DOWN during
    analysis (sequential phases). So we probe once at server start via
-   nvidia-smi and cache the result. Non-NVIDIA / no nvidia-smi → null, which
-   disables adaptive eviction (keep-alive falls back to the flat knob). */
+   nvidia-smi and cache the result. Non-NVIDIA / no nvidia-smi → null. In fs-45
+   v1 this is recorded but unconsumed (keepAliveFor uses the flat knob today);
+   it primes the v2 adaptive-eviction decision when that lands. */
 
 import { execFile } from 'node:child_process';
 

--- a/server/src/routes/qwen-voice.test.ts
+++ b/server/src/routes/qwen-voice.test.ts
@@ -71,6 +71,17 @@ vi.mock('../gpu/gpu-load.js', () => ({
   },
 }));
 
+/* fs-45 v1 — spy on the TTS VRAM sampler so we can assert the design call site
+   invokes it with 'qwen:design'. The whole function is replaced, so the call
+   fires regardless of the suite-wide CASTWRIGHT_VRAM_SAMPLE='0' env gate (which
+   lives inside the real function). */
+const { maybeSampleSidecarEngineMock } = vi.hoisted(() => ({
+  maybeSampleSidecarEngineMock: vi.fn(async (_key: string) => {}),
+}));
+vi.mock('../gpu/sidecar-vram-sample.js', () => ({
+  maybeSampleSidecarEngine: (key: string) => maybeSampleSidecarEngineMock(key),
+}));
+
 const characters = [
   { id: 'narrator', name: 'Narrator', role: 'narrator', color: 'narrator' },
   {
@@ -183,6 +194,7 @@ beforeEach(() => {
   fetchMock.mockResolvedValue(okSidecarResponse());
   synthesize.mockReset();
   synthesize.mockResolvedValue({ pcm: Buffer.alloc(24_000 * 2 * 0.3, 0), sampleRate: 24_000 });
+  maybeSampleSidecarEngineMock.mockClear();
   for (const f of readdirSync(audioDir)) rmSync(join(audioDir, f), { force: true });
   /* Wipe designed-voice sidecars between tests so the persona GET cases stay
      isolated (a sidecar written by one test must not leak into the next). */
@@ -199,6 +211,17 @@ afterAll(() => {
 });
 
 describe('POST /api/books/:bookId/cast/:characterId/design-voice', () => {
+  it('records a qwen:design VRAM sample at the design call site (fs-45 v1 wiring)', async () => {
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/maerin/design-voice`)
+      .send(designBody);
+
+    expect(res.status).toBe(200);
+    // The design site calls maybeSampleSidecarEngine('qwen:design') while
+    // VoiceDesign is still resident (inside the withGpuLoad callback, before return).
+    expect(maybeSampleSidecarEngineMock).toHaveBeenCalledWith('qwen:design');
+  });
+
   it('forwards persona + a calibrationText from the character line, caches the MP3, returns {voiceId,url}', async () => {
     const res = await request(app)
       .post(`/api/books/${bookId}/cast/maerin/design-voice`)


### PR DESCRIPTION
## Summary

Sweeps the three deferred Minors from the #861 whole-branch review (all non-blocking, now done):

1. **Comments** — `model-vram-stats.ts` / `device-total.ts` described `keepAliveFor` reading the EMA as if shipped. Reworded: that's the **deferred v2** consumer; fs-45 v1 is record-only and nothing reads the store for a decision (`keepAliveFor` still uses the flat `RESIDENT_MODELS` logic). Removes a comment that actively misled anyone verifying the record-only invariant.
2. **Doc** — plan 223 now notes the benign **old-sidecar edge**: a pre-fs-45 sidecar omitting `qwen_design_ever_loaded` maps to `false`, so a `qwen:synth`/`coqui` sample against it would record a design-sized (over-estimate, OOM-safe) row that self-heals after one restart.
3. **Test** — adds a `qwen:design` wiring test: the design route invokes `maybeSampleSidecarEngine('qwen:design')` (the synth site already had its round-trip test; the design site was unit-covered only).

## Test plan

- `npm run typecheck` ✓ · `npm run lint` ✓ (max-warnings 0)
- `npm run test:server -- qwen-voice` → 44/44 (the +1 design-wiring test; existing green under the new module spy)
- `model-vram-stats` + `device-total` → 11/11
- Full pre-push `npm run verify` green (lint, typecheck, all tests, e2e, e2e:visual, build).

Comment/doc-only changes plus one additive test — no behavior change.

Refs #845

🤖 Generated with [Claude Code](https://claude.com/claude-code)