### PR TITLE
fix(server): align atomic-rename.test.ts retry count with #921 (6 not 5)

### DIFF
--- a/server/src/workspace/atomic-rename.test.ts
+++ b/server/src/workspace/atomic-rename.test.ts
@@ -56,8 +56,8 @@ describe('renameWithRetry', () => {
       throw makeErr('EBUSY');
     });
     await expect(renameWithRetry('src', 'dest')).rejects.toThrow(/EBUSY/);
-    /* 1 initial + 4 retry delays = 5 attempts total. */
-    expect(renameMock).toHaveBeenCalledTimes(5);
+    /* 1 initial + 5 retry delays = 6 attempts total (RENAME_RETRY_DELAYS_MS grew to 5 in #921). */
+    expect(renameMock).toHaveBeenCalledTimes(6);
   });
 
   it('throws when the error has no `code` field (defensive — never retry an unknown shape)', async () => {


### PR DESCRIPTION
## Summary

`test:server` has been deterministically red on `main` since #921 merged. #921
(`bb72b453`, jitter rename-retry backoff) grew `RENAME_RETRY_DELAYS_MS` from
`[25, 75, 200, 500]` to `[25, 75, 200, 500, 1000]` (4 → 5 delays ⇒ 6 attempts)
and updated `state-io.test.ts` to `expect(6)`, but left the sibling
`atomic-rename.test.ts` asserting **5** attempts. The source is correct (6 is the
intended retry budget); the stale test is the only defect.

This updates `atomic-rename.test.ts` to expect 6 (and corrects its comment).
Source unchanged.

## Test plan

- `npx vitest run src/workspace/atomic-rename.test.ts` → 9/9 pass (was 1 fail).
- Full `test:server` green: 284 files / 3011 tests pass.
- Full `npm run verify` (typecheck + tests + e2e + build) green at pre-push.

Regression from #921 (#915). No behaviour change — test-only fix.