### PR TITLE
fix(server): don't mint a voiceUuid during variant design (#1057 recurrence guard)

### DIFF
--- a/server/src/routes/cast-design.ts
+++ b/server/src/routes/cast-design.ts
@@ -336,8 +336,18 @@ async function runDesignJob(
          "unreachable"-class error while the supervisor respawns the sidecar.
          Wait for it to come back (ensureSidecarEngineReady polls /load through
          the respawn) and retry THIS character, up to MAX_RECYCLE_RIDEOUTS. */
-      /* srv-43 — mint/persist voiceUuid before the core names the .pt. */
-      const voiceUuid = await ensureCharacterVoiceUuid(job.bookDir, characterId, seriesFilter);
+      /* srv-43 — mint/persist a voiceUuid before the core names the .pt, but
+         ONLY for a BASE design. A base design writes the `.pt` at the resulting
+         `qwen-<uuid>` key, so minting is safe. A VARIANT must NOT mint: it
+         doesn't write the base `.pt`, so stamping a fresh uuid would flip the
+         base's storage key to `qwen-<uuid>` while its embedding still sits at the
+         old key — orphaning it (silent Kokoro fallback on re-render; the variant
+         mint then can't load its base). #1057: this is exactly how a bulk
+         "Emotion variants" run orphaned every base. A variant anchors on the
+         base's CURRENT key, so it reuses the character's existing voiceUuid. */
+      const voiceUuid = emotion
+        ? character.voiceUuid
+        : await ensureCharacterVoiceUuid(job.bookDir, characterId, seriesFilter);
       const characterForDesign = { ...character, voiceUuid: voiceUuid ?? character.voiceUuid };
 
       let rideouts = 0;

--- a/server/src/routes/qwen-voice.test.ts
+++ b/server/src/routes/qwen-voice.test.ts
@@ -482,6 +482,28 @@ describe('fs-25 — design-voice emotion variants (Wave 3)', () => {
     expect(maerin.overrideTtsVoices.qwen.variants.angry).toEqual({ name: 'qwen-v_maerin__angry' });
   });
 
+  it('#1057: designing a VARIANT for a no-uuid character does NOT mint a uuid (would orphan the base .pt)', async () => {
+    /* Strip maerin's pre-seeded uuid so it resolves via the legacy voiceId key
+       (qwen-v_maerin), where its base .pt actually lives. Designing a VARIANT
+       must anchor on that key WITHOUT minting a fresh uuid — minting would flip
+       the base's storage key to qwen-<uuid> while the base .pt stays put,
+       orphaning it (the bulk "Emotion variants" no-op bug). */
+    const noUuid = characters.map((c) => (c.id === 'maerin' ? { ...c, voiceUuid: undefined } : c));
+    writeBookOnDisk(noUuid);
+
+    const res = await request(app)
+      .post(`/api/books/${bookId}/cast/maerin/design-voice`)
+      .send({ ...designBody, emotion: 'angry' });
+
+    expect(res.status).toBe(200);
+    // Anchors on the legacy key, not a freshly-minted qwen-<uuid>.
+    const sent = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(sent.baseVoiceId).toBe('qwen-v_maerin');
+    // Crucially: no uuid was stamped onto the character.
+    const maerin = readCast().characters.find((c) => c.id === 'maerin') as Record<string, unknown>;
+    expect(maerin.voiceUuid).toBeUndefined();
+  });
+
   it('rejects an out-of-enum / neutral emotion with 400', async () => {
     const bad = await request(app)
       .post(`/api/books/${bookId}/cast/maerin/design-voice`)

--- a/server/src/routes/qwen-voice.ts
+++ b/server/src/routes/qwen-voice.ts
@@ -533,8 +533,15 @@ qwenVoiceRouter.post(
        promotes it on approve. Default false keeps the original in-place design. */
     const isStandalone = located.state?.isStandalone === true;
     const seriesInfo = isStandalone ? null : await findAuthorSeriesForBookId(bookId);
-    /* srv-43 — mint/persist voiceUuid before the core names the .pt. */
-    const voiceUuid = await ensureCharacterVoiceUuid(bookDir, characterId, seriesInfo ?? undefined);
+    /* srv-43 — mint/persist a voiceUuid before the core names the .pt, but ONLY
+       for a BASE design (which writes the `.pt` at the resulting `qwen-<uuid>`
+       key). A VARIANT must NOT mint: it doesn't write the base `.pt`, so a fresh
+       uuid would flip the base's storage key while its embedding stays at the
+       old key — orphaning it (#1057). A variant reuses the character's existing
+       voiceUuid and anchors on the base's current key. */
+    const voiceUuid = emotion
+      ? character.voiceUuid
+      : await ensureCharacterVoiceUuid(bookDir, characterId, seriesInfo ?? undefined);
     const characterForDesign: CastCharacter = { ...character, voiceUuid: voiceUuid ?? character.voiceUuid };
     try {
       const { voiceId, url } = await designQwenVoiceForCharacter({


### PR DESCRIPTION
## Summary

Permanent recurrence guard for #1057 (whose data half was healed by the one-shot repair script in #1067/#1075).

Both design paths — the bulk "Design full cast" loop (`cast-design.ts`) and the single design-voice route (`qwen-voice.ts`) — called `ensureCharacterVoiceUuid` for **every** task, including emotion-variant tasks. Minting a uuid is safe for a **base** design (it writes the `.pt` at the resulting `qwen-<uuid>` key), but a **variant** design never writes the base `.pt`: stamping a fresh uuid flips the base's storage key (`qwenStorageKey`) to `qwen-<uuid>` while the embedding stays at the old `qwen-<voiceId ?? id>` key — orphaning it. That is exactly how a bulk "Emotion variants" run orphaned every base voice (silent Kokoro fallback on re-render; the variant mint then can't load its base → the 0→100% no-op).

**Fix:** gate the uuid mint on a base design (`!emotion`). A variant reuses the character's existing `voiceUuid` and anchors on the base's current storage key. No file migration — the orphan never forms.

## Test plan

- New regression test (`qwen-voice.test.ts`): designing a variant for a no-uuid character must NOT stamp a uuid and must anchor on the legacy `qwen-<voiceId>` key.
- qwen-voice 51/51, cast-design 21/21, typecheck green; full pre-push `npm run verify` battery green (the first run hit the known `test:server-slow` tinypool flake — confirmed 244/244 in isolation — and passed on re-run).

Closes #1076
Refs #1057

🤖 Generated with [Claude Code](https://claude.com/claude-code)