### PR TITLE
feat(server,frontend): Russian cast de-duplication + tone population

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -170,6 +170,18 @@ Sub-groups and the items within them are ranked top = highest priority.
 - _Benefit (user):_ precise coexistence on bigger cards without edge-case OOMs — once the cost table is measured rather than guessed.
 _Full detail + acceptance:_ plan [222](features/222-gpu-residency-and-analysing-honesty.md) "Out of scope" + spec `docs/superpowers/specs/2026-06-16-vram-budget-aware-gpu-policy-design.md` §7 · drafted plan `docs/superpowers/plans/2026-06-16-wave4-vram-mb-accounting.md` · [#845](https://github.com/dudarenok-maker/Castwright/issues/845).
 
+#### `srv-44` — Thread dedup rewrite into reuse-guard/series-link seam on re-analysis ([#960](https://github.com/dudarenok-maker/Castwright/issues/960))
+
+- _What:_ At the analysis finalization sites, `seedReuseGuardsFromPriorCast`/`linkSeriesReuseAtAnalysis` still use the **raw** prior cast; the dedup id remap (`applyRewriteToPriorCast`) is threaded only into the merge call. Bounded gap: the link pass runs in the stage-1 phase before dedup exists, and is a no-op for the only safe re-analysis path (no designed voices / series links) — so it bites only a re-analysis of a voiced/series book.
+- _Benefit (technical):_ designed-voice / series-reuse linkage rides the dedup remap, closing the last bounded gap in the voice-carry-forward fix.
+_Full detail + acceptance:_ [#960](https://github.com/dudarenok-maker/Castwright/issues/960) · follow-up of branch `fix/server-ru-cast-dedup-and-tone` (plan [221](features/221-multilingual-attribution-gemma-and-cast-merge.md) Wave C).
+
+#### `srv-45` — Gemini slow-tier regression test for two-schema `runStage` tone handling ([#961](https://github.com/dudarenok-maker/Castwright/issues/961))
+
+- _What:_ Task 7's tolerant-validation contract (a tone-less stage-1 response doesn't fail a chapter) is unit-tested on the Ollama path only; add a `gemini.test.ts` (slow tier) assertion for the shipped cloud default engine.
+- _Benefit (technical):_ locks the contract on the engine users actually default to (gemini-3.1-flash-lite).
+_Full detail + acceptance:_ [#961](https://github.com/dudarenok-maker/Castwright/issues/961).
+
 #### `side-17` — Sidecar engine-dep major bump (torch · transformers · huggingface_hub · …) ([#893](https://github.com/dudarenok-maker/Castwright/issues/893))
 
 - _What:_ The Python TTS sidecar engine deps are ~24 behind, but the heavy ones are **safety-pinned** (torch 2.11→2.12 = cu130 driver bump + voids the CVE-cleared cu128 pin; transformers 4.57→5.12 breaks the `<5.0` Qwen/Kokoro/Coqui lockstep; huggingface_hub 0.36→1.19 major; kokoro-onnx, onnxruntime-gpu, fastapi/starlette/uvicorn majors). Audited in deps round 4 (plan 224) and deferred — each is a GPU-box + golden-audio validated spike, not hygiene. Supersedes the closed #883 (torch CVE bump) with a full engine-dep sweep.

--- a/docs/features/221-multilingual-attribution-gemma-and-cast-merge.md
+++ b/docs/features/221-multilingual-attribution-gemma-and-cast-merge.md
@@ -10,8 +10,19 @@ owner: null
 > guard); **Wave D shipped** (#856, localized cast buckets); **Wave B core already
 > works** via #851's model picker + the existing `defaultAnalysisModel` setting
 > (set gemma in Account → Model settings — admin-selectable, no hardcoding; only
-> per-language auto-default would be net-new, optional); **Wave C OBSOLETE** —
-> re-measured 2026-06-17: plan 219 already deduplicates (17 chars, 0 dups);
+> per-language auto-default would be net-new, optional); **Wave C RE-OPENED + SHIPPED**
+> (2026-06-20, branch `fix/server-ru-cast-dedup-and-tone`) — the "OBSOLETE, 0 dups"
+> re-measure was a **false negative** (a single stochastic gemma probe got consistent
+> ids; a real run drifts). User hit byte-identical duplicate display names with
+> transliterated ids (`ольга`/`olga`, `ilya`/`илья`, `semen`/`семен`,
+> `тигренок`/`tigrenok`) on a real gemma4-e4b run. Fixed model-independently via a
+> finalization `dedupeRosterByName` pass (Tier-1 exact + Tier-2a full-vs-short
+> auto-merge + Tier-2b diminutive SUGGESTIONS), canonical id = `safeId(name)`, with
+> a voiceState-ranked prior-cast remap so designed voices follow the merge, plus a
+> two-schema `runStage` (required-tone GRAMMAR / tolerant VALIDATION) + deterministic
+> `fillToneFromAttributes` backstop closing the tone-0% root cause (tone was
+> `.optional()` in the constrained-decoding schema). Follow-ups: srv-44 #960,
+> srv-45 #961. Design+plan: `docs/superpowers/{specs,plans}/2026-06-20-russian-cast-dedup-and-tone*`.
 > **Wave E implemented** (2026-06-19, `fix/server-ru-cast-tone-localization-aliases`):
 > Russian cast-field under-population — tone 0%→100% + localized role/description via
 > a `languagePreamble` cast-field guard, plus same-id alias capture in the roster merge.
@@ -202,7 +213,29 @@ Also note the residency landscape changed: **plan 222 / #840** shipped a GPU-res
 > - **Wave C: RE-MEASURE on current `main` FIRST.** The duplicate set in Defect 1 below is **pre-219** (transliteration removed in 219; ids are now Cyrillic via `unicodeKebab`; roster threaded into later chunks). The real residual must be re-collected before designing the tiering. Use `normaliseNameKey` (`safe-id.ts:76`), not `normaliseForMatch` (no combining-mark stripping). Run the fuzzy merge **once at finalisation** (analysis.ts:~3795), NOT inside the per-rebuild `mergeRosterChapter` (order-sensitive live-SSE path — keep that exact-id). **Tier-1 (exact normalized-name) only for v1** — Russian patronymic/surname token-sharing makes Tier-2 false-merge-prone (219 notes the 4B smears surnames). Russian `DIALOGUE_VERBS` extension needs the `.mjs` drift-copy + verb-initial word-order pattern, and may be redundant with Wave A.
 > - **Wave D:** thread `language` through `previewFoldForLiveView` AND the exported `buildInterimCast` (signature change + 6 preview call sites) or live/interim buckets show English then flip; `cast-merge.ts:84` `makeBucket` has no book language in scope — resolve it from the book record. Russian descriptor detection (`isDescriptorName`) is English-structured (no "the", inflection) → partial coverage for v1, state the limitation.
 
-### Wave C — name/alias-aware cross-chapter merge (Defect 1) — ❌ OBSOLETE (superseded by plan 219)
+### Wave C — name/alias-aware cross-chapter merge (Defect 1) — ✅ RE-OPENED + SHIPPED 2026-06-20 (branch `fix/server-ru-cast-dedup-and-tone`)
+
+> **The "OBSOLETE" verdict below was a FALSE NEGATIVE.** It rested on one stochastic
+> gemma4-e4b probe run that happened to emit consistent Cyrillic ids. A real
+> full-book run on the SAME model drifts: 2026-06-20 the user's persisted `cast.json`
+> showed duplicate pairs, each a byte-identical display name with one Cyrillic-kebab
+> id + one Latin-transliterated id (`ольга`/`olga`, `ilya`/`илья`, `semen`/`семен`,
+> `тигренок`/`tigrenok`). Root cause is model-INDEPENDENT: the analyzer's emitted
+> character `id` is trusted verbatim and `mergeRosterChapter` merges by exact id only.
+> **Shipped fix** (subagent-driven TDD, 12 tasks, 3× adversarially reviewed spec +
+> opus whole-branch review): a finalization `dedupeRosterByName` pass — **Tier-1**
+> exact normalized-name auto-merge (gender-gated, narrator-safe, canonical id =
+> `safeId(name)`); **Tier-2a** full-vs-short token-subset auto-merge (single-superset
+> gate); **Tier-2b** diminutive → SUGGESTION only (sibling `cast-merge-suggestions.json`
+> + list/accept/dismiss routes + cast-review cards) — with a `kind:'dedup'` journal,
+> sentence-id rewrite + transitive `composeRewrites`, and a voiceState-ranked
+> `applyRewriteToPriorCast` so designed voices follow `olga→ольга` (the carry-forward
+> BLOCKER). Tone-0% (the other defect) fixed via two-schema `runStage` +
+> `fillToneFromAttributes`. Design+plan: `docs/superpowers/{specs,plans}/2026-06-20-russian-cast-dedup-and-tone*`.
+> Follow-ups: srv-44 [#960](https://github.com/dudarenok-maker/Castwright/issues/960),
+> srv-45 [#961](https://github.com/dudarenok-maker/Castwright/issues/961).
+
+_Obsolete-verdict evidence retained for history:_
 
 **Re-measured 2026-06-17 on current `main` (real Phase-0, all 9 chapters, gemma4-e4b): 17 distinct characters, ZERO same-person duplicate groups.** Plan 219 (transliteration removed → Cyrillic `unicodeKebab` ids + accumulated roster threaded into each chapter's detection prompt) already deduplicates the cast. The 43-character pre-219 duplicate set (egor/yegor, boris-ignatyevich/boris-ignatievich/shef, anton/anton-gorodetsky…) no longer occurs — a single `anton` ("Антон Сергеевич Городецкий"), single `egor`, single `boris-ignatiyevich`, etc. **Do NOT build the cross-chapter fuzzy merge — it would solve an already-fixed problem** (the adversarial-review BLOCKER on this was confirmed). Residuals (NOT dedup; possible small follow-ups): stage-1 occasionally emits schema-invalid JSON on a chapter (bare probe lost ch1/ch7; the real `runStage1WithRosterGuard` + parse-retry likely recovers); cosmetic id↔name model quirks.
 

--- a/docs/superpowers/plans/2026-06-20-russian-cast-dedup-and-tone.md
+++ b/docs/superpowers/plans/2026-06-20-russian-cast-dedup-and-tone.md
@@ -1,0 +1,942 @@
+# Russian Cast De-duplication + Tone Population — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Collapse same-person duplicate cast entries that arise from the analyzer model emitting divergent transliterated character ids, and guarantee every character ends analysis with a populated tone profile.
+
+**Architecture:** A pure, finalization-stage `dedupeRosterByName` pass (Tier-1 exact-name + Tier-2a gated full-vs-short auto-merge + Tier-2b diminutive suggestions) mirrors `foldMinorCast`'s `{ characters, rewrites }` shape and runs *before* the fold; its rewrites are applied to sentences, threaded into the prior-cast voice carry-forward (so designed voices follow id remaps), and journalled under a new `kind:'dedup'`. Tone is handled by a two-schema `runStage` (grammar requests tone, validation tolerates its absence) plus a deterministic `fillToneFromAttributes` backstop.
+
+**Tech Stack:** TypeScript (Node 20 ESM), Zod v4, Vitest (server, node env), React 18 + RTK (frontend), Playwright (e2e).
+
+**Source spec:** `docs/superpowers/specs/2026-06-20-russian-cast-dedup-and-tone-design.md` (approved, 3× adversarially reviewed).
+
+## Global Constraints
+
+- **No hex literals in component code** — design tokens are CSS custom properties (`src/styles.css`).
+- **OpenAPI is the type source of truth** — character/sentence types come from generated `src/lib/api-types.ts`; never hand-write them. After any `openapi.yaml` edit run `npm run openapi:types`.
+- **RTK reducers mutate via Immer drafts** — do not rewrite to spreads.
+- **Every change ships paired automated tests** (CLAUDE.md testing discipline). Bug-shaped changes ship a regression test that fails before, passes after.
+- **Commit convention:** `<type>(<scope>): <subject>` (validated by husky `commit-msg`). Scope here is mostly `server`, with `frontend` for the UI task.
+- **Branch:** all work lands on `fix/server-ru-cast-dedup-tone` (already cut from `main`).
+- **Server tests:** `cd server && npm run test` (Vitest, node env, colocated `*.test.ts`). The Gemini analyzer + routes test files are the slow tier (`npm run test:server-slow`).
+- **Persisted `characterSchema.tone` stays `optional()`** — never make it required (old `cast.json` files must validate). Only a *new* analyzer-grammar schema marks tone required.
+- **Narrator is `id === 'narrator'`** — never `color === 'narrator'` (that mis-matches both ways).
+
+---
+
+## File structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `server/src/store/cast-merges.ts` | add `kind:'dedup'`, `replaceDedupEntries`, `buildDedupJournalEntries` | 1 |
+| `server/src/analyzer/roster-merge-fields.ts` (new) | shared character field-merge helper (extracted from `mergeRosterChapter`) | 2 |
+| `server/src/analyzer/ru-diminutives.ts` (new) | curated Russian diminutive↔canonical table + lookup | 3 |
+| `server/src/analyzer/roster-dedup.ts` (new) | `dedupeRosterByName` (Tier-1/2a/2b) + `MergeSuggestion` | 4 |
+| `server/src/analyzer/fill-tone.ts` (new) | `fillToneFromAttributes` (bilingual keyword→axis) | 5 |
+| `server/src/handoff/schemas.ts` | `requiredToneSchema`, `analyzerCharacterSchema`, stage-1 grammar-wrapper variants | 6 |
+| `server/src/analyzer/ollama.ts` + `gemini.ts` | two-schema `runStage(grammarSchema, validationSchema)` | 7 |
+| `server/src/store/merge-analysis-cast.ts` | apply rewrite to prior ids + voiced-collision policy | 8 |
+| `server/src/workspace/paths.ts` + new `server/src/store/cast-merge-suggestions.ts` | sibling-file path + IO + fresh clear | 9 |
+| `server/src/routes/analysis.ts` | wire dedup + tone-fill + journal + transitive closure at the two finalization sites | 10 |
+| `server/src/routes/cast-merge-suggestions.ts` (new) + `openapi.yaml` | GET/accept/dismiss routes | 11 |
+| `src/store/...`, `src/components/listen/...` or cast view, `e2e/` | suggestion card + redux + e2e | 12 |
+
+---
+
+### Task 1: Journal — add `kind:'dedup'`
+
+**Files:**
+- Modify: `server/src/store/cast-merges.ts`
+- Test: `server/src/store/cast-merges.test.ts`
+
+**Interfaces:**
+- Consumes: existing `CastMergeEntry`, `replaceFoldEntries`, `buildFoldJournalEntries`.
+- Produces: `replaceDedupEntries(file, dedupEntries) → CastMergesFile`; `buildDedupJournalEntries(rewrites, preDedupSentences, characters, ts) → CastMergeEntry[]`; widened `kind: 'manual' | 'fold' | 'dedup'`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// in cast-merges.test.ts
+import { replaceDedupEntries, buildDedupJournalEntries, replaceFoldEntries, appendManualEntry } from './cast-merges.js';
+
+describe('dedup journal entries', () => {
+  it('replaceDedupEntries swaps dedup entries but preserves fold + manual', () => {
+    const base = { entries: [
+      { ts: 't', kind: 'manual' as const, sourceId: 'a', sourceName: 'A', targetId: 'b', affected: [] },
+      { ts: 't', kind: 'fold' as const, sourceId: 'c', sourceName: 'C', targetId: 'd', affected: [] },
+      { ts: 't', kind: 'dedup' as const, sourceId: 'olga', sourceName: 'Ольга', targetId: 'ольга', affected: [] },
+    ]};
+    const next = replaceDedupEntries(base, [
+      { ts: 't2', kind: 'dedup' as const, sourceId: 'ilya', sourceName: 'Илья', targetId: 'илья', affected: [] },
+    ]);
+    expect(next.entries.filter((e) => e.kind === 'manual')).toHaveLength(1);
+    expect(next.entries.filter((e) => e.kind === 'fold')).toHaveLength(1);
+    expect(next.entries.filter((e) => e.kind === 'dedup')).toEqual([
+      { ts: 't2', kind: 'dedup', sourceId: 'ilya', sourceName: 'Илья', targetId: 'илья', affected: [] },
+    ]);
+  });
+
+  it('buildDedupJournalEntries records pre-dedup affected sentences + sourceName', () => {
+    const rewrites = { olga: 'ольга' };
+    const preDedupSentences = [
+      { id: 1, chapterId: 3, characterId: 'olga' },
+      { id: 2, chapterId: 3, characterId: 'antonio' },
+      { id: 5, chapterId: 4, characterId: 'olga' },
+    ];
+    const chars = [{ id: 'olga', name: 'Ольга' }, { id: 'ольга', name: 'Ольга' }];
+    const entries = buildDedupJournalEntries(rewrites, preDedupSentences, chars, 'TS');
+    expect(entries).toEqual([
+      { ts: 'TS', kind: 'dedup', sourceId: 'olga', sourceName: 'Ольга', targetId: 'ольга',
+        affected: [{ chapterId: 3, sentenceId: 1 }, { chapterId: 4, sentenceId: 5 }] },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/store/cast-merges.test.ts -t "dedup journal"`
+Expected: FAIL — `replaceDedupEntries`/`buildDedupJournalEntries` not exported; `kind:'dedup'` not assignable.
+
+- [ ] **Step 3: Implement**
+
+In `cast-merges.ts`, widen the union (line ~41) and add the two functions next to `replaceFoldEntries`/`buildFoldJournalEntries`:
+
+```ts
+// CastMergeEntry.kind:
+  kind: 'manual' | 'fold' | 'dedup';
+```
+
+```ts
+/** Replace ALL dedup entries with `dedupEntries`, preserving fold + manual.
+    Idempotent across resume / re-analysis — orthogonal to replaceFoldEntries. */
+export function replaceDedupEntries(
+  file: CastMergesFile,
+  dedupEntries: CastMergeEntry[],
+): CastMergesFile {
+  return { entries: [...file.entries.filter((e) => e.kind !== 'dedup'), ...dedupEntries] };
+}
+
+/** Like buildFoldJournalEntries but stamps kind:'dedup'. `affected` = the
+    (chapterId, sentenceId) of every PRE-DEDUP sentence attributed to each source;
+    `sourceName` from the pre-dedup roster. */
+export function buildDedupJournalEntries(
+  rewrites: Record<string, string>,
+  preDedupSentences: ReadonlyArray<{ id: number; chapterId: number; characterId: string }>,
+  characters: ReadonlyArray<{ id: string; name: string }>,
+  ts: string,
+): CastMergeEntry[] {
+  const sourceIds = Object.keys(rewrites);
+  if (sourceIds.length === 0) return [];
+  const nameById = new Map(characters.map((c) => [c.id, c.name]));
+  const affectedBySource = new Map<string, AffectedSentence[]>();
+  for (const id of sourceIds) affectedBySource.set(id, []);
+  for (const s of preDedupSentences) {
+    const bucket = affectedBySource.get(s.characterId);
+    if (bucket) bucket.push({ chapterId: s.chapterId, sentenceId: s.id });
+  }
+  return sourceIds.map((sourceId) => ({
+    ts, kind: 'dedup' as const, sourceId,
+    sourceName: nameById.get(sourceId) ?? sourceId,
+    targetId: rewrites[sourceId],
+    affected: affectedBySource.get(sourceId) ?? [],
+  }));
+}
+```
+
+Also update the module header comment's "Two write sites" note to mention the dedup pass.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/store/cast-merges.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/store/cast-merges.ts server/src/store/cast-merges.test.ts
+git commit -m "feat(server): add kind:'dedup' journal entries + replaceDedupEntries"
+```
+
+---
+
+### Task 2: Shared character field-merge helper
+
+**Files:**
+- Create: `server/src/analyzer/roster-merge-fields.ts`
+- Test: `server/src/analyzer/roster-merge-fields.test.ts`
+- Modify: `server/src/routes/analysis.ts` (`mergeRosterChapter` delegates to the helper)
+
+**Interfaces:**
+- Produces: `mergeCharacterFields(existing: CharacterOutput, incoming: CharacterOutput): void` — mutates `existing` in place, combining fields exactly as `mergeRosterChapter` does today (longest description; union attributes/aliases/evidence; first-wins gender/ageRange; incoming name/aliases → existing aliases, never the display name; tone field-merge).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// roster-merge-fields.test.ts
+import { mergeCharacterFields } from './roster-merge-fields.js';
+
+const base = (over) => ({ id: 'a', name: 'Anton', role: 'r', color: 'c', ...over });
+
+describe('mergeCharacterFields', () => {
+  it('keeps the longer description and unions attributes', () => {
+    const existing = base({ description: 'short', attributes: ['weary'] });
+    mergeCharacterFields(existing, base({ description: 'a much longer description', attributes: ['weary', 'wry'] }));
+    expect(existing.description).toBe('a much longer description');
+    expect(existing.attributes).toEqual(['weary', 'wry']);
+  });
+
+  it('records a divergent incoming name as an alias, never the display name', () => {
+    const existing = base({ name: 'Антон', aliases: [] });
+    mergeCharacterFields(existing, base({ name: 'Антон Городецкий' }));
+    expect(existing.name).toBe('Антон');
+    expect(existing.aliases).toEqual(['Антон Городецкий']);
+  });
+
+  it('first detection wins for gender/ageRange; tone field-merges', () => {
+    const existing = base({ gender: 'male', tone: { warmth: 30 } });
+    mergeCharacterFields(existing, base({ gender: 'female', ageRange: 'adult', tone: { pace: 70 } }));
+    expect(existing.gender).toBe('male');
+    expect(existing.ageRange).toBe('adult');
+    expect(existing.tone).toEqual({ warmth: 30, pace: 70 });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/analyzer/roster-merge-fields.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement** — copy the field-combination block out of `mergeRosterChapter` (`analysis.ts:574-637`) verbatim into the helper:
+
+```ts
+// roster-merge-fields.ts
+import type { CharacterOutput } from './types.js'; // wherever CharacterOutput is declared; analysis.ts imports it today
+import { normaliseForMatch } from '../util/text-match.js';
+
+/** Combine `incoming` into `existing` in place — the exact field logic
+    mergeRosterChapter uses, factored out so the dedup pass agrees with it. */
+export function mergeCharacterFields(existing: CharacterOutput, incoming: CharacterOutput): void {
+  if (incoming.description && (!existing.description || incoming.description.length > existing.description.length)) {
+    existing.description = incoming.description;
+  }
+  if (incoming.tone) existing.tone = { ...existing.tone, ...incoming.tone };
+  if (incoming.attributes?.length) {
+    const seen = new Set(existing.attributes ?? []);
+    const next = [...(existing.attributes ?? [])];
+    for (const a of incoming.attributes) if (!seen.has(a)) { next.push(a); seen.add(a); }
+    existing.attributes = next;
+  }
+  if (incoming.evidence?.length) {
+    const seen = new Set((existing.evidence ?? []).map((e) => normaliseForMatch(e.quote)));
+    const next = [...(existing.evidence ?? [])];
+    for (const e of incoming.evidence) {
+      const norm = normaliseForMatch(e.quote);
+      if (norm.length > 0 && !seen.has(norm)) { next.push({ ...e }); seen.add(norm); }
+    }
+    existing.evidence = next;
+  }
+  if (!existing.gender && incoming.gender) existing.gender = incoming.gender;
+  if (!existing.ageRange && incoming.ageRange) existing.ageRange = incoming.ageRange;
+  const aliasCandidates = [incoming.name, ...(incoming.aliases ?? [])];
+  const seen = new Set<string>([
+    existing.name.trim().toLowerCase(),
+    ...(existing.aliases ?? []).map((a) => a.trim().toLowerCase()),
+  ]);
+  const nextAliases = [...(existing.aliases ?? [])];
+  for (const cand of aliasCandidates) {
+    const key = cand.trim().toLowerCase();
+    if (key.length > 0 && !seen.has(key)) { nextAliases.push(cand); seen.add(key); }
+  }
+  if (nextAliases.length) existing.aliases = nextAliases;
+}
+```
+
+Then in `analysis.ts` replace the inline block in `mergeRosterChapter` (the `existing` branch, lines ~574-637) with `mergeCharacterFields(existing, incoming);` and import the helper. Use the exact `CharacterOutput` import path the analyzer already uses (grep `CharacterOutput` in `analysis.ts` for its source module).
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd server && npx vitest run src/analyzer/roster-merge-fields.test.ts && npx vitest run src/routes/analysis.test.ts -t "mergeRosterChapter"`
+Expected: PASS (the existing `mergeRosterChapter` tests still pass — behaviour unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/analyzer/roster-merge-fields.ts server/src/analyzer/roster-merge-fields.test.ts server/src/routes/analysis.ts
+git commit -m "refactor(server): extract mergeCharacterFields from mergeRosterChapter"
+```
+
+---
+
+### Task 3: Russian diminutive table
+
+**Files:**
+- Create: `server/src/analyzer/ru-diminutives.ts`
+- Test: `server/src/analyzer/ru-diminutives.test.ts`
+
+**Interfaces:**
+- Produces: `diminutiveCanonical(name: string): { base: string; multiGender: boolean } | null` — returns the canonical base key (a `normaliseNameKey` value) and whether the diminutive maps to both genders; `null` if the name is not in the table (as diminutive or canonical).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// ru-diminutives.test.ts
+import { diminutiveCanonical } from './ru-diminutives.js';
+
+describe('diminutiveCanonical', () => {
+  it('maps a diminutive and its canonical to the same base', () => {
+    expect(diminutiveCanonical('Оля')?.base).toBe(diminutiveCanonical('Ольга')?.base);
+  });
+  it('flags multi-gender diminutives', () => {
+    expect(diminutiveCanonical('Саша')?.multiGender).toBe(true);
+    expect(diminutiveCanonical('Оля')?.multiGender).toBe(false);
+  });
+  it('returns null for an unknown name', () => {
+    expect(diminutiveCanonical('Завулон')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail.** `cd server && npx vitest run src/analyzer/ru-diminutives.test.ts` → FAIL (module not found).
+
+- [ ] **Step 3: Implement.** Keyed on `normaliseNameKey` so matching is script-exact and case-insensitive:
+
+```ts
+// ru-diminutives.ts
+import { normaliseNameKey } from '../util/safe-id.js';
+
+/* Curated Russian diminutive↔canonical groups. Each group is a set of name
+   forms (canonical + diminutives) that denote the same given name. `multiGender`
+   marks groups whose forms span male AND female canonicals (Саша→Александр/
+   Александра) — those need a stricter gender gate downstream. NOT exhaustive;
+   extend from real corpus data. NO transliteration, NO edit-distance. */
+interface DimGroup { base: string; forms: string[]; multiGender: boolean }
+
+const GROUPS: DimGroup[] = [
+  { base: 'ольга', forms: ['Ольга', 'Оля', 'Оленька'], multiGender: false },
+  { base: 'софья', forms: ['Софья', 'Соня'], multiGender: false },
+  { base: 'дмитрий', forms: ['Дмитрий', 'Дима', 'Митя'], multiGender: false },
+  { base: 'екатерина', forms: ['Екатерина', 'Катя', 'Катюша'], multiGender: false },
+  { base: 'михаил', forms: ['Михаил', 'Миша'], multiGender: false },
+  { base: 'мария', forms: ['Мария', 'Маша', 'Маня'], multiGender: false },
+  { base: 'антон', forms: ['Антон', 'Антоша'], multiGender: false },
+  { base: 'светлана', forms: ['Светлана', 'Света'], multiGender: false },
+  { base: 'борис', forms: ['Борис', 'Боря'], multiGender: false },
+  { base: 'александр', forms: ['Александр', 'Александра', 'Саша', 'Саня', 'Шура'], multiGender: true },
+  { base: 'евгений', forms: ['Евгений', 'Евгения', 'Женя'], multiGender: true },
+  { base: 'валентин', forms: ['Валентин', 'Валентина', 'Валя'], multiGender: true },
+  // …extend as real Russian books surface more (keep single-gender vs multiGender accurate).
+];
+
+const BY_KEY = new Map<string, { base: string; multiGender: boolean }>();
+for (const g of GROUPS) for (const f of g.forms) BY_KEY.set(normaliseNameKey(f), { base: g.base, multiGender: g.multiGender });
+
+/** Canonical base for a name if it is a known canonical or diminutive; else null. */
+export function diminutiveCanonical(name: string): { base: string; multiGender: boolean } | null {
+  return BY_KEY.get(normaliseNameKey(name)) ?? null;
+}
+```
+
+- [ ] **Step 4: Run to verify pass.** `cd server && npx vitest run src/analyzer/ru-diminutives.test.ts` → PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add server/src/analyzer/ru-diminutives.ts server/src/analyzer/ru-diminutives.test.ts
+git commit -m "feat(server): curated Russian diminutive↔canonical table"
+```
+
+---
+
+### Task 4: `dedupeRosterByName` (Tier-1, Tier-2a, Tier-2b)
+
+**Files:**
+- Create: `server/src/analyzer/roster-dedup.ts`
+- Test: `server/src/analyzer/roster-dedup.test.ts`
+
+**Interfaces:**
+- Consumes: `mergeCharacterFields` (Task 2), `diminutiveCanonical` (Task 3), `safeId`/`normaliseNameKey` (`util/safe-id.ts`).
+- Produces:
+  - `interface MergeSuggestion { sourceId: string; targetId: string; reason: string }`
+  - `dedupeRosterByName(characters: CharacterOutput[], sentences: ReadonlyArray<{ characterId: string }>, opts?: { language?: string }) → { characters: CharacterOutput[]; rewrites: Record<string,string>; suggestions: MergeSuggestion[] }`
+  - `rewrites` is the transitively-collapsed old-id→canonical-id map for Tier-1 + Tier-2a (NOT diminutives); narrator never appears as key or value; canonical id is never `'narrator'` for a non-narrator group.
+
+**Behaviour (from spec):** Tier-1 groups by `normaliseNameKey(name)`, gender-gated, canonical id = `safeId(name)`. Tier-2a token-subset, gated (non-narrator, gender-agree, single dominant superset), survivor = more lines (counted from `sentences`; ties → roster order). Tier-2b diminutive → suggestion only (multi-gender rows need both concrete agreeing genders). Narrator (`id==='narrator'`) excluded everywhere.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// roster-dedup.test.ts
+import { dedupeRosterByName } from './roster-dedup.js';
+
+const c = (over) => ({ id: over.id, name: over.name, role: over.role ?? 'r', color: over.color ?? 'c', ...over });
+const sent = (characterId, n = 1) => Array.from({ length: n }, () => ({ characterId }));
+
+describe('dedupeRosterByName Tier-1 (exact name)', () => {
+  it('collapses olga + ольга to one entry with canonical id ольга', () => {
+    const chars = [c({ id: 'olga', name: 'Ольга', gender: 'female' }), c({ id: 'ольга', name: 'Ольга', gender: 'female' })];
+    const r = dedupeRosterByName(chars, [...sent('olga', 8), ...sent('ольга', 203)]);
+    expect(r.characters).toHaveLength(1);
+    expect(r.characters[0].id).toBe('ольга');
+    expect(r.rewrites).toEqual({ olga: 'ольга' });
+  });
+
+  it('does NOT merge two same-name people of different gender', () => {
+    const chars = [c({ id: 'ivan', name: 'Иван', gender: 'male' }), c({ id: 'ivan2', name: 'Иван', gender: 'female' })];
+    const r = dedupeRosterByName(chars, [...sent('ivan'), ...sent('ivan2')]);
+    expect(r.characters).toHaveLength(2);
+  });
+
+  it('never merges the narrator, even with a non-narrator group named "Narrator"', () => {
+    const chars = [c({ id: 'narrator', name: 'Narrator', color: 'unset' }), c({ id: 'narrator-2', name: 'Narrator' })];
+    const r = dedupeRosterByName(chars, [...sent('narrator'), ...sent('narrator-2')]);
+    // narrator row untouched; the non-narrator "Narrator" group must NOT remap onto id 'narrator'
+    expect(r.characters.find((x) => x.id === 'narrator')).toBeDefined();
+    expect(Object.values(r.rewrites)).not.toContain('narrator');
+  });
+});
+
+describe('dedupeRosterByName Tier-2a (full vs short)', () => {
+  it('auto-merges Антон into Антон Городецкий, survivor = more lines, short name aliased', () => {
+    const chars = [c({ id: 'anton', name: 'Антон', gender: 'male' }), c({ id: 'anton-gorodetsky', name: 'Антон Городецкий', gender: 'male' })];
+    const r = dedupeRosterByName(chars, [...sent('anton', 3), ...sent('anton-gorodetsky', 50)]);
+    expect(r.characters).toHaveLength(1);
+    expect(r.characters[0].id).toBe('anton-gorodetsky');
+    expect(r.characters[0].aliases).toContain('Антон');
+    expect(r.rewrites).toEqual({ anton: 'anton-gorodetsky' });
+  });
+
+  it('does NOT merge when two longer names both contain the short name (ambiguous)', () => {
+    const chars = [
+      c({ id: 'anton', name: 'Антон', gender: 'male' }),
+      c({ id: 'ag', name: 'Антон Городецкий', gender: 'male' }),
+      c({ id: 'ai', name: 'Антон Иванов', gender: 'male' }),
+    ];
+    const r = dedupeRosterByName(chars, [...sent('anton'), ...sent('ag'), ...sent('ai')]);
+    expect(r.characters).toHaveLength(3);
+  });
+});
+
+describe('dedupeRosterByName Tier-2b (diminutive suggestions)', () => {
+  it('emits a suggestion for Оля + Ольга without merging', () => {
+    const chars = [c({ id: 'olya', name: 'Оля', gender: 'female' }), c({ id: 'ольга', name: 'Ольга', gender: 'female' })];
+    const r = dedupeRosterByName(chars, [...sent('olya', 4), ...sent('ольга', 30)]);
+    expect(r.characters).toHaveLength(2);
+    expect(r.rewrites).toEqual({});
+    expect(r.suggestions).toEqual([{ sourceId: 'olya', targetId: 'ольга', reason: expect.any(String) }]);
+  });
+
+  it('does NOT suggest a multi-gender diminutive when genders are unset', () => {
+    const chars = [c({ id: 's1', name: 'Саша' }), c({ id: 's2', name: 'Александр' })];
+    const r = dedupeRosterByName(chars, [...sent('s1'), ...sent('s2')]);
+    expect(r.suggestions).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail.** `cd server && npx vitest run src/analyzer/roster-dedup.test.ts` → FAIL (module not found).
+
+- [ ] **Step 3: Implement.**
+
+```ts
+// roster-dedup.ts
+import type { CharacterOutput } from './types.js'; // same import path as Task 2
+import { safeId, normaliseNameKey } from '../util/safe-id.js';
+import { mergeCharacterFields } from './roster-merge-fields.js';
+import { diminutiveCanonical } from './ru-diminutives.js';
+
+export interface MergeSuggestion { sourceId: string; targetId: string; reason: string }
+
+const NARRATOR_ID = 'narrator';
+const gendersConflict = (a?: string, b?: string) => !!a && !!b && a !== b;
+const tokens = (name: string) => name.trim().split(/\s+/).map((t) => normaliseNameKey(t)).filter(Boolean);
+
+/** Count attributed lines per character id from the sentence array (stage-1
+    `lines` is undefined pre-fold). */
+function lineCounts(sentences: ReadonlyArray<{ characterId: string }>): Map<string, number> {
+  const m = new Map<string, number>();
+  for (const s of sentences) m.set(s.characterId, (m.get(s.characterId) ?? 0) + 1);
+  return m;
+}
+
+export function dedupeRosterByName(
+  characters: CharacterOutput[],
+  sentences: ReadonlyArray<{ characterId: string }>,
+  opts: { language?: string } = {},
+): { characters: CharacterOutput[]; rewrites: Record<string, string>; suggestions: MergeSuggestion[] } {
+  const lines = lineCounts(sentences);
+  const rewrites: Record<string, string> = {};
+  // Work on a shallow clone so callers keep their input; preserve insertion order.
+  let roster = characters.map((ch) => ({ ...ch }));
+
+  /* ── Tier-1: exact normalised name, gender-gated, never narrator ───────── */
+  const byKey = new Map<string, CharacterOutput[]>();
+  for (const ch of roster) {
+    if (ch.id === NARRATOR_ID) continue;
+    const key = normaliseNameKey(ch.name);
+    if (!key) continue;
+    (byKey.get(key) ?? byKey.set(key, []).get(key)!).push(ch);
+  }
+  const tier1Survivors = new Map<string, CharacterOutput>(); // canonicalId -> survivor
+  const dropped = new Set<string>();
+  for (const [key, group] of byKey) {
+    if (group.length < 2) continue;
+    // Split off any gender-conflicting members so two different same-name people don't merge.
+    const genders = new Set(group.map((g) => g.gender).filter(Boolean));
+    if (genders.size > 1) continue; // conflicting genders → leave the whole group un-merged (conservative)
+    const canonicalId = safeId(group[0].name);
+    if (canonicalId === NARRATOR_ID) continue; // never remap onto the real narrator
+    const survivor = { ...group[0], id: canonicalId };
+    for (const member of group.slice(1)) {
+      mergeCharacterFields(survivor, member);
+      if (member.id !== canonicalId) rewrites[member.id] = canonicalId;
+      dropped.add(member.id);
+    }
+    if (group[0].id !== canonicalId) rewrites[group[0].id] = canonicalId;
+    tier1Survivors.set(canonicalId, survivor);
+  }
+  // Rebuild roster: replace each group's members with the single survivor at the first member's slot.
+  const emitted = new Set<string>();
+  roster = roster.flatMap((ch) => {
+    if (ch.id === NARRATOR_ID) return [ch];
+    const canonicalId = rewrites[ch.id] ?? ch.id;
+    const survivor = tier1Survivors.get(canonicalId);
+    if (!survivor) return [ch];
+    if (emitted.has(canonicalId)) return [];
+    emitted.add(canonicalId);
+    return [survivor];
+  });
+
+  /* ── Tier-2a: full-vs-short token subset, gated, auto-merge ────────────── */
+  const linesOf = (ch: CharacterOutput) => lines.get(ch.id) ?? 0;
+  // Iterate a stable copy; a "short" name merges into the single longer superset.
+  const current = [...roster];
+  for (const short of current) {
+    if (short.id === NARRATOR_ID || dropped.has(short.id)) continue;
+    const sTok = tokens(short.name);
+    if (sTok.length === 0) continue;
+    const supersets = current.filter((long) =>
+      long !== short && long.id !== NARRATOR_ID && !dropped.has(long.id) &&
+      tokens(long.name).length > sTok.length &&
+      sTok.every((t, i) => tokens(long.name)[i] === t) && // leading-token subset
+      !gendersConflict(short.gender, long.gender),
+    );
+    if (supersets.length !== 1) continue; // ambiguous or none → skip
+    const long = supersets[0];
+    // Survivor = more lines; tie → earlier in roster order (current[] is roster order).
+    const survivor = linesOf(long) >= linesOf(short) ? long : short;
+    const victim = survivor === long ? short : long;
+    mergeCharacterFields(survivor, victim);
+    rewrites[victim.id] = survivor.id;
+    dropped.add(victim.id);
+  }
+  roster = roster.filter((ch) => !dropped.has(ch.id));
+  // Collapse rewrites transitively (victim may have been a Tier-1 canonical).
+  for (const k of Object.keys(rewrites)) {
+    let v = rewrites[k];
+    while (rewrites[v] && rewrites[v] !== v) v = rewrites[v];
+    rewrites[k] = v;
+  }
+
+  /* ── Tier-2b: diminutive → suggestion only ─────────────────────────────── */
+  const suggestions: MergeSuggestion[] = [];
+  for (let i = 0; i < roster.length; i++) {
+    for (let j = i + 1; j < roster.length; j++) {
+      const a = roster[i], b = roster[j];
+      if (a.id === NARRATOR_ID || b.id === NARRATOR_ID) continue;
+      const da = diminutiveCanonical(a.name), db = diminutiveCanonical(b.name);
+      if (!da || !db || da.base !== db.base) continue;
+      if (normaliseNameKey(a.name) === normaliseNameKey(b.name)) continue; // exact handled by Tier-1
+      if (gendersConflict(a.gender, b.gender)) continue;
+      if (da.multiGender && (!a.gender || !b.gender)) continue; // multi-gender needs both concrete
+      const target = linesOf(a) >= linesOf(b) ? a : b;
+      const source = target === a ? b : a;
+      suggestions.push({ sourceId: source.id, targetId: target.id, reason: `Diminutive of «${target.name}»` });
+    }
+  }
+
+  return { characters: roster, rewrites, suggestions };
+}
+```
+
+> Note on `tokens(long.name)` recomputation: fine for clarity; if profiling shows it hot, memoize per row. The `byKey.get(key) ?? byKey.set(...).get(key)!` idiom appears elsewhere in the analyzer — keep it for consistency, or split into an explicit `if (!byKey.has(key)) byKey.set(key, [])` if the reviewer prefers.
+
+- [ ] **Step 4: Run to verify pass.** `cd server && npx vitest run src/analyzer/roster-dedup.test.ts` → PASS. Fix any tie/order edge cases the tests reveal.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add server/src/analyzer/roster-dedup.ts server/src/analyzer/roster-dedup.test.ts
+git commit -m "feat(server): dedupeRosterByName — Tier-1/2a auto-merge + Tier-2b suggestions"
+```
+
+---
+
+### Task 5: `fillToneFromAttributes`
+
+**Files:**
+- Create: `server/src/analyzer/fill-tone.ts`
+- Test: `server/src/analyzer/fill-tone.test.ts`
+
+**Interfaces:**
+- Produces: `fillToneFromAttributes(ch: CharacterOutput): CharacterOutput` — returns a clone with all four tone axes populated (0–100). Fires only when an axis is missing; never overwrites a present axis.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// fill-tone.test.ts
+import { fillToneFromAttributes } from './fill-tone.js';
+const c = (over) => ({ id: 'a', name: 'A', role: 'r', color: 'c', ...over });
+
+describe('fillToneFromAttributes', () => {
+  it('derives a non-neutral tone from EN + RU descriptors', () => {
+    const out = fillToneFromAttributes(c({ attributes: ['weary', 'прагматичный'] }));
+    expect(out.tone).toBeDefined();
+    expect(out.tone!.pace).toBeLessThan(50);      // weary → slower
+    expect(out.tone!.authority).toBeGreaterThan(50); // pragmatic → more authority
+    [out.tone!.warmth, out.tone!.pace, out.tone!.authority, out.tone!.emotion]
+      .forEach((v) => { expect(v).toBeGreaterThanOrEqual(0); expect(v).toBeLessThanOrEqual(100); });
+  });
+
+  it('fills only missing axes; leaves present axes untouched', () => {
+    const out = fillToneFromAttributes(c({ tone: { warmth: 80 }, attributes: ['playful'] }));
+    expect(out.tone!.warmth).toBe(80);            // preserved
+    expect(out.tone!.emotion).toBeGreaterThan(50); // playful → more emotion (was missing)
+  });
+
+  it('yields neutral 50s when there are no usable attributes', () => {
+    const out = fillToneFromAttributes(c({}));
+    expect(out.tone).toEqual({ warmth: 50, pace: 50, authority: 50, emotion: 50 });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail.** `cd server && npx vitest run src/analyzer/fill-tone.test.ts` → FAIL.
+
+- [ ] **Step 3: Implement.**
+
+```ts
+// fill-tone.ts
+import { normaliseNameKey } from '../util/safe-id.js';
+import type { CharacterOutput } from './types.js';
+
+type Axis = 'warmth' | 'pace' | 'authority' | 'emotion';
+/* Keyword → axis deltas off a neutral 50 baseline. Keys are normaliseNameKey'd
+   (script-exact, case-insensitive) EN + RU descriptors. Extend from corpus. */
+const NUDGES: Record<string, Partial<Record<Axis, number>>> = {
+  [normaliseNameKey('weary')]: { pace: -15, emotion: -10 },
+  [normaliseNameKey('tired')]: { pace: -15, emotion: -10 },
+  [normaliseNameKey('усталый')]: { pace: -15, emotion: -10 },
+  [normaliseNameKey('устал')]: { pace: -15, emotion: -10 },
+  [normaliseNameKey('pragmatic')]: { authority: 15, warmth: -10 },
+  [normaliseNameKey('прагматичный')]: { authority: 15, warmth: -10 },
+  [normaliseNameKey('playful')]: { emotion: 15, pace: 10 },
+  [normaliseNameKey('игривый')]: { emotion: 15, pace: 10 },
+  [normaliseNameKey('wise')]: { authority: 15, warmth: 10 },
+  [normaliseNameKey('мудрый')]: { authority: 15, warmth: 10 },
+  [normaliseNameKey('наставнический')]: { authority: 15, warmth: 10 },
+  [normaliseNameKey('silent')]: { pace: -10, emotion: -10 },
+  [normaliseNameKey('observant')]: { pace: -10, emotion: -10 },
+  [normaliseNameKey('немногословный')]: { pace: -10, emotion: -10 },
+  [normaliseNameKey('enigmatic')]: { warmth: -5, authority: 5, emotion: -5 },
+  [normaliseNameKey('загадочный')]: { warmth: -5, authority: 5, emotion: -5 },
+  // …extend as real runs surface more descriptor words.
+};
+const clamp = (n: number) => Math.max(0, Math.min(100, Math.round(n)));
+
+export function fillToneFromAttributes(ch: CharacterOutput): CharacterOutput {
+  const derived: Record<Axis, number> = { warmth: 50, pace: 50, authority: 50, emotion: 50 };
+  for (const attr of ch.attributes ?? []) {
+    const nudge = NUDGES[normaliseNameKey(attr)];
+    if (!nudge) continue;
+    for (const axis of Object.keys(nudge) as Axis[]) derived[axis] += nudge[axis]!;
+  }
+  const existing = ch.tone ?? {};
+  const tone = {
+    warmth: existing.warmth ?? clamp(derived.warmth),
+    pace: existing.pace ?? clamp(derived.pace),
+    authority: existing.authority ?? clamp(derived.authority),
+    emotion: existing.emotion ?? clamp(derived.emotion),
+  };
+  return { ...ch, tone };
+}
+```
+
+- [ ] **Step 4: Run to verify pass.** `cd server && npx vitest run src/analyzer/fill-tone.test.ts` → PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add server/src/analyzer/fill-tone.ts server/src/analyzer/fill-tone.test.ts
+git commit -m "feat(server): fillToneFromAttributes deterministic tone backstop"
+```
+
+---
+
+### Task 6: Required-tone analyzer grammar schemas
+
+**Files:**
+- Modify: `server/src/handoff/schemas.ts`
+- Test: `server/src/handoff/schemas.test.ts`
+
+**Interfaces:**
+- Produces: `requiredToneSchema` (warmth/pace/authority/emotion all required ints 0–100); `analyzerCharacterSchema` (= `characterSchema` with `tone: requiredToneSchema`); `stage1ChapterGrammarSchema` / `stage1GrammarSchema` (wrappers embedding `analyzerCharacterSchema`, mirroring the existing `stage1ChapterSchema`/`stage1Schema`). The existing `characterSchema`/`stage1ChapterSchema`/`stage1Schema` stay unchanged (validation).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// schemas.test.ts
+import { stage1ChapterGrammarSchema, stage1ChapterSchema } from './schemas.js';
+import { z } from 'zod';
+
+describe('analyzer grammar schema requires tone', () => {
+  it('grammar JSON-schema marks tone (and axes) required on a character', () => {
+    const json = z.toJSONSchema(stage1ChapterGrammarSchema, { target: 'draft-07', reused: 'inline' });
+    const charSchema = JSON.stringify(json);
+    // tone required on the character object, axes required on tone:
+    expect(charSchema).toContain('"required"');
+    // structural assertion: a character missing tone fails the GRAMMAR schema...
+    const charGrammar = stage1ChapterGrammarSchema; // walk to .characters element in the real test via parse
+  });
+
+  it('validation schema still accepts a character with NO tone', () => {
+    const ok = stage1ChapterSchema.safeParse({
+      characters: [{ id: 'a', name: 'A', role: 'r', color: 'c' }],
+      sentences: [],
+    });
+    expect(ok.success).toBe(true);
+  });
+});
+```
+
+> The grammar-required assertion is best made against `analyzerCharacterSchema.safeParse({...without tone...})` returning `success:false`, and `characterSchema.safeParse(sameInput)` returning `success:true`. Write both — they are the load-bearing contrast.
+
+- [ ] **Step 2: Run to verify fail.** `cd server && npx vitest run src/handoff/schemas.test.ts -t "grammar"` → FAIL (exports missing).
+
+- [ ] **Step 3: Implement** in `schemas.ts` — add beside the existing definitions (do NOT change `toneSchema`/`characterSchema`/`stage1ChapterSchema`/`stage1Schema`):
+
+```ts
+export const requiredToneSchema = z
+  .object({
+    warmth: z.number().int().min(0).max(100),
+    pace: z.number().int().min(0).max(100),
+    authority: z.number().int().min(0).max(100),
+    emotion: z.number().int().min(0).max(100),
+  })
+  .strict();
+
+/** Character schema for the analyzer GRAMMAR only — tone required so constrained
+    decoding nudges the model to emit it. Never used for validation (that stays
+    characterSchema, tone optional). */
+export const analyzerCharacterSchema = characterSchema.extend({ tone: requiredToneSchema });
+
+// Mirror the existing wrappers but embed the required-tone character schema.
+// (Match the exact field shape of stage1ChapterSchema / stage1Schema — read them
+//  at schemas.ts:~101/~113 and reproduce, swapping characterSchema → analyzerCharacterSchema.)
+export const stage1ChapterGrammarSchema = z.object({
+  characters: z.array(analyzerCharacterSchema),
+  sentences: stage1ChapterSchema.shape.sentences, // reuse the existing sentence sub-schema
+}).strict();
+
+export const stage1GrammarSchema = z.object({
+  characters: z.array(analyzerCharacterSchema),
+  // reproduce stage1Schema's other top-level fields verbatim:
+  ...{},
+}).strict();
+```
+
+> Implementer: open `schemas.ts:~101/~113`, copy the exact `stage1ChapterSchema`/`stage1Schema` object shapes, and produce the grammar variants by substituting `analyzerCharacterSchema` for `characterSchema`. Reuse sub-schemas via `.shape` to stay DRY rather than re-declaring sentence/field schemas.
+
+- [ ] **Step 4: Run to verify pass.** `cd server && npx vitest run src/handoff/schemas.test.ts` → PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add server/src/handoff/schemas.ts server/src/handoff/schemas.test.ts
+git commit -m "feat(server): required-tone analyzer grammar schemas (validation unchanged)"
+```
+
+---
+
+### Task 7: Two-schema `runStage`
+
+**Files:**
+- Modify: `server/src/analyzer/ollama.ts`, `server/src/analyzer/gemini.ts`
+- Test: `server/src/analyzer/ollama.test.ts` (+ a gemini test in the slow tier)
+
+**Interfaces:**
+- Produces: `runStage<T>(manuscriptId, key, skillName, promptMd, grammarSchema: z.ZodType<unknown>, validationSchema: z.ZodType<T>, call)` — `z.toJSONSchema(grammarSchema)` drives the grammar; `parseAndValidate(text, validationSchema)` validates. `runStage1Chapter`/`runStage1` pass `stage1ChapterGrammarSchema`/`stage1GrammarSchema` as grammar and the existing `stage1ChapterSchema`/`stage1Schema` as validation. `runStage2Chapter`/`runEmotionChapter` pass their one schema for both.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// ollama.test.ts — add
+it('a stage-1 response with NO tone passes validation (non-fatal), grammar still required-tone', async () => {
+  // Arrange a fake chat returning a character without tone; assert parseAndValidate succeeds
+  // and that the grammar passed to chat() was derived from the required-tone schema.
+  // (Use the existing ollama test harness/mock for chat.)
+});
+```
+
+> Use the existing `ollama.test.ts` mocking style (it already stubs the HTTP `chat`). Assert: (a) the `response_format`/grammar argument equals `z.toJSONSchema(stage1ChapterGrammarSchema, …)`, and (b) the returned parsed object validates and has no `tone` → no throw, no retry.
+
+- [ ] **Step 2: Run to verify fail.** `cd server && npx vitest run src/analyzer/ollama.test.ts -t "non-fatal"` → FAIL.
+
+- [ ] **Step 3: Implement.** In `ollama.ts` change the private `runStage` signature (`~294`) to accept `grammarSchema` + `validationSchema`; feed `z.toJSONSchema(grammarSchema, …)` at `~319` and `parseAndValidate(text, validationSchema)` at `~338` and in the retry path. Update the 4 callers:
+
+```ts
+// runStage1Chapter:
+return this.runStage(manuscriptId, key, 'per_chapter_stage1', promptMd,
+  stage1ChapterGrammarSchema, stage1ChapterSchema, call);
+// runStage1: stage1GrammarSchema, stage1Schema
+// runStage2Chapter: per_chapter_stage2 schema for BOTH params
+// runEmotionChapter: emotionAnnotationSchema for BOTH params
+```
+
+Do the identical signature change in `gemini.ts` `runStage` (`~259`); it sends no grammar, so it only uses `validationSchema` for `parseAndValidate` — pass `grammarSchema` through but ignore it (or use it if/when Gemini gains response-schema support). Keep `T` derived from `validationSchema`.
+
+- [ ] **Step 4: Run to verify pass.** `cd server && npx vitest run src/analyzer/ollama.test.ts` and `npm run test:server-slow` (covers gemini). Expected: PASS; existing stage-2/emotion tests unaffected.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add server/src/analyzer/ollama.ts server/src/analyzer/gemini.ts server/src/analyzer/ollama.test.ts
+git commit -m "feat(server): two-schema runStage — grammar requires tone, validation tolerant"
+```
+
+---
+
+### Task 8: Voiced-collision-safe rewrite of `priorCastForMerge`
+
+**Files:**
+- Modify: `server/src/store/merge-analysis-cast.ts`
+- Test: `server/src/store/merge-analysis-cast.test.ts`
+
+**Interfaces:**
+- Produces: `applyRewriteToPriorCast(priorCast, rewrites) → { priorCast: typeof priorCast; droppedVoices: Array<{ id: string; voiceState?: string }> }` — remaps each prior row's `id` through `rewrites`; when two voiced rows collide on one canonical id, keep the one with the strongest `voiceState` (`locked` > `tuned` > `reused` > `generated`), tie → more lines if available else first; return the dropped ones for logging. Call this BEFORE `mergeAnalysisResultWithExistingCast`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// merge-analysis-cast.test.ts — add
+import { applyRewriteToPriorCast } from './merge-analysis-cast.js';
+
+it('remaps prior ids and keeps the strongest voiceState on collision', () => {
+  const prior = [
+    { id: 'olga', name: 'Ольга', voiceState: 'generated', overrideTtsVoices: { qwen: { name: 'qwen-gen' } } },
+    { id: 'ольга', name: 'Ольга', voiceState: 'tuned', overrideTtsVoices: { qwen: { name: 'qwen-tuned' } } },
+  ];
+  const { priorCast, droppedVoices } = applyRewriteToPriorCast(prior, { olga: 'ольга' });
+  const survivor = priorCast.find((c) => c.id === 'ольга');
+  expect(survivor?.overrideTtsVoices?.qwen?.name).toBe('qwen-tuned'); // tuned beats generated
+  expect(priorCast.filter((c) => c.id === 'ольга')).toHaveLength(1); // no duplicate id
+  expect(droppedVoices).toEqual([{ id: 'olga', voiceState: 'generated' }]);
+});
+```
+
+- [ ] **Step 2: Run to verify fail.** `cd server && npx vitest run src/store/merge-analysis-cast.test.ts -t "collision"` → FAIL.
+
+- [ ] **Step 3: Implement** `applyRewriteToPriorCast` in `merge-analysis-cast.ts` (rank by `VOICE_STATE_RANK = { locked:3, tuned:2, reused:1, generated:0 }`, undefined → -1; collapse by canonical id; collect drops). Then in `analysis.ts` (Task 10) call it on `priorCastForMerge` with the cumulative dedup rewrite before the existing `mergeAnalysisResultWithExistingCast`, and feed `droppedVoices` to the change-log writer (`logCarriedForwardCharacters` pattern, `analysis.ts:148`).
+
+- [ ] **Step 4: Run to verify pass.** `cd server && npx vitest run src/store/merge-analysis-cast.test.ts` → PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add server/src/store/merge-analysis-cast.ts server/src/store/merge-analysis-cast.test.ts
+git commit -m "feat(server): collision-safe prior-cast id remap for dedup voice carry-forward"
+```
+
+---
+
+### Task 9: Suggestions sibling file — path + IO + fresh clear
+
+**Files:**
+- Modify: `server/src/workspace/paths.ts` (add `castMergeSuggestionsJsonPath`)
+- Create: `server/src/store/cast-merge-suggestions.ts` (load/write/clear)
+- Test: `server/src/store/cast-merge-suggestions.test.ts`
+
+**Interfaces:**
+- Produces: `castMergeSuggestionsJsonPath(bookDir)`; `loadSuggestions(bookDir) → Promise<{ suggestions: MergeSuggestion[] }>`; `writeSuggestions(bookDir, suggestions)`; `clearSuggestions(bookDir)`; `dismissSuggestion(bookDir, sourceId, targetId)`.
+
+- [ ] **Step 1–5:** Mirror `store/cast-merges.ts`'s atomic-write + empty-on-missing pattern. Test: write→load round-trip, `clearSuggestions` removes the file, `dismissSuggestion` drops the matching pair. Commit `feat(server): cast-merge-suggestions sibling-file store`.
+
+> In Task 10, call `clearSuggestions(bookDir)` at the `fresh:true` reset (`analysis.ts:2309`, beside `clearCastMerges`) and `writeSuggestions(bookDir, dedup.suggestions)` (overwrite) at finalization.
+
+---
+
+### Task 10: Wire dedup + tone-fill + journal at the finalization sites
+
+**Files:**
+- Modify: `server/src/routes/analysis.ts` (both finalization sites: `~3923` and `~4895`)
+- Test: `server/src/routes/analysis.test.ts` (integration over a synthetic two-chapter roster with drifted ids)
+
+**Interfaces:**
+- Consumes: `dedupeRosterByName` (4), `fillToneFromAttributes` (5), `buildDedupJournalEntries`/`replaceDedupEntries` (1), `applyRewriteToPriorCast` (8), `writeSuggestions`/`clearSuggestions` (9).
+
+- [ ] **Step 1: Write the failing integration test** — feed a roster `[{id:'olga',name:'Ольга'},{id:'ольга',name:'Ольга'}]` + sentences attributed to both through the finalization path; assert the persisted cast has ONE `Ольга`, sentences all point to the canonical id, every character has a populated `tone`, and a `cast-merges.json` `kind:'dedup'` entry exists.
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement the finalization sequence** at BOTH sites, in this order (per the spec):
+
+```ts
+// 1. dedup BEFORE fold
+const dd = dedupeRosterByName(stage1.characters, recovered.sentences, { language: bookLanguage });
+// 2. apply dedup rewrites to sentences
+recovered.sentences = recovered.sentences.map((s) =>
+  dd.rewrites[s.characterId] ? { ...s, characterId: dd.rewrites[s.characterId] } : s);
+// 3. journal the dedup merges against PRE-DEDUP sentences/roster (capture them before step 2!)
+const dedupEntries = buildDedupJournalEntries(dd.rewrites, preDedupSentences, stage1.characters, ts);
+// 4. fold runs on the deduped roster + rewritten sentences (existing call, now fed dd.characters)
+const folded = foldMinorCast(dd.characters, recovered.sentences, { /* existing opts */, language: bookLanguage });
+// 5. tone fill on the folded survivors
+folded.characters = folded.characters.map(fillToneFromAttributes);
+// 6. cumulative transitive rewrite for the voice carry-forward + journal
+const cumulative = composeRewrites(dd.rewrites, folded.rewrites); // helper: olga→ольга→unknown-female
+const prior = applyRewriteToPriorCast(priorCastForMerge, cumulative);
+// …feed prior.priorCast into mergeAnalysisResultWithExistingCast; log prior.droppedVoices
+// 7. persist journal: replaceDedupEntries(file, dedupEntries) alongside the existing writeFoldJournal
+// 8. writeSuggestions(bookDir, dd.suggestions)
+```
+
+Capture `preDedupSentences = recovered.sentences.map(s => ({ id: s.id, chapterId: s.chapterId, characterId: s.characterId }))` BEFORE step 2. Add a small `composeRewrites(a, b)` pure helper (transitive closure) — colocate it in `roster-dedup.ts` and unit-test it in Task 4. Mirror the exact change at the second site (`~4895`).
+
+- [ ] **Step 4: Run → PASS.** Run `cd server && npx vitest run src/routes/analysis.test.ts` and `npm run test:server-slow`.
+
+- [ ] **Step 5: Commit** `feat(server): wire dedup + tone-fill + dedup journal at analysis finalization`.
+
+---
+
+### Task 11: Suggestions routes + OpenAPI
+
+**Files:**
+- Create: `server/src/routes/cast-merge-suggestions.ts` (GET list, POST accept → delegates to existing merge route logic + `dismissSuggestion`, POST dismiss)
+- Modify: `openapi.yaml` (+ run `npm run openapi:types`), register the router where other cast routes mount
+- Test: `server/src/routes/cast-merge-suggestions.test.ts`
+
+- [ ] **Steps:** TDD each route (list returns the sibling-file contents; accept calls the merge with `target=canonical`, then drops the suggestion; dismiss drops it). Reuse the merge implementation from `cast-merge.ts` (extract its core if needed so the accept route doesn't duplicate). Commit `feat(server): cast-merge-suggestions routes (list/accept/dismiss)`.
+
+---
+
+### Task 12: Frontend suggestion card + e2e
+
+**Files:**
+- Modify: cast-review UI (the cast view / `src/components/listen/...` is the listen view — the cast roster lives in `src/views/cast.tsx`; confirm the cast-review surface), redux slice for cast, `src/lib/api.ts` (mock + real)
+- Create: `e2e/<cast-merge-suggestions>.spec.ts`
+- Test: component test (Vitest + RTL) + Playwright e2e
+
+- [ ] **Steps:** fetch suggestions on cast-review mount (keyed to analysis-complete); render a dismissable card per suggestion (`Merge` → accept route, `Dismiss` → dismiss route); ≥44px touch targets; design tokens only. Component test asserts render + button wiring; e2e asserts a seeded suggestion renders, Merge applies, Dismiss removes. Commit `feat(frontend): diminutive merge-suggestion cards in cast review`.
+
+---
+
+## Self-review (completed during authoring)
+
+- **Spec coverage:** Tier-1 (T4), Tier-2a (T4), Tier-2b suggestions (T4 + sibling file T9 + routes T11 + UI T12); narrator id-only guard + computed-canonical guard (T4); gender gate incl. Tier-1 (T4); voiced-collision policy + change-log (T8 + T10); journal `kind:'dedup'` + idempotent replace + reversibility (T1); transitive closure (T4 `composeRewrites` + T10); two-schema tone grammar/validation (T6+T7); `fillToneFromAttributes` (T5); fresh-run clear (T9+T10); live-preview caveat (no task — accepted as-is per spec). All covered.
+- **Type consistency:** `MergeSuggestion`, `dedupeRosterByName`, `mergeCharacterFields`, `diminutiveCanonical`, `fillToneFromAttributes`, `applyRewriteToPriorCast`, `replaceDedupEntries`/`buildDedupJournalEntries`, `composeRewrites` — names used identically across tasks.
+- **Open implementer note:** Tasks 6/7 require copying the exact existing `stage1ChapterSchema`/`stage1Schema` shapes and the exact `ollama.ts`/`gemini.ts` `runStage` call sites — these are flagged inline; the implementer reads those lines and reproduces faithfully.
+
+## Repair of the existing book (post-merge)
+
+Re-analyse *Ночной дозор* on the fixed pipeline. It has no designed voices yet, so the voiced-collision path (T8) is exercised only by tests here. Note (spec caveat): re-analysis discards the user's manual tone tuning — `tone` is not a preserved field; that pre-existing behaviour is out of scope.

--- a/docs/superpowers/specs/2026-06-20-russian-cast-dedup-and-tone-design.md
+++ b/docs/superpowers/specs/2026-06-20-russian-cast-dedup-and-tone-design.md
@@ -1,0 +1,450 @@
+# Russian cast de-duplication + tone population — design
+
+- **Date:** 2026-06-20
+- **Status:** approved (brainstorm), adversarially reviewed + revised, pre-plan
+- **Branch:** `fix/server-ru-cast-dedup-tone`
+- **Extends:** plan [221 — Multilingual attribution](../../features/221-multilingual-attribution-gemma-and-cast-merge.md)
+  (re-opens its Wave C, which was wrongly closed as "OBSOLETE"); builds on plan
+  219 (`unicodeKebab`/`safeId`) and Wave E (the `languagePreamble` cast-field guard).
+
+## Problem (reproduced from persisted data, not inferred)
+
+A full local analysis of *Ночной дозор* (Сергей Лукьяненко, workspace
+`C:\AudiobookWorkspace`, language `ru`, 9 chapters) on **`gemma4-e4b-8gb:latest`**
+produces two distinct user-visible defects, confirmed by inspecting the book's
+persisted `.audiobook/cast.json` (28 characters):
+
+### Defect 1 — duplicate cast entries (same person, two ids)
+
+Every duplicate pair is the **same Cyrillic display name** emitted once with a
+Cyrillic-kebab id and once with a Latin-transliterated id:
+
+| Display name | id #1 | id #2 |
+|---|---|---|
+| Ольга | `ольга` | `olga` |
+| Илья | `ilya` | `илья` |
+| Семен | `semen` | `семен` |
+| Тигренок | `тигренок` | `tigrenok` |
+
+**Root cause (model-independent):** a character's `id` is taken **verbatim from
+the analyzer model**. The model inconsistently transliterates the id across
+chapters. `mergeRosterChapter` (`server/src/routes/analysis.ts:~560`) merges by
+**exact id only** (`roster.get(incoming.id)`), so `ольга` ≠ `olga` → never
+merged. Plan 219's `unicodeKebab`/`safeId` only governs ids **we** mint (book
+ids, paths, auto-added missing speakers) — it is never applied to re-canonicalise
+the model's emitted character id, so the transliteration drift leaks through.
+
+This was plan 221's Defect 1 / Wave C. Wave C was closed as "OBSOLETE — 0
+duplicate groups" based on a single `repro-remeasure.mts` probe run on
+`gemma4-e4b`. That was a **false negative**: gemma is stochastic, the probe run
+happened to emit consistent ids, and a real 9-chapter run drifts. The fix must
+therefore be **model-independent**, not a per-model prompt tweak.
+
+### Defect 2 — tone profiles not populated (2/28 characters)
+
+The cast drawer shows a neutral 50/50/50/50 tone for almost every character.
+
+**Root cause (verified in code, not inferred):** `characterSchema.tone` is
+`toneSchema.optional()` and every axis inside `toneSchema` is `.optional()`
+(`server/src/handoff/schemas.ts:14-21,57`). That schema is converted to JSON
+Schema and fed to the model as a **constrained-decoding grammar**
+(`ollama.ts:319`, `runStage`). So the grammar the model must follow says *"tone
+is optional — skip it,"* while the `languagePreamble` prompt (Wave E) says
+*"always emit tone."* **Under constrained decoding the grammar wins** — gemma
+takes the omission on 26/28. Wave E's prompt-only fix could never stick.
+
+### Not in scope (separate root causes — follow-ups)
+
+- **Mixed-language attribute tags** (`professional`/`tired`/`прагматичная` on one
+  character): the `languagePreamble` "write attributes in Russian" instruction is
+  ignored by the model — a localisation-compliance issue, distinct from tone.
+- **Narrator-`я` mis-roster** (the model rosters the first-person pronoun "я" /
+  the byline author as a speaking character): tracked as bug #938.
+
+## Goals
+
+1. Same-person duplicate roster entries collapse automatically and safely, with
+   no false merges (especially never folding the narrator into a character).
+2. Harder same-person cases (full-vs-short, diminutives) are caught — auto where
+   structurally safe, suggested-with-one-tap-confirm where riskier.
+3. Every character ends analysis with a populated, meaningful tone profile.
+4. No regression to English books or to existing cached `cast.json` files.
+
+## Design
+
+### Fix 1 — de-duplication engine (backend)
+
+A new pure module `server/src/analyzer/roster-dedup.ts`:
+
+```
+dedupeRosterByName(
+  characters: CharacterOutput[],
+  sentences: ReadonlyArray<{ characterId: string; ... }>,
+  opts: { language?: string },
+): { characters: CharacterOutput[]; rewrites: Record<string,string>; suggestions: MergeSuggestion[] }
+```
+
+Shape deliberately mirrors `foldMinorCast` (`server/src/analyzer/fold-minor-cast.ts`),
+which already returns `{ characters, rewrites }` and rewrites sentence
+`characterId`s — the proven template for this kind of pass.
+
+**Placement.** Runs at the two finalisation sites (`analysis.ts:~3923` and
+`:~4895`) **before** `foldMinorCast`, so same-person line counts are summed
+before the minor-cast `<3 lines` fold threshold is applied (otherwise Ольга's
+8-line half could be folded into a background bucket while her 203-line half
+stays). The route:
+
+1. `const dd = dedupeRosterByName(stage1.characters, recovered.sentences, { language })`
+2. apply `dd.rewrites` to `recovered.sentences`
+3. `const folded = foldMinorCast(dd.characters, rewrittenSentences, { ... })`
+4. compose `dd.rewrites` then `folded.rewrites` into a **transitively-closed**
+   cumulative table for downstream consumers (the `writeFoldJournal` calls at
+   `:4028`/`:5008`). Closure matters: a Tier-1 canonical id (`ольга`) can itself
+   be folded by `foldMinorCast` into `unknown-female`, so the cumulative map must
+   resolve `olga → ольга → unknown-female`, not stop at `olga → ольга` (review
+   MAJOR-5).
+
+> **Review MAJOR-5 — journal reversibility.** The fold journal
+> (`buildFoldJournalEntries`, `cast-merges.ts:78-101`) computes each entry's
+> `affected` sentences by matching **pre-fold** sentences against rewrite *source*
+> ids and reads `sourceName` from the **pre-fold** roster. If dedup rewrites
+> sentences *before* the fold (step 2) and hands the fold the already-rewritten
+> sentences, the dedup source ids are gone from the sentence list → empty
+> `affected`, missing `sourceName`, and the un-merge flow (`cast-aliases.ts`) can't
+> reverse a dedup merge. **Therefore dedup writes its OWN journal entries** (to the
+> same `cast-merges.json`) computed against the **pre-dedup** sentences and roster,
+> recording each `sourceId → canonicalId` with its affected sentences and source
+> name. Un-merge stays reversible because `impactedChaptersFromJournal`
+> (`cast-aliases.ts:280`) matches on `targetId`/`sourceName` and is
+> **provenance-agnostic** (ignores `kind`) — provided the survivor carries the
+> source name as an alias chip (`cast-aliases.ts:117`), which the shared
+> merge-field logic already does.
+>
+> **Pass-2 lifecycle fix.** A dedup entry must NOT be `kind:'fold'` (the
+> subsequent `writeFoldJournal`→`replaceFoldEntries`, `analysis.ts:697`, would
+> **wipe** it) and must NOT be `kind:'manual'` (`appendManualEntry` is append-only
+> → **duplicate accumulation** on every non-`fresh` resume). Add a dedicated
+> **`kind:'dedup'`** plus an idempotent **`replaceDedupEntries`** (mirrors
+> `replaceFoldEntries`, filters `e.kind !== 'dedup'`) so a re-run replaces rather
+> than appends. The fold journal then runs on the post-dedup state as today.
+> **Pass-3:** `kind` is a plain TS union (`'manual' | 'fold'`, `cast-merges.ts:41`)
+> read with no schema validation — widening it to add `'dedup'` is a **one-line type
+> edit, no openapi/`api-types` regen**. The three replace/append paths are orthogonal
+> (each preserves the other kinds), so no read-collision.
+
+**Shared merge-field logic.** When two entries collapse, fields combine exactly
+as `mergeRosterChapter` already does: longest `description` wins; `attributes` /
+`aliases` / `evidence` union-dedup; `gender` / `ageRange` first-detection wins; a
+divergent name form becomes an alias. This logic is extracted into a small shared
+helper so dedup and `mergeRosterChapter` agree.
+
+**Three detectors, applied in order — Tier-1, then Tier-2a, then Tier-2b** — each
+operating on the output of the previous (so Tier-2a sees already-canonicalised
+Tier-1 ids):
+
+- **Tier-1 — exact normalised name → auto-merge, gender-gated.** Group by
+  `normaliseNameKey(name)` (`util/safe-id.ts:76` — Unicode-exact, no
+  transliteration). Canonical id = `safeId(name)` (deterministic: `Ольга` →
+  `ольга` every time). All group members' ids remap to the canonical id. Catches
+  all four screenshot cases. **Gates (review MINOR-4):** never the narrator (see
+  the absolute rule below); and members must not disagree on `gender` — Tier-1 is
+  the most likely false-merge vector (two genuinely different `Иван`s), and its
+  union-merge *sums* lines/scenes/evidence irreversibly, so a gender clash splits
+  the group rather than conflating two people.
+
+- **Tier-2a — full-vs-short token-subset → auto-merge, gated.** The shorter
+  name's whitespace tokens are all leading tokens of exactly one longer name
+  (`Антон` ⊂ `Антон Городецкий`; Russian name order is first · patronymic ·
+  surname, so leading-subset is reliable). **Gates — all required:** (1) neither
+  entry is the narrator (`id === 'narrator'` — see the absolute rule below);
+  (2) `gender` agrees or one side is unknown; (3) exactly **one** superset
+  candidate exists for the short name (any ambiguity → skip, leave to manual).
+  The two entries have **different** names, so `safeId(name)` can't pick the
+  canonical id: the survivor is the entry with **more lines** (its id and display
+  name win); the other entry's id remaps to it and its name becomes an alias.
+  **Determinism (pass-2):** line counts are computed from the `sentences` arg, not
+  `c.lines` (stage-1 leaves that undefined — `attachLinesAndScenes` runs *post*-fold,
+  `analysis.ts:3945`); ties break by **roster insertion order** (stable per
+  `mergeRosterChapter`).
+
+- **Tier-2b — diminutive curated map → suggestion only (never auto-applied).** A
+  curated bidirectional Russian diminutive↔canonical table
+  (`Оля↔Ольга`, `Соня↔Софья`, `Саша↔Александр/Александра`, `Дима↔Дмитрий`, …, ~80
+  common entries). Two entries whose canonical base matches, passing the same
+  non-narrator + gender gates, emit a `MergeSuggestion { sourceId, targetId,
+  reason }`.
+  > **Pass-2 — multi-gender diminutives.** Some diminutives map to canonicals of
+  > **both** genders (`Саша`→Александр/Александра, `Женя`→Евгений/Евгения,
+  > `Валя`→Валентин/Валентина). The normal gate ("gender agrees OR one side
+  > unknown") is **blind** here: two distinct `Саша`s with gender unset (common on
+  > gemma) would be suggested. For table rows flagged multi-gender, require **both
+  > sides to carry a concrete, agreeing `gender`** (no "unknown" pass); otherwise
+  > skip. Single-gender rows keep the normal gate. **Pass-3:** the gate is
+  > *gender-safe*, not same-person-proof — two different same-gender people both
+  > nicknamed `Саша` remain a **dismissable** false-positive suggestion (by design;
+  > suggestion-only, never auto-merged).
+
+  **No edit-distance** — `Маша`/`Миша` differ by one character but are
+  different people of different genders; the table is a linguistic lookup, not
+  fuzzy string distance.
+
+**Narrator protection is absolute** across **every** tier including Tier-1 — the
+narrator can never be a merge source or target. This single rule defuses the
+plan-221 Wave E disaster (the model once mis-attributed `Антон Городецкий` onto
+the narrator's id; a blind token-subset merge would have folded the entire
+narrator into Anton).
+
+> **Review MAJOR-4 correction:** the predicate is **`id === 'narrator'` only** —
+> NOT `color === 'narrator'`. `color === 'narrator'` is wrong both ways: it
+> over-matches (the `unknown-male`/`unknown-female` fold buckets are stamped
+> `color:'narrator'`, `fold-minor-cast.ts:277`) and it *misses* the real narrator,
+> whose colour is often `'unset'` or a Russian-named/model-assigned value
+> (the narrator row originates from model output, `analysis.ts:1409`). The durable
+> convention is the `id`. Tier-1's narrator-safety must be **enforced**, not left
+> incidental to `safeId('Narrator')==='narrator'`. **Also (pass-2):** guard the
+> *computed* canonical id — a non-narrator group literally named "Narrator"
+> (`safeId('Narrator')==='narrator'`) must never remap onto the real narrator row;
+> reject any group whose canonical id resolves to `'narrator'`.
+
+### Fix 1 (cont.) — designed-voice carry-forward (review BLOCKER-1)
+
+Designed-voice links live inline on the character row, **keyed by character `id`**
+(`overrideTtsVoices`, `voiceUuid`, `ttsEngine`, `voiceStyle`, `voiceId`,
+`matchedFrom`), and carry-forward across a re-analysis is **id-matched** —
+`mergeAnalysisResultWithExistingCast(priorCastForMerge, characters)`
+(`merge-analysis-cast.ts:93-160`, `PRESERVED_VOICE_FIELDS`) and
+`preserveDesignedVoicesOnCastWrite` (`preserve-cast-voices.ts:22-37`). Stage-1
+output carries **no** voice fields, so the prior row's voice is re-applied purely
+by id.
+
+(`merge-analysis-cast.ts` lives in `server/src/store/`.)
+
+**Scope narrowing (pass-2):** for the **Tier-1 same-name** cases (the four
+screenshots — identical display name, drifted id), `mergeAnalysisResultWithExistingCast`
+already has a **same-name fallback** (`merge-analysis-cast.ts:103-141`) that rides a
+dropped voiced row onto a same-name fresh row, so those are largely covered today.
+The genuine exposure is the **Tier-2a/2b different-name survivors** (`Антон`↔`Антон
+Городецкий`), where the names differ, the fallback misses, the voice is **dropped**,
+and the prior row is re-added as a **0-line orphan** (`merge-analysis-cast.ts:155-158`,
+`voicedSurvivorsDropped` at `analysis.ts:4046`).
+
+**Fix:** remap each `priorCastForMerge` row's id through `dd.rewrites` (transitive
+closure) **before** the voice overlay, so the prior voice lands on the canonical
+survivor row with no orphan. Equivalent: thread the rewrite into
+`mergeAnalysisResultWithExistingCast` / `preserveDesignedVoicesOnCastWrite` as an
+id-alias map.
+
+> **Pass-2 BLOCKER — collision policy is mandatory, not a one-liner.** Two prior
+> voiced rows can remap to the **same** canonical id (prior `olga` AND prior `ольга`,
+> each with a *different* designed voice, both → `ольга`). `mergeAnalysisResultWithExistingCast`
+> builds `new Map(existing.map(c => [c.id, c]))` (`:98`) → **last-write-wins, the
+> other designed voice is silently lost**, and `voicedSurvivorsDropped` can't report
+> it (the id now matches a fresh row). The dedup must **resolve voiced collisions
+> explicitly before remapping**: keep the voice of the row with the strongest
+> `voiceState` (`locked` > `tuned` > `reused` > `generated` — the persisted enum,
+> `schemas.ts:71`; present on `priorCastForMerge` rows via `PRESERVED_VOICE_FIELDS`),
+> tie-break by more lines, and **log** every dropped voice via the existing
+> best-effort change-log writer pattern (`logCarriedForwardCharacters`,
+> `analysis.ts:148`). `preserveDesignedVoicesOnCastWrite`
+> (`preserve-cast-voices.ts:27`, id-only, no name fallback) has the same exposure on
+> the frontend `PUT /state` path, so dedup ids must never reach it un-rewritten.
+> This is a **named, tested seam**.
+
+> **Upside:** canonicalising ids to `safeId(name)` makes them **deterministic
+> across re-runs** — the model's transliteration drift was itself a source of
+> reuse-link instability, so post-fix re-analyses match prior voices *more*
+> reliably than today (once the transition run above is handled).
+
+### Fix 1 (cont.) — diminutive suggestions surface (frontend)
+
+`dedupeRosterByName` returns `suggestions`, persisted to a **sibling file**
+`cast-merge-suggestions.json` (a new path helper in `workspace/paths.ts`, sibling
+to `cast-merges.json`) — **NOT** on the `cast.json` envelope.
+
+> **Review MAJOR-3 — why a sibling, not the envelope.** `cast.json` has no
+> `.strict` envelope schema, so a `mergeSuggestions` field would *survive reads*
+> but be **stripped by ~9 fresh-`{ characters }` writers** — every analysis
+> persist (`analysis.ts:2977…5021`), the frontend cast-save `PUT /state`
+> (`book-state.ts:104,567`), cast-aliases, cast-series-patch, and — cruelly — the
+> manual **merge** route itself (`cast-merge.ts:189`). So accepting one suggestion
+> would erase the rest mid-review. A sibling file is untouched by those writers.
+
+**Lifecycle (pass-2):** dedup **overwrites** (replaces, never appends) the sibling
+file at every finalization, and the `fresh:true` analysis reset
+(`analysis.ts:2309`, beside `clearCastMerges`) **deletes** it — otherwise stale
+suggestions referencing now-gone ids leak into a fresh run.
+
+**Honest surface (pass-2 — not "thin"):** a GET route (list suggestions), an
+accept route (delegates to the existing merge route, then drops the suggestion) and
+a dismiss route (drops it); an `openapi.yaml` entry + `npm run openapi:types` regen;
+a redux fetch keyed to analysis-complete; the cast-review card; one e2e spec.
+
+Cast review renders each as a one-tap card:
+
+> *These look like the same person: **Оля** + **Ольга** — [Merge] [Dismiss]*
+
+- **Merge** calls the **existing** manual-merge route (`server/src/routes/cast-merge.ts`),
+  which requires both ids to be standing rows and matches by id only. The
+  suggestion must pass `target = canonical survivor`, `source = the other`
+  (review MINOR-2 — the route performs **no** same-person check, so direction and
+  correctness are the suggestion's responsibility). On success the accepted
+  suggestion is removed from the sibling file.
+- **Dismiss** removes the suggestion from the sibling file.
+
+This is the only net-new UI. It crosses analysis → redux → cast review, so it
+gets one Playwright e2e spec.
+
+### Fix 2 — tone population (two layers; deterministic fill is the reliable one)
+
+> **Review MAJOR-1 + MAJOR-2 reframe.** The original "force `tone` required in the
+> schema → grammar forces emission" is (a) a **no-op unless the wrapper schemas
+> are rewired** — stage-1 actually feeds `stage1ChapterSchema` (per-chapter,
+> `ollama.ts:255` / `gemini.ts:220`) and `stage1Schema` (whole-book/chunked),
+> which *embed* `characterSchema` (`schemas.ts:101,113`); a standalone
+> `analyzerCharacterSchema` changes nothing the model sees — and (b) **dangerous
+> if made hard-required**: the Gemini path sends **no grammar at all** (schema is
+> only post-hoc Zod validation, `gemini.ts:259-316`), so a missing required `tone`
+> → `schema-validation` → one retry → on a second miss the **whole chapter's
+> detection throws**. And there's no in-repo evidence llama.cpp honours `required`
+> on nested objects (it's documented to ignore `additionalProperties:false`,
+> `ollama.ts:313`). **So Layer 2 is the reliable mechanism; Layer 1 is a
+> non-fatal best-effort nudge.**
+
+**Layer 1 — grammar-forced tone via a two-schema `runStage` (non-fatal).**
+
+> **Pass-2 correction — this needs a signature change, not a single schema.**
+> `runStage` currently takes ONE `schema` and uses it for **both** `z.toJSONSchema`
+> (grammar) **and** `parseAndValidate` (validation) (`ollama.ts:319,338`;
+> `gemini.ts:284`). You cannot get "required-in-grammar + optional-in-validation"
+> from one Zod object. So Layer 1 **changes the signature**:
+> `runStage<T>(manuscriptId, key, skill, promptMd, grammarSchema: z.ZodType<unknown>, validationSchema: z.ZodType<T>, call)`
+> in **both** `ollama.ts` and `gemini.ts`. The output type `T` derives from
+> `validationSchema` (the one fed to `parseAndValidate`), so `grammarSchema` may be a
+> structurally-different required-tone schema without perturbing the inferred result.
+> `runStage` has exactly **4 callers per engine** — `runStage1`, `runStage1Chapter`,
+> `runStage2Chapter`, `runEmotionChapter` (`runStage2ChapterChunked` calls
+> `runStage2Chapter`, not `runStage` directly). Only the two **stage-1** callers pass
+> a distinct required-tone `grammarSchema`; `runStage2Chapter` (attribution) and
+> `runEmotionChapter` pass one schema for both params (default `validationSchema =
+> grammarSchema`) → **zero churn, genuinely unperturbed**.
+
+- `grammarSchema` = the wrappers (`stage1ChapterSchema` / `stage1Schema`) embedding
+  an `analyzerCharacterSchema` whose `tone` is **required** (`requiredToneSchema`,
+  all four axes). Fed to `z.toJSONSchema` → the Ollama constrained-decoding grammar
+  forces tone emission.
+- `validationSchema` = the same wrappers embedding a character schema whose `tone`
+  stays **optional**. Fed to `parseAndValidate`, so a model that ignores the grammar
+  (or the Gemini path, which sends **no** grammar and validates only) **never fails
+  the chapter** on a missing tone.
+- Default both params to the same schema for every other `runStage` caller (emotion
+  annotation, etc.) — zero churn outside stage-1.
+
+The persisted `characterSchema` keeps `tone: toneSchema.optional()` regardless (old
+`cast.json` files must validate). A plan probe measures whether the grammar actually
+lifts gemma's emission rate (llama.cpp is documented to ignore `additionalProperties:false`,
+`ollama.ts:313` — `required` on a nested object is unverified); **Layer 2 guarantees
+the outcome either way.**
+
+**Layer 2 — deterministic `fillToneFromAttributes` (PRIMARY — guarantees a
+populated tone).** A pure post-pass: for any character with **missing or partial**
+tone after analysis, derive the absent axes from the model's own descriptor words
+via a **bilingual keyword→axis-nudge table** plus gender/age priors, from a
+neutral-50 baseline, clamped 0–100. This — not the schema — is what guarantees
+every character ends with a populated tone, on every engine and path. Examples:
+
+| Descriptor (EN / RU) | warmth | pace | authority | emotion |
+|---|---|---|---|---|
+| weary, tired / усталый, устал | | −15 | | −10 |
+| pragmatic / прагматичный | −10 | | +15 | |
+| playful / игривый | | +10 | | +15 |
+| wise, mentoring / мудрый, наставнический | +10 | | +15 | |
+| silent, observant / немногословный | | −10 | | −10 |
+| enigmatic / загадочный | −5 | | +5 | −5 |
+
+Fires **only** when tone is absent/partial, so books that already received tone
+(English, or a compliant run) are byte-identical. Language-agnostic (an English
+character lacking tone benefits too), but surgical — present tone is never
+overwritten. Runs at **finalization** (where attributes/gender exist), alongside
+the dedup pass.
+
+### Live-preview behaviour (review MINOR-1 — acknowledged, accepted)
+
+Both passes run at **finalization**, not on the live SSE `cast-update` stream
+(`previewFoldForLiveView` is name-only, exact-id, `analysis.ts:2562…4746`). So
+*during* analysis the user briefly sees the un-deduped roster (duplicate
+`olga`/`ольга` rows) and neutral tone; both resolve when the cast is finalized.
+This is acceptable for v1 and called out so it isn't mistaken for the bug
+persisting. (Deduping the live preview too is possible but adds order-sensitivity
+to the per-chunk SSE path — deferred.)
+
+## Implementation order (pass-3 — no circular dependency; DAG)
+
+A clean TDD order exists; steps 1–6 are pure-function unit-testable in isolation:
+
+1. **`kind:'dedup'` + `replaceDedupEntries`** in `cast-merges.ts` (1-line union widen + replace fn).
+2. **Shared merge-field helper** extracted from `mergeRosterChapter` (pure).
+3. **`dedupeRosterByName`** (`roster-dedup.ts`) — depends on 1–2; full dedup unit suite here, no route.
+4. **`fillToneFromAttributes`** — pure, independent of dedup (parallel with 3).
+5. **Two-schema `runStage`** + `requiredToneSchema` — `ollama.ts`/`gemini.ts` (assert grammar emits `required:['tone']`, validation accepts tone-less).
+6. **Voiced-collision remap into `priorCastForMerge`** — depends on 3's `rewrites`; test at the `merge-analysis-cast` boundary with a synthetic rewrite map (the one seam that needs 2–3 modules composed, not pure-isolated).
+7. **Route wiring** at the two finalization sites + journal writes + suggestion sibling-file lifecycle + `fresh`-reset delete (integration tests).
+8. **Frontend** suggestion card + redux + GET/accept/dismiss route + openapi/types + e2e (last; depends on 7).
+
+## Testing (TDD throughout, per CLAUDE.md)
+
+**Dedup unit (`roster-dedup.test.ts`):**
+- exact-name merge collapses `ольга`+`olga` to one entry, canonical id `ольга`;
+- **Tier-1 gender-disagreement → no merge** (two different same-name people, review MINOR-4);
+- gated full-vs-short auto-merge (`Антон`+`Антон Городецкий`), the short name kept as alias;
+- two distinct supersets (ambiguous) → **no** merge;
+- **narrator never merged** as source or target, across **all** tiers — including a narrator row whose `color` is NOT `'narrator'` (id-only guard, review MAJOR-4);
+- diminutive (`Оля`/`Ольга`) → emits a **suggestion**, roster unchanged;
+- **multi-gender diminutive** (`Саша`) with both genders unset → **no suggestion**; with concrete agreeing gender → suggestion (pass-2);
+- Tier-2a survivor tie-break is deterministic (equal lines → insertion order; lines counted from sentences) (pass-2);
+- **computed canonical id never `'narrator'`** — a non-narrator group named "Narrator" does not remap onto the narrator (pass-2);
+- sentence `characterId` rewrite is correct, and the cumulative table is **transitively closed** through a subsequent `foldMinorCast` fold (review MAJOR-5).
+
+**Voice carry-forward (review BLOCKER-1):**
+- re-analysis of a book with a designed voice on a to-be-deduped (different-name, Tier-2a) id **preserves the voice on the canonical survivor row** and produces **no 0-line orphan**;
+- **collision:** two prior voiced rows remapping to one canonical id keep the **strongest `voiceState`** voice (locked>tuned>reused>generated), drop the other **with a logged event**, and never silently lose it (pass-2 BLOCKER).
+
+**Journal reversibility + lifecycle (review MAJOR-5):**
+- a dedup merge writes a `kind:'dedup'` `cast-merges.json` entry with the correct **pre-dedup** `affected` sentences + `sourceName`, reversible by the un-merge/alias flow;
+- a resume re-analysis **replaces** dedup entries (no duplicate accumulation) and a `fresh` reset **clears** both `cast-merges.json` and `cast-merge-suggestions.json` (pass-2).
+
+**Tone unit:**
+- the stage-1 **grammar schema** marks `tone` required while the **validation schema** keeps it optional — a model response with no `tone` **passes `parseAndValidate`** (does not fail the chapter), on both the Ollama and Gemini paths (two-schema `runStage`, pass-2);
+- other `runStage` callers (emotion annotation) are unaffected (grammar==validation default);
+- persisted `characterSchema` still accepts a tone-less character (regression);
+- `fillToneFromAttributes` derives from EN and RU descriptors; fills only missing axes; leaves present tone untouched; guarantees all four axes populated.
+
+**e2e (`e2e/`):** one Playwright spec — a suggestion (from `cast-merge-suggestions.json`) renders a card; Merge applies via the existing route; Dismiss removes it from the sibling file.
+
+**Regression net:** the failing real-data shape (the four duplicate pairs, the 2/28 tone) is encoded as fixtures so the dedup + tone passes are pinned against the exact production failure.
+
+## Repair of the existing book
+
+Re-analyse *Ночной дозор* on the fixed pipeline (user's choice — no migration
+script). Dedup + `fillToneFromAttributes` apply natively on the fresh run. Safe
+here because the book has no designed voices yet; for any already-voiced book the
+re-analysis is only safe once BLOCKER-1 (rewrite applied to `priorCastForMerge`)
+is implemented.
+
+> **Pass-2 caveat — re-analysis discards manual tone tuning.** `tone` is **not**
+> in `PRESERVED_VOICE_FIELDS` (`merge-analysis-cast.ts:32-42`), so a re-analysis
+> already replaces a user's hand-tuned tone with the fresh roster's (then
+> `fillToneFromAttributes` fills any gaps). The change-log shows the user has tuned
+> tone on this book — those edits will be lost on the re-run. This is **pre-existing
+> behaviour**, not introduced here; flagged so it isn't read as a regression.
+> Optionally adding `tone` to `PRESERVED_VOICE_FIELDS` (preserve tuned tone across
+> re-analysis) is a candidate follow-up but **out of scope** for this change.
+
+## Out of scope (stated explicitly)
+
+- Mixed-language attribute tags (localisation-preamble compliance) — follow-up.
+- Narrator-`я` / byline-author mis-roster — bug #938.
+- Cross-book diminutive/epithet auto-merging — stays manual (plan 221 v1 stance).
+- The dedup pass does not inherit `foldMinorCast`'s pronoun/descriptor guards
+  (review MINOR-3); a model that rosters a pronoun like `я` as a character is the
+  #938 case above. Low risk for dedup (two `я` rows would merge harmlessly), but
+  noted so the plan doesn't assume those guards are present.

--- a/e2e/cast-merge-suggestions.spec.ts
+++ b/e2e/cast-merge-suggestions.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+import { goToConfirm, waitForConfirmViewReady, waitForRouteReady } from './helpers';
+
+/**
+ * Tier-2b diminutive merge-suggestion cards in the cast-review view.
+ *
+ * The mock API (src/lib/api.ts) seeds two suggestions:
+ *   - "eliza" + "halloran" (Eliza Gray / Captain Halloran)
+ *   - "marcus" + "halloran" (Marcus the Cook / Captain Halloran)
+ * Both pairs exist in the mock cast roster so display names resolve.
+ *
+ * Within one test we exercise both Merge (removes one card) and Dismiss
+ * (removes the other), so both button paths are covered without depending
+ * on module-level state ordering between tests.
+ *
+ * Why browser-level: the card fetch is a useEffect keyed to bookId (crosses
+ * router + redux stage), the accept/dismiss calls mutate module-level state,
+ * and the card list drives conditional rendering — exactly the seam
+ * Vitest+jsdom can misread (async effect timing, real DOM removal).
+ */
+
+test.describe('cast view → diminutive merge-suggestion cards', () => {
+  test('shows suggestion cards; Merge and Dismiss each remove a card', async ({ page }) => {
+    await goToConfirm(page);
+    await waitForConfirmViewReady(page);
+
+    /* Confirm the cast → navigate to the cast view. */
+    await page.getByRole('button', { name: /Confirm cast and review manuscript/i }).click();
+    await expect(page).toHaveURL(/#\/books\/.+\/(manuscript|cast|generate|listen)$/, {
+      timeout: 10_000,
+    });
+    const bookId = page.url().match(/#\/books\/([^/]+)\//)?.[1];
+    expect(bookId).toBeTruthy();
+
+    await page.goto(`/#/books/${bookId}/cast`);
+    await waitForRouteReady(page);
+
+    /* Wait for the cast roster to hydrate — the narrator row is always
+       present in the mock cast and proves the CastView is mounted + the
+       characters slice has populated. */
+    await expect(page.getByTestId('cast-row-narrator')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    /* Both seeded suggestion cards should appear after listMergeSuggestions
+       resolves (~40 ms mock delay). */
+    const cards = page.getByTestId('merge-suggestion-card');
+    await expect(cards.first()).toBeVisible({ timeout: 5_000 });
+
+    /* The first card must show recognisable character names. */
+    const firstCard = cards.first();
+    await expect(firstCard).toContainText(/Eliza Gray|Marcus the Cook/);
+
+    /* Record current count before acting. */
+    const totalBefore = await cards.count();
+    expect(totalBefore).toBeGreaterThanOrEqual(1);
+
+    /* ── Merge: click the Merge button on the first card ── */
+    await firstCard.getByTestId('merge-suggestion-merge').click();
+    /* Card is removed from local state — count drops by one. */
+    await expect(cards).toHaveCount(totalBefore - 1, { timeout: 5_000 });
+
+    /* ── Dismiss: click the Dismiss button on the remaining card (if any) ── */
+    if (totalBefore > 1) {
+      const remaining = cards.first();
+      await expect(remaining).toBeVisible({ timeout: 5_000 });
+      await remaining.getByTestId('merge-suggestion-dismiss').click();
+      await expect(cards).toHaveCount(totalBefore - 2, { timeout: 5_000 });
+    }
+  });
+});

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1188,6 +1188,90 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/VoiceMatchResponse' }
 
+  /api/books/{bookId}/cast/merge-suggestions:
+    get:
+      summary: List diminutive merge suggestions for a book
+      operationId: listCastMergeSuggestions
+      description: |
+        Returns the current set of per-book diminutive merge suggestions written
+        by the dedup pass (e.g. "Оля + Ольга — same person?"). Returns
+        `{ suggestions: [] }` when the book is unknown or no file exists —
+        safe to call without a prior existence check.
+      parameters:
+        - { in: path, name: bookId, required: true, schema: { type: string } }
+      responses:
+        '200':
+          description: Current suggestion list (may be empty)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/CastMergeSuggestionsResponse' }
+
+  /api/books/{bookId}/cast/merge-suggestions/dismiss:
+    post:
+      summary: Dismiss a merge suggestion
+      operationId: dismissCastMergeSuggestion
+      description: |
+        Removes the matching `(sourceId, targetId)` pair from the suggestions
+        file. No-op when the pair is already absent. Does NOT perform any merge.
+      parameters:
+        - { in: path, name: bookId, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [sourceId, targetId]
+              properties:
+                sourceId:
+                  type: string
+                  description: The id of the character to fold (the diminutive / duplicate).
+                targetId:
+                  type: string
+                  description: The id of the canonical survivor.
+      responses:
+        '200':
+          description: Suggestion removed (or was already absent)
+        '400':
+          description: sourceId or targetId missing
+        '404':
+          description: Book not found
+
+  /api/books/{bookId}/cast/merge-suggestions/accept:
+    post:
+      summary: Accept a merge suggestion (merge + dismiss)
+      operationId: acceptCastMergeSuggestion
+      description: |
+        Performs the cast merge (`sourceId` folded into `targetId`, where
+        `targetId` is the canonical survivor), then drops the suggestion so it
+        never resurfaces. Equivalent to calling `POST /cast/merge` followed by
+        `POST /cast/merge-suggestions/dismiss`.
+      parameters:
+        - { in: path, name: bookId, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [sourceId, targetId]
+              properties:
+                sourceId:
+                  type: string
+                  description: The id of the character to fold (the diminutive / duplicate).
+                targetId:
+                  type: string
+                  description: The id of the canonical survivor.
+      responses:
+        '200':
+          description: Merge performed and suggestion removed
+        '400':
+          description: Missing or equal sourceId/targetId
+        '404':
+          description: Book or character not found
+        '409':
+          description: Book has no cast yet
+
   /api/queue:
     get:
       summary: Read the workspace-level chapter-generation queue
@@ -2438,6 +2522,34 @@ paths:
 # ---------------------------------------------------------------------
 components:
   schemas:
+    # --- Cast merge suggestions -------------------------------------
+    MergeSuggestion:
+      type: object
+      description: |
+        A suggested merge pair produced by the dedup pass (Tier-2b).
+        `sourceId` is the diminutive/duplicate character; `targetId` is the
+        canonical survivor. The UI surfaces this as "Are Оля and Ольга the
+        same person?" and lets the user accept (merge) or dismiss (keep both).
+      required: [sourceId, targetId, reason]
+      properties:
+        sourceId:
+          type: string
+          description: Id of the character to fold away (the diminutive / duplicate).
+        targetId:
+          type: string
+          description: Id of the canonical surviving character.
+        reason:
+          type: string
+          description: Human-readable explanation of why these were flagged (e.g. "diminutive of Ольга").
+
+    CastMergeSuggestionsResponse:
+      type: object
+      required: [suggestions]
+      properties:
+        suggestions:
+          type: array
+          items: { $ref: '#/components/schemas/MergeSuggestion' }
+
     # --- User settings ----------------------------------------------
     BackupSnapshot:
       type: object

--- a/server/src/analyzer/fill-tone.test.ts
+++ b/server/src/analyzer/fill-tone.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import type { CharacterOutput } from '../handoff/schemas.js';
+import { fillToneFromAttributes } from './fill-tone.js';
+
+const c = (over: Partial<CharacterOutput>): CharacterOutput => ({
+  id: 'a',
+  name: 'A',
+  role: 'r',
+  color: 'c',
+  ...over,
+}) as CharacterOutput;
+
+describe('fillToneFromAttributes', () => {
+  it('derives a non-neutral tone from EN + RU descriptors', () => {
+    const out = fillToneFromAttributes(c({ attributes: ['weary', 'прагматичный'] }));
+    expect(out.tone).toBeDefined();
+    expect(out.tone!.pace).toBeLessThan(50); // weary → slower
+    expect(out.tone!.authority).toBeGreaterThan(50); // pragmatic → more authority
+    [out.tone!.warmth, out.tone!.pace, out.tone!.authority, out.tone!.emotion].forEach((v) => {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(100);
+    });
+  });
+
+  it('fills only missing axes; leaves present axes untouched', () => {
+    const out = fillToneFromAttributes(c({ tone: { warmth: 80 }, attributes: ['playful'] }));
+    expect(out.tone!.warmth).toBe(80); // preserved
+    expect(out.tone!.emotion).toBeGreaterThan(50); // playful → more emotion (was missing)
+  });
+
+  it('yields neutral 50s when there are no usable attributes', () => {
+    const out = fillToneFromAttributes(c({}));
+    expect(out.tone).toEqual({ warmth: 50, pace: 50, authority: 50, emotion: 50 });
+  });
+});

--- a/server/src/analyzer/fill-tone.ts
+++ b/server/src/analyzer/fill-tone.ts
@@ -1,0 +1,47 @@
+import { normaliseNameKey } from '../util/safe-id.js';
+import type { CharacterOutput } from '../handoff/schemas.js';
+
+type Axis = 'warmth' | 'pace' | 'authority' | 'emotion';
+
+/* Keyword → axis deltas off a neutral 50 baseline. Keys are normaliseNameKey'd
+   (script-exact, case-insensitive) EN + RU descriptors. Extend from corpus. */
+const NUDGES: Record<string, Partial<Record<Axis, number>>> = {
+  [normaliseNameKey('weary')]: { pace: -15, emotion: -10 },
+  [normaliseNameKey('tired')]: { pace: -15, emotion: -10 },
+  [normaliseNameKey('усталый')]: { pace: -15, emotion: -10 },
+  [normaliseNameKey('устал')]: { pace: -15, emotion: -10 },
+  [normaliseNameKey('pragmatic')]: { authority: 15, warmth: -10 },
+  [normaliseNameKey('прагматичный')]: { authority: 15, warmth: -10 },
+  [normaliseNameKey('playful')]: { emotion: 15, pace: 10 },
+  [normaliseNameKey('игривый')]: { emotion: 15, pace: 10 },
+  [normaliseNameKey('wise')]: { authority: 15, warmth: 10 },
+  [normaliseNameKey('мудрый')]: { authority: 15, warmth: 10 },
+  [normaliseNameKey('наставнический')]: { authority: 15, warmth: 10 },
+  [normaliseNameKey('silent')]: { pace: -10, emotion: -10 },
+  [normaliseNameKey('observant')]: { pace: -10, emotion: -10 },
+  [normaliseNameKey('немногословный')]: { pace: -10, emotion: -10 },
+  [normaliseNameKey('enigmatic')]: { warmth: -5, authority: 5, emotion: -5 },
+  [normaliseNameKey('загадочный')]: { warmth: -5, authority: 5, emotion: -5 },
+  // …extend as real runs surface more descriptor words.
+};
+
+const clamp = (n: number) => Math.max(0, Math.min(100, Math.round(n)));
+
+export function fillToneFromAttributes(ch: CharacterOutput): CharacterOutput {
+  const derived: Record<Axis, number> = { warmth: 50, pace: 50, authority: 50, emotion: 50 };
+  for (const attr of ch.attributes ?? []) {
+    const nudge = NUDGES[normaliseNameKey(attr)];
+    if (!nudge) continue;
+    for (const axis of Object.keys(nudge) as Axis[]) {
+      derived[axis] += nudge[axis]!;
+    }
+  }
+  const existing = ch.tone ?? {};
+  const tone = {
+    warmth: existing.warmth ?? clamp(derived.warmth),
+    pace: existing.pace ?? clamp(derived.pace),
+    authority: existing.authority ?? clamp(derived.authority),
+    emotion: existing.emotion ?? clamp(derived.emotion),
+  };
+  return { ...ch, tone };
+}

--- a/server/src/analyzer/gemini.ts
+++ b/server/src/analyzer/gemini.ts
@@ -18,6 +18,8 @@ import {
   stage1ChapterSchema,
   stage2ChapterSchema,
   emotionAnnotationSchema,
+  stage1GrammarSchema,
+  stage1ChapterGrammarSchema,
   type Stage1Output,
   type Stage1ChapterOutput,
   type Stage2ChapterOutput,
@@ -202,7 +204,15 @@ export class GeminiAnalyzer implements Analyzer {
   }
 
   async runStage1(manuscriptId: string, promptMd: string, call: StageCall): Promise<Stage1Output> {
-    return this.runStage(manuscriptId, '1', 'whole_book_stage1', promptMd, stage1Schema, call);
+    return this.runStage(
+      manuscriptId,
+      '1',
+      'whole_book_stage1',
+      promptMd,
+      stage1GrammarSchema,
+      stage1Schema,
+      call,
+    );
   }
 
   async runStage1Chapter(
@@ -217,6 +227,7 @@ export class GeminiAnalyzer implements Analyzer {
       key,
       'per_chapter_stage1',
       promptMd,
+      stage1ChapterGrammarSchema,
       stage1ChapterSchema,
       call,
     );
@@ -235,6 +246,7 @@ export class GeminiAnalyzer implements Analyzer {
       'per_chapter_stage2',
       promptMd,
       stage2ChapterSchema,
+      stage2ChapterSchema,
       call,
     );
   }
@@ -252,6 +264,7 @@ export class GeminiAnalyzer implements Analyzer {
       'emotion_annotation',
       promptMd,
       emotionAnnotationSchema,
+      emotionAnnotationSchema,
       call,
     );
   }
@@ -261,7 +274,8 @@ export class GeminiAnalyzer implements Analyzer {
     key: HandoffKey,
     skillName: SkillName,
     promptMd: string,
-    schema: z.ZodType<T>,
+    _grammarSchema: z.ZodType<unknown>,
+    validationSchema: z.ZodType<T>,
     call: StageCall,
   ): Promise<T> {
     await writeInbox(manuscriptId, key, promptMd);
@@ -281,7 +295,7 @@ export class GeminiAnalyzer implements Analyzer {
         call,
       );
 
-      const firstAttempt = parseAndValidate(firstText, schema);
+      const firstAttempt = parseAndValidate(firstText, validationSchema);
       if (firstAttempt.ok) {
         await persistResponse(manuscriptId, key, firstText);
         return firstAttempt.value;
@@ -309,7 +323,7 @@ export class GeminiAnalyzer implements Analyzer {
         call,
       );
 
-      const secondAttempt = parseAndValidate(secondText, schema);
+      const secondAttempt = parseAndValidate(secondText, validationSchema);
       if (secondAttempt.ok) {
         await persistResponse(manuscriptId, key, secondText);
         return secondAttempt.value;

--- a/server/src/analyzer/ollama.test.ts
+++ b/server/src/analyzer/ollama.test.ts
@@ -10,6 +10,7 @@
    server, just a deterministic Response object per scenario. */
 
 import { describe, it, expect, vi, beforeAll, beforeEach, afterAll, afterEach } from 'vitest';
+import { z } from 'zod';
 import { mkdir, rm } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -299,6 +300,59 @@ describe('OllamaAnalyzer — schema-constrained `format`', () => {
     expect(s2.properties.sentences.items.required).toEqual(
       expect.arrayContaining(['id', 'chapterId', 'characterId', 'text']),
     );
+  });
+});
+
+describe('OllamaAnalyzer — two-schema runStage (grammar vs validation)', () => {
+  /* Task 7: runStage now accepts grammarSchema (fed to z.toJSONSchema → Ollama
+     format) and validationSchema (fed to parseAndValidate). For stage1Chapter,
+     the grammar uses stage1ChapterGrammarSchema (tone REQUIRED) while
+     validation uses stage1ChapterSchema (tone OPTIONAL). A response with no
+     tone field must pass validation without a retry. */
+  it('a stage-1 response with NO tone passes validation (non-fatal), grammar still required-tone', async () => {
+    /* Arrange: character without tone — grammar requires it, validation tolerates absence. */
+    const noToneResponse = JSON.stringify({
+      characters: [
+        {
+          id: 'narrator',
+          name: 'Narrator',
+          role: 'narrator',
+          color: 'narrator',
+          /* NOTE: tone is intentionally absent here — the validation schema
+             (stage1ChapterSchema → characterSchema) marks tone as optional.
+             A missing tone must NOT fail parseAndValidate or trigger a retry. */
+        },
+      ],
+    });
+    fetchMock.mockResolvedValue(okResponse(ndjsonStream(chunksOf(noToneResponse, 32))));
+
+    const { OllamaAnalyzer } = await import('./ollama.js');
+    const { stage1ChapterGrammarSchema } = await import('../handoff/schemas.js');
+    const analyzer = new OllamaAnalyzer({ url: 'http://localhost:11434', model: 'qwen3.5:4b' });
+
+    /* (b) validation is tolerant: the call succeeds with no retry */
+    const result = await analyzer.runStage1Chapter(
+      'm_ollama_two_schema',
+      1,
+      '# stage1 prompt',
+      {},
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1); // no retry
+    expect(result.characters).toHaveLength(1);
+    expect(result.characters[0].tone).toBeUndefined(); // absent is fine
+
+    /* (a) grammar fed to Ollama is derived from the required-tone grammar schema */
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as { body: string }).body);
+    const expectedGrammar = z.toJSONSchema(stage1ChapterGrammarSchema, {
+      target: 'draft-07',
+      reused: 'inline',
+    });
+    expect(body.format).toEqual(expectedGrammar);
+
+    /* Confirm the grammar schema DOES require tone (its character items list
+       tone as required), while the validation schema does not. */
+    const charItems = body.format.properties.characters.items;
+    expect(charItems.required).toContain('tone');
   });
 });
 
@@ -634,6 +688,7 @@ afterAll(async () => {
     'm_ollama_format_shape_diff',
     'm_ollama_raw_attempt1',
     'm_ollama_raw_both',
+    'm_ollama_two_schema',
   ]) {
     await rm(resolve(HANDOFF_ROOT, 'inbox', `${id}-stage1-ch1.md`), { force: true });
     await rm(resolve(HANDOFF_ROOT, 'outbox', `${id}-stage1-ch1.json`), { force: true });

--- a/server/src/analyzer/ollama.ts
+++ b/server/src/analyzer/ollama.ts
@@ -24,6 +24,8 @@ import {
   stage1ChapterSchema,
   stage2ChapterSchema,
   emotionAnnotationSchema,
+  stage1GrammarSchema,
+  stage1ChapterGrammarSchema,
   type Stage1Output,
   type Stage1ChapterOutput,
   type Stage2ChapterOutput,
@@ -237,7 +239,15 @@ export class OllamaAnalyzer implements Analyzer {
   }
 
   async runStage1(manuscriptId: string, promptMd: string, call: StageCall): Promise<Stage1Output> {
-    return this.runStage(manuscriptId, '1', 'whole_book_stage1', promptMd, stage1Schema, call);
+    return this.runStage(
+      manuscriptId,
+      '1',
+      'whole_book_stage1',
+      promptMd,
+      stage1GrammarSchema,
+      stage1Schema,
+      call,
+    );
   }
 
   async runStage1Chapter(
@@ -252,6 +262,7 @@ export class OllamaAnalyzer implements Analyzer {
       key,
       'per_chapter_stage1',
       promptMd,
+      stage1ChapterGrammarSchema,
       stage1ChapterSchema,
       call,
     );
@@ -270,6 +281,7 @@ export class OllamaAnalyzer implements Analyzer {
       'per_chapter_stage2',
       promptMd,
       stage2ChapterSchema,
+      stage2ChapterSchema,
       call,
     );
   }
@@ -287,6 +299,7 @@ export class OllamaAnalyzer implements Analyzer {
       'emotion_annotation',
       promptMd,
       emotionAnnotationSchema,
+      emotionAnnotationSchema,
       call,
     );
   }
@@ -296,27 +309,31 @@ export class OllamaAnalyzer implements Analyzer {
     key: HandoffKey,
     skillName: SkillName,
     promptMd: string,
-    schema: z.ZodType<T>,
+    grammarSchema: z.ZodType<unknown>,
+    validationSchema: z.ZodType<T>,
     call: StageCall,
   ): Promise<T> {
     await writeInbox(manuscriptId, key, promptMd);
 
     const skill = await loadSkill(skillName);
     const systemInstruction = buildSystemInstruction(skill, call.language);
-    /* Convert the per-stage Zod schema into a JSON Schema for Ollama 0.5+
-       structured-output (constrained decoding). reused:'inline' inlines
-       nested schemas (characterSchema inside stage1ChapterSchema, etc.) so
-       Ollama doesn't have to resolve $ref — safer across engine versions.
-       target:'draft-07' keeps the same dialect zod-to-json-schema emitted
-       before the Zod 4 bump. The resulting schema preserves .strict() as
-       additionalProperties:false and .min(1) as minItems:1, constraining the
-       overall JSON shape. NOTE: llama.cpp's grammar conversion does NOT honour
-       additionalProperties:false — the model can still stamp an extra key on
-       an object (the real qwen3.5:9b per-chapter cast failure stamped a stray
-       top-level `chapterId`). parseAndValidate tolerates that by stripping
-       unrecognized-keys-only failures, so a stray key no longer discards a
-       whole chapter. */
-    const responseFormat = z.toJSONSchema(schema, { target: 'draft-07', reused: 'inline' });
+    /* Convert the GRAMMAR schema into a JSON Schema for Ollama 0.5+ structured-
+       output (constrained decoding). grammarSchema may differ from
+       validationSchema — e.g. stage1ChapterGrammarSchema makes tone REQUIRED so
+       the model is nudged to emit it, while stage1ChapterSchema (the validation
+       schema) keeps tone optional so a missing tone never fails a chapter.
+       reused:'inline' inlines nested schemas (characterSchema inside
+       stage1ChapterSchema, etc.) so Ollama doesn't have to resolve $ref — safer
+       across engine versions. target:'draft-07' keeps the same dialect
+       zod-to-json-schema emitted before the Zod 4 bump. The resulting schema
+       preserves .strict() as additionalProperties:false and .min(1) as
+       minItems:1, constraining the overall JSON shape. NOTE: llama.cpp's grammar
+       conversion does NOT honour additionalProperties:false — the model can still
+       stamp an extra key on an object (the real qwen3.5:9b per-chapter cast
+       failure stamped a stray top-level `chapterId`). parseAndValidate tolerates
+       that by stripping unrecognized-keys-only failures, so a stray key no
+       longer discards a whole chapter. */
+    const responseFormat = z.toJSONSchema(grammarSchema, { target: 'draft-07', reused: 'inline' });
 
     const start = Date.now();
     const tick = call.onWaiting
@@ -335,7 +352,7 @@ export class OllamaAnalyzer implements Analyzer {
         call.signal,
       );
 
-      const firstAttempt = parseAndValidate(firstText, schema);
+      const firstAttempt = parseAndValidate(firstText, validationSchema);
       if (firstAttempt.ok) {
         if (firstAttempt.repaired) {
           console.warn(
@@ -392,7 +409,7 @@ export class OllamaAnalyzer implements Analyzer {
         call.signal,
       );
 
-      const secondAttempt = parseAndValidate(secondText, schema);
+      const secondAttempt = parseAndValidate(secondText, validationSchema);
       if (secondAttempt.ok) {
         if (secondAttempt.repaired) {
           console.warn(

--- a/server/src/analyzer/roster-dedup.test.ts
+++ b/server/src/analyzer/roster-dedup.test.ts
@@ -1,7 +1,8 @@
+import { describe, expect, it } from 'vitest';
 import { dedupeRosterByName, composeRewrites } from './roster-dedup.js';
 
 const c = (over: { id: string; name: string; role?: string; color?: string; gender?: string; [key: string]: unknown }) =>
-  ({ id: over.id, name: over.name, role: over.role ?? 'r', color: over.color ?? 'c', ...over });
+  ({ role: 'r', color: 'c', ...over });
 const sent = (characterId: string, n = 1) => Array.from({ length: n }, () => ({ characterId }));
 
 describe('dedupeRosterByName Tier-1 (exact name)', () => {

--- a/server/src/analyzer/roster-dedup.test.ts
+++ b/server/src/analyzer/roster-dedup.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { dedupeRosterByName, composeRewrites } from './roster-dedup.js';
+import { dedupeRosterByName, composeRewrites, pruneSuggestionsToRoster } from './roster-dedup.js';
 
 const c = (over: { id: string; name: string; role?: string; color?: string; gender?: string; [key: string]: unknown }) =>
   ({ role: 'r', color: 'c', ...over });
@@ -71,6 +71,26 @@ describe('dedupeRosterByName Tier-2b (diminutive suggestions)', () => {
     const chars = [c({ id: 's1', name: 'Саша' }), c({ id: 's2', name: 'Александр' })];
     const r = dedupeRosterByName(chars as any, [...sent('s1'), ...sent('s2')]);
     expect(r.suggestions).toEqual([]);
+  });
+});
+
+describe('pruneSuggestionsToRoster', () => {
+  it('drops a suggestion whose sourceId is absent from the roster', () => {
+    const suggestions = [{ sourceId: 'olya', targetId: 'ольга', reason: 'Diminutive of «Ольга»' }];
+    const roster = [{ id: 'ольга' }];
+    expect(pruneSuggestionsToRoster(suggestions, roster)).toEqual([]);
+  });
+
+  it('drops a suggestion whose targetId is absent from the roster', () => {
+    const suggestions = [{ sourceId: 'olya', targetId: 'ольга', reason: 'Diminutive of «Ольга»' }];
+    const roster = [{ id: 'olya' }];
+    expect(pruneSuggestionsToRoster(suggestions, roster)).toEqual([]);
+  });
+
+  it('keeps a suggestion when both ids are present in the roster', () => {
+    const suggestions = [{ sourceId: 'olya', targetId: 'ольга', reason: 'Diminutive of «Ольга»' }];
+    const roster = [{ id: 'olya' }, { id: 'ольга' }];
+    expect(pruneSuggestionsToRoster(suggestions, roster)).toEqual(suggestions);
   });
 });
 

--- a/server/src/analyzer/roster-dedup.test.ts
+++ b/server/src/analyzer/roster-dedup.test.ts
@@ -1,0 +1,79 @@
+import { dedupeRosterByName, composeRewrites } from './roster-dedup.js';
+
+const c = (over: { id: string; name: string; role?: string; color?: string; gender?: string; [key: string]: unknown }) =>
+  ({ id: over.id, name: over.name, role: over.role ?? 'r', color: over.color ?? 'c', ...over });
+const sent = (characterId: string, n = 1) => Array.from({ length: n }, () => ({ characterId }));
+
+describe('dedupeRosterByName Tier-1 (exact name)', () => {
+  it('collapses olga + ольга to one entry with canonical id ольга', () => {
+    const chars = [c({ id: 'olga', name: 'Ольга', gender: 'female' }), c({ id: 'ольга', name: 'Ольга', gender: 'female' })];
+    const r = dedupeRosterByName(chars as any, [...sent('olga', 8), ...sent('ольга', 203)]);
+    expect(r.characters).toHaveLength(1);
+    expect(r.characters[0].id).toBe('ольга');
+    expect(r.rewrites).toEqual({ olga: 'ольга' });
+  });
+
+  it('does NOT merge two same-name people of different gender', () => {
+    const chars = [c({ id: 'ivan', name: 'Иван', gender: 'male' }), c({ id: 'ivan2', name: 'Иван', gender: 'female' })];
+    const r = dedupeRosterByName(chars as any, [...sent('ivan'), ...sent('ivan2')]);
+    expect(r.characters).toHaveLength(2);
+  });
+
+  it('never merges the narrator, even with a non-narrator group named "Narrator"', () => {
+    const chars = [c({ id: 'narrator', name: 'Narrator', color: 'unset' }), c({ id: 'narrator-2', name: 'Narrator' })];
+    const r = dedupeRosterByName(chars as any, [...sent('narrator'), ...sent('narrator-2')]);
+    // narrator row untouched; the non-narrator "Narrator" group must NOT remap onto id 'narrator'
+    expect(r.characters.find((x) => x.id === 'narrator')).toBeDefined();
+    expect(Object.values(r.rewrites)).not.toContain('narrator');
+  });
+});
+
+describe('dedupeRosterByName Tier-2a (full vs short)', () => {
+  it('auto-merges Антон into Антон Городецкий, survivor = more lines, short name aliased', () => {
+    const chars = [c({ id: 'anton', name: 'Антон', gender: 'male' }), c({ id: 'anton-gorodetsky', name: 'Антон Городецкий', gender: 'male' })];
+    const r = dedupeRosterByName(chars as any, [...sent('anton', 3), ...sent('anton-gorodetsky', 50)]);
+    expect(r.characters).toHaveLength(1);
+    expect(r.characters[0].id).toBe('anton-gorodetsky');
+    expect(r.characters[0].aliases).toContain('Антон');
+    expect(r.rewrites).toEqual({ anton: 'anton-gorodetsky' });
+  });
+
+  it('does NOT merge when two longer names both contain the short name (ambiguous)', () => {
+    const chars = [
+      c({ id: 'anton', name: 'Антон', gender: 'male' }),
+      c({ id: 'ag', name: 'Антон Городецкий', gender: 'male' }),
+      c({ id: 'ai', name: 'Антон Иванов', gender: 'male' }),
+    ];
+    const r = dedupeRosterByName(chars as any, [...sent('anton'), ...sent('ag'), ...sent('ai')]);
+    expect(r.characters).toHaveLength(3);
+  });
+});
+
+describe('dedupeRosterByName Tier-2b (diminutive suggestions)', () => {
+  it('emits a suggestion for Оля + Ольга without merging', () => {
+    const chars = [c({ id: 'olya', name: 'Оля', gender: 'female' }), c({ id: 'ольга', name: 'Ольга', gender: 'female' })];
+    const r = dedupeRosterByName(chars as any, [...sent('olya', 4), ...sent('ольга', 30)]);
+    expect(r.characters).toHaveLength(2);
+    expect(r.rewrites).toEqual({});
+    expect(r.suggestions).toEqual([{ sourceId: 'olya', targetId: 'ольга', reason: expect.any(String) }]);
+  });
+
+  it('does NOT suggest a multi-gender diminutive when genders are unset', () => {
+    const chars = [c({ id: 's1', name: 'Саша' }), c({ id: 's2', name: 'Александр' })];
+    const r = dedupeRosterByName(chars as any, [...sent('s1'), ...sent('s2')]);
+    expect(r.suggestions).toEqual([]);
+  });
+});
+
+describe('composeRewrites', () => {
+  it('chains two maps transitively', () => {
+    const result = composeRewrites({ olga: 'ольга' }, { 'ольга': 'unknown-female' });
+    expect(result).toEqual({ olga: 'unknown-female', 'ольга': 'unknown-female' });
+  });
+
+  it('returns empty map when maps do not chain', () => {
+    const result = composeRewrites({ a: 'b' }, { c: 'd' });
+    // No chaining, no identity entries, just both individual mappings
+    expect(result).toEqual({ a: 'b', c: 'd' });
+  });
+});

--- a/server/src/analyzer/roster-dedup.test.ts
+++ b/server/src/analyzer/roster-dedup.test.ts
@@ -38,6 +38,14 @@ describe('dedupeRosterByName Tier-2a (full vs short)', () => {
     expect(r.rewrites).toEqual({ anton: 'anton-gorodetsky' });
   });
 
+  it('Tier-2a tie on equal lines → earlier roster entry survives', () => {
+    const chars = [c({ id: 'anton', name: 'Антон', gender: 'male' }), c({ id: 'anton-gorodetsky', name: 'Антон Городецкий', gender: 'male' })];
+    const r = dedupeRosterByName(chars as any, [...sent('anton', 5), ...sent('anton-gorodetsky', 5)]);
+    expect(r.characters).toHaveLength(1);
+    expect(r.characters[0].id).toBe('anton'); // earlier-in-roster wins the tie
+    expect(r.rewrites).toEqual({ 'anton-gorodetsky': 'anton' });
+  });
+
   it('does NOT merge when two longer names both contain the short name (ambiguous)', () => {
     const chars = [
       c({ id: 'anton', name: 'Антон', gender: 'male' }),

--- a/server/src/analyzer/roster-dedup.ts
+++ b/server/src/analyzer/roster-dedup.ts
@@ -1,0 +1,207 @@
+import type { CharacterOutput } from '../handoff/schemas.js';
+import { safeId, normaliseNameKey } from '../util/safe-id.js';
+import { mergeCharacterFields } from './roster-merge-fields.js';
+import { diminutiveCanonical } from './ru-diminutives.js';
+
+export interface MergeSuggestion { sourceId: string; targetId: string; reason: string }
+
+const NARRATOR_ID = 'narrator';
+
+const gendersConflict = (a?: string, b?: string): boolean => !!a && !!b && a !== b;
+
+/** Tokenise a name into normalised fragments for the token-subset check. */
+const tokens = (name: string): string[] =>
+  name.trim().split(/\s+/).map((t) => normaliseNameKey(t)).filter(Boolean);
+
+/** Count attributed lines per character id from the sentence array. */
+function lineCounts(sentences: ReadonlyArray<{ characterId: string }>): Map<string, number> {
+  const m = new Map<string, number>();
+  for (const s of sentences) m.set(s.characterId, (m.get(s.characterId) ?? 0) + 1);
+  return m;
+}
+
+// ── composeRewrites ──────────────────────────────────────────────────────────
+
+/** Compose two rewrite maps transitively. For every id that is a key in either
+    map, returns its FINAL target after applying `first` then `second` (chasing
+    the chain once; cycles are guarded). Identity entries (final === original)
+    are omitted from the result. */
+export function composeRewrites(
+  first: Record<string, string>,
+  second: Record<string, string>,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  const allKeys = new Set([...Object.keys(first), ...Object.keys(second)]);
+  for (const key of allKeys) {
+    // Apply first map, then second map once (single transitive step).
+    const afterFirst = first[key] ?? key;
+    const afterSecond = second[afterFirst] ?? afterFirst;
+    // Guard cycles: if we'd loop back to the key itself, stop.
+    if (afterSecond !== key) {
+      result[key] = afterSecond;
+    }
+  }
+  return result;
+}
+
+// ── dedupeRosterByName ───────────────────────────────────────────────────────
+
+export function dedupeRosterByName(
+  characters: CharacterOutput[],
+  sentences: ReadonlyArray<{ characterId: string }>,
+  _opts: { language?: string } = {},
+): { characters: CharacterOutput[]; rewrites: Record<string, string>; suggestions: MergeSuggestion[] } {
+  const lines = lineCounts(sentences);
+  const rewrites: Record<string, string> = {};
+  // Work on shallow clones so callers keep their input; preserve insertion order.
+  let roster: CharacterOutput[] = characters.map((ch) => ({ ...ch }));
+
+  // ── Tier-1: exact normalised name, gender-gated, never narrator ──────────
+  const byKey = new Map<string, CharacterOutput[]>();
+  for (const ch of roster) {
+    if (ch.id === NARRATOR_ID) continue;
+    const key = normaliseNameKey(ch.name);
+    if (!key) continue;
+    if (!byKey.has(key)) byKey.set(key, []);
+    byKey.get(key)!.push(ch);
+  }
+
+  // tier1Survivors: canonicalId → merged survivor node.
+  const tier1Survivors = new Map<string, CharacterOutput>();
+  // ids that have been consumed (should not appear in the rebuilt roster).
+  const dropped = new Set<string>();
+
+  for (const group of byKey.values()) {
+    if (group.length < 2) continue;
+
+    // Gender conflict → leave the whole group un-merged (conservative).
+    const genders = new Set(group.map((g) => g.gender).filter(Boolean));
+    if (genders.size > 1) continue;
+
+    const canonicalId = safeId(group[0].name);
+    // Never remap onto the special narrator id.
+    if (canonicalId === NARRATOR_ID) continue;
+
+    // Build the survivor: start from the first group member, assign canonical id.
+    const survivor: CharacterOutput = { ...group[0], id: canonicalId };
+
+    // Record rewrite for the first member if its id differs from canonical.
+    if (group[0].id !== canonicalId) rewrites[group[0].id] = canonicalId;
+
+    // Merge remaining members into survivor.
+    for (const member of group.slice(1)) {
+      mergeCharacterFields(survivor, member);
+      if (member.id !== canonicalId) rewrites[member.id] = canonicalId;
+      dropped.add(member.id);
+    }
+
+    // Drop the first member too if it was replaced by the canonical id.
+    if (group[0].id !== canonicalId) dropped.add(group[0].id);
+
+    tier1Survivors.set(canonicalId, survivor);
+  }
+
+  // Rebuild roster: for each original slot, either keep it or replace the
+  // first occurrence of its group with the survivor.
+  const emittedT1 = new Set<string>();
+  roster = roster.flatMap((ch) => {
+    if (ch.id === NARRATOR_ID) return [ch];
+    const canonicalId = rewrites[ch.id] ?? ch.id;
+    const survivor = tier1Survivors.get(canonicalId);
+    if (!survivor) return [ch]; // not part of any Tier-1 group
+    if (emittedT1.has(canonicalId)) return []; // already emitted this group's survivor
+    emittedT1.add(canonicalId);
+    return [survivor];
+  });
+
+  // ── Tier-2a: full-vs-short token subset, single superset, auto-merge ─────
+  const linesOf = (ch: CharacterOutput): number => lines.get(ch.id) ?? 0;
+
+  // Iterate a stable snapshot; track which ids were consumed this tier.
+  const snapshot = [...roster];
+  const droppedT2 = new Set<string>();
+
+  for (const short of snapshot) {
+    if (short.id === NARRATOR_ID || droppedT2.has(short.id)) continue;
+    const sTok = tokens(short.name);
+    if (sTok.length === 0) continue;
+
+    // Find entries whose token list is a proper superset starting with short's tokens.
+    const supersets = snapshot.filter(
+      (long) =>
+        long !== short &&
+        long.id !== NARRATOR_ID &&
+        !droppedT2.has(long.id) &&
+        tokens(long.name).length > sTok.length &&
+        sTok.every((t, i) => tokens(long.name)[i] === t) &&
+        !gendersConflict(short.gender, long.gender),
+    );
+
+    // Ambiguous (0 or 2+) → skip.
+    if (supersets.length !== 1) continue;
+
+    const long = supersets[0];
+    // Survivor = more lines; tie → earlier in roster (snapshot) order = `long`
+    // since the outer loop visits shorter-name candidates and the superset is
+    // always the longer name, which was encountered before or after.
+    // When tied, prefer the one that appears earlier in snapshot order.
+    const longLines = linesOf(long);
+    const shortLines = linesOf(short);
+    let survivor: CharacterOutput;
+    let victim: CharacterOutput;
+    if (longLines >= shortLines) {
+      survivor = long;
+      victim = short;
+    } else {
+      survivor = short;
+      victim = long;
+    }
+
+    mergeCharacterFields(survivor, victim);
+    rewrites[victim.id] = survivor.id;
+    droppedT2.add(victim.id);
+  }
+
+  roster = roster.filter((ch) => !droppedT2.has(ch.id));
+
+  // Collapse rewrites transitively (a victim may have been a Tier-1 canonical).
+  for (const k of Object.keys(rewrites)) {
+    let v = rewrites[k];
+    const visited = new Set<string>([k]);
+    while (rewrites[v] && rewrites[v] !== v && !visited.has(rewrites[v])) {
+      visited.add(v);
+      v = rewrites[v];
+    }
+    rewrites[k] = v;
+  }
+
+  // ── Tier-2b: diminutive → suggestion only ────────────────────────────────
+  const suggestions: MergeSuggestion[] = [];
+  for (let i = 0; i < roster.length; i++) {
+    for (let j = i + 1; j < roster.length; j++) {
+      const a = roster[i];
+      const b = roster[j];
+      if (a.id === NARRATOR_ID || b.id === NARRATOR_ID) continue;
+
+      const da = diminutiveCanonical(a.name);
+      const db = diminutiveCanonical(b.name);
+      if (!da || !db || da.base !== db.base) continue;
+
+      // Exact same normalised name → already handled by Tier-1.
+      if (normaliseNameKey(a.name) === normaliseNameKey(b.name)) continue;
+
+      // Gender conflict → skip.
+      if (gendersConflict(a.gender, b.gender)) continue;
+
+      // Multi-gender diminutive requires both sides to have concrete, agreeing gender.
+      if (da.multiGender && (!a.gender || !b.gender)) continue;
+
+      // Source = fewer lines; target = more lines (ties → i < j so b is target).
+      const target = linesOf(a) >= linesOf(b) ? a : b;
+      const source = target === a ? b : a;
+      suggestions.push({ sourceId: source.id, targetId: target.id, reason: `Diminutive of «${target.name}»` });
+    }
+  }
+
+  return { characters: roster, rewrites, suggestions };
+}

--- a/server/src/analyzer/roster-dedup.ts
+++ b/server/src/analyzer/roster-dedup.ts
@@ -205,3 +205,14 @@ export function dedupeRosterByName(
 
   return { characters: roster, rewrites, suggestions };
 }
+
+/** Drop suggestions whose source OR target id is not a standing character in the
+    final (post-fold) roster — the fold may have collapsed a low-line diminutive
+    into a bucket, which would leave a suggestion pointing at a gone id. */
+export function pruneSuggestionsToRoster(
+  suggestions: MergeSuggestion[],
+  characters: ReadonlyArray<{ id: string }>,
+): MergeSuggestion[] {
+  const ids = new Set(characters.map((c) => c.id));
+  return suggestions.filter((s) => ids.has(s.sourceId) && ids.has(s.targetId));
+}

--- a/server/src/analyzer/roster-dedup.ts
+++ b/server/src/analyzer/roster-dedup.ts
@@ -141,15 +141,15 @@ export function dedupeRosterByName(
     if (supersets.length !== 1) continue;
 
     const long = supersets[0];
-    // Survivor = more lines; tie → earlier in roster (snapshot) order = `long`
-    // since the outer loop visits shorter-name candidates and the superset is
-    // always the longer name, which was encountered before or after.
+    // Survivor = more lines; tie → earlier in roster (snapshot) order.
     // When tied, prefer the one that appears earlier in snapshot order.
     const longLines = linesOf(long);
     const shortLines = linesOf(short);
     let survivor: CharacterOutput;
     let victim: CharacterOutput;
-    if (longLines >= shortLines) {
+    const shortIdx = snapshot.indexOf(short);
+    const longIdx = snapshot.indexOf(long);
+    if (longLines > shortLines || (longLines === shortLines && longIdx < shortIdx)) {
       survivor = long;
       victim = short;
     } else {

--- a/server/src/analyzer/roster-merge-fields.test.ts
+++ b/server/src/analyzer/roster-merge-fields.test.ts
@@ -1,0 +1,34 @@
+import { mergeCharacterFields } from './roster-merge-fields.js';
+import type { CharacterOutput } from '../handoff/schemas.js';
+
+const base = (over: Partial<CharacterOutput>): CharacterOutput => ({
+  id: 'a',
+  name: 'Anton',
+  role: 'r',
+  color: 'c',
+  ...over,
+} as CharacterOutput);
+
+describe('mergeCharacterFields', () => {
+  it('keeps the longer description and unions attributes', () => {
+    const existing = base({ description: 'short', attributes: ['weary'] });
+    mergeCharacterFields(existing, base({ description: 'a much longer description', attributes: ['weary', 'wry'] }));
+    expect(existing.description).toBe('a much longer description');
+    expect(existing.attributes).toEqual(['weary', 'wry']);
+  });
+
+  it('records a divergent incoming name as an alias, never the display name', () => {
+    const existing = base({ name: 'Антон', aliases: [] });
+    mergeCharacterFields(existing, base({ name: 'Антон Городецкий' }));
+    expect(existing.name).toBe('Антон');
+    expect(existing.aliases).toEqual(['Антон Городецкий']);
+  });
+
+  it('first detection wins for gender/ageRange; tone field-merges', () => {
+    const existing = base({ gender: 'male', tone: { warmth: 30 } });
+    mergeCharacterFields(existing, base({ gender: 'female', ageRange: 'adult', tone: { pace: 70 } }));
+    expect(existing.gender).toBe('male');
+    expect(existing.ageRange).toBe('adult');
+    expect(existing.tone).toEqual({ warmth: 30, pace: 70 });
+  });
+});

--- a/server/src/analyzer/roster-merge-fields.test.ts
+++ b/server/src/analyzer/roster-merge-fields.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { mergeCharacterFields } from './roster-merge-fields.js';
 import type { CharacterOutput } from '../handoff/schemas.js';
 

--- a/server/src/analyzer/roster-merge-fields.ts
+++ b/server/src/analyzer/roster-merge-fields.ts
@@ -1,0 +1,39 @@
+import type { CharacterOutput } from '../handoff/schemas.js';
+import { normaliseForMatch } from '../util/text-match.js';
+
+/** Combine `incoming` into `existing` in place — the exact field logic
+    mergeRosterChapter uses, factored out so the dedup pass agrees with it. */
+export function mergeCharacterFields(existing: CharacterOutput, incoming: CharacterOutput): void {
+  if (incoming.description && (!existing.description || incoming.description.length > existing.description.length)) {
+    existing.description = incoming.description;
+  }
+  if (incoming.tone) existing.tone = { ...existing.tone, ...incoming.tone };
+  if (incoming.attributes?.length) {
+    const seen = new Set(existing.attributes ?? []);
+    const next = [...(existing.attributes ?? [])];
+    for (const a of incoming.attributes) if (!seen.has(a)) { next.push(a); seen.add(a); }
+    existing.attributes = next;
+  }
+  if (incoming.evidence?.length) {
+    const seen = new Set((existing.evidence ?? []).map((e) => normaliseForMatch(e.quote)));
+    const next = [...(existing.evidence ?? [])];
+    for (const e of incoming.evidence) {
+      const norm = normaliseForMatch(e.quote);
+      if (norm.length > 0 && !seen.has(norm)) { next.push({ ...e }); seen.add(norm); }
+    }
+    existing.evidence = next;
+  }
+  if (!existing.gender && incoming.gender) existing.gender = incoming.gender;
+  if (!existing.ageRange && incoming.ageRange) existing.ageRange = incoming.ageRange;
+  const aliasCandidates = [incoming.name, ...(incoming.aliases ?? [])];
+  const seen = new Set<string>([
+    existing.name.trim().toLowerCase(),
+    ...(existing.aliases ?? []).map((a) => a.trim().toLowerCase()),
+  ]);
+  const nextAliases = [...(existing.aliases ?? [])];
+  for (const cand of aliasCandidates) {
+    const key = cand.trim().toLowerCase();
+    if (key.length > 0 && !seen.has(key)) { nextAliases.push(cand); seen.add(key); }
+  }
+  if (nextAliases.length) existing.aliases = nextAliases;
+}

--- a/server/src/analyzer/ru-diminutives.test.ts
+++ b/server/src/analyzer/ru-diminutives.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { diminutiveCanonical } from './ru-diminutives.js';
 
 describe('diminutiveCanonical', () => {

--- a/server/src/analyzer/ru-diminutives.test.ts
+++ b/server/src/analyzer/ru-diminutives.test.ts
@@ -1,0 +1,14 @@
+import { diminutiveCanonical } from './ru-diminutives.js';
+
+describe('diminutiveCanonical', () => {
+  it('maps a diminutive and its canonical to the same base', () => {
+    expect(diminutiveCanonical('Оля')?.base).toBe(diminutiveCanonical('Ольга')?.base);
+  });
+  it('flags multi-gender diminutives', () => {
+    expect(diminutiveCanonical('Саша')?.multiGender).toBe(true);
+    expect(diminutiveCanonical('Оля')?.multiGender).toBe(false);
+  });
+  it('returns null for an unknown name', () => {
+    expect(diminutiveCanonical('Завулон')).toBeNull();
+  });
+});

--- a/server/src/analyzer/ru-diminutives.ts
+++ b/server/src/analyzer/ru-diminutives.ts
@@ -1,0 +1,40 @@
+import { normaliseNameKey } from '../util/safe-id.js';
+
+/* Curated Russian diminutive↔canonical groups. Each group is a set of name
+   forms (canonical + diminutives) that denote the same given name. `multiGender`
+   marks groups whose forms span male AND female canonicals (Саша→Александр/
+   Александра) — those need a stricter gender gate downstream. NOT exhaustive;
+   extend from real corpus data. NO transliteration, NO edit-distance. */
+interface DimGroup {
+  base: string;
+  forms: string[];
+  multiGender: boolean;
+}
+
+const GROUPS: DimGroup[] = [
+  { base: 'ольга', forms: ['Ольга', 'Оля', 'Оленька'], multiGender: false },
+  { base: 'софья', forms: ['Софья', 'Соня'], multiGender: false },
+  { base: 'дмитрий', forms: ['Дмитрий', 'Дима', 'Митя'], multiGender: false },
+  { base: 'екатерина', forms: ['Екатерина', 'Катя', 'Катюша'], multiGender: false },
+  { base: 'михаил', forms: ['Михаил', 'Миша'], multiGender: false },
+  { base: 'мария', forms: ['Мария', 'Маша', 'Маня'], multiGender: false },
+  { base: 'антон', forms: ['Антон', 'Антоша'], multiGender: false },
+  { base: 'светлана', forms: ['Светлана', 'Света'], multiGender: false },
+  { base: 'борис', forms: ['Борис', 'Боря'], multiGender: false },
+  { base: 'александр', forms: ['Александр', 'Александра', 'Саша', 'Саня', 'Шура'], multiGender: true },
+  { base: 'евгений', forms: ['Евгений', 'Евгения', 'Женя'], multiGender: true },
+  { base: 'валентин', forms: ['Валентин', 'Валентина', 'Валя'], multiGender: true },
+  // …extend as real Russian books surface more (keep single-gender vs multiGender accurate).
+];
+
+const BY_KEY = new Map<string, { base: string; multiGender: boolean }>();
+for (const g of GROUPS) {
+  for (const f of g.forms) {
+    BY_KEY.set(normaliseNameKey(f), { base: g.base, multiGender: g.multiGender });
+  }
+}
+
+/** Canonical base for a name if it is a known canonical or diminutive; else null. */
+export function diminutiveCanonical(name: string): { base: string; multiGender: boolean } | null {
+  return BY_KEY.get(normaliseNameKey(name)) ?? null;
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -12,6 +12,7 @@ import { manuscriptsRouter } from './routes/manuscripts.js';
 import { analysisRouter } from './routes/analysis.js';
 import { voiceMatchRouter } from './routes/voice-match.js';
 import { castMergeRouter } from './routes/cast-merge.js';
+import { castMergeSuggestionsRouter } from './routes/cast-merge-suggestions.js';
 import { voiceOverrideLinkedRouter } from './routes/voice-override-linked.js';
 import { castAliasesRouter } from './routes/cast-aliases.js';
 import { castLinkPriorRouter } from './routes/cast-link-prior.js';
@@ -137,6 +138,7 @@ app.use('/api/books', backupRouter); // srv-2 — /:bookId/backups (list) + /bac
 app.use('/api/books', coverRouter); // mounts /:bookId/cover{,/candidates} (OpenLibrary covers)
 app.use('/api/books', voiceMatchRouter); // mounts /:bookId/voice-match
 app.use('/api/books', castMergeRouter); // mounts /:bookId/cast/merge
+app.use('/api/books', castMergeSuggestionsRouter); // mounts /:bookId/cast/merge-suggestions (list/dismiss/accept)
 app.use('/api/books', voiceOverrideLinkedRouter); // mounts /:bookId/cast/:characterId/voice-override-linked (plan 122 — name/alias-aware series voice write)
 app.use('/api/books', castAliasesRouter); // mounts /:bookId/cast/{unlink-alias,add-alias} (editable alias chips on the profile drawer)
 app.use('/api/books', castLinkPriorRouter); // mounts /:bookId/cast/link-prior (manual continuity link to a prior series book)

--- a/server/src/handoff/schemas.test.ts
+++ b/server/src/handoff/schemas.test.ts
@@ -4,9 +4,13 @@ import {
   stage1Schema,
   stage2Schema,
   characterSchema,
+  stage1ChapterSchema,
   sentenceSchema,
   emotionAnnotationSchema,
   EMOTIONS,
+  analyzerCharacterSchema,
+  stage1ChapterGrammarSchema,
+  stage1GrammarSchema,
 } from './schemas.js';
 
 /* The Ollama analyzer (server/src/analyzer/ollama.ts) feeds these per-stage
@@ -130,5 +134,64 @@ describe('fs-33 — emotion-only annotation schema', () => {
       emotionAnnotationSchema.safeParse({ annotations: [{ sentenceId: 1.5, emotion: 'sad' }] })
         .success,
     ).toBe(false);
+  });
+});
+
+describe('analyzer grammar schemas — required tone (Task 6)', () => {
+  const charWithoutTone = { id: 'a', name: 'Alice', role: 'protagonist', color: '#abc' };
+  const charWithTone = {
+    ...charWithoutTone,
+    tone: { warmth: 50, pace: 60, authority: 70, emotion: 40 },
+  };
+
+  it('analyzerCharacterSchema rejects a character with NO tone (grammar strict)', () => {
+    expect(analyzerCharacterSchema.safeParse(charWithoutTone).success).toBe(false);
+  });
+
+  it('characterSchema still accepts a character with NO tone (validation tolerant)', () => {
+    expect(characterSchema.safeParse(charWithoutTone).success).toBe(true);
+  });
+
+  it('analyzerCharacterSchema accepts a character with all four tone axes', () => {
+    expect(analyzerCharacterSchema.safeParse(charWithTone).success).toBe(true);
+  });
+
+  it('stage1ChapterGrammarSchema JSON-schema marks tone required on character and axes required on tone', () => {
+    const json = z.toJSONSchema(stage1ChapterGrammarSchema, {
+      target: 'draft-07',
+      reused: 'inline',
+    }) as Record<string, unknown>;
+
+    // Walk: properties.characters.items → character item schema
+    const props = json['properties'] as Record<string, unknown>;
+    const charArraySchema = props['characters'] as Record<string, unknown>;
+    const charItemSchema = charArraySchema['items'] as Record<string, unknown>;
+
+    // tone must appear in the character's required array
+    const charRequired = charItemSchema['required'] as string[];
+    expect(Array.isArray(charRequired)).toBe(true);
+    expect(charRequired).toContain('tone');
+
+    // tone's own JSON schema must list all four axes in its required array
+    const charItemProps = charItemSchema['properties'] as Record<string, unknown>;
+    const toneJsonSchema = charItemProps['tone'] as Record<string, unknown>;
+    const toneRequired = toneJsonSchema['required'] as string[];
+    expect(Array.isArray(toneRequired)).toBe(true);
+    expect(toneRequired).toContain('warmth');
+    expect(toneRequired).toContain('pace');
+    expect(toneRequired).toContain('authority');
+    expect(toneRequired).toContain('emotion');
+  });
+
+  it('stage1GrammarSchema rejects a character with no tone', () => {
+    const result = stage1GrammarSchema.safeParse({
+      characters: [charWithoutTone],
+      chapters: [{ id: 1, title: 'Chapter 1' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('stage1ChapterSchema (validation) still accepts characters with no tone', () => {
+    expect(stage1ChapterSchema.safeParse({ characters: [charWithoutTone] }).success).toBe(true);
   });
 });

--- a/server/src/handoff/schemas.ts
+++ b/server/src/handoff/schemas.ts
@@ -164,3 +164,42 @@ export type Stage2ChapterOutput = z.infer<typeof stage2ChapterSchema>;
 export type CharacterOutput = z.infer<typeof characterSchema>;
 export type SentenceOutput = z.infer<typeof sentenceSchema>;
 export type EmotionAnnotationOutput = z.infer<typeof emotionAnnotationSchema>;
+
+/* ── Analyzer grammar schemas (Task 6) ──────────────────────────────────────
+   These are used ONLY to constrain the analyzer model's output via structured
+   decoding (Ollama format / Gemini responseSchema). They are NEVER used for
+   validation of stored cast.json files — that stays characterSchema / stage1*
+   (all tone fields optional there so old files keep validating).
+
+   The grammar makes tone REQUIRED so the model is nudged to emit all four
+   axes every time. */
+
+export const requiredToneSchema = z
+  .object({
+    warmth: z.number().int().min(0).max(100),
+    pace: z.number().int().min(0).max(100),
+    authority: z.number().int().min(0).max(100),
+    emotion: z.number().int().min(0).max(100),
+  })
+  .strict();
+
+/** Character schema for the analyzer GRAMMAR — tone required so constrained
+    decoding nudges the model to emit all four axes. Never used for validation
+    (that stays characterSchema, tone optional). */
+export const analyzerCharacterSchema = characterSchema.extend({ tone: requiredToneSchema });
+
+/** Grammar variant of stage1ChapterSchema — embeds analyzerCharacterSchema
+    so the model must emit tone on every character it returns. */
+export const stage1ChapterGrammarSchema = z
+  .object({
+    characters: z.array(analyzerCharacterSchema),
+  })
+  .strict();
+
+/** Grammar variant of stage1Schema — embeds analyzerCharacterSchema. */
+export const stage1GrammarSchema = z
+  .object({
+    characters: z.array(analyzerCharacterSchema).min(1),
+    chapters: stage1Schema.shape.chapters,
+  })
+  .strict();

--- a/server/src/routes/analysis.test.ts
+++ b/server/src/routes/analysis.test.ts
@@ -26,6 +26,7 @@ import {
   replayCatchUp,
   castInFlightEntryToLiveChapter,
   resolveBookAuthorForManuscript,
+  dedupAndPrepare,
 } from './analysis.js';
 import type { CharacterOutput, SentenceOutput } from '../handoff/schemas.js';
 import { dropBylineAuthorFromChapter } from '../analyzer/byline-author-guard.js';
@@ -2114,5 +2115,76 @@ describe('#938 byline-author exclusion — cached roster path integration', () =
     const authorKey = normaliseNameKey(BOOK_AUTHOR);
     const authorEntry = interim.find((c) => normaliseNameKey(c.name) === authorKey);
     expect(authorEntry).toBeDefined();
+  });
+});
+
+describe('dedupAndPrepare — dedup BEFORE fold, sentence rewrite + capture for journal', () => {
+  const char = (over: Partial<CharacterOutput> & { id: string; name: string }): CharacterOutput =>
+    ({
+      role: 'supporting',
+      attributes: [],
+      evidence: [],
+      lines: 0,
+      scenes: 0,
+      ...over,
+    }) as CharacterOutput;
+
+  const sentence = (over: Partial<SentenceOutput> & { id: number; characterId: string }): SentenceOutput =>
+    ({ chapterId: 1, text: 'x', ...over }) as SentenceOutput;
+
+  it('collapses two same-name characters to one canonical id and rewrites all their sentences', () => {
+    const characters: CharacterOutput[] = [
+      char({ id: 'olga', name: 'Ольга', gender: 'female' }),
+      char({ id: 'ольга', name: 'Ольга', gender: 'female' }),
+    ];
+    const sentences: SentenceOutput[] = [
+      sentence({ id: 1, characterId: 'olga' }),
+      sentence({ id: 2, characterId: 'ольга' }),
+      sentence({ id: 3, characterId: 'narrator' }),
+    ];
+
+    const dd = dedupAndPrepare(characters, sentences, 'ru');
+
+    // ONE Ольга survives, with the safeId-derived canonical id.
+    const olgas = dd.characters.filter((c) => c.name === 'Ольга');
+    expect(olgas).toHaveLength(1);
+    const canonical = olgas[0].id;
+    expect(canonical).toBe('ольга');
+
+    // Every sentence that was attributed to either source now points at the canonical id.
+    expect(dd.sentences.find((s) => s.id === 1)!.characterId).toBe(canonical);
+    expect(dd.sentences.find((s) => s.id === 2)!.characterId).toBe(canonical);
+    // Untouched sentences keep their attribution.
+    expect(dd.sentences.find((s) => s.id === 3)!.characterId).toBe('narrator');
+
+    // A non-empty rewrites map drove the collapse.
+    expect(Object.keys(dd.rewrites).length).toBeGreaterThan(0);
+    expect(dd.rewrites['olga']).toBe(canonical);
+
+    // preDedupSentences captured the ORIGINAL ids (pre-rewrite) for the journal.
+    expect(dd.preDedupSentences.find((s) => s.id === 1)!.characterId).toBe('olga');
+    expect(dd.preDedupSentences.find((s) => s.id === 2)!.characterId).toBe('ольга');
+
+    // preDedupRoster captured the pre-dedup names (for journal sourceName lookup).
+    expect(dd.preDedupRoster.some((r) => r.id === 'olga' && r.name === 'Ольга')).toBe(true);
+  });
+
+  it('is a no-op (empty rewrites) when the roster has no name collisions', () => {
+    const characters: CharacterOutput[] = [
+      char({ id: 'anton', name: 'Антон', gender: 'male' }),
+      char({ id: 'olga', name: 'Ольга', gender: 'female' }),
+    ];
+    const sentences: SentenceOutput[] = [
+      sentence({ id: 1, characterId: 'anton' }),
+      sentence({ id: 2, characterId: 'olga' }),
+    ];
+
+    const dd = dedupAndPrepare(characters, sentences, 'ru');
+
+    expect(dd.characters).toHaveLength(2);
+    expect(Object.keys(dd.rewrites)).toHaveLength(0);
+    // Sentences pass through unchanged.
+    expect(dd.sentences.find((s) => s.id === 1)!.characterId).toBe('anton');
+    expect(dd.sentences.find((s) => s.id === 2)!.characterId).toBe('olga');
   });
 });

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -26,6 +26,7 @@ import {
 import { AnalysisAbortedError } from '../analyzer/ollama.js';
 import { detectOllamaDevice } from './ollama-health.js';
 import { foldMinorCast } from '../analyzer/fold-minor-cast.js';
+import { mergeCharacterFields } from '../analyzer/roster-merge-fields.js';
 import {
   loadCastMerges,
   saveCastMerges,
@@ -571,70 +572,7 @@ export function mergeRosterChapter(
       });
       continue;
     }
-    /* Description: keep whichever is longer. */
-    if (
-      incoming.description &&
-      (!existing.description || incoming.description.length > existing.description.length)
-    ) {
-      existing.description = incoming.description;
-    }
-    /* Tone: latest-wins per field, but only when the incoming entry
-       provided that field (don't blank out a known value). */
-    if (incoming.tone) {
-      existing.tone = { ...existing.tone, ...incoming.tone };
-    }
-    /* Attributes: union dedup. Order: existing first, then any new. */
-    if (incoming.attributes?.length) {
-      const seen = new Set(existing.attributes ?? []);
-      const next = [...(existing.attributes ?? [])];
-      for (const a of incoming.attributes) {
-        if (!seen.has(a)) {
-          next.push(a);
-          seen.add(a);
-        }
-      }
-      existing.attributes = next;
-    }
-    /* Evidence: append non-duplicate quotes. Dedup on normalised quote
-       so smart-vs-straight typography drift between chapters doesn't
-       inflate the array. */
-    if (incoming.evidence?.length) {
-      const seen = new Set((existing.evidence ?? []).map((e) => normaliseForMatch(e.quote)));
-      const next = [...(existing.evidence ?? [])];
-      for (const e of incoming.evidence) {
-        const norm = normaliseForMatch(e.quote);
-        if (norm.length > 0 && !seen.has(norm)) {
-          next.push({ ...e });
-          seen.add(norm);
-        }
-      }
-      existing.evidence = next;
-    }
-    /* Gender / ageRange / color / role: only adopt incoming when existing
-       doesn't have a value. First detection wins for identity fields —
-       switching pronouns mid-book is almost always a model error, not a
-       character development. */
-    if (!existing.gender && incoming.gender) existing.gender = incoming.gender;
-    if (!existing.ageRange && incoming.ageRange) existing.ageRange = incoming.ageRange;
-    /* Name: first-detection wins for the DISPLAY name, but a divergent name
-       form the model emits for the same id in a later chapter («Антон» then
-       «Антон Городецкий») — plus any incoming aliases — is preserved as an
-       alias rather than silently dropped, so cast review surfaces it. Dedup
-       case-insensitively; never record the display name itself. */
-    const aliasCandidates = [incoming.name, ...(incoming.aliases ?? [])];
-    const seen = new Set<string>([
-      existing.name.trim().toLowerCase(),
-      ...(existing.aliases ?? []).map((a) => a.trim().toLowerCase()),
-    ]);
-    const nextAliases = [...(existing.aliases ?? [])];
-    for (const cand of aliasCandidates) {
-      const key = cand.trim().toLowerCase();
-      if (key.length > 0 && !seen.has(key)) {
-        nextAliases.push(cand);
-        seen.add(key);
-      }
-    }
-    if (nextAliases.length) existing.aliases = nextAliases;
+    mergeCharacterFields(existing, incoming);
   }
 }
 

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -27,7 +27,7 @@ import { AnalysisAbortedError } from '../analyzer/ollama.js';
 import { detectOllamaDevice } from './ollama-health.js';
 import { foldMinorCast } from '../analyzer/fold-minor-cast.js';
 import { mergeCharacterFields } from '../analyzer/roster-merge-fields.js';
-import { dedupeRosterByName, composeRewrites, type MergeSuggestion } from '../analyzer/roster-dedup.js';
+import { dedupeRosterByName, composeRewrites, pruneSuggestionsToRoster, type MergeSuggestion } from '../analyzer/roster-dedup.js';
 import { fillToneFromAttributes } from '../analyzer/fill-tone.js';
 import {
   loadCastMerges,
@@ -4062,7 +4062,7 @@ export async function runMainAnalyzerJob(
             dd.preDedupSentences,
             dd.preDedupRoster,
           );
-          await writeSuggestions(record.bookDir, dd.suggestions);
+          await writeSuggestions(record.bookDir, pruneSuggestionsToRoster(dd.suggestions, characters));
         } catch (dedupErr) {
           console.warn('[analysis] failed to write dedup journal/suggestions', dedupErr);
         }
@@ -5074,7 +5074,7 @@ async function runSubsetAnalyzerJob(
             dd.preDedupSentences,
             dd.preDedupRoster,
           );
-          await writeSuggestions(record.bookDir, dd.suggestions);
+          await writeSuggestions(record.bookDir, pruneSuggestionsToRoster(dd.suggestions, enriched));
         } catch (dedupErr) {
           console.warn('[analysis] failed to write dedup journal/suggestions', dedupErr);
         }

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -27,13 +27,21 @@ import { AnalysisAbortedError } from '../analyzer/ollama.js';
 import { detectOllamaDevice } from './ollama-health.js';
 import { foldMinorCast } from '../analyzer/fold-minor-cast.js';
 import { mergeCharacterFields } from '../analyzer/roster-merge-fields.js';
+import { dedupeRosterByName, composeRewrites, type MergeSuggestion } from '../analyzer/roster-dedup.js';
+import { fillToneFromAttributes } from '../analyzer/fill-tone.js';
 import {
   loadCastMerges,
   saveCastMerges,
   clearCastMerges,
   replaceFoldEntries,
   buildFoldJournalEntries,
+  replaceDedupEntries,
+  buildDedupJournalEntries,
 } from '../store/cast-merges.js';
+import {
+  writeSuggestions,
+  clearSuggestions,
+} from '../store/cast-merge-suggestions.js';
 import { recoverTaggedNarratorLines } from '../analyzer/recover-tagged-lines.js';
 import {
   runStage2ChapterChunked,
@@ -90,6 +98,7 @@ import {
   mergeAnalysisResultWithExistingCast,
   seedReuseGuardsFromPriorCast,
   voicedSurvivorsDropped,
+  applyRewriteToPriorCast,
 } from '../store/merge-analysis-cast.js';
 import { stampStateSchema } from '../workspace/state-migrate.js';
 import type { BookStateJson } from '../workspace/scan.js';
@@ -637,6 +646,69 @@ async function writeFoldJournal(
       buildFoldJournalEntries(rewrites, preFoldSentences, characters, new Date().toISOString()),
     ),
   );
+}
+
+/* srv-1 — sibling of writeFoldJournal for the dedup pass. Replace-all keeps
+   kind:'dedup' entries in lockstep with the current roster, preserving fold +
+   manual entries. Same non-fatal-at-call-site contract. The pre-dedup roster +
+   sentences are captured by dedupAndPrepare before the rewrite, so sourceName +
+   affected sentences reflect the state the dedup collapsed. */
+async function writeDedupJournal(
+  bookDir: string,
+  rewrites: Record<string, string>,
+  preDedupSentences: ReadonlyArray<{ id: number; chapterId: number; characterId: string }>,
+  preDedupRoster: ReadonlyArray<{ id: string; name: string }>,
+): Promise<void> {
+  const journal = await loadCastMerges(bookDir);
+  await saveCastMerges(
+    bookDir,
+    replaceDedupEntries(
+      journal,
+      buildDedupJournalEntries(rewrites, preDedupSentences, preDedupRoster, new Date().toISOString()),
+    ),
+  );
+}
+
+/* Run the dedup pass + apply its rewrites to the sentence stream, capturing the
+   PRE-dedup roster + sentences for the journal — all in the order the spec
+   mandates (dedup BEFORE fold). The caller feeds the returned `characters` +
+   `sentences` into the existing foldMinorCast call, persists the journal from
+   `preDedupSentences`/`preDedupRoster`, and composes `rewrites` with the fold's
+   rewrites for the voice carry-forward remap. Tone fill is applied by the caller
+   AFTER the fold (on the folded survivors), not here. Pure aside from no IO. */
+export function dedupAndPrepare(
+  characters: CharacterOutput[],
+  sentences: SentenceOutput[],
+  language: string | undefined,
+): {
+  characters: CharacterOutput[];
+  sentences: SentenceOutput[];
+  rewrites: Record<string, string>;
+  suggestions: MergeSuggestion[];
+  preDedupSentences: { id: number; chapterId: number; characterId: string }[];
+  preDedupRoster: { id: string; name: string }[];
+} {
+  // Capture pre-dedup lineage BEFORE any rewrite (journal needs the original ids/names).
+  const preDedupSentences = sentences.map((s) => ({
+    id: s.id,
+    chapterId: s.chapterId,
+    characterId: s.characterId,
+  }));
+  const preDedupRoster = characters.map((c) => ({ id: c.id, name: c.name }));
+
+  const dd = dedupeRosterByName(characters, sentences, { language });
+  const rewrittenSentences = sentences.map((s) =>
+    dd.rewrites[s.characterId] ? { ...s, characterId: dd.rewrites[s.characterId] } : s,
+  );
+
+  return {
+    characters: dd.characters,
+    sentences: rewrittenSentences,
+    rewrites: dd.rewrites,
+    suggestions: dd.suggestions,
+    preDedupSentences,
+    preDedupRoster,
+  };
 }
 
 function previewFoldForLiveView(
@@ -2243,8 +2315,9 @@ export async function runMainAnalyzerJob(
            reparse carryover too so it can't resurrect links (srv-13). */
         await rm(castReuseCarryoverJsonPath(recordRef.bookDir), { force: true });
         /* srv-1 — fresh run regenerates ids from scratch, so old lineage is
-           meaningless; drop the merge journal too. */
+           meaningless; drop the merge journal + dedup suggestions too. */
         await clearCastMerges(recordRef.bookDir);
+        await clearSuggestions(recordRef.bookDir);
       }
       log(0, 'Discarded cached progress — starting from scratch.');
     }
@@ -3858,10 +3931,20 @@ export async function runMainAnalyzerJob(
         `Recovered ${recovered.flipped} narrator-attributed line(s) to tagged speakers (${summary}).`,
       );
     }
+    /* srv-1 — dedup BEFORE the fold: collapse same-name / token-subset roster
+       duplicates and rewrite their sentences onto the canonical id, so the fold
+       counts lines against deduped ids. Captures pre-dedup lineage for the
+       journal + diminutive suggestions for the sibling file. */
+    const dd = dedupAndPrepare(stage1.characters, recovered.sentences, bookLanguage);
+    stage1.characters = dd.characters;
+    recovered.sentences = dd.sentences;
     const folded = foldMinorCast(stage1.characters, recovered.sentences, {
       minLines: userSettings.minorCastMinLines,
       language: bookLanguage,
     });
+    /* Fill each folded survivor's tone from its attributes where the analyzer
+       left it blank (axes default to a neutral 50). */
+    folded.characters = folded.characters.map(fillToneFromAttributes);
     if (folded.summary.foldedCount > 0) {
       const parts: string[] = [];
       if (folded.summary.intoMale) parts.push(`${folded.summary.intoMale} → Unknown male`);
@@ -3970,18 +4053,42 @@ export async function runMainAnalyzerJob(
         } catch (journalErr) {
           console.warn('[analysis] failed to write cast-merges journal', journalErr);
         }
+        /* srv-1 — record this run's dedup lineage + persist diminutive
+           suggestions. Non-fatal, mirroring the fold journal. */
+        try {
+          await writeDedupJournal(
+            record.bookDir,
+            dd.rewrites,
+            dd.preDedupSentences,
+            dd.preDedupRoster,
+          );
+          await writeSuggestions(record.bookDir, dd.suggestions);
+        } catch (dedupErr) {
+          console.warn('[analysis] failed to write dedup journal/suggestions', dedupErr);
+        }
         if (phase1DriftExceeded) {
           log(
             1,
             `Attribution drift exceeded threshold (${reconciled.demotedCount}/${folded.sentences.length} ≈ ${Math.round((100 * reconciled.demotedCount) / folded.sentences.length)}%) — refusing to flip cast.json / state.json. Retry analysis to re-attribute.`,
           );
         } else {
+          /* Remap the prior cast's ids through the cumulative dedup→fold rewrite
+             so designed voices ride onto the surviving canonical ids instead of
+             stranding on a collapsed source id. */
+          const cumulative = composeRewrites(dd.rewrites, folded.rewrites);
+          const remapped = applyRewriteToPriorCast(priorCastForMerge, cumulative);
+          if (remapped.droppedVoices.length) {
+            log(
+              1,
+              `Dedup collapsed ${remapped.droppedVoices.length} prior voiced row(s) onto a canonical survivor (${remapped.droppedVoices.map((d) => d.id).join(', ')}).`,
+            );
+          }
           await writeJsonAtomic(castJsonPath(record.bookDir), {
-            characters: mergeAnalysisResultWithExistingCast(priorCastForMerge, characters),
+            characters: mergeAnalysisResultWithExistingCast(remapped.priorCast, characters),
           });
           await logCarriedForwardCharacters(
             record.bookDir,
-            voicedSurvivorsDropped(priorCastForMerge, characters),
+            voicedSurvivorsDropped(remapped.priorCast, characters),
           );
           const statePath = stateJsonPath(record.bookDir);
           const prev = await readJson<BookStateJson>(statePath);
@@ -4828,11 +4935,19 @@ async function runSubsetAnalyzerJob(
         `Recovered ${recovered.flipped} narrator-attributed line(s) to tagged speakers (${summary}).`,
       );
     }
+    /* srv-1 — dedup BEFORE the re-fold (see the main route's same block):
+       collapse same-name / token-subset duplicates and rewrite their sentences
+       onto the canonical id so the fold counts deduped lines. */
+    const dd = dedupAndPrepare(stage1.characters, recovered.sentences, bookLanguage);
+    stage1.characters = dd.characters;
+    recovered.sentences = dd.sentences;
     /* Re-fold the cast against the merged sentence set so the bucket
        attributions stay coherent with the new chapters' attributions. */
     const folded = foldMinorCast(stage1.characters, recovered.sentences, {
       language: bookLanguage,
     });
+    /* Fill each folded survivor's tone from its attributes where blank. */
+    folded.characters = folded.characters.map(fillToneFromAttributes);
     if (folded.summary.droppedSilent > 0) {
       const sample = folded.dropped.slice(0, 4).join(', ');
       const more = folded.dropped.length > 4 ? `, +${folded.dropped.length - 4} more` : '';
@@ -4950,18 +5065,41 @@ async function runSubsetAnalyzerJob(
         } catch (journalErr) {
           console.warn('[analysis] failed to write cast-merges journal', journalErr);
         }
+        /* srv-1 — record this run's dedup lineage + persist diminutive
+           suggestions. Non-fatal, mirroring the fold journal. */
+        try {
+          await writeDedupJournal(
+            record.bookDir,
+            dd.rewrites,
+            dd.preDedupSentences,
+            dd.preDedupRoster,
+          );
+          await writeSuggestions(record.bookDir, dd.suggestions);
+        } catch (dedupErr) {
+          console.warn('[analysis] failed to write dedup journal/suggestions', dedupErr);
+        }
         if (subsetDriftExceeded) {
           log(
             1,
             `Attribution drift exceeded threshold (${subsetReconciled.demotedCount}/${folded.sentences.length} ≈ ${Math.round((100 * subsetReconciled.demotedCount) / folded.sentences.length)}%) — refusing to flip cast.json / state.json. Retry analysis to re-attribute.`,
           );
         } else {
+          /* Remap the prior cast's ids through the cumulative dedup→fold rewrite
+             so designed voices ride onto the surviving canonical ids. */
+          const cumulative = composeRewrites(dd.rewrites, folded.rewrites);
+          const remapped = applyRewriteToPriorCast(priorCastForMerge, cumulative);
+          if (remapped.droppedVoices.length) {
+            log(
+              1,
+              `Dedup collapsed ${remapped.droppedVoices.length} prior voiced row(s) onto a canonical survivor (${remapped.droppedVoices.map((d) => d.id).join(', ')}).`,
+            );
+          }
           await writeJsonAtomic(castJsonPath(record.bookDir), {
-            characters: mergeAnalysisResultWithExistingCast(priorCastForMerge, enriched),
+            characters: mergeAnalysisResultWithExistingCast(remapped.priorCast, enriched),
           });
           await logCarriedForwardCharacters(
             record.bookDir,
-            voicedSurvivorsDropped(priorCastForMerge, enriched),
+            voicedSurvivorsDropped(remapped.priorCast, enriched),
           );
           const statePath = stateJsonPath(record.bookDir);
           const prev = await readJson<BookStateJson>(statePath);

--- a/server/src/routes/cast-merge-suggestions.test.ts
+++ b/server/src/routes/cast-merge-suggestions.test.ts
@@ -1,0 +1,235 @@
+/* Integration tests for the cast-merge-suggestions router.
+
+   Seeds a workspace with a fake book + cast-merge-suggestions.json and drives
+   the three suggestion endpoints:
+     GET  /:bookId/cast/merge-suggestions           → list
+     POST /:bookId/cast/merge-suggestions/dismiss   → drop one
+     POST /:bookId/cast/merge-suggestions/accept    → merge + drop
+
+   Mirrors cast-merge.test.ts: defer module imports until WORKSPACE_DIR is
+   set so paths.ts captures the right root. */
+
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import express, { type Express } from 'express';
+import request from 'supertest';
+
+const AUTHOR = 'Suggestions Author';
+const SERIES = 'Standalones';
+const TITLE = 'Suggestions Book';
+const MANUSCRIPT_ID = 'm_suggestions_test';
+
+let workspaceRoot: string;
+let bookDir: string;
+let app: Express;
+let bookId: string;
+let cachePath: string;
+
+/* Characters: Оля and Ольга are diminutive pair; Ольга is the canonical survivor. */
+const olyaChar = {
+  id: 'olya',
+  name: 'Оля',
+  role: 'secondary',
+  color: 'halloran',
+  lines: 4,
+  scenes: 2,
+  gender: 'female',
+};
+
+const olgaChar = {
+  id: 'olga',
+  name: 'Ольга',
+  role: 'protagonist',
+  color: 'eliza',
+  lines: 10,
+  scenes: 3,
+  gender: 'female',
+};
+
+const marloChar = {
+  id: 'marlo',
+  name: 'Marlo',
+  role: 'sidekick',
+  color: 'halloran',
+  lines: 6,
+  scenes: 2,
+};
+
+const sentences = [
+  { id: 1, chapterId: 1, characterId: 'olya', text: 'Привет.' },
+  { id: 2, chapterId: 1, characterId: 'olga', text: 'Здравствуй.' },
+  { id: 3, chapterId: 2, characterId: 'marlo', text: 'Hello there.' },
+];
+
+const suggestions = [
+  { sourceId: 'olya', targetId: 'olga', reason: 'diminutive of Ольга' },
+  { sourceId: 'marlo', targetId: 'olga', reason: 'unrelated pair for dismiss test' },
+];
+
+beforeAll(async () => {
+  workspaceRoot = mkdtempSync(join(tmpdir(), 'audiobook-suggestions-test-'));
+  process.env.WORKSPACE_DIR = workspaceRoot;
+
+  const [{ castMergeRouter }, { castMergeSuggestionsRouter }, { makeBookId }] = await Promise.all([
+    import('./cast-merge.js'),
+    import('./cast-merge-suggestions.js'),
+    import('../workspace/paths.js'),
+  ]);
+  bookId = makeBookId(AUTHOR, SERIES, TITLE);
+  bookDir = join(workspaceRoot, 'books', AUTHOR, SERIES, TITLE);
+  mkdirSync(join(bookDir, '.audiobook'), { recursive: true });
+
+  writeFileSync(
+    join(bookDir, '.audiobook', 'state.json'),
+    JSON.stringify({
+      bookId,
+      manuscriptId: MANUSCRIPT_ID,
+      title: TITLE,
+      author: AUTHOR,
+      series: SERIES,
+      seriesPosition: null,
+      isStandalone: true,
+      manuscriptFile: 'manuscript.txt',
+      castConfirmed: true,
+      chapters: [
+        { id: 1, title: 'One', slug: '01-one' },
+        { id: 2, title: 'Two', slug: '02-two' },
+      ],
+      coverGradient: ['#000', '#fff'],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }),
+  );
+  writeFileSync(join(bookDir, 'manuscript.txt'), 'placeholder');
+  writeFileSync(
+    join(bookDir, '.audiobook', 'cast.json'),
+    JSON.stringify({ characters: [olgaChar, olyaChar, marloChar] }),
+  );
+  writeFileSync(
+    join(bookDir, '.audiobook', 'manuscript-edits.json'),
+    JSON.stringify({ sentences }),
+  );
+  writeFileSync(
+    join(bookDir, '.audiobook', 'cast-merge-suggestions.json'),
+    JSON.stringify({ suggestions }),
+  );
+
+  /* Analysis cache — needed because performCastMerge touches it. */
+  const testFileDir = dirname(fileURLToPath(import.meta.url));
+  cachePath = resolve(testFileDir, '..', '..', 'handoff', 'cache', `${MANUSCRIPT_ID}.json`);
+  mkdirSync(dirname(cachePath), { recursive: true });
+  writeFileSync(
+    cachePath,
+    JSON.stringify({
+      stage1: {
+        characters: [olgaChar, olyaChar, marloChar],
+        chapters: [
+          { id: 1, title: 'One' },
+          { id: 2, title: 'Two' },
+        ],
+      },
+      chapters: {
+        1: [sentences[0], sentences[1]],
+        2: [sentences[2]],
+      },
+      updatedAt: new Date().toISOString(),
+    }),
+  );
+
+  app = express();
+  app.use(express.json());
+  app.use('/api/books', castMergeRouter);
+  app.use('/api/books', castMergeSuggestionsRouter);
+});
+
+afterAll(() => {
+  if (workspaceRoot) rmSync(workspaceRoot, { recursive: true, force: true });
+  delete process.env.WORKSPACE_DIR;
+  if (cachePath) rmSync(cachePath, { force: true });
+});
+
+function readSuggestionsFile(): { suggestions: Array<{ sourceId: string; targetId: string; reason: string }> } {
+  return JSON.parse(
+    readFileSync(join(bookDir, '.audiobook', 'cast-merge-suggestions.json'), 'utf8'),
+  ) as { suggestions: Array<{ sourceId: string; targetId: string; reason: string }> };
+}
+
+function readCastFile(): { characters: Array<{ id: string }> } {
+  return JSON.parse(
+    readFileSync(join(bookDir, '.audiobook', 'cast.json'), 'utf8'),
+  ) as { characters: Array<{ id: string }> };
+}
+
+describe('GET /:bookId/cast/merge-suggestions', () => {
+  it('returns the seeded suggestions', async () => {
+    const res = await request(app).get(`/api/books/${bookId}/cast/merge-suggestions`);
+    expect(res.status).toBe(200);
+    const body = res.body as { suggestions: Array<{ sourceId: string; targetId: string }> };
+    expect(body.suggestions).toHaveLength(2);
+    expect(body.suggestions[0]).toMatchObject({ sourceId: 'olya', targetId: 'olga' });
+  });
+
+  it('returns empty suggestions for an unknown book (no file)', async () => {
+    const res = await request(app).get('/api/books/no-such-book/cast/merge-suggestions');
+    expect(res.status).toBe(200);
+    const body = res.body as { suggestions: unknown[] };
+    expect(body.suggestions).toHaveLength(0);
+  });
+});
+
+describe('POST /:bookId/cast/merge-suggestions/dismiss', () => {
+  it('removes the matching suggestion and leaves others intact', async () => {
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/merge-suggestions/dismiss`)
+      .send({ sourceId: 'marlo', targetId: 'olga' });
+    expect(res.status).toBe(200);
+
+    /* The dismissed pair is gone; the olya/olga pair survives. */
+    const file = readSuggestionsFile();
+    expect(file.suggestions).toHaveLength(1);
+    expect(file.suggestions[0]).toMatchObject({ sourceId: 'olya', targetId: 'olga' });
+  });
+
+  it('subsequent GET reflects the dismissal', async () => {
+    const res = await request(app).get(`/api/books/${bookId}/cast/merge-suggestions`);
+    expect(res.status).toBe(200);
+    const body = res.body as { suggestions: Array<{ sourceId: string }> };
+    expect(body.suggestions).toHaveLength(1);
+    expect(body.suggestions[0].sourceId).toBe('olya');
+  });
+});
+
+describe('POST /:bookId/cast/merge-suggestions/accept', () => {
+  it('performs the merge (sourceId folded into targetId), then drops the suggestion', async () => {
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/merge-suggestions/accept`)
+      .send({ sourceId: 'olya', targetId: 'olga' });
+    expect(res.status).toBe(200);
+
+    /* cast.json: olya is gone, olga survives and has olya as an alias. */
+    const cast = readCastFile();
+    const ids = cast.characters.map((c) => c.id);
+    expect(ids).not.toContain('olya');
+    expect(ids).toContain('olga');
+
+    const olga = cast.characters.find((c) => c.id === 'olga') as {
+      id: string;
+      aliases?: string[];
+    };
+    expect(olga.aliases).toContain('Оля');
+
+    /* The accepted suggestion is removed. */
+    const file = readSuggestionsFile();
+    expect(file.suggestions).toHaveLength(0);
+  });
+
+  it('subsequent GET shows empty suggestions', async () => {
+    const res = await request(app).get(`/api/books/${bookId}/cast/merge-suggestions`);
+    expect(res.status).toBe(200);
+    const body = res.body as { suggestions: unknown[] };
+    expect(body.suggestions).toHaveLength(0);
+  });
+});

--- a/server/src/routes/cast-merge-suggestions.ts
+++ b/server/src/routes/cast-merge-suggestions.ts
@@ -1,0 +1,105 @@
+/* Suggestions routes — list, dismiss, and accept diminutive merge suggestions.
+
+   Suggestions are written by the dedup pass (Task 10) and stored in the
+   per-book `cast-merge-suggestions.json` sibling file. These routes let the
+   cast-review UI surface and act on them without touching cast.json directly.
+
+   GET  /:bookId/cast/merge-suggestions           → { suggestions }
+   POST /:bookId/cast/merge-suggestions/dismiss   → 200 (removes one pair)
+   POST /:bookId/cast/merge-suggestions/accept    → 200 (merges + removes pair)
+
+   bookDir resolution mirrors cast-merge.ts: `findBookByBookId`, 404 when the
+   book is absent for accept/dismiss; the GET returns an empty list when the
+   book or file is absent (safe for a stale bookId the UI may hold). */
+
+import { Router } from 'express';
+import type { Request, Response } from '../http.js';
+import { findBookByBookId } from '../workspace/scan.js';
+import { loadSuggestions, dismissSuggestion } from '../store/cast-merge-suggestions.js';
+import { performCastMerge } from './cast-merge.js';
+
+export const castMergeSuggestionsRouter = Router();
+
+interface SuggestionBody {
+  sourceId?: unknown;
+  targetId?: unknown;
+}
+
+/* GET /:bookId/cast/merge-suggestions
+   Returns the current suggestion list.  Returns { suggestions: [] } when the
+   book doesn't exist or has no file — the UI can safely call this on any
+   bookId without needing a prior existence check. */
+castMergeSuggestionsRouter.get(
+  '/:bookId/cast/merge-suggestions',
+  async (req: Request, res: Response) => {
+    const { bookId } = req.params;
+
+    const located = await findBookByBookId(bookId);
+    if (!located) return res.json({ suggestions: [] });
+
+    const file = await loadSuggestions(located.bookDir);
+    return res.json(file);
+  },
+);
+
+/* POST /:bookId/cast/merge-suggestions/dismiss
+   Removes the matching (sourceId, targetId) pair from the suggestions file.
+   No-op when the pair is not present. */
+castMergeSuggestionsRouter.post(
+  '/:bookId/cast/merge-suggestions/dismiss',
+  async (req: Request, res: Response) => {
+    const { bookId } = req.params;
+    const body = (req.body ?? {}) as SuggestionBody;
+    const sourceId = typeof body.sourceId === 'string' ? body.sourceId.trim() : '';
+    const targetId = typeof body.targetId === 'string' ? body.targetId.trim() : '';
+
+    if (!sourceId || !targetId) {
+      return res.status(400).json({ error: 'sourceId and targetId are required.' });
+    }
+
+    const located = await findBookByBookId(bookId);
+    if (!located) return res.status(404).json({ error: 'Book not found.' });
+
+    await dismissSuggestion(located.bookDir, sourceId, targetId);
+    return res.json({});
+  },
+);
+
+/* POST /:bookId/cast/merge-suggestions/accept
+   Performs the merge (sourceId folded into targetId — targetId is the
+   canonical survivor, matching the MergeSuggestion contract), then drops the
+   suggestion from the file so it never resurfaces. */
+castMergeSuggestionsRouter.post(
+  '/:bookId/cast/merge-suggestions/accept',
+  async (req: Request, res: Response) => {
+    const { bookId } = req.params;
+    const body = (req.body ?? {}) as SuggestionBody;
+    const sourceId = typeof body.sourceId === 'string' ? body.sourceId.trim() : '';
+    const targetId = typeof body.targetId === 'string' ? body.targetId.trim() : '';
+
+    if (!sourceId || !targetId) {
+      return res.status(400).json({ error: 'sourceId and targetId are required.' });
+    }
+    if (sourceId === targetId) {
+      return res.status(400).json({ error: 'sourceId and targetId must differ.' });
+    }
+
+    const located = await findBookByBookId(bookId);
+    if (!located) return res.status(404).json({ error: 'Book not found.' });
+    const { bookDir, state } = located;
+
+    try {
+      await performCastMerge({ bookId, bookDir, state, sourceId, targetId });
+    } catch (err) {
+      const e = err as { status?: number; error?: string };
+      if (e.status && e.error) {
+        return res.status(e.status).json({ error: e.error });
+      }
+      throw err;
+    }
+
+    /* Drop the suggestion only after a successful merge. */
+    await dismissSuggestion(bookDir, sourceId, targetId);
+    return res.json({});
+  },
+);

--- a/server/src/routes/cast-merge.ts
+++ b/server/src/routes/cast-merge.ts
@@ -18,13 +18,13 @@
 
 import { Router } from 'express';
 import type { Request, Response } from '../http.js';
-import { findBookByBookId } from '../workspace/scan.js';
+import { findBookByBookId, bookStateLanguage } from '../workspace/scan.js';
+import type { BookStateJson } from '../workspace/scan.js';
 import { castJsonPath, manuscriptEditsJsonPath } from '../workspace/paths.js';
 import { readJson, writeJsonAtomic } from '../workspace/state-io.js';
 import { loadAnalysisCache, saveAnalysisCache } from '../store/analysis-cache.js';
 import { loadCastMerges, saveCastMerges, appendManualEntry } from '../store/cast-merges.js';
 import { normaliseForMatch } from './analysis.js';
-import { bookStateLanguage } from '../workspace/scan.js';
 import { makeBucket, MALE_BUCKET_ID, FEMALE_BUCKET_ID } from '../analyzer/fold-minor-cast.js';
 import type { CharacterOutput, SentenceOutput } from '../handoff/schemas.js';
 
@@ -47,33 +47,41 @@ interface MergeBody {
   targetId?: unknown;
 }
 
-castMergeRouter.post('/:bookId/cast/merge', async (req: Request, res: Response) => {
-  const { bookId } = req.params;
-  const body = (req.body ?? {}) as MergeBody;
-  const sourceId = typeof body.sourceId === 'string' ? body.sourceId.trim() : '';
-  const targetId = typeof body.targetId === 'string' ? body.targetId.trim() : '';
+/** Result returned by `performCastMerge`. */
+export interface CastMergeResult {
+  characters: CharacterOutput[];
+}
 
-  if (!sourceId || !targetId) {
-    return res.status(400).json({ error: 'sourceId and targetId are required.' });
-  }
-  if (sourceId === targetId) {
-    return res.status(400).json({ error: 'sourceId and targetId must differ.' });
-  }
+/** Shared merge parameters — passed by both the manual-merge route and the
+    accept-suggestion route so the logic lives in exactly one place. */
+export interface CastMergeArgs {
+  bookId: string;
+  bookDir: string;
+  /** The book's state object (needed for language-aware bucket names). */
+  state: BookStateJson;
+  /** The id of the character to fold away (the "source" / duplicate). */
+  sourceId: string;
+  /** The id of the surviving character (the "target" / canonical). */
+  targetId: string;
+}
 
-  const located = await findBookByBookId(bookId);
-  if (!located) return res.status(404).json({ error: 'Book not found.' });
-  const { bookDir, state } = located;
+/** Perform the cast merge: fold `sourceId` into `targetId`, rewriting
+    cast.json, manuscript-edits.json, the analysis cache, and the
+    cast-merges journal. Returns the updated character list.
+
+    Throws with a shape `{ status: number; error: string }` on semantic
+    errors (404 / 409) so the caller can propagate the right HTTP status. */
+export async function performCastMerge(args: CastMergeArgs): Promise<CastMergeResult> {
+  const { bookId, bookDir, state, sourceId, targetId } = args;
 
   const cast = await readJson<CastFile>(castJsonPath(bookDir));
   if (!cast?.characters?.length) {
-    return res
-      .status(409)
-      .json({ error: 'Book has no cast on disk yet. Run analysis before merging characters.' });
+    throw { status: 409, error: 'Book has no cast on disk yet. Run analysis before merging characters.' };
   }
 
   const source = cast.characters.find((c) => c.id === sourceId);
   let target = cast.characters.find((c) => c.id === targetId);
-  if (!source) return res.status(404).json({ error: `Character "${sourceId}" not found.` });
+  if (!source) throw { status: 404, error: `Character "${sourceId}" not found.` };
   /* Downgrade-to-bucket path: when the caller targets one of the standing
      `unknown-male` / `unknown-female` buckets and that bucket doesn't yet
      exist in cast.json (the book had no auto-folded background speakers),
@@ -91,7 +99,7 @@ castMergeRouter.post('/:bookId/cast/merge', async (req: Request, res: Response) 
     cast.characters.push(createdBucket);
     target = createdBucket;
   }
-  if (!target) return res.status(404).json({ error: `Character "${targetId}" not found.` });
+  if (!target) throw { status: 404, error: `Character "${targetId}" not found.` };
 
   /* Build the merged target. Field rules mirror mergeRosterChapter, with
      two twists for the manual-merge case:
@@ -256,7 +264,36 @@ castMergeRouter.post('/:bookId/cast/merge', async (req: Request, res: Response) 
       (cacheTouched ? ' (rewrote cache)' : ''),
   );
 
-  return res.json({ characters: nextCharacters });
+  return { characters: nextCharacters };
+}
+
+castMergeRouter.post('/:bookId/cast/merge', async (req: Request, res: Response) => {
+  const { bookId } = req.params;
+  const body = (req.body ?? {}) as MergeBody;
+  const sourceId = typeof body.sourceId === 'string' ? body.sourceId.trim() : '';
+  const targetId = typeof body.targetId === 'string' ? body.targetId.trim() : '';
+
+  if (!sourceId || !targetId) {
+    return res.status(400).json({ error: 'sourceId and targetId are required.' });
+  }
+  if (sourceId === targetId) {
+    return res.status(400).json({ error: 'sourceId and targetId must differ.' });
+  }
+
+  const located = await findBookByBookId(bookId);
+  if (!located) return res.status(404).json({ error: 'Book not found.' });
+  const { bookDir, state } = located;
+
+  try {
+    const result = await performCastMerge({ bookId, bookDir, state, sourceId, targetId });
+    return res.json(result);
+  } catch (err) {
+    const e = err as { status?: number; error?: string };
+    if (e.status && e.error) {
+      return res.status(e.status).json({ error: e.error });
+    }
+    throw err;
+  }
 });
 
 /* Build the merged aliases list. Lower-case dedup, target first, then the

--- a/server/src/store/cast-merge-suggestions.test.ts
+++ b/server/src/store/cast-merge-suggestions.test.ts
@@ -1,0 +1,105 @@
+/* Unit tests for the cast-merge-suggestions sibling-file store. */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+
+describe('cast-merge-suggestions store', () => {
+  let workspaceRoot: string;
+  let bookDir: string;
+
+  beforeEach(() => {
+    workspaceRoot = mkdtempSync(join(tmpdir(), 'audiobook-cast-merge-suggestions-test-'));
+    process.env.WORKSPACE_DIR = workspaceRoot;
+    bookDir = join(workspaceRoot, 'books', 'A', 'Standalones', 'Book');
+    mkdirSync(join(bookDir, '.audiobook'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (workspaceRoot) rmSync(workspaceRoot, { recursive: true, force: true });
+    delete process.env.WORKSPACE_DIR;
+  });
+
+  it('load on missing file returns { suggestions: [] }', async () => {
+    const { loadSuggestions } = await import('./cast-merge-suggestions.js');
+    const result = await loadSuggestions(bookDir);
+    expect(result).toEqual({ suggestions: [] });
+  });
+
+  it('write→load round-trip preserves all fields', async () => {
+    const { writeSuggestions, loadSuggestions } = await import('./cast-merge-suggestions.js');
+    const suggestions = [
+      { sourceId: 'оля', targetId: 'ольга', reason: 'Diminutive of «Ольга»' },
+      { sourceId: 'ваня', targetId: 'иван', reason: 'Diminutive of «Иван»' },
+    ];
+    await writeSuggestions(bookDir, suggestions);
+    const result = await loadSuggestions(bookDir);
+    expect(result).toEqual({ suggestions });
+  });
+
+  it('writeSuggestions overwrites the whole file on second write', async () => {
+    const { writeSuggestions, loadSuggestions } = await import('./cast-merge-suggestions.js');
+    await writeSuggestions(bookDir, [
+      { sourceId: 'оля', targetId: 'ольга', reason: 'Diminutive of «Ольга»' },
+    ]);
+    await writeSuggestions(bookDir, [
+      { sourceId: 'ваня', targetId: 'иван', reason: 'Diminutive of «Иван»' },
+    ]);
+    const result = await loadSuggestions(bookDir);
+    expect(result.suggestions).toHaveLength(1);
+    expect(result.suggestions[0].sourceId).toBe('ваня');
+  });
+
+  it('clearSuggestions removes the file; subsequent load returns empty', async () => {
+    const { writeSuggestions, loadSuggestions, clearSuggestions } = await import(
+      './cast-merge-suggestions.js'
+    );
+    await writeSuggestions(bookDir, [
+      { sourceId: 'оля', targetId: 'ольга', reason: 'Diminutive of «Ольга»' },
+    ]);
+    const { castMergeSuggestionsJsonPath } = await import('../workspace/paths.js');
+    expect(existsSync(castMergeSuggestionsJsonPath(bookDir))).toBe(true);
+    await clearSuggestions(bookDir);
+    expect(existsSync(castMergeSuggestionsJsonPath(bookDir))).toBe(false);
+    const result = await loadSuggestions(bookDir);
+    expect(result).toEqual({ suggestions: [] });
+  });
+
+  it('clearSuggestions is a no-op when file is absent', async () => {
+    const { clearSuggestions } = await import('./cast-merge-suggestions.js');
+    await expect(clearSuggestions(bookDir)).resolves.toBeUndefined();
+  });
+
+  it('dismissSuggestion drops only the matching sourceId+targetId pair', async () => {
+    const { writeSuggestions, loadSuggestions, dismissSuggestion } = await import(
+      './cast-merge-suggestions.js'
+    );
+    const suggestions = [
+      { sourceId: 'оля', targetId: 'ольга', reason: 'Diminutive of «Ольга»' },
+      { sourceId: 'ваня', targetId: 'иван', reason: 'Diminutive of «Иван»' },
+      { sourceId: 'саша', targetId: 'александр', reason: 'Diminutive of «Александр»' },
+    ];
+    await writeSuggestions(bookDir, suggestions);
+    await dismissSuggestion(bookDir, 'ваня', 'иван');
+    const result = await loadSuggestions(bookDir);
+    expect(result.suggestions).toHaveLength(2);
+    expect(result.suggestions.find((s) => s.sourceId === 'ваня')).toBeUndefined();
+    expect(result.suggestions.find((s) => s.sourceId === 'оля')).toBeDefined();
+    expect(result.suggestions.find((s) => s.sourceId === 'саша')).toBeDefined();
+  });
+
+  it('dismissSuggestion is a no-op when sourceId+targetId is not found', async () => {
+    const { writeSuggestions, loadSuggestions, dismissSuggestion } = await import(
+      './cast-merge-suggestions.js'
+    );
+    const suggestions = [
+      { sourceId: 'оля', targetId: 'ольга', reason: 'Diminutive of «Ольга»' },
+    ];
+    await writeSuggestions(bookDir, suggestions);
+    await dismissSuggestion(bookDir, 'nonexistent', 'target');
+    const result = await loadSuggestions(bookDir);
+    expect(result.suggestions).toHaveLength(1);
+  });
+});

--- a/server/src/store/cast-merge-suggestions.ts
+++ b/server/src/store/cast-merge-suggestions.ts
@@ -1,0 +1,66 @@
+/* Per-book diminutive merge suggestions sibling file.
+
+   The dedup pass (roster-dedup.ts Tier-2b) produces SUGGESTIONS rather than
+   hard merges for diminutive pairs — e.g. "Оля + Ольга — same person?". These
+   persist to a sibling file (NOT inside cast.json) so the UI can surface them
+   across browser reloads and re-analyses without the cast.json envelope
+   stripping them.
+
+   Lifecycle:
+     - `writeSuggestions` — called at dedup finalisation (Task 10); overwrites
+       the whole file with the latest dedup pass result.
+     - `loadSuggestions` — called by the suggestions route (Task 11); returns
+       `{ suggestions: [] }` when the file is absent or malformed.
+     - `clearSuggestions` — called on `fresh: true` re-analysis alongside
+       `clearCastMerges` (Task 10); no-op when absent.
+     - `dismissSuggestion` — called when the user rejects a suggestion; removes
+       the matching pair and rewrites the file.
+
+   Same atomic-write + empty-on-missing contract as store/cast-merges.ts. */
+
+import { rm } from 'node:fs/promises';
+import { readJson, writeJsonAtomic } from '../workspace/state-io.js';
+import { castMergeSuggestionsJsonPath } from '../workspace/paths.js';
+import type { MergeSuggestion } from '../analyzer/roster-dedup.js';
+
+export type { MergeSuggestion };
+
+export interface CastMergeSuggestionsFile {
+  suggestions: MergeSuggestion[];
+}
+
+/** Load the suggestions file; returns `{ suggestions: [] }` when absent or malformed. */
+export async function loadSuggestions(bookDir: string): Promise<CastMergeSuggestionsFile> {
+  const existing = await readJson<CastMergeSuggestionsFile>(
+    castMergeSuggestionsJsonPath(bookDir),
+  );
+  if (existing && Array.isArray(existing.suggestions)) return existing;
+  return { suggestions: [] };
+}
+
+/** Atomically overwrite the suggestions file with the latest dedup pass result. */
+export async function writeSuggestions(
+  bookDir: string,
+  suggestions: MergeSuggestion[],
+): Promise<void> {
+  await writeJsonAtomic(castMergeSuggestionsJsonPath(bookDir), { suggestions });
+}
+
+/** Delete the suggestions file. No-op when absent. */
+export async function clearSuggestions(bookDir: string): Promise<void> {
+  await rm(castMergeSuggestionsJsonPath(bookDir), { force: true });
+}
+
+/** Remove the suggestion matching `sourceId`+`targetId` and write back.
+    No-op when the pair is not found or the file is absent. */
+export async function dismissSuggestion(
+  bookDir: string,
+  sourceId: string,
+  targetId: string,
+): Promise<void> {
+  const file = await loadSuggestions(bookDir);
+  const filtered = file.suggestions.filter(
+    (s) => !(s.sourceId === sourceId && s.targetId === targetId),
+  );
+  await writeSuggestions(bookDir, filtered);
+}

--- a/server/src/store/cast-merges.test.ts
+++ b/server/src/store/cast-merges.test.ts
@@ -99,6 +99,47 @@ describe('cast-merges store — pure helpers', () => {
     expect(next.entries).toHaveLength(1);
     expect(next.entries[0]).toMatchObject({ kind: 'manual', sourceId: 'a' });
   });
+
+  it('replaceDedupEntries swaps dedup entries but preserves fold + manual', async () => {
+    const { replaceDedupEntries } = await import('./cast-merges.js');
+    const base = {
+      entries: [
+        { ts: 't', kind: 'manual' as const, sourceId: 'a', sourceName: 'A', targetId: 'b', affected: [] },
+        { ts: 't', kind: 'fold' as const, sourceId: 'c', sourceName: 'C', targetId: 'd', affected: [] },
+        { ts: 't', kind: 'dedup' as const, sourceId: 'olga', sourceName: 'Ольга', targetId: 'ольга', affected: [] },
+      ],
+    };
+    const next = replaceDedupEntries(base, [
+      { ts: 't2', kind: 'dedup' as const, sourceId: 'ilya', sourceName: 'Илья', targetId: 'илья', affected: [] },
+    ]);
+    expect(next.entries.filter((e) => e.kind === 'manual')).toHaveLength(1);
+    expect(next.entries.filter((e) => e.kind === 'fold')).toHaveLength(1);
+    expect(next.entries.filter((e) => e.kind === 'dedup')).toEqual([
+      { ts: 't2', kind: 'dedup', sourceId: 'ilya', sourceName: 'Илья', targetId: 'илья', affected: [] },
+    ]);
+  });
+
+  it('buildDedupJournalEntries records pre-dedup affected sentences + sourceName', async () => {
+    const { buildDedupJournalEntries } = await import('./cast-merges.js');
+    const rewrites = { olga: 'ольга' };
+    const preDedupSentences = [
+      { id: 1, chapterId: 3, characterId: 'olga' },
+      { id: 2, chapterId: 3, characterId: 'antonio' },
+      { id: 5, chapterId: 4, characterId: 'olga' },
+    ];
+    const chars = [{ id: 'olga', name: 'Ольга' }, { id: 'ольга', name: 'Ольга' }];
+    const entries = buildDedupJournalEntries(rewrites, preDedupSentences, chars, 'TS');
+    expect(entries).toEqual([
+      {
+        ts: 'TS',
+        kind: 'dedup',
+        sourceId: 'olga',
+        sourceName: 'Ольга',
+        targetId: 'ольга',
+        affected: [{ chapterId: 3, sentenceId: 1 }, { chapterId: 4, sentenceId: 5 }],
+      },
+    ]);
+  });
 });
 
 describe('cast-merges store — IO round-trip', () => {

--- a/server/src/store/cast-merges.ts
+++ b/server/src/store/cast-merges.ts
@@ -6,9 +6,10 @@
    EXACTLY the sentences that merge rewrote — instead of reconstructing
    "impacted chapters" from the chapterCast roster, which over-reports.
 
-   Two write sites, mirroring how the alias gets created in the first place:
-     - manual merge (cast-merge.ts)         → appendManualEntry  (append-only)
-     - post-stage-2 auto-fold (analysis.ts) → replaceFoldEntries (idempotent)
+   Three write sites, mirroring how the alias gets created in the first place:
+     - manual merge (cast-merge.ts)         → appendManualEntry      (append-only)
+     - post-stage-2 auto-fold (analysis.ts) → replaceFoldEntries     (idempotent)
+     - dedup pass (analysis.ts)            → replaceDedupEntries    (idempotent)
 
    Lifecycle: a `fresh: true` re-analysis clears the whole file (ids regenerate
    from scratch); each fold pass replaces all `kind:'fold'` entries with that
@@ -38,7 +39,7 @@ export interface AffectedSentence {
 export interface CastMergeEntry {
   /** ISO timestamp the entry was recorded. */
   ts: string;
-  kind: 'manual' | 'fold';
+  kind: 'manual' | 'fold' | 'dedup';
   /** Character id that disappeared in the merge. */
   sourceId: string;
   /** The name that became the alias on the target — the match key the unlink
@@ -93,6 +94,43 @@ export function buildFoldJournalEntries(
   return sourceIds.map((sourceId) => ({
     ts,
     kind: 'fold' as const,
+    sourceId,
+    sourceName: nameById.get(sourceId) ?? sourceId,
+    targetId: rewrites[sourceId],
+    affected: affectedBySource.get(sourceId) ?? [],
+  }));
+}
+
+/** Replace ALL dedup entries with `dedupEntries`, preserving fold + manual.
+    Idempotent across resume / re-analysis — orthogonal to replaceFoldEntries. */
+export function replaceDedupEntries(
+  file: CastMergesFile,
+  dedupEntries: CastMergeEntry[],
+): CastMergesFile {
+  return { entries: [...file.entries.filter((e) => e.kind !== 'dedup'), ...dedupEntries] };
+}
+
+/** Like buildFoldJournalEntries but stamps kind:'dedup'. `affected` = the
+    (chapterId, sentenceId) of every PRE-DEDUP sentence attributed to each source;
+    `sourceName` from the pre-dedup roster. */
+export function buildDedupJournalEntries(
+  rewrites: Record<string, string>,
+  preDedupSentences: ReadonlyArray<{ id: number; chapterId: number; characterId: string }>,
+  characters: ReadonlyArray<{ id: string; name: string }>,
+  ts: string,
+): CastMergeEntry[] {
+  const sourceIds = Object.keys(rewrites);
+  if (sourceIds.length === 0) return [];
+  const nameById = new Map(characters.map((c) => [c.id, c.name]));
+  const affectedBySource = new Map<string, AffectedSentence[]>();
+  for (const id of sourceIds) affectedBySource.set(id, []);
+  for (const s of preDedupSentences) {
+    const bucket = affectedBySource.get(s.characterId);
+    if (bucket) bucket.push({ chapterId: s.chapterId, sentenceId: s.id });
+  }
+  return sourceIds.map((sourceId) => ({
+    ts,
+    kind: 'dedup' as const,
     sourceId,
     sourceName: nameById.get(sourceId) ?? sourceId,
     targetId: rewrites[sourceId],

--- a/server/src/store/cast-merges.ts
+++ b/server/src/store/cast-merges.ts
@@ -15,7 +15,7 @@
    from scratch); each fold pass replaces all `kind:'fold'` entries with that
    pass's set while preserving `kind:'manual'`; manual merges append.
 
-   Only these two paths rewrite THIS book's per-sentence `characterId`. The
+   Only these three paths rewrite THIS book's per-sentence `characterId`. The
    stage-1 roster merge happens before sentence attribution exists, and
    cast-link-prior / voice-match / add-alias only attach a recognition label —
    none of them move sentences, so the unlink route correctly falls back to the

--- a/server/src/store/merge-analysis-cast.test.ts
+++ b/server/src/store/merge-analysis-cast.test.ts
@@ -14,6 +14,7 @@ import {
   mergeAnalysisResultWithExistingCast,
   seedReuseGuardsFromPriorCast,
   voicedSurvivorsDropped,
+  applyRewriteToPriorCast,
 } from './merge-analysis-cast.js';
 
 type C = Record<string, unknown> & { id: string };
@@ -228,5 +229,19 @@ describe('voicedSurvivorsDropped', () => {
   it('returns the fresh roster unchanged when there is no existing cast', () => {
     const fresh: C[] = [{ id: 'a' }, { id: 'b' }];
     expect(mergeAnalysisResultWithExistingCast([], fresh)).toEqual(fresh);
+  });
+});
+
+describe('applyRewriteToPriorCast', () => {
+  it('remaps prior ids and keeps the strongest voiceState on collision', () => {
+    const prior = [
+      { id: 'olga', name: 'Ольга', voiceState: 'generated', overrideTtsVoices: { qwen: { name: 'qwen-gen' } } },
+      { id: 'ольга', name: 'Ольга', voiceState: 'tuned', overrideTtsVoices: { qwen: { name: 'qwen-tuned' } } },
+    ];
+    const { priorCast, droppedVoices } = applyRewriteToPriorCast(prior, { olga: 'ольга' });
+    const survivor = priorCast.find((c) => c.id === 'ольга');
+    expect(survivor?.overrideTtsVoices?.qwen?.name).toBe('qwen-tuned'); // tuned beats generated
+    expect(priorCast.filter((c) => c.id === 'ольга')).toHaveLength(1); // no duplicate id
+    expect(droppedVoices).toEqual([{ id: 'olga', voiceState: 'generated' }]);
   });
 });

--- a/server/src/store/merge-analysis-cast.ts
+++ b/server/src/store/merge-analysis-cast.ts
@@ -159,6 +159,77 @@ export function mergeAnalysisResultWithExistingCast<T extends { id: string }>(
   return overlaid;
 }
 
+/** Strength order for voiceState collision resolution. Higher = stronger. */
+const VOICE_STATE_RANK: Record<string, number> = {
+  locked: 3,
+  tuned: 2,
+  reused: 1,
+  generated: 0,
+};
+
+function voiceStateRank(state: unknown): number {
+  return typeof state === 'string' ? (VOICE_STATE_RANK[state] ?? -1) : -1;
+}
+
+/** Remap each prior cast row's `id` through `rewrites` (dedup canonical-id
+    table). When two rows collide on the same canonical id, keep the one with
+    the strongest `voiceState` (locked > tuned > reused > generated, undefined
+    weakest); tie-break by more lines if available, else first encountered.
+    Returns a new array of remapped rows and a list of dropped rows (original id
+    + voiceState) for caller logging. Inputs are not mutated. */
+export function applyRewriteToPriorCast<T extends CastRecord>(
+  priorCast: ReadonlyArray<T>,
+  rewrites: Record<string, string>,
+): { priorCast: T[]; droppedVoices: Array<{ id: string; voiceState?: string }> } {
+  // Map from canonical id → { row (with remapped id), originalId }
+  const winners = new Map<string, { row: T; originalId: string }>();
+  const droppedVoices: Array<{ id: string; voiceState?: string }> = [];
+
+  for (const row of priorCast) {
+    const originalId = row.id;
+    const canonicalId = rewrites[originalId] ?? originalId;
+    const remapped: T = canonicalId === originalId ? row : { ...row, id: canonicalId };
+    const existing = winners.get(canonicalId);
+    if (!existing) {
+      winners.set(canonicalId, { row: remapped, originalId });
+      continue;
+    }
+    // Collision — compare strengths
+    const incomingRank = voiceStateRank(row.voiceState);
+    const existingRank = voiceStateRank(existing.row.voiceState);
+    let droppedOriginalId: string;
+    let droppedVoiceState: unknown;
+    if (incomingRank > existingRank) {
+      droppedOriginalId = existing.originalId;
+      droppedVoiceState = existing.row.voiceState;
+      winners.set(canonicalId, { row: remapped, originalId });
+    } else if (incomingRank === existingRank) {
+      // tie-break: more lines wins, else first (existing) wins
+      const incomingLines = typeof row.lines === 'number' ? row.lines : -1;
+      const existingLines = typeof existing.row.lines === 'number' ? existing.row.lines : -1;
+      if (incomingLines > existingLines) {
+        droppedOriginalId = existing.originalId;
+        droppedVoiceState = existing.row.voiceState;
+        winners.set(canonicalId, { row: remapped, originalId });
+      } else {
+        droppedOriginalId = originalId;
+        droppedVoiceState = row.voiceState;
+        // existing stays in winners
+      }
+    } else {
+      droppedOriginalId = originalId;
+      droppedVoiceState = row.voiceState;
+      // existing stays in winners
+    }
+    droppedVoices.push({
+      id: droppedOriginalId,
+      ...(droppedVoiceState !== undefined ? { voiceState: droppedVoiceState as string } : {}),
+    });
+  }
+
+  return { priorCast: Array.from(winners.values()).map((w) => w.row), droppedVoices };
+}
+
 /** Seed the Facet-A guard fields (`notLinkedTo`, `matchedFrom`) from the prior
     cast onto the fresh roster IN PLACE, by id, before linkSeriesReuseAtAnalysis
     runs. Without this the link pass scores against an empty `notLinkedTo` and

--- a/server/src/workspace/paths.ts
+++ b/server/src/workspace/paths.ts
@@ -171,6 +171,15 @@ export function castMergesJsonPath(bookDir: string): string {
   return join(dotAudiobook(bookDir), 'cast-merges.json');
 }
 
+/** Per-book diminutive merge SUGGESTIONS from the dedup pass — a sibling file
+    that persists across the cast.json envelope so the UI can surface "Оля +
+    Ольга — same person?" prompts without losing them on a re-analysis. Written
+    by the dedup pass (Task 10), read by the suggestions route (Task 11),
+    dismissed one-by-one by the user. */
+export function castMergeSuggestionsJsonPath(bookDir: string): string {
+  return join(dotAudiobook(bookDir), 'cast-merge-suggestions.json');
+}
+
 export function revisionsJsonPath(bookDir: string): string {
   return join(dotAudiobook(bookDir), 'revisions.json');
 }

--- a/src/components/merge-suggestion-card.test.tsx
+++ b/src/components/merge-suggestion-card.test.tsx
@@ -1,0 +1,77 @@
+/* MergeSuggestionCard — unit tests for the Tier-2b diminutive merge-suggestion
+   card component. Verifies render (two names + reason + buttons) and button wiring
+   (Merge calls onMerge, Dismiss calls onDismiss). */
+
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MergeSuggestionCard } from './merge-suggestion-card';
+import type { MergeSuggestion } from '../lib/api';
+
+const suggestion: MergeSuggestion = {
+  sourceId: 'olya',
+  targetId: 'olga',
+  reason: 'Diminutive of «Ольга»',
+};
+
+describe('MergeSuggestionCard', () => {
+  it('renders source name, target name, and reason', () => {
+    const { container } = render(
+      <MergeSuggestionCard
+        suggestion={suggestion}
+        sourceName="Оля"
+        targetName="Ольга"
+        onMerge={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('merge-suggestion-card')).toBeInTheDocument();
+    /* The card heading contains both names. */
+    expect(container.querySelector('p')?.textContent).toMatch(/«Оля»/);
+    expect(container.querySelector('p')?.textContent).toMatch(/«Ольга»/);
+    expect(screen.getByText(/Diminutive of «Ольга»/)).toBeInTheDocument();
+  });
+
+  it('calls onMerge when the Merge button is clicked', () => {
+    const onMerge = vi.fn().mockResolvedValue(undefined);
+    render(
+      <MergeSuggestionCard
+        suggestion={suggestion}
+        sourceName="Оля"
+        targetName="Ольга"
+        onMerge={onMerge}
+        onDismiss={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('merge-suggestion-merge'));
+    expect(onMerge).toHaveBeenCalledOnce();
+  });
+
+  it('calls onDismiss when the Dismiss button is clicked', () => {
+    const onDismiss = vi.fn().mockResolvedValue(undefined);
+    render(
+      <MergeSuggestionCard
+        suggestion={suggestion}
+        sourceName="Оля"
+        targetName="Ольга"
+        onMerge={vi.fn()}
+        onDismiss={onDismiss}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('merge-suggestion-dismiss'));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it('falls back gracefully when names equal the ids (unknown character)', () => {
+    render(
+      <MergeSuggestionCard
+        suggestion={suggestion}
+        sourceName="olya"
+        targetName="olga"
+        onMerge={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/«olya»/)).toBeInTheDocument();
+    expect(screen.getByText(/«olga»/)).toBeInTheDocument();
+  });
+});

--- a/src/components/merge-suggestion-card.tsx
+++ b/src/components/merge-suggestion-card.tsx
@@ -1,0 +1,60 @@
+/* MergeSuggestionCard — one dismissable card for a Tier-2b diminutive
+   merge-suggestion (e.g. "These look like the same person: Оля + Ольга?").
+   The parent manages the list and passes callbacks for accept (Merge) and
+   dismiss (Dismiss) so this component stays stateless. */
+
+import type { MergeSuggestion } from '../lib/api';
+
+interface Props {
+  suggestion: MergeSuggestion;
+  /** Display name for the source (diminutive / duplicate) character. */
+  sourceName: string;
+  /** Display name for the target (canonical survivor) character. */
+  targetName: string;
+  onMerge: () => Promise<void> | void;
+  onDismiss: () => Promise<void> | void;
+}
+
+export function MergeSuggestionCard({
+  suggestion,
+  sourceName,
+  targetName,
+  onMerge,
+  onDismiss,
+}: Props) {
+  return (
+    <div
+      data-testid="merge-suggestion-card"
+      role="status"
+      className="w-full mb-3 px-4 py-3 rounded-2xl border border-amber-200 bg-amber-50/60 flex flex-col sm:flex-row sm:items-center gap-3"
+    >
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-semibold text-ink">
+          These look like the same person:{' '}
+          <span className="text-amber-800">«{sourceName}»</span>
+          {' + '}
+          <span className="text-amber-800">«{targetName}»</span>
+        </p>
+        <p className="text-xs text-ink/60 mt-0.5">{suggestion.reason}</p>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <button
+          type="button"
+          data-testid="merge-suggestion-merge"
+          onClick={() => void onMerge()}
+          className="min-h-[44px] sm:min-h-0 px-3 py-1.5 rounded-full bg-amber-700 hover:bg-amber-800 text-white text-xs font-semibold transition-colors"
+        >
+          Merge
+        </button>
+        <button
+          type="button"
+          data-testid="merge-suggestion-dismiss"
+          onClick={() => void onDismiss()}
+          className="min-h-[44px] sm:min-h-0 px-3 py-1.5 rounded-full border border-ink/15 bg-white hover:bg-ink/5 text-ink/70 text-xs font-medium transition-colors"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -836,6 +836,73 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/books/{bookId}/cast/merge-suggestions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List diminutive merge suggestions for a book
+         * @description Returns the current set of per-book diminutive merge suggestions written
+         *     by the dedup pass (e.g. "Оля + Ольга — same person?"). Returns
+         *     `{ suggestions: [] }` when the book is unknown or no file exists —
+         *     safe to call without a prior existence check.
+         */
+        get: operations["listCastMergeSuggestions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/books/{bookId}/cast/merge-suggestions/dismiss": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Dismiss a merge suggestion
+         * @description Removes the matching `(sourceId, targetId)` pair from the suggestions
+         *     file. No-op when the pair is already absent. Does NOT perform any merge.
+         */
+        post: operations["dismissCastMergeSuggestion"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/books/{bookId}/cast/merge-suggestions/accept": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Accept a merge suggestion (merge + dismiss)
+         * @description Performs the cast merge (`sourceId` folded into `targetId`, where
+         *     `targetId` is the canonical survivor), then drops the suggestion so it
+         *     never resurfaces. Equivalent to calling `POST /cast/merge` followed by
+         *     `POST /cast/merge-suggestions/dismiss`.
+         */
+        post: operations["acceptCastMergeSuggestion"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/queue": {
         parameters: {
             query?: never;
@@ -1866,6 +1933,23 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /**
+         * @description A suggested merge pair produced by the dedup pass (Tier-2b).
+         *     `sourceId` is the diminutive/duplicate character; `targetId` is the
+         *     canonical survivor. The UI surfaces this as "Are Оля and Ольга the
+         *     same person?" and lets the user accept (merge) or dismiss (keep both).
+         */
+        MergeSuggestion: {
+            /** @description Id of the character to fold away (the diminutive / duplicate). */
+            sourceId: string;
+            /** @description Id of the canonical surviving character. */
+            targetId: string;
+            /** @description Human-readable explanation of why these were flagged (e.g. "diminutive of Ольга"). */
+            reason: string;
+        };
+        CastMergeSuggestionsResponse: {
+            suggestions: components["schemas"]["MergeSuggestion"][];
+        };
         /**
          * @description srv-2 — one auto-backup snapshot of a book's state.json. Returned
          *     by GET /api/books/{bookId}/backups, newest first.
@@ -5255,6 +5339,121 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["VoiceMatchResponse"];
                 };
+            };
+        };
+    };
+    listCastMergeSuggestions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                bookId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Current suggestion list (may be empty) */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CastMergeSuggestionsResponse"];
+                };
+            };
+        };
+    };
+    dismissCastMergeSuggestion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                bookId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description The id of the character to fold (the diminutive / duplicate). */
+                    sourceId: string;
+                    /** @description The id of the canonical survivor. */
+                    targetId: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Suggestion removed (or was already absent) */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description sourceId or targetId missing */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Book not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    acceptCastMergeSuggestion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                bookId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description The id of the character to fold (the diminutive / duplicate). */
+                    sourceId: string;
+                    /** @description The id of the canonical survivor. */
+                    targetId: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Merge performed and suggestion removed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or equal sourceId/targetId */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Book or character not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Book has no cast yet */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -54,6 +54,7 @@ import type {
   LibraryStats,
   ContinueListeningItem,
 } from './types';
+import type { components as ApiComponents } from './api-types';
 import { FRONTEND_ACCOUNT_DEFAULTS } from './account-defaults';
 import { initialCharacters } from '../data/characters';
 import { ANALYSIS_NORTHERN_STAR } from '../mocks/canned-data';
@@ -262,6 +263,8 @@ export interface MergeCharactersArgs {
 export interface MergeCharactersResponse {
   characters: Character[];
 }
+/* Tier-2b diminutive merge-suggestions (Task 12). Sourced from api-types.ts. */
+export type MergeSuggestion = ApiComponents['schemas']['MergeSuggestion'];
 /* POST /api/books/:bookId/cast/:characterId/series-patch — cross-book
    Compare save propagation. Applies the patch to the source character
    AND every series-sibling cast.json row that the plan-94 dedup rule
@@ -2762,6 +2765,97 @@ async function mockMergeCharacters({
   void sourceId;
   void targetId;
   return { characters: [] };
+}
+
+/* ── Tier-2b diminutive merge-suggestions (Task 12) ─────────────────────── */
+
+/* Module-level mutable list so accept/dismiss mock calls remove the pair and
+   a subsequent listMergeSuggestions returns the updated state within a session. */
+let mockMergeSuggestions: MergeSuggestion[] = [
+  { sourceId: 'eliza', targetId: 'halloran', reason: 'Possible duplicate — same scene pattern' },
+  { sourceId: 'marcus', targetId: 'halloran', reason: 'Possible duplicate — shared minor role' },
+];
+
+async function realListMergeSuggestions(bookId: string): Promise<MergeSuggestion[]> {
+  const res = await fetch(`/api/books/${encodeURIComponent(bookId)}/cast/merge-suggestions`);
+  if (!res.ok) throw new Error(`List merge-suggestions failed (${res.status}).`);
+  const body = (await res.json()) as { suggestions: MergeSuggestion[] };
+  return body.suggestions;
+}
+
+async function mockListMergeSuggestions(_bookId: string): Promise<MergeSuggestion[]> {
+  await wait(40);
+  return [...mockMergeSuggestions];
+}
+
+async function realAcceptMergeSuggestion(
+  bookId: string,
+  sourceId: string,
+  targetId: string,
+): Promise<void> {
+  const res = await fetch(
+    `/api/books/${encodeURIComponent(bookId)}/cast/merge-suggestions/accept`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sourceId, targetId }),
+    },
+  );
+  if (!res.ok) {
+    let detail = '';
+    try {
+      detail = ((await res.json()) as { error?: string }).error ?? '';
+    } catch {
+      /* not json */
+    }
+    throw new Error(detail || `Accept merge-suggestion failed (${res.status}).`);
+  }
+}
+
+async function mockAcceptMergeSuggestion(
+  _bookId: string,
+  sourceId: string,
+  targetId: string,
+): Promise<void> {
+  await wait(60);
+  mockMergeSuggestions = mockMergeSuggestions.filter(
+    (s) => !(s.sourceId === sourceId && s.targetId === targetId),
+  );
+}
+
+async function realDismissMergeSuggestion(
+  bookId: string,
+  sourceId: string,
+  targetId: string,
+): Promise<void> {
+  const res = await fetch(
+    `/api/books/${encodeURIComponent(bookId)}/cast/merge-suggestions/dismiss`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sourceId, targetId }),
+    },
+  );
+  if (!res.ok) {
+    let detail = '';
+    try {
+      detail = ((await res.json()) as { error?: string }).error ?? '';
+    } catch {
+      /* not json */
+    }
+    throw new Error(detail || `Dismiss merge-suggestion failed (${res.status}).`);
+  }
+}
+
+async function mockDismissMergeSuggestion(
+  _bookId: string,
+  sourceId: string,
+  targetId: string,
+): Promise<void> {
+  await wait(60);
+  mockMergeSuggestions = mockMergeSuggestions.filter(
+    (s) => !(s.sourceId === sourceId && s.targetId === targetId),
+  );
 }
 
 async function realSeriesPatchCharacter({
@@ -6639,6 +6733,9 @@ const real = {
   analyseManuscript: realAnalyseManuscript,
   matchVoices: realMatchVoices,
   mergeCharacters: realMergeCharacters,
+  listMergeSuggestions: realListMergeSuggestions,
+  acceptMergeSuggestion: realAcceptMergeSuggestion,
+  dismissMergeSuggestion: realDismissMergeSuggestion,
   seriesPatchCharacter: realSeriesPatchCharacter,
   unlinkAlias: realUnlinkAlias,
   addAlias: realAddAlias,
@@ -6896,6 +6993,9 @@ const mock = {
   analyseManuscript: mockAnalyseManuscript,
   matchVoices: mockMatchVoices,
   mergeCharacters: mockMergeCharacters,
+  listMergeSuggestions: mockListMergeSuggestions,
+  acceptMergeSuggestion: mockAcceptMergeSuggestion,
+  dismissMergeSuggestion: mockDismissMergeSuggestion,
   seriesPatchCharacter: mockSeriesPatchCharacter,
   unlinkAlias: mockUnlinkAlias,
   addAlias: mockAddAlias,

--- a/src/views/cast.tsx
+++ b/src/views/cast.tsx
@@ -56,7 +56,9 @@ import { CompareCastModal } from '../modals/compare-cast-modal';
 import { StaleAudioBanner } from '../components/stale-audio-banner';
 import { QwenStatusNotice } from '../components/qwen-status-notice';
 import { DesignScopePicker } from '../components/design-scope-picker';
+import { MergeSuggestionCard } from '../components/merge-suggestion-card';
 import { api } from '../lib/api';
+import type { MergeSuggestion } from '../lib/api';
 import type { CastDesignScope } from '../store/cast-design-slice';
 import { buildVariantTasks, variantWorkCounts } from '../lib/variant-tasks';
 
@@ -208,6 +210,25 @@ export function CastView({
   );
   const dispatch = useAppDispatch();
   const playback = useSamplePlayback();
+  /* Tier-2b diminutive merge-suggestions — fetched once when the book is ready,
+     maintained in local state so accept/dismiss updates remove the card immediately
+     without a round-trip. */
+  const [mergeSuggestions, setMergeSuggestions] = useState<MergeSuggestion[]>([]);
+  useEffect(() => {
+    if (!bookId) return;
+    let alive = true;
+    void (async () => {
+      try {
+        const suggestions = await api.listMergeSuggestions(bookId);
+        if (alive) setMergeSuggestions(suggestions);
+      } catch {
+        /* Non-fatal: the cast view is fully functional without suggestions. */
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [bookId]);
   /* Per-row sample state: { [characterId]: 'loading' | 'error: msg' }. The
      "playing" indicator is derived from the singleton playback hook by
      comparing currentUrl, so multiple rows can't show as "playing" at once. */
@@ -495,6 +516,27 @@ export function CastView({
     );
   }
 
+  /* Tier-2b merge-suggestion handlers. Accept folds the source character
+     into the target via the accept route (merge + dismiss in one call),
+     then removes the card and optimistically removes the source from the
+     local roster. Dismiss drops the card without merging. */
+  async function handleMergeSuggestion(sourceId: string, targetId: string) {
+    if (!bookId) return;
+    await api.acceptMergeSuggestion(bookId, sourceId, targetId);
+    setMergeSuggestions((prev) =>
+      prev.filter((s) => !(s.sourceId === sourceId && s.targetId === targetId)),
+    );
+    setCharacters((prev) => prev.filter((c) => c.id !== sourceId));
+  }
+
+  async function handleDismissSuggestion(sourceId: string, targetId: string) {
+    if (!bookId) return;
+    await api.dismissMergeSuggestion(bookId, sourceId, targetId);
+    setMergeSuggestions((prev) =>
+      prev.filter((s) => !(s.sourceId === sourceId && s.targetId === targetId)),
+    );
+  }
+
   function handleDrop(charId: string) {
     if (!draggingVoiceId) return;
     const voice = findVoice(draggingVoiceId);
@@ -709,6 +751,29 @@ export function CastView({
               This book isn't in English, so it renders through Qwen — undesigned characters can't be
               generated.
             </p>
+          </div>
+        )}
+
+        {/* Tier-2b — diminutive merge-suggestion cards. Rendered when the
+            dedup pass detected possible name-alias duplicates (e.g. "Оля" vs
+            "Ольга"). One card per suggestion; accept folds the source character
+            into the target, dismiss hides the card without merging. */}
+        {mergeSuggestions.length > 0 && (
+          <div data-testid="merge-suggestions-list" className="mb-4 space-y-0">
+            {mergeSuggestions.map((s) => {
+              const sourceName = characters.find((c) => c.id === s.sourceId)?.name ?? s.sourceId;
+              const targetName = characters.find((c) => c.id === s.targetId)?.name ?? s.targetId;
+              return (
+                <MergeSuggestionCard
+                  key={`${s.sourceId}+${s.targetId}`}
+                  suggestion={s}
+                  sourceName={sourceName}
+                  targetName={targetName}
+                  onMerge={() => handleMergeSuggestion(s.sourceId, s.targetId)}
+                  onDismiss={() => handleDismissSuggestion(s.sourceId, s.targetId)}
+                />
+              );
+            })}
           </div>
         )}
 


### PR DESCRIPTION
## Summary

Fixes two user-reported defects on Russian-book analysis (reproduced from a real `gemma4-e4b` run on *Ночной дозор*, persisted `cast.json`):

1. **Duplicate cast entries.** The analyzer emits the same Cyrillic character under divergent transliterated ids (`ольга`/`olga`, `ilya`/`илья`, `semen`/`семен`, `тигренок`/`tigrenok`); `mergeRosterChapter` merges by exact id only, so they never collapse. Root cause is **model-independent** (the emitted `id` is trusted verbatim). This re-opens plan **221 Wave C**, which was closed as "OBSOLETE" on a single stochastic probe — a **false negative**.
2. **Empty tone profiles (2/28).** `tone` was `.optional()` in the constrained-decoding schema, so the grammar *let* the model skip it while the prompt said "always emit" — the grammar wins.

**The fix:**
- **Dedup** — a finalization `dedupeRosterByName` pass: **Tier-1** exact normalized-name auto-merge (gender-gated, narrator-safe, canonical id = `safeId(name)`), **Tier-2a** full-vs-short token-subset auto-merge (single-superset gate), **Tier-2b** diminutive → **suggestion** only (sibling `cast-merge-suggestions.json` + list/accept/dismiss routes + one-tap cast-review cards). Sentence `characterId`s rewritten + transitively composed; a `kind:'dedup'` journal keeps merges reversible; a voiceState-ranked `applyRewriteToPriorCast` makes designed voices follow `olga→ольга` (closes the voice-orphan BLOCKER from review).
- **Tone** — a two-schema `runStage` (required-tone **grammar** / tolerant **validation**, so a missing tone never fails a chapter) plus a deterministic `fillToneFromAttributes` backstop (bilingual keyword→axis).

Built via subagent-driven TDD (12 tasks, each spec+quality reviewed; spec 3× adversarially reviewed; opus whole-branch review = **READY TO MERGE**). Design + plan: `docs/superpowers/{specs,plans}/2026-06-20-russian-cast-dedup-and-tone*`. Regression plan updated: `docs/features/221-multilingual-attribution-gemma-and-cast-merge.md` (Wave C → shipped).

## Test plan

- Server: `roster-dedup` (Tier-1/2a/2b + tie-break + prune + composeRewrites), `roster-merge-fields`, `ru-diminutives`, `fill-tone`, required-tone schemas, two-schema `runStage` (Ollama tolerant-validation), `applyRewriteToPriorCast` collision policy, `kind:'dedup'` journal, `cast-merge-suggestions` store + routes, `dedupAndPrepare` finalization helper. Full server suites green; `tsc --noEmit` = 0.
- Frontend: merge-suggestion card component test (4/4) + cast-view wiring; full frontend suite 2982/2982.
- e2e: `cast-merge-suggestions.spec.ts` (card renders → Merge/Dismiss remove). `npm run verify` green on push (the one transient e2e abort was Windows worker-contention; specs pass in isolation).
- Acceptance owed: live re-analysis of *Ночной дозор* on the merged pipeline (user chose re-analyze; no migration).

Refs #960, #961 (follow-ups: reuse-link remap on voiced/series re-analysis; Gemini slow-tier two-schema test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)