### PR TITLE
feat(frontend,server): fs-58 LLM Script Review (Unit A)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -72,11 +72,14 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.draft == false &&
        contains(github.event.pull_request.labels.*.name, 'run-ci'))
-    # 20 (not 15): a run that dies AT the cap bills the full cap for nothing and
-    # forces a re-run = double charge. Full-scope runs sit ~13-15 min, so 15 rode
-    # the edge. Headroom is bounded by the cancel-in-progress concurrency above.
+    # 30 (was 20): a run that dies AT the cap bills the full cap for nothing and
+    # forces a re-run = double charge, so the cap must clear the SLOWEST real run.
+    # Full-scope runs were ~13-15 min historically, but a full-stack PR (frontend +
+    # server + e2e) on a cold cloud runner now lands ~20+ min (the suite has grown
+    # — e.g. fs-58 added server + e2e coverage), so 20 was being hit mid-battery
+    # while green. Headroom is bounded by the cancel-in-progress concurrency above.
     # See docs/features/118-ci-cost-round-2.md.
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -157,11 +157,17 @@ _Full detail + acceptance:_ [#976](https://github.com/dudarenok-maker/Castwright
 - _Benefit (user / architectural):_ a fully Russian-speaking user gets a Russian app, not just Russian audio. The i18n framework makes every future language an incremental translation-file add rather than a code change. Pairs with fs-2 to make Russian a first-class end-to-end experience. (Large; ranked below the smaller wins.)
 _Full detail + acceptance:_ [#396](https://github.com/dudarenok-maker/AudioBook-Generator/issues/396).
 
-#### `fs-58` — LLM Script Review: optional second-pass annotation correction ([#998](https://github.com/dudarenok-maker/Castwright/issues/998))
+#### `fs-58` — LLM Script Review (Unit A): per-chapter read-only annotation-repair pass ([#998](https://github.com/dudarenok-maker/Castwright/issues/998))
 
-- _What:_ Operator-triggered ("Review Script") second LLM pass over Phase-1 output, before `manuscript-edits.json`, repairing five annotation-error classes (strip attribution tags from dialogue; split narration out of dialogue; extract dialogue from narrator runs; merge over-split narrator runs; validate/repair `instruct` fields). Accept/reject diff. Engine-agnostic (no GPU) — shippable independently. MUST preserve sentence-ID stability (no orphaned emotion/instruct/audio).
+- _What:_ Operator-triggered ("Review Script"), **per-chapter, read-only** LLM pass that proposes annotation repairs and applies the accepted ones **client-side** (dispatching the existing manual-edit Redux reducers). Unit A = five classes: `strip_tag`, `split`, `extract_dialogue` (two-anchor), `merge` (adjacent same-speaker narrator runs), `fix_emotion`. Accept/reject diff modal. Standalone job, runnable anytime (incl. post-generation), optional `chapterId` (per-chapter default; whole-book opt-in with an RPD warning). **Engine-agnostic — no TTS engine load** (analyzer Ollama/Gemini only). `validate_instruct` → fs-56 (#1041); `reattribute`/`flag_nonstory` → Unit B (#1040).
 - _Benefit (user):_ higher annotation quality, fewer manual fixes; Alexandria parity.
-_Full detail + acceptance:_ spec `docs/superpowers/specs/2026-06-22-expressive-tts-instruct-tiers-design.md` §4.6 · [#998](https://github.com/dudarenok-maker/Castwright/issues/998).
+_Full detail + acceptance:_ spec `docs/superpowers/specs/2026-06-23-fs58-llm-script-review-design.md` · plan `docs/superpowers/plans/2026-06-23-fs58-script-review-unit-a.md` · [#998](https://github.com/dudarenok-maker/Castwright/issues/998).
+
+#### `fs-58 Unit B` — LLM Script Review: `reattribute` + `flag_nonstory` ([#1040](https://github.com/dudarenok-maker/Castwright/issues/1040))
+
+- _What:_ The two deferred Script Review classes on the Unit A harness — `reattribute` (re-assign a dialogue line to the correct existing cast member) and `flag_nonstory` (flag import residue for synthesis exclusion). Each carries an unmet dependency (cast-create wiring + cross-chapter context for reattribute; a new `excludeFromSynthesis` field + a positive fixture for flag_nonstory), so it's tracked separately from Unit A. Both default OFF.
+- _Benefit (user):_ completes the Script Review error-class set on top of Unit A.
+_Full detail + acceptance:_ spec `docs/superpowers/specs/2026-06-23-fs58-llm-script-review-design.md` §13 · [#1040](https://github.com/dudarenok-maker/Castwright/issues/1040).
 
 ### Agents & integrations
 

--- a/docs/superpowers/plans/2026-06-23-fs58-script-review-unit-a.md
+++ b/docs/superpowers/plans/2026-06-23-fs58-script-review-unit-a.md
@@ -1,0 +1,931 @@
+# fs-58 LLM Script Review (Unit A) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** An operator-triggered, per-chapter, read-only LLM pass that proposes annotation repairs (strip stray attribution tags, split/extract/merge sentence boundaries, correct a wrong emotion) and applies the accepted ones client-side by dispatching the existing manual-edit reducers.
+
+**Architecture:** The server review pass mirrors fs-33's `runEmotionChapter` (a per-chapter analyzer call over already-attributed sentences) but **writes no manuscript state** — it streams suggestions over SSE. Accepted suggestions are applied in the browser by dispatching Redux reducers (`splitSentence`, `setSentenceEmotion`, plus two new ones: `setSentenceText`, `mergeSentences`), so apply inherits the existing ID-allocation and debounced persistence. Audio staleness for the edits the precise `characterId`-only diff misses (text change, retained split piece, `angry→neutral`) is fixed once by adding a per-sentence **content hash** to the render-time map.
+
+**Tech Stack:** TypeScript, Vitest (frontend `npm test`, server `npm run test:server`), Redux Toolkit (Immer reducers), Zod (analyzer schemas), Playwright (`npm run test:e2e`), Express SSE, Ollama/Gemini analyzers.
+
+**Spec:** `docs/superpowers/specs/2026-06-23-fs58-llm-script-review-design.md` (read it; this plan implements Unit A = 5 classes incl `merge`).
+
+## Global Constraints
+
+- **OpenAPI is the type source of truth.** A new endpoint path goes in `openapi.yaml`. Unit A persists **no new types** (suggestions are ephemeral) → **no `npm run openapi:types` regen**.
+- **No hex literals in component code** — use the CSS custom properties / Tailwind tokens (`--peach`, `--ink`, …).
+- **RTK reducers mutate via Immer drafts** — match the existing slice style; don't rewrite to spreads.
+- **Commit convention:** `<type>(<scope>): <subject>`; scopes used here: `frontend`, `server`, `docs`. End every commit body with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- **Mocks behind `api = USE_MOCKS ? mock : real`** — every new `api.*` method needs BOTH a real and a mock impl, registered in both objects.
+- **Tests are required** — new behaviour ships paired tests; this plan is TDD (failing test first).
+- **Run before declaring done:** `npm run verify` (typecheck + all tests + e2e + build).
+- **Engine-agnostic = no TTS engine load.** This feature never loads Kokoro/Coqui/Qwen; it uses the analyzer path (Ollama/Gemini).
+
+---
+
+## Phase 0 — Governance (file with the plan; the #998/BACKLOG rewrite is the hard gate to leave `draft`)
+
+### Task 0: Re-scope the tracking artifacts
+
+**Files:**
+- Modify: `docs/BACKLOG.md` (the `fs-58` row, ~line 153)
+- (GitHub, via `gh`): issue #998; new issues for Unit B, `validate_instruct`; edits to #996 (fs-56) and #721 (fs-44)
+
+- [ ] **Step 1: Rewrite the `fs-58` BACKLOG row** to the Unit A scope — replace "five error classes … validate/repair instruct fields … Engine-agnostic (no GPU)" with: "Unit A: strip_tag/split/extract_dialogue/merge + fix_emotion; read-only per-chapter LLM pass, client-side apply; engine-agnostic (no TTS engine — uses the analyzer)." Link the spec + plan.
+
+- [ ] **Step 2: Rewrite issue #998** to match (What/Acceptance/Key files), noting `validate_instruct`→fs-56, `reattribute`/`flag_nonstory`→Unit B, placement is now standalone-anytime.
+
+```bash
+gh issue edit 998 --body-file -   # paste the rewritten body
+```
+
+- [ ] **Step 3: File the Unit B issue** (`reattribute` + `flag_nonstory`) with its deps (spec §13) and add a thin BACKLOG row.
+
+- [ ] **Step 4: File the `validate_instruct` issue** (blocked on fs-56's per-sentence `instruct`) and **edit #996 (fs-56)** to carry the move-here note (bidirectional capture).
+
+- [ ] **Step 5: Edit #721 (fs-44)** to add the dependency note: "script-review apply is client-side (Redux dispatch); a headless/MCP apply path needs a server-side equivalent."
+
+- [ ] **Step 6: Commit the BACKLOG change**
+
+```bash
+git add docs/BACKLOG.md
+git commit -m "docs(docs): re-scope fs-58 row to Unit A"
+```
+
+---
+
+## Phase 1 — Apply foundations (client-side; highest-risk, test-first)
+
+This phase builds everything needed to *apply* an accepted suggestion, independent of where suggestions come from. It carries the latent-bug staleness fixes, so it's valuable even before the review pass exists.
+
+### Task 1: `setSentenceText` reducer (`strip_tag` apply target)
+
+**Files:**
+- Modify: `src/store/manuscript-slice.ts` (add reducer next to `setSentenceCharacter` ~line 254)
+- Test: `src/store/manuscript-slice.test.ts`
+
+**Interfaces:**
+- Produces: action `manuscriptActions.setSentenceText({ chapterId: number; sentenceId: number; text: string })` — mutates the matching sentence's `text` in place; no-op if not found.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/store/manuscript-slice.test.ts
+import { describe, it, expect } from 'vitest';
+import reducer, { manuscriptActions } from './manuscript-slice';
+
+describe('setSentenceText', () => {
+  it('replaces the text of the matching sentence and leaves others untouched', () => {
+    const start = reducer(undefined, manuscriptActions.hydrateFromAnalysis({
+      manuscriptId: 'm1', bookId: 'b1',
+      sentences: [
+        { id: 1, chapterId: 1, characterId: 'narrator', text: 'He ran. "Stop," she said.' },
+        { id: 2, chapterId: 1, characterId: 'narrator', text: 'Quiet.' },
+      ],
+    } as never));
+    const next = reducer(start, manuscriptActions.setSentenceText({
+      chapterId: 1, sentenceId: 1, text: 'He ran. "Stop,"',
+    }));
+    expect(next.sentences.find((s) => s.id === 1)?.text).toBe('He ran. "Stop,"');
+    expect(next.sentences.find((s) => s.id === 2)?.text).toBe('Quiet.');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/store/manuscript-slice.test.ts -t setSentenceText`
+Expected: FAIL — `manuscriptActions.setSentenceText is not a function`.
+
+- [ ] **Step 3: Add the reducer** (after `setSentenceCharacter`, mirroring its shape)
+
+```typescript
+setSentenceText: (
+  s,
+  a: PayloadAction<{ chapterId: number; sentenceId: number; text: string }>,
+) => {
+  const sent = s.sentences.find(
+    (x) => x.chapterId === a.payload.chapterId && x.id === a.payload.sentenceId,
+  );
+  if (sent) sent.text = a.payload.text;
+},
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/store/manuscript-slice.test.ts -t setSentenceText`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/manuscript-slice.ts src/store/manuscript-slice.test.ts
+git commit -m "feat(frontend): add setSentenceText reducer for script-review strip_tag"
+```
+
+### Task 2: `mergeSentences` reducer + merge tombstone (survives re-analysis)
+
+**Files:**
+- Modify: `src/store/manuscript-slice.ts` — add `mergedAwayKeys: string[]` to `ManuscriptState` (init `[]`), the `mergeSentences` reducer, and a guard in `hydrateFromAnalysis`'s incoming-append branch; clear the tombstone in `reset` and on a manuscript re-upload (`applyReupload`).
+- Test: `src/store/manuscript-slice.test.ts`
+
+**Interfaces:**
+- Produces: action `manuscriptActions.mergeSentences({ chapterId: number; sentenceIds: number[] })` — concatenates the named sentences (document order) into the lowest id, drops the rest, records dropped `${chapterId}:${id}` in `mergedAwayKeys`. State gains `mergedAwayKeys: string[]`.
+
+- [ ] **Step 1: Write the failing tests** (merge behaviour + resurrection guard)
+
+```typescript
+describe('mergeSentences', () => {
+  const hydrate = (sentences: unknown[]) =>
+    reducer(undefined, manuscriptActions.hydrateFromAnalysis({
+      manuscriptId: 'm1', bookId: 'b1', sentences,
+    } as never));
+
+  it('merges into the lowest id, concatenates text in order, drops the rest', () => {
+    const start = hydrate([
+      { id: 5, chapterId: 3, characterId: 'narrator', text: 'The hall was dark.' },
+      { id: 6, chapterId: 3, characterId: 'narrator', text: 'Dust hung in the air.' },
+    ]);
+    const next = reducer(start, manuscriptActions.mergeSentences({ chapterId: 3, sentenceIds: [5, 6] }));
+    const ch3 = next.sentences.filter((s) => s.chapterId === 3);
+    expect(ch3).toHaveLength(1);
+    expect(ch3[0].id).toBe(5);
+    expect(ch3[0].text).toBe('The hall was dark. Dust hung in the air.');
+    expect(next.mergedAwayKeys).toContain('3:6');
+  });
+
+  it('does NOT resurrect the merged-away id on a subsequent re-analysis', () => {
+    const start = hydrate([
+      { id: 5, chapterId: 3, characterId: 'narrator', text: 'The hall was dark.' },
+      { id: 6, chapterId: 3, characterId: 'narrator', text: 'Dust hung in the air.' },
+    ]);
+    const merged = reducer(start, manuscriptActions.mergeSentences({ chapterId: 3, sentenceIds: [5, 6] }));
+    // Re-analysis re-mints ids 5 and 6 from the unchanged source text:
+    const reanalysed = reducer(merged, manuscriptActions.hydrateFromAnalysis({
+      manuscriptId: 'm1', bookId: 'b1',
+      sentences: [
+        { id: 5, chapterId: 3, characterId: 'narrator', text: 'The hall was dark.' },
+        { id: 6, chapterId: 3, characterId: 'narrator', text: 'Dust hung in the air.' },
+      ],
+    } as never));
+    const ch3 = reanalysed.sentences.filter((s) => s.chapterId === 3);
+    expect(ch3.map((s) => s.id)).toEqual([5]); // 6 stays dead; no duplicate
+    expect(ch3[0].text).toBe('The hall was dark. Dust hung in the air.');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npm test -- src/store/manuscript-slice.test.ts -t mergeSentences`
+Expected: FAIL — `mergeSentences is not a function`.
+
+- [ ] **Step 3: Add `mergedAwayKeys` to state + init**
+
+In `ManuscriptState` add `mergedAwayKeys: string[];`. In the slice's `initialState` add `mergedAwayKeys: []`. In the `reset` reducer set `s.mergedAwayKeys = []`. In `applyReupload` set `s.mergedAwayKeys = []` (a new manuscript invalidates old merges).
+
+- [ ] **Step 4: Add the `mergeSentences` reducer**
+
+```typescript
+mergeSentences: (
+  s,
+  a: PayloadAction<{ chapterId: number; sentenceIds: number[] }>,
+) => {
+  const ids = [...a.payload.sentenceIds].sort((x, y) => x - y);
+  if (ids.length < 2) return;
+  const members = ids
+    .map((id) => s.sentences.find((x) => x.chapterId === a.payload.chapterId && x.id === id))
+    .filter((x): x is (typeof s.sentences)[number] => Boolean(x));
+  if (members.length !== ids.length) return; // some id missing — reject
+  const surviving = members[0]; // lowest id (ids sorted)
+  surviving.text = members.map((m) => m.text).join(' ');
+  for (const m of members.slice(1)) {
+    const i = s.sentences.findIndex((x) => x.chapterId === a.payload.chapterId && x.id === m.id);
+    if (i >= 0) s.sentences.splice(i, 1);
+    s.mergedAwayKeys.push(`${a.payload.chapterId}:${m.id}`);
+  }
+},
+```
+
+- [ ] **Step 5: Guard the resurrection branch in `hydrateFromAnalysis`**
+
+Change the incoming-append loop (currently lines ~149-151) to skip tombstoned keys:
+
+```typescript
+const tomb = new Set(s.mergedAwayKeys);
+for (const inc of incoming) {
+  if (!stateKeys.has(key(inc)) && !tomb.has(key(inc))) merged.push(inc);
+}
+```
+
+- [ ] **Step 6: Run to verify they pass**
+
+Run: `npm test -- src/store/manuscript-slice.test.ts -t mergeSentences`
+Expected: PASS (both cases).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/store/manuscript-slice.ts src/store/manuscript-slice.test.ts
+git commit -m "feat(frontend): add mergeSentences reducer + merge tombstone (re-analysis-safe)"
+```
+
+### Task 3: Content-hash on the render map (the unified staleness fix)
+
+The precise staleness path (`isChapterReassignedSinceRender`) compares `characterId` only, so it misses `strip_tag` (text change), the retained `split`/`extract` piece (text shrinks, id+characterId unchanged), and `fix_emotion` `angry→neutral`. Fix once: make the render map carry a per-sentence **content hash**, and diff hashes.
+
+**Files:**
+- Create: `src/lib/sentence-hash.ts`
+- Modify: `src/lib/stale-chapters.ts` (`isChapterReassignedSinceRender` accepts a hash map), `src/views/generation.tsx` (build the current-hash input)
+- Modify (server): `server/src/audio/segments-io.ts` (`collectRenderedSpeakerMaps` → also emit a hash map) and the book-state GET that ships `renderedSpeakersByChapter`; `src/store/chapters-slice.ts` (carry `renderedSentenceHashesByChapter`)
+- Test: `src/lib/stale-chapters.test.ts`, `src/lib/sentence-hash.test.ts`
+
+**Interfaces:**
+- Produces: `sentenceContentHash(s: { text: string; characterId: string; emotion?: string }): string` (stable, order-independent of object key order).
+- Produces: `isChapterStaleSinceRender(renderedHashes: Record<number, string> | undefined, current: Array<{ id: number; text: string; characterId: string; emotion?: string }>): boolean` — true if any rendered id's current hash differs (or the id is gone).
+- Consumes (server): the existing render-map builder; adds a sibling `renderedSentenceHashesByChapter: Record<number, Record<number, string>>` to the book-state GET and `hydrateFromBookState` payload.
+
+- [ ] **Step 1: Write the failing hash test**
+
+```typescript
+// src/lib/sentence-hash.test.ts
+import { describe, it, expect } from 'vitest';
+import { sentenceContentHash } from './sentence-hash';
+
+describe('sentenceContentHash', () => {
+  it('changes when text, characterId, or emotion change; stable otherwise', () => {
+    const base = { text: 'Hello.', characterId: 'narrator', emotion: undefined as string | undefined };
+    const h = sentenceContentHash(base);
+    expect(sentenceContentHash({ ...base })).toBe(h);
+    expect(sentenceContentHash({ ...base, text: 'Hello!' })).not.toBe(h);
+    expect(sentenceContentHash({ ...base, characterId: 'maerin' })).not.toBe(h);
+    expect(sentenceContentHash({ ...base, emotion: 'angry' })).not.toBe(h);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm test -- src/lib/sentence-hash.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the hash** (a tiny stable string hash; no crypto dep needed)
+
+```typescript
+// src/lib/sentence-hash.ts
+/** Stable content fingerprint for staleness: any change to the spoken text,
+    the speaker, or the delivery emotion produces a different hash, so a
+    rendered chapter whose sentence content drifted reads stale. */
+export function sentenceContentHash(s: {
+  text: string;
+  characterId: string;
+  emotion?: string;
+}): string {
+  const payload = `${s.characterId} ${s.emotion ?? ''} ${s.text}`;
+  let h = 5381;
+  for (let i = 0; i < payload.length; i++) h = ((h << 5) + h + payload.charCodeAt(i)) | 0;
+  return (h >>> 0).toString(36);
+}
+```
+
+- [ ] **Step 4: Write the failing staleness test**
+
+```typescript
+// src/lib/stale-chapters.test.ts (add)
+import { isChapterStaleSinceRender } from './stale-chapters';
+import { sentenceContentHash } from './sentence-hash';
+
+describe('isChapterStaleSinceRender (content hash)', () => {
+  const s1 = { id: 1, text: '"Stop," she said.', characterId: 'maerin', emotion: undefined as string | undefined };
+  const rendered = { 1: sentenceContentHash(s1) };
+
+  it('not stale when content is unchanged', () => {
+    expect(isChapterStaleSinceRender(rendered, [s1])).toBe(false);
+  });
+  it('stale on a strip_tag text change', () => {
+    expect(isChapterStaleSinceRender(rendered, [{ ...s1, text: '"Stop,"' }])).toBe(true);
+  });
+  it('stale on fix_emotion angry->neutral (rendered had a variant)', () => {
+    const renderedAngry = { 1: sentenceContentHash({ ...s1, emotion: 'angry' }) };
+    expect(isChapterStaleSinceRender(renderedAngry, [{ ...s1, emotion: undefined }])).toBe(true);
+  });
+  it('stale when a rendered id no longer exists (merged away)', () => {
+    expect(isChapterStaleSinceRender(rendered, [])).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 5: Run to verify it fails**
+
+Run: `npm test -- src/lib/stale-chapters.test.ts -t "content hash"`
+Expected: FAIL — `isChapterStaleSinceRender` not exported.
+
+- [ ] **Step 6: Implement `isChapterStaleSinceRender`** (add next to `isChapterReassignedSinceRender`)
+
+```typescript
+import { sentenceContentHash } from './sentence-hash';
+
+export function isChapterStaleSinceRender(
+  renderedHashes: Record<number, string> | undefined,
+  current: Array<{ id: number; text: string; characterId: string; emotion?: string }>,
+): boolean {
+  if (!renderedHashes || Object.keys(renderedHashes).length === 0) return false;
+  const byId = new Map(current.map((s) => [s.id, s]));
+  for (const sidStr of Object.keys(renderedHashes)) {
+    const sid = Number(sidStr);
+    const s = byId.get(sid);
+    if (!s || sentenceContentHash(s) !== renderedHashes[sid]) return true;
+  }
+  return false;
+}
+```
+
+- [ ] **Step 7: Wire the server render map** — in `server/src/audio/segments-io.ts` where `collectRenderedSpeakerMaps` builds `{ [chapterId]: { [sentenceId]: characterId } }`, build a parallel `{ [chapterId]: { [sentenceId]: sentenceContentHash(...) } }` from the same rendered sentences (port `sentenceContentHash` to a server util or duplicate the 6-line function in `server/src/audio/`), and include it in the book-state GET response as `renderedSentenceHashesByChapter`. Add the field to `chapters-slice.ts` `hydrateFromBookState` payload + state (mirror `renderedSpeakersByChapter`).
+
+- [ ] **Step 8: Flip `generation.tsx` to the hash path** — where the `stale={…}` gate (lines ~1108-1115) uses `reassignedSinceRenderSet`, compute staleness from `renderedSentenceHashesByChapter[ch.id]` + the live chapter sentences via `isChapterStaleSinceRender`. Keep the `isChapterStaleFromReassign` time-based fallback for chapters with no hash map (older servers/mocks).
+
+- [ ] **Step 9: Run frontend + server tests**
+
+Run: `npm test -- src/lib/stale-chapters.test.ts src/lib/sentence-hash.test.ts` then `npm run test:server`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/lib/sentence-hash.ts src/lib/stale-chapters.ts src/views/generation.tsx src/store/chapters-slice.ts server/src/audio/segments-io.ts src/lib/sentence-hash.test.ts src/lib/stale-chapters.test.ts
+git commit -m "feat(frontend,server): content-hash render map for script-review staleness"
+```
+
+### Task 4: Client anchor resolver + op validation/ordering (closes TOCTOU)
+
+**Files:**
+- Create: `src/lib/script-review-apply.ts`
+- Test: `src/lib/script-review-apply.test.ts`
+
+**Interfaces:**
+- Consumes: the suggestion op type (define here, frontend-side, structurally matching the server `ScriptReviewOp`): `interface ReviewOp { id: number; op: 'strip_tag'|'split'|'extract_dialogue'|'merge'|'fix_emotion'; newText?: string; anchor?: string; pieceCharacterIds?: string[]; mergeIds?: number[]; emotion?: string; rationale: string; confidence?: number; }`
+- Produces:
+  - `normalizeForMatch(text: string): string` — NFC + fold curly→straight quotes, em/en-dash→`-`, ellipsis→`...`, collapse whitespace.
+  - `resolveAnchorOffset(text: string, anchor: string): number | null` — normalized `indexOf` that is unique (`indexOf === lastIndexOf`), returns the offset **in the original text** of the split point (end of the anchor's "before" half), else null.
+  - `planApply(ops: ReviewOp[], live: Array<{ id: number; chapterId: number; text: string; characterId: string }>): { appliable: ReviewOp[]; unappliable: Array<{ op: ReviewOp; reason: string }> }` — applies §5.6 ordering/validation: structural ops first, reject a field edit whose id a structural op consumed, reject >1 structural op per id, reject anchors that don't resolve uniquely against live text, reject merges whose members aren't adjacent + same characterId.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// src/lib/script-review-apply.test.ts
+import { describe, it, expect } from 'vitest';
+import { normalizeForMatch, resolveAnchorOffset, planApply } from './script-review-apply';
+
+describe('anchor resolution', () => {
+  it('matches across curly/straight quote + em-dash normalization', () => {
+    const text = 'He paused—then ran. “Stop,” she said.';
+    // anchor uses straight quotes / hyphen as an LLM might "normalize" them:
+    const off = resolveAnchorOffset(text, 'ran. "Stop,"');
+    expect(off).not.toBeNull();
+    expect(text.slice(0, off!)).toContain('ran.');
+  });
+  it('returns null when the anchor is not unique', () => {
+    expect(resolveAnchorOffset('he said, he said', 'he said')).toBeNull();
+  });
+  it('returns null when the anchor is absent (mid-review edit / TOCTOU)', () => {
+    expect(resolveAnchorOffset('totally different now', 'ran. "Stop,"')).toBeNull();
+  });
+});
+
+describe('planApply ordering + validation', () => {
+  const live = [
+    { id: 5, chapterId: 3, text: 'The hall was dark.', characterId: 'narrator' },
+    { id: 6, chapterId: 3, text: 'Dust hung in the air.', characterId: 'narrator' },
+  ];
+  it('rejects a field edit whose id a structural op consumed', () => {
+    const r = planApply(
+      [
+        { id: 6, op: 'merge', mergeIds: [5, 6], rationale: 'over-split' },
+        { id: 6, op: 'strip_tag', newText: 'x', rationale: 'tag' },
+      ],
+      live,
+    );
+    expect(r.appliable.map((o) => o.op)).toEqual(['merge']);
+    expect(r.unappliable[0].reason).toMatch(/consumed/);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm test -- src/lib/script-review-apply.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the resolver + planner**
+
+```typescript
+// src/lib/script-review-apply.ts
+export interface ReviewOp {
+  id: number;
+  op: 'strip_tag' | 'split' | 'extract_dialogue' | 'merge' | 'fix_emotion';
+  newText?: string;
+  anchor?: string;
+  pieceCharacterIds?: string[];
+  mergeIds?: number[];
+  emotion?: string;
+  rationale: string;
+  confidence?: number;
+}
+
+export function normalizeForMatch(text: string): string {
+  return text
+    .normalize('NFC')
+    .replace(/[‘’]/g, "'")
+    .replace(/[“”]/g, '"')
+    .replace(/[–—]/g, '-')
+    .replace(/…/g, '...')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** Locate the split point: the anchor is a boundary-spanning substring; the
+    returned offset is the END of its match in the ORIGINAL text (so callers
+    can slice [0,off] / [off,len]). Null if not found OR not unique. */
+export function resolveAnchorOffset(text: string, anchor: string): number | null {
+  const nText = normalizeForMatch(text);
+  const nAnchor = normalizeForMatch(anchor);
+  if (!nAnchor) return null;
+  const first = nText.indexOf(nAnchor);
+  if (first < 0 || first !== nText.lastIndexOf(nAnchor)) return null;
+  // Map the normalized end-offset back to the original text by proportional
+  // re-scan: walk the original, normalizing incrementally, until we reach the
+  // normalized end index. (Whitespace collapse is the only length-changing op
+  // we apply; quote/dash/ellipsis swaps are handled char-wise below.)
+  const targetNormEnd = first + nAnchor.length;
+  let normCount = 0;
+  for (let i = 0; i < text.length; i++) {
+    const piece = normalizeForMatch(text[i]);
+    normCount += piece.length;
+    if (normCount >= targetNormEnd) return i + 1;
+  }
+  return text.length;
+}
+
+export function planApply(
+  ops: ReviewOp[],
+  live: Array<{ id: number; chapterId: number; text: string; characterId: string }>,
+): { appliable: ReviewOp[]; unappliable: Array<{ op: ReviewOp; reason: string }> } {
+  const byId = new Map(live.map((s) => [s.id, s]));
+  const appliable: ReviewOp[] = [];
+  const unappliable: Array<{ op: ReviewOp; reason: string }> = [];
+  const STRUCTURAL = new Set(['split', 'extract_dialogue', 'merge']);
+  const consumed = new Set<number>(); // ids removed/reshaped by a structural op
+  const structuralTargets = new Set<number>();
+
+  // Pass 1: structural ops first.
+  for (const op of ops.filter((o) => STRUCTURAL.has(o.op))) {
+    if (structuralTargets.has(op.id)) {
+      unappliable.push({ op, reason: 'second structural op on the same id' });
+      continue;
+    }
+    if (op.op === 'merge') {
+      const ids = [...(op.mergeIds ?? [])].sort((a, b) => a - b);
+      const members = ids.map((id) => byId.get(id));
+      if (members.some((m) => !m)) { unappliable.push({ op, reason: 'merge member missing' }); continue; }
+      const ch = members[0]!.chapterId;
+      const sameChar = members.every((m) => m!.characterId === members[0]!.characterId);
+      const adjacent = ids.every((id, k) => k === 0 || id === ids[k - 1] + 1);
+      if (!sameChar || !adjacent || members.some((m) => m!.chapterId !== ch)) {
+        unappliable.push({ op, reason: 'merge members not adjacent / same character / same chapter' });
+        continue;
+      }
+      ids.forEach((id) => { consumed.add(id); structuralTargets.add(id); });
+      appliable.push(op);
+    } else {
+      const s = byId.get(op.id);
+      if (!s) { unappliable.push({ op, reason: 'target id missing' }); continue; }
+      if (resolveAnchorOffset(s.text, op.anchor ?? '') === null) {
+        unappliable.push({ op, reason: 'anchor not found or not unique' });
+        continue;
+      }
+      consumed.add(op.id);
+      structuralTargets.add(op.id);
+      appliable.push(op);
+    }
+  }
+
+  // Pass 2: field edits, skipping consumed ids.
+  for (const op of ops.filter((o) => !STRUCTURAL.has(o.op))) {
+    if (consumed.has(op.id)) { unappliable.push({ op, reason: 'id consumed by a structural op' }); continue; }
+    if (!byId.has(op.id)) { unappliable.push({ op, reason: 'target id missing' }); continue; }
+    appliable.push(op);
+  }
+  return { appliable, unappliable };
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm test -- src/lib/script-review-apply.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/script-review-apply.ts src/lib/script-review-apply.test.ts
+git commit -m "feat(frontend): client-side anchor resolver + op validation for script review"
+```
+
+### Task 5: The accept→dispatch wiring (pure function over ops → reducer dispatches)
+
+**Files:**
+- Modify: `src/lib/script-review-apply.ts` (add `dispatchAcceptedOps`)
+- Test: `src/lib/script-review-apply.test.ts`
+
+**Interfaces:**
+- Consumes: `manuscriptActions` (`splitSentence`, `setSentenceText`, `setSentenceEmotion`, `mergeSentences`), `changeLogActions.bumpBoundaryMove`, the `planApply` output, the live sentence list.
+- Produces: `dispatchAcceptedOps(dispatch, accepted: ReviewOp[], live, { onBoundaryMove })` — for each op resolves the anchor against live text and dispatches the matching reducer; counts boundary moves for the change-log.
+
+- [ ] **Step 1: Write the failing test** (capture dispatched actions)
+
+```typescript
+import { manuscriptActions } from '../store/manuscript-slice';
+import { dispatchAcceptedOps } from './script-review-apply';
+
+it('dispatches the mapped reducer per op type', () => {
+  const calls: Array<{ type: string; payload: unknown }> = [];
+  const dispatch = ((a: { type: string; payload: unknown }) => calls.push(a)) as never;
+  const live = [
+    { id: 1, chapterId: 1, text: 'He ran. "Stop," she said.', characterId: 'maerin' },
+  ];
+  dispatchAcceptedOps(dispatch, [
+    { id: 1, op: 'strip_tag', newText: 'He ran. "Stop,"', rationale: 'tag' },
+    { id: 1, op: 'fix_emotion', emotion: 'neutral', rationale: 'calm' },
+  ], live, { onBoundaryMove: () => {} });
+  expect(calls.map((c) => c.type)).toEqual([
+    manuscriptActions.setSentenceText.type,
+    manuscriptActions.setSentenceEmotion.type,
+  ]);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** (`dispatchAcceptedOps` not exported).
+
+Run: `npm test -- src/lib/script-review-apply.test.ts -t "mapped reducer"`
+
+- [ ] **Step 3: Implement**
+
+```typescript
+import type { Dispatch } from '@reduxjs/toolkit';
+import { manuscriptActions } from '../store/manuscript-slice';
+
+export function dispatchAcceptedOps(
+  dispatch: Dispatch,
+  accepted: ReviewOp[],
+  live: Array<{ id: number; chapterId: number; text: string; characterId: string }>,
+  { onBoundaryMove }: { onBoundaryMove: (chapterId: number) => void },
+): void {
+  const byId = new Map(live.map((s) => [s.id, s]));
+  for (const op of accepted) {
+    const target = byId.get(op.op === 'merge' ? (op.mergeIds?.[0] ?? op.id) : op.id);
+    if (!target) continue;
+    const chapterId = target.chapterId;
+    switch (op.op) {
+      case 'strip_tag':
+        dispatch(manuscriptActions.setSentenceText({ chapterId, sentenceId: op.id, text: op.newText ?? target.text }));
+        break;
+      case 'fix_emotion':
+        dispatch(manuscriptActions.setSentenceEmotion({ chapterId, sentenceId: op.id, emotion: op.emotion ?? 'neutral' }));
+        break;
+      case 'split':
+      case 'extract_dialogue': {
+        const off = resolveAnchorOffset(target.text, op.anchor ?? '');
+        if (off === null) break;
+        dispatch(manuscriptActions.splitSentence({
+          chapterId, sentenceId: op.id, offsets: [off],
+          characterIds: op.pieceCharacterIds ?? [target.characterId, target.characterId],
+        }));
+        onBoundaryMove(chapterId);
+        break;
+      }
+      case 'merge':
+        dispatch(manuscriptActions.mergeSentences({ chapterId, sentenceIds: op.mergeIds ?? [] }));
+        onBoundaryMove(chapterId);
+        break;
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes.**
+
+Run: `npm test -- src/lib/script-review-apply.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/script-review-apply.ts src/lib/script-review-apply.test.ts
+git commit -m "feat(frontend): script-review accept->reducer dispatch"
+```
+
+---
+
+## Phase 2 — Read-only review pass + endpoint (server)
+
+Mirrors fs-33's `runEmotionChapter` exactly; the only novelty is the op schema and the prompt.
+
+### Task 6: The review op schema (envelope + imperative-validated payloads)
+
+**Files:**
+- Modify: `server/src/handoff/schemas.ts` (add `scriptReviewSchema` next to `emotionAnnotationSchema`)
+- Test: `server/src/handoff/schemas.test.ts`
+
+**Interfaces:**
+- Produces: `scriptReviewSchema` (Zod), `ScriptReviewOp`, `ScriptReviewOutput`. Envelope-only: payload fields optional; per-op shape is enforced imperatively in the client planner (Task 4) — the schema deliberately does NOT use a discriminated union (Gemini can't constrain it; Ollama only softly).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// server/src/handoff/schemas.test.ts (add)
+import { scriptReviewSchema } from './schemas';
+it('parses a flat review envelope of heterogeneous ops', () => {
+  const r = scriptReviewSchema.safeParse({
+    ops: [
+      { id: 1, op: 'strip_tag', newText: 'x', rationale: 'tag' },
+      { id: 2, op: 'merge', mergeIds: [2, 3], rationale: 'over-split' },
+      { id: 4, op: 'fix_emotion', emotion: 'neutral', rationale: 'calm' },
+    ],
+  });
+  expect(r.success).toBe(true);
+});
+it('rejects an unknown op', () => {
+  expect(scriptReviewSchema.safeParse({ ops: [{ id: 1, op: 'rewrite', rationale: 'x' }] }).success).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails.** Run: `npm run test:server -- schemas.test.ts`
+
+- [ ] **Step 3: Implement the schema**
+
+```typescript
+export const scriptReviewSchema = z
+  .object({
+    ops: z.array(
+      z
+        .object({
+          id: z.number().int().positive(),
+          op: z.enum(['strip_tag', 'split', 'extract_dialogue', 'merge', 'fix_emotion']),
+          newText: z.string().optional(),
+          anchor: z.string().optional(),
+          pieceCharacterIds: z.array(z.string()).optional(),
+          mergeIds: z.array(z.number().int().positive()).optional(),
+          emotion: z.enum(EMOTIONS).optional(),
+          rationale: z.string(),
+          confidence: z.number().min(0).max(1).optional(),
+        })
+        .strict(),
+    ),
+  })
+  .strict();
+export type ScriptReviewOp = z.infer<typeof scriptReviewSchema>['ops'][number];
+export type ScriptReviewOutput = z.infer<typeof scriptReviewSchema>;
+```
+
+- [ ] **Step 4: Run to verify it passes.** Run: `npm run test:server -- schemas.test.ts` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/handoff/schemas.ts server/src/handoff/schemas.test.ts
+git commit -m "feat(server): scriptReviewSchema (flat envelope) for the review pass"
+```
+
+### Task 7: Analyzer extension — `runScriptReviewChapter` (interface + both impls + fallback)
+
+**Files:**
+- Modify: `server/src/analyzer/index.ts` (interface method + `FallbackAnalyzer` delegation)
+- Modify: `server/src/analyzer/gemini.ts` (impl + `SKILL_FILES` + `SkillName` + `SKILL_TO_PROMPT_ID`)
+- Modify: `server/src/analyzer/ollama.ts` (impl)
+- Modify: `server/src/handoff/protocol.ts` (`HandoffKey` += `` `review-ch${number}` ``)
+- Modify: `server/src/config/registry.ts` (`prompt.scriptReview` knob, `isPrompt:true`)
+- Create: `skills/audiobook-script-review.md` (the prompt)
+- Test: `server/src/analyzer/script-review.test.ts` (mock the HTTP layer like the existing analyzer tests)
+
+**Interfaces:**
+- Produces: `Analyzer.runScriptReviewChapter(manuscriptId, chapterId, promptMd, call): Promise<ScriptReviewOutput>`.
+
+- [ ] **Step 1: Add the `HandoffKey` variant**
+
+```typescript
+// server/src/handoff/protocol.ts
+export type HandoffKey =
+  | '1' | `1-ch${number}` | '2' | `2-ch${number}`
+  | `emotion-ch${number}`
+  | `review-ch${number}`;
+```
+
+- [ ] **Step 2: Extend the `Analyzer` interface** (add after `runEmotionChapter`)
+
+```typescript
+// server/src/analyzer/index.ts
+  runScriptReviewChapter(
+    manuscriptId: string,
+    chapterId: number,
+    promptMd: string,
+    call: StageCall,
+  ): Promise<ScriptReviewOutput>;
+```
+
+- [ ] **Step 3: Add the `FallbackAnalyzer` delegation** (copy the `runEmotionChapter` fallback verbatim, renamed)
+
+```typescript
+  async runScriptReviewChapter(manuscriptId: string, chapterId: number, promptMd: string, call: StageCall): Promise<ScriptReviewOutput> {
+    try {
+      return await this.primary.runScriptReviewChapter(manuscriptId, chapterId, promptMd, call);
+    } catch (err) {
+      if (err instanceof AnalysisAbortedError) throw err;
+      if (err instanceof LocalUnreachableError) {
+        return await this.fallback.runScriptReviewChapter(manuscriptId, chapterId, promptMd, call);
+      }
+      throw err;
+    }
+  }
+```
+
+- [ ] **Step 4: Register the skill + prompt id (gemini.ts)** — add to `SKILL_FILES`: `script_review: 'audiobook-script-review.md',` and to `SKILL_TO_PROMPT_ID`: `script_review: 'prompt.scriptReview',`.
+
+- [ ] **Step 5: Add the `prompt.scriptReview` registry knob** (registry.ts, mirror `prompt.emotionAnnotation`)
+
+```typescript
+{
+  key: 'prompt.scriptReview', env: '', group: 'analyzer-prompts',
+  label: 'Script review prompt',
+  help: 'Skill sent to the analysis model for the LLM Script Review pass. Editing forks a local copy; live.',
+  type: 'string', isPrompt: true,
+  default: 'skills/audiobook-script-review.md', apply: 'live', risk: 'high',
+},
+```
+
+- [ ] **Step 6: Add the impls** (gemini.ts and ollama.ts — identical bodies, mirror `runEmotionChapter`)
+
+```typescript
+  async runScriptReviewChapter(manuscriptId: string, chapterId: number, promptMd: string, call: StageCall): Promise<ScriptReviewOutput> {
+    const key = `review-ch${chapterId}` as const;
+    return this.runStage(manuscriptId, key, 'script_review', promptMd, scriptReviewSchema, scriptReviewSchema, call);
+  }
+```
+
+- [ ] **Step 7: Write the prompt** `skills/audiobook-script-review.md` — instruct the model: given a chapter's attributed sentences + cast, return `{ ops: [...] }` for the 5 classes; **never strip intentional vocalizations** ("Ah!", "Haah…"); for `split`/`extract_dialogue` return a short **boundary-spanning `anchor`** substring (copy it verbatim from the sentence text) + `pieceCharacterIds`; for `merge` return `mergeIds` of adjacent same-speaker narrator sentences; for `fix_emotion` only when the current emotion is clearly wrong; always include a one-line `rationale`. Output JSON only.
+
+- [ ] **Step 8: Write a failing impl test** (mock the chat/generate layer to return a canned envelope; assert the analyzer returns the parsed ops). Follow the existing `server/src/analyzer/*.test.ts` mocking pattern.
+
+- [ ] **Step 9: Run → fail → (code already added) → pass.** Run: `npm run test:server -- script-review.test.ts`
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add server/src/analyzer/index.ts server/src/analyzer/gemini.ts server/src/analyzer/ollama.ts server/src/handoff/protocol.ts server/src/config/registry.ts skills/audiobook-script-review.md server/src/analyzer/script-review.test.ts
+git commit -m "feat(server): runScriptReviewChapter analyzer pass (Ollama+Gemini+fallback)"
+```
+
+### Task 8: The SSE endpoint `POST /api/books/:bookId/script-review`
+
+**Files:**
+- Create: `server/src/routes/script-review.ts` (copy `annotate-emotion.ts` structure)
+- Modify: `server/src/app.ts` (mount the router under `/api/books`, beside `annotateEmotionRouter`)
+- Modify: `openapi.yaml` (add the path entry, mirroring the annotate-emotion path)
+- Test: `server/src/routes/script-review.test.ts`
+
+**Interfaces:**
+- Consumes: `selectAnalyzerForPhase`, `loadPostFoldSentencesByChapter`, `runScriptReviewChapter`.
+- Produces: SSE events `phase` / `ops` (`{ kind:'ops', chapterId, ops }`) / `throttle` / `chapter-failed` / `error` / `result`. Accepts `{ chapterId?: number, model?: string }` in the POST body.
+
+- [ ] **Step 1: Write the failing route test** (supertest against the app; mock the analyzer to emit a canned envelope; assert the SSE stream contains an `ops` event and a `result`). Mirror `annotate-emotion.test.ts`.
+
+- [ ] **Step 2: Run → fail.** Run: `npm run test:server -- script-review.test.ts`
+
+- [ ] **Step 3: Implement the route** — copy `annotate-emotion.ts` verbatim, then: rename the router/path to `script-review`; honor an optional `req.body.chapterId` (filter `chapterIds` to `[chapterId]` when present); build the prompt from the chapter's post-fold sentences + the post-fold roster; call `runScriptReviewChapter`; emit `{ kind:'ops', chapterId, ops: result.ops }` instead of `annotation`. Keep the same SSE scaffolding, keep-alive, abort, `DailyQuotaExhaustedError` handling, and per-chapter `chapter-failed` resilience.
+
+- [ ] **Step 4: Mount + openapi** — `app.use('/api/books', scriptReviewRouter);` (after annotate-emotion); add the `openapi.yaml` path block (copy annotate-emotion's, adjust path + request body `chapterId?`).
+
+- [ ] **Step 5: Run → pass.** Run: `npm run test:server -- script-review.test.ts` → PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/routes/script-review.ts server/src/app.ts openapi.yaml server/src/routes/script-review.test.ts
+git commit -m "feat(server): POST /api/books/:bookId/script-review SSE endpoint"
+```
+
+### Task 9: Frontend api client (`reviewScript`) — real + mock
+
+**Files:**
+- Modify: `src/lib/api.ts` (add `realReviewScript`, `mockReviewScript`, `ReviewScriptOpts`/`Result`/`Error`, register in both `real`/`mock`)
+- Test: `src/lib/api.test.ts` (mock `fetch` streaming, mirror the detect-emotions test if present)
+
+**Interfaces:**
+- Produces: `api.reviewScript(bookId, { chapterId?, model?, signal?, onPhase?, onThrottle?, onOps? }): Promise<{ reviewedChapters: number; totalOps: number }>` where `onOps({ chapterId, ops })` delivers `ReviewOp[]`.
+
+- [ ] **Step 1: Write the failing test** (mock a streamed SSE body with one `ops` + `result`; assert `onOps` fired and the result returned). Mirror `realDetectEmotions`.
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement** — copy `realDetectEmotions`/`mockDetectEmotions` verbatim; change the URL to `/script-review`; send `{ chapterId, model }`; handle `kind:'ops'` → `onOps`. Register `reviewScript: realReviewScript` / `reviewScript: mockReviewScript` in both api objects.
+
+- [ ] **Step 4: Run → pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/api.ts src/lib/api.test.ts
+git commit -m "feat(frontend): api.reviewScript client (real+mock)"
+```
+
+---
+
+## Phase 3 — Operator UX
+
+### Task 10: The dedicated suggestions slice (non-polled, bookId-keyed)
+
+**Files:**
+- Create: `src/store/script-review-slice.ts`
+- Modify: `src/store/index.ts` (register `scriptReview: scriptReviewSlice.reducer`)
+- Test: `src/store/script-review-slice.test.ts`
+
+**Interfaces:**
+- Produces: state `{ byBook: Record<string, { ops: ReviewOp[]; selected: Record<string, boolean>; unappliable: Array<{ op: ReviewOp; reason: string }> } | undefined> }`; actions `setReview({ bookId, ops, unappliable })`, `toggleOp({ bookId, key, on })`, `toggleClass({ bookId, op, on })`, `clearReview({ bookId })`; selector `selectActiveReview(state, bookId)` reads ONLY that book's bucket. (Op key = `${chapterId}:${id}:${op}`.)
+
+- [ ] **Step 1: Write the failing test** — `setReview` then `selectActiveReview` returns only that book's ops; a second book's `setReview` doesn't wipe the first; `toggleClass` flips all ops of a class.
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement the slice** (RTK `createSlice`, Immer; default-ON selection for all Unit A classes — initialize `selected[key] = true` in `setReview`).
+
+- [ ] **Step 4: Register in `store/index.ts`** under the reducer map (beside `revisions`).
+
+- [ ] **Step 5: Run → pass.**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/store/script-review-slice.ts src/store/index.ts src/store/script-review-slice.test.ts
+git commit -m "feat(frontend): dedicated non-polled script-review suggestions slice"
+```
+
+### Task 11: `ScriptReviewDiff` modal + the "Review Script" trigger
+
+**Files:**
+- Create: `src/components/script-review-diff.tsx`
+- Modify: the manuscript editing surface (`src/views/manuscript.tsx`) — add the "Review Script" button + the run/stream wiring (calls `api.reviewScript`, runs `planApply` on completion, dispatches `setReview`)
+- Test: `src/components/script-review-diff.test.tsx`
+
+**Interfaces:**
+- Consumes: `selectActiveReview`, `scriptReviewActions`, `dispatchAcceptedOps`, `planApply`, `manuscriptActions`, `changeLogActions.bumpBoundaryMove`.
+- Behaviour: groups rows by class; per-class + per-change toggles; before→after preview; `Apply` runs `planApply` against the LIVE manuscript (re-validates at accept — TOCTOU), `dispatchAcceptedOps` for the selected appliable set, emits `bumpBoundaryMove` per affected chapter, then `clearReview`.
+
+- [ ] **Step 1: Write the failing component test** — render with a seeded review (one `strip_tag`, one `fix_emotion`), toggle one off, click Apply, assert the expected reducer actions dispatched (spy the store) and the modal cleared.
+
+- [ ] **Step 2: Run → fail.** Run: `npm test -- src/components/script-review-diff.test.tsx`
+
+- [ ] **Step 3: Implement the modal** — follow the DriftReport accept-reject layout pattern; use design tokens (no hex). On Apply: `const { appliable } = planApply(selectedOps, liveSentences); dispatchAcceptedOps(dispatch, appliable, liveSentences, { onBoundaryMove: (c) => dispatch(changeLogActions.bumpBoundaryMove({ chapterId: c, count: 1 })) }); dispatch(scriptReviewActions.clearReview({ bookId }));`
+
+- [ ] **Step 4: Add the "Review Script" button** to `manuscript.tsx` — min-h-[44px] sm:min-h-0 touch target; on click, stream `api.reviewScript(bookId, { chapterId: currentChapterId, onOps })`, accumulate ops, then `planApply` + `dispatch(setReview(...))` to open the modal.
+
+- [ ] **Step 5: Run → pass.**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/script-review-diff.tsx src/views/manuscript.tsx src/components/script-review-diff.test.tsx
+git commit -m "feat(frontend): ScriptReviewDiff modal + Review Script trigger"
+```
+
+### Task 12: E2E — per-chapter review → accept → stale
+
+**Files:**
+- Create: `e2e/script-review.spec.ts`
+- Modify: `e2e/responsive/coverage.spec.ts` (append a case for the new modal)
+- (mock-mode driven: `mockReviewScript` returns a deterministic op so the flow is testable without an LLM)
+
+- [ ] **Step 1: Write the spec** — open a book to the manuscript view, click "Review Script", assert the `ScriptReviewDiff` modal opens with the mock op, accept it, assert the sentence text/emotion updated and (navigating to Generate) the chapter shows the stale badge.
+
+- [ ] **Step 2: Run** — `npm run test:e2e -- script-review.spec.ts`. Expected: PASS (chromium).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/script-review.spec.ts e2e/responsive/coverage.spec.ts
+git commit -m "test(e2e): script-review per-chapter accept flow"
+```
+
+### Task 13: Full verify + plan/index hygiene
+
+- [ ] **Step 1:** Run `npm run verify` (typecheck + all tests + e2e + build). Fix any red leg in-scope; surface anything pre-existing to the user rather than bundling.
+- [ ] **Step 2:** Move the spec to `status: active`/`stable` per the project's shipping checklist; add the spec/plan to `docs/features/INDEX.md` if it's tracked there. Fill the spec's Ship notes when merged.
+- [ ] **Step 3:** Open the PR with `Closes #998` (Unit A scope), `## Summary` + `## Test plan` filled, linking the spec.
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:** every §3 class has an apply path (Task 1 `strip_tag`; Task 4/5 `split`/`extract`; Task 2 `merge`; existing `setSentenceEmotion` `fix_emotion`); §5.3 unified staleness = Task 3; §5.6 op-validation/TOCTOU = Task 4; §4.2 ~16-site pass = Tasks 6-9; §4.3 flat-envelope = Task 6; §5.5 dedicated slice = Task 10; §6 UX = Task 11; §8 tests distributed per task (merge-resurrection = Task 2; staleness gaps = Task 3; anchor normalization + TOCTOU = Task 4; M5 abstention = Task 7 prompt + a Task-7 test; E2E = Task 12); §9 follow-ups = Task 0. **No api-types regen** (Global Constraints) — Unit A persists no new type.
+
+**Placeholder scan:** the prompt content (Task 7 Step 7) and the openapi block (Task 8 Step 4) are described, not transcribed verbatim — these are content-authoring steps, not code with a fixed answer; every code step shows real code.
+
+**Type consistency:** `ReviewOp` (frontend, Task 4) and `ScriptReviewOp` (server Zod, Task 6) carry the same fields; `setSentenceText` / `mergeSentences` / `setSentenceEmotion` / `splitSentence` payloads match the reducers; `isChapterStaleSinceRender` signature is consistent across Tasks 3's definition and `generation.tsx` use.

--- a/docs/superpowers/plans/2026-06-23-fs58-script-review-unit-a.md
+++ b/docs/superpowers/plans/2026-06-23-fs58-script-review-unit-a.md
@@ -4,22 +4,23 @@
 
 **Goal:** An operator-triggered, per-chapter, read-only LLM pass that proposes annotation repairs (strip stray attribution tags, split/extract/merge sentence boundaries, correct a wrong emotion) and applies the accepted ones client-side by dispatching the existing manual-edit reducers.
 
-**Architecture:** The server review pass mirrors fs-33's `runEmotionChapter` (a per-chapter analyzer call over already-attributed sentences) but **writes no manuscript state** — it streams suggestions over SSE. Accepted suggestions are applied in the browser by dispatching Redux reducers (`splitSentence`, `setSentenceEmotion`, plus two new ones: `setSentenceText`, `mergeSentences`), so apply inherits the existing ID-allocation and debounced persistence. Audio staleness for the edits the precise `characterId`-only diff misses (text change, retained split piece, `angry→neutral`) is fixed once by adding a per-sentence **content hash** to the render-time map.
+**Architecture:** The server review pass mirrors fs-33's `runEmotionChapter` (a per-chapter analyzer call over already-attributed sentences) but **writes no manuscript state** — it streams suggestions over SSE. Accepted suggestions are applied in the browser by dispatching Redux reducers (`splitSentence`, `setSentenceEmotion`, plus three new: `setSentenceText`, `mergeSentences`). Apply inherits ID-allocation + debounced persistence. Audio staleness is signalled the way manual edits already do it: every accepted op emits a `boundary_move` change-log event, and the Generate-view stale gate is widened so a post-render `boundary_move` marks a rendered chapter stale even when a precise render-map exists.
 
-**Tech Stack:** TypeScript, Vitest (frontend `npm test`, server `npm run test:server`), Redux Toolkit (Immer reducers), Zod (analyzer schemas), Playwright (`npm run test:e2e`), Express SSE, Ollama/Gemini analyzers.
+**Tech Stack:** TypeScript, Vitest (frontend `npm test`, server `npm run test:server`), Redux Toolkit (Immer), Zod, Playwright (`npm run test:e2e`), Express SSE, Ollama/Gemini analyzers.
 
-**Spec:** `docs/superpowers/specs/2026-06-23-fs58-llm-script-review-design.md` (read it; this plan implements Unit A = 5 classes incl `merge`).
+**Spec:** `docs/superpowers/specs/2026-06-23-fs58-llm-script-review-design.md` (Unit A = 5 classes incl `merge`). This plan supersedes the spec's §5.3 content-hash idea with the simpler `boundary_move` + OR-gate staleness (decided after plan review — `segments.json` does not persist rendered text/emotion, so a content hash has nothing to hash).
 
 ## Global Constraints
 
-- **OpenAPI is the type source of truth.** A new endpoint path goes in `openapi.yaml`. Unit A persists **no new types** (suggestions are ephemeral) → **no `npm run openapi:types` regen**.
-- **No hex literals in component code** — use the CSS custom properties / Tailwind tokens (`--peach`, `--ink`, …).
-- **RTK reducers mutate via Immer drafts** — match the existing slice style; don't rewrite to spreads.
-- **Commit convention:** `<type>(<scope>): <subject>`; scopes used here: `frontend`, `server`, `docs`. End every commit body with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- **OpenAPI is the type source of truth.** The new endpoint path goes in `openapi.yaml` (transcribed, Task 8). Unit A persists **no new sentence type** → **no `npm run openapi:types` regen**.
+- **No hex literals in component code** — use the CSS-custom-property / Tailwind tokens.
+- **RTK reducers mutate via Immer drafts** — match the existing slice style.
+- **Commit convention:** `<type>(<scope>): <subject>`; scopes: `frontend`, `server`, `docs`. **One scope per commit** where possible (the husky `verify:fast:scoped` pre-commit runs only the legs the staged diff touches). End every body with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
 - **Mocks behind `api = USE_MOCKS ? mock : real`** — every new `api.*` method needs BOTH a real and a mock impl, registered in both objects.
-- **Tests are required** — new behaviour ships paired tests; this plan is TDD (failing test first).
-- **Run before declaring done:** `npm run verify` (typecheck + all tests + e2e + build).
-- **Engine-agnostic = no TTS engine load.** This feature never loads Kokoro/Coqui/Qwen; it uses the analyzer path (Ollama/Gemini).
+- **TDD** — failing test first; verify it fails for the RIGHT reason before implementing.
+- **Run before declaring done:** `npm run verify`.
+- **Engine-agnostic = no TTS engine load** — uses the analyzer (Ollama/Gemini) only.
+- **No regression plan under `docs/features/` is owed** — this superpowers spec + the paired tests below ARE the spec (per CLAUDE.md "say so" rule for localized work).
 
 ---
 
@@ -27,179 +28,136 @@
 
 ### Task 0: Re-scope the tracking artifacts
 
-**Files:**
-- Modify: `docs/BACKLOG.md` (the `fs-58` row, ~line 153)
-- (GitHub, via `gh`): issue #998; new issues for Unit B, `validate_instruct`; edits to #996 (fs-56) and #721 (fs-44)
+**Files:** Modify `docs/BACKLOG.md` (the `fs-58` row); GitHub via `gh` (#998, new Unit B + `validate_instruct` issues, edits to #996 + #721).
 
-- [ ] **Step 1: Rewrite the `fs-58` BACKLOG row** to the Unit A scope — replace "five error classes … validate/repair instruct fields … Engine-agnostic (no GPU)" with: "Unit A: strip_tag/split/extract_dialogue/merge + fix_emotion; read-only per-chapter LLM pass, client-side apply; engine-agnostic (no TTS engine — uses the analyzer)." Link the spec + plan.
-
-- [ ] **Step 2: Rewrite issue #998** to match (What/Acceptance/Key files), noting `validate_instruct`→fs-56, `reattribute`/`flag_nonstory`→Unit B, placement is now standalone-anytime.
-
-```bash
-gh issue edit 998 --body-file -   # paste the rewritten body
-```
-
-- [ ] **Step 3: File the Unit B issue** (`reattribute` + `flag_nonstory`) with its deps (spec §13) and add a thin BACKLOG row.
-
-- [ ] **Step 4: File the `validate_instruct` issue** (blocked on fs-56's per-sentence `instruct`) and **edit #996 (fs-56)** to carry the move-here note (bidirectional capture).
-
-- [ ] **Step 5: Edit #721 (fs-44)** to add the dependency note: "script-review apply is client-side (Redux dispatch); a headless/MCP apply path needs a server-side equivalent."
-
-- [ ] **Step 6: Commit the BACKLOG change**
-
-```bash
-git add docs/BACKLOG.md
-git commit -m "docs(docs): re-scope fs-58 row to Unit A"
-```
+- [ ] **Step 1:** Rewrite the `fs-58` BACKLOG row to the Unit A scope (strip_tag/split/extract_dialogue/merge + fix_emotion; read-only per-chapter pass; client-side apply; "engine-agnostic — no TTS engine"). Link spec + plan.
+- [ ] **Step 2:** Rewrite issue #998 to match (`gh issue edit 998 --body-file -`), noting `validate_instruct`→fs-56, `reattribute`/`flag_nonstory`→Unit B, placement now standalone-anytime, "no TTS engine" (not "no GPU").
+- [ ] **Step 3:** File the Unit B issue (`reattribute` + `flag_nonstory`) with its deps (spec §13) + a thin BACKLOG row.
+- [ ] **Step 4:** File the `validate_instruct` issue (blocked on fs-56) and **edit #996 (fs-56)** with the move-here note.
+- [ ] **Step 5:** Edit #721 (fs-44): "script-review apply is client-side (Redux dispatch); a headless/MCP apply path needs a server-side equivalent."
+- [ ] **Step 6:** Commit `docs/BACKLOG.md`: `docs(docs): re-scope fs-58 row to Unit A`.
 
 ---
 
 ## Phase 1 — Apply foundations (client-side; highest-risk, test-first)
 
-This phase builds everything needed to *apply* an accepted suggestion, independent of where suggestions come from. It carries the latent-bug staleness fixes, so it's valuable even before the review pass exists.
-
 ### Task 1: `setSentenceText` reducer (`strip_tag` apply target)
 
-**Files:**
-- Modify: `src/store/manuscript-slice.ts` (add reducer next to `setSentenceCharacter` ~line 254)
-- Test: `src/store/manuscript-slice.test.ts`
+**Files:** Modify `src/store/manuscript-slice.ts` (add reducer near `setSentenceCharacter`); Test `src/store/manuscript-slice.test.ts`.
 
-**Interfaces:**
-- Produces: action `manuscriptActions.setSentenceText({ chapterId: number; sentenceId: number; text: string })` — mutates the matching sentence's `text` in place; no-op if not found.
+**Interfaces:** Produces `manuscriptActions.setSentenceText({ chapterId: number; sentenceId: number; text: string })` — mutates the matching sentence's `text`; no-op if not found.
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Write the failing test** — build the start state as a literal with `manuscriptId` set (so we don't depend on `hydrateFromAnalysis`, which never sets `manuscriptId`):
 
 ```typescript
 // src/store/manuscript-slice.test.ts
 import { describe, it, expect } from 'vitest';
 import reducer, { manuscriptActions } from './manuscript-slice';
 
+const seeded = (sentences: Array<{ id: number; chapterId: number; characterId: string; text: string; emotion?: string }>) =>
+  reducer(undefined, manuscriptActions.reset()); // reset → initialState; then patch via a known reducer below
+
+// Helper: a real starting state with manuscriptId set + sentences present.
+function start(sentences: Parameters<typeof seeded>[0]) {
+  // hydrateFromBookState is the reducer that sets manuscriptId from disk; use it to seed.
+  return reducer(
+    { ...reducer(undefined, manuscriptActions.reset()), manuscriptId: 'm1', bookId: 'b1', sentences } as never,
+    { type: '@@noop' } as never,
+  );
+}
+
 describe('setSentenceText', () => {
-  it('replaces the text of the matching sentence and leaves others untouched', () => {
-    const start = reducer(undefined, manuscriptActions.hydrateFromAnalysis({
-      manuscriptId: 'm1', bookId: 'b1',
-      sentences: [
-        { id: 1, chapterId: 1, characterId: 'narrator', text: 'He ran. "Stop," she said.' },
-        { id: 2, chapterId: 1, characterId: 'narrator', text: 'Quiet.' },
-      ],
-    } as never));
-    const next = reducer(start, manuscriptActions.setSentenceText({
-      chapterId: 1, sentenceId: 1, text: 'He ran. "Stop,"',
-    }));
-    expect(next.sentences.find((s) => s.id === 1)?.text).toBe('He ran. "Stop,"');
-    expect(next.sentences.find((s) => s.id === 2)?.text).toBe('Quiet.');
+  it('replaces the matching sentence text, leaves others untouched', () => {
+    const s = start([
+      { id: 1, chapterId: 1, characterId: 'narrator', text: 'He ran. "Stop," she said.' },
+      { id: 2, chapterId: 1, characterId: 'narrator', text: 'Quiet.' },
+    ]);
+    const next = reducer(s, manuscriptActions.setSentenceText({ chapterId: 1, sentenceId: 1, text: 'He ran. "Stop,"' }));
+    expect(next.sentences.find((x) => x.id === 1)?.text).toBe('He ran. "Stop,"');
+    expect(next.sentences.find((x) => x.id === 2)?.text).toBe('Quiet.');
   });
 });
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `npm test -- src/store/manuscript-slice.test.ts -t setSentenceText`
-Expected: FAIL — `manuscriptActions.setSentenceText is not a function`.
-
-- [ ] **Step 3: Add the reducer** (after `setSentenceCharacter`, mirroring its shape)
+- [ ] **Step 2: Run → fail.** `npm test -- src/store/manuscript-slice.test.ts -t setSentenceText` → `setSentenceText is not a function`.
+- [ ] **Step 3: Add the reducer** (after `setSentenceCharacter`):
 
 ```typescript
-setSentenceText: (
-  s,
-  a: PayloadAction<{ chapterId: number; sentenceId: number; text: string }>,
-) => {
-  const sent = s.sentences.find(
-    (x) => x.chapterId === a.payload.chapterId && x.id === a.payload.sentenceId,
-  );
+setSentenceText: (s, a: PayloadAction<{ chapterId: number; sentenceId: number; text: string }>) => {
+  const sent = s.sentences.find((x) => x.chapterId === a.payload.chapterId && x.id === a.payload.sentenceId);
   if (sent) sent.text = a.payload.text;
 },
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 4: Run → pass.**
+- [ ] **Step 5: Commit** `feat(frontend): add setSentenceText reducer for script-review strip_tag`.
 
-Run: `npm test -- src/store/manuscript-slice.test.ts -t setSentenceText`
-Expected: PASS.
+### Task 2: `mergeSentences` reducer + in-memory tombstone + re-analysis guard
 
-- [ ] **Step 5: Commit**
+**Files:** Modify `src/store/manuscript-slice.ts` (`mergedAwayKeys: string[]` on `ManuscriptState` + init in `initialState`/`reset`/`applyReupload`; the reducer; the guard in `hydrateFromAnalysis`'s append loop); Test `src/store/manuscript-slice.test.ts`.
 
-```bash
-git add src/store/manuscript-slice.ts src/store/manuscript-slice.test.ts
-git commit -m "feat(frontend): add setSentenceText reducer for script-review strip_tag"
-```
+**Interfaces:** Produces `manuscriptActions.mergeSentences({ chapterId: number; sentenceIds: number[] })` — concatenates (document order) into the lowest id, drops the rest, records dropped `${chapterId}:${id}` in `mergedAwayKeys`. State gains `mergedAwayKeys: string[]`.
 
-### Task 2: `mergeSentences` reducer + merge tombstone (survives re-analysis)
-
-**Files:**
-- Modify: `src/store/manuscript-slice.ts` — add `mergedAwayKeys: string[]` to `ManuscriptState` (init `[]`), the `mergeSentences` reducer, and a guard in `hydrateFromAnalysis`'s incoming-append branch; clear the tombstone in `reset` and on a manuscript re-upload (`applyReupload`).
-- Test: `src/store/manuscript-slice.test.ts`
-
-**Interfaces:**
-- Produces: action `manuscriptActions.mergeSentences({ chapterId: number; sentenceIds: number[] })` — concatenates the named sentences (document order) into the lowest id, drops the rest, records dropped `${chapterId}:${id}` in `mergedAwayKeys`. State gains `mergedAwayKeys: string[]`.
-
-- [ ] **Step 1: Write the failing tests** (merge behaviour + resurrection guard)
+- [ ] **Step 1: Write the failing tests** (note the start-state helper sets `manuscriptId`, so the re-analysis hydrate reaches the merge/append branch — this is the fix for the broken scaffold the review caught):
 
 ```typescript
-describe('mergeSentences', () => {
-  const hydrate = (sentences: unknown[]) =>
-    reducer(undefined, manuscriptActions.hydrateFromAnalysis({
-      manuscriptId: 'm1', bookId: 'b1', sentences,
-    } as never));
+import { start } from './manuscript-slice.test-helpers'; // extract the start() helper from Task 1 into a shared file
 
-  it('merges into the lowest id, concatenates text in order, drops the rest', () => {
-    const start = hydrate([
+describe('mergeSentences', () => {
+  it('merges into the lowest id, concatenates in order, drops the rest, tombstones', () => {
+    const s = start([
       { id: 5, chapterId: 3, characterId: 'narrator', text: 'The hall was dark.' },
       { id: 6, chapterId: 3, characterId: 'narrator', text: 'Dust hung in the air.' },
     ]);
-    const next = reducer(start, manuscriptActions.mergeSentences({ chapterId: 3, sentenceIds: [5, 6] }));
-    const ch3 = next.sentences.filter((s) => s.chapterId === 3);
-    expect(ch3).toHaveLength(1);
-    expect(ch3[0].id).toBe(5);
+    const next = reducer(s, manuscriptActions.mergeSentences({ chapterId: 3, sentenceIds: [5, 6] }));
+    const ch3 = next.sentences.filter((x) => x.chapterId === 3);
+    expect(ch3.map((x) => x.id)).toEqual([5]);
     expect(ch3[0].text).toBe('The hall was dark. Dust hung in the air.');
     expect(next.mergedAwayKeys).toContain('3:6');
   });
 
   it('does NOT resurrect the merged-away id on a subsequent re-analysis', () => {
-    const start = hydrate([
-      { id: 5, chapterId: 3, characterId: 'narrator', text: 'The hall was dark.' },
-      { id: 6, chapterId: 3, characterId: 'narrator', text: 'Dust hung in the air.' },
-    ]);
-    const merged = reducer(start, manuscriptActions.mergeSentences({ chapterId: 3, sentenceIds: [5, 6] }));
-    // Re-analysis re-mints ids 5 and 6 from the unchanged source text:
+    const merged = reducer(
+      start([
+        { id: 5, chapterId: 3, characterId: 'narrator', text: 'The hall was dark.' },
+        { id: 6, chapterId: 3, characterId: 'narrator', text: 'Dust hung in the air.' },
+      ]),
+      manuscriptActions.mergeSentences({ chapterId: 3, sentenceIds: [5, 6] }),
+    );
+    // manuscriptId is set (via start()), so hydrateFromAnalysis takes the merge/append branch:
     const reanalysed = reducer(merged, manuscriptActions.hydrateFromAnalysis({
-      manuscriptId: 'm1', bookId: 'b1',
+      bookId: 'b1',
       sentences: [
         { id: 5, chapterId: 3, characterId: 'narrator', text: 'The hall was dark.' },
         { id: 6, chapterId: 3, characterId: 'narrator', text: 'Dust hung in the air.' },
       ],
     } as never));
-    const ch3 = reanalysed.sentences.filter((s) => s.chapterId === 3);
-    expect(ch3.map((s) => s.id)).toEqual([5]); // 6 stays dead; no duplicate
+    const ch3 = reanalysed.sentences.filter((x) => x.chapterId === 3);
+    expect(ch3.map((x) => x.id)).toEqual([5]); // 6 stays dead
     expect(ch3[0].text).toBe('The hall was dark. Dust hung in the air.');
+  });
+
+  it('rejects a merge naming a missing id, and a single-id merge', () => {
+    const s = start([{ id: 5, chapterId: 3, characterId: 'narrator', text: 'A.' }]);
+    expect(reducer(s, manuscriptActions.mergeSentences({ chapterId: 3, sentenceIds: [5, 9] })).sentences).toHaveLength(1);
+    expect(reducer(s, manuscriptActions.mergeSentences({ chapterId: 3, sentenceIds: [5] })).sentences).toHaveLength(1);
   });
 });
 ```
 
-- [ ] **Step 2: Run to verify they fail**
-
-Run: `npm test -- src/store/manuscript-slice.test.ts -t mergeSentences`
-Expected: FAIL — `mergeSentences is not a function`.
-
-- [ ] **Step 3: Add `mergedAwayKeys` to state + init**
-
-In `ManuscriptState` add `mergedAwayKeys: string[];`. In the slice's `initialState` add `mergedAwayKeys: []`. In the `reset` reducer set `s.mergedAwayKeys = []`. In `applyReupload` set `s.mergedAwayKeys = []` (a new manuscript invalidates old merges).
-
-- [ ] **Step 4: Add the `mergeSentences` reducer**
+- [ ] **Step 2: Run → fail.** (`mergeSentences is not a function`.)
+- [ ] **Step 3: Add `mergedAwayKeys` to state + init.** Add `mergedAwayKeys: string[];` to `ManuscriptState`; `mergedAwayKeys: []` in `initialState`; `s.mergedAwayKeys = []` in `reset` and `applyReupload`.
+- [ ] **Step 4: Add the reducer:**
 
 ```typescript
-mergeSentences: (
-  s,
-  a: PayloadAction<{ chapterId: number; sentenceIds: number[] }>,
-) => {
+mergeSentences: (s, a: PayloadAction<{ chapterId: number; sentenceIds: number[] }>) => {
   const ids = [...a.payload.sentenceIds].sort((x, y) => x - y);
   if (ids.length < 2) return;
-  const members = ids
-    .map((id) => s.sentences.find((x) => x.chapterId === a.payload.chapterId && x.id === id))
-    .filter((x): x is (typeof s.sentences)[number] => Boolean(x));
-  if (members.length !== ids.length) return; // some id missing — reject
-  const surviving = members[0]; // lowest id (ids sorted)
-  surviving.text = members.map((m) => m.text).join(' ');
-  for (const m of members.slice(1)) {
+  const members = ids.map((id) => s.sentences.find((x) => x.chapterId === a.payload.chapterId && x.id === id));
+  if (members.some((m) => !m)) return;
+  const live = members as NonNullable<(typeof members)[number]>[];
+  live[0].text = live.map((m) => m.text).join(' ');
+  for (const m of live.slice(1)) {
     const i = s.sentences.findIndex((x) => x.chapterId === a.payload.chapterId && x.id === m.id);
     if (i >= 0) s.sentences.splice(i, 1);
     s.mergedAwayKeys.push(`${a.payload.chapterId}:${m.id}`);
@@ -207,9 +165,7 @@ mergeSentences: (
 },
 ```
 
-- [ ] **Step 5: Guard the resurrection branch in `hydrateFromAnalysis`**
-
-Change the incoming-append loop (currently lines ~149-151) to skip tombstoned keys:
+- [ ] **Step 5: Guard the resurrection branch in `hydrateFromAnalysis`** (the final append loop ~line 149-151):
 
 ```typescript
 const tomb = new Set(s.mergedAwayKeys);
@@ -218,213 +174,140 @@ for (const inc of incoming) {
 }
 ```
 
-- [ ] **Step 6: Run to verify they pass**
+- [ ] **Step 6: Run → pass** (all three cases).
+- [ ] **Step 7: Commit** `feat(frontend): add mergeSentences reducer + in-memory merge tombstone`.
 
-Run: `npm test -- src/store/manuscript-slice.test.ts -t mergeSentences`
-Expected: PASS (both cases).
+### Task 2b: Persist the merge tombstone across reload
 
-- [ ] **Step 7: Commit**
+A merge is a *committed* manuscript edit, but the tombstone is in-memory — after a reload (`hydrateFromBookState`) a re-analysis could resurrect the merged id. Persist `mergedAwayKeys` in book state and rehydrate it; also clear it on cross-book load (fixes the cross-book leak the review flagged).
 
-```bash
-git add src/store/manuscript-slice.ts src/store/manuscript-slice.test.ts
-git commit -m "feat(frontend): add mergeSentences reducer + merge tombstone (re-analysis-safe)"
-```
+**Files:** Modify `src/store/manuscript-slice.ts` (`hydrateFromBookState` sets `s.mergedAwayKeys = a.payload.mergedAwayKeys ?? []`); `src/store/persistence-middleware.ts` (include `mergedAwayKeys` in the manuscript PUT payload); `server/src/routes/book-state.ts` (persist + return `mergedAwayKeys` on the book-state GET; accept it on the PUT `manuscript` case); Test `src/store/manuscript-slice.test.ts` + a server book-state test.
 
-### Task 3: Content-hash on the render map (the unified staleness fix)
+**Interfaces:** Consumes/produces: book-state GET response gains `mergedAwayKeys?: string[]`; `hydrateFromBookState` payload gains `mergedAwayKeys?: string[]`.
 
-The precise staleness path (`isChapterReassignedSinceRender`) compares `characterId` only, so it misses `strip_tag` (text change), the retained `split`/`extract` piece (text shrinks, id+characterId unchanged), and `fix_emotion` `angry→neutral`. Fix once: make the render map carry a per-sentence **content hash**, and diff hashes.
-
-**Files:**
-- Create: `src/lib/sentence-hash.ts`
-- Modify: `src/lib/stale-chapters.ts` (`isChapterReassignedSinceRender` accepts a hash map), `src/views/generation.tsx` (build the current-hash input)
-- Modify (server): `server/src/audio/segments-io.ts` (`collectRenderedSpeakerMaps` → also emit a hash map) and the book-state GET that ships `renderedSpeakersByChapter`; `src/store/chapters-slice.ts` (carry `renderedSentenceHashesByChapter`)
-- Test: `src/lib/stale-chapters.test.ts`, `src/lib/sentence-hash.test.ts`
-
-**Interfaces:**
-- Produces: `sentenceContentHash(s: { text: string; characterId: string; emotion?: string }): string` (stable, order-independent of object key order).
-- Produces: `isChapterStaleSinceRender(renderedHashes: Record<number, string> | undefined, current: Array<{ id: number; text: string; characterId: string; emotion?: string }>): boolean` — true if any rendered id's current hash differs (or the id is gone).
-- Consumes (server): the existing render-map builder; adds a sibling `renderedSentenceHashesByChapter: Record<number, Record<number, string>>` to the book-state GET and `hydrateFromBookState` payload.
-
-- [ ] **Step 1: Write the failing hash test**
+- [ ] **Step 1: Write the failing test** — `hydrateFromBookState` with `mergedAwayKeys: ['3:6']` sets state; the same payload for a *different* book clears a prior book's keys.
 
 ```typescript
-// src/lib/sentence-hash.test.ts
-import { describe, it, expect } from 'vitest';
-import { sentenceContentHash } from './sentence-hash';
-
-describe('sentenceContentHash', () => {
-  it('changes when text, characterId, or emotion change; stable otherwise', () => {
-    const base = { text: 'Hello.', characterId: 'narrator', emotion: undefined as string | undefined };
-    const h = sentenceContentHash(base);
-    expect(sentenceContentHash({ ...base })).toBe(h);
-    expect(sentenceContentHash({ ...base, text: 'Hello!' })).not.toBe(h);
-    expect(sentenceContentHash({ ...base, characterId: 'maerin' })).not.toBe(h);
-    expect(sentenceContentHash({ ...base, emotion: 'angry' })).not.toBe(h);
-  });
+it('rehydrates and book-scopes the merge tombstone', () => {
+  const a = reducer(undefined, manuscriptActions.hydrateFromBookState({ bookId: 'A', chapters: [], completedSlugs: [], characters: [], mergedAwayKeys: ['3:6'] } as never));
+  expect(a.mergedAwayKeys).toEqual(['3:6']);
+  const b = reducer(a, manuscriptActions.hydrateFromBookState({ bookId: 'B', chapters: [], completedSlugs: [], characters: [] } as never));
+  expect(b.mergedAwayKeys).toEqual([]); // B's load doesn't inherit A's tombstone
 });
 ```
 
-- [ ] **Step 2: Run to verify it fails**
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Frontend** — add `mergedAwayKeys?: string[]` to the `hydrateFromBookState` payload type and set `s.mergedAwayKeys = a.payload.mergedAwayKeys ?? []`. In `persistence-middleware.ts`, include `mergedAwayKeys` in the manuscript slice's PUT body.
+- [ ] **Step 4: Server** — in `book-state.ts`: persist `mergedAwayKeys` (store alongside the manuscript edits, e.g. a `merged-away.json` sibling or a field in state.json) on the PUT `manuscript` case; include it in the GET response. Add a server test asserting round-trip.
+- [ ] **Step 5: Run → pass** (frontend `npm test`, server `npm run test:server`).
+- [ ] **Step 6: Commit** `feat(frontend,server): persist the script-review merge tombstone across reload` *(mixed scope is unavoidable here — it's one feature spanning the PUT/GET contract).*
 
-Run: `npm test -- src/lib/sentence-hash.test.ts`
-Expected: FAIL — module not found.
+### Task 3: Staleness — emit `boundary_move` for all ops + widen the stale gate
 
-- [ ] **Step 3: Implement the hash** (a tiny stable string hash; no crypto dep needed)
+The precise render-map diff (`isChapterReassignedSinceRender`) compares `characterId` only, so it misses `strip_tag` (text), the retained `split`/`extract` piece, and `fix_emotion`. Fix the simple way: every accepted op emits a `boundary_move` (done in Tasks 5/11), and the Generate-view gate marks a rendered chapter stale if EITHER the precise diff OR the time-based `boundary_move` heuristic fires.
+
+**Files:** Modify `src/views/generation.tsx` (the `stale={…}` gate ~line 1108-1115); Test `src/views/generation.test.tsx` (or the nearest existing staleness test) + triage existing #650 staleness tests.
+
+**Interfaces:** No new exports. Behavior change: `stale = precise || timeBased` (was `renderMap ? precise : timeBased`).
+
+- [ ] **Step 1: Write the failing test** — a rendered chapter (has a render map) whose only post-render change is a `boundary_move` event (no characterId change) reads **stale**.
 
 ```typescript
-// src/lib/sentence-hash.ts
-/** Stable content fingerprint for staleness: any change to the spoken text,
-    the speaker, or the delivery emotion produces a different hash, so a
-    rendered chapter whose sentence content drifted reads stale. */
-export function sentenceContentHash(s: {
-  text: string;
-  characterId: string;
-  emotion?: string;
-}): string {
-  const payload = `${s.characterId} ${s.emotion ?? ''} ${s.text}`;
-  let h = 5381;
-  for (let i = 0; i < payload.length; i++) h = ((h << 5) + h + payload.charCodeAt(i)) | 0;
-  return (h >>> 0).toString(36);
+// assert via the gate's logic: with a render map present AND a post-render boundary_move,
+// the chapter is stale even though isChapterReassignedSinceRender returns false.
+```
+
+(Render the Generate view with a `done` chapter that has `renderedSpeakersByChapter[id]` matching current characterIds, plus a `boundary_move` change-log event dated after `audioRenderedAt`; assert the stale badge shows.)
+
+- [ ] **Step 2: Run → fail** (current gate ignores the time-based path when a render map exists).
+- [ ] **Step 3: Widen the gate:**
+
+```typescript
+stale={
+  // Stale if the precise render-map diff flags a speaker change OR a post-render
+  // boundary_move was logged (covers text/emotion edits the characterId-only
+  // precise diff can't see — script-review strip_tag/fix_emotion + the retained
+  // split/extract piece).
+  (renderedSpeakersByChapter[ch.id] ? reassignedSinceRenderSet.has(ch.id) : false) ||
+  isChapterStaleFromReassign(ch, activityEvents)
 }
 ```
 
-- [ ] **Step 4: Write the failing staleness test**
+- [ ] **Step 4: Triage existing staleness tests** — any #650 test asserting "move-then-undo reads NOT stale" will now read stale (the OR path catches the boundary_move). Update those tests to reflect the conservative behavior, and add a comment that the OR-gate intentionally trades a rare move-then-undo false positive for catching text/emotion edits. If a test is genuinely about a different invariant, leave it.
+- [ ] **Step 5: Run → pass** (`npm test -- src/views/generation.test.tsx`).
+- [ ] **Step 6: Commit** `feat(frontend): widen Generate stale gate to OR the boundary_move heuristic`.
 
-```typescript
-// src/lib/stale-chapters.test.ts (add)
-import { isChapterStaleSinceRender } from './stale-chapters';
-import { sentenceContentHash } from './sentence-hash';
+### Task 4: Client anchor resolver + op validation/ordering (TOCTOU + two-anchor extract)
 
-describe('isChapterStaleSinceRender (content hash)', () => {
-  const s1 = { id: 1, text: '"Stop," she said.', characterId: 'maerin', emotion: undefined as string | undefined };
-  const rendered = { 1: sentenceContentHash(s1) };
-
-  it('not stale when content is unchanged', () => {
-    expect(isChapterStaleSinceRender(rendered, [s1])).toBe(false);
-  });
-  it('stale on a strip_tag text change', () => {
-    expect(isChapterStaleSinceRender(rendered, [{ ...s1, text: '"Stop,"' }])).toBe(true);
-  });
-  it('stale on fix_emotion angry->neutral (rendered had a variant)', () => {
-    const renderedAngry = { 1: sentenceContentHash({ ...s1, emotion: 'angry' }) };
-    expect(isChapterStaleSinceRender(renderedAngry, [{ ...s1, emotion: undefined }])).toBe(true);
-  });
-  it('stale when a rendered id no longer exists (merged away)', () => {
-    expect(isChapterStaleSinceRender(rendered, [])).toBe(true);
-  });
-});
-```
-
-- [ ] **Step 5: Run to verify it fails**
-
-Run: `npm test -- src/lib/stale-chapters.test.ts -t "content hash"`
-Expected: FAIL — `isChapterStaleSinceRender` not exported.
-
-- [ ] **Step 6: Implement `isChapterStaleSinceRender`** (add next to `isChapterReassignedSinceRender`)
-
-```typescript
-import { sentenceContentHash } from './sentence-hash';
-
-export function isChapterStaleSinceRender(
-  renderedHashes: Record<number, string> | undefined,
-  current: Array<{ id: number; text: string; characterId: string; emotion?: string }>,
-): boolean {
-  if (!renderedHashes || Object.keys(renderedHashes).length === 0) return false;
-  const byId = new Map(current.map((s) => [s.id, s]));
-  for (const sidStr of Object.keys(renderedHashes)) {
-    const sid = Number(sidStr);
-    const s = byId.get(sid);
-    if (!s || sentenceContentHash(s) !== renderedHashes[sid]) return true;
-  }
-  return false;
-}
-```
-
-- [ ] **Step 7: Wire the server render map** — in `server/src/audio/segments-io.ts` where `collectRenderedSpeakerMaps` builds `{ [chapterId]: { [sentenceId]: characterId } }`, build a parallel `{ [chapterId]: { [sentenceId]: sentenceContentHash(...) } }` from the same rendered sentences (port `sentenceContentHash` to a server util or duplicate the 6-line function in `server/src/audio/`), and include it in the book-state GET response as `renderedSentenceHashesByChapter`. Add the field to `chapters-slice.ts` `hydrateFromBookState` payload + state (mirror `renderedSpeakersByChapter`).
-
-- [ ] **Step 8: Flip `generation.tsx` to the hash path** — where the `stale={…}` gate (lines ~1108-1115) uses `reassignedSinceRenderSet`, compute staleness from `renderedSentenceHashesByChapter[ch.id]` + the live chapter sentences via `isChapterStaleSinceRender`. Keep the `isChapterStaleFromReassign` time-based fallback for chapters with no hash map (older servers/mocks).
-
-- [ ] **Step 9: Run frontend + server tests**
-
-Run: `npm test -- src/lib/stale-chapters.test.ts src/lib/sentence-hash.test.ts` then `npm run test:server`
-Expected: PASS.
-
-- [ ] **Step 10: Commit**
-
-```bash
-git add src/lib/sentence-hash.ts src/lib/stale-chapters.ts src/views/generation.tsx src/store/chapters-slice.ts server/src/audio/segments-io.ts src/lib/sentence-hash.test.ts src/lib/stale-chapters.test.ts
-git commit -m "feat(frontend,server): content-hash render map for script-review staleness"
-```
-
-### Task 4: Client anchor resolver + op validation/ordering (closes TOCTOU)
-
-**Files:**
-- Create: `src/lib/script-review-apply.ts`
-- Test: `src/lib/script-review-apply.test.ts`
+**Files:** Create `src/lib/script-review-apply.ts`; Test `src/lib/script-review-apply.test.ts`.
 
 **Interfaces:**
-- Consumes: the suggestion op type (define here, frontend-side, structurally matching the server `ScriptReviewOp`): `interface ReviewOp { id: number; op: 'strip_tag'|'split'|'extract_dialogue'|'merge'|'fix_emotion'; newText?: string; anchor?: string; pieceCharacterIds?: string[]; mergeIds?: number[]; emotion?: string; rationale: string; confidence?: number; }`
-- Produces:
-  - `normalizeForMatch(text: string): string` — NFC + fold curly→straight quotes, em/en-dash→`-`, ellipsis→`...`, collapse whitespace.
-  - `resolveAnchorOffset(text: string, anchor: string): number | null` — normalized `indexOf` that is unique (`indexOf === lastIndexOf`), returns the offset **in the original text** of the split point (end of the anchor's "before" half), else null.
-  - `planApply(ops: ReviewOp[], live: Array<{ id: number; chapterId: number; text: string; characterId: string }>): { appliable: ReviewOp[]; unappliable: Array<{ op: ReviewOp; reason: string }> }` — applies §5.6 ordering/validation: structural ops first, reject a field edit whose id a structural op consumed, reject >1 structural op per id, reject anchors that don't resolve uniquely against live text, reject merges whose members aren't adjacent + same characterId.
+- `ReviewOp` (frontend type, mirrors the server Zod): `{ id; op: 'strip_tag'|'split'|'extract_dialogue'|'merge'|'fix_emotion'; newText?; anchor?; anchorEnd?; pieceCharacterIds?; mergeIds?; emotion?; rationale; confidence? }`. `anchorEnd` is for `extract_dialogue` (mid-run = two boundaries → 3 pieces).
+- `normalizeForMatch(text): string` — NFC + curly→straight quotes + em/en-dash→`-` + `…`→`...`. **No whitespace collapse** (it isn't position-preserving — the review caught this).
+- `resolveAnchorOffset(text, anchor): number | null` — builds an original→normalized index map in ONE pass, finds a unique normalized match, returns the **original** offset of the anchor's end (or null if absent / non-unique).
+- `planApply(ops, live): { appliable; unappliable }` — §5.6 ordering/validation (structural first; reject consumed-id field edits, 2nd structural op on one id, non-resolving anchors, merge members not adjacent/same-char/same-chapter, `fix_emotion` to a non-`EMOTIONS` value).
 
-- [ ] **Step 1: Write the failing tests**
+- [ ] **Step 1: Write the failing tests** (incl. the EXACT-offset assertion the review demanded + two-anchor extract + planApply TOCTOU + merge rejections + invalid-enum):
 
 ```typescript
-// src/lib/script-review-apply.test.ts
-import { describe, it, expect } from 'vitest';
-import { normalizeForMatch, resolveAnchorOffset, planApply } from './script-review-apply';
+import { resolveAnchorOffset, planApply } from './script-review-apply';
 
-describe('anchor resolution', () => {
-  it('matches across curly/straight quote + em-dash normalization', () => {
-    const text = 'He paused—then ran. “Stop,” she said.';
-    // anchor uses straight quotes / hyphen as an LLM might "normalize" them:
-    const off = resolveAnchorOffset(text, 'ran. "Stop,"');
+describe('resolveAnchorOffset', () => {
+  it('returns the EXACT original offset across quote/dash normalization', () => {
+    const text = 'He paused—then ran. "Stop," she said.';
+    const off = resolveAnchorOffset(text, 'ran. "Stop,"'); // anchor uses straight quotes
     expect(off).not.toBeNull();
-    expect(text.slice(0, off!)).toContain('ran.');
+    expect(text.slice(off!)).toBe(' she said.'); // exact, not toContain
   });
-  it('returns null when the anchor is not unique', () => {
-    expect(resolveAnchorOffset('he said, he said', 'he said')).toBeNull();
-  });
-  it('returns null when the anchor is absent (mid-review edit / TOCTOU)', () => {
-    expect(resolveAnchorOffset('totally different now', 'ran. "Stop,"')).toBeNull();
-  });
+  it('null when not unique', () => expect(resolveAnchorOffset('he said, he said', 'he said')).toBeNull());
+  it('null when absent (TOCTOU edit)', () => expect(resolveAnchorOffset('totally different', 'ran.')).toBeNull());
 });
 
-describe('planApply ordering + validation', () => {
+describe('planApply', () => {
   const live = [
     { id: 5, chapterId: 3, text: 'The hall was dark.', characterId: 'narrator' },
     { id: 6, chapterId: 3, text: 'Dust hung in the air.', characterId: 'narrator' },
+    { id: 7, chapterId: 3, text: 'He sighed. "At last," she said. He left.', characterId: 'narrator' },
   ];
   it('rejects a field edit whose id a structural op consumed', () => {
-    const r = planApply(
-      [
-        { id: 6, op: 'merge', mergeIds: [5, 6], rationale: 'over-split' },
-        { id: 6, op: 'strip_tag', newText: 'x', rationale: 'tag' },
-      ],
-      live,
-    );
+    const r = planApply([
+      { id: 6, op: 'merge', mergeIds: [5, 6], rationale: 'over-split' },
+      { id: 6, op: 'strip_tag', newText: 'x', rationale: 'tag' },
+    ], live);
     expect(r.appliable.map((o) => o.op)).toEqual(['merge']);
     expect(r.unappliable[0].reason).toMatch(/consumed/);
+  });
+  it('rejects a non-adjacent / cross-character merge', () => {
+    const r = planApply([{ id: 5, op: 'merge', mergeIds: [5, 7], rationale: 'x' }], live);
+    expect(r.appliable).toHaveLength(0);
+    expect(r.unappliable[0].reason).toMatch(/adjacent|character/);
+  });
+  it('TOCTOU: a structural op whose anchor no longer resolves is unappliable', () => {
+    const r = planApply([{ id: 5, op: 'split', anchor: 'no such text', pieceCharacterIds: ['narrator', 'maerin'], rationale: 'x' }], live);
+    expect(r.appliable).toHaveLength(0);
+    expect(r.unappliable[0].reason).toMatch(/anchor/);
+  });
+  it('rejects fix_emotion to an invalid enum', () => {
+    const r = planApply([{ id: 5, op: 'fix_emotion', emotion: 'furious', rationale: 'x' }], live);
+    expect(r.appliable).toHaveLength(0);
+    expect(r.unappliable[0].reason).toMatch(/emotion/);
   });
 });
 ```
 
-- [ ] **Step 2: Run to verify it fails**
-
-Run: `npm test -- src/lib/script-review-apply.test.ts`
-Expected: FAIL — module not found.
-
-- [ ] **Step 3: Implement the resolver + planner**
+- [ ] **Step 2: Run → fail** (module not found).
+- [ ] **Step 3: Implement** (index-map resolver — the per-char-rescan bug is gone; whitespace is preserved by NOT collapsing it):
 
 ```typescript
 // src/lib/script-review-apply.ts
+export const REVIEW_EMOTIONS = ['neutral', 'whisper', 'angry', 'excited', 'sad'] as const;
+
 export interface ReviewOp {
   id: number;
   op: 'strip_tag' | 'split' | 'extract_dialogue' | 'merge' | 'fix_emotion';
   newText?: string;
   anchor?: string;
+  anchorEnd?: string;
   pieceCharacterIds?: string[];
   mergeIds?: number[];
   emotion?: string;
@@ -432,38 +315,37 @@ export interface ReviewOp {
   confidence?: number;
 }
 
+/** NFC + quote/dash/ellipsis folds ONLY — every fold maps 1 original char to a
+    known number of normalized chars, so an index map is exact. No whitespace
+    collapse (it would desync positions — the plan-review bug). */
+function normChar(c: string): string {
+  if (c === '‘' || c === '’') return "'";
+  if (c === '“' || c === '”') return '"';
+  if (c === '–' || c === '—') return '-';
+  if (c === '…') return '...';
+  return c.normalize('NFC');
+}
 export function normalizeForMatch(text: string): string {
-  return text
-    .normalize('NFC')
-    .replace(/[‘’]/g, "'")
-    .replace(/[“”]/g, '"')
-    .replace(/[–—]/g, '-')
-    .replace(/…/g, '...')
-    .replace(/\s+/g, ' ')
-    .trim();
+  let out = '';
+  for (const ch of text) out += normChar(ch);
+  return out;
 }
 
-/** Locate the split point: the anchor is a boundary-spanning substring; the
-    returned offset is the END of its match in the ORIGINAL text (so callers
-    can slice [0,off] / [off,len]). Null if not found OR not unique. */
+/** Returns the ORIGINAL-text offset of the END of a unique anchor match, or null. */
 export function resolveAnchorOffset(text: string, anchor: string): number | null {
-  const nText = normalizeForMatch(text);
+  // Build normalized string + a map from each normalized index to the original index AFTER it.
+  let norm = '';
+  const origEndForNormLen: number[] = [0]; // origEndForNormLen[k] = original index after k normalized chars
+  for (let i = 0; i < text.length; i++) {
+    const piece = normChar(text[i]);
+    for (let j = 0; j < piece.length; j++) origEndForNormLen.push(i + 1);
+    norm += piece;
+  }
   const nAnchor = normalizeForMatch(anchor);
   if (!nAnchor) return null;
-  const first = nText.indexOf(nAnchor);
-  if (first < 0 || first !== nText.lastIndexOf(nAnchor)) return null;
-  // Map the normalized end-offset back to the original text by proportional
-  // re-scan: walk the original, normalizing incrementally, until we reach the
-  // normalized end index. (Whitespace collapse is the only length-changing op
-  // we apply; quote/dash/ellipsis swaps are handled char-wise below.)
-  const targetNormEnd = first + nAnchor.length;
-  let normCount = 0;
-  for (let i = 0; i < text.length; i++) {
-    const piece = normalizeForMatch(text[i]);
-    normCount += piece.length;
-    if (normCount >= targetNormEnd) return i + 1;
-  }
-  return text.length;
+  const first = norm.indexOf(nAnchor);
+  if (first < 0 || first !== norm.lastIndexOf(nAnchor)) return null;
+  return origEndForNormLen[first + nAnchor.length];
 }
 
 export function planApply(
@@ -474,101 +356,55 @@ export function planApply(
   const appliable: ReviewOp[] = [];
   const unappliable: Array<{ op: ReviewOp; reason: string }> = [];
   const STRUCTURAL = new Set(['split', 'extract_dialogue', 'merge']);
-  const consumed = new Set<number>(); // ids removed/reshaped by a structural op
-  const structuralTargets = new Set<number>();
+  const consumed = new Set<number>();
+  const structTargets = new Set<number>();
 
-  // Pass 1: structural ops first.
   for (const op of ops.filter((o) => STRUCTURAL.has(o.op))) {
-    if (structuralTargets.has(op.id)) {
-      unappliable.push({ op, reason: 'second structural op on the same id' });
-      continue;
-    }
+    const primary = op.op === 'merge' ? (op.mergeIds ?? [])[0] : op.id;
+    if (structTargets.has(primary)) { unappliable.push({ op, reason: 'second structural op on the same id' }); continue; }
     if (op.op === 'merge') {
       const ids = [...(op.mergeIds ?? [])].sort((a, b) => a - b);
       const members = ids.map((id) => byId.get(id));
       if (members.some((m) => !m)) { unappliable.push({ op, reason: 'merge member missing' }); continue; }
       const ch = members[0]!.chapterId;
       const sameChar = members.every((m) => m!.characterId === members[0]!.characterId);
+      const sameChapter = members.every((m) => m!.chapterId === ch);
       const adjacent = ids.every((id, k) => k === 0 || id === ids[k - 1] + 1);
-      if (!sameChar || !adjacent || members.some((m) => m!.chapterId !== ch)) {
-        unappliable.push({ op, reason: 'merge members not adjacent / same character / same chapter' });
-        continue;
-      }
-      ids.forEach((id) => { consumed.add(id); structuralTargets.add(id); });
+      if (!sameChar || !adjacent || !sameChapter) { unappliable.push({ op, reason: 'merge members not adjacent / same character / same chapter' }); continue; }
+      ids.forEach((id) => { consumed.add(id); structTargets.add(id); });
       appliable.push(op);
     } else {
       const s = byId.get(op.id);
       if (!s) { unappliable.push({ op, reason: 'target id missing' }); continue; }
-      if (resolveAnchorOffset(s.text, op.anchor ?? '') === null) {
-        unappliable.push({ op, reason: 'anchor not found or not unique' });
-        continue;
-      }
-      consumed.add(op.id);
-      structuralTargets.add(op.id);
-      appliable.push(op);
+      if (resolveAnchorOffset(s.text, op.anchor ?? '') === null) { unappliable.push({ op, reason: 'anchor not found or not unique' }); continue; }
+      if (op.op === 'extract_dialogue' && resolveAnchorOffset(s.text, op.anchorEnd ?? '') === null) { unappliable.push({ op, reason: 'extract anchorEnd not found or not unique' }); continue; }
+      consumed.add(op.id); structTargets.add(op.id); appliable.push(op);
     }
   }
 
-  // Pass 2: field edits, skipping consumed ids.
   for (const op of ops.filter((o) => !STRUCTURAL.has(o.op))) {
     if (consumed.has(op.id)) { unappliable.push({ op, reason: 'id consumed by a structural op' }); continue; }
     if (!byId.has(op.id)) { unappliable.push({ op, reason: 'target id missing' }); continue; }
+    if (op.op === 'fix_emotion' && !REVIEW_EMOTIONS.includes(op.emotion as never)) { unappliable.push({ op, reason: 'invalid emotion value' }); continue; }
     appliable.push(op);
   }
   return { appliable, unappliable };
 }
 ```
 
-- [ ] **Step 4: Run to verify it passes**
+- [ ] **Step 4: Run → pass.**
+- [ ] **Step 5: Commit** `feat(frontend): script-review anchor resolver + op validation (TOCTOU, two-anchor extract)`.
 
-Run: `npm test -- src/lib/script-review-apply.test.ts`
-Expected: PASS.
+### Task 5: Accept→dispatch wiring (all 5 classes, real reducers, boundary_move for every op)
 
-- [ ] **Step 5: Commit**
+**Files:** Modify `src/lib/script-review-apply.ts` (add `dispatchAcceptedOps`); Test `src/lib/script-review-apply.test.ts` (run against a REAL store + assert state + ID allocation).
 
-```bash
-git add src/lib/script-review-apply.ts src/lib/script-review-apply.test.ts
-git commit -m "feat(frontend): client-side anchor resolver + op validation for script review"
-```
+**Interfaces:** `dispatchAcceptedOps(dispatch, accepted: ReviewOp[], live, { onBoundaryMove })` — dispatches the mapped reducer per op; resolves anchors against `live` text; calls `onBoundaryMove(chapterId)` for **every** op (so staleness fires per Task 3).
 
-### Task 5: The accept→dispatch wiring (pure function over ops → reducer dispatches)
+- [ ] **Step 1: Write the failing test** — use a REAL store (`configureStore({ reducer: { manuscript } })`), seed via the `start()` helper's state, dispatch `dispatchAcceptedOps` for one of each class, assert the resulting manuscript state (split offspring id = global max+1; merge survivor text; strip_tag text; fix_emotion emotion) and that `onBoundaryMove` fired once per op.
 
-**Files:**
-- Modify: `src/lib/script-review-apply.ts` (add `dispatchAcceptedOps`)
-- Test: `src/lib/script-review-apply.test.ts`
-
-**Interfaces:**
-- Consumes: `manuscriptActions` (`splitSentence`, `setSentenceText`, `setSentenceEmotion`, `mergeSentences`), `changeLogActions.bumpBoundaryMove`, the `planApply` output, the live sentence list.
-- Produces: `dispatchAcceptedOps(dispatch, accepted: ReviewOp[], live, { onBoundaryMove })` — for each op resolves the anchor against live text and dispatches the matching reducer; counts boundary moves for the change-log.
-
-- [ ] **Step 1: Write the failing test** (capture dispatched actions)
-
-```typescript
-import { manuscriptActions } from '../store/manuscript-slice';
-import { dispatchAcceptedOps } from './script-review-apply';
-
-it('dispatches the mapped reducer per op type', () => {
-  const calls: Array<{ type: string; payload: unknown }> = [];
-  const dispatch = ((a: { type: string; payload: unknown }) => calls.push(a)) as never;
-  const live = [
-    { id: 1, chapterId: 1, text: 'He ran. "Stop," she said.', characterId: 'maerin' },
-  ];
-  dispatchAcceptedOps(dispatch, [
-    { id: 1, op: 'strip_tag', newText: 'He ran. "Stop,"', rationale: 'tag' },
-    { id: 1, op: 'fix_emotion', emotion: 'neutral', rationale: 'calm' },
-  ], live, { onBoundaryMove: () => {} });
-  expect(calls.map((c) => c.type)).toEqual([
-    manuscriptActions.setSentenceText.type,
-    manuscriptActions.setSentenceEmotion.type,
-  ]);
-});
-```
-
-- [ ] **Step 2: Run to verify it fails** (`dispatchAcceptedOps` not exported).
-
-Run: `npm test -- src/lib/script-review-apply.test.ts -t "mapped reducer"`
-
-- [ ] **Step 3: Implement**
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement:**
 
 ```typescript
 import type { Dispatch } from '@reduxjs/toolkit';
@@ -592,340 +428,192 @@ export function dispatchAcceptedOps(
       case 'fix_emotion':
         dispatch(manuscriptActions.setSentenceEmotion({ chapterId, sentenceId: op.id, emotion: op.emotion ?? 'neutral' }));
         break;
-      case 'split':
-      case 'extract_dialogue': {
+      case 'split': {
         const off = resolveAnchorOffset(target.text, op.anchor ?? '');
-        if (off === null) break;
-        dispatch(manuscriptActions.splitSentence({
-          chapterId, sentenceId: op.id, offsets: [off],
-          characterIds: op.pieceCharacterIds ?? [target.characterId, target.characterId],
-        }));
-        onBoundaryMove(chapterId);
+        if (off === null) continue;
+        dispatch(manuscriptActions.splitSentence({ chapterId, sentenceId: op.id, offsets: [off], characterIds: op.pieceCharacterIds ?? [target.characterId, target.characterId] }));
+        break;
+      }
+      case 'extract_dialogue': {
+        const start = resolveAnchorOffset(target.text, op.anchor ?? '');
+        const end = resolveAnchorOffset(target.text, op.anchorEnd ?? '');
+        if (start === null || end === null || end <= start) continue;
+        dispatch(manuscriptActions.splitSentence({ chapterId, sentenceId: op.id, offsets: [start, end], characterIds: op.pieceCharacterIds ?? [target.characterId, target.characterId, target.characterId] }));
         break;
       }
       case 'merge':
         dispatch(manuscriptActions.mergeSentences({ chapterId, sentenceIds: op.mergeIds ?? [] }));
-        onBoundaryMove(chapterId);
         break;
     }
+    onBoundaryMove(chapterId);
   }
 }
 ```
 
-- [ ] **Step 4: Run to verify it passes.**
-
-Run: `npm test -- src/lib/script-review-apply.test.ts`
-Expected: PASS.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add src/lib/script-review-apply.ts src/lib/script-review-apply.test.ts
-git commit -m "feat(frontend): script-review accept->reducer dispatch"
-```
+- [ ] **Step 4: Run → pass.**
+- [ ] **Step 5: Commit** `feat(frontend): script-review accept->reducer dispatch (all 5 classes)`.
 
 ---
 
 ## Phase 2 — Read-only review pass + endpoint (server)
 
-Mirrors fs-33's `runEmotionChapter` exactly; the only novelty is the op schema and the prompt.
+### Task 6: The review op schema (flat envelope, incl. `anchorEnd`)
 
-### Task 6: The review op schema (envelope + imperative-validated payloads)
+**Files:** Modify `server/src/handoff/schemas.ts`; Test `server/src/handoff/schemas.test.ts`.
 
-**Files:**
-- Modify: `server/src/handoff/schemas.ts` (add `scriptReviewSchema` next to `emotionAnnotationSchema`)
-- Test: `server/src/handoff/schemas.test.ts`
+**Interfaces:** Produces `scriptReviewSchema`, `ScriptReviewOp`, `ScriptReviewOutput`. Flat envelope (no discriminated union — Gemini can't constrain it; Ollama only softly); per-op payload validated imperatively client-side (Task 4) and server pre-apply is N/A (apply is client-side).
 
-**Interfaces:**
-- Produces: `scriptReviewSchema` (Zod), `ScriptReviewOp`, `ScriptReviewOutput`. Envelope-only: payload fields optional; per-op shape is enforced imperatively in the client planner (Task 4) — the schema deliberately does NOT use a discriminated union (Gemini can't constrain it; Ollama only softly).
-
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Write the failing test** — parses a heterogeneous `{ ops: [...] }` incl. an `extract_dialogue` with `anchor`+`anchorEnd`; rejects an unknown op.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** (note `EMOTIONS` is already exported from this same file, `schemas.ts:11`):
 
 ```typescript
-// server/src/handoff/schemas.test.ts (add)
-import { scriptReviewSchema } from './schemas';
-it('parses a flat review envelope of heterogeneous ops', () => {
-  const r = scriptReviewSchema.safeParse({
-    ops: [
-      { id: 1, op: 'strip_tag', newText: 'x', rationale: 'tag' },
-      { id: 2, op: 'merge', mergeIds: [2, 3], rationale: 'over-split' },
-      { id: 4, op: 'fix_emotion', emotion: 'neutral', rationale: 'calm' },
-    ],
-  });
-  expect(r.success).toBe(true);
-});
-it('rejects an unknown op', () => {
-  expect(scriptReviewSchema.safeParse({ ops: [{ id: 1, op: 'rewrite', rationale: 'x' }] }).success).toBe(false);
-});
-```
-
-- [ ] **Step 2: Run to verify it fails.** Run: `npm run test:server -- schemas.test.ts`
-
-- [ ] **Step 3: Implement the schema**
-
-```typescript
-export const scriptReviewSchema = z
-  .object({
-    ops: z.array(
-      z
-        .object({
-          id: z.number().int().positive(),
-          op: z.enum(['strip_tag', 'split', 'extract_dialogue', 'merge', 'fix_emotion']),
-          newText: z.string().optional(),
-          anchor: z.string().optional(),
-          pieceCharacterIds: z.array(z.string()).optional(),
-          mergeIds: z.array(z.number().int().positive()).optional(),
-          emotion: z.enum(EMOTIONS).optional(),
-          rationale: z.string(),
-          confidence: z.number().min(0).max(1).optional(),
-        })
-        .strict(),
-    ),
-  })
-  .strict();
+export const scriptReviewSchema = z.object({
+  ops: z.array(z.object({
+    id: z.number().int().positive(),
+    op: z.enum(['strip_tag', 'split', 'extract_dialogue', 'merge', 'fix_emotion']),
+    newText: z.string().optional(),
+    anchor: z.string().optional(),
+    anchorEnd: z.string().optional(),
+    pieceCharacterIds: z.array(z.string()).optional(),
+    mergeIds: z.array(z.number().int().positive()).optional(),
+    emotion: z.enum(EMOTIONS).optional(),
+    rationale: z.string(),
+    confidence: z.number().min(0).max(1).optional(),
+  }).strict()),
+}).strict();
 export type ScriptReviewOp = z.infer<typeof scriptReviewSchema>['ops'][number];
 export type ScriptReviewOutput = z.infer<typeof scriptReviewSchema>;
 ```
 
-- [ ] **Step 4: Run to verify it passes.** Run: `npm run test:server -- schemas.test.ts` → PASS.
+- [ ] **Step 4: Run → pass.**
+- [ ] **Step 5: Commit** `feat(server): scriptReviewSchema (flat envelope) for the review pass`.
 
-- [ ] **Step 5: Commit**
+### Task 7a: Analyzer interface + fallback delegation (testable red-first)
 
-```bash
-git add server/src/handoff/schemas.ts server/src/handoff/schemas.test.ts
-git commit -m "feat(server): scriptReviewSchema (flat envelope) for the review pass"
-```
+**Files:** Modify `server/src/analyzer/index.ts` (interface method + `FallbackAnalyzer` delegation), `server/src/handoff/protocol.ts` (`HandoffKey += \`review-ch${number}\``); Test `server/src/analyzer/fallback.test.ts` (mirror the existing `runEmotionChapter` delegation test).
 
-### Task 7: Analyzer extension — `runScriptReviewChapter` (interface + both impls + fallback)
+**Interfaces:** `Analyzer.runScriptReviewChapter(manuscriptId, chapterId, promptMd, call): Promise<ScriptReviewOutput>`.
 
-**Files:**
-- Modify: `server/src/analyzer/index.ts` (interface method + `FallbackAnalyzer` delegation)
-- Modify: `server/src/analyzer/gemini.ts` (impl + `SKILL_FILES` + `SkillName` + `SKILL_TO_PROMPT_ID`)
-- Modify: `server/src/analyzer/ollama.ts` (impl)
-- Modify: `server/src/handoff/protocol.ts` (`HandoffKey` += `` `review-ch${number}` ``)
-- Modify: `server/src/config/registry.ts` (`prompt.scriptReview` knob, `isPrompt:true`)
-- Create: `skills/audiobook-script-review.md` (the prompt)
-- Test: `server/src/analyzer/script-review.test.ts` (mock the HTTP layer like the existing analyzer tests)
+- [ ] **Step 1: Write the failing delegation test** — mirror `fallback.test.ts`'s `runEmotionChapter` case: a primary that throws `LocalUnreachableError` falls back; `AnalysisAbortedError` rethrows.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Add the `HandoffKey` variant** (`| \`review-ch${number}\``), the interface method (after `runEmotionChapter`), and the `FallbackAnalyzer.runScriptReviewChapter` delegation (copy the `runEmotionChapter` fallback body, renamed). Add a stub `runScriptReviewChapter` to any test-double analyzers so the interface compiles.
+- [ ] **Step 4: Run → pass.**
+- [ ] **Step 5: Commit** `feat(server): runScriptReviewChapter on the Analyzer interface + fallback`.
 
-**Interfaces:**
-- Produces: `Analyzer.runScriptReviewChapter(manuscriptId, chapterId, promptMd, call): Promise<ScriptReviewOutput>`.
+### Task 7b: Ollama + Gemini impls, skill prompt, registry knob
 
-- [ ] **Step 1: Add the `HandoffKey` variant**
+**Files:** Modify `server/src/analyzer/gemini.ts` (impl + `SKILL_FILES` + `SkillName` + `SKILL_TO_PROMPT_ID` + **`scriptReviewSchema`/`ScriptReviewOutput` imports**), `server/src/analyzer/ollama.ts` (impl + **the same imports**), `server/src/config/registry.ts` (`prompt.scriptReview` knob); Create `skills/audiobook-script-review.md`; Test `server/src/analyzer/script-review.test.ts` (copy the two-schema `runStage` mock block from `ollama.test.ts`), `skills/audiobook-script-review.test.ts` (M5 snapshot).
+
+- [ ] **Step 1: Register skill + prompt id (gemini.ts)** — `SKILL_FILES`: `script_review: 'audiobook-script-review.md',`; `SKILL_TO_PROMPT_ID`: `script_review: 'prompt.scriptReview',`.
+- [ ] **Step 2: Add the registry knob** (registry.ts, mirror `prompt.emotionAnnotation`): key `prompt.scriptReview`, `isPrompt: true`, `default: 'skills/audiobook-script-review.md'`, `apply: 'live'`, `risk: 'high'`.
+- [ ] **Step 3: Add the impls** (gemini.ts AND ollama.ts — add the imports first, then the method; passing `scriptReviewSchema` for both grammar+validation mirrors `runEmotionChapter` exactly):
 
 ```typescript
-// server/src/handoff/protocol.ts
-export type HandoffKey =
-  | '1' | `1-ch${number}` | '2' | `2-ch${number}`
-  | `emotion-ch${number}`
-  | `review-ch${number}`;
+async runScriptReviewChapter(manuscriptId: string, chapterId: number, promptMd: string, call: StageCall): Promise<ScriptReviewOutput> {
+  const key = `review-ch${chapterId}` as const;
+  return this.runStage(manuscriptId, key, 'script_review', promptMd, scriptReviewSchema, scriptReviewSchema, call);
+}
 ```
 
-- [ ] **Step 2: Extend the `Analyzer` interface** (add after `runEmotionChapter`)
-
-```typescript
-// server/src/analyzer/index.ts
-  runScriptReviewChapter(
-    manuscriptId: string,
-    chapterId: number,
-    promptMd: string,
-    call: StageCall,
-  ): Promise<ScriptReviewOutput>;
-```
-
-- [ ] **Step 3: Add the `FallbackAnalyzer` delegation** (copy the `runEmotionChapter` fallback verbatim, renamed)
-
-```typescript
-  async runScriptReviewChapter(manuscriptId: string, chapterId: number, promptMd: string, call: StageCall): Promise<ScriptReviewOutput> {
-    try {
-      return await this.primary.runScriptReviewChapter(manuscriptId, chapterId, promptMd, call);
-    } catch (err) {
-      if (err instanceof AnalysisAbortedError) throw err;
-      if (err instanceof LocalUnreachableError) {
-        return await this.fallback.runScriptReviewChapter(manuscriptId, chapterId, promptMd, call);
-      }
-      throw err;
-    }
-  }
-```
-
-- [ ] **Step 4: Register the skill + prompt id (gemini.ts)** — add to `SKILL_FILES`: `script_review: 'audiobook-script-review.md',` and to `SKILL_TO_PROMPT_ID`: `script_review: 'prompt.scriptReview',`.
-
-- [ ] **Step 5: Add the `prompt.scriptReview` registry knob** (registry.ts, mirror `prompt.emotionAnnotation`)
-
-```typescript
-{
-  key: 'prompt.scriptReview', env: '', group: 'analyzer-prompts',
-  label: 'Script review prompt',
-  help: 'Skill sent to the analysis model for the LLM Script Review pass. Editing forks a local copy; live.',
-  type: 'string', isPrompt: true,
-  default: 'skills/audiobook-script-review.md', apply: 'live', risk: 'high',
-},
-```
-
-- [ ] **Step 6: Add the impls** (gemini.ts and ollama.ts — identical bodies, mirror `runEmotionChapter`)
-
-```typescript
-  async runScriptReviewChapter(manuscriptId: string, chapterId: number, promptMd: string, call: StageCall): Promise<ScriptReviewOutput> {
-    const key = `review-ch${chapterId}` as const;
-    return this.runStage(manuscriptId, key, 'script_review', promptMd, scriptReviewSchema, scriptReviewSchema, call);
-  }
-```
-
-- [ ] **Step 7: Write the prompt** `skills/audiobook-script-review.md` — instruct the model: given a chapter's attributed sentences + cast, return `{ ops: [...] }` for the 5 classes; **never strip intentional vocalizations** ("Ah!", "Haah…"); for `split`/`extract_dialogue` return a short **boundary-spanning `anchor`** substring (copy it verbatim from the sentence text) + `pieceCharacterIds`; for `merge` return `mergeIds` of adjacent same-speaker narrator sentences; for `fix_emotion` only when the current emotion is clearly wrong; always include a one-line `rationale`. Output JSON only.
-
-- [ ] **Step 8: Write a failing impl test** (mock the chat/generate layer to return a canned envelope; assert the analyzer returns the parsed ops). Follow the existing `server/src/analyzer/*.test.ts` mocking pattern.
-
-- [ ] **Step 9: Run → fail → (code already added) → pass.** Run: `npm run test:server -- script-review.test.ts`
-
-- [ ] **Step 10: Commit**
-
-```bash
-git add server/src/analyzer/index.ts server/src/analyzer/gemini.ts server/src/analyzer/ollama.ts server/src/handoff/protocol.ts server/src/config/registry.ts skills/audiobook-script-review.md server/src/analyzer/script-review.test.ts
-git commit -m "feat(server): runScriptReviewChapter analyzer pass (Ollama+Gemini+fallback)"
-```
+- [ ] **Step 4: Write the prompt** `skills/audiobook-script-review.md` — instruct: given a chapter's attributed sentences + cast, return `{ ops: [...] }` for the 5 classes. **Transcribe the M5 clause verbatim:** "NEVER strip intentional non-verbal vocalizations such as \"Ah!\", \"Haah…\", \"Mmm\" — these are spoken content, not attribution tags. Only strip true speech-attribution tags (\"he said\", \"she whispered\")." For `split`: return a boundary-spanning `anchor` (copied verbatim from the sentence) + `pieceCharacterIds`. For `extract_dialogue`: return `anchor` (start of the dialogue span) + `anchorEnd` (end of it) + 3-element `pieceCharacterIds` (narrator, speaker, narrator). For `merge`: `mergeIds` of adjacent same-speaker narrator sentences. For `fix_emotion`: only when the current emotion is clearly wrong; `emotion` ∈ neutral|whisper|angry|excited|sad. Always a one-line `rationale`. Output JSON only.
+- [ ] **Step 5: Write the M5 snapshot test** `skills/audiobook-script-review.test.ts` — read the skill file, assert it contains the vocalization-protection clause (so the constraint can't silently disappear). (Abstention is model behavior — this snapshot is the automated guard; full behavioral check is manual/eval, noted in the spec.)
+- [ ] **Step 6: Write the impl test** `script-review.test.ts` — copy the two-schema `runStage` HTTP-mock block from `ollama.test.ts`; mock the chat layer to return a canned `{ops:[...]}`; assert `runScriptReviewChapter` returns the parsed ops + writes the inbox/outbox handoff. Run → fail (before Step 3 lands for the engine under test) → pass.
+- [ ] **Step 7: Run → pass.** `npm run test:server -- script-review.test.ts` + `npm test -- skills/audiobook-script-review.test.ts`.
+- [ ] **Step 8: Commit** `feat(server): runScriptReviewChapter Ollama+Gemini impls + skill + M5 guard`.
 
 ### Task 8: The SSE endpoint `POST /api/books/:bookId/script-review`
 
-**Files:**
-- Create: `server/src/routes/script-review.ts` (copy `annotate-emotion.ts` structure)
-- Modify: `server/src/app.ts` (mount the router under `/api/books`, beside `annotateEmotionRouter`)
-- Modify: `openapi.yaml` (add the path entry, mirroring the annotate-emotion path)
-- Test: `server/src/routes/script-review.test.ts`
+**Files:** Create `server/src/routes/script-review.ts` (copy `annotate-emotion.ts`); Modify `server/src/app.ts` (mount under `/api/books`), `openapi.yaml` (transcribe the path); Test `server/src/routes/script-review.test.ts` (mirror `annotate-emotion.test.ts`).
 
-**Interfaces:**
-- Consumes: `selectAnalyzerForPhase`, `loadPostFoldSentencesByChapter`, `runScriptReviewChapter`.
-- Produces: SSE events `phase` / `ops` (`{ kind:'ops', chapterId, ops }`) / `throttle` / `chapter-failed` / `error` / `result`. Accepts `{ chapterId?: number, model?: string }` in the POST body.
+**Interfaces:** Body `{ chapterId?: number; model?: string }`. SSE events: `phase` / `ops` (`{kind:'ops', chapterId, ops}`) / `throttle` / `chapter-failed` / `error` / `result`.
 
-- [ ] **Step 1: Write the failing route test** (supertest against the app; mock the analyzer to emit a canned envelope; assert the SSE stream contains an `ops` event and a `result`). Mirror `annotate-emotion.test.ts`.
+- [ ] **Step 1: Write the failing route test** — supertest POST; mock the analyzer to emit a canned envelope; assert the SSE stream contains an `ops` event + a `result`; assert `{chapterId: N}` limits the pass to one chapter.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** — copy `annotate-emotion.ts`; rename router/path; honor optional `req.body.chapterId` (filter `chapterIds` to `[chapterId]`); build the prompt from the chapter's post-fold sentences + **post-fold roster**; **overflow:** if a chapter's prompt would exceed the model budget, chunk-with-overlap (reuse the `stage2-chunk.ts` budget constant) — **OR**, if deferring, emit a `chapter-failed` with a clear "chapter too large — split it first" message and state this assumption in a code comment. Call `runScriptReviewChapter`; emit `{kind:'ops', chapterId, ops: result.ops}`. Keep the SSE scaffolding/keep-alive/abort/`DailyQuotaExhaustedError`/per-chapter `chapter-failed`.
+- [ ] **Step 4: Mount + openapi** — `app.use('/api/books', scriptReviewRouter);` (after annotate-emotion). **Transcribe** the `openapi.yaml` path block (copy the annotate-emotion path operation; change the path to `/books/{bookId}/script-review`; add `requestBody` with optional `chapterId: integer` + `model: string`; document the `text/event-stream` response). OpenAPI is the source of truth — write it out, don't describe it.
+- [ ] **Step 5: Run → pass.**
+- [ ] **Step 6: Commit** `feat(server): POST /api/books/:bookId/script-review SSE endpoint`.
 
-- [ ] **Step 2: Run → fail.** Run: `npm run test:server -- script-review.test.ts`
+### Task 9: Frontend api client (`reviewScript`) — real + mock + explicit stream test
 
-- [ ] **Step 3: Implement the route** — copy `annotate-emotion.ts` verbatim, then: rename the router/path to `script-review`; honor an optional `req.body.chapterId` (filter `chapterIds` to `[chapterId]` when present); build the prompt from the chapter's post-fold sentences + the post-fold roster; call `runScriptReviewChapter`; emit `{ kind:'ops', chapterId, ops: result.ops }` instead of `annotation`. Keep the same SSE scaffolding, keep-alive, abort, `DailyQuotaExhaustedError` handling, and per-chapter `chapter-failed` resilience.
+**Files:** Modify `src/lib/api.ts` (`realReviewScript`, `mockReviewScript`, `ReviewScriptOpts`/`Result`/`Error`, register in both `real`/`mock`); Test `src/lib/api.test.ts`.
 
-- [ ] **Step 4: Mount + openapi** — `app.use('/api/books', scriptReviewRouter);` (after annotate-emotion); add the `openapi.yaml` path block (copy annotate-emotion's, adjust path + request body `chapterId?`).
+**Interfaces:** `api.reviewScript(bookId, { chapterId?, model?, signal?, onPhase?, onThrottle?, onOps? }): Promise<{ reviewedChapters: number; totalOps: number }>`; `onOps({ chapterId, ops: ReviewOp[] })`.
 
-- [ ] **Step 5: Run → pass.** Run: `npm run test:server -- script-review.test.ts` → PASS.
+- [ ] **Step 1: Write the failing test EXPLICITLY** (there is no detect-emotions test to mirror — write the fetch stub):
 
-- [ ] **Step 6: Commit**
-
-```bash
-git add server/src/routes/script-review.ts server/src/app.ts openapi.yaml server/src/routes/script-review.test.ts
-git commit -m "feat(server): POST /api/books/:bookId/script-review SSE endpoint"
+```typescript
+it('parses the SSE stream and surfaces ops', async () => {
+  const chunks = [
+    'data: {"kind":"ops","chapterId":1,"ops":[{"id":1,"op":"strip_tag","newText":"x","rationale":"tag"}]}\n\n',
+    'data: {"kind":"result","reviewedChapters":1,"totalOps":1}\n\n',
+  ].map((s) => new TextEncoder().encode(s));
+  let i = 0;
+  const body = { getReader: () => ({ read: async () => (i < chunks.length ? { done: false, value: chunks[i++] } : { done: true, value: undefined }) }) };
+  global.fetch = (async () => ({ ok: true, status: 200, body })) as never;
+  const seen: unknown[] = [];
+  const res = await api.reviewScript('b1', { onOps: (e) => seen.push(e) });
+  expect(seen).toHaveLength(1);
+  expect(res.totalOps).toBe(1);
+});
 ```
-
-### Task 9: Frontend api client (`reviewScript`) — real + mock
-
-**Files:**
-- Modify: `src/lib/api.ts` (add `realReviewScript`, `mockReviewScript`, `ReviewScriptOpts`/`Result`/`Error`, register in both `real`/`mock`)
-- Test: `src/lib/api.test.ts` (mock `fetch` streaming, mirror the detect-emotions test if present)
-
-**Interfaces:**
-- Produces: `api.reviewScript(bookId, { chapterId?, model?, signal?, onPhase?, onThrottle?, onOps? }): Promise<{ reviewedChapters: number; totalOps: number }>` where `onOps({ chapterId, ops })` delivers `ReviewOp[]`.
-
-- [ ] **Step 1: Write the failing test** (mock a streamed SSE body with one `ops` + `result`; assert `onOps` fired and the result returned). Mirror `realDetectEmotions`.
 
 - [ ] **Step 2: Run → fail.**
-
-- [ ] **Step 3: Implement** — copy `realDetectEmotions`/`mockDetectEmotions` verbatim; change the URL to `/script-review`; send `{ chapterId, model }`; handle `kind:'ops'` → `onOps`. Register `reviewScript: realReviewScript` / `reviewScript: mockReviewScript` in both api objects.
-
+- [ ] **Step 3: Implement** — copy `realDetectEmotions`/`mockDetectEmotions`; change URL to `/script-review`; send `{ chapterId, model }`; handle `kind:'ops'` → `onOps`. Register `reviewScript` in both `real` and `mock` api objects.
 - [ ] **Step 4: Run → pass.**
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add src/lib/api.ts src/lib/api.test.ts
-git commit -m "feat(frontend): api.reviewScript client (real+mock)"
-```
+- [ ] **Step 5: Commit** `feat(frontend): api.reviewScript client (real+mock) + SSE stream test`.
 
 ---
 
 ## Phase 3 — Operator UX
 
-### Task 10: The dedicated suggestions slice (non-polled, bookId-keyed)
+### Task 10: Dedicated suggestions slice (non-polled, bookId-keyed)
 
-**Files:**
-- Create: `src/store/script-review-slice.ts`
-- Modify: `src/store/index.ts` (register `scriptReview: scriptReviewSlice.reducer`)
-- Test: `src/store/script-review-slice.test.ts`
+**Files:** Create `src/store/script-review-slice.ts`; Modify `src/store/index.ts` (register `scriptReview`); Test `src/store/script-review-slice.test.ts`.
 
-**Interfaces:**
-- Produces: state `{ byBook: Record<string, { ops: ReviewOp[]; selected: Record<string, boolean>; unappliable: Array<{ op: ReviewOp; reason: string }> } | undefined> }`; actions `setReview({ bookId, ops, unappliable })`, `toggleOp({ bookId, key, on })`, `toggleClass({ bookId, op, on })`, `clearReview({ bookId })`; selector `selectActiveReview(state, bookId)` reads ONLY that book's bucket. (Op key = `${chapterId}:${id}:${op}`.)
+**Interfaces:** State `{ byBook: Record<string, { ops: ReviewOp[]; unappliable: Array<{op,reason}>; selected: Record<string, boolean> } | undefined> }`; actions `setReview`, `toggleOp`, `toggleClass`, `clearReview`; selector `selectActiveReview(state, bookId)` reads ONLY that book's bucket. Op key = `${chapterId}:${id}:${op}` (chapterId carried on the ReviewOp envelope from the `ops` SSE event).
 
-- [ ] **Step 1: Write the failing test** — `setReview` then `selectActiveReview` returns only that book's ops; a second book's `setReview` doesn't wipe the first; `toggleClass` flips all ops of a class.
-
+- [ ] **Step 1: Write the failing test** — `setReview` defaults all selected ON; `selectActiveReview` returns only that book; a second book's `setReview` doesn't wipe the first; `toggleClass` flips all of a class.
 - [ ] **Step 2: Run → fail.**
-
-- [ ] **Step 3: Implement the slice** (RTK `createSlice`, Immer; default-ON selection for all Unit A classes — initialize `selected[key] = true` in `setReview`).
-
-- [ ] **Step 4: Register in `store/index.ts`** under the reducer map (beside `revisions`).
-
+- [ ] **Step 3: Implement** (RTK, Immer; init `selected[key]=true` in `setReview`).
+- [ ] **Step 4: Register** in `store/index.ts` reducer map beside `revisions`.
 - [ ] **Step 5: Run → pass.**
+- [ ] **Step 6: Commit** `feat(frontend): dedicated non-polled script-review suggestions slice`.
 
-- [ ] **Step 6: Commit**
+### Task 11: `ScriptReviewDiff` modal + "Review Script" trigger + RPD warning
 
-```bash
-git add src/store/script-review-slice.ts src/store/index.ts src/store/script-review-slice.test.ts
-git commit -m "feat(frontend): dedicated non-polled script-review suggestions slice"
-```
+**Files:** Create `src/components/script-review-diff.tsx`; Modify `src/views/manuscript.tsx` (button + run/stream wiring); Test `src/components/script-review-diff.test.tsx`.
 
-### Task 11: `ScriptReviewDiff` modal + the "Review Script" trigger
+**Interfaces:** Consumes `selectActiveReview`, `scriptReviewActions`, `dispatchAcceptedOps`, `planApply`, `changeLogActions.bumpBoundaryMove`.
 
-**Files:**
-- Create: `src/components/script-review-diff.tsx`
-- Modify: the manuscript editing surface (`src/views/manuscript.tsx`) — add the "Review Script" button + the run/stream wiring (calls `api.reviewScript`, runs `planApply` on completion, dispatches `setReview`)
-- Test: `src/components/script-review-diff.test.tsx`
-
-**Interfaces:**
-- Consumes: `selectActiveReview`, `scriptReviewActions`, `dispatchAcceptedOps`, `planApply`, `manuscriptActions`, `changeLogActions.bumpBoundaryMove`.
-- Behaviour: groups rows by class; per-class + per-change toggles; before→after preview; `Apply` runs `planApply` against the LIVE manuscript (re-validates at accept — TOCTOU), `dispatchAcceptedOps` for the selected appliable set, emits `bumpBoundaryMove` per affected chapter, then `clearReview`.
-
-- [ ] **Step 1: Write the failing component test** — render with a seeded review (one `strip_tag`, one `fix_emotion`), toggle one off, click Apply, assert the expected reducer actions dispatched (spy the store) and the modal cleared.
-
-- [ ] **Step 2: Run → fail.** Run: `npm test -- src/components/script-review-diff.test.tsx`
-
-- [ ] **Step 3: Implement the modal** — follow the DriftReport accept-reject layout pattern; use design tokens (no hex). On Apply: `const { appliable } = planApply(selectedOps, liveSentences); dispatchAcceptedOps(dispatch, appliable, liveSentences, { onBoundaryMove: (c) => dispatch(changeLogActions.bumpBoundaryMove({ chapterId: c, count: 1 })) }); dispatch(scriptReviewActions.clearReview({ bookId }));`
-
-- [ ] **Step 4: Add the "Review Script" button** to `manuscript.tsx` — min-h-[44px] sm:min-h-0 touch target; on click, stream `api.reviewScript(bookId, { chapterId: currentChapterId, onOps })`, accumulate ops, then `planApply` + `dispatch(setReview(...))` to open the modal.
-
+- [ ] **Step 1: Write the failing component test** — render with a seeded review (one `strip_tag`, one `fix_emotion`), toggle one off, click Apply; assert the kept op's reducer action dispatched (real store), `bumpBoundaryMove` fired for the chapter, and the review cleared.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement the modal** — DriftReport accept-reject layout; group by class; per-class + per-change toggles; before→after; design tokens (no hex). On Apply: `const live = selectLiveSentences(); const { appliable } = planApply(selectedOps, live); dispatchAcceptedOps(dispatch, appliable, live, { onBoundaryMove: (c) => dispatch(changeLogActions.bumpBoundaryMove({ chapterId: c, count: 1 })) }); dispatch(scriptReviewActions.clearReview({ bookId }));` (re-running `planApply` against LIVE sentences at Apply time is the TOCTOU guard.)
+- [ ] **Step 4: Add the "Review Script" button** to `manuscript.tsx` — `min-h-[44px] sm:min-h-0`; per-chapter by default (`chapterId: currentChapterId`); a whole-book opt-in that, when the book's chapter count exceeds the selected model's RPD (`rate-limit.ts` caps), shows a warning ("This book has N chapters; the selected model allows only M reviews/day — switch to a local model or review per chapter"). Stream `api.reviewScript`, accumulate ops, then `planApply` + `dispatch(setReview)` to open the modal. Model is **per-run** (passed to `reviewScript`); no persisted review-model knob in Unit A (descope; noted in spec follow-ups).
 - [ ] **Step 5: Run → pass.**
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add src/components/script-review-diff.tsx src/views/manuscript.tsx src/components/script-review-diff.test.tsx
-git commit -m "feat(frontend): ScriptReviewDiff modal + Review Script trigger"
-```
+- [ ] **Step 6: Commit** `feat(frontend): ScriptReviewDiff modal + Review Script trigger + RPD guard`.
 
 ### Task 12: E2E — per-chapter review → accept → stale
 
-**Files:**
-- Create: `e2e/script-review.spec.ts`
-- Modify: `e2e/responsive/coverage.spec.ts` (append a case for the new modal)
-- (mock-mode driven: `mockReviewScript` returns a deterministic op so the flow is testable without an LLM)
+**Files:** Create `e2e/script-review.spec.ts`; Modify `e2e/responsive/coverage.spec.ts`. `mockReviewScript` returns a deterministic op so the flow runs without an LLM.
 
-- [ ] **Step 1: Write the spec** — open a book to the manuscript view, click "Review Script", assert the `ScriptReviewDiff` modal opens with the mock op, accept it, assert the sentence text/emotion updated and (navigating to Generate) the chapter shows the stale badge.
+- [ ] **Step 1: Write the spec** — open a book to the manuscript view; click "Review Script"; assert the modal opens with the mock op; accept; assert the sentence updated and (navigating to Generate) the chapter shows the stale badge.
+- [ ] **Step 2: Run** `npm run test:e2e -- script-review.spec.ts` → PASS (chromium).
+- [ ] **Step 3: Commit** `test(e2e): script-review per-chapter accept flow`.
 
-- [ ] **Step 2: Run** — `npm run test:e2e -- script-review.spec.ts`. Expected: PASS (chromium).
+### Task 13: Full verify + hygiene + PR
 
-- [ ] **Step 3: Commit**
-
-```bash
-git add e2e/script-review.spec.ts e2e/responsive/coverage.spec.ts
-git commit -m "test(e2e): script-review per-chapter accept flow"
-```
-
-### Task 13: Full verify + plan/index hygiene
-
-- [ ] **Step 1:** Run `npm run verify` (typecheck + all tests + e2e + build). Fix any red leg in-scope; surface anything pre-existing to the user rather than bundling.
-- [ ] **Step 2:** Move the spec to `status: active`/`stable` per the project's shipping checklist; add the spec/plan to `docs/features/INDEX.md` if it's tracked there. Fill the spec's Ship notes when merged.
-- [ ] **Step 3:** Open the PR with `Closes #998` (Unit A scope), `## Summary` + `## Test plan` filled, linking the spec.
+- [ ] **Step 1:** `npm run verify` (typecheck + all tests + e2e + build). Fix in-scope red; surface pre-existing failures to the user rather than bundling.
+- [ ] **Step 2:** Set the spec `status: active`. (No `docs/features/` regression plan owed — see Global Constraints. No `INDEX.md` entry, which tracks `docs/features/` plans only.) Fill the spec's Ship notes when merged → then `stable`.
+- [ ] **Step 3:** Open the PR: title `feat(frontend,server): fs-58 LLM Script Review (Unit A)`, `Closes #998`, `## Summary` + `## Test plan` filled, linking the spec.
 
 ---
 
-## Self-Review (completed by plan author)
+## Self-Review (completed by plan author, post-plan-review)
 
-**Spec coverage:** every §3 class has an apply path (Task 1 `strip_tag`; Task 4/5 `split`/`extract`; Task 2 `merge`; existing `setSentenceEmotion` `fix_emotion`); §5.3 unified staleness = Task 3; §5.6 op-validation/TOCTOU = Task 4; §4.2 ~16-site pass = Tasks 6-9; §4.3 flat-envelope = Task 6; §5.5 dedicated slice = Task 10; §6 UX = Task 11; §8 tests distributed per task (merge-resurrection = Task 2; staleness gaps = Task 3; anchor normalization + TOCTOU = Task 4; M5 abstention = Task 7 prompt + a Task-7 test; E2E = Task 12); §9 follow-ups = Task 0. **No api-types regen** (Global Constraints) — Unit A persists no new type.
+**Spec coverage:** every §3 class has an apply path (Task 1 strip_tag; Task 4/5 split + two-anchor extract; Task 2 merge; existing setSentenceEmotion fix_emotion); staleness (revised: §5.3 → boundary_move + OR-gate) = Task 3; op-validation/TOCTOU = Task 4; the ~16-site pass = Tasks 6-9 (interface/fallback 7a; impls/skill/registry 7b; protocol HandoffKey 7a; openapi 8; api real+mock 9; slice+store 10); §5.5 dedicated slice = Task 10; §6 UX = Task 11; per-chapter overflow = Task 8 Step 3 (handle or stated assumption); RPD warning = Task 11 Step 4; merge tombstone persistence = Task 2b. Follow-ups = Task 0.
 
-**Placeholder scan:** the prompt content (Task 7 Step 7) and the openapi block (Task 8 Step 4) are described, not transcribed verbatim — these are content-authoring steps, not code with a fixed answer; every code step shows real code.
+**Plan-review fixes folded:** resolveAnchorOffset index-map (no whitespace-collapse) + exact-offset test (Task 4); extract_dialogue two-anchor (Tasks 4/5/6/7b); test scaffolds set manuscriptId via a state literal (Tasks 1/2); merge re-analysis test reaches the tombstone (Task 2); tombstone persisted + book-scoped (Task 2b); content-hash dropped for boundary_move+OR-gate (Task 3); Task 3/7 split for scope/TDD; ollama scriptReviewSchema import (Task 7b); openapi + M5 prompt clause transcribed (Tasks 8/7b); missing tests added (split-staleness via Task 3, planApply TOCTOU + merge-rejection + invalid-enum in Task 4, all-5 apply-via-real-reducer + ID alloc in Task 5, explicit SSE stream test in Task 9, M5 snapshot in Task 7b); the "distinct Ollama grammar schema" gap is a non-issue (fs-33 passes one schema for both — Task 7b mirrors it).
 
-**Type consistency:** `ReviewOp` (frontend, Task 4) and `ScriptReviewOp` (server Zod, Task 6) carry the same fields; `setSentenceText` / `mergeSentences` / `setSentenceEmotion` / `splitSentence` payloads match the reducers; `isChapterStaleSinceRender` signature is consistent across Tasks 3's definition and `generation.tsx` use.
+**Type consistency:** `ReviewOp` defined once (Task 4), consumed by Tasks 5/9/10/11; server `ScriptReviewOp` (Task 6) is the structural parallel; reducer payloads match across Tasks 1/2/5; `resolveAnchorOffset` signature consistent. No forward references (Task 4 precedes all `ReviewOp` consumers; Task 6 precedes the server impl in 7b).

--- a/docs/superpowers/specs/2026-06-23-fs58-llm-script-review-design.md
+++ b/docs/superpowers/specs/2026-06-23-fs58-llm-script-review-design.md
@@ -1,6 +1,6 @@
 ---
 title: 'fs-58 — LLM Script Review, Unit A: annotation mechanics + emotion correction'
-status: draft
+status: active
 date: 2026-06-23
 issue: '#998'
 related:

--- a/docs/superpowers/specs/2026-06-23-fs58-llm-script-review-design.md
+++ b/docs/superpowers/specs/2026-06-23-fs58-llm-script-review-design.md
@@ -1,254 +1,361 @@
 ---
-title: fs-58 — LLM Script Review (premium annotation-QA pass)
+title: fs-58 — LLM Script Review (annotation-QA second pass)
 status: draft
 date: 2026-06-23
 issue: '#998'
 related:
-  - 2026-06-22-expressive-tts-instruct-tiers-design.md (§4.6 — fs-58's original sketch; this spec supersedes it)
-  - fs-56 (#996) — per-line `instruct` field; owns the deferred instruct-validation class
-  - fs-25 (#479) — per-quote emotion enum (the field `fix_emotion` repairs)
-  - fs-33 (#596) — emotion-only backfill pass (precedent for a second analyzer pass)
-  - Russian stage-2 attribution under-production (plan 221) — the attribution-quality pain `reattribute` targets
+  - 2026-06-22-expressive-tts-instruct-tiers-design.md (§4.6 — fs-58's original sketch; this spec supersedes it, incl. placement)
+  - fs-56 (#996) — per-line `instruct` field; owns the deferred `validate_instruct` class
+  - fs-33 (#596) — emotion-only backfill pass; emotion correction is routed here, NOT duplicated in fs-58
+  - fs-35 — per-chapter scoping follow-up for the whole-book emotion pass (precedent: whole-book is too coarse)
+  - fs-25 (#479) — per-quote emotion enum
+  - Russian stage-2 attribution under-production (plan 221) — the attribution pain `reattribute` targets
+  - com-1 — Cast Pass entitlement seam (no gate in fs-58; see §9)
 inspiration: github.com/Finrandojin/alexandria-audiobook (Alexandria — LLM Script Review)
 ---
 
 # fs-58 — LLM Script Review
 
+> **Supersedes** the §4.6 sketch in `2026-06-22-expressive-tts-instruct-tiers-design.md`, **including its
+> placement** ("before `manuscript-edits.json` is written"). This spec runs the pass as a standalone job
+> *over* `manuscript-edits.json`, runnable anytime (incl. post-generation) — see §4.1.
+>
+> **Re-scoping note (2026-06-23):** issue #998 / BACKLOG describe *five* classes + "engine-agnostic
+> (no GPU)." This spec ships **six live classes** (drops `fix_emotion` → fs-33; defers `validate_instruct`
+> → fs-56; adds `reattribute` + `flag_nonstory`) and corrects "no GPU" to "no TTS-synthesis engine"
+> (§4.4). **#998 + the BACKLOG row must be updated to match before this leaves `draft`.**
+
 ## 1. Summary
 
-An **optional, operator-triggered, premium QA pass** that runs a second LLM over already-attributed
-sentences and repairs common annotation errors, presented as an **accept/reject diff**. It is modeled
-as **"just another editor"**: every accepted change produces the same kind of edit a human makes in the
-confirm stage and is applied through the *existing* manual-edit + audio-invalidation machinery. The LLM
-only *proposes*; the server applies deterministically and owns all sentence-ID allocation.
+An **optional, operator-triggered, per-chapter QA pass** that runs a second LLM over already-attributed
+sentences and repairs common annotation errors, presented as an **accept/reject diff**. The LLM only
+*proposes*; the **server applies deterministically** and owns all sentence-ID allocation. It is
+**additive** — off → today's behaviour, exactly.
 
-It is **additive** — off → today's behaviour, exactly. It reuses the **analyzer** compute path (no TTS
-engine), so it is independent of Kokoro/Coqui/Qwen and shippable on its own.
+"Engine-agnostic" means **TTS-engine-agnostic** (no Kokoro/Coqui/Qwen load) — *not* GPU-free: it reuses
+the analyzer compute path (local Ollama on GPU, or Gemini cloud). See §4.4.
 
 ## 2. Background
 
-**Source feature (Alexandria):** an optional second pass fixing annotation-error classes after the
-initial attribution. Castwright's Phase-1 attribution (`server/src/routes/analysis.ts`, the
-`runStage2Chapter` analyzer call) produces, per chapter, a list of `Sentence`s:
-
-```
-{ id, chapterId, characterId, text, confidence?, emotion? }   // emotion = fixed 5-value enum
-```
-
+Phase-1 attribution (`server/src/routes/analysis.ts`, the `runStage2Chapter` analyzer call) produces,
+per chapter, `Sentence`s `{ id, chapterId, characterId, text, confidence?, emotion?, startMs?, endMs? }`,
 written (post-fold/dedup) to `manuscript-edits.json` at `analysis.ts:~4043`. Phase-1 is good but not
-perfect: it leaks attribution tags into dialogue, over-/under-splits sentences at narrator↔dialogue
-boundaries, mis-assigns speakers in tagless back-and-forth, occasionally sets a wrong `emotion`, and
-treats front/back-matter residue (page numbers, headers) as narration. fs-58 is the targeted repair
-pass for exactly those errors.
+perfect: it leaks attribution tags into dialogue, over-/under-splits at narrator↔dialogue boundaries,
+mis-assigns speakers in tagless back-and-forth, and treats front/back-matter residue (page numbers,
+headers) as narration. fs-58 is the targeted repair pass for those errors.
 
-There is a strong in-repo precedent: **fs-33's emotion-only backfill** (`emotionAnnotationSchema`,
-`server/src/handoff/schemas.ts`) already runs a second analyzer pass over attributed sentences and
-returns only `{ sentenceId, emotion }`. fs-58 generalises that shape to multiple error classes.
+**Precedent:** fs-33's emotion-only backfill (`emotionAnnotationSchema`, `server/src/handoff/schemas.ts`)
+already runs a second analyzer pass over attributed sentences and returns `{ sentenceId, emotion }`.
+fs-58 generalises that *shape* (a second per-chapter analyzer pass) to additional error classes.
+**Emotion correction stays with fs-33** — fs-58 does not duplicate it (§3, §10).
 
-## 3. Error classes (v1 = 7 live + 1 deferred)
+## 3. Error classes (v1 = 6 live + 1 deferred + 1 routed)
 
-Two tiers. **Mechanics** classes fix sentence *shape*; **content** classes fix *who/how*. The premium
-value is in the content tier — that is where "wrong speaker / wrong delivery / junk read aloud" lives.
+Two tiers. **Mechanics** classes fix sentence *shape*; **content** classes fix *who*.
 
 **Mechanics (structural):**
-1. `strip_tag` — remove an attribution tag ("she said") that leaked into dialogue text. *Field delta, text-only.*
-2. `split` — split narration out of a dialogue entry. *Structural.*
+1. `strip_tag` — remove an attribution tag ("she said") that leaked into dialogue text. *Field delta (newText).*
+2. `split` — split narration out of a dialogue entry. *Structural (content-addressed pieces, §4.3).*
 3. `extract_dialogue` — pull dialogue out of a narrator run into its own sentence with a `characterId`. *Structural.*
-4. `merge` — merge over-split narrator entries back into one. *Structural.*
+4. `merge` — merge over-split narrator entries into one. *Structural.*
 
 **Content (QA):**
-5. `reattribute` — re-assign a dialogue line to the correct character (incl. tagless turn-taking runs).
-   *Field delta on `characterId`; constrained to the existing cast roster — never invents a character.*
-6. `fix_emotion` — correct an obviously-wrong `emotion` enum value (shouted line left `neutral`; calm
-   line marked `angry`). *Field delta on `emotion`.*
-7. `flag_nonstory` — flag front/back-matter residue and artifact lines (page numbers, headers, empty/
-   punctuation-only) that Phase-1 mislabeled as narration, so the TTS never reads "Page 47" aloud.
-   *Soft `excludeFromSynthesis` flag — no deletion, no ID churn.*
+5. `reattribute` — re-assign a dialogue line to the correct **existing** cast member (incl. tagless
+   turn-taking). *Field delta on `characterId`.* Constrained to the **post-fold** roster (§4.2); never
+   invents a character. When the correct speaker is **off-roster** (e.g. folded into `unknown-male`), the
+   model instead emits a **read-only `reattribute_blocked` advisory** (rationale only, no apply, no roster
+   mutation) so the operator can decide to add a cast member — converting a silent mis-attribution into a
+   signal.
+6. `flag_nonstory` — flag front/back-matter residue and artifact lines (page numbers, headers, empty/
+   punctuation-only) that Phase-1 mislabeled as narration, via a soft `excludeFromSynthesis` flag (no
+   deletion, no ID churn). **Constrained** to lines whose `characterId` is `narrator` AND that match
+   artifact signatures (digit-only, header-case, page-number patterns) — never a line the model would
+   otherwise `reattribute`, and never a short legitimate narration/dialogue line ("Silence.", "Run!").
 
-**Deferred — `validate_instruct`** (the 8th class). The per-sentence free-text `instruct` field does
-not exist yet (fs-56 owns it; only voice-design-level `instruct` exists today). The class is therefore
-**parked in fs-56's scope** with a bidirectional cross-link: **if fs-56 ships the per-sentence
-`instruct` field before fs-58, the instruct-validation class moves back here into Script Review to
-implement.** No dead code ships in fs-58.
+**Routed — `fix_emotion`:** emotion correction is **out of fs-58**; it belongs to fs-33's emotion pass. If
+fs-33 needs a "correct an existing wrong emotion" mode (vs. backfill-only), that is filed against fs-33
+(§9). Rationale: avoid a second, divergent emotion path (Simplicity-first); and emotion staleness has its
+own 3-way-gated rule (`sentence-emotion-control.tsx:77-87`) that fs-33 already lives next to.
 
-**M5 carve-out (from the parent spec's adversarial review):** the prompt explicitly instructs the model
-**never to strip intentional non-verbal vocalizations** ("Ah!", "Haah…") as if they were attribution
-tags — they are legitimate content, not annotation noise. This is a hard, tested constraint on
-`strip_tag` (and on `flag_nonstory`, which must not flag a vocalization line as junk).
+**Deferred — `validate_instruct`:** the per-sentence free-text `instruct` field does not exist yet
+(fs-56 owns it). **Parked in fs-56's scope** with a bidirectional cross-link filed as a tracked issue
+(§9) — if fs-56 ships the field before fs-58, the class moves back here. No dead code ships in fs-58.
+
+**M5 carve-out:** the prompt **never strips intentional non-verbal vocalizations** ("Ah!", "Haah…") as
+attribution tags, and `flag_nonstory` never flags a vocalization line as junk. Hard, tested constraint.
 
 ## 4. Architecture & flow
 
 ### 4.1 Where it slots
 
-A **standalone job**, *not* inside the analyse SSE — because it must be runnable **anytime**, including
-after audio has been generated:
+A **standalone, per-chapter job** (not inside the analyse SSE), runnable **anytime** incl. post-generation:
 
-- New endpoint **`POST /api/books/:bookId/script-review`** with its own SSE stream, mirroring the
-  analysis SSE event grammar (`phase` / per-chapter progress / `result`).
-- Triggerable from the confirm/cast stage **and** post-generation — wherever the manuscript is editable.
+- New endpoint **`POST /api/books/:bookId/script-review`** taking an **optional `chapterId`** (default:
+  the chapter being edited; whole-book is opt-in). Own SSE stream mirroring the analysis grammar
+  (`phase` / per-chapter progress / `result`). Per-chapter default keeps the diff usable at novel scale
+  (fs-35 precedent: a whole-book-only pass is too coarse).
+- Mounts under `/api`, so it **inherits `requireLanToken` + `requireSameOrigin` CSRF** (`app.ts:111-114`)
+  — no per-route auth needed.
+- **Non-sticky / no resume** (like fs-33's annotate-emotion): a disconnect mid-run aborts; re-run from
+  scratch. Set this UX expectation.
 
-### 4.2 The review pass
+### 4.2 The review pass — interface touch-list (NOT "wholesale reuse")
 
-Per chapter, reusing the analyzer call path wholesale:
+The `Analyzer` interface is **closed and per-stage** (`index.ts:62-94`); adding a pass means a ~7-site
+extension in lockstep (exactly what fs-33 did):
+1. `runScriptReviewChapter` on the `Analyzer` interface (`index.ts`).
+2. `OllamaAnalyzer` impl (`ollama.ts`) — grammar via `format`/`z.toJSONSchema`.
+3. `GeminiAnalyzer` impl (`gemini.ts`).
+4. `FallbackAnalyzer` delegation (`index.ts`).
+5. The review op/delta schema pair (`schemas.ts`).
+6. A skill/prompt file + prompt-registry id.
+7. A `HandoffKey`.
+8. The route (§4.1).
 
-- `selectAnalyzer({ model })` → local Ollama-with-Gemini-fallback (`FallbackAnalyzer`), same
-  `RateLimiter`, same schema-constrained JSON output, same `onThrottle` / `signal` plumbing
-  (`server/src/analyzer/`).
-- **Dedicated review-model knob** — a separate user setting so review can point at a stronger model than
-  bulk attribution; **defaults to the analyzer's configured model** when unset.
-- **Input:** the chapter's current `sentences[]` (post-fold, from `manuscript-edits.json`) + the cast roster.
+- Model selection: reuse `selectAnalyzer` / per-phase selection (`select-analyzer.ts`,
+  `isPerPhaseModelSelectionActive`) with a **dedicated review-model knob** (separate user setting;
+  defaults to the analyzer's configured model).
+- **Input:** the target chapter's current `sentences[]` + the **post-fold** cast roster (the cache retains
+  pre-fold descriptor ids, `book-state.ts:296-304`; passing the post-fold roster prevents every
+  `reattribute` to a folded id being dropped as off-roster).
 
-### 4.3 Output format — hybrid
+### 4.3 Output format — flat schema, content-addressed structural ops
 
-The LLM returns, per chapter, a list of proposed edits in two shapes. **The LLM never invents sentence
-IDs**; it only references existing `id`s. The server allocates any new IDs.
+**Flat schema, no discriminated union.** Reason: the **Gemini path does not send `responseSchema`** today
+(`gemini.ts:561-566` sets only `responseMimeType`) — output is free-form JSON repaired by `parseAndValidate`.
+A tagged union with integer offsets is unsafe in that regime. Two options, decided at plan time:
+(a) keep a **flat** array of edits in the working free-form-JSON regime (preferred), or (b) **wire
+`config.responseSchema` into `gemini.ts`** as an explicit prerequisite (verify no regression to existing
+passes). **Stop asserting Gemini is schema-constrained until (b) lands.**
 
-- **Field deltas** keyed by existing `id` — `strip_tag` (newText), `reattribute` (characterId),
-  `fix_emotion` (emotion), `flag_nonstory` (exclude).
-- **Explicit structural ops** referencing existing `id`s — `split(id, offset, pieceCharacterIds[])`,
-  `extract_dialogue(id, span, characterId)`, `merge(ids[])`.
+Each edit is one row: `{ id, op, ...payload, rationale, confidence }`. **The LLM never invents sentence
+IDs.** Payloads:
+- **Field deltas** keyed by existing `id`: `strip_tag` (newText), `reattribute` (characterId),
+  `flag_nonstory` (exclude=true).
+- **Structural ops, content-addressed (no offsets):** `split`/`extract_dialogue` return the resulting
+  text **pieces verbatim** + per-piece `characterIds`; `merge` returns the member `ids`. The server
+  validates `normalizeWhitespace(concat(pieces)) === normalizeWhitespace(original.text)` before applying
+  — deterministic, self-validating, no character-counting. Off-roster `reattribute` → `reattribute_blocked`
+  advisory row (no payload, rationale only).
 
-This avoids array-diffing entirely (the fragile "which old ID maps to which new entry" heuristic the
-parent spec's R2-M3 warned about). Each op/delta maps to exactly one diff row.
+**Apply order (resolves same-id collisions).** Per chapter: apply **structural ops first** (merge →
+split/extract) to fix the id set, **then** field deltas against surviving ids. **Reject** (drop + log,
+surface as un-appliable) any field delta whose target id was consumed by a structural op, and any 2nd
+structural op on the same id.
 
-Every proposed edit also carries a one-line **rationale** (shown in the diff) and the **class**.
+### 4.4 Compute note
 
-### 4.4 Compute note (corrects the parent spec's "no GPU" framing)
+Reuses the **analyzer** path — local Ollama (**GPU, same footprint as Phase-1**; holds the analyzer GPU
+semaphore slot, `ollama.ts:523`) or Gemini (cloud, GPU-free). Loads **no TTS model**, adds **no new
+resident GPU model**, never co-resident with a TTS engine — clear of the parent spec's §4.7 VRAM
+invariant. On a single small (8 GB) GPU it **contends with the analyzer and is evicted-by/evicts TTS** —
+you cannot run a review pass concurrently with a generation on one small card.
 
-Script Review reuses the **analyzer** path — local Ollama (**runs on the GPU, identical footprint to
-Phase-1 attribution**) or Gemini (cloud, GPU-free). It loads **no TTS-synthesis model** (Kokoro/Coqui/
-Qwen) and adds **no new resident GPU model** beyond whatever the analyzer already uses. It is a text
-pass, never co-resident with a TTS engine — so it stays clear of the §4.7 VRAM invariant of the parent
-spec. "Engine-agnostic" means *TTS-engine-agnostic*, not *GPU-free*.
+### 4.5 Cost & latency
 
-## 5. The ID-stability & audio-invalidation contract
+Per-chapter trigger = **one LLM call per run** (book-wide = one per chapter). The free-tier RPD caps bite
+on book-wide runs: `gemini-2.5/3.5-flash` RPD **20** (`rate-limit.ts:38-40`) — a 20+-chapter book cannot
+finish in a day on those; `gemini-3.1-flash-lite` is RPD 500 / RPM 15. The **stronger** models have the
+**lowest** RPD, so the review-model knob's "point at a stronger model" actively worsens book-wide cost.
+*Spec requirement:* the UI knob **warns when (book-wide chapters > model RPD)**, and the recommended
+default is **local Ollama or a high-RPD Gemma**. The limiter serializes + emits `throttle` SSE events.
 
-The load-bearing part (parent spec M1 / R2-M3). Every accepted change is applied **server-side,
-deterministically**, writing through to `manuscript-edits.json`.
+## 5. The ID-stability & audio-staleness contract
 
-### 5.1 Field deltas (no ID change)
+The load-bearing part. Every accepted change is applied **server-side**, writing through to
+`manuscript-edits.json` as the **sole ID allocator**.
 
-`strip_tag`, `reattribute`, `fix_emotion`, `flag_nonstory` mutate the existing sentence in place by
-`id`. Trivially ID-stable.
+### 5.1 ID allocation — global, server-only
 
-### 5.2 `split` / `extract_dialogue`
+- Sentence ids are **per-chapter** (restart at 1, `stage2-chunk.ts:259`), but the reparse-survival filter
+  keeps any edit with `id > maxCacheId` where `maxCacheId` is computed over the **flattened cache across
+  all chapters** (`book-state.ts:281-284`). So new ids must be allocated from the **global** max across the
+  whole manuscript's current sentence set — **not** the per-chapter max (a per-chapter allocation would
+  mint an id ≤ global max and be orphan-filtered on the next GET, `book-state.ts:289`).
+- **Sole allocator:** the server apply read-modify-writes `manuscript-edits.json` under the existing
+  mutation serialization (`serializeQueueMutation`, `generation.ts:305-315`). The client does **not**
+  optimistically merge — it **refetches** the manuscript after apply. This kills the client+server
+  dual-allocator collision/race (two independent allocators minting the same id).
 
-- The original sentence **keeps its `id`**.
-- Each new piece is allocated `maxId+1, +2, …` — above the analyzer's max. This is exactly the rule that
-  makes user-split offspring survive re-analysis: `book-state.ts:278–295` keeps any edit whose
-  `id > maxCacheId`, and the frontend `splitSentence` reducer (`src/store/manuscript-slice.ts`) uses the
-  same `maxId+1` allocation. fs-58 reuses this rule rather than inventing one.
-- `extract_dialogue` assigns the extracted piece the dialogue `characterId`; the remainder stays narrator.
+### 5.2 Field deltas (no ID change)
 
-### 5.3 `merge` — reconciliation rule (answers R2-M3)
+`strip_tag`, `reattribute`, `flag_nonstory` mutate the existing sentence in place by `id`. ID-stable.
 
-- **Surviving `id`** = the **lowest** id in the set (the original analyzer id — maximally stable across reparse).
-- `text` = concatenated in document order, single-space joiner.
-- `characterId` = **must be identical** across the set (merge only applies to over-split *narrator* runs).
-  The apply step **validates** this and **rejects** a merge whose members disagree, rather than silently
-  picking one.
-- `emotion` = first non-neutral, else neutral; `confidence` = min (conservative).
-- Non-surviving ids are dropped.
+### 5.3 `split` / `extract_dialogue`
 
-### 5.4 Audio invalidation = the manual-edit path, made eager
+- Original keeps its `id`; each new piece gets a **global** `maxId+1, +2, …` (§5.1).
+- `extract_dialogue` assigns the extracted piece the dialogue `characterId`; remainder stays narrator.
+- **Drop `startMs`/`endMs`** on the original and all pieces — render-time timing is invalid the moment the
+  shape changes; the next render restamps. (Silently copying corrupts listen-view seek / clip-share.)
 
-Any structural op, any `reattribute`/`fix_emotion` (changes the voice/variant rendered), or
-`flag_nonstory` marks the affected chapter's audio **needs-regeneration** through the *same*
-`segments.json` ↔ live-manuscript drift mechanism that a manual sentence reallocation already trips
-(`segments.json.segments[].sentenceIds` vs the rendered speaker map). fs-58 triggers it **eagerly on
-apply** rather than waiting for the next poll. This is the operator's stated model: *"treat audio as
-needing regeneration — same as you manually change the chapter sentence allocations."*
+### 5.4 `merge` — restructure, not pure drop (re-analysis must not resurrect)
 
-### 5.5 Guards
+- Surviving `id` = **lowest** in the set; `text` = members concatenated in document order (single space).
+- **Validation:** members must share an identical `characterId` AND be **all `neutral`** (so no emotion is
+  orphaned — the parent spec's M1 forbids orphaning emotion) AND lie within **one `chapterId`**. Reject
+  otherwise (drop + log). Drop `startMs`/`endMs`.
+- **Contract requirement (the C3 hazard):** a merge must **survive a subsequent re-analysis** without
+  resurrecting the dropped ids as duplicate content. A pure drop from `manuscript-edits.json` is
+  insufficient — re-analysis re-mints the per-chapter ids and the frontend `hydrateFromAnalysis` append
+  branch (`manuscript-slice.ts:149-151`) re-adds them. **Candidate mechanism (verify at plan time):** model
+  merge/split as a server-side chapter **restructure with a remap table** (mirroring
+  `applyChapterRestructure`, `manuscript-slice.ts:378-401`, which drops un-remapped ids deterministically)
+  and/or a persisted **tombstone set** the hydrate-append branch consults. *The hydrate-append branch is
+  the corruptor and must be addressed.*
 
-1. **Server-side op validation before apply** — offset in range, referenced ids exist, merge set
-   contiguous + same characterId, `reattribute` target ∈ cast roster. Invalid ops are **dropped with a
-   logged reason**; they never corrupt state.
-2. **In-flight generation guard** — if a generation job is running on a chapter, applying review changes
-   to that chapter is **blocked/queued** (the explore map's render-stall hazard).
-3. **Apply is transactional per chapter** — a write failure applies nothing for that chapter.
+### 5.5 Audio staleness — the real lever is `boundary_move`, not a server stale flag
 
-### 5.6 Suggestion lifetime
+There is **no server-side stale flag**; staleness is **client-derived** (`stale-chapters.ts:58-70` diffs
+the render-time speaker map against the live Redux manuscript; `generation.tsx:629-646`). The only
+server-reachable lever is the **change-log `boundary_move` event** (the time-based heuristic,
+`stale-chapters.ts:18-44`, whose precondition is *"EVERY reassignment path must emit a `boundary_move`"*).
 
-Suggestions are **ephemeral per run** — computed, streamed, held client-side for review; only *accepted*
-changes write through to `manuscript-edits.json`. Persisting pending suggestions across a page reload
-(`script-review-suggestions.json`) is a **named follow-up** (§9), not v1.
+- The server apply **appends a `boundary_move` change-log event** for **every affected chapter** on:
+  any structural op, any `reattribute`, and any `flag_nonstory` exclude. The client then re-derives
+  staleness on its next manuscript refetch (which §5.1 already forces).
+- **Remove** the prior "eager server-side invalidation via the segments-map drift mechanism" claim — that
+  mechanism is client-only and carries `characterId` only.
+- **Cross-tab caveat:** manuscript mutations are **not** broadcast (`broadcast-middleware.ts:60-62`), so a
+  second open tab keeps a stale manuscript + stale-audio badges until it refetches. State this; don't
+  promise cross-tab freshness.
+
+### 5.6 Guards
+
+1. **Op validation before apply:** concat-equality for structural ops (§4.3); referenced ids exist;
+   merge same-`characterId` + all-`neutral` + same-`chapterId`; `reattribute` target ∈ **post-fold**
+   roster; ≤1 structural op per id; no field delta on a consumed id. Invalid → dropped + logged + surfaced
+   as un-appliable; never corrupt state.
+2. **In-flight generation guard (v1 = book-level):** only `isGenerationActive(bookId)` is exported
+   (`generation.ts:396`); the per-chapter registry is private. **v1 blocks apply for the whole book while
+   any generation job runs.** A chapter-level guard is a filed follow-up (§9).
+3. **Transactional per chapter** — a write failure applies nothing for that chapter.
+
+### 5.7 Suggestion lifetime & storage
+
+Ephemeral per run. Stored in a **dedicated, non-polled, bookId-keyed** slice — **NOT** `revisions.pending`,
+which `applyPoll` replaces wholesale per poll (`revisions-slice.ts:160-163`) and would wipe an in-progress
+review (and violate the concurrent-multi-book invariant). "Extends the revisions/DriftReport pattern" means
+the **UI pattern only**. Persisting suggestions across reload is a follow-up (§9).
 
 ## 6. Operator UX
 
-- A **"Review Script"** button surfaces wherever the manuscript is editable (confirm/cast stage **and**
-  post-generation). It fires `POST /api/books/:bookId/script-review`; a per-chapter progress bar reuses
-  the analysis SSE `phase` grammar.
-- Results land in a **`ScriptReviewDiff` modal**, extending the existing revisions / `DriftReport`
-  accept-reject pattern (`src/store/revisions-slice.ts`).
-- **Grouped by the 7 classes**, with a **per-class accept/reject** toggle and **drill-down to per-change
-  toggles** within a class. Each change shows **before → after** (text / characterId / emotion / exclude),
-  the **class**, and the LLM **rationale**.
-- **Default selection:** all suggestions pre-selected; the operator deselects what it doesn't want
-  (efficient for a bulk QA pass). **Apply** writes the selected set, triggers audio-invalidation
-  (§5.4), and records a change-log entry.
+- A **"Review Script"** button on the manuscript editing surface (per-chapter; whole-book is an explicit
+  opt-in). Fires `POST …/script-review`; per-chapter progress reuses the analysis SSE `phase` grammar.
+- Results land in a **`ScriptReviewDiff` modal** (the DriftReport accept-reject *pattern*, dedicated slice
+  per §5.7), **grouped by chapter then class**, with per-class accept/reject and drill-down to per-change
+  toggles. Each row: before → after (text / characterId / exclude), class, LLM rationale, confidence.
+  `reattribute_blocked` rows render **read-only** (advisory).
+- **Tiered defaults:** mechanics classes (`strip_tag`/`split`/`extract_dialogue`/`merge`) pre-selected
+  **ON**; content classes (`reattribute`, `flag_nonstory`) default **OFF** (explicit opt-in). **Apply**
+  writes the selected set, emits `boundary_move` per affected chapter (§5.5), records a change-log entry,
+  and triggers a client manuscript refetch.
 
 ## 7. Error handling
 
-- LLM unreachable → Gemini fallback (`FallbackAnalyzer`); both down → SSE `error` event, modal shows
-  failure, **no state change**.
-- Throttle / rate-limit → `onThrottle` SSE event, identical to analysis.
-- Malformed LLM op → **dropped + logged**, the chapter continues (one bad op never fails the run).
+- LLM unreachable → Gemini fallback (`FallbackAnalyzer`); both down → SSE `error`, **no state change**.
+- Throttle / RPD → `onThrottle` SSE event; book-wide may hit `DailyQuotaExhaustedError` mid-run (§4.5) —
+  surface partial progress, no partial corruption (per-chapter transactional apply).
+- Malformed / invalid op → dropped + logged + surfaced as un-appliable; the run continues.
 - Cancel / abort → `signal` propagates; ephemeral suggestions discarded.
 
 ## 8. Testing & acceptance
 
-- **Server unit:** one before/after fixture **per class** (7); the apply step's ID allocation
-  (`split` maxId+1, `merge` surviving-id reconciliation §5.3), op-validation rejections (§5.5), the
-  audio-invalidation trigger (§5.4).
-- **Server regression (M1 / R2-M3):** split/merge preserve ID stability, do not orphan emotion/audio,
-  and respect prior manual edits; reparse-survival (a split offspring `id > maxCacheId` survives a
-  re-analysis).
-- **M5 regression:** a fixture containing intentional vocalizations ("Ah!") that `strip_tag` must **not**
-  strip and `flag_nonstory` must **not** flag.
-- **Frontend unit:** `ScriptReviewDiff` selection logic (per-class / per-change toggles → apply payload).
-- **E2E (Playwright):** trigger → diff → accept a subset → manuscript updates → affected audio marked
-  stale. Append a case to `e2e/responsive/coverage.spec.ts` for the new modal.
+- **Server unit, per class (6):** before/after fixtures; the apply step's **global** ID allocation (§5.1),
+  the **restructure remap** for `split` + `merge` (§5.3/§5.4), apply-order on mixed same-id ops (§4.3),
+  op-validation rejections (§5.6), the `boundary_move` emission (§5.5).
+- **Re-analysis regression (the C3 hazard):** after a `merge`/`split`, run a re-analysis and assert the
+  dropped ids do **not** resurrect and content is **not** duplicated.
+- **M1/R2-M3 regression:** structural ops preserve ID stability, don't orphan emotion/audio, respect prior
+  manual edits; split offspring (`id > global maxCacheId`) survive re-analysis.
+- **Abstention fixtures (precision):** `reattribute` must NOT fire on correctly-attributed dialogue;
+  `flag_nonstory` must NOT exclude short legitimate narration/dialogue; `strip_tag`/`flag_nonstory` must
+  NOT touch M5 vocalizations ("Ah!").
+- **Synth consumer:** a `excludeFromSynthesis` sentence produces **no audio segment** (filter in
+  `buildSentenceGroups`, §10).
+- **Frontend unit:** `ScriptReviewDiff` selection logic (tiered defaults, per-class/per-change → apply
+  payload); the dedicated slice is **not wiped** by a revisions poll.
+- **E2E (Playwright):** per-chapter trigger → diff → accept a subset → manuscript refetches → affected
+  chapter reads stale. Append a case to `e2e/responsive/coverage.spec.ts`.
 - **No sidecar/golden-audio tier** — fs-58 loads no TTS model.
 
 ## 9. Non-goals & follow-ups
 
 **Non-goals (v1):**
-- **No TTS-synthesis engine involvement** — no Kokoro/Coqui/Qwen load (this is what "engine-agnostic"
-  means; it is *not* "no GPU" — see §4.4).
-- No cast-roster changes — `reattribute` targets only existing cast; never invents a character.
-- No `validate_instruct` — deferred to fs-56 (§3).
-- No suggestion persistence across reload — follow-up below.
-- No auto-apply without operator review.
-- No free-form text rewriting beyond `strip_tag` (no paraphrasing / content rewriting).
+- No TTS-synthesis engine involvement (this is what "engine-agnostic" means; it is *not* GPU-free, §4.4).
+- No cast-roster mutation — `reattribute` targets only existing post-fold cast; off-roster → read-only
+  `reattribute_blocked` advisory.
+- No `fix_emotion` — routed to fs-33 (below).
+- No `validate_instruct` — deferred to fs-56 (below).
+- No suggestion persistence across reload (below).
+- No chapter-level in-flight guard — v1 blocks at book level (below).
+- No auto-apply without review; no free-form text rewriting beyond `strip_tag`.
+- No entitlement/paywall gate (the word "premium" is dropped; relationship to com-1 Cast Pass is TBD at
+  that seam, not here).
 
-**Follow-ups to file (BACKLOG + issues):**
-1. **Persist suggestions** across page reload (`script-review-suggestions.json`) so a long review survives
-   a refresh.
-2. **`validate_instruct` class** — implement once fs-56's per-sentence `instruct` field lands (tracked in
-   fs-56's scope with the bidirectional move-here note).
+**Follow-ups — FILE NOW (issue + thin BACKLOG row, per the project rule):**
+1. **Persist suggestions** across reload (`script-review-suggestions.json`).
+2. **`validate_instruct` class** — blocked on fs-56's per-sentence `instruct`; **also edit the fs-56
+   issue/spec** to carry the move-here note (make the cross-link bidirectional in tracked artifacts).
+3. **fs-33 "correct an existing wrong emotion" mode** — the home for emotion correction fs-58 declined.
+4. **Chapter-level in-flight generation guard** — replace the v1 book-level block.
 
 ## 10. Dependencies & linkage
 
-- **fs-56 (#996)** owns the per-sentence `instruct` field; the `validate_instruct` class is added to
-  fs-56's scope with a bidirectional cross-link (§3).
-- **New optional `excludeFromSynthesis` sentence field** for `flag_nonstory` — fs-58 owns it; added to
-  `openapi.yaml` + regenerated `src/lib/api-types.ts` (OpenAPI is the type source of truth) + the Zod
-  `sentenceSchema`. **Relationship:** the existing `isLikelyFrontMatter` flag is *chapter-level*
-  (`openapi.yaml:3342`, confirm-view auto-suggests excluding whole front/back-matter chapters);
-  `excludeFromSynthesis` is the *sentence-level* counterpart for artifact lines inside a story chapter.
-- **Reuses:** analyzer call path + `RateLimiter` (`server/src/analyzer/`), revisions-style diff modal
-  (`src/store/revisions-slice.ts`), drift / `segments.json` audio invalidation, `splitSentence` maxId
-  rule (`src/store/manuscript-slice.ts`), `manuscript-edits.json` I/O (`book-state.ts`).
+- **fs-56 (#996)** — owns the per-sentence `instruct` field; `validate_instruct` parked there (§9.2).
+- **fs-33 (#596)** — owns emotion correction (§9.3).
+- **New optional `excludeFromSynthesis` sentence field** — fs-58 owns it: `openapi.yaml` →
+  regenerated `src/lib/api-types.ts` → Zod `sentenceSchema`. **Synth consumer in scope:** a
+  `.filter(s => !s.excludeFromSynthesis)` in `buildSentenceGroups` (`synthesise-chapter.ts:~659`) + test
+  (§8) — without it the flag is cosmetic. **`.strict()` is safe on disk:** persisted `manuscript-edits.json`
+  / cache are read leniently (`book-state.ts:225`, no `sentenceSchema.parse()`), so the new optional field
+  needs **no migration** and isn't stripped on read — **but** keep the review output **delta-only** (never
+  a full strict `Sentence`, which would require the field in the grammar schema). **Precedence vs the
+  chapter-level `isLikelyFrontMatter`** (`openapi.yaml:3342`): chapter-level exclusion wins; a sentence
+  flag inside an already-excluded chapter is a no-op.
+- **Reuses:** analyzer call path + `RateLimiter` (`server/src/analyzer/`); `serializeQueueMutation`
+  (`generation.ts`); the `boundary_move` change-log + `stale-chapters.ts` staleness derivation; the
+  `applyChapterRestructure` remap pattern (`manuscript-slice.ts:378-401`); `manuscript-edits.json` I/O
+  (`server/src/routes/book-state.ts`); the DriftReport accept-reject UI pattern.
 
 ## 11. Implementation ordering (for the plan)
 
-A sketch for writing-plans, not a delivery commitment:
+1. **Schema + server apply contract (highest-risk, test-first):** the `excludeFromSynthesis` field
+   (OpenAPI → types → Zod) + the synth-side filter + test; the review op/delta schema; the server **apply
+   module** — global allocator under `serializeQueueMutation` (§5.1), restructure-based split/merge with
+   the re-analysis-no-resurrect guarantee (§5.4), apply-order (§4.3), `boundary_move` emission (§5.5),
+   op-validation (§5.6) — with the C3 re-analysis regression + M1/R2-M3 + abstention fixtures.
+2. **Review pass + endpoint:** the 7-site `runScriptReviewChapter` extension (§4.2); the flat output
+   schema (decide flat-vs-wire-Gemini-responseSchema, §4.3); the per-chapter endpoint + optional
+   book-wide; the review-model knob + RPD warning (§4.5); the prompt with M5 + abstention constraints.
+3. **Operator UX:** the dedicated non-polled slice (§5.7); `ScriptReviewDiff` (per-chapter, tiered
+   defaults, `reattribute_blocked` advisories); apply → `boundary_move` → change-log → client refetch; the
+   book-level in-flight guard; the E2E spec.
 
-1. **Schema + contract** — `excludeFromSynthesis` field (OpenAPI → types → Zod); the review op/delta
-   schema; the server-side **apply** module (field deltas + structural ops + §5 contract) with its unit
-   + M1/R2-M3 regression tests. *Highest-risk, test-first.*
-2. **Review pass + endpoint** — `runScriptReviewChapter` over the analyzer path; `POST
-   /api/books/:bookId/script-review` SSE; the dedicated review-model knob; the M5 prompt carve-out.
-3. **Operator UX** — `ScriptReviewDiff` modal (per-class + per-change toggles), the "Review Script"
-   button, the apply → invalidate → change-log wire-up; the E2E spec.
+## 12. Adversarial review — resolutions (2026-06-23)
+
+Three independent code-grounded reviewers (data-integrity, scope/product, architecture). Findings resolved
+into the sections above:
+
+- **§5.4 server-side invalidation was fictional → §5.5 rewritten** around `boundary_move` + client
+  re-derive (staleness is client-derived; `stale-chapters.ts`).
+- **`fix_emotion` was doubly wrong + overlapped fs-33 → routed to fs-33** (§3, §9.3); emotion is not in the
+  speaker-map diff and the real rule is 3-way gated incl. the neutral-direction miss.
+- **merge-as-drop resurrected on re-analysis → §5.4 restructure/tombstone contract** (`hydrateFromAnalysis`
+  append branch is the corruptor).
+- **Gemini `responseSchema` never wired → §4.3 flat schema** (drop the union; or wire it as a prerequisite).
+- **Offsets fragile → §4.3 content-addressed pieces** with concat-equality validation.
+- **Undefined mixed-op order → §4.3 apply-order rule.**
+- **maxId is global not per-chapter → §5.1.** **Dual allocator race → §5.1 sole-allocator + refetch.**
+- **"Wholesale reuse" overstated → §4.2 7-site touch-list.**
+- **In-flight guard chapter-level didn't exist → §5.6 book-level v1 + §9.4 follow-up.**
+- **`excludeFromSynthesis` cosmetic → §10 synth consumer in scope.**
+- **Pre-selected-all unsafe → §6 tiered defaults.** **`reattribute` off-roster → §3 advisory.**
+  **`flag_nonstory` false-positives → §3 constraints + §8 abstention tests.**
+- **`validate_instruct` orphan deferral → §9.2 file now + edit fs-56.**
+- **Whole-book unusable → §4.1/§6 per-chapter (fs-35 precedent).**
+- **`ScriptReviewDiff` on `revisions.pending` → §5.7 dedicated non-polled slice.**
+- **Scope 5→7 + no-GPU reversal → re-scoping note (header) + #998/BACKLOG update gate.**
+- **Moderates/minors folded in:** `startMs/endMs` dropped on structural ops (§5.3/5.4); token/RPD cost
+  (§4.5); cross-chapter merge rejected (§5.4/5.6); placement supersedes (header); `.strict()` safe on disk
+  + delta-only output (§10); post-fold roster (§4.2); auth inherited (§4.1); non-sticky (§4.1); cross-tab
+  caveat (§5.5); corrected `book-state.ts` path (§10); "premium" dropped (§9).

--- a/docs/superpowers/specs/2026-06-23-fs58-llm-script-review-design.md
+++ b/docs/superpowers/specs/2026-06-23-fs58-llm-script-review-design.md
@@ -16,26 +16,25 @@ inspiration: github.com/Finrandojin/alexandria-audiobook (Alexandria — LLM Scr
 
 # fs-58 — LLM Script Review (Unit A)
 
-> **Decomposed (2026-06-23, after two adversarial review rounds).** fs-58 splits at the mechanics/content
+> **Decomposed (2026-06-23, after three adversarial review rounds).** fs-58 splits at the mechanics/content
 > seam:
-> - **Unit A (this spec):** 4 structural-mechanics classes + `fix_emotion`. Self-contained, fully testable,
->   no unmet dependencies. **Apply is client-side** (§5).
+> - **Unit A (this spec):** 4 structural-mechanics classes + `fix_emotion`. **Apply is client-side** (§5):
+>   the server review pass is read-only; accepted suggestions dispatch the manual-edit reducers. Two new
+>   reducers are needed (`setSentenceText`, `mergeSentences`) — see §5.2; this is NOT zero-new-infra.
 > - **Unit B (deferred, §13):** `reattribute` + `flag_nonstory`. Carved out — each drags in a real
->   dependency that isn't fs-58's job (cast-create wiring; a new `excludeFromSynthesis` field + an
->   exclusion-staleness fix; an artifact-bearing test fixture).
+>   dependency (cast-create wiring; a new `excludeFromSynthesis` field + exclusion-staleness; a fixture).
 > - **Deferred to fs-56:** `validate_instruct` (the per-sentence `instruct` field doesn't exist yet).
 >
-> **Supersedes** the §4.6 sketch in `2026-06-22-expressive-tts-instruct-tiers-design.md`, **including its
-> placement** ("before `manuscript-edits.json` is written"): this runs as a standalone job *over* the
-> manuscript, anytime. **#998 + the BACKLOG row must be updated** (5 classes + "no GPU" → this scope +
-> "no TTS engine") before leaving `draft`.
+> **Supersedes** the §4.6 sketch in `2026-06-22-expressive-tts-instruct-tiers-design.md` (incl. its
+> "before `manuscript-edits.json`" placement). **#998 + the BACKLOG row must be rewritten** (old: 5 classes
+> incl `validate_instruct`, "no GPU", "before manuscript-edits"; new: this Unit A scope, "no TTS engine",
+> standalone-anytime) — a doc action landing **with the plan**, the hard gate to leave `draft`.
 
 ## 1. Summary
 
 An optional, operator-triggered, **per-chapter** QA pass: a **read-only** second LLM pass over
 already-attributed sentences proposes annotation repairs, shown as an accept/reject diff; accepted changes
-are applied **client-side by dispatching the same reducers a manual edit uses**. Additive — off → today's
-behaviour exactly.
+are applied **client-side by dispatching manual-edit reducers**. Additive — off → today's behaviour exactly.
 
 "Engine-agnostic" = **TTS-engine-agnostic** (no Kokoro/Coqui/Qwen load), *not* GPU-free: it reuses the
 analyzer compute (local Ollama on GPU, or Gemini cloud). See §4.4.
@@ -45,15 +44,15 @@ analyzer compute (local Ollama on GPU, or Gemini cloud). See §4.4.
 Phase-1 attribution (`server/src/routes/analysis.ts`, `runStage2Chapter`) produces per chapter
 `Sentence`s `{ id, chapterId, characterId, text, confidence?, emotion?, startMs?, endMs? }`, written
 (post-fold/dedup) to `manuscript-edits.json` at `analysis.ts:~4043`. It is good but leaks attribution
-tags into dialogue, over-/under-splits at narrator↔dialogue boundaries, and sometimes sets a wrong
-`emotion`. Unit A repairs exactly those.
+tags into dialogue, over-/under-splits at narrator↔dialogue boundaries (often at intra-chapter chunk
+seams Phase-1 couldn't see across, `stage2-chunk.ts`), and sometimes sets a wrong `emotion`. Unit A
+repairs exactly those.
 
-**fs-33 is backfill-only and cannot correct emotion.** Its apply path `applyDetectedEmotions`
+**fs-33 is backfill-only and cannot correct emotion.** `applyDetectedEmotions`
 (`manuscript-slice.ts:288-306`) skips any sentence that already has an emotion (`:302` —
-`if (sent.emotion) continue`), and its prompt never sends the current emotion to the model. So "correct a
-*wrong* emotion" has no home in fs-33 without new overwrite-mode work — which is why `fix_emotion` lives
-here (it's a cheap field-delta; §5.2). fs-33 (fill empty) and `fix_emotion` (correct wrong) are
-complementary, not duplicative.
+`if (sent.emotion) continue`) and never sends the current emotion to the model. So "correct a *wrong*
+emotion" has no home in fs-33 without new overwrite work — which is why `fix_emotion` lives here (a cheap
+field-delta; §5.2). fs-33 (fill empty) and `fix_emotion` (correct wrong) are complementary.
 
 ## 3. Error classes — Unit A (5 live)
 
@@ -61,12 +60,11 @@ complementary, not duplicative.
 1. `strip_tag` — remove an attribution tag ("she said") that leaked into dialogue text. *Text edit.*
 2. `split` — split narration out of a dialogue entry. *Structural (anchor-located, §4.3).*
 3. `extract_dialogue` — pull dialogue out of a narrator run into its own sentence. *Structural.*
-4. `merge` — merge over-split narrator entries into one. *Structural.*
+4. `merge` — merge over-split narrator entries into one. *Structural (new reducer + tombstone, §5.2).*
 
-**Content (rides along — ready, no unmet deps):**
+**Content (rides along):**
 5. `fix_emotion` — correct an obviously-wrong `emotion` enum value (calm line marked `angry` → `neutral`).
-   *Field delta on `emotion`.* Reuses `setSentenceEmotion`; carries the neutral-direction staleness fix
-   (§5.3).
+   *Field delta on `emotion`.* Reuses `setSentenceEmotion`.
 
 **M5 carve-out:** the prompt **never strips intentional non-verbal vocalizations** ("Ah!", "Haah…") as
 attribution tags. Hard, tested constraint on `strip_tag`.
@@ -81,255 +79,259 @@ A **standalone, per-chapter job** (not inside the analyse SSE), runnable anytime
 
 - `POST /api/books/:bookId/script-review` taking an **optional `chapterId`** (default: the chapter being
   edited; whole-book is opt-in). Own SSE stream mirroring the analysis grammar. Per-chapter keeps the diff
-  usable at novel scale (fs-35 precedent).
-- Mounts under `/api` → inherits `requireLanToken` + `requireSameOrigin` CSRF (`app.ts:111-114`).
-- **Non-sticky / no resume** (like fs-33's annotate-emotion): a disconnect mid-run aborts; re-run from
-  scratch. On a book-wide run this re-spends RPD (§4.5) — surface the expectation.
+  usable at novel scale (fs-35) AND gives the pass the whole-chapter context Phase-1's chunking lacked
+  (the right granularity for the mechanics classes; verified round 3).
+- Mounts under `/api` → inherits `requireLanToken` + `requireSameOrigin` CSRF (`app.ts:111-114`), matching
+  the annotate-emotion / generation / splice operator-job family.
+- **Non-sticky / no resume** (like annotate-emotion): disconnect aborts; re-run from scratch. A book-wide
+  run re-spends RPD (§4.5) — surface the expectation.
 
-### 4.2 The review pass — read-only, ~13-site touch-list
+### 4.2 The review pass — read-only, ~16-site touch-list
 
-The pass **writes nothing**; it returns suggestions (§4.3). The `Analyzer` interface is closed and
-per-stage; adding a pass is a multi-site extension across server **and frontend** (re-derived from the
-fs-33 `runEmotionChapter` diff — the round-1 "~7 sites" was undercounted):
+The pass writes **no manuscript/cache state** (the analyzer handoff inbox/outbox/error debug files are
+written as for every stage); it returns suggestions (§4.3). The `Analyzer` interface is closed/per-stage;
+adding a pass is a multi-site extension across server **and frontend** (re-derived from fs-33's
+`runEmotionChapter`/`detectEmotions` diff — the prior "~7 / ~13" counts were both low):
 
-*Server:* (1) `runScriptReviewChapter` on the `Analyzer` interface (`index.ts`); (2) `OllamaAnalyzer`
-impl; (3) `GeminiAnalyzer` impl; (4) `FallbackAnalyzer` delegation; (5) the **validation** schema +
-(6) the **grammar** schema for Ollama constrained-decode (distinct artifacts, cf. `stage1ChapterGrammarSchema`);
-(7) the skill prompt `.md`; (8) `SKILL_FILES` + the `SkillName` union (`gemini.ts:123`); (9)
-`SKILL_TO_PROMPT_ID` (`gemini.ts:130`); (10) a `HandoffKey`; (11) the route + SSE; (12) the
-`openapi.yaml` *path* entry. *Frontend:* (13) the `api.ts` client method + its SSE-event/Opts/Result
-types (cf. fs-33's `detectEmotions`, `api.ts:~2655`).
+*Server:* (1) `runScriptReviewChapter` on `Analyzer` (`index.ts`); (2) `OllamaAnalyzer` impl; (3)
+`GeminiAnalyzer` impl; (4) `FallbackAnalyzer` delegation; (5) validation schema + (6) Ollama grammar
+schema (distinct artifacts); (7) skill prompt `.md`; (8) `SKILL_FILES` + `SkillName` union
+(`gemini.ts:111-125`); (9) `SKILL_TO_PROMPT_ID` (`gemini.ts:130`); (10) **the `prompt.scriptReview`
+registry knob in `config/registry.ts`** (`isPrompt:true` — else `readPrompt`/`assertValidId` throws,
+`prompts.ts:46-71`); (11) `HandoffKey` (`protocol.ts`); (12) route + SSE; (13) `openapi.yaml` *path* entry.
+*Frontend:* (14) `api.ts` **real AND mock** client + registration in both `real`/`mock` objects
+(`api.ts:~2654/2736/6803/7064`) + the SSE callback signatures + Error class; (15) the dedicated suggestions
+slice file (§5.5) + (16) its registration in `store/index.ts`.
 
 - Model selection reuses `selectAnalyzer` / per-phase selection with a **dedicated review-model knob**
-  (defaults to the analyzer's model).
-- **Input:** the target chapter's `sentences[]` + the **post-fold** cast roster (the cache holds pre-fold
-  descriptor ids, `book-state.ts:296-304`; post-fold avoids spurious drops).
+  (persists in **user-settings**, like the analyzer model; defaults to it).
+- **Input:** the target chapter's `sentences[]` + the **post-fold** cast roster (cache holds pre-fold
+  descriptor ids, `book-state.ts:296-304`).
+- **Per-call budget:** assumes a chapter fits one call. A chapter that overflowed Phase-1's ~9000-char
+  chunk budget (`stage2-chunk.ts`) is **chunked-with-overlap** for review (don't silently re-introduce the
+  chunk-seam blind spot); state overflow behaviour in the plan.
 
-### 4.3 Output format — flat envelope + imperative validation; anchor-located structural ops
+### 4.3 Output format — flat envelope + imperative validation; anchor-located, resolved at accept
 
-Each suggestion is one row `{ id, op, ...payload, rationale, confidence }`. The Zod schema validates the
-**envelope only**; per-op payload shape is validated **imperatively in the apply layer** (§5.6), because
-the Gemini path sends no `responseSchema` (`gemini.ts:561-566`) — output is free-form JSON. *(Asymmetry to
-decide at plan time: Ollama **can** enforce a discriminated union via constrained decode / `z.toJSONSchema`
-— `ollama.ts:312-328`; Gemini cannot. Either keep a union for Ollama + imperative checks for Gemini, or
-flatten both. Don't claim "schema-constrained" for Gemini.)*
+Each suggestion is one row `{ id, op, ...payload, rationale, confidence }`. **Decided: flatten both
+engines** + imperative per-op validation in the apply layer (§5.6). Rationale: Gemini sends no
+`responseSchema` (`gemini.ts:561-566`, free-form JSON); Ollama *can* constrain a discriminated union
+(`z.toJSONSchema`, `ollama.ts:336`) but only **softly** (llama.cpp ignores `additionalProperties:false`,
+`ollama.ts:330-335`), so an imperative check is required regardless — the asymmetry buys nothing. Don't
+claim "schema-constrained" for Gemini.
 
 Payloads:
 - **Field edits** keyed by `id`: `strip_tag` (newText), `fix_emotion` (emotion).
-- **Structural ops — ANCHOR-LOCATED, not verbatim pieces.** The LLM returns a **short unique anchor
-  substring** marking the split point (`split`/`extract_dialogue`) or the member `ids` (`merge`). The
-  apply layer locates the anchor with `indexOf` in the *original* text (+ uniqueness check) and **slices
-  the pieces itself**. The model only *points*; it never reproduces text. *(Round 2 reversed the round-1
-  "content-addressed pieces" fix: verbatim-piece concat-equality is MORE fragile here — LLMs normalize
-  curly quotes / em-dashes, and the Gemini JSON-repair walker rewrites quotes inside strings,
-  `gemini.ts:865`, so quote/dash-bearing dialogue — the main split target — would fail equality and drop
-  silently. Anchor-locate keeps the server the sole source of truth for text.)*
+- **Structural ops — ANCHOR substring (the model points, never reproduces text):** `split`/
+  `extract_dialogue` return a short **boundary-spanning** anchor (last N chars before + first N after the
+  split point, joined) + per-piece characterIds; `merge` returns the member `ids`. *(Round 2 picked
+  anchor over verbatim-pieces — concat-equality is fragile because LLMs/`gemini.ts:865`'s repair walker
+  rewrite quotes/em-dashes. Round 3: the anchor inherits the SAME normalization risk, so the locator
+  **NFC- + quote/dash-normalizes both the anchor and the live text before `indexOf`**.)*
 
-**Apply order** (same-id collisions): structural ops first (merge → split/extract), then field edits vs
-surviving ids; reject a field edit whose id was consumed, and a 2nd structural op on one id.
+**Anchor resolution happens CLIENT-SIDE at accept time** against the **live** `s.sentences[idx].text`
+(NOT server-side → offsets) — this closes the TOCTOU where an operator edits the sentence between the
+server read and accept (§5.6).
 
 ### 4.4 Compute note
 
-Reuses the analyzer path — local Ollama (**GPU, same footprint as Phase-1**; holds the analyzer GPU
-semaphore, `ollama.ts:523`) or Gemini (cloud). Loads no TTS model; adds no new resident GPU model; never
-co-resident with a TTS engine — clear of the parent spec's §4.7 VRAM invariant. On one small (8 GB) GPU it
-**contends with the analyzer and evicts/evicted-by TTS** — can't run concurrently with a generation there.
+Local Ollama (**GPU, same footprint as Phase-1**; holds the analyzer GPU semaphore) or Gemini (cloud).
+No TTS model; no new resident GPU model; never co-resident with a TTS engine — clear of the parent spec's
+VRAM invariant. On one small (8 GB) GPU it contends with the analyzer and can't run concurrently with a
+generation there.
 
 ### 4.5 Cost & latency
 
-Per-chapter = **one LLM call/run** (book-wide = one per chapter). Free-tier RPD bites on book-wide:
-`gemini-2.5/3.5-flash` RPD **20** (`rate-limit.ts:37-43`) — a 20+-chapter book can't finish in a day;
-`gemini-3.1-flash-lite` RPD 500, `gemma` 1500. **Stronger models have the LOWEST RPD**, so the review-model
-knob's "stronger model" worsens book-wide cost. The UI knob **warns when book-wide chapters > model RPD**;
-recommended default is local Ollama or a high-RPD Gemma. Non-sticky (§4.1) + RPD-capped means an
-interrupted book-wide run is unrecoverable within the day — another reason per-chapter is the default.
+Per-chapter = **one LLM call/run**. Free-tier RPD bites book-wide: `gemini-2.5/3.5-flash` RPD **20**
+(`rate-limit.ts:37-43`) — a 20+-chapter book can't finish in a day; `flash-lite` 500, `gemma` 1500.
+Stronger models have the LOWEST RPD. The UI knob **warns when book-wide chapters > model RPD**; default
+local Ollama / high-RPD Gemma. Non-sticky + RPD-capped ⇒ interrupted book-wide is unrecoverable that day
+— another reason per-chapter is the default.
 
 ## 5. Apply — client-side dispatch (the inversion)
 
 ### 5.1 The model
 
-The server review pass **writes nothing**. Accepted suggestions are applied in the browser by
-**dispatching the existing manual-edit reducers**. Consequence: Unit A **inherits manual-edit semantics
-wholesale** — ID allocation (the global `maxId+1` rule in `splitSentence`/restructure), persistence (the
-debounced `putBookState` manuscript PUT), staleness derivation, the change-log, and in-flight-generation
-behaviour all come for free, because an accepted suggestion *is* a manual edit. This dissolves the round-1/2
-server-apply hazards (wrong write-lock, refetch-clobbers-unflushed-edits, server can't reuse the frontend
-restructure reducer, tombstone has no consumer) — none arise when apply never leaves the client.
+The server review pass **writes no manuscript state**. Accepted suggestions are applied in the browser by
+**dispatching the manual-edit reducers**. What is inherited *automatically*: **ID allocation** (the global
+`maxId+1` in `splitSentence`, `manuscript-slice.ts:347`) and **persistence** (the debounced
+`putBookState` manuscript PUT, a blind whole-array write, `book-state.ts:570`). What the apply layer must
+dispatch **explicitly per class** (these are call-site responsibilities, NOT reducer freebies — round-3
+correction): **staleness** and the **change-log** event. See §5.2/§5.3.
 
-**fs-44 note (filed, §9):** this makes apply browser-only. A headless/MCP agent (no Redux) cannot apply,
-so an equivalent **server apply path is an explicit fs-44 dependency** — captured so the agent surface
-doesn't silently inherit a browser-only assumption.
+**fs-44 (#721) dependency:** this makes apply browser-only; a headless/MCP agent can't apply. A server
+apply path is an explicit fs-44 dependency — to be **filed against #721** with the plan (§9), not assumed.
 
 ### 5.2 Per-class reducer mapping
 
 | Class | Reducer | Status |
 |---|---|---|
-| `split` / `extract_dialogue` | `splitSentence` (`manuscript-slice.ts:330`) | exists; server resolves the anchor (§4.3) → offsets before dispatch |
-| `merge` | `applyChapterRestructure` via the existing `/chapters/merge` route + remap (`restructure.tsx`, `manuscript-slice.ts:378`) | exists; **merge uses the same path manual merges use**, so re-analysis resurrection is handled by the path that already handles it |
+| `split` / `extract_dialogue` | `splitSentence` (`manuscript-slice.ts:330`, takes `offsets[]`+`characterIds[]`; supports narrator/dialogue/narrator 3-piece, `manuscript.tsx:533`) | exists; client resolves the live anchor → offsets at accept (§4.3) |
 | `fix_emotion` | `setSentenceEmotion` (`manuscript-slice.ts:269`) | exists |
-| `strip_tag` | **NEW `setSentenceText` reducer** | **no text-edit reducer exists today** — see §5.3 |
+| `strip_tag` | **NEW `setSentenceText` reducer** | no text-edit reducer exists today |
+| `merge` | **NEW `mergeSentences` reducer** | NO sentence-merge path exists — `/chapters/merge` is CHAPTER-level (`restructure.ts:528`); not reusable. New reducer: concat adjacent same-`characterId` texts, drop the consumed id(s); + a **tombstone** so re-analysis can't resurrect the dropped id(s) (§5.3) |
 
-### 5.3 Two staleness/reducer gaps Unit A must close (honest)
+After each dispatch the apply layer also emits the matching **change-log** event (e.g.
+`bumpBoundaryMove` for structural ops, `manuscript.tsx:537`) and triggers staleness (§5.3).
 
-The precise staleness path (`stale-chapters.ts:58-70`) diffs **`characterId` only** of rendered sentences.
-Two Unit A edits change neither id-set nor characterId, so they would NOT mark audio stale:
+### 5.3 Staleness — one unified content-hash mechanism
 
-1. **`strip_tag` (text change).** Needs (a) a new `setSentenceText` reducer (persists via the existing
-   whole-array manuscript PUT, `book-state.ts:570`) and (b) extending the rendered-sentence diff to flag a
-   **text change** on a rendered id (the spoken words changed → audio is stale). NEW.
-2. **`fix_emotion` neutral-direction.** The emotion-staleness rule (`sentence-emotion-control.tsx:77-87`)
-   only marks stale when the *new* value is `≠ neutral` (+ Qwen + a designed variant). Correcting
-   `angry → neutral` — `fix_emotion`'s signature case — leaves the angry-variant audio in place silently.
-   Fix: compare *rendered* emotion-variant vs *new* emotion, not just `≠ neutral`. (A latent bug in the
-   existing manual emotion-edit flow; worth fixing regardless.)
+Today the precise staleness path (`stale-chapters.ts:58-70`) diffs **`characterId` only** of rendered
+sentence ids. That misses **every** Unit A edit that doesn't drop/move an id: `strip_tag` (text change),
+`split`/`extract` (the retained first piece keeps its id + characterId, only its text shrinks — round-3
+THIRD gap), and `fix_emotion` `angry → neutral` (the `value !== 'neutral'` gate,
+`sentence-emotion-control.tsx:82`). Rather than patch each:
 
-`split`/`extract`/`merge` need no staleness work — they change the rendered id-set, which the precise path
-already detects.
+**Extend the render-time map to carry a per-sentence content hash** (`hash(text + characterId +
+emotion-variant)`) — server-side in the GET that builds `renderedSpeakersByChapter` + `segments.json`
+(the map is currently `id → characterId` only, `chapters-slice.ts:98`). The precise path then flags any
+rendered id whose **current hash ≠ rendered hash**. One mechanism covers all four cases (and the
+`fix_emotion` neutral-direction bug — a real latent bug in today's manual flow). `merge` is also covered
+(the dropped id disappears from the current set).
 
 ### 5.4 In-flight generation
 
-Applying during a generation = manually editing during a generation: **inherits existing semantics** (no
-bespoke per-chapter guard, no book-level block). Whatever the app does for a manual edit mid-render, it
-does here — by construction.
+Applying during a generation = manually editing during one: **inherits existing semantics** (no bespoke
+guard).
 
 ### 5.5 Suggestion lifetime & storage
 
 Ephemeral per run, in a **dedicated, non-polled, bookId-keyed** slice — **NOT** `revisions.pending`
-(`applyPoll` replaces it wholesale, `revisions-slice.ts:160-163`, which would wipe an in-progress review
-and break the concurrent-multi-book invariant). The modal's read-selector reads **only the active book's
-bucket**. "Extends the revisions/DriftReport pattern" = the **UI pattern only**. A reload discards the run
-(consistent with non-sticky, §4.1); persisting suggestions is a follow-up (§9). No cross-tab sync
-(manuscript isn't broadcast, `broadcast-middleware.ts:60-62`) — consistent with manual edits.
+(`applyPoll` wholesale-replaces it, `revisions-slice.ts:160-163`). The modal's read-selector reads **only
+the active book's** bucket (concurrent-multi-book invariant). "Extends the DriftReport pattern" = the **UI
+pattern only**. A reload discards the run (non-sticky, §4.1); persisting is a follow-up (§9). No cross-tab
+sync (manuscript isn't broadcast, `broadcast-middleware.ts:60-62`) — consistent with manual edits.
+
+### 5.6 Imperative op-validation (at accept, against live state)
+
+The apply layer validates each accepted suggestion against the **live client manuscript** immediately
+before dispatch; any failure → the suggestion is marked **un-appliable** (the §7 drop path), never
+mis-applied:
+
+- **Anchor (structural):** NFC+quote/dash-normalize the anchor and the live sentence text; require
+  `indexOf` found **and unique** (`indexOf === lastIndexOf`). A non-unique/absent anchor (common on
+  repeated quote chars, or after a mid-review edit) → un-appliable. *(Closes the TOCTOU.)*
+- **Apply order (same-id collisions):** structural ops first (merge → split/extract), then field edits vs
+  surviving ids; reject a field edit whose id was consumed, and a 2nd structural op on one id.
+- **Referenced ids exist** in the live manuscript; `merge` members are adjacent + same `characterId`;
+  `fix_emotion` target value is a valid enum.
 
 ## 6. Operator UX
 
-- A **"Review Script"** button on the manuscript editing surface (per-chapter; whole-book is an explicit
-  opt-in). Fires `POST …/script-review`; per-chapter progress reuses the analysis SSE `phase` grammar.
-- Results in a **`ScriptReviewDiff` modal** (the DriftReport accept-reject *pattern*, dedicated slice
-  §5.5), grouped by class, per-class accept/reject + per-change drill-down. Each row: before → after,
-  class, rationale, confidence.
-- **Defaults:** all Unit A classes are corrective/low-risk → pre-selected **ON** (operator deselects).
-  **Apply** dispatches the §5.2 reducers, which trigger the inherited staleness/change-log/persistence.
-  (The high-risk default-OFF tiering applies to Unit B's content classes, not Unit A.)
+- A **"Review Script"** button on the manuscript editing surface (per-chapter; whole-book opt-in). Fires
+  `POST …/script-review`; per-chapter progress reuses the analysis SSE `phase` grammar.
+- Results in a **`ScriptReviewDiff` modal** (DriftReport accept-reject *pattern*, dedicated slice §5.5),
+  grouped by class, per-class accept/reject + per-change drill-down. Each row: before → after, class,
+  rationale, confidence.
+- **Defaults:** all 5 Unit A classes are corrective/low-risk → pre-selected **ON** (operator deselects).
+  **Apply** dispatches the §5.2 reducers + change-log + staleness (§5.1/§5.3). (Default-OFF tiering is a
+  Unit B concern.)
 
 ## 7. Error handling
 
 - LLM unreachable → Gemini fallback; both down → SSE `error`, no suggestions, no state change.
-- Throttle / RPD → `onThrottle` SSE event; book-wide may hit `DailyQuotaExhaustedError` mid-run (§4.5).
-- Malformed / invalid op (anchor not found / not unique, consumed-id edit) → dropped + logged + surfaced
-  as un-appliable; the run continues.
-- Cancel / abort → `signal` propagates; ephemeral suggestions discarded.
+- Throttle / RPD → `onThrottle` SSE; book-wide may hit `DailyQuotaExhaustedError` mid-run (§4.5).
+- Invalid op (anchor absent/non-unique, consumed-id edit, stale id) → dropped + logged + surfaced
+  un-appliable; run continues.
+- Cancel/abort → `signal` propagates; ephemeral suggestions discarded.
 
 ## 8. Testing & acceptance
 
-- **Server unit, per class (5):** before/after fixtures; the anchor-locator resolution (found + unique →
-  correct slice; not-found / ambiguous → rejected); apply-order on mixed same-id ops (§4.3); op-validation
-  rejections (§5.6/§7).
-- **Staleness regressions (§5.3):** `strip_tag` on a rendered sentence marks the chapter stale;
-  `fix_emotion` `angry → neutral` on a rendered sentence marks it stale (the neutral-direction fix).
-- **Apply-via-reducer:** accepted `split`/`merge`/`fix_emotion`/`strip_tag` dispatch the mapped reducers
-  and produce the same state a manual edit would (incl. global ID allocation, survives re-analysis).
+- **Server unit, per class (5):** before/after fixtures; op-envelope parse + imperative validation.
+- **Client apply-via-reducer:** accepted `strip_tag`/`split`/`extract`/`merge`/`fix_emotion` dispatch the
+  mapped reducers (incl. the new `setSentenceText` + `mergeSentences`) and produce the same state a manual
+  edit would, incl. global ID allocation.
+- **Staleness (unified hash, §5.3):** `strip_tag`, a `split` retained piece, and `fix_emotion`
+  `angry → neutral` each mark a *rendered* chapter stale (the three gaps the characterId-only diff missed).
+- **`merge` re-analysis survival:** a sentence-merge + a subsequent re-analysis does NOT resurrect the
+  dropped id / duplicate content (the tombstone works).
+- **Anchor locator:** found/unique → correct split; non-unique → un-appliable; **quote-normalization**
+  (LLM returns a curly-quote/em-dash anchor; live text has straight) → resolves or rejects deterministically.
+- **TOCTOU:** a well-formed suggestion whose target sentence was edited between run and accept is rejected
+  as un-appliable (anchor no longer unique / id text changed), not mis-applied.
 - **M5 abstention:** `strip_tag` must NOT strip intentional vocalizations ("Ah!").
-- **Frontend unit:** `ScriptReviewDiff` selection logic → dispatch payload; the dedicated slice is **not
-  wiped** by a revisions poll and **shows only the active book** (concurrent-multi-book).
+- **Frontend unit:** `ScriptReviewDiff` selection → dispatch; the dedicated slice is **not wiped** by a
+  revisions poll and **shows only the active book**.
 - **E2E (Playwright):** per-chapter trigger → diff → accept a subset → manuscript updates → chapter reads
   stale. Append a case to `e2e/responsive/coverage.spec.ts`.
-- **No sidecar/golden-audio tier** — Unit A loads no TTS model.
+- **No api-types regen** (suggestions are ephemeral — no new persisted type); **no sidecar/golden tier**
+  (no TTS model).
 
 ## 9. Non-goals & follow-ups
 
 **Non-goals (Unit A):** no TTS-engine involvement (§4.4); no `reattribute`/`flag_nonstory` (Unit B, §13);
-no `validate_instruct` (fs-56); no headless/server apply (browser-only, §5.1 — fs-44 dep below); no
-suggestion persistence (below); no auto-apply without review; no free-form rewriting beyond `strip_tag`;
-no entitlement gate ("premium" dropped).
+no `validate_instruct` (fs-56); no headless/server apply (browser-only, §5.1); no suggestion persistence;
+no auto-apply without review; no free-form rewriting beyond `strip_tag`; no entitlement gate.
 
-**Follow-ups — FILE NOW (issue + thin BACKLOG row, per the project rule); the #998/BACKLOG update is a
-hard gate to leave `draft`:**
-1. **Update #998 + BACKLOG** to Unit A scope + the "no TTS engine" correction.
-2. **fs-58 Unit B** (`reattribute` + `flag_nonstory`) — file with its deps (§13).
-3. **`validate_instruct`** — blocked on fs-56's per-sentence `instruct`; **also edit the fs-56 issue/spec**
-   to carry the move-here note (bidirectional in tracked artifacts).
-4. **fs-44 server apply path** — headless equivalent of §5's client apply.
-5. **Persist suggestions** across reload (`script-review-suggestions.json`).
+**Follow-ups — to FILE WITH THE PLAN (none are filed yet; the spec does not claim otherwise):**
+1. **Rewrite #998 + the BACKLOG row** to Unit A scope + "no TTS engine" — the hard gate to leave `draft`.
+2. **fs-58 Unit B** issue (`reattribute` + `flag_nonstory`) with its deps (§13).
+3. **`validate_instruct`** issue (blocked on fs-56's `instruct`) **+ edit fs-56 (#996)** to carry the
+   move-here note (bidirectional capture in tracked artifacts).
+4. **Edit fs-44 (#721)** with the server-apply dependency note (§5.1).
+5. **Persist suggestions** across reload (can wait).
 
 ## 10. Dependencies & linkage
 
-- **Reuses (no new infra):** `splitSentence`, `applyChapterRestructure` + the `/chapters/merge` route,
-  `setSentenceEmotion`, the debounced `putBookState` manuscript persistence, the change-log + staleness
-  derivation, the analyzer call path + `RateLimiter`, the DriftReport accept-reject UI pattern.
-- **New:** `setSentenceText` reducer + text-change staleness (§5.3.1); the neutral-direction emotion
-  staleness fix (§5.3.2); the dedicated suggestions slice (§5.5); the review pass + endpoint + diff modal.
-- **fs-56 (#996)** — `validate_instruct` parked there (§9.3). **fs-33 (#596)** — backfill, complementary to
-  `fix_emotion` (§2). **fs-44 (#721)** — server apply path (§5.1, §9.4).
+- **Reuses:** `splitSentence`, `setSentenceEmotion`, the debounced `putBookState` persistence, the
+  change-log (`bumpBoundaryMove`), the analyzer call path + `RateLimiter`, the DriftReport UI pattern,
+  the SSE operator-job pattern.
+- **New:** `setSentenceText` reducer + the **`mergeSentences`** reducer + the merge **tombstone**; the
+  unified content-hash on the render map (server GET + `segments.json` + `chapters-slice` type, §5.3); the
+  dedicated suggestions slice (§5.5); the review pass + endpoint + diff modal; the `registry.ts` prompt
+  knob (§4.2). **No `api-types.ts` regen** (ephemeral suggestions).
+- **fs-56 (#996)** `validate_instruct`; **fs-33 (#596)** complementary backfill; **fs-44 (#721)** server
+  apply path.
 
 ## 11. Implementation ordering (for the plan)
 
-1. **Apply foundations (client-side):** the `setSentenceText` reducer + text-change staleness; the
-   neutral-direction emotion staleness fix; the per-class reducer mapping (§5.2) + anchor→offset
-   resolution; with the §8 apply-via-reducer + staleness regressions. *Self-contained, test-first.*
-2. **Read-only review pass + endpoint:** the ~13-site extension (§4.2); the flat-envelope schema +
-   imperative op-validation (decide Ollama-union vs flatten, §4.3); the per-chapter endpoint + optional
-   book-wide; the review-model knob + RPD warning (§4.5); the prompt + M5 carve-out + abstention prompting.
-3. **Operator UX:** the dedicated slice (§5.5); `ScriptReviewDiff` (per-chapter, per-class toggles); the
-   accept → dispatch wiring; the E2E spec.
+1. **Apply foundations (client-side, test-first):** the `setSentenceText` + `mergeSentences` reducers; the
+   unified content-hash staleness (render map + server GET + precise-path diff); the client anchor
+   resolver (§4.3/§5.6); per-class change-log emission. With the §8 apply/staleness/merge-resurrection/
+   anchor/TOCTOU regressions. *Highest-risk; carries the latent-bug staleness fixes.*
+2. **Read-only review pass + endpoint:** the ~16-site extension (§4.2); the flat-envelope schema +
+   imperative validation; the per-chapter endpoint + optional book-wide + overflow chunking; the
+   review-model knob + RPD warning; the prompt + M5 carve-out + abstention prompting.
+3. **Operator UX:** the dedicated slice + `store/index.ts` registration; `ScriptReviewDiff`; the accept →
+   dispatch wiring; the E2E spec.
 
-## 12. Adversarial review — resolutions (R1 + R2, 2026-06-23)
+*Smallest still-valuable slice if scope must shrink later: steps share the harness, so a field-edits-only
+cut (`strip_tag` + `fix_emotion` + the staleness fixes, no anchor/structural reducers) remains a clean
+fallback — recorded per the round-3 recommendation, not the chosen scope (all 5).*
 
-Two rounds, three code-grounded reviewers each. Net effect: decompose to Unit A + invert apply to the
-client.
+## 12. Adversarial review — resolutions (R1+R2+R3, 2026-06-23)
 
-**Round 1 → revision 1:** server-side invalidation was fictional (staleness is client-derived);
-merge-as-drop resurrected on re-analysis; Gemini `responseSchema` unwired; offsets fragile; mixed-op order
-undefined; maxId global not per-chapter; "wholesale reuse" overstated; `excludeFromSynthesis` cosmetic;
-pre-selected-all unsafe; whole-book unusable. *(Revision 1 fixed several but introduced new errors —
-caught in round 2.)*
+Three rounds, three code-grounded reviewers each.
 
-**Round 2 → this spec (Unit A):**
-- **Server apply fights the architecture (C3/C4/H1) → §5 client-side apply.** Wrong write-lock,
-  refetch-clobbers-unflushed-edits, and the frontend-only restructure reducer all dissolve when apply
-  never leaves the client.
-- **`boundary_move` is the wrong staleness primitive for rendered chapters → §5.3.** The precise
-  characterId-diff supersedes it; `strip_tag`/`fix_emotion` need explicit staleness fixes.
-- **Verbatim-pieces MORE fragile than offsets → §4.3 anchor-locator.**
-- **`fix_emotion`→fs-33 was a silent capability regression → kept in Unit A (§2/§3).** fs-33 is
-  backfill-only.
-- **`reattribute_blocked` advisory points at a non-existent add-cast path; `flag_nonstory` is
-  import-residue-specific + untestable on the canonical fixture → both carved to Unit B (§13).**
-- **Touch-list undercounted → §4.2 ~13 sites incl. frontend.**
-- **Decompose at the mechanics/content seam → Unit A / Unit B.**
-- **Folded:** per-chapter trigger (fs-35); flat-envelope honesty + Ollama-union asymmetry (§4.3);
-  dedicated non-polled slice + reload story + active-book selector (§5.5); RPD cost (§4.5); `.strict()`
-  safe on disk; dropping `startMs/endMs` on structural ops (no runtime consumer — verified); the count
-  corrected to **5 live (Unit A)**; the `isLikelyFrontMatter` precedence note dropped (real chapter
-  exclusion is `excludedSlugs`, pre-analysis, so no sentences exist to interact — moved to Unit B's
-  concern).
+- **R1:** server-side invalidation fictional; merge-as-drop resurrects; Gemini `responseSchema` unwired;
+  offsets fragile; mixed-op order undefined; maxId global; reuse overstated; pre-selected-all unsafe;
+  whole-book unusable.
+- **R2:** server apply fights the client-driven architecture (wrong lock / refetch-clobber / frontend-only
+  restructure) → **invert apply to the client (§5)**; `boundary_move` wrong primitive; verbatim-pieces
+  more fragile than offsets → **anchor (§4.3)**; `fix_emotion`→fs-33 a silent regression → **kept (§2)**;
+  `reattribute`/`flag_nonstory` deps → **Unit B**; touch-list undercounted; **decompose**.
+- **R3:** **`merge` has no reducer** (`/chapters/merge` is chapter-level) → **new `mergeSentences` +
+  tombstone (§5.2/§5.3)**; **TOCTOU** (server offset vs live text) → **client-side anchor resolution at
+  accept (§4.3/§5.6)**; "inherits wholesale" overstated → **staleness/change-log are call-site dispatches
+  (§5.1)**; **third staleness gap** (split/extract retain ids) → **unified content-hash (§5.3)**;
+  touch-list ~16 (registry knob + mock api + store registration); **§5.6 created**; flatten-both
+  **decided (§4.3)**; per-chapter verified the right granularity; #998 stale + follow-ups unfiled →
+  **file with the plan (§9)**.
 
-## 13. Unit B (deferred — carved out, file as a follow-up)
+## 13. Unit B (deferred — file as a follow-up)
 
-`reattribute` + `flag_nonstory`. Same harness as Unit A (review pass, diff modal, client-side apply); each
-adds a class plus an unmet dependency:
+`reattribute` + `flag_nonstory`. Same harness as Unit A; each adds a class + an unmet dependency:
 
-**`reattribute`** — re-assign a dialogue line to the correct **existing** cast member (field delta on
-`characterId` via `setSentenceCharacter`; detected by the precise staleness path). Deps:
-- **Off-roster actionability.** When the correct speaker isn't in the roster (folded into `unknown-*`), the
-  intended `reattribute_blocked` advisory has **nowhere to go** — there is no "add a never-detected
-  character" path (the "Add character" button `manuscript.tsx:1053` is inert; only `add-from-roster` +
-  alias-unlink exist). Needs net-new cast-create wiring, or the advisory must be narrowed to the cases
-  that work.
-- **Cross-chapter context.** Tagless turn-taking can straddle a chapter boundary; per-chapter review
-  inherits Phase-1's boundary blind spot. Book-wide is the only way to catch chapter-straddling
-  reattributions (in tension with the RPD/usability limits).
-- **Default OFF** in the diff (high-risk — re-voices dialogue + invalidates audio).
+**`reattribute`** — re-assign a dialogue line to the correct existing cast member (field delta on
+`characterId` via `setSentenceCharacter`; covered by the §5.3 hash). Deps: **off-roster actionability** —
+no path to add a never-detected character (the "Add character" button `manuscript.tsx:1053` is inert; only
+`add-from-roster` + alias-unlink exist), so the intended `reattribute_blocked` advisory has nowhere to go
+without new cast-create wiring; **cross-chapter context** (tagless turn-taking straddles chapters → needs
+book-wide, in tension with RPD); **default OFF**.
 
-**`flag_nonstory`** — flag import residue (page numbers, running headers) so the TTS doesn't read them.
-Deps:
-- **New `excludeFromSynthesis` field** (OpenAPI → types → Zod) + a synth-side filter in
-  `buildSentenceGroups` (`synthesise-chapter.ts:~659`, location verified) — without it the flag is
-  cosmetic.
-- **Exclusion-staleness fix:** excluding a sentence changes no `characterId`, so the precise path won't
-  mark the chapter stale — already-rendered audio keeps speaking the junk line. Needs an exclusion-aware
-  branch in `isChapterReassignedSinceRender` (`stale-chapters.ts`).
-- **A positive test fixture:** the canonical `the-coalfall-commission.md` is clean markdown with zero
-  artifact lines (markdown/plaintext import strips none); needs a PDF/synthetic artifact-bearing fixture —
-  the class is **import-residue-specific** (mostly PDF/EPUB), narrower than "front-matter" implies.
-- **Default OFF** in the diff (can silently mute real story lines if it over-fires).
+**`flag_nonstory`** — flag import residue (page numbers, running headers). Deps: **new
+`excludeFromSynthesis` field** (OpenAPI → types → Zod) + a synth filter in `buildSentenceGroups`
+(`synthesise-chapter.ts:~659`, location verified) + **`api-types.ts` regen**; **exclusion-staleness** (an
+excluded sentence changes no `characterId` and isn't dropped — needs the §5.3 hash to also notice the
+exclude flag); **a positive fixture** (the canonical `the-coalfall-commission.md` is clean markdown with
+zero artifacts — the class is **import-residue-specific**, mostly PDF/EPUB); **default OFF**.

--- a/docs/superpowers/specs/2026-06-23-fs58-llm-script-review-design.md
+++ b/docs/superpowers/specs/2026-06-23-fs58-llm-script-review-design.md
@@ -1,361 +1,335 @@
 ---
-title: fs-58 — LLM Script Review (annotation-QA second pass)
+title: 'fs-58 — LLM Script Review, Unit A: annotation mechanics + emotion correction'
 status: draft
 date: 2026-06-23
 issue: '#998'
 related:
   - 2026-06-22-expressive-tts-instruct-tiers-design.md (§4.6 — fs-58's original sketch; this spec supersedes it, incl. placement)
   - fs-56 (#996) — per-line `instruct` field; owns the deferred `validate_instruct` class
-  - fs-33 (#596) — emotion-only backfill pass; emotion correction is routed here, NOT duplicated in fs-58
-  - fs-35 — per-chapter scoping follow-up for the whole-book emotion pass (precedent: whole-book is too coarse)
-  - fs-25 (#479) — per-quote emotion enum
-  - Russian stage-2 attribution under-production (plan 221) — the attribution pain `reattribute` targets
-  - com-1 — Cast Pass entitlement seam (no gate in fs-58; see §9)
+  - fs-33 (#596) — emotion-only BACKFILL pass; cannot correct an existing emotion (see §2), so `fix_emotion` stays here
+  - fs-44 (#721) — MCP/agent surface; client-side apply (§5) is browser-only → a server apply path is an fs-44 dependency (§9)
+  - fs-35 — per-chapter scoping precedent (whole-book pass is too coarse)
+  - fs-25 (#479) — per-quote emotion enum (the field `fix_emotion` repairs)
+  - Russian stage-2 attribution under-production (plan 221) — the attribution pain Unit B's `reattribute` targets
 inspiration: github.com/Finrandojin/alexandria-audiobook (Alexandria — LLM Script Review)
 ---
 
-# fs-58 — LLM Script Review
+# fs-58 — LLM Script Review (Unit A)
 
-> **Supersedes** the §4.6 sketch in `2026-06-22-expressive-tts-instruct-tiers-design.md`, **including its
-> placement** ("before `manuscript-edits.json` is written"). This spec runs the pass as a standalone job
-> *over* `manuscript-edits.json`, runnable anytime (incl. post-generation) — see §4.1.
+> **Decomposed (2026-06-23, after two adversarial review rounds).** fs-58 splits at the mechanics/content
+> seam:
+> - **Unit A (this spec):** 4 structural-mechanics classes + `fix_emotion`. Self-contained, fully testable,
+>   no unmet dependencies. **Apply is client-side** (§5).
+> - **Unit B (deferred, §13):** `reattribute` + `flag_nonstory`. Carved out — each drags in a real
+>   dependency that isn't fs-58's job (cast-create wiring; a new `excludeFromSynthesis` field + an
+>   exclusion-staleness fix; an artifact-bearing test fixture).
+> - **Deferred to fs-56:** `validate_instruct` (the per-sentence `instruct` field doesn't exist yet).
 >
-> **Re-scoping note (2026-06-23):** issue #998 / BACKLOG describe *five* classes + "engine-agnostic
-> (no GPU)." This spec ships **six live classes** (drops `fix_emotion` → fs-33; defers `validate_instruct`
-> → fs-56; adds `reattribute` + `flag_nonstory`) and corrects "no GPU" to "no TTS-synthesis engine"
-> (§4.4). **#998 + the BACKLOG row must be updated to match before this leaves `draft`.**
+> **Supersedes** the §4.6 sketch in `2026-06-22-expressive-tts-instruct-tiers-design.md`, **including its
+> placement** ("before `manuscript-edits.json` is written"): this runs as a standalone job *over* the
+> manuscript, anytime. **#998 + the BACKLOG row must be updated** (5 classes + "no GPU" → this scope +
+> "no TTS engine") before leaving `draft`.
 
 ## 1. Summary
 
-An **optional, operator-triggered, per-chapter QA pass** that runs a second LLM over already-attributed
-sentences and repairs common annotation errors, presented as an **accept/reject diff**. The LLM only
-*proposes*; the **server applies deterministically** and owns all sentence-ID allocation. It is
-**additive** — off → today's behaviour, exactly.
+An optional, operator-triggered, **per-chapter** QA pass: a **read-only** second LLM pass over
+already-attributed sentences proposes annotation repairs, shown as an accept/reject diff; accepted changes
+are applied **client-side by dispatching the same reducers a manual edit uses**. Additive — off → today's
+behaviour exactly.
 
-"Engine-agnostic" means **TTS-engine-agnostic** (no Kokoro/Coqui/Qwen load) — *not* GPU-free: it reuses
-the analyzer compute path (local Ollama on GPU, or Gemini cloud). See §4.4.
+"Engine-agnostic" = **TTS-engine-agnostic** (no Kokoro/Coqui/Qwen load), *not* GPU-free: it reuses the
+analyzer compute (local Ollama on GPU, or Gemini cloud). See §4.4.
 
 ## 2. Background
 
-Phase-1 attribution (`server/src/routes/analysis.ts`, the `runStage2Chapter` analyzer call) produces,
-per chapter, `Sentence`s `{ id, chapterId, characterId, text, confidence?, emotion?, startMs?, endMs? }`,
-written (post-fold/dedup) to `manuscript-edits.json` at `analysis.ts:~4043`. Phase-1 is good but not
-perfect: it leaks attribution tags into dialogue, over-/under-splits at narrator↔dialogue boundaries,
-mis-assigns speakers in tagless back-and-forth, and treats front/back-matter residue (page numbers,
-headers) as narration. fs-58 is the targeted repair pass for those errors.
+Phase-1 attribution (`server/src/routes/analysis.ts`, `runStage2Chapter`) produces per chapter
+`Sentence`s `{ id, chapterId, characterId, text, confidence?, emotion?, startMs?, endMs? }`, written
+(post-fold/dedup) to `manuscript-edits.json` at `analysis.ts:~4043`. It is good but leaks attribution
+tags into dialogue, over-/under-splits at narrator↔dialogue boundaries, and sometimes sets a wrong
+`emotion`. Unit A repairs exactly those.
 
-**Precedent:** fs-33's emotion-only backfill (`emotionAnnotationSchema`, `server/src/handoff/schemas.ts`)
-already runs a second analyzer pass over attributed sentences and returns `{ sentenceId, emotion }`.
-fs-58 generalises that *shape* (a second per-chapter analyzer pass) to additional error classes.
-**Emotion correction stays with fs-33** — fs-58 does not duplicate it (§3, §10).
+**fs-33 is backfill-only and cannot correct emotion.** Its apply path `applyDetectedEmotions`
+(`manuscript-slice.ts:288-306`) skips any sentence that already has an emotion (`:302` —
+`if (sent.emotion) continue`), and its prompt never sends the current emotion to the model. So "correct a
+*wrong* emotion" has no home in fs-33 without new overwrite-mode work — which is why `fix_emotion` lives
+here (it's a cheap field-delta; §5.2). fs-33 (fill empty) and `fix_emotion` (correct wrong) are
+complementary, not duplicative.
 
-## 3. Error classes (v1 = 6 live + 1 deferred + 1 routed)
-
-Two tiers. **Mechanics** classes fix sentence *shape*; **content** classes fix *who*.
+## 3. Error classes — Unit A (5 live)
 
 **Mechanics (structural):**
-1. `strip_tag` — remove an attribution tag ("she said") that leaked into dialogue text. *Field delta (newText).*
-2. `split` — split narration out of a dialogue entry. *Structural (content-addressed pieces, §4.3).*
-3. `extract_dialogue` — pull dialogue out of a narrator run into its own sentence with a `characterId`. *Structural.*
+1. `strip_tag` — remove an attribution tag ("she said") that leaked into dialogue text. *Text edit.*
+2. `split` — split narration out of a dialogue entry. *Structural (anchor-located, §4.3).*
+3. `extract_dialogue` — pull dialogue out of a narrator run into its own sentence. *Structural.*
 4. `merge` — merge over-split narrator entries into one. *Structural.*
 
-**Content (QA):**
-5. `reattribute` — re-assign a dialogue line to the correct **existing** cast member (incl. tagless
-   turn-taking). *Field delta on `characterId`.* Constrained to the **post-fold** roster (§4.2); never
-   invents a character. When the correct speaker is **off-roster** (e.g. folded into `unknown-male`), the
-   model instead emits a **read-only `reattribute_blocked` advisory** (rationale only, no apply, no roster
-   mutation) so the operator can decide to add a cast member — converting a silent mis-attribution into a
-   signal.
-6. `flag_nonstory` — flag front/back-matter residue and artifact lines (page numbers, headers, empty/
-   punctuation-only) that Phase-1 mislabeled as narration, via a soft `excludeFromSynthesis` flag (no
-   deletion, no ID churn). **Constrained** to lines whose `characterId` is `narrator` AND that match
-   artifact signatures (digit-only, header-case, page-number patterns) — never a line the model would
-   otherwise `reattribute`, and never a short legitimate narration/dialogue line ("Silence.", "Run!").
-
-**Routed — `fix_emotion`:** emotion correction is **out of fs-58**; it belongs to fs-33's emotion pass. If
-fs-33 needs a "correct an existing wrong emotion" mode (vs. backfill-only), that is filed against fs-33
-(§9). Rationale: avoid a second, divergent emotion path (Simplicity-first); and emotion staleness has its
-own 3-way-gated rule (`sentence-emotion-control.tsx:77-87`) that fs-33 already lives next to.
-
-**Deferred — `validate_instruct`:** the per-sentence free-text `instruct` field does not exist yet
-(fs-56 owns it). **Parked in fs-56's scope** with a bidirectional cross-link filed as a tracked issue
-(§9) — if fs-56 ships the field before fs-58, the class moves back here. No dead code ships in fs-58.
+**Content (rides along — ready, no unmet deps):**
+5. `fix_emotion` — correct an obviously-wrong `emotion` enum value (calm line marked `angry` → `neutral`).
+   *Field delta on `emotion`.* Reuses `setSentenceEmotion`; carries the neutral-direction staleness fix
+   (§5.3).
 
 **M5 carve-out:** the prompt **never strips intentional non-verbal vocalizations** ("Ah!", "Haah…") as
-attribution tags, and `flag_nonstory` never flags a vocalization line as junk. Hard, tested constraint.
+attribution tags. Hard, tested constraint on `strip_tag`.
+
+(`reattribute`, `flag_nonstory` → Unit B, §13. `validate_instruct` → fs-56.)
 
 ## 4. Architecture & flow
 
 ### 4.1 Where it slots
 
-A **standalone, per-chapter job** (not inside the analyse SSE), runnable **anytime** incl. post-generation:
+A **standalone, per-chapter job** (not inside the analyse SSE), runnable anytime incl. post-generation:
 
-- New endpoint **`POST /api/books/:bookId/script-review`** taking an **optional `chapterId`** (default:
-  the chapter being edited; whole-book is opt-in). Own SSE stream mirroring the analysis grammar
-  (`phase` / per-chapter progress / `result`). Per-chapter default keeps the diff usable at novel scale
-  (fs-35 precedent: a whole-book-only pass is too coarse).
-- Mounts under `/api`, so it **inherits `requireLanToken` + `requireSameOrigin` CSRF** (`app.ts:111-114`)
-  — no per-route auth needed.
+- `POST /api/books/:bookId/script-review` taking an **optional `chapterId`** (default: the chapter being
+  edited; whole-book is opt-in). Own SSE stream mirroring the analysis grammar. Per-chapter keeps the diff
+  usable at novel scale (fs-35 precedent).
+- Mounts under `/api` → inherits `requireLanToken` + `requireSameOrigin` CSRF (`app.ts:111-114`).
 - **Non-sticky / no resume** (like fs-33's annotate-emotion): a disconnect mid-run aborts; re-run from
-  scratch. Set this UX expectation.
+  scratch. On a book-wide run this re-spends RPD (§4.5) — surface the expectation.
 
-### 4.2 The review pass — interface touch-list (NOT "wholesale reuse")
+### 4.2 The review pass — read-only, ~13-site touch-list
 
-The `Analyzer` interface is **closed and per-stage** (`index.ts:62-94`); adding a pass means a ~7-site
-extension in lockstep (exactly what fs-33 did):
-1. `runScriptReviewChapter` on the `Analyzer` interface (`index.ts`).
-2. `OllamaAnalyzer` impl (`ollama.ts`) — grammar via `format`/`z.toJSONSchema`.
-3. `GeminiAnalyzer` impl (`gemini.ts`).
-4. `FallbackAnalyzer` delegation (`index.ts`).
-5. The review op/delta schema pair (`schemas.ts`).
-6. A skill/prompt file + prompt-registry id.
-7. A `HandoffKey`.
-8. The route (§4.1).
+The pass **writes nothing**; it returns suggestions (§4.3). The `Analyzer` interface is closed and
+per-stage; adding a pass is a multi-site extension across server **and frontend** (re-derived from the
+fs-33 `runEmotionChapter` diff — the round-1 "~7 sites" was undercounted):
 
-- Model selection: reuse `selectAnalyzer` / per-phase selection (`select-analyzer.ts`,
-  `isPerPhaseModelSelectionActive`) with a **dedicated review-model knob** (separate user setting;
-  defaults to the analyzer's configured model).
-- **Input:** the target chapter's current `sentences[]` + the **post-fold** cast roster (the cache retains
-  pre-fold descriptor ids, `book-state.ts:296-304`; passing the post-fold roster prevents every
-  `reattribute` to a folded id being dropped as off-roster).
+*Server:* (1) `runScriptReviewChapter` on the `Analyzer` interface (`index.ts`); (2) `OllamaAnalyzer`
+impl; (3) `GeminiAnalyzer` impl; (4) `FallbackAnalyzer` delegation; (5) the **validation** schema +
+(6) the **grammar** schema for Ollama constrained-decode (distinct artifacts, cf. `stage1ChapterGrammarSchema`);
+(7) the skill prompt `.md`; (8) `SKILL_FILES` + the `SkillName` union (`gemini.ts:123`); (9)
+`SKILL_TO_PROMPT_ID` (`gemini.ts:130`); (10) a `HandoffKey`; (11) the route + SSE; (12) the
+`openapi.yaml` *path* entry. *Frontend:* (13) the `api.ts` client method + its SSE-event/Opts/Result
+types (cf. fs-33's `detectEmotions`, `api.ts:~2655`).
 
-### 4.3 Output format — flat schema, content-addressed structural ops
+- Model selection reuses `selectAnalyzer` / per-phase selection with a **dedicated review-model knob**
+  (defaults to the analyzer's model).
+- **Input:** the target chapter's `sentences[]` + the **post-fold** cast roster (the cache holds pre-fold
+  descriptor ids, `book-state.ts:296-304`; post-fold avoids spurious drops).
 
-**Flat schema, no discriminated union.** Reason: the **Gemini path does not send `responseSchema`** today
-(`gemini.ts:561-566` sets only `responseMimeType`) — output is free-form JSON repaired by `parseAndValidate`.
-A tagged union with integer offsets is unsafe in that regime. Two options, decided at plan time:
-(a) keep a **flat** array of edits in the working free-form-JSON regime (preferred), or (b) **wire
-`config.responseSchema` into `gemini.ts`** as an explicit prerequisite (verify no regression to existing
-passes). **Stop asserting Gemini is schema-constrained until (b) lands.**
+### 4.3 Output format — flat envelope + imperative validation; anchor-located structural ops
 
-Each edit is one row: `{ id, op, ...payload, rationale, confidence }`. **The LLM never invents sentence
-IDs.** Payloads:
-- **Field deltas** keyed by existing `id`: `strip_tag` (newText), `reattribute` (characterId),
-  `flag_nonstory` (exclude=true).
-- **Structural ops, content-addressed (no offsets):** `split`/`extract_dialogue` return the resulting
-  text **pieces verbatim** + per-piece `characterIds`; `merge` returns the member `ids`. The server
-  validates `normalizeWhitespace(concat(pieces)) === normalizeWhitespace(original.text)` before applying
-  — deterministic, self-validating, no character-counting. Off-roster `reattribute` → `reattribute_blocked`
-  advisory row (no payload, rationale only).
+Each suggestion is one row `{ id, op, ...payload, rationale, confidence }`. The Zod schema validates the
+**envelope only**; per-op payload shape is validated **imperatively in the apply layer** (§5.6), because
+the Gemini path sends no `responseSchema` (`gemini.ts:561-566`) — output is free-form JSON. *(Asymmetry to
+decide at plan time: Ollama **can** enforce a discriminated union via constrained decode / `z.toJSONSchema`
+— `ollama.ts:312-328`; Gemini cannot. Either keep a union for Ollama + imperative checks for Gemini, or
+flatten both. Don't claim "schema-constrained" for Gemini.)*
 
-**Apply order (resolves same-id collisions).** Per chapter: apply **structural ops first** (merge →
-split/extract) to fix the id set, **then** field deltas against surviving ids. **Reject** (drop + log,
-surface as un-appliable) any field delta whose target id was consumed by a structural op, and any 2nd
-structural op on the same id.
+Payloads:
+- **Field edits** keyed by `id`: `strip_tag` (newText), `fix_emotion` (emotion).
+- **Structural ops — ANCHOR-LOCATED, not verbatim pieces.** The LLM returns a **short unique anchor
+  substring** marking the split point (`split`/`extract_dialogue`) or the member `ids` (`merge`). The
+  apply layer locates the anchor with `indexOf` in the *original* text (+ uniqueness check) and **slices
+  the pieces itself**. The model only *points*; it never reproduces text. *(Round 2 reversed the round-1
+  "content-addressed pieces" fix: verbatim-piece concat-equality is MORE fragile here — LLMs normalize
+  curly quotes / em-dashes, and the Gemini JSON-repair walker rewrites quotes inside strings,
+  `gemini.ts:865`, so quote/dash-bearing dialogue — the main split target — would fail equality and drop
+  silently. Anchor-locate keeps the server the sole source of truth for text.)*
+
+**Apply order** (same-id collisions): structural ops first (merge → split/extract), then field edits vs
+surviving ids; reject a field edit whose id was consumed, and a 2nd structural op on one id.
 
 ### 4.4 Compute note
 
-Reuses the **analyzer** path — local Ollama (**GPU, same footprint as Phase-1**; holds the analyzer GPU
-semaphore slot, `ollama.ts:523`) or Gemini (cloud, GPU-free). Loads **no TTS model**, adds **no new
-resident GPU model**, never co-resident with a TTS engine — clear of the parent spec's §4.7 VRAM
-invariant. On a single small (8 GB) GPU it **contends with the analyzer and is evicted-by/evicts TTS** —
-you cannot run a review pass concurrently with a generation on one small card.
+Reuses the analyzer path — local Ollama (**GPU, same footprint as Phase-1**; holds the analyzer GPU
+semaphore, `ollama.ts:523`) or Gemini (cloud). Loads no TTS model; adds no new resident GPU model; never
+co-resident with a TTS engine — clear of the parent spec's §4.7 VRAM invariant. On one small (8 GB) GPU it
+**contends with the analyzer and evicts/evicted-by TTS** — can't run concurrently with a generation there.
 
 ### 4.5 Cost & latency
 
-Per-chapter trigger = **one LLM call per run** (book-wide = one per chapter). The free-tier RPD caps bite
-on book-wide runs: `gemini-2.5/3.5-flash` RPD **20** (`rate-limit.ts:38-40`) — a 20+-chapter book cannot
-finish in a day on those; `gemini-3.1-flash-lite` is RPD 500 / RPM 15. The **stronger** models have the
-**lowest** RPD, so the review-model knob's "point at a stronger model" actively worsens book-wide cost.
-*Spec requirement:* the UI knob **warns when (book-wide chapters > model RPD)**, and the recommended
-default is **local Ollama or a high-RPD Gemma**. The limiter serializes + emits `throttle` SSE events.
+Per-chapter = **one LLM call/run** (book-wide = one per chapter). Free-tier RPD bites on book-wide:
+`gemini-2.5/3.5-flash` RPD **20** (`rate-limit.ts:37-43`) — a 20+-chapter book can't finish in a day;
+`gemini-3.1-flash-lite` RPD 500, `gemma` 1500. **Stronger models have the LOWEST RPD**, so the review-model
+knob's "stronger model" worsens book-wide cost. The UI knob **warns when book-wide chapters > model RPD**;
+recommended default is local Ollama or a high-RPD Gemma. Non-sticky (§4.1) + RPD-capped means an
+interrupted book-wide run is unrecoverable within the day — another reason per-chapter is the default.
 
-## 5. The ID-stability & audio-staleness contract
+## 5. Apply — client-side dispatch (the inversion)
 
-The load-bearing part. Every accepted change is applied **server-side**, writing through to
-`manuscript-edits.json` as the **sole ID allocator**.
+### 5.1 The model
 
-### 5.1 ID allocation — global, server-only
+The server review pass **writes nothing**. Accepted suggestions are applied in the browser by
+**dispatching the existing manual-edit reducers**. Consequence: Unit A **inherits manual-edit semantics
+wholesale** — ID allocation (the global `maxId+1` rule in `splitSentence`/restructure), persistence (the
+debounced `putBookState` manuscript PUT), staleness derivation, the change-log, and in-flight-generation
+behaviour all come for free, because an accepted suggestion *is* a manual edit. This dissolves the round-1/2
+server-apply hazards (wrong write-lock, refetch-clobbers-unflushed-edits, server can't reuse the frontend
+restructure reducer, tombstone has no consumer) — none arise when apply never leaves the client.
 
-- Sentence ids are **per-chapter** (restart at 1, `stage2-chunk.ts:259`), but the reparse-survival filter
-  keeps any edit with `id > maxCacheId` where `maxCacheId` is computed over the **flattened cache across
-  all chapters** (`book-state.ts:281-284`). So new ids must be allocated from the **global** max across the
-  whole manuscript's current sentence set — **not** the per-chapter max (a per-chapter allocation would
-  mint an id ≤ global max and be orphan-filtered on the next GET, `book-state.ts:289`).
-- **Sole allocator:** the server apply read-modify-writes `manuscript-edits.json` under the existing
-  mutation serialization (`serializeQueueMutation`, `generation.ts:305-315`). The client does **not**
-  optimistically merge — it **refetches** the manuscript after apply. This kills the client+server
-  dual-allocator collision/race (two independent allocators minting the same id).
+**fs-44 note (filed, §9):** this makes apply browser-only. A headless/MCP agent (no Redux) cannot apply,
+so an equivalent **server apply path is an explicit fs-44 dependency** — captured so the agent surface
+doesn't silently inherit a browser-only assumption.
 
-### 5.2 Field deltas (no ID change)
+### 5.2 Per-class reducer mapping
 
-`strip_tag`, `reattribute`, `flag_nonstory` mutate the existing sentence in place by `id`. ID-stable.
+| Class | Reducer | Status |
+|---|---|---|
+| `split` / `extract_dialogue` | `splitSentence` (`manuscript-slice.ts:330`) | exists; server resolves the anchor (§4.3) → offsets before dispatch |
+| `merge` | `applyChapterRestructure` via the existing `/chapters/merge` route + remap (`restructure.tsx`, `manuscript-slice.ts:378`) | exists; **merge uses the same path manual merges use**, so re-analysis resurrection is handled by the path that already handles it |
+| `fix_emotion` | `setSentenceEmotion` (`manuscript-slice.ts:269`) | exists |
+| `strip_tag` | **NEW `setSentenceText` reducer** | **no text-edit reducer exists today** — see §5.3 |
 
-### 5.3 `split` / `extract_dialogue`
+### 5.3 Two staleness/reducer gaps Unit A must close (honest)
 
-- Original keeps its `id`; each new piece gets a **global** `maxId+1, +2, …` (§5.1).
-- `extract_dialogue` assigns the extracted piece the dialogue `characterId`; remainder stays narrator.
-- **Drop `startMs`/`endMs`** on the original and all pieces — render-time timing is invalid the moment the
-  shape changes; the next render restamps. (Silently copying corrupts listen-view seek / clip-share.)
+The precise staleness path (`stale-chapters.ts:58-70`) diffs **`characterId` only** of rendered sentences.
+Two Unit A edits change neither id-set nor characterId, so they would NOT mark audio stale:
 
-### 5.4 `merge` — restructure, not pure drop (re-analysis must not resurrect)
+1. **`strip_tag` (text change).** Needs (a) a new `setSentenceText` reducer (persists via the existing
+   whole-array manuscript PUT, `book-state.ts:570`) and (b) extending the rendered-sentence diff to flag a
+   **text change** on a rendered id (the spoken words changed → audio is stale). NEW.
+2. **`fix_emotion` neutral-direction.** The emotion-staleness rule (`sentence-emotion-control.tsx:77-87`)
+   only marks stale when the *new* value is `≠ neutral` (+ Qwen + a designed variant). Correcting
+   `angry → neutral` — `fix_emotion`'s signature case — leaves the angry-variant audio in place silently.
+   Fix: compare *rendered* emotion-variant vs *new* emotion, not just `≠ neutral`. (A latent bug in the
+   existing manual emotion-edit flow; worth fixing regardless.)
 
-- Surviving `id` = **lowest** in the set; `text` = members concatenated in document order (single space).
-- **Validation:** members must share an identical `characterId` AND be **all `neutral`** (so no emotion is
-  orphaned — the parent spec's M1 forbids orphaning emotion) AND lie within **one `chapterId`**. Reject
-  otherwise (drop + log). Drop `startMs`/`endMs`.
-- **Contract requirement (the C3 hazard):** a merge must **survive a subsequent re-analysis** without
-  resurrecting the dropped ids as duplicate content. A pure drop from `manuscript-edits.json` is
-  insufficient — re-analysis re-mints the per-chapter ids and the frontend `hydrateFromAnalysis` append
-  branch (`manuscript-slice.ts:149-151`) re-adds them. **Candidate mechanism (verify at plan time):** model
-  merge/split as a server-side chapter **restructure with a remap table** (mirroring
-  `applyChapterRestructure`, `manuscript-slice.ts:378-401`, which drops un-remapped ids deterministically)
-  and/or a persisted **tombstone set** the hydrate-append branch consults. *The hydrate-append branch is
-  the corruptor and must be addressed.*
+`split`/`extract`/`merge` need no staleness work — they change the rendered id-set, which the precise path
+already detects.
 
-### 5.5 Audio staleness — the real lever is `boundary_move`, not a server stale flag
+### 5.4 In-flight generation
 
-There is **no server-side stale flag**; staleness is **client-derived** (`stale-chapters.ts:58-70` diffs
-the render-time speaker map against the live Redux manuscript; `generation.tsx:629-646`). The only
-server-reachable lever is the **change-log `boundary_move` event** (the time-based heuristic,
-`stale-chapters.ts:18-44`, whose precondition is *"EVERY reassignment path must emit a `boundary_move`"*).
+Applying during a generation = manually editing during a generation: **inherits existing semantics** (no
+bespoke per-chapter guard, no book-level block). Whatever the app does for a manual edit mid-render, it
+does here — by construction.
 
-- The server apply **appends a `boundary_move` change-log event** for **every affected chapter** on:
-  any structural op, any `reattribute`, and any `flag_nonstory` exclude. The client then re-derives
-  staleness on its next manuscript refetch (which §5.1 already forces).
-- **Remove** the prior "eager server-side invalidation via the segments-map drift mechanism" claim — that
-  mechanism is client-only and carries `characterId` only.
-- **Cross-tab caveat:** manuscript mutations are **not** broadcast (`broadcast-middleware.ts:60-62`), so a
-  second open tab keeps a stale manuscript + stale-audio badges until it refetches. State this; don't
-  promise cross-tab freshness.
+### 5.5 Suggestion lifetime & storage
 
-### 5.6 Guards
-
-1. **Op validation before apply:** concat-equality for structural ops (§4.3); referenced ids exist;
-   merge same-`characterId` + all-`neutral` + same-`chapterId`; `reattribute` target ∈ **post-fold**
-   roster; ≤1 structural op per id; no field delta on a consumed id. Invalid → dropped + logged + surfaced
-   as un-appliable; never corrupt state.
-2. **In-flight generation guard (v1 = book-level):** only `isGenerationActive(bookId)` is exported
-   (`generation.ts:396`); the per-chapter registry is private. **v1 blocks apply for the whole book while
-   any generation job runs.** A chapter-level guard is a filed follow-up (§9).
-3. **Transactional per chapter** — a write failure applies nothing for that chapter.
-
-### 5.7 Suggestion lifetime & storage
-
-Ephemeral per run. Stored in a **dedicated, non-polled, bookId-keyed** slice — **NOT** `revisions.pending`,
-which `applyPoll` replaces wholesale per poll (`revisions-slice.ts:160-163`) and would wipe an in-progress
-review (and violate the concurrent-multi-book invariant). "Extends the revisions/DriftReport pattern" means
-the **UI pattern only**. Persisting suggestions across reload is a follow-up (§9).
+Ephemeral per run, in a **dedicated, non-polled, bookId-keyed** slice — **NOT** `revisions.pending`
+(`applyPoll` replaces it wholesale, `revisions-slice.ts:160-163`, which would wipe an in-progress review
+and break the concurrent-multi-book invariant). The modal's read-selector reads **only the active book's
+bucket**. "Extends the revisions/DriftReport pattern" = the **UI pattern only**. A reload discards the run
+(consistent with non-sticky, §4.1); persisting suggestions is a follow-up (§9). No cross-tab sync
+(manuscript isn't broadcast, `broadcast-middleware.ts:60-62`) — consistent with manual edits.
 
 ## 6. Operator UX
 
 - A **"Review Script"** button on the manuscript editing surface (per-chapter; whole-book is an explicit
   opt-in). Fires `POST …/script-review`; per-chapter progress reuses the analysis SSE `phase` grammar.
-- Results land in a **`ScriptReviewDiff` modal** (the DriftReport accept-reject *pattern*, dedicated slice
-  per §5.7), **grouped by chapter then class**, with per-class accept/reject and drill-down to per-change
-  toggles. Each row: before → after (text / characterId / exclude), class, LLM rationale, confidence.
-  `reattribute_blocked` rows render **read-only** (advisory).
-- **Tiered defaults:** mechanics classes (`strip_tag`/`split`/`extract_dialogue`/`merge`) pre-selected
-  **ON**; content classes (`reattribute`, `flag_nonstory`) default **OFF** (explicit opt-in). **Apply**
-  writes the selected set, emits `boundary_move` per affected chapter (§5.5), records a change-log entry,
-  and triggers a client manuscript refetch.
+- Results in a **`ScriptReviewDiff` modal** (the DriftReport accept-reject *pattern*, dedicated slice
+  §5.5), grouped by class, per-class accept/reject + per-change drill-down. Each row: before → after,
+  class, rationale, confidence.
+- **Defaults:** all Unit A classes are corrective/low-risk → pre-selected **ON** (operator deselects).
+  **Apply** dispatches the §5.2 reducers, which trigger the inherited staleness/change-log/persistence.
+  (The high-risk default-OFF tiering applies to Unit B's content classes, not Unit A.)
 
 ## 7. Error handling
 
-- LLM unreachable → Gemini fallback (`FallbackAnalyzer`); both down → SSE `error`, **no state change**.
-- Throttle / RPD → `onThrottle` SSE event; book-wide may hit `DailyQuotaExhaustedError` mid-run (§4.5) —
-  surface partial progress, no partial corruption (per-chapter transactional apply).
-- Malformed / invalid op → dropped + logged + surfaced as un-appliable; the run continues.
+- LLM unreachable → Gemini fallback; both down → SSE `error`, no suggestions, no state change.
+- Throttle / RPD → `onThrottle` SSE event; book-wide may hit `DailyQuotaExhaustedError` mid-run (§4.5).
+- Malformed / invalid op (anchor not found / not unique, consumed-id edit) → dropped + logged + surfaced
+  as un-appliable; the run continues.
 - Cancel / abort → `signal` propagates; ephemeral suggestions discarded.
 
 ## 8. Testing & acceptance
 
-- **Server unit, per class (6):** before/after fixtures; the apply step's **global** ID allocation (§5.1),
-  the **restructure remap** for `split` + `merge` (§5.3/§5.4), apply-order on mixed same-id ops (§4.3),
-  op-validation rejections (§5.6), the `boundary_move` emission (§5.5).
-- **Re-analysis regression (the C3 hazard):** after a `merge`/`split`, run a re-analysis and assert the
-  dropped ids do **not** resurrect and content is **not** duplicated.
-- **M1/R2-M3 regression:** structural ops preserve ID stability, don't orphan emotion/audio, respect prior
-  manual edits; split offspring (`id > global maxCacheId`) survive re-analysis.
-- **Abstention fixtures (precision):** `reattribute` must NOT fire on correctly-attributed dialogue;
-  `flag_nonstory` must NOT exclude short legitimate narration/dialogue; `strip_tag`/`flag_nonstory` must
-  NOT touch M5 vocalizations ("Ah!").
-- **Synth consumer:** a `excludeFromSynthesis` sentence produces **no audio segment** (filter in
-  `buildSentenceGroups`, §10).
-- **Frontend unit:** `ScriptReviewDiff` selection logic (tiered defaults, per-class/per-change → apply
-  payload); the dedicated slice is **not wiped** by a revisions poll.
-- **E2E (Playwright):** per-chapter trigger → diff → accept a subset → manuscript refetches → affected
-  chapter reads stale. Append a case to `e2e/responsive/coverage.spec.ts`.
-- **No sidecar/golden-audio tier** — fs-58 loads no TTS model.
+- **Server unit, per class (5):** before/after fixtures; the anchor-locator resolution (found + unique →
+  correct slice; not-found / ambiguous → rejected); apply-order on mixed same-id ops (§4.3); op-validation
+  rejections (§5.6/§7).
+- **Staleness regressions (§5.3):** `strip_tag` on a rendered sentence marks the chapter stale;
+  `fix_emotion` `angry → neutral` on a rendered sentence marks it stale (the neutral-direction fix).
+- **Apply-via-reducer:** accepted `split`/`merge`/`fix_emotion`/`strip_tag` dispatch the mapped reducers
+  and produce the same state a manual edit would (incl. global ID allocation, survives re-analysis).
+- **M5 abstention:** `strip_tag` must NOT strip intentional vocalizations ("Ah!").
+- **Frontend unit:** `ScriptReviewDiff` selection logic → dispatch payload; the dedicated slice is **not
+  wiped** by a revisions poll and **shows only the active book** (concurrent-multi-book).
+- **E2E (Playwright):** per-chapter trigger → diff → accept a subset → manuscript updates → chapter reads
+  stale. Append a case to `e2e/responsive/coverage.spec.ts`.
+- **No sidecar/golden-audio tier** — Unit A loads no TTS model.
 
 ## 9. Non-goals & follow-ups
 
-**Non-goals (v1):**
-- No TTS-synthesis engine involvement (this is what "engine-agnostic" means; it is *not* GPU-free, §4.4).
-- No cast-roster mutation — `reattribute` targets only existing post-fold cast; off-roster → read-only
-  `reattribute_blocked` advisory.
-- No `fix_emotion` — routed to fs-33 (below).
-- No `validate_instruct` — deferred to fs-56 (below).
-- No suggestion persistence across reload (below).
-- No chapter-level in-flight guard — v1 blocks at book level (below).
-- No auto-apply without review; no free-form text rewriting beyond `strip_tag`.
-- No entitlement/paywall gate (the word "premium" is dropped; relationship to com-1 Cast Pass is TBD at
-  that seam, not here).
+**Non-goals (Unit A):** no TTS-engine involvement (§4.4); no `reattribute`/`flag_nonstory` (Unit B, §13);
+no `validate_instruct` (fs-56); no headless/server apply (browser-only, §5.1 — fs-44 dep below); no
+suggestion persistence (below); no auto-apply without review; no free-form rewriting beyond `strip_tag`;
+no entitlement gate ("premium" dropped).
 
-**Follow-ups — FILE NOW (issue + thin BACKLOG row, per the project rule):**
-1. **Persist suggestions** across reload (`script-review-suggestions.json`).
-2. **`validate_instruct` class** — blocked on fs-56's per-sentence `instruct`; **also edit the fs-56
-   issue/spec** to carry the move-here note (make the cross-link bidirectional in tracked artifacts).
-3. **fs-33 "correct an existing wrong emotion" mode** — the home for emotion correction fs-58 declined.
-4. **Chapter-level in-flight generation guard** — replace the v1 book-level block.
+**Follow-ups — FILE NOW (issue + thin BACKLOG row, per the project rule); the #998/BACKLOG update is a
+hard gate to leave `draft`:**
+1. **Update #998 + BACKLOG** to Unit A scope + the "no TTS engine" correction.
+2. **fs-58 Unit B** (`reattribute` + `flag_nonstory`) — file with its deps (§13).
+3. **`validate_instruct`** — blocked on fs-56's per-sentence `instruct`; **also edit the fs-56 issue/spec**
+   to carry the move-here note (bidirectional in tracked artifacts).
+4. **fs-44 server apply path** — headless equivalent of §5's client apply.
+5. **Persist suggestions** across reload (`script-review-suggestions.json`).
 
 ## 10. Dependencies & linkage
 
-- **fs-56 (#996)** — owns the per-sentence `instruct` field; `validate_instruct` parked there (§9.2).
-- **fs-33 (#596)** — owns emotion correction (§9.3).
-- **New optional `excludeFromSynthesis` sentence field** — fs-58 owns it: `openapi.yaml` →
-  regenerated `src/lib/api-types.ts` → Zod `sentenceSchema`. **Synth consumer in scope:** a
-  `.filter(s => !s.excludeFromSynthesis)` in `buildSentenceGroups` (`synthesise-chapter.ts:~659`) + test
-  (§8) — without it the flag is cosmetic. **`.strict()` is safe on disk:** persisted `manuscript-edits.json`
-  / cache are read leniently (`book-state.ts:225`, no `sentenceSchema.parse()`), so the new optional field
-  needs **no migration** and isn't stripped on read — **but** keep the review output **delta-only** (never
-  a full strict `Sentence`, which would require the field in the grammar schema). **Precedence vs the
-  chapter-level `isLikelyFrontMatter`** (`openapi.yaml:3342`): chapter-level exclusion wins; a sentence
-  flag inside an already-excluded chapter is a no-op.
-- **Reuses:** analyzer call path + `RateLimiter` (`server/src/analyzer/`); `serializeQueueMutation`
-  (`generation.ts`); the `boundary_move` change-log + `stale-chapters.ts` staleness derivation; the
-  `applyChapterRestructure` remap pattern (`manuscript-slice.ts:378-401`); `manuscript-edits.json` I/O
-  (`server/src/routes/book-state.ts`); the DriftReport accept-reject UI pattern.
+- **Reuses (no new infra):** `splitSentence`, `applyChapterRestructure` + the `/chapters/merge` route,
+  `setSentenceEmotion`, the debounced `putBookState` manuscript persistence, the change-log + staleness
+  derivation, the analyzer call path + `RateLimiter`, the DriftReport accept-reject UI pattern.
+- **New:** `setSentenceText` reducer + text-change staleness (§5.3.1); the neutral-direction emotion
+  staleness fix (§5.3.2); the dedicated suggestions slice (§5.5); the review pass + endpoint + diff modal.
+- **fs-56 (#996)** — `validate_instruct` parked there (§9.3). **fs-33 (#596)** — backfill, complementary to
+  `fix_emotion` (§2). **fs-44 (#721)** — server apply path (§5.1, §9.4).
 
 ## 11. Implementation ordering (for the plan)
 
-1. **Schema + server apply contract (highest-risk, test-first):** the `excludeFromSynthesis` field
-   (OpenAPI → types → Zod) + the synth-side filter + test; the review op/delta schema; the server **apply
-   module** — global allocator under `serializeQueueMutation` (§5.1), restructure-based split/merge with
-   the re-analysis-no-resurrect guarantee (§5.4), apply-order (§4.3), `boundary_move` emission (§5.5),
-   op-validation (§5.6) — with the C3 re-analysis regression + M1/R2-M3 + abstention fixtures.
-2. **Review pass + endpoint:** the 7-site `runScriptReviewChapter` extension (§4.2); the flat output
-   schema (decide flat-vs-wire-Gemini-responseSchema, §4.3); the per-chapter endpoint + optional
-   book-wide; the review-model knob + RPD warning (§4.5); the prompt with M5 + abstention constraints.
-3. **Operator UX:** the dedicated non-polled slice (§5.7); `ScriptReviewDiff` (per-chapter, tiered
-   defaults, `reattribute_blocked` advisories); apply → `boundary_move` → change-log → client refetch; the
-   book-level in-flight guard; the E2E spec.
+1. **Apply foundations (client-side):** the `setSentenceText` reducer + text-change staleness; the
+   neutral-direction emotion staleness fix; the per-class reducer mapping (§5.2) + anchor→offset
+   resolution; with the §8 apply-via-reducer + staleness regressions. *Self-contained, test-first.*
+2. **Read-only review pass + endpoint:** the ~13-site extension (§4.2); the flat-envelope schema +
+   imperative op-validation (decide Ollama-union vs flatten, §4.3); the per-chapter endpoint + optional
+   book-wide; the review-model knob + RPD warning (§4.5); the prompt + M5 carve-out + abstention prompting.
+3. **Operator UX:** the dedicated slice (§5.5); `ScriptReviewDiff` (per-chapter, per-class toggles); the
+   accept → dispatch wiring; the E2E spec.
 
-## 12. Adversarial review — resolutions (2026-06-23)
+## 12. Adversarial review — resolutions (R1 + R2, 2026-06-23)
 
-Three independent code-grounded reviewers (data-integrity, scope/product, architecture). Findings resolved
-into the sections above:
+Two rounds, three code-grounded reviewers each. Net effect: decompose to Unit A + invert apply to the
+client.
 
-- **§5.4 server-side invalidation was fictional → §5.5 rewritten** around `boundary_move` + client
-  re-derive (staleness is client-derived; `stale-chapters.ts`).
-- **`fix_emotion` was doubly wrong + overlapped fs-33 → routed to fs-33** (§3, §9.3); emotion is not in the
-  speaker-map diff and the real rule is 3-way gated incl. the neutral-direction miss.
-- **merge-as-drop resurrected on re-analysis → §5.4 restructure/tombstone contract** (`hydrateFromAnalysis`
-  append branch is the corruptor).
-- **Gemini `responseSchema` never wired → §4.3 flat schema** (drop the union; or wire it as a prerequisite).
-- **Offsets fragile → §4.3 content-addressed pieces** with concat-equality validation.
-- **Undefined mixed-op order → §4.3 apply-order rule.**
-- **maxId is global not per-chapter → §5.1.** **Dual allocator race → §5.1 sole-allocator + refetch.**
-- **"Wholesale reuse" overstated → §4.2 7-site touch-list.**
-- **In-flight guard chapter-level didn't exist → §5.6 book-level v1 + §9.4 follow-up.**
-- **`excludeFromSynthesis` cosmetic → §10 synth consumer in scope.**
-- **Pre-selected-all unsafe → §6 tiered defaults.** **`reattribute` off-roster → §3 advisory.**
-  **`flag_nonstory` false-positives → §3 constraints + §8 abstention tests.**
-- **`validate_instruct` orphan deferral → §9.2 file now + edit fs-56.**
-- **Whole-book unusable → §4.1/§6 per-chapter (fs-35 precedent).**
-- **`ScriptReviewDiff` on `revisions.pending` → §5.7 dedicated non-polled slice.**
-- **Scope 5→7 + no-GPU reversal → re-scoping note (header) + #998/BACKLOG update gate.**
-- **Moderates/minors folded in:** `startMs/endMs` dropped on structural ops (§5.3/5.4); token/RPD cost
-  (§4.5); cross-chapter merge rejected (§5.4/5.6); placement supersedes (header); `.strict()` safe on disk
-  + delta-only output (§10); post-fold roster (§4.2); auth inherited (§4.1); non-sticky (§4.1); cross-tab
-  caveat (§5.5); corrected `book-state.ts` path (§10); "premium" dropped (§9).
+**Round 1 → revision 1:** server-side invalidation was fictional (staleness is client-derived);
+merge-as-drop resurrected on re-analysis; Gemini `responseSchema` unwired; offsets fragile; mixed-op order
+undefined; maxId global not per-chapter; "wholesale reuse" overstated; `excludeFromSynthesis` cosmetic;
+pre-selected-all unsafe; whole-book unusable. *(Revision 1 fixed several but introduced new errors —
+caught in round 2.)*
+
+**Round 2 → this spec (Unit A):**
+- **Server apply fights the architecture (C3/C4/H1) → §5 client-side apply.** Wrong write-lock,
+  refetch-clobbers-unflushed-edits, and the frontend-only restructure reducer all dissolve when apply
+  never leaves the client.
+- **`boundary_move` is the wrong staleness primitive for rendered chapters → §5.3.** The precise
+  characterId-diff supersedes it; `strip_tag`/`fix_emotion` need explicit staleness fixes.
+- **Verbatim-pieces MORE fragile than offsets → §4.3 anchor-locator.**
+- **`fix_emotion`→fs-33 was a silent capability regression → kept in Unit A (§2/§3).** fs-33 is
+  backfill-only.
+- **`reattribute_blocked` advisory points at a non-existent add-cast path; `flag_nonstory` is
+  import-residue-specific + untestable on the canonical fixture → both carved to Unit B (§13).**
+- **Touch-list undercounted → §4.2 ~13 sites incl. frontend.**
+- **Decompose at the mechanics/content seam → Unit A / Unit B.**
+- **Folded:** per-chapter trigger (fs-35); flat-envelope honesty + Ollama-union asymmetry (§4.3);
+  dedicated non-polled slice + reload story + active-book selector (§5.5); RPD cost (§4.5); `.strict()`
+  safe on disk; dropping `startMs/endMs` on structural ops (no runtime consumer — verified); the count
+  corrected to **5 live (Unit A)**; the `isLikelyFrontMatter` precedence note dropped (real chapter
+  exclusion is `excludedSlugs`, pre-analysis, so no sentences exist to interact — moved to Unit B's
+  concern).
+
+## 13. Unit B (deferred — carved out, file as a follow-up)
+
+`reattribute` + `flag_nonstory`. Same harness as Unit A (review pass, diff modal, client-side apply); each
+adds a class plus an unmet dependency:
+
+**`reattribute`** — re-assign a dialogue line to the correct **existing** cast member (field delta on
+`characterId` via `setSentenceCharacter`; detected by the precise staleness path). Deps:
+- **Off-roster actionability.** When the correct speaker isn't in the roster (folded into `unknown-*`), the
+  intended `reattribute_blocked` advisory has **nowhere to go** — there is no "add a never-detected
+  character" path (the "Add character" button `manuscript.tsx:1053` is inert; only `add-from-roster` +
+  alias-unlink exist). Needs net-new cast-create wiring, or the advisory must be narrowed to the cases
+  that work.
+- **Cross-chapter context.** Tagless turn-taking can straddle a chapter boundary; per-chapter review
+  inherits Phase-1's boundary blind spot. Book-wide is the only way to catch chapter-straddling
+  reattributions (in tension with the RPD/usability limits).
+- **Default OFF** in the diff (high-risk — re-voices dialogue + invalidates audio).
+
+**`flag_nonstory`** — flag import residue (page numbers, running headers) so the TTS doesn't read them.
+Deps:
+- **New `excludeFromSynthesis` field** (OpenAPI → types → Zod) + a synth-side filter in
+  `buildSentenceGroups` (`synthesise-chapter.ts:~659`, location verified) — without it the flag is
+  cosmetic.
+- **Exclusion-staleness fix:** excluding a sentence changes no `characterId`, so the precise path won't
+  mark the chapter stale — already-rendered audio keeps speaking the junk line. Needs an exclusion-aware
+  branch in `isChapterReassignedSinceRender` (`stale-chapters.ts`).
+- **A positive test fixture:** the canonical `the-coalfall-commission.md` is clean markdown with zero
+  artifact lines (markdown/plaintext import strips none); needs a PDF/synthetic artifact-bearing fixture —
+  the class is **import-residue-specific** (mostly PDF/EPUB), narrower than "front-matter" implies.
+- **Default OFF** in the diff (can silently mute real story lines if it over-fires).

--- a/docs/superpowers/specs/2026-06-23-fs58-llm-script-review-design.md
+++ b/docs/superpowers/specs/2026-06-23-fs58-llm-script-review-design.md
@@ -1,0 +1,254 @@
+---
+title: fs-58 — LLM Script Review (premium annotation-QA pass)
+status: draft
+date: 2026-06-23
+issue: '#998'
+related:
+  - 2026-06-22-expressive-tts-instruct-tiers-design.md (§4.6 — fs-58's original sketch; this spec supersedes it)
+  - fs-56 (#996) — per-line `instruct` field; owns the deferred instruct-validation class
+  - fs-25 (#479) — per-quote emotion enum (the field `fix_emotion` repairs)
+  - fs-33 (#596) — emotion-only backfill pass (precedent for a second analyzer pass)
+  - Russian stage-2 attribution under-production (plan 221) — the attribution-quality pain `reattribute` targets
+inspiration: github.com/Finrandojin/alexandria-audiobook (Alexandria — LLM Script Review)
+---
+
+# fs-58 — LLM Script Review
+
+## 1. Summary
+
+An **optional, operator-triggered, premium QA pass** that runs a second LLM over already-attributed
+sentences and repairs common annotation errors, presented as an **accept/reject diff**. It is modeled
+as **"just another editor"**: every accepted change produces the same kind of edit a human makes in the
+confirm stage and is applied through the *existing* manual-edit + audio-invalidation machinery. The LLM
+only *proposes*; the server applies deterministically and owns all sentence-ID allocation.
+
+It is **additive** — off → today's behaviour, exactly. It reuses the **analyzer** compute path (no TTS
+engine), so it is independent of Kokoro/Coqui/Qwen and shippable on its own.
+
+## 2. Background
+
+**Source feature (Alexandria):** an optional second pass fixing annotation-error classes after the
+initial attribution. Castwright's Phase-1 attribution (`server/src/routes/analysis.ts`, the
+`runStage2Chapter` analyzer call) produces, per chapter, a list of `Sentence`s:
+
+```
+{ id, chapterId, characterId, text, confidence?, emotion? }   // emotion = fixed 5-value enum
+```
+
+written (post-fold/dedup) to `manuscript-edits.json` at `analysis.ts:~4043`. Phase-1 is good but not
+perfect: it leaks attribution tags into dialogue, over-/under-splits sentences at narrator↔dialogue
+boundaries, mis-assigns speakers in tagless back-and-forth, occasionally sets a wrong `emotion`, and
+treats front/back-matter residue (page numbers, headers) as narration. fs-58 is the targeted repair
+pass for exactly those errors.
+
+There is a strong in-repo precedent: **fs-33's emotion-only backfill** (`emotionAnnotationSchema`,
+`server/src/handoff/schemas.ts`) already runs a second analyzer pass over attributed sentences and
+returns only `{ sentenceId, emotion }`. fs-58 generalises that shape to multiple error classes.
+
+## 3. Error classes (v1 = 7 live + 1 deferred)
+
+Two tiers. **Mechanics** classes fix sentence *shape*; **content** classes fix *who/how*. The premium
+value is in the content tier — that is where "wrong speaker / wrong delivery / junk read aloud" lives.
+
+**Mechanics (structural):**
+1. `strip_tag` — remove an attribution tag ("she said") that leaked into dialogue text. *Field delta, text-only.*
+2. `split` — split narration out of a dialogue entry. *Structural.*
+3. `extract_dialogue` — pull dialogue out of a narrator run into its own sentence with a `characterId`. *Structural.*
+4. `merge` — merge over-split narrator entries back into one. *Structural.*
+
+**Content (QA):**
+5. `reattribute` — re-assign a dialogue line to the correct character (incl. tagless turn-taking runs).
+   *Field delta on `characterId`; constrained to the existing cast roster — never invents a character.*
+6. `fix_emotion` — correct an obviously-wrong `emotion` enum value (shouted line left `neutral`; calm
+   line marked `angry`). *Field delta on `emotion`.*
+7. `flag_nonstory` — flag front/back-matter residue and artifact lines (page numbers, headers, empty/
+   punctuation-only) that Phase-1 mislabeled as narration, so the TTS never reads "Page 47" aloud.
+   *Soft `excludeFromSynthesis` flag — no deletion, no ID churn.*
+
+**Deferred — `validate_instruct`** (the 8th class). The per-sentence free-text `instruct` field does
+not exist yet (fs-56 owns it; only voice-design-level `instruct` exists today). The class is therefore
+**parked in fs-56's scope** with a bidirectional cross-link: **if fs-56 ships the per-sentence
+`instruct` field before fs-58, the instruct-validation class moves back here into Script Review to
+implement.** No dead code ships in fs-58.
+
+**M5 carve-out (from the parent spec's adversarial review):** the prompt explicitly instructs the model
+**never to strip intentional non-verbal vocalizations** ("Ah!", "Haah…") as if they were attribution
+tags — they are legitimate content, not annotation noise. This is a hard, tested constraint on
+`strip_tag` (and on `flag_nonstory`, which must not flag a vocalization line as junk).
+
+## 4. Architecture & flow
+
+### 4.1 Where it slots
+
+A **standalone job**, *not* inside the analyse SSE — because it must be runnable **anytime**, including
+after audio has been generated:
+
+- New endpoint **`POST /api/books/:bookId/script-review`** with its own SSE stream, mirroring the
+  analysis SSE event grammar (`phase` / per-chapter progress / `result`).
+- Triggerable from the confirm/cast stage **and** post-generation — wherever the manuscript is editable.
+
+### 4.2 The review pass
+
+Per chapter, reusing the analyzer call path wholesale:
+
+- `selectAnalyzer({ model })` → local Ollama-with-Gemini-fallback (`FallbackAnalyzer`), same
+  `RateLimiter`, same schema-constrained JSON output, same `onThrottle` / `signal` plumbing
+  (`server/src/analyzer/`).
+- **Dedicated review-model knob** — a separate user setting so review can point at a stronger model than
+  bulk attribution; **defaults to the analyzer's configured model** when unset.
+- **Input:** the chapter's current `sentences[]` (post-fold, from `manuscript-edits.json`) + the cast roster.
+
+### 4.3 Output format — hybrid
+
+The LLM returns, per chapter, a list of proposed edits in two shapes. **The LLM never invents sentence
+IDs**; it only references existing `id`s. The server allocates any new IDs.
+
+- **Field deltas** keyed by existing `id` — `strip_tag` (newText), `reattribute` (characterId),
+  `fix_emotion` (emotion), `flag_nonstory` (exclude).
+- **Explicit structural ops** referencing existing `id`s — `split(id, offset, pieceCharacterIds[])`,
+  `extract_dialogue(id, span, characterId)`, `merge(ids[])`.
+
+This avoids array-diffing entirely (the fragile "which old ID maps to which new entry" heuristic the
+parent spec's R2-M3 warned about). Each op/delta maps to exactly one diff row.
+
+Every proposed edit also carries a one-line **rationale** (shown in the diff) and the **class**.
+
+### 4.4 Compute note (corrects the parent spec's "no GPU" framing)
+
+Script Review reuses the **analyzer** path — local Ollama (**runs on the GPU, identical footprint to
+Phase-1 attribution**) or Gemini (cloud, GPU-free). It loads **no TTS-synthesis model** (Kokoro/Coqui/
+Qwen) and adds **no new resident GPU model** beyond whatever the analyzer already uses. It is a text
+pass, never co-resident with a TTS engine — so it stays clear of the §4.7 VRAM invariant of the parent
+spec. "Engine-agnostic" means *TTS-engine-agnostic*, not *GPU-free*.
+
+## 5. The ID-stability & audio-invalidation contract
+
+The load-bearing part (parent spec M1 / R2-M3). Every accepted change is applied **server-side,
+deterministically**, writing through to `manuscript-edits.json`.
+
+### 5.1 Field deltas (no ID change)
+
+`strip_tag`, `reattribute`, `fix_emotion`, `flag_nonstory` mutate the existing sentence in place by
+`id`. Trivially ID-stable.
+
+### 5.2 `split` / `extract_dialogue`
+
+- The original sentence **keeps its `id`**.
+- Each new piece is allocated `maxId+1, +2, …` — above the analyzer's max. This is exactly the rule that
+  makes user-split offspring survive re-analysis: `book-state.ts:278–295` keeps any edit whose
+  `id > maxCacheId`, and the frontend `splitSentence` reducer (`src/store/manuscript-slice.ts`) uses the
+  same `maxId+1` allocation. fs-58 reuses this rule rather than inventing one.
+- `extract_dialogue` assigns the extracted piece the dialogue `characterId`; the remainder stays narrator.
+
+### 5.3 `merge` — reconciliation rule (answers R2-M3)
+
+- **Surviving `id`** = the **lowest** id in the set (the original analyzer id — maximally stable across reparse).
+- `text` = concatenated in document order, single-space joiner.
+- `characterId` = **must be identical** across the set (merge only applies to over-split *narrator* runs).
+  The apply step **validates** this and **rejects** a merge whose members disagree, rather than silently
+  picking one.
+- `emotion` = first non-neutral, else neutral; `confidence` = min (conservative).
+- Non-surviving ids are dropped.
+
+### 5.4 Audio invalidation = the manual-edit path, made eager
+
+Any structural op, any `reattribute`/`fix_emotion` (changes the voice/variant rendered), or
+`flag_nonstory` marks the affected chapter's audio **needs-regeneration** through the *same*
+`segments.json` ↔ live-manuscript drift mechanism that a manual sentence reallocation already trips
+(`segments.json.segments[].sentenceIds` vs the rendered speaker map). fs-58 triggers it **eagerly on
+apply** rather than waiting for the next poll. This is the operator's stated model: *"treat audio as
+needing regeneration — same as you manually change the chapter sentence allocations."*
+
+### 5.5 Guards
+
+1. **Server-side op validation before apply** — offset in range, referenced ids exist, merge set
+   contiguous + same characterId, `reattribute` target ∈ cast roster. Invalid ops are **dropped with a
+   logged reason**; they never corrupt state.
+2. **In-flight generation guard** — if a generation job is running on a chapter, applying review changes
+   to that chapter is **blocked/queued** (the explore map's render-stall hazard).
+3. **Apply is transactional per chapter** — a write failure applies nothing for that chapter.
+
+### 5.6 Suggestion lifetime
+
+Suggestions are **ephemeral per run** — computed, streamed, held client-side for review; only *accepted*
+changes write through to `manuscript-edits.json`. Persisting pending suggestions across a page reload
+(`script-review-suggestions.json`) is a **named follow-up** (§9), not v1.
+
+## 6. Operator UX
+
+- A **"Review Script"** button surfaces wherever the manuscript is editable (confirm/cast stage **and**
+  post-generation). It fires `POST /api/books/:bookId/script-review`; a per-chapter progress bar reuses
+  the analysis SSE `phase` grammar.
+- Results land in a **`ScriptReviewDiff` modal**, extending the existing revisions / `DriftReport`
+  accept-reject pattern (`src/store/revisions-slice.ts`).
+- **Grouped by the 7 classes**, with a **per-class accept/reject** toggle and **drill-down to per-change
+  toggles** within a class. Each change shows **before → after** (text / characterId / emotion / exclude),
+  the **class**, and the LLM **rationale**.
+- **Default selection:** all suggestions pre-selected; the operator deselects what it doesn't want
+  (efficient for a bulk QA pass). **Apply** writes the selected set, triggers audio-invalidation
+  (§5.4), and records a change-log entry.
+
+## 7. Error handling
+
+- LLM unreachable → Gemini fallback (`FallbackAnalyzer`); both down → SSE `error` event, modal shows
+  failure, **no state change**.
+- Throttle / rate-limit → `onThrottle` SSE event, identical to analysis.
+- Malformed LLM op → **dropped + logged**, the chapter continues (one bad op never fails the run).
+- Cancel / abort → `signal` propagates; ephemeral suggestions discarded.
+
+## 8. Testing & acceptance
+
+- **Server unit:** one before/after fixture **per class** (7); the apply step's ID allocation
+  (`split` maxId+1, `merge` surviving-id reconciliation §5.3), op-validation rejections (§5.5), the
+  audio-invalidation trigger (§5.4).
+- **Server regression (M1 / R2-M3):** split/merge preserve ID stability, do not orphan emotion/audio,
+  and respect prior manual edits; reparse-survival (a split offspring `id > maxCacheId` survives a
+  re-analysis).
+- **M5 regression:** a fixture containing intentional vocalizations ("Ah!") that `strip_tag` must **not**
+  strip and `flag_nonstory` must **not** flag.
+- **Frontend unit:** `ScriptReviewDiff` selection logic (per-class / per-change toggles → apply payload).
+- **E2E (Playwright):** trigger → diff → accept a subset → manuscript updates → affected audio marked
+  stale. Append a case to `e2e/responsive/coverage.spec.ts` for the new modal.
+- **No sidecar/golden-audio tier** — fs-58 loads no TTS model.
+
+## 9. Non-goals & follow-ups
+
+**Non-goals (v1):**
+- **No TTS-synthesis engine involvement** — no Kokoro/Coqui/Qwen load (this is what "engine-agnostic"
+  means; it is *not* "no GPU" — see §4.4).
+- No cast-roster changes — `reattribute` targets only existing cast; never invents a character.
+- No `validate_instruct` — deferred to fs-56 (§3).
+- No suggestion persistence across reload — follow-up below.
+- No auto-apply without operator review.
+- No free-form text rewriting beyond `strip_tag` (no paraphrasing / content rewriting).
+
+**Follow-ups to file (BACKLOG + issues):**
+1. **Persist suggestions** across page reload (`script-review-suggestions.json`) so a long review survives
+   a refresh.
+2. **`validate_instruct` class** — implement once fs-56's per-sentence `instruct` field lands (tracked in
+   fs-56's scope with the bidirectional move-here note).
+
+## 10. Dependencies & linkage
+
+- **fs-56 (#996)** owns the per-sentence `instruct` field; the `validate_instruct` class is added to
+  fs-56's scope with a bidirectional cross-link (§3).
+- **New optional `excludeFromSynthesis` sentence field** for `flag_nonstory` — fs-58 owns it; added to
+  `openapi.yaml` + regenerated `src/lib/api-types.ts` (OpenAPI is the type source of truth) + the Zod
+  `sentenceSchema`. **Relationship:** the existing `isLikelyFrontMatter` flag is *chapter-level*
+  (`openapi.yaml:3342`, confirm-view auto-suggests excluding whole front/back-matter chapters);
+  `excludeFromSynthesis` is the *sentence-level* counterpart for artifact lines inside a story chapter.
+- **Reuses:** analyzer call path + `RateLimiter` (`server/src/analyzer/`), revisions-style diff modal
+  (`src/store/revisions-slice.ts`), drift / `segments.json` audio invalidation, `splitSentence` maxId
+  rule (`src/store/manuscript-slice.ts`), `manuscript-edits.json` I/O (`book-state.ts`).
+
+## 11. Implementation ordering (for the plan)
+
+A sketch for writing-plans, not a delivery commitment:
+
+1. **Schema + contract** — `excludeFromSynthesis` field (OpenAPI → types → Zod); the review op/delta
+   schema; the server-side **apply** module (field deltas + structural ops + §5 contract) with its unit
+   + M1/R2-M3 regression tests. *Highest-risk, test-first.*
+2. **Review pass + endpoint** — `runScriptReviewChapter` over the analyzer path; `POST
+   /api/books/:bookId/script-review` SSE; the dedicated review-model knob; the M5 prompt carve-out.
+3. **Operator UX** — `ScriptReviewDiff` modal (per-class + per-change toggles), the "Review Script"
+   button, the apply → invalidate → change-log wire-up; the E2E spec.

--- a/e2e/responsive/coverage.spec.ts
+++ b/e2e/responsive/coverage.spec.ts
@@ -312,4 +312,23 @@ test.describe('responsive coverage (all views × all viewports)', () => {
     await page.waitForTimeout(300);
     await expectNoHorizontalScroll(page);
   });
+
+  test('script-review modal (fs-58)', async ({ page }) => {
+    /* Navigate to Solway Bay manuscript. The "Review Script" button is in the
+       chapter header area. Click it and assert the modal renders without
+       horizontal overflow at every viewport. */
+    await page.goto('/#/books/sb/manuscript');
+    await expect(page.getByRole('heading', { name: /^Chapter \d+/i, level: 1 })).toBeVisible({
+      timeout: 10_000,
+    });
+    const reviewBtn = page.getByTestId('review-script-chapter');
+    await expect(reviewBtn).toBeVisible({ timeout: 5_000 });
+    await reviewBtn.click();
+    /* Wait for the ScriptReviewDiff modal (mock resolves in ~60 ms). */
+    await expect(page.getByRole('heading', { name: /Script review suggestions/i })).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.waitForTimeout(300);
+    await expectNoHorizontalScroll(page);
+  });
 });

--- a/e2e/script-review.spec.ts
+++ b/e2e/script-review.spec.ts
@@ -1,0 +1,127 @@
+/* fs-58 — browser-level proof of the per-chapter LLM script-review flow:
+ *
+ *  1. Open the Solway Bay fixture book to the manuscript view.
+ *  2. Click the per-chapter "Review Script" button.
+ *  3. The ScriptReviewDiff modal opens showing the mock strip_tag suggestion.
+ *  4. Accept (Apply) — sentence id:1 gets text "x".
+ *  5. Navigate to the Generate view — chapter 3 shows the stale badge
+ *     because a boundary_move was logged after its audioRenderedAt.
+ *
+ * Mock contract: `mockReviewScript` returns a deterministic op:
+ *   { chapterId: 1, ops: [{ id: 1, op: 'strip_tag', newText: 'x', rationale: 'tag' }] }
+ * `initialSentences` seeds sentence id:1 in chapter 3, so planApply
+ * resolves it and dispatchAcceptedOps fires setSentenceText + bumpBoundaryMove
+ * for chapterId 3.
+ *
+ * Stale badge precondition: we inject a past `audioRenderedAt` onto chapter 3
+ * via window.__store__ so `isChapterStaleFromReassign` trips when the
+ * boundary_move timestamp is newer. */
+
+import { test, expect } from '@playwright/test';
+
+/* Serial mode: the store-injection and stale-badge assertion depend on a
+   specific chapter state; run sequentially so parallel workers can't
+   collide on the same in-memory Vite dev server mock state. */
+test.describe.configure({ mode: 'serial' });
+
+type Store = {
+  getState: () => {
+    chapters: {
+      chapters: Array<{
+        id: number;
+        state: string;
+        audioRenderedAt?: string;
+      }>;
+    };
+    manuscript: {
+      sentences: Array<{ id: number; chapterId: number; text: string }>;
+    };
+  };
+  dispatch: (action: unknown) => void;
+};
+
+test.describe('fs-58 — script-review per-chapter accept flow', () => {
+  test('modal opens → accept → sentence updated → stale badge in Generate', async ({ page }) => {
+    /* Navigate directly to the Solway Bay fixture book manuscript view.
+       SB is the fixture with 18 done chapters, populated by buildSolwayBayMockState.
+       The manuscript slice uses initialSentences (chapterId: 3 for id:1) because
+       SB's manuscriptEdits is null.
+       READY_DEFAULTS seeds currentChapterId = 3, so the "per-chapter" review
+       targets chapter 3. */
+    await page.goto('/#/books/sb/manuscript');
+
+    /* Wait for the manuscript view to hydrate — the chapter heading (h1) for
+       chapter 3 is our hydration signal. */
+    await expect(page.getByRole('heading', { name: /^Chapter \d+/i, level: 1 })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    /* Inject a past audioRenderedAt on chapter 3 so the stale gate trips
+       after the boundary_move from Accept. The time must predate the
+       boundary_move we're about to trigger; using a 2-hour-old ISO string
+       is safely in the past. */
+    const pastRenderedAt = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    await page.evaluate((renderedAt) => {
+      const store = (window as unknown as { __store__: Store }).__store__;
+      const chapters = store.getState().chapters.chapters;
+      const patched = chapters.map((c) =>
+        c.id === 3 ? { ...c, state: 'done', audioRenderedAt: renderedAt } : c,
+      );
+      store.dispatch({ type: 'chapters/setChapters', payload: patched });
+    }, pastRenderedAt);
+
+    /* Click the per-chapter "Review Script" button. The mock resolves in ~60 ms.
+       The button label flips to "Reviewing…" then back; wait for the modal. */
+    const reviewBtn = page.getByTestId('review-script-chapter');
+    await expect(reviewBtn).toBeVisible({ timeout: 5_000 });
+    await expect(reviewBtn).toBeEnabled();
+    await reviewBtn.click();
+
+    /* The ScriptReviewDiff modal opens once mockReviewScript resolves and
+       setReview lands in the store. The modal header is the hydration signal. */
+    await expect(page.getByRole('heading', { name: /Script review suggestions/i })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    /* The mock op is strip_tag: the class heading "Strip tag" should be visible. */
+    await expect(page.getByText(/Strip tag/i)).toBeVisible();
+
+    /* The "Apply N selected" button — 1 op selected by default. */
+    const applyBtn = page.getByTestId('apply-button');
+    await expect(applyBtn).toBeVisible();
+    await expect(applyBtn).toContainText(/Apply 1 selected/i);
+
+    /* Accept: click Apply → dispatchAcceptedOps fires setSentenceText on
+       sentence id:1 (chapterId:3) with newText:"x" and bumpBoundaryMove for
+       chapterId:3 at a timestamp AFTER the injected pastRenderedAt. */
+    await applyBtn.click();
+
+    /* Modal should close after Apply. */
+    await expect(
+      page.getByRole('heading', { name: /Script review suggestions/i }),
+    ).toBeHidden({ timeout: 5_000 });
+
+    /* Assert the sentence text was updated. Sentence id:1 lives in chapterId:3;
+       `dispatchAcceptedOps` dispatches setSentenceText with newText: 'x'. */
+    const sentenceUpdated = await page.evaluate(() => {
+      const store = (window as unknown as { __store__: Store }).__store__;
+      const s = store.getState().manuscript.sentences.find((s) => s.id === 1 && s.chapterId === 3);
+      return s?.text === 'x';
+    });
+    expect(sentenceUpdated, 'sentence id:1 text should be "x" after accept').toBe(true);
+
+    /* Navigate to the Generate view. The stale badge for chapter 3 should be
+       visible because a boundary_move was logged for chapterId:3 AFTER
+       pastRenderedAt, satisfying isChapterStaleFromReassign. */
+    await page.goto('/#/books/sb/generate');
+
+    /* Wait for the Generate view to hydrate — CH 03 appears once chapters load. */
+    await expect(page.getByText(/^CH 03$/)).toBeVisible({ timeout: 10_000 });
+
+    /* The stale badge is a span with "⚠ Sentences reassigned · regenerate to refresh"
+       visible beneath the chapter 3 row. */
+    await expect(
+      page.getByText(/Sentences reassigned.*regenerate to refresh/i),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2509,7 +2509,8 @@ paths:
         `chapterId` is provided, only that chapter is reviewed. SSE event
         kinds: `phase`, `throttle`, `heartbeat`, `ops`
         (`{ chapterId, ops: [{ id, op, anchor?, newText?, rationale, ... }] }`),
-        `chapter-failed`, `error` (`code: no_attribution | quota_exhausted`),
+        `chapter-failed`,
+        `error` (`code: no_attribution | no_such_chapter | quota_exhausted`),
         and a terminal `result` (`{ done, reviewedChapters, totalOps }`).
       parameters:
         - { in: path, name: bookId, required: true, schema: { type: string } }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2496,6 +2496,51 @@ paths:
         '409':
           description: Book has not been analysed yet
 
+  /api/books/{bookId}/script-review:
+    post:
+      summary: LLM script-review pass (fs-58)
+      operationId: scriptReview
+      description: |
+        Runs an LLM pass over the book's already-attributed sentences and
+        streams per-chapter editing ops over Server-Sent Events. The ops
+        (strip_tag, split, extract_dialogue, merge, fix_emotion) carry anchors
+        and rationale; the client applies them through existing Redux
+        manual-edit reducers. The route never writes a file. When an optional
+        `chapterId` is provided, only that chapter is reviewed. SSE event
+        kinds: `phase`, `throttle`, `heartbeat`, `ops`
+        (`{ chapterId, ops: [{ id, op, anchor?, newText?, rationale, ... }] }`),
+        `chapter-failed`, `error` (`code: no_attribution | quota_exhausted`),
+        and a terminal `result` (`{ done, reviewedChapters, totalOps }`).
+      parameters:
+        - { in: path, name: bookId, required: true, schema: { type: string } }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                chapterId:
+                  {
+                    type: integer,
+                    description: 'Optional chapter id — when present, limits the pass to that chapter only.',
+                  }
+                model:
+                  {
+                    type: string,
+                    description: 'Optional analyzer model id override (matches the analysis endpoints).',
+                  }
+      responses:
+        '200':
+          description: SSE stream of ops/phase/result events.
+          content:
+            text/event-stream:
+              schema: { type: object }
+        '404':
+          description: Book not found
+        '409':
+          description: Book has not been analysed yet
+
   /api/books/{bookId}/cast/{characterId}/emotion-variant/{emotion}:
     delete:
       summary: Remove a designed emotion variant (fs-34)

--- a/server/src/analyzer/fallback.test.ts
+++ b/server/src/analyzer/fallback.test.ts
@@ -14,6 +14,7 @@ import type {
   Stage1ChapterOutput,
   Stage2ChapterOutput,
   EmotionAnnotationOutput,
+  ScriptReviewOutput,
 } from '../handoff/schemas.js';
 
 const STAGE1_RESULT: Stage1Output = {
@@ -29,12 +30,16 @@ const STAGE2_RESULT: Stage2ChapterOutput = {
 const EMOTION_RESULT: EmotionAnnotationOutput = {
   annotations: [{ sentenceId: 1, emotion: 'angry' }],
 };
+const SCRIPT_REVIEW_RESULT: ScriptReviewOutput = {
+  ops: [{ id: 1, op: 'fix_emotion', emotion: 'excited', rationale: 'test' }],
+};
 
 function makeAnalyzer(impl: Partial<Analyzer>): Analyzer & {
   runStage1: ReturnType<typeof vi.fn>;
   runStage1Chapter: ReturnType<typeof vi.fn>;
   runStage2Chapter: ReturnType<typeof vi.fn>;
   runEmotionChapter: ReturnType<typeof vi.fn>;
+  runScriptReviewChapter: ReturnType<typeof vi.fn>;
 } {
   return {
     runStage1: vi.fn(impl.runStage1 ?? (() => Promise.resolve(STAGE1_RESULT))),
@@ -43,6 +48,9 @@ function makeAnalyzer(impl: Partial<Analyzer>): Analyzer & {
     ),
     runStage2Chapter: vi.fn(impl.runStage2Chapter ?? (() => Promise.resolve(STAGE2_RESULT))),
     runEmotionChapter: vi.fn(impl.runEmotionChapter ?? (() => Promise.resolve(EMOTION_RESULT))),
+    runScriptReviewChapter: vi.fn(
+      impl.runScriptReviewChapter ?? (() => Promise.resolve(SCRIPT_REVIEW_RESULT)),
+    ),
   };
 }
 
@@ -187,5 +195,41 @@ describe('FallbackAnalyzer — all three Analyzer methods share the same policy'
       AnalysisAbortedError,
     );
     expect(fallback.runEmotionChapter).not.toHaveBeenCalled();
+  });
+
+  it('runScriptReviewChapter (fs-58) follows the same fallback rule', async () => {
+    const primary = makeAnalyzer({
+      runScriptReviewChapter: () => Promise.reject(new LocalUnreachableError('down')),
+    });
+    const fallback = makeAnalyzer({});
+    const f = new FallbackAnalyzer(primary, fallback);
+    const result = await f.runScriptReviewChapter('m', 1, '# p', CALL);
+    expect(result).toBe(SCRIPT_REVIEW_RESULT);
+    expect(primary.runScriptReviewChapter).toHaveBeenCalledTimes(1);
+    expect(fallback.runScriptReviewChapter).toHaveBeenCalledTimes(1);
+  });
+
+  it('runScriptReviewChapter does NOT fall back on a plain Error', async () => {
+    const primary = makeAnalyzer({
+      runScriptReviewChapter: () => Promise.reject(new Error('validation failed')),
+    });
+    const fallback = makeAnalyzer({});
+    const f = new FallbackAnalyzer(primary, fallback);
+    await expect(f.runScriptReviewChapter('m', 1, '# p', CALL)).rejects.toThrow(
+      /validation failed/,
+    );
+    expect(fallback.runScriptReviewChapter).not.toHaveBeenCalled();
+  });
+
+  it('runScriptReviewChapter does NOT fall back on AnalysisAbortedError', async () => {
+    const primary = makeAnalyzer({
+      runScriptReviewChapter: () => Promise.reject(new AnalysisAbortedError('client gone')),
+    });
+    const fallback = makeAnalyzer({});
+    const f = new FallbackAnalyzer(primary, fallback);
+    await expect(f.runScriptReviewChapter('m', 1, '# p', CALL)).rejects.toBeInstanceOf(
+      AnalysisAbortedError,
+    );
+    expect(fallback.runScriptReviewChapter).not.toHaveBeenCalled();
   });
 });

--- a/server/src/analyzer/gemini.ts
+++ b/server/src/analyzer/gemini.ts
@@ -18,6 +18,7 @@ import {
   stage1ChapterSchema,
   stage2ChapterSchema,
   emotionAnnotationSchema,
+  scriptReviewSchema,
   stage1GrammarSchema,
   stage1ChapterGrammarSchema,
   type Stage1Output,
@@ -122,6 +123,9 @@ const SKILL_FILES = {
   /* fs-33 — emotion-only backfill pass (does NOT re-attribute).
      Routes through the prompt-fork loader (prompt.emotionAnnotation). */
   emotion_annotation: 'audiobook-emotion-annotation.md',
+  /* fs-58 — per-chapter script review (strip_tag/split/extract_dialogue/merge/fix_emotion).
+     Routes through the prompt-fork loader (prompt.scriptReview). */
+  script_review: 'audiobook-script-review.md',
 } as const;
 export type SkillName = keyof typeof SKILL_FILES;
 
@@ -132,6 +136,7 @@ const SKILL_TO_PROMPT_ID: Partial<Record<SkillName, string>> = {
   per_chapter_stage1: 'prompt.castDetection',
   per_chapter_stage2: 'prompt.sentenceAttribution',
   emotion_annotation: 'prompt.emotionAnnotation',
+  script_review: 'prompt.scriptReview',
 };
 
 /* Read the skill file fresh on every request so prompt iteration doesn't
@@ -283,14 +288,14 @@ export class GeminiAnalyzer implements Analyzer {
     );
   }
 
-  // fs-58 — real body lands in Task 7b
   async runScriptReviewChapter(
-    _manuscriptId: string,
-    _chapterId: number,
-    _promptMd: string,
-    _call: StageCall,
+    manuscriptId: string,
+    chapterId: number,
+    promptMd: string,
+    call: StageCall,
   ): Promise<ScriptReviewOutput> {
-    throw new Error('runScriptReviewChapter not implemented (Task 7b)');
+    const key = `review-ch${chapterId}` as const;
+    return this.runStage(manuscriptId, key, 'script_review', promptMd, scriptReviewSchema, scriptReviewSchema, call);
   }
 
   private async runStage<T>(

--- a/server/src/analyzer/gemini.ts
+++ b/server/src/analyzer/gemini.ts
@@ -24,6 +24,7 @@ import {
   type Stage1ChapterOutput,
   type Stage2ChapterOutput,
   type EmotionAnnotationOutput,
+  type ScriptReviewOutput,
 } from '../handoff/schemas.js';
 import type { Analyzer, StageCall, StageChunkInfo } from './index.js';
 import { isNonEnglish, normaliseBookLanguage } from '../tts/language.js';
@@ -280,6 +281,16 @@ export class GeminiAnalyzer implements Analyzer {
       emotionAnnotationSchema,
       call,
     );
+  }
+
+  // fs-58 — real body lands in Task 7b
+  async runScriptReviewChapter(
+    _manuscriptId: string,
+    _chapterId: number,
+    _promptMd: string,
+    _call: StageCall,
+  ): Promise<ScriptReviewOutput> {
+    throw new Error('runScriptReviewChapter not implemented (Task 7b)');
   }
 
   private async runStage<T>(

--- a/server/src/analyzer/index.ts
+++ b/server/src/analyzer/index.ts
@@ -13,6 +13,7 @@ import type {
   Stage1ChapterOutput,
   Stage2ChapterOutput,
   EmotionAnnotationOutput,
+  ScriptReviewOutput,
 } from '../handoff/schemas.js';
 import { GeminiAnalyzer } from './gemini.js';
 import { OllamaAnalyzer, LocalUnreachableError, AnalysisAbortedError } from './ollama.js';
@@ -91,6 +92,16 @@ export interface Analyzer {
     promptMd: string,
     call: StageCall,
   ): Promise<EmotionAnnotationOutput>;
+  /* fs-58 — LLM script review pass. Reads a chapter's attributed sentences
+     and returns a flat list of editing ops (strip_tag, split, extract_dialogue,
+     merge, fix_emotion) with anchors and rationale. Client-side apply dispatches
+     the ops through existing Redux manual-edit reducers. */
+  runScriptReviewChapter(
+    manuscriptId: string,
+    chapterId: number,
+    promptMd: string,
+    call: StageCall,
+  ): Promise<ScriptReviewOutput>;
 }
 
 export interface SelectAnalyzerOptions {
@@ -242,6 +253,28 @@ export class FallbackAnalyzer implements Analyzer {
       if (err instanceof AnalysisAbortedError) throw err;
       if (err instanceof LocalUnreachableError) {
         return await this.fallback.runEmotionChapter(manuscriptId, chapterId, promptMd, call);
+      }
+      throw err;
+    }
+  }
+
+  async runScriptReviewChapter(
+    manuscriptId: string,
+    chapterId: number,
+    promptMd: string,
+    call: StageCall,
+  ): Promise<ScriptReviewOutput> {
+    try {
+      return await this.primary.runScriptReviewChapter(manuscriptId, chapterId, promptMd, call);
+    } catch (err) {
+      if (err instanceof AnalysisAbortedError) throw err;
+      if (err instanceof LocalUnreachableError) {
+        return await this.fallback.runScriptReviewChapter(
+          manuscriptId,
+          chapterId,
+          promptMd,
+          call,
+        );
       }
       throw err;
     }

--- a/server/src/analyzer/ollama.ts
+++ b/server/src/analyzer/ollama.ts
@@ -30,6 +30,7 @@ import {
   type Stage1ChapterOutput,
   type Stage2ChapterOutput,
   type EmotionAnnotationOutput,
+  type ScriptReviewOutput,
 } from '../handoff/schemas.js';
 import type { Analyzer, StageCall, StageChunkInfo } from './index.js';
 import { AnalyzerTruncatedError } from './errors.js';
@@ -302,6 +303,16 @@ export class OllamaAnalyzer implements Analyzer {
       emotionAnnotationSchema,
       call,
     );
+  }
+
+  // fs-58 — real body lands in Task 7b
+  async runScriptReviewChapter(
+    _manuscriptId: string,
+    _chapterId: number,
+    _promptMd: string,
+    _call: StageCall,
+  ): Promise<ScriptReviewOutput> {
+    throw new Error('runScriptReviewChapter not implemented (Task 7b)');
   }
 
   private async runStage<T>(

--- a/server/src/analyzer/ollama.ts
+++ b/server/src/analyzer/ollama.ts
@@ -24,6 +24,7 @@ import {
   stage1ChapterSchema,
   stage2ChapterSchema,
   emotionAnnotationSchema,
+  scriptReviewSchema,
   stage1GrammarSchema,
   stage1ChapterGrammarSchema,
   type Stage1Output,
@@ -305,14 +306,14 @@ export class OllamaAnalyzer implements Analyzer {
     );
   }
 
-  // fs-58 — real body lands in Task 7b
   async runScriptReviewChapter(
-    _manuscriptId: string,
-    _chapterId: number,
-    _promptMd: string,
-    _call: StageCall,
+    manuscriptId: string,
+    chapterId: number,
+    promptMd: string,
+    call: StageCall,
   ): Promise<ScriptReviewOutput> {
-    throw new Error('runScriptReviewChapter not implemented (Task 7b)');
+    const key = `review-ch${chapterId}` as const;
+    return this.runStage(manuscriptId, key, 'script_review', promptMd, scriptReviewSchema, scriptReviewSchema, call);
   }
 
   private async runStage<T>(

--- a/server/src/analyzer/script-review.test.ts
+++ b/server/src/analyzer/script-review.test.ts
@@ -1,0 +1,178 @@
+/* runScriptReviewChapter — covers both OllamaAnalyzer and GeminiAnalyzer impls
+   (Task 7b). Mirrors the two-schema runStage mock block from ollama.test.ts:
+   mock the chat/generate layer to return a canned { ops:[...] }; assert the
+   call succeeds, returns the parsed ops, and writes the inbox/outbox handoff. */
+
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll, afterEach } from 'vitest';
+import { z } from 'zod';
+import { mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { geminiRateLimiter } from './rate-limit.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const HANDOFF_ROOT = resolve(__dirname, '..', '..', 'handoff');
+
+/* A valid ScriptReviewOutput — one strip_tag op */
+const VALID_REVIEW_RESPONSE = JSON.stringify({
+  ops: [
+    {
+      id: 1,
+      op: 'strip_tag',
+      anchor: 'Hard to starboard,',
+      newText: '"Hard to starboard,"',
+      rationale: 'Remove attribution tag from narrated dialogue',
+    },
+  ],
+});
+
+// ── Gemini SDK mock (top-level so vi.mock hoisting works) ──────────────────────
+const generateContentStream = vi.fn();
+
+vi.mock('@google/genai', () => {
+  return {
+    GoogleGenAI: class {
+      models = { generateContentStream };
+    },
+  };
+});
+
+/* Build a ReadableStream that emits Ollama-style NDJSON: one line per
+   content chunk, terminated by a `done: true` line. Mirrors ollama.test.ts. */
+function ndjsonStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (i < chunks.length) {
+        const line = JSON.stringify({
+          message: { role: 'assistant', content: chunks[i] },
+          done: false,
+        });
+        controller.enqueue(encoder.encode(line + '\n'));
+        i += 1;
+      } else if (i === chunks.length) {
+        const done = JSON.stringify({ message: { role: 'assistant', content: '' }, done: true });
+        controller.enqueue(encoder.encode(done + '\n'));
+        i += 1;
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+function chunksOf(text: string, size: number): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < text.length; i += size) out.push(text.slice(i, i + size));
+  return out;
+}
+
+function okResponse(stream: ReadableStream<Uint8Array>): Response {
+  return new Response(stream, { status: 200, headers: { 'Content-Type': 'application/x-ndjson' } });
+}
+
+async function* asyncFromChunks(items: Array<{ text: string; finishReason?: string }>) {
+  for (const item of items) {
+    yield {
+      text: item.text,
+      usageMetadata: { promptTokenCount: 50 },
+      candidates: item.finishReason ? [{ finishReason: item.finishReason }] : [],
+    };
+  }
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(async () => {
+  fetchMock.mockReset();
+  generateContentStream.mockReset();
+  geminiRateLimiter._reset();
+  vi.stubGlobal('fetch', fetchMock);
+  await mkdir(resolve(HANDOFF_ROOT, 'inbox'), { recursive: true });
+  await mkdir(resolve(HANDOFF_ROOT, 'outbox'), { recursive: true });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+beforeAll(() => { process.env.CASTWRIGHT_VRAM_SAMPLE = '0'; });
+afterAll(() => { delete process.env.CASTWRIGHT_VRAM_SAMPLE; });
+
+// ── OllamaAnalyzer tests ────────────────────────────────────────────────────
+
+describe('OllamaAnalyzer — runScriptReviewChapter (Task 7b)', () => {
+  it('returns the parsed ops and writes the inbox/outbox handoff', async () => {
+    const pieces = chunksOf(VALID_REVIEW_RESPONSE, 32);
+    fetchMock.mockResolvedValue(okResponse(ndjsonStream(pieces)));
+
+    const { OllamaAnalyzer } = await import('./ollama.js');
+    const analyzer = new OllamaAnalyzer({ url: 'http://localhost:11434', model: 'qwen3.5:4b' });
+
+    const result = await analyzer.runScriptReviewChapter(
+      'm_review_ollama',
+      1,
+      '# script-review prompt',
+      {},
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.ops).toHaveLength(1);
+    expect(result.ops[0].op).toBe('strip_tag');
+    expect(result.ops[0].id).toBe(1);
+    expect(result.ops[0].rationale).toBeTruthy();
+  });
+
+  it('uses scriptReviewSchema for both grammar (format) and validation', async () => {
+    fetchMock.mockResolvedValue(okResponse(ndjsonStream(chunksOf(VALID_REVIEW_RESPONSE, 32))));
+
+    const { OllamaAnalyzer } = await import('./ollama.js');
+    const { scriptReviewSchema } = await import('../handoff/schemas.js');
+    const analyzer = new OllamaAnalyzer({ url: 'http://localhost:11434', model: 'qwen3.5:4b' });
+
+    await analyzer.runScriptReviewChapter('m_review_schema', 1, '# prompt', {});
+
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as { body: string }).body);
+    const expectedFormat = z.toJSONSchema(scriptReviewSchema, { target: 'draft-07', reused: 'inline' });
+    expect(body.format).toEqual(expectedFormat);
+  });
+
+  it('uses the script-review skill (system instruction references the op classes)', async () => {
+    fetchMock.mockResolvedValue(okResponse(ndjsonStream(chunksOf(VALID_REVIEW_RESPONSE, 32))));
+
+    const { OllamaAnalyzer } = await import('./ollama.js');
+    const analyzer = new OllamaAnalyzer({ url: 'http://localhost:11434', model: 'qwen3.5:4b' });
+
+    await analyzer.runScriptReviewChapter('m_review_key', 3, '# prompt', {});
+
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as { body: string }).body);
+    const sysMsg = body.messages.find((m: { role: string }) => m.role === 'system');
+    expect(sysMsg).toBeDefined();
+    expect(sysMsg.content).toMatch(/strip_tag|extract_dialogue|fix_emotion/i);
+  });
+});
+
+// ── GeminiAnalyzer tests ────────────────────────────────────────────────────
+
+describe('GeminiAnalyzer — runScriptReviewChapter (Task 7b)', () => {
+  it('returns the parsed ops', async () => {
+    generateContentStream.mockResolvedValue(
+      asyncFromChunks([{ text: VALID_REVIEW_RESPONSE, finishReason: 'STOP' }]),
+    );
+
+    const { GeminiAnalyzer } = await import('./gemini.js');
+    const analyzer = new GeminiAnalyzer({ apiKey: 'test-key', model: 'gemma-4-31b-it' });
+
+    const result = await analyzer.runScriptReviewChapter(
+      'm_review_gemini',
+      1,
+      '# script-review prompt',
+      {},
+    );
+
+    expect(result.ops).toHaveLength(1);
+    expect(result.ops[0].op).toBe('strip_tag');
+    expect(result.ops[0].id).toBe(1);
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -24,6 +24,7 @@ import { qwenVoiceRouter } from './routes/qwen-voice.js';
 import { castDesignRouter } from './routes/cast-design.js';
 import { singleDesignRouter } from './routes/single-design.js';
 import { annotateEmotionRouter } from './routes/annotate-emotion.js';
+import { scriptReviewRouter } from './routes/script-review.js';
 import { libraryCastOverrideRouter } from './routes/library-cast-override.js';
 import { seriesRosterRouter } from './routes/series-roster.js';
 import { seriesCastRouter } from './routes/series-cast.js';
@@ -152,6 +153,7 @@ app.use('/api/books', qwenVoiceRouter); // mounts /:bookId/cast/:characterId/des
 app.use('/api/books', castDesignRouter); // mounts /:bookId/cast/design{,/status,/pause} ("Design full cast" bulk-design job — server-owned SSE)
 app.use('/api/books', singleDesignRouter); // mounts /:bookId/cast/:characterId/design-voice/stream + /:bookId/cast/design-single/{subscribe,status} (single-design background job)
 app.use('/api/books', annotateEmotionRouter); // mounts /:bookId/annotate-emotion (fs-33 — emotion-only backfill SSE pass)
+app.use('/api/books', scriptReviewRouter); // mounts /:bookId/script-review (fs-58 — LLM script-review SSE pass)
 app.use('/api/books', seriesRosterRouter); // mounts /:bookId/series-roster (prior-book characters in the same series)
 app.use('/api/books', seriesCastRouter); // mounts /:bookId/series-cast (full-fidelity cast of every OTHER series book — rebaseline aggregation)
 app.use('/api', libraryCastOverrideRouter); // mounts /library-cast/override (cross-book; not under /:bookId)

--- a/server/src/config/registry.ts
+++ b/server/src/config/registry.ts
@@ -848,6 +848,16 @@ export const KNOBS: ConfigKnob[] = [
     apply: 'live', risk: 'high',
   },
   {
+    key: 'prompt.scriptReview',
+    env: '',
+    group: 'analyzer-prompts',
+    label: 'Script review prompt',
+    help: 'The skill file sent to the analysis model for per-chapter script review (strip_tag/split/extract_dialogue/merge/fix_emotion ops). Editing forks a local copy; changes take effect without a restart.',
+    type: 'string', isPrompt: true,
+    default: 'skills/audiobook-script-review.md', // ← confirmed exists at skills/audiobook-script-review.md
+    apply: 'live', risk: 'high',
+  },
+  {
     key: 'prompt.voiceStyle',
     env: '',
     group: 'analyzer-prompts',

--- a/server/src/handoff/protocol.ts
+++ b/server/src/handoff/protocol.ts
@@ -25,7 +25,8 @@ export type HandoffKey =
   | `1-ch${number}`
   | '2'
   | `2-ch${number}`
-  | `emotion-ch${number}`;
+  | `emotion-ch${number}`
+  | `review-ch${number}`;
 
 async function ensureDirs(): Promise<void> {
   await mkdir(INBOX, { recursive: true });

--- a/server/src/handoff/schemas.test.ts
+++ b/server/src/handoff/schemas.test.ts
@@ -11,6 +11,9 @@ import {
   analyzerCharacterSchema,
   stage1ChapterGrammarSchema,
   stage1GrammarSchema,
+  scriptReviewSchema,
+  ScriptReviewOp,
+  ScriptReviewOutput,
 } from './schemas.js';
 
 /* The Ollama analyzer (server/src/analyzer/ollama.ts) feeds these per-stage
@@ -193,5 +196,138 @@ describe('analyzer grammar schemas — required tone (Task 6)', () => {
 
   it('stage1ChapterSchema (validation) still accepts characters with no tone', () => {
     expect(stage1ChapterSchema.safeParse({ characters: [charWithoutTone] }).success).toBe(true);
+  });
+});
+
+describe('fs-58 — script review schema (flat envelope)', () => {
+  it('parses a heterogeneous ops array with extract_dialogue including both anchor and anchorEnd', () => {
+    const payload = {
+      ops: [
+        {
+          id: 1,
+          op: 'extract_dialogue',
+          anchor: 'She said,',
+          anchorEnd: 'goodbye"',
+          rationale: 'Extracted dialogue from narration',
+          confidence: 0.95,
+        },
+        {
+          id: 2,
+          op: 'strip_tag',
+          newText: 'corrected text',
+          rationale: 'Removed formatting tag',
+          confidence: 0.88,
+        },
+        {
+          id: 3,
+          op: 'split',
+          pieceCharacterIds: ['char-a', 'char-b'],
+          rationale: 'Split sentence across speakers',
+        },
+        {
+          id: 4,
+          op: 'merge',
+          mergeIds: [5, 6],
+          rationale: 'Merged two related sentences',
+        },
+        {
+          id: 5,
+          op: 'fix_emotion',
+          emotion: 'angry',
+          rationale: 'Changed emotion for delivery',
+          confidence: 0.92,
+        },
+      ],
+    };
+
+    const result = scriptReviewSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.ops).toHaveLength(5);
+      expect(result.data.ops[0].op).toBe('extract_dialogue');
+      expect(result.data.ops[0].anchor).toBe('She said,');
+      expect(result.data.ops[0].anchorEnd).toBe('goodbye"');
+      expect(result.data.ops[4].emotion).toBe('angry');
+    }
+  });
+
+  it('rejects an unknown op type', () => {
+    const payload = {
+      ops: [
+        {
+          id: 1,
+          op: 'frobnicate',
+          rationale: 'This op does not exist',
+        },
+      ],
+    };
+
+    const result = scriptReviewSchema.safeParse(payload);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an op with an unknown emotion value', () => {
+    const payload = {
+      ops: [
+        {
+          id: 1,
+          op: 'fix_emotion',
+          emotion: 'furious',
+          rationale: 'Invalid emotion',
+        },
+      ],
+    };
+
+    const result = scriptReviewSchema.safeParse(payload);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects strict violations — extra fields on op or root', () => {
+    const payloadExtraOpField = {
+      ops: [
+        {
+          id: 1,
+          op: 'strip_tag',
+          rationale: 'test',
+          unknownField: 'should not be here',
+        },
+      ],
+    };
+
+    const payloadExtraRootField = {
+      ops: [{ id: 1, op: 'strip_tag', rationale: 'test' }],
+      unknownField: 'should not be here',
+    };
+
+    expect(scriptReviewSchema.safeParse(payloadExtraOpField).success).toBe(false);
+    expect(scriptReviewSchema.safeParse(payloadExtraRootField).success).toBe(false);
+  });
+
+  it('accepts an empty ops array — a chapter with no suggestions', () => {
+    const payload = { ops: [] };
+    const result = scriptReviewSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.ops).toEqual([]);
+    }
+  });
+
+  it('types ScriptReviewOp and ScriptReviewOutput correctly', () => {
+    const payload: ScriptReviewOutput = {
+      ops: [
+        {
+          id: 1,
+          op: 'extract_dialogue',
+          anchor: 'text',
+          anchorEnd: 'text2',
+          rationale: 'reason',
+        },
+      ],
+    };
+
+    // This is a type-only check; if it compiles, the types are correct.
+    // We can also access individual ops:
+    const op: ScriptReviewOp = payload.ops[0];
+    expect(op.op).toBe('extract_dialogue');
   });
 });

--- a/server/src/handoff/schemas.ts
+++ b/server/src/handoff/schemas.ts
@@ -203,3 +203,38 @@ export const stage1GrammarSchema = z
     chapters: stage1Schema.shape.chapters,
   })
   .strict();
+
+/* ── fs-58 Script Review schema (Task 6) ────────────────────────────────────
+   Flat envelope for LLM script-review ops. No discriminated union — Gemini
+   can't constrain it; Ollama only softly. Per-op validation is imperative
+   client-side (Task 4) and server pre-apply is N/A (apply is client-side).
+
+   Typical ops: strip_tag (remove formatting), split (sentence across speakers),
+   extract_dialogue (narration → dialogue), merge (join sentences), fix_emotion
+   (set delivery emotion). Each op carries an anchor or range for location,
+   optional new-text / pieceCharacterIds / mergeIds / emotion, and a rationale
+   + optional confidence score. */
+
+export const scriptReviewSchema = z
+  .object({
+    ops: z.array(
+      z
+        .object({
+          id: z.number().int().positive(),
+          op: z.enum(['strip_tag', 'split', 'extract_dialogue', 'merge', 'fix_emotion']),
+          newText: z.string().optional(),
+          anchor: z.string().optional(),
+          anchorEnd: z.string().optional(),
+          pieceCharacterIds: z.array(z.string()).optional(),
+          mergeIds: z.array(z.number().int().positive()).optional(),
+          emotion: z.enum(EMOTIONS).optional(),
+          rationale: z.string(),
+          confidence: z.number().min(0).max(1).optional(),
+        })
+        .strict(),
+    ),
+  })
+  .strict();
+
+export type ScriptReviewOp = z.infer<typeof scriptReviewSchema>['ops'][number];
+export type ScriptReviewOutput = z.infer<typeof scriptReviewSchema>;

--- a/server/src/routes/analysis-pipelining.test.ts
+++ b/server/src/routes/analysis-pipelining.test.ts
@@ -211,6 +211,9 @@ function makePipelineFixture(): {
     async runEmotionChapter() {
       throw new Error('Phase 0 analyzer does not run emotion calls');
     },
+    async runScriptReviewChapter() {
+      throw new Error('Phase 0 analyzer does not run script review calls');
+    },
   };
 
   const phase1Analyzer: Analyzer = {
@@ -255,6 +258,9 @@ function makePipelineFixture(): {
     },
     async runEmotionChapter() {
       throw new Error('Phase 1 analyzer does not run emotion calls');
+    },
+    async runScriptReviewChapter() {
+      throw new Error('Phase 1 analyzer does not run script review calls');
     },
   };
 

--- a/server/src/routes/analysis.phase-model.test.ts
+++ b/server/src/routes/analysis.phase-model.test.ts
@@ -58,6 +58,9 @@ function buildSpyPhase0Analyzer(): Analyzer {
     async runEmotionChapter() {
       throw new Error('Phase-0 analyzer does not run emotion calls');
     },
+    async runScriptReviewChapter() {
+      throw new Error('Phase-0 analyzer does not run script review calls');
+    },
   };
 }
 
@@ -88,6 +91,9 @@ function buildSpyPhase1Analyzer(): Analyzer {
     },
     async runEmotionChapter() {
       throw new Error('Phase-1 analyzer does not run emotion calls');
+    },
+    async runScriptReviewChapter() {
+      throw new Error('Phase-1 analyzer does not run script review calls');
     },
   };
 }

--- a/server/src/routes/annotate-emotion.test.ts
+++ b/server/src/routes/annotate-emotion.test.ts
@@ -36,6 +36,7 @@ vi.mock('../analyzer/select-analyzer.js', async (importOriginal) => {
     runStage1Chapter: () => Promise.reject(new Error('not used')),
     runStage2Chapter: () => Promise.reject(new Error('not used')),
     runEmotionChapter: (m, c, p, call) => runEmotion(m, c, p, call),
+    runScriptReviewChapter: () => Promise.reject(new Error('not used')),
   };
   return {
     ...actual,

--- a/server/src/routes/book-state.merge-tombstone.test.ts
+++ b/server/src/routes/book-state.merge-tombstone.test.ts
@@ -1,0 +1,120 @@
+/* fs-58 — Round-trip test: mergedAwayKeys persists through PUT manuscript
+   → GET and survives the sentences-filter reconciliation path.
+
+   Follows the book-state.test.ts pattern: tempdir workspace, deferred
+   module imports so paths.ts picks up WORKSPACE_DIR, supertest against
+   the real router. */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import express, { type Express } from 'express';
+import request from 'supertest';
+
+const AUTHOR = 'Test Author';
+const SERIES = 'Standalones';
+const TITLE = 'Merge Tombstone Book';
+
+let workspaceRoot: string;
+let bookDir: string;
+let app: Express;
+let bookId: string;
+
+beforeAll(async () => {
+  workspaceRoot = await mkdtemp(join(tmpdir(), 'audiobook-merge-tombstone-test-'));
+  process.env.WORKSPACE_DIR = workspaceRoot;
+
+  const [{ bookStateRouter }, { makeBookId }] = await Promise.all([
+    import('./book-state.js'),
+    import('../workspace/paths.js'),
+  ]);
+  bookId = makeBookId(AUTHOR, SERIES, TITLE);
+
+  bookDir = join(workspaceRoot, 'books', AUTHOR, SERIES, TITLE);
+  mkdirSync(join(bookDir, '.audiobook'), { recursive: true });
+  writeFileSync(
+    join(bookDir, '.audiobook', 'state.json'),
+    JSON.stringify({
+      bookId,
+      manuscriptId: 'm_test',
+      title: TITLE,
+      author: AUTHOR,
+      series: SERIES,
+      seriesPosition: null,
+      isStandalone: true,
+      manuscriptFile: 'manuscript.txt',
+      castConfirmed: true,
+      chapters: [{ id: 1, title: 'Chapter 1', slug: 'chapter-one' }],
+      coverGradient: ['#000', '#fff'],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }),
+  );
+  writeFileSync(join(bookDir, 'manuscript.txt'), 'placeholder');
+
+  app = express();
+  app.use(express.json());
+  app.use('/api/books', bookStateRouter);
+});
+
+afterAll(() => {
+  if (workspaceRoot) rmSync(workspaceRoot, { recursive: true, force: true });
+  delete process.env.WORKSPACE_DIR;
+});
+
+describe('book-state router — mergedAwayKeys round-trip (fs-58 task-2b)', () => {
+  it('PUT slice=manuscript with mergedAwayKeys → GET returns mergedAwayKeys in manuscriptEdits', async () => {
+    const sentences = [
+      { id: 1, chapterId: 1, characterId: 'narrator', text: 'The hall was dark. Dust hung in the air.' },
+    ];
+    const mergedAwayKeys = ['1:2'];
+
+    // PUT persists sentences + tombstone.
+    const putRes = await request(app)
+      .put(`/api/books/${bookId}/state`)
+      .set('Content-Type', 'application/json')
+      .send({ slice: 'manuscript', patch: { sentences, mergedAwayKeys } });
+    expect(putRes.status).toBe(204);
+
+    // GET returns mergedAwayKeys in manuscriptEdits.
+    const getRes = await request(app).get(`/api/books/${bookId}/state`);
+    expect(getRes.status).toBe(200);
+    expect(getRes.body.manuscriptEdits?.mergedAwayKeys).toEqual(['1:2']);
+    expect(getRes.body.manuscriptEdits?.sentences).toHaveLength(1);
+  });
+
+  it('mergedAwayKeys is absent (not null) when the manuscript was never PUT with tombstone', async () => {
+    /* Fresh book with no manuscript-edits.json written → manuscriptEdits
+       is null (the file was never created). */
+    const TITLE2 = 'Merge Tombstone Book 2';
+    const bookId2 = (await import('../workspace/paths.js')).makeBookId(AUTHOR, SERIES, TITLE2);
+    const bookDir2 = join(workspaceRoot, 'books', AUTHOR, SERIES, TITLE2);
+    mkdirSync(join(bookDir2, '.audiobook'), { recursive: true });
+    writeFileSync(
+      join(bookDir2, '.audiobook', 'state.json'),
+      JSON.stringify({
+        bookId: bookId2,
+        manuscriptId: 'm_test2',
+        title: TITLE2,
+        author: AUTHOR,
+        series: SERIES,
+        seriesPosition: null,
+        isStandalone: true,
+        manuscriptFile: 'manuscript.txt',
+        castConfirmed: true,
+        chapters: [{ id: 1, title: 'Chapter 1', slug: 'chapter-one' }],
+        coverGradient: ['#000', '#fff'],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+    writeFileSync(join(bookDir2, 'manuscript.txt'), 'placeholder');
+
+    const getRes = await request(app).get(`/api/books/${bookId2}/state`);
+    expect(getRes.status).toBe(200);
+    // manuscriptEdits is null when no file has been written yet.
+    expect(getRes.body.manuscriptEdits).toBeNull();
+  });
+});

--- a/server/src/routes/book-state.ts
+++ b/server/src/routes/book-state.ts
@@ -222,7 +222,7 @@ bookStateRouter.get('/:bookId/state', async (req: Request, res: Response) => {
       await writeStateJsonAtomic(stateJsonPath(bookDir), state);
     }
     const cast = await readJson<{ characters: unknown[] }>(castJsonPath(bookDir));
-    let edits = await readJson<{ sentences?: unknown[] }>(manuscriptEditsJsonPath(bookDir));
+    let edits = await readJson<{ sentences?: unknown[]; mergedAwayKeys?: string[] }>(manuscriptEditsJsonPath(bookDir));
     const revs = await readJson<{
       pending?: unknown[];
       drift?: unknown[];
@@ -288,7 +288,8 @@ bookStateRouter.get('/:bookId/state', async (req: Request, res: Response) => {
             if (cacheIds.has(s.id)) return true; // still a valid sentence
             return s.id > maxCacheId; // likely a split offspring
           });
-          edits = { sentences: filtered };
+          // fs-58 — preserve mergedAwayKeys across the sentences-filter reassignment.
+          edits = { sentences: filtered, mergedAwayKeys: edits.mergedAwayKeys };
         }
       } else if (cachedSentences.length > 0) {
         edits = { sentences: cachedSentences };

--- a/server/src/routes/script-review.test.ts
+++ b/server/src/routes/script-review.test.ts
@@ -1,0 +1,262 @@
+/* fs-58 — integration tests for the script-review SSE route
+   POST /api/books/:bookId/script-review.
+
+   The analyzer is faked via vi.mock('../analyzer/select-analyzer.js') so no
+   real LLM is hit. The route is the contract under test: it streams per-chapter
+   `ops` events with the review operations, guards an unattributed book with a
+   `no_attribution` error, and on mid-pass DailyQuotaExhaustedError emits a
+   `quota_exhausted` error after the chapters it already streamed.
+   When an optional `chapterId` is supplied in the body, only that chapter is
+   reviewed (the analyzer is called exactly once). */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import express, { type Express } from 'express';
+import request from 'supertest';
+import type { Analyzer } from '../analyzer/index.js';
+import type { ScriptReviewOutput } from '../handoff/schemas.js';
+
+const AUTHOR = 'Test Author';
+const SERIES = 'Test Series';
+const BOOK = 'Test Book';
+
+let workspaceRoot: string;
+let app: Express;
+let bookId: string;
+let manuscriptId: string;
+
+/* The fake analyzer's runScriptReviewChapter — each test swaps its implementation. */
+const { runReview } = vi.hoisted(() => ({ runReview: vi.fn() }));
+
+vi.mock('../analyzer/select-analyzer.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../analyzer/select-analyzer.js')>();
+  const fakeAnalyzer: Analyzer = {
+    runStage1: () => Promise.reject(new Error('not used')),
+    runStage1Chapter: () => Promise.reject(new Error('not used')),
+    runStage2Chapter: () => Promise.reject(new Error('not used')),
+    runEmotionChapter: () => Promise.reject(new Error('not used')),
+    runScriptReviewChapter: (m, c, p, call) => runReview(m, c, p, call),
+  };
+  return {
+    ...actual,
+    selectAnalyzerForPhase: () => ({
+      analyzer: fakeAnalyzer,
+      engine: 'gemini' as const,
+      model: 'test-model',
+      fallbackModel: null,
+    }),
+  };
+});
+
+function bookDir(): string {
+  return join(workspaceRoot, 'books', AUTHOR, SERIES, BOOK);
+}
+
+function writeBook(sentences: unknown[] | null): void {
+  const dir = bookDir();
+  mkdirSync(join(dir, '.audiobook'), { recursive: true });
+  writeFileSync(
+    join(dir, '.audiobook', 'state.json'),
+    JSON.stringify({
+      bookId,
+      manuscriptId,
+      title: BOOK,
+      author: AUTHOR,
+      series: SERIES,
+      seriesPosition: 1,
+      isStandalone: true,
+      manuscriptFile: 'manuscript.txt',
+      castConfirmed: true,
+      chapters: [],
+      coverGradient: ['#000', '#fff'],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }),
+  );
+  writeFileSync(join(dir, 'manuscript.txt'), 'placeholder');
+  writeFileSync(
+    join(dir, '.audiobook', 'cast.json'),
+    JSON.stringify({
+      characters: [{ id: 'wren', name: 'Wren', role: 'protagonist', color: '#ff0000' }],
+    }),
+  );
+  if (sentences) {
+    writeFileSync(
+      join(dir, '.audiobook', 'manuscript-edits.json'),
+      JSON.stringify({ sentences }),
+    );
+  }
+}
+
+/** Parse an SSE response body into the array of JSON `data:` payloads. */
+function parseSse(body: string): Array<Record<string, unknown>> {
+  return body
+    .split('\n')
+    .filter((l) => l.startsWith('data: '))
+    .map((l) => JSON.parse(l.slice('data: '.length)));
+}
+
+const SENTENCES = [
+  { id: 1, chapterId: 1, characterId: 'narrator', text: 'The room was quiet.' },
+  { id: 2, chapterId: 1, characterId: 'wren', text: '"Get down!"' },
+  { id: 3, chapterId: 2, characterId: 'marlow', text: '"It will be okay," he whispered.' },
+];
+
+const CANNED_OPS: ScriptReviewOutput = {
+  ops: [
+    {
+      id: 1,
+      op: 'strip_tag',
+      anchor: 'Get down',
+      newText: '"Get down!"',
+      rationale: 'Remove attribution tag',
+    },
+  ],
+};
+
+beforeAll(async () => {
+  workspaceRoot = mkdtempSync(join(tmpdir(), 'audiobook-script-review-test-'));
+  process.env.WORKSPACE_DIR = workspaceRoot;
+  const [{ scriptReviewRouter }, { makeBookId }] = await Promise.all([
+    import('./script-review.js'),
+    import('../workspace/paths.js'),
+  ]);
+  bookId = makeBookId(AUTHOR, SERIES, BOOK);
+  manuscriptId = `m_${bookId}`;
+  app = express();
+  app.use(express.json());
+  app.use('/api/books', scriptReviewRouter);
+});
+
+beforeEach(() => {
+  runReview.mockReset();
+  rmSync(join(workspaceRoot, 'books'), { recursive: true, force: true });
+});
+
+afterAll(() => {
+  if (workspaceRoot) rmSync(workspaceRoot, { recursive: true, force: true });
+  delete process.env.WORKSPACE_DIR;
+});
+
+describe('POST /api/books/:bookId/script-review', () => {
+  it('streams per-chapter ops events and a final result', async () => {
+    writeBook(SENTENCES);
+    runReview.mockImplementation((_m, chapterId): Promise<ScriptReviewOutput> => {
+      if (chapterId === 1) return Promise.resolve(CANNED_OPS);
+      return Promise.resolve({ ops: [] });
+    });
+
+    const res = await request(app).post(`/api/books/${bookId}/script-review`).send({});
+    expect(res.status).toBe(200);
+    const events = parseSse(res.text);
+
+    const opsEvents = events.filter((e) => e.kind === 'ops');
+    expect(opsEvents).toHaveLength(2);
+    expect(opsEvents[0]).toMatchObject({ kind: 'ops', chapterId: 1, ops: CANNED_OPS.ops });
+    expect(opsEvents[1]).toMatchObject({ kind: 'ops', chapterId: 2, ops: [] });
+
+    const result = events.find((e) => e.kind === 'result');
+    expect(result).toMatchObject({ done: true, reviewedChapters: 2 });
+  });
+
+  it('limits the pass to one chapter when chapterId is provided', async () => {
+    writeBook(SENTENCES);
+    runReview.mockResolvedValue(CANNED_OPS);
+
+    const res = await request(app)
+      .post(`/api/books/${bookId}/script-review`)
+      .send({ chapterId: 1 });
+    expect(res.status).toBe(200);
+
+    // Analyzer called exactly once (for chapter 1 only)
+    expect(runReview).toHaveBeenCalledTimes(1);
+    expect(runReview.mock.calls[0][1]).toBe(1);
+
+    const events = parseSse(res.text);
+    const opsEvents = events.filter((e) => e.kind === 'ops');
+    expect(opsEvents).toHaveLength(1);
+    expect(opsEvents[0]).toMatchObject({ kind: 'ops', chapterId: 1 });
+  });
+
+  it('emits a no_attribution error when the book has no attributed sentences', async () => {
+    writeBook(null); // no manuscript-edits.json, no cache
+    const res = await request(app).post(`/api/books/${bookId}/script-review`).send({});
+    const events = parseSse(res.text);
+    expect(events.some((e) => e.kind === 'error' && e.code === 'no_attribution')).toBe(true);
+    expect(events.some((e) => e.kind === 'result')).toBe(false);
+    expect(runReview).not.toHaveBeenCalled();
+  });
+
+  it('404s for an unknown book', async () => {
+    const res = await request(app).post(`/api/books/does-not-exist/script-review`).send({});
+    expect(res.status).toBe(404);
+  });
+
+  it('on mid-pass daily-quota exhaustion, keeps already-streamed chapters and stops with quota_exhausted', async () => {
+    writeBook(SENTENCES);
+    const { DailyQuotaExhaustedError } = await import('../analyzer/rate-limit.js');
+    runReview.mockImplementation((_m, chapterId): Promise<ScriptReviewOutput> => {
+      if (chapterId === 1) return Promise.resolve(CANNED_OPS);
+      return Promise.reject(new DailyQuotaExhaustedError('test-model', new Date('2099-01-01')));
+    });
+
+    const res = await request(app).post(`/api/books/${bookId}/script-review`).send({});
+    const events = parseSse(res.text);
+
+    // Chapter 1 ops survived.
+    expect(events.some((e) => e.kind === 'ops' && e.chapterId === 1)).toBe(true);
+    // Quota error reported; no success result.
+    expect(events.some((e) => e.kind === 'error' && e.code === 'quota_exhausted')).toBe(true);
+    expect(events.some((e) => e.kind === 'result')).toBe(false);
+  });
+
+  it('a single chapter failure does not abort the rest of the pass', async () => {
+    writeBook(SENTENCES);
+    runReview.mockImplementation((_m, chapterId): Promise<ScriptReviewOutput> => {
+      if (chapterId === 1) return Promise.reject(new Error('flaky chapter'));
+      return Promise.resolve({ ops: [] });
+    });
+
+    const res = await request(app).post(`/api/books/${bookId}/script-review`).send({});
+    const events = parseSse(res.text);
+    expect(events.some((e) => e.kind === 'chapter-failed' && e.chapterId === 1)).toBe(true);
+    expect(events.some((e) => e.kind === 'ops' && e.chapterId === 2)).toBe(true);
+    expect(events.find((e) => e.kind === 'result')).toMatchObject({ reviewedChapters: 1 });
+  });
+
+  it('emits chapter-failed for an oversized chapter and continues to the next', async () => {
+    // Build a chapter whose serialised prompt exceeds DEFAULT_STAGE2_CHUNK_CHAR_BUDGET (9000).
+    // buildScriptReviewChapterInbox produces a ~150-char header + JSON-stringified sentences.
+    // Each sentence object serialises to ~{"sentenceId":N,"characterId":"narrator","text":"..."}.
+    // 12 sentences × ~800-char text each ≈ 9600 chars of sentence JSON alone — comfortably over
+    // the 9000-char budget even before the header/roster are added.
+    const longText = 'A'.repeat(800);
+    const bigChapterSentences = Array.from({ length: 12 }, (_, i) => ({
+      id: 100 + i,
+      chapterId: 10,
+      characterId: 'narrator',
+      text: longText,
+    }));
+    const normalSentence = { id: 200, chapterId: 11, characterId: 'wren', text: 'Short line.' };
+    writeBook([...bigChapterSentences, normalSentence]);
+    runReview.mockResolvedValue({ ops: [] });
+
+    const res = await request(app).post(`/api/books/${bookId}/script-review`).send({});
+    expect(res.status).toBe(200);
+    const events = parseSse(res.text);
+
+    // (a) Oversized chapter emits chapter-failed with a message about being too large.
+    const failedEvent = events.find((e) => e.kind === 'chapter-failed' && e.chapterId === 10);
+    expect(failedEvent).toBeDefined();
+    expect(typeof failedEvent!.message).toBe('string');
+    expect((failedEvent!.message as string).toLowerCase()).toContain('too large');
+
+    // (b) The normal chapter still produces an ops event — the overflow `continue` did not abort.
+    expect(events.some((e) => e.kind === 'ops' && e.chapterId === 11)).toBe(true);
+
+    // (c) A final result event arrives.
+    expect(events.some((e) => e.kind === 'result')).toBe(true);
+  });
+});

--- a/server/src/routes/script-review.test.ts
+++ b/server/src/routes/script-review.test.ts
@@ -189,6 +189,19 @@ describe('POST /api/books/:bookId/script-review', () => {
     expect(runReview).not.toHaveBeenCalled();
   });
 
+  it('emits a no_such_chapter error when a requested chapterId matches no attributed chapter', async () => {
+    writeBook(SENTENCES); // book IS analysed — chapters 1 and 2 carry sentences
+    const res = await request(app)
+      .post(`/api/books/${bookId}/script-review`)
+      .send({ chapterId: 99 }); // no such chapter
+    const events = parseSse(res.text);
+    expect(events.some((e) => e.kind === 'error' && e.code === 'no_such_chapter')).toBe(true);
+    // Must NOT be conflated with the unanalysed-book code.
+    expect(events.some((e) => e.kind === 'error' && e.code === 'no_attribution')).toBe(false);
+    expect(events.some((e) => e.kind === 'result')).toBe(false);
+    expect(runReview).not.toHaveBeenCalled();
+  });
+
   it('404s for an unknown book', async () => {
     const res = await request(app).post(`/api/books/does-not-exist/script-review`).send({});
     expect(res.status).toBe(404);

--- a/server/src/routes/script-review.ts
+++ b/server/src/routes/script-review.ts
@@ -184,11 +184,25 @@ scriptReviewRouter.post(
       clearInterval(keepAlive);
     });
 
-    if (chapterIds.length === 0) {
+    if (byChapter.size === 0) {
+      /* The book carries no attributed sentences at all — it was never
+         analysed (or analysis produced nothing). */
       send({
         kind: 'error',
         code: 'no_attribution',
         message: 'Run analysis first — there are no attributed sentences to review.',
+      });
+      clearInterval(keepAlive);
+      res.end();
+      return;
+    }
+    if (chapterIds.length === 0) {
+      /* The book IS analysed, but the requested chapterId matched no chapter
+         with attributed sentences — a distinct case from the unanalysed book. */
+      send({
+        kind: 'error',
+        code: 'no_such_chapter',
+        message: `Chapter ${requestedChapterId} has no attributed sentences to review.`,
       });
       clearInterval(keepAlive);
       res.end();

--- a/server/src/routes/script-review.ts
+++ b/server/src/routes/script-review.ts
@@ -1,0 +1,293 @@
+/* fs-58 — LLM script-review route. Streams a per-chapter LLM pass that
+   reads a book's attributed sentences + post-fold cast roster and emits
+   editing ops (strip_tag, split, extract_dialogue, merge, fix_emotion).
+   The route never writes a file: it streams `ops` events and the FRONTEND
+   applies them through existing Redux manual-edit reducers.
+
+   Non-sticky by design: a disconnect aborts the in-flight analyzer call.
+   Already-streamed chapters are already applied client-side, so a re-run
+   just fills the remaining chapters.
+
+   ASSUMPTION — overflow deferral: when a chapter's prompt text exceeds the
+   model budget (DEFAULT_STAGE2_CHUNK_CHAR_BUDGET), this route emits a
+   `chapter-failed` event with a "chapter too large — split it first" message
+   and continues to the next chapter. Chunk-with-overlap (the richer approach
+   from stage2-chunk.ts) is deferred to a follow-up task. */
+
+import { Router } from 'express';
+import type { Request, Response } from '../http.js';
+import { findBookByBookId } from '../workspace/scan.js';
+import { manuscriptEditsJsonPath, castJsonPath } from '../workspace/paths.js';
+import { readJson } from '../workspace/state-io.js';
+import { loadAnalysisCache } from '../store/analysis-cache.js';
+import { selectAnalyzerForPhase } from '../analyzer/select-analyzer.js';
+import { makeThrottledHeartbeat } from './analysis-heartbeat.js';
+import { AnalysisAbortedError } from '../analyzer/ollama.js';
+import { DailyQuotaExhaustedError } from '../analyzer/rate-limit.js';
+import { DEFAULT_STAGE2_CHUNK_CHAR_BUDGET } from '../analyzer/stage2-chunk.js';
+import type { SentenceOutput } from '../handoff/schemas.js';
+
+export const scriptReviewRouter = Router();
+
+/* Local type for the parts of cast.json we need. */
+interface CastCharacterSlim {
+  id: string;
+  name: string;
+  role?: string;
+}
+interface CastFile {
+  characters?: CastCharacterSlim[];
+}
+
+/* Load the book's POST-FOLD attributed sentences grouped by chapter — the
+   same source synth + the manuscript view use. Mirrors loadPostFoldSentencesByChapter
+   from annotate-emotion.ts exactly (same reconciliation logic). */
+async function loadPostFoldSentencesByChapter(
+  manuscriptId: string,
+  bookDir: string,
+): Promise<Map<number, SentenceOutput[]>> {
+  const cache = await loadAnalysisCache(manuscriptId);
+  const cachedSentences = Object.values(cache.chapters ?? {}).flat();
+  const edits = await readJson<{ sentences?: SentenceOutput[] }>(manuscriptEditsJsonPath(bookDir));
+
+  let sentences: SentenceOutput[];
+  if (edits && Array.isArray(edits.sentences) && edits.sentences.length > 0) {
+    if (cachedSentences.length > 0) {
+      const cacheIds = new Set<number>();
+      let maxCacheId = 0;
+      for (const s of cachedSentences) {
+        cacheIds.add(s.id);
+        if (s.id > maxCacheId) maxCacheId = s.id;
+      }
+      sentences = edits.sentences.filter(
+        (s) => typeof s?.id !== 'number' || cacheIds.has(s.id) || s.id > maxCacheId,
+      );
+    } else {
+      sentences = edits.sentences;
+    }
+  } else {
+    sentences = cachedSentences;
+  }
+
+  const byChapter = new Map<number, SentenceOutput[]>();
+  for (const s of sentences) {
+    if (typeof s?.chapterId !== 'number') continue;
+    const bucket = byChapter.get(s.chapterId);
+    if (bucket) bucket.push(s);
+    else byChapter.set(s.chapterId, [s]);
+  }
+  return byChapter;
+}
+
+/* Build the per-chapter script-review prompt. We send the full chapter
+   sentence sequence plus the post-fold cast roster (id/name/role) so the
+   model can identify characters and propose attribution-level edits.
+   Only id/characterId/text go out for the sentences; the model returns a
+   flat list of ops each with an anchor and optional new-text/pieceCharacterIds
+   /mergeIds/emotion. */
+export function buildScriptReviewChapterInbox(
+  manuscriptId: string,
+  chapterId: number,
+  sentences: SentenceOutput[],
+  roster: CastCharacterSlim[],
+): string {
+  const sentencePayload = sentences.map((s) => ({
+    sentenceId: s.id,
+    characterId: s.characterId,
+    text: s.text,
+  }));
+  const rosterPayload = roster.map((c) => ({
+    id: c.id,
+    name: c.name,
+    ...(c.role ? { role: c.role } : {}),
+  }));
+  return `---
+manuscriptId: ${manuscriptId}
+task: script-review
+chapterId: ${chapterId}
+---
+
+## Cast roster (post-fold)
+
+\`\`\`json
+${JSON.stringify(rosterPayload, null, 2)}
+\`\`\`
+
+## Sentences (already attributed)
+
+\`\`\`json
+${JSON.stringify(sentencePayload, null, 2)}
+\`\`\`
+`;
+}
+
+scriptReviewRouter.post(
+  '/:bookId/script-review',
+  async (req: Request, res: Response): Promise<void> => {
+    const { bookId } = req.params;
+    const requestedChapterId: number | undefined =
+      typeof req.body?.chapterId === 'number' ? req.body.chapterId : undefined;
+
+    const located = await findBookByBookId(bookId);
+    if (!located) {
+      res.status(404).json({ error: 'Book not found.' });
+      return;
+    }
+    const manuscriptId = located.state.manuscriptId;
+    if (!manuscriptId) {
+      res.status(409).json({ error: 'Book has not been analysed yet.' });
+      return;
+    }
+
+    const byChapter = await loadPostFoldSentencesByChapter(manuscriptId, located.bookDir);
+
+    /* When chapterId is supplied in the body, limit the pass to that one chapter. */
+    let chapterIds = [...byChapter.keys()].sort((a, b) => a - b);
+    if (requestedChapterId !== undefined) {
+      chapterIds = chapterIds.filter((id) => id === requestedChapterId);
+    }
+
+    /* Load the post-fold cast roster so the prompt carries character names+roles.
+       cast.json is written after the minor-cast fold so it already has folded ids.
+       A missing or empty cast.json falls back to an empty roster — the model
+       will still review the prose even without character context. */
+    const castFile = await readJson<CastFile>(castJsonPath(located.bookDir));
+    const roster: CastCharacterSlim[] = castFile?.characters ?? [];
+
+    /* SSE setup (mirrors annotate-emotion.ts). */
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.setHeader('X-Accel-Buffering', 'no');
+    res.flushHeaders();
+    res.write(':ok\n\n');
+    const keepAlive = setInterval(() => {
+      try {
+        res.write(':ka\n\n');
+      } catch {
+        /* socket gone */
+      }
+    }, 15_000);
+    const send = (payload: unknown): void => {
+      try {
+        res.write(`data: ${JSON.stringify(payload)}\n\n`);
+      } catch {
+        /* dead socket */
+      }
+    };
+
+    const controller = new AbortController();
+    let closed = false;
+    res.on('close', () => {
+      closed = true;
+      controller.abort();
+      clearInterval(keepAlive);
+    });
+
+    if (chapterIds.length === 0) {
+      send({
+        kind: 'error',
+        code: 'no_attribution',
+        message: 'Run analysis first — there are no attributed sentences to review.',
+      });
+      clearInterval(keepAlive);
+      res.end();
+      return;
+    }
+
+    const heartbeat = makeThrottledHeartbeat(send, 2000);
+    const selection = selectAnalyzerForPhase({ phase: 'phase1', model: req.body?.model });
+
+    let totalOps = 0;
+    let reviewedChapters = 0;
+    try {
+      for (let i = 0; i < chapterIds.length; i += 1) {
+        if (closed) break;
+        const chapterId = chapterIds[i];
+        send({
+          kind: 'phase',
+          phaseId: 0,
+          progress: i / chapterIds.length,
+          label: `Reviewing script — chapter ${chapterId}`,
+          chapterId,
+        });
+
+        const prompt = buildScriptReviewChapterInbox(
+          manuscriptId,
+          chapterId,
+          byChapter.get(chapterId) ?? [],
+          roster,
+        );
+
+        /* ASSUMPTION (overflow deferral): if the prompt exceeds the stage-2 char
+           budget we emit chapter-failed with a clear message rather than
+           silently truncating. Chunk-with-overlap (the richer approach) is
+           deferred to a follow-up task. */
+        if (prompt.length > DEFAULT_STAGE2_CHUNK_CHAR_BUDGET) {
+          send({
+            kind: 'chapter-failed',
+            chapterId,
+            message:
+              `Chapter ${chapterId} is too large for a single review call (prompt ${prompt.length} chars ` +
+              `> ${DEFAULT_STAGE2_CHUNK_CHAR_BUDGET} char budget) — split it first.`,
+          });
+          continue;
+        }
+
+        try {
+          const result = await selection.analyzer.runScriptReviewChapter(
+            manuscriptId,
+            chapterId,
+            prompt,
+            {
+              signal: controller.signal,
+              onChunk: (info) =>
+                heartbeat(0, chapterId, {
+                  receivedBytes: info.receivedBytes,
+                  elapsedMs: info.elapsedMs,
+                  sinceLastChunkMs: info.sinceLastChunkMs,
+                }),
+              onThrottle: (waitMs, reason) =>
+                send({
+                  kind: 'throttle',
+                  phaseId: 0,
+                  chapterIndex: chapterId,
+                  model: selection.model,
+                  waitMs,
+                  reason,
+                }),
+            },
+          );
+          send({ kind: 'ops', chapterId, ops: result.ops });
+          totalOps += result.ops.length;
+          reviewedChapters += 1;
+        } catch (err) {
+          if (err instanceof AnalysisAbortedError) break;
+          if (err instanceof DailyQuotaExhaustedError) {
+            send({
+              kind: 'error',
+              code: 'quota_exhausted',
+              message:
+                'Daily analyzer quota exhausted. Already-reviewed chapters are streamed — re-run to finish.',
+              resetAt: err.resetAt instanceof Date ? err.resetAt.toISOString() : undefined,
+            });
+            clearInterval(keepAlive);
+            if (!closed) res.end();
+            return;
+          }
+          /* One bad chapter shouldn't kill the whole pass — report it and
+             carry on so the rest of the book still gets reviewed. */
+          send({ kind: 'chapter-failed', chapterId, message: (err as Error).message });
+        }
+      }
+    } finally {
+      clearInterval(keepAlive);
+    }
+
+    if (!closed) {
+      send({ kind: 'phase', phaseId: 0, progress: 1, label: 'Done' });
+      send({ kind: 'result', done: true, reviewedChapters, totalOps });
+      res.end();
+    }
+  },
+);

--- a/skills/audiobook-script-review.md
+++ b/skills/audiobook-script-review.md
@@ -1,0 +1,76 @@
+---
+name: audiobook-script-review
+description: fs-58 per-chapter script review pass. Reads a chapter's attributed sentences + cast and returns a list of edit ops (strip_tag, split, extract_dialogue, merge, fix_emotion). Does NOT re-attribute from scratch — only targeted surgical corrections.
+---
+
+# Audiobook script review
+
+You are given a single chapter's attributed sentences and the book's cast. Your
+job is to identify and return a list of targeted edit ops that would improve the
+script for text-to-speech performance. You must NOT re-write the whole chapter —
+only flag the specific sentences that need correction.
+
+## Input
+
+The input contains:
+1. The chapter's sentences as a JSON array, each with:
+   ```jsonc
+   { "sentenceId": 3, "characterId": "halloran", "text": ""Hard to starboard,"" }
+   ```
+2. The book's cast (id → name mapping) so you can reference character ids.
+
+## Op classes
+
+Return ONLY a JSON object `{ "ops": [...] }`. Each op has:
+
+- `id` — a unique positive integer (sequential, starting from 1)
+- `op` — one of the five classes below
+- `rationale` — one-line explanation (required for every op)
+- `confidence` — optional float 0–1
+
+### M1 — `strip_tag`
+
+Remove a speech-attribution tag that was incorrectly left in the text (e.g. `"he
+said"`, `"she whispered softly"`). Supply `anchor` (verbatim substring to locate
+the sentence) and `newText` (the sentence with the tag stripped).
+
+**M5 — Vocalization protection:** NEVER strip intentional non-verbal vocalizations
+such as "Ah!", "Haah…", "Mmm" — these are spoken content, not attribution tags.
+Only strip true speech-attribution tags ("he said", "she whispered").
+
+### M2 — `split`
+
+Split a sentence that spans two speakers. Supply:
+- `anchor` — copied verbatim from the sentence (enough to locate it uniquely)
+- `pieceCharacterIds` — array of character ids, one per piece after the split
+
+### M3 — `extract_dialogue`
+
+A narration sentence contains embedded dialogue that should become its own
+sentence attributed to the speaker. Supply:
+- `anchor` — start of the dialogue span (verbatim)
+- `anchorEnd` — end of the dialogue span (verbatim)
+- `pieceCharacterIds` — exactly 3 elements: [narrator_id, speaker_id, narrator_id]
+
+### M4 — `merge`
+
+Merge two or more adjacent same-speaker narrator sentences into one. Supply:
+- `mergeIds` — array of sentence ids to merge (must be adjacent, same speaker)
+
+### M5 — `fix_emotion`
+
+Override the delivery emotion only when the current emotion is clearly wrong for
+the sentence. Supply:
+- `anchor` — verbatim substring to locate the sentence
+- `emotion` — one of: `neutral` | `whisper` | `angry` | `excited` | `sad`
+
+## Rules
+
+- Only flag sentences that clearly need correction. When in doubt, omit.
+- Every `anchor` must be copied **verbatim** from the sentence text — do not
+  paraphrase or summarise.
+- Every `id` in `mergeIds` must be a real sentenceId from the input.
+- Every character id in `pieceCharacterIds` must be a real cast id from the
+  input.
+- Return `{ "ops": [] }` if the chapter needs no corrections.
+- Output JSON only. No prose, no markdown code fences.

--- a/skills/audiobook-script-review.md
+++ b/skills/audiobook-script-review.md
@@ -23,7 +23,8 @@ The input contains:
 
 Return ONLY a JSON object `{ "ops": [...] }`. Each op has:
 
-- `id` — a unique positive integer (sequential, starting from 1)
+- `id` — the `sentenceId` of the target sentence, copied exactly from the input
+  (NOT a new sequential counter starting from 1)
 - `op` — one of the five classes below
 - `rationale` — one-line explanation (required for every op)
 - `confidence` — optional float 0–1

--- a/skills/audiobook-script-review.md
+++ b/skills/audiobook-script-review.md
@@ -28,23 +28,23 @@ Return ONLY a JSON object `{ "ops": [...] }`. Each op has:
 - `rationale` — one-line explanation (required for every op)
 - `confidence` — optional float 0–1
 
-### M1 — `strip_tag`
+### `strip_tag`
 
 Remove a speech-attribution tag that was incorrectly left in the text (e.g. `"he
 said"`, `"she whispered softly"`). Supply `anchor` (verbatim substring to locate
 the sentence) and `newText` (the sentence with the tag stripped).
 
-**M5 — Vocalization protection:** NEVER strip intentional non-verbal vocalizations
+**Vocalization protection:** NEVER strip intentional non-verbal vocalizations
 such as "Ah!", "Haah…", "Mmm" — these are spoken content, not attribution tags.
 Only strip true speech-attribution tags ("he said", "she whispered").
 
-### M2 — `split`
+### `split`
 
 Split a sentence that spans two speakers. Supply:
 - `anchor` — copied verbatim from the sentence (enough to locate it uniquely)
 - `pieceCharacterIds` — array of character ids, one per piece after the split
 
-### M3 — `extract_dialogue`
+### `extract_dialogue`
 
 A narration sentence contains embedded dialogue that should become its own
 sentence attributed to the speaker. Supply:
@@ -52,12 +52,12 @@ sentence attributed to the speaker. Supply:
 - `anchorEnd` — end of the dialogue span (verbatim)
 - `pieceCharacterIds` — exactly 3 elements: [narrator_id, speaker_id, narrator_id]
 
-### M4 — `merge`
+### `merge`
 
 Merge two or more adjacent same-speaker narrator sentences into one. Supply:
 - `mergeIds` — array of sentence ids to merge (must be adjacent, same speaker)
 
-### M5 — `fix_emotion`
+### `fix_emotion`
 
 Override the delivery emotion only when the current emotion is clearly wrong for
 the sentence. Supply:

--- a/skills/audiobook-script-review.test.ts
+++ b/skills/audiobook-script-review.test.ts
@@ -13,6 +13,17 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SKILL_PATH = resolve(__dirname, 'audiobook-script-review.md');
 
+describe('skills/audiobook-script-review.md — op.id contract', () => {
+  it('states that op id is the sentenceId of the target sentence, copied exactly from the input', () => {
+    const text = readFileSync(SKILL_PATH, 'utf8');
+    /* The id field must NOT describe a sequential counter. It must be
+       unambiguous that the value comes from the input sentenceId.
+       The backtick-wrapped form matches the markdown source in the file. */
+    expect(text).toContain('`sentenceId` of the target sentence');
+    expect(text).toContain('copied exactly from the input');
+  });
+});
+
 describe('skills/audiobook-script-review.md — M5 vocalization-protection clause', () => {
   it('contains the verbatim M5 vocalization-protection clause', () => {
     const text = readFileSync(SKILL_PATH, 'utf8');

--- a/skills/audiobook-script-review.test.ts
+++ b/skills/audiobook-script-review.test.ts
@@ -1,0 +1,42 @@
+/* Snapshot guard for the M5 vocalization-protection clause in the script-review
+   skill prompt. The clause is load-bearing: the LLM must never strip
+   intentional non-verbal vocalizations (e.g. "Ah!", "Haah…", "Mmm"). If the
+   clause is accidentally edited or removed, this test fails immediately —
+   behavioural enforcement lives in manual eval, but this guard ensures the
+   text at least reaches the model unchanged. */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SKILL_PATH = resolve(__dirname, 'audiobook-script-review.md');
+
+describe('skills/audiobook-script-review.md — M5 vocalization-protection clause', () => {
+  it('contains the verbatim M5 vocalization-protection clause', () => {
+    const text = readFileSync(SKILL_PATH, 'utf8');
+    /* Stable substrings from the M5 clause — must survive any future edits
+       to surrounding prose. Checked in three parts because the clause is
+       line-wrapped in the source file. The ellipsis must be the real Unicode
+       char U+2026 (…), not three ASCII dots (...). */
+    expect(text).toContain('NEVER strip intentional non-verbal vocalizations');
+    expect(text).toContain('"Ah!", "Haah…", "Mmm"');
+    expect(text).toContain(
+      'Only strip true speech-attribution tags ("he said", "she whispered").',
+    );
+  });
+
+  it('contains the real Unicode ellipsis U+2026 (not ASCII dots)', () => {
+    const text = readFileSync(SKILL_PATH, 'utf8');
+    expect(text).toContain('…'); // …
+  });
+
+  it('is UTF-8 without BOM', () => {
+    const buf = readFileSync(SKILL_PATH);
+    // BOM would be EF BB BF at the start
+    expect(buf[0]).not.toBe(0xef);
+    // No mojibake sequence for … (C3 A2 E2 80 A6 mangled as latin1)
+    expect(buf.includes(Buffer.from([0xc3, 0xa2]))).toBe(false);
+  });
+});

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -728,6 +728,8 @@ export function Layout() {
             sentences: res.manuscriptEdits?.sentences ?? null,
             wordCount: res.manuscript?.wordCount ?? null,
             format: res.manuscript?.format ?? null,
+            // fs-58 — rehydrate the merge tombstone so re-analysis can't resurrect merged ids.
+            mergedAwayKeys: res.manuscriptEdits?.mergedAwayKeys,
           }),
         );
         /* Always overwrite the cast slice from disk — including the empty

--- a/src/components/script-review-diff.test.tsx
+++ b/src/components/script-review-diff.test.tsx
@@ -153,4 +153,58 @@ describe('fs-58 — ScriptReviewDiff', () => {
     fireEvent.click(screen.getByTestId('close-button'));
     expect(store.getState().scriptReview.byBook['book-A']).toBeUndefined();
   });
+
+  it('renders the unappliable notice when bucket.unappliable is non-empty', () => {
+    const store = configureStore({
+      reducer: {
+        ui: uiSlice.reducer,
+        manuscript: manuscriptSlice.reducer,
+        scriptReview: scriptReviewSlice.reducer,
+        changeLog: changeLogSlice.reducer,
+      },
+      preloadedState: {
+        ui: {
+          ...uiSlice.getInitialState(),
+          stage: {
+            kind: 'ready',
+            bookId: 'book-A',
+            view: 'manuscript',
+            currentChapterId: 1,
+            openProfileId: null,
+          } as never,
+        },
+        manuscript: { ...manuscriptSlice.getInitialState() },
+      },
+    });
+    store.dispatch(
+      scriptReviewActions.setReview({
+        bookId: 'book-A',
+        ops: [{ id: 1, op: 'fix_emotion', emotion: 'angry', rationale: 'r', chapterId: 1 }],
+        unappliable: [
+          {
+            op: { id: 99, op: 'strip_tag', anchor: 'x', newText: 'x', rationale: 'r', chapterId: 1 },
+            reason: 'anchor not found',
+          },
+        ],
+      }),
+    );
+    render(
+      <Provider store={store}>
+        <ScriptReviewDiff bookId="book-A" />
+      </Provider>,
+    );
+    const notice = screen.getByTestId('unappliable-notice');
+    expect(notice).toBeTruthy();
+    expect(notice.textContent).toContain("1 suggestion couldn't be applied");
+  });
+
+  it('does not render the unappliable notice when bucket.unappliable is empty', () => {
+    const store = makeStore(); // makeStore seeds unappliable: []
+    render(
+      <Provider store={store}>
+        <ScriptReviewDiff bookId="book-A" />
+      </Provider>,
+    );
+    expect(screen.queryByTestId('unappliable-notice')).toBeNull();
+  });
 });

--- a/src/components/script-review-diff.test.tsx
+++ b/src/components/script-review-diff.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { uiSlice } from '../store/ui-slice';
+import { manuscriptSlice } from '../store/manuscript-slice';
+import { scriptReviewSlice, scriptReviewActions, opKey } from '../store/script-review-slice';
+import { changeLogSlice } from '../store/change-log-slice';
+import { ScriptReviewDiff } from './script-review-diff';
+
+function makeStore() {
+  const store = configureStore({
+    reducer: {
+      ui: uiSlice.reducer,
+      manuscript: manuscriptSlice.reducer,
+      scriptReview: scriptReviewSlice.reducer,
+      changeLog: changeLogSlice.reducer,
+    },
+    preloadedState: {
+      ui: {
+        ...uiSlice.getInitialState(),
+        stage: {
+          kind: 'ready',
+          bookId: 'book-A',
+          view: 'manuscript',
+          currentChapterId: 1,
+          openProfileId: null,
+        } as never,
+      },
+      manuscript: {
+        ...manuscriptSlice.getInitialState(),
+        sentences: [
+          { id: 1, chapterId: 1, text: '<em>Hello world</em>', characterId: 'narr' },
+          { id: 2, chapterId: 1, text: 'She laughed.', characterId: 'narr' },
+        ] as never,
+      },
+    },
+  });
+
+  // Seed the review bucket with two ops: one strip_tag and one fix_emotion
+  store.dispatch(
+    scriptReviewActions.setReview({
+      bookId: 'book-A',
+      ops: [
+        {
+          id: 1,
+          op: 'strip_tag',
+          newText: 'Hello world',
+          rationale: 'remove tag',
+          chapterId: 1,
+        },
+        {
+          id: 2,
+          op: 'fix_emotion',
+          emotion: 'excited',
+          rationale: 'energy up',
+          chapterId: 1,
+        },
+      ],
+      unappliable: [],
+    }),
+  );
+
+  return store;
+}
+
+describe('fs-58 — ScriptReviewDiff', () => {
+  it('returns null when there is no active review', () => {
+    const store = configureStore({
+      reducer: {
+        ui: uiSlice.reducer,
+        manuscript: manuscriptSlice.reducer,
+        scriptReview: scriptReviewSlice.reducer,
+        changeLog: changeLogSlice.reducer,
+      },
+    });
+    const { container } = render(
+      <Provider store={store}>
+        <ScriptReviewDiff bookId="book-A" />
+      </Provider>,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('applies selected ops and skips deselected ops on Apply', () => {
+    const store = makeStore();
+    render(
+      <Provider store={store}>
+        <ScriptReviewDiff bookId="book-A" />
+      </Provider>,
+    );
+
+    // Verify the modal is rendered with both ops shown
+    expect(screen.getByText('Script review suggestions')).toBeTruthy();
+
+    // Toggle op 2 (fix_emotion) OFF by clicking its checkbox
+    const op2key = opKey(1, 2, 'fix_emotion');
+    const checkbox = screen.getByTestId(`op-toggle-${op2key}`);
+    fireEvent.click(checkbox);
+
+    // Verify op2 is now deselected
+    expect((checkbox as HTMLInputElement).checked).toBe(false);
+
+    // Click Apply
+    fireEvent.click(screen.getByTestId('apply-button'));
+
+    // clearReview should have fired → bucket is gone
+    expect(store.getState().scriptReview.byBook['book-A']).toBeUndefined();
+
+    // strip_tag (op 1) WAS selected → sentence id=1 text updated
+    const sentences = store.getState().manuscript.sentences;
+    const sent1 = sentences.find((s) => s.chapterId === 1 && s.id === 1);
+    expect(sent1?.text).toBe('Hello world');
+
+    // fix_emotion (op 2) was DESELECTED → sentence id=2 emotion NOT set to excited
+    const sent2 = sentences.find((s) => s.chapterId === 1 && s.id === 2);
+    expect(sent2?.emotion).not.toBe('excited');
+
+    // bumpBoundaryMove should have fired (op 1 applied → boundary_move event)
+    const events = store.getState().changeLog.events;
+    const boundaryEvent = events.find((e) => e.type === 'boundary_move');
+    expect(boundaryEvent).toBeTruthy();
+    expect(events[0]?.type).toBe('boundary_move');
+  });
+
+  it('dismisses all without applying on Dismiss all', () => {
+    const store = makeStore();
+    render(
+      <Provider store={store}>
+        <ScriptReviewDiff bookId="book-A" />
+      </Provider>,
+    );
+
+    fireEvent.click(screen.getByTestId('dismiss-button'));
+
+    // clearReview fired → no bucket
+    expect(store.getState().scriptReview.byBook['book-A']).toBeUndefined();
+
+    // No sentence changes applied
+    const sentences = store.getState().manuscript.sentences;
+    const sent1 = sentences.find((s) => s.chapterId === 1 && s.id === 1);
+    expect(sent1?.text).toBe('<em>Hello world</em>');
+  });
+
+  it('close button dispatches clearReview', () => {
+    const store = makeStore();
+    render(
+      <Provider store={store}>
+        <ScriptReviewDiff bookId="book-A" />
+      </Provider>,
+    );
+
+    fireEvent.click(screen.getByTestId('close-button'));
+    expect(store.getState().scriptReview.byBook['book-A']).toBeUndefined();
+  });
+});

--- a/src/components/script-review-diff.tsx
+++ b/src/components/script-review-diff.tsx
@@ -28,13 +28,19 @@ function classLabel(op: string): string {
   return CLASS_LABELS[op] ?? op;
 }
 
-/* Format the before → after preview for a single op row. */
-function OpPreview({ op }: { op: ReviewOpWithChapter }) {
+/* Format the before → after preview for a single op row. `before` is the
+   live sentence text (the original) when available, so strip_tag shows the
+   tagged source struck-through next to the cleaned result. */
+function OpPreview({ op, before }: { op: ReviewOpWithChapter; before?: string }) {
   if (op.op === 'strip_tag' && op.newText !== undefined) {
     return (
       <span className="text-xs text-ink/70 min-w-0 truncate">
-        <span className="line-through text-ink/45">{op.newText}</span>
-        {' → '}
+        {before !== undefined && before !== op.newText && (
+          <>
+            <span className="line-through text-ink/45">{before}</span>
+            {' → '}
+          </>
+        )}
         <span className="text-ink font-medium">{op.newText}</span>
       </span>
     );
@@ -181,6 +187,9 @@ export function ScriptReviewDiff({ bookId }: { bookId: string }) {
                   {classOps.map((op) => {
                     const key = opKey(op.chapterId, op.id, op.op);
                     const isSelected = !!selected[key];
+                    const liveText = sentences.find(
+                      (s) => s.chapterId === op.chapterId && s.id === op.id,
+                    )?.text;
                     return (
                       <div
                         key={key}
@@ -198,7 +207,7 @@ export function ScriptReviewDiff({ bookId }: { bookId: string }) {
                           />
                         </label>
                         <div className="flex-1 min-w-0 space-y-1">
-                          <OpPreview op={op} />
+                          <OpPreview op={op} before={liveText} />
                           <p className="text-xs text-ink/55 leading-relaxed">{op.rationale}</p>
                           {op.confidence !== undefined && (
                             <p className="text-[10px] text-ink/40 tabular-nums">

--- a/src/components/script-review-diff.tsx
+++ b/src/components/script-review-diff.tsx
@@ -205,6 +205,7 @@ export function ScriptReviewDiff({ bookId }: { bookId: string }) {
                             }
                             className="accent-ink w-4 h-4"
                           />
+                          <span className="sr-only">Toggle this {op.op} suggestion</span>
                         </label>
                         <div className="flex-1 min-w-0 space-y-1">
                           <OpPreview op={op} before={liveText} />

--- a/src/components/script-review-diff.tsx
+++ b/src/components/script-review-diff.tsx
@@ -77,7 +77,7 @@ export function ScriptReviewDiff({ bookId }: { bookId: string }) {
 
   if (!bucket) return null;
 
-  const { ops, selected } = bucket;
+  const { ops, selected, unappliable } = bucket;
 
   /* Group ops by their class. Preserve insertion order so the class list is
      deterministic. */
@@ -156,6 +156,17 @@ export function ScriptReviewDiff({ bookId }: { bookId: string }) {
 
           {/* Body */}
           <div className="p-6 space-y-6 overflow-y-auto scrollbar-thin">
+            {unappliable.length > 0 && (
+              <div
+                data-testid="unappliable-notice"
+                className="rounded-2xl border border-ink/10 bg-canvas/50 px-4 py-3 text-xs text-ink/60"
+              >
+                <span className="font-semibold text-ink/70">
+                  {unappliable.length} suggestion{unappliable.length === 1 ? '' : 's'} couldn&apos;t be applied
+                </span>
+                {' '}(stale text or invalid)
+              </div>
+            )}
             {classes.map((cls) => {
               const classOps = byClass.get(cls) ?? [];
               const allClassSelected = classOps.every(

--- a/src/components/script-review-diff.tsx
+++ b/src/components/script-review-diff.tsx
@@ -1,0 +1,242 @@
+/* fs-58 — ScriptReviewDiff modal.
+   Shows the LLM script-review suggestions bucketed by op class (strip_tag,
+   fix_emotion, split, etc.), lets the user select/deselect individual ops or
+   whole classes, then applies the selected set via planApply +
+   dispatchAcceptedOps. Mirrors drift-report.tsx overlay pattern. */
+
+import { useAppDispatch, useAppSelector } from '../store';
+import {
+  scriptReviewActions,
+  selectActiveReview,
+  opKey,
+  type ReviewOpWithChapter,
+} from '../store/script-review-slice';
+import { planApply, dispatchAcceptedOps } from '../lib/script-review-apply';
+import { changeLogActions } from '../store/change-log-slice';
+import { IconClose } from '../lib/icons';
+
+/* Human-readable class labels. */
+const CLASS_LABELS: Record<string, string> = {
+  strip_tag: 'Strip tag',
+  split: 'Split sentence',
+  extract_dialogue: 'Extract dialogue',
+  merge: 'Merge sentences',
+  fix_emotion: 'Fix emotion',
+};
+
+function classLabel(op: string): string {
+  return CLASS_LABELS[op] ?? op;
+}
+
+/* Format the before → after preview for a single op row. */
+function OpPreview({ op }: { op: ReviewOpWithChapter }) {
+  if (op.op === 'strip_tag' && op.newText !== undefined) {
+    return (
+      <span className="text-xs text-ink/70 min-w-0 truncate">
+        <span className="line-through text-ink/45">{op.newText}</span>
+        {' → '}
+        <span className="text-ink font-medium">{op.newText}</span>
+      </span>
+    );
+  }
+  if (op.op === 'fix_emotion' && op.emotion) {
+    return (
+      <span className="text-xs text-ink/70 min-w-0 truncate">
+        emotion → <span className="font-semibold text-ink">{op.emotion}</span>
+      </span>
+    );
+  }
+  if (op.op === 'merge' && op.mergeIds) {
+    return (
+      <span className="text-xs text-ink/70 min-w-0 truncate">
+        merge sentences {op.mergeIds.join(', ')}
+      </span>
+    );
+  }
+  if ((op.op === 'split' || op.op === 'extract_dialogue') && op.anchor) {
+    return (
+      <span className="text-xs text-ink/70 min-w-0 truncate">
+        split at: <span className="font-medium text-ink">{op.anchor}</span>
+      </span>
+    );
+  }
+  return null;
+}
+
+export function ScriptReviewDiff({ bookId }: { bookId: string }) {
+  const dispatch = useAppDispatch();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const bucket = useAppSelector((s) => selectActiveReview(s as any, bookId));
+  const sentences = useAppSelector((s) => s.manuscript.sentences);
+
+  if (!bucket) return null;
+
+  const { ops, selected } = bucket;
+
+  /* Group ops by their class. Preserve insertion order so the class list is
+     deterministic. */
+  const classes = [...new Set(ops.map((o) => o.op))];
+  const byClass = new Map<string, ReviewOpWithChapter[]>();
+  for (const cls of classes) {
+    byClass.set(cls, ops.filter((o) => o.op === cls));
+  }
+
+  const selectedCount = ops.filter((o) => selected[opKey(o.chapterId, o.id, o.op)]).length;
+
+  function handleClose() {
+    dispatch(scriptReviewActions.clearReview({ bookId }));
+  }
+
+  function handleDismiss() {
+    dispatch(scriptReviewActions.clearReview({ bookId }));
+  }
+
+  function handleApply() {
+    // Gather only the ops the user selected
+    const selectedOps = ops.filter((o) => selected[opKey(o.chapterId, o.id, o.op)]);
+
+    // Build the live snapshot for planApply
+    const live = sentences.map((s) => ({
+      id: s.id,
+      chapterId: s.chapterId,
+      text: s.text,
+      characterId: s.characterId,
+    }));
+
+    const { appliable } = planApply(selectedOps, live);
+
+    dispatchAcceptedOps(dispatch, appliable, live, {
+      onBoundaryMove: (chapterId) =>
+        dispatch(changeLogActions.bumpBoundaryMove({ chapterId, count: 1 })),
+    });
+
+    dispatch(scriptReviewActions.clearReview({ bookId }));
+  }
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        onClick={handleClose}
+        className="fixed inset-0 bg-ink/40 z-50"
+        aria-hidden="true"
+      />
+
+      {/* Dialog */}
+      <div className="fixed inset-0 z-50 grid place-items-center p-4 sm:p-6 pointer-events-none">
+        <div className="bg-white rounded-3xl shadow-float w-full max-w-2xl pointer-events-auto overflow-hidden max-h-[90vh] flex flex-col">
+          {/* Header */}
+          <div className="px-6 py-4 border-b border-ink/10 flex items-center gap-3">
+            <div className="flex-1 min-w-0">
+              <p className="text-[10px] uppercase tracking-widest text-ink/50 font-semibold">
+                LLM script review
+              </p>
+              <h3 className="text-base font-bold text-ink leading-tight">
+                Script review suggestions
+                <span className="ml-2 text-sm font-normal text-ink/50">
+                  ({ops.length} suggestion{ops.length === 1 ? '' : 's'})
+                </span>
+              </h3>
+            </div>
+            <button
+              data-testid="close-button"
+              onClick={handleClose}
+              className="p-2 rounded-full hover:bg-ink/5 text-ink/60 min-h-[44px] sm:min-h-0 min-w-[44px] sm:min-w-0 flex items-center justify-center"
+              aria-label="Close"
+            >
+              <IconClose className="w-4 h-4" />
+            </button>
+          </div>
+
+          {/* Body */}
+          <div className="p-6 space-y-6 overflow-y-auto scrollbar-thin">
+            {classes.map((cls) => {
+              const classOps = byClass.get(cls) ?? [];
+              const allClassSelected = classOps.every(
+                (o) => selected[opKey(o.chapterId, o.id, o.op)],
+              );
+
+              return (
+                <section key={cls} className="space-y-2">
+                  {/* Class header */}
+                  <div className="flex items-center gap-3 pb-1 border-b border-ink/10">
+                    <h4 className="text-xs font-bold uppercase tracking-wider text-ink/60 flex-1">
+                      {classLabel(cls)}
+                    </h4>
+                    <label className="flex items-center gap-1.5 text-xs text-ink/55 cursor-pointer select-none min-h-[44px] sm:min-h-0">
+                      <input
+                        type="checkbox"
+                        data-testid={`class-toggle-${cls}`}
+                        checked={allClassSelected}
+                        onChange={() =>
+                          dispatch(scriptReviewActions.toggleClass({ bookId, op: cls as ReviewOpWithChapter['op'] }))
+                        }
+                        className="accent-ink w-4 h-4"
+                      />
+                      Select all
+                    </label>
+                  </div>
+
+                  {/* Op rows */}
+                  {classOps.map((op) => {
+                    const key = opKey(op.chapterId, op.id, op.op);
+                    const isSelected = !!selected[key];
+                    return (
+                      <div
+                        key={key}
+                        className="flex items-start gap-3 p-3 rounded-2xl border border-ink/10 bg-canvas/50"
+                      >
+                        <label className="flex items-center min-h-[44px] sm:min-h-0 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            data-testid={`op-toggle-${key}`}
+                            checked={isSelected}
+                            onChange={() =>
+                              dispatch(scriptReviewActions.toggleOp({ bookId, key }))
+                            }
+                            className="accent-ink w-4 h-4"
+                          />
+                        </label>
+                        <div className="flex-1 min-w-0 space-y-1">
+                          <OpPreview op={op} />
+                          <p className="text-xs text-ink/55 leading-relaxed">{op.rationale}</p>
+                          {op.confidence !== undefined && (
+                            <p className="text-[10px] text-ink/40 tabular-nums">
+                              Confidence: {Math.round(op.confidence * 100)}%
+                            </p>
+                          )}
+                        </div>
+                        <span className="text-[10px] text-ink/35 tabular-nums shrink-0 mt-0.5">
+                          ch{op.chapterId} · #{op.id}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </section>
+              );
+            })}
+          </div>
+
+          {/* Footer */}
+          <div className="px-6 py-3 border-t border-ink/10 flex items-center gap-3 flex-wrap">
+            <button
+              data-testid="apply-button"
+              onClick={handleApply}
+              disabled={selectedCount === 0}
+              className="shrink-0 inline-flex items-center gap-2 px-5 min-h-[44px] sm:min-h-0 py-2 rounded-full bg-ink text-canvas text-sm font-semibold hover:bg-ink/90 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              Apply {selectedCount} selected
+            </button>
+            <button
+              data-testid="dismiss-button"
+              onClick={handleDismiss}
+              className="text-sm font-medium text-ink/50 hover:text-ink/80 min-h-[44px] sm:min-h-0"
+            >
+              Dismiss all
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1923,6 +1923,36 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/books/{bookId}/script-review": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * LLM script-review pass (fs-58)
+         * @description Runs an LLM pass over the book's already-attributed sentences and
+         *     streams per-chapter editing ops over Server-Sent Events. The ops
+         *     (strip_tag, split, extract_dialogue, merge, fix_emotion) carry anchors
+         *     and rationale; the client applies them through existing Redux
+         *     manual-edit reducers. The route never writes a file. When an optional
+         *     `chapterId` is provided, only that chapter is reviewed. SSE event
+         *     kinds: `phase`, `throttle`, `heartbeat`, `ops`
+         *     (`{ chapterId, ops: [{ id, op, anchor?, newText?, rationale, ... }] }`),
+         *     `chapter-failed`,
+         *     `error` (`code: no_attribution | no_such_chapter | quota_exhausted`),
+         *     and a terminal `result` (`{ done, reviewedChapters, totalOps }`).
+         */
+        post: operations["scriptReview"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/books/{bookId}/cast/{characterId}/emotion-variant/{emotion}": {
         parameters: {
             query?: never;
@@ -6923,6 +6953,51 @@ export interface operations {
         };
         responses: {
             /** @description SSE stream of annotation/phase/result events. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/event-stream": Record<string, never>;
+                };
+            };
+            /** @description Book not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Book has not been analysed yet */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    scriptReview: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                bookId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /** @description Optional chapter id — when present, limits the pass to that chapter only. */
+                    chapterId?: number;
+                    /** @description Optional analyzer model id override (matches the analysis endpoints). */
+                    model?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description SSE stream of ops/phase/result events. */
             200: {
                 headers: {
                     [name: string]: unknown;

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -9,6 +9,7 @@ import {
   mockSetShelfStatus,
   _resetMockListenStats,
   readE2eUpdateOverride,
+  api,
 } from './api';
 
 describe('mockGetSetupReadiness', () => {
@@ -110,6 +111,22 @@ describe('mock listen-stats client', () => {
     await mockSetShelfStatus('h', { hidden: true });
     expect(await mockGetContinueListening()).toEqual([]);
     delete (globalThis as any).__SEED_CONTINUE__;
+  });
+});
+
+describe('api.reviewScript', () => {
+  it('parses the SSE stream and surfaces ops', async () => {
+    const chunks = [
+      'data: {"kind":"ops","chapterId":1,"ops":[{"id":1,"op":"strip_tag","newText":"x","rationale":"tag"}]}\n\n',
+      'data: {"kind":"result","reviewedChapters":1,"totalOps":1}\n\n',
+    ].map((s) => new TextEncoder().encode(s));
+    let i = 0;
+    const body = { getReader: () => ({ read: async () => (i < chunks.length ? { done: false, value: chunks[i++] } : { done: true, value: undefined }) }) };
+    global.fetch = (async () => ({ ok: true, status: 200, body })) as never;
+    const seen: unknown[] = [];
+    const res = await api.reviewScript('b1', { onOps: (e) => seen.push(e) });
+    expect(seen).toHaveLength(1);
+    expect(res.totalOps).toBe(1);
   });
 });
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2855,9 +2855,10 @@ async function realReviewScript(
 
 async function mockReviewScript(
   _bookId: string,
-  { onOps }: ReviewScriptOpts = {},
+  { onOps, onPhase }: ReviewScriptOpts = {},
 ): Promise<ReviewScriptResult> {
   await wait(60);
+  onPhase?.({ progress: 0.5, label: 'Reviewing…', chapterId: 1 });
   onOps?.({
     chapterId: 1,
     ops: [{ id: 1, op: 'strip_tag', newText: 'x', rationale: 'tag' }],

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2744,6 +2744,127 @@ async function mockDetectEmotions(
   return { annotatedChapters: 1, totalAnnotations: 1 };
 }
 
+/* fs-58 — LLM script-review SSE stream. Mirrors realDetectEmotions' SSE
+   reader. Emits per-chapter op batches; the caller applies them via
+   script-review-apply.ts. */
+export interface ReviewScriptOpts {
+  chapterId?: number;
+  model?: string;
+  signal?: AbortSignal;
+  onPhase?: (e: { progress: number; label?: string; chapterId?: number }) => void;
+  onThrottle?: (e: { chapterId: number; waitMs: number; reason: string }) => void;
+  onOps?: (e: { chapterId: number; ops: import('./script-review-apply').ReviewOp[] }) => void;
+}
+export interface ReviewScriptResult {
+  reviewedChapters: number;
+  totalOps: number;
+}
+export class ReviewScriptError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+  ) {
+    super(message);
+    this.name = 'ReviewScriptError';
+  }
+}
+
+async function realReviewScript(
+  bookId: string,
+  { chapterId, model, signal, onPhase, onThrottle, onOps }: ReviewScriptOpts = {},
+): Promise<ReviewScriptResult> {
+  const body: Record<string, unknown> = {};
+  if (chapterId !== undefined) body.chapterId = chapterId;
+  if (model !== undefined) body.model = model;
+  const res = await fetch(`/api/books/${encodeURIComponent(bookId)}/script-review`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal,
+  });
+  if (res.status === 404) throw new ReviewScriptError('Book not found.', 'not_found');
+  if (!res.ok || !res.body) throw new Error(`Script-review stream failed (${res.status}).`);
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = '';
+  let result: ReviewScriptResult | null = null;
+
+  const handle = (p: Record<string, unknown>) => {
+    switch (p.kind) {
+      case 'phase':
+        if (typeof p.progress === 'number') {
+          onPhase?.({
+            progress: p.progress,
+            label: typeof p.label === 'string' ? p.label : undefined,
+            chapterId: typeof p.chapterId === 'number' ? p.chapterId : undefined,
+          });
+        }
+        break;
+      case 'throttle':
+        if (typeof p.chapterIndex === 'number' && typeof p.waitMs === 'number') {
+          onThrottle?.({
+            chapterId: p.chapterIndex,
+            waitMs: p.waitMs,
+            reason: String(p.reason ?? ''),
+          });
+        }
+        break;
+      case 'ops':
+        if (typeof p.chapterId === 'number' && Array.isArray(p.ops)) {
+          onOps?.({
+            chapterId: p.chapterId,
+            ops: p.ops as import('./script-review-apply').ReviewOp[],
+          });
+        }
+        break;
+      case 'result':
+        result = {
+          reviewedChapters: typeof p.reviewedChapters === 'number' ? p.reviewedChapters : 0,
+          totalOps: typeof p.totalOps === 'number' ? p.totalOps : 0,
+        };
+        break;
+      case 'error':
+        throw new ReviewScriptError(
+          typeof p.message === 'string' ? p.message : 'Script review failed.',
+          typeof p.code === 'string' ? p.code : 'unknown',
+        );
+    }
+  };
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    let sep;
+    while ((sep = buf.indexOf('\n\n')) >= 0) {
+      const raw = buf.slice(0, sep);
+      buf = buf.slice(sep + 2);
+      const dataLines = raw
+        .split('\n')
+        .filter((l) => l.startsWith('data: '))
+        .map((l) => l.slice(6));
+      if (!dataLines.length) continue;
+      handle(JSON.parse(dataLines.join('\n')) as Record<string, unknown>);
+    }
+  }
+
+  if (!result) throw new Error('Script-review stream ended without a result event.');
+  return result;
+}
+
+async function mockReviewScript(
+  _bookId: string,
+  { onOps }: ReviewScriptOpts = {},
+): Promise<ReviewScriptResult> {
+  await wait(60);
+  onOps?.({
+    chapterId: 1,
+    ops: [{ id: 1, op: 'strip_tag', newText: 'x', rationale: 'tag' }],
+  });
+  return { reviewedChapters: 1, totalOps: 1 };
+}
+
 /* fs-34 — drop a designed Qwen emotion variant (route deletes the slot + .pt). */
 async function realRemoveQwenVariant(
   bookId: string,
@@ -6801,6 +6922,7 @@ const real = {
   fetchDesignedPersona: realFetchDesignedPersona,
   designQwenVoice: realDesignQwenVoice,
   detectEmotions: realDetectEmotions,
+  reviewScript: realReviewScript,
   removeQwenVariant: realRemoveQwenVariant,
   promoteQwenVoice: realPromoteQwenVoice,
   discardQwenPreview: realDiscardQwenPreview,
@@ -7062,6 +7184,7 @@ const mock = {
   fetchDesignedPersona: mockFetchDesignedPersona,
   designQwenVoice: mockDesignQwenVoice,
   detectEmotions: mockDetectEmotions,
+  reviewScript: mockReviewScript,
   removeQwenVariant: mockRemoveQwenVariant,
   promoteQwenVoice: mockPromoteQwenVoice,
   discardQwenPreview: mockDiscardQwenPreview,

--- a/src/lib/script-review-apply.test.ts
+++ b/src/lib/script-review-apply.test.ts
@@ -1,4 +1,8 @@
-import { resolveAnchorOffset, planApply } from './script-review-apply';
+import { configureStore } from '@reduxjs/toolkit';
+import { vi } from 'vitest';
+import { resolveAnchorOffset, planApply, dispatchAcceptedOps, type ReviewOp } from './script-review-apply';
+import { manuscriptSlice } from '../store/manuscript-slice';
+import { start } from '../store/manuscript-slice.test-helpers';
 
 describe('resolveAnchorOffset', () => {
   it('returns the EXACT original offset across quote/dash normalization', () => {
@@ -86,5 +90,119 @@ describe('planApply', () => {
     }], live);
     expect(r.appliable).toHaveLength(0);
     expect(r.unappliable[0].reason).toMatch(/anchorEnd|extract|anchor/i);
+  });
+});
+
+describe('dispatchAcceptedOps', () => {
+  // Seed sentences:
+  //   ch=3, id=1 — strip_tag target: text has a tag [laughing]
+  //   ch=3, id=2 — fix_emotion target
+  //   ch=3, id=3 — split target: "Hello world. Goodbye world."
+  //   ch=3, id=4 — extract_dialogue target: 'He said. "Come on," she urged. He left.'
+  //   ch=3, id=5 — merge survivor
+  //   ch=3, id=6 — merge secondary (adjacent, same characterId)
+  const sentences = [
+    { id: 1, chapterId: 3, characterId: 'narrator', text: '[laughing] The hall was dark.' },
+    { id: 2, chapterId: 3, characterId: 'narrator', text: 'Dust hung in the air.' },
+    { id: 3, chapterId: 3, characterId: 'narrator', text: 'Hello world. Goodbye world.' },
+    { id: 4, chapterId: 3, characterId: 'narrator', text: 'He said. "Come on," she urged. He left.' },
+    { id: 5, chapterId: 3, characterId: 'narrator', text: 'First piece.' },
+    { id: 6, chapterId: 3, characterId: 'narrator', text: 'Second piece.' },
+  ];
+
+  // The live array dispatchAcceptedOps will use for anchor resolution
+  const liveForDispatch = sentences.map((s) => ({ ...s }));
+
+  const ops: ReviewOp[] = [
+    // strip_tag: replace text of sentence 1
+    { id: 1, op: 'strip_tag', newText: 'The hall was dark.', rationale: 'remove tag' },
+    // fix_emotion: set emotion on sentence 2
+    { id: 2, op: 'fix_emotion', emotion: 'sad', rationale: 'detected sadness' },
+    // split: anchor = "Hello world." — ends at offset 12; pieces narrator+narrator
+    { id: 3, op: 'split', anchor: 'Hello world.', pieceCharacterIds: ['narrator', 'narrator'], rationale: 'over-long sentence' },
+    // extract_dialogue: anchor = '"Come on,"' (start), anchorEnd = 'she urged.' (end)
+    // text = 'He said. "Come on," she urged. He left.'
+    // anchor ends at offset 19 (' she urged. He left.' remains)
+    // anchorEnd ends at offset 30 (' He left.' remains as third piece)
+    { id: 4, op: 'extract_dialogue', anchor: '"Come on,"', anchorEnd: 'she urged.', pieceCharacterIds: ['narrator', 'maerin', 'narrator'], rationale: 'dialogue extraction' },
+    // merge: join sentences 5 and 6
+    { id: 5, op: 'merge', mergeIds: [5, 6], rationale: 'under-split' },
+  ];
+
+  it('applies all 5 op classes and fires onBoundaryMove once per op', () => {
+    const store = configureStore({
+      reducer: { manuscript: manuscriptSlice.reducer },
+      preloadedState: { manuscript: start(sentences) },
+    });
+
+    const spy = vi.fn();
+    dispatchAcceptedOps(store.dispatch, ops, liveForDispatch, { onBoundaryMove: spy });
+
+    const state = store.getState().manuscript;
+
+    // strip_tag: sentence 1 text replaced
+    const s1 = state.sentences.find((x) => x.chapterId === 3 && x.id === 1);
+    expect(s1?.text).toBe('The hall was dark.');
+
+    // fix_emotion: sentence 2 emotion set to 'sad'
+    const s2 = state.sentences.find((x) => x.chapterId === 3 && x.id === 2);
+    expect(s2?.emotion).toBe('sad');
+
+    // split: sentence 3 becomes 2 pieces; first keeps id=3, second gets maxId+1=7
+    const s3first = state.sentences.find((x) => x.chapterId === 3 && x.id === 3);
+    const s3second = state.sentences.find((x) => x.chapterId === 3 && x.id === 7);
+    expect(s3first?.text).toBe('Hello world.');
+    expect(s3second?.text).toBe(' Goodbye world.');
+
+    // extract_dialogue: sentence 4 becomes 3 pieces; ids 4, 8, 9 (max before extract = 7 post-split)
+    // After the split op, maxId = 7. extract produces 3 pieces: id=4, id=8, id=9
+    // anchor '"Come on,"' ends at offset 19; anchorEnd 'she urged.' ends at offset 30
+    // piece 0: 'He said. "Come on,"' (id=4, keeps original id)
+    // piece 1: ' she urged.' (id=8, global max+1)
+    // piece 2: ' He left.' (id=9, global max+2)
+    const s4first = state.sentences.find((x) => x.chapterId === 3 && x.id === 4);
+    const s4second = state.sentences.find((x) => x.chapterId === 3 && x.id === 8);
+    const s4third = state.sentences.find((x) => x.chapterId === 3 && x.id === 9);
+    expect(s4first).toBeDefined();
+    expect(s4second).toBeDefined();
+    expect(s4third).toBeDefined();
+    // All 3 pieces together should reconstruct the original text
+    const reconstructed = (s4first?.text ?? '') + (s4second?.text ?? '') + (s4third?.text ?? '');
+    expect(reconstructed).toBe('He said. "Come on," she urged. He left.');
+
+    // merge: sentences 5+6 → survivor id=5 with joined text; id=6 removed
+    const s5 = state.sentences.find((x) => x.chapterId === 3 && x.id === 5);
+    const s6 = state.sentences.find((x) => x.chapterId === 3 && x.id === 6);
+    expect(s5?.text).toBe('First piece. Second piece.');
+    expect(s6).toBeUndefined();
+
+    // onBoundaryMove fired once per op (5 ops)
+    expect(spy).toHaveBeenCalledTimes(5);
+    expect(spy).toHaveBeenCalledWith(3); // chapterId = 3 for all ops
+  });
+
+  it('skips an op whose anchor does not resolve, WITHOUT firing onBoundaryMove', () => {
+    const store = configureStore({
+      reducer: { manuscript: manuscriptSlice.reducer },
+      preloadedState: { manuscript: start(sentences) },
+    });
+    const spy = vi.fn();
+    const badOp: ReviewOp = { id: 3, op: 'split', anchor: 'no such anchor text', pieceCharacterIds: ['narrator', 'narrator'], rationale: 'bad' };
+    dispatchAcceptedOps(store.dispatch, [badOp], liveForDispatch, { onBoundaryMove: spy });
+    // sentence 3 should be unchanged
+    const s3 = store.getState().manuscript.sentences.find((x) => x.chapterId === 3 && x.id === 3);
+    expect(s3?.text).toBe('Hello world. Goodbye world.');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('skips an op whose id is missing from live, WITHOUT firing onBoundaryMove', () => {
+    const store = configureStore({
+      reducer: { manuscript: manuscriptSlice.reducer },
+      preloadedState: { manuscript: start(sentences) },
+    });
+    const spy = vi.fn();
+    const missingOp: ReviewOp = { id: 999, op: 'strip_tag', newText: 'x', rationale: 'missing' };
+    dispatchAcceptedOps(store.dispatch, [missingOp], liveForDispatch, { onBoundaryMove: spy });
+    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/script-review-apply.test.ts
+++ b/src/lib/script-review-apply.test.ts
@@ -1,0 +1,90 @@
+import { resolveAnchorOffset, planApply } from './script-review-apply';
+
+describe('resolveAnchorOffset', () => {
+  it('returns the EXACT original offset across quote/dash normalization', () => {
+    const text = 'He paused—then ran. "Stop," she said.';
+    const off = resolveAnchorOffset(text, 'ran. "Stop,"'); // anchor uses straight quotes
+    expect(off).not.toBeNull();
+    expect(text.slice(off!)).toBe(' she said.'); // exact, not toContain
+  });
+  it('null when not unique', () => expect(resolveAnchorOffset('he said, he said', 'he said')).toBeNull());
+  it('null when absent (TOCTOU edit)', () => expect(resolveAnchorOffset('totally different', 'ran.')).toBeNull());
+});
+
+describe('planApply', () => {
+  const live = [
+    { id: 5, chapterId: 3, text: 'The hall was dark.', characterId: 'narrator' },
+    { id: 6, chapterId: 3, text: 'Dust hung in the air.', characterId: 'narrator' },
+    { id: 7, chapterId: 3, text: 'He sighed. "At last," she said. He left.', characterId: 'narrator' },
+  ];
+  it('rejects a field edit whose id a structural op consumed', () => {
+    const r = planApply([
+      { id: 6, op: 'merge', mergeIds: [5, 6], rationale: 'over-split' },
+      { id: 6, op: 'strip_tag', newText: 'x', rationale: 'tag' },
+    ], live);
+    expect(r.appliable.map((o) => o.op)).toEqual(['merge']);
+    expect(r.unappliable[0].reason).toMatch(/consumed/);
+  });
+  it('rejects a non-adjacent / cross-character merge', () => {
+    const r = planApply([{ id: 5, op: 'merge', mergeIds: [5, 7], rationale: 'x' }], live);
+    expect(r.appliable).toHaveLength(0);
+    expect(r.unappliable[0].reason).toMatch(/adjacent|character/);
+  });
+  it('TOCTOU: a structural op whose anchor no longer resolves is unappliable', () => {
+    const r = planApply([{ id: 5, op: 'split', anchor: 'no such text', pieceCharacterIds: ['narrator', 'maerin'], rationale: 'x' }], live);
+    expect(r.appliable).toHaveLength(0);
+    expect(r.unappliable[0].reason).toMatch(/anchor/);
+  });
+  it('rejects fix_emotion to an invalid enum', () => {
+    const r = planApply([{ id: 5, op: 'fix_emotion', emotion: 'furious', rationale: 'x' }], live);
+    expect(r.appliable).toHaveLength(0);
+    expect(r.unappliable[0].reason).toMatch(/emotion/);
+  });
+
+  // IP-1 regression: merge guard must check ALL member ids, not just mergeIds[0]
+  it('IP-1: rejects second merge whose non-primary member overlaps a prior merge', () => {
+    const liveLong = [
+      { id: 3, chapterId: 1, text: 'Sentence three.', characterId: 'narrator' },
+      { id: 4, chapterId: 1, text: 'Sentence four.', characterId: 'narrator' },
+      { id: 5, chapterId: 1, text: 'Sentence five.', characterId: 'narrator' },
+    ];
+    // merge [4,5] claims ids 4 and 5; merge [3,4] has primary=3 (unclaimed) but member 4 is claimed
+    const r = planApply([
+      { id: 4, op: 'merge', mergeIds: [4, 5], rationale: 'x' },
+      { id: 3, op: 'merge', mergeIds: [3, 4], rationale: 'y' },
+    ], liveLong);
+    expect(r.appliable).toHaveLength(1);
+    expect(r.appliable[0].mergeIds).toEqual([4, 5]);
+    expect(r.unappliable).toHaveLength(1);
+    expect(r.unappliable[0].reason).toMatch(/same id|consumed|structural/i);
+  });
+
+  // M-3 extract_dialogue green path: both anchor and anchorEnd resolve
+  it('extract_dialogue is appliable when both anchor and anchorEnd resolve uniquely', () => {
+    const r = planApply([{
+      id: 7,
+      op: 'extract_dialogue',
+      anchor: '"At last,"',
+      anchorEnd: 'He left.',
+      pieceCharacterIds: ['narrator', 'maerin'],
+      rationale: 'dialogue extract',
+    }], live);
+    expect(r.appliable).toHaveLength(1);
+    expect(r.appliable[0].op).toBe('extract_dialogue');
+    expect(r.unappliable).toHaveLength(0);
+  });
+
+  // M-3 extract_dialogue rejection: anchorEnd does not resolve
+  it('extract_dialogue is unappliable when anchorEnd does not resolve', () => {
+    const r = planApply([{
+      id: 7,
+      op: 'extract_dialogue',
+      anchor: '"At last,"',
+      anchorEnd: 'no such text in sentence',
+      pieceCharacterIds: ['narrator', 'maerin'],
+      rationale: 'dialogue extract',
+    }], live);
+    expect(r.appliable).toHaveLength(0);
+    expect(r.unappliable[0].reason).toMatch(/anchorEnd|extract|anchor/i);
+  });
+});

--- a/src/lib/script-review-apply.test.ts
+++ b/src/lib/script-review-apply.test.ts
@@ -205,4 +205,30 @@ describe('dispatchAcceptedOps', () => {
     dispatchAcceptedOps(store.dispatch, [missingOp], liveForDispatch, { onBoundaryMove: spy });
     expect(spy).not.toHaveBeenCalled();
   });
+
+  it('skips extract_dialogue when anchorEnd resolves before anchor (end <= start), WITHOUT firing onBoundaryMove', () => {
+    const store = configureStore({
+      reducer: { manuscript: manuscriptSlice.reducer },
+      preloadedState: { manuscript: start(sentences) },
+    });
+    const spy = vi.fn();
+    // sentence 4 text: 'He said. "Come on," she urged. He left.'
+    // anchor = 'she urged.' ends at offset 29 (later in the sentence)
+    // anchorEnd = '"Come on,"' ends at offset 19 (earlier in the sentence)
+    // end (19) <= start (29), so the op should be skipped
+    const badExtractionOp: ReviewOp = {
+      id: 4,
+      op: 'extract_dialogue',
+      anchor: 'she urged.',
+      anchorEnd: '"Come on,"',
+      pieceCharacterIds: ['narrator', 'maerin', 'narrator'],
+      rationale: 'invalid range',
+    };
+    dispatchAcceptedOps(store.dispatch, [badExtractionOp], liveForDispatch, { onBoundaryMove: spy });
+    // sentence 4 should be unchanged
+    const s4 = store.getState().manuscript.sentences.find((x) => x.chapterId === 3 && x.id === 4);
+    expect(s4?.text).toBe('He said. "Come on," she urged. He left.');
+    // onBoundaryMove should not have been called
+    expect(spy).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/script-review-apply.test.ts
+++ b/src/lib/script-review-apply.test.ts
@@ -1,6 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { vi } from 'vitest';
-import { resolveAnchorOffset, planApply, dispatchAcceptedOps, type ReviewOp } from './script-review-apply';
+import {
+  resolveAnchorOffset,
+  planApply,
+  dispatchAcceptedOps,
+  rpdWarningFor,
+  type ReviewOp,
+} from './script-review-apply';
 import { manuscriptSlice } from '../store/manuscript-slice';
 import { start } from '../store/manuscript-slice.test-helpers';
 
@@ -230,5 +236,33 @@ describe('dispatchAcceptedOps', () => {
     expect(s4?.text).toBe('He said. "Come on," she urged. He left.');
     // onBoundaryMove should not have been called
     expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('rpdWarningFor', () => {
+  it('warns when chapter count exceeds the model RPD cap', () => {
+    const w = rpdWarningFor(30, 'gemini-2.5-flash'); // cap 20
+    expect(w).not.toBeNull();
+    expect(w!.chapterCount).toBe(30);
+    expect(w!.rpd).toBe(20);
+    expect(w!.model).toBe('gemini-2.5-flash');
+  });
+
+  it('stays quiet when chapter count is at or under the cap', () => {
+    expect(rpdWarningFor(20, 'gemini-2.5-flash')).toBeNull(); // exactly at cap
+    expect(rpdWarningFor(5, 'gemini-2.5-flash')).toBeNull();
+    expect(rpdWarningFor(400, 'gemini-3.1-flash-lite')).toBeNull(); // cap 500
+  });
+
+  it('never warns for a local / unknown model (no daily cap)', () => {
+    expect(rpdWarningFor(10_000, 'qwen3.5:9b')).toBeNull(); // local Ollama model
+    expect(rpdWarningFor(10_000, undefined)).toBeNull(); // server default local
+  });
+
+  it('uses the per-model cap, not a shared one', () => {
+    // gemma has a 1500/day cap → 30 chapters is fine
+    expect(rpdWarningFor(30, 'gemma-4-31b-it')).toBeNull();
+    // but flash preview only allows 20/day
+    expect(rpdWarningFor(30, 'gemini-3-flash-preview')).not.toBeNull();
   });
 });

--- a/src/lib/script-review-apply.ts
+++ b/src/lib/script-review-apply.ts
@@ -1,3 +1,6 @@
+import type { Dispatch } from '@reduxjs/toolkit';
+import { manuscriptActions } from '../store/manuscript-slice';
+
 export const REVIEW_EMOTIONS = ['neutral', 'whisper', 'angry', 'excited', 'sad'] as const;
 
 export interface ReviewOp {
@@ -87,4 +90,43 @@ export function planApply(
     appliable.push(op);
   }
   return { appliable, unappliable };
+}
+
+export function dispatchAcceptedOps(
+  dispatch: Dispatch,
+  accepted: ReviewOp[],
+  live: Array<{ id: number; chapterId: number; text: string; characterId: string }>,
+  { onBoundaryMove }: { onBoundaryMove: (chapterId: number) => void },
+): void {
+  const byId = new Map(live.map((s) => [s.id, s]));
+  for (const op of accepted) {
+    const target = byId.get(op.op === 'merge' ? (op.mergeIds?.[0] ?? op.id) : op.id);
+    if (!target) continue;
+    const chapterId = target.chapterId;
+    switch (op.op) {
+      case 'strip_tag':
+        dispatch(manuscriptActions.setSentenceText({ chapterId, sentenceId: op.id, text: op.newText ?? target.text }));
+        break;
+      case 'fix_emotion':
+        dispatch(manuscriptActions.setSentenceEmotion({ chapterId, sentenceId: op.id, emotion: op.emotion ?? 'neutral' }));
+        break;
+      case 'split': {
+        const off = resolveAnchorOffset(target.text, op.anchor ?? '');
+        if (off === null) continue;
+        dispatch(manuscriptActions.splitSentence({ chapterId, sentenceId: op.id, offsets: [off], characterIds: op.pieceCharacterIds ?? [target.characterId, target.characterId] }));
+        break;
+      }
+      case 'extract_dialogue': {
+        const start = resolveAnchorOffset(target.text, op.anchor ?? '');
+        const end = resolveAnchorOffset(target.text, op.anchorEnd ?? '');
+        if (start === null || end === null || end <= start) continue;
+        dispatch(manuscriptActions.splitSentence({ chapterId, sentenceId: op.id, offsets: [start, end], characterIds: op.pieceCharacterIds ?? [target.characterId, target.characterId, target.characterId] }));
+        break;
+      }
+      case 'merge':
+        dispatch(manuscriptActions.mergeSentences({ chapterId, sentenceIds: op.mergeIds ?? [] }));
+        break;
+    }
+    onBoundaryMove(chapterId);
+  }
 }

--- a/src/lib/script-review-apply.ts
+++ b/src/lib/script-review-apply.ts
@@ -3,6 +3,43 @@ import { manuscriptActions } from '../store/manuscript-slice';
 
 export const REVIEW_EMOTIONS = ['neutral', 'whisper', 'angry', 'excited', 'sad'] as const;
 
+/* fs-58 — per-model requests-per-day caps for the whole-book script-review
+   sweep. A whole-book run fires ONE script-review request per chapter, so a
+   book with more chapters than the selected model's RPD cap will exhaust the
+   free-tier quota mid-run. We mirror the server caps here (they live in
+   server/src/analyzer/rate-limit.ts BUILTIN_LIMITS — keep in lockstep when
+   they change) because rate-limit.ts is a server module not importable
+   client-side. A model absent from this map (notably any LOCAL Ollama model)
+   has no daily cap → no warning. */
+export const REVIEW_MODEL_RPD: Record<string, number> = {
+  'gemini-3.1-flash-lite': 500,
+  'gemini-3.5-flash': 20,
+  'gemini-3-flash-preview': 20,
+  'gemini-2.5-flash': 20,
+  'gemma-4-31b-it': 1500,
+  'gemma-4-26b-a4b-it': 1500,
+};
+
+export interface RpdWarning {
+  chapterCount: number;
+  /** The matched model's daily request cap. */
+  rpd: number;
+  model: string;
+}
+
+/* Pure helper: should a whole-book sweep of `chapterCount` chapters with
+   `model` warn the user that they'll blow the daily quota? Returns the
+   warning payload when chapterCount exceeds the model's RPD cap, else null.
+   A model with no entry in REVIEW_MODEL_RPD (e.g. a local Ollama model, or
+   undefined when the server default is local) is uncapped → null. */
+export function rpdWarningFor(chapterCount: number, model: string | undefined): RpdWarning | null {
+  if (!model) return null;
+  const rpd = REVIEW_MODEL_RPD[model];
+  if (rpd === undefined) return null;
+  if (chapterCount <= rpd) return null;
+  return { chapterCount, rpd, model };
+}
+
 export interface ReviewOp {
   id: number;
   op: 'strip_tag' | 'split' | 'extract_dialogue' | 'merge' | 'fix_emotion';

--- a/src/lib/script-review-apply.ts
+++ b/src/lib/script-review-apply.ts
@@ -1,0 +1,90 @@
+export const REVIEW_EMOTIONS = ['neutral', 'whisper', 'angry', 'excited', 'sad'] as const;
+
+export interface ReviewOp {
+  id: number;
+  op: 'strip_tag' | 'split' | 'extract_dialogue' | 'merge' | 'fix_emotion';
+  newText?: string;
+  anchor?: string;
+  anchorEnd?: string;
+  pieceCharacterIds?: string[];
+  mergeIds?: number[];
+  emotion?: string;
+  rationale: string;
+  confidence?: number;
+}
+
+/** NFC + quote/dash/ellipsis folds ONLY — every fold maps 1 original char to a
+    known number of normalized chars, so an index map is exact. No whitespace
+    collapse (it would desync positions — the plan-review bug). */
+function normChar(c: string): string {
+  if (c === "‘" || c === "’") return "'";
+  if (c === "“" || c === "”") return '"';
+  if (c === "–" || c === "—") return '-';
+  if (c === "…") return '...';
+  return c.normalize('NFC');
+}
+export function normalizeForMatch(text: string): string {
+  let out = '';
+  for (const ch of text) out += normChar(ch);
+  return out;
+}
+
+/** Returns the ORIGINAL-text offset of the END of a unique anchor match, or null. */
+export function resolveAnchorOffset(text: string, anchor: string): number | null {
+  // Build normalized string + a map from each normalized index to the original index AFTER it.
+  let norm = '';
+  const origEndForNormLen: number[] = [0]; // origEndForNormLen[k] = original index after k normalized chars
+  for (let i = 0; i < text.length; i++) {
+    const piece = normChar(text[i]);
+    for (let j = 0; j < piece.length; j++) origEndForNormLen.push(i + 1);
+    norm += piece;
+  }
+  const nAnchor = normalizeForMatch(anchor);
+  if (!nAnchor) return null;
+  const first = norm.indexOf(nAnchor);
+  if (first < 0 || first !== norm.lastIndexOf(nAnchor)) return null;
+  return origEndForNormLen[first + nAnchor.length];
+}
+
+export function planApply(
+  ops: ReviewOp[],
+  live: Array<{ id: number; chapterId: number; text: string; characterId: string }>,
+): { appliable: ReviewOp[]; unappliable: Array<{ op: ReviewOp; reason: string }> } {
+  const byId = new Map(live.map((s) => [s.id, s]));
+  const appliable: ReviewOp[] = [];
+  const unappliable: Array<{ op: ReviewOp; reason: string }> = [];
+  const STRUCTURAL = new Set(['split', 'extract_dialogue', 'merge']);
+  const consumed = new Set<number>();
+  const structTargets = new Set<number>();
+
+  for (const op of ops.filter((o) => STRUCTURAL.has(o.op))) {
+    if (op.op === 'merge') {
+      const ids = [...(op.mergeIds ?? [])].sort((a, b) => a - b);
+      if (ids.some((id) => structTargets.has(id))) { unappliable.push({ op, reason: 'second structural op on the same id' }); continue; }
+      const members = ids.map((id) => byId.get(id));
+      if (members.some((m) => !m)) { unappliable.push({ op, reason: 'merge member missing' }); continue; }
+      const ch = members[0]!.chapterId;
+      const sameChar = members.every((m) => m!.characterId === members[0]!.characterId);
+      const sameChapter = members.every((m) => m!.chapterId === ch);
+      const adjacent = ids.every((id, k) => k === 0 || id === ids[k - 1] + 1);
+      if (!sameChar || !adjacent || !sameChapter) { unappliable.push({ op, reason: 'merge members not adjacent / same character / same chapter' }); continue; }
+      ids.forEach((id) => { consumed.add(id); structTargets.add(id); });
+      appliable.push(op);
+    } else {
+      if (structTargets.has(op.id)) { unappliable.push({ op, reason: 'second structural op on the same id' }); continue; }
+      const s = byId.get(op.id);
+      if (!s) { unappliable.push({ op, reason: 'target id missing' }); continue; }
+      if (resolveAnchorOffset(s.text, op.anchor ?? '') === null) { unappliable.push({ op, reason: 'anchor not found or not unique' }); continue; }
+      if (op.op === 'extract_dialogue' && resolveAnchorOffset(s.text, op.anchorEnd ?? '') === null) { unappliable.push({ op, reason: 'extract anchorEnd not found or not unique' }); continue; }
+      consumed.add(op.id); structTargets.add(op.id); appliable.push(op);
+    }
+  }
+
+  for (const op of ops.filter((o) => !STRUCTURAL.has(o.op))) {
+    if (consumed.has(op.id)) { unappliable.push({ op, reason: 'id consumed by a structural op' }); continue; }
+    if (!byId.has(op.id)) { unappliable.push({ op, reason: 'target id missing' }); continue; }
+    if (op.op === 'fix_emotion' && !REVIEW_EMOTIONS.includes(op.emotion as never)) { unappliable.push({ op, reason: 'invalid emotion value' }); continue; }
+    appliable.push(op);
+  }
+  return { appliable, unappliable };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -374,7 +374,7 @@ export interface BookStateResponse {
       in-memory ManuscriptRecord. Lets the Analysing screen show a size-aware
       ETA without loading the full sourceText. */
   manuscript: { wordCount: number; format: UploadResponse['format'] } | null;
-  manuscriptEdits: { sentences?: Sentence[] } | null;
+  manuscriptEdits: { sentences?: Sentence[]; /** fs-58 — merge tombstone keys. */ mergedAwayKeys?: string[] } | null;
   revisions: {
     pending?: Revision[];
     drift?: DriftEvent[];

--- a/src/modals/reattribute-lines.test.tsx
+++ b/src/modals/reattribute-lines.test.tsx
@@ -38,6 +38,7 @@ function makeStore({
         sentences,
         importCandidate: null,
         pendingReupload: null,
+        mergedAwayKeys: [],
       },
     },
   });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -58,6 +58,7 @@ import { spliceSlice } from './splice-slice';
 import { configSlice } from './config-slice';
 import { tourSlice } from './tour-slice';
 import { continueListeningSlice } from './continue-listening-slice';
+import { scriptReviewSlice } from './script-review-slice';
 import { persistenceMiddleware } from './persistence-middleware';
 import { generationStreamMiddleware } from './generation-stream-middleware';
 import { analysisStreamMiddleware } from './analysis-stream-middleware';
@@ -201,6 +202,7 @@ export const store = configureStore({
     config: configSlice.reducer,
     tour: tourSlice.reducer,
     continueListening: continueListeningSlice.reducer,
+    scriptReview: scriptReviewSlice.reducer,
   },
   middleware: (getDefault) =>
     getDefault({

--- a/src/store/manuscript-slice.test-helpers.ts
+++ b/src/store/manuscript-slice.test-helpers.ts
@@ -1,0 +1,22 @@
+/* Shared test helpers for manuscript-slice tests.
+   Extracted from manuscript-slice.test.ts so Task 2+ can reuse start()
+   without duplicating the scaffold. */
+
+import { manuscriptSlice, manuscriptActions } from './manuscript-slice';
+
+/** Build a real ManuscriptState with manuscriptId set + the given sentences
+ *  present. `manuscriptId: 'm1'` ensures hydrateFromAnalysis takes the
+ *  merge/append branch (not the wholesale-replace branch). */
+export function start(
+  sentencesArray: Array<{ id: number; chapterId: number; characterId: string; text: string; emotion?: string }>,
+) {
+  return manuscriptSlice.reducer(
+    {
+      ...manuscriptSlice.reducer(undefined, manuscriptActions.reset()),
+      manuscriptId: 'm1',
+      bookId: 'b1',
+      sentences: sentencesArray,
+    } as never,
+    { type: '@@noop' } as never,
+  );
+}

--- a/src/store/manuscript-slice.test.ts
+++ b/src/store/manuscript-slice.test.ts
@@ -760,3 +760,26 @@ describe('manuscriptSlice — applyChapterRestructure', () => {
     expect(next.sentences[0].text).toBe('kept');
   });
 });
+
+const seeded = (sentencesArray: Array<{ id: number; chapterId: number; characterId: string; text: string; emotion?: string }>) =>
+  manuscriptSlice.reducer(undefined, manuscriptActions.reset());
+
+// Helper: a real starting state with manuscriptId set + sentences present.
+function start(sentencesArray: Parameters<typeof seeded>[0]) {
+  return manuscriptSlice.reducer(
+    { ...manuscriptSlice.reducer(undefined, manuscriptActions.reset()), manuscriptId: 'm1', bookId: 'b1', sentences: sentencesArray } as never,
+    { type: '@@noop' } as never,
+  );
+}
+
+describe('setSentenceText', () => {
+  it('replaces the matching sentence text, leaves others untouched', () => {
+    const s = start([
+      { id: 1, chapterId: 1, characterId: 'narrator', text: 'He ran. "Stop," she said.' },
+      { id: 2, chapterId: 1, characterId: 'narrator', text: 'Quiet.' },
+    ]);
+    const next = manuscriptSlice.reducer(s, manuscriptActions.setSentenceText({ chapterId: 1, sentenceId: 1, text: 'He ran. "Stop,"' }));
+    expect(next.sentences.find((x) => x.id === 1)?.text).toBe('He ran. "Stop,"');
+    expect(next.sentences.find((x) => x.id === 2)?.text).toBe('Quiet.');
+  });
+});

--- a/src/store/manuscript-slice.test.ts
+++ b/src/store/manuscript-slice.test.ts
@@ -19,6 +19,7 @@ const baseState = (initial: Sentence[]) => ({
   sentences: initial,
   importCandidate: null,
   pendingReupload: null,
+  mergedAwayKeys: [] as string[],
 });
 
 describe('manuscriptSlice — splitSentence', () => {
@@ -814,5 +815,22 @@ describe('mergeSentences', () => {
     const s = start([{ id: 5, chapterId: 3, characterId: 'narrator', text: 'A.' }]);
     expect(reducer(s, manuscriptActions.mergeSentences({ chapterId: 3, sentenceIds: [5, 9] })).sentences).toHaveLength(1);
     expect(reducer(s, manuscriptActions.mergeSentences({ chapterId: 3, sentenceIds: [5] })).sentences).toHaveLength(1);
+  });
+});
+
+describe('hydrateFromBookState — merge tombstone persistence (task-2b)', () => {
+  it('rehydrates and book-scopes the merge tombstone', () => {
+    const a = reducer(undefined, manuscriptActions.hydrateFromBookState({
+      state: { bookId: 'A', manuscriptId: 'mns_a', title: 'Book A' } as never,
+      sentences: null,
+      mergedAwayKeys: ['3:6'],
+    }));
+    expect(a.mergedAwayKeys).toEqual(['3:6']);
+    // Loading a different book with no mergedAwayKeys clears the prior book's tombstone.
+    const b = reducer(a, manuscriptActions.hydrateFromBookState({
+      state: { bookId: 'B', manuscriptId: 'mns_b', title: 'Book B' } as never,
+      sentences: null,
+    }));
+    expect(b.mergedAwayKeys).toEqual([]); // B's load doesn't inherit A's tombstone
   });
 });

--- a/src/store/manuscript-slice.test.ts
+++ b/src/store/manuscript-slice.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from 'vitest';
 import { manuscriptSlice, manuscriptActions } from './manuscript-slice';
 import type { Sentence } from '../lib/types';
+import { start } from './manuscript-slice.test-helpers';
 
 const sentences = (
   xs: Array<Partial<Sentence> & { id: number; text: string; characterId: string }>,
@@ -761,16 +762,7 @@ describe('manuscriptSlice — applyChapterRestructure', () => {
   });
 });
 
-const seeded = (sentencesArray: Array<{ id: number; chapterId: number; characterId: string; text: string; emotion?: string }>) =>
-  manuscriptSlice.reducer(undefined, manuscriptActions.reset());
-
-// Helper: a real starting state with manuscriptId set + sentences present.
-function start(sentencesArray: Parameters<typeof seeded>[0]) {
-  return manuscriptSlice.reducer(
-    { ...manuscriptSlice.reducer(undefined, manuscriptActions.reset()), manuscriptId: 'm1', bookId: 'b1', sentences: sentencesArray } as never,
-    { type: '@@noop' } as never,
-  );
-}
+const reducer = manuscriptSlice.reducer;
 
 describe('setSentenceText', () => {
   it('replaces the matching sentence text, leaves others untouched', () => {
@@ -778,8 +770,49 @@ describe('setSentenceText', () => {
       { id: 1, chapterId: 1, characterId: 'narrator', text: 'He ran. "Stop," she said.' },
       { id: 2, chapterId: 1, characterId: 'narrator', text: 'Quiet.' },
     ]);
-    const next = manuscriptSlice.reducer(s, manuscriptActions.setSentenceText({ chapterId: 1, sentenceId: 1, text: 'He ran. "Stop,"' }));
+    const next = reducer(s, manuscriptActions.setSentenceText({ chapterId: 1, sentenceId: 1, text: 'He ran. "Stop,"' }));
     expect(next.sentences.find((x) => x.id === 1)?.text).toBe('He ran. "Stop,"');
     expect(next.sentences.find((x) => x.id === 2)?.text).toBe('Quiet.');
+  });
+});
+
+describe('mergeSentences', () => {
+  it('merges into the lowest id, concatenates in order, drops the rest, tombstones', () => {
+    const s = start([
+      { id: 5, chapterId: 3, characterId: 'narrator', text: 'The hall was dark.' },
+      { id: 6, chapterId: 3, characterId: 'narrator', text: 'Dust hung in the air.' },
+    ]);
+    const next = reducer(s, manuscriptActions.mergeSentences({ chapterId: 3, sentenceIds: [5, 6] }));
+    const ch3 = next.sentences.filter((x) => x.chapterId === 3);
+    expect(ch3.map((x) => x.id)).toEqual([5]);
+    expect(ch3[0].text).toBe('The hall was dark. Dust hung in the air.');
+    expect(next.mergedAwayKeys).toContain('3:6');
+  });
+
+  it('does NOT resurrect the merged-away id on a subsequent re-analysis', () => {
+    const merged = reducer(
+      start([
+        { id: 5, chapterId: 3, characterId: 'narrator', text: 'The hall was dark.' },
+        { id: 6, chapterId: 3, characterId: 'narrator', text: 'Dust hung in the air.' },
+      ]),
+      manuscriptActions.mergeSentences({ chapterId: 3, sentenceIds: [5, 6] }),
+    );
+    // manuscriptId is set (via start()), so hydrateFromAnalysis takes the merge/append branch:
+    const reanalysed = reducer(merged, manuscriptActions.hydrateFromAnalysis({
+      bookId: 'b1',
+      sentences: [
+        { id: 5, chapterId: 3, characterId: 'narrator', text: 'The hall was dark.' },
+        { id: 6, chapterId: 3, characterId: 'narrator', text: 'Dust hung in the air.' },
+      ],
+    } as never));
+    const ch3 = reanalysed.sentences.filter((x) => x.chapterId === 3);
+    expect(ch3.map((x) => x.id)).toEqual([5]); // 6 stays dead
+    expect(ch3[0].text).toBe('The hall was dark. Dust hung in the air.');
+  });
+
+  it('rejects a merge naming a missing id, and a single-id merge', () => {
+    const s = start([{ id: 5, chapterId: 3, characterId: 'narrator', text: 'A.' }]);
+    expect(reducer(s, manuscriptActions.mergeSentences({ chapterId: 3, sentenceIds: [5, 9] })).sentences).toHaveLength(1);
+    expect(reducer(s, manuscriptActions.mergeSentences({ chapterId: 3, sentenceIds: [5] })).sentences).toHaveLength(1);
   });
 });

--- a/src/store/manuscript-slice.ts
+++ b/src/store/manuscript-slice.ts
@@ -37,6 +37,10 @@ export interface ManuscriptState {
       sentences, etc.) remain untouched while this is non-null — that's
       the "preview before apply" invariant. */
   pendingReupload: PendingReupload | null;
+  /** fs-58 — tombstone of merged-away (chapterId:sentenceId) keys.
+      Prevents a re-analysis from resurrecting sentence ids that were
+      deliberately merged away by the user. Format: `"${chapterId}:${id}"`. */
+  mergedAwayKeys: string[];
 }
 
 export interface PendingReupload {
@@ -77,6 +81,7 @@ const initialState: ManuscriptState = {
   sentences: initialSentences,
   importCandidate: null,
   pendingReupload: null,
+  mergedAwayKeys: [],
 };
 
 export const manuscriptSlice = createSlice({
@@ -146,8 +151,9 @@ export const manuscriptSlice = createSlice({
           merged.push(x);
         }
       }
+      const tomb = new Set(s.mergedAwayKeys);
       for (const inc of incoming) {
-        if (!stateKeys.has(key(inc))) merged.push(inc);
+        if (!stateKeys.has(key(inc)) && !tomb.has(key(inc))) merged.push(inc);
       }
       s.sentences = merged;
     },
@@ -182,6 +188,7 @@ export const manuscriptSlice = createSlice({
       s.sentences = initialSentences;
       s.importCandidate = null;
       s.pendingReupload = null;
+      s.mergedAwayKeys = [];
     },
 
     /* Plan 74 — capture the user's re-uploaded manuscript without
@@ -238,6 +245,7 @@ export const manuscriptSlice = createSlice({
       s.title = newCandidate.title;
       s.format = newCandidate.format;
       s.pendingReupload = null;
+      s.mergedAwayKeys = [];
     },
 
     /* Plan 74 — drop the pending re-upload without touching anything
@@ -406,6 +414,25 @@ export const manuscriptSlice = createSlice({
       }
       next.sort((x, y) => x.chapterId - y.chapterId || x.id - y.id);
       s.sentences = next;
+    },
+
+    /* fs-58 — User edit: merge adjacent sentences into the lowest id.
+       sentenceIds are sorted ascending; the lowest becomes the survivor
+       (its text = all members joined by a space). Dropped ids are recorded
+       in mergedAwayKeys so a subsequent re-analysis cannot resurrect them.
+       No-op if any named id is missing or only one id is given. */
+    mergeSentences: (s, a: PayloadAction<{ chapterId: number; sentenceIds: number[] }>) => {
+      const ids = [...a.payload.sentenceIds].sort((x, y) => x - y);
+      if (ids.length < 2) return;
+      const members = ids.map((id) => s.sentences.find((x) => x.chapterId === a.payload.chapterId && x.id === id));
+      if (members.some((m) => !m)) return;
+      const live = members as NonNullable<(typeof members)[number]>[];
+      live[0].text = live.map((m) => m.text).join(' ');
+      for (const m of live.slice(1)) {
+        const i = s.sentences.findIndex((x) => x.chapterId === a.payload.chapterId && x.id === m.id);
+        if (i >= 0) s.sentences.splice(i, 1);
+        s.mergedAwayKeys.push(`${a.payload.chapterId}:${m.id}`);
+      }
     },
   },
 });

--- a/src/store/manuscript-slice.ts
+++ b/src/store/manuscript-slice.ts
@@ -167,6 +167,10 @@ export const manuscriptSlice = createSlice({
         sentences: Sentence[] | null;
         wordCount?: number | null;
         format?: UploadResponse['format'] | null;
+        /** fs-58 — tombstone of merged-away sentence keys for this book.
+            The `?? []` also book-scopes the tombstone: loading Book B with
+            no keys clears Book A's tombstone from the prior load. */
+        mergedAwayKeys?: string[];
       }>,
     ) => {
       const { state, sentences, wordCount, format } = a.payload;
@@ -177,6 +181,7 @@ export const manuscriptSlice = createSlice({
       if (typeof wordCount === 'number' && wordCount > 0) s.wordCount = wordCount;
       if (format) s.format = format;
       if (sentences?.length) s.sentences = sentences;
+      s.mergedAwayKeys = a.payload.mergedAwayKeys ?? [];
     },
     reset: (s) => {
       s.bookId = null;

--- a/src/store/manuscript-slice.ts
+++ b/src/store/manuscript-slice.ts
@@ -261,6 +261,14 @@ export const manuscriptSlice = createSlice({
       if (sent) sent.characterId = a.payload.characterId;
     },
 
+    /* fs-58 — User edit: replace a sentence's text (strip_tag review op target).
+       Scoped by (chapterId, sentenceId) like setSentenceCharacter. No-op if the
+       sentence is not found. */
+    setSentenceText: (s, a: PayloadAction<{ chapterId: number; sentenceId: number; text: string }>) => {
+      const sent = s.sentences.find((x) => x.chapterId === a.payload.chapterId && x.id === a.payload.sentenceId);
+      if (sent) sent.text = a.payload.text;
+    },
+
     /* fs-25 — User edit: set (or clear) a quote's delivery emotion. Scoped by
        (chapterId, sentenceId) like setSentenceCharacter. `'neutral'` clears the
        field back to undefined (the default render on every engine) so the store

--- a/src/store/persistence-middleware.test.ts
+++ b/src/store/persistence-middleware.test.ts
@@ -334,6 +334,33 @@ describe('persistenceMiddleware — payload shape', () => {
     });
   });
 
+  it('fs-58 batch ordering: mergedAwayKeys survives a subsequent setSentenceText in the same debounce window', async () => {
+    /* Regression guard for the Task-2b correctness gap: when an Apply batch
+       dispatches mergeSentences then setSentenceText, the later action was the
+       last writer of pending['manuscript'], so the flush sent only { sentences }
+       and the tombstone was silently dropped — causing a re-analysis to
+       resurrect the merged-away id on reload.
+       Both actions must land the same tombstone in the final PUT patch. */
+    const next = vi.fn((x) => x);
+    const state = baseState({
+      manuscript: {
+        sentences: [{ id: 1, chapterId: 1, text: 'Corrected text.' }],
+        mergedAwayKeys: ['1:2'],
+      },
+    });
+    const mw = persistenceMiddleware(makeStore(state))(next);
+
+    mw({ type: 'manuscript/mergeSentences' });
+    mw({ type: 'manuscript/setSentenceText' });
+    await advance(500);
+
+    expect(putBookState).toHaveBeenCalledOnce();
+    expect(putBookState).toHaveBeenCalledWith('book-1', {
+      slice: 'manuscript',
+      patch: expect.objectContaining({ mergedAwayKeys: ['1:2'] }),
+    });
+  });
+
   it('sends castConfirmed=true for ui/confirmCast (slice="state")', async () => {
     const next = vi.fn((x) => x);
     persistenceMiddleware(makeStore(baseState()))(next)({ type: 'ui/confirmCast' });

--- a/src/store/persistence-middleware.ts
+++ b/src/store/persistence-middleware.ts
@@ -80,27 +80,40 @@ const PERSIST_RULES: Record<
 
   'manuscript/setSentenceCharacter': {
     slice: 'manuscript',
-    build: (s) => ({ sentences: s.manuscript.sentences }),
+    build: (s) => ({ sentences: s.manuscript.sentences, mergedAwayKeys: s.manuscript.mergedAwayKeys }),
   },
   'manuscript/setSentencesCharacter': {
     slice: 'manuscript',
-    build: (s) => ({ sentences: s.manuscript.sentences }),
+    build: (s) => ({ sentences: s.manuscript.sentences, mergedAwayKeys: s.manuscript.mergedAwayKeys }),
   },
   /* fs-25 — a hand-set per-quote emotion persists like a reassignment, so the
      manual override survives reload and wins over analyzer/seed emotion. */
   'manuscript/setSentenceEmotion': {
     slice: 'manuscript',
-    build: (s) => ({ sentences: s.manuscript.sentences }),
+    build: (s) => ({ sentences: s.manuscript.sentences, mergedAwayKeys: s.manuscript.mergedAwayKeys }),
   },
   /* fs-33 — the bulk emotion backfill persists like a manual tag so detected
      emotions survive reload and reach synth via manuscript-edits.json. */
   'manuscript/applyDetectedEmotions': {
     slice: 'manuscript',
-    build: (s) => ({ sentences: s.manuscript.sentences }),
+    build: (s) => ({ sentences: s.manuscript.sentences, mergedAwayKeys: s.manuscript.mergedAwayKeys }),
   },
   'manuscript/splitSentence': {
     slice: 'manuscript',
-    build: (s) => ({ sentences: s.manuscript.sentences }),
+    build: (s) => ({ sentences: s.manuscript.sentences, mergedAwayKeys: s.manuscript.mergedAwayKeys }),
+  },
+  /* fs-58 — a merge is a committed edit; the tombstone must survive reload
+     so a re-analysis cannot resurrect the merged-away sentence id.
+     Persisted alongside sentences in manuscript-edits.json. */
+  'manuscript/mergeSentences': {
+    slice: 'manuscript',
+    build: (s) => ({ sentences: s.manuscript.sentences, mergedAwayKeys: s.manuscript.mergedAwayKeys }),
+  },
+  /* fs-58 — text edit (strip_tag review op). Persisted the same way as other
+     sentence edits so the corrected text survives reload. */
+  'manuscript/setSentenceText': {
+    slice: 'manuscript',
+    build: (s) => ({ sentences: s.manuscript.sentences, mergedAwayKeys: s.manuscript.mergedAwayKeys }),
   },
 
   /* dismissed ids ride with every revisions persist so the backend drift

--- a/src/store/script-review-slice.test.ts
+++ b/src/store/script-review-slice.test.ts
@@ -154,4 +154,111 @@ describe('scriptReviewSlice', () => {
     store.dispatch(scriptReviewActions.clearReview({ bookId: 'book-a' }));
     expect(selectReview(store.getState(), 'book-a')).toBeUndefined();
   });
+
+  it('unappliable is stored and accessible', () => {
+    const store = makeStore();
+    const unappliableOp: ReviewOpWithChapter = {
+      id: 99,
+      op: 'strip_tag',
+      newText: 'test',
+      rationale: 'test',
+      chapterId: 10,
+    };
+    store.dispatch(
+      scriptReviewActions.setReview({
+        bookId: 'book-a',
+        ops: [op1],
+        unappliable: [{ op: unappliableOp, reason: 'anchor not found' }],
+      }),
+    );
+    const bucket = selectReview(store.getState(), 'book-a');
+    expect(bucket!.unappliable).toHaveLength(1);
+    expect(bucket!.unappliable[0].op.id).toBe(99);
+    expect(bucket!.unappliable[0].reason).toBe('anchor not found');
+  });
+
+  it('toggleClass isolates to the target book (cross-book test)', () => {
+    const store = makeStore();
+    store.dispatch(
+      scriptReviewActions.setReview({
+        bookId: 'book-a',
+        ops: [op1, op2],
+        unappliable: [],
+      }),
+    );
+    store.dispatch(
+      scriptReviewActions.setReview({
+        bookId: 'book-b',
+        ops: [op3],
+        unappliable: [],
+      }),
+    );
+    const bookBBefore = selectReview(store.getState(), 'book-b')!;
+    const bookBSelectedBefore = { ...bookBBefore.selected };
+
+    // Toggle strip_tag on book-a
+    store.dispatch(scriptReviewActions.toggleClass({ bookId: 'book-a', op: 'strip_tag' }));
+
+    // book-b's selected map should be identical
+    const bookBAfter = selectReview(store.getState(), 'book-b')!;
+    expect(bookBAfter.selected).toEqual(bookBSelectedBefore);
+  });
+
+  it('toggleOp isolates to the target book (cross-book test)', () => {
+    const store = makeStore();
+    store.dispatch(
+      scriptReviewActions.setReview({
+        bookId: 'book-a',
+        ops: [op1],
+        unappliable: [],
+      }),
+    );
+    store.dispatch(
+      scriptReviewActions.setReview({
+        bookId: 'book-b',
+        ops: [op2],
+        unappliable: [],
+      }),
+    );
+    const bookBBefore = selectReview(store.getState(), 'book-b')!;
+    const bookBSelectedBefore = { ...bookBBefore.selected };
+
+    // Toggle op on book-a
+    store.dispatch(
+      scriptReviewActions.toggleOp({
+        bookId: 'book-a',
+        key: opKey(10, 1, 'strip_tag'),
+      }),
+    );
+
+    // book-b's selected map should be identical
+    const bookBAfter = selectReview(store.getState(), 'book-b')!;
+    expect(bookBAfter.selected).toEqual(bookBSelectedBefore);
+  });
+
+  it('toggleOp ignores an unknown key (defensive guard)', () => {
+    const store = makeStore();
+    store.dispatch(
+      scriptReviewActions.setReview({
+        bookId: 'book-a',
+        ops: [op1, op2],
+        unappliable: [],
+      }),
+    );
+    const beforeToggle = selectReview(store.getState(), 'book-a')!;
+    const selectedBefore = { ...beforeToggle.selected };
+
+    // Try to toggle a key that was never in the ops
+    store.dispatch(
+      scriptReviewActions.toggleOp({
+        bookId: 'book-a',
+        key: 'nonexistent:99:strip_tag',
+      }),
+    );
+
+    // The nonexistent key should NOT be created; all existing keys untouched
+    const afterToggle = selectReview(store.getState(), 'book-a')!;
+    expect('nonexistent:99:strip_tag' in afterToggle.selected).toBe(false);
+    expect(afterToggle.selected).toEqual(selectedBefore);
+  });
 });

--- a/src/store/script-review-slice.test.ts
+++ b/src/store/script-review-slice.test.ts
@@ -24,10 +24,9 @@ type TestState = ReturnType<TestStore['getState']>;
 // Re-wire selectActiveReview against the test store's state shape.
 function selectReview(state: TestState, bookId: string) {
   // Cast: the test store has only scriptReview, which matches the key the
-  // selector reads. Use 'as any' to satisfy the full RootState type param
-  // without pulling in the real store (which has side-effects).
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return selectActiveReview(state as any, bookId);
+  // selector reads. Cast to satisfy the full RootState type param without
+  // pulling in the real store (which has side-effects).
+  return selectActiveReview(state as never, bookId);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/store/script-review-slice.test.ts
+++ b/src/store/script-review-slice.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import { configureStore } from '@reduxjs/toolkit';
+import {
+  scriptReviewSlice,
+  scriptReviewActions,
+  selectActiveReview,
+  opKey,
+  type ReviewOpWithChapter,
+} from './script-review-slice';
+
+// ---------------------------------------------------------------------------
+// Minimal test store — includes only scriptReview so tests don't depend on
+// the full store shape (avoids redux-persist / env complications).
+// ---------------------------------------------------------------------------
+function makeStore() {
+  return configureStore({
+    reducer: { scriptReview: scriptReviewSlice.reducer },
+  });
+}
+
+type TestStore = ReturnType<typeof makeStore>;
+type TestState = ReturnType<TestStore['getState']>;
+
+// Re-wire selectActiveReview against the test store's state shape.
+function selectReview(state: TestState, bookId: string) {
+  // Cast: the test store has only scriptReview, which matches the key the
+  // selector reads. Use 'as any' to satisfy the full RootState type param
+  // without pulling in the real store (which has side-effects).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return selectActiveReview(state as any, bookId);
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+const op1: ReviewOpWithChapter = {
+  id: 1,
+  op: 'strip_tag',
+  newText: 'Hello',
+  rationale: 'remove tag',
+  chapterId: 10,
+};
+const op2: ReviewOpWithChapter = {
+  id: 2,
+  op: 'fix_emotion',
+  emotion: 'angry',
+  rationale: 'wrong tone',
+  chapterId: 10,
+};
+const op3: ReviewOpWithChapter = {
+  id: 3,
+  op: 'strip_tag',
+  newText: 'World',
+  rationale: 'another tag',
+  chapterId: 11,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('scriptReviewSlice', () => {
+  it('setReview defaults all selected ON', () => {
+    const store = makeStore();
+    store.dispatch(
+      scriptReviewActions.setReview({
+        bookId: 'book-a',
+        ops: [op1, op2],
+        unappliable: [],
+      }),
+    );
+    const bucket = selectReview(store.getState(), 'book-a');
+    expect(bucket).toBeDefined();
+    expect(bucket!.selected[opKey(10, 1, 'strip_tag')]).toBe(true);
+    expect(bucket!.selected[opKey(10, 2, 'fix_emotion')]).toBe(true);
+    // Every key is true
+    expect(Object.values(bucket!.selected).every(Boolean)).toBe(true);
+  });
+
+  it('selectActiveReview returns only the requested book bucket', () => {
+    const store = makeStore();
+    store.dispatch(
+      scriptReviewActions.setReview({ bookId: 'book-a', ops: [op1], unappliable: [] }),
+    );
+    store.dispatch(
+      scriptReviewActions.setReview({ bookId: 'book-b', ops: [op2], unappliable: [] }),
+    );
+    const a = selectReview(store.getState(), 'book-a');
+    const b = selectReview(store.getState(), 'book-b');
+    expect(a!.ops).toHaveLength(1);
+    expect(a!.ops[0].id).toBe(1);
+    expect(b!.ops).toHaveLength(1);
+    expect(b!.ops[0].id).toBe(2);
+  });
+
+  it("a second book's setReview does NOT wipe the first book's bucket", () => {
+    const store = makeStore();
+    store.dispatch(
+      scriptReviewActions.setReview({ bookId: 'book-a', ops: [op1], unappliable: [] }),
+    );
+    store.dispatch(
+      scriptReviewActions.setReview({ bookId: 'book-b', ops: [op2], unappliable: [] }),
+    );
+    // book-a must still be intact
+    const a = selectReview(store.getState(), 'book-a');
+    expect(a).toBeDefined();
+    expect(a!.ops[0].id).toBe(1);
+  });
+
+  it('toggleClass flips all ops of one class and ONLY that class', () => {
+    const store = makeStore();
+    // op1 + op3 are both 'strip_tag'; op2 is 'fix_emotion'
+    store.dispatch(
+      scriptReviewActions.setReview({
+        bookId: 'book-a',
+        ops: [op1, op2, op3],
+        unappliable: [],
+      }),
+    );
+    // All start true. Toggle strip_tag → both should become false.
+    store.dispatch(scriptReviewActions.toggleClass({ bookId: 'book-a', op: 'strip_tag' }));
+    const after1 = selectReview(store.getState(), 'book-a')!;
+    expect(after1.selected[opKey(10, 1, 'strip_tag')]).toBe(false);
+    expect(after1.selected[opKey(11, 3, 'strip_tag')]).toBe(false);
+    // fix_emotion must remain true (different class)
+    expect(after1.selected[opKey(10, 2, 'fix_emotion')]).toBe(true);
+
+    // Toggle strip_tag again → both should become true again.
+    store.dispatch(scriptReviewActions.toggleClass({ bookId: 'book-a', op: 'strip_tag' }));
+    const after2 = selectReview(store.getState(), 'book-a')!;
+    expect(after2.selected[opKey(10, 1, 'strip_tag')]).toBe(true);
+    expect(after2.selected[opKey(11, 3, 'strip_tag')]).toBe(true);
+    expect(after2.selected[opKey(10, 2, 'fix_emotion')]).toBe(true);
+  });
+
+  it('toggleOp flips a single op without touching others', () => {
+    const store = makeStore();
+    store.dispatch(
+      scriptReviewActions.setReview({ bookId: 'book-a', ops: [op1, op2], unappliable: [] }),
+    );
+    const key1 = opKey(10, 1, 'strip_tag');
+    const key2 = opKey(10, 2, 'fix_emotion');
+    store.dispatch(scriptReviewActions.toggleOp({ bookId: 'book-a', key: key1 }));
+    const s = selectReview(store.getState(), 'book-a')!;
+    expect(s.selected[key1]).toBe(false);
+    expect(s.selected[key2]).toBe(true);
+  });
+
+  it('clearReview removes the book bucket', () => {
+    const store = makeStore();
+    store.dispatch(
+      scriptReviewActions.setReview({ bookId: 'book-a', ops: [op1], unappliable: [] }),
+    );
+    expect(selectReview(store.getState(), 'book-a')).toBeDefined();
+    store.dispatch(scriptReviewActions.clearReview({ bookId: 'book-a' }));
+    expect(selectReview(store.getState(), 'book-a')).toBeUndefined();
+  });
+});

--- a/src/store/script-review-slice.ts
+++ b/src/store/script-review-slice.ts
@@ -1,0 +1,97 @@
+/* Script-review suggestions slice — dedicated, non-polled, bookId-keyed.
+   MUST NOT be revisions.pending (that slice's applyPoll wholesale-replaces
+   `pending` and would wipe active suggestions). Each book's bucket is
+   independent so concurrent multi-book workflows coexist without collision.
+
+   Op key shape: `${chapterId}:${id}:${op}` — chapterId is not on the base
+   ReviewOp (it lives on the SSE envelope), so we define ReviewOpWithChapter
+   which extends ReviewOp with the chapter context. setReview expects
+   `ops: ReviewOpWithChapter[]` already tagged by the SSE consumer. */
+
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import type { ReviewOp } from '../lib/script-review-apply';
+import type { RootState } from './index';
+
+/** ReviewOp extended with the chapterId from the SSE `ops` event envelope. */
+export type ReviewOpWithChapter = ReviewOp & { chapterId: number };
+
+/** Serialise an op to its lookup key. */
+export function opKey(chapterId: number, id: number, op: string): string {
+  return `${chapterId}:${id}:${op}`;
+}
+
+export interface ScriptReviewBucket {
+  ops: ReviewOpWithChapter[];
+  unappliable: Array<{ op: ReviewOpWithChapter; reason: string }>;
+  /** Key = opKey(chapterId, id, op); value = whether this op is selected. */
+  selected: Record<string, boolean>;
+}
+
+export interface ScriptReviewState {
+  byBook: Record<string, ScriptReviewBucket | undefined>;
+}
+
+const initialState: ScriptReviewState = {
+  byBook: {},
+};
+
+export const scriptReviewSlice = createSlice({
+  name: 'scriptReview',
+  initialState,
+  reducers: {
+    /** Replace the full review bucket for one book; default ALL ops selected. */
+    setReview: (
+      s,
+      a: PayloadAction<{
+        bookId: string;
+        ops: ReviewOpWithChapter[];
+        unappliable: Array<{ op: ReviewOpWithChapter; reason: string }>;
+      }>,
+    ) => {
+      const { bookId, ops, unappliable } = a.payload;
+      const selected: Record<string, boolean> = {};
+      for (const o of ops) {
+        selected[opKey(o.chapterId, o.id, o.op)] = true;
+      }
+      s.byBook[bookId] = { ops, unappliable, selected };
+    },
+
+    /** Flip the selected state of one op by key. */
+    toggleOp: (s, a: PayloadAction<{ bookId: string; key: string }>) => {
+      const { bookId, key } = a.payload;
+      const bucket = s.byBook[bookId];
+      if (!bucket) return;
+      bucket.selected[key] = !bucket.selected[key];
+    },
+
+    /** Flip ALL ops of a given class (op.op value) for one book. When the
+        class is currently ALL selected → deselect all; otherwise → select all. */
+    toggleClass: (s, a: PayloadAction<{ bookId: string; op: ReviewOp['op'] }>) => {
+      const { bookId, op: opClass } = a.payload;
+      const bucket = s.byBook[bookId];
+      if (!bucket) return;
+      const classOps = bucket.ops.filter((o) => o.op === opClass);
+      const allSelected = classOps.every(
+        (o) => bucket.selected[opKey(o.chapterId, o.id, o.op)],
+      );
+      for (const o of classOps) {
+        bucket.selected[opKey(o.chapterId, o.id, o.op)] = !allSelected;
+      }
+    },
+
+    /** Remove one book's bucket entirely (e.g. on modal close / dismiss). */
+    clearReview: (s, a: PayloadAction<{ bookId: string }>) => {
+      delete s.byBook[a.payload.bookId];
+    },
+  },
+});
+
+export const scriptReviewActions = scriptReviewSlice.actions;
+
+/** Returns only the active book's bucket (or undefined). */
+export function selectActiveReview(
+  state: RootState,
+  bookId: string,
+): ScriptReviewBucket | undefined {
+  return state.scriptReview.byBook[bookId];
+}

--- a/src/store/script-review-slice.ts
+++ b/src/store/script-review-slice.ts
@@ -60,7 +60,7 @@ export const scriptReviewSlice = createSlice({
     toggleOp: (s, a: PayloadAction<{ bookId: string; key: string }>) => {
       const { bookId, key } = a.payload;
       const bucket = s.byBook[bookId];
-      if (!bucket) return;
+      if (!bucket || !(key in bucket.selected)) return;
       bucket.selected[key] = !bucket.selected[key];
     },
 

--- a/src/views/generation.test.tsx
+++ b/src/views/generation.test.tsx
@@ -1358,6 +1358,71 @@ describe('GenerationView — precise reassignment staleness via render map (#650
     renderWithRenderMap({ 1: { 1: 'narrator', 2: 'marlow', 3: 'marlow' } });
     expect(screen.queryByText(/Sentences reassigned/i)).toBeNull();
   });
+
+  it('shows the caption when the render map matches but a post-render boundary_move was logged (OR-gate fs-58)', () => {
+    /* The precise render-map diff returns false (characterIds unchanged), but a
+       boundary_move event was logged after audioRenderedAt — e.g. a strip_tag or
+       fix_emotion op that doesn't change which character speaks. The OR-gate
+       (Task 3) must catch this and mark the chapter stale. */
+    const RENDERED_PAST = '2020-01-01T00:00:00Z';
+    const doneWithStamp: Chapter = {
+      ...chapter1,
+      audioRenderedAt: RENDERED_PAST,
+    };
+    const store = configureStore({
+      reducer: {
+        ui: uiSlice.reducer,
+        chapters: chaptersSlice.reducer,
+        manuscript: manuscriptSlice.reducer,
+        changeLog: changeLogSlice.reducer,
+        cast: castSlice.reducer,
+        library: librarySlice.reducer,
+        queue: queueSlice.reducer,
+      },
+    });
+    /* Render map exactly matches current sentences → precise diff returns false. */
+    store.dispatch(
+      chaptersSlice.actions.hydrateFromBookState({
+        bookId: 'b1',
+        chapters: [
+          { id: 1, title: 'Chapter 1', slug: '01-a' },
+          { id: 2, title: 'Chapter 2', slug: '02-b' },
+        ],
+        completedSlugs: ['01-a'],
+        characters,
+        renderedSpeakersByChapter: { 1: { 1: 'narrator', 2: 'marlow', 3: 'marlow' } },
+      } as any),
+    );
+    store.dispatch(chaptersSlice.actions.setChapters([doneWithStamp, chapter2]));
+    store.dispatch(
+      manuscriptSlice.actions.hydrateFromAnalysis({
+        bookId: 'b1',
+        characters,
+        chapters: [doneWithStamp, chapter2],
+        sentences,
+      } as any),
+    );
+    /* A post-render boundary_move (e.g. from strip_tag / fix_emotion) that
+       doesn't change characterId assignments. */
+    store.dispatch(changeLogSlice.actions.bumpBoundaryMove({ chapterId: 1, count: 1 }));
+    render(
+      <Provider store={store}>
+        <HostedGenerationView
+          chapters={[doneWithStamp, chapter2]}
+          characters={characters}
+          paused
+          title="OR-gate Fixture"
+          bookId="b1"
+          modelKey="kokoro-v1"
+          onRegenerate={() => {}}
+          onRegenerateBook={() => {}}
+          onRegenerateCharacterInChapter={() => {}}
+          onPreview={() => {}}
+        />
+      </Provider>,
+    );
+    expect(screen.getByText(/Sentences reassigned · regenerate to refresh/i)).toBeInTheDocument();
+  });
 });
 
 describe('GenerationView — bulk Regenerate all drifted (plan 35 follow-up)', () => {

--- a/src/views/generation.tsx
+++ b/src/views/generation.tsx
@@ -1106,12 +1106,15 @@ export function GenerationView({
               onCancelSubset={handleCancelSubset}
               onRetrySubset={handleRetrySubset}
               stale={
-                /* Precise diff when the server shipped this chapter's render
-                   map (#650); otherwise the time-based change-log heuristic
-                   (Bug 2) so older servers / mocks still flag staleness. */
-                renderedSpeakersByChapter[ch.id]
-                  ? reassignedSinceRenderSet.has(ch.id)
-                  : isChapterStaleFromReassign(ch, activityEvents)
+                /* OR-gate (fs-58 Task 3): stale if the precise render-map diff
+                   flags a speaker change OR a post-render boundary_move was
+                   logged (covers text/emotion edits the characterId-only precise
+                   diff can't see — strip_tag / fix_emotion + the retained
+                   split/extract piece). Intentionally conservative: a
+                   move-then-undo still reads stale, trading that rare false
+                   positive for catching edits that don't change characterIds. */
+                (renderedSpeakersByChapter[ch.id] ? reassignedSinceRenderSet.has(ch.id) : false) ||
+                isChapterStaleFromReassign(ch, activityEvents)
               }
               subsetProgress={subsetByChapter[ch.id] ?? null}
               activeModelKey={modelKey}

--- a/src/views/low-confidence-nav.test.tsx
+++ b/src/views/low-confidence-nav.test.tsx
@@ -74,6 +74,7 @@ function makeStore(s: Sentence[]) {
         sentences: s,
         importCandidate: null,
         pendingReupload: null,
+        mergedAwayKeys: [],
       },
     },
   });

--- a/src/views/manuscript.test.tsx
+++ b/src/views/manuscript.test.tsx
@@ -20,6 +20,8 @@ import { changeLogSlice } from '../store/change-log-slice';
 import { tourSlice } from '../store/tour-slice';
 import { scriptReviewSlice } from '../store/script-review-slice';
 import { uiSlice } from '../store/ui-slice';
+import { notificationsSlice } from '../store/notifications-slice';
+import type { Toast } from '../store/notifications-slice';
 import { TOUR_STEPS } from '../lib/tour-steps';
 import { ManuscriptView } from './manuscript';
 import type { Chapter, Character, Sentence } from '../lib/types';
@@ -1094,5 +1096,89 @@ describe('ManuscriptView — script-review planApply quarantine at seed', () => 
       /* The stale op must be in unappliable. */
       expect(review.unappliable.some((u) => u.op.id === 999)).toBe(true);
     });
+  });
+});
+
+/* fs-58 — handleReviewScript error surface (Fix 2).
+   When api.reviewScript rejects, an error toast must be dispatched so
+   the user sees feedback rather than the button going silently dead.
+
+   The mock uses a controlled-resolution promise so the rejection fires
+   AFTER the component's async handler is already awaiting it — this
+   ensures the try/catch in handleReviewScript is the one that sees the
+   rejection (rather than vitest's global unhandled-rejection tracker
+   seeing a synchronously-thrown error from a mockRejectedValue call). */
+describe('ManuscriptView — handleReviewScript error toast', () => {
+  it('dispatches an error toast when api.reviewScript rejects', async () => {
+    const user = userEvent.setup();
+
+    /* Controlled promise: resolve/reject are captured so we can fire the
+       rejection after the component has started awaiting. */
+    let triggerReject!: (e: Error) => void;
+    reviewScript.mockImplementation(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          triggerReject = reject;
+        }),
+    );
+
+    const store = configureStore({
+      reducer: {
+        manuscript: manuscriptSlice.reducer,
+        notifications: notificationsSlice.reducer,
+        scriptReview: scriptReviewSlice.reducer,
+        changeLog: changeLogSlice.reducer,
+        ui: uiSlice.reducer,
+      },
+      preloadedState: {
+        ui: {
+          ...uiSlice.getInitialState(),
+          stage: {
+            kind: 'ready',
+            bookId: 'bk-err',
+            view: 'manuscript',
+            currentChapterId: 1,
+            openProfileId: null,
+          } as never,
+        },
+      },
+    });
+
+    const errChapter: Chapter = {
+      id: 1,
+      title: 'Chapter One',
+      duration: '10:00',
+      state: 'done',
+      progress: 1,
+      characters: {},
+    };
+
+    render(
+      <Provider store={store}>
+        <ManuscriptView
+          characters={characters}
+          chapters={[errChapter]}
+          currentChapterId={1}
+          setCurrentChapterId={() => {}}
+          sentencesFromStore={[]}
+        />
+      </Provider>,
+    );
+
+    /* Click the review button — the component starts awaiting the promise. */
+    await user.click(screen.getByTestId('review-script-chapter'));
+
+    /* Now reject the controlled promise so handleReviewScript's catch fires. */
+    triggerReject(new Error('Quota exceeded'));
+
+    await waitFor(() => {
+      const toasts: Toast[] = store.getState().notifications.toasts;
+      expect(toasts.some((t) => t.kind === 'error' && t.message.includes('Quota exceeded'))).toBe(
+        true,
+      );
+    });
+
+    /* Reset the mock so the next test run doesn't get a dangling promise. */
+    reviewScript.mockReset();
   });
 });

--- a/src/views/manuscript.test.tsx
+++ b/src/views/manuscript.test.tsx
@@ -490,6 +490,7 @@ describe('ManuscriptView — cross-chapter reassign isolation', () => {
           sentences: twoChapterSentences,
           importCandidate: null,
           pendingReupload: null,
+          mergedAwayKeys: [],
         },
       },
     });
@@ -585,6 +586,7 @@ describe('ManuscriptView — reassign picker (post-90 portal + dismissal polish)
           sentences: [sentence],
           importCandidate: null,
           pendingReupload: null,
+          mergedAwayKeys: [],
         },
       },
     });

--- a/src/views/manuscript.test.tsx
+++ b/src/views/manuscript.test.tsx
@@ -10,17 +10,26 @@
    Also covers the chapter-filter affordance added so a 500+ chapter book
    does not push the cast list off the bottom of the sidebar. */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { manuscriptSlice } from '../store/manuscript-slice';
 import { changeLogSlice } from '../store/change-log-slice';
 import { tourSlice } from '../store/tour-slice';
+import { scriptReviewSlice } from '../store/script-review-slice';
+import { uiSlice } from '../store/ui-slice';
 import { TOUR_STEPS } from '../lib/tour-steps';
 import { ManuscriptView } from './manuscript';
 import type { Chapter, Character, Sentence } from '../lib/types';
+
+/* fs-58 — api mock for reviewScript trigger tests. */
+const { reviewScript } = vi.hoisted(() => ({ reviewScript: vi.fn() }));
+vi.mock('../lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/api')>();
+  return { ...actual, api: { ...(actual as { api: object }).api, reviewScript } };
+});
 
 const characters: Character[] = [
   { id: 'narrator', name: 'Narrator', role: 'Narrator', color: 'narrator' },
@@ -920,5 +929,170 @@ describe('ManuscriptView — guided-tour demonstrations (fe-38)', () => {
     expect(screen.getAllByLabelText('Close inspector').length).toBeGreaterThan(0);
     /* The speaker dim is cleared on this step. */
     expect(screen.queryByTitle('Clear filter')).toBeNull();
+  });
+});
+
+/* fs-58 Task 11 — whole-book disclosure menu dismissal (Fix 2).
+   The ⌄ toggle opens a small popover; an outside pointerdown or Escape
+   must close it so it doesn't linger after the user clicks away. */
+describe('ManuscriptView — review-menu dismissal', () => {
+  const reviewChapter: Chapter = {
+    id: 1,
+    title: 'Chapter One',
+    duration: '10:00',
+    state: 'done',
+    progress: 1,
+    characters: {},
+  };
+
+  function renderReviewView() {
+    const store = configureStore({
+      reducer: {
+        manuscript: manuscriptSlice.reducer,
+        changeLog: changeLogSlice.reducer,
+        scriptReview: scriptReviewSlice.reducer,
+        ui: uiSlice.reducer,
+      },
+      preloadedState: {
+        ui: {
+          ...uiSlice.getInitialState(),
+          stage: {
+            kind: 'ready',
+            bookId: 'bk-menu',
+            view: 'manuscript',
+            currentChapterId: 1,
+            openProfileId: null,
+          } as never,
+        },
+      },
+    });
+    render(
+      <Provider store={store}>
+        <ManuscriptView
+          characters={characters}
+          chapters={[reviewChapter]}
+          currentChapterId={1}
+          setCurrentChapterId={() => {}}
+          sentencesFromStore={[]}
+        />
+      </Provider>,
+    );
+  }
+
+  it('dismisses the whole-book menu on Escape', async () => {
+    const user = userEvent.setup();
+    renderReviewView();
+
+    const toggle = screen.getByTestId('review-script-menu-toggle');
+    await user.click(toggle);
+    /* Menu must now be open. */
+    expect(screen.getByTestId('review-script-wholebook')).toBeInTheDocument();
+
+    /* Press Escape — menu must close. */
+    await user.keyboard('{Escape}');
+    expect(screen.queryByTestId('review-script-wholebook')).toBeNull();
+  });
+
+  it('dismisses the whole-book menu on outside pointerdown', async () => {
+    const user = userEvent.setup();
+    renderReviewView();
+
+    const toggle = screen.getByTestId('review-script-menu-toggle');
+    await user.click(toggle);
+    expect(screen.getByTestId('review-script-wholebook')).toBeInTheDocument();
+
+    /* Pointer-down on the document body (outside the menu wrapper). */
+    fireEvent.pointerDown(document.body);
+    expect(screen.queryByTestId('review-script-wholebook')).toBeNull();
+  });
+});
+
+/* fs-58 Task 11 — planApply quarantine at seed time (Fix 1).
+   When the SSE stream returns an op whose target id is NOT in the live
+   sentences, it must land in `unappliable` — NOT in the selectable `ops`
+   list — so the diff modal never presents a no-op to the user. */
+describe('ManuscriptView — script-review planApply quarantine at seed', () => {
+  beforeEach(() => reviewScript.mockReset());
+
+  const quarantineChapter: Chapter = {
+    id: 1,
+    title: 'Chapter One',
+    duration: '10:00',
+    state: 'done',
+    progress: 1,
+    characters: {},
+  };
+  const liveSentence: Sentence = { id: 1, chapterId: 1, characterId: 'narrator', text: 'Live line.' };
+
+  function makeQuarantineStore() {
+    return configureStore({
+      reducer: {
+        manuscript: manuscriptSlice.reducer,
+        changeLog: changeLogSlice.reducer,
+        scriptReview: scriptReviewSlice.reducer,
+        ui: uiSlice.reducer,
+      },
+      preloadedState: {
+        manuscript: {
+          ...manuscriptSlice.getInitialState(),
+          sentences: [liveSentence] as never,
+        },
+        ui: {
+          ...uiSlice.getInitialState(),
+          stage: {
+            kind: 'ready',
+            bookId: 'bk-1',
+            view: 'manuscript',
+            currentChapterId: 1,
+            openProfileId: null,
+          } as never,
+        },
+      },
+    });
+  }
+
+  it('seeds ops with only resolvable ops; stale-id op goes to unappliable', async () => {
+    const user = userEvent.setup();
+    const store = makeQuarantineStore();
+
+    /* Mock: stream returns one resolvable strip_tag (id=1) and one stale
+       fix_emotion (id=999, which does not exist in live sentences). */
+    reviewScript.mockImplementation(async (_bookId: string, opts?: { onOps?: (arg: { chapterId: number; ops: object[] }) => void }) => {
+      opts?.onOps?.({
+        chapterId: 1,
+        ops: [
+          { id: 1, op: 'strip_tag', newText: 'Live line fixed.', rationale: 'tag' },
+          { id: 999, op: 'fix_emotion', emotion: 'excited', rationale: 'stale' },
+        ],
+      });
+    });
+
+    render(
+      <Provider store={store}>
+        <ManuscriptView
+          characters={characters}
+          chapters={[quarantineChapter]}
+          currentChapterId={1}
+          setCurrentChapterId={() => {}}
+          sentencesFromStore={[liveSentence]}
+        />
+      </Provider>,
+    );
+
+    /* Trigger per-chapter review. */
+    await user.click(screen.getByTestId('review-script-chapter'));
+
+    /* Wait for the async handler to dispatch. */
+    await waitFor(() => {
+      const state = store.getState() as { scriptReview: { byBook: Record<string, { ops: { id: number }[]; unappliable: { op: { id: number } }[] }> } };
+      const review = state.scriptReview.byBook['bk-1'];
+      expect(review).toBeDefined();
+      /* The resolvable op (id=1) must be in ops. */
+      expect(review.ops.some((o) => o.id === 1)).toBe(true);
+      /* The stale op (id=999) must NOT be in ops. */
+      expect(review.ops.some((o) => o.id === 999)).toBe(false);
+      /* The stale op must be in unappliable. */
+      expect(review.unappliable.some((u) => u.op.id === 999)).toBe(true);
+    });
   });
 });

--- a/src/views/manuscript.tsx
+++ b/src/views/manuscript.tsx
@@ -35,6 +35,9 @@ import { uiActions } from '../store/ui-slice';
 import { RestructureChaptersButton } from '../components/restructure-chapters-button';
 import { DetectEmotionsButton } from '../components/detect-emotions-button';
 import { ManuscriptStickyStatsBar } from '../components/manuscript/sticky-stats-bar';
+import { ScriptReviewDiff } from '../components/script-review-diff';
+import { api } from '../lib/api';
+import { scriptReviewActions, selectActiveReview, type ReviewOpWithChapter } from '../store/script-review-slice';
 import type { Character, Chapter, Sentence, CharColor } from '../lib/types';
 import type { SeriesRosterEntry } from '../lib/api';
 
@@ -106,6 +109,11 @@ export function ManuscriptView({
   onAddFromSeriesRoster,
 }: Props) {
   const dispatch = useAppDispatch();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const bookId = useAppSelector((s) => ((s as any).ui?.stage as { bookId?: string } | undefined)?.bookId ?? null);
+  const [reviewLoading, setReviewLoading] = useState(false);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const hasActiveReview = useAppSelector((s) => !!(bookId && (s as any).scriptReview && selectActiveReview(s as any, bookId)));
   /* Sentences are the single source of truth in Redux. All edits go via
      dispatch(manuscriptActions.*) — no local copy. */
   const sentences: Sentence[] = sentencesFromStore ?? initialSentences;
@@ -610,11 +618,37 @@ export function ManuscriptView({
     />
   );
 
+  /* fs-58 — per-chapter LLM script-review trigger.
+     RPD note: each chapter call uses one Gemini RPD slot. The per-chapter
+     button is the default (not a whole-book sweep) to stay within free-tier
+     limits. Operators can override the model via the `model` opt. */
+  async function handleReviewScript() {
+    if (!bookId || reviewLoading || currentChapterId == null) return;
+    const allOps: ReviewOpWithChapter[] = [];
+    setReviewLoading(true);
+    try {
+      await api.reviewScript(bookId, {
+        chapterId: currentChapterId,
+        onOps: ({ chapterId: chId, ops }) => {
+          for (const op of ops) allOps.push({ ...op, chapterId: chId });
+        },
+      });
+      dispatch(scriptReviewActions.setReview({ bookId, ops: allOps, unappliable: [] }));
+    } catch {
+      // error surfaced via notifications elsewhere
+    } finally {
+      setReviewLoading(false);
+    }
+  }
+
   return (
     <div
       className="max-w-[1500px] mx-auto px-3 md:px-6 py-6 md:py-8 lg:grid lg:grid-cols-[280px_1fr_360px] lg:gap-6"
       ref={containerRef}
     >
+      {/* fs-58 — ScriptReviewDiff modal: fixed-overlay, renders null when no active review */}
+      {hasActiveReview && bookId && <ScriptReviewDiff bookId={bookId} />}
+
       {/* Desktop-only sticky sidebar (chapters + detected).
           Sidebar shell — flex column with no outer scroll. Each card owns
           its own internal scroll region (min-h-0 + overflow-y-auto on the
@@ -666,6 +700,14 @@ export function ManuscriptView({
                 onClick={() => dispatch(uiActions.changeView('restructure'))}
               />
               <DetectEmotionsButton disabled={sentences.length === 0} />
+              {/* fs-58 — per-chapter LLM script review trigger */}
+              <button
+                onClick={() => void handleReviewScript()}
+                disabled={reviewLoading || !bookId}
+                className="shrink-0 inline-flex items-center gap-2 px-4 min-h-[44px] sm:min-h-0 py-2 rounded-full border border-ink/20 bg-white text-ink text-sm font-semibold hover:bg-ink/5 disabled:opacity-50"
+              >
+                {reviewLoading ? 'Reviewing…' : 'Review Script'}
+              </button>
               {onStartGenerating && (
                 <button
                   onClick={onStartGenerating}

--- a/src/views/manuscript.tsx
+++ b/src/views/manuscript.tsx
@@ -38,6 +38,7 @@ import { ManuscriptStickyStatsBar } from '../components/manuscript/sticky-stats-
 import { ScriptReviewDiff } from '../components/script-review-diff';
 import { api } from '../lib/api';
 import { scriptReviewActions, selectActiveReview, type ReviewOpWithChapter } from '../store/script-review-slice';
+import { notificationsActions } from '../store/notifications-slice';
 import { rpdWarningFor, planApply } from '../lib/script-review-apply';
 import type { Character, Chapter, Sentence, CharColor } from '../lib/types';
 import type { SeriesRosterEntry } from '../lib/api';
@@ -702,8 +703,13 @@ export function ManuscriptView({
         unappliable: Array<{ op: ReviewOpWithChapter; reason: string }>;
       };
       dispatch(scriptReviewActions.setReview({ bookId, ops: appliable, unappliable }));
-    } catch {
-      // error surfaced via notifications elsewhere
+    } catch (err) {
+      dispatch(
+        notificationsActions.pushToast({
+          kind: 'error',
+          message: err instanceof Error ? err.message : 'Script review failed.',
+        }),
+      );
     } finally {
       setReviewLoading(false);
     }

--- a/src/views/manuscript.tsx
+++ b/src/views/manuscript.tsx
@@ -38,14 +38,13 @@ import { ManuscriptStickyStatsBar } from '../components/manuscript/sticky-stats-
 import { ScriptReviewDiff } from '../components/script-review-diff';
 import { api } from '../lib/api';
 import { scriptReviewActions, selectActiveReview, type ReviewOpWithChapter } from '../store/script-review-slice';
-import { rpdWarningFor } from '../lib/script-review-apply';
+import { rpdWarningFor, planApply } from '../lib/script-review-apply';
 import type { Character, Chapter, Sentence, CharColor } from '../lib/types';
 import type { SeriesRosterEntry } from '../lib/api';
 
-/* fs-58 — default per-run script-review model. Unit A has no persisted
-   review-model knob, so the trigger passes the server free-tier default
-   (mirrors server/.env GEMINI_MODEL). Used both for the per-run `model`
-   opt and to compute the whole-book RPD warning. */
+/* fs-58 — Unit-A per-run default model. No persisted model-picker knob in
+   Unit A; a per-run local-model option is deferred to srv-48. Used both for
+   the per-run `model` opt and to compute the whole-book RPD warning. */
 const REVIEW_MODEL = 'gemma-4-31b-it';
 
 interface Props {
@@ -122,11 +121,17 @@ export function ManuscriptView({
   /* fs-58 — whole-book opt-in is gated behind a small disclosure so the
      per-chapter "Review Script" stays the primary, low-cost default. */
   const [reviewMenuOpen, setReviewMenuOpen] = useState(false);
+  const reviewMenuRef = useRef<HTMLDivElement>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const hasActiveReview = useAppSelector((s) => !!(bookId && (s as any).scriptReview && selectActiveReview(s as any, bookId)));
   /* Sentences are the single source of truth in Redux. All edits go via
      dispatch(manuscriptActions.*) — no local copy. */
   const sentences: Sentence[] = sentencesFromStore ?? initialSentences;
+  /* Keep a ref so async handlers (e.g. handleReviewScript) always read
+     the LIVE sentences even after an await, without depending on a
+     potentially stale closure. */
+  const sentencesRef = useRef<Sentence[]>(sentences);
+  sentencesRef.current = sentences;
   const [selectedSeg, setSelectedSeg] = useState<string | null>(null);
   const [filterChar, setFilterChar] = useState<string | null>(null);
   const [chapterFilter, setChapterFilter] = useState<string>('');
@@ -175,6 +180,27 @@ export function ManuscriptView({
       el.scrollIntoView({ block: 'nearest' });
     }
   }, [currentChapterId]);
+
+  /* fs-58 — dismiss the review-scope disclosure on outside-click (pointerdown)
+     or Escape. Mirrors the NavDrawer / HelpMenu pattern in top-bar.tsx. */
+  useEffect(() => {
+    if (!reviewMenuOpen) return;
+    function onDocPointerDown(e: PointerEvent) {
+      const t = e.target as Node | null;
+      if (!t) return;
+      if (reviewMenuRef.current?.contains(t)) return;
+      setReviewMenuOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setReviewMenuOpen(false);
+    }
+    document.addEventListener('pointerdown', onDocPointerDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('pointerdown', onDocPointerDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [reviewMenuOpen]);
 
   /* Segments are scoped to the currently-selected chapter so the manuscript
      view shows only sentences from that chapter — clicking a chapter in
@@ -654,7 +680,28 @@ export function ManuscriptView({
           for (const op of ops) allOps.push({ ...op, chapterId: chId });
         },
       });
-      dispatch(scriptReviewActions.setReview({ bookId, ops: allOps, unappliable: [] }));
+      /* fs-58 Task 11 — run planApply at seed time so ops that can't be
+         resolved against the LIVE sentences (stale ids, missing anchors,
+         invalid merges) land in `unappliable` rather than appearing as
+         selectable no-ops in the diff modal. The Apply-time planApply in
+         the modal stays — it's the TOCTOU re-validation for any edits
+         that arrived between stream-complete and the user clicking Accept.
+         sentencesRef.current gives the latest Redux value even after the
+         await, without depending on the stale-closure capture. */
+      const live = sentencesRef.current.map((s) => ({
+        id: s.id,
+        chapterId: s.chapterId,
+        text: s.text,
+        characterId: s.characterId,
+      }));
+      /* planApply filters from allOps whose entries are ReviewOpWithChapter —
+         the chapterId is preserved on each returned object at runtime, so
+         casting back to the wider type is safe here. */
+      const { appliable, unappliable } = planApply(allOps, live) as {
+        appliable: ReviewOpWithChapter[];
+        unappliable: Array<{ op: ReviewOpWithChapter; reason: string }>;
+      };
+      dispatch(scriptReviewActions.setReview({ bookId, ops: appliable, unappliable }));
     } catch {
       // error surfaced via notifications elsewhere
     } finally {
@@ -725,7 +772,7 @@ export function ManuscriptView({
                   (low-cost default); the ⌄ disclosure opens the whole-book
                   opt-in, which is RPD-gated when the book is longer than the
                   selected model's daily cap. */}
-              <div className="relative shrink-0 inline-flex items-stretch">
+              <div ref={reviewMenuRef} className="relative shrink-0 inline-flex items-stretch">
                 <button
                   data-testid="review-script-chapter"
                   onClick={() => void handleReviewScript(false)}

--- a/src/views/manuscript.tsx
+++ b/src/views/manuscript.tsx
@@ -38,8 +38,15 @@ import { ManuscriptStickyStatsBar } from '../components/manuscript/sticky-stats-
 import { ScriptReviewDiff } from '../components/script-review-diff';
 import { api } from '../lib/api';
 import { scriptReviewActions, selectActiveReview, type ReviewOpWithChapter } from '../store/script-review-slice';
+import { rpdWarningFor } from '../lib/script-review-apply';
 import type { Character, Chapter, Sentence, CharColor } from '../lib/types';
 import type { SeriesRosterEntry } from '../lib/api';
+
+/* fs-58 — default per-run script-review model. Unit A has no persisted
+   review-model knob, so the trigger passes the server free-tier default
+   (mirrors server/.env GEMINI_MODEL). Used both for the per-run `model`
+   opt and to compute the whole-book RPD warning. */
+const REVIEW_MODEL = 'gemma-4-31b-it';
 
 interface Props {
   characters: Character[];
@@ -112,6 +119,9 @@ export function ManuscriptView({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const bookId = useAppSelector((s) => ((s as any).ui?.stage as { bookId?: string } | undefined)?.bookId ?? null);
   const [reviewLoading, setReviewLoading] = useState(false);
+  /* fs-58 — whole-book opt-in is gated behind a small disclosure so the
+     per-chapter "Review Script" stays the primary, low-cost default. */
+  const [reviewMenuOpen, setReviewMenuOpen] = useState(false);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const hasActiveReview = useAppSelector((s) => !!(bookId && (s as any).scriptReview && selectActiveReview(s as any, bookId)));
   /* Sentences are the single source of truth in Redux. All edits go via
@@ -618,17 +628,28 @@ export function ManuscriptView({
     />
   );
 
-  /* fs-58 — per-chapter LLM script-review trigger.
-     RPD note: each chapter call uses one Gemini RPD slot. The per-chapter
-     button is the default (not a whole-book sweep) to stay within free-tier
-     limits. Operators can override the model via the `model` opt. */
-  async function handleReviewScript() {
-    if (!bookId || reviewLoading || currentChapterId == null) return;
+  /* fs-58 — LLM script-review trigger. The model is per-run in Unit A (no
+     persisted knob); we pass the server free-tier default so the RPD warning
+     can reason about quota. Per-chapter (the default) uses one request; a
+     whole-book sweep fires one request per chapter, so the RPD warning below
+     gates it when the book is longer than the model's daily cap. */
+  const reviewModel = REVIEW_MODEL;
+  /* Non-excluded chapters are the ones a whole-book sweep would actually hit
+     (excluded chapters never reach the analyzer). */
+  const reviewableChapterCount = chapters.filter((c) => !c.excluded).length;
+  const rpdWarning = rpdWarningFor(reviewableChapterCount, reviewModel);
+
+  async function handleReviewScript(wholeBook: boolean) {
+    if (!bookId || reviewLoading) return;
+    if (!wholeBook && currentChapterId == null) return;
     const allOps: ReviewOpWithChapter[] = [];
     setReviewLoading(true);
+    setReviewMenuOpen(false);
     try {
       await api.reviewScript(bookId, {
-        chapterId: currentChapterId,
+        /* Omitting chapterId reviews every (non-excluded) chapter server-side. */
+        ...(wholeBook ? {} : { chapterId: currentChapterId ?? undefined }),
+        model: reviewModel,
         onOps: ({ chapterId: chId, ops }) => {
           for (const op of ops) allOps.push({ ...op, chapterId: chId });
         },
@@ -700,14 +721,59 @@ export function ManuscriptView({
                 onClick={() => dispatch(uiActions.changeView('restructure'))}
               />
               <DetectEmotionsButton disabled={sentences.length === 0} />
-              {/* fs-58 — per-chapter LLM script review trigger */}
-              <button
-                onClick={() => void handleReviewScript()}
-                disabled={reviewLoading || !bookId}
-                className="shrink-0 inline-flex items-center gap-2 px-4 min-h-[44px] sm:min-h-0 py-2 rounded-full border border-ink/20 bg-white text-ink text-sm font-semibold hover:bg-ink/5 disabled:opacity-50"
-              >
-                {reviewLoading ? 'Reviewing…' : 'Review Script'}
-              </button>
+              {/* fs-58 — LLM script-review trigger. Primary = per-chapter
+                  (low-cost default); the ⌄ disclosure opens the whole-book
+                  opt-in, which is RPD-gated when the book is longer than the
+                  selected model's daily cap. */}
+              <div className="relative shrink-0 inline-flex items-stretch">
+                <button
+                  data-testid="review-script-chapter"
+                  onClick={() => void handleReviewScript(false)}
+                  disabled={reviewLoading || !bookId}
+                  className="inline-flex items-center gap-2 px-4 min-h-[44px] sm:min-h-0 py-2 rounded-l-full border border-ink/20 bg-white text-ink text-sm font-semibold hover:bg-ink/5 disabled:opacity-50"
+                >
+                  {reviewLoading ? 'Reviewing…' : 'Review Script'}
+                </button>
+                <button
+                  data-testid="review-script-menu-toggle"
+                  onClick={() => setReviewMenuOpen((o) => !o)}
+                  disabled={reviewLoading || !bookId}
+                  aria-label="Script review options"
+                  aria-expanded={reviewMenuOpen}
+                  className="inline-flex items-center justify-center px-2 min-h-[44px] sm:min-h-0 py-2 rounded-r-full border border-l-0 border-ink/20 bg-white text-ink/60 hover:bg-ink/5 hover:text-ink disabled:opacity-50"
+                >
+                  <IconArrowDn className="w-4 h-4" />
+                </button>
+                {reviewMenuOpen && (
+                  <div className="absolute top-full left-0 mt-2 z-20 w-72 rounded-2xl border border-ink/10 bg-white shadow-float p-3 space-y-2">
+                    <p className="text-[11px] uppercase tracking-wider font-semibold text-ink/50">
+                      Review scope
+                    </p>
+                    <button
+                      data-testid="review-script-wholebook"
+                      onClick={() => void handleReviewScript(true)}
+                      disabled={reviewLoading || !bookId}
+                      className="w-full text-left px-3 min-h-[44px] sm:min-h-0 py-2 rounded-xl hover:bg-ink/5 text-sm font-medium text-ink disabled:opacity-50"
+                    >
+                      Review whole book
+                      <span className="block text-xs font-normal text-ink/50">
+                        {reviewableChapterCount} chapter
+                        {reviewableChapterCount === 1 ? '' : 's'}
+                      </span>
+                    </button>
+                    {rpdWarning && (
+                      <p
+                        data-testid="review-script-rpd-warning"
+                        className="text-xs text-magenta leading-relaxed px-1"
+                      >
+                        This book has {rpdWarning.chapterCount} chapters; the
+                        selected model allows only {rpdWarning.rpd} reviews/day —
+                        switch to a local model or review per chapter.
+                      </p>
+                    )}
+                  </div>
+                )}
+              </div>
               {onStartGenerating && (
                 <button
                   onClick={onStartGenerating}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
-    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'skills/**/*.test.ts'],
     /* `vitest run --changed <base>` (CI cost round 2 — verify.yml frontend leg)
        narrows the run to tests whose module graph touches the diff. The setup
        file is injected by the runner, NOT imported by any test, so a change to


### PR DESCRIPTION
## Summary

fs-58 **LLM Script Review (Unit A)** — an operator-triggered, per-chapter, **read-only** LLM pass that proposes annotation repairs and applies the accepted ones **client-side** by dispatching the existing manual-edit Redux reducers. Engine-agnostic (analyzer Ollama/Gemini only — no TTS engine load).

The review pass mirrors fs-33's `runEmotionChapter` (a per-chapter analyzer call over already-attributed sentences) but writes **no manuscript state** — it streams suggestions over SSE. Accepted suggestions are applied in the browser; apply inherits the existing ID-allocation + debounced persistence. Audio staleness is signalled the way manual edits already do it: every accepted op emits a `boundary_move`, and the Generate-view stale gate is widened so a post-render `boundary_move` marks a rendered chapter stale even when a precise render-map exists.

**Five error classes (Unit A):**
- `strip_tag` — strip a stray attribution tag from a dialogue line (new `setSentenceText` reducer).
- `split` — split a sentence spanning two speakers (existing `splitSentence`, anchor → offset at accept).
- `extract_dialogue` — pull a dialogue span out of a narrator run (two-anchor → 3 pieces narrator│dialogue│narrator).
- `merge` — re-join adjacent same-speaker narrator sentences (new `mergeSentences` reducer + a persisted, book-scoped tombstone so a later re-analysis can't resurrect the merged-away id).
- `fix_emotion` — correct a clearly-wrong per-quote emotion (existing `setSentenceEmotion`).

**Operator UX:** a "Review Script" button on the manuscript view — per-chapter by default; a whole-book opt-in that warns when the book's chapter count exceeds the selected model's free-tier RPD cap (mirrored from `rate-limit.ts`: Gemini flash = 20/day, flash-lite = 500, gemma-4 = 1500; local models uncapped). Results open in a `ScriptReviewDiff` modal (DriftReport accept-reject pattern) grouped by class with per-class + per-change toggles, all pre-selected ON. Suggestions live in a dedicated, **non-polled, bookId-keyed** slice (not `revisions.pending`, which a poll would wipe) so the concurrent-multi-book invariant holds.

**Correctness guards:**
- **TOCTOU** — anchors are resolved **client-side at accept time** against live sentence text (one-pass original→normalized index map, NFC + quote/dash/ellipsis folds, no whitespace collapse → exact offsets). `planApply` re-validates every accepted op against the live manuscript immediately before dispatch (structural ops first; rejects consumed-id field edits, a 2nd structural op on one id, non-resolving anchors, non-adjacent/cross-character merges, invalid emotion values).
- **Merge tombstone persistence** — `mergedAwayKeys` round-trips through the book-state GET/PUT and is carried by **every** manuscript persistence rule, so a sentence edit dispatched after a merge in the same debounce window can't drop the tombstone off disk.

## What's new (operator / user / dev visible)

**Frontend**
- New `setSentenceText` + `mergeSentences` reducers + a persisted, book-scoped merge tombstone (`mergedAwayKeys`).
- Generate-view stale gate widened to `precise || boundary_move` (now catches text/emotion edits the characterId-only diff missed — a latent gap for manual `fix_emotion`/text edits too).
- `src/lib/script-review-apply.ts` — anchor resolver + `planApply` (op validation/ordering) + `dispatchAcceptedOps` (maps each class to its reducer, emits `boundary_move` per op).
- `api.reviewScript` SSE client (real + mock).
- Dedicated `script-review-slice` (non-polled, bookId-keyed) + `ScriptReviewDiff` modal + the "Review Script" trigger with the whole-book RPD warning.

**Server**
- `runScriptReviewChapter` on the `Analyzer` interface + Ollama/Gemini impls + `FallbackAnalyzer` delegation.
- `scriptReviewSchema` flat envelope (`server/src/handoff/schemas.ts`); `prompt.scriptReview` registry knob; `skills/audiobook-script-review.md` prompt (with the verbatim vocalization-protection clause + an M5 snapshot guard).
- `POST /api/books/:bookId/script-review` SSE endpoint (optional `chapterId`; over-budget chapters emit `chapter-failed` and continue; chunk-with-overlap deferred with a code comment).
- `openapi.yaml` path transcribed **and `api-types.ts` regenerated** (the branch had added the path to the spec without regenerating; the regen is additive — 0 deletions — and brings the generated file back in sync).
- **srv-51 (#1045)** — the SSE error guard now distinguishes `no_such_chapter` (book is analysed, requested `chapterId` matched no attributed chapter) from `no_attribution` (book never analysed), naming the requested id in the message.

**Governance** (Closes #998): #998 rewritten to Unit A scope (needs-plan dropped); filed #1040 (Unit B: `reattribute` + `flag_nonstory`) and #1041 (`validate_instruct`, blocked on fs-56); cross-linked #996 (fs-56) and #721 (fs-44 server-apply dependency); BACKLOG re-scoped.

## Test plan

`npm run verify` (typecheck + all tests + e2e + build) green on the rebased branch. New automated coverage, paired to each behaviour:
- **Reducers** — `setSentenceText`; `mergeSentences` (merge into lowest id, tombstone, re-analysis-survival via a `manuscriptId`-seeded scaffold so the merge/append branch is actually exercised).
- **Tombstone persistence** — `hydrateFromBookState` book-scoping; server PUT→GET round-trip; a batch-ordering regression (a `setSentenceText` after a `mergeSentences` in one debounce window still persists `mergedAwayKeys`).
- **Stale gate** — a rendered chapter with a matching render map + a post-render `boundary_move` reads stale (isolates the new OR branch).
- **Anchor resolver / planApply** — exact-offset across quote/dash normalization; non-unique/absent anchor → unappliable; TOCTOU; two-anchor extract (valid + invalid `anchorEnd`); consumed-id rejection; overlapping-merge rejection; invalid-emotion rejection.
- **Apply wiring** — all 5 classes dispatch the right reducer against a real store (split offspring id = global max+1); `onBoundaryMove` fires once per applied op and not on a skipped op.
- **Schema** — heterogeneous parse incl. `extract_dialogue` with `anchor`+`anchorEnd`; unknown-op reject; `{ops:[]}` ("no suggestions") accepted; strict on both levels.
- **Analyzer** — fallback delegation (LocalUnreachable → fall back; AnalysisAborted → rethrow); Ollama+Gemini impls return parsed ops + write the handoff; M5 vocalization-clause snapshot.
- **Endpoint** — SSE `ops`+`result`; `chapterId` limits to one chapter; over-budget chapter emits `chapter-failed` and continues.
- **api client** — SSE stream parse → `onOps`; registered in both real/mock.
- **Slice** — book-scoped (a second book's `setReview` doesn't wipe the first); `toggleClass`/`toggleOp` cross-book isolation; unknown-key guard.
- **Modal** — toggle off → Apply dispatches only kept ops, fires `bumpBoundaryMove`, clears the review; `rpdWarningFor` (warns over cap, quiet at/under, silent for local/unknown).
- **E2E (Playwright)** — per-chapter trigger → modal → accept → sentence updates → Generate shows the stale badge; responsive coverage case across viewports.

A final whole-branch review (opus) caught one bug the unit tests + mock had masked — the skill prompt documented the op `id` as a sequential counter while the apply path uses it as the target `sentenceId`; fixed prompt-side (the apply code was correct) and pinned with a snapshot. It also flagged the silent error catch (now surfaces a toast) and the unrendered `unappliable` bucket (now shows a "couldn't be applied" notice).

## Follow-ups (filed)

- **#1040** — fs-58 Unit B (`reattribute` + `flag_nonstory`).
- **#1041** — `validate_instruct` Script Review class (blocked on fs-56).
- **#1046** — extract the shared `loadPostFoldSentencesByChapter` helper (currently copied from annotate-emotion).
- Persisting suggestions across reload, and a per-run review-model picker (srv-48), remain deferred per the spec's non-goals.

Spec: `docs/superpowers/specs/2026-06-23-fs58-llm-script-review-design.md` · plan: `docs/superpowers/plans/2026-06-23-fs58-script-review-unit-a.md`. No `docs/features/` regression plan owed — the superpowers spec + paired tests are the spec.

Closes #998
Closes #1045

🤖 Generated with [Claude Code](https://claude.com/claude-code)


