### PR TITLE
docs(docs,ci): prep repo for public — SECURITY.md, CLA, checklist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,43 @@
+name: CLA Assistant
+
+# Collect a Contributor License Agreement signature on every pull request.
+# Lightweight and conditionally gated, so it stays compatible with the opt-in
+# CI posture (plan 215): it runs only the tiny CLA check, not the verify
+# battery. Internal contributors are allow-listed and auto-pass.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    name: Check / record CLA signature
+    runs-on: ubuntu-latest
+    # Tiny check; cap explicitly so a hung run can't bill the 360-min default.
+    timeout-minutes: 5
+    steps:
+      - name: CLA Assistant
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A PAT (repo scope) is required so the action can commit signatures
+          # to the cla-signatures branch. Add it as the CLA_SIGNATURES_TOKEN
+          # repository secret.
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}
+        with:
+          path-to-signatures: signatures/version1/cla.json
+          path-to-document: https://github.com/dudarenok-maker/Castwright/blob/main/docs/legal/CLA.md
+          branch: cla-signatures
+          custom-notsigned-prcomment: 'Thanks for your pull request. Before we can merge it, please sign our [Contributor License Agreement](https://github.com/dudarenok-maker/Castwright/blob/main/docs/legal/CLA.md).'
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-allsigned-prcomment: 'All contributors have signed the CLA. ✅'
+          # Maintainer + bots don't need to sign.
+          allowlist: dudarenok-maker,*[bot]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,17 +27,20 @@ the model in one paragraph. The Castwright name and brand assets are **not**
 covered by the code licence and are not part of this repository — see
 [`docs/legal/brand-and-trademarks.md`](docs/legal/brand-and-trademarks.md).
 
-**Posture today: issues welcome, PRs by invitation.** Until the CLA tooling is in
-place, please open an issue to discuss a change before sending a PR.
+**Posture today: issues welcome, PRs by invitation.** Please open an issue to
+discuss a change before sending a PR.
 
-**When external PRs open up,** two things will be required on every contribution:
+**Two things are required on every contribution:**
 
 - **DCO sign-off** — add `Signed-off-by: Your Name <you@example.com>` to each
   commit (`git commit -s`), certifying you wrote the change and may submit it
   under the project licence.
 - **A lightweight CLA** — so the maintainer retains the right to relicense (the
-  FSL future-grant and any relicensing depend on owning the copyright). This will
-  be collected by a CLA bot; see [`docs/legal/licensing.md`](docs/legal/licensing.md).
+  FSL future-grant and any relicensing depend on owning the copyright). The full
+  text is [`docs/legal/CLA.md`](docs/legal/CLA.md); the `CLA Assistant` GitHub
+  Action comments on each PR and records your one-time signature when you reply
+  `I have read the CLA Document and I hereby sign the CLA`. See
+  [`docs/legal/licensing.md`](docs/legal/licensing.md).
 
 ## Branching model
 
