### PR TITLE
fix(server): make ASR content-QA language-aware (non-English scaffold)

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -510,6 +510,10 @@ SEG_ASR_MAX_RERECORDS=2
 SEG_ASR_SAMPLE_EVERY=1
 # Word-error-rate above this threshold is flagged as content drift. [live]
 SEG_ASR_MAX_WER=0.4
+# Spanish-specific WER drift cap; defaults to the global ASR max WER until tuned on-box (#1084). [live]
+SEG_ASR_MAX_WER_ES=0.4
+# Russian-specific WER drift cap; defaults to the global ASR max WER until tuned on-box (#1084). [live]
+SEG_ASR_MAX_WER_RU=0.4
 # When on, each rendered line of a stochastic-engine character is embedded (ECAPA speaker model) and checked for acoustic match against the character's voice centroid, flagging misfires. Off by default. CPU (zero VRAM). [live]
 SEG_SPK_ENABLED=false
 # "cpu" (default) uses zero VRAM and never competes with synthesis. "cuda" runs the embed on the GPU — only worthwhile with GPU_VRAM_BUDGET >= 2 (at the default budget of 1 it serialises behind synth and is likely slower than cpu). Changing the device restarts the sidecar. [restart-sidecar]

--- a/server/src/config/registry.ts
+++ b/server/src/config/registry.ts
@@ -230,6 +230,31 @@ export const KNOBS: ConfigKnob[] = [
     default: 0.4, // ← DEFAULT_ASR_THRESHOLDS.maxWer in tts/segment-asr-qa.ts
     apply: 'live', risk: 'low',
   },
