### PR TITLE
fix(server): strip leading chapter-title heading from EPUB/MOBI body

### DIFF
--- a/server/src/parsers/epub.ts
+++ b/server/src/parsers/epub.ts
@@ -18,7 +18,7 @@ import type { ChapterHint } from '../store/manuscripts.js';
 import type { ParsedManuscript } from './text.js';
 import { parseFilenameMetadata, parseSeriesFromTitle } from './text.js';
 import { tagExcitedDialog, tagHesitantDialog, tagShoutingDialog } from './audio-tags.js';
-import { stripHtml, extractFirstHeading, GENERIC_NCX_RE } from './html-utils.js';
+import { stripHtml, extractFirstHeading, stripTitleHeading, GENERIC_NCX_RE } from './html-utils.js';
 import { UnusableMediaError } from './errors.js';
 
 type EpubOpts = { fileName?: string; sourcePath?: string };
@@ -137,9 +137,6 @@ async function tryEpub2Parse(filePath: string, opts: EpubOpts): Promise<ParsedMa
           err ? reject(err) : resolve(text ?? ''),
         );
       });
-      const body = tagHesitantDialog(tagExcitedDialog(tagShoutingDialog(stripHtml(html))));
-      if (!body) continue;
-
       // Title from the epub2-supplied NCX/spine label, merged with the body
       // heading via the shared resolver (see {@link mergeChapterTitle}).
       const chTitle = mergeChapterTitle(
@@ -147,6 +144,12 @@ async function tryEpub2Parse(filePath: string, opts: EpubOpts): Promise<ParsedMa
         extractFirstHeading(html),
         chapters.length + 1,
       );
+      // Drop the leading title heading from the body so it isn't spoken twice
+      // (title beat + body opening line) — see {@link stripTitleHeading}.
+      const body = tagHesitantDialog(
+        tagExcitedDialog(tagShoutingDialog(stripHtml(stripTitleHeading(html, chTitle)))),
+      );
+      if (!body) continue;
       chapters.push({ id: chapters.length + 1, title: chTitle, body });
     }
 
@@ -231,8 +234,6 @@ async function parseEpubRawZip(bytes: Buffer, opts: EpubOpts): Promise<ParsedMan
        document, so <head>/<title>/<style> text would otherwise leak into the
        prose. */
     const bodyHtml = htmlBodyOnly(buf.toString('utf8'));
-    const body = tagHesitantDialog(tagExcitedDialog(tagShoutingDialog(stripHtml(bodyHtml))));
-    if (!body) continue;
     /* Title from the NCX navLabel (parity with the epub2 path), merged with
        the body heading. Try the raw and URL-decoded chapter paths — mirrors
        resolveEntry, since the NCX src and the manifest href may differ in
@@ -249,6 +250,12 @@ async function parseEpubRawZip(bytes: Buffer, opts: EpubOpts): Promise<ParsedMan
       }
     }
     const chTitle = mergeChapterTitle(ncxTitle, extractFirstHeading(bodyHtml), chapters.length + 1);
+    // Drop the leading title heading so it isn't spoken twice — see
+    // {@link stripTitleHeading}.
+    const body = tagHesitantDialog(
+      tagExcitedDialog(tagShoutingDialog(stripHtml(stripTitleHeading(bodyHtml, chTitle)))),
+    );
+    if (!body) continue;
     chapters.push({ id: chapters.length + 1, title: chTitle, body });
   }
 

--- a/server/src/parsers/html-utils.test.ts
+++ b/server/src/parsers/html-utils.test.ts
@@ -7,7 +7,12 @@
    narrator. stripHtml decoded only the DECIMAL `&#39;`, never the hex form. */
 
 import { describe, it, expect } from 'vitest';
