### PR TITLE
fix(scripts): normalise stale Qwen voice names to the storage key

### DIFF
--- a/scripts/repair-qwen-voice-uuid-keys.mjs
+++ b/scripts/repair-qwen-voice-uuid-keys.mjs
@@ -97,6 +97,17 @@ export function classifyVoiceGroup(name, uuids, ptExists) {
   return { action: 'flag', oldKey: name, newKey, reason: `no .pt at "${name}" or "${newKey}" — (re)design this voice` };
 }
 
+/** The on-disk storage key a row's voice is ACTUALLY loaded from at synth time
+    (`pickVoiceForEngine` → `qwenStorageKey`): `qwen-<voiceUuid>` when a uuid was
+    minted, else `qwen-<voiceId ?? id>`. The persisted `overrideTtsVoices.qwen.name`
+    SHOULD equal this; when it drifts (a stale name left after a re-design/reuse),
+    the voice still resolves correctly (resolution ignores the name) but the
+    record is misleading and the `designed-persona` route reads the wrong `.json`.
+    Normalising `name` → this key makes the cast honest. */
+export function storageKeyForRow(character) {
+  return character.voiceUuid ? `qwen-${character.voiceUuid}` : `qwen-${character.voiceId ?? character.id}`;
+}
+
 /** Rewrite a character's qwen base name + variant slot names from oldKey to
     newKey (pure; returns a new character). */
 export function rekeyCharacterNames(character, oldKey, newKey) {
@@ -167,21 +178,45 @@ async function main() {
 
   const casts = await listCastJsons(booksRoot);
 
-  // ── Pass 1: parse every cast; build voice GROUPS keyed by persisted qwen.name.
-  // A voice is shared across books, so its rows span casts; each group collects
-  // its distinct uuids and the (book, char) coordinates of its rows.
+  // ── Pass 1: parse every cast.
   const parsed = []; // index-aligned with `casts`; null for an unparseable cast
-  const groups = new Map(); // name -> { uuids:Set, rows:[{ bookIdx, charIdx }] }
   for (let b = 0; b < casts.length; b++) {
-    let cast;
     try {
-      cast = JSON.parse(await readFile(casts[b].path, 'utf8'));
+      parsed.push({ path: casts[b].path, label: casts[b].label, cast: JSON.parse(await readFile(casts[b].path, 'utf8')) });
     } catch {
       parsed.push(null);
-      continue;
     }
-    parsed.push({ path: casts[b].path, label: casts[b].label, cast });
-    const chars = cast.characters ?? [];
+  }
+
+  // ── Pass 2 (NORMALISE names): set every row's persisted name to the storage
+  // key its voice already loads from, when that key's `.pt` is on disk. This is
+  // a pure cast.json fix (no file renames) that heals stale names left by
+  // re-designs / reuse — and, by making names honest, dissolves false "rows
+  // disagree on uuid" groups before the consolidation pass below.
+  const dirtyBooks = new Set();
+  let normalised = 0;
+  for (let b = 0; b < parsed.length; b++) {
+    const entry = parsed[b];
+    if (!entry) continue;
+    const chars = entry.cast.characters ?? [];
+    for (let i = 0; i < chars.length; i++) {
+      const nm = chars[i]?.overrideTtsVoices?.qwen?.name;
+      if (!nm) continue;
+      const key = storageKeyForRow(chars[i]);
+      if (nm === key || !ptExists(key)) continue; // already honest, or .pt not at the key (leave for consolidation)
+      chars[i] = rekeyCharacterNames(chars[i], nm, key);
+      dirtyBooks.add(b);
+      normalised++;
+      console.log(`  name    ${entry.label}: ${chars[i].id}  ${nm} → ${key}`);
+    }
+  }
+
+  // ── Pass 3 (CONSOLIDATE misplaced files): build voice GROUPS keyed by the
+  // now-normalised name. A voice is shared across books, so its rows span casts.
+  const groups = new Map(); // name -> { uuids:Set, rows:[{ bookIdx, charIdx }] }
+  for (let b = 0; b < parsed.length; b++) {
+    if (!parsed[b]) continue;
+    const chars = parsed[b].cast.characters ?? [];
     for (let i = 0; i < chars.length; i++) {
       const nm = chars[i]?.overrideTtsVoices?.qwen?.name;
       if (!nm) continue;
@@ -201,9 +236,8 @@ async function main() {
     else if (c.action === 'flag') flags.push({ name, ...c });
   }
 
-  // ── Pass 2: apply. Re-key each voice's files once, then rewrite the name +
-  // stamp the shared uuid on every row of the group.
-  const dirtyBooks = new Set();
+  // Apply consolidations: re-key each voice's files once, then rewrite the name
+  // + stamp the shared uuid on every row of the group.
   let rowCount = 0;
   for (const { oldKey, newKey, uuid, rows } of consolidations) {
     for (const { from, to } of planRenames(voiceFiles, oldKey, newKey)) {
@@ -228,13 +262,14 @@ async function main() {
       await writeFile(parsed[b].path, JSON.stringify(parsed[b].cast, null, 2) + '\n');
 
   console.log(
-    `\n${APPLY ? 'Consolidated' : 'Would consolidate'}: ${consolidations.length} voice(s) re-keyed on disk; ${rowCount} cast row(s) rewritten.`,
+    `\n${APPLY ? 'Done' : 'Would change'}: ${normalised} name(s) normalised; ` +
+      `${consolidations.length} voice(s) re-keyed on disk (${rowCount} rows).`,
   );
   if (flags.length) {
     console.log(`\nNeeds manual attention (not auto-fixed):`);
     for (const f of flags) console.log(`  ${f.name}${f.newKey ? ` → ${f.newKey}` : ''}\n      ↳ ${f.reason}`);
   }
-  if (!APPLY && (consolidations.length || flags.length))
+  if (!APPLY && (normalised || consolidations.length || flags.length))
     console.log(`\nReview the plan above, back up ${voicesDir}, stop the server, then re-run with --apply.`);
 }
 

--- a/scripts/tests/repair-qwen-voice-uuid-keys.test.mjs
+++ b/scripts/tests/repair-qwen-voice-uuid-keys.test.mjs
@@ -5,7 +5,14 @@ import {
   planRenames,
   classifyVoiceGroup,
   rekeyCharacterNames,
+  storageKeyForRow,
 } from '../repair-qwen-voice-uuid-keys.mjs';
+
+test('storageKeyForRow: uuid wins, else voiceId, else id', () => {
+  assert.equal(storageKeyForRow({ id: 'x', voiceId: 'vx', voiceUuid: 'U' }), 'qwen-U');
+  assert.equal(storageKeyForRow({ id: 'x', voiceId: 'vx' }), 'qwen-vx');
+  assert.equal(storageKeyForRow({ id: 'x' }), 'qwen-x');
+});
 
 test('belongsToKey matches base + variants but not prefix-siblings', () => {
   assert.equal(belongsToKey('qwen-dad.pt', 'qwen-dad'), true);


### PR DESCRIPTION
## Summary

Finalises #1057. After the file re-key (#1067), some cast rows still carried a stale `overrideTtsVoices.qwen.name` that no longer matched the key their voice actually loads from (`qwenStorageKey` = `qwen-<uuid>`, else `qwen-<voiceId ?? id>`) — e.g. a re-designed voice, or the Coalfall EN/ES fixtures where Narrator/Maerin/Wren were designed independently per language but shared one name string. The voice still resolved (synth ignores the name), but the record was misleading, the `designed-persona` route read the wrong `.json`, and the group-by-name consolidation pass false-flagged them as "rows disagree on uuid".

Adds a **normalise** pass (pure cast.json, no file renames) that runs *before* consolidation: for every row whose name != its storage key AND that key's `.pt` is on disk, rewrite the base + variant slot names to the key. Making names honest dissolves the false "disagree" groups, so consolidation then sees clean single-uuid groups. `storageKeyForRow` added + unit-tested.

## Applied + verified on the live workspace (cast.json backed up first)

13 names normalised (Coalfall Narrator/Maerin/Wren + the KotLC/Skulduggery narrators + unknown-male); idempotent re-run reports **0 changes and 0 flags**. The workspace is now fully consistent — every row's name equals its storage key, every `.pt` present.

## Test plan

- `scripts/tests/repair-qwen-voice-uuid-keys.test.mjs` (`node:test`): adds `storageKeyForRow` (uuid > voiceId > id); existing `classifyVoiceGroup` / `planRenames` / `rekeyCharacterNames` stay green.
- Manual dry-run + `--apply` + idempotent re-run on the real workspace (above).
- Pre-push `npm run verify` battery green.

Closes #1057

🤖 Generated with [Claude Code](https://claude.com/claude-code)