### PR TITLE
feat(server): narrator-default guard for English + all quote conventions

### DIFF
--- a/docs/superpowers/plans/2026-06-20-english-narrator-default.md
+++ b/docs/superpowers/plans/2026-06-20-english-narrator-default.md
@@ -1,0 +1,397 @@
+# English narrator-default attribution guard — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop English close-third-person narration ("She was lost.") from being voiced in a character's voice by generalizing the existing deterministic narrator-default guard to English, and flag each demoted block as low-confidence for review.
+
+**Architecture:** The guard already exists for non-English (`server/src/analyzer/narrator-default.ts`). We (1) extend its `isSpokenLine` predicate to recognize smart single-quote dialogue, (2) replace the non-English-gated `applyNonEnglishNarratorDefault` with a language-agnostic `applyNarratorDefault` that demotes non-spoken character lines to `narrator` and clamps the *first* sentence of each demoted run to confidence `0.5` (so the Confirm-view low-confidence navigator gets one review stop per block, not one per sentence), and update the single call site in the same commit. Pure functions, no I/O, no model calls.
+
+**Tech Stack:** TypeScript, Vitest (node env), server-side analyzer.
+
+**Spec:** `docs/superpowers/specs/2026-06-20-english-narrator-default-attribution-design.md`
+
+## Global Constraints
+
+- **Commit convention:** `<type>(<scope>): <subject>` — use scope `server` (e.g. `feat(server): …`). Enforced by `.husky/commit-msg`.
+- **No commit may leave the tree non-compiling.** The export rename touches both `narrator-default.ts` and its importer `analysis.ts`; they are changed together in one commit (Task 2), with a `typecheck` gate before committing. Pre-commit does NOT run typecheck (it is pre-push only), so run it explicitly.
+- **Demote-only at the sentence level:** the guard sets a non-spoken sentence's `characterId` to `narrator`; it NEVER reassigns a quoted line to a different speaker and NEVER promotes `narrator` → character. (It DOES lower line counts, which can fold/drop a character — intended; see Task 3.)
+- **`'narrator'` is the always-present fallback id** and must stay a valid roster id (it is — `analysis.ts:1044-1045`, `:4940`). Guard output is therefore invisible to the `attribution_drift` counter.
+- **All common quote conventions (defense in depth).** Recognize double, smart-single `'…'`, straight-single `'…'` (leading + word-boundary-anchored embedded), guillemet, and dash. The boundary anchor is what keeps straight `'` from colliding with apostrophes (`don't`, `dogs'`).
+- **One review stop per demoted block:** clamp only the FIRST override in each contiguous demoted run to `0.5`; later overrides in the run are demoted but keep their model confidence.
+- **`Math.min`, not overwrite:** `confidence = Math.min(existing ?? 1, 0.5)` so a line the model already rated below 0.5 keeps its lower value.
+- **Run server tests** for a single file: `cd server && npx vitest run src/analyzer/narrator-default.test.ts`. Full server suite from repo root: `npm run test:server` (note: the root scripts `test:server`/`test:server-slow` map to the server package's `test`/`test:slow`).
+- Branch: `feat/server-english-narrator-default` (already cut).
+
+---
+
+## Preflight — informational (not a blocker)
+
+Quote convention is no longer a gate: Task 1 hardens `isSpokenLine` to cover
+double, smart-single, **straight-single**, guillemet, and dash conventions
+(defense in depth — books arrive from arbitrary `.env` locations in every style).
+A glance at a real _Scepter_ dialogue line is still useful to sanity-check the
+live result, but no convention blocks the build.
+
+- [ ] (Optional) Noted _Scepter_'s quote style for the manual-acceptance check.
+
+---
+
+## Task 1: Harden `isSpokenLine` to all common quote conventions (defense in depth)
+
+**Files:**
+- Modify: `server/src/analyzer/narrator-default.ts:31-38` (the `isSpokenLine` predicate)
+- Test: `server/src/analyzer/narrator-default.test.ts` (add to the existing `describe('isSpokenLine')` block, after line 46)
+
+**Interfaces:**
+- Produces: `isSpokenLine(text: string): boolean` — unchanged signature; now also returns `true` for leading smart single `'` (U+2018) and straight single `'`, embedded smart-single `'…'` (U+2018…U+2019), and word-boundary-anchored embedded straight-single `'…'` spans. Apostrophes (`don't`, `O'Brien`, `dogs'`) do NOT trigger it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add inside `describe('isSpokenLine', () => { … })` in `server/src/analyzer/narrator-default.test.ts`:
+
+```ts
+it('treats smart single-quote dialogue as spoken (UK/Irish typeset convention)', () => {
+  expect(isSpokenLine('‘I’m lost,’ she said.')).toBe(true); // leading U+2018
+  expect(isSpokenLine('She said ‘this way’ firmly.')).toBe(true); // embedded U+2018…U+2019
+});
+it('treats straight single-quote dialogue as spoken (leading + boundary-anchored embedded)', () => {
+  expect(isSpokenLine("'I'm lost,' she said.")).toBe(true); // leading straight '
+  expect(isSpokenLine("She said 'go away' angrily.")).toBe(true); // embedded, boundary-anchored
+  expect(isSpokenLine("'Aye, Captain,'")).toBe(true); // leading-only spoken split
+});
+it('a single quote used as an apostrophe does NOT make narration spoken', () => {
+  expect(isSpokenLine('She didn’t know where she was.')).toBe(false); // smart apostrophe (lone U+2019)
+  expect(isSpokenLine("She didn't know where she'd been.")).toBe(false); // straight apostrophes, word-internal
+  expect(isSpokenLine("The dogs' bones lay by the cats' bowls.")).toBe(false); // possessive apostrophes
+  expect(isSpokenLine("O'Brien walked past the corner.")).toBe(false); // name apostrophe
+});
+it('narration quoting a sign with straight double quotes still reads as spoken (documented false-negative)', () => {
+  expect(isSpokenLine('She read the sign that said "Exit".')).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd server && npx vitest run src/analyzer/narrator-default.test.ts -t "single-quote"`
+Expected: FAIL — `'I'm lost,' she said.` (smart and straight) currently returns `false`.
+
+- [ ] **Step 3: Implement the predicate extension**
+
+In `server/src/analyzer/narrator-default.ts`, update the quote checks in `isSpokenLine` (currently lines 35-36) to:
+
+```ts
+  if (/^[«"“‘']/.test(t)) return true; // any opening quote: guillemet / straight+smart double / smart+straight single
+  if (/«[^»]+»/.test(t) || /"[^"]+"/.test(t) || /“[^”]+”/.test(t) || /‘[^’]+’/.test(t)) return true; // embedded span: guillemet / straight+smart double / smart single
+  // embedded STRAIGHT single, word-boundary-anchored: opens after start/space/bracket/dash, closes before space/punct.
+  // Avoids apostrophes (don't, O'Brien, dogs') whose ' is never at a word boundary.
+  if (/(?:^|[\s([{<«—–-])'(?=\S)[^']*?\S'(?=[\s.,!?;:)\]}>»]|$)/.test(t)) return true;
+```
+
+Leave the leading-dash and HTML-entity checks (lines 32-34) unchanged.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd server && npx vitest run src/analyzer/narrator-default.test.ts`
+Expected: PASS — all `isSpokenLine` tests green (the new convention/apostrophe cases plus the existing dash/quote/false-positive cases at lines 13-46).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/analyzer/narrator-default.ts server/src/analyzer/narrator-default.test.ts
+git commit -m "feat(server): harden isSpokenLine to all common quote conventions (single/double/guillemet/dash)"
+```
+
+---
+
+## Task 2: Add `applyNarratorDefault` and wire it into the route (single commit)
+
+**Files:**
+- Modify: `server/src/analyzer/narrator-default.ts` — update the module header comment (lines 1-18); remove the `isNonEnglish` import (line 21); remove `applyNonEnglishNarratorDefault` (lines 48-57); add `applyNarratorDefault`.
+- Modify: `server/src/routes/analysis.ts:13` (import) and `:1558-1563` (comment + single call site).
+- Test: `server/src/analyzer/narrator-default.test.ts` (replace the `describe('applyNonEnglishNarratorDefault')` block, lines 72-87).
+
+**Interfaces:**
+- Consumes: `isSpokenLine` (Task 1); the module const `NARRATOR_ID = 'narrator'` (line 23).
+- Produces: `applyNarratorDefault(sentences: SentenceOutput[]): SentenceOutput[]` — runs for ALL languages; demotes each non-spoken **override** (model-assigned real character) to `narrator`; clamps the first override of each contiguous demoted run to `Math.min(existing ?? 1, 0.5)`; leaves spoken lines and pre-existing-narrator lines untouched (same reference). `forceNarratorOnNonSpokenLines` is kept, unchanged and field-preserving.
+
+> **Why one commit:** removing `applyNonEnglishNarratorDefault` while `analysis.ts` still imports it leaves the tree non-compiling. The function and its only importer are changed together so every commit builds.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `server/src/analyzer/narrator-default.test.ts`, change the import (lines 3-7) from `applyNonEnglishNarratorDefault` to `applyNarratorDefault`, and **replace** the entire `describe('applyNonEnglishNarratorDefault', …)` block (lines 72-87) with:
+
+```ts
+describe('applyNarratorDefault', () => {
+  it('runs for English: demotes non-spoken character lines to narrator, leaves spoken lines', () => {
+    const en = [s(1, 'stephanie', 'She was lost.'), s(2, 'stephanie', '“Hard to starboard,”')];
+    expect(applyNarratorDefault(en).map((x) => x.characterId)).toEqual(['narrator', 'stephanie']);
+  });
+
+  it('clamps only the FIRST override in a contiguous demoted run to 0.5', () => {
+    const run = [
+      s(1, 'stephanie', 'She was lost.'),
+      s(2, 'stephanie', 'She turned away from the dead end.'),
+      s(3, 'stephanie', 'She tried to remember the way.'),
+    ];
+    const out = applyNarratorDefault(run);
+    expect(out.map((x) => x.characterId)).toEqual(['narrator', 'narrator', 'narrator']);
+    expect(out.map((x) => x.confidence)).toEqual([0.5, 0.9, 0.9]);
+  });
+
+  it('a spoken line resets the run so each demoted block gets its own single flag', () => {
+    const seq = [
+      s(1, 'stephanie', 'She was lost.'),       // override -> clamp 0.5
+      s(2, 'stephanie', 'She turned away.'),     // override -> 0.9
+      s(3, 'stephanie', '“This way,”'),          // spoken -> reset
+      s(4, 'stephanie', 'She walked on.'),       // override -> clamp 0.5 (new run)
+    ];
+    const out = applyNarratorDefault(seq);
+    expect(out.map((x) => x.characterId)).toEqual(['narrator', 'narrator', 'stephanie', 'narrator']);
+    expect(out.map((x) => x.confidence)).toEqual([0.5, 0.9, 0.9, 0.5]);
+  });
+
+  it('leaves pre-existing narrator lines untouched and they do not consume the clamp slot', () => {
+    const seq = [
+      s(1, 'narrator', 'The hall was dark.'),  // already narrator
+      s(2, 'stephanie', 'She was lost.'),       // first override of the run -> 0.5
+    ];
+    const out = applyNarratorDefault(seq);
+    expect(out[0]).toBe(seq[0]); // unchanged reference
+    expect(out[1].characterId).toBe('narrator');
+    expect(out[1].confidence).toBe(0.5);
+  });
+
+  it('clamp is min, not overwrite: a model confidence already below 0.5 stays', () => {
+    const low = [
+      { id: 1, chapterId: 1, characterId: 'stephanie', text: 'She was lost.', confidence: 0.3 } as SentenceOutput,
+    ];
+    expect(applyNarratorDefault(low)[0].confidence).toBe(0.3);
+  });
+
+  it('demotes non-English narration too AND now flags it (both-language flag)', () => {
+    const ru = [s(1, 'egor', 'Егор побежал.'), s(2, 'woman', '— Стой!')];
+    const out = applyNarratorDefault(ru);
+    expect(out.map((x) => x.characterId)).toEqual(['narrator', 'woman']);
+    expect(out[0].confidence).toBe(0.5); // previously silent, now flagged
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd server && npx vitest run src/analyzer/narrator-default.test.ts -t "applyNarratorDefault"`
+Expected: FAIL — `applyNarratorDefault` is not exported / not defined.
+
+- [ ] **Step 3: Update the module header comment and the appliers in `narrator-default.ts`**
+
+1. Replace the module header comment (lines 1-18) so it no longer claims non-English-only gating. Use:
+
+```ts
+/* Deterministic narrator-default heuristic (plan 221 Wave A; generalized to all
+   languages 2026-06-20).
+
+   The per-sentence attribution model mislabels third-person NARRATION as the
+   named character (e.g. "She was lost." → `stephanie`, or "Егор засунул руки в
+   карманы" → `egor`), which would read narration in that character's voice. The
+   spoken-vs-narration distinction is mechanical, so we decide it in code: any
+   sentence that is NOT a spoken line is forced to `narrator`. Runs for English
+   too (the model ignores the same rule in the skill prompt).
+
+   A "spoken line" = begins with a dialogue dash (—/–/-) or any opening quote
+   («/"/“/‘/'), OR contains a quoted span (double / guillemet / smart-single /
+   boundary-anchored straight-single). Everything else is narration. Demote-only
+   at the sentence level: it never reassigns a
+   quoted line and never promotes narrator→character (it does lower line counts,
+   which fold/reconcile consume downstream). Coverage is unaffected (the coverage
+   guard keys on sentence text, not characterId). Pure: no I/O, no model calls. */
+```
+
+2. Delete the `import { isNonEnglish } from '../tts/language.js';` line (line 21).
+3. Delete the JSDoc + `applyNonEnglishNarratorDefault` function (lines 48-57 — the doc is 48-50, the function 51-57).
+4. Add (keep `forceNarratorOnNonSpokenLines` exactly as-is). Note: after this commit `forceNarratorOnNonSpokenLines` is no longer called by production code — it is retained intentionally as the field-preserving primitive exercised by the `:65-69` and `:89-124` tests. Do NOT delete it as "dead code."
+
+```ts
+/** Apply the narrator-default heuristic for ALL languages. Each non-spoken
+    sentence whose model-assigned characterId is a real character is demoted to
+    `narrator`; the FIRST such override in each contiguous demoted run has its
+    confidence clamped to <= 0.5 so the Confirm-view low-confidence navigator
+    gets one review stop per block (not one per sentence). Spoken lines and
+    pre-existing-narrator lines are returned by reference, untouched. Pure. */
+export function applyNarratorDefault(sentences: SentenceOutput[]): SentenceOutput[] {
+  let clampedThisRun = false;
+  return sentences.map((s) => {
+    if (isSpokenLine(s.text)) {
+      clampedThisRun = false;
+      return s;
+    }
+    if (s.characterId === NARRATOR_ID) return s; // already narrator — not an override
+    if (!clampedThisRun) {
+      clampedThisRun = true;
+      return { ...s, characterId: NARRATOR_ID, confidence: Math.min(s.confidence ?? 1, 0.5) };
+    }
+    return { ...s, characterId: NARRATOR_ID };
+  });
+}
+```
+
+- [ ] **Step 4: Update the call site in `analysis.ts`**
+
+1. Change the import at `server/src/routes/analysis.ts:13` from:
+
+```ts
+import { applyNonEnglishNarratorDefault } from '../analyzer/narrator-default.js';
+```
+
+to:
+
+```ts
+import { applyNarratorDefault } from '../analyzer/narrator-default.js';
+```
+
+2. Replace the comment + call site at `server/src/routes/analysis.ts:1558-1563` (the comment ending "No-op for English. Runs AFTER coverage…" and the `result.sentences = applyNonEnglishNarratorDefault(...)` line) with:
+
+```ts
+  /* Deterministic narrator-default: force non-spoken sentences to `narrator`
+     and flag the first of each demoted block low-confidence. Runs for ALL
+     languages, AFTER coverage (coverage keys on text, not characterId, so the
+     verdict is unchanged) and UPSTREAM of fold/reconcile. */
+  result.sentences = applyNarratorDefault(result.sentences);
+  return result;
+```
+
+- [ ] **Step 5: Type-check (catches the cross-file rename)**
+
+Run: `npm run typecheck`
+Expected: PASS — no remaining reference to `applyNonEnglishNarratorDefault` in compiled code. If it reports the old name, run `git grep -n "applyNonEnglishNarratorDefault" -- 'server/src/**'` and fix each hit.
+
+- [ ] **Step 6: Run the analyzer tests**
+
+Run: `cd server && npx vitest run src/analyzer/narrator-default.test.ts`
+Expected: PASS — the new `applyNarratorDefault` block plus the unchanged `isSpokenLine`, `forceNarratorOnNonSpokenLines`, and fold-interaction blocks (the latter still call `forceNarratorOnNonSpokenLines`, which is unchanged).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/analyzer/narrator-default.ts server/src/analyzer/narrator-default.test.ts server/src/routes/analysis.ts
+git commit -m "feat(server): run language-agnostic narrator-default guard with per-block low-confidence flag"
+```
+
+---
+
+## Task 3: Pin the cast-roster effect (corrected invariant) for English
+
+**Files:**
+- Test: `server/src/analyzer/narrator-default.test.ts` (add to the existing `describe('narrator-default + foldMinorCast interaction')` block, after line 124)
+
+**Interfaces:**
+- Consumes: `applyNarratorDefault` (Task 2), `foldMinorCast` (already imported at test line 8).
+
+This task locks the spec's corrected invariant: demoting a mostly-narrated character's lines lowers their count and can fold/drop them — the *intended* outcome — while a separately-quoted character keeps her slot. It uses the real `applyNarratorDefault` path (the existing Russian fold tests use the lower-level `forceNarratorOnNonSpokenLines`).
+
+- [ ] **Step 1: Write the tests**
+
+Add inside `describe('narrator-default + foldMinorCast interaction', () => { … })`:
+
+```ts
+it('English: a character whose only lines are demoted narration folds out (intended)', () => {
+  const sentences = [
+    s(1, 'extra', 'A passer-by walked past.'),
+    s(2, 'extra', 'He paused at the corner.'),
+    s(3, 'extra', '“What?”'), // one real quoted line
+  ];
+  const chars = [
+    { id: 'narrator', name: 'Narrator', role: 'narrator', gender: 'neutral' },
+    { id: 'extra', name: 'Passer-by', role: 'Passerby', gender: 'male' },
+  ] as any;
+  const fixed = applyNarratorDefault(sentences); // 2 narration -> narrator, 1 quoted stays
+  const folded = foldMinorCast(chars, fixed, { minLines: 3 });
+  expect(folded.rewrites['extra']).toBe('unknown-male'); // 1 dialogue line < 3 -> folded (correct)
+});
+
+it('English: a character with >= minLines real quoted lines survives the fold', () => {
+  const sentences = [
+    s(1, 'stephanie', 'She was lost.'),
+    s(2, 'stephanie', 'She turned away.'),
+    s(3, 'stephanie', '“This way,”'),
+    s(4, 'stephanie', '“No, wait,”'),
+    s(5, 'stephanie', '“Here.”'),
+  ];
+  const chars = [
+    { id: 'narrator', name: 'Narrator', role: 'narrator', gender: 'neutral' },
+    { id: 'stephanie', name: 'Stephanie', role: 'Protagonist', gender: 'female' },
+  ] as any;
+  const fixed = applyNarratorDefault(sentences); // 2 narration -> narrator, 3 quoted stay
+  const folded = foldMinorCast(chars, fixed, { minLines: 3 });
+  expect(folded.characters.some((c) => c.id === 'stephanie')).toBe(true); // survived (3 quoted lines)
+  expect(folded.rewrites['stephanie']).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cd server && npx vitest run src/analyzer/narrator-default.test.ts` (run the whole file — do NOT use `-t "English"`; that substring also matches Task 2's "both-language" test and a zero-match typo would exit 0 and false-pass).
+Expected: PASS — these assert behavior already produced by Tasks 1-2 + `foldMinorCast` (a bare quoted line does not earn `proseTagged` protection, so `extra` with 1 line < `minLines` folds to `unknown-male`; `stephanie` with 3 quoted lines survives). If either FAILS, the fold interaction differs from the spec — STOP and reconcile against `fold-minor-cast.ts:303,356,362` before forcing the assertion.
+
+- [ ] **Step 3: Run the full analyzer test file**
+
+Run: `cd server && npx vitest run src/analyzer/narrator-default.test.ts`
+Expected: PASS — all blocks green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/src/analyzer/narrator-default.test.ts
+git commit -m "test(server): pin English cast-roster fold/drop effect of the narrator-default guard"
+```
+
+---
+
+## Task 4: Full verification + spec status
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-20-english-narrator-default-attribution-design.md` (frontmatter `status:` → `active`)
+
+- [ ] **Step 1: Run the full server suite**
+
+Run: `npm run test:server`
+Expected: PASS — no regressions across the analyzer/routes tests. (`narrator-default.test.ts` is in the main config, not the slow split — only `gemini.test.ts` is routed to `test:server-slow`.)
+
+- [ ] **Step 2: Confirm no stale CODE references remain**
+
+Run: `git grep -n "applyNonEnglishNarratorDefault" -- 'server/src/**'`
+Expected: **no output.** (The old name still appears intentionally in historical `docs/**` plans/feature notes — do NOT rewrite those.)
+
+- [ ] **Step 3: Run the full pre-push battery**
+
+Run: `npm run verify`
+Expected: PASS — typecheck + all tests + e2e + build green.
+
+- [ ] **Step 4: Mark the spec active**
+
+In `docs/superpowers/specs/2026-06-20-english-narrator-default-attribution-design.md`, change `- **Status:** draft` to `- **Status:** active`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-06-20-english-narrator-default-attribution-design.md
+git commit -m "docs(docs): mark narrator-default spec active after implementation"
+```
+
+---
+
+## Manual acceptance (after merge, on the GPU box)
+
+Not a code task — the live check that closes the loop:
+
+1. Re-run analysis on the _Scepter of the Ancients_ chapter that showed the Stephanie misattribution (Confirm view).
+2. Confirm the "She was lost." narration block is attributed to **narrator**, and the block surfaces as **one** "Low confidence" review stop (first sentence), not one per sentence.
+3. Confirm real dialogue (whichever quote style the manuscript uses) still carries its character voice.
+
+---
+
+## Self-Review (completed by plan author)
+
+- **Spec coverage:** Component 1 → Tasks 1-2; Component 2 (first-of-run clamp, both languages) → Task 2; corrected cast invariant → Task 3; drift-guard safety → Global Constraints + the `narrator`-is-valid fact (Task 2's output is only `narrator`/spoken ids); verification gates → Preflight + Task 4 Step 2; single-quote no-regression → Task 1 + Task 2 spoken-line assertions; scare-quote false-negative → Task 1 Step 1 test 3. Non-goals (no chunking, no prompt text, no setting) → nothing in the plan touches them.
+- **No broken commits:** the rename + importer update share one commit (Task 2) with a typecheck gate (Step 5). Verified the only `server/src` importer is `analysis.ts:13`.
+- **Placeholder scan:** none — every code step shows the actual code; every run step shows the command + expected result.
+- **Type consistency:** `applyNarratorDefault(sentences: SentenceOutput[]): SentenceOutput[]` used identically in Tasks 2, 3; `forceNarratorOnNonSpokenLines` kept unchanged; `NARRATOR_ID` is the existing module const.

--- a/docs/superpowers/plans/2026-06-20-english-narrator-default.md
+++ b/docs/superpowers/plans/2026-06-20-english-narrator-default.md
@@ -123,7 +123,7 @@ In `server/src/analyzer/narrator-default.test.ts`, change the import (lines 3-7)
 ```ts
 describe('applyNarratorDefault', () => {
   it('runs for English: demotes non-spoken character lines to narrator, leaves spoken lines', () => {
-    const en = [s(1, 'stephanie', 'She was lost.'), s(2, 'stephanie', '“Hard to starboard,”')];
+    const en = [s(1, 'stephanie', 'She was lost.'), s(2, 'stephanie', '"Hard to starboard,"')];
     expect(applyNarratorDefault(en).map((x) => x.characterId)).toEqual(['narrator', 'stephanie']);
   });
 
@@ -142,7 +142,7 @@ describe('applyNarratorDefault', () => {
     const seq = [
       s(1, 'stephanie', 'She was lost.'),       // override -> clamp 0.5
       s(2, 'stephanie', 'She turned away.'),     // override -> 0.9
-      s(3, 'stephanie', '“This way,”'),          // spoken -> reset
+      s(3, 'stephanie', '"This way,"'),          // spoken -> reset
       s(4, 'stephanie', 'She walked on.'),       // override -> clamp 0.5 (new run)
     ];
     const out = applyNarratorDefault(seq);
@@ -191,20 +191,24 @@ Expected: FAIL — `applyNarratorDefault` is not exported / not defined.
    languages 2026-06-20).
 
    The per-sentence attribution model mislabels third-person NARRATION as the
-   named character (e.g. "She was lost." → `stephanie`, or "Егор засунул руки в
-   карманы" → `egor`), which would read narration in that character's voice. The
-   spoken-vs-narration distinction is mechanical, so we decide it in code: any
-   sentence that is NOT a spoken line is forced to `narrator`. Runs for English
-   too (the model ignores the same rule in the skill prompt).
+   named character (e.g. "She was lost." -> stephanie), which would read
+   narration in that character's voice. The spoken-vs-narration distinction is
+   mechanical, so we decide it in code: any sentence that is NOT a spoken line is
+   forced to narrator. Runs for English too (the model ignores the same rule in
+   the skill prompt).
 
-   A "spoken line" = begins with a dialogue dash (—/–/-) or any opening quote
-   («/"/“/‘/'), OR contains a quoted span (double / guillemet / smart-single /
-   boundary-anchored straight-single). Everything else is narration. Demote-only
-   at the sentence level: it never reassigns a
-   quoted line and never promotes narrator→character (it does lower line counts,
-   which fold/reconcile consume downstream). Coverage is unaffected (the coverage
-   guard keys on sentence text, not characterId). Pure: no I/O, no model calls. */
+   A spoken line begins with a dialogue dash or any opening quote, OR contains a
+   quoted span (double / guillemet / smart-single / boundary-anchored
+   straight-single). Everything else is narration. Demote-only at the sentence
+   level: it never reassigns a quoted line and never promotes narrator->character
+   (it does lower line counts, which fold/reconcile consume downstream). Coverage
+   is unaffected (the coverage guard keys on sentence text, not characterId).
+   Pure: no I/O, no model calls. */
 ```
+
+**ASCII-only by design** — write this comment exactly as shown (no smart quotes, no
+Cyrillic, no arrows). The only non-ASCII in this file lives in the `isSpokenLine`
+regex, which Task 2 does NOT touch.
 
 2. Delete the `import { isNonEnglish } from '../tts/language.js';` line (line 21).
 3. Delete the JSDoc + `applyNonEnglishNarratorDefault` function (lines 48-57 — the doc is 48-50, the function 51-57).
@@ -297,7 +301,7 @@ it('English: a character whose only lines are demoted narration folds out (inten
   const sentences = [
     s(1, 'extra', 'A passer-by walked past.'),
     s(2, 'extra', 'He paused at the corner.'),
-    s(3, 'extra', '“What?”'), // one real quoted line
+    s(3, 'extra', '"What?"'), // one real quoted line
   ];
   const chars = [
     { id: 'narrator', name: 'Narrator', role: 'narrator', gender: 'neutral' },
@@ -312,9 +316,9 @@ it('English: a character with >= minLines real quoted lines survives the fold', 
   const sentences = [
     s(1, 'stephanie', 'She was lost.'),
     s(2, 'stephanie', 'She turned away.'),
-    s(3, 'stephanie', '“This way,”'),
-    s(4, 'stephanie', '“No, wait,”'),
-    s(5, 'stephanie', '“Here.”'),
+    s(3, 'stephanie', '"This way,"'),
+    s(4, 'stephanie', '"No, wait,"'),
+    s(5, 'stephanie', '"Here."'),
   ];
   const chars = [
     { id: 'narrator', name: 'Narrator', role: 'narrator', gender: 'neutral' },

--- a/docs/superpowers/specs/2026-06-20-english-narrator-default-attribution-design.md
+++ b/docs/superpowers/specs/2026-06-20-english-narrator-default-attribution-design.md
@@ -245,8 +245,13 @@ full-pipeline path where applicable):
    spoken and **not** demoted (documented false-negative — safe direction).
 5. **Both-language flag:** a non-English override now also carries the clamped
    confidence (previously it did not).
-6. **Drift-guard ordering pin:** guard demotions emit `'narrator'` and are not
-   counted by `reconcileSentenceCharacterIds` / do not trip `attributionDriftExceeded`.
+6. **Drift-guard ordering pin (covered transitively):** guard demotions emit
+   `'narrator'` — a valid roster id — so `reconcileSentenceCharacterIds` passes them
+   through uncounted and `attributionDriftExceeded` cannot trip. This invariant is
+   pinned by the existing reconcile test in `analysis.test.ts` (a sentence whose
+   characterId is in `validIds` is never demoted/counted), not by a new
+   guard-specific test — `applyNarratorDefault` only ever emits `'narrator'` or
+   leaves a spoken line unchanged, so the coverage is genuine.
 7. **One-stop-per-block:** a contiguous demoted run of N>1 sentences yields exactly
    one sentence with `confidence === 0.5`; a spoken line between two demoted runs
    resets the run so each block gets its own single flag.

--- a/docs/superpowers/specs/2026-06-20-english-narrator-default-attribution-design.md
+++ b/docs/superpowers/specs/2026-06-20-english-narrator-default-attribution-design.md
@@ -1,0 +1,307 @@
+# English narrator-default attribution guard — design
+
+- **Date:** 2026-06-20
+- **Status:** draft
+- **Area:** server / analyzer (stage-2 sentence attribution)
+- **Branch:** `feat/server-english-narrator-default`
+
+## Problem
+
+Listening to _Scepter of the Ancients_ (English, analyzed with the default
+Gemini/`gemma-4-31b-it` model), runs of close third-person narration are voiced
+in a character's voice instead of the narrator's. Confirmed from the Confirm-view
+screenshot: a block attributed to **Stephanie Edgley** that is pure narration
+_about_ her —
+
+> "She'd taken a wrong turn… and she didn't know where she was."
+> "She was lost."
+> "She turned away from the dead end, wanting to scream at herself in frustration…"
+> "She tried remembering their trail from the hall to the iron door…"
+
+None of these are spoken. The model sweeps POV narration (and unquoted interior
+thought / free indirect discourse) onto the dominant nearby character.
+
+### Why it happens
+
+The skill `skills/audiobook-sentence-attribution.md` **already** instructs the
+correct behaviour — "Narrative prose (no quotes) → `narrator`" (line 127),
+"third person about themself is still narration → `narrator`" (line 131),
+"Free indirect discourse stays with the narrator" (line 132). The model
+(especially the small default `gemma-4-31b-it`) **ignores rules it was given.**
+
+There is already a deterministic safety net for exactly this failure —
+`applyNonEnglishNarratorDefault` in `server/src/analyzer/narrator-default.ts` —
+but it is **gated to non-English manuscripts only** (it took Russian attribution
+from 0/6 to 6/6 with zero dialogue damage). English manuscripts get **no**
+narrator protection at all.
+
+### What it is NOT
+
+Chunk size is a **red herring** for this bug. The misattribution is a _local_
+pattern (the model latches onto the nearest dominant character name), so shrinking
+the stage-2 chunk window would not change it — "She was lost." next to Stephanie
+still gets pulled onto Stephanie in a small window too. Lowering the 9000-char
+chunk threshold would add Gemini cost and boundary seams without fixing this.
+This design does **not** touch chunking.
+
+## The structural tell
+
+Every misattributed line in the screenshot has **no quotation marks at all**. In
+English (as in the skill contract), a sentence with no quote and no dialogue-dash
+is narration regardless of whose name appears in it. The existing
+`isSpokenLine()` predicate already encodes this and already handles English
+straight (`"…"`) and smart (`"…"`) quotes.
+
+### Why the guard is safe — including across quote conventions (defense in depth)
+
+The skill contract guarantees every **spoken** split keeps its quote characters
+verbatim (`"Hard to starboard,"` → speaker; `he said,` → narrator) and "if a
+sentence has no embedded quotes at all, do NOT split it." So a quote-less row is,
+by contract, narrator material. Demoting quote-less character-rows to narrator
+**enforces** the contract rather than fighting it. A multi-sentence quoted
+utterance split into per-sentence rows that strips interior quotes is covered by
+the no-regression test against the Coalfall fixture.
+
+**The "demote-only is safe" claim holds only for the quote styles `isSpokenLine`
+recognizes** — anything it fails to see as spoken gets muted to narrator. The
+original predicate (`narrator-default.ts:31-38`) recognized **double quotes and
+guillemets only**, so **single-quote dialogue** (`'I'm lost,' she said.` — the
+standard UK / Irish convention) would have been muted. Since we ingest books from
+arbitrary `.env` locations and *will* hit every convention, the guard is hardened
+to recognize the full set up front (defense in depth) rather than gating on each
+book's style:
+
+- **All common opening quotes** at line-start — guillemet `«`, straight double
+  `"`, smart double `"`, smart single `'`, **straight single `'`** — plus the
+  dialogue dashes already handled. A **leading** quote is unambiguous: apostrophes
+  never appear at line-start, so straight `'` is safe here even though it is
+  ambiguous mid-word. And because the skill contract makes spoken splits
+  **quote-initial**, this leading-class check alone catches essentially all
+  contract-following dialogue in every convention.
+- **Embedded quoted spans**, including a **word-boundary-anchored** straight-single
+  matcher (opens after start/space/bracket/dash, closes before space/punctuation)
+  so mid-line dialogue is caught even when the model violates the splitting
+  contract — without colliding with apostrophes (`don't`, `O'Brien`, possessive
+  `dogs'`), whose `'` is never at a word boundary.
+
+The guard remains **demote-only**, so any residual misfire is in the safe
+direction: an unrecognized-as-spoken case is left as the model attributed it
+(a false-negative), never a silenced dialogue line.
+
+### Verification gates (do these before/while building)
+
+1. **Quote convention is no longer a blocker.** With the full opening-quote class
+   + boundary-aware embedded matcher, the guard handles double / smart-single /
+   straight-single / guillemet / dash conventions. Still worth a glance at a real
+   _Scepter_ dialogue line to confirm the live result, but it does not gate the
+   build.
+2. **Confirm `'narrator'` is in the valid-id set on BOTH routes** so guard
+   demotions stay clear of the `attribution_drift` counter (see _Interaction with
+   the drift guard_ below). Verified true at design time — main (`analysis.ts:1044-1045`,
+   `:3955`) and subset (`:4940`, narrator exempt at `fold-minor-cast.ts:343`);
+   re-confirm if that code moves.
+
+## Design
+
+Three components, all in `server/src/analyzer/narrator-default.ts` plus its
+single call site in `server/src/routes/analysis.ts`.
+
+### Component 1 — Generalize the guard to all languages + recognize single quotes
+
+Drop the non-English gate so the narrator-default runs for English too, **and**
+extend `isSpokenLine` to recognize single-quote dialogue so the guard does not
+mute real single-quoted dialogue:
+
+- Rename `applyNonEnglishNarratorDefault(sentences, language)` →
+  `applyNarratorDefault(sentences)`. The `language` argument is no longer needed
+  (it only drove the gate) — drop it, and **remove the now-dead `isNonEnglish`
+  import** (`narrator-default.ts:21`).
+- **There is exactly ONE call site** — `analysis.ts:1563`, inside the shared
+  `attributeChapterStage2` runner. Both the main route (`:3650`) and the subset
+  route (`:4805`) reach the guard through that single call, so full, subset,
+  cached, and resumed runs all get identical treatment for free. Update that one
+  call.
+- **Extend `isSpokenLine` to cover all common quote conventions (defense in
+  depth):**
+  - **Leading-quote class** → add smart single `'` and straight single `'`:
+    `/^[«"“‘']/`. Safe because a line-leading `'` is a dialogue opener, never a
+    mid-word apostrophe. This is the load-bearing change — spoken splits are
+    quote-initial by contract, so it catches dialogue in every convention.
+  - **Embedded smart single** `‘[^’]+’` — unambiguous (only matches with a real
+    U+2018 opener; a lone U+2019 apostrophe in `don't` cannot trigger it).
+  - **Embedded straight single, word-boundary-anchored** — opens after
+    start/whitespace/bracket/dash, closes before whitespace/punctuation:
+    `/(?:^|[\s([{<«—–-])'(?=\S)[^']*?\S'(?=[\s.,!?;:)\]}>»]|$)/`. This catches
+    mid-line dialogue (`She said 'go away' angrily.`) without matching apostrophes
+    (`don't`, `she'd`, `O'Brien`) or possessives (`dogs'`), whose `'` is never at a
+    word boundary. A straight-single span that *contains* an internal contraction
+    and has no leading quote (e.g. a mid-line `'I'm here'`) is not matched by the
+    embedded form — but the leading-class check covers the quote-initial case, and
+    a miss here is the safe direction (left as-is, never muted).
+
+**Invariant: sentence-level demote-only — but line counts (and therefore the
+cast roster) DO change.** A non-spoken sentence has its `characterId` set to
+`narrator`; a spoken line is returned unchanged; the guard never reassigns a
+quoted line to a different speaker and never promotes `narrator` → character.
+**However**, the guard runs **upstream** of `foldMinorCast` (`analysis.ts:1563`
+→ fold at `:3923`/`:4895`), and fold counts dialogue lines per character off the
+**already-demoted** list (`fold-minor-cast.ts:303,356,362`). So demoting a
+character's misattributed narration **lowers that character's line count**, which
+can fold them into the `unknown-male`/`unknown-female` bucket (`<minLines`, default
+3) or drop them from the cast entirely (`lines === 0`, unless `proseTagged` /
+role-protected). **This is accepted as more-accurate counting** — a "character"
+who only ever appears in narration is not a speaking role. (Explicitly-tagged
+speakers are already protected by `proseTagged` at `fold-minor-cast.ts:315,355`
+and by `recoverTaggedNarratorLines` at `analysis.ts:3885`.) The earlier
+"cannot change the cast" framing was wrong; the roster effect is intended and
+pinned by a test (Component 3, item 3a). No special protagonist protection is
+added (YAGNI — a book-wide-quoted protagonist keeps her slot; fold counts
+book-wide).
+
+**Always-on for English** — no setting or feature flag. It is deterministic, and
+every demoted block is reviewable via the low-confidence pill (Component 2).
+
+### Component 2 — Flag demoted blocks low-confidence (one stop per block, both languages)
+
+When the guard demotes a sentence whose model-assigned `characterId` was a **real
+character** (an actual override, not a line the model already called `narrator`),
+clamp its `confidence` to `Math.min(existing ?? 1, 0.5)` so the existing "Low
+confidence" pill (`< 0.75`) surfaces it in the Confirm-view checks.
+
+**Clamp only the FIRST override in each contiguous demoted run — not every
+sentence.** The Confirm-view low-confidence *navigator* filters per sentence
+(`manuscript.tsx:321`, `s.confidence < 0.75`), so clamping all four sentences of a
+narration block would create four navigator stops on (correctly) narrator lines.
+Clamping only the first gives the user **one review stop per demoted block**;
+consecutive same-id sentences already merge into a single pill
+(`manuscript.tsx:172`), so the visual remains one pill either way. Subsequent
+overrides in the same run are still demoted (correct attribution) but keep their
+model confidence (no extra navigator stop).
+
+Run semantics (a pure forward pass; reset the "clamped this run" flag on every
+spoken line):
+
+- `isSpokenLine(s)` → return `s` unchanged; reset the run flag.
+- non-spoken, `characterId === 'narrator'` already → return `s` unchanged (not an
+  override; does not consume the run's clamp slot).
+- non-spoken override, **first** in this run → `{ ...s, characterId: 'narrator',
+  confidence: Math.min(s.confidence ?? 1, 0.5) }`; set the run flag.
+- non-spoken override, later in the run → `{ ...s, characterId: 'narrator' }`
+  (demoted, confidence untouched).
+
+`Math.min` (not a flat assignment) so a first-of-run line the model already rated
+below 0.5 keeps its lower value. Applies to **both** language paths — the
+non-English guard previously overrode silently; it now flags too.
+
+**Keep `forceNarratorOnNonSpokenLines` field-preserving (id-only).** The clamp +
+first-of-run logic lives in `applyNarratorDefault`, NOT in the low-level force
+helper — so the helper's existing field-preservation test (`narrator-default.test.ts:65-69`,
+which asserts confidence survives demotion) stays green, and the two concerns
+stay cleanly separated.
+
+The model's **original** `characterId` is discarded on override — no audit trail
+of what a demoted line was attributed _from_. Accepted for v1 (the pill invites
+the user to re-check / re-attribute the block); revisit only if debugging demands.
+
+### Interaction with the attribution-drift guard (verified safe, both routes)
+
+`reconcileSentenceCharacterIds` (`analysis.ts:3957`) demotes and **counts** only
+ids that are NOT in the valid-id set, feeding the `>5%` `attributionDriftExceeded`
+abort. The guard runs upstream (`:1563`) and emits `'narrator'`, which **is** a
+valid roster id on **both** routes — main (`:3955`, narrator added at
+`:1044-1045`) and subset (`:4940`, narrator exempt in `foldMinorCast`
+`fold-minor-cast.ts:343` / `dropEvidencelessCast` `analysis.ts:404`). So guard
+demotions are invisible to the drift counter and cannot trip the abort
+(`:3979`/`:4964`) even on a near-100%-narrator chapter. `warnPerChapterDrift`
+(`:1098-1119`) likewise keys on reconcile's orphan-id demotions, **not** guard
+demotions, so the per-chapter WARN also stays quiet on heavy guard demotion — the
+intended outcome. This ordering is load-bearing: the guard must stay upstream of
+reconcile, and `'narrator'` must remain valid on both routes. A test pins it.
+
+### Component 3 — Tests
+
+In `server/src/analyzer/narrator-default.test.ts` (and the Coalfall
+full-pipeline path where applicable):
+
+1. **Scepter regression (English, double-quote):** a run of quote-less POV
+   narration attributed to a real character → all demoted to `narrator`; **only
+   the first** carries `confidence === 0.5`, the rest keep their model confidence
+   (one-stop-per-block).
+2. **No-regression, double-quote dialogue:** the Coalfall fixture's real, quoted
+   multi-sentence dialogue is **not** demoted; spoken lines keep their speaker
+   and confidence.
+3. **No-regression, SINGLE-quote dialogue (the critical one):** an English line
+   using smart single quotes (`'I'm lost,' she said.`) is **not** demoted. Coalfall
+   is double-quoted and does NOT exercise this — use a dedicated inline fixture.
+   This is the test that guards the Component-1 single-quote extension; without it
+   the suite gives false confidence.
+3a. **Cast-roster effect (the corrected invariant):** an English character whose
+   only "lines" are demoted narration drops below `minLines` and folds to the
+   unknown bucket / is dropped — the *intended* outcome (mirror the existing
+   non-English fold test `narrator-default.test.ts:89-124` in English). A
+   separately-quoted (book-wide) character keeps her slot.
+4. **Scare-quote narration is left alone:** a narration sentence containing an
+   embedded quoted span (`She read the sign that said "Exit".`) is treated as
+   spoken and **not** demoted (documented false-negative — safe direction).
+5. **Both-language flag:** a non-English override now also carries the clamped
+   confidence (previously it did not).
+6. **Drift-guard ordering pin:** guard demotions emit `'narrator'` and are not
+   counted by `reconcileSentenceCharacterIds` / do not trip `attributionDriftExceeded`.
+7. **One-stop-per-block:** a contiguous demoted run of N>1 sentences yields exactly
+   one sentence with `confidence === 0.5`; a spoken line between two demoted runs
+   resets the run so each block gets its own single flag.
+
+**Existing tests that change** (no test deleted without a replacement assertion):
+- `narrator-default.test.ts` "no-op for English / same array reference" — English
+  now runs the guard; replace with the new English behaviour.
+- The clamp lives in `applyNarratorDefault`, so the field-preservation test at
+  `:65-69` (on `forceNarratorOnNonSpokenLines`) **stays green** — that helper is
+  unchanged. The fold-interaction tests at `:89-124` stay valid (and 3a adds the
+  English counterpart).
+
+## Non-goals & documented limitations
+
+- No change to chunking / chunk-size thresholds.
+- No new prompt/skill text (the rules already exist and are ignored — see above).
+- No reassignment of mis-attributed _quoted_ dialogue to a different speaker
+  (a separate, harder "who is speaking" problem; not observed in this report).
+- No quote-span state machine unless the no-regression tests prove it necessary.
+- No user-facing setting/flag.
+- **Free-indirect / interior monologue → narrator is a deliberate product
+  choice, not an objective truth.** Unquoted interior thought ("Weren't there any
+  signs?") will read in the narrator's voice. The user confirmed this is desired;
+  it is a choice, and could be revisited if interior monologue should one day get
+  the POV character's voice.
+- **Scare-quote / title narration is a known false-negative.** A narration
+  sentence containing an embedded quoted span (a sign, a title, an air-quote) is
+  treated as spoken and left as the model attributed it. Safe direction (never a
+  _wrong_ demotion), but it means such lines are not auto-corrected.
+- **Straight-single-quote (`'`) dialogue IS now handled** (leading class +
+  boundary-aware embedded matcher — see Component 1). Residual limitation: a
+  *mid-line* straight-single span that contains an internal contraction and has
+  no leading quote is not matched by the embedded form — rare, and a miss is the
+  safe direction (left as-is, never muted).
+- **CJK corner-bracket quotes (`「…」`) are not recognized** by `isSpokenLine`.
+  Pre-existing (the non-English path already shipped with this gap); not widened
+  here, but now more visible since the guard runs for all languages. Out of scope.
+
+## Files touched
+
+- `server/src/analyzer/narrator-default.ts` — drop the language gate (and the
+  now-dead `isNonEnglish` import), extend `isSpokenLine` to the full opening-quote
+  class + boundary-aware embedded single-quote matcher, add the first-of-run
+  low-confidence clamp in `applyNarratorDefault` (keep `forceNarratorOnNonSpokenLines`
+  field-preserving), rename the applier.
+- `server/src/routes/analysis.ts` — update the single call site (`:1563`) to the
+  renamed applier.
+- `server/src/analyzer/narrator-default.test.ts` — new + updated tests.
+
+## Acceptance
+
+- The Stephanie-shaped narration block in _Scepter of the Ancients_ is attributed
+  to `narrator`, and the block surfaces as one "Low confidence" review stop
+  (first sentence flagged), not one per sentence.
+- No real dialogue is demoted — **double-quote** (Coalfall) **and smart
+  single-quote** dialogue both keep their speaker.
+- Quote convention of the actual _Scepter_ manuscript checked (verification gate 1).
+- `npm run verify` is green.

--- a/docs/superpowers/specs/2026-06-20-english-narrator-default-attribution-design.md
+++ b/docs/superpowers/specs/2026-06-20-english-narrator-default-attribution-design.md
@@ -1,7 +1,7 @@
 # English narrator-default attribution guard — design
 
 - **Date:** 2026-06-20
-- **Status:** draft
+- **Status:** active
 - **Area:** server / analyzer (stage-2 sentence attribution)
 - **Branch:** `feat/server-english-narrator-default`
 

--- a/server/src/analyzer/narrator-default.test.ts
+++ b/server/src/analyzer/narrator-default.test.ts
@@ -44,6 +44,24 @@ describe('isSpokenLine', () => {
     // to the model rather than forced to narrator — never the reverse.
     expect(isSpokenLine('На двери висела табличка «Закрыто».')).toBe(true);
   });
+  it('treats smart single-quote dialogue as spoken (UK/Irish typeset convention)', () => {
+    expect(isSpokenLine('‘I’m lost,’ she said.')).toBe(true); // leading U+2018
+    expect(isSpokenLine('She said ‘this way’ firmly.')).toBe(true); // embedded U+2018…U+2019
+  });
+  it('treats straight single-quote dialogue as spoken (leading + boundary-anchored embedded)', () => {
+    expect(isSpokenLine("'I'm lost,' she said.")).toBe(true); // leading straight '
+    expect(isSpokenLine("She said 'go away' angrily.")).toBe(true); // embedded, boundary-anchored
+    expect(isSpokenLine("'Aye, Captain,'")).toBe(true); // leading-only spoken split
+  });
+  it('a single quote used as an apostrophe does NOT make narration spoken', () => {
+    expect(isSpokenLine('She didn’t know where she was.')).toBe(false); // smart apostrophe (lone U+2019)
+    expect(isSpokenLine("She didn't know where she'd been.")).toBe(false); // straight apostrophes, word-internal
+    expect(isSpokenLine("The dogs' bones lay by the cats' bowls.")).toBe(false); // possessive apostrophes
+    expect(isSpokenLine("O'Brien walked past the corner.")).toBe(false); // name apostrophe
+  });
+  it('narration quoting a sign with straight double quotes still reads as spoken (documented false-negative)', () => {
+    expect(isSpokenLine('She read the sign that said "Exit".')).toBe(true);
+  });
 });
 
 describe('forceNarratorOnNonSpokenLines', () => {

--- a/server/src/analyzer/narrator-default.test.ts
+++ b/server/src/analyzer/narrator-default.test.ts
@@ -178,4 +178,37 @@ describe('narrator-default + foldMinorCast interaction', () => {
     const folded = foldMinorCast(chars, fixed, { minLines: 3 });
     expect(folded.rewrites['extra']).toBe('unknown-male'); // 1 dialogue line < 3 -> folded (correct)
   });
+
+  it('English: a character whose only lines are demoted narration folds out (intended)', () => {
+    const sentences = [
+      s(1, 'extra', 'A passer-by walked past.'),
+      s(2, 'extra', 'He paused at the corner.'),
+      s(3, 'extra', '"What?"'), // one real quoted line
+    ];
+    const chars = [
+      { id: 'narrator', name: 'Narrator', role: 'narrator', gender: 'neutral' },
+      { id: 'extra', name: 'Passer-by', role: 'Passerby', gender: 'male' },
+    ] as any;
+    const fixed = applyNarratorDefault(sentences); // 2 narration -> narrator, 1 quoted stays
+    const folded = foldMinorCast(chars, fixed, { minLines: 3 });
+    expect(folded.rewrites['extra']).toBe('unknown-male'); // 1 dialogue line < 3 -> folded (correct)
+  });
+
+  it('English: a character with >= minLines real quoted lines survives the fold', () => {
+    const sentences = [
+      s(1, 'stephanie', 'She was lost.'),
+      s(2, 'stephanie', 'She turned away.'),
+      s(3, 'stephanie', '"This way,"'),
+      s(4, 'stephanie', '"No, wait,"'),
+      s(5, 'stephanie', '"Here."'),
+    ];
+    const chars = [
+      { id: 'narrator', name: 'Narrator', role: 'narrator', gender: 'neutral' },
+      { id: 'stephanie', name: 'Stephanie', role: 'Protagonist', gender: 'female' },
+    ] as any;
+    const fixed = applyNarratorDefault(sentences); // 2 narration -> narrator, 3 quoted stay
+    const folded = foldMinorCast(chars, fixed, { minLines: 3 });
+    expect(folded.characters.some((c) => c.id === 'stephanie')).toBe(true); // survived (3 quoted lines)
+    expect(folded.rewrites['stephanie']).toBeUndefined();
+  });
 });

--- a/server/src/analyzer/narrator-default.test.ts
+++ b/server/src/analyzer/narrator-default.test.ts
@@ -3,7 +3,7 @@ import type { SentenceOutput } from '../handoff/schemas.js';
 import {
   isSpokenLine,
   forceNarratorOnNonSpokenLines,
-  applyNonEnglishNarratorDefault,
+  applyNarratorDefault,
 } from './narrator-default.js';
 import { foldMinorCast } from './fold-minor-cast.js';
 
@@ -87,20 +87,58 @@ describe('forceNarratorOnNonSpokenLines', () => {
   });
 });
 