-import { stripHtml, extractFirstHeading, GENERIC_NCX_RE } from './html-utils.js';
+import {
+  stripHtml,
+  extractFirstHeading,
+  stripTitleHeading,
+  GENERIC_NCX_RE,
+} from './html-utils.js';
 
 describe('stripHtml — tag stripping', () => {
   it('still strips tags and reaches a fixed point (replace-until-stable)', () => {
@@ -54,6 +59,54 @@ describe('stripHtml — numeric character references', () => {
 describe('extractFirstHeading — numeric character references', () => {
   it('decodes a hex apostrophe in the heading text', () => {
     expect(extractFirstHeading('<h1>Oduvan&#x27;s Forge</h1>')).toBe("Oduvan's Forge");
+  });
+});
+
+/* The chapter's <h1> is promoted to the title (spoken by synthesise-chapter's
+   title beat) AND, because stripHtml flattens the whole document, it also
+   survives as the body's opening line — so the listener hears the chapter name
+   twice (the EPUB/MOBI duplicate-title bug). stripTitleHeading removes that one
+   leading heading element when its text is already represented in the resolved
+   title, but leaves a heading carrying content the title doesn't cover. */
+describe('stripTitleHeading — drop the leading heading already spoken as the title', () => {
+  it('removes the leading <h1> when it equals the resolved title', () => {
+    const html = '<h1>The Berth at Liverpool</h1><p>It was cold.</p>';
+    expect(stripHtml(stripTitleHeading(html, 'The Berth at Liverpool'))).toBe('It was cold.');
+  });
+
+  it('removes the heading when the title is the merged "Chapter N — Heading" form', () => {
+    const html = '<h2>The Berth at Liverpool</h2><p>It was cold.</p>';
+    expect(stripHtml(stripTitleHeading(html, 'Chapter 1 — The Berth at Liverpool'))).toBe(
+      'It was cold.',
+    );
+  });
+
+  it('matches case- and punctuation-insensitively (and through hex entities)', () => {
+    const html = "<h1>Oduvan&#x27;s Forge</h1><p>Body.</p>";
+    expect(stripHtml(stripTitleHeading(html, "ODUVAN'S FORGE"))).toBe('Body.');
+  });
+
+  it('leaves the body untouched when the heading is content the title does not cover', () => {
+    // NCX title won outright; the body heading is a different string → keep it.
+    const html = '<h1>Part One: Beginnings</h1><p>Body.</p>';
+    expect(stripTitleHeading(html, 'The Arrival')).toBe(html);
+  });
+
+  it('does not strip on a partial within-word match', () => {
+    const html = '<h1>Arr</h1><p>Body.</p>';
+    expect(stripTitleHeading(html, 'The Arrival')).toBe(html);
+  });
+
+  it('is a no-op when there is no heading', () => {
+    const html = '<p>Just prose, no heading.</p>';
+    expect(stripTitleHeading(html, 'Chapter 1')).toBe(html);
+  });
+
+  it('removes only the first heading, leaving later section headings in the body', () => {
+    const html = '<h1>The Title</h1><p>Intro.</p><h2>A Section</h2><p>More.</p>';
+    const out = stripHtml(stripTitleHeading(html, 'The Title'));
+    expect(out.startsWith('The Title')).toBe(false);
+    expect(out).toContain('A Section');
   });
 });
 

--- a/server/src/parsers/html-utils.ts
+++ b/server/src/parsers/html-utils.ts
@@ -79,6 +79,38 @@ export function extractFirstHeading(html: string): string | null {
   return raw;
 }
 
+/* Remove the chapter's leading title heading from its HTML body when that
+   heading's text is already represented in the resolved chapter title.
+
+   Why: `extractFirstHeading` promotes the first <h1-3> to the chapter title,
+   which synthesise-chapter speaks as a "title beat" before the body. But
+   `stripHtml` flattens the WHOLE document — including that heading — so the
+   same words also lead the body and get spoken a second time (the EPUB/MOBI
+   duplicate-chapter-name bug). Stripping that one element before stripHtml
+   leaves the title spoken exactly once.
+
+   Conservative by design: it strips ONLY when the resolved title contains the
+   heading text (whole-word, case/punctuation-insensitive). A heading carrying
+   content the title doesn't cover — e.g. NCX title "The Arrival" beside a body
+   <h1>"Part One: Beginnings"> — is left in the body so no prose is lost. */
+function normaliseForTitleMatch(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim();
+}
+
+export function stripTitleHeading(html: string, resolvedTitle: string): string {
+  const heading = extractFirstHeading(html);
+  if (!heading) return html;
+  const t = ` ${normaliseForTitleMatch(resolvedTitle)} `;
+  const h = ` ${normaliseForTitleMatch(heading)} `;
+  if (h.trim().length === 0 || !t.includes(h)) return html;
+  // FIRST_HEADING_RE is non-global, so this removes only the first heading —
+  // the same element extractFirstHeading just matched.
+  return html.replace(FIRST_HEADING_RE, '');
+}
+
 /* "Chapter 1" / "Chapter IV" / "Chapter Twelve" / "Capítulo 3" / "Глава 2" etc.
    with nothing else. Used to detect generic NCX titles that should be augmented
    with the body's <h1>. Mirrors the bare-numbered-heading test in text.ts but

--- a/server/src/parsers/mobi.test.ts
+++ b/server/src/parsers/mobi.test.ts
@@ -234,6 +234,19 @@ describe('parseMobi — chapters', () => {
     expect(out.chapters[0].title).toBe('Chapter 1 — The Berth at Liverpool');
   });
 
+  it('drops the body <h1> once it is promoted to the title (no duplicate-title audio)', async () => {
+    /* The <h1> is spoken by synthesise-chapter's title beat; without this guard
+       it ALSO leads the body, so the listener hears the chapter name twice. */
+    const buf = mobiBufferWithEncryption(0);
+    tocMock = [{ label: 'Chapter 1', href: 'c1' }];
+    chaptersMock = [
+      { id: 'c1', html: '<h1>The Berth at Liverpool</h1><p>It was a cold morning.</p>' },
+    ];
+    const out = await parseMobi(buf, { fileName: 'x.mobi' });
+    expect(out.chapters[0].title).toBe('Chapter 1 — The Berth at Liverpool');
+    expect(out.chapters[0].body).toBe('It was a cold morning.');
+  });
+
   it('falls back to "Chapter N" when neither TOC nor body heading is present', async () => {
     const buf = mobiBufferWithEncryption(0);
     chaptersMock = [{ id: 'c1', html: '<p>bare body</p>' }];

--- a/server/src/parsers/mobi.ts
+++ b/server/src/parsers/mobi.ts
@@ -22,7 +22,7 @@ import type { ChapterHint } from '../store/manuscripts.js';
 import type { ParsedManuscript } from './text.js';
 import { parseFilenameMetadata, parseSeriesFromTitle } from './text.js';
 import { tagExcitedDialog, tagHesitantDialog, tagShoutingDialog } from './audio-tags.js';
-import { stripHtml, extractFirstHeading, GENERIC_NCX_RE } from './html-utils.js';
+import { stripHtml, extractFirstHeading, stripTitleHeading, GENERIC_NCX_RE } from './html-utils.js';
 import { UnusableMediaError } from './errors.js';
 
 /* Thrown when the MOBI / AZW3 file is DRM-protected. Both upload routes map
@@ -138,8 +138,6 @@ export async function parseMobi(
       const chapter = parser.loadChapter(entry.id);
       const html = chapter?.html ?? '';
       if (!html.trim()) continue;
-      const body = tagHesitantDialog(tagExcitedDialog(tagShoutingDialog(stripHtml(html))));
-      if (!body) continue;
 
       /* Title resolution mirrors the EPUB parser:
          - TOC label is the primary source.
@@ -162,6 +160,12 @@ export async function parseMobi(
       } else {
         chTitle = tocTitle;
       }
+      // Drop the leading title heading so it isn't spoken twice (title beat +
+      // body opening line) — see {@link stripTitleHeading}.
+      const body = tagHesitantDialog(
+        tagExcitedDialog(tagShoutingDialog(stripHtml(stripTitleHeading(html, chTitle)))),
+      );
+      if (!body) continue;
       chapters.push({ id: chapters.length + 1, title: chTitle, body });
     }
 


### PR DESCRIPTION
## Summary

Fixes the chapter name being **spoken twice** at the top of generated audio for EPUB/MOBI books: once as the synthesised "title beat" and again as the body's opening line.

**Root cause:** for EPUB/MOBI chapters the same `<h1>/<h2>/<h3>` element is used twice — `extractFirstHeading(html)` promotes it to the chapter **title** (which `synthesise-chapter` speaks as a title beat), while `stripHtml(html)` flattens the whole document *including that heading* into the chapter **body**, so the heading text survives as the body's first line and is spoken again. Markdown/plaintext are unaffected (their parser consumes the heading line). Nothing downstream deduped it, so the duplicate also leaked into the script-review UI and the analyzer (the title got attributed as a body "sentence").

**Fix:** a shared `stripTitleHeading(html, resolvedTitle)` helper in `html-utils.ts` removes the leading heading element from the body **before** `stripHtml`, but only when the resolved title already contains the heading text (whole-word, case/punctuation-insensitive). A heading carrying content the title doesn't cover — e.g. NCX title `The Arrival` beside a body `<h1>Part One: Beginnings</h1>` — is left in the body so no prose is lost. Applied at all three HTML parse sites: epub2 path, epub raw-zip fallback, and MOBI. Fixing it at the parser means the audio, the on-screen script-review, and the analyzer all see the title only once.

## Test plan

- `server/src/parsers/html-utils.test.ts` — 8 new unit cases for `stripTitleHeading`: title equals heading, merged `Chapter N — Heading` form, case/hex-entity normalisation, divergent-heading no-op, within-word partial-match no-op, no-heading no-op, and "only the first heading removed, later section headings retained".
- `server/src/parsers/mobi.test.ts` — end-to-end: a chapter whose HTML is `<h1>The Berth at Liverpool</h1><p>…</p>` now yields a body that does not repeat the title.
- Full server suite green (3751 passed); full `npm run verify` (typecheck + all tests + e2e + build) green on push.

Localized bug fix — no regression-plan doc (issue + paired tests are the spec, per CONTRIBUTING).

Closes #1132