### PR TITLE
fix(app): sync transport to real play state + configure audio focus

### DIFF
--- a/apps/android/lib/main.dart
+++ b/apps/android/lib/main.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:app_links/app_links.dart';
 import 'package:audio_service/audio_service.dart';
+import 'package:audio_session/audio_session.dart';
 import 'package:flutter/material.dart';
 
 import 'src/data/cert_pinning.dart';
@@ -22,6 +23,15 @@ import 'src/ui/pairing_screen.dart';
 /// needed to open the downloaded library).
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  // app-5: configure the OS audio session BEFORE any playback so just_audio
+  // actually requests/holds audio focus and auto-pauses on interruptions and
+  // route changes (headset unplug / Bluetooth / Android Auto disconnect emit
+  // becomingNoisy). Without this, focus loss silently stalls audio while the
+  // engine still reports `playing == true` — the lock-screen/headset buttons
+  // then act on a desynced state and a single press appears dead. `.speech()`
+  // is the audiobook-appropriate preset (matches the audio_service example).
+  final session = await AudioSession.instance;
+  await session.configure(const AudioSessionConfiguration.speech());
   // app-5/app-9: the media session must exist before the UI (lock-screen /
   // Bluetooth / Android Auto). The runtime attaches the live player once paired.
   final handler = await AudioService.init(

--- a/apps/android/lib/src/data/player_controller.dart
+++ b/apps/android/lib/src/data/player_controller.dart
@@ -101,6 +101,13 @@ class PlayerController {
   final StreamController<NowPlaying?> _nowPlaying =
       StreamController<NowPlaying?>.broadcast();
 
+  /// Re-broadcasts the engine's playing state so the player UI *and* the media
+  /// session can each subscribe independently (the engine stream gets a single
+  /// subscriber here). Decoupling this is what lets the in-app transport track
+  /// out-of-band stops (headset/Android Auto disconnect, audio-focus loss).
+  final StreamController<bool> _playing =
+      StreamController<bool>.broadcast();
+
   /// Emits a chapter's `uuid` when it plays to its end (app-4 finished-tracking).
   final StreamController<String> _chapterCompleted =
       StreamController<String>.broadcast();
@@ -118,8 +125,10 @@ class PlayerController {
   Stream<Duration?> get durationStream => _engine.durationStream;
   Duration? get duration => _engine.duration;
 
-  /// Playing/paused for the media session.
-  Stream<bool> get playingStream => _engine.playingStream;
+  /// Playing/paused for the media session and the in-app transport. Mirrors the
+  /// engine via the single [_playingSub] subscription, re-broadcast so multiple
+  /// listeners (UI + handler) never multi-subscribe the engine stream.
+  Stream<bool> get playingStream => _playing.stream;
   bool get playing => _engine.playing;
 
   /// Emits on every chapter load (incl. auto-advance) so the media session
@@ -277,6 +286,9 @@ class PlayerController {
 
   // fs-16: drive the accumulator from the engine's playing-state stream.
   void _onPlayingChanged(bool isPlaying) {
+    // Re-broadcast first so the UI/media session update even when no accumulator
+    // is wired (the early-return below is stats-only).
+    if (!_playing.isClosed) _playing.add(isPlaying);
     // Accrual is gated on play/pause intent only. Safe because playback is always
     // from local downloaded files (setFilePath), so there are no sustained buffer
     // stalls. If streaming (setStreamUrl) is ever wired into the player flow,
@@ -344,6 +356,7 @@ class PlayerController {
     await _sub?.cancel();
     await _completionSub?.cancel();
     await _playingSub?.cancel();
+    await _playing.close();
     await _nowPlaying.close();
     await _chapterCompleted.close();
     await _engine.dispose();

--- a/apps/android/lib/src/ui/player_screen.dart
+++ b/apps/android/lib/src/ui/player_screen.dart
@@ -104,12 +104,19 @@ class _PlayerScreenState extends State<PlayerScreen> {
           _chapters = chapters;
           _finished = finished;
           _ready = true;
+          _playing = widget.runtime.player.playing; // seed from real state
         });
         _ensureCurrentPeaks();
         WidgetsBinding.instance.addPostFrameCallback((_) {
           _scrollToCurrent(animate: false);
         });
       }
+      // Track the real engine playing state so the transport reflects out-of-band
+      // stops (headset/Android Auto disconnect, audio-focus loss) — not a local
+      // flag that only flips on tap (which caused the "tap twice to restart" bug).
+      _subs.add(widget.runtime.player.playingStream.listen((playing) {
+        if (mounted) setState(() => _playing = playing);
+      }));
       // Move the highlight + progress as chapters change (incl. auto-advance).
       _subs.add(widget.runtime.player.nowPlayingStream.listen((_) {
         if (mounted) {
@@ -143,18 +150,20 @@ class _PlayerScreenState extends State<PlayerScreen> {
 
   Future<void> _playChapter(String uuid) async {
     await widget.runtime.player.playChapter(uuid);
-    if (mounted) setState(() => _playing = true);
+    // _playing follows playingStream; no optimistic flip.
     _ensureCurrentPeaks();
   }
 
   Future<void> _togglePlay() async {
     final p = widget.runtime.player;
-    if (_playing) {
+    // Decide off the real engine state, not a local flag that can be stale after
+    // an out-of-band stop — otherwise the first tap is a silent no-op.
+    if (p.playing) {
       await p.pause();
     } else {
       await p.play();
     }
-    if (mounted) setState(() => _playing = !_playing);
+    // _playing updates via playingStream.
   }
 
   bool _isFinished(String uuid) => _finished.contains(uuid);

--- a/apps/android/pubspec.lock
+++ b/apps/android/pubspec.lock
@@ -98,7 +98,7 @@ packages:
     source: hosted
     version: "0.1.4"
   audio_session:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: audio_session
       sha256: "7217b229db57cc4dc577a8abb56b7429a5a212b978517a5be578704bfe5e568b"

--- a/apps/android/pubspec.yaml
+++ b/apps/android/pubspec.yaml
@@ -54,6 +54,11 @@ dependencies:
   image: ^4.9.1
   just_audio: ^0.10.5
   audio_service: ^0.18.18
+  # app-5: configure the OS audio session (audio focus + becomingNoisy on
+  # headset/route change) in main(). Already resolved transitively via
+  # just_audio/audio_service; pinned here as a direct dep because main.dart
+  # imports it. Constraint tracks the resolved version.
+  audio_session: ^0.2.3
   # app-9: per-folder BehaviorSubjects backing AudioHandler.subscribeToChildren,
   # so the car browse tree can push a "children changed" refresh to Android Auto.
   # Already resolved transitively via audio_service; pinned here as a direct dep.

--- a/apps/android/test/data/player_controller_playing_stream_test.dart
+++ b/apps/android/test/data/player_controller_playing_stream_test.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:castwright/src/data/audio_engine.dart';
+import 'package:castwright/src/data/playback_store.dart';
+import 'package:castwright/src/data/player_controller.dart';
+import 'package:castwright/src/domain/skip_behavior.dart';
+
+/// Engine whose playing state is driven by the test, so we can assert the
+/// controller re-broadcasts out-of-band stops (audio-focus loss / headset
+/// disconnect) — the seam the in-app transport now subscribes to.
+class DrivableEngine implements AudioEngine {
+  final _playing = StreamController<bool>.broadcast();
+  bool _playingNow = false;
+
+  void emitPlaying(bool v) {
+    _playingNow = v;
+    _playing.add(v);
+  }
+
+  @override
+  bool get playing => _playingNow;
+  @override
+  Stream<bool> get playingStream => _playing.stream;
+
+  @override
+  Duration get position => Duration.zero;
+  @override
+  Stream<Duration> get positionStream => const Stream.empty();
+  @override
+  Duration? get duration => null;
+  @override
+  Stream<Duration?> get durationStream => const Stream.empty();
+  @override
+  Stream<void> get completionStream => const Stream.empty();
+
+  @override
+  Future<void> setFilePath(String path) async {}
+  @override
+  Future<void> setStreamUrl(String url, {Map<String, String>? headers}) async {}
+  @override
+  Future<void> play() async => emitPlaying(true);
+  @override
+  Future<void> pause() async => emitPlaying(false);
+  @override
+  Future<void> seek(Duration p) async {}
+  @override
+  Future<void> setSpeed(double s) async {}
+  @override
+  Future<void> setVolumeBoost(double db) async {}
+  @override
+  Future<void> dispose() async => _playing.close();
+}
+
+class _MemStore implements PlaybackStore {
+  @override
+  Future<void> savePlayback(String b, String u, int ms, String iso) async {}
+  @override
+  Future<PlaybackPoint?> loadPlayback(String b) async => null;
+}
+
+void main() {
+  test('playingStream re-broadcasts engine playing changes (incl. out-of-band)',
+      () async {
+    final engine = DrivableEngine();
+    final controller = PlayerController(
+      audioEngine: engine,
+      playbackStore: _MemStore(),
+      playlistLoader: (_) async => const [],
+      clock: () => DateTime.utc(2026, 6, 19, 12),
+    );
+
+    final seen = <bool>[];
+    final sub = controller.playingStream.listen(seen.add);
+
+    await controller.play(); // engine emits true
+    await Future<void>.delayed(Duration.zero);
+    engine.emitPlaying(false); // out-of-band stop (focus loss / unplug)
+    await Future<void>.delayed(Duration.zero);
+
+    expect(seen, [true, false]);
+    await sub.cancel();
+    await controller.dispose();
+  });
+
+  test('two listeners can subscribe without multi-subscribing the engine',
+      () async {
+    // The engine stream gets a single subscriber (the controller); UI + media
+    // session both listen to the re-broadcast. A passthrough would have thrown
+    // on a single-subscription engine stream.
+    final engine = DrivableEngine();
+    final controller = PlayerController(
+      audioEngine: engine,
+      playbackStore: _MemStore(),
+      playlistLoader: (_) async => const [],
+      clock: () => DateTime.utc(2026, 6, 19, 12),
+    );
+
+    final a = controller.playingStream.listen((_) {});
+    final b = controller.playingStream.listen((_) {});
+    engine.emitPlaying(true);
+    await Future<void>.delayed(Duration.zero);
+
+    await a.cancel();
+    await b.cancel();
+    await controller.dispose();
+  });
+}

--- a/apps/android/test/ui/player_screen_test.dart
+++ b/apps/android/test/ui/player_screen_test.dart
@@ -25,6 +25,27 @@ void main() {
     expect(find.byKey(const Key('progress-ht1-c2')), findsOneWidget);
   });
 
+  testWidgets(
+      'transport play/pause icon reflects the real engine playing state, not a local flag',
+      (tester) async {
+    // Regression: the in-app player used a local `_playing` bool that only
+    // flipped on tap, so it never tracked the engine. When playback stopped
+    // out-of-band (headset/Android Auto disconnect) the icon stayed "pause"
+    // and the first tap was a silent no-op ("click twice to restart"). The
+    // demo engine reports playing==true, so a correctly-bound transport shows
+    // the pause icon without any tap.
+    final rt = await buildDemoRuntime(fs: InMemoryFileStore(), root: '/demo');
+    await tester.pumpWidget(MaterialApp(
+      home: PlayerScreen(
+          runtime: rt, bookId: 'hollow-tide-1', title: 'The Drowning Bell'),
+    ));
+    await tester.pumpAndSettle();
+
+    final button = tester.widget<IconButton>(
+        find.byKey(const Key('player-playpause')));
+    expect((button.icon as Icon).icon, Icons.pause_circle);
+  });
+
   testWidgets('bottom transport names the current chapter', (tester) async {
     final rt = await buildDemoRuntime(fs: InMemoryFileStore(), root: '/demo');
     await tester.pumpWidget(MaterialApp(

--- a/docs/superpowers/specs/2026-06-19-responsive-topbar-nav-design.md
+++ b/docs/superpowers/specs/2026-06-19-responsive-topbar-nav-design.md
@@ -1,0 +1,184 @@
+# Responsive top-bar nav — `<xl` hamburger drawer
+
+**Date:** 2026-06-19
+**Status:** design (approved; revised after adversarial review)
+**Area:** frontend / `src/components/top-bar.tsx`
+
+## Problem
+
+On tablet and phone viewports the top-bar navigation is unusable:
+
+1. **The nav strip starves and disappears.** The central nav lives in a
+   `flex-1 min-w-0 … overflow-x-auto` strip (`top-bar.tsx:292`). The logo, the
+   breadcrumb (`projectTitle`, `shrink-0`, `max-w-none` on `sm:`+ so a long
+   title never truncates — line 286), and the whole right cluster (Status pill,
+   Admin, version, help, theme, avatar — all `shrink-0`) claim the row first.
+   The flex-1 nav collapses toward zero width, so when a book is open the
+   per-book tabs (Manuscript, Cast, Voices, Generate, Listen, Log) scroll out of
+   sight — **you can't reach Cast or Manuscript.**
+2. **Horizontal-scroll-to-reach is hostile on touch.** Even with a sliver of
+   width, the tabs sit in an `overflow-x-auto` lane with no scroll affordance —
+   "almost impossible" to hit on a tablet.
+3. **Touch targets shrink at the wrong breakpoint.** Every nav button is
+   `min-h-[44px] sm:min-h-0` (lines 299, 312), so at `sm:`+ (≥640px — *all*
+   tablets) the WCAG 2.5.5 44px target is removed. Tablets are touch devices.
+
+The plan-81 "swipeable strip" decision (`top-bar.tsx:240`) is the root cause: a
+squeezed horizontal-scroll strip does not survive a starved row.
+
+Confirmed by on-device screenshots (book open, tablet in landscape → no tab
+strip visible) and the user report ("when a book is selected the whole menu
+disappears"; "you can't even get to cast or manuscript").
+
+## Goal
+
+Below `xl` (1280px), the nav collapses into a hamburger → drawer menu so every
+destination is reachable with a comfortable touch target. Desktop (`xl+`) is
+pixel-identical to today.
+
+## Decisions (locked)
+
+- **Scope = nav only.** Only the navigation strip moves into the drawer. Help
+  (its own working portaled `min-h-[44px]` menu), Theme, Version, Status, Admin,
+  queue, and avatar all stay in the bar, unchanged. This deliberately avoids the
+  regression surface flagged by review (no theme-row reshape, no version-
+  discoverability change, no duplicate Help/Theme selectors).
+- **Breakpoint = `xl` (1280px).** A real landscape tablet (the device in the
+  user's screenshots) commonly reports ≥1024 CSS px, so an `lg` breakpoint would
+  not trigger on it. `xl` collapses for phones + portrait *and* landscape
+  tablets. A narrow desktop window (1024–1279px) also gets the hamburger — this
+  is acceptable and arguably correct, since the full strip genuinely does not fit
+  there with a book open.
+
+## Design
+
+### Layout on `<xl`
+
+- A hamburger button (`≡`) is the **leftmost** element (`shrink-0`,
+  `xl:hidden`), then logo + breadcrumb (matches the approved mockup).
+- The inline nav `<nav>`s (TABS / GLOBAL_NAV) become `hidden xl:flex`, so they
+  no longer compete for row width. Removing the strip (the biggest space
+  consumer) frees enough room for the breadcrumb + the unchanged right cluster
+  to fit at tablet widths; the existing `overflow-x-clip` + `truncate
+  max-w-[140px]` on the title (load-bearing — keep them) handle the 375–412px
+  phone edge as they do today.
+- The hamburger renders **only when there is nav to show** — i.e. when
+  `stage === 'ready'` (per-book tabs) OR `showGlobalNav` (books/voices/changelog).
+  On other stages (upload, analysing, confirm, account, admin, help,
+  model-manager) no strip exists today and none is added — parity with desktop;
+  the logo remains the home affordance.
+
+### The drawer
+
+A left slide-in panel, **portaled to `document.body`** (app convention; the
+clip-path lesson from the voice-compare modal), following the **proven
+ProfileDrawer pattern** (`profile-drawer.tsx:803–806`): a `fixed inset-x-0
+top-16 bottom-0 bg-ink/30` scrim that closes on click, and a `fixed top-16
+bottom-0 left-0 w-[min(80vw,320px)]` panel that slides in from the left. **No
+body-scroll-lock** (ProfileDrawer doesn't use one; copying it avoids a net-new
+mechanism and the sticky-header interaction). `top-16` keeps the top bar — and
+the always-visible Status pill — interactive while the drawer is open.
+
+Behaviour (mirrors `HelpMenu` in the same file — portal + outside-click +
+Escape, already implemented there):
+- Opens on `≡` tap; trigger carries `aria-haspopup="menu"` /
+  `aria-expanded={open}` and `data-testid="topbar-nav-toggle"`.
+- **Content is unmounted when closed** (`{open && createPortal(...)}`), exactly
+  like `HelpMenu`. This is the key duplicate-selector mitigation (see Testing).
+- Closes on: selecting a destination, scrim/outside click, Escape.
+- On open, focus moves to the first drawer item; on Escape, focus returns to `≡`.
+
+Drawer contents are **stage-aware**, mirroring exactly what the desktop strip
+shows — no new destinations:
+
+| Stage | Drawer rows |
+|---|---|
+| `ready` (book open) | the 6 per-book tabs, active row marked `aria-current` |
+| `books` / `voices` / `changelog` | Books, Voices, Change log, active row marked |
+
+Each row is a full-width control, `min-h-[44px]`, left-aligned label, optional
+trailing check on the active destination, and calls the **same handler** the
+inline button does (`setView(id)` for tabs; `onHome`/`onOpenVoices`/
+`onOpenChangelog` via the existing `onGlobal` map). Rows carry **distinct**
+testids (`data-testid="nav-drawer-link-{id}"`) — they do NOT reuse the inline
+buttons' names-as-only-selector, so tests can disambiguate.
+
+### Touch-target fix
+
+The inline buttons' `min-h-[44px] sm:min-h-0` is now moot for nav: the inline
+strip is `xl`-only (pointer devices), and the drawer rows carry the 44px target
+for touch. No sub-44px *nav* tap zones remain `<xl`.
+
+### What does NOT change
+
+- Desktop `xl+`: inline strip + full right cluster — byte-identical. The
+  hamburger uses `xl:hidden` (display:none at `xl`), so it is absent from the
+  desktop accessibility tree and tab order.
+- The concurrent-multibook invariant: the Status pill stays visible on all
+  viewports (NOT moved into the drawer).
+- Status / Admin / queue / Help / Theme / Version / avatar — all unchanged in
+  position and behaviour. (Known, deliberate out-of-scope: their
+  `min-h-[44px] sm:min-h-0` touch sizing on tablet is the existing app-wide
+  convention and is not re-keyed here — see Out of scope.)
+- Hash-router grammar; `setView` / `onGlobal` dispatch wiring.
+
+## Components & boundaries
+
+All changes local to `src/components/top-bar.tsx`:
+
+- **`TopBar`** — add the `xl:hidden` hamburger trigger (leftmost); change the two
+  inline `<nav>`s from `shrink-0` to `hidden xl:flex shrink-0`. Nothing else in
+  the bar moves.
+- **`NavDrawer`** (new, in-file) — owns drawer open state (local `useState`,
+  like `HelpMenu`), the portal, scrim, focus + Escape + outside-click, and
+  renders the stage-aware rows. Receives the props `TopBar` already holds
+  (`stage`, `view`, `setView`, `onHome`, `onOpenVoices`, `onOpenChangelog`);
+  reuses the existing `TABS` / `GLOBAL_NAV` constants and the `onGlobal` map. No
+  new files, no new shared primitive, no edits to `theme-toggle.tsx` or any
+  other component.
+
+## Testing
+
+**Duplicate-selector safety (the review's top risk):** because the drawer is
+**unmounted when closed**, existing `top-bar.test.tsx` / `layout.test.tsx`
+(which never open the drawer) see only the inline strip — no duplicate "Cast" /
+"Log" / "Change log" / `theme-toggle` nodes. Any test that opens the drawer MUST
+scope queries with `within(getByTestId('topbar-nav-drawer'))` and/or use the
+`nav-drawer-link-{id}` testids. State this in the test file.
+
+**Unit (`src/components/top-bar.test.tsx`):**
+- Hamburger renders for `ready` and global stages, carries `xl:hidden` +
+  `data-testid="topbar-nav-toggle"`, and is ABSENT on a non-nav stage (e.g.
+  `upload`).
+- Drawer is unmounted when closed (`queryByTestId('topbar-nav-drawer')` is null
+  before the trigger is clicked) — guards the duplicate-selector invariant.
+- Opening renders the correct rows per stage (scoped with `within`):
+  `ready` → six tab labels, active one `aria-current`; `books` → Books / Voices
+  / Change log.
+- Clicking a drawer row calls the right handler (`setView('cast')`, `onHome` for
+  Books, `onOpenVoices`, `onOpenChangelog`) and unmounts the drawer.
+- Every drawer row matches `/min-h-\[44px\]/`.
+- Escape and outside/scrim click close the drawer; Escape returns focus to `≡`.
+- Desktop guard: the inline `<nav>` carries `hidden xl:flex` (catches a future
+  regression that drops the desktop strip).
+
+**E2E (`e2e/responsive/`, `mobile-chrome` + `tablet-chrome`):** new spec locking
+the exact reported bug — with a book open, the inline tab strip is not visible,
+the hamburger IS visible, tapping it then "Cast" navigates to the Cast view.
+(`tablet-chrome` = iPad Pro 11 @ 834px < 1280 → hamburger shows; jsdom can't see
+the media query, so this is the only layer that proves the breakpoint.)
+
+**a11y:** the hamburger gets `aria-haspopup`/`aria-expanded`; drawer rows are
+real `<button>`/`<a>` with discernible names and `aria-current` on the active
+one. (The existing `a11y.test.tsx` scans views, not `TopBar`; adding a TopBar
+axe render is a nice-to-have, not required for this change.)
+
+## Out of scope
+
+- Folding Help / Theme / Version into the drawer (Option B — deferred; Help
+  already has a working touch menu).
+- Re-keying the `sm:min-h-0` touch sizing on the Status pill / queue chip / other
+  right-cluster items (existing app-wide convention; not the reported bug).
+- Moving Status / Admin / queue into the drawer (must stay visible).
+- Any change to desktop layout, router grammar, or per-view content.
+- Drawer animation beyond the existing `slide-in` / `fade-in` CSS classes.


### PR DESCRIPTION
## Summary

Fixes broken playback control on the Android companion, reported from the lock screen + Pixel Buds. Two compounding defects:

1. **In-app transport never observed real playback state.** `player_screen.dart` drove its play/pause icon from a local `bool _playing` that only flipped on tap — it never subscribed to `playingStream`. When playback stopped out-of-band (headset / Android Auto disconnect), the flag stayed `true`, so the first tap was a silent `pause()` no-op and only the second tap resumed ("click twice to restart"). The icon now follows the engine: seeded from `player.playing` on load, updated via a `playingStream` subscription; `_togglePlay` decides off the real state. `PlayerController` re-broadcasts the engine's playing state through its own broadcast stream so the UI and media session subscribe independently (single engine subscriber).

2. **No OS audio session was ever configured.** Without it, just_audio never reliably held audio focus or auto-paused on interruptions / becomingNoisy (headset unplug, BT / Android Auto disconnect). Focus loss silently stalled audio while the engine still reported `playing == true`, so the lock-screen + headset buttons acted on a desynced state and a single press appeared dead. `main()` now configures `AudioSessionConfiguration.speech()` before `AudioService.init`; `audio_session` pinned as a direct dep (was transitive).

Diagnosed with the systematic-debugging skill (root cause → failing test → fix).

## Test plan

- New regression test in `test/ui/player_screen_test.dart` — transport icon reflects the real engine playing state (fails before, passes after).
- New `test/data/player_controller_playing_stream_test.dart` — re-broadcast emits engine changes + supports multiple independent listeners.
- Full `flutter test`: 327 passing. `flutter analyze`: clean.
- **On-device (owed):** defect 2 is native audio-focus behavior — not unit-testable. Confirm on the phone: lock-screen + Pixel Buds play/pause drive playback on a single press, and disconnect auto-pauses with the in-app icon flipping to "play".

🤖 Generated with [Claude Code](https://claude.com/claude-code)