### PR TITLE
docs(sidecar): mark torch-bump spec/plan shipped (#884, #885)

### DIFF
--- a/docs/superpowers/plans/2026-06-18-sidecar-torch-cve-bump.md
+++ b/docs/superpowers/plans/2026-06-18-sidecar-torch-cve-bump.md
@@ -1,5 +1,10 @@
 # Sidecar torch CVE bump (2.8.0 → 2.11.0) + pytest Implementation Plan
 
+> **✅ SHIPPED 2026-06-18** via **#884** (core bump, merge `7ae1c120`) + **#885**
+> (cu128-torch + skew-proof ORT-swap on-box follow-ups, merge `7ba0d5a4`).
+> On-box validated on RTX 4070 (torch 2.11.0+cu128, CUDA, all engines on GPU).
+> See the spec's **Ship notes** for the full record. Tracking issue: #883.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Remediate the public-repo Dependabot torch/pytest alerts on the Python TTS sidecar by bumping `torch`/`torchaudio` 2.8.0 → 2.11.0 (NVIDIA cu128 + CPU profiles) and pytest → ≥9.0.3, updating the tests/docs that pin 2.8.0, and adding a forward guardrail test — without breaking any TTS engine.

--- a/docs/superpowers/specs/2026-06-17-sidecar-torch-cve-bump-design.md
+++ b/docs/superpowers/specs/2026-06-17-sidecar-torch-cve-bump-design.md
@@ -1,9 +1,24 @@
 ---
 title: Sidecar torch CVE bump (2.8.0 → 2.11.0) + pytest bump
 date: 2026-06-17
-status: draft
+status: shipped
 area: sidecar / security
 ---
+
+> **Shipped 2026-06-18** — tracking issue #883. Delivered across two PRs:
+> - **#884** (merge `7ae1c120`) — torch/torchaudio 2.8.0→2.11.0 + pytest≥9.0.3;
+>   matched-pair / `no_torchcodec` / fs-38 `test_audio_io_invariant` tests; doc
+>   sweep; RELEASE_NOTES. `unpack_sequence` + `lstm_cell` alerts auto-resolved;
+>   `jit.script` (CVE-2025-3000) dismissed ×3 as `tolerable_risk`.
+> - **#885** (merge `7ba0d5a4`) — on-box validation follow-ups (NOT in the
+>   original scope, surfaced during the RTX 4070 rebuild): nvidia torch
+>   pre-installed from the **cu128 index** (PyPI's default torch is CPU-only on
+>   Windows → a plain install silently dropped GPU), and a **skew-proof ONNX
+>   runtime swap** (uninstall both + `--force-reinstall`, so an onnxruntime /
+>   onnxruntime-gpu version skew can't corrupt the shared namespace).
+>
+> On-box validated: torch 2.11.0+cu128, CUDA, all engines `device: cuda`.
+> Dependabot went 14 → 3 open alerts this cycle.
 
 # Sidecar torch CVE bump (2.8.0 → 2.11.0) + pytest bump
 


### PR DESCRIPTION
## Summary

Post-delivery doc hygiene: marks the torch CVE-bump spec/plan **shipped** with ship notes. No code change.

**Delivered (this tracking issue, #883):**
- **#884** (merge `7ae1c120`) — torch/torchaudio 2.8.0→2.11.0 + pytest≥9.0.3; the matched-pair / `no_torchcodec` / fs-38 `test_audio_io_invariant` guardrail tests; INSTALL/README/RELEASE_NOTES sweep. `unpack_sequence` (CVE-2025-2999) + `lstm_cell` (CVE-2025-3001) auto-resolved by the bump; `jit.script` (CVE-2025-3000) dismissed ×3 as `tolerable_risk` (no fix through 2.12.0).
- **#885** (merge `7ba0d5a4`) — on-box-validation follow-ups: nvidia torch pre-installed from the **cu128 index** (PyPI default is CPU-only on Windows) + a **skew-proof ONNX-runtime swap** (uninstall both + `--force-reinstall`).

**On-box validated** on RTX 4070: torch 2.11.0+cu128, CUDA, all three engines `device: cuda`. Dependabot: **14 → 3** open alerts this cycle.

Closes #883

## Test plan

Doc-only (pre-commit scope-skipped all test legs; pre-push verify cached green). No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)