### PR TITLE
fix(frontend): LAN access card hides revoked devices + cert-trust helper

### DIFF
--- a/src/components/lan-access-card.test.tsx
+++ b/src/components/lan-access-card.test.tsx
@@ -64,6 +64,28 @@ describe('LanAccessCard', () => {
     await waitFor(() => expect(api.revokeDevice).toHaveBeenCalledWith('1'));
   });
 
+  it('does not render a revoked device', async () => {
+    vi.mocked(api.listDevices).mockResolvedValue({ devices: [{ ...DEVICE, revoked: true }] });
+
+    render(<LanAccessCard />);
+
+    await waitFor(() => screen.getByText('LAN access'));
+    expect(screen.queryByText('Mike phone')).not.toBeInTheDocument();
+  });
+
+  it('Revoke removes the row (the re-fetch returns it revoked)', async () => {
+    vi.mocked(api.listDevices)
+      .mockResolvedValueOnce({ devices: [DEVICE] })
+      .mockResolvedValueOnce({ devices: [{ ...DEVICE, revoked: true }] });
+    vi.mocked(api.revokeDevice).mockResolvedValue({ ok: true });
+
+    render(<LanAccessCard />);
+
+    await waitFor(() => screen.getByText('Mike phone'));
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke' }));
+    await waitFor(() => expect(screen.queryByText('Mike phone')).not.toBeInTheDocument());
+  });
+
   it('Authorize a device: type label → createDevicePairSession called → QR img appears', async () => {
     vi.mocked(api.listDevices).mockResolvedValue({ devices: [] });
     vi.mocked(api.createDevicePairSession).mockResolvedValue(PAIR_SESSION);

--- a/src/components/lan-access-card.tsx
+++ b/src/components/lan-access-card.tsx
@@ -25,7 +25,15 @@ export function LanAccessCard() {
     try { setSession(await api.createDevicePairSession({ label: label.trim() || 'Device' })); }
     catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
   };
-  const revoke = async (id: string) => { await api.revokeDevice(id); refresh(); };
+  const revoke = async (id: string) => {
+    setErr(null);
+    try {
+      await api.revokeDevice(id);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    }
+    refresh(); // re-read: a revoked device drops out of the list below
+  };
 
   return (
     <section className="bg-white rounded-3xl border border-ink/10 shadow-card p-6">
@@ -48,7 +56,7 @@ export function LanAccessCard() {
             </div>
           )}
           <ul className="mt-6 divide-y divide-ink/8">
-            {(devices ?? []).map((d) => (
+            {(devices ?? []).filter((d) => !d.revoked).map((d) => (
               <li key={d.id} className="py-3 flex items-center justify-between gap-3 text-sm">
                 <span className="text-ink">
                   <span className="font-medium">{d.label}</span>
@@ -61,6 +69,18 @@ export function LanAccessCard() {
               </li>
             ))}
           </ul>
+          <details className="mt-5 text-xs text-ink/55">
+            <summary className="cursor-pointer text-ink/70">Phone shows "Not secure" / certificate warning?</summary>
+            <p className="mt-2 leading-relaxed">
+              The phone's browser must trust this computer's local certificate (one-time). Run{' '}
+              <code className="px-1 py-0.5 rounded bg-ink/5">npm run install:cert-mobile</code> on this
+              computer — it prints a QR + per-OS steps to download and install the root certificate
+              (served at <code className="px-1 py-0.5 rounded bg-ink/5">/cert/root.crt</code>). On
+              Android: Settings → Security → Install a certificate → CA certificate; on iOS: install
+              the profile, then General → About → Certificate Trust Settings → enable it. The companion
+              app trusts it automatically (cert pinning) — only browsers need this step.
+            </p>
+          </details>
         </>
       )}
     </section>


### PR DESCRIPTION
## Summary

Two fixes to the shipped LAN-access Admin card (#900 / srv-42):

1. **Revoke now visibly removes the device.** `revokeDevice` marks the record `revoked: true` (the token is killed — the guard rejects it), but `listDevices()` returns *all* records and the card never filtered them, so the row stayed put → "Revoke does nothing." The card now filters out revoked devices and **surfaces revoke errors** (previously swallowed — no `.catch`).
2. **Cert-trust helper.** A collapsible "Phone shows 'Not secure'?" note on the card (the spec called for linking the cert-install steps; it was missing) explaining the one-time mkcert root-CA trust + pointing to `npm run install:cert-mobile` and `/cert/root.crt`.

## Test plan

`npm run verify` green. New `lan-access-card.test.tsx` cases: a revoked device is not rendered; Revoke removes the row after the re-fetch returns it revoked.

Refs #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)