### PR TITLE
fix(frontend): preserve user emotion/instruct/vocalization on re-analysis

### DIFF
--- a/src/store/manuscript-slice.test.ts
+++ b/src/store/manuscript-slice.test.ts
@@ -446,6 +446,62 @@ describe('manuscriptSlice — hydrateFromAnalysis merge', () => {
     expect(next.sentences[1]).toMatchObject({ id: 2, characterId: 'narrator' });
   });
 
+  it('preserves user-set emotion / instruct / vocalization on re-analysis (manual wins)', () => {
+    /* Regression for #1121: the merge spread `...inc` over everything but
+       characterId/text/excludeFromSynthesis, silently stomping the user's
+       hand-set delivery edits. emotion + instruct are user-authored ("manual
+       wins"); vocalization tracks the preserved `text`, so all three must
+       survive a re-analyse exactly like characterId/text already do. */
+    const start = {
+      ...baseState(
+        sentences([
+          // user hand-set delivery on id=1
+          {
+            id: 1,
+            text: 'old',
+            characterId: 'eliza',
+            emotion: 'angry',
+            instruct: 'in a hushed whisper',
+            vocalization: true,
+          },
+          // id=2 left with no delivery edits
+          { id: 2, text: 'old-2', characterId: 'narrator' },
+        ]),
+      ),
+      manuscriptId: 'mns_open',
+    };
+    const next = manuscriptSlice.reducer(
+      start,
+      manuscriptActions.hydrateFromAnalysis(
+        analyse([
+          // analyzer re-guesses different delivery — must NOT overwrite the user's
+          { id: 1, text: 'fresh-1', characterId: 'narrator', emotion: 'sad' },
+          // fresh analyzer delivery on a matched-but-unedited sentence is discarded
+          // too (state wins on re-analysis, same as characterId/text)
+          {
+            id: 2,
+            text: 'fresh-2',
+            characterId: 'narrator',
+            emotion: 'excited',
+            instruct: 'loudly',
+            vocalization: true,
+          },
+        ]),
+      ),
+    );
+    // id=1: user's hand-set delivery survives the analyzer's fresh guesses
+    expect(next.sentences[0]).toMatchObject({
+      id: 1,
+      emotion: 'angry',
+      instruct: 'in a hushed whisper',
+      vocalization: true,
+    });
+    // id=2: user never set delivery → stays cleared; analyzer's fresh values don't leak in
+    expect(next.sentences[1].emotion).toBeUndefined();
+    expect(next.sentences[1].instruct).toBeUndefined();
+    expect(next.sentences[1].vocalization).toBeUndefined();
+  });
+
   it('keeps split-sentence offsprings whose ids the new analysis does not produce', () => {
     // Start state mirrors what splitSentence would have produced: original id=5 split → 5,42,43.
     const start = {

--- a/src/store/manuscript-slice.ts
+++ b/src/store/manuscript-slice.ts
@@ -140,10 +140,23 @@ export const manuscriptSlice = createSlice({
         const inc = incomingByKey.get(key(x));
         if (inc) {
           /* Sentence still exists in the new analysis. Refresh fields from
-             incoming but preserve characterId (the user's reassignment) and
-             text (in case the sentence was split — splitSentence rewrites
-             text in place and the analyzer wouldn't know about it). */
-          merged.push({ ...inc, characterId: x.characterId, text: x.text, excludeFromSynthesis: x.excludeFromSynthesis });
+             incoming but preserve the user-authored ones: characterId (the
+             reassignment), text (in case the sentence was split —
+             splitSentence rewrites text in place and the analyzer wouldn't
+             know about it), excludeFromSynthesis (fs-58 import-residue
+             exclusion), and the per-quote delivery edits emotion / instruct
+             ("manual wins" — #1121). vocalization tracks the preserved text,
+             so it rides along too rather than picking up the fresh analyzer's
+             flag for text we're discarding. */
+          merged.push({
+            ...inc,
+            characterId: x.characterId,
+            text: x.text,
+            excludeFromSynthesis: x.excludeFromSynthesis,
+            emotion: x.emotion,
+            instruct: x.instruct,
+            vocalization: x.vocalization,
+          });
         } else {
           /* Either a split offspring (id assigned above analyzer max) or a
              sentence the new analysis dropped. Keep it — the GET-side merge


### PR DESCRIPTION
## Summary

Fixes #1121 — the manuscript hydrate-merge on re-analysis silently dropped the user's hand-set per-quote delivery edits.

`hydrateFromAnalysis` (`src/store/manuscript-slice.ts`) spread the analyzer's fresh sentence (`...inc`) over everything but `characterId`/`text`/`excludeFromSynthesis`, so any user-set `emotion`/`instruct` fell through to the analyzer's value (its own guess, or `undefined`). On a confirm → reanalyse (or re-confirm cast) cycle, the manual delivery edit was lost — unlike reassignments, which were already preserved.

**Fix:** add `emotion`, `instruct`, and `vocalization` to the preserve object, mirroring `characterId`/`text`.
- `emotion` + `instruct` are user-authored delivery fields ("manual wins" per fs-25/fs-57).
- `vocalization` is the text-coupled Stage-3 flag; since `text` is already preserved, taking the analyzer's fresh `vocalization` for text we're discarding could mis-mark narration as a sound-effect token — so it rides along with `text`.

**Server is not a second instance.** I traced the data flow across the boundary: the GET-side merge in `book-state.ts` and `loadPostFoldSentencesByChapter` take the persisted `manuscript-edits.json` sentence list wholesale (filter by id only — no analyzer spread), so persisted delivery fields already survive a reload. The drop was purely the frontend redux merge.

## Test plan

- New regression test in `manuscript-slice.test.ts`: a re-analysis preserves a hand-set `emotion`/`instruct`/`vocalization` on a matched sentence, and does **not** leak the analyzer's fresh delivery onto a matched-but-unedited sentence (state wins, consistent with `characterId`/`text`). Fails before the fix (analyzer's `sad` overwrites the user's `angry`), passes after.
- Full local pre-push battery green: `lint` + `typecheck` + frontend (3227) + server (3736) + e2e + build. (First push hit the known tinypool worker-exit flake under `bootstrap-venv` contention; cleared on re-run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)