### PR TITLE
fix(frontend): keep Help/Theme/Account reachable on the phone top bar (#916)

### DIFF
--- a/e2e/responsive/topbar-nav.spec.ts
+++ b/e2e/responsive/topbar-nav.spec.ts
@@ -41,4 +41,49 @@ test.describe('top-bar nav — responsive collapse', () => {
     // The hamburger is in the DOM but display:none at xl — assert hidden, not absent.
     await expect(page.getByTestId('topbar-nav-toggle')).toBeHidden();
   });
+
+  /* #916 regression — before the inline-chrome trim, the 44px hamburger (added
+     with the responsive nav) pushed the right cluster (Help / Theme / Account)
+     ~120px past the 412px phone viewport, where `overflow-x-clip` hid them: the
+     controls were in the DOM but positioned off-screen and unclickable (this is
+     exactly what timed out the guided-tour spec on the Linux mobile-e2e leg).
+     Assert every right-cluster control's box sits inside the viewport on phone. */
+  test('phone: Help / Theme / Account are inside the viewport (not clipped off-screen)', async ({
+    page,
+  }) => {
+    const width = page.viewportSize()?.width ?? 0;
+    test.skip(width >= 640, 'phone-only: at sm+ the full inline chrome fits and is unchanged');
+
+    await page.goto('/#/');
+    const inViewport = async (locator: ReturnType<typeof page.locator>, label: string) => {
+      await expect(locator, `${label} present`).toBeVisible();
+      const box = await locator.boundingBox();
+      const vw = page.viewportSize()?.width ?? 0;
+      expect(box, `${label} has a box`).not.toBeNull();
+      expect(box!.x, `${label} not clipped off the left`).toBeGreaterThanOrEqual(-1);
+      expect(box!.x + box!.width, `${label} not clipped off the right (vw=${vw})`).toBeLessThanOrEqual(
+        vw + 1,
+      );
+    };
+
+    await inViewport(page.getByTestId('topbar-help'), 'Help button');
+    await inViewport(page.getByTestId('theme-toggle'), 'Theme toggle');
+    await inViewport(page.getByRole('button', { name: /account/i }), 'Account avatar');
+  });
+
+  /* #916 — Admin moves off the inline phone bar into the hamburger drawer (it
+     stays inline at sm+). Confirm it is still reachable on phone via the drawer. */
+  test('phone: Admin is reachable via the hamburger drawer', async ({ page }) => {
+    const width = page.viewportSize()?.width ?? 0;
+    test.skip(width >= 640, 'phone-only: Admin stays an inline pill at sm+');
+
+    await page.goto('/#/');
+    // Inline Admin pill is hidden on a nav stage at phone width.
+    await expect(page.getByTestId('topbar-admin-link')).toBeHidden();
+
+    await page.getByTestId('topbar-nav-toggle').click();
+    await expect(page.getByTestId('topbar-nav-drawer')).toBeVisible();
+    await page.getByTestId('nav-drawer-link-admin').click();
+    await expect(page).toHaveURL(/#\/admin/);
+  });
 });

--- a/src/components/top-bar.test.tsx
+++ b/src/components/top-bar.test.tsx
@@ -673,7 +673,8 @@ describe('TopBar — responsive nav drawer (<xl hamburger)', () => {
     renderWithStore(<TopBar {...makeProps({ stage: 'ready', view: 'listen' })} />);
     fireEvent.click(screen.getByTestId('topbar-nav-toggle'));
     const rows = within(screen.getByTestId('topbar-nav-drawer')).getAllByRole('menuitem');
-    expect(rows.length).toBe(6);
+    /* 6 per-book tabs + the phone-only Admin row (#916). */
+    expect(rows.length).toBe(7);
     for (const r of rows) expect(r.className).toMatch(/min-h-\[44px\]/);
   });
 
