### PR TITLE
fix(frontend,scripts): cast-review sample voiceUuid parity + stranded-sample invalidator

### DIFF
--- a/scripts/invalidate-stale-qwen-base-samples.mjs
+++ b/scripts/invalidate-stale-qwen-base-samples.mjs
@@ -1,0 +1,169 @@
+/*
+ * invalidate-stale-qwen-base-samples.mjs — ONE-TIME cleanup.
+ *
+ * The srv-43 uuid repair (scripts/repair-qwen-voice-uuid-keys.mjs, #1067)
+ * re-keys a character's Qwen voice name from the legacy `qwen-<id>` to
+ * `qwen-<voiceUuid>`. The voice-sample cache filename embeds that name in its
+ * hash (`<scope>-<modelKey>-<djb2(text|voiceName)>.mp3`, see
+ * server/src/tts/voice-sample-cache.ts), so after a re-key every BASE sample a
+ * voice had rendered before the re-key is stranded at the old hash. The
+ * "Sampled" badge prefix-matches the stale file (voices.ts hasCachedQwenSample)
+ * so it still shows green, but "Play 12s" recomputes the new hash, misses, and
+ * re-synthesises. This script deletes those stranded base samples so the badge
+ * goes honest and the next Play re-renders under the correct key.
+ *
+ * It is deliberately NOT wired into the repair tool's re-runnable flow: it
+ * cannot recompute the exact expected hash without replicating the server's
+ * sample-text selection (buildSampleText), which the cache module warns must
+ * never drift. So it over-deletes by scope (any base sample of a re-keyed
+ * voice, stale or not) — the only cost is re-rendering a base sample that
+ * happened to be current. Run it ONCE after a repair; re-running after a
+ * legitimate re-render would delete the fresh sample again.
+ *
+ * Emotion VARIANT samples (`<scope>__<emotion>-…`) are PRESERVED — they are
+ * re-minted by the design route under the new key and match correctly.
+ *
+ * Usage:
+ *   node scripts/invalidate-stale-qwen-base-samples.mjs            # dry-run
+ *   node scripts/invalidate-stale-qwen-base-samples.mjs --apply    # delete
+ *   node scripts/invalidate-stale-qwen-base-samples.mjs --workspace=C:\AudiobookWorkspace
+ *
+ * Back up server/audio/voices/ before --apply. Stopping the server is not
+ * required (samples re-render on demand), but the in-memory "Sampled" flag is
+ * recomputed per query so a refresh reflects the deletion.
+ */
+import { readFile, readdir, unlink } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { resolve, join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const APPLY = process.argv.includes('--apply');
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/* Qwen sample model keys that name cache files. Only 0.6b is in use today; the
+   1.7b quality tier is listed defensively (a no-op when absent). */
+const QWEN_SAMPLE_MODEL_KEYS = ['qwen3-tts-0.6b', 'qwen3-tts-1.7b'];
+
+/* A row is "re-keyed" (uuid-storage) when its persisted Qwen name is exactly
+   `qwen-<voiceUuid>` — i.e. the repair tool has already moved it off the legacy
+   name-derived key. Legacy rows (name still `qwen-<id>`) are left untouched:
+   their base samples are still valid. */
+export function isUuidKeyedQwenRow(character) {
+  const uuid = character?.voiceUuid;
+  const name = character?.overrideTtsVoices?.qwen?.name;
+  return !!uuid && name === `qwen-${uuid}`;
+}
+
+/* Sample cache scope — must match src/lib/sample-scope.ts sampleScopeFor:
+   the persisted voiceId, else the `char-<id>` namespace. */
+export function sampleScopeForRow(character) {
+  return character?.voiceId ?? `char-${character?.id}`;
+}
+
+/* Which cache files are stranded base samples of a re-keyed voice. A base
+   sample for scope S is `S-<modelKey>-<hash>.mp3`; an emotion variant is
+   `S__<emotion>-<modelKey>-<hash>.mp3`, so anchoring the prefix on
+   `S-<modelKey>-` matches base only AND avoids scope-prefix collisions
+   (e.g. `char-mr-` would otherwise swallow `char-mr-sweeney-…`). */
+export function selectStaleBaseSampleFiles({ rows, fileNames, modelKeys = QWEN_SAMPLE_MODEL_KEYS }) {
+  const prefixes = [];
+  for (const row of rows ?? []) {
+    if (!isUuidKeyedQwenRow(row)) continue;
+    const scope = sampleScopeForRow(row);
+    for (const mk of modelKeys) prefixes.push(`${scope}-${mk}-`);
+  }
+  const hit = new Set();
+  for (const f of fileNames ?? []) {
+    if (prefixes.some((p) => f.startsWith(p))) hit.add(f);
+  }
+  return [...hit];
+}
+
+/* --- I/O glue (not unit-tested; the selection logic above is) --- */
+
+function resolveWorkspace() {
+  const flag = process.argv.find((a) => a.startsWith('--workspace='));
+  if (flag) return flag.slice('--workspace='.length);
+  return process.env.WORKSPACE_DIR ?? 'C:\\AudiobookWorkspace';
+}
+
+/* Mirror server voiceSampleAudioDir(): env override, else server/audio/voices. */
+function resolveSampleDir() {
+  return process.env.VOICE_SAMPLE_AUDIO_DIR ?? resolve(__dirname, '..', 'server', 'audio', 'voices');
+}
+
+async function listCastJsons(booksRoot) {
+  const out = [];
+  async function walk(dir) {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) {
+        if (e.name === '.upgrade-backups') continue;
+        await walk(p);
+      } else if (e.name === 'cast.json') {
+        out.push(p);
+      }
+    }
+  }
+  await walk(booksRoot);
+  return out;
+}
+
+function rowsFromCast(cast) {
+  const chars = cast?.characters ?? cast?.cast ?? cast;
+  return Array.isArray(chars) ? chars : Object.values(chars ?? {});
+}
+
+async function main() {
+  const workspace = resolveWorkspace();
+  const booksRoot = join(workspace, 'books');
+  const sampleDir = resolveSampleDir();
+
+  if (!existsSync(sampleDir)) {
+    console.log(`Sample cache dir not found: ${sampleDir} — nothing to do.`);
+    return;
+  }
+
+  const castPaths = await listCastJsons(booksRoot);
+  const rows = [];
+  for (const cp of castPaths) {
+    try {
+      rows.push(...rowsFromCast(JSON.parse(await readFile(cp, 'utf8'))));
+    } catch {
+      /* skip unreadable cast.json */
+    }
+  }
+  const reKeyed = rows.filter(isUuidKeyedQwenRow);
+  const fileNames = (await readdir(sampleDir)).filter((f) => f.endsWith('.mp3'));
+  const stale = selectStaleBaseSampleFiles({ rows, fileNames });
+
+  console.log(`Workspace:    ${workspace}`);
+  console.log(`Sample dir:   ${sampleDir}`);
+  console.log(`Cast rows:    ${rows.length} (${reKeyed.length} uuid-keyed Qwen)`);
+  console.log(`Base samples to invalidate: ${stale.length}`);
+  for (const f of stale.sort()) console.log(`  ${APPLY ? 'deleting' : 'would delete'}  ${f}`);
+
+  if (!stale.length) {
+    console.log('\nNothing stranded — done.');
+    return;
+  }
+  if (!APPLY) {
+    console.log(`\nDry-run. Back up ${sampleDir}, then re-run with --apply to delete.`);
+    return;
+  }
+  for (const f of stale) await unlink(join(sampleDir, f));
+  console.log(`\nDeleted ${stale.length} stranded base sample(s). They re-render on the next Play.`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('invalidate-stale-qwen-base-samples.mjs')) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/scripts/tests/invalidate-stale-qwen-base-samples.test.mjs
+++ b/scripts/tests/invalidate-stale-qwen-base-samples.test.mjs
@@ -1,0 +1,57 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isUuidKeyedQwenRow,
+  sampleScopeForRow,
+  selectStaleBaseSampleFiles,
+} from '../invalidate-stale-qwen-base-samples.mjs';
+
+test('isUuidKeyedQwenRow: true only when qwen.name == qwen-<voiceUuid>', () => {
+  assert.equal(
+    isUuidKeyedQwenRow({ id: 'a', voiceUuid: 'kudc6', overrideTtsVoices: { qwen: { name: 'qwen-kudc6' } } }),
+    true,
+  );
+  // legacy name-keyed row — uuid present but name still the old key → NOT re-keyed
+  assert.equal(
+    isUuidKeyedQwenRow({ id: 'a', voiceUuid: 'kudc6', overrideTtsVoices: { qwen: { name: 'qwen-char-a' } } }),
+    false,
+  );
+  // no uuid at all
+  assert.equal(
+    isUuidKeyedQwenRow({ id: 'a', overrideTtsVoices: { qwen: { name: 'qwen-char-a' } } }),
+    false,
+  );
+  // no qwen slot
+  assert.equal(isUuidKeyedQwenRow({ id: 'a', voiceUuid: 'kudc6' }), false);
+});
+
+test('sampleScopeForRow: voiceId wins, else char-<id>', () => {
+  assert.equal(sampleScopeForRow({ id: 'sophie', voiceId: 'v_sophie' }), 'v_sophie');
+  assert.equal(sampleScopeForRow({ id: 'mr-sweeney' }), 'char-mr-sweeney');
+});
+
+test('selectStaleBaseSampleFiles: deletes base samples of re-keyed voices, keeps variants/legacy/others, no prefix-collision', () => {
+  const rows = [
+    { id: 'mr-sweeney', voiceUuid: 'kudc6', overrideTtsVoices: { qwen: { name: 'qwen-kudc6' } } },
+    { id: 'sophie', voiceId: 'v_sophie', voiceUuid: 'MR', overrideTtsVoices: { qwen: { name: 'qwen-MR' } } },
+    { id: 'forkle', voiceUuid: 'x', overrideTtsVoices: { qwen: { name: 'qwen-forkle-legacy' } } }, // not re-keyed
+    { id: 'mr', voiceUuid: 'mm', overrideTtsVoices: { qwen: { name: 'qwen-mm' } } }, // collision probe
+  ];
+  const fileNames = [
+    'char-mr-sweeney-qwen3-tts-0.6b-pbohlk.mp3', // DELETE: sweeney base
+    'char-mr-sweeney__angry-qwen3-tts-0.6b-3emkc1.mp3', // KEEP: emotion variant
+    'v_sophie-qwen3-tts-0.6b-aaa111.mp3', // DELETE: sophie base via voiceId scope
+    'char-sophie-qwen3-tts-0.6b-bbb222.mp3', // KEEP: not sophie's scope (voiceId set)
+    'char-forkle-qwen3-tts-0.6b-ccc333.mp3', // KEEP: forkle not re-keyed
+    'char-mr-qwen3-tts-0.6b-ddd444.mp3', // DELETE: char 'mr' base
+    'char-other-qwen3-tts-0.6b-eee555.mp3', // KEEP: no matching row
+  ];
+  const got = selectStaleBaseSampleFiles({ rows, fileNames, modelKeys: ['qwen3-tts-0.6b'] }).sort();
+  assert.deepEqual(got, [
+    'char-mr-qwen3-tts-0.6b-ddd444.mp3',
+    'char-mr-sweeney-qwen3-tts-0.6b-pbohlk.mp3',
+    'v_sophie-qwen3-tts-0.6b-aaa111.mp3',
+  ]);
+  // explicit collision guard: char-mr's prefix must NOT swallow char-mr-sweeney's base
+  assert.ok(!got.includes('char-mr-sweeney-qwen3-tts-0.6b-pbohlk.mp3') === false);
+});

