### PR TITLE
fix(server): transforming id sanitizer at path sinks (CodeQL re-scan round 4)

### DIFF
--- a/server/src/handoff/protocol.ts
+++ b/server/src/handoff/protocol.ts
@@ -8,7 +8,7 @@
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { safeSegment, assertContained } from '../util/safe-path.js';
+import { safeSegment, assertContained, sanitizeIdSegment } from '../util/safe-path.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const HANDOFF_ROOT = resolve(__dirname, '..', '..', 'handoff');
@@ -33,19 +33,19 @@ async function ensureDirs(): Promise<void> {
 }
 
 export function inboxPath(manuscriptId: string, key: HandoffKey): string {
-  const p = join(INBOX, `${safeSegment(manuscriptId)}-stage${key}.md`);
+  const p = join(INBOX, `${sanitizeIdSegment(safeSegment(manuscriptId))}-stage${key}.md`);
   assertContained(INBOX, p);
   return p;
 }
 
 export function outboxPath(manuscriptId: string, key: HandoffKey): string {
-  const p = join(OUTBOX, `${safeSegment(manuscriptId)}-stage${key}.json`);
+  const p = join(OUTBOX, `${sanitizeIdSegment(safeSegment(manuscriptId))}-stage${key}.json`);
   assertContained(OUTBOX, p);
   return p;
 }
 
 export function errorPath(manuscriptId: string, key: HandoffKey): string {
-  const p = join(OUTBOX, `${safeSegment(manuscriptId)}-stage${key}.errors.json`);
+  const p = join(OUTBOX, `${sanitizeIdSegment(safeSegment(manuscriptId))}-stage${key}.errors.json`);
   assertContained(OUTBOX, p);
   return p;
 }
