### PR TITLE
docs(docs): fs-48 Fish Audio S2-Pro engine design spec (parked Could)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -339,6 +339,12 @@ _Full detail + acceptance:_ [#593](https://github.com/dudarenok-maker/AudioBook-
 - _Benefit (user):_ the variant filter never silently carries over to a tab where it shows nothing.
 _Full detail + acceptance:_ [#644](https://github.com/dudarenok-maker/AudioBook-Generator/issues/644).
 
+#### `fs-48` — Fish Audio S2-Pro TTS engine (16GB premium tier) ([#964](https://github.com/dudarenok-maker/Castwright/issues/964))
+
+- _What:_ Opt-in fourth TTS engine (alongside Kokoro/Coqui/Qwen) targeting **16GB consumer GPUs** via **BNB NF4 4-bit** (FP8 ≈ 20GB, GGUF too slow at RTF≈3). Prefer in-process PyTorch reuse; clone-from-seed voices on a Qwen-style per-character lifecycle + a bundled age×gender seed-reference library. **Parked — blocked on four gates:** legal sign-off (Fish Audio Research License — personal use OK, for-sale is the user's own licence), a physical 16GB card for the hardware-gated Task-0 spike, `srv-43` (`voiceUuid`), and the unproven make-or-break 4-bit prosody-quality question.
+- _Benefit (user):_ the best-quality, expressive, multilingual engine within reach of quality-chasers on a mainstream 16GB card (no 24GB required).
+_Full detail + acceptance:_ spec `docs/superpowers/specs/2026-06-20-fish-audio-s2pro-engine-design.md` (brainstormed + 3 adversarial reviews) · [#964](https://github.com/dudarenok-maker/Castwright/issues/964).
+
 ### Security & hardening
 
 Source for the whole sub-group: the [2026-05-31 security review](security/2026-05-31-security-review.md). All are scoped to the **opt-in LAN exposure surface** (`npm run start:lan`) or local-only defense-in-depth — the app is single-user/local-first by design, so these harden the hostile-LAN and local-write threat models rather than fixing an exploited-today hole. `srv-19` (draft plan 157) is the partner default-bind fix.

--- a/docs/superpowers/specs/2026-06-20-fish-audio-s2pro-engine-design.md
+++ b/docs/superpowers/specs/2026-06-20-fish-audio-s2pro-engine-design.md
@@ -3,15 +3,18 @@
 - **Date:** 2026-06-20
 - **Issue:** _to be filed_ (`area:fs`, `moscow:could`, `type:feat`)
 - **Branch:** _none yet — backlog Could item; spec only_
-- **Status:** approved design (brainstormed + two adversarial reviews folded in) — captured as a
-  future Could item, not slated for build
-- **Revision note:** v2 corrects v1's factual and codebase claims after two adversarial reviews
-  and a dedicated 16GB-feasibility research pass. Material changes: **16GB is the primary target**
-  (per product steer — 24GB cards are out of reach for most local users), reached via **BNB NF4
-  4-bit** (the chosen quant; FP8 is really a 20GB path, GGUF is too slow); license terms are
-  stronger with personal-use as the through-line; **in-process PyTorch reuse is the preferred
-  integration** (NF4/`bitsandbytes` is pure torch), with an out-of-process HTTP child as the
-  documented fallback; several v1 file/function names were wrong and are corrected below.
+- **Status:** approved design (brainstormed + three adversarial reviews folded in) — a
+  **parked Could**, blocked on a physical 16GB card + legal sign-off + srv-43; not slated for build
+- **Revision note:** v3 after three adversarial reviews + a 16GB-feasibility research pass.
+  **16GB is the design target** (per product steer — 24GB cards are out of reach for most local
+  users), reached via **BNB NF4 4-bit** (FP8 is really a 20GB path, GGUF too slow) — but framed
+  honestly as a **bet unproven until the hardware spike**, not a settled fact. License terms
+  sharpened (Research License; personal-use through-line). **In-process PyTorch reuse is the
+  preferred integration** (NF4/`bitsandbytes` is pure torch); out-of-process HTTP child is the
+  fallback. Round 3 added: the **parked/blocked MoSCoW honesty** (four hard gates), the
+  **fallback-ladder honesty** (24GB rung is a different product), the chunk-length spike task,
+  and fixed a stray "Redux models state" claim (it's local component state). Wrong v1
+  file/function names corrected throughout; codebase claims re-verified.
 
 ## Summary
 
@@ -28,11 +31,13 @@ It is **not** a default engine and **not** auto-installed. You opt in through th
 of reach for most local users**, so a 24GB-only engine would miss the audience. fishaudio's
 *official* recommendation is ~24GB and they declined to ship a 16GB-fitting path themselves
 (issue #1168, closed "not planned") — but the **consumer ecosystem already runs S2-Pro on
-≤16GB via community 4-bit quantization** (BNB NF4; see §"The 16GB path"). So **16GB is the primary
-design target**; **24GB is the comfortable fallback** for users who have it, and the
-**full-precision 24GB path is the safety net** if the 16GB path can't hit an acceptable quality
-or speed bar. The 16GB path is **measured, not assumed** — it's gated on the hardware spike
-(§Gate 2 / §Acceptance). See §"The 16GB path" for the concrete approach.
+≤16GB via community 4-bit quantization** (BNB NF4; see §"The 16GB path"). So **16GB is the design
+target we're betting on** — but it is **a bet, not a settled fact**: the NF4 ~16GB figure is an
+unverified community claim, never measured on a real 16GB card, and 4-bit's effect on S2-Pro's
+expressive quality is untested (§"The 16GB path", §Risks). The bet is only confirmed by the
+hardware spike (§Gate 2 / §Acceptance). **24GB/full precision is the safety net** if the 16GB
+path can't hit the VRAM/speed/quality bar — though note (§Gate 2) that falling back to 24GB
+ships a *different* product that no longer serves this item's headline audience.
 
 S2-Pro's multilingual reach is a real incidental benefit but not the headline.
 
@@ -76,14 +81,21 @@ only run once a **16GB card is physically in hand**. Its job is to confirm a cho
 quantization path hits **peak VRAM ≤ 16GB at an acceptable speed and quality** (bar in
 §Acceptance). The candidate paths and evidence are detailed in §"The 16GB path."
 
-**Fallback ladder if the NF4 spike underperforms** (so the item never just dies):
+**Fallback ladder if the NF4 spike underperforms.** Be honest about what each rung actually
+saves: rung 1 saves the 16GB target; rungs 2–3 save *an* engine but **not this item's headline
+benefit** — "premium quality on a *16GB* card." A 24GB-class engine is a different product
+serving a different (smaller) audience, so reaching rung 2 should trigger an explicit
+*should-we-even-ship* re-evaluation, not an automatic yes.
 1. Add **chunked synthesis** (ComfyUI-style chunk-length) to cap KV-cache peak; if still over,
-   try the build-it-yourself sequential stage-load / codec CPU-offload.
-2. If 16GB can't hit the VRAM/speed/quality bar, ship as a **20GB (FP8) or 24GB (full)**
-   engine with 16GB marked experimental — still useful, just not the headline.
+   try the build-it-yourself sequential stage-load / codec CPU-offload. *(Saves the 16GB target.)*
+2. If 16GB can't hit the VRAM/speed bar, ship as a **20GB (FP8) or 24GB (full)** engine with
+   16GB experimental. *(Saves an engine, loses the 16GB headline — re-evaluate whether it's worth
+   it.)*
 3. The GGUF/`s2.cpp` path covers sub-12GB/CPU users but at RTF≈3 — offer it only as an explicit
    "slow but tiny" option, never the default.
-4. Only if *none* works does the item park.
+4. If the **4-bit quality gate** (Acceptance #3) *or* the **better-than-Qwen gate**
+   (Acceptance #5) fails at every precision, **the item parks** — an engine no better than the
+   resident Qwen isn't worth its VRAM.
 
 ## Engine architecture
 
@@ -183,9 +195,13 @@ our own numbers on our own pipeline.
    quantization is most likely to degrade exactly that, and **no report has tested it.** If NF4
    guts the emotion control, the "premium quality" premise fails even if VRAM fits — fall back
    to FP8@20GB or full@24GB and drop the 16GB headline.
-2. **Peak under a long KV cache.** 16GB-NF4 is a *claim*; a real 16GB card could OOM once the KV
-   cache grows over a long sentence. Chunked synthesis (the ComfyUI `chunk-length` knob, 100-400)
-   is the mitigation; the spike must confirm peak stays ≤16GB with desktop/OS headroom.
+2. **Peak under a long KV cache — and the arithmetic is tight.** The table's "~16GB" is the
+   *model + KV* figure with **no OS/desktop headroom** (Windows idle alone is ~1–2GB), and it's
+   *before* KV-cache growth over a long sentence. On those numbers the raw NF4 path **fails
+   Acceptance #2** (≤16GB *including* headroom *and* KV cache) — chunked synthesis is what's
+   expected to rescue it. **Spike task:** sweep the ComfyUI `chunk-length` knob (100–400) to find
+   the largest chunk that holds **peak ≤16GB with OS headroom**; if no chunk size does, the 16GB
+   target falls to rung 2 of the ladder. This knob is the literal make-or-break lever.
 
 **Undocumented-but-plausible levers** (build-it-yourself, no S2-Pro precedent): sequential
 stage-loading (load slow-AR → free → load codec) and CPU-offloading the codec stage. Only reach
@@ -222,6 +238,13 @@ approximate).
 
 ### Bundled seed-reference voice library (a first-class deliverable, with its own picker path)
 
+_Captured here at the product owner's request while the thinking was fresh — but this taxonomy is
+**plan-time design, not a go/no-go input.** The go/no-go rests only on Gate 1 (legal) + Gate 2
+(16GB VRAM/quality spike). The one decision-relevant fact is the **cost flag**: clone-only means
+we must source and bundle a seed library, which is non-trivial, ethically-constrained asset work
+— "mirror Qwen" is not free. The grid below is the proposed shape for when the item is actually
+planned._
+
 A curated **age × gender grid** of short reference clips:
 
 - **Age (5):** `child`, `teenager`, `young-adult`, `adult`, `elderly`.
@@ -250,7 +273,12 @@ ethically constrained asset work — part of the item, not an afterthought. **Br
 note:** the engine also lets a user clone *any* uploaded clip, including a real child's — a
 misuse surface the seed-sourcing rule does not cover; worth a usage/ToS line.
 
-## Integration seams (corrected touch-list)
+## Integration seams (indicative — plan-time detail)
+
+_File/function names below are **indicative**, verified against today's code to size the work and
+surface hidden costs — not a frozen contract (v1 got several wrong; an unbuilt parked item will
+drift). The genuinely **load-bearing** seam for the go/no-go is the **srv-43 `qwenStorageKey`
+dependency** (a hard external blocker); the rest is plan-time content captured early._
 
 **Sidecar (Python):**
 - `server/tts-sidecar/main.py` — `FishAudioS2ProEngine` registered in `ENGINES`; **preferred:
@@ -287,7 +315,9 @@ misuse surface the seed-sourcing rule does not cover; worth a usage/ToS line.
 - `src/components/ModelControlPill.tsx` — Fish health card + Load / Stop / Repair (the real
   Model-Manager component; there is **no** `server/src/model-control/` dir nor a
   `use-model-control.ts` hook — v1 named both wrongly).
-- The models inventory state (Redux + `models-inventory` route) — install/tier surfacing.
+- The model inventory surfacing — the `models-inventory` route read into **local component
+  state** (`model-manager.tsx` `useState` / `ModelControlPill.tsx`); **not** Redux (there is no
+  models slice in `src/store/`).
 - Voice-picker UI — Fish's age×gender grid + the tone/persona text box.
 
 **Docs:** a regression plan under `docs/features/`; `INDEX.md` entry; INSTALL/README engine
@@ -368,8 +398,13 @@ generating," with a clear error otherwise.
 
 ## Backlog framing
 
-- **MoSCoW: Could.** Prefix `fs-` (full-stack engine). **Next free id confirmed = `fs-48`**
-  (highest existing across GitHub issues is `fs-47`).
+- **MoSCoW: Could — explicitly *parked / blocked*.** A plain "Could" would over-state
+  readiness: the item sits behind **four independent hard gates**, any of which can kill it —
+  (1) legal sign-off on the Research License, (2) srv-43 must land first, (3) a physical 16GB
+  card must be acquired for Task 0, (4) the 4-bit quality gate is unproven and make-or-break. So
+  it's filed as a Could but tagged **"parked — blocked on hardware + legal + srv-43"** in
+  `docs/BACKLOG.md`, not as a ready-to-pull Could. Prefix `fs-` (full-stack engine).
+  **Next free id confirmed = `fs-48`** (highest existing across GitHub issues is `fs-47`).
 - Issue carries What / Acceptance / **Key files** / **Depends on (legal sign-off + srv-43 +
   16GB hardware spike)** / Benefit; a thin row lands in `docs/BACKLOG.md` under **Could**,
   linking this spec.

--- a/docs/superpowers/specs/2026-06-20-fish-audio-s2pro-engine-design.md
+++ b/docs/superpowers/specs/2026-06-20-fish-audio-s2pro-engine-design.md
@@ -1,0 +1,186 @@
+# fs-48 — Fish Audio S2-Pro TTS engine (premium quality, 16GB-card tier)
+
+- **Date:** 2026-06-20
+- **Issue:** _to be filed_ (`area:fs`, `moscow:could`, `type:feat`)
+- **Branch:** _none yet — backlog Could item; spec only_
+- **Status:** approved design (brainstormed) — captured as a future Could item, not slated for build
+
+## Summary
+
+Add **Fish Audio S2-Pro** as a fourth, **opt-in** synthesis engine alongside Kokoro, Coqui
+XTTS, and Qwen. It targets **quality-chasing users on 16GB GPUs** — people who have headroom
+beyond the 8GB default box and want the best timbre/expressiveness we can offer. S2-Pro is a
+~4.4B-param zero-shot **clone** model (a 4B "slow AR" semantic stage + a 400M "fast AR"
+acoustic stage) with inline tone control and 80+ language coverage.
+
+It is **not** a default engine and **not** auto-installed. You opt in through the Model
+Manager (like Coqui today), and it loads **button-driven** like Qwen — resident only while in
+use, evicted otherwise. That lifecycle is what keeps it honest on a 16GB card.
+
+The headline framing stays **"premium quality on a 16GB card."** Its multilingual reach
+(including Russian) is a real incidental benefit but is not the pitch.
+
+## Why this is a Could, and what gates it
+
+Two facts shape the entire item and are written here so a future implementer inherits them
+rather than rediscovering them:
+
+1. **License boundary (the commercial gate).** Fish Audio S2 / S2-Pro is **source-available,
+   not open-source**: weights are free for **personal and research** use, but **commercial
+   use is restricted** and requires an agreement with Fish Audio. Castwright is a commercial
+   product. Therefore this ships **opt-in only**, with the user fetching weights from
+   HuggingFace under their own personal/research use — and a **Fish Audio commercial license
+   is a hard prerequisite before S2-Pro could ever become a default or shipped-on engine.**
+   This belongs in the issue's **Depends on**.
+
+2. **16GB feasibility is a real engineering bet, not a given (the technical gate).** Real-world
+   reports put **peak inference VRAM at ~17GB at full precision** — i.e. it *overflows* a 16GB
+   card as-shipped (9GB FP16 checkpoint + activations + KV cache). The path to 16GB is **FP8
+   quantization** (weights roughly halve to ~4.4GB; peak likely lands ~10–13GB) plus
+   **streaming/chunked synthesis** to cap KV-cache growth. Whether a released FP8 build exists,
+   or we quantize ourselves, or streaming is required, is **unresolved** — it is a **Task-0
+   spike**. If a 16GB peak proves unachievable, the item's premise fails and it should be
+   re-scoped (e.g. 24GB-only) or dropped.
+
+## Engine architecture (mirrors the Qwen treatment)
+
+- **New `FishAudioS2ProEngine(Engine)`** in `server/tts-sidecar/main.py`, registered in the
+  `ENGINES` map under engine id **`fish_audio_s2pro`** (short key `fish`). Implements the
+  existing `Engine` contract: `synthesize(model, voice, text) -> SynthResult` (int16-LE PCM +
+  sample rate), idempotent `unload()` (`gc.collect()` + `torch.cuda.empty_cache()`), lazy
+  `_ensure_loaded()`, and an idle-evict hook.
+- **Lifecycle = Qwen's.** Lazy / button-driven `/load` (default `PRELOAD_FISH=0`); loading
+  **auto-evicts the analyzer Ollama** and vice-versa (the existing inline "TTS / Analyzer
+  unloaded to free VRAM" banner); an **idle-evict watchdog** (`FISH_IDLE_TTL`, mirroring the
+  Qwen VoiceDesign / ASR watchdogs) frees it after inactivity. VRAM is accounted through the
+  **weighted semaphore** with a new, **empirically-profiled** weight (provisionally heavy,
+  e.g. `fish:4` — confirmed by the Task-0 spike, not assumed).
+- **16GB strategy (the core bet).** Run the **FP8-quantized** weights; use streaming/chunked
+  synthesis to cap KV-cache. This is the open risk from the §gate above.
+- **Co-residency discipline.** On a 16GB card S2-Pro is heavy enough that it must not co-reside
+  with another heavy model (analyzer, Coqui). The load path evicts the analyzer; the Model
+  Manager must not allow an accidental Coqui `/load` on top (the plan-108 OOM lesson, applied
+  to the larger card).
+- **Install.** New `scripts/install-fish-audio.{ps1,sh}` fetching weights from HuggingFace into
+  `server/tts-sidecar/voices/fish/`; Python deps pinned in `requirements/nvidia-cuda.txt`
+  (AMD/CPU left to a follow-on). **Not** in the release zip (license + size) — same posture as
+  Kokoro weights / Coqui.
+
+## Voice model (Qwen lifecycle, clone-from-seed)
+
+S2-Pro has **no fixed voice catalog** — it is clone-only. So the **bundled seed-reference
+library _is_ the catalog**. The cast UX is otherwise the Qwen lifecycle:
+
+- Each cast member carries `overrideTtsVoices.fish.name`; a voice is **designed during cast
+  review**, cached per character, and reused at synthesis.
+- **A/B re-design compare** modal like Qwen's. **Implementation note:** if the modal is
+  drawer-nested it MUST `createPortal` to `document.body` — the known clip-path trap that
+  clipped the Qwen voice-compare modal (PR #832).
+- **Design step (the one delta from Qwen).** Qwen designs from a *text persona* with no audio.
+  S2-Pro's design input is a **seed reference clip + a tone/persona text box**: the text becomes
+  S2-Pro's inline tone tags (`[whisper]`, `[professional broadcast tone]`, `[pitch up]`), the
+  clip is cloned, and the result is cached. Same lifecycle and UX; the only difference is a
+  seed clip feeds the clone where Qwen needs none.
+
+### Bundled seed-reference voice library (a first-class deliverable)
+
+A curated **age × gender grid** of short reference clips:
+
+- **Age (5):** `child`, `teenager`, `young-adult`, `adult`, `elderly`.
+- **Gender (3 per age):** `male`, `female`, `neutral`.
+- → **~15 base seed cells**; more clips per cell can be added later for collision-avoidance via
+  the existing per-profile hash-selection pattern.
+
+**Relationship to today's taxonomy.** This age×gender grid sits **alongside** the existing
+per-engine profile scheme (`male-deep` / `female-mid` / `narrator-*`). Those existing buckets
+are effectively the **adult** row, just with finer timbre granularity. **Out of scope:**
+whether this age taxonomy is ever promoted to a cross-engine profile concept (Kokoro / Coqui /
+Qwen) — that is a noted follow-on, not part of this item.
+
+**Sourcing constraint (written in deliberately).** Every seed clip must be **synthetic or
+properly consented / licensed** — no cloning of real people's voices without consent. This is
+sharpest for the **`child` and `teenager`** rows: reference audio of minors must be synthetic
+or consented/licensed, never harvested. This asset work is non-trivial and is part of the item,
+not an afterthought.
+
+## Integration seams (the touch-list)
+
+Verified against the codebase — adding an engine is a known, bounded edit set:
+
+**Sidecar (Python):**
+- `server/tts-sidecar/main.py` — `FishAudioS2ProEngine` class + `ENGINES` registry entry +
+  idle-evict watchdog wiring.
+- `server/tts-sidecar/requirements/nvidia-cuda.txt` — Fish Audio package + torch-compat pins.
+- `server/tts-sidecar/scripts/install-fish-audio.{ps1,sh}` — new weight-fetch script.
+- Seed-clip assets under `voices/fish/` (or an env-overridable assets dir).
+- New `server/tts-sidecar/tests/test_fish.py` (see Testing).
+
+**Server (Node/TypeScript):**
+- `server/src/tts/model-keys.ts` — add `fish_audio_s2pro` to `TtsEngine`, a `fish-s2pro`
+  `TtsModelKey`, a display label, and arms in `isTtsModelKey()`, `engineForModelKey()`,
+  `canonicalModelKeyForEngine()`, `sidecarModelId()`.
+- `server/src/tts/voice-mapping.ts` — `FISH_S2PRO_PROFILE_VOICES` (the age×gender seed grid),
+  `FISH_S2PRO_VOICE_DESCRIPTIONS`, and arms in `profileVoicesForEngine()` /
+  `voiceDescriptionForEngine()`. `pickEmotionVariantVoice()` is a no-op for Fish.
+- `server/src/tts/sidecar.ts` — health-probe shape for the new engine (`ready | loading |
+  error`, install state).
+- `server/src/config/registry.ts` — engine **tier = opt-in**, VRAM weight, idle TTL.
+- `server/src/model-control/` — health card + Load / Stop / Repair action.
+- `server/src/tts/synthesise-chapter.ts` — per-character routing on `ttsEngine ===
+  'fish_audio_s2pro'` + fallback (undesigned → Kokoro for English, error otherwise, per the
+  existing plan-146 fallback policy).
+- Voice-design route — extend the design flow to accept S2-Pro's seed-clip + tone-text input.
+
+**Frontend (React/TypeScript):**
+- `src/views/cast.tsx` — engine picker exposes Fish when installed.
+- Voice-picker UI — Fish voices surface from the seed grid; tone/persona text box in the design
+  flow.
+- `src/hooks/use-model-control.ts` + the models Redux slice — Model Manager integration
+  (health, Load, Stop, Repair).
+
+**Docs:**
+- A regression plan under `docs/features/` (new number) from `TEMPLATE.md`.
+- `docs/features/INDEX.md` entry; INSTALL / README supported-engines list.
+
+## Testing approach
+
+- **Sidecar pytest** — `test_fish.py` mirroring `test_kokoro.py`: load / synthesize / unload,
+  PCM shape + per-response sample-rate header, idle-evict, and "clone-from-seed produces audio."
+  **Triple-gated SKIP** (venv / pytest / weights absent), like the golden tiers, so it never
+  blocks a box without weights.
+- **Server vitest** — `model-keys` and `voice-mapping` arms for the new engine and the new
+  age×gender seed buckets; routing + fallback in `synthesise-chapter`.
+- **Frontend vitest** — the engine appears in the picker **only when installed**; the A/B
+  compare modal structural test asserts it portals to `document.body` (the clip-path
+  regression guard).
+- **Golden-audio (deferred, noted)** — add a Fish line to the opt-in golden tier once the
+  engine is stable; not part of the core item.
+
+## Risks & dependencies
+
+1. **License boundary** *(Depends on)* — source-available, personal/research only; **a Fish
+   Audio commercial license is required before this can ever be a default/shipped engine.**
+2. **FP8-on-16GB is unproven** *(gating spike, Task 0)* — must confirm a ≤16GB peak is
+   achievable (released FP8 build vs. self-quantize vs. streaming). If not, the premise fails.
+3. **Seed-voice sourcing** — curated age×gender library incl. child/teenager needs
+   synthetic / consented audio; non-trivial, ethically constrained asset work.
+4. **No fixed catalog** — everything is clone-based; the seed library is the only catalog.
+5. **VRAM weight is an assumption** until profiled — the semaphore weight must be measured, not
+   guessed.
+
+## Out of scope
+
+- AMD/ROCm and CPU support (NVIDIA-CUDA first; follow-on).
+- Promoting the age×gender taxonomy to a cross-engine profile concept.
+- Using S2-Pro as the engine behind user voice-cloning (fs-38) — a natural follow-on once
+  voice cloning ships, deliberately kept out so this item stays self-contained.
+- Inclusion in the release zip (weights are user-fetched, license-gated).
+
+## Backlog framing
+
+- **MoSCoW: Could.** Prefix `fs-` (full-stack engine). **Next free id confirmed = `fs-48`**
+  (highest existing across GitHub issues is `fs-47`).
+- Issue carries What / Acceptance / **Key files** / **Depends on (commercial license + FP8/16GB
+  spike)** / Benefit; a thin row lands in `docs/BACKLOG.md` under **Could**, linking this spec.
+- **Benefit (user):** premium-quality, expressive, multilingual voices for users who have a
+  16GB card and are chasing quality beyond the 8GB default engines.

--- a/docs/superpowers/specs/2026-06-20-fish-audio-s2pro-engine-design.md
+++ b/docs/superpowers/specs/2026-06-20-fish-audio-s2pro-engine-design.md
@@ -236,6 +236,23 @@ S2-Pro's free-form inline tone tags — the model supports 15,000+ tags, e.g. `[
 is "a few seconds" (the often-cited "5–15s" is **not** a sourced fishaudio figure — treat as
 approximate).
 
+> **💭 Thought bubble (future idea, not committed scope) — "design in Qwen, perform in Fish".**
+> The seed clip doesn't have to be bundled or uploaded — we already have a *text-persona →
+> bespoke-timbre* generator: **Qwen-VoiceDesign**. So a natural authoring flow is: the user
+> *describes* a character → Qwen-VoiceDesign invents the timbre and we **capture that clip** →
+> hand it to S2-Pro as the **clone/timbre prompt**, then drive **per-line expression** with
+> S2-Pro's tone engine. *Design in Qwen, perform in Fish.* This preserves our describe-a-voice
+> authoring flow (no clip to pick or record) and **demotes the bundled seed library from "the
+> catalog" to a cold-start fallback** (for when Qwen isn't installed, or the user wants an
+> instant pick). It also fits the VRAM budget: design and performance are **sequential phases**,
+> not co-resident — design (Qwen-VoiceDesign loaded) → capture clip → evict VoiceDesign via the
+> existing idle watchdog → load Fish and perform — so the two heavy models never stack on a 16GB
+> card. *Open questions for plan-time:* does a Qwen-generated clip clone *well* under S2-Pro
+> (clip quality feeds clone fidelity — a spike check), and is the extra Qwen→Fish hop worth it
+> vs. a curated seed. The same pattern is exactly how **IndexTTS-2** (a separate strong
+> emotion-engine clone model) would slot in too — so this aside doubles as the seam for any
+> future "Qwen-timbre + expressive-clone-engine" pairing, not just Fish.
+
 ### Bundled seed-reference voice library (a first-class deliverable, with its own picker path)
 
 _Captured here at the product owner's request while the thinking was fresh — but this taxonomy is

--- a/docs/superpowers/specs/2026-06-20-fish-audio-s2pro-engine-design.md
+++ b/docs/superpowers/specs/2026-06-20-fish-audio-s2pro-engine-design.md
@@ -1,186 +1,378 @@
-# fs-48 — Fish Audio S2-Pro TTS engine (premium quality, 16GB-card tier)
+# fs-48 — Fish Audio S2-Pro TTS engine (premium-quality tier)
 
 - **Date:** 2026-06-20
 - **Issue:** _to be filed_ (`area:fs`, `moscow:could`, `type:feat`)
 - **Branch:** _none yet — backlog Could item; spec only_
-- **Status:** approved design (brainstormed) — captured as a future Could item, not slated for build
+- **Status:** approved design (brainstormed + two adversarial reviews folded in) — captured as a
+  future Could item, not slated for build
+- **Revision note:** v2 corrects v1's factual and codebase claims after two adversarial reviews
+  and a dedicated 16GB-feasibility research pass. Material changes: **16GB is the primary target**
+  (per product steer — 24GB cards are out of reach for most local users), reached via **BNB NF4
+  4-bit** (the chosen quant; FP8 is really a 20GB path, GGUF is too slow); license terms are
+  stronger with personal-use as the through-line; **in-process PyTorch reuse is the preferred
+  integration** (NF4/`bitsandbytes` is pure torch), with an out-of-process HTTP child as the
+  documented fallback; several v1 file/function names were wrong and are corrected below.
 
 ## Summary
 
 Add **Fish Audio S2-Pro** as a fourth, **opt-in** synthesis engine alongside Kokoro, Coqui
-XTTS, and Qwen. It targets **quality-chasing users on 16GB GPUs** — people who have headroom
-beyond the 8GB default box and want the best timbre/expressiveness we can offer. S2-Pro is a
-~4.4B-param zero-shot **clone** model (a 4B "slow AR" semantic stage + a 400M "fast AR"
-acoustic stage) with inline tone control and 80+ language coverage.
+XTTS, and Qwen, for **quality-chasing users on a 16GB consumer GPU**. S2-Pro is a ~4.4B-param
+zero-shot **clone** model (a 4B "slow AR" semantic stage + a 400M "fast AR" acoustic stage, a
+Dual-AR architecture) with free-form inline tone tags and ~80-language coverage (incl. Russian).
 
-It is **not** a default engine and **not** auto-installed. You opt in through the Model
-Manager (like Coqui today), and it loads **button-driven** like Qwen — resident only while in
-use, evicted otherwise. That lifecycle is what keeps it honest on a 16GB card.
+It is **not** a default engine and **not** auto-installed. You opt in through the Model Manager
+(like Coqui today), and it loads on demand and evicts when idle — resident only while in use.
 
-The headline framing stays **"premium quality on a 16GB card."** Its multilingual reach
-(including Russian) is a real incidental benefit but is not the pitch.
+**Target is 16GB — deliberately.** The whole point of this item is to reach users on
+**16GB consumer cards** (RTX 4060 Ti 16GB / 4070 Ti Super / 4080-class); **24GB cards are out
+of reach for most local users**, so a 24GB-only engine would miss the audience. fishaudio's
+*official* recommendation is ~24GB and they declined to ship a 16GB-fitting path themselves
+(issue #1168, closed "not planned") — but the **consumer ecosystem already runs S2-Pro on
+≤16GB via community 4-bit quantization** (BNB NF4; see §"The 16GB path"). So **16GB is the primary
+design target**; **24GB is the comfortable fallback** for users who have it, and the
+**full-precision 24GB path is the safety net** if the 16GB path can't hit an acceptable quality
+or speed bar. The 16GB path is **measured, not assumed** — it's gated on the hardware spike
+(§Gate 2 / §Acceptance). See §"The 16GB path" for the concrete approach.
 
-## Why this is a Could, and what gates it
+S2-Pro's multilingual reach is a real incidental benefit but not the headline.
 
-Two facts shape the entire item and are written here so a future implementer inherits them
-rather than rediscovering them:
+## Why this is a Could, and the two things that gate it
 
-1. **License boundary (the commercial gate).** Fish Audio S2 / S2-Pro is **source-available,
-   not open-source**: weights are free for **personal and research** use, but **commercial
-   use is restricted** and requires an agreement with Fish Audio. Castwright is a commercial
-   product. Therefore this ships **opt-in only**, with the user fetching weights from
-   HuggingFace under their own personal/research use — and a **Fish Audio commercial license
-   is a hard prerequisite before S2-Pro could ever become a default or shipped-on engine.**
-   This belongs in the issue's **Depends on**.
+These shape the whole item and are stated up front so a future implementer inherits them.
 
-2. **16GB feasibility is a real engineering bet, not a given (the technical gate).** Real-world
-   reports put **peak inference VRAM at ~17GB at full precision** — i.e. it *overflows* a 16GB
-   card as-shipped (9GB FP16 checkpoint + activations + KV cache). The path to 16GB is **FP8
-   quantization** (weights roughly halve to ~4.4GB; peak likely lands ~10–13GB) plus
-   **streaming/chunked synthesis** to cap KV-cache growth. Whether a released FP8 build exists,
-   or we quantize ourselves, or streaming is required, is **unresolved** — it is a **Task-0
-   spike**. If a 16GB peak proves unachievable, the item's premise fails and it should be
-   re-scoped (e.g. 24GB-only) or dropped.
+### Gate 1 — License (personal-use through-line; commercial is the *user's* responsibility)
 
-## Engine architecture (mirrors the Qwen treatment)
+S2-Pro ships under the **Fish Audio Research License** (© 39 AI, INC.) — a **custom
+source-available license, not CC-BY-NC or Apache**. The relevant facts (verbatim from the
+LICENSE):
 
-- **New `FishAudioS2ProEngine(Engine)`** in `server/tts-sidecar/main.py`, registered in the
-  `ENGINES` map under engine id **`fish_audio_s2pro`** (short key `fish`). Implements the
-  existing `Engine` contract: `synthesize(model, voice, text) -> SynthResult` (int16-LE PCM +
-  sample rate), idempotent `unload()` (`gc.collect()` + `torch.cuda.empty_cache()`), lazy
-  `_ensure_loaded()`, and an idle-evict hook.
-- **Lifecycle = Qwen's.** Lazy / button-driven `/load` (default `PRELOAD_FISH=0`); loading
-  **auto-evicts the analyzer Ollama** and vice-versa (the existing inline "TTS / Analyzer
-  unloaded to free VRAM" banner); an **idle-evict watchdog** (`FISH_IDLE_TTL`, mirroring the
-  Qwen VoiceDesign / ASR watchdogs) frees it after inactivity. VRAM is accounted through the
-  **weighted semaphore** with a new, **empirically-profiled** weight (provisionally heavy,
-  e.g. `fish:4` — confirmed by the Task-0 spike, not assumed).
-- **16GB strategy (the core bet).** Run the **FP8-quantized** weights; use streaming/chunked
-  synthesis to cap KV-cache. This is the open risk from the §gate above.
-- **Co-residency discipline.** On a 16GB card S2-Pro is heavy enough that it must not co-reside
-  with another heavy model (analyzer, Coqui). The load path evicts the analyzer; the Model
-  Manager must not allow an accidental Coqui `/load` on top (the plan-108 OOM lesson, applied
-  to the larger card).
-- **Install.** New `scripts/install-fish-audio.{ps1,sh}` fetching weights from HuggingFace into
-  `server/tts-sidecar/voices/fish/`; Python deps pinned in `requirements/nvidia-cuda.txt`
-  (AMD/CPU left to a follow-on). **Not** in the release zip (license + size) — same posture as
-  Kokoro weights / Coqui.
+- **Personal / research use is permitted.** "Commercial Purpose" use — anything "primarily
+  intended for or directed toward commercial advantage or monetary compensation" — **requires a
+  separate written agreement** from Fish Audio (business@fish.audio). No commercial rights are
+  granted by default.
+- Redistribution / use must carry the attribution string and display **"Built with Fish Audio"**
+  prominently.
+- The model may **not** be used to create or improve a foundational generative AI model.
+- Community FP8/GGUF derivatives inherit this same license.
 
-## Voice model (Qwen lifecycle, clone-from-seed)
+**Product stance (decided):** Castwright ships the *integration* (code that drives the model);
+the **user fetches the weights from HuggingFace and runs them locally for personal audiobooks**
+under the research license. This **does not preclude personal use.** The product MUST make
+clear — in-app at the point of enabling the engine, and in docs — that **creating audiobooks
+*for sale* with S2-Pro requires the user to obtain their own commercial license from Fish
+Audio**, and the **"Built with Fish Audio" attribution obligation** must be surfaced.
 
-S2-Pro has **no fixed voice catalog** — it is clone-only. So the **bundled seed-reference
-library _is_ the catalog**. The cast UX is otherwise the Qwen lifecycle:
+**Residual risk (flag, not a certification):** whether bundling the S2-Pro integration inside a
+*paid* product (Cast Pass) is itself a "Commercial Purpose" is a legal judgment call. This spec
+does **not** certify it as clean — it recommends a **legal sign-off** before the engine is
+exposed in a paid tier, and treats personal/free use as the safe default. This belongs in the
+issue's **Depends on**.
 
-- Each cast member carries `overrideTtsVoices.fish.name`; a voice is **designed during cast
-  review**, cached per character, and reused at synthesis.
-- **A/B re-design compare** modal like Qwen's. **Implementation note:** if the modal is
-  drawer-nested it MUST `createPortal` to `document.body` — the known clip-path trap that
-  clipped the Qwen voice-compare modal (PR #832).
-- **Design step (the one delta from Qwen).** Qwen designs from a *text persona* with no audio.
-  S2-Pro's design input is a **seed reference clip + a tone/persona text box**: the text becomes
-  S2-Pro's inline tone tags (`[whisper]`, `[professional broadcast tone]`, `[pitch up]`), the
-  clip is cloned, and the result is cached. Same lifecycle and UX; the only difference is a
-  seed clip feeds the clone where Qwen needs none.
+### Gate 2 — Proving the 16GB path (hardware-gated Task 0)
 
-### Bundled seed-reference voice library (a first-class deliverable)
+16GB is the target, and the consumer ecosystem already runs S2-Pro there — but **we must
+measure it on our own pipeline before claiming it.** The spike is **hardware-gated:** it can
+only run once a **16GB card is physically in hand**. Its job is to confirm a chosen
+quantization path hits **peak VRAM ≤ 16GB at an acceptable speed and quality** (bar in
+§Acceptance). The candidate paths and evidence are detailed in §"The 16GB path."
+
+**Fallback ladder if the NF4 spike underperforms** (so the item never just dies):
+1. Add **chunked synthesis** (ComfyUI-style chunk-length) to cap KV-cache peak; if still over,
+   try the build-it-yourself sequential stage-load / codec CPU-offload.
+2. If 16GB can't hit the VRAM/speed/quality bar, ship as a **20GB (FP8) or 24GB (full)**
+   engine with 16GB marked experimental — still useful, just not the headline.
+3. The GGUF/`s2.cpp` path covers sub-12GB/CPU users but at RTF≈3 — offer it only as an explicit
+   "slow but tiny" option, never the default.
+4. Only if *none* works does the item park.
+
+## Engine architecture
+
+### Integration shape — prefer in-process PyTorch reuse; out-of-process server is the fallback
+
+**Preferred (the goal): reuse the existing sidecar PyTorch/CUDA stack in-process,** exactly like
+Coqui and Qwen. fish-speech *is* a PyTorch project, and the chosen 16GB path — **BNB NF4 4-bit
+via `bitsandbytes`** (§"The 16GB path") — is **pure PyTorch**, so in-process reuse is genuinely
+viable, not wishful. The `groxaxo/fish-speech-int4-patch` already demonstrates the torch
+`--bnb4` loader over the full dual-AR + codec pipeline; we vendor those modifications into
+`FishAudioS2ProEngine` so it's a **normal in-process engine** in the `ENGINES` map: loads with
+our device-selection (`cuda` → `mps`/`cpu`) and `bitsandbytes` 4-bit config, and its
+`synthesize()` is a direct model call returning `SynthResult` (int16-LE PCM + rate). No new
+process, no new IPC — the cleanest outcome, and it reuses the torch install we already pin.
+
+**Fallback (only if the in-process torch path proves unworkable):** run the `groxaxo` patch (or
+fish-speech's official SGLang server) as a **child process** and call its **OpenAI-compatible
+HTTP API** (`:8880` for groxaxo), adapting the result into `SynthResult`. fish-speech's
+officially documented entry points are CLI stages + the SGLang server, not a high-level Python
+`synthesize()`, so if vendoring the raw torch `--bnb4` stages in-process proves too brittle,
+this HTTP-child path is the known fallback. It's heavier — process lifecycle, health, port, and
+teardown on `taskkill /T /F` for Windows parity — and documented here so it's not a surprise.
+(The GGUF/`s2.cpp` runner is a *separate*, non-torch, Vulkan-based path — reserved for the
+sub-12GB/CPU fallback only, given its RTF≈3.)
+
+**Task 0 decides which.** The hardware spike must determine whether the in-process torch path is
+viable on a 16GB card; the integration shape (and a chunk of the effort estimate) follows from
+that answer. Either way, a thin `FishAudioS2ProEngine` registers in `ENGINES` under id
+**`fish_audio_s2pro`** (short key `fish`) to satisfy routing; only its internals (direct torch
+call vs. HTTP/subprocess adapter) differ. The base `Engine` class declares **only**
+`synthesize(...)`; `unload()` / `_ensure_loaded()` / idle-evict are **per-engine conventions**
+(Coqui/Qwen) Fish follows.
+
+### Lifecycle
+
+- **Opt-in, on-demand load** (`PRELOAD_FISH=0`); loading **evicts the analyzer Ollama** via the
+  existing load-time eviction (the real OOM guard — *not* the semaphore), and vice-versa.
+- **Idle-evict modelled on ASR, not Qwen-VoiceDesign.** Qwen's idle watchdog frees only the
+  *transient* VoiceDesign model, leaving the resident Base synth loaded. S2-Pro is a single
+  ~4.4B synth model, so its idle-evict must free the **whole engine** (and, in the out-of-process
+  fallback, tear down its child process), mirroring `WhisperEngine.maybe_free_idle`, not the
+  Qwen-VoiceDesign watchdog.
+- **VRAM accounting is advisory, not a safety net.** The weighted semaphore arbitrates
+  **unitless tokens, not GB** (`engine-vram-cost.ts`, "PROVISIONAL VALUES … not measured"); it
+  clamps any cost above the budget down to capacity and **cannot prevent OOM**. Fish must
+  register a **`gpu.weight.fish` knob in `registry.ts`** (with a `GPU_WEIGHT_FISH` env, like
+  `gpu.weight.qwen`) **and** update the budget help-text that currently hard-lists
+  "kokoro 1, qwen 1, coqui 3, analyzer 4, asr 1." A measured weight comes out of Task 0; until
+  then it is a guess. **16GB co-residency support also requires recommending a larger
+  `GPU_VRAM_BUDGET`** — the default budget (4, sized for 8GB) neither expresses 16GB headroom
+  nor protects against OOM, so OOM-prevention rests on **load-time eviction + the measured
+  weight**, not the token count. (fs-45 VRAM telemetry records but does **not** yet drive
+  eviction.)
+
+### Install
+
+- New `scripts/install-fish-audio.{ps1,sh}` fetching the **base** weights with the official
+  `hf download fishaudio/s2-pro --local-dir …` CLI (not `git lfs clone`) into
+  `server/tts-sidecar/voices/fish/`; the repo is ~11GB (9GB LM + ~1.9GB codec). The **16GB NF4
+  path quantizes the base weights on-the-fly via `bitsandbytes`** — no separate quantized
+  download needed (unlike FP8, which would fetch a community FP8 checkpoint for the 20GB path).
+- Python deps pinned in `requirements/nvidia-cuda.txt`: fish-speech + **`bitsandbytes`** (the
+  NF4 dependency). AMD/CPU + the GGUF/`s2.cpp` (Vulkan) low-VRAM fallback left to a follow-on.
+- **`bitsandbytes` NF4 requires a compatible CUDA build/arch** — the install script must verify
+  it loads, since a wrong build silently breaks 4-bit.
+- **Not** in the release zip (license + size) — same posture as Kokoro weights / Coqui.
+
+## The 16GB path (the core engineering bet)
+
+16GB is the target (§Summary), and the consumer ecosystem proves it's reachable — but only via
+quantization, and the right quant matters. Evidence (community FP8/GGUF cards, the
+`Saganaki22/ComfyUI-FishAudioS2` per-tier table, the `groxaxo/fish-speech-int4-patch`):
+
+| Path | Peak VRAM | Speed | Verdict for us |
+|---|---|---|---|
+| Full bf16 (official) | **~17GB measured** (24GB rec.) | ~15-17 it/s | overflows 16GB — the 24GB fallback baseline |
+| FP8 weight-only | ~12GB weights / **~20GB practical** | ~15 it/s | **NOT a clean 16GB fit**; a 20GB+ (Ada/Blackwell) path only |
+| BNB INT8 (on-the-fly) | ~18GB | ~10-11 it/s | barely helps; NF4 strictly better |
+| **BNB NF4 4-bit** | **~16GB** (claimed; 12GB on a 3060) | **~10-11 it/s** | **the chosen 16GB path** — any NVIDIA card, pure-torch via `bitsandbytes` |
+| GGUF / s2.cpp (Q4-Q8) | 3-8GB | **RTF ≈ 3 (3× slower than real-time)** | sub-12GB/CPU fallback only; **too slow for audiobooks** |
+
+**Chosen path: BNB NF4 4-bit.** It's the only one that fits 16GB at a usable speed, needs no
+special FP8 hardware, and is **pure PyTorch + `bitsandbytes`** — so it aligns with the
+in-process torch reuse we want (§Integration shape). The `groxaxo` patch (a fish-speech fork
+exposing `--bnb4 --half`, lazy-load, full dual-AR + codec pipeline + voice cloning) is the
+**reference implementation** — we either vendor its `--bnb4` modifications into our in-process
+loader (preferred) or run its server as the out-of-process fallback.
+
+**The evidence is thin — this is exactly why Task 0 exists.** Every credible number traces back
+to two or three sources that quote each other; there is **no independent measured peak-VRAM for
+NF4 on a real 16GB card** (the only *measured* peak anywhere is 17GB, unquantized, on a 48GB
+card), and **no published RTF→seconds-per-sentence** for the NF4 tier. The spike must produce
+our own numbers on our own pipeline.
+
+**Two unknowns the spike must resolve, beyond "does it fit":**
+1. **Quality at 4-bit.** S2-Pro's selling point is fine-grained *expressive prosody*; 4-bit
+   quantization is most likely to degrade exactly that, and **no report has tested it.** If NF4
+   guts the emotion control, the "premium quality" premise fails even if VRAM fits — fall back
+   to FP8@20GB or full@24GB and drop the 16GB headline.
+2. **Peak under a long KV cache.** 16GB-NF4 is a *claim*; a real 16GB card could OOM once the KV
+   cache grows over a long sentence. Chunked synthesis (the ComfyUI `chunk-length` knob, 100-400)
+   is the mitigation; the spike must confirm peak stays ≤16GB with desktop/OS headroom.
+
+**Undocumented-but-plausible levers** (build-it-yourself, no S2-Pro precedent): sequential
+stage-loading (load slow-AR → free → load codec) and CPU-offloading the codec stage. Only reach
+for these if NF4 + chunking can't hold 16GB.
+
+## Voice model (Qwen-style lifecycle, clone-from-seed — but it drags in real machinery)
+
+S2-Pro has **no fixed voice catalog** — it is clone-only, so the **bundled seed-reference
+library _is_ the catalog**. The cast UX follows the Qwen per-character bespoke-voice lifecycle,
+but "mirror Qwen" is **not** a one-line delta; it pulls in the following, each of which Fish
+must explicitly opt into or out of:
+
+- **Per-character storage key + uuid (srv-43).** Qwen synth keys off `qwenStorageKey(voice,
+  voice.id)`, which prefers the srv-43 `voiceUuid` (`qwen-${voiceUuid}`), minted/persisted at
+  design time (`ensureCharacterVoiceUuid`) and used to name the per-character `.pt`/`.json`.
+  Fish, being clone-only and per-character, needs its **own `fishStorageKey` + voiceUuid
+  handling** mirroring this — it is a real subsystem, not free. **Depends on srv-43** landing.
+- **Persona auto-generation.** Qwen's design route auto-generates a persona via Gemini when the
+  text box is empty. Fish should decide whether to reuse this (the tone text feeds S2-Pro's
+  inline tags) or skip it.
+- **Prompt/clone cache** — Fish may cache the encoded reference-clip tokens; state the choice.
+- **Batched synthesis — OPT OUT.** Qwen has a `synthesize_batch` path gated in
+  `synthesise-chapter.ts`. Fish synthesizes **per-call** (like Coqui); do not copy the Qwen
+  batch path.
+- **A/B re-design compare** modal like Qwen's. **If drawer-nested it MUST `createPortal` to
+  `document.body`** — the clip-path trap that clipped the Qwen voice-compare modal (PR #832).
+
+**Design step (the genuine UX delta):** Qwen designs from a *text persona* with no audio.
+S2-Pro's design input is a **seed reference clip + a tone/persona text box** (the text becomes
+S2-Pro's free-form inline tone tags — the model supports 15,000+ tags, e.g. `[whisper]`,
+`[professional broadcast tone]`, `[excited]`); the clip is cloned and cached. Reference length
+is "a few seconds" (the often-cited "5–15s" is **not** a sourced fishaudio figure — treat as
+approximate).
+
+### Bundled seed-reference voice library (a first-class deliverable, with its own picker path)
 
 A curated **age × gender grid** of short reference clips:
 
 - **Age (5):** `child`, `teenager`, `young-adult`, `adult`, `elderly`.
 - **Gender (3 per age):** `male`, `female`, `neutral`.
-- → **~15 base seed cells**; more clips per cell can be added later for collision-avoidance via
-  the existing per-profile hash-selection pattern.
+- → **~15 base seed cells**; more clips per cell later for collision-avoidance.
 
-**Relationship to today's taxonomy.** This age×gender grid sits **alongside** the existing
-per-engine profile scheme (`male-deep` / `female-mid` / `narrator-*`). Those existing buckets
-are effectively the **adult** row, just with finer timbre granularity. **Out of scope:**
-whether this age taxonomy is ever promoted to a cross-engine profile concept (Kokoro / Coqui /
-Qwen) — that is a noted follow-on, not part of this item.
+**This needs its OWN picker path — it does not slot into the existing `VoiceProfile` system.**
+`VoiceProfile` is a closed 8-member union (`male-deep`…`narrator-cool`) and every engine catalog
+is a `Record<VoiceProfile, string[]>` consumed by the private `catalogForEngine` / `describeVoice`
+and `auditEngineCatalog`. A 15-cell age×gender grid **cannot** be keyed by `VoiceProfile`, so
+Fish needs a **separate `pickVoiceForFish` path and its own catalog type** — the generic
+catalog helpers do not extend to it. The existing buckets are roughly the **adult** row with
+finer timbre granularity.
 
-**Sourcing constraint (written in deliberately).** Every seed clip must be **synthetic or
-properly consented / licensed** — no cloning of real people's voices without consent. This is
-sharpest for the **`child` and `teenager`** rows: reference audio of minors must be synthetic
-or consented/licensed, never harvested. This asset work is non-trivial and is part of the item,
-not an afterthought.
+**Age-vocabulary mismatch to reconcile:** the analyzer emits `ageRange?: 'child' | 'teen' |
+'adult' | 'elderly'` — **no `teenager`, no `young-adult`.** Any "pick the seed cell from the
+character's detected age" logic needs an **explicit mapping table** (`teen → teenager`;
+`young-adult` has no analyzer signal and must fall back, e.g. to `adult`) or it silently
+misses. Likewise **`neutral` gender has no upstream auto-cast signal** (auto-casting keys off
+male/female), so `neutral` is a *manual* selection only — state that.
 
-## Integration seams (the touch-list)
+**Sourcing constraint (deliberate).** Every seed clip must be **synthetic or properly consented
+/ licensed** — no cloning of real people without consent, **sharpest for the `child`/`teenager`
+rows** (audio of minors must be synthetic or consented/licensed, never harvested). Non-trivial,
+ethically constrained asset work — part of the item, not an afterthought. **Broader misuse
+note:** the engine also lets a user clone *any* uploaded clip, including a real child's — a
+misuse surface the seed-sourcing rule does not cover; worth a usage/ToS line.
 
-Verified against the codebase — adding an engine is a known, bounded edit set:
+## Integration seams (corrected touch-list)
 
 **Sidecar (Python):**
-- `server/tts-sidecar/main.py` — `FishAudioS2ProEngine` class + `ENGINES` registry entry +
-  idle-evict watchdog wiring.
-- `server/tts-sidecar/requirements/nvidia-cuda.txt` — Fish Audio package + torch-compat pins.
-- `server/tts-sidecar/scripts/install-fish-audio.{ps1,sh}` — new weight-fetch script.
-- Seed-clip assets under `voices/fish/` (or an env-overridable assets dir).
-- New `server/tts-sidecar/tests/test_fish.py` (see Testing).
+- `server/tts-sidecar/main.py` — `FishAudioS2ProEngine` registered in `ENGINES`; **preferred:
+  in-process NF4/`bitsandbytes` torch loader** (vendored from the groxaxo `--bnb4` path);
+  *fallback:* HTTP-child adapter. ASR-style whole-engine idle-evict.
+- `server/tts-sidecar/requirements/nvidia-cuda.txt` — fish-speech + **`bitsandbytes`** + pins.
+- `server/tts-sidecar/scripts/install-fish-audio.{ps1,sh}` — `hf download` base-weight fetch
+  (NF4 quantizes on-the-fly; FP8 checkpoint only for the 20GB path).
+- Seed-clip assets under `voices/fish/`.
+- New `server/tts-sidecar/tests/test_fish.py`.
 
 **Server (Node/TypeScript):**
-- `server/src/tts/model-keys.ts` — add `fish_audio_s2pro` to `TtsEngine`, a `fish-s2pro`
-  `TtsModelKey`, a display label, and arms in `isTtsModelKey()`, `engineForModelKey()`,
-  `canonicalModelKeyForEngine()`, `sidecarModelId()`.
-- `server/src/tts/voice-mapping.ts` — `FISH_S2PRO_PROFILE_VOICES` (the age×gender seed grid),
-  `FISH_S2PRO_VOICE_DESCRIPTIONS`, and arms in `profileVoicesForEngine()` /
-  `voiceDescriptionForEngine()`. `pickEmotionVariantVoice()` is a no-op for Fish.
-- `server/src/tts/sidecar.ts` — health-probe shape for the new engine (`ready | loading |
-  error`, install state).
-- `server/src/config/registry.ts` — engine **tier = opt-in**, VRAM weight, idle TTL.
-- `server/src/model-control/` — health card + Load / Stop / Repair action.
-- `server/src/tts/synthesise-chapter.ts` — per-character routing on `ttsEngine ===
-  'fish_audio_s2pro'` + fallback (undesigned → Kokoro for English, error otherwise, per the
-  existing plan-146 fallback policy).
-- Voice-design route — extend the design flow to accept S2-Pro's seed-clip + tone-text input.
+- `server/src/tts/model-keys.ts` — add `fish_audio_s2pro` to `TtsEngine`; a `fish-s2pro`
+  `TtsModelKey`; a label; arms in `isTtsModelKey()`, `engineForModelKey()` (else it falls
+  through to `gemini`), `canonicalModelKeyForEngine()`, `sidecarModelId()`. *(These four exist
+  and are correctly named — verified.)*
+- `server/src/tts/voice-mapping.ts` — Fish's **own** catalog type + `pickVoiceForFish`; extend
+  the **private** `catalogForEngine` / `describeVoice` switch bodies and `auditEngineCatalog`;
+  a `fishStorageKey` mirroring `qwenStorageKey`. (`pickVoiceForEngine` / `pickEmotionVariantVoice`
+  exist; the latter is a no-op for Fish.)
+- `server/src/tts/engine-health.ts` — add `'fish'` to the `EngineId` union; **leave out of the
+  `STANDARD` set** so `engineTier` ⇒ `secondary` (the real tier vocabulary is
+  `'standard' | 'secondary'`, not "opt-in").
+- `server/src/routes/sidecar-health.ts` + `routes/models-inventory.ts` — per-engine install /
+  health state (`not-installed | weights-missing | ready | loaded`), mirroring `qwen_install_state`.
+- `server/src/config/registry.ts` — `gpu.weight.fish` knob (+ `GPU_WEIGHT_FISH`) and the
+  budget help-text update; idle TTL.
+- `server/src/tts/synthesise-chapter.ts` — per-character routing on `fish_audio_s2pro`; and
+  **generalise `applyQwenFallback`'s hardcoded `=== 'qwen'` guard** (see Fallback below).
+- The voice-design route — accept S2-Pro's seed-clip + tone-text input; mint the Fish voiceUuid.
 
 **Frontend (React/TypeScript):**
 - `src/views/cast.tsx` — engine picker exposes Fish when installed.
-- Voice-picker UI — Fish voices surface from the seed grid; tone/persona text box in the design
-  flow.
-- `src/hooks/use-model-control.ts` + the models Redux slice — Model Manager integration
-  (health, Load, Stop, Repair).
+- `src/components/ModelControlPill.tsx` — Fish health card + Load / Stop / Repair (the real
+  Model-Manager component; there is **no** `server/src/model-control/` dir nor a
+  `use-model-control.ts` hook — v1 named both wrongly).
+- The models inventory state (Redux + `models-inventory` route) — install/tier surfacing.
+- Voice-picker UI — Fish's age×gender grid + the tone/persona text box.
 
-**Docs:**
-- A regression plan under `docs/features/` (new number) from `TEMPLATE.md`.
-- `docs/features/INDEX.md` entry; INSTALL / README supported-engines list.
+**Docs:** a regression plan under `docs/features/`; `INDEX.md` entry; INSTALL/README engine
+list + the license/attribution notice.
+
+### Fallback + multilingual (a known UX gap, not a solved fallback)
+
+`applyQwenFallback` is **hardcoded to `route.engine === 'qwen'`** and falls back **only to
+English-only Kokoro**, throwing `MissingDesignedVoiceError` when `forbidKokoroFallback` (non-
+English books). So: (a) the guard must be **generalised** to fire for Fish, and (b) because
+S2-Pro's headline is **multilingual**, an undesigned multilingual character has **no graceful
+fallback — it is a hard error** (Kokoro can't cover non-English). This is called out as a
+**known gap**, not papered over: the realistic expectation is "design the Fish voice before
+generating," with a clear error otherwise.
+
+## Acceptance criteria (the spike's pass/fail bar)
+
+1. A cast member can be assigned an S2-Pro voice (designed from a seed clip + tone text), and a
+   chapter generates end-to-end with that voice.
+2. **16GB primary target (hardware-gated spike):** on a 16GB consumer card (e.g. RTX 4060 Ti
+   16GB), the **NF4 4-bit** build generates a full chapter with **peak VRAM ≤ 16GB** *including
+   OS/desktop headroom* and *under a long sentence's KV cache* (chunked if needed), at
+   **speed ≥ a min RTF threshold set at spike time** — usable for chapter-length audio, not just
+   a demo sentence. This is the bar the item lives or dies on.
+3. **4-bit quality (the make-or-break quality gate):** a subjective A/B of **NF4 vs.
+   full-precision** S2-Pro on emotional/expressive lines shows **no meaningful prosody
+   degradation** — because 4-bit most threatens exactly S2-Pro's selling point, and no public
+   report has tested it. If NF4 guts expressiveness, the 16GB headline is dropped (fall to
+   FP8@20GB / full@24GB).
+4. **24GB fallback (sanity baseline):** full-precision S2-Pro generates a chapter on a 24GB card
+   with no OOM/recycle storm — the safety net behind the 16GB path.
+5. **Quality vs. the resident engine:** S2-Pro (at the shipped precision) is **audibly at least
+   as good as Qwen** on the same lines — an engine that isn't better than the resident one isn't
+   worth the VRAM.
+6. License/attribution surfaced: enabling the engine shows the personal-use / commercial-licensing
+   notice and the "Built with Fish Audio" attribution.
 
 ## Testing approach
 
-- **Sidecar pytest** — `test_fish.py` mirroring `test_kokoro.py`: load / synthesize / unload,
-  PCM shape + per-response sample-rate header, idle-evict, and "clone-from-seed produces audio."
-  **Triple-gated SKIP** (venv / pytest / weights absent), like the golden tiers, so it never
-  blocks a box without weights.
-- **Server vitest** — `model-keys` and `voice-mapping` arms for the new engine and the new
-  age×gender seed buckets; routing + fallback in `synthesise-chapter`.
-- **Frontend vitest** — the engine appears in the picker **only when installed**; the A/B
-  compare modal structural test asserts it portals to `document.body` (the clip-path
-  regression guard).
-- **Golden-audio (deferred, noted)** — add a Fish line to the opt-in golden tier once the
-  engine is stable; not part of the core item.
+- **Sidecar pytest** — `test_fish.py` mirroring `test_kokoro.py`: load/synthesize/unload (the
+  in-process NF4 path — or, for the fallback, process spawn/teardown), returns PCM + sample-rate
+  header, idle-evict frees the whole engine, clone-from-seed produces audio. **Triple-gated SKIP**
+  (venv / pytest / weights absent), like the golden tiers.
+- **Server vitest** — `model-keys` and `voice-mapping` arms; the new Fish picker path + age
+  mapping table; the **generalised fallback** (Fish English → Kokoro; Fish non-English →
+  `MissingDesignedVoiceError`).
+- **Frontend vitest** — engine appears in the picker **only when installed**; A/B compare modal
+  portals to `document.body` (clip-path regression guard).
+- **Golden-audio** — add a Fish line to the opt-in golden tier once stable (deferred).
 
 ## Risks & dependencies
 
-1. **License boundary** *(Depends on)* — source-available, personal/research only; **a Fish
-   Audio commercial license is required before this can ever be a default/shipped engine.**
-2. **FP8-on-16GB is unproven** *(gating spike, Task 0)* — must confirm a ≤16GB peak is
-   achievable (released FP8 build vs. self-quantize vs. streaming). If not, the premise fails.
-3. **Seed-voice sourcing** — curated age×gender library incl. child/teenager needs
-   synthetic / consented audio; non-trivial, ethically constrained asset work.
-4. **No fixed catalog** — everything is clone-based; the seed library is the only catalog.
-5. **VRAM weight is an assumption** until profiled — the semaphore weight must be measured, not
-   guessed.
+1. **License** *(Depends on — legal sign-off)* — personal use OK; **commercial/for-sale use is
+   the user's responsibility to license from Fish Audio**; mandatory "Built with Fish Audio"
+   attribution; **legal confirmation needed** on bundling the integration in a paid tier.
+2. **16GB unproven + hardware-gated** *(Task 0)* — the 16GB NF4 figure is a maintainer *claim*,
+   never independently measured on a real 16GB card (only measured peak anywhere is 17GB
+   unquantized); spike needs a physical 16GB card.
+3. **4-bit quality is untested on prosody** *(make-or-break)* — NF4 most threatens S2-Pro's
+   headline expressive control; if it degrades, the premium-quality premise fails.
+4. **Integration shape is Task-0-dependent** — *preferred* is in-process PyTorch reuse (NF4 via
+   `bitsandbytes` is pure torch, like Coqui/Qwen and what ComfyUI consumer users do); *fallback*
+   is an out-of-process groxaxo/SGLang HTTP child if the in-process pipeline is too brittle. The
+   GGUF path is a separate non-torch (Vulkan) runner. Effort estimate swings on which the spike confirms.
+5. **srv-43 dependency** — Fish's per-character storage key needs the `voiceUuid` apparatus.
+6. **`bitsandbytes` CUDA-arch dependency** — wrong build silently breaks NF4; install must verify it.
+7. **Seed-voice sourcing + misuse surface** — synthetic/consented assets; clone-any-clip ToS line.
+8. **No graceful multilingual fallback** — undesigned non-English Fish character = hard error.
+9. **VRAM weight is a guess** until Task 0 measures it; the semaphore is advisory, not an OOM guard.
 
 ## Out of scope
 
-- AMD/ROCm and CPU support (NVIDIA-CUDA first; follow-on).
-- Promoting the age×gender taxonomy to a cross-engine profile concept.
-- Using S2-Pro as the engine behind user voice-cloning (fs-38) — a natural follow-on once
-  voice cloning ships, deliberately kept out so this item stays self-contained.
+- AMD/ROCm and CPU support (NVIDIA-CUDA first).
+- Promoting the age×gender taxonomy to a cross-engine `VoiceProfile` concept.
+- S2-Pro as the engine behind user voice-cloning (fs-38) — a natural follow-on once cloning ships.
 - Inclusion in the release zip (weights are user-fetched, license-gated).
+- Exposing the engine in a **paid** tier before the legal sign-off in Gate 1.
 
 ## Backlog framing
 
 - **MoSCoW: Could.** Prefix `fs-` (full-stack engine). **Next free id confirmed = `fs-48`**
   (highest existing across GitHub issues is `fs-47`).
-- Issue carries What / Acceptance / **Key files** / **Depends on (commercial license + FP8/16GB
-  spike)** / Benefit; a thin row lands in `docs/BACKLOG.md` under **Could**, linking this spec.
-- **Benefit (user):** premium-quality, expressive, multilingual voices for users who have a
-  16GB card and are chasing quality beyond the 8GB default engines.
+- Issue carries What / Acceptance / **Key files** / **Depends on (legal sign-off + srv-43 +
+  16GB hardware spike)** / Benefit; a thin row lands in `docs/BACKLOG.md` under **Could**,
+  linking this spec.
+- **Benefit (user):** premium-quality, expressive, multilingual voices on a **mainstream 16GB
+  consumer GPU** (NF4 4-bit) — bringing the best-quality engine within reach of quality-chasers
+  who don't have a 24GB card, beyond what the default engines offer.


### PR DESCRIPTION
## Summary

Parks **fs-48 — Fish Audio S2-Pro TTS engine** as a fully-designed Could item, ready to pick up once a 16GB card is in hand. Docs-only (spec + BACKLOG row); no code.

- **Design spec** `docs/superpowers/specs/2026-06-20-fish-audio-s2pro-engine-design.md` — brainstormed, then hardened through **three adversarial reviews** (codebase-feasibility, external-facts, fresh-eyes logic).
- **Target:** 16GB consumer GPUs via **BNB NF4 4-bit** (FP8 ≈ 20GB, GGUF too slow at RTF≈3), reusing the existing **in-process PyTorch** stack; out-of-process HTTP child is the documented fallback. Framed honestly as a bet unproven until the hardware-gated Task-0 spike.
- **Voice model:** Qwen-style per-character lifecycle, clone-from-seed, age×gender seed library — plus a 💭 thought-bubble capturing the "design in Qwen, perform in Fish" pattern (which also fits IndexTTS-2).
- **Parked/blocked** on four gates: legal sign-off (Fish Audio Research License), a physical 16GB card, srv-43 (`voiceUuid`), and the make-or-break 4-bit prosody-quality question.
- Issue **#964**; thin BACKLOG row under Could → Net-new capabilities.

## Test plan

Docs-only — no automated tests apply. Pre-push `verify` battery passed. Codebase claims in the spec were re-verified against the current tree by an adversarial reviewer (one stale "Redux models state" claim found and corrected).

Refs #964