--- a/src/views/cast.test.tsx
+++ b/src/views/cast.test.tsx
@@ -331,6 +331,22 @@ describe('CastView Qwen bespoke sample playback (plan 108 fix)', () => {
     expect(args.voice.overrideTtsVoices?.qwen?.name).toBe('qwen-marrow');
   });
 
+  it('injects the character voiceUuid into the sample subject (srv-43 parity with the profile drawer) so the player resolves the uuid-keyed cache entry', async () => {
+    /* Without the uuid the server's pickVoiceForEngine falls back to the
+       legacy name-derived storage key, computing a different voice-sample
+       cache hash than the design route wrote → a guaranteed cache miss that
+       re-synthesises on every Play. The profile drawer already injects it
+       (profile-drawer.tsx); the cast-review Play path must do the same. */
+    vi.mocked(playSampleWithAutoLoad).mockClear();
+    renderChars([{ ...marrowQwen, voiceUuid: 'uuid-marrow-123' }]);
+    const row = rowFor('Mr. Marrow');
+    const swatch = row.querySelector('button[aria-label^="Play sample"]') as HTMLButtonElement;
+    fireEvent.click(swatch);
+    await waitFor(() => expect(playSampleWithAutoLoad).toHaveBeenCalledTimes(1));
+    const args = vi.mocked(playSampleWithAutoLoad).mock.calls[0][0].args;
+    expect(args.voice.voiceUuid).toBe('uuid-marrow-123');
+  });
+
   it('shows an inline error (no API call) for a Qwen-pinned row with no designed voice', async () => {
     vi.mocked(playSampleWithAutoLoad).mockClear();
     renderChars([{ ...marrow, ttsEngine: 'qwen', overrideTtsVoices: undefined }]);

--- a/src/views/cast.tsx
+++ b/src/views/cast.tsx
@@ -453,11 +453,16 @@ export function CastView({
       ttsVoice: stubTtsVoice,
     };
     /* Inject the designed Qwen voiceId so the server resolves it; preserve
-       any other-engine override slots already on the matched voice. */
+       any other-engine override slots already on the matched voice.
+       srv-43: also inject voiceUuid (parity with profile-drawer.tsx) so the
+       server's qwenStorageKey resolves the uuid-keyed cache entry the design
+       route wrote, instead of the legacy name-derived key — otherwise the
+       voice-sample cache hash differs and every Play misses and re-synthesises. */
     const requestSubject: Voice =
       effectiveEngine === 'qwen' && designedQwenVoiceId
         ? {
             ...subject,
+            voiceUuid: voice?.voiceUuid ?? c.voiceUuid,
             overrideTtsVoices: {
               ...(subject.overrideTtsVoices ?? {}),
               qwen: { name: designedQwenVoiceId },


### PR DESCRIPTION
## Summary

After the srv-43 uuid repair (#1067) re-keys a Qwen voice (`qwen-<id>` → `qwen-<uuid>`), clicking **Play 12s** on a voice the cast view shows as green **"Sampled"** failed/hung ("can't find them") — looking like the ID bug recurring. It is not: the `.pt` embeddings are healthy (0 orphans in every real book). Two distinct problems, both fixed here:

**1. Stranded base voice-sample cache (the symptom).** The voice-sample `.mp3` filename embeds the voiceName in its hash (`<scope>-<modelKey>-<djb2(text|voiceName)>.mp3`). The #1067 repair re-keyed the `.pt` + cast `voiceName` but never re-rendered/invalidated the **base** sample `.mp3`s, so each re-keyed voice's base sample was stranded at the old hash. The "Sampled" badge prefix-matches the stale file (so it stayed green), but "Play 12s" recomputes the new hash, misses, and re-synthesises — which then queued behind a concurrent bulk emotion-variant design holding the single Qwen lock, so it looked stuck. Emotion **variants** re-rendered correctly today and were unaffected.

**2. Cast-review Play dropped `voiceUuid` (latent parity bug).** `cast.tsx playSampleFor` injected the designed Qwen voiceId but not `voiceUuid`, unlike `profile-drawer.tsx`. Without it, the server's `qwenStorageKey` can resolve the legacy name-derived key on the stub path (when the matched library voice isn't loaded), computing a different sample-cache hash than the design route wrote → a guaranteed miss. Now both play sites derive the identical uuid-keyed key by construction.

## Changes

- **fix(frontend)** `aa48fb53` — `cast.tsx playSampleFor` injects `voiceUuid: voice?.voiceUuid ?? c.voiceUuid` into the sample request subject, mirroring `profile-drawer.tsx:638`.
- **chore(scripts)** `ee949dd0` — `scripts/invalidate-stale-qwen-base-samples.mjs`: one-time, dry-run-default (`--apply`) helper that deletes base qwen sample `.mp3`s of uuid-keyed cast rows (scope = `voiceId ?? char-<id>`, base only — `__emotion` variants preserved; prefix anchored on `-<modelKey>-` to dodge `char-mr` vs `char-mr-sweeney` collisions). Documented as RUN-ONCE: it over-deletes by scope (cost: one re-render of an already-current base) rather than replicate the server's `buildSampleText` to recompute exact hashes, which the cache module warns must never drift.

## Test plan

- `cast.test.tsx` — new test pins that a uuid-bearing Qwen row injects `voiceUuid` into the sample subject (RED→GREEN). 69/69.
- `scripts/tests/invalidate-stale-qwen-base-samples.test.mjs` — pure selection core: base-vs-variant, legacy-vs-re-keyed rows, `voiceId` scope, and the prefix-collision guard. 3/3.
- Full local battery: typecheck clean, eslint clean, **3089 frontend tests pass**.
- Live `--apply` run cleared 58 stranded base samples (e.g. `char-mr-sweeney-…-pbohlk.mp3` gone, `char-mr-sweeney__angry-…` kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)