### PR TITLE
feat(scripts): companion APK build+drop with auto versionCode + signer verify

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,16 @@ Define success criteria, then loop until verified.
 - `npm run verify:quick` — all tests (no e2e, no typecheck, no build) — alias for `test:all`.
 - `npm run verify:fast` — fast tests only (alias for `test:fast`) — pre-commit gate.
 - `npm run build` — production build into `dist/`.
+- `npm run apk:companion` — build the Android companion APK and drop it at
+  `companion/castwright-companion.apk` (the path `GET /api/companion/apk` serves;
+  set `COMPANION_APK_PATH` to drop elsewhere). Stamps an **auto-incrementing
+  timestamp `versionCode`** (minutes since epoch) via `flutter build --build-number`,
+  so every build's code strictly increases and it **update-installs** over the prior
+  one — never the "same versionCode → won't update / had to uninstall" trap. It also
+  **verifies the built APK's signer cert** == the upload key (`ba7b147d…`) and refuses
+  to drop a debug-/wrong-key build (which would fail `INSTALL_FAILED_UPDATE_INCOMPATIBLE`).
+  Run from a checkout that has `apps/android/android/key.properties` + `upload-keystore.jks`
+  (git-ignored). Pure helpers unit-tested in `scripts/tests/build-companion-apk.test.mjs`.
 - `npm run openapi:types` — regenerate `src/lib/api-types.ts` from `openapi.yaml`.
 - `cd server && npm run dev` — local analysis backend on `:8080`. Reads `server/.env`
   (Node 20.6+ native `process.loadEnvFile`, no dotenv dep).

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "start:lan": "cross-env LAN_HTTPS=1 node scripts/start-app-prod.mjs",
     "install:cert-mobile": "node scripts/print-cert-install-instructions.mjs",
     "tts:sidecar": "node scripts/launch-sidecar.mjs",
+    "apk:companion": "node scripts/build-companion-apk.mjs",
     "build": "tsc -b && vite build && npm --prefix server run build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit && npm --prefix server run typecheck",

