### PR TITLE
feat(server,frontend): Qwen 1.7B-Base in Model Manager — inventory row + load/unload/remove

### DIFF
--- a/server/src/routes/models-inventory.test.ts
+++ b/server/src/routes/models-inventory.test.ts
@@ -128,6 +128,18 @@ describe('buildModelInventory', () => {
       5000,
     );
   }
+  function installQwenBase17() {
+    writeFile(
+      join(
+        hfCache,
+        'models--Qwen--Qwen3-TTS-12Hz-1.7B-Base',
+        'snapshots',
+        'abc',
+        'model.safetensors',
+      ),
+      8000,
+    );
+  }
 
   it('reports a present Kokoro with size, path, residency, and fallback flag', () => {
     installKokoro();
@@ -185,6 +197,46 @@ describe('buildModelInventory', () => {
     const row = inv.items.find((i) => i.id === 'qwen-base')!;
     expect(row.installState).toBe('package-missing');
     expect(row.tier).toBe('standard');
+  });
+
+  it('qwen-base17: present when HF snapshot exists, label matches, kind tts', () => {
+    installQwenBase17();
+    const inv = buildModelInventory(baseDeps());
+    const row = inv.items.find((i) => i.id === 'qwen-base17')!;
+    expect(row).toBeDefined();
+    expect(row.label).toBe('Qwen3-TTS Base (1.7B)');
+    expect(row.kind).toBe('tts');
+    expect(row.present).toBe(true);
+    expect(row.sizeBytes).toBe(8000);
+    expect(row.removable).toBe(true);
+    expect(row.isDefaultEngine).toBe(false);
+    expect(row.isFallbackEngine).toBe(false);
+  });
+
+  it('qwen-base17: absent when snapshot dir is missing', () => {
+    const inv = buildModelInventory(baseDeps());
+    const row = inv.items.find((i) => i.id === 'qwen-base17')!;
+    expect(row.present).toBe(false);
+    expect(row.sizeBytes).toBeNull();
+    expect(row.removable).toBe(false);
+  });
+
+  it('qwen-base17: loaded reflects sidecar.qwenBase17Loaded', () => {
+    installQwenBase17();
+    const inv = buildModelInventory(
+      baseDeps({
+        sidecar: { ...reachableSidecar, qwenBase17Loaded: true },
+      }),
+    );
+    const row = inv.items.find((i) => i.id === 'qwen-base17')!;
+    expect(row.loaded).toBe(true);
+  });
+
+  it('qwen-base17: not loaded when qwenBase17Loaded is false/undefined', () => {
+    installQwenBase17();
+    const inv = buildModelInventory(baseDeps());
+    const row = inv.items.find((i) => i.id === 'qwen-base17')!;
+    expect(row.loaded).toBe(false);
   });
 
   it('coqui row tier is secondary and carries an integrity verdict', () => {
@@ -351,6 +403,19 @@ describe('performRemoval', () => {
     const res = await performRemoval('coqui', repoRoot);
     expect(res).toEqual({ removed: true, freedBytes: 0 });
   });
+
+  it('deletes the qwen-base17 HF snapshot dir and reports freed bytes', async () => {
+    writeFile(
+      join(hfCache, 'models--Qwen--Qwen3-TTS-12Hz-1.7B-Base', 'snapshots', 'abc', 'model.safetensors'),
+      8000,
+    );
+    const res = await performRemoval('qwen-base17', repoRoot);
+    expect(res.removed).toBe(true);
+    expect(res.freedBytes).toBe(8000);
+    expect(
+      dirSizeBytes(join(hfCache, 'models--Qwen--Qwen3-TTS-12Hz-1.7B-Base')).bytes,
+    ).toBe(0);
+  });
 });
 
 describe('POST /api/models/:id/remove', () => {
@@ -384,7 +449,7 @@ describe('GET /api/models/inventory', () => {
     /* The five fixed engine rows are always present even with no sidecar. */
     const ids = res.body.items.map((i: { id: string }) => i.id);
     expect(ids).toEqual(
-      expect.arrayContaining(['kokoro', 'qwen-base', 'qwen-design', 'coqui', 'whisper']),
+      expect.arrayContaining(['kokoro', 'qwen-base', 'qwen-base17', 'qwen-design', 'coqui', 'whisper']),
     );
   });
 });

--- a/server/src/routes/models-inventory.ts
+++ b/server/src/routes/models-inventory.ts
@@ -37,6 +37,7 @@ import {
   kokoroWeightDir,
   coquiWeightDir,
   qwenBaseRepoDir,
+  qwenBase17RepoDir,
   qwenDesignRepoDir,
   whisperRepoDir,
   dirSizeBytes,
@@ -60,6 +61,7 @@ const OLLAMA_TIMEOUT_MS = 2_000;
 export type ModelInventoryId =
   | 'kokoro'
   | 'qwen-base'
+  | 'qwen-base17'
   | 'qwen-design'
   | 'coqui'
   | 'whisper'
@@ -201,6 +203,32 @@ export function buildModelInventory(deps: InventoryDeps): ModelInventoryResponse
       present: weightsPresent,
       sizeBytes: weightsPresent ? qwenDesignSize.bytes : null,
       diskPath: qwenDesignPath,
+      loaded,
+      installState: deriveEngineHealth('qwen', { packageInstalled, weightsPresent, loaded }).state,
+      tier: engineTier('qwen'),
+      isDefaultEngine: false,
+      isFallbackEngine: false,
+      removable: weightsPresent,
+      updatable: true,
+      integrity: engineIntegrity('qwen', repoRoot),
+    });
+  }
+
+  /* ── Qwen3-TTS Base 1.7B (button-driven synth model, pr-1008) ──────── */
+  const qwenBase17Path = qwenBase17RepoDir();
+  const qwenBase17Size = dirSizeBytes(qwenBase17Path);
+  const qwenBase17Present = qwenBase17Size.bytes > 0;
+  {
+    const weightsPresent = qwenBase17Present;
+    const loaded = sidecar.qwenBase17Loaded === true;
+    const packageInstalled = pkgInstalled(sidecar.qwenPackageInstalled, qwenPackageInstalled(repoRoot));
+    items.push({
+      id: 'qwen-base17',
+      kind: 'tts',
+      label: 'Qwen3-TTS Base (1.7B)',
+      present: weightsPresent,
+      sizeBytes: weightsPresent ? qwenBase17Size.bytes : null,
+      diskPath: qwenBase17Path,
       loaded,
       installState: deriveEngineHealth('qwen', { packageInstalled, weightsPresent, loaded }).state,
       tier: engineTier('qwen'),
@@ -380,6 +408,8 @@ function removalPaths(id: string, repoRoot: string): string[] {
       return [qwenBaseRepoDir()];
     case 'qwen-design':
       return [qwenDesignRepoDir()];
+    case 'qwen-base17':
+      return [qwenBase17RepoDir()];
     case 'coqui':
       return [coquiWeightDir()];
     case 'whisper':

--- a/server/src/tts/model-paths.ts
+++ b/server/src/tts/model-paths.ts
@@ -18,6 +18,7 @@ import { coquiModelDir } from './coqui-install-detect.js';
 /* Same repo ids the sidecar engines resolve (main.py), env-overridable in
    lockstep so a relocated model is sized/removed where it actually lives. */
 const QWEN_BASE_MODEL = process.env.QWEN_BASE_MODEL || 'Qwen/Qwen3-TTS-12Hz-0.6B-Base';
+const QWEN_BASE17_MODEL = process.env.QWEN_BASE_17B_MODEL || 'Qwen/Qwen3-TTS-12Hz-1.7B-Base';
 const QWEN_DESIGN_MODEL =
   process.env.QWEN_VOICEDESIGN_MODEL || 'Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign';
 const ASR_MODEL = process.env.ASR_MODEL || 'base';
@@ -70,9 +71,12 @@ export function coquiWeightDir(): string {
   return coquiModelDir();
 }
 
-/** Qwen Base / VoiceDesign HF snapshot repo dirs. */
+/** Qwen Base / Base-1.7B / VoiceDesign HF snapshot repo dirs. */
 export function qwenBaseRepoDir(): string {
   return hfRepoDir(QWEN_BASE_MODEL);
+}
+export function qwenBase17RepoDir(): string {
+  return hfRepoDir(QWEN_BASE17_MODEL);
 }
 export function qwenDesignRepoDir(): string {
   return hfRepoDir(QWEN_DESIGN_MODEL);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4860,6 +4860,7 @@ async function mockPauseAnalysis(_: { manuscriptId: string }): Promise<void> {
 export type ModelInventoryId =
   | 'kokoro'
   | 'qwen-base'
+  | 'qwen-base17'
   | 'qwen-design'
   | 'coqui'
   | 'whisper'

--- a/src/views/model-manager.test.tsx
+++ b/src/views/model-manager.test.tsx
@@ -235,6 +235,76 @@ describe('ModelManagerView — inventory', () => {
   });
 });
 
+describe('ModelManagerView — qwen-base17 row', () => {
+  const QWEN_BASE17_ITEM = {
+    id: 'qwen-base17' as const,
+    kind: 'tts' as const,
+    label: 'Qwen3-TTS Base (1.7B)',
+    present: true,
+    sizeBytes: 2_000_000_000,
+    diskPath: 'hub/models--Qwen--Qwen3-TTS-12Hz-1.7B-Base',
+    loaded: false,
+    installState: 'ready' as const,
+    isDefaultEngine: false,
+    isFallbackEngine: false,
+    removable: true,
+    updatable: true,
+  };
+
+  beforeEach(() => {
+    mockInventory.mockResolvedValue({
+      ...INVENTORY,
+      items: [...INVENTORY.items, QWEN_BASE17_ITEM],
+    });
+  });
+
+  it('renders a qwen-base17 row with label and disk path', async () => {
+    renderManager();
+    const row = await screen.findByTestId('model-row-qwen-base17');
+    expect(within(row).getByText('Qwen3-TTS Base (1.7B)')).toBeInTheDocument();
+    expect(within(row).getByText(/1.7B-Base/)).toBeInTheDocument();
+  });
+
+  it('Load calls api.loadSidecar with { engine: "qwen", model: "1.7b" }', async () => {
+    renderManager();
+    const row = await screen.findByTestId('model-row-qwen-base17');
+    within(row).getByRole('button', { name: /load model/i }).click();
+    await waitFor(() =>
+      expect(mockLoad).toHaveBeenCalledWith({ engine: 'qwen', model: '1.7b' }),
+    );
+  });
+
+  it('Unload calls api.unloadSidecar with { engine: "qwen", model: "1.7b" }', async () => {
+    mockInventory.mockResolvedValue({
+      ...INVENTORY,
+      items: [...INVENTORY.items, { ...QWEN_BASE17_ITEM, loaded: true }],
+    });
+    renderManager();
+    const row = await screen.findByTestId('model-row-qwen-base17');
+    within(row).getByRole('button', { name: /stop/i }).click();
+    await waitFor(() =>
+      expect(mockUnload).toHaveBeenCalledWith({ engine: 'qwen', model: '1.7b' }),
+    );
+  });
+
+  it('Remove opens the confirm modal and calls api.removeModel("qwen-base17")', async () => {
+    mockRemove.mockResolvedValue({ ok: true, id: 'qwen-base17', removed: true, freedBytes: 2_000_000_000 });
+    renderManager();
+    const row = await screen.findByTestId('model-row-qwen-base17');
+    within(row).getByTestId('model-remove-qwen-base17').click();
+    const modal = await screen.findByTestId('model-remove-confirm');
+    within(modal).getByTestId('model-remove-confirm-button').click();
+    await waitFor(() => expect(mockRemove).toHaveBeenCalledWith('qwen-base17'));
+  });
+
+  it('qwen-base Load still calls without model qualifier (not affected by 1.7b change)', async () => {
+    renderManager();
+    const qwen = await screen.findByTestId('model-row-qwen-base');
+    within(qwen).getByRole('button', { name: /load model/i }).click();
+    await waitFor(() => expect(mockLoad).toHaveBeenCalledWith({ engine: 'qwen' }));
+  });
+});
+
 describe('ModelManagerView — remove', () => {
   it('removes an idle, non-default, non-fallback model via the confirm modal', async () => {
     renderManager();

--- a/src/views/model-manager.tsx
+++ b/src/views/model-manager.tsx
@@ -32,7 +32,14 @@ const INVENTORY_POLL_MS = 30_000;
 const TTS_ENGINE_BY_ID: Partial<Record<string, 'coqui' | 'kokoro' | 'qwen'>> = {
   kokoro: 'kokoro',
   'qwen-base': 'qwen',
+  'qwen-base17': 'qwen',
   coqui: 'coqui',
+};
+
+/* For rows that need a specific model qualifier on the sidecar load/unload call
+   (e.g. qwen-base17 → { engine: 'qwen', model: '1.7b' }). */
+const TTS_LOAD_MODEL_BY_ID: Partial<Record<string, '1.7b'>> = {
+  'qwen-base17': '1.7b',
 };
 
 /* Inventory ids with an in-app installer, rendered inline under the row (fs-23
@@ -434,6 +441,7 @@ function ModelRow({
   const [installerOpen, setInstallerOpen] = useState(false);
   const Installer = INSTALLER_BY_ID[item.id];
   const engine = TTS_ENGINE_BY_ID[item.id];
+  const loadModel = TTS_LOAD_MODEL_BY_ID[item.id];
   const isAnalyzer = item.kind === 'analyzer';
   /* A Load/Unload pill is meaningful only when the engine is actually usable.
      For analyzer/ollama rows installState is undefined — keep them working by
@@ -464,13 +472,13 @@ function ModelRow({
   const doLoad = () =>
     onAction(() =>
       engine
-        ? api.loadSidecar({ engine })
+        ? api.loadSidecar({ engine, ...(loadModel ? { model: loadModel } : {}) })
         : api.loadAnalyzer(analyzerModel ? { model: analyzerModel } : undefined),
     );
   const doStop = () =>
     onAction(() =>
       engine
-        ? api.unloadSidecar({ engine })
+        ? api.unloadSidecar({ engine, ...(loadModel ? { model: loadModel } : {}) })
         : api.unloadAnalyzer(analyzerModel ? { model: analyzerModel } : undefined),
     );
 


### PR DESCRIPTION
## Summary

Closes the Model Manager gap left by #1008: the Qwen **1.7B-Base** had a top-bar pill + cast-picker toggle but no inventory row, so it never appeared in the Model Manager. This adds a `qwen-base17` row — **"Qwen3-TTS Base (1.7B)"** — with present? · size · disk path · **Load / Unload / Remove**, full parity with the 0.6B `qwen-base`.

- `model-paths.ts` — `QWEN_BASE17_MODEL` const + `qwenBase17RepoDir()`.
- `models-inventory.ts` — `qwen-base17` in the id union, inventory block (reads `sidecar.qwenBase17Loaded`, same package probe as 0.6B), and a `removalPaths` case (deletes the **1.7B** HF repo, not the 0.6B).
- `model-manager.tsx` — `TTS_ENGINE_BY_ID` entry + `TTS_LOAD_MODEL_BY_ID = { 'qwen-base17': '1.7b' }`; Load/Unload spread `model` only when present, so `qwen-base` stays `{engine:'qwen'}` and `qwen-base17` sends `{engine:'qwen', model:'1.7b'}`.
- `api.ts` — `qwen-base17` added to the mirrored frontend `ModelInventoryId` union.

## Test plan

5 server (`models-inventory`) + 5 frontend (`model-manager`) cases; full `npm run verify` green (typecheck + all tests + e2e + build). No cloud CI requested — local battery is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UX4gD6L7bmjjuNoAGqzhCa
