### PR TITLE
chore: ignore castwright-workspace/ (renamed default workspace dir)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,10 +111,15 @@ __pycache__/
 server/audio/
 
 # On-disk book workspace (manuscripts + .audiobook/ state + audio output).
-# Lives at <repo>/audiobook-workspace/ by default; override via WORKSPACE_DIR.
-# Belongs-to-the-user data — never sent to GitHub.
+# Default landed at <repo>/audiobook-workspace/ historically; the Castwright
+# rebrand renamed the default to <repo>/castwright-workspace/ (server/src/
+# workspace/paths.ts). Override via WORKSPACE_DIR. Both are ignored so running
+# the app from the repo never stages a user's library (and never trips the
+# release clean-tree pre-flight). Belongs-to-the-user data — never sent to GitHub.
 audiobook-workspace/
 /audiobook-workspace/
+castwright-workspace/
+/castwright-workspace/
 
 # Local revert-safety backups of cast.json, written before a data-repair run
 # (scripts/repair-series-reuse.mjs). Belongs-to-the-user data — local only,


### PR DESCRIPTION
## Summary

The Castwright rebrand renamed the default on-disk workspace from
`audiobook-workspace/` to `castwright-workspace/` (`server/src/workspace/paths.ts`),
but `.gitignore` was never updated to match. Running the app from the repo now
leaves an **untracked `castwright-workspace/books/` tree**, which risks committing
a user's library and trips the **clean-tree pre-flight in `bump-version.mjs`** at
release-cut time. Ignore the new name alongside the old.

Found while preparing the 1.8.0 release.

## Test plan

- `git check-ignore castwright-workspace/` → now matched.
- Pre-push `npm run verify` battery green (lint + typecheck + all tests + e2e + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)