@@ -305,7 +308,7 @@ live. Regression plan: [docs/features/166-github-issues-backlog-integration.md](
 
 - **One backlog item ↔ one issue.** The issue title leads with the permanent
   `<prefix>-<n>` ID: `<prefix>-<n> — <one-line what>` (e.g. `srv-1 — Merge
-  journal for alias un-link`). The ID stays the durable cross-reference in
+journal for alias un-link`). The ID stays the durable cross-reference in
   code/commits/plans; the issue `#NN` is just the auto-close hook.
 - **The issue body is canonical** — What / Acceptance / Key files / Depends on /
   Benefit. `docs/BACKLOG.md` keeps a thin summary + the issue link for
@@ -334,7 +337,8 @@ Three axes + two helpers, version-controlled in `scripts/gh-labels.mjs` (run
 Substantial / cross-cutting issues still get a numbered `docs/features/NN-*.md`
 regression plan (label the issue `needs-plan`; the plan cites the issue, the
 issue links the plan). Small / localized issues skip the plan — the issue body
-+ a paired test is the spec, and the work goes straight issue → PR.
+
+- a paired test is the spec, and the work goes straight issue → PR.
 
 ### Linking from PRs
 
@@ -352,9 +356,10 @@ the durable reference, `#NN` is the GitHub hook.
 ### Server-side enforcement
 
 Issue templates + labels are a **soft convention** (the same posture as the
-commit/PR-title rules). On the Free plan there's no Actions budget to spend on
-label-lint or required-field enforcement beyond the forms themselves; the
-`blank_issues_enabled: false` config funnels every issue through a template.
+commit/PR-title rules). CI is opt-in (plan 215), so we deliberately don't spend
+Actions minutes on label-lint or required-field enforcement beyond the forms
+themselves; the `blank_issues_enabled: false` config funnels every issue through
+a template.
 
 ## Pull requests
 
@@ -481,7 +486,7 @@ A PR whose changed-file set lives entirely under `docs/**`, root-level
 The PR still requires a valid title (`pr-title-lint.yml` runs on every
 PR) and GitHub's native `mergeable` status still surfaces conflicts —
 the gate stays "PR required + title valid + no conflicts", just without
-the 10–15 min full battery. Since plan 215 CI is opt-in for *every* PR, this
+the 10–15 min full battery. Since plan 215 CI is opt-in for _every_ PR, this
 `paths-ignore` is now a second layer — it additionally ensures that even a
 `run-ci`-labeled PR whose files are all docs won't spin up the battery.
 Rationale and the exact glob list:
@@ -531,7 +536,8 @@ can't ship — without re-paying the matrix on every PR. `release.yml` then runs
 `verify:quick` on Ubuntu against the tagged commit and publishes the
 platform-independent zip + SHA-256 using the tag annotation as the body. Full spec:
 [`docs/features/archive/127-release-cross-os-gate.md`](docs/features/archive/127-release-cross-os-gate.md)
-+ [`docs/features/archive/49-release-package.md`](docs/features/archive/49-release-package.md).
+
+- [`docs/features/archive/49-release-package.md`](docs/features/archive/49-release-package.md).
 
 **Invariants the bumper enforces** — read these before you bypass it:
 
@@ -542,7 +548,7 @@ platform-independent zip + SHA-256 using the tag annotation as the body. Full sp
 - `package.json` and `server/package.json` versions MUST stay in lockstep
   (the bumper refuses to run if they've drifted).
 - Every `vX.Y.Z` tag is an annotated tag pointing at a `chore: bump version
-  to X.Y.Z` commit. Lightweight tags do NOT fire the workflow.
+to X.Y.Z` commit. Lightweight tags do NOT fire the workflow.
 - Release notes live in the tag annotation, not the GitHub Release UI. The
   workflow reads `git tag -l --format='%(contents)' vX.Y.Z` and uses that
   verbatim as the body.
@@ -611,7 +617,7 @@ a new emoji per release — consistency across the releases index is the point.
 
 The four old buckets (Features / Fixes / Retirements / Engineering) are no
 longer top-level sections — their content is distributed across the headline
-block and the themed sections — but the writing rules for each *kind* of line
+block and the themed sections — but the writing rules for each _kind_ of line
 still hold:
 
 - **Feature lines** (headline sub-bullets + most themed bullets). A functional
@@ -625,7 +631,7 @@ still hold:
   what the listener / deployer / operator saw and couldn't do — then close with
   the new behaviour (`Now legible`, `Now self-heals`, `Now stacks correctly`)
   and the plan / PR ref. Internal vocabulary (`bg-amber-50/60`,
-  `BookStateJson.description`) is fine *inside* the line to disambiguate the
+  `BookStateJson.description`) is fine _inside_ the line to disambiguate the
   surface, never as the leading words.
 - **Retirements.** Behaviour that **shipped in a previous release** and is now
   removed or downgraded — surface it loudly (the `⚠️ Upgrade note` blockquote,
@@ -672,7 +678,7 @@ still hold:
    note → `## ✨ Headline features` → themed sections → `**Full changelog:**`
    footer. Reference plan / PR numbers in parens throughout.
 6. **Draft in the GitHub Release UI first.** `gh release create vX.Y.Z --draft
-   --target main --notes-file <path>` (a draft is collaborator-only — nothing
+--target main --notes-file <path>` (a draft is collaborator-only — nothing
    public changes) so the user can review the rendered body. Iterate with
    `gh release edit vX.Y.Z --notes-file <path>`.
 7. Once approved, the same body becomes the annotated-tag message for the bump

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ the branching model, and the commit convention are documented in
 - **[`apps/android/README.md`](apps/android/README.md)** — the Android companion.
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** — building from source, branching, and
   the commit convention.
+- **[SECURITY.md](SECURITY.md)** — supported versions and how to report a
+  vulnerability privately.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,71 @@
+# Security Policy
+
+Castwright is a **local-first, single-user** application: by default the
+analyzer and the voice engine run on your own machine and nothing leaves it.
+The remote attack surface is therefore small and almost entirely **opt-in** —
+it appears only when you deliberately expose the app to your home network
+(`npm run start:lan`) or pair the Android companion. The
+[2026-05-31 security review](docs/security/2026-05-31-security-review.md)
+documents that surface and the hardening backlog.
+
+## Supported versions
+
+Security fixes land on `main` and ship in the next tagged release. Only the
+**latest published release** is supported — please reproduce on the newest
+version before reporting.
+
+| Version                 | Supported                                                      |
+| ----------------------- | -------------------------------------------------------------- |
+| Latest release (`main`) | ✅                                                             |
+| Older releases          | ❌ — upgrade first (in-app: **Account → Application updates**) |
+
+## Reporting a vulnerability
+
+**Please report privately — do not open a public issue for a security bug.**
+
+1. **Preferred:** use GitHub's private vulnerability reporting — the
+   **"Report a vulnerability"** button under this repository's **Security** tab
+   (Security → Advisories). This keeps the report confidential and threads the
+   fix through a private advisory.
+2. **Alternative:** email **hello@castwright.ai** with `SECURITY` in the
+   subject. PGP available on request.
+
+Please include: affected version, environment (OS, GPU, local vs. LAN/companion
+exposure), reproduction steps, and impact. A proof of concept helps but isn't
+required.
+
+### What to expect
+
+- **Acknowledgement** within 5 business days.
+- An initial assessment (severity + whether it's in scope) within 10 business
+  days.
+- We'll keep you updated through the fix and credit you in the advisory unless
+  you'd prefer to remain anonymous.
+
+This is a solo-maintained project — timelines are best-effort, not contractual.
+There is **no paid bug-bounty program**.
+
+## Scope
+
+In scope — issues that let an attacker who is **not** the local user do
+something they shouldn't:
+
+- Authentication / cert-pinning bypass on the LAN exposure surface
+  (`start:lan`) or the companion pairing flow.
+- Remote code execution, path traversal, or arbitrary file read/write reachable
+  over the network.
+- Code-execution from loading an **untrusted** shared voice artifact
+  (see `side-13` in [docs/BACKLOG.md](docs/BACKLOG.md)).
+- Secret leakage (API keys, tokens) from the running server.
+
+Out of scope (by design, not vulnerabilities):
+
+- The **opt-in** cloud analyzer (Gemini) sending your manuscript text to Google
+  — that is the documented trade-off of choosing a cloud analyzer; the local
+  Ollama analyzer keeps everything on-device.
+- Anything requiring local access to a single-user machine the attacker already
+  controls (the app trusts the local user by design).
+- Model output quality / mispronunciation (use the in-app issue forms).
+- Denial of service against your own local instance.
+
+Thank you for helping keep Castwright users safe.

--- a/docs/legal/CLA.md
+++ b/docs/legal/CLA.md
@@ -1,0 +1,99 @@
+# Castwright Contributor License Agreement
+
+Thank you for your interest in contributing to Castwright ("the Project"),
+maintained by Mikhail Dudarenok trading as Castwright ("the Maintainer", "we",
+"us").
+
+This Contributor License Agreement ("Agreement") clarifies the intellectual
+property rights granted with Contributions from any person or entity. It
+protects both you and the Project; it does **not** change your right to use your
+own Contributions for any other purpose.
+
+By signing this Agreement (see "How to sign" below), you accept and agree to the
+following terms for your present and future Contributions submitted to the
+Project.
+
+## 1. Definitions
+
+- **"You"** means the individual or legal entity making a Contribution. For a
+  legal entity, the entity and all entities that control, are controlled by, or
+  are under common control with it are considered a single Contributor.
+- **"Contribution"** means any original work of authorship, including any
+  modifications or additions to existing work, that you intentionally submit to
+  the Project for inclusion in or documentation of any of its products
+  (collectively "Work"). "Submit" means any form of electronic, verbal, or
+  written communication sent to the Project — for example a pull request, patch,
+  or comment — excluding communication you conspicuously mark "Not a
+  Contribution".
+
+## 2. Copyright license
+
+You grant to the Maintainer, and to recipients of software distributed by the
+Maintainer, a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare derivative works of,
+publicly display, publicly perform, sublicense, and distribute your
+Contributions and such derivative works. This includes the right for the
+Maintainer to license your Contribution under the Project's current license
+(the Functional Source License v1.1 with an Apache-2.0 future grant) and under
+any other license the Maintainer chooses for the Project.
+
+## 3. Patent license
+
+You grant to the Maintainer, and to recipients of software distributed by the
+Maintainer, a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by you that are
+necessarily infringed by your Contribution alone or by combination of your
+Contribution with the Work to which it was submitted. If any entity institutes
+patent litigation against you or any other entity alleging that your
+Contribution, or the Work to which you contributed, constitutes direct or
+contributory patent infringement, then any patent licenses granted to that
+entity under this Agreement for that Contribution or Work terminate.
+
+## 4. Your representations
+
+You represent that:
+
+1. each of your Contributions is your original creation, or you have the right
+   to submit it under the terms of this Agreement;
+2. you are legally entitled to grant the above licenses — and if your employer
+   has rights to intellectual property you create, you have received permission
+   to make Contributions on behalf of that employer, or your employer has waived
+   such rights;
+3. your Contribution does not, to your knowledge, violate any third party's
+   copyrights, trademarks, patents, or other intellectual property rights; and
+4. you will notify the Maintainer if you become aware of any facts or
+   circumstances that would make these representations inaccurate.
+
+## 5. No obligation; "as is"
+
+You are not expected to provide support for your Contributions except to the
+extent you wish to. Unless required by applicable law or agreed in writing, you
+provide your Contributions on an "AS IS" basis, without warranties or conditions
+of any kind, either express or implied.
+
+## 6. Retained rights
+
+Except for the licenses granted in this Agreement, you reserve all right, title,
+and interest in and to your Contributions. This Agreement does not transfer
+ownership of your Contributions.
+
+## How to sign
+
+We collect signatures automatically on each pull request via the CLA Assistant
+GitHub Action.
+
+1. Open your pull request as normal.
+2. The CLA bot will comment if you have not yet signed.
+3. Reply on the pull request with **exactly**:
+
+   > I have read the CLA Document and I hereby sign the CLA
+
+Your GitHub username and the signing timestamp are recorded in
+`signatures/version1/cla.json` on the `cla-signatures` branch. You sign once;
+the signature applies to all your future Contributions to the Project.
+
+Contributions are also expected to carry a Developer Certificate of Origin
+(`Signed-off-by:`) line — see
+[CONTRIBUTING.md](../../CONTRIBUTING.md) for the `git commit -s` convention.

--- a/docs/legal/licensing.md
+++ b/docs/legal/licensing.md
@@ -9,7 +9,7 @@ public. Companion to the local-only planning brief
 ## The model
 
 - **Code** — Functional Source License v1.1 with an Apache-2.0 future grant
-  (**FSL-1.1-ALv2**, a.k.a. FSL-1.1-Apache-2.0). Source-available, *not* OSI
+  (**FSL-1.1-ALv2**, a.k.a. FSL-1.1-Apache-2.0). Source-available, _not_ OSI
   open source: any use is permitted except a Competing Use, and each release's
   code converts to plain Apache-2.0 two years after it is made available. File:
   [`/LICENSE`](../../LICENSE).
@@ -29,13 +29,13 @@ Verified 8 June 2026 from the Hugging Face model cards. **Re-verify at the
 pinned release version before every public release** — a model card licence can
 change between snapshots.
 
-| Engine | Model(s) | Upstream licence | Bundled? | Verified |
-|---|---|---|---|---|
-| Kokoro v1 | hexgrad/Kokoro-82M (ONNX via thewh1teagle/kokoro-onnx) | Apache-2.0 | **Yes** — weights ship / install with the app | 8 Jun 2026 |
-| Qwen3-TTS Base | Qwen/Qwen3-TTS-12Hz-0.6B-Base | Apache-2.0 | No — download-on-demand | 8 Jun 2026 |
-| Qwen3-TTS VoiceDesign | Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign | Apache-2.0 | No — download-on-demand | 8 Jun 2026 |
-| Coqui XTTS v2 | coqui/XTTS-v2 | **CPML — non-commercial** | No — download-on-demand, licence shown at install | 8 Jun 2026 |
-| Whisper (QA, optional) | faster-whisper models | MIT | No — download-on-demand | known; re-confirm |
+| Engine                 | Model(s)                                               | Upstream licence          | Bundled?                                          | Verified          |
+| ---------------------- | ------------------------------------------------------ | ------------------------- | ------------------------------------------------- | ----------------- |
+| Kokoro v1              | hexgrad/Kokoro-82M (ONNX via thewh1teagle/kokoro-onnx) | Apache-2.0                | **Yes** — weights ship / install with the app     | 8 Jun 2026        |
+| Qwen3-TTS Base         | Qwen/Qwen3-TTS-12Hz-0.6B-Base                          | Apache-2.0                | No — download-on-demand                           | 8 Jun 2026        |
+| Qwen3-TTS VoiceDesign  | Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign                   | Apache-2.0                | No — download-on-demand                           | 8 Jun 2026        |
+| Coqui XTTS v2          | coqui/XTTS-v2                                          | **CPML — non-commercial** | No — download-on-demand, licence shown at install | 8 Jun 2026        |
+| Whisper (QA, optional) | faster-whisper models                                  | MIT                       | No — download-on-demand                           | known; re-confirm |
 
 Rule of thumb: the installer may fetch weights from their official home; the
 release archive bundles nothing whose licence is unverified.
@@ -50,26 +50,44 @@ release archive bundles nothing whose licence is unverified.
 - [x] README license statement (source-available, brand carve-out, model notice)
 - [x] CONTRIBUTING contribution-licensing terms (DCO / CLA / PRs-by-invitation)
 
-**Pending before flipping the repo public:**
+**Cleared for the public flip (2026-06-17):**
 
-- [ ] **Companion website (`castwright.ai`) live** — the stated gate for going
-      public; the public-flip and any "Cast Pass" messaging wait for it.
-- [ ] **Git history scrub — DESTRUCTIVE, force-push.** Audit history for
-      committed secrets and copyrighted fixtures, then rewrite if found:
-  - Audit: `git log --all --full-history -- '**/.env' 'server/.env'` and a
-    secret scan (e.g. `gitleaks detect`, `trufflehog`). Also check the canonical
-    copyrighted manuscript fixture never entered history:
-    `git log --all --full-history --oneline -- '**/*Marlow*'`.
-  - If anything is found: back up the repo, rewrite with
-    `git filter-repo --invert-paths --path <file>` (or BFG), force-push, and
-    have every clone re-clone. Do **not** run casually.
-- [ ] **cla-assistant bot** wired (GitHub App) so external PRs collect the CLA.
-- [ ] **Branch protection on `main`** (available once the repo is public / Pro):
-      require the PR-title check and a review. Also update the now-stale
-      `CONTRIBUTING.md` heading "Server-side enforcement (private repo on Free
-      plan)".
-- [ ] **`gh repo edit --visibility public`** and confirm the repo name is
-      `Castwright`.
+- [x] **Companion website (`castwright.ai`) live** — went live on Cloudflare
+      Pages 2026-06-17 (www served, apex 301-forward, canonical → www). The
+      stated gate for going public is met.
+- [x] **Git history scrub — audited clean, no rewrite needed.** Verified
+      2026-06-17 before the flip:
+  - Secret scan clean — `git log --all --full-history -- '**/.env' 'server/.env'`
+    returns nothing (no `.env` ever committed); a pattern sweep for
+    `AIza…` / `ghp_…` / `sk-…` / `BEGIN … PRIVATE KEY` across all of history
+    found nothing; the only `token:` literal in the tree is the mock
+    `mock-lan-token-…` in `src/lib/api.ts`. The runtime `user-settings.json`
+    (where a real Gemini key would live) is git-ignored, not tracked.
+  - Copyrighted-fixture check clean — `… --oneline -- '**/*Marlow*'` returns
+    nothing; the canonical fixture is the Castwright-owned original
+    _The Coalfall Commission_. No `git filter-repo`/BFG rewrite was required.
+- [x] **Branch protection on `main`** — a server-side ruleset
+      (`id 17654264`, `enforcement: active`) blocks force-push + deletion, and a
+      second ruleset protects release tags. We **deliberately do not** add
+      required-status-check or required-review/required-PR rules: CI is opt-in
+      (plan 215) so a required `verify` would deadlock PRs that never run it, and
+      direct-to-`main` trivial fixes + tag-based releases must keep working —
+      and on a solo project a required review with no second reviewer blocks all
+      merges. `pr-title-lint.yml` (runs on every PR) plus the local
+      `guard-protected-push.mjs` hook are the soft layer. See
+      `CONTRIBUTING.md` → "Server-side enforcement (branch protection)".
+- [x] **`gh repo edit --visibility public`** — flipped 2026-06-17; repo name
+      confirmed `dudarenok-maker/Castwright`.
+
+**Follow-ups (do not block the flip):**
+
+- [~] **CLA collection** wired in-repo via the **`contributor-assistant/github-action`**
+  workflow (`.github/workflows/cla.yml`), with the agreement text at
+  [`CLA.md`](CLA.md) and signatures stored in `signatures/version1/cla.json`
+  on a `cla-signatures` branch. **One step left:** add a repo secret
+  **`CLA_SIGNATURES_TOKEN`** (a PAT with `repo` scope) so the action can
+  commit signatures — until then the check posts the sign prompt but can't
+  persist the signature. Lower urgency while PRs are by-invitation (README).
 - [ ] **Licence-key seam (Cast Pass)** — needs an `fs-` plan (server settings +
       companion pairing + series matcher). Not a blocker for a free-tier-only
       public release.


### PR DESCRIPTION
## Summary

Final repo-opening prep before flipping `Castwright` public (the `castwright.ai` gate is now met). Companion to the checklist in `docs/legal/licensing.md`.

- **SECURITY.md** (new) — supported versions + private vulnerability reporting (GitHub advisories preferred, `hello@castwright.ai` fallback), scoped to the local-first / opt-in-LAN threat model; linked from the README Documentation list.
- **CLA collection wired in-repo** — `.github/workflows/cla.yml` (`contributor-assistant/github-action`) + `docs/legal/CLA.md`. Contributors sign by PR comment; signatures persist to a `cla-signatures` branch. One manual follow-up: add the `CLA_SIGNATURES_TOKEN` repo secret (a `repo`-scope PAT).
- **docs/legal/licensing.md** — repo-opening checklist marked cleared (castwright.ai live, history audited clean, branch-protection ruleset active) and the deliberate *no required-review/status-check* decision recorded; CLA + Cast Pass moved to non-blocking follow-ups.
- **CONTRIBUTING.md** — CLA paragraph now points at `CLA.md` + the sign flow; dropped the stale "Free plan / no Actions budget" reason (opt-in CI on Pro now).

### Pre-flip audit (verified 2026-06-17)
- Secret scan clean: no `.env`/keystore ever committed; no `AIza…`/`ghp_…`/`sk-…`/private-key patterns in history; only the mock `mock-lan-token` literal in the tree. Runtime `user-settings.json` is git-ignored.
- Copyrighted-fixture check clean (`*Marlow*` never in history) → no `git filter-repo`/BFG rewrite needed.
- Branch protection: force-push/deletion ruleset on `main` + release-tag ruleset both active.

## Test plan

Docs + one CI workflow only. Full `npm run verify` (typecheck + all tests + e2e + build) ran green on push; `profile-regen-preview` flaked once under the parallel battery and passed 3/3 in isolation (confirmed flake, unrelated to a docs-only change).