### PR TITLE
docs(docs): surface QA-gate + series-memory moats in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,12 @@ or MP3.
 - **Full-cast performance** — every character speaks in their own voice; one
   narrator can't be everyone.
 - **Series memory** — a character keeps the same voice across every book in a
-  series.
+  series, even when an author renames someone mid-series. *(No other tool does
+  this for readers.)*
 - **Designed voices** — every character gets a unique voice designed from its persona, kept consistent across the series. (Cloning a voice from your own sample is the next major release.)
+- **Quality gate** — every line is acoustically checked, transcript-verified, and drift-checked
+  before a chapter is assembled, and any that fail are re-recorded automatically; the plainly
+  broken lines never reach your ears.
 - **On-device by default** — analysis and speech run on your machine; cloud is
   opt-in.
 - **You own the files** — export standard M4B / MP3 / AAC / Opus and keep them.


### PR DESCRIPTION
## Summary

Adds the **README claims block** (Category C of the OSS gap analysis) — surfacing the two claims no rival matches, in `## What you get`:

- **Quality gate** — new bullet for the integrated audio-QA gate (acoustic + transcript + drift, automatic re-record). Wording aligned to the verified integrated-gate claim in `brand-guidelines.md` §3 ("Proof, not promises"), so the README does not under-claim the moat.
- **Series memory** — sharpened with the mid-series-rename detail and the verified onlyness line (*No other tool does this for readers*).

Companion Category C items are already live: repo topics + About fixed (20 recommended topics, `local-first` removed, `qwen`→`qwen3-tts`), and the §3 QA re-word landed separately.

## Test plan

- Doc-only change — no code paths touched.
- Brand-voice mechanical audit (`brand/_skills/castwright-voice/scripts/audit.py`) run on the README: clean (sole finding is a markdown image-syntax `!` false positive).
- Full `npm run verify` battery passed via the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)