### PR TITLE
docs(docs): retire srv-22 backlog row + mark CodeQL spec shipped

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -355,12 +355,6 @@ Source for the whole sub-group: the [2026-05-31 security review](security/2026-0
 - _Benefit (technical):_ removes a local RCE-on-untrusted-file footgun; aligns with torch's `weights_only` default direction.
 _Full detail + acceptance:_ [#428](https://github.com/dudarenok-maker/AudioBook-Generator/issues/428).
 
-#### `srv-22` — Constrain / document the `sync-folder/test` write-probe path ([#427](https://github.com/dudarenok-maker/AudioBook-Generator/issues/427))
-
-- _What:_ the probe is a legitimate "is this folder writable" UX check, so the fix is proportionate: keep the feature but (a) refuse obviously-dangerous targets (system roots), and/or (b) document the trust boundary explicitly and lean on `srv-19`/`srv-20` to remove the unauth-LAN reachability. Decide between hard-constraint vs. document-and-gate when the item opens.
-- _Benefit (technical):_ removes a small unauthenticated filesystem-touch primitive without breaking the Test button.
-_Full detail + acceptance:_ [#427](https://github.com/dudarenok-maker/AudioBook-Generator/issues/427).
-
 ### Ops, CI & distribution
 
 #### `fe-1` — In-app LAN HTTPS banner under dev settings ([#401](https://github.com/dudarenok-maker/AudioBook-Generator/issues/401))

--- a/docs/superpowers/specs/2026-06-17-codeql-remediation-design.md
+++ b/docs/superpowers/specs/2026-06-17-codeql-remediation-design.md
@@ -2,9 +2,18 @@
 
 **Date:** 2026-06-17
 **Branch:** `fix/security-codeql-remediation`
-**Status:** draft
+**Status:** stable — **SHIPPED 2026-06-18** (fs-46 #886, srv-22 #427).
 **Disposition chosen:** Maximal / defense-in-depth (drive open alerts to ~0 + real
 hardening of the genuine LAN-exposed surface)
+
+> **Ship notes (2026-06-18):** 146 → **0 open** (149 fixed in code, 17 dismissed with
+> justification). Merged to `main` via PRs **#887** (`Closes #886`/`Closes #427`),
+> **#889**, **#890**, **#891**. Key correction the re-scan loop surfaced: CodeQL
+> `js/path-injection` only propagates a **transforming `.replace()` sanitizer**
+> (`sanitizeIdSegment` in `server/src/util/safe-path.ts`) across the builder→caller
+> boundary — a throwing validator (`safeSegment`) or an in-function guard
+> (`assertContained`) sanitizes only its own function. Dismissal rationale:
+> `docs/security/codeql-dismissal-residue.md`.
 
 > **Revised twice after two adversarial-review passes** (six reviews total:
 > CodeQL-efficacy ×2, correctness/regression ×2, threat-model, spec-consistency).


### PR DESCRIPTION
Post-ship backlog/plan hygiene for the CodeQL remediation (fs-46): removes the delivered srv-22 (#427) row from `docs/BACKLOG.md` per the ship-a-backlog-item convention, and moves the remediation spec from `draft` → `stable` with ship notes (146→0 open; PRs #887/#889/#890/#891).

Refs #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)