### PR TITLE
fix(frontend,server): per-phase analysing ticker + honest section/sentence counters

### DIFF
--- a/e2e/analysing-progress.spec.ts
+++ b/e2e/analysing-progress.spec.ts
@@ -35,10 +35,17 @@ test('attribution shows a non-snapping sentence count + chars/s', async ({ page 
 
   /* Poll the count ~8 times at 250 ms intervals (2 s total window).
      Deduplicate consecutive equal reads so a fast phase doesn't inflate
-     the sample; then assert the deduplicated series is monotone. */
+     the sample; then assert the deduplicated series is monotone.
+
+     The headline belongs to the phase that's actively attributing; once that
+     phase completes its ticker is (correctly) removed, so a read can land
+     after it's gone. Use a SHORT per-read timeout + count() guard so the loop
+     samples the visible window and moves on instead of auto-waiting the full
+     test timeout for a detached element (which previously hung the test). */
   const reads: number[] = [];
   for (let i = 0; i < 8; i += 1) {
-    const txt = await headline.textContent().catch(() => null);
+    const present = (await headline.count()) > 0;
+    const txt = present ? await headline.textContent({ timeout: 500 }).catch(() => null) : null;
     if (txt) {
       const n = Number(/~(\d+) of/.exec(txt)?.[1] ?? '0');
       if (reads.length === 0 || reads[reads.length - 1] !== n) reads.push(n);

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -739,21 +739,6 @@ const STAGE1_BASELINE_RATE = 1.0; // input chars / ms; tuned for gemini-2.5-flas
    the side of "we promised more time than it took" beats pegging at 95%. */
 const STAGE2_STRETCH = 5.0;
 const MIN_EST_MS = 3000;
-/* When elapsed exceeds the per-chapter estimate, the bar asymptotes toward
-   the cap instead of pegging — overage frac is mapped through 1 - 1/(1+x)
-   so a 2× overage adds half the remaining headroom, a 4× overage adds 80%.
-   Log lines fire at each threshold so the user gets a textual signal too. */
-const OVERAGE_LOG_THRESHOLDS = [1.5, 2.0, 3.0] as const;
-
-/* Wall-clock heartbeat thresholds (ms). Independent of the per-chapter
-   estimate — guarantees the log gets a fresh line at predictable intervals
-   even when the estimate is small (a 22s estimate's 1.5×/2×/3× thresholds
-   are only 33s/44s/66s, so without these the log would stall on a 5-minute
-   chapter). Each threshold fires once per chapter. */
-const HEARTBEAT_MS_THRESHOLDS = [
-  30_000, 60_000, 120_000, 180_000, 300_000, 420_000, 600_000, 900_000,
-] as const;
-
 /* Streaming-chunk feedback. Throttle SSE heartbeat emission so a fast model
    pumping 200 chunks/s doesn't drown the client. 2 s is high-signal:
    noticeable to the user, low overhead on the wire. */
@@ -3445,8 +3430,6 @@ export async function runMainAnalyzerJob(
         );
       }
       const chapterEstMs = chapterEstMsFor(ch.body.length);
-      const loggedOverages = new Set<number>();
-      const loggedHeartbeats = new Set<number>();
       const startedAt = Date.now();
       inFlight.set(i, {
         chapterIndex: i,
@@ -3497,33 +3480,14 @@ export async function runMainAnalyzerJob(
           refineEstMs(slot, elapsed);
         }
         sendLiveTick();
-        /* Over-budget log thresholds — fire once per chapter. */
-        for (const t of OVERAGE_LOG_THRESHOLDS) {
-          if (loggedOverages.has(t)) continue;
-          if (elapsed >= chapterEstMs * t) {
-            loggedOverages.add(t);
-            log(
-              1,
-              `Chapter ${i + 1}/${totalChapters} still running — ${humanSeconds(elapsed)} elapsed (est was ${humanSeconds(chapterEstMs)}, ${t}× exceeded). Continuing.`,
-            );
-          }
-        }
-        /* Wall-clock heartbeats. */
-        for (const ms of HEARTBEAT_MS_THRESHOLDS) {
-          if (loggedHeartbeats.has(ms)) continue;
-          if (elapsed >= ms) {
-            loggedHeartbeats.add(ms);
-            const overageRecent = Array.from(loggedOverages).some(
-              (t) => Math.abs(chapterEstMs * t - ms) < 5000,
-            );
-            if (!overageRecent) {
-              log(
-                1,
-                `Chapter ${i + 1}/${totalChapters} — ${humanSeconds(elapsed)} elapsed, still waiting on the model.`,
-              );
-            }
-          }
-        }
+        /* The per-chapter "Nm elapsed, still waiting on the model" wall-clock
+           heartbeats and the "still running, Nx exceeded" over-budget lines
+           used to live here. They've been removed: the live ticker ("M:SS of
+           ~M:SS · section X/Y · Attributed ~N of ~M sentences") is the proper,
+           always-fresh progress readout, and the elapsed log lines both
+           duplicated it AND disagreed with it (they tracked chapter-total
+           elapsed while the ticker re-anchors per server tick). The silence
+           watchdog (onWaiting below) still warns on genuine model stalls. */
       };
 
       log(

--- a/src/components/analysing/phase-card.test.tsx
+++ b/src/components/analysing/phase-card.test.tsx
@@ -46,8 +46,11 @@ const activePhase: AnalysisPhase = {
 
 describe('LiveChapterRow — section sub-bar', () => {
   /* When a chapter has sectionsTotal > 1 the row must show "section M/N"
-     and a thin sub-bar; single-section (or absent) chapters must stay clean. */
-  it('shows "section M/N" text when sectionsTotal > 1', () => {
+     and a thin sub-bar; single-section (or absent) chapters must stay clean.
+     The counter reads the section CURRENTLY being processed (1-based) so it
+     never sits on the confusing "section 0/N" while a slow first section
+     grinds — sectionsDone is the completed count, so current = done + 1. */
+  it('shows the in-progress (1-based) section as "section M/N" when sectionsTotal > 1', () => {
     const store = mountStore();
     render(
       <Provider store={store}>
@@ -77,7 +80,42 @@ describe('LiveChapterRow — section sub-bar', () => {
         />
       </Provider>,
     );
-    expect(screen.getByText(/section 3\/4/i)).toBeInTheDocument();
+    // 3 sections done → currently on section 4 of 4.
+    expect(screen.getByText(/section 4\/4/i)).toBeInTheDocument();
+  });
+
+  it('shows "section 1/N" (never 0) while the first section is still in flight', () => {
+    const store = mountStore();
+    render(
+      <Provider store={store}>
+        <PhaseCard
+          phase={activePhase}
+          activePhaseId={activePhase.id}
+          phaseProgress={0.1}
+          phaseLogs={[]}
+          live={{
+            totalChapters: 10,
+            chapters: [
+              {
+                chapterIndex: 8,
+                chapterTitle: 'Chapter 8',
+                elapsedMs: 60000,
+                estMs: 120000,
+                sectionsDone: 0,
+                sectionsTotal: 10,
+              },
+            ],
+          }}
+          isLocalAnalyzer={false}
+          analysisStarted={true}
+          conn="streaming"
+          bookId={null}
+          droppedQuotesRefreshKey={0}
+        />
+      </Provider>,
+    );
+    expect(screen.getByText(/section 1\/10/i)).toBeInTheDocument();
+    expect(screen.queryByText(/section 0\//i)).toBeNull();
   });
 
   it('renders no "section" text when sectionsTotal is 1', () => {
@@ -198,6 +236,52 @@ describe('LiveChapterRow sentence headline', () => {
   it('omits the sentence headline before sentence mode', () => {
     renderCard({ live: { totalChapters: 9, chapters: [liveChapter()] } });
     expect(screen.queryByText(/Attributed/)).not.toBeInTheDocument();
+  });
+
+  it('formats the sentence counts with thousands separators', () => {
+    renderCard({
+      live: {
+        totalChapters: 9,
+        chapters: [liveChapter({ sentencesDone: 1129, sentencesTotal: 2220, inSentenceMode: true })],
+      },
+    });
+    expect(screen.getByText(/Attributed ~1,129 of ~2,220 sentences/)).toBeInTheDocument();
+  });
+});
+
+describe('LiveChapterRow section count formatting', () => {
+  it('formats large section totals with thousands separators', () => {
+    renderCard({
+      live: {
+        totalChapters: 9,
+        chapters: [liveChapter({ sectionsDone: 1200, sectionsTotal: 1500 })],
+      },
+    });
+    // current section = done + 1 = 1,201 of 1,500.
+    expect(screen.getByText(/section 1,201\/1,500/)).toBeInTheDocument();
+  });
+});
+
+describe('PhaseCard per-phase active/done overrides (pipelined phases)', () => {
+  /* When the parent derives per-phase state, it passes isPhaseActive/
+     isPhaseDone explicitly so two pipelined phases can both render their
+     own live ticker — the override wins over the activePhaseId fallback. */
+  it('renders the live ticker when isPhaseActive is forced true even though activePhaseId differs', () => {
+    renderCard({
+      activePhaseId: 0, // a different phase is the global "max"
+      isPhaseActive: true,
+      live: { totalChapters: 9, chapters: [liveChapter({ chapterTitle: 'Forced Active' })] },
+    });
+    expect(screen.getByText('Forced Active')).toBeInTheDocument();
+  });
+
+  it('hides the live ticker when isPhaseActive is forced false even though activePhaseId matches', () => {
+    renderCard({
+      activePhaseId: 1, // matches phase1.id → fallback would be active
+      isPhaseActive: false,
+      live: { totalChapters: 9, chapters: [liveChapter({ chapterTitle: 'Should Be Hidden' })] },
+    });
+    expect(screen.queryByText('Should Be Hidden')).not.toBeInTheDocument();
   });
 
   it('keeps the chars/s speed pulse in the heartbeat row', () => {

--- a/src/components/analysing/phase-card.tsx
+++ b/src/components/analysing/phase-card.tsx
@@ -56,8 +56,13 @@ function LiveChapterRow({
 
   const overBudget = displayMs > chapter.estMs * 1.25;
   const showSections = chapter.sectionsTotal !== undefined && chapter.sectionsTotal > 1;
-  const sectionPct = showSections
-    ? ((chapter.sectionsDone ?? 0) / chapter.sectionsTotal!) * 100
+  const sectionsDone = chapter.sectionsDone ?? 0;
+  const sectionPct = showSections ? (sectionsDone / chapter.sectionsTotal!) * 100 : 0;
+  /* Show the section CURRENTLY being processed (1-based) rather than the
+     completed count — otherwise a slow first section reads as a stuck
+     "section 0/N". Clamp to the total so the last section never overshoots. */
+  const currentSection = showSections
+    ? Math.min(sectionsDone + 1, chapter.sectionsTotal!)
     : 0;
   return (
     <div className="flex flex-col gap-0.5">
@@ -80,7 +85,7 @@ function LiveChapterRow({
           <>
             <span className="text-ink/30">·</span>
             <span className="text-ink/50">
-              section {chapter.sectionsDone}/{chapter.sectionsTotal}
+              section {currentSection.toLocaleString()}/{chapter.sectionsTotal!.toLocaleString()}
             </span>
           </>
         )}
@@ -95,7 +100,8 @@ function LiveChapterRow({
         <>
           <div className="inline-flex items-center gap-2 text-[11px] font-mono tabular-nums text-ink/70">
             <span className="font-semibold">
-              Attributed ~{chapter.sentencesDone ?? 0} of ~{chapter.sentencesTotal} sentences
+              Attributed ~{(chapter.sentencesDone ?? 0).toLocaleString()} of ~
+              {chapter.sentencesTotal.toLocaleString()} sentences
             </span>
           </div>
           <div className="h-0.5 w-48 rounded-full bg-ink/10 overflow-hidden">
@@ -375,6 +381,12 @@ function ThrottleRow({
 interface PhaseCardProps {
   phase: AnalysisPhase;
   activePhaseId: number;
+  /** Explicit per-phase render state, used when the parent derives each
+      phase independently so pipelined Phase 0 + Phase 1 can both be active
+      at once (kills the active-card flicker). When omitted, falls back to the
+      legacy `activePhaseId === phase.id` comparison. */
+  isPhaseActive?: boolean;
+  isPhaseDone?: boolean;
   phaseProgress: number;
   phaseLogs: string[];
   live: AnalysisLiveInfo | null;
@@ -401,6 +413,8 @@ interface PhaseCardProps {
 export function PhaseCard({
   phase: p,
   activePhaseId,
+  isPhaseActive,
+  isPhaseDone,
   phaseProgress,
   phaseLogs,
   live,
@@ -414,8 +428,8 @@ export function PhaseCard({
   bookId,
   droppedQuotesRefreshKey,
 }: PhaseCardProps) {
-  const isActive = activePhaseId === p.id;
-  const isDone = activePhaseId > p.id;
+  const isActive = isPhaseActive ?? activePhaseId === p.id;
+  const isDone = isPhaseDone ?? activePhaseId > p.id;
   const throttleActive = throttle && throttle.until > Date.now();
   /* The "warms up after ch. N" handoff only happens when the two-model split
      is engaged — then Phase 1 dispatches `minLag` chapters behind Phase 0

--- a/src/lib/analysis-phase-state.test.ts
+++ b/src/lib/analysis-phase-state.test.ts
@@ -43,6 +43,15 @@ describe('derivePhaseState', () => {
     ).toBe('done');
   });
 
+  /* Live payloads are sticky (we never blank a phase's last live), so a
+     completed phase can still carry stale live chapters. Completion (progress
+     1) must win over that stale live → done, so its ticker stops rendering. */
+  it('is done at completion even if a stale live payload lingers', () => {
+    expect(
+      derivePhaseState(0, { progressByPhase: { 0: 1 }, liveByPhase: { 0: live(1) }, maxPhase: 1 }),
+    ).toBe('done');
+  });
+
   it('is done when a later phase has advanced past it and it has no live left', () => {
     expect(
       derivePhaseState(0, { progressByPhase: { 0: 0.4, 1: 0.2 }, liveByPhase: {}, maxPhase: 1 }),

--- a/src/lib/analysis-phase-state.test.ts
+++ b/src/lib/analysis-phase-state.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import type { AnalysisLiveInfo } from './api';
+import { derivePhaseState } from './analysis-phase-state';
+
+const live = (n: number): AnalysisLiveInfo => ({
+  totalChapters: 9,
+  chapters: Array.from({ length: n }, (_, i) => ({
+    chapterIndex: i + 1,
+    chapterTitle: `Chapter ${i + 1}`,
+    elapsedMs: 1000,
+    estMs: 5000,
+  })),
+});
+
+describe('derivePhaseState', () => {
+  it('is active when it is the frontier even with no progress/live yet (initial phase 0)', () => {
+    expect(
+      derivePhaseState(0, { progressByPhase: {}, liveByPhase: {}, maxPhase: 0 }),
+    ).toBe('active');
+  });
+
+  it('is pending for a phase beyond the frontier', () => {
+    expect(
+      derivePhaseState(2, { progressByPhase: { 0: 0.3 }, liveByPhase: {}, maxPhase: 0 }),
+    ).toBe('pending');
+  });
+
+  it('is active when the phase has live chapters', () => {
+    expect(
+      derivePhaseState(0, { progressByPhase: { 0: 0.3 }, liveByPhase: { 0: live(1) }, maxPhase: 0 }),
+    ).toBe('active');
+  });
+
+  it('is active when the phase has started (progress) but no live yet (e.g. library match)', () => {
+    expect(
+      derivePhaseState(2, { progressByPhase: { 2: 0.1 }, liveByPhase: {}, maxPhase: 2 }),
+    ).toBe('active');
+  });
+
+  it('is done when its progress has reached completion', () => {
+    expect(
+      derivePhaseState(0, { progressByPhase: { 0: 1 }, liveByPhase: {}, maxPhase: 1 }),
+    ).toBe('done');
+  });
+
+  it('is done when a later phase has advanced past it and it has no live left', () => {
+    expect(
+      derivePhaseState(0, { progressByPhase: { 0: 0.4, 1: 0.2 }, liveByPhase: {}, maxPhase: 1 }),
+    ).toBe('done');
+  });
+
+  /* The core flicker fix: when Phase 0 (cast) and Phase 1 (attribution)
+     pipeline, BOTH carry live chapters at the same time and BOTH must read
+     as active — neither clobbers the other into 'done'/'pending'. */
+  it('keeps two pipelined phases both active when each has live chapters', () => {
+    const opts = {
+      progressByPhase: { 0: 0.6, 1: 0.1 },
+      liveByPhase: { 0: live(1), 1: live(1) },
+      maxPhase: 1,
+    };
+    expect(derivePhaseState(0, opts)).toBe('active');
+    expect(derivePhaseState(1, opts)).toBe('active');
+    expect(derivePhaseState(2, opts)).toBe('pending');
+  });
+
+  it('live presence on an earlier phase wins over the later-phase "done" rule', () => {
+    // Phase 0 still streaming a slow chapter while Phase 1 has started.
+    expect(
+      derivePhaseState(0, {
+        progressByPhase: { 0: 0.5, 1: 0.05 },
+        liveByPhase: { 0: live(1) },
+        maxPhase: 1,
+      }),
+    ).toBe('active');
+  });
+
+  it('treats an empty live payload as no live (not active on that basis alone)', () => {
+    expect(
+      derivePhaseState(2, { progressByPhase: {}, liveByPhase: { 2: live(0) }, maxPhase: 1 }),
+    ).toBe('pending');
+  });
+});

--- a/src/lib/analysis-phase-state.ts
+++ b/src/lib/analysis-phase-state.ts
@@ -25,9 +25,11 @@ const DONE_THRESHOLD = 0.999;
  * per-phase data lets both pipelined phases stay active at once.
  *
  * Rules, in order:
+ *  - progress at completion → done (checked FIRST: live payloads are sticky —
+ *    we never blank a phase's last live — so a finished phase can still carry
+ *    stale live chapters; completion must win or its ticker would never clear);
  *  - live chapters present  → active (a phase that's streaming work is active,
  *    even when a later phase has also started — pipelining);
- *  - progress at completion → done;
  *  - a later phase has advanced past it (and no live remains) → done;
  *  - it IS the frontier (the highest phase reached, incl. the initial phase 0
  *    before any event) → active — mirrors the legacy `activePhaseId === id`;
@@ -38,8 +40,8 @@ export function derivePhaseState(phaseId: number, inputs: PhaseStateInputs): Pha
   const liveInfo = inputs.liveByPhase[phaseId];
   const hasLive = !!liveInfo && liveInfo.chapters.length > 0;
 
-  if (hasLive) return 'active';
   if (prog !== undefined && prog >= DONE_THRESHOLD) return 'done';
+  if (hasLive) return 'active';
   if (phaseId < inputs.maxPhase) return 'done';
   if (phaseId === inputs.maxPhase) return 'active';
   return 'pending';

--- a/src/lib/analysis-phase-state.ts
+++ b/src/lib/analysis-phase-state.ts
@@ -1,0 +1,46 @@
+import type { AnalysisLiveInfo } from './api';
+
+/** Coarse render state of one analysis phase card. */
+export type PhaseRenderState = 'pending' | 'active' | 'done';
+
+/** Inputs needed to decide one phase's render state, all keyed by phase id. */
+export interface PhaseStateInputs {
+  /** Latest per-phase progress in [0,1], as reported by `phase` SSE events. */
+  progressByPhase: Record<number, number>;
+  /** Latest per-phase live payload (null/absent when the phase isn't ticking). */
+  liveByPhase: Record<number, AnalysisLiveInfo | null | undefined>;
+  /** Highest phase id seen so far this run (the pipeline frontier). */
+  maxPhase: number;
+}
+
+const DONE_THRESHOLD = 0.999;
+
+/** Decide whether a phase card should read as pending / active / done.
+ *
+ * The split analyzer pipelines Phase 0 (cast) and Phase 1 (attribution): both
+ * emit `phase` SSE events with their own `live` payload in the same window. The
+ * analysing view used to collapse these into a single `phase`/`live` state, so
+ * the active card and its ticker flip-flopped between the two — the timer
+ * "flicker" the user saw. Deriving each card's state independently from
+ * per-phase data lets both pipelined phases stay active at once.
+ *
+ * Rules, in order:
+ *  - live chapters present  → active (a phase that's streaming work is active,
+ *    even when a later phase has also started — pipelining);
+ *  - progress at completion → done;
+ *  - a later phase has advanced past it (and no live remains) → done;
+ *  - it IS the frontier (the highest phase reached, incl. the initial phase 0
+ *    before any event) → active — mirrors the legacy `activePhaseId === id`;
+ *  - otherwise (a phase beyond the frontier) → pending.
+ */
+export function derivePhaseState(phaseId: number, inputs: PhaseStateInputs): PhaseRenderState {
+  const prog = inputs.progressByPhase[phaseId];
+  const liveInfo = inputs.liveByPhase[phaseId];
+  const hasLive = !!liveInfo && liveInfo.chapters.length > 0;
+
+  if (hasLive) return 'active';
+  if (prog !== undefined && prog >= DONE_THRESHOLD) return 'done';
+  if (phaseId < inputs.maxPhase) return 'done';
+  if (phaseId === inputs.maxPhase) return 'active';
+  return 'pending';
+}

--- a/src/views/analysing.test.tsx
+++ b/src/views/analysing.test.tsx
@@ -174,6 +174,59 @@ describe('AnalysingView — live ticker (regression for stuck-chapter screenshot
     expect(overBudget).toHaveLength(1);
   });
 
+  it('keeps BOTH pipelined phases live at once (Phase 0 + Phase 1 tickers do not clobber each other)', async () => {
+    await renderViewWaitingForAnalysis();
+
+    /* Split-analyzer pipelining: Phase 0 (cast) and Phase 1 (attribution)
+       emit interleaved `phase` events, each with its OWN live payload. The
+       bug was a single shared `live`/`phase` state — the later event wiped
+       the earlier one, so the active card + its timer flip-flopped between
+       the two phases (the 5:59 ↔ 45:33 flicker the user filmed). */
+    const castLive: AnalysisLiveInfo = {
+      totalChapters: 9,
+      chapters: [{ chapterIndex: 8, chapterTitle: 'CAST CH8', elapsedMs: 476_000, estMs: 2_066_000 }],
+    };
+    const attribLive: AnalysisLiveInfo = {
+      totalChapters: 9,
+      chapters: [{ chapterIndex: 1, chapterTitle: 'ATTRIB CH1', elapsedMs: 184_000, estMs: 362_000 }],
+    };
+
+    act(() => {
+      capturedOpts?.onPhase?.({ phaseId: 0, progress: 0.6, live: castLive });
+      capturedOpts?.onPhase?.({ phaseId: 1, progress: 0.1, live: attribLive });
+    });
+
+    // Both phase tickers stay on screen simultaneously — neither overwrites the other.
+    expect(screen.getByText('CAST CH8')).toBeInTheDocument();
+    expect(screen.getByText('ATTRIB CH1')).toBeInTheDocument();
+  });
+
+  it('clears a phase ticker when that phase reports no live, without disturbing the other phase', async () => {
+    await renderViewWaitingForAnalysis();
+
+    act(() => {
+      capturedOpts?.onPhase?.({
+        phaseId: 0,
+        progress: 0.6,
+        live: { totalChapters: 9, chapters: [{ chapterIndex: 8, chapterTitle: 'CAST CH8', elapsedMs: 1000, estMs: 2000 }] },
+      });
+      capturedOpts?.onPhase?.({
+        phaseId: 1,
+        progress: 0.1,
+        live: { totalChapters: 9, chapters: [{ chapterIndex: 1, chapterTitle: 'ATTRIB CH1', elapsedMs: 1000, estMs: 2000 }] },
+      });
+    });
+    expect(screen.getByText('CAST CH8')).toBeInTheDocument();
+
+    // Phase 0 finishes (emits a phase event with no live) — its ticker clears,
+    // but Phase 1's ticker is untouched.
+    act(() => {
+      capturedOpts?.onPhase?.({ phaseId: 0, progress: 1 });
+    });
+    expect(screen.queryByText('CAST CH8')).not.toBeInTheDocument();
+    expect(screen.getByText('ATTRIB CH1')).toBeInTheDocument();
+  });
+
   it('hides the ticker entirely when no chapters are in flight (between completion and next start)', async () => {
     await renderViewWaitingForAnalysis();
 

--- a/src/views/analysing.test.tsx
+++ b/src/views/analysing.test.tsx
@@ -201,7 +201,44 @@ describe('AnalysingView — live ticker (regression for stuck-chapter screenshot
     expect(screen.getByText('ATTRIB CH1')).toBeInTheDocument();
   });
 
-  it('clears a phase ticker when that phase reports no live, without disturbing the other phase', async () => {
+  it('keeps a phase headline STICKY across a mid-phase tick that carries no live payload', async () => {
+    await renderViewWaitingForAnalysis();
+
+    /* Regression for the e2e timeout (#930 follow-up): the server (and the
+       mock) emit `live` only while a chapter is in flight; a later same-phase
+       tick can arrive with no `live` (progress still < 1). The ticker MUST
+       persist that phase's last live rather than blanking — otherwise the
+       headline flickers out mid-phase and a poller waiting on it hangs. */
+    act(() => {
+      capturedOpts?.onPhase?.({
+        phaseId: 0,
+        progress: 0.5,
+        live: {
+          totalChapters: 2,
+          chapters: [
+            {
+              chapterIndex: 1,
+              chapterTitle: 'Chapter 1',
+              elapsedMs: 1000,
+              estMs: 2000,
+              sentencesDone: 60,
+              sentencesTotal: 120,
+              inSentenceMode: true,
+            },
+          ],
+        },
+      });
+    });
+    expect(screen.getByText(/Attributed ~60 of ~120 sentences/)).toBeInTheDocument();
+
+    // A later mid-phase tick with NO live (progress still < 1) must NOT blank it.
+    act(() => {
+      capturedOpts?.onPhase?.({ phaseId: 0, progress: 0.8 });
+    });
+    expect(screen.getByText(/Attributed ~60 of ~120 sentences/)).toBeInTheDocument();
+  });
+
+  it('stops showing a phase ticker once that phase completes (progress 1), without disturbing the other phase', async () => {
     await renderViewWaitingForAnalysis();
 
     act(() => {
@@ -218,8 +255,8 @@ describe('AnalysingView — live ticker (regression for stuck-chapter screenshot
     });
     expect(screen.getByText('CAST CH8')).toBeInTheDocument();
 
-    // Phase 0 finishes (emits a phase event with no live) — its ticker clears,
-    // but Phase 1's ticker is untouched.
+    // Phase 0 completes (progress 1) — it reads as done, so its ticker is no
+    // longer rendered, but Phase 1's ticker is untouched.
     act(() => {
       capturedOpts?.onPhase?.({ phaseId: 0, progress: 1 });
     });

--- a/src/views/analysing.tsx
+++ b/src/views/analysing.tsx
@@ -454,12 +454,14 @@ export function AnalysingView({
             }
             /* Per-phase state: each phase owns its progress + live payload so
                pipelined cast (Phase 0) and attribution (Phase 1) ticks don't
-               overwrite one another. A phase event with no `live` clears that
-               phase's ticker (it's finished a chapter / the whole phase) while
-               leaving the other phase untouched. A done phase's stale heartbeat
-               never renders because PhaseCard gates it on isActive. */
+               overwrite one another. Live is STICKY — only replaced when a tick
+               carries a fresh `live`, never blanked on a no-live tick. The
+               server/mock emit `live` only while a chapter is in flight, so a
+               mid-phase no-live tick must not flicker the ticker out. A phase's
+               ticker stops rendering once it reads as done (progress 1 →
+               derivePhaseState), which also hides its now-stale live + heartbeat. */
             setProgressByPhase((prev) => ({ ...prev, [phaseId]: progress }));
-            setLiveByPhase((prev) => ({ ...prev, [phaseId]: live ?? null }));
+            if (live) setLiveByPhase((prev) => ({ ...prev, [phaseId]: live }));
             const prevMax = maxPhaseRef.current;
             const newMax = Math.max(prevMax, phaseId);
             maxPhaseRef.current = newMax;
@@ -801,7 +803,7 @@ export function AnalysingView({
           markEvent();
           setConn('streaming');
           setProgressByPhase((prev) => ({ ...prev, [phaseId]: progress }));
-          setLiveByPhase((prev) => ({ ...prev, [phaseId]: live ?? null }));
+          if (live) setLiveByPhase((prev) => ({ ...prev, [phaseId]: live }));
           const newMax = Math.max(maxPhaseRef.current, phaseId);
           maxPhaseRef.current = newMax;
           setPhase(newMax);

--- a/src/views/analysing.tsx
+++ b/src/views/analysing.tsx
@@ -13,6 +13,7 @@ import {
 } from '../lib/api';
 import { ANALYSIS_PHASES } from '../data/analysis-phases';
 import { computeOverallProgress } from '../lib/analysis-progress';
+import { derivePhaseState } from '../lib/analysis-phase-state';
 import {
   MODEL_OPTIONS,
   buildLocalModelOptions,
@@ -128,8 +129,16 @@ export function AnalysingView({
   onComplete,
 }: Props) {
   const dispatch = useAppDispatch();
+  /* `phase` is the pipeline FRONTIER — the highest phase id seen this run.
+     It drives the overall %, the sticky bar, and the cross-nav snapshot. The
+     per-phase progress + live payloads are kept in separate maps so two
+     pipelined phases (cast + attribution, under the split analyzer) never
+     clobber each other's ticker — the old single `live`/`phaseProgress` state
+     was the active-card "flicker" the user filmed. */
   const [phase, setPhase] = useState(0);
-  const [phaseProgress, setPhaseProgress] = useState(0);
+  const maxPhaseRef = useRef(0);
+  const [progressByPhase, setProgressByPhase] = useState<Record<number, number>>({});
+  const [liveByPhase, setLiveByPhase] = useState<Record<number, AnalysisLiveInfo | null>>({});
   const [logs, setLogs] = useState<Record<number, string[]>>({});
   const [error, setError] = useState<{
     message: string;
@@ -144,7 +153,6 @@ export function AnalysingView({
   }>({ nonce: 0, fresh: false });
   const [conn, setConn] = useState<ConnState>('idle');
   const [lastEventAt, setLastEventAt] = useState<number | null>(null);
-  const [live, setLive] = useState<AnalysisLiveInfo | null>(null);
   /* Per-phase live "Receiving response" indicator. Cleared whenever the
      active phase changes so a stale heartbeat never bleeds into the next
      phase's UI. Heartbeat events arrive throttled (~one per 2s); the local
@@ -383,12 +391,13 @@ export function AnalysingView({
     analysisControllerRef.current = controller;
     hasStartedOnceRef.current = true;
     setPhase(0);
-    setPhaseProgress(0);
+    maxPhaseRef.current = 0;
+    setProgressByPhase({});
+    setLiveByPhase({});
     setLogs({});
     setError(null);
     setConn('connecting');
     setLastEventAt(null);
-    setLive(null);
     setHeartbeatByPhase({});
     setServerModelByPhase({});
     setRemainingMs(null);
@@ -443,38 +452,35 @@ export function AnalysingView({
             if (serverModel) {
               setServerModelByPhase((prev) => ({ ...prev, [phaseId]: serverModel }));
             }
+            /* Per-phase state: each phase owns its progress + live payload so
+               pipelined cast (Phase 0) and attribution (Phase 1) ticks don't
+               overwrite one another. A phase event with no `live` clears that
+               phase's ticker (it's finished a chapter / the whole phase) while
+               leaving the other phase untouched. A done phase's stale heartbeat
+               never renders because PhaseCard gates it on isActive. */
+            setProgressByPhase((prev) => ({ ...prev, [phaseId]: progress }));
+            setLiveByPhase((prev) => ({ ...prev, [phaseId]: live ?? null }));
+            const prevMax = maxPhaseRef.current;
+            const newMax = Math.max(prevMax, phaseId);
+            maxPhaseRef.current = newMax;
+            if (newMax !== prevMax) setPhase(newMax);
+            /* Only the frontier phase drives the cross-nav snapshot's phase
+               label/progress (so the top-bar pill doesn't flip-flop between the
+               two pipelined phases); lagging-phase ticks just refresh the
+               liveness timestamp. */
             dispatch(
-              analysisActions.applyAnalysisSnapshotTick({
-                manuscriptId,
-                phaseId,
-                phaseLabel: ANALYSIS_PHASES[phaseId]?.label ?? 'Analysing',
-                phaseProgress: progress,
-                lastTickAt: Date.now(),
-              }),
+              analysisActions.applyAnalysisSnapshotTick(
+                phaseId === newMax
+                  ? {
+                      manuscriptId,
+                      phaseId,
+                      phaseLabel: ANALYSIS_PHASES[phaseId]?.label ?? 'Analysing',
+                      phaseProgress: progress,
+                      lastTickAt: Date.now(),
+                    }
+                  : { manuscriptId, lastTickAt: Date.now() },
+              ),
             );
-            setPhase((prev) => {
-              /* Drop heartbeat for the previous phase the moment the active
-                 phase advances — completed phases shouldn't keep a "still
-                 receiving" hint. */
-              if (prev !== phaseId) {
-                setHeartbeatByPhase((hbs) => {
-                  if (!(prev in hbs)) return hbs;
-                  const { [prev]: _drop, ...rest } = hbs;
-                  return rest;
-                });
-                setThrottleByPhase((ts) => {
-                  if (!(prev in ts)) return ts;
-                  const { [prev]: _drop, ...rest } = ts;
-                  return rest;
-                });
-              }
-              return phaseId;
-            });
-            setPhaseProgress(progress);
-            /* Carry the realtime "what's running right now" payload so the
-               active phase header can render a ticking elapsed indicator.
-               Cleared as soon as the active phase changes (below). */
-            if (live) setLive(live);
           },
           onLog: ({ phaseId, message }) => {
             if (cancelled) return;
@@ -794,9 +800,11 @@ export function AnalysingView({
         onPhase: ({ phaseId, progress, live }) => {
           markEvent();
           setConn('streaming');
-          setPhase(phaseId);
-          setPhaseProgress(progress);
-          if (live) setLive(live);
+          setProgressByPhase((prev) => ({ ...prev, [phaseId]: progress }));
+          setLiveByPhase((prev) => ({ ...prev, [phaseId]: live ?? null }));
+          const newMax = Math.max(maxPhaseRef.current, phaseId);
+          maxPhaseRef.current = newMax;
+          setPhase(newMax);
           /* Snapshot tick — proof to the middleware that the subset
            SSE is alive so it can attach as a second subscriber. */
           dispatch(
@@ -907,7 +915,7 @@ export function AnalysingView({
       });
   };
 
-  const overall = computeOverallProgress(phase, phaseProgress);
+  const overall = computeOverallProgress(phase, progressByPhase[phase] ?? 0);
   const sinceLastSec = lastEventAt
     ? Math.max(0, Math.round((Date.now() - lastEventAt) / 1000))
     : null;
@@ -1352,25 +1360,34 @@ export function AnalysingView({
         </div>
 
         <div className="bg-white rounded-3xl border border-ink/10 shadow-card divide-y divide-ink/5">
-          {ANALYSIS_PHASES.map((p) => (
-            <PhaseCard
-              key={p.id}
-              phase={p}
-              activePhaseId={phase}
-              phaseProgress={phaseProgress}
-              phaseLogs={logs[p.id] ?? []}
-              live={live}
-              heartbeat={heartbeatByPhase[p.id]}
-              throttle={throttleByPhase[p.id]}
-              serverModelByPhase={serverModelByPhase}
-              isLocalAnalyzer={isLocalAnalyzer}
-              analysisStarted={analysisStarted}
-              conn={conn}
-              isResuming={resuming}
-              bookId={bookId}
-              droppedQuotesRefreshKey={droppedQuotesRefreshKey}
-            />
-          ))}
+          {ANALYSIS_PHASES.map((p) => {
+            const phaseState = derivePhaseState(p.id, {
+              progressByPhase,
+              liveByPhase,
+              maxPhase: phase,
+            });
+            return (
+              <PhaseCard
+                key={p.id}
+                phase={p}
+                activePhaseId={phase}
+                isPhaseActive={phaseState === 'active'}
+                isPhaseDone={phaseState === 'done'}
+                phaseProgress={progressByPhase[p.id] ?? 0}
+                phaseLogs={logs[p.id] ?? []}
+                live={liveByPhase[p.id] ?? null}
+                heartbeat={heartbeatByPhase[p.id]}
+                throttle={throttleByPhase[p.id]}
+                serverModelByPhase={serverModelByPhase}
+                isLocalAnalyzer={isLocalAnalyzer}
+                analysisStarted={analysisStarted}
+                conn={conn}
+                isResuming={resuming}
+                bookId={bookId}
+                droppedQuotesRefreshKey={droppedQuotesRefreshKey}
+              />
+            );
+          })}
         </div>
 
         {/* Stage 1 shrink-refused banner. The server refused to overwrite


### PR DESCRIPTION
## Summary

Fixes the Analysing-view per-chapter ticker flicker and inconsistent counters (filmed/screenshotted 2026-06-18/19).

Root cause: the view stored a **single** `phase`/`phaseProgress`/`live` state. Under the split analyzer, Phase 0 (cast) and Phase 1 (attribution) pipeline and each emits `phase` SSE events with its own `live` payload, so each event clobbered the other — the active card + elapsed ticker flip-flopped (the `5:59` ↔ `45:33` flicker).

- **Per-phase state** (`progressByPhase`/`liveByPhase` + a frontier ref) and a pure, unit-tested `derivePhaseState` helper → both pipelined phases render their own ticker at once. Only the frontier phase drives the cross-nav snapshot so the top-bar pill stops flipping labels.
- `PhaseCard` gains optional `isPhaseActive`/`isPhaseDone` overrides (back-compat: falls back to `activePhaseId === id`).
- **Section counter** now shows the in-progress section (1-based, clamped) → `section 1/10` not a stuck `section 0/10`; consistent across cast + attribution.
- **Thousands separators** on section + sentence counts (`1129` → `1,129`).
- **Removed** the redundant per-chapter `"Nm elapsed, still waiting on the model"` + over-budget `"still running, Nx exceeded"` log lines — they duplicated the live ticker and disagreed with it (chapter-total vs per-tick elapsed). The silence watchdog still warns on genuine model stalls.

Closes #930

## Test plan

- `src/lib/analysis-phase-state.test.ts` — `derivePhaseState` incl. "two pipelined phases both active".
- `src/views/analysing.test.tsx` — interleaved Phase 0/1 events keep **both** tickers visible; a no-live phase event clears only its own ticker.
- `src/components/analysing/phase-card.test.tsx` — 1-based section display (never `0/N`), thousands separators, `isPhaseActive`/`isPhaseDone` overrides.
- Server `analysis.test.ts` stays green after removing the log lines.
- Local: typecheck + lint + full frontend (2972) + server analysis (123) + build all green. e2e is flaky on the local Windows box (browser crashes, reproduces on `main`); run via `run-ci` for the clean-room check.