### PR TITLE
docs(docs): note narrator-default heuristic generalized to all languages

### DIFF
--- a/docs/features/162-fs2-multilanguage.md
+++ b/docs/features/162-fs2-multilanguage.md
@@ -112,6 +112,8 @@ language param.
 
 ### Non-English narrator-default heuristic (plan 221 Wave A)
 
+> **Update (2026-06-20, bug #954 / PR #955):** this heuristic now runs for ALL languages — renamed `applyNarratorDefault` with the `isNonEnglish` gate removed — recognizing every common quote convention (incl. boundary-anchored straight-single, apostrophe-safe) and flagging the first sentence of each demoted block low-confidence. The English path is no longer a byte-identical no-op. Full design: `docs/superpowers/specs/2026-06-20-english-narrator-default-attribution-design.md`.
+
 The per-sentence attribution model — especially on non-Latin scripts —
 mislabels third-person NARRATION as the named character (e.g. "Егор засунул
 руки в карманы" → `egor`), which would read narration in that character's

--- a/docs/features/221-multilingual-attribution-gemma-and-cast-merge.md
+++ b/docs/features/221-multilingual-attribution-gemma-and-cast-merge.md
@@ -162,6 +162,8 @@ preamble guard, rather than guard-text-only:
    verdict is unchanged; English is a byte-identical no-op. Empirically (the
    model's narration correctness 0–1/6 → a deterministic 6/6 every run, dialogue
    untouched). See [162](162-fs2-multilanguage.md) for the full write-up.
+
+> **Update (2026-06-20, bug #954 / PR #955):** the narrator-default heuristic was generalized to ALL languages — `applyNonEnglishNarratorDefault` renamed `applyNarratorDefault`, the `isNonEnglish` gate dropped — to fix English close-third-person narration being voiced as the POV character. `isSpokenLine` now recognizes all common quote conventions (US double, UK/Irish single, guillemet, dash; a word-boundary-anchored straight-single matcher ignores apostrophes/possessives), and the first sentence of each demoted block is flagged low-confidence (both language paths). English is therefore NO LONGER a no-op. Design: `docs/superpowers/specs/2026-06-20-english-narrator-default-attribution-design.md`.
 2. **Russian dash-dialogue tag guard** in `languagePreamble`
    (`server/src/analyzer/gemini.ts`): the one class the heuristic deliberately
    leaves to the model is the dashed narrative TAG (`— сказал юноша`,


### PR DESCRIPTION
## Summary
Follow-up to #955: plans **221** (Wave A) and **162** described the narrator-default attribution guard as non-English-only with "English is a byte-identical no-op" — now false. PR #955 generalized it to all languages, all quote conventions (incl. boundary-anchored straight-single), and a per-block low-confidence flag. Adds an update callout to each plan pointing at the design spec.

## Test plan
Docs-only. `npm run verify` green on push (no code touched).

Refs #954

🤖 Generated with [Claude Code](https://claude.com/claude-code)