### PR TITLE
feat(server): fs-41/fs-50 language registry foundation + spec (seam 1)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -49,11 +49,23 @@ _Full detail + acceptance:_ plan [`194-voice-cloning.md`](features/194-voice-clo
 
 ### Reach & perception — win the comparison
 
-#### `fs-50` — Language packs: ES/FR/DE/ZH/JA end-to-end ([#974](https://github.com/dudarenok-maker/Castwright/issues/974))
+#### `fs-50` — Language packs: ES/FR/DE end-to-end, Latin Qwen tranche ([#974](https://github.com/dudarenok-maker/Castwright/issues/974))
 
-- _What:_ Stand up ES/FR/DE/ZH/JA end-to-end on the engines that already support them (Kokoro/Qwen3-TTS) — incremental config + per-language listener-validation, not new architecture (framework exists post-`fs-2`).
-- _Benefit (user / strategic):_ the **biggest single perception gap** — rivals market 1,158 languages, we show 2. Pairs with `fs-41` (auto-detect).
-_Full detail + acceptance:_ [#974](https://github.com/dudarenok-maker/Castwright/issues/974).
+- _What:_ Stand up **ES/FR/DE** end-to-end through **Qwen design** (Latin-script tranche), folding in `fs-41` (auto-detect on ingest + voice-library language filtering). Keeps the shipped `non-English ⇒ Qwen, fail-loud` invariant unchanged; the bulk is the engine-independent **analyze half** (detection, chapter/quote/attribution/token + the English prompt skills) plus the Qwen design-path i18n. **CJK (ZH/JA) split to `fs-59`; the Kokoro/XTTS engine relaxation split to `fs-60`.**
+- _Benefit (user / strategic):_ the **biggest single perception gap** — rivals market 1,158 languages, we show 2. Now spec'd + decomposed into 5 desk-verifiable seams.
+_Spec:_ [`2026-06-22-fs41-fs50-language-aware-ingest-and-breadth-design.md`](superpowers/specs/2026-06-22-fs41-fs50-language-aware-ingest-and-breadth-design.md) · _Detail:_ [#974](https://github.com/dudarenok-maker/Castwright/issues/974).
+
+#### `fs-59` — CJK (Chinese/Japanese) language support ([#1004](https://github.com/dudarenok-maker/Castwright/issues/1004))
+
+- _What:_ ZH/JA end-to-end — the deferred CJK follow-on to `fs-50`. Needs its own foundations: a server-side word segmenter (`Intl.Segmenter`/jieba/fugashi), CJK quote handling (「」), a CJK token divisor, per-language prompt examples, and fluent ZH/JA labelers for the attribution gate.
+- _Benefit (user / strategic):_ the two highest-population CJK languages — breadth Latin alone can't reach. Deferred until the `fs-50` Latin framework lands.
+_Full detail + acceptance:_ [#1004](https://github.com/dudarenok-maker/Castwright/issues/1004).
+
+#### `fs-60` — Kokoro/XTTS per-language engine eligibility (gap-fill beyond Qwen) ([#1005](https://github.com/dudarenok-maker/Castwright/issues/1005))
+
+- _What:_ Let non-English books use Kokoro-native / Coqui-XTTS voices instead of forced Qwen — the gap-fill tail. Owns the Kokoro non-English G2P deps, per-language default voices, the 3-engine VRAM constraint, Coqui per-synth language threading, and a cross-language voice-identity check (srv-36 ECAPA).
+- _Benefit (user / strategic):_ languages + voice variety beyond Qwen's reach; same engine choice for non-English books. Lowest strategic priority.
+_Full detail + acceptance:_ [#1005](https://github.com/dudarenok-maker/Castwright/issues/1005).
 
 #### `fs-52` — Caption/SRT export (.srt/.vtt; line/sentence/word) ([#975](https://github.com/dudarenok-maker/Castwright/issues/975))
 
@@ -65,8 +77,10 @@ _`fs-2` (multi-language, Russian first) shipped — the engine half via
 [plan 108](features/108-qwen-coexistence.md), the language half via
 [plan 162](features/162-fs2-multilanguage.md); the library/cast language UX
 polish (`fe-16`) shipped via [plan 165](features/165-fe-15-16-language-and-revision-e2e.md).
-`fs-50` extends that framework to five more languages; the remaining deferred
-follow-up is `fs-14` (Russian UI localization, now under Should → Ingest & languages)._
+`fs-50` extends that framework to ES/FR/DE (the Latin Qwen tranche, folding in
+`fs-41`); CJK (ZH/JA) is split to `fs-59` and the Kokoro/XTTS engine relaxation to
+`fs-60`; the remaining deferred follow-up is `fs-14` (Russian UI localization, now
+under Should → Ingest & languages)._
 
 ### Adoption — widen the funnel (ship-now first)
 
@@ -120,11 +134,9 @@ blocked companion follow-up.
 
 ### Ingest & languages
 
-#### `fs-41` — Auto-detect manuscript language on ingest (filter voice library + auto-load engine) ([#666](https://github.com/dudarenok-maker/AudioBook-Generator/issues/666))
+#### `fs-41` — Auto-detect manuscript language on ingest — **folded into `fs-50`** ([#666](https://github.com/dudarenok-maker/AudioBook-Generator/issues/666))
 
-- _What:_ Complete the multi-language "second half": on ingest, auto-detect the manuscript language, filter the voice library to it, and auto-load the right engine (Qwen3-TTS for Russian, Kokoro for English), preserving the never-cross-language-within-a-book invariant. Today the language path works end-to-end (`fs-2`) but the user drives engine/voice selection by hand.
-- _Benefit (user):_ removes the most error-prone manual step for non-English books; one of the most-requested multi-language directions. Pairs with `fs-2` (engine half, shipped) and `fs-14` (Russian UI). _(Promoted Could → Should 2026-06-21 — pairs with the Must language packs.)_
-_Full detail + acceptance:_ [#666](https://github.com/dudarenok-maker/AudioBook-Generator/issues/666).
+- _Folded:_ the detect + auto-load halves shipped via `fs-2`/`fe-16`; the remaining voice-library language filtering is now part of the `fs-50` Latin-Qwen initiative spec (§6, `docs/superpowers/specs/2026-06-22-fs41-fs50-language-aware-ingest-and-breadth-design.md`). Tracked there; row kept for ID continuity. _Detail:_ [#666](https://github.com/dudarenok-maker/AudioBook-Generator/issues/666).
 
 #### `fs-53` — Automatic text normalisation (numbers/dates/currency/abbreviations) ([#976](https://github.com/dudarenok-maker/Castwright/issues/976))
 

--- a/docs/superpowers/plans/2026-06-22-fs41-fs50-seam1-language-registry.md
+++ b/docs/superpowers/plans/2026-06-22-fs41-fs50-seam1-language-registry.md
@@ -1,0 +1,258 @@
+# fs-41/fs-50 Seam 1 — Language Registry Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce a server-side language registry as the single source of truth for per-language data, and rewire `language.ts` to read from it — with **zero behavior change** for the shipped `en`/`ru` paths.
+
+**Architecture:** A new `server/src/tts/language-registry.ts` holds `LanguageEntry` records (seeded with `en` + `ru`, both `supported: true`). `language.ts` keeps its exact public API (`normaliseBookLanguage`, `sidecarLanguageName`, `isNonEnglish`, `DEFAULT_LANGUAGE`) so its ~11 consumers are untouched; only the internal `SIDECAR_LANGUAGE_NAMES` lookup table moves into the registry. Later seams extend `LanguageEntry` (detection slice, text-pipeline lexicons, `refText`, etc. — spec §2) and add `es`/`fr`/`de`.
+
+**Tech Stack:** TypeScript (ESM, `.js` import extensions), Node 20+, Vitest (server `node` env).
+
+## Global Constraints
+
+- **No behavior change in this seam.** All existing `server/src/tts/language.test.ts` assertions stay green — including `sidecarLanguageName('de') === 'English'` + one `console.warn` (the unknown-code fallback). The fail-loud **throw** for unsupported codes is **seam 5**, NOT here. Do not invert any existing test.
+- **`en` and `ru` are seeded `supported: true`** (grandfathered — `ru` shipped validated under fs-2). The registry must never regress them.
+- **ESM imports use `.js` extensions** (e.g. `import { getLanguageEntry } from './language-registry.js'`), matching the codebase (`'../tts/language.js'` everywhere).
+- **The full registry is server-side.** Do NOT expose it to the frontend in this seam — the detection slice (`{code, detect, sidecarName, supported}`) is wired in seam 2 when the frontend detector consumes it (see Scope note).
+- **Commit convention:** `<type>(<scope>): <subject>` — husky `commit-msg` rejects malformed subjects. Pre-commit runs `verify:fast:scoped`; these tasks touch `server/src/tts`, so the **server test leg runs** — it must be green before commit.
+
+## Scope note (this is seam 1 of 5)
+
+The spec (§7) groups "the frontend/server sharing seam" into seam 1. It is **deliberately deferred to seam 2's plan** here: the detection slice the frontend consumes must carry the `detect` field, which does not exist until the seam-2 detection work defines it, and an exporter with no consumer is not independently testable. Seam 1 delivers the registry module + the `language.ts` rewire — a complete, behavior-preserving, server-only unit.
+
+---
+
+### Task 1: Create the language registry module
+
+**Files:**
+- Create: `server/src/tts/language-registry.ts`
+- Test: `server/src/tts/language-registry.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (leaf module).
+- Produces:
+  - `interface LanguageEntry { code: string; sidecarName: string; supported: boolean }`
+  - `getLanguageEntry(code: string): LanguageEntry | undefined` — `code` is an already-normalised BCP-47 primary subtag (lower-case).
+  - `isSupportedLanguage(code: string): boolean`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/src/tts/language-registry.test.ts`:
+
+```typescript
+/* language-registry — single source of truth for per-language data.
+   Seam 1: pins the en/ru entries + the accessor contract. */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getLanguageEntry,
+  isSupportedLanguage,
+  type LanguageEntry,
+} from './language-registry.js';
+
+describe('getLanguageEntry', () => {
+  it('returns the en entry, supported', () => {
+    const en = getLanguageEntry('en');
+    expect(en).toEqual<LanguageEntry>({
+      code: 'en',
+      sidecarName: 'English',
+      supported: true,
+    });
+  });
+
+  it('returns the ru entry, supported (grandfathered under fs-2)', () => {
+    const ru = getLanguageEntry('ru');
+    expect(ru).toEqual<LanguageEntry>({
+      code: 'ru',
+      sidecarName: 'Russian',
+      supported: true,
+    });
+  });
+
+  it('returns undefined for a code not in the registry', () => {
+    expect(getLanguageEntry('de')).toBeUndefined();
+    expect(getLanguageEntry('')).toBeUndefined();
+  });
+});
+
+describe('isSupportedLanguage', () => {
+  it('is true for seeded en/ru, false otherwise', () => {
+    expect(isSupportedLanguage('en')).toBe(true);
+    expect(isSupportedLanguage('ru')).toBe(true);
+    expect(isSupportedLanguage('de')).toBe(false);
+    expect(isSupportedLanguage('')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/tts/language-registry.test.ts`
+Expected: FAIL — `Failed to resolve import "./language-registry.js"` (module does not exist yet).
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `server/src/tts/language-registry.ts`:
+
+```typescript
+/* language-registry — the single source of truth for per-language data
+   (fs-41/fs-50). Seam 1 (foundation) holds only the fields `language.ts`
+   reads today: `code`, `sidecarName`, `supported`. Later seams EXTEND
+   LanguageEntry with the detection slice, text-pipeline lexicons, and
+   `refText` (see the fs-41/fs-50 spec §2) and add es/fr/de entries — each
+   gated `supported:false` until its validation gate passes.
+
+   `en` and `ru` are seeded `supported:true`: ru shipped validated under
+   fs-2, so it is grandfathered past the per-language gate. */
+
+export interface LanguageEntry {
+  /** BCP-47 primary subtag, lower-cased (e.g. 'en', 'ru'). */
+  code: string;
+  /** Sidecar/analyzer language word — Qwen design + the analyzer preamble. */
+  sidecarName: string;
+  /** True only once the language has passed its validation gate. */
+  supported: boolean;
+}
+
+const ENTRIES: readonly LanguageEntry[] = [
+  { code: 'en', sidecarName: 'English', supported: true },
+  { code: 'ru', sidecarName: 'Russian', supported: true },
+];
+
+const BY_CODE: ReadonlyMap<string, LanguageEntry> = new Map(
+  ENTRIES.map((e) => [e.code, e]),
+);
+
+/** Look up a registry entry by an already-normalised BCP-47 primary subtag. */
+export function getLanguageEntry(code: string): LanguageEntry | undefined {
+  return BY_CODE.get(code);
+}
+
+/** True when the language has passed its validation gate (registry `supported`). */
+export function isSupportedLanguage(code: string): boolean {
+  return BY_CODE.get(code)?.supported ?? false;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/tts/language-registry.test.ts`
+Expected: PASS (5 assertions across 2 describe blocks).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/tts/language-registry.ts server/src/tts/language-registry.test.ts
+git commit -m "feat(server): add language registry as per-language source of truth (en/ru)"
+```
+
+---
+
+### Task 2: Rewire `sidecarLanguageName` to read from the registry
+
+**Files:**
+- Modify: `server/src/tts/language.ts:14-44` (remove `SIDECAR_LANGUAGE_NAMES`; `sidecarLanguageName` reads the registry)
+- Test: `server/src/tts/language.test.ts` (existing — stays green; add one delegation assertion)
+
+**Interfaces:**
+- Consumes: `getLanguageEntry` from Task 1.
+- Produces: no public-API change. `sidecarLanguageName(bcp47: string): string`, `isNonEnglish(bcp47: string): boolean`, `normaliseBookLanguage`, `DEFAULT_LANGUAGE` all keep their exact current signatures and behavior. (The ~11 consumers — `generation.ts`, `gemini.ts`, `chapter-splice.ts`, `chapter-qa-repair.ts`, `qwen-voice.ts`, `cast-design.ts`, `single-design.ts`, `scan.ts`, `import.ts`, `fold-minor-cast.ts`, `verify-designed-voice-language.ts` — are untouched.)
+
+- [ ] **Step 1: Add a delegation assertion to the existing test**
+
+Append to `server/src/tts/language.test.ts` inside the existing `describe('sidecarLanguageName', …)` block (after the existing `it` cases, before its closing `});`):
+
+```typescript
+  it('sources the language word from the registry entry', async () => {
+    const { getLanguageEntry } = await import('./language-registry.js');
+    expect(sidecarLanguageName('ru')).toBe(getLanguageEntry('ru')?.sidecarName);
+    expect(sidecarLanguageName('en')).toBe(getLanguageEntry('en')?.sidecarName);
+  });
+```
+
+(Leave every existing assertion — including `sidecarLanguageName('de') === 'English'` with one `console.warn`, and the `isNonEnglish('de') === true` case — unchanged. Seam 1 preserves them.)
+
+- [ ] **Step 2: Run the test to verify the new assertion fails**
+
+Run: `cd server && npx vitest run src/tts/language.test.ts`
+Expected: FAIL only on the new "sources the language word from the registry entry" case — `getLanguageEntry` resolves, but `sidecarLanguageName` still reads the local `SIDECAR_LANGUAGE_NAMES` table, so the assertion is comparing two equal strings and actually PASSES even before the rewire.
+
+> Note: this assertion passes pre-rewire because the values coincide (`'Russian'`/`'English'`). That is acceptable — its purpose is a **regression lock** that the registry stays the canonical word source after the rewire, not a red-before-green gate. The genuine red-before-green for this task is the *removal* verified in Step 4 (the old `SIDECAR_LANGUAGE_NAMES` symbol must be gone and all cases still green). Proceed to Step 3.
+
+- [ ] **Step 3: Rewire `language.ts`**
+
+In `server/src/tts/language.ts`, add the import at the top (after the file's opening comment, alongside no other imports today):
+
+```typescript
+import { getLanguageEntry } from './language-registry.js';
+```
+
+Delete the `SIDECAR_LANGUAGE_NAMES` constant (currently lines ~12-17):
+
+```typescript
+/* Primary-subtag → sidecar language word. Keep keys lower-cased primary
+   subtags; the lookup normalises before indexing. */
+const SIDECAR_LANGUAGE_NAMES: Record<string, string> = {
+  en: 'English',
+  ru: 'Russian',
+};
+```
+
+Replace the body of `sidecarLanguageName` so it reads the registry:
+
+```typescript
+/** The sidecar's language word for a BCP-47 book language. Unknown codes fall
+    back to `'English'` with a warning — a stray code must never throw and break
+    generation, but it also must never silently mis-route, so we log it.
+    (Seam 5 replaces this fallback with a throw gated on the registry's
+    `supported` set; seam 1 preserves the shipped behaviour.) */
+export function sidecarLanguageName(bcp47: string): string {
+  const primary = normaliseBookLanguage(bcp47);
+  const entry = getLanguageEntry(primary);
+  if (!entry) {
+    console.warn(
+      `[language] no sidecar language name for "${bcp47}" (primary "${primary}") — falling back to English`,
+    );
+    return 'English';
+  }
+  return entry.sidecarName;
+}
+```
+
+Leave `DEFAULT_LANGUAGE`, `primarySubtag`, `normaliseBookLanguage`, and `isNonEnglish` exactly as they are.
+
+- [ ] **Step 4: Run the full language test file to verify all cases pass**
+
+Run: `cd server && npx vitest run src/tts/language.test.ts`
+Expected: PASS — every existing case (en/ru words, `''`→English, `de`→English+warn, `isNonEnglish` matrix, `normaliseBookLanguage`) plus the new registry-delegation case. The `de`→`English`+`console.warn` behavior is unchanged (an unknown code yields `getLanguageEntry(...) === undefined` → the same warn+fallback).
+
+- [ ] **Step 5: Verify no consumer regressed — run the broader tts/analyzer suite**
+
+Run: `cd server && npx vitest run src/tts src/analyzer/gemini.test.ts src/analyzer/fold-minor-cast.test.ts`
+Expected: PASS — the `language.ts` consumers (`isNonEnglish`/`sidecarLanguageName`/`normaliseBookLanguage`) see an identical API and identical en/ru behavior.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/tts/language.ts server/src/tts/language.test.ts
+git commit -m "refactor(server): read sidecar language word from the registry (no behaviour change)"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage (seam 1 slice of §2/§7/§10):** registry module is the source of truth ✓ (Task 1); `language.ts` reads from it / `SIDECAR_LANGUAGE_NAMES` removed ✓ (Task 2); `en`+`ru` seeded `supported:true` ✓ (Task 1); `ru` no-regression preserved by the unchanged existing `isNonEnglish('ru')`/`sidecarLanguageName('ru')` assertions ✓ (Task 2 Steps 4-5). Deferred-by-design to later seams (noted): the `sidecarLanguageName` **throw** (seam 5), the detection slice + frontend sharing (seam 2), es/fr/de entries + the `LanguageEntry` text-pipeline fields (seams 2-5).
+- **Placeholder scan:** none — every step carries the literal code/command/expected output.
+- **Type consistency:** `LanguageEntry`, `getLanguageEntry`, `isSupportedLanguage` are spelled identically in Task 1 (definition), Task 1 test, and Task 2 (import + usage). `sidecarLanguageName` keeps its `(bcp47: string): string` signature.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-22-fs41-fs50-seam1-language-registry.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — a fresh subagent per task with a review gate between tasks.
+2. **Inline Execution** — execute both tasks in this session with a checkpoint after each.
+
+This seam is small (2 tasks, no behavior change), so inline execution is reasonable; subagent-driven still gives a clean per-task review gate.

--- a/docs/superpowers/specs/2026-06-22-fs41-fs50-language-aware-ingest-and-breadth-design.md
+++ b/docs/superpowers/specs/2026-06-22-fs41-fs50-language-aware-ingest-and-breadth-design.md
@@ -1,0 +1,393 @@
+---
+status: draft
+date: 2026-06-22
+topic: fs-41 + fs-50 — language-aware ingest + Latin-script Qwen breadth (one initiative)
+issues: >
+  fs-41 (#666, Could→Should) auto-detect manuscript language on ingest, filter
+  voice library, auto-load engine; fs-50 (#974, Must) language packs end-to-end.
+  Folded into ONE initiative per user direction; this spec covers the
+  Latin-script Qwen tranche (ES/FR/DE).
+depends_on: >
+  fs-2 (multi-language Russian, shipped: engine half plan 108, language half plan
+  162); fe-16 (library/cast language UX polish, shipped plan 165)
+relates_to: >
+  fs-25 (per-emotion variants) — EMOTION_INSTRUCT is an English design hardcode
+  this spec internationalises; fs-53 (#976) text normalisation; fs-14 (#396) UI
+  localization — DISTINCT per-USER axis; fs-38 (#624) standalone/cloned voices
+defers: >
+  (1) CJK (ZH/JA) → a SEPARATE follow-on sub-spec — it needs a server-side word
+  segmenter dependency, per-language prompt examples, and fluent ZH/JA labelers
+  (§11.1). (2) The Kokoro-unfilter + Coqui-XTTS per-language engine-eligibility
+  relaxation → a SEPARATE gap-fill sub-spec (§11.2).
+supersedes_in_part: >
+  fs-41 is largely realised by fe-16 except voice-library language filtering;
+  this spec completes it and extends the shipped en/ru path to ES/FR/DE
+---
+
+# fs-41 + fs-50 — Language-aware ingest + Latin-script Qwen breadth
+
+> **Scope at a glance.** Add **Spanish, French, German** end-to-end through **Qwen
+> design only**, keeping the shipped `non-English ⇒ Qwen, fail-loud` invariant
+> **unchanged**. Two hard things are split into their own follow-on sub-specs:
+> **CJK (ZH/JA)** (§11.1) and the **Kokoro/XTTS engine relaxation** (§11.2). The
+> bulk of the build is the **analyze half** (chapter/quote/attribution/token/prompt
+> internationalisation), which is engine-independent. Direction validated by two
+> adversarial review rounds (2026-06-22); this revision folds in all of round 2.
+
+## 0. The reframe
+
+fs-50's acceptance is **fs-41's three sub-goals (detect / filter / auto-load) plus
+a per-language validation gate, applied to more languages**. So **fs-41 is the
+mechanism; fs-50 is the breadth through it.** Built N-language from the start; the
+packs roll out through it. fs-50 is **Must**, so the fold elevates fs-41's
+filtering work.
+
+### 0.0 The north star (the goal all this work serves)
+Every language **Qwen** can speak — Qwen is the main, design-baked engine — then,
+as separate later initiatives, **CJK** (its own analysis hardness, §11.1) and
+**whatever the other engines add that Qwen can't** (Kokoro/XTTS, §11.2). Closing
+the "rivals show 1,158 languages, we show 2" gap is a **Qwen-first** programme;
+**this spec ships the Latin-script Qwen tranche (ES/FR/DE)** as the first concrete
+breadth, on a framework reusable by both follow-ons.
+
+### 0.1 Two scope narrowings (review-driven, deliberate)
+- **Qwen-only (no engine relaxation).** Review showed the Kokoro-native "cheapest
+  path" is *not* free (its non-English G2P backend — `misaki[ja,zh]`, espeak
+  language data — is absent from every requirements file; the only Kokoro tests
+  pin the opposite), and relaxing the binary `isNonEnglish` guard reopens
+  silent-wrong-language / wrong-identity paths, needs per-language default voices,
+  touches four frontend binary sites, and can force a 3-engine 8 GB VRAM spill.
+  So we **keep the existing fail-loud `non-English ⇒ Qwen` invariant unchanged**
+  and add languages through Qwen design. (Gap-fill deferred — §11.2.)
+- **Latin-script only (defer CJK).** Review showed CJK analysis needs a
+  **server-side word segmenter** (`Intl.Segmenter` minimum; jieba/fugashi for
+  quality — a real dependency the "no new deps" posture denies), **per-language
+  prompt examples**, and **fluent ZH/JA labelers** for the attribution gate. That
+  is a distinct sub-project (§11.1). ES/FR/DE are Latin-script, lexicon-tractable,
+  and desk-verifiable.
+
+### 0.2 Current ground truth (verified across two review rounds — corrects an
+earlier draft claim that "synthesis is basically done")
+- **The *enforcement* invariant is genuinely language-agnostic.** `isNonEnglish`
+  forces every character to a designed Qwen voice; `forbidKokoroFallback` throws
+  `MissingDesignedVoiceError`; `clearMismatchedDesignedVoices` drops a reused voice
+  whose manifest language ≠ the book's. None of this is en/ru-specific — it works
+  for any language word. fe-16's cast banner, Qwen auto-load, and `lockedToQwen`
+  stay correct.
+- **BUT the Qwen *design path* has multiple English hardcodes the voice actually
+  speaks through** (round 2's biggest correction): the **persona/`instruct`** is
+  hard-English (`skills/audiobook-voice-style.md:16` ends `- English.`;
+  `analyzer/voice-style.ts` never receives book language) and is the *primary*
+  identity input to VoiceDesign (`main.py:1553`); the **timbre reference clip**
+  uses the hardcoded English `CALIBRATION_TEXT` (`main.py:1509`, not the
+  Node-supplied `calibrationText`, which is only the audition); **`EMOTION_INSTRUCT`**
+  (`qwen-voice.ts:106`) and **`fill-tone` NUDGES** (`fill-tone.ts:8`) are en/ru
+  hardcoded; and **`sidecarLanguageName` silently defaults unknown→`'English'`**
+  (`language.ts:34`), which *disarms* the mismatch guard.
+- **The analyze half is English/Latin-centric and is the bulk of the work** — and
+  its single largest surface is the **prompt skills themselves** (~500 lines of
+  English instructions + English few-shot examples in
+  `skills/audiobook-character-detection-per-chapter.md` and
+  `…sentence-attribution.md`), not just the 3-sentence `languagePreamble`. Plus a
+  dozen English/Latin-assuming parser/analyzer primitives (§4).
+- **Voice-library language filtering does NOT ship** (`DerivedVoice` carries no
+  language; the late clear is a server-side `console.warn` with no frontend
+  transport).
+- **Things that are already correct — don't re-fix** (review-confirmed):
+  `safe-id.ts` is Unicode-`\p{L}\p{N}`; `stage2-coverage.ts` `words()` Cyrillic
+  erasure is already fixed; gender/age are model-output fields (no name→gender
+  table to internationalise); EPUB chapter boundaries are NCX-structural
+  (one-chapter-collapse risk is plaintext/markdown/PDF only).
+
+### 0.3 What this is NOT
+- Not CJK (§11.1) and not the Kokoro/XTTS relaxation (§11.2).
+- Not UI-localization (fs-14, per-USER axis); not text normalisation (fs-53).
+- Not "claim a language we can't read or analyse well" — `supported` flips only
+  after the §7 gate (synthesis pronunciation **and** attribution correctness).
+
+## 1. The work surface (three areas)
+
+| Area | What ships here |
+|---|---|
+| **A. Qwen design-path i18n** (§5) | Thread book-language through the persona generator + drop the `- English.` rule; per-language `ref_text`, `EMOTION_INSTRUCT`, `fill-tone` NUDGES; make `sidecarLanguageName` **throw** for unsupported codes |
+| **B. Analyze-half i18n** (§3–§4) | The bulk, engine-independent: detection, chapter split + title normalisation, quote/dialogue + audio-tags, attribution/roster guard (all 4 sites), minor-cast folding, token estimation, **the prompt skills**, front-matter strip, the attribution eval harness |
+| **C. Voice-library UX** (§6) | fs-41 filtering + a real early-warning transport |
+
+*Verification owed on-box before sequencing locks:* **Qwen3-TTS's real ES/FR/DE
+quality** — `language` is a free-text word passed unvalidated
+(`QwenEngine.DEFAULT_LANGUAGE="English"`), so German et al. are assumed. Pin
+quality per language before flipping `supported`.
+
+## 2. The language registry (one source of truth)
+
+`server/src/tts/language-registry.ts` replaces the scattered en/ru hardcodes and
+carries the analyze-half data. Shape:
+
+```
+LanguageEntry {
+  code: string            // BCP-47 primary subtag: 'en','ru','es','fr','de'
+  sidecarName: string     // Qwen design word + analyzer word: 'Spanish','German'
+  whisperCode: string     // ASR/QA-repair hint code (faster-whisper): 'es','de' (≠ word)
+  detect: { script: 'latin'|'cyrillic'; iso6393: string[] } // franc → this code
+  refText: string         // phonetically-rich line IN THIS LANGUAGE → Qwen ref clip
+  charsPerToken: number   // token-estimate divisor (Latin≈4, German≈3.3, Cyrillic≈2.5)
+  text: {
+    headingLexicon: string[]        // capítulo/chapitre/kapitel + native numerals
+    frontMatterLexicon: string[]    // derechos de autor / dédicace / Urheberrecht …
+    genericChapterLabel: RegExp     // per-language NCX generic-title match
+    quoteChars: { open: string[]; close: string[] } // "" | «» | „"  (NOT CJK here)
+    dialogueVerbs: string[]; verbBeforeName: boolean // —dijo Juan inverts
+    descriptorNouns: string[]; functionWords: string[]; bucketName: string
+    emotionInstruct: Record<Emotion,string> // per-language fs-25 variant clauses
+    promptExamples: { roster: string; attribution: string } // few-shot in-language
+  }
+  supported: boolean      // flipped true ONLY after the §7 gate
+}
+```
+
+- **`en` + `ru` seeded `supported:true` from day one** (grandfathered — `ru` shipped
+  validated under fs-2; a regression test asserts a `ru` book still forces Qwen +
+  `forbidKokoroFallback`). No `engines{}` map — non-English is always Qwen (§0.1).
+- **Frontend/server sharing seam (specified, not hand-mirrored).** The full registry
+  lives server-side; only the **detection slice** (`code`, `detect`, `sidecarName`,
+  `supported`) is exposed to the browser via the existing `openapi.yaml` →
+  `api-types.ts` generated path. The heavy `text`/`refText`/lexicon data never
+  enters the bundle. ("Adding a language = one entry" holds only with this seam.)
+- CJK adds the same shape **plus** a segmenter (the §11.1 sub-spec owns it).
+
+## 3. Detection (Latin + script pre-pass, fails safe)
+
+- **Script pre-pass is authoritative** (deterministic): Cyrillic⇒ru. This preserves
+  the shipped Russian path exactly and never depends on franc. (Han/Kana⇒block-as-
+  unsupported now; the §11.1 sub-spec turns them into zh/ja.)
+- **franc-min only disambiguates Latin** (en/es/fr/de), with a **confidence floor**
+  below which it falls back to `en`, and an explicit **"English never misdetects"**
+  regression test (an English chapter dense with French proper nouns must stay en).
+  Map franc ISO 639-3 → registry BCP-47 via `detect.iso6393`.
+- **Strip front-matter BEFORE detecting** (registry `frontMatterLexicon`), sampling
+  the book body, not the raw first 20k chars — translated editions carry English
+  copyright pages that misdetect to `en`.
+- **Fail safe — never silent `en`.** A confident detection of a non-`supported`
+  language lands in a distinct **`detected-but-unsupported`** state that **blocks
+  generation** (or forces an explicit override). `en` must never be the
+  safe-harbour default — `isNonEnglish('en')===false` disarms the guard.
+- **The confirm selector is BUILT, not gated.** Today it is a hardcoded 2-item
+  `<select>` (`confirm-metadata.tsx:22`) with Russian-specific copy
+  (`:300-312`) — there is no open-text field. Generate the options from
+  `registry.supported`; generalise the "Auto-detected Russian — verify" copy to the
+  detected language. (Updates `detect-language.test.ts` thresholds,
+  `confirm-metadata.test.tsx`, `e2e/language-detection.spec.ts` — see §10
+  test-contract list.)
+
+## 4. Analyze-half i18n (the bulk — engine-independent, Latin)
+
+Each primitive becomes registry-driven. CJK-specific segmentation is **out of scope
+here** (§11.1); these all matter for ES/FR/DE.
+
+- **4.1 Chapter splitting + title normalisation.** (a) Build the chapter regex from
+  `headingLexicon` (`parsers/text.ts:25`) — else a non-English book collapses to one
+  chapter. (b) **Widen `normaliseHeading`** (`text.ts:113,134`) from `[^A-Za-z0-9]`
+  to `\p{L}\p{N}` (matching `safe-id.ts`) so `¿Capítulo Tres?` isn't stripped to
+  empty; gate `looksLikeTitle`/`findSubtitle` (`:110,222`) per-script. (c) Make
+  `FRONT_MATTER_RX` (`parsers/front-matter.ts:11`) + `GENERIC_NCX_RE`
+  (`parsers/html-utils.ts:85`, mirrored in `src/lib/chapter-heuristics.ts`)
+  registry-driven so translated EPUB front-matter is filtered.
+- **4.2 Quote/dialogue + audio-tags.** Drive `isSpokenLine`
+  (`analyzer/narrator-default.ts:29`) from `quoteChars` (`«»` for ES/FR, `„"` for
+  DE). The parse-time audio-tag detectors (`parsers/audio-tags.ts`) share
+  `quoteChars` **and** need the all-caps shout heuristic (`isShoutingRun:33`,
+  `denormaliseShouting:46`) moved to Unicode `\p{Lu}/\p{Ll}` — it is `[A-Za-z]`-only
+  today, **already silently broken for shipped Russian** (German `„…!"` also misses).
+- **4.3 Attribution / roster guard — all FOUR sites.** The `[A-Z][A-Za-z]+ <verb>`
+  pattern lives in `roster-coverage.ts:182` **and** `:313`,
+  `recover-tagged-lines.ts:85`, and the synced copy in
+  `scripts/recover-missing-character.mjs` (drift-tested). Supply `dialogueVerbs` +
+  `verbBeforeName` + `quoteChars`; the `[A-Z]` name token needs per-script handling
+  (German capitalises every noun → `Haus sagte` false positives). **Known-partial
+  bound:** a flat verb list cannot express conjugation/separable verbs/enclitics —
+  the shipped Russian code already concedes "nominative singular only." Per language,
+  decide **gate-on** (ES/FR/DE: viable with the lexicon) vs **gate-off + document the
+  lost net** rather than silently no-op.
+- **4.4 Minor-cast folding + diminutives.** `fold-minor-cast.ts` (`GENERIC_ROLE_RU:167`,
+  `RU_FUNCTION_WORDS:184`, `BUCKET_NAMES.ru:112`) and the `ru-diminutives.ts`
+  subsystem are en/ru-only; add `descriptorNouns`/`functionWords`/`bucketName` to the
+  registry (so a Spanish minor cast folds with a Spanish bucket label), or document
+  the loss per language. Diminutive merging is a real inflected-language lever — note
+  whether ES/FR/DE need it (largely not) vs defer.
+- **4.5 Token estimation.** Rewrite `estimateInputTokens` (`gemini.ts:735`) — today a
+  fixed Cyrillic-fraction interpolation — to read the book's `charsPerToken`
+  (German's compounds tokenise denser than the Latin≈4 assumption).
+- **4.6 The prompt skills (the largest English surface).** The stage-1/2 skills are
+  ~500 lines of English rules + English few-shot examples; few-shot dominates
+  small-model behaviour, so a Spanish book is still pattern-matched against
+  `"…," Halloran said`. Inject the registry's in-language `promptExamples` (+
+  convention hints) into the **skill body**, and pass `sidecarName` ("Spanish") to
+  `languagePreamble` (`gemini.ts:175`) instead of the raw code (`es`).
+- **4.7 Front-matter boilerplate strip.** `strip-front-matter.ts` `GLOBAL_BOILERPLATE`
+  (`:13`) is en/ru; make it registry-driven (so a Spanish copyright page is stripped
+  before detect, feeding 4.1 + §3). (`isNarrativeLine` `length<60` is Latin-char
+  reasonable for ES/FR/DE; the CJK fix belongs to §11.1.)
+- **4.8 Attribution-correctness eval harness (net-new infra — its own deliverable).**
+  No speaker→line labelling/eval exists today (the golden gate is audio-only). Build:
+  (a) a labelled-sample schema `{chapterText, lines:[{text, speakerId}]}`, (b) a
+  scorer that aligns analyzer output ids to truth (handling alias-merge/id-stability)
+  and emits attribution FP/FN, (c) a per-language labelled chapter. The §7 gate
+  consumes this — without it, "attribution check" is unverifiable.
+
+## 5. Qwen design-path i18n (synthesis area A)
+
+- **Enforcement invariant unchanged** — the three sites (`generation.ts`,
+  `chapter-qa-repair.ts`, `chapter-splice.ts`) gate on `isNonEnglish`, which stays
+  correct; **no rewrite**.
+- **`sidecarLanguageName` must THROW** for a non-`supported` code (`language.ts:34`),
+  caught at the generation/splice sites as a hard block — so an unsupported code can
+  never bake an `'English'` manifest and disarm `clearMismatchedDesignedVoices`,
+  regardless of how it entered `state.json`.
+- **Per-language `refText`** replaces the hardcoded English `CALIBRATION_TEXT` at the
+  **reference-clip** assignment (`main.py:1509`) — NOT the Node `calibrationText`
+  param (which is only the audition; the Node side already passes an in-language
+  evidence quote there).
+- **Persona/`instruct` threaded** — pass `sidecarName` into `buildVoiceStylePrompt`
+  (`analyzer/voice-style.ts:88`) and drop/condition the `- English.` rule
+  (`skills/audiobook-voice-style.md:16`); extend `fill-tone` NUDGES (`fill-tone.ts:8`)
+  per language. (On-box: confirm whether Qwen VoiceDesign honours a non-English
+  persona at all — part of the §1 verification.)
+- **Per-language `EMOTION_INSTRUCT`** (`qwen-voice.ts:106`) for fs-25 variant design,
+  from the registry `emotionInstruct`.
+- **ASR/QA-repair** passes the registry `whisperCode` (`chapter-qa-repair.ts:149`),
+  kept distinct from the Qwen `sidecarName` word; a test asserts they agree per entry.
+
+## 6. Voice-library filtering + early-warning (area C)
+
+- **Filter the reuse picker** (`VoiceLibraryPanel`): in a non-English book, show only
+  Qwen voices whose manifest language matches, behind **"N hidden · can't read
+  &lt;Language&gt;" + "show all"**. **Global `#/voices` facet:** language tag + filter.
+- **Early-warning with a REAL transport** (named, not hand-waved): surface the
+  `clearMismatchedDesignedVoices` cleared-voice list on the existing cast/generation
+  payload and render via the `notifications` slice (cross-tab via the existing
+  `broadcast-middleware`) — so the cast view warns up-front instead of the user
+  discovering the silent server-side clear at generation. Net-new UI/state.
+
+## 7. Delivery & rollout
+
+**Decompose Phase 1 into independently-verifiable seams** (it is otherwise one
+unmergeable frontend+server+sidecar lump, ~2k LOC). All but the last are
+desk-verifiable on synthetic fixtures:
+
+1. **Registry module + en/ru seeding + the frontend/server sharing seam** — no
+   behaviour change; `ru` no-regression test.
+2. **Detection upgrade + confirm-selector rebuild** — frontend-only; script pre-pass
+   + franc-for-Latin + block-unsupported + generalised copy.
+3. **Analyze-half primitives** (§4.1–4.7) — server-only, one PR per 1–2 primitives,
+   synthetic-ES-fixture-gated; each lists the shipped tests whose contract changes.
+4. **Voice filtering + early-warning transport** — frontend+server.
+5. **`sidecarLanguageName`-throw + Qwen design-path i18n** (§5) + the **attribution
+   eval harness** (§4.8) — server/sidecar; the operator-gated leg.
+
+**`supported` flips only in the operator-gated tail**, in a tiny follow-up PR, once
+the on-box dual gate passes — so seams 1–4 land with `es.supported=false` and aren't
+held hostage to operator/GPU availability.
+
+**Rollout phases (Latin Qwen):**
+- **Phase 1 — framework + Spanish canary.** Seams 1–5; Spanish end-to-end; dual gate
+  (operator **audio** listen + **attribution-correctness** eval) → `es.supported`.
+- **Phase 2 — German.** Exercises the registry for a second Latin language; German's
+  capitalised-noun attribution edge (4.3) + denser token ratio (4.5). Dual gate.
+- **Phase 3 — French (+ any further Latin Qwen languages).** Templated repetition.
+- **Follow-on sub-projects:** CJK (§11.1), Kokoro/XTTS gap-fill (§11.2).
+
+**Why gated, not one PR:** validation needs the GPU box, real Qwen weights, the
+operator's ears, AND the labelled attribution sample — it cannot be desk-verified.
+
+## 8. Settings & cost posture
+- No new master flag; the registry's `supported` set + the `detected-but-unsupported`
+  block are the only gates. Engine auto-load unchanged (non-English ⇒ Qwen).
+- **No new runtime deps for the Latin tranche** — `franc-min` (frontend, tiny) is the
+  only addition; no G2P backend, no word segmenter (that is the CJK sub-spec's), no
+  extra VRAM beyond Qwen's existing footprint.
+
+## 9. Reuse (NOT built here)
+- fs-2 data-model + Qwen design-time baking + the never-cross-language enforcement
+  (`language.ts`, `synthesise-chapter.ts`, `verify-designed-voice-language.ts`,
+  `generation.ts`) — reused unchanged.
+- fe-16 cast banner, Qwen auto-load, `lockedToQwen` — reused unchanged (correct under
+  Qwen-only).
+- `DerivedVoice` aggregation, `VoiceLibraryPanel`, `#/voices`, the `notifications`
+  slice + `broadcast-middleware`, the analyzer stage-1/2 pipeline.
+
+## 10. Acceptance
+
+**Cross-cutting (every seam):**
+- [ ] Registry is the source of truth (replaces `SIDECAR_LANGUAGE_NAMES` + the
+      Cyrillic detector) with the §2 shape + the frontend/server sharing seam;
+      `en`+`ru` seeded `supported:true`; **`ru` no-regression test** (forces Qwen +
+      `forbidKokoroFallback`).
+- [ ] **`sidecarLanguageName` throws** for a non-`supported` code; a test proves an
+      unsupported code never reaches a synth call (no `'English'` manifest downgrade).
+- [ ] **Contract-changing shipped tests enumerated + replaced in the same diff**
+      (not silently inverted): `language.test.ts:46` (de→word, no warn),
+      `parsers/text.test.ts` (heading lexicon), `narrator-default`/`audio-tags`
+      (quote chars + Unicode case), `roster-coverage.test.ts` + the
+      `dialogue-verbs` drift test, `detect-language.test.ts:35` (script-rule cases,
+      not franc short-string thresholds), `confirm-metadata.test.tsx:236` +
+      `e2e/language-detection.spec.ts` (generalised copy).
+
+**Phase 1 — framework + Spanish canary (the build DoD):**
+- [ ] Detection: script pre-pass authoritative (ru preserved); franc-for-Latin with a
+      confidence floor + an **English-never-misdetects** test; 639-3→BCP-47 map;
+      front-matter stripped before detect; a confident unsupported language **blocks**
+      (`detected-but-unsupported`), never clamps to `en` (regression test: a French
+      manuscript never reaches a synth call as English).
+- [ ] Analyze-half §4.1–4.7 registry-driven; synthetic-ES-fixture tests (chapter
+      split + title normalisation, quote/dialogue + audio-tag case, roster guard,
+      minor-cast fold, token divisor, prompt examples + `sidecarName` preamble,
+      front-matter strip).
+- [ ] Qwen design-path i18n (§5): per-language `refText` at the reference clip;
+      persona threaded + `- English.` dropped/conditioned; `EMOTION_INSTRUCT` +
+      `fill-tone` per language; `whisperCode` wired (agrees-with-word test).
+- [ ] Voice filter hides ineligible voices with "N hidden · show all"; `#/voices`
+      facet; early-warning via the `notifications` transport (not a server-only warn).
+- [ ] **Attribution eval harness built** (schema + scorer + Spanish labelled chapter).
+- [ ] Spanish: full analyze→generate→export; on-box Qwen ES quality pinned; dual gate
+      (audio FP/FN + attribution FP/FN) recorded; `es.supported=true` only after both.
+- [ ] Paired EN/ES manuscript tests (fs-41); e2e detect → filter → cast for Spanish.
+
+**Phase 2 — German / Phase 3 — French (+ further Latin Qwen):**
+- [ ] Per language: registry entry + per-language Qwen `refText`/persona/emotion +
+      dual gate; German's capitalised-noun attribution edge + token density handled;
+      `supported` flips only on pass; result (sample book, audio FP/FN, attribution
+      FP/FN, operator verdict) in Ship notes.
+
+## 11. Out of scope (this spec) — the two named follow-on sub-projects
+
+### 11.1 CJK (ZH/JA) — its own sub-spec
+Deferred because it needs, beyond this framework: a **server-side word segmenter**
+(`Intl.Segmenter` minimum; jieba/fugashi for quality) for sentence/coverage/word-
+boundary logic (`stage2-chunk.ts`, `stage2-coverage.ts` `.split(/\s+/)` collapse);
+**CJK quote handling** (`「」『』`) in `isSpokenLine`/audio-tags; the **CJK token
+divisor** (~1.2); **per-language prompt examples**; **fluent ZH/JA labelers** for the
+attribution eval; and `isNarrativeLine`'s `length<60` CJK fix. The registry shape and
+gate are reused; the script pre-pass already routes Han/Kana to a block today.
+
+### 11.2 Kokoro-unfilter + Coqui-XTTS engine relaxation — its own sub-spec
+The per-engine eligibility model that would let non-English use Kokoro-native /
+XTTS instead of forced Qwen. Owns: the Kokoro G2P dependency surface
+(`misaki[ja,zh]`, espeak language data), per-language default voices, the 3-engine
+8 GB VRAM constraint, Coqui per-synth `xttsLang` threading, and the srv-36
+cross-language identity check.
+
+### 11.3 Also out
+UI localization (fs-14); text normalisation (fs-53); LLM/hybrid detection beyond the
+script+franc v1; languages outside Qwen's verified set; voice cloning (fs-38).
+
+## 12. Backlog reconciliation (do in the Round-0 docs PR)
+- Fold **fs-41**'s row into **fs-50** (fs-41 is realised except voice filtering,
+  which this spec completes); fs-50 carries the **Latin Qwen lead tranche**.
+- File the **CJK sub-project** (§11.1) and the **Kokoro/XTTS gap-fill** (§11.2) as new
+  Backlog-item issues + thin BACKLOG rows in the same docs round.
+
+## Ship notes
+_(filled per phase on ship: date · commit SHA · seam PRs · registry + sharing seam ·
+Qwen verified ES/FR/DE quality · detector accuracy + English-stability · design-path
+i18n (refText/persona/emotion) · attribution eval harness · Spanish canary (audio
+FP/FN + attribution FP/FN) · then one block per Phase-2/3 language.)_

--- a/server/src/tts/language-registry.test.ts
+++ b/server/src/tts/language-registry.test.ts
@@ -1,0 +1,43 @@
+/* language-registry — single source of truth for per-language data.
+   Seam 1: pins the en/ru entries + the accessor contract. */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getLanguageEntry,
+  isSupportedLanguage,
+  type LanguageEntry,
+} from './language-registry.js';
+
+describe('getLanguageEntry', () => {
+  it('returns the en entry, supported', () => {
+    const en = getLanguageEntry('en');
+    expect(en).toEqual<LanguageEntry>({
+      code: 'en',
+      sidecarName: 'English',
+      supported: true,
+    });
+  });
+
+  it('returns the ru entry, supported (grandfathered under fs-2)', () => {
+    const ru = getLanguageEntry('ru');
+    expect(ru).toEqual<LanguageEntry>({
+      code: 'ru',
+      sidecarName: 'Russian',
+      supported: true,
+    });
+  });
+
+  it('returns undefined for a code not in the registry', () => {
+    expect(getLanguageEntry('de')).toBeUndefined();
+    expect(getLanguageEntry('')).toBeUndefined();
+  });
+});
+
+describe('isSupportedLanguage', () => {
+  it('is true for seeded en/ru, false otherwise', () => {
+    expect(isSupportedLanguage('en')).toBe(true);
+    expect(isSupportedLanguage('ru')).toBe(true);
+    expect(isSupportedLanguage('de')).toBe(false);
+    expect(isSupportedLanguage('')).toBe(false);
+  });
+});

--- a/server/src/tts/language-registry.ts
+++ b/server/src/tts/language-registry.ts
@@ -1,0 +1,37 @@
+/* language-registry — the single source of truth for per-language data
+   (fs-41/fs-50). Seam 1 (foundation) holds only the fields `language.ts`
+   reads today: `code`, `sidecarName`, `supported`. Later seams EXTEND
+   LanguageEntry with the detection slice, text-pipeline lexicons, and
+   `refText` (see the fs-41/fs-50 spec §2) and add es/fr/de entries — each
+   gated `supported:false` until its validation gate passes.
+
+   `en` and `ru` are seeded `supported:true`: ru shipped validated under
+   fs-2, so it is grandfathered past the per-language gate. */
+
+export interface LanguageEntry {
+  /** BCP-47 primary subtag, lower-cased (e.g. 'en', 'ru'). */
+  code: string;
+  /** Sidecar/analyzer language word — Qwen design + the analyzer preamble. */
+  sidecarName: string;
+  /** True only once the language has passed its validation gate. */
+  supported: boolean;
+}
+
+const ENTRIES: readonly LanguageEntry[] = [
+  { code: 'en', sidecarName: 'English', supported: true },
+  { code: 'ru', sidecarName: 'Russian', supported: true },
+];
+
+const BY_CODE: ReadonlyMap<string, LanguageEntry> = new Map(
+  ENTRIES.map((e) => [e.code, e]),
+);
+
+/** Look up a registry entry by an already-normalised BCP-47 primary subtag. */
+export function getLanguageEntry(code: string): LanguageEntry | undefined {
+  return BY_CODE.get(code);
+}
+
+/** True when the language has passed its validation gate (registry `supported`). */
+export function isSupportedLanguage(code: string): boolean {
+  return BY_CODE.get(code)?.supported ?? false;
+}

--- a/server/src/tts/language.test.ts
+++ b/server/src/tts/language.test.ts
@@ -49,6 +49,12 @@ describe('sidecarLanguageName', () => {
     expect(warn).toHaveBeenCalledOnce();
     expect(warn.mock.calls[0]?.[0]).toContain('de');
   });
+
+  it('sources the language word from the registry entry', async () => {
+    const { getLanguageEntry } = await import('./language-registry.js');
+    expect(sidecarLanguageName('ru')).toBe(getLanguageEntry('ru')?.sidecarName);
+    expect(sidecarLanguageName('en')).toBe(getLanguageEntry('en')?.sidecarName);
+  });
 });
 
 describe('isNonEnglish', () => {

--- a/server/src/tts/language.ts
+++ b/server/src/tts/language.ts
@@ -7,14 +7,9 @@
    wired in v1 — adding a language is a one-line table entry here, not a
    contract migration (the field stays an open string everywhere else). */
 
-export const DEFAULT_LANGUAGE = 'en';
+import { getLanguageEntry } from './language-registry.js';
 
-/* Primary-subtag → sidecar language word. Keep keys lower-cased primary
-   subtags; the lookup normalises before indexing. */
-const SIDECAR_LANGUAGE_NAMES: Record<string, string> = {
-  en: 'English',
-  ru: 'Russian',
-};
+export const DEFAULT_LANGUAGE = 'en';
 
 /** Lower-cased primary subtag of a BCP-47 tag (`'ru-RU'` → `'ru'`). */
 function primarySubtag(bcp47: string): string {
@@ -30,17 +25,19 @@ export function normaliseBookLanguage(raw: string | undefined | null): string {
 
 /** The sidecar's language word for a BCP-47 book language. Unknown codes fall
     back to `'English'` with a warning — a stray code must never throw and break
-    generation, but it also must never silently mis-route, so we log it. */
+    generation, but it also must never silently mis-route, so we log it.
+    (Seam 5 replaces this fallback with a throw gated on the registry's
+    `supported` set; seam 1 preserves the shipped behaviour.) */
 export function sidecarLanguageName(bcp47: string): string {
   const primary = normaliseBookLanguage(bcp47);
-  const name = SIDECAR_LANGUAGE_NAMES[primary];
-  if (!name) {
+  const entry = getLanguageEntry(primary);
+  if (!entry) {
     console.warn(
       `[language] no sidecar language name for "${bcp47}" (primary "${primary}") — falling back to English`,
     );
     return 'English';
   }
-  return name;
+  return entry.sidecarName;
 }
 
 /** True when the book is not English (primary subtag ≠ `'en'`). Drives the


### PR DESCRIPTION
## Summary

First slice of the folded **fs-41 + fs-50** language-breadth initiative (Latin-Qwen tranche). Lands the design spec, the seam-1 implementation, the seam-1 plan, and the backlog reconciliation.

**Docs**
- New spec `docs/superpowers/specs/2026-06-22-fs41-fs50-language-aware-ingest-and-breadth-design.md` — fs-41 + fs-50 folded into one **Qwen-only, Latin-script (ES/FR/DE)** initiative, hardened across two four-lens adversarial review rounds. Keeps the shipped `non-English ⇒ Qwen, fail-loud` invariant unchanged; the bulk of the work is the engine-independent **analyze half** (detection, chapter/quote/attribution/token + the English prompt skills). CJK (ZH/JA) and the Kokoro/XTTS engine relaxation are deferred to their own sub-specs.
- Seam-1 plan `docs/superpowers/plans/2026-06-22-fs41-fs50-seam1-language-registry.md`.
- Backlog reconciliation: fs-41 folded into fs-50; fs-50 retitled to the Latin Qwen tranche; new rows **fs-59 (#1004, CJK)** and **fs-60 (#1005, Kokoro/XTTS gap-fill)**.

**Code (seam 1 — behaviour-preserving)**
- New `server/src/tts/language-registry.ts` — single source of truth for per-language data (`LanguageEntry { code, sidecarName, supported }`), `en`/`ru` seeded `supported: true` (ru grandfathered under fs-2), with `getLanguageEntry` / `isSupportedLanguage` accessors.
- `server/src/tts/language.ts` — `sidecarLanguageName` now reads the registry instead of a local `SIDECAR_LANGUAGE_NAMES` table; public API unchanged, all 11 consumers untouched, en/ru behaviour (incl. the unknown-code English+warn fallback) byte-for-byte preserved. The fail-loud throw for unsupported codes is deferred to seam 5.

No user-visible behaviour change in this PR — it is the foundation seam.

## Test plan

- `server/src/tts/language-registry.test.ts` — new; 4 tests pin the en/ru entries + the accessor contract.
- `server/src/tts/language.test.ts` — all existing assertions preserved (incl. `de`→English+warn, the `isNonEnglish` matrix) + a delegation assertion that `sidecarLanguageName` sources its word from the registry.
- Broader server suite green (740 tests across the tts + analyzer consumers).
- Full `npm run verify` (typecheck + all tests + e2e + build) green at pre-push.

Refs #974, #666, #1004, #1005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLg2Zazw3rSSE2kRq1JUzz