--- a/scripts/build-companion-apk.mjs
+++ b/scripts/build-companion-apk.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/*
+ * Build + drop the companion Android APK so it ALWAYS update-installs on device.
+ *
+ * Two things break a sideload update-install (we hit both 2026-06-18):
+ *   1. A versionCode that isn't STRICTLY higher than what's installed → Android
+ *      rejects it (or won't see it as an update). Fixed here by stamping a
+ *      monotonic timestamp versionCode (minutes since epoch) on every build via
+ *      `flutter build --build-number`, so no two real builds collide and the
+ *      number only ever climbs — no pubspec edits, no git churn.
+ *   2. A signing-key mismatch (a debug-signed or Play-signed build vs the upload
+ *      key) → INSTALL_FAILED_UPDATE_INCOMPATIBLE. Fixed here by VERIFYING the
+ *      built APK's signer cert == the known upload cert before dropping; we
+ *      refuse to publish a wrong-key APK.
+ *
+ * Output lands at the path the server serves (`GET /api/companion/apk`):
+ *   <repoRoot>/companion/castwright-companion.apk  (+ a refreshed .sha1)
+ * or wherever COMPANION_APK_PATH points (mirrors server/src/companion/apk.ts).
+ *
+ * Usage:  node scripts/build-companion-apk.mjs
+ *         COMPANION_APK_PATH=/abs/companion/castwright-companion.apk node scripts/build-companion-apk.mjs
+ */
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  copyFileSync,
+  writeFileSync,
+  statSync,
+} from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const ANDROID_DIR = join(REPO_ROOT, 'apps', 'android');
+
+/** Known upload-keystore cert (CN=Mikhail Dudarenok, O=Castwright). A built APK
+ *  whose signer SHA-256 differs from this must NOT be dropped — it would fail to
+ *  update-install over an upload-signed build on device. */
+export const EXPECTED_UPLOAD_CERT_SHA256 =
+  'ba7b147d8d844643d2d24001ca5e233bbfac6e57cdd94b683413692ac60de66b';
+
+// ---- pure helpers (unit-tested) ------------------------------------------
+
+/** Monotonic versionCode: whole minutes since the Unix epoch. Strictly climbs
+ *  over time; two builds in the same minute would tie, but a release build
+ *  takes minutes, so real back-to-back builds never collide. ~29.7M in 2026 —
+ *  far above any hand-set code and far below Play's 2.1e9 ceiling for ages. */
+export function nextBuildNumber(nowMs = Date.now()) {
+  return Math.floor(nowMs / 60_000);
+}
+
+/** Pull the signer cert SHA-256 (lowercase hex) out of `apksigner verify
+ *  --print-certs` output, or null if absent. */
+export function parseSignerSha256(apksignerOutput) {
+  const m = /SHA-256 digest:\s*([0-9a-fA-F]{64})/.exec(apksignerOutput);
+  return m ? m[1].toLowerCase() : null;
+}
+
+/** SHA-1 hex (lowercase) of a buffer — the format of the sidecar .sha1 file. */
+export function sha1Hex(buffer) {
+  return createHash('sha1').update(buffer).digest('hex');
+}
+
+// ---- side-effecting steps -------------------------------------------------
+
+function die(msg) {
+  console.error(`\n✗ ${msg}\n`);
+  process.exit(1);
+}
+
+/** Locate apksigner.bat/apksigner under the Android SDK, newest build-tools first. */
+function findApksigner() {
+  const sdk =
+    process.env.ANDROID_HOME ||
+    process.env.ANDROID_SDK_ROOT ||
+    (process.env.LOCALAPPDATA ? join(process.env.LOCALAPPDATA, 'Android', 'Sdk') : '') ||
+    (process.env.HOME ? join(process.env.HOME, 'Android', 'Sdk') : '');
+  const bt = sdk && join(sdk, 'build-tools');
+  if (!bt || !existsSync(bt)) return null;
+  const bin = process.platform === 'win32' ? 'apksigner.bat' : 'apksigner';
+  const dirs = readdirSync(bt).sort().reverse(); // newest version first
+  for (const d of dirs) {
+    const p = join(bt, d, bin);
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+function main() {
+  // Guard 2 (signing) starts here: refuse to build if the release-signing config
+  // is missing, since the build would silently fall back to DEBUG signing.
+  if (!existsSync(join(ANDROID_DIR, 'android', 'key.properties'))) {
+    die(
+      'apps/android/android/key.properties is missing → release build would fall back to\n' +
+        '  DEBUG signing, which cannot update-install over an upload-signed app. Copy your\n' +
+        '  key.properties + upload-keystore.jks into apps/android/android/ first.',
+    );
+  }
+
+  const buildNumber = nextBuildNumber();
+  console.log(`→ versionCode (build number): ${buildNumber}`);
+
+  // Build. shell:true so `flutter` resolves to flutter.bat on Windows PATH.
+  const build = spawnSync(`flutter build apk --release --build-number=${buildNumber}`, {
+    cwd: ANDROID_DIR,
+    stdio: 'inherit',
+    shell: true,
+  });
+  if (build.status !== 0) die(`flutter build apk failed (exit ${build.status}).`);
+
+  const apk = join(ANDROID_DIR, 'build', 'app', 'outputs', 'flutter-apk', 'app-release.apk');
+  if (!existsSync(apk)) die(`expected APK not found at ${apk}`);
+
+  // Guard 2 continued: verify the signer cert is the upload key.
+  const apksigner = findApksigner();
+  if (apksigner) {
+    // shell:true so a Windows `apksigner.bat` runs (Node refuses to spawn
+    // .bat/.cmd without a shell); quote paths for safety.
+    const r = spawnSync(`"${apksigner}" verify --print-certs "${apk}"`, {
+      encoding: 'utf8',
+      shell: true,
+    });
+    const out = `${r.stdout || ''}${r.stderr || ''}`;
+    const got = parseSignerSha256(out);
+    if (!got) die('could not read the signer cert from apksigner output.');
+    if (got !== EXPECTED_UPLOAD_CERT_SHA256) {
+      die(
+        `signer cert MISMATCH — refusing to drop.\n  expected ${EXPECTED_UPLOAD_CERT_SHA256}\n  got      ${got}\n` +
+          '  This APK would fail to update-install over the upload-signed app. Check key.properties.',
+      );
+    }
+    console.log(`✓ signer cert verified: ${got}`);
+  } else {
+    console.warn(
+      '⚠ apksigner not found (set ANDROID_HOME) — skipping signer verification.\n' +
+        '  key.properties is present, so release signing was used, but the cert was NOT confirmed.',
+    );
+  }
+
+  // Drop to the served path (mirror server/src/companion/apk.ts).
+  const dest =
+    process.env.COMPANION_APK_PATH?.trim() ||
+    join(REPO_ROOT, 'companion', 'castwright-companion.apk');
+  mkdirSync(dirname(dest), { recursive: true });
+  copyFileSync(apk, dest);
+  const bytes = readFileSync(dest);
+  const sha1 = sha1Hex(bytes);
+  writeFileSync(`${dest}.sha1`, `${sha1}\n`);
+
+  const mb = (statSync(dest).size / (1024 * 1024)).toFixed(1);
+  console.log(`\n✓ dropped ${dest}`);
+  console.log(`  size  ${mb} MB`);
+  console.log(`  sha1  ${sha1}`);
+  console.log(`  code  ${buildNumber} (strictly increases each build → update-installs)\n`);
+}
+
+// Only run when invoked directly (not when imported by the test).
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  main();
+}

--- a/scripts/tests/build-companion-apk.test.mjs
+++ b/scripts/tests/build-companion-apk.test.mjs
@@ -1,0 +1,51 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  nextBuildNumber,
+  parseSignerSha256,
+  sha1Hex,
+  EXPECTED_UPLOAD_CERT_SHA256,
+} from '../build-companion-apk.mjs';
+
+test('nextBuildNumber: whole minutes since epoch for a fixed instant', () => {
+  // 2026-06-18T18:00:00Z = 1781200800000 ms → /60000 = 29686680
+  assert.equal(nextBuildNumber(1781200800000), 29686680);
+});
+
+test('nextBuildNumber: floors sub-minute remainder', () => {
+  assert.equal(nextBuildNumber(59_999), 0);
+  assert.equal(nextBuildNumber(60_000), 1);
+  assert.equal(nextBuildNumber(119_999), 1);
+});
+
+test('nextBuildNumber: monotonic — a later instant never yields a lower code', () => {
+  const earlier = nextBuildNumber(1781200800000);
+  const later = nextBuildNumber(1781200800000 + 5 * 60_000);
+  assert.ok(later > earlier);
+});
+
+test('nextBuildNumber: stays under the Play 2.1e9 ceiling and above hand-set 10.8M', () => {
+  const now = nextBuildNumber(1781200800000);
+  assert.ok(now > 10_800_000, 'must exceed the last hand-set versionCode');
+  assert.ok(now < 2_100_000_000, 'must stay under Google Play versionCode limit');
+});
+
+test('parseSignerSha256: extracts the cert from real apksigner output', () => {
+  const out = [
+    'Signer #1 certificate DN: CN=Mikhail Dudarenok, O=Castwright',
+    `Signer #1 certificate SHA-256 digest: ${EXPECTED_UPLOAD_CERT_SHA256}`,
+    'Signer #1 certificate SHA-1 digest: 09e839c121e312cc6d2eb7c99a74e9b79731daba',
+  ].join('\n');
+  assert.equal(parseSignerSha256(out), EXPECTED_UPLOAD_CERT_SHA256);
+});
+
+test('parseSignerSha256: lowercases and returns null when absent', () => {
+  const upper = `Signer #1 certificate SHA-256 digest: ${EXPECTED_UPLOAD_CERT_SHA256.toUpperCase()}`;
+  assert.equal(parseSignerSha256(upper), EXPECTED_UPLOAD_CERT_SHA256);
+  assert.equal(parseSignerSha256('no digest here'), null);
+});
+
+test('sha1Hex: known vector', () => {
+  // SHA-1("abc") = a9993e364706816aba3e25717850c26c9cd0d89d
+  assert.equal(sha1Hex(Buffer.from('abc')), 'a9993e364706816aba3e25717850c26c9cd0d89d');
+});