@@ -722,6 +723,48 @@ describe('TopBar — responsive nav drawer (<xl hamburger)', () => {
     const inlineNav = screen.getByRole('button', { name: 'Manuscript' }).closest('nav')!;
     expect(inlineNav.className).toMatch(/hidden/);
     expect(inlineNav.className).toMatch(/xl:flex/);
+  });
+});
+
+/* #916 — phone inline-chrome trim. The responsive nav's 44px hamburger pushed
+   the right cluster (Help / Theme / Account) ~120px past the 412px phone
+   viewport, where overflow-x-clip hid them. The fix reclaims width by hiding the
+   wordmark text on phone and moving the Admin pill into the drawer on nav stages
+   (it stays inline where there is no drawer, and inline at sm+). jsdom can't see
+   the pixel clip, so these lock the responsive-class intent + drawer reachability;
+   the geometry itself is gated by e2e/responsive/topbar-nav.spec.ts at Pixel-7. */
+describe('TopBar — #916 phone inline-chrome trim', () => {
+  it('hides the Castwright wordmark text on phone (the mark stays as the home affordance)', () => {
+    renderWithStore(<TopBar {...makeProps({ stage: 'books' })} />);
+    const home = screen.getByRole('button', { name: 'Castwright — home' });
+    const wordmark = within(home).getByText('Castwright');
+    expect(wordmark.className).toMatch(/hidden/);
+    expect(wordmark.className).toMatch(/sm:inline/);
+  });
+
+  it('hides the inline Admin pill on phone for a nav stage (it lives in the drawer there)', () => {
+    renderWithStore(<TopBar {...makeProps({ stage: 'books' })} />);
+    const wrap = screen.getByTestId('topbar-admin-link').parentElement!;
+    expect(wrap.className).toMatch(/hidden/);
+    expect(wrap.className).toMatch(/sm:inline-flex/);
+  });
+
+  it('keeps the inline Admin pill on phone for a no-nav stage (upload) so it is never stranded', () => {
+    renderWithStore(<TopBar {...makeProps({ stage: 'upload', view: null })} />);
+    const wrap = screen.getByTestId('topbar-admin-link').parentElement!;
+    expect(wrap.className).not.toMatch(/hidden/);
+    expect(wrap.className).toMatch(/inline-flex/);
+  });
+
+  it('surfaces Admin as a phone-only drawer row that fires onOpenAdmin and closes the drawer', () => {
+    const onOpenAdmin = vi.fn();
+    renderWithStore(<TopBar {...makeProps({ stage: 'books', onOpenAdmin })} />);
+    fireEvent.click(screen.getByTestId('topbar-nav-toggle'));
+    const row = screen.getByTestId('nav-drawer-link-admin');
+    expect(row.className).toMatch(/sm:hidden/);
+    fireEvent.click(row);
+    expect(onOpenAdmin).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('topbar-nav-drawer')).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -233,6 +233,11 @@ export function TopBar({
   onOpenQueue,
 }: TopBarProps) {
   const showGlobalNav = stage === 'books' || stage === 'voices' || stage === 'changelog';
+  /* The hamburger drawer renders only when there's nav to host (#916). On phone
+     the Admin pill moves into that drawer to reclaim the ~120px the right
+     cluster needs; on a no-nav stage (upload/analysing/confirm) there's no
+     drawer, so the inline pill stays visible there instead of being stranded. */
+  const hasNav = stage === 'ready' || showGlobalNav;
   const onGlobal = (id: 'books' | 'voices' | 'changelog') => {
     if (id === 'books') onHome();
     else if (id === 'voices') onOpenVoices();
@@ -276,6 +281,8 @@ export function TopBar({
           setView={setView}
           onGlobal={onGlobal}
           showGlobalNav={showGlobalNav}
+          onOpenAdmin={onOpenAdmin}
+          adminActive={stage === 'admin'}
         />
         <button
           onClick={onHome}
@@ -283,7 +290,9 @@ export function TopBar({
           className="font-bold text-base tracking-tight inline-flex items-center gap-2 hover:opacity-80 transition-opacity shrink-0 min-h-[44px]"
         >
           <CastwaveMark className="w-6 h-6 shrink-0" aria-hidden="true" />
-          <span>Castwright</span>
+          {/* Wordmark text hidden on phone (#916) — the mark alone is the home
+              affordance there; this reclaims ~85px so the right cluster fits. */}
+          <span className="hidden sm:inline">Castwright</span>
         </button>
         {projectTitle && (
           <button
@@ -338,7 +347,12 @@ export function TopBar({
           </div>
         )}
         <div className="flex items-center gap-3 shrink-0">
-          <AdminPill onClick={onOpenAdmin} active={stage === 'admin'} />
+          {/* On phone, a nav-stage Admin pill moves into the hamburger drawer
+              (#916) to reclaim width; on a no-nav stage (no drawer) it stays
+              inline so Admin is never unreachable. sm+ always shows it inline. */}
+          <span className={hasNav ? 'hidden sm:inline-flex' : 'inline-flex'}>
+            <AdminPill onClick={onOpenAdmin} active={stage === 'admin'} />
+          </span>
           {(queueCount ?? 0) > 0 && onOpenQueue && (
             <button
               type="button"
@@ -385,12 +399,16 @@ function NavDrawer({
   setView,
   onGlobal,
   showGlobalNav,
+  onOpenAdmin,
+  adminActive,
 }: {
   stage: Stage['kind'];
   view: View | null;
   setView: (v: View) => void;
   onGlobal: (id: 'books' | 'voices' | 'changelog') => void;
   showGlobalNav: boolean;
+  onOpenAdmin: () => void;
+  adminActive: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -497,6 +515,22 @@ function NavDrawer({
                   {r.active && <IconCheck className="w-4 h-4 shrink-0" />}
                 </button>
               ))}
+              {/* Admin lives inline at sm+ but moves here on phone (#916). Phone
+                  -only (sm:hidden) so tablet/desktop keep the single inline pill
+                  and never double-show it. */}
+              <button
+                type="button"
+                role="menuitem"
+                data-testid="nav-drawer-link-admin"
+                aria-current={adminActive ? 'page' : undefined}
+                onClick={() => select(onOpenAdmin)}
+                className={`sm:hidden mt-1 pt-3 border-t border-ink/10 w-full min-h-[44px] flex items-center justify-between gap-3 px-4 py-2.5 rounded-xl text-sm font-medium text-left transition-colors ${
+                  adminActive ? 'bg-ink/6 text-ink' : 'text-ink/70 hover:bg-ink/5'
+                }`}
+              >
+                <span>Admin</span>
+                {adminActive && <IconCheck className="w-4 h-4 shrink-0" />}
+              </button>
             </div>
           </>,
           document.body,


### PR DESCRIPTION
## Summary

The responsive top-bar nav (#911) added a 44px hamburger to the left of an already-full bar. On a **412px phone** the fixed-width right cluster then ran ~120px past the viewport, where the header's `overflow-x-clip` **silently hid Help, the Theme toggle, and the Account avatar** — present in the DOM but positioned off-screen and unclickable.

That is exactly what timed out the guided-tour spec on the Ubuntu `test:e2e:mobile` leg (it only *runs* there, but reproduces at the Pixel-7 viewport on any OS). The page-overflow coverage assertion stayed green because `overflow-x-clip` suppresses page scroll, so the regression went unnoticed.

Measured at Pixel-7 (412px), before the fix:

| control | x → right | in viewport? |
|---|---|---|
| admin-link | 293 → 388 | ✅ |
| topbar-help | 400 → 444 | ❌ 32px off |
| theme-toggle | 456 → 488 | ❌ |
| account avatar | 500 → 532 | ❌ |

### Fix (reclaim width on phone only)

- Hide the **"Castwright" wordmark text** below `sm` (the mark stays as the home affordance) — ~85px.
- Move the **Admin pill into the hamburger drawer** on nav stages below `sm`. It stays inline at `sm+` **and** inline on no-nav stages (upload/analysing/confirm) where there is no drawer, so Admin is never stranded (it was already reachable on phone — only Help/Theme/Account were clipped).

Tablet (≥`sm`) and desktop (`xl` inline strip) are unchanged.

## Test plan

- [x] `top-bar.test.tsx`: wordmark hidden-on-phone class; Admin inline hidden on a nav stage but kept on a no-nav stage; phone-only Admin drawer row fires `onOpenAdmin`. (58 pass)
- [x] `e2e/responsive/topbar-nav.spec.ts`: phone-viewport geometry guard — Help/Theme/Account boxes inside the viewport, + Admin reachable via the drawer. (passes at mobile-chrome)
- [x] The previously-failing `coverage.spec.ts:284` guided-tour spec now passes at mobile-chrome.
- [x] `npm run verify` green (pre-push).

## Follow-up (release-gating)

This phone-only change drifts the **mobile-chrome visual baselines** (the `visual.spec.ts` page-level screenshots include the top bar). After merge, re-run `.github/workflows/regen-visual-baselines.yml` to refresh them before the next `vX.Y.Z` tag — same pass that #910 did for the hamburger nav. Tablet/desktop baselines are unaffected.

Closes #916
Refs #910 #911

🤖 Generated with [Claude Code](https://claude.com/claude-code)
