### PR TITLE
fix(frontend): surface script-review chapter-failed instead of a silent empty modal

### DIFF
--- a/src/lib/api-review-script.test.ts
+++ b/src/lib/api-review-script.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+function sseResponse(events: string[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) { for (const e of events) c.enqueue(encoder.encode(`data: ${e}\n\n`)); c.close(); },
+  });
+  return new Response(stream, { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+}
+
+describe('realReviewScript — chapter-failed is surfaced', () => {
+  beforeEach(() => vi.restoreAllMocks());
+  it('calls onChapterFailed and still resolves on a chapter-failed-only stream', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(sseResponse([
+      JSON.stringify({ kind: 'phase', phaseId: 0, progress: 0, label: 'Reviewing — chapter 2', chapterId: 2 }),
+      JSON.stringify({ kind: 'chapter-failed', chapterId: 2, message: 'Chapter 2 is too large — split it first.' }),
+      JSON.stringify({ kind: 'result', done: true, reviewedChapters: 0, totalOps: 0 }),
+    ])));
+    const { api } = await import('./api');
+    const failed: Array<{ chapterId: number; message: string }> = [];
+    const res = await api.reviewScript('bk', { chapterId: 2, onChapterFailed: (e) => failed.push(e) });
+    expect(failed).toEqual([{ chapterId: 2, message: 'Chapter 2 is too large — split it first.' }]);
+    expect(res.totalOps).toBe(0);
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2897,6 +2897,7 @@ export interface ReviewScriptOpts {
   onPhase?: (e: { progress: number; label?: string; chapterId?: number }) => void;
   onThrottle?: (e: { chapterId: number; waitMs: number; reason: string }) => void;
   onOps?: (e: { chapterId: number; ops: import('./script-review-apply').ReviewOp[] }) => void;
+  onChapterFailed?: (e: { chapterId: number; message: string }) => void;
 }
 export interface ReviewScriptResult {
   reviewedChapters: number;
@@ -2914,7 +2915,7 @@ export class ReviewScriptError extends Error {
 
 async function realReviewScript(
   bookId: string,
-  { chapterId, model, signal, onPhase, onThrottle, onOps }: ReviewScriptOpts = {},
+  { chapterId, model, signal, onPhase, onThrottle, onOps, onChapterFailed }: ReviewScriptOpts = {},
 ): Promise<ReviewScriptResult> {
   const body: Record<string, unknown> = {};
   if (chapterId !== undefined) body.chapterId = chapterId;
@@ -2961,6 +2962,11 @@ async function realReviewScript(
           });
         }
         break;
+      case 'chapter-failed':
+        if (typeof p.chapterId === 'number') {
+          onChapterFailed?.({ chapterId: p.chapterId, message: typeof p.message === 'string' ? p.message : 'Chapter review failed.' });
+        }
+        break;
       case 'result':
         result = {
           reviewedChapters: typeof p.reviewedChapters === 'number' ? p.reviewedChapters : 0,
@@ -2998,7 +3004,7 @@ async function realReviewScript(
 
 async function mockReviewScript(
   _bookId: string,
-  { onOps, onPhase }: ReviewScriptOpts = {},
+  { onOps, onPhase, onChapterFailed: _onChapterFailed }: ReviewScriptOpts = {},
 ): Promise<ReviewScriptResult> {
   await wait(60);
   onPhase?.({ progress: 0.5, label: 'Reviewing…', chapterId: 3 });

--- a/src/views/manuscript-review-chapter-failed.test.tsx
+++ b/src/views/manuscript-review-chapter-failed.test.tsx
@@ -1,0 +1,100 @@
+/* Regression for the Review-Script empty-modal bug: when a chapter review
+   fails server-side, the SSE stream emits a `chapter-failed` event and ends
+   with `result{totalOps:0}`. Previously handleReviewScript unconditionally
+   called scriptReviewActions.setReview, creating an empty bucket → the diff
+   modal opened empty with no explanation. The fix surfaces a warn toast and
+   skips the empty bucket. */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { manuscriptSlice } from '../store/manuscript-slice';
+import { changeLogSlice } from '../store/change-log-slice';
+import { scriptReviewSlice } from '../store/script-review-slice';
+import { uiSlice } from '../store/ui-slice';
+import { bookMetaSlice } from '../store/book-meta-slice';
+import { notificationsSlice } from '../store/notifications-slice';
+import type { Toast } from '../store/notifications-slice';
+import { ManuscriptView } from './manuscript';
+import type { Chapter, Character, Sentence } from '../lib/types';
+
+const { reviewScript } = vi.hoisted(() => ({ reviewScript: vi.fn() }));
+vi.mock('../lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/api')>();
+  return { ...actual, api: { ...(actual as { api: object }).api, reviewScript } };
+});
+
+const characters: Character[] = [{ id: 'narrator', name: 'Narrator', role: 'Narrator', color: 'narrator' }];
+const chapter: Chapter = { id: 2, title: 'Chapter Two', duration: '10:00', state: 'done', progress: 1, characters: {} };
+const liveSentence: Sentence = { id: 1, chapterId: 2, characterId: 'narrator', text: 'Live line.' };
+
+function makeStore() {
+  return configureStore({
+    reducer: {
+      manuscript: manuscriptSlice.reducer,
+      changeLog: changeLogSlice.reducer,
+      scriptReview: scriptReviewSlice.reducer,
+      ui: uiSlice.reducer,
+      bookMeta: bookMetaSlice.reducer,
+      notifications: notificationsSlice.reducer,
+    },
+    preloadedState: {
+      manuscript: { ...manuscriptSlice.getInitialState(), sentences: [liveSentence] as never },
+      ui: {
+        ...uiSlice.getInitialState(),
+        stage: {
+          kind: 'ready',
+          bookId: 'bk-1',
+          view: 'manuscript',
+          currentChapterId: 2,
+          openProfileId: null,
+        } as never,
+      },
+    },
+  });
+}
+
+describe('ManuscriptView — script-review chapter-failed', () => {
+  beforeEach(() => reviewScript.mockReset());
+
+  it('toasts and opens no empty review modal when the only chapter fails', async () => {
+    const user = userEvent.setup();
+    const store = makeStore();
+
+    reviewScript.mockImplementation(
+      async (
+        _bookId: string,
+        opts?: { onChapterFailed?: (e: { chapterId: number; message: string }) => void },
+      ) => {
+        opts?.onChapterFailed?.({ chapterId: 2, message: 'Chapter 2 is too large — split it first.' });
+        return { reviewedChapters: 0, totalOps: 0 };
+      },
+    );
+
+    render(
+      <Provider store={store}>
+        <ManuscriptView
+          characters={characters}
+          chapters={[chapter]}
+          currentChapterId={2}
+          setCurrentChapterId={() => {}}
+          sentencesFromStore={[liveSentence]}
+        />
+      </Provider>,
+    );
+
+    await user.click(screen.getByTestId('review-script-chapter'));
+
+    await waitFor(() => {
+      const toasts: Toast[] = store.getState().notifications.toasts;
+      expect(toasts).toHaveLength(1);
+      expect(toasts[0].message).toMatch(/too large/);
+    });
+
+    /* No empty bucket → the diff modal never opens. */
+    const state = store.getState() as { scriptReview: { byBook: Record<string, unknown> } };
+    expect(state.scriptReview.byBook['bk-1']).toBeUndefined();
+  });
+});

--- a/src/views/manuscript.tsx
+++ b/src/views/manuscript.tsx
@@ -688,6 +688,7 @@ export function ManuscriptView({
     if (!bookId || reviewLoading) return;
     if (!wholeBook && currentChapterId == null) return;
     const allOps: ReviewOpWithChapter[] = [];
+    const failed: Array<{ chapterId: number; message: string }> = [];
     setReviewLoading(true);
     setReviewMenuOpen(false);
     try {
@@ -698,6 +699,7 @@ export function ManuscriptView({
         onOps: ({ chapterId: chId, ops }) => {
           for (const op of ops) allOps.push({ ...op, chapterId: chId });
         },
+        onChapterFailed: (e) => failed.push(e),
       });
       /* fs-58 Task 11 — run planApply at seed time so ops that can't be
          resolved against the LIVE sentences (stale ids, missing anchors,
@@ -722,7 +724,17 @@ export function ManuscriptView({
         appliable: ReviewOpWithChapter[];
         unappliable: Array<{ op: ReviewOpWithChapter; reason: string }>;
       };
-      dispatch(scriptReviewActions.setReview({ bookId, ops: appliable, unappliable }));
+      if (appliable.length === 0 && unappliable.length === 0 && failed.length > 0) {
+        dispatch(notificationsActions.pushToast({
+          kind: 'warn',
+          message: failed.length === 1 ? failed[0].message : `${failed.length} chapters couldn't be reviewed (too large or failed).`,
+        }));
+      } else {
+        if (failed.length > 0) {
+          dispatch(notificationsActions.pushToast({ kind: 'warn', message: `${failed.length} chapter(s) skipped; showing the rest.` }));
+        }
+        dispatch(scriptReviewActions.setReview({ bookId, ops: appliable, unappliable }));
+      }
     } catch (err) {
       dispatch(
         notificationsActions.pushToast({


### PR DESCRIPTION
## Summary

Review Script opened an empty "No suggestions found" modal with no error whenever a chapter review failed (e.g. a too-large chapter). The server emits a `chapter-failed` SSE event, but the client `realReviewScript` handler dropped it, so the stream ended with `result{totalOps:0}` and `setReview` created an empty bucket — opening the modal with no explanation.

This surfaces the failure:
- `realReviewScript` (`src/lib/api.ts`) gains an `onChapterFailed` opt + a `chapter-failed` case in its SSE `handle()` switch (mock twin updated).
- `handleReviewScript` (`src/views/manuscript.tsx`) collects failures: when **all** chapters failed (no ops), it shows a warn toast and does **not** open an empty modal; on a partial result it shows a "chapters skipped" toast and still opens the diff.

Underlying too-large-chapter limitation is fixed separately by the script-review chunker (its own PR). Design: `docs/superpowers/specs/2026-06-25-phase3-prosody-and-scriptreview-chunking-design.md` §2A.

## Test plan

- New `src/lib/api-review-script.test.ts` — a `chapter-failed`-only stream calls `onChapterFailed` and still resolves (`totalOps:0`). Fails before the handler change.
- New `src/views/manuscript-review-chapter-failed.test.tsx` — a chapter-failed-only review dispatches a toast and creates **no** review bucket (no empty modal).
- Full `npm run verify` green locally (typecheck + all tests + e2e + build).

Closes #1124

🤖 Generated with [Claude Code](https://claude.com/claude-code)