### PR TITLE
fix(scripts,docs): release body can't silently become a placeholder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -513,14 +513,20 @@ Cutting a public release is one command (after the notes file is ready):
 git switch main
 git pull --ff-only
 
-# 2. Author release notes (markdown file, sections per "Release notes" below).
-$EDITOR ~/Desktop/vX.Y.Z-notes.md   # or notepad on Windows
+# 2. Author the release body in docs/release-notes-next.md (sections per
+#    "Release notes" below) and set its `release-notes-next-version:` marker to
+#    the version you're cutting. This file IS the GitHub release body, and
+#    bump-version uses it by DEFAULT — no --notes-file flag needed.
+$EDITOR docs/release-notes-next.md
 
 # 3. Bump versions, GATE on a green cross-OS run, then create the chore commit
 #    + annotated tag. Same command on Windows, macOS, Linux. This fires
 #    cross-os.yml on main and BLOCKS (~15–20 min); if it fails the tag is NOT
 #    created — fix main and re-run. --skip-cross-os bypasses the gate.
-node scripts/bump-version.mjs --level minor --notes-file ~/Desktop/vX.Y.Z-notes.md
+#    The bump REFUSES if the notes are missing or their version marker is stale
+#    (a release can't ship a placeholder body); --allow-placeholder overrides.
+node scripts/bump-version.mjs --level minor
+#    (Or point at a different file: --notes-file path/to/notes.md)
 
 # 4. Push the bump, then the tag. The tag push fires .github/workflows/release.yml.
 git push origin main
@@ -565,11 +571,16 @@ git tag -d vX.Y.Z
 
 ## Release notes
 
-Release notes live in the annotated git tag message (`git tag -a vX.Y.Z`),
-which the release workflow uses verbatim as the GitHub Release body. The tag
-message is the source of truth; the regression plans under `docs/features/`
-are the long-form companion (reference plan / PR numbers in parens, e.g.
-`(#637, plan 195)`).
+Release notes are authored in `docs/release-notes-next.md` (technical
+register). `bump-version.mjs` feeds that file verbatim into the annotated git
+tag message, which the release workflow uses as the GitHub Release body — so the
+file IS the source of truth. Its leading HTML-comment carries a
+`release-notes-next-version:` marker the bump checks against the version being
+cut (a stale or missing file fails the bump rather than shipping a placeholder).
+The regression plans under `docs/features/` are the long-form companion
+(reference plan / PR numbers in parens, e.g. `(#637, plan 195)`). The
+user-facing, brand-voice notes are separate — `RELEASE_NOTES.md`, shown in-app
+at `#/release-notes`.
 
 A release describes what shipped, diffed against the **previous public
 release**, and is organised as a **headline block + emoji-themed sections**

--- a/docs/release-notes-next.md
+++ b/docs/release-notes-next.md
@@ -1,13 +1,23 @@
-# Castwright v1.8.0
+<!--
+Draft release notes for the NEXT version (technical register — this IS the
+GitHub release body). bump-version.mjs feeds this file verbatim as the
+annotated-tag message → release.yml, and now uses it by DEFAULT (no
+--notes-file needed). Everything in this HTML comment is invisible in the
+rendered release, so it never leaks into the body.
 
