### PR TITLE
fix(app): drop unused skip_behavior import (flutter analyze green)

### DIFF
--- a/apps/android/test/data/player_controller_playing_stream_test.dart
+++ b/apps/android/test/data/player_controller_playing_stream_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:castwright/src/data/audio_engine.dart';
 import 'package:castwright/src/data/playback_store.dart';
 import 'package:castwright/src/data/player_controller.dart';
-import 'package:castwright/src/domain/skip_behavior.dart';
 
 /// Engine whose playing state is driven by the test, so we can assert the
 /// controller re-broadcasts out-of-band stops (audio-focus loss / headset


### PR DESCRIPTION
## Summary

The companion's `app.yml` **`flutter analyze`** step has been red on `main` since `796d2752` (predates the ops-17 work) — `flutter analyze` treats warnings as errors and there was a single:

> warning • Unused import: `package:castwright/src/domain/skip_behavior.dart` • `test/data/player_controller_playing_stream_test.dart:7:8` • unused_import

The import is genuinely orphaned — none of `skip_behavior.dart`'s symbols (`SkipButtonBehavior`, `SkipAction`, `SeekBy`, `ChapterStep`) are referenced anywhere in that test file. Removing it takes analyze from **1 issue → 0**, turning the companion CI lane green again.

Surgical: one deleted import line, nothing else.

## Test plan

- `flutter analyze` (this PR's `app.yml` run) goes green — that's the gate this fixes (it's the only automated coverage for the Flutter companion; no local hook runs it).
- Local pre-push `npm run verify` passed (unrelated JS battery, unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)