+  // Per-language ASR max WER (#1084 scaffold). The ASR gate's English-tuned 0.4
+  // cap went live on non-English books at 3a56bf74 without per-language
+  // validation; these override knobs default to the global maxWer so behaviour
+  // is unchanged until the owed on-box calibration tunes each language.
+  // resolveAsrThresholds(_, language) consults qa.asr.maxWer.<lang> when set.
+  {
+    key: 'qa.asr.maxWer.es',
+    env: 'SEG_ASR_MAX_WER_ES',
+    group: 'qa-gates',
+    label: 'ASR max WER (Spanish)',
+    help: 'Spanish-specific WER drift cap; defaults to the global ASR max WER until tuned on-box (#1084).',
+    type: 'number', min: 0, max: 1, step: 0.05,
+    default: 0.4,
+    apply: 'live', risk: 'low',
+  },
+  {
+    key: 'qa.asr.maxWer.ru',
+    env: 'SEG_ASR_MAX_WER_RU',
+    group: 'qa-gates',
+    label: 'ASR max WER (Russian)',
+    help: 'Russian-specific WER drift cap; defaults to the global ASR max WER until tuned on-box (#1084).',
+    type: 'number', min: 0, max: 1, step: 0.05,
+    default: 0.4,
+    apply: 'live', risk: 'low',
+  },
   {
     key: 'qa.speaker.enabled',
     env: 'SEG_SPK_ENABLED',

--- a/server/src/tts/segment-asr-qa.test.ts
+++ b/server/src/tts/segment-asr-qa.test.ts
@@ -10,10 +10,11 @@
      - short sentences are not scored.
    classifyTranscript is pure, so these inject the transcript directly. */
 
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import {
   classifyTranscript,
   normalizeForWer,
+  resolveAsrThresholds,
   verifySegmentTranscript,
   type AsrSignals,
 } from './segment-asr-qa.js';
@@ -32,6 +33,18 @@ describe('normalizeForWer', () => {
     expect(normalizeForWer('“Hello,” she said—softly.')).toEqual([
       'hello', 'she', 'said', 'softly',
     ]);
+  });
+
+  it('English-spells integers for English / default language', () => {
+    expect(normalizeForWer('I have 3 keys.')).toEqual(['i', 'have', 'three', 'keys']);
+    expect(normalizeForWer('I have 3 keys.', 'en')).toEqual(['i', 'have', 'three', 'keys']);
+  });
+
+  it('does NOT English-spell integers for a non-English language (keeps the digit)', () => {
+    // "3" → "three" only makes sense against English audio; on a Spanish/Russian
+    // book Whisper hears "tres"/"три", so injecting "three" is a false error (#1084).
+    expect(normalizeForWer('Tengo 3 llaves.', 'es')).toEqual(['tengo', '3', 'llaves']);
+    expect(normalizeForWer('У меня 3 ключа.', 'ru')).toEqual(['у', 'меня', '3', 'ключа']);
   });
 
   it('keeps non-Latin (Cyrillic) words instead of erasing them', () => {
@@ -130,6 +143,39 @@ describe('classifyTranscript', () => {
     const c = classifyTranscript(expected, heard, CLEAN);
     expect(c.verdict).toBe('drift');
     expect(c.wer).toBeGreaterThan(0.4);
+  });
+
+  it('threads language so a non-English digit is not English-spelled into extra errors', () => {
+    // "21" → "twenty one" inflates the expected tokens and mis-aligns against the
+    // Spanish "veintiún" Whisper actually heard; with language=es the digit stays
+    // one token → a single clean substitution (#1084).
+    const esExpected = 'Compró 21 manzanas rojas en el mercado.';
+    const esHeard = 'Compró veintiún manzanas rojas en el mercado.';
+    const withEs = classifyTranscript(esExpected, esHeard, CLEAN, { language: 'es' });
+    const withoutLang = classifyTranscript(esExpected, esHeard, CLEAN);
+    expect(withEs.sub).toBe(1);
+    expect(withEs.del).toBe(0);
+    expect(withEs.verdict).toBe('ok');
+    expect(withoutLang.wer).toBeGreaterThan(withEs.wer);
+  });
+});
+
+describe('resolveAsrThresholds per-language maxWer (#1084 scaffold)', () => {
+  afterEach(() => {
+    delete process.env.SEG_ASR_MAX_WER_ES;
+  });
+
+  it('defaults every language to the global maxWer', () => {
+    expect(resolveAsrThresholds(undefined, 'es').maxWer).toBe(0.4);
+    expect(resolveAsrThresholds(undefined, 'ru').maxWer).toBe(0.4);
+    expect(resolveAsrThresholds(undefined).maxWer).toBe(0.4);
+  });
+
+  it('honours a per-language override, leaving other languages on the global', () => {
+    process.env.SEG_ASR_MAX_WER_ES = '0.55';
+    expect(resolveAsrThresholds(undefined, 'es').maxWer).toBeCloseTo(0.55);
+    expect(resolveAsrThresholds(undefined, 'ru').maxWer).toBe(0.4);
+    expect(resolveAsrThresholds(undefined, 'en').maxWer).toBe(0.4);
   });
 });
 

--- a/server/src/tts/segment-asr-qa.ts
+++ b/server/src/tts/segment-asr-qa.ts
@@ -26,7 +26,8 @@
    transcribe call. Env-override pattern mirrors `segment-qa.ts`. */
 
 import { transcribeSegment, type TranscribeResult } from './transcribe-client.js';
-import { configValue } from '../config/resolver.js';
+import { configValue, resolveKnob } from '../config/resolver.js';
+import { allKnobs } from '../config/registry.js';
 
 export type AsrVerdict = 'ok' | 'drift' | 'inconclusive';
 
@@ -76,9 +77,31 @@ export const DEFAULT_ASR_THRESHOLDS: AsrThresholds = {
   maxNoSpeechProb: 0.6,
 };
 
-export function resolveAsrThresholds(override?: Partial<AsrThresholds>): AsrThresholds {
+/** BCP-47 primary subtag, lower-cased ('es-ES' → 'es', '' for nullish). */
+function baseSubtag(language?: string | null): string {
+  return (language ?? '').toLowerCase().split('-')[0];
+}
+
+/** Per-language ASR `maxWer` override (#1084 scaffold). Returns the configured
+    value ONLY when an operator has explicitly set this language's knob (env or
+    app override); otherwise undefined, so the global `maxWer` (including its own
+    override) applies. The per-language knobs default to the global value, so
+    behaviour is unchanged until the owed on-box calibration tunes them. */
+function perLanguageMaxWer(language?: string | null): number | undefined {
+  const lang = baseSubtag(language);
+  if (!lang) return undefined;
+  const knob = allKnobs().find((k) => k.key === `qa.asr.maxWer.${lang}`);
+  if (!knob) return undefined;
+  const state = resolveKnob(knob);
+  return state.source === 'default' ? undefined : (state.effective as number);
+}
+
+export function resolveAsrThresholds(
+  override?: Partial<AsrThresholds>,
+  language?: string | null,
+): AsrThresholds {
   const base: AsrThresholds = {
-    maxWer: configValue<number>('qa.asr.maxWer'),
+    maxWer: perLanguageMaxWer(language) ?? configValue<number>('qa.asr.maxWer'),
     maxDeletionRun: configValue<number>('qa.asr.maxDeletionRun'),
     minChars: configValue<number>('qa.asr.minChars'),
     maxCompressionRatio: configValue<number>('qa.asr.maxCompression'),
@@ -162,14 +185,22 @@ function spellInteger(n: number): string | null {
   return null;
 }
 
-/** Normalise to a token array: lowercase, NFKC, smart-punctuation→ascii,
-    contraction expansion, integer 0..99 → words, strip residual punctuation. */
-export function normalizeForWer(text: string): string[] {
+/** Normalise to a token array: lowercase, NFKC, smart-punctuation→ascii, and
+    — for English (or unspecified language) only — contraction expansion and
+    integer 0..99 → words. The English number-speller ("3" → "three") matches
+    Whisper's English word output; on a non-English book Whisper hears "tres" /
+    "три", so spelling the digit in English injects a false substitution, hence
+    it is gated on `language` (#1084). Full per-language number spelling is owed
+    on-box calibration. */
+export function normalizeForWer(text: string, language?: string | null): string[] {
+  const english = baseSubtag(language) === 'en' || !language;
   let s = (text ?? '').normalize('NFKC').toLowerCase();
   s = s.replace(SMART_QUOTES, "'").replace(SMART_DQUOTES, '"').replace(DASHES, '-');
-  // Expand contractions before stripping apostrophes.
-  for (const [from, to] of Object.entries(CONTRACTIONS)) {
-    s = s.replace(new RegExp(`\\b${from.replace(/'/g, "['’]")}\\b`, 'g'), to);
+  // Expand contractions before stripping apostrophes (English-only forms).
+  if (english) {
+    for (const [from, to] of Object.entries(CONTRACTIONS)) {
+      s = s.replace(new RegExp(`\\b${from.replace(/'/g, "['’]")}\\b`, 'g'), to);
+    }
   }
   // Drop possessive 's and any remaining apostrophes inside words.
   s = s.replace(/'s\b/g, '').replace(/'/g, '');
@@ -180,6 +211,7 @@ export function normalizeForWer(text: string): string[] {
   // (2026-06-15; mirrors the stage2-coverage.ts fix). English is unchanged.
   s = s.replace(/[^\p{L}\p{N}]+/gu, ' ');
   const tokens = s.split(/\s+/).filter(Boolean);
+  if (!english) return tokens; // skip English integer-spelling for other languages
   const out: string[] = [];
   for (const tok of tokens) {
     if (/^\d+$/.test(tok)) {
@@ -247,6 +279,10 @@ export interface ClassifyOptions {
   /** Per-book proper-noun allowlist (cast names). Tokens here don't count as
       drift when substituted/deleted — Whisper mangles invented names. */
   nameAllowlist?: Iterable<string>;
+  /** BCP-47 base subtag of the book. Gates English-only normalization (integer
+      spelling / contractions) and selects the per-language `maxWer` (#1084).
+      Unset → English behaviour, byte-identical to before. */
+  language?: string | null;
 }
 
 /** Pure verdict from a transcript + signals. No I/O — inject the transcript. */
@@ -256,7 +292,7 @@ export function classifyTranscript(
   signals: AsrSignals,
   opts: ClassifyOptions = {},
 ): AsrClassification {
-  const t = resolveAsrThresholds(opts.thresholds);
+  const t = resolveAsrThresholds(opts.thresholds, opts.language);
   const reasons: string[] = [];
   const base = (verdict: AsrVerdict, extra: Partial<AsrClassification> = {}): AsrClassification => ({
     verdict,
@@ -304,8 +340,8 @@ export function classifyTranscript(
     }
   }
 
-  const expectedTokens = normalizeForWer(expectedText);
-  const actualTokens = normalizeForWer(transcript);
+  const expectedTokens = normalizeForWer(expectedText, opts.language);
+  const actualTokens = normalizeForWer(transcript, opts.language);
   if (expectedTokens.length === 0) {
     reasons.push('Not scored — expected text normalised to empty.');
     return base('inconclusive');
@@ -314,7 +350,7 @@ export function classifyTranscript(
   const allow = new Set<string>();
   if (opts.nameAllowlist) {
     for (const name of opts.nameAllowlist) {
-      for (const tok of normalizeForWer(name)) allow.add(tok);
+      for (const tok of normalizeForWer(name, opts.language)) allow.add(tok);
     }
   }
 
@@ -397,6 +433,6 @@ export async function verifySegmentTranscript(
     expectedText,
     r.text,
     { avgLogprob: r.avgLogprob, noSpeechProb: r.noSpeechProb, compressionRatio: r.compressionRatio },
-    { thresholds: opts.thresholds, nameAllowlist: opts.nameAllowlist },
+    { thresholds: opts.thresholds, nameAllowlist: opts.nameAllowlist, language: opts.language },
   );
 }


### PR DESCRIPTION
## Summary

The ASR content-QA gate (`segment-asr-qa.ts`, srv-31) went live on non-English books at `3a56bf74` (the script-aware normalizer fix) but its English-tuned normalization + 0.4 WER cap were never validated per language (#1084). This lands the **offline-safe half**; the actual per-language threshold *values* are owed on-box calibration and tracked in #1084.

- **Language threading.** `classifyTranscript` → `normalizeForWer` (and the proper-noun allowlist) now take the book `language`. `generation.ts` already passes `bookLanguage` as `asr.language` for non-English books, so the *classify* pass — not just the transcribe hint — is language-aware. English / unspecified is byte-identical to before.
- **English-only normalizers gated to English.** `"21" → "twenty one"` inflated the expected tokens and mis-aligned against the Spanish `"veintiún"` Whisper actually heard, manufacturing false substitutions. A non-English book now keeps the digit (full per-language number spelling is owed calibration).
- **Per-language `maxWer` knobs (scaffold).** `qa.asr.maxWer.es` / `.ru` (`SEG_ASR_MAX_WER_ES` / `_RU`), defaulting to the global `maxWer`. `resolveAsrThresholds(_, language)` only consults them when explicitly set, so behaviour is unchanged until on-box calibration tunes each language. `.env.example` synced via `config:sync`.

No guessed thresholds — the knobs are where the validated numbers will go.

## Test plan

- `segment-asr-qa.test.ts`: non-English keeps digits while English still spells; a language-threaded Spanish classify yields fewer errors (lower WER) than the English-spelled path on a `"21"`/`"veintiún"` line; per-language `maxWer` defaults to the global and honours an explicit `SEG_ASR_MAX_WER_ES` override without affecting other languages.
- Full server suite green (3467 passing); typecheck clean; `.env.example` in sync (`config:check`); pre-push `npm run verify` battery passed.

## Owed (tracked in #1084, issue stays open)

Per-language `maxWer` **values** validated against real non-English renders; full per-language number spelling; a per-language WER fixture set; fr/de knobs at activation.

Refs #1084