### PR TITLE
feat(sidecar): srv-36 Phase-2 --counts sizing helper (clean segments per voiceUuid per book)

### DIFF
--- a/server/tts-sidecar/spikes/srv36/README.md
+++ b/server/tts-sidecar/spikes/srv36/README.md
@@ -113,6 +113,12 @@ with `<BOOKS_ROOT>` pointing at the re-rendered Keeper library:
    characters carry a `voiceUuid` (series-reuse).
 2. **`python -m spikes.srv36.crossbook_run <BOOKS_ROOT>`** — inventory; confirm
    Keeper shows ≥2 books with a recurring `voiceUuid` key (kind `voiceUuid`).
+2b. **`… crossbook_run <BOOKS_ROOT> --counts [target]`** (GPU-free, no embed) —
+   clean ≥3 s dialogue-segment counts per recurring `voiceUuid` per book, flagged
+   `OK`/`THIN` vs `target` (default 20). **Sizing tool: you do NOT need all
+   chapters.** Render a bounded matched subset (~5–8 chapters/book to start),
+   run `--counts`, and render more only for characters flagged `THIN` (or if no
+   keys recur — then re-render the SAME characters in both books).
 3. **G0** (needs the live sidecar): prepare `results/g0_keys_cfg.json` =
    `{"<voiceUuid>": {"text": "<audition text>", "voice": "qwen-<voiceUuid>"}}` —
    *confirm the audition-text source + `/synthesize` contract on-box* — then

--- a/server/tts-sidecar/spikes/srv36/crossbook_measure.py
+++ b/server/tts-sidecar/spikes/srv36/crossbook_measure.py
@@ -43,6 +43,22 @@ def _decode(audio_path: str, cache: dict) -> bytes:
     return cache[audio_path]
 
 
