### PR TITLE
chore(server): extract shared loadPostFoldSentencesByChapter (srv-50)

### DIFF
--- a/server/src/routes/annotate-emotion.ts
+++ b/server/src/routes/annotate-emotion.ts
@@ -13,9 +13,7 @@
 import { Router } from 'express';
 import type { Request, Response } from '../http.js';
 import { findBookByBookId } from '../workspace/scan.js';
-import { manuscriptEditsJsonPath } from '../workspace/paths.js';
-import { readJson } from '../workspace/state-io.js';
-import { loadAnalysisCache } from '../store/analysis-cache.js';
+import { loadPostFoldSentencesByChapter } from '../store/post-fold-sentences.js';
 import { selectAnalyzerForPhase } from '../analyzer/select-analyzer.js';
 import { makeThrottledHeartbeat } from './analysis-heartbeat.js';
 import { AnalysisAbortedError } from '../analyzer/ollama.js';
@@ -23,49 +21,6 @@ import { DailyQuotaExhaustedError } from '../analyzer/rate-limit.js';
 import type { SentenceOutput } from '../handoff/schemas.js';
 
 export const annotateEmotionRouter = Router();
-
-/* Load the book's POST-FOLD attributed sentences grouped by chapter — the
-   same source synth + the manuscript view use. Prefers manuscript-edits.json
-   (the folded, user-edited list) when present, falling back to the analysis
-   cache. Mirrors the reconciliation in book-state.ts: keep an edit sentence
-   when its id still exists in the cache (or exceeds the max cache id, i.e. a
-   user-created split offspring). */
-export async function loadPostFoldSentencesByChapter(
-  manuscriptId: string,
-  bookDir: string,
-): Promise<Map<number, SentenceOutput[]>> {
-  const cache = await loadAnalysisCache(manuscriptId);
-  const cachedSentences = Object.values(cache.chapters ?? {}).flat();
-  const edits = await readJson<{ sentences?: SentenceOutput[] }>(manuscriptEditsJsonPath(bookDir));
-
-  let sentences: SentenceOutput[];
-  if (edits && Array.isArray(edits.sentences) && edits.sentences.length > 0) {
-    if (cachedSentences.length > 0) {
-      const cacheIds = new Set<number>();
-      let maxCacheId = 0;
-      for (const s of cachedSentences) {
-        cacheIds.add(s.id);
-        if (s.id > maxCacheId) maxCacheId = s.id;
-      }
-      sentences = edits.sentences.filter(
-        (s) => typeof s?.id !== 'number' || cacheIds.has(s.id) || s.id > maxCacheId,
-      );
-    } else {
-      sentences = edits.sentences;
-    }
-  } else {
-    sentences = cachedSentences;
-  }
-
-  const byChapter = new Map<number, SentenceOutput[]>();
-  for (const s of sentences) {
-    if (typeof s?.chapterId !== 'number') continue;
-    const bucket = byChapter.get(s.chapterId);
-    if (bucket) bucket.push(s);
-    else byChapter.set(s.chapterId, [s]);
-  }
-  return byChapter;
-}
 
 /* Build the per-chapter emotion-annotation prompt. We send the FULL chapter
    sentence sequence (narrator splits included) so the model has the

--- a/server/src/routes/script-review.ts
+++ b/server/src/routes/script-review.ts
@@ -17,9 +17,9 @@
 import { Router } from 'express';
 import type { Request, Response } from '../http.js';
 import { findBookByBookId } from '../workspace/scan.js';
-import { manuscriptEditsJsonPath, castJsonPath } from '../workspace/paths.js';
+import { castJsonPath } from '../workspace/paths.js';
 import { readJson } from '../workspace/state-io.js';
-import { loadAnalysisCache } from '../store/analysis-cache.js';
+import { loadPostFoldSentencesByChapter } from '../store/post-fold-sentences.js';
 import { selectAnalyzerForPhase } from '../analyzer/select-analyzer.js';
 import { makeThrottledHeartbeat } from './analysis-heartbeat.js';
 import { AnalysisAbortedError } from '../analyzer/ollama.js';
@@ -37,46 +37,6 @@ interface CastCharacterSlim {
 }
 interface CastFile {
   characters?: CastCharacterSlim[];
-}
-
-/* Load the book's POST-FOLD attributed sentences grouped by chapter — the
-   same source synth + the manuscript view use. Mirrors loadPostFoldSentencesByChapter
-   from annotate-emotion.ts exactly (same reconciliation logic). */
-async function loadPostFoldSentencesByChapter(
-  manuscriptId: string,
-  bookDir: string,
-): Promise<Map<number, SentenceOutput[]>> {
-  const cache = await loadAnalysisCache(manuscriptId);
-  const cachedSentences = Object.values(cache.chapters ?? {}).flat();
-  const edits = await readJson<{ sentences?: SentenceOutput[] }>(manuscriptEditsJsonPath(bookDir));
-
-  let sentences: SentenceOutput[];
-  if (edits && Array.isArray(edits.sentences) && edits.sentences.length > 0) {
-    if (cachedSentences.length > 0) {
-      const cacheIds = new Set<number>();
-      let maxCacheId = 0;
-      for (const s of cachedSentences) {
-        cacheIds.add(s.id);
-        if (s.id > maxCacheId) maxCacheId = s.id;
-      }
-      sentences = edits.sentences.filter(
-        (s) => typeof s?.id !== 'number' || cacheIds.has(s.id) || s.id > maxCacheId,
-      );
-    } else {
-      sentences = edits.sentences;
-    }
-  } else {
-    sentences = cachedSentences;
-  }
-
-  const byChapter = new Map<number, SentenceOutput[]>();
-  for (const s of sentences) {
-    if (typeof s?.chapterId !== 'number') continue;
-    const bucket = byChapter.get(s.chapterId);
-    if (bucket) bucket.push(s);
-    else byChapter.set(s.chapterId, [s]);
-  }
-  return byChapter;
 }
 
 /* Build the per-chapter script-review prompt. We send the full chapter

--- a/server/src/store/post-fold-sentences.test.ts
+++ b/server/src/store/post-fold-sentences.test.ts
@@ -1,0 +1,124 @@
+/* srv-50 — unit coverage for the shared post-fold sentence loader hoisted out
+   of annotate-emotion.ts + script-review.ts. The originals were only covered
+   indirectly through their route integration tests; this locks the
+   reconciliation branches directly so the two routes can't drift on it.
+
+   The reconciliation rule (mirrors book-state.ts): when BOTH a folded
+   manuscript-edits.json and an analysis cache exist, keep an edit sentence iff
+   its id still appears in the cache OR exceeds the cache's max id (a
+   user-created split offspring whose id was minted after analysis). */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { SentenceOutput } from '../handoff/schemas.js';
+import { saveAnalysisCache, clearAnalysisCache } from './analysis-cache.js';
+import { loadPostFoldSentencesByChapter } from './post-fold-sentences.js';
+
+/* Minimal SentenceOutput — the loader only reads `id` and `chapterId`, but we
+   carry text/characterId so the assertions read like real sentences. */
+function sent(id: number, chapterId: number, text = `s${id}`): SentenceOutput {
+  return { id, chapterId, characterId: 'narrator', text } as SentenceOutput;
+}
+
+let bookDir: string;
+let manuscriptId: string;
+let seq = 0;
+
+function newBook(): void {
+  bookDir = mkdtempSync(join(tmpdir(), 'audiobook-postfold-'));
+  mkdirSync(join(bookDir, '.audiobook'), { recursive: true });
+  manuscriptId = `m_postfold_${process.pid}_${seq++}`;
+}
+
+function writeEdits(sentences: unknown[]): void {
+  writeFileSync(join(bookDir, '.audiobook', 'manuscript-edits.json'), JSON.stringify({ sentences }));
+}
+
+afterEach(async () => {
+  if (manuscriptId) await clearAnalysisCache(manuscriptId);
+  if (bookDir) rmSync(bookDir, { recursive: true, force: true });
+});
+
+describe('loadPostFoldSentencesByChapter', () => {
+  it('falls back to the analysis cache when no edits file exists', async () => {
+    newBook();
+    await saveAnalysisCache(manuscriptId, {
+      chapters: { 1: [sent(1, 1), sent(2, 1)], 2: [sent(3, 2)] },
+    });
+
+    const byChapter = await loadPostFoldSentencesByChapter(manuscriptId, bookDir);
+
+    expect([...byChapter.keys()].sort()).toEqual([1, 2]);
+    expect(byChapter.get(1)!.map((s) => s.id)).toEqual([1, 2]);
+    expect(byChapter.get(2)!.map((s) => s.id)).toEqual([3]);
+  });
+
+  it('uses the edits list wholesale when no cache exists', async () => {
+    newBook();
+    writeEdits([sent(10, 1), sent(11, 2)]);
+
+    const byChapter = await loadPostFoldSentencesByChapter(manuscriptId, bookDir);
+
+    expect(byChapter.get(1)!.map((s) => s.id)).toEqual([10]);
+    expect(byChapter.get(2)!.map((s) => s.id)).toEqual([11]);
+  });
+
+  it('reconciles edits against the cache: keeps ids still in cache, drops stale ids', async () => {
+    newBook();
+    // maxCacheId = 50, so a stale id must be ≤ 50 to be dropped (above it = split offspring).
+    await saveAnalysisCache(manuscriptId, { chapters: { 1: [sent(1, 1), sent(2, 1), sent(50, 1)] } });
+    // id 1 survives (in cache); id 30 is stale (not in cache, ≤ maxCacheId) → dropped.
+    writeEdits([sent(1, 1, 'edited'), sent(30, 1)]);
+
+    const byChapter = await loadPostFoldSentencesByChapter(manuscriptId, bookDir);
+
+    const ch1 = byChapter.get(1)!;
+    expect(ch1.map((s) => s.id)).toEqual([1]);
+    expect(ch1[0].text).toBe('edited'); // the edited copy wins, not the cache copy
+  });
+
+  it('keeps a split offspring whose id exceeds the cache max id', async () => {
+    newBook();
+    await saveAnalysisCache(manuscriptId, { chapters: { 1: [sent(1, 1), sent(2, 1)] } });
+    // id 1000 isn't in the cache but is > maxCacheId (2) → a user-created split offspring, kept.
+    writeEdits([sent(1, 1), sent(1000, 1)]);
+
+    const byChapter = await loadPostFoldSentencesByChapter(manuscriptId, bookDir);
+
+    expect(byChapter.get(1)!.map((s) => s.id)).toEqual([1, 1000]);
+  });
+
+  it('passes through an edit sentence with a non-numeric id during reconciliation', async () => {
+    newBook();
+    await saveAnalysisCache(manuscriptId, { chapters: { 1: [sent(1, 1)] } });
+    writeEdits([{ id: 'oops', chapterId: 1, characterId: 'narrator', text: 'malformed' }]);
+
+    const byChapter = await loadPostFoldSentencesByChapter(manuscriptId, bookDir);
+
+    expect(byChapter.get(1)!.map((s) => s.text)).toEqual(['malformed']);
+  });
+
+  it('skips sentences with a non-numeric chapterId when grouping', async () => {
+    newBook();
+    writeEdits([
+      sent(1, 1),
+      { id: 2, chapterId: 'nope', characterId: 'narrator', text: 'orphan' },
+      sent(3, 1),
+    ]);
+
+    const byChapter = await loadPostFoldSentencesByChapter(manuscriptId, bookDir);
+
+    expect([...byChapter.keys()]).toEqual([1]);
+    expect(byChapter.get(1)!.map((s) => s.id)).toEqual([1, 3]);
+  });
+
+  it('returns an empty map when neither cache nor edits exist', async () => {
+    newBook();
+
+    const byChapter = await loadPostFoldSentencesByChapter(manuscriptId, bookDir);
+
+    expect(byChapter.size).toBe(0);
+  });
+});

