### PR TITLE
fix(server): add @types/cookie devDependency so the server typechecks

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -26,6 +26,7 @@
         "zod": "^4.0.0"
       },
       "devDependencies": {
+        "@types/cookie": "^0.6.0",
         "@types/express": "^5.0.0",
         "@types/multer": "^2.1.0",
         "@types/node": "^20.12.7",
@@ -1762,6 +1763,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",

--- a/server/package.json
+++ b/server/package.json
@@ -33,6 +33,7 @@
     "zod": "^4.0.0"
   },
   "devDependencies": {
+    "@types/cookie": "^0.6.0",
     "@types/express": "^5.0.0",
     "@types/multer": "^2.1.0",
     "@types/node": "^20.12.7",


### PR DESCRIPTION
## Summary

`server/src/lan-auth.ts` imports `parse` from `cookie` (`^0.7.2`), but `cookie@0.7.x` ships no bundled type declarations and `@types/cookie` was never declared, so `tsc --noEmit` failed with `TS7016` ("Could not find a declaration file for module 'cookie'"). This is a pre-existing breakage on `main` — uncaught because CI is opt-in and the local pre-push hook was bypassed when `lan-auth` landed. Adds `@types/cookie@^0.6.0` (the DefinitelyTyped package matching `cookie` 0.x) to the server devDependencies.

Discovered while finishing srv/#1028: the #1028 branch's pre-push `verify` couldn't go green until `main` typechecked again, so this lands first as a standalone prerequisite.

## Test plan

- `cd server && npm run typecheck` — was red (`TS7016` on `lan-auth.ts`), now green.
- Full `npm run verify` battery (typecheck + all tests + e2e + build) passed on push.
- Types-only devDependency — zero runtime impact.
