### PR TITLE
fix(sidecar,server): 409 voice_not_designed instead of opaque 500 for a missing voice .pt

### DIFF
--- a/server/src/routes/voice-sample.test.ts
+++ b/server/src/routes/voice-sample.test.ts
@@ -136,6 +136,37 @@ describe('voice-sample router', () => {
     });
   });
 
+  describe('error mapping', () => {
+    it('maps a sidecar "voice not designed" 409 to a clean 409 voice_not_designed (#1063)', async () => {
+      // The sidecar now returns 409 `voice_not_designed` for a missing .pt;
+      // sidecar.ts surfaces it as "Local voice engine returned 409: {json}".
+      // The route must re-map that to a distinct 4xx + actionable copy, NOT the
+      // generic 502 tts_failed.
+      synthesize.mockRejectedValueOnce(
+        new Error(
+          'Local voice engine returned 409: {"detail":"Qwen voice \'qwen-x\' has not been designed yet. Design it first via POST /qwen/design-voice.","code":"voice_not_designed"}',
+        ),
+      );
+      const res = await request(app)
+        .post('/api/voices/v_x/sample')
+        .send({ modelKey: 'qwen3-tts-0.6b', voice: { id: 'v_x', character: 'X' }, text: 'Hi.' });
+      expect(res.status).toBe(409);
+      expect(res.body.code).toBe('voice_not_designed');
+      expect(res.body.message).toMatch(/design it first/i);
+      // The friendly copy must not echo the raw sidecar JSON / path.
+      expect(res.body.message).not.toMatch(/\.pt|POST \/qwen/);
+    });
+
+    it('still maps an unrecognised synth failure to 502 tts_failed', async () => {
+      synthesize.mockRejectedValueOnce(new Error('some unexpected boom'));
+      const res = await request(app)
+        .post('/api/voices/v_y/sample')
+        .send({ modelKey: 'coqui-xtts-v2', voice: { id: 'v_y', character: 'Y' }, text: 'Hi.' });
+      expect(res.status).toBe(502);
+      expect(res.body.code).toBe('tts_failed');
+    });
+  });
+
   describe('evidence-driven sample text (no text in body)', () => {
     /* The route's buildSampleText is internal, but we can verify its
        behaviour through synthesize's call arguments — the route hands

--- a/server/src/routes/voice-sample.ts
+++ b/server/src/routes/voice-sample.ts
@@ -159,6 +159,20 @@ voiceSampleRouter.post('/:voiceId/sample', async (req: Request, res: Response) =
     return res.json({ url: publicUrl, durationSec, cached: false, modelKey });
   } catch (err) {
     const msg = (err as Error).message ?? 'TTS synthesis failed.';
+    /* #1063 — the sidecar returns 409 `voice_not_designed` when the requested
+       voice/variant has no cached embedding (a bad-input condition, not an
+       engine fault). Surface it as a clean 4xx with a distinct code + actionable
+       message instead of re-wrapping it as the generic 502 `tts_failed` below,
+       so the UI can say "design this voice first". The raw `msg` is the
+       "Local voice engine returned 409: {json}" wrapper (sidecar.ts) — we
+       replace it with friendly copy rather than echo the JSON body. */
+    if (/voice_not_designed|not been designed yet/i.test(msg)) {
+      return res.status(409).json({
+        code: 'voice_not_designed',
+        message:
+          'This voice or emotion variant has not been designed yet — design it first, then play the sample.',
+      });
+    }
     /* ffmpeg-not-on-PATH is a deploy issue, not a runtime TTS issue —
        surface it as its own code so the UI can hint at the install fix
        (scripts/start-app.ps1 preflight should normally prevent this). */

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -2080,10 +2080,13 @@ class QwenEngine(Engine):
 
         pt_path, json_path = self._voice_paths(voice)
         if not os.path.isfile(pt_path):
-            raise RuntimeError(
+            # Typed so the /synthesize route can map it to a clear 409 instead
+            # of the opaque 500 (#1063). The absolute path is omitted from the
+            # message (it may reach the client body) — the voice id is enough to
+            # act on; the disk location stays in the server-side log.
+            raise VoiceNotDesignedError(
                 f"Qwen voice '{voice}' has not been designed yet (no cached "
-                f"embedding at {pt_path}). Design it first via "
-                "POST /qwen/design-voice."
+                "embedding). Design it first via POST /qwen/design-voice."
             )
         lang = self.DEFAULT_LANGUAGE
         if os.path.isfile(json_path):
@@ -4191,6 +4194,21 @@ async def synthesize(req: Request) -> Response:
         # control back to the event loop, so /health stays sub-50ms during
         # synthesis. This is the single biggest UX fix in the sidecar.
         result = await asyncio.to_thread(engine.synthesize, model, voice, text)
+    except VoiceNotDesignedError as exc:
+        # #1063 — the requested voice/variant has no cached embedding on disk.
+        # That's a bad-input condition (design the voice/variant first), not an
+        # engine fault, so surface a clear, actionable 409 instead of the opaque
+        # 500 below. Mirrors the /qwen/mint-variant handler. The CUDA-poison
+        # fence is intentionally skipped — a missing .pt never poisons the
+        # context — so the process keeps serving other voices.
+        log.warning(
+            "/synthesize: voice not designed — engine=%s voice=%s: %s",
+            engine_id, voice, exc,
+        )
+        return JSONResponse(
+            {"detail": str(exc), "code": "voice_not_designed"},
+            status_code=409,
+        )
     except Exception as e:
         # Internal-only — feeds CUDA-poison detection + the server-side log,
         # never a response body (the body stays generic below).

--- a/server/tts-sidecar/tests/test_qwen3.py
+++ b/server/tts-sidecar/tests/test_qwen3.py
@@ -894,13 +894,21 @@ def test_synthesize_route_routes_qwen(fake_qwen_runtime) -> None:
     assert len(resp.content) > 0
 
 
-def test_synthesize_route_500s_on_undesigned_qwen_voice(fake_qwen_runtime) -> None:
+def test_synthesize_route_409s_on_undesigned_qwen_voice(fake_qwen_runtime) -> None:
+    # #1063 — a voice/variant with no cached .pt is a bad-input condition, not an
+    # engine fault: surface a clear, actionable 409 (was an opaque 500). Mirrors
+    # the /qwen/mint-variant handler so the UI can say "design this voice first".
     client = TestClient(main.app)
     resp = client.post(
         "/synthesize",
         json={"engine": "qwen", "model": "qwen3-tts-0.6b", "voice": "ghost", "text": "Hi."},
     )
-    assert resp.status_code == 500
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["code"] == "voice_not_designed"
+    assert "designed" in body["detail"].lower()
+    # The actionable message must NOT leak the absolute on-disk path.
+    assert ".pt" not in body["detail"] and ":\\" not in body["detail"]
 
 
 # ── load / unload ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #1063. Clicking an emotion-variant preview (or any synth) for a Qwen voice/variant with no cached embedding returned `500 {"detail":"Internal error."}` — the generic catch hid the real, actionable cause. A missing `.pt` is a bad-input condition (design the voice/variant first), not an engine fault.

- **Sidecar** (`main.py`): `_load_voice_prompt` now raises the typed `VoiceNotDesignedError` (already used by `/qwen/mint-variant`) instead of a bare `RuntimeError`, with the absolute path dropped from the message (it can reach the client body; the disk location stays in the server log). `/synthesize` catches it before the CUDA-poison/500 path → `409 {detail, code:"voice_not_designed"}`. The poison fence is intentionally skipped — a missing `.pt` never poisons the CUDA context.
- **Server** (`voice-sample.ts`): maps that sidecar 409 to a clean `409 voice_not_designed` with friendly copy ("design it first, then play the sample") instead of re-wrapping it as the generic `502 tts_failed`, so the UI can act on it. Other synth failures still map to 502.

Pairs with #1057 (the data fix that re-keys the orphaned `.pt` files so the voice is actually found): this PR makes the *remaining* missing-`.pt` cases (a genuinely undesigned variant, or the divergent voices) fail gracefully instead of opaquely.

## Test plan

- `server/tts-sidecar/tests/test_qwen3.py`: the undesigned-voice case flips **500 → 409** (+ asserts `code: voice_not_designed` and no path leak). Full `test_qwen3.py` green.
- `server/src/routes/voice-sample.test.ts`: +2 — the 409 `voice_not_designed` mapping, and a guard that an unrelated failure still maps to 502 `tts_failed`. Suite green.
- Pre-push `npm run verify` battery green.

## Owed (follow-up)
- On-GPU: confirm the formerly-500 ANGRY preview now returns the clean 409 from a real click (work item 1 of #1063 — the true traceback — is moot once the embedding is found via #1057; this PR covers the graceful-failure half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)