### PR TITLE
test(sidecar): expressive-prose A/B fixture for #1098 (Phase-2 prep)

### DIFF
--- a/server/tts-sidecar/tests/golden/expressive_passage.json
+++ b/server/tts-sidecar/tests/golden/expressive_passage.json
@@ -1,0 +1,27 @@
+{
+  "description": "Expressive-prose A/B fixture for the #1098 live-instruct delivery comparison. A single Castwright-original micro-scene whose consecutive sentences span all five emotions (whisper/neutral/excited/angry/sad) with natural narrative flow, so each render option produces a MIXED batch you can listen to end-to-end — transitions and pacing included — rather than the same sentence repeated. Safe to commit (Castwright-owned).",
+  "ab_options": {
+    "a_fixed_temp_plain_instruct": "Today's baseline: emotion-derived/plain instruct + the fixed QWEN_INSTRUCT_TEMP. Render with `instruct` stripped (let the pipeline derive from `emotion`).",
+    "b_per_emotion_temp": "The #1098 mechanism: per-emotion temperature (whisper~0.6 / sad~1.0 / neutral~0.9 / excited~1.5 / angry~2.0 — placeholder values from 0.6B-era tuning), plain/derived instruct. Requires the not-yet-built emotion-partitioned batcher.",
+    "c_fixed_temp_rich_instruct": "The leading hypothesis: fold the prosodic intent into the instruct TEXT (the `instruct` field below) at the fixed temp — one big batch, no partitioning. Build (b) only if it clearly beats this."
+  },
+  "voice": "REPLACE_WITH_A_DESIGNED_1.7B_VOICE_ID",
+  "model": "1.7b",
+  "sentences": [
+    { "id": 1, "emotion": "whisper", "text": "Stay close, she breathed, barely louder than the dark itself.", "instruct": "a hushed, breathy whisper, tense and careful, almost no voice" },
+    { "id": 2, "emotion": "whisper", "text": "The floor here remembers every footstep.", "instruct": "whispered and conspiratorial, slow and deliberate" },
+    { "id": 3, "emotion": "neutral", "text": "The corridor narrowed until the lantern light touched both walls at once.", "instruct": "calm, even narration, unhurried" },
+    { "id": 4, "emotion": "neutral", "text": "They had been walking the better part of an hour, and the air grew colder with every turn.", "instruct": "measured, matter-of-fact narration" },
+    { "id": 5, "emotion": "excited", "text": "There, do you see it?", "instruct": "bright and eager, rising with delight" },
+    { "id": 6, "emotion": "excited", "text": "It is the seal, the real one, exactly where the letter said it would be!", "instruct": "fast and thrilled, breathless with excitement" },
+    { "id": 7, "emotion": "neutral", "text": "The bronze disc lay half-buried in the dust, its edges still catching the light.", "instruct": "steady narration with a touch of wonder" },
+    { "id": 8, "emotion": "angry", "text": "You knew, he said, and his voice dropped to something hard.", "instruct": "cold, controlled anger, clipped and sharp" },
+    { "id": 9, "emotion": "angry", "text": "You knew it was here the whole time and you let us crawl through that filth for nothing!", "instruct": "loud and furious, sharp and forceful, rising" },
+    { "id": 10, "emotion": "neutral", "text": "For a moment neither of them moved.", "instruct": "quiet, flat narration, holding the tension" },
+    { "id": 11, "emotion": "sad", "text": "I did not tell you, she said softly, because I knew what it would cost.", "instruct": "soft and heavy with regret, slow and weary" },
+    { "id": 12, "emotion": "sad", "text": "He never came back from the last one either.", "instruct": "grief-stricken and trembling, fading at the end" },
+    { "id": 13, "emotion": "neutral", "text": "The lantern guttered, and the shadows leaned in around them.", "instruct": "subdued narration, closing the scene" },
+    { "id": 14, "emotion": "whisper", "text": "We finish this, she whispered, and then we go home.", "instruct": "a fragile, determined whisper, almost breaking" },
+    { "id": 15, "emotion": "neutral", "text": "Somewhere far above, the old house settled, and went still.", "instruct": "calm, final narration, a slow close" }
+  ]
+}