--- a/server/src/store/post-fold-sentences.ts
+++ b/server/src/store/post-fold-sentences.ts
@@ -1,0 +1,53 @@
+/* srv-50 — shared post-fold sentence loader. Extracted byte-for-byte from the
+   duplicate copies that fs-58 deliberately kept in annotate-emotion.ts and
+   script-review.ts (to avoid cross-route coupling at build time). Hoisting it
+   here means the two routes can't silently drift if one ever gets a
+   reconciliation bugfix. Behaviour is identical to the originals. */
+
+import { manuscriptEditsJsonPath } from '../workspace/paths.js';
+import { readJson } from '../workspace/state-io.js';
+import { loadAnalysisCache } from './analysis-cache.js';
+import type { SentenceOutput } from '../handoff/schemas.js';
+
+/* Load the book's POST-FOLD attributed sentences grouped by chapter — the
+   same source synth + the manuscript view use. Prefers manuscript-edits.json
+   (the folded, user-edited list) when present, falling back to the analysis
+   cache. Mirrors the reconciliation in book-state.ts: keep an edit sentence
+   when its id still exists in the cache (or exceeds the max cache id, i.e. a
+   user-created split offspring). */
+export async function loadPostFoldSentencesByChapter(
+  manuscriptId: string,
+  bookDir: string,
+): Promise<Map<number, SentenceOutput[]>> {
+  const cache = await loadAnalysisCache(manuscriptId);
+  const cachedSentences = Object.values(cache.chapters ?? {}).flat();
+  const edits = await readJson<{ sentences?: SentenceOutput[] }>(manuscriptEditsJsonPath(bookDir));
+
+  let sentences: SentenceOutput[];
+  if (edits && Array.isArray(edits.sentences) && edits.sentences.length > 0) {
+    if (cachedSentences.length > 0) {
+      const cacheIds = new Set<number>();
+      let maxCacheId = 0;
+      for (const s of cachedSentences) {
+        cacheIds.add(s.id);
+        if (s.id > maxCacheId) maxCacheId = s.id;
+      }
+      sentences = edits.sentences.filter(
+        (s) => typeof s?.id !== 'number' || cacheIds.has(s.id) || s.id > maxCacheId,
+      );
+    } else {
+      sentences = edits.sentences;
+    }
+  } else {
+    sentences = cachedSentences;
+  }
+
+  const byChapter = new Map<number, SentenceOutput[]>();
+  for (const s of sentences) {
+    if (typeof s?.chapterId !== 'number') continue;
+    const bucket = byChapter.get(s.chapterId);
+    if (bucket) bucket.push(s);
+    else byChapter.set(s.chapterId, [s]);
+  }
+  return byChapter;
+}


