### PR TITLE
fix(server): quarantine calibration-bleed segments instead of shipping them

### DIFF
--- a/server/src/tts/segment-asr-qa.test.ts
+++ b/server/src/tts/segment-asr-qa.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   classifyTranscript,
+  looksLikeCalibrationBleed,
   normalizeForWer,
   verifySegmentTranscript,
   type AsrSignals,
@@ -130,6 +131,43 @@ describe('classifyTranscript', () => {
     const c = classifyTranscript(expected, heard, CLEAN);
     expect(c.verdict).toBe('drift');
     expect(c.wer).toBeGreaterThan(0.4);
+  });
+});
+
+describe('looksLikeCalibrationBleed', () => {
+  // A bad/runaway Qwen voice clone can echo its ICL ref_text (the voice-design
+  // calibration pangram) into chapter audio (#1074). The detector catches that
+  // bleed in an ASR transcript so the QA path can quarantine it — but only when
+  // the manuscript ITSELF doesn't contain the pangram (a legit quote stays).
+  const NARRATION = 'Sophie hurried down the long museum hallway toward the exit.';
+  const EN_PANGRAM =
+    'The quick brown fox jumps over the lazy dog, and she wondered what tomorrow would bring.';
+
+  it('English calibration pangram in transcript over normal narration → bleed', () => {
+    expect(looksLikeCalibrationBleed(EN_PANGRAM, NARRATION)).toBe(true);
+  });
+
+  it('does NOT fire when the manuscript itself contains the pangram (legit quote)', () => {
+    expect(looksLikeCalibrationBleed(EN_PANGRAM, `He typed it out: ${EN_PANGRAM}`)).toBe(false);
+  });
+
+  it('ordinary transcript that matches the line → not a bleed', () => {
+    expect(looksLikeCalibrationBleed(NARRATION, NARRATION)).toBe(false);
+  });
+
+  it('detects the per-language calibration siblings (es/fr/de/ru)', () => {
+    expect(
+      looksLikeCalibrationBleed('El veloz murciélago hindú comía feliz cardillo y kiwi.', NARRATION),
+    ).toBe(true);
+    expect(
+      looksLikeCalibrationBleed('Portez ce vieux whisky au juge blond qui fume.', NARRATION),
+    ).toBe(true);
+    expect(
+      looksLikeCalibrationBleed('Zwölf Boxkämpfer jagen Viktor quer über den großen Sylter Deich.', NARRATION),
+    ).toBe(true);
+    expect(
+      looksLikeCalibrationBleed('Съешь же ещё этих мягких французских булок да выпей чаю.', NARRATION),
+    ).toBe(true);
   });
 });
 

--- a/server/src/tts/segment-asr-qa.ts
+++ b/server/src/tts/segment-asr-qa.ts
@@ -120,6 +120,36 @@ export function buildCastNameAllowlist(
   return [...names];
 }
 
+/* Voice-design calibration / ref_text signatures. The sidecar speaks a short
+   phonetically-rich pangram when cloning a voice (its ICL reference clip);
+   source of truth is `server/tts-sidecar/main.py` CALIBRATION_TEXT (English) +
+   CALIBRATION_TEXTS (per-language siblings). A runaway / bad clone can echo that
+   reference clip into chapter audio (#1074), where it reads as fluent speech the
+   word-error gate flags but ships anyway. These distinctive lowercased
+   substrings detect the bleed in an ASR transcript. Latin signatures are kept
+   ASCII-only (avoiding accent variance in Whisper's output); the Russian one
+   stays Cyrillic, the form Whisper emits for Russian audio. */
+const CALIBRATION_SIGNATURES: readonly string[] = [
+  'quick brown fox', // English
+  'wondered what tomorrow would bring', // English (2nd clause)
+  'cardillo y kiwi', // Spanish
+  'portez ce vieux whisky', // French
+  'sylter deich', // German
+  'французских булок', // Russian
+];
+
+/** True when an ASR transcript is the voice-design calibration clip bleeding
+    into audio (#1083) — it contains a calibration signature that the manuscript
+    sentence does NOT (so a book legitimately quoting the pangram is not a bleed). */
+export function looksLikeCalibrationBleed(transcript: string, expectedText: string): boolean {
+  const norm = (s: string): string =>
+    (s ?? '').normalize('NFKC').toLowerCase().replace(/\s+/g, ' ');
+  const t = norm(transcript);
+  if (!t) return false;
+  const e = norm(expectedText);
+  return CALIBRATION_SIGNATURES.some((sig) => t.includes(sig) && !e.includes(sig));
+}
+
 /* --- Normalization --- */
 
 const SMART_QUOTES = /[‘’‚‛′‵]/g; // ' ' ‚ ‛ ′ ‵

