### PR TITLE
feat(app): player-screen listening cues — auto-scroll, finished check, chapter label

### DIFF
--- a/apps/android/lib/src/data/drift_local_library.dart
+++ b/apps/android/lib/src/data/drift_local_library.dart
@@ -296,6 +296,15 @@ class DriftLocalLibrary implements LocalLibrary, PlaybackStore, ThumbnailStore {
         .write(ChaptersCompanion(finished: Value(finished)));
   }
 
+  /// The uuids of [bookId]'s chapters the user has played to the end
+  /// (the persisted `finished` flag). Drives the chapter-list "done" check.
+  Future<Set<String>> finishedChapterUuids(String bookId) async {
+    final rows = await (_db.select(_db.chapters)
+          ..where((c) => c.bookId.equals(bookId) & c.finished.equals(true)))
+        .get();
+    return {for (final r in rows) r.uuid};
+  }
+
   /// Apply a [planStorageEviction] result: drop finished chapter files (keep the
   /// row, clear fingerprint + bytes) and evict whole books.
   Future<void> applyEviction(EvictionPlan plan) async {

--- a/apps/android/lib/src/domain/chapter_scroll.dart
+++ b/apps/android/lib/src/domain/chapter_scroll.dart
@@ -1,0 +1,15 @@
+/// Pixel offset to scroll a fixed-row chapter list so [index] sits near the top
+/// with [contextRows] rows still visible above it, clamped to `[0, maxExtent]`.
+/// Pure so the player screen's auto-scroll math is testable without a widget
+/// tree; the row height is an estimate (rows are near-uniform), so this brings
+/// the current chapter into view rather than pixel-aligning it.
+double chapterScrollOffset({
+  required int index,
+  required double rowHeight,
+  double contextRows = 1,
+  required double maxExtent,
+}) {
+  final raw = (index - contextRows) * rowHeight;
+  if (raw <= 0) return 0;
+  return raw > maxExtent ? maxExtent : raw;
+}

--- a/apps/android/lib/src/ui/player_screen.dart
+++ b/apps/android/lib/src/ui/player_screen.dart
@@ -130,6 +130,17 @@ class _PlayerScreenState extends State<PlayerScreen> {
 
   bool _isFinished(String uuid) => _finished.contains(uuid);
 
+  /// `Ch. <id> · <title>` for the loaded chapter, or empty when none.
+  String _currentChapterLabel(PlayerController player) {
+    final uuid = player.currentChapterUuid;
+    if (uuid == null) return '';
+    final match = _chapters.where((c) => c.uuid == uuid);
+    if (match.isEmpty) return '';
+    final c = match.first;
+    final title = c.title.isEmpty ? 'Chapter ${c.id}' : c.title;
+    return 'Ch. ${c.id} · $title';
+  }
+
   String _fmt(Duration d) {
     final h = d.inHours;
     final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
@@ -249,6 +260,19 @@ class _PlayerScreenState extends State<PlayerScreen> {
                 return Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 2, 16, 4),
+                      child: Align(
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          _currentChapterLabel(player),
+                          key: const Key('player-current-chapter'),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.titleSmall,
+                        ),
+                      ),
+                    ),
                     Builder(builder: (context) {
                       final uuid = player.currentChapterUuid;
                       final peaks = uuid != null ? _peaks[uuid] : null;

--- a/apps/android/lib/src/ui/player_screen.dart
+++ b/apps/android/lib/src/ui/player_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../data/companion_runtime.dart';
@@ -31,6 +33,8 @@ class _PlayerScreenState extends State<PlayerScreen> {
   bool _playing = false;
   String? _error;
   List<SyncManifestChapter> _chapters = const [];
+  Set<String> _finished = {};
+  final List<StreamSubscription<Object?>> _subs = [];
   final Map<String, List<double>> _peaks = {}; // chapter uuid -> RMS peaks
 
   /// Fetch + cache a chapter's waveform peaks. Local-first (survives offline +
@@ -70,13 +74,25 @@ class _PlayerScreenState extends State<PlayerScreen> {
       await widget.runtime.player.openBook(widget.bookId,
           bookTitle: widget.title, artPath: art); // loads + restores resume
       // feeds the lock-screen/notification metadata via nowPlayingStream
+      final chapters = widget.runtime.sync.chaptersOf(widget.bookId);
+      final finished =
+          await widget.runtime.library.finishedChapterUuids(widget.bookId);
       if (mounted) {
         setState(() {
-          _chapters = widget.runtime.sync.chaptersOf(widget.bookId);
+          _chapters = chapters;
+          _finished = finished;
           _ready = true;
         });
         _ensureCurrentPeaks();
       }
+      // Move the highlight + progress as chapters change (incl. auto-advance).
+      _subs.add(widget.runtime.player.nowPlayingStream.listen((_) {
+        if (mounted) setState(() {});
+      }));
+      // Tick a chapter to "done" the moment it finishes, no reopen needed.
+      _subs.add(widget.runtime.player.chapterCompletedStream.listen((uuid) {
+        if (mounted) setState(() => _finished = {..._finished, uuid});
+      }));
     } catch (e) {
       if (mounted) setState(() => _error = '$e');
     }
@@ -84,6 +100,9 @@ class _PlayerScreenState extends State<PlayerScreen> {
 
   @override
   void dispose() {
+    for (final s in _subs) {
+      s.cancel();
+    }
     // Save locally, then push the latest position to the server (app-6),
     // best-effort + offline-safe.
     widget.runtime.player
@@ -108,6 +127,8 @@ class _PlayerScreenState extends State<PlayerScreen> {
     }
     if (mounted) setState(() => _playing = !_playing);
   }
+
+  bool _isFinished(String uuid) => _finished.contains(uuid);
 
   String _fmt(Duration d) {
     final h = d.inHours;
@@ -146,20 +167,39 @@ class _PlayerScreenState extends State<PlayerScreen> {
               itemBuilder: (_, i) {
                 final c = _chapters[i];
                 final current = c.uuid == player.currentChapterUuid;
-                return ListTile(
-                  key: Key('chapter-${c.uuid}'),
-                  leading: CircleAvatar(child: Text('${c.id}')),
-                  title: Text(c.title.isEmpty ? 'Chapter ${c.id}' : c.title),
-                  subtitle: c.durationSec != null
-                      ? Text(formatDuration(c.durationSec))
-                      : null,
-                  trailing: current
-                      ? Icon(_playing ? Icons.volume_up : Icons.pause,
-                          color: Theme.of(context).colorScheme.primary)
-                      : null,
-                  selected: current,
-                  onTap: c.hasAudio ? () => _playChapter(c.uuid) : null,
-                  enabled: c.hasAudio,
+                final finished = _isFinished(c.uuid);
+                return Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ListTile(
+                      key: Key('chapter-${c.uuid}'),
+                      leading: CircleAvatar(child: Text('${c.id}')),
+                      title: Text(
+                        c.title.isEmpty ? 'Chapter ${c.id}' : c.title,
+                        style: finished && !current
+                            ? TextStyle(
+                                color: Theme.of(context)
+                                    .colorScheme
+                                    .onSurfaceVariant)
+                            : null,
+                      ),
+                      subtitle: c.durationSec != null
+                          ? Text(formatDuration(c.durationSec))
+                          : null,
+                      trailing: current
+                          ? Icon(_playing ? Icons.volume_up : Icons.pause,
+                              color: Theme.of(context).colorScheme.primary)
+                          : (finished
+                              ? Icon(Icons.check_circle,
+                                  color:
+                                      Theme.of(context).colorScheme.primary)
+                              : null),
+                      selected: current,
+                      onTap: c.hasAudio ? () => _playChapter(c.uuid) : null,
+                      enabled: c.hasAudio,
+                    ),
+                    if (current) _currentProgressBar(c),
+                  ],
                 );
               },
             ),
@@ -168,6 +208,24 @@ class _PlayerScreenState extends State<PlayerScreen> {
           _transport(player),
         ],
       ),
+    );
+  }
+
+  /// A 2px progress bar under the current chapter row, position / duration.
+  Widget _currentProgressBar(SyncManifestChapter c) {
+    final durMs = (c.durationSec ?? 0) * 1000;
+    if (durMs <= 0) return const SizedBox.shrink();
+    return StreamBuilder<Duration>(
+      stream: widget.runtime.player.positionStream,
+      builder: (_, snap) {
+        final posMs = (snap.data ?? Duration.zero).inMilliseconds.toDouble();
+        final value = (posMs / durMs).clamp(0.0, 1.0);
+        return LinearProgressIndicator(
+          minHeight: 2,
+          value: value,
+          key: Key('progress-${c.uuid}'),
+        );
+      },
     );
   }
 

--- a/apps/android/lib/src/ui/player_screen.dart
+++ b/apps/android/lib/src/ui/player_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../data/companion_runtime.dart';
 import '../data/player_controller.dart';
+import '../domain/chapter_scroll.dart';
 import '../domain/listen_progress.dart';
 import '../domain/resume_reconcile.dart';
 import '../domain/sync_manifest.dart';
@@ -36,6 +37,8 @@ class _PlayerScreenState extends State<PlayerScreen> {
   Set<String> _finished = {};
   final List<StreamSubscription<Object?>> _subs = [];
   final Map<String, List<double>> _peaks = {}; // chapter uuid -> RMS peaks
+  final ScrollController _scroll = ScrollController();
+  static const double _kRowHeight = 72;
 
   /// Fetch + cache a chapter's waveform peaks. Local-first (survives offline +
   /// screen recreation + restart); falls back to a live fetch (and persists)
@@ -52,6 +55,25 @@ class _PlayerScreenState extends State<PlayerScreen> {
     if (uuid == null) return;
     final ch = _chapters.where((c) => c.uuid == uuid);
     if (ch.isNotEmpty) _ensurePeaks(uuid, ch.first.id);
+  }
+
+  void _scrollToCurrent({required bool animate}) {
+    if (!_scroll.hasClients) return;
+    final uuid = widget.runtime.player.currentChapterUuid;
+    if (uuid == null) return;
+    final i = _chapters.indexWhere((c) => c.uuid == uuid);
+    if (i < 0) return;
+    final target = chapterScrollOffset(
+      index: i,
+      rowHeight: _kRowHeight,
+      maxExtent: _scroll.position.maxScrollExtent,
+    );
+    if (animate) {
+      _scroll.animateTo(target,
+          duration: const Duration(milliseconds: 300), curve: Curves.easeOut);
+    } else {
+      _scroll.jumpTo(target);
+    }
   }
 
   @override
@@ -84,10 +106,16 @@ class _PlayerScreenState extends State<PlayerScreen> {
           _ready = true;
         });
         _ensureCurrentPeaks();
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          _scrollToCurrent(animate: false);
+        });
       }
       // Move the highlight + progress as chapters change (incl. auto-advance).
       _subs.add(widget.runtime.player.nowPlayingStream.listen((_) {
-        if (mounted) setState(() {});
+        if (mounted) {
+          setState(() {});
+          _scrollToCurrent(animate: true);
+        }
       }));
       // Tick a chapter to "done" the moment it finishes, no reopen needed.
       _subs.add(widget.runtime.player.chapterCompletedStream.listen((uuid) {
@@ -103,6 +131,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
     for (final s in _subs) {
       s.cancel();
     }
+    _scroll.dispose();
     // Save locally, then push the latest position to the server (app-6),
     // best-effort + offline-safe.
     widget.runtime.player
@@ -174,6 +203,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
         children: [
           Expanded(
             child: ListView.builder(
+              controller: _scroll,
               itemCount: _chapters.length,
               itemBuilder: (_, i) {
                 final c = _chapters[i];
@@ -264,12 +294,15 @@ class _PlayerScreenState extends State<PlayerScreen> {
                       padding: const EdgeInsets.fromLTRB(16, 2, 16, 4),
                       child: Align(
                         alignment: Alignment.centerLeft,
-                        child: Text(
-                          _currentChapterLabel(player),
-                          key: const Key('player-current-chapter'),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: Theme.of(context).textTheme.titleSmall,
+                        child: InkWell(
+                          onTap: () => _scrollToCurrent(animate: true),
+                          child: Text(
+                            _currentChapterLabel(player),
+                            key: const Key('player-current-chapter'),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: Theme.of(context).textTheme.titleSmall,
+                          ),
                         ),
                       ),
                     ),

--- a/apps/android/test/data/drift_local_library_test.dart
+++ b/apps/android/test/data/drift_local_library_test.dart
@@ -278,6 +278,28 @@ void main() {
     });
   });
 
+  group('DriftLocalLibrary (player cues)', () {
+    test('finishedChapterUuids returns only chapters flagged finished', () async {
+      final lib = DriftLocalLibrary(
+          LibraryDatabase(NativeDatabase.memory()), InMemoryFileStore(),
+          root: '/t');
+      await lib.recordChapterMeta(
+          bookId: 'b1', uuid: 'u1', chapterId: 1, title: 'One',
+          fingerprint: 'demo|10', urlSuffix: 'audio.mp3', durationSec: 100);
+      await lib.recordChapterMeta(
+          bookId: 'b1', uuid: 'u2', chapterId: 2, title: 'Two',
+          fingerprint: 'demo|10', urlSuffix: 'audio.mp3', durationSec: 100);
+      await lib.recordChapterMeta(
+          bookId: 'b2', uuid: 'u3', chapterId: 1, title: 'Other',
+          fingerprint: 'demo|10', urlSuffix: 'audio.mp3', durationSec: 100);
+
+      await lib.setChapterFinished('u1', true);
+      await lib.setChapterFinished('u3', true); // different book
+
+      expect(await lib.finishedChapterUuids('b1'), {'u1'});
+    });
+  });
+
   group('DriftLocalLibrary legacy JSON import', () {
     test('imports an app-3 sync-state.json then deletes it', () async {
       final fs = InMemoryFileStore();

--- a/apps/android/test/domain/chapter_scroll_test.dart
+++ b/apps/android/test/domain/chapter_scroll_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:castwright/src/domain/chapter_scroll.dart';
+
+void main() {
+  test('index 0 stays at the top', () {
+    expect(
+        chapterScrollOffset(index: 0, rowHeight: 72, maxExtent: 5000), 0);
+  });
+
+  test('deep index scrolls with one row of context above', () {
+    // (10 - 1) * 72 = 648
+    expect(
+        chapterScrollOffset(index: 10, rowHeight: 72, maxExtent: 5000), 648);
+  });
+
+  test('offset is clamped to maxExtent', () {
+    expect(
+        chapterScrollOffset(index: 100, rowHeight: 72, maxExtent: 1000), 1000);
+  });
+
+  test('early index that would be negative clamps to 0', () {
+    expect(
+        chapterScrollOffset(index: 1, rowHeight: 72, contextRows: 2, maxExtent: 5000),
+        0);
+  });
+}

--- a/apps/android/test/ui/player_screen_test.dart
+++ b/apps/android/test/ui/player_screen_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:castwright/src/demo/demo_runtime.dart';
+import 'package:castwright/src/data/file_store.dart';
+import 'package:castwright/src/ui/player_screen.dart';
+
+void main() {
+  testWidgets('finished chapter shows a check; current chapter shows a progress bar',
+      (tester) async {
+    final rt = await buildDemoRuntime(fs: InMemoryFileStore(), root: '/demo');
+    await rt.library.setChapterFinished('ht1-c1', true); // mark chapter 1 done
+
+    await tester.pumpWidget(MaterialApp(
+      home: PlayerScreen(
+          runtime: rt, bookId: 'hollow-tide-1', title: 'The Drowning Bell'),
+    ));
+    await tester.pumpAndSettle();
+
+    // Chapter 1 (finished, not current) → a check icon.
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+
+    // The current chapter (ht1-c2, the resume point) → its progress bar.
+    // The bar is a SIBLING of the ListTile in the row Column, not a descendant,
+    // so assert on the bar's own key — NOT find.descendant of the chapter tile.
+    expect(find.byKey(const Key('progress-ht1-c2')), findsOneWidget);
+  });
+}

--- a/apps/android/test/ui/player_screen_test.dart
+++ b/apps/android/test/ui/player_screen_test.dart
@@ -24,4 +24,16 @@ void main() {
     // so assert on the bar's own key — NOT find.descendant of the chapter tile.
     expect(find.byKey(const Key('progress-ht1-c2')), findsOneWidget);
   });
+
+  testWidgets('bottom transport names the current chapter', (tester) async {
+    final rt = await buildDemoRuntime(fs: InMemoryFileStore(), root: '/demo');
+    await tester.pumpWidget(MaterialApp(
+      home: PlayerScreen(
+          runtime: rt, bookId: 'hollow-tide-1', title: 'The Drowning Bell'),
+    ));
+    await tester.pumpAndSettle();
+
+    // Resume point is ht1-c2 = id 2, title "Bells Beneath".
+    expect(find.text('Ch. 2 · Bells Beneath'), findsOneWidget);
+  });
 }

--- a/apps/android/test/ui/player_screen_test.dart
+++ b/apps/android/test/ui/player_screen_test.dart
@@ -36,4 +36,22 @@ void main() {
     // Resume point is ht1-c2 = id 2, title "Bells Beneath".
     expect(find.text('Ch. 2 · Bells Beneath'), findsOneWidget);
   });
+
+  testWidgets('chapter list has a scroll controller and the label is tappable',
+      (tester) async {
+    final rt = await buildDemoRuntime(fs: InMemoryFileStore(), root: '/demo');
+    await tester.pumpWidget(MaterialApp(
+      home: PlayerScreen(
+          runtime: rt, bookId: 'hollow-tide-1', title: 'The Drowning Bell'),
+    ));
+    await tester.pumpAndSettle();
+
+    final listView = tester.widget<ListView>(find.byType(ListView));
+    expect(listView.controller, isNotNull);
+
+    // Tapping the current-chapter label must not throw (scrolls to current).
+    await tester.tap(find.byKey(const Key('player-current-chapter')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('player-current-chapter')), findsOneWidget);
+  });
 }

--- a/docs/superpowers/plans/2026-06-18-mobile-player-listening-cues.md
+++ b/docs/superpowers/plans/2026-06-18-mobile-player-listening-cues.md
@@ -217,13 +217,10 @@ void main() {
     // Chapter 1 (finished, not current) → a check icon.
     expect(find.byIcon(Icons.check_circle), findsOneWidget);
 
-    // The current chapter (ht1-c2, the resume point) → a LinearProgressIndicator.
-    expect(
-        find.descendant(
-          of: find.byKey(const Key('chapter-ht1-c2')),
-          matching: find.byType(LinearProgressIndicator),
-        ),
-        findsOneWidget);
+    // The current chapter (ht1-c2, the resume point) → its progress bar.
+    // The bar is a SIBLING of the ListTile in the row Column, not a descendant,
+    // so assert on the bar's own key — NOT find.descendant of the chapter tile.
+    expect(find.byKey(const Key('progress-ht1-c2')), findsOneWidget);
   });
 }
 ```
@@ -239,11 +236,10 @@ Expected: FAIL — no `check_circle` icon / no `LinearProgressIndicator` under t
 
 In `apps/android/lib/src/ui/player_screen.dart`:
 
-Add imports at the top:
+Add the async import at the top (the `chapter_scroll.dart` import is added in Task 5, where `chapterScrollOffset` is first used — keeping this commit's imports all used):
 
 ```dart
 import 'dart:async';
-import '../domain/chapter_scroll.dart';
 ```
 
 Add state fields to `_PlayerScreenState` (alongside `_chapters`):

--- a/docs/superpowers/plans/2026-06-18-mobile-player-listening-cues.md
+++ b/docs/superpowers/plans/2026-06-18-mobile-player-listening-cues.md
@@ -1,0 +1,654 @@
+# Mobile Player Listening Cues Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three listening cues to the Flutter companion's per-book player screen — auto-scroll to the current chapter, a finished-checkmark + current-chapter progress bar, and a chapter label in the bottom transport.
+
+**Architecture:** All UI changes land in one screen (`player_screen.dart`). The "finished" state reuses the already-persisted per-chapter `finished` flag (new read method on `DriftLocalLibrary`). The current chapter's progress comes from the existing `positionStream` + the chapter's manifest `durationSec`. Auto-scroll offset is a pure, unit-tested helper applied via a `ScrollController`; the screen follows chapter changes (incl. auto-advance) by listening to `nowPlayingStream`.
+
+**Tech Stack:** Dart / Flutter, drift (SQLite), `flutter_test` (widget tests), the in-memory `buildDemoRuntime` test harness.
+
+## Global Constraints
+
+- **Surface is `apps/android` only.** No server, web-frontend, sync-manifest, or OpenAPI changes.
+- **No new package dependencies.** Auto-scroll uses `ScrollController` + a pure offset helper, NOT `scrollable_positioned_list`.
+- **"Finished" = played to its end only.** Reuse the persisted `finished` flag; do NOT invent a positional "everything behind me is done" heuristic.
+- **Run tests with `flutter test <path>`** from `apps/android/`. On Windows PowerShell the binary is `flutter.bat`.
+- **Match existing style:** colours via `Theme.of(context).colorScheme` (no hex literals); follow the discriminated/`SyncManifestChapter` data already on the screen.
+- **Branch:** `fix/app-player-listening-cues` (already cut). Commit after each task.
+
+---
+
+### Task 1: `finishedChapterUuids` read on `DriftLocalLibrary`
+
+Surfaces the persisted per-chapter `finished` flag as a set the UI can query. `DownloadedChapter` does not carry `finished`, so a dedicated read is correct.
+
+**Files:**
+- Modify: `apps/android/lib/src/data/drift_local_library.dart` (add method near `setChapterFinished`, ~line 294)
+- Test: `apps/android/test/data/drift_local_library_test.dart` (append)
+
+**Interfaces:**
+- Produces: `Future<Set<String>> DriftLocalLibrary.finishedChapterUuids(String bookId)` — the uuids of that book's chapters whose `finished` column is `true`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/android/test/data/drift_local_library_test.dart` (reuse the file's existing in-memory `DriftLocalLibrary` setup — typically `DriftLocalLibrary(LibraryDatabase(NativeDatabase.memory()), <fileStore>, root: ...)` plus `recordChapterMeta`/`recordChapter`). If the file has a helper that seeds a book + chapters, use it; otherwise seed inline as below:
+
+```dart
+test('finishedChapterUuids returns only chapters flagged finished', () async {
+  final lib = DriftLocalLibrary(
+      LibraryDatabase(NativeDatabase.memory()), InMemoryFileStore(),
+      root: '/t');
+  await lib.recordChapterMeta(
+      bookId: 'b1', uuid: 'u1', chapterId: 1, title: 'One',
+      fingerprint: 'demo|10', urlSuffix: 'audio.mp3', durationSec: 100);
+  await lib.recordChapterMeta(
+      bookId: 'b1', uuid: 'u2', chapterId: 2, title: 'Two',
+      fingerprint: 'demo|10', urlSuffix: 'audio.mp3', durationSec: 100);
+  await lib.recordChapterMeta(
+      bookId: 'b2', uuid: 'u3', chapterId: 1, title: 'Other',
+      fingerprint: 'demo|10', urlSuffix: 'audio.mp3', durationSec: 100);
+
+  await lib.setChapterFinished('u1', true);
+  await lib.setChapterFinished('u3', true); // different book
+
+  expect(await lib.finishedChapterUuids('b1'), {'u1'});
+});
+```
+
+Ensure imports at the top of the file cover `package:drift/native.dart` (`NativeDatabase`), `library_database.dart`, `drift_local_library.dart`, and the file store used by the file's other tests (`InMemoryFileStore` from `file_store.dart`). Reuse whatever the existing tests already import.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/data/drift_local_library_test.dart`
+Expected: FAIL — `The method 'finishedChapterUuids' isn't defined`.
+
+- [ ] **Step 3: Add the read method**
+
+In `apps/android/lib/src/data/drift_local_library.dart`, immediately after `setChapterFinished`:
+
+```dart
+  /// The uuids of [bookId]'s chapters the user has played to the end
+  /// (the persisted `finished` flag). Drives the chapter-list "done" check.
+  Future<Set<String>> finishedChapterUuids(String bookId) async {
+    final rows = await (_db.select(_db.chapters)
+          ..where((c) => c.bookId.equals(bookId) & c.finished.equals(true)))
+        .get();
+    return {for (final r in rows) r.uuid};
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/data/drift_local_library_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/android/lib/src/data/drift_local_library.dart apps/android/test/data/drift_local_library_test.dart
+git commit -m "feat(app): read finished chapter uuids from drift store"
+```
+
+---
+
+### Task 2: Pure chapter-scroll offset helper
+
+The scroll math, isolated so it is unit-tested without the widget tree (approach A). The screen wiring in Task 5 just applies it.
+
+**Files:**
+- Create: `apps/android/lib/src/domain/chapter_scroll.dart`
+- Test: `apps/android/test/domain/chapter_scroll_test.dart`
+
+**Interfaces:**
+- Produces: `double chapterScrollOffset({required int index, required double rowHeight, double contextRows, required double maxExtent})` — pixel offset placing `index` near the top with `contextRows` rows above it, clamped to `[0, maxExtent]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/android/test/domain/chapter_scroll_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:castwright/src/domain/chapter_scroll.dart';
+
+void main() {
+  test('index 0 stays at the top', () {
+    expect(
+        chapterScrollOffset(index: 0, rowHeight: 72, maxExtent: 5000), 0);
+  });
+
+  test('deep index scrolls with one row of context above', () {
+    // (10 - 1) * 72 = 648
+    expect(
+        chapterScrollOffset(index: 10, rowHeight: 72, maxExtent: 5000), 648);
+  });
+
+  test('offset is clamped to maxExtent', () {
+    expect(
+        chapterScrollOffset(index: 100, rowHeight: 72, maxExtent: 1000), 1000);
+  });
+
+  test('early index that would be negative clamps to 0', () {
+    expect(
+        chapterScrollOffset(index: 1, rowHeight: 72, contextRows: 2, maxExtent: 5000),
+        0);
+  });
+}
+```
+
+> Replace `castwright` with the actual package name from `apps/android/pubspec.yaml` (`name:` field) if it differs — match the imports other test files in `test/domain/` use.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/domain/chapter_scroll_test.dart`
+Expected: FAIL — target of URI doesn't exist (`chapter_scroll.dart`).
+
+- [ ] **Step 3: Write the helper**
+
+Create `apps/android/lib/src/domain/chapter_scroll.dart`:
+
+```dart
+/// Pixel offset to scroll a fixed-row chapter list so [index] sits near the top
+/// with [contextRows] rows still visible above it, clamped to `[0, maxExtent]`.
+/// Pure so the player screen's auto-scroll math is testable without a widget
+/// tree; the row height is an estimate (rows are near-uniform), so this brings
+/// the current chapter into view rather than pixel-aligning it.
+double chapterScrollOffset({
+  required int index,
+  required double rowHeight,
+  double contextRows = 1,
+  required double maxExtent,
+}) {
+  final raw = (index - contextRows) * rowHeight;
+  if (raw <= 0) return 0;
+  return raw > maxExtent ? maxExtent : raw;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/domain/chapter_scroll_test.dart`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/android/lib/src/domain/chapter_scroll.dart apps/android/test/domain/chapter_scroll_test.dart
+git commit -m "feat(app): pure chapter-list scroll offset helper"
+```
+
+---
+
+### Task 3: Finished checkmark + current-chapter progress bar
+
+Reads the finished set (Task 1), refreshes it live on completion, rebuilds on chapter change, and renders the three row states.
+
+**Files:**
+- Modify: `apps/android/lib/src/ui/player_screen.dart`
+- Test: `apps/android/test/ui/player_screen_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `DriftLocalLibrary.finishedChapterUuids(String)` (Task 1); `PlayerController.chapterCompletedStream`, `.nowPlayingStream`, `.positionStream`, `.currentChapterUuid` (existing).
+- Produces: state field `Set<String> _finished` and helper `bool _isFinished(String uuid)` used by Task 5's row taps; a `StreamSubscription` list disposed in `dispose()`.
+
+- [ ] **Step 1: Write the failing widget test**
+
+Create `apps/android/test/ui/player_screen_test.dart`. Build the screen over the in-memory demo runtime and assert the finished check + progress bar. (`buildDemoRuntime` seeds `hollow-tide-1` with chapters `ht1-c1/c2/c3` and a resume at `ht1-c2`.)
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:castwright/src/demo/demo_runtime.dart';
+import 'package:castwright/src/data/file_store.dart';
+import 'package:castwright/src/ui/player_screen.dart';
+
+void main() {
+  testWidgets('finished chapter shows a check; current chapter shows a progress bar',
+      (tester) async {
+    final rt = await buildDemoRuntime(fs: InMemoryFileStore(), root: '/demo');
+    await rt.library.setChapterFinished('ht1-c1', true); // mark chapter 1 done
+
+    await tester.pumpWidget(MaterialApp(
+      home: PlayerScreen(
+          runtime: rt, bookId: 'hollow-tide-1', title: 'The Drowning Bell'),
+    ));
+    await tester.pumpAndSettle();
+
+    // Chapter 1 (finished, not current) → a check icon.
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+
+    // The current chapter (ht1-c2, the resume point) → a LinearProgressIndicator.
+    expect(
+        find.descendant(
+          of: find.byKey(const Key('chapter-ht1-c2')),
+          matching: find.byType(LinearProgressIndicator),
+        ),
+        findsOneWidget);
+  });
+}
+```
+
+> Match the package name and `InMemoryFileStore` import to the conventions in the existing `test/ui/*` and `test/demo/demo_runtime_test.dart` files.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/ui/player_screen_test.dart`
+Expected: FAIL — no `check_circle` icon / no `LinearProgressIndicator` under the current row.
+
+- [ ] **Step 3: Load + refresh the finished set, rebuild on chapter change**
+
+In `apps/android/lib/src/ui/player_screen.dart`:
+
+Add imports at the top:
+
+```dart
+import 'dart:async';
+import '../domain/chapter_scroll.dart';
+```
+
+Add state fields to `_PlayerScreenState` (alongside `_chapters`):
+
+```dart
+  Set<String> _finished = {};
+  final List<StreamSubscription<Object?>> _subs = [];
+```
+
+In `_prepare()`, after `_chapters = widget.runtime.sync.chaptersOf(widget.bookId);` and before `_ready = true;`, load the finished set:
+
+```dart
+          _finished =
+              await widget.runtime.library.finishedChapterUuids(widget.bookId);
+```
+
+> Note: `finishedChapterUuids` is async — assign it on a line *before* the `setState(() { ... })` block (await it, store in a local, then set state), or `await` it just above the `setState`. Keep the existing `setState` synchronous. Concretely, restructure the tail of `_prepare()`:
+>
+> ```dart
+>       final chapters = widget.runtime.sync.chaptersOf(widget.bookId);
+>       final finished =
+>           await widget.runtime.library.finishedChapterUuids(widget.bookId);
+>       if (mounted) {
+>         setState(() {
+>           _chapters = chapters;
+>           _finished = finished;
+>           _ready = true;
+>         });
+>         _ensureCurrentPeaks();
+>       }
+> ```
+
+At the end of `_prepare()`'s `try` (after the `setState`), wire two subscriptions:
+
+```dart
+      // Move the highlight + progress as chapters change (incl. auto-advance).
+      _subs.add(widget.runtime.player.nowPlayingStream.listen((_) {
+        if (mounted) setState(() {});
+      }));
+      // Tick a chapter to "done" the moment it finishes, no reopen needed.
+      _subs.add(widget.runtime.player.chapterCompletedStream.listen((uuid) {
+        if (mounted) setState(() => _finished = {..._finished, uuid});
+      }));
+```
+
+In `dispose()`, cancel them (add before `super.dispose()` is reached — the existing dispose already pauses/syncs; insert at the top of the method):
+
+```dart
+    for (final s in _subs) {
+      s.cancel();
+    }
+```
+
+Add the helper method:
+
+```dart
+  bool _isFinished(String uuid) => _finished.contains(uuid);
+```
+
+- [ ] **Step 4: Render the three row states**
+
+Replace the `itemBuilder` body in `build()` (the `ListTile` for each chapter) with:
+
+```dart
+              itemBuilder: (_, i) {
+                final c = _chapters[i];
+                final current = c.uuid == player.currentChapterUuid;
+                final finished = _isFinished(c.uuid);
+                return Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ListTile(
+                      key: Key('chapter-${c.uuid}'),
+                      leading: CircleAvatar(child: Text('${c.id}')),
+                      title: Text(
+                        c.title.isEmpty ? 'Chapter ${c.id}' : c.title,
+                        style: finished && !current
+                            ? TextStyle(
+                                color: Theme.of(context)
+                                    .colorScheme
+                                    .onSurfaceVariant)
+                            : null,
+                      ),
+                      subtitle: c.durationSec != null
+                          ? Text(formatDuration(c.durationSec))
+                          : null,
+                      trailing: current
+                          ? Icon(_playing ? Icons.volume_up : Icons.pause,
+                              color: Theme.of(context).colorScheme.primary)
+                          : (finished
+                              ? Icon(Icons.check_circle,
+                                  color:
+                                      Theme.of(context).colorScheme.primary)
+                              : null),
+                      selected: current,
+                      onTap: c.hasAudio ? () => _playChapter(c.uuid) : null,
+                      enabled: c.hasAudio,
+                    ),
+                    if (current) _currentProgressBar(c),
+                  ],
+                );
+              },
+```
+
+Add the progress-bar builder method (a thin bar driven by the live position over the chapter's duration):
+
+```dart
+  /// A 2px progress bar under the current chapter row, position / duration.
+  Widget _currentProgressBar(SyncManifestChapter c) {
+    final durMs = (c.durationSec ?? 0) * 1000;
+    if (durMs <= 0) return const SizedBox.shrink();
+    return StreamBuilder<Duration>(
+      stream: widget.runtime.player.positionStream,
+      builder: (_, snap) {
+        final posMs = (snap.data ?? Duration.zero).inMilliseconds.toDouble();
+        final value = (posMs / durMs).clamp(0.0, 1.0);
+        return LinearProgressIndicator(
+          minHeight: 2,
+          value: value,
+          key: Key('progress-${c.uuid}'),
+        );
+      },
+    );
+  }
+```
+
+> `SyncManifestChapter` is already imported via `../domain/sync_manifest.dart` (the screen uses it for `_chapters`). If the import is missing, add it.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `flutter test test/ui/player_screen_test.dart`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/android/lib/src/ui/player_screen.dart apps/android/test/ui/player_screen_test.dart
+git commit -m "feat(app): finished check + current-chapter progress bar in player list"
+```
+
+---
+
+### Task 4: Name the current chapter in the bottom transport
+
+Adds a single ellipsized `Ch. N · Title` line above the scrubber.
+
+**Files:**
+- Modify: `apps/android/lib/src/ui/player_screen.dart` (the `_transport` method)
+- Test: `apps/android/test/ui/player_screen_test.dart` (append)
+
+**Interfaces:**
+- Consumes: `_chapters`, `player.currentChapterUuid` (existing).
+- Produces: a `Text` widget with `Key('player-current-chapter')` (Task 5 wraps it in a tap target).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/android/test/ui/player_screen_test.dart`:
+
+```dart
+  testWidgets('bottom transport names the current chapter', (tester) async {
+    final rt = await buildDemoRuntime(fs: InMemoryFileStore(), root: '/demo');
+    await tester.pumpWidget(MaterialApp(
+      home: PlayerScreen(
+          runtime: rt, bookId: 'hollow-tide-1', title: 'The Drowning Bell'),
+    ));
+    await tester.pumpAndSettle();
+
+    // Resume point is ht1-c2 = id 2, title "Bells Beneath".
+    expect(find.text('Ch. 2 · Bells Beneath'), findsOneWidget);
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/ui/player_screen_test.dart`
+Expected: FAIL — `Ch. 2 · Bells Beneath` not found.
+
+- [ ] **Step 3: Add the label builder and render it in `_transport`**
+
+Add a helper method to `_PlayerScreenState`:
+
+```dart
+  /// `Ch. <id> · <title>` for the loaded chapter, or empty when none.
+  String _currentChapterLabel(PlayerController player) {
+    final uuid = player.currentChapterUuid;
+    if (uuid == null) return '';
+    final match = _chapters.where((c) => c.uuid == uuid);
+    if (match.isEmpty) return '';
+    final c = match.first;
+    final title = c.title.isEmpty ? 'Chapter ${c.id}' : c.title;
+    return 'Ch. ${c.id} · $title';
+  }
+```
+
+In `_transport`, inside the `Column(children: [...])` returned by the inner `StreamBuilder<Duration>` builder, insert as the FIRST child (above the waveform/slider `Builder`):
+
+```dart
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 2, 16, 4),
+                      child: Align(
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          _currentChapterLabel(player),
+                          key: const Key('player-current-chapter'),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.titleSmall,
+                        ),
+                      ),
+                    ),
+```
+
+> `_transport(PlayerController player)` already receives `player`. `context` is available inside the builder closures.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/ui/player_screen_test.dart`
+Expected: PASS (3 tests in the file now).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/android/lib/src/ui/player_screen.dart apps/android/test/ui/player_screen_test.dart
+git commit -m "feat(app): show current chapter name in player transport"
+```
+
+---
+
+### Task 5: Auto-scroll to the current chapter + tap-the-label to scroll
+
+Wires the `ScrollController` + Task-2 helper: jump on open, follow on chapter change, and scroll back when the transport label is tapped.
+
+**Files:**
+- Modify: `apps/android/lib/src/ui/player_screen.dart`
+- Test: `apps/android/test/ui/player_screen_test.dart` (append)
+
+**Interfaces:**
+- Consumes: `chapterScrollOffset(...)` (Task 2); the `nowPlayingStream` subscription added in Task 3; the `player-current-chapter` label (Task 4).
+- Produces: `ScrollController _scroll` attached to the chapter `ListView`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/android/test/ui/player_screen_test.dart`. The demo book has only 3 chapters (no scroll room), so assert the wiring is present and the tap is handled rather than a pixel offset — offset correctness is covered by `chapter_scroll_test.dart` (Task 2) and the on-device pass.
+
+```dart
+  testWidgets('chapter list has a scroll controller and the label is tappable',
+      (tester) async {
+    final rt = await buildDemoRuntime(fs: InMemoryFileStore(), root: '/demo');
+    await tester.pumpWidget(MaterialApp(
+      home: PlayerScreen(
+          runtime: rt, bookId: 'hollow-tide-1', title: 'The Drowning Bell'),
+    ));
+    await tester.pumpAndSettle();
+
+    final listView = tester.widget<ListView>(find.byType(ListView));
+    expect(listView.controller, isNotNull);
+
+    // Tapping the current-chapter label must not throw (scrolls to current).
+    await tester.tap(find.byKey(const Key('player-current-chapter')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('player-current-chapter')), findsOneWidget);
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/ui/player_screen_test.dart`
+Expected: FAIL — `listView.controller` is null (no controller wired yet), or the label is not wrapped in a tap target.
+
+- [ ] **Step 3: Add the controller + scroll method**
+
+In `_PlayerScreenState`, add the field and a row-height constant:
+
+```dart
+  final ScrollController _scroll = ScrollController();
+  static const double _kRowHeight = 72;
+```
+
+Dispose it — in `dispose()`, alongside the `_subs` cancellation from Task 3:
+
+```dart
+    _scroll.dispose();
+```
+
+Add the scroll method:
+
+```dart
+  void _scrollToCurrent({required bool animate}) {
+    if (!_scroll.hasClients) return;
+    final uuid = widget.runtime.player.currentChapterUuid;
+    if (uuid == null) return;
+    final i = _chapters.indexWhere((c) => c.uuid == uuid);
+    if (i < 0) return;
+    final target = chapterScrollOffset(
+      index: i,
+      rowHeight: _kRowHeight,
+      maxExtent: _scroll.position.maxScrollExtent,
+    );
+    if (animate) {
+      _scroll.animateTo(target,
+          duration: const Duration(milliseconds: 300), curve: Curves.easeOut);
+    } else {
+      _scroll.jumpTo(target);
+    }
+  }
+```
+
+- [ ] **Step 4: Attach the controller, jump on open, follow on change, tap to scroll**
+
+(a) Attach the controller to the chapter `ListView.builder` in `build()`:
+
+```dart
+            child: ListView.builder(
+              controller: _scroll,
+              itemCount: _chapters.length,
+              ...
+```
+
+(b) Jump to the current chapter once after the first frame. In `_prepare()`, immediately after the `setState(() { ... _ready = true; })` block, add:
+
+```dart
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          _scrollToCurrent(animate: false);
+        });
+```
+
+(c) Make the `nowPlayingStream` listener (added in Task 3) also follow the new chapter. Update that listener body to:
+
+```dart
+      _subs.add(widget.runtime.player.nowPlayingStream.listen((_) {
+        if (mounted) {
+          setState(() {});
+          _scrollToCurrent(animate: true);
+        }
+      }));
+```
+
+(d) Make the transport label tappable. In `_transport` (Task 4), wrap the `Text` in an `InkWell` (replace the `child: Text(...)` inside the `Align` with):
+
+```dart
+                        child: InkWell(
+                          onTap: () => _scrollToCurrent(animate: true),
+                          child: Text(
+                            _currentChapterLabel(player),
+                            key: const Key('player-current-chapter'),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: Theme.of(context).textTheme.titleSmall,
+                          ),
+                        ),
+```
+
+- [ ] **Step 5: Run the full screen test file**
+
+Run: `flutter test test/ui/player_screen_test.dart`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/android/lib/src/ui/player_screen.dart apps/android/test/ui/player_screen_test.dart
+git commit -m "feat(app): auto-scroll player list to the current chapter"
+```
+
+---
+
+### Task 6: Full suite, analyze, and device-pass note
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Analyze**
+
+Run: `flutter analyze` (from `apps/android/`)
+Expected: No new issues. Fix any introduced (unused imports, missing `const`).
+
+- [ ] **Step 2: Run the app's test suite**
+
+Run: `flutter test`
+Expected: All pass, including the new `drift_local_library_test.dart`, `chapter_scroll_test.dart`, and `player_screen_test.dart`.
+
+- [ ] **Step 3: Manual device pass (record in the PR, not blocking the suite)**
+
+On a paired device, open a deep book (e.g. "Unraveled") resumed mid-book and confirm:
+1. The list scrolls to the current chapter on open.
+2. Finished chapters show the check; the current chapter shows a moving progress bar.
+3. The bottom transport names the current chapter; tapping it scrolls back to that row.
+4. On auto-advance to the next chapter, the highlight + progress bar + bottom label move and the list follows.
+
+- [ ] **Step 4: Final commit (if analyze required fixes)**
+
+```bash
+git add -A
+git commit -m "chore(app): lint cleanups for player listening cues"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:**
+  - Issue 1 (auto-scroll) → Task 2 (offset helper) + Task 5 (wiring, follow-on-advance, tap-to-scroll). ✓
+  - Issue 2 (finished check + progress bar) → Task 1 (read) + Task 3 (render + live refresh). ✓
+  - Issue 3 (bottom-bar chapter label) → Task 4. ✓
+  - "Finished = played to end" → Task 1 reads the persisted flag only; no positional heuristic. ✓
+  - Testing (finished rows, progress bar, bottom label, scroll target, read path) → Tasks 1–5 each carry the matching test; Task 6 adds the manual pass. ✓
+  - Out of scope (no deps, no server, reject `scrollable_positioned_list`) → Global Constraints + Task 2 helper. ✓
+- **Placeholder scan:** No TBD/TODO; every code step shows complete code. Two parameterized notes (package name, existing test-setup reuse) are explicit instructions, not placeholders. ✓
+- **Type consistency:** `finishedChapterUuids` (Task 1) consumed in Task 3; `chapterScrollOffset` signature identical in Task 2 test, helper, and Task 5 call; `_currentChapterLabel`/`_scrollToCurrent`/`_isFinished` defined once and reused; `player-current-chapter` key shared by Tasks 4 and 5. ✓

--- a/docs/superpowers/specs/2026-06-18-mobile-player-listening-cues-design.md
+++ b/docs/superpowers/specs/2026-06-18-mobile-player-listening-cues-design.md
@@ -1,0 +1,149 @@
+# Mobile player-screen listening cues — design
+
+- **Date:** 2026-06-18
+- **Surface:** `apps/android` (Flutter companion app), `lib/src/ui/player_screen.dart`
+- **Branch:** `fix/app-player-listening-cues`
+- **Type:** UX fix (no server, no web frontend, no new feature surface)
+
+## Problem
+
+On the per-book player screen (the chapter list + bottom transport), three
+listening cues are missing. Observed on a real device (book "Unraveled", ~45
+chapters):
+
+1. **No auto-scroll to the current chapter.** The list always opens at chapter
+   1. When you resume mid-book (e.g. chapter 38), you must manually scroll to
+   find where you are.
+2. **No "finished" indicator.** A chapter you have completed looks identical to
+   one you have never started. The only visible state is the currently-playing
+   chapter (highlight + speaker icon).
+3. **The bottom transport doesn't name the current chapter.** The scrubber +
+   transport buttons carry no chapter title — the only way to see which chapter
+   is playing is the speaker icon in the list, which requires scrolling.
+
+All three live in one file (`player_screen.dart`) and are one cohesive change.
+
+## What already exists (no new tracking needed)
+
+- **Per-chapter `finished` is already persisted.** The drift `Chapters` table
+  has a `finished` boolean column (`library_database.dart:69`), written via
+  `DriftLocalLibrary.setChapterFinished(uuid, bool)`. It is set `true` whenever
+  a chapter plays to its end — `companion_runtime.dart:189` wires
+  `PlayerController.chapterCompletedStream` → `setChapterFinished(uuid, true)`.
+  Nothing reads it back for display today.
+- **Live position + per-chapter duration are available.**
+  `PlayerController.positionStream` ticks the current position;
+  `SyncManifestChapter.durationSec` carries each chapter's length; the screen
+  already knows `player.currentChapterUuid`.
+- **The screen is presentational and store-free-testable** — it takes a
+  `CompanionRuntime` and renders from `_chapters` (the sync manifest) +
+  controller streams, so the three cues are widget-testable.
+
+## Definition of "finished" (decided)
+
+A chapter shows **finished** only when it was actually played to its end (the
+persisted `finished` flag). Manually skipping to the next chapter before the end
+does **not** mark the prior chapter finished — this is honest about true
+completion and reuses data already stored, rather than inventing a positional
+"everything behind me is done" heuristic.
+
+The **current** chapter additionally shows a live within-chapter progress bar.
+
+## Design
+
+### 1. Auto-scroll to the current chapter — approach A (no new dependency)
+
+`ListView.builder` gets a `ScrollController`. After the first frame
+(`WidgetsBinding.instance.addPostFrameCallback`), jump to the current chapter's
+index using an estimated fixed row height, clamped to the scroll extent, placing
+the current chapter near the top with one row of context above it:
+
+```
+target = (currentIndex * estimatedRowHeight) - oneRowOfContext
+controller.jumpTo(target.clamp(0, position.maxScrollExtent))
+```
+
+For a ~45-chapter list the estimate lands within a row or so — sufficient to
+"bring it into view." When a chapter **auto-advances**, animate (not jump) to
+the new current index so the list follows playback.
+
+Rationale: matches the project's "simplicity first / no speculative deps" rule.
+The exact alternative (`scrollable_positioned_list` with `initialScrollIndex`)
+was considered and rejected to avoid adding a dependency for a "good enough"
+visual nicety.
+
+### 2. Finished checkmark + current-chapter progress bar
+
+**Read path.** Add `Future<Set<String>> finishedChapterUuids(String bookId)` to
+`DriftLocalLibrary` — a query over the `Chapters` table for rows of that book
+with `finished == true`. The player screen:
+
+- loads it once in `_prepare()` into a `Set<String> _finished`, and
+- refreshes it on `PlayerController.chapterCompletedStream` (so a chapter ticks
+  to "done" live the moment it finishes, without a screen reopen).
+
+**Row rendering** (in the existing `ListView.builder` item):
+
+| State | Leading | Text | Extra |
+|---|---|---|---|
+| Finished (`uuid ∈ _finished`, not current) | check glyph | dimmed | — |
+| Current (`uuid == currentChapterUuid`) | existing CircleAvatar + speaker/pause trailing icon (unchanged) | highlighted (unchanged `selected`) | thin `LinearProgressIndicator` under the tile |
+| Not started | existing CircleAvatar | neutral | — |
+
+The progress bar is a 1–2px `LinearProgressIndicator` whose value is
+`position / chapterDuration`, driven by the same `positionStream` the transport
+already listens to (clamped to `0..1`; hidden when duration is unknown).
+
+A chapter can be both finished and current (you finished it and it is still
+loaded) — current-state styling wins so the row still reads as "now playing."
+
+### 3. Name the current chapter in the bottom transport
+
+Add one ellipsized line above the scrubber inside `_transport`:
+
+```
+Ch. 38 · Chapter Thirty-Two
+```
+
+Built from `currentChapterUuid` → the matching `_chapters` entry's `id` +
+`title` (falling back to `Chapter <id>` when the title is empty, matching the
+list's existing fallback). Tapping the line scrolls the list back to the current
+chapter (reuses the Issue-1 scroll target). No new data.
+
+## Out of scope
+
+- Positional / "everything before me is done" completion heuristics.
+- Per-chapter resume positions (the app stores a single per-book resume point —
+  unchanged).
+- Any server, sync-manifest, or web-frontend change.
+- The exact `scrollable_positioned_list` approach (rejected above).
+
+## Testing
+
+Flutter widget tests on `PlayerScreen` (store-free, via a fake/seeded
+`CompanionRuntime`), one case per behavior:
+
+1. **Finished rows** render the check glyph and dimmed styling for uuids in the
+   finished set; a non-finished, non-current row does not.
+2. **Current-chapter progress bar** renders a `LinearProgressIndicator` at the
+   expected fraction for a given position/duration, and only on the current row.
+3. **Bottom-bar label** shows `Ch. <id> · <title>` for the current chapter and
+   updates when the current chapter changes.
+4. **Auto-scroll** target: the screen computes/applies the current-index scroll
+   offset on open (assert the controller's resolved offset is non-zero for a
+   deep resume index, ~zero for index 0).
+5. **Finished read path**: a unit test that `DriftLocalLibrary
+   .finishedChapterUuids(bookId)` returns exactly the uuids flagged via
+   `setChapterFinished`.
+
+Plus a manual device pass (the screen is the on-device surface): resume "Unraveled"
+mid-book → confirm it scrolls to the current chapter, finished chapters carry
+checks, the current chapter shows a moving progress bar, and the bottom bar names
+the chapter.
+
+## Files
+
+- `apps/android/lib/src/ui/player_screen.dart` — all three cues.
+- `apps/android/lib/src/data/drift_local_library.dart` — add
+  `finishedChapterUuids(bookId)` read.
+- `apps/android/test/…` — new widget + unit tests above.


### PR DESCRIPTION
## Summary

Three listening cues on the companion's per-book player screen (`apps/android/lib/src/ui/player_screen.dart`), all reusing data that already exists:

1. **Auto-scroll to the current chapter** on open, follow chapter changes (incl. auto-advance), and tap the bottom-transport chapter label to scroll back. Approach A — a pure, unit-tested `chapterScrollOffset` helper applied via a `ScrollController` (no new dependency; `scrollable_positioned_list` deliberately rejected).
2. **Finished checkmark + live progress bar** — a check on chapters played to their end (reusing the persisted `finished` drift flag, surfaced via a new `DriftLocalLibrary.finishedChapterUuids`), plus a thin `LinearProgressIndicator` under the current chapter. A chapter that is both finished and current renders as "now playing" (current styling wins).
3. **Chapter label in the transport** — `Ch. <id> · <title>` above the scrubber.

Built spec → plan → adversarial review → subagent-driven TDD (one implementer + reviewer per task) → whole-branch review. Design + plan: `docs/superpowers/specs/2026-06-18-mobile-player-listening-cues-design.md`, `docs/superpowers/plans/2026-06-18-mobile-player-listening-cues.md`.

## Test plan

- `flutter analyze` — no issues.
- `flutter test` (whole app) — **314 passing**, including:
  - `test/data/drift_local_library_test.dart` — `finishedChapterUuids` returns only this book's finished uuids (cross-book isolation).
  - `test/domain/chapter_scroll_test.dart` — offset math: top=0, deep-index context, clamp-to-maxExtent, negative→0.
  - `test/ui/player_screen_test.dart` — finished check (one `check_circle`), current-chapter progress bar (`progress-<uuid>` key), transport label `Ch. 2 · Bells Beneath`, scroll controller attached + label tappable.

### Manual device pass (owed before merge — widget tests can't reach these)

- [ ] Resume a long book mid-way → list scrolls to the current chapter on open.
- [ ] On a real chapter boundary (auto-advance): previous chapter checkmarks, next chapter highlights with its own progress bar, list follows.
- [ ] `_kRowHeight=72` estimate brings the current chapter into view on a long book (rows with 2-line titles are taller — approach A is intentionally approximate).
- [ ] Tap the transport chapter label with the list scrolled away → animates back to the current row.
- [ ] Dimmed "finished" title legibility in light **and** dark theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)