### PR TITLE
feat(server,frontend): fs-41/fs-50 seam 4b — voice-mismatch early warning + voices language facet

### DIFF
--- a/docs/superpowers/plans/2026-06-23-fs41-fs50-seam4b-early-warning.md
+++ b/docs/superpowers/plans/2026-06-23-fs41-fs50-seam4b-early-warning.md
@@ -1,0 +1,156 @@
+# fs-41/fs-50 Seam 4b — Early-warning transport + #/voices language facet Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a non-English book's generation (or splice re-record) **clears** a designed voice because it was designed for a different language, tell the user instead of clearing it silently (today it only `console.warn`s server-side). And add a language facet to the global `#/voices` view so a user can see which voices read which language.
+
+**Architecture:** `clearMismatchedDesignedVoices` (`server/src/tts/verify-designed-voice-language.ts`) gains a **return value** — the list of cleared characters (id + name + the language they were designed for). Both call sites (`generation.ts`, `chapter-splice.ts`) already have an SSE `send()` in scope and already gate on `nonEnglishBook`; when the returned list is non-empty they emit the **existing `warning` tick** (`{ type: 'warning', message, code }`), which the frontend already turns into a dedup'd toast (`generation-stream-runner.ts`). No new tick type, no openapi change, no new frontend path for Task 1. Task 2 adds a language filter to `voices.tsx` keyed on the `Voice.languageCode` that seam 4a already surfaced.
+
+**Tech Stack:** TypeScript (ESM, `.js` imports), Node 20+ (server), React (Vite), Vitest.
+
+## Global Constraints
+
+- **English/existing behaviour unchanged.** `clearMismatchedDesignedVoices` is only called inside the `if (nonEnglishBook)` branch; English books never reach it. The new return value is additive (callers that ignore it are unaffected); the `console.warn` stays. No existing assertion modified.
+- **Reuse the existing `warning` tick** (already in the openapi `GenerationTick` enum + already toasted by `generation-stream-runner.ts`). Dedupe by a stable `code` (`voice_language_mismatch`) so a re-emit doesn't stack toasts.
+- ESM `.js`. Commit `<type>(<scope>): <subject>`. Husky pre-commit runs the in-scope legs (green, no `--no-verify`). Work from the worktree `C:/Claude/Audiobook-Generator-wt-fs41`, branch `docs/docs-fs41-fs50-seam4b-early-warning`.
+
+---
+
+### Task 1: `clearMismatchedDesignedVoices` returns cleared chars; call sites warn
+
+**Files:**
+- Modify: `server/src/tts/verify-designed-voice-language.ts` (return the cleared list)
+- Modify: `server/src/routes/generation.ts` (~line 566) + `server/src/routes/chapter-splice.ts` (~line 252) — emit the `warning` tick
+- Test: `server/src/tts/verify-designed-voice-language.test.ts` (+ a generation-route assertion if a harness exists; otherwise unit-test the function's return)
+
+**Interfaces:**
+- `clearMismatchedDesignedVoices(cast, expectedLang, bookLanguage): Promise<ClearedVoice[]>` where `ClearedVoice = { id: string; name: string; designedLanguage: string }` (`designedLanguage` = the manifest's language word, or a sentinel like `'unknown'` when the manifest was missing). Returns `[]` when nothing was cleared.
+
+- [ ] **Step 1: Write the failing test** — in `server/src/tts/verify-designed-voice-language.test.ts` (mirror its existing fixtures — read them):
+
+```typescript
+it('returns the characters whose mismatched voices were cleared', async () => {
+  // A cast with one qwen voice designed for English on a Russian ('ru') book.
+  const cast = [
+    makeCastChar({ id: 'ivan', name: 'Ivan', overrideTtsVoices: { qwen: { name: 'qwen-ivan' } } }),
+  ];
+  // (set up the manifest read so qwen-ivan's manifest.language === 'English')
+  const cleared = await clearMismatchedDesignedVoices(cast, 'Russian', 'ru');
+  expect(cleared).toEqual([{ id: 'ivan', name: 'Ivan', designedLanguage: 'English' }]);
+  expect(cast[0].overrideTtsVoices?.qwen).toBeUndefined(); // still cleared in place
+});
+
+it('returns [] when every designed voice matches the book language', async () => {
+  const cast = [makeCastChar({ id: 'ivan', name: 'Ivan', overrideTtsVoices: { qwen: { name: 'qwen-ivan' } } })];
+  // (manifest.language === 'Russian')
+  expect(await clearMismatchedDesignedVoices(cast, 'Russian', 'ru')).toEqual([]);
+});
+```
+
+(Read the existing test for how it stubs the manifest read — `readJson`/`qwenVoiceSidecarPath`. Match the real fixture style. If the existing test already mocks the manifest, reuse that mock.)
+
+- [ ] **Step 2: Run → fail.** `cd C:/Claude/Audiobook-Generator-wt-fs41/server && npx vitest run src/tts/verify-designed-voice-language.test.ts` → FAIL (function returns void).
+
+- [ ] **Step 3: Implement the return** — in `verify-designed-voice-language.ts`:
+- Change the signature to `Promise<ClearedVoice[]>` (export the `ClearedVoice` type).
+- Accumulate a `cleared: ClearedVoice[]` as you clear each character: push `{ id: c.id, name: c.name ?? c.id, designedLanguage: manifest?.language ?? 'unknown' }` at the same point you `delete c.overrideTtsVoices.qwen` + `console.warn` (keep the warn).
+- `return cleared;` at the end.
+
+- [ ] **Step 4: Run → pass.** Same command → PASS (the cleared-list + the empty case).
+
+- [ ] **Step 5: Emit the warning tick at both call sites.** In `generation.ts` (~566) and `chapter-splice.ts` (~252), capture the return + emit:
+
+```typescript
+const cleared = await clearMismatchedDesignedVoices(
+  cast.characters,
+  sidecarLanguageName(bookLanguage),
+  bookLanguage,
+);
+if (cleared.length > 0) {
+  const names = cleared.map((c) => c.name).join(', ');
+  send({
+    type: 'warning',
+    code: 'voice_language_mismatch',
+    message:
+      `${cleared.length} designed voice(s) were cleared because they were designed for a ` +
+      `different language than this book — re-design ${names} before generating.`,
+  });
+}
+```
+
+Use the `send` function already in scope at each handler (generation.ts ~line 488; chapter-splice.ts ~line 98). Confirm the `warning` tick shape matches the openapi `GenerationTick` (`type`, `message`, `code`) — it does; no schema change.
+
+- [ ] **Step 6: Verify the frontend already toasts it (no change) + the splice consumer.** Read `src/store/generation-stream-runner.ts` (~line 367) to confirm the `warning` handler dispatches `pushToast` with `dedupeKey` from `ev.code` — the generation path is covered. CHECK whether the **splice** SSE is consumed by the same runner (search for the splice stream consumer); if a different consumer handles the splice stream and does NOT handle `warning`, note it in your report as a known gap (the generation path is the primary surface; do not build a second toast path in this task).
+
+- [ ] **Step 7: Run server tests + typecheck**
+
+Run: `cd C:/Claude/Audiobook-Generator-wt-fs41/server && npx vitest run src/tts/verify-designed-voice-language.test.ts && cd C:/Claude/Audiobook-Generator-wt-fs41 && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/src/tts/verify-designed-voice-language.ts server/src/routes/generation.ts server/src/routes/chapter-splice.ts server/src/tts/verify-designed-voice-language.test.ts
+git commit -m "feat(server): warn when a designed voice is cleared for a language mismatch"
+```
+
+---
+
+### Task 2: `#/voices` language facet
+
+**Files:**
+- Modify: `src/views/voices.tsx` (add a language filter keyed on `Voice.languageCode`)
+- Test: `src/views/voices.test.tsx` (create if absent; or the nearest voices-view test)
+
+**Interfaces:** `Voice.languageCode?: string` already exists (seam 4a). The facet filters the displayed voices by language.
+
+- [ ] **Step 1: Write the failing test** — in `src/views/voices.test.tsx` (mirror existing voices-view test fixtures — read them):
+
+```tsx
+it('filters the voice list by language when a language facet is selected', async () => {
+  // voices: one ru-designed (languageCode 'ru'), one preset (no languageCode = English)
+  renderVoicesView({ voices: [makeVoice({ character: 'Ivan', languageCode: 'ru' }), makeVoice({ character: 'Preset', languageCode: undefined })] });
+  // default: both visible
+  expect(screen.getByText('Ivan')).toBeInTheDocument();
+  expect(screen.getByText('Preset')).toBeInTheDocument();
+  // pick the Russian facet → only the ru voice
+  await userEvent.click(screen.getByRole('button', { name: /Russian/i }));
+  expect(screen.getByText('Ivan')).toBeInTheDocument();
+  expect(screen.queryByText('Preset')).not.toBeInTheDocument();
+});
+```
+
+(Adapt to the actual voices-view render harness + the families/tab structure — read `voices.tsx` + any existing test. If the view groups into families, assert on the family/voice the language filter keeps.)
+
+- [ ] **Step 2: Run → fail.** `cd C:/Claude/Audiobook-Generator-wt-fs41 && npx vitest run src/views/voices.test.tsx` → FAIL.
+
+- [ ] **Step 3: Implement** — in `src/views/voices.tsx`:
+- Add `const [languageFilter, setLanguageFilter] = useState<string | null>(null);` (null = all).
+- Compute the unique languages present: `const languages = useMemo(() => [...new Set(voices.map((v) => v.languageCode).filter(Boolean))], [voices]);` — only render the facet when `languages.length > 0` (an all-English library shows no facet → English view unchanged).
+- Apply the filter alongside the existing tab/variant filters: a voice is kept when `languageFilter === null || v.languageCode === languageFilter`. Thread it through the families/members computation the same way `variantFilter` is applied (read the existing cascade and mirror it — don't invent a parallel structure).
+- Render the facet next to the existing `variantFilter` row: an "All" button + one button per present language (label via a code→word map `{ ru:'Russian', es:'Spanish', fr:'French', de:'German' }[code] ?? code`). Touch target `min-h-[44px] sm:min-h-0`, design tokens, no hex literals.
+
+- [ ] **Step 4: Run → pass + typecheck**
+
+Run: `cd C:/Claude/Audiobook-Generator-wt-fs41 && npx vitest run src/views/voices.test.tsx && npm run typecheck`
+Expected: PASS — the facet filters; an all-English library renders no facet (unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/views/voices.tsx src/views/voices.test.tsx
+git commit -m "feat(frontend): language facet on the global voices view"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage (seam 4b):** the silent voice-clearing is surfaced to the user via the existing `warning`→toast path ✓ (T1); the global `#/voices` view gains a language facet ✓ (T2). No new SSE tick type, no openapi change, no second toast path.
+- **Placeholder scan:** the test snippets say "read the existing fixtures / mirror the cascade" — concrete adapt-to-real-code instructions. Each code step shows the change.
+- **Type consistency:** `ClearedVoice` exported from the verify module + consumed at both call sites; the `warning` tick shape (`type`/`message`/`code`) matches the openapi union; `languageCode` (seam 4a) drives the facet.
+- **English-unchanged check:** T1 only runs inside `nonEnglishBook`; T2's facet renders only when ≥1 non-English voice is present, so an English-only library is byte-identical.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-23-fs41-fs50-seam4b-early-warning.md`. Subagent-Driven recommended. After 4b, seam 4 (voice-library filtering + early-warning) is complete. Remaining fs-41/fs-50: seam 5 rest (`sidecarLanguageName`-throw + attribution-eval harness — calibration already shipped) + the Spanish canary flip.

--- a/server/src/routes/chapter-splice.ts
+++ b/server/src/routes/chapter-splice.ts
@@ -249,11 +249,21 @@ chapterSpliceRouter.post(
              baked manifest language ≠ this book's is cleared so the
              forbidKokoroFallback gate blocks it (undesigned) rather than
              re-recording the line in the wrong language. */
-          await clearMismatchedDesignedVoices(
+          const clearedVoices = await clearMismatchedDesignedVoices(
             cast.characters,
             sidecarLanguageName(bookLanguage),
             bookLanguage,
           );
+          if (clearedVoices.length > 0) {
+            const names = clearedVoices.map((c) => c.name).join(', ');
+            send({
+              type: 'warning',
+              code: 'voice_language_mismatch',
+              message:
+                `${clearedVoices.length} designed voice(s) were cleared because they were designed for a ` +
+                `different language than this book — re-design ${names} before generating.`,
+            });
+          }
         }
         const requiredEngines = new Set(cast.characters.map((c) => resolveCharacterEngine(c, engine)));
         const qwenInUse = requiredEngines.has('qwen');

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -563,11 +563,21 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
        splice re-record path: clears any designed Qwen voice whose baked
        manifest language ≠ the book's, so the forbidKokoroFallback gate blocks
        it as undesigned rather than reading wrong-language audio. */
-    await clearMismatchedDesignedVoices(
+    const clearedVoices = await clearMismatchedDesignedVoices(
       cast.characters,
       sidecarLanguageName(bookLanguage),
       bookLanguage,
     );
+    if (clearedVoices.length > 0) {
+      const names = clearedVoices.map((c) => c.name).join(', ');
+      send({
+        type: 'warning',
+        code: 'voice_language_mismatch',
+        message:
+          `${clearedVoices.length} designed voice(s) were cleared because they were designed for a ` +
+          `different language than this book — re-design ${names} before generating.`,
+      });
+    }
   }
 
   /* Per-character engine routing (plan 108). Engine is no longer one global

--- a/server/src/tts/verify-designed-voice-language.test.ts
+++ b/server/src/tts/verify-designed-voice-language.test.ts
@@ -102,4 +102,39 @@ describe('clearMismatchedDesignedVoices', () => {
     /* No crash, and the non-existent qwen slot remains absent. */
     expect(cast[0].overrideTtsVoices?.qwen).toBeUndefined();
   });
+
+  /* seam-4b — the function returns the cleared characters so call sites can
+     emit a user-facing warning SSE tick. */
+  it('returns the characters whose mismatched voices were cleared', async () => {
+    /* Character id 'ivan-return' → storage key 'qwen-ivan-return'. */
+    writeManifest('qwen-ivan-return', 'English'); // designed under an English book
+    const cast = [char('ivan-return', 'Ivan')];
+
+    const cleared = await clearMismatchedDesignedVoices(cast, 'Russian', 'ru');
+
+    expect(cleared).toEqual([{ id: 'ivan-return', name: 'ivan-return', designedLanguage: 'English' }]);
+    expect(cast[0].overrideTtsVoices?.qwen).toBeUndefined(); // still cleared in place
+  });
+
+  it('returns [] when every designed voice matches the book language', async () => {
+    /* Character id 'ivan-match-return' → storage key 'qwen-ivan-match-return'. */
+    writeManifest('qwen-ivan-match-return', 'Russian');
+    const cast = [char('ivan-match-return', 'Ivan')];
+
+    const cleared = await clearMismatchedDesignedVoices(cast, 'Russian', 'ru');
+
+    expect(cleared).toEqual([]);
+    expect(cast[0].overrideTtsVoices?.qwen?.name).toBe('Ivan'); // voice untouched
+  });
+
+  it('returns "unknown" as designedLanguage when the manifest file is missing', async () => {
+    /* No manifest written for 'ivan-missing-return' → missing → cleared with unknown. */
+    const cast = [char('ivan-missing-return', 'no-such-voice')];
+
+    const cleared = await clearMismatchedDesignedVoices(cast, 'Russian', 'ru');
+
+    expect(cleared).toEqual([
+      { id: 'ivan-missing-return', name: 'ivan-missing-return', designedLanguage: 'unknown' },
+    ]);
+  });
 });

--- a/server/src/tts/verify-designed-voice-language.ts
+++ b/server/src/tts/verify-designed-voice-language.ts
@@ -17,16 +17,27 @@ import { qwenVoiceSidecarPath } from '../workspace/paths.js';
 import type { CastCharacter } from './synthesise-chapter.js';
 import { qwenStorageKey } from './voice-mapping.js';
 
+/** A character whose designed Qwen voice was cleared because its baked manifest
+    language didn't match the book's language. */
+export interface ClearedVoice {
+  id: string;
+  name: string;
+  /** The manifest's `language` word, or `'unknown'` when the manifest was missing. */
+  designedLanguage: string;
+}
+
 /** Clear any reused designed Qwen voice whose baked manifest language doesn't
     match the book's. `expectedLang` is the sidecar language WORD
     (`sidecarLanguageName(bookLanguage)`); `bookLanguage` is the raw BCP-47 tag,
-    used only for the warning text. Mutates the cast in place. No-op for English
-    books (callers gate this behind `isNonEnglish`). */
+    used only for the warning text. Mutates the cast in place and returns the
+    list of characters whose voices were cleared. Returns `[]` when nothing was
+    cleared. No-op for English books (callers gate this behind `isNonEnglish`). */
 export async function clearMismatchedDesignedVoices(
   cast: CastCharacter[],
   expectedLang: string,
   bookLanguage: string,
-): Promise<void> {
+): Promise<ClearedVoice[]> {
+  const cleared: ClearedVoice[] = [];
   for (const c of cast) {
     const designedName = c.overrideTtsVoices?.qwen?.name;
     if (!designedName) continue;
@@ -40,6 +51,12 @@ export async function clearMismatchedDesignedVoices(
           `is not ${expectedLang} (manifest: ${manifest?.language ?? 'missing'}) — ` +
           `treating as undesigned, re-design required for this ${bookLanguage} book.`,
       );
+      cleared.push({
+        id: c.id,
+        name: c.name ?? c.id,
+        designedLanguage: manifest?.language ?? 'unknown',
+      });
     }
   }
+  return cleared;
 }

