### PR TITLE
test(server): make tmpSeq race test retry-proof (assert distinct temps)

### DIFF
--- a/server/src/store/analysis-cache.race.test.ts
+++ b/server/src/store/analysis-cache.race.test.ts
@@ -52,9 +52,12 @@ describe('analysis-cache concurrent same-tick writes (tmpSeq race)', () => {
     ]);
 
     // The two same-tick writes MUST have used different temp files (tmpSeq).
-    // A broken impl (no seq counter) would reuse the same temp path and this
-    // assertion would fail: Set.size(1) !== length(2).
-    expect(renamed.length).toBe(2);
-    expect(new Set(renamed).size).toBe(renamed.length);
+    // The invariant is DISTINCT temp paths, not an exact rename-call count:
+    // renameWithRetry re-attempts the same src on a retryable (cloud-sync)
+    // error, and the mock pushes src per attempt, so renamed.length can
+    // legitimately exceed 2 under load. Counting distinct paths is retry-proof
+    // and still red on a regression: a broken impl (no seq counter) reuses one
+    // temp path, collapsing the set to size 1.
+    expect(new Set(renamed).size).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

The same-tick cache-write regression guard (`analysis-cache.race.test.ts`, added today in the flaky-hardening work, commit `31c4cc1a`) asserted an exact rename-*call* count, `renamed.length === 2`. But `renameWithRetry` legitimately re-attempts the **same** `src` on retryable cloud-sync errors (EPERM/EBUSY/ENOENT/EACCES/EIO), and the test's `rename` mock does `renamed.push(src)` on every attempt. Under the parallel server suite on the Windows host a retry fires, the count reaches 3, and the test fails `expected 3 to be 2` — a false alarm; the product behaviour is correct (distinct temp paths, last-write-wins file is intact).

This was reproducing **3/3** in standalone `npm run test:server` on `main`, blocking the pre-push gate for *every* branch.

Fix is test-only and **strengthens** the assertion: check the true invariant — two same-tick writes use **distinct** temp paths (`new Set(renamed).size === 2`). Retry-proof, and still red on a real regression (a broken impl without the `tmpSeq` counter reuses one temp path → set size 1).

Not a product bug; no `state-io.ts`/`atomic-rename.ts` change.

## Test plan

- `npm run test:server` standalone: was 3/3 red at this assertion, now green (2936 passed).
- Full `npm run verify` green locally (typecheck + all tests + e2e + build).
- Invariant still fails on regression: removing the `tmpSeq` seq counter collapses the set to size 1 → red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)