### PR TITLE
ci(ci): add weekly CodeQL static analysis (JS/TS + Python)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+# Static security analysis (CodeQL) for the JS/TS frontend+server and the
+# Python TTS sidecar. Scheduled weekly + manual only — deliberately NOT on
+# push/pull_request, to stay within the opt-in CI cost posture (plan 215).
+# Free for public repos. Each run scans the whole codebase from the default
+# branch and uploads results to the Security → Code scanning tab.
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, python]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # JS/TS + Python are interpreted — no compilation step needed.
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary

Adds CodeQL static security analysis for the JS/TS frontend+server and the Python TTS sidecar, now that the repo is public (CodeQL is free for public repos).

- **Scheduled weekly + manual only** (`cron: '0 6 * * 1'` + `workflow_dispatch`) — deliberately **no** push/pull_request triggers, to stay within the opt-in CI cost posture (plan 215).
- Matrix over `javascript-typescript` and `python`, `build-mode: none` (interpreted languages, no compile step).
- Results land in **Security → Code scanning**.

## Test plan

Single new workflow file; doesn't touch app code. Full `npm run verify` ran green on push (e2e 212+16 passed, build OK). The workflow's own first run fires on the schedule (or can be triggered now via Actions → CodeQL → Run workflow).