### PR TITLE
fix(frontend,server): manuscript review-session fixes + analyzer model pill

### DIFF
--- a/server/src/routes/annotate-emotion.test.ts
+++ b/server/src/routes/annotate-emotion.test.ts
@@ -53,7 +53,7 @@ function bookDir(): string {
   return join(workspaceRoot, 'books', AUTHOR, SERIES, BOOK);
 }
 
-function writeBook(sentences: unknown[] | null): void {
+function writeBook(sentences: unknown[] | null, chapters: unknown[] = []): void {
   const dir = bookDir();
   mkdirSync(join(dir, '.audiobook'), { recursive: true });
   writeFileSync(
@@ -68,7 +68,7 @@ function writeBook(sentences: unknown[] | null): void {
       isStandalone: true,
       manuscriptFile: 'manuscript.txt',
       castConfirmed: true,
-      chapters: [],
+      chapters,
       coverGradient: ['#000', '#fff'],
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
@@ -179,6 +179,33 @@ describe('POST /api/books/:bookId/annotate-emotion', () => {
   it('404s for an unknown book', async () => {
     const res = await request(app).post(`/api/books/does-not-exist/annotate-emotion`).send({});
     expect(res.status).toBe(404);
+  });
+
+  it('skips chapters the user excluded from narration', async () => {
+    writeBook(SENTENCES, [
+      { id: 1, title: 'One', slug: 'one' },
+      { id: 2, title: 'Two', slug: 'two', excluded: true },
+    ]);
+    runEmotion.mockImplementation((_m, chapterId): Promise<EmotionAnnotationOutput> =>
+      Promise.resolve({
+        annotations:
+          chapterId === 1
+            ? [{ sentenceId: 2, emotion: 'angry' }]
+            : [{ sentenceId: 3, emotion: 'sad' }],
+      }),
+    );
+
+    const res = await request(app).post(`/api/books/${bookId}/annotate-emotion`).send({});
+    expect(res.status).toBe(200);
+
+    // The analyzer is only called for the included chapter, never the excluded one.
+    const calledChapters = runEmotion.mock.calls.map((c) => c[1]);
+    expect(calledChapters).toContain(1);
+    expect(calledChapters).not.toContain(2);
+
+    const events = parseSse(res.text);
+    expect(events.some((e) => e.kind === 'annotation' && e.chapterId === 1)).toBe(true);
+    expect(events.some((e) => e.kind === 'annotation' && e.chapterId === 2)).toBe(false);
   });
 
   it('on mid-pass daily-quota exhaustion, keeps already-streamed chapters and stops with quota_exhausted', async () => {

--- a/server/src/routes/annotate-emotion.ts
+++ b/server/src/routes/annotate-emotion.ts
@@ -114,7 +114,16 @@ annotateEmotionRouter.post(
     }
 
     const byChapter = await loadPostFoldSentencesByChapter(manuscriptId, located.bookDir);
-    const chapterIds = [...byChapter.keys()].sort((a, b) => a - b);
+    /* Skip chapters the user excluded from narration (front/back-matter they
+       opted out of). Mirrors the generation route's `!c.excluded` filter
+       (analysis.ts) so emotion detection never burns analyzer calls on
+       chapters that will never be rendered. */
+    const excludedChapterIds = new Set<number>(
+      located.state.chapters.filter((c) => c.excluded).map((c) => c.id),
+    );
+    const chapterIds = [...byChapter.keys()]
+      .filter((id) => !excludedChapterIds.has(id))
+      .sort((a, b) => a - b);
 
     /* SSE setup (mirrors analysis.ts). */
     res.setHeader('Content-Type', 'text/event-stream');

--- a/server/src/routes/script-review.test.ts
+++ b/server/src/routes/script-review.test.ts
@@ -54,7 +54,7 @@ function bookDir(): string {
   return join(workspaceRoot, 'books', AUTHOR, SERIES, BOOK);
 }
 
-function writeBook(sentences: unknown[] | null): void {
+function writeBook(sentences: unknown[] | null, chapters: unknown[] = []): void {
   const dir = bookDir();
   mkdirSync(join(dir, '.audiobook'), { recursive: true });
   writeFileSync(
@@ -69,7 +69,7 @@ function writeBook(sentences: unknown[] | null): void {
       isStandalone: true,
       manuscriptFile: 'manuscript.txt',
       castConfirmed: true,
-      chapters: [],
+      chapters,
       coverGradient: ['#000', '#fff'],
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
@@ -159,6 +159,30 @@ describe('POST /api/books/:bookId/script-review', () => {
 
     const result = events.find((e) => e.kind === 'result');
     expect(result).toMatchObject({ done: true, reviewedChapters: 2 });
+  });
+
+  it('skips excluded chapters on a whole-book review but honours an explicit per-chapter request', async () => {
+    writeBook(SENTENCES, [
+      { id: 1, title: 'One', slug: 'one' },
+      { id: 2, title: 'Two', slug: 'two', excluded: true },
+    ]);
+    runReview.mockResolvedValue(CANNED_OPS);
+
+    // Whole-book review: the excluded chapter 2 must be skipped.
+    const whole = await request(app).post(`/api/books/${bookId}/script-review`).send({});
+    expect(whole.status).toBe(200);
+    const wholeChapters = runReview.mock.calls.map((c) => c[1]);
+    expect(wholeChapters).toContain(1);
+    expect(wholeChapters).not.toContain(2);
+
+    // An explicit per-chapter request for the excluded chapter is still honoured.
+    runReview.mockClear();
+    const single = await request(app)
+      .post(`/api/books/${bookId}/script-review`)
+      .send({ chapterId: 2 });
+    expect(single.status).toBe(200);
+    expect(runReview).toHaveBeenCalledTimes(1);
+    expect(runReview.mock.calls[0][1]).toBe(2);
   });
 
   it('limits the pass to one chapter when chapterId is provided', async () => {

--- a/server/src/routes/script-review.ts
+++ b/server/src/routes/script-review.ts
@@ -145,6 +145,14 @@ scriptReviewRouter.post(
     let chapterIds = [...byChapter.keys()].sort((a, b) => a - b);
     if (requestedChapterId !== undefined) {
       chapterIds = chapterIds.filter((id) => id === requestedChapterId);
+    } else {
+      /* Whole-book review skips chapters the user excluded from narration
+         (front/back-matter). Mirrors the detect-emotions + generation filters.
+         An explicit per-chapter request above is honoured even when excluded. */
+      const excludedChapterIds = new Set<number>(
+        located.state.chapters.filter((c) => c.excluded).map((c) => c.id),
+      );
+      chapterIds = chapterIds.filter((id) => !excludedChapterIds.has(id));
     }
 
     /* Load the post-fold cast roster so the prompt carries character names+roles.

--- a/src/components/detect-emotions-button.tsx
+++ b/src/components/detect-emotions-button.tsx
@@ -97,7 +97,7 @@ export function DetectEmotionsButton({ disabled = false }: { disabled?: boolean 
         title={
           disabled
             ? 'Analyse the book first to detect emotions'
-            : 'Detect per-quote delivery emotions across the whole book'
+            : 'Detect per-quote delivery emotions across all included chapters'
         }
         className="shrink-0 inline-flex items-center gap-2 px-4 min-h-11 rounded-full border border-ink/15 text-sm font-semibold text-ink hover:bg-ink/5 disabled:opacity-40"
       >
@@ -118,12 +118,12 @@ export function DetectEmotionsButton({ disabled = false }: { disabled?: boolean 
         <span
           role="dialog"
           aria-label="Detect emotions"
-          className="absolute z-50 left-0 top-full mt-2 w-72 rounded-xl border border-ink/10 bg-canvas shadow-lg p-3 text-left"
+          className="absolute z-50 left-0 top-full mt-2 w-72 rounded-xl border border-ink/10 bg-white picker-surface shadow-lg p-3 text-left"
         >
           <p className="text-xs text-ink/70 leading-snug">
-            Run an LLM pass over the whole book to detect per-quote delivery emotions. This uses
-            your analyzer quota and can take a few minutes on a long book. Hand-set emotions are
-            never overwritten.
+            Run an LLM pass over all included chapters to detect per-quote delivery emotions. This
+            uses your analyzer quota and can take a few minutes on a long book. Hand-set emotions
+            are never overwritten.
           </p>
           <div className="mt-3 flex items-center justify-end gap-2">
             <button

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1212,6 +1212,7 @@ export function Layout() {
       kind,
       subsetChapterIds,
       phaseElapsedMs,
+      model,
     } = analysisStream;
     /* Single source of truth for work-weighted analysis progress —
        shared with the analysing view's "Overall" bar via
@@ -1249,6 +1250,7 @@ export function Layout() {
          undefined. */
       kind,
       subsetChapterCount: kind === 'subset' ? (subsetChapterIds?.length ?? 0) : undefined,
+      model,
       onClick: () => {
         if (streamBookId) {
           navigate(`/books/${streamBookId}/analysing`);

--- a/src/components/script-review-diff.test.tsx
+++ b/src/components/script-review-diff.test.tsx
@@ -82,6 +82,29 @@ describe('fs-58 — ScriptReviewDiff', () => {
     expect(container.firstChild).toBeNull();
   });
 
+  it('shows an explicit empty state (not a blank body) when there are zero suggestions', () => {
+    const store = configureStore({
+      reducer: {
+        ui: uiSlice.reducer,
+        manuscript: manuscriptSlice.reducer,
+        scriptReview: scriptReviewSlice.reducer,
+        changeLog: changeLogSlice.reducer,
+      },
+    });
+    /* A review that produced no ops still opens the modal (the bucket exists).
+       Before the fix this rendered a blank body; now it must show a clear
+       "No suggestions found" empty state. */
+    store.dispatch(scriptReviewActions.setReview({ bookId: 'book-A', ops: [], unappliable: [] }));
+    render(
+      <Provider store={store}>
+        <ScriptReviewDiff bookId="book-A" />
+      </Provider>,
+    );
+    expect(screen.getByText('Script review suggestions')).toBeTruthy();
+    expect(screen.getByTestId('script-review-empty')).toBeInTheDocument();
+    expect(screen.getByText('No suggestions found')).toBeInTheDocument();
+  });
+
   it('applies selected ops and skips deselected ops on Apply', () => {
     const store = makeStore();
     render(

--- a/src/components/script-review-diff.tsx
+++ b/src/components/script-review-diff.tsx
@@ -167,6 +167,19 @@ export function ScriptReviewDiff({ bookId }: { bookId: string }) {
                 {' '}(stale text or invalid)
               </div>
             )}
+            {classes.length === 0 && (
+              <div
+                data-testid="script-review-empty"
+                className="rounded-2xl border border-ink/10 bg-canvas/50 px-6 py-10 text-center"
+              >
+                <p className="text-sm font-medium text-ink/70">No suggestions found</p>
+                <p className="mt-1 text-xs text-ink/50">
+                  {unappliable.length > 0
+                    ? "All suggestions were stale or invalid and couldn't be applied."
+                    : "The reviewer didn't find anything to change in this scope."}
+                </p>
+              </div>
+            )}
             {classes.map((cls) => {
               const classOps = byClass.get(cls) ?? [];
               const allClassSelected = classOps.every(

--- a/src/components/sentence-emotion-control.test.tsx
+++ b/src/components/sentence-emotion-control.test.tsx
@@ -56,6 +56,22 @@ describe('fs-25 — SentenceEmotionControl', () => {
     expect(store.getState().manuscript.sentences[0].emotion).toBe('angry');
   });
 
+  it('renders the variant menu as an opaque elevated surface (picker-surface, not bg-canvas)', () => {
+    const store = makeStore([{ id: 2, chapterId: 1, characterId: 'wren', text: 'Stop.' }]);
+    render(
+      <Provider store={store}>
+        <SentenceEmotionControl chapterId={1} sentenceId={2} />
+      </Provider>,
+    );
+    fireEvent.click(screen.getByTestId('emotion-chip'));
+    /* The menu must use the opaque picker-surface elevation so manuscript text
+       behind it never shows through (the dark-mode bg-canvas blended into the
+       page canvas → unreadable). */
+    const menu = screen.getByRole('menu');
+    expect(menu.className).toContain('picker-surface');
+    expect(menu.className).not.toContain('bg-canvas');
+  });
+
   it('shows the current emotion and clears it via Neutral', () => {
     const store = makeStore([
       { id: 2, chapterId: 1, characterId: 'wren', text: 'Stop.', emotion: 'angry' },

--- a/src/components/sentence-emotion-control.tsx
+++ b/src/components/sentence-emotion-control.tsx
@@ -169,7 +169,7 @@ export function SentenceEmotionControl({
       {open && (
         <span
           role="menu"
-          className="absolute z-30 left-0 top-full mt-1 min-w-[120px] rounded-lg border border-ink/10 bg-canvas shadow-lg py-1 flex flex-col"
+          className="absolute z-50 left-0 top-full mt-1 min-w-[120px] rounded-lg border border-ink/10 bg-white picker-surface shadow-lg py-1 flex flex-col"
         >
           {EMOTION_OPTIONS.map((opt) => (
             <button

--- a/src/components/status-popover.test.tsx
+++ b/src/components/status-popover.test.tsx
@@ -86,6 +86,19 @@ describe('StatusPopover', () => {
     expect(screen.getByText('No pending revisions.')).toBeInTheDocument();
   });
 
+  it('shows the analyzer model chip when analysis.model is set', () => {
+    render(<StatusPopover {...makeProps({ analysis: { ...analysis, model: 'gizmo-local:1b' } })} />);
+    const chip = screen.getByTestId('status-popover-analysis-model');
+    expect(chip).toBeInTheDocument();
+    /* Unknown id falls back to the raw model id (known ids map to a label). */
+    expect(chip.textContent).toContain('gizmo-local:1b');
+  });
+
+  it('omits the model chip when analysis has no model', () => {
+    render(<StatusPopover {...makeProps()} />);
+    expect(screen.queryByTestId('status-popover-analysis-model')).toBeNull();
+  });
+
   it('routes the analysis pill click through onGoToAnalysing', () => {
     const onGoToAnalysing = vi.fn();
     render(<StatusPopover {...makeProps({ onGoToAnalysing })} />);

--- a/src/components/status-popover.tsx
+++ b/src/components/status-popover.tsx
@@ -30,6 +30,7 @@ import {
   type GenerationPillData,
   type DesignPillData,
 } from './top-bar';
+import { MODEL_OPTIONS } from '../lib/models';
 
 const PANEL_WIDTH = 340;
 const ESTIMATED_HEIGHT = 320;
@@ -159,7 +160,20 @@ export function StatusPopover({
       </Section>
       <Section title="Analysis" testid="status-popover-analysis">
         {analysis ? (
-          <AnalysisPill data={{ ...analysis, onClick: onGoToAnalysing }} />
+          <div className="flex flex-col items-start gap-1.5">
+            <AnalysisPill data={{ ...analysis, onClick: onGoToAnalysing }} />
+            {analysis.model && (
+              <span
+                data-testid="status-popover-analysis-model"
+                className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-medium bg-ink/5 text-ink/70"
+              >
+                <span className="w-1.5 h-1.5 rounded-full bg-ink/30" />
+                <span className="tabular-nums">
+                  {MODEL_OPTIONS.find((m) => m.id === analysis.model)?.label ?? analysis.model}
+                </span>
+              </span>
+            )}
+          </div>
         ) : (
           <p className="text-sm text-ink/60">No analysis running.</p>
         )}

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -47,6 +47,10 @@ export interface AnalysisPillData {
   /** Number of chapters being retried — only meaningful when
       `kind === 'subset'`. Drives the "Retrying N chapters" copy. */
   subsetChapterCount?: number;
+  /** Server-resolved analyzer model id (from the SSE `model` field). Rendered
+      as a small chip in the Status popover's Analysis section so the user can
+      see which model the run is on. Undefined pre-stream. */
+  model?: string;
   onClick: () => void;
 }
 

--- a/src/store/analysis-slice.test.ts
+++ b/src/store/analysis-slice.test.ts
@@ -61,6 +61,21 @@ describe('analysisSlice — activeStream snapshot reducers', () => {
     expect(s2.activeStream?.state).toBe('running');
   });
 
+  it('applyAnalysisSnapshotTick captures the server model id and preserves it across ticks that omit it', () => {
+    const s1 = analysisSlice.reducer(undefined, analysisActions.setActiveStream(baseSnapshot));
+    const s2 = analysisSlice.reducer(
+      s1,
+      analysisActions.applyAnalysisSnapshotTick({ manuscriptId: 'm1', model: 'qwen3.5:9b' }),
+    );
+    expect(s2.activeStream?.model).toBe('qwen3.5:9b');
+    /* A later eta-only tick (no model field) must NOT wipe the captured model. */
+    const s3 = analysisSlice.reducer(
+      s2,
+      analysisActions.applyAnalysisSnapshotTick({ manuscriptId: 'm1', remainingMs: 5000 }),
+    );
+    expect(s3.activeStream?.model).toBe('qwen3.5:9b');
+  });
+
   it('applyAnalysisSnapshotTick only updates fields supplied — undefined leaves prior values intact', () => {
     const s1 = analysisSlice.reducer(
       undefined,

--- a/src/store/analysis-slice.ts
+++ b/src/store/analysis-slice.ts
@@ -31,6 +31,12 @@ export interface AnalysisStreamSnapshot {
       `ui.selectedModel`) so a user model-switch mid-stream cannot
       misclassify the running analysis. */
   engine?: 'local' | 'gemini';
+  /** Server-resolved analyzer model id, carried from the `model` field on SSE
+      phase events (the same source the analysing view's PhaseModelChip reads).
+      Captured so the global Status popover can show WHICH model the run is on —
+      especially the local model id, which the user otherwise can't see.
+      Undefined pre-stream (before the first phase tick). */
+  model?: string;
   /** Active phase id (0 = detecting characters, 1 = parsing+attribution,
       2 = matching library). */
   phaseId: number;
@@ -118,11 +124,13 @@ export const analysisSlice = createSlice({
         phaseElapsedMs?: number;
         remainingMs?: number;
         lastTickAt?: number;
+        model?: string;
       }>,
     ) {
       const snap = state.activeStream;
       if (!snap) return;
       if (snap.manuscriptId !== action.payload.manuscriptId) return;
+      if (typeof action.payload.model === 'string') snap.model = action.payload.model;
       const phaseChanged =
         typeof action.payload.phaseId === 'number' && action.payload.phaseId !== snap.phaseId;
       if (typeof action.payload.phaseId === 'number') snap.phaseId = action.payload.phaseId;

--- a/src/store/analysis-stream-middleware.ts
+++ b/src/store/analysis-stream-middleware.ts
@@ -90,7 +90,15 @@ export const analysisStreamMiddleware: Middleware = (store) => {
 
     const callbacks = {
       signal: controller.signal,
-      onPhase: ({ phaseId, progress }: { phaseId: number; progress: number }) => {
+      onPhase: ({
+        phaseId,
+        progress,
+        model,
+      }: {
+        phaseId: number;
+        progress: number;
+        model?: string;
+      }) => {
         dispatch(
           analysisActions.applyAnalysisSnapshotTick({
             manuscriptId,
@@ -98,6 +106,7 @@ export const analysisStreamMiddleware: Middleware = (store) => {
             phaseLabel: ANALYSIS_PHASES[phaseId]?.label ?? 'Analysing',
             phaseProgress: progress,
             lastTickAt: Date.now(),
+            model,
           }),
         );
       },

--- a/src/views/manuscript.test.tsx
+++ b/src/views/manuscript.test.tsx
@@ -1007,6 +1007,20 @@ describe('ManuscriptView — review-menu dismissal', () => {
     fireEvent.pointerDown(document.body);
     expect(screen.queryByTestId('review-script-wholebook')).toBeNull();
   });
+
+  it('renders the whole-book menu above sibling sections (z-50 + opaque picker-surface)', async () => {
+    const user = userEvent.setup();
+    renderReviewView();
+
+    await user.click(screen.getByTestId('review-script-menu-toggle'));
+    /* The dropdown flyout is the parent of the whole-book button. It must sit
+       at z-50 (above the z-40 content below it — the old z-20 left it hidden
+       behind sibling sections) and carry the opaque picker-surface elevation. */
+    const menu = screen.getByTestId('review-script-wholebook').parentElement!;
+    expect(menu.className).toContain('z-50');
+    expect(menu.className).toContain('picker-surface');
+    expect(menu.className).not.toContain('z-20');
+  });
 });
 
 /* fs-58 Task 11 — planApply quarantine at seed time (Fix 1).

--- a/src/views/manuscript.tsx
+++ b/src/views/manuscript.tsx
@@ -798,7 +798,7 @@ export function ManuscriptView({
                   <IconArrowDn className="w-4 h-4" />
                 </button>
                 {reviewMenuOpen && (
-                  <div className="absolute top-full left-0 mt-2 z-20 w-72 rounded-2xl border border-ink/10 bg-white shadow-float p-3 space-y-2">
+                  <div className="absolute top-full left-0 mt-2 z-50 w-72 rounded-2xl border border-ink/10 bg-white picker-surface shadow-float p-3 space-y-2">
                     <p className="text-[11px] uppercase tracking-wider font-semibold text-ink/50">
                       Review scope
                     </p>


### PR DESCRIPTION
## Summary

A batch of fixes from a live manuscript/analysis review session (2026-06-24), each with paired regression coverage. Four bug fixes + one small enhancement.

- **Review Script scope flyout was hidden behind sibling sections** (`src/views/manuscript.tsx`) — opened at `z-20`, below the `z-40` content beneath it. Bumped to `z-50` + `picker-surface`. (Closes #1059)
- **Script-review modal showed a blank body at 0 suggestions** (`src/components/script-review-diff.tsx`) — the body only mapped over `ops`, so an empty result rendered nothing. Added an explicit "No suggestions found" empty state (the mock always returned 1 op, so #1047 never hit it). (Closes #1060)
- **Emotion-variant menu popover was see-through in dark mode** (`src/components/sentence-emotion-control.tsx`) — `bg-canvas` resolves to the same colour as the page canvas (`#14110f`); switched to the documented floating-popover treatment `bg-white picker-surface` (`styles.css:255`). Same fix applied to the detect-emotions confirm popover. (Closes #1061)
- **Detect emotions + whole-book Review Script processed excluded chapters** (`server/src/routes/annotate-emotion.ts`, `script-review.ts`) — neither filtered the `excluded` flag, so analyzer calls were spent on front/back-matter. Now filtered against the excluded set (mirroring the generation route); an explicit per-chapter request is still honoured. Button copy corrected to "across all included chapters". (Closes #1062)
- **Analyzer model is now shown as a pill in the Status popover** (`analysis-slice.ts` → `analysis-stream-middleware.ts` → `top-bar.tsx`/`layout.tsx` → `status-popover.tsx`) — the server already emitted the resolved model id on SSE `phase` events; plumbed it into the snapshot and surfaced it so the user can see which (esp. local) model is running. (Closes #1064)

Refs #1063 — the ANGRY emotion-preview 500 was root-caused to the shared srv-43 voiceUuid `.pt`-key migration gap (same as #1057) and is being fixed there, not in this PR.

## Test plan

Validated locally (GPU box was busy with a live render, so e2e/server-slow were skipped in favour of the targeted gate):

- `npm run lint` — clean
- `npm run build` — frontend + server green
- `npm run test:fast` — 3446 passed / 8 skipped
- `npm run typecheck` — clean

New/extended regression tests: Review Script flyout `z-50`/`picker-surface` assertion (`manuscript.test.tsx`); emotion menu `picker-surface` not `bg-canvas` (`sentence-emotion-control.test.tsx`); script-review empty state with `ops: []` (`script-review-diff.test.tsx`); excluded-chapter skip on both server routes incl. honoured per-chapter request (`annotate-emotion.test.ts`, `script-review.test.ts`); analyzer model captured + preserved across ticks (`analysis-slice.test.ts`) and the model chip render/omit (`status-popover.test.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)