### PR TITLE
fix(frontend,server): flag a chapter stale when a rendered sentence's text is edited (#1105)

### DIFF
--- a/docs/features/198-stale-chapter-reassign-indicator.md
+++ b/docs/features/198-stale-chapter-reassign-indicator.md
@@ -103,9 +103,48 @@ immediacy:
   the chapter, else the time-based heuristic — so older servers / mocks still flag
   staleness with no regression.
 
+## Precise per-sentence TEXT diff (#1105 — the text sibling of #650)
+
+The #650 diff compares `characterId` only, so it misses a **text edit** of an
+already-rendered sentence (Script Review `strip_tag`, a future manual editor, or a
+direct `manuscript-edits.json` / MCP edit). Synth is keyed on sentence text, so an
+edited line's audio is stale on **every** engine — yet, before #1105, the only
+text-staleness signal was the transient `boundary_move` the strip_tag UI happened to
+log, invisible to any edit path that touches the JSON directly. #1105 makes text
+staleness **derivable from the persisted JSON**, mirroring #650:
+
+- **Server (render time)** (`synthesise-chapter.ts`): each segment is stamped with a
+  `textHash` — `textHashForStale(group.text)`, a djb2-base36 hash of the RAW sentence
+  text — into `segments.json`. New renders only; pre-#1105 renders carry no hash.
+- **Server (book-state GET)** (`segments-io.ts` `collectRenderedTextHashesByChapter`
+  → `renderedTextByChapter`): inverts each chapter's segments into a
+  `sentenceId → textHash` map. A chapter with no stamped hashes (pre-#1105 render) is
+  omitted, so the client reads it as "can't tell" rather than "all edited".
+- **Frontend** (`isChapterTextEditedSinceRender`): the Generate view hashes the live
+  raw `sent.text` and diffs it against the render-time hash — same asymmetric,
+  reload-surviving, false-positive-free shape as #650 (edit-then-revert ⇒ hashes
+  match ⇒ not stale). Added as a third clause to the Generate-row OR-gate.
+- **Cross-package hash contract:** `textHashForStale` is defined byte-identically in
+  `src/lib/stale-chapters.ts` and `server/src/audio/segments-io.ts`; a shared vector
+  (`'"Stop," she said.'` → `2rq6ja`) is pinned in BOTH test files so a drift on either
+  side fails loudly. Hash the RAW text on both sides (the server stamps `group.text`
+  pre-normalisation; the client hashes live `sent.text`) so normalisation can't desync.
+- **Why not the stale-audio banner:** the `setStaleAudio` banner (emotion/instruct
+  edits) is session-only, character-keyed (wrong semantics for a text change), and
+  invisible to a direct-JSON edit — so it can't be the source of truth for text
+  staleness. The derived diff is.
+
+Coverage: `isChapterTextEditedSinceRender` + `textHashForStale` units
+(`stale-chapters.test.ts`); `collectRenderedTextHashesByChapter` + the hash vector
+(`segments-io.test.ts`); the GET field (`book-state.test.ts`); the Generate-row badge
+on a text edit with speakers unchanged (`generation.test.tsx`).
+
 ## Out of scope
 
