### PR TITLE
fix(server,sidecar): thread path sanitizers into sinks (CodeQL re-scan follow-up)

### DIFF
--- a/server/src/analyzer/gemini.ts
+++ b/server/src/analyzer/gemini.ts
@@ -13,7 +13,6 @@ import { fileURLToPath } from 'node:url';
 import { GoogleGenAI } from '@google/genai';
 import type { z } from 'zod';
 import { writeInbox, outboxPath, errorPath, type HandoffKey } from '../handoff/protocol.js';
-import { safeSegment } from '../util/safe-path.js';
 import {
   stage1Schema,
   stage1ChapterSchema,
@@ -258,7 +257,6 @@ export class GeminiAnalyzer implements Analyzer {
     schema: z.ZodType<T>,
     call: StageCall,
   ): Promise<T> {
-    safeSegment(manuscriptId);
     await writeInbox(manuscriptId, key, promptMd);
 
     const skill = await loadSkill(skillName);
@@ -689,7 +687,7 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
     const timer = setTimeout(() => {
       signal?.removeEventListener('abort', onAbort);
       resolve();
-    }, ms);
+    }, Math.min(ms, 60_000));
     const onAbort = () => {
       clearTimeout(timer);
       reject(new AnalysisAbortedError('Aborted during gemini retry backoff.'));
@@ -1175,6 +1173,5 @@ export async function persistResponse(
   key: HandoffKey,
   raw: string,
 ): Promise<void> {
-  safeSegment(manuscriptId);
   await writeFile(outboxPath(manuscriptId, key), raw, 'utf8');
 }

--- a/server/src/analyzer/ollama.ts
+++ b/server/src/analyzer/ollama.ts
@@ -19,7 +19,6 @@ import { configValue } from '../config/resolver.js';
 import type { Accelerator } from '../gpu/vram-state.js';
 import { getLastKnownVram } from '../gpu/vram-state.js';
 import { writeInbox, errorPath, rawAttemptPath, type HandoffKey } from '../handoff/protocol.js';
-import { safeSegment } from '../util/safe-path.js';
 import {
   stage1Schema,
   stage1ChapterSchema,
@@ -300,7 +299,6 @@ export class OllamaAnalyzer implements Analyzer {
     schema: z.ZodType<T>,
     call: StageCall,
   ): Promise<T> {
-    safeSegment(manuscriptId);
     await writeInbox(manuscriptId, key, promptMd);
 
     const skill = await loadSkill(skillName);

--- a/server/src/handoff/protocol.ts
+++ b/server/src/handoff/protocol.ts
@@ -33,15 +33,15 @@ async function ensureDirs(): Promise<void> {
 }
 
 export function inboxPath(manuscriptId: string, key: HandoffKey): string {
-  return join(INBOX, `${manuscriptId}-stage${key}.md`);
+  return join(INBOX, `${safeSegment(manuscriptId)}-stage${key}.md`);
 }
 
 export function outboxPath(manuscriptId: string, key: HandoffKey): string {
-  return join(OUTBOX, `${manuscriptId}-stage${key}.json`);
+  return join(OUTBOX, `${safeSegment(manuscriptId)}-stage${key}.json`);
 }
 
 export function errorPath(manuscriptId: string, key: HandoffKey): string {
-  return join(OUTBOX, `${manuscriptId}-stage${key}.errors.json`);
+  return join(OUTBOX, `${safeSegment(manuscriptId)}-stage${key}.errors.json`);
 }
 
 /* Forensic record of a model response that failed parse/validation. Lives
@@ -51,7 +51,7 @@ export function errorPath(manuscriptId: string, key: HandoffKey): string {
    they fail, so a partial-success retry preserves the first attempt's text
    for comparison. */
 export function rawAttemptPath(manuscriptId: string, key: HandoffKey, attempt: 1 | 2): string {
-  return join(OUTBOX, `${manuscriptId}-stage${key}.attempt${attempt}.raw.txt`);
+  return join(OUTBOX, `${safeSegment(manuscriptId)}-stage${key}.attempt${attempt}.raw.txt`);
 }
 
 export async function writeInbox(

--- a/server/src/routes/qwen-voice.ts
+++ b/server/src/routes/qwen-voice.ts
@@ -182,8 +182,7 @@ function previewVoiceIdFor(realVoiceId: string): string {
   return `${realVoiceId}${PREVIEW_SUFFIX}`;
 }
 export function qwenVoicePtPath(name: string): string {
-  safeSegment(name);
-  return join(qwenVoicesDir(), `${name}.pt`);
+  return join(qwenVoicesDir(), `${safeSegment(name)}.pt`);
 }
 
 /* GET /api/books/:bookId/cast/:characterId/designed-persona

--- a/server/src/routes/samples.ts
+++ b/server/src/routes/samples.ts
@@ -49,12 +49,12 @@ samplesRouter.get('/', async (_req: Request, res: Response) => {
 samplesRouter.post('/:slug/load', async (req: Request, res: Response) => {
   try {
     const slug = req.params.slug;
+    let src: string;
     try {
-      safeSegment(slug);
+      src = join(SAMPLES_ROOT, safeSegment(slug));
     } catch {
       return res.status(400).json({ error: 'Invalid sample slug.' });
     }
-    const src = join(SAMPLES_ROOT, slug);
     if (!existsSync(join(src, '.audiobook', 'state.json'))) {
       return res.status(404).json({ error: `Sample not found: ${slug}` });
     }
@@ -62,8 +62,9 @@ samplesRouter.post('/:slug/load', async (req: Request, res: Response) => {
 
     const bundleState = JSON.parse(await readFile(join(src, '.audiobook', 'state.json'), 'utf8'));
     const { author, series, title, manuscriptFile } = bundleState;
+    let safeManuscriptFile: string;
     try {
-      safeSegment(manuscriptFile);
+      safeManuscriptFile = safeSegment(manuscriptFile);
     } catch {
       return res.status(400).json({ error: 'Invalid bundle manuscript file.' });
     }
@@ -78,7 +79,7 @@ samplesRouter.post('/:slug/load', async (req: Request, res: Response) => {
     await mkdir(dotAudiobook(bookDir), { recursive: true });
 
     // 1. Manuscript.
-    await copyFile(join(src, manuscriptFile), join(bookDir, manuscriptFile));
+    await copyFile(join(src, safeManuscriptFile), join(bookDir, safeManuscriptFile));
 
     // 2. .audiobook/{cast,manuscript-edits}.
     for (const f of ['cast.json', 'manuscript-edits.json']) {
@@ -112,11 +113,11 @@ samplesRouter.post('/:slug/load', async (req: Request, res: Response) => {
     }
 
     // 5. Register the ManuscriptRecord so the analysis/generation pipeline is wired.
-    const buffer = await readFile(join(bookDir, manuscriptFile));
+    const buffer = await readFile(join(bookDir, safeManuscriptFile));
     const parsed = await parseManuscript({
       buffer,
-      fileName: manuscriptFile,
-      sourcePath: join(bookDir, manuscriptFile),
+      fileName: safeManuscriptFile,
+      sourcePath: join(bookDir, safeManuscriptFile),
     });
     const record: ManuscriptRecord = {
       manuscriptId,

--- a/server/src/routes/voice-sample.ts
+++ b/server/src/routes/voice-sample.ts
@@ -9,6 +9,7 @@ import { Router } from 'express';
 import type { Request, Response } from '../http.js';
 import { existsSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
+import { safeSegment } from '../util/safe-path.js';
 import {
   engineForModelKey,
   isTtsModelKey,
@@ -117,7 +118,7 @@ voiceSampleRouter.post('/:voiceId/sample', async (req: Request, res: Response) =
     cacheScope = voiceId;
   }
   const fileName = voiceSampleFileName({ cacheScope, modelKey: effectiveModelKey, text, voiceName });
-  const filePath = voiceSampleFilePath(fileName);
+  const filePath = voiceSampleFilePath(safeSegment(fileName));
   const publicUrl = voiceSamplePublicUrl(fileName);
 
   if (existsSync(filePath)) {

--- a/server/src/store/analysis-cache.ts
+++ b/server/src/store/analysis-cache.ts
@@ -110,8 +110,7 @@ export interface AnalysisCache {
 }
 
 export function cachePath(manuscriptId: string): string {
-  safeSegment(manuscriptId);
-  return join(CACHE_DIR, `${manuscriptId}.json`);
+  return join(CACHE_DIR, `${safeSegment(manuscriptId)}.json`);
 }
 
 export async function loadAnalysisCache(manuscriptId: string): Promise<AnalysisCache> {

--- a/server/src/tts/voice-sample-cache.ts
+++ b/server/src/tts/voice-sample-cache.ts
@@ -13,6 +13,7 @@ import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { TtsModelKey } from './index.js';
 import type { CharacterHint, VoiceLike } from './voice-mapping.js';
+import { stripEdges } from '../util/text-match.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -54,12 +55,9 @@ export function listVoiceSampleFiles(): string[] {
 const MAX_CHARS = 320;
 
 export function stripQuoteMarks(s: string): string {
-  // Two anchored single-sided replaces — the `^…|…$` alternation is the
-  // polynomial-redos shape.
-  return s
-    .replace(/^[“”"'‘’\s]+/, '')
-    .replace(/[“”"'‘’\s]+$/, '')
-    .trim();
+  // Linear two-pointer edge strip — the trailing-anchored `[…]+$` form is
+  // polynomial-redos (per-start-position backtracking).
+  return stripEdges(s, /[“”"'‘’\s]/).trim();
 }
 
 export function buildSampleText(voice: VoiceLike, hint?: CharacterHint): string {

--- a/server/src/util/text-match.ts
+++ b/server/src/util/text-match.ts
@@ -3,18 +3,28 @@
    typography drift (smart quotes, em-dashes, ellipses) is handled the same
    way everywhere. */
 
+/** Strip leading and trailing characters matching `edge` (a single-char class)
+    via a linear two-pointer scan. The trailing-anchored `[…]+$` regex form is
+    polynomial-redos (per-start-position backtracking); a single-char `.test`
+    per edge has no backtracking, so this is O(n). */
+export function stripEdges(s: string, edge: RegExp): string {
+  let a = 0,
+    b = s.length;
+  while (a < b && edge.test(s[a])) a++;
+  while (b > a && edge.test(s[b - 1])) b--;
+  return s.slice(a, b);
+}
+
 export function normaliseForMatch(s: string): string {
-  return s
-    .toLowerCase()
-    .replace(/[‘’]/g, "'")
-    .replace(/[“”]/g, '"')
-    .replace(/[—–]/g, '-')
-    .replace(/…/g, '...')
-    // Split the two-sided trim into two anchored single-sided replaces — the
-    // `^…|…$` alternation is the polynomial-redos shape.
-    .replace(/^[\s"'`]+/, '')
-    .replace(/[\s"'`]+$/, '')
-    .replace(/\s+/g, ' ');
+  return stripEdges(
+    s
+      .toLowerCase()
+      .replace(/[‘’]/g, "'")
+      .replace(/[“”]/g, '"')
+      .replace(/[—–]/g, '-')
+      .replace(/…/g, '...'),
+    /[\s"'`]/,
+  ).replace(/\s+/g, ' ');
 }
 
 /** Strip trailing terminal-sentence punctuation (`.,;:!?`) from an already-

--- a/server/src/workspace/auto-backup.ts
+++ b/server/src/workspace/auto-backup.ts
@@ -18,6 +18,7 @@ import { mkdir, readdir, readFile, stat, unlink } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { BOOKS_ROOT, bookBackupsDir, stateJsonPath } from './paths.js';
+import { safeSegment } from '../util/safe-path.js';
 import { findBookByBookId } from './scan.js';
 import { writeJsonAtomic } from './state-io.js';
 import { getResolvedBackupConfig } from './user-settings.js';
@@ -51,7 +52,7 @@ export async function listBackups(bookId: string): Promise<BackupSnapshot[]> {
   const names = (await readdir(dir)).filter((n) => STAMP_RE.test(n));
   const out: BackupSnapshot[] = [];
   for (const file of names) {
-    const s = await stat(join(dir, file));
+    const s = await stat(join(dir, safeSegment(file)));
     out.push({ file, sizeBytes: s.size, createdAt: s.mtime.toISOString() });
   }
   /* Zero-padded stamp ⇒ filename sort is chronological; newest first. */
@@ -66,7 +67,7 @@ export async function pruneBackups(bookId: string, keep: number): Promise<number
   const stale = (await listBackups(bookId)).slice(keep); // newest-first
   const dir = bookBackupsDir(bookId);
   for (const s of stale) {
-    await unlink(join(dir, s.file)).catch(() => {});
+    await unlink(join(dir, safeSegment(s.file))).catch(() => {});
   }
   return stale.length;
 }
@@ -194,7 +195,7 @@ export async function restoreBackup(bookId: string, file: string): Promise<void>
   const found = await findBookByBookId(bookId);
   if (!found) throw new BackupRestoreError('book not found');
   const bookDir = found.bookDir;
-  const snapPath = join(bookBackupsDir(bookId), file);
+  const snapPath = join(bookBackupsDir(bookId), safeSegment(file));
   if (!existsSync(snapPath)) throw new BackupRestoreError('backup not found');
   const raw = await readFile(snapPath, 'utf8');
   let value: unknown;

--- a/server/src/workspace/paths.ts
+++ b/server/src/workspace/paths.ts
@@ -10,6 +10,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { unicodeKebab } from '../util/safe-id.js';
 import { safeSegment, assertContained } from '../util/safe-path.js';
+import { stripEdges } from '../util/text-match.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SERVER_ROOT = resolve(__dirname, '..', '..');
@@ -94,10 +95,7 @@ export function parseBookId(
    scan.ts/samples.ts/findBookBy all compose through bookDirByDisplay, so the
    on-disk name they compute always matches what import wrote. */
 function sanitizeDisplaySegment(s: string): string {
-  const cleaned = s
-    .replace(/[/\\:*?"<>|\x00]/g, '_')
-    .replace(/\.{2,}/g, '_')
-    .replace(/[. ]+$/g, '')
+  const cleaned = stripEdges(s.replace(/[/\\:*?"<>|\x00]/g, '_').replace(/\.{2,}/g, '_'), /[. ]/)
     .trim()
     .slice(0, 120);
   return cleaned.length > 0 ? cleaned : '_';
@@ -240,8 +238,7 @@ export function qwenVoicesDir(): string {
 /** Path to a single designed Qwen voice's JSON sidecar (its `instruct`
     persona + ref text). `name` is the designed voiceId, e.g. `qwen-wren`. */
 export function qwenVoiceSidecarPath(name: string): string {
-  safeSegment(name);
-  return join(qwenVoicesDir(), `${name}.json`);
+  return join(qwenVoicesDir(), `${safeSegment(name)}.json`);
 }
 
 /** Plan 102 — workspace-level chapter-generation queue. ONE file holds the
@@ -271,7 +268,7 @@ export function backupsRootDir(): string {
 }
 
 export function bookBackupsDir(bookId: string): string {
-  return join(backupsRootDir(), bookId);
+  return join(backupsRootDir(), safeSegment(bookId));
 }
 
 /** fs-20 — workspace-level telemetry jail. Per-run resource telemetry (RTF,

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -2830,7 +2830,6 @@ def health() -> dict[str, Any]:
     # Process-wide — a CUDA context is shared by every engine, so poison is not
     # Coqui-specific (a Qwen / Kokoro CUDA error corrupts it just the same).
     poisoned = _process_poisoned
-    poison_reason = _process_poison_reason
     if isinstance(coqui, CoquiEngine):
         model_loaded = coqui._tts is not None
         loading = coqui._loading
@@ -2902,7 +2901,10 @@ def health() -> dict[str, Any]:
         "devices_state": _device_probe_state,
         "device": device,
         "poisoned": poisoned,
-        "poison_reason": poison_reason,
+        # `poison_reason` (raw exception text) is deliberately NOT surfaced here —
+        # it would leak a stack-trace fragment to any /health caller (CodeQL
+        # py/stack-trace-exposure). The trigger lives in the server-side log +
+        # the internal `_process_poison_reason` global only.
         # side-11 item 2 — SOFT recycle signal. `recycle_pending` flips True once
         # committed crosses SIDECAR_RECYCLE_SOFT_MB OR reserved VRAM crosses the
         # VRAM soft ceiling (below either hard ceiling); the generation worker
@@ -3290,13 +3292,15 @@ async def synthesize(req: Request) -> Response:
     # we fail fast and give the Node side a single fatal classification
     # that surfaces a clear "restart the sidecar" banner.
     if _process_poisoned:
+        # The poison trigger (raw exception text) is logged server-side via
+        # _mark_cuda_poisoned's caller; it is NEVER echoed into the response
+        # body (CodeQL py/stack-trace-exposure).
         return JSONResponse(
             {
                 "detail": (
                     "Voice engine is in a poisoned CUDA state from a prior CUDA "
                     "error and must be restarted. A fresh process is being "
                     "respawned automatically; retry once /health responds again."
-                    + (f" (trigger: {_process_poison_reason})" if _process_poison_reason else "")
                 ),
                 "poisoned": True,
             },
@@ -3399,11 +3403,11 @@ async def transcribe(req: Request) -> Response:
     Offloaded to a worker thread like /synthesize so /health stays sub-50 ms
     while a transcribe runs. Honours the same poison + recycle-drain fences."""
     if _process_poisoned:
+        # Trigger text is server-side log only — never echoed to the response.
         return JSONResponse(
             {
                 "detail": (
                     "Voice engine is in a poisoned CUDA state and must be restarted."
-                    + (f" (trigger: {_process_poison_reason})" if _process_poison_reason else "")
                 ),
                 "poisoned": True,
             },
@@ -3500,7 +3504,6 @@ async def synthesize_batch(req: Request) -> Response:
                     "Voice engine is in a poisoned CUDA state from a prior CUDA "
                     "error and must be restarted. A fresh process is being "
                     "respawned automatically; retry once /health responds again."
-                    + (f" (trigger: {_process_poison_reason})" if _process_poison_reason else "")
                 ),
                 "poisoned": True,
             },

--- a/server/tts-sidecar/tests/test_synthesize.py
+++ b/server/tts-sidecar/tests/test_synthesize.py
@@ -9,6 +9,7 @@ the env-var → flag decision tree lives in test_smoke.py's
 test_resolve_runtime_options_* cases."""
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -355,7 +356,11 @@ def test_health_reports_poisoned_flag(monkeypatch) -> None:
     assert r.status_code == 200
     body = r.json()
     assert body["poisoned"] is True
-    assert "device-side assert" in body["poison_reason"]
+    # The raw poison trigger (exception text) must NOT leak into the response —
+    # it lives only in the server-side log + internal global (stack-trace-exposure).
+    assert "poison_reason" not in body
+    assert "device-side assert" not in json.dumps(body)
+    assert "device-side assert" in main._process_poison_reason
 
 
 def test_synthesize_poison_fence_fires_for_non_coqui_engine(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #887. The post-merge CodeQL re-scan left 49 code-fixable alerts open because the path-injection guards used the **side-effect pattern** (`safeSegment(id); join(root, id)`) — which CodeQL does not credit — instead of the **return-value pattern** (`join(root, safeSegment(id))`), the shape CodeQL recognizes (and which `book-state`/`bookDirByDisplay`/`cover-store` already used, so they cleared first time).

This threads the sanitizer's return value into each join, fixing the central `protocol.ts`/`paths.ts` builders so the `ollama.ts`/`gemini.ts` callers cascade-clear. Also: a **linear two-pointer `stripEdges`** replaces the `[...]+$` trims (genuinely polynomial), a `Math.min(ms, 60_000)` clamp on the gemini `sleep`, and the 4 sidecar stack-trace sites the first pass missed (the CUDA-poison-reason leaking into `/health` + 3 poison-fence bodies).

The 16 genuine-dismissal alerts (state-io/atomic-rename composed paths, text.ts filename ReDoS, 4 cover `<img src>`, audio-tags loop) were dismissed by number with justifications linking `docs/security/codeql-dismissal-residue.md`.

## Test plan
- `npm run verify` green at pre-push.
- server 2956 · server-slow 240 · sidecar 22 (incl. updated poison/health + source-grep tests).

## Post-merge
Re-scan `gh workflow run codeql.yml --ref main` → expect **0 open** (49 cleared here + 16 already dismissed).

Refs #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)