### PR TITLE
fix(server): jitter rename-retry backoff to de-flake concurrent state.json writes (#915)

### DIFF
--- a/server/src/workspace/atomic-rename.ts
+++ b/server/src/workspace/atomic-rename.ts
@@ -15,7 +15,20 @@
 
 import { rename } from 'node:fs/promises';
 
-const RENAME_RETRY_DELAYS_MS = [25, 75, 200, 500];
+/* Base backoff schedule. The tail was extended (added 1000ms) for the case the
+   budget proved too small for: many `writeJsonAtomic` calls racing the SAME
+   target (Phase 0 + Phase 1 both save `state.json`). 20-way contention on a
+   loaded Windows CI runner exhausted the prior ~800ms budget (#915). */
+const RENAME_RETRY_DELAYS_MS = [25, 75, 200, 500, 1000];
+
+/* Add up to 100% randomised jitter to each backoff so N writers retrying the
+   SAME target do not retry in lockstep. Without jitter, concurrent retriers
+   wake on the identical schedule and re-collide on the rename every round
+   (thundering herd) — the real driver of #915's intermittent EPERM, more than
+   the budget size. Pure + injectable RNG so the jitter stays unit-testable. */
+export function jitteredDelayMs(baseMs: number, rand: () => number = Math.random): number {
+  return baseMs + Math.floor(rand() * baseMs);
+}
 
 /* Codes worth retrying. Per the comment above this is intentionally broad
    for cloud-sync mounts; the cost of an extra retry on a transient failure
@@ -40,7 +53,7 @@ export async function renameWithRetry(src: string, dest: string): Promise<void> 
       if (!code || !RETRYABLE_CODES.has(code)) throw e;
       lastErr = e;
       if (attempt === RENAME_RETRY_DELAYS_MS.length) break;
-      await new Promise((r) => setTimeout(r, RENAME_RETRY_DELAYS_MS[attempt]));
+      await new Promise((r) => setTimeout(r, jitteredDelayMs(RENAME_RETRY_DELAYS_MS[attempt])));
     }
   }
   throw lastErr;

--- a/server/src/workspace/state-io.test.ts
+++ b/server/src/workspace/state-io.test.ts
@@ -29,6 +29,7 @@ function setRenameImpl(fn: ((src: string, dest: string) => Promise<void>) | null
 
 /* Import AFTER vi.mock so state-io.ts picks up the mocked rename. */
 const { writeJsonAtomic, readJsonWithRecovery } = await import('./state-io.js');
+const { jitteredDelayMs } = await import('./atomic-rename.js');
 
 let workdir: string;
 
@@ -128,6 +129,27 @@ describe('renameWithRetry transient-error handling', () => {
     await exerciseTransient('ENOENT');
   });
 
+  it('survives 5 consecutive transient EPERM failures (extended budget #915)', async () => {
+    /* #915 — 20-way same-target contention on a loaded Windows CI runner
+       exhausted the prior 4-delay (~800ms) budget. The tail was extended to
+       5 delays (6 attempts total), so a writer that loses the rename race up
+       to 5 times in a row still lands. This fails on the pre-#915 budget
+       (only 5 attempts → all 5 throw → surfaces EPERM) and passes after. */
+    const target = join(workdir, 'state.json');
+    let attempts = 0;
+    const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+    setRenameImpl(async (src: string, dest: string) => {
+      attempts++;
+      if (attempts <= 5) throw Object.assign(new Error('EPERM: simulated'), { code: 'EPERM' });
+      return actual.rename(src, dest);
+    });
+
+    await writeJsonAtomic(target, { ok: true });
+
+    expect(attempts).toBe(6);
+    expect(JSON.parse(await readFile(target, 'utf8'))).toEqual({ ok: true });
+  });
+
   it('does NOT retry past EROFS (read-only filesystem) — surfaces immediately', async () => {
     /* Plan 79 widened the retry list to cover EACCES + EIO because Drive
        for Desktop surfaces those transiently during cache flushes. EROFS
@@ -143,7 +165,7 @@ describe('renameWithRetry transient-error handling', () => {
 
     await expect(writeJsonAtomic(target, { ok: true })).rejects.toThrow(/EROFS/);
     /* Exactly one attempt — non-transient errors must NOT spam retries
-       and waste 800ms of backoff before failing. */
+       and waste the full retry budget on backoff before failing. */
     expect(attempts).toBe(1);
   });
 
@@ -294,3 +316,27 @@ describe('readJsonWithRecovery — fallback to .bak.N on corrupt JSON', () => {
     );
   });
 });
+
+describe('jitteredDelayMs (#915 thundering-herd decorrelation)', () => {
+  it('returns the base delay when rand() is 0 (lower bound)', () => {
+    expect(jitteredDelayMs(200, () => 0)).toBe(200);
+  });
+
+  it('adds up to ~100% jitter as rand() approaches 1 (upper bound)', () => {
+    expect(jitteredDelayMs(200, () => 0.5)).toBe(300);
+    /* floor(0.999 * 200) = 199 → 399, strictly below 2× so the bound is [base, 2*base). */
+    expect(jitteredDelayMs(200, () => 0.999)).toBe(399);
+  });
+
+  it('decorrelates equal base delays — two writers on the same schedule get different waits', () => {
+    /* The whole point: concurrent retriers must NOT wake in lockstep. Same
+       base, different rand() draws → different sleeps → no re-collision. */
+    const a = jitteredDelayMs(500, () => 0.1);
+    const b = jitteredDelayMs(500, () => 0.8);
+    expect(a).not.toBe(b);
+    for (const d of [a, b]) {
+      expect(d).toBeGreaterThanOrEqual(500);
+      expect(d).toBeLessThan(1000);
+    }
+  });
+})


### PR DESCRIPTION
## Summary

`writeJsonAtomic` already retried `EPERM`/`EBUSY`/`ENOENT` via `renameWithRetry`, but every concurrent writer shared **one fixed backoff schedule**. When ~20 writes race the **same** target (Phase 0 + Phase 1 both save `state.json`), the retriers wake in lockstep and re-collide on the rename every round — a **thundering herd** that exhausted the ~800ms budget on a loaded Windows CI runner and surfaced an intermittent `EPERM` (#915).

### Fix
- **Jitter** — add up to 100% randomised jitter per backoff (`jitteredDelayMs`, pure + injectable RNG) so concurrent retriers decorrelate instead of re-colliding. This is the root-cause fix for the thundering herd.
- **Headroom** — extend the backoff tail by one step (`1000ms`, 6 attempts total) for extra slack under heavy contention.

Hardens the real concurrent-write path, not just the test — no quarantine needed.

## Test plan
- [x] `jitteredDelayMs`: lower bound (`rand=0` → base), upper bound (`<2×base`), and decorrelation of equal base delays.
- [x] `survives 5 consecutive transient EPERM failures (extended budget #915)` — **fails on the pre-#915 5-attempt budget, passes on the extended 6-attempt one** (regression guard).
- [x] Existing transient-error + concurrent-writes specs stay green (21 pass).
- [x] `npm run verify` green (pre-push).

## Context
The intermittent failure was first observed validating #910/#916 on `cross-os.yml`; it passed on the subsequent run (confirming intermittency). This removes the underlying race so a future release-tag's Windows verify leg can't flake on it.

Closes #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)