-- n/a — the precise diff (#650) closed the only remaining gap.
+- The `setStaleAudio` banner is intentionally NOT fired on text edits (see above).
+- Backfilling text hashes onto books rendered before #1105 — they fall back to the
+  time-based `boundary_move` heuristic until their next render (decision: new renders
+  only, no migration).
 
 ## Ship notes
 

--- a/server/src/audio/segments-io.test.ts
+++ b/server/src/audio/segments-io.test.ts
@@ -10,6 +10,8 @@ import {
   collectRenderedFallbackEngines,
   collectRenderedQwenVoiceNames,
   collectRenderedSpeakerMaps,
+  collectRenderedTextHashesByChapter,
+  textHashForStale,
 } from './segments-io.js';
 
 let bookDir: string;
@@ -120,5 +122,64 @@ describe('collectRenderedSpeakerMaps (#650)', () => {
   it('returns an empty map when no audio dir exists', async () => {
     rmSync(join(bookDir, 'audio'), { recursive: true, force: true });
     await expect(collectRenderedSpeakerMaps(bookDir, chapters)).resolves.toEqual({});
+  });
+});
+
+describe('textHashForStale (#1105)', () => {
+  it('is deterministic and differs on a text change', () => {
+    expect(textHashForStale('Hello there.')).toBe(textHashForStale('Hello there.'));
+    expect(textHashForStale('Hello there.')).not.toBe(textHashForStale('Hello there!'));
+  });
+
+  it('matches the frontend djb2-base36 vector (cross-package contract)', () => {
+    /* MUST equal src/lib/stale-chapters.ts textHashForStale for the same input —
+       the frontend staleness diff compares this server-stamped hash against a
+       client-computed one. Same vector pinned in both test files. */
+    expect(textHashForStale('"Stop," she said.')).toBe('2rq6ja');
+  });
+});
+
+describe('collectRenderedTextHashesByChapter (#1105)', () => {
+  function writeSegmentsWithText(
+    slug: string,
+    segments: Array<{ characterId?: string; sentenceIds?: number[]; textHash?: string; kind?: string }>,
+  ) {
+    writeFileSync(
+      join(bookDir, 'audio', `${slug}.segments.json`),
+      JSON.stringify({ chapterId: Number(slug.slice(0, 2)), segments }),
+    );
+  }
+
+  it('maps each rendered sentenceId to its segment textHash per chapter', async () => {
+    writeSegmentsWithText('01-one', [
+      { characterId: 'narrator', sentenceIds: [1], textHash: textHashForStale('The fire caught.') },
+      { characterId: 'marlow', sentenceIds: [2], textHash: textHashForStale('"Run," she said.') },
+    ]);
+    writeSegmentsWithText('02-two', [
+      { characterId: 'wren', sentenceIds: [4], textHash: textHashForStale('No one moved.') },
+    ]);
+    await expect(collectRenderedTextHashesByChapter(bookDir, chapters)).resolves.toEqual({
+      1: { 1: textHashForStale('The fire caught.'), 2: textHashForStale('"Run," she said.') },
+      2: { 4: textHashForStale('No one moved.') },
+    });
+  });
+
+  it('skips segments missing a textHash and omits a chapter with no hashes (pre-#1105 render)', async () => {
+    writeSegmentsWithText('01-one', [
+      { characterId: 'narrator', sentenceIds: [1], kind: 'title' }, // no textHash
+      { characterId: 'narrator', sentenceIds: [2], textHash: textHashForStale('Body line.') },
+    ]);
+    /* A whole chapter rendered before #1105 carries no textHash on any segment →
+       omitted entirely, so the client treats it as "can't tell" rather than "all
+       sentences edited". */
+    writeSegmentsWithText('02-two', [{ characterId: 'wren', sentenceIds: [4] }]);
+    await expect(collectRenderedTextHashesByChapter(bookDir, chapters)).resolves.toEqual({
+      1: { 2: textHashForStale('Body line.') },
+    });
+  });
+
+  it('returns an empty map when no audio dir exists', async () => {
+    rmSync(join(bookDir, 'audio'), { recursive: true, force: true });
+    await expect(collectRenderedTextHashesByChapter(bookDir, chapters)).resolves.toEqual({});
   });
 });

--- a/server/src/audio/segments-io.ts
+++ b/server/src/audio/segments-io.ts
@@ -50,8 +50,28 @@ export interface SegmentsFile {
       `renderedFallbackEngine` is the per-SEGMENT fallback engine (srv-36 aggregate
       reads this to exclude individual fallback lines from anchor-eligible set;
       do NOT use `characterSnapshots[id].renderedFallbackEngine` for this — that
-      is a per-CHARACTER collapse that over-excludes). */
-  segments?: Array<{ characterId?: string; sentenceIds?: number[]; renderedFallbackEngine?: string | null }>;
+      is a per-CHARACTER collapse that over-excludes).
+      `textHash` (#1105) is the djb2-base36 hash of the segment's RAW rendered
+      sentence text, stamped at synthesis time. The frontend diffs it against the
+      live manuscript text to flag a chapter whose text was edited after it
+      rendered (the text sibling of the speaker-map diff). Absent on pre-#1105
+      renders. */
+  segments?: Array<{
+    characterId?: string;
+    sentenceIds?: number[];
+    renderedFallbackEngine?: string | null;
+    textHash?: string;
+  }>;
+}
+
+/* #1105 — djb2 base-36 hash of a sentence's RAW text. Byte-identical to
+   src/lib/stale-chapters.ts textHashForStale (the cross-package staleness
+   contract is pinned by a shared vector in both test files). Stamped into each
+   segment at render time and compared client-side against the live text. */
+export function textHashForStale(s: string): string {
+  let h = 5381;
+  for (let i = 0; i < s.length; i += 1) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return Math.abs(h).toString(36);
 }
 
 /* Load every rendered chapter's segments file for a book, in chapter order.
@@ -129,6 +149,34 @@ export async function collectRenderedSpeakerMaps(
     /* Only surface chapters that actually carried per-sentence segments — an
        empty map (legacy file without `segments`) would otherwise read as "every
        sentence reassigned" on the client. */
+    if (Object.keys(map).length > 0) out[seg.chapterId] = map;
+  }
+  return out;
+}
+
+/* #1105 — the render-time sentence→textHash map per rendered chapter, recovered
+   from each segment's `textHash`. Shape: `{ [chapterId]: { [sentenceId]: textHash } }`.
+   The frontend diffs it against the live manuscript text to flag a `done` chapter
+   whose text was EDITED after it rendered (synth is keyed on sentence text, so the
+   audio is stale on every engine) — the text sibling of collectRenderedSpeakerMaps.
+
+   Only chapters with at least one stamped textHash appear; a chapter rendered
+   before #1105 (no textHash on any segment) is omitted so the client reads it as
+   "can't tell" rather than "every sentence edited". */
+export async function collectRenderedTextHashesByChapter(
+  bookDir: string,
+  chapters: Array<{ id: number; slug: string }>,
+): Promise<Record<number, Record<number, string>>> {
+  const out: Record<number, Record<number, string>> = {};
+  const segs = await loadSegmentsFiles(bookDir, chapters);
+  for (const seg of segs) {
+    const map: Record<number, string> = {};
+    for (const s of seg.segments ?? []) {
+      if (!s.textHash || !Array.isArray(s.sentenceIds)) continue;
+      for (const sid of s.sentenceIds) {
+        if (typeof sid === 'number') map[sid] = s.textHash;
+      }
+    }
     if (Object.keys(map).length > 0) out[seg.chapterId] = map;
   }
   return out;

--- a/server/src/routes/book-state.test.ts
+++ b/server/src/routes/book-state.test.ts
@@ -35,6 +35,12 @@ let workspaceRoot: string;
 let bookDir: string;
 let app: Express;
 let bookId: string;
+/* #1105 — imported DYNAMICALLY in beforeAll (after WORKSPACE_DIR is set), not at
+   the top, because segments-io.js pulls in the workspace-path module graph; a
+   static import here would initialise it before beforeAll sets WORKSPACE_DIR and
+   poison the cached workspace root (every GET /state then 404s "Book not found").
+   Same reason book-state.js itself is dynamically imported below. */
+let textHashForStale: (s: string) => string;
 
 beforeAll(async () => {
   /* Plan 45 (vitest pool tuning) — async mkdtemp yields the event loop during
@@ -43,10 +49,12 @@ beforeAll(async () => {
   workspaceRoot = await mkdtemp(join(tmpdir(), 'audiobook-changelog-test-'));
   process.env.WORKSPACE_DIR = workspaceRoot;
 
-  const [{ bookStateRouter }, { makeBookId }] = await Promise.all([
+  const [{ bookStateRouter }, { makeBookId }, segmentsIo] = await Promise.all([
     import('./book-state.js'),
     import('../workspace/paths.js'),
+    import('../audio/segments-io.js'),
   ]);
+  textHashForStale = segmentsIo.textHashForStale;
   bookId = makeBookId(AUTHOR, SERIES, TITLE);
 
   bookDir = join(workspaceRoot, 'books', AUTHOR, SERIES, TITLE);
@@ -215,6 +223,39 @@ describe('book-state router — renderedFallbackByCharacter (fe-16)', () => {
     const res = await request(app).get(`/api/books/${bookId}/state`);
     expect(res.status).toBe(200);
     expect(res.body.renderedFallbackByCharacter).toEqual({ wren: 'kokoro' });
+    rmSync(join(audioRoot, 'chapter-one.segments.json'), { force: true });
+  });
+});
+
+describe('book-state router — renderedTextByChapter (#1105)', () => {
+  /* The GET ships a per-chapter sentence→textHash map recovered from each rendered
+     chapter's segments file, so the Generate view can flag a chapter whose text was
+     edited after it rendered. */
+  it('returns {} when no segments files exist', async () => {
+    const res = await request(app).get(`/api/books/${bookId}/state`);
+    expect(res.status).toBe(200);
+    expect(res.body.renderedTextByChapter).toEqual({});
+  });
+
+  it('maps rendered sentenceIds to their stamped textHash per chapter', async () => {
+    const audioRoot = join(bookDir, 'audio');
+    mkdirSync(audioRoot, { recursive: true });
+    /* Chapter 1 slug = 'chapter-one' (beforeAll). */
+    writeFileSync(
+      join(audioRoot, 'chapter-one.segments.json'),
+      JSON.stringify({
+        chapterId: 1,
+        segments: [
+          { characterId: 'narrator', sentenceIds: [1], textHash: textHashForStale('The fire caught.') },
+          { characterId: 'marlow', sentenceIds: [2], textHash: textHashForStale('"Run," she said.') },
+        ],
+      }),
+    );
+    const res = await request(app).get(`/api/books/${bookId}/state`);
+    expect(res.status).toBe(200);
+    expect(res.body.renderedTextByChapter).toEqual({
+      1: { 1: textHashForStale('The fire caught.'), 2: textHashForStale('"Run," she said.') },
+    });
     rmSync(join(audioRoot, 'chapter-one.segments.json'), { force: true });
   });
 });

--- a/server/src/routes/book-state.ts
+++ b/server/src/routes/book-state.ts
@@ -60,6 +60,7 @@ import { preserveDesignedVoicesOnCastWrite } from '../workspace/preserve-cast-vo
 import {
   collectRenderedFallbackEngines,
   collectRenderedSpeakerMaps,
+  collectRenderedTextHashesByChapter,
 } from '../audio/segments-io.js';
 import type { LoudnormSidecarJson } from '../tts/loudnorm.js';
 
@@ -442,6 +443,16 @@ bookStateRouter.get('/:bookId/state', async (req: Request, res: Response) => {
       state.chapters,
     ).catch(() => ({}));
 
+    /* #1105 — render-time sentence→textHash map per rendered chapter. The frontend
+       diffs it against the live manuscript text to flag a `done` chapter whose text
+       was edited after it rendered (the text sibling of renderedSpeakersByChapter;
+       synth is keyed on text, so an edited line is stale on every engine). Tolerant
+       of a missing audio dir; empty on books rendered before #1105. */
+    const renderedTextByChapter = await collectRenderedTextHashesByChapter(
+      bookDir,
+      state.chapters,
+    ).catch(() => ({}));
+
     /* Apply the brand default for narratorCredit in the GET response so the
        frontend always sees 'Castwright' when no explicit credit has been set.
        The on-disk value is left untouched — the PATCH/write path persists the
@@ -465,6 +476,7 @@ bookStateRouter.get('/:bookId/state', async (req: Request, res: Response) => {
       chapterLufs,
       renderedFallbackByCharacter,
       renderedSpeakersByChapter,
+      renderedTextByChapter,
       changeLog: changeLog?.events ?? null,
       analysis: { failedChapterIds, failedChapterErrors },
     });

--- a/server/src/tts/synthesise-chapter.ts
+++ b/server/src/tts/synthesise-chapter.ts
@@ -35,6 +35,7 @@ import {
   type EmbeddingRow,
 } from '../audio/render-integrity/embeddings-io.js';
 import { MIN_DURATION_SEC } from '../audio/render-integrity/constants.js';
+import { textHashForStale } from '../audio/segments-io.js';
 import { resamplePcm16 } from './resample-pcm16.js';
 import { withTtsRetry, isTransient } from './retry.js';
 import { gpuSemaphore } from '../gpu/semaphore.js';
@@ -287,6 +288,11 @@ export interface ChapterSegment {
   startSec: number;
   /** Exclusive end time in the chapter audio, in seconds. */
   endSec: number;
+  /** #1105 — djb2-base36 hash of this group's RAW sentence text, stamped so the
+      frontend can flag a chapter whose text was edited after it rendered (synth is
+      keyed on text → stale on every engine). Absent on the title beat (no manuscript
+      sentence) and on pre-#1105 renders. See audio/segments-io.ts textHashForStale. */
+  textHash?: string;
   /** Discriminator for synthetic segments that aren't backed by a manuscript
       sentence. `'title'` marks the narrator-voiced chapter-title beat
       prepended to each chapter (see CHAPTER_LEAD_SILENCE_SEC below). Body
@@ -1659,6 +1665,7 @@ export async function synthesiseChapter(
       groupIndex: group.index,
       characterId: group.characterId,
       sentenceIds: group.sentenceIds.slice(),
+      textHash: textHashForStale(group.text),
       startSec,
       endSec,
       renderedFallbackEngine: resolveGroup(group).renderedFallbackEngine,

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -759,6 +759,11 @@ export function Layout() {
                Older servers omit it; the slice leaves the map empty and the
                view falls back to the time-based heuristic. */
             renderedSpeakersByChapter: res.renderedSpeakersByChapter,
+            /* #1105 — render-time sentence→textHash map per chapter so the Generate
+               view can flag chapters whose text was edited since they rendered.
+               Older servers/renders omit it; the slice leaves the map empty and the
+               view falls back to the time-based heuristic for text edits. */
+            renderedTextByChapter: res.renderedTextByChapter,
           }),
         );
         dispatch(

--- a/src/lib/stale-chapters.test.ts
+++ b/src/lib/stale-chapters.test.ts
@@ -4,6 +4,8 @@ import {
   latestReassignAt,
   isChapterStaleFromReassign,
   isChapterReassignedSinceRender,
+  textHashForStale,
+  isChapterTextEditedSinceRender,
 } from './stale-chapters';
 import type { Chapter, ChangeLogEvent } from './types';
 
@@ -141,5 +143,75 @@ describe('isChapterReassignedSinceRender (#650 precise diff)', () => {
   it('returns false when there is no render map for the chapter (fall back to heuristic)', () => {
     expect(isChapterReassignedSinceRender(undefined, [{ id: 1, characterId: 'x' }])).toBe(false);
     expect(isChapterReassignedSinceRender({}, [{ id: 1, characterId: 'x' }])).toBe(false);
+  });
+});
+
+describe('textHashForStale (#1105)', () => {
+  it('is deterministic and differs on a text change', () => {
+    expect(textHashForStale('Hello there.')).toBe(textHashForStale('Hello there.'));
+    expect(textHashForStale('Hello there.')).not.toBe(textHashForStale('Hello there!'));
+  });
+
+  it('matches the server djb2-base36 vector (cross-package contract)', () => {
+    /* MUST equal server/src/audio/segments-io.ts textHashForStale for the same
+       input — the staleness diff compares a server-stamped hash against this
+       client-computed one. Pin a known vector so a drift on either side fails
+       loudly here and in the server test. */
+    expect(textHashForStale('"Stop," she said.')).toBe('2rq6ja');
+  });
+});
+
+describe('isChapterTextEditedSinceRender (#1105 precise text diff)', () => {
+  const h = textHashForStale;
+  const rendered = { 1: h('The fire caught.'), 2: h('"Run," she said.'), 3: h('No one moved.') };
+
+  it('not stale when every rendered sentence still has byte-identical text', () => {
+    const current = [
+      { id: 1, text: 'The fire caught.' },
+      { id: 2, text: '"Run," she said.' },
+      { id: 3, text: 'No one moved.' },
+    ];
+    expect(isChapterTextEditedSinceRender(rendered, current)).toBe(false);
+  });
+
+  it('stale when a rendered sentence text was edited', () => {
+    const current = [
+      { id: 1, text: 'The fire caught.' },
+      { id: 2, text: '"Run!" she screamed.' }, // edited
+      { id: 3, text: 'No one moved.' },
+    ];
+    expect(isChapterTextEditedSinceRender(rendered, current)).toBe(true);
+  });
+
+  it('stale when a rendered sentence is gone (split/merge/delete)', () => {
+    const current = [
+      { id: 1, text: 'The fire caught.' },
+      { id: 3, text: 'No one moved.' }, // id 2 removed
+    ];
+    expect(isChapterTextEditedSinceRender(rendered, current)).toBe(true);
+  });
+
+  it('NO false positive on edit-then-revert (the derived-from-JSON win)', () => {
+    const current = [
+      { id: 1, text: 'The fire caught.' },
+      { id: 2, text: '"Run," she said.' },
+      { id: 3, text: 'No one moved.' },
+    ];
+    expect(isChapterTextEditedSinceRender(rendered, current)).toBe(false);
+  });
+
+  it('does not false-positive on a current sentence never in the render map', () => {
+    const current = [
+      { id: 1, text: 'The fire caught.' },
+      { id: 2, text: '"Run," she said.' },
+      { id: 3, text: 'No one moved.' },
+      { id: 99, text: 'A new line.' },
+    ];
+    expect(isChapterTextEditedSinceRender(rendered, current)).toBe(false);
+  });
+
+  it('returns false when there is no render text map (pre-1105 render → fall back)', () => {
+    expect(isChapterTextEditedSinceRender(undefined, [{ id: 1, text: 'x' }])).toBe(false);
+    expect(isChapterTextEditedSinceRender({}, [{ id: 1, text: 'x' }])).toBe(false);
   });
 });

--- a/src/lib/stale-chapters.ts
+++ b/src/lib/stale-chapters.ts
@@ -69,6 +69,48 @@ export function isChapterReassignedSinceRender(
   return false;
 }
 
+/* #1105 — PRECISE text staleness, the text sibling of isChapterReassignedSinceRender.
+   A rendered chapter whose sentence TEXT was edited after it rendered is stale on
+   EVERY engine (synth is keyed on sentence text), yet the speaker-diff above can't
+   see it (it compares characterId only). Derived from persisted JSON — the live
+   manuscript text vs the render-time text hash stamped into segments.json — so it's
+   precise (edit-then-revert reads not-stale), immediate (no refetch), survives a
+   reload, AND catches EVERY edit path (Script Review strip_tag, a future manual
+   editor, a direct manuscript-edits.json/MCP edit), not just the ones that remember
+   to log a boundary_move.
+
+   djb2 base-36, byte-identical to server/src/audio/segments-io.ts textHashForStale
+   (the cross-package contract is pinned by a shared vector in both test files).
+   Hash the RAW sentence text — the server stamps the raw group text, and this side
+   hashes the live raw `sent.text`, so a normalisation mismatch can't desync them. */
+export function textHashForStale(s: string): string {
+  let h = 5381;
+  for (let i = 0; i < s.length; i += 1) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return Math.abs(h).toString(36);
+}
+
+/** True when any sentence the chapter RENDERED now has different text (edited) or is
+    gone. Asymmetric on purpose — iterate the RENDERED ids only, mirroring
+    isChapterReassignedSinceRender: a current sentence that was never rendered (a
+    structural/empty line, or one added after render) isn't a key, so it can't trip a
+    false positive. Returns false when no render text map exists (pre-#1105 render),
+    letting the caller fall back to the time-based heuristic. */
+export function isChapterTextEditedSinceRender(
+  renderedTextHashes: Record<number, string> | undefined,
+  currentSentences: Array<{ id: number; text: string }>,
+): boolean {
+  if (!renderedTextHashes || Object.keys(renderedTextHashes).length === 0) return false;
+  const current = new Map<number, string>();
+  for (const s of currentSentences) current.set(s.id, s.text);
+  for (const sidStr of Object.keys(renderedTextHashes)) {
+    const sid = Number(sidStr);
+    const liveText = current.get(sid);
+    if (liveText === undefined) return true; // rendered sentence now gone
+    if (textHashForStale(liveText) !== renderedTextHashes[sid]) return true;
+  }
+  return false;
+}
+
 /** Returns a callback that marks a character's rendered audio stale (no-op when
     the character speaks in no `done` chapter). Reads chapters from the store. */
 export function useMarkCharacterStaleIfRendered(): (character: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -417,6 +417,14 @@ export interface BookStateResponse {
       immediate. Absent for legacy/unrendered chapters; the view falls back to
       the time-based change-log heuristic when a chapter has no entry. */
   renderedSpeakersByChapter?: Record<number, Record<number, string>>;
+  /** #1105 — render-time sentence→textHash map per rendered chapter
+      (`{ [chapterId]: { [sentenceId]: djb2-base36 } }`), recovered from each
+      chapter's `<slug>.segments.json`. The Generate view diffs it against the live
+      manuscript text to flag a `done` chapter whose text was edited after it
+      rendered (the text sibling of renderedSpeakersByChapter). Absent for
+      pre-#1105/unrendered chapters; the view falls back to the time-based heuristic
+      when a chapter has no entry. */
+  renderedTextByChapter?: Record<number, Record<number, string>>;
   /** Editorial activity trail (regenerate confirms, etc.). Null when no
       change-log.json has been written yet — the layout falls back to an
       empty list so the Activity view doesn't replay a stale demo seed for

--- a/src/modals/edit-chapter-title.test.tsx
+++ b/src/modals/edit-chapter-title.test.tsx
@@ -58,6 +58,7 @@ function renderModal(
         currentBookId: null,
         activeStreams: {},
         renderedSpeakersByChapter: {},
+        renderedTextByChapter: {},
       },
     },
   });

--- a/src/store/chapters-slice.test.ts
+++ b/src/store/chapters-slice.test.ts
@@ -31,6 +31,7 @@ const baseState = (chapters: Chapter[]): ChaptersState => ({
   currentBookId: null,
   activeStreams: {},
   renderedSpeakersByChapter: {},
+  renderedTextByChapter: {},
 });
 
 const tick = (t: Partial<GenerationTick> & { type: GenerationTick['type'] }): GenerationTick =>

--- a/src/store/chapters-slice.ts
+++ b/src/store/chapters-slice.ts
@@ -96,6 +96,12 @@ export interface ChaptersState {
       Empty for older servers / before the first hydrate; the view then falls
       back to the time-based change-log heuristic. */
   renderedSpeakersByChapter: Record<number, Record<number, string>>;
+  /** #1105 — render-time sentence→textHash map per rendered chapter, hydrated from
+      the book-state GET. The Generate view diffs it against the live manuscript text
+      to flag a `done` chapter whose text was edited after it rendered. Empty for
+      older servers / before the first hydrate; the view then falls back to the
+      time-based change-log heuristic. */
+  renderedTextByChapter: Record<number, Record<number, string>>;
 }
 
 const initialState: ChaptersState = {
@@ -106,6 +112,7 @@ const initialState: ChaptersState = {
   currentBookId: null,
   activeStreams: {},
   renderedSpeakersByChapter: {},
+  renderedTextByChapter: {},
 };
 
 export const chaptersSlice = createSlice({
@@ -249,6 +256,10 @@ export const chaptersSlice = createSlice({
         /** #650 — render-time sentence→speaker map per chapter. Absent on older
           servers → left empty, view falls back to the change-log heuristic. */
         renderedSpeakersByChapter?: Record<number, Record<number, string>>;
+        /** #1105 — render-time sentence→textHash map per chapter. Absent on
+          pre-#1105 servers/renders → left empty, view falls back to the
+          change-log heuristic for text edits. */
+        renderedTextByChapter?: Record<number, Record<number, string>>;
       }>,
     ) => {
       const {
@@ -259,9 +270,11 @@ export const chaptersSlice = createSlice({
         chapterCharacters,
         chapterLufs,
         renderedSpeakersByChapter,
+        renderedTextByChapter,
       } = a.payload;
       if (bookId) s.currentBookId = bookId;
       s.renderedSpeakersByChapter = renderedSpeakersByChapter ?? {};
+      s.renderedTextByChapter = renderedTextByChapter ?? {};
       const done = new Set(completedSlugs);
       const allCastQueued: Record<string, 'queued'> = {};
       for (const c of characters) allCastQueued[c.id] = 'queued';

--- a/src/views/generation.test.tsx
+++ b/src/views/generation.test.tsx
@@ -15,6 +15,7 @@ import { accountSlice } from '../store/account-slice';
 import { queueSlice } from '../store/queue-slice';
 import { bookMetaSlice } from '../store/book-meta-slice';
 import { GenerationView, ChapterSegmentStrip } from './generation';
+import { textHashForStale } from '../lib/stale-chapters';
 import { api } from '../lib/api';
 import { useTtsLifecycle } from '../lib/use-tts-lifecycle';
 import type { LayoutContext } from '../components/layout';
@@ -1438,6 +1439,94 @@ describe('GenerationView — precise reassignment staleness via render map (#650
       </Provider>,
     );
     expect(screen.getByText(/Sentences reassigned · regenerate to refresh/i)).toBeInTheDocument();
+  });
+});
+
+describe('GenerationView — precise text-edit staleness via render text map (#1105)', () => {
+  /* When the server ships a per-chapter render-time sentence→textHash map, the
+     Generate view flags a done chapter whose live sentence TEXT differs from what
+     was rendered — even when the speaker assignments are unchanged (the case a
+     strip_tag / manual / direct-JSON text edit produces). Chapter 1's fixture
+     sentences are id1 'A long room.', id2 'Hello there friend!',
+     id3 'How are you today on this fine evening?'. */
+  function renderWithTextMap(renderedTextByChapter: Record<number, Record<number, string>>): void {
+    const store = configureStore({
+      reducer: {
+        ui: uiSlice.reducer,
+        chapters: chaptersSlice.reducer,
+        manuscript: manuscriptSlice.reducer,
+        changeLog: changeLogSlice.reducer,
+        cast: castSlice.reducer,
+        library: librarySlice.reducer,
+        queue: queueSlice.reducer,
+        bookMeta: bookMetaSlice.reducer,
+      },
+    });
+    store.dispatch(
+      chaptersSlice.actions.hydrateFromBookState({
+        bookId: 'b1',
+        chapters: [
+          { id: 1, title: 'Chapter 1', slug: '01-a' },
+          { id: 2, title: 'Chapter 2', slug: '02-b' },
+        ],
+        completedSlugs: ['01-a'],
+        characters,
+        /* Speaker map matches the fixture → the #650 diff returns false, isolating
+           the #1105 text diff as the only thing that can flag staleness here. */
+        renderedSpeakersByChapter: { 1: { 1: 'narrator', 2: 'marlow', 3: 'marlow' } },
+        renderedTextByChapter,
+      } as any),
+    );
+    store.dispatch(chaptersSlice.actions.setChapters([chapter1, chapter2]));
+    store.dispatch(
+      manuscriptSlice.actions.hydrateFromAnalysis({
+        bookId: 'b1',
+        characters,
+        chapters: [chapter1, chapter2],
+        sentences,
+      } as any),
+    );
+    render(
+      <Provider store={store}>
+        <HostedGenerationView
+          chapters={[chapter1, chapter2]}
+          characters={characters}
+          paused
+          title="Text Map Fixture"
+          bookId="b1"
+          modelKey="kokoro-v1"
+          onRegenerate={() => {}}
+          onRegenerateBook={() => {}}
+          onRegenerateCharacterInChapter={() => {}}
+          onPreview={() => {}}
+        />
+      </Provider>,
+    );
+  }
+
+  it('shows the caption when a rendered sentence text was edited (speakers unchanged)', () => {
+    /* Render-time text for id2 was the OLD wording; the live fixture now has
+       'Hello there friend!'. Hash differs → stale, even though the speaker map
+       matches and no boundary_move was logged. */
+    renderWithTextMap({
+      1: {
+        1: textHashForStale('A long room.'),
+        2: textHashForStale('Hello there, old friend.'), // edited since render
+        3: textHashForStale('How are you today on this fine evening?'),
+      },
+    });
+    expect(screen.getByText(/Sentences reassigned · regenerate to refresh/i)).toBeInTheDocument();
+  });
+
+  it('does NOT show the caption when the live text matches the render text map (no false positive)', () => {
+    renderWithTextMap({
+      1: {
+        1: textHashForStale('A long room.'),
+        2: textHashForStale('Hello there friend!'),
+        3: textHashForStale('How are you today on this fine evening?'),
+      },
+    });
+    expect(screen.queryByText(/Sentences reassigned/i)).toBeNull();
   });
 });
 

--- a/src/views/generation.tsx
+++ b/src/views/generation.tsx
@@ -67,6 +67,7 @@ import { stripChapterPrefix } from '../lib/format-chapter-title';
 import {
   isChapterStaleFromReassign,
   isChapterReassignedSinceRender,
+  isChapterTextEditedSinceRender,
 } from '../lib/stale-chapters';
 import {
   characterLinePositionsByChapter,
@@ -166,6 +167,11 @@ export function GenerationView({
      reassignment-staleness diff (vs the time-based change-log fallback). */
   const renderedSpeakersByChapter = useAppSelector(
     (s) => s.chapters.renderedSpeakersByChapter,
+  );
+  /* #1105 — render-time sentence→textHash map per chapter, for the PRECISE
+     text-edit-staleness diff (the text sibling of the speaker-map diff). */
+  const renderedTextByChapter = useAppSelector(
+    (s) => s.chapters.renderedTextByChapter,
   );
   /* Drives the "View queue · N" pill in the header. Reflects real workspace
      queue entries when present, else the live generation run (the primary,
@@ -656,6 +662,30 @@ export function GenerationView({
     }
     return set;
   }, [renderedSpeakersByChapter, sentences]);
+
+  /* #1105 — the set of chapters whose live sentence TEXT differs from what was
+     rendered (precise text-edit staleness). Mirrors reassignedSinceRenderSet but
+     diffs text hashes instead of speakers, so a strip_tag / manual / JSON text edit
+     flags the chapter stale even though characterIds are unchanged. Only chapters
+     the server shipped a render TEXT map for (post-#1105 renders) are considered. */
+  const textEditedSinceRenderSet = useMemo(() => {
+    const renderedIds = Object.keys(renderedTextByChapter);
+    if (renderedIds.length === 0) return new Set<number>();
+    const byChapter = new Map<number, Array<{ id: number; text: string }>>();
+    for (const s of sentences) {
+      let arr = byChapter.get(s.chapterId);
+      if (!arr) byChapter.set(s.chapterId, (arr = []));
+      arr.push({ id: s.id, text: s.text });
+    }
+    const set = new Set<number>();
+    for (const cidStr of renderedIds) {
+      const cid = Number(cidStr);
+      if (isChapterTextEditedSinceRender(renderedTextByChapter[cid], byChapter.get(cid) ?? [])) {
+        set.add(cid);
+      }
+    }
+    return set;
+  }, [renderedTextByChapter, sentences]);
 
   /* SSE ownership lives in src/store/generation-stream-middleware.ts so the
      stream survives navigating away from this view. The view is a pure
@@ -1148,14 +1178,16 @@ export function GenerationView({
               onCancelSubset={handleCancelSubset}
               onRetrySubset={handleRetrySubset}
               stale={
-                /* OR-gate (fs-58 Task 3): stale if the precise render-map diff
-                   flags a speaker change OR a post-render boundary_move was
-                   logged (covers text/emotion edits the characterId-only precise
-                   diff can't see — strip_tag / fix_emotion + the retained
-                   split/extract piece). Intentionally conservative: a
-                   move-then-undo still reads stale, trading that rare false
-                   positive for catching edits that don't change characterIds. */
+                /* OR-gate (fs-58 Task 3 + #1105): stale if the precise render-map
+                   diff flags a speaker change OR the precise text-hash diff flags a
+                   text edit (#1105 — strip_tag / manual / direct-JSON edits the
+                   characterId-only diff can't see, derived from JSON so it survives
+                   reload) OR a post-render boundary_move was logged (the time-based
+                   fallback for pre-#1105 renders with no text map). Intentionally
+                   conservative: a move-then-undo still reads stale via the last
+                   clause, but the two precise diffs never false-positive on a revert. */
                 (renderedSpeakersByChapter[ch.id] ? reassignedSinceRenderSet.has(ch.id) : false) ||
+                (renderedTextByChapter[ch.id] ? textEditedSinceRenderSet.has(ch.id) : false) ||
                 isChapterStaleFromReassign(ch, activityEvents)
               }
               subsetProgress={subsetByChapter[ch.id] ?? null}


### PR DESCRIPTION
## Summary

Fixes #1105 — a text edit of an already-rendered sentence left the chapter's audio **silently stale**. Synth is keyed on sentence text, so an edited line's audio no longer matches, yet no "re-render needed" indication appeared. The only text-staleness signal was the transient `boundary_move` the Script Review `strip_tag` UI happened to log — invisible to any path that edits the persisted JSON directly (a future manual editor, a direct `manuscript-edits.json` / MCP edit) and gone after a reload.

The fix makes text staleness **derivable from the persisted JSON**, mirroring the #650 speaker-map diff — so it catches every edit path, survives reload, and never false-positives on edit-then-revert.

### What changed

- **Render time** (`synthesise-chapter.ts`): each segment is stamped with `textHash` — a djb2-base36 hash of the **raw** sentence text — into `segments.json`. *New renders only.*
- **book-state GET** (`segments-io.ts` `collectRenderedTextHashesByChapter` → `renderedTextByChapter`): inverts each chapter's segments into a `sentenceId → textHash` map. A chapter with no stamped hashes (pre-#1105 render) is **omitted**, so the client reads "can't tell" rather than "all sentences edited".
- **Frontend** (`isChapterTextEditedSinceRender` in `stale-chapters.ts`): the Generate view hashes the live raw `sent.text` and diffs it against the render-time hash, added as a **third clause** to the stale-row OR-gate (`generation.tsx`). Threaded through `types.ts` → `chapters-slice.ts` (hydrate) → `layout.tsx`.
- **Cross-package hash contract**: `textHashForStale` is byte-identical in `src/lib/stale-chapters.ts` and `server/src/audio/segments-io.ts`; a shared vector (`'"Stop," she said.'` → `2rq6ja`) is pinned in **both** test files so a drift on either side fails loudly. Both sides hash the **raw** text (server stamps `group.text` pre-normalisation; client hashes live `sent.text`) so normalisation can't desync them.

### Decisions (confirmed with the issue owner)

- **New renders only** — no backfill/migration; pre-#1105 renders fall back to the time-based `boundary_move` heuristic until their next render.
- **Keep both signals** — the existing `strip_tag` `boundary_move` dispatch stays (drives the Activity log + is the fallback); the derived diff is the authoritative, reload-surviving signal.
- **Not the `setStaleAudio` banner** — it's session-only, character-keyed (wrong semantics for a text change), and invisible to a direct-JSON edit, so it can't be the source of truth for text staleness.

## Test plan

CPU-only locally (GPU left free for an in-flight A/B render); full e2e + build routed to CI:

- ✅ `src/lib/stale-chapters.test.ts` — `textHashForStale` (determinism + cross-package vector) and `isChapterTextEditedSinceRender` (edit / gone / no-false-positive-on-revert / never-rendered / no-map).
- ✅ `server/src/audio/segments-io.test.ts` — `collectRenderedTextHashesByChapter` + the pinned hash vector.
- ✅ `server/src/routes/book-state.test.ts` — GET ships `renderedTextByChapter` (imported **dynamically** so the workspace module graph initialises after `WORKSPACE_DIR` is set — a static import 404s every `GET /state`).
- ✅ `src/views/generation.test.tsx` — the stale badge renders on a text edit with speakers unchanged; no false positive when live text matches.
- ✅ Full frontend (3161) + server (3709) suites, typecheck, ESLint all green locally.

Regression plan `docs/features/198-stale-chapter-reassign-indicator.md` updated with the #1105 text-diff section.

Closes #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)