-describe('applyNonEnglishNarratorDefault', () => {
-  const input = [s(1, 'egor', 'Егор побежал.'), s(2, 'woman', '— Стой!')];
-  it('applies the heuristic for non-English languages', () => {
-    expect(applyNonEnglishNarratorDefault(input, 'ru').map((x) => x.characterId)).toEqual(['narrator', 'woman']);
-    expect(applyNonEnglishNarratorDefault(input, 'ru-RU').map((x) => x.characterId)).toEqual(['narrator', 'woman']);
+describe('applyNarratorDefault', () => {
+  it('runs for English: demotes non-spoken character lines to narrator, leaves spoken lines', () => {
+    const en = [s(1, 'stephanie', 'She was lost.'), s(2, 'stephanie', '"Hard to starboard,"')];
+    expect(applyNarratorDefault(en).map((x) => x.characterId)).toEqual(['narrator', 'stephanie']);
   });
-  it('is a no-op for English and for missing language (returns the same array reference)', () => {
-    expect(applyNonEnglishNarratorDefault(input, 'en')).toBe(input);
-    expect(applyNonEnglishNarratorDefault(input, undefined)).toBe(input);
+
+  it('clamps only the FIRST override in a contiguous demoted run to 0.5', () => {
+    const run = [
+      s(1, 'stephanie', 'She was lost.'),
+      s(2, 'stephanie', 'She turned away from the dead end.'),
+      s(3, 'stephanie', 'She tried to remember the way.'),
+    ];
+    const out = applyNarratorDefault(run);
+    expect(out.map((x) => x.characterId)).toEqual(['narrator', 'narrator', 'narrator']);
+    expect(out.map((x) => x.confidence)).toEqual([0.5, 0.9, 0.9]);
   });
-  it('leaves English characterIds unchanged in VALUE, not just reference (guards a gate regression)', () => {
-    const en = [s(1, 'halloran', 'The wind had turned.'), s(2, 'halloran', '"Hard to starboard,"')];
-    const out = applyNonEnglishNarratorDefault(en, 'en');
-    expect(out.map((x) => x.characterId)).toEqual(['halloran', 'halloran']);
+
+  it('a spoken line resets the run so each demoted block gets its own single flag', () => {
+    const seq = [
+      s(1, 'stephanie', 'She was lost.'),       // override -> clamp 0.5
+      s(2, 'stephanie', 'She turned away.'),     // override -> 0.9
+      s(3, 'stephanie', '"This way,"'),          // spoken -> reset
+      s(4, 'stephanie', 'She walked on.'),       // override -> clamp 0.5 (new run)
+    ];
+    const out = applyNarratorDefault(seq);
+    expect(out.map((x) => x.characterId)).toEqual(['narrator', 'narrator', 'stephanie', 'narrator']);
+    expect(out.map((x) => x.confidence)).toEqual([0.5, 0.9, 0.9, 0.5]);
+  });
+
+  it('leaves pre-existing narrator lines untouched and they do not consume the clamp slot', () => {
+    const seq = [
+      s(1, 'narrator', 'The hall was dark.'),  // already narrator
+      s(2, 'stephanie', 'She was lost.'),       // first override of the run -> 0.5
+    ];
+    const out = applyNarratorDefault(seq);
+    expect(out[0]).toBe(seq[0]); // unchanged reference
+    expect(out[1].characterId).toBe('narrator');
+    expect(out[1].confidence).toBe(0.5);
+  });
+
+  it('clamp is min, not overwrite: a model confidence already below 0.5 stays', () => {
+    const low = [
+      { id: 1, chapterId: 1, characterId: 'stephanie', text: 'She was lost.', confidence: 0.3 } as SentenceOutput,
+    ];
+    expect(applyNarratorDefault(low)[0].confidence).toBe(0.3);
+  });
+
+  it('demotes non-English narration too AND now flags it (both-language flag)', () => {
+    const ru = [s(1, 'egor', 'Егор побежал.'), s(2, 'woman', '— Стой!')];
+    const out = applyNarratorDefault(ru);
+    expect(out.map((x) => x.characterId)).toEqual(['narrator', 'woman']);
+    expect(out[0].confidence).toBe(0.5); // previously silent, now flagged
   });
 });
 

--- a/server/src/analyzer/narrator-default.ts
+++ b/server/src/analyzer/narrator-default.ts
@@ -1,24 +1,22 @@
-/* Deterministic narrator-default heuristic (plan 221, Wave A).
+/* Deterministic narrator-default heuristic (plan 221 Wave A; generalized to all
+   languages 2026-06-20).
 
-   The per-sentence attribution model — especially on non-Latin scripts —
-   mislabels third-person NARRATION as the named character (e.g. "Егор засунул
-   руки в карманы" → `egor`), which would read narration in that character's
-   voice. The spoken-vs-narration distinction is mechanical, so we decide it in
-   code instead of trusting the model: any sentence that is NOT a spoken line is
-   forced to `narrator`.
+   The per-sentence attribution model mislabels third-person NARRATION as the
+   named character (e.g. “She was lost.” -> stephanie), which would read
+   narration in that character's voice. The spoken-vs-narration distinction is
+   mechanical, so we decide it in code: any sentence that is NOT a spoken line is
+   forced to narrator. Runs for English too (the model ignores the same rule in
+   the skill prompt).
 
-   A "spoken line" = begins with a dialogue dash (—/–/-) or an opening quote
-   («/"/“), OR contains a quoted span. Everything else is narration. This
-   deliberately LEAVES dashed narrative tags ("— сказал юноша") to the model +
-   language preamble (they look spoken), and never touches dialogue lines, so it
-   cannot break speaker attribution — it only ever changes a non-spoken line to
-   `narrator`. Coverage is unaffected (the coverage guard keys on sentence text,
-   not characterId). Empirically (server/repro-heuristic.mts) this took the
-   model's narration-block correctness from 0–1/6 to 6/6 on every run with zero
-   dialogue damage. Pure: no I/O, no model calls. */
+   A spoken line begins with a dialogue dash or any opening quote, OR contains a
+   quoted span (double / guillemet / smart-single / boundary-anchored
+   straight-single). Everything else is narration. Demote-only at the sentence
+   level: it never reassigns a quoted line and never promotes narrator->character
+   (it does lower line counts, which fold/reconcile consume downstream). Coverage
+   is unaffected (the coverage guard keys on sentence text, not characterId).
+   Pure: no I/O, no model calls. */
 
 import type { SentenceOutput } from '../handoff/schemas.js';
-import { isNonEnglish } from '../tts/language.js';
 
 const NARRATOR_ID = 'narrator';
 
@@ -48,13 +46,24 @@ export function forceNarratorOnNonSpokenLines(sentences: SentenceOutput[]): Sent
   );
 }
 
-/** Apply the narrator-default heuristic only for non-English books. For English
-    (and missing language) returns the SAME array reference (no-op) so the
-    English path is byte-identical. */
-export function applyNonEnglishNarratorDefault(
-  sentences: SentenceOutput[],
-  language: string | undefined,
-): SentenceOutput[] {
-  if (!isNonEnglish(language ?? '')) return sentences;
-  return forceNarratorOnNonSpokenLines(sentences);
+/** Apply the narrator-default heuristic for ALL languages. Each non-spoken
+    sentence whose model-assigned characterId is a real character is demoted to
+    `narrator`; the FIRST such override in each contiguous demoted run has its
+    confidence clamped to <= 0.5 so the Confirm-view low-confidence navigator
+    gets one review stop per block (not one per sentence). Spoken lines and
+    pre-existing-narrator lines are returned by reference, untouched. Pure. */
+export function applyNarratorDefault(sentences: SentenceOutput[]): SentenceOutput[] {
+  let clampedThisRun = false;
+  return sentences.map((s) => {
+    if (isSpokenLine(s.text)) {
+      clampedThisRun = false;
+      return s;
+    }
+    if (s.characterId === NARRATOR_ID) return s; // already narrator — not an override
+    if (!clampedThisRun) {
+      clampedThisRun = true;
+      return { ...s, characterId: NARRATOR_ID, confidence: Math.min(s.confidence ?? 1, 0.5) };
+    }
+    return { ...s, characterId: NARRATOR_ID };
+  });
 }

--- a/server/src/analyzer/narrator-default.ts
+++ b/server/src/analyzer/narrator-default.ts
@@ -2,7 +2,7 @@
    languages 2026-06-20).
 
    The per-sentence attribution model mislabels third-person NARRATION as the
-   named character (e.g. “She was lost.” -> stephanie), which would read
+   named character (e.g. "She was lost." -> stephanie), which would read
    narration in that character's voice. The spoken-vs-narration distinction is
    mechanical, so we decide it in code: any sentence that is NOT a spoken line is
    forced to narrator. Runs for English too (the model ignores the same rule in

--- a/server/src/analyzer/narrator-default.ts
+++ b/server/src/analyzer/narrator-default.ts
@@ -32,8 +32,11 @@ export function isSpokenLine(text: string): boolean {
   const t = (text ?? '').trimStart();
   if (!t) return false;
   if (/^(&mdash;|&ndash;|[-–—])/i.test(t)) return true; // dash entities + literal dashes
-  if (/^[«"“]/.test(t)) return true; // opening guillemet / straight / smart quote
-  if (/«[^»]+»/.test(t) || /"[^"]+"/.test(t) || /“[^”]+”/.test(t)) return true; // embedded quoted span
+  if (/^[«"“‘']/.test(t)) return true; // any opening quote: guillemet / straight+smart double / smart+straight single
+  if (/«[^»]+»/.test(t) || /"[^"]+"/.test(t) || /“[^”]+”/.test(t) || /‘[^’]+’/.test(t)) return true; // embedded span: guillemet / straight+smart double / smart single
+  // embedded STRAIGHT single, word-boundary-anchored: opens after start/space/bracket/dash, closes before space/punct.
+  // Avoids apostrophes (don't, O'Brien, dogs') whose ' is never at a word boundary.
+  if (/(?:^|[\s([{<«—–-])'(?=\S)[^']*?\S'(?=[\s.,!?;:)\]}>»]|$)/.test(t)) return true;
   return false;
 }
 

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -10,7 +10,7 @@ import type { Request, Response } from '../http.js';
 import { getOrHydrateManuscript } from '../store/manuscripts.js';
 import { safeBookId } from '../util/safe-id.js';
 import { runStage1ChapterChunked, resolveStage1ChunkCharBudget } from '../analyzer/stage1-chunk.js';
-import { applyNonEnglishNarratorDefault } from '../analyzer/narrator-default.js';
+import { applyNarratorDefault } from '../analyzer/narrator-default.js';
 import { makeThrottledHeartbeat } from './analysis-heartbeat.js';
 import { type AnalyzerSelection, type Analyzer, type StageCall } from '../analyzer/index.js';
 import {
@@ -1555,12 +1555,11 @@ async function attributeChapterStage2(opts: {
     onChunk: opts.onChunk,
     onSectionDone: opts.onSectionDone,
   });
-  /* plan 221 Wave A — non-English narrator-default heuristic. The model
-     mislabels third-person narration as a character on non-Latin scripts;
-     force non-spoken sentences to `narrator`. No-op for English. Runs AFTER
-     coverage (coverage keys on text, not characterId), so the verdict is
-     unchanged. */
-  result.sentences = applyNonEnglishNarratorDefault(result.sentences, opts.stageCall.language);
+  /* Deterministic narrator-default: force non-spoken sentences to `narrator`
+     and flag the first of each demoted block low-confidence. Runs for ALL
+     languages, AFTER coverage (coverage keys on text, not characterId, so the
+     verdict is unchanged) and UPSTREAM of fold/reconcile. */
+  result.sentences = applyNarratorDefault(result.sentences);
   return result;
 }
 


### PR DESCRIPTION
## Summary
Generalizes the deterministic stage-2 narrator-default attribution guard from non-English-only to **all languages**, so English manuscripts no longer voice close third-person narration in a character's voice (the *Scepter of the Ancients* "She was lost." → Stephanie misattribution).

- `applyNonEnglishNarratorDefault` → `applyNarratorDefault` — runs for every language; English gate dropped.
- `isSpokenLine` hardened to all common quote conventions (US double, UK/Irish single, guillemet, dash) with a **word-boundary-anchored straight-single** matcher that ignores apostrophes/possessives (`don't`, `O'Brien`, `dogs'`) — defense in depth for arbitrarily-sourced books.
- First sentence of each demoted block flagged low-confidence (one Confirm-view review stop per block, not per sentence); both language paths.
- Demote-only at the sentence level; lowering line counts feeds fold/reconcile (intended; drift-guard safety preserved on both the main and subset routes).

Spec: `docs/superpowers/specs/2026-06-20-english-narrator-default-attribution-design.md`
Plan: `docs/superpowers/plans/2026-06-20-english-narrator-default.md`

## Test plan
- 23 unit tests in `server/src/analyzer/narrator-default.test.ts` — quote-convention recognition incl. apostrophe-safety; clamp-first-of-run; run reset on spoken; min-not-overwrite; both-language flag; English fold/drop roster effect.
- Full `npm run verify` green (typecheck + all unit/integration + e2e + e2e:visual + build).
- Spec adversarially reviewed ×2, plan reviewed ×2, whole-branch final review: READY TO MERGE.

Closes #954

🤖 Generated with [Claude Code](https://claude.com/claude-code)