+def _clean_seg_cid(seg: dict, floor: float):
+    """characterId of a countable CLEAN dialogue segment, or None to skip:
+    needs a characterId, a non-empty sentenceIds, a valid duration >= floor, and
+    must not be gate-flagged. Shared by collect_book_vectors (embeds) and
+    count_clean_segments (counts) so both apply the identical clean-render filter."""
+    cid = seg.get("characterId") or seg.get("character")
+    if not cid or not (seg.get("sentenceIds") or []):
+        return None
+    st, en = seg.get("startSec"), seg.get("endSec")
+    if st is None or en is None or (en - st) < floor:
+        return None
+    if is_gate_flagged(seg):
+        return None
+    return cid
+
+
 def collect_book_vectors(book_dir: str, cast: dict, floor: float = FLOOR) -> dict:
     """Embed every gate-OK, >=floor-second segment of one rendered book, keyed by
     the character's resolved voiceUuid (cast.json join). Returns
@@ -67,27 +83,54 @@ def collect_book_vectors(book_dir: str, cast: dict, floor: float = FLOOR) -> dic
         except Exception:
             continue
         for seg in data.get("segments", []):
-            cid = seg.get("characterId") or seg.get("character")
-            if not cid:
-                continue
-            sids = seg.get("sentenceIds") or []
-            sentence_id = "-".join(str(s) for s in sids) if sids else None
-            st, en = seg.get("startSec"), seg.get("endSec")
-            if sentence_id is None or st is None or en is None or (en - st) < floor:
-                continue
-            if is_gate_flagged(seg):
+            cid = _clean_seg_cid(seg, floor)
+            if cid is None:
                 continue
             vu = resolve_voice_uuid(cid, cast)
             if not vu:
                 continue
+            sentence_id = "-".join(str(s) for s in seg["sentenceIds"])
+            st, en = float(seg["startSec"]), float(seg["endSec"])
             try:
-                vec = embed_pcm(slice_pcm(pcm, SR, float(st), float(en)), SR)
+                vec = embed_pcm(slice_pcm(pcm, SR, st, en), SR)
             except Exception:
                 continue
             rec = out.setdefault(vu, {"vecs": [], "meta": []})
             rec["vecs"].append(vec)
             rec["meta"].append({"chapter": chapter, "sentence_id": sentence_id,
                                  "start": float(st), "end": float(en)})
+    return out
+
+
+def count_clean_segments(books_root: str, series: str | None = None,
+                         floor: float = FLOOR) -> dict:
+    """GPU-FREE sizing helper: count clean >=floor-second dialogue segments per
+    voiceUuid per book — NO audio decode, NO embed (just reads segments.json +
+    cast.json). Use before the expensive re-render/embed to check each recurring
+    character has enough clean lines per book for a stable cross-book centroid.
+    Returns {voiceUuid: {"character_id": cid, "by_book": {bookId: count}}}."""
+    out: dict = {}
+    for b in iter_series_books(books_root):
+        if series and b["series"] != series:
+            continue
+        cast_path = Path(b["cast_path"])
+        cast = json.loads(cast_path.read_text("utf-8")) if cast_path.exists() else {}
+        for segf in sorted(Path(b["segments_path"]).parent.glob("*.segments.json")):
+            if ".previous." in segf.name:
+                continue
+            try:
+                data = json.loads(segf.read_text("utf-8"))
+            except Exception:
+                continue
+            for seg in data.get("segments", []):
+                cid = _clean_seg_cid(seg, floor)
+                if cid is None:
+                    continue
+                vu = resolve_voice_uuid(cid, cast)
+                if not vu:
+                    continue
+                rec = out.setdefault(vu, {"character_id": cid, "by_book": {}})
+                rec["by_book"][b["bookId"]] = rec["by_book"].get(b["bookId"], 0) + 1
     return out
 
 

--- a/server/tts-sidecar/spikes/srv36/crossbook_run.py
+++ b/server/tts-sidecar/spikes/srv36/crossbook_run.py
@@ -55,6 +55,34 @@ if __name__ == "__main__":
         measured = assemble_measured(per_gate)
         verdict = evaluate_axes(measured, thresholds)
         print(json.dumps(verdict, indent=2))
+    elif len(sys.argv) > 2 and sys.argv[2] == "--counts":
+        # GPU-free sizing: python -m spikes.srv36.crossbook_run <BOOKS_ROOT> --counts [series] [target]
+        # Counts clean >=3s dialogue segments per recurring voiceUuid per book so
+        # you can decide whether the re-render has enough lines for stable centroids.
+        from spikes.srv36 import crossbook_measure as m
+        books_root = sys.argv[1]
+        series = sys.argv[3] if len(sys.argv) > 3 and not sys.argv[3].isdigit() else None
+        target = next((int(a) for a in sys.argv[3:] if a.isdigit()), 20)
+        counts = m.count_clean_segments(books_root, series)
+        recurring = {vu: r for vu, r in counts.items() if len(r["by_book"]) >= 2}
+        print(f"{len(recurring)} voiceUuid key(s) recur in >=2 books "
+              f"(target >={target} clean >=3s segments per book for a stable centroid):")
+        for vu, r in sorted(recurring.items(), key=lambda kv: min(kv[1]["by_book"].values())):
+            worst = min(r["by_book"].values())
+            flag = "OK  " if worst >= target else "THIN"
+            books_str = "  ".join(f"{b}={n}" for b, n in sorted(r["by_book"].items()))
+            print(f"  [{flag}] {r['character_id']:<22} {books_str}   ({vu})")
+        thin = sorted(r["character_id"] for r in recurring.values()
+                      if min(r["by_book"].values()) < target)
+        if not recurring:
+            print("NO recurring voiceUuid keys across >=2 books — re-render the SAME "
+                  "characters in both books (carried voiceUuid via series-reuse).",
+                  file=sys.stderr)
+        elif thin:
+            print(f"render more chapters featuring: {', '.join(thin)}", file=sys.stderr)
+        else:
+            print("all recurring characters meet the target — ready to run --g1..--g6.",
+                  file=sys.stderr)
     elif len(sys.argv) > 2 and sys.argv[2].startswith("--g"):
         # Measurement gate: python -m spikes.srv36.crossbook_run <BOOKS_ROOT> --gN [series]
         from spikes.srv36 import crossbook_measure as m

--- a/server/tts-sidecar/spikes/srv36/tests/test_crossbook_measure.py
+++ b/server/tts-sidecar/spikes/srv36/tests/test_crossbook_measure.py
@@ -1,0 +1,41 @@
+"""GPU-free tests for the measurement layer's pure parts (segment counting /
+clean-render predicate). The audio decode + embed paths need ffmpeg + weights
+and are operator-run, not tested here."""
+import json
+
+from spikes.srv36.crossbook_measure import _clean_seg_cid, count_clean_segments
+
+
+def test_clean_seg_cid_accepts_and_rejects():
+    floor = 3.0
+    assert _clean_seg_cid({"characterId": "sophie", "sentenceIds": [1],
+                           "startSec": 0.0, "endSec": 4.0}, floor) == "sophie"
+    # too short
+    assert _clean_seg_cid({"characterId": "s", "sentenceIds": [1],
+                           "startSec": 0.0, "endSec": 2.0}, floor) is None
+    # no sentenceIds (non-dialogue, e.g. chapter title)
+    assert _clean_seg_cid({"characterId": "s", "sentenceIds": [],
+                           "startSec": 0.0, "endSec": 9.0}, floor) is None
+    # gate-flagged (ASR drift) → excluded
+    assert _clean_seg_cid({"characterId": "s", "sentenceIds": [1], "startSec": 0.0,
+                           "endSec": 9.0, "asr": {"verdict": "drift"}}, floor) is None
+
+
+def _mk_book(root, book, segs):
+    d = root / "author" / "keeper" / book / "audio"
+    d.mkdir(parents=True)
+    (d / "c1.segments.json").write_text(json.dumps({"segments": segs}), "utf-8")
+    (root / "author" / "keeper" / book / "cast.json").write_text(
+        json.dumps({"characters": [{"id": "sophie", "voice": {"voiceUuid": "u-soph"}}]}), "utf-8")
+
+
+def test_count_clean_segments_per_voiceuuid_per_book(tmp_path):
+    clean = {"characterId": "sophie", "sentenceIds": [1], "startSec": 0.0, "endSec": 4.0}
+    short = {"characterId": "sophie", "sentenceIds": [2], "startSec": 4.0, "endSec": 5.0}
+    flagged = {"characterId": "sophie", "sentenceIds": [3], "startSec": 5.0,
+               "endSec": 9.0, "asr": {"verdict": "drift"}}
+    _mk_book(tmp_path, "book1", [clean, clean, short, flagged])  # 2 clean (short+flagged excluded)
+    _mk_book(tmp_path, "book2", [clean])                          # 1 clean
+    out = count_clean_segments(str(tmp_path))
+    assert out["u-soph"]["character_id"] == "sophie"
+    assert out["u-soph"]["by_book"] == {"book1": 2, "book2": 1}


### PR DESCRIPTION
## Summary

A GPU-free pre-render **sizing helper** so the operator can decide how many chapters to re-render for the srv-36 Phase-2 spike instead of guessing — or wastefully rendering whole books.

- **`crossbook_measure.count_clean_segments`** — counts clean ≥3 s, gate-OK dialogue segments per `voiceUuid` per book by reading `segments.json` + `cast.json` only (**no ffmpeg decode, no embed**). Extracted the shared clean-render predicate `_clean_seg_cid` so `collect_book_vectors` (embeds) and the counter apply the identical filter (DRY).
- **`crossbook_run.py … --counts [target]`** — prints recurring `voiceUuid` keys with per-book counts flagged `OK`/`THIN` vs `target` (default 20), plus a stderr verdict (`render more chapters featuring: …` / `ready to run --g1..g6` / `no recurring keys`).
- **`test_crossbook_measure.py`** (new) — GPU-free tests for the predicate + counter.
- **README** — `--counts` added as run-order step 2b (you do **not** need all chapters; bounded matched subsets over target are enough).

Answers the operator question "how many chapters?": render a bounded matched subset (~5–8 chapters/book to start), run `--counts`, render more only for `THIN` characters.

## Test plan

- `cd server/tts-sidecar && ./.venv/Scripts/python.exe -m pytest spikes/srv36/tests/test_crossbook_measure.py spikes/srv36/tests/test_crossbook.py -q` — 30 passing.
- `--counts` dry-run on a synthetic fixture: correctly flags `THIN` vs target and prints the per-book counts + "render more" hint. The audio/embed paths are unchanged (the refactor only shares the existing filter predicate).

Refs #665.

🤖 Generated with [Claude Code](https://claude.com/claude-code)