### PR TITLE
fix(server): tolerate compound splits + deny Whisper boilerplate in ASR QA

### DIFF
--- a/server/src/tts/segment-asr-qa.test.ts
+++ b/server/src/tts/segment-asr-qa.test.ts
@@ -133,6 +133,65 @@ describe('classifyTranscript', () => {
   });
 });
 
+describe('compound-word tolerance', () => {
+  // Whisper splits closed compounds the manuscript writes solid
+  // ("Curvebuster" → "Curve Buster") and joins ones it writes open
+  // ("good bye" → "goodbye"). On a short sentence a single split is 1 sub + 1
+  // ins on a tiny denominator → WER 0.5 > 0.4 → a false 'drift' on audio that
+  // says exactly the right words. The bridge reconciles solid↔split forms.
+
+  it('Whisper splitting a solid compound is not drift (Curvebuster → Curve Buster)', () => {
+    const c = classifyTranscript('They called her Curvebuster.', 'They called her Curve Buster?', CLEAN);
+    expect(c.verdict).toBe('ok');
+    expect(c.wer).toBe(0);
+    expect(c.sub).toBe(0);
+    expect(c.ins).toBe(0);
+  });
+
+  it('Whisper joining an open compound is not drift (good bye → goodbye)', () => {
+    const c = classifyTranscript('Tell him good bye now please.', 'Tell him goodbye now please.', CLEAN);
+    expect(c.verdict).toBe('ok');
+    expect(c.wer).toBe(0);
+    expect(c.del).toBe(0);
+    expect(c.sub).toBe(0);
+  });
+
+  it('does NOT mask a genuine wrong-word swap as a compound', () => {
+    // None of these substitutions concatenate to the expected token, so the
+    // bridge must leave them as real drift.
+    const c = classifyTranscript(
+      'She opened the wooden door slowly.',
+      'She closed the metal gate quickly.',
+      CLEAN,
+    );
+    expect(c.verdict).toBe('drift');
+    expect(c.wer).toBeGreaterThan(0.4);
+  });
+});
+
+describe('hallucination deny-list', () => {
+  // Whisper emits training-data boilerplate (pirate-EPUB watermarks, subtitle
+  // credits, "thanks for watching") *confidently* on short/ambiguous audio, so
+  // it sails past the logprob / no-speech guards and lands as 'drift'. These are
+  // never real book content → inconclusive, not a re-record.
+  const long = 'Sophie hurried down the long museum hallway toward the bright exit.';
+
+  it('OceansofPDF.com watermark hallucination → inconclusive, not drift', () => {
+    const c = classifyTranscript(long, 'OceansofPDF.com', CLEAN);
+    expect(c.verdict).toBe('inconclusive');
+  });
+
+  it('subtitle-credit hallucination → inconclusive', () => {
+    const c = classifyTranscript(long, 'Subtitles by the Amara.org community', CLEAN);
+    expect(c.verdict).toBe('inconclusive');
+  });
+
+  it('thanks-for-watching hallucination → inconclusive', () => {
+    const c = classifyTranscript(long, 'Thank you for watching!', CLEAN);
+    expect(c.verdict).toBe('inconclusive');
+  });
+});
+
 describe('verifySegmentTranscript', () => {
   it('transcribes via the injected fn and classifies', async () => {
     const c = await verifySegmentTranscript(Buffer.from([0, 0]), 24000, EXPECTED, {

--- a/server/src/tts/segment-asr-qa.ts
+++ b/server/src/tts/segment-asr-qa.ts
@@ -194,6 +194,55 @@ export function normalizeForWer(text: string): string[] {
   return out;
 }
 
+/* Known Whisper hallucinations — boilerplate the model emits from its training
+   data on short / ambiguous audio (pirate-EPUB watermarks, subtitle credits,
+   video sign-offs). It emits these CONFIDENTLY, so they pass the avg_logprob /
+   no_speech_prob guards and would otherwise land as content drift. They are
+   never real book content, so a match → `inconclusive` (never a re-record). */
+const HALLUCINATION_PATTERNS: readonly RegExp[] = [
+  /oceansofpdf/i,
+  /\bsub(title|titles|s)?\s+by\b/i,
+  /\bcaptions?\s+by\b/i,
+  /\btranscri(bed|ption)\s+by\b/i,
+  /\bamara\.org\b/i,
+  /\bthanks?\s+(you\s+)?for\s+watching\b/i,
+  /\b(please\s+)?(like\s+and\s+)?subscribe\b/i,
+];
+
+/** True when the transcript is dominated by known Whisper boilerplate. */
+export function looksLikeHallucination(transcript: string): boolean {
+  const s = (transcript ?? '').trim();
+  return s.length > 0 && HALLUCINATION_PATTERNS.some((re) => re.test(s));
+}
+
+/* Reconcile solid↔split compound forms between the expected and actual token
+   streams. Whisper routinely splits a closed compound the manuscript writes
+   solid ("curvebuster" → "curve buster") or joins an open one the manuscript
+   writes apart ("good bye" → "goodbye"); on a short sentence that single
+   re-tokenisation is 1 sub + 1 ins on a tiny denominator → WER over the cap → a
+   false 'drift' on audio that says exactly the right words. We collapse an
+   adjacent PAIR only when its concatenation appears as a single token in the
+   OTHER stream — a genuinely wrong word won't concatenate to the expected
+   token, so this can never mask real drift. Pairs only (2↔1); 3+ token
+   compounds are rare and out of scope. */
+export function bridgeCompounds(expected: string[], actual: string[]): [string[], string[]] {
+  const collapse = (tokens: string[], other: ReadonlySet<string>): string[] => {
+    const out: string[] = [];
+    for (let i = 0; i < tokens.length; i += 1) {
+      if (i + 1 < tokens.length && other.has(tokens[i] + tokens[i + 1])) {
+        out.push(tokens[i] + tokens[i + 1]);
+        i += 1; // consumed the pair
+      } else {
+        out.push(tokens[i]);
+      }
+    }
+    return out;
+  };
+  const expSet = new Set(expected);
+  const actSet = new Set(actual);
+  return [collapse(expected, actSet), collapse(actual, expSet)];
+}
+
 /* --- Word-level alignment (Levenshtein with backtrace) --- */
 
 type Op = { type: 'match' | 'sub' | 'del' | 'ins'; expected?: string };
@@ -276,6 +325,15 @@ export function classifyTranscript(
     return base('inconclusive');
   }
 
+  // Known Whisper boilerplate hallucination → untrustworthy transcript, never a
+  // re-record (it's emitted confidently, so the signal guards below miss it).
+  if (looksLikeHallucination(transcript)) {
+    reasons.push(
+      'Transcript is known Whisper boilerplate/hallucination (not book content); not scoring.',
+    );
+    return base('inconclusive');
+  }
+
   // Loop/repeat hallucination is positive drift evidence even at low WER.
   if (signals.compressionRatio != null && signals.compressionRatio > t.maxCompressionRatio) {
     reasons.push(
@@ -304,8 +362,10 @@ export function classifyTranscript(
     }
   }
 
-  const expectedTokens = normalizeForWer(expectedText);
-  const actualTokens = normalizeForWer(transcript);
+  const [expectedTokens, actualTokens] = bridgeCompounds(
+    normalizeForWer(expectedText),
+    normalizeForWer(transcript),
+  );
   if (expectedTokens.length === 0) {
     reasons.push('Not scored — expected text normalised to empty.');
     return base('inconclusive');


### PR DESCRIPTION
## Summary

Kills two language-agnostic false-positive sources in the per-sentence ASR content-QA gate (`server/src/tts/segment-asr-qa.ts`, srv-31). Both were confirmed against a real KotLC render (book 1, ch."ONE") whose audio said exactly the right words but was flagged `drift` — the kind of noise that trains the operator to ignore the gate.

- **Compound-word re-tokenisation.** Whisper splits a closed compound the manuscript writes solid (`"Curvebuster"` → `"Curve Buster"`) or joins an open one (`"good bye"` → `"goodbye"`). On a short sentence that single re-tokenisation is 1 sub + 1 ins on a tiny denominator → WER 0.5 > the 0.4 cap → false `drift`. `bridgeCompounds()` reconciles solid↔split forms, collapsing an adjacent pair **only** when its concatenation appears as a token in the other stream — a genuinely wrong word can't concatenate to the expected token, so this can never mask real drift. (EPUB-confirmed: manuscript reads "Curvebuster" / "superfreak".)
- **Confident Whisper boilerplate hallucinations.** Whisper emits training-data boilerplate — pirate-EPUB watermarks (`OceansofPDF.com`), subtitle credits (`"subtitles by …"`), sign-offs (`"thanks for watching"`) — *confidently* on short/ambiguous audio, so it passes the `avg_logprob` / `no_speech_prob` guards and lands as `drift`. `looksLikeHallucination()` routes these to `inconclusive` (never a re-record), mirroring the existing untrusted-transcript policy.

Both changes are language-agnostic, so they also reduce non-English false positives — but the broader non-English WER calibration gap is tracked separately in #1084.

## Test plan

- 6 new tests in `segment-asr-qa.test.ts`: both compound directions → `ok`/wer 0; all three boilerplate classes → `inconclusive`; and a guard that a genuine wrong-word swap still flags `drift` (no masking).
- Existing Cyrillic / proper-noun / deletion-run regressions stay green.
- Full server suite green (3468 passing); typecheck clean; pre-push `npm run verify` battery passed.

Closes #1085