### PR TITLE
fix(server): rate-limit companion /redeem + cover redeem-browser 410 (#900 follow-ups)

### DIFF
--- a/docs/features/225-lan-browser-device-auth.md
+++ b/docs/features/225-lan-browser-device-auth.md
@@ -34,7 +34,7 @@ Design of record: [`../superpowers/specs/2026-06-18-lan-browser-device-auth-desi
 4. **`persist()` writes then sets the cache** (`device-tokens.ts`): `await writeJsonAtomic(...); cache = devices;` — never cache-before-write (else a failed write leaves a phantom device or resurrects a revoked one on restart). `persist` writes `{ schema: 2 }`.
 5. **CSRF: cookie-bearing writes are Origin-gated** (`server/src/csrf-origin.ts`, `requireSameOrigin`): only state-changing methods carrying `__Host-cw_lan` are checked, via the SAME `readCwLanCookie` parser as the guard (no parser divergence). Allow-list = `enumerateLanUrls(port,'https').urls` + explicit loopback origins, recomputed per request, **fails closed** to loopback-only if enumeration throws, and 403s when Origin+Referer are both absent.
 6. **All token-minting paths are loopback-gated** (`devices.ts`: `POST /api/devices` admin mint + `POST /api/devices/pair-session`) — a stolen browser cookie cannot mint a fresh durable token that survives revocation.
-7. **`/redeem-browser` is pre-guard, code-gated, and LAN-only** (`server/src/routes/pairing.ts` + mount order in `app.ts`): mounted on `pairRedeemRouter` **before** `requireLanToken`; `isPrivateNetworkRequest` 403 + `isLanTokenEnforced` 409 + dedicated 5/min `browserRedeemLimiter` + its own `express.json({ limit: '1kb' })`. Sets `__Host-cw_lan` (`HttpOnly; Secure; SameSite=Strict; Path=/`) and **never returns the raw token in the body**.
+7. **`/redeem-browser` is pre-guard, code-gated, and LAN-only** (`server/src/routes/pairing.ts` + mount order in `app.ts`): mounted on `pairRedeemRouter` **before** `requireLanToken`; `isPrivateNetworkRequest` 403 + `isLanTokenEnforced` 409 + the shared 5/min `redeemLimiter` + its own `express.json({ limit: '1kb' })`. Sets `__Host-cw_lan` (`HttpOnly; Secure; SameSite=Strict; Path=/`) and **never returns the raw token in the body**. The companion `/redeem` shares the same `redeemLimiter` (the global `apiLimiter` never covered these pre-guard routes).
 8. **`app.ts` middleware order** (`server/src/app.ts`): `pairRedeemRouter` (pre-guard, before the global `express.json({limit:'20mb'})` so the 1 KB caps engage) → `requireLanToken` → `requireSameOrigin` → routers. `assertNoTrustProxy(app)` runs at assembly; `trust proxy` stays unset (loopback gate would be spoofable otherwise).
 9. **`#/pair` is a top-level, Layout-free route** (`src/routes/index.tsx`): a second `createHashRouter` entry (NOT under `Layout.children`), so an unauthorized phone doesn't fire Layout's boot effects (no 401-storm). `PairShell` reads `c` via `useSearchParams`.
 10. **Library scan failure is recoverable** (`src/store/library-slice.ts` `error`/`hydrateError`; `src/components/layout.tsx` catch; `src/views/book-library.tsx`): a failed `/api/library` shows "Couldn't load — Retry", not an eternal skeleton. `hydrate` clears `error`.
@@ -47,7 +47,7 @@ Design of record: [`../superpowers/specs/2026-06-18-lan-browser-device-auth-desi
 - `server/src/lan-auth.test.ts` — cookie-auth pass/reject through the guard; header/Bearer/query paths intact; loopback bypass.
 - `server/src/csrf-origin.test.ts` — allowed/loopback origin pass, foreign origin 403, no-Origin+no-Referer 403, header-token bypass, parser-agreement (a cookie `cookie.parse` accepts still gates).
 - `server/src/routes/devices.test.ts` — `pair-session` loopback-only URL payload + 409; admin mint 403 from non-loopback; label cap.
-- `server/src/routes/pairing.test.ts` — `/redeem-browser` cookie-set + no-raw-token + 409 + 5/min 429 + **403 off-network**; `/redeem` **403 off-network**; body-size 413 caps on both routes (parser-order regression anchor).
+- `server/src/routes/pairing.test.ts` — `/redeem-browser` cookie-set + no-raw-token + 409 + 5/min 429 + **403 off-network** + **410 (already-consumed code)**; `/redeem` **403 off-network** + **5/min 429** (shared `redeemLimiter`); body-size 413 caps on both routes (parser-order regression anchor).
 - `server/src/routes/lan-cookie-integration.test.ts` — **the real chain**: redeem-browser → capture `Set-Cookie` → replay on a guarded `GET /api/library` (not 401) + foreign-Origin write → 403. No mocks, temp workspace, real `app`.
 - `server/src/lan-safety.test.ts` + `server/src/lan-auth.invariants.test.ts` — `assertNoTrustProxy` throws when set; `lanExposureWarning` fires only when bound-LAN + token-unset; `app.ts` mount order (`requireSameOrigin` after `requireLanToken`) + no `trust proxy` in source.
 - `server/src/config/registry.test.ts` — `lan.deviceTokenTtlDays` knob (default 30, integer, `apply: live`) + the `lan-access` group.
@@ -70,8 +70,8 @@ Real device, the real backend (`npm run start:lan` with `LAN_HTTPS=1` + `LAN_AUT
 
 - Per-user accounts / roles, or a read-only token tier — any valid token grants the full `/api` surface (single-owner LAN tool). See the design's "Defense-in-depth notes".
 - The shared-secret `LAN_AUTH_TOKEN` remains an unexpiring, unrevocable, CSRF-exempt superuser (companion bootstrap; exposed in the LAN QR) — device tokens are the revocable/expiring tier.
-- Global `apiLimiter` does not cover the pre-guard pair routes (pre-existing; `/redeem-browser` has its own limiter, `/redeem` is single-use code-gated) — follow-up on #900.
-- A direct unit test for the `/redeem-browser` 410 path — follow-up on #900.
+
+(The two #900 follow-ups are **resolved**: the global `apiLimiter` doesn't cover the pre-guard pair routes, so `/redeem` now shares the dedicated `redeemLimiter` with `/redeem-browser`; and the `/redeem-browser` 410 consumed-code path now has a direct unit test.)
 
 ## Ship notes
 

--- a/docs/superpowers/specs/2026-06-18-lan-browser-device-auth-design.md
+++ b/docs/superpowers/specs/2026-06-18-lan-browser-device-auth-design.md
@@ -461,10 +461,11 @@ cross-origin write is 403. (A legacy companion token, if any, re-pairs once.)
 
 Filed as `srv-42` (#900, `area:fs`/`type:feature`) and **delivered in the same
 PR** (`Closes #900`), so it never sits on `docs/BACKLOG.md` (the backlog tracks
-outstanding work). Two follow-ups noted on #900: global `apiLimiter` doesn't
-cover the pre-guard pair routes (pre-existing; `/redeem-browser` has its own
-limiter, `/redeem` is single-use code-gated); add a direct unit test for the
-`/redeem-browser` 410 path.
+outstanding work). The two #900 follow-ups were **resolved** in a fast-follow
+(`fix/server-redeem-hardening`): the global `apiLimiter` doesn't cover the
+pre-guard pair routes, so `/redeem` now shares the dedicated `redeemLimiter`
+with `/redeem-browser`; and the `/redeem-browser` 410 consumed-code path got a
+direct unit test.
 
 ## Decisions locked (after three review rounds)
 

--- a/server/src/routes/pairing.test.ts
+++ b/server/src/routes/pairing.test.ts
@@ -64,7 +64,7 @@ vi.mock('../workspace/device-tokens.js', () => ({
   clampTtlDays: (v: unknown) => (typeof v === 'number' && Number.isInteger(v) && v >= 1 ? v : 30),
 }));
 
-import { pairSessionRouter, pairRedeemRouter, browserRedeemLimiter } from './pairing.js';
+import { pairSessionRouter, pairRedeemRouter, redeemLimiter } from './pairing.js';
 import { _resetPairingSessionsForTests, createPairingSession } from '../workspace/pairing-sessions.js';
 import { isLoopbackRequest, isLanTokenEnforced, isPrivateNetworkRequest } from '../lan-auth.js';
 
@@ -78,7 +78,7 @@ function appWith(router: express.Router) {
 describe('pairing routes', () => {
   beforeEach(() => {
     _resetPairingSessionsForTests();
-    browserRedeemLimiter.resetKey('::ffff:127.0.0.1');
+    redeemLimiter.resetKey('::ffff:127.0.0.1');
   });
 
   it('POST /session returns a qrPayload + code + fpTag', async () => {
@@ -155,6 +155,23 @@ describe('pairing routes', () => {
     const res = await request(appWith(pairRedeemRouter)).post('/api/pair/redeem-browser').send({ code });
     expect(res.status).toBe(403);
   });
+
+  // Follow-up (#900): the companion /redeem now shares the dedicated redeemLimiter
+  // (the global apiLimiter never covered these pre-guard routes).
+  it('redeem rate-limits after 5/min', async () => {
+    for (let i = 0; i < 5; i++) await request(appWith(pairRedeemRouter)).post('/api/pair/redeem').send({ code: 'WRONGWRONGWRONG1' });
+    const res = await request(appWith(pairRedeemRouter)).post('/api/pair/redeem').send({ code: 'WRONGWRONGWRONG1' });
+    expect(res.status).toBe(429);
+  });
+
+  // Follow-up (#900): the redeem-browser consumed/expired (410) branch was untested.
+  it('redeem-browser returns 410 for an already-consumed code', async () => {
+    const { code } = createPairingSession('x', undefined, 10);
+    const first = await request(appWith(pairRedeemRouter)).post('/api/pair/redeem-browser').send({ code });
+    expect(first.status).toBe(201);
+    const second = await request(appWith(pairRedeemRouter)).post('/api/pair/redeem-browser').send({ code });
+    expect(second.status).toBe(410);
+  });
 });
 
 // Body-size enforcement tests — reproduce the parser-order bug by building a
@@ -182,7 +199,7 @@ function appWithPreGuardRouterFirst() {
 describe('pairing body-size cap — parser-order regression', () => {
   beforeEach(() => {
     _resetPairingSessionsForTests();
-    browserRedeemLimiter.resetKey('::ffff:127.0.0.1');
+    redeemLimiter.resetKey('::ffff:127.0.0.1');
   });
 
   // These two tests FAIL before the fix (global parser accepts the body, no 413)

--- a/server/src/routes/pairing.ts
+++ b/server/src/routes/pairing.ts
@@ -65,7 +65,20 @@ pairSessionRouter.post('/session', (req: Request, res: Response) => {
 
 export const pairRedeemRouter = Router();
 
-pairRedeemRouter.post('/redeem', express.json({ limit: '1kb' }), async (req: Request, res: Response) => {
+// Dedicated per-IP rate limiter shared by BOTH pre-guard mint endpoints
+// (/redeem + /redeem-browser). The global apiLimiter does NOT cover pre-guard
+// routes (the router responds before it runs), so without this the code-gated
+// mints had no rate cap. NOT skipped under Vitest (the global apiLimiter is).
+// Exported so tests can reset its store between cases (shared IP under supertest).
+export const redeemLimiter = rateLimit({
+  windowMs: 60_000,
+  limit: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => req.ip ?? 'unknown',
+});
+
+pairRedeemRouter.post('/redeem', redeemLimiter, express.json({ limit: '1kb' }), async (req: Request, res: Response) => {
   if (!isPrivateNetworkRequest(req)) {
     res.status(403).json({ error: 'Pairing can only be redeemed from the local network.' });
     return;
@@ -83,19 +96,9 @@ pairRedeemRouter.post('/redeem', express.json({ limit: '1kb' }), async (req: Req
   res.status(201).json({ token });
 });
 
-// dedicated limiter — NOT skipped under Vitest (the global apiLimiter is).
-// Exported so tests can reset its store between cases (shared IP under supertest).
-export const browserRedeemLimiter = rateLimit({
-  windowMs: 60_000,
-  limit: 5,
-  standardHeaders: true,
-  legacyHeaders: false,
-  keyGenerator: (req) => req.ip ?? 'unknown',
-});
-
 pairRedeemRouter.post(
   '/redeem-browser',
-  browserRedeemLimiter,
+  redeemLimiter,
   express.json({ limit: '1kb' }),
   async (req: Request, res: Response) => {
     // Same local-network restriction app-17 applies to /redeem: this sibling


### PR DESCRIPTION
## Summary

Closes out the two follow-ups noted on #900 (srv-42 / LAN browser device-auth):

1. **Companion `/redeem` now rate-limited.** The global `apiLimiter` never covered the pre-guard pair routes (the router responds before it runs), so `/redeem` had no rate cap. `browserRedeemLimiter` is renamed to a shared **`redeemLimiter`** (5/min/IP) and applied to **both** `/redeem` and `/redeem-browser`. Hardens the companion 40-bit-code mint.
2. **`/redeem-browser` 410 path covered.** Added a direct unit test for the already-consumed-code (410) branch, which was previously untested.

Docs: regression plan `docs/features/225` (invariant + out-of-scope + test plan) and the design spec updated to mark both follow-ups resolved.

## Test plan

`npm run verify` green locally (typecheck + lint + all test tiers + `test:e2e` + `test:e2e:visual` + build). New `pairing.test.ts` cases: `/redeem` 429 after 5/min (shared `redeemLimiter`); `/redeem-browser` 410 for an already-consumed code. The `lan-cookie-integration.test.ts` chain stays green.

Refs #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)