### PR TITLE
feat(server,frontend): enable Spanish (es) — canary-validated

### DIFF
--- a/server/src/routes/import.test.ts
+++ b/server/src/routes/import.test.ts
@@ -447,10 +447,11 @@ describe('POST /api/import — language detection (fs-41/fs-50)', () => {
       'El horno se había enfriado hasta el color de un atardecer cubierto de ceniza, y Wren raspaba la última escoria cuando alguien llamó a la puerta de su taller.';
     const res = await request(app).post('/api/import').send({ text: es }).expect(200);
     expect(res.body.candidate.language).toBe('es');
-    expect(res.body.candidate.languageSupported).toBe(false);
+    expect(res.body.candidate.languageSupported).toBe(true);
     expect(res.body.candidate.supportedLanguages).toEqual([
       { code: 'en', label: 'English' },
       { code: 'ru', label: 'Russian' },
+      { code: 'es', label: 'Spanish' },
     ]);
   });
 });

--- a/server/src/tts/detect-language.test.ts
+++ b/server/src/tts/detect-language.test.ts
@@ -11,10 +11,10 @@ describe('detectManuscriptLanguage', () => {
     expect(detectManuscriptLanguage(ru)).toEqual({ language: 'ru', supported: true });
   });
 
-  it('detects Spanish (present in the registry, not yet supported)', () => {
+  it('detects Spanish (present in the registry, supported — canary-validated)', () => {
     const es =
       'El horno se había enfriado hasta el color de un atardecer cubierto de ceniza, y Wren raspaba la última escoria cuando alguien llamó a la puerta de su taller.';
-    expect(detectManuscriptLanguage(es)).toEqual({ language: 'es', supported: false });
+    expect(detectManuscriptLanguage(es)).toEqual({ language: 'es', supported: true });
   });
 
   it('detects French (not yet supported)', () => {
@@ -46,7 +46,7 @@ describe('detectManuscriptLanguage', () => {
       'El horno se había enfriado hasta el color de un atardecer cubierto de ceniza, y Wren raspaba la última escoria cuando alguien llamó a la puerta de su taller, una y otra vez, hasta que abrió.';
     // stripFrontMatterBoilerplate drops the bare-URL + copyright lines; the Spanish
     // body dominates the sample, so franc must return Spanish, not English.
-    expect(detectManuscriptLanguage(text)).toEqual({ language: 'es', supported: false });
+    expect(detectManuscriptLanguage(text)).toEqual({ language: 'es', supported: true });
   });
 
   it('flags a CJK manuscript as detected-but-unsupported (no zh/ja registry entry yet)', () => {

--- a/server/src/tts/language-registry.test.ts
+++ b/server/src/tts/language-registry.test.ts
@@ -50,9 +50,10 @@ describe('getLanguageEntry', () => {
 });
 
 describe('isSupportedLanguage', () => {
-  it('is true for seeded en/ru, false otherwise', () => {
+  it('is true for en/ru/es (es canary-validated), false otherwise', () => {
     expect(isSupportedLanguage('en')).toBe(true);
     expect(isSupportedLanguage('ru')).toBe(true);
+    expect(isSupportedLanguage('es')).toBe(true);
     expect(isSupportedLanguage('de')).toBe(false);
     expect(isSupportedLanguage('')).toBe(false);
   });
@@ -64,8 +65,14 @@ describe('detect field + Latin entries', () => {
     expect(getLanguageEntry('ru')?.detect).toEqual({ script: 'cyrillic', iso6393: 'rus' });
   });
 
-  it('es/fr/de exist, are Latin, and are NOT yet supported', () => {
-    for (const [code, iso] of [['es', 'spa'], ['fr', 'fra'], ['de', 'deu']] as const) {
+  it('es exists, is Latin, and IS supported (canary-validated)', () => {
+    const e = getLanguageEntry('es');
+    expect(e?.detect).toEqual({ script: 'latin', iso6393: 'spa' });
+    expect(e?.supported).toBe(true);
+  });
+
+  it('fr/de exist, are Latin, and are NOT yet supported', () => {
+    for (const [code, iso] of [['fr', 'fra'], ['de', 'deu']] as const) {
       const e = getLanguageEntry(code);
       expect(e?.detect).toEqual({ script: 'latin', iso6393: iso });
       expect(e?.supported).toBe(false);
@@ -74,9 +81,9 @@ describe('detect field + Latin entries', () => {
 });
 
 describe('isSupportedLanguage with a present-but-unsupported entry', () => {
-  it('is false for es (present, supported:false) — not just for absent codes', () => {
-    expect(getLanguageEntry('es')).toBeDefined();
-    expect(isSupportedLanguage('es')).toBe(false);
+  it('is false for fr (present, supported:false) — not just for absent codes', () => {
+    expect(getLanguageEntry('fr')).toBeDefined();
+    expect(isSupportedLanguage('fr')).toBe(false);
   });
 });
 
@@ -86,6 +93,7 @@ describe('supportedLanguages', () => {
     expect(list).toEqual([
       { code: 'en', label: 'English' },
       { code: 'ru', label: 'Russian' },
+      { code: 'es', label: 'Spanish' },
     ]);
   });
 });

--- a/server/src/tts/language-registry.ts
+++ b/server/src/tts/language-registry.ts
@@ -6,7 +6,9 @@
    gated `supported:false` until its validation gate passes.
 
    `en` and `ru` are seeded `supported:true`: ru shipped validated under
-   fs-2, so it is grandfathered past the per-language gate. */
+   fs-2, so it is grandfathered past the per-language gate.
+   `es` flipped `supported:true` 2026-06-23 after canary validation + operator
+   acceptance (fs-41/fs-50 Spanish rollout). `fr` and `de` remain gated. */
 
 export interface LanguageEntry {
   /** BCP-47 primary subtag, lower-cased (e.g. 'en', 'ru', 'es'). */
@@ -38,9 +40,10 @@ const ENTRIES: readonly LanguageEntry[] = [
       'об авторе', 'предисловие', 'послесловие', 'приложение', 'глоссарий', 'библиография', 'указатель',
       'примечания', 'выходные данные', 'эпиграф'],
   },
-  // es/fr/de: detection identifies them, but they are not claimed until their
-  // rollout phase's operator gate flips `supported` (not in this seam).
-  { code: 'es', sidecarName: 'Spanish', supported: false, detect: { script: 'latin',    iso6393: 'spa' },
+  // es: canary-validated + operator-accepted (2026-06-23); fr/de remain gated.
+  // fr/de: detection identifies them, but they are not claimed until their
+  // rollout phase's operator gate flips `supported`.
+  { code: 'es', sidecarName: 'Spanish', supported: true,  detect: { script: 'latin',    iso6393: 'spa' },
     headingLexicon: {
       keywords: ['capítulo', 'parte', 'día', 'libro', 'acto', 'escena', 'sección'],
       numberWords: ['uno', 'dos', 'tres', 'cuatro', 'cinco', 'seis', 'siete', 'ocho', 'nueve', 'diez',

--- a/src/views/confirm-metadata.test.tsx
+++ b/src/views/confirm-metadata.test.tsx
@@ -244,13 +244,13 @@ describe('ConfirmMetadataView — fs-41/fs-50 language selector (server-detected
   });
 
   it('shows a detected-but-unsupported banner and defaults to English when the detection is unsupported', () => {
-    renderWithCandidate({ language: 'es', languageSupported: false,
-      supportedLanguages: [{ code: 'en', label: 'English' }, { code: 'ru', label: 'Russian' }] });
+    renderWithCandidate({ language: 'fr', languageSupported: false,
+      supportedLanguages: [{ code: 'en', label: 'English' }, { code: 'ru', label: 'Russian' }, { code: 'es', label: 'Spanish' }] });
     const select = screen.getByTestId('confirm-language') as HTMLSelectElement;
     expect(select.value).toBe('en'); // not yet supported → user must pick a supported language
-    expect(screen.getByText(/spanish.*not.*supported/i)).toBeInTheDocument();
+    expect(screen.getByText(/french.*not.*supported/i)).toBeInTheDocument();
     // the unsupported language is NOT a selectable option
-    expect(within(select).queryByText('Spanish')).not.toBeInTheDocument();
+    expect(within(select).queryByText('French')).not.toBeInTheDocument();
   });
 
   it('clears the auto-detected chip once the user changes the selector', async () => {


### PR DESCRIPTION
## Summary

Enables **Spanish (`es`) as a supported language** — the culmination of fs-41/fs-50. `es.supported: false → true` in the language registry; `fr`/`de` stay gated (only Spanish is validated).

## Validation (the record)

On-box Spanish canary, driven end-to-end against the real stack with a Spanish translation of the canonical book (`samples/the-coalfall-commission/manuscript.es.md`):
- **Detection** → `es`, supported.
- **Attribution** → scored by the new eval harness: **RECALL 13/13 (100%), PRECISION 93%** (only the known Dragón/Coalfall split).
- **Voice design** → Spanish-calibrated: the manifest `refText` is now "El veloz murciélago…" (the #1019 calibration fix), not the English pangram.
- **Synthesis** → full chapter rendered (66/66, ~4m27s MP3).
- **ASR content-QA** → clean Spanish round-trip, **0 flagged segments**.
- **Operator listen → accepted.** ✅

## Changes

- `language-registry.ts`: `es` → `supported: true`.
- Tests re-pointed off `es` as the "unsupported" example: `detect-language.test.ts` (×2 → supported), `language-registry.test.ts` (present-but-unsupported example → `fr`, + a new `isSupportedLanguage('es') === true` assertion), `confirm-metadata.test.tsx` (unsupported-banner example → `fr`, `es` added to supportedLanguages), `import.test.ts` (Spanish body → supported, `es` in the list).

## Follow-ups filed (none block this)

- #1027 — per-language sample books in the demo pack
- #1028 — non-English minor-cast protection (Berrin/Ivo fold; the seam-3d `taggedSpeakerIds` gating side-effect)
- #1029 — chapter assembly stalls with the `SEG_SPK` drift gate on (8 GB box)
- #1030 — two server instances fight over the `:9000` sidecar (recycle-storm guard)

Plus a noted refinement: the Qwen design `instruct` persona is still English (lower-impact further-i18n; operator accepted the sound without it).

## Note on verification

Pushed `--no-verify` (author-authorized) — the local pre-push e2e fails on an overloaded dev box (environmental). `run-ci` runs the full battery on a clean Ubuntu runner.

Closes the fs-41/fs-50 Spanish milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLg2Zazw3rSSE2kRq1JUzz
