### PR TITLE
feat(server): sidecarLanguageName throws for an unsupported language (fail-loud)

### DIFF
--- a/server/src/routes/cast-design.ts
+++ b/server/src/routes/cast-design.ts
@@ -433,7 +433,14 @@ castDesignRouter.post('/:bookId/cast/design', async (req: Request, res: Response
   }
 
   /* ── Start path: register the job + run the loop detached. */
-  const language = sidecarLanguageName(bookStateLanguage(located.state));
+  let language: string;
+  try {
+    language = sidecarLanguageName(bookStateLanguage(located.state));
+  } catch (e) {
+    send({ type: 'error', code: 'unsupported_language', message: (e as Error).message });
+    clearInterval(keepAlive);
+    return res.end();
+  }
   const isStandalone = located.state?.isStandalone === true;
   const seriesInfo = isStandalone ? null : await findAuthorSeriesForBookId(bookId);
   const seriesFilter = seriesInfo ?? undefined;

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -563,9 +563,16 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
        splice re-record path: clears any designed Qwen voice whose baked
        manifest language ≠ the book's, so the forbidKokoroFallback gate blocks
        it as undesigned rather than reading wrong-language audio. */
+    let sidecarLang: string;
+    try {
+      sidecarLang = sidecarLanguageName(bookLanguage);
+    } catch (e) {
+      send({ type: 'chapter_failed', errorReason: (e as Error).message });
+      return res.end();
+    }
     const clearedVoices = await clearMismatchedDesignedVoices(
       cast.characters,
-      sidecarLanguageName(bookLanguage),
+      sidecarLang,
       bookLanguage,
     );
     if (clearedVoices.length > 0) {

--- a/server/src/routes/single-design.ts
+++ b/server/src/routes/single-design.ts
@@ -237,7 +237,14 @@ singleDesignRouter.post(
       }
     };
 
-    const language = sidecarLanguageName(bookStateLanguage(located.state));
+    let language: string;
+    try {
+      language = sidecarLanguageName(bookStateLanguage(located.state));
+    } catch (e) {
+      send({ type: 'error', code: 'unsupported_language', message: (e as Error).message });
+      clearInterval(keepAlive);
+      return res.end();
+    }
     const isStandalone = located.state?.isStandalone === true;
     const seriesInfo = isStandalone ? null : await findAuthorSeriesForBookId(bookId);
 

--- a/server/src/tts/language.test.ts
+++ b/server/src/tts/language.test.ts
@@ -1,18 +1,15 @@
 /* language — the BCP-47 ↔ sidecar language-name bridge (fs-2). Pins the
-   normalisation, the en/ru mapping, the unknown-code fallback-with-warn, and
-   the isNonEnglish predicate that gates the never-cross-language enforcement. */
+   normalisation, the en/ru mapping, the fail-loud throw for unsupported codes
+   (seam 5a), and the isNonEnglish predicate that gates the never-cross-language
+   enforcement. */
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import {
   DEFAULT_LANGUAGE,
   normaliseBookLanguage,
   sidecarLanguageName,
   isNonEnglish,
 } from './language.js';
-
-afterEach(() => {
-  vi.restoreAllMocks();
-});
 
 describe('normaliseBookLanguage', () => {
   it('defaults missing/empty/whitespace to en', () => {
@@ -39,15 +36,25 @@ describe('sidecarLanguageName', () => {
     expect(sidecarLanguageName('ru-RU')).toBe('Russian');
   });
 
-  it('treats missing/empty as English', () => {
+  it('treats missing/empty as English (normalises to "en" which resolves)', () => {
     expect(sidecarLanguageName('')).toBe('English');
   });
 
-  it('falls back to English with a warning for an unknown code', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    expect(sidecarLanguageName('xy')).toBe('English');
-    expect(warn).toHaveBeenCalledOnce();
-    expect(warn.mock.calls[0]?.[0]).toContain('xy');
+  /* seam 5a — fail loud: an unsupported language code must THROW, not silently
+     return 'English' and ship cross-language garbage through the voice pipeline. */
+  it('throws for an unknown BCP-47 code', () => {
+    expect(() => sidecarLanguageName('xy')).toThrow(/unsupported language/);
+    expect(() => sidecarLanguageName('xy')).toThrow(/xy/);
+  });
+
+  it('throws for a language not in the registry (e.g. Japanese)', () => {
+    expect(() => sidecarLanguageName('ja')).toThrow(/unsupported language/);
+    expect(() => sidecarLanguageName('ja-JP')).toThrow(/unsupported language/);
+  });
+
+  it('throw message includes the bcp47 tag and the primary subtag', () => {
+    expect(() => sidecarLanguageName('zz-ZZ')).toThrow(/zz-ZZ/);
+    expect(() => sidecarLanguageName('zz-ZZ')).toThrow(/"zz"/);
   });
 
   it('sources the language word from the registry entry', async () => {

--- a/server/src/tts/language.ts
+++ b/server/src/tts/language.ts
@@ -23,19 +23,20 @@ export function normaliseBookLanguage(raw: string | undefined | null): string {
   return primary || DEFAULT_LANGUAGE;
 }
 
-/** The sidecar's language word for a BCP-47 book language. Unknown codes fall
-    back to `'English'` with a warning — a stray code must never throw and break
-    generation, but it also must never silently mis-route, so we log it.
-    (Seam 5 replaces this fallback with a throw gated on the registry's
-    `supported` set; seam 1 preserves the shipped behaviour.) */
+/** The sidecar's language word for a BCP-47 book language.
+    Throws for any language code not present in the registry — an unsupported
+    language must never silently default to English and ship cross-language garbage.
+    The confirm-screen support gate blocks unsupported languages before they reach
+    the voice pipeline, so a throw here is a fail-loud safety net for the cases
+    where that gate was bypassed or the registry is out of sync. */
 export function sidecarLanguageName(bcp47: string): string {
   const primary = normaliseBookLanguage(bcp47);
   const entry = getLanguageEntry(primary);
   if (!entry) {
-    console.warn(
-      `[language] no sidecar language name for "${bcp47}" (primary "${primary}") — falling back to English`,
+    throw new Error(
+      `[language] unsupported language reached the voice pipeline: bcp47="${bcp47}" primary="${primary}". ` +
+        `Add it to the language registry or block it at the confirm-screen support gate.`,
     );
-    return 'English';
   }
   return entry.sidecarName;
 }


### PR DESCRIPTION
## Summary

fs-41/fs-50 seam 5a. `sidecarLanguageName` mapped a book's BCP-47 language to the sidecar language word, but for an **unmapped** code it `console.warn`ed and silently **returned `'English'`** — so an unsupported non-English book that slipped past the confirm-screen gate would design/synthesise its voices in English (cross-language garbage) without anyone knowing.

Now it **throws** for an unmapped code (fail-loud safety net). Supported languages (en/ru/es/fr/de) resolve to a registry entry → byte-unchanged, never throw.

The 5 callers all surface the throw cleanly (no crash/hang):
- `chapter-splice.ts` (already inside `try/catch`) and `qwen-voice.ts` (JSON endpoint — headers not flushed → Express global error handler → clean 500) needed no change.
- The 3 SSE design/generation call sites (`generation.ts`, `cast-design.ts`, `single-design.ts`) had their headers already flushed, so each got a **narrow** `try/catch` around just the `sidecarLanguageName(...)` call that emits an error/`chapter_failed` tick + `res.end()` (no double-send, no "headers already sent", `clearInterval(keepAlive)` to avoid a timer leak).

## Test plan

- `language.test.ts`: the old "falls back to English with a warning" test is flipped to assert the **throw** (covering `xy`/`ja`/`zz-ZZ`); `en/ru/es` still return their words; empty/missing still resolves to English (normalises to `en`). 9/9 language + 728 server + typecheck green.

## Note on verification

Pushed with `--no-verify` (author-authorized) — the local pre-push e2e is failing on an overloaded dev box (orphaned dev-server processes → `page.goto` navigation timeouts on unrelated specs, confirmed environmental). `run-ci` runs the **full battery on a clean Ubuntu runner**.

Refs #974, #666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLg2Zazw3rSSE2kRq1JUzz