--- a/src/views/voices.test.tsx
+++ b/src/views/voices.test.tsx
@@ -1995,3 +1995,108 @@ describe('fe-34 — variant filter toggle', () => {
     expect(screen.getByTestId('variants-badge')).toHaveTextContent('Variants');
   });
 });
+
+describe('fs-41/fs-50 seam 4b — language facet on the global #/voices view', () => {
+  /* Test-local makeVoice that adds languageCode support on top of the
+     module-level makeVoice without modifying it. */
+  function makeLangVoice(
+    over: Partial<Voice> & Pick<Voice, 'id' | 'character' | 'bookId' | 'bookTitle' | 'source'>,
+  ): Voice {
+    return makeVoice(over);
+  }
+
+  function renderLangView(lib: Voice[]) {
+    return render(
+      <Provider store={makeStore()}>
+        <LibraryView library={lib} />
+      </Provider>,
+    );
+  }
+
+  it('shows no language facet when all voices lack a languageCode (English-only library)', async () => {
+    /* Preset English voices carry no languageCode. The facet must not appear. */
+    const lib: Voice[] = [
+      makeLangVoice({ id: 'v_narrator', character: 'Narrator', bookId: 'b1', bookTitle: 'Book One', source: 'current' }),
+      makeLangVoice({ id: 'v_marlow', character: 'Marlow', bookId: 'b1', bookTitle: 'Book One', source: 'current' }),
+    ];
+    renderLangView(lib);
+    await act(async () => {});
+    expect(screen.queryByRole('group', { name: 'Filter by language' })).toBeNull();
+    /* Both voices visible — nothing filtered. */
+    expect(screen.getByText('Narrator')).toBeInTheDocument();
+    expect(screen.getByText('Marlow')).toBeInTheDocument();
+  });
+
+  it('shows the language facet when at least one voice has a non-English languageCode', async () => {
+    const lib: Voice[] = [
+      makeLangVoice({ id: 'v_ivan', character: 'Ivan', bookId: 'b1', bookTitle: 'Book One', source: 'current', languageCode: 'ru' }),
+      makeLangVoice({ id: 'v_preset', character: 'Preset', bookId: 'b1', bookTitle: 'Book One', source: 'current' }),
+    ];
+    renderLangView(lib);
+    await act(async () => {});
+    expect(screen.getByRole('group', { name: 'Filter by language' })).toBeInTheDocument();
+    /* "All" and "Russian" buttons present. */
+    const group = screen.getByRole('group', { name: 'Filter by language' });
+    expect(within(group).getByRole('button', { name: 'All' })).toBeInTheDocument();
+    expect(within(group).getByRole('button', { name: 'Russian' })).toBeInTheDocument();
+  });
+
+  it('filters the voice list to the selected language when a facet is clicked', async () => {
+    /* One Russian-designed voice + one preset (no languageCode = English). */
+    const lib: Voice[] = [
+      makeLangVoice({ id: 'v_ivan', character: 'Ivan', bookId: 'b1', bookTitle: 'Book One', source: 'current', languageCode: 'ru' }),
+      makeLangVoice({ id: 'v_preset', character: 'Preset', bookId: 'b1', bookTitle: 'Book One', source: 'current' }),
+    ];
+    renderLangView(lib);
+    await act(async () => {});
+    /* Default "All": both voices present. */
+    expect(screen.getByText('Ivan')).toBeInTheDocument();
+    expect(screen.getByText('Preset')).toBeInTheDocument();
+    /* Click "Russian" → only Ivan stays. */
+    fireEvent.click(screen.getByRole('button', { name: 'Russian' }));
+    expect(screen.getByText('Ivan')).toBeInTheDocument();
+    expect(screen.queryByText('Preset')).not.toBeInTheDocument();
+  });
+
+  it('restores all voices when "All" is clicked after a language selection', async () => {
+    const lib: Voice[] = [
+      makeLangVoice({ id: 'v_ivan', character: 'Ivan', bookId: 'b1', bookTitle: 'Book One', source: 'current', languageCode: 'ru' }),
+      makeLangVoice({ id: 'v_preset', character: 'Preset', bookId: 'b1', bookTitle: 'Book One', source: 'current' }),
+    ];
+    renderLangView(lib);
+    await act(async () => {});
+    fireEvent.click(screen.getByRole('button', { name: 'Russian' }));
+    expect(screen.queryByText('Preset')).not.toBeInTheDocument();
+    const group = screen.getByRole('group', { name: 'Filter by language' });
+    fireEvent.click(within(group).getByRole('button', { name: 'All' }));
+    expect(screen.getByText('Preset')).toBeInTheDocument();
+    expect(screen.getByText('Ivan')).toBeInTheDocument();
+  });
+
+  it('labels known language codes with their English word (Russian, Spanish, French, German)', async () => {
+    const lib: Voice[] = [
+      makeLangVoice({ id: 'v_ru', character: 'Ru', bookId: 'b1', bookTitle: 'B1', source: 'current', languageCode: 'ru' }),
+      makeLangVoice({ id: 'v_es', character: 'Es', bookId: 'b1', bookTitle: 'B1', source: 'current', languageCode: 'es' }),
+      makeLangVoice({ id: 'v_fr', character: 'Fr', bookId: 'b1', bookTitle: 'B1', source: 'current', languageCode: 'fr' }),
+      makeLangVoice({ id: 'v_de', character: 'De', bookId: 'b1', bookTitle: 'B1', source: 'current', languageCode: 'de' }),
+    ];
+    renderLangView(lib);
+    await act(async () => {});
+    const group = screen.getByRole('group', { name: 'Filter by language' });
+    expect(within(group).getByRole('button', { name: 'Russian' })).toBeInTheDocument();
+    expect(within(group).getByRole('button', { name: 'Spanish' })).toBeInTheDocument();
+    expect(within(group).getByRole('button', { name: 'French' })).toBeInTheDocument();
+    expect(within(group).getByRole('button', { name: 'German' })).toBeInTheDocument();
+  });
+
+  it('falls back to the raw BCP-47 code when the language is not in the label map', async () => {
+    const lib: Voice[] = [
+      makeLangVoice({ id: 'v_ja', character: 'Tanaka', bookId: 'b1', bookTitle: 'B1', source: 'current', languageCode: 'ja' }),
+    ];
+    renderLangView(lib);
+    await act(async () => {});
+    const group = screen.getByRole('group', { name: 'Filter by language' });
+    /* 'ja' is not in the label map → rendered as-is. */
+    expect(within(group).getByRole('button', { name: 'ja' })).toBeInTheDocument();
+  });
+});

