### PR TITLE
fix(frontend): surface QA issue details on hover + fill the player waveform

### DIFF
--- a/docs/features/227-generation-issue-waveform.md
+++ b/docs/features/227-generation-issue-waveform.md
@@ -84,6 +84,23 @@ The canonical pipeline fixture for deeper regression: `server/src/__fixtures__/t
 - Surfacing suspect segments in the Listen view — the waveform scrubber there is unchanged.
 - Whisper ASR enablement (`SEG_ASR_ENABLED`) — plan 186; this plan only ensures ASR reasons pass through correctly when ASR is on.
 
+## Follow-up fixes (2026-06-24, `fix/frontend-generation-issue-tooltips`)
+
+Three gaps surfaced when this shipped against a real book:
+
+1. **Amber markers had no hover affordance.** The issue `reasons` were rendered
+   `sr-only` only, so sighted users hovering the amber bars saw nothing. Each
+   amber bar now carries a `title` (`Issue at <time>: <reasons>`) via a
+   bar-index→region map in `Waveform`; the "N issues to review" caption and the
+   MiniPlayer ⚠ jump buttons gained summarising `title`s too.
+2. **The MiniPlayer scrubber waveform under-filled.** `Waveform` rendered
+   fixed-width (`w-[3px]`) bars, so the 48 bars spanned only ~238 px and left a
+   flat tail in the wide scrubber. Bars are now `flex-1` so they fill any
+   container (no visual-baseline change — the waveforms sit below the
+   `fullPage:false` snapshot fold).
+3. Paired unit tests in `waveform.test.tsx`, `generation.test.tsx`,
+   `mini-player.test.tsx`.
+
 ## Ship notes
 
 (To be filled when status flips to `stable`.)

--- a/src/components/mini-player.test.tsx
+++ b/src/components/mini-player.test.tsx
@@ -1138,6 +1138,15 @@ describe('MiniPlayer — jump-to-issue + auto-seek', () => {
     expect(el.currentTime).toBe(8);
   });
 
+  it('lists the flagged issues in a hover title on the ⚠ jump button', async () => {
+    getChapterAudioFn.mockResolvedValue(audioWithIssues as never);
+    renderMiniPlayer({ id: 1, title: 'Ch', duration: '0:30' });
+    const btn = await screen.findByLabelText(/Next issue/);
+    // The ⚠ icon must reveal what the issues actually are on hover, not just
+    // read "Next issue".
+    expect(btn).toHaveAttribute('title', expect.stringContaining('Long sentence'));
+  });
+
   it('auto-seeks to the first issue in the generate context, overriding resume', async () => {
     getChapterAudioFn.mockResolvedValue(audioWithIssues as never);
     getListenProgressMock.mockResolvedValue({ chapterId: 1, currentSec: 25 } as never);

--- a/src/components/mini-player.tsx
+++ b/src/components/mini-player.tsx
@@ -99,6 +99,12 @@ export function MiniPlayer({
      even if it runs before the first render with non-empty issues. */
   const issuesRef = useRef(issues);
   issuesRef.current = issues;
+  /* Human-readable summary for the ⚠ jump-button hover title, so the warning
+     icon reveals what the issues actually are — not just "Next issue". */
+  const issueSummary = useMemo(
+    () => issues.map((r) => `${formatTime(r.seekSec)}: ${r.reasons.join(', ')}`).join(' · '),
+    [issues],
+  );
   const [currentSec, setCurrentSec] = useState(0);
   const [playing, setPlaying] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -785,7 +791,7 @@ export function MiniPlayer({
                   type="button"
                   onClick={() => jumpToIssue(-1)}
                   aria-label="Previous issue"
-                  title="Previous issue"
+                  title={`Previous issue · ${issueSummary}`}
                   className="hidden md:grid place-items-center p-2 rounded-full hover:bg-canvas/10 text-amber-300"
                 >
                   <span aria-hidden>‹⚠</span>
@@ -794,7 +800,7 @@ export function MiniPlayer({
                   type="button"
                   onClick={() => jumpToIssue(1)}
                   aria-label="Next issue"
-                  title="Next issue"
+                  title={`Next issue · ${issueSummary}`}
                   data-testid="mini-player-next-issue"
                   className="grid place-items-center min-w-[44px] min-h-[44px] md:min-w-0 md:min-h-0 md:p-2 rounded-full hover:bg-canvas/10 text-amber-300"
                 >

--- a/src/components/waveform.test.tsx
+++ b/src/components/waveform.test.tsx
@@ -20,6 +20,16 @@ describe('Waveform', () => {
     expect(barHeights(container)).toHaveLength(48);
   });
 
+  it('stretches its bars to fill the container width (flex-1, not a fixed pixel width)', () => {
+    const { container } = render(<Waveform progress={0} active />);
+    const bars = Array.from(container.querySelectorAll('span')) as HTMLElement[];
+    expect(bars).toHaveLength(48);
+    // Fixed-width bars under-fill a wide container (the mini-player scrubber),
+    // leaving a flat tail; flex-1 makes them span the full track.
+    expect(bars.every((b) => b.className.includes('flex-1'))).toBe(true);
+    expect(bars.some((b) => b.className.includes('w-[3px]'))).toBe(false);
+  });
+
   it('produces identical bar heights across unmount/remount', () => {
     const first = render(<Waveform progress={0.3} active />);
     const heightsA = barHeights(first.container);
@@ -86,6 +96,23 @@ describe('Waveform issue overlay', () => {
     expect(container.querySelectorAll('.bg-amber-400').length).toBeGreaterThan(0);
     // bar row is hidden from AT
     expect(container.querySelector('[aria-hidden="true"]')).toBeInTheDocument();
+  });
+
+  it('exposes the issue reasons in a hover title on every amber bar', () => {
+    const { container } = render(
+      <Waveform
+        progress={0}
+        active
+        peaks={Array(240).fill(0.5)}
+        issues={[{ startFrac: 0.25, endFrac: 0.5, seekSec: 90, reasons: ['Suspiciously long'] }]}
+      />,
+    );
+    const amber = Array.from(container.querySelectorAll('.bg-amber-400')) as HTMLElement[];
+    expect(amber.length).toBeGreaterThan(0);
+    // Every amber bar surfaces the reason + timestamp on hover (the sr-only list
+    // alone left sighted users with nothing to read).
+    expect(amber.every((b) => b.title.includes('Suspiciously long'))).toBe(true);
+    expect(amber[0].title).toMatch(/1:30/);
   });
 
   it('renders unchanged (no amber, no list) with no issues', () => {

--- a/src/components/waveform.tsx
+++ b/src/components/waveform.tsx
@@ -28,14 +28,21 @@ const BARS: number[] = (() => {
   return out;
 })();
 
-function issueBarSet(issues: IssueRegion[] | undefined, count: number): Set<number> {
-  const set = new Set<number>();
+/* Map each in-issue bar index to the region that covers it, so an amber bar can
+   carry that region's reasons in a hover `title` (the sr-only list alone left
+   sighted users with no way to read what the markers mean). First region wins on
+   the rare overlap — the same index-coverage as the previous Set. */
+function issueBarMap(
+  issues: IssueRegion[] | undefined,
+  count: number,
+): Map<number, IssueRegion> {
+  const map = new Map<number, IssueRegion>();
   for (const r of issues ?? []) {
     const lo = Math.max(0, Math.floor(r.startFrac * count));
     const hi = Math.min(count - 1, Math.ceil(r.endFrac * count) - 1);
-    for (let i = lo; i <= hi; i += 1) set.add(i);
+    for (let i = lo; i <= hi; i += 1) if (!map.has(i)) map.set(i, r);
   }
-  return set;
+  return map;
 }
 
 /* Reduce the server's variable-length RMS envelope (240 bins in practice) to
@@ -62,14 +69,15 @@ export function peaksToBars(peaks: number[] | undefined, count = BAR_COUNT): num
 
 export function Waveform({ progress, active, peaks, issues }: WaveformProps) {
   const bars = peaksToBars(peaks) ?? BARS;
-  const amber = issueBarSet(issues, bars.length);
+  const amber = issueBarMap(issues, bars.length);
   const hasIssues = (issues?.length ?? 0) > 0;
 
   const barRow = (
-    <div className="flex items-end gap-[2px] h-7" aria-hidden={hasIssues || undefined}>
+    <div className="flex items-end gap-[2px] h-7 w-full" aria-hidden={hasIssues || undefined}>
       {bars.map((h, i) => {
+        const region = amber.get(i);
         const filled = i / bars.length <= progress;
-        const cls = amber.has(i)
+        const cls = region
           ? 'bg-amber-400'
           : active && filled
             ? 'bg-magenta'
@@ -79,8 +87,16 @@ export function Waveform({ progress, active, peaks, issues }: WaveformProps) {
         return (
           <span
             key={i}
-            className={`w-[3px] rounded-sm transition-colors ${cls}`}
+            // flex-1 (not a fixed pixel width) so the 48 bars span the full
+            // container — a fixed width under-fills the wide mini-player scrubber,
+            // leaving a flat tail (the "waveform not rendering" report).
+            className={`flex-1 min-w-[2px] rounded-sm transition-colors ${cls}`}
             style={{ height: `${h * 100}%` }}
+            title={
+              region
+                ? `Issue at ${formatTime(region.seekSec)}: ${region.reasons.join('; ')}`
+                : undefined
+            }
           />
         );
       })}

--- a/src/views/generation.test.tsx
+++ b/src/views/generation.test.tsx
@@ -2433,6 +2433,14 @@ describe('ChapterSegmentStrip — issue waveform', () => {
     expect(await screen.findByText(/1 issue to review/)).toBeInTheDocument();
   });
 
+  it('summarises the flagged issues in a hover title on the count label', async () => {
+    vi.mocked(api.getChapterAudio).mockResolvedValue(baseAudio as never);
+    render(<ChapterSegmentStrip chapter={{ id: 1, audioQa: { status: 'suspect', reasons: [] } } as never}
+      bookId="b" characters={[]} />);
+    const label = await screen.findByText(/1 issue to review/);
+    expect(label).toHaveAttribute('title', expect.stringContaining('Long sentence'));
+  });
+
   it('shows the chapter-level baseline note when suspect but no per-segment issue', async () => {
     vi.mocked(api.getChapterAudio).mockResolvedValue({
       ...baseAudio,

--- a/src/views/generation.tsx
+++ b/src/views/generation.tsx
@@ -2147,7 +2147,10 @@ export function ChapterSegmentStrip({
       )}
 
       {issues.length > 0 && (
-        <p className="mt-1 text-[10px] font-semibold text-amber-700 flex items-center gap-1">
+        <p
+          className="mt-1 text-[10px] font-semibold text-amber-700 flex items-center gap-1"
+          title={issues.map((r) => `${formatTime(r.seekSec)}: ${r.reasons.join(', ')}`).join(' · ')}
+        >
           <span aria-hidden>⚠</span>
           {issues.length} issue{issues.length > 1 ? 's' : ''} to review
         </p>


### PR DESCRIPTION
## Summary

Closes #1070
Closes #1071

Two gaps from the plan-227 issue waveform, hit on a real book:

- **Issue markers had no hover affordance (#1070).** The QA `reasons` were rendered `sr-only` only, so hovering the amber bars showed nothing. Each amber bar now carries a `title` ("Issue at <time>: <reasons>") via a bar-index→region map in `Waveform`; the "N issues to review" caption and the MiniPlayer ⚠ jump buttons gained summarising `title`s too.
- **The preview-player waveform under-filled the scrubber (#1071).** `Waveform` used fixed-width (`w-[3px]`) bars, so 48 bars spanned only ~238px and left a flat tail in the wide MiniPlayer scrubber. Bars are now `flex-1` so they fill any container.

No visual-baseline change (verified by regenerating win32 snapshots — the waveforms sit below the `fullPage:false` fold). Plan 227 updated with a follow-up note.

## Test plan

- New unit tests: amber bars expose reasons in a `title`; bars use `flex-1` (not fixed width); "N issues to review" caption title; MiniPlayer ⚠ button title carries the issue detail.
- Full frontend suite green (3084); `tsc --noEmit` clean; ESLint clean; visual baselines unchanged.