@@ -57,7 +57,7 @@ export function errorPath(manuscriptId: string, key: HandoffKey): string {
    they fail, so a partial-success retry preserves the first attempt's text
    for comparison. */
 export function rawAttemptPath(manuscriptId: string, key: HandoffKey, attempt: 1 | 2): string {
-  const p = join(OUTBOX, `${safeSegment(manuscriptId)}-stage${key}.attempt${attempt}.raw.txt`);
+  const p = join(OUTBOX, `${sanitizeIdSegment(safeSegment(manuscriptId))}-stage${key}.attempt${attempt}.raw.txt`);
   assertContained(OUTBOX, p);
   return p;
 }

--- a/server/src/routes/qwen-voice.ts
+++ b/server/src/routes/qwen-voice.ts
@@ -32,7 +32,7 @@ import { join } from 'node:path';
 import { findBookByBookId, bookStateLanguage } from '../workspace/scan.js';
 import { sidecarLanguageName } from '../tts/language.js';
 import { castJsonPath, qwenVoiceSidecarPath, qwenVoicesDir } from '../workspace/paths.js';
-import { safeSegment, assertContained } from '../util/safe-path.js';
+import { safeSegment, assertContained, sanitizeIdSegment } from '../util/safe-path.js';
 import { readJson, writeJsonAtomic } from '../workspace/state-io.js';
 import { EMOTIONS, type Emotion } from '../handoff/schemas.js';
 import { getResolvedSidecarUrl } from '../workspace/user-settings.js';
@@ -182,7 +182,7 @@ function previewVoiceIdFor(realVoiceId: string): string {
   return `${realVoiceId}${PREVIEW_SUFFIX}`;
 }
 export function qwenVoicePtPath(name: string): string {
-  const p = join(qwenVoicesDir(), `${safeSegment(name)}.pt`);
+  const p = join(qwenVoicesDir(), `${sanitizeIdSegment(safeSegment(name))}.pt`);
   assertContained(qwenVoicesDir(), p);
   return p;
 }

--- a/server/src/routes/samples.ts
+++ b/server/src/routes/samples.ts
@@ -12,7 +12,7 @@ import { readFile, mkdir, copyFile, readdir } from 'node:fs/promises';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { nanoid } from 'nanoid';
-import { safeSegment, assertContained } from '../util/safe-path.js';
+import { safeSegment, assertContained, sanitizeIdSegment } from '../util/safe-path.js';
 import {
   WORKSPACE_ROOT,
   bookDirByDisplay,
@@ -51,7 +51,7 @@ samplesRouter.post('/:slug/load', async (req: Request, res: Response) => {
     const slug = req.params.slug;
     let src: string;
     try {
-      src = join(SAMPLES_ROOT, safeSegment(slug));
+      src = join(SAMPLES_ROOT, sanitizeIdSegment(safeSegment(slug)));
       assertContained(SAMPLES_ROOT, src);
     } catch {
       return res.status(400).json({ error: 'Invalid sample slug.' });
@@ -65,7 +65,7 @@ samplesRouter.post('/:slug/load', async (req: Request, res: Response) => {
     const { author, series, title, manuscriptFile } = bundleState;
     let safeManuscriptFile: string;
     try {
-      safeManuscriptFile = safeSegment(manuscriptFile);
+      safeManuscriptFile = sanitizeIdSegment(safeSegment(manuscriptFile));
     } catch {
       return res.status(400).json({ error: 'Invalid bundle manuscript file.' });
     }
@@ -116,8 +116,8 @@ samplesRouter.post('/:slug/load', async (req: Request, res: Response) => {
       const dstVoices = join(WORKSPACE_ROOT, 'voices', 'qwen');
       await mkdir(dstVoices, { recursive: true });
       for (const f of await readdir(srcVoices)) {
-        const srcVoiceFile = join(srcVoices, safeSegment(f));
-        const dstVoiceFile = join(dstVoices, safeSegment(f));
+        const srcVoiceFile = join(srcVoices, sanitizeIdSegment(safeSegment(f)));
+        const dstVoiceFile = join(dstVoices, sanitizeIdSegment(safeSegment(f)));
         assertContained(srcVoices, srcVoiceFile);
         assertContained(dstVoices, dstVoiceFile);
         if (!existsSync(dstVoiceFile)) {

--- a/server/src/store/analysis-cache.ts
+++ b/server/src/store/analysis-cache.ts
@@ -12,7 +12,7 @@ import { fileURLToPath } from 'node:url';
 import type { CharacterOutput, SentenceOutput, Stage1Output } from '../handoff/schemas.js';
 import { extractInlineEmotion } from '../handoff/emotion-from-tags.js';
 import { readJson, writeJsonAtomic } from '../workspace/state-io.js';
-import { safeSegment, assertContained } from '../util/safe-path.js';
+import { safeSegment, assertContained, sanitizeIdSegment } from '../util/safe-path.js';
 
 /* fs-25 — absorb any legacy inline audio-tag in a freshly-analysed sentence
    into the structured `emotion` field and strip the bracket from the stored
@@ -110,7 +110,7 @@ export interface AnalysisCache {
 }
 
 export function cachePath(manuscriptId: string): string {
-  const p = join(CACHE_DIR, `${safeSegment(manuscriptId)}.json`);
+  const p = join(CACHE_DIR, `${sanitizeIdSegment(safeSegment(manuscriptId))}.json`);
   assertContained(CACHE_DIR, p);
   return p;
 }

--- a/server/src/tts/voice-sample-cache.ts
+++ b/server/src/tts/voice-sample-cache.ts
@@ -14,7 +14,7 @@ import { fileURLToPath } from 'node:url';
 import type { TtsModelKey } from './index.js';
 import type { CharacterHint, VoiceLike } from './voice-mapping.js';
 import { stripEdges } from '../util/text-match.js';
-import { assertContained } from '../util/safe-path.js';
+import { assertContained, sanitizeIdSegment } from '../util/safe-path.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -125,7 +125,7 @@ export function voiceSamplePublicUrl(fileName: string): string {
 
 /* Absolute on-disk path for a cached sample file. */
 export function voiceSampleFilePath(fileName: string): string {
-  const p = resolve(voiceSampleAudioDir(), fileName);
+  const p = resolve(voiceSampleAudioDir(), sanitizeIdSegment(fileName));
   assertContained(voiceSampleAudioDir(), p);
   return p;
 }

--- a/server/src/util/safe-path.ts
+++ b/server/src/util/safe-path.ts
@@ -25,6 +25,19 @@ export function safeSegment(seg: string): string {
   return seg;
 }
 
+/** TRANSFORMING sanitizer for an id used as a single path segment. Unlike the
+    validating `safeSegment` (which throws), this REPLACES path separators / NUL
+    and collapses any `..` run, so the RETURN VALUE is a guaranteed-contained
+    component. CodeQL models a separator/`..`-stripping `.replace()` as a path
+    sanitizer and — crucially — propagates it across function boundaries (a
+    throwing guard does not), so wrapping an id in `sanitizeIdSegment(...)` inside
+    a path builder clears that builder's callers too. Legitimate ids (slugs,
+    nanoids, `qwen-<id>`, Cyrillic) contain none of these, so they pass through
+    unchanged. */
+export function sanitizeIdSegment(seg: string): string {
+  return seg.replace(/[/\\\x00]/g, '_').replace(/\.\.+/g, '_');
+}
+
 /** Throw unless `resolved` is inside `root`. CodeQL-recognized barrier
     (RelativePathStartsWithSanitizer) — keep the raw relative string. */
 export function assertContained(root: string, resolved: string): void {

--- a/server/src/workspace/auto-backup.ts
+++ b/server/src/workspace/auto-backup.ts
@@ -18,7 +18,7 @@ import { mkdir, readdir, readFile, stat, unlink } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { BOOKS_ROOT, bookBackupsDir, stateJsonPath } from './paths.js';
-import { safeSegment, assertContained } from '../util/safe-path.js';
+import { safeSegment, assertContained, sanitizeIdSegment } from '../util/safe-path.js';
 import { findBookByBookId } from './scan.js';
 import { writeJsonAtomic } from './state-io.js';
 import { getResolvedBackupConfig } from './user-settings.js';
@@ -52,7 +52,7 @@ export async function listBackups(bookId: string): Promise<BackupSnapshot[]> {
   const names = (await readdir(dir)).filter((n) => STAMP_RE.test(n));
   const out: BackupSnapshot[] = [];
   for (const file of names) {
-    const snap = join(dir, safeSegment(file));
+    const snap = join(dir, sanitizeIdSegment(safeSegment(file)));
     assertContained(dir, snap);
     const s = await stat(snap);
     out.push({ file, sizeBytes: s.size, createdAt: s.mtime.toISOString() });
@@ -69,7 +69,7 @@ export async function pruneBackups(bookId: string, keep: number): Promise<number
   const stale = (await listBackups(bookId)).slice(keep); // newest-first
   const dir = bookBackupsDir(bookId);
   for (const s of stale) {
-    const snap = join(dir, safeSegment(s.file));
+    const snap = join(dir, sanitizeIdSegment(safeSegment(s.file)));
     assertContained(dir, snap);
     await unlink(snap).catch(() => {});
   }
@@ -119,7 +119,7 @@ export async function backupBook(
   const dir = bookBackupsDir(book.bookId);
   await mkdir(dir, { recursive: true });
   const file = `${backupStamp(opts.now)}.json`;
-  const snap = join(dir, safeSegment(file));
+  const snap = join(dir, sanitizeIdSegment(safeSegment(file)));
   assertContained(dir, snap);
   await writeJsonAtomic(snap, value);
   await pruneBackups(book.bookId, opts.keep);
@@ -202,7 +202,7 @@ export async function restoreBackup(bookId: string, file: string): Promise<void>
   if (!found) throw new BackupRestoreError('book not found');
   const bookDir = found.bookDir;
   const backupsDir = bookBackupsDir(bookId);
-  const snapPath = join(backupsDir, safeSegment(file));
+  const snapPath = join(backupsDir, sanitizeIdSegment(safeSegment(file)));
   assertContained(backupsDir, snapPath);
   if (!existsSync(snapPath)) throw new BackupRestoreError('backup not found');
   const raw = await readFile(snapPath, 'utf8');

--- a/server/src/workspace/paths.ts
+++ b/server/src/workspace/paths.ts
@@ -9,7 +9,7 @@ import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { unicodeKebab } from '../util/safe-id.js';
-import { safeSegment, assertContained } from '../util/safe-path.js';
+import { safeSegment, assertContained, sanitizeIdSegment } from '../util/safe-path.js';
 import { stripEdges } from '../util/text-match.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -238,7 +238,7 @@ export function qwenVoicesDir(): string {
 /** Path to a single designed Qwen voice's JSON sidecar (its `instruct`
     persona + ref text). `name` is the designed voiceId, e.g. `qwen-wren`. */
 export function qwenVoiceSidecarPath(name: string): string {
-  const p = join(qwenVoicesDir(), `${safeSegment(name)}.json`);
+  const p = join(qwenVoicesDir(), `${sanitizeIdSegment(safeSegment(name))}.json`);
   assertContained(qwenVoicesDir(), p);
   return p;
 }
@@ -270,7 +270,7 @@ export function backupsRootDir(): string {
 }
 
 export function bookBackupsDir(bookId: string): string {
-  const p = join(backupsRootDir(), safeSegment(bookId));
+  const p = join(backupsRootDir(), sanitizeIdSegment(safeSegment(bookId)));
   assertContained(backupsRootDir(), p);
   return p;
 }


### PR DESCRIPTION
## Summary

Final follow-up. Three re-scans isolated the mechanism precisely: CodeQL propagates a **transforming `.replace()` sanitizer** across the builder→caller boundary (as `bookDirByDisplay`'s `sanitizeDisplaySegment` did), but a **throwing validator** (`safeSegment`) or an **in-function guard** (`assertContained`) only sanitizes within its own function.

This adds `sanitizeIdSegment(seg)` (strips path separators/NUL, collapses `..` — a no-op on legitimate slug/nanoid/`qwen-<id>` ids) and wraps it inside the join at every central path builder (`protocol.ts` ×4, `qwenVoicePtPath`/`qwenVoiceSidecarPath`, `cachePath`, `voiceSampleFilePath`, `bookBackupsDir`) and the `samples.ts`/`auto-backup.ts` inline sinks — so the builders' callers (`ollama`/`gemini`/`qwen-voice`/`voice-sample`) cascade-clear. `safeSegment`/`assertContained` stay as belt-and-suspenders.

## Test plan
- `npm run verify` green at pre-push. typecheck clean; server 2956 · server-slow 240; transform is a no-op on all legit ids (no test value changed).

## Post-merge
Re-scan → expect 0 open (the final 42 path-injection + the gemini resource alert; 16 already dismissed).

Refs #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)