### PR TITLE
docs(docs): Phase 3 + script-review chunking design + plan (2A/2B shipped, Phase 3 deferred)

### DIFF
--- a/docs/superpowers/plans/2026-06-25-phase3-prosody-and-scriptreview-chunking.md
+++ b/docs/superpowers/plans/2026-06-25-phase3-prosody-and-scriptreview-chunking.md
@@ -294,6 +294,16 @@ git commit -m "feat(server): script review chunks large chapters via owned-core 
 
 ## PR3 — Phase 3 prosody annotation (branch `feat/analysis-phase3-prosody`)
 
+> **DEFERRED (2026-06-25).** PR1 (#1126) and PR2 (#1128) shipped. PR3 is paused:
+> the concurrent `feat/server-1.7b-implies-prosody` change drops `liveInstruct`
+> (the gate every task below keys on) in favor of "1.7B implies prosody". Do NOT
+> execute Tasks 7–14 as written. When that change + the book-level 1.7B override
+> land on `main`, **redesign the gate**: replace the `liveInstruct` toggle/trigger
+> (Tasks 11–12) with a trigger keyed on the new 1.7B signal (per-cast `is17b` /
+> book-quality override), and re-confirm the watermark (Task 7) + chunked
+> annotation passes (Tasks 8–10, 13) still apply. The chunker (PR2, merged) is the
+> reusable asset this will consume. Tracked in the deferred Phase-3 issue.
+
 **PREREQUISITE — PR2 MUST be merged first.** Task 8 imports `server/src/analyzer/chapter-chunker.ts`, which only exists once PR2 lands. **Cut `feat/analysis-phase3-prosody` off the updated `origin/main` AFTER PR2 has merged** (do not branch off PR1 or off a pre-PR2 main, or Task 8's import will not resolve).
 
 **COORDINATION GATE (do first):** rebase on latest `origin/main`; check whether the concurrent book-1.7B work has landed a quality flag. Reuse `liveInstruct`; do NOT add a competing flag. If their `bookQualityOverride` exists, the toggle here still SETS `liveInstruct` (annotation generation is gated on `liveInstruct`, independent of their synth-time override).

--- a/docs/superpowers/plans/2026-06-25-phase3-prosody-and-scriptreview-chunking.md
+++ b/docs/superpowers/plans/2026-06-25-phase3-prosody-and-scriptreview-chunking.md
@@ -1,0 +1,387 @@
+# Phase 3 prosody annotation + script-review chunking — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop script review from silently failing on normal-sized chapters, make it work on huge (Cyrillic) chapters via a sentence-chunker, and auto-generate per-line prosody annotations as a gated post-analysis pass.
+
+**Architecture:** Three independent PRs. PR1 surfaces a dropped SSE event (client only). PR2 adds a server sentence-chunker (owned-core ownership rule) consumed by script-review. PR3 auto-triggers the existing annotation routes (through PR2's chunker) after analysis when a per-book `liveInstruct` flag is on, with a completion watermark.
+
+**Tech Stack:** Vite + React 18 + Redux Toolkit (frontend, Vitest + jsdom); Node/Express + TypeScript (server, Vitest + node env); Playwright (e2e). SSE for streamed analyzer passes.
+
+**Spec:** `docs/superpowers/specs/2026-06-25-phase3-prosody-and-scriptreview-chunking-design.md` (read it; adversarial rounds 1+2 are folded there — do not re-derive the architecture).
+
+## Global Constraints
+
+- **OpenAPI is the type source of truth** — `Character`/`Chapter`/`Sentence` come from `src/lib/api-types.ts` (generated). Don't hand-write them.
+- **Design tokens are CSS custom properties** — no hex literals in component code (`--peach`, `--ink`, `--magenta`).
+- **RTK immer** — slice reducers mutate via Immer drafts. Don't rewrite to spreads.
+- **Mocks behind `VITE_USE_MOCKS`** — components import only from `api.*`. Every new `real*` API fn needs a `mock*` twin registered in the api object.
+- **Commit convention:** `<type>(<scope>): <subject>`. End every commit body with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- **One branch = one PR.** PR1 `fix/frontend-scriptreview-chapter-failed`; PR2 `feat/server-analyzer-chapter-chunker`; PR3 `feat/analysis-phase3-prosody`. Cut each off the latest `origin/main`.
+- **Verify gates:** frontend `npm test`; server `cd server && npm run test`; full `npm run verify` before each PR push.
+- **PR3 coordination:** a concurrent session owns `docs/superpowers/specs/2026-06-25-book-level-higher-quality-tier-design.md` (the synth-time book 1.7B override). PR3 MUST reuse the shared `liveInstruct` flag and MUST NOT introduce a competing book-quality flag. Rebase + reconcile before PR3 lands.
+
+---
+
+## PR1 — Surface `chapter-failed` (branch `fix/frontend-scriptreview-chapter-failed`)
+
+Root cause (spec §2A): `realReviewScript`'s `handle()` has no `chapter-failed` case, so a too-large/failed chapter is dropped and the modal opens empty with no error.
+
+### Task 1: `realReviewScript` surfaces `chapter-failed`
+
+**Files:**
+- Modify: `src/lib/api.ts` — `ReviewScriptOpts` (lines 2893–2900) + `realReviewScript`'s `handle()` (the switch ~lines 2922–2961) + `mockReviewScript` twin.
+- Test: `src/lib/api-review-script.test.ts` (create; colocated unit test driving the SSE parser via a fake `fetch`).
+
+**Interfaces:**
+- Produces: `ReviewScriptOpts.onChapterFailed?: (e: { chapterId: number; message: string }) => void`.
+
+- [ ] **Step 1: Write the failing test** — a `chapter-failed`-only stream calls `onChapterFailed`, still resolves (no throw), `totalOps === 0`.
+
+```ts
+// src/lib/api-review-script.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+function sseResponse(events: string[]): Response {
+  const body = events.map((e) => `data: ${e}\n\n`).join('');
+  return new Response(new Blob([body]).stream(), { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+}
+
+describe('realReviewScript — chapter-failed is surfaced', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('calls onChapterFailed and still resolves on a chapter-failed-only stream', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(sseResponse([
+      JSON.stringify({ kind: 'phase', phaseId: 0, progress: 0, label: 'Reviewing — chapter 2', chapterId: 2 }),
+      JSON.stringify({ kind: 'chapter-failed', chapterId: 2, message: 'Chapter 2 is too large — split it first.' }),
+      JSON.stringify({ kind: 'result', done: true, reviewedChapters: 0, totalOps: 0 }),
+    ])));
+    const { api } = await import('./api');
+    const failed: Array<{ chapterId: number; message: string }> = [];
+    const res = await api.reviewScript('bk', { chapterId: 2, onChapterFailed: (e) => failed.push(e) });
+    expect(failed).toEqual([{ chapterId: 2, message: 'Chapter 2 is too large — split it first.' }]);
+    expect(res.totalOps).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run it, verify it fails** — `npm test -- src/lib/api-review-script.test.ts` → FAIL (`onChapterFailed` never called).
+
+- [ ] **Step 3: Implement** — add the field + the case.
+
+```ts
+// ReviewScriptOpts (add one line):
+  onChapterFailed?: (e: { chapterId: number; message: string }) => void;
+
+// inside handle()'s switch in realReviewScript, add:
+      case 'chapter-failed':
+        if (typeof p.chapterId === 'number') {
+          onChapterFailed?.({
+            chapterId: p.chapterId,
+            message: typeof p.message === 'string' ? p.message : 'Chapter review failed.',
+          });
+        }
+        break;
+```
+Destructure `onChapterFailed` in the `realReviewScript` opts signature. In `mockReviewScript`, accept (and ignore) `onChapterFailed` so types match.
+
+- [ ] **Step 4: Run it, verify it passes** — `npm test -- src/lib/api-review-script.test.ts` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/api.ts src/lib/api-review-script.test.ts
+git commit -m "fix(frontend): surface chapter-failed in realReviewScript SSE handler"
+```
+
+### Task 2: `handleReviewScript` shows a toast instead of an empty modal
+
+**Files:**
+- Modify: `src/views/manuscript.tsx` — `handleReviewScript` (lines 672–719).
+- Test: `src/views/manuscript-review-chapter-failed.test.tsx` (create).
+
+**Interfaces:**
+- Consumes: `api.reviewScript(..., { onChapterFailed })`; `notificationsActions.pushToast({ kind, message })` (`'error'|'warn'|'info'`).
+
+- [ ] **Step 1: Write the failing test** — render the manuscript review trigger with `api.reviewScript` mocked to emit one `chapter-failed` and zero ops; assert a toast is dispatched and `hasActiveReview` stays false (no modal).
+
+```tsx
+// src/views/manuscript-review-chapter-failed.test.tsx
+// Arrange a store + a mocked api.reviewScript that calls opts.onChapterFailed once and resolves {reviewedChapters:0,totalOps:0}.
+// Click the "Review Script" button (data-testid="review-script-chapter").
+// Assert: notifications slice has 1 toast whose message includes "too large";
+//         scriptReview.byBook[bookId] is undefined (no empty bucket / no modal).
+```
+(Full arrange/act/assert mirrors the existing `src/components/detect-emotions-button.test.tsx` store-harness pattern; mock `../lib/api`'s `reviewScript`.)
+
+- [ ] **Step 2: Run it, verify it fails** — `npm test -- manuscript-review-chapter-failed` → FAIL (today it dispatches an empty `setReview`, opening the modal).
+
+- [ ] **Step 3: Implement** — collect failures, branch on ops vs failures.
+
+```ts
+// in handleReviewScript, before the try: const failed: Array<{chapterId:number;message:string}> = [];
+// pass to api.reviewScript opts: onChapterFailed: (e) => failed.push(e),
+// after planApply, REPLACE the unconditional dispatch(setReview(...)) with:
+      if (appliable.length === 0 && unappliable.length === 0 && failed.length > 0) {
+        dispatch(notificationsActions.pushToast({
+          kind: 'warn',
+          message: failed.length === 1
+            ? failed[0].message
+            : `${failed.length} chapters couldn't be reviewed (too large or failed).`,
+        }));
+      } else {
+        if (failed.length > 0) {
+          dispatch(notificationsActions.pushToast({ kind: 'warn', message: `${failed.length} chapter(s) skipped; showing the rest.` }));
+        }
+        dispatch(scriptReviewActions.setReview({ bookId, ops: appliable, unappliable }));
+      }
+```
+
+- [ ] **Step 4: Run it, verify it passes** — `npm test -- manuscript-review-chapter-failed` → PASS. Then `npm test -- manuscript` to confirm no regression in existing review tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/views/manuscript.tsx src/views/manuscript-review-chapter-failed.test.tsx
+git commit -m "fix(frontend): toast on script-review chapter-failed instead of empty modal"
+```
+
+### Task 3: PR1 verify + open
+
+- [ ] `npm run verify` (frontend leg green). Rebase on `origin/main`. Push `fix/frontend-scriptreview-chapter-failed`. Open PR titled `fix(frontend): surface script-review chapter-failed instead of a silent empty modal`, body links the spec §2A + `Closes #<2A issue>`.
+
+---
+
+## PR2 — Sentence-chunker + script-review chunking (branch `feat/server-analyzer-chapter-chunker`)
+
+Root cause (spec §2B): the borrowed 9 K guard refuses normal chapters; Dozor chapters are 3–5× local `num_ctx`. Reuse only the budget helper; window sentence-objects with an owned-core ownership rule.
+
+### Task 4: `chapter-chunker.ts` — sentence windowing + ownership
+
+**Files:**
+- Create: `server/src/analyzer/chapter-chunker.ts`.
+- Test: `server/src/analyzer/chapter-chunker.test.ts`.
+
+**Interfaces:**
+- Consumes: `stage1ChunkBudgetForEngine(configured, numCtxTokens, engine)` (`stage1-chunk.ts:48`), `resolveAnalyzerNumCtx()` (`ollama.ts:216`).
+- Produces:
+```ts
+export interface SentenceChunk<S> { core: S[]; context: S[]; coreIds: Set<number>; }
+// `withContext` = context-before + core + context-after, in order, for prompt building.
+export function chunkSentencesByBudget<S extends { id: number; text: string }>(
+  sentences: S[],
+  opts: { charBudget: number; overlap: number; serialize: (s: S) => string },
+): SentenceChunk<S>[];
+export function chunkWithContext<S>(chunk: SentenceChunk<S>): S[]; // context-before ++ core ++ context-after
+export function ownsOp(coreIds: Set<number>, primaryId: number): boolean; // primaryId in core
+export function primarySentenceId(op: { id: number; op: string; mergeIds?: number[] }): number; // min(mergeIds) for merge, else id
+export function chapterChunkBudget(engine: 'gemini' | 'local'): number; // wraps stage1ChunkBudgetForEngine w/ resolveAnalyzerNumCtx()
+```
+
+- [ ] **Step 1: Write the failing test** — windowing, overlap, owned-core, ownership.
+
+```ts
+// server/src/analyzer/chapter-chunker.test.ts
+import { describe, it, expect } from 'vitest';
+import { chunkSentencesByBudget, chunkWithContext, ownsOp, primarySentenceId } from './chapter-chunker.js';
+
+const S = (id: number, len = 10) => ({ id, text: 'x'.repeat(len) });
+
+describe('chunkSentencesByBudget', () => {
+  it('cores partition the sentences with no gaps or overlaps', () => {
+    const sents = Array.from({ length: 10 }, (_, i) => S(i + 1, 30));
+    const chunks = chunkSentencesByBudget(sents, { charBudget: 90, overlap: 1, serialize: (s) => s.text });
+    const cores = chunks.flatMap((c) => c.core.map((s) => s.id));
+    expect(cores).toEqual([1,2,3,4,5,6,7,8,9,10]);          // every sentence owned once
+    expect(chunks.length).toBeGreaterThan(1);                // multi-chunk forced by budget
+  });
+  it('context overlaps neighbours but is excluded from coreIds', () => {
+    const sents = Array.from({ length: 6 }, (_, i) => S(i + 1, 40));
+    const chunks = chunkSentencesByBudget(sents, { charBudget: 80, overlap: 1, serialize: (s) => s.text });
+    const second = chunks[1];
+    expect(chunkWithContext(second).length).toBeGreaterThan(second.core.length); // has context
+    for (const s of second.core) expect(second.coreIds.has(s.id)).toBe(true);
+    expect([...second.coreIds].some((id) => chunks[0].coreIds.has(id))).toBe(false); // disjoint cores
+  });
+});
+
+describe('ownership', () => {
+  it('primarySentenceId is min(mergeIds) for merge, else id', () => {
+    expect(primarySentenceId({ id: 0, op: 'merge', mergeIds: [7, 5, 6] })).toBe(5);
+    expect(primarySentenceId({ id: 9, op: 'strip_tag' })).toBe(9);
+  });
+  it('ownsOp is true only when the primary id is in the core', () => {
+    const core = new Set([5, 6]);
+    expect(ownsOp(core, 5)).toBe(true);
+    expect(ownsOp(core, 7)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run it, verify it fails** — `cd server && npm run test -- chapter-chunker` → FAIL (module missing).
+
+- [ ] **Step 3: Implement** — greedy accumulation by serialized char length; cores are disjoint contiguous runs; context = `overlap` sentences each side (clamped); ownership helpers as specified. `chapterChunkBudget(engine)` = `stage1ChunkBudgetForEngine(resolveStage1ChunkCharBudget(engine), resolveAnalyzerNumCtx(), engine)`. (Keep it a pure function over the sentence array; no I/O.)
+
+- [ ] **Step 4: Run it, verify it passes** — `cd server && npm run test -- chapter-chunker` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/analyzer/chapter-chunker.ts server/src/analyzer/chapter-chunker.test.ts
+git commit -m "feat(server): sentence-chunker with owned-core ownership rule"
+```
+
+### Task 5: script-review consumes the chunker
+
+**Files:**
+- Modify: `server/src/routes/script-review.ts` — the per-chapter loop (lines 204–234): remove the `DEFAULT_STAGE2_CHUNK_CHAR_BUDGET` guard; loop chunks; emit owned-core ops only.
+- Test: `server/src/routes/script-review.test.ts` (extend).
+
+**Interfaces:**
+- Consumes: `chunkSentencesByBudget`, `chunkWithContext`, `ownsOp`, `primarySentenceId`, `chapterChunkBudget` (Task 4); `buildScriptReviewChapterInbox` (existing); `selection.analyzer.runScriptReviewChapter` (`analyzer/index.ts:100`); `selection.engine` (`'local'|'gemini'`).
+
+- [ ] **Step 1: Write the failing test** — with `num_ctx` forced low (stub `resolveAnalyzerNumCtx` → e.g. 800) and a multi-sentence chapter, the route emits chunked `ops` with **no** `chapter-failed`, and an op whose `primarySentenceId` is NOT in any chunk's core is dropped (ownership). Assert each sentence id appears in ops at most once.
+
+```ts
+// extend server/src/routes/script-review.test.ts
+// Mock the analyzer's runScriptReviewChapter to echo one strip_tag op per sentence id present in the chunk prompt.
+// Force a small budget so the chapter splits into >=2 chunks.
+// Expect: union of emitted op ids == chapter sentence ids (each once); zero 'chapter-failed' events.
+```
+
+- [ ] **Step 2: Run it, verify it fails** — `cd server && npm run test -- script-review` → FAIL (today: single call + 9 K guard).
+
+- [ ] **Step 3: Implement** — replace the guard+single-call body:
+
+```ts
+const chunks = chunkSentencesByBudget(byChapter.get(chapterId) ?? [], {
+  charBudget: chapterChunkBudget(selection.engine),
+  overlap: 3,
+  serialize: (s) => JSON.stringify({ id: s.id, characterId: s.characterId, text: s.text }),
+});
+for (const chunk of chunks) {
+  if (closed) break;
+  const prompt = buildScriptReviewChapterInbox(manuscriptId, chapterId, chunkWithContext(chunk), roster);
+  try {
+    const result = await selection.analyzer.runScriptReviewChapter(manuscriptId, chapterId, prompt, { /* same call opts */ });
+    const owned = result.ops.filter((op) => ownsOp(chunk.coreIds, primarySentenceId(op)));
+    if (owned.length) { send({ kind: 'ops', chapterId, ops: owned }); totalOps += owned.length; }
+  } catch (err) { /* keep existing catch: AnalysisAbortedError break; DailyQuotaExhaustedError → error+return; else chapter-failed (now genuinely-impossible single-sentence case) */ }
+}
+reviewedChapters += 1;
+```
+Remove the `DEFAULT_STAGE2_CHUNK_CHAR_BUDGET` import + guard. Keep the `result` event and SSE plumbing unchanged.
+
+- [ ] **Step 4: Run it, verify it passes** — `cd server && npm run test -- script-review` → PASS. Run `cd server && npm run test -- chapter-chunker script-review` together.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/script-review.ts server/src/routes/script-review.test.ts
+git commit -m "feat(server): script review chunks large chapters via owned-core chunker"
+```
+
+### Task 6: PR2 verify + open
+
+- [ ] `npm run verify` (server + server-slow legs). Rebase on `origin/main`. Push `feat/server-analyzer-chapter-chunker`. PR title `feat(server): chunk script review over large chapters (owned-core sentence chunker)`, body links spec §2B + shared-component section + `Closes #<2B issue>`.
+
+---
+
+## PR3 — Phase 3 prosody annotation (branch `feat/analysis-phase3-prosody`)
+
+**COORDINATION GATE (do first):** rebase on latest `origin/main`; check whether the concurrent book-1.7B work has landed a quality flag. Reuse `liveInstruct`; do NOT add a competing flag. If their `bookQualityOverride` exists, the toggle here still SETS `liveInstruct` (annotation generation is gated on `liveInstruct`, independent of their synth-time override).
+
+### Task 7: book-state `prosodyAnnotated` watermark
+
+**Files:**
+- Modify: `server/src/workspace/scan.ts` (`BookStateJson`, near `liveInstruct?` at lines 230–236); `server/src/routes/book-state.ts` (the `case 'state':` patch handler, lines 605–765).
+- Test: `server/src/routes/book-state.test.ts` (extend).
+
+**Interfaces:**
+- Produces: `BookStateJson.prosodyAnnotated?: boolean` — true once both prosody passes complete for the book; the auto-trigger fires only when absent/false.
+
+- [ ] **Step 1: Write the failing test** — `PUT /api/books/:bookId/state {patch:{prosodyAnnotated:true}}` persists the field; an absent/non-boolean patch leaves it unchanged.
+- [ ] **Step 2: Run, verify fail** — `cd server && npm run test -- book-state` → FAIL.
+- [ ] **Step 3: Implement** — add the optional field (JSDoc, additive — do NOT bump `CURRENT_STATE_SCHEMA`, mirror the `liveInstruct` note) + a boolean picker in the `case 'state':` spread (mirror the existing `liveInstruct` ternary).
+- [ ] **Step 4: Run, verify pass.**
+- [ ] **Step 5: Commit** — `feat(server): prosodyAnnotated watermark on book state`.
+
+### Task 8: annotation routes consume the chunker
+
+**Files:**
+- Modify: `server/src/routes/instruct-annotation.ts` (the per-chapter loop ~129) and `server/src/routes/annotate-emotion.ts` (its sibling loop).
+- Test: `server/src/routes/instruct-annotation.test.ts`, `server/src/routes/annotate-emotion.test.ts` (extend).
+
+**Interfaces:**
+- Consumes: PR2's `chunkSentencesByBudget`/`chunkWithContext`/`chapterChunkBudget`; annotation ownership uses `coreIds.has(ann.sentenceId)` (no structural ops here — annotations are per-sentence).
+
+- [ ] **Step 1: Write the failing test** — with a forced-low `num_ctx`, a large chapter is chunked; each sentence's annotation is emitted exactly once (owned-core), no truncation/`chapter-failed`.
+- [ ] **Step 2: Run, verify fail.**
+- [ ] **Step 3: Implement** — wrap the existing `runStage3Chapter` / emotion call in a per-chunk loop building the inbox from `chunkWithContext(chunk)`, filtering returned annotations to `chunk.coreIds.has(ann.sentenceId)` before `send({kind:'annotation',...})`.
+- [ ] **Step 4: Run, verify pass.**
+- [ ] **Step 5: Commit** — `feat(server): emotion+instruct annotation passes chunk large chapters`.
+
+### Task 9: `chapter-failed` surfaced in detect handlers (the §2A sibling gap)
+
+**Files:**
+- Modify: `src/lib/api.ts` — `DetectEmotionsOpts`/`DetectInstructOpts` (+ their `handle()` switches) gain `onChapterFailed`.
+- Test: `src/lib/api-detect-emotions.test.ts` (extend).
+
+- [ ] TDD as Task 1, applied to `realDetectEmotions`/`realDetectInstruct`. Commit `fix(frontend): surface chapter-failed in detect-emotions/instruct handlers`.
+
+### Task 10: extract reusable `runProsodyPasses` thunk
+
+**Files:**
+- Create: `src/store/prosody-thunk.ts` (the two-pass sequence factored out of `DetectEmotionsButton.run`, lines 38–96).
+- Modify: `src/components/detect-emotions-button.tsx` to call it (button behaviour unchanged).
+- Test: `src/store/prosody-thunk.test.ts`.
+
+**Interfaces:**
+- Produces: `runProsodyPasses(bookId, { dispatch, signal, onProgress? }): Promise<{ totalAnnotations: number; totalChapters: number; failed: number }>` — runs `api.detectEmotions` then `api.detectInstruct`, dispatching `applyDetectedEmotions`/`applyDetectedInstruct`, summing failures via `onChapterFailed`.
+
+- [ ] TDD: test that it calls both api passes in order and dispatches both apply actions; mock `api`. Commit `refactor(frontend): extract runProsodyPasses from DetectEmotionsButton`.
+
+### Task 11: analysis-form "High-quality prosody (Qwen 1.7B)" toggle
+
+**Files:**
+- Modify: `src/views/analysing.tsx` (the start-analysis surface) — add the toggle; on change dispatch `bookMetaActions.setLiveInstruct({ bookId, value })` and PUT `{slice:'state',patch:{liveInstruct}}` (existing book-state PUT path); **await the PUT before the analysis POST fires** (spec ordering note).
+- Test: `src/views/analysing-prosody-toggle.test.tsx` + one e2e `e2e/analysis-prosody-toggle.spec.ts`.
+
+**Interfaces:**
+- Consumes: `bookMetaActions.setLiveInstruct({ bookId, value })` (`book-meta-slice.ts:119`); `selectLiveInstruct(bookId)` (`:167`).
+
+- [ ] TDD: toggling sets `bookMeta.liveInstruct[bookId]` and issues the PUT; default off. Commit `feat(frontend): high-quality prosody toggle on the analysis form`.
+
+### Task 12: post-analysis auto-trigger + watermark
+
+**Files:**
+- Modify: `src/components/layout.tsx` (or a small effect host that observes `ui.stage` reaching `confirm`/`ready`) — when `selectLiveInstruct(bookId)` is true AND the book's `prosodyAnnotated` watermark is not set AND no prosody run is active → `runProsodyPasses(bookId, …)`; on success PUT `{patch:{prosodyAnnotated:true}}`.
+- Test: `src/store/prosody-autotrigger.test.tsx`.
+
+**Interfaces:**
+- Consumes: `runProsodyPasses` (Task 10); `selectLiveInstruct` (Task 11); `prosodyAnnotated` from book state (Task 7, read via book-meta hydration or a fetch).
+
+- [ ] TDD: fires exactly once when gate on + watermark incomplete; does NOT fire when off or watermark complete; a re-fire after partial fills only empties (assert `applyDetectedInstruct` fill-only-empty preserved). Commit `feat(frontend): auto-run prosody passes after analysis when enabled`.
+
+### Task 13: global prosody progress pill
+
+**Files:**
+- Create: `src/store/prosody-slice.ts` (`activeStream: { bookId, progress, label } | null`), registered in `src/store/index.ts`.
+- Modify: `src/components/layout.tsx` (lines ~1209–1251, beside `analysisPill`) to render a `prosodyPill` from `s.prosody.activeStream`; `runProsodyPasses` updates it via `onProgress`.
+- Test: `src/store/prosody-slice.test.ts` + `src/components/layout-prosody-pill.test.tsx`.
+
+- [ ] TDD: slice set/clear; pill renders label + percent while active, absent when null. Commit `feat(frontend): global prosody-detection progress pill`.
+
+### Task 14: PR3 e2e + verify + open
+
+- [ ] e2e `e2e/analysis-prosody-toggle.spec.ts`: toggle on → analysis completes → user reaches cast while the prosody pill runs → annotations land (assert a sentence gains an `instruct`).
+- [ ] `npm run verify` (full battery incl. e2e). Rebase on `origin/main` + reconcile with the concurrent 1.7B branch. Push `feat/analysis-phase3-prosody`. PR title `feat: auto-generate per-line prosody annotations after analysis (Phase 3)`, body links the spec §Deliverable-1 + the coordination note + `Closes #<Phase3 issue>`.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** §2A → PR1 Tasks 1–2 + PR3 Task 9 (detect handlers). §2B shared chunker → PR2 Task 4; script-review consumption → Task 5. §Deliverable-1: toggle → Task 11; separate post-analysis trigger → Task 12; watermark → Task 7; chunker reuse by annotation passes → Task 8; global-pill surfacing → Task 13; reusable pass → Task 10. Coordination note → PR3 gate.
+- **Owned-core rule** (the round-2 fix) is centralized in Task 4 and consumed by Tasks 5 + 8 — no `opKey` cross-chunk dedupe anywhere.
+- **No 4th in-pipeline phase / no `PHASE_WEIGHTS` edits** (round-2 blast-radius avoided): Phase 3 surfaces via its own `prosody-slice` pill (Task 13), not `ANALYSIS_PHASES`.
+- **liveInstruct is the single shared flag** (Tasks 11–12) — no competing book-quality flag; the concurrent synth-time override reads `liveInstruct || bookQualityOverride`.

