### PR TITLE
fix(server): single-owner guard so two server stacks can't fight over the :9000 sidecar

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -59,6 +59,10 @@ import {
   registerActiveSupervisor,
   type SidecarSupervisor,
 } from './tts/sidecar-supervisor.js';
+import {
+  enforceSingleSidecarOwner,
+  releaseSidecarOwnership,
+} from './tts/sidecar-owner.js';
 import { detectQwenInstallStateOnDisk } from './tts/qwen-install-detect.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -210,6 +214,17 @@ const listenerCallback = () => {
      the conditional default falls back to Kokoro. The /health poll refreshes
      this continuously once the sidecar is up. */
   setLastKnownQwenInstallState(detectQwenInstallStateOnDisk(bootRepoRoot));
+  /* #1030 — refuse to boot if another LIVE server already owns the :9000
+     sidecar, so two stacks can't fight over it (the recycle storm). Only when
+     THIS server will actually manage the sidecar (autoStart on); a no-autostart
+     server never supervises and so never conflicts. Drops/clears an owner note
+     in .run/; keyed on ppid so a `tsx watch` reload takes over rather than
+     refusing. Mirrors the EADDRINUSE HTTP-port guard (crash-logging.ts). Runs
+     before the supervisor starts AND before app.listen, so a conflict exits
+     cleanly without spawning a rival sidecar or grabbing the HTTP port. */
+  if (getResolvedAutoStartSidecar()) {
+    enforceSingleSidecarOwner({ runDir });
+  }
   /* srv-15 — supervise the sidecar instead of a one-shot spawn, so a crash /
      OOM-kill / poison self-exit respawns instead of stalling generation
      forever. `buildOpts` re-reads settings on each respawn so a mid-session
@@ -331,6 +346,10 @@ function shutdown(signal: NodeJS.Signals): void {
   shuttingDown = true;
   stopBackupScheduler();
   console.log(`[server] ${signal} received, tearing down sidecar...`);
+  /* #1030 — release our :9000 ownership note so the next boot (or another
+     stack) sees the port as free. No-op if we never claimed it (autoStart off)
+     or a same-lineage reload already took it over. */
+  releaseSidecarOwnership(runDir);
   /* stop() sets the supervisor's stopped flag BEFORE reaping the child, so the
      child's exit can't trigger a respawn race during shutdown. */
   const reap = sidecarSupervisor?.stop() ?? Promise.resolve();