--- a/src/views/voices.tsx
+++ b/src/views/voices.tsx
@@ -165,6 +165,8 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
   const [unmarkBusyKey, setUnmarkBusyKey] = useState<string | null>(null);
   /* fe-34 — variant filter for the Qwen "Designed voices" section. */
   const [variantFilter, setVariantFilter] = useState<'all' | 'has' | 'needs'>('all');
+  /* fs-41/fs-50 seam 4b — language facet. null = show all. */
+  const [languageFilter, setLanguageFilter] = useState<string | null>(null);
   /* fe-34 — sentences per foreign book, cached from the same getBookState the
      duplicate/compare flows already fetch. The open book reads redux below. */
   const [sentencesByBookId, setSentencesByBookId] = useState<Map<string, Sentence[]>>(
@@ -241,7 +243,26 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
     () => library.filter((v) => v.ttsVoice?.provider === 'qwen'),
     [library],
   );
-  const families = useMemo(() => buildFamilies(presetLibrary, tab), [presetLibrary, tab]);
+  /* fs-41/fs-50 seam 4b — unique non-English languageCodes present in the
+     full library. The facet only renders when this is non-empty (English-only
+     or no-languageCode libraries show no facet). */
+  const languages = useMemo(
+    () => [...new Set(library.map((v) => v.languageCode).filter(Boolean))] as string[],
+    [library],
+  );
+  /* fs-41/fs-50 seam 4b — language-filtered preset library fed into
+     buildFamilies; mirrors how variantFilter narrows filteredQwenLibrary. */
+  const languageFilteredPresetLibrary = useMemo(
+    () =>
+      languageFilter === null
+        ? presetLibrary
+        : presetLibrary.filter((v) => v.languageCode === languageFilter),
+    [presetLibrary, languageFilter],
+  );
+  const families = useMemo(
+    () => buildFamilies(languageFilteredPresetLibrary, tab),
+    [languageFilteredPresetLibrary, tab],
+  );
   /* fs-34 — per-voice designed-variant count for the cross-book Voices badge.
      Resolve each Qwen voice to its character (redux for the open book, the
      global cast cache for others) and count its qwen.variants. */
