### PR TITLE
docs(docs): mark srv-52 shipped (BACKLOG row + spec stable)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -416,11 +416,6 @@ _Full detail + acceptance:_ spec `docs/superpowers/specs/2026-06-22-expressive-t
 - _Benefit (technical / community):_ unblocks FA2 on the real stack; community goodwill + visibility.
 _Full detail + acceptance:_ spec `docs/superpowers/specs/2026-06-22-expressive-tts-instruct-tiers-design.md` §4.8/§10 · [#1001](https://github.com/dudarenok-maker/Castwright/issues/1001).
 
-#### `srv-52` — Mint-variant fallback to design-voice when the 1.7B-Base is unavailable ([#1091](https://github.com/dudarenok-maker/Castwright/issues/1091))
-
-- _What:_ When an emotion variant is requested but the Qwen 1.7B-Base (the anchored-mint engine) is not installed or fails to load, route the variant through `/qwen/design-voice` with `persona + EMOTION_INSTRUCT[emotion]` (the old design path) — logged, not silent — instead of orphaning the `.pt` into a silent Kokoro fallback (the #1057/#1063 class). Use the anchored mint only when both base models are available.
-- _Benefit (user / technical):_ emotion variants still ship via the old design path when the 1.7B isn't resident, instead of a silent Kokoro fallback / orphaned `.pt`. Surfaced during #1089.
-
 ### Revisions & regen
 
 #### `fs-5` — Multi-step rollback / snapshot-per-entry (revision history) ([#415](https://github.com/dudarenok-maker/AudioBook-Generator/issues/415))

--- a/docs/superpowers/specs/2026-06-24-srv-52-mint-variant-design-voice-fallback-design.md
+++ b/docs/superpowers/specs/2026-06-24-srv-52-mint-variant-design-voice-fallback-design.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: stable
 issue: 1091
 backlog-id: srv-52
 area: srv
@@ -478,4 +478,4 @@ Per-harness paired coverage (CLAUDE.md testing discipline):
 
 ## Ship notes
 
-_(filled at ship)_
+Shipped 2026-06-25 via PR #1096 (merge commit `95cba1c3`), Closes #1091. Built spec → plan → subagent-driven TDD (10 tasks + an H3 narrow-catch regression test), with 2 adversarial spec-review rounds, 2 adversarial plan-review rounds, per-task reviews, and an opus whole-branch review. Merged atop `origin/main` after it advanced with fs-53; resolved the overlap with #1089's design-progress threading by composing `progressFields` into the new fallback control flow. `test:sidecar` is venv-gated (SKIPs in CI / fresh worktrees) — the sidecar pytest was validated against the dev venv. No `docs/features/` plan was created (the superpowers spec + plan are the record).


### PR DESCRIPTION
## Summary

Post-ship housekeeping for srv-52 (shipped in #1096): drop the `srv-52` row from `docs/BACKLOG.md`, and flip the design spec to `status: stable` with Ship notes. Docs-only.

Refs #1091.

🤖 Generated with [Claude Code](https://claude.com/claude-code)