### PR TITLE
chore(scripts): drop unused dirname import in rekey-qwen-voices script

### DIFF
--- a/scripts/rekey-qwen-voices-to-uuid.mjs
+++ b/scripts/rekey-qwen-voices-to-uuid.mjs
@@ -24,7 +24,7 @@
    and updates each descriptor's `voiceId` + adds the inert `voiceUuid`.
    Idempotent: a character that already has a `voiceUuid` is skipped. */
 import { readFileSync, writeFileSync, existsSync, renameSync, copyFileSync, readdirSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 
 const args = process.argv.slice(2);


### PR DESCRIPTION
## Summary

Removes an unused `dirname` import in `scripts/rekey-qwen-voices-to-uuid.mjs` (landed with srv-44, #942) that tripped the pre-push `eslint --max-warnings 0` gate. It reached `main` because PRs merge via the GitHub button, which doesn't run the local lint gate.

## Test plan

- `npx eslint scripts/rekey-qwen-voices-to-uuid.mjs --max-warnings 0` → clean
- Full `npm run verify` passed via pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)