### PR TITLE
feat(server): localize minor-cast fold + roster guard for es/ru/fr/de (#1050, #1051)

### DIFF
--- a/docs/superpowers/plans/2026-06-24-es-ru-fr-de-analyzer-heuristic-localization.md
+++ b/docs/superpowers/plans/2026-06-24-es-ru-fr-de-analyzer-heuristic-localization.md
@@ -1,0 +1,1194 @@
+# es/ru/fr/de Analyzer-Heuristic Localization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Localize two English-only analyzer heuristics — the minor-cast descriptor fold (`isDescriptorName`, #1050) and the roster-coverage guard (#1051) — for es/ru/fr/de, reusing the `tag-grammar.ts` substrate from #1028/#1049.
+
+**Architecture:** A new sibling module `descriptor-grammar.ts` holds per-language descriptor data (Unit A); `tag-grammar.ts` gains a per-order regex **array** model plus fr/de rows, German titles, and wider quote glyphs (Unit B). The roster guard drops its `isNonEnglish` gate for a `grammarFor()` null-guard and scans body text with the grammar's regexes. English behavior is byte-identical throughout; es/ru/fr/de behavior intentionally changes.
+
+**Tech Stack:** TypeScript (Node 20.x, ESM, `.js` import specifiers), Vitest (node env), the existing `server/src/analyzer/` modules.
+
+**Spec:** `docs/superpowers/specs/2026-06-24-es-ru-fr-de-analyzer-heuristic-localization-design.md` (carries two folded-in adversarial-review rounds; every guard below traces to a finding there).
+
+## Global Constraints
+
+- **Node 20.x runtime** — NO ES2025-only regex features. Duplicate named capture groups (`(?<name>…|…)`) are a SyntaxError; never use them (finding A).
+- **English byte-identical** — the `en` code paths and existing English test assertions must not change. Passing no `language` defaults to `'en'`. `EN_NAME` keeps the curly apostrophe `'` (U+2019).
+- **Unmapped languages stay gated** — any language without a grammar row resolves `grammarFor()` / `descriptorGrammarFor()` → `null` → no-op (the gate moves, it doesn't vanish).
+- **No `--no-verify`** — every commit goes through the husky gate. Docs/scoped commits skip the test legs automatically.
+- **Inclusion-biased word lists** — a missing verb/noun silently drops a real speaker; an over-broad one is filtered downstream. Bias toward adding.
+- **`.js` import specifiers** in all TypeScript imports (ESM/NodeNext).
+- **Function-word fold rule is ru-only** (finding B) — es/fr/de carry empty `functionWords`; never add Romance/German nobiliary particles (`de`, `del`, `du`, `des`, `von`) to a fold list.
+- **Both-orders detection is an ARRAY of regexes, never a single alternation** (finding A); the name stays capture group 1 in each.
+
+## Plan review (round 1) — findings folded in
+
+| # | Severity | Finding | Resolved in |
+|---|---|---|---|
+| P-1 | 🔴 | Widening `QUOTE_CHARS` in place breaks English byte-identity (the guard's adjacency window runs for `en` too; em-dashes are common in English prose). | Task 6 §4 — narrow `QUOTE_CHARS` (en) + `QUOTE_CHARS_WIDE` (es/ru/fr/de), selected by `normaliseBookLanguage(language)`. |
+| P-2 | 🟠 | `validateAttributionCoverage` changes were described, not shown (different id-keyed map). | Task 6 §3.4 — explicit full code. |
+| P-3 | 🟡 | `tagScanRegexesFor` flag handling could duplicate a flag. | Task 3 — `replace(/[gm]/g, '')`. |
+| P-4 | 🟡 | en `verbBeatRegexFor` gains a `u` flag; a flags/source assertion could trip. | Task 3 §5 note. |
+| P-5 | 🟡 | Task 2 re-export could throw TS2484. | Task 2 §2 — `import … ; export { … };` clean form. |
+| P-6 | 🟡 | FR `s’exclama` curly apostrophe; DE `fuhr` weak verb. | Task 5 §3 note. |
+
+## Plan review (round 2) — findings folded in
+
+| # | Severity | Finding | Resolved in |
+|---|---|---|---|
+| R-1 | 🟠 | `validateAttributionCoverage` is modified (P-2) but its `de` gate test is deleted with no localized replacement — modified code with zero localized tests. | Task 6 §1.2 — es/ru half-state tests added. |
+| R-2 | 🟡 | Test snippets re-`import` overlapping symbols → duplicate-import compile error if pasted literally. | "Test-snippet imports" note + inline reminders. |
+| R-3 | 🟡 | Task 2 note could lead to wrongly deleting `normaliseBookLanguage` (still used by `bucketName`). | Task 2 §4 — explicit "keep it". |
+| R-4 | 🟡 | `tagScanRegexesFor` (incl. P-3 flag manip) shipped untested in Task 3. | Task 3 §5 — direct assertion. |
+
+---
+
+## File Structure
+
+| File | Responsibility | Tasks |
+|---|---|---|
+| `server/src/analyzer/descriptor-grammar.ts` | **NEW.** Per-language descriptor data (es/ru/fr/de extras) + `isDescriptorName` matcher (English baseline universal). | 1 |
+| `server/src/analyzer/descriptor-grammar.test.ts` | **NEW.** Matcher + per-language unit tests. | 1 |
+| `server/src/analyzer/fold-minor-cast.ts` | Re-export `isDescriptorName` from the new module; delete the inline `GENERIC_ROLE_TAIL`/`GENERIC_ROLE_RU`/`RU_FUNCTION_WORDS` + matcher. | 2 |
+| `server/src/analyzer/tag-grammar.ts` | `orders[]`, `tagRegexesFor`/`tagScanRegexesFor` array model, remove `tagRegexFor`, multi-order `verbBeatRegexFor` w/ Unicode boundaries, fr/de rows, German `titles` + title-skip, `QUOTE_GLYPHS` += U+201E. | 3,4,5 |
+| `server/src/analyzer/recover-tagged-lines.ts` | Consumers loop over the regex array (3 `m[1]` sites). | 3,7 |
+| `server/src/analyzer/roster-coverage.ts` | Gate swap, grammar-driven array body-scan w/ per-position dedupe, widened `QUOTE_CHARS`, stopword union, remove `isNonEnglish` import. | 6 |
+| `server/src/routes/analysis.ts` | **Verify-only** — language threading to the guard + both `foldMinorCast` passes. | 8 |
+| Test files | `fold-minor-cast.test.ts`, `tag-grammar.test.ts`, `roster-coverage.test.ts`, `recover-tagged-lines.test.ts`. | 2,4,5,6,7 |
+
+**Implementation order:** Unit A (Tasks 1–2) lands before Unit B (Tasks 3–8) — the fold is Unit B's fr/de safety net (finding B / full-parity). Within Unit B, Task 3 (array refactor, behavior-preserving) precedes the behavior changes (4–5) and the guard (6).
+
+**How to run the tests:** the server suite runs from the repo root: `npm run test:server -- <path>` (Vitest single-run). For one file: `npm run test:server -- server/src/analyzer/descriptor-grammar.test.ts`. For one test by name add `-t "<name>"`.
+
+**Test-snippet imports (R-2):** the `import { … } from './tag-grammar.js'` lines shown inside test snippets below are illustrative of the symbols each block needs. When adding a block to an **existing** test file (`tag-grammar.test.ts`, `recover-tagged-lines.test.ts`, etc.), **merge the missing symbols into the file's existing top-level import** — do NOT paste a second `import` statement for a symbol already imported, or TypeScript/ESLint will reject the duplicate. The `capturesName` helper introduced in Task 4 likewise lives once at the top of `tag-grammar.test.ts` and is reused by Task 5.
+
+---
+
+## Task 1: `descriptor-grammar.ts` — data + matcher (Unit A core, #1050)
+
+**Files:**
+- Create: `server/src/analyzer/descriptor-grammar.ts`
+- Test: `server/src/analyzer/descriptor-grammar.test.ts`
+
+**Interfaces:**
+- Consumes: `normaliseBookLanguage` from `../tts/language.js`.
+- Produces:
+  - `interface DescriptorGrammar { articles: ReadonlySet<string>; genericNouns: ReadonlySet<string>; nounMatch: 'bare' | 'trailing' | 'both'; functionWords: ReadonlySet<string> }`
+  - `descriptorGrammarFor(language?: string): DescriptorGrammar | null` — returns **extras** for es/ru/fr/de; `null` for en + unmapped.
+  - `isDescriptorName(name: string, language?: string): boolean`
+
+**Key design note (byte-identity):** the historical `isDescriptorName` applied the English rules (`^unknown`, `^the …`, English trailing-noun) to **every** language, then added Russian rules for ru. We preserve that exactly: the English rules are a **universal baseline** in the matcher; the per-language grammar holds only the **extras** (so `descriptorGrammarFor('en')` is `null` and English = baseline alone, identical to today). es/ru/fr/de get baseline + their row.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/src/analyzer/descriptor-grammar.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { isDescriptorName, descriptorGrammarFor } from './descriptor-grammar.js';
+
+describe('isDescriptorName — English baseline (byte-identical, universal)', () => {
+  it('folds the Unknown contract in any language', () => {
+    expect(isDescriptorName('Unknown Jogger')).toBe(true);
+    expect(isDescriptorName('Unknown Jogger', 'ru')).toBe(true);
+    expect(isDescriptorName('Unknown Hombre', 'es')).toBe(true);
+  });
+  it('folds "The <1-2 words>" and trailing English role nouns (all langs)', () => {
+    expect(isDescriptorName('The Jogger')).toBe(true);
+    expect(isDescriptorName('The Council of Twelve')).toBe(false); // >2 words
+    expect(isDescriptorName('Drooly Boy')).toBe(true);
+    expect(isDescriptorName('The Jogger', 'de')).toBe(true); // English slip on a de book
+  });
+  it('does not fold a real proper name', () => {
+    expect(isDescriptorName('Wren Sparrow')).toBe(false);
+    expect(isDescriptorName('Theodore')).toBe(false);
+  });
+});
+
+describe('isDescriptorName — ru extras (byte-identical to historical ru)', () => {
+  it('folds a lone Russian generic noun', () => {
+    expect(isDescriptorName('девушка', 'ru')).toBe(true);
+    expect(isDescriptorName('оператор', 'ru')).toBe(true);
+  });
+  it('folds a Russian phrase carrying a function word', () => {
+    expect(isDescriptorName('женщина с двумя овчарками', 'ru')).toBe(true);
+  });
+  it('does NOT fold a real Russian name or a 2-word noun phrase', () => {
+    expect(isDescriptorName('Одуван', 'ru')).toBe(false);
+    expect(isDescriptorName('Молодой парень', 'ru')).toBe(false); // bare rule needs 1 token
+  });
+});
+
+describe('isDescriptorName — es/fr/de (new)', () => {
+  it('folds article-led descriptors', () => {
+    expect(isDescriptorName('El Hombre', 'es')).toBe(true);
+    expect(isDescriptorName('Una Voz', 'es')).toBe(true);
+    expect(isDescriptorName('Le Garçon', 'fr')).toBe(true);
+    expect(isDescriptorName("L'Homme", 'fr')).toBe(true); // elision, single token
+    expect(isDescriptorName('Der Mann', 'de')).toBe(true);
+  });
+  it('folds bare generic nouns', () => {
+    expect(isDescriptorName('Desconocido', 'es')).toBe(true);
+    expect(isDescriptorName('Mann', 'de')).toBe(true);
+  });
+  it('does NOT fold real names carrying nobiliary/patronymic particles (finding B)', () => {
+    expect(isDescriptorName('María de la Cruz', 'es')).toBe(false);
+    expect(isDescriptorName('Charles de Gaulle', 'fr')).toBe(false);
+    expect(isDescriptorName('Otto von Bismarck', 'de')).toBe(false);
+  });
+});
+
+describe('descriptorGrammarFor', () => {
+  it('returns null for en and unmapped (baseline-only)', () => {
+    expect(descriptorGrammarFor('en')).toBeNull();
+    expect(descriptorGrammarFor('pt')).toBeNull();
+    expect(descriptorGrammarFor(undefined)).toBeNull();
+  });
+  it('returns a row for es/ru/fr/de', () => {
+    expect(descriptorGrammarFor('es')).not.toBeNull();
+    expect(descriptorGrammarFor('ru-RU')).not.toBeNull(); // subtag-normalised
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:server -- server/src/analyzer/descriptor-grammar.test.ts`
+Expected: FAIL — `Cannot find module './descriptor-grammar.js'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `server/src/analyzer/descriptor-grammar.ts`:
+
+```ts
+/* Per-language "is this character name a throwaway descriptor?" data, sibling to
+   tag-grammar.ts and consumed by foldMinorCast's isDescriptorName (#1050).
+
+   The English rules (Unknown / "The <1-2 words>" / trailing role noun) are a
+   UNIVERSAL baseline applied to every language — the model emits English
+   descriptors even on non-English books (same rationale as the Unknown contract),
+   and the historical isDescriptorName applied them unconditionally. Each non-English
+   language adds EXTRAS via a grammar row; en + unmapped languages get the baseline
+   alone (byte-identical to the historical behaviour).
+
+   Function-word rule is RUSSIAN-ONLY: a proper Russian name never contains a
+   preposition as a standalone token, but Romance/German names carry nobiliary
+   particles (de Gaulle, von Bismarck), so es/fr/de leave functionWords empty
+   (#938 lesson — never fold a real character). */
+
+import { normaliseBookLanguage } from '../tts/language.js';
+
+export interface DescriptorGrammar {
+  /** Leading article tokens for the article-led rule (lowercased). Empty = off. */
+  articles: ReadonlySet<string>;
+  /** Generic role nouns (lowercased). */
+  genericNouns: ReadonlySet<string>;
+  /** bare = lone token; trailing = last token of a >=2-word name; both = either. */
+  nounMatch: 'bare' | 'trailing' | 'both';
+  /** Standalone prep/conj tokens marking a multi-word name as a description
+      (lowercased). RU-ONLY; empty for es/fr/de. Empty = rule off. */
+  functionWords: ReadonlySet<string>;
+}
+
+/* Universal English baseline (applied for EVERY language). Moved verbatim from
+   fold-minor-cast.ts so the historical behaviour is byte-identical. */
+const ENGLISH_GENERIC_TAIL: ReadonlySet<string> = new Set([
+  'boy', 'girl', 'man', 'woman', 'guy', 'lady', 'kid', 'person', 'figure',
+  'stranger', 'voice',
+]);
+
+const RU: DescriptorGrammar = {
+  articles: new Set(),
+  genericNouns: new Set([
+    'девушка', 'парень', 'юноша', 'мужчина', 'женщина', 'незнакомец',
+    'незнакомка', 'человек', 'голос', 'старик', 'старуха', 'парнишка',
+    'оператор', 'водитель',
+  ]),
+  nounMatch: 'bare',
+  functionWords: new Set([
+    'с', 'со', 'в', 'во', 'на', 'по', 'под', 'из', 'у', 'за', 'к', 'ко',
+    'о', 'об', 'обо', 'при', 'про', 'для', 'без', 'до', 'от', 'над',
+    'и', 'или', 'а', 'но',
+  ]),
+};
+
+const ES: DescriptorGrammar = {
+  articles: new Set(['el', 'la', 'los', 'las', 'un', 'una', 'unos', 'unas']),
+  genericNouns: new Set([
+    'hombre', 'mujer', 'chico', 'chica', 'desconocido', 'desconocida',
+    'anciano', 'anciana', 'niño', 'niña', 'señor', 'señora', 'voz', 'conductor',
+  ]),
+  nounMatch: 'both',
+  functionWords: new Set(), // ru-only rule (finding B)
+};
+
+const FR: DescriptorGrammar = {
+  articles: new Set(['le', 'la', "l'", 'les', 'un', 'une', 'des']),
+  genericNouns: new Set([
+    'homme', 'femme', 'garçon', 'fille', 'inconnu', 'inconnue', 'vieil',
+    'vieille', 'voix', 'conducteur', 'enfant',
+  ]),
+  nounMatch: 'both',
+  functionWords: new Set(),
+};
+
+const DE: DescriptorGrammar = {
+  articles: new Set(['der', 'die', 'das', 'ein', 'eine']), // nominative only (R2-7)
+  genericNouns: new Set([
+    'mann', 'frau', 'junge', 'mädchen', 'fremder', 'fremde', 'stimme',
+    'fahrer', 'alte', 'alter', 'kind',
+  ]),
+  nounMatch: 'both',
+  functionWords: new Set(),
+};
+
+/* Extras only — en is the universal baseline (null), unmapped stays gated (null). */
+const GRAMMARS: Record<string, DescriptorGrammar> = { ru: RU, es: ES, fr: FR, de: DE };
+
+export function descriptorGrammarFor(language?: string): DescriptorGrammar | null {
+  return GRAMMARS[normaliseBookLanguage(language)] ?? null;
+}
+
+/* Decides whether a character name reads as a descriptor rather than a proper
+   name. English baseline first (universal), then language-specific extras. */
+export function isDescriptorName(name: string, language?: string): boolean {
+  const trimmed = name.trim();
+  if (!trimmed) return false;
+
+  // (1) Stage-1 contract — language-independent.
+  if (/^unknown\b/i.test(trimmed)) return true;
+  // (2) English baseline — every language.
+  if (/^the\s+\S+(\s+\S+)?$/i.test(trimmed)) return true;
+  const parts = trimmed.split(/\s+/);
+  const lower = parts.map((p) => p.toLowerCase());
+  if (parts.length >= 2 && ENGLISH_GENERIC_TAIL.has(lower[lower.length - 1])) return true;
+
+  // (3) Language-specific extras (en + unmapped → baseline only).
+  const g = descriptorGrammarFor(language);
+  if (!g) return false;
+
+  // article-led: <article> + 1–2 words.
+  if (g.articles.size) {
+    if ((parts.length === 2 || parts.length === 3) && g.articles.has(lower[0])) return true;
+    // FR elision: "L'Homme" tokenises as ONE part "l'homme".
+    if (parts.length <= 2) {
+      for (const art of g.articles) {
+        if (art.endsWith("'") && lower[0].startsWith(art) && lower[0].length > art.length) {
+          return true;
+        }
+      }
+    }
+  }
+  // generic noun.
+  if ((g.nounMatch === 'bare' || g.nounMatch === 'both') &&
+      parts.length === 1 && g.genericNouns.has(lower[0])) {
+    return true;
+  }
+  if ((g.nounMatch === 'trailing' || g.nounMatch === 'both') &&
+      parts.length >= 2 && g.genericNouns.has(lower[lower.length - 1])) {
+    return true;
+  }
+  // function-word phrase (ru-only; empty set → never fires for es/fr/de).
+  if (g.functionWords.size && parts.length >= 2) {
+    const hit = lower.some((p) => g.functionWords.has(p.replace(/^[—–-]+|[—–-]+$/g, '')));
+    if (hit) return true;
+  }
+  return false;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test:server -- server/src/analyzer/descriptor-grammar.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/analyzer/descriptor-grammar.ts server/src/analyzer/descriptor-grammar.test.ts
+git commit -m "feat(server): descriptor-grammar module for es/ru/fr/de minor-cast fold (#1050)"
+```
+
+---
+
+## Task 2: Wire `fold-minor-cast.ts` to the new grammar (Unit A integration, #1050)
+
+**Files:**
+- Modify: `server/src/analyzer/fold-minor-cast.ts` (remove inline `GENERIC_ROLE_TAIL`, `GENERIC_ROLE_RU`, `RU_FUNCTION_WORDS`, and the inline `isDescriptorName` body; import + re-export from `descriptor-grammar.js`).
+- Test: `server/src/analyzer/fold-minor-cast.test.ts` (existing — must stay green unedited).
+
+**Interfaces:**
+- Consumes: `isDescriptorName` from `./descriptor-grammar.js`.
+- Produces: `fold-minor-cast.ts` continues to export `isDescriptorName` (re-export) so existing importers (`fold-minor-cast.test.ts`) are unaffected.
+
+- [ ] **Step 1: Confirm the baseline is green before touching it**
+
+Run: `npm run test:server -- server/src/analyzer/fold-minor-cast.test.ts`
+Expected: PASS (this is the byte-identity baseline you must preserve).
+
+- [ ] **Step 2: Replace the inline matcher with an import + re-export**
+
+In `server/src/analyzer/fold-minor-cast.ts`:
+
+1. **Delete** the inline constants `GENERIC_ROLE_TAIL`, `GENERIC_ROLE_RU`, `RU_FUNCTION_WORDS` and the **entire** `export function isDescriptorName(name, language) { … }` body (the block that currently lives around lines 144–256).
+
+2. Add this single import + re-export near the top (P-5 — import the local binding once, then re-export *that binding*; this is the clean form that avoids the TS2484 "export declaration conflicts" you'd hit from combining `import { X }` with `export { X } from './m'`):
+
+```ts
+/* isDescriptorName moved to descriptor-grammar.ts (#1050). Import for the fold's
+   internal use at the `isDescriptorName(c.name, language)` call site, and re-export
+   the same binding for back-compat with existing importers (fold-minor-cast.test.ts). */
+import { isDescriptorName } from './descriptor-grammar.js';
+export { isDescriptorName };
+```
+
+Leave the internal call site `const isDescriptor = isDescriptorName(c.name, language);` unchanged.
+
+- [ ] **Step 3: Run the full fold + descriptor suites to verify byte-identity**
+
+Run: `npm run test:server -- server/src/analyzer/fold-minor-cast.test.ts server/src/analyzer/descriptor-grammar.test.ts`
+Expected: PASS, with **no edits** to `fold-minor-cast.test.ts`. If any ru/en case regresses, the constant migration diverged — diff the moved sets against the originals.
+
+- [ ] **Step 4: Typecheck (the deletion may orphan imports)**
+
+Run: `npm run typecheck`
+Expected: clean. **R-3: keep the `normaliseBookLanguage` import — it is still used by `bucketName` (`fold-minor-cast.ts:121`); only the descriptor constants and the inline matcher leave.** Do not remove it just because `isDescriptorName` no longer references it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/analyzer/fold-minor-cast.ts
+git commit -m "refactor(server): fold-minor-cast consumes descriptor-grammar; drop inline constants (#1050)"
+```
+
+---
+
+## Task 3: `tag-grammar.ts` — per-order regex ARRAY model (Unit B foundation, behavior-preserving)
+
+This is a **pure refactor**: convert `order` → `orders[]` and the single regex builders → array builders, update consumers, but keep every language's **current single order** so behavior (and all existing tests) are unchanged. Finding A (no alternation) + R2-2 (remove `tagRegexFor`).
+
+**Files:**
+- Modify: `server/src/analyzer/tag-grammar.ts`
+- Modify: `server/src/analyzer/recover-tagged-lines.ts` (3 consumer sites)
+- Test: `server/src/analyzer/tag-grammar.test.ts`, `server/src/analyzer/recover-tagged-lines.test.ts` (existing — stay green)
+
+**Interfaces:**
+- Produces:
+  - `TagGrammar.orders: readonly ('name-verb' | 'verb-name')[]` (replaces `order`)
+  - `tagRegexesFor(g: TagGrammar): RegExp[]` (one regex per order; name = capture group 1 in each; NO `g` flag — per-sentence use)
+  - `tagScanRegexesFor(g: TagGrammar): RegExp[]` (same, but each is fresh + global + multiline; body-scan ONLY)
+  - `verbBeatRegexFor(g: TagGrammar): RegExp` (now OR of every order's verb-beat; Unicode-safe)
+  - **REMOVED:** `tagRegexFor` (R2-2 — no singular form; callers must use the array)
+
+- [ ] **Step 1: Confirm existing tag-grammar + recover suites are green**
+
+Run: `npm run test:server -- server/src/analyzer/tag-grammar.test.ts server/src/analyzer/recover-tagged-lines.test.ts`
+Expected: PASS (the behavior you must preserve in this task).
+
+- [ ] **Step 2: Convert the interface + rows to `orders[]` (single order each, unchanged)**
+
+In `server/src/analyzer/tag-grammar.ts`, change the interface field and every row. Replace `order: 'name-verb' | 'verb-name'` with:
+
+```ts
+  /** Word orders the language uses, in priority. Each yields its own regex
+      (NEVER a single alternation — finding A: that would move the name out of
+      capture group 1). en is name-verb only; es/ru/fr/de gain a second order
+      in a later task. */
+  orders: readonly ('name-verb' | 'verb-name')[];
+```
+
+Update the rows (keep the SAME single order each for now):
+
+```ts
+const TAG_GRAMMARS: Record<string, TagGrammar> = {
+  en: { verbs: DIALOGUE_VERBS, orders: ['name-verb'], nameCapture: EN_NAME, flipStrategy: 'preceding' },
+  es: { verbs: ES_VERBS, orders: ['verb-name'], nameCapture: UNI_NAME, flipStrategy: 'adjacent', stopwords: ES_STOPWORDS },
+  ru: { verbs: RU_VERBS, orders: ['verb-name'], nameCapture: UNI_NAME, flipStrategy: 'adjacent', stopwords: RU_STOPWORDS },
+};
+```
+
+- [ ] **Step 3: Replace the regex builders with array forms (a single-order helper does the per-order work)**
+
+In `tag-grammar.ts`, replace `tagRegexFor` and `verbBeatRegexFor` with:
+
+```ts
+/* Build ONE regex for a single order. Name is capture group 1. No flags. */
+function buildOrderRegex(g: TagGrammar, order: 'name-verb' | 'verb-name'): RegExp {
+  const verbs = g.verbs.join('|');
+  if (order === 'name-verb') {
+    if (g.nameCapture === EN_NAME) {
+      // English: byte-identical to the historical makeTagRegex (ASCII \b, no u).
+      return new RegExp(`\\b(${g.nameCapture})\\s+(?:${verbs})\\b`);
+    }
+    // Unicode languages: \b is ASCII-only and fails next to non-ASCII letters on
+    // BOTH ends (e.g. trailing \b after Cyrillic "сказал") — use lookarounds (R2-8).
+    return new RegExp(`(?<!\\p{L})(${g.nameCapture})\\s+(?:${verbs})(?!\\p{L})`, 'u');
+  }
+  // verb-name: beat + verb + up to two lowercase role tokens + the name.
+  return new RegExp(
+    `${VERB_BEAT}(?:${verbs})\\s+(?:\\p{Ll}[\\p{L}’'-]*\\s+){0,2}(${g.nameCapture})`,
+    'u',
+  );
+}
+
+/** One regex PER order (finding A: array, not alternation). Name = group 1 each.
+    No `g` flag — for the per-sentence `.exec` model (recover-tagged-lines.ts). */
+export function tagRegexesFor(g: TagGrammar): RegExp[] {
+  return g.orders.map((order) => buildOrderRegex(g, order));
+}
+
+/** Body-scan variants: one FRESH regex PER order, each global (+ multiline so
+    VERB_BEAT's ^ matches each line start). Body-scan ONLY — never use in the
+    per-sentence model (its lastIndex would leak across sentences). */
+export function tagScanRegexesFor(g: TagGrammar): RegExp[] {
+  return g.orders.map((order) => {
+    const re = buildOrderRegex(g, order);
+    // Strip BOTH g and m before re-adding so a future builder that adds either
+    // can't produce a duplicate-flag SyntaxError (P-3). Preserves u when present.
+    return new RegExp(re.source, re.flags.replace(/[gm]/g, '') + 'gm');
+  });
+}
+
+/** "This text carries a dialogue verb on a beat" — name NOT required; used to
+    disqualify a flip neighbour that is itself a tag. OR of every order's beat;
+    Unicode-safe (JS \b never fires on Cyrillic). */
+export function verbBeatRegexFor(g: TagGrammar): RegExp {
+  const verbs = g.verbs.join('|');
+  const alts: string[] = [];
+  for (const order of g.orders) {
+    if (order === 'name-verb') {
+      // ASCII for en (byte-identical), Unicode-safe lookarounds otherwise.
+      alts.push(g.nameCapture === EN_NAME ? `\\b(?:${verbs})\\b` : `(?<!\\p{L})(?:${verbs})(?!\\p{L})`);
+    } else {
+      alts.push(`${VERB_BEAT}(?:${verbs})(?!\\p{L})`);
+    }
+  }
+  // `u` is required by \p{…}; harmless for the en-only ASCII alternative.
+  return new RegExp(alts.join('|'), 'u');
+}
+```
+
+> Note: `new RegExp('\\b…', 'u')` is legal — the ASCII-`\b` alternative compiles fine under the `u` flag. The en path of `buildOrderRegex` deliberately stays **non-`u`** to remain byte-identical; only `verbBeatRegexFor` unifies under `u`, which does not change `\b`/verb matching for ASCII English verbs.
+
+- [ ] **Step 4: Update the 3 consumer sites in `recover-tagged-lines.ts` to loop**
+
+In `server/src/analyzer/recover-tagged-lines.ts`:
+
+1. Change the import from `tagRegexFor` to `tagRegexesFor`:
+
+```ts
+import { grammarFor, tagRegexesFor, verbBeatRegexFor, isQuoteBearing } from './tag-grammar.js';
+```
+
+2. In `taggedSpeakerIds`, replace `const tagRe = tagRegexFor(g);` and the single `.exec` with a loop over the array:
+
+```ts
+  const tagRes = tagRegexesFor(g);
+  const ids = new Set<string>();
+  for (const s of sentences) {
+    for (const tagRe of tagRes) {
+      const m = tagRe.exec(s.text);
+      if (!m) continue;
+      const id = resolveNameToId(m[1], nameToId, stop);
+      if (id) ids.add(id);
+    }
+  }
+  return ids;
+```
+
+3. In `recoverTaggedNarratorLines`, both flip branches use `tagRe.exec(out[i].text)`. Replace the single `const tagRe = tagRegexFor(g);` with `const tagRes = tagRegexesFor(g);`, and in each branch try each regex until one matches:
+
+```ts
+  // helper local to recoverTaggedNarratorLines:
+  const firstTagMatch = (text: string): RegExpExecArray | null => {
+    for (const tagRe of tagRes) {
+      const m = tagRe.exec(text);
+      if (m) return m;
+    }
+    return null;
+  };
+```
+
+Then replace `const m = tagRe.exec(out[i].text);` with `const m = firstTagMatch(out[i].text);` in **both** the `'preceding'` loop and the `'adjacent'` loop.
+
+- [ ] **Step 5: Add a direct `tagScanRegexesFor` assertion (R-4)**
+
+`tagScanRegexesFor` (and its P-3 flag manipulation) is otherwise only exercised
+indirectly in Task 6 — pin it here, where it's written. Add to `tag-grammar.test.ts`
+(merge `grammarFor`/`tagScanRegexesFor` into the file's existing import block — do
+**not** add a duplicate `import` line, R-2):
+
+```ts
+import { grammarFor, tagScanRegexesFor } from './tag-grammar.js';
+
+describe('tagScanRegexesFor — body-scan flags (R-4)', () => {
+  it('returns global+multiline regexes that still capture the name in group 1', () => {
+    const res = tagScanRegexesFor(grammarFor('en')!);
+    expect(res.length).toBe(1);
+    for (const re of res) {
+      expect(re.global).toBe(true);
+      expect(re.multiline).toBe(true);
+    }
+    const m = res[0].exec('Wren said hello.');
+    expect(m?.[1]).toBe('Wren');
+  });
+});
+```
+
+- [ ] **Step 6: Run the suites — behavior must be unchanged**
+
+Run: `npm run test:server -- server/src/analyzer/tag-grammar.test.ts server/src/analyzer/recover-tagged-lines.test.ts`
+Expected: PASS, unedited. Allowed mechanical test edits only (same assertions): if `tag-grammar.test.ts` references `tagRegexFor` or `g.order`, update those call sites to `tagRegexesFor(g)[0]` / `g.orders[0]`. **P-4:** `verbBeatRegexFor` now always carries the `u` flag; if a test asserts its exact `.flags`/`.source`, update that assertion (matching behavior is unchanged for ASCII English verbs — and en uses the `'preceding'` flip, which never calls `verbBeatRegexFor`).
+
+- [ ] **Step 7: Typecheck**
+
+Run: `npm run typecheck`
+Expected: clean (no remaining `tagRegexFor` / `g.order` references anywhere).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/src/analyzer/tag-grammar.ts server/src/analyzer/recover-tagged-lines.ts server/src/analyzer/tag-grammar.test.ts
+git commit -m "refactor(server): tag-grammar per-order regex array; remove tagRegexFor (#1051 prep)"
+```
+
+---
+
+## Task 4: es/ru second word order + Unicode boundaries + stopword expansion (#1051)
+
+Adds `name-verb` to es/ru (so `María dijo` / `Иван сказал` are detected), and expands their stopwords so sentence-openers don't manufacture junk candidates (finding J). Behavior change for es/ru (re-acceptance owed — see spec "Owed validation").
+
+**Files:**
+- Modify: `server/src/analyzer/tag-grammar.ts` (es/ru `orders`, expanded `ES_STOPWORDS`/`RU_STOPWORDS`)
+- Test: `server/src/analyzer/tag-grammar.test.ts`
+
+**Interfaces:**
+- Consumes: `tagRegexesFor`, `grammarFor` (Task 3).
+- Produces: es/ru rows now `orders: ['verb-name', 'name-verb']`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/src/analyzer/tag-grammar.test.ts`:
+
+```ts
+import { grammarFor, tagRegexesFor } from './tag-grammar.js';
+
+/** Helper: does ANY of the language's order-regexes capture `expectedName`? */
+function capturesName(language: string, text: string): string | null {
+  const g = grammarFor(language)!;
+  for (const re of tagRegexesFor(g)) {
+    const m = re.exec(text);
+    if (m) return m[1];
+  }
+  return null;
+}
+
+describe('both-orders detection (es/ru) — finding A array, R2-8 boundaries', () => {
+  it('detects verb-name AND name-verb in Spanish', () => {
+    expect(capturesName('es', '—Está bien —dijo Berrin.')).toBe('Berrin');
+    expect(capturesName('es', 'María dijo algo en voz baja.')).toBe('María');
+  });
+  it('detects name-verb in Russian (trailing boundary after a Cyrillic verb)', () => {
+    expect(capturesName('ru', 'Иван сказал, что согласен.')).toBe('Иван');
+    expect(capturesName('ru', '«…», — сказал Одуван.')).toBe('Одуван');
+  });
+  it('es/ru rows expose two orders, NOT a single alternation regex', () => {
+    expect(tagRegexesFor(grammarFor('es')!).length).toBe(2);
+    expect(tagRegexesFor(grammarFor('ru')!).length).toBe(2);
+  });
+});
+
+describe('stopword suppression for name-verb (finding J)', () => {
+  it('does not capture a Spanish sentence-opener as a name', () => {
+    // "Entonces dijo" — name-verb would capture "Entonces"; the stopword must veto it.
+    // (the guard resolves only rostered/non-stopword candidates; here we assert the
+    //  grammar stopword set contains the opener so roster-coverage can filter it.)
+    expect(grammarFor('es')!.stopwords).toContain('entonces');
+    expect(grammarFor('ru')!.stopwords).toContain('тогда');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm run test:server -- server/src/analyzer/tag-grammar.test.ts -t "both-orders"`
+Expected: FAIL — Russian name-verb returns `null` (only verb-name present), and `length` is 1.
+
+- [ ] **Step 3: Add the second order and expand stopwords**
+
+In `tag-grammar.ts`, change the es/ru rows to two orders:
+
+```ts
+  es: { verbs: ES_VERBS, orders: ['verb-name', 'name-verb'], nameCapture: UNI_NAME, flipStrategy: 'adjacent', stopwords: ES_STOPWORDS },
+  ru: { verbs: RU_VERBS, orders: ['verb-name', 'name-verb'], nameCapture: UNI_NAME, flipStrategy: 'adjacent', stopwords: RU_STOPWORDS },
+```
+
+Expand the stopword constants (sentence-opener adverbs/pronouns that look like a name in name-verb order):
+
+```ts
+const ES_STOPWORDS = [
+  'él', 'ella', 'ellos', 'ellas', 'este', 'esta', 'eso', 'que', 'quien', 'aquí', 'allí',
+  // name-verb openers (finding J)
+  'entonces', 'luego', 'después', 'así', 'pero', 'aunque', 'mientras', 'cuando',
+  'también', 'además', 'sin', 'por', 'finalmente', 'de', 'pronto',
+] as const;
+const RU_STOPWORDS = [
+  'он', 'она', 'оно', 'они', 'это', 'тот', 'та', 'кто', 'что', 'там', 'тут', 'так', 'вот',
+  // name-verb openers (finding J)
+  'тогда', 'потом', 'затем', 'однако', 'хотя', 'наконец', 'вдруг', 'теперь', 'здесь',
+] as const;
+```
+
+- [ ] **Step 4: Run the new + existing tests**
+
+Run: `npm run test:server -- server/src/analyzer/tag-grammar.test.ts`
+Expected: PASS (both-orders + stopword cases green; existing es/ru verb-name cases still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/analyzer/tag-grammar.ts server/src/analyzer/tag-grammar.test.ts
+git commit -m "feat(server): es/ru both-orders tag detection + name-verb stopwords (#1051)"
+```
+
+---
+
+## Task 5: fr/de grammar rows + German title-skip + `QUOTE_GLYPHS` U+201E (#1051)
+
+Adds `fr` and `de` rows (both orders), German honorific titles (so `Frau Schmidt` → `Schmidt`), and the German low-opening quote to `QUOTE_GLYPHS`. Activating fr/de rows also turns on #1028's flip + keep-protection for those languages (intended).
+
+**Files:**
+- Modify: `server/src/analyzer/tag-grammar.ts`
+- Test: `server/src/analyzer/tag-grammar.test.ts`
+
+**Interfaces:**
+- Produces: `TagGrammar.titles?: readonly string[]`; rows `fr`, `de`; `QUOTE_GLYPHS` includes `„` (U+201E).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/src/analyzer/tag-grammar.test.ts`:
+
+```ts
+import { grammarFor, tagRegexesFor, isQuoteBearing } from './tag-grammar.js';
+
+describe('fr/de grammar rows (#1051)', () => {
+  it('detects French inversion and name-verb', () => {
+    expect(capturesName('fr', '— Bonjour, dit Marie.')).toBe('Marie');
+    expect(capturesName('fr', 'Marie dit bonjour.')).toBe('Marie');
+  });
+  it('detects German inversion and name-verb', () => {
+    expect(capturesName('de', '„Hallo“, sagte Anna.')).toBe('Anna');
+    expect(capturesName('de', 'Anna sagte leise etwas.')).toBe('Anna');
+  });
+  it('skips a German capitalized title and captures the surname', () => {
+    expect(capturesName('de', '„Guten Tag“, sagte Frau Schmidt.')).toBe('Schmidt');
+    expect(capturesName('de', 'sagte Herr Berger')).toBe('Berger');
+  });
+  it('captures a lone German title-noun (no surname) for the fold to bucket', () => {
+    expect(capturesName('de', 'sagte Frau')).toBe('Frau');
+  });
+  it('unmapped languages stay gated', () => {
+    expect(grammarFor('pt')).toBeNull();
+  });
+});
+
+describe('QUOTE_GLYPHS recognises German low-opening quote (R2-3)', () => {
+  it('treats „… as quote-bearing', () => {
+    expect(isQuoteBearing('„Hallo, wie geht es dir?')).toBe(true); // opening only
+    expect(isQuoteBearing('«Hola»')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm run test:server -- server/src/analyzer/tag-grammar.test.ts -t "fr/de"`
+Expected: FAIL — `grammarFor('fr')`/`('de')` are `null` → `capturesName` throws / returns null.
+
+- [ ] **Step 3: Add fr/de verbs, stopwords, titles, rows; widen `QUOTE_GLYPHS`**
+
+> **Word-list notes (P-6, conscious choices, inclusion-biased):** `FR_VERBS` lists
+> `s’exclama` with a **curly** apostrophe (U+2019) — a manuscript using a straight
+> `s'exclama` won't match; add the straight form too if a fr fixture shows it.
+> `DE_VERBS` includes `fuhr` (really "fuhr fort" = continued); as a bare verb it can
+> over-match "fuhr" (drove), but the roster-resolution + fold backstop absorbs a
+> stray candidate. Both are acceptable for v1; a missing verb silently drops a real
+> speaker, an extra one is filtered downstream.
+
+In `tag-grammar.ts` add the verb + stopword + title constants:
+
+```ts
+const FR_VERBS = [
+  'dit', 'demanda', 'répondit', 'répliqua', 'ajouta', 'cria', 'murmura',
+  'chuchota', 's’exclama', 'reprit', 'répéta', 'insista', 'continua', 'soupira',
+  'lança', 'ordonna',
+] as const;
+const DE_VERBS = [
+  'sagte', 'fragte', 'antwortete', 'erwiderte', 'rief', 'flüsterte', 'murmelte',
+  'entgegnete', 'fuhr', 'meinte', 'erklärte', 'wiederholte', 'fügte', 'seufzte',
+  'brüllte', 'stammelte',
+] as const;
+const FR_STOPWORDS = [
+  'il', 'elle', 'ils', 'elles', 'je', 'tu', 'nous', 'vous', 'ce', 'cela', 'qui', 'que',
+  'alors', 'puis', 'ensuite', 'mais', 'donc', 'quand', 'enfin', 'ici', 'là',
+] as const;
+const DE_STOPWORDS = [
+  'er', 'sie', 'es', 'ich', 'du', 'wir', 'ihr', 'das', 'dies', 'wer', 'was',
+  'dann', 'da', 'als', 'doch', 'aber', 'also', 'hier', 'dort', 'schließlich', 'plötzlich',
+] as const;
+/* German honorifics: capitalized, so the lowercase role-token skip in the verb-name
+   regex won't skip them — list them explicitly to capture the following surname. */
+const DE_TITLES = [
+  'Herr', 'Frau', 'Fräulein', 'Dr', 'Doktor', 'Professor', 'Prof', 'Graf',
+  'Gräfin', 'Baron', 'Baronin', 'König', 'Königin', 'Prinz', 'Prinzessin',
+  'Meister', 'Hauptmann',
+] as const;
+```
+
+Add the optional `titles` field to the `TagGrammar` interface:
+
+```ts
+  /** Capitalized honorifics to skip before the name in verb-name order (de). */
+  titles?: readonly string[];
+```
+
+Add the rows:
+
+```ts
+  fr: { verbs: FR_VERBS, orders: ['verb-name', 'name-verb'], nameCapture: UNI_NAME, flipStrategy: 'adjacent', stopwords: FR_STOPWORDS },
+  de: { verbs: DE_VERBS, orders: ['verb-name', 'name-verb'], nameCapture: UNI_NAME, flipStrategy: 'adjacent', stopwords: DE_STOPWORDS, titles: DE_TITLES },
+```
+
+Widen `QUOTE_GLYPHS` to include the German low-opening quote `„` (U+201E):
+
+```ts
+const QUOTE_GLYPHS = /[«»„“”"]|^\s*[—–]/u;
+```
+
+- [ ] **Step 4: Add the title-skip to the verb-name builder**
+
+In `buildOrderRegex`'s verb-name branch, insert an optional title-skip when the grammar carries `titles`:
+
+```ts
+  // verb-name: beat + verb + up to two lowercase role tokens + optional
+  // capitalized title (de) + the name.
+  const titleSkip = g.titles?.length
+    ? `(?:(?:${g.titles.join('|')})\\.?\\s+)?`
+    : '';
+  return new RegExp(
+    `${VERB_BEAT}(?:${verbs})\\s+(?:\\p{Ll}[\\p{L}’'-]*\\s+){0,2}${titleSkip}(${g.nameCapture})`,
+    'u',
+  );
+```
+
+(Regex backtracking makes the optional group correct: `sagte Frau Schmidt` → eats `Frau `, captures `Schmidt`; lone `sagte Frau` → backtracks, captures `Frau`.)
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npm run test:server -- server/src/analyzer/tag-grammar.test.ts`
+Expected: PASS (fr/de detection, German title-skip, lone-title, `isQuoteBearing` German open, plus all earlier cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/analyzer/tag-grammar.ts server/src/analyzer/tag-grammar.test.ts
+git commit -m "feat(server): fr/de tag-grammar rows + German title-skip + U+201E quote (#1051)"
+```
+
+---
+
+## Task 6: Roster-coverage guard — un-gate + grammar-driven array scan (#1051 core)
+
+Replaces the `isNonEnglish` gate with the grammar null-guard, builds the body scan from `tagScanRegexesFor` with per-position dedupe (R2-1), widens `QUOTE_CHARS` (R2-3), unions stopwords, removes the orphaned import (E), inverts the de gate tests (F), and adds the ADD-path tests (the trap #1028 fell into).
+
+**Files:**
+- Modify: `server/src/analyzer/roster-coverage.ts` (both `validateRosterCoverage` and `validateAttributionCoverage`)
+- Test: `server/src/analyzer/roster-coverage.test.ts`
+
+**Interfaces:**
+- Consumes: `grammarFor`, `tagScanRegexesFor` from `./tag-grammar.js`.
+- Produces: no signature changes — `validateRosterCoverage(bodyText, rosterNames, thresholds?, language?)` and `validateAttributionCoverage(...)` keep their shapes; behavior un-gates for es/ru/fr/de.
+
+- [ ] **Step 1: Write the failing ADD-path test + invert the de gate test**
+
+In `server/src/analyzer/roster-coverage.test.ts`:
+
+1. **Replace** the `describe('roster guard — non-English gate (seam 3d)', …)` block (the one asserting `de` no-ops at ~`:280–304`) with detection assertions:
+
+```ts
+describe('roster guard — localized detection (es/ru/fr/de) #1051', () => {
+  it('flags a Spanish prose-tagged speaker missing from the roster (Berrin)', () => {
+    const body = '—Está bien —dijo Berrin, mirando la campana.';
+    const res = validateRosterCoverage(body, new Set<string>(['Mara']), DEFAULT_ROSTER_COVERAGE_THRESHOLDS, 'es');
+    expect(res.ok).toBe(false);
+    expect(res.missingSpeakers.map((s) => s.name)).toContain('Berrin');
+  });
+  it('flags a Russian prose-tagged speaker missing from the roster (Одуван)', () => {
+    const body = '«Одну минуту», — сказал Одуван и улыбнулся.';
+    const res = validateRosterCoverage(body, new Set<string>(['Мара']), DEFAULT_ROSTER_COVERAGE_THRESHOLDS, 'ru');
+    expect(res.ok).toBe(false);
+    expect(res.missingSpeakers.map((s) => s.name)).toContain('Одуван');
+  });
+  it('recovers the German SURNAME, not the title (Frau Schmidt → Schmidt)', () => {
+    const body = '„Guten Tag“, sagte Frau Schmidt zu ihrem Nachbarn.';
+    const res = validateRosterCoverage(body, new Set<string>(['Mara']), DEFAULT_ROSTER_COVERAGE_THRESHOLDS, 'de');
+    expect(res.missingSpeakers.map((s) => s.name)).toContain('Schmidt');
+    expect(res.missingSpeakers.map((s) => s.name)).not.toContain('Frau');
+  });
+  it('does NOT flag a Spanish sentence-opener (stopword, finding J)', () => {
+    const body = 'Entonces dijo que la noche sería larga. Entonces dijo otra cosa.';
+    const res = validateRosterCoverage(body, new Set<string>(['Mara']), DEFAULT_ROSTER_COVERAGE_THRESHOLDS, 'es');
+    expect(res.missingSpeakers.map((s) => s.name)).not.toContain('Entonces');
+  });
+  it('still gates an unmapped language (pt → no-op)', () => {
+    const body = 'qualquer coisa';
+    const res = validateRosterCoverage(body, new Set<string>(), DEFAULT_ROSTER_COVERAGE_THRESHOLDS, 'pt');
+    expect(res.ok).toBe(true);
+    expect(res.missingSpeakers).toEqual([]);
+  });
+});
+```
+
+2. **Also add a localized `validateAttributionCoverage` test (R-1)** — the old seam-3d block had a `de` gate test for this function too; un-gating it must be paired with a localized half-state test (a rostered, prose-tagged speaker with 0 attributed lines in the chapter), not silently dropped:
+
+```ts
+describe('validateAttributionCoverage — localized half-state (es/ru) #1051', () => {
+  it('flags a rostered Spanish speaker prose-tagged but with 0 attributed lines', () => {
+    const body = '—Está bien —dijo Berrin, mirando la campana.';
+    const roster = [{ id: 'berrin', name: 'Berrin' }];
+    const chapterSentences = [{ characterId: 'narrator' }]; // Berrin's quote stranded on narrator
+    const res = validateAttributionCoverage(body, roster, chapterSentences, DEFAULT_ROSTER_COVERAGE_THRESHOLDS, 'es');
+    expect(res.ok).toBe(false);
+    expect(res.halfStateSpeakers.map((s) => s.id)).toContain('berrin');
+  });
+  it('does not flag a rostered Spanish speaker who already has lines', () => {
+    const body = '—Está bien —dijo Berrin.';
+    const roster = [{ id: 'berrin', name: 'Berrin' }];
+    const chapterSentences = [{ characterId: 'berrin' }]; // has a line → not a half-state
+    const res = validateAttributionCoverage(body, roster, chapterSentences, DEFAULT_ROSTER_COVERAGE_THRESHOLDS, 'es');
+    expect(res.halfStateSpeakers.map((s) => s.id)).not.toContain('berrin');
+  });
+  it('still gates an unmapped language (pt → no-op)', () => {
+    const res = validateAttributionCoverage('qualquer', [{ id: 'x', name: 'X' }], [], DEFAULT_ROSTER_COVERAGE_THRESHOLDS, 'pt');
+    expect(res.ok).toBe(true);
+  });
+});
+```
+
+(`validateAttributionCoverage` is already imported at the top of the file from the original seam-3d test — reuse that import, R-2.)
+
+3. Confirm the English describe blocks above remain **untouched**.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm run test:server -- server/src/analyzer/roster-coverage.test.ts -t "localized"`
+Expected: FAIL (both new blocks) — es/ru/fr currently no-op (`isNonEnglish` gate), so `ok` is `true` and `missingSpeakers`/`halfStateSpeakers` empty.
+
+- [ ] **Step 3: Swap the gate + build the grammar-driven array scan with dedupe**
+
+In `server/src/analyzer/roster-coverage.ts`:
+
+1. Imports: drop `isNonEnglish`, add the grammar + `normaliseBookLanguage` (needed
+   to keep English on the narrow quote set — P-1):
+
+```ts
+import { grammarFor, tagScanRegexesFor } from './tag-grammar.js';
+import { normaliseBookLanguage } from '../tts/language.js';
+```
+
+2. In `validateRosterCoverage`, replace the `if (isNonEnglish(language)) return {…}` early-return and the hardcoded `tagRe` construction:
+
+```ts
+export function validateRosterCoverage(
+  bodyText: string,
+  rosterNames: Iterable<string>,
+  thresholds?: RosterCoverageThresholds,
+  language: string = 'en',
+): RosterCoverageVerdict {
+  const g = grammarFor(language);
+  if (!g) return { ok: true, missingSpeakers: [], issues: [] }; // unmapped → gated
+  const t = resolveThresholds(thresholds);
+  const roster = rosterTokenSet(rosterNames);
+  const ignore = ignoredNames();
+  const langStops = langStopwords(g); // language sentence-opener stopwords (es/ru/fr/de)
+  const tagRes = tagScanRegexesFor(g);
+  // P-1: English keeps the historical NARROW quote set (byte-identity); es/ru/fr/de
+  // use the wide set their dialogue marks require.
+  const quoteChars = normaliseBookLanguage(language) === 'en' ? QUOTE_CHARS : QUOTE_CHARS_WIDE;
+
+  const body = bodyText || '';
+  interface Acc { name: string; tagCount: number; sampleTag: string; quoteAdjacent: boolean }
+  const candidates = new Map<string, Acc>();
+  const seenSpans = new Set<number>(); // R2-1: count each source span once
+
+  for (const tagRe of tagRes) {
+    for (let m = tagRe.exec(body); m; m = tagRe.exec(body)) {
+      const nameIdx = m.index + m[0].indexOf(m[1]);
+      if (seenSpans.has(nameIdx)) continue; // matched by another order already
+      seenSpans.add(nameIdx);
+      const rawName = stripPossessive(m[1]);
+      const key = rawName.toLowerCase();
+      if (key.includes('-as-')) continue;
+      const root = key.split(/['’]/)[0];
+      // English de-pluralization via isStopword (byte-identical); language
+      // sentence-openers via langStops (finding J). en → langStops empty.
+      if (isStopword(key) || isStopword(root) || langStops.has(key) || ignore.has(key)) continue;
+      if (roster.has(key)) continue;
+      const start = Math.max(0, m.index - t.quoteProximityChars);
+      const end = Math.min(body.length, m.index + m[0].length + t.quoteProximityChars);
+      const adjacent = quoteChars.test(body.slice(start, end));
+      const prev = candidates.get(key);
+      if (prev) {
+        prev.tagCount += 1;
+        prev.quoteAdjacent = prev.quoteAdjacent || adjacent;
+      } else {
+        candidates.set(key, { name: rawName, tagCount: 1, sampleTag: m[0].trim(), quoteAdjacent: adjacent });
+      }
+    }
+  }
+  // …unchanged from here: build missingSpeakers from candidates with the
+  // tagCount/quote-adjacency bound, sort, map to issues, return.
+```
+
+> Byte-identity note: the existing English `isStopword(key)` predicate (with its `-s`/`-es` de-pluralization) is **kept and still checked first** — that's what preserves the English path exactly. `langStops` only *adds* the language sentence-openers. For English, `g.stopwords` is undefined → `langStops` is empty → behavior is identical to today.
+
+3. Add the language-stopword helper near `isStopword` (do NOT remove or fold `isStopword` — it carries English de-pluralization the new languages don't need):
+
+```ts
+/** A grammar's language sentence-opener stopwords as a Set (es/ru/fr/de). Empty
+    for en (no g.stopwords) so the English path stays byte-identical — the loop
+    still applies the existing isStopword() de-pluralization predicate first. */
+function langStopwords(g: { stopwords?: readonly string[] }): Set<string> {
+  return new Set<string>(g.stopwords ?? []);
+}
+```
+
+4. Make the **same** edits to `validateAttributionCoverage` — shown explicitly (P-2)
+   because its candidate map is keyed by **character id** (resolved via `tokenToId`),
+   not name. Replace its `isNonEnglish` gate + `tagRe` build + `m[1]` loop with:
+
+```ts
+export function validateAttributionCoverage(
+  bodyText: string,
+  roster: Iterable<{ id: string; name: string; aliases?: string[] }>,
+  chapterSentences: Iterable<{ characterId: string }>,
+  thresholds?: RosterCoverageThresholds,
+  language: string = 'en',
+): AttributionCoverageVerdict {
+  const g = grammarFor(language);
+  if (!g) return { ok: true, halfStateSpeakers: [], issues: [] }; // unmapped → gated
+  const t = resolveThresholds(thresholds);
+  const tokenToId = rosterTokenToId(roster);
+  const ignore = ignoredNames();
+  const langStops = langStopwords(g);
+  const tagRes = tagScanRegexesFor(g);
+  const quoteChars = normaliseBookLanguage(language) === 'en' ? QUOTE_CHARS : QUOTE_CHARS_WIDE;
+  const body = bodyText || '';
+
+  // Attributed-line counts per character id for THIS chapter (unchanged).
+  const linesById = new Map<string, number>();
+  for (const s of chapterSentences) {
+    linesById.set(s.characterId, (linesById.get(s.characterId) ?? 0) + 1);
+  }
+  const narratorLines = linesById.get('narrator') ?? 0;
+
+  interface Acc { id: string; name: string; tagCount: number; sampleTag: string; quoteAdjacent: boolean }
+  const candidates = new Map<string, Acc>(); // keyed by character id
+  const seenSpans = new Set<number>(); // R2-1
+
+  for (const tagRe of tagRes) {
+    for (let m = tagRe.exec(body); m; m = tagRe.exec(body)) {
+      const nameIdx = m.index + m[0].indexOf(m[1]);
+      if (seenSpans.has(nameIdx)) continue;
+      seenSpans.add(nameIdx);
+      const rawName = stripPossessive(m[1]);
+      const key = rawName.toLowerCase();
+      if (key.includes('-as-')) continue;
+      const root = key.split(/['’]/)[0];
+      if (isStopword(key) || isStopword(root) || langStops.has(key) || ignore.has(key)) continue;
+      const id = tokenToId.get(key);
+      if (!id) continue; // not rostered — that's validateRosterCoverage's job
+      if (id === 'narrator' || id.startsWith('unknown-')) continue; // buckets never flag
+      const start = Math.max(0, m.index - t.quoteProximityChars);
+      const end = Math.min(body.length, m.index + m[0].length + t.quoteProximityChars);
+      const adjacent = quoteChars.test(body.slice(start, end));
+      const prev = candidates.get(id);
+      if (prev) {
+        prev.tagCount += 1;
+        prev.quoteAdjacent = prev.quoteAdjacent || adjacent;
+      } else {
+        candidates.set(id, { id, name: rawName, tagCount: 1, sampleTag: m[0].trim(), quoteAdjacent: adjacent });
+      }
+    }
+  }
+  // …unchanged from here: for each candidate, apply the tagCount/quote-adjacency
+  // bound, skip if attributedLines > 0, push the half-state, sort, map issues, return.
+```
+
+- [ ] **Step 4: Add a WIDE quote-char set for non-English; keep `QUOTE_CHARS` narrow (R2-3 + P-1)**
+
+Do **NOT** widen `QUOTE_CHARS` in place — `validateRosterCoverage` runs for `en`
+too, and adding em-dash/guillemets to the English adjacency window changes which
+English single-hit candidates get flagged (em-dashes are common in English prose),
+breaking the byte-identity invariant. Instead keep the narrow set for English and
+add a sibling wide set, selected by language (the `quoteChars` line in Step 3):
+
+```ts
+const QUOTE_CHARS = /["“”]/;              // en — UNCHANGED (byte-identity)
+const QUOTE_CHARS_WIDE = /["“”„«»—–]/;    // es/ru/fr/de — guillemets + German „ + dashes
+```
+
+(The `quoteChars = normaliseBookLanguage(language) === 'en' ? QUOTE_CHARS : QUOTE_CHARS_WIDE`
+selection in both `validateRosterCoverage` and `validateAttributionCoverage` does the rest.)
+
+- [ ] **Step 5: Run the roster suite + typecheck**
+
+Run: `npm run test:server -- server/src/analyzer/roster-coverage.test.ts`
+Expected: PASS — localized-detection cases green, English cases unedited & green.
+
+Run: `npm run typecheck`
+Expected: clean (no `isNonEnglish` import left in `roster-coverage.ts`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/analyzer/roster-coverage.ts server/src/analyzer/roster-coverage.test.ts
+git commit -m "feat(server): localize roster-coverage guard for es/ru/fr/de (#1051)"
+```
+
+---
+
+## Task 7: Activated #1028 paths — fr/de coverage + es/ru both-orders review
+
+Because Task 5 turned on the flip + keep-protection for fr/de and Task 4 changed es/ru detection, add fr/de coverage and re-verify es/ru in the `recover-tagged-lines` + fold keep-protection suites.
+
+**Files:**
+- Test: `server/src/analyzer/recover-tagged-lines.test.ts`, `server/src/analyzer/fold-minor-cast.test.ts`
+
+**Interfaces:** consumes the shipped grammar; no production code changes expected (tests only — unless a real defect surfaces, which then gets fixed under finding-driven TDD).
+
+- [ ] **Step 1: Add fr/de flip + keep-protection tests**
+
+Add to `server/src/analyzer/recover-tagged-lines.test.ts` a describe block exercising both languages, e.g. German inversion flipping a narrator-stranded quote onto the rostered speaker:
+
+```ts
+describe('recoverTaggedNarratorLines — fr/de (activated by #1051 rows)', () => {
+  it('flips a German narrator quote onto the inversion-tagged speaker', () => {
+    const roster = [{ id: 'anna', name: 'Anna' }];
+    const sentences = [
+      { id: 1, chapterId: 1, characterId: 'narrator', text: '„Ich komme mit.“' },
+      { id: 2, chapterId: 1, characterId: 'narrator', text: 'sagte Anna entschlossen.' },
+    ];
+    const { sentences: out, flipped } = recoverTaggedNarratorLines(sentences, roster, 'de');
+    expect(flipped).toBe(1);
+    expect(out[0].characterId).toBe('anna');
+  });
+  it('keeps a 0-line French tagged speaker via taggedSpeakerIds', () => {
+    const roster = [{ id: 'marie', name: 'Marie' }];
+    const ids = taggedSpeakerIds(
+      [{ id: 1, chapterId: 1, characterId: 'narrator', text: '— Bonjour, dit Marie.' }],
+      roster,
+      'fr',
+    );
+    expect(ids.has('marie')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Re-verify es/ru — adjust any assertion the both-orders change shifted**
+
+Run: `npm run test:server -- server/src/analyzer/recover-tagged-lines.test.ts`
+Expected: PASS. If an existing es/ru assertion shifted because name-verb detection now fires (a legitimately-changed expectation, not a regression), update it to the new expected attribution and add a one-line comment citing the both-orders change. Do **not** weaken a real invariant; if a flip now misfires, treat it as a bug and fix the grammar/flip.
+
+- [ ] **Step 3: Add an es/fr/de fold keep-protection case**
+
+Add to `server/src/analyzer/fold-minor-cast.test.ts` a case proving a prose-tagged es/fr/de speaker with 0 lines is kept (not dropped), mirroring the existing ru/en keep-protection test:
+
+```ts
+it('keeps a prose-tagged Spanish 0-line speaker (es keep-protection)', () => {
+  const characters = [
+    { id: 'narrator', name: 'Narrator', role: 'narrator', color: 'narrator', gender: 'neutral', description: '', aliases: [] },
+    { id: 'berrin', name: 'Berrin', role: 'minor', color: 'narrator', gender: 'male', description: '', aliases: [] },
+  ];
+  const sentences = [
+    { id: 1, chapterId: 1, characterId: 'narrator', text: '—Está bien —dijo Berrin.' },
+  ];
+  const result = foldMinorCast(characters as any, sentences as any, { language: 'es' });
+  expect(result.characters.map((c) => c.id)).toContain('berrin');
+});
+```
+
+- [ ] **Step 4: Run both suites**
+
+Run: `npm run test:server -- server/src/analyzer/recover-tagged-lines.test.ts server/src/analyzer/fold-minor-cast.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/analyzer/recover-tagged-lines.test.ts server/src/analyzer/fold-minor-cast.test.ts
+git commit -m "test(server): fr/de flip+keep coverage; es/ru both-orders review (#1051)"
+```
+
+---
+
+## Task 8: Verify call-site language threading (#1050 + #1051)
+
+Verify-only: confirm `language` reaches the roster guard and **both** `foldMinorCast` passes. Thread it into the interim pass if it isn't already (R2-4).
+
+**Files:**
+- Inspect/Modify (only if a gap is found): `server/src/routes/analysis.ts`
+- Test: an integration assertion if a thread is added; otherwise none.
+
+- [ ] **Step 1: Trace the roster-guard call sites**
+
+Read `server/src/routes/analysis.ts` around the `runStage1Guarded` wrapper (~`:529`) and its callers (~`:2783`, ~`:4608`). Confirm each passes the resolved `bookLanguage` (via `resolveBookLanguageForManuscript`, ~`:2178`/`:4451`) through `opts.language` to `runStage1WithRosterGuard`. Document the line numbers in the commit message.
+
+Run (sanity grep): `npm run test:server -- server/src/routes/analysis.test.ts`
+Expected: existing route tests PASS.
+
+- [ ] **Step 2: Trace both `foldMinorCast` call sites**
+
+Find every `foldMinorCast(` call in `server/src/routes/analysis.ts`. Confirm:
+- the **final** (post-stage-2) pass passes `{ language: … }` (it already must, since #1028's keep-protection needs `taggedSpeakerIds(…, language)`),
+- the **interim** (`nameOnly: true`) pass also passes `{ language: …, nameOnly: true }`.
+
+If the interim pass omits `language`, add it (one-line change). This makes es/fr/de descriptors fold at the interim cast write, not only at the final pass.
+
+- [ ] **Step 3: If a thread was added, pin it with a test; else record the trace**
+
+If you modified a call site, add/extend a route test asserting an es manuscript's interim cast folds a descriptor (or buckets it). If no change was needed, no test — record the verified line numbers in the commit body instead.
+
+- [ ] **Step 4: Full server suite + typecheck**
+
+Run: `npm run test:server && npm run typecheck`
+Expected: PASS / clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/analysis.ts
+git commit -m "fix(server): thread bookLanguage to interim foldMinorCast pass (#1050)"
+```
+
+(If nothing changed, skip the commit and note the verification in the PR body instead.)
+
+---
+
+## Final verification (before opening the PR)
+
+- [ ] **Run the whole server battery:** `npm run test:server && npm run test:server-slow`
+- [ ] **Typecheck + lint + build:** `npm run typecheck && npm run lint && npm run build`
+- [ ] **Full local gate (matches pre-push):** `npm run verify`
+- [ ] Confirm **no English assertion was edited** in `fold-minor-cast.test.ts` / `roster-coverage.test.ts` (byte-identity invariant).
+- [ ] Confirm `grep -rn "tagRegexFor\b\|isNonEnglish" server/src/analyzer/` returns nothing (R2-2 / E).
+
+## Owed validation (post-merge, on-box — out of this plan's CI)
+
+Per the spec's "Owed validation": **es re-acceptance** (both-orders changes the accepted render — re-run the Gemini e2e via `scratchpad/gateA.mjs`; pass = Berrin and Ivo are their own cast members and `«Está bien»` → `berrin`), **ru** equivalent when its background pass lands, **fr/de** smoke pass on the translated Coalfall fixtures. These belong in the PR's "owed gates" note, not as blockers on the unit-test landing.
+
+## Suggested follow-ups (not in scope)
+
+- **#1046** helper dedup between `roster-coverage.ts` and `recover-tagged-lines.ts` (`rosterTokenSet`/`buildNameToId`, the two `stripPossessive`s).
+- A stemmer for inflected descriptor nouns / verbs (listed surface forms only today).
+- Localizing `scripts/recover-missing-character.mjs` (manual hotfix, stays English).

--- a/docs/superpowers/specs/2026-06-24-es-ru-fr-de-analyzer-heuristic-localization-design.md
+++ b/docs/superpowers/specs/2026-06-24-es-ru-fr-de-analyzer-heuristic-localization-design.md
@@ -1,0 +1,523 @@
+---
+status: draft
+issues: ['#1050', '#1051']
+depends_on: ['#1028', '#1049']
+languages: ['es', 'ru', 'fr', 'de']
+---
+
+# es/ru/fr/de analyzer-heuristic localization (#1050 + #1051)
+
+Localize two analyzer heuristics that are currently English-only, for **es, ru, fr,
+de**, reusing the per-language `tag-grammar.ts` substrate that #1028/#1049 landed:
+
+- **#1050** — `isDescriptorName` (the minor-cast fold) only folds throwaway
+  "descriptor" names for `en` (and `ru`, partially). Spanish/French/German
+  background descriptors leak their own one-off voice slots.
+- **#1051** — the roster-coverage guard (`validateRosterCoverage`,
+  `validateAttributionCoverage`, `runStage1WithRosterGuard`) is gated off for
+  **all** non-English. A speaker stage-1 drops from the roster is never
+  recovered. This is the actual fix for the on-box Berrin/Ivo loss that
+  motivated #1028 (see "Motivating evidence").
+
+## Motivating evidence (why #1051 matters)
+
+On-box Gemini analysis of `samples/the-coalfall-commission/manuscript.es.md`
+(`language=es`) post-#1049:
+
+- Cast had 13 members; **Berrin and Ivo were absent entirely** — stage-1 never
+  rostered them.
+- `«Está bien»,` (prose: `…, dijo Berrin`) → attributed to `unknown-male`.
+- Ivo's lines → `unknown-male` / `narrator`.
+- #1028's keep-protection + narrator-flip **couldn't fire** because they are
+  *rostered-only*: `taggedSpeakerIds` / `resolveNameToId` require the captured
+  name to match a rostered character, and Berrin/Ivo aren't rostered. #1051 is
+  the layer that gets them rostered; the two compose (see "How the layers
+  compose"). The #1028 flip did **not** misfire (no line went to a wrong
+  speaker), so #1051 doesn't risk regressing it.
+
+## Scope decisions (locked with the user)
+
+1. **Languages: es + ru + fr + de** for both units.
+2. **Architecture (Approach A):** `tag-grammar.ts` stays the single source of
+   truth for dialogue-tag grammar; a **new** sibling `descriptor-grammar.ts`
+   houses the descriptor data. Neither heuristic hand-rolls `if (lang === …)`
+   ladders. (Rejected: B — one unified module, overloads a single unit and
+   churns the just-shipped `tag-grammar.ts`; C — inline per-language branches,
+   duplicates the verb-name machinery the grammar already encodes.)
+3. **fr/de full parity, lean on existing filters.** The roster guard auto-adds
+   missing speakers for fr/de just like es/ru; a wrong add (e.g. German `Mann`)
+   gets no lines → folded by Unit A's descriptor grammar or dropped as a 0-line
+   non-speaker. **This makes Unit A a prerequisite for Unit B's fr/de safety →
+   land Unit A first.**
+4. **Both-orders detection for all four** (name-verb **and** verb-name). The
+   flip already handles quote-on-either-side; this is a detection-only change.
+5. **Consequence accepted by the user:** un-gating fr/de in `tag-grammar.ts`
+   also activates #1028's flip + fold-keep-protection for fr/de (shared
+   `grammarFor()` gate). Adding name-verb detection to es/ru/fr/de changes their
+   attribution output, which **invalidates the Spanish operator-acceptance**
+   (re-render + re-accept owed) and shifts ru. See "Owed validation".
+
+## Invariants (reviewer-checked)
+
+- **English is byte-identical.** Both modules' `en` path is unchanged; passing
+  no `language` defaults to `'en'`. `EN_NAME` keeps the curly apostrophe `'`
+  (U+2019). Existing **English** assertions in `fold-minor-cast.test.ts` and
+  `roster-coverage.test.ts` stay green **and unedited**.
+- **The unmapped tail stays gated.** Any language without a grammar row resolves
+  `grammarFor()` / `descriptorGrammarFor()` → `null` → no-op. The gate moves from
+  "is English?" to "do we have a row?"; it does not vanish.
+- **es/ru/fr/de behavior intentionally changes** (both-orders + new descriptor
+  rows + un-gated guard). Existing es/ru tests are reviewed and updated to the
+  new expectations, not frozen.
+
+## Adversarial review (round 1) — findings folded in
+
+| # | Severity | Finding | Resolved in |
+|---|---|---|---|
+| A | 🔴 | A single both-orders *alternation* regex puts the name in group 1 *or* 2, breaking 5 `m[1]` reads (`undefined`); duplicate named groups are a Node-20 SyntaxError. | §B.2 "Capture-group model" + §B.6 array model (`tagRegexesFor[]`), 5 consumer sites loop. |
+| B | 🔴 | Porting the ru function-word rule to es/fr/de folds **real names** with nobiliary/patronymic particles (`de Gaulle`, `von Bismarck`). | "Function-word rule is ru-only"; es/fr/de `functionWords` empty. |
+| J | 🟠 | Name-verb mode makes thin es/ru stopwords manufacture junk roster adds (`Entonces dijo`). | §B.3 stopword expansion + a pinning test. |
+| D | 🟠 | `orders[]` also breaks `verbBeatRegexFor` (reads `g.order`). | §B.6 multi-order `verbBeatRegexFor`. |
+| C | 🟡 | Bare-noun match folds a *recurring* narrator-named role even with many lines. | Accepted limit (Unit A "Known v1 limits"). |
+| E | 🟡 | Removing the gate orphans the `isNonEnglish` import. | Files-touched note. |
+| F | 🟡 | de seam-3d gate tests must be *inverted to detection*, not deleted. | Testing strategy. |
+| G | 🟡 | `recover-missing-character.mjs` stays English. | Out of scope. |
+| H | ✅ | `m`-flag byte-identity for en — *verified no-op* (no anchors in en regex). | §B.2. |
+
+## Adversarial review (round 2) — findings folded in
+
+| # | Severity | Finding | Resolved in |
+|---|---|---|---|
+| R2-1 | 🟠 | The per-order regex array can **double-count one physical tag** (matched by two orders) → `tagCount` hits 2 → passes the `≥2-hits` gate without quote-adjacency, defeating the single-hit false-positive bound. | §B.2 — dedupe matches by capture position (`m.index`), not just by name. |
+| R2-2 | 🟠 | A `tagRegexFor` single-regex shim (proposed in round 1) is a **footgun**: a caller using `[0]` silently gets only the first order, dropping name-verb detection. | §B.6 — **remove `tagRegexFor` entirely**; all callers use the array. |
+| R2-3 | 🟠 | **Verified glyph gaps:** roster `QUOTE_CHARS` (`/["“”]/`) lacks guillemets `« »` (es/ru) **and** German `„` (U+201E); `QUOTE_GLYPHS` (isQuoteBearing) lacks German `„` (U+201E). Quote-adjacency is blind to es/ru/de dialogue marks. | §B.4 + §7 — widen both, exact code points named. |
+| R2-8 | 🟠 | **Verified:** the name-verb branch's `\b` is ASCII-only → the **trailing `\b` after a Cyrillic verb** (`сказал`) never fires, so ru name-verb tags don't match. (de verbs are ASCII, fine.) | §B.6 — Unicode-safe boundaries on **both** sides of the name-verb tag for ru. |
+| R2-4 | 🟡 | Unit A only fires for es/fr/de if `language` reaches `foldMinorCast` at **both** the interim (`nameOnly`) and final passes. Final already gets it (#1028); interim unverified. | Call-sites section. |
+| R2-5 | 🟡 | Roster-guard auto-adds carry no gender → a false-add `Frau` folds into the **male** bucket (wrong gender). | Unit B §5 note. |
+| R2-6 | 🟢 | `m`+`VERB_BEAT` `^` interacts with manuscript hard-wrapping. | Verify-at-implementation note (§B.2). |
+| R2-7 | 🟢 | German `articles` `den/dem` are unnecessary (analyzer emits nominative). | Trimmed to nominative in the rows. |
+
+---
+
+## Unit A — `descriptor-grammar.ts` (#1050)
+
+New module `server/src/analyzer/descriptor-grammar.ts`, mirroring
+`tag-grammar.ts`. One row per language; `isDescriptorName(name, lang)` becomes a
+data-driven matcher over it.
+
+```ts
+export interface DescriptorGrammar {
+  /** Leading article tokens for the article-led rule (lowercased). Empty = rule off. */
+  articles: ReadonlySet<string>;
+  /** Generic role nouns (lowercased). */
+  genericNouns: ReadonlySet<string>;
+  /** How a generic noun matches: lone token / last token of a ≥2-word name / either. */
+  nounMatch: 'bare' | 'trailing' | 'both';
+  /** Standalone prepositions/conjunctions whose presence in a multi-word name
+      marks it a description, not a name (lowercased). Empty = rule off. */
+  functionWords: ReadonlySet<string>;
+}
+export function descriptorGrammarFor(language: string): DescriptorGrammar | null;
+```
+
+`isDescriptorName` applies, in order:
+
+1. **`^unknown\b`** — the Stage-1 contract, **language-independent** (the model
+   emits "Unknown …" even on non-English books). Kept exactly as today.
+2. **Article-led** — `^<article> <word>( <word>)?$` (≤2 words after the article),
+   built from `articles`, case-insensitive + Unicode. FR `l'` elision handled
+   (both `le/la/les… ` with a space and `l'…` apostrophe-no-space).
+3. **Generic noun** — `bare` (lone token), `trailing` (last token of a ≥2-word
+   name), or `both`.
+4. **Function-word phrase (ru-only)** — a multi-word name carrying a standalone
+   token from `functionWords` is a description. Leading/trailing dashes stripped
+   per token (as the existing ru rule does). **This rule is RUSSIAN-ONLY** — see
+   "Function-word rule is ru-only" below for why it is unsafe for es/fr/de. For
+   those languages `functionWords` is empty and the rule never fires.
+
+### The rows
+
+| lang | articles | genericNouns (representative — full list curated, inclusion-biased) | nounMatch | functionWords |
+|---|---|---|---|---|
+| en | `the` | boy, girl, man, woman, guy, lady, kid, person, figure, stranger, voice *(= today's `GENERIC_ROLE_TAIL`)* | `trailing` | *(empty — en unchanged)* |
+| ru | *(none)* | девушка, парень, юноша, мужчина, женщина, незнакомец, незнакомка, человек, голос, старик, старуха, парнишка, оператор, водитель *(= today's `GENERIC_ROLE_RU`)* | `bare` | *(= today's `RU_FUNCTION_WORDS`)* |
+| es | el, la, los, las, un, una, unos, unas | hombre, mujer, chico, chica, desconocido, desconocida, anciano, anciana, niño, niña, señor, señora, voz, conductor | `both` | *(empty — see "Function-word rule is ru-only")* |
+| fr | le, la, l', les, un, une, des | homme, femme, garçon, fille, inconnu, inconnue, vieil, vieille, voix, conducteur, enfant | `both` | *(empty)* |
+| de | der, die, das, ein, eine | mann, frau, junge, mädchen, fremder, fremde, stimme, fahrer, alte, alter, kind | `both` | *(empty)* |
+
+### Byte-identity & migration
+
+- The inline `GENERIC_ROLE_TAIL`, `GENERIC_ROLE_RU`, `RU_FUNCTION_WORDS`
+  constants **move** from `fold-minor-cast.ts` into the `en`/`ru` rows (one home,
+  not copied). en (`the` + `trailing`) reproduces the `^the…$` regex + the
+  trailing-noun rule; ru (`bare` + function-words) reproduces the lone-noun +
+  function-word rules. Existing en/ru fold tests stay green unedited.
+
+### Function-word rule is ru-only (adversarial-review finding B)
+
+The Russian function-word rule is safe **only because of a Russian-specific
+property** the existing code comment states outright: *a proper Russian name
+structurally never contains a preposition/conjunction as a separate token.*
+**That property is false for Romance and German**, whose proper names routinely
+carry nobiliary/patronymic particles as standalone tokens:
+
+- `María **de** la Cruz`, `Charles **de** Gaulle`, `Ponce **de** León`,
+  `Otto **von** Bismarck`, `**von** Trapp`.
+
+A naive port would fire on `de` / `del` / `du` / `des` / `von` and **fold real
+characters into `unknown-male`** — a direct violation of the #938 lesson ("never
+let a widened fold swallow a real character"). Therefore:
+
+- **`functionWords` is empty for es/fr/de**; the rule fires for **ru only**.
+- Descriptive es/fr/de phrases (`el hombre de la chaqueta`, `der Mann mit dem
+  Hund`) still fold — via the **post-stage-2 line-count fold**, since by
+  definition a one-off background phrase is a low-line speaker. We trade a little
+  precision (these don't fold at the pre-stage-2 interim pass) for zero
+  real-name false-folds.
+
+### Known v1 limits (documented, not bugs)
+
+- **`nounMatch:'both'`** for es/fr/de enables **bare** single-token matching —
+  more aggressive (could fold a real character literally named a common noun).
+  Mitigated by exact-token match against a *curated* list (not fuzzy) + the
+  line-count fold + the #938 lesson backstop. de specifically *needs* bare match
+  so the roster guard's German false-adds (`Mann`) get folded. **Accepted
+  consequence (finding C):** a *recurring* narrator-named role rendered as a
+  generic noun (`El Conductor`, `Der Hauptmann`) folds into the bucket **even with
+  many lines**, because descriptor-match ignores line count — same pre-existing
+  behavior as English `The Stranger`. Re-cast manually if a book makes such a
+  role a main character.
+- **Inflection is partial-coverage v1** (same as ru today): listed surface forms
+  only, both genders spelled out, no stemmer.
+
+---
+
+## Unit B — roster-guard localization (#1051)
+
+Changes in `server/src/analyzer/roster-coverage.ts` (both
+`validateRosterCoverage` and `validateAttributionCoverage`) plus small additions
+to `tag-grammar.ts`.
+
+### 1. Replace the gate
+
+Delete the `if (isNonEnglish(language)) return {ok:true,…}` early-returns.
+Replace with the grammar null-guard (mirrors `recover-tagged-lines.ts`):
+
+```ts
+const g = grammarFor(language);
+if (!g) return { ok: true, missingSpeakers: [], issues: [] }; // unmapped → gated
+```
+
+### 2. Build the scan from the grammar
+
+Replace the hardcoded English `new RegExp('\\b([A-Z]…)\\s+(?:${verbAlt})\\b','g')`
+with grammar-driven regexes. The guard scans **whole chapter prose** (stage-1,
+pre-segmentation — only raw body text exists), so it needs a **global + multiline**
+variant. Because a language can have **multiple word orders** (see §6), this is an
+**array of regexes — one per order** — NOT a single alternation regex (see
+"Capture-group model" below for why). Add one export to `tag-grammar.ts`:
+
+```ts
+/** Body-scan variants of tagRegexesFor: one FRESH regex PER order, each with g
+    (+ m, + u as appropriate), for the whole-chapter exec-loop in
+    roster-coverage.ts. Name is capture group 1 in EACH (single-group) regex.
+    Body-scan ONLY — never use in the per-sentence model (its lastIndex would
+    leak across sentences). Fresh objects per call → no shared state. */
+export function tagScanRegexesFor(g: TagGrammar): RegExp[];
+```
+
+The body-scan loop runs each regex over the body, merging candidates. **Dedupe by
+capture position, not just by name (adversarial-review finding R2-1):** the same
+physical tag can be matched by two order-regexes; if both increment the candidate's
+`tagCount`, a single real tag reads as 2 hits and **passes the `≥2-hits` gate
+without quote-adjacency**, defeating the single-hit false-positive bound. Track
+matched `m.index` spans and count each source span once. `m` (multiline) so
+`VERB_BEAT`'s `^` matches each line start in a multi-line body, not just string
+start. `m` is a **no-op for `en`** (its name-verb regex has no `^`/`$` anchor), so
+the English scan stays byte-identical.
+
+**Hard-wrap caveat (R2-6, verify-at-implementation):** with `m`, `VERB_BEAT`'s `^`
+fires at every line start. If chapter `bodyText` is hard-wrapped mid-sentence
+(newlines inside a sentence), a verb that happens to begin a wrapped line could
+anchor a spurious verb-name match. Low risk (a name capture still requires a
+following capitalized token), but confirm the imported body is paragraph-per-line,
+not hard-wrapped, during implementation.
+
+**Capture-group model (adversarial-review finding A):** the name is **capture
+group 1 in each single-order regex**, so every `m[1]` read stays valid. We do
+**NOT** build a single alternation `(?:‹nv›|‹vn›)` — that would put the name in
+group 1 *or* group 2, breaking the five existing `m[1]` reads
+(`recover-tagged-lines.ts:108/144/166`, `roster-coverage.ts:195/342`) with
+`undefined`. Duplicate named groups `(?<name>…|…)` would fix it but are an
+**ES2025 SyntaxError on Node 20** (this project's runtime) → ruled out. The array
+model keeps `m[1]` semantics per regex; `en`'s single-element array is the exact
+regex of today.
+
+**Regex-model reconciliation (the briefing's "no `g` flag" warning):** that
+warning targets the **per-sentence** consumers (`recover-tagged-lines.ts` `.exec`s
+a non-global regex once per sentence; a `g` flag would leak `lastIndex` across
+sentences). The roster guard is the **body-scan** consumer and legitimately needs
+`g`. `tagScanRegexesFor` is documented body-scan-only.
+
+### 3. Stopwords
+
+Scan stopwords = roster-coverage's English `STOPWORDS` ∪ `g.stopwords`.
+
+**Stopword expansion for name-verb mode (adversarial-review finding J).** The
+existing `ES_STOPWORDS`/`RU_STOPWORDS` were tuned for **verb-name** detection and
+are too thin for name-verb: with name-verb on, `(Capital)\s+verb` matches
+sentence-openers — Spanish `Entonces dijo…` → captures `Entonces`. In the roster
+guard a non-rostered candidate is *exactly what gets auto-added*, so a thin
+stopword set manufactures junk roster entries (later dropped as 0-line, but
+wasteful and occasionally line-catching). So **enabling both-orders requires
+expanding every multi-order language's stopwords with capitalized
+sentence-opener adverbs/pronouns**, not just adding fr/de rows:
+- es: + `entonces, luego, después, así, pero, aunque, mientras, cuando` …
+- ru: + `тогда, потом, затем, однако, хотя` …
+- de (new row): `er, sie, es, dann, da, ich, du, wir, als, doch, aber` …
+- fr (new row): `il, elle, je, tu, nous, alors, puis, mais, donc, quand` …
+
+English keeps its `isStopword` de-pluralization; other languages match listed
+forms only (partial, documented). The legacy English `STOPWORDS` also suppresses
+*role nouns* (`man`, `council`…) at the guard; for the new languages we
+deliberately do **not** port an exhaustive role-noun list here — a leaked role
+noun is auto-added then **folded by Unit A**. Same outcome via the chosen
+backstop.
+
+### 4. Quote-adjacency
+
+Today's `QUOTE_CHARS = /["“”]/` proximity window is **straight + U+201C + U+201D
+only** — verified at `77ba6ec1`. It is **blind to the dialogue marks the new
+languages actually use**, so it must widen to include (R2-3, exact code points):
+- guillemets `«` U+00AB / `»` U+00BB (es/ru),
+- German low-opening `„` U+201E (German opens `„…“`; only the *close* U+201C is
+  in today's set),
+- em/en-dash dialogue openers `—` U+2014 / `–` U+2013.
+
+Looser for dash-dialogue languages, but that's the correct signal there (dialogue
+*is* dash-delimited), and the fold backstops over-capture.
+
+### 5. Auto-add: no logic change
+
+Once the verdict goes non-ok for es/ru/fr/de, the existing
+`runStage1WithRosterGuard` retry→inject path fires unchanged. `toKebabId` is
+already `safeId` (Unicode-safe, plan 219), so Cyrillic/accented auto-added names
+get stable ids.
+
+**Gender of auto-adds (R2-5).** A `MissingSpeaker` carries no gender, so a
+false-add German noun (`Frau`) folds into the **male** bucket (Unit A's
+`pickBucket` defaults non-female → male). Cosmetic — it's a generic background
+bucket either way — but noted; we do **not** add gender inference to the roster
+guard (out of scope, and the bucket label isn't a per-character voice).
+
+### 6. Both-orders detection (the word-order fix)
+
+`tag-grammar.ts`: replace `order: 'name-verb' | 'verb-name'` with
+`orders: readonly ('name-verb' | 'verb-name')[]`. Expose
+`tagRegexesFor(g): RegExp[]` — **one regex per order, NOT an alternation** (per
+finding A above; each keeps the name in capture group 1). **Remove the singular
+`tagRegexFor` entirely (R2-2)** — keeping it as a `tagRegexesFor(g)[0]` shim is a
+footgun: a caller using `[0]` silently gets only the *first* order and drops
+name-verb detection for es/ru/fr/de. Forcing every caller onto the array makes the
+"both orders" contract unskippable. `flipStrategy` is unchanged.
+
+**Consumer fan-out (finding A, full blast radius).** Every consumer that today
+does `const m = tagRe.exec(text); … m[1]` must loop over the order regexes
+instead. Confirmed consumers on `77ba6ec1`: `recover-tagged-lines.ts` (3 sites:
+`taggedSpeakerIds`, both flip branches) and `roster-coverage.ts` (2 sites). `en`
+(single order) iterates a one-element array → behavior identical. This edits
+#1028's just-merged `recover-tagged-lines.ts`; its existing es/ru assertions are
+reviewed and updated to the both-orders expectations.
+
+**`verbBeatRegexFor` also changes (finding D).** It currently reads `g.order`
+(`tag-grammar.ts:81–84`) to pick its shape. With `orders[]` it must accept **any**
+of the language's orders — a neighbour that is itself a tag must be disqualified
+whether it's name-verb or verb-name. Build it as the OR of each order's verb-beat
+form (still name-less; Unicode-safe via `(?!\p{L})`, not `\b`).
+
+| lang | orders | rationale |
+|---|---|---|
+| en | `['name-verb']` | English narration; verb-name is archaic. Byte-identical regex. |
+| es | `['verb-name', 'name-verb']` | inversion dominant + `María dijo` form. |
+| fr | `['verb-name', 'name-verb']` | inversion dominant + `Marie dit` form. |
+| ru | `['verb-name', 'name-verb']` | free word order; both common. |
+| de | `['verb-name', 'name-verb']` | free word order; `», sagte Anna` and `Anna sagte:` both common. |
+
+- **Why the flip needs no change:** the `'adjacent'` strategy (es/ru/fr/de)
+  already flips **both** the preceding and following neighbor (guarded). A
+  name-verb tag `Anna sagte: „…"` has its quote as the *next* sentence; a
+  verb-name tag `„…", sagte Anna` has it as the *prev*. `'adjacent'` covers both.
+  So once detection finds the tag, the existing flip recovers the quote.
+- **Unicode-safe boundaries on BOTH sides (R2-8, verified).** The current
+  name-verb shape is `\b(name)\s+(?:verbs)\b`. JS `\b` is ASCII-only, so it fails
+  next to non-ASCII letters — and the failure is on **both** ends for ru: the
+  leading `\b` before a Cyrillic name *and* the **trailing `\b` after a Cyrillic
+  verb** (`сказал` ends in `л`), so `Иван сказал` never matches. The Unicode
+  name-verb regex (and its `verbBeatRegexFor` form) must use lookaround
+  boundaries (`(?<!\p{L})…(?!\p{L})`), not `\b`, on both sides. de verbs/names are
+  ASCII-ish so `\b` would *appear* to work, but the row uses the same Unicode form
+  for consistency. **en's name-verb branch keeps its exact ASCII `\b` regex**
+  (byte-identity — en stays the single, unchanged regex).
+
+### 7. German capitalized-title skip (the `Frau Schmidt` fix)
+
+`Frau Schmidt` / `Herr Berger` is the normal German dialogue-tag shape, not a
+corner case. In verb-name order the lowercase role-token skip
+(`(?:\p{Ll}…){0,2}`) doesn't skip a **capitalized** German title, so `sagte Frau
+Schmidt` would capture `Frau` instead of `Schmidt`.
+
+- Add an optional `titles?: readonly string[]` field to `TagGrammar`
+  (capitalized honorifics).
+- the verb-name regex builder (inside `tagRegexesFor`) inserts an **optional
+  title-skip** before the name capture *when the row has `titles`*:
+  `… {lowercase tokens}{0,2} (?:(?:Frau|Herr|Dr|Doktor|Professor|Prof|Graf|Gräfin|König|Königin|Prinz|Prinzessin|Baron|Baronin|Meister|Hauptmann|Fräulein)\.?\s+)? (NAME)`
+  (`\.?` absorbs `Dr.`).
+- **de row only carries `titles`.** en/es/ru/fr rows have no `titles` → the regex
+  is byte-identical for them (es/ru honorifics are lowercase, already covered by
+  the lowercase skip).
+- **Regex backtracking handles the degenerate cases:** `sagte Frau Schmidt` →
+  captures `Schmidt`; `sagte Anna` → captures `Anna`; lone `sagte Frau.` →
+  title-skip can't satisfy a trailing name, backtracks, captures `Frau` → folds
+  as a `genericNouns` descriptor. In name-verb order the pre-verb token is the
+  surname already (`Frau Schmidt sagte` → single-token capture `Schmidt`), so no
+  title-skip needed there.
+- **Bonus:** because this lives in `tag-grammar.ts`, it also fixes #1028's flip +
+  keep-protection for `Frau Schmidt` once de is mapped.
+- **`isQuoteBearing` needs German `„` U+201E (R2-3, second surface).** `QUOTE_GLYPHS`
+  (which `isQuoteBearing` tests, and which the flip's `qualifies()` relies on) was
+  verified to contain `« » “ ”` + dashes but **not** `„` U+201E. German opens with
+  `„` and closes with `“`; only the close is covered, so a German narrator quote
+  tagged near its *opening* mark isn't recognized as quote-bearing and the flip
+  skips it. Add U+201E to `QUOTE_GLYPHS`.
+
+### Remaining de limit (documented)
+
+Single-token name capture means `sagte Frau von Habsburg`-style multi-token
+surnames are partially covered — the capture lands on one token (`Habsburg`),
+dropping the `von` particle. Acceptable v1; backstopped. (Note: `von` is **not**
+in any descriptor `functionWords` set — those are ru-only per finding B — so this
+is purely a tag-capture granularity limit, not a fold-safety issue.)
+
+---
+
+## How the layers compose (ordering)
+
+The roster guard runs at **stage-1** (`runStage1WithRosterGuard`); #1028's
+keep-protection + flip run **post-stage-2**. So #1051 **feeds** #1028: once #1051
+rosters Berrin, #1028's `taggedSpeakerIds` keeps his slot and the flip pulls his
+stranded quote off narrator. Complementary layers — #1051 unlocks #1028's value
+on the real analyzer.
+
+Implementation order: **Unit A (#1050) → Unit B (#1051)** (Unit A is the fold
+backstop that makes Unit B's fr/de full-parity safe).
+
+## Call sites (verify, don't rewrite)
+
+`server/src/routes/analysis.ts`: `runStage1Guarded` wrapper (~`:529`) and callers
+(~`:2783`, ~`:4608`) already thread `bookLanguage` (via
+`resolveBookLanguageForManuscript` ~`:2178`/`:4451`), the same path #1028's
+consumers use. Implementation must **verify** es/ru/fr/de actually reach the guard
+— a quick trace, not a rewrite.
+
+**Also verify `foldMinorCast` gets `language` at BOTH passes (R2-4).** Unit A only
+fires for es/fr/de if `opts.language` reaches `foldMinorCast`. The **final**
+(post-stage-2) pass already threads it — #1028's keep-protection needs it
+(`taggedSpeakerIds(…, language)`). The **interim** (`nameOnly`) cast-write pass is
+**unverified**; if it doesn't pass `language`, es/fr/de descriptors fold only at
+the final pass (acceptable — the interim cast briefly shows an un-folded
+descriptor — but make it a conscious choice, not an accident). Verify both call
+sites; thread `language` into the interim pass if cheap.
+
+## Testing strategy
+
+**Unit A (#1050):**
+- New `descriptor-grammar.test.ts` — table/matcher unit tests per language.
+- `fold-minor-cast.test.ts`: en/ru cases stay green **unedited** (byte-identity) —
+  including the ru function-word phrase case (`женщина с двумя овчарками`), which
+  must still fold (ru keeps the rule). **Add** es/fr/de descriptor cases —
+  article-led (`El Hombre`, `Le Garçon`, `Der Mann`), bare noun (`Desconocido`,
+  `Mann`). **Add negative cases (finding B):** a real es/fr/de name carrying a
+  particle (`María de la Cruz`, `Charles de Gaulle`, `Otto von Bismarck`) must
+  **NOT** fold — proves the function-word rule is off for those languages.
+
+**Unit B (#1051):**
+- `roster-coverage.test.ts`: en stays green **unedited**; the de seam-3d gate
+  tests (confirmed `:285–287`, `:303–304`, asserting de no-ops) are **inverted to
+  detection assertions** — de is now mapped, so they must assert it *flags/adds*,
+  not no-op (finding F; this is a rewrite-in-place, never a delete/`.skip`). es/ru/fr
+  have no conflicting no-op gate tests there (de-only).
+- **Both-orders stopword cases (finding J):** a Spanish sentence-opener
+  (`Entonces dijo …`) must **not** produce a roster add — pin the expanded
+  stopwords so junk candidates are suppressed.
+- **Test the ADD path — the trap #1028 fell into.** Feed a prose-tagged speaker
+  **NOT in the roster** and assert recovery: es `«Está bien», dijo Berrin`, ru
+  `«…», — сказал Одуван` (+ fr/de analogues) → `validateRosterCoverage` returns
+  them in `missingSpeakers`, and `runStage1WithRosterGuard` **auto-adds** them.
+  (Not the rostered-input path that hid the bug.)
+- **Both-orders cases:** a speaker tagged **only** in name-verb form
+  (`Anna sagte`, `María dijo`, `Иван сказал`) is recovered, alongside the
+  verb-name form (`sagte Anna`, `dijo María`, `сказал Иван`).
+- **German title case:** `sagte Frau Schmidt` recovers **`Schmidt`** (not `Frau`);
+  lone `sagte Frau` folds as descriptor.
+
+**`tag-grammar.test.ts`:** add fr/de row tests (verb list, both orders each
+capture the name in group 1, German title-skip, `tagScanRegexesFor`
+global/multiline array behavior). Pin that **no single alternation regex is
+built** (finding A) — e.g. assert `tagRegexesFor(g).length === g.orders.length`.
+
+**Activated #1028 paths (consequence of the all-four choice):** because fr/de
+tag-grammar rows + both-orders detection turn on / change the flip +
+keep-protection for those languages, **add fr/de coverage** to
+`recover-tagged-lines.test.ts` and the fold keep-protection tests, and **review**
+existing es/ru assertions there for the both-orders change.
+
+**Drift/integration:** `DIALOGUE_VERBS` is untouched (fr/de verbs live in
+`tag-grammar.ts`), so the `dialogue-verbs-drift` test is unaffected — confirm.
+
+## Owed validation (post-merge, on-box — cannot run in this environment)
+
+- **es re-acceptance.** Both-orders detection changes the accepted Spanish render
+  → re-run the Gemini e2e (`scratchpad/gateA.mjs` driver, per the briefing) and
+  re-confirm operator acceptance. **Pass = Berrin and Ivo appear as their own
+  cast members and `«Está bien»` → `berrin` (not `unknown-male`).**
+- **ru** equivalent once the background ru pass lands (briefing will append ru
+  data to #1051).
+- **fr/de** smoke pass at minimum (translated Coalfall fixtures exist:
+  `samples/the-coalfall-commission/manuscript.{fr,de}.md`).
+- These are flagged here and belong in the plan's per-task gates + the eventual
+  Ship notes, not as blocking the unit-test landing.
+
+## Files touched
+
+- `server/src/analyzer/descriptor-grammar.ts` — **new** (Unit A).
+- `server/src/analyzer/descriptor-grammar.test.ts` — **new**.
+- `server/src/analyzer/fold-minor-cast.ts` — `isDescriptorName` consumes the new
+  grammar; inline constants move out.
+- `server/src/analyzer/tag-grammar.ts` — `orders[]`, optional `titles`,
+  `tagRegexesFor`/`tagScanRegexesFor` (array model, finding A), **`tagRegexFor`
+  removed (R2-2)**, `verbBeatRegexFor` multi-order + Unicode boundaries both sides
+  (finding D, R2-8), `QUOTE_GLYPHS` += `„` U+201E (R2-3), expanded es/ru stopwords
+  + new fr/de rows (finding J), fr/de grammar rows (de articles nominative-only, R2-7).
+- `server/src/analyzer/recover-tagged-lines.ts` — **not just a consumer**: its 3
+  `m[1]` sites loop over the order-regex array (finding A); en path unchanged.
+- `server/src/analyzer/roster-coverage.ts` — gate swap, grammar-driven array scan
+  with **per-position match dedupe (R2-1)**, `QUOTE_CHARS` widened to `« » „` +
+  dashes (R2-3), stopword union, and **remove the now-orphaned `isNonEnglish`
+  import** (finding E).
+- Tests: `fold-minor-cast.test.ts`, `tag-grammar.test.ts`,
+  `roster-coverage.test.ts`, `recover-tagged-lines.test.ts` (+ fold keep-protection).
+- Verify-only: `server/src/routes/analysis.ts` language threading at the three
+  call sites.
+
+## Out of scope
+
+- Full helper dedup between `roster-coverage.ts` and `recover-tagged-lines.ts`
+  (`rosterTokenSet`/`buildNameToId`, the two `stripPossessive`s) — that's the
+  separately-tracked **#1046**. Reuse what's natural via the grammar; don't
+  scope-creep the dedup here.
+- Languages beyond es/ru/fr/de — stay gated (unmapped → no-op).
+- A stemmer for inflected descriptor nouns / verbs — listed surface forms only.
+- `scripts/recover-missing-character.mjs` (the manual operator hotfix) carries its
+  own literal English verb scan and **stays English-only** (finding G) — it's
+  operator-run, not in the analysis pipeline. Localizing it is a separate item if
+  ever needed.

--- a/server/src/analyzer/descriptor-grammar.test.ts
+++ b/server/src/analyzer/descriptor-grammar.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { isDescriptorName, descriptorGrammarFor } from './descriptor-grammar.js';
+
+describe('isDescriptorName — English baseline (byte-identical, universal)', () => {
+  it('folds the Unknown contract in any language', () => {
+    expect(isDescriptorName('Unknown Jogger')).toBe(true);
+    expect(isDescriptorName('Unknown Jogger', 'ru')).toBe(true);
+    expect(isDescriptorName('Unknown Hombre', 'es')).toBe(true);
+  });
+  it('folds "The <1-2 words>" and trailing English role nouns (all langs)', () => {
+    expect(isDescriptorName('The Jogger')).toBe(true);
+    expect(isDescriptorName('The Council of Twelve')).toBe(false); // >2 words
+    expect(isDescriptorName('Drooly Boy')).toBe(true);
+    expect(isDescriptorName('The Jogger', 'de')).toBe(true); // English slip on a de book
+  });
+  it('does not fold a real proper name', () => {
+    expect(isDescriptorName('Wren Sparrow')).toBe(false);
+    expect(isDescriptorName('Theodore')).toBe(false);
+  });
+});
+
+describe('isDescriptorName — ru extras (byte-identical to historical ru)', () => {
+  it('folds a lone Russian generic noun', () => {
+    expect(isDescriptorName('девушка', 'ru')).toBe(true);
+    expect(isDescriptorName('оператор', 'ru')).toBe(true);
+  });
+  it('folds a Russian phrase carrying a function word', () => {
+    expect(isDescriptorName('женщина с двумя овчарками', 'ru')).toBe(true);
+  });
+  it('does NOT fold a real Russian name or a 2-word noun phrase', () => {
+    expect(isDescriptorName('Одуван', 'ru')).toBe(false);
+    expect(isDescriptorName('Молодой парень', 'ru')).toBe(false); // bare rule needs 1 token
+  });
+});
+
+describe('isDescriptorName — es/fr/de (new)', () => {
+  it('folds article-led descriptors', () => {
+    expect(isDescriptorName('El Hombre', 'es')).toBe(true);
+    expect(isDescriptorName('Una Voz', 'es')).toBe(true);
+    expect(isDescriptorName('Le Garçon', 'fr')).toBe(true);
+    expect(isDescriptorName("L'Homme", 'fr')).toBe(true); // elision, single token
+    expect(isDescriptorName('Der Mann', 'de')).toBe(true);
+  });
+  it('folds bare generic nouns', () => {
+    expect(isDescriptorName('Desconocido', 'es')).toBe(true);
+    expect(isDescriptorName('Mann', 'de')).toBe(true);
+  });
+  it('does NOT fold real names carrying nobiliary/patronymic particles (finding B)', () => {
+    expect(isDescriptorName('María de la Cruz', 'es')).toBe(false);
+    expect(isDescriptorName('Charles de Gaulle', 'fr')).toBe(false);
+    expect(isDescriptorName('Otto von Bismarck', 'de')).toBe(false);
+  });
+});
+
+describe('descriptorGrammarFor', () => {
+  it('returns null for en and unmapped (baseline-only)', () => {
+    expect(descriptorGrammarFor('en')).toBeNull();
+    expect(descriptorGrammarFor('pt')).toBeNull();
+    expect(descriptorGrammarFor(undefined)).toBeNull();
+  });
+  it('returns a row for es/ru/fr/de', () => {
+    expect(descriptorGrammarFor('es')).not.toBeNull();
+    expect(descriptorGrammarFor('ru-RU')).not.toBeNull(); // subtag-normalised
+  });
+});

--- a/server/src/analyzer/descriptor-grammar.ts
+++ b/server/src/analyzer/descriptor-grammar.ts
@@ -1,0 +1,134 @@
+/* Per-language "is this character name a throwaway descriptor?" data, sibling to
+   tag-grammar.ts and consumed by foldMinorCast's isDescriptorName (#1050).
+
+   The English rules (Unknown / "The <1-2 words>" / trailing role noun) are a
+   UNIVERSAL baseline applied to every language — the model emits English
+   descriptors even on non-English books (same rationale as the Unknown contract),
+   and the historical isDescriptorName applied them unconditionally. Each non-English
+   language adds EXTRAS via a grammar row; en + unmapped languages get the baseline
+   alone (byte-identical to the historical behaviour).
+
+   Function-word rule is RUSSIAN-ONLY: a proper Russian name never contains a
+   preposition as a standalone token, but Romance/German names carry nobiliary
+   particles (de Gaulle, von Bismarck), so es/fr/de leave functionWords empty
+   (#938 lesson — never fold a real character). */
+
+import { normaliseBookLanguage } from '../tts/language.js';
+
+export interface DescriptorGrammar {
+  /** Leading article tokens for the article-led rule (lowercased). Empty = off. */
+  articles: ReadonlySet<string>;
+  /** Generic role nouns (lowercased). */
+  genericNouns: ReadonlySet<string>;
+  /** bare = lone token; trailing = last token of a >=2-word name; both = either. */
+  nounMatch: 'bare' | 'trailing' | 'both';
+  /** Standalone prep/conj tokens marking a multi-word name as a description
+      (lowercased). RU-ONLY; empty for es/fr/de. Empty = rule off. */
+  functionWords: ReadonlySet<string>;
+}
+
+/* Universal English baseline (applied for EVERY language). Moved verbatim from
+   fold-minor-cast.ts so the historical behaviour is byte-identical. */
+const ENGLISH_GENERIC_TAIL: ReadonlySet<string> = new Set([
+  'boy', 'girl', 'man', 'woman', 'guy', 'lady', 'kid', 'person', 'figure',
+  'stranger', 'voice',
+]);
+
+const RU: DescriptorGrammar = {
+  articles: new Set(),
+  genericNouns: new Set([
+    'девушка', 'парень', 'юноша', 'мужчина', 'женщина', 'незнакомец',
+    'незнакомка', 'человек', 'голос', 'старик', 'старуха', 'парнишка',
+    'оператор', 'водитель',
+  ]),
+  nounMatch: 'bare',
+  functionWords: new Set([
+    'с', 'со', 'в', 'во', 'на', 'по', 'под', 'из', 'у', 'за', 'к', 'ко',
+    'о', 'об', 'обо', 'при', 'про', 'для', 'без', 'до', 'от', 'над',
+    'и', 'или', 'а', 'но',
+  ]),
+};
+
+const ES: DescriptorGrammar = {
+  articles: new Set(['el', 'la', 'los', 'las', 'un', 'una', 'unos', 'unas']),
+  genericNouns: new Set([
+    'hombre', 'mujer', 'chico', 'chica', 'desconocido', 'desconocida',
+    'anciano', 'anciana', 'niño', 'niña', 'señor', 'señora', 'voz', 'conductor',
+  ]),
+  nounMatch: 'both',
+  functionWords: new Set(), // ru-only rule (finding B)
+};
+
+const FR: DescriptorGrammar = {
+  articles: new Set(['le', 'la', "l'", 'les', 'un', 'une', 'des']),
+  genericNouns: new Set([
+    'homme', 'femme', 'garçon', 'fille', 'inconnu', 'inconnue', 'vieil',
+    'vieille', 'voix', 'conducteur', 'enfant',
+  ]),
+  nounMatch: 'both',
+  functionWords: new Set(),
+};
+
+const DE: DescriptorGrammar = {
+  articles: new Set(['der', 'die', 'das', 'ein', 'eine']), // nominative only (R2-7)
+  genericNouns: new Set([
+    'mann', 'frau', 'junge', 'mädchen', 'fremder', 'fremde', 'stimme',
+    'fahrer', 'alte', 'alter', 'kind',
+  ]),
+  nounMatch: 'both',
+  functionWords: new Set(),
+};
+
+/* Extras only — en is the universal baseline (null), unmapped stays gated (null). */
+const GRAMMARS: Record<string, DescriptorGrammar> = { ru: RU, es: ES, fr: FR, de: DE };
+
+export function descriptorGrammarFor(language?: string): DescriptorGrammar | null {
+  return GRAMMARS[normaliseBookLanguage(language)] ?? null;
+}
+
+/* Decides whether a character name reads as a descriptor rather than a proper
+   name. English baseline first (universal), then language-specific extras. */
+export function isDescriptorName(name: string, language?: string): boolean {
+  const trimmed = name.trim();
+  if (!trimmed) return false;
+
+  // (1) Stage-1 contract — language-independent.
+  if (/^unknown\b/i.test(trimmed)) return true;
+  // (2) English baseline — every language.
+  if (/^the\s+\S+(\s+\S+)?$/i.test(trimmed)) return true;
+  const parts = trimmed.split(/\s+/);
+  const lower = parts.map((p) => p.toLowerCase());
+  if (parts.length >= 2 && ENGLISH_GENERIC_TAIL.has(lower[lower.length - 1])) return true;
+
+  // (3) Language-specific extras (en + unmapped → baseline only).
+  const g = descriptorGrammarFor(language);
+  if (!g) return false;
+
+  // article-led: <article> + 1–2 words.
+  if (g.articles.size) {
+    if ((parts.length === 2 || parts.length === 3) && g.articles.has(lower[0])) return true;
+    // FR elision: "L'Homme" tokenises as ONE part "l'homme".
+    if (parts.length <= 2) {
+      for (const art of g.articles) {
+        if (art.endsWith("'") && lower[0].startsWith(art) && lower[0].length > art.length) {
+          return true;
+        }
+      }
+    }
+  }
+  // generic noun.
+  if ((g.nounMatch === 'bare' || g.nounMatch === 'both') &&
+      parts.length === 1 && g.genericNouns.has(lower[0])) {
+    return true;
+  }
+  if ((g.nounMatch === 'trailing' || g.nounMatch === 'both') &&
+      parts.length >= 2 && g.genericNouns.has(lower[lower.length - 1])) {
+    return true;
+  }
+  // function-word phrase (ru-only; empty set → never fires for es/fr/de).
+  if (g.functionWords.size && parts.length >= 2) {
+    const hit = lower.some((p) => g.functionWords.has(p.replace(/^[—–-]+|[—–-]+$/g, '')));
+    if (hit) return true;
+  }
+  return false;
+}

--- a/server/src/analyzer/fold-minor-cast.test.ts
+++ b/server/src/analyzer/fold-minor-cast.test.ts
@@ -892,6 +892,17 @@ describe('Wave D — localized minor-cast fold buckets', () => {
 });
 
 describe('foldMinorCast — keeps a prose-tagged Spanish minor speaker (#1028)', () => {
+  it('keeps a prose-tagged Spanish 0-line speaker (es keep-protection)', () => {
+    const characters = [
+      { id: 'narrator', name: 'Narrator', role: 'narrator', color: 'narrator', gender: 'neutral', description: '', aliases: [] },
+      { id: 'berrin', name: 'Berrin', role: 'minor', color: 'narrator', gender: 'male', description: '', aliases: [] },
+    ];
+    const sentences = [
+      { id: 1, chapterId: 1, characterId: 'narrator', text: '—Está bien —dijo Berrin.' },
+    ];
+    const result = foldMinorCast(characters as any, sentences as any, { language: 'es' });
+    expect(result.characters.map((c) => c.id)).toContain('berrin');
+  });
   it('does not drop a 0-line speaker whose quote the prose tags (es)', () => {
     const chars = [
       makeChar('narrator'),

--- a/server/src/analyzer/fold-minor-cast.ts
+++ b/server/src/analyzer/fold-minor-cast.ts
@@ -35,6 +35,11 @@
 import type { CharacterOutput, SentenceOutput } from '../handoff/schemas.js';
 import { taggedSpeakerIds } from './recover-tagged-lines.js';
 import { normaliseBookLanguage } from '../tts/language.js';
+/* isDescriptorName moved to descriptor-grammar.ts (#1050). Import for the fold's
+   internal use at the `isDescriptorName(c.name, language)` call site, and re-export
+   the same binding for back-compat with existing importers (fold-minor-cast.test.ts). */
+import { isDescriptorName } from './descriptor-grammar.js';
+export { isDescriptorName };
 
 export interface FoldOptions {
   /** A character whose attributed line count is strictly below this
@@ -133,127 +138,6 @@ export function matchesProtectedRole(role: string | undefined, protectedRoles: s
   return protectedRoles.some((protectedRole) => normalised.includes(protectedRole.toLowerCase()));
 }
 
-/* Generic-role nouns that, when they appear as the LAST word of a
-   character name preceded by at least one other word, indicate a
-   descriptor rather than a proper name: "Drooly Boy", "Old Man",
-   "Tall Woman". A bare "Boy" / "Man" alone is also descriptive but
-   rarely emitted by the model — those would be caught by the
-   line-count threshold downstream. Kept narrow on purpose: a future
-   "<adj> Doctor" / "<adj> Captain" extension is easy if observed in
-   real runs. */
-const GENERIC_ROLE_TAIL = new Set([
-  'boy',
-  'girl',
-  'man',
-  'woman',
-  'guy',
-  'lady',
-  'kid',
-  'person',
-  'figure',
-  'stranger',
-  'voice',
-]);
-
-/* Russian generic-role nouns that read as descriptors rather than proper
-   names ("девушка" = girl, "парень" = guy, "незнакомец" = stranger). Only
-   consulted when the book language is Russian. Unlike the English tail-word
-   rule these match a BARE single-word name (Russian background speakers are
-   typically emitted as a lone noun, not "<adj> <noun>"). Russian inflection
-   means this is PARTIAL coverage for v1 — case-declined forms ("девушку",
-   "парня") and adjective-prefixed phrases are not stemmed; we match the
-   nominative singular only. Extending to a stemmer is deliberately out of
-   scope (don't over-engineer). */
-const GENERIC_ROLE_RU = new Set([
-  'девушка',
-  'парень',
-  'юноша',
-  'мужчина',
-  'женщина',
-  'незнакомец',
-  'незнакомка',
-  'человек',
-  'голос',
-  'старик',
-  'старуха',
-  'парнишка',
-  'оператор',
-  'водитель',
-]);
-
-/* Russian function words (prepositions + a few conjunctions) that appear as a
-   standalone token ONLY inside a descriptive PHRASE — "женщина С двумя
-   овчарками НА поводке", "молодой В куртке". A proper Russian name (first ·
-   patronymic · surname · diminutive) structurally never contains one of these
-   as a separate word, so a multi-word "name" carrying a function-word token is
-   a description, not a person — the highest-precision fold signal we have, with
-   effectively zero false-positive risk against real names (the #938 lesson:
-   never let a widened fold swallow a real character). Single-letter forms
-   (с/в/к/у/о/а/и) are included on purpose — capitalised initials carry a dot
-   ("А.") so they don't collide. Russian-only, mirrors GENERIC_ROLE_RU. */
-const RU_FUNCTION_WORDS = new Set([
-  'с', 'со', 'в', 'во', 'на', 'по', 'под', 'из', 'у', 'за', 'к', 'ко',
-  'о', 'об', 'обо', 'при', 'про', 'для', 'без', 'до', 'от', 'над',
-  'и', 'или', 'а', 'но',
-]);
-
-/* Decides whether a character's `name` reads as a descriptor rather
-   than a proper name. The three patterns we catch in order:
-     1. `^Unknown\b...` — the Stage-1 contract ("Unknown <descriptor>"
-        for nameless speakers). Stable across analyzer engines.
-     2. `^The <Word>($| <Word>$)` — definite-article-led descriptor.
-        Models routinely emit "The Jogger", "The Stranger", "The
-        Shopkeeper" in spite of the Stage-1 instruction. Capped at
-        two words after "The" so multi-word proper titles
-        ("The Council of Twelve", "The Forbidden Cities") don't get
-        folded — those are usually places, not speakers, and the
-        skill drops them anyway.
-     3. Trailing generic-role word ("Drooly Boy", "Old Man",
-        "Ponytail Girl"). Requires at least one word before the
-        role tail so a bare proper name that happens to be a role
-        ("Boy" used as a nickname) doesn't get folded.
-   Trim + lowercase normalisation up front so the model's casing
-   choices don't matter.
-
-   When `language` is Russian the English patterns above still apply (the
-   model occasionally emits "Unknown …" even on a Russian book) AND two further
-   Russian-only signals fold:
-     - a bare Russian generic noun ("девушка", "парень", "оператор") — see
-       `GENERIC_ROLE_RU`;
-     - a multi-word phrase carrying a standalone function word ("женщина С
-       двумя овчарками", "молодой В куртке") — a description, never a proper
-       name (see `RU_FUNCTION_WORDS`).
-   Deliberately NOT folded: "<adjective> <role-noun>" forms like "Тёмный маг"
-   (could be a meaningful role character) — those are left to the post-stage-2
-   line-count fold. Russian inflection still means partial coverage for v1. */
-export function isDescriptorName(name: string, language?: string): boolean {
-  const trimmed = name.trim();
-  if (!trimmed) return false;
-  if (/^unknown\b/i.test(trimmed)) return true;
-  if (/^the\s+\S+(\s+\S+)?$/i.test(trimmed)) return true;
-  const parts = trimmed.split(/\s+/);
-  if (parts.length >= 2) {
-    const tail = parts[parts.length - 1].toLowerCase();
-    if (GENERIC_ROLE_TAIL.has(tail)) return true;
-  }
-  if (normaliseBookLanguage(language) === 'ru') {
-    /* Match a lone Russian generic noun (the typical background-speaker form). */
-    if (parts.length === 1 && GENERIC_ROLE_RU.has(parts[0].toLowerCase())) return true;
-    /* A multi-word Russian phrase carrying a standalone function-word token is
-       a DESCRIPTION, not a proper name ("женщина с двумя овчарками на поводке",
-       "молодой в яркой оранжевой куртке"). Strip leading/trailing dashes from
-       each token so a "Имя — с …" dash beat still tokenises cleanly. Safe
-       against real names — they never contain a preposition/conjunction word
-       (see RU_FUNCTION_WORDS). */
-    if (parts.length >= 2) {
-      const hasFunctionWord = parts.some((p) =>
-        RU_FUNCTION_WORDS.has(p.toLowerCase().replace(/^[—–-]+|[—–-]+$/g, '')),
-      );
-      if (hasFunctionWord) return true;
-    }
-  }
-  return false;
-}
 
 function pickBucket(c: CharacterOutput): string {
   /* Female only when the analyzer explicitly tagged it; everything else

--- a/server/src/analyzer/recover-tagged-lines.test.ts
+++ b/server/src/analyzer/recover-tagged-lines.test.ts
@@ -139,6 +139,28 @@ describe('taggedSpeakerIds — localized (es/ru, #1028)', () => {
   });
 });
 
+describe('recoverTaggedNarratorLines — fr/de (activated by #1051 rows)', () => {
+  it('flips a German narrator quote onto the inversion-tagged speaker', () => {
+    const roster = [{ id: 'anna', name: 'Anna' }];
+    const sentences = [
+      { id: 1, chapterId: 1, characterId: 'narrator', text: '„Ich komme mit.“' },
+      { id: 2, chapterId: 1, characterId: 'narrator', text: 'sagte Anna entschlossen.' },
+    ];
+    const { sentences: out, flipped } = recoverTaggedNarratorLines(sentences, roster, 'de');
+    expect(flipped).toBe(1);
+    expect(out[0].characterId).toBe('anna');
+  });
+  it('keeps a 0-line French tagged speaker via taggedSpeakerIds', () => {
+    const roster = [{ id: 'marie', name: 'Marie' }];
+    const ids = taggedSpeakerIds(
+      [{ id: 1, chapterId: 1, characterId: 'narrator', text: '— Bonjour, dit Marie.' }],
+      roster,
+      'fr',
+    );
+    expect(ids.has('marie')).toBe(true);
+  });
+});
+
 describe('recoverTaggedNarratorLines — localized adjacency (es/ru)', () => {
   const ruRoster = [{ id: 'oduvan', name: 'Одуван' }, { id: 'wren', name: 'Рен' }];
 

--- a/server/src/analyzer/recover-tagged-lines.ts
+++ b/server/src/analyzer/recover-tagged-lines.ts
@@ -20,7 +20,7 @@
    keep a 0-line speaker that the prose clearly tags (backstop for speakers whose
    quote isn't narrator-adjacent and so can't be flipped). Pure — no I/O. */
 
-import { grammarFor, tagRegexFor, verbBeatRegexFor, isQuoteBearing } from './tag-grammar.js';
+import { grammarFor, tagRegexesFor, verbBeatRegexFor, isQuoteBearing } from './tag-grammar.js';
 
 interface Sentence {
   id: number;
@@ -100,13 +100,15 @@ export function taggedSpeakerIds(
   if (!g) return new Set<string>(); // unmapped language → stay gated
   const stop = stopwordsFor(g.stopwords);
   const nameToId = buildNameToId(roster, stop);
-  const tagRe = tagRegexFor(g);
+  const tagRes = tagRegexesFor(g);
   const ids = new Set<string>();
   for (const s of sentences) {
-    const m = tagRe.exec(s.text);
-    if (!m) continue;
-    const id = resolveNameToId(m[1], nameToId, stop);
-    if (id) ids.add(id);
+    for (const tagRe of tagRes) {
+      const m = tagRe.exec(s.text);
+      if (!m) continue;
+      const id = resolveNameToId(m[1], nameToId, stop);
+      if (id) ids.add(id);
+    }
   }
   return ids;
 }
@@ -124,10 +126,19 @@ export function recoverTaggedNarratorLines<T extends Sentence>(
   if (!g) return { sentences, flipped: 0, byId: new Map() }; // unmapped → no-op
   const stop = stopwordsFor(g.stopwords);
   const nameToId = buildNameToId(roster, stop);
-  const tagRe = tagRegexFor(g);
+  const tagRes = tagRegexesFor(g);
   const out = sentences.map((s) => ({ ...s }));
   const byId = new Map<string, number>();
   let flipped = 0;
+
+  // helper local to recoverTaggedNarratorLines:
+  const firstTagMatch = (text: string): RegExpExecArray | null => {
+    for (const tagRe of tagRes) {
+      const m = tagRe.exec(text);
+      if (m) return m;
+    }
+    return null;
+  };
 
   const flipQ = (q: T, id: string) => {
     if (q.characterId !== NARRATOR_ID || q.characterId === id) return;
@@ -139,7 +150,7 @@ export function recoverTaggedNarratorLines<T extends Sentence>(
   if (g.flipStrategy === 'preceding') {
     // English — UNCHANGED behaviour: the tag is its own beat; flip the prior sentence.
     for (let i = 1; i < out.length; i++) {
-      const m = tagRe.exec(out[i].text);
+      const m = firstTagMatch(out[i].text);
       if (!m) continue;
       const id = resolveNameToId(m[1], nameToId, stop);
       if (!id) continue;
@@ -161,7 +172,7 @@ export function recoverTaggedNarratorLines<T extends Sentence>(
     !verbBeat.test(q.text); // a neighbour that is itself a tag is never stolen
 
   for (let i = 0; i < out.length; i++) {
-    const m = tagRe.exec(out[i].text);
+    const m = firstTagMatch(out[i].text);
     if (!m) continue;
     const id = resolveNameToId(m[1], nameToId, stop);
     if (!id) continue;

--- a/server/src/analyzer/roster-coverage.test.ts
+++ b/server/src/analyzer/roster-coverage.test.ts
@@ -122,6 +122,12 @@ describe('validateRosterCoverage', () => {
     const v = validateRosterCoverage(LESSOM_BODY, ['Aldous']);
     expect(v.missingSpeakers.map((s) => s.name)).not.toContain('Lessom');
   });
+
+  it('flags a single-hit English speaker that is straight-double-quote adjacent', () => {
+    const body = '"Fine," Lessom agreed.';
+    const res = validateRosterCoverage(body, new Set<string>(['Mara']), DEFAULT_ROSTER_COVERAGE_THRESHOLDS, 'en');
+    expect(res.missingSpeakers.map((s) => s.name)).toContain('Lessom');
+  });
 });
 
 // Minimal character shape — the guard only requires { id, name } on C. (The

--- a/server/src/analyzer/roster-coverage.test.ts
+++ b/server/src/analyzer/roster-coverage.test.ts
@@ -277,31 +277,56 @@ describe('validateAttributionCoverage (#529 half-state)', () => {
   });
 });
 
-describe('roster guard — non-English gate (seam 3d)', () => {
-  it('skips the roster guard for a German book (no false positives from capitalised nouns)', () => {
-    // German prose: every noun is capitalised; "Diener"/"Frau"/"Soldat" before a
-    // verb would false-flag as missing speakers if the English guard ran.
-    const body = '„Ja", sagte der Diener. „Nein", antwortete die Frau. „Schnell", rief der Soldat.';
-    const res = validateRosterCoverage(body, new Set<string>(), DEFAULT_ROSTER_COVERAGE_THRESHOLDS, 'de');
-    expect(res.missingSpeakers).toEqual([]); // gated off → no missing-speaker flags
-    expect(res.ok).toBe(true);
-    expect(res.issues).toEqual([]);
-  });
-
-  it('still runs the guard for English (default language) — Lessom regression intact', () => {
-    // No language arg → defaults to 'en' → guard runs → Lessom flagged.
-    const res = validateRosterCoverage(LESSOM_BODY, new Set<string>(), DEFAULT_ROSTER_COVERAGE_THRESHOLDS);
-    expect(res.missingSpeakers.map((m) => m.name.toLowerCase())).toContain('lessom');
+describe('roster guard — localized detection (es/ru/fr/de) #1051', () => {
+  it('flags a Spanish prose-tagged speaker missing from the roster (Berrin)', () => {
+    const body = '—Está bien —dijo Berrin, mirando la campana.';
+    const res = validateRosterCoverage(body, new Set<string>(['Mara']), DEFAULT_ROSTER_COVERAGE_THRESHOLDS, 'es');
     expect(res.ok).toBe(false);
+    expect(res.missingSpeakers.map((s) => s.name)).toContain('Berrin');
   });
-
-  it('skips the attribution guard for a German book', () => {
-    // German prose tagged with German verbs — attribution guard must not fire.
-    const body = '„Ja", sagte der Diener. „Nein", antwortete die Frau. „Schnell", rief der Soldat.';
-    const roster = [{ id: 'diener', name: 'Diener' }];
-    const sentences = [{ characterId: 'narrator' }];
-    const res = validateAttributionCoverage(body, roster, sentences, DEFAULT_ROSTER_COVERAGE_THRESHOLDS, 'de');
+  it('flags a Russian prose-tagged speaker missing from the roster (Одуван)', () => {
+    const body = '«Одну минуту», — сказал Одуван и улыбнулся.';
+    const res = validateRosterCoverage(body, new Set<string>(['Мара']), DEFAULT_ROSTER_COVERAGE_THRESHOLDS, 'ru');
+    expect(res.ok).toBe(false);
+    expect(res.missingSpeakers.map((s) => s.name)).toContain('Одуван');
+  });
+  it('recovers the German SURNAME, not the title (Frau Schmidt → Schmidt)', () => {
+    const body = '„Guten Tag", sagte Frau Schmidt zu ihrem Nachbarn.';
+    const res = validateRosterCoverage(body, new Set<string>(['Mara']), DEFAULT_ROSTER_COVERAGE_THRESHOLDS, 'de');
+    expect(res.missingSpeakers.map((s) => s.name)).toContain('Schmidt');
+    expect(res.missingSpeakers.map((s) => s.name)).not.toContain('Frau');
+  });
+  it('does NOT flag a Spanish sentence-opener (stopword, finding J)', () => {
+    const body = 'Entonces dijo que la noche sería larga. Entonces dijo otra cosa.';
+    const res = validateRosterCoverage(body, new Set<string>(['Mara']), DEFAULT_ROSTER_COVERAGE_THRESHOLDS, 'es');
+    expect(res.missingSpeakers.map((s) => s.name)).not.toContain('Entonces');
+  });
+  it('still gates an unmapped language (pt → no-op)', () => {
+    const body = 'qualquer coisa';
+    const res = validateRosterCoverage(body, new Set<string>(), DEFAULT_ROSTER_COVERAGE_THRESHOLDS, 'pt');
     expect(res.ok).toBe(true);
-    expect(res.halfStateSpeakers).toEqual([]);
+    expect(res.missingSpeakers).toEqual([]);
+  });
+});
+
+describe('validateAttributionCoverage — localized half-state (es/ru) #1051', () => {
+  it('flags a rostered Spanish speaker prose-tagged but with 0 attributed lines', () => {
+    const body = '—Está bien —dijo Berrin, mirando la campana.';
+    const roster = [{ id: 'berrin', name: 'Berrin' }];
+    const chapterSentences = [{ characterId: 'narrator' }]; // Berrin's quote stranded on narrator
+    const res = validateAttributionCoverage(body, roster, chapterSentences, DEFAULT_ROSTER_COVERAGE_THRESHOLDS, 'es');
+    expect(res.ok).toBe(false);
+    expect(res.halfStateSpeakers.map((s) => s.id)).toContain('berrin');
+  });
+  it('does not flag a rostered Spanish speaker who already has lines', () => {
+    const body = '—Está bien —dijo Berrin.';
+    const roster = [{ id: 'berrin', name: 'Berrin' }];
+    const chapterSentences = [{ characterId: 'berrin' }]; // has a line → not a half-state
+    const res = validateAttributionCoverage(body, roster, chapterSentences, DEFAULT_ROSTER_COVERAGE_THRESHOLDS, 'es');
+    expect(res.halfStateSpeakers.map((s) => s.id)).not.toContain('berrin');
+  });
+  it('still gates an unmapped language (pt → no-op)', () => {
+    const res = validateAttributionCoverage('qualquer', [{ id: 'x', name: 'X' }], [], DEFAULT_ROSTER_COVERAGE_THRESHOLDS, 'pt');
+    expect(res.ok).toBe(true);
   });
 });

--- a/server/src/analyzer/roster-coverage.ts
+++ b/server/src/analyzer/roster-coverage.ts
@@ -29,9 +29,9 @@
    Purity: no I/O, no model calls (the stage-1 call is injected). Mirrors the
    env-override + injected-`call` shape of stage2-coverage.ts. */
 
-import { DIALOGUE_VERBS } from './dialogue-verbs.js';
 import { safeId } from '../util/safe-id.js';
-import { isNonEnglish } from '../tts/language.js';
+import { grammarFor, tagScanRegexesFor } from './tag-grammar.js';
+import { normaliseBookLanguage } from '../tts/language.js';
 
 export interface RosterCoverageThresholds {
   /** A candidate with fewer than this many tags must be quote-adjacent to count. */
@@ -164,7 +164,15 @@ function rosterTokenSet(rosterNames: Iterable<string>): Set<string> {
   return set;
 }
 
-const QUOTE_CHARS = /["“”]/;
+const QUOTE_CHARS = /[“””]/;              // en — UNCHANGED (byte-identity)
+const QUOTE_CHARS_WIDE = /[“””„«»—–]/;    // es/ru/fr/de — guillemets + German „ + dashes
+
+/** A grammar's language sentence-opener stopwords as a Set (es/ru/fr/de). Empty
+    for en (no g.stopwords) so the English path stays byte-identical — the loop
+    still applies the existing isStopword() de-pluralization predicate first. */
+function langStopwords(g: { stopwords?: readonly string[] }): Set<string> {
+  return new Set<string>(g.stopwords ?? []);
+}
 
 /** Scan chapter prose for `<Name> <speech-verb>` tags whose Name is not on the
     roster. See the module header for the false-positive bounding. */
@@ -174,50 +182,54 @@ export function validateRosterCoverage(
   thresholds?: RosterCoverageThresholds,
   language: string = 'en',
 ): RosterCoverageVerdict {
-  // fs-41/fs-50 §4.3 — the [A-Z]+verb roster heuristic is English-only (German
-  // capitalises every noun → false positives; ES/FR invert verb/name → false
-  // negatives). Gate it off for non-English; localisation is a follow-up.
-  if (isNonEnglish(language)) return { ok: true, missingSpeakers: [], issues: [] };
+  const g = grammarFor(language);
+  if (!g) return { ok: true, missingSpeakers: [], issues: [] }; // unmapped → gated
   const t = resolveThresholds(thresholds);
   const roster = rosterTokenSet(rosterNames);
   const ignore = ignoredNames();
-  const verbAlt = DIALOGUE_VERBS.join('|');
-  /* Name = a capitalised token (letters, internal apostrophes/hyphens) directly
-     followed by a lowercase speech verb. Case-sensitive: the verb must be
-     lowercase (a real tag is `Lessom said`, never `Lessom Said`). */
-  const tagRe = new RegExp(`\\b([A-Z][A-Za-z’'\\-]+)\\s+(?:${verbAlt})\\b`, 'g');
+  const langStops = langStopwords(g); // language sentence-opener stopwords (es/ru/fr/de)
+  const tagRes = tagScanRegexesFor(g);
+  // P-1: English keeps the historical NARROW quote set (byte-identity); es/ru/fr/de
+  // use the wide set their dialogue marks require.
+  const quoteChars = normaliseBookLanguage(language) === 'en' ? QUOTE_CHARS : QUOTE_CHARS_WIDE;
 
   const body = bodyText || '';
   interface Acc { name: string; tagCount: number; sampleTag: string; quoteAdjacent: boolean }
   const candidates = new Map<string, Acc>();
+  const seenSpans = new Set<number>(); // R2-1: count each source span once
 
-  for (let m = tagRe.exec(body); m; m = tagRe.exec(body)) {
-    const rawName = stripPossessive(m[1]);
-    const key = rawName.toLowerCase();
-    // Disguise notation ("Marlow-as-Lady-Renna") — the underlying character is
-    // already cast; the prose alias isn't a new speaker.
-    if (key.includes('-as-')) continue;
-    // Contraction guard: "I've"/"You've"/"They'll" → test the root before the
-    // apostrophe against the stopword set so contracted pronouns don't slip in.
-    const root = key.split(/['’]/)[0];
-    if (isStopword(key) || isStopword(root) || ignore.has(key)) continue;
-    if (roster.has(key)) continue;
-    // last-token match (tag "Casper" vs roster token "casper") already covered
-    // because rosterTokenSet stores last tokens too.
-    const start = Math.max(0, m.index - t.quoteProximityChars);
-    const end = Math.min(body.length, m.index + m[0].length + t.quoteProximityChars);
-    const adjacent = QUOTE_CHARS.test(body.slice(start, end));
-    const prev = candidates.get(key);
-    if (prev) {
-      prev.tagCount += 1;
-      prev.quoteAdjacent = prev.quoteAdjacent || adjacent;
-    } else {
-      candidates.set(key, {
-        name: rawName,
-        tagCount: 1,
-        sampleTag: m[0].trim(),
-        quoteAdjacent: adjacent,
-      });
+  for (const tagRe of tagRes) {
+    for (let m = tagRe.exec(body); m; m = tagRe.exec(body)) {
+      const nameIdx = m.index + m[0].indexOf(m[1]);
+      if (seenSpans.has(nameIdx)) continue; // matched by another order already
+      seenSpans.add(nameIdx);
+      const rawName = stripPossessive(m[1]);
+      const key = rawName.toLowerCase();
+      // Disguise notation ("Marlow-as-Lady-Renna") — the underlying character is
+      // already cast; the prose alias isn’t a new speaker.
+      if (key.includes('-as-')) continue;
+      // Contraction guard: "I’ve"/"You’ve"/"They’ll" → test the root before the
+      // apostrophe against the stopword set so contracted pronouns don’t slip in.
+      const root = key.split(/[‘’]/)[0];
+      // English de-pluralization via isStopword (byte-identical); language
+      // sentence-openers via langStops (finding J). en → langStops empty.
+      if (isStopword(key) || isStopword(root) || langStops.has(key) || ignore.has(key)) continue;
+      if (roster.has(key)) continue;
+      const start = Math.max(0, m.index - t.quoteProximityChars);
+      const end = Math.min(body.length, m.index + m[0].length + t.quoteProximityChars);
+      const adjacent = quoteChars.test(body.slice(start, end));
+      const prev = candidates.get(key);
+      if (prev) {
+        prev.tagCount += 1;
+        prev.quoteAdjacent = prev.quoteAdjacent || adjacent;
+      } else {
+        candidates.set(key, {
+          name: rawName,
+          tagCount: 1,
+          sampleTag: m[0].trim(),
+          quoteAdjacent: adjacent,
+        });
+      }
     }
   }
 
@@ -313,13 +325,14 @@ export function validateAttributionCoverage(
   thresholds?: RosterCoverageThresholds,
   language: string = 'en',
 ): AttributionCoverageVerdict {
-  // fs-41/fs-50 §4.3 — same English-only gate as validateRosterCoverage.
-  if (isNonEnglish(language)) return { ok: true, halfStateSpeakers: [], issues: [] };
+  const g = grammarFor(language);
+  if (!g) return { ok: true, halfStateSpeakers: [], issues: [] }; // unmapped → gated
   const t = resolveThresholds(thresholds);
   const tokenToId = rosterTokenToId(roster);
   const ignore = ignoredNames();
-  const verbAlt = DIALOGUE_VERBS.join('|');
-  const tagRe = new RegExp(`\\b([A-Z][A-Za-z’'\\-]+)\\s+(?:${verbAlt})\\b`, 'g');
+  const langStops = langStopwords(g);
+  const tagRes = tagScanRegexesFor(g);
+  const quoteChars = normaliseBookLanguage(language) === 'en' ? QUOTE_CHARS : QUOTE_CHARS_WIDE;
   const body = bodyText || '';
 
   /* Attributed-line counts per character id for THIS chapter. */
@@ -337,31 +350,37 @@ export function validateAttributionCoverage(
     quoteAdjacent: boolean;
   }
   const candidates = new Map<string, Acc>(); // keyed by character id
+  const seenSpans = new Set<number>(); // R2-1
 
-  for (let m = tagRe.exec(body); m; m = tagRe.exec(body)) {
-    const rawName = stripPossessive(m[1]);
-    const key = rawName.toLowerCase();
-    if (key.includes('-as-')) continue;
-    const root = key.split(/['’]/)[0];
-    if (isStopword(key) || isStopword(root) || ignore.has(key)) continue;
-    const id = tokenToId.get(key);
-    if (!id) continue; // not a rostered speaker — that's validateRosterCoverage's job
-    if (id === 'narrator' || id.startsWith('unknown-')) continue; // buckets never flag
-    const start = Math.max(0, m.index - t.quoteProximityChars);
-    const end = Math.min(body.length, m.index + m[0].length + t.quoteProximityChars);
-    const adjacent = QUOTE_CHARS.test(body.slice(start, end));
-    const prev = candidates.get(id);
-    if (prev) {
-      prev.tagCount += 1;
-      prev.quoteAdjacent = prev.quoteAdjacent || adjacent;
-    } else {
-      candidates.set(id, {
-        id,
-        name: rawName,
-        tagCount: 1,
-        sampleTag: m[0].trim(),
-        quoteAdjacent: adjacent,
-      });
+  for (const tagRe of tagRes) {
+    for (let m = tagRe.exec(body); m; m = tagRe.exec(body)) {
+      const nameIdx = m.index + m[0].indexOf(m[1]);
+      if (seenSpans.has(nameIdx)) continue;
+      seenSpans.add(nameIdx);
+      const rawName = stripPossessive(m[1]);
+      const key = rawName.toLowerCase();
+      if (key.includes('-as-')) continue;
+      const root = key.split(/[‘’]/)[0];
+      if (isStopword(key) || isStopword(root) || langStops.has(key) || ignore.has(key)) continue;
+      const id = tokenToId.get(key);
+      if (!id) continue; // not a rostered speaker — that’s validateRosterCoverage's job
+      if (id === 'narrator' || id.startsWith('unknown-')) continue; // buckets never flag
+      const start = Math.max(0, m.index - t.quoteProximityChars);
+      const end = Math.min(body.length, m.index + m[0].length + t.quoteProximityChars);
+      const adjacent = quoteChars.test(body.slice(start, end));
+      const prev = candidates.get(id);
+      if (prev) {
+        prev.tagCount += 1;
+        prev.quoteAdjacent = prev.quoteAdjacent || adjacent;
+      } else {
+        candidates.set(id, {
+          id,
+          name: rawName,
+          tagCount: 1,
+          sampleTag: m[0].trim(),
+          quoteAdjacent: adjacent,
+        });
+      }
     }
   }
 

--- a/server/src/analyzer/roster-coverage.ts
+++ b/server/src/analyzer/roster-coverage.ts
@@ -164,8 +164,12 @@ function rosterTokenSet(rosterNames: Iterable<string>): Set<string> {
   return set;
 }
 
-const QUOTE_CHARS = /[“””]/;              // en — UNCHANGED (byte-identity)
-const QUOTE_CHARS_WIDE = /[“””„«»—–]/;    // es/ru/fr/de — guillemets + German „ + dashes
+// Quote glyphs for the adjacency window, written as \u escapes so an editor
+// can't silently flatten the curly/guillemet chars (P-1 regression guard).
+// QUOTE_CHARS (en, narrow): straight " + curly open/close \u201C \u201D.
+const QUOTE_CHARS = /[\u0022\u201C\u201D]/;
+// QUOTE_CHARS_WIDE (es/ru/fr/de): + \u201E (German low), \u00AB \u00BB (guillemets), \u2014 \u2013 (dashes).
+const QUOTE_CHARS_WIDE = /[\u0022\u201C\u201D\u201E\u00AB\u00BB\u2014\u2013]/;
 
 /** A grammar's language sentence-opener stopwords as a Set (es/ru/fr/de). Empty
     for en (no g.stopwords) so the English path stays byte-identical — the loop

--- a/server/src/analyzer/tag-grammar.test.ts
+++ b/server/src/analyzer/tag-grammar.test.ts
@@ -9,9 +9,13 @@ describe('grammarFor', () => {
     expect(grammarFor('ru-RU')?.flipStrategy).toBe('adjacent');
   });
   it('returns null for unmapped languages (still gated) and empty input', () => {
-    expect(grammarFor('de')).toBeNull();
-    expect(grammarFor('fr')).toBeNull();
+    expect(grammarFor('pt')).toBeNull();
     expect(grammarFor('')).toBe(grammarFor('en')); // '' normalises to en
+  });
+  it('maps fr and de (added in #1051)', () => {
+    expect(grammarFor('fr')?.orders[0]).toBe('verb-name');
+    expect(grammarFor('de')?.orders[0]).toBe('verb-name');
+    expect(grammarFor('de-DE')?.flipStrategy).toBe('adjacent');
   });
 });
 
@@ -117,6 +121,34 @@ describe('stopword suppression for name-verb (finding J)', () => {
     //  grammar stopword set contains the opener so roster-coverage can filter it.)
     expect(grammarFor('es')!.stopwords).toContain('entonces');
     expect(grammarFor('ru')!.stopwords).toContain('тогда');
+  });
+});
+
+describe('fr/de grammar rows (#1051)', () => {
+  it('detects French inversion and name-verb', () => {
+    expect(capturesName('fr', '— Bonjour, dit Marie.')).toBe('Marie');
+    expect(capturesName('fr', 'Marie dit bonjour.')).toBe('Marie');
+  });
+  it('detects German inversion and name-verb', () => {
+    expect(capturesName('de', '„Hallo", sagte Anna.')).toBe('Anna');
+    expect(capturesName('de', 'Anna sagte leise etwas.')).toBe('Anna');
+  });
+  it('skips a German capitalized title and captures the surname', () => {
+    expect(capturesName('de', '„Guten Tag", sagte Frau Schmidt.')).toBe('Schmidt');
+    expect(capturesName('de', 'sagte Herr Berger')).toBe('Berger');
+  });
+  it('captures a lone German title-noun (no surname) for the fold to bucket', () => {
+    expect(capturesName('de', 'sagte Frau')).toBe('Frau');
+  });
+  it('unmapped languages stay gated', () => {
+    expect(grammarFor('pt')).toBeNull();
+  });
+});
+
+describe('QUOTE_GLYPHS recognises German low-opening quote (R2-3)', () => {
+  it('treats „… as quote-bearing', () => {
+    expect(isQuoteBearing('„Hallo, wie geht es dir?')).toBe(true); // opening only
+    expect(isQuoteBearing('«Hola»')).toBe(true);
   });
 });
 

--- a/server/src/analyzer/tag-grammar.test.ts
+++ b/server/src/analyzer/tag-grammar.test.ts
@@ -85,6 +85,41 @@ describe('isQuoteBearing', () => {
   });
 });
 
+/** Helper: does ANY of the language's order-regexes capture `expectedName`? */
+function capturesName(language: string, text: string): string | null {
+  const g = grammarFor(language)!;
+  for (const re of tagRegexesFor(g)) {
+    const m = re.exec(text);
+    if (m) return m[1];
+  }
+  return null;
+}
+
+describe('both-orders detection (es/ru) — finding A array, R2-8 boundaries', () => {
+  it('detects verb-name AND name-verb in Spanish', () => {
+    expect(capturesName('es', '—Está bien —dijo Berrin.')).toBe('Berrin');
+    expect(capturesName('es', 'María dijo algo en voz baja.')).toBe('María');
+  });
+  it('detects name-verb in Russian (trailing boundary after a Cyrillic verb)', () => {
+    expect(capturesName('ru', 'Иван сказал, что согласен.')).toBe('Иван');
+    expect(capturesName('ru', '«…», — сказал Одуван.')).toBe('Одуван');
+  });
+  it('es/ru rows expose two orders, NOT a single alternation regex', () => {
+    expect(tagRegexesFor(grammarFor('es')!).length).toBe(2);
+    expect(tagRegexesFor(grammarFor('ru')!).length).toBe(2);
+  });
+});
+
+describe('stopword suppression for name-verb (finding J)', () => {
+  it('does not capture a Spanish sentence-opener as a name', () => {
+    // "Entonces dijo" — name-verb would capture "Entonces"; the stopword must veto it.
+    // (the guard resolves only rostered/non-stopword candidates; here we assert the
+    //  grammar stopword set contains the opener so roster-coverage can filter it.)
+    expect(grammarFor('es')!.stopwords).toContain('entonces');
+    expect(grammarFor('ru')!.stopwords).toContain('тогда');
+  });
+});
+
 describe('tagScanRegexesFor — body-scan flags (R-4)', () => {
   it('returns global+multiline regexes that still capture the name in group 1', () => {
     const res = tagScanRegexesFor(grammarFor('en')!);

--- a/server/src/analyzer/tag-grammar.test.ts
+++ b/server/src/analyzer/tag-grammar.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { grammarFor, tagRegexFor, verbBeatRegexFor, isQuoteBearing } from './tag-grammar.js';
+import { grammarFor, tagRegexesFor, tagScanRegexesFor, verbBeatRegexFor, isQuoteBearing } from './tag-grammar.js';
 import { DIALOGUE_VERBS } from './dialogue-verbs.js';
 
 describe('grammarFor', () => {
   it('maps en/es/ru and normalises region subtags', () => {
-    expect(grammarFor('en')?.order).toBe('name-verb');
-    expect(grammarFor('es-ES')?.order).toBe('verb-name');
+    expect(grammarFor('en')?.orders[0]).toBe('name-verb');
+    expect(grammarFor('es-ES')?.orders[0]).toBe('verb-name');
     expect(grammarFor('ru-RU')?.flipStrategy).toBe('adjacent');
   });
   it('returns null for unmapped languages (still gated) and empty input', () => {
@@ -15,24 +15,24 @@ describe('grammarFor', () => {
   });
 });
 
-describe('tagRegexFor — English is byte-identical to the historical regex', () => {
+describe('tagRegexesFor — English is byte-identical to the historical regex', () => {
   it('reproduces makeTagRegex source with no u/g flag', () => {
-    const re = tagRegexFor(grammarFor('en')!);
+    const re = tagRegexesFor(grammarFor('en')!)[0];
     expect(re.source).toBe(`\\b([A-Z][A-Za-z’'-]+)\\s+(?:${DIALOGUE_VERBS.join('|')})\\b`);
     expect(re.flags).toBe('');
   });
   it('captures the name before the verb', () => {
-    expect(tagRegexFor(grammarFor('en')!).exec('Behnam noted.')?.[1]).toBe('Behnam');
+    expect(tagRegexesFor(grammarFor('en')!)[0].exec('Behnam noted.')?.[1]).toBe('Behnam');
   });
   it('captures an English name containing a typographic apostrophe (byte-identity guard)', () => {
-    // Historical regex class is [A-Za-z’'-]; a curly-apostrophe name must capture in full.
+    // Historical regex class is [A-Za-z''-]; a curly-apostrophe name must capture in full.
     const name = 'D’Artagnan';
-    expect(tagRegexFor(grammarFor('en')!).exec(`${name} said hello`)?.[1]).toBe(name);
+    expect(tagRegexesFor(grammarFor('en')!)[0].exec(`${name} said hello`)?.[1]).toBe(name);
   });
 });
 
-describe('tagRegexFor — Spanish (verb-name)', () => {
-  const re = () => tagRegexFor(grammarFor('es')!);
+describe('tagRegexesFor — Spanish (verb-name)', () => {
+  const re = () => tagRegexesFor(grammarFor('es')!)[0];
   it('uses the u flag', () => expect(re().flags).toBe('u'));
   it('captures the name after the verb on a quote beat', () => {
     expect(re().exec('«Está bien», dijo Berrin.')?.[1]).toBe('Berrin');
@@ -50,8 +50,8 @@ describe('tagRegexFor — Spanish (verb-name)', () => {
   });
 });
 
-describe('tagRegexFor — Russian (verb-name)', () => {
-  const re = () => tagRegexFor(grammarFor('ru')!);
+describe('tagRegexesFor — Russian (verb-name)', () => {
+  const re = () => tagRegexesFor(grammarFor('ru')!)[0];
   it('captures the name after a gendered verb', () => {
     expect(re().exec('«…», — сказала Рен.')?.[1]).toBe('Рен');
   });
@@ -82,5 +82,18 @@ describe('isQuoteBearing', () => {
     expect(isQuoteBearing('—Está bien')).toBe(true);
     expect(isQuoteBearing('то потеряю сварку».')).toBe(true);
     expect(isQuoteBearing('La viuda asesoró sin piedad.')).toBe(false);
+  });
+});
+
+describe('tagScanRegexesFor — body-scan flags (R-4)', () => {
+  it('returns global+multiline regexes that still capture the name in group 1', () => {
+    const res = tagScanRegexesFor(grammarFor('en')!);
+    expect(res.length).toBe(1);
+    for (const re of res) {
+      expect(re.global).toBe(true);
+      expect(re.multiline).toBe(true);
+    }
+    const m = res[0].exec('Wren said hello.');
+    expect(m?.[1]).toBe('Wren');
   });
 });

--- a/server/src/analyzer/tag-grammar.ts
+++ b/server/src/analyzer/tag-grammar.ts
@@ -40,9 +40,14 @@ const RU_VERBS = [
 ] as const;
 const ES_STOPWORDS = [
   'él', 'ella', 'ellos', 'ellas', 'este', 'esta', 'eso', 'que', 'quien', 'aquí', 'allí',
+  // name-verb openers (finding J)
+  'entonces', 'luego', 'después', 'así', 'pero', 'aunque', 'mientras', 'cuando',
+  'también', 'además', 'sin', 'por', 'finalmente', 'de', 'pronto',
 ] as const;
 const RU_STOPWORDS = [
   'он', 'она', 'оно', 'они', 'это', 'тот', 'та', 'кто', 'что', 'там', 'тут', 'так', 'вот',
+  // name-verb openers (finding J)
+  'тогда', 'потом', 'затем', 'однако', 'хотя', 'наконец', 'вдруг', 'теперь', 'здесь',
 ] as const;
 
 // English name token — IDENTICAL to the historical makeTagRegex character class.
@@ -52,8 +57,8 @@ const UNI_NAME = "\\p{Lu}[\\p{L}’'-]+";
 
 const TAG_GRAMMARS: Record<string, TagGrammar> = {
   en: { verbs: DIALOGUE_VERBS, orders: ['name-verb'], nameCapture: EN_NAME, flipStrategy: 'preceding' },
-  es: { verbs: ES_VERBS, orders: ['verb-name'], nameCapture: UNI_NAME, flipStrategy: 'adjacent', stopwords: ES_STOPWORDS },
-  ru: { verbs: RU_VERBS, orders: ['verb-name'], nameCapture: UNI_NAME, flipStrategy: 'adjacent', stopwords: RU_STOPWORDS },
+  es: { verbs: ES_VERBS, orders: ['verb-name', 'name-verb'], nameCapture: UNI_NAME, flipStrategy: 'adjacent', stopwords: ES_STOPWORDS },
+  ru: { verbs: RU_VERBS, orders: ['verb-name', 'name-verb'], nameCapture: UNI_NAME, flipStrategy: 'adjacent', stopwords: RU_STOPWORDS },
 };
 
 /** Grammar row for a book language, or null when unmapped (caller stays gated). */

--- a/server/src/analyzer/tag-grammar.ts
+++ b/server/src/analyzer/tag-grammar.ts
@@ -23,6 +23,8 @@ export interface TagGrammar {
   flipStrategy: 'preceding' | 'adjacent';
   /** Pronouns/articles that look like a name in verb-name order but aren't. */
   stopwords?: readonly string[];
+  /** Capitalized honorifics to skip before the name in verb-name order (de). */
+  titles?: readonly string[];
 }
 
 // Curated, inclusion-biased (a missing verb silently drops a real speaker; an
@@ -49,6 +51,31 @@ const RU_STOPWORDS = [
   // name-verb openers (finding J)
   'тогда', 'потом', 'затем', 'однако', 'хотя', 'наконец', 'вдруг', 'теперь', 'здесь',
 ] as const;
+const FR_VERBS = [
+  'dit', 'demanda', 'répondit', 'répliqua', 'ajouta', 'cria', 'murmura',
+  'chuchota', 's’exclama', 'reprit', 'répéta', 'insista', 'continua', 'soupira',
+  'lança', 'ordonna',
+] as const;
+const DE_VERBS = [
+  'sagte', 'fragte', 'antwortete', 'erwiderte', 'rief', 'flüsterte', 'murmelte',
+  'entgegnete', 'fuhr', 'meinte', 'erklärte', 'wiederholte', 'fügte', 'seufzte',
+  'brüllte', 'stammelte',
+] as const;
+const FR_STOPWORDS = [
+  'il', 'elle', 'ils', 'elles', 'je', 'tu', 'nous', 'vous', 'ce', 'cela', 'qui', 'que',
+  'alors', 'puis', 'ensuite', 'mais', 'donc', 'quand', 'enfin', 'ici', 'là',
+] as const;
+const DE_STOPWORDS = [
+  'er', 'sie', 'es', 'ich', 'du', 'wir', 'ihr', 'das', 'dies', 'wer', 'was',
+  'dann', 'da', 'als', 'doch', 'aber', 'also', 'hier', 'dort', 'schließlich', 'plötzlich',
+] as const;
+/* German honorifics: capitalized, so the lowercase role-token skip in the verb-name
+   regex won't skip them — list them explicitly to capture the following surname. */
+const DE_TITLES = [
+  'Herr', 'Frau', 'Fräulein', 'Dr', 'Doktor', 'Professor', 'Prof', 'Graf',
+  'Gräfin', 'Baron', 'Baronin', 'König', 'Königin', 'Prinz', 'Prinzessin',
+  'Meister', 'Hauptmann',
+] as const;
 
 // English name token — IDENTICAL to the historical makeTagRegex character class.
 const EN_NAME = "[A-Z][A-Za-z’'-]+";
@@ -59,6 +86,8 @@ const TAG_GRAMMARS: Record<string, TagGrammar> = {
   en: { verbs: DIALOGUE_VERBS, orders: ['name-verb'], nameCapture: EN_NAME, flipStrategy: 'preceding' },
   es: { verbs: ES_VERBS, orders: ['verb-name', 'name-verb'], nameCapture: UNI_NAME, flipStrategy: 'adjacent', stopwords: ES_STOPWORDS },
   ru: { verbs: RU_VERBS, orders: ['verb-name', 'name-verb'], nameCapture: UNI_NAME, flipStrategy: 'adjacent', stopwords: RU_STOPWORDS },
+  fr: { verbs: FR_VERBS, orders: ['verb-name', 'name-verb'], nameCapture: UNI_NAME, flipStrategy: 'adjacent', stopwords: FR_STOPWORDS },
+  de: { verbs: DE_VERBS, orders: ['verb-name', 'name-verb'], nameCapture: UNI_NAME, flipStrategy: 'adjacent', stopwords: DE_STOPWORDS, titles: DE_TITLES },
 };
 
 /** Grammar row for a book language, or null when unmapped (caller stays gated). */
@@ -83,9 +112,13 @@ function buildOrderRegex(g: TagGrammar, order: 'name-verb' | 'verb-name'): RegEx
     // BOTH ends (e.g. trailing \b after Cyrillic "сказал") — use lookarounds (R2-8).
     return new RegExp(`(?<!\\p{L})(${g.nameCapture})\\s+(?:${verbs})(?!\\p{L})`, 'u');
   }
-  // verb-name: beat + verb + up to two lowercase role tokens + the name.
+  // verb-name: beat + verb + up to two lowercase role tokens + optional
+  // capitalized title (de) + the name.
+  const titleSkip = g.titles?.length
+    ? `(?:(?:${g.titles.join('|')})\\.?\\s+)?`
+    : '';
   return new RegExp(
-    `${VERB_BEAT}(?:${verbs})\\s+(?:\\p{Ll}[\\p{L}''-]*\\s+){0,2}(${g.nameCapture})`,
+    `${VERB_BEAT}(?:${verbs})\\s+(?:\\p{Ll}[\\p{L}''-]*\\s+){0,2}${titleSkip}(${g.nameCapture})`,
     'u',
   );
 }
@@ -126,7 +159,7 @@ export function verbBeatRegexFor(g: TagGrammar): RegExp {
   return new RegExp(alts.join('|'), 'u');
 }
 
-const QUOTE_GLYPHS = /[«»"""]|^\s*[—–]/u;
+const QUOTE_GLYPHS = /[«»„"""]|^\s*[—–]/u;
 /** True if the sentence looks like (part of) a quote: a guillemet/curly/straight
     quote glyph, or a leading em/en-dash (ES/RU dialogue opener). */
 export function isQuoteBearing(text: string): boolean {

--- a/server/src/analyzer/tag-grammar.ts
+++ b/server/src/analyzer/tag-grammar.ts
@@ -11,9 +11,11 @@ export interface TagGrammar {
   /** Localized dialogue verbs. All gendered/inflected surface forms listed
       explicitly (not stemmed): RU 'сказал' AND 'сказала'. Inclusion-biased. */
   verbs: readonly string[];
-  /** Word order of the tag relative to the name. Also selects the regex flag
-      set: 'name-verb' is ASCII (no `u`), 'verb-name' uses `u` for \p{Lu}/\p{L}. */
-  order: 'name-verb' | 'verb-name';
+  /** Word orders the language uses, in priority. Each yields its own regex
+      (NEVER a single alternation — finding A: that would move the name out of
+      capture group 1). en is name-verb only; es/ru/fr/de gain a second order
+      in a later task. */
+  orders: readonly ('name-verb' | 'verb-name')[];
   /** Regex source (no flags) capturing one capitalized name token. */
   nameCapture: string;
   /** Flip target: 'preceding' (en, the prior sentence) or 'adjacent' (es/ru,
@@ -49,9 +51,9 @@ const EN_NAME = "[A-Z][A-Za-z’'-]+";
 const UNI_NAME = "\\p{Lu}[\\p{L}’'-]+";
 
 const TAG_GRAMMARS: Record<string, TagGrammar> = {
-  en: { verbs: DIALOGUE_VERBS, order: 'name-verb', nameCapture: EN_NAME, flipStrategy: 'preceding' },
-  es: { verbs: ES_VERBS, order: 'verb-name', nameCapture: UNI_NAME, flipStrategy: 'adjacent', stopwords: ES_STOPWORDS },
-  ru: { verbs: RU_VERBS, order: 'verb-name', nameCapture: UNI_NAME, flipStrategy: 'adjacent', stopwords: RU_STOPWORDS },
+  en: { verbs: DIALOGUE_VERBS, orders: ['name-verb'], nameCapture: EN_NAME, flipStrategy: 'preceding' },
+  es: { verbs: ES_VERBS, orders: ['verb-name'], nameCapture: UNI_NAME, flipStrategy: 'adjacent', stopwords: ES_STOPWORDS },
+  ru: { verbs: RU_VERBS, orders: ['verb-name'], nameCapture: UNI_NAME, flipStrategy: 'adjacent', stopwords: RU_STOPWORDS },
 };
 
 /** Grammar row for a book language, or null when unmapped (caller stays gated). */
@@ -64,24 +66,59 @@ export function grammarFor(language: string): TagGrammar | null {
 // alternative (else a narrative polysemous verb false-matches — spec C).
 const VERB_BEAT = '(?:^|[—–\\-«»""",:]\\s*)';
 
-/** Full tag regex: one capture group = the speaker name. No `g` flag. */
-export function tagRegexFor(g: TagGrammar): RegExp {
+/* Build ONE regex for a single order. Name is capture group 1. No flags. */
+function buildOrderRegex(g: TagGrammar, order: 'name-verb' | 'verb-name'): RegExp {
   const verbs = g.verbs.join('|');
-  if (g.order === 'name-verb') {
-    // Byte-identical to the historical makeTagRegex (no `u`, no `g`).
-    return new RegExp(`\\b(${g.nameCapture})\\s+(?:${verbs})\\b`);
+  if (order === 'name-verb') {
+    if (g.nameCapture === EN_NAME) {
+      // English: byte-identical to the historical makeTagRegex (ASCII \b, no u).
+      return new RegExp(`\\b(${g.nameCapture})\\s+(?:${verbs})\\b`);
+    }
+    // Unicode languages: \b is ASCII-only and fails next to non-ASCII letters on
+    // BOTH ends (e.g. trailing \b after Cyrillic "сказал") — use lookarounds (R2-8).
+    return new RegExp(`(?<!\\p{L})(${g.nameCapture})\\s+(?:${verbs})(?!\\p{L})`, 'u');
   }
   // verb-name: beat + verb + up to two lowercase role tokens + the name.
-  return new RegExp(`${VERB_BEAT}(?:${verbs})\\s+(?:\\p{Ll}[\\p{L}''-]*\\s+){0,2}(${g.nameCapture})`, 'u');
+  return new RegExp(
+    `${VERB_BEAT}(?:${verbs})\\s+(?:\\p{Ll}[\\p{L}''-]*\\s+){0,2}(${g.nameCapture})`,
+    'u',
+  );
 }
 
-/** "This text carries a dialogue verb on a beat" — name NOT required. Used to
-    disqualify a flip neighbour that is itself a tag (resolvable OR pronoun). */
+/** One regex PER order (finding A: array, not alternation). Name = group 1 each.
+    No `g` flag — for the per-sentence `.exec` model (recover-tagged-lines.ts). */
+export function tagRegexesFor(g: TagGrammar): RegExp[] {
+  return g.orders.map((order) => buildOrderRegex(g, order));
+}
+
+/** Body-scan variants: one FRESH regex PER order, each global (+ multiline so
+    VERB_BEAT's ^ matches each line start). Body-scan ONLY — never use in the
+    per-sentence model (its lastIndex would leak across sentences). */
+export function tagScanRegexesFor(g: TagGrammar): RegExp[] {
+  return g.orders.map((order) => {
+    const re = buildOrderRegex(g, order);
+    // Strip BOTH g and m before re-adding so a future builder that adds either
+    // can't produce a duplicate-flag SyntaxError (P-3). Preserves u when present.
+    return new RegExp(re.source, re.flags.replace(/[gm]/g, '') + 'gm');
+  });
+}
+
+/** "This text carries a dialogue verb on a beat" — name NOT required; used to
+    disqualify a flip neighbour that is itself a tag. OR of every order's beat;
+    Unicode-safe (JS \b never fires on Cyrillic). */
 export function verbBeatRegexFor(g: TagGrammar): RegExp {
   const verbs = g.verbs.join('|');
-  if (g.order === 'name-verb') return new RegExp(`\\b(?:${verbs})\\b`);
-  // \b does not fire on Cyrillic (non-ASCII-word chars); use \p{L} lookahead instead.
-  return new RegExp(`${VERB_BEAT}(?:${verbs})(?!\\p{L})`, 'u');
+  const alts: string[] = [];
+  for (const order of g.orders) {
+    if (order === 'name-verb') {
+      // ASCII for en (byte-identical), Unicode-safe lookarounds otherwise.
+      alts.push(g.nameCapture === EN_NAME ? `\\b(?:${verbs})\\b` : `(?<!\\p{L})(?:${verbs})(?!\\p{L})`);
+    } else {
+      alts.push(`${VERB_BEAT}(?:${verbs})(?!\\p{L})`);
+    }
+  }
+  // `u` is required by \p{…}; harmless for the en-only ASCII alternative.
+  return new RegExp(alts.join('|'), 'u');
 }
 
 const QUOTE_GLYPHS = /[«»"""]|^\s*[—–]/u;


### PR DESCRIPTION
## Summary

Localizes two previously English-only analyzer heuristics for **es, ru, fr, de**, reusing the per-language `tag-grammar.ts` substrate shipped in #1028/#1049:

- **#1050 — minor-cast descriptor fold** (`isDescriptorName`): Spanish/French/German background descriptors now fold into the `unknown-male/female` buckets instead of each leaking a one-off voice slot.
- **#1051 — roster-coverage guard** (`validateRosterCoverage` / `validateAttributionCoverage`): a speaker stage-1 drops from the roster is now recovered for es/ru/fr/de. This is the actual fix for the on-box Berrin/Ivo loss that motivated #1028 (which was rostered-only and so couldn't help an under-rostered speaker).

English behavior is **byte-identical** throughout; unmapped languages stay gated (`grammarFor()`/`descriptorGrammarFor()` → `null` → no-op).

## What changed

**New `descriptor-grammar.ts` (#1050)** — per-language descriptor data (es/ru/fr/de extras) consumed by the fold. The English rules (`Unknown` / `The <1-2 words>` / trailing role noun) stay a universal baseline; the function-word "phrase" rule is **ru-only** (Romance/German names carry nobiliary particles like `de Gaulle`, `von Bismarck`, so folding on those would swallow real characters — negative tests pin this). `fold-minor-cast.ts` now consumes the module; its inline constants were removed.

**`tag-grammar.ts` (#1051)** — `order` → `orders[]` with a **per-order regex array** (`tagRegexesFor`/`tagScanRegexesFor`), never a single alternation, so the name stays capture group 1 (Node-20 has no duplicate-named-group support). `tagRegexFor` removed. es/ru/fr/de gain **both-orders** detection (verb-name + name-verb) with Unicode-safe boundaries (`(?<!\p{L})…(?!\p{L})`) for non-English. New `fr`/`de` rows; a **German capitalized-title skip** so `sagte Frau Schmidt` recovers `Schmidt`, not `Frau`. `QUOTE_GLYPHS` gained the German low-opening quote `„` (U+201E).

**`roster-coverage.ts` (#1051)** — the `isNonEnglish` no-op gate is replaced by the grammar null-guard in both functions; the body scan is driven by `tagScanRegexesFor` with per-position dedupe (so one tag matched by two orders can't slip the ≥2-hits false-positive bound). `QUOTE_CHARS` stays narrow for English (byte-identity) with a wide `QUOTE_CHARS_WIDE` (guillemets + `„` + dashes) selected by language. Both quote sets are written as `\u` escapes (flatten-proof). Language stopwords expanded for name-verb sentence-openers.

**`recover-tagged-lines.ts`** — its three name-extraction sites loop over the regex array (en unchanged). Adding fr/de rows intentionally activates #1028's narrator-flip + keep-protection for those languages.

Call sites in `routes/analysis.ts` were verified (no change needed): `language` already threads to the roster guard and all three `foldMinorCast` passes (incl. the interim `nameOnly` pass).

## Test plan

Built via subagent-driven TDD (8 tasks, per-task review + a whole-branch opus review). Local battery green in an isolated worktree:

- Server tests: **3413 passed** (8 skipped). New/changed analyzer suites: descriptor-grammar, tag-grammar, roster-coverage, recover-tagged-lines, fold-minor-cast.
- Frontend tests: **3073 passed**. Typecheck (frontend + server): clean. Lint (`--max-warnings 0`): clean. Build: clean.
- English byte-identity asserted at the source/byte level (en regex `.source` unchanged, ASCII `\b` retained, `EN_NAME`/`UNI_NAME` keep the U+2019 curly apostrophe, `D'Artagnan` captures in full, narrow `QUOTE_CHARS`).
- Review caught and fixed a silent Unicode regression: the editor flattened the straight `"` in `QUOTE_CHARS` to a curly quote (breaking English straight-quote adjacency); fixed via `\u` escapes + a single-hit straight-quote regression test (RED→GREEN).

Regression plan: `docs/superpowers/specs/2026-06-24-es-ru-fr-de-analyzer-heuristic-localization-design.md` (two folded-in adversarial-review rounds) and the implementation plan alongside it.

## Owed validation (post-merge, on-box — could not run in this environment)

Both-orders detection changes the **accepted Spanish render**, so the operator acceptance is owed again:

- **es re-acceptance** — re-run the Gemini analysis of `samples/the-coalfall-commission/manuscript.es.md`; pass = **Berrin and Ivo appear as their own cast members** and `«Está bien»` attributes to `berrin` (not `unknown-male`).
- **ru** equivalent once its background pass lands; **fr/de** smoke pass on the translated Coalfall fixtures.

These are post-merge gates, not blockers on landing the unit-tested code.

## Deferred follow-ups (cosmetic, from the final review)

- `recover-tagged-lines.test.ts` — the `'non-English gate (seam 3d)'` describe block name/comments are now stale (de is mapped; those tests pass because English verbs aren't in `DE_VERBS`, not because de is gated). Worth a rename.
- The new es fold keep-protection test uses a raw object literal instead of the file's `makeChar` helper.

Closes #1050
Closes #1051

🤖 Generated with [Claude Code](https://claude.com/claude-code)
