### PR TITLE
feat(server): expose QWEN_BASE17_IDLE_TTL as a gpu-lifecycle setting

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -554,6 +554,8 @@ GPU_WEIGHT_SPK=1
 GPU_SAFE_COEXIST_MB=11000
 # Seconds of voice-design inactivity before the watchdog frees the transient Qwen VoiceDesign 1.7B model (reclaiming ~4–5 GB VRAM). Values below 5 fall back to the default (120) to avoid reload thrash. A real /synthesize also frees it immediately. [restart-sidecar · high risk]
 QWEN_DESIGN_IDLE_TTL=120
+# Seconds of inactivity before the watchdog frees the resident Qwen 1.7B-Base model (reclaiming ~3.4 GB VRAM). It stays warm across back-to-back emotion-variant mints and 1.7B (Quality-tier) synths so a full-library re-mint runs in one pass without fragmenting the CUDA allocator (issue #1024); lower this to shrink the warm window on a small card. Values below 5 fall back to the default (120) to avoid reload thrash. [restart-sidecar · high risk]
+QWEN_BASE17_IDLE_TTL=120
 # Seconds of ASR inactivity before the sidecar frees the Whisper model. Mainly reclaims VRAM on ASR_DEVICE=cuda; on cpu it frees host RAM. Values below 5 fall back to the default (120) to avoid reload thrash. [restart-sidecar · high risk]
 ASR_IDLE_TTL=120
 # Seconds of speaker-embed inactivity before the sidecar frees the ECAPA model. Reclaims VRAM only on SPK_DEVICE=cuda (a no-op on cpu). Values below 5 fall back to the default (120) to avoid reload thrash. [restart-sidecar · high risk]

--- a/server/src/config/registry.ts
+++ b/server/src/config/registry.ts
@@ -548,6 +548,16 @@ export const KNOBS: ConfigKnob[] = [
     apply: 'restart-sidecar', risk: 'high',
   },
   {
+    key: 'sidecar.qwenBase17IdleTtl',
+    env: 'QWEN_BASE17_IDLE_TTL',
+    group: 'gpu-lifecycle',
+    label: 'Qwen 1.7B-Base idle TTL (s)',
+    help: 'Seconds of inactivity before the watchdog frees the resident Qwen 1.7B-Base model (reclaiming ~3.4 GB VRAM). It stays warm across back-to-back emotion-variant mints and 1.7B (Quality-tier) synths so a full-library re-mint runs in one pass without fragmenting the CUDA allocator (issue #1024); lower this to shrink the warm window on a small card. Values below 5 fall back to the default (120) to avoid reload thrash.',
+    type: 'integer', min: 0,
+    default: 120, // ← _DESIGN_IDLE_TTL_DEFAULT reused by _base17_idle_ttl() in tts-sidecar/main.py
+    apply: 'restart-sidecar', risk: 'high',
+  },
+  {
     key: 'sidecar.asrIdleTtl',
     env: 'ASR_IDLE_TTL',
     group: 'gpu-lifecycle',


### PR DESCRIPTION
## Summary

Follow-up to #1024 / #1025. That PR added the `QWEN_BASE17_IDLE_TTL` sidecar env knob (the warm-window before the idle watchdog frees the resident 1.7B-Base) but left it **env-only** — inconsistent with its three sibling idle-TTL knobs, which are all registered in `config/registry.ts` and surface as user-tweakable **advanced settings** under the `gpu-lifecycle` group:

- `sidecar.qwenDesignIdleTtl` → `QWEN_DESIGN_IDLE_TTL` (Qwen VoiceDesign)
- `sidecar.asrIdleTtl` → `ASR_IDLE_TTL` (Whisper)
- `sidecar.spkIdleTtl` → `SPK_IDLE_TTL` (ECAPA speaker-embed)

This registers the fourth one so it's editable in the UI like the others.

### What changed

- Added `sidecar.qwenBase17IdleTtl` → `QWEN_BASE17_IDLE_TTL` to the registry (`integer`, `min 0`, default `120`, `apply: restart-sidecar`, `risk: high`), mirroring `sidecar.qwenDesignIdleTtl`. Help text explains the warm-across-mints behavior + the #1024 rationale.
- Regenerated `server/.env.example` via `npm run config:sync`.

`spawn-sidecar.ts` already injects any `restart-sidecar` knob whose value differs from the registry default, so registration **auto-plumbs** it to the sidecar — no allowlist change. **No behaviour change:** the sidecar already reads `QWEN_BASE17_IDLE_TTL`; this only makes it visible + editable in advanced settings.

## Test plan

- `registry` + `env-example` + `resolver` + `spawn-sidecar` vitest — 61 passed
- `npm run config:check` — `.env.example` in sync ✓
- full server suite (pre-commit gate) — 3304 passed
- `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)