### PR TITLE
chore: calibrate design-phase progress budgets from on-box measurements (#1092)

### DIFF
--- a/src/components/design-progress.test.tsx
+++ b/src/components/design-progress.test.tsx
@@ -38,21 +38,24 @@ describe('DesignProgress (honest)', () => {
 
   it('flips to the honest slow warning only past a real per-phase overage', () => {
     render(<DesignProgress phase="designing" />);
-    act(() => vi.advanceTimersByTime(140_000)); // > 2× the designing budget
+    // 60s > 2× the designing budget (~39.8s) but < 2× the total (~117.4s), so
+    // this isolates the per-phase trip from the total-elapsed OR-clause.
+    act(() => vi.advanceTimersByTime(60_000));
     expect(screen.getByTestId('design-eta')).toHaveTextContent(/taking longer than usual/i);
   });
 
   it('flips to slow via the total-elapsed OR-clause after a past phase overran (#1092)', () => {
-    // Total design budget ≈ 86.5s; the OR-clause fires past 2× that (≈173s).
+    // Total design budget ≈ 58.7s (on-box calibrated); the OR-clause fires past
+    // 2× that (≈117.4s).
     const { rerender } = render(<DesignProgress phase="designing" />);
     // designing overran badly (per-phase warning fired here), then advanced on.
-    act(() => vi.advanceTimersByTime(160_000));
+    act(() => vi.advanceTimersByTime(110_000));
     rerender(<DesignProgress phase="rendering" />); // resets the in-phase clock
-    // In rendering the in-phase clock is small (no per-phase trip, budget 12s),
+    // In rendering the in-phase clock is small (no per-phase trip, budget ≈20s),
     // but the cumulative elapsed is still climbing toward 2× the total.
-    act(() => vi.advanceTimersByTime(12_000)); // total 172s < 173s → still quiet
+    act(() => vi.advanceTimersByTime(5_000)); // total 115s < 117.4s → still quiet
     expect(screen.getByTestId('design-eta')).not.toHaveTextContent(/taking longer than usual/i);
-    act(() => vi.advanceTimersByTime(2_000)); // total 174s > 173s, in-phase 14s < 24s
+    act(() => vi.advanceTimersByTime(5_000)); // total 120s > 117.4s, in-phase 10s < 40.6s
     expect(screen.getByTestId('design-eta')).toHaveTextContent(/taking longer than usual/i);
   });
 

--- a/src/lib/design-phase.ts
+++ b/src/lib/design-phase.ts
@@ -1,7 +1,9 @@
-/* Shared vocabulary for the honest single-design progress bar. Budgets are
-   placeholder estimates until the on-box `qwen voice design:` numbers seed them
-   (spec Open items); the bar self-corrects when the next real phase event
-   arrives early (AR8). */
+/* Shared vocabulary for the honest single-design progress bar. The design-path
+   budgets (loading-model / designing / distilling / rendering) are seeded from
+   an on-box COLD `qwen voice design:` run (#1092 — the first design, where the
+   ETA matters most). freeing-vram (not emitted when there's nothing to evict)
+   and the mint-only anchoring / performing phases stay estimates. The bar
+   self-corrects when the next real phase event arrives early (AR8). */
 export type DesignPhase =
   | 'freeing-vram'
   | 'loading-model'
@@ -40,11 +42,11 @@ export const DESIGN_PHASE_LABELS: Record<DesignPhase, string> = {
 };
 
 export const DESIGN_PHASE_BUDGETS_MS: Record<DesignPhase, number> = {
-  'freeing-vram': 1_500,
-  'loading-model': 12_000,
-  designing: 55_000,
-  anchoring: 6_000,
-  performing: 60_000,
-  distilling: 6_000,
-  rendering: 12_000,
+  'freeing-vram': 1_500, // estimate — not emitted on a clean box (nothing to evict)
+  'loading-model': 16_700, // on-box cold (#1092)
+  designing: 19_900, // on-box cold (#1092)
+  anchoring: 6_000, // estimate — mint-only, off the single-design path
+  performing: 60_000, // estimate — mint-only, off the single-design path
+  distilling: 300, // on-box cold (#1092)
+  rendering: 20_300, // on-box cold (#1092)
 };


### PR DESCRIPTION
## Summary

Replaces the placeholder `DESIGN_PHASE_BUDGETS_MS` in `src/lib/design-phase.ts` with values measured from a **real on-box COLD single-voice design** (the first design — where the progress-bar ETA matters most), so the honest single-design progress bar's per-phase sub-fill and ETA reflect reality instead of guesses.

Measured on a clean 8GB CUDA box (one cold + one warm design, captured via `design_voice`'s `report_progress` phase callbacks, cross-checked against the `qwen voice design:` log line):

| phase | old (placeholder) | new (on-box cold) |
|---|---|---|
| `loading-model` | 12.0s | **16.7s** |
| `designing` | 55.0s | **19.9s** |
| `distilling` | 6.0s | **0.3s** |
| `rendering` | 12.0s | **20.3s** |
| `freeing-vram` | 1.5s | 1.5s (kept — not emitted on a clean box; nothing to evict) |
| `anchoring` / `performing` | 6s / 60s | unchanged (mint-only; off the single-design path the drawer drives) |

Net: the design-path total drops from ~86.5s to **~58.7s**, so both the ETA (`~X:XX left`) and the slow-warning OR-clause threshold (2× total, now ~117.4s) are realistic. Cold total measured 57.3s, matching the new budget sum.

## Changes

- `src/lib/design-phase.ts` — calibrated the four design-path budgets; header comment updated to note which are on-box-measured vs estimates.
- `src/components/design-progress.test.tsx` — retimed the two budget-dependent tests: the total-elapsed OR-clause test (2× total 173s → 117.4s) and the per-phase-overage test (now advances 60s to isolate the per-phase trip from the total OR-clause).

## Test plan

- `vitest run src/lib/design-phase.test.ts src/components/design-progress.test.tsx` → **10 passed**.
- `tsc --noEmit -p tsconfig.json` → clean.

The other minor follow-ups listed on #1092 (relay empty-token 400→200, initial-label seed, e2e tidy) were cleared as defer-able by the original review and are cosmetic; this PR delivers the on-box calibration that was the substantive blocker. Closing the issue per the Phase-2 plan; reopen/refile if the cosmetic items are still wanted.

Closes #1092.