### PR TITLE
feat(frontend): fs-63 auto-voice a created off-roster character

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -67,12 +67,6 @@ _Full detail + acceptance:_ [#1005](https://github.com/dudarenok-maker/Castwrigh
 - _Benefit (user / strategic):_ a non-English user gets a generate-able demo in their own language out of the box, not a dead English-voiced sample. Surfaced by the `fs-50` Spanish ship.
 _Full detail + acceptance:_ [#1027](https://github.com/dudarenok-maker/Castwright/issues/1027).
 
-#### `fs-63` — auto-voice a created off-roster character (fs-58 Unit B follow-up) ([#1119](https://github.com/dudarenok-maker/Castwright/issues/1119))
-
-- _What:_ An off-roster `reattribute` mints a new cast member (operator-confirmed `CreateCharacterForm` → `POST /cast/create`) that lands voice-unassigned and is silent until manually voiced in the Cast view. Auto-assign/design a voice for a character created through the reattribute confirm flow.
-- _Benefit (user):_ off-roster reattribute becomes audible in one pass, not two.
-_Full detail + acceptance:_ [#1119](https://github.com/dudarenok-maker/Castwright/issues/1119).
-
 #### `fs-64` — cross-chapter context for reattribute (fs-58 Unit B follow-up) ([#1120](https://github.com/dudarenok-maker/Castwright/issues/1120))
 
 - _What:_ `reattribute` runs per-chapter, so a chapter-opening tagless line whose speaker was set by the previous chapter's last turn can mis-resolve. Feed the prior chapter's tail into the review prompt so straddling turn-taking resolves. Weigh against RPD cost.

--- a/docs/superpowers/plans/2026-06-25-fs63-auto-voice-off-roster-character.md
+++ b/docs/superpowers/plans/2026-06-25-fs63-auto-voice-off-roster-character.md
@@ -578,6 +578,7 @@ Create `src/components/script-review-voice-nudge.test.ts`:
 ```ts
 import { describe, it, expect, vi } from 'vitest';
 import { maybePushVoiceNudge } from './script-review-diff';
+import { QWEN_MODEL_KEY } from '../lib/tts-voice-mapping';
 
 describe('maybePushVoiceNudge', () => {
   it('pushes a nudge on a qwen project with the right payload + dedupeKey', () => {
@@ -591,10 +592,13 @@ describe('maybePushVoiceNudge', () => {
     const action = dispatch.mock.calls[0][0];
     expect(action.type).toBe('notifications/pushToast');
     expect(action.payload.dedupeKey).toBe('off-roster-voice-nudge:b1');
+    // modelKey is the constant sampleModelKeyForEngine('qwen', …) substitutes,
+    // NOT an echo of the input — assert against the constant so a future
+    // "fix" that echoes the input fails this test.
     expect(action.payload.nudge).toEqual({
       bookId: 'b1',
       characterIds: ['mara'],
-      modelKey: 'qwen3-tts-0.6b',
+      modelKey: QWEN_MODEL_KEY,
       names: ['Mara'],
     });
   });

--- a/docs/superpowers/plans/2026-06-25-fs63-auto-voice-off-roster-character.md
+++ b/docs/superpowers/plans/2026-06-25-fs63-auto-voice-off-roster-character.md
@@ -32,69 +32,60 @@
   `{ created: number; createdCharacters: { id: string; name: string }[]; aborted: boolean }`.
   `createdCharacters` lists `{id, name}` for every character minted this batch (in creation order; partial on abort; empty when all ops dedupe to existing roster members).
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1a: Update the existing strict return assertion (it WILL break)**
 
-Add to `src/lib/apply-proposed.test.ts`:
+`apply-proposed.test.ts:25` uses a strict `toEqual` on the whole result object. Adding
+`createdCharacters` breaks it. Update that line:
 
 ```ts
-it('returns createdCharacters with {id,name} for each minted member', async () => {
-  let n = 0;
-  const result = await applyProposedReattributions(
-    [
-      { chapterId: 1, id: 10, op: 'reattribute', proposed: { name: 'Mara' } } as never,
-      { chapterId: 1, id: 11, op: 'reattribute', proposed: { name: 'Mara' } } as never, // dup name
-      { chapterId: 2, id: 12, op: 'reattribute', proposed: { name: 'Tom' } } as never,
-    ],
-    {
-      rosterByName: new Map(),
-      createCharacter: async (p) => ({ id: `id-${++n}`, name: p.name }),
-      addCharacter: () => {},
-      setSentenceCharacter: () => {},
-      onBoundaryMove: () => {},
-      isSameBook: () => true,
-    },
-  );
-  expect(result.created).toBe(2);
-  expect(result.createdCharacters).toEqual([
-    { id: 'id-1', name: 'Mara' },
-    { id: 'id-2', name: 'Tom' },
+// BEFORE:
+//   expect(r).toEqual({ created: 1, aborted: false });
+// AFTER:
+expect(r).toEqual({ created: 1, createdCharacters: [{ id: 'ferra', name: 'Ferra' }], aborted: false });
+```
+
+(`createCharacter` in the file's `deps()` helper resolves `{ id: p.name.toLowerCase(), name: p.name }`,
+so the created id is `'ferra'`.) Leave the line-52 `expect(r.aborted).toBe(true)` partial assertion
+as-is.
+
+- [ ] **Step 1b: Write the failing tests for `createdCharacters`**
+
+Add to `src/lib/apply-proposed.test.ts`, reusing the file's existing `deps()` helper:
+
+```ts
+it('returns createdCharacters with {id,name} for each minted member (dedup within batch)', async () => {
+  const d = deps();
+  const r = await applyProposedReattributions([
+    { chapterId: 1, id: 10, op: 'reattribute', proposed: { name: 'Mara' } },
+    { chapterId: 1, id: 11, op: 'reattribute', proposed: { name: 'mara ' } }, // dup name → one create
+    { chapterId: 2, id: 12, op: 'reattribute', proposed: { name: 'Tom' } },
+  ] as any, d);
+  expect(r.created).toBe(2);
+  expect(r.createdCharacters).toEqual([
+    { id: 'mara', name: 'Mara' },
+    { id: 'tom', name: 'Tom' },
   ]);
-  expect(result.aborted).toBe(false);
+  expect(r.aborted).toBe(false);
 });
 
 it('returns empty createdCharacters when every op dedupes to an existing roster member', async () => {
-  const result = await applyProposedReattributions(
-    [{ chapterId: 1, id: 10, op: 'reattribute', proposed: { name: 'Hart' } } as never],
-    {
-      rosterByName: new Map([['hart', { id: 'hart-1' }]]),
-      createCharacter: async () => { throw new Error('should not create'); },
-      addCharacter: () => {},
-      setSentenceCharacter: () => {},
-      onBoundaryMove: () => {},
-      isSameBook: () => true,
-    },
-  );
-  expect(result.createdCharacters).toEqual([]);
+  const d = deps({ rosterByName: new Map([['hart', { id: 'hart-1' }]]) });
+  const r = await applyProposedReattributions(
+    [{ chapterId: 1, id: 10, op: 'reattribute', proposed: { name: 'Hart' } }] as any, d);
+  expect(r.createdCharacters).toEqual([]);
 });
 
 it('carries partial createdCharacters when the batch aborts on a book switch', async () => {
-  let n = 0;
-  const result = await applyProposedReattributions(
-    [
-      { chapterId: 1, id: 10, op: 'reattribute', proposed: { name: 'Mara' } } as never,
-      { chapterId: 2, id: 12, op: 'reattribute', proposed: { name: 'Tom' } } as never,
-    ],
-    {
-      rosterByName: new Map(),
-      createCharacter: async (p) => ({ id: `id-${++n}`, name: p.name }),
-      addCharacter: () => {},
-      setSentenceCharacter: () => {},
-      onBoundaryMove: () => {},
-      isSameBook: () => n < 1, // true before the first create's post-await check, false after
-    },
-  );
-  expect(result.aborted).toBe(true);
-  expect(result.createdCharacters).toEqual([{ id: 'id-1', name: 'Mara' }]);
+  // isSameBook is checked once right after each create: true for Mara (recorded),
+  // false for Tom (abort BEFORE Tom is recorded).
+  const isSameBook = vi.fn().mockReturnValueOnce(true).mockReturnValueOnce(false);
+  const d = deps({ isSameBook });
+  const r = await applyProposedReattributions([
+    { chapterId: 1, id: 10, op: 'reattribute', proposed: { name: 'Mara' } },
+    { chapterId: 2, id: 12, op: 'reattribute', proposed: { name: 'Tom' } },
+  ] as any, d);
+  expect(r.aborted).toBe(true);
+  expect(r.createdCharacters).toEqual([{ id: 'mara', name: 'Mara' }]);
 });
 ```
 
@@ -340,14 +331,25 @@ import { VoiceNudgeToast } from './voice-nudge-toast';
 import { notificationsSlice, type Toast } from '../store/notifications-slice';
 import { castDesignSlice } from '../store/cast-design-slice';
 
-const makeStore = (designRunning: boolean) =>
-  configureStore({
+// Recording middleware — the idiomatic way to assert designAllRequested fired
+// (its reducer is a no-op; real interception lives in middleware not installed here).
+const recorded: { type: string; payload: unknown }[] = [];
+const recorder = () => (next: (a: unknown) => unknown) => (a: unknown) => {
+  recorded.push(a as { type: string; payload: unknown });
+  return next(a);
+};
+
+const makeStore = (designRunning: boolean) => {
+  recorded.length = 0;
+  return configureStore({
     reducer: { notifications: notificationsSlice.reducer, castDesign: castDesignSlice.reducer },
     preloadedState: {
       notifications: { toasts: [] },
       castDesign: { active: designRunning ? ({ state: 'running', bookId: 'b1' } as never) : null },
     },
+    middleware: (gdm) => gdm().concat(recorder),
   });
+};
 
 const toast: Toast = {
   id: 't1', kind: 'info', message: 'New character «Mara» needs a voice', createdAt: 0,
@@ -358,25 +360,15 @@ const toast: Toast = {
 describe('VoiceNudgeToast', () => {
   it('idle: tapping the button dispatches designAllRequested and dismisses the toast', () => {
     const store = makeStore(false);
-    const spy: { type: string; payload: unknown }[] = [];
-    store.subscribe(() => {});
-    const origDispatch = store.dispatch;
-    (store as { dispatch: typeof origDispatch }).dispatch = ((a: never) => {
-      spy.push(a);
-      return origDispatch(a);
-    }) as never;
-    // seed the toast so dismiss has something to remove
-    origDispatch(notificationsSlice.actions.pushToast({ kind: 'info', message: 'x' }));
-
     render(<Provider store={store}><VoiceNudgeToast toast={toast} /></Provider>);
     fireEvent.click(screen.getByRole('button', { name: /design now/i }));
 
-    const design = spy.find((a) => a.type === 'castDesign/designAllRequested');
+    const design = recorded.find((a) => a.type === 'castDesign/designAllRequested');
     expect(design).toBeTruthy();
     expect((design!.payload as { characterIds: string[] }).characterIds).toEqual(['mara']);
     expect((design!.payload as { scope: string }).scope).toBe('bases');
     expect((design!.payload as { modelKey: string }).modelKey).toBe('qwen3-tts-0.6b');
-    expect(spy.some((a) => a.type === 'notifications/dismissToast')).toBe(true);
+    expect(recorded.some((a) => a.type === 'notifications/dismissToast')).toBe(true);
   });
 
   it('busy: button is disabled and the nudge is NOT dismissed', () => {
@@ -575,65 +567,89 @@ git commit -m "feat(frontend): ToastStack routes nudge toasts to VoiceNudgeToast
   `engineForModelKey(ttsModelKey) === 'qwen'`, dispatch `pushToast` with the nudge payload +
   `dedupeKey: \`off-roster-voice-nudge:${startBookId}\``.
 
+**Primary path: extract a pure helper, unit-test it directly.** Driving the full async confirm
+UI in jsdom is brittle, so factor the engine-gate + payload logic into a small exported helper and
+test THAT. The component just calls it.
+
 - [ ] **Step 1: Write the failing test**
 
-Add to `src/components/script-review-diff.test.tsx` two cases (adapt to the file's existing
-render harness + mock of `api.createCharacter`). The key assertions:
+Create `src/components/script-review-voice-nudge.test.ts`:
 
-```tsx
-it('pushes a Design-now nudge after an off-roster create on a Qwen project', async () => {
-  // store seeded with ui.ttsModelKey = 'qwen3-tts-0.6b', an active off-roster review bucket,
-  // and api.createCharacter mocked to resolve { character: { id: 'mara', name: 'Mara' } }.
-  // …drive the confirm flow to completion (create "Mara")…
-  await waitFor(() => {
-    const t = store.getState().notifications.toasts.find((x) => x.nudge);
-    expect(t).toBeTruthy();
-    expect(t!.nudge!.characterIds).toEqual(['mara']);
-    expect(t!.nudge!.modelKey).toBe('qwen3-tts-0.6b');
-    expect(t!.dedupeKey).toMatch(/^off-roster-voice-nudge:/);
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { maybePushVoiceNudge } from './script-review-diff';
+
+describe('maybePushVoiceNudge', () => {
+  it('pushes a nudge on a qwen project with the right payload + dedupeKey', () => {
+    const dispatch = vi.fn();
+    maybePushVoiceNudge(dispatch, {
+      ttsModelKey: 'qwen3-tts-0.6b',
+      startBookId: 'b1',
+      createdCharacters: [{ id: 'mara', name: 'Mara' }],
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const action = dispatch.mock.calls[0][0];
+    expect(action.type).toBe('notifications/pushToast');
+    expect(action.payload.dedupeKey).toBe('off-roster-voice-nudge:b1');
+    expect(action.payload.nudge).toEqual({
+      bookId: 'b1',
+      characterIds: ['mara'],
+      modelKey: 'qwen3-tts-0.6b',
+      names: ['Mara'],
+    });
   });
-});
 
-it('pushes NO nudge on a preset-engine (kokoro) project', async () => {
-  // same flow but ui.ttsModelKey = 'kokoro-v1'
-  await waitFor(() => { /* flow done */ });
-  expect(store.getState().notifications.toasts.some((x) => x.nudge)).toBe(false);
+  it('does nothing on a preset-engine (kokoro) project', () => {
+    const dispatch = vi.fn();
+    maybePushVoiceNudge(dispatch, {
+      ttsModelKey: 'kokoro-v1',
+      startBookId: 'b1',
+      createdCharacters: [{ id: 'mara', name: 'Mara' }],
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no characters were created', () => {
+    const dispatch = vi.fn();
+    maybePushVoiceNudge(dispatch, {
+      ttsModelKey: 'qwen3-tts-0.6b', startBookId: 'b1', createdCharacters: [],
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
 });
 ```
 
-> If driving the full confirm UI is heavy in this suite, factor the push into a tiny exported
-> helper `maybePushVoiceNudge(dispatch, { ttsModelKey, startBookId, createdCharacters })` in
-> `script-review-diff.tsx` and unit-test THAT directly (engine gate + payload), keeping the
-> component test to a single happy-path render. Either satisfies the gate.
+> Confirm the exact valid `TtsModelKey` strings for qwen + kokoro from `src/lib/tts-models.ts`
+> (`QWEN_MODEL_KEY` / the kokoro key) and use those literals; the helper only branches on
+> `engineForModelKey`, so any valid qwen/kokoro key works.
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `npm run test -- src/components/script-review-diff.test.tsx`
-Expected: FAIL — no nudge toast pushed.
+Run: `npm run test -- src/components/script-review-voice-nudge.test.ts`
+Expected: FAIL — `maybePushVoiceNudge` is not exported.
 
 - [ ] **Step 3: Write minimal implementation**
 
-Add imports to `src/components/script-review-diff.tsx`:
+Add imports + the exported helper to `src/components/script-review-diff.tsx`:
 
 ```tsx
+import type { Dispatch } from '@reduxjs/toolkit';
 import { notificationsActions } from '../store/notifications-slice';
 import { engineForModelKey } from '../lib/tts-models';
 import { sampleModelKeyForEngine } from '../lib/tts-voice-mapping';
-```
+import type { TtsModelKey } from '../lib/types'; // or wherever TtsModelKey is declared
 
-Read the model key at component scope (near the other `useAppSelector`s, ~line 143):
-
-```tsx
-const ttsModelKey = useAppSelector((s) => s.ui.ttsModelKey);
-```
-
-In `runProposed`, capture the result and push the nudge:
-
-```tsx
-const { createdCharacters } = await applyProposedReattributions(finalized, {
-  /* …existing deps unchanged… */
-});
-if (createdCharacters.length > 0 && engineForModelKey(ttsModelKey) === 'qwen') {
+/** fs-63 — push the off-roster "Design now" nudge, gated to a Qwen project.
+    Exported (and pure-ish: side effect is the single dispatch) so it's unit
+    testable without driving the confirm UI. No-op on preset engines or an
+    empty batch. */
+export function maybePushVoiceNudge(
+  dispatch: Dispatch,
+  args: { ttsModelKey: TtsModelKey; startBookId: string; createdCharacters: { id: string; name: string }[] },
+): void {
+  const { ttsModelKey, startBookId, createdCharacters } = args;
+  if (createdCharacters.length === 0) return;
+  if (engineForModelKey(ttsModelKey) !== 'qwen') return;
   dispatch(
     notificationsActions.pushToast({
       kind: 'info',
@@ -651,23 +667,39 @@ if (createdCharacters.length > 0 && engineForModelKey(ttsModelKey) === 'qwen') {
     }),
   );
 }
+```
+
+Read the model key at component scope (near the other `useAppSelector`s, ~line 143):
+
+```tsx
+const ttsModelKey = useAppSelector((s) => s.ui.ttsModelKey);
+```
+
+In `runProposed`, capture the result and call the helper before clearing the review:
+
+```tsx
+const { createdCharacters } = await applyProposedReattributions(finalized, {
+  /* …existing deps unchanged… */
+});
+maybePushVoiceNudge(dispatch, { ttsModelKey, startBookId, createdCharacters });
 setConfirm(null);
 dispatch(scriptReviewActions.clearReview({ bookId: startBookId }));
 ```
 
-> The `message` here seeds the dedupe-display text; `VoiceNudgeToast` recomputes its own copy
-> from `nudge`, so the two stay consistent. `startBookId` (not the live `bookId`) keeps the
-> nudge bound to the book the characters were created in.
+> `VoiceNudgeToast` recomputes its own copy from `nudge`, so the seeded `message` and the rendered
+> copy stay consistent. `startBookId` (not the live `bookId`) keeps the nudge bound to the book the
+> characters were created in. Push happens even on an aborted batch (non-empty `createdCharacters`),
+> per spec §3.3.
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `npm run test -- src/components/script-review-diff.test.tsx`
-Expected: PASS (Qwen pushes nudge; kokoro pushes none).
+Run: `npm run test -- src/components/script-review-voice-nudge.test.ts`
+Expected: PASS (Qwen pushes nudge; kokoro/empty push none).
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add src/components/script-review-diff.tsx src/components/script-review-diff.test.tsx
+git add src/components/script-review-diff.tsx src/components/script-review-voice-nudge.test.ts
 git commit -m "feat(frontend): push off-roster voice nudge after apply (qwen-only)"
 ```
 
@@ -692,14 +724,17 @@ test('off-roster reattribute on a Qwen book surfaces a Design-now nudge that act
   //   confirm CreateCharacterForm with a new name…
   await expect(page.getByRole('button', { name: /design now/i })).toBeVisible();
   await page.getByRole('button', { name: /design now/i }).click();
-  // The DesignPill seeds synchronously via castDesign begin.
-  await expect(page.getByTestId('design-pill')).toBeVisible();
+  // The design pill seeds synchronously via castDesign `begin`; assert on its
+  // visible progress text ("Designing"/"Designed") rather than a guessed testid.
+  await expect(page.getByText(/design(ing|ed)/i)).toBeVisible();
 });
 ```
 
 > Reuse the spec's existing helpers for entering script review and the off-roster confirm path.
-> Confirm the real `data-testid` of the design pill from `src/components/layout.tsx` (search
-> `design-pill` / the `DesignPill` render) and match it; adjust the selector if it differs.
+> There is NO `data-testid="design-pill"` today — `layout.tsx` builds a `DesignPillData` and renders
+> the pill from it. Locate the pill's actual rendered text/component at implementation time and
+> match on its visible label (or add a minimal `data-testid` to the pill component if a text match
+> proves flaky). Do NOT hard-code an unverified testid.
 
 - [ ] **Step 2: Run test to verify it fails (or is RED before wiring)**
 

--- a/docs/superpowers/plans/2026-06-25-fs63-auto-voice-off-roster-character.md
+++ b/docs/superpowers/plans/2026-06-25-fs63-auto-voice-off-roster-character.md
@@ -1,0 +1,763 @@
+# fs-63 — Auto-voice a Created Off-Roster Character Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When an off-roster `reattribute` mints new cast member(s) on a Qwen project, surface a sticky "Design now" nudge that enqueues bespoke Qwen voice design for exactly those characters.
+
+**Architecture:** A dedicated, busy-aware nudge component (`VoiceNudgeToast`) is discriminated by an optional `nudge` field on the existing `Toast` model (NOT a new `kind`). It reuses the existing `castDesignActions.designAllRequested` bulk-design pipeline (server SSE job + `DesignPill`), scoped to the created character ids. The push happens from `script-review-diff.tsx` after the apply helper resolves, gated to the `qwen` effective engine.
+
+**Tech Stack:** Vite + React 18 + TypeScript + Redux Toolkit (Immer reducers), Vitest + React Testing Library, Playwright (e2e).
+
+## Global Constraints
+
+- **Design tokens are CSS custom properties** — no hex literals in component code; use existing classes (`text-ink`, `bg-canvas`, `text-ink/70`, etc.).
+- **RTK immer** — slice reducers mutate Immer drafts; never rewrite to spreads.
+- **Touch targets** ≥ 44×44 px on phone: action button uses `min-h-[44px] sm:min-h-0`.
+- **Spec:** `docs/superpowers/specs/2026-06-25-fs63-auto-voice-off-roster-character-design.md` is the source of truth.
+- **Qwen-only:** the nudge fires only when `engineForModelKey(ttsModelKey) === 'qwen'`. Preset engines push nothing.
+- **No new server route.** Reuses `POST /cast/create` and the existing cast-design SSE job.
+- Commit message convention: `<type>(<scope>): <subject>`. Scope here is `frontend`.
+
+---
+
+### Task 1: `apply-proposed.ts` returns the created characters
+
+**Files:**
+- Modify: `src/lib/apply-proposed.ts`
+- Test: `src/lib/apply-proposed.test.ts`
+
+**Interfaces:**
+- Consumes: existing `ApplyProposedDeps` (unchanged), whose `createCharacter` resolves to `{ id: string; name: string }`.
+- Produces: `applyProposedReattributions(...)` now returns
+  `{ created: number; createdCharacters: { id: string; name: string }[]; aborted: boolean }`.
+  `createdCharacters` lists `{id, name}` for every character minted this batch (in creation order; partial on abort; empty when all ops dedupe to existing roster members).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/lib/apply-proposed.test.ts`:
+
+```ts
+it('returns createdCharacters with {id,name} for each minted member', async () => {
+  let n = 0;
+  const result = await applyProposedReattributions(
+    [
+      { chapterId: 1, id: 10, op: 'reattribute', proposed: { name: 'Mara' } } as never,
+      { chapterId: 1, id: 11, op: 'reattribute', proposed: { name: 'Mara' } } as never, // dup name
+      { chapterId: 2, id: 12, op: 'reattribute', proposed: { name: 'Tom' } } as never,
+    ],
+    {
+      rosterByName: new Map(),
+      createCharacter: async (p) => ({ id: `id-${++n}`, name: p.name }),
+      addCharacter: () => {},
+      setSentenceCharacter: () => {},
+      onBoundaryMove: () => {},
+      isSameBook: () => true,
+    },
+  );
+  expect(result.created).toBe(2);
+  expect(result.createdCharacters).toEqual([
+    { id: 'id-1', name: 'Mara' },
+    { id: 'id-2', name: 'Tom' },
+  ]);
+  expect(result.aborted).toBe(false);
+});
+
+it('returns empty createdCharacters when every op dedupes to an existing roster member', async () => {
+  const result = await applyProposedReattributions(
+    [{ chapterId: 1, id: 10, op: 'reattribute', proposed: { name: 'Hart' } } as never],
+    {
+      rosterByName: new Map([['hart', { id: 'hart-1' }]]),
+      createCharacter: async () => { throw new Error('should not create'); },
+      addCharacter: () => {},
+      setSentenceCharacter: () => {},
+      onBoundaryMove: () => {},
+      isSameBook: () => true,
+    },
+  );
+  expect(result.createdCharacters).toEqual([]);
+});
+
+it('carries partial createdCharacters when the batch aborts on a book switch', async () => {
+  let n = 0;
+  const result = await applyProposedReattributions(
+    [
+      { chapterId: 1, id: 10, op: 'reattribute', proposed: { name: 'Mara' } } as never,
+      { chapterId: 2, id: 12, op: 'reattribute', proposed: { name: 'Tom' } } as never,
+    ],
+    {
+      rosterByName: new Map(),
+      createCharacter: async (p) => ({ id: `id-${++n}`, name: p.name }),
+      addCharacter: () => {},
+      setSentenceCharacter: () => {},
+      onBoundaryMove: () => {},
+      isSameBook: () => n < 1, // true before the first create's post-await check, false after
+    },
+  );
+  expect(result.aborted).toBe(true);
+  expect(result.createdCharacters).toEqual([{ id: 'id-1', name: 'Mara' }]);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/lib/apply-proposed.test.ts`
+Expected: FAIL — `result.createdCharacters` is `undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/lib/apply-proposed.ts`, change the return type and collect created characters:
+
+```ts
+export async function applyProposedReattributions(
+  proposed: ReviewOpWithChapter[],
+  deps: ApplyProposedDeps,
+): Promise<{ created: number; createdCharacters: { id: string; name: string }[]; aborted: boolean }> {
+  const memo = new Map<string, string>(); // normName -> id created this batch
+  const createdCharacters: { id: string; name: string }[] = [];
+  let created = 0;
+  for (const op of proposed) {
+    if (!op.proposed) continue;
+    const key = norm(op.proposed.name);
+    let id = deps.rosterByName.get(key)?.id ?? memo.get(key);
+    if (!id) {
+      const c = await deps.createCharacter(op.proposed);
+      if (!deps.isSameBook()) return { created, createdCharacters, aborted: true };
+      deps.addCharacter(c);
+      id = c.id;
+      memo.set(key, id);
+      createdCharacters.push({ id: c.id, name: c.name });
+      created += 1;
+    }
+    deps.setSentenceCharacter(op.chapterId, op.id, id);
+    deps.onBoundaryMove(op.chapterId);
+  }
+  return { created, createdCharacters, aborted: false };
+}
+```
+
+> Note: the `createdCharacters.push` lands AFTER the `isSameBook()` guard returns on abort, so an aborted batch keeps only the characters created before the abort — matching the partial-abort test.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- src/lib/apply-proposed.test.ts`
+Expected: PASS (all three new cases + existing cases green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/apply-proposed.ts src/lib/apply-proposed.test.ts
+git commit -m "feat(frontend): apply-proposed returns createdCharacters {id,name}"
+```
+
+---
+
+### Task 2: `notifications-slice` — `nudge` field + merge-dedupe
+
+**Files:**
+- Modify: `src/store/notifications-slice.ts`
+- Test: `src/store/notifications-slice.test.ts` (create if absent)
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export interface VoiceNudge {
+    bookId: string;
+    characterIds: string[];
+    modelKey: string;
+    names: string[];
+  }
+  ```
+  `Toast` gains `nudge?: VoiceNudge`. `pushToast`'s payload gains `nudge?: VoiceNudge`.
+  When a push carries a `dedupeKey` matching an existing toast AND both carry a `nudge`, the
+  existing nudge's `characterIds`/`names` are **unioned** (dedupe by id, preserve order) rather
+  than overwritten.
+
+- [ ] **Step 1: Write the failing test**
+
+Create/extend `src/store/notifications-slice.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { notificationsSlice, notificationsActions, type VoiceNudge } from './notifications-slice';
+
+const reduce = (actions: ReturnType<typeof notificationsActions.pushToast>[]) =>
+  actions.reduce((s, a) => notificationsSlice.reducer(s, a), notificationsSlice.reducer(undefined, { type: '@@INIT' }));
+
+const nudge = (over: Partial<VoiceNudge>): VoiceNudge => ({
+  bookId: 'b1', modelKey: 'qwen3-tts-0.6b', characterIds: ['mara'], names: ['Mara'], ...over,
+});
+
+describe('notifications nudge merge-dedupe', () => {
+  it('unions characterIds/names into an existing same-key nudge instead of overwriting', () => {
+    const s = reduce([
+      notificationsActions.pushToast({ kind: 'info', message: '1 needs a voice', dedupeKey: 'k', nudge: nudge({}) }),
+      notificationsActions.pushToast({
+        kind: 'info', message: '1 needs a voice', dedupeKey: 'k',
+        nudge: nudge({ characterIds: ['tom'], names: ['Tom'] }),
+      }),
+    ]);
+    expect(s.toasts).toHaveLength(1);
+    expect(s.toasts[0].nudge?.characterIds).toEqual(['mara', 'tom']);
+    expect(s.toasts[0].nudge?.names).toEqual(['Mara', 'Tom']);
+  });
+
+  it('does not duplicate an id already present in the existing nudge', () => {
+    const s = reduce([
+      notificationsActions.pushToast({ kind: 'info', message: 'x', dedupeKey: 'k', nudge: nudge({}) }),
+      notificationsActions.pushToast({ kind: 'info', message: 'x', dedupeKey: 'k', nudge: nudge({}) }),
+    ]);
+    expect(s.toasts[0].nudge?.characterIds).toEqual(['mara']);
+  });
+
+  it('carries nudge on a fresh (non-dedupe) push', () => {
+    const s = reduce([
+      notificationsActions.pushToast({ kind: 'info', message: 'x', nudge: nudge({}) }),
+    ]);
+    expect(s.toasts[0].nudge?.characterIds).toEqual(['mara']);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/store/notifications-slice.test.ts`
+Expected: FAIL — `VoiceNudge` not exported / `nudge` not stored / not merged.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/store/notifications-slice.ts`:
+
+```ts
+export interface VoiceNudge {
+  bookId: string;
+  characterIds: string[];
+  modelKey: string;
+  names: string[];
+}
+
+export interface Toast {
+  id: string;
+  kind: ToastKind;
+  message: string;
+  dedupeKey?: string;
+  createdAt: number;
+  /** fs-63 — present only on the off-roster "Design now" nudge; routes the
+      toast to <VoiceNudgeToast> and exempts it from auto-dismiss. */
+  nudge?: VoiceNudge;
+}
+```
+
+Add `nudge?: VoiceNudge` to `PushToastPayload`, thread it through `prepare`, and merge in the reducer:
+
+```ts
+pushToast: {
+  reducer: (s, a: PayloadAction<{ id: string; createdAt: number } & PushToastPayload>) => {
+    const { id, kind, message, dedupeKey, createdAt, nudge } = a.payload;
+    if (dedupeKey) {
+      const existing = s.toasts.find((t) => t.dedupeKey === dedupeKey);
+      if (existing) {
+        existing.createdAt = createdAt;
+        existing.kind = kind;
+        existing.message = message;
+        // fs-63 — union nudge work-lists so a burst of off-roster creates
+        // yields ONE nudge covering every still-unvoiced character.
+        if (nudge && existing.nudge) {
+          for (let i = 0; i < nudge.characterIds.length; i++) {
+            const cid = nudge.characterIds[i];
+            if (!existing.nudge.characterIds.includes(cid)) {
+              existing.nudge.characterIds.push(cid);
+              existing.nudge.names.push(nudge.names[i]);
+            }
+          }
+        } else if (nudge) {
+          existing.nudge = nudge;
+        }
+        return;
+      }
+    }
+    s.toasts.push({ id, kind, message, dedupeKey, createdAt, nudge });
+  },
+  prepare: (payload: PushToastPayload) => ({
+    payload: {
+      ...payload,
+      id:
+        typeof crypto !== 'undefined' && 'randomUUID' in crypto
+          ? crypto.randomUUID()
+          : Math.random().toString(36).slice(2),
+      createdAt: Date.now(),
+    },
+  }),
+},
+```
+
+And extend `PushToastPayload`:
+
+```ts
+interface PushToastPayload {
+  kind: ToastKind;
+  message: string;
+  dedupeKey?: string;
+  nudge?: VoiceNudge;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- src/store/notifications-slice.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/notifications-slice.ts src/store/notifications-slice.test.ts
+git commit -m "feat(frontend): notifications Toast.nudge field + merge-dedupe"
+```
+
+---
+
+### Task 3: `VoiceNudgeToast` — dedicated busy-aware component
+
+**Files:**
+- Create: `src/components/voice-nudge-toast.tsx`
+- Test: `src/components/voice-nudge-toast.test.tsx`
+
+**Interfaces:**
+- Consumes: `Toast` (with `nudge: VoiceNudge`) from Task 2; `castDesignActions.designAllRequested`
+  (`src/store/cast-design-slice.ts`); `notificationsActions.dismissToast`; `useAppSelector`/`useAppDispatch`.
+- Reads `s.castDesign.active?.state` to decide busy.
+- Produces: `export function VoiceNudgeToast({ toast }: { toast: Toast })`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/voice-nudge-toast.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { VoiceNudgeToast } from './voice-nudge-toast';
+import { notificationsSlice, type Toast } from '../store/notifications-slice';
+import { castDesignSlice } from '../store/cast-design-slice';
+
+const makeStore = (designRunning: boolean) =>
+  configureStore({
+    reducer: { notifications: notificationsSlice.reducer, castDesign: castDesignSlice.reducer },
+    preloadedState: {
+      notifications: { toasts: [] },
+      castDesign: { active: designRunning ? ({ state: 'running', bookId: 'b1' } as never) : null },
+    },
+  });
+
+const toast: Toast = {
+  id: 't1', kind: 'info', message: 'New character «Mara» needs a voice', createdAt: 0,
+  dedupeKey: 'off-roster-voice-nudge:b1',
+  nudge: { bookId: 'b1', characterIds: ['mara'], modelKey: 'qwen3-tts-0.6b', names: ['Mara'] },
+};
+
+describe('VoiceNudgeToast', () => {
+  it('idle: tapping the button dispatches designAllRequested and dismisses the toast', () => {
+    const store = makeStore(false);
+    const spy: { type: string; payload: unknown }[] = [];
+    store.subscribe(() => {});
+    const origDispatch = store.dispatch;
+    (store as { dispatch: typeof origDispatch }).dispatch = ((a: never) => {
+      spy.push(a);
+      return origDispatch(a);
+    }) as never;
+    // seed the toast so dismiss has something to remove
+    origDispatch(notificationsSlice.actions.pushToast({ kind: 'info', message: 'x' }));
+
+    render(<Provider store={store}><VoiceNudgeToast toast={toast} /></Provider>);
+    fireEvent.click(screen.getByRole('button', { name: /design now/i }));
+
+    const design = spy.find((a) => a.type === 'castDesign/designAllRequested');
+    expect(design).toBeTruthy();
+    expect((design!.payload as { characterIds: string[] }).characterIds).toEqual(['mara']);
+    expect((design!.payload as { scope: string }).scope).toBe('bases');
+    expect((design!.payload as { modelKey: string }).modelKey).toBe('qwen3-tts-0.6b');
+    expect(spy.some((a) => a.type === 'notifications/dismissToast')).toBe(true);
+  });
+
+  it('busy: button is disabled and the nudge is NOT dismissed', () => {
+    const store = makeStore(true);
+    render(<Provider store={store}><VoiceNudgeToast toast={toast} /></Provider>);
+    const btn = screen.getByRole('button', { name: /design now/i });
+    expect(btn).toBeDisabled();
+    expect(screen.getByText(/a voice design is already running/i)).toBeTruthy();
+  });
+
+  it('plural copy when several characters need voices', () => {
+    const store = makeStore(false);
+    const plural: Toast = {
+      ...toast,
+      nudge: { ...toast.nudge!, characterIds: ['mara', 'tom'], names: ['Mara', 'Tom'] },
+    };
+    render(<Provider store={store}><VoiceNudgeToast toast={plural} /></Provider>);
+    expect(screen.getByText(/2 new characters need voices/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /design all/i })).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/components/voice-nudge-toast.test.tsx`
+Expected: FAIL — module `./voice-nudge-toast` not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/components/voice-nudge-toast.tsx`:
+
+```tsx
+/* fs-63 — off-roster "Design now" nudge. A sticky toast (no auto-dismiss)
+   rendered by ToastStack when a Toast carries a `nudge`. It mirrors the Cast
+   view's busy semantics: while a cast-design run is active (any book) the
+   action is disabled, so a tap can never silently no-op against the
+   single-stream middleware. Tapping enqueues bespoke Qwen design for exactly
+   the created characters via the existing designAllRequested pipeline. */
+
+import { useAppDispatch, useAppSelector } from '../store';
+import { IconWarning, IconClose } from '../lib/icons';
+import { notificationsActions, type Toast } from '../store/notifications-slice';
+import { castDesignActions } from '../store/cast-design-slice';
+
+export function VoiceNudgeToast({ toast }: { toast: Toast }) {
+  const dispatch = useAppDispatch();
+  const designRunning = useAppSelector((s) => s.castDesign.active?.state === 'running');
+  const nudge = toast.nudge!;
+  const count = nudge.characterIds.length;
+  const label = count > 1 ? 'Design all' : 'Design now';
+  const message =
+    count > 1
+      ? `${count} new characters need voices`
+      : `New character «${nudge.names[0]}» needs a voice`;
+
+  const onDesign = () => {
+    dispatch(
+      castDesignActions.designAllRequested({
+        bookId: nudge.bookId,
+        characterIds: nudge.characterIds,
+        modelKey: nudge.modelKey,
+        scope: 'bases',
+      }),
+    );
+    dispatch(notificationsActions.dismissToast(toast.id));
+  };
+
+  return (
+    <div className="flex flex-col gap-2 rounded-2xl border border-ink/10 bg-white px-4 py-3 shadow-card min-w-[280px] max-w-[360px] fade-in text-ink">
+      <div className="flex items-start gap-3">
+        <IconWarning className="w-4 h-4 mt-0.5 shrink-0" />
+        <p className="flex-1 text-sm leading-snug">{message}</p>
+        <button
+          type="button"
+          aria-label="Dismiss notification"
+          onClick={() => dispatch(notificationsActions.dismissToast(toast.id))}
+          className="p-1 rounded-full hover:bg-ink/10 shrink-0"
+        >
+          <IconClose className="w-3.5 h-3.5" />
+        </button>
+      </div>
+      <div className="flex items-center gap-2 pl-7">
+        <button
+          type="button"
+          disabled={designRunning}
+          onClick={onDesign}
+          className="px-3 min-h-[44px] sm:min-h-0 sm:py-1.5 rounded-full bg-ink text-canvas text-sm font-semibold disabled:opacity-40"
+        >
+          {label}
+        </button>
+        {designRunning && (
+          <span className="text-xs text-ink/55">A voice design is already running…</span>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- src/components/voice-nudge-toast.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/voice-nudge-toast.tsx src/components/voice-nudge-toast.test.tsx
+git commit -m "feat(frontend): VoiceNudgeToast busy-aware off-roster design nudge"
+```
+
+---
+
+### Task 4: `ToastStack` routes `nudge` toasts (sticky, no auto-dismiss)
+
+**Files:**
+- Modify: `src/components/toast-stack.tsx`
+- Test: `src/components/toast-stack.test.tsx`
+
+**Interfaces:**
+- Consumes: `VoiceNudgeToast` (Task 3), `Toast.nudge` (Task 2).
+- Behaviour: a toast with `nudge` renders `<VoiceNudgeToast>` (which has no auto-dismiss timer → sticky); a plain toast renders the existing `<ToastItem>` (still auto-dismisses at 6 s).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/components/toast-stack.test.tsx` (adapt to the file's existing store/render helpers):
+
+```tsx
+it('renders a nudge toast via VoiceNudgeToast and does not auto-dismiss it', () => {
+  vi.useFakeTimers();
+  const store = makeStoreWithToast({
+    id: 'n1', kind: 'info', message: 'New character «Mara» needs a voice', createdAt: Date.now(),
+    nudge: { bookId: 'b1', characterIds: ['mara'], modelKey: 'qwen3-tts-0.6b', names: ['Mara'] },
+  });
+  render(<Provider store={store}><ToastStack /></Provider>);
+  expect(screen.getByRole('button', { name: /design now/i })).toBeTruthy();
+  act(() => { vi.advanceTimersByTime(7000); });
+  // still present after the 6s window — nudge toasts are sticky
+  expect(screen.getByRole('button', { name: /design now/i })).toBeTruthy();
+  vi.useRealTimers();
+});
+```
+
+> If `toast-stack.test.tsx` has no `makeStoreWithToast` helper, build a store with
+> `notifications` + `castDesign` reducers and a preloaded `toasts: [theToast]`, mirroring the
+> Task 3 test's `makeStore`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/components/toast-stack.test.tsx`
+Expected: FAIL — no "Design now" button (nudge not routed).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/components/toast-stack.tsx`, import the component and branch in the map:
+
+```tsx
+import { VoiceNudgeToast } from './voice-nudge-toast';
+```
+
+```tsx
+{toasts.map((t) =>
+  t.nudge ? <VoiceNudgeToast key={t.id} toast={t} /> : <ToastItem key={t.id} toast={t} />,
+)}
+```
+
+(No change to `ToastItem`; its 6 s auto-dismiss is untouched, so plain toasts behave exactly as before. Nudge toasts never mount `ToastItem`, so they have no dismiss timer → sticky.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- src/components/toast-stack.test.tsx`
+Expected: PASS (new case + existing cases green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/toast-stack.tsx src/components/toast-stack.test.tsx
+git commit -m "feat(frontend): ToastStack routes nudge toasts to VoiceNudgeToast"
+```
+
+---
+
+### Task 5: `script-review-diff.tsx` pushes the nudge after apply
+
+**Files:**
+- Modify: `src/components/script-review-diff.tsx`
+- Test: `src/components/script-review-diff.test.tsx`
+
+**Interfaces:**
+- Consumes: `applyProposedReattributions` (now returns `createdCharacters`, Task 1);
+  `engineForModelKey` (`src/lib/tts-models.ts`); `sampleModelKeyForEngine`
+  (`src/lib/tts-voice-mapping.ts`); `notificationsActions.pushToast` with `nudge` (Task 2);
+  `s.ui.ttsModelKey`.
+- Behaviour: after `runProposed`, when `createdCharacters` is non-empty AND
+  `engineForModelKey(ttsModelKey) === 'qwen'`, dispatch `pushToast` with the nudge payload +
+  `dedupeKey: \`off-roster-voice-nudge:${startBookId}\``.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/components/script-review-diff.test.tsx` two cases (adapt to the file's existing
+render harness + mock of `api.createCharacter`). The key assertions:
+
+```tsx
+it('pushes a Design-now nudge after an off-roster create on a Qwen project', async () => {
+  // store seeded with ui.ttsModelKey = 'qwen3-tts-0.6b', an active off-roster review bucket,
+  // and api.createCharacter mocked to resolve { character: { id: 'mara', name: 'Mara' } }.
+  // …drive the confirm flow to completion (create "Mara")…
+  await waitFor(() => {
+    const t = store.getState().notifications.toasts.find((x) => x.nudge);
+    expect(t).toBeTruthy();
+    expect(t!.nudge!.characterIds).toEqual(['mara']);
+    expect(t!.nudge!.modelKey).toBe('qwen3-tts-0.6b');
+    expect(t!.dedupeKey).toMatch(/^off-roster-voice-nudge:/);
+  });
+});
+
+it('pushes NO nudge on a preset-engine (kokoro) project', async () => {
+  // same flow but ui.ttsModelKey = 'kokoro-v1'
+  await waitFor(() => { /* flow done */ });
+  expect(store.getState().notifications.toasts.some((x) => x.nudge)).toBe(false);
+});
+```
+
+> If driving the full confirm UI is heavy in this suite, factor the push into a tiny exported
+> helper `maybePushVoiceNudge(dispatch, { ttsModelKey, startBookId, createdCharacters })` in
+> `script-review-diff.tsx` and unit-test THAT directly (engine gate + payload), keeping the
+> component test to a single happy-path render. Either satisfies the gate.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/components/script-review-diff.test.tsx`
+Expected: FAIL — no nudge toast pushed.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add imports to `src/components/script-review-diff.tsx`:
+
+```tsx
+import { notificationsActions } from '../store/notifications-slice';
+import { engineForModelKey } from '../lib/tts-models';
+import { sampleModelKeyForEngine } from '../lib/tts-voice-mapping';
+```
+
+Read the model key at component scope (near the other `useAppSelector`s, ~line 143):
+
+```tsx
+const ttsModelKey = useAppSelector((s) => s.ui.ttsModelKey);
+```
+
+In `runProposed`, capture the result and push the nudge:
+
+```tsx
+const { createdCharacters } = await applyProposedReattributions(finalized, {
+  /* …existing deps unchanged… */
+});
+if (createdCharacters.length > 0 && engineForModelKey(ttsModelKey) === 'qwen') {
+  dispatch(
+    notificationsActions.pushToast({
+      kind: 'info',
+      message:
+        createdCharacters.length > 1
+          ? `${createdCharacters.length} new characters need voices`
+          : `New character «${createdCharacters[0].name}» needs a voice`,
+      dedupeKey: `off-roster-voice-nudge:${startBookId}`,
+      nudge: {
+        bookId: startBookId,
+        characterIds: createdCharacters.map((c) => c.id),
+        modelKey: sampleModelKeyForEngine('qwen', ttsModelKey),
+        names: createdCharacters.map((c) => c.name),
+      },
+    }),
+  );
+}
+setConfirm(null);
+dispatch(scriptReviewActions.clearReview({ bookId: startBookId }));
+```
+
+> The `message` here seeds the dedupe-display text; `VoiceNudgeToast` recomputes its own copy
+> from `nudge`, so the two stay consistent. `startBookId` (not the live `bookId`) keeps the
+> nudge bound to the book the characters were created in.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- src/components/script-review-diff.test.tsx`
+Expected: PASS (Qwen pushes nudge; kokoro pushes none).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/script-review-diff.tsx src/components/script-review-diff.test.tsx
+git commit -m "feat(frontend): push off-roster voice nudge after apply (qwen-only)"
+```
+
+---
+
+### Task 6: e2e — nudge appears and activates the design pill
+
+**Files:**
+- Modify: `e2e/script-review.spec.ts`
+
+**Interfaces:**
+- Consumes: the mock-mode script-review flow already exercised by this spec.
+
+- [ ] **Step 1: Write the failing test**
+
+Add a spec that drives an off-roster reattribute on a Qwen mock book, confirms the create, then
+asserts the nudge appears and tapping it activates the `DesignPill`:
+
+```ts
+test('off-roster reattribute on a Qwen book surfaces a Design-now nudge that activates the design pill', async ({ page }) => {
+  // …open a Qwen mock book, open script review, pick an off-roster reattribute op,
+  //   confirm CreateCharacterForm with a new name…
+  await expect(page.getByRole('button', { name: /design now/i })).toBeVisible();
+  await page.getByRole('button', { name: /design now/i }).click();
+  // The DesignPill seeds synchronously via castDesign begin.
+  await expect(page.getByTestId('design-pill')).toBeVisible();
+});
+```
+
+> Reuse the spec's existing helpers for entering script review and the off-roster confirm path.
+> Confirm the real `data-testid` of the design pill from `src/components/layout.tsx` (search
+> `design-pill` / the `DesignPill` render) and match it; adjust the selector if it differs.
+
+- [ ] **Step 2: Run test to verify it fails (or is RED before wiring)**
+
+Run: `npm run test:e2e -- script-review`
+Expected: FAIL until Tasks 1–5 are merged into the running build.
+
+- [ ] **Step 3: Implement** — no new app code; this task validates Tasks 1–5 end-to-end. If the
+selector or flow needs a `data-testid`, add the minimal one to the relevant component.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test:e2e -- script-review`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/script-review.spec.ts
+git commit -m "test(frontend): e2e off-roster voice nudge → design pill"
+```
+
+---
+
+### Task 7: Docs, issue, and backlog cleanup
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-25-fs63-auto-voice-off-roster-character-design.md` (frontmatter `status: draft` → `stable` + Ship notes)
+- Modify: `docs/BACKLOG.md` (remove the fs-63 row)
+- Modify: `docs/features/INDEX.md` (only if a regression plan doc is added — this feature is small/localized, so the spec + paired tests are the record; note that explicitly in the PR)
+- External: GitHub issue #1119 (soften benefit line), PR body (`Closes #1119`)
+
+- [ ] **Step 1:** Flip the spec frontmatter to `status: stable`; add a **Ship notes** line with the merge date + commit SHA (filled at merge time).
+- [ ] **Step 2:** Remove the fs-63 row from `docs/BACKLOG.md`.
+- [ ] **Step 3:** Edit issue #1119's benefit line from *"audible in one pass"* to *"audible in one tap"* (the consent-gate consequence): `gh issue edit 1119 --body-file -`.
+- [ ] **Step 4:** Commit:
+
+```bash
+git add docs/superpowers/specs/2026-06-25-fs63-auto-voice-off-roster-character-design.md docs/BACKLOG.md
+git commit -m "docs(docs): ship fs-63 — backlog row + spec status + ship notes"
+```
+
+> Final delivery gate (outside the task commits): `npm run verify` green, then open the PR with a
+> conventional title and a mini-release-notes body containing `Closes #1119`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3.1 created-characters return → Task 1. ✓
+- §3.2 `Toast.nudge` field + merge-dedupe → Task 2. ✓
+- §3.2 dedicated busy-aware `VoiceNudgeToast` (disabled while running, sticky) → Task 3. ✓
+- §3.2 `ToastStack` routing on the `nudge` field (no new `kind`) → Task 4. ✓
+- §3.3 push gated to qwen, dedupeKey, abort-inclusive → Task 5. ✓
+- §4 edge cases (busy, already-designed, book-switch, mixed batch) → covered across Tasks 1/3/5 tests. ✓
+- §5 testing (unit slice, unit component, unit script-review, e2e) → Tasks 2/3/5/6. ✓
+- §6/§7 docs + benefit-line softening + backlog → Task 7. ✓
+
+**Placeholder scan:** all code steps carry full code; the e2e/script-review tests note "adapt to existing harness" but give exact assertions — acceptable since the harness specifics are discoverable and the behavioural contract is concrete.
+
+**Type consistency:** `VoiceNudge` (`bookId`, `characterIds`, `modelKey`, `names`) is defined in Task 2 and consumed unchanged in Tasks 3 & 5. `createdCharacters: {id,name}[]` defined in Task 1, consumed in Task 5. `designAllRequested({ bookId, characterIds, modelKey, scope })` matches `DesignAllRequestedPayload` in `cast-design-slice.ts`. Busy predicate `castDesign.active?.state === 'running'` consistent across Task 3 impl + test.

--- a/docs/superpowers/specs/2026-06-25-fs63-auto-voice-off-roster-character-design.md
+++ b/docs/superpowers/specs/2026-06-25-fs63-auto-voice-off-roster-character-design.md
@@ -1,11 +1,15 @@
 ---
-status: draft
+status: stable
 issue: 1119
 backlog-id: fs-63
 follow-up-of: fs-58 Unit B (#1040)
 ---
 
 # fs-63 — Auto-voice a created off-roster character
+
+> **Ship notes.** Shipped 2026-06-25 on branch `feat/frontend-fs-63-auto-voice` (impl commits
+> `8c7f87ec`…`c6d5139b` + e2e). Benefit line softened from "audible in one pass" to "audible in
+> one tap" (the consent-gate consequence — §6). Closes #1119.
 
 ## 1. Problem
 

--- a/docs/superpowers/specs/2026-06-25-fs63-auto-voice-off-roster-character-design.md
+++ b/docs/superpowers/specs/2026-06-25-fs63-auto-voice-off-roster-character-design.md
@@ -57,64 +57,76 @@ intact.
 
 ## 3. Architecture & data flow
 
-Three small touch points; no new server route, no new infra beyond a generic actionable-toast
-capability.
+Three small touch points; no new server route, no new infra. The nudge is a **dedicated,
+cast-design-aware component**, not a generic actionable-toast capability — see §3.2 for why.
 
-### 3.1 `src/lib/apply-proposed.ts` — return the created ids
+### 3.1 `src/lib/apply-proposed.ts` — return the created characters
 
 `applyProposedReattributions` already tracks ids minted this batch in its `memo` map. Extend its
 return from `{ created: number; aborted: boolean }` to
-`{ created: number; createdIds: string[]; aborted: boolean }`. `createdIds` lists the ids
-actually minted this batch (empty when every proposed op deduped to an existing roster member).
-The order matches creation order; on an aborted batch it carries the ids created before the
-abort.
+`{ created: number; createdCharacters: { id: string; name: string }[]; aborted: boolean }`.
+`createdCharacters` carries the `{id, name}` of every character actually minted this batch
+(empty when every proposed op deduped to an existing roster member). The `name` rides along so
+the nudge copy can name the character without a second lookup — `createCharacter` already returns
+`{id, name}`. The order matches creation order; on an aborted batch it carries the characters
+created before the abort.
 
-### 3.2 `src/store/notifications-slice.ts` + `src/components/toast-stack.tsx` — actionable toasts
+### 3.2 The nudge is a dedicated, busy-aware component — NOT a generic actionable toast
 
-Extend the `Toast` model with an optional, **serializable** action descriptor:
+A first design sketched a generic `{ label, dispatch }` action on every `Toast`. It was rejected
+on two grounds:
 
-```ts
-interface ToastAction {
-  /** Button label, e.g. "Design now" / "Design all". */
-  label: string;
-  /** A plain, serializable Redux action object dispatched on click. */
-  dispatch: { type: string; payload: unknown };
-}
-```
+1. **YAGNI.** A serializable-action-on-any-toast capability is speculative for a single consumer.
+2. **It can't handle the re-entrancy reality.** The cast-design middleware enforces ONE in-flight
+   design stream at a time, for any book: `cast-design-stream-middleware.ts` early-returns on
+   `if (handle) …` when a bulk, single (drawer), or cold-boot-resubscribe stream is already open.
+   The Cast view copes by **disabling its "Design full cast" button** while a run is active
+   (`designRunningHere` / `designRunningElsewhere`). A dumb dispatch-then-dismiss toast has no way
+   to know the middleware is busy — tapping it would silently no-op AND dismiss the nudge, leaving
+   the character undesigned with zero feedback.
 
-- `pushToast`'s payload gains an optional `action?: ToastAction`.
-- `ToastItem` renders `action.label` as a button beside the dismiss control; on click it
-  dispatches `toast.action.dispatch` then dismisses the toast.
-- **Actionable toasts are sticky** — the 6 s auto-dismiss timer is skipped when `action` is
-  present, so the operator doesn't lose the window before a GPU action. Plain toasts are
-  unchanged (still auto-dismiss at 6 s).
+So the nudge is its own small component (`src/components/voice-nudge-toast.tsx`), rendered by
+`ToastStack` for a new `Toast.kind: 'action'` carrying a typed `nudge` payload
+(`{ bookId, characterIds, modelKey, names: string[] }`) — NOT an opaque action object. It reads
+`castDesign.active` live and mirrors the Cast view's busy semantics:
 
-This is a **generic** capability (any future toast can carry an action), not a cast-design
-special-case. The notifications slice stays decoupled: it holds an opaque `{ type, payload }`
-object and never imports cast-design. The action object is a plain serializable literal, so RTK's
-`serializableCheck` is satisfied.
+- **Idle:** the action button reads "Design now" / "Design all"; tapping dispatches
+  `castDesignActions.designAllRequested(...)` (built from the `nudge` payload) and dismisses.
+- **A design is already running (any book):** the button is **disabled** with sub-text
+  *"A voice design is already running…"* — the nudge **stays** (sticky), so the operator can act
+  once the current run settles. No silent loss.
+- **Sticky.** Action-kind toasts skip the 6 s auto-dismiss (a GPU action needs a real window);
+  they clear on action, on manual dismiss, or via dedupe replacement.
+
+`notifications-slice.ts` gains the `'action'` kind + the typed `nudge` field on `Toast`; the
+payload is a plain serializable literal (ids + strings), so RTK's `serializableCheck` is satisfied
+and the slice still never imports cast-design (the *component* owns that dependency).
 
 ### 3.3 `src/components/script-review-diff.tsx` `runProposed` — push the nudge
 
 `ttsModelKey` is read once at component scope via `useAppSelector(s => s.ui.ttsModelKey)`
 (the async `runProposed` can't call hooks). Mirror the existing `stageBookIdRef` pattern if a
-fresh value is needed at resolve time. After `applyProposedReattributions` resolves with
-non-empty `createdIds`:
+fresh value is needed at resolve time. After `applyProposedReattributions` resolves with a
+non-empty `createdCharacters`:
 
-1. Compute the effective engine via `engineForModelKey(ttsModelKey)`.
-2. **Only when the effective engine is `'qwen'`**, push the actionable toast. Its baked action is:
+1. Compute the effective engine via `engineForModelKey(ttsModelKey)` — mirroring exactly how
+   `cast.tsx` derives the active engine, so the gate can't diverge from the Cast view.
+2. **Only when the effective engine is `'qwen'`**, push the action-kind nudge with payload:
 
    ```ts
-   castDesignActions.designAllRequested({
+   {
      bookId: startBookId,
-     characterIds: createdIds,
+     characterIds: createdCharacters.map((c) => c.id),
      modelKey: sampleModelKeyForEngine('qwen', ttsModelKey),
-     scope: 'bases',
-   })
+     names: createdCharacters.map((c) => c.name),
+   }
    ```
 
-One toast covers the whole batch (designs all `createdIds` at once), not one toast per character.
-The message is count-aware: singular names the character, plural states the count.
+   plus `dedupeKey: \`off-roster-voice-nudge:${startBookId}\`` so a second off-roster batch
+   replaces the prior nudge rather than stacking a duplicate.
+
+One nudge covers the whole batch (designs all created ids at once via `scope: 'bases'`), not one
+per character. The copy is count-aware: singular names the character, plural states the count.
 
 ## 4. Edge cases & gating
 
@@ -128,22 +140,33 @@ The message is count-aware: singular names the character, plural states the coun
   bulk job no-ops against a book that has moved on).
 - **Already designed before the tap.** The bulk job's freshness-skip already protects a character
   that gained a Qwen voice in the interim — it is skipped, never clobbered.
-- **Batch with mixed creates + reattribute-to-existing.** Only minted ids enter `createdIds`;
-  reattribute-to-existing decisions never mint a character, so they never trigger a nudge.
+- **A design is already running when the operator taps.** The nudge button is disabled with
+  *"A voice design is already running…"* (§3.2) and the nudge stays sticky — no silent no-op.
+  Once the in-flight run settles, the button re-enables and the operator can act.
+- **Batch with mixed creates + reattribute-to-existing.** Only minted characters enter
+  `createdCharacters`; reattribute-to-existing decisions never mint a character, so they never
+  trigger a nudge.
+- **Relationship to the generation-time fallback gate.** The created character also trips the
+  existing `computeQwenKokoroFallbackSet`, which *pauses the chapter at generation time* to warn
+  about the generic-Kokoro fallback. The nudge is the **proactive complement** to that safety
+  net — design early via the nudge and the generation-time pause never fires. The two reinforce
+  each other; neither is removed.
 
 ## 5. Testing
 
-- **Unit — `src/lib/apply-proposed.test.ts`:** `createdIds` lists every minted id for new
-  creates; empty when all proposed ops dedupe to existing roster members; carries
-  partial ids on an aborted (book-switch) batch.
-- **Unit — `src/components/toast-stack.test.tsx`:** an actionable toast renders its label
-  button and dispatches the stored action on click; actionable toasts are sticky (no
-  auto-dismiss); plain toasts still auto-dismiss at 6 s.
+- **Unit — `src/lib/apply-proposed.test.ts`:** `createdCharacters` lists `{id, name}` for every
+  minted character; empty when all proposed ops dedupe to existing roster members; carries
+  partial entries on an aborted (book-switch) batch.
+- **Unit — `src/components/voice-nudge-toast.test.tsx`:** idle → the action button dispatches
+  `designAllRequested` with the right `characterIds`/`modelKey`/`scope` then dismisses;
+  **design-running → button disabled, nudge stays (not dismissed)**; count-aware copy (singular
+  names the character, plural states the count); action-kind toasts are sticky (no 6 s
+  auto-dismiss) while plain toasts still auto-dismiss.
 - **Unit — `src/components/script-review-diff.test.tsx`:** a Qwen-effective project pushes the
-  nudge with the correct `characterIds` + `modelKey`; a preset-engine project pushes nothing;
-  a batch that only reattributes-to-existing pushes nothing.
+  nudge with the correct payload; a preset-engine project pushes nothing; a batch that only
+  reattributes-to-existing pushes nothing.
 - **E2E — `e2e/script-review.spec.ts`:** off-roster reattribute on a Qwen mock book → nudge
-  toast appears → tap the action → the `DesignPill` activates. One spec, per the e2e bar for
+  appears → tap the action → the `DesignPill` activates. One spec, per the e2e bar for
   behaviour crossing router / redux / layout seams.
 
 ## 6. Non-goals & notes

--- a/docs/superpowers/specs/2026-06-25-fs63-auto-voice-off-roster-character-design.md
+++ b/docs/superpowers/specs/2026-06-25-fs63-auto-voice-off-roster-character-design.md
@@ -1,0 +1,166 @@
+---
+status: draft
+issue: 1119
+backlog-id: fs-63
+follow-up-of: fs-58 Unit B (#1040)
+---
+
+# fs-63 — Auto-voice a created off-roster character
+
+## 1. Problem
+
+fs-58 Unit B added an off-roster `reattribute` flow: when the LLM script review proposes
+moving a line to a speaker not on the roster, the operator confirms a `CreateCharacterForm`,
+which mints a brand-new cast member via `POST /cast/create` and reassigns the line to it.
+
+The minted member lands `voiceState: 'generated'` with **no voice override**. What that means
+for audibility depends entirely on the project's TTS engine — and the engine split is the
+crux of this feature:
+
+- **Preset engines (Kokoro / Coqui / Gemini):** `pickVoiceForEngine` infers a
+  gender/age-appropriate voice from the character's profile, so the new member is **already
+  audible** with a sensible preset. Nothing is broken here.
+- **Qwen (the default / main generation engine):** `pickVoiceForEngine('qwen', …)` returns
+  `''` for an undesigned character. That is worse than silent: `computeQwenKokoroFallbackSet`
+  detects the undesigned-voice fallback and **pauses the chapter at generation time** asking
+  the operator to confirm or skip a generic-Kokoro fallback. The missing voice becomes a
+  generation *blocker*, and the reassigned line never sounds like its own character.
+
+So fs-63 is, in practice, a **Qwen-project** problem: a created off-roster character needs a
+bespoke Qwen voice before its reattributed line is properly audible.
+
+**Benefit (user):** an off-roster reattribute becomes properly audible in one tap, without a
+separate trip to the Cast view to design a voice.
+
+## 2. Approach
+
+After an off-roster create on a Qwen project, surface a single **actionable toast** nudging the
+operator to design voices for the freshly-created character(s). Tapping the action enqueues
+exactly those characters into the **existing bulk-design pipeline** (`designAllRequested`),
+which runs the srv-48 persona pre-pass + Qwen VoiceDesign and reports progress on the
+`DesignPill` — the same machinery as "Design full cast", scoped to the new ids.
+
+### 2.1 Why a toast nudge, not fully automatic
+
+Bespoke Qwen design loads the VoiceDesign 1.7B model (~4–5 GB, evicts the analyzer) and takes
+tens of seconds per character. Firing that silently on create would surprise an operator who is
+mid-review and not yet ready to generate. A consent-driven nudge keeps the heavy GPU work
+deliberate. The cost is honest: this is **one tap, not zero** — see §6.
+
+### 2.2 Why bespoke design, not a cheap preset stamp
+
+A lighter alternative — stamping a deterministic Kokoro override on create — would make the line
+audible instantly with no GPU. It was rejected: an explicit override renders the character in
+Kokoro *forever* and drops it out of the "Design full cast" nudge, leaving a non-bespoke voice
+on a bespoke-voice project. Reusing the real design pipeline keeps the Qwen project's intent
+intact.
+
+## 3. Architecture & data flow
+
+Three small touch points; no new server route, no new infra beyond a generic actionable-toast
+capability.
+
+### 3.1 `src/lib/apply-proposed.ts` — return the created ids
+
+`applyProposedReattributions` already tracks ids minted this batch in its `memo` map. Extend its
+return from `{ created: number; aborted: boolean }` to
+`{ created: number; createdIds: string[]; aborted: boolean }`. `createdIds` lists the ids
+actually minted this batch (empty when every proposed op deduped to an existing roster member).
+The order matches creation order; on an aborted batch it carries the ids created before the
+abort.
+
+### 3.2 `src/store/notifications-slice.ts` + `src/components/toast-stack.tsx` — actionable toasts
+
+Extend the `Toast` model with an optional, **serializable** action descriptor:
+
+```ts
+interface ToastAction {
+  /** Button label, e.g. "Design now" / "Design all". */
+  label: string;
+  /** A plain, serializable Redux action object dispatched on click. */
+  dispatch: { type: string; payload: unknown };
+}
+```
+
+- `pushToast`'s payload gains an optional `action?: ToastAction`.
+- `ToastItem` renders `action.label` as a button beside the dismiss control; on click it
+  dispatches `toast.action.dispatch` then dismisses the toast.
+- **Actionable toasts are sticky** — the 6 s auto-dismiss timer is skipped when `action` is
+  present, so the operator doesn't lose the window before a GPU action. Plain toasts are
+  unchanged (still auto-dismiss at 6 s).
+
+This is a **generic** capability (any future toast can carry an action), not a cast-design
+special-case. The notifications slice stays decoupled: it holds an opaque `{ type, payload }`
+object and never imports cast-design. The action object is a plain serializable literal, so RTK's
+`serializableCheck` is satisfied.
+
+### 3.3 `src/components/script-review-diff.tsx` `runProposed` — push the nudge
+
+`ttsModelKey` is read once at component scope via `useAppSelector(s => s.ui.ttsModelKey)`
+(the async `runProposed` can't call hooks). Mirror the existing `stageBookIdRef` pattern if a
+fresh value is needed at resolve time. After `applyProposedReattributions` resolves with
+non-empty `createdIds`:
+
+1. Compute the effective engine via `engineForModelKey(ttsModelKey)`.
+2. **Only when the effective engine is `'qwen'`**, push the actionable toast. Its baked action is:
+
+   ```ts
+   castDesignActions.designAllRequested({
+     bookId: startBookId,
+     characterIds: createdIds,
+     modelKey: sampleModelKeyForEngine('qwen', ttsModelKey),
+     scope: 'bases',
+   })
+   ```
+
+One toast covers the whole batch (designs all `createdIds` at once), not one toast per character.
+The message is count-aware: singular names the character, plural states the count.
+
+## 4. Edge cases & gating
+
+- **Engine gate.** Qwen only, computed at push time from `ttsModelKey`. Preset-engine projects
+  push nothing — the picker already voices the character.
+- **Qwen unavailable / cold.** The toast still shows; tapping kicks the job, which auto-loads
+  Qwen exactly as "Design full cast" does. A load failure surfaces per-character in the
+  `DesignPill` completion summary — no bespoke handling.
+- **Book switch during apply.** The existing `isSameBook()` guard aborts the create loop; the
+  toast's baked action carries `startBookId`, so a later tap targets the correct book (and the
+  bulk job no-ops against a book that has moved on).
+- **Already designed before the tap.** The bulk job's freshness-skip already protects a character
+  that gained a Qwen voice in the interim — it is skipped, never clobbered.
+- **Batch with mixed creates + reattribute-to-existing.** Only minted ids enter `createdIds`;
+  reattribute-to-existing decisions never mint a character, so they never trigger a nudge.
+
+## 5. Testing
+
+- **Unit — `src/lib/apply-proposed.test.ts`:** `createdIds` lists every minted id for new
+  creates; empty when all proposed ops dedupe to existing roster members; carries
+  partial ids on an aborted (book-switch) batch.
+- **Unit — `src/components/toast-stack.test.tsx`:** an actionable toast renders its label
+  button and dispatches the stored action on click; actionable toasts are sticky (no
+  auto-dismiss); plain toasts still auto-dismiss at 6 s.
+- **Unit — `src/components/script-review-diff.test.tsx`:** a Qwen-effective project pushes the
+  nudge with the correct `characterIds` + `modelKey`; a preset-engine project pushes nothing;
+  a batch that only reattributes-to-existing pushes nothing.
+- **E2E — `e2e/script-review.spec.ts`:** off-roster reattribute on a Qwen mock book → nudge
+  toast appears → tap the action → the `DesignPill` activates. One spec, per the e2e bar for
+  behaviour crossing router / redux / layout seams.
+
+## 6. Non-goals & notes
+
+- **"One tap, not zero."** The issue's benefit line reads *"audible in one pass."* This design
+  deliberately makes it **one tap** — the consent gate for a 4–5 GB GPU load is the point of the
+  chosen toast-nudge trigger. The backlog/issue benefit should read *"audible in one tap."*
+- **No preset-engine behaviour change.** Preset projects already auto-voice the character; this
+  feature adds nothing there.
+- **No new server route.** Reuses `POST /cast/create` (unchanged) and the existing cast-design
+  SSE job.
+- **No cross-chapter reattribute context** (a separate fs-58 Unit B follow-up).
+
+## 7. Ship checklist
+
+- Close #1119 via `Closes #1119` in the delivering PR; remove the fs-63 row from
+  `docs/BACKLOG.md`.
+- Update `docs/features/INDEX.md` if a regression plan is added.
+- Soften the issue/backlog benefit line to *"audible in one tap"* (§6).
+- Run `npm run verify`.

--- a/docs/superpowers/specs/2026-06-25-fs63-auto-voice-off-roster-character-design.md
+++ b/docs/superpowers/specs/2026-06-25-fs63-auto-voice-off-roster-character-design.md
@@ -34,8 +34,9 @@ separate trip to the Cast view to design a voice.
 
 ## 2. Approach
 
-After an off-roster create on a Qwen project, surface a single **actionable toast** nudging the
-operator to design voices for the freshly-created character(s). Tapping the action enqueues
+After an off-roster create on a Qwen project, surface a single **action nudge** (a sticky toast
+with a "Design now" button — see §3.2) prompting the operator to design voices for the
+freshly-created character(s). Tapping the action enqueues
 exactly those characters into the **existing bulk-design pipeline** (`designAllRequested`),
 which runs the srv-48 persona pre-pass + Qwen VoiceDesign and reports progress on the
 `DesignPill` — the same machinery as "Design full cast", scoped to the new ids.
@@ -86,21 +87,50 @@ on two grounds:
    the character undesigned with zero feedback.
 
 So the nudge is its own small component (`src/components/voice-nudge-toast.tsx`), rendered by
-`ToastStack` for a new `Toast.kind: 'action'` carrying a typed `nudge` payload
-(`{ bookId, characterIds, modelKey, names: string[] }`) — NOT an opaque action object. It reads
-`castDesign.active` live and mirrors the Cast view's busy semantics:
+`ToastStack`. It is discriminated by an **optional `nudge` field** on `Toast`, NOT a new
+`kind` value:
 
-- **Idle:** the action button reads "Design now" / "Design all"; tapping dispatches
-  `castDesignActions.designAllRequested(...)` (built from the `nudge` payload) and dismisses.
-- **A design is already running (any book):** the button is **disabled** with sub-text
-  *"A voice design is already running…"* — the nudge **stays** (sticky), so the operator can act
-  once the current run settles. No silent loss.
-- **Sticky.** Action-kind toasts skip the 6 s auto-dismiss (a GPU action needs a real window);
-  they clear on action, on manual dismiss, or via dedupe replacement.
+```ts
+interface VoiceNudge {
+  bookId: string;
+  characterIds: string[];
+  modelKey: string;
+  names: string[];
+}
+// Toast gains:  nudge?: VoiceNudge;   kind stays 'error' | 'warn' | 'info' (use 'info').
+```
 
-`notifications-slice.ts` gains the `'action'` kind + the typed `nudge` field on `Toast`; the
-payload is a plain serializable literal (ids + strings), so RTK's `serializableCheck` is satisfied
-and the slice still never imports cast-design (the *component* owns that dependency).
+**Why a field, not a `kind: 'action'`:** the toast `kind` union is **re-declared as a literal**
+in `layout.tsx` (`pushToast`'s arg type is `kind: 'error' | 'warn' | 'info'`, not an imported
+`ToastKind`), and `toast-stack.tsx`'s `kindClass` switch is non-exhaustive. A new kind would
+compile-break `layout.tsx` and fall through the style switch. Discriminating on the presence of
+`nudge` adds zero churn to either: `ToastStack` renders `<VoiceNudgeToast>` when `toast.nudge` is
+set, else the existing `<ToastItem>`.
+
+`<VoiceNudgeToast>` reads `castDesign.active` live and mirrors the Cast view's busy semantics:
+
+- **Idle** (`castDesign.active?.state !== 'running'`): the button reads "Design now" / "Design
+  all"; tapping dispatches `castDesignActions.designAllRequested({ ...nudge, scope: 'bases' })`
+  and dismisses.
+- **A design is already running** (`castDesign.active?.state === 'running'`, any book — the exact
+  predicate behind the Cast view's `designRunningHere || designRunningElsewhere`): the button is
+  **disabled** with sub-text *"A voice design is already running…"* — the nudge **stays**
+  (sticky), so the operator can act once the current run settles. No silent loss. (The micro-race
+  between this `state` read and the middleware's `handle` guard is the same one the Cast view
+  already lives with — parity, accepted.)
+- **Sticky.** A toast carrying `nudge` skips the 6 s auto-dismiss (a GPU action needs a real
+  window); it clears on action, on manual dismiss, or via merge-dedupe (below).
+
+`notifications-slice.ts` gains the typed `nudge?` field on `Toast`; the payload is a plain
+serializable literal (ids + strings), so RTK's `serializableCheck` is satisfied and the slice
+still never imports cast-design (the *component* owns that dependency).
+
+**Merge-dedupe (load-bearing).** The current `pushToast` dedupe branch copies only
+`createdAt`/`kind`/`message` onto an existing same-key toast — it would NOT update `nudge`, so a
+second off-roster batch would silently keep the first batch's stale `characterIds`. The slice
+must therefore **merge** an incoming `nudge` into the existing same-`dedupeKey` toast: union
+`characterIds` and `names` (dedupe by id, preserve order). A burst of off-roster creates then
+yields ONE nudge covering every still-unvoiced character, not a nudge frozen on the first batch.
 
 ### 3.3 `src/components/script-review-diff.tsx` `runProposed` — push the nudge
 
@@ -123,10 +153,14 @@ non-empty `createdCharacters`:
    ```
 
    plus `dedupeKey: \`off-roster-voice-nudge:${startBookId}\`` so a second off-roster batch
-   replaces the prior nudge rather than stacking a duplicate.
+   **merges** into the prior nudge (§3.2 merge-dedupe) rather than stacking or clobbering it.
 
-One nudge covers the whole batch (designs all created ids at once via `scope: 'bases'`), not one
-per character. The copy is count-aware: singular names the character, plural states the count.
+Push the nudge whenever `createdCharacters` is non-empty — **including an aborted (book-switch)
+batch**: those characters are already persisted on disk and genuinely need voices, and the nudge
+carries their own `startBookId`, so a later tap targets the right book regardless of where the
+operator navigated. One nudge covers the whole batch (designs all created ids at once via
+`scope: 'bases'`), not one per character. The copy is count-aware: singular names the character,
+plural states the count.
 
 ## 4. Edge cases & gating
 
@@ -157,11 +191,14 @@ per character. The copy is count-aware: singular names the character, plural sta
 - **Unit — `src/lib/apply-proposed.test.ts`:** `createdCharacters` lists `{id, name}` for every
   minted character; empty when all proposed ops dedupe to existing roster members; carries
   partial entries on an aborted (book-switch) batch.
+- **Unit — `src/store/notifications-slice.test.ts`:** a `nudge`-bearing push merges (unions
+  `characterIds`/`names`, dedupe by id) into an existing same-`dedupeKey` toast rather than
+  overwriting it; a `nudge` toast is exempt from auto-dismiss.
 - **Unit — `src/components/voice-nudge-toast.test.tsx`:** idle → the action button dispatches
-  `designAllRequested` with the right `characterIds`/`modelKey`/`scope` then dismisses;
-  **design-running → button disabled, nudge stays (not dismissed)**; count-aware copy (singular
-  names the character, plural states the count); action-kind toasts are sticky (no 6 s
-  auto-dismiss) while plain toasts still auto-dismiss.
+  `designAllRequested` with the right `characterIds`/`modelKey`/`scope: 'bases'` then dismisses;
+  **design-running (`castDesign.active.state==='running'`) → button disabled, nudge stays (not
+  dismissed)**; count-aware copy (singular names the character, plural states the count);
+  `ToastStack` routes a `nudge` toast to `VoiceNudgeToast` and a plain toast to `ToastItem`.
 - **Unit — `src/components/script-review-diff.test.tsx`:** a Qwen-effective project pushes the
   nudge with the correct payload; a preset-engine project pushes nothing; a batch that only
   reattributes-to-existing pushes nothing.

--- a/e2e/script-review.spec.ts
+++ b/e2e/script-review.spec.ts
@@ -237,3 +237,59 @@ test.describe('fs-58 Unit B — reattribute + flag_nonstory accept flow', () => 
     ).toBeVisible({ timeout: 5_000 });
   });
 });
+
+/* fs-63 — auto-voice a created off-roster character.
+   On a Qwen project, the off-roster reattribute that mints "Ferra" surfaces a
+   sticky "Design now" nudge; tapping it enqueues bespoke design (the design job
+   activates — pill "Designing"/"Designed N" + the cast-design-done toast). On a
+   preset-engine project no nudge would fire (covered by the unit tests). */
+test.describe('fs-63 — off-roster auto-voice nudge', () => {
+  test('Qwen project: off-roster create surfaces a Design-now nudge that kicks design', async ({
+    page,
+  }) => {
+    await page.goto('/#/books/sb/manuscript');
+    await expect(page.getByRole('heading', { name: /^Chapter \d+/i, level: 1 })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    /* Put the project on Qwen so the nudge gate (engineForModelKey === 'qwen')
+       passes. setTtsModelKey flips ttsModelKeyExplicit, so the default-seed
+       effect won't overwrite it. */
+    await page.evaluate(() => {
+      const store = (window as unknown as { __store__: Store }).__store__;
+      store.dispatch({ type: 'ui/setTtsModelKey', payload: 'qwen3-tts-0.6b' });
+    });
+
+    /* Open review, opt into the off-roster reattribute class, apply. */
+    const reviewBtn = page.getByTestId('review-script-chapter');
+    await expect(reviewBtn).toBeVisible({ timeout: 5_000 });
+    await expect(reviewBtn).toBeEnabled();
+    await reviewBtn.click();
+    await expect(page.getByRole('heading', { name: /Script review suggestions/i })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const reattributeToggle = page.getByTestId('class-toggle-reattribute');
+    await expect(reattributeToggle).toBeVisible();
+    await reattributeToggle.check();
+
+    await page.getByTestId('apply-button').click();
+
+    /* Confirm the off-roster create of «Ferra». */
+    await expect(page.getByTestId('confirm-reattribute')).toBeVisible({ timeout: 5_000 });
+    await page.getByTestId('create-character-submit').click();
+
+    /* fs-63 — a sticky "Design now" nudge appears for the newly-created Ferra. */
+    const designNow = page.getByRole('button', { name: /design now/i });
+    await expect(designNow).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByText(/Ferra.*needs a voice/i)).toBeVisible();
+
+    /* Tapping enqueues bespoke design → the design job activates. The mock
+       streams onProgress → onCharacterDesigned → onIdle, the last of which
+       pushes a "Designed 1." summary toast (viewport-independent, lingers ~5s),
+       so a "design(ing|ed)" match is race-free. "Design now" itself does not
+       match this regex (no ing/ed), and the nudge is dismissed on tap. */
+    await designNow.click();
+    await expect(page.getByText(/design(ing|ed)/i)).toBeVisible({ timeout: 8_000 });
+  });
+});

--- a/src/components/script-review-diff.tsx
+++ b/src/components/script-review-diff.tsx
@@ -5,6 +5,7 @@
    dispatchAcceptedOps. Mirrors drift-report.tsx overlay pattern. */
 
 import { useRef, useState } from 'react';
+import type { Dispatch } from '@reduxjs/toolkit';
 import { useAppDispatch, useAppSelector } from '../store';
 import {
   scriptReviewActions,
@@ -21,6 +22,9 @@ import { notificationsActions } from '../store/notifications-slice';
 import { api } from '../lib/api';
 import { CreateCharacterForm } from './create-character-form';
 import { IconClose } from '../lib/icons';
+import { engineForModelKey } from '../lib/tts-models';
+import { sampleModelKeyForEngine } from '../lib/tts-voice-mapping';
+import type { TtsModelKey } from '../lib/types';
 
 /* Human-readable class labels. */
 const CLASS_LABELS: Record<string, string> = {
@@ -36,6 +40,35 @@ const CLASS_LABELS: Record<string, string> = {
 
 function classLabel(op: string): string {
   return CLASS_LABELS[op] ?? op;
+}
+
+/** fs-63 — push the off-roster "Design now" nudge, gated to a Qwen project.
+    Exported (and pure-ish: side effect is the single dispatch) so it's unit
+    testable without driving the confirm UI. No-op on preset engines or an
+    empty batch. */
+export function maybePushVoiceNudge(
+  dispatch: Dispatch,
+  args: { ttsModelKey: TtsModelKey; startBookId: string; createdCharacters: { id: string; name: string }[] },
+): void {
+  const { ttsModelKey, startBookId, createdCharacters } = args;
+  if (createdCharacters.length === 0) return;
+  if (engineForModelKey(ttsModelKey) !== 'qwen') return;
+  dispatch(
+    notificationsActions.pushToast({
+      kind: 'info',
+      message:
+        createdCharacters.length > 1
+          ? `${createdCharacters.length} new characters need voices`
+          : `New character «${createdCharacters[0].name}» needs a voice`,
+      dedupeKey: `off-roster-voice-nudge:${startBookId}`,
+      nudge: {
+        bookId: startBookId,
+        characterIds: createdCharacters.map((c) => c.id),
+        modelKey: sampleModelKeyForEngine('qwen', ttsModelKey),
+        names: createdCharacters.map((c) => c.name),
+      },
+    }),
+  );
 }
 
 /* Format the before → after preview for a single op row. `before` is the
@@ -150,6 +183,7 @@ export function ScriptReviewDiff({ bookId }: { bookId: string }) {
   );
   const stageBookIdRef = useRef(stageBookId);
   stageBookIdRef.current = stageBookId;
+  const ttsModelKey = useAppSelector((s) => s.ui.ttsModelKey);
 
   /* The confirm queue. While `confirm` is non-null we overlay a
      CreateCharacterForm for `confirm.queue[confirm.index]`. Direct ops are
@@ -190,7 +224,7 @@ export function ScriptReviewDiff({ bookId }: { bookId: string }) {
   async function runProposed(finalized: FinalizedProposed[], startBookId: string) {
     const rosterByName = new Map(cast.map((c) => [c.name.trim().toLowerCase(), { id: c.id }]));
     try {
-      await applyProposedReattributions(finalized, {
+      const { createdCharacters } = await applyProposedReattributions(finalized, {
         rosterByName,
         createCharacter: async (p) => {
           // api.createCharacter resolves to a { character } envelope — unwrap it.
@@ -206,6 +240,10 @@ export function ScriptReviewDiff({ bookId }: { bookId: string }) {
           dispatch(changeLogActions.bumpBoundaryMove({ chapterId, count: 1 })),
         isSameBook: () => stageBookIdRef.current === startBookId,
       });
+      // fs-63 — on success, nudge to auto-voice any newly-created off-roster
+      // character (qwen-only; no-op otherwise). Inside the try so a failed
+      // create falls to the catch and never nudges.
+      maybePushVoiceNudge(dispatch, { ttsModelKey, startBookId, createdCharacters });
     } catch {
       // A create failed mid-batch. Reset the confirm machine and surface a toast,
       // but DON'T clearReview — the operator can re-trigger. Re-run is safe because

--- a/src/components/script-review-voice-nudge.test.ts
+++ b/src/components/script-review-voice-nudge.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { maybePushVoiceNudge } from './script-review-diff';
+import { QWEN_MODEL_KEY } from '../lib/tts-voice-mapping';
+
+describe('maybePushVoiceNudge', () => {
+  it('pushes a nudge on a qwen project with the right payload + dedupeKey', () => {
+    const dispatch = vi.fn();
+    maybePushVoiceNudge(dispatch, {
+      ttsModelKey: 'qwen3-tts-0.6b',
+      startBookId: 'b1',
+      createdCharacters: [{ id: 'mara', name: 'Mara' }],
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const action = dispatch.mock.calls[0][0];
+    expect(action.type).toBe('notifications/pushToast');
+    expect(action.payload.dedupeKey).toBe('off-roster-voice-nudge:b1');
+    // modelKey is the constant sampleModelKeyForEngine('qwen', …) substitutes,
+    // NOT an echo of the input — assert against the constant so a future
+    // "fix" that echoes the input fails this test.
+    expect(action.payload.nudge).toEqual({
+      bookId: 'b1',
+      characterIds: ['mara'],
+      modelKey: QWEN_MODEL_KEY,
+      names: ['Mara'],
+    });
+  });
+
+  it('does nothing on a preset-engine (kokoro) project', () => {
+    const dispatch = vi.fn();
+    maybePushVoiceNudge(dispatch, {
+      ttsModelKey: 'kokoro-v1',
+      startBookId: 'b1',
+      createdCharacters: [{ id: 'mara', name: 'Mara' }],
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no characters were created', () => {
+    const dispatch = vi.fn();
+    maybePushVoiceNudge(dispatch, {
+      ttsModelKey: 'qwen3-tts-0.6b', startBookId: 'b1', createdCharacters: [],
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/toast-stack.test.tsx
+++ b/src/components/toast-stack.test.tsx
@@ -7,7 +7,8 @@ import { render, screen, fireEvent, act } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { ToastStack } from './toast-stack';
-import { notificationsSlice, notificationsActions } from '../store/notifications-slice';
+import { notificationsSlice, notificationsActions, type Toast } from '../store/notifications-slice';
+import { castDesignSlice } from '../store/cast-design-slice';
 
 vi.mock('../store', async () => {
   const actual = await vi.importActual<typeof import('../store')>('../store');
@@ -23,7 +24,17 @@ let sharedStore: ReturnType<typeof makeStore>;
 
 function makeStore() {
   return configureStore({
-    reducer: { notifications: notificationsSlice.reducer },
+    reducer: { notifications: notificationsSlice.reducer, castDesign: castDesignSlice.reducer },
+  });
+}
+
+function makeStoreWithToast(toast: Toast) {
+  return configureStore({
+    reducer: { notifications: notificationsSlice.reducer, castDesign: castDesignSlice.reducer },
+    preloadedState: {
+      notifications: { toasts: [toast] },
+      castDesign: { active: null },
+    },
   });
 }
 
@@ -127,5 +138,23 @@ describe('ToastStack — auto-dismiss timer', () => {
       vi.advanceTimersByTime(5999);
     });
     expect(sharedStore.getState().notifications.toasts).toHaveLength(1);
+  });
+});
+
+describe('ToastStack — nudge routing', () => {
+  it('renders a nudge toast via VoiceNudgeToast and does not auto-dismiss it', () => {
+    vi.useFakeTimers();
+    const store = makeStoreWithToast({
+      id: 'n1', kind: 'info', message: 'New character «Mara» needs a voice', createdAt: Date.now(),
+      nudge: { bookId: 'b1', characterIds: ['mara'], modelKey: 'qwen3-tts-0.6b', names: ['Mara'] },
+    });
+    // Override sharedStore so the mock's useAppSelector/useAppDispatch see the new store
+    sharedStore = store as ReturnType<typeof makeStore>;
+    render(<Provider store={store}><ToastStack /></Provider>);
+    expect(screen.getByRole('button', { name: /design now/i })).toBeTruthy();
+    act(() => { vi.advanceTimersByTime(7000); });
+    // still present after the 6s window — nudge toasts are sticky
+    expect(screen.getByRole('button', { name: /design now/i })).toBeTruthy();
+    vi.useRealTimers();
   });
 });

--- a/src/components/toast-stack.tsx
+++ b/src/components/toast-stack.tsx
@@ -15,6 +15,7 @@ import { useEffect } from 'react';
 import { useAppDispatch, useAppSelector } from '../store';
 import { IconClose, IconWarning, IconCheck } from '../lib/icons';
 import { notificationsActions, selectToasts, type Toast } from '../store/notifications-slice';
+import { VoiceNudgeToast } from './voice-nudge-toast';
 
 const AUTO_DISMISS_MS = 6000;
 
@@ -27,9 +28,9 @@ export function ToastStack() {
       aria-live="polite"
       className="fixed bottom-20 right-6 z-60 flex flex-col gap-2"
     >
-      {toasts.map((t) => (
-        <ToastItem key={t.id} toast={t} />
-      ))}
+      {toasts.map((t) =>
+        t.nudge ? <VoiceNudgeToast key={t.id} toast={t} /> : <ToastItem key={t.id} toast={t} />,
+      )}
     </div>
   );
 }

--- a/src/components/voice-nudge-toast.test.tsx
+++ b/src/components/voice-nudge-toast.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { VoiceNudgeToast } from './voice-nudge-toast';
+import { notificationsSlice, type Toast } from '../store/notifications-slice';
+import { castDesignSlice } from '../store/cast-design-slice';
+
+// Recording middleware — the idiomatic way to assert designAllRequested fired
+// (its reducer is a no-op; real interception lives in middleware not installed here).
+const recorded: { type: string; payload: unknown }[] = [];
+const recorder = () => (next: (a: unknown) => unknown) => (a: unknown) => {
+  recorded.push(a as { type: string; payload: unknown });
+  return next(a);
+};
+
+const makeStore = (designRunning: boolean) => {
+  recorded.length = 0;
+  return configureStore({
+    reducer: { notifications: notificationsSlice.reducer, castDesign: castDesignSlice.reducer },
+    preloadedState: {
+      notifications: { toasts: [] },
+      castDesign: { active: designRunning ? ({ state: 'running', bookId: 'b1' } as never) : null },
+    },
+    middleware: (gdm) => gdm().concat(recorder),
+  });
+};
+
+const toast: Toast = {
+  id: 't1', kind: 'info', message: 'New character «Mara» needs a voice', createdAt: 0,
+  dedupeKey: 'off-roster-voice-nudge:b1',
+  nudge: { bookId: 'b1', characterIds: ['mara'], modelKey: 'qwen3-tts-0.6b', names: ['Mara'] },
+};
+
+describe('VoiceNudgeToast', () => {
+  it('idle: tapping the button dispatches designAllRequested and dismisses the toast', () => {
+    const store = makeStore(false);
+    render(<Provider store={store}><VoiceNudgeToast toast={toast} /></Provider>);
+    fireEvent.click(screen.getByRole('button', { name: /design now/i }));
+
+    const design = recorded.find((a) => a.type === 'castDesign/designAllRequested');
+    expect(design).toBeTruthy();
+    expect((design!.payload as { characterIds: string[] }).characterIds).toEqual(['mara']);
+    expect((design!.payload as { scope: string }).scope).toBe('bases');
+    expect((design!.payload as { modelKey: string }).modelKey).toBe('qwen3-tts-0.6b');
+    expect(recorded.some((a) => a.type === 'notifications/dismissToast')).toBe(true);
+  });
+
+  it('busy: button is disabled and the nudge is NOT dismissed', () => {
+    const store = makeStore(true);
+    render(<Provider store={store}><VoiceNudgeToast toast={toast} /></Provider>);
+    const btn = screen.getByRole('button', { name: /design now/i });
+    expect(btn).toBeDisabled();
+    expect(screen.getByText(/a voice design is already running/i)).toBeTruthy();
+  });
+
+  it('plural copy when several characters need voices', () => {
+    const store = makeStore(false);
+    const plural: Toast = {
+      ...toast,
+      nudge: { ...toast.nudge!, characterIds: ['mara', 'tom'], names: ['Mara', 'Tom'] },
+    };
+    render(<Provider store={store}><VoiceNudgeToast toast={plural} /></Provider>);
+    expect(screen.getByText(/2 new characters need voices/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /design all/i })).toBeTruthy();
+  });
+});

--- a/src/components/voice-nudge-toast.tsx
+++ b/src/components/voice-nudge-toast.tsx
@@ -1,0 +1,65 @@
+/* fs-63 — off-roster "Design now" nudge. A sticky toast (no auto-dismiss)
+   rendered by ToastStack when a Toast carries a `nudge`. It mirrors the Cast
+   view's busy semantics: while a cast-design run is active (any book) the
+   action is disabled, so a tap can never silently no-op against the
+   single-stream middleware. Tapping enqueues bespoke Qwen design for exactly
+   the created characters via the existing designAllRequested pipeline. */
+
+import { useAppDispatch, useAppSelector } from '../store';
+import { IconWarning, IconClose } from '../lib/icons';
+import { notificationsActions, type Toast } from '../store/notifications-slice';
+import { castDesignActions } from '../store/cast-design-slice';
+
+export function VoiceNudgeToast({ toast }: { toast: Toast }) {
+  const dispatch = useAppDispatch();
+  const designRunning = useAppSelector((s) => s.castDesign.active?.state === 'running');
+  const nudge = toast.nudge!;
+  const count = nudge.characterIds.length;
+  const label = count > 1 ? 'Design all' : 'Design now';
+  const message =
+    count > 1
+      ? `${count} new characters need voices`
+      : `New character «${nudge.names[0]}» needs a voice`;
+
+  const onDesign = () => {
+    dispatch(
+      castDesignActions.designAllRequested({
+        bookId: nudge.bookId,
+        characterIds: nudge.characterIds,
+        modelKey: nudge.modelKey,
+        scope: 'bases',
+      }),
+    );
+    dispatch(notificationsActions.dismissToast(toast.id));
+  };
+
+  return (
+    <div className="flex flex-col gap-2 rounded-2xl border border-ink/10 bg-white px-4 py-3 shadow-card min-w-[280px] max-w-[360px] fade-in text-ink">
+      <div className="flex items-start gap-3">
+        <IconWarning className="w-4 h-4 mt-0.5 shrink-0" />
+        <p className="flex-1 text-sm leading-snug">{message}</p>
+        <button
+          type="button"
+          aria-label="Dismiss notification"
+          onClick={() => dispatch(notificationsActions.dismissToast(toast.id))}
+          className="p-1 rounded-full hover:bg-ink/10 shrink-0"
+        >
+          <IconClose className="w-3.5 h-3.5" />
+        </button>
+      </div>
+      <div className="flex items-center gap-2 pl-7">
+        <button
+          type="button"
+          disabled={designRunning}
+          onClick={onDesign}
+          className="px-3 min-h-[44px] sm:min-h-0 sm:py-1.5 rounded-full bg-ink text-canvas text-sm font-semibold disabled:opacity-40"
+        >
+          {label}
+        </button>
+        {designRunning && (
+          <span className="text-xs text-ink/55">A voice design is already running…</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/apply-proposed.test.ts
+++ b/src/lib/apply-proposed.test.ts
@@ -22,7 +22,7 @@ describe('fs-58 Unit B — applyProposedReattributions', () => {
       [{ chapterId: 1, id: 5, op: 'reattribute', proposed: { name: 'Ferra' } }] as any, d);
     expect(d.createCharacter).toHaveBeenCalledTimes(1);
     expect(d.spy).toEqual([['add', 'ferra'], ['reassign', 5, 'ferra']]);
-    expect(r).toEqual({ created: 1, aborted: false });
+    expect(r).toEqual({ created: 1, createdCharacters: [{ id: 'ferra', name: 'Ferra' }], aborted: false });
   });
 
   it('dedupes the same proposed name to ONE create within a batch', async () => {
@@ -40,6 +40,41 @@ describe('fs-58 Unit B — applyProposedReattributions', () => {
     await applyProposedReattributions([{ chapterId: 1, id: 5, op: 'reattribute', proposed: { name: 'Ferra' } }] as any, d);
     expect(d.createCharacter).not.toHaveBeenCalled();
     expect(d.spy).toEqual([['reassign', 5, 'ferra']]);
+  });
+
+  it('returns createdCharacters with {id,name} for each minted member (dedup within batch)', async () => {
+    const d = deps();
+    const r = await applyProposedReattributions([
+      { chapterId: 1, id: 10, op: 'reattribute', proposed: { name: 'Mara' } },
+      { chapterId: 1, id: 11, op: 'reattribute', proposed: { name: 'mara ' } }, // dup name → one create
+      { chapterId: 2, id: 12, op: 'reattribute', proposed: { name: 'Tom' } },
+    ] as any, d);
+    expect(r.created).toBe(2);
+    expect(r.createdCharacters).toEqual([
+      { id: 'mara', name: 'Mara' },
+      { id: 'tom', name: 'Tom' },
+    ]);
+    expect(r.aborted).toBe(false);
+  });
+
+  it('returns empty createdCharacters when every op dedupes to an existing roster member', async () => {
+    const d = deps({ rosterByName: new Map([['hart', { id: 'hart-1' }]]) });
+    const r = await applyProposedReattributions(
+      [{ chapterId: 1, id: 10, op: 'reattribute', proposed: { name: 'Hart' } }] as any, d);
+    expect(r.createdCharacters).toEqual([]);
+  });
+
+  it('carries partial createdCharacters when the batch aborts on a book switch', async () => {
+    // isSameBook is checked once right after each create: true for Mara (recorded),
+    // false for Tom (abort BEFORE Tom is recorded).
+    const isSameBook = vi.fn().mockReturnValueOnce(true).mockReturnValueOnce(false);
+    const d = deps({ isSameBook });
+    const r = await applyProposedReattributions([
+      { chapterId: 1, id: 10, op: 'reattribute', proposed: { name: 'Mara' } },
+      { chapterId: 2, id: 12, op: 'reattribute', proposed: { name: 'Tom' } },
+    ] as any, d);
+    expect(r.aborted).toBe(true);
+    expect(r.createdCharacters).toEqual([{ id: 'mara', name: 'Mara' }]);
   });
 
   it('aborts remaining ops when the book changed mid-await', async () => {

--- a/src/lib/apply-proposed.ts
+++ b/src/lib/apply-proposed.ts
@@ -18,8 +18,9 @@ const norm = (s: string) => s.trim().toLowerCase();
 export async function applyProposedReattributions(
   proposed: ReviewOpWithChapter[],
   deps: ApplyProposedDeps,
-): Promise<{ created: number; aborted: boolean }> {
+): Promise<{ created: number; createdCharacters: { id: string; name: string }[]; aborted: boolean }> {
   const memo = new Map<string, string>(); // normName -> id created this batch
+  const createdCharacters: { id: string; name: string }[] = [];
   let created = 0;
   for (const op of proposed) {
     if (!op.proposed) continue;
@@ -27,14 +28,15 @@ export async function applyProposedReattributions(
     let id = deps.rosterByName.get(key)?.id ?? memo.get(key);
     if (!id) {
       const c = await deps.createCharacter(op.proposed);
-      if (!deps.isSameBook()) return { created, aborted: true };
+      if (!deps.isSameBook()) return { created, createdCharacters, aborted: true };
       deps.addCharacter(c);
       id = c.id;
       memo.set(key, id);
+      createdCharacters.push({ id: c.id, name: c.name });
       created += 1;
     }
     deps.setSentenceCharacter(op.chapterId, op.id, id);
     deps.onBoundaryMove(op.chapterId);
   }
-  return { created, aborted: false };
+  return { created, createdCharacters, aborted: false };
 }

--- a/src/store/notifications-slice.test.ts
+++ b/src/store/notifications-slice.test.ts
@@ -1,7 +1,7 @@
 // Pairs with docs/features/archive/48-toast-surface.md
 
 import { describe, expect, it } from 'vitest';
-import { notificationsSlice, notificationsActions } from './notifications-slice';
+import { notificationsSlice, notificationsActions, type VoiceNudge } from './notifications-slice';
 
 const emptyState = () => ({ toasts: [] });
 
@@ -130,5 +130,42 @@ describe('notificationsSlice — dismiss', () => {
     const next = notificationsSlice.reducer(s2, notificationsActions.dismissByKey('export'));
     expect(next.toasts).toHaveLength(1);
     expect(next.toasts[0].message).toBe('two');
+  });
+});
+
+const reduce = (actions: ReturnType<typeof notificationsActions.pushToast>[]) =>
+  actions.reduce((s, a) => notificationsSlice.reducer(s, a), notificationsSlice.reducer(undefined, { type: '@@INIT' }));
+
+const nudge = (over: Partial<VoiceNudge>): VoiceNudge => ({
+  bookId: 'b1', modelKey: 'qwen3-tts-0.6b', characterIds: ['mara'], names: ['Mara'], ...over,
+});
+
+describe('notifications nudge merge-dedupe', () => {
+  it('unions characterIds/names into an existing same-key nudge instead of overwriting', () => {
+    const s = reduce([
+      notificationsActions.pushToast({ kind: 'info', message: '1 needs a voice', dedupeKey: 'k', nudge: nudge({}) }),
+      notificationsActions.pushToast({
+        kind: 'info', message: '1 needs a voice', dedupeKey: 'k',
+        nudge: nudge({ characterIds: ['tom'], names: ['Tom'] }),
+      }),
+    ]);
+    expect(s.toasts).toHaveLength(1);
+    expect(s.toasts[0].nudge?.characterIds).toEqual(['mara', 'tom']);
+    expect(s.toasts[0].nudge?.names).toEqual(['Mara', 'Tom']);
+  });
+
+  it('does not duplicate an id already present in the existing nudge', () => {
+    const s = reduce([
+      notificationsActions.pushToast({ kind: 'info', message: 'x', dedupeKey: 'k', nudge: nudge({}) }),
+      notificationsActions.pushToast({ kind: 'info', message: 'x', dedupeKey: 'k', nudge: nudge({}) }),
+    ]);
+    expect(s.toasts[0].nudge?.characterIds).toEqual(['mara']);
+  });
+
+  it('carries nudge on a fresh (non-dedupe) push', () => {
+    const s = reduce([
+      notificationsActions.pushToast({ kind: 'info', message: 'x', nudge: nudge({}) }),
+    ]);
+    expect(s.toasts[0].nudge?.characterIds).toEqual(['mara']);
   });
 });

--- a/src/store/notifications-slice.ts
+++ b/src/store/notifications-slice.ts
@@ -18,12 +18,22 @@ import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 export type ToastKind = 'error' | 'warn' | 'info';
 
+export interface VoiceNudge {
+  bookId: string;
+  characterIds: string[];
+  modelKey: string;
+  names: string[];
+}
+
 export interface Toast {
   id: string;
   kind: ToastKind;
   message: string;
   dedupeKey?: string;
   createdAt: number;
+  /** fs-63 — present only on the off-roster "Design now" nudge; routes the
+      toast to <VoiceNudgeToast> and exempts it from auto-dismiss. */
+  nudge?: VoiceNudge;
 }
 
 export interface NotificationsState {
@@ -36,6 +46,7 @@ interface PushToastPayload {
   kind: ToastKind;
   message: string;
   dedupeKey?: string;
+  nudge?: VoiceNudge;
 }
 
 export const notificationsSlice = createSlice({
@@ -44,17 +55,30 @@ export const notificationsSlice = createSlice({
   reducers: {
     pushToast: {
       reducer: (s, a: PayloadAction<{ id: string; createdAt: number } & PushToastPayload>) => {
-        const { id, kind, message, dedupeKey, createdAt } = a.payload;
+        const { id, kind, message, dedupeKey, createdAt, nudge } = a.payload;
         if (dedupeKey) {
           const existing = s.toasts.find((t) => t.dedupeKey === dedupeKey);
           if (existing) {
             existing.createdAt = createdAt;
             existing.kind = kind;
             existing.message = message;
+            // fs-63 — union nudge work-lists so a burst of off-roster creates
+            // yields ONE nudge covering every still-unvoiced character.
+            if (nudge && existing.nudge) {
+              for (let i = 0; i < nudge.characterIds.length; i++) {
+                const cid = nudge.characterIds[i];
+                if (!existing.nudge.characterIds.includes(cid)) {
+                  existing.nudge.characterIds.push(cid);
+                  existing.nudge.names.push(nudge.names[i]);
+                }
+              }
+            } else if (nudge) {
+              existing.nudge = nudge;
+            }
             return;
           }
         }
-        s.toasts.push({ id, kind, message, dedupeKey, createdAt });
+        s.toasts.push({ id, kind, message, dedupeKey, createdAt, nudge });
       },
       prepare: (payload: PushToastPayload) => ({
         payload: {


### PR DESCRIPTION
## Summary

fs-63 — auto-voice a created off-roster character (fs-58 Unit B follow-up). When an off-roster `reattribute` mints a brand-new cast member through the script-review confirm flow **on a Qwen project**, a sticky **"Design now"** nudge now appears and enqueues bespoke Qwen voice design for exactly that character — so the reassigned line becomes audible in one tap instead of a separate trip to the Cast view.

**Why Qwen-only:** on preset engines (Kokoro/Coqui/Gemini) `pickVoiceForEngine` already auto-voices a new character. On Qwen, an undesigned character returns `''` and trips the generation-time `computeQwenKokoroFallbackSet` pause — so Qwen is where the gap actually bites. The nudge is the proactive complement to that existing safety net.

**Why a nudge, not automatic:** bespoke design loads the ~4–5 GB VoiceDesign model (evicts the analyzer). The one-tap consent gate keeps that deliberate — "audible in one tap, not zero."

### User-visible delta
- After confirming an off-roster create on a Qwen project: a sticky toast — *"New character «X» needs a voice — Design now"* (plural: *"N new characters need voices — Design all"*).
- Tapping enqueues the existing **Design full cast** pipeline scoped to the created character(s); the `DesignPill` shows progress.
- The action button is **disabled while any cast-design run is in flight** (mirrors the Cast view's busy-disable) so a tap can never silently no-op against the single-stream middleware — the nudge stays until it can act.
- A burst of off-roster creates **merges** into one nudge covering every still-unvoiced character (no earlier character dropped).

### Implementation
- `src/lib/apply-proposed.ts` — `applyProposedReattributions` returns `createdCharacters: {id,name}[]`.
- `src/store/notifications-slice.ts` — optional `Toast.nudge` field (no new `kind`, avoiding the literal kind-union re-declared in `layout.tsx`) + **merge-dedupe** that unions `characterIds`/`names` on a same-key push.
- `src/components/voice-nudge-toast.tsx` (new) — dedicated busy-aware nudge; reads `castDesign.active.state === 'running'`.
- `src/components/toast-stack.tsx` — routes `nudge` toasts to `VoiceNudgeToast` (sticky; no 6 s auto-dismiss).
- `src/components/script-review-diff.tsx` — exported `maybePushVoiceNudge` helper, Qwen-gated, called from `runProposed`.

## Test plan
- **Unit (31 new/updated):** `apply-proposed` (created-characters incl. partial-abort), `notifications-slice` (merge-dedupe union), `voice-nudge-toast` (idle dispatch+dismiss / busy-disabled-and-sticky / count-aware copy), `toast-stack` (nudge routing + sticky), `script-review-voice-nudge` (qwen pushes / kokoro+empty don't / `modelKey === QWEN_MODEL_KEY`).
- **E2E:** `e2e/script-review.spec.ts` — Qwen project off-roster create → "Design now" nudge → tap kicks the design job. Full `script-review` spec 5/5 green.
- **Local `npm run verify`:** full battery (typecheck + all tests + e2e + build) green.

Spec: `docs/superpowers/specs/2026-06-25-fs63-auto-voice-off-roster-character-design.md` (adversarially reviewed ×2). Plan: `docs/superpowers/plans/2026-06-25-fs63-auto-voice-off-roster-character.md` (reviewed ×2).

Closes #1119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
