### PR TITLE
fix(frontend): fs-57 minor follow-ups — split/merge fields, toggle grey-out, gain seam test

### DIFF
--- a/e2e/generation-live-instruct.spec.ts
+++ b/e2e/generation-live-instruct.spec.ts
@@ -47,15 +47,38 @@ test.describe('liveInstruct toggle (fs-57)', () => {
     await page.getByRole('button', { name: /^Generate$/ }).click();
     await expect(page).toHaveURL(/#\/books\/.+\/generate/, { timeout: 5_000 });
 
-    /* Toggle should be rendered and unchecked by default */
+    /* Toggle is rendered but GREYED OUT (disabled) — the default mock cast has
+       no Qwen 1.7B member, so flipping it would be a no-op (#1100). */
     const toggle = page.getByTestId('live-instruct-toggle');
     await expect(toggle).toBeVisible({ timeout: 5_000 });
 
     const checkbox = toggle.locator('input[type="checkbox"]');
     await expect(checkbox).not.toBeChecked();
+    await expect(checkbox).toBeDisabled();
 
     /* Store confirms liveInstruct starts false */
     expect(await liveInstructFromStore(page)).toBe(false);
+
+    /* Promote the first cast member to the 1.7B Quality tier so the toggle
+       becomes active (the view's `characters` prop reads s.cast.characters). */
+    await page.evaluate(() => {
+      const s = (
+        window as unknown as {
+          __store__?: {
+            getState: () => { cast: { characters: Array<{ id: string }> } };
+            dispatch: (a: unknown) => void;
+          };
+        }
+      ).__store__;
+      if (!s) throw new Error('window.__store__ is not exposed');
+      const chars = s.getState().cast.characters;
+      if (!chars.length) throw new Error('no cast characters to promote to 1.7B');
+      s.dispatch({
+        type: 'cast/updateCharacter',
+        payload: { ...chars[0], ttsModelKey: 'qwen3-tts-1.7b' },
+      });
+    });
+    await expect(checkbox).toBeEnabled();
 
     /* Click to enable */
     await checkbox.click();

--- a/server/tts-sidecar/tests/test_instruct_synth.py
+++ b/server/tts-sidecar/tests/test_instruct_synth.py
@@ -366,17 +366,48 @@ def test_gain_for_item_variant_path_unchanged() -> None:
     assert main._gain_for_item({"voice": "base-voice", "emotion": "angry"}, False) == pytest.approx(1.0)
 
 
-def test_synthesize_batch_live_instruct_gain_applied() -> None:
-    """synthesize_batch(live_instruct=True) applies per-emotion gain to each item's PCM.
+def _amp_ratios(pcms: list[bytes]) -> list[float]:
+    """Mean absolute int16 amplitude of each PCM buffer, normalised to [0, 1]."""
+    INT16_MAX = 32767
+    return [
+        float(np.abs(np.frombuffer(p, dtype="<i2").astype(np.float32) / INT16_MAX).mean())
+        for p in pcms
+    ]
 
-    The synth is mocked so no GPU is needed.  We feed a known-amplitude float32
-    waveform and assert the output int16 amplitude ratio matches the expected gain.
+
+def test_synthesize_batch_live_instruct_gain_drives_real_method(monkeypatch) -> None:
+    """Integration seam (#1100): drive the REAL QwenEngine.synthesize_batch on the
+    1.7B live-instruct path with ONLY the inner model forward mocked, and assert the
+    per-emotion gain lands on the returned PCM.
+
+    Unlike the prior version (which reimplemented the gain loop in the test), this
+    exercises the real call site — `_gain_for_item(items[i], live_instruct)` +
+    `_float_audio_to_int16_le` inside `synthesize_batch`. So a call-site regression
+    (e.g. reverting to `_apply_emotion_gain` keyed on the voice name, or dropping the
+    `live_instruct` flag) is now caught here, not silently passed.
     """
+    import contextlib
+
     engine = main.ENGINES["qwen"]
     assert isinstance(engine, main.QwenEngine)
 
-    # Amplitude of the fake wav — high enough that whisper×0.35 stays non-zero.
-    AMPLITUDE = 0.5
+    AMPLITUDE = 0.5  # high enough that whisper×0.35 stays well above the int16 floor
+    SR = 24000
+    fake_wav = np.full(6000, AMPLITUDE, dtype=np.float32)
+
+    # Neutralise every model/VRAM touchpoint so no GPU/weights are needed; the
+    # gain application below is the REAL code under test.
+    monkeypatch.setattr(engine, "_design", None, raising=False)
+    monkeypatch.setattr(engine, "_base17_activity", lambda: contextlib.nullcontext())
+    monkeypatch.setattr(engine, "_ensure_base17_loaded", lambda: None)
+    monkeypatch.setattr(engine, "_load_voice_prompt_17b", lambda voice: (object(), "English", True))
+    # The inner batched forward returns one fake wav per text and NO gain — the
+    # real synthesize_batch must add the per-emotion gain on top.
+    monkeypatch.setattr(
+        engine,
+        "_icl_instruct_synth_batch",
+        lambda prompt_lists, texts, instructs, langs: ([fake_wav.copy() for _ in texts], SR),
+    )
 
     items = [
         {"voice": "base-voice", "text": "Whispering softly.", "emotion": "whisper"},
@@ -384,79 +415,55 @@ def test_synthesize_batch_live_instruct_gain_applied() -> None:
         {"voice": "base-voice", "text": "Feeling sad.", "emotion": "sad"},
         {"voice": "base-voice", "text": "Neutral line.", "emotion": "neutral"},
     ]
+    result = engine.synthesize_batch("1.7b", items, live_instruct=True)
 
-    fake_wav = np.full(6000, AMPLITUDE, dtype=np.float32)
-    fake_sr = 24000
-
-    expected_gains = [0.35, 1.7, 0.6, 1.0]
-
-    # Patch synthesize_batch to bypass the model entirely, returning fake wavs.
-    def fake_synthesize_batch(model, items_arg, live_instruct=False):
-        from main import SynthBatchResult
-        wavs = [fake_wav.copy() for _ in items_arg]
-        # Replicate the real gain application logic directly.
-        pcms = [
-            main._float_audio_to_int16_le(
-                np.asarray(w, dtype=np.float32) * g
-                if (g := main._gain_for_item(items_arg[i], live_instruct)) != 1.0
-                else w
-            )
-            for i, w in enumerate(wavs)
-        ]
-        return SynthBatchResult(pcms=pcms, sample_rate=fake_sr, gen_ms=0.0, audio_ms=0.0)
-
-    result = fake_synthesize_batch("1.7b", items, live_instruct=True)
-
+    assert result.sample_rate == SR
     assert len(result.pcms) == 4
-
-    INT16_MAX = 32767
-    for i, (pcm_bytes, expected_gain) in enumerate(zip(result.pcms, expected_gains)):
-        arr = np.frombuffer(pcm_bytes, dtype="<i2").astype(np.float32) / INT16_MAX
-        # All samples should be AMPLITUDE * expected_gain (within clamp).
-        expected_val = min(AMPLITUDE * expected_gain, 1.0)
-        assert np.allclose(arr, expected_val, atol=1e-2), (
-            f"item {i} (emotion={items[i].get('emotion')!r}): "
-            f"expected amplitude ~{expected_val:.4f}, got mean {arr.mean():.4f}"
+    for ratio, emo in zip(_amp_ratios(result.pcms), ["whisper", "angry", "sad", "neutral"]):
+        expected = min(AMPLITUDE * main._live_instruct_gain(emo), 1.0)
+        assert abs(ratio - expected) < 1e-2, (
+            f"emotion={emo!r}: expected amplitude ~{expected:.4f}, got {ratio:.4f} "
+            "— the live-instruct gain call site may have regressed."
         )
 
 
-def test_synthesize_batch_variant_path_gain_unchanged() -> None:
-    """synthesize_batch(live_instruct=False) still uses voice __<emotion> suffix gain.
-
-    The anchored-variant path must be byte-identical to its pre-fs-57 behaviour.
+def test_synthesize_batch_variant_path_gain_drives_real_method(monkeypatch) -> None:
+    """Integration seam (#1100): drive the REAL synthesize_batch on the anchored-variant
+    path (live_instruct=False) with only the wrapper forward mocked, asserting the gain
+    is keyed on the voice's `__<emotion>` suffix — NOT the per-item emotion key. Guards
+    the variant path against the same class of call-site regression.
     """
+    engine = main.ENGINES["qwen"]
+    assert isinstance(engine, main.QwenEngine)
+
     AMPLITUDE = 0.5
-    items_variant = [
-        {"voice": "qwen-x__whisper", "text": "Whispering variant."},
+    SR = 24000
+    fake_wav = np.full(6000, AMPLITUDE, dtype=np.float32)
+
+    class _FakeBase:
+        def generate_voice_clone(self, text, language, voice_clone_prompt):
+            return ([fake_wav.copy() for _ in text], SR)
+
+    monkeypatch.setattr(engine, "_design", None, raising=False)
+    monkeypatch.setattr(engine, "_ensure_base_loaded", lambda: None)
+    monkeypatch.setattr(engine, "_load_voice_prompt", lambda voice: (object(), "English", True))
+    monkeypatch.setattr(engine, "_base", _FakeBase(), raising=False)
+
+    # `emotion` is set but must be IGNORED on the variant path — only the voice
+    # suffix drives gain there.
+    items = [
+        {"voice": "qwen-x__whisper", "text": "Whispering variant.", "emotion": "angry"},
         {"voice": "qwen-narrator", "text": "Neutral narrator."},
     ]
-    expected_gains = [0.45, 1.0]
+    result = engine.synthesize_batch("0.6b", items, live_instruct=False)
 
-    fake_wav = np.full(6000, AMPLITUDE, dtype=np.float32)
-    fake_sr = 24000
-
-    def fake_synthesize_batch_variant(model, items_arg, live_instruct=False):
-        from main import SynthBatchResult
-        wavs = [fake_wav.copy() for _ in items_arg]
-        pcms = [
-            main._float_audio_to_int16_le(
-                np.asarray(w, dtype=np.float32) * g
-                if (g := main._gain_for_item(items_arg[i], live_instruct)) != 1.0
-                else w
-            )
-            for i, w in enumerate(wavs)
-        ]
-        return SynthBatchResult(pcms=pcms, sample_rate=fake_sr, gen_ms=0.0, audio_ms=0.0)
-
-    result = fake_synthesize_batch_variant("0.6b", items_variant, live_instruct=False)
-
-    INT16_MAX = 32767
-    for i, (pcm_bytes, expected_gain) in enumerate(zip(result.pcms, expected_gains)):
-        arr = np.frombuffer(pcm_bytes, dtype="<i2").astype(np.float32) / INT16_MAX
-        expected_val = min(AMPLITUDE * expected_gain, 1.0)
-        assert np.allclose(arr, expected_val, atol=1e-2), (
-            f"item {i} (voice={items_variant[i]['voice']!r}): "
-            f"expected amplitude ~{expected_val:.4f}, got mean {arr.mean():.4f}"
+    assert result.sample_rate == SR
+    expected_gains = [0.45, 1.0]  # __whisper suffix, then unity — emotion key ignored
+    for ratio, expected_gain in zip(_amp_ratios(result.pcms), expected_gains):
+        expected = min(AMPLITUDE * expected_gain, 1.0)
+        assert abs(ratio - expected) < 1e-2, (
+            f"expected amplitude ~{expected:.4f}, got {ratio:.4f} "
+            "— the variant gain call site may have regressed."
         )
 
 

--- a/src/store/manuscript-slice.test-helpers.ts
+++ b/src/store/manuscript-slice.test-helpers.ts
@@ -8,7 +8,15 @@ import { manuscriptSlice, manuscriptActions } from './manuscript-slice';
  *  present. `manuscriptId: 'm1'` ensures hydrateFromAnalysis takes the
  *  merge/append branch (not the wholesale-replace branch). */
 export function start(
-  sentencesArray: Array<{ id: number; chapterId: number; characterId: string; text: string; emotion?: string }>,
+  sentencesArray: Array<{
+    id: number;
+    chapterId: number;
+    characterId: string;
+    text: string;
+    emotion?: string;
+    instruct?: string;
+    vocalization?: boolean;
+  }>,
 ) {
   return manuscriptSlice.reducer(
     {

--- a/src/store/manuscript-slice.test.ts
+++ b/src/store/manuscript-slice.test.ts
@@ -39,6 +39,30 @@ describe('manuscriptSlice — splitSentence', () => {
     expect(next.sentences[1]).toMatchObject({ id: 2, text: 'world.', characterId: 'eliza' });
   });
 
+  it('keeps instruct/vocalization on the first piece only, nulls them on later fragments (#1100)', () => {
+    const start = baseState(
+      sentences([
+        { id: 1, text: '*gasp* he froze', characterId: 'wren', instruct: 'a sharp gasp', vocalization: true },
+      ]),
+    );
+    const next = manuscriptSlice.reducer(
+      start,
+      manuscriptActions.splitSentence({
+        chapterId: 1,
+        sentenceId: 1,
+        offsets: [7],
+        characterIds: ['wren', 'wren'],
+      }),
+    );
+    expect(next.sentences).toHaveLength(2);
+    // First piece is the original's head — keeps the id + the delivery hints.
+    expect(next.sentences[0]).toMatchObject({ id: 1, text: '*gasp* ', instruct: 'a sharp gasp', vocalization: true });
+    // Later fragment is NEW text — a stale vocalization:true would turn narration into a sound-effect token.
+    expect(next.sentences[1].text).toBe('he froze');
+    expect(next.sentences[1].instruct).toBeUndefined();
+    expect(next.sentences[1].vocalization).toBeUndefined();
+  });
+
   it('splits at multiple offsets into N+1 pieces with new sequential ids', () => {
     const start = baseState(
       sentences([
@@ -815,6 +839,19 @@ describe('mergeSentences', () => {
     const s = start([{ id: 5, chapterId: 3, characterId: 'narrator', text: 'A.' }]);
     expect(reducer(s, manuscriptActions.mergeSentences({ chapterId: 3, sentenceIds: [5, 9] })).sentences).toHaveLength(1);
     expect(reducer(s, manuscriptActions.mergeSentences({ chapterId: 3, sentenceIds: [5] })).sentences).toHaveLength(1);
+  });
+
+  it('clears the survivor instruct/vocalization — the joined text is new (#1100)', () => {
+    const s = start([
+      { id: 5, chapterId: 3, characterId: 'wren', text: 'Ah!', instruct: 'a sharp gasp', vocalization: true },
+      { id: 6, chapterId: 3, characterId: 'wren', text: 'he froze.', instruct: 'whisper this' },
+    ]);
+    const next = reducer(s, manuscriptActions.mergeSentences({ chapterId: 3, sentenceIds: [5, 6] }));
+    const survivor = next.sentences.find((x) => x.chapterId === 3 && x.id === 5);
+    expect(survivor?.text).toBe('Ah! he froze.');
+    // A vocalization flag / instruct written for the old short text must not ride the merged sentence.
+    expect(survivor?.vocalization).toBeUndefined();
+    expect(survivor?.instruct).toBeUndefined();
   });
 });
 

--- a/src/store/manuscript-slice.ts
+++ b/src/store/manuscript-slice.ts
@@ -411,6 +411,13 @@ export const manuscriptSlice = createSlice({
           id: isFirst ? original.id : ++newIdCounter,
           text: piece,
           characterId: a.payload.characterIds[i] ?? original.characterId,
+          /* fs-57 follow-up (#1100): per-sentence delivery hints describe the
+             ORIGINAL text. The first piece is the original sentence's head (it
+             keeps the id + the hints); every later fragment is NEW text, so
+             null both — a stale `vocalization:true` would turn real narration
+             into a sound-effect token, and an `instruct` written for the whole
+             sentence may not fit a fragment. */
+          ...(isFirst ? {} : { instruct: undefined, vocalization: undefined }),
         });
       }
       if (pieces.length === 0) return;
@@ -467,6 +474,13 @@ export const manuscriptSlice = createSlice({
       if (members.some((m) => !m)) return;
       const live = members as NonNullable<(typeof members)[number]>[];
       live[0].text = live.map((m) => m.text).join(' ');
+      /* fs-57 follow-up (#1100): the survivor's joined text is NEW — drop its
+         instruct/vocalization (a `vocalization:true` flag on a now-much-longer
+         merged sentence is wrong; an `instruct` written for the old short text
+         may no longer fit). The merged-away members' fields were already
+         discarded with their rows. */
+      live[0].instruct = undefined;
+      live[0].vocalization = undefined;
       for (const m of live.slice(1)) {
         const i = s.sentences.findIndex((x) => x.chapterId === a.payload.chapterId && x.id === m.id);
         if (i >= 0) s.sentences.splice(i, 1);

--- a/src/views/generation-live-instruct.test.tsx
+++ b/src/views/generation-live-instruct.test.tsx
@@ -88,6 +88,11 @@ function HostedOutlet() {
 const characters: Character[] = [
   { id: 'narrator', name: 'Narrator', role: 'Narrator', color: 'narrator' },
 ];
+/* #1100 — a roster with one 1.7B Quality-tier member, which enables the toggle. */
+const charactersWith17: Character[] = [
+  { id: 'narrator', name: 'Narrator', role: 'Narrator', color: 'narrator' },
+  { id: 'wren', name: 'Wren', role: 'Lead', color: 'magenta', ttsModelKey: 'qwen3-tts-1.7b' },
+];
 const chapter1: Chapter = {
   id: 1,
   title: 'Chapter 1',
@@ -121,12 +126,12 @@ function makeStore(liveInstruct = false) {
   return store;
 }
 
-function renderView(store: ReturnType<typeof makeStore>) {
+function renderView(store: ReturnType<typeof makeStore>, roster: Character[] = charactersWith17) {
   return render(
     <Provider store={store}>
       <HostedGenerationView
         chapters={[chapter1]}
-        characters={characters}
+        characters={roster}
         paused
         title="The Coalfall Commission"
         bookId="book-1"
@@ -187,6 +192,24 @@ describe('GenerationView — liveInstruct toggle (fs-57)', () => {
     const toggle = screen.getByTestId('live-instruct-toggle');
     expect(toggle.className).toContain('min-h-[44px]');
     expect(toggle.className).toContain('sm:min-h-0');
+  });
+
+  it('greys out + disables the toggle when no cast member is on the 1.7B tier (#1100)', () => {
+    renderView(makeStore(false), characters); // narrator only — no 1.7B member
+    const toggle = screen.getByTestId('live-instruct-toggle');
+    const checkbox = toggle.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox.disabled).toBe(true);
+    expect(toggle.className).toContain('opacity-50');
+    expect(toggle.className).toContain('cursor-not-allowed');
+    expect(screen.getByText(/No effect until a cast member is on the Qwen 1\.7B/)).toBeInTheDocument();
+  });
+
+  it('enables the toggle when a cast member is on the 1.7B tier (#1100)', () => {
+    renderView(makeStore(false), charactersWith17);
+    const toggle = screen.getByTestId('live-instruct-toggle');
+    const checkbox = toggle.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox.disabled).toBe(false);
+    expect(toggle.className).toContain('cursor-pointer');
   });
 });
 

--- a/src/views/generation.tsx
+++ b/src/views/generation.tsx
@@ -177,6 +177,12 @@ export function GenerationView({
      'bookMeta/setLiveInstruct' rule. selectLiveInstruct is keyed by bookId so
      switching books always reflects the correct per-book value. */
   const liveInstruct = useAppSelector(selectLiveInstruct(bookId));
+  /* #1100 — the liveInstruct toggle only does anything when at least one cast
+     member is on the Qwen 1.7B Quality tier (the fs-56 per-character opt-in,
+     `ttsModelKey === 'qwen3-tts-1.7b'`). With no such member it's a pure no-op,
+     so we grey it out rather than offer a switch that changes nothing. Read
+     off the `characters` prop — the same roster the view renders rows from. */
+  const hasLiveInstructMember = characters.some((c) => c.ttsModelKey === 'qwen3-tts-1.7b');
   /* Plan 102 — Generate view scroll consumer. ui.stage.currentChapterId
      is set by the queue modal's "Jump to chapter" affordance (modal pushes
      #/books/<bookId>/generate?chapter=<id>); we scroll the chapter row
@@ -853,19 +859,22 @@ export function GenerationView({
             )}
           </p>
           {/* fs-57 — per-book live-instruct toggle. Only meaningful for
-              1.7B-tier characters; shown for all books so the operator can
-              flip it before starting generation. */}
+              1.7B-tier characters; greyed out (#1100) when the cast has none,
+              since flipping it would change nothing. */}
           <label
-            className="mt-2 flex items-center gap-2 cursor-pointer select-none min-h-[44px] sm:min-h-0"
+            className={`mt-2 flex items-center gap-2 select-none min-h-[44px] sm:min-h-0 ${
+              hasLiveInstructMember ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'
+            }`}
             data-testid="live-instruct-toggle"
           >
             <input
               type="checkbox"
               checked={liveInstruct}
+              disabled={!hasLiveInstructMember}
               onChange={(e) =>
                 dispatch(bookMetaActions.setLiveInstruct({ bookId, value: e.target.checked }))
               }
-              className="accent-magenta w-4 h-4 shrink-0"
+              className="accent-magenta w-4 h-4 shrink-0 disabled:cursor-not-allowed"
             />
             <span className="text-xs text-ink/60 leading-snug">
               <span className="font-medium text-ink/75">
@@ -873,8 +882,9 @@ export function GenerationView({
               </span>{' '}
               — re-render to hear it
               <span className="block text-ink/45 mt-0.5">
-                Uses real-time instruct prompts to shape emotion + vocalizations on
-                Qwen 1.7B characters. Has no effect on Kokoro or 0.6B voices.
+                {hasLiveInstructMember
+                  ? 'Uses real-time instruct prompts to shape emotion + vocalizations on Qwen 1.7B characters. Has no effect on Kokoro or 0.6B voices.'
+                  : 'No effect until a cast member is on the Qwen 1.7B Quality tier — set it per character in the voice picker.'}
               </span>
             </span>
           </label>


### PR DESCRIPTION
## Summary

Clears the actionable items on the fs-57 follow-up tracker (#1100):

- **Split/merge field propagation** *(fix + unit tests)*. `splitSentence` spread `{...original}` onto every piece, so later fragments inherited the original's `vocalization:true`/`instruct` (marking pure-text fragments as sound-effect tokens); `mergeSentences` kept the survivor's own fields though the joined text is new. Now the **first** split piece (the original's head) keeps the hints; **later fragments and the merge survivor null both** — a stale `vocalization:true` would swap real narration for a sound effect. Pre-existing spread behaviour surfaced by fs-57.
- **liveInstruct toggle grey-out** *(fix + unit + e2e tests)*. The per-book "Live expressive delivery (1.7B)" toggle rendered enabled for all books, but it's a no-op unless a cast member is on the Qwen 1.7B Quality tier (`ttsModelKey === 'qwen3-tts-1.7b'`). It's now disabled + greyed (with copy pointing at the per-character voice picker) when the cast has none. Detection reads the `characters` prop (the roster the view renders). Browser-covered: disabled with the default cast → promote a member to 1.7B via the store → enabled, then the flip flow.
- **Gain integration-seam test** *(test only)*. The Task-20 PCM-gain tests reimplemented `synthesize_batch`'s gain loop in the test, so a call-site regression (reverting to `_apply_emotion_gain` by voice, or dropping `live_instruct`) wouldn't be caught. Replaced both with integration tests that monkeypatch **only** the inner forward and drive the real `QwenEngine.synthesize_batch`, asserting per-emotion gain (live path) and voice-suffix gain (variant path) on the returned PCM.

**P-Mi4 (deferred — won't-do):** a hand-typed vocalization leaves `vocalization:undefined`, so a Stage-3 re-run could prepend a second token. Skipped deliberately — the issue gated it on "if it bites," there's no evidence it does, and the proper recovery already exists (re-run attribution via the Manuscript button re-flags it correctly). A brittle text-pattern pre-check isn't worth adding speculatively.

## Test plan

- `npm run test` (frontend): green — incl. new split/merge reducer tests + toggle disabled/enabled tests.
- `npm run test:sidecar` → `test_instruct_synth.py`: **18/18** (incl. real-GPU batch tests on the dev box).
- `npx playwright test e2e/generation-live-instruct.spec.ts`: green (now covers the grey-out).
- Full local pre-push battery (typecheck + all tests + e2e + build): **green** on push.

Closes #1100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)