### PR TITLE
fix(frontend): reconnecting bridge so reload doesn't blank analysing elapsed

### DIFF
--- a/src/components/analysing/phase-card.test.tsx
+++ b/src/components/analysing/phase-card.test.tsx
@@ -281,3 +281,26 @@ describe('PhaseCard layout', () => {
     expect(wrapper.className).toMatch(/overflow-hidden/);
   });
 });
+
+describe('PhaseCard resume indicator (reload re-attach)', () => {
+  it('shows "Reconnecting to the running analysis…" while resuming with no live data yet', () => {
+    renderCard({ isResuming: true, live: null });
+    expect(screen.getByText(/Reconnecting to the running analysis/)).toBeInTheDocument();
+  });
+
+  it('hides the reconnecting line once live chapter data arrives', () => {
+    renderCard({
+      isResuming: true,
+      live: {
+        totalChapters: 9,
+        chapters: [liveChapter({ sentencesDone: 5, sentencesTotal: 100, inSentenceMode: true })],
+      },
+    });
+    expect(screen.queryByText(/Reconnecting to the running analysis/)).not.toBeInTheDocument();
+  });
+
+  it('does not show the reconnecting line on a normal (non-resume) start', () => {
+    renderCard({ isResuming: false, live: null });
+    expect(screen.queryByText(/Reconnecting to the running analysis/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/analysing/phase-card.tsx
+++ b/src/components/analysing/phase-card.tsx
@@ -385,6 +385,11 @@ interface PhaseCardProps {
   isLocalAnalyzer: boolean;
   analysisStarted: boolean;
   conn: ConnState;
+  /** True while re-attaching to an already-running analysis after a page
+      reload, until the first replayed event arrives. Drives the
+      "Reconnecting…" bridge so the live row never reads as a blank/lost
+      elapsed during the sub-second resume window (issue #865). */
+  isResuming?: boolean;
   bookId: string | null | undefined;
   droppedQuotesRefreshKey: number;
 }
@@ -405,6 +410,7 @@ export function PhaseCard({
   isLocalAnalyzer,
   analysisStarted,
   conn,
+  isResuming,
   bookId,
   droppedQuotesRefreshKey,
 }: PhaseCardProps) {
@@ -481,6 +487,18 @@ export function PhaseCard({
             {p.id === 0 && phaseLogs.length === 0 && analysisStarted && conn === 'connecting' && (
               <p className="mt-3 text-xs font-mono text-ink/50 italic">
                 Reading the manuscript (parsing chapters)…
+              </p>
+            )}
+            {/* Reload re-attach bridge (issue #865). After a page reload the
+                view re-subscribes to the still-running sticky job; the elapsed
+                ticker has no `live` data until the first replayed phase event
+                lands (sub-second). Show a "Reconnecting…" line in that gap so
+                the elapsed never reads as blank/lost — the real rows replace it
+                the moment the replay arrives. */}
+            {isResuming && (!live || live.chapters.length === 0) && (
+              <p className="mt-3 inline-flex items-center gap-2 text-xs font-mono text-ink/50 italic">
+                <IconSpinner className="w-3 h-3 text-magenta" />
+                Reconnecting to the running analysis…
               </p>
             )}
             {throttleActive && throttle ? (

--- a/src/views/analysing.tsx
+++ b/src/views/analysing.tsx
@@ -223,6 +223,13 @@ export function AnalysingView({
      an explicit click the user controls when the analysis kicks off,
      and the server log shows exactly one [analysis] entry per click. */
   const [analysisStarted, setAnalysisStarted] = useState(false);
+  /* True only while re-attaching to an already-running job after a page
+     reload — set when the cold-boot rehydrate finds a `running` snapshot,
+     cleared on the first replayed event (markEvent) or any explicit
+     start/retry. Drives PhaseCard's "Reconnecting…" bridge so the elapsed
+     ticker never reads as a blank/lost during the sub-second resume window
+     before the SSE replay lands (issue #865). */
+  const [resuming, setResuming] = useState(false);
 
   /* Marketing capture (VITE_DEMO_CAPTURE): auto-start so a deep-link to the
      analysing screen poses a live run. The analyzer is Gemini in mock mode
@@ -267,6 +274,7 @@ export function AnalysingView({
     hasStartedOnceRef.current = true;
     if (activeStreamSnapshot.state === 'running') {
       setAnalysisStarted(true);
+      setResuming(true);
     }
   }, [manuscriptId, activeStreamSnapshot]);
 
@@ -393,7 +401,12 @@ export function AnalysingView({
        succeeds (banner stays cleared) or hits the gate again and the
        catch below re-sets it with fresh counts. */
     setStage1ShrinkInfo(null);
-    const markEvent = () => setLastEventAt(Date.now());
+    const markEvent = () => {
+      setLastEventAt(Date.now());
+      /* First event of any run means we're re-attached — drop the
+         "Reconnecting…" bridge (issue #865). No-op when not resuming. */
+      setResuming(false);
+    };
     /* Seed the cross-navigation analysis snapshot so the AnalysisPill
        (B3) can read live progress from Redux even after the user
        navigates away from this view. The snapshot updates on every
@@ -715,7 +728,12 @@ export function AnalysingView({
     if (!manuscriptId) return;
     if (retryingChapterId !== null) return;
     setRetryingChapterId(chapterId);
-    const markEvent = () => setLastEventAt(Date.now());
+    const markEvent = () => {
+      setLastEventAt(Date.now());
+      /* First event of any run means we're re-attached — drop the
+         "Reconnecting…" bridge (issue #865). No-op when not resuming. */
+      setResuming(false);
+    };
     /* Snapshot whether the main run is in flight RIGHT NOW. If yes,
        abort it before firing subset (avoids the cache-write race) and
        remember to resume it after subset settles.
@@ -878,6 +896,7 @@ export function AnalysingView({
             }),
           );
           setAnalysisStarted(true);
+          setResuming(false);
           setRetry((r) => ({ nonce: r.nonce + 1, fresh: false }));
         } else {
           /* Main wasn't running — retry was a standalone (cast_incomplete
@@ -1050,6 +1069,7 @@ export function AnalysingView({
       setConn('idle');
     } else {
       setAnalysisStarted(true);
+      setResuming(false);
       setRetry((r) => ({ nonce: r.nonce + 1, fresh: false }));
     }
   };
@@ -1346,6 +1366,7 @@ export function AnalysingView({
               isLocalAnalyzer={isLocalAnalyzer}
               analysisStarted={analysisStarted}
               conn={conn}
+              isResuming={resuming}
               bookId={bookId}
               droppedQuotesRefreshKey={droppedQuotesRefreshKey}
             />


### PR DESCRIPTION
## Summary

Closes #865. On a hard reload during analysing, the elapsed time briefly disappeared — reported as "loses the elapsed time on reload."

Systematic investigation **corrected the issue's premise** (twice):
- The reload **already re-attaches** to the still-running sticky job: `layout.tsx` → `getAnalysisState` → cold-boot effect → SSE **subscribe** (`fresh:false`) → server existing-job branch → `replayCatchUp`. It does **not** start a new analysis, and the replay carries fresh server-computed `elapsedMs` (proven in PR #864).
- The `LiveChapterRow` clock math is **correct** — not the cause.

The real residual is a **sub-second blank**: the per-chapter `live` ticker is component-local state (`useState(null)`), null from the cold-boot reset until the first replayed phase event lands.

**Fix (frontend-only):** a `resuming` flag — set when cold-boot rehydrates a `running` snapshot, cleared on the first replayed event or any explicit start/retry — drives a **"Reconnecting to the running analysis…"** bridge in `PhaseCard`'s active section (mirrors the existing "Reading the manuscript…" bridge). The elapsed never reads as lost; the real rows replace the bridge the instant the replay arrives.

Deliberately **not** the heavier "seed live through the cold-boot discovery endpoint" approach (4 layers + touches the delicate cold-boot path) — disproportionate for a sub-second blank, per the simplicity/surgical principles.

## Test plan

- Paired regression test in `src/components/analysing/phase-card.test.tsx` (RED→GREEN): the bridge shows while `isResuming` with no live data, hides once live chapters arrive, and never shows on a normal (non-resume) start.
- `npm run typecheck` clean (frontend + server); full frontend suite (2909) green; `npm run verify` full battery green locally (incl. e2e + build).

Does not touch the server, the cold-boot discovery endpoint, or the normal start flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)