--- a/server/tts-sidecar/tests/golden/expressive_passage.md
+++ b/server/tts-sidecar/tests/golden/expressive_passage.md
@@ -1,0 +1,64 @@
+# Expressive-prose A/B fixture (#1098)
+
+A Castwright-original micro-scene for the **Phase-2 live-instruct delivery A/B**
+(issue #1098). The structured data the renderer consumes is
+[`expressive_passage.json`](./expressive_passage.json); this file is the
+human-readable prose + how to use it.
+
+## Why a passage, not a sentence
+
+The A/B compares *delivery strategies* on the 1.7B live-instruct path. Rendering
+the **same** sentence at different temperatures hides exactly what matters —
+emotional **flow**, transitions between beats, and how a real **mixed batch**
+behaves. So the fixture is one continuous scene whose consecutive sentences move
+through all five emotions (whisper → neutral → excited → neutral → angry →
+neutral → sad → whisper → neutral). Render it as a single batch and listen
+end-to-end.
+
+## The scene
+
+> "Stay close," she breathed, barely louder than the dark itself. "The floor
+> here remembers every footstep."
+>
+> The corridor narrowed until the lantern light touched both walls at once. They
+> had been walking the better part of an hour, and the air grew colder with
+> every turn.
+>
+> "There — do you see it? It is the seal, the real one, exactly where the letter
+> said it would be!"
+>
+> The bronze disc lay half-buried in the dust, its edges still catching the
+> light.
+>
+> "You knew," he said, and his voice dropped to something hard. "You knew it was
+> here the whole time and you let us crawl through that filth for nothing!"
+>
+> For a moment neither of them moved.
+>
+> "I did not tell you," she said softly, "because I knew what it would cost. He
+> never came back from the last one either."
+>
+> The lantern guttered, and the shadows leaned in around them.
+>
+> "We finish this," she whispered, "and then we go home."
+>
+> Somewhere far above, the old house settled, and went still.
+
+## How to run the A/B (Phase 2, on the box)
+
+1. Set `"voice"` in the JSON to a **designed 1.7B** voice id present in the
+   workspace.
+2. Render the 15 `sentences` as one `synthesize_batch(model="1.7b",
+   live_instruct=True, …)` call three ways, saving each to its own WAV:
+   - **(a) baseline** — strip `instruct` (let the pipeline derive from
+     `emotion`), fixed `QWEN_INSTRUCT_TEMP`.
+   - **(b) per-emotion temp** — plain/derived instruct, per-emotion temperature
+     (the not-yet-built #1098 partitioned batcher; placeholder temps in the
+     JSON's `ab_options`).
+   - **(c) rich instruct** — use the per-sentence `instruct` text below at the
+     fixed temp (no partitioning, one batch).
+3. Listen to all three end-to-end. **Decision rule:** build (b)'s mechanism only
+   if it clearly beats (c) on prosody *without* losing (c)'s single-batch
+   flow/speed; otherwise close #1098 in favour of (c).
+
+The per-sentence `emotion` + rich `instruct` directions live in the JSON.

--- a/server/tts-sidecar/tests/test_expressive_passage.py
+++ b/server/tts-sidecar/tests/test_expressive_passage.py
@@ -1,0 +1,58 @@
+"""Shape guard for the #1098 expressive-prose A/B fixture
+(tests/golden/expressive_passage.json).
+
+The fixture itself is rendered on the box in Phase 2; this weight-free test just
+keeps it well-formed so it can't silently rot — every sentence carries the four
+fields the A/B runner reads, emotions are real Emotion-enum values, and the whole
+five-emotion spread is present (the entire point of the fixture is a MIXED batch,
+so a passage that lost an emotion would defeat it)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+# The five Emotion-enum values (openapi Sentence.emotion). neutral is the default.
+VALID_EMOTIONS = {"neutral", "whisper", "angry", "excited", "sad"}
+# The expressive emotions the A/B must exercise (neutral alone wouldn't be a test).
+EXPRESSIVE_EMOTIONS = VALID_EMOTIONS - {"neutral"}
+
+FIXTURE = Path(__file__).resolve().parent / "golden" / "expressive_passage.json"
+
+
+def _load() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_fixture_exists_and_parses() -> None:
+    data = _load()
+    assert isinstance(data.get("sentences"), list) and data["sentences"], "non-empty sentences[]"
+
+
+def test_every_sentence_has_the_four_ab_fields() -> None:
+    for s in _load()["sentences"]:
+        assert isinstance(s.get("id"), int), f"id must be int: {s!r}"
+        assert isinstance(s.get("text"), str) and s["text"].strip(), f"text required: {s!r}"
+        assert s.get("emotion") in VALID_EMOTIONS, f"bad emotion: {s!r}"
+        # The rich instruct (A/B option c) must be present and non-trivial.
+        assert isinstance(s.get("instruct"), str) and len(s["instruct"]) >= 8, f"instruct required: {s!r}"
+
+
+def test_ids_are_unique() -> None:
+    ids = [s["id"] for s in _load()["sentences"]]
+    assert len(ids) == len(set(ids)), f"duplicate sentence ids: {ids}"
+
+
+def test_covers_the_full_emotion_spread() -> None:
+    """A MIXED batch is the whole point — every expressive emotion must appear."""
+    seen = {s["emotion"] for s in _load()["sentences"]}
+    missing = EXPRESSIVE_EMOTIONS - seen
+    assert not missing, f"fixture is missing expressive emotion(s): {sorted(missing)}"
+    assert "neutral" in seen, "fixture should include neutral narration beats for contrast"
+
+
+def test_consecutive_emotion_transitions_exist() -> None:
+    """Listening for FLOW needs transitions — assert the passage isn't grouped by
+    emotion (which would read as five blocks, not a scene)."""
+    emotions = [s["emotion"] for s in _load()["sentences"]]
+    transitions = sum(1 for a, b in zip(emotions, emotions[1:]) if a != b)
+    assert transitions >= 6, f"too few emotion transitions for a flowing scene: {transitions}"


### PR DESCRIPTION
## Summary

Phase-2 prep for the #1098 live-instruct delivery A/B. A Castwright-original micro-scene whose 15 consecutive sentences span all five emotions (whisper/neutral/excited/angry/sad) with natural narrative flow, so the on-box A/B renders a realistic **mixed batch** to listen to end-to-end — transitions and pacing included — rather than the same sentence repeated (which hides exactly what we need to judge). Each sentence carries an `emotion` + a rich, prosody-encoding `instruct` (A/B option c).

Code-only; no on-box render here (that's Phase 2). Files:
- `server/tts-sidecar/tests/golden/expressive_passage.json` — renderer input + the three A/B option definitions (a: fixed-temp baseline, b: per-emotion temp, c: rich instruct text).
- `server/tts-sidecar/tests/golden/expressive_passage.md` — the prose + how to run the 3-way A/B on the box.
- `server/tts-sidecar/tests/test_expressive_passage.py` — weight-free shape guard so the fixture can't rot.

Decision rule (from #1098): build the per-emotion-temperature mechanism **only** if (b) clearly beats (c) on this passage without losing (c)'s single-batch flow/speed; otherwise close #1098 in favour of richer instruct text.

## Test plan

- `python -m pytest server/tts-sidecar/tests/test_expressive_passage.py`: **5/5** (fields present, real Emotion values, full five-emotion spread, ≥6 transitions so it reads as a scene).
- Full local pre-push battery: **green** on push.

Refs #1098.

🤖 Generated with [Claude Code](https://claude.com/claude-code)