@@ -275,10 +296,14 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
     return map;
   }, [qwenLibrary, currentBookId, characters, globalCastCache, openBookSentences, sentencesByBookId]);
   const filteredQwenLibrary = useMemo(() => {
-    if (variantFilter === 'all') return qwenLibrary;
+    const langFiltered =
+      languageFilter === null
+        ? qwenLibrary
+        : qwenLibrary.filter((v) => v.languageCode === languageFilter);
+    if (variantFilter === 'all') return langFiltered;
     const map = variantFilter === 'has' ? variantCountByVoiceId : missingVariantCountByVoiceId;
-    return qwenLibrary.filter((v) => (map.get(v.id) ?? 0) > 0);
-  }, [qwenLibrary, variantFilter, variantCountByVoiceId, missingVariantCountByVoiceId]);
+    return langFiltered.filter((v) => (map.get(v.id) ?? 0) > 0);
+  }, [qwenLibrary, languageFilter, variantFilter, variantCountByVoiceId, missingVariantCountByVoiceId]);
   const qwenGroups = useMemo(
     () => buildQwenStatusGroups(filteredQwenLibrary, tab),
     [filteredQwenLibrary, tab],
@@ -1125,6 +1150,43 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
               </div>
             )}
           </div>
+          {/* fs-41/fs-50 seam 4b — language facet. Only shown when ≥1 voice
+              carries a non-English languageCode; an all-English library shows
+              nothing here, preserving the existing view byte-for-byte. */}
+          {languages.length > 0 && (
+            <div
+              className="flex items-center gap-2 flex-wrap"
+              role="group"
+              aria-label="Filter by language"
+            >
+              <span className="text-xs text-ink/50">Language:</span>
+              {([null, ...languages] as Array<string | null>).map((code) => {
+                const LANGUAGE_LABELS: Record<string, string> = {
+                  ru: 'Russian',
+                  es: 'Spanish',
+                  fr: 'French',
+                  de: 'German',
+                };
+                const label = code === null ? 'All' : (LANGUAGE_LABELS[code] ?? code);
+                const active = languageFilter === code;
+                return (
+                  <button
+                    key={code ?? '__all__'}
+                    type="button"
+                    onClick={() => setLanguageFilter(code)}
+                    aria-pressed={active}
+                    className={`min-h-[44px] sm:min-h-0 inline-flex items-center px-3 py-2 sm:py-1.5 rounded-full text-sm font-medium transition-colors ${
+                      active
+                        ? 'bg-ink text-canvas'
+                        : 'border border-ink/10 bg-white text-ink/70 hover:text-ink hover:bg-ink/4'
+                    }`}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+          )}
           {qwenLibrary.length > 0 && (
             <div
               className="flex items-center gap-2 flex-wrap"

--- a/src/views/voices.tsx
+++ b/src/views/voices.tsx
@@ -1178,7 +1178,7 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
                     className={`min-h-[44px] sm:min-h-0 inline-flex items-center px-3 py-2 sm:py-1.5 rounded-full text-sm font-medium transition-colors ${
                       active
                         ? 'bg-ink text-canvas'
-                        : 'border border-ink/10 bg-white text-ink/70 hover:text-ink hover:bg-ink/4'
+                        : 'border border-ink/10 bg-canvas text-ink/70 hover:text-ink hover:bg-ink/4'
                     }`}
                   >
                     {label}


### PR DESCRIPTION
## Summary

Seam 4b of fs-41/fs-50 — completes seam 4 (the voice-library language work).

- **Early-warning transport** (server): `clearMismatchedDesignedVoices` now **returns** the cleared characters (id + name + the language they were designed for) instead of clearing them silently. Both call sites (`generation.ts`, `chapter-splice.ts`, inside the `nonEnglishBook` branch) emit the **existing `warning` SSE tick** (`code: voice_language_mismatch`) when the list is non-empty — which the frontend already turns into a dedup'd toast (`generation-stream-runner.ts`). So a user whose cross-language designed voice gets dropped at generation now *sees* it. No new tick type, no openapi change, no new frontend path.
- **`#/voices` language facet** (frontend): a language filter on the global voices view keyed on the `Voice.languageCode` seam 4a added, mirroring the existing `variantFilter` cascade across both the preset and Qwen pipelines. The facet renders **only when ≥1 non-English voice is present**, so an English-only library is byte-identical.

**Known gap (follow-up):** the **splice** stream consumer (`splice-runner-middleware.ts`) only handles `splice_complete`, so the `warning` tick is emitted but not toasted on the splice path — the generation path (the primary surface) is fully covered. A splice-path toast is a small follow-up.

## Test plan

- Server: `verify-designed-voice-language` return tests (cleared list / empty / missing-manifest 'unknown'); full server suite green.
- Frontend: 5 new `voices.test.tsx` facet tests (filter by language; all-English → no facet; label map; unknown-code fallback) on top of pre-existing (62/62). Typecheck clean.

## Note on verification

Pushed with `--no-verify` (author-authorized) — the local pre-push e2e is failing on an overloaded dev box (orphaned dev-server processes → `page.goto` navigation timeouts on unrelated specs, confirmed environmental). `run-ci` runs the **full battery on a clean Ubuntu runner**.

Refs #974, #666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLg2Zazw3rSSE2kRq1JUzz
