### PR TITLE
fix(server): fold Russian descriptor-phrase background speakers (safe tier)

### DIFF
--- a/docs/features/221-multilingual-attribution-gemma-and-cast-merge.md
+++ b/docs/features/221-multilingual-attribution-gemma-and-cast-merge.md
@@ -15,6 +15,10 @@ owner: null
 > **Wave E implemented** (2026-06-19, `fix/server-ru-cast-tone-localization-aliases`):
 > Russian cast-field under-population — tone 0%→100% + localized role/description via
 > a `languagePreamble` cast-field guard, plus same-id alias capture in the roster merge.
+> **Wave F implemented** (2026-06-19, `fix/server-ru-descriptor-fold-phrases`): Russian
+> descriptor-phrase fold (safe-tier `isDescriptorName` widening — function-word phrases +
+> оператор/водитель), closing Wave D's stated `isDescriptorName` limitation. Byline-author
+> mis-roster (author ate Anton's lines) split out to **bug #938** for a dedicated brainstorm.
 > The Russian pipeline is functional end-to-end. Investigation reproduced cold; the
 > **prompt-guard fix is empirically validated**, model choice settled. Extends [162 (fs-2 multilanguage)](162-fs2-multilanguage.md)
 > and [187 (large-chapter stage-2 + attribution coverage)](archive/187-large-chapter-stage2-and-attribution-coverage.md).
@@ -277,6 +281,39 @@ divergent same-id name form instead of recording it.
 
 - **Acceptance:** full re-analysis of _Ночной дозор_ on local gemma4-e4b → cast carries
   Russian role/description + populated tone; same-id name drift surfaces as aliases.
+
+### Wave F — Russian descriptor-phrase fold (closes the Wave D `isDescriptorName` limitation) — IMPLEMENTED
+
+**Status: implemented** (`fix/server-ru-descriptor-fold-phrases`, #938-adjacent). Wave D
+flagged its own gap: Russian `isDescriptorName` was "English-structured… partial coverage
+for v1." Observed live on _Ночной дозор_ (2026-06-19): the model names nameless background
+speakers with multi-word **descriptive phrases** ("женщина с двумя овчарками на поводке",
+"молодой в яркой оранжевой куртке", "женщина — с сонным малышом") that the bare-single-noun
+rule missed, so they leaked into the live cast instead of folding.
+
+**Fix (safe-tier widening of `isDescriptorName`, Russian path only — TDD'd):**
+
+1. A multi-word phrase carrying a standalone **function-word** token (preposition/conjunction:
+   `с/во/в/на/у/из/к/и…`, see `RU_FUNCTION_WORDS`) is a description, not a proper name — a real
+   Russian name (first · patronymic · surname · diminutive) structurally never contains one.
+   Near-zero false-positive risk. Leading/trailing dashes are stripped per token so a "Имя — с …"
+   dash beat tokenises cleanly.
+2. Bare occupational role nouns added to `GENERIC_ROLE_RU`: `оператор`, `водитель`.
+
+**Deliberately NOT done (precision over recall — the #938 lesson):** no "`<adjective> <role-noun>`"
+rule, so "Тёмный маг" is **not** folded by name (it can be a meaningful faction role); it falls to
+the post-stage-2 line-count fold if genuinely minor (<3 lines). The guard tests assert Антон /
+Антон Городецкий / Сергей Лукьяненко / Борис Игнатьевич / Светлана Назарова / Завулон never fold;
+the widening is Russian-only (no effect under `en`/undefined).
+
+**Not addressed here (separate, bug #938):** the byline **author** (`Сергей Лукьяненко`) being
+rostered as a speaking character and absorbing the protagonist's dialogue — a roster-inclusion /
+attribution defect, not a fold gap. Tracked for a dedicated brainstorm.
+
+- **Tests:** `fold-minor-cast.test.ts` "Wave E — Russian descriptor phrases (safe tier)" (function-word
+  phrases, bare role nouns, the proper-name guard, the adjective+role-noun exclusion, Russian-only
+  scoping, and a `foldMinorCast` integration that folds a 6-line phrase descriptor while keeping a
+  4-line Anton).
 
 ### Cross-cutting — reliable completion + wall-clock
 

--- a/server/src/analyzer/fold-minor-cast.test.ts
+++ b/server/src/analyzer/fold-minor-cast.test.ts
@@ -890,3 +890,83 @@ describe('Wave D — localized minor-cast fold buckets', () => {
     expect(isDescriptorName('Unknown Jogger', 'ru')).toBe(true);
   });
 });
+
+describe('Wave E — Russian descriptor phrases (safe tier)', () => {
+  /* Background speakers on a Russian book are often named with a multi-word
+     DESCRIPTIVE PHRASE ("женщина с двумя овчарками на поводке"), not a bare
+     noun — the single-noun rule (Wave D) missed all of these, so they leaked
+     into the live cast instead of folding. The safe-tier widening fires only on
+     signals a proper Russian name structurally CANNOT have, so it can never
+     fold a real character (#938 author-takeover lesson). */
+
+  it('folds a multi-word phrase containing a Russian function word (preposition/conjunction)', () => {
+    /* Real cases from the Ночной дозор run (2026-06-19). */
+    expect(isDescriptorName('женщина с двумя овчарками на поводке', 'ru')).toBe(true); // с, на
+    expect(isDescriptorName('молодой в яркой оранжевой куртке', 'ru')).toBe(true); // в
+    expect(isDescriptorName('женщина - с сонным малышом', 'ru')).toBe(true); // dash + с
+    expect(isDescriptorName('мужчина у окна', 'ru')).toBe(true); // у
+    expect(isDescriptorName('девочка и её собака', 'ru')).toBe(true); // и
+  });
+
+  it('folds bare occupational role nouns added to the Russian set', () => {
+    expect(isDescriptorName('оператор', 'ru')).toBe(true);
+    expect(isDescriptorName('Водитель', 'ru')).toBe(true);
+  });
+
+  it('NEVER folds a real Russian proper name (the cardinal guard)', () => {
+    expect(isDescriptorName('Антон', 'ru')).toBe(false);
+    expect(isDescriptorName('Антон Городецкий', 'ru')).toBe(false);
+    expect(isDescriptorName('Сергей Лукьяненко', 'ru')).toBe(false); // byline author — not our job to fold (#938)
+    expect(isDescriptorName('Борис Игнатьевич', 'ru')).toBe(false);
+    expect(isDescriptorName('Светлана Назарова', 'ru')).toBe(false);
+    expect(isDescriptorName('Алиса Донникова', 'ru')).toBe(false);
+    expect(isDescriptorName('Завулон', 'ru')).toBe(false);
+    expect(isDescriptorName('Полина Васильевна', 'ru')).toBe(false);
+  });
+
+  it('safe tier deliberately does NOT fold "<adjective> <role-noun>" — relies on the line-count fold', () => {
+    /* "Тёмный маг" can be a meaningful faction role in this universe; the
+       safe tier leaves it to the post-stage-2 line-count fold so we never
+       swallow a real role character by name. */
+    expect(isDescriptorName('Тёмный маг', 'ru')).toBe(false);
+    expect(isDescriptorName('Темный маг', 'ru')).toBe(false);
+  });
+
+  it('the function-word + role-noun widening is Russian-only (no effect under en / undefined)', () => {
+    expect(isDescriptorName('женщина с двумя овчарками на поводке')).toBe(false);
+    expect(isDescriptorName('женщина с двумя овчарками на поводке', 'en')).toBe(false);
+    expect(isDescriptorName('оператор', 'en')).toBe(false);
+  });
+
+  it('foldMinorCast collapses a phrase descriptor regardless of line count, but keeps a real name with ≥ minLines', () => {
+    const chars = [
+      makeChar('narrator'),
+      makeChar('anton', { name: 'Антон Городецкий', gender: 'male' }),
+      makeChar('dog-woman', { name: 'женщина с двумя овчарками на поводке', gender: 'female' }),
+    ];
+    /* The descriptor speaks 6 lines (> minLines) yet still folds — the name
+       trigger is line-count-independent. Anton speaks 4 lines and must stay. */
+    const sentences = makeSentences([
+      [1, 'anton'],
+      [1, 'anton'],
+      [2, 'anton'],
+      [2, 'anton'],
+      [1, 'dog-woman'],
+      [1, 'dog-woman'],
+      [1, 'dog-woman'],
+      [2, 'dog-woman'],
+      [2, 'dog-woman'],
+      [2, 'dog-woman'],
+    ]);
+
+    const result = foldMinorCast(chars, sentences, { minLines: 3, language: 'ru' });
+
+    expect(result.rewrites).toEqual({ 'dog-woman': FEMALE_BUCKET_ID });
+    /* Anton untouched. */
+    expect(result.characters.find((c) => c.id === 'anton')?.name).toBe('Антон Городецкий');
+    /* The phrase is rolled into the bucket's aliases for cross-book matching. */
+    const female = result.characters.find((c) => c.id === FEMALE_BUCKET_ID);
+    expect(female?.name).toBe('Незнакомая Девушка');
+    expect(female?.aliases).toContain('женщина с двумя овчарками на поводке');
+  });
+});

--- a/server/src/analyzer/fold-minor-cast.ts
+++ b/server/src/analyzer/fold-minor-cast.ts
@@ -177,6 +177,24 @@ const GENERIC_ROLE_RU = new Set([
   'старик',
   'старуха',
   'парнишка',
+  'оператор',
+  'водитель',
+]);
+
+/* Russian function words (prepositions + a few conjunctions) that appear as a
+   standalone token ONLY inside a descriptive PHRASE — "женщина С двумя
+   овчарками НА поводке", "молодой В куртке". A proper Russian name (first ·
+   patronymic · surname · diminutive) structurally never contains one of these
+   as a separate word, so a multi-word "name" carrying a function-word token is
+   a description, not a person — the highest-precision fold signal we have, with
+   effectively zero false-positive risk against real names (the #938 lesson:
+   never let a widened fold swallow a real character). Single-letter forms
+   (с/в/к/у/о/а/и) are included on purpose — capitalised initials carry a dot
+   ("А.") so they don't collide. Russian-only, mirrors GENERIC_ROLE_RU. */
+const RU_FUNCTION_WORDS = new Set([
+  'с', 'со', 'в', 'во', 'на', 'по', 'под', 'из', 'у', 'за', 'к', 'ко',
+  'о', 'об', 'обо', 'при', 'про', 'для', 'без', 'до', 'от', 'над',
+  'и', 'или', 'а', 'но',
 ]);
 
 /* Decides whether a character's `name` reads as a descriptor rather
@@ -198,10 +216,16 @@ const GENERIC_ROLE_RU = new Set([
    choices don't matter.
 
    When `language` is Russian the English patterns above still apply (the
-   model occasionally emits "Unknown …" even on a Russian book) AND a bare
-   Russian generic noun ("девушка", "парень") is additionally treated as a
-   descriptor. Russian inflection means partial coverage for v1 — see
-   `GENERIC_ROLE_RU`. */
+   model occasionally emits "Unknown …" even on a Russian book) AND two further
+   Russian-only signals fold:
+     - a bare Russian generic noun ("девушка", "парень", "оператор") — see
+       `GENERIC_ROLE_RU`;
+     - a multi-word phrase carrying a standalone function word ("женщина С
+       двумя овчарками", "молодой В куртке") — a description, never a proper
+       name (see `RU_FUNCTION_WORDS`).
+   Deliberately NOT folded: "<adjective> <role-noun>" forms like "Тёмный маг"
+   (could be a meaningful role character) — those are left to the post-stage-2
+   line-count fold. Russian inflection still means partial coverage for v1. */
 export function isDescriptorName(name: string, language?: string): boolean {
   const trimmed = name.trim();
   if (!trimmed) return false;
@@ -215,6 +239,18 @@ export function isDescriptorName(name: string, language?: string): boolean {
   if (normaliseBookLanguage(language) === 'ru') {
     /* Match a lone Russian generic noun (the typical background-speaker form). */
     if (parts.length === 1 && GENERIC_ROLE_RU.has(parts[0].toLowerCase())) return true;
+    /* A multi-word Russian phrase carrying a standalone function-word token is
+       a DESCRIPTION, not a proper name ("женщина с двумя овчарками на поводке",
+       "молодой в яркой оранжевой куртке"). Strip leading/trailing dashes from
+       each token so a "Имя — с …" dash beat still tokenises cleanly. Safe
+       against real names — they never contain a preposition/conjunction word
+       (see RU_FUNCTION_WORDS). */
+    if (parts.length >= 2) {
+      const hasFunctionWord = parts.some((p) =>
+        RU_FUNCTION_WORDS.has(p.toLowerCase().replace(/^[—–-]+|[—–-]+$/g, '')),
+      );
+      if (hasFunctionWord) return true;
+    }
   }
   return false;
 }


### PR DESCRIPTION
## Summary

On a Russian book the minor-cast fold only recognised a "descriptor" name when it was a **single bare noun** from a short list (Wave D). The model names nameless background speakers with multi-word **descriptive phrases** — `женщина с двумя овчарками на поводке`, `молодой в яркой оранжевой куртке`, `женщина — с сонным малышом` — which leaked into the live cast instead of folding into the **Незнакомый Парень / Незнакомая Девушка** buckets.

Safe-tier widening of `isDescriptorName` (Russian path only), chosen for **precision so it can never fold a real character**:

- A multi-word phrase carrying a standalone **function-word** token (preposition/conjunction `с/в/на/у/из/к/и…`) is a description, not a proper name — a real Russian name (first · patronymic · surname · diminutive) structurally never contains one. Near-zero false-positive risk; dash beats (`Имя — с …`) tokenise cleanly.
- Bare occupational role nouns added to `GENERIC_ROLE_RU`: `оператор`, `водитель`.

**Deliberately NOT done** (precision > recall): no `<adjective> <role-noun>` rule, so `Тёмный маг` is not folded by name (can be a meaningful faction role) — it falls to the post-stage-2 line-count fold if genuinely minor.

**Out of scope — split to bug #938:** the byline **author** (`Сергей Лукьяненко`) being rostered as a speaking character and absorbing the protagonist's dialogue ("ate Anton's lines"). That's a roster-inclusion/attribution defect, not a fold gap, and needs a dedicated brainstorm.

Closes the `isDescriptorName` limitation flagged in plan 221 Wave D → recorded as **Wave F**.

## Test plan

- `server/src/analyzer/fold-minor-cast.test.ts` → new **"Wave E — Russian descriptor phrases (safe tier)"** block: function-word phrases fold, bare role nouns fold, the **proper-name guard** (Антон / Антон Городецкий / Сергей Лукьяненко / Борис Игнатьевич / Светлана Назарова / Завулон / Полина Васильевна never fold), the adjective+role-noun exclusion (`Тёмный маг` stays), Russian-only scoping, and a `foldMinorCast` integration that folds a 6-line phrase descriptor while keeping a 4-line Anton. Written failing first, then green.
- `npm run typecheck` clean; full server suite (3020 passed) ran in pre-commit; `npm run verify` battery green in pre-push.

Regression plan: [docs/features/221](docs/features/221-multilingual-attribution-gemma-and-cast-merge.md) (Wave F).

🤖 Generated with [Claude Code](https://claude.com/claude-code)