### PR TITLE
feat(sidecar): srv-36 Phase-2 --gN measurement wiring (operator runs, not writes)

### DIFF
--- a/server/tts-sidecar/spikes/srv36/README.md
+++ b/server/tts-sidecar/spikes/srv36/README.md
@@ -102,3 +102,30 @@ A file present but missing these keys produces a silent safe-fail default in
 **G2 gotcha:** the `seed_divergence()` helper returns `{"central": ..., "spread": ...}`
 and the evaluator key is `g2_divergence` — but the result file key is `central`
 (NOT `divergence`). The `--g2` writer must emit `{"central": ..., "spread": ...}`.
+
+## Phase-2 operator run order (on the GPU box)
+
+The `--gN` writers (`crossbook_measure.py`, wired into `crossbook_run.py`) are
+implemented — run them in this order from the sidecar root (`server/tts-sidecar`),
+with `<BOOKS_ROOT>` pointing at the re-rendered Keeper library:
+
+1. **Re-render** 2 Keeper books through the app (`SEG_SPK_ENABLED=1`) so recurring
+   characters carry a `voiceUuid` (series-reuse).
+2. **`python -m spikes.srv36.crossbook_run <BOOKS_ROOT>`** — inventory; confirm
+   Keeper shows ≥2 books with a recurring `voiceUuid` key (kind `voiceUuid`).
+3. **G0** (needs the live sidecar): prepare `results/g0_keys_cfg.json` =
+   `{"<voiceUuid>": {"text": "<audition text>", "voice": "qwen-<voiceUuid>"}}` —
+   *confirm the audition-text source + `/synthesize` contract on-box* — then
+   `… crossbook_run <BOOKS_ROOT> --g0`. Writes `crossbook_g0.json` (the floor std
+   G1 divides by) + `crossbook_audition_centroids.json` (reused by G2).
+4. **`--g1`**, **`--g2`**, **`--g6`**, **`--g4`**, **`--g3`** (g3 is a documented
+   stub — emotion isn't on-disk; needs a manuscript-emotion join).
+5. **G5**: build the blind set from G1/G6 low-cosine candidates + matched controls
+   via `blind_listen.build_blind_set` + `extract_listen.extract_clip`, listen blind,
+   then `score_blind` → write `crossbook_g5.json` (`{"fp_rate": …}`).
+6. **`--report`** → per-axis `{go|no-go}`; copy the numbers into the FINDINGS
+   Phase-2 section (the raw `results/*.json` are git-ignored / machine-specific).
+
+The pure scoring is unit-tested (`test_crossbook.py`); this measurement layer is
+operator-run (ffmpeg + weights + sidecar) and validated end-to-end on a no-audio
+fixture (walk + collect + runners + report), not against real renders.

--- a/server/tts-sidecar/spikes/srv36/crossbook.py
+++ b/server/tts-sidecar/spikes/srv36/crossbook.py
@@ -110,3 +110,47 @@ def malformed_gates(per_gate: dict) -> list:
         if d is not None and any(k not in d for k in keys):
             bad.append(gate)
     return sorted(bad)
+
+
+# --- pure aggregation/composition over the per-key/per-book embedding corpus ---
+# (the crossbook_measure I/O layer collects vectors from disk, then calls these)
+
+def _median(values) -> float:
+    a = np.asarray(list(values), np.float64)
+    return float(np.median(a)) if a.size else 0.0
+
+
+def aggregate_drift_stds(per_key_per_book: dict, floor_std: float) -> dict:
+    """G1 over the whole cast: median genuine-voice cross-book drift (in G0
+    floor-std units) across every storage key recurring in >=2 books.
+    per_key_per_book: {voiceUuid: {bookId: [vecs]}}. A key in <2 books has no
+    cross-book signal and is skipped. **Safe-fail:** if NO key recurs across >=2
+    books, returns a high drift (1e9) so cross-book forces no-go rather than a
+    spurious 'consistent'."""
+    per_key = {}
+    for key, per_book in per_key_per_book.items():
+        books = {b: v for b, v in per_book.items() if len(v)}
+        if len(books) < 2:
+            continue
+        per_key[key] = crossbook_genuine_drift_stds(books, floor_std)
+    finite = [s for s in per_key.values() if np.isfinite(s)]
+    drift = _median(finite) if finite else 1e9
+    return {"genuine_drift_stds": drift, "per_key": per_key, "n_keys": len(per_key)}
+
+
+def g6_separation(held_book_by_key: dict, anchors_by_key: dict) -> dict:
+    """G6 out-of-sample per-line separability. Each held-out-book line is scored
+    vs its OWN key's anchor (genuine) and vs every OTHER key's anchor (impostor);
+    returns the genuine-vs-impostor AUC. held_book_by_key: {key: [vecs]} (the
+    held-out book). anchors_by_key: {key: centroid} built from the OTHER books."""
+    genuine, impostor = [], []
+    for key, vecs in held_book_by_key.items():
+        own = anchors_by_key.get(key)
+        if own is None:
+            continue
+        others = [a for k, a in anchors_by_key.items() if k != key]
+        for v in vecs:
+            genuine.append(cosine(v, own))
+            for o in others:
+                impostor.append(cosine(v, o))
+    return {"separation_auc": separation_auc(genuine, impostor)}

--- a/server/tts-sidecar/spikes/srv36/crossbook_measure.py
+++ b/server/tts-sidecar/spikes/srv36/crossbook_measure.py
@@ -168,9 +168,13 @@ def run_g6(by_book: dict, held_out_book: str | None = None) -> dict:
     if len(book_ids) < 2:
         return _write("g6", {"separation_auc": 0.5, "note": "need >=2 books for held-out G6"})
     held = held_out_book or book_ids[-1]
-    held_by_key = {vu: rec["vecs"] for vu, rec in by_book.get(held, {}).items()}
+    recurring = _recurring_keys(by_book)
+    # restrict to recurring keys only — a voice present in just the held-out book
+    # has no anchor and must not enter the genuine/impostor scoring (review I-1)
+    held_by_key = {vu: by_book.get(held, {}).get(vu, {}).get("vecs", [])
+                   for vu in recurring if vu in by_book.get(held, {})}
     anchors: dict = {}
-    for vu in _recurring_keys(by_book):
+    for vu in recurring:
         other_vecs = [v for b, by_key in by_book.items() if b != held
                       for v in by_key.get(vu, {}).get("vecs", [])]
         if other_vecs:

--- a/server/tts-sidecar/spikes/srv36/crossbook_measure.py
+++ b/server/tts-sidecar/spikes/srv36/crossbook_measure.py
@@ -1,0 +1,259 @@
+"""crossbook_measure.py — on-box measurement orchestration for the srv-36
+Phase-2 cross-book spike. Operator-run (needs ffmpeg + the speechbrain weights,
+and the live sidecar for G0). NOT unit-tested: the pure scoring it composes lives
+in crossbook.py (tested); this layer is the disk/audio/sidecar I/O.
+
+Pipeline per gate: collect per-(voiceUuid, book) ECAPA vectors from the
+re-rendered Keeper books (reusing the proven decode->slice->embed loop), then
+feed the tested crossbook helpers, then write results/crossbook_gN.json matching
+GATE_EXPECTED_KEYS so `crossbook_run.py --report` can assemble the verdict.
+
+Run via crossbook_run.py: `python -m spikes.srv36.crossbook_run <BOOKS_ROOT> --g1` etc.
+"""
+from __future__ import annotations
+import json
+import subprocess
+from pathlib import Path
+
+import numpy as np
+
+from spikes.srv36.embed import embed_pcm
+from spikes.srv36.metrics import centroid, cosine
+from spikes.srv36.segments_io import slice_pcm
+from spikes.srv36.gates import is_gate_flagged
+from spikes.srv36.voice_index import iter_series_books, resolve_voice_uuid
+from spikes.srv36 import crossbook as cb
+
+SR = 16000
+FLOOR = 3.0  # min segment seconds (matches the spec's duration floor)
+RESULTS = Path(__file__).resolve().parent / "results"
+
+
+# --------------------------------------------------------------------------
+# Collection — per-(voiceUuid, book) clean-render vectors from disk
+# --------------------------------------------------------------------------
+
+def _decode(audio_path: str, cache: dict) -> bytes:
+    if audio_path not in cache:
+        cache[audio_path] = subprocess.run(
+            ["ffmpeg", "-v", "error", "-i", audio_path,
+             "-ac", "1", "-ar", str(SR), "-f", "s16le", "-"],
+            capture_output=True, check=True,
+        ).stdout
+    return cache[audio_path]
+
+
+def collect_book_vectors(book_dir: str, cast: dict, floor: float = FLOOR) -> dict:
+    """Embed every gate-OK, >=floor-second segment of one rendered book, keyed by
+    the character's resolved voiceUuid (cast.json join). Returns
+    {voiceUuid: {"vecs": [np.ndarray], "meta": [{chapter, sentence_id, start, end}]}}.
+    Mirrors probe_real_library.embed_book_segments but returns RAW vectors (needed
+    for cross-book centroid comparison), keyed by voiceUuid not characterId."""
+    pcm_cache: dict = {}
+    out: dict = {}
+    for segf in sorted(Path(book_dir).glob("*.segments.json")):
+        if ".previous." in segf.name:
+            continue
+        try:
+            data = json.loads(segf.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        mp3 = str(segf).replace(".segments.json", ".mp3")
+        if not Path(mp3).exists():
+            continue
+        chapter = segf.name.replace(".segments.json", "")
+        try:
+            pcm = _decode(mp3, pcm_cache)
+        except Exception:
+            continue
+        for seg in data.get("segments", []):
+            cid = seg.get("characterId") or seg.get("character")
+            if not cid:
+                continue
+            sids = seg.get("sentenceIds") or []
+            sentence_id = "-".join(str(s) for s in sids) if sids else None
+            st, en = seg.get("startSec"), seg.get("endSec")
+            if sentence_id is None or st is None or en is None or (en - st) < floor:
+                continue
+            if is_gate_flagged(seg):
+                continue
+            vu = resolve_voice_uuid(cid, cast)
+            if not vu:
+                continue
+            try:
+                vec = embed_pcm(slice_pcm(pcm, SR, float(st), float(en)), SR)
+            except Exception:
+                continue
+            rec = out.setdefault(vu, {"vecs": [], "meta": []})
+            rec["vecs"].append(vec)
+            rec["meta"].append({"chapter": chapter, "sentence_id": sentence_id,
+                                 "start": float(st), "end": float(en)})
+    return out
+
+
+def collect_series(books_root: str, series: str | None = None) -> dict:
+    """Walk the library and collect per-book vectors for one series (or all).
+    Returns {bookId: {voiceUuid: {"vecs": [...], "meta": [...]}}}."""
+    by_book: dict = {}
+    for b in iter_series_books(books_root):
+        if series and b["series"] != series:
+            continue
+        cast_path = Path(b["cast_path"])
+        cast = json.loads(cast_path.read_text("utf-8")) if cast_path.exists() else {}
+        by_book[b["bookId"]] = collect_book_vectors(str(Path(b["segments_path"]).parent), cast)
+    return by_book
+
+
+def _write(name: str, payload: dict) -> dict:
+    RESULTS.mkdir(parents=True, exist_ok=True)
+    (RESULTS / f"crossbook_{name}.json").write_text(json.dumps(payload, indent=2), "utf-8")
+    return payload
+
+
+def _per_key_per_book(by_book: dict) -> dict:
+    """{voiceUuid: {bookId: [vecs]}} from {bookId: {voiceUuid: {vecs,...}}}."""
+    out: dict = {}
+    for book_id, by_key in by_book.items():
+        for vu, rec in by_key.items():
+            out.setdefault(vu, {})[book_id] = rec["vecs"]
+    return out
+
+
+def _recurring_keys(by_book: dict) -> set:
+    counts: dict = {}
+    for by_key in by_book.values():
+        for vu in by_key:
+            counts[vu] = counts.get(vu, 0) + 1
+    return {vu for vu, n in counts.items() if n >= 2}
+
+
+# --------------------------------------------------------------------------
+# Gate runners — each writes results/crossbook_gN.json
+# --------------------------------------------------------------------------
+
+def run_g1(by_book: dict, floor_std: float) -> dict:
+    """G1 — median genuine-voice cross-book drift, in G0-floor-std units."""
+    out = cb.aggregate_drift_stds(_per_key_per_book(by_book), floor_std)
+    out["floor_std_used"] = floor_std
+    return _write("g1", out)
+
+
+def run_g2(by_book: dict, audition_centroids: dict) -> dict:
+    """G2 — seed divergence + per-voice cross-book spread. audition_centroids:
+    {voiceUuid: centroid} (from G0's K audition renders). central drives Branch
+    A-vs-B; spread sets the (single-series, provisional) sanity-gate band."""
+    ppb = _per_key_per_book(by_book)
+    centrals, spreads, per_key = [], [], {}
+    for vu, per_book in ppb.items():
+        aud = audition_centroids.get(vu)
+        if aud is None:
+            continue
+        book_cens = [centroid(v) for v in per_book.values() if len(v)]
+        if len(book_cens) < 1:
+            continue
+        sd = cb.seed_divergence(aud, book_cens)
+        per_key[vu] = sd
+        centrals.append(sd["central"])
+        spreads.append(sd["spread"])
+    return _write("g2", {
+        "central": cb._median(centrals), "spread": cb._median(spreads),
+        "per_key": per_key, "single_series_provisional": True,
+    })
+
+
+def run_g6(by_book: dict, held_out_book: str | None = None) -> dict:
+    """G6 — out-of-sample per-line separability on a held-out book: each held-out
+    line scored vs its own-key anchor (built from the OTHER books) vs other keys."""
+    book_ids = list(by_book)
+    if len(book_ids) < 2:
+        return _write("g6", {"separation_auc": 0.5, "note": "need >=2 books for held-out G6"})
+    held = held_out_book or book_ids[-1]
+    held_by_key = {vu: rec["vecs"] for vu, rec in by_book.get(held, {}).items()}
+    anchors: dict = {}
+    for vu in _recurring_keys(by_book):
+        other_vecs = [v for b, by_key in by_book.items() if b != held
+                      for v in by_key.get(vu, {}).get("vecs", [])]
+        if other_vecs:
+            anchors[vu] = centroid(other_vecs)
+    out = cb.g6_separation(held_by_key, anchors)
+    out["held_out_book"] = held
+    return _write("g6", out)
+
+
+def run_g4(by_book: dict) -> dict:
+    """G4 — within-book temporal wander: per (key, book), order clean-line
+    cosines-to-(book anchor) by render position and fit a slope; report the
+    median slope + the fraction of slope-flagged lines NOT already per-line
+    low-cosine (residual). Prior: likely no-go (a single config renders the
+    voice near-identically)."""
+    slopes, residual_hits, residual_total = [], 0, 0
+    for by_key in by_book.values():
+        for rec in by_key.values():
+            vecs, meta = rec["vecs"], rec["meta"]
+            if len(vecs) < 3:
+                continue
+            anchor = centroid(vecs)
+            order = sorted(range(len(vecs)),
+                           key=lambda i: (meta[i]["chapter"], meta[i]["start"]))
+            cos_seq = [cosine(vecs[i], anchor) for i in order]
+            slope = cb.wander_slope(cos_seq)
+            slopes.append(slope)
+            # residual: a downward-trend tail not already a low-cosine outlier
+            lo = float(np.percentile(cos_seq, 10)) if cos_seq else 0.0
+            for c in cos_seq:
+                residual_total += 1
+                if slope < -0.01 and c > lo:
+                    residual_hits += 1
+    return _write("g4", {
+        "wander_slope": cb._median([abs(s) for s in slopes]),
+        "residual_fraction": (residual_hits / residual_total) if residual_total else 0.0,
+        "n_units": len(slopes),
+    })
+
+
+def run_g0(keys_cfg: dict, K: int = 12) -> dict:
+    """G0 — same-text content control. NEEDS THE LIVE SIDECAR. For each voiceUuid,
+    render the SAME fixed audition text K times (same config) and embed; the std
+    of pairwise distances is the stochastic+identical-content floor that G1
+    divides by. keys_cfg: {voiceUuid: {"text": <audition text>, "voice": <storage key>}}.
+
+    OPERATOR: confirm the audition-text source and the sidecar /synthesize contract
+    on-box before trusting these numbers — this is the one gate that re-renders.
+    Returns {floor_std_median, per_key, floor_std_by_key}."""
+    from spikes.srv36.synth_client import render
+    per_key, stds, centroids = {}, [], {}
+    for vu, cfg in keys_cfg.items():
+        embs = []
+        for _ in range(K):
+            try:
+                pcm, sr = render(cfg["text"], cfg["voice"])
+                embs.append(embed_pcm(pcm, sr))
+            except Exception:
+                continue
+        if len(embs) < 2:
+            per_key[vu] = {"mean": None, "std": None, "n": len(embs), "withheld": True}
+            continue
+        f = cb.same_text_floor(embs)
+        per_key[vu] = {**f, "n": len(embs)}
+        stds.append(f["std"])
+        centroids[vu] = [float(x) for x in centroid(embs)]  # G2 reuses these
+    # persist audition centroids so --g2 can reuse them without re-rendering
+    _write("audition_centroids", centroids)
+    return _write("g0", {
+        "floor_std_median": cb._median(stds), "per_key": per_key,
+        "floor_std_by_key": {vu: per_key[vu].get("std") for vu in per_key},
+    })
+
+
+def run_g3(by_book: dict) -> dict:
+    """G3 — per-emotion shift. NOT measurable from on-disk renders: the persisted
+    segment record carries no emotion tag (segments-io.ts:54), so a neutral-vs-
+    emotional split needs a manuscript-emotion join by sentenceId — deferred.
+    Writes emotion_shift=0.0 (safe: per_emotion → no-go = 'no material shift
+    measured') with an explicit note rather than fabricating a number."""
+    return _write("g3", {
+        "emotion_shift": 0.0,
+        "note": ("not measurable on-disk — rendered segments carry no emotion tag; "
+                 "needs a manuscript-emotion join by sentenceId (plan M3/I4). "
+                 "Treated as no-material-shift until that join is wired."),
+    })

--- a/server/tts-sidecar/spikes/srv36/crossbook_run.py
+++ b/server/tts-sidecar/spikes/srv36/crossbook_run.py
@@ -55,6 +55,54 @@ if __name__ == "__main__":
         measured = assemble_measured(per_gate)
         verdict = evaluate_axes(measured, thresholds)
         print(json.dumps(verdict, indent=2))
+    elif len(sys.argv) > 2 and sys.argv[2].startswith("--g"):
+        # Measurement gate: python -m spikes.srv36.crossbook_run <BOOKS_ROOT> --gN [series]
+        from spikes.srv36 import crossbook_measure as m
+        books_root, gate = sys.argv[1], sys.argv[2]
+        series = sys.argv[3] if len(sys.argv) > 3 else None
+
+        if gate == "--g0":
+            cfg_path = m.RESULTS / "g0_keys_cfg.json"
+            if not cfg_path.exists():
+                print("ERROR: prepare results/g0_keys_cfg.json first — "
+                      '{"<voiceUuid>": {"text": "<audition text>", "voice": "qwen-<voiceUuid>"}}. '
+                      "OPERATOR: confirm the audition-text source + sidecar /synthesize contract.",
+                      file=sys.stderr)
+                sys.exit(1)
+            keys_cfg = json.loads(cfg_path.read_text("utf-8"))
+            print(json.dumps(m.run_g0(keys_cfg), indent=2, default=str))
+        else:
+            by_book = m.collect_series(books_root, series)
+            n_books = len(by_book)
+            recurring = len(m._recurring_keys(by_book))
+            print(f"collected {n_books} books, {recurring} voiceUuid keys recurring >=2 books",
+                  file=sys.stderr)
+            if gate == "--g1":
+                g0 = m.RESULTS / "crossbook_g0.json"
+                floor = (json.loads(g0.read_text("utf-8")).get("floor_std_median")
+                         if g0.exists() else None)
+                if not floor:
+                    print("WARNING: no G0 floor (run --g0 first); using 1.0 placeholder — "
+                          "G1 stds are NOT trustworthy until G0 runs.", file=sys.stderr)
+                    floor = 1.0
+                print(json.dumps(m.run_g1(by_book, floor), indent=2, default=str))
+            elif gate == "--g2":
+                ac = m.RESULTS / "crossbook_audition_centroids.json"
+                centroids = json.loads(ac.read_text("utf-8")) if ac.exists() else {}
+                if not centroids:
+                    print("WARNING: no audition centroids (run --g0 first); G2 will be empty.",
+                          file=sys.stderr)
+                print(json.dumps(m.run_g2(by_book, centroids), indent=2, default=str))
+            elif gate == "--g6":
+                print(json.dumps(m.run_g6(by_book), indent=2, default=str))
+            elif gate == "--g4":
+                print(json.dumps(m.run_g4(by_book), indent=2, default=str))
+            elif gate == "--g3":
+                print(json.dumps(m.run_g3(by_book), indent=2, default=str))
+            else:
+                print(f"unknown gate {gate} (use --g0..--g6, or --g5 via blind_listen.py)",
+                      file=sys.stderr)
+                sys.exit(1)
     else:
         inv = build_inventory(sys.argv[1])
         Path("spikes/srv36/results/crossbook_inventory.json").write_text(json.dumps(inv, indent=2), "utf-8")

--- a/server/tts-sidecar/spikes/srv36/crossbook_run.py
+++ b/server/tts-sidecar/spikes/srv36/crossbook_run.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
                 g0 = m.RESULTS / "crossbook_g0.json"
                 floor = (json.loads(g0.read_text("utf-8")).get("floor_std_median")
                          if g0.exists() else None)
-                if not floor:
+                if floor is None:  # absent file/key — NOT a legitimate zero floor (review M-1)
                     print("WARNING: no G0 floor (run --g0 first); using 1.0 placeholder — "
                           "G1 stds are NOT trustworthy until G0 runs.", file=sys.stderr)
                     floor = 1.0

--- a/server/tts-sidecar/spikes/srv36/tests/test_crossbook.py
+++ b/server/tts-sidecar/spikes/srv36/tests/test_crossbook.py
@@ -162,3 +162,35 @@ def test_same_text_floor_single_input_returns_zero():
     # single embedding → no pairs → mean and std both 0.0
     out = same_text_floor([np.array([1.0, 0.0])])
     assert out == {"mean": 0.0, "std": 0.0}
+
+
+# --- measurement-wiring aggregation helpers (G1 over the cast, G6 separability) ---
+from spikes.srv36.crossbook import aggregate_drift_stds, g6_separation
+
+
+def test_aggregate_drift_stds_skips_single_book_keys_and_medians():
+    per_key_per_book = {
+        "keyA": {1: [np.array([1.0, 0.0]), np.array([0.99, 0.01])],
+                 2: [np.array([0.98, 0.02]), np.array([1.0, 0.0])]},  # 2 books → counted
+        "keyB": {1: [np.array([0.0, 1.0])]},                          # 1 book → skipped
+    }
+    out = aggregate_drift_stds(per_key_per_book, floor_std=0.01)
+    assert out["n_keys"] == 1 and out["genuine_drift_stds"] < 5.0
+
+
+def test_aggregate_drift_stds_safe_fail_when_no_recurring_keys():
+    # no key recurs across >=2 books → safe-fail high drift forces cross-book no-go
+    out = aggregate_drift_stds({"k": {1: [np.array([1.0, 0.0])]}}, floor_std=0.01)
+    assert out["n_keys"] == 0 and out["genuine_drift_stds"] == 1e9
+
+
+def test_g6_separation_perfect_when_voices_distinct():
+    anchors = {"a": np.array([1.0, 0.0]), "b": np.array([0.0, 1.0])}
+    held = {"a": [np.array([1.0, 0.0])], "b": [np.array([0.0, 1.0])]}
+    assert g6_separation(held, anchors)["separation_auc"] == pytest.approx(1.0)
+
+
+def test_g6_separation_half_when_anchors_identical():
+    anchors = {"a": np.array([1.0, 0.0]), "b": np.array([1.0, 0.0])}
+    held = {"a": [np.array([1.0, 0.0])], "b": [np.array([1.0, 0.0])]}
+    assert g6_separation(held, anchors)["separation_auc"] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary

Pre-writes the srv-36 Phase-2 spike's **on-box measurement orchestration** that the spike plan deferred — so the operator **runs** `--g0..g6` instead of writing the glue live on the GPU box. Builds on the proven Phase-0/1 decode→slice→embed primitive + the `cast.json` `voiceUuid` join + the already-tested cross-book scoring helpers.

- **`crossbook.py`** — two new PURE, unit-tested helpers: `aggregate_drift_stds` (median genuine-voice cross-book drift across keys recurring in ≥2 books; **safe-fails to 1e9** when no key recurs → forces cross-book no-go) and `g6_separation` (held-out per-line genuine-vs-impostor AUC). +4 tests (28/28 green).
- **`crossbook_measure.py`** (new, operator-run I/O) — `collect_book_vectors` / `collect_series` (per-`(voiceUuid, book)` ECAPA vectors, gate-OK + duration floor), and `run_g0..g6` each writing `results/crossbook_gN.json` matching `GATE_EXPECTED_KEYS`. G0 also persists `audition_centroids.json` for G2. **G3** is a documented stub (emotion isn't in the persisted segment — needs a manuscript join). **G0** needs the live sidecar; its audition-text source + `/synthesize` contract are flagged for on-box confirmation.
- **`crossbook_run.py`** — `--g0..--g6` CLI dispatch (threads the G0 floor into G1, audition centroids into G2; clear stderr warnings when a prerequisite gate hasn't run).
- **`README.md`** — Phase-2 operator run order.

Independent review: **Ready to merge** — composition correct end-to-end (every I/O shape matches what the tested helpers consume; result keys match `GATE_EXPECTED_KEYS`; all safe-fail paths force no-go). Its two edge-case findings are fixed (G6 restricted to recurring keys; `--g1` floor guard distinguishes absent from zero).

## Test plan

- `cd server/tts-sidecar && ./.venv/Scripts/python.exe -m pytest spikes/srv36/tests/test_crossbook.py -q` — 28 passing (pure scoring + aggregation).
- End-to-end dry-run on a no-audio fixture library: walk + collect + every `--gN` runner + `--report` all sound; safe-fails to all-no-go with no real measurements.
- The actual audio embedding + the G0 sidecar render are operator/GPU — not exercised in CI.

Refs #665.

🤖 Generated with [Claude Code](https://claude.com/claude-code)