### PR TITLE
fix(scripts): repoint brand SVG render paths after brand/ reorg

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,8 @@ cast — effortlessly. Even in your own voice._ Brand assets + guidelines live i
 design spec is `docs/superpowers/specs/2026-06-07-castwright-brand-design.md`; the brand story
 is `brand/project-narrative.md`. **`brand/` and `mockups/` are local-only (git-ignored)** —
 the brand identity is "all rights reserved" and these are working/scratch artifacts. The app
-ships the _generated_ assets in `public/` (PNGs rendered from `brand/*.svg` via
-`scripts/render-brand-pngs.mjs`), which ARE committed, so the build never depends on the
+ships the _generated_ assets in `public/` (PNGs rendered from `brand/identity/logo/*.svg`
+via `scripts/render-brand-pngs.mjs`), which ARE committed, so the build never depends on the
 sources. **`mockups/` is the home for all brand / style / UI exploration work** — put any
 future visual concepts or HTML mockups there, not in a new tracked directory.
 npm packages: `castwright` (frontend) / `castwright-server`

--- a/scripts/render-brand-pngs.mjs
+++ b/scripts/render-brand-pngs.mjs
@@ -3,7 +3,8 @@
 //
 //   node scripts/render-brand-pngs.mjs
 //
-// Re-run whenever brand/castwright-icon.svg or brand/castwright-og.svg change.
+// Re-run whenever brand/identity/logo/castwright-icon.svg or
+// brand/identity/logo/castwright-og.svg change.
 //
 // NOTE (fe-37): the small-size favicons — public/favicon-16.png, favicon-32.png
 // and favicon.svg — are HAND-DESIGNED (committed in public/, per the ≤32px glyph
@@ -15,8 +16,8 @@ import { dirname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const root = resolve(import.meta.dirname, '..');
-const ICON = resolve(root, 'brand/castwright-icon.svg');
-const OG = resolve(root, 'brand/castwright-og.svg');
+const ICON = resolve(root, 'brand/identity/logo/castwright-icon.svg');
+const OG = resolve(root, 'brand/identity/logo/castwright-og.svg');
 
 // out, src, width, height, omitBackground (transparent outside the artwork)
 export const JOBS = [


### PR DESCRIPTION
## Summary

The local-only `brand/` tree was reorganised into purpose-named subfolders; the icon and OG SVG masters moved from `brand/` root to `brand/identity/logo/`. `scripts/render-brand-pngs.mjs` still read the old root paths (`brand/castwright-icon.svg` / `brand/castwright-og.svg`), so it resolved non-existent files and could no longer regenerate the committed `public/` PNGs (icons, apple-touch-icon, og, Android/iOS launcher icons).

- Repoint the `ICON` / `OG` source paths (and the re-run comment) to `brand/identity/logo/`.
- Update the matching `brand/*.svg` → `brand/identity/logo/*.svg` pointer in `CLAUDE.md`.

No `.gitignore` change is needed — the blanket `brand/` ignore already covers every new subfolder. No `src/` runtime impact — the app ships rendered PNGs from `public/`, with zero runtime references into `brand/`.

## Test plan

- `node --test scripts/tests/render-brand-pngs.test.mjs` — green. The render-script test asserts on output paths and iOS job sizes only, not the `ICON`/`OG` source strings, so the path change doesn't affect it.
- Full pre-push `npm run verify` battery (typecheck + all tests + e2e + build) — green.

No linked issue (the brand reorg is tracked locally, not via a GitHub issue).