### PR TITLE
feat(frontend): fe-40 follow-ups — Carried vocabulary, table chip, PNG export

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -451,28 +451,6 @@ _Full detail + acceptance:_ [#401](https://github.com/dudarenok-maker/AudioBook-
 - _Benefit (technical):_ stays on a supported eslint line; clears the last row of the round-3 `npm outdated`.
 _Full detail + acceptance:_ [#711](https://github.com/dudarenok-maker/AudioBook-Generator/issues/711).
 
-### Library & discovery (fe-40 follow-ups)
-
-_(All three are deferred out-of-scope decisions from the fe-40 series-memory ship; filed 2026-06-21.)_
-
-#### `fe-41` — Series-memory chip + sparkline in LibraryTable view ([#983](https://github.com/dudarenok-maker/Castwright/issues/983))
-
-- _What:_ Extend the fe-40 `SeriesMemoryChip` + `SeriesSparkline` into the `LibraryTable` table view (`src/components/library/library-table.tsx`). The card view (`LibraryGrid`) already shows the chip; the table row for a series shows nothing yet. Add a compact chip cell (label + count, no full sparkline in the row — expand to sparkline on hover/focus) reusing the same `LibraryBook.seriesMemory` summary data.
-- _Benefit (user):_ users who prefer the dense table view get the same series-memory signal without switching to card view.
-_Full detail + acceptance:_ plan [228](features/archive/228-fe-40-series-memory.md) "Out of scope".
-
-#### `fe-42` — Harmonise cast-row "Reused · Matched" badge to "carried / kept" vocabulary ([#984](https://github.com/dudarenok-maker/Castwright/issues/984))
-
-- _What:_ The confirm-cast and cast views surface per-character status as "Reused" / "Matched" — legacy vocabulary from the series-reuse matcher. The fe-40 series-memory surface uses "carried" / "kept true" as the user-facing terms for the same concept. Align the badge wording so the whole app speaks one vocabulary: "Carried" (character was explicitly matched from a prior book) / "Kept" (voice kept from the prior cast without a new match). Audit all badge render sites + update copy; no behaviour change.
-- _Benefit (user / architectural):_ consistent vocabulary removes the "what's the difference between Reused and Carried?" confusion; future features can refer to a single term.
-_Full detail + acceptance:_ plan [228](features/archive/228-fe-40-series-memory.md) "Out of scope".
-
-#### `fe-43` — PNG share-card export (series memory) ([#985](https://github.com/dudarenok-maker/Castwright/issues/985))
-
-- _What:_ Add a "Download PNG" button to the `ShareCardModal` (fe-40) that screenshots the rendered `SeriesShareCard` via `html-to-image` (or equivalent) and triggers a client-side download. **Gated on dependency sign-off**: `html-to-image` adds ~50 KB gzipped and has a known SVG/font limitation; alternatives include `dom-to-image-more` or a server-side Playwright screenshot. Ship only after explicit dep + approach sign-off.
-- _Benefit (user):_ share the series cast story as an image on social media / in notes without needing a manual screenshot.
-_Full detail + acceptance:_ plan [228](features/archive/228-fe-40-series-memory.md) "Out of scope".
-
 ---
 
 ## Won't (this round) — explicitly parked

--- a/docs/features/archive/228-fe-40-series-memory.md
+++ b/docs/features/archive/228-fe-40-series-memory.md
@@ -157,3 +157,11 @@ Behaviour delta vs. original spec:
 - PNG export deferred (T13 decision, Task 15 confirmed) — `html-to-image` dep requires a separate sign-off; the "Export PNG" button was intentionally omitted from the share-card modal at v1.
 - `cloned` signal for Coqui: defaulted to `preset` until an explicit `cloned` marker exists in the voice override. The headline bespoke case is Qwen `designed` anyway.
 - `buildInputsFromBooks` is the library-path variant (reuses scanned books); `buildSeriesInputs` is the route-only variant (reads from disk). The double-scan noted in the Round 2 review was fixed in T3.
+
+## fe-40 follow-ups (delivered 2026-06-22)
+
+The three "Out of scope" items above shipped as a single FE-only round — spec `docs/superpowers/specs/2026-06-22-fe-40-followups-design.md`, plan `docs/superpowers/plans/2026-06-22-fe-40-followups.md`, branch `feat/frontend-fe-40-followups-iso`.
+
+- **fe-42 (#984) — single-word "Carried" vocabulary.** `ReusedBadge` → `CarriedBadge` (stable `data-testid="reused-badge"`), the cast filter chip relabelled via `CHIP_LABELS` (`Reused: 'Carried'` — internal key unchanged), and confirm-cast `Matched · N%` → `Carried · N%`. The lifecycle `Matched` pill (from `voiceState`, not `matchedFrom`) is deliberately untouched, so a reused-preset row reads "Matched · Carried". The issue's second term "Kept" was dropped — no data distinguishes it (`reused === !!matchedFrom`). Owed at merge: regenerate the `confirm` visual baselines (text changed).
+- **fe-41 (#983) — series-memory chip in the table view.** `SeriesMemoryChip` gained `showBooks?` (default `true`); the table renders the compact `showBooks={false}` variant in a restructured section header (chip as a responsive sibling of the collapse button). The orchestrator's filter mapping was extracted into the exported pure `applyLibraryFilters`, unit-locking the "seriesMemory survives filtering" invariant. (Table-view-only — the inline sparkline stayed out of scope.)
+- **fe-43 (#985) — PNG share-card export.** A "Download image (.png)" button captures the `SeriesShareCard` via a lazily-imported `html-to-image` (2×, `document.fonts?.ready`-gated); a shared `slugifyFilename` sanitises both the PNG and the existing JSON download. Dep signed off as `html-to-image`.

--- a/docs/superpowers/plans/2026-06-22-fe-40-followups.md
+++ b/docs/superpowers/plans/2026-06-22-fe-40-followups.md
@@ -1,0 +1,687 @@
+# fe-40 follow-ups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the three deferred fe-40 follow-ups — fe-42 (single-word "Carried" vocabulary), fe-41 (series-memory chip in the table view), fe-43 (PNG share-card export) — as one frontend-only branch.
+
+**Architecture:** Pure frontend, no API changes. fe-42 is copy + a component rename behind a stable `data-testid`, relabelling the cast filter chip through the existing `CHIP_LABELS` indirection. fe-41 reuses the shipped `SeriesMemoryChip` (gaining a `showBooks` prop) inside the table's series-section header, wired to the orchestrator's already-global reveal/share modals. fe-43 adds a client-side PNG capture of the existing `SeriesShareCard` via a lazily-imported `html-to-image`.
+
+**Tech Stack:** Vite + React 18 + TypeScript + Redux Toolkit; Vitest + React Testing Library (jsdom); Playwright (chromium) e2e; `html-to-image` (new dep).
+
+**Spec:** `docs/superpowers/specs/2026-06-22-fe-40-followups-design.md`. **Issues:** fe-41 (#983), fe-42 (#984), fe-43 (#985).
+
+**Deviation from the spec (intentional, discovered during planning):** fe-42's filter-chip relabel uses the existing `CHIP_LABELS` map (`cast.tsx:129`, whose comment states "the key stays stable… only the displayed text changes") rather than renaming the internal `'Reused'` key across `CHIP_ORDER` / `tally.set` / `statusFilterKeys`. This is the codebase's own idiom (cf. `Variants: 'Has variants'`), strictly more surgical, and leaves the internal key churn-free. The spec's render-site list for the chip is superseded by Task 1 Step 6. (Spec will be synced in Task 5.)
+
+## Global Constraints
+
+- **No hex literals in component code** — use the CSS-custom-property tokens via Tailwind (`text-magenta`, `bg-peach`, `text-ink`, etc.). Existing `bg-[#1b1714]` on the share card is pre-existing and not touched.
+- **No API/OpenAPI changes** — fe-42 is copy, fe-41 reuses the existing `seriesMemory` summary, fe-43 is client-side. `openapi.yaml` and `src/lib/api-types.ts` are untouched.
+- **Touch targets ≥44×44 px on phone** — `min-h-[44px] sm:min-h-0` (the chip already complies; the new PNG button must too).
+- **Keep `data-testid="reused-badge"`** stable through the badge rename (internal hook, not user-facing copy).
+- **Delivery:** one branch `feat/frontend-fe-40-followups` (already cut); one PR closing all three — body carries `Closes #983`, `Closes #984`, `Closes #985`.
+- **Test discipline:** every task ships paired tests; fe-42 additionally regenerates the `confirm` visual baselines.
+
+## File structure
+
+| File | Responsibility | Tasks |
+|---|---|---|
+| `src/components/primitives.tsx` | `ReusedBadge` → `CarriedBadge` (text + title; testid kept) | 1 |
+| `src/views/cast.tsx` | badge import/use rename; `CHIP_LABELS` adds `Reused: 'Carried'` | 1 |
+| `src/modals/profile-drawer.tsx` | badge import/use rename | 1 |
+| `src/views/confirm-cast.tsx` | `Matched · N%` → `Carried · N%` | 1 |
+| `e2e/{linux,win32}/…/confirm*.png` | regenerated visual baselines | 1 |
+| `src/components/series-memory/series-memory-chip.tsx` | add `showBooks?: boolean` (default `true`) | 2 |
+| `src/components/library/library-table.tsx` | thread `series` into `SeriesGroup`; restructure header; render compact chip | 3 |
+| `src/views/book-library.tsx` | pass `onOpenSeriesMemory` to `<LibraryTable>`; orchestrator-level filter-preservation test target | 3 |
+| `src/components/series-memory/share-card-modal.tsx` | `slugifyFilename`, ref wrapper, PNG button, lazy `toPng` | 4 |
+| `package.json` | add `html-to-image` | 4 |
+| `docs/features/archive/228-fe-40-series-memory.md` | "fe-40 follow-ups (delivered)" note | 5 |
+| spec file | sync the CHIP_LABELS deviation | 5 |
+
+---
+
+## Task 1: fe-42 — single-word "Carried" vocabulary
+
+Unify every `matchedFrom`-driven marker to "Carried". Rename the badge component (name matches reality; testid stays), relabel the filter chip through `CHIP_LABELS`, and change the confirm-cast pill. The **lifecycle** `Matched` pill (preset-voice state, derived from `voiceState` not `matchedFrom`) is intentionally left as `Matched`.
+
+**Files:**
+- Modify: `src/components/primitives.tsx:225-236`
+- Modify: `src/views/cast.tsx:19` (import), `:1450` (usage), `:129-131` (`CHIP_LABELS`)
+- Modify: `src/modals/profile-drawer.tsx:22` (import), `:899` (usage)
+- Modify: `src/views/confirm-cast.tsx:433-437`
+- Test: `src/views/cast.test.tsx`, `src/views/confirm-cast.test.tsx`, `src/modals/profile-drawer.test.tsx`
+- Regenerate: `e2e/linux/responsive/visual.spec.ts-snapshots/confirm*.png`, `e2e/win32/responsive/visual.spec.ts-snapshots/confirm*.png`
+
+**Interfaces:**
+- Produces: `CarriedBadge` (replaces `ReusedBadge`) — `export function CarriedBadge(): JSX.Element`, same call shape (no props), same `data-testid="reused-badge"`.
+
+- [ ] **Step 1: Update the tests to expect "Carried" (write the failing assertions)**
+
+In `src/views/confirm-cast.test.tsx`, change the matched-pill assertions:
+```ts
+// was: expect(screen.getByText('Matched · 95%')).toBeInTheDocument();
+expect(screen.getByText('Carried · 95%')).toBeInTheDocument();
+// and any queryByText(/Matched · /) → /Carried · /
+```
+In `src/views/cast.test.tsx`, change the provenance-badge + chip assertions (NOT the lifecycle `Matched` pill assertions). Search for `getByText('Reused')` / `chip(/^Reused/)` and switch the visible text to `Carried`:
+```ts
+// badge text:
+expect(within(narratorRow).getByText('Carried')).toBeInTheDocument();
+// filter chip (label is now "Carried", internal key stays 'Reused'):
+expect(chip(/^Carried/).textContent).toContain('1');
+// the click-to-filter test still targets the chip by its visible label:
+fireEvent.click(chip(/^Carried/));
+```
+In `src/modals/profile-drawer.test.tsx`, the reused-badge assertions switch `Reused` → `Carried` (the badge still has `data-testid="reused-badge"`, so any testid-based query is unchanged; only `getByText('Reused')` → `getByText('Carried')`).
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm test -- cast.test confirm-cast.test profile-drawer.test`
+Expected: FAIL — assertions for `Carried` don't match the still-"Reused"/"Matched ·" DOM.
+
+- [ ] **Step 3: Rename the badge in `primitives.tsx`**
+
+Replace `src/components/primitives.tsx:225-236`:
+```tsx
+export function CarriedBadge() {
+  return (
+    <span
+      data-testid="reused-badge"
+      title="Voice carried from a prior book in this series"
+      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium text-purple-deep/70 bg-purple-deep/4"
+    >
+      <IconLink className="w-2.5 h-2.5" />
+      Carried
+    </span>
+  );
+}
+```
+Also update the doc comment above it (lines 220-224): "marks a character whose voice was **carried** from a prior book in the series."
+
+- [ ] **Step 4: Update both badge importers**
+
+`src/views/cast.tsx:19` — in the `from '../components/primitives'` import block, `ReusedBadge` → `CarriedBadge`. `src/views/cast.tsx:1450` — `{reused && <CarriedBadge />}`.
+
+`src/modals/profile-drawer.tsx:22` — same import rename. `:899` — `{reused && <CarriedBadge />}`.
+
+- [ ] **Step 5: Relabel the cast filter chip via `CHIP_LABELS`**
+
+`src/views/cast.tsx:129-131` — add the `Reused` entry (keep `Variants`):
+```ts
+const CHIP_LABELS: Record<string, string> = {
+  Variants: 'Has variants',
+  Reused: 'Carried',
+};
+```
+Do **not** touch `CHIP_ORDER` (line 120), `tally.set('Reused', …)` (line 386), or `statusFilterKeys` (`voice-status.ts:173`) — the internal `'Reused'` key stays stable; only its display text changes. This mirrors the existing `Variants` pattern.
+
+- [ ] **Step 6: Change the confirm-cast pill**
+
+`src/views/confirm-cast.tsx:433-437`:
+```tsx
+{matched && character.matchedFrom?.confidence != null && (
+  <Pill color="library">
+    Carried · {Math.round(character.matchedFrom.confidence * 100)}%
+  </Pill>
+)}
+```
+
+- [ ] **Step 7: Run typecheck + tests to verify green**
+
+Run: `npm run typecheck`
+Expected: PASS (the rename reaches both importers — a missed importer would error here).
+Run: `npm test -- cast.test confirm-cast.test profile-drawer.test`
+Expected: PASS.
+Run: `npm test` (full frontend) to catch any other site asserting the old strings (e.g. `src/test/a11y.test.tsx`). Fix any stragglers by switching the visible string `Reused`→`Carried` / `Matched · `→`Carried · ` (never the bare lifecycle `Matched`).
+
+- [ ] **Step 8: Regenerate the `confirm` visual baselines**
+
+The confirm fixture renders the `Carried · N%` pill (matchedFrom seeds in `src/data/characters.ts`), so `confirm.png` / `confirm-dark.png` change.
+
+Local (Windows) — regenerate the `e2e/win32` baselines so pre-push passes:
+```bash
+npx playwright test e2e/responsive/visual.spec.ts --project=chromium -g "confirm" --update-snapshots
+```
+Expected: the `e2e/win32/responsive/visual.spec.ts-snapshots/confirm.png` and `confirm-dark.png` files are rewritten. (Per `docs/testing` history these confirm baselines are Windows-font-flaky; if the immediately-following verification run diffs, re-run once — see `feedback_visual_baselines_flaky_on_windows`.)
+
+`e2e/linux` baselines (the ones CI uses) cannot be produced on Windows — **flag to the controller/user** to trigger the `regen-visual-baselines` GitHub workflow on this branch (or regenerate on a Linux box) so the `run-ci` / merge visual leg is green. Note this explicitly in the task report.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/components/primitives.tsx src/views/cast.tsx src/modals/profile-drawer.tsx src/views/confirm-cast.tsx src/views/cast.test.tsx src/views/confirm-cast.test.tsx src/modals/profile-drawer.test.tsx e2e/win32
+git commit -m "refactor(frontend): fe-42 unify series-carry vocabulary to 'Carried'
+
+Rename ReusedBadge -> CarriedBadge (testid kept), relabel the cast
+filter chip via CHIP_LABELS, and change confirm-cast 'Matched · N%' ->
+'Carried · N%'. Lifecycle 'Matched' pill (voiceState, not matchedFrom)
+unchanged. Regenerated the confirm visual baseline (win32); linux
+baseline owed via the regen workflow.
+
+Refs #984"
+```
+
+---
+
+## Task 2: fe-41a — `showBooks` prop on `SeriesMemoryChip`
+
+Give the shared chip an opt-out for its trailing books clause, so the table can render a compact "Your cast · N voices" without a second book count next to the header's own. The grid keeps the default.
+
+**Files:**
+- Modify: `src/components/series-memory/series-memory-chip.tsx`
+- Test: `src/components/series-memory/series-memory-chip.test.tsx`
+
+**Interfaces:**
+- Produces: `SeriesMemoryChip` now accepts `showBooks?: boolean` (default `true`). Signature: `{ summary: SeriesMemorySummary; bookCount: number; showBooks?: boolean; onOpen: () => void }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/components/series-memory/series-memory-chip.test.tsx`:
+```tsx
+it('omits the books clause when showBooks is false', () => {
+  const summary = {
+    carriedCount: 8, bespokeCount: 5, designedCount: 5,
+    confirmedBookCount: 3, spanBooks: 3, perBook: [],
+  };
+  render(<SeriesMemoryChip summary={summary} bookCount={3} showBooks={false} onOpen={() => {}} />);
+  const chip = screen.getByTestId('series-memory-chip');
+  expect(chip).toHaveTextContent('Your cast · 8 voices');
+  expect(chip).not.toHaveTextContent('books');
+});
+
+it('keeps the books clause by default', () => {
+  const summary = {
+    carriedCount: 8, bespokeCount: 5, designedCount: 5,
+    confirmedBookCount: 3, spanBooks: 3, perBook: [],
+  };
+  render(<SeriesMemoryChip summary={summary} bookCount={3} onOpen={() => {}} />);
+  expect(screen.getByTestId('series-memory-chip')).toHaveTextContent('Your cast · 8 voices, 3 books');
+});
+```
+(If the file has no imports yet, mirror the existing chip test's imports: `render`, `screen` from `@testing-library/react`.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- series-memory-chip.test`
+Expected: FAIL — `showBooks` is not a prop; the books clause always renders.
+
+- [ ] **Step 3: Implement the prop**
+
+Replace `src/components/series-memory/series-memory-chip.tsx`:
+```tsx
+import type { SeriesMemorySummary } from '../../lib/types';
+import { CastwaveGlyph } from '../../lib/castwave-glyph';
+
+export function SeriesMemoryChip({ summary, bookCount, showBooks = true, onOpen }: {
+  summary: SeriesMemorySummary; bookCount: number; showBooks?: boolean; onOpen: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      data-testid="series-memory-chip"
+      onClick={onOpen}
+      className="inline-flex items-center gap-1.5 rounded-full px-3 min-h-[44px] sm:min-h-0 sm:py-1 text-xs font-semibold text-white dark:text-ink bg-gradient-to-r from-magenta to-peach hover:-translate-y-px transition-transform"
+    >
+      <CastwaveGlyph className="w-3.5 h-3.5" />
+      Your cast · {summary.carriedCount} voices{showBooks ? `, ${bookCount} books` : ''}
+    </button>
+  );
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm test -- series-memory-chip.test`
+Expected: PASS (both new tests + any pre-existing chip tests, which use the default and still see ", N books").
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/series-memory/series-memory-chip.tsx src/components/series-memory/series-memory-chip.test.tsx
+git commit -m "feat(frontend): fe-41 add showBooks prop to SeriesMemoryChip
+
+Optional showBooks (default true) lets the table render a compact
+'Your cast · N voices' variant; grid keeps the books clause.
+
+Refs #983"
+```
+
+---
+
+## Task 3: fe-41b — series-memory chip in the table view
+
+Thread the `LibrarySeries` into the table's group model, restructure the collapsible section header so a clickable chip can sit beside the collapse toggle (responsively), render the compact chip, and wire the open handler to the orchestrator's existing reveal. Add the filter-preservation invariant test at the orchestrator layer.
+
+**Files:**
+- Modify: `src/components/library/library-table.tsx` (`SeriesGroup` interface ~58-71; groups `useMemo` ~91-123; section header ~140-161; `Props` ~42-56)
+- Modify: `src/views/book-library.tsx:420-432` (pass `onOpenSeriesMemory`)
+- Test: `src/components/library/library-table.test.tsx`, `src/views/book-library.test.tsx`
+
+**Interfaces:**
+- Consumes: `SeriesMemoryChip` with `showBooks` (Task 2); `LibrarySeries` (`src/lib/types.ts:612`, has `name`, `books`, `seriesMemory?`); the orchestrator's `setOpenSM` already renders `<SeriesMemoryReveal>`/`<ShareCardModal>` (book-library.tsx:435-451).
+- Produces: `LibraryTable` prop `onOpenSeriesMemory?: (s: LibrarySeries) => void`.
+
+- [ ] **Step 1: Write the failing table tests**
+
+Add to `src/components/library/library-table.test.tsx`. First extend the `renderTable` helper to pass the new prop (add `onOpenSeriesMemory?` to its `opts` type and `onOpenSeriesMemory={opts.onOpenSeriesMemory}` to the `<LibraryTable>` element). Then:
+```tsx
+const SUMMARY = {
+  carriedCount: 8, bespokeCount: 5, designedCount: 5,
+  confirmedBookCount: 3, spanBooks: 3, perBook: [],
+};
+
+describe('LibraryTable — series-memory chip (fe-41)', () => {
+  const authorsWith = (seriesMemory: typeof SUMMARY | undefined): LibraryAuthor[] => [
+    {
+      name: 'Marin Vale',
+      series: [
+        {
+          name: 'Northern Coast Trilogy',
+          seriesMemory,
+          books: [makeBook({ bookId: 'n1', title: 'North One', seriesPosition: 1 })],
+        },
+      ],
+    },
+  ];
+
+  it('renders the compact chip (no books clause) for a series with seriesMemory', () => {
+    renderTable({ authors: authorsWith(SUMMARY) });
+    const chip = screen.getByTestId('series-memory-chip');
+    expect(chip).toHaveTextContent('Your cast · 8 voices');
+    expect(chip).not.toHaveTextContent('books');
+  });
+
+  it('renders no chip when the series has no seriesMemory', () => {
+    renderTable({ authors: authorsWith(undefined) });
+    expect(screen.queryByTestId('series-memory-chip')).toBeNull();
+  });
+
+  it('renders no chip in the Standalones section', () => {
+    const authors: LibraryAuthor[] = [
+      { name: 'A', series: [{ name: 'S', seriesMemory: SUMMARY,
+        books: [makeBook({ bookId: 's1', title: 'Solo', isStandalone: true })] }] },
+    ];
+    renderTable({ authors });
+    expect(screen.queryByTestId('series-memory-chip')).toBeNull();
+  });
+
+  it('clicking the chip fires onOpenSeriesMemory without toggling collapse', () => {
+    const onOpenSeriesMemory = vi.fn();
+    renderTable({ authors: authorsWith(SUMMARY), onOpenSeriesMemory });
+    // chip scoped by testid (the section also has the collapse button) — R3-2
+    fireEvent.click(screen.getByTestId('series-memory-chip'));
+    expect(onOpenSeriesMemory).toHaveBeenCalledTimes(1);
+    expect(onOpenSeriesMemory.mock.calls[0][0].name).toBe('Northern Coast Trilogy');
+    // collapse did NOT fire: the book row is still present
+    expect(screen.getByText('North One')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm test -- library-table.test`
+Expected: FAIL — no chip is rendered, `onOpenSeriesMemory` is not a prop.
+
+- [ ] **Step 3: Add the prop and thread the series into `SeriesGroup`**
+
+In `src/components/library/library-table.tsx`:
+
+Import the chip and type (top of file, alongside existing imports):
+```tsx
+import { SeriesMemoryChip } from '../series-memory/series-memory-chip';
+import type { LibraryAuthor, LibraryBook, LibrarySeries } from '../../lib/types';
+```
+Add to `Props` (the interface ~42-56):
+```tsx
+  onOpenSeriesMemory?: (s: LibrarySeries) => void;
+```
+Add it to the destructured params of `LibraryTable({ … })`.
+
+Add `series` to the `SeriesGroup` interface (~58-71):
+```tsx
+interface SeriesGroup {
+  id: string;
+  label: string;
+  authorOverride: string | null;
+  /** Original LibrarySeries (for the series-memory chip + reveal); null for
+      the synthetic Standalones group. */
+  series: LibrarySeries | null;
+  books: LibraryBook[];
+}
+```
+In the groups `useMemo` (~101-108 and the standalones push ~112-119), set `series`:
+```tsx
+        if (groupBooks.length > 0) {
+          out.push({
+            id: `${author.name}::${series.name}`,
+            label: `${author.name} — ${series.name}`,
+            authorOverride: null,
+            series,
+            books: groupBooks,
+          });
+        }
+```
+and for the standalones group add `series: null,`.
+
+- [ ] **Step 4: Restructure the section header and render the chip (responsive)**
+
+Replace the header `<button>` block (`library-table.tsx:141-161`) with a flex row holding the collapse button (unchanged aria) and the chip as a sibling that wraps below on phone:
+```tsx
+            <div className="flex flex-wrap items-center gap-2 mb-3">
+              <button
+                type="button"
+                onClick={() => setCollapsed((m) => ({ ...m, [group.id]: !isCollapsed }))}
+                aria-expanded={!isCollapsed}
+                aria-controls={`library-table-body-${group.id}`}
+                className="flex-1 min-w-0 flex items-center justify-between gap-3 px-1 py-1 rounded-lg hover:bg-ink/3 transition-colors"
+              >
+                <span className="inline-flex items-center gap-2 min-w-0">
+                  {isCollapsed ? (
+                    <IconChevR className="w-3.5 h-3.5 text-ink/60" />
+                  ) : (
+                    <IconArrowDn className="w-3.5 h-3.5 text-ink/60" />
+                  )}
+                  <span className="text-[11px] uppercase tracking-[0.18em] font-semibold text-ink/55 truncate">
+                    {group.label}
+                  </span>
+                </span>
+                <span className="text-[11px] text-ink/40 shrink-0">
+                  {group.books.length} {group.books.length === 1 ? 'book' : 'books'}
+                </span>
+              </button>
+              {group.series?.seriesMemory && (
+                <SeriesMemoryChip
+                  summary={group.series.seriesMemory}
+                  bookCount={group.series.seriesMemory.confirmedBookCount}
+                  showBooks={false}
+                  onOpen={() => onOpenSeriesMemory?.(group.series!)}
+                />
+              )}
+            </div>
+```
+(The collapse button is now `flex-1 min-w-0` with a `truncate` label; the chip is a sibling, so it never nests in the button and wraps below it when the row is too narrow.)
+
+- [ ] **Step 5: Run the table tests to verify they pass**
+
+Run: `npm test -- library-table.test`
+Expected: PASS (all four new cases + the existing collapse/grouping cases — those fixtures carry no `seriesMemory`, so no chip renders and their `getByRole('button')` queries stay unambiguous).
+
+- [ ] **Step 6: Wire the orchestrator**
+
+`src/views/book-library.tsx:420-432` — add the prop to `<LibraryTable>` (mirrors the grid at line 406):
+```tsx
+          <LibraryTable
+            loaded={loaded}
+            isLibraryEmpty={authors.length === 0}
+            authors={filteredAuthors}
+            activeBookId={activeBookId}
+            onOpenBook={onOpenBook}
+            onDeleteBook={onDeleteBook}
+            onReparseBook={onReparseBook}
+            onReplaceManuscript={onReplaceManuscript}
+            onEditBook={onEditBook}
+            onCoverChanged={onCoverChanged}
+            onStartNew={onStartNew}
+            onOpenSeriesMemory={(s) => setOpenSM(s)}
+          />
+```
+
+- [ ] **Step 7: Add the filter-preservation invariant test (orchestrator layer)**
+
+The chip only renders because `filteredAuthors` (book-library.tsx:316-327) spreads `{ ...series }`, keeping `seriesMemory` while `filterBooks` narrows `books`. Lock it where it lives. In `src/views/book-library.test.tsx`, add a test that renders the library (table view) with a search filter that narrows — but does not empty — a series carrying `seriesMemory`, and asserts the chip still shows:
+```tsx
+it('keeps the series-memory chip when an active search filter narrows the series (table view)', async () => {
+  // Arrange a library whose Northern Coast Trilogy has seriesMemory and ≥2 books,
+  // switch to table view, type a search that matches only one of its books.
+  // (Reuse this file's existing render/store setup + MOCK_LIBRARY helpers.)
+  // Assert: getByTestId('series-memory-chip') is still present after the filter.
+});
+```
+If `book-library.test.tsx` lacks a table-view harness, assert the invariant directly against the memo's logic instead: a focused test that applies the same `{ ...series, books: filterBooks(...) }` shape to a `seriesMemory`-bearing series and asserts `result.series[0].seriesMemory` is defined. Pick whichever matches the file's existing conventions; the point is the assertion lives above `LibraryTable`, which does not filter.
+
+- [ ] **Step 8: Run the full frontend suite + typecheck**
+
+Run: `npm run typecheck && npm test`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/components/library/library-table.tsx src/components/library/library-table.test.tsx src/views/book-library.tsx src/views/book-library.test.tsx
+git commit -m "feat(frontend): fe-41 series-memory chip in the table view
+
+Thread LibrarySeries through SeriesGroup, restructure the section header
+(collapse toggle + chip as responsive siblings), render the compact
+showBooks=false chip, and wire onOpenSeriesMemory to the orchestrator's
+existing reveal. Filter-preservation invariant locked at the orchestrator.
+
+Closes #983"
+```
+
+---
+
+## Task 4: fe-43 — PNG share-card export
+
+Add a "Download image (.png)" button to the share modal that captures the existing `SeriesShareCard` via a lazily-imported `html-to-image`, plus a shared `slugifyFilename` applied to both the PNG and the existing JSON download.
+
+**Files:**
+- Modify: `package.json` (add `html-to-image`)
+- Modify: `src/components/series-memory/share-card-modal.tsx`
+- Test: `src/components/series-memory/share-card-modal.test.tsx`, `e2e/series-memory.spec.ts`
+
+**Interfaces:**
+- Consumes: `SeriesShareCard` (renders `data-testid="series-share-card"`, self-contained `bg-[#1b1714]`).
+
+- [ ] **Step 1: Add the dependency**
+
+Run: `npm install --save html-to-image`
+Expected: `html-to-image` appears in `package.json` `dependencies` and `package-lock.json` updates.
+
+- [ ] **Step 2: Update the existing unit tests (write the failing assertions)**
+
+In `src/components/series-memory/share-card-modal.test.tsx`, the current test asserts the PNG button is ABSENT (lines 30-38). Flip it and add the new behaviour. Update the imports and add a mock at the top:
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ShareCardModal, slugifyFilename } from './share-card-modal';
+
+vi.mock('html-to-image', () => ({
+  toPng: vi.fn().mockResolvedValue('data:image/png;base64,AAAA'),
+}));
+```
+Replace the "no PNG dep in v1" test (lines 30-38) with:
+```tsx
+it('renders the Download image (.png) button', () => {
+  render(<ShareCardModal detail={detail} seriesName="X" onClose={() => {}} />);
+  expect(screen.getByRole('button', { name: /download image \(\.png\)/i })).toBeInTheDocument();
+});
+
+it('captures the card and triggers a .png download on click', async () => {
+  const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+  render(<ShareCardModal detail={detail} seriesName="X" onClose={() => {}} />);
+  fireEvent.click(screen.getByRole('button', { name: /download image \(\.png\)/i }));
+  const { toPng } = await import('html-to-image');
+  await waitFor(() => expect(toPng).toHaveBeenCalled());
+  await waitFor(() => expect(click).toHaveBeenCalled());
+});
+
+it('surfaces an alert when capture fails', async () => {
+  const { toPng } = await import('html-to-image');
+  (toPng as unknown as { mockRejectedValueOnce: (e: Error) => void }).mockRejectedValueOnce(new Error('boom'));
+  render(<ShareCardModal detail={detail} seriesName="X" onClose={() => {}} />);
+  fireEvent.click(screen.getByRole('button', { name: /download image \(\.png\)/i }));
+  expect(await screen.findByRole('alert')).toHaveTextContent(/couldn't render/i);
+});
+```
+And add a direct unit test for the exported helper (this is where the sanitisation is asserted concretely — the helper is shared by both downloads):
+```tsx
+describe('slugifyFilename', () => {
+  it('replaces filename-illegal characters with a single dash', () => {
+    expect(slugifyFilename('Marin Vale: North/Coast')).toBe('Marin Vale- North-Coast');
+    expect(slugifyFilename('A::B')).toBe('A-B');
+    expect(slugifyFilename('')).toBe('series');
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `npm test -- share-card-modal.test`
+Expected: FAIL — no PNG button / no `role="alert"` exists yet.
+
+- [ ] **Step 4: Implement the modal changes**
+
+Edit `src/components/series-memory/share-card-modal.tsx`. Add the slug helper near `downloadJson`, apply it to the JSON filename, and add the ref/button/handler:
+```tsx
+import { useEffect, useRef, useState } from 'react';
+
+export function slugifyFilename(s: string): string {
+  return s.replace(/[\\/:*?"<>|]+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '') || 'series';
+}
+
+function downloadJson(detail: SeriesMemoryDetail, seriesName: string) {
+  const blob = new Blob([JSON.stringify(detail, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${slugifyFilename(seriesName)}-series-memory.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+```
+Inside `ShareCardModal`, add state + ref + handler:
+```tsx
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(false);
+
+  async function downloadPng() {
+    const node = cardRef.current;
+    if (!node) return;
+    setBusy(true);
+    setError(false);
+    try {
+      const { toPng } = await import('html-to-image');
+      await document.fonts?.ready;
+      const url = await toPng(node, { pixelRatio: 2, cacheBust: true });
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${slugifyFilename(seriesName)}-series-cast.png`;
+      a.click();
+    } catch {
+      setError(true);
+    } finally {
+      setBusy(false);
+    }
+  }
+```
+Wrap the card in the ref'd div and add the button + alert. Replace the `<SeriesShareCard … />` + button block (lines 62-71):
+```tsx
+        <div ref={cardRef} className="w-full max-w-sm mx-auto">
+          <SeriesShareCard detail={detail} seriesName={seriesName} owner={owner} />
+        </div>
+
+        <div className="mt-4 flex flex-wrap justify-center gap-2">
+          <button
+            onClick={() => downloadJson(detail, seriesName)}
+            className="rounded-full px-5 py-2.5 font-semibold text-ink bg-gradient-to-r from-magenta to-peach"
+          >
+            Download data (.json)
+          </button>
+          <button
+            onClick={downloadPng}
+            disabled={busy}
+            className="rounded-full px-5 py-2.5 font-semibold text-cream border border-cream/30 hover:bg-white/10 disabled:opacity-60"
+          >
+            {busy ? 'Rendering…' : 'Download image (.png)'}
+          </button>
+        </div>
+        {error && (
+          <p role="alert" className="mt-2 text-center text-xs text-peach">
+            Couldn't render the image — try again.
+          </p>
+        )}
+```
+
+- [ ] **Step 5: Run the unit tests to verify they pass**
+
+Run: `npm test -- share-card-modal.test`
+Expected: PASS. (jsdom has no `document.fonts`; the `?.` lets `await document.fonts?.ready` resolve and reach the mocked `toPng`.)
+
+- [ ] **Step 6: Add the e2e download assertion**
+
+Append to `e2e/series-memory.spec.ts`, after the share card is shown (the existing spec ends at line 56 with the card visible). Add a second test that repeats the navigation and clicks the PNG button:
+```ts
+  test('share card exports a PNG download', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('button', { name: /Start a new book/i }).first()).toBeVisible({ timeout: 10_000 });
+    await page.getByTestId('series-memory-chip').first().click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    await dialog.getByText('Share this cast').click();
+    await expect(page.getByTestId('series-share-card')).toBeVisible({ timeout: 5_000 });
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: /download image \(\.png\)/i }).click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/\.png$/);
+  });
+```
+
+- [ ] **Step 7: Run the e2e to verify it passes**
+
+Run: `npm run test:e2e -- series-memory`
+Expected: PASS — a `download` event fires with a `.png` filename. (This proves the export wire end-to-end in mock mode; it does not assert pixel/font fidelity.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add package.json package-lock.json src/components/series-memory/share-card-modal.tsx src/components/series-memory/share-card-modal.test.tsx e2e/series-memory.spec.ts
+git commit -m "feat(frontend): fe-43 PNG share-card export via html-to-image
+
+Add a 'Download image (.png)' button that lazily imports html-to-image
+and captures the SeriesShareCard at 2x; shared slugifyFilename sanitizes
+both the PNG and the existing JSON download. Busy/disabled state + an
+aria role=alert on capture failure.
+
+Closes #985"
+```
+
+---
+
+## Task 5: docs — record the follow-ups + sync the spec
+
+**Files:**
+- Modify: `docs/features/archive/228-fe-40-series-memory.md`
+- Modify: `docs/superpowers/specs/2026-06-22-fe-40-followups-design.md`
+
+- [ ] **Step 1: Append a "fe-40 follow-ups (delivered)" subsection to the archived plan**
+
+In `docs/features/archive/228-fe-40-series-memory.md`, add a short subsection recording the three deltas with dates + the issues they closed (fe-41 #983 table chip, fe-42 #984 "Carried" vocabulary, fe-43 #985 PNG export), and pointing at this plan + the spec. One paragraph per item; no need to restate the spec.
+
+- [ ] **Step 2: Sync the spec's CHIP_LABELS deviation**
+
+In the fe-42 "Render sites" of the spec, replace the `CHIP_ORDER`/`tally`/`statusFilterKeys` key-rename instruction with the `CHIP_LABELS` approach actually used (add `Reused: 'Carried'`; internal key stays stable). One-line correction so the spec matches the shipped code.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/features/archive/228-fe-40-series-memory.md docs/superpowers/specs/2026-06-22-fe-40-followups-design.md
+git commit -m "docs(docs): record fe-40 follow-ups delivery + sync CHIP_LABELS approach
+
+Refs #983 #984 #985"
+```
+
+---
+
+## Final verification (before opening the PR)
+
+- [ ] Run `npm run verify` — full battery (typecheck + all tests + e2e + build). Expected: green, except the **`e2e/linux` confirm visual baseline**, which must be regenerated via the `regen-visual-baselines` workflow on this branch (it cannot be produced on Windows; the local `e2e/win32` baseline was regenerated in Task 1).
+- [ ] Open the PR with `Closes #983`, `Closes #984`, `Closes #985` in the body; enumerate the three user-visible deltas + the incidental JSON-filename sanitisation.
+
+## Self-review notes
+
+- **Spec coverage:** fe-42 → Task 1; fe-41 (`showBooks`) → Task 2; fe-41 (table) → Task 3; fe-43 → Task 4; docs/spec-sync → Task 5. Every spec section maps to a task. The CHIP_LABELS deviation is documented in the header and synced in Task 5.
+- **Invariants from the spec:** filter preservation → Task 3 Step 7 (orchestrator layer, per R2-2); compact chip avoids the double-count → Task 2 + Task 3 Step 4; ref wrapper / self-contained bg → Task 4 Step 4; lazy import → Task 4 Step 4; `role="alert"` → Task 4 Step 4; `document.fonts?.ready` → Task 4 Step 4; visual baseline regen → Task 1 Step 8.
+- **Type consistency:** `SeriesMemoryChip` gains `showBooks?: boolean` in Task 2 and is consumed with `showBooks={false}` in Task 3. `onOpenSeriesMemory?: (s: LibrarySeries) => void` is declared in Task 3 (table) and supplied in Task 3 (orchestrator). `CarriedBadge` replaces `ReusedBadge` in Task 1 across all three files.

--- a/docs/superpowers/plans/2026-06-22-fe-40-followups.md
+++ b/docs/superpowers/plans/2026-06-22-fe-40-followups.md
@@ -138,9 +138,9 @@ Run: `npm test` (full frontend) to catch any other site asserting the old string
 
 The confirm fixture renders the `Carried · N%` pill (matchedFrom seeds in `src/data/characters.ts`), so `confirm.png` / `confirm-dark.png` change.
 
-Local (Windows) — regenerate the `e2e/win32` baselines so pre-push passes:
+Local (Windows) — regenerate the `e2e/win32` baselines so pre-push passes. Use the project script (it pins `--workers=1`, which guards against the Windows font-hinting race that raw `playwright test` would re-introduce):
 ```bash
-npx playwright test e2e/responsive/visual.spec.ts --project=chromium -g "confirm" --update-snapshots
+npm run test:e2e:visual -- -g confirm --update-snapshots
 ```
 Expected: the `e2e/win32/responsive/visual.spec.ts-snapshots/confirm.png` and `confirm-dark.png` files are rewritten. (Per `docs/testing` history these confirm baselines are Windows-font-flaky; if the immediately-following verification run diffs, re-run once — see `feedback_visual_baselines_flaky_on_windows`.)
 
@@ -149,7 +149,9 @@ Expected: the `e2e/win32/responsive/visual.spec.ts-snapshots/confirm.png` and `c
 - [ ] **Step 9: Commit**
 
 ```bash
-git add src/components/primitives.tsx src/views/cast.tsx src/modals/profile-drawer.tsx src/views/confirm-cast.tsx src/views/cast.test.tsx src/views/confirm-cast.test.tsx src/modals/profile-drawer.test.tsx e2e/win32
+git add src/components/primitives.tsx src/views/cast.tsx src/modals/profile-drawer.tsx src/views/confirm-cast.tsx \
+  src/views/cast.test.tsx src/views/confirm-cast.test.tsx src/modals/profile-drawer.test.tsx \
+  'e2e/win32/responsive/visual.spec.ts-snapshots/confirm*.png'
 git commit -m "refactor(frontend): fe-42 unify series-carry vocabulary to 'Carried'
 
 Rename ReusedBadge -> CarriedBadge (testid kept), relabel the cast
@@ -158,8 +160,9 @@ filter chip via CHIP_LABELS, and change confirm-cast 'Matched · N%' ->
 unchanged. Regenerated the confirm visual baseline (win32); linux
 baseline owed via the regen workflow.
 
-Refs #984"
+Closes #984"
 ```
+(Stage the specific `confirm*.png` snapshot files, not the whole `e2e/win32` dir, so an unrelated baseline drift doesn't ride along. `Closes #984` — fe-42 is fully delivered in this single task.)
 
 ---
 
@@ -427,18 +430,26 @@ Expected: PASS (all four new cases + the existing collapse/grouping cases — th
           />
 ```
 
-- [ ] **Step 7: Add the filter-preservation invariant test (orchestrator layer)**
+- [ ] **Step 7: Add the filter-preservation invariant test (orchestrator render, not a reconstruction)**
 
-The chip only renders because `filteredAuthors` (book-library.tsx:316-327) spreads `{ ...series }`, keeping `seriesMemory` while `filterBooks` narrows `books`. Lock it where it lives. In `src/views/book-library.test.tsx`, add a test that renders the library (table view) with a search filter that narrows — but does not empty — a series carrying `seriesMemory`, and asserts the chip still shows:
+The chip only renders because `filteredAuthors` (book-library.tsx:316-327) spreads `{ ...series }`, keeping `seriesMemory` while `filterBooks` narrows `books`. This must be locked by a **real render of the orchestrator** — `LibraryTable` itself never filters, and a hand-rolled `{ ...series, books: filterBooks(...) }` test would only assert the test's own reconstruction (a fake-lock). 
+
+First read `src/views/book-library.test.tsx` and follow its existing render harness (it already renders the library from mock authors — the card view's coverage lives here per the `library-table.tsx` header comment). Add a case that drives the **real** filter path:
 ```tsx
-it('keeps the series-memory chip when an active search filter narrows the series (table view)', async () => {
-  // Arrange a library whose Northern Coast Trilogy has seriesMemory and ≥2 books,
-  // switch to table view, type a search that matches only one of its books.
-  // (Reuse this file's existing render/store setup + MOCK_LIBRARY helpers.)
-  // Assert: getByTestId('series-memory-chip') is still present after the filter.
+it('keeps the series-memory chip when an active search filter narrows a series', async () => {
+  // Using this file's existing render helper + a mock library whose series
+  // carries `seriesMemory` and has ≥2 books (e.g. the Northern Coast Trilogy
+  // shape from src/mocks/library.ts):
+  //   1. render the library (default card view is fine — same filteredAuthors
+  //      memo feeds both views, so this locks the shared spread).
+  //   2. type into the library search box a query that matches ONE book of
+  //      that series (narrows books from N→1, does NOT empty the series).
+  //   3. assert screen.getByTestId('series-memory-chip') is STILL present.
+  // The assertion exercises filteredAuthors' `{ ...series }` spread for real —
+  // if a future refactor drops seriesMemory during filtering, this goes red.
 });
 ```
-If `book-library.test.tsx` lacks a table-view harness, assert the invariant directly against the memo's logic instead: a focused test that applies the same `{ ...series, books: filterBooks(...) }` shape to a `seriesMemory`-bearing series and asserts `result.series[0].seriesMemory` is defined. Pick whichever matches the file's existing conventions; the point is the assertion lives above `LibraryTable`, which does not filter.
+Mirror the exact render call, store setup, and search-input selector from the neighbouring tests in that file — do not invent helpers. The card view is acceptable here because both views consume the same `filteredAuthors` memo; the point is to exercise the orchestrator's spread, which `LibraryTable` cannot.
 
 - [ ] **Step 8: Run the full frontend suite + typecheck**
 
@@ -611,7 +622,7 @@ Expected: PASS. (jsdom has no `document.fonts`; the `?.` lets `await document.fo
 
 - [ ] **Step 6: Add the e2e download assertion**
 
-Append to `e2e/series-memory.spec.ts`, after the share card is shown (the existing spec ends at line 56 with the card visible). Add a second test that repeats the navigation and clicks the PNG button:
+Add a second `test(...)` **inside** the existing `test.describe('series-memory: …', () => { … })` block (before its closing `});` at line 57) — not at file top level. It repeats the navigation and clicks the PNG button:
 ```ts
   test('share card exports a PNG download', async ({ page }) => {
     await page.goto('/');
@@ -650,25 +661,35 @@ Closes #985"
 
 ---
 
-## Task 5: docs — record the follow-ups + sync the spec
+## Task 5: docs — record the follow-ups, remove backlog rows, sync the spec
 
 **Files:**
 - Modify: `docs/features/archive/228-fe-40-series-memory.md`
+- Modify: `docs/BACKLOG.md`
 - Modify: `docs/superpowers/specs/2026-06-22-fe-40-followups-design.md`
 
 - [ ] **Step 1: Append a "fe-40 follow-ups (delivered)" subsection to the archived plan**
 
 In `docs/features/archive/228-fe-40-series-memory.md`, add a short subsection recording the three deltas with dates + the issues they closed (fe-41 #983 table chip, fe-42 #984 "Carried" vocabulary, fe-43 #985 PNG export), and pointing at this plan + the spec. One paragraph per item; no need to restate the spec.
 
-- [ ] **Step 2: Sync the spec's CHIP_LABELS deviation**
+- [ ] **Step 2: Remove the shipped backlog rows (CLAUDE.md ship step)**
+
+Delete the three rows from `docs/BACKLOG.md` — they are now shipped:
+- `#### \`fe-41\` …` (line ~458)
+- `#### \`fe-42\` …` (line ~464)
+- `#### \`fe-43\` …` (line ~470)
+
+Remove each item's full block (heading + its What/Benefit/Acceptance lines), not just the heading. Verify with `grep -n "fe-41\|fe-42\|fe-43" docs/BACKLOG.md` → no matches remain.
+
+- [ ] **Step 3: Sync the spec's CHIP_LABELS deviation**
 
 In the fe-42 "Render sites" of the spec, replace the `CHIP_ORDER`/`tally`/`statusFilterKeys` key-rename instruction with the `CHIP_LABELS` approach actually used (add `Reused: 'Carried'`; internal key stays stable). One-line correction so the spec matches the shipped code.
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 4: Commit**
 
 ```bash
-git add docs/features/archive/228-fe-40-series-memory.md docs/superpowers/specs/2026-06-22-fe-40-followups-design.md
-git commit -m "docs(docs): record fe-40 follow-ups delivery + sync CHIP_LABELS approach
+git add docs/features/archive/228-fe-40-series-memory.md docs/BACKLOG.md docs/superpowers/specs/2026-06-22-fe-40-followups-design.md
+git commit -m "docs(docs): record fe-40 follow-ups delivery, drop backlog rows, sync spec
 
 Refs #983 #984 #985"
 ```

--- a/docs/superpowers/plans/2026-06-22-fe-40-followups.md
+++ b/docs/superpowers/plans/2026-06-22-fe-40-followups.md
@@ -133,6 +133,7 @@ Expected: PASS (the rename reaches both importers — a missed importer would er
 Run: `npm test -- cast.test confirm-cast.test profile-drawer.test`
 Expected: PASS.
 Run: `npm test` (full frontend) to catch any other site asserting the old strings (e.g. `src/test/a11y.test.tsx`). Fix any stragglers by switching the visible string `Reused`→`Carried` / `Matched · `→`Carried · ` (never the bare lifecycle `Matched`).
+Also run `grep -rn "Matched · " e2e/` — if a non-visual e2e spec asserts the confirm pill text, update it to `Carried · ` here (so it surfaces before the full `verify` battery, not after).
 
 - [ ] **Step 8: Regenerate the `confirm` visual baselines**
 
@@ -257,12 +258,12 @@ Thread the `LibrarySeries` into the table's group model, restructure the collaps
 
 **Files:**
 - Modify: `src/components/library/library-table.tsx` (`SeriesGroup` interface ~58-71; groups `useMemo` ~91-123; section header ~140-161; `Props` ~42-56)
-- Modify: `src/views/book-library.tsx:420-432` (pass `onOpenSeriesMemory`)
+- Modify: `src/views/book-library.tsx` (pass `onOpenSeriesMemory` to `<LibraryTable>` ~420-432; extract `applyLibraryFilters` from the `filteredAuthors` memo ~314-331)
 - Test: `src/components/library/library-table.test.tsx`, `src/views/book-library.test.tsx`
 
 **Interfaces:**
 - Consumes: `SeriesMemoryChip` with `showBooks` (Task 2); `LibrarySeries` (`src/lib/types.ts:612`, has `name`, `books`, `seriesMemory?`); the orchestrator's `setOpenSM` already renders `<SeriesMemoryReveal>`/`<ShareCardModal>` (book-library.tsx:435-451).
-- Produces: `LibraryTable` prop `onOpenSeriesMemory?: (s: LibrarySeries) => void`.
+- Produces: `LibraryTable` prop `onOpenSeriesMemory?: (s: LibrarySeries) => void`; exported `applyLibraryFilters(authors, { filter, search, tags, languages }): LibraryAuthor[]` from `book-library.tsx`.
 
 - [ ] **Step 1: Write the failing table tests**
 
@@ -430,33 +431,91 @@ Expected: PASS (all four new cases + the existing collapse/grouping cases — th
           />
 ```
 
-- [ ] **Step 7: Add the filter-preservation invariant test (orchestrator render, not a reconstruction)**
+- [ ] **Step 7: Extract the filter mapping into an exported pure helper**
 
-The chip only renders because `filteredAuthors` (book-library.tsx:316-327) spreads `{ ...series }`, keeping `seriesMemory` while `filterBooks` narrows `books`. This must be locked by a **real render of the orchestrator** — `LibraryTable` itself never filters, and a hand-rolled `{ ...series, books: filterBooks(...) }` test would only assert the test's own reconstruction (a fake-lock). 
+The chip only renders because the orchestrator's `filteredAuthors` memo spreads `{ ...series }`, keeping `seriesMemory` while `filterBooks` narrows `books`. To lock that invariant cleanly — without a slow, debounce-dependent render test against an unknown harness — extract the memo body into an exported pure function and have the memo call it. Behaviour-preserving; existing `book-library.test.tsx` tests stay green.
 
-First read `src/views/book-library.test.tsx` and follow its existing render harness (it already renders the library from mock authors — the card view's coverage lives here per the `library-table.tsx` header comment). Add a case that drives the **real** filter path:
+In `src/views/book-library.tsx`, replace the inline `filteredAuthors` memo (lines ~314-331) with a call to a new exported helper defined at module scope:
 ```tsx
-it('keeps the series-memory chip when an active search filter narrows a series', async () => {
-  // Using this file's existing render helper + a mock library whose series
-  // carries `seriesMemory` and has ≥2 books (e.g. the Northern Coast Trilogy
-  // shape from src/mocks/library.ts):
-  //   1. render the library (default card view is fine — same filteredAuthors
-  //      memo feeds both views, so this locks the shared spread).
-  //   2. type into the library search box a query that matches ONE book of
-  //      that series (narrows books from N→1, does NOT empty the series).
-  //   3. assert screen.getByTestId('series-memory-chip') is STILL present.
-  // The assertion exercises filteredAuthors' `{ ...series }` spread for real —
-  // if a future refactor drops seriesMemory during filtering, this goes red.
+export function applyLibraryFilters(
+  authors: LibraryAuthor[],
+  opts: { filter: Filter; search: string; tags: string[]; languages: string[] },
+): LibraryAuthor[] {
+  return authors
+    .map((author) => ({
+      ...author,
+      series: author.series
+        .map((series) => ({
+          ...series,
+          books: filterBooks(
+            series.books.filter((b) => matchesFilter(b, opts.filter)),
+            opts.search,
+            opts.tags,
+            opts.languages,
+          ),
+        }))
+        .filter((series) => series.books.length > 0),
+    }))
+    .filter((author) => author.series.length > 0);
+}
+```
+And the memo becomes:
+```tsx
+  const filteredAuthors = useMemo<LibraryAuthor[]>(
+    () =>
+      applyLibraryFilters(authors, {
+        filter,
+        search: debouncedSearch,
+        tags: activeTags,
+        languages: activeLanguages,
+      }),
+    [authors, filter, debouncedSearch, activeTags, activeLanguages],
+  );
+```
+(`Filter` is the local `type Filter = 'all' | 'in_progress' | 'complete'`; `matchesFilter` and `filterBooks` are already imported in this file.) Run `npm run typecheck && npm test -- book-library` — existing orchestrator tests stay green (pure refactor).
+
+- [ ] **Step 8: Lock the invariant — unit-test the helper directly**
+
+In `src/views/book-library.test.tsx`, add a focused test (no render, no debounce):
+```tsx
+import { applyLibraryFilters } from './book-library';
+// ...
+it('applyLibraryFilters preserves seriesMemory when a search narrows the books', () => {
+  const summary = {
+    carriedCount: 8, bespokeCount: 5, designedCount: 5,
+    confirmedBookCount: 3, spanBooks: 3, perBook: [],
+  };
+  const authors: LibraryAuthor[] = [
+    {
+      name: 'Marin Vale',
+      series: [
+        {
+          name: 'Northern Coast Trilogy',
+          seriesMemory: summary,
+          books: [
+            // shape via this file's existing book factory if it has one;
+            // otherwise a minimal LibraryBook with title 'North One' / 'North Two'.
+            makeLibBook({ bookId: 'n1', title: 'North One' }),
+            makeLibBook({ bookId: 'n2', title: 'North Two' }),
+          ],
+        },
+      ],
+    },
+  ];
+  const out = applyLibraryFilters(authors, { filter: 'all', search: 'North One', tags: [], languages: [] });
+  // search narrowed books 2→1 but the series object kept its seriesMemory:
+  expect(out[0].series[0].books).toHaveLength(1);
+  expect(out[0].series[0].seriesMemory).toEqual(summary);
 });
 ```
-Mirror the exact render call, store setup, and search-input selector from the neighbouring tests in that file — do not invent helpers. The card view is acceptable here because both views consume the same `filteredAuthors` memo; the point is to exercise the orchestrator's spread, which `LibraryTable` cannot.
+Reuse the file's existing `LibraryBook` factory if present (mirror its name); otherwise define a tiny local `makeLibBook` like `library-table.test.tsx`'s `makeBook`. The assertion exercises the real `{ ...series }` spread — if a future refactor drops `seriesMemory` during filtering, this goes red.
 
-- [ ] **Step 8: Run the full frontend suite + typecheck**
+- [ ] **Step 9: Run the full frontend suite + typecheck**
 
 Run: `npm run typecheck && npm test`
 Expected: PASS.
 
-- [ ] **Step 9: Commit**
+- [ ] **Step 10: Commit**
 
 ```bash
 git add src/components/library/library-table.tsx src/components/library/library-table.test.tsx src/views/book-library.tsx src/views/book-library.test.tsx
@@ -465,7 +524,8 @@ git commit -m "feat(frontend): fe-41 series-memory chip in the table view
 Thread LibrarySeries through SeriesGroup, restructure the section header
 (collapse toggle + chip as responsive siblings), render the compact
 showBooks=false chip, and wire onOpenSeriesMemory to the orchestrator's
-existing reveal. Filter-preservation invariant locked at the orchestrator.
+existing reveal. Extract applyLibraryFilters so the filter-preservation
+invariant (seriesMemory survives filtering) is unit-locked.
 
 Closes #983"
 ```
@@ -543,10 +603,12 @@ Expected: FAIL — no PNG button / no `role="alert"` exists yet.
 
 - [ ] **Step 4: Implement the modal changes**
 
-Edit `src/components/series-memory/share-card-modal.tsx`. Add the slug helper near `downloadJson`, apply it to the JSON filename, and add the ref/button/handler:
+Edit `src/components/series-memory/share-card-modal.tsx`. First **replace the existing line-1 import** `import { useEffect } from 'react';` with the three hooks below. Then add the slug helper at module scope (near the existing `downloadJson`, lines ~6-14) and apply it to the JSON filename:
 ```tsx
+// line 1 — replaces `import { useEffect } from 'react';`
 import { useEffect, useRef, useState } from 'react';
 
+// module scope, beside the existing downloadJson:
 export function slugifyFilename(s: string): string {
   return s.replace(/[\\/:*?"<>|]+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '') || 'series';
 }
@@ -704,5 +766,5 @@ Refs #983 #984 #985"
 ## Self-review notes
 
 - **Spec coverage:** fe-42 → Task 1; fe-41 (`showBooks`) → Task 2; fe-41 (table) → Task 3; fe-43 → Task 4; docs/spec-sync → Task 5. Every spec section maps to a task. The CHIP_LABELS deviation is documented in the header and synced in Task 5.
-- **Invariants from the spec:** filter preservation → Task 3 Step 7 (orchestrator layer, per R2-2); compact chip avoids the double-count → Task 2 + Task 3 Step 4; ref wrapper / self-contained bg → Task 4 Step 4; lazy import → Task 4 Step 4; `role="alert"` → Task 4 Step 4; `document.fonts?.ready` → Task 4 Step 4; visual baseline regen → Task 1 Step 8.
+- **Invariants from the spec:** filter preservation → Task 3 Steps 7-8 (extract `applyLibraryFilters` + unit-test it directly, per R2-2 / P2-1); compact chip avoids the double-count → Task 2 + Task 3 Step 4; ref wrapper / self-contained bg → Task 4 Step 4; lazy import → Task 4 Step 4; `role="alert"` → Task 4 Step 4; `document.fonts?.ready` → Task 4 Step 4; visual baseline regen → Task 1 Step 8.
 - **Type consistency:** `SeriesMemoryChip` gains `showBooks?: boolean` in Task 2 and is consumed with `showBooks={false}` in Task 3. `onOpenSeriesMemory?: (s: LibrarySeries) => void` is declared in Task 3 (table) and supplied in Task 3 (orchestrator). `CarriedBadge` replaces `ReusedBadge` in Task 1 across all three files.

--- a/docs/superpowers/specs/2026-06-22-fe-40-followups-design.md
+++ b/docs/superpowers/specs/2026-06-22-fe-40-followups-design.md
@@ -13,9 +13,9 @@ series-memory chip in the table view, and add a PNG export to the share card.
 
 ## Scope & delivery
 
-Three independent, FE-scoped items. They share **no files except the
-orchestrator** (`src/views/book-library.tsx`, one prop wiring line), so they
-cannot collide.
+Three independent, FE-scoped items. Their file sets are disjoint: only **fe-41**
+touches the orchestrator (`src/views/book-library.tsx`, one prop-wiring line);
+fe-42 and fe-43 don't touch it at all. Nothing collides.
 
 - **One branch:** `feat/frontend-fe-40-followups`.
 - **Three commits**, one per item, in this order: fe-42 (copy) → fe-41 (table
@@ -79,14 +79,32 @@ would be a category error.
   - **Keep `data-testid="reused-badge"`** unchanged to avoid unrelated test
     churn (the testid is an internal hook, not user-facing copy). The icon
     (`IconLink`) and lighter-weight styling stay.
-- `src/views/cast.tsx` — update the single `ReusedBadge` import to
-  `CarriedBadge` and its one usage (`{reused && <CarriedBadge />}`); update the
-  filter-chip `CHIP_ORDER` entry and tally key `'Reused'` → `'Carried'` (the
-  string is both the Map key and the visible chip label, so they move
-  together); update the explanatory comments that say "Reused".
+- **`CarriedBadge` has two render sites — both must update or the rename is a
+  TypeScript build break:**
+  - `src/views/cast.tsx` — update the `ReusedBadge` import (line ~19) to
+    `CarriedBadge` and its usage `{reused && <CarriedBadge />}` (line ~1450);
+    update the filter-chip `CHIP_ORDER` entry and tally key `'Reused'` →
+    `'Carried'` (the string is both the Map key and the visible chip label, so
+    they move together — and `statusKeysFor` at cast.tsx:286 just wraps
+    `statusFilterKeys`, so the chip-definition key and the row-matching key stay
+    consistent once both producers are renamed); update the "Reused" comments.
+  - `src/modals/profile-drawer.tsx` — update the `ReusedBadge` import (line ~22)
+    to `CarriedBadge` and its usage `{reused && <CarriedBadge />}` (line ~899).
+    The drawer mirrors the cast row's badge; missing it fails `tsc`.
 - `src/lib/voice-status.ts` (~line 173) — the chip-key push `keys.push('Reused')`
   → `keys.push('Carried')` (keeps the chip count keyed consistently with
   `cast.tsx`).
+- Comments mentioning "Reused" in the touched files updated to match.
+
+**Not touched — the lifecycle `Matched` pill (separate concept, derived from
+`voiceState`, not `matchedFrom`).** Expected consequence, *not* a missed rename: a
+reused **preset** character (`voiceState:'reused'`) resolves its lifecycle label to
+`'Matched'` (`voice-status.ts:124-127`) **and** carries the badge. Today that row
+reads "Matched · Reused"; after fe-42 it reads **"Matched · Carried."** The
+lifecycle "Matched" (preset voice is ready) is a different axis from carry
+provenance, so it correctly stays. A reviewer seeing a surviving bare "Matched"
+must not read it as an incomplete rename. The confirm-cast `Matched · N%` pill is a
+separate surface; the `· N%` distinguishes it from the bare lifecycle "Matched".
 
 ### Tests
 
@@ -99,13 +117,16 @@ Update the exact-string assertions in:
 - `src/views/confirm-cast.test.tsx` — `getByText('Matched · 95%')` →
   `getByText('Carried · 95%')` and the `/Matched · /` queries.
 - `src/modals/profile-drawer.test.tsx` — the reused-badge assertions.
-- `src/test/a11y.test.tsx` and `src/modals/match-detail.test.tsx` — any
-  `Reused`/`Matched · %` assertions surfaced by a repo-wide grep at
-  implementation time.
+- `src/test/a11y.test.tsx` — any `Reused`/`Matched · %` assertions surfaced by a
+  repo-wide grep at implementation time. (`match-detail.tsx`/`.test.tsx` are
+  **not** sites — their earlier grep hits were `matchedFrom`, not the visible
+  strings.)
 
-**Acceptance:** a repo-wide grep for the visible strings `Reused` and
-`Matched · ` returns zero *user-facing* `matchedFrom`-driven sites afterward;
-the lifecycle `Matched` pill still renders `Matched`; all existing tests green.
+**Acceptance:** `npm run typecheck` is green (the `ReusedBadge → CarriedBadge`
+rename is a build concern — both `cast.tsx` and `profile-drawer.tsx` import it);
+a repo-wide grep for the visible strings `Reused` and `Matched · ` returns zero
+*user-facing* `matchedFrom`-driven sites afterward; the bare lifecycle `Matched`
+pill still renders `Matched`; all existing tests green.
 
 ---
 
@@ -151,6 +172,24 @@ it **drops** the `LibrarySeries` reference.
    `SeriesMemoryReveal` + `ShareCardModal` are already rendered globally and need
    no change.
 
+### Invariants this relies on (verified, pin them)
+
+- **Filter preserves `seriesMemory`.** The chip only renders because the
+  orchestrator builds `filteredAuthors` with `{ ...series, books: filterBooks(...) }`
+  (`book-library.tsx:316-327`) — the spread keeps `seriesMemory`, and `filterBooks`
+  only narrows the `books` array. This is an *implicit, currently-untested*
+  dependency shared with the grid: a future refactor that reconstructs series
+  objects would silently kill the chip in both views. The fe-41 test (below) locks
+  it for the table.
+- **Count is the unfiltered series total — intentional parity with the grid.**
+  The chip shows `seriesMemory.confirmedBookCount`, which is *not* recomputed on
+  filter, so with an active search/tag filter the table can show 2 rows while the
+  chip reads "5 books." This is identical to the grid's existing behaviour, so
+  fe-41 is not a regression; it is deliberate parity, not an oversight.
+- **`onOpenSeriesMemory` needs the original `LibrarySeries`** (the reveal reads
+  `series.books[0].author` + `series.name`). Pass `group.series` — the original
+  object threaded in step 1 — not a reconstructed one.
+
 ### Tests
 
 Extend `src/components/library/library-table.test.tsx`:
@@ -161,6 +200,9 @@ Extend `src/components/library/library-table.test.tsx`:
   section.
 - Clicking the chip fires `onOpenSeriesMemory` with the series and does **not**
   toggle the section's collapse state.
+- **Chip survives an active filter** — render the table with a search/tag filter
+  that narrows a qualifying series' `books`, and assert the chip still shows (locks
+  the `{ ...series }` filter-preservation invariant above).
 
 `e2e/responsive/coverage.spec.ts` already auto-runs the table at every viewport;
 no new e2e case is required for fe-41 (the chip is exercised by the grid's
@@ -192,29 +234,44 @@ no mock-mode support — wrong fit for an FE-only round).
     "Download data (.json)" button, same pill styling family.
   - Handler:
     ```ts
-    await document.fonts.ready;               // ensure self-hosted woff2 loaded
+    await document.fonts?.ready;              // optional-chain: jsdom has no document.fonts
     const url = await toPng(node, { pixelRatio: 2, cacheBust: true });
     const a = document.createElement('a');
     a.href = url;
-    a.download = `${seriesName}-series-cast.png`;
+    a.download = `${slugifyFilename(seriesName)}-series-cast.png`;
     a.click();
     ```
-    (filename mirrors the JSON export's `${seriesName}-series-memory.json`.)
+    **The `?.` is load-bearing for the unit test:** jsdom does **not** implement
+    `document.fonts`, so a bare `document.fonts.ready` throws `TypeError` *before*
+    the mocked `toPng` is reached and the test can't exercise the path. Optional
+    chaining is a no-op in the browser (where `document.fonts` exists) and safe in
+    jsdom (where it's `undefined` → the `await undefined` resolves immediately).
+  - **Filename — `slugifyFilename` (small shared helper).** `seriesName` can hold
+    characters illegal in filenames (`:` / `/` — the mock series key even uses
+    `::`). The existing JSON download (`${seriesName}-series-memory.json`) has this
+    same latent issue. Add a tiny `slugifyFilename(s)` (strip/replace
+    `[\\/:*?"<>|]` → `-`, collapse repeats) and apply it to **both** the new PNG
+    and the existing JSON download in this file — a one-liner that fixes both
+    rather than propagating the bug. (Scoped to this file; not a new module.)
   - **States:** local `busy` flag → button shows a disabled "Rendering…" label
     during capture; local `error` flag → an inline error line under the buttons
     ("Couldn't render the image — try again.") on a rejected `toPng`. No toast
     dependency; the modal stays self-contained.
 - Fonts (General Sans + Lora) are self-hosted, same-origin woff2, so
-  html-to-image inlines them; the `document.fonts.ready` await guards against a
+  html-to-image inlines them; the `document.fonts?.ready` await guards against a
   capture firing before the faces are ready.
 
 ### Tests
 
 - **Vitest** (`share-card-modal.test.tsx`): mock `html-to-image`'s `toPng`.
   - Clicking "Download image (.png)" awaits `toPng`, creates an anchor with the
-    returned data URL and `download="${seriesName}-series-cast.png"`, and clicks
-    it (spy on `HTMLAnchorElement.prototype.click` / `createElement`).
+    returned data URL and the slugified `download` filename, and clicks it (spy on
+    `HTMLAnchorElement.prototype.click` / `createElement`). Runs under jsdom with
+    no `document.fonts` — the `?.` guard is what lets this test reach `toPng`.
   - A rejected `toPng` surfaces the inline error line and re-enables the button.
+  - `slugifyFilename` replaces illegal characters (assert a `seriesName` with `:`
+    / `/` yields a safe `.png` *and* `.json` filename — covers the shared helper
+    on both downloads).
 - **e2e** (`e2e/series-memory.spec.ts`): open the share card → click
   "Download image (.png)" → assert a Playwright `download` event fires with a
   `.png` suggested filename. Runs in mock mode.
@@ -225,9 +282,11 @@ works in mock mode, and is covered by unit + e2e tests.
 
 ## Risks & mitigations
 
-- **fe-42** — blast radius is *test strings*, not logic; risk is a missed
-  assertion site, caught by `npm test`. The lifecycle-vs-carry `Matched` overload
-  is the one trap; the spec pins which sites move and which stay.
+- **fe-42** — two failure modes: (a) the `ReusedBadge → CarriedBadge` export
+  rename is a **build break** if either importer (`cast.tsx`, `profile-drawer.tsx`)
+  is missed — caught by `npm run typecheck`; (b) a missed test-string assertion —
+  caught by `npm test`. The lifecycle-vs-carry `Matched` overload is the
+  interpretation trap; the spec pins which sites move and which stay.
 - **fe-41** — only non-trivial bit is the header restructure; chip + modal are
   pure reuse. Risk: breaking the collapse `aria-*` wiring — covered by the
   "collapse still toggles independently" test.

--- a/docs/superpowers/specs/2026-06-22-fe-40-followups-design.md
+++ b/docs/superpowers/specs/2026-06-22-fe-40-followups-design.md
@@ -1,0 +1,243 @@
+# fe-40 follow-ups — design spec
+
+**Date:** 2026-06-22
+**Issues:** fe-41 (#983), fe-42 (#984), fe-43 (#985)
+**Predecessor:** fe-40 series memory (shipped 2026-06-21, plan [228](../../features/archive/228-fe-40-series-memory.md), PR #986)
+**Status:** approved — ready for implementation plan
+
+## Goal
+
+Ship the three deliberately-deferred fe-40 follow-ups as one cohesive,
+frontend-only round: harmonise the series-carry vocabulary, surface the
+series-memory chip in the table view, and add a PNG export to the share card.
+
+## Scope & delivery
+
+Three independent, FE-scoped items. They share **no files except the
+orchestrator** (`src/views/book-library.tsx`, one prop wiring line), so they
+cannot collide.
+
+- **One branch:** `feat/frontend-fe-40-followups`.
+- **Three commits**, one per item, in this order: fe-42 (copy) → fe-41 (table
+  chip) → fe-43 (PNG export). Ordering is convenience only; there are no
+  inter-item dependencies.
+- **One PR** closing all three: `Closes #983`, `Closes #984`, `Closes #985`.
+- **One local `npm run verify`** (the pre-push gate is the real CI here; cloud
+  CI stays opt-in).
+- **Docs:** append a short "fe-40 follow-ups (delivered)" subsection to the
+  archived plan `docs/features/archive/228-fe-40-series-memory.md` recording the
+  three deltas. No new plan doc — each item is small and issue-specified, and
+  ships paired tests.
+
+## Global constraints
+
+Copied from project conventions; every task inherits these.
+
+- **No hex literals in component code** — use the CSS-custom-property design
+  tokens (`--magenta`, `--peach`, `--ink`, `--cream`, etc.) via Tailwind.
+- **OpenAPI is the type source of truth** — but these three items add **no new
+  API shapes** (fe-42 is copy, fe-41 reuses the existing `seriesMemory`
+  summary, fe-43 is pure client-side). `openapi.yaml` is untouched.
+- **Touch-equivalence + 44px touch targets** — any new interactive control
+  ships its tap path and meets WCAG 2.5.5 on phone (`min-h-[44px] sm:min-h-0`).
+- **Test discipline** — new behaviour ships paired automated tests; the PNG
+  button (crosses a redux/layout-free but DOM-capture seam) gets a Vitest unit
+  test plus a Playwright e2e download assertion.
+- **Reproduce the existing look** — fe-41's chip is the *same* `SeriesMemoryChip`
+  the grid uses; fe-43 captures the *existing* locked `SeriesShareCard`. No
+  visual redesign.
+
+---
+
+## fe-42 — single-word "Carried" vocabulary
+
+### Decision & rationale
+
+The series-carry concept is a **single** data signal: `voice-status.ts:149`
+derives `reused: !!c.matchedFrom`. There is **no** existing signal for "a voice
+kept from the prior cast *without* a match", so the issue's proposed second term
+("Kept") would be dead vocabulary — it has no population to render. Building a
+real "Kept" predicate would mean new cross-book derivation and a new
+per-character flag; that scope is explicitly **out** for this round (revisit when
+voice-cloning / series work gives a second term real data).
+
+Therefore: **one concept, one word — "Carried"** — applied only to the
+`matchedFrom`-driven markers. The unrelated **lifecycle** `Matched` pill (a
+preset-voice state for Kokoro/Coqui, derived from `voiceState`, not
+`matchedFrom`) is a different concept and is **left untouched** — renaming it
+would be a category error.
+
+### Render sites (copy + symbol changes only — no logic change)
+
+- `src/views/confirm-cast.tsx` (~line 435) — the cast-review pill
+  `Matched · {Math.round(confidence*100)}%` → `Carried · {…}%`. Guard
+  (`matched && character.matchedFrom?.confidence != null`) unchanged.
+- `src/components/primitives.tsx` (~line 225) — the badge component:
+  - Rename the export `ReusedBadge` → `CarriedBadge`.
+  - Visible label `Reused` → `Carried`.
+  - `title` attribute → "Voice carried from a prior book in this series".
+  - **Keep `data-testid="reused-badge"`** unchanged to avoid unrelated test
+    churn (the testid is an internal hook, not user-facing copy). The icon
+    (`IconLink`) and lighter-weight styling stay.
+- `src/views/cast.tsx` — update the single `ReusedBadge` import to
+  `CarriedBadge` and its one usage (`{reused && <CarriedBadge />}`); update the
+  filter-chip `CHIP_ORDER` entry and tally key `'Reused'` → `'Carried'` (the
+  string is both the Map key and the visible chip label, so they move
+  together); update the explanatory comments that say "Reused".
+- `src/lib/voice-status.ts` (~line 173) — the chip-key push `keys.push('Reused')`
+  → `keys.push('Carried')` (keeps the chip count keyed consistently with
+  `cast.tsx`).
+
+### Tests
+
+No behaviour changes, so test *structure* stays; only the asserted strings flip.
+Update the exact-string assertions in:
+
+- `src/views/cast.test.tsx` — the `Matched`/`Reused` chip + badge assertions
+  (e.g. `chip(/^Reused/)` → `chip(/^Carried/)`; the lifecycle `Matched`
+  assertions that are **not** `matchedFrom`-driven stay as `Matched`).
+- `src/views/confirm-cast.test.tsx` — `getByText('Matched · 95%')` →
+  `getByText('Carried · 95%')` and the `/Matched · /` queries.
+- `src/modals/profile-drawer.test.tsx` — the reused-badge assertions.
+- `src/test/a11y.test.tsx` and `src/modals/match-detail.test.tsx` — any
+  `Reused`/`Matched · %` assertions surfaced by a repo-wide grep at
+  implementation time.
+
+**Acceptance:** a repo-wide grep for the visible strings `Reused` and
+`Matched · ` returns zero *user-facing* `matchedFrom`-driven sites afterward;
+the lifecycle `Matched` pill still renders `Matched`; all existing tests green.
+
+---
+
+## fe-41 — series-memory chip in the table view
+
+### Structural context
+
+`src/components/library/library-table.tsx` renders **per-book rows grouped by
+series**; there is no dedicated series row. Each series is a collapsible
+`<section>` whose header is a single full-width `<button>` (toggles collapse,
+carries `aria-expanded`/`aria-controls` + the book count). The `seriesMemory`
+summary lives on the `LibrarySeries` object, but the table's internal
+`SeriesGroup` currently captures only `{ id, label, authorOverride, books }` —
+it **drops** the `LibrarySeries` reference.
+
+### Changes
+
+1. **Thread the series through `SeriesGroup`.** Add `series: LibrarySeries | null`
+   (null for the synthetic `__standalones__` group). Populate it when building
+   `groups` in the `useMemo`.
+2. **Restructure the section header.** A clickable chip cannot nest inside the
+   collapse `<button>` (invalid HTML; the click would also toggle collapse).
+   Wrap the header in a flex `<div>`: the existing collapse `<button>` (left,
+   `flex-1`, all current aria + book-count preserved) and the chip as a sibling
+   (right). The chip's `onOpen` is independent of the collapse toggle.
+3. **Render the chip** when `group.series?.seriesMemory` is present, identical to
+   the grid:
+   ```tsx
+   {group.series?.seriesMemory && (
+     <SeriesMemoryChip
+       summary={group.series.seriesMemory}
+       bookCount={group.series.seriesMemory.confirmedBookCount}
+       onOpen={() => onOpenSeriesMemory?.(group.series!)}
+     />
+   )}
+   ```
+   No inline sparkline (chip-only); click opens the existing
+   `SeriesMemoryReveal`. Standalones and below-threshold series render no chip.
+4. **Prop + orchestrator wiring.** `LibraryTable` gains
+   `onOpenSeriesMemory?: (s: LibrarySeries) => void` (same signature the grid
+   already has). In `book-library.tsx`, pass
+   `onOpenSeriesMemory={(s) => setOpenSM(s)}` to `<LibraryTable>` — one line; the
+   `SeriesMemoryReveal` + `ShareCardModal` are already rendered globally and need
+   no change.
+
+### Tests
+
+Extend `src/components/library/library-table.test.tsx`:
+
+- Chip renders in the section header for a series carrying `seriesMemory`
+  (label + `confirmedBookCount`).
+- No chip for a series without `seriesMemory`, and none in the Standalones
+  section.
+- Clicking the chip fires `onOpenSeriesMemory` with the series and does **not**
+  toggle the section's collapse state.
+
+`e2e/responsive/coverage.spec.ts` already auto-runs the table at every viewport;
+no new e2e case is required for fe-41 (the chip is exercised by the grid's
+existing `e2e/series-memory.spec.ts` reveal flow, and the table render is unit
+covered).
+
+**Acceptance:** in table view, a qualifying series row shows the same chip as the
+card view; clicking it opens the reveal; standalone rows show no chip; the
+collapse toggle still works independently.
+
+---
+
+## fe-43 — PNG share-card export
+
+### Decision
+
+Capture approach: **`html-to-image`** (client-side, ~50 KB gzipped, works in
+mock mode). Chosen over `dom-to-image-more` (marginal size win, same font
+caveat) and a server-side Playwright shot (most font-faithful but server-scoped,
+no mock-mode support — wrong fit for an FE-only round).
+
+### Changes
+
+- **Dependency:** add `html-to-image` to `package.json`.
+- **`src/components/series-memory/share-card-modal.tsx`:**
+  - Put a `ref` on the `SeriesShareCard` wrapper element (the exact DOM node to
+    capture — card only, not the modal chrome).
+  - Add a **"Download image (.png)"** button beside the existing
+    "Download data (.json)" button, same pill styling family.
+  - Handler:
+    ```ts
+    await document.fonts.ready;               // ensure self-hosted woff2 loaded
+    const url = await toPng(node, { pixelRatio: 2, cacheBust: true });
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${seriesName}-series-cast.png`;
+    a.click();
+    ```
+    (filename mirrors the JSON export's `${seriesName}-series-memory.json`.)
+  - **States:** local `busy` flag → button shows a disabled "Rendering…" label
+    during capture; local `error` flag → an inline error line under the buttons
+    ("Couldn't render the image — try again.") on a rejected `toPng`. No toast
+    dependency; the modal stays self-contained.
+- Fonts (General Sans + Lora) are self-hosted, same-origin woff2, so
+  html-to-image inlines them; the `document.fonts.ready` await guards against a
+  capture firing before the faces are ready.
+
+### Tests
+
+- **Vitest** (`share-card-modal.test.tsx`): mock `html-to-image`'s `toPng`.
+  - Clicking "Download image (.png)" awaits `toPng`, creates an anchor with the
+    returned data URL and `download="${seriesName}-series-cast.png"`, and clicks
+    it (spy on `HTMLAnchorElement.prototype.click` / `createElement`).
+  - A rejected `toPng` surfaces the inline error line and re-enables the button.
+- **e2e** (`e2e/series-memory.spec.ts`): open the share card → click
+  "Download image (.png)" → assert a Playwright `download` event fires with a
+  `.png` suggested filename. Runs in mock mode.
+
+**Acceptance:** the share modal's "Download image (.png)" triggers a client-side
+download of the full `SeriesShareCard` (Castwave glyph + attribution included),
+works in mock mode, and is covered by unit + e2e tests.
+
+## Risks & mitigations
+
+- **fe-42** — blast radius is *test strings*, not logic; risk is a missed
+  assertion site, caught by `npm test`. The lifecycle-vs-carry `Matched` overload
+  is the one trap; the spec pins which sites move and which stay.
+- **fe-41** — only non-trivial bit is the header restructure; chip + modal are
+  pure reuse. Risk: breaking the collapse `aria-*` wiring — covered by the
+  "collapse still toggles independently" test.
+- **fe-43** — web-font embedding under html-to-image is the real-world risk;
+  `document.fonts.ready` + same-origin fonts mitigate it, and the e2e download
+  assertion is the proof it renders end-to-end.
+
+## Out of scope (explicit)
+
+- A real "Kept" badge / any second carry term (no backing data this round).
+- Inline sparkline in the table row (chip-only, by decision).
+- Server-side / Playwright PNG rendering.
+- `LibraryTable` column sort/resize/density (pre-existing plan 76 follow-ups).

--- a/docs/superpowers/specs/2026-06-22-fe-40-followups-design.md
+++ b/docs/superpowers/specs/2026-06-22-fe-40-followups-design.md
@@ -83,17 +83,18 @@ would be a category error.
   TypeScript build break:**
   - `src/views/cast.tsx` — update the `ReusedBadge` import (line ~19) to
     `CarriedBadge` and its usage `{reused && <CarriedBadge />}` (line ~1450);
-    update the filter-chip `CHIP_ORDER` entry and tally key `'Reused'` →
-    `'Carried'` (the string is both the Map key and the visible chip label, so
-    they move together — and `statusKeysFor` at cast.tsx:286 just wraps
-    `statusFilterKeys`, so the chip-definition key and the row-matching key stay
-    consistent once both producers are renamed); update the "Reused" comments.
+    relabel the filter chip via the existing `CHIP_LABELS` map — add
+    `Reused: 'Carried'` (the codebase idiom: its comment states "the key stays
+    stable… only the displayed text changes", cf. `Variants: 'Has variants'`).
+    The internal `'Reused'` key in `CHIP_ORDER` / `tally.set` / `statusFilterKeys`
+    stays UNCHANGED — only its display label flips; update the "Reused" comments.
   - `src/modals/profile-drawer.tsx` — update the `ReusedBadge` import (line ~22)
     to `CarriedBadge` and its usage `{reused && <CarriedBadge />}` (line ~899).
     The drawer mirrors the cast row's badge; missing it fails `tsc`.
-- `src/lib/voice-status.ts` (~line 173) — the chip-key push `keys.push('Reused')`
-  → `keys.push('Carried')` (keeps the chip count keyed consistently with
-  `cast.tsx`).
+- `src/lib/voice-status.ts` (~line 173) — `keys.push('Reused')` stays UNCHANGED
+  (internal chip key; the relabel lives only in `CHIP_LABELS`). _(An earlier spec
+  draft renamed this key; superseded by the CHIP_LABELS approach during plan
+  authoring — see plan header "Deviation from the spec".)_
 - Comments mentioning "Reused" in the touched files updated to match.
 
 **Not touched — the lifecycle `Matched` pill (separate concept, derived from

--- a/docs/superpowers/specs/2026-06-22-fe-40-followups-design.md
+++ b/docs/superpowers/specs/2026-06-22-fe-40-followups-design.md
@@ -122,11 +122,24 @@ Update the exact-string assertions in:
   **not** sites — their earlier grep hits were `matchedFrom`, not the visible
   strings.)
 
+**Visual baselines (R4-2) — fe-42 busts the `confirm` snapshot.** The visual suite
+snapshots `#/books/:id/confirm`, whose fixture cast (`src/data/characters.ts`,
+`matchedFrom` on the Eliza/Marcus seeds) renders the `Matched · N%` pill. Changing
+it to `Carried · N%` changes the rendered pixels, so `confirm.png` (and
+`confirm-dark.png`, if present) **will fail `test:e2e:visual`** — green unit tests
+won't reveal it; it surfaces at pre-push / `run-ci`. Regen these per-platform
+baselines as part of fe-42: `e2e/linux/` (CI, regen on Linux via the
+`regen-visual-baselines` workflow) **and** `e2e/win32/` (local pre-push). No other
+snapshot is affected (no `cast`/`table` snapshot exists).
+
 **Acceptance:** `npm run typecheck` is green (the `ReusedBadge → CarriedBadge`
 rename is a build concern — both `cast.tsx` and `profile-drawer.tsx` import it);
 a repo-wide grep for the visible strings `Reused` and `Matched · ` returns zero
 *user-facing* `matchedFrom`-driven sites afterward; the bare lifecycle `Matched`
-pill still renders `Matched`; all existing tests green.
+pill still renders `Matched`; the `confirm` visual baselines are regenerated; all
+tests green. **`Carried · N%` at the confirm (proposal) stage is the deliberate
+choice** (R2-4) — single-word "Carried" everywhere beats re-introducing a second
+word for the pre-confirmation moment.
 
 ---
 
@@ -147,24 +160,42 @@ it **drops** the `LibrarySeries` reference.
 1. **Thread the series through `SeriesGroup`.** Add `series: LibrarySeries | null`
    (null for the synthetic `__standalones__` group). Populate it when building
    `groups` in the `useMemo`.
-2. **Restructure the section header.** A clickable chip cannot nest inside the
-   collapse `<button>` (invalid HTML; the click would also toggle collapse).
-   Wrap the header in a flex `<div>`: the existing collapse `<button>` (left,
-   `flex-1`, all current aria + book-count preserved) and the chip as a sibling
-   (right). The chip's `onOpen` is independent of the collapse toggle.
-3. **Render the chip** when `group.series?.seriesMemory` is present, identical to
-   the grid:
+2. **Restructure the section header, responsively.** A clickable chip cannot nest
+   inside the collapse `<button>` (invalid HTML; the click would also toggle
+   collapse). Wrap the header in a flex `<div>`: the existing collapse `<button>`
+   (left, `flex-1`, all current aria + book-count preserved) and the chip as a
+   sibling. The chip's `onOpen` is independent of the collapse toggle.
+   - **Phone (`<640px`):** the wrapper is `flex-wrap` (or `flex-col sm:flex-row`)
+     so the chip drops to its own line under the collapse row rather than
+     overflowing the narrow header. The mobile protocol mandates `<640px` behave,
+     and `e2e/responsive/coverage.spec.ts` runs the table at phone width.
+3. **Compact chip variant — no books clause in the table.** Add an optional
+   `showBooks?: boolean` (default `true`) to `SeriesMemoryChip`. The grid keeps the
+   default ("Your cast · N voices, M books"); the **table passes
+   `showBooks={false}`** → "Your cast · N voices". Two reasons:
+   - **Avoids a contradictory adjacent count.** The table header already renders
+     `{group.books.length} books` (the filtered group size); the chip's own
+     `confirmedBookCount` is a *different* number, so showing both inches apart
+     reads as a bug. Dropping the chip's books clause removes the clash — the
+     header owns the book count, the chip owns the voice count.
+   - Shorter text fits the narrow header (helps step 2).
+
+   Render when `group.series?.seriesMemory` is present:
    ```tsx
    {group.series?.seriesMemory && (
      <SeriesMemoryChip
        summary={group.series.seriesMemory}
        bookCount={group.series.seriesMemory.confirmedBookCount}
+       showBooks={false}
        onOpen={() => onOpenSeriesMemory?.(group.series!)}
      />
    )}
    ```
    No inline sparkline (chip-only); click opens the existing
    `SeriesMemoryReveal`. Standalones and below-threshold series render no chip.
+   (`bookCount` stays a required prop; the table just passes it and the component
+   omits the clause when `showBooks={false}` — no separate `aria-label` needed, the
+   visible "Your cast · N voices" is a complete accessible name.)
 4. **Prop + orchestrator wiring.** `LibraryTable` gains
    `onOpenSeriesMemory?: (s: LibrarySeries) => void` (same signature the grid
    already has). In `book-library.tsx`, pass
@@ -181,33 +212,46 @@ it **drops** the `LibrarySeries` reference.
   dependency shared with the grid: a future refactor that reconstructs series
   objects would silently kill the chip in both views. The fe-41 test (below) locks
   it for the table.
-- **Count is the unfiltered series total — intentional parity with the grid.**
-  The chip shows `seriesMemory.confirmedBookCount`, which is *not* recomputed on
-  filter, so with an active search/tag filter the table can show 2 rows while the
-  chip reads "5 books." This is identical to the grid's existing behaviour, so
-  fe-41 is not a regression; it is deliberate parity, not an oversight.
+- **Table chip hides its book count (`showBooks={false}`)** so it never sits a
+  `confirmedBookCount` next to the header's filtered `group.books.length` — see
+  change 3. (The grid keeps showing books; there the chip isn't adjacent to a
+  second book count.)
 - **`onOpenSeriesMemory` needs the original `LibrarySeries`** (the reveal reads
   `series.books[0].author` + `series.name`). Pass `group.series` — the original
   object threaded in step 1 — not a reconstructed one.
 
 ### Tests
 
-Extend `src/components/library/library-table.test.tsx`:
+Extend `src/components/library/library-table.test.tsx` (the table *renders* what
+it's given — it does not filter, so these prove rendering, not preservation):
 
-- Chip renders in the section header for a series carrying `seriesMemory`
-  (label + `confirmedBookCount`).
+- Chip renders in the section header for a series carrying `seriesMemory`, showing
+  the compact text "Your cast · N voices" (**no** books clause).
 - No chip for a series without `seriesMemory`, and none in the Standalones
   section.
 - Clicking the chip fires `onOpenSeriesMemory` with the series and does **not**
   toggle the section's collapse state.
-- **Chip survives an active filter** — render the table with a search/tag filter
-  that narrows a qualifying series' `books`, and assert the chip still shows (locks
-  the `{ ...series }` filter-preservation invariant above).
+- **Query scoping (R3-2):** the section now contains two buttons (collapse + chip).
+  New chip assertions must target `getByTestId('series-memory-chip')` (or the chip's
+  exact accessible name), **not** a loose `getByRole('button', { name: /…/ })`, or
+  they'll throw "multiple elements." Existing collapse-toggle tests stay green —
+  their fixtures carry no `seriesMemory`, so no chip renders there.
+
+**Filter-preservation invariant lives one layer up (R2-2).** `LibraryTable` can't
+prove the orchestrator's filter keeps `seriesMemory` — it never filters. Add the
+assertion where the spread happens: a test that runs `filteredAuthors`' logic (an
+orchestrator-level test in `book-library`, or a `library-slice` test if `filterBooks`
+is exercised there) and asserts a series retains `seriesMemory` after an active
+search/tag filter narrows its `books`.
 
 `e2e/responsive/coverage.spec.ts` already auto-runs the table at every viewport;
 no new e2e case is required for fe-41 (the chip is exercised by the grid's
 existing `e2e/series-memory.spec.ts` reveal flow, and the table render is unit
 covered).
+
+**Visual baselines:** fe-41 busts **none** — the visual suite has no `cast`/`table`
+snapshot, and `library.png` defaults to card view (whose grid chip already shipped
+in fe-40's baseline). No regen for fe-41.
 
 **Acceptance:** in table view, a qualifying series row shows the same chip as the
 card view; clicking it opens the reveal; standalone rows show no chip; the
@@ -228,12 +272,23 @@ no mock-mode support — wrong fit for an FE-only round).
 
 - **Dependency:** add `html-to-image` to `package.json`.
 - **`src/components/series-memory/share-card-modal.tsx`:**
-  - Put a `ref` on the `SeriesShareCard` wrapper element (the exact DOM node to
-    capture — card only, not the modal chrome).
+  - **Ref strategy (R2-1):** `SeriesShareCard` is a plain component, **not** a
+    `forwardRef`, so there's no node to hand `toPng`. The **surgical** approach is
+    for the modal to wrap `<SeriesShareCard/>` in its own ref'd `<div>` — *don't*
+    modify the shipped card component. The wrapper must be `w-full max-w-sm` so the
+    card (its own `mx-auto max-w-sm`, self-contained `bg-[#1b1714]` — verified
+    series-share-card.tsx:23) fills it edge-to-edge with **no transparent margin**;
+    capture `wrapperRef.current`. No `backgroundColor` capture option needed (the
+    card paints its own background).
   - Add a **"Download image (.png)"** button beside the existing
     "Download data (.json)" button, same pill styling family.
+  - **Lazy-load the lib (R4-1).** `ShareCardModal` is a *static* import in
+    `book-library.tsx`, so a static `import { toPng } from 'html-to-image'` would
+    pull ~50 KB gz into the library chunk for everyone. Dynamic-import it inside the
+    handler instead — it only loads when a user actually exports.
   - Handler:
     ```ts
+    const { toPng } = await import('html-to-image');   // lazy — keeps 50KB off the library chunk
     await document.fonts?.ready;              // optional-chain: jsdom has no document.fonts
     const url = await toPng(node, { pixelRatio: 2, cacheBust: true });
     const a = document.createElement('a');
@@ -254,9 +309,15 @@ no mock-mode support — wrong fit for an FE-only round).
     and the existing JSON download in this file — a one-liner that fixes both
     rather than propagating the bug. (Scoped to this file; not a new module.)
   - **States:** local `busy` flag → button shows a disabled "Rendering…" label
-    during capture; local `error` flag → an inline error line under the buttons
-    ("Couldn't render the image — try again.") on a rejected `toPng`. No toast
-    dependency; the modal stays self-contained.
+    during capture (also blocks double-fire); local `error` flag → an inline error
+    line under the buttons ("Couldn't render the image — try again.") on a rejected
+    `toPng`/`import`. **The error line carries `role="alert"` (R3-3)** so a
+    screen-reader user hears the failure — axe won't flag a missing live region, so
+    this only happens if specified. No toast dependency; the modal stays
+    self-contained.
+  - **Filename stem (R3-4):** PNG is `…-series-cast.png` vs the JSON's
+    `…-series-memory.json` — a deliberate distinction (the card is the *cast* story;
+    the JSON is the full *memory* detail), not an oversight.
 - Fonts (General Sans + Lora) are self-hosted, same-origin woff2, so
   html-to-image inlines them; the `document.fonts?.ready` await guards against a
   capture firing before the faces are ready.
@@ -272,9 +333,13 @@ no mock-mode support — wrong fit for an FE-only round).
   - `slugifyFilename` replaces illegal characters (assert a `seriesName` with `:`
     / `/` yields a safe `.png` *and* `.json` filename — covers the shared helper
     on both downloads).
-- **e2e** (`e2e/series-memory.spec.ts`): open the share card → click
-  "Download image (.png)" → assert a Playwright `download` event fires with a
-  `.png` suggested filename. Runs in mock mode.
+- **e2e** (`e2e/series-memory.spec.ts`): wrap the click in
+  `page.waitForEvent('download')`, open the share card → click "Download image
+  (.png)" → assert the `download` fires with a `.png` suggested filename. Runs in
+  mock mode. **This proves the wire, not pixel fidelity** — `toPng` yields a PNG
+  even on font fallback, so a green e2e means "the export button works end-to-end,"
+  not "fonts embedded perfectly." (`vi.mock('html-to-image')` still intercepts the
+  dynamic `import()` in the unit test — no change to the mock approach.)
 
 **Acceptance:** the share modal's "Download image (.png)" triggers a client-side
 download of the full `SeriesShareCard` (Castwave glyph + attribution included),
@@ -282,17 +347,23 @@ works in mock mode, and is covered by unit + e2e tests.
 
 ## Risks & mitigations
 
-- **fe-42** — two failure modes: (a) the `ReusedBadge → CarriedBadge` export
+- **fe-42** — three failure modes: (a) the `ReusedBadge → CarriedBadge` export
   rename is a **build break** if either importer (`cast.tsx`, `profile-drawer.tsx`)
   is missed — caught by `npm run typecheck`; (b) a missed test-string assertion —
-  caught by `npm test`. The lifecycle-vs-carry `Matched` overload is the
-  interpretation trap; the spec pins which sites move and which stay.
-- **fe-41** — only non-trivial bit is the header restructure; chip + modal are
-  pure reuse. Risk: breaking the collapse `aria-*` wiring — covered by the
-  "collapse still toggles independently" test.
+  caught by `npm test`; (c) the **`confirm` visual baseline bust** — *not* caught by
+  unit tests, only at pre-push/`run-ci`; the spec mandates regenerating
+  `confirm.png`/`confirm-dark.png` for `e2e/linux` + `e2e/win32`. The
+  lifecycle-vs-carry `Matched` overload is the interpretation trap; the spec pins
+  which sites move and which stay.
+- **fe-41** — non-trivial bits are the header restructure (risk: breaking the
+  collapse `aria-*` wiring — covered by the "collapse still toggles independently"
+  test) and the `showBooks` prop (keep the grid's default behaviour unchanged —
+  covered by the grid's existing chip tests staying green). Busts no visual
+  baseline.
 - **fe-43** — web-font embedding under html-to-image is the real-world risk;
-  `document.fonts.ready` + same-origin fonts mitigate it, and the e2e download
-  assertion is the proof it renders end-to-end.
+  `document.fonts?.ready` + same-origin fonts mitigate it; the e2e download
+  assertion proves the wire (not pixel fidelity). The lazy `import()` keeps the
+  ~50 KB off the library chunk.
 
 ## Out of scope (explicit)
 

--- a/e2e/series-memory.spec.ts
+++ b/e2e/series-memory.spec.ts
@@ -54,4 +54,19 @@ test.describe('series-memory: chip → reveal → share card', () => {
     /* Footer of the share card carries the branding. */
     await expect(shareCard.getByText('castwright.ai')).toBeVisible();
   });
+
+  test('share card exports a PNG download', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('button', { name: /Start a new book/i }).first()).toBeVisible({ timeout: 10_000 });
+    await page.getByTestId('series-memory-chip').first().click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    await dialog.getByText('Share this cast').click();
+    await expect(page.getByTestId('series-share-card')).toBeVisible({ timeout: 5_000 });
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: /download image \(\.png\)/i }).click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/\.png$/);
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@reduxjs/toolkit": "^2.5.0",
         "@tanstack/react-virtual": "^3.13.25",
         "@types/qrcode": "^1.5.6",
+        "html-to-image": "^1.11.13",
         "qrcode": "^1.5.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -4851,6 +4852,12 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@reduxjs/toolkit": "^2.5.0",
     "@tanstack/react-virtual": "^3.13.25",
     "@types/qrcode": "^1.5.6",
+    "html-to-image": "^1.11.13",
     "qrcode": "^1.5.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/components/library/library-table.test.tsx
+++ b/src/components/library/library-table.test.tsx
@@ -12,7 +12,7 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import { librarySlice } from '../../store/library-slice';
 import { accountSlice } from '../../store/account-slice';
 import { LibraryTable } from './library-table';
-import type { LibraryAuthor, LibraryBook } from '../../lib/types';
+import type { LibraryAuthor, LibraryBook, LibrarySeries } from '../../lib/types';
 
 function makeBook(over: Partial<LibraryBook> & Pick<LibraryBook, 'bookId' | 'title'>): LibraryBook {
   const base: LibraryBook = {
@@ -46,6 +46,7 @@ function renderTable(opts: {
   onReplaceManuscript?: (b: LibraryBook, file: File) => void;
   onEditBook?: (b: LibraryBook) => Promise<void>;
   onStartNew?: () => void;
+  onOpenSeriesMemory?: (s: LibrarySeries) => void;
 }) {
   const store = configureStore({
     reducer: { account: accountSlice.reducer, library: librarySlice.reducer },
@@ -72,6 +73,7 @@ function renderTable(opts: {
         onReplaceManuscript={opts.onReplaceManuscript ?? vi.fn()}
         onEditBook={opts.onEditBook ?? vi.fn().mockResolvedValue(undefined)}
         onStartNew={opts.onStartNew ?? vi.fn()}
+        onOpenSeriesMemory={opts.onOpenSeriesMemory}
       />
     </Provider>,
   );
@@ -340,5 +342,57 @@ describe('LibraryTable — interactions', () => {
     expect(onReplaceManuscript).toHaveBeenCalledTimes(1);
     expect(onReplaceManuscript.mock.calls[0][0]).toBe(book);
     expect(onReplaceManuscript.mock.calls[0][1]).toBe(file);
+  });
+});
+
+const SUMMARY = {
+  carriedCount: 8, bespokeCount: 5, designedCount: 5,
+  confirmedBookCount: 3, spanBooks: 3, perBook: [],
+};
+
+describe('LibraryTable — series-memory chip (fe-41)', () => {
+  const authorsWith = (seriesMemory: typeof SUMMARY | undefined): LibraryAuthor[] => [
+    {
+      name: 'Marin Vale',
+      series: [
+        {
+          name: 'Northern Coast Trilogy',
+          seriesMemory,
+          books: [makeBook({ bookId: 'n1', title: 'North One', seriesPosition: 1 })],
+        },
+      ],
+    },
+  ];
+
+  it('renders the compact chip (no books clause) for a series with seriesMemory', () => {
+    renderTable({ authors: authorsWith(SUMMARY) });
+    const chip = screen.getByTestId('series-memory-chip');
+    expect(chip).toHaveTextContent('Your cast · 8 voices');
+    expect(chip).not.toHaveTextContent('books');
+  });
+
+  it('renders no chip when the series has no seriesMemory', () => {
+    renderTable({ authors: authorsWith(undefined) });
+    expect(screen.queryByTestId('series-memory-chip')).toBeNull();
+  });
+
+  it('renders no chip in the Standalones section', () => {
+    const authors: LibraryAuthor[] = [
+      { name: 'A', series: [{ name: 'S', seriesMemory: SUMMARY,
+        books: [makeBook({ bookId: 's1', title: 'Solo', isStandalone: true })] }] },
+    ];
+    renderTable({ authors });
+    expect(screen.queryByTestId('series-memory-chip')).toBeNull();
+  });
+
+  it('clicking the chip fires onOpenSeriesMemory without toggling collapse', () => {
+    const onOpenSeriesMemory = vi.fn();
+    renderTable({ authors: authorsWith(SUMMARY), onOpenSeriesMemory });
+    // chip scoped by testid (the section also has the collapse button) — R3-2
+    fireEvent.click(screen.getByTestId('series-memory-chip'));
+    expect(onOpenSeriesMemory).toHaveBeenCalledTimes(1);
+    expect(onOpenSeriesMemory.mock.calls[0][0].name).toBe('Northern Coast Trilogy');
+    // collapse did NOT fire: the book row is still present
+    expect(screen.getByText('North One')).toBeInTheDocument();
   });
 });

--- a/src/components/library/library-table.tsx
+++ b/src/components/library/library-table.tsx
@@ -35,9 +35,10 @@ import { EditBookMetaModal, type EditBookMetaPatch } from '../../modals/edit-boo
 import { CoverPicker } from '../../modals/cover-picker';
 import { computeCoverStyle } from '../../lib/cover-framing';
 import { safeImageSrc } from '../../lib/safe-url';
-import type { LibraryAuthor, LibraryBook } from '../../lib/types';
+import type { LibraryAuthor, LibraryBook, LibrarySeries } from '../../lib/types';
 import { STATUS_UI } from './library-status-ui';
 import { EmptyLibrary, LibrarySkeleton, NoFilterMatch } from './library-empty-states';
+import { SeriesMemoryChip } from '../series-memory/series-memory-chip';
 
 interface Props {
   loaded: boolean;
@@ -53,6 +54,7 @@ interface Props {
   onEditBook: (book: LibraryBook, patch: EditBookMetaPatch) => Promise<void>;
   onCoverChanged?: (book: LibraryBook) => Promise<void> | void;
   onStartNew: () => void;
+  onOpenSeriesMemory?: (s: LibrarySeries) => void;
 }
 
 interface SeriesGroup {
@@ -67,6 +69,9 @@ interface SeriesGroup {
       hides the author cell to avoid duplicating it after a series header
       that already names one author. */
   authorOverride: string | null;
+  /** Original LibrarySeries (for the series-memory chip + reveal); null for
+      the synthetic Standalones group. */
+  series: LibrarySeries | null;
   books: LibraryBook[];
 }
 
@@ -82,6 +87,7 @@ export function LibraryTable({
   onEditBook,
   onCoverChanged,
   onStartNew,
+  onOpenSeriesMemory,
 }: Props) {
   /* Group the post-filter authors into the renderable series list, then
      append a synthetic Standalones group at the bottom (no header dupe
@@ -103,6 +109,7 @@ export function LibraryTable({
             id: `${author.name}::${series.name}`,
             label: `${author.name} — ${series.name}`,
             authorOverride: null,
+            series,
             books: groupBooks,
           });
         }
@@ -115,6 +122,7 @@ export function LibraryTable({
         /* Standalones span every author with at least one standalone —
            keep the author column in the table to disambiguate. */
         authorOverride: 'show',
+        series: null,
         books: standalones,
       });
     }
@@ -138,27 +146,37 @@ export function LibraryTable({
         const isCollapsed = collapsed[group.id] === true;
         return (
           <section key={group.id} data-testid={`library-table-section-${group.id}`}>
-            <button
-              type="button"
-              onClick={() => setCollapsed((m) => ({ ...m, [group.id]: !isCollapsed }))}
-              aria-expanded={!isCollapsed}
-              aria-controls={`library-table-body-${group.id}`}
-              className="w-full flex items-center justify-between gap-3 mb-3 px-1 py-1 rounded-lg hover:bg-ink/3 transition-colors"
-            >
-              <span className="inline-flex items-center gap-2">
-                {isCollapsed ? (
-                  <IconChevR className="w-3.5 h-3.5 text-ink/60" />
-                ) : (
-                  <IconArrowDn className="w-3.5 h-3.5 text-ink/60" />
-                )}
-                <span className="text-[11px] uppercase tracking-[0.18em] font-semibold text-ink/55">
-                  {group.label}
+            <div className="flex flex-wrap items-center gap-2 mb-3">
+              <button
+                type="button"
+                onClick={() => setCollapsed((m) => ({ ...m, [group.id]: !isCollapsed }))}
+                aria-expanded={!isCollapsed}
+                aria-controls={`library-table-body-${group.id}`}
+                className="flex-1 min-w-0 flex items-center justify-between gap-3 px-1 py-1 rounded-lg hover:bg-ink/3 transition-colors"
+              >
+                <span className="inline-flex items-center gap-2 min-w-0">
+                  {isCollapsed ? (
+                    <IconChevR className="w-3.5 h-3.5 text-ink/60" />
+                  ) : (
+                    <IconArrowDn className="w-3.5 h-3.5 text-ink/60" />
+                  )}
+                  <span className="text-[11px] uppercase tracking-[0.18em] font-semibold text-ink/55 truncate">
+                    {group.label}
+                  </span>
                 </span>
-              </span>
-              <span className="text-[11px] text-ink/40">
-                {group.books.length} {group.books.length === 1 ? 'book' : 'books'}
-              </span>
-            </button>
+                <span className="text-[11px] text-ink/40 shrink-0">
+                  {group.books.length} {group.books.length === 1 ? 'book' : 'books'}
+                </span>
+              </button>
+              {group.series?.seriesMemory && (
+                <SeriesMemoryChip
+                  summary={group.series.seriesMemory}
+                  bookCount={group.series.seriesMemory.confirmedBookCount}
+                  showBooks={false}
+                  onOpen={() => onOpenSeriesMemory?.(group.series!)}
+                />
+              )}
+            </div>
             {!isCollapsed && (
               <div
                 id={`library-table-body-${group.id}`}

--- a/src/components/primitives.tsx
+++ b/src/components/primitives.tsx
@@ -218,19 +218,19 @@ export function Pill({ children, color = 'neutral' }: { children: ReactNode; col
 }
 
 /* Small provenance badge — sits beside the lifecycle status pill (the "tag")
-   to mark a character whose voice was reused/matched from a prior book in the
+   to mark a character whose voice was carried from a prior book in the
    series. Orthogonal to the lifecycle state (Designed/Generated/Tuned/Locked)
    so both can show at once. Deliberately lighter-weight than `Pill` (smaller
    text, no border) so it reads as a secondary marker, not a second tag. */
-export function ReusedBadge() {
+export function CarriedBadge() {
   return (
     <span
       data-testid="reused-badge"
-      title="Voice reused from a prior book in this series"
+      title="Voice carried from a prior book in this series"
       className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium text-purple-deep/70 bg-purple-deep/4"
     >
       <IconLink className="w-2.5 h-2.5" />
-      Reused
+      Carried
     </span>
   );
 }

--- a/src/components/series-memory/series-memory-chip.test.tsx
+++ b/src/components/series-memory/series-memory-chip.test.tsx
@@ -15,4 +15,22 @@ describe('SeriesMemoryChip', () => {
     fireEvent.click(screen.getByTestId('series-memory-chip'));
     expect(onOpen).toHaveBeenCalledOnce();
   });
+  it('omits the books clause when showBooks is false', () => {
+    const testSummary = {
+      carriedCount: 8, bespokeCount: 5, designedCount: 5,
+      confirmedBookCount: 3, spanBooks: 3, perBook: [],
+    };
+    render(<SeriesMemoryChip summary={testSummary} bookCount={3} showBooks={false} onOpen={() => {}} />);
+    const chip = screen.getByTestId('series-memory-chip');
+    expect(chip).toHaveTextContent('Your cast · 8 voices');
+    expect(chip).not.toHaveTextContent('books');
+  });
+  it('keeps the books clause by default', () => {
+    const testSummary = {
+      carriedCount: 8, bespokeCount: 5, designedCount: 5,
+      confirmedBookCount: 3, spanBooks: 3, perBook: [],
+    };
+    render(<SeriesMemoryChip summary={testSummary} bookCount={3} onOpen={() => {}} />);
+    expect(screen.getByTestId('series-memory-chip')).toHaveTextContent('Your cast · 8 voices, 3 books');
+  });
 });

--- a/src/components/series-memory/series-memory-chip.tsx
+++ b/src/components/series-memory/series-memory-chip.tsx
@@ -1,8 +1,8 @@
 import type { SeriesMemorySummary } from '../../lib/types';
 import { CastwaveGlyph } from '../../lib/castwave-glyph';
 
-export function SeriesMemoryChip({ summary, bookCount, onOpen }: {
-  summary: SeriesMemorySummary; bookCount: number; onOpen: () => void;
+export function SeriesMemoryChip({ summary, bookCount, showBooks = true, onOpen }: {
+  summary: SeriesMemorySummary; bookCount: number; showBooks?: boolean; onOpen: () => void;
 }) {
   return (
     <button
@@ -12,7 +12,7 @@ export function SeriesMemoryChip({ summary, bookCount, onOpen }: {
       className="inline-flex items-center gap-1.5 rounded-full px-3 min-h-[44px] sm:min-h-0 sm:py-1 text-xs font-semibold text-white dark:text-ink bg-gradient-to-r from-magenta to-peach hover:-translate-y-px transition-transform"
     >
       <CastwaveGlyph className="w-3.5 h-3.5" />
-      Your cast · {summary.carriedCount} voices, {bookCount} books
+      Your cast · {summary.carriedCount} voices{showBooks ? `, ${bookCount} books` : ''}
     </button>
   );
 }

--- a/src/components/series-memory/share-card-modal.test.tsx
+++ b/src/components/series-memory/share-card-modal.test.tsx
@@ -1,7 +1,11 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import { ShareCardModal } from './share-card-modal';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ShareCardModal, slugifyFilename } from './share-card-modal';
 import type { SeriesMemoryDetail } from '../../lib/types';
+
+vi.mock('html-to-image', () => ({
+  toPng: vi.fn().mockResolvedValue('data:image/png;base64,AAAA'),
+}));
 
 const detail: SeriesMemoryDetail = {
   series: { confirmedBookCount: 3, spanBooks: 3, books: [] },
@@ -27,14 +31,34 @@ const detail: SeriesMemoryDetail = {
 };
 
 describe('ShareCardModal', () => {
-  it('renders the card and the zero-dep JSON download (no PNG dep in v1)', () => {
+  it('renders the card and the zero-dep JSON download', () => {
     render(<ShareCardModal detail={detail} seriesName="X" onClose={() => {}} />);
     expect(screen.getByTestId('series-share-card')).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /download data \(\.json\)/i }),
     ).toBeInTheDocument();
-    // PNG download is a gated follow-up (requires html-to-image dep sign-off)
-    expect(screen.queryByRole('button', { name: /download image/i })).toBeNull();
+  });
+
+  it('renders the Download image (.png) button', () => {
+    render(<ShareCardModal detail={detail} seriesName="X" onClose={() => {}} />);
+    expect(screen.getByRole('button', { name: /download image \(\.png\)/i })).toBeInTheDocument();
+  });
+
+  it('captures the card and triggers a .png download on click', async () => {
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    render(<ShareCardModal detail={detail} seriesName="X" onClose={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /download image \(\.png\)/i }));
+    const { toPng } = await import('html-to-image');
+    await waitFor(() => expect(toPng).toHaveBeenCalled());
+    await waitFor(() => expect(click).toHaveBeenCalled());
+  });
+
+  it('surfaces an alert when capture fails', async () => {
+    const { toPng } = await import('html-to-image');
+    (toPng as unknown as { mockRejectedValueOnce: (e: Error) => void }).mockRejectedValueOnce(new Error('boom'));
+    render(<ShareCardModal detail={detail} seriesName="X" onClose={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /download image \(\.png\)/i }));
+    expect(await screen.findByRole('alert')).toHaveTextContent(/couldn't render/i);
   });
 
   it('is a dialog with aria-modal', () => {
@@ -69,5 +93,13 @@ describe('ShareCardModal', () => {
   it('shows the fallback footer when owner is an empty string', () => {
     render(<ShareCardModal detail={detail} seriesName="X" owner="" onClose={() => {}} />);
     expect(screen.getByText("Your cast · kept true")).toBeInTheDocument();
+  });
+});
+
+describe('slugifyFilename', () => {
+  it('replaces filename-illegal characters with a single dash', () => {
+    expect(slugifyFilename('Marin Vale: North/Coast')).toBe('Marin Vale- North-Coast');
+    expect(slugifyFilename('A::B')).toBe('A-B');
+    expect(slugifyFilename('')).toBe('series');
   });
 });

--- a/src/components/series-memory/share-card-modal.tsx
+++ b/src/components/series-memory/share-card-modal.tsx
@@ -1,14 +1,18 @@
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { SeriesMemoryDetail } from '../../lib/types';
 import { IconClose } from '../../lib/icons';
 import { SeriesShareCard } from './series-share-card';
+
+export function slugifyFilename(s: string): string {
+  return s.replace(/[\\/:*?"<>|]+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '') || 'series';
+}
 
 function downloadJson(detail: SeriesMemoryDetail, seriesName: string) {
   const blob = new Blob([JSON.stringify(detail, null, 2)], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = `${seriesName}-series-memory.json`;
+  a.download = `${slugifyFilename(seriesName)}-series-memory.json`;
   a.click();
   URL.revokeObjectURL(url);
 }
@@ -24,6 +28,10 @@ export function ShareCardModal({
   owner?: string;
   onClose: () => void;
 }) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(false);
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
@@ -31,6 +39,26 @@ export function ShareCardModal({
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
   }, [onClose]);
+
+  async function downloadPng() {
+    const node = cardRef.current;
+    if (!node) return;
+    setBusy(true);
+    setError(false);
+    try {
+      const { toPng } = await import('html-to-image');
+      await document.fonts?.ready;
+      const url = await toPng(node, { pixelRatio: 2, cacheBust: true });
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${slugifyFilename(seriesName)}-series-cast.png`;
+      a.click();
+    } catch {
+      setError(true);
+    } finally {
+      setBusy(false);
+    }
+  }
 
   return (
     <div
@@ -59,17 +87,30 @@ export function ShareCardModal({
           Share series memory card for {seriesName}
         </p>
 
-        <SeriesShareCard detail={detail} seriesName={seriesName} owner={owner} />
+        <div ref={cardRef} className="w-full max-w-sm mx-auto">
+          <SeriesShareCard detail={detail} seriesName={seriesName} owner={owner} />
+        </div>
 
-        <div className="mt-4 flex justify-center">
+        <div className="mt-4 flex flex-wrap justify-center gap-2">
           <button
             onClick={() => downloadJson(detail, seriesName)}
             className="rounded-full px-5 py-2.5 font-semibold text-ink bg-gradient-to-r from-magenta to-peach"
           >
             Download data (.json)
           </button>
+          <button
+            onClick={downloadPng}
+            disabled={busy}
+            className="rounded-full px-5 py-2.5 font-semibold text-cream border border-cream/30 hover:bg-white/10 disabled:opacity-60"
+          >
+            {busy ? 'Rendering…' : 'Download image (.png)'}
+          </button>
         </div>
-        {/* PNG download button is a gated follow-up pending html-to-image dep sign-off. */}
+        {error && (
+          <p role="alert" className="mt-2 text-center text-xs text-peach">
+            Couldn't render the image — try again.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/src/modals/profile-drawer.test.tsx
+++ b/src/modals/profile-drawer.test.tsx
@@ -1534,7 +1534,7 @@ describe('ProfileDrawer reused Qwen voice (drawer/table parity)', () => {
     expect(playBtn.disabled).toBe(false);
   });
 
-  it('shows the lifecycle pill and the Reused badge together', () => {
+  it('shows the lifecycle pill and the Carried badge together', () => {
     renderReused();
     /* voice.generated === true ⇒ "Generated" lifecycle; matchedFrom ⇒ badge. */
     expect(screen.getByText('Generated')).toBeTruthy();

--- a/src/modals/profile-drawer.tsx
+++ b/src/modals/profile-drawer.tsx
@@ -19,7 +19,7 @@ import {
   VoiceSwatch,
   Pill,
   PrimaryButton,
-  ReusedBadge,
+  CarriedBadge,
   VariantsBadge,
 } from '../components/primitives';
 import { resolveVoiceStatus } from '../lib/voice-status';
@@ -885,9 +885,9 @@ export function ProfileDrawer({
                 Voice profile
               </p>
               <div className="flex items-center gap-2">
-                {/* Lifecycle pill + Reused badge, resolved the same way as the
+                {/* Lifecycle pill + Carried badge, resolved the same way as the
                     cast view's Status column so the two surfaces agree (a
-                    reused Qwen voice shows "Designed/Generated · Reused"). The
+                    reused Qwen voice shows "Designed/Generated · Carried"). The
                     4th arg (fe-16) surfaces "Fallback (Kokoro)" when this
                     character actually rendered in Kokoro last generation. */}
                 {(() => {
@@ -896,7 +896,7 @@ export function ProfileDrawer({
                   return (
                     <>
                       {lifecycle && <Pill color={lifecycle.color}>{lifecycle.label}</Pill>}
-                      {reused && <ReusedBadge />}
+                      {reused && <CarriedBadge />}
                       {hasEmotionVariants && <VariantsBadge count={variantCount} />}
                     </>
                   );

--- a/src/views/book-library.test.tsx
+++ b/src/views/book-library.test.tsx
@@ -11,7 +11,7 @@ import { tourSlice } from '../store/tour-slice';
 import { uiSlice } from '../store/ui-slice';
 import { continueListeningSlice } from '../store/continue-listening-slice';
 import { notificationsSlice } from '../store/notifications-slice';
-import { BookLibraryView } from './book-library';
+import { BookLibraryView, applyLibraryFilters } from './book-library';
 import type { ActiveAnalysisSummary, LibraryAuthor, LibraryBook } from '../lib/types';
 
 import type { ContinueItem } from '../store/continue-listening-slice';
@@ -875,5 +875,55 @@ describe('BookLibraryView — loading affordance', () => {
     expect(
       screen.getByRole('heading', { level: 2, name: 'Della Renwick' }),
     ).toBeInTheDocument();
+  });
+});
+
+/* Helper for pure-function tests — mirrors makeBook in library-table.test.tsx */
+function makeLibBook(over: Partial<LibraryBook> & Pick<LibraryBook, 'bookId' | 'title'>): LibraryBook {
+  const base: LibraryBook = {
+    bookId: over.bookId,
+    title: over.title,
+    author: 'Marin Vale',
+    series: 'Northern Coast Trilogy',
+    seriesPosition: 1,
+    isStandalone: false,
+    status: 'complete',
+    chapterCount: 10,
+    completedChapters: 10,
+    characterCount: 5,
+    voiceCount: 5,
+    lastWorkedOn: 'today',
+    coverGradient: ['#000', '#fff'],
+    runtime: '5h 0m',
+    tags: [],
+  };
+  return { ...base, ...over };
+}
+
+describe('applyLibraryFilters', () => {
+  it('preserves seriesMemory when a search narrows the books', () => {
+    const summary = {
+      carriedCount: 8, bespokeCount: 5, designedCount: 5,
+      confirmedBookCount: 3, spanBooks: 3, perBook: [],
+    };
+    const authors: LibraryAuthor[] = [
+      {
+        name: 'Marin Vale',
+        series: [
+          {
+            name: 'Northern Coast Trilogy',
+            seriesMemory: summary,
+            books: [
+              makeLibBook({ bookId: 'n1', title: 'North One' }),
+              makeLibBook({ bookId: 'n2', title: 'North Two' }),
+            ],
+          },
+        ],
+      },
+    ];
+    const out = applyLibraryFilters(authors, { filter: 'all', search: 'North One', tags: [], languages: [] });
+    // search narrowed books 2→1 but the series object kept its seriesMemory:
+    expect(out[0].series[0].books).toHaveLength(1);
+    expect(out[0].series[0].seriesMemory).toEqual(summary);
   });
 });

--- a/src/views/book-library.tsx
+++ b/src/views/book-library.tsx
@@ -106,6 +106,28 @@ function matchesFilter(book: LibraryBook, filter: Filter): boolean {
   return true;
 }
 
+export function applyLibraryFilters(
+  authors: LibraryAuthor[],
+  opts: { filter: Filter; search: string; tags: string[]; languages: string[] },
+): LibraryAuthor[] {
+  return authors
+    .map((author) => ({
+      ...author,
+      series: author.series
+        .map((series) => ({
+          ...series,
+          books: filterBooks(
+            series.books.filter((b) => matchesFilter(b, opts.filter)),
+            opts.search,
+            opts.tags,
+            opts.languages,
+          ),
+        }))
+        .filter((series) => series.books.length > 0),
+    }))
+    .filter((author) => author.series.length > 0);
+}
+
 export function BookLibraryView({
   authors,
   activeBookId,
@@ -311,24 +333,16 @@ export function BookLibraryView({
      boundary so <LibraryGrid /> stays a pure render of whatever it's
      handed. Series with no matching books are dropped, and authors with
      no matching series collapse out entirely — same pre-split semantics. */
-  const filteredAuthors = useMemo<LibraryAuthor[]>(() => {
-    return authors
-      .map((author) => ({
-        ...author,
-        series: author.series
-          .map((series) => ({
-            ...series,
-            books: filterBooks(
-              series.books.filter((b) => matchesFilter(b, filter)),
-              debouncedSearch,
-              activeTags,
-              activeLanguages,
-            ),
-          }))
-          .filter((series) => series.books.length > 0),
-      }))
-      .filter((author) => author.series.length > 0);
-  }, [authors, filter, debouncedSearch, activeTags, activeLanguages]);
+  const filteredAuthors = useMemo<LibraryAuthor[]>(
+    () =>
+      applyLibraryFilters(authors, {
+        filter,
+        search: debouncedSearch,
+        tags: activeTags,
+        languages: activeLanguages,
+      }),
+    [authors, filter, debouncedSearch, activeTags, activeLanguages],
+  );
 
   const matchedBookCount = useMemo(
     () =>
@@ -429,6 +443,7 @@ export function BookLibraryView({
             onEditBook={onEditBook}
             onCoverChanged={onCoverChanged}
             onStartNew={onStartNew}
+            onOpenSeriesMemory={(s) => setOpenSM(s)}
           />
         </div>
       )}

--- a/src/views/cast.test.tsx
+++ b/src/views/cast.test.tsx
@@ -539,12 +539,12 @@ describe('CastView Qwen status pill (plan 117)', () => {
     );
   });
 
-  it('renders the lifecycle pill and the Reused badge as separate, coexisting markers', () => {
+  it('renders the lifecycle pill and the Carried badge as separate, coexisting markers', () => {
     renderView();
     /* marrow: coqui, voiceState 'generated', no match → "Matched" pill only.
        narrator: coqui voice, voiceState 'reused' + matchedFrom → "Matched"
-       lifecycle pill AND a Reused provenance badge (they no longer collapse
-       into a single "Reused" pill). */
+       lifecycle pill AND a Carried provenance badge (they no longer collapse
+       into a single "Carried" pill). */
     const marrowRow = rowFor('Mr. Marrow');
     expect(within(marrowRow).getByText('Matched')).toBeInTheDocument();
     expect(within(marrowRow).queryByTestId('reused-badge')).toBeNull();
@@ -552,14 +552,15 @@ describe('CastView Qwen status pill (plan 117)', () => {
     const narratorRow = rowFor('Narrator');
     expect(within(narratorRow).getByText('Matched')).toBeInTheDocument();
     expect(within(narratorRow).getByTestId('reused-badge')).toBeInTheDocument();
+    expect(within(narratorRow).getByText('Carried')).toBeInTheDocument();
   });
 
-  it('shows "Generated · Reused" together for a reused Qwen voice', () => {
+  it('shows "Generated · Carried" together for a reused Qwen voice', () => {
     /* The real-world case the badge split fixes: a character reused from a
        prior book whose matched library voice is a bespoke Qwen voice. The
        provenance lives on `matchedFrom`; the Qwen lifecycle on the matched
        voice (its `generated` flag) — both must render, where the old single
-       pill showed only "Reused". */
+       pill showed only "Carried". */
     const reusedQwen: Character = { ...narrator, voiceId: 'v_qwen_narrator' };
     const qwenLib: Voice[] = [
       {
@@ -579,6 +580,7 @@ describe('CastView Qwen status pill (plan 117)', () => {
     const row = rowFor('Narrator');
     expect(within(row).getByText('Generated')).toBeInTheDocument();
     expect(within(row).getByTestId('reused-badge')).toBeInTheDocument();
+    expect(within(row).getByText('Carried')).toBeInTheDocument();
   });
 
   it('renders a Qwen row without throwing when the library is empty (defensive)', () => {
@@ -1121,7 +1123,7 @@ describe('CastView status filter', () => {
     expect(chip(/^Needs voice/).textContent).toContain('1');
     expect(chip(/^Matched/).textContent).toContain('2'); // narrator + marrow
     expect(chip(/^Unset/).textContent).toContain('1');
-    expect(chip(/^Reused/).textContent).toContain('1'); // narrator only
+    expect(chip(/^Carried/).textContent).toContain('1'); // narrator only
   });
 
   it('filters to a single status when one chip is active', () => {
@@ -1143,9 +1145,9 @@ describe('CastView status filter', () => {
     expect(isPresent('Blank')).toBe(false); // Unset — excluded
   });
 
-  it('isolates reused characters via the Reused chip', () => {
+  it('isolates reused characters via the Carried chip', () => {
     renderFilterView();
-    fireEvent.click(chip(/^Reused/));
+    fireEvent.click(chip(/^Carried/));
     expect(isPresent('Narrator')).toBe(true);
     expect(isPresent('Ghost')).toBe(false);
     expect(isPresent('Mr. Marrow')).toBe(false);

--- a/src/views/cast.tsx
+++ b/src/views/cast.tsx
@@ -16,7 +16,7 @@ import {
   Avatar,
   Pill,
   VoiceSwatch,
-  ReusedBadge,
+  CarriedBadge,
 } from '../components/primitives';
 import { VariantGlyphStrip } from '../components/variant-glyph-strip';
 import {
@@ -128,6 +128,7 @@ const CHIP_ORDER = [
    only the displayed text changes. */
 const CHIP_LABELS: Record<string, string> = {
   Variants: 'Has variants',
+  Reused: 'Carried',
 };
 
 export function CastView({
@@ -1407,9 +1408,9 @@ function ttsLabel(key: TtsModelKey): string {
 /* Engine-aware Status display (plan 117 + reused-badge split). Renders two
    ORTHOGONAL markers via `resolveVoiceStatus`: the lifecycle pill (Needs voice
    → Designed → Generated for Qwen; Matched / Tuned / Locked otherwise) plus a
-   small Reused badge whenever the voice was matched from a prior book — so a
-   reused Qwen voice reads "Generated · Reused" instead of collapsing to a lone
-   "Reused" pill. See src/lib/voice-status.ts for the resolution rules. */
+   small Carried badge whenever the voice was matched from a prior book — so a
+   reused Qwen voice reads "Generated · Carried" instead of collapsing to a lone
+   "Carried" pill. See src/lib/voice-status.ts for the resolution rules. */
 function StatusPill({
   c,
   voice,
@@ -1447,7 +1448,7 @@ function StatusPill({
     <span className="inline-flex flex-col items-start gap-1.5">
       <span className="inline-flex items-center gap-1.5 flex-wrap">
         {lifecycle && <Pill color={lifecycle.color}>{lifecycle.label}</Pill>}
-        {reused && <ReusedBadge />}
+        {reused && <CarriedBadge />}
       </span>
       {showStrip && <VariantGlyphStrip usedEmotions={usedEmotions} designedEmotions={designed} />}
     </span>

--- a/src/views/confirm-cast.test.tsx
+++ b/src/views/confirm-cast.test.tsx
@@ -93,10 +93,10 @@ function renderView(
 }
 
 describe('ConfirmCastView — voice-match wiring', () => {
-  it('renders a "Matched · N%" pill for characters carrying matchedFrom', () => {
+  it('renders a "Carried · N%" pill for characters carrying matchedFrom', () => {
     renderView();
     /* Pill text rounds confidence to whole percent. */
-    expect(screen.getByText('Matched · 95%')).toBeInTheDocument();
+    expect(screen.getByText('Carried · 95%')).toBeInTheDocument();
   });
 
   it("shows the source book title in the matched character's Reuse tile", () => {
@@ -115,7 +115,7 @@ describe('ConfirmCastView — voice-match wiring', () => {
     /* Wren's row should not show any Matched · % pill. */
     const wrenHeading = screen.getByRole('heading', { name: 'Wren' });
     const wrenCard = wrenHeading.closest('article')!;
-    expect(within(wrenCard).queryByText(/Matched · /)).toBeNull();
+    expect(within(wrenCard).queryByText(/Carried · /)).toBeNull();
   });
 
   it("defaults the matched character's decision to Reuse (continuity message visible)", () => {

--- a/src/views/confirm-cast.tsx
+++ b/src/views/confirm-cast.tsx
@@ -432,7 +432,7 @@ function ConfirmCharacterCard({
             <h3 className="text-lg font-bold text-ink truncate">{character.name}</h3>
             {matched && character.matchedFrom?.confidence != null && (
               <Pill color="library">
-                Matched · {Math.round(character.matchedFrom.confidence * 100)}%
+                Carried · {Math.round(character.matchedFrom.confidence * 100)}%
               </Pill>
             )}
           </div>


### PR DESCRIPTION
## Summary

Ships the three deferred fe-40 series-memory follow-ups as one frontend-only round (spec + plan under `docs/superpowers/`). Delivered via subagent-driven TDD; the final whole-branch review came back *Ready to merge*.

- **fe-42 — single-word "Carried" vocabulary.** Unifies every `matchedFrom`-driven marker to "Carried": `ReusedBadge`→`CarriedBadge` (keeps `data-testid="reused-badge"`), the cast filter chip relabelled via the existing `CHIP_LABELS` map (internal `'Reused'` key unchanged), and confirm-cast `Matched · N%`→`Carried · N%`. The lifecycle `Matched` pill (derived from `voiceState`, not `matchedFrom`) is deliberately left alone, so a reused-preset row reads "Matched · Carried". The issue's second term "Kept" was dropped — no data distinguishes it (`reused === !!matchedFrom`).
- **fe-41 — series-memory chip in the table view.** `SeriesMemoryChip` gains `showBooks?` (default `true`, so the grid is unchanged); the table renders the compact `showBooks={false}` variant in a restructured collapsible section header (chip as a responsive sibling of the collapse button). The orchestrator's filter mapping was extracted into the exported pure `applyLibraryFilters`, with a unit test locking that `seriesMemory` survives filtering.
- **fe-43 — PNG share-card export.** A "Download image (.png)" button captures `SeriesShareCard` via a lazily-imported `html-to-image` (2×, `document.fonts?.ready`-gated); a shared `slugifyFilename` sanitises both the PNG and the existing JSON download; busy state + a `role="alert"` error line on capture failure.

## Test plan

- Frontend unit suite green (3038+ tests), incl. new coverage: table chip (renders / absent / standalones / click-doesn't-collapse), `showBooks` default+false, PNG capture + failure-alert paths, `slugifyFilename` edge cases, and the `applyLibraryFilters` invariant.
- e2e: a new "share card exports a PNG download" spec asserts an actual `.png` download (3/3 series-memory specs green).
- Full `npm run verify` green (typecheck + all tests + e2e + build). The `confirm` visual baseline was verified unaffected — fe-42's "Carried" text isn't in the snapshot's captured viewport.

## Notes

- This branch carries an `-iso` suffix: execution was relocated to an isolated worktree mid-run after a concurrent session committed unrelated work onto the original `feat/frontend-fe-40-followups`. Only the three follow-up features are in this branch.

Closes #983
Closes #984
Closes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)