### PR TITLE
fix(server): populate tone + localize cast fields + capture same-id aliases on non-English

### DIFF
--- a/docs/features/221-multilingual-attribution-gemma-and-cast-merge.md
+++ b/docs/features/221-multilingual-attribution-gemma-and-cast-merge.md
@@ -11,8 +11,11 @@ owner: null
 > works** via #851's model picker + the existing `defaultAnalysisModel` setting
 > (set gemma in Account → Model settings — admin-selectable, no hardcoding; only
 > per-language auto-default would be net-new, optional); **Wave C OBSOLETE** —
-> re-measured 2026-06-17: plan 219 already deduplicates (17 chars, 0 dups). The
-> Russian pipeline is functional end-to-end. Investigation reproduced cold; the
+> re-measured 2026-06-17: plan 219 already deduplicates (17 chars, 0 dups);
+> **Wave E implemented** (2026-06-19, `fix/server-ru-cast-tone-localization-aliases`):
+> Russian cast-field under-population — tone 0%→100% + localized role/description via
+> a `languagePreamble` cast-field guard, plus same-id alias capture in the roster merge.
+> The Russian pipeline is functional end-to-end. Investigation reproduced cold; the
 > **prompt-guard fix is empirically validated**, model choice settled. Extends [162 (fs-2 multilanguage)](162-fs2-multilanguage.md)
 > and [187 (large-chapter stage-2 + attribution coverage)](archive/187-large-chapter-stage2-and-attribution-coverage.md).
 > Trigger: full analysis of a Russian book (Ночной дозор / Night Watch, 9 ch,
@@ -229,6 +232,51 @@ manual-downgrade `makeBucket` call too.
 
 - **Tests:** `makeBucket('ru')` names survive the canonicalizer; Russian
   `isDescriptorName` positives/negatives; fold threads language.
+
+### Wave E — Russian cast-field under-population (tone + localization + same-id aliases) — IMPLEMENTED
+
+**Status: implemented** (`fix/server-ru-cast-tone-localization-aliases`). A separate
+defect from the attribution ones above, found 2026-06-19 on the same _Ночной дозор_
+book: cast **metadata** comes back under-populated even when attribution completes.
+
+**Root cause (measured on the persisted analysis cache + a live gemma4-e4b probe).**
+Across **188 raw per-chapter character emissions**, gemma4-e4b emitted `gender` and
+`ageRange` **100%** but `tone` **0%** and `aliases` **0%**. The per-chapter detection
+skill says _"`tone`: Skip a field rather than guess"_, so the model takes the skip
+option for every character on Russian → the drawer falls back to a neutral 50/50/50/50
+(`profile-drawer.tsx:213`). Role/description came back in mixed English/Russian
+(the skill's English JSON example leaks; the preamble never told it to localize).
+Alias forms (Антон / Антон Городецкий) were never captured: the model reuses the
+short name under one id, and `mergeRosterChapter` (`analysis.ts`) **dropped** any
+divergent same-id name form instead of recording it.
+
+**Fix (two surgical changes, both TDD'd):**
+
+1. **`languagePreamble` cast-field guard** (`gemini.ts`, reaches the local path via
+   `ollama.ts:305`): for any non-English manuscript, instruct the model to ALWAYS
+   emit `tone`, and to write `role`/`description`/`attributes` (incl. the narrator)
+   in the manuscript's language. Phrased "when you output a character" so it is a
+   no-op for the stage-2 attribution pass. **Live-validated: tone 0% → 100%, role +
+   description returned in Russian** on gemma4-e4b. English is byte-identical (empty
+   preamble). Tests: `gemini.test.ts` "Russian cast-field guards".
+2. **Same-id alias capture in `mergeRosterChapter`** (`analysis.ts`): a divergent
+   name form for the same id (plus any incoming `aliases`) is appended to `aliases`
+   (case-insensitive dedup, never the display name) instead of dropped — runs at the
+   Phase-1 finalisation rebuild. Tests: `analysis.test.ts` "mergeRosterChapter".
+
+**Deliberately NOT done (evidence-backed decisions):**
+- **No deterministic attribute→tone fill** — the prompt nudge already hits 100%, and
+  a fill keyed on attributes would be fragile once attributes are localized.
+- **No prompt `aliases` nudge** — the model ignored an explicit alias instruction in
+  both live probes (0% compliance).
+- **No automatic cross-id fuzzy fold** (`anton`≡`anton-gorodetsky`). On this book the
+  full name was mis-attributed once to the **narrator's id** (12k lines); a name-based
+  fold would merge the narrator into Anton. Cross-id same-person linking stays a
+  **manual merge at cast review** (which already records aliases) — confirming Wave C's
+  obsolete/risky verdict. Re-confirms: exact-name Tier-1 wouldn't catch full-vs-short anyway.
+
+- **Acceptance:** full re-analysis of _Ночной дозор_ on local gemma4-e4b → cast carries
+  Russian role/description + populated tone; same-id name drift surfaces as aliases.
 
 ### Cross-cutting — reliable completion + wall-clock
 

--- a/docs/superpowers/specs/2026-06-19-srv-43-voice-uuid-design.md
+++ b/docs/superpowers/specs/2026-06-19-srv-43-voice-uuid-design.md
@@ -1,0 +1,178 @@
+# srv-43 — Stable per-voice identity (`voiceUuid`)
+
+- **Date:** 2026-06-19
+- **Issue:** [#934](https://github.com/dudarenok-maker/Castwright/issues/934) (`area:srv`, `moscow:should`, `type:chore`)
+- **Branch:** `chore/server-srv-43-voice-uuid`
+- **Status:** approved design (revised after two adversarial passes) — ready for implementation plan
+
+## Problem
+
+A designed Qwen voice has no stable identifier. Its **on-disk storage key** is the derived
+string `qwen-${voiceId ?? characterId}` (`deriveQwenVoiceId`, `server/src/routes/qwen-voice.ts`),
+which is also written into `overrideTtsVoices.qwen.name` and handed verbatim to the sidecar at
+synth time to load `voices/qwen/<key>.pt`. `voiceId` / `characterId` are stable **within** a
+series but **repeat across** unrelated series: two different characters that share a name/id in
+different books (e.g. a "Wren" in two unrelated series) both derive `qwen-wren`, write to the
+**same** `.pt`/`.json`, and the sidecar prompt cache keys on that same string. The second design
+silently **overwrites** the first (last-write-wins).
+
+The collision is purely an **on-disk storage-key collision**. It is *not* a linker bug: both
+`series-reuse-link.ts` and `cross-book-duplicates.ts` are already same-author + same-series scoped.
+Only **Qwen** persists per-character designed files (no `coquiVoicesDir` / `kokoroVoicesDir`);
+Coqui / Kokoro / Gemini use shared catalog voices — zero collision risk, out of scope.
+
+## Design — forward-only
+
+No on-disk migration. Correctness rests on two mechanisms that are reliable regardless of
+upgrade path (a boot migration would be version-gated — fresh installs / restores / Pinokio
+reinstalls skip it — so correctness must not depend on one):
+
+1. **Design-time minting.** When a Qwen voice is first designed, mint an immutable
+   `voiceUuid = nanoid()` on the `Character` (if absent), and write its storage key as
+   `qwen-<voiceUuid>` into `overrideTtsVoices.qwen.name`. New designs are globally unique →
+   **100 % of new cross-series collisions are prevented.**
+2. **Runtime legacy fallback.** The key resolver returns the uuid-derived key when a
+   `voiceUuid` is present, else the legacy `qwen-${voiceId ?? characterId}` key. Existing
+   name-keyed voices keep resolving to their existing `.pt` files untouched — no migration,
+   no data movement, no breakage.
+
+Legacy voices stay name-keyed until they are next re-designed (at which point they lazily gain a
+`voiceUuid`). Already-collided legacy pairs remain collided — that overwrite already happened on
+disk and is unrecoverable by any approach.
+
+**Downgrade-safe.** Because the full storage key still lives in `overrideTtsVoices.qwen.name`
+(`qwen-<uuid>`), an older pre-srv-43 server ignores the unknown `voiceUuid` field, reads
+`qwen.name` as the synth key, and finds the `.pt` we wrote. No schema bump, no
+`UnsupportedSchemaError` refusal, no silent mis-synth.
+
+### `voiceUuid` placement and the key resolver
+
+- `voiceUuid` lives on the **`Character`**, not inside the qwen slot. It is the only id that
+  survives an engine switch (the qwen slot can be absent when a character is on Coqui/Kokoro),
+  and it is the engine-agnostic id future cross-book features want. This is *why* it is stored
+  separately even though it is prefix-strippable from `qwen.name` — do not "simplify" it away.
+- **Invariant** (uuid-backed voices only): `overrideTtsVoices.qwen.name === 'qwen-' + voiceUuid`,
+  with `voiceUuid` as the source of truth. Asserted by a unit test.
+- `deriveQwenVoiceId(character, characterId)` becomes the single resolver:
+  `character.voiceUuid ? 'qwen-' + character.voiceUuid : 'qwen-' + (voiceId ?? characterId)`.
+  It is **read-only** (resolve); minting happens at the genuine design-creation entry point.
+  Every consumer must route through it: the **six call-sites** in `qwen-voice.ts`
+  (≈ lines 141, 224, 265, 548, 642, 703), `persistEmotionVariant` (a *second* cast.json writer
+  that defaults the base name), the `designed-persona` GET, `delete-variant`, and the `-preview`
+  `promote-voice` / `discard-voice` validation (`expectedPreview = deriveQwenVoiceId(...) +
+  '-preview'`). Update the stale `qwen-voice.ts:169-183` comment that says the committed id is
+  kept stable to avoid rippling duplicate-detection — srv-43 changes that committed id.
+
+The synth path is **untouched**: `pickVoiceForEngine` (`server/src/tts/voice-mapping.ts:248`)
+keeps returning `overrideTtsVoices.qwen.name` verbatim — which is now `qwen-<uuid>` for designed
+voices and the legacy name for unmigrated ones. The sidecar contract does not change.
+
+### Propagating `voiceUuid` on reuse
+
+So that two books in a series **share** one voice (one uuid, one `.pt`) — and so the invariant
+holds on reused rows — `voiceUuid` must travel with the qwen override everywhere `voiceId`
+already does. Reuse uses explicit **allowlists**, so each must name the field:
+
+- `merge-analysis-cast.ts` — add `voiceUuid` to the `PRESERVED_VOICE_FIELDS` constant (`:32-41`),
+  or a reparse/re-analysis **strips it** from the whole cast.
+- `server/src/tts/hydrate-reused-voice.ts` (note: under `tts/`, not `workspace/`) —
+  `ReuseHydratable`, `ResolvedReusedVoice`, `resolveReusedVoiceFields`, and `hydrateCharacterVoice`
+  each carry `voiceUuid` alongside `overrideTtsVoices`/`ttsEngine`.
+- `series-reuse-link.ts:324-339` denormalises `overrideTtsVoices.qwen.name = qwen-<sourceKey>`
+  onto the reused character — it must set the source's `voiceUuid` on the same lines, or the
+  reused row has `qwen.name` set with a blank `voiceUuid` (invariant break; dedup-skip never fires).
+- **Audit every `voiceId`-copy site and copy `voiceUuid` alongside**: `cast-link-prior.ts`
+  (`:192,230`), `voice-match.ts:227`, `voice-override-linked.ts:182`, `cast-add-from-roster.ts:136`,
+  `series-roster.ts:48`, `revisions.ts:256`, `character-snapshots.ts:38`.
+
+`import.ts` writes cast.json directly without a `voiceUuid`; that is benign (the voice keeps its
+name-keyed `qwen.name`, resolved via the legacy fallback) — note it, no fix required.
+
+### Cross-book dedup re-bucket (Qwen only)
+
+`detectDuplicateCandidates` (`cross-book-duplicates.ts:129`) buckets by `${provider}|${ttsVoice.name}`
+(`:137`) and then re-checks `looksLikeSameName(a.character, b.character)` (`:160`, **substring-aware**:
+`"wren" ⊂ "wren sparrow"` — the header comment calls that the detector's reason to exist). Once
+designed Qwen names are globally unique (`qwen-<uuid>`), the name bucket makes every Qwen voice a
+singleton → dedup silently returns nothing.
+
+Fix, **scoped to Qwen only**: coarsen the Qwen bucket key to `qwen|${author}|${series}` (available
+via `ctx.seriesByBookId`), and let the existing in-bucket `looksLikeSameName` + author/series/
+standalone/`notLinkedTo`/alias guards (`:153-195`) do the real, substring-tolerant match. **Leave
+catalog engines (Coqui/Kokoro/Gemini) on `provider|name`** — re-bucketing them would change a
+shipped feature's results. Do **not** "match on `voiceUuid`": separately-designed same-character
+voices have *different* uuids by construction. A shared `voiceUuid` is used only to **skip** pairs
+that are already linked.
+
+### Frontend plumbing
+
+- Add `voiceUuid?: string` (**optional**, additive) to the `Character` **and** `Voice` schemas in
+  `openapi.yaml`; regenerate `src/lib/api-types.ts` (`npm run openapi:types`). Optional ⇒ no
+  `src/mocks/canned-data.ts` fixture breaks.
+- The voices aggregator in `voices.ts` (≈ 335–361) must **copy `c.voiceUuid`** onto each derived
+  `Voice`, or the field never reaches the frontend and the dedup change is dead code.
+- `voices.ts:350,355` key `gradientForTtsVoice` and the `generated`/`sampled` badges on
+  `ttsVoice.name`; ensure `renderedQwenNames` / sample scope are keyed on the new `qwen-<uuid>`
+  name so gradients/badges don't silently re-roll or mis-show. Cosmetic.
+
+### Sidecar
+
+`server/tts-sidecar/main.py` — the designed-voice `.json` descriptor gains a `voiceUuid` field per
+the issue's acceptance. It is **inert / forward-looking**: the sidecar loads purely by filename and
+reads `instruct`/`language`/`refText`; nothing keys on `voiceUuid` today. No sidecar logic change.
+
+### Out of scope / non-goals
+
+- **No on-disk file migration, no schema bump, no `upgrade-coordinator` / fs-1-seam wiring, no
+  writer-side schema stamping.** (The boot-migration approach was rejected: a pure per-doc
+  transform splits legitimately-shared reused voices into independent uuids; it is version-gated
+  so unreliable; and it is unnecessary given the runtime fallback.)
+- No rename UI. The qwen storage name is never user-facing (the cast view shows the character name
+  + "Designed voice"); the issue's "`name` becomes a renamable mirror" acceptance is satisfied
+  **vacuously** — references resolve via `voiceUuid`, so any future label rename is safe.
+- No change to the `voiceId` field (still the reuse-link match key), to `pickVoiceForEngine`, or to
+  the sidecar synth contract.
+- Coqui / Kokoro / Gemini voices.
+
+## Testing
+
+Paired automated tests are required (CLAUDE.md testing discipline). All are GPU-free — the
+`qwen-voice.test.ts` harness mocks `global.fetch` (the sidecar) and `selectTtsProvider`/
+`synthesize` and writes designed-voice JSON manually (`:54-66, 110, 177`):
+
+- **Collision regression** (route integration, mocked fetch) — design two same-named characters in
+  different series; assert distinct `voiceUuid` and that two *different* `qwen-<uuid>.pt` paths are
+  written, no overwrite. Fails on `main`.
+- **Legacy fallback** — a character with **no** `voiceUuid` resolves through `deriveQwenVoiceId` to
+  `qwen-${voiceId ?? characterId}` (unmigrated voices keep working).
+- **Invariant** — a freshly-designed voice satisfies `qwen.name === 'qwen-' + voiceUuid`; its
+  emotion variants are `qwen-<uuid>__<emotion>` with the base name unchanged.
+- **Reuse propagation** — a reused character in a later book of the same series inherits the
+  owner's `voiceUuid` (via `resolveReusedVoiceFields` + `series-reuse-link`); a reparse preserves
+  it (`PRESERVED_VOICE_FIELDS`).
+- **Dedup re-bucket** (pure unit test feeding synthetic `Voice[]` carrying `voiceUuid`, since mock
+  mode leaves the field undefined) — two separately-designed same-character Qwen voices (different
+  uuids, same series, substring names like "Wren" / "Wren Sparrow") are still surfaced as a
+  candidate; catalog-engine (Coqui/Kokoro) dedup results are unchanged; an already-linked pair
+  (shared uuid) is skipped.
+- **api-types** — `voiceUuid` present on the derived `Voice` from the voices aggregator.
+- **Sidecar descriptor** — `.json` round-trips `voiceUuid` (pytest); explicitly noted as inert.
+
+No e2e spec expected (no router / redux / layout seam, and `voiceUuid` is undefined in mock mode).
+Confirmed in the plan; add a Playwright spec only if a UI-visible path is found.
+
+## Key files
+
+- `server/src/routes/qwen-voice.ts` — `deriveQwenVoiceId` resolver (uuid-or-legacy) + design-time
+  mint; the 6 call-sites, `persistEmotionVariant`, `designed-persona` GET, `delete-variant`,
+  `-preview` promote/discard derivation; update the stale `:169-183` comment.
+- `server/src/store/merge-analysis-cast.ts` — add `voiceUuid` to `PRESERVED_VOICE_FIELDS`.
+- `server/src/tts/hydrate-reused-voice.ts` + `server/src/workspace/series-reuse-link.ts` — carry
+  `voiceUuid` through reuse hydration + denormalisation (match key unchanged).
+- `voiceId`-copy sites: `cast-link-prior.ts`, `voice-match.ts`, `voice-override-linked.ts`,
+  `cast-add-from-roster.ts`, `series-roster.ts`, `revisions.ts`, `character-snapshots.ts`.
+- `server/src/routes/voices.ts` — `applyOverrideToCastFiles` storage-name write; the voices
+  aggregator (≈ 335–361) copies `c.voiceUuid`; gradient/badge keying (`:350,355`).
+- `src/lib/cross-book-duplicates.ts` — Qwen-only series-axis re-bucket.
+- `server/tts-sidecar/main.py` — `.json` descriptor gains inert `voiceUuid`.
+- `openapi.yaml` + `src/lib/api-types.ts` — optional `voiceUuid` on `Character` and `Voice`.

--- a/server/src/analyzer/gemini.test.ts
+++ b/server/src/analyzer/gemini.test.ts
@@ -277,6 +277,29 @@ describe('fs-2 — languagePreamble + estimateInputTokens', () => {
     });
   });
 
+  describe('languagePreamble — Russian cast-field guards (tone + localization)', () => {
+    it('tells the model to always provide tone, for ru', async () => {
+      const { languagePreamble } = await import('./gemini.js');
+      const p = languagePreamble('ru');
+      /* gemma4-e4b skips the optional numeric tone 100% of the time on
+         Russian unless explicitly told not to (measured). */
+      expect(p).toMatch(/tone/i);
+      expect(p).toMatch(/warmth|always/i);
+    });
+    it('tells the model to write role/description/attributes in Russian, incl. the narrator', async () => {
+      const { languagePreamble } = await import('./gemini.js');
+      const p = languagePreamble('ru');
+      expect(p).toMatch(/role/i);
+      expect(p).toMatch(/description/i);
+      expect(p).toMatch(/attributes/i);
+      expect(p).toMatch(/narrator/i);
+    });
+    it('adds none of the cast-field guards for English', async () => {
+      const { languagePreamble } = await import('./gemini.js');
+      expect(languagePreamble('en')).toBe('');
+    });
+  });
+
   it('buildSystemInstruction appends the preamble only for non-English', async () => {
     const { buildSystemInstruction } = await import('./gemini.js');
     expect(buildSystemInstruction('SKILL', 'ru')).toMatch(/manuscript text is in Russian/i);

--- a/server/src/analyzer/gemini.ts
+++ b/server/src/analyzer/gemini.ts
@@ -177,7 +177,14 @@ export function languagePreamble(language?: string): string {
   const conventions = ru
     ? ' Dialogue is often marked with guillemets «…» or an em-dash —, not English "quotes". Characters may be named by first name, patronymic, surname, or diminutive (e.g. "Соня" for "Софья") — treat these as the same person. IMPORTANT: a dashed line that is a narrative TAG describing who spoke or what they did — e.g. «— сказал юноша.», «— тихо произнесла девушка.», «— Девушка улыбнулась.» (verbs like сказал/произнёс(ла)/воскликнул(а)/спросил(а)/засмеялся/улыбнулась/нахмурился) — is the narrator, NOT the speaker. Only the actually-spoken words belong to the speaker.'
     : '';
-  return `\n\nIMPORTANT: the manuscript text is in ${where}. Quote evidence VERBATIM from the manuscript (do not translate or transliterate it). Keep all JSON field names and enum values in English exactly as the schema shows.${conventions}`;
+  /* Cast-field guards for any non-English manuscript (validated on Russian +
+     gemma4-e4b, 2026-06-19: without these the local model emits gender/age
+     100% but `tone` 0% and writes role/description in mixed English/target
+     language). Phrased "when you output a character" so it is a no-op for the
+     stage-2 attribution pass (which lists sentences, not characters). Field
+     NAMES + enum values stay English as the line above already mandates. */
+  const castFields = ` When you output a character, ALWAYS include the \`tone\` object (integers 0–100 for warmth, pace, authority, emotion) estimated from how they speak — never omit it. Write the human-readable text — \`role\`, \`description\`, and each \`attributes\` tag, for every character INCLUDING the narrator — in ${where} (the manuscript's language), and always include a \`description\`.`;
+  return `\n\nIMPORTANT: the manuscript text is in ${where}. Quote evidence VERBATIM from the manuscript (do not translate or transliterate it). Keep all JSON field names and enum values in English exactly as the schema shows.${castFields}${conventions}`;
 }
 
 interface GeminiOptions {

--- a/server/src/routes/analysis.test.ts
+++ b/server/src/routes/analysis.test.ts
@@ -563,6 +563,47 @@ describe('mergeRosterChapter — Phase 0a roster merging', () => {
     expect(roster.get('wren')!.ageRange).toBe('teen');
   });
 
+  it('records a divergent same-id name form as an alias instead of dropping it', () => {
+    /* The model emits the same id with a fuller name in a later chapter
+       (e.g. «Антон» then «Антон Городецкий»). First-detection wins for the
+       display name, but the divergent form must be preserved as an alias
+       so cast review can surface it — not silently discarded. */
+    const roster = new Map<string, CharacterOutput>();
+    mergeRosterChapter(roster, [{ id: 'anton', name: 'Антон', role: 'Иной', color: 'blue' }]);
+    mergeRosterChapter(roster, [
+      { id: 'anton', name: 'Антон Городецкий', role: 'Иной', color: 'blue' },
+    ]);
+    const anton = roster.get('anton')!;
+    expect(anton.name).toBe('Антон');
+    expect(anton.aliases).toEqual(['Антон Городецкий']);
+  });
+
+  it('does not alias an identical name, and never adds the entry’s own name', () => {
+    const roster = new Map<string, CharacterOutput>();
+    mergeRosterChapter(roster, [{ id: 'wren', name: 'Wren', role: 'p', color: 'orange' }]);
+    mergeRosterChapter(roster, [{ id: 'wren', name: 'Wren', role: 'p', color: 'orange' }]);
+    expect(roster.get('wren')!.aliases ?? []).toEqual([]);
+  });
+
+  it('unions incoming aliases, deduping case-insensitively and excluding the display name', () => {
+    const roster = new Map<string, CharacterOutput>();
+    mergeRosterChapter(roster, [
+      { id: 'wren', name: 'Wren', role: 'p', color: 'orange', aliases: ['Wren Sparrow'] },
+    ]);
+    mergeRosterChapter(roster, [
+      {
+        id: 'wren',
+        name: 'Sparrow',
+        role: 'p',
+        color: 'orange',
+        aliases: ['wren sparrow', 'Wren'] /* dup of alias (case) + dup of display name */,
+      },
+    ]);
+    /* 'Sparrow' (divergent name) added; 'Wren Sparrow' kept once (case dedup);
+       'Wren' never added because it is the display name. */
+    expect(roster.get('wren')!.aliases).toEqual(['Wren Sparrow', 'Sparrow']);
+  });
+
   it('does not mutate the incoming chapter outputs (defensive clone)', () => {
     const roster = new Map<string, CharacterOutput>();
     const incoming: CharacterOutput[] = [

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -563,6 +563,7 @@ export function mergeRosterChapter(
       roster.set(incoming.id, {
         ...incoming,
         attributes: incoming.attributes ? [...incoming.attributes] : undefined,
+        aliases: incoming.aliases ? [...incoming.aliases] : undefined,
         evidence: incoming.evidence ? incoming.evidence.map((e) => ({ ...e })) : undefined,
         tone: incoming.tone ? { ...incoming.tone } : undefined,
       });
@@ -607,12 +608,31 @@ export function mergeRosterChapter(
       }
       existing.evidence = next;
     }
-    /* Gender / ageRange / color / role / name: only adopt incoming when
-       existing doesn't have a value. First detection wins for identity
-       fields — switching pronouns mid-book is almost always a model
-       error, not a character development. */
+    /* Gender / ageRange / color / role: only adopt incoming when existing
+       doesn't have a value. First detection wins for identity fields —
+       switching pronouns mid-book is almost always a model error, not a
+       character development. */
     if (!existing.gender && incoming.gender) existing.gender = incoming.gender;
     if (!existing.ageRange && incoming.ageRange) existing.ageRange = incoming.ageRange;
+    /* Name: first-detection wins for the DISPLAY name, but a divergent name
+       form the model emits for the same id in a later chapter («Антон» then
+       «Антон Городецкий») — plus any incoming aliases — is preserved as an
+       alias rather than silently dropped, so cast review surfaces it. Dedup
+       case-insensitively; never record the display name itself. */
+    const aliasCandidates = [incoming.name, ...(incoming.aliases ?? [])];
+    const seen = new Set<string>([
+      existing.name.trim().toLowerCase(),
+      ...(existing.aliases ?? []).map((a) => a.trim().toLowerCase()),
+    ]);
+    const nextAliases = [...(existing.aliases ?? [])];
+    for (const cand of aliasCandidates) {
+      const key = cand.trim().toLowerCase();
+      if (key.length > 0 && !seen.has(key)) {
+        nextAliases.push(cand);
+        seen.add(key);
+      }
+    }
+    if (nextAliases.length) existing.aliases = nextAliases;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes non-English (Russian) cast **metadata** under-population (Plan 221 Wave E). On `gemma4-e4b`, across 188 raw per-chapter emissions the model produced `gender`/`ageRange` 100% but `tone` 0% and `aliases` 0%, and wrote role/description in mixed English/Russian.

Two surgical, analyzer-agnostic changes:

1. **`languagePreamble` cast-field guard** (`gemini.ts`) — reaches **both** analyzers (Gemini via `gemini.ts:270`, local Ollama via `ollama.ts:305`). For any non-English manuscript: always emit `tone`, and write `role`/`description`/`attributes` (incl. the narrator) in the manuscript's language. Phrased "when you output a character" so it's a no-op for the stage-2 attribution pass. **Live-validated on gemma4-e4b: tone 0% → 100%, role + description in Russian.** English is byte-identical (empty preamble).
2. **Same-id alias capture** in `mergeRosterChapter` (`analysis.ts`) — a divergent same-id name form (+ incoming aliases) is appended to `aliases` (case-insensitive dedup, never the display name) instead of dropped, at the Phase-1 finalisation rebuild.

**Deliberately not done (evidence-backed):** no deterministic attribute→tone fill (nudge already 100%); no prompt alias nudge (0% model compliance in two live probes); no automatic cross-id fuzzy fold (would merge the narrator into Anton on this book) — cross-id linking stays a manual merge at cast review.

## Test plan

- `gemini.test.ts` — "Russian cast-field guards": ru preamble requires tone + localized role/description/attributes incl. narrator; English adds nothing.
- `analysis.test.ts` — "mergeRosterChapter": divergent same-id name recorded as alias; identical name adds none; incoming aliases unioned/deduped excluding the display name.
- `npm run verify` green locally (pre-push): typecheck + all tests + e2e + build.
- **Acceptance:** full re-analysis of _Ночной дозор_ on local gemma4-e4b.

Regression plan: `docs/features/221-multilingual-attribution-gemma-and-cast-merge.md` (Wave E).

Closes #935