### PR TITLE
ci(verify): run e2e visual baselines on label-gated PR CI

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -212,6 +212,16 @@ jobs:
         if: steps.changes.outputs.frontend == 'true' || steps.changes.outputs.e2e == 'true' || steps.changes.outputs.shared == 'true'
         run: npm run test:e2e
 
+      # Visual snapshots run as their own serial step (workers=1) so they can't
+      # race the parallel test:e2e battery for the Vite dev server — mirrors the
+      # local `verify` (verify-cache.mjs). CI is Ubuntu, so this validates the
+      # committed `e2e/linux/**` baselines; without it, visual regressions slip
+      # past every PR and only surface at release time (release.yml runs the full
+      # `npm run verify`, which includes this leg, on Ubuntu).
+      - name: E2E visual baselines (chromium)
+        if: steps.changes.outputs.frontend == 'true' || steps.changes.outputs.e2e == 'true' || steps.changes.outputs.shared == 'true'
+        run: npm run test:e2e:visual
+
       - name: Build
         if: steps.changes.outputs.frontend == 'true' || steps.changes.outputs.server == 'true' || steps.changes.outputs.shared == 'true'
         run: npm run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ Define success criteria, then loop until verified.
   Cross-engine sanity needs `GOLDEN_COQUI=1` / `GOLDEN_QWEN_VOICE=<id>`.
 - `npm run test:e2e` — Playwright (chromium) against Vite in mock mode on port 5174.
   Requires one-time `npx playwright install chromium`. Excludes the visual baselines (run via `test:e2e:visual` separately). See `docs/features/archive/37-e2e-playwright.md`.
-- `npm run test:e2e:visual` — Playwright visual-snapshot specs at `e2e/responsive/visual.spec.ts`, chromium-only, `--workers=1` so per-snapshot Windows font-hinting drift can't race against the parallel `test:e2e` battery. Lands in pre-push `verify`.
+- `npm run test:e2e:visual` — Playwright visual-snapshot specs at `e2e/responsive/visual.spec.ts`, chromium-only, `--workers=1` so per-snapshot Windows font-hinting drift can't race against the parallel `test:e2e` battery. Baselines are per-platform (`e2e/{linux,win32}/**`). Lands in pre-push `verify` AND label-gated PR CI (`verify.yml`, Ubuntu → `e2e/linux` baselines), so visual regressions surface at PR time rather than only at release.
 - `npm run test:fast` — frontend + server only (matches the pre-commit hook).
 - `npm run test:all` — frontend + server + server-slow + PowerShell-scripts + sidecar tests (no e2e).
 - `npm run verify` — full battery: typecheck + all tests + e2e + build (matches the pre-push hook).


### PR DESCRIPTION
## Summary

`verify.yml` ran only `test:e2e`, which excludes the visual baselines (`--grep-invert="visual baselines"`). So visual regressions weren't caught on any PR — they could only surface at **release** (`release.yml` gates publish on the full `npm run verify`, which includes the visual leg, on Ubuntu). This adds a serial `test:e2e:visual` step to PR CI with the same frontend/e2e/shared scope filter, so visual drift is caught at PR time.

- CI is Ubuntu → validates the committed `e2e/linux/**` baselines.
- The per-platform `e2e/win32/**` set still covers the local Windows pre-push (`verify`).
- Runs `--workers=1` (its own serial step) so it can't race the parallel `test:e2e` battery for the Vite dev server — mirrors `verify-cache.mjs`.

This PR's own `run-ci` run is the proof: it executes the new step against `main`'s current state.

## Test plan

- `run-ci` on this PR → the new "E2E visual baselines (chromium)" step runs green on Ubuntu against `e2e/linux/**`.