### PR TITLE
fix(sidecar): language-aware ref_text in Qwen voice design (es/fr/de/ru calibration)

### DIFF
--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -1142,6 +1142,40 @@ class QwenEngine(Engine):
         "The quick brown fox jumps over the lazy dog, "
         "and she wondered what tomorrow would bring."
     )
+    # fs-41/fs-50 (seam 5) — language-aware calibration. The English
+    # CALIBRATION_TEXT above stays the default; a non-English voice needs a
+    # phonetically rich line in ITS OWN language so the design reference clip +
+    # clone prompt fix the timbre on the right phoneme set. An English ref_text
+    # on a Spanish voice (the "quick brown fox" baked into every es voice) was
+    # the gap the Spanish canary surfaced. Values are well-known per-language
+    # pangrams + a reflective tail mirroring the English line's prosody. Keys are
+    # the sidecar language WORD (sidecarLanguageName → e.g. 'Spanish').
+    CALIBRATION_TEXTS = {
+        "Spanish": (
+            "El veloz murciélago hindú comía feliz cardillo y kiwi, "
+            "y se preguntaba qué traería el mañana."
+        ),
+        "French": (
+            "Portez ce vieux whisky au juge blond qui fume, "
+            "et demandez-vous ce que demain réserve."
+        ),
+        "German": (
+            "Zwölf Boxkämpfer jagen Viktor quer über den großen Sylter Deich, "
+            "und sie fragte sich, was der morgige Tag bringen würde."
+        ),
+        "Russian": (
+            "Съешь же ещё этих мягких французских булок да выпей чаю, "
+            "и она подумала, что принесёт завтрашний день."
+        ),
+    }
+
+    def _calibration_text(self, language: Optional[str]) -> str:
+        """Short, phonetically rich calibration/ref_text line in `language` (the
+        sidecar language WORD, e.g. 'Spanish'). Falls back to the English
+        CALIBRATION_TEXT for English/unknown languages, so English behaviour is
+        byte-identical and an unmapped language degrades to English, never fails."""
+        lang = (language or "").strip()
+        return self.CALIBRATION_TEXTS.get(lang, self.CALIBRATION_TEXT)
 
     def __init__(self) -> None:
         self._base: Any = None  # resident clone/synth model (0.6B-Base)
@@ -1681,8 +1715,9 @@ class QwenEngine(Engine):
         # voice the SHORT CALIBRATION_TEXT here, never the caller's evidence
         # quote (up to 320 chars). The reference is generated on the heavy 1.7B
         # VoiceDesign model, and voicing a long quote there at design-RTF ~10 is
-        # what pushed cold designs past the 120s server budget.
-        ref_text = self.CALIBRATION_TEXT
+        # what pushed cold designs past the 120s server budget. fs-41/fs-50
+        # (seam 5) — in the voice's OWN language, not a hardcoded English line.
+        ref_text = self._calibration_text(lang)
         # The audition preview speaks the caller's own calibration line, so the
         # UI plays back the character's actual words AND the MP3 the design
         # route caches matches the "Play 12s" player's cache key (the server
@@ -1805,7 +1840,8 @@ class QwenEngine(Engine):
         import torch  # type: ignore
 
         lang = (language or self.DEFAULT_LANGUAGE).strip() or self.DEFAULT_LANGUAGE
-        ref_text = self.CALIBRATION_TEXT
+        # fs-41/fs-50 (seam 5) — language-aware ref_text (see design_voice).
+        ref_text = self._calibration_text(lang)
         audition_text = (calibration_text or self.CALIBRATION_TEXT).strip() or self.CALIBRATION_TEXT
 
         base_pt, _base_json = self._voice_paths(base_voice_id)

--- a/server/tts-sidecar/tests/test_calibration_i18n.py
+++ b/server/tts-sidecar/tests/test_calibration_i18n.py
@@ -1,0 +1,47 @@
+"""fs-41/fs-50 (seam 5) — the Qwen voice-design ref_text/calibration line is
+language-aware. A hardcoded English ref_text baked into every non-English voice
+("the quick brown fox jumps over the lazy dog" on a Spanish voice) was the gap
+the Spanish canary surfaced: the clone prompt fixed the timbre on English
+phonemes. These tests pin `QwenEngine._calibration_text` — a per-language pangram
+for the mapped languages, the English CALIBRATION_TEXT for English/unknown, and
+the English path byte-unchanged."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SIDECAR_ROOT = Path(__file__).resolve().parent.parent
+if str(SIDECAR_ROOT) not in sys.path:
+    sys.path.insert(0, str(SIDECAR_ROOT))
+
+import main  # noqa: E402
+
+
+def _engine() -> "main.QwenEngine":
+    # __init__ sets up locks/state only (no model load) — cheap to construct.
+    return main.QwenEngine()
+
+
+def test_spanish_calibration_is_spanish_not_the_english_pangram() -> None:
+    text = _engine()._calibration_text("Spanish")
+    assert "murciélago" in text  # the Spanish pangram phoneme set
+    assert "quick brown fox" not in text  # NOT the English line
+
+
+def test_each_mapped_language_returns_its_own_line() -> None:
+    eng = _engine()
+    assert "Portez ce vieux whisky" in eng._calibration_text("French")
+    assert "Boxkämpfer" in eng._calibration_text("German")
+    assert "французских булок" in eng._calibration_text("Russian")
+
+
+def test_english_and_unknown_fall_back_to_the_default_calibration_text() -> None:
+    eng = _engine()
+    default = main.QwenEngine.CALIBRATION_TEXT
+    assert eng._calibration_text("English") == default
+    assert eng._calibration_text("Klingon") == default  # unmapped → English
+    assert eng._calibration_text(None) == default
+    assert eng._calibration_text("") == default
+    # English default is still the quick-brown-fox line (byte-unchanged).
+    assert "quick brown fox" in default


### PR DESCRIPTION
## Summary

Fixes the one genuine defect the **fs-41/fs-50 Spanish canary** surfaced (the other two "findings" were API-test-harness artifacts, not server bugs — see below). Qwen voice design hardcoded the English `CALIBRATION_TEXT` ("The quick brown fox…") as the `ref_text` the clone prompt is built from, regardless of the voice's language — so every non-English voice had its timbre fixed on English phonemes.

- **`server/tts-sidecar/main.py`**: per-language `CALIBRATION_TEXTS` map (es/fr/de/ru pangrams) + `_calibration_text(language)` helper, used for `ref_text` in both design paths (`design_voice` + the emotion-variant path). English/unknown fall back to the existing `CALIBRATION_TEXT`, so the **English path is byte-unchanged** and an unmapped language degrades to English rather than failing. The audition preview (already speaks the caller's evidence quote) + its server cache-key contract are untouched.
- **`server/src/__fixtures__/the-coalfall-commission.es.md`**: a faithful Spanish translation of the canonical book (mirrors the `.ru.md` variant) — the canary input, reusable for future Spanish regression.

The canary itself was strongly positive: Qwen synthesises **intelligible, accurate Spanish** (Whisper ASR round-trip recovered the source text almost verbatim, 0 QA-gate repairs) — this fix improves accent/naturalness, not intelligibility.

## Test plan

- New `server/tts-sidecar/tests/test_calibration_i18n.py` (3 cases: Spanish/French/German/Russian return their own line; English/unknown/None/"" fall back to the English default byte-unchanged).
- `test_qwen3.py` stays green (57 passed). `main.py` parses clean.

## Note on verification

Pushed with `--no-verify` (author-authorized) because the **local pre-push e2e is failing on an overloaded dev box** (orphaned dev-server processes → `page.goto` 30s navigation timeouts on unrelated *frontend* specs — confirmed environmental: 2 of 3 pass in isolation, the third fails on navigation timeout, not assertion). A **sidecar-only change cannot affect frontend mock-mode e2e**, and the change's real gate (sidecar pytest + server tests) is green. The `run-ci` label triggers the **full battery on a clean Ubuntu runner** to verify in a clean room.

Closes #1017
Refs the fs-50 (seam 5) Qwen design-path i18n work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLg2Zazw3rSSE2kRq1JUzz
