### PR TITLE
chore(frontend): fs-58 Unit B polish — excluded-line split/drag + minor cleanups

### DIFF
--- a/docs/superpowers/plans/2026-06-25-fs58-unit-b-polish.md
+++ b/docs/superpowers/plans/2026-06-25-fs58-unit-b-polish.md
@@ -1,0 +1,656 @@
+# fs-58 Unit B polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the four deferred fs-58 Unit B polish items in #1122 — disable split/drag edit affordances on excluded lines, surface a toast on a failed character-create, harden the reattribute-to-existing test, and drop two trivia (button `type`, dead param).
+
+**Architecture:** Pure-frontend chore. Item 1 gates two existing manuscript edit affordances behind an `excludeFromSynthesis` check (one extracted pure predicate + two call-site guards) and is verified by a new Playwright e2e because jsdom can't drive `getSelection`/`elementFromPoint`. Items 2–4 are localized component/lib changes with colocated Vitest tests.
+
+**Tech Stack:** Vite + React 18 + TypeScript, Redux Toolkit, Vitest + React Testing Library (jsdom), Playwright (chromium).
+
+**Spec:** `docs/superpowers/specs/2026-06-25-fs58-unit-b-polish-design.md`
+
+## Global Constraints
+
+- Branch: `chore/frontend-fs58-unit-b-polish` (already cut from `main`; spec committed on it).
+- No analyzer, server, or OpenAPI-contract changes — frontend only.
+- Toast API: `notificationsActions.pushToast({ kind: 'error' | 'warn', message: string, dedupeKey?: string })` from `src/store/notifications-slice.ts`.
+- Commit subjects MUST match `<type>(<scope>): <subject>` (scope `frontend`); the commit-msg hook rejects otherwise.
+- Tests colocate next to the unit (`*.test.ts(x)`); e2e under `e2e/`.
+- `pre-commit` runs `verify:fast:scoped` (skips out-of-scope legs). Do NOT use `--no-verify`.
+- Each task ends green and is committed before the next starts.
+
+---
+
+### Task 1: CreateCharacterForm — explicit button `type` + reattribute-vs-create test
+
+Covers Item 2 (reattribute-to-existing test) and Item 4a (`type="button"`).
+
+**Files:**
+- Modify: `src/components/create-character-form.tsx` (the two `<button>`s in the action row)
+- Test: `src/components/create-character-form.test.tsx`
+
+**Interfaces:**
+- Consumes: `CreateCharacterForm({ initial?, rosterByName, onSubmit, onReattributeExisting?, onCancel })` (existing, unchanged).
+- Produces: nothing new — behaviour-preserving plus explicit `type="button"` on both buttons.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/components/create-character-form.test.tsx`:
+
+```tsx
+it('routes a roster-name match to onReattributeExisting and never onSubmit', () => {
+  const onSubmit = vi.fn();
+  const onReattributeExisting = vi.fn();
+  render(
+    <CreateCharacterForm
+      initial={{ name: 'Halloran' }}
+      rosterByName={new Map([['halloran', { id: 'halloran', name: 'Halloran' }]])}
+      onSubmit={onSubmit}
+      onReattributeExisting={onReattributeExisting}
+      onCancel={() => {}}
+    />,
+  );
+  const submit = screen.getByTestId('create-character-submit');
+  expect(submit).toHaveTextContent(/Reattribute to «Halloran»/);
+  fireEvent.click(submit);
+  expect(onReattributeExisting).toHaveBeenCalledWith('halloran');
+  expect(onSubmit).not.toHaveBeenCalled();
+});
+
+it('routes a novel name to onSubmit and never onReattributeExisting', () => {
+  const onSubmit = vi.fn();
+  const onReattributeExisting = vi.fn();
+  render(
+    <CreateCharacterForm
+      rosterByName={new Map([['halloran', { id: 'halloran', name: 'Halloran' }]])}
+      onSubmit={onSubmit}
+      onReattributeExisting={onReattributeExisting}
+      onCancel={() => {}}
+    />,
+  );
+  fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Ferra' } });
+  const submit = screen.getByTestId('create-character-submit');
+  expect(submit).toHaveTextContent('Create character');
+  fireEvent.click(submit);
+  expect(onSubmit).toHaveBeenCalledWith({ name: 'Ferra', gender: undefined, ageRange: undefined });
+  expect(onReattributeExisting).not.toHaveBeenCalled();
+});
+
+it('gives both action buttons an explicit type="button"', () => {
+  render(<CreateCharacterForm rosterByName={new Map()} onSubmit={() => {}} onCancel={() => {}} />);
+  expect(screen.getByTestId('create-character-submit')).toHaveAttribute('type', 'button');
+  expect(screen.getByRole('button', { name: /cancel/i })).toHaveAttribute('type', 'button');
+});
+```
+
+- [ ] **Step 2: Run the tests to verify the new ones' state**
+
+Run: `npm run test -- src/components/create-character-form.test.tsx`
+Expected: the two routing tests PASS (existing behaviour); the `type="button"` test FAILS (`expected attribute type to equal "button"` — buttons have no `type` today).
+
+- [ ] **Step 3: Add `type="button"` to both buttons**
+
+In `src/components/create-character-form.tsx`, the submit button:
+
+```tsx
+        <button
+          type="button"
+          data-testid="create-character-submit"
+          disabled={disabled}
+```
+
+and the cancel button:
+
+```tsx
+        <button type="button" onClick={onCancel} className="px-4 min-h-[44px] sm:min-h-0 text-sm text-ink/50">
+          Cancel
+        </button>
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm run test -- src/components/create-character-form.test.tsx`
+Expected: PASS (all, including `type="button"`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/create-character-form.tsx src/components/create-character-form.test.tsx
+git commit -m "chore(frontend): explicit button type + reattribute-branch test for CreateCharacterForm (#1122)"
+```
+
+---
+
+### Task 2: Drop the dead `_roster` param from `dispatchAcceptedOps`
+
+Covers Item 4b. Pure refactor — guarded by `typecheck` + existing suites (no new behaviour to test).
+
+**Files:**
+- Modify: `src/lib/script-review-apply.ts` (`dispatchAcceptedOps` signature)
+- Modify: `src/components/script-review-diff.tsx` (the call site that passes `roster` as the 5th arg)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `dispatchAcceptedOps(dispatch, accepted, live, { onBoundaryMove })` — 4 params (was 5). `planApply(ops, live, roster)` is UNCHANGED (its `roster` is used).
+
+- [ ] **Step 1: Remove the unused param from the signature**
+
+In `src/lib/script-review-apply.ts`, change:
+
+```ts
+export function dispatchAcceptedOps(
+  dispatch: Dispatch,
+  accepted: ReviewOp[],
+  live: Array<{ id: number; chapterId: number; text: string; characterId: string; instruct?: string; vocalization?: boolean }>,
+  { onBoundaryMove }: { onBoundaryMove: (chapterId: number) => void },
+  _roster: Set<string> = new Set(),
+): void {
+```
+
+to:
+
+```ts
+export function dispatchAcceptedOps(
+  dispatch: Dispatch,
+  accepted: ReviewOp[],
+  live: Array<{ id: number; chapterId: number; text: string; characterId: string; instruct?: string; vocalization?: boolean }>,
+  { onBoundaryMove }: { onBoundaryMove: (chapterId: number) => void },
+): void {
+```
+
+- [ ] **Step 2: Remove the 5th argument at the call site**
+
+In `src/components/script-review-diff.tsx`, find the `dispatchAcceptedOps(...)` call (it passes `roster` as the final argument) and delete that final `roster,` argument line. The remaining call passes `dispatch, directOps (or appliable), live, { onBoundaryMove: ... }`. Leave the local `roster` set in place — it is still passed to `planApply(...)`.
+
+- [ ] **Step 3: Verify typecheck + existing tests are green**
+
+Run: `npm run typecheck`
+Expected: PASS (no "expected 5 arguments" / unused-symbol errors).
+
+Run: `npm run test -- src/lib/script-review-apply.test.ts src/components/script-review-diff.test.tsx`
+Expected: PASS (no behaviour change).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/script-review-apply.ts src/components/script-review-diff.tsx
+git commit -m "refactor(frontend): drop unused _roster param from dispatchAcceptedOps (#1122)"
+```
+
+---
+
+### Task 3: Toast + keep-open on a failed sidebar character-create
+
+Covers Item 3a. On a rejected `api.createCharacter`, the form already stays open (the throw skips `setAddingChar(false)`), but the rejection is unhandled and there is no error surface.
+
+**Files:**
+- Modify: `src/views/manuscript.tsx` (`handleCreateCharacter`; the `CreateCharacterForm` `onSubmit` in `SidebarPanels`)
+- Test: `src/views/manuscript.test.tsx`
+
+**Interfaces:**
+- Consumes: `notificationsActions.pushToast` (already imported at `manuscript.tsx:46`), the `createCharacter` api mock (already wired at `manuscript.test.tsx:34-38`), `notificationsSlice` (already imported in the test file).
+- Produces: `handleCreateCharacter` rejects on failure AFTER dispatching an error toast; the sidebar `onSubmit` closes the form only on success.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `describe('ManuscriptView — Add character button ...')` block in `src/views/manuscript.test.tsx`. It needs the `notifications` reducer, which the existing `renderAddCharView` store omits — add a local store that includes it:
+
+```tsx
+it('on a failed create: shows an error toast and keeps the form open (#1122)', async () => {
+  const user = userEvent.setup();
+  createCharacter.mockReset();
+  createCharacter.mockRejectedValue(new Error('boom'));
+
+  const store = configureStore({
+    reducer: {
+      manuscript: manuscriptSlice.reducer,
+      changeLog: changeLogSlice.reducer,
+      ui: uiSlice.reducer,
+      bookMeta: bookMetaSlice.reducer,
+      cast: castSlice.reducer,
+      notifications: notificationsSlice.reducer,
+    },
+    preloadedState: {
+      ui: {
+        ...uiSlice.getInitialState(),
+        stage: { kind: 'ready', bookId: 'bk-addchar', view: 'manuscript', currentChapterId: 1, openProfileId: null } as never,
+      },
+      cast: { characters: [{ id: 'narrator', name: 'Narrator', role: 'Narrator', color: 'narrator' }], renderedFallbackByCharacter: {} },
+    },
+  });
+
+  render(
+    <Provider store={store}>
+      <ManuscriptView
+        characters={[{ id: 'narrator', name: 'Narrator', role: 'Narrator', color: 'narrator' }]}
+        chapters={[{ id: 1, title: 'Chapter One', duration: '10:00', state: 'done', progress: 1, characters: { narrator: 'done' } }]}
+        currentChapterId={1}
+        setCurrentChapterId={() => {}}
+        sentencesFromStore={[]}
+      />
+    </Provider>,
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /add character/i }));
+  fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Ferra' } });
+  await user.click(screen.getByTestId('create-character-submit'));
+
+  // Error toast surfaced.
+  await waitFor(() => {
+    const toasts: Toast[] = store.getState().notifications.toasts;
+    expect(toasts.some((t) => t.kind === 'error' && /create character/i.test(t.message))).toBe(true);
+  });
+  // Form still open for retry.
+  expect(screen.getByTestId('create-character-form')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test -- src/views/manuscript.test.tsx -t "failed create"`
+Expected: FAIL — no error toast is dispatched (and an unhandled rejection may be logged).
+
+- [ ] **Step 3: Wrap the handler and the parent onSubmit**
+
+In `src/views/manuscript.tsx`, change `handleCreateCharacter`:
+
+```tsx
+  const handleCreateCharacter = useCallback(
+    async (fields: { name: string; gender?: string; ageRange?: string }) => {
+      if (!bookId) return;
+      try {
+        const result = await api.createCharacter(bookId, fields as Parameters<typeof api.createCharacter>[1]);
+        dispatch(castActions.addCharacter(result.character));
+      } catch (err) {
+        dispatch(
+          notificationsActions.pushToast({
+            kind: 'error',
+            message: "Couldn't create character",
+            dedupeKey: 'create-character',
+          }),
+        );
+        throw err;
+      }
+    },
+    [bookId, dispatch],
+  );
+```
+
+and the sidebar form's `onSubmit` (in `SidebarPanels`) — close only on success, swallow the re-thrown error so there is no unhandled rejection:
+
+```tsx
+                onSubmit={async (f) => {
+                  try {
+                    await onCreateCharacter(f);
+                    setAddingChar(false);
+                  } catch {
+                    /* handler already surfaced a toast; keep the form open for retry */
+                  }
+                }}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm run test -- src/views/manuscript.test.tsx -t "failed create"`
+Expected: PASS. Also re-run the existing happy-path: `npm run test -- src/views/manuscript.test.tsx -t "Add character"` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/views/manuscript.tsx src/views/manuscript.test.tsx
+git commit -m "fix(frontend): toast + keep-open on failed sidebar character-create (#1122)"
+```
+
+---
+
+### Task 4: Toast + clean reset on a failed off-roster reattribute batch
+
+Covers Item 3b. On a rejected `api.createCharacter` inside `runProposed`, the confirm machine never resets and the review bucket is never cleared, wedging the modal.
+
+**Files:**
+- Modify: `src/components/script-review-diff.tsx` (`runProposed`; add `notificationsActions` import)
+- Test: `src/components/script-review-diff.test.tsx`
+
+**Interfaces:**
+- Consumes: `notificationsActions.pushToast`; the existing `makeProposedStore` + `createSpy` harness in the test file.
+- Produces: `runProposed` catches a create failure, pushes an error toast, calls `setConfirm(null)`, and leaves the review bucket (no `clearReview`) so the operator can re-trigger. Re-run is safe because `setSentenceCharacter` is idempotent.
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/components/script-review-diff.test.tsx`, add the `notifications` reducer to `makeProposedStore` (add `notifications: notificationsSlice.reducer` to its `reducer` map and `import { notificationsSlice, type Toast } from '../store/notifications-slice';` at the top). Then add, inside the off-roster `describe`:
+
+```tsx
+it('a failed create surfaces a toast, closes the confirm dialog, and keeps the review for retry (#1122)', async () => {
+  createSpy.mockRejectedValueOnce(new Error('boom'));
+  const store = makeProposedStore(
+    [{ id: 5, chapterId: 1, proposed: { name: 'Ferra' } }],
+    [{ id: 5, chapterId: 1, text: 'Line five.', characterId: 'narr' }],
+  );
+  render(
+    <Provider store={store}>
+      <ScriptReviewDiff bookId="book-A" />
+    </Provider>,
+  );
+
+  fireEvent.click(screen.getByTestId('apply-button'));
+  expect(screen.getByTestId('confirm-reattribute')).toBeInTheDocument();
+  fireEvent.click(screen.getByTestId('create-character-submit'));
+
+  // Error toast surfaced.
+  await waitFor(() => {
+    const toasts: Toast[] = store.getState().notifications.toasts;
+    expect(toasts.some((t) => t.kind === 'error' && /create character/i.test(t.message))).toBe(true);
+  });
+  // Confirm dialog closed.
+  expect(screen.queryByTestId('confirm-reattribute')).toBeNull();
+  // Review bucket retained for retry (NOT cleared).
+  expect(store.getState().scriptReview.byBook['book-A']).toBeDefined();
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test -- src/components/script-review-diff.test.tsx -t "failed create"`
+Expected: FAIL — no toast; the confirm dialog state is left inconsistent.
+
+- [ ] **Step 3: Wrap `runProposed`**
+
+Add the import at the top of `src/components/script-review-diff.tsx`:
+
+```tsx
+import { notificationsActions } from '../store/notifications-slice';
+```
+
+Wrap the `applyProposedReattributions` await in `runProposed`. Replace:
+
+```tsx
+  async function runProposed(finalized: FinalizedProposed[], startBookId: string) {
+    const rosterByName = new Map(cast.map((c) => [c.name.trim().toLowerCase(), { id: c.id }]));
+    await applyProposedReattributions(finalized, {
+      // ...deps unchanged...
+    });
+    setConfirm(null);
+    dispatch(scriptReviewActions.clearReview({ bookId: startBookId }));
+  }
+```
+
+with:
+
+```tsx
+  async function runProposed(finalized: FinalizedProposed[], startBookId: string) {
+    const rosterByName = new Map(cast.map((c) => [c.name.trim().toLowerCase(), { id: c.id }]));
+    try {
+      await applyProposedReattributions(finalized, {
+        // ...deps unchanged...
+      });
+    } catch {
+      // A create failed mid-batch. Reset the confirm machine and surface a toast,
+      // but DON'T clearReview — the operator can re-trigger. Re-run is safe because
+      // setSentenceCharacter is idempotent for an already-applied reattribute.
+      setConfirm(null);
+      dispatch(
+        notificationsActions.pushToast({
+          kind: 'error',
+          message: "Couldn't create character",
+          dedupeKey: 'create-character',
+        }),
+      );
+      return;
+    }
+    setConfirm(null);
+    dispatch(scriptReviewActions.clearReview({ bookId: startBookId }));
+  }
+```
+
+(Keep the existing `deps` object body of `applyProposedReattributions` exactly as-is inside the `try`.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm run test -- src/components/script-review-diff.test.tsx -t "failed create"`
+Expected: PASS. Re-run the dedupe/cancel tests: `npm run test -- src/components/script-review-diff.test.tsx` → PASS (success path still clears the review).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/script-review-diff.tsx src/components/script-review-diff.test.tsx
+git commit -m "fix(frontend): toast + clean reset on a failed off-roster reattribute batch (#1122)"
+```
+
+---
+
+### Task 5: Disable split + drag affordances on excluded lines
+
+Covers Item 1. Extract a pure predicate (unit-tested), wire two call-site guards, and prove the user-facing behaviour with a Playwright e2e (jsdom can't drive `getSelection`/`elementFromPoint`).
+
+**Files:**
+- Modify: `src/views/manuscript.tsx` (export `isExcludedSentenceId`; gate `<SelectionPopover>`; guard `assignSelectionTo`; guard the boundary-drag `onMove`; remove the `follow-up:` comment)
+- Test: `src/views/manuscript.test.tsx` (predicate unit test)
+- Create: `e2e/manuscript-excluded-line-noedit.spec.ts`
+
+**Interfaces:**
+- Consumes: the current-chapter `sentences` array and `currentChapterId` (both already in scope in the component body), `selection` from `useSentenceSelection`.
+- Produces: `export function isExcludedSentenceId(sentences, chapterId, sentenceId): boolean`.
+
+- [ ] **Step 1: Write the failing predicate unit test**
+
+Append to `src/views/manuscript.test.tsx` (add `isExcludedSentenceId` to the existing `import { ManuscriptView } from './manuscript';` → `import { ManuscriptView, isExcludedSentenceId } from './manuscript';`):
+
+```tsx
+describe('isExcludedSentenceId', () => {
+  const rows = [
+    { chapterId: 1, id: 1, excludeFromSynthesis: true },
+    { chapterId: 1, id: 2 },
+    { chapterId: 2, id: 1 }, // same id, different chapter, NOT excluded
+  ];
+  it('is true for an excluded sentence', () => {
+    expect(isExcludedSentenceId(rows, 1, 1)).toBe(true);
+  });
+  it('is false for a non-excluded sentence', () => {
+    expect(isExcludedSentenceId(rows, 1, 2)).toBe(false);
+  });
+  it('is scoped by chapter (no cross-chapter id collision)', () => {
+    expect(isExcludedSentenceId(rows, 2, 1)).toBe(false);
+  });
+  it('is false when the sentence is not found', () => {
+    expect(isExcludedSentenceId(rows, 9, 9)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test -- src/views/manuscript.test.tsx -t isExcludedSentenceId`
+Expected: FAIL — `isExcludedSentenceId is not a function` / import error.
+
+- [ ] **Step 3: Add the predicate**
+
+In `src/views/manuscript.tsx`, near the other module-scope helpers (e.g. just above `function renderSentenceText`):
+
+```tsx
+/* fs-58 Unit B — a sentence excluded from synthesis offers no split/reassign
+   affordance (it won't be rendered either way). Scoped by chapter because
+   sentence ids restart per chapter. */
+export function isExcludedSentenceId(
+  sentences: ReadonlyArray<{ chapterId: number; id: number; excludeFromSynthesis?: boolean }>,
+  chapterId: number,
+  sentenceId: number,
+): boolean {
+  return Boolean(
+    sentences.find((s) => s.chapterId === chapterId && s.id === sentenceId)?.excludeFromSynthesis,
+  );
+}
+```
+
+- [ ] **Step 4: Run to verify the predicate test passes**
+
+Run: `npm run test -- src/views/manuscript.test.tsx -t isExcludedSentenceId`
+Expected: PASS.
+
+- [ ] **Step 5: Wire the popover gate**
+
+In `src/views/manuscript.tsx`, the `<SelectionPopover sel={selection} ... />` render. Change `sel` to suppress on an excluded line:
+
+```tsx
+      <SelectionPopover
+        sel={
+          selection &&
+          currentChapterId != null &&
+          isExcludedSentenceId(sentences, currentChapterId, selection.sentenceId)
+            ? null
+            : selection
+        }
+        characters={characters}
+        onAssign={assignSelectionTo}
+      />
+```
+
+- [ ] **Step 6: Guard `assignSelectionTo` (belt-and-suspenders)**
+
+In `assignSelectionTo`, broaden the early return:
+
+```tsx
+    const sentence = sentences.find(
+      (s) => s.chapterId === currentChapterId && s.id === selection.sentenceId,
+    );
+    if (!sentence || sentence.excludeFromSynthesis) return;
+```
+
+- [ ] **Step 7: Guard the boundary-drag `onMove`**
+
+In the `onMove` handler inside the drag `useEffect`, skip an excluded sentence as a drop candidate:
+
+```tsx
+    const onMove = (e: globalThis.PointerEvent) => {
+      const el = document.elementFromPoint(e.clientX, e.clientY) as HTMLElement | null;
+      const sentenceEl = el?.closest?.('[data-sentence-idx]') as HTMLElement | null;
+      if (sentenceEl) {
+        const idx = Number(sentenceEl.dataset.sentenceIdx);
+        if (sentences[idx]?.excludeFromSynthesis) return; // fs-58 Unit B — excluded line isn't a drop target
+        setDrag((d) =>
+          d && d.candidateSentenceIdx !== idx ? { ...d, candidateSentenceIdx: idx } : d,
+        );
+      }
+    };
+```
+
+- [ ] **Step 8: Remove the resolved follow-up comment**
+
+Delete the line `follow-up: disable split/drag affordance on excluded lines.` from the excluded-line comment block (keep the rest of that comment describing the re-include toggle).
+
+- [ ] **Step 9: Run the full manuscript unit suite + typecheck**
+
+Run: `npm run test -- src/views/manuscript.test.tsx`
+Expected: PASS (predicate test + all pre-existing).
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 10: Write the e2e spec**
+
+Create `e2e/manuscript-excluded-line-noedit.spec.ts`. It marks a sentence excluded via the exposed store, then asserts the selection popover is suppressed (with a non-excluded positive control). The selection targets the INNER `[data-text-offset]` text node — that is what `useSentenceSelection` reads.
+
+```ts
+/* fs-58 Unit B (#1122) — an excluded (flag_nonstory) line offers no split/
+ * reassign affordance. jsdom can't drive getSelection/elementFromPoint, so the
+ * gate is proven here. */
+import { test, expect } from '@playwright/test';
+
+type Store = { dispatch: (a: unknown) => void };
+
+async function selectSentenceText(page: import('@playwright/test').Page, sentenceId: number) {
+  await page.evaluate((id) => {
+    const inner = document.querySelector(`[data-sentence-id="${id}"] [data-text-offset]`);
+    const textNode = inner?.firstChild;
+    if (!textNode) throw new Error(`no text node for sentence ${id}`);
+    const range = document.createRange();
+    range.setStart(textNode, 0);
+    range.setEnd(textNode, (textNode as Text).length);
+    const sel = window.getSelection()!;
+    sel.removeAllRanges();
+    sel.addRange(range);
+    document.dispatchEvent(new Event('selectionchange'));
+  }, sentenceId);
+}
+
+test.describe('fs-58 Unit B — excluded line: no edit affordance', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('no selection popover on an excluded line; present on a normal line', async ({ page }) => {
+    await page.goto('/#/books/sb/manuscript');
+    await expect(page.getByRole('heading', { name: /^Chapter \d+/i, level: 1 })).toBeVisible({ timeout: 10_000 });
+
+    // Mark sentence id:1 in the current chapter (3) excluded via the store.
+    await page.evaluate(() => {
+      const store = (window as unknown as { __store__: Store }).__store__;
+      store.dispatch({ type: 'manuscript/setSentenceExcluded', payload: { chapterId: 3, sentenceId: 1, excluded: true } });
+    });
+    await expect(page.locator('[data-sentence-id="1"]').first()).toHaveClass(/line-through/);
+
+    // (a) Selecting the excluded line shows NO popover.
+    await selectSentenceText(page, 1);
+    await expect(page.getByText('Assign selection to')).toHaveCount(0);
+
+    // Positive control: a normal line (id:3 is a seeded ch3 sentence) DOES show it.
+    await selectSentenceText(page, 3);
+    await expect(page.getByText('Assign selection to')).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 11: Run the e2e and verify it passes**
+
+Run: `npm run test:e2e -- manuscript-excluded-line-noedit`
+Expected: PASS. If the positive control can't find a normal sentence at id:3, inspect the seeded ch3 sentences (`window.__store__.getState().manuscript.sentences`) in headed mode (`--headed --debug`) and pick a present non-excluded id. The drag-candidate half is NOT scripted here (real boundary-drag negative assertions are flaky); it is covered by the predicate unit test (Step 1) plus manual acceptance — see the spec's Testing section.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add src/views/manuscript.tsx src/views/manuscript.test.tsx e2e/manuscript-excluded-line-noedit.spec.ts
+git commit -m "fix(frontend): no split/drag affordance on excluded manuscript lines (#1122)"
+```
+
+---
+
+### Task 6: Docs, full verify, and ship
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-25-fs58-unit-b-polish-design.md` (status + Ship notes)
+- Modify: the fs-58 regression plan/feature doc (note the polish items closed) and `docs/features/INDEX.md` if a row needs updating
+- Modify: `docs/BACKLOG.md` only if #1122 has a row (it is a `type:chore`; confirm before editing)
+
+- [ ] **Step 1: Run the full pre-push battery**
+
+Run: `npm run verify`
+Expected: typecheck + all unit suites + e2e + build all green (e2e includes the new spec).
+
+- [ ] **Step 2: Update the spec status + Ship notes**
+
+Set frontmatter `status: stable` and fill the **Ship notes** section with the date (2026-06-25) and the squash/merge SHA once known. If the fs-58 plan under `docs/features/` references Unit B follow-ups, add a one-line "polish items #1122 closed" note there.
+
+- [ ] **Step 3: Commit docs**
+
+```bash
+git add docs/
+git commit -m "docs(docs): mark fs-58 Unit B polish shipped (#1122)"
+```
+
+- [ ] **Step 4: Open the PR**
+
+Push and open a PR titled `chore(frontend): fs-58 Unit B polish — excluded-line split/drag + minor cleanups`. Body: enumerate the four items as a mini-release-note, link the spec, and put `Closes #1122` in the body. CI is opt-in — add the `run-ci` label if a clean-room cloud check is wanted before merge.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Item 1 (split + drag disable) → Task 5 (predicate + popover gate + assignSelectionTo guard + onMove guard + e2e). ✓
+- Item 2 (reattribute-to-existing test) → Task 1 (routing tests). ✓
+- Item 3 (catch + toast, both create flows) → Task 3 (sidebar) + Task 4 (script-review batch). ✓
+- Item 4 (`type="button"` + drop `_roster`) → Task 1 (buttons) + Task 2 (param). ✓
+- Spec "extract a pure predicate" + "new Playwright e2e" + "predicate unit test" → Task 5. ✓
+- Spec idempotency note for partial failure → Task 4 Step 3 comment. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows the exact code. The only deferred detail is the e2e positive-control sentence id, which carries a concrete fallback procedure (Step 11), not a placeholder.
+
+**Type consistency:** `isExcludedSentenceId(sentences, chapterId, sentenceId): boolean` is defined in Task 5 Step 3 and consumed identically in Step 5 and the Task 5 Step 1 test. `notificationsActions.pushToast({ kind, message, dedupeKey })` is used identically in Tasks 3 and 4. `dispatchAcceptedOps` drops to 4 params consistently across signature (Task 2 Step 1) and call site (Step 2).

--- a/docs/superpowers/plans/2026-06-25-fs58-unit-b-polish.md
+++ b/docs/superpowers/plans/2026-06-25-fs58-unit-b-polish.md
@@ -352,7 +352,7 @@ it('a failed create surfaces a toast, closes the confirm dialog, and keeps the r
 - [ ] **Step 2: Run the test to verify it fails**
 
 Run: `npm run test -- src/components/script-review-diff.test.tsx -t "failed create"`
-Expected: FAIL — no toast; the confirm dialog state is left inconsistent.
+Expected: FAIL — the **toast** assertion is the discriminator (no error toast is dispatched pre-fix). Note: the other two assertions are NOT discriminating — the confirm dialog closes on its own once the queue is exhausted (`confirmOp` becomes null regardless of `runProposed`), and the review bucket is retained pre-fix too (the throw skips `clearReview`). They pin the desired end-state; only the toast proves the fix.
 
 - [ ] **Step 3: Wrap `runProposed`**
 

--- a/docs/superpowers/specs/2026-06-25-fs58-unit-b-polish-design.md
+++ b/docs/superpowers/specs/2026-06-25-fs58-unit-b-polish-design.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: stable
 issue: 1122
 area: fs
 type: chore
@@ -213,4 +213,13 @@ softened rationale for the `assignSelectionTo` belt-and-suspenders guard.
 
 ## Ship notes
 
-_(filled at ship time: date, commit SHA; close #1122.)_
+Shipped 2026-06-25 via the fs-58 Unit B polish branch (`chore/frontend-fs58-unit-b-polish`), Closes #1122.
+
+Five code commits (`26d1fff7..6ba895fd`):
+- `26d1fff7` chore — `type="button"` on CreateCharacterForm + reattribute-vs-create routing tests (Items 4a, 2)
+- `a2ce8e9e` refactor — drop unused `_roster` param from `dispatchAcceptedOps` (Item 4b)
+- `cd42a67c` fix — toast + keep-open on a failed sidebar character-create (Item 3a)
+- `fe433a40` fix — toast + clean reset on a failed off-roster reattribute batch (Item 3b)
+- `6ba895fd` fix — no split/drag affordance on excluded manuscript lines: `isExcludedSentenceId` predicate + popover/assignSelectionTo/onMove gates + Playwright e2e (Item 1)
+
+Built via subagent-driven development (implementer + per-task review each, opus whole-branch review: 0 Critical/Important). Spec + plan each passed one adversarial review round before execution. Deferred cosmetic test-clarity Minors (zero-risk): tighten the toast-assert regex; a non-discriminating-assertion comment in the script-review batch test; `isExcludedSentenceId` placement; e2e `toHaveCount(0)` vs `not.toBeVisible()`.

--- a/docs/superpowers/specs/2026-06-25-fs58-unit-b-polish-design.md
+++ b/docs/superpowers/specs/2026-06-25-fs58-unit-b-polish-design.md
@@ -48,8 +48,10 @@ or splits it into pieces (`assignSelectionTo`). Gate at two points:
   chapter's `sentences[]` (the same per-chapter scoping `assignSelectionTo`
   already uses, because sentence ids restart per chapter).
 - Belt-and-suspenders: early-return in `assignSelectionTo` if the resolved
-  sentence is excluded, so a stale selection captured before exclusion can't
-  split.
+  sentence is excluded, so a selection captured before exclusion can't split.
+  (This race is near-unreachable today — a line can only be excluded via the
+  script-review `flag_nonstory` op, not an inline control — so the guard is
+  cheap insurance, not a load-bearing path.)
 
 **(b) Boundary drag.** Dragging a boundary handle highlights a *candidate*
 sentence (`candidateSentenceIdx`) and, on drop, reassigns a contiguous run of
@@ -88,22 +90,46 @@ add an explicit case:
 
 Files: `src/views/manuscript.tsx`, `src/components/script-review-diff.tsx`.
 
-Two create flows `await api.createCharacter` with no `catch`, so a failed
-`POST /cast/create` rejects unhandled — the form/confirm UI is left mid-flow
-with no error surface:
+Two create flows `await api.createCharacter` with no `catch`. The exact current
+behaviour (verified against source, correcting the original spec draft):
 
-- `handleCreateCharacter` (`manuscript.tsx`) — the sidebar "create character"
-  path. Wrap the `await` in `try/catch`; on failure dispatch
-  `notificationsActions.pushToast({ kind: 'error', message: "Couldn't create character", dedupeKey: 'create-character' })`.
-  Keep the form open for retry (do not advance/close on failure).
-- `runProposed` (`script-review-diff.tsx`) — the off-roster reattribute confirm
-  batch runs `applyProposedReattributions`, which calls `api.createCharacter`
-  internally. Wrap the `await`; on failure push the same error toast. Only
-  clear `confirm` / the review bucket on success.
+**(a) Sidebar "Add character" form (`manuscript.tsx`).** The form's `onSubmit`
+is `async (f) => { await onCreateCharacter(f); setAddingChar(false); }`
+(line ~1263), where `onCreateCharacter` is `handleCreateCharacter` (line ~597),
+which `await`s `api.createCharacter`. On rejection the `await` throws, so
+`setAddingChar(false)` is **skipped** — the form already stays open — but the
+async `onSubmit` promise rejects **unhandled** and the user gets **no error
+surface**. Fix:
+
+- In `handleCreateCharacter`, wrap the `await` in `try/catch`; on failure
+  dispatch
+  `notificationsActions.pushToast({ kind: 'error', message: "Couldn't create character", dedupeKey: 'create-character' })`
+  and **re-throw**.
+- In the parent `onSubmit` (line ~1263), wrap in `try/catch`: call
+  `setAddingChar(false)` **only** on success; on the re-thrown error do nothing
+  (form stays open for retry, no unhandled rejection).
+
+This split is deliberate: the close decision lives in the parent (`setAddingChar`),
+so the catch that *suppresses* the rejection must also live there, while the
+toast lives in the handler that knows the API failed.
+
+**(b) Script-review off-roster confirm batch (`script-review-diff.tsx`).**
+`runProposed` (line ~189) calls `applyProposedReattributions`, which calls
+`api.createCharacter` internally. On rejection mid-batch the error propagates,
+so `setConfirm(null)` and `clearReview` (line ~207-208) never run — the confirm
+machinery is left wedged. Fix: wrap the `await applyProposedReattributions(...)`
+in `try/catch`; on failure push the same error toast and call `setConfirm(null)`
+to reset the per-op confirm machine, but **do not** `clearReview` — leaving the
+review bucket lets the operator re-trigger. Partial application is safe to
+re-run: `setSentenceCharacter` is idempotent for an already-applied
+chapter/sentence/character (a reattribute applied before the failing
+`createCharacter` simply re-applies to the same value on retry). Add a one-line
+comment noting this idempotency reliance.
 
 The toast API is the existing `notificationsActions.pushToast` from
-`src/store/notifications-slice.ts` (same pattern as `book-library.tsx`'s
-export-failure toast). Paired tests assert the toast dispatch against a mocked
+`src/store/notifications-slice.ts` (signature `{ kind, message, dedupeKey? }`;
+same pattern as `book-library.tsx`'s export-failure toast). Paired tests assert
+the toast dispatch — and, for (a), that the form stays open — against a mocked
 `api.createCharacter` rejection.
 
 ### Item 4 — Trivia
@@ -121,18 +147,35 @@ export-failure toast). Paired tests assert the toast dispatch against a mocked
 
 - No change to exclusion semantics, the synth filter, or the `flag_nonstory`
   op itself.
-- No new e2e spec — all four items are unit-testable, and the existing
-  `e2e/script-review.spec.ts` already covers the confirm flow end to end.
+- No new error-recovery beyond a toast + keep-open (no automatic retry, no
+  rollback of partially-applied reattributes — idempotent re-run covers it).
 - Items #1119 (fs-63 auto-voice), #1120 (fs-64 cross-chapter context), and
   #1121 (hydrate-merge bug) are tracked separately and out of scope here.
 
 ## Testing
 
-- **Item 1:** Vitest component test on `manuscript.tsx` — an excluded sentence
-  yields no `SelectionPopover` for a selection within it, and the
-  `pointermove` candidate detection skips it. (jsdom can drive the selection /
-  pointer paths the existing manuscript tests already exercise.)
-- **Item 2 / Item 3:** Vitest component tests as described above.
+**Item 1 cannot be unit-tested in jsdom** — both gates depend on
+`window.getSelection()` / `range.getBoundingClientRect()` (popover) and
+`document.elementFromPoint()` (drag), none of which jsdom implements, and no
+existing e2e drives the selection-popover or boundary-drag paths. So:
+
+- **Extract the gate decision into a pure predicate** (e.g.
+  `isExcludedSentence(sentences, chapterId, sentenceId)` in a small helper, or
+  reuse the existing lookup) and **unit-test the predicate** — cheap, real
+  coverage of the decision logic, independent of the DOM.
+- **New Playwright e2e** (`e2e/manuscript-excluded-line-noedit.spec.ts`): on a
+  manuscript with an excluded line, (a) selecting that line's text shows **no**
+  "Assign selection to" popover (a normal line still does — positive control),
+  and (b) dragging a boundary handle over the excluded line never adds the
+  `sentence-candidate` class to it (a normal line does). Getting an excluded
+  line in e2e: prefer seeding a mock manuscript fixture with one
+  `excludeFromSynthesis` sentence; fall back to driving the script-review
+  `flag_nonstory` flow if no fixture seam exists. If the drag-negative
+  assertion proves flaky, keep the selection-popover e2e + predicate unit test
+  and document the drag half as manual acceptance (explicitly, per the
+  before-shipping checklist) rather than shipping a flaky spec.
+- **Item 2 / Item 3:** Vitest component tests as described above (Item 3 also
+  asserts the sidebar form stays open on a mocked rejection).
 - **Item 4:** Covered transitively; `type="button"` asserted in the Item 2
   render, `_roster` removal is a pure refactor caught by `typecheck` + existing
   `script-review-apply` tests.
@@ -150,6 +193,23 @@ export-failure toast). Paired tests assert the toast dispatch against a mocked
    `onReattributeExisting` (0 `api.createCharacter` calls); a novel name calls
    `onSubmit`.
 5. `npm run verify` is green.
+
+## Adversarial review (folded)
+
+Round 1 (against source) found two blockers, both folded above:
+
+- **Item 1 is not jsdom-testable** (`getSelection`/`elementFromPoint` seam, no
+  existing e2e harness) — Testing now specifies a pure predicate unit test + a
+  new Playwright e2e, and the "no new e2e" non-goal was removed.
+- **Item 3's original "keep form open" claim was inverted** — the form already
+  stays open on failure (the throw skips the close); the real defects are an
+  unhandled rejection + no toast, and the fix must span both the handler and
+  the parent `onSubmit`. Item 3 was rewritten around the verified behaviour.
+
+Also folded: `runProposed` partial-failure handling (catch + toast + reset
+confirm, leave review bucket; rely on `setSentenceCharacter` idempotency for
+re-run), the `_roster` call-site removal (5th arg at the call site), and a
+softened rationale for the `assignSelectionTo` belt-and-suspenders guard.
 
 ## Ship notes
 

--- a/docs/superpowers/specs/2026-06-25-fs58-unit-b-polish-design.md
+++ b/docs/superpowers/specs/2026-06-25-fs58-unit-b-polish-design.md
@@ -1,0 +1,156 @@
+---
+status: draft
+issue: 1122
+area: fs
+type: chore
+---
+
+# fs-58 Unit B polish — excluded-line split/drag disable + minor cleanups
+
+Deferred polish and review-Minors from fs-58 Unit B (LLM Script Review;
+#1040, PR #1118). Bundled into one chore (#1122) so they aren't lost. All
+four items are frontend-only and unit-testable; none change the analyzer or
+server contract.
+
+## Background
+
+fs-58 Unit B added two new script-review op kinds, `reattribute` and
+`flag_nonstory`. An excluded (`flag_nonstory`) sentence is rendered with
+`line-through opacity-50` and a one-tap **include** toggle, but it keeps its
+`absIdx` slot in the chapter's `sentences[]` array (excluding is a display +
+synth-filter flag, not a structural removal). Because the slot survives, the
+two manuscript edit affordances — the selection-popover split and the
+boundary-drag reassign — still fire on excluded lines. The synth pipeline
+drops the line regardless, so this is **UX-only**: offering edit affordances on
+a line that won't be synthesised is misleading.
+
+The remaining three items are deferred review-Minors from the Unit B PR.
+
+## Scope
+
+Branch: `chore/frontend-fs58-unit-b-polish`, cut from `main`.
+
+### Item 1 — Disable split + drag on excluded lines
+
+File: `src/views/manuscript.tsx`.
+
+Both edit affordances are gated so they never act on a sentence whose
+`excludeFromSynthesis` is set. A re-include toggle remains the only action
+offered on an excluded line (unchanged).
+
+**(a) Selection-popover split.** Selecting text inside a sentence raises the
+"Assign selection to…" popover; assigning either reassigns the whole sentence
+or splits it into pieces (`assignSelectionTo`). Gate at two points:
+
+- At the `<SelectionPopover>` render site, suppress the popover when the
+  selected sentence is excluded — pass `sel={null}` in that case. The selected
+  sentence is resolved from `selection.sentenceId` against the current
+  chapter's `sentences[]` (the same per-chapter scoping `assignSelectionTo`
+  already uses, because sentence ids restart per chapter).
+- Belt-and-suspenders: early-return in `assignSelectionTo` if the resolved
+  sentence is excluded, so a stale selection captured before exclusion can't
+  split.
+
+**(b) Boundary drag.** Dragging a boundary handle highlights a *candidate*
+sentence (`candidateSentenceIdx`) and, on drop, reassigns a contiguous run of
+sentences to a character (`commitBoundaryMove`). Gate in the `pointermove`
+`onMove` handler: when the hovered sentence (`data-sentence-idx`) is excluded,
+do **not** set it as `candidateSentenceIdx`. The `sentence-candidate` highlight
+and the drop target then skip excluded lines.
+
+Out of scope (and called out so the limit is explicit): a reassign *run* that
+merely **contains** an excluded line in its interior is unavoidable — the run
+is a contiguous `[start, end]` index range — and is harmless, because the
+excluded line won't synthesise regardless of which character it's attributed
+to. Only the **drop target / candidate** is gated, not run membership.
+
+Remove the `follow-up:` comment at `src/views/manuscript.tsx` (currently
+adjacent to the excluded-line re-include toggle) once both gates land.
+
+### Item 2 — Component test for reattribute-to-existing
+
+File: `src/components/create-character-form.test.tsx`.
+
+`CreateCharacterForm` routes its primary button to `onReattributeExisting`
+(not `onSubmit`) when the typed name matches a `rosterByName` entry — the
+branch that maps to a direct `setSentenceCharacter` reassign with **zero**
+`api.createCharacter` calls. The logic is sound and indirectly covered today;
+add an explicit case:
+
+- Render with a `rosterByName` containing `{ "alice": { id: "c1", name: "Alice" } }`.
+- Type `Alice`, assert the button label becomes `Reattribute to «Alice»`.
+- Click it; assert `onReattributeExisting` was called with `"c1"` and
+  `onSubmit` was **not** called.
+- Symmetric assertion for a non-matching name: `onSubmit` fires, label reads
+  `Create character`, `onReattributeExisting` not called.
+
+### Item 3 — Catch + toast on a failed create
+
+Files: `src/views/manuscript.tsx`, `src/components/script-review-diff.tsx`.
+
+Two create flows `await api.createCharacter` with no `catch`, so a failed
+`POST /cast/create` rejects unhandled — the form/confirm UI is left mid-flow
+with no error surface:
+
+- `handleCreateCharacter` (`manuscript.tsx`) — the sidebar "create character"
+  path. Wrap the `await` in `try/catch`; on failure dispatch
+  `notificationsActions.pushToast({ kind: 'error', message: "Couldn't create character", dedupeKey: 'create-character' })`.
+  Keep the form open for retry (do not advance/close on failure).
+- `runProposed` (`script-review-diff.tsx`) — the off-roster reattribute confirm
+  batch runs `applyProposedReattributions`, which calls `api.createCharacter`
+  internally. Wrap the `await`; on failure push the same error toast. Only
+  clear `confirm` / the review bucket on success.
+
+The toast API is the existing `notificationsActions.pushToast` from
+`src/store/notifications-slice.ts` (same pattern as `book-library.tsx`'s
+export-failure toast). Paired tests assert the toast dispatch against a mocked
+`api.createCharacter` rejection.
+
+### Item 4 — Trivia
+
+- `src/components/create-character-form.tsx` — add explicit `type="button"` to
+  both buttons (defensive against accidental form submission if the component
+  is ever nested in a `<form>`).
+- `src/lib/script-review-apply.ts` — drop the unused `_roster` parameter from
+  `dispatchAcceptedOps`, and its argument at the call site in
+  `script-review-diff.tsx`. (`planApply` keeps its `roster` param — it is used
+  there to gate on-roster reattributes; only the dispatch helper's copy is
+  dead.)
+
+## Non-goals
+
+- No change to exclusion semantics, the synth filter, or the `flag_nonstory`
+  op itself.
+- No new e2e spec — all four items are unit-testable, and the existing
+  `e2e/script-review.spec.ts` already covers the confirm flow end to end.
+- Items #1119 (fs-63 auto-voice), #1120 (fs-64 cross-chapter context), and
+  #1121 (hydrate-merge bug) are tracked separately and out of scope here.
+
+## Testing
+
+- **Item 1:** Vitest component test on `manuscript.tsx` — an excluded sentence
+  yields no `SelectionPopover` for a selection within it, and the
+  `pointermove` candidate detection skips it. (jsdom can drive the selection /
+  pointer paths the existing manuscript tests already exercise.)
+- **Item 2 / Item 3:** Vitest component tests as described above.
+- **Item 4:** Covered transitively; `type="button"` asserted in the Item 2
+  render, `_roster` removal is a pure refactor caught by `typecheck` + existing
+  `script-review-apply` tests.
+- Full gate: `npm run verify` (typecheck + unit + e2e + build) before push.
+
+## Acceptance
+
+1. On an excluded line, selecting text shows **no** "Assign selection to…"
+   popover, and dragging a boundary onto it does **not** highlight it as a drop
+   candidate. The **include** toggle still works.
+2. A non-excluded line behaves exactly as before (popover + drag unchanged).
+3. A simulated `POST /cast/create` failure surfaces an error toast and leaves
+   the create/confirm UI open rather than failing silently.
+4. `CreateCharacterForm` with a name matching the roster calls
+   `onReattributeExisting` (0 `api.createCharacter` calls); a novel name calls
+   `onSubmit`.
+5. `npm run verify` is green.
+
+## Ship notes
+
+_(filled at ship time: date, commit SHA; close #1122.)_

--- a/e2e/manuscript-excluded-line-noedit.spec.ts
+++ b/e2e/manuscript-excluded-line-noedit.spec.ts
@@ -1,0 +1,45 @@
+/* fs-58 Unit B (#1122) — an excluded (flag_nonstory) line offers no split/
+ * reassign affordance. jsdom can't drive getSelection/elementFromPoint, so the
+ * gate is proven here. */
+import { test, expect } from '@playwright/test';
+
+type Store = { dispatch: (a: unknown) => void };
+
+async function selectSentenceText(page: import('@playwright/test').Page, sentenceId: number) {
+  await page.evaluate((id) => {
+    const inner = document.querySelector(`[data-sentence-id="${id}"] [data-text-offset]`);
+    const textNode = inner?.firstChild;
+    if (!textNode) throw new Error(`no text node for sentence ${id}`);
+    const range = document.createRange();
+    range.setStart(textNode, 0);
+    range.setEnd(textNode, (textNode as Text).length);
+    const sel = window.getSelection()!;
+    sel.removeAllRanges();
+    sel.addRange(range);
+    document.dispatchEvent(new Event('selectionchange'));
+  }, sentenceId);
+}
+
+test.describe('fs-58 Unit B — excluded line: no edit affordance', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('no selection popover on an excluded line; present on a normal line', async ({ page }) => {
+    await page.goto('/#/books/sb/manuscript');
+    await expect(page.getByRole('heading', { name: /^Chapter \d+/i, level: 1 })).toBeVisible({ timeout: 10_000 });
+
+    // Mark sentence id:1 in the current chapter (3) excluded via the store.
+    await page.evaluate(() => {
+      const store = (window as unknown as { __store__: Store }).__store__;
+      store.dispatch({ type: 'manuscript/setSentenceExcluded', payload: { chapterId: 3, sentenceId: 1, excluded: true } });
+    });
+    await expect(page.locator('[data-sentence-id="1"]').first()).toHaveClass(/line-through/);
+
+    // (a) Selecting the excluded line shows NO popover.
+    await selectSentenceText(page, 1);
+    await expect(page.getByText('Assign selection to')).toHaveCount(0);
+
+    // Positive control: a normal line (id:3 is a seeded ch3 sentence) DOES show it.
+    await selectSentenceText(page, 3);
+    await expect(page.getByText('Assign selection to')).toBeVisible();
+  });
+});

--- a/src/components/create-character-form.test.tsx
+++ b/src/components/create-character-form.test.tsx
@@ -20,6 +20,50 @@ it('offers reattribute-to-existing when the name matches a roster member', () =>
   expect(onReattributeExisting).toHaveBeenCalledWith('halloran');
 });
 
+it('routes a roster-name match to onReattributeExisting and never onSubmit', () => {
+  const onSubmit = vi.fn();
+  const onReattributeExisting = vi.fn();
+  render(
+    <CreateCharacterForm
+      initial={{ name: 'Halloran' }}
+      rosterByName={new Map([['halloran', { id: 'halloran', name: 'Halloran' }]])}
+      onSubmit={onSubmit}
+      onReattributeExisting={onReattributeExisting}
+      onCancel={() => {}}
+    />,
+  );
+  const submit = screen.getByTestId('create-character-submit');
+  expect(submit).toHaveTextContent(/Reattribute to «Halloran»/);
+  fireEvent.click(submit);
+  expect(onReattributeExisting).toHaveBeenCalledWith('halloran');
+  expect(onSubmit).not.toHaveBeenCalled();
+});
+
+it('routes a novel name to onSubmit and never onReattributeExisting', () => {
+  const onSubmit = vi.fn();
+  const onReattributeExisting = vi.fn();
+  render(
+    <CreateCharacterForm
+      rosterByName={new Map([['halloran', { id: 'halloran', name: 'Halloran' }]])}
+      onSubmit={onSubmit}
+      onReattributeExisting={onReattributeExisting}
+      onCancel={() => {}}
+    />,
+  );
+  fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Ferra' } });
+  const submit = screen.getByTestId('create-character-submit');
+  expect(submit).toHaveTextContent('Create character');
+  fireEvent.click(submit);
+  expect(onSubmit).toHaveBeenCalledWith({ name: 'Ferra', gender: undefined, ageRange: undefined });
+  expect(onReattributeExisting).not.toHaveBeenCalled();
+});
+
+it('gives both action buttons an explicit type="button"', () => {
+  render(<CreateCharacterForm rosterByName={new Map()} onSubmit={() => {}} onCancel={() => {}} />);
+  expect(screen.getByTestId('create-character-submit')).toHaveAttribute('type', 'button');
+  expect(screen.getByRole('button', { name: /cancel/i })).toHaveAttribute('type', 'button');
+});
+
 describe('gender and ageRange selects', () => {
   it('renders gender select with all options and empty default', () => {
     render(<CreateCharacterForm rosterByName={new Map()} onSubmit={() => {}} onCancel={() => {}} />);

--- a/src/components/create-character-form.tsx
+++ b/src/components/create-character-form.tsx
@@ -75,6 +75,7 @@ export function CreateCharacterForm({
 
       <div className="flex gap-2">
         <button
+          type="button"
           data-testid="create-character-submit"
           disabled={disabled}
           onClick={() =>
@@ -90,7 +91,7 @@ export function CreateCharacterForm({
         >
           {existing ? `Reattribute to «${existing.name}»` : 'Create character'}
         </button>
-        <button onClick={onCancel} className="px-4 min-h-[44px] sm:min-h-0 text-sm text-ink/50">
+        <button type="button" onClick={onCancel} className="px-4 min-h-[44px] sm:min-h-0 text-sm text-ink/50">
           Cancel
         </button>
       </div>

--- a/src/components/script-review-diff.test.tsx
+++ b/src/components/script-review-diff.test.tsx
@@ -7,6 +7,7 @@ import { manuscriptSlice } from '../store/manuscript-slice';
 import { castSlice } from '../store/cast-slice';
 import { scriptReviewSlice, scriptReviewActions, opKey } from '../store/script-review-slice';
 import { changeLogSlice } from '../store/change-log-slice';
+import { notificationsSlice, type Toast } from '../store/notifications-slice';
 import { api } from '../lib/api';
 import { ScriptReviewDiff } from './script-review-diff';
 
@@ -406,6 +407,7 @@ describe('fs-58 — ScriptReviewDiff', () => {
         cast: castSlice.reducer,
         scriptReview: scriptReviewSlice.reducer,
         changeLog: changeLogSlice.reducer,
+        notifications: notificationsSlice.reducer,
       },
       preloadedState: {
         ui: {
@@ -507,6 +509,33 @@ describe('fs-58 — ScriptReviewDiff', () => {
     const sentences = store.getState().manuscript.sentences;
     expect(sentences.find((s) => s.id === 5)?.characterId).toBe(newId);
     expect(sentences.find((s) => s.id === 7)?.characterId).toBe(newId);
+  });
+
+  it('a failed create surfaces a toast, closes the confirm dialog, and keeps the review for retry (#1122)', async () => {
+    createSpy.mockRejectedValueOnce(new Error('boom'));
+    const store = makeProposedStore(
+      [{ id: 5, chapterId: 1, proposed: { name: 'Ferra' } }],
+      [{ id: 5, chapterId: 1, text: 'Line five.', characterId: 'narr' }],
+    );
+    render(
+      <Provider store={store}>
+        <ScriptReviewDiff bookId="book-A" />
+      </Provider>,
+    );
+
+    fireEvent.click(screen.getByTestId('apply-button'));
+    expect(screen.getByTestId('confirm-reattribute')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('create-character-submit'));
+
+    // Error toast surfaced.
+    await waitFor(() => {
+      const toasts: Toast[] = store.getState().notifications.toasts;
+      expect(toasts.some((t) => t.kind === 'error' && /create character/i.test(t.message))).toBe(true);
+    });
+    // Confirm dialog closed.
+    expect(screen.queryByTestId('confirm-reattribute')).toBeNull();
+    // Review bucket retained for retry (NOT cleared).
+    expect(store.getState().scriptReview.byBook['book-A']).toBeDefined();
   });
 
   it('cancelling mid-confirm creates NO not-yet-confirmed member and clears the review', async () => {

--- a/src/components/script-review-diff.tsx
+++ b/src/components/script-review-diff.tsx
@@ -284,7 +284,6 @@ export function ScriptReviewDiff({ bookId }: { bookId: string }) {
         onBoundaryMove: (chapterId) =>
           dispatch(changeLogActions.bumpBoundaryMove({ chapterId, count: 1 })),
       },
-      roster,
     );
 
     if (proposedOps.length > 0) {

--- a/src/components/script-review-diff.tsx
+++ b/src/components/script-review-diff.tsx
@@ -17,6 +17,7 @@ import { applyProposedReattributions } from '../lib/apply-proposed';
 import { changeLogActions } from '../store/change-log-slice';
 import { manuscriptActions } from '../store/manuscript-slice';
 import { castActions } from '../store/cast-slice';
+import { notificationsActions } from '../store/notifications-slice';
 import { api } from '../lib/api';
 import { CreateCharacterForm } from './create-character-form';
 import { IconClose } from '../lib/icons';
@@ -188,22 +189,37 @@ export function ScriptReviewDiff({ bookId }: { bookId: string }) {
      review bucket. Called once, after the LAST confirm resolves. */
   async function runProposed(finalized: FinalizedProposed[], startBookId: string) {
     const rosterByName = new Map(cast.map((c) => [c.name.trim().toLowerCase(), { id: c.id }]));
-    await applyProposedReattributions(finalized, {
-      rosterByName,
-      createCharacter: async (p) => {
-        // api.createCharacter resolves to a { character } envelope — unwrap it.
-        // `p` widens gender/ageRange to string (the proposed shape); the API's
-        // narrower enum tolerates the values the form's <select>s produce.
-        const { character } = await api.createCharacter(startBookId, p as never);
-        return character;
-      },
-      addCharacter: (c) => dispatch(castActions.addCharacter(c as never)),
-      setSentenceCharacter: (chapterId, sentenceId, characterId) =>
-        dispatch(manuscriptActions.setSentenceCharacter({ chapterId, sentenceId, characterId })),
-      onBoundaryMove: (chapterId) =>
-        dispatch(changeLogActions.bumpBoundaryMove({ chapterId, count: 1 })),
-      isSameBook: () => stageBookIdRef.current === startBookId,
-    });
+    try {
+      await applyProposedReattributions(finalized, {
+        rosterByName,
+        createCharacter: async (p) => {
+          // api.createCharacter resolves to a { character } envelope — unwrap it.
+          // `p` widens gender/ageRange to string (the proposed shape); the API's
+          // narrower enum tolerates the values the form's <select>s produce.
+          const { character } = await api.createCharacter(startBookId, p as never);
+          return character;
+        },
+        addCharacter: (c) => dispatch(castActions.addCharacter(c as never)),
+        setSentenceCharacter: (chapterId, sentenceId, characterId) =>
+          dispatch(manuscriptActions.setSentenceCharacter({ chapterId, sentenceId, characterId })),
+        onBoundaryMove: (chapterId) =>
+          dispatch(changeLogActions.bumpBoundaryMove({ chapterId, count: 1 })),
+        isSameBook: () => stageBookIdRef.current === startBookId,
+      });
+    } catch {
+      // A create failed mid-batch. Reset the confirm machine and surface a toast,
+      // but DON'T clearReview — the operator can re-trigger. Re-run is safe because
+      // setSentenceCharacter is idempotent for an already-applied reattribute.
+      setConfirm(null);
+      dispatch(
+        notificationsActions.pushToast({
+          kind: 'error',
+          message: "Couldn't create character",
+          dedupeKey: 'create-character',
+        }),
+      );
+      return;
+    }
     setConfirm(null);
     dispatch(scriptReviewActions.clearReview({ bookId: startBookId }));
   }

--- a/src/lib/script-review-apply.test.ts
+++ b/src/lib/script-review-apply.test.ts
@@ -298,12 +298,12 @@ describe('reattribute (fs-58 Unit B)', () => {
   });
   it('dispatchAcceptedOps fires setSentenceCharacter for on-roster reattribute', () => {
     const calls: any[] = [];
-    dispatchAcceptedOps((a) => { calls.push(a); return a; }, [{ id: 5, op: 'reattribute', anchor: 'x', characterId: 'ferra', rationale: 'r' }] as any, live, { onBoundaryMove: () => {} }, new Set(['ferra']));
+    dispatchAcceptedOps((a) => { calls.push(a); return a; }, [{ id: 5, op: 'reattribute', anchor: 'x', characterId: 'ferra', rationale: 'r' }] as any, live, { onBoundaryMove: () => {} });
     expect(calls).toContainEqual(manuscriptActions.setSentenceCharacter({ chapterId: 1, sentenceId: 5, characterId: 'ferra' }));
   });
   it('flag_nonstory dispatches setSentenceExcluded(true)', () => {
     const calls: any[] = [];
-    dispatchAcceptedOps((a) => { calls.push(a); return a; }, [{ id: 5, op: 'flag_nonstory', anchor: 'x', rationale: 'r' }] as any, live, { onBoundaryMove: () => {} }, new Set());
+    dispatchAcceptedOps((a) => { calls.push(a); return a; }, [{ id: 5, op: 'flag_nonstory', anchor: 'x', rationale: 'r' }] as any, live, { onBoundaryMove: () => {} });
     expect(calls).toContainEqual(manuscriptActions.setSentenceExcluded({ chapterId: 1, sentenceId: 5, excluded: true }));
   });
   it('a proposed (off-roster) reattribute is appliable but NOT dispatched here', () => {
@@ -311,7 +311,7 @@ describe('reattribute (fs-58 Unit B)', () => {
     const ops = [{ id: 5, op: 'reattribute', anchor: 'x', proposed: { name: 'Ferra' }, rationale: 'r' }] as any;
     const { appliable } = planApply(ops, live, new Set());
     expect(appliable).toHaveLength(1);
-    dispatchAcceptedOps((a) => { calls.push(a); return a; }, appliable, live, { onBoundaryMove: () => {} }, new Set());
+    dispatchAcceptedOps((a) => { calls.push(a); return a; }, appliable, live, { onBoundaryMove: () => {} });
     expect(calls.find((c) => c.type?.includes('setSentenceCharacter'))).toBeUndefined();
   });
 });

--- a/src/lib/script-review-apply.ts
+++ b/src/lib/script-review-apply.ts
@@ -216,7 +216,6 @@ export function dispatchAcceptedOps(
   accepted: ReviewOp[],
   live: Array<{ id: number; chapterId: number; text: string; characterId: string; instruct?: string; vocalization?: boolean }>,
   { onBoundaryMove }: { onBoundaryMove: (chapterId: number) => void },
-  _roster: Set<string> = new Set(),
 ): void {
   const byId = new Map(live.map((s) => [s.id, s]));
   for (const op of accepted) {

--- a/src/views/manuscript.test.tsx
+++ b/src/views/manuscript.test.tsx
@@ -1484,4 +1484,52 @@ describe('ManuscriptView — Add character button (fs-58 Unit B Task 14)', () =>
     /* The form must be dismissed after a successful create. */
     await waitFor(() => expect(screen.queryByTestId('create-character-form')).toBeNull());
   });
+
+  it('on a failed create: shows an error toast and keeps the form open (#1122)', async () => {
+    const user = userEvent.setup();
+    createCharacter.mockReset();
+    createCharacter.mockRejectedValue(new Error('boom'));
+
+    const store = configureStore({
+      reducer: {
+        manuscript: manuscriptSlice.reducer,
+        changeLog: changeLogSlice.reducer,
+        ui: uiSlice.reducer,
+        bookMeta: bookMetaSlice.reducer,
+        cast: castSlice.reducer,
+        notifications: notificationsSlice.reducer,
+      },
+      preloadedState: {
+        ui: {
+          ...uiSlice.getInitialState(),
+          stage: { kind: 'ready', bookId: 'bk-addchar', view: 'manuscript', currentChapterId: 1, openProfileId: null } as never,
+        },
+        cast: { characters: [{ id: 'narrator', name: 'Narrator', role: 'Narrator', color: 'narrator' }], renderedFallbackByCharacter: {} },
+      },
+    });
+
+    render(
+      <Provider store={store}>
+        <ManuscriptView
+          characters={[{ id: 'narrator', name: 'Narrator', role: 'Narrator', color: 'narrator' }]}
+          chapters={[{ id: 1, title: 'Chapter One', duration: '10:00', state: 'done', progress: 1, characters: { narrator: 'done' } }]}
+          currentChapterId={1}
+          setCurrentChapterId={() => {}}
+          sentencesFromStore={[]}
+        />
+      </Provider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /add character/i }));
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Ferra' } });
+    await user.click(screen.getByTestId('create-character-submit'));
+
+    // Error toast surfaced.
+    await waitFor(() => {
+      const toasts: Toast[] = store.getState().notifications.toasts;
+      expect(toasts.some((t) => t.kind === 'error' && /create character/i.test(t.message))).toBe(true);
+    });
+    // Form still open for retry.
+    expect(screen.getByTestId('create-character-form')).toBeInTheDocument();
+  });
 });

--- a/src/views/manuscript.test.tsx
+++ b/src/views/manuscript.test.tsx
@@ -25,7 +25,7 @@ import { bookMetaSlice } from '../store/book-meta-slice';
 import { castSlice } from '../store/cast-slice';
 import type { Toast } from '../store/notifications-slice';
 import { TOUR_STEPS } from '../lib/tour-steps';
-import { ManuscriptView } from './manuscript';
+import { ManuscriptView, isExcludedSentenceId } from './manuscript';
 import type { Chapter, Character, Sentence } from '../lib/types';
 
 /* fs-58 — api mock for reviewScript + createCharacter trigger tests. */
@@ -1531,5 +1531,25 @@ describe('ManuscriptView — Add character button (fs-58 Unit B Task 14)', () =>
     });
     // Form still open for retry.
     expect(screen.getByTestId('create-character-form')).toBeInTheDocument();
+  });
+});
+
+describe('isExcludedSentenceId', () => {
+  const rows = [
+    { chapterId: 1, id: 1, excludeFromSynthesis: true },
+    { chapterId: 1, id: 2 },
+    { chapterId: 2, id: 1 }, // same id, different chapter, NOT excluded
+  ];
+  it('is true for an excluded sentence', () => {
+    expect(isExcludedSentenceId(rows, 1, 1)).toBe(true);
+  });
+  it('is false for a non-excluded sentence', () => {
+    expect(isExcludedSentenceId(rows, 1, 2)).toBe(false);
+  });
+  it('is scoped by chapter (no cross-chapter id collision)', () => {
+    expect(isExcludedSentenceId(rows, 2, 1)).toBe(false);
+  });
+  it('is false when the sentence is not found', () => {
+    expect(isExcludedSentenceId(rows, 9, 9)).toBe(false);
   });
 });

--- a/src/views/manuscript.tsx
+++ b/src/views/manuscript.tsx
@@ -597,8 +597,19 @@ export function ManuscriptView({
   const handleCreateCharacter = useCallback(
     async (fields: { name: string; gender?: string; ageRange?: string }) => {
       if (!bookId) return;
-      const result = await api.createCharacter(bookId, fields as Parameters<typeof api.createCharacter>[1]);
-      dispatch(castActions.addCharacter(result.character));
+      try {
+        const result = await api.createCharacter(bookId, fields as Parameters<typeof api.createCharacter>[1]);
+        dispatch(castActions.addCharacter(result.character));
+      } catch (err) {
+        dispatch(
+          notificationsActions.pushToast({
+            kind: 'error',
+            message: "Couldn't create character",
+            dedupeKey: 'create-character',
+          }),
+        );
+        throw err;
+      }
     },
     [bookId, dispatch],
   );
@@ -1260,7 +1271,14 @@ function SidebarPanels({
             <div className="mt-3">
               <CreateCharacterForm
                 rosterByName={new Map(characters.map((c) => [c.name.trim().toLowerCase(), { id: c.id, name: c.name }]))}
-                onSubmit={async (f) => { await onCreateCharacter(f); setAddingChar(false); }}
+                onSubmit={async (f) => {
+                  try {
+                    await onCreateCharacter(f);
+                    setAddingChar(false);
+                  } catch {
+                    /* handler already surfaced a toast; keep the form open for retry */
+                  }
+                }}
                 onReattributeExisting={() => setAddingChar(false)}
                 onCancel={() => setAddingChar(false)}
               />

--- a/src/views/manuscript.tsx
+++ b/src/views/manuscript.tsx
@@ -514,6 +514,7 @@ export function ManuscriptView({
       const sentenceEl = el?.closest?.('[data-sentence-idx]') as HTMLElement | null;
       if (sentenceEl) {
         const idx = Number(sentenceEl.dataset.sentenceIdx);
+        if (sentences[idx]?.excludeFromSynthesis) return; // fs-58 Unit B — excluded line isn't a drop target
         setDrag((d) =>
           d && d.candidateSentenceIdx !== idx ? { ...d, candidateSentenceIdx: idx } : d,
         );
@@ -562,7 +563,7 @@ export function ManuscriptView({
     const sentence = sentences.find(
       (s) => s.chapterId === currentChapterId && s.id === selection.sentenceId,
     );
-    if (!sentence) return;
+    if (!sentence || sentence.excludeFromSynthesis) return;
     const len = sentence.text.length;
     /* Whole sentence selected → simple reassign. Otherwise split into
        three pieces with the middle reassigned. The reducer drops empty
@@ -1044,7 +1045,17 @@ export function ManuscriptView({
         {inspectorContent}
       </BottomSheet>
 
-      <SelectionPopover sel={selection} characters={characters} onAssign={assignSelectionTo} />
+      <SelectionPopover
+        sel={
+          selection &&
+          currentChapterId != null &&
+          isExcludedSentenceId(sentences, currentChapterId, selection.sentenceId)
+            ? null
+            : selection
+        }
+        characters={characters}
+        onAssign={assignSelectionTo}
+      />
     </div>
   );
 }
@@ -1551,8 +1562,7 @@ function SegmentRow({
                   {renderSentenceText(s.text)}
                 </span>
                 {/* fs-58 Unit B — excluded lines: re-include toggle outside the
-                    span so split offsets are unaffected; chips suppressed.
-                    follow-up: disable split/drag affordance on excluded lines. */}
+                    span so split offsets are unaffected; chips suppressed. */}
                 {s.excludeFromSynthesis ? (
                   <button
                     data-testid={`reinclude-toggle-${s.id}`}
@@ -1875,6 +1885,19 @@ function SegmentInspector({
 function renderSentenceText(text: string) {
   if (!text) return null;
   return <span data-text-offset={0}>{text}</span>;
+}
+
+/* fs-58 Unit B — a sentence excluded from synthesis offers no split/reassign
+   affordance (it won't be rendered either way). Scoped by chapter because
+   sentence ids restart per chapter. */
+export function isExcludedSentenceId(
+  sentences: ReadonlyArray<{ chapterId: number; id: number; excludeFromSynthesis?: boolean }>,
+  chapterId: number,
+  sentenceId: number,
+): boolean {
+  return Boolean(
+    sentences.find((s) => s.chapterId === chapterId && s.id === sentenceId)?.excludeFromSynthesis,
+  );
 }
 
 /* ── Selection-based split popover ─────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Closes #1122 — the four deferred fs-58 Unit B polish items, bundled.

- **Disable split + drag on excluded lines** (`manuscript.tsx`). An excluded (`flag_nonstory`) sentence keeps its `absIdx` slot, so the selection-popover split and the boundary-drag reassign still fired on it — offering edits on a line that won't synthesise. New exported `isExcludedSentenceId` predicate gates the `SelectionPopover` (suppressed on an excluded line), `assignSelectionTo` (early-return), and the boundary-drag `onMove` (an excluded line is never a drop candidate). The re-include toggle is unchanged.
- **Toast + keep-open on a failed character-create** (`manuscript.tsx`, `script-review-diff.tsx`). Both create flows `await api.createCharacter` with no catch. The sidebar form already stayed open on failure (the throw skips the close) but left an unhandled rejection and no error surface; `runProposed` left the confirm machine wedged. Both now surface an error toast; the sidebar keeps the form open for retry; `runProposed` resets the confirm machine and retains the review bucket so the operator can re-trigger (safe — `setSentenceCharacter` is idempotent).
- **Reattribute-to-existing test** (`create-character-form.test.tsx`). Explicit coverage that a roster-name match routes to `onReattributeExisting` (0 `api.createCharacter` calls) and a novel name routes to `onSubmit`.
- **Trivia.** Explicit `type="button"` on both `CreateCharacterForm` buttons; dropped the unused `_roster` param from `dispatchAcceptedOps` (+ call site). `planApply`'s `roster` is unchanged.

Frontend only — no analyzer/server/OpenAPI-contract change.

## Test plan

- `npm run verify` green locally (typecheck + unit + server + e2e + build). E2e showed unrelated load-contention flakes that retried green; the new spec passed.
- New unit coverage: `isExcludedSentenceId` (4 cases), the reattribute-vs-create routing tests, the two create-failure toast tests (sidebar + script-review batch).
- New Playwright e2e `e2e/manuscript-excluded-line-noedit.spec.ts`: on an excluded line, selecting its text shows no "Assign selection to" popover; a normal line still does (positive control). The boundary-drag negative is covered by the predicate unit test + manual acceptance (a real drag-negative e2e is flaky), per the spec.

## Process

Built via subagent-driven development (implementer + per-task review each; opus whole-branch review found 0 Critical/Important). Spec and plan each passed one adversarial review round before execution. Spec: `docs/superpowers/specs/2026-06-25-fs58-unit-b-polish-design.md`; plan: `docs/superpowers/plans/2026-06-25-fs58-unit-b-polish.md`.

Deferred (zero-risk cosmetic test-clarity nits, noted for a future pass): tighten the toast-assert regex to `/couldn't create character/i`; add a "only the toast assertion is discriminating" comment in the script-review batch test; `isExcludedSentenceId` placement; e2e `toHaveCount(0)` vs `not.toBeVisible()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
