### PR TITLE
fix(frontend): honest voice-design progress follow-ups (#1092)

### DIFF
--- a/e2e/single-design-progress.spec.ts
+++ b/e2e/single-design-progress.spec.ts
@@ -90,11 +90,7 @@ test.describe('single-design progress phase labels', () => {
     const phaseText = await page.evaluate(() => {
       const eta = document.querySelector('[data-testid="design-eta"]');
       if (!eta) return null;
-      /* Walk from design-eta up to the DesignProgress wrapper, then find
-         the sibling row that holds the phase label (it's the element
-         immediately before design-eta in the wrapper). */
-      const wrapper = eta.parentElement;
-      if (!wrapper) return null;
+      /* The phase-label row is the element immediately before design-eta. */
       const labelRow = eta.previousElementSibling;
       return labelRow?.querySelector('span')?.textContent?.trim() ?? null;
     });
@@ -106,8 +102,8 @@ test.describe('single-design progress phase labels', () => {
     expect(phaseText).toMatch(
       /loading the design model|designing the voice|distilling the voice|rendering the 12s audition|freeing gpu memory|anchoring to the base voice|performing the emotion/i,
     );
-    /* Explicitly confirm the old fake copy is gone. */
-    expect(phaseText).not.toMatch(/about 15s/i);
+    /* The "about 15s" fake-copy guard lives on design-eta above (the real
+       surface it appeared on); a duplicate check on the label added nothing. */
 
     await page.clock.resume();
   });

--- a/server/src/routes/design-progress-relay.test.ts
+++ b/server/src/routes/design-progress-relay.test.ts
@@ -62,4 +62,12 @@ describe('POST /api/internal/design-progress', () => {
     expect(res.status).toBe(400);
     dropProgressToken('tok2');
   });
+
+  it('no-ops (200 {ok:false}) on an empty token with a valid phase (#1092)', async () => {
+    const res = await request(appWith())
+      .post('/api/internal/design-progress')
+      .send({ token: '', phase: 'designing' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: false });
+  });
 });

--- a/server/src/routes/design-progress-relay.ts
+++ b/server/src/routes/design-progress-relay.ts
@@ -21,7 +21,11 @@ designProgressRelayRouter.post('/design-progress', (req: Request, res: Response)
   if (!isLoopback(req)) return res.status(403).json({ error: 'loopback only' });
   const token = typeof req.body?.token === 'string' ? req.body.token : '';
   const phase = typeof req.body?.phase === 'string' ? req.body.phase : '';
-  if (!token || !PHASES.has(phase)) return res.status(400).json({ error: 'bad request' });
+  // An unknown phase is a malformed request (400). An empty token is a
+  // well-formed request that simply can't resolve a job — same shape as an
+  // unknown token: 200 {ok:false} (spec PR-D; #1092).
+  if (!PHASES.has(phase)) return res.status(400).json({ error: 'bad request' });
+  if (!token) return res.status(200).json({ ok: false });
   const job = resolveProgressToken(token);
   if (!job) return res.status(200).json({ ok: false });
   job.phase = phase as SingleJob['phase']; // keep the resume-seed current (PR-D)

--- a/src/components/design-progress.test.tsx
+++ b/src/components/design-progress.test.tsx
@@ -36,16 +36,24 @@ describe('DesignProgress (honest)', () => {
     expect(screen.getByTestId('design-eta')).not.toHaveTextContent(/taking longer than usual/i);
   });
 
-  it('flips to the honest slow warning only past a real overage', () => {
+  it('flips to the honest slow warning only past a real per-phase overage', () => {
     render(<DesignProgress phase="designing" />);
     act(() => vi.advanceTimersByTime(140_000)); // > 2× the designing budget
     expect(screen.getByTestId('design-eta')).toHaveTextContent(/taking longer than usual/i);
   });
 
-  it('snaps to complete', () => {
-    const { container } = render(<DesignProgress phase="rendering" complete />);
-    const fill = container.querySelector('[data-testid="design-fill"] > i') as HTMLElement;
-    expect(fill.style.width).toBe('100%');
+  it('flips to slow via the total-elapsed OR-clause after a past phase overran (#1092)', () => {
+    // Total design budget ≈ 86.5s; the OR-clause fires past 2× that (≈173s).
+    const { rerender } = render(<DesignProgress phase="designing" />);
+    // designing overran badly (per-phase warning fired here), then advanced on.
+    act(() => vi.advanceTimersByTime(160_000));
+    rerender(<DesignProgress phase="rendering" />); // resets the in-phase clock
+    // In rendering the in-phase clock is small (no per-phase trip, budget 12s),
+    // but the cumulative elapsed is still climbing toward 2× the total.
+    act(() => vi.advanceTimersByTime(12_000)); // total 172s < 173s → still quiet
+    expect(screen.getByTestId('design-eta')).not.toHaveTextContent(/taking longer than usual/i);
+    act(() => vi.advanceTimersByTime(2_000)); // total 174s > 173s, in-phase 14s < 24s
+    expect(screen.getByTestId('design-eta')).toHaveTextContent(/taking longer than usual/i);
   });
 
   it('renders the waveform + fill scaffold', () => {

--- a/src/components/design-progress.tsx
+++ b/src/components/design-progress.tsx
@@ -13,7 +13,6 @@ const OVERAGE_MULT = 2;
 
 interface Props {
   phase: DesignPhase;
-  complete?: boolean;
 }
 
 function fmt(ms: number): string {
@@ -37,7 +36,7 @@ function budgetBounds(phase: DesignPhase): { before: number; total: number } {
   return { before, total };
 }
 
-export function DesignProgress({ phase, complete = false }: Props) {
+export function DesignProgress({ phase }: Props) {
   const [now, setNow] = useState(0);
   const startRef = useRef(Date.now());
   const phaseStartRef = useRef(Date.now());
@@ -50,10 +49,9 @@ export function DesignProgress({ phase, complete = false }: Props) {
   }
 
   useEffect(() => {
-    if (complete) return;
     const id = setInterval(() => setNow(Date.now()), 1000);
     return () => clearInterval(id);
-  }, [complete]);
+  }, []);
 
   const elapsedTotal = now === 0 ? 0 : now - startRef.current;
   const inPhase = now === 0 ? 0 : now - phaseStartRef.current;
@@ -63,16 +61,18 @@ export function DesignProgress({ phase, complete = false }: Props) {
   // Cumulative fill: phases before this one are "done"; within this phase ease
   // toward (but never past) its budget until the next real event arrives.
   const inPhaseFill = Math.min(inPhase, budget * 0.92);
-  const pct = complete ? 100 : Math.min(99, ((before + inPhaseFill) / total) * 100);
+  const pct = Math.min(99, ((before + inPhaseFill) / total) * 100);
 
-  const slow = !complete && inPhase > budget * OVERAGE_MULT;
+  // Slow when EITHER this phase has run past 2× its budget OR the whole design
+  // has run past 2× the expected total (the spec's OR-clause: catches a run that
+  // is uniformly slow across phases without any single one tripping the per-phase
+  // bar — e.g. a contended GPU).
+  const slow = inPhase > budget * OVERAGE_MULT || elapsedTotal > total * OVERAGE_MULT;
   const remaining = Math.max(0, total - before - inPhase);
 
-  const fillStyle: CSSProperties = complete
-    ? { width: '100%', transition: 'width 300ms ease-out', animation: 'none' }
-    : slow
-      ? { width: `${pct}%`, transition: 'width 700ms ease-out' }
-      : { width: `${pct}%`, transition: 'width 700ms ease-out', animation: 'none' };
+  const fillStyle: CSSProperties = slow
+    ? { width: `${pct}%`, transition: 'width 700ms ease-out' }
+    : { width: `${pct}%`, transition: 'width 700ms ease-out', animation: 'none' };
   const fillClass = `design-fill mt-2${slow ? ' design-fill--indeterminate' : ''}`;
 
   return (
@@ -96,9 +96,7 @@ export function DesignProgress({ phase, complete = false }: Props) {
       <div className="mt-1 text-[11px] text-ink/40" data-testid="design-eta">
         {slow
           ? 'Taking longer than usual — the GPU may be busy with another job.'
-          : complete
-            ? 'Done'
-            : `~${fmt(remaining)} left`}
+          : `~${fmt(remaining)} left`}
       </div>
     </div>
   );

--- a/src/modals/profile-drawer.test.tsx
+++ b/src/modals/profile-drawer.test.tsx
@@ -1244,8 +1244,9 @@ describe('ProfileDrawer per-character engine + Qwen bespoke voice (plan 108)', (
       );
     });
     expect(await screen.findByTestId('design-waveform')).toBeInTheDocument();
-    // beginSingle sets phase:'freeing-vram' — the real phase now flows through
-    expect(screen.getByText(/freeing gpu memory/i)).toBeInTheDocument();
+    // beginSingle seeds phase:'loading-model' (#1092 — avoids the freeing-vram
+    // flash); the real phase still flows through via the SSE relay.
+    expect(screen.getByText(/loading the design model/i)).toBeInTheDocument();
   });
 
   it('opens the compare modal when the slice is ready-to-compare for this character', async () => {

--- a/src/store/cast-design-slice.test.ts
+++ b/src/store/cast-design-slice.test.ts
@@ -119,13 +119,13 @@ describe('castDesignSlice — active snapshot reducers', () => {
 });
 
 describe('single-design snapshot', () => {
-  it('beginSingle opens a kind:single snapshot with phase freeing-vram', () => {
+  it('beginSingle opens a kind:single snapshot seeded at phase loading-model', () => {
     const s = castDesignSlice.reducer(undefined, castDesignActions.beginSingle({
       bookId: 'b1', characterId: 'c1', name: 'Aria', mode: 'first', lastTickAt: 10,
     }));
     expect(s.active).toMatchObject({
       kind: 'single', bookId: 'b1', characterId: 'c1', currentName: 'Aria',
-      total: 1, done: 0, mode: 'first', phase: 'freeing-vram', state: 'running',
+      total: 1, done: 0, mode: 'first', phase: 'loading-model', state: 'running',
     });
   });
 
@@ -179,12 +179,12 @@ describe('single-design snapshot', () => {
     expect(s.active?.preview?.voiceUuid).toBeUndefined();
   });
 
-  it('beginSingle seeds the lowest phase so early phases still show', () => {
+  it('beginSingle seeds loading-model, not freeing-vram, to avoid the GPU-memory flash (#1092)', () => {
     const s = castDesignSlice.reducer(
       undefined,
       castDesignActions.beginSingle({ bookId: 'b', characterId: 'c', name: 'N', mode: 'first', lastTickAt: 0 }),
     );
-    expect(s.active?.phase).toBe('freeing-vram');
+    expect(s.active?.phase).toBe('loading-model');
   });
 
   it('setPhase advances forward through the real phase order but never rewinds', () => {

--- a/src/store/cast-design-slice.ts
+++ b/src/store/cast-design-slice.ts
@@ -275,7 +275,11 @@ export const castDesignSlice = createSlice({
         currentName: action.payload.name,
         characterId: action.payload.characterId,
         mode: action.payload.mode,
-        phase: 'freeing-vram',
+        /* #1092 — seed 'loading-model', not 'freeing-vram': a single BASE-voice
+           design doesn't reliably emit a freeing-vram event, so seeding it made
+           the drawer flash "Freeing GPU memory…" before "Loading the design
+           model…" arrived. The real freeing-vram event still shows if it fires. */
+        phase: 'loading-model',
         state: 'running',
         lastTickAt: action.payload.lastTickAt,
         failures: [],


### PR DESCRIPTION
## Summary

Clears the code-side follow-ups from the honest streamed-phase voice-design progress work (#1092). The opus whole-branch review of #1089 had cleared all of these as defer-able.

- **Relay empty-token branch** *(server)* — `design-progress-relay` 400'd any empty-token request; an empty token with a valid phase is well-formed but unresolvable, so it now returns `200 {ok:false}` (matching the unknown-token path, spec PR-D). Only an unknown **phase** is a 400 now. Unreachable today (the sidecar always sends a real UUID); aligned for tidiness.
- **Drop the dead `complete` prop** *(frontend)* — `DesignProgress` unmounts on terminal events, so `complete` was never `true` in production. Removed the prop + its `width:100%`/"Done"/interval-gate branches + the test that exercised it.
- **Total-elapsed slow OR-clause** *(frontend)* — the "taking longer than usual" warning now fires on **either** one phase past 2× its budget **or** the whole design past 2× the expected total. Catches a uniformly-slow (contended-GPU) run that no single phase trips, and keeps the warning up after a past phase overran rather than vanishing on phase advance.
- **Seed `loading-model`, not `freeing-vram`** *(frontend)* — a single BASE-voice design doesn't reliably emit a `freeing-vram` event, so the drawer flashed "Freeing GPU memory…" before "Loading the design model…". The real event still shows if it fires.
- **e2e tidy** — removed a dead `wrapper` var + a redundant `not.toMatch(/about 15s/)` label assertion (the real guard is on `design-eta`).

**Deferred to Phase 2 (on-box):** the placeholder `DESIGN_PHASE_BUDGETS_MS` calibration — it needs a real `qwen voice design:` log line off the GPU box. The issue stays open for that.

## Test plan

- `npm run test` (frontend): green — incl. the new total-elapsed OR-clause test, updated cast-design-slice seed tests, and the profile-drawer "loading-model" assertion.
- `cd server && npm test`: green — incl. the new relay empty-token case (5/5 in that file; 3704 in the suite).
- `npx playwright test e2e/single-design-progress.spec.ts`: green.
- Full local pre-push battery (typecheck + all tests + e2e + build): **green** on push.

Refs #1092.

🤖 Generated with [Claude Code](https://claude.com/claude-code)