### PR TITLE
fix(server): assert path containment at sinks (CodeQL barrier, re-scan round 3)

### DIFF
--- a/server/src/analyzer/gemini.ts
+++ b/server/src/analyzer/gemini.ts
@@ -683,11 +683,14 @@ function describeStatus(err: unknown): string {
    structured `error: aborted` event the UI uses to distinguish pause
    from a real failure. */
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  /* Bind the clamp to a const that feeds setTimeout directly so the bound is
+     provable at the sink (js/resource-exhaustion barrier). */
+  const delay = Math.min(ms, 60_000);
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
       signal?.removeEventListener('abort', onAbort);
       resolve();
-    }, Math.min(ms, 60_000));
+    }, delay);
     const onAbort = () => {
       clearTimeout(timer);
       reject(new AnalysisAbortedError('Aborted during gemini retry backoff.'));

--- a/server/src/handoff/protocol.ts
+++ b/server/src/handoff/protocol.ts
@@ -8,7 +8,7 @@
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { safeSegment } from '../util/safe-path.js';
+import { safeSegment, assertContained } from '../util/safe-path.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const HANDOFF_ROOT = resolve(__dirname, '..', '..', 'handoff');
@@ -33,15 +33,21 @@ async function ensureDirs(): Promise<void> {
 }
 
 export function inboxPath(manuscriptId: string, key: HandoffKey): string {
-  return join(INBOX, `${safeSegment(manuscriptId)}-stage${key}.md`);
+  const p = join(INBOX, `${safeSegment(manuscriptId)}-stage${key}.md`);
+  assertContained(INBOX, p);
+  return p;
 }
 
 export function outboxPath(manuscriptId: string, key: HandoffKey): string {
-  return join(OUTBOX, `${safeSegment(manuscriptId)}-stage${key}.json`);
+  const p = join(OUTBOX, `${safeSegment(manuscriptId)}-stage${key}.json`);
+  assertContained(OUTBOX, p);
+  return p;
 }
 
 export function errorPath(manuscriptId: string, key: HandoffKey): string {
-  return join(OUTBOX, `${safeSegment(manuscriptId)}-stage${key}.errors.json`);
+  const p = join(OUTBOX, `${safeSegment(manuscriptId)}-stage${key}.errors.json`);
+  assertContained(OUTBOX, p);
+  return p;
 }
 
 /* Forensic record of a model response that failed parse/validation. Lives
@@ -51,7 +57,9 @@ export function errorPath(manuscriptId: string, key: HandoffKey): string {
    they fail, so a partial-success retry preserves the first attempt's text
    for comparison. */
 export function rawAttemptPath(manuscriptId: string, key: HandoffKey, attempt: 1 | 2): string {
-  return join(OUTBOX, `${safeSegment(manuscriptId)}-stage${key}.attempt${attempt}.raw.txt`);
+  const p = join(OUTBOX, `${safeSegment(manuscriptId)}-stage${key}.attempt${attempt}.raw.txt`);
+  assertContained(OUTBOX, p);
+  return p;
 }
 
 export async function writeInbox(

--- a/server/src/routes/qwen-voice.ts
+++ b/server/src/routes/qwen-voice.ts
@@ -32,7 +32,7 @@ import { join } from 'node:path';
 import { findBookByBookId, bookStateLanguage } from '../workspace/scan.js';
 import { sidecarLanguageName } from '../tts/language.js';
 import { castJsonPath, qwenVoiceSidecarPath, qwenVoicesDir } from '../workspace/paths.js';
-import { safeSegment } from '../util/safe-path.js';
+import { safeSegment, assertContained } from '../util/safe-path.js';
 import { readJson, writeJsonAtomic } from '../workspace/state-io.js';
 import { EMOTIONS, type Emotion } from '../handoff/schemas.js';
 import { getResolvedSidecarUrl } from '../workspace/user-settings.js';
@@ -182,7 +182,9 @@ function previewVoiceIdFor(realVoiceId: string): string {
   return `${realVoiceId}${PREVIEW_SUFFIX}`;
 }
 export function qwenVoicePtPath(name: string): string {
-  return join(qwenVoicesDir(), `${safeSegment(name)}.pt`);
+  const p = join(qwenVoicesDir(), `${safeSegment(name)}.pt`);
+  assertContained(qwenVoicesDir(), p);
+  return p;
 }
 
 /* GET /api/books/:bookId/cast/:characterId/designed-persona

--- a/server/src/routes/samples.ts
+++ b/server/src/routes/samples.ts
@@ -12,7 +12,7 @@ import { readFile, mkdir, copyFile, readdir } from 'node:fs/promises';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { nanoid } from 'nanoid';
-import { safeSegment } from '../util/safe-path.js';
+import { safeSegment, assertContained } from '../util/safe-path.js';
 import {
   WORKSPACE_ROOT,
   bookDirByDisplay,
@@ -52,6 +52,7 @@ samplesRouter.post('/:slug/load', async (req: Request, res: Response) => {
     let src: string;
     try {
       src = join(SAMPLES_ROOT, safeSegment(slug));
+      assertContained(SAMPLES_ROOT, src);
     } catch {
       return res.status(400).json({ error: 'Invalid sample slug.' });
     }
@@ -79,12 +80,20 @@ samplesRouter.post('/:slug/load', async (req: Request, res: Response) => {
     await mkdir(dotAudiobook(bookDir), { recursive: true });
 
     // 1. Manuscript.
-    await copyFile(join(src, safeManuscriptFile), join(bookDir, safeManuscriptFile));
+    const srcManuscript = join(src, safeManuscriptFile);
+    const dstManuscript = join(bookDir, safeManuscriptFile);
+    assertContained(src, srcManuscript);
+    assertContained(bookDir, dstManuscript);
+    await copyFile(srcManuscript, dstManuscript);
 
     // 2. .audiobook/{cast,manuscript-edits}.
     for (const f of ['cast.json', 'manuscript-edits.json']) {
-      if (existsSync(join(src, '.audiobook', f))) {
-        await copyFile(join(src, '.audiobook', f), join(dotAudiobook(bookDir), f));
+      const srcAudiobookFile = join(src, '.audiobook', f);
+      assertContained(src, srcAudiobookFile);
+      if (existsSync(srcAudiobookFile)) {
+        const dstAudiobookFile = join(dotAudiobook(bookDir), f);
+        assertContained(bookDir, dstAudiobookFile);
+        await copyFile(srcAudiobookFile, dstAudiobookFile);
       }
     }
 
@@ -102,22 +111,27 @@ samplesRouter.post('/:slug/load', async (req: Request, res: Response) => {
 
     // 4. Merge bundle voices into workspace voices/qwen (no clobber).
     const srcVoices = join(src, 'voices', 'qwen');
+    assertContained(src, srcVoices);
     if (existsSync(srcVoices)) {
       const dstVoices = join(WORKSPACE_ROOT, 'voices', 'qwen');
       await mkdir(dstVoices, { recursive: true });
       for (const f of await readdir(srcVoices)) {
-        if (!existsSync(join(dstVoices, f))) {
-          await copyFile(join(srcVoices, f), join(dstVoices, f));
+        const srcVoiceFile = join(srcVoices, safeSegment(f));
+        const dstVoiceFile = join(dstVoices, safeSegment(f));
+        assertContained(srcVoices, srcVoiceFile);
+        assertContained(dstVoices, dstVoiceFile);
+        if (!existsSync(dstVoiceFile)) {
+          await copyFile(srcVoiceFile, dstVoiceFile);
         }
       }
     }
 
     // 5. Register the ManuscriptRecord so the analysis/generation pipeline is wired.
-    const buffer = await readFile(join(bookDir, safeManuscriptFile));
+    const buffer = await readFile(dstManuscript);
     const parsed = await parseManuscript({
       buffer,
       fileName: safeManuscriptFile,
-      sourcePath: join(bookDir, safeManuscriptFile),
+      sourcePath: dstManuscript,
     });
     const record: ManuscriptRecord = {
       manuscriptId,

--- a/server/src/store/analysis-cache.ts
+++ b/server/src/store/analysis-cache.ts
@@ -12,7 +12,7 @@ import { fileURLToPath } from 'node:url';
 import type { CharacterOutput, SentenceOutput, Stage1Output } from '../handoff/schemas.js';
 import { extractInlineEmotion } from '../handoff/emotion-from-tags.js';
 import { readJson, writeJsonAtomic } from '../workspace/state-io.js';
-import { safeSegment } from '../util/safe-path.js';
+import { safeSegment, assertContained } from '../util/safe-path.js';
 
 /* fs-25 — absorb any legacy inline audio-tag in a freshly-analysed sentence
    into the structured `emotion` field and strip the bracket from the stored
@@ -110,7 +110,9 @@ export interface AnalysisCache {
 }
 
 export function cachePath(manuscriptId: string): string {
-  return join(CACHE_DIR, `${safeSegment(manuscriptId)}.json`);
+  const p = join(CACHE_DIR, `${safeSegment(manuscriptId)}.json`);
+  assertContained(CACHE_DIR, p);
+  return p;
 }
 
 export async function loadAnalysisCache(manuscriptId: string): Promise<AnalysisCache> {

--- a/server/src/tts/voice-sample-cache.ts
+++ b/server/src/tts/voice-sample-cache.ts
@@ -14,6 +14,7 @@ import { fileURLToPath } from 'node:url';
 import type { TtsModelKey } from './index.js';
 import type { CharacterHint, VoiceLike } from './voice-mapping.js';
 import { stripEdges } from '../util/text-match.js';
+import { assertContained } from '../util/safe-path.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -124,5 +125,7 @@ export function voiceSamplePublicUrl(fileName: string): string {
 
 /* Absolute on-disk path for a cached sample file. */
 export function voiceSampleFilePath(fileName: string): string {
-  return resolve(voiceSampleAudioDir(), fileName);
+  const p = resolve(voiceSampleAudioDir(), fileName);
+  assertContained(voiceSampleAudioDir(), p);
+  return p;
 }

--- a/server/src/workspace/auto-backup.ts
+++ b/server/src/workspace/auto-backup.ts
@@ -18,7 +18,7 @@ import { mkdir, readdir, readFile, stat, unlink } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { BOOKS_ROOT, bookBackupsDir, stateJsonPath } from './paths.js';
-import { safeSegment } from '../util/safe-path.js';
+import { safeSegment, assertContained } from '../util/safe-path.js';
 import { findBookByBookId } from './scan.js';
 import { writeJsonAtomic } from './state-io.js';
 import { getResolvedBackupConfig } from './user-settings.js';
@@ -52,7 +52,9 @@ export async function listBackups(bookId: string): Promise<BackupSnapshot[]> {
   const names = (await readdir(dir)).filter((n) => STAMP_RE.test(n));
   const out: BackupSnapshot[] = [];
   for (const file of names) {
-    const s = await stat(join(dir, safeSegment(file)));
+    const snap = join(dir, safeSegment(file));
+    assertContained(dir, snap);
+    const s = await stat(snap);
     out.push({ file, sizeBytes: s.size, createdAt: s.mtime.toISOString() });
   }
   /* Zero-padded stamp ⇒ filename sort is chronological; newest first. */
@@ -67,7 +69,9 @@ export async function pruneBackups(bookId: string, keep: number): Promise<number
   const stale = (await listBackups(bookId)).slice(keep); // newest-first
   const dir = bookBackupsDir(bookId);
   for (const s of stale) {
-    await unlink(join(dir, safeSegment(s.file))).catch(() => {});
+    const snap = join(dir, safeSegment(s.file));
+    assertContained(dir, snap);
+    await unlink(snap).catch(() => {});
   }
   return stale.length;
 }
@@ -115,7 +119,9 @@ export async function backupBook(
   const dir = bookBackupsDir(book.bookId);
   await mkdir(dir, { recursive: true });
   const file = `${backupStamp(opts.now)}.json`;
-  await writeJsonAtomic(join(dir, file), value);
+  const snap = join(dir, safeSegment(file));
+  assertContained(dir, snap);
+  await writeJsonAtomic(snap, value);
   await pruneBackups(book.bookId, opts.keep);
   return file;
 }
@@ -195,7 +201,9 @@ export async function restoreBackup(bookId: string, file: string): Promise<void>
   const found = await findBookByBookId(bookId);
   if (!found) throw new BackupRestoreError('book not found');
   const bookDir = found.bookDir;
-  const snapPath = join(bookBackupsDir(bookId), safeSegment(file));
+  const backupsDir = bookBackupsDir(bookId);
+  const snapPath = join(backupsDir, safeSegment(file));
+  assertContained(backupsDir, snapPath);
   if (!existsSync(snapPath)) throw new BackupRestoreError('backup not found');
   const raw = await readFile(snapPath, 'utf8');
   let value: unknown;

--- a/server/src/workspace/paths.ts
+++ b/server/src/workspace/paths.ts
@@ -238,7 +238,9 @@ export function qwenVoicesDir(): string {
 /** Path to a single designed Qwen voice's JSON sidecar (its `instruct`
     persona + ref text). `name` is the designed voiceId, e.g. `qwen-wren`. */
 export function qwenVoiceSidecarPath(name: string): string {
-  return join(qwenVoicesDir(), `${safeSegment(name)}.json`);
+  const p = join(qwenVoicesDir(), `${safeSegment(name)}.json`);
+  assertContained(qwenVoicesDir(), p);
+  return p;
 }
 
 /** Plan 102 — workspace-level chapter-generation queue. ONE file holds the
@@ -268,7 +270,9 @@ export function backupsRootDir(): string {
 }
 
 export function bookBackupsDir(bookId: string): string {
-  return join(backupsRootDir(), safeSegment(bookId));
+  const p = join(backupsRootDir(), safeSegment(bookId));
+  assertContained(backupsRootDir(), p);
+  return p;
 }
 
 /** fs-20 — workspace-level telemetry jail. Per-run resource telemetry (RTF,


### PR DESCRIPTION
## Summary

Final follow-up to #887/#889. Two re-scans proved that `safeSegment` (a regex validator) is **not** a CodeQL-recognized path-injection sanitizer in any position, while `assertContained` (`path.relative(root, x).startsWith('..')` — the `RelativePathStartsWithSanitizer`) **is**, and propagates from a builder to its callers (as `bookDirByDisplay`→`import.ts` demonstrated).

This adds `assertContained(root, composedPath)` at every remaining flagged sink — in the central builders (`protocol.ts` inbox/outbox/error/rawAttempt, `qwenVoicePtPath`/`qwenVoiceSidecarPath`, `cachePath`, `voiceSampleFilePath`, `bookBackupsDir`) so their callers cascade-clear, and inline in the `samples.ts`/`auto-backup.ts` handlers. `safeSegment` stays as belt-and-suspenders. Also binds the gemini `sleep` clamp to a const the `setTimeout` consumes.

## Test plan
- `npm run verify` green at pre-push.
- typecheck clean; server 2947+ · server-slow 240 · targeted suites green.

## Post-merge
Re-scan → expect **0 open** (42 cleared here; 16 already dismissed with justification).

Refs #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)