-Draft release notes for the next version (technical register — this is the
-**GitHub release body**, fed to `bump-version.mjs` as
-`--notes-file docs/release-notes-next.md` → the annotated tag → `release.yml`).
-The user-facing, brand-voice notes live separately in the committed
-`RELEASE_NOTES.md` (shown in-app at `#/release-notes`). Remove this header after
-the tag is created.
+Keep it current for each release:
+  1. Update the version marker below.
+  2. Rewrite the body (theme paragraph → ## ✨ Headline features with
+     ### … (new) subsections → emoji-themed sections → bold-lead bullets with
+     (#PR) refs → **Full changelog:** vPREV...vNEW footer). v1.7.0 is the
+     canonical example; see CONTRIBUTING.md "Release notes".
 
----
+The marker is what bump-version checks: if it doesn't match the version being
+cut, the bump refuses (so a stale file can't ship as the body). The
+user-facing, brand-voice notes live separately in RELEASE_NOTES.md (#/release-notes).
+
+release-notes-next-version: 1.8.0
+-->
 
 **The open-beta release.** Castwright reaches more machines this cycle — an early **AMD GPU** preview and a **one-click Pinokio** install — on top of a deep round of analysis honesty, multilingual depth, and GPU-contention resilience that keeps long runs upright on an 8 GB card.
 

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -45,6 +45,7 @@ function parseArgs(argv) {
     dryRun: false,
     force: false,
     skipCrossOs: false,
+    allowPlaceholder: false,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -53,6 +54,7 @@ function parseArgs(argv) {
     else if (a === '--dry-run') out.dryRun = true;
     else if (a === '--force') out.force = true;
     else if (a === '--skip-cross-os') out.skipCrossOs = true;
+    else if (a === '--allow-placeholder') out.allowPlaceholder = true;
     else if (a === '--help' || a === '-h') {
       printHelpAndExit(0);
     } else {
@@ -65,7 +67,7 @@ function parseArgs(argv) {
 function printHelpAndExit(code) {
   process.stdout.write(
     'Usage: node scripts/bump-version.mjs --level patch|minor|major ' +
-      '[--notes-file <path>] [--dry-run] [--force] [--skip-cross-os]\n',
+      '[--notes-file <path>] [--allow-placeholder] [--dry-run] [--force] [--skip-cross-os]\n',
   );
   process.exit(code);
 }
@@ -325,6 +327,30 @@ function refreshCodeStats() {
   }
 }
 
+// The canonical in-repo technical release notes (the GitHub release body).
+// Defaulting to this means the tag annotation is never a silent placeholder —
+// the v1.8.0 cut shipped an empty body because --notes-file was omitted.
+export const DEFAULT_NOTES_FILE = 'docs/release-notes-next.md';
+
+/** Which notes file to use: an explicit --notes-file wins; otherwise the
+ *  canonical in-repo file when it exists; otherwise null (placeholder
+ *  territory, which main() refuses unless --allow-placeholder). */
+export function resolveNotesFile(explicit, fileExists) {
+  if (explicit) return explicit;
+  if (fileExists(DEFAULT_NOTES_FILE)) return DEFAULT_NOTES_FILE;
+  return null;
+}
+
+/** The stale version string if the notes file declares a
+ *  `release-notes-next-version: X.Y.Z` marker that doesn't match `version`,
+ *  else null. No marker → null (can't verify, so don't block). Reading an
+ *  explicit marker (not the first version token) avoids false positives from
+ *  the `vA.B.C...vX.Y.Z` changelog footer. */
+export function staleNotesVersion(notesText, version) {
+  const m = /release-notes-next-version:\s*v?(\d+\.\d+\.\d+)/i.exec(notesText ?? '');
+  return m && m[1] !== version ? m[1] : null;
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   if (!args.level) {
@@ -333,6 +359,9 @@ async function main() {
   if (args.notesFile && !existsSync(args.notesFile)) {
     die(`--notes-file does not exist: ${args.notesFile}`);
   }
+  // Default to the canonical in-repo notes so a release can't ship a silent
+  // placeholder body (the refusal is enforced after the cheap pre-flights).
+  args.notesFile = resolveNotesFile(args.notesFile, existsSync);
 
   // Pre-flight 1: clean working tree (unless dry-run).
   const status = git(['status', '--porcelain'], { capture: true });
@@ -399,6 +428,34 @@ async function main() {
         die(
           `Release-notes gate: ${notesCheck.reason} Update RELEASE_NOTES.md ` +
             `(top entry = the new version, brand voice) before tagging, or pass --force.`,
+        );
+    }
+  }
+
+  // Pre-flight 5b: refuse a silent placeholder body. A release can't ship empty
+  // technical notes; --allow-placeholder opts in on purpose, --dry-run warns.
+  if (!args.notesFile) {
+    const msg =
+      `No release notes. Author ${DEFAULT_NOTES_FILE} (technical register — the ` +
+      `GitHub release body), or pass --notes-file <path>. To ship a placeholder ` +
+      `body on purpose, pass --allow-placeholder.`;
+    if (args.allowPlaceholder) info('[WARN] --allow-placeholder: tag annotation will be a placeholder.');
+    else if (args.dryRun) info(`[DRY-RUN][WARN] ${msg}`);
+    else die(msg);
+  }
+
+  // Pre-flight 6: the technical notes file must be current for THIS version.
+  // Catches the "release-notes-next.md still holds the last release" trap —
+  // a stale marker would otherwise become the GitHub release body verbatim.
+  if (args.notesFile) {
+    const stale = staleNotesVersion(readFileSync(resolve(args.notesFile), 'utf8'), newVersion);
+    if (stale) {
+      if (args.force) info(`[WARN] notes-file gate (--force): ${args.notesFile} declares ${stale}, cutting ${newVersion}`);
+      else if (args.dryRun) info(`[DRY-RUN][WARN] notes-file gate: ${args.notesFile} declares ${stale}, cutting ${newVersion}`);
+      else
+        die(
+          `${args.notesFile} declares release-notes-next-version: ${stale} but you're ` +
+            `cutting ${newVersion}. Refresh it for this release (or pass --force).`,
         );
     }
   }

--- a/scripts/tests/bump-version.test.mjs
+++ b/scripts/tests/bump-version.test.mjs
@@ -18,7 +18,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 // Pure helper from the script (import is inert — the script's procedure is
 // behind an import.meta-main guard, so loading it here doesn't run a release).
-import { pickWorkflowRun, readSidecarVersion, writeSidecarVersion, sidecarVersionPath, readPubspecVersion, writePubspecVersion, pubspecPath, pubspecBuildNumber } from '../bump-version.mjs';
+import { pickWorkflowRun, readSidecarVersion, writeSidecarVersion, sidecarVersionPath, readPubspecVersion, writePubspecVersion, pubspecPath, pubspecBuildNumber, resolveNotesFile, staleNotesVersion, DEFAULT_NOTES_FILE } from '../bump-version.mjs';
 import { join } from 'node:path';
 import { execFileSync, spawnSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
@@ -141,7 +141,7 @@ test('bump-version --dry-run prints the plan and does not mutate', () => {
 test('bump-version --level patch advances both versions, commits, tags', () => {
   const dir = setupRepo('1.2.3');
   try {
-    const out = runBump(dir, ['--level', 'patch', '--skip-cross-os']);
+    const out = runBump(dir, ['--level', 'patch', '--skip-cross-os', '--allow-placeholder']);
     assert.equal(out.status, 0, out.stderr);
     assert.equal(readVersion(dir, 'package.json'), '1.2.4');
     assert.equal(readVersion(dir, 'server/package.json'), '1.2.4');
@@ -170,7 +170,7 @@ test('bump-version --level patch advances both versions, commits, tags', () => {
 test('bump-version --level minor zeros the patch field', () => {
   const dir = setupRepo('2.4.7');
   try {
-    const out = runBump(dir, ['--level', 'minor', '--skip-cross-os']);
+    const out = runBump(dir, ['--level', 'minor', '--skip-cross-os', '--allow-placeholder']);
     assert.equal(out.status, 0, out.stderr);
     assert.equal(readVersion(dir, 'package.json'), '2.5.0');
     assert.equal(readVersion(dir, 'server/package.json'), '2.5.0');
@@ -182,7 +182,7 @@ test('bump-version --level minor zeros the patch field', () => {
 test('bump-version --level major zeros minor + patch', () => {
   const dir = setupRepo('3.4.5');
   try {
-    const out = runBump(dir, ['--level', 'major', '--skip-cross-os']);
+    const out = runBump(dir, ['--level', 'major', '--skip-cross-os', '--allow-placeholder']);
     assert.equal(out.status, 0, out.stderr);
     assert.equal(readVersion(dir, 'package.json'), '4.0.0');
     assert.equal(readVersion(dir, 'server/package.json'), '4.0.0');
@@ -203,7 +203,7 @@ test('bump-version refuses lockstep drift', () => {
     gitExec( ['add', 'server/package.json'], { cwd: dir });
     gitExec( ['commit', '-q', '-m', 'drift'], { cwd: dir });
 
-    const out = runBump(dir, ['--level', 'patch', '--skip-cross-os']);
+    const out = runBump(dir, ['--level', 'patch', '--skip-cross-os', '--allow-placeholder']);
     assert.notEqual(out.status, 0);
     assert.match(out.stderr, /Lockstep invariant violated/);
   } finally {
@@ -346,7 +346,7 @@ test('bump-version preserves ## section headers in the tag annotation', () => {
 test('bump-version --skip-cross-os skips the gate and still bumps + tags', () => {
   const dir = setupRepo('1.0.0');
   try {
-    const out = runBump(dir, ['--level', 'patch', '--skip-cross-os']);
+    const out = runBump(dir, ['--level', 'patch', '--skip-cross-os', '--allow-placeholder']);
     assert.equal(out.status, 0, out.stderr);
     assert.match(out.stdout, /\[SKIP\] cross-OS gate skipped/);
     assert.equal(readVersion(dir, 'package.json'), '1.0.1');
@@ -376,7 +376,7 @@ test('bump-version reports code-stats skipped in --dry-run when the script is ab
 test('bump-version skips the code-stats refresh (script absent) but still bumps + tags', () => {
   const dir = setupRepo('1.0.0');
   try {
-    const out = runBump(dir, ['--level', 'patch', '--skip-cross-os']);
+    const out = runBump(dir, ['--level', 'patch', '--skip-cross-os', '--allow-placeholder']);
     assert.equal(out.status, 0, out.stderr);
     assert.match(out.stdout, /\[SKIP\] code-stats: scripts\/code-stats\.mjs not found/);
     assert.equal(readVersion(dir, 'package.json'), '1.0.1');
@@ -500,6 +500,62 @@ test('readPubspecVersion returns null when pubspec is absent', () => {
   const dir = mkdtempSync(join(tmpdir(), 'bump-pubspec-none-'));
   try {
     assert.equal(readPubspecVersion(dir), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── Release-notes safeguards (so a cut can't ship a placeholder body) ──
+
+test('resolveNotesFile: explicit --notes-file always wins', () => {
+  assert.equal(
+    resolveNotesFile('custom/notes.md', () => true),
+    'custom/notes.md',
+  );
+  // wins even if the default also exists
+  assert.equal(
+    resolveNotesFile('custom/notes.md', (p) => p === DEFAULT_NOTES_FILE),
+    'custom/notes.md',
+  );
+});
+
+test('resolveNotesFile: defaults to the canonical file when present', () => {
+  assert.equal(
+    resolveNotesFile(null, (p) => p === DEFAULT_NOTES_FILE),
+    DEFAULT_NOTES_FILE,
+  );
+});
+
+test('resolveNotesFile: null when nothing supplied and the default is absent', () => {
+  // null is the "placeholder territory" main() refuses without --allow-placeholder
+  assert.equal(
+    resolveNotesFile(null, () => false),
+    null,
+  );
+});
+
+test('staleNotesVersion: flags a marker that does not match the cut version', () => {
+  const notes = '<!--\nrelease-notes-next-version: 1.7.0\n-->\n# body';
+  assert.equal(staleNotesVersion(notes, '1.8.0'), '1.7.0');
+});
+
+test('staleNotesVersion: null when the marker matches (v-prefix tolerated)', () => {
+  assert.equal(staleNotesVersion('release-notes-next-version: v1.8.0', '1.8.0'), null);
+});
+
+test('staleNotesVersion: null when no marker is present (cannot verify, do not block)', () => {
+  // The `vA.B.C...vX.Y.Z` changelog footer must NOT be mistaken for the marker.
+  assert.equal(staleNotesVersion('body\n\n**Full changelog:** `v1.7.0...v1.8.0`', '1.8.0'), null);
+});
+
+test('bump-version refuses to cut without notes (no placeholder by default)', () => {
+  const dir = setupRepo('1.0.0');
+  try {
+    // No docs/release-notes-next.md in the fixture, no --notes-file, no
+    // --allow-placeholder → it must refuse rather than ship an empty body.
+    const out = runBump(dir, ['--level', 'patch', '--skip-cross-os']);
+    assert.notEqual(out.status, 0);
+    assert.match(out.stderr, /No release notes/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Guards bump-version so the GitHub release body can't silently become a placeholder (the v1.8.0 cause). Auto-defaults --notes-file to docs/release-notes-next.md; refuses an empty body without --allow-placeholder; staleness gate on the release-notes-next-version marker; preamble moved to an HTML comment; CONTRIBUTING runbook updated. Tests: bump-version.test.mjs 31/31, verified end-to-end via a real --dry-run.