--- a/docs/superpowers/plans/2026-06-25-phase3-prosody-and-scriptreview-chunking.md
+++ b/docs/superpowers/plans/2026-06-25-phase3-prosody-and-scriptreview-chunking.md
@@ -43,8 +43,13 @@ Root cause (spec §2A): `realReviewScript`'s `handle()` has no `chapter-failed` 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 function sseResponse(events: string[]): Response {
-  const body = events.map((e) => `data: ${e}\n\n`).join('');
-  return new Response(new Blob([body]).stream(), { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+  // jsdom-safe: ReadableStream + TextEncoder (Blob.stream() is unreliable in jsdom;
+  // this mirrors the existing src/lib/api-detect-emotions.test.ts pattern).
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) { for (const e of events) c.enqueue(encoder.encode(`data: ${e}\n\n`)); c.close(); },
+  });
+  return new Response(stream, { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
 }
 
 describe('realReviewScript — chapter-failed is surfaced', () => {
@@ -175,7 +180,7 @@ export function chunkSentencesByBudget<S extends { id: number; text: string }>(
 export function chunkWithContext<S>(chunk: SentenceChunk<S>): S[]; // context-before ++ core ++ context-after
 export function ownsOp(coreIds: Set<number>, primaryId: number): boolean; // primaryId in core
 export function primarySentenceId(op: { id: number; op: string; mergeIds?: number[] }): number; // min(mergeIds) for merge, else id
-export function chapterChunkBudget(engine: 'gemini' | 'local'): number; // wraps stage1ChunkBudgetForEngine w/ resolveAnalyzerNumCtx()
+export function chapterChunkBudget(engine: 'gemini' | 'local'): number; // = resolveStage1ChunkCharBudget(engine) — already num_ctx-derived for local, MAX_SAFE_INTEGER for gemini
 ```
 
 - [ ] **Step 1: Write the failing test** — windowing, overlap, owned-core, ownership.
@@ -220,7 +225,7 @@ describe('ownership', () => {
 
 - [ ] **Step 2: Run it, verify it fails** — `cd server && npm run test -- chapter-chunker` → FAIL (module missing).
 
-- [ ] **Step 3: Implement** — greedy accumulation by serialized char length; cores are disjoint contiguous runs; context = `overlap` sentences each side (clamped); ownership helpers as specified. `chapterChunkBudget(engine)` = `stage1ChunkBudgetForEngine(resolveStage1ChunkCharBudget(engine), resolveAnalyzerNumCtx(), engine)`. (Keep it a pure function over the sentence array; no I/O.)
+- [ ] **Step 3: Implement** — greedy accumulation by serialized char length; cores are disjoint contiguous runs; context = `overlap` sentences each side (clamped); ownership helpers as specified. `chapterChunkBudget(engine)` returns `resolveStage1ChunkCharBudget(engine)` **directly** — it already derives from `num_ctx` for `'local'` and returns `Number.MAX_SAFE_INTEGER` for `'gemini'`; do NOT re-wrap it in `stage1ChunkBudgetForEngine` (that double-derives and corrupts the budget). `chunkSentencesByBudget` stays a pure function over the sentence array (no I/O); only `chapterChunkBudget` reads config.
 
 - [ ] **Step 4: Run it, verify it passes** — `cd server && npm run test -- chapter-chunker` → PASS.
 
@@ -344,7 +349,7 @@ git commit -m "feat(server): script review chunks large chapters via owned-core 
 ### Task 11: analysis-form "High-quality prosody (Qwen 1.7B)" toggle
 
 **Files:**
-- Modify: `src/views/analysing.tsx` (the start-analysis surface) — add the toggle; on change dispatch `bookMetaActions.setLiveInstruct({ bookId, value })` and PUT `{slice:'state',patch:{liveInstruct}}` (existing book-state PUT path); **await the PUT before the analysis POST fires** (spec ordering note).
+- Modify: `src/views/analysing.tsx` (the start-analysis surface, near the "Start analysis" button ~line 1172) — add the toggle. On change: `dispatch(bookMetaActions.setLiveInstruct({ bookId, value }))` AND `void api.putBookState(bookId, { slice: 'state', patch: { liveInstruct: value } })` for durability. **Do NOT gate the analysis POST on this** — round-2 established Phase 3 runs *after* analysis with a client-side gate, so the server never reads `liveInstruct` during analysis. There is no "await PUT before POST" requirement (the original plan's wording was wrong: `setLiveInstruct` persistence is not awaitable middleware, and ordering doesn't matter here). The store value is the source of truth for the Task-12 trigger; the PUT is just so it survives reload.
 - Test: `src/views/analysing-prosody-toggle.test.tsx` + one e2e `e2e/analysis-prosody-toggle.spec.ts`.
 
 **Interfaces:**
@@ -355,7 +360,7 @@ git commit -m "feat(server): script review chunks large chapters via owned-core 
 ### Task 12: post-analysis auto-trigger + watermark
 
 **Files:**
-- Modify: `src/components/layout.tsx` (or a small effect host that observes `ui.stage` reaching `confirm`/`ready`) — when `selectLiveInstruct(bookId)` is true AND the book's `prosodyAnnotated` watermark is not set AND no prosody run is active → `runProsodyPasses(bookId, …)`; on success PUT `{patch:{prosodyAnnotated:true}}`.
+- Modify: `src/components/layout.tsx` — add a `useEffect` that **mirrors the existing voice-match auto-trigger** (`layout.tsx:895-917`): a `prosodyFiredFor = useRef<string|null>(null)` guard, gated on `stageKind === 'confirm'` (reset the ref to null when not confirm). When `stageKind === 'confirm'` && `bookId` && `selectLiveInstruct(bookId)` && `prosodyFiredFor.current !== bookId`: set `prosodyFiredFor.current = bookId`, then `const st = await api.getBookState(bookId)` — if `st.state.prosodyAnnotated` is already true, return (watermark complete; never re-run); else `await runProsodyPasses(bookId, { dispatch, signal })` and on success `void api.putBookState(bookId, { slice: 'state', patch: { prosodyAnnotated: true } })`. `prosodyAnnotated` is NOT hydrated into any slice today, so it MUST be fetched inline via `api.getBookState` (do not assume a store field). Effect deps: `[stageKind, bookId]`.
 - Test: `src/store/prosody-autotrigger.test.tsx`.
 
 **Interfaces:**
@@ -366,7 +371,7 @@ git commit -m "feat(server): script review chunks large chapters via owned-core 
 ### Task 13: global prosody progress pill
 
 **Files:**
-- Create: `src/store/prosody-slice.ts` (`activeStream: { bookId, progress, label } | null`), registered in `src/store/index.ts`.
+- Create: `src/store/prosody-slice.ts` (`activeStream: { bookId, progress, label } | null`), registered in `src/store/index.ts` reducer map only. **The slice is TRANSIENT** — UI-only progress state, like `notifications`: add ONLY the reducer to the map; do NOT add it to `persistence-middleware` or `broadcast-middleware` (no persistence/cross-tab sync). Confirm by grepping `src/store/index.ts` for how `notifications` is wired and match that (reducer-only).
 - Modify: `src/components/layout.tsx` (lines ~1209–1251, beside `analysisPill`) to render a `prosodyPill` from `s.prosody.activeStream`; `runProsodyPasses` updates it via `onProgress`.
 - Test: `src/store/prosody-slice.test.ts` + `src/components/layout-prosody-pill.test.tsx`.
 

--- a/docs/superpowers/plans/2026-06-25-phase3-prosody-and-scriptreview-chunking.md
+++ b/docs/superpowers/plans/2026-06-25-phase3-prosody-and-scriptreview-chunking.md
@@ -294,6 +294,8 @@ git commit -m "feat(server): script review chunks large chapters via owned-core 
 
 ## PR3 — Phase 3 prosody annotation (branch `feat/analysis-phase3-prosody`)
 
+**PREREQUISITE — PR2 MUST be merged first.** Task 8 imports `server/src/analyzer/chapter-chunker.ts`, which only exists once PR2 lands. **Cut `feat/analysis-phase3-prosody` off the updated `origin/main` AFTER PR2 has merged** (do not branch off PR1 or off a pre-PR2 main, or Task 8's import will not resolve).
+
 **COORDINATION GATE (do first):** rebase on latest `origin/main`; check whether the concurrent book-1.7B work has landed a quality flag. Reuse `liveInstruct`; do NOT add a competing flag. If their `bookQualityOverride` exists, the toggle here still SETS `liveInstruct` (annotation generation is gated on `liveInstruct`, independent of their synth-time override).
 
 ### Task 7: book-state `prosodyAnnotated` watermark
@@ -314,15 +316,33 @@ git commit -m "feat(server): script review chunks large chapters via owned-core 
 ### Task 8: annotation routes consume the chunker
 
 **Files:**
-- Modify: `server/src/routes/instruct-annotation.ts` (the per-chapter loop ~129) and `server/src/routes/annotate-emotion.ts` (its sibling loop).
+- Modify: `server/src/routes/instruct-annotation.ts` (per-chapter loop, lines 129–186 — builds `buildInstructChapterInbox(...)`, calls `selection.analyzer.runStage3Chapter(...)`, then `send({kind:'annotation', chapterId, annotations: result.annotations})`).
+- Modify: `server/src/routes/annotate-emotion.ts` (the structurally-identical sibling loop — builds `buildEmotionChapterInbox(...)`, calls `selection.analyzer.runEmotionChapter(...)`, same `send({kind:'annotation',...})`). Both verified same shape by review.
 - Test: `server/src/routes/instruct-annotation.test.ts`, `server/src/routes/annotate-emotion.test.ts` (extend).
 
 **Interfaces:**
-- Consumes: PR2's `chunkSentencesByBudget`/`chunkWithContext`/`chapterChunkBudget`; annotation ownership uses `coreIds.has(ann.sentenceId)` (no structural ops here — annotations are per-sentence).
+- Consumes: PR2's `chunkSentencesByBudget`/`chunkWithContext`/`chapterChunkBudget` (`chapter-chunker.ts` — requires PR2 merged, see PREREQUISITE); annotation ownership is `chunk.coreIds.has(ann.sentenceId)` (no structural ops — annotations are per-sentence, so no `primarySentenceId` needed here).
 
-- [ ] **Step 1: Write the failing test** — with a forced-low `num_ctx`, a large chapter is chunked; each sentence's annotation is emitted exactly once (owned-core), no truncation/`chapter-failed`.
-- [ ] **Step 2: Run, verify fail.**
-- [ ] **Step 3: Implement** — wrap the existing `runStage3Chapter` / emotion call in a per-chunk loop building the inbox from `chunkWithContext(chunk)`, filtering returned annotations to `chunk.coreIds.has(ann.sentenceId)` before `send({kind:'annotation',...})`.
+- [ ] **Step 1: Write the failing test** — stub `resolveAnalyzerNumCtx` low + `selection.engine='local'`; a multi-sentence chapter splits into ≥2 chunks; each sentence's annotation is emitted exactly once (owned-core), zero `chapter-failed`/truncation. Assert the union of emitted `sentenceId`s == the chapter's sentence ids, each once.
+- [ ] **Step 2: Run, verify fail** — `cd server && npm run test -- instruct-annotation annotate-emotion` → FAIL.
+- [ ] **Step 3: Implement** — in EACH route, replace the single-call body inside the per-chapter loop with a per-chunk loop (identical shape in both; only the inbox builder + analyzer method name differ):
+
+```ts
+const sentences = byChapter.get(chapterId) ?? [];
+const chunks = chunkSentencesByBudget(sentences, {
+  charBudget: chapterChunkBudget(selection.engine),
+  overlap: 3,
+  serialize: (s) => JSON.stringify({ sentenceId: s.id, characterId: s.characterId, text: s.text }),
+});
+for (const chunk of chunks) {
+  if (closed) break;
+  const prompt = buildInstructChapterInbox(manuscriptId, chapterId, chunkWithContext(chunk)); // annotate-emotion: buildEmotionChapterInbox
+  const result = await selection.analyzer.runStage3Chapter(manuscriptId, chapterId, prompt, { /* same StageCall opts */ }); // annotate-emotion: runEmotionChapter
+  const owned = result.annotations.filter((a) => chunk.coreIds.has(a.sentenceId));
+  if (owned.length) { send({ kind: 'annotation', chapterId, annotations: owned }); totalAnnotations += owned.length; }
+}
+annotatedChapters += 1; // once per chapter, after the chunk loop — keep the existing try/catch (chapter-failed) around the loop body
+```
 - [ ] **Step 4: Run, verify pass.**
 - [ ] **Step 5: Commit** — `feat(server): emotion+instruct annotation passes chunk large chapters`.
 
@@ -360,7 +380,25 @@ git commit -m "feat(server): script review chunks large chapters via owned-core 
 ### Task 12: post-analysis auto-trigger + watermark
 
 **Files:**
-- Modify: `src/components/layout.tsx` — add a `useEffect` that **mirrors the existing voice-match auto-trigger** (`layout.tsx:895-917`): a `prosodyFiredFor = useRef<string|null>(null)` guard, gated on `stageKind === 'confirm'` (reset the ref to null when not confirm). When `stageKind === 'confirm'` && `bookId` && `selectLiveInstruct(bookId)` && `prosodyFiredFor.current !== bookId`: set `prosodyFiredFor.current = bookId`, then `const st = await api.getBookState(bookId)` — if `st.state.prosodyAnnotated` is already true, return (watermark complete; never re-run); else `await runProsodyPasses(bookId, { dispatch, signal })` and on success `void api.putBookState(bookId, { slice: 'state', patch: { prosodyAnnotated: true } })`. `prosodyAnnotated` is NOT hydrated into any slice today, so it MUST be fetched inline via `api.getBookState` (do not assume a store field). Effect deps: `[stageKind, bookId]`.
+- Modify: `src/components/layout.tsx` — add a `useEffect` that **mirrors the existing voice-match auto-trigger** (`layout.tsx:895-917`), which uses a `useRef` guard + a `cancelled` cleanup boolean (it has NO AbortController — create one here). Shape:
+```tsx
+const prosodyFiredFor = useRef<string | null>(null);
+useEffect(() => {
+  if (stageKind !== 'confirm') { prosodyFiredFor.current = null; return; }
+  if (!bookId || !liveInstruct) return;                 // liveInstruct = useAppSelector(selectLiveInstruct(bookId))
+  if (prosodyFiredFor.current === bookId) return;
+  prosodyFiredFor.current = bookId;
+  const ac = new AbortController();
+  (async () => {
+    const st = await api.getBookState(bookId);
+    if (ac.signal.aborted || st?.state.prosodyAnnotated) return;   // watermark complete → never re-run
+    await runProsodyPasses(bookId, { dispatch, signal: ac.signal });
+    if (!ac.signal.aborted) void api.putBookState(bookId, { slice: 'state', patch: { prosodyAnnotated: true } });
+  })();
+  return () => ac.abort();
+}, [stageKind, bookId, liveInstruct]);
+```
+`prosodyAnnotated` is NOT hydrated into any slice today, so it MUST be fetched inline via `api.getBookState` (returns `BookStateResponse | null`; read `st?.state.prosodyAnnotated`). The AbortController is created in the effect (the voice-match sibling has none) and aborted in cleanup so a stage change cancels an in-flight run.
 - Test: `src/store/prosody-autotrigger.test.tsx`.
 
 **Interfaces:**

--- a/docs/superpowers/specs/2026-06-25-phase3-prosody-and-scriptreview-chunking-design.md
+++ b/docs/superpowers/specs/2026-06-25-phase3-prosody-and-scriptreview-chunking-design.md
@@ -1,0 +1,264 @@
+# Phase 3 prosody annotation + analyzer sentence-chunking (script review large chapters)
+
+**Date:** 2026-06-25 · **Status:** design (approved, pre-plan; adversarial rounds 1+2 folded)
+
+Origin: a `/superpowers:systematic-debugging` session over two reported symptoms
+("Phase 3 doesn't show in the analysing view" and "Review Script is always
+empty"). Root-causing both surfaced three deliverables that share one new
+component. They ship as **separate branches/PRs**; this is the single design
+that scopes them.
+
+## Symptoms → confirmed root causes
+
+1. **"Review Script always opens an empty modal, with no way to know why."**
+   Live-reproduced against the German *Der Auftrag von Coalfall* book. The SSE
+   stream for a per-chapter review of a normal-sized chapter:
+
+   ```
+   data: {"kind":"chapter-failed","chapterId":2,
+          "message":"Chapter 2 is too large for a single review call
+                     (prompt 10222 chars > 9000 char budget) — split it first."}
+   data: {"kind":"result","done":true,"reviewedChapters":0,"totalOps":0}
+   ```
+
+   Two independent faults:
+   - **2A — silent failure.** The client SSE handler (`realReviewScript`'s
+     `handle()`, `src/lib/api.ts`) has **no `chapter-failed` case**, so it drops
+     the event. The stream still ends with `result{totalOps:0}` → `setReview`
+     creates an empty bucket → the modal opens empty with subtitle "didn't find
+     anything to change" and **no error**. The same gap exists in the
+     instruct/emotion stream handlers.
+   - **2B — the budget is wrong for the job.** The `9000`-char limit is
+     `DEFAULT_STAGE2_CHUNK_CHAR_BUDGET` — the stage-2 *attribution* chunk
+     budget — borrowed wholesale by `server/src/routes/script-review.ts`.
+     Script review's *output* is a few ops; its input can be large, and the
+     analyzer models (`gemma-4-31b-it`, `gemini-3.1-flash-lite`) have
+     hundreds-of-K-to-~1M-token contexts. A 10 K-char chapter is normal. The
+     measured worst case — *Ночной дозор* (Night Watch) — has chapters of
+     **2,509 sentences / ~220 K prompt chars / ~73–110 K tokens (Cyrillic)**,
+     i.e. **3–5× the local model's entire 32 K `num_ctx`**, and *every* chapter
+     exceeds it. Chunk-with-overlap (explicitly deferred at the `ASSUMPTION`
+     comment, `script-review.ts:222`) is required.
+
+2. **"Phase 3 (invariants) doesn't show after analysis."**
+   The "invariants" are the per-line **delivery directions submitted to Qwen
+   1.7B for emotion + prosody** — the fs-57 instruct/emotion/vocalization
+   annotations — *not* the attribution-side `verifyEvidenceAgainstSource` check.
+   These products exist only behind the opt-in **"Detect emotions"** button,
+   which runs two sequential whole-book LLM passes (`detectEmotions` +
+   `detectInstruct`/`runStage3Chapter`). They were never made automatic.
+   **Phase 3 = run those passes automatically and visibly once attribution is
+   done, gated to when they'll be used.**
+
+## Shared component — analyzer sentence-chunker
+
+Common dependency of 2B and Phase 3. Both passes today send a chapter's *entire*
+sentence payload in one call; on a Dozor-sized chapter, script-review **refuses**
+it (the 9 K guard) and the emotion/instruct passes **silently truncate** the
+model's JSON (no guard at all).
+
+Design:
+
+- New `server/src/analyzer/chapter-chunker.ts`. **Reuse** the existing budget
+  helper `stage1ChunkBudgetForEngine` (`stage1-chunk.ts` — 70 % of `num_ctx` ×
+  ~2 chars/token, floor 2000; cloud → effectively unbounded, one chunk) and the
+  stage-2 sentence-splitting helpers (`splitParagraphIntoSentences`,
+  `precedingContext`). It is **not** a drop-in reuse of `runStage1ChapterChunked`
+  itself — that returns a roster, threads no overlap, and is attribution-shaped.
+- **Sentence-boundary core + overlap.** Each chunk has an **owned core** set of
+  sentences plus ~3 sentences of **context-only overlap** on each side, so a
+  boundary-straddling `merge`/`split`/`extract` or a delivery cue in an adjacent
+  narrator split is visible.
+- **Ownership dedupe rule (eliminates double-application).** A chunk emits a
+  result for a sentence **only when that sentence is in its owned core** — never
+  for an overlap/context sentence. For a **structural op** (`merge`, `split`,
+  `extract_dialogue`), ownership is decided by the op's **primary sentence = the
+  lowest member id** (`min(mergeIds)` for merge; the anchor sentence id for
+  split/extract). Consequence: every sentence is reviewed/annotated **exactly
+  once**, so there is no post-hoc dedupe and **no reliance on `opKey`**. This
+  sidesteps two real bugs: (a) `opKey` can't distinguish two `merge` ops (shared
+  `id`, differ only by `mergeIds`); (b) `applyDetectedInstruct` applies
+  vocalization `text` last-write-wins (`manuscript-slice.ts:387`). Both are moot
+  when a sentence is only ever emitted by one chunk.
+  - **Accepted limitation:** if a boundary-straddling structural op is proposed
+    *only* by the non-owning chunk, ownership suppresses it and nobody emits it.
+    The owning chunk has the trailing-overlap context to detect it, but model
+    nondeterminism makes detection non-guaranteed. Acceptable for v1.
+- Budget derived from the **live** analyzer `num_ctx`: cloud → one chunk; local
+  (32 K) → many ~24 K-char chunks.
+- **Chunker-safety confirmed:** the Stage-3 pass is annotation-only
+  (`stage3ChapterSchema` is `.strict()` → `{sentenceId, text?, instruct?,
+  vocalization?}`; `applyDetectedInstruct` mutates existing sentences in place,
+  never allocates new ids), so the per-chapter sentence-id set is stable across
+  annotation.
+
+## Deliverable 2A — surface `chapter-failed` (bugfix, TDD)
+
+- Add a `chapter-failed` case to `realReviewScript`'s `handle()` and to the
+  instruct/emotion stream handlers carrying the same gap. Extend the result/
+  callback surface so the caller learns a chapter failed (an `onChapterFailed`
+  callback or a `failedChapters` count — the current `ReviewScriptResult`
+  carries neither).
+- In `handleReviewScript` (`src/views/manuscript.tsx`): when chapters failed and
+  **no** ops were produced, surface the failure (toast; do **not** open an empty
+  modal); when some chapters failed alongside real ops, surface a non-blocking
+  notice and still open the diff.
+- **Regression test:** a stream of only `chapter-failed` + `result{totalOps:0}`
+  must surface the message, not a silent empty bucket. (Fails before, passes
+  after.) Ships **first** (independent; fixes the reported symptom immediately,
+  while the 9 K guard still exists pre-2B).
+
+## Deliverable 2B — script review chunks large chapters (feature)
+
+- `script-review.ts` loops the shared chunker per chapter, runs the review per
+  chunk passing overlap as context, and emits ops **only for the chunk's owned
+  core** (ownership rule) — so no `opKey`-based dedupe is needed.
+- The 9 K hard-fail guard is **removed**; the only remaining `chapter-failed` is
+  the genuinely-impossible case (a single sentence that can't fit one chunk),
+  which 2A now surfaces honestly.
+- Cloud → 1 chunk/chapter (unchanged behaviour); local → N chunks.
+
+## Deliverable 1 — Phase 3 auto-annotation (feature)
+
+**Architecture — separate auto-triggered pass AFTER analysis completes (NOT
+inline, NOT a tail step).** Adversarial round 2 killed both inline placements:
+inline-mid-stream reads *unfolded* sentences; tail-before-`result` (a) has a
+resume hole — `cast.json`/`state.json` are written before it (`analysis.ts:4088/
+4123`), so a resume sees "analysis done" and never re-enters Phase 3, and (b)
+**blocks the user on the analysing screen** until every annotation pass finishes,
+even though annotations don't affect casting (`result` is the *only* signal that
+moves `analysing → confirm`, `ui-slice.ts:195`).
+
+So Phase 3 runs as a **separate streamed pass that auto-fires once the book
+reaches the confirm/ready stage with `liveInstruct` on and prosody not yet
+complete.** It reuses the **existing** `detectEmotions` + `detectInstruct`
+routes (factored out of `DetectEmotionsButton.run`), now driven through the PR2
+chunker so they don't truncate large chapters. The user proceeds to cast
+immediately; prosody annotates in the background.
+
+- **Gate / trigger.** A new form toggle "High-quality prosody (Qwen 1.7B)" on the
+  analysis-start surface (`src/views/analysing.tsx`) sets the book's
+  `liveInstruct=true` (default off — extra quota + vocalization mutates text).
+  The post-analysis auto-trigger reads `liveInstruct` from the **frontend store**
+  (`book-meta-slice`, already hydrated) — **no server-side analysis-time read is
+  needed.** Setting the toggle pre-analysis is what makes prosody run
+  automatically right after the first analysis; toggling it on later (or the
+  manual button) covers the rest.
+- **Surfacing.** Phase 3 progress shows in the **global progress pill**
+  (`src/components/layout.tsx` AnalysisPill region) + a card on the
+  confirm/manuscript view, labeled "Phase 3 — Detecting prosody". The analysing
+  view's 3-phase list is **unchanged** (no `ANALYSIS_PHASES`/`PHASE_WEIGHTS`
+  edits — the static-const blast radius is avoided entirely by not making it a
+  4th in-pipeline phase).
+- **Resume / idempotency.** A completion watermark on the book (a `state.json`
+  field, e.g. `prosodyAnnotated` per chapter or a single status) records
+  progress. The passes are fill-only-empty (`applyDetectedEmotions`/
+  `applyDetectedInstruct`), so an interrupted run is recovered by re-firing — it
+  fills the remaining empties. The auto-trigger fires only when the watermark is
+  incomplete, so it never re-runs needlessly or loops.
+- **Cancellable + non-blocking.** The pass is abortable (existing
+  AbortController path) and never blocks navigation or casting.
+- **The "Detect emotions" button stays** as the manual re-run / top-up.
+
+### Coordination with the concurrent "Book-level Higher quality (1.7B)" spec
+
+A parallel design (`docs/superpowers/specs/2026-06-25-book-level-higher-quality-tier-design.md`)
+adds a **book "Higher quality (1.7B)" override + bulk pin** that, at **synth /
+regenerate time**, forces every Qwen cast member to the 1.7B model and opens the
+`liveInstruct` AND-gate. That control and this Phase 3 are **two stages of one
+feature, not duplicates**, and must use the **same `liveInstruct` flag** — do not
+introduce a competing book-quality flag here:
+
+- **Their toggle is meaningful later** (regenerate/generation): it enforces 1.7B
+  + opens the gate at synth.
+- **This Phase 3 toggle is meaningful at analysis time**: it must stay on the
+  analysis UX so the per-line prosody **annotations are generated *before*
+  generation reaches the 1.7B model** — otherwise opening their gate only yields
+  the four canned `emotionToInstruct` phrases, not real per-line delivery.
+- **Shared signal:** the analysis-form "High-quality prosody (Qwen 1.7B)" toggle
+  sets `liveInstruct`; their override reads `liveInstruct || bookQualityOverride`.
+  One intent, two entry points. The two specs cross-reference each other and the
+  work is coordinated with that session (the user oversees both). If the concurrent
+  feature lands a unified "quality" control first, this toggle becomes an
+  analysis-stage surfacing of the same flag rather than a new switch.
+
+## Error handling
+
+- A failed chunk emits `chapter-failed` (now surfaced by 2A) and the pass
+  carries on (one bad chunk never kills the chapter or the pass).
+- `DailyQuotaExhaustedError` keeps its `error{code:'quota_exhausted'}` behaviour
+  (already client-handled) — partial progress is preserved and the user re-runs.
+- Phase 3 with `liveInstruct` off simply never fires — a deliberate non-event,
+  not an error. The progress pill is absent.
+
+## Known accepted limitations
+
+- `liveInstruct` (the trigger gate) is *not* the synth-time gate
+  (`is17b && liveInstruct`, `resolve-instruct.ts`). A user can toggle prosody on,
+  get annotations, then render with Kokoro (which ignores `instruct`), wasting
+  the passes. Accepted: explicit user choice.
+- Multi-book: each book's Phase 3 is a separate stream sharing the per-model
+  analyzer rate-limit bucket (same as today's button). No per-manuscript
+  prioritisation; throttles queue internally. Acceptable.
+- Boundary-straddling structural op detected only by the non-owning chunk can be
+  dropped (see chunker section).
+
+## Testing
+
+- **2A:** frontend unit tests on the SSE handler + `handleReviewScript`
+  (chapter-failed-only stream → toast, no empty modal).
+- **Chunker:** server unit tests — core/overlap boundaries never split a
+  sentence; a structural op is owned by exactly one chunk (lowest-member rule);
+  budget scales with `num_ctx` (use a low-`num_ctx` override + a small synthetic
+  fixture to force multi-chunk, **not** the real 220 K Dozor text); an overlapped
+  sentence is emitted exactly once.
+- **2B:** server route test — a chapter over budget yields chunked `ops` with no
+  `chapter-failed`; a boundary-straddling `merge` is emitted once.
+- **Phase 3:** frontend test — the form toggle sets `liveInstruct`; the
+  post-analysis auto-trigger fires once when `liveInstruct` on + watermark
+  incomplete, and does NOT fire when off or when the watermark is complete;
+  re-fire fills only empties; the global pill renders progress. Server test —
+  the annotation routes run through the chunker; the watermark is written on
+  completion. One e2e: toggle on → analysis completes → user reaches cast while
+  the prosody pill runs → annotations land.
+
+## PR decomposition
+
+1. `fix/frontend-scriptreview-chapter-failed` — 2A (small, ship first; fixes the
+   reported "useless empty modal" immediately).
+2. `feat/server-analyzer-chapter-chunker` — the shared chunker + 2B (script
+   review consumes it).
+3. `feat/analysis-phase3-prosody` — form toggle + post-analysis auto-trigger of
+   the annotation passes (through the chunker) + global-pill surfacing +
+   completion watermark. Cross-cutting (server watermark + frontend trigger/UI),
+   but smaller than the tail-of-stream version (no analysis.ts surgery, no
+   4th-phase static-array changes).
+
+Sequence 2 before 3 (Phase 3's passes consume the chunker). 1 is independent.
+
+## Adversarial review log
+
+**Round 1** (two verifier agents): inline Phase 3 reads unfolded sentences +
+sticky/non-sticky clash → moved off inline. liveInstruct unreadable at analysis
+time. `opKey` dedupe broken for `merge`; vocalization-text last-write-wins →
+owned-core rule. No skipped-phase UI. `stage1-chunk` not a drop-in.
+
+**Round 2** (two verifier agents): **tail-of-stream is also unsafe** — resume
+short-circuits on `cast.json` presence (annotations silently partial) and
+`result`-before-Phase-3 **blocks the user from casting** → flipped to a
+**separate post-analysis auto-triggered pass**. This flip *removed* two round-1
+work items: the 4th-phase static-array surgery (Phase 3 now has its own progress
+surface, not an in-pipeline phase) and the server-side analysis-time
+`liveInstruct` read (trigger reads the frontend store). Confirmed safe: Stage-3
+is annotation-only (no new sentence ids → chunker-safe). Named accepted limits:
+non-owning-chunk structural-op drop; multi-book rate-limit sharing.
+
+## Out of scope
+
+- The in-flight working-tree change to `server/src/util/text-match.ts`
+  (multilingual quote folding for the **render-integrity** verifier) is
+  unrelated to these three deliverables and ships on its own.
+- No change to the synth-side resolver ladder, the Qwen engine, or the
+  `instruct`/emotion schema — all shipped by fs-57.
+- A literal 4th bar in the analysing phase list, and a per-chapter trigger for
+  "Detect emotions" — both deferred follow-ups.

--- a/docs/superpowers/specs/2026-06-25-phase3-prosody-and-scriptreview-chunking-design.md
+++ b/docs/superpowers/specs/2026-06-25-phase3-prosody-and-scriptreview-chunking-design.md
@@ -1,6 +1,18 @@
 # Phase 3 prosody annotation + analyzer sentence-chunking (script review large chapters)
 
-**Date:** 2026-06-25 · **Status:** design (approved, pre-plan; adversarial rounds 1+2 folded)
+**Date:** 2026-06-25 · **Status:** 2A + 2B SHIPPED (PR #1126, #1128); Phase 3 DEFERRED (gate superseded — see below)
+
+> **Status update (2026-06-25): Phase 3 is DEFERRED.** A concurrent change
+> (`feat/server-1.7b-implies-prosody`) collapses the synth prosody gate to
+> `is17b` alone and **drops `liveInstruct`** ("1.7B implies prosody"). That
+> removes the flag this Phase 3 design gates on (analysis-form toggle *sets*
+> `liveInstruct`; the post-analysis trigger *reads* it). Phase 3's **intent
+> survives** — the per-line prosody annotations still must be generated before a
+> 1.7B render — but its **trigger/gate must be redesigned on the new 1.7B signal**
+> (per-cast `is17b` / the book-level quality override) once that work + the
+> book-level 1.7B override spec land on `main`. Deliverables **2A** (chapter-failed
+> surfacing) and **2B** (script-review chunker) are unaffected and already shipped.
+> The chunker (2B) is the reusable asset Phase 3 will still consume.
 
 Origin: a `/superpowers:systematic-debugging` session over two reported symptoms
 ("Phase 3 doesn't show in the analysing view" and "Review Script is always


### PR DESCRIPTION
## Summary

Captures the design + implementation plan from a systematic-debugging → brainstorming → planning session, with all four adversarial review rounds folded in (2 spec, 2 plan).

- **Spec** `docs/superpowers/specs/2026-06-25-phase3-prosody-and-scriptreview-chunking-design.md`
- **Plan** `docs/superpowers/plans/2026-06-25-phase3-prosody-and-scriptreview-chunking.md`

Three deliverables; outcome:
- **2A** surface `chapter-failed` — SHIPPED #1126 (closes #1124)
- **2B** owned-core sentence chunker for script review — SHIPPED #1128 (closes srv-53 #1127)
- **Phase 3** auto-generate prosody annotations — **DEFERRED** (fs-65 #1129): the concurrent `feat/server-1.7b-implies-prosody` drops `liveInstruct` (the gate this design keys on); trigger to be redesigned on the new 1.7B signal once that work lands. Deferral notes are in both docs.

## Test plan

Docs-only. Full `npm run verify` green locally (no code change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)