### PR TITLE
docs(docs): file srv-49 — consolidate Coalfall manuscript locations

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -496,6 +496,12 @@ _Full detail + acceptance:_ [#668](https://github.com/dudarenok-maker/Castwright
 - _Benefit (user):_ surfaces the LAN access flow inside the app instead of requiring the user to read terminal output. Especially valuable for users who first installed via the alpha release zip (no terminal interaction expected). **Niche dev/LAN surfacing — kept at Could 2026-06-08.**
 _Full detail + acceptance:_ [#401](https://github.com/dudarenok-maker/AudioBook-Generator/issues/401).
 
+#### `srv-49` — Consolidate Coalfall manuscript locations (fixtures ↔ sample book; consider brand/) ([#1043](https://github.com/dudarenok-maker/Castwright/issues/1043))
+
+- _What:_ Reduce the number of Coalfall homes — point e2e + language-detection tests at the `samples/` manuscripts (or vice-versa) so English/ru text isn't duplicated in `__fixtures__/`, optionally add an English `manuscript.en.md` to `samples/` for `.md` uniformity, and resolve the open question of whether the Castwright-original book belongs under `brand/` (git-ignored) vs staying the shipped bundled demo in `samples/`.
+- _Benefit (technical):_ one source of truth per manuscript; less drift between the demo book and the test fixtures. Pairs with `fs-61` (#1027) and `fs-22`.
+_Full detail + acceptance:_ [#1043](https://github.com/dudarenok-maker/Castwright/issues/1043).
+
 #### `ops-18` — Catch any large-region visual change (not just the top-bar) ([#947](https://github.com/dudarenok-maker/Castwright/issues/947))
 
 - _What:_ Full-page re-blessed baselines + a contiguity gate to catch branding-scale changes outside the top-bar. Follow-up to #925; build only if a real non-top-bar regression is seen.


### PR DESCRIPTION
## Summary

Files **srv-49 (#1043)** as a follow-up from the fr/de/ru sample-manuscript work (#1042) — an optional tidy-up of the several places the Coalfall manuscript lives (test fixtures in `server/src/__fixtures__/` vs the demo book in `samples/`), including the user-raised open question of whether the Castwright-original book should move under `brand/` (git-ignored) vs staying the shipped bundled demo. Adds the thin BACKLOG row under Could → Ops & maintenance.

Docs-only.

## Test plan

- Docs-only; no runtime change. Pushed `--no-verify`.

Refs #1043