### PR DESCRIPTION
## Summary

Fixes the recurring companion-APK install failure: a manually-dropped APK kept the **same `versionCode`** as what was installed, so the device couldn't update over it (and any signing-key mismatch forced an uninstall). New `npm run apk:companion` (`scripts/build-companion-apk.mjs`) makes every drop reliably update-installable:

- **Auto versionCode** — stamps a strictly-increasing timestamp `versionCode` (minutes since epoch) via `flutter build --build-number`. No pubspec edits, no git churn; back-to-back builds never collide (a build takes minutes).
- **Signer verification** — confirms the built APK's signer cert == the upload key `ba7b147d…` and **refuses to drop** a debug-/wrong-key build (the `INSTALL_FAILED_UPDATE_INCOMPATIBLE` cause). Errors early if `key.properties` is missing (would fall back to debug signing).
- **Drops to the served path** — `companion/castwright-companion.apk` + a refreshed `.sha1`, mirroring `server/src/companion/apk.ts` (honors `COMPANION_APK_PATH`).

Documented in CLAUDE.md under Commands.

## Test plan

- `node --test scripts/tests/build-companion-apk.test.mjs` — **7/7 pass** (pure helpers: timestamp versionCode is monotonic, floors sub-minute, stays in `(10.8M, 2.1e9)`; signer-cert parse incl. lowercase + absent→null; sha1 known vector). Auto-runs via `test:hooks`.
- **End-to-end run on this box:** built the release APK, signer verified `ba7b147d…`, dropped with `versionCode 29696185` (> the installed `10800000`, so it update-installs), `.sha1` refreshed.
- `prettier --check` + `eslint` clean on the new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)