### PR TITLE
fix(server): stop the byline author being cast as the protagonist (#938)

### DIFF
--- a/docs/superpowers/plans/2026-06-20-byline-author-cast-collision.md
+++ b/docs/superpowers/plans/2026-06-20-byline-author-cast-collision.md
@@ -463,14 +463,25 @@ git commit -m "feat(server): strip front-matter from chapter bodies at analysis 
 
 ---
 
-### Task 5: Wire Layer B — drop the byline author at per-chapter roster capture (both entrypoints)
+### Task 5: Wire Layer B — guard the roster build (covers cached + fresh chapters)
+
+> **Adversarial-review correction (2026-06-20):** the guard must NOT sit at the
+> `chapterCast[ch.id] = result.characters` write (it runs only for *freshly-detected*
+> chapters — on a resume, or on an already-analyzed book like the user's *Ночной
+> дозор*, `chapterCast` is loaded from cache at `const chapterCast = cache.chapterCast ?? {}`
+> ~line 2538 and would bypass the guard). The guard goes inside **`rebuildRoster()`** —
+> the choke point that turns `chapterCast` into the running roster, the final roster
+> (~3044), and the live "Cast so far" SSE view (~2572→2578). Guarding on *read* there
+> covers cached AND fresh, in both entrypoints. `buildInterimCast` is guarded too so
+> the on-disk interim cast.json the user watches never shows the author.
 
 **Files:**
-- Modify: `server/src/routes/analysis.ts` — the two `chapterCast[ch.id] = result.characters;` assignments (~2880 full, ~4546 subset).
-- Test: `server/src/routes/analysis.test.ts` (integration in Task 7; this task verified by suite + typecheck).
+- Modify: `server/src/routes/analysis.ts` — `rebuildRoster` in `runMainAnalyzerJob` (~2556) and in the subset entrypoint (~4476); `buildInterimCast` (~650) + its two callers (~2921, ~4561).
+- Test: `server/src/routes/analysis.test.ts` (Task 7 integration covers this; verified here by suite + typecheck).
 
 **Interfaces:**
-- Consumes: `dropBylineAuthorFromChapter` (Task 2), `bookAuthor` (Task 4 — in scope in both entrypoints), `ch.title` (chapter hint), `log`.
+- Consumes: `dropBylineAuthorFromChapter` (Task 2), `bookAuthor` (Task 4 — in scope in both entrypoints), `ch.title` (chapter hint).
+- Produces: `buildInterimCast(chapterCast, chapterOrder, language, author?)` — new trailing optional `author` param.
 
 - [ ] **Step 1: Add the import**
 
@@ -480,46 +491,100 @@ At the top of `server/src/routes/analysis.ts`, add:
 import { dropBylineAuthorFromChapter } from '../analyzer/byline-author-guard.js';
 ```
 
-- [ ] **Step 2: Replace the full-entrypoint assignment (~2880)**
+- [ ] **Step 2: Guard the full-entrypoint `rebuildRoster` (~2556)**
 
 Find:
 
 ```ts
-        chapterCast[ch.id] = result.characters;
+      const rebuildRoster = (): Map<string, CharacterOutput> => {
+        const r = new Map<string, CharacterOutput>();
+        for (const ch of recordRef.chapterHints) {
+          const cast = chapterCast[ch.id];
+          if (cast?.length) mergeRosterChapter(r, cast);
+        }
+        return r;
+      };
 ```
 
-(in `runMainAnalyzerJob`, inside the cast-detection loop) and replace with:
+Replace the loop body so each chapter's cast is filtered before merge:
 
 ```ts
-        {
-          /* #938 Layer B — drop the byline author from this chapter's roster
-             (unless a framed author's-note) so stage-2 can't attribute the
-             protagonist's dialogue to the real-world author. */
-          const guarded = dropBylineAuthorFromChapter(result.characters, {
-            author: bookAuthor,
-            chapterTitle: ch.title,
-          });
-          chapterCast[ch.id] = guarded.characters;
-          if (guarded.dropped.length > 0) {
-            log(0, `Excluded byline author from cast (${guarded.dropped.join(', ')}) — ${ch.title}.`);
+      const rebuildRoster = (): Map<string, CharacterOutput> => {
+        const r = new Map<string, CharacterOutput>();
+        for (const ch of recordRef.chapterHints) {
+          const cast = chapterCast[ch.id];
+          if (cast?.length) {
+            /* #938 Layer B — keep the byline author out of every roster build
+               (covers cached chapterCast too, unlike guarding only fresh writes).
+               Framed author's-note chapters keep the author. */
+            const guarded = dropBylineAuthorFromChapter(cast, {
+              author: bookAuthor,
+              chapterTitle: ch.title,
+            });
+            mergeRosterChapter(r, guarded.characters);
           }
         }
+        return r;
+      };
 ```
 
-- [ ] **Step 3: Replace the subset-entrypoint assignment (~4546)**
+- [ ] **Step 3: Guard the subset-entrypoint `rebuildRoster` (~4476)**
 
-Find the subset loop's `chapterCast[ch.id] = result.characters;` and apply the same replacement (same code; `bookAuthor`, `ch.title`, `log` are all in scope there — confirm the `log` helper name used in that function).
+Find the subset entrypoint's identical `rebuildRoster` (iterates `record.chapterHints`) and apply the same filter-before-merge change (use that function's record local — `record` — and its in-scope `bookAuthor` from Task 4).
 
-- [ ] **Step 4: Run the route suite + typecheck**
+- [ ] **Step 4: Guard `buildInterimCast` so the on-disk interim cast.json is clean too**
+
+In `buildInterimCast` (signature ~650), add a trailing optional `author` param and filter each chapter's cast inside its merge loop (~657). It has no per-chapter title in scope, so it drops the author unconditionally — acceptable for the transient interim write; the authoritative final cast.json is produced from the title-aware `rebuildRoster` above:
+
+```ts
+export function buildInterimCast(
+  chapterCast: Record<number, CharacterOutput[]>,
+  chapterOrder: number[],
+  language?: string,
+  author = '',
+): CharacterOutput[] {
+```
+
+At its merge loop, change:
+
+```ts
+    const cast = chapterCast[chapterId];
+    if (cast?.length) mergeRosterChapter(roster, cast);
+```
+
+to:
+
+```ts
+    const cast = chapterCast[chapterId];
+    if (cast?.length) {
+      const guarded = dropBylineAuthorFromChapter(cast, { author }); // #938 — no title here (transient interim)
+      mergeRosterChapter(roster, guarded.characters);
+    }
+```
+
+Then pass `bookAuthor` at the two `buildInterimCast(...)` call sites (~2921 full, ~4561 subset) as the new 4th argument:
+
+```ts
+          const interim = buildInterimCast(
+            chapterCast,
+            recordRef.chapterHints.map((h) => h.id),
+            bookLanguage,
+            bookAuthor,
+          );
+```
+
+(Use the matching record/language locals at each call site.)
+
+- [ ] **Step 5: Run the route suite + typecheck**
 
 Run: `cd server && npx vitest run src/routes/analysis.test.ts && cd .. && npm run typecheck`
-Expected: PASS + clean.
+Expected: PASS + clean. (Existing `buildInterimCast` tests still pass — the new param is optional and a book with no author is a no-op.)
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add server/src/routes/analysis.ts
-git commit -m "feat(server): drop byline author from per-chapter roster (#938 Layer B wiring)"
+git commit -m "feat(server): guard byline author out of roster builds incl. cached cast (#938 Layer B wiring)"
 ```
 
 ---
@@ -658,7 +723,7 @@ git commit -m "feat(server): clarify byline-author + first-person rule in detect
 
 - [ ] **Step 1: Write the failing test**
 
-Add a case that drives the analysis route/job with a stub analyzer whose stage-1 returns a roster containing the byline author (with `role: "Protagonist"`) plus the real protagonist, on a book whose `author` is that same name. Assert the final roster/cast contains the protagonist and the narrator but NOT the byline author. Mirror the existing harness in the file (book fixture creation, stub `Analyzer` wiring, how the test reads the resulting `stage1.characters` / cast.json). Skeleton:
+Add a case that drives the analysis route/job with a stub analyzer whose stage-1 returns a roster containing the byline author (with `role: "Protagonist"`) plus the real protagonist, on a book whose `author` is that same name. **Critically, also cover the cached path** — seed `cache.chapterCast` (or run twice so the second run reads the cache) so the test would catch the adversarial-review bug where only fresh chapters were guarded. Assert the final roster/cast contains the protagonist and the narrator but NOT the byline author. Mirror the existing harness in the file (book fixture creation, stub `Analyzer` wiring, how the test reads the resulting `stage1.characters` / cast.json). Skeleton:
 
 ```ts
 it('#938 — excludes the byline author from the final cast on a story chapter', async () => {
@@ -743,4 +808,13 @@ gh pr create --base main --title "fix(server): stop the byline author being cast
 
 **Type consistency:** `dropBylineAuthorFromChapter` / `isFramedAuthorNote` / `stripFrontMatterBoilerplate` / `resolveBookAuthorForManuscript` signatures are identical across their defining task and their call sites. `buildStage1ChapterInbox` gains a trailing optional `author` param (back-compatible with existing callers and tests).
 
-**Known implementation checks called out inline:** confirm `findBookByManuscriptId(...).state.author` field path (Task 3); confirm the subset entrypoint's local names (`record` vs `recordRef`, its `log` helper) (Tasks 4-6); confirm the route-test harness shape (Task 7).
+**Known implementation checks called out inline:** `findBookByManuscriptId(...)` returns BOTH `.author` and `.state` (verified — `server/src/workspace/scan.ts:636`), so `located.state.author` is valid (Task 3); confirm the subset entrypoint's local names (`record` vs `recordRef`) (Tasks 4-6); confirm the route-test harness shape (Task 7).
+
+**Adversarial-review correction (applied):** Layer B was moved from the per-chapter
+`chapterCast[ch.id] = result.characters` write to `rebuildRoster()` (+ `buildInterimCast`)
+so it covers **cached** chapterCast entries, not just freshly-detected ones — otherwise
+the fix silently no-ops on a resume or on an already-analyzed book (the exact case the
+user will test). Verified: `rebuildRoster` (full ~2556, subset ~4476) is the single
+choke point feeding the running roster, final roster (~3044), and live SSE view
+(~2572). `chapterHints.body` is read-only (never persisted), so Layer A's in-place
+strip is safe.

--- a/docs/superpowers/plans/2026-06-20-byline-author-cast-collision.md
+++ b/docs/superpowers/plans/2026-06-20-byline-author-cast-collision.md
@@ -1,0 +1,746 @@
+# Byline Author Cast Collision Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the book's byline author from being cast as a speaking character and stealing the first-person protagonist's dialogue, while preserving legitimate framed author's-note speakers.
+
+**Architecture:** Three layers on the analysis pipeline. **A** strips title-page/byline/e-library boilerplate from each chapter body before the model sees it. **B** drops any detected character whose name equals the book's byline author from the per-chapter roster (unless the chapter is a framed author's-note) — empirically, stage-2 then attributes the protagonist's dialogue to the real protagonist on its own. **C** clarifies the detection prompt (the byline author is not a character; the first-person-document rule is for framed embedded documents, not whole first-person novels).
+
+**Tech Stack:** TypeScript (NodeNext ESM, `.js` import specifiers), Vitest (node env), existing analyzer/route modules under `server/src/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-20-byline-author-cast-collision-design.md` · **Issue:** #938 · **Branch:** `fix/server-byline-author-cast-collision` (already checked out).
+
+## Global Constraints
+
+- **OpenAPI is the type source of truth** — `CharacterOutput` comes from `server/src/handoff/schemas.js`; do not hand-write character shapes.
+- **Pure modules stay pure** — the two new analyzer modules do no I/O, mirroring `fold-minor-cast.ts`.
+- **Name matching uses `normaliseNameKey`** (`server/src/util/safe-id.js`) — Unicode-exact, NO transliteration. Never introduce a lossy transliterated match (false cross-book merges).
+- **Russian strings are user-facing and must stay exact.**
+- **TDD**: every task writes the failing test first, watches it fail, implements minimally, watches it pass, commits.
+- **Test command (frontend+server scope):** server tests run with `cd server && npx vitest run <path>`. Typecheck: `npm run typecheck` from repo root.
+- **Conventional commits**: `<type>(<scope>): <subject>` (e.g. `feat(server): …`, `test(server): …`). End commit bodies with the project's Co-Authored-By / session trailer is handled by the harness — a plain subject is fine for task commits.
+
+---
+
+### Task 1: Layer A — front-matter / boilerplate stripper (pure)
+
+**Files:**
+- Create: `server/src/analyzer/strip-front-matter.ts`
+- Test: `server/src/analyzer/strip-front-matter.test.ts`
+
+**Interfaces:**
+- Consumes: `normaliseNameKey` from `../util/safe-id.js`.
+- Produces: `export function stripFrontMatterBoilerplate(body: string, opts?: { author?: string; title?: string }): string`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/src/analyzer/strip-front-matter.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { stripFrontMatterBoilerplate } from './strip-front-matter.js';
+
+/* The actual Ночной дозор Ch1 head the analyzer saw (abridged but verbatim shapes). */
+const NW_HEAD = [
+  '_###ICE#BOOK#READER#PROFESSIONAL#HEADER#START###_ AUTHOR: Сергей Лукьяненко TITLE: Ночной дозор CODEPAGE: -3 _###ICE#BOOK#READER#PROFESSIONAL#HEADER#FINISH###_',
+  '',
+  'НОЧНОЙ ДОЗОР',
+  '',
+  'Сергей ЛУКЬЯНЕНКО',
+  '',
+  'http://www.bestlibrary.ru',
+  '',
+  'Любое коммерческое использование настоящего текста без ведома и прямого согласия владельца авторских прав НЕ ДОПУСКАЕТСЯ. (С) Сергей Лукьяненко',
+  '',
+  'Данный текст одобрен к распространению как способствующий делу Света. Ночной Дозор.',
+  '',
+  'ИСТОРИЯ ПЕРВАЯ',
+  '',
+  'ПРОЛОГ',
+  '',
+  'Эскалатор полз медленно, натужно. Старая станция, ничего не поделаешь. Зато ветер гулял в бетонной трубе вовсю, трепал волосы.',
+].join('\n');
+
+describe('stripFrontMatterBoilerplate', () => {
+  it('strips the Night Watch title-page block but keeps headings and prose', () => {
+    const out = stripFrontMatterBoilerplate(NW_HEAD, { author: 'Сергей Лукьяненко', title: 'Ночной дозор' });
+    // byline + title echo gone
+    expect(out).not.toMatch(/Сергей ЛУКЬЯНЕНКО/);
+    expect(out).not.toMatch(/НОЧНОЙ ДОЗОР/);
+    // reader header / copyright / url / distribution boilerplate gone
+    expect(out).not.toMatch(/ICE#BOOK#READER/);
+    expect(out).not.toMatch(/AUTHOR:/);
+    expect(out).not.toMatch(/bestlibrary\.ru/);
+    expect(out).not.toMatch(/коммерческое использование/);
+    expect(out).not.toMatch(/одобрен к распространению/);
+    // real structural headings + prose preserved
+    expect(out).toMatch(/ИСТОРИЯ ПЕРВАЯ/);
+    expect(out).toMatch(/ПРОЛОГ/);
+    expect(out).toMatch(/Эскалатор полз медленно/);
+  });
+
+  it('leaves an author-name mention inside ordinary prose intact (conservative boundary)', () => {
+    const body = 'Эскалатор полз медленно, и я вспомнил, что Сергей Лукьяненко однажды написал об этом в длинном абзаце про метро и людей.';
+    const out = stripFrontMatterBoilerplate(body, { author: 'Сергей Лукьяненко', title: 'Ночной дозор' });
+    expect(out).toBe(body);
+  });
+
+  it('is a no-op for an English book with no byline/boilerplate', () => {
+    const body = 'The bell tolled twice over Coalfall. Marlow pulled his collar up and stepped into the rain.';
+    expect(stripFrontMatterBoilerplate(body, { author: 'Castwright', title: 'The Coalfall Commission' })).toBe(body);
+  });
+
+  it('is a no-op when author/title are absent', () => {
+    const body = 'НОЧНОЙ ДОЗОР\n\nСергей ЛУКЬЯНЕНКО\n\nЭскалатор полз медленно, и ветер гулял в трубе вовсю, трепал волосы и капюшон.';
+    // Without author/title we cannot identify the byline; only global boilerplate would be removed (none here).
+    expect(stripFrontMatterBoilerplate(body)).toBe(body);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/analyzer/strip-front-matter.test.ts`
+Expected: FAIL — "Cannot find module './strip-front-matter.js'".
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `server/src/analyzer/strip-front-matter.ts`:
+
+```ts
+/* Layer A (#938) — strip title-page byline + e-library boilerplate from a chapter
+   body before the analyzer sees it, so the byline author never reaches stage-1/2.
+   Pure; applied in-memory to the analysis copy of the body (never persisted).
+
+   Two removal classes:
+     - Always-safe global patterns (reader-tool headers, copyright/distribution
+       notices, bare URLs) — ordinary prose never contains these, so drop anywhere.
+     - Leading-region byline/title echo — a standalone line equal (normalized) to
+       the book author or title, removed only before substantial narrative prose
+       begins, so a story that *mentions* the author mid-prose is untouched. */
+import { normaliseNameKey } from '../util/safe-id.js';
+
+const GLOBAL_BOILERPLATE: RegExp[] = [
+  /_###ICE#BOOK#READER/i, // reader-tool header marker (whole line is the header)
+  /^\s*(AUTHOR|TITLE|CODEPAGE)\s*:/i, // reader header fields on their own line
+  /коммерческое использование/i, // e-library usage notice
+  /одобрен к распространению/i, // e-library distribution notice
+  /^\s*\((С|C)\)\s/i, // "(С) <author>" copyright line
+  /^\s*https?:\/\/\S+\s*$/i, // bare URL line
+];
+
+function isGlobalBoilerplate(line: string): boolean {
+  return GLOBAL_BOILERPLATE.some((re) => re.test(line));
+}
+
+/* A line that reads as narrative prose: reasonably long, contains sentence
+   punctuation AND a lowercase letter. All-caps headings ("ПРОЛОГ", "ИСТОРИЯ
+   ПЕРВАЯ") and bare bylines are short / have no lowercase → not narrative. */
+function isNarrativeLine(line: string): boolean {
+  if (line.length < 60) return false;
+  return /[.!?…]/.test(line) && /\p{Ll}/u.test(line);
+}
+
+export function stripFrontMatterBoilerplate(
+  body: string,
+  opts: { author?: string; title?: string } = {},
+): string {
+  const authorKey = normaliseNameKey(opts.author);
+  const titleKey = normaliseNameKey(opts.title);
+  const lines = body.split(/\r?\n/);
+  const out: string[] = [];
+  let inFrontMatter = true;
+  let changed = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Global boilerplate: drop anywhere, without ending the front-matter region.
+    if (trimmed && isGlobalBoilerplate(trimmed)) {
+      changed = true;
+      continue;
+    }
+
+    if (inFrontMatter && trimmed) {
+      const key = normaliseNameKey(trimmed);
+      if (key && (key === authorKey || key === titleKey)) {
+        changed = true;
+        continue; // standalone byline / title echo
+      }
+      if (isNarrativeLine(trimmed)) inFrontMatter = false;
+    }
+
+    out.push(line);
+  }
+
+  return changed ? out.join('\n') : body;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/analyzer/strip-front-matter.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/analyzer/strip-front-matter.ts server/src/analyzer/strip-front-matter.test.ts
+git commit -m "feat(server): add front-matter/boilerplate stripper for analysis (#938 Layer A)"
+```
+
+---
+
+### Task 2: Layer B — byline-author roster guard (pure)
+
+**Files:**
+- Create: `server/src/analyzer/byline-author-guard.ts`
+- Test: `server/src/analyzer/byline-author-guard.test.ts`
+
+**Interfaces:**
+- Consumes: `CharacterOutput` from `../handoff/schemas.js`; `normaliseNameKey` from `../util/safe-id.js`.
+- Produces:
+  - `export function isFramedAuthorNote(chapterTitle: string | undefined): boolean`
+  - `export function dropBylineAuthorFromChapter(characters: CharacterOutput[], opts: { author?: string; chapterTitle?: string }): { characters: CharacterOutput[]; dropped: string[] }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/src/analyzer/byline-author-guard.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { dropBylineAuthorFromChapter, isFramedAuthorNote } from './byline-author-guard.js';
+import type { CharacterOutput } from '../handoff/schemas.js';
+
+function ch(id: string, name: string, role = 'role'): CharacterOutput {
+  return { id, name, role, color: 'slot-4' };
+}
+
+const ROSTER: CharacterOutput[] = [
+  ch('narrator', 'Narrator', 'Third-person observer'),
+  ch('sergey-lukyanenko', 'Сергей Лукьяненко', 'Protagonist / Investigator'),
+  ch('anton', 'Антон', 'Оперативник'),
+  ch('anton-gorodetsky', 'Антон Городецкий', 'Иной'),
+];
+
+describe('isFramedAuthorNote', () => {
+  it('matches author-note chapter titles (bilingual), not story chapters', () => {
+    expect(isFramedAuthorNote("Author's Note")).toBe(true);
+    expect(isFramedAuthorNote('Notes from the Author')).toBe(true);
+    expect(isFramedAuthorNote('От автора')).toBe(true);
+    expect(isFramedAuthorNote('Послесловие автора')).toBe(true);
+    expect(isFramedAuthorNote('Chapter 1')).toBe(false);
+    expect(isFramedAuthorNote('ПРОЛОГ')).toBe(false);
+    expect(isFramedAuthorNote(undefined)).toBe(false);
+  });
+});
+
+describe('dropBylineAuthorFromChapter', () => {
+  it('drops the byline author by name-match (case/inflection-tolerant) from a story chapter', () => {
+    const r = dropBylineAuthorFromChapter(ROSTER, { author: 'Сергей Лукьяненко', chapterTitle: 'Chapter 1' });
+    expect(r.dropped).toEqual(['Сергей Лукьяненко']);
+    expect(r.characters.map((c) => c.id)).toEqual(['narrator', 'anton', 'anton-gorodetsky']);
+  });
+
+  it('matches an uppercased byline form too', () => {
+    const roster = [ch('a', 'Сергей ЛУКЬЯНЕНКО', 'Protagonist'), ch('anton', 'Антон')];
+    const r = dropBylineAuthorFromChapter(roster, { author: 'Сергей Лукьяненко', chapterTitle: 'Глава 2' });
+    expect(r.characters.map((c) => c.id)).toEqual(['anton']);
+  });
+
+  it('KEEPS the author in a framed author-note chapter (legit case)', () => {
+    const r = dropBylineAuthorFromChapter(ROSTER, { author: 'Сергей Лукьяненко', chapterTitle: 'От автора' });
+    expect(r.dropped).toEqual([]);
+    expect(r.characters).toBe(ROSTER); // referential identity preserved on no-op
+  });
+
+  it('never drops narrator and is a no-op when the author is absent or unset', () => {
+    expect(dropBylineAuthorFromChapter(ROSTER, { author: '', chapterTitle: 'Chapter 1' }).characters).toBe(ROSTER);
+    const noAuthorOnRoster = [ch('narrator', 'Narrator'), ch('anton', 'Антон')];
+    const r = dropBylineAuthorFromChapter(noAuthorOnRoster, { author: 'Сергей Лукьяненко', chapterTitle: 'Chapter 1' });
+    expect(r.characters).toBe(noAuthorOnRoster);
+    expect(r.dropped).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/analyzer/byline-author-guard.test.ts`
+Expected: FAIL — "Cannot find module './byline-author-guard.js'".
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `server/src/analyzer/byline-author-guard.ts`:
+
+```ts
+/* Layer B (#938) — drop the book's byline author from a chapter's detected roster
+   before stage-2 attribution. Empirically (gemma4-e4b, Ночной дозор Ch1): once the
+   "Protagonist"-roled author entity is gone, stage-2 attributes the protagonist's
+   dialogue to the real protagonist on its own — no reclamation/anchor needed.
+
+   The legit author-as-character case (a framed author's-note where the author
+   genuinely speaks) is preserved by exempting chapters whose title marks an
+   author's-note. Pure; mirrors fold-minor-cast.ts. */
+import type { CharacterOutput } from '../handoff/schemas.js';
+import { normaliseNameKey } from '../util/safe-id.js';
+
+const NARRATOR_ID = 'narrator';
+
+/* Bilingual author's-note chapter-title patterns. Start small; extend on real
+   corpus data (same discipline as GENERIC_ROLE_RU). */
+const AUTHOR_NOTE_TITLE_RX =
+  /author'?s?\s+note|notes?\s+from\s+the\s+author|от\s+автора|предислови|послеслови|об\s+авторе/i;
+
+export function isFramedAuthorNote(chapterTitle: string | undefined): boolean {
+  if (!chapterTitle) return false;
+  return AUTHOR_NOTE_TITLE_RX.test(chapterTitle);
+}
+
+export function dropBylineAuthorFromChapter(
+  characters: CharacterOutput[],
+  opts: { author?: string; chapterTitle?: string },
+): { characters: CharacterOutput[]; dropped: string[] } {
+  const authorKey = normaliseNameKey(opts.author);
+  if (!authorKey) return { characters, dropped: [] };
+  if (isFramedAuthorNote(opts.chapterTitle)) return { characters, dropped: [] };
+
+  const dropped: string[] = [];
+  const kept = characters.filter((c) => {
+    if (c.id === NARRATOR_ID) return true;
+    if (normaliseNameKey(c.name) === authorKey) {
+      dropped.push(c.name);
+      return false;
+    }
+    return true;
+  });
+  if (dropped.length === 0) return { characters, dropped: [] }; // preserve identity on no-op
+  return { characters: kept, dropped };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/analyzer/byline-author-guard.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/analyzer/byline-author-guard.ts server/src/analyzer/byline-author-guard.test.ts
+git commit -m "feat(server): add byline-author roster guard (#938 Layer B)"
+```
+
+---
+
+### Task 3: Plumbing — resolve the book's byline author in the analysis route
+
+**Files:**
+- Modify: `server/src/routes/analysis.ts` (add `resolveBookAuthorForManuscript` next to `resolveBookLanguageForManuscript` at ~2118)
+- Test: `server/src/routes/analysis.test.ts` (add a focused unit test)
+
+**Interfaces:**
+- Consumes: `findBookByManuscriptId` (already imported in analysis.ts).
+- Produces: `export async function resolveBookAuthorForManuscript(manuscriptId: string): Promise<string>`
+
+- [ ] **Step 1: Write the failing test**
+
+In `server/src/routes/analysis.test.ts`, add (place near other `resolveBookLanguageForManuscript`-style tests; import the new symbol from the route module):
+
+```ts
+import { resolveBookAuthorForManuscript } from './analysis.js';
+
+describe('resolveBookAuthorForManuscript', () => {
+  it('returns "" for an unknown manuscript (no throw)', async () => {
+    await expect(resolveBookAuthorForManuscript('mns_does_not_exist')).resolves.toBe('');
+  });
+});
+```
+
+> Note: this asserts the safe fallback path (mirrors how `resolveBookLanguageForManuscript` returns `'en'` on miss). The happy path is covered by the integration test in Task 7.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/routes/analysis.test.ts -t resolveBookAuthorForManuscript`
+Expected: FAIL — `resolveBookAuthorForManuscript is not a function` / import error.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `server/src/routes/analysis.ts`, immediately after `resolveBookLanguageForManuscript` (ends ~line 2125), add:
+
+```ts
+/* #938 — the book's byline author (cover/byline name), for the Layer A front-matter
+   strip + the Layer B roster guard. Mirrors resolveBookLanguageForManuscript's
+   fail-open shape: "" on any miss so the guard/strip degrade to no-ops. */
+export async function resolveBookAuthorForManuscript(manuscriptId: string): Promise<string> {
+  try {
+    const located = await findBookByManuscriptId(manuscriptId);
+    return located?.state?.author ?? '';
+  } catch {
+    return '';
+  }
+}
+```
+
+> If `located.state` is not the shape (verify against the `findBookByManuscriptId` return type — `resolveBookLanguageForManuscript` reads `located.state`), adjust to the field that carries `author: string` from `BookStateJson`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/routes/analysis.test.ts -t resolveBookAuthorForManuscript`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/analysis.ts server/src/routes/analysis.test.ts
+git commit -m "feat(server): resolve book byline author for analysis (#938 plumbing)"
+```
+
+---
+
+### Task 4: Wire Layer A — strip chapter bodies at job start (both entrypoints)
+
+**Files:**
+- Modify: `server/src/routes/analysis.ts` — `runMainAnalyzerJob` (~2136, after `bookLanguage`) and the subset entrypoint (~4355, after its `bookLanguage`).
+
+**Interfaces:**
+- Consumes: `stripFrontMatterBoilerplate` (Task 1), `resolveBookAuthorForManuscript` (Task 3).
+- Produces: in-memory stripped `recordRef.chapterHints[*].body` consumed by every downstream stage-1/stage-2 builder.
+
+- [ ] **Step 1: Add the import and the strip loop (no new test file — covered by Task 7 integration; verified here by the existing suite staying green)**
+
+At the top of `server/src/routes/analysis.ts`, add to the analyzer imports:
+
+```ts
+import { stripFrontMatterBoilerplate } from '../analyzer/strip-front-matter.js';
+```
+
+In `runMainAnalyzerJob`, immediately after:
+
+```ts
+  const bookLanguage = await resolveBookLanguageForManuscript(manuscriptId);
+```
+
+insert:
+
+```ts
+  /* #938 Layer A — resolve the byline author + strip title-page/e-library
+     boilerplate from each chapter body BEFORE the model sees it. In-memory only
+     (the hydrated analysis copy), never persisted; idempotent so a re-run is safe. */
+  const bookAuthor = await resolveBookAuthorForManuscript(manuscriptId);
+  for (const ch of recordRef.chapterHints) {
+    ch.body = stripFrontMatterBoilerplate(ch.body, { author: bookAuthor, title: recordRef.title });
+  }
+```
+
+In the subset entrypoint (the function starting ~4340 with its own `const bookLanguage = await resolveBookLanguageForManuscript(manuscriptId);` at ~4355), insert the analogous block right after that line, using that function's record variable name (it uses `record`, not `recordRef` — confirm the local name and `record.title` / `record.chapterHints`):
+
+```ts
+  const bookAuthor = await resolveBookAuthorForManuscript(manuscriptId);
+  for (const ch of record.chapterHints) {
+    ch.body = stripFrontMatterBoilerplate(ch.body, { author: bookAuthor, title: record.title });
+  }
+```
+
+> `bookAuthor` is now in scope for Tasks 5 and 6 in BOTH entrypoints — keep these declarations.
+
+- [ ] **Step 2: Run the route suite to verify nothing regressed**
+
+Run: `cd server && npx vitest run src/routes/analysis.test.ts`
+Expected: PASS (existing tests green; ETA/length assertions tolerate the small body trim, which only affects chapter 1's leading boilerplate).
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: clean (confirms `recordRef.chapterHints[*].body` and `record.title` are mutable/readable as used).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/src/routes/analysis.ts
+git commit -m "feat(server): strip front-matter from chapter bodies at analysis start (#938 Layer A wiring)"
+```
+
+---
+
+### Task 5: Wire Layer B — drop the byline author at per-chapter roster capture (both entrypoints)
+
+**Files:**
+- Modify: `server/src/routes/analysis.ts` — the two `chapterCast[ch.id] = result.characters;` assignments (~2880 full, ~4546 subset).
+- Test: `server/src/routes/analysis.test.ts` (integration in Task 7; this task verified by suite + typecheck).
+
+**Interfaces:**
+- Consumes: `dropBylineAuthorFromChapter` (Task 2), `bookAuthor` (Task 4 — in scope in both entrypoints), `ch.title` (chapter hint), `log`.
+
+- [ ] **Step 1: Add the import**
+
+At the top of `server/src/routes/analysis.ts`, add:
+
+```ts
+import { dropBylineAuthorFromChapter } from '../analyzer/byline-author-guard.js';
+```
+
+- [ ] **Step 2: Replace the full-entrypoint assignment (~2880)**
+
+Find:
+
+```ts
+        chapterCast[ch.id] = result.characters;
+```
+
+(in `runMainAnalyzerJob`, inside the cast-detection loop) and replace with:
+
+```ts
+        {
+          /* #938 Layer B — drop the byline author from this chapter's roster
+             (unless a framed author's-note) so stage-2 can't attribute the
+             protagonist's dialogue to the real-world author. */
+          const guarded = dropBylineAuthorFromChapter(result.characters, {
+            author: bookAuthor,
+            chapterTitle: ch.title,
+          });
+          chapterCast[ch.id] = guarded.characters;
+          if (guarded.dropped.length > 0) {
+            log(0, `Excluded byline author from cast (${guarded.dropped.join(', ')}) — ${ch.title}.`);
+          }
+        }
+```
+
+- [ ] **Step 3: Replace the subset-entrypoint assignment (~4546)**
+
+Find the subset loop's `chapterCast[ch.id] = result.characters;` and apply the same replacement (same code; `bookAuthor`, `ch.title`, `log` are all in scope there — confirm the `log` helper name used in that function).
+
+- [ ] **Step 4: Run the route suite + typecheck**
+
+Run: `cd server && npx vitest run src/routes/analysis.test.ts && cd .. && npm run typecheck`
+Expected: PASS + clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/analysis.ts
+git commit -m "feat(server): drop byline author from per-chapter roster (#938 Layer B wiring)"
+```
+
+---
+
+### Task 6: Layer C — prompt clarification (inbox builder + skill file)
+
+**Files:**
+- Modify: `server/src/routes/analysis.ts` — `buildStage1ChapterInbox` (~1242): add an `author` param, render a "book author is not a character" block, and narrow the first-person-document rule.
+- Modify: `skills/audiobook-character-detection-per-chapter.md` — mirror the narrowed first-person-document rule.
+- Test: `server/src/routes/analysis.test.ts` (buildStage1ChapterInbox renders the guidance).
+
+**Interfaces:**
+- Consumes: `bookAuthor` (Task 4) at the `buildStage1ChapterInbox` call sites (~2757 and the subset ~4517).
+- Produces: `buildStage1ChapterInbox(manuscriptId, title, chapter, runningRoster, seriesPrior, author?)` — new trailing optional `author` param (keeps existing callers/tests compiling).
+
+- [ ] **Step 1: Write the failing test**
+
+In `server/src/routes/analysis.test.ts`, add:
+
+```ts
+import { buildStage1ChapterInbox } from './analysis.js';
+
+describe('buildStage1ChapterInbox — #938 byline-author guidance', () => {
+  const chapter = { id: 1, title: 'Chapter 1', body: 'Эскалатор полз медленно.' };
+
+  it('renders a "book author is not a character" block when an author is provided', () => {
+    const md = buildStage1ChapterInbox('m1', 'Ночной дозор', chapter, [], [], 'Сергей Лукьяненко');
+    expect(md).toMatch(/Сергей Лукьяненко/);
+    expect(md).toMatch(/not a character/i);
+  });
+
+  it('omits the block when no author is provided (back-compat)', () => {
+    const md = buildStage1ChapterInbox('m1', 'Ночной дозор', chapter, [], []);
+    expect(md).not.toMatch(/not a character/i);
+  });
+
+  it('narrows the first-person-document rule to framed embedded documents', () => {
+    const md = buildStage1ChapterInbox('m1', 'X', chapter, [], [], 'Author');
+    expect(md).toMatch(/first-person novel is NOT/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/routes/analysis.test.ts -t "byline-author guidance"`
+Expected: FAIL — author param ignored / strings absent.
+
+- [ ] **Step 3: Implement — add the param and prompt text**
+
+In `buildStage1ChapterInbox` (signature ~1242), add a trailing optional param:
+
+```ts
+export function buildStage1ChapterInbox(
+  manuscriptId: string,
+  title: string,
+  chapter: { id: number; title: string; body: string },
+  runningRoster: CharacterOutput[],
+  seriesPrior: SeriesPriorCharacter[] = [],
+  author = '',
+): string {
+```
+
+Build an author block before the final `return` (near where `priorBlock` is built, ~1294):
+
+```ts
+  /* #938 — the book's byline author is NOT a character. Rendered only when known. */
+  const authorBlock = author.trim()
+    ? `
+## Book author — NOT a character
+
+The byline author of this book is **${author.trim()}**. This is the real-world author printed on the cover — they are NOT a character in the story. Do NOT add them to the roster, and never assign the narrator's prose or the protagonist's first-person lines to them — UNLESS this chapter is an explicitly-framed author's note/letter in which the author speaks in the first person about the book.
+`
+    : '';
+```
+
+Insert `${authorBlock}` into the returned template — put it immediately after the `${priorBlock}` interpolation.
+
+Then narrow the inline first-person-document rule. Find the rule text in the template (the "first-person document" clause, ~1313-1320, starting `2. The chapter is a **first-person document**`) and append this sentence to that clause:
+
+```
+   A whole **first-person novel is NOT** such a document — its first-person
+   voice is the protagonist/narrator, NOT the book's author; never roster the
+   byline author as that voice.
+```
+
+- [ ] **Step 4: Update the skill file (parity)**
+
+In `skills/audiobook-character-detection-per-chapter.md`, find the "First-person prose by an identifiable author" rule (~line 71) and append the same clarification:
+
+```
+   A whole first-person **novel** is NOT such a document — its first-person voice
+   is the protagonist/narrator, not the book's author. Never roster the book's
+   byline author as a character unless they explicitly act or speak in the story
+   (e.g. a clearly-framed author's note).
+```
+
+- [ ] **Step 5: Thread `bookAuthor` into the call sites**
+
+At the `buildStage1ChapterInbox(...)` call in `runMainAnalyzerJob` (~2757) add `bookAuthor` as the final argument:
+
+```ts
+                    buildStage1ChapterInbox(
+                      manuscriptId,
+                      recordRef.title,
+                      { ...ch, body: subBody },
+                      Array.from(rebuildRoster().values()),
+                      seriesPrior,
+                      bookAuthor,
+                    ),
+```
+
+Do the same at the subset entrypoint's `buildStage1ChapterInbox(...)` call (~4517), using that function's record/author locals.
+
+- [ ] **Step 6: Run tests + typecheck**
+
+Run: `cd server && npx vitest run src/routes/analysis.test.ts && cd .. && npm run typecheck`
+Expected: PASS + clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/routes/analysis.ts skills/audiobook-character-detection-per-chapter.md server/src/routes/analysis.test.ts
+git commit -m "feat(server): clarify byline-author + first-person rule in detection prompt (#938 Layer C)"
+```
+
+---
+
+### Task 7: Integration regression — full cast excludes the byline author
+
+**Files:**
+- Test: `server/src/routes/analysis.test.ts` (add a route-level case using the existing stub-analyzer harness).
+
+**Interfaces:**
+- Consumes: the existing analysis-route test harness (stub `Analyzer`, in-memory book). Match the established pattern already used in `analysis.test.ts` for driving `runMainAnalyzerJob` / the analyse route with a stub analyzer.
+
+- [ ] **Step 1: Write the failing test**
+
+Add a case that drives the analysis route/job with a stub analyzer whose stage-1 returns a roster containing the byline author (with `role: "Protagonist"`) plus the real protagonist, on a book whose `author` is that same name. Assert the final roster/cast contains the protagonist and the narrator but NOT the byline author. Mirror the existing harness in the file (book fixture creation, stub `Analyzer` wiring, how the test reads the resulting `stage1.characters` / cast.json). Skeleton:
+
+```ts
+it('#938 — excludes the byline author from the final cast on a story chapter', async () => {
+  // Arrange: in-memory book with author "Сергей Лукьяненко"; stub analyzer returns
+  // stage-1 roster [narrator, sergey-lukyanenko(Protagonist), anton] for the chapter.
+  // (Use the same fixture/harness helpers the other route tests in this file use.)
+  // Act: run the analysis job to completion.
+  // Assert:
+  //   finalRoster.map(c => c.id) includes 'anton' and 'narrator'
+  //   finalRoster.find(c => normaliseNameKey(c.name) === normaliseNameKey('Сергей Лукьяненко')) is undefined
+});
+```
+
+> Implementer: wire this to the file's existing harness rather than inventing a new one. If the harness only exposes the pure pieces, assert on the result of `dropBylineAuthorFromChapter` applied across `chapterCast` + `mergeRosterChapter` (the exact wiring Tasks 5 added), which still constitutes an integration check across Layer B + the roster merge.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/routes/analysis.test.ts -t "excludes the byline author"`
+Expected: FAIL before wiring is exercised / passes only with Tasks 1-6 in place — if it passes immediately, strengthen it so it would fail with the guard removed (temporarily comment the guard to confirm red, then restore).
+
+- [ ] **Step 3: Confirm it passes with the implementation**
+
+Run: `cd server && npx vitest run src/routes/analysis.test.ts -t "excludes the byline author"`
+Expected: PASS.
+
+- [ ] **Step 4: Full server suite + typecheck**
+
+Run: `cd server && npx vitest run && cd .. && npm run typecheck`
+Expected: PASS + clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/analysis.test.ts
+git commit -m "test(server): integration regression for byline-author exclusion (#938)"
+```
+
+---
+
+### Task 8: Spec ship-notes + verify
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-20-byline-author-cast-collision-design.md` (add a short "Shipped" note: date + commit range).
+- Modify: `docs/features/221-multilingual-attribution-gemma-and-cast-merge.md` (one line referencing #938 fix, if it still mentions the author-takeover as open).
+
+- [ ] **Step 1: Run the full verify battery**
+
+Run: `npm run verify`
+Expected: typecheck + all tests + e2e + build green.
+
+- [ ] **Step 2: Add ship notes to the spec**
+
+Append a `## Shipped` section to the spec with the date (2026-06-20) and the commit SHAs from Tasks 1-7.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-06-20-byline-author-cast-collision-design.md docs/features/221-multilingual-attribution-gemma-and-cast-merge.md
+git commit -m "docs(docs): ship notes for #938 byline-author cast collision"
+```
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git push -u origin fix/server-byline-author-cast-collision
+gh pr create --base main --title "fix(server): stop the byline author being cast as the protagonist (#938)" --body "Closes #938. Three layers (front-matter strip + byline-author roster guard + prompt clarification). Empirically validated on Ночной дозор: removing the byline author from the roster makes stage-2 attribute the protagonist's dialogue to anton. See docs/superpowers/specs/2026-06-20-byline-author-cast-collision-design.md."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Layer A (front-matter strip) → Tasks 1, 4. ✓
+- Layer B (per-chapter roster guard, framed-note exemption) → Tasks 2, 5. ✓
+- Layer C (prompt clarification + skill parity) → Task 6. ✓
+- Shared plumbing (resolve book author) → Task 3. ✓
+- Testing (pure unit per layer + integration regression) → Tasks 1, 2, 6, 7. ✓
+- Non-goals (Anton dedup, world-knowledge denylist) → not implemented, by design. ✓
+
+**Placeholder scan:** Task 7's test is a guided skeleton (the route-test harness shape is file-specific and must be read at implementation time) — flagged explicitly with the fallback assertion path, not a silent TODO. All code-bearing steps show complete code.
+
+**Type consistency:** `dropBylineAuthorFromChapter` / `isFramedAuthorNote` / `stripFrontMatterBoilerplate` / `resolveBookAuthorForManuscript` signatures are identical across their defining task and their call sites. `buildStage1ChapterInbox` gains a trailing optional `author` param (back-compatible with existing callers and tests).
+
+**Known implementation checks called out inline:** confirm `findBookByManuscriptId(...).state.author` field path (Task 3); confirm the subset entrypoint's local names (`record` vs `recordRef`, its `log` helper) (Tasks 4-6); confirm the route-test harness shape (Task 7).

--- a/docs/superpowers/specs/2026-06-20-byline-author-cast-collision-design.md
+++ b/docs/superpowers/specs/2026-06-20-byline-author-cast-collision-design.md
@@ -1,0 +1,230 @@
+# Byline author cast collision — design
+
+**Issue:** #938 · **Date:** 2026-06-20 · **Status:** design (approved, pre-plan)
+**Area:** server (analyzer) · **Relates to:** plan 221 (multilingual attribution), #935
+
+## Problem
+
+On a first-person novel whose manuscript carries a title-page byline, the analyzer
+rosters the **book's real-world author as a speaking character** and routes the
+**first-person protagonist's narration and dialogue to that author entity** — the
+author "eats" the hero's lines.
+
+Reproduced on real data — *Ночной дозор* (Sergei Lukyanenko / Night Watch),
+`C:\AudiobookWorkspace\books\Сергей Лукьяненко\…\Ночной дозор`:
+
+- The detected cast (`.audiobook/cast.json`) contains
+  `sergey-lukyanenko | Сергей Лукьяненко` with **`role: "Protagonist / Investigator"`** —
+  the model literally cast the byline author as the hero.
+- The book's true protagonist Anton appears separately (and, incidentally, split
+  across `anton` / `anton-gorodetsky`).
+
+### Root cause (two independent layers, both evidence-backed)
+
+1. **Front matter is not stripped.** The opening content document the analyzer
+   read (`temp_calibre_txt_input_to_html_split_000.html`) is a title-page /
+   boilerplate block in the prose: `НОЧНОЙ ДОЗОР`, the byline `Сергей ЛУКЬЯНЕНКО`,
+   an `_###ICE#BOOK#READER…###_ … AUTHOR: Сергей Лукьяненко TITLE: Ночной дозор`
+   header, `(С) Сергей Лукьяненко` copyright, and `bestlibrary.ru` URLs. The
+   EPUB `dc:creator` is `Сергей Лукьяненко`, matching the byline — so the author
+   name is **literally in the text the model saw**.
+
+2. **The "first-person document author" rule misfires.** The cast-detection
+   prompt (inline in `buildStage1ChapterInbox`, `server/src/routes/analysis.ts:1313-1320`,
+   mirrored in `skills/audiobook-character-detection-per-chapter.md`) says: *a
+   first-person document whose author is named → the author is the character, not
+   narrator.* That rule is meant for **in-fiction** documents (a diary, a letter,
+   a registry file). *Ночной дозор* is a first-person **novel** ("Давным-давно **я**
+   научился…"; Anton speaks as "— Не совсем, — **сказал я**"), and the byline is the
+   "named author" in view — so the model assigns Anton's first-person voice to
+   Сергей Лукьяненко.
+
+## Goals / non-goals
+
+**Goals**
+- The book's byline author is **not** cast as a speaking character in normal story prose.
+- The first-person protagonist **keeps** their narration and dialogue — reclaimed
+  lines go to the protagonist, **not** dumped on narrator.
+- The **legitimate** author-as-character case is preserved: a genuine, explicitly
+  **framed** author's-note / in-fiction document still rosters its author (e.g.
+  Unraveled's author's-note chapters; Oduvan's journal, Marlow's diary).
+
+**Non-goals**
+- General `anton` ↔ `anton-gorodetsky` cross-id de-duplication (plan 221 Wave C —
+  deliberately a manual merge at cast review; risky to automate).
+- A world-knowledge denylist for an author **not** present in the text. Layers A+C
+  make that case unlikely and Layer B still catches it whenever the invented name
+  matches book metadata, but we do not add a generic "famous author" filter.
+
+## Design overview
+
+Three layers, deterministic where it matters. Layer A removes the source so the
+problem rarely arises; Layer B is the deterministic safety net that reclaims lines
+for the protagonist; Layer C is a cheap prompt nudge that reduces how often B fires.
+
+All three need the same **shared plumbing**: thread the book's `author` (and
+`title`, `language`) — already stored in `state.json` / the analysis `record` — into
+the body-prep path (A), the per-chapter attribution flow (B), and
+`buildStage1ChapterInbox` (C). No new persisted state.
+
+---
+
+### Layer A — front-matter / boilerplate stripping (deterministic source fix)
+
+New pure module `server/src/analyzer/strip-front-matter.ts`:
+
+```ts
+stripFrontMatterBoilerplate(body: string, opts: { author?: string; title?: string }): string
+```
+
+Applied to each chapter body **before** it enters stage-1 detection and stage-2
+attribution, so the author name never reaches the model. It removes:
+
+- **Always-safe global patterns** (anywhere in the body — ordinary prose never
+  contains these): `_###ICE#BOOK#READER…###_` markers; `AUTHOR:` / `TITLE:` /
+  `CODEPAGE:` reader-header fields; e-library distribution boilerplate
+  ("Любое коммерческое использование…", "одобрен к распространению…"); bare
+  library URLs; `(С)` / `(C)` copyright lines.
+- **Byline / title echo — leading region only**: a *standalone short line* equal
+  (normalized, case-insensitive — handles `Сергей ЛУКЬЯНЕНКО` ≈ `Сергей Лукьяненко`)
+  to the book `author` or `title`, but only within the head block of the first
+  chapter, before substantial narrative prose has begun.
+
+**Conservative by construction:** the author/title-line removal is gated to a
+leading non-narrative block, so a story that *mentions* the author mid-prose is
+untouched. The global patterns are specific enough to be safe everywhere.
+
+Applied at **analysis time** (the stored manuscript is left intact), so re-analysis
+picks up improvements and the user's source file is never rewritten.
+
+---
+
+### Layer B — incremental per-chapter realignment with an early protagonist anchor
+
+The byline-author guard runs **inside the existing per-chapter flow**, not as a
+single end-of-run pass. Anchoring the protagonist from Chapter 1 — where the real
+protagonist is established and dominant — makes the realignment target robust and
+avoids guessing from end-of-book totals the author has already skewed.
+
+New pure module `server/src/analyzer/byline-author-guard.ts` (exact shape settled in
+the plan), driven by the analysis route across chapters:
+
+1. **Stage-1 (per chapter) — flag the byline author.** When a detected character's
+   name matches the book `author` (normalized via `normaliseNameKey`), flag it as
+   the byline-author entity and **ignore the model-assigned role** (e.g. the bogus
+   `"Protagonist"`).
+
+2. **Protagonist anchor (sticky, established early).** Maintain a running anchor =
+   the dominant **non-author, non-narrator** speaker accumulated so far. The real
+   protagonist appears and dominates from Chapter 1, so the anchor locks on early
+   (Anton via his dialogue) and **stays sticky** — a chatty side-character in a
+   later chapter cannot steal it.
+
+3. **Stage-2 (per chapter, as each chapter is attributed) — reclaim lines.** Any
+   sentence attributed to the byline-author entity is **reassigned to the current
+   anchor right then**. Cheap, incremental, self-correcting as the book flows.
+   - **Reassignment target = the anchor (the protagonist). No confidence/margin
+     gate** — that gate is what would force the bad narrator fallback. With two
+     Anton rows the larger one wins; the protagonist keeps their voice.
+   - **Narrator is a last resort only** when a book genuinely has no other speaker
+     (degenerate; never true for a novel).
+
+4. **Author-only-prologue edge.** If an early chapter is a prologue spoken only by
+   the first-person voice and no other named speaker has appeared yet, there is no
+   anchor at that instant. **Hold** those byline-author sentences and retroactively
+   reassign them once the anchor establishes (almost always within Ch 1–2) — the
+   protagonist still reclaims the prologue rather than losing it to narrator.
+
+5. **Framed author's-note exemption (preserves the legit case).** If the byline
+   author's lines fall inside an explicitly **framed** author's-note / in-fiction
+   document section — detected by chapter title matching author-note patterns
+   (`Author's Note`, `Notes from the author`, `От автора`,
+   `Предисловие/Послесловие автора`, …; a small, extensible bilingual set) — those
+   lines are **kept** on the author entity (legitimate author-as-speaker). Only
+   non-framed (story) lines are reclaimed.
+
+6. **End state.** The byline-author entity has no story lines left → dropped from
+   the roster (removing the bogus `role: "Protagonist"` ghost). The protagonist
+   carries the reclaimed narration + dialogue. A summary line is emitted for the
+   analysing-view log (e.g. *"Byline author 'Сергей Лукьяненко' removed; N lines
+   reassigned → Антон"*).
+
+**Stated limitation.** "Dominant non-author speaker = protagonist" is a heuristic.
+In a rare book whose most-talkative character is not the POV protagonist, reclaimed
+lines land on that major character instead — still a named voice, recoverable by
+manual re-cast, and strictly better than narrator per the chosen preference. The
+residual two-Anton split for the protagonist's *own* originally-correct lines stays
+a manual merge (Wave C); this fix only guarantees the reclaimed lines land on a real
+protagonist, never narrator.
+
+---
+
+### Layer C — prompt clarification (soft; reduces how often B must fire)
+
+In `buildStage1ChapterInbox` (`analysis.ts`) **and** the skill file
+`skills/audiobook-character-detection-per-chapter.md` (kept in sync — both carry the
+rule today):
+
+- **Pass the byline author into the prompt** and state: the book's listed author is
+  **not** a character unless they explicitly act or speak *in the story*; never
+  assign them the narrator's or protagonist's first-person lines.
+- **Narrow the first-person-document rule** to **clearly-framed embedded documents**
+  (explicit header / signature / title — a journal, letter, registry file). Add: a
+  whole first-person **novel** is not such a document; its first-person voice is the
+  protagonist/narrator, not the book's author.
+
+Soft by nature (the local `gemma4-e4b` follows prompt nudges unreliably — prior alias
+nudges hit ~0% compliance), so it is the cheap top layer; A and B are the
+deterministic guarantees beneath it.
+
+## Data flow
+
+```
+parse (epub) → chapters + book meta { author, title, language }
+   │
+   ├─ Layer A: stripFrontMatterBoilerplate(body, {author,title})  ← per chapter, pre-model
+   │
+stage-1 cast detection (per chapter)
+   ├─ Layer C: byline author rendered into the inbox prompt
+   └─ Layer B(1): flag byline-author entity by name==author
+   │
+stage-2 attribution (per chapter)
+   └─ Layer B(2,3,4,5): update sticky anchor; reassign byline-author sentences
+                        to anchor (hold-until-anchor for early prologue;
+                        framed author's-note sections exempt)
+   │
+finalisation: recoverTaggedNarratorLines → foldMinorCast
+   └─ Layer B(6): byline-author entity now line-less → dropped; summary logged
+```
+
+## Testing
+
+Per the project's testing discipline (paired automated tests for every change):
+
+- **Layer A** — pure unit tests on `stripFrontMatterBoilerplate` using the *actual*
+  Night Watch head (ICE BOOK READER markers, `Сергей ЛУКЬЯНЕНКО` byline, `(С)`
+  copyright, library URLs) → stripped; ordinary narrative prose preserved; an
+  author-name mention *inside* story prose left intact (conservative-boundary test);
+  English book with no byline → no-op.
+- **Layer B** — pure unit tests on the guard: byline-author detected by name-match;
+  anchor establishes from Ch 1's dominant non-author speaker; anchor sticky across
+  later chapters; per-chapter reassignment moves author sentences to the anchor;
+  author-only prologue **held then retroactively reassigned**; framed author's-note
+  section **kept** (Unraveled case); narrator only when no candidate exists; the
+  line-less author entity is dropped at the end.
+- **Layer C** — `buildStage1ChapterInbox` renders the byline-author guidance + the
+  narrowed first-person rule; skill-file parity assertion.
+- **Integration regression** — a small first-person fixture with a byline (a variant
+  of the canonical `the-coalfall-commission` fixture, or a purpose-built minimal one)
+  run through the analysis path → final cast contains **no author-as-character** and
+  the protagonist holds the reclaimed first-person lines.
+
+## Open questions for the plan
+
+1. Exact insertion points in `analysis.ts` for Layer B across the full and subset
+   analysis entrypoints (the route already threads per-chapter results; the guard
+   should ride that, not a separate pass).
+2. Whether the anchor is recomputed per chapter or maintained as a running tally
+   (the plan picks the cheapest correct shape).
+3. The bilingual author-note title pattern set's initial membership (start small,
+   extend on real corpus data — same discipline as `GENERIC_ROLE_RU`).

--- a/docs/superpowers/specs/2026-06-20-byline-author-cast-collision-design.md
+++ b/docs/superpowers/specs/2026-06-20-byline-author-cast-collision-design.md
@@ -240,3 +240,11 @@ Per the project's testing discipline (paired automated tests for every change):
    extend on real corpus data — same discipline as `GENERIC_ROLE_RU`).
 3. Whether to emit a one-line analysing-view log when the guard drops an author, and
    whether to surface it in the change-log so a user can see why the author isn't cast.
+
+## Shipped
+
+- **Date:** 2026-06-20 · **Branch:** `fix/server-byline-author-cast-collision` · **Closes #938.**
+- **Commits:** plan/spec `27a4c69b`, `e9d3f47b`, `5589a433`, `cd6a909d`; implementation `f8049ac7` (Layer A module) → `eff34609` (integration regression + review fix), 7 TDD tasks.
+- **Build via subagent-driven execution:** adversarial plan review caught (and fixed) a cache-bypass bug — the guard was moved from the fresh-detection write to `rebuildRoster` + `buildInterimCast` so it covers a resumed / already-analyzed book. Empirically grounded on real `gemma4-e4b` + *Ночной дозор* (the byline author stole 8 of Anton's dialogue lines; removing it from the roster returned them to `anton`).
+- **Open questions resolved in implementation:** (1) guard rides `rebuildRoster` (both entrypoints) + `buildInterimCast`, on the read path; (2) author-note pattern set seeded bilingual (`AUTHOR_NOTE_TITLE_RX` in `byline-author-guard.ts`); (3) a one-line analysing-view log is emitted when the guard drops an author.
+- `npm run verify` green (typecheck + all tests + e2e + build); final whole-branch review (opus): ready to merge.

--- a/docs/superpowers/specs/2026-06-20-byline-author-cast-collision-design.md
+++ b/docs/superpowers/specs/2026-06-20-byline-author-cast-collision-design.md
@@ -59,12 +59,14 @@ Reproduced on real data — *Ночной дозор* (Sergei Lukyanenko / Night
 ## Design overview
 
 Three layers, deterministic where it matters. Layer A removes the source so the
-problem rarely arises; Layer B is the deterministic safety net that reclaims lines
-for the protagonist; Layer C is a cheap prompt nudge that reduces how often B fires.
+problem rarely arises; Layer B is the deterministic guarantee — it **drops the
+byline-author entity from the roster before stage-2**, after which the model
+attributes the protagonist's dialogue to the real protagonist on its own (empirically
+validated, see Layer B); Layer C is a cheap prompt nudge that reduces how often B fires.
 
 All three need the same **shared plumbing**: thread the book's `author` (and
 `title`, `language`) — already stored in `state.json` / the analysis `record` — into
-the body-prep path (A), the per-chapter attribution flow (B), and
+the body-prep path (A), the per-chapter roster-finalization (B), and
 `buildStage1ChapterInbox` (C). No new persisted state.
 
 ---
@@ -99,63 +101,71 @@ picks up improvements and the user's source file is never rewritten.
 
 ---
 
-### Layer B — incremental per-chapter realignment with an early protagonist anchor
+### Layer B — per-chapter stage-1 roster guard (drop the byline author before stage-2)
 
-The byline-author guard runs **inside the existing per-chapter flow**, not as a
-single end-of-run pass. Anchoring the protagonist from Chapter 1 — where the real
-protagonist is established and dominant — makes the realignment target robust and
-avoids guessing from end-of-book totals the author has already skewed.
+**This layer was redesigned after an empirical observation (2026-06-20) overturned the
+original "reclaim and reassign" approach.** See "Empirical grounding" below — the data
+showed that simply *removing* the byline-author entity from the roster before stage-2
+makes the model attribute the protagonist's dialogue to the real protagonist on its
+own. No anchor, no line-reassignment, no narrator fallback is needed.
 
-New pure module `server/src/analyzer/byline-author-guard.ts` (exact shape settled in
-the plan), driven by the analysis route across chapters:
+New pure helper (e.g. `server/src/analyzer/byline-author-guard.ts`), applied at the
+**per-chapter stage-1 roster-finalization** step (where the route already finalizes
+each chapter's detected roster, before stage-2 attribution runs for that chapter):
 
-1. **Stage-1 (per chapter) — flag the byline author.** When a detected character's
-   name matches the book `author` (normalized via `normaliseNameKey`), flag it as
-   the byline-author entity and **ignore the model-assigned role** (e.g. the bogus
-   `"Protagonist"`).
+1. **Detect the byline author.** A detected character whose name matches the book
+   `author` (normalized via `normaliseNameKey`) is the byline-author entity,
+   regardless of the model-assigned role (e.g. the bogus `"Protagonist / Investigator"`).
 
-2. **Protagonist anchor (sticky, established early).** Maintain a running anchor =
-   the dominant **non-author, non-narrator** speaker accumulated so far. The real
-   protagonist appears and dominates from Chapter 1, so the anchor locks on early
-   (Anton via his dialogue) and **stays sticky** — a chatty side-character in a
-   later chapter cannot steal it.
+2. **Framed author's-note exemption (preserves the legit case).** If the chapter is an
+   explicitly **framed** author's-note / in-fiction document — detected by chapter
+   title matching author-note patterns (`Author's Note`, `Notes from the author`,
+   `От автора`, `Предисловие/Послесловие автора`, …; a small, extensible bilingual
+   set) — **keep** the author entity (legitimate author-as-speaker, the Unraveled
+   case). Otherwise → step 3.
 
-3. **Stage-2 (per chapter, as each chapter is attributed) — reclaim lines.** Any
-   sentence attributed to the byline-author entity is **reassigned to the current
-   anchor right then**. Cheap, incremental, self-correcting as the book flows.
-   - **Reassignment target = the anchor (the protagonist). No confidence/margin
-     gate** — that gate is what would force the bad narrator fallback. With two
-     Anton rows the larger one wins; the protagonist keeps their voice.
-   - **Narrator is a last resort only** when a book genuinely has no other speaker
-     (degenerate; never true for a novel).
+3. **Drop it from the roster for this chapter.** Remove the byline-author entity from
+   the chapter's roster contribution so it never reaches that chapter's stage-2
+   attribution. Because the entity is dropped from the *running* roster too, later
+   chapters don't carry it forward; if a later chapter's stage-1 independently re-mints
+   it, the same per-chapter guard drops it again — idempotent and self-correcting.
 
-4. **Author-only-prologue edge.** If an early chapter is a prologue spoken only by
-   the first-person voice and no other named speaker has appeared yet, there is no
-   anchor at that instant. **Hold** those byline-author sentences and retroactively
-   reassign them once the anchor establishes (almost always within Ch 1–2) — the
-   protagonist still reclaims the prologue rather than losing it to narrator.
+4. **Let stage-2 re-attribute naturally.** With no "Protagonist"-labeled author in the
+   roster, stage-2 attributes the protagonist's dialogue to the real protagonist
+   (`anton`), addressed by name in the prose. **Empirically validated** (see below):
+   the 8 dialogue lines that the author stole went to `anton` once the author was
+   dropped. No reclamation pass needed.
 
-5. **Framed author's-note exemption (preserves the legit case).** If the byline
-   author's lines fall inside an explicitly **framed** author's-note / in-fiction
-   document section — detected by chapter title matching author-note patterns
-   (`Author's Note`, `Notes from the author`, `От автора`,
-   `Предисловие/Послесловие автора`, …; a small, extensible bilingual set) — those
-   lines are **kept** on the author entity (legitimate author-as-speaker). Only
-   non-framed (story) lines are reclaimed.
+5. **End state + log.** The byline author is absent from the final roster (no bogus
+   `role: "Protagonist"` ghost). A summary line is emitted for the analysing-view log
+   (e.g. *"Byline author 'Сергей Лукьяненко' excluded from N story chapters"*).
 
-6. **End state.** The byline-author entity has no story lines left → dropped from
-   the roster (removing the bogus `role: "Protagonist"` ghost). The protagonist
-   carries the reclaimed narration + dialogue. A summary line is emitted for the
-   analysing-view log (e.g. *"Byline author 'Сергей Лукьяненко' removed; N lines
-   reassigned → Антон"*).
+**Why this is simpler than the prior design.** The original Layer B reclaimed the
+author's already-attributed sentences and reassigned them to a "dominant non-author
+speaker = protagonist" anchor. The empirical run showed that heuristic would have
+mis-picked **Larisa (11 lines)** over **Anton (0 lines — starved by the bug itself)**.
+Dropping the author *before* stage-2 sidesteps the whole anchor problem: there are no
+author-attributed sentences to reclaim, and stage-2's own name-resolution puts the
+lines on the right character.
 
-**Stated limitation.** "Dominant non-author speaker = protagonist" is a heuristic.
-In a rare book whose most-talkative character is not the POV protagonist, reclaimed
-lines land on that major character instead — still a named voice, recoverable by
-manual re-cast, and strictly better than narrator per the chosen preference. The
-residual two-Anton split for the protagonist's *own* originally-correct lines stays
-a manual merge (Wave C); this fix only guarantees the reclaimed lines land on a real
-protagonist, never narrator.
+**Residual (unchanged, out of scope).** The `anton` / `anton-gorodetsky` duplication
+remains (Wave C, manual merge): in the validation run the reclaimed dialogue split
+`anton: 8` / `anton-gorodetsky: 1`. The protagonist's lines land on a real Anton, not
+the author — the split is a cosmetic roster issue, not a loss of voice.
+
+### Empirical grounding (2026-06-20, real gemma4-e4b on *Ночной дозор* Ch 1)
+
+Real stage-2 attribution via local `gemma4-e4b-8gb`, same scene, same roster
+(scratch harness, since deleted):
+
+| Roster | `sergey-lukyanenko` | `anton` | `narrator` | `larisa` |
+|---|---|---|---|---|
+| **as detected** (author = "Protagonist") | **8 dialogue lines** | 0 | 97 (narration) | 11 |
+| **author removed** | 0 | **8 dialogue lines** | 96 | 10 |
+
+- The author stole the protagonist's **dialogue** (8 spoken lines: "— Не надо," "— Спасибо," …); first-person **narration** correctly went to `narrator` both ways.
+- Removing the author from the roster → the dialogue went to `anton` with **no other change** to the design needed.
+- A "dominant non-author = protagonist" anchor would have chosen Larisa, not Anton — the heuristic is disproven for this case. Dropping-before-stage-2 is the correct, simpler fix.
 
 ---
 
@@ -186,15 +196,16 @@ parse (epub) → chapters + book meta { author, title, language }
    │
 stage-1 cast detection (per chapter)
    ├─ Layer C: byline author rendered into the inbox prompt
-   └─ Layer B(1): flag byline-author entity by name==author
+   └─ Layer B: at per-chapter roster finalization, DROP the byline-author entity
+              (name==author) from the roster — unless the chapter is a framed
+              author's-note. Dropped from the running roster too, so it isn't
+              carried forward; idempotent if re-minted later.
    │
 stage-2 attribution (per chapter)
-   └─ Layer B(2,3,4,5): update sticky anchor; reassign byline-author sentences
-                        to anchor (hold-until-anchor for early prologue;
-                        framed author's-note sections exempt)
+   └─ runs against the cleaned roster → protagonist's dialogue lands on `anton`
+      (empirically validated; no reclamation pass)
    │
-finalisation: recoverTaggedNarratorLines → foldMinorCast
-   └─ Layer B(6): byline-author entity now line-less → dropped; summary logged
+finalisation: recoverTaggedNarratorLines → foldMinorCast  (unchanged)
 ```
 
 ## Testing
@@ -206,25 +217,26 @@ Per the project's testing discipline (paired automated tests for every change):
   copyright, library URLs) → stripped; ordinary narrative prose preserved; an
   author-name mention *inside* story prose left intact (conservative-boundary test);
   English book with no byline → no-op.
-- **Layer B** — pure unit tests on the guard: byline-author detected by name-match;
-  anchor establishes from Ch 1's dominant non-author speaker; anchor sticky across
-  later chapters; per-chapter reassignment moves author sentences to the anchor;
-  author-only prologue **held then retroactively reassigned**; framed author's-note
-  section **kept** (Unraveled case); narrator only when no candidate exists; the
-  line-less author entity is dropped at the end.
+- **Layer B** — pure unit tests on the roster guard: byline-author detected by
+  name-match (`normaliseNameKey`, case/inflection-tolerant: `Сергей Лукьяненко` ≈
+  `sergey-lukyanenko`); dropped from a normal story chapter's roster (and the running
+  roster); **kept** when the chapter title marks a framed author's-note (Unraveled
+  case); idempotent re-mint drop; no-op when the book has no `author` or the author
+  isn't on the roster.
 - **Layer C** — `buildStage1ChapterInbox` renders the byline-author guidance + the
   narrowed first-person rule; skill-file parity assertion.
-- **Integration regression** — a small first-person fixture with a byline (a variant
-  of the canonical `the-coalfall-commission` fixture, or a purpose-built minimal one)
-  run through the analysis path → final cast contains **no author-as-character** and
-  the protagonist holds the reclaimed first-person lines.
+- **Integration regression** — a small first-person fixture with a byline run through
+  the analysis path → final cast contains **no author-as-character** and the
+  protagonist (not the author, not narrator) holds the dialogue. Mirrors the validated
+  *Ночной дозор* observation.
 
 ## Open questions for the plan
 
-1. Exact insertion points in `analysis.ts` for Layer B across the full and subset
-   analysis entrypoints (the route already threads per-chapter results; the guard
-   should ride that, not a separate pass).
-2. Whether the anchor is recomputed per chapter or maintained as a running tally
-   (the plan picks the cheapest correct shape).
-3. The bilingual author-note title pattern set's initial membership (start small,
+1. Exact insertion point in `analysis.ts` for the Layer-B roster guard across the full
+   **and** subset analysis entrypoints (it should ride the existing per-chapter
+   roster-finalization / `mergeRosterChapter` path, before stage-2 runs for the
+   chapter — not a separate end pass).
+2. The bilingual author-note title pattern set's initial membership (start small,
    extend on real corpus data — same discipline as `GENERIC_ROLE_RU`).
+3. Whether to emit a one-line analysing-view log when the guard drops an author, and
+   whether to surface it in the change-log so a user can see why the author isn't cast.

--- a/server/src/analyzer/byline-author-guard.test.ts
+++ b/server/src/analyzer/byline-author-guard.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { dropBylineAuthorFromChapter, isFramedAuthorNote } from './byline-author-guard.js';
+import type { CharacterOutput } from '../handoff/schemas.js';
+
+function ch(id: string, name: string, role = 'role'): CharacterOutput {
+  return { id, name, role, color: 'slot-4' };
+}
+
+const ROSTER: CharacterOutput[] = [
+  ch('narrator', 'Narrator', 'Third-person observer'),
+  ch('sergey-lukyanenko', 'Сергей Лукьяненко', 'Protagonist / Investigator'),
+  ch('anton', 'Антон', 'Оперативник'),
+  ch('anton-gorodetsky', 'Антон Городецкий', 'Иной'),
+];
+
+describe('isFramedAuthorNote', () => {
+  it('matches author-note chapter titles (bilingual), not story chapters', () => {
+    expect(isFramedAuthorNote("Author's Note")).toBe(true);
+    expect(isFramedAuthorNote('Notes from the Author')).toBe(true);
+    expect(isFramedAuthorNote('От автора')).toBe(true);
+    expect(isFramedAuthorNote('Послесловие автора')).toBe(true);
+    expect(isFramedAuthorNote('Chapter 1')).toBe(false);
+    expect(isFramedAuthorNote('ПРОЛОГ')).toBe(false);
+    expect(isFramedAuthorNote(undefined)).toBe(false);
+  });
+});
+
+describe('dropBylineAuthorFromChapter', () => {
+  it('drops the byline author by name-match (case/inflection-tolerant) from a story chapter', () => {
+    const r = dropBylineAuthorFromChapter(ROSTER, { author: 'Сергей Лукьяненко', chapterTitle: 'Chapter 1' });
+    expect(r.dropped).toEqual(['Сергей Лукьяненко']);
+    expect(r.characters.map((c) => c.id)).toEqual(['narrator', 'anton', 'anton-gorodetsky']);
+  });
+
+  it('matches an uppercased byline form too', () => {
+    const roster = [ch('a', 'Сергей ЛУКЬЯНЕНКО', 'Protagonist'), ch('anton', 'Антон')];
+    const r = dropBylineAuthorFromChapter(roster, { author: 'Сергей Лукьяненко', chapterTitle: 'Глава 2' });
+    expect(r.characters.map((c) => c.id)).toEqual(['anton']);
+  });
+
+  it('KEEPS the author in a framed author-note chapter (legit case)', () => {
+    const r = dropBylineAuthorFromChapter(ROSTER, { author: 'Сергей Лукьяненко', chapterTitle: 'От автора' });
+    expect(r.dropped).toEqual([]);
+    expect(r.characters).toBe(ROSTER); // referential identity preserved on no-op
+  });
+
+  it('never drops narrator and is a no-op when the author is absent or unset', () => {
+    expect(dropBylineAuthorFromChapter(ROSTER, { author: '', chapterTitle: 'Chapter 1' }).characters).toBe(ROSTER);
+    const noAuthorOnRoster = [ch('narrator', 'Narrator'), ch('anton', 'Антон')];
+    const r = dropBylineAuthorFromChapter(noAuthorOnRoster, { author: 'Сергей Лукьяненко', chapterTitle: 'Chapter 1' });
+    expect(r.characters).toBe(noAuthorOnRoster);
+    expect(r.dropped).toEqual([]);
+  });
+});

--- a/server/src/analyzer/byline-author-guard.ts
+++ b/server/src/analyzer/byline-author-guard.ts
@@ -1,0 +1,43 @@
+/* Layer B (#938) — drop the book's byline author from a chapter's detected roster
+   before stage-2 attribution. Empirically (gemma4-e4b, Ночной дозор Ch1): once the
+   "Protagonist"-roled author entity is gone, stage-2 attributes the protagonist's
+   dialogue to the real protagonist on its own — no reclamation/anchor needed.
+
+   The legit author-as-character case (a framed author's-note where the author
+   genuinely speaks) is preserved by exempting chapters whose title marks an
+   author's-note. Pure; mirrors fold-minor-cast.ts. */
+import type { CharacterOutput } from '../handoff/schemas.js';
+import { normaliseNameKey } from '../util/safe-id.js';
+
+const NARRATOR_ID = 'narrator';
+
+/* Bilingual author's-note chapter-title patterns. Start small; extend on real
+   corpus data (same discipline as GENERIC_ROLE_RU). */
+const AUTHOR_NOTE_TITLE_RX =
+  /author'?s?\s+note|notes?\s+from\s+the\s+author|от\s+автора|предислови|послеслови|об\s+авторе/i;
+
+export function isFramedAuthorNote(chapterTitle: string | undefined): boolean {
+  if (!chapterTitle) return false;
+  return AUTHOR_NOTE_TITLE_RX.test(chapterTitle);
+}
+
+export function dropBylineAuthorFromChapter(
+  characters: CharacterOutput[],
+  opts: { author?: string; chapterTitle?: string },
+): { characters: CharacterOutput[]; dropped: string[] } {
+  const authorKey = normaliseNameKey(opts.author);
+  if (!authorKey) return { characters, dropped: [] };
+  if (isFramedAuthorNote(opts.chapterTitle)) return { characters, dropped: [] };
+
+  const dropped: string[] = [];
+  const kept = characters.filter((c) => {
+    if (c.id === NARRATOR_ID) return true;
+    if (normaliseNameKey(c.name) === authorKey) {
+      dropped.push(c.name);
+      return false;
+    }
+    return true;
+  });
+  if (dropped.length === 0) return { characters, dropped: [] }; // preserve identity on no-op
+  return { characters: kept, dropped };
+}

--- a/server/src/analyzer/strip-front-matter.test.ts
+++ b/server/src/analyzer/strip-front-matter.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { stripFrontMatterBoilerplate } from './strip-front-matter.js';
+
+/* The actual Ночной дозор Ch1 head the analyzer saw (abridged but verbatim shapes). */
+const NW_HEAD = [
+  '_###ICE#BOOK#READER#PROFESSIONAL#HEADER#START###_ AUTHOR: Сергей Лукьяненко TITLE: Ночной дозор CODEPAGE: -3 _###ICE#BOOK#READER#PROFESSIONAL#HEADER#FINISH###_',
+  '',
+  'НОЧНОЙ ДОЗОР',
+  '',
+  'Сергей ЛУКЬЯНЕНКО',
+  '',
+  'http://www.bestlibrary.ru',
+  '',
+  'Любое коммерческое использование настоящего текста без ведома и прямого согласия владельца авторских прав НЕ ДОПУСКАЕТСЯ. (С) Сергей Лукьяненко',
+  '',
+  'Данный текст одобрен к распространению как способствующий делу Света. Ночной Дозор.',
+  '',
+  'ИСТОРИЯ ПЕРВАЯ',
+  '',
+  'ПРОЛОГ',
+  '',
+  'Эскалатор полз медленно, натужно. Старая станция, ничего не поделаешь. Зато ветер гулял в бетонной трубе вовсю, трепал волосы.',
+].join('\n');
+
+describe('stripFrontMatterBoilerplate', () => {
+  it('strips the Night Watch title-page block but keeps headings and prose', () => {
+    const out = stripFrontMatterBoilerplate(NW_HEAD, { author: 'Сергей Лукьяненко', title: 'Ночной дозор' });
+    // byline + title echo gone
+    expect(out).not.toMatch(/Сергей ЛУКЬЯНЕНКО/);
+    expect(out).not.toMatch(/НОЧНОЙ ДОЗОР/);
+    // reader header / copyright / url / distribution boilerplate gone
+    expect(out).not.toMatch(/ICE#BOOK#READER/);
+    expect(out).not.toMatch(/AUTHOR:/);
+    expect(out).not.toMatch(/bestlibrary\.ru/);
+    expect(out).not.toMatch(/коммерческое использование/);
+    expect(out).not.toMatch(/одобрен к распространению/);
+    // real structural headings + prose preserved
+    expect(out).toMatch(/ИСТОРИЯ ПЕРВАЯ/);
+    expect(out).toMatch(/ПРОЛОГ/);
+    expect(out).toMatch(/Эскалатор полз медленно/);
+  });
+
+  it('leaves an author-name mention inside ordinary prose intact (conservative boundary)', () => {
+    const body = 'Эскалатор полз медленно, и я вспомнил, что Сергей Лукьяненко однажды написал об этом в длинном абзаце про метро и людей.';
+    const out = stripFrontMatterBoilerplate(body, { author: 'Сергей Лукьяненко', title: 'Ночной дозор' });
+    expect(out).toBe(body);
+  });
+
+  it('is a no-op for an English book with no byline/boilerplate', () => {
+    const body = 'The bell tolled twice over Coalfall. Marlow pulled his collar up and stepped into the rain.';
+    expect(stripFrontMatterBoilerplate(body, { author: 'Castwright', title: 'The Coalfall Commission' })).toBe(body);
+  });
+
+  it('is a no-op when author/title are absent', () => {
+    const body = 'НОЧНОЙ ДОЗОР\n\nСергей ЛУКЬЯНЕНКО\n\nЭскалатор полз медленно, и ветер гулял в трубе вовсю, трепал волосы и капюшон.';
+    // Without author/title we cannot identify the byline; only global boilerplate would be removed (none here).
+    expect(stripFrontMatterBoilerplate(body)).toBe(body);
+  });
+});

--- a/server/src/analyzer/strip-front-matter.ts
+++ b/server/src/analyzer/strip-front-matter.ts
@@ -1,0 +1,67 @@
+/* Layer A (#938) — strip title-page byline + e-library boilerplate from a chapter
+   body before the analyzer sees it, so the byline author never reaches stage-1/2.
+   Pure; applied in-memory to the analysis copy of the body (never persisted).
+
+   Two removal classes:
+     - Always-safe global patterns (reader-tool headers, copyright/distribution
+       notices, bare URLs) — ordinary prose never contains these, so drop anywhere.
+     - Leading-region byline/title echo — a standalone line equal (normalized) to
+       the book author or title, removed only before substantial narrative prose
+       begins, so a story that *mentions* the author mid-prose is untouched. */
+import { normaliseNameKey } from '../util/safe-id.js';
+
+const GLOBAL_BOILERPLATE: RegExp[] = [
+  /_###ICE#BOOK#READER/i, // reader-tool header marker (whole line is the header)
+  /^\s*(AUTHOR|TITLE|CODEPAGE)\s*:/i, // reader header fields on their own line
+  /коммерческое использование/i, // e-library usage notice
+  /одобрен к распространению/i, // e-library distribution notice
+  /^\s*\((С|C)\)\s/i, // "(С) <author>" copyright line
+  /^\s*https?:\/\/\S+\s*$/i, // bare URL line
+];
+
+function isGlobalBoilerplate(line: string): boolean {
+  return GLOBAL_BOILERPLATE.some((re) => re.test(line));
+}
+
+/* A line that reads as narrative prose: reasonably long, contains sentence
+   punctuation AND a lowercase letter. All-caps headings ("ПРОЛОГ", "ИСТОРИЯ
+   ПЕРВАЯ") and bare bylines are short / have no lowercase → not narrative. */
+function isNarrativeLine(line: string): boolean {
+  if (line.length < 60) return false;
+  return /[.!?…]/.test(line) && /\p{Ll}/u.test(line);
+}
+
+export function stripFrontMatterBoilerplate(
+  body: string,
+  opts: { author?: string; title?: string } = {},
+): string {
+  const authorKey = normaliseNameKey(opts.author);
+  const titleKey = normaliseNameKey(opts.title);
+  const lines = body.split(/\r?\n/);
+  const out: string[] = [];
+  let inFrontMatter = true;
+  let changed = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Global boilerplate: drop anywhere, without ending the front-matter region.
+    if (trimmed && isGlobalBoilerplate(trimmed)) {
+      changed = true;
+      continue;
+    }
+
+    if (inFrontMatter && trimmed) {
+      const key = normaliseNameKey(trimmed);
+      if (key && (key === authorKey || key === titleKey)) {
+        changed = true;
+        continue; // standalone byline / title echo
+      }
+      if (isNarrativeLine(trimmed)) inFrontMatter = false;
+    }
+
+    out.push(line);
+  }
+
+  return changed ? out.join('\n') : body;
+}

--- a/server/src/routes/analysis.test.ts
+++ b/server/src/routes/analysis.test.ts
@@ -1546,6 +1546,26 @@ describe('buildStage1ChapterInbox — Phase 0a per-chapter prompt', () => {
   });
 });
 
+describe('buildStage1ChapterInbox — #938 byline-author guidance', () => {
+  const chapter = { id: 1, title: 'Chapter 1', body: 'Эскалатор полз медленно.' };
+
+  it('renders a "book author is not a character" block when an author is provided', () => {
+    const md = buildStage1ChapterInbox('m1', 'Ночной дозор', chapter, [], [], 'Сергей Лукьяненко');
+    expect(md).toMatch(/Сергей Лукьяненко/);
+    expect(md).toMatch(/not a character/i);
+  });
+
+  it('omits the block when no author is provided (back-compat)', () => {
+    const md = buildStage1ChapterInbox('m1', 'Ночной дозор', chapter, [], []);
+    expect(md).not.toMatch(/not a character/i);
+  });
+
+  it('narrows the first-person-document rule to framed embedded documents', () => {
+    const md = buildStage1ChapterInbox('m1', 'X', chapter, [], [], 'Author');
+    expect(md).toMatch(/first-person novel is NOT/i);
+  });
+});
+
 /* buildInterimCast underpins the mid-run cast.json writes — the helper
    must produce a deduped, palette-coloured roster with lines:0/scenes:0
    placeholders so the file shape matches the post-Phase-1 end-of-run

--- a/server/src/routes/analysis.test.ts
+++ b/server/src/routes/analysis.test.ts
@@ -28,6 +28,8 @@ import {
   resolveBookAuthorForManuscript,
 } from './analysis.js';
 import type { CharacterOutput, SentenceOutput } from '../handoff/schemas.js';
+import { dropBylineAuthorFromChapter } from '../analyzer/byline-author-guard.js';
+import { normaliseNameKey } from '../util/safe-id.js';
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -1986,5 +1988,103 @@ describe('castInFlightEntryToLiveChapter — live tick chapter map (Phase-0a cas
 describe('resolveBookAuthorForManuscript', () => {
   it('returns "" for an unknown manuscript (no throw)', async () => {
     await expect(resolveBookAuthorForManuscript('mns_does_not_exist')).resolves.toBe('');
+  });
+});
+
+/* #938 regression — byline-author exclusion on the CACHED roster path.
+   The adversarial-review insight: the guard sits on the roster-BUILD
+   (read) path inside rebuildRoster(), so it must drop the author even
+   when chapterCast came from cache (a resume / already-analyzed book),
+   not only for freshly-detected chapters.
+
+   We cannot import rebuildRoster() (it is a closure inside the route),
+   so we exercise the EXACT wiring Task 5 added:
+     chapterCast → dropBylineAuthorFromChapter → mergeRosterChapter
+   This is the composition that both entrypoints share and is the precise
+   seam Task 5 introduced. The test FAILS without the guard. */
+describe('#938 byline-author exclusion — cached roster path integration', () => {
+  const BOOK_AUTHOR = 'Сергей Лукьяненко';
+
+  /* Simulate a chapterCast record that came from CACHE (a prior
+     completed analysis run). Chapter 1 is a story chapter; the
+     stage-1 model mistakenly included the byline author. */
+  const cachedChapterCast: Record<number, CharacterOutput[]> = {
+    1: [
+      {
+        id: 'narrator',
+        name: 'Narrator',
+        role: 'Omniscient narrator',
+        color: 'narrator',
+        evidence: [{ quote: 'Эскалатор вниз полз медленно.' }],
+      },
+      {
+        /* The bug: stage-1 detected the book's author as a character. */
+        id: 'sergey-lukyanenko',
+        name: 'Сергей Лукьяненко',
+        role: 'Protagonist',
+        color: 'unset',
+        evidence: [{ quote: 'Я — Иной.' }],
+      },
+      {
+        id: 'anton',
+        name: 'Антон',
+        role: 'Protagonist',
+        color: 'unset',
+        evidence: [{ quote: 'Поехали.' }],
+      },
+    ],
+  };
+
+  /* Inline the same logic rebuildRoster() uses in analysis.ts
+     (both the main-route and subset-route closures do exactly this). */
+  function rebuildRosterInline(
+    chapterCast: Record<number, CharacterOutput[]>,
+    chapterHints: Array<{ id: number; title?: string }>,
+    author: string,
+  ): Map<string, CharacterOutput> {
+    const r = new Map<string, CharacterOutput>();
+    for (const ch of chapterHints) {
+      const cast = chapterCast[ch.id];
+      if (cast?.length) {
+        const guarded = dropBylineAuthorFromChapter(cast, {
+          author,
+          chapterTitle: ch.title,
+        });
+        mergeRosterChapter(r, guarded.characters);
+      }
+    }
+    return r;
+  }
+
+  it('excludes the byline author from the final roster when chapterCast came from cache', () => {
+    const chapterHints = [{ id: 1, title: 'Пролог' }];
+
+    const finalRoster = rebuildRosterInline(cachedChapterCast, chapterHints, BOOK_AUTHOR);
+    const rosterArray = Array.from(finalRoster.values());
+
+    /* The real protagonist and narrator must survive. */
+    expect(rosterArray.some((c) => c.id === 'anton')).toBe(true);
+    expect(rosterArray.some((c) => c.id === 'narrator')).toBe(true);
+
+    /* The byline author must NOT appear in the final roster (match
+       case-insensitively via normaliseNameKey, same as the guard uses). */
+    const authorKey = normaliseNameKey(BOOK_AUTHOR);
+    const authorEntry = rosterArray.find((c) => normaliseNameKey(c.name) === authorKey);
+    expect(authorEntry).toBeUndefined();
+  });
+
+  it('would include the byline author if the guard were absent (confirms the test is meaningful)', () => {
+    /* Simulate rebuildRoster WITHOUT the guard — raw mergeRosterChapter
+       from cache. If the guard is removed, the author leaks through. */
+    const r = new Map<string, CharacterOutput>();
+    mergeRosterChapter(r, cachedChapterCast[1]!);
+    const rosterArray = Array.from(r.values());
+
+    const authorKey = normaliseNameKey(BOOK_AUTHOR);
+    const authorEntry = rosterArray.find((c) => normaliseNameKey(c.name) === authorKey);
+
+    /* Without the guard the author IS in the roster — this confirms the
+       test above is a meaningful regression (the guard is the diff). */
+    expect(authorEntry).toBeDefined();
   });
 });

--- a/server/src/routes/analysis.test.ts
+++ b/server/src/routes/analysis.test.ts
@@ -25,6 +25,7 @@ import {
   trackForReplay,
   replayCatchUp,
   castInFlightEntryToLiveChapter,
+  resolveBookAuthorForManuscript,
 } from './analysis.js';
 import type { CharacterOutput, SentenceOutput } from '../handoff/schemas.js';
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
@@ -1959,5 +1960,11 @@ describe('castInFlightEntryToLiveChapter — live tick chapter map (Phase-0a cas
     expect(result.chapterTitle).toBe('Chapter Three');
     expect(result.elapsedMs).toBeGreaterThanOrEqual(0);
     expect(typeof result.estMs).toBe('number');
+  });
+});
+
+describe('resolveBookAuthorForManuscript', () => {
+  it('returns "" for an unknown manuscript (no throw)', async () => {
+    await expect(resolveBookAuthorForManuscript('mns_does_not_exist')).resolves.toBe('');
   });
 });

--- a/server/src/routes/analysis.test.ts
+++ b/server/src/routes/analysis.test.ts
@@ -2087,4 +2087,32 @@ describe('#938 byline-author exclusion — cached roster path integration', () =
        test above is a meaningful regression (the guard is the diff). */
     expect(authorEntry).toBeDefined();
   });
+
+  /* The two cases below exercise buildInterimCast directly — the exported
+     function that wires dropBylineAuthorFromChapter inside its own loop.
+     If the guard is deleted from buildInterimCast specifically, these
+     cases go red even if the rebuildRosterInline cases above stay green. */
+  it('buildInterimCast — excludes the byline author when author arg is supplied', () => {
+    const interim = buildInterimCast(cachedChapterCast, [1], undefined, BOOK_AUTHOR);
+
+    /* Real characters survive. */
+    expect(interim.some((c) => c.id === 'anton')).toBe(true);
+    expect(interim.some((c) => c.id === 'narrator')).toBe(true);
+
+    /* The byline author must be absent. */
+    const authorKey = normaliseNameKey(BOOK_AUTHOR);
+    const authorEntry = interim.find((c) => normaliseNameKey(c.name) === authorKey);
+    expect(authorEntry).toBeUndefined();
+  });
+
+  it('buildInterimCast — includes the byline author when author arg is omitted (witness: exclusion is from the guard)', () => {
+    /* Without the author arg the guard has nothing to match against, so
+       the author entry passes through. This proves the exclusion in the
+       case above is attributable to the guard, not some other filter. */
+    const interim = buildInterimCast(cachedChapterCast, [1]);
+
+    const authorKey = normaliseNameKey(BOOK_AUTHOR);
+    const authorEntry = interim.find((c) => normaliseNameKey(c.name) === authorKey);
+    expect(authorEntry).toBeDefined();
+  });
 });

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -1251,6 +1251,7 @@ export function buildStage1ChapterInbox(
   chapter: { id: number; title: string; body: string },
   runningRoster: CharacterOutput[],
   seriesPrior: SeriesPriorCharacter[] = [],
+  author = '',
 ): string {
   /* Compact roster format — only the identity fields the model needs to
      reuse ids verbatim. Skipping evidence/tone/description keeps each
@@ -1299,6 +1300,15 @@ ${priorJson}
 \`\`\`
 `;
 
+  /* #938 — the book's byline author is NOT a character. Rendered only when known. */
+  const authorBlock = author.trim()
+    ? `
+## Book author — NOT a character
+
+The byline author of this book is **${author.trim()}**. This is the real-world author printed on the cover — they are NOT a character in the story. Do NOT add them to the roster, and never assign the narrator's prose or the protagonist's first-person lines to them — UNLESS this chapter is an explicitly-framed author's note/letter in which the author speaks in the first person about the book.
+`
+    : '';
+
   return `---
 manuscriptId: ${manuscriptId}
 stage: 1-ch${chapter.id}
@@ -1324,6 +1334,9 @@ true:
    the *author* is the character, with their \`id\` set to their name,
    and the document's prose becomes their evidence. \`narrator\` is
    reserved for omniscient third-person prose with no in-fiction author.
+   A whole **first-person novel is NOT** such a document — its first-person
+   voice is the protagonist/narrator, NOT the book's author; never roster the
+   byline author as that voice.
 
 **An explicit \`<Name> <speech-verb>\` dialogue tag is binding** — \`"…,"
 Lessom repeated.\`, \`"Fine," Sela agreed.\`, \`"Where?" Wren asked.\`
@@ -1371,7 +1384,7 @@ For any character below who appears in this chapter, use the existing \`id\`
 duplicate roster entry.
 
 ${rosterBlock}
-${priorBlock}
+${priorBlock}${authorBlock}
 ## Chapter
 
 ${chapter.body}
@@ -2794,6 +2807,7 @@ export async function runMainAnalyzerJob(
                       { ...ch, body: subBody },
                       Array.from(rebuildRoster().values()),
                       seriesPrior,
+                      bookAuthor,
                     ),
                     {
                       signal: abortController.signal,
@@ -4574,6 +4588,7 @@ async function runSubsetAnalyzerJob(
                     { ...ch, body: subBody },
                     Array.from(rebuildRoster().values()),
                     subsetSeriesPrior,
+                    bookAuthor,
                   ),
                   {
                     signal: abortController.signal,

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -2124,6 +2124,18 @@ export async function resolveBookLanguageForManuscript(manuscriptId: string): Pr
   }
 }
 
+/* #938 — the book's byline author (cover/byline name), for the Layer A front-matter
+   strip + the Layer B roster guard. Mirrors resolveBookLanguageForManuscript's
+   fail-open shape: "" on any miss so the guard/strip degrade to no-ops. */
+export async function resolveBookAuthorForManuscript(manuscriptId: string): Promise<string> {
+  try {
+    const located = await findBookByManuscriptId(manuscriptId);
+    return located?.state?.author ?? '';
+  } catch {
+    return '';
+  }
+}
+
 export async function runMainAnalyzerJob(
   job: AnalysisJob,
   record: NonNullable<Awaited<ReturnType<typeof getOrHydrateManuscript>>>,

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -116,6 +116,7 @@ import {
   tryParseApiError,
   FAILURE_REMEDIATIONS,
 } from './failure-taxonomy.js';
+import { dropBylineAuthorFromChapter } from '../analyzer/byline-author-guard.js';
 
 /* srv-13 — the existing cast's voice/reuse fields to overlay onto a fresh
    analysis roster. Prefer cast.json; when it's absent (a reparse just deleted
@@ -652,11 +653,15 @@ export function buildInterimCast(
   chapterCast: Record<number, CharacterOutput[]>,
   chapterOrder: number[],
   language?: string,
+  author = '',
 ): CharacterOutput[] {
   const roster = new Map<string, CharacterOutput>();
   for (const chapterId of chapterOrder) {
     const cast = chapterCast[chapterId];
-    if (cast?.length) mergeRosterChapter(roster, cast);
+    if (cast?.length) {
+      const guarded = dropBylineAuthorFromChapter(cast, { author }); // #938 — no title here (transient interim)
+      mergeRosterChapter(roster, guarded.characters);
+    }
   }
   if (roster.size === 0) return [];
   const folded = previewFoldForLiveView(Array.from(roster.values()), language);
@@ -2577,7 +2582,16 @@ export async function runMainAnalyzerJob(
         const r = new Map<string, CharacterOutput>();
         for (const ch of recordRef.chapterHints) {
           const cast = chapterCast[ch.id];
-          if (cast?.length) mergeRosterChapter(r, cast);
+          if (cast?.length) {
+            /* #938 Layer B — keep the byline author out of every roster build
+               (covers cached chapterCast too, unlike guarding only fresh writes).
+               Framed author's-note chapters keep the author. */
+            const guarded = dropBylineAuthorFromChapter(cast, {
+              author: bookAuthor,
+              chapterTitle: ch.title,
+            });
+            mergeRosterChapter(r, guarded.characters);
+          }
         }
         return r;
       };
@@ -2942,6 +2956,7 @@ export async function runMainAnalyzerJob(
             chapterCast,
             recordRef.chapterHints.map((h) => h.id),
             bookLanguage,
+            bookAuthor,
           );
           if (interim.length > 0) {
             try {
@@ -4504,7 +4519,16 @@ async function runSubsetAnalyzerJob(
       const r = new Map<string, CharacterOutput>();
       for (const ch of record.chapterHints) {
         const cast = chapterCast[ch.id];
-        if (cast?.length) mergeRosterChapter(r, cast);
+        if (cast?.length) {
+          /* #938 Layer B — keep the byline author out of every roster build
+             (covers cached chapterCast too, unlike guarding only fresh writes).
+             Framed author's-note chapters keep the author. */
+          const guarded = dropBylineAuthorFromChapter(cast, {
+            author: bookAuthor,
+            chapterTitle: ch.title,
+          });
+          mergeRosterChapter(r, guarded.characters);
+        }
       }
       return r;
     };
@@ -4589,6 +4613,7 @@ async function runSubsetAnalyzerJob(
             chapterCast,
             record.chapterHints.map((h) => h.id),
             bookLanguage,
+            bookAuthor,
           );
           if (interim.length > 0) {
             try {

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -52,6 +52,7 @@ import {
   chapterDriftExceeded,
   type MissingSpeaker,
 } from '../analyzer/roster-coverage.js';
+import { stripFrontMatterBoilerplate } from '../analyzer/strip-front-matter.js';
 import {
   readUserSettings,
   getCachedUserSettings,
@@ -2146,6 +2147,13 @@ export async function runMainAnalyzerJob(
   /* fs-2 — book language for the analyzer preamble + Cyrillic token estimate.
      Resolved once per job; threaded into every runStage* call below. */
   const bookLanguage = await resolveBookLanguageForManuscript(manuscriptId);
+  /* #938 Layer A — resolve the byline author + strip title-page/e-library
+     boilerplate from each chapter body BEFORE the model sees it. In-memory only
+     (the hydrated analysis copy), never persisted; idempotent so a re-run is safe. */
+  const bookAuthor = await resolveBookAuthorForManuscript(manuscriptId);
+  for (const ch of record.chapterHints) {
+    ch.body = stripFrontMatterBoilerplate(ch.body, { author: bookAuthor, title: record.title });
+  }
   const requestedFresh = opts.requestedFresh;
   const allowStage1Shrink = opts.allowStage1Shrink;
   const abortController = job.controller;
@@ -4365,6 +4373,13 @@ async function runSubsetAnalyzerJob(
   const manuscriptId = job.manuscriptId;
   /* fs-2 — book language for the analyzer preamble + Cyrillic token estimate. */
   const bookLanguage = await resolveBookLanguageForManuscript(manuscriptId);
+  /* #938 Layer A — resolve the byline author + strip title-page/e-library
+     boilerplate from each chapter body BEFORE the model sees it. In-memory only
+     (the hydrated analysis copy), never persisted; idempotent so a re-run is safe. */
+  const bookAuthor = await resolveBookAuthorForManuscript(manuscriptId);
+  for (const ch of record.chapterHints) {
+    ch.body = stripFrontMatterBoilerplate(ch.body, { author: bookAuthor, title: record.title });
+  }
   const abortController = job.controller;
   const analyzer = selection.analyzer;
   const analyzerLabel = engineLabel(selection.engine, selection.model);

--- a/skills/audiobook-character-detection-per-chapter.md
+++ b/skills/audiobook-character-detection-per-chapter.md
@@ -74,6 +74,10 @@ one **verbatim utterance** that is theirs — either:
    `FILED BY: ODUVAN`, signature `—Marlow`, chapter title `Wren's
 Registry File`, the surrounding bio block, etc.). The author of
    such text is a character whose `id` is their name, NOT `narrator`.
+   A whole first-person **novel** is NOT such a document — its first-person voice
+   is the protagonist/narrator, not the book's author. Never roster the book's
+   byline author as a character unless they explicitly act or speak in the story
+   (e.g. a clearly-framed author's note).
 
 **Binding rule — an explicit dialogue tag always counts.** If the chapter
 contains a `<Name> <speech-verb>` attribution beat next to a quote — `"…,"


### PR DESCRIPTION
## Summary

Closes #938. On a first-person novel whose manuscript carries a title-page byline, the analyzer cast the book's **real-world author** as a speaking character and routed the **protagonist's dialogue** to it. Reproduced on real data — *Ночной дозор* (Lukyanenko): the detected cast had `Сергей Лукьяненко` with `role: "Protagonist / Investigator"`, present in 8/9 chapters.

Three layers (defense-in-depth), all in `server/src/`:

- **Layer A — front-matter strip** (`analyzer/strip-front-matter.ts`): removes the title-page byline + e-library boilerplate (ICE-reader header, copyright, library URLs) from each chapter body before the model sees it; applied in-memory at job start in both analysis entrypoints.
- **Layer B — byline-author roster guard** (`analyzer/byline-author-guard.ts`): drops a detected character whose name matches the book's `author` (via `normaliseNameKey`) from the roster **unless** the chapter is a framed author's-note (`isFramedAuthorNote` — preserves the legit "author's note" case). Wired into both `rebuildRoster` closures **and** the exported `buildInterimCast`, on the roster-**build** path — so it covers a **cached** `chapterCast` (a resume / already-analyzed book), not just freshly-detected chapters.
- **Layer C — prompt clarification**: `buildStage1ChapterInbox` tells the model the byline author is not a character and narrows the first-person-document rule to framed embedded documents; mirrored in `skills/audiobook-character-detection-per-chapter.md`.
- Plumbing: `resolveBookAuthorForManuscript` (fail-open `''`).

**Empirically validated** on real `gemma4-e4b`: removing the byline author from the roster made stage-2 hand Anton's 8 stolen dialogue lines back to `anton` on its own — so Layer B is the deterministic core; no line-reassignment heuristic is needed. (An earlier "find the protagonist by line count" design was disproven by the data — it would have mis-picked Larisa, since the bug had starved Anton to 0 lines.)

## Test plan

- Pure unit tests: `strip-front-matter.test.ts` (Night Watch head stripped; mid-prose author mention preserved; English no-op) and `byline-author-guard.test.ts` (name-match drop incl. ALL-CAPS byline; framed-note exemption; narrator never dropped; referential-identity no-ops).
- Route tests: `buildStage1ChapterInbox` renders the byline-author guidance + narrowed rule; `resolveBookAuthorForManuscript` fail-open.
- Integration regression (`analysis.test.ts`): exercises the **cached** `chapterCast` path through both the `rebuildRoster`-style composition and the exported `buildInterimCast`, with witness cases proving the author leaks **without** the guard (so the test fails if the guard is removed).
- `npm run verify` green (typecheck + all tests + e2e + build). Built via subagent-driven execution with per-task reviews + an opus whole-branch review (ready to merge, no Critical/Important findings).

Spec: `docs/superpowers/specs/2026-06-20-byline-author-cast-collision-design.md` · Plan: `docs/superpowers/plans/2026-06-20-byline-author-cast-collision.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)