### PR DESCRIPTION
## Summary

Extracts the `loadPostFoldSentencesByChapter` helper that fs-58 deliberately copied **byte-for-byte** into both `server/src/routes/annotate-emotion.ts` and `server/src/routes/script-review.ts` (the original copy avoided cross-route coupling at build time). It now lives once in `server/src/store/post-fold-sentences.ts`, so the two routes can't silently drift if one ever picks up a reconciliation bugfix. Pure refactor — behaviour is identical; both routes import the shared function and their now-orphaned imports (`loadAnalysisCache`, `manuscriptEditsJsonPath`, and `readJson` in annotate-emotion) are removed.

Net **−88 lines of duplication** across the two routes.

## Test plan

- New direct unit test `server/src/store/post-fold-sentences.test.ts` (7 cases) locks every reconciliation branch the originals only exercised indirectly through their route integration tests:
  - cache-only fallback (no edits file)
  - edits-without-cache (edits used wholesale)
  - cache↔edits reconcile: keep-id-still-in-cache, **drop-stale-id** (absent + ≤ maxCacheId), **keep split-offspring** (absent + > maxCacheId)
  - non-numeric id passthrough during reconciliation
  - non-numeric `chapterId` skipped during grouping
  - empty map when neither source exists
- `cd server && npm run test` — full server suite green (3457 passed) incl. the new file + both route suites (`annotate-emotion`, `script-review`).
- `npm run typecheck` + `eslint` on the touched files — clean.

> Pre-push note: the local battery's one red was an unrelated, confirmed-flaky e2e spec (`analysing-multi-model › live ticker "section 2/5"`) that failed only under concurrent GPU-generation load (`LOW_CONCURRENCY=1`) and passes cleanly in isolation. This change is server-only and cannot affect a mock-mode frontend e2e. `run-ci` requested for a clean-room confirmation.

Closes #1046