--- a/server/src/tts/synthesise-chapter-asr.test.ts
+++ b/server/src/tts/synthesise-chapter-asr.test.ts
@@ -181,6 +181,54 @@ describe('synthesiseChapter ASR content-QA pass', () => {
     expect(calls.map((c) => c.verified)).toEqual([0, 1]);
   });
 
+  it('quarantines a calibration-bleed segment instead of shipping the pangram (#1083)', async () => {
+    const provider = makeProvider();
+    // A runaway clone bled its ICL ref_text (the calibration pangram) into the
+    // audio. The narration line is ordinary, but every take transcribes as the
+    // pangram → drift that never recovers → must be quarantined, not shipped.
+    const NARRATION = 'Sophie hurried down the long museum hallway toward the exit.';
+    const PANGRAM =
+      'The quick brown fox jumps over the lazy dog, and she wondered what tomorrow would bring.';
+    const { fn } = makeTranscriber([PANGRAM]);
+    const res = await synthesiseChapter({
+      sentences: [sentence(1, NARRATION)],
+      cast,
+      provider,
+      modelKey: 'gemini-2.5-flash',
+      engine: 'gemini',
+      asr: { maxRerecords: 1, transcribeFn: fn },
+    });
+    // Re-recorded up to budget (initial + 1) before quarantining.
+    expect(provider.calls).toHaveLength(2);
+    const seg = res.segments.find((s) => s.kind !== 'title');
+    expect(seg?.quarantined).toBe(true);
+    expect(seg?.suspect).toBe(true);
+    // The bleeding take is NOT shipped — replaced with silence (a distinct,
+    // non-trivial length vs the 2-byte stub the provider returns).
+    expect(seg!.endSec - seg!.startSec).toBeGreaterThan(0.2);
+    // Forensics retained for the QA report.
+    expect(seg?.asr?.transcript).toContain('quick brown fox');
+  });
+
+  it('does not quarantine when the manuscript legitimately quotes the pangram', async () => {
+    const provider = makeProvider();
+    // Both the line AND the transcript are the pangram → faithful render, ship it.
+    const PANGRAM =
+      'The quick brown fox jumps over the lazy dog, and she wondered what tomorrow would bring.';
+    const { fn } = makeTranscriber([PANGRAM]);
+    const res = await synthesiseChapter({
+      sentences: [sentence(1, PANGRAM)],
+      cast,
+      provider,
+      modelKey: 'gemini-2.5-flash',
+      engine: 'gemini',
+      asr: { maxRerecords: 1, transcribeFn: fn },
+    });
+    const seg = res.segments.find((s) => s.kind !== 'title');
+    expect(seg?.quarantined).toBeUndefined();
+    expect(seg?.asr?.verdict).toBe('ok');
+  });
+
   it('is a no-op when asr is absent (byte-identical to today)', async () => {
     const provider = makeProvider();
     const res = await synthesiseChapter({

--- a/server/src/tts/synthesise-chapter.ts
+++ b/server/src/tts/synthesise-chapter.ts
@@ -21,6 +21,7 @@ import { pcmDurationSec } from './pcm.js';
 import { configValue } from '../config/resolver.js';
 import { evaluateSegmentPcm, type SegmentQaVerdict, type SegmentQaThresholds } from './segment-qa.js';
 import {
+  looksLikeCalibrationBleed,
   verifySegmentTranscript,
   type AsrClassification,
   type AsrThresholds,
@@ -312,6 +313,11 @@ export interface ChapterSegment {
       "fluent but wrong words" surface. Undefined when ASR passed, was
       inconclusive, or did not run. */
   asrSuspect?: boolean;
+  /** True when this segment's audio bled the voice-design calibration clip
+      (#1083) and was QUARANTINED — its take was dropped (replaced with brief
+      silence) rather than shipped, after the ASR re-record budget failed to
+      recover it. A hard `suspect` flag rides alongside. Undefined otherwise. */
+  quarantined?: boolean;
 }
 
 /** Silence padding bookending the spoken chapter-title narration. Each chapter
@@ -322,6 +328,11 @@ export interface ChapterSegment {
     in `docs/features/archive/28-chapter-audio-format.md`; adjust both at once. */
 const CHAPTER_LEAD_SILENCE_SEC = 1.5;
 const CHAPTER_POST_TITLE_SILENCE_SEC = 1.5;
+
+/** Brief silence that replaces a quarantined calibration-bleed take (#1083) —
+    enough to preserve a perceptible sentence slot in the timeline without
+    subjecting the listener to the (typically runaway-long) bled clip. */
+const QUARANTINE_SILENCE_SEC = 0.3;
 
 /** Build a zero-filled mono 16-bit LE PCM buffer of the requested duration.
     Matches the per-chapter PCM contract — same byte layout as what the TTS
@@ -1550,12 +1561,27 @@ export async function synthesiseChapter(
     if (r.sampleRate !== sampleRate) {
       pcmForGroup = resamplePcm16(r.pcm, r.sampleRate, sampleRate);
     }
+    const qa = segmentQaByIndex.get(group.index);
+    const asrClass = segmentAsrByIndex.get(group.index);
+    /* Calibration-bleed quarantine (#1083): a runaway clone that echoed its
+       voice-design ref_text (the pangram) into audio must never ship, even as
+       the least-bad take. The ASR re-record budget already tried to recover it
+       above; if the final transcript still bleeds, drop the take — replace it
+       with brief silence — and hard-flag it. Belt-and-suspenders over the
+       flag-only ASR gate. */
+    const quarantined =
+      asrClass != null && looksLikeCalibrationBleed(asrClass.transcript, group.text);
+    if (quarantined) {
+      pcmForGroup = buildSilencePcm16(sampleRate, QUARANTINE_SILENCE_SEC);
+      console.warn(
+        `[synthesiseChapter] quarantined calibration-bleed segment (group ${group.index}): ` +
+          JSON.stringify(asrClass.transcript.slice(0, 80)),
+      );
+    }
     const startSec = pcmDurationSec(runningBytes, sampleRate);
     chunks.push(pcmForGroup);
     runningBytes += pcmForGroup.length;
     const endSec = pcmDurationSec(runningBytes, sampleRate);
-    const qa = segmentQaByIndex.get(group.index);
-    const asrClass = segmentAsrByIndex.get(group.index);
     segments.push({
       groupIndex: group.index,
       characterId: group.characterId,
@@ -1565,9 +1591,10 @@ export async function synthesiseChapter(
       renderedFallbackEngine: resolveGroup(group).renderedFallbackEngine,
       voiceSubstitutedFrom: r.voiceSubstitutedFrom,
       qa,
-      suspect: qa?.status === 'suspect' ? true : undefined,
+      suspect: quarantined || qa?.status === 'suspect' ? true : undefined,
       asr: asrClass,
       asrSuspect: asrClass?.verdict === 'drift' ? true : undefined,
+      quarantined: quarantined ? true : undefined,
     });
   }
   void completedCount;


### PR DESCRIPTION
## Summary

Belt-and-suspenders gate so a bleeding voice design can never reach chapter audio. A runaway / bad Qwen clone can echo its ICL `ref_text` — the voice-design calibration pangram (`"the quick brown fox … and she wondered what tomorrow would bring"` + per-language siblings, sidecar `main.py CALIBRATION_TEXT`/`CALIBRATION_TEXTS`) — into chapter audio (#1074). The signal-QA and ASR gates **detect** it (runaway / drift) but are flag-only: the least-bad take ships anyway, so the pangram reaches the listener.

- `looksLikeCalibrationBleed(transcript, expectedText)` (`segment-asr-qa.ts`) matches the per-language calibration signatures (en/es/fr/de/ru) against the ASR transcript — but only when the manuscript sentence does **not** contain the pangram, so a book that legitimately quotes it is untouched (no false positives on ordinary text).
- `synthesiseChapter`, at the single assembly seam, quarantines a still-bleeding segment **after** the ASR re-record budget fails to recover it: the take is dropped — replaced with brief silence via `buildSilencePcm16` — instead of emitted, and hard-flagged `suspect` + `quarantined` for the QA surface.

The English calibration line is `"the quick brown fox …"`; non-Latin (Russian) signatures stay Cyrillic, the form Whisper emits for that audio.

## Test plan

- Detector unit cases (`segment-asr-qa.test.ts`): English bleed → true; legit-quote manuscript exemption → false; ordinary line → false; es/fr/de/ru siblings → true.
- `synthesiseChapter` integration (`synthesise-chapter-asr.test.ts`): a calibration-bleed segment → `quarantined: true` + silence (not the pangram) shipped, after re-recording up to budget; a manuscript that legitimately is the pangram → shipped `ok`, not quarantined.
- Full server suite green (3468 passing); typecheck clean; pre-push `npm run verify` battery passed.

Closes #1083
Refs #1074