### PR TITLE
docs(app): retire app-18 backlog row; connectivity_plus 7.x merged via #926

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -135,12 +135,6 @@ _Full detail + acceptance:_ [#431](https://github.com/dudarenok-maker/AudioBook-
 - _Benefit (technical):_ keeps the companion buildable on future Flutter versions before the temporary KGP support is dropped (avoids a hard build failure later). Not a current break.
 _Full detail + acceptance:_ [#790](https://github.com/dudarenok-maker/Castwright/issues/790).
 
-#### `app-18` — connectivity_plus 6→7 blocked on iOS SDK (`NWPath.isUltraConstrained`) ([#895](https://github.com/dudarenok-maker/Castwright/issues/895))
-
-- _What:_ Bumping `connectivity_plus` 6.1.0→7.1.1 (deps round 4) passed Android but **broke the iOS compile** — 7.x's iOS code calls `NWPath.isUltraConstrained`, which needs a newer iOS SDK (iOS 26-era) than the CI runner's Xcode has. Reverted to 6.1.0 (identical Dart API). **Blocked** on the GitHub macOS image shipping that SDK (or connectivity_plus guarding the call behind an availability check), then re-bump + confirm `app.yml` ios-compile is green.
-- _Benefit (technical):_ keeps the companion's connectivity dep current once iOS can build it; no feature needs 7.x today.
-_Full detail + acceptance:_ [#895](https://github.com/dudarenok-maker/Castwright/issues/895).
-
 #### `srv-40` — Non-Latin (Cyrillic) book support: on-box acceptance ([#823](https://github.com/dudarenok-maker/Castwright/issues/823))
 
 - _What:_ Plan [219](docs/features/219-non-latin-names-and-ids.md) (Unicode-aware coverage/ASR normalizers, `safe-id.ts` chokepoint, `makeBookId`/`slug`, cross-book keys, hardened sidecar/voice-sample filename boundaries) is merged with unit/pytest coverage. The off-box-unverifiable bits remain: a full analyze→generate→export of a Cyrillic book on Windows (ffmpeg + Cyrillic paths — pre-existing risk via `bookDirByDisplay`), real model-id shapes for Cyrillic names, and cross-book voice carryover for a Russian series.

--- a/docs/features/archive/224-deps-round-4.md
+++ b/docs/features/archive/224-deps-round-4.md
@@ -48,7 +48,7 @@ owner: null
   `sharp(buffer).jpeg({ quality: JPEG_QUALITY }).toBuffer()`.
 - `apps/android/lib/src/data/network_info.dart:11-23` — `checkConnectivity()`
   returns `List<ConnectivityResult>`; the mapping is the connectivity contract
-  (locked by `network_info_test.dart`, 5/5; held at connectivity_plus 6.1.0 — see app-18).
+  (locked by `network_info_test.dart`, 5/5; bumped to connectivity_plus 7.1.1 in app-18/#895).
 
 ## What shipped
 
@@ -94,7 +94,7 @@ Six commits on `chore/deps-round-4`, each gated by its own full `npm run verify`
   sharp 0.35 (38/38).
 - Flutter (`apps/android/test/data/network_info_test.dart`) — five-case
   connectivity mapping; `List<ConnectivityResult>` shape (5/5), held at
-  connectivity_plus 6.1.0 (see app-18). Full Flutter suite: 306/306.
+  connectivity_plus 6.1.0 at round-4 ship (since re-bumped to 7.1.1 in app-18/#895). Full Flutter suite: 306/306.
 - Full `npm run verify` (frontend + server + e2e + build) green on the JS
   surfaces after each commit; final clean-room `verify -- --no-cache` before the PR.
 


### PR DESCRIPTION
## Summary

Closes out **app-18**. The functional change — `connectivity_plus` 6.1.0 → 7.1.1
plus moving the `ios-compile` CI job to `runs-on: macos-26` (iOS 26 SDK) — already
landed on `main` via #926, and that PR's **`ios-compile` job passed (3m29s)**,
proving 7.x compiles against the iOS 26 SDK (the exact gate #895 was blocked on).

This PR is the doc cleanup that the #926 sweep didn't carry:
- Removes the `app-18` row from `docs/BACKLOG.md`.
- Updates two stale present-tense invariants in
  `docs/features/archive/224-deps-round-4.md` (lines 51, 97) to note the
  re-bump; the three historical round-4 lines are intentionally left as-is.

Spec + plan: `docs/superpowers/specs/2026-06-19-app-18-connectivity-plus-7-design.md`,
`docs/superpowers/plans/2026-06-19-app-18-connectivity-plus-7.md` (both already on main via #926).

## Test plan

Docs-only. Full `npm run verify` green at pre-push.

Closes #895