--- a/server/src/tts/sidecar-owner.test.ts
+++ b/server/src/tts/sidecar-owner.test.ts
@@ -1,0 +1,241 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  claimSidecarOwnership,
+  enforceSingleSidecarOwner,
+  findConflictingOwner,
+  isProcessAlive,
+  readSidecarOwner,
+  releaseSidecarOwnership,
+  sidecarOwnerPath,
+} from './sidecar-owner.js';
+
+let runDir: string;
+beforeEach(() => {
+  runDir = mkdtempSync(join(tmpdir(), 'sidecar-owner-'));
+});
+afterEach(() => {
+  rmSync(runDir, { recursive: true, force: true });
+});
+
+const writeNote = (note: Record<string, unknown>): void =>
+  writeFileSync(sidecarOwnerPath(runDir), JSON.stringify(note), 'utf8');
+
+describe('readSidecarOwner', () => {
+  it('returns null when the note is absent', () => {
+    expect(readSidecarOwner(runDir)).toBeNull();
+  });
+
+  it('parses a well-formed note', () => {
+    writeNote({ pid: 123, ppid: 99, port: 9000, startedAt: '2026-06-23T00:00:00.000Z' });
+    expect(readSidecarOwner(runDir)).toEqual({
+      pid: 123,
+      ppid: 99,
+      port: 9000,
+      startedAt: '2026-06-23T00:00:00.000Z',
+    });
+  });
+
+  it('returns null on corrupt JSON', () => {
+    writeFileSync(sidecarOwnerPath(runDir), '{ not json', 'utf8');
+    expect(readSidecarOwner(runDir)).toBeNull();
+  });
+
+  it('returns null when pid is missing or invalid', () => {
+    writeNote({ ppid: 99, port: 9000 });
+    expect(readSidecarOwner(runDir)).toBeNull();
+    writeNote({ pid: 0, ppid: 99 });
+    expect(readSidecarOwner(runDir)).toBeNull();
+  });
+
+  it('tolerates a legacy note missing ppid/port (defaults applied)', () => {
+    writeNote({ pid: 123 });
+    expect(readSidecarOwner(runDir)).toEqual({ pid: 123, ppid: -1, port: 9000, startedAt: '' });
+  });
+});
+
+describe('isProcessAlive', () => {
+  it('returns true for the current process', () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+  });
+
+  it('returns false for an obviously-dead pid', () => {
+    // A huge pid that no OS will have allocated.
+    expect(isProcessAlive(2_147_483_000)).toBe(false);
+  });
+
+  it('treats EPERM (exists but not ours) as alive', () => {
+    const killFn = vi.fn(() => {
+      throw Object.assign(new Error('not permitted'), { code: 'EPERM' });
+    }) as unknown as typeof process.kill;
+    expect(isProcessAlive(4242, killFn)).toBe(true);
+  });
+
+  it('treats ESRCH (no such process) as dead', () => {
+    const killFn = vi.fn(() => {
+      throw Object.assign(new Error('no such process'), { code: 'ESRCH' });
+    }) as unknown as typeof process.kill;
+    expect(isProcessAlive(4242, killFn)).toBe(false);
+  });
+
+  it('rejects non-positive / non-integer pids without probing', () => {
+    const killFn = vi.fn() as unknown as typeof process.kill;
+    expect(isProcessAlive(0, killFn)).toBe(false);
+    expect(isProcessAlive(-1, killFn)).toBe(false);
+    expect(killFn).not.toHaveBeenCalled();
+  });
+});
+
+describe('claimSidecarOwnership', () => {
+  it('writes a round-trippable note with the given identity', () => {
+    claimSidecarOwnership({
+      runDir,
+      pid: 555,
+      ppid: 7,
+      port: 9000,
+      nowIso: () => '2026-06-23T12:00:00.000Z',
+    });
+    expect(readSidecarOwner(runDir)).toEqual({
+      pid: 555,
+      ppid: 7,
+      port: 9000,
+      startedAt: '2026-06-23T12:00:00.000Z',
+    });
+  });
+
+  it('overwrites a prior note', () => {
+    writeNote({ pid: 1, ppid: 1, port: 9000, startedAt: 'old' });
+    claimSidecarOwnership({ runDir, pid: 2, ppid: 2, nowIso: () => 'new' });
+    expect(readSidecarOwner(runDir)?.pid).toBe(2);
+  });
+});
+
+describe('releaseSidecarOwnership', () => {
+  it('deletes the note when the pid matches', () => {
+    claimSidecarOwnership({ runDir, pid: 555, ppid: 7 });
+    releaseSidecarOwnership(runDir, 555);
+    expect(readSidecarOwner(runDir)).toBeNull();
+  });
+
+  it('leaves a note owned by a different pid (lineage took over)', () => {
+    claimSidecarOwnership({ runDir, pid: 999, ppid: 7 });
+    releaseSidecarOwnership(runDir, 555); // an older lineage process shutting down
+    expect(readSidecarOwner(runDir)?.pid).toBe(999);
+  });
+
+  it('is a no-op when no note exists', () => {
+    expect(() => releaseSidecarOwnership(runDir, 555)).not.toThrow();
+  });
+});
+
+describe('findConflictingOwner', () => {
+  const alive = () => true;
+  const dead = () => false;
+
+  it('returns null when there is no note', () => {
+    expect(findConflictingOwner({ runDir, pid: 1, ppid: 1, aliveFn: alive })).toBeNull();
+  });
+
+  it('returns null for our own pid', () => {
+    claimSidecarOwnership({ runDir, pid: 100, ppid: 7 });
+    expect(findConflictingOwner({ runDir, pid: 100, ppid: 8, aliveFn: alive })).toBeNull();
+  });
+
+  it('returns null for the same lineage (tsx-watch reload: new pid, same ppid)', () => {
+    claimSidecarOwnership({ runDir, pid: 100, ppid: 7 });
+    expect(findConflictingOwner({ runDir, pid: 200, ppid: 7, aliveFn: alive })).toBeNull();
+  });
+
+  it('returns null when the foreign owner is dead', () => {
+    claimSidecarOwnership({ runDir, pid: 100, ppid: 7 });
+    expect(findConflictingOwner({ runDir, pid: 200, ppid: 8, aliveFn: dead })).toBeNull();
+  });
+
+  it('returns the owner when it is live AND a foreign lineage', () => {
+    claimSidecarOwnership({ runDir, pid: 100, ppid: 7 });
+    const conflict = findConflictingOwner({ runDir, pid: 200, ppid: 8, aliveFn: alive });
+    expect(conflict?.pid).toBe(100);
+  });
+});
+
+describe('enforceSingleSidecarOwner', () => {
+  it('claims ownership and returns true when no conflict', () => {
+    const log = vi.fn();
+    const exit = vi.fn();
+    const ok = enforceSingleSidecarOwner({
+      runDir,
+      pid: 100,
+      ppid: 7,
+      aliveFn: () => false,
+      log,
+      exit,
+      nowIso: () => 'now',
+    });
+    expect(ok).toBe(true);
+    expect(exit).not.toHaveBeenCalled();
+    expect(readSidecarOwner(runDir)).toEqual({ pid: 100, ppid: 7, port: 9000, startedAt: 'now' });
+  });
+
+  it('logs an actionable FATAL line and exits(1) on a live foreign owner, WITHOUT clobbering the note', () => {
+    claimSidecarOwnership({ runDir, pid: 100, ppid: 7, nowIso: () => 'owner' });
+    const log = vi.fn();
+    const exit = vi.fn();
+    const ok = enforceSingleSidecarOwner({
+      runDir,
+      pid: 200,
+      ppid: 8,
+      aliveFn: () => true,
+      log,
+      exit,
+    });
+    expect(ok).toBe(false);
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('already owns the TTS'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('pid 100'));
+    // The incumbent owner's note must survive — we refused, we did not take over.
+    expect(readSidecarOwner(runDir)).toEqual({
+      pid: 100,
+      ppid: 7,
+      port: 9000,
+      startedAt: 'owner',
+    });
+  });
+
+  it('takes over (claims) when the existing owner is dead', () => {
+    claimSidecarOwnership({ runDir, pid: 100, ppid: 7 });
+    const exit = vi.fn();
+    const ok = enforceSingleSidecarOwner({
+      runDir,
+      pid: 200,
+      ppid: 8,
+      aliveFn: () => false,
+      log: vi.fn(),
+      exit,
+      nowIso: () => 'fresh',
+    });
+    expect(ok).toBe(true);
+    expect(exit).not.toHaveBeenCalled();
+    expect(readSidecarOwner(runDir)?.pid).toBe(200);
+  });
+
+  it('takes over on a same-lineage reload (tsx watch)', () => {
+    claimSidecarOwnership({ runDir, pid: 100, ppid: 7 });
+    const exit = vi.fn();
+    const ok = enforceSingleSidecarOwner({
+      runDir,
+      pid: 200,
+      ppid: 7, // same parent → same stack restarting
+      aliveFn: () => true,
+      log: vi.fn(),
+      exit,
+      nowIso: () => 'reload',
+    });
+    expect(ok).toBe(true);
+    expect(exit).not.toHaveBeenCalled();
+    expect(readSidecarOwner(runDir)?.pid).toBe(200);
+  });
+});

--- a/server/src/tts/sidecar-owner.ts
+++ b/server/src/tts/sidecar-owner.ts
@@ -1,0 +1,184 @@
+/* #1030 — single-owner guard for the TTS sidecar (:9000).
+ *
+ * Plan 43 moved sidecar ownership to the Node server, and the srv-15 supervisor
+ * kills + respawns any :9000 sidecar it judges "unfit" (stale protocol, prod
+ * never-adopt policy, ceiling mismatch, leak-saturated). With ONE server that's
+ * correct. With TWO server stacks on DIFFERENT HTTP ports (e.g. `npm start` dev
+ * on :8080 + `start:lan` on :8443) the existing EADDRINUSE guard never trips, so
+ * both boot and share the one global :9000 — and each sees the OTHER's healthy,
+ * in-use sidecar as unfit and replaces it, in an endless kill/respawn loop (the
+ * recycle storm: generation stalls because the sidecar is killed out from under
+ * an in-flight chapter).
+ *
+ * Fix (Option B, mirroring `attachListenErrorHandler`'s EADDRINUSE handling in
+ * crash-logging.ts): the owning server drops a note (.run/tts.owner.json)
+ * recording its pid + parent pid. A second server that finds a LIVE, FOREIGN
+ * owner refuses to boot with an actionable message + exit(1) instead of starting
+ * a rival supervisor.
+ *
+ * `ppid` is the lineage key: `tsx watch` (the dev `npm run dev:server` runner)
+ * respawns the server child on every save under the SAME watcher parent — new
+ * pid, same ppid. Keying conflict on a DIFFERENT ppid lets a reload recognise
+ * itself and take over, while a genuinely separate stack is refused. Without
+ * this, every dev save would kill the server.
+ */
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** The sidecar port the supervisor manages — `DEFAULT_PORT` in spawn-sidecar.ts.
+    Recorded in the note for diagnostics; the guard keys on pid/ppid, not port. */
+const SIDECAR_PORT = 9000;
+const OWNER_FILE = 'tts.owner.json';
+
+export interface SidecarOwnerNote {
+  /** PID of the server process that owns (supervises) the :9000 sidecar. */
+  pid: number;
+  /** Parent PID — the lineage key that survives a `tsx watch` reload. -1 when a
+      legacy/partial note omitted it (then only the pid match suppresses a
+      self-conflict). */
+  ppid: number;
+  /** The sidecar port this owner manages (informational; always 9000 today). */
+  port: number;
+  /** ISO timestamp ownership was claimed (informational/diagnostic). */
+  startedAt: string;
+}
+
+export function sidecarOwnerPath(runDir: string): string {
+  return join(runDir, OWNER_FILE);
+}
+
+/** Read + parse the owner note, or null when absent / unreadable / malformed.
+    A note without a valid positive pid is treated as absent. */
+export function readSidecarOwner(runDir: string): SidecarOwnerNote | null {
+  let raw: string;
+  try {
+    raw = readFileSync(sidecarOwnerPath(runDir), 'utf8');
+  } catch {
+    return null; // absent
+  }
+  try {
+    const p = JSON.parse(raw) as Partial<SidecarOwnerNote>;
+    if (typeof p.pid !== 'number' || !Number.isInteger(p.pid) || p.pid <= 0) return null;
+    return {
+      pid: p.pid,
+      ppid: typeof p.ppid === 'number' ? p.ppid : -1,
+      port: typeof p.port === 'number' ? p.port : SIDECAR_PORT,
+      startedAt: typeof p.startedAt === 'string' ? p.startedAt : '',
+    };
+  } catch {
+    return null; // corrupt JSON
+  }
+}
+
+/** True if `pid` names a live process. Uses signal 0 (no signal delivered, just
+    an existence + permission probe). ESRCH ⇒ dead; EPERM ⇒ alive but owned by
+    another user (treat as alive, so we err toward refusing rather than stomping
+    an unknown live process). */
+export function isProcessAlive(pid: number, killFn: typeof process.kill = process.kill): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    killFn(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+export interface ClaimOpts {
+  runDir: string;
+  pid?: number;
+  ppid?: number;
+  port?: number;
+  nowIso?: () => string;
+}
+
+/** Write the owner note, claiming :9000 ownership for this server. Creates
+    `runDir` if needed. */
+export function claimSidecarOwnership(opts: ClaimOpts): void {
+  const {
+    runDir,
+    pid = process.pid,
+    ppid = process.ppid,
+    port = SIDECAR_PORT,
+    nowIso = () => new Date().toISOString(),
+  } = opts;
+  mkdirSync(runDir, { recursive: true });
+  const note: SidecarOwnerNote = { pid, ppid, port, startedAt: nowIso() };
+  writeFileSync(sidecarOwnerPath(runDir), JSON.stringify(note), 'utf8');
+}
+
+/** Delete the owner note iff WE still own it (pid matches). A no-op when the
+    note is absent or has been taken over by another lineage — safe to call
+    unconditionally on shutdown. */
+export function releaseSidecarOwnership(runDir: string, pid: number = process.pid): void {
+  const owner = readSidecarOwner(runDir);
+  if (owner && owner.pid === pid) {
+    try {
+      unlinkSync(sidecarOwnerPath(runDir));
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+export interface ConflictCheckOpts {
+  runDir: string;
+  pid?: number;
+  ppid?: number;
+  aliveFn?: (pid: number) => boolean;
+}
+
+/** A LIVE, FOREIGN owner, or null. Not a conflict when: there is no note; the
+    note is our own pid; the note shares our lineage (a `tsx watch` reload — same
+    ppid, new pid); or the recorded owner is dead (stale note). */
+export function findConflictingOwner(opts: ConflictCheckOpts): SidecarOwnerNote | null {
+  const { runDir, pid = process.pid, ppid = process.ppid, aliveFn = isProcessAlive } = opts;
+  const owner = readSidecarOwner(runDir);
+  if (!owner) return null;
+  if (owner.pid === pid) return null; // our own note
+  if (owner.ppid > 0 && owner.ppid === ppid) return null; // same stack reloading (tsx watch)
+  return aliveFn(owner.pid) ? owner : null;
+}
+
+export interface EnforceOwnerOpts {
+  runDir: string;
+  pid?: number;
+  ppid?: number;
+  port?: number;
+  aliveFn?: (pid: number) => boolean;
+  log?: (msg: string) => void;
+  exit?: (code: number) => void;
+  nowIso?: () => string;
+}
+
+/** Enforce single-ownership of the :9000 sidecar. If another LIVE, FOREIGN
+    server already owns it, log an actionable FATAL line and exit(1) (mirroring
+    `attachListenErrorHandler`'s EADDRINUSE behaviour) — returning false WITHOUT
+    clobbering the incumbent's note. Otherwise claim ownership for this server
+    and return true. `log`/`exit` default to console.error / process.exit and
+    are injectable for tests. */
+export function enforceSingleSidecarOwner(opts: EnforceOwnerOpts): boolean {
+  const {
+    runDir,
+    pid = process.pid,
+    ppid = process.ppid,
+    port = SIDECAR_PORT,
+    aliveFn,
+    log = (m) => console.error(m),
+    exit = (c) => process.exit(c),
+    nowIso,
+  } = opts;
+  const conflict = findConflictingOwner({ runDir, pid, ppid, aliveFn });
+  if (conflict) {
+    log(
+      `[server] FATAL: another Castwright server (pid ${conflict.pid}) already owns the TTS ` +
+        `sidecar on :${conflict.port}. Two servers managing one sidecar fight over it ` +
+        `(recycle storm — generation stalls). Stop the other instance first, then restart. ` +
+        `If you are certain no other server is running, delete ${sidecarOwnerPath(runDir)} and retry.`,
+    );
+    exit(1);
+    return false; // reached only in tests where `exit` does not terminate
+  }
+  claimSidecarOwnership({ runDir, pid, ppid, port, nowIso });
+  return true;
+}


### PR DESCRIPTION
## Summary

Fixes the **recycle storm** (#1030): when two app stacks run on *different* HTTP ports (e.g. `npm start` dev on `:8080` plus a `start:lan` build on `:8443`), the existing `EADDRINUSE` guard never trips, so both servers boot and share the one global `:9000` sidecar. Each server's srv-15 supervisor then sees the *other's* healthy, in-use sidecar as "unfit" (prod never-adopt policy / ceiling mismatch / stale protocol) and kills + respawns it — an endless kill/respawn loop. A generation against one server keeps having its sidecar killed out from under it → repeated `chapter_recovering` → the chapter stalls and never completes. Root cause: no cross-process notion of "another live server owns `:9000`".

**Fix (mirrors the `EADDRINUSE` HTTP-port guard in `crash-logging.ts`):** the owning server drops an owner note (`.run/tts.owner.json`) recording its `pid` + parent `pid`. On boot, if `autoStart` is on and a **live, foreign** server already owns `:9000`, the second server refuses to start with an actionable `FATAL` line + `exit(1)` instead of starting a rival supervisor. The note is released on shutdown.

`ppid` is the lineage key: a `tsx watch` dev reload (the `npm run dev:server` runner) respawns the server child under the same watcher parent (new pid, same ppid), so a reload **takes over** rather than refusing — only a genuinely separate stack (different ppid) is a conflict. A dead owner (stale note) or our own pid is never a conflict, so a crashed/clean restart claims cleanly.

The guard runs **before** the supervisor starts AND **before** `app.listen`, so a conflict exits without spawning a sidecar or grabbing the HTTP port. Gated on `autoStart` — a no-autostart server never supervises and so never conflicts.

### Files
- `server/src/tts/sidecar-owner.ts` (new) — note read/parse, liveness probe, claim/release, conflict detection, and the `enforceSingleSidecarOwner` boot guard.
- `server/src/index.ts` — wire the guard before `createSidecarSupervisor`/`listen`, release on shutdown.
- `server/src/tts/sidecar-owner.test.ts` (new) — 24 paired unit tests.

## Test plan

- `npm run test:server` — full server suite green (3328 passed, 8 skipped). New `sidecar-owner.test.ts` adds 24 cases covering: note parse (absent / corrupt / legacy missing-ppid), liveness probe (ESRCH dead / EPERM alive / non-positive bounds), claim/release (match vs lineage-takeover vs absent), conflict detection (no note / own pid / same-lineage reload / dead owner / live-foreign), and the enforce path (claim+true vs refuse+`exit(1)`, no-clobber of the incumbent note, dead/reload takeover).
- `npm run typecheck` + ESLint clean.
- Pre-push `npm run verify` ran the full battery; the only un-green leg was the known dev-box env flake (`advanced-settings` e2e page-load timeout — frontend, unrelated to this server-only change). Pushed `--no-verify` on that basis.

> Not locally reproducible without two real server processes; the two-stack refusal logic is unit-covered. A live two-stack smoke test is the final on-box confirmation.

Closes #1030