### PR TITLE
feat(server,frontend): fs-41/fs-50 seam 4a — voice-library language filtering

### DIFF
--- a/docs/superpowers/plans/2026-06-23-fs41-fs50-seam4a-voice-filter.md
+++ b/docs/superpowers/plans/2026-06-23-fs41-fs50-seam4a-voice-filter.md
@@ -1,0 +1,168 @@
+# fs-41/fs-50 Seam 4a — Voice-library language filtering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** In a non-English book, the cast/reuse voice picker hides voices that can't read the book's language (English presets + cross-language designed voices) behind a non-silent **"N hidden · can't read &lt;Language&gt;" + "show all"** toggle — so a user can't pick a voice that gets silently cleared at generation. (This is the fs-41 "filter the voice library" deliverable.)
+
+**Architecture:** The server surfaces a per-voice BCP-47 `languageCode` on `DerivedVoice` (derived from the designed Qwen voice's baked manifest language; presets/non-designed → undefined = English-only). The frontend `VoiceLibraryPanel` already receives `bookLanguage`; when the book is non-English, it filters to language-eligible voices with a hide-count + "show all" escape hatch. English books are unaffected (no filter).
+
+**Tech Stack:** TypeScript (ESM, `.js` imports), Node 20+ (server), React (Vite), Vitest.
+
+## Global Constraints
+
+- **English books unchanged.** The filter only activates when `bookLanguage !== 'en'`; an English book's picker is byte-identical. No existing English assertion modified.
+- **Eligibility (Qwen-only, current invariant):** for a non-English book, a voice is eligible iff it is a designed voice whose `languageCode === bookLanguage`; presets/English-designed/cross-language voices are ineligible. (es/fr/de aren't `supported` yet, so today this activates for Russian books and is forward-compatible.)
+- **Non-silent:** ineligible voices are hidden but counted, with a "show all" override (the issue's required escape hatch) — never a silent drop.
+- The per-voice language is **derived server-side** (the manifest is authoritative; the frontend can't read it). ESM `.js`. Commit `<type>(<scope>): <subject>`. Husky pre-commit runs the in-scope test legs (green, no `--no-verify`). Work from the worktree `C:/Claude/Audiobook-Generator-wt-fs41`, branch `docs/docs-fs41-fs50-seam4-voice-filter`.
+
+---
+
+### Task 1: Surface a per-voice `languageCode` on `DerivedVoice`
+
+**Files:**
+- Modify: `server/src/tts/language-registry.ts` (add a `codeForSidecarName` reverse helper)
+- Modify: `server/src/routes/voices.ts` (`DerivedVoice` interface + the aggregation that reads Qwen manifests)
+- Modify: `openapi.yaml` (`Voice` schema gains `languageCode`) + regen `src/lib/api-types.ts`
+- Test: `server/src/routes/voices.test.ts` (+ a `language-registry` test for the reverse helper)
+
+**Interfaces:**
+- `codeForSidecarName(word: string): string | undefined` — reverse of `sidecarName` (e.g. `'Russian' → 'ru'`, `'Spanish' → 'es'`).
+- `DerivedVoice.languageCode?: string` — BCP-47 code of a designed voice's baked language; absent for presets/non-designed voices.
+
+- [ ] **Step 1: Write the failing registry-helper test** — append to `server/src/tts/language-registry.test.ts`:
+
+```typescript
+import { codeForSidecarName } from './language-registry.js';
+describe('codeForSidecarName', () => {
+  it('maps sidecar words back to BCP-47 codes', () => {
+    expect(codeForSidecarName('Russian')).toBe('ru');
+    expect(codeForSidecarName('Spanish')).toBe('es');
+    expect(codeForSidecarName('German')).toBe('de');
+    expect(codeForSidecarName('English')).toBe('en');
+    expect(codeForSidecarName('Klingon')).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run → fail.** `cd C:/Claude/Audiobook-Generator-wt-fs41/server && npx vitest run src/tts/language-registry.test.ts` → FAIL (export missing).
+
+- [ ] **Step 3: Implement the helper** — in `server/src/tts/language-registry.ts`:
+
+```typescript
+/** Reverse of `sidecarName` — the BCP-47 code for a sidecar/manifest language word. */
+export function codeForSidecarName(word: string): string | undefined {
+  return ENTRIES.find((e) => e.sidecarName === word)?.code;
+}
+```
+
+- [ ] **Step 4: Run → pass.** Same command → PASS.
+
+- [ ] **Step 5: Surface `languageCode` on `DerivedVoice`** — in `server/src/routes/voices.ts`:
+
+(a) Add to the `DerivedVoice` interface: `languageCode?: string;` (with a comment: BCP-47 of a designed Qwen voice's baked manifest language; absent for presets).
+
+(b) In the aggregation, for a designed Qwen voice, read the manifest language (the code already reads Qwen manifests for `generated`/`sampled` — reuse that path; the manifest carries `{ language?: string }` as a sidecar WORD). Map it via `codeForSidecarName(manifest.language)` and set `languageCode`. For non-Qwen/preset voices, leave `languageCode` undefined. (If the manifest read already happens once, attach `languageCode` there; do not add a second disk read.)
+
+(c) Add a server test (`server/src/routes/voices.test.ts`, mirror an existing case): a designed Qwen voice with a Russian manifest surfaces `languageCode: 'ru'`; a preset voice has no `languageCode`.
+
+- [ ] **Step 6: openapi + api-types** — add `languageCode` (optional string) to the `Voice` schema in `openapi.yaml`, then:
+
+Run: `cd C:/Claude/Audiobook-Generator-wt-fs41 && npm run openapi:types`
+Expected: `src/lib/api-types.ts` regenerates with `languageCode?: string` on `Voice`.
+
+- [ ] **Step 7: Run server tests + typecheck**
+
+Run: `cd C:/Claude/Audiobook-Generator-wt-fs41/server && npx vitest run src/routes/voices.test.ts src/tts/language-registry.test.ts && cd C:/Claude/Audiobook-Generator-wt-fs41 && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/src/tts/language-registry.ts server/src/routes/voices.ts openapi.yaml src/lib/api-types.ts server/src/routes/voices.test.ts server/src/tts/language-registry.test.ts
+git commit -m "feat(server): surface per-voice languageCode on derived voices (from the Qwen manifest)"
+```
+
+---
+
+### Task 2: Filter the cast/reuse picker by language (hide-with-count)
+
+**Files:**
+- Modify: `src/components/voice-library-panel.tsx` (add the language filter + the hidden-count affordance)
+- Test: `src/components/voice-library-panel.test.tsx` (create if absent)
+
+**Interfaces:** `VoiceLibraryPanel` already receives `library: Voice[]` + `bookLanguage?: string`. Now `voice.languageCode` (Task 1) drives eligibility.
+
+- [ ] **Step 1: Write the failing test** — in `src/components/voice-library-panel.test.tsx`:
+
+```tsx
+// A Russian book: an English preset + an English-designed Qwen voice are hidden;
+// a Russian-designed voice shows. The hidden count + "show all" appear.
+it('hides language-ineligible voices in a non-English book, with a show-all toggle', async () => {
+  const library = [
+    makeVoice({ character: 'Ivan', languageCode: 'ru' }),          // eligible
+    makeVoice({ character: 'John', languageCode: 'en' }),          // ineligible (English-designed)
+    makeVoice({ character: 'Preset', languageCode: undefined }),   // ineligible (preset → English)
+  ];
+  render(<VoiceLibraryPanel library={library} bookLanguage="ru" {...noopProps} />);
+  expect(screen.getByText('Ivan')).toBeInTheDocument();
+  expect(screen.queryByText('John')).not.toBeInTheDocument();
+  expect(screen.getByText(/2 hidden/i)).toBeInTheDocument();
+  await userEvent.click(screen.getByRole('button', { name: /show all/i }));
+  expect(screen.getByText('John')).toBeInTheDocument();           // override reveals
+});
+
+it('does not filter in an English book', () => {
+  const library = [makeVoice({ character: 'John', languageCode: 'en' }), makeVoice({ character: 'Preset', languageCode: undefined })];
+  render(<VoiceLibraryPanel library={library} bookLanguage="en" {...noopProps} />);
+  expect(screen.getByText('John')).toBeInTheDocument();
+  expect(screen.queryByText(/hidden/i)).not.toBeInTheDocument();
+});
+```
+
+(Provide `makeVoice` + `noopProps` helpers mirroring existing panel/voice test fixtures — read them.)
+
+- [ ] **Step 2: Run → fail.** `cd C:/Claude/Audiobook-Generator-wt-fs41 && npx vitest run src/components/voice-library-panel.test.tsx` → FAIL (no language filter).
+
+- [ ] **Step 3: Implement** — in `src/components/voice-library-panel.tsx`:
+
+(a) Compute eligibility: `const filterByLanguage = !!bookLanguage && bookLanguage !== 'en';` and `const isEligible = (v: Voice) => !filterByLanguage || v.languageCode === bookLanguage;`.
+
+(b) Apply it AFTER the existing tab + search filter; partition into shown (eligible) vs hidden (ineligible). A `showAll` `useState(false)` reveals the hidden ones.
+
+(c) Render the hidden-count affordance below the list when `filterByLanguage && hidden.length > 0 && !showAll`:
+
+```tsx
+{filterByLanguage && hiddenCount > 0 && !showAll && (
+  <button type="button" onClick={() => setShowAll(true)}
+    className="w-full text-center text-xs text-ink/50 hover:text-ink py-2 min-h-[44px] sm:min-h-0">
+    {hiddenCount} hidden · can't read {languageLabel} · <span className="underline">show all</span>
+  </button>
+)}
+```
+
+Derive `languageLabel` from the supported-list the confirm screen already uses, or a minimal code→label (`{ ru: 'Russian', es: 'Spanish', fr: 'French', de: 'German' }[bookLanguage] ?? bookLanguage`).
+
+- [ ] **Step 4: Run → pass + the frontend suite + typecheck**
+
+Run: `cd C:/Claude/Audiobook-Generator-wt-fs41 && npx vitest run src/components/voice-library-panel.test.tsx && npm run typecheck`
+Expected: PASS — the filter cases + an English book unaffected.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/voice-library-panel.tsx src/components/voice-library-panel.test.tsx
+git commit -m "feat(frontend): hide language-ineligible voices in the cast picker (hide-with-count + show-all)"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage (§6 filter):** per-voice language signal server-side ✓ (T1); cast-picker hides ineligible voices with "N hidden · show all" ✓ (T2); English books unaffected ✓. The early-warning transport + global `#/voices` facet are explicitly deferred to seam 4b.
+- **Placeholder scan:** the test snippets say "mirror existing fixtures / read them" — concrete instructions, not TODOs. Each code step shows the change.
+- **Type consistency:** `languageCode` spelled identically on `DerivedVoice` (T1), the openapi `Voice`, and the frontend filter (T2); `codeForSidecarName` is the reverse of `sidecarName`.
+- **English-unchanged check:** the filter is gated on `bookLanguage !== 'en'`; T2's second test pins an English book showing all voices with no "hidden" affordance.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-23-fs41-fs50-seam4a-voice-filter.md`. Subagent-Driven recommended (T1 spans server + openapi, T2 is the UI). Seam 4b (next) = the early-warning transport (surface `clearMismatchedDesignedVoices` to the cast view via the `notifications` toast / generation stream) + the global `#/voices` language facet.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4035,6 +4035,14 @@ components:
             query is 'qwen'); preset voices omit it. Drives the new "Sampled"
             cast Status pill / Voices badge. Cross-book like `generated`; a
             `generated` voice outranks it. Absent ⇒ not sampled / not applicable.
+        languageCode:
+          type: string
+          description: >-
+            BCP-47 code of a designed Qwen voice's baked manifest language
+            (e.g. 'ru' for Russian). Derived from the sidecar manifest
+            `{ language }` word via the registry reverse-lookup.
+            Absent for preset/catalog voices and voices whose manifest is
+            missing or has no language field.
         ttsVoice: { $ref: '#/components/schemas/TtsVoiceAssignment' }
         overrideTtsVoices:
           type: object

--- a/server/src/routes/voices.test.ts
+++ b/server/src/routes/voices.test.ts
@@ -573,6 +573,47 @@ describe('GET /api/voices?engine=qwen — generated flag', () => {
   });
 });
 
+describe('GET /api/voices — languageCode on designed Qwen voices', () => {
+  /* A designed Qwen voice whose sidecar manifest carries `language: "Russian"`
+     must surface `languageCode: "ru"` on the derived voice. A preset voice
+     (no qwen override, no manifest) must omit `languageCode` entirely.
+     Uses the v_oduvan character from the Qwen series above (already in the
+     workspace) — no new books required. */
+
+  let qwenVoicesPath: string;
+
+  beforeAll(async () => {
+    const [{ qwenVoiceSidecarPath: sidecarPath }, { dirname }] = await Promise.all([
+      import('../workspace/paths.js'),
+      import('node:path'),
+    ]);
+    /* Oduvan's storage key (no uuid) → qwen-v_oduvan. */
+    qwenVoicesPath = sidecarPath('qwen-v_oduvan');
+    mkdirSync(dirname(qwenVoicesPath), { recursive: true });
+    /* Write a manifest with Russian as the baked language. */
+    writeFileSync(qwenVoicesPath, JSON.stringify({ voiceId: 'qwen-v_oduvan', instruct: 'persona', language: 'Russian' }));
+  });
+
+  afterAll(() => {
+    rmSync(qwenVoicesPath, { force: true });
+  });
+
+  it('surfaces languageCode ru on a Russian-designed Qwen voice', async () => {
+    const res = await request(app).get('/api/voices?engine=qwen');
+    expect(res.status).toBe(200);
+    const oduvan = res.body.voices.find((v: { id: string }) => v.id === 'v_oduvan');
+    expect(oduvan).toBeDefined();
+    expect(oduvan.languageCode).toBe('ru');
+  });
+
+  it('omits languageCode on a preset (non-Qwen-designed) voice', async () => {
+    const res = await request(app).get('/api/voices');
+    const v_brann = res.body.voices.find((v: { id: string }) => v.id === 'v_brann');
+    expect(v_brann).toBeDefined();
+    expect(v_brann.languageCode).toBeUndefined();
+  });
+});
+
 describe('GET /api/voices?currentBookId — inCurrentSeries scoping', () => {
   /* A self-contained author with: a two-book series (Trilogy), a same-author
      spinoff in a DIFFERENT series, and a standalone. Distinct voiceIds per

--- a/server/src/routes/voices.ts
+++ b/server/src/routes/voices.ts
@@ -33,6 +33,7 @@ import {
   BOOKS_ROOT,
   castJsonPath,
   ensureWorkspace,
+  qwenVoiceSidecarPath,
   stateJsonPath,
   voicesMetaPath,
 } from '../workspace/paths.js';
@@ -43,6 +44,7 @@ import {
   qwenStorageKey,
   type TtsVoiceAssignment,
 } from '../tts/voice-mapping.js';
+import { codeForSidecarName } from '../tts/language-registry.js';
 import { gradientForTtsVoice } from '../tts/voice-palette.js';
 import { buildHintFromCast, type CastCharacter } from '../tts/synthesise-chapter.js';
 import {
@@ -128,6 +130,10 @@ interface DerivedVoice {
       Copied from the source Character. Absent on pre-srv-43 designs and
       catalog voices. */
   voiceUuid?: string;
+  /** BCP-47 code of a designed Qwen voice's baked manifest language (e.g. 'ru').
+      Derived from the sidecar manifest `{ language }` word via codeForSidecarName.
+      Absent for presets and voices whose manifest is missing or has no language. */
+  languageCode?: string;
 }
 
 /* Read-time migration. Older cast.json files (pre-Kokoro) stored a
@@ -346,6 +352,23 @@ async function aggregateVoices(
             }
             continue;
           }
+          /* Read the sidecar manifest for a designed Qwen voice to derive its
+             baked language code. One read per new voice family entry (first-
+             occurrence wins, same as identity fields). The storage key is
+             computed independently of the engine query parameter so languageCode
+             is always present on a designed Qwen voice regardless of which engine
+             tab is active. */
+          const qwenDesignedName = c.overrideTtsVoices?.qwen?.name;
+          let languageCode: string | undefined;
+          if (qwenDesignedName) {
+            const manifestKey = qwenStorageKey({ voiceUuid: c.voiceUuid, voiceId: c.voiceId }, id);
+            const manifest = await readJson<{ language?: string }>(
+              qwenVoiceSidecarPath(manifestKey),
+            ).catch(() => null);
+            if (manifest?.language) {
+              languageCode = codeForSidecarName(manifest.language);
+            }
+          }
           const isCurrent = !!currentBookId && state.bookId === currentBookId;
           const ttsVoiceRaw = resolveVoiceAssignment(
             engine,
@@ -397,6 +420,7 @@ async function aggregateVoices(
             overrideTtsVoices: overrideMap,
             overrideTtsVoice: legacyShape,
             voiceUuid: c.voiceUuid,
+            languageCode,
             books: new Set([state.bookId]),
           });
         }

--- a/server/src/tts/language-registry.test.ts
+++ b/server/src/tts/language-registry.test.ts
@@ -10,6 +10,7 @@ import {
   supportedLanguages,
   nonEnglishHeadingLexicon,
   nonEnglishFrontMatterKeywords,
+  codeForSidecarName,
 } from './language-registry.js';
 
 describe('getLanguageEntry', () => {
@@ -133,5 +134,15 @@ describe('nonEnglishFrontMatterKeywords', () => {
   it('ru/es/fr/de carry frontMatterKeywords; en does not', () => {
     expect(getLanguageEntry('en')?.frontMatterKeywords).toBeUndefined();
     for (const c of ['ru', 'es', 'fr', 'de']) expect(getLanguageEntry(c)?.frontMatterKeywords).toBeDefined();
+  });
+});
+
+describe('codeForSidecarName', () => {
+  it('maps sidecar words back to BCP-47 codes', () => {
+    expect(codeForSidecarName('Russian')).toBe('ru');
+    expect(codeForSidecarName('Spanish')).toBe('es');
+    expect(codeForSidecarName('German')).toBe('de');
+    expect(codeForSidecarName('English')).toBe('en');
+    expect(codeForSidecarName('Klingon')).toBeUndefined();
   });
 });

--- a/server/src/tts/language-registry.ts
+++ b/server/src/tts/language-registry.ts
@@ -122,3 +122,8 @@ export function nonEnglishFrontMatterKeywords(): string[] {
   for (const e of ENTRIES) e.frontMatterKeywords?.forEach((w) => out.add(w));
   return [...out];
 }
+
+/** Reverse of `sidecarName` — the BCP-47 code for a sidecar/manifest language word. */
+export function codeForSidecarName(word: string): string | undefined {
+  return ENTRIES.find((e) => e.sidecarName === word)?.code;
+}

--- a/src/components/voice-library-panel.test.tsx
+++ b/src/components/voice-library-panel.test.tsx
@@ -5,6 +5,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { render, fireEvent, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { VoiceCard, VoiceLibraryPanel } from './voice-library-panel';
 import type { Character, Voice } from '../lib/types';
 
@@ -465,5 +466,38 @@ describe('VoiceLibraryPanel — Series tab scoping & default tab', () => {
     fireEvent.click(screen.getByRole('button', { name: 'This book' }));
     expect(screen.getByText('Captain Halloran')).toBeInTheDocument();
     expect(screen.queryByText('Series Sibling')).toBeNull();
+  });
+});
+
+describe('VoiceLibraryPanel — language filter (fs-41/fs-50 seam 4a)', () => {
+  /* Shared noop props: the minimal set required by VoiceLibraryPanel beyond
+     library + bookLanguage. */
+  const noopProps = {
+    draggingVoiceId: null as string | null,
+    setDraggingVoiceId: vi.fn(),
+  };
+
+  it('hides language-ineligible voices in a non-English book, with a show-all toggle', async () => {
+    const library: Voice[] = [
+      makeVoice('v_ivan', 'Ivan', { languageCode: 'ru' }),        // eligible
+      makeVoice('v_john', 'John', { languageCode: 'en' }),        // ineligible (English-designed)
+      makeVoice('v_preset', 'Preset', { languageCode: undefined }),// ineligible (preset → English)
+    ];
+    render(<VoiceLibraryPanel library={library} bookLanguage="ru" {...noopProps} />);
+    expect(screen.getByText('Ivan')).toBeInTheDocument();
+    expect(screen.queryByText('John')).not.toBeInTheDocument();
+    expect(screen.getByText(/2 hidden/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /show all/i }));
+    expect(screen.getByText('John')).toBeInTheDocument();
+  });
+
+  it('does not filter in an English book', () => {
+    const library: Voice[] = [
+      makeVoice('v_john', 'John', { languageCode: 'en' }),
+      makeVoice('v_preset', 'Preset', { languageCode: undefined }),
+    ];
+    render(<VoiceLibraryPanel library={library} bookLanguage="en" {...noopProps} />);
+    expect(screen.getByText('John')).toBeInTheDocument();
+    expect(screen.queryByText(/hidden/i)).not.toBeInTheDocument();
   });
 });

--- a/src/components/voice-library-panel.test.tsx
+++ b/src/components/voice-library-panel.test.tsx
@@ -489,6 +489,7 @@ describe('VoiceLibraryPanel — language filter (fs-41/fs-50 seam 4a)', () => {
     expect(screen.getByText(/2 hidden/i)).toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', { name: /show all/i }));
     expect(screen.getByText('John')).toBeInTheDocument();
+    expect(screen.queryByText(/hidden/i)).not.toBeInTheDocument();
   });
 
   it('does not filter in an English book', () => {

--- a/src/components/voice-library-panel.tsx
+++ b/src/components/voice-library-panel.tsx
@@ -32,6 +32,12 @@ interface VoiceLibraryPanelProps {
      to apply). Drag-and-drop on desktop stays intact regardless. */
   onTapAssign?: (voice: Voice) => void;
   assigningVoiceId?: string | null;
+  /* fs-41/fs-50 seam 4a — BCP-47 language of the current book. When set
+     to a non-English code, voices whose `languageCode` doesn't match are
+     hidden behind a "N hidden · can't read <Language> · show all" toggle
+     so the user can't pick a voice that would be cleared at generation.
+     English books (`bookLanguage === 'en'` or absent) are unaffected. */
+  bookLanguage?: string;
 }
 
 export function VoiceLibraryPanel({
@@ -45,8 +51,10 @@ export function VoiceLibraryPanel({
   displayMode = 'aside',
   onTapAssign,
   assigningVoiceId,
+  bookLanguage,
 }: VoiceLibraryPanelProps) {
   const [query, setQuery] = useState('');
+  const [showAll, setShowAll] = useState(false);
   /* Whether any voice belongs to the open book's series (a sibling book — the
      `source === 'library'` half — that shares its author + series). The server
      tags these `inCurrentSeries`. A standalone (or a one-book series) has none,
@@ -94,6 +102,20 @@ export function VoiceLibraryPanel({
         v.character.toLowerCase().includes(q) ||
         v.bookTitle.toLowerCase().includes(q),
     );
+  /* fs-41/fs-50 seam 4a — language eligibility filter. Only active for
+     non-English books: a voice is eligible when its `languageCode` matches
+     the book's language. Preset/catalog voices (no `languageCode`) are
+     ineligible for a non-English book because they can't read foreign text.
+     English books skip the filter entirely so the picker stays byte-identical. */
+  const filterByLanguage = !!bookLanguage && bookLanguage !== 'en';
+  const isEligible = (v: Voice) => !filterByLanguage || v.languageCode === bookLanguage;
+  const shown = filterByLanguage && !showAll ? filtered.filter(isEligible) : filtered;
+  const hidden = filterByLanguage && !showAll ? filtered.filter((v) => !isEligible(v)) : [];
+  const hiddenCount = hidden.length;
+  const languageLabel =
+    ({ ru: 'Russian', es: 'Spanish', fr: 'French', de: 'German' } as Record<string, string>)[
+      bookLanguage ?? ''
+    ] ?? bookLanguage ?? '';
   const bookCount = new Set(library.map((v) => v.bookId)).size;
   const tabs: Array<{ id: Tab; label: string }> = [
     { id: 'all', label: 'All' },
@@ -151,12 +173,12 @@ export function VoiceLibraryPanel({
         data-testid="voice-library-scroll"
         className="p-5 overflow-y-auto scrollbar-thin space-y-2"
       >
-        {filtered.length === 0 && q ? (
+        {shown.length === 0 && q ? (
           <p className="text-center text-xs text-ink/40 py-6">
             No voices match “{query.trim()}”
           </p>
         ) : (
-          filtered.map((v) => (
+          shown.map((v) => (
             <VoiceCard
               key={v.id}
               voice={v}
@@ -170,6 +192,16 @@ export function VoiceLibraryPanel({
               isAssigningTarget={assigningVoiceId === v.id}
             />
           ))
+        )}
+        {filterByLanguage && hiddenCount > 0 && !showAll && (
+          <button
+            type="button"
+            onClick={() => setShowAll(true)}
+            className="w-full text-center text-xs text-ink/50 hover:text-ink py-2 min-h-[44px] sm:min-h-0"
+          >
+            {hiddenCount} hidden · can&apos;t read {languageLabel} ·{' '}
+            <span className="underline">show all</span>
+          </button>
         )}
       </div>
     </div>

--- a/src/components/voice-library-panel.tsx
+++ b/src/components/voice-library-panel.tsx
@@ -112,10 +112,9 @@ export function VoiceLibraryPanel({
   const shown = filterByLanguage && !showAll ? filtered.filter(isEligible) : filtered;
   const hidden = filterByLanguage && !showAll ? filtered.filter((v) => !isEligible(v)) : [];
   const hiddenCount = hidden.length;
-  const languageLabel =
-    ({ ru: 'Russian', es: 'Spanish', fr: 'French', de: 'German' } as Record<string, string>)[
-      bookLanguage ?? ''
-    ] ?? bookLanguage ?? '';
+  const languageLabel = bookLanguage
+    ? ({ ru: 'Russian', es: 'Spanish', fr: 'French', de: 'German' }[bookLanguage] ?? bookLanguage)
+    : '';
   const bookCount = new Set(library.map((v) => v.bookId)).size;
   const tabs: Array<{ id: Tab; label: string }> = [
     { id: 'all', label: 'All' },

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -3079,6 +3079,8 @@ export interface components {
             generated?: boolean;
             /** @description True when a 12s audition has been synthesised for this voiceId — the lifecycle tier between "Designed" and "Generated". Populated only for bespoke Qwen voices (the server checks the voice-sample cache for a `<scope>-qwen3-tts-0.6b-*.mp3` file when the engine query is 'qwen'); preset voices omit it. Drives the new "Sampled" cast Status pill / Voices badge. Cross-book like `generated`; a `generated` voice outranks it. Absent ⇒ not sampled / not applicable. */
             sampled?: boolean;
+            /** @description BCP-47 code of a designed Qwen voice's baked manifest language (e.g. 'ru' for Russian). Derived from the sidecar manifest `{ language }` word via the registry reverse-lookup. Absent for preset/catalog voices and voices whose manifest is missing or has no language field. */
+            languageCode?: string;
             ttsVoice: components["schemas"]["TtsVoiceAssignment"];
             /**
              * @description User-set TTS voice overrides per engine. Each entry pins a


### PR DESCRIPTION
## Summary

Seam 4a of fs-41/fs-50 (the fs-41 "filter the voice library" deliverable). In a non-English book, the cast/reuse voice picker hides voices that can't read the book's language behind a non-silent **"N hidden · can't read <Language>" + "show all"** toggle — so a user can't pick a voice that gets cleared at generation. English books are byte-identical (filter gated on `bookLanguage !== 'en'`).

- **Server** (`voices.ts` + `language-registry.ts`): a `codeForSidecarName` reverse helper + a per-voice BCP-47 `languageCode` on `DerivedVoice` (derived from a designed Qwen voice's baked manifest language, one read per unique designed voice; absent for presets/non-Qwen). Surfaced on the `Voice` openapi schema + regenerated `api-types.ts`.
- **Frontend** (`voice-library-panel.tsx`): when `bookLanguage !== 'en'`, partition the tab+search-filtered list into eligible (`languageCode === bookLanguage`) vs hidden, with a `showAll` reveal. Touch target `min-h-[44px] sm:min-h-0`, design tokens.

Each task was reviewed (spec + quality, both Approved); two review Minors were fixed.

Seam 4b (next) = the early-warning transport (surface `clearMismatchedDesignedVoices` to the cast view) + the global `#/voices` language facet.

## Test plan

- Server: `codeForSidecar` (15) + `voices` (34) tests; frontend: 2 new filter tests (non-English hides ineligible with count+show-all; English unaffected) on top of 20 pre-existing (22/22). Typecheck clean.

## Note on verification

Pushed with `--no-verify` (author-authorized) — the local pre-push e2e is failing on an overloaded dev box (orphaned dev-server processes → `page.goto` navigation timeouts on unrelated specs, confirmed environmental). The `run-ci` label runs the **full battery on a clean Ubuntu runner**; as a frontend-touching change this gets the real e2e + frontend suites in the clean room.

Refs #974, #666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLg2Zazw3rSSE2kRq1JUzz

<!-- title corrected to feat(server,frontend) per scope convention -->