### PR TITLE
feat(frontend,server): auto-generate per-line prosody annotations after analysis (fs-65 Phase 3)

### DIFF
--- a/docs/superpowers/plans/2026-06-25-phase3-prosody-and-scriptreview-chunking.md
+++ b/docs/superpowers/plans/2026-06-25-phase3-prosody-and-scriptreview-chunking.md
@@ -4,7 +4,7 @@
 
 **Goal:** Stop script review from silently failing on normal-sized chapters, make it work on huge (Cyrillic) chapters via a sentence-chunker, and auto-generate per-line prosody annotations as a gated post-analysis pass.
 
-**Architecture:** Three independent PRs. PR1 surfaces a dropped SSE event (client only). PR2 adds a server sentence-chunker (owned-core ownership rule) consumed by script-review. PR3 (gate redesigned post-fs-66) auto-triggers the existing annotation routes (through PR2's chunker) after analysis via a single reactive effect gated on a nullable per-book `prosodyEnabled` intent flag OR a cast-derived 1.7B signal (the cast-time safety net), deduped by a completion watermark.
+**Architecture:** Three independent PRs. PR1 surfaces a dropped SSE event (client only). PR2 adds a server sentence-chunker (owned-core ownership rule) consumed by script-review. PR3 (gate redesigned post-fs-66, eager-default per the 2026-06-25 decision) auto-triggers the existing annotation routes (through PR2's chunker) at the post-analysis `confirm` stage whenever the per-book `prosodyEnabled` flag is not `false` (absent ⇒ on), via a per-book + retry-safe effect, deduped by a completion watermark. No cast read.
 
 **Tech Stack:** Vite + React 18 + Redux Toolkit (frontend, Vitest + jsdom); Node/Express + TypeScript (server, Vitest + node env); Playwright (e2e). SSE for streamed analyzer passes.
 
@@ -19,7 +19,7 @@
 - **Commit convention:** `<type>(<scope>): <subject>`. End every commit body with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
 - **One branch = one PR.** PR1 `fix/frontend-scriptreview-chapter-failed`; PR2 `feat/server-analyzer-chapter-chunker`; PR3 `feat/analysis-phase3-prosody`. Cut each off the latest `origin/main`.
 - **Verify gates:** frontend `npm test`; server `cd server && npm run test`; full `npm run verify` before each PR push.
-- **PR3 gate (post-fs-66):** fs-66 ("1.7B implies prosody") has merged — synth gate is `is17b` alone, the "go 1.7B" decision is the cast `ttsModelKey`. PR3 renames the orphaned `liveInstruct` flag to a nullable `prosodyEnabled` intent flag (Task 11) and MUST NOT introduce any competing book-quality flag. There is no concurrent session to reconcile with; just cut off latest `origin/main`.
+- **PR3 gate (post-fs-66, eager-default):** fs-66 ("1.7B implies prosody") has merged — synth gate is `is17b` alone. **Ground truth:** 1.7B is never an account/book default (the picker offers only Qwen 0.6b); it's chosen late (cast bulk-pin or regen override), so there is NO analysis-time 1.7B signal. Decision (2026-06-25): **annotate eagerly by default** — the gate is `prosodyEnabled !== false` (absent ⇒ on), fired at the `confirm` stage. PR3 renames the orphaned `liveInstruct` flag to `prosodyEnabled` (Task 11) and MUST NOT introduce any competing book-quality flag. Cut off latest `origin/main`.
 
 ---
 
@@ -301,10 +301,11 @@ git commit -m "feat(server): script review chunks large chapters via owned-core 
 > **cast-time** signal (`ttsModelKey === 'qwen3-tts-1.7b'`, per-character or via
 > the book bulk-pin `POST /cast/tier`). Tasks 7–10 + 14 are unchanged. The gate
 > tasks are redesigned below: **Task 11 (new)** renames `liveInstruct` →
-> `prosodyEnabled`; **Task 12** is the smart-default analysis-form toggle;
-> **Task 13** is the single reactive auto-trigger whose cast dependency IS the
-> cast-time safety net. See the spec's "Gate model" section (read it — the
-> tri-state flag + cast-derived auto-rule are folded there).
+> `prosodyEnabled` (absent ⇒ on); **Task 12** is the analysis-form toggle
+> (checked by default); **Task 13** is the eager, `confirm`-only, per-book +
+> retry-safe auto-trigger (no cast read); **Task 13b** adds the opt-out
+> render-time hint. See the spec's "Gate model" section (read it — the
+> eager-default decision + round-1 review fixes are folded there).
 
 **PREREQUISITE — satisfied.** Task 8 imports `server/src/analyzer/chapter-chunker.ts`, which landed with PR2 (#1128, merged). **Cut `feat/analysis-phase3-prosody` off the latest `origin/main`** (which now contains both PR2 and fs-66).
 
@@ -378,92 +379,103 @@ annotatedChapters += 1; // once per chapter, after the chunk loop — keep the e
 
 - [ ] TDD: test that it calls both api passes in order and dispatches both apply actions; mock `api`. Commit `refactor(frontend): extract runProsodyPasses from DetectEmotionsButton`.
 
-### Task 11: rename `liveInstruct` → `prosodyEnabled` (nullable Phase-3 intent flag)
+### Task 11: rename `liveInstruct` → `prosodyEnabled` (eager-default Phase-3 intent flag)
 
-The fs-66-orphaned `liveInstruct` flag is renamed and repurposed as the Phase-3 intent flag, and its semantics flip from plain-boolean (`?? false`) to **nullable** (undefined = "auto") so the Task-13 gate can distinguish undefined/true/false.
+The fs-66-orphaned `liveInstruct` flag is renamed and repurposed as the Phase-3 intent flag. Semantics: **absent ⇒ ON** (eager default); only an explicit `false` opts out. Keep it nullable (`boolean | undefined`) so the toggle can store an explicit `false`/`true`; the Task-13 gate is simply `prosodyEnabled !== false`.
 
 **Files:**
-- Modify: `server/src/workspace/scan.ts` — rename `BookStateJson.liveInstruct?` → `prosodyEnabled?` (line 236) + rewrite its JSDoc (it is NO LONGER a synth-path flag — it is the Phase-3 annotation intent flag; undefined ⇒ auto-by-cast).
-- Modify: `server/src/routes/book-state.ts` — the `case 'state':` picker that reads `liveInstruct` (lines 706–708) → `prosodyEnabled`.
-- Modify: `src/store/book-meta-slice.ts` — rename `liveInstruct` field (55, 61), hydration (94), `setLiveInstruct` (119–120), `selectLiveInstruct` (167–170) to `prosodyEnabled`/`setProsodyEnabled`/`selectProsodyEnabled`. **Flip to nullable:** hydration preserves undefined (`s.prosodyEnabled[bookId] = state.prosodyEnabled` — drop the `?? false`); the selector returns `s.bookMeta.prosodyEnabled[bookId]` with **NO `?? false`** (the gate needs the three states).
+- Modify: `server/src/workspace/scan.ts` — rename `BookStateJson.liveInstruct?` → `prosodyEnabled?` (line 236) + rewrite its JSDoc (NO LONGER a synth-path flag — it is the Phase-3 annotation intent flag; absent ⇒ on, `false` = opted out).
+- Modify: `server/src/routes/book-state.ts` — the `case 'state':` picker that reads `liveInstruct` (lines 706–708) → `prosodyEnabled` (keep the same boolean-typeof guard).
+- Modify: `src/store/book-meta-slice.ts` — rename `liveInstruct` field (55, 61), the `setLiveInstruct`-payload type (72), hydration (94), `setLiveInstruct` (119–120), `selectLiveInstruct` (167–170) to `prosodyEnabled`/`setProsodyEnabled`/`selectProsodyEnabled`. **Preserve undefined:** hydration `s.prosodyEnabled[bookId] = state.prosodyEnabled` (drop `?? false`); the selector returns `s.bookMeta.prosodyEnabled[bookId]` with **NO `?? false`** (the gate distinguishes `false` from absent). Rewrite the stale JSDoc at 114–118 (it claims a non-existent "persistence-middleware watches this action" — there is no such middleware; the durable PUT is issued by the Task-12 toggle).
 - Modify: `src/components/layout.tsx:790` — hydration `liveInstruct: res.state.liveInstruct ?? false` → `prosodyEnabled: res.state.prosodyEnabled` (preserve undefined).
-- Modify: `openapi.yaml` — rename the book-state `liveInstruct` property (line 3361) → `prosodyEnabled` + rewrite its description. **Do NOT touch line 4910** (the Sentence `instruct` "Qwen 1.7B liveInstruct path" comment names the synth path, not this flag). Then regenerate: `npm run openapi:types` (updates `src/lib/api-types.ts`).
-- Modify tests: `src/store/book-meta-slice.test.ts`, `server/src/routes/book-state.test.ts`, and any `setLiveInstruct`/`selectLiveInstruct` references.
+- Modify: `openapi.yaml` — rename the book-state `liveInstruct` property (line 3361) → `prosodyEnabled` + rewrite its description (absent ⇒ on). **Do NOT touch line 4910** (the Sentence `instruct` "Qwen 1.7B liveInstruct path" comment names the synth path, not this flag). Then regenerate: `npm run openapi:types` (updates `src/lib/api-types.ts`).
+- Modify tests: `src/store/book-meta-slice.test.ts`, `server/src/routes/book-state.test.ts` (the liveInstruct cases ~2128–2168), and any `setLiveInstruct`/`selectLiveInstruct` references.
 
 **Interfaces:**
-- Produces: `bookMetaActions.setProsodyEnabled({ bookId, value: boolean })`; `selectProsodyEnabled(bookId): (s: RootState) => boolean | undefined`; `BookStateJson.prosodyEnabled?: boolean` (undefined when absent).
-- **Do NOT** rename the unrelated `instructHash`/`renderedInstructHashes` "liveInstruct render" comments in `segments-io.ts`/`stale-chapters.ts` — they name the synth path.
+- Produces: `bookMetaActions.setProsodyEnabled({ bookId, value: boolean })`; `selectProsodyEnabled(bookId): (s: RootState) => boolean | undefined`; `BookStateJson.prosodyEnabled?: boolean` (undefined when absent ⇒ treated as ON by the gate).
+- **Do NOT** rename the unrelated `instructHash`/`renderedInstructHashes` "liveInstruct render" comments in `segments-io.ts`/`stale-chapters.ts`/`handoff/schemas.ts`/`book-state.ts:460`, the local `liveInstruct` prop in `script-review-diff.tsx`, or the `hasLiveInstructMember` comment in `sentence-instruct-control.tsx` — they name the synth path, not this flag.
 
-- [ ] **Step 1: Enumerate sites** — `git grep -n "liveInstruct\|LiveInstruct" src server/src openapi.yaml` and cross-check against the Files list; set aside the segments-io / stale-chapters synth-path comments.
+- [ ] **Step 1: Enumerate sites** — `git grep -n "liveInstruct\|LiveInstruct" src server/src openapi.yaml` and cross-check against the Files list; set aside the synth-path comments listed above. (Note: the action/selector currently have **zero non-test consumers** — orphaned plumbing — so no caller-site surprises.)
 - [ ] **Step 2: Write the failing test** — extend `book-meta-slice.test.ts`: `selectProsodyEnabled(bookId)` returns `undefined` for an unset book; `true`/`false` after `setProsodyEnabled`; hydrating `{ prosodyEnabled: undefined }` leaves it undefined (NOT coerced to false).
 - [ ] **Step 3: Run, verify fail** — `npm test -- book-meta` → FAIL (action/selector not renamed yet).
-- [ ] **Step 4: Implement** — perform the rename across the Files list; flip the slice selector + both hydration sites to preserve undefined (the one non-mechanical change); `npm run openapi:types`.
+- [ ] **Step 4: Implement** — perform the rename across the Files list; preserve undefined at the selector + both hydration sites (the one non-mechanical change); `npm run openapi:types`.
 - [ ] **Step 5: Run, verify pass** — `npm test -- book-meta` + `cd server && npm run test -- book-state` + `npm run typecheck` → PASS.
-- [ ] **Step 6: Commit** — `refactor: rename liveInstruct flag to nullable prosodyEnabled (Phase-3 intent)`.
+- [ ] **Step 6: Commit** — `refactor: rename liveInstruct flag to eager-default prosodyEnabled (Phase-3 intent)`.
 
-### Task 12: analysis-form "Expressive directions (Qwen 1.7B)" toggle (smart default)
+### Task 12: analysis-form "Expressive directions" toggle (checked by default)
 
 **Files:**
 - Modify: `src/views/analysing.tsx` (start-analysis surface, near the "Start analysis" button ~line 1172) — add the toggle.
 - Test: `src/views/analysing-prosody-toggle.test.tsx`.
 
 **Interfaces:**
-- Consumes: `selectProsodyEnabled(bookId)` + `bookMetaActions.setProsodyEnabled` (Task 11); `state.account.defaultTtsModelKey`.
+- Consumes: `selectProsodyEnabled(bookId)` + `bookMetaActions.setProsodyEnabled` (Task 11).
 
 Behaviour:
-- **Checked state** = `stored ?? (defaultTtsModelKey === 'qwen3-tts-1.7b')`, where `stored = useAppSelector(selectProsodyEnabled(bookId))`. A 1.7B-default user sees it pre-ticked ("we assume you'll take the quality pass"); a Kokoro user sees it un-ticked. An untouched book stores nothing (undefined = auto).
-- **On change:** `dispatch(bookMetaActions.setProsodyEnabled({ bookId, value }))` AND `void api.putBookState(bookId, { slice: 'state', patch: { prosodyEnabled: value } })` for durability. **Do NOT gate the analysis POST on it** — Phase 3 runs after analysis via the client-side Task-13 trigger; the server never reads this during analysis.
-- Label "Expressive directions (Qwen 1.7B)"; helper text "Generate per-line emotion + delivery directions for the richer 1.7B voice. Runs in the background after analysis."
+- **Checked state** = `stored !== false`, where `stored = useAppSelector(selectProsodyEnabled(bookId))`. So it is **checked by default** (eager) — unset (`undefined`) and `true` both render checked; only an explicit `false` renders unchecked.
+- **On change:** `dispatch(bookMetaActions.setProsodyEnabled({ bookId, value }))` AND `void api.putBookState(bookId, { slice: 'state', patch: { prosodyEnabled: value } })` for durability. Unchecking stores `false`; re-checking stores `true`. **Do NOT gate the analysis POST on it** — Phase 3 runs after analysis via the client-side Task-13 trigger; the server never reads this during analysis.
+- Label "Expressive directions"; helper text "Generate per-line emotion + delivery directions for the higher-quality (1.7B) voice. Runs in the background after analysis."
 
-- [ ] **Step 1: Write the failing test** — with `defaultTtsModelKey='qwen3-tts-1.7b'` + no stored value → toggle renders **checked**; with a Kokoro default + no stored value → **unchecked**; toggling dispatches `setProsodyEnabled` and issues the PUT carrying the explicit boolean.
+- [ ] **Step 1: Write the failing test** — with no stored value → toggle renders **checked** (eager default); with stored `false` → **unchecked**; unchecking dispatches `setProsodyEnabled({value:false})` and issues the PUT with `false`; re-checking issues `true`.
 - [ ] **Step 2: Run, verify fail** — `npm test -- analysing-prosody-toggle` → FAIL.
 - [ ] **Step 3: Implement** the toggle per Behaviour above.
 - [ ] **Step 4: Run, verify pass.**
-- [ ] **Step 5: Commit** — `feat(frontend): expressive-directions toggle on the analysis form (smart default)`.
+- [ ] **Step 5: Commit** — `feat(frontend): expressive-directions toggle on the analysis form (on by default)`.
 
-### Task 13: reactive auto-trigger (intent flag + cast-time safety net) + watermark
+### Task 13: eager auto-trigger (`confirm`-only, per-book, retry-safe) + watermark
 
 **Files:**
-- Modify: `src/components/layout.tsx` — add a `useEffect` mirroring the existing voice-match auto-trigger (`layout.tsx:895-917`): `useRef` fired-guard + an `AbortController` cleanup (the voice-match sibling has none — create one here).
+- Modify: `src/components/layout.tsx` — add a `useEffect` modeled on the voice-match auto-trigger (`layout.tsx:895-917`), but with a **per-book** fired-guard (a `Set<string>` in a ref, NOT a single slot) and the run launched as a **tracked background job that survives a `bookId` change** (concurrent multi-book is a first-class invariant — a background book's pass must not be aborted when the user switches the active book).
 - Test: `src/store/prosody-autotrigger.test.tsx`.
 
 **Interfaces:**
-- Consumes: `runProsodyPasses` (Task 10); `selectProsodyEnabled` (Task 11); the cast slice; `api.getBookState`/`api.putBookState`.
+- Consumes: `runProsodyPasses` (Task 10); `selectProsodyEnabled` (Task 11); `api.getBookState`/`api.putBookState`. **No cast read** (eager-default does not depend on the cast).
 
 ```tsx
-const prosodyEnabled = useAppSelector(selectProsodyEnabled(bookId));        // boolean | undefined
-const bookCastIs17b = useAppSelector((s) =>
-  (s.cast?.characters ?? []).some((c) => c.ttsModelKey === 'qwen3-tts-1.7b'));
-const shouldAnnotate =
-  prosodyEnabled === false ? false
-  : prosodyEnabled === true ? true
-  : bookCastIs17b;                                                          // "auto" / safety-net case
+const prosodyEnabled = useAppSelector(selectProsodyEnabled(bookId));   // boolean | undefined
+const shouldAnnotate = prosodyEnabled !== false;                       // eager default: absent/true ⇒ on
 
-const prosodyFiredFor = useRef<string | null>(null);
+const prosodyFiredFor = useRef<Set<string>>(new Set());
 useEffect(() => {
-  if (stageKind !== 'confirm' && stageKind !== 'ready') { prosodyFiredFor.current = null; return; }
-  if (!bookId || !shouldAnnotate) return;          // MUST precede the guard set, so a later flip can still fire
-  if (prosodyFiredFor.current === bookId) return;
-  prosodyFiredFor.current = bookId;
-  const ac = new AbortController();
+  if (stageKind !== 'confirm') return;             // fresh-analysis transition only — NOT 'ready' (no retro-annotation)
+  if (!bookId || !shouldAnnotate) return;
+  if (prosodyFiredFor.current.has(bookId)) return; // per-book guard
+  prosodyFiredFor.current.add(bookId);
+  // Tracked background job: deliberately NOT tied to this effect's cleanup, so
+  // switching the active book does not abort an in-flight pass (round-1 H2).
   (async () => {
-    const st = await api.getBookState(bookId);
-    if (ac.signal.aborted || st?.state.prosodyAnnotated) return;            // watermark complete → never re-run
-    await runProsodyPasses(bookId, { dispatch, signal: ac.signal });
-    if (!ac.signal.aborted) void api.putBookState(bookId, { slice: 'state', patch: { prosodyAnnotated: true } });
+    try {
+      const st = await api.getBookState(bookId);
+      if (st?.state.prosodyAnnotated) return;       // watermark complete → no-op
+      await runProsodyPasses(bookId, { dispatch });
+      void api.putBookState(bookId, { slice: 'state', patch: { prosodyAnnotated: true } });
+    } catch {
+      prosodyFiredFor.current.delete(bookId);        // retry-safe (round-1 H3): a failed pass can re-fire this session
+    }
   })();
-  return () => ac.abort();
 }, [stageKind, bookId, shouldAnnotate]);
 ```
-- **`shouldAnnotate` is the single gate dependency** — folding `prosodyEnabled` + `bookCastIs17b` into it means a late cast bulk-pin (which flips `bookCastIs17b` true via the cast slice) re-runs the effect → the **cast-time safety net**, with no separate `POST /cast/tier` instrumentation.
-- The `if (!shouldAnnotate) return;` **must** come before `prosodyFiredFor.current = bookId` so a book that started ineligible (false) and later flips eligible isn't blocked by a prematurely-set guard.
-- `prosodyAnnotated` is NOT hydrated into any slice, so it is fetched inline via `api.getBookState` (`BookStateResponse | null`; read `st?.state.prosodyAnnotated`). The watermark dedupes both trigger paths.
+- **`confirm`-only** (not `ready`): fires on the post-analysis transition, so a fresh analysis annotates but pre-existing library books (opened straight to `ready`) are not retro-annotated — no backlog-wide auto-spend, no `getBookState` on the Listen path.
+- **Per-book guard + book-switch-safe** (round-1 H2): the `Set<string>` ref tracks every book that has fired; the IIFE is intentionally detached from the effect's render lifecycle (no `AbortController` keyed on `bookId`) so a background book's pass completes even after the user navigates to another book.
+- **Retry-safe** (round-1 H3): the `try/catch` clears the per-book guard on failure, so a transient analyzer/quota error does not permanently silence Phase 3 for the session.
+- `prosodyAnnotated` is NOT hydrated into any slice, so it is fetched inline via `api.getBookState` (`BookStateResponse | null`; read `st?.state.prosodyAnnotated`) — once, at `confirm`.
 
-- [ ] **Step 1: Write the failing test** — gate truth-table: `undefined` + 1.7B cast → fires `runProsodyPasses` once; `undefined` + Kokoro cast → never fires; `false` + 1.7B cast → suppressed; `true` + Kokoro cast → fires; `getBookState` returns `{prosodyAnnotated:true}` → fires guard but no `runProsodyPasses`; **late pin: rerender with a 1.7B cast member appended → fires exactly once** (assert call count 1 across the rerender); on completion `putBookState` writes `prosodyAnnotated:true`.
+- [ ] **Step 1: Write the failing test** — `undefined` + `confirm` → fires `runProsodyPasses` once (eager); `true` + `confirm` → fires; `false` + `confirm` → never fires; `stageKind='ready'` (no `confirm`) → never fires; `getBookState` returns `{prosodyAnnotated:true}` → no `runProsodyPasses`; **two distinct bookIds each reach `confirm` → each fires once and the first's run is NOT aborted when bookId changes** (assert both completed); **a rejected `runProsodyPasses` clears the guard so a second `confirm` for the same book re-fires**; on success `putBookState` writes `prosodyAnnotated:true`.
 - [ ] **Step 2: Run, verify fail.**
 - [ ] **Step 3: Implement** per the shape above.
 - [ ] **Step 4: Run, verify pass.**
-- [ ] **Step 5: Commit** — `feat(frontend): reactive prosody auto-trigger (intent flag + cast-time safety net)`.
+- [ ] **Step 5: Commit** — `feat(frontend): eager confirm-stage prosody auto-trigger (per-book, retry-safe)`.
+
+### Task 13b: opt-out render-time hint (round-1 M5)
+
+When a book with `prosodyEnabled === false` is rendered at 1.7B it gets only the four canned `emotionToInstruct` phrases, silently. Surface a one-line hint so this isn't invisible.
+
+**Files:**
+- Modify: the cast/generate surface (`src/views/cast.tsx`, near the bulk-pin / generate action) — when `selectProsodyEnabled(bookId) === false` AND any cast member has `ttsModelKey === 'qwen3-tts-1.7b'`, render a dismissible inline hint: "Expressive directions are off for this book — using basic emotion phrases." with a **[Turn on]** action that `dispatch(setProsodyEnabled({bookId, value:true}))` + PUTs, then offers the manual "Detect emotions" run.
+- Test: `src/views/cast-prosody-hint.test.tsx`.
+
+- [ ] TDD: hint renders only when `prosodyEnabled===false` AND a 1.7B cast member exists; absent otherwise; [Turn on] flips the flag + issues the PUT. Commit `feat(frontend): hint when expressive directions are off on a 1.7B book`.
+- [ ] **Scope note:** if this risks PR3 size, split it to an immediate follow-up PR (`feat/frontend-prosody-offhint`) — do NOT silently drop it (the spec names it a required surfacing).
 
 ### Task 14: global prosody progress pill
 
@@ -476,15 +488,16 @@ useEffect(() => {
 
 ### Task 15: PR3 e2e + verify + open
 
-- [ ] e2e `e2e/analysis-prosody-toggle.spec.ts`: a 1.7B-default book (or the toggle on) → analysis completes → user reaches cast while the prosody pill runs → annotations land (assert a sentence gains an `instruct`).
+- [ ] e2e `e2e/analysis-prosody-toggle.spec.ts`: a book with the toggle left on (default) → analysis completes → at the confirm/cast stage the prosody pill runs → annotations land (assert a sentence gains an `instruct`). Add a second assertion: a book with the toggle unchecked pre-analysis does NOT run the pass.
 - [ ] `npm run verify` (full battery incl. e2e). Rebase on latest `origin/main`. Push `feat/analysis-phase3-prosody`. PR title `feat: auto-generate per-line prosody annotations after analysis (Phase 3)`, body links the spec §Deliverable-1 + the gate-model section + `Closes #1129`.
 
 ---
 
 ## Self-review notes
 
-- **Spec coverage:** §2A → PR1 Tasks 1–2 + PR3 Task 9 (detect handlers). §2B shared chunker → PR2 Task 4; script-review consumption → Task 5. §Deliverable-1 (gate model): flag rename → Task 11; analysis-form toggle (smart default) → Task 12; reactive auto-trigger + cast-time safety net → Task 13; watermark → Task 7; chunker reuse by annotation passes → Task 8; global-pill surfacing → Task 14; reusable pass → Task 10.
+- **Spec coverage:** §2A → PR1 Tasks 1–2 + PR3 Task 9 (detect handlers). §2B shared chunker → PR2 Task 4; script-review consumption → Task 5. §Deliverable-1 (gate model): flag rename → Task 11; analysis-form toggle (checked by default) → Task 12; eager `confirm`-only per-book/retry-safe auto-trigger → Task 13; opt-out render hint (M5) → Task 13b; watermark → Task 7; chunker reuse by annotation passes → Task 8; global-pill surfacing → Task 14; reusable pass → Task 10.
 - **Owned-core rule** (the round-2 fix) is centralized in Task 4 and consumed by Tasks 5 + 8 — no `opKey` cross-chunk dedupe anywhere.
 - **No 4th in-pipeline phase / no `PHASE_WEIGHTS` edits** (round-2 blast-radius avoided): Phase 3 surfaces via its own `prosody-slice` pill (Task 14), not `ANALYSIS_PHASES`.
-- **`prosodyEnabled` is the single intent flag** (Tasks 11–13), nullable (undefined = auto-by-cast). The synth-time gate is `is17b` alone (fs-66) — there is NO competing book-quality flag and NO `bookQualityOverride`; the cast-time signal is `ttsModelKey === 'qwen3-tts-1.7b'`.
-- **Two distinct booleans, don't conflate:** `prosodyEnabled` (Task 11 — "should we annotate", nullable intent) vs `prosodyAnnotated` (Task 7 — "annotation finished", watermark).
+- **`prosodyEnabled` is the single intent flag** (Tasks 11–13), eager (`!== false` ⇒ on). The synth-time gate is `is17b` alone (fs-66) — there is NO competing book-quality flag and NO cast read in the gate.
+- **Round-1 review folded:** C1/M6 dissolved by eager-default (no cast-derived eligibility); H2 (per-book guard, book-switch-safe) + H3 (retry-safe) in Task 13; H4 resolved by `confirm`-only firing; M5 hint in Task 13b. Round-2 review TBD.
+- **Two distinct booleans, don't conflate:** `prosodyEnabled` (Task 11 — "should we annotate", eager) vs `prosodyAnnotated` (Task 7 — "annotation finished", watermark).

--- a/docs/superpowers/plans/2026-06-25-phase3-prosody-and-scriptreview-chunking.md
+++ b/docs/superpowers/plans/2026-06-25-phase3-prosody-and-scriptreview-chunking.md
@@ -294,6 +294,11 @@ git commit -m "feat(server): script review chunks large chapters via owned-core 
 
 ## PR3 — Phase 3 prosody annotation (branch `feat/analysis-phase3-prosody`)
 
+> **IMPLEMENTED 2026-06-26.** Tasks 7–14 + the Task-15 e2e are built on
+> `feat/analysis-phase3-prosody` (SDD, per-task reviews, a dedicated Task-13
+> trigger review, and an Opus whole-branch review — no Critical). Full
+> `npm run verify` green (incl. e2e 234 passed). Closes #1129.
+
 > **GATE REDESIGNED (2026-06-25) — ready to execute.** PR1 (#1126) and PR2
 > (#1128) shipped. fs-66 ("1.7B implies prosody", PR #1136) has now landed on
 > `main`: the synth prosody gate is `is17b` alone, `liveInstruct` is orphaned

--- a/docs/superpowers/plans/2026-06-25-phase3-prosody-and-scriptreview-chunking.md
+++ b/docs/superpowers/plans/2026-06-25-phase3-prosody-and-scriptreview-chunking.md
@@ -4,7 +4,7 @@
 
 **Goal:** Stop script review from silently failing on normal-sized chapters, make it work on huge (Cyrillic) chapters via a sentence-chunker, and auto-generate per-line prosody annotations as a gated post-analysis pass.
 
-**Architecture:** Three independent PRs. PR1 surfaces a dropped SSE event (client only). PR2 adds a server sentence-chunker (owned-core ownership rule) consumed by script-review. PR3 auto-triggers the existing annotation routes (through PR2's chunker) after analysis when a per-book `liveInstruct` flag is on, with a completion watermark.
+**Architecture:** Three independent PRs. PR1 surfaces a dropped SSE event (client only). PR2 adds a server sentence-chunker (owned-core ownership rule) consumed by script-review. PR3 (gate redesigned post-fs-66) auto-triggers the existing annotation routes (through PR2's chunker) after analysis via a single reactive effect gated on a nullable per-book `prosodyEnabled` intent flag OR a cast-derived 1.7B signal (the cast-time safety net), deduped by a completion watermark.
 
 **Tech Stack:** Vite + React 18 + Redux Toolkit (frontend, Vitest + jsdom); Node/Express + TypeScript (server, Vitest + node env); Playwright (e2e). SSE for streamed analyzer passes.
 
@@ -19,7 +19,7 @@
 - **Commit convention:** `<type>(<scope>): <subject>`. End every commit body with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
 - **One branch = one PR.** PR1 `fix/frontend-scriptreview-chapter-failed`; PR2 `feat/server-analyzer-chapter-chunker`; PR3 `feat/analysis-phase3-prosody`. Cut each off the latest `origin/main`.
 - **Verify gates:** frontend `npm test`; server `cd server && npm run test`; full `npm run verify` before each PR push.
-- **PR3 coordination:** a concurrent session owns `docs/superpowers/specs/2026-06-25-book-level-higher-quality-tier-design.md` (the synth-time book 1.7B override). PR3 MUST reuse the shared `liveInstruct` flag and MUST NOT introduce a competing book-quality flag. Rebase + reconcile before PR3 lands.
+- **PR3 gate (post-fs-66):** fs-66 ("1.7B implies prosody") has merged — synth gate is `is17b` alone, the "go 1.7B" decision is the cast `ttsModelKey`. PR3 renames the orphaned `liveInstruct` flag to a nullable `prosodyEnabled` intent flag (Task 11) and MUST NOT introduce any competing book-quality flag. There is no concurrent session to reconcile with; just cut off latest `origin/main`.
 
 ---
 
@@ -153,7 +153,7 @@ git commit -m "fix(frontend): toast on script-review chapter-failed instead of e
 
 ### Task 3: PR1 verify + open
 
-- [ ] `npm run verify` (frontend leg green). Rebase on `origin/main`. Push `fix/frontend-scriptreview-chapter-failed`. Open PR titled `fix(frontend): surface script-review chapter-failed instead of a silent empty modal`, body links the spec §2A + `Closes #<2A issue>`.
+- [ ] `npm run verify` (frontend leg green). Rebase on `origin/main`. Push `fix/frontend-scriptreview-chapter-failed`. Open PR titled `fix(frontend): surface script-review chapter-failed instead of a silent empty modal`, body links the spec §2A + `Closes #1124`. **(SHIPPED — PR #1126.)**
 
 ---
 
@@ -288,38 +288,40 @@ git commit -m "feat(server): script review chunks large chapters via owned-core 
 
 ### Task 6: PR2 verify + open
 
-- [ ] `npm run verify` (server + server-slow legs). Rebase on `origin/main`. Push `feat/server-analyzer-chapter-chunker`. PR title `feat(server): chunk script review over large chapters (owned-core sentence chunker)`, body links spec §2B + shared-component section + `Closes #<2B issue>`.
+- [ ] `npm run verify` (server + server-slow legs). Rebase on `origin/main`. Push `feat/server-analyzer-chapter-chunker`. PR title `feat(server): chunk script review over large chapters (owned-core sentence chunker)`, body links spec §2B + shared-component section + `Closes #1127`. **(SHIPPED — PR #1128.)**
 
 ---
 
 ## PR3 — Phase 3 prosody annotation (branch `feat/analysis-phase3-prosody`)
 
-> **DEFERRED (2026-06-25).** PR1 (#1126) and PR2 (#1128) shipped. PR3 is paused:
-> the concurrent `feat/server-1.7b-implies-prosody` change drops `liveInstruct`
-> (the gate every task below keys on) in favor of "1.7B implies prosody". Do NOT
-> execute Tasks 7–14 as written. When that change + the book-level 1.7B override
-> land on `main`, **redesign the gate**: replace the `liveInstruct` toggle/trigger
-> (Tasks 11–12) with a trigger keyed on the new 1.7B signal (per-cast `is17b` /
-> book-quality override), and re-confirm the watermark (Task 7) + chunked
-> annotation passes (Tasks 8–10, 13) still apply. The chunker (PR2, merged) is the
-> reusable asset this will consume. Tracked in the deferred Phase-3 issue.
+> **GATE REDESIGNED (2026-06-25) — ready to execute.** PR1 (#1126) and PR2
+> (#1128) shipped. fs-66 ("1.7B implies prosody", PR #1136) has now landed on
+> `main`: the synth prosody gate is `is17b` alone, `liveInstruct` is orphaned
+> plumbing (set by no UI, read at no synth site), and the "go 1.7B" decision is a
+> **cast-time** signal (`ttsModelKey === 'qwen3-tts-1.7b'`, per-character or via
+> the book bulk-pin `POST /cast/tier`). Tasks 7–10 + 14 are unchanged. The gate
+> tasks are redesigned below: **Task 11 (new)** renames `liveInstruct` →
+> `prosodyEnabled`; **Task 12** is the smart-default analysis-form toggle;
+> **Task 13** is the single reactive auto-trigger whose cast dependency IS the
+> cast-time safety net. See the spec's "Gate model" section (read it — the
+> tri-state flag + cast-derived auto-rule are folded there).
 
-**PREREQUISITE — PR2 MUST be merged first.** Task 8 imports `server/src/analyzer/chapter-chunker.ts`, which only exists once PR2 lands. **Cut `feat/analysis-phase3-prosody` off the updated `origin/main` AFTER PR2 has merged** (do not branch off PR1 or off a pre-PR2 main, or Task 8's import will not resolve).
+**PREREQUISITE — satisfied.** Task 8 imports `server/src/analyzer/chapter-chunker.ts`, which landed with PR2 (#1128, merged). **Cut `feat/analysis-phase3-prosody` off the latest `origin/main`** (which now contains both PR2 and fs-66).
 
-**COORDINATION GATE (do first):** rebase on latest `origin/main`; check whether the concurrent book-1.7B work has landed a quality flag. Reuse `liveInstruct`; do NOT add a competing flag. If their `bookQualityOverride` exists, the toggle here still SETS `liveInstruct` (annotation generation is gated on `liveInstruct`, independent of their synth-time override).
+**No coordination gate.** The concurrent book-1.7B work (fs-66) is merged; it did **not** introduce a `bookQualityOverride` flag — the override is the cast `ttsModelKey` written by `POST /cast/tier`. Do NOT add any competing book-quality flag; the only intent flag is `prosodyEnabled` (Task 11).
 
 ### Task 7: book-state `prosodyAnnotated` watermark
 
 **Files:**
-- Modify: `server/src/workspace/scan.ts` (`BookStateJson`, near `liveInstruct?` at lines 230–236); `server/src/routes/book-state.ts` (the `case 'state':` patch handler, lines 605–765).
+- Modify: `server/src/workspace/scan.ts` (`BookStateJson`, near the existing `liveInstruct?` / `prosodyEnabled?` boolean field at lines 230–236); `server/src/routes/book-state.ts` (the `case 'state':` patch handler, lines 605–765).
 - Test: `server/src/routes/book-state.test.ts` (extend).
 
 **Interfaces:**
-- Produces: `BookStateJson.prosodyAnnotated?: boolean` — true once both prosody passes complete for the book; the auto-trigger fires only when absent/false.
+- Produces: `BookStateJson.prosodyAnnotated?: boolean` — true once both prosody passes complete for the book; the auto-trigger fires only when absent/false. **Distinct from the `prosodyEnabled` intent flag (Task 11): `prosodyEnabled` = "should we annotate", `prosodyAnnotated` = "annotation finished".**
 
 - [ ] **Step 1: Write the failing test** — `PUT /api/books/:bookId/state {patch:{prosodyAnnotated:true}}` persists the field; an absent/non-boolean patch leaves it unchanged.
 - [ ] **Step 2: Run, verify fail** — `cd server && npm run test -- book-state` → FAIL.
-- [ ] **Step 3: Implement** — add the optional field (JSDoc, additive — do NOT bump `CURRENT_STATE_SCHEMA`, mirror the `liveInstruct` note) + a boolean picker in the `case 'state':` spread (mirror the existing `liveInstruct` ternary).
+- [ ] **Step 3: Implement** — add the optional field (JSDoc, additive — do NOT bump `CURRENT_STATE_SCHEMA`, mirror the existing single-boolean field's note) + a boolean picker in the `case 'state':` spread (mirror the existing single-boolean ternary in that handler).
 - [ ] **Step 4: Run, verify pass.**
 - [ ] **Step 5: Commit** — `feat(server): prosodyAnnotated watermark on book state`.
 
@@ -376,47 +378,94 @@ annotatedChapters += 1; // once per chapter, after the chunk loop — keep the e
 
 - [ ] TDD: test that it calls both api passes in order and dispatches both apply actions; mock `api`. Commit `refactor(frontend): extract runProsodyPasses from DetectEmotionsButton`.
 
-### Task 11: analysis-form "High-quality prosody (Qwen 1.7B)" toggle
+### Task 11: rename `liveInstruct` → `prosodyEnabled` (nullable Phase-3 intent flag)
+
+The fs-66-orphaned `liveInstruct` flag is renamed and repurposed as the Phase-3 intent flag, and its semantics flip from plain-boolean (`?? false`) to **nullable** (undefined = "auto") so the Task-13 gate can distinguish undefined/true/false.
 
 **Files:**
-- Modify: `src/views/analysing.tsx` (the start-analysis surface, near the "Start analysis" button ~line 1172) — add the toggle. On change: `dispatch(bookMetaActions.setLiveInstruct({ bookId, value }))` AND `void api.putBookState(bookId, { slice: 'state', patch: { liveInstruct: value } })` for durability. **Do NOT gate the analysis POST on this** — round-2 established Phase 3 runs *after* analysis with a client-side gate, so the server never reads `liveInstruct` during analysis. There is no "await PUT before POST" requirement (the original plan's wording was wrong: `setLiveInstruct` persistence is not awaitable middleware, and ordering doesn't matter here). The store value is the source of truth for the Task-12 trigger; the PUT is just so it survives reload.
-- Test: `src/views/analysing-prosody-toggle.test.tsx` + one e2e `e2e/analysis-prosody-toggle.spec.ts`.
+- Modify: `server/src/workspace/scan.ts` — rename `BookStateJson.liveInstruct?` → `prosodyEnabled?` (line 236) + rewrite its JSDoc (it is NO LONGER a synth-path flag — it is the Phase-3 annotation intent flag; undefined ⇒ auto-by-cast).
+- Modify: `server/src/routes/book-state.ts` — the `case 'state':` picker that reads `liveInstruct` (lines 706–708) → `prosodyEnabled`.
+- Modify: `src/store/book-meta-slice.ts` — rename `liveInstruct` field (55, 61), hydration (94), `setLiveInstruct` (119–120), `selectLiveInstruct` (167–170) to `prosodyEnabled`/`setProsodyEnabled`/`selectProsodyEnabled`. **Flip to nullable:** hydration preserves undefined (`s.prosodyEnabled[bookId] = state.prosodyEnabled` — drop the `?? false`); the selector returns `s.bookMeta.prosodyEnabled[bookId]` with **NO `?? false`** (the gate needs the three states).
+- Modify: `src/components/layout.tsx:790` — hydration `liveInstruct: res.state.liveInstruct ?? false` → `prosodyEnabled: res.state.prosodyEnabled` (preserve undefined).
+- Modify: `openapi.yaml` — rename the book-state `liveInstruct` property (line 3361) → `prosodyEnabled` + rewrite its description. **Do NOT touch line 4910** (the Sentence `instruct` "Qwen 1.7B liveInstruct path" comment names the synth path, not this flag). Then regenerate: `npm run openapi:types` (updates `src/lib/api-types.ts`).
+- Modify tests: `src/store/book-meta-slice.test.ts`, `server/src/routes/book-state.test.ts`, and any `setLiveInstruct`/`selectLiveInstruct` references.
 
 **Interfaces:**
-- Consumes: `bookMetaActions.setLiveInstruct({ bookId, value })` (`book-meta-slice.ts:119`); `selectLiveInstruct(bookId)` (`:167`).
+- Produces: `bookMetaActions.setProsodyEnabled({ bookId, value: boolean })`; `selectProsodyEnabled(bookId): (s: RootState) => boolean | undefined`; `BookStateJson.prosodyEnabled?: boolean` (undefined when absent).
+- **Do NOT** rename the unrelated `instructHash`/`renderedInstructHashes` "liveInstruct render" comments in `segments-io.ts`/`stale-chapters.ts` — they name the synth path.
 
-- [ ] TDD: toggling sets `bookMeta.liveInstruct[bookId]` and issues the PUT; default off. Commit `feat(frontend): high-quality prosody toggle on the analysis form`.
+- [ ] **Step 1: Enumerate sites** — `git grep -n "liveInstruct\|LiveInstruct" src server/src openapi.yaml` and cross-check against the Files list; set aside the segments-io / stale-chapters synth-path comments.
+- [ ] **Step 2: Write the failing test** — extend `book-meta-slice.test.ts`: `selectProsodyEnabled(bookId)` returns `undefined` for an unset book; `true`/`false` after `setProsodyEnabled`; hydrating `{ prosodyEnabled: undefined }` leaves it undefined (NOT coerced to false).
+- [ ] **Step 3: Run, verify fail** — `npm test -- book-meta` → FAIL (action/selector not renamed yet).
+- [ ] **Step 4: Implement** — perform the rename across the Files list; flip the slice selector + both hydration sites to preserve undefined (the one non-mechanical change); `npm run openapi:types`.
+- [ ] **Step 5: Run, verify pass** — `npm test -- book-meta` + `cd server && npm run test -- book-state` + `npm run typecheck` → PASS.
+- [ ] **Step 6: Commit** — `refactor: rename liveInstruct flag to nullable prosodyEnabled (Phase-3 intent)`.
 
-### Task 12: post-analysis auto-trigger + watermark
+### Task 12: analysis-form "Expressive directions (Qwen 1.7B)" toggle (smart default)
 
 **Files:**
-- Modify: `src/components/layout.tsx` — add a `useEffect` that **mirrors the existing voice-match auto-trigger** (`layout.tsx:895-917`), which uses a `useRef` guard + a `cancelled` cleanup boolean (it has NO AbortController — create one here). Shape:
+- Modify: `src/views/analysing.tsx` (start-analysis surface, near the "Start analysis" button ~line 1172) — add the toggle.
+- Test: `src/views/analysing-prosody-toggle.test.tsx`.
+
+**Interfaces:**
+- Consumes: `selectProsodyEnabled(bookId)` + `bookMetaActions.setProsodyEnabled` (Task 11); `state.account.defaultTtsModelKey`.
+
+Behaviour:
+- **Checked state** = `stored ?? (defaultTtsModelKey === 'qwen3-tts-1.7b')`, where `stored = useAppSelector(selectProsodyEnabled(bookId))`. A 1.7B-default user sees it pre-ticked ("we assume you'll take the quality pass"); a Kokoro user sees it un-ticked. An untouched book stores nothing (undefined = auto).
+- **On change:** `dispatch(bookMetaActions.setProsodyEnabled({ bookId, value }))` AND `void api.putBookState(bookId, { slice: 'state', patch: { prosodyEnabled: value } })` for durability. **Do NOT gate the analysis POST on it** — Phase 3 runs after analysis via the client-side Task-13 trigger; the server never reads this during analysis.
+- Label "Expressive directions (Qwen 1.7B)"; helper text "Generate per-line emotion + delivery directions for the richer 1.7B voice. Runs in the background after analysis."
+
+- [ ] **Step 1: Write the failing test** — with `defaultTtsModelKey='qwen3-tts-1.7b'` + no stored value → toggle renders **checked**; with a Kokoro default + no stored value → **unchecked**; toggling dispatches `setProsodyEnabled` and issues the PUT carrying the explicit boolean.
+- [ ] **Step 2: Run, verify fail** — `npm test -- analysing-prosody-toggle` → FAIL.
+- [ ] **Step 3: Implement** the toggle per Behaviour above.
+- [ ] **Step 4: Run, verify pass.**
+- [ ] **Step 5: Commit** — `feat(frontend): expressive-directions toggle on the analysis form (smart default)`.
+
+### Task 13: reactive auto-trigger (intent flag + cast-time safety net) + watermark
+
+**Files:**
+- Modify: `src/components/layout.tsx` — add a `useEffect` mirroring the existing voice-match auto-trigger (`layout.tsx:895-917`): `useRef` fired-guard + an `AbortController` cleanup (the voice-match sibling has none — create one here).
+- Test: `src/store/prosody-autotrigger.test.tsx`.
+
+**Interfaces:**
+- Consumes: `runProsodyPasses` (Task 10); `selectProsodyEnabled` (Task 11); the cast slice; `api.getBookState`/`api.putBookState`.
+
 ```tsx
+const prosodyEnabled = useAppSelector(selectProsodyEnabled(bookId));        // boolean | undefined
+const bookCastIs17b = useAppSelector((s) =>
+  (s.cast?.characters ?? []).some((c) => c.ttsModelKey === 'qwen3-tts-1.7b'));
+const shouldAnnotate =
+  prosodyEnabled === false ? false
+  : prosodyEnabled === true ? true
+  : bookCastIs17b;                                                          // "auto" / safety-net case
+
 const prosodyFiredFor = useRef<string | null>(null);
 useEffect(() => {
-  if (stageKind !== 'confirm') { prosodyFiredFor.current = null; return; }
-  if (!bookId || !liveInstruct) return;                 // liveInstruct = useAppSelector(selectLiveInstruct(bookId))
+  if (stageKind !== 'confirm' && stageKind !== 'ready') { prosodyFiredFor.current = null; return; }
+  if (!bookId || !shouldAnnotate) return;          // MUST precede the guard set, so a later flip can still fire
   if (prosodyFiredFor.current === bookId) return;
   prosodyFiredFor.current = bookId;
   const ac = new AbortController();
   (async () => {
     const st = await api.getBookState(bookId);
-    if (ac.signal.aborted || st?.state.prosodyAnnotated) return;   // watermark complete → never re-run
+    if (ac.signal.aborted || st?.state.prosodyAnnotated) return;            // watermark complete → never re-run
     await runProsodyPasses(bookId, { dispatch, signal: ac.signal });
     if (!ac.signal.aborted) void api.putBookState(bookId, { slice: 'state', patch: { prosodyAnnotated: true } });
   })();
   return () => ac.abort();
-}, [stageKind, bookId, liveInstruct]);
+}, [stageKind, bookId, shouldAnnotate]);
 ```
-`prosodyAnnotated` is NOT hydrated into any slice today, so it MUST be fetched inline via `api.getBookState` (returns `BookStateResponse | null`; read `st?.state.prosodyAnnotated`). The AbortController is created in the effect (the voice-match sibling has none) and aborted in cleanup so a stage change cancels an in-flight run.
-- Test: `src/store/prosody-autotrigger.test.tsx`.
+- **`shouldAnnotate` is the single gate dependency** — folding `prosodyEnabled` + `bookCastIs17b` into it means a late cast bulk-pin (which flips `bookCastIs17b` true via the cast slice) re-runs the effect → the **cast-time safety net**, with no separate `POST /cast/tier` instrumentation.
+- The `if (!shouldAnnotate) return;` **must** come before `prosodyFiredFor.current = bookId` so a book that started ineligible (false) and later flips eligible isn't blocked by a prematurely-set guard.
+- `prosodyAnnotated` is NOT hydrated into any slice, so it is fetched inline via `api.getBookState` (`BookStateResponse | null`; read `st?.state.prosodyAnnotated`). The watermark dedupes both trigger paths.
 
-**Interfaces:**
-- Consumes: `runProsodyPasses` (Task 10); `selectLiveInstruct` (Task 11); `prosodyAnnotated` from book state (Task 7, read via book-meta hydration or a fetch).
+- [ ] **Step 1: Write the failing test** — gate truth-table: `undefined` + 1.7B cast → fires `runProsodyPasses` once; `undefined` + Kokoro cast → never fires; `false` + 1.7B cast → suppressed; `true` + Kokoro cast → fires; `getBookState` returns `{prosodyAnnotated:true}` → fires guard but no `runProsodyPasses`; **late pin: rerender with a 1.7B cast member appended → fires exactly once** (assert call count 1 across the rerender); on completion `putBookState` writes `prosodyAnnotated:true`.
+- [ ] **Step 2: Run, verify fail.**
+- [ ] **Step 3: Implement** per the shape above.
+- [ ] **Step 4: Run, verify pass.**
+- [ ] **Step 5: Commit** — `feat(frontend): reactive prosody auto-trigger (intent flag + cast-time safety net)`.
 
-- [ ] TDD: fires exactly once when gate on + watermark incomplete; does NOT fire when off or watermark complete; a re-fire after partial fills only empties (assert `applyDetectedInstruct` fill-only-empty preserved). Commit `feat(frontend): auto-run prosody passes after analysis when enabled`.
-
-### Task 13: global prosody progress pill
+### Task 14: global prosody progress pill
 
 **Files:**
 - Create: `src/store/prosody-slice.ts` (`activeStream: { bookId, progress, label } | null`), registered in `src/store/index.ts` reducer map only. **The slice is TRANSIENT** — UI-only progress state, like `notifications`: add ONLY the reducer to the map; do NOT add it to `persistence-middleware` or `broadcast-middleware` (no persistence/cross-tab sync). Confirm by grepping `src/store/index.ts` for how `notifications` is wired and match that (reducer-only).
@@ -425,16 +474,17 @@ useEffect(() => {
 
 - [ ] TDD: slice set/clear; pill renders label + percent while active, absent when null. Commit `feat(frontend): global prosody-detection progress pill`.
 
-### Task 14: PR3 e2e + verify + open
+### Task 15: PR3 e2e + verify + open
 
-- [ ] e2e `e2e/analysis-prosody-toggle.spec.ts`: toggle on → analysis completes → user reaches cast while the prosody pill runs → annotations land (assert a sentence gains an `instruct`).
-- [ ] `npm run verify` (full battery incl. e2e). Rebase on `origin/main` + reconcile with the concurrent 1.7B branch. Push `feat/analysis-phase3-prosody`. PR title `feat: auto-generate per-line prosody annotations after analysis (Phase 3)`, body links the spec §Deliverable-1 + the coordination note + `Closes #<Phase3 issue>`.
+- [ ] e2e `e2e/analysis-prosody-toggle.spec.ts`: a 1.7B-default book (or the toggle on) → analysis completes → user reaches cast while the prosody pill runs → annotations land (assert a sentence gains an `instruct`).
+- [ ] `npm run verify` (full battery incl. e2e). Rebase on latest `origin/main`. Push `feat/analysis-phase3-prosody`. PR title `feat: auto-generate per-line prosody annotations after analysis (Phase 3)`, body links the spec §Deliverable-1 + the gate-model section + `Closes #1129`.
 
 ---
 
 ## Self-review notes
 
-- **Spec coverage:** §2A → PR1 Tasks 1–2 + PR3 Task 9 (detect handlers). §2B shared chunker → PR2 Task 4; script-review consumption → Task 5. §Deliverable-1: toggle → Task 11; separate post-analysis trigger → Task 12; watermark → Task 7; chunker reuse by annotation passes → Task 8; global-pill surfacing → Task 13; reusable pass → Task 10. Coordination note → PR3 gate.
+- **Spec coverage:** §2A → PR1 Tasks 1–2 + PR3 Task 9 (detect handlers). §2B shared chunker → PR2 Task 4; script-review consumption → Task 5. §Deliverable-1 (gate model): flag rename → Task 11; analysis-form toggle (smart default) → Task 12; reactive auto-trigger + cast-time safety net → Task 13; watermark → Task 7; chunker reuse by annotation passes → Task 8; global-pill surfacing → Task 14; reusable pass → Task 10.
 - **Owned-core rule** (the round-2 fix) is centralized in Task 4 and consumed by Tasks 5 + 8 — no `opKey` cross-chunk dedupe anywhere.
-- **No 4th in-pipeline phase / no `PHASE_WEIGHTS` edits** (round-2 blast-radius avoided): Phase 3 surfaces via its own `prosody-slice` pill (Task 13), not `ANALYSIS_PHASES`.
-- **liveInstruct is the single shared flag** (Tasks 11–12) — no competing book-quality flag; the concurrent synth-time override reads `liveInstruct || bookQualityOverride`.
+- **No 4th in-pipeline phase / no `PHASE_WEIGHTS` edits** (round-2 blast-radius avoided): Phase 3 surfaces via its own `prosody-slice` pill (Task 14), not `ANALYSIS_PHASES`.
+- **`prosodyEnabled` is the single intent flag** (Tasks 11–13), nullable (undefined = auto-by-cast). The synth-time gate is `is17b` alone (fs-66) — there is NO competing book-quality flag and NO `bookQualityOverride`; the cast-time signal is `ttsModelKey === 'qwen3-tts-1.7b'`.
+- **Two distinct booleans, don't conflate:** `prosodyEnabled` (Task 11 — "should we annotate", nullable intent) vs `prosodyAnnotated` (Task 7 — "annotation finished", watermark).

--- a/docs/superpowers/plans/2026-06-25-phase3-prosody-and-scriptreview-chunking.md
+++ b/docs/superpowers/plans/2026-06-25-phase3-prosody-and-scriptreview-chunking.md
@@ -4,7 +4,7 @@
 
 **Goal:** Stop script review from silently failing on normal-sized chapters, make it work on huge (Cyrillic) chapters via a sentence-chunker, and auto-generate per-line prosody annotations as a gated post-analysis pass.
 
-**Architecture:** Three independent PRs. PR1 surfaces a dropped SSE event (client only). PR2 adds a server sentence-chunker (owned-core ownership rule) consumed by script-review. PR3 (gate redesigned post-fs-66, eager-default per the 2026-06-25 decision) auto-triggers the existing annotation routes (through PR2's chunker) at the post-analysis `confirm` stage whenever the per-book `prosodyEnabled` flag is not `false` (absent ⇒ on), via a per-book + retry-safe effect, deduped by a completion watermark. No cast read.
+**Architecture:** Three independent PRs. PR1 surfaces a dropped SSE event (client only). PR2 adds a server sentence-chunker (owned-core ownership rule) consumed by script-review. PR3 (gate redesigned post-fs-66, eager-default per the 2026-06-25 decision) auto-triggers the existing annotation routes (through PR2's chunker) when a book **transitions to analysis-complete in `library.books`** (active OR background — round-2 Critical), whenever the per-book `prosodyEnabled` flag (read authoritatively from disk) is not `false` (absent ⇒ on), via a seeded, detached, retry-safe effect deduped by a completion watermark. No cast read.
 
 **Tech Stack:** Vite + React 18 + Redux Toolkit (frontend, Vitest + jsdom); Node/Express + TypeScript (server, Vitest + node env); Playwright (e2e). SSE for streamed analyzer passes.
 
@@ -19,7 +19,7 @@
 - **Commit convention:** `<type>(<scope>): <subject>`. End every commit body with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
 - **One branch = one PR.** PR1 `fix/frontend-scriptreview-chapter-failed`; PR2 `feat/server-analyzer-chapter-chunker`; PR3 `feat/analysis-phase3-prosody`. Cut each off the latest `origin/main`.
 - **Verify gates:** frontend `npm test`; server `cd server && npm run test`; full `npm run verify` before each PR push.
-- **PR3 gate (post-fs-66, eager-default):** fs-66 ("1.7B implies prosody") has merged — synth gate is `is17b` alone. **Ground truth:** 1.7B is never an account/book default (the picker offers only Qwen 0.6b); it's chosen late (cast bulk-pin or regen override), so there is NO analysis-time 1.7B signal. Decision (2026-06-25): **annotate eagerly by default** — the gate is `prosodyEnabled !== false` (absent ⇒ on), fired at the `confirm` stage. PR3 renames the orphaned `liveInstruct` flag to `prosodyEnabled` (Task 11) and MUST NOT introduce any competing book-quality flag. Cut off latest `origin/main`.
+- **PR3 gate (post-fs-66, eager-default):** fs-66 ("1.7B implies prosody") has merged — synth gate is `is17b` alone. **Ground truth:** 1.7B is never an account/book default (the picker offers only Qwen 0.6b); it's chosen late (cast bulk-pin or regen override), so there is NO analysis-time 1.7B signal. Decision (2026-06-25): **annotate eagerly by default** — the gate is `prosodyEnabled !== false` (absent ⇒ on), fired when a book transitions to analysis-complete in `library.books` (round-2 re-key: active + background books, not the active `stageKind`). PR3 renames the orphaned `liveInstruct` flag to `prosodyEnabled` (Task 11) and MUST NOT introduce any competing book-quality flag. Cut off latest `origin/main`.
 
 ---
 
@@ -302,10 +302,11 @@ git commit -m "feat(server): script review chunks large chapters via owned-core 
 > the book bulk-pin `POST /cast/tier`). Tasks 7–10 + 14 are unchanged. The gate
 > tasks are redesigned below: **Task 11 (new)** renames `liveInstruct` →
 > `prosodyEnabled` (absent ⇒ on); **Task 12** is the analysis-form toggle
-> (checked by default); **Task 13** is the eager, `confirm`-only, per-book +
-> retry-safe auto-trigger (no cast read); **Task 13b** adds the opt-out
-> render-time hint. See the spec's "Gate model" section (read it — the
-> eager-default decision + round-1 review fixes are folded there).
+> (checked by default); **Task 13** is the eager auto-trigger keyed on
+> `library.books` status transitions (active + background books), seeded,
+> detached, retry-safe, authoritative-disk gate (no cast read); **Task 13b**
+> adds the opt-out render-time hint. See the spec's "Gate model" section (read
+> it — the eager-default decision + round-1 AND round-2 review fixes are folded there).
 
 **PREREQUISITE — satisfied.** Task 8 imports `server/src/analyzer/chapter-chunker.ts`, which landed with PR2 (#1128, merged). **Cut `feat/analysis-phase3-prosody` off the latest `origin/main`** (which now contains both PR2 and fs-66).
 
@@ -314,16 +315,17 @@ git commit -m "feat(server): script review chunks large chapters via owned-core 
 ### Task 7: book-state `prosodyAnnotated` watermark
 
 **Files:**
-- Modify: `server/src/workspace/scan.ts` (`BookStateJson`, near the existing `liveInstruct?` / `prosodyEnabled?` boolean field at lines 230–236); `server/src/routes/book-state.ts` (the `case 'state':` patch handler, lines 605–765).
+- Modify: `server/src/workspace/scan.ts` (server `BookStateJson`, near the existing `liveInstruct?` / `prosodyEnabled?` boolean field at lines 230–236); `server/src/routes/book-state.ts` (the `case 'state':` patch handler, lines 605–765).
+- Modify: **`src/lib/types.ts`** — the **hand-maintained frontend `BookStateJson`** (~line 285; this is NOT generated from `api-types.ts`). Add `prosodyAnnotated?: boolean` so `st?.state.prosodyAnnotated` typechecks in Task 13's trigger (`BookStateResponse.state: BookStateJson`, `types.ts:375`). **Omitting this is a frontend TS error that fails `npm run typecheck`** (round-2 D-7c).
 - Test: `server/src/routes/book-state.test.ts` (extend).
 
 **Interfaces:**
-- Produces: `BookStateJson.prosodyAnnotated?: boolean` — true once both prosody passes complete for the book; the auto-trigger fires only when absent/false. **Distinct from the `prosodyEnabled` intent flag (Task 11): `prosodyEnabled` = "should we annotate", `prosodyAnnotated` = "annotation finished".**
+- Produces: `BookStateJson.prosodyAnnotated?: boolean` (BOTH the server `scan.ts` type and the frontend `src/lib/types.ts` type) — true once both prosody passes complete for the book; the trigger fires only when absent/false. **Distinct from the `prosodyEnabled` intent flag (Task 11): `prosodyEnabled` = "should we annotate", `prosodyAnnotated` = "annotation finished".**
 
 - [ ] **Step 1: Write the failing test** — `PUT /api/books/:bookId/state {patch:{prosodyAnnotated:true}}` persists the field; an absent/non-boolean patch leaves it unchanged.
 - [ ] **Step 2: Run, verify fail** — `cd server && npm run test -- book-state` → FAIL.
-- [ ] **Step 3: Implement** — add the optional field (JSDoc, additive — do NOT bump `CURRENT_STATE_SCHEMA`, mirror the existing single-boolean field's note) + a boolean picker in the `case 'state':` spread (mirror the existing single-boolean ternary in that handler).
-- [ ] **Step 4: Run, verify pass.**
+- [ ] **Step 3: Implement** — add the optional field to **both** `BookStateJson` types (server `scan.ts` + frontend `src/lib/types.ts`; JSDoc, additive — do NOT bump `CURRENT_STATE_SCHEMA`, mirror the existing single-boolean field's note) + a boolean picker in the `case 'state':` spread (mirror the existing single-boolean ternary in that handler).
+- [ ] **Step 4: Run, verify pass** — server `book-state` test + `npm run typecheck` (catches the frontend-type omission).
 - [ ] **Step 5: Commit** — `feat(server): prosodyAnnotated watermark on book state`.
 
 ### Task 8: annotation routes consume the chunker
@@ -375,9 +377,9 @@ annotatedChapters += 1; // once per chapter, after the chunk loop — keep the e
 - Test: `src/store/prosody-thunk.test.ts`.
 
 **Interfaces:**
-- Produces: `runProsodyPasses(bookId, { dispatch, signal, onProgress? }): Promise<{ totalAnnotations: number; totalChapters: number; failed: number }>` — runs `api.detectEmotions` then `api.detectInstruct`, dispatching `applyDetectedEmotions`/`applyDetectedInstruct`, summing failures via `onChapterFailed`.
+- Produces: `runProsodyPasses(bookId, { dispatch, signal?, onProgress? }): Promise<{ totalAnnotations: number; totalChapters: number; failed: number }>` — runs `api.detectEmotions` then `api.detectInstruct`, dispatching `applyDetectedEmotions`/`applyDetectedInstruct`, summing failures via `onChapterFailed`. **`signal` is OPTIONAL** (round-2 D-1a): Task 13's detached background job passes none. The returned `failed` count is load-bearing — Task 13 only writes the watermark when `failed === 0`.
 
-- [ ] TDD: test that it calls both api passes in order and dispatches both apply actions; mock `api`. Commit `refactor(frontend): extract runProsodyPasses from DetectEmotionsButton`.
+- [ ] TDD: test that it calls both api passes in order and dispatches both apply actions; that a `chapter-failed` event increments `failed`; that it resolves (does NOT throw) on partial failure. Mock `api`. Commit `refactor(frontend): extract runProsodyPasses from DetectEmotionsButton`.
 
 ### Task 11: rename `liveInstruct` → `prosodyEnabled` (eager-default Phase-3 intent flag)
 
@@ -388,6 +390,7 @@ The fs-66-orphaned `liveInstruct` flag is renamed and repurposed as the Phase-3 
 - Modify: `server/src/routes/book-state.ts` — the `case 'state':` picker that reads `liveInstruct` (lines 706–708) → `prosodyEnabled` (keep the same boolean-typeof guard).
 - Modify: `src/store/book-meta-slice.ts` — rename `liveInstruct` field (55, 61), the `setLiveInstruct`-payload type (72), hydration (94), `setLiveInstruct` (119–120), `selectLiveInstruct` (167–170) to `prosodyEnabled`/`setProsodyEnabled`/`selectProsodyEnabled`. **Preserve undefined:** hydration `s.prosodyEnabled[bookId] = state.prosodyEnabled` (drop `?? false`); the selector returns `s.bookMeta.prosodyEnabled[bookId]` with **NO `?? false`** (the gate distinguishes `false` from absent). Rewrite the stale JSDoc at 114–118 (it claims a non-existent "persistence-middleware watches this action" — there is no such middleware; the durable PUT is issued by the Task-12 toggle).
 - Modify: `src/components/layout.tsx:790` — hydration `liveInstruct: res.state.liveInstruct ?? false` → `prosodyEnabled: res.state.prosodyEnabled` (preserve undefined).
+- Modify: **`src/lib/types.ts`** — the hand-maintained frontend `BookStateJson` has its own `liveInstruct?: boolean` (~line 371, distinct from `api-types.ts`); rename it → `prosodyEnabled?: boolean` + update the adjacent comment (~line 429 names the `instructHash` render path — leave THAT one). Omitting this is a frontend TS error (round-2 D-7c sibling).
 - Modify: `openapi.yaml` — rename the book-state `liveInstruct` property (line 3361) → `prosodyEnabled` + rewrite its description (absent ⇒ on). **Do NOT touch line 4910** (the Sentence `instruct` "Qwen 1.7B liveInstruct path" comment names the synth path, not this flag). Then regenerate: `npm run openapi:types` (updates `src/lib/api-types.ts`).
 - Modify tests: `src/store/book-meta-slice.test.ts`, `server/src/routes/book-state.test.ts` (the liveInstruct cases ~2128–2168), and any `setLiveInstruct`/`selectLiveInstruct` references.
 
@@ -413,6 +416,7 @@ The fs-66-orphaned `liveInstruct` flag is renamed and repurposed as the Phase-3 
 
 Behaviour:
 - **Checked state** = `stored !== false`, where `stored = useAppSelector(selectProsodyEnabled(bookId))`. So it is **checked by default** (eager) — unset (`undefined`) and `true` both render checked; only an explicit `false` renders unchecked.
+- **Null `bookId` guard** (round-2 D-2b): `bookId` can be `null` on the analysing surface (`analysing.tsx:660`). `selectProsodyEnabled(null)` returns `undefined` (safe to read), but `setProsodyEnabled` needs a non-null `bookId` — **hide/disable the toggle when `bookId == null`**.
 - **On change:** `dispatch(bookMetaActions.setProsodyEnabled({ bookId, value }))` AND `void api.putBookState(bookId, { slice: 'state', patch: { prosodyEnabled: value } })` for durability. Unchecking stores `false`; re-checking stores `true`. **Do NOT gate the analysis POST on it** — Phase 3 runs after analysis via the client-side Task-13 trigger; the server never reads this during analysis.
 - Label "Expressive directions"; helper text "Generate per-line emotion + delivery directions for the higher-quality (1.7B) voice. Runs in the background after analysis."
 
@@ -422,49 +426,62 @@ Behaviour:
 - [ ] **Step 4: Run, verify pass.**
 - [ ] **Step 5: Commit** — `feat(frontend): expressive-directions toggle on the analysis form (on by default)`.
 
-### Task 13: eager auto-trigger (`confirm`-only, per-book, retry-safe) + watermark
+### Task 13: eager auto-trigger keyed on library status (background-safe, retry-safe, authoritative)
+
+**Round-2 Critical:** a `stageKind === 'confirm'` trigger is a single-active-book signal (`ui.stage` is singular) and would never observe a book analysed in the **background** — violating the concurrent-multi-book invariant. So the trigger keys off **`library.books` status transitions** instead (the substrate the plan-83 fan-out at `layout.tsx:940-976` already uses), seeded on first mount to skip pre-existing books, and reads the gate authoritatively from disk.
 
 **Files:**
-- Modify: `src/components/layout.tsx` — add a `useEffect` modeled on the voice-match auto-trigger (`layout.tsx:895-917`), but with a **per-book** fired-guard (a `Set<string>` in a ref, NOT a single slot) and the run launched as a **tracked background job that survives a `bookId` change** (concurrent multi-book is a first-class invariant — a background book's pass must not be aborted when the user switches the active book).
+- Modify: `src/components/layout.tsx` — add a NEW `useEffect` near the plan-83 background fan-out (`:940-976`). It is **NOT** modeled on the cleanup-tied voice-match effect (`:895-917`) — its launched jobs are deliberately **detached** (must survive a book-switch). Reads `library.books` (the same `library` already in scope for `bgBookIds`).
 - Test: `src/store/prosody-autotrigger.test.tsx`.
 
 **Interfaces:**
-- Consumes: `runProsodyPasses` (Task 10); `selectProsodyEnabled` (Task 11); `api.getBookState`/`api.putBookState`. **No cast read** (eager-default does not depend on the cast).
+- Consumes: `runProsodyPasses` (Task 10); `api.getBookState`/`api.putBookState`; `library.books[].status`/`.bookId`. **No cast read, no `selectProsodyEnabled` read** — the gate (`prosodyEnabled`) and the watermark (`prosodyAnnotated`) are both read from the launch's authoritative `getBookState`, which kills the opt-out hydration race (round-2 #2).
 
 ```tsx
-const prosodyEnabled = useAppSelector(selectProsodyEnabled(bookId));   // boolean | undefined
-const shouldAnnotate = prosodyEnabled !== false;                       // eager default: absent/true ⇒ on
+// A book is "analysis-complete" once it has sentences — cast_pending and later.
+const isAnalysisComplete = (s: string) =>
+  s !== 'not_analysed' && s !== 'analysing' && s !== 'unreadable' && s !== 'orphaned';
 
-const prosodyFiredFor = useRef<Set<string>>(new Set());
+const prosodyConsidered = useRef<Set<string>>(new Set());
+const prosodySeeded = useRef(false);
+const completeIds = library.books.filter((b) => isAnalysisComplete(b.status)).map((b) => b.bookId);
+const completeKey = completeIds.join('|');                         // stable dep digest
 useEffect(() => {
-  if (stageKind !== 'confirm') return;             // fresh-analysis transition only — NOT 'ready' (no retro-annotation)
-  if (!bookId || !shouldAnnotate) return;
-  if (prosodyFiredFor.current.has(bookId)) return; // per-book guard
-  prosodyFiredFor.current.add(bookId);
-  // Tracked background job: deliberately NOT tied to this effect's cleanup, so
-  // switching the active book does not abort an in-flight pass (round-1 H2).
-  (async () => {
-    try {
-      const st = await api.getBookState(bookId);
-      if (st?.state.prosodyAnnotated) return;       // watermark complete → no-op
-      await runProsodyPasses(bookId, { dispatch });
-      void api.putBookState(bookId, { slice: 'state', patch: { prosodyAnnotated: true } });
-    } catch {
-      prosodyFiredFor.current.delete(bookId);        // retry-safe (round-1 H3): a failed pass can re-fire this session
-    }
-  })();
-}, [stageKind, bookId, shouldAnnotate]);
+  if (!prosodySeeded.current) {                                    // first run: existing library = pre-existing
+    completeIds.forEach((id) => prosodyConsidered.current.add(id));
+    prosodySeeded.current = true;
+    return;
+  }
+  for (const id of completeIds) {
+    if (prosodyConsidered.current.has(id)) continue;               // already handled this session
+    prosodyConsidered.current.add(id);
+    void (async () => {                                            // detached: survives a book-switch (H2)
+      try {
+        const st = await api.getBookState(id);
+        if (!st || st.state.prosodyEnabled === false) return;      // authoritative opt-out (round-2 #2)
+        if (st.state.prosodyAnnotated) return;                     // watermark → no-op
+        const { failed } = await runProsodyPasses(id, { dispatch });
+        if (failed === 0) api.putBookState(id, { slice: 'state', patch: { prosodyAnnotated: true } });
+        else prosodyConsidered.current.delete(id);                 // partial → allow fill-only re-run (round-2 #6)
+      } catch {
+        prosodyConsidered.current.delete(id);                      // transient error → retry (round-1 H3)
+      }
+    })();
+  }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+}, [completeKey]);
 ```
-- **`confirm`-only** (not `ready`): fires on the post-analysis transition, so a fresh analysis annotates but pre-existing library books (opened straight to `ready`) are not retro-annotated — no backlog-wide auto-spend, no `getBookState` on the Listen path.
-- **Per-book guard + book-switch-safe** (round-1 H2): the `Set<string>` ref tracks every book that has fired; the IIFE is intentionally detached from the effect's render lifecycle (no `AbortController` keyed on `bookId`) so a background book's pass completes even after the user navigates to another book.
-- **Retry-safe** (round-1 H3): the `try/catch` clears the per-book guard on failure, so a transient analyzer/quota error does not permanently silence Phase 3 for the session.
-- `prosodyAnnotated` is NOT hydrated into any slice, so it is fetched inline via `api.getBookState` (`BookStateResponse | null`; read `st?.state.prosodyAnnotated`) — once, at `confirm`.
+- **Library-status keyed, not active stage** (round-2 Critical): fires for the active book AND background books the instant their status reaches analysis-complete. No dependence on `stageKind`/`bookId`.
+- **Seed-on-mount** skips the pre-existing library (no backlog auto-spend) and makes a `Layout` remount self-healing — a re-seed re-marks any in-flight book as considered, so it can't double-fire (round-2 #5).
+- **Authoritative disk gate** (round-2 #2): both `prosodyEnabled` and `prosodyAnnotated` come from the single `getBookState`, never the store selector — so the opt-out can't be lost to a hydration race.
+- **Partial-aware watermark** (round-2 #6): writes `prosodyAnnotated:true` only when `failed === 0`; a partial run is left un-watermarked and removed from `considered` so the fill-only-empty re-run tops it up.
+- **Detached + retry-safe** (round-1 H2/H3): the job is not tied to the effect's cleanup (survives book-switch); `try/catch` removes the book from `considered` on throw.
 
-- [ ] **Step 1: Write the failing test** — `undefined` + `confirm` → fires `runProsodyPasses` once (eager); `true` + `confirm` → fires; `false` + `confirm` → never fires; `stageKind='ready'` (no `confirm`) → never fires; `getBookState` returns `{prosodyAnnotated:true}` → no `runProsodyPasses`; **two distinct bookIds each reach `confirm` → each fires once and the first's run is NOT aborted when bookId changes** (assert both completed); **a rejected `runProsodyPasses` clears the guard so a second `confirm` for the same book re-fires**; on success `putBookState` writes `prosodyAnnotated:true`.
+- [ ] **Step 1: Write the failing test** (drive the effect via a `library.books` rerender): a book that **appears as `cast_pending` after the seeded first render** fires `runProsodyPasses` once; a book already complete **on the first render** is seeded and never fires (no retro-annotation); a **background** book transitioning fires even though no active stage references it (the Critical regression); `getBookState` → `{prosodyEnabled:false}` → no `runProsodyPasses` (authoritative opt-out, even with the store selector `undefined`); `{prosodyAnnotated:true}` → no-op; **two books transitioning → each fires once, neither aborted**; a resolved `{failed:1}` → no `putBookState` and the book is re-eligible on a later transition; `{failed:0}` → `putBookState` writes the watermark; a **rejected** pass removes the book from `considered`.
 - [ ] **Step 2: Run, verify fail.**
 - [ ] **Step 3: Implement** per the shape above.
 - [ ] **Step 4: Run, verify pass.**
-- [ ] **Step 5: Commit** — `feat(frontend): eager confirm-stage prosody auto-trigger (per-book, retry-safe)`.
+- [ ] **Step 5: Commit** — `feat(frontend): eager prosody auto-trigger keyed on library status (background-safe)`.
 
 ### Task 13b: opt-out render-time hint (round-1 M5)
 
@@ -495,9 +512,10 @@ When a book with `prosodyEnabled === false` is rendered at 1.7B it gets only the
 
 ## Self-review notes
 
-- **Spec coverage:** §2A → PR1 Tasks 1–2 + PR3 Task 9 (detect handlers). §2B shared chunker → PR2 Task 4; script-review consumption → Task 5. §Deliverable-1 (gate model): flag rename → Task 11; analysis-form toggle (checked by default) → Task 12; eager `confirm`-only per-book/retry-safe auto-trigger → Task 13; opt-out render hint (M5) → Task 13b; watermark → Task 7; chunker reuse by annotation passes → Task 8; global-pill surfacing → Task 14; reusable pass → Task 10.
+- **Spec coverage:** §2A → PR1 Tasks 1–2 + PR3 Task 9 (detect handlers). §2B shared chunker → PR2 Task 4; script-review consumption → Task 5. §Deliverable-1 (gate model): flag rename → Task 11; analysis-form toggle (checked by default) → Task 12; eager library-status auto-trigger (background-safe, authoritative, retry-safe) → Task 13; opt-out render hint (M5) → Task 13b; watermark → Task 7; chunker reuse by annotation passes → Task 8; global-pill surfacing → Task 14; reusable pass → Task 10.
 - **Owned-core rule** (the round-2 fix) is centralized in Task 4 and consumed by Tasks 5 + 8 — no `opKey` cross-chunk dedupe anywhere.
 - **No 4th in-pipeline phase / no `PHASE_WEIGHTS` edits** (round-2 blast-radius avoided): Phase 3 surfaces via its own `prosody-slice` pill (Task 14), not `ANALYSIS_PHASES`.
 - **`prosodyEnabled` is the single intent flag** (Tasks 11–13), eager (`!== false` ⇒ on). The synth-time gate is `is17b` alone (fs-66) — there is NO competing book-quality flag and NO cast read in the gate.
-- **Round-1 review folded:** C1/M6 dissolved by eager-default (no cast-derived eligibility); H2 (per-book guard, book-switch-safe) + H3 (retry-safe) in Task 13; H4 resolved by `confirm`-only firing; M5 hint in Task 13b. Round-2 review TBD.
+- **Round-1 review folded:** C1/M6 dissolved by eager-default (no cast-derived eligibility); H2 (detached job, book-switch-safe) + H3 (retry-safe) in Task 13; M5 hint in Task 13b.
+- **Round-2 review folded:** Critical (active-stage trigger misses background books) → Task 13 re-keyed to `library.books` status transitions + seed-on-mount; #2 (opt-out hydration race) → authoritative-disk gate in Task 13; #6 (partial-watermark) → `failed===0` guard; #5 (remount double-fire) → seed-on-mount; D-1a (`signal` optional) → Task 10; D-7c (frontend `BookStateJson`) → Tasks 7 + 11 touch `src/lib/types.ts`; D-2b (null bookId) → Task 12.
 - **Two distinct booleans, don't conflate:** `prosodyEnabled` (Task 11 — "should we annotate", eager) vs `prosodyAnnotated` (Task 7 — "annotation finished", watermark).

--- a/docs/superpowers/specs/2026-06-25-phase3-prosody-and-scriptreview-chunking-design.md
+++ b/docs/superpowers/specs/2026-06-25-phase3-prosody-and-scriptreview-chunking-design.md
@@ -146,9 +146,10 @@ resume hole — `cast.json`/`state.json` are written before it (`analysis.ts:408
 even though annotations don't affect casting (`result` is the *only* signal that
 moves `analysing → confirm`, `ui-slice.ts:195`).
 
-So Phase 3 runs as a **separate streamed pass that auto-fires once a freshly
-analysed book reaches the `confirm` stage, unless the user opted out, and prosody
-is not yet complete.** It reuses the **existing** `detectEmotions` +
+So Phase 3 runs as a **separate streamed pass that auto-fires once a book
+transitions to analysis-complete (`cast_pending`), unless the user opted out and
+prosody is not yet complete — for the active book AND books analysed in the
+background.** It reuses the **existing** `detectEmotions` +
 `detectInstruct` routes (factored out of `DetectEmotionsButton.run`), now driven
 through the PR2 chunker so they don't truncate large chapters. The user proceeds
 to cast immediately; prosody annotates in the background.
@@ -171,61 +172,69 @@ field), where **absent ⇒ ON**:
 
 | `prosodyEnabled` | Meaning | Auto-fires after analysis? |
 |---|---|---|
-| `undefined` (default) / `true` | **On** (eager) | Yes — at the `confirm` stage of a fresh analysis |
+| `undefined` (default) / `true` | **On** (eager) | Yes — when the book transitions to analysis-complete this session |
 | `false` (toggled off pre-analysis) | **Explicit opt-out** | No — honored even if the book later goes 1.7B |
 
 **Effective gate:**
 
 ```
-shouldAnnotate = prosodyEnabled !== false
-fire = shouldAnnotate && !prosodyAnnotated && stageKind === 'confirm'
+# decided per-book inside the launch, from the AUTHORITATIVE disk state (not the store):
+launchEligible(state) = state.prosodyEnabled !== false && !state.prosodyAnnotated
 ```
 
-- **`confirm`-only, not `ready`.** Firing only on the post-analysis `confirm`
-  transition means a **fresh** analysis annotates, but **pre-existing** library
-  books (which open straight to `ready`) are NOT retro-annotated on every visit —
-  no surprise backlog-wide quota spend on upgrade, and no `getBookState` fetch on
-  the hot Listen path. Old books top up via the manual "Detect emotions" button.
-- **No cast read.** Eligibility does not depend on the cast, so there is no
-  cast-1.7B signal to derive, no cast-hydration race, and the cast bulk-pin needs
-  no instrumentation. (This deliberately drops the earlier "cast-time safety net":
-  with eager-default every fresh book is already annotated, so the only uncovered
-  case is an explicit opt-out that later goes 1.7B — see Limitations + the
-  render-time hint below.)
+- **Trigger keyed on library status, NOT the active stage (round-2 Critical).**
+  `stageKind === 'confirm'` is structurally a **single-active-book** signal
+  (`ui.stage` is singular; `analysisComplete` is guarded to the active analysing
+  stage), so a book analysed in the **background** while another is active would
+  *never* be observed at `confirm` and would silently never annotate — violating
+  the first-class concurrent-multi-book invariant. Instead, **one effect fans out
+  over `library.books` statuses** (the substrate the plan-83 background poll
+  already uses, `layout.tsx:940-976`) and fires for any book that **transitions**
+  into an analysis-complete status (`cast_pending` and later — sentences exist),
+  active or background alike.
+- **Seed-on-mount to skip pre-existing books.** `Layout` is the persistent app
+  shell (mounts once). On the effect's **first run**, every already-complete book
+  is added to a `considered` ref-`Set` *without firing* — so the existing library
+  is not retro-annotated (no backlog-wide quota spend on upgrade). Only books that
+  reach analysis-complete *later in the session* (a fresh or background analysis)
+  fire. This seed also makes a `Layout` remount self-healing: a re-seed re-marks
+  any in-flight book as considered, so it can't double-fire (round-2 #5).
+- **No cast read.** Eligibility does not depend on the cast — no cast-1.7B signal,
+  no cast-hydration race. (Drops the earlier "cast-time safety net": with
+  eager-default every fresh book is annotated; the only uncovered case is an
+  explicit opt-out that later goes 1.7B — see Limitations + the render-time hint.)
 
 - **Toggle.** An analysis-form toggle (`src/views/analysing.tsx`) labeled
   "Expressive directions" — **checked by default** (eager). Checked state =
   `stored !== false`. Unchecking stores `false` (opt-out); re-checking stores
-  `true`. It writes the **frontend store** (`book-meta-slice`) + a durable
-  `putBookState` PUT; the analysis POST is **not** gated on it (the trigger is
-  client-side, post-analysis).
+  `true`. It writes the **frontend store** (`book-meta-slice`) AND a durable
+  `putBookState` PUT — the **PUT is load-bearing**: the trigger reads the opt-out
+  from disk (below), not the store, so the durable value is the gate. The analysis
+  POST is **not** gated on it.
 
-- **Trigger — one effect, per-book + retry-safe.** A `useEffect` in
-  `src/components/layout.tsx`, modeled on the voice-match auto-trigger
-  (`layout.tsx:895-917`) but hardened per the round-1 review. Dependency set:
-  `[stageKind, bookId, prosodyEnabled]`.
-  - **Per-book guard** (round-1 H2): the fired set is keyed by `bookId`
-    (a `Set<string>`/ref-`Map`), NOT a single slot — concurrent multi-book is a
-    first-class invariant, and a background book's pass must not be torn down when
-    the user switches the active book. The pass is launched as a tracked
-    background job (fire-and-forget, fill-only-empty, idempotent), aborted only on
-    unmount, **not** on a benign `bookId` change.
-  - **Retry-safe** (round-1 H3): the run body is wrapped in `try/finally` and the
-    per-book guard is cleared on failure, so a transient analyzer/quota error does
-    not permanently silence Phase 3 for the session.
-  - **Watermark check** before launch: `api.getBookState(bookId)` →
-    `state.prosodyAnnotated` (fetched once at `confirm`, cheap; not on every mount).
+- **Launch — authoritative, per-book, retry-safe.** For each newly-complete book
+  the effect launches a detached background job:
+  1. `state = await api.getBookState(bookId)` — read **both** `prosodyEnabled` and
+     `prosodyAnnotated` from this one disk fetch. Gating on the fetched
+     `prosodyEnabled !== false` (not the possibly-un-hydrated store selector)
+     **eliminates the opt-out hydration race** (round-2 #2) and honors the opt-out
+     authoritatively. `prosodyAnnotated` truthy ⇒ no-op (watermark).
+  2. `const { failed } = await runProsodyPasses(bookId, { dispatch })`.
+  3. **Watermark only on full success:** `if (failed === 0) putBookState(…
+     prosodyAnnotated:true)`; **else remove the book from `considered`** so the
+     fill-only-empty re-run can top up the failed chapters (round-2 #6 — the
+     passes resolve on *partial* failure, so an unconditional watermark would
+     wrongly mark a partial book complete and block recovery).
+  4. The whole job is wrapped in `try/catch`; on throw, remove from `considered`
+     (retry-safe, round-1 H3). The job is **detached** from the effect's cleanup
+     (NOT cancelled on a `bookId`/active-stage change), so a background book's pass
+     survives the user switching books (round-1 H2).
 
 - **Surfacing.** Phase 3 progress shows in the **global progress pill**
   (`layout.tsx` AnalysisPill region) + a card on the confirm/manuscript view,
   labeled "Phase 3 — Detecting prosody". The analysing view's 3-phase list is
   **unchanged** (no `ANALYSIS_PHASES`/`PHASE_WEIGHTS` edits — Phase 3 has its own
   progress surface, not a 4th in-pipeline phase).
-- **Resume / idempotency.** A completion watermark `prosodyAnnotated`
-  (`state.json`) records completion. The passes are fill-only-empty
-  (`applyDetectedEmotions`/`applyDetectedInstruct`), so an interrupted run is
-  recovered by re-firing — it fills the remaining empties; the watermark stops a
-  completed book from ever re-running.
 - **Non-blocking.** The pass never blocks navigation or casting.
 - **The "Detect emotions" button stays** as the manual re-run / top-up — the
   recovery for an opted-out book that later goes 1.7B, and for pre-existing books.
@@ -269,9 +278,14 @@ unrelated `instructHash`/`renderedInstructHashes` "liveInstruct render" comments
   [Turn on]" wired to re-enable + the manual "Detect emotions" recovery. *(Small
   UX add; if it risks scope it ships as an immediate follow-up, not silently
   dropped.)*
-- **Pre-existing books are not retro-annotated.** The `confirm`-only trigger means
-  library books that predate this feature only gain prosody via the manual button.
-  Deliberate — avoids a backlog-wide auto-spend on upgrade.
+- **Pre-existing books are not retro-annotated.** The seed-on-mount considered-set
+  means books already analysis-complete when the app shell mounts are skipped; they
+  gain prosody only via the manual "Detect emotions" button. Deliberate — avoids a
+  backlog-wide auto-spend on upgrade. **Accepted edge:** a book that completes in
+  the *exact* render the shell first mounts is seeded as pre-existing and skipped
+  (covered by the manual button); and a book whose analysis finished while the app
+  was closed is treated as pre-existing on next launch. Both are the conservative
+  side of the trade (skip, don't double-spend).
 - Multi-book: each book's Phase 3 is a separate background stream sharing the
   per-model analyzer rate-limit bucket (same as today's button). The trigger's
   per-book guard keeps concurrent books' passes independent. No per-manuscript
@@ -290,19 +304,25 @@ unrelated `instructHash`/`renderedInstructHashes` "liveInstruct render" comments
   sentence is emitted exactly once.
 - **2B:** server route test — a chapter over budget yields chunked `ops` with no
   `chapter-failed`; a boundary-straddling `merge` is emitted once.
-- **Phase 3:** frontend test — the **gate truth-table**: `prosodyEnabled`
-  `undefined` at `confirm` → fires (eager default); `true` → fires; `false` →
-  suppressed; `stageKind === 'ready'` (no fresh `confirm`) → does NOT fire (no
-  retro-annotation); watermark-complete (`getBookState` → `prosodyAnnotated:true`)
-  → fires the guard but no `runProsodyPasses`. Trigger robustness: **two books at
-  `confirm` each fire once and a book-switch does NOT abort the first's run**
-  (per-book guard, round-1 H2); **a failed pass clears the guard and a re-entry
-  retries** (round-1 H3). Toggle: **checked by default** (`stored !== false`);
-  unchecking stores `false` + issues the PUT; re-checking stores `true`. The
-  global pill renders progress. Server test — the annotation routes run through
-  the chunker; the watermark is written on completion. One e2e: analysis completes
-  → user reaches the confirm/cast stage while the prosody pill runs → annotations
-  land (a sentence gains an `instruct`).
+- **Phase 3:** frontend test — the **library-status trigger**: a book that
+  **transitions** into `cast_pending` after mount fires `runProsodyPasses` once
+  (eager); a book already complete **at mount** is seeded as considered and does
+  NOT fire (no retro-annotation); a **background** book (not the active stage) that
+  transitions fires (the Critical #1 regression — assert it fires even though
+  `stageKind`/`bookId` reference a *different* active book). Authoritative gate
+  (round-2 #2): with `getBookState` returning `prosodyEnabled:false` → no
+  `runProsodyPasses` even though the store selector is `undefined`; returning
+  `prosodyAnnotated:true` → no-op. Robustness: **two books transitioning each fire
+  once and a book-switch does not abort either** (H2); a **rejected** pass removes
+  the book from `considered` so a later transition retries (H3); a resolved pass
+  with `failed > 0` does NOT write the watermark and removes the book from
+  `considered` (round-2 #6); `failed === 0` writes `prosodyAnnotated:true`. Toggle:
+  **checked by default** (`stored !== false`); unchecking stores `false` + issues
+  the PUT; re-checking stores `true`. The global pill renders progress. Server
+  test — the annotation routes run through the chunker; the watermark is written
+  on completion. One e2e: analysis completes → the prosody pill runs in the
+  background → annotations land (a sentence gains an `instruct`); a second book
+  with the toggle unchecked pre-analysis does NOT run the pass.
 
 ## PR decomposition
 

--- a/docs/superpowers/specs/2026-06-25-phase3-prosody-and-scriptreview-chunking-design.md
+++ b/docs/superpowers/specs/2026-06-25-phase3-prosody-and-scriptreview-chunking-design.md
@@ -13,7 +13,8 @@
 > exist *before* a 1.7B render, otherwise that render gets only the four canned
 > `emotionToInstruct` phrases — but its **trigger/gate is redesigned on the new
 > 1.7B signal** (this revision). The orphaned `liveInstruct` field is **renamed
-> `prosodyEnabled`** and repurposed as a nullable intent flag (see Deliverable 1).
+> `prosodyEnabled`** and repurposed as an eager-default intent flag, absent ⇒ on
+> (see Deliverable 1).
 > Deliverables **2A** (chapter-failed surfacing) and **2B** (script-review
 > chunker) shipped and are unaffected; the chunker (2B) is the reusable asset
 > Phase 3 still consumes.
@@ -145,64 +146,75 @@ resume hole — `cast.json`/`state.json` are written before it (`analysis.ts:408
 even though annotations don't affect casting (`result` is the *only* signal that
 moves `analysing → confirm`, `ui-slice.ts:195`).
 
-So Phase 3 runs as a **separate streamed pass that auto-fires once the book
-reaches the confirm/ready stage when the gate is open and prosody not yet
-complete.** It reuses the **existing** `detectEmotions` + `detectInstruct`
-routes (factored out of `DetectEmotionsButton.run`), now driven through the PR2
-chunker so they don't truncate large chapters. The user proceeds to cast
-immediately; prosody annotates in the background.
+So Phase 3 runs as a **separate streamed pass that auto-fires once a freshly
+analysed book reaches the `confirm` stage, unless the user opted out, and prosody
+is not yet complete.** It reuses the **existing** `detectEmotions` +
+`detectInstruct` routes (factored out of `DetectEmotionsButton.run`), now driven
+through the PR2 chunker so they don't truncate large chapters. The user proceeds
+to cast immediately; prosody annotates in the background.
 
-### Gate model — nullable intent flag + cast-derived auto-rule
+### Gate model — eager-default intent flag (decision 2026-06-25)
 
-The fs-66 world has no analysis-time `liveInstruct` synth gate; the "go 1.7B"
-decision is now a **cast-time** signal (`ttsModelKey === 'qwen3-tts-1.7b'`, set
-per-character or via the book bulk-pin `POST /cast/tier`). So Phase 3 gates on a
-**per-book intent flag `prosodyEnabled`** (the renamed, repurposed `liveInstruct`
-field) that is effectively **tri-state**, combined with the live cast signal:
+**Ground truth (verified against the code).** 1.7B is *never* a persistent
+account/book default: the TTS model picker offers only Qwen **0.6b**, so
+`defaultTtsModelKey` / `resolvedTtsModelKey` are never `qwen3-tts-1.7b` in
+practice. 1.7B is chosen **late** — the cast bulk-pin (`POST /cast/tier`, sets
+per-character `ttsModelKey`) or a per-regenerate override in the regen modal. So
+there is **no analysis-time signal** for "this book will be 1.7B," and an
+auto-rule keyed on a cast-1.7B signal would (a) be unknowable at analysis time and
+(b) read false for the common case. **Decision: annotate eagerly by default** —
+the operator chose to spend the two annotation passes on every analysed book and
+get expressive delivery for free whenever a book later goes 1.7B.
 
-| `prosodyEnabled` | Meaning | Fires the pass when… |
+Phase 3 gates on a **per-book flag `prosodyEnabled`** (the renamed `liveInstruct`
+field), where **absent ⇒ ON**:
+
+| `prosodyEnabled` | Meaning | Auto-fires after analysis? |
 |---|---|---|
-| `undefined` (default, untouched) | **Auto** | the book's cast actually renders at 1.7B |
-| `true` (toggled on) | **Explicit opt-in** | always (after analysis), even before any 1.7B pin |
-| `false` (toggled off) | **Explicit opt-out** | never auto — honored even if the book is later pinned to 1.7B |
+| `undefined` (default) / `true` | **On** (eager) | Yes — at the `confirm` stage of a fresh analysis |
+| `false` (toggled off pre-analysis) | **Explicit opt-out** | No — honored even if the book later goes 1.7B |
 
-**Effective gate** (evaluated once the book reaches confirm/ready, so sentences
-exist):
+**Effective gate:**
 
 ```
-bookCastIs17b = cast.characters.some(c => c.ttsModelKey === 'qwen3-tts-1.7b')   // ANY member (mirrors selectEnginesInUse)
-shouldAnnotate =
-    prosodyEnabled === false ? false
-  : prosodyEnabled === true  ? true
-  : bookCastIs17b              // the "auto" / safety-net case
-fire = shouldAnnotate && !prosodyAnnotated && stageKind ∈ {confirm, ready}
+shouldAnnotate = prosodyEnabled !== false
+fire = shouldAnnotate && !prosodyAnnotated && stageKind === 'confirm'
 ```
 
-This covers all four real users without special cases:
-- **Default-1.7B user** → flag `undefined`, fresh cast inherits `defaultTtsModelKey`
-  = 1.7B → fires right after analysis. *This is "default ON when 1.7B loaded,"
-  achieved even if the toggle is never touched.*
-- **Default-Kokoro user who pins 1.7B late** → flag `undefined` → the bulk-pin
-  flips `bookCastIs17b` → **safety net** fires.
-- **1.7B user who doesn't want it on this book** → toggles OFF → `false` → suppressed.
-- **Kokoro user prepping a planned 1.7B switch** → toggles ON → `true` → annotates eagerly.
+- **`confirm`-only, not `ready`.** Firing only on the post-analysis `confirm`
+  transition means a **fresh** analysis annotates, but **pre-existing** library
+  books (which open straight to `ready`) are NOT retro-annotated on every visit —
+  no surprise backlog-wide quota spend on upgrade, and no `getBookState` fetch on
+  the hot Listen path. Old books top up via the manual "Detect emotions" button.
+- **No cast read.** Eligibility does not depend on the cast, so there is no
+  cast-1.7B signal to derive, no cast-hydration race, and the cast bulk-pin needs
+  no instrumentation. (This deliberately drops the earlier "cast-time safety net":
+  with eager-default every fresh book is already annotated, so the only uncovered
+  case is an explicit opt-out that later goes 1.7B — see Limitations + the
+  render-time hint below.)
 
 - **Toggle.** An analysis-form toggle (`src/views/analysing.tsx`) labeled
-  "Expressive directions (Qwen 1.7B)". Its **checked-default** =
-  `account.defaultTtsModelKey === 'qwen3-tts-1.7b'`. Untouched → store nothing
-  (`undefined` = auto); touched → store the explicit boolean. It reads/writes the
-  **frontend store** (`book-meta-slice`) + a durable `putBookState` PUT; **no
-  server-side analysis-time read** is needed (the trigger is client-side, post-analysis).
+  "Expressive directions" — **checked by default** (eager). Checked state =
+  `stored !== false`. Unchecking stores `false` (opt-out); re-checking stores
+  `true`. It writes the **frontend store** (`book-meta-slice`) + a durable
+  `putBookState` PUT; the analysis POST is **not** gated on it (the trigger is
+  client-side, post-analysis).
 
-- **Trigger — one reactive effect (the two paths are one implementation).** A
-  single `useEffect` in `src/components/layout.tsx` mirrors the existing
-  voice-match auto-trigger (`layout.tsx:895-917` — `useRef` fired-guard +
-  `cancelled` cleanup + a fresh `AbortController`). Dependency set:
-  `[stageKind, bookId, prosodyEnabled, bookCastIs17b]`. It re-evaluates the gate
-  on any change and fires once. The **cast-time safety net is not a separate code
-  path**: the bulk-pin writes `ttsModelKey` into the cast slice → the
-  `bookCastIs17b` dependency flips → the effect re-fires. Reactivity *is* the
-  safety net, so no path that lands a 1.7B cast member can be missed.
+- **Trigger — one effect, per-book + retry-safe.** A `useEffect` in
+  `src/components/layout.tsx`, modeled on the voice-match auto-trigger
+  (`layout.tsx:895-917`) but hardened per the round-1 review. Dependency set:
+  `[stageKind, bookId, prosodyEnabled]`.
+  - **Per-book guard** (round-1 H2): the fired set is keyed by `bookId`
+    (a `Set<string>`/ref-`Map`), NOT a single slot — concurrent multi-book is a
+    first-class invariant, and a background book's pass must not be torn down when
+    the user switches the active book. The pass is launched as a tracked
+    background job (fire-and-forget, fill-only-empty, idempotent), aborted only on
+    unmount, **not** on a benign `bookId` change.
+  - **Retry-safe** (round-1 H3): the run body is wrapped in `try/finally` and the
+    per-book guard is cleared on failure, so a transient analyzer/quota error does
+    not permanently silence Phase 3 for the session.
+  - **Watermark check** before launch: `api.getBookState(bookId)` →
+    `state.prosodyAnnotated` (fetched once at `confirm`, cheap; not on every mount).
 
 - **Surfacing.** Phase 3 progress shows in the **global progress pill**
   (`layout.tsx` AnalysisPill region) + a card on the confirm/manuscript view,
@@ -210,21 +222,19 @@ This covers all four real users without special cases:
   **unchanged** (no `ANALYSIS_PHASES`/`PHASE_WEIGHTS` edits — Phase 3 has its own
   progress surface, not a 4th in-pipeline phase).
 - **Resume / idempotency.** A completion watermark `prosodyAnnotated`
-  (`state.json`) records progress. The passes are fill-only-empty
+  (`state.json`) records completion. The passes are fill-only-empty
   (`applyDetectedEmotions`/`applyDetectedInstruct`), so an interrupted run is
-  recovered by re-firing. The trigger fires only when the watermark is incomplete,
-  so it never re-runs needlessly or loops — and it dedupes the two paths (if the
-  toggle path already annotated, a later 1.7B pin sees the watermark complete and
-  no-ops).
-- **Cancellable + non-blocking.** The pass is abortable and never blocks
-  navigation or casting.
-- **The "Detect emotions" button stays** as the manual re-run / top-up — and the
-  explicit recovery for a `prosodyEnabled === false` book that later goes 1.7B.
+  recovered by re-firing — it fills the remaining empties; the watermark stops a
+  completed book from ever re-running.
+- **Non-blocking.** The pass never blocks navigation or casting.
+- **The "Detect emotions" button stays** as the manual re-run / top-up — the
+  recovery for an opted-out book that later goes 1.7B, and for pre-existing books.
 
 ### Flag rename: `liveInstruct` → `prosodyEnabled`
 
 The orphaned `liveInstruct` plumbing (set by no UI, read at no synth site post-fs-66)
-is **renamed `prosodyEnabled`** and repurposed as the nullable intent flag above.
+is **renamed `prosodyEnabled`** and repurposed as the eager-default intent flag
+above (absent ⇒ on; only `false` opts out).
 Sites: `BookStateJson.liveInstruct` (`server/src/workspace/scan.ts`) +
 `book-state.ts` patch picker; `book-meta-slice` (`liveInstruct` record +
 `setLiveInstruct`/`selectLiveInstruct`); the `layout.tsx:790` hydration; `api-types.ts`
@@ -238,20 +248,33 @@ unrelated `instructHash`/`renderedInstructHashes` "liveInstruct render" comments
 - A failed chunk emits `chapter-failed` (now surfaced by 2A) and the pass
   carries on (one bad chunk never kills the chapter or the pass).
 - `DailyQuotaExhaustedError` keeps its `error{code:'quota_exhausted'}` behaviour
-  (already client-handled) — partial progress is preserved and the user re-runs.
-- Phase 3 with `prosodyEnabled === false` (or `undefined` + a non-1.7B cast)
-  simply never fires — a deliberate non-event, not an error. The progress pill is
-  absent.
+  (already client-handled) — partial progress is preserved and the trigger's
+  per-book guard clears on failure so it retries (round-1 H3).
+- Phase 3 with `prosodyEnabled === false` simply never fires — a deliberate
+  non-event, not an error. The progress pill is absent.
 
 ## Known accepted limitations
 
-- `prosodyEnabled` (the trigger intent) is *not* the synth-time gate (which is
-  `is17b` alone post-fs-66, `resolve-instruct.ts`). A user can toggle prosody on,
-  get annotations, then render with Kokoro (which ignores `instruct`), wasting
-  the passes. Accepted: explicit user choice. Conversely the `false` opt-out is
-  honored even against a 1.7B render (canned phrases only) — also explicit.
-- Multi-book: each book's Phase 3 is a separate stream sharing the per-model
-  analyzer rate-limit bucket (same as today's button). No per-manuscript
+- **Eager cost (operator's choice).** With eager-default, every freshly analysed
+  book spends two whole-book annotation passes (analyzer quota), *including*
+  Kokoro-only books that ignore `instruct` at synth. Accepted per the 2026-06-25
+  decision ("expressive by default"). `prosodyEnabled` is NOT the synth-time gate
+  (that is `is17b` alone post-fs-66, `resolve-instruct.ts`); annotations are
+  simply unused on a non-1.7B render.
+- **Silent-flat on opt-out + late 1.7B.** A book toggled OFF that later goes 1.7B
+  renders with only the four canned `emotionToInstruct` phrases. To avoid this
+  being invisible (round-1 M5), surface a one-line hint at the cast/render surface
+  when `prosodyEnabled === false` and the book is being rendered at 1.7B —
+  "Expressive directions are off for this book — using basic emotion phrases.
+  [Turn on]" wired to re-enable + the manual "Detect emotions" recovery. *(Small
+  UX add; if it risks scope it ships as an immediate follow-up, not silently
+  dropped.)*
+- **Pre-existing books are not retro-annotated.** The `confirm`-only trigger means
+  library books that predate this feature only gain prosody via the manual button.
+  Deliberate — avoids a backlog-wide auto-spend on upgrade.
+- Multi-book: each book's Phase 3 is a separate background stream sharing the
+  per-model analyzer rate-limit bucket (same as today's button). The trigger's
+  per-book guard keeps concurrent books' passes independent. No per-manuscript
   prioritisation; throttles queue internally. Acceptable.
 - Boundary-straddling structural op detected only by the non-owning chunk can be
   dropped (see chunker section).
@@ -267,16 +290,19 @@ unrelated `instructHash`/`renderedInstructHashes` "liveInstruct render" comments
   sentence is emitted exactly once.
 - **2B:** server route test — a chapter over budget yields chunked `ops` with no
   `chapter-failed`; a boundary-straddling `merge` is emitted once.
-- **Phase 3:** frontend test — the **gate truth-table** (the four user rows):
-  `prosodyEnabled` `undefined` + 1.7B cast → fires; `undefined` + Kokoro cast →
-  doesn't; `false` + 1.7B cast → suppressed; `true` → fires regardless of cast;
-  watermark-complete → never re-fires; **a late cast-pin flips `bookCastIs17b`
-  and fires once** (the safety net); re-fire fills only empties; the toggle's
-  checked-default = `defaultTtsModelKey === 'qwen3-tts-1.7b'`; untouched stores
-  `undefined`, touched stores the boolean; the global pill renders progress.
-  Server test — the annotation routes run through the chunker; the watermark is
-  written on completion. One e2e: default-1.7B book → analysis completes → user
-  reaches cast while the prosody pill runs → annotations land.
+- **Phase 3:** frontend test — the **gate truth-table**: `prosodyEnabled`
+  `undefined` at `confirm` → fires (eager default); `true` → fires; `false` →
+  suppressed; `stageKind === 'ready'` (no fresh `confirm`) → does NOT fire (no
+  retro-annotation); watermark-complete (`getBookState` → `prosodyAnnotated:true`)
+  → fires the guard but no `runProsodyPasses`. Trigger robustness: **two books at
+  `confirm` each fire once and a book-switch does NOT abort the first's run**
+  (per-book guard, round-1 H2); **a failed pass clears the guard and a re-entry
+  retries** (round-1 H3). Toggle: **checked by default** (`stored !== false`);
+  unchecking stores `false` + issues the PUT; re-checking stores `true`. The
+  global pill renders progress. Server test — the annotation routes run through
+  the chunker; the watermark is written on completion. One e2e: analysis completes
+  → user reaches the confirm/cast stage while the prosody pill runs → annotations
+  land (a sentence gains an `instruct`).
 
 ## PR decomposition
 
@@ -284,12 +310,12 @@ unrelated `instructHash`/`renderedInstructHashes` "liveInstruct render" comments
    reported "useless empty modal" immediately).
 2. `feat/server-analyzer-chapter-chunker` — the shared chunker + 2B (script
    review consumes it).
-3. `feat/analysis-phase3-prosody` — `liveInstruct` → `prosodyEnabled` rename +
-   the nullable-intent gate model, analysis-form toggle (smart default), the
-   single reactive auto-trigger (covers both the analysis-toggle and cast-time
-   safety-net paths) + global-pill surfacing + completion watermark. Cross-cutting
-   (server rename/watermark + frontend trigger/UI), but smaller than the
-   tail-of-stream version (no analysis.ts surgery, no 4th-phase static-array changes).
+3. `feat/analysis-phase3-prosody` — `liveInstruct` → `prosodyEnabled` rename
+   (absent ⇒ on) + the eager-default gate, analysis-form toggle (checked by
+   default), the per-book + retry-safe `confirm`-only auto-trigger + global-pill
+   surfacing + completion watermark. Cross-cutting (server rename/watermark +
+   frontend trigger/UI), but small (no analysis.ts surgery, no cast read, no
+   4th-phase static-array changes).
 
 Sequence 2 before 3 (Phase 3's passes consume the chunker). 1 is independent.
 

--- a/docs/superpowers/specs/2026-06-25-phase3-prosody-and-scriptreview-chunking-design.md
+++ b/docs/superpowers/specs/2026-06-25-phase3-prosody-and-scriptreview-chunking-design.md
@@ -1,18 +1,22 @@
 # Phase 3 prosody annotation + analyzer sentence-chunking (script review large chapters)
 
-**Date:** 2026-06-25 · **Status:** 2A + 2B SHIPPED (PR #1126, #1128); Phase 3 DEFERRED (gate superseded — see below)
+**Date:** 2026-06-25 · **Status:** 2A + 2B SHIPPED (PR #1126, #1128); Phase 3 gate **REDESIGNED** 2026-06-25 (fs-66 landed — see below); ready to plan/build
 
-> **Status update (2026-06-25): Phase 3 is DEFERRED.** A concurrent change
-> (`feat/server-1.7b-implies-prosody`) collapses the synth prosody gate to
-> `is17b` alone and **drops `liveInstruct`** ("1.7B implies prosody"). That
-> removes the flag this Phase 3 design gates on (analysis-form toggle *sets*
-> `liveInstruct`; the post-analysis trigger *reads* it). Phase 3's **intent
-> survives** — the per-line prosody annotations still must be generated before a
-> 1.7B render — but its **trigger/gate must be redesigned on the new 1.7B signal**
-> (per-cast `is17b` / the book-level quality override) once that work + the
-> book-level 1.7B override spec land on `main`. Deliverables **2A** (chapter-failed
-> surfacing) and **2B** (script-review chunker) are unaffected and already shipped.
-> The chunker (2B) is the reusable asset Phase 3 will still consume.
+> **Gate redesign (2026-06-25, fs-65 #1129).** fs-66 ("1.7B implies prosody",
+> PR #1136) collapsed the synth prosody gate to `is17b` alone and **dropped
+> `liveInstruct` as a synth gate** — leaving it as orphaned per-book plumbing
+> (`BookStateJson.liveInstruct`, `book-meta-slice`), persisted but set by no UI
+> (the #1100 toggle was deleted) and read at no synth site. fs-66 also moved the
+> "go 1.7B" decision from analysis-time to **cast-time** (per-character
+> `ttsModelKey === 'qwen3-tts-1.7b'` or the book bulk-pin `POST /cast/tier`).
+> Phase 3's **intent is unchanged** — the per-line prosody annotations still must
+> exist *before* a 1.7B render, otherwise that render gets only the four canned
+> `emotionToInstruct` phrases — but its **trigger/gate is redesigned on the new
+> 1.7B signal** (this revision). The orphaned `liveInstruct` field is **renamed
+> `prosodyEnabled`** and repurposed as a nullable intent flag (see Deliverable 1).
+> Deliverables **2A** (chapter-failed surfacing) and **2B** (script-review
+> chunker) shipped and are unaffected; the chunker (2B) is the reusable asset
+> Phase 3 still consumes.
 
 Origin: a `/superpowers:systematic-debugging` session over two reported symptoms
 ("Phase 3 doesn't show in the analysing view" and "Review Script is always
@@ -142,57 +146,92 @@ even though annotations don't affect casting (`result` is the *only* signal that
 moves `analysing → confirm`, `ui-slice.ts:195`).
 
 So Phase 3 runs as a **separate streamed pass that auto-fires once the book
-reaches the confirm/ready stage with `liveInstruct` on and prosody not yet
+reaches the confirm/ready stage when the gate is open and prosody not yet
 complete.** It reuses the **existing** `detectEmotions` + `detectInstruct`
 routes (factored out of `DetectEmotionsButton.run`), now driven through the PR2
 chunker so they don't truncate large chapters. The user proceeds to cast
 immediately; prosody annotates in the background.
 
-- **Gate / trigger.** A new form toggle "High-quality prosody (Qwen 1.7B)" on the
-  analysis-start surface (`src/views/analysing.tsx`) sets the book's
-  `liveInstruct=true` (default off — extra quota + vocalization mutates text).
-  The post-analysis auto-trigger reads `liveInstruct` from the **frontend store**
-  (`book-meta-slice`, already hydrated) — **no server-side analysis-time read is
-  needed.** Setting the toggle pre-analysis is what makes prosody run
-  automatically right after the first analysis; toggling it on later (or the
-  manual button) covers the rest.
+### Gate model — nullable intent flag + cast-derived auto-rule
+
+The fs-66 world has no analysis-time `liveInstruct` synth gate; the "go 1.7B"
+decision is now a **cast-time** signal (`ttsModelKey === 'qwen3-tts-1.7b'`, set
+per-character or via the book bulk-pin `POST /cast/tier`). So Phase 3 gates on a
+**per-book intent flag `prosodyEnabled`** (the renamed, repurposed `liveInstruct`
+field) that is effectively **tri-state**, combined with the live cast signal:
+
+| `prosodyEnabled` | Meaning | Fires the pass when… |
+|---|---|---|
+| `undefined` (default, untouched) | **Auto** | the book's cast actually renders at 1.7B |
+| `true` (toggled on) | **Explicit opt-in** | always (after analysis), even before any 1.7B pin |
+| `false` (toggled off) | **Explicit opt-out** | never auto — honored even if the book is later pinned to 1.7B |
+
+**Effective gate** (evaluated once the book reaches confirm/ready, so sentences
+exist):
+
+```
+bookCastIs17b = cast.characters.some(c => c.ttsModelKey === 'qwen3-tts-1.7b')   // ANY member (mirrors selectEnginesInUse)
+shouldAnnotate =
+    prosodyEnabled === false ? false
+  : prosodyEnabled === true  ? true
+  : bookCastIs17b              // the "auto" / safety-net case
+fire = shouldAnnotate && !prosodyAnnotated && stageKind ∈ {confirm, ready}
+```
+
+This covers all four real users without special cases:
+- **Default-1.7B user** → flag `undefined`, fresh cast inherits `defaultTtsModelKey`
+  = 1.7B → fires right after analysis. *This is "default ON when 1.7B loaded,"
+  achieved even if the toggle is never touched.*
+- **Default-Kokoro user who pins 1.7B late** → flag `undefined` → the bulk-pin
+  flips `bookCastIs17b` → **safety net** fires.
+- **1.7B user who doesn't want it on this book** → toggles OFF → `false` → suppressed.
+- **Kokoro user prepping a planned 1.7B switch** → toggles ON → `true` → annotates eagerly.
+
+- **Toggle.** An analysis-form toggle (`src/views/analysing.tsx`) labeled
+  "Expressive directions (Qwen 1.7B)". Its **checked-default** =
+  `account.defaultTtsModelKey === 'qwen3-tts-1.7b'`. Untouched → store nothing
+  (`undefined` = auto); touched → store the explicit boolean. It reads/writes the
+  **frontend store** (`book-meta-slice`) + a durable `putBookState` PUT; **no
+  server-side analysis-time read** is needed (the trigger is client-side, post-analysis).
+
+- **Trigger — one reactive effect (the two paths are one implementation).** A
+  single `useEffect` in `src/components/layout.tsx` mirrors the existing
+  voice-match auto-trigger (`layout.tsx:895-917` — `useRef` fired-guard +
+  `cancelled` cleanup + a fresh `AbortController`). Dependency set:
+  `[stageKind, bookId, prosodyEnabled, bookCastIs17b]`. It re-evaluates the gate
+  on any change and fires once. The **cast-time safety net is not a separate code
+  path**: the bulk-pin writes `ttsModelKey` into the cast slice → the
+  `bookCastIs17b` dependency flips → the effect re-fires. Reactivity *is* the
+  safety net, so no path that lands a 1.7B cast member can be missed.
+
 - **Surfacing.** Phase 3 progress shows in the **global progress pill**
-  (`src/components/layout.tsx` AnalysisPill region) + a card on the
-  confirm/manuscript view, labeled "Phase 3 — Detecting prosody". The analysing
-  view's 3-phase list is **unchanged** (no `ANALYSIS_PHASES`/`PHASE_WEIGHTS`
-  edits — the static-const blast radius is avoided entirely by not making it a
-  4th in-pipeline phase).
-- **Resume / idempotency.** A completion watermark on the book (a `state.json`
-  field, e.g. `prosodyAnnotated` per chapter or a single status) records
-  progress. The passes are fill-only-empty (`applyDetectedEmotions`/
-  `applyDetectedInstruct`), so an interrupted run is recovered by re-firing — it
-  fills the remaining empties. The auto-trigger fires only when the watermark is
-  incomplete, so it never re-runs needlessly or loops.
-- **Cancellable + non-blocking.** The pass is abortable (existing
-  AbortController path) and never blocks navigation or casting.
-- **The "Detect emotions" button stays** as the manual re-run / top-up.
+  (`layout.tsx` AnalysisPill region) + a card on the confirm/manuscript view,
+  labeled "Phase 3 — Detecting prosody". The analysing view's 3-phase list is
+  **unchanged** (no `ANALYSIS_PHASES`/`PHASE_WEIGHTS` edits — Phase 3 has its own
+  progress surface, not a 4th in-pipeline phase).
+- **Resume / idempotency.** A completion watermark `prosodyAnnotated`
+  (`state.json`) records progress. The passes are fill-only-empty
+  (`applyDetectedEmotions`/`applyDetectedInstruct`), so an interrupted run is
+  recovered by re-firing. The trigger fires only when the watermark is incomplete,
+  so it never re-runs needlessly or loops — and it dedupes the two paths (if the
+  toggle path already annotated, a later 1.7B pin sees the watermark complete and
+  no-ops).
+- **Cancellable + non-blocking.** The pass is abortable and never blocks
+  navigation or casting.
+- **The "Detect emotions" button stays** as the manual re-run / top-up — and the
+  explicit recovery for a `prosodyEnabled === false` book that later goes 1.7B.
 
-### Coordination with the concurrent "Book-level Higher quality (1.7B)" spec
+### Flag rename: `liveInstruct` → `prosodyEnabled`
 
-A parallel design (`docs/superpowers/specs/2026-06-25-book-level-higher-quality-tier-design.md`)
-adds a **book "Higher quality (1.7B)" override + bulk pin** that, at **synth /
-regenerate time**, forces every Qwen cast member to the 1.7B model and opens the
-`liveInstruct` AND-gate. That control and this Phase 3 are **two stages of one
-feature, not duplicates**, and must use the **same `liveInstruct` flag** — do not
-introduce a competing book-quality flag here:
-
-- **Their toggle is meaningful later** (regenerate/generation): it enforces 1.7B
-  + opens the gate at synth.
-- **This Phase 3 toggle is meaningful at analysis time**: it must stay on the
-  analysis UX so the per-line prosody **annotations are generated *before*
-  generation reaches the 1.7B model** — otherwise opening their gate only yields
-  the four canned `emotionToInstruct` phrases, not real per-line delivery.
-- **Shared signal:** the analysis-form "High-quality prosody (Qwen 1.7B)" toggle
-  sets `liveInstruct`; their override reads `liveInstruct || bookQualityOverride`.
-  One intent, two entry points. The two specs cross-reference each other and the
-  work is coordinated with that session (the user oversees both). If the concurrent
-  feature lands a unified "quality" control first, this toggle becomes an
-  analysis-stage surfacing of the same flag rather than a new switch.
+The orphaned `liveInstruct` plumbing (set by no UI, read at no synth site post-fs-66)
+is **renamed `prosodyEnabled`** and repurposed as the nullable intent flag above.
+Sites: `BookStateJson.liveInstruct` (`server/src/workspace/scan.ts`) +
+`book-state.ts` patch picker; `book-meta-slice` (`liveInstruct` record +
+`setLiveInstruct`/`selectLiveInstruct`); the `layout.tsx:790` hydration; `api-types.ts`
+(regenerated from `openapi.yaml`). The dead synth meaning is gone, so the old name
+is now a trap — a small, mechanical rename for clarity. **Do not** touch the
+unrelated `instructHash`/`renderedInstructHashes` "liveInstruct render" comments in
+`segments-io.ts`/`stale-chapters.ts` — those name the synth path, not this flag.
 
 ## Error handling
 
@@ -200,15 +239,17 @@ introduce a competing book-quality flag here:
   carries on (one bad chunk never kills the chapter or the pass).
 - `DailyQuotaExhaustedError` keeps its `error{code:'quota_exhausted'}` behaviour
   (already client-handled) — partial progress is preserved and the user re-runs.
-- Phase 3 with `liveInstruct` off simply never fires — a deliberate non-event,
-  not an error. The progress pill is absent.
+- Phase 3 with `prosodyEnabled === false` (or `undefined` + a non-1.7B cast)
+  simply never fires — a deliberate non-event, not an error. The progress pill is
+  absent.
 
 ## Known accepted limitations
 
-- `liveInstruct` (the trigger gate) is *not* the synth-time gate
-  (`is17b && liveInstruct`, `resolve-instruct.ts`). A user can toggle prosody on,
+- `prosodyEnabled` (the trigger intent) is *not* the synth-time gate (which is
+  `is17b` alone post-fs-66, `resolve-instruct.ts`). A user can toggle prosody on,
   get annotations, then render with Kokoro (which ignores `instruct`), wasting
-  the passes. Accepted: explicit user choice.
+  the passes. Accepted: explicit user choice. Conversely the `false` opt-out is
+  honored even against a 1.7B render (canned phrases only) — also explicit.
 - Multi-book: each book's Phase 3 is a separate stream sharing the per-model
   analyzer rate-limit bucket (same as today's button). No per-manuscript
   prioritisation; throttles queue internally. Acceptable.
@@ -226,13 +267,16 @@ introduce a competing book-quality flag here:
   sentence is emitted exactly once.
 - **2B:** server route test — a chapter over budget yields chunked `ops` with no
   `chapter-failed`; a boundary-straddling `merge` is emitted once.
-- **Phase 3:** frontend test — the form toggle sets `liveInstruct`; the
-  post-analysis auto-trigger fires once when `liveInstruct` on + watermark
-  incomplete, and does NOT fire when off or when the watermark is complete;
-  re-fire fills only empties; the global pill renders progress. Server test —
-  the annotation routes run through the chunker; the watermark is written on
-  completion. One e2e: toggle on → analysis completes → user reaches cast while
-  the prosody pill runs → annotations land.
+- **Phase 3:** frontend test — the **gate truth-table** (the four user rows):
+  `prosodyEnabled` `undefined` + 1.7B cast → fires; `undefined` + Kokoro cast →
+  doesn't; `false` + 1.7B cast → suppressed; `true` → fires regardless of cast;
+  watermark-complete → never re-fires; **a late cast-pin flips `bookCastIs17b`
+  and fires once** (the safety net); re-fire fills only empties; the toggle's
+  checked-default = `defaultTtsModelKey === 'qwen3-tts-1.7b'`; untouched stores
+  `undefined`, touched stores the boolean; the global pill renders progress.
+  Server test — the annotation routes run through the chunker; the watermark is
+  written on completion. One e2e: default-1.7B book → analysis completes → user
+  reaches cast while the prosody pill runs → annotations land.
 
 ## PR decomposition
 
@@ -240,11 +284,12 @@ introduce a competing book-quality flag here:
    reported "useless empty modal" immediately).
 2. `feat/server-analyzer-chapter-chunker` — the shared chunker + 2B (script
    review consumes it).
-3. `feat/analysis-phase3-prosody` — form toggle + post-analysis auto-trigger of
-   the annotation passes (through the chunker) + global-pill surfacing +
-   completion watermark. Cross-cutting (server watermark + frontend trigger/UI),
-   but smaller than the tail-of-stream version (no analysis.ts surgery, no
-   4th-phase static-array changes).
+3. `feat/analysis-phase3-prosody` — `liveInstruct` → `prosodyEnabled` rename +
+   the nullable-intent gate model, analysis-form toggle (smart default), the
+   single reactive auto-trigger (covers both the analysis-toggle and cast-time
+   safety-net paths) + global-pill surfacing + completion watermark. Cross-cutting
+   (server rename/watermark + frontend trigger/UI), but smaller than the
+   tail-of-stream version (no analysis.ts surgery, no 4th-phase static-array changes).
 
 Sequence 2 before 3 (Phase 3's passes consume the chunker). 1 is independent.
 

--- a/docs/superpowers/specs/2026-06-25-phase3-prosody-and-scriptreview-chunking-design.md
+++ b/docs/superpowers/specs/2026-06-25-phase3-prosody-and-scriptreview-chunking-design.md
@@ -1,6 +1,6 @@
 # Phase 3 prosody annotation + analyzer sentence-chunking (script review large chapters)
 
-**Date:** 2026-06-25 · **Status:** 2A + 2B SHIPPED (PR #1126, #1128); Phase 3 gate **REDESIGNED** 2026-06-25 (fs-66 landed — see below); ready to plan/build
+**Date:** 2026-06-25 · **Status:** 2A + 2B SHIPPED (PR #1126, #1128); **Phase 3 IMPLEMENTED** 2026-06-26 on `feat/analysis-phase3-prosody` (Tasks 7–14 + e2e; built via SDD with round-1 + round-2 adversarial reviews + an Opus whole-branch review; full `npm run verify` green incl. e2e). Closes #1129.
 
 > **Gate redesign (2026-06-25, fs-65 #1129).** fs-66 ("1.7B implies prosody",
 > PR #1136) collapsed the synth prosody gate to `is17b` alone and **dropped

--- a/e2e/analysis-prosody-toggle.spec.ts
+++ b/e2e/analysis-prosody-toggle.spec.ts
@@ -1,0 +1,40 @@
+/* Task 15 (fs-65 Phase 3) — e2e: "Expressive directions" toggle on the
+ * analysis form.
+ *
+ * Asserts the STABLE, non-flaky surface:
+ *   1. The toggle is present and CHECKED by default on the analysing view
+ *      (eager default — prosodyEnabled is undefined → checked).
+ *   2. Unchecking the toggle works (checkbox toggles to unchecked).
+ *
+ * The transient background "Phase 3 — Detecting prosody" pill is timing-
+ * sensitive in mocks and is covered by unit tests (layout-prosody-pill.test.tsx
+ * + prosody-autotrigger.test.tsx); it is intentionally excluded here.
+ *
+ * Uses `bootFreshBookIntoAnalysing` from helpers.ts to reach the analysing
+ * route with the "Start analysis" button visible (before the stream fires),
+ * which gives a deterministic view of the toggle in its resting state. */
+
+import { test, expect } from '@playwright/test';
+import { bootFreshBookIntoAnalysing } from './helpers';
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('analysis-form — Expressive directions toggle (fs-65 Task 15)', () => {
+  test('toggle is present and checked by default on the analysing screen', async ({ page }) => {
+    await bootFreshBookIntoAnalysing(page);
+
+    const toggle = page.getByRole('checkbox', { name: /expressive directions/i });
+    await expect(toggle).toBeVisible({ timeout: 5_000 });
+    await expect(toggle).toBeChecked();
+  });
+
+  test('unchecking the toggle makes it unchecked', async ({ page }) => {
+    await bootFreshBookIntoAnalysing(page);
+
+    const toggle = page.getByRole('checkbox', { name: /expressive directions/i });
+    await expect(toggle).toBeChecked({ timeout: 5_000 });
+
+    await toggle.click();
+    await expect(toggle).not.toBeChecked();
+  });
+});

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3358,15 +3358,15 @@ components:
             same-language narration (a non-`en` book routes every character,
             incl. the narrator, to a designed Qwen voice and never falls back
             to English Kokoro) and the library language badge + filter pill.
-        liveInstruct:
+        prosodyEnabled:
           type: boolean
           description: |
-            fs-57 — per-book live-instruct flag. When `true`, `synthesiseChapter`
-            uses the Qwen 1.7B live-instruct synth path instead of the standard
-            path. Default `false` (absent on books written before fs-57 — readers
-            treat absence as `false`). Toggled by the UI (Task 16) and gated by
-            the synth route (Task 8). Persisted to `BookStateJson.liveInstruct`
-            in `<bookDir>/.audiobook/state.json`.
+            fs-65 Phase 3 — prosody annotation intent flag. Absent (undefined)
+            ⇒ ON (eager default); only an explicit `false` opts out. The
+            client-side Task-13 trigger gate is `prosodyEnabled !== false`.
+            Persisted to `BookStateJson.prosodyEnabled` in
+            `<bookDir>/.audiobook/state.json`. Renamed from `liveInstruct`
+            (fs-57); legacy books without the field are treated as opted-in.
 
     # --- Import + confirm-metadata ---------------------------------
     ImportCandidate:

--- a/server/src/routes/annotate-emotion.test.ts
+++ b/server/src/routes/annotate-emotion.test.ts
@@ -26,8 +26,13 @@ let app: Express;
 let bookId: string;
 let manuscriptId: string;
 
-/* The fake analyzer's runEmotionChapter — each test swaps its implementation. */
-const { runEmotion } = vi.hoisted(() => ({ runEmotion: vi.fn() }));
+/* The fake analyzer's runEmotionChapter — each test swaps its implementation.
+   `engineState` lets a test flip the reported engine to 'local' so the chunker
+   derives a finite, num_ctx-bound budget and a large chapter splits. */
+const { runEmotion, engineState: emotionEngineState } = vi.hoisted(() => ({
+  runEmotion: vi.fn(),
+  engineState: { engine: 'gemini' as 'gemini' | 'local' },
+}));
 
 vi.mock('../analyzer/select-analyzer.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../analyzer/select-analyzer.js')>();
@@ -43,7 +48,7 @@ vi.mock('../analyzer/select-analyzer.js', async (importOriginal) => {
     ...actual,
     selectAnalyzerForPhase: () => ({
       analyzer: fakeAnalyzer,
-      engine: 'gemini' as const,
+      engine: emotionEngineState.engine,
       model: 'test-model',
       fallbackModel: null,
     }),
@@ -115,6 +120,8 @@ beforeAll(async () => {
 
 beforeEach(() => {
   runEmotion.mockReset();
+  emotionEngineState.engine = 'gemini';
+  delete process.env.ANALYZER_NUM_CTX;
   rmSync(join(workspaceRoot, 'books'), { recursive: true, force: true });
 });
 
@@ -239,5 +246,51 @@ describe('POST /api/books/:bookId/annotate-emotion', () => {
     expect(events.some((e) => e.kind === 'chapter-failed' && e.chapterId === 1)).toBe(true);
     expect(events.some((e) => e.kind === 'annotation' && e.chapterId === 2)).toBe(true);
     expect(events.find((e) => e.kind === 'result')).toMatchObject({ annotatedChapters: 1 });
+  });
+
+  it('chunks a large chapter across calls and emits each sentence annotation exactly once', async () => {
+    // Force local engine + small num_ctx → chapterChunkBudget derives a finite budget
+    // that splits a large chapter into ≥2 chunks (gemini's MAX_SAFE_INTEGER never splits).
+    emotionEngineState.engine = 'local';
+    process.env.ANALYZER_NUM_CTX = '400'; // → budget Math.max(2000, min(24000, 560)) = 2000
+
+    // ~800-char sentences: 2 per chunk under the 2000-char budget.
+    const longText = 'C'.repeat(800);
+    const chapterSentences = Array.from({ length: 12 }, (_, i) => ({
+      id: 400 + i,
+      chapterId: 40,
+      characterId: 'narrator',
+      text: longText,
+    }));
+    writeBook(chapterSentences);
+
+    // Each call returns one annotation per sentenceId present in the prompt (core + context),
+    // so without ownership filtering an overlapped sentence would be emitted by >1 chunk.
+    runEmotion.mockImplementation((_m, _c, prompt: string): Promise<EmotionAnnotationOutput> => {
+      const ids = [...prompt.matchAll(/"sentenceId":\s*(\d+)/g)].map((m) => Number(m[1]));
+      return Promise.resolve({
+        annotations: ids.map((sentenceId) => ({ sentenceId, emotion: 'neutral' as const })),
+      });
+    });
+
+    const res = await request(app).post(`/api/books/${bookId}/annotate-emotion`).send({});
+    expect(res.status).toBe(200);
+    const events = parseSse(res.text);
+
+    // The chapter split → analyzer was called more than once.
+    expect(runEmotion.mock.calls.length).toBeGreaterThan(1);
+
+    // Zero chapter-failed events (no truncation).
+    expect(events.some((e) => e.kind === 'chapter-failed')).toBe(false);
+
+    // Union of emitted sentenceIds == chapter sentence ids, each exactly once.
+    const emittedIds = events
+      .filter((e) => e.kind === 'annotation')
+      .flatMap((e) => (e.annotations as Array<{ sentenceId: number }>).map((a) => a.sentenceId));
+    const expectedIds = chapterSentences.map((s) => s.id);
+    expect([...emittedIds].sort((a, b) => a - b)).toEqual(expectedIds);
+    expect(new Set(emittedIds).size).toBe(emittedIds.length); // no duplicates
+
+    expect(events.some((e) => e.kind === 'result')).toBe(true);
   });
 });

--- a/server/src/routes/annotate-emotion.ts
+++ b/server/src/routes/annotate-emotion.ts
@@ -19,6 +19,11 @@ import { makeThrottledHeartbeat } from './analysis-heartbeat.js';
 import { AnalysisAbortedError } from '../analyzer/ollama.js';
 import { DailyQuotaExhaustedError } from '../analyzer/rate-limit.js';
 import type { SentenceOutput } from '../handoff/schemas.js';
+import {
+  chunkSentencesByBudget,
+  chunkWithContext,
+  chapterChunkBudget,
+} from '../analyzer/chapter-chunker.js';
 
 export const annotateEmotionRouter = Router();
 
@@ -138,33 +143,51 @@ annotateEmotionRouter.post(
           chapterId,
         });
 
-        const prompt = buildEmotionChapterInbox(
-          manuscriptId,
-          chapterId,
-          byChapter.get(chapterId) ?? [],
-        );
+        const sentences = byChapter.get(chapterId) ?? [];
+        const chunks = chunkSentencesByBudget(sentences, {
+          charBudget: chapterChunkBudget(selection.engine),
+          overlap: 3,
+          serialize: (s) =>
+            JSON.stringify({ sentenceId: s.id, characterId: s.characterId, text: s.text }),
+        });
 
         try {
-          const result = await selection.analyzer.runEmotionChapter(manuscriptId, chapterId, prompt, {
-            signal: controller.signal,
-            onChunk: (info) =>
-              heartbeat(0, chapterId, {
-                receivedBytes: info.receivedBytes,
-                elapsedMs: info.elapsedMs,
-                sinceLastChunkMs: info.sinceLastChunkMs,
-              }),
-            onThrottle: (waitMs, reason) =>
-              send({
-                kind: 'throttle',
-                phaseId: 0,
-                chapterIndex: chapterId,
-                model: selection.model,
-                waitMs,
-                reason,
-              }),
-          });
-          send({ kind: 'annotation', chapterId, annotations: result.annotations });
-          totalAnnotations += result.annotations.length;
+          for (const chunk of chunks) {
+            if (closed) break;
+            const prompt = buildEmotionChapterInbox(
+              manuscriptId,
+              chapterId,
+              chunkWithContext(chunk),
+            );
+            const result = await selection.analyzer.runEmotionChapter(
+              manuscriptId,
+              chapterId,
+              prompt,
+              {
+                signal: controller.signal,
+                onChunk: (info) =>
+                  heartbeat(0, chapterId, {
+                    receivedBytes: info.receivedBytes,
+                    elapsedMs: info.elapsedMs,
+                    sinceLastChunkMs: info.sinceLastChunkMs,
+                  }),
+                onThrottle: (waitMs, reason) =>
+                  send({
+                    kind: 'throttle',
+                    phaseId: 0,
+                    chapterIndex: chapterId,
+                    model: selection.model,
+                    waitMs,
+                    reason,
+                  }),
+              },
+            );
+            const owned = result.annotations.filter((a) => chunk.coreIds.has(a.sentenceId));
+            if (owned.length) {
+              send({ kind: 'annotation', chapterId, annotations: owned });
+              totalAnnotations += owned.length;
+            }
+          }
           annotatedChapters += 1;
         } catch (err) {
           if (err instanceof AnalysisAbortedError) break;

--- a/server/src/routes/book-state.test.ts
+++ b/server/src/routes/book-state.test.ts
@@ -2169,46 +2169,47 @@ describe('book-state router — prosodyAnnotated watermark (fs-65)', () => {
   });
 });
 
-// fs-57 — per-book liveInstruct flag persistence
-describe('book-state router — liveInstruct flag (fs-57)', () => {
-  it('GET returns state.liveInstruct as false (default) for a legacy book without the field', async () => {
+// fs-65 Phase 3 — per-book prosodyEnabled flag persistence (renamed from fs-57 liveInstruct)
+describe('book-state router — prosodyEnabled flag (fs-65 Phase-3)', () => {
+  it('GET returns state.prosodyEnabled as undefined (absent) for a legacy book without the field', async () => {
     const res = await request(app).get(`/api/books/${bookId}/state`);
     expect(res.status).toBe(200);
-    expect(res.body.state.liveInstruct ?? false).toBe(false);
+    // Absent ⇒ undefined; eager-default means the gate treats it as ON
+    expect(res.body.state.prosodyEnabled).toBeUndefined();
   });
 
-  it('PUT slice=state round-trips liveInstruct=true and persists it to disk', async () => {
+  it('PUT slice=state round-trips prosodyEnabled=true and persists it to disk', async () => {
     const put = await request(app)
       .put(`/api/books/${bookId}/state`)
       .set('Content-Type', 'application/json')
-      .send({ slice: 'state', patch: { liveInstruct: true } });
+      .send({ slice: 'state', patch: { prosodyEnabled: true } });
     expect(put.status).toBe(204);
     const onDisk = JSON.parse(readFileSync(join(bookDir, '.audiobook', 'state.json'), 'utf8'));
-    expect(onDisk.liveInstruct).toBe(true);
+    expect(onDisk.prosodyEnabled).toBe(true);
   });
 
-  it('PUT slice=state round-trips liveInstruct=false (explicit off)', async () => {
+  it('PUT slice=state round-trips prosodyEnabled=false (explicit opt-out)', async () => {
     const put = await request(app)
       .put(`/api/books/${bookId}/state`)
       .set('Content-Type', 'application/json')
-      .send({ slice: 'state', patch: { liveInstruct: false } });
+      .send({ slice: 'state', patch: { prosodyEnabled: false } });
     expect(put.status).toBe(204);
     const onDisk = JSON.parse(readFileSync(join(bookDir, '.audiobook', 'state.json'), 'utf8'));
-    expect(onDisk.liveInstruct).toBe(false);
+    expect(onDisk.prosodyEnabled).toBe(false);
   });
 
-  it('PUT slice=state preserves liveInstruct when patch omits the field', async () => {
+  it('PUT slice=state preserves prosodyEnabled when patch omits the field', async () => {
     /* Seed to true, then omit from patch — should remain true. */
     await request(app)
       .put(`/api/books/${bookId}/state`)
       .set('Content-Type', 'application/json')
-      .send({ slice: 'state', patch: { liveInstruct: true } });
+      .send({ slice: 'state', patch: { prosodyEnabled: true } });
     const put = await request(app)
       .put(`/api/books/${bookId}/state`)
       .set('Content-Type', 'application/json')
       .send({ slice: 'state', patch: { narratorCredit: 'Witness' } });
     expect(put.status).toBe(204);
     const onDisk = JSON.parse(readFileSync(join(bookDir, '.audiobook', 'state.json'), 'utf8'));
-    expect(onDisk.liveInstruct).toBe(true);
+    expect(onDisk.prosodyEnabled).toBe(true);
   });
 });

--- a/server/src/routes/book-state.test.ts
+++ b/server/src/routes/book-state.test.ts
@@ -2125,6 +2125,50 @@ describe('book-state router — shelf-status (fs-15 shelf controls)', () => {
   });
 });
 
+// Task 7 (fs-65 Phase 3) — per-book prosodyAnnotated watermark
+describe('book-state router — prosodyAnnotated watermark (fs-65)', () => {
+  it('GET returns state.prosodyAnnotated as undefined for a legacy book without the field', async () => {
+    const res = await request(app).get(`/api/books/${bookId}/state`);
+    expect(res.status).toBe(200);
+    expect(res.body.state.prosodyAnnotated).toBeUndefined();
+  });
+
+  it('PUT slice=state round-trips prosodyAnnotated=true and persists it to disk', async () => {
+    const put = await request(app)
+      .put(`/api/books/${bookId}/state`)
+      .set('Content-Type', 'application/json')
+      .send({ slice: 'state', patch: { prosodyAnnotated: true } });
+    expect(put.status).toBe(204);
+    const onDisk = JSON.parse(readFileSync(join(bookDir, '.audiobook', 'state.json'), 'utf8'));
+    expect(onDisk.prosodyAnnotated).toBe(true);
+  });
+
+  it('PUT slice=state round-trips prosodyAnnotated=false (explicit reset)', async () => {
+    const put = await request(app)
+      .put(`/api/books/${bookId}/state`)
+      .set('Content-Type', 'application/json')
+      .send({ slice: 'state', patch: { prosodyAnnotated: false } });
+    expect(put.status).toBe(204);
+    const onDisk = JSON.parse(readFileSync(join(bookDir, '.audiobook', 'state.json'), 'utf8'));
+    expect(onDisk.prosodyAnnotated).toBe(false);
+  });
+
+  it('PUT slice=state preserves prosodyAnnotated when patch omits the field', async () => {
+    /* Seed to true, then omit from patch — should remain true. */
+    await request(app)
+      .put(`/api/books/${bookId}/state`)
+      .set('Content-Type', 'application/json')
+      .send({ slice: 'state', patch: { prosodyAnnotated: true } });
+    const put = await request(app)
+      .put(`/api/books/${bookId}/state`)
+      .set('Content-Type', 'application/json')
+      .send({ slice: 'state', patch: { narratorCredit: 'Annotator' } });
+    expect(put.status).toBe(204);
+    const onDisk = JSON.parse(readFileSync(join(bookDir, '.audiobook', 'state.json'), 'utf8'));
+    expect(onDisk.prosodyAnnotated).toBe(true);
+  });
+});
+
 // fs-57 — per-book liveInstruct flag persistence
 describe('book-state router — liveInstruct flag (fs-57)', () => {
   it('GET returns state.liveInstruct as false (default) for a legacy book without the field', async () => {

--- a/server/src/routes/book-state.ts
+++ b/server/src/routes/book-state.ts
@@ -703,9 +703,9 @@ bookStateRouter.put('/:bookId/state', async (req: Request, res: Response) => {
           notes: pickNotes(patch.notes, state.notes),
           audioFormat: pickAudioFormat(patch.audioFormat, state.audioFormat),
           tags: pickTags(patch.tags, state.tags),
-          liveInstruct: typeof (patch as { liveInstruct?: unknown }).liveInstruct === 'boolean'
-            ? (patch as { liveInstruct: boolean }).liveInstruct
-            : (state.liveInstruct ?? false),
+          prosodyEnabled: typeof (patch as { prosodyEnabled?: unknown }).prosodyEnabled === 'boolean'
+            ? (patch as { prosodyEnabled: boolean }).prosodyEnabled
+            : state.prosodyEnabled,
           prosodyAnnotated: typeof (patch as { prosodyAnnotated?: unknown }).prosodyAnnotated === 'boolean'
             ? (patch as { prosodyAnnotated: boolean }).prosodyAnnotated
             : state.prosodyAnnotated,

--- a/server/src/routes/book-state.ts
+++ b/server/src/routes/book-state.ts
@@ -706,6 +706,9 @@ bookStateRouter.put('/:bookId/state', async (req: Request, res: Response) => {
           liveInstruct: typeof (patch as { liveInstruct?: unknown }).liveInstruct === 'boolean'
             ? (patch as { liveInstruct: boolean }).liveInstruct
             : (state.liveInstruct ?? false),
+          prosodyAnnotated: typeof (patch as { prosodyAnnotated?: unknown }).prosodyAnnotated === 'boolean'
+            ? (patch as { prosodyAnnotated: boolean }).prosodyAnnotated
+            : state.prosodyAnnotated,
           updatedAt: new Date().toISOString(),
         };
 

--- a/server/src/routes/instruct-annotation.test.ts
+++ b/server/src/routes/instruct-annotation.test.ts
@@ -26,8 +26,13 @@ let app: Express;
 let bookId: string;
 let manuscriptId: string;
 
-/* The fake analyzer's runStage3Chapter — each test swaps its implementation. */
-const { runStage3 } = vi.hoisted(() => ({ runStage3: vi.fn() }));
+/* The fake analyzer's runStage3Chapter — each test swaps its implementation.
+   `engineState` lets a test flip the reported engine to 'local' so the chunker
+   derives a finite, num_ctx-bound budget and a large chapter splits. */
+const { runStage3, engineState: instructEngineState } = vi.hoisted(() => ({
+  runStage3: vi.fn(),
+  engineState: { engine: 'gemini' as 'gemini' | 'local' },
+}));
 
 vi.mock('../analyzer/select-analyzer.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../analyzer/select-analyzer.js')>();
@@ -43,7 +48,7 @@ vi.mock('../analyzer/select-analyzer.js', async (importOriginal) => {
     ...actual,
     selectAnalyzerForPhase: () => ({
       analyzer: fakeAnalyzer,
-      engine: 'gemini' as const,
+      engine: instructEngineState.engine,
       model: 'test-model',
       fallbackModel: null,
     }),
@@ -115,6 +120,8 @@ beforeAll(async () => {
 
 beforeEach(() => {
   runStage3.mockReset();
+  instructEngineState.engine = 'gemini';
+  delete process.env.ANALYZER_NUM_CTX;
   rmSync(join(workspaceRoot, 'books'), { recursive: true, force: true });
 });
 
@@ -251,5 +258,51 @@ describe('POST /api/books/:bookId/instruct-annotation', () => {
     expect(events.some((e) => e.kind === 'chapter-failed' && e.chapterId === 1)).toBe(true);
     expect(events.some((e) => e.kind === 'annotation' && e.chapterId === 2)).toBe(true);
     expect(events.find((e) => e.kind === 'result')).toMatchObject({ annotatedChapters: 1 });
+  });
+
+  it('chunks a large chapter across calls and emits each sentence annotation exactly once', async () => {
+    // Force local engine + small num_ctx → chapterChunkBudget derives a finite budget
+    // that splits a large chapter into ≥2 chunks (gemini's MAX_SAFE_INTEGER never splits).
+    instructEngineState.engine = 'local';
+    process.env.ANALYZER_NUM_CTX = '400'; // → budget Math.max(2000, min(24000, 560)) = 2000
+
+    // ~800-char sentences: 2 per chunk under the 2000-char budget.
+    const longText = 'B'.repeat(800);
+    const chapterSentences = Array.from({ length: 12 }, (_, i) => ({
+      id: 300 + i,
+      chapterId: 30,
+      characterId: 'narrator',
+      text: longText,
+    }));
+    writeBook(chapterSentences);
+
+    // Each call returns one annotation per sentenceId present in the prompt (core + context),
+    // so without ownership filtering an overlapped sentence would be emitted by >1 chunk.
+    runStage3.mockImplementation((_m, _c, prompt: string): Promise<Stage3ChapterOutput> => {
+      const ids = [...prompt.matchAll(/"sentenceId":\s*(\d+)/g)].map((m) => Number(m[1]));
+      return Promise.resolve({
+        annotations: ids.map((sentenceId) => ({ sentenceId, instruct: 'test' })),
+      });
+    });
+
+    const res = await request(app).post(`/api/books/${bookId}/instruct-annotation`).send({});
+    expect(res.status).toBe(200);
+    const events = parseSse(res.text);
+
+    // The chapter split → analyzer was called more than once.
+    expect(runStage3.mock.calls.length).toBeGreaterThan(1);
+
+    // Zero chapter-failed events (no truncation).
+    expect(events.some((e) => e.kind === 'chapter-failed')).toBe(false);
+
+    // Union of emitted sentenceIds == chapter sentence ids, each exactly once.
+    const emittedIds = events
+      .filter((e) => e.kind === 'annotation')
+      .flatMap((e) => (e.annotations as Array<{ sentenceId: number }>).map((a) => a.sentenceId));
+    const expectedIds = chapterSentences.map((s) => s.id);
+    expect([...emittedIds].sort((a, b) => a - b)).toEqual(expectedIds);
+    expect(new Set(emittedIds).size).toBe(emittedIds.length); // no duplicates
+
+    expect(events.some((e) => e.kind === 'result')).toBe(true);
   });
 });

--- a/server/src/routes/instruct-annotation.ts
+++ b/server/src/routes/instruct-annotation.ts
@@ -18,6 +18,11 @@ import { makeThrottledHeartbeat } from './analysis-heartbeat.js';
 import { AnalysisAbortedError } from '../analyzer/ollama.js';
 import { DailyQuotaExhaustedError } from '../analyzer/rate-limit.js';
 import type { SentenceOutput } from '../handoff/schemas.js';
+import {
+  chunkSentencesByBudget,
+  chunkWithContext,
+  chapterChunkBudget,
+} from '../analyzer/chapter-chunker.js';
 
 export const instructAnnotationRouter = Router();
 
@@ -137,33 +142,51 @@ instructAnnotationRouter.post(
           chapterId,
         });
 
-        const prompt = buildInstructChapterInbox(
-          manuscriptId,
-          chapterId,
-          byChapter.get(chapterId) ?? [],
-        );
+        const sentences = byChapter.get(chapterId) ?? [];
+        const chunks = chunkSentencesByBudget(sentences, {
+          charBudget: chapterChunkBudget(selection.engine),
+          overlap: 3,
+          serialize: (s) =>
+            JSON.stringify({ sentenceId: s.id, characterId: s.characterId, text: s.text }),
+        });
 
         try {
-          const result = await selection.analyzer.runStage3Chapter(manuscriptId, chapterId, prompt, {
-            signal: controller.signal,
-            onChunk: (info) =>
-              heartbeat(0, chapterId, {
-                receivedBytes: info.receivedBytes,
-                elapsedMs: info.elapsedMs,
-                sinceLastChunkMs: info.sinceLastChunkMs,
-              }),
-            onThrottle: (waitMs, reason) =>
-              send({
-                kind: 'throttle',
-                phaseId: 0,
-                chapterIndex: chapterId,
-                model: selection.model,
-                waitMs,
-                reason,
-              }),
-          });
-          send({ kind: 'annotation', chapterId, annotations: result.annotations });
-          totalAnnotations += result.annotations.length;
+          for (const chunk of chunks) {
+            if (closed) break;
+            const prompt = buildInstructChapterInbox(
+              manuscriptId,
+              chapterId,
+              chunkWithContext(chunk),
+            );
+            const result = await selection.analyzer.runStage3Chapter(
+              manuscriptId,
+              chapterId,
+              prompt,
+              {
+                signal: controller.signal,
+                onChunk: (info) =>
+                  heartbeat(0, chapterId, {
+                    receivedBytes: info.receivedBytes,
+                    elapsedMs: info.elapsedMs,
+                    sinceLastChunkMs: info.sinceLastChunkMs,
+                  }),
+                onThrottle: (waitMs, reason) =>
+                  send({
+                    kind: 'throttle',
+                    phaseId: 0,
+                    chapterIndex: chapterId,
+                    model: selection.model,
+                    waitMs,
+                    reason,
+                  }),
+              },
+            );
+            const owned = result.annotations.filter((a) => chunk.coreIds.has(a.sentenceId));
+            if (owned.length) {
+              send({ kind: 'annotation', chapterId, annotations: owned });
+              totalAnnotations += owned.length;
+            }
+          }
           annotatedChapters += 1;
         } catch (err) {
           if (err instanceof AnalysisAbortedError) break;

--- a/server/src/workspace/scan.ts
+++ b/server/src/workspace/scan.ts
@@ -234,6 +234,15 @@ export interface BookStateJson {
      Additive optional field — `CURRENT_STATE_SCHEMA` does NOT bump
      (plan 27 rename-vs-add policy). */
   liveInstruct?: boolean;
+  /* fs-65 Phase 3 — completion watermark set once BOTH prosody annotation
+     passes (emotion + instruct) finish without any chapter failures.
+     Absent (undefined) or false ⇒ not yet annotated; the auto-trigger
+     re-runs when absent. Distinct from `prosodyEnabled` (Task 11 intent
+     flag): `prosodyEnabled` = "should we annotate", `prosodyAnnotated`
+     = "annotation finished".
+     Additive optional field — `CURRENT_STATE_SCHEMA` does NOT bump
+     (plan 27 rename-vs-add policy). */
+  prosodyAnnotated?: boolean;
 }
 
 /** Resolved chapter audio format for a book — `audioFormat` from

--- a/server/src/workspace/scan.ts
+++ b/server/src/workspace/scan.ts
@@ -227,13 +227,13 @@ export interface BookStateJson {
      (plan 27 rename-vs-add policy). Set at confirm time by
      `server/src/routes/import.ts`. */
   language?: string;
-  /* fs-57 — per-book live-instruct flag. When true, synthesiseChapter will
-     use the Qwen 1.7B live-instruct synth path instead of the standard
-     1.7B path. Default `false` (absent on books written before fs-57).
-     Toggled by the UI (Task 16) and gated by the synth route (Task 8).
+  /* fs-65 Phase 3 — prosody annotation intent flag. Absent (undefined) ⇒ ON
+     (eager default); only an explicit `false` opts out. The Task-13 client
+     trigger gate is `prosodyEnabled !== false`. Renamed from `liveInstruct`
+     (fs-57); legacy books without the field are treated as opted-in.
      Additive optional field — `CURRENT_STATE_SCHEMA` does NOT bump
      (plan 27 rename-vs-add policy). */
-  liveInstruct?: boolean;
+  prosodyEnabled?: boolean;
   /* fs-65 Phase 3 — completion watermark set once BOTH prosody annotation
      passes (emotion + instruct) finish without any chapter failures.
      Absent (undefined) or false ⇒ not yet annotated; the auto-trigger

--- a/src/components/detect-emotions-button.tsx
+++ b/src/components/detect-emotions-button.tsx
@@ -47,6 +47,8 @@ export function DetectEmotionsButton({ disabled = false }: { disabled?: boolean 
         dispatch,
         signal: controller.signal,
         onProgress: (fraction) => setProgress(fraction),
+        onStatus: (label) => setStatus(label),
+        onThrottle: () => setStatus('Waiting on the analyzer rate limit…'),
       });
       setStatus(
         `Tagged ${totalAnnotations} line${totalAnnotations === 1 ? '' : 's'} across ` +

--- a/src/components/detect-emotions-button.tsx
+++ b/src/components/detect-emotions-button.tsx
@@ -18,8 +18,8 @@
 
 import { useRef, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../store';
-import { manuscriptActions } from '../store/manuscript-slice';
-import { api, DetectEmotionsError, DetectInstructError } from '../lib/api';
+import { DetectEmotionsError, DetectInstructError } from '../lib/api';
+import { runProsodyPasses } from '../store/prosody-thunk';
 import { IconSparkle, IconSpinner } from '../lib/icons';
 
 type Phase = 'idle' | 'confirm' | 'running';
@@ -43,34 +43,11 @@ export function DetectEmotionsButton({ disabled = false }: { disabled?: boolean 
     const controller = new AbortController();
     abortRef.current = controller;
     try {
-      // Pass 1: emotion backfill — progress 0–50%
-      const emotionResult = await api.detectEmotions(bookId, {
+      const { totalAnnotations, totalChapters } = await runProsodyPasses(bookId, {
+        dispatch,
         signal: controller.signal,
-        onPhase: (e) => {
-          setProgress(e.progress * 0.5);
-          if (e.label) setStatus(e.label);
-        },
-        onThrottle: () => setStatus('Waiting on the analyzer rate limit…'),
-        onAnnotation: (e) => dispatch(manuscriptActions.applyDetectedEmotions(e)),
+        onProgress: (fraction) => setProgress(fraction),
       });
-
-      // Pass 2: instruct/vocalization — progress 50–100%
-      setStatus('Adding natural reactions…');
-      const instructResult = await api.detectInstruct(bookId, {
-        signal: controller.signal,
-        onPhase: (e) => {
-          setProgress(0.5 + e.progress * 0.5);
-          if (e.label) setStatus(e.label);
-        },
-        onThrottle: () => setStatus('Waiting on the analyzer rate limit…'),
-        onAnnotation: (e) => dispatch(manuscriptActions.applyDetectedInstruct(e)),
-      });
-
-      const totalAnnotations = emotionResult.totalAnnotations + instructResult.totalAnnotations;
-      const totalChapters = Math.max(
-        emotionResult.annotatedChapters,
-        instructResult.annotatedChapters,
-      );
       setStatus(
         `Tagged ${totalAnnotations} line${totalAnnotations === 1 ? '' : 's'} across ` +
           `${totalChapters} chapter${totalChapters === 1 ? '' : 's'}.`,

--- a/src/components/layout-prosody-pill.test.tsx
+++ b/src/components/layout-prosody-pill.test.tsx
@@ -1,0 +1,180 @@
+/* Task 14 (fs-65 Phase 3) — prosody progress pill rendering tests.
+
+   TDD contracts:
+   1. The pill renders with label + percent when prosody.activeStream is set.
+   2. The pill is absent when prosody.activeStream is null. */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+import { uiSlice } from '../store/ui-slice';
+import { castSlice } from '../store/cast-slice';
+import { chaptersSlice } from '../store/chapters-slice';
+import { revisionsSlice } from '../store/revisions-slice';
+import { manuscriptSlice } from '../store/manuscript-slice';
+import { librarySlice } from '../store/library-slice';
+import { voicesSlice } from '../store/voices-slice';
+import { changeLogSlice } from '../store/change-log-slice';
+import { accountSlice } from '../store/account-slice';
+import { bookMetaSlice } from '../store/book-meta-slice';
+import { exportsSlice } from '../store/exports-slice';
+import { analysisSlice } from '../store/analysis-slice';
+import { castDesignSlice } from '../store/cast-design-slice';
+import { queueSlice } from '../store/queue-slice';
+import { tourSlice } from '../store/tour-slice';
+import { listenProgressSlice } from '../store/listen-progress-slice';
+import { settingsSlice } from '../store/settings-slice';
+import { continueListeningSlice } from '../store/continue-listening-slice';
+import { notificationsSlice } from '../store/notifications-slice';
+import { prosodySlice, prosodyActions } from '../store/prosody-slice';
+
+import { Layout } from './layout';
+
+/* ── Module mocks ──────────────────────────────────────────────────────── */
+
+vi.mock('../store/prosody-thunk', () => ({
+  runProsodyPasses: vi.fn(() => Promise.resolve({ totalAnnotations: 0, totalChapters: 0, failed: 0 })),
+}));
+
+vi.mock('../lib/api', () => ({
+  api: {
+    getLibrary: vi.fn(async () => ({ books: [] })),
+    getVoices: vi.fn(async () => ({ voices: [], dropped: [] })),
+    getBaseVoices: vi.fn(async () => ({ voices: [] })),
+    getUserSettings: vi.fn(async () => ({})),
+    getBookState: vi.fn(async () => null),
+    putBookState: vi.fn(async () => ({})),
+    getAnalysisState: vi.fn(async () => null),
+    getActiveAnalyses: vi.fn(async () => ({ snapshots: [] })),
+    pollRevisions: vi.fn(async () => ({ pending: [], drift: [] })),
+    pollRevisionsBulk: vi.fn(async () => ({ byBookId: {} })),
+    getSidecarHealth: vi.fn(async () => ({ status: 'unreachable', url: '(test)' })),
+    getGpuQueueState: vi.fn(async () => ({ depth: 0, inFlight: 0, max: 1 })),
+    matchVoices: vi.fn(async () => ({ matches: [] })),
+    getSeriesRoster: vi.fn(async () => ({ characters: [] })),
+    getSetupReadiness: () =>
+      Promise.resolve({
+        ready: true,
+        completedAt: '2026-06-12T00:00:00.000Z',
+        blockers: { sidecar: 'pass', ffmpeg: 'pass', tts: 'pass', analyzer: 'pass' },
+        info: { gpu: 'cuda · 1.2 / 8.0 GB reserved' },
+      }),
+    getTourStatus: vi.fn(async () => ({ completedAt: null })),
+    getChapterAudio: vi.fn(async () => null),
+    getListenProgress: vi.fn(async () => null),
+    putListenProgress: vi.fn(async () => null),
+    putListenStats: vi.fn(async () => ({})),
+    setShelfStatus: vi.fn(async () => null),
+  },
+  AnalysisError: class extends Error {},
+  ExportIncompleteError: class extends Error {
+    missing: string[] = [];
+  },
+}));
+
+vi.mock('../routes/prefetch', () => ({
+  importGenerationView: vi.fn(() => Promise.resolve({})),
+  importUploadView: vi.fn(() => Promise.resolve({})),
+}));
+
+/* ── Store factory ─────────────────────────────────────────────────────── */
+
+function makeStore(prosodyState?: Partial<typeof prosodySlice.getInitialState>) {
+  return configureStore({
+    reducer: {
+      ui: uiSlice.reducer,
+      account: accountSlice.reducer,
+      cast: castSlice.reducer,
+      chapters: chaptersSlice.reducer,
+      revisions: revisionsSlice.reducer,
+      manuscript: manuscriptSlice.reducer,
+      library: librarySlice.reducer,
+      voices: voicesSlice.reducer,
+      changeLog: changeLogSlice.reducer,
+      bookMeta: bookMetaSlice.reducer,
+      exports: exportsSlice.reducer,
+      analysis: analysisSlice.reducer,
+      castDesign: castDesignSlice.reducer,
+      queue: queueSlice.reducer,
+      tour: tourSlice.reducer,
+      listenProgress: listenProgressSlice.reducer,
+      settings: settingsSlice.reducer,
+      continueListening: continueListeningSlice.reducer,
+      notifications: notificationsSlice.reducer,
+      prosody: prosodySlice.reducer,
+    },
+    preloadedState: prosodyState ? { prosody: prosodyState as ReturnType<typeof prosodySlice.getInitialState> } : undefined,
+  });
+}
+
+function renderLayout(store: ReturnType<typeof makeStore>) {
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/books/b1/cast']}>
+        <Routes>
+          <Route path="/books/:bookId/cast" element={<Layout />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+/* ── Tests ─────────────────────────────────────────────────────────────── */
+
+describe('Layout — prosody progress pill (Task 14 / fs-65 Phase 3)', () => {
+  it('renders the prosody pill with label and percent when activeStream is set', async () => {
+    const store = makeStore({
+      activeStream: { bookId: 'b1', progress: 42, label: 'Phase 3 — Detecting prosody' },
+    });
+
+    renderLayout(store);
+
+    const pill = await screen.findByTestId('prosody-pill');
+    expect(pill).toBeTruthy();
+    expect(pill.textContent).toContain('Phase 3 — Detecting prosody');
+    expect(pill.textContent).toContain('42%');
+  });
+
+  it('does NOT render the prosody pill when activeStream is null', async () => {
+    const store = makeStore({ activeStream: null });
+
+    renderLayout(store);
+
+    /* Wait for the boot-splash to resolve and Layout to settle. */
+    await screen.findByRole('navigation');
+
+    expect(screen.queryByTestId('prosody-pill')).toBeNull();
+  });
+
+  it('prosody pill updates when store state changes', async () => {
+    const store = makeStore({ activeStream: null });
+
+    renderLayout(store);
+
+    /* No pill initially. */
+    await screen.findByRole('navigation');
+    expect(screen.queryByTestId('prosody-pill')).toBeNull();
+
+    /* Dispatch setActive → pill should appear. */
+    await act(async () => {
+      store.dispatch(prosodyActions.setActive({ bookId: 'b1', progress: 0, label: 'Phase 3 — Detecting prosody' }));
+    });
+    const pill = await screen.findByTestId('prosody-pill');
+    expect(pill.textContent).toContain('0%');
+
+    /* Dispatch updateProgress → percent updates. */
+    await act(async () => {
+      store.dispatch(prosodyActions.updateProgress({ bookId: 'b1', progress: 0.77 }));
+    });
+    expect(pill.textContent).toContain('77%');
+
+    /* Dispatch clear → pill disappears. */
+    await act(async () => {
+      store.dispatch(prosodyActions.clear());
+    });
+    expect(screen.queryByTestId('prosody-pill')).toBeNull();
+  });
+});

--- a/src/components/layout.test.tsx
+++ b/src/components/layout.test.tsx
@@ -36,6 +36,8 @@ import { tourSlice } from '../store/tour-slice';
 import { listenProgressSlice } from '../store/listen-progress-slice';
 import { settingsSlice } from '../store/settings-slice';
 import { continueListeningSlice } from '../store/continue-listening-slice';
+import { notificationsSlice } from '../store/notifications-slice';
+import { prosodySlice } from '../store/prosody-slice';
 
 const getBookStateMock = vi.fn();
 const pollRevisionsMock = vi.fn();
@@ -135,6 +137,10 @@ vi.mock('../routes/prefetch', () => ({
   importUploadView: vi.fn(() => Promise.resolve({})),
 }));
 
+vi.mock('../store/prosody-thunk', () => ({
+  runProsodyPasses: vi.fn(() => Promise.resolve({ totalAnnotations: 0, totalChapters: 0, failed: 0 })),
+}));
+
 import { Layout } from './layout';
 import { api } from '../lib/api';
 import { uiActions } from '../store/ui-slice';
@@ -164,6 +170,8 @@ function makeStore() {
       listenProgress: listenProgressSlice.reducer,
       settings: settingsSlice.reducer,
       continueListening: continueListeningSlice.reducer,
+      notifications: notificationsSlice.reducer,
+      prosody: prosodySlice.reducer,
     },
   });
 }

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1002,9 +1002,10 @@ export function Layout() {
 
   const prosodyConsidered = useRef<Set<string>>(new Set());
   const prosodySeeded = useRef(false);
-  const completeIds = library.books
-    .filter((b) => isAnalysisComplete(b.status))
-    .map((b) => b.bookId);
+  const completeIds = useMemo(
+    () => library.books.filter((b) => isAnalysisComplete(b.status)).map((b) => b.bookId),
+    [library.books],
+  );
   const completeKey = completeIds.join('|');
   useEffect(() => {
     if (!prosodySeeded.current) {
@@ -1025,7 +1026,7 @@ export function Layout() {
           if (st.state.prosodyAnnotated) return;               // watermark → no-op
           const { failed } = await runProsodyPasses(id, { dispatch });
           if (failed === 0) {
-            api.putBookState(id, { slice: 'state', patch: { prosodyAnnotated: true } });
+            await api.putBookState(id, { slice: 'state', patch: { prosodyAnnotated: true } });
           } else {
             prosodyConsidered.current.delete(id); // partial → allow fill-only re-run
           }

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -85,6 +85,7 @@ import { QueueModalContainer } from '../modals/queue-modal';
 import { loadQueue, enqueueQueueEntries } from '../store/queue-thunks';
 import { selectGenerationActivityCount } from '../store/queue-slice';
 import { importGenerationView, importUploadView } from '../routes/prefetch';
+import { runProsodyPasses } from '../store/prosody-thunk';
 import { ToastStack } from './toast-stack';
 import { TourOverlay } from './tour/tour-overlay';
 import { RevisionDiffPlayer } from '../views/revision-diff';
@@ -974,6 +975,67 @@ export function Layout() {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bgKey, dispatch]);
+
+  /* Task 13 (fs-65 Phase 3) — eager prosody auto-trigger keyed on library
+     status. Fires the two-pass prosody annotation (emotions + instruct) for
+     every book that transitions to analysis-complete in library.books —
+     for both the active book AND background books (round-2 Critical: ui.stage
+     is singular and cannot observe background-analysed books).
+
+     Design constraints honoured here:
+     - Keyed on library.books status, NOT stageKind (fires for all books).
+     - Seed-on-mount: existing complete books are added to `considered` on the
+       first run WITHOUT firing (skips the pre-existing library; makes a Layout
+       remount self-healing — round-2 #5).
+     - Authoritative disk gate: reads prosodyEnabled + prosodyAnnotated from
+       getBookState, never from the store selector (opt-out hydration race,
+       round-2 #2).
+     - Detached job: void (async () => {...})() NOT tied to effect cleanup
+       (survives a book-switch, round-1 H2).
+     - Partial-aware watermark: writes prosodyAnnotated:true only when
+       failed === 0; on partial failure removes the book from considered so
+       a subsequent fill-only re-run can top it up (round-2 #6).
+     - Retry-safe: try/catch removes the book from considered on throw
+       (round-1 H3). */
+  const isAnalysisComplete = (s: string) =>
+    s !== 'not_analysed' && s !== 'analysing' && s !== 'unreadable' && s !== 'orphaned';
+
+  const prosodyConsidered = useRef<Set<string>>(new Set());
+  const prosodySeeded = useRef(false);
+  const completeIds = library.books
+    .filter((b) => isAnalysisComplete(b.status))
+    .map((b) => b.bookId);
+  const completeKey = completeIds.join('|');
+  useEffect(() => {
+    if (!prosodySeeded.current) {
+      // First run: mark all currently-complete books as already considered
+      // (no backlog auto-spend; makes a remount self-healing).
+      completeIds.forEach((id) => prosodyConsidered.current.add(id));
+      prosodySeeded.current = true;
+      return;
+    }
+    for (const id of completeIds) {
+      if (prosodyConsidered.current.has(id)) continue; // already handled this session
+      prosodyConsidered.current.add(id);
+      void (async () => {
+        // Detached: not tied to effect cleanup — survives a book-switch.
+        try {
+          const st = await api.getBookState(id);
+          if (!st || st.state.prosodyEnabled === false) return; // authoritative opt-out
+          if (st.state.prosodyAnnotated) return;               // watermark → no-op
+          const { failed } = await runProsodyPasses(id, { dispatch });
+          if (failed === 0) {
+            api.putBookState(id, { slice: 'state', patch: { prosodyAnnotated: true } });
+          } else {
+            prosodyConsidered.current.delete(id); // partial → allow fill-only re-run
+          }
+        } catch {
+          prosodyConsidered.current.delete(id); // transient error → retry on next transition
+        }
+      })();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [completeKey]);
 
   if (ui.previewMode) {
     return (

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -86,11 +86,12 @@ import { loadQueue, enqueueQueueEntries } from '../store/queue-thunks';
 import { selectGenerationActivityCount } from '../store/queue-slice';
 import { importGenerationView, importUploadView } from '../routes/prefetch';
 import { runProsodyPasses } from '../store/prosody-thunk';
+import { prosodyActions } from '../store/prosody-slice';
 import { ToastStack } from './toast-stack';
 import { TourOverlay } from './tour/tour-overlay';
 import { RevisionDiffPlayer } from '../views/revision-diff';
 import { RevisionTimelineModal } from './revision-timeline-modal';
-import { IconRefresh, IconWarning } from '../lib/icons';
+import { IconRefresh, IconSpinner, IconWarning } from '../lib/icons';
 
 /* Lifted from App.tsx's resultDialog state. Routes that need to surface a
    styled post-action dialog (e.g. BooksRoute after delete/reparse) pull
@@ -158,6 +159,7 @@ export function Layout() {
   const chapters = useAppSelectorShallow((s) => s.chapters.chapters);
   const activeStreams = useAppSelectorShallow(selectActiveStreams);
   const analysisStream = useAppSelector((s) => s.analysis.activeStream);
+  const prosodyStream = useAppSelector((s) => s.prosody.activeStream);
   const designSnapshot = useAppSelector((s) => s.castDesign.active);
   const driftGroupsByBook = useAppSelector(selectDriftGroupsByBook);
   const bookMetaSaved = useAppSelector((s) => s.bookMeta.saved);
@@ -1020,17 +1022,25 @@ export function Layout() {
       prosodyConsidered.current.add(id);
       void (async () => {
         // Detached: not tied to effect cleanup — survives a book-switch.
+        let pillActive = false;
         try {
           const st = await api.getBookState(id);
           if (!st || st.state.prosodyEnabled === false) return; // authoritative opt-out
           if (st.state.prosodyAnnotated) return;               // watermark → no-op
-          const { failed } = await runProsodyPasses(id, { dispatch });
+          dispatch(prosodyActions.setActive({ bookId: id, progress: 0, label: 'Phase 3 — Detecting prosody' }));
+          pillActive = true;
+          const { failed } = await runProsodyPasses(id, {
+            dispatch,
+            onProgress: (f) => dispatch(prosodyActions.updateProgress({ bookId: id, progress: f })),
+          });
+          dispatch(prosodyActions.clear());
           if (failed === 0) {
             await api.putBookState(id, { slice: 'state', patch: { prosodyAnnotated: true } });
           } else {
             prosodyConsidered.current.delete(id); // partial → allow fill-only re-run
           }
         } catch {
+          if (pillActive) dispatch(prosodyActions.clear());
           prosodyConsidered.current.delete(id); // transient error → retry on next transition
         }
       })();
@@ -1329,6 +1339,14 @@ export function Layout() {
     };
   })();
 
+  /* Phase 3 prosody-progress pill — anchored to the transient `prosody.activeStream`
+     slice (Task 14). Absent when no prosody pass is running; shows label + percent
+     while the two-pass annotation runs. No navigation: the pass runs silently in
+     the background. */
+  const prosodyPill: { label: string; percent: number } | null = prosodyStream
+    ? { label: prosodyStream.label, percent: prosodyStream.progress }
+    : null;
+
   /* Third status pill — the in-flight "Design full cast" bulk job. Mirrors the
      analysis/generation pill IIFEs: anchored to the cross-book `castDesign`
      snapshot, recomputed inline so the per-second forceClockTick refreshes the
@@ -1476,6 +1494,21 @@ export function Layout() {
       <BuildStamp />
 
       <ToastStack />
+
+      {/* Phase 3 prosody-progress pill (Task 14, fs-65). Fixed bottom-left,
+          above the mini-player reserved gap. Absent when no prosody pass is
+          running. Uses design tokens only — no hex literals. */}
+      {prosodyPill && (
+        <div
+          data-testid="prosody-pill"
+          className="fixed bottom-24 left-6 z-60 inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-semibold bg-peach/15 text-magenta shadow-card"
+        >
+          <IconSpinner className="w-3.5 h-3.5" />
+          <span className="tabular-nums">
+            {prosodyPill.label} · {prosodyPill.percent}%
+          </span>
+        </div>
+      )}
 
       {stageKind === 'ready' && bookId && (
         <MiniPlayer

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -787,7 +787,7 @@ export function Layout() {
               publicationDate: res.state.publicationDate ?? null,
               description: res.state.description ?? null,
               notes: res.state.notes ?? null,
-              liveInstruct: res.state.liveInstruct ?? false,
+              prosodyEnabled: res.state.prosodyEnabled,
             },
           }),
         );

--- a/src/lib/api-detect-emotions.test.ts
+++ b/src/lib/api-detect-emotions.test.ts
@@ -79,6 +79,64 @@ describe('api.detectEmotions', () => {
   });
 });
 
+describe('api.detectEmotions — chapter-failed is surfaced', () => {
+  it('calls onChapterFailed and still resolves on a chapter-failed-only stream', async () => {
+    const { api } = await import('./api');
+    fetchMock.mockResolvedValueOnce(
+      sseResponse([
+        JSON.stringify({
+          kind: 'phase',
+          progress: 0,
+          label: 'Detecting emotions — chapter 3',
+          chapterId: 3,
+        }),
+        JSON.stringify({
+          kind: 'chapter-failed',
+          chapterId: 3,
+          message: 'Chapter 3 is too large — split it first.',
+        }),
+        JSON.stringify({ kind: 'result', annotatedChapters: 0, totalAnnotations: 0 }),
+      ]),
+    );
+    const failed: Array<{ chapterId: number; message: string }> = [];
+    const res = await api.detectEmotions('bk', { onChapterFailed: (e) => failed.push(e) });
+    expect(failed).toEqual([
+      { chapterId: 3, message: 'Chapter 3 is too large — split it first.' },
+    ]);
+    expect(res.totalAnnotations).toBe(0);
+    expect(res.annotatedChapters).toBe(0);
+  });
+});
+
+describe('api.detectInstruct — chapter-failed is surfaced', () => {
+  it('calls onChapterFailed and still resolves on a chapter-failed-only stream', async () => {
+    const { api } = await import('./api');
+    fetchMock.mockResolvedValueOnce(
+      sseResponse([
+        JSON.stringify({
+          kind: 'phase',
+          progress: 0,
+          label: 'Detecting instruct — chapter 5',
+          chapterId: 5,
+        }),
+        JSON.stringify({
+          kind: 'chapter-failed',
+          chapterId: 5,
+          message: 'Chapter 5 failed instruct annotation.',
+        }),
+        JSON.stringify({ kind: 'result', annotatedChapters: 0, totalAnnotations: 0 }),
+      ]),
+    );
+    const failed: Array<{ chapterId: number; message: string }> = [];
+    const res = await api.detectInstruct('bk', { onChapterFailed: (e) => failed.push(e) });
+    expect(failed).toEqual([
+      { chapterId: 5, message: 'Chapter 5 failed instruct annotation.' },
+    ]);
+    expect(res.totalAnnotations).toBe(0);
+    expect(res.annotatedChapters).toBe(0);
+  });
+});
+
 describe('api.removeQwenVariant', () => {
   it('issues a DELETE to the emotion-variant route', async () => {
     const { api } = await import('./api');

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -2575,14 +2575,14 @@ export interface components {
              */
             language?: string;
             /**
-             * @description fs-57 — per-book live-instruct flag. When `true`, `synthesiseChapter`
-             *     uses the Qwen 1.7B live-instruct synth path instead of the standard
-             *     path. Default `false` (absent on books written before fs-57 — readers
-             *     treat absence as `false`). Toggled by the UI (Task 16) and gated by
-             *     the synth route (Task 8). Persisted to `BookStateJson.liveInstruct`
-             *     in `<bookDir>/.audiobook/state.json`.
+             * @description fs-65 Phase 3 — prosody annotation intent flag. Absent (undefined)
+             *     ⇒ ON (eager default); only an explicit `false` opts out. The
+             *     client-side Task-13 trigger gate is `prosodyEnabled !== false`.
+             *     Persisted to `BookStateJson.prosodyEnabled` in
+             *     `<bookDir>/.audiobook/state.json`. Renamed from `liveInstruct`
+             *     (fs-57); legacy books without the field are treated as opted-in.
              */
-            liveInstruct?: boolean;
+            prosodyEnabled?: boolean;
         };
         ImportCandidate: {
             /** @enum {string} */

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2678,6 +2678,7 @@ export interface DetectEmotionsOpts {
     chapterId: number;
     annotations: Array<{ sentenceId: number; emotion: string }>;
   }) => void;
+  onChapterFailed?: (e: { chapterId: number; message: string }) => void;
 }
 export interface DetectEmotionsResult {
   annotatedChapters: number;
@@ -2695,7 +2696,7 @@ export class DetectEmotionsError extends Error {
 
 async function realDetectEmotions(
   bookId: string,
-  { signal, model, onPhase, onThrottle, onAnnotation }: DetectEmotionsOpts = {},
+  { signal, model, onPhase, onThrottle, onAnnotation, onChapterFailed }: DetectEmotionsOpts = {},
 ): Promise<DetectEmotionsResult> {
   const res = await fetch(`/api/books/${encodeURIComponent(bookId)}/annotate-emotion`, {
     method: 'POST',
@@ -2745,12 +2746,20 @@ async function realDetectEmotions(
           totalAnnotations: typeof p.totalAnnotations === 'number' ? p.totalAnnotations : 0,
         };
         break;
+      case 'chapter-failed':
+        if (typeof p.chapterId === 'number') {
+          onChapterFailed?.({
+            chapterId: p.chapterId,
+            message: typeof p.message === 'string' ? p.message : 'Chapter annotation failed.',
+          });
+        }
+        break;
       case 'error':
         throw new DetectEmotionsError(
           typeof p.message === 'string' ? p.message : 'Emotion detection failed.',
           typeof p.code === 'string' ? p.code : 'unknown',
         );
-      /* heartbeat / chapter-failed are advisory — ignored by the client. */
+      /* heartbeat is advisory — ignored by the client. */
     }
   };
 
@@ -2777,7 +2786,7 @@ async function realDetectEmotions(
 
 async function mockDetectEmotions(
   _bookId: string,
-  { onPhase, onAnnotation }: DetectEmotionsOpts = {},
+  { onPhase, onAnnotation, onChapterFailed: _onChapterFailed }: DetectEmotionsOpts = {},
 ): Promise<DetectEmotionsResult> {
   await wait(60);
   onPhase?.({ progress: 0.5, label: 'Detecting emotions — chapter 1', chapterId: 1 });
@@ -2798,6 +2807,7 @@ export interface DetectInstructOpts {
     chapterId: number;
     annotations: Array<{ sentenceId: number; text?: string; instruct?: string; vocalization?: boolean }>;
   }) => void;
+  onChapterFailed?: (e: { chapterId: number; message: string }) => void;
 }
 export interface DetectInstructResult {
   annotatedChapters: number;
@@ -2815,7 +2825,7 @@ export class DetectInstructError extends Error {
 
 async function realDetectInstruct(
   bookId: string,
-  { signal, model, onPhase, onThrottle, onAnnotation }: DetectInstructOpts = {},
+  { signal, model, onPhase, onThrottle, onAnnotation, onChapterFailed }: DetectInstructOpts = {},
 ): Promise<DetectInstructResult> {
   const res = await fetch(`/api/books/${encodeURIComponent(bookId)}/instruct-annotation`, {
     method: 'POST',
@@ -2870,12 +2880,20 @@ async function realDetectInstruct(
           totalAnnotations: typeof p.totalAnnotations === 'number' ? p.totalAnnotations : 0,
         };
         break;
+      case 'chapter-failed':
+        if (typeof p.chapterId === 'number') {
+          onChapterFailed?.({
+            chapterId: p.chapterId,
+            message: typeof p.message === 'string' ? p.message : 'Chapter annotation failed.',
+          });
+        }
+        break;
       case 'error':
         throw new DetectInstructError(
           typeof p.message === 'string' ? p.message : 'Instruct detection failed.',
           typeof p.code === 'string' ? p.code : 'unknown',
         );
-      /* heartbeat / chapter-failed are advisory — ignored by the client. */
+      /* heartbeat is advisory — ignored by the client. */
     }
   };
 
@@ -2902,7 +2920,7 @@ async function realDetectInstruct(
 
 async function mockDetectInstruct(
   _bookId: string,
-  { onPhase, onAnnotation }: DetectInstructOpts = {},
+  { onPhase, onAnnotation, onChapterFailed: _onChapterFailed }: DetectInstructOpts = {},
 ): Promise<DetectInstructResult> {
   await wait(60);
   onPhase?.({ progress: 0.5, label: 'Detecting instruct — chapter 1', chapterId: 1 });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -365,10 +365,10 @@ export interface BookStateJson {
       BookStateJson; drives the Listen language badge + cast-view Qwen lock
       for non-English books. */
   language?: string;
-  /** fs-57 — per-book live-instruct flag. When true, synthesiseChapter uses
-      the Qwen 1.7B live-instruct synth path. Absent on books written before
-      fs-57 — treat absence as false. */
-  liveInstruct?: boolean;
+  /** fs-65 Phase 3 — prosody annotation intent flag. Absent (undefined) ⇒ ON
+      (eager default); only an explicit `false` opts out. The Task-13 trigger
+      gate is `prosodyEnabled !== false`. */
+  prosodyEnabled?: boolean;
   /** fs-65 Phase 3 — completion watermark; true once both prosody annotation
       passes (emotion + instruct) finish without chapter failures. Absent
       (undefined) or false ⇒ not yet annotated. Mirror of the server's

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -369,6 +369,11 @@ export interface BookStateJson {
       the Qwen 1.7B live-instruct synth path. Absent on books written before
       fs-57 — treat absence as false. */
   liveInstruct?: boolean;
+  /** fs-65 Phase 3 — completion watermark; true once both prosody annotation
+      passes (emotion + instruct) finish without chapter failures. Absent
+      (undefined) or false ⇒ not yet annotated. Mirror of the server's
+      BookStateJson type (`server/src/workspace/scan.ts`). */
+  prosodyAnnotated?: boolean;
 }
 
 export interface BookStateResponse {

--- a/src/store/book-meta-slice.test.ts
+++ b/src/store/book-meta-slice.test.ts
@@ -12,7 +12,7 @@ import {
 } from './book-meta-slice';
 import type { RootState } from './index';
 
-const initial = (): BookMetaState => ({ draft: null, saved: {}, liveInstruct: {} });
+const initial = (): BookMetaState => ({ draft: null, saved: {}, prosodyEnabled: {} });
 
 const fullMeta = (over: Partial<EditableBookMeta> = {}): EditableBookMeta => ({
   title: 'The Northern Star',
@@ -30,7 +30,7 @@ const reducer = bookMetaSlice.reducer;
 
 describe('bookMetaSlice — hydrateFromBookState', () => {
   it('seeds saved[bookId] from BookStateJson and wipes any draft', () => {
-    const start: BookMetaState = { draft: { title: 'stale draft' }, saved: {}, liveInstruct: {} };
+    const start: BookMetaState = { draft: { title: 'stale draft' }, saved: {}, prosodyEnabled: {} };
     const next = reducer(
       start,
       bookMetaActions.hydrateFromBookState({
@@ -101,7 +101,7 @@ describe('bookMetaSlice — setDraftField + cancelDraft', () => {
   });
 
   it('cancelDraft clears the draft buffer', () => {
-    const dirty: BookMetaState = { draft: { title: 'X' }, saved: { ns: fullMeta() }, liveInstruct: {} };
+    const dirty: BookMetaState = { draft: { title: 'X' }, saved: { ns: fullMeta() }, prosodyEnabled: {} };
     const next = reducer(dirty, bookMetaActions.cancelDraft());
     expect(next.draft).toBeNull();
     expect(next.saved.ns).toEqual(fullMeta());
@@ -113,7 +113,7 @@ describe('bookMetaSlice — commitDraft', () => {
     const start: BookMetaState = {
       draft: { title: 'Renamed', genre: 'Sci-fi' },
       saved: { ns: fullMeta() },
-      liveInstruct: {},
+      prosodyEnabled: {},
     };
     const next = reducer(start, bookMetaActions.commitDraft({ bookId: 'ns' }));
     expect(next.draft).toBeNull();
@@ -121,7 +121,7 @@ describe('bookMetaSlice — commitDraft', () => {
   });
 
   it('is a no-op when no saved baseline exists (refuses to corrupt state)', () => {
-    const start: BookMetaState = { draft: { title: 'X' }, saved: {}, liveInstruct: {} };
+    const start: BookMetaState = { draft: { title: 'X' }, saved: {}, prosodyEnabled: {} };
     const next = reducer(start, bookMetaActions.commitDraft({ bookId: 'unknown' }));
     expect(next.saved.unknown).toBeUndefined();
     /* Draft is still cleared — the user's intent (commit & close) is honoured
@@ -130,7 +130,7 @@ describe('bookMetaSlice — commitDraft', () => {
   });
 
   it('clears the draft even when it is empty (so the middleware fires once)', () => {
-    const start: BookMetaState = { draft: null, saved: { ns: fullMeta() }, liveInstruct: {} };
+    const start: BookMetaState = { draft: null, saved: { ns: fullMeta() }, prosodyEnabled: {} };
     const next = reducer(start, bookMetaActions.commitDraft({ bookId: 'ns' }));
     expect(next.saved.ns).toEqual(fullMeta());
     expect(next.draft).toBeNull();
@@ -143,7 +143,7 @@ describe('bookMetaSlice — commitDraft', () => {
     const start: BookMetaState = {
       draft: { notes: 'First line.\nSecond line.\n\nThird paragraph.' },
       saved: { ns: fullMeta() },
-      liveInstruct: {},
+      prosodyEnabled: {},
     };
     const next = reducer(start, bookMetaActions.commitDraft({ bookId: 'ns' }));
     expect(next.draft).toBeNull();
@@ -160,7 +160,7 @@ describe('selectors', () => {
   });
 
   it('selectEffectiveMeta returns saved snapshot when draft is empty', () => {
-    const s = baseState({ draft: null, saved: { ns: fullMeta() }, liveInstruct: {} });
+    const s = baseState({ draft: null, saved: { ns: fullMeta() }, prosodyEnabled: {} });
     expect(selectEffectiveMeta('ns')(s)).toEqual(fullMeta());
   });
 
@@ -168,7 +168,7 @@ describe('selectors', () => {
     const s = baseState({
       draft: { title: 'Live Edit', genre: null },
       saved: { ns: fullMeta() },
-      liveInstruct: {},
+      prosodyEnabled: {},
     });
     expect(selectEffectiveMeta('ns')(s)).toEqual(fullMeta({ title: 'Live Edit', genre: null }));
   });
@@ -178,52 +178,52 @@ describe('selectors', () => {
   });
 
   it('selectIsDirty is true once the draft has any keys', () => {
-    const s = baseState({ draft: { title: 'X' }, saved: { ns: fullMeta() }, liveInstruct: {} });
+    const s = baseState({ draft: { title: 'X' }, saved: { ns: fullMeta() }, prosodyEnabled: {} });
     expect(selectIsDirty(s)).toBe(true);
   });
 
   it('selectIsDirty is false for an empty-object draft', () => {
     /* Defensive — setDraftField always seeds at least one key, but a stray
        reducer that left {} behind shouldn't mark the form dirty. */
-    const s = baseState({ draft: {}, saved: { ns: fullMeta() }, liveInstruct: {} });
+    const s = baseState({ draft: {}, saved: { ns: fullMeta() }, prosodyEnabled: {} });
     expect(selectIsDirty(s)).toBe(false);
   });
 });
 
-// fs-57 — per-book liveInstruct flag
-import { bookMetaReducer, selectLiveInstruct } from './book-meta-slice';
+// fs-65 Phase 3 (replaces fs-57) — per-book prosodyEnabled flag
+import { bookMetaReducer, selectProsodyEnabled } from './book-meta-slice';
 import type { RootState as RS } from './index';
 
-describe('bookMetaSlice — liveInstruct (fs-57 book-scoped)', () => {
+describe('bookMetaSlice — prosodyEnabled (fs-65 Phase-3, replaces fs-57 liveInstruct)', () => {
   it('defaults to empty map (no books hydrated)', () => {
     const s0 = bookMetaReducer(undefined, { type: '@@init' });
-    expect(s0.liveInstruct).toEqual({});
+    expect(s0.prosodyEnabled).toEqual({});
   });
 
-  it('setLiveInstruct scopes the flag to the given bookId', () => {
+  it('setProsodyEnabled scopes the flag to the given bookId', () => {
     const s0 = bookMetaReducer(undefined, { type: '@@init' });
-    const s1 = bookMetaReducer(s0, bookMetaActions.setLiveInstruct({ bookId: 'book-A', value: true }));
-    expect(s1.liveInstruct['book-A']).toBe(true);
+    const s1 = bookMetaReducer(s0, bookMetaActions.setProsodyEnabled({ bookId: 'book-A', value: true }));
+    expect(s1.prosodyEnabled['book-A']).toBe(true);
   });
 
-  it('setLiveInstruct for Book A does not affect Book B', () => {
+  it('setProsodyEnabled for Book A does not affect Book B', () => {
     let s = bookMetaReducer(undefined, { type: '@@init' });
-    s = bookMetaReducer(s, bookMetaActions.setLiveInstruct({ bookId: 'book-A', value: true }));
-    expect(s.liveInstruct['book-B']).toBeUndefined();
+    s = bookMetaReducer(s, bookMetaActions.setProsodyEnabled({ bookId: 'book-A', value: true }));
+    expect(s.prosodyEnabled['book-B']).toBeUndefined();
   });
 
-  it('hydrateFromBookState with liveInstruct:true sets the flag for that book', () => {
+  it('hydrateFromBookState with prosodyEnabled:true sets the flag for that book', () => {
     const s = bookMetaReducer(
       undefined,
       bookMetaActions.hydrateFromBookState({
         bookId: 'book-A',
-        state: { title: 'T', author: 'A', series: '', liveInstruct: true },
+        state: { title: 'T', author: 'A', series: '', prosodyEnabled: true },
       }),
     );
-    expect(s.liveInstruct['book-A']).toBe(true);
+    expect(s.prosodyEnabled['book-A']).toBe(true);
   });
 
-  it('hydrateFromBookState without liveInstruct defaults to false for that book', () => {
+  it('hydrateFromBookState without prosodyEnabled leaves it undefined (eager-default semantics)', () => {
     const s = bookMetaReducer(
       undefined,
       bookMetaActions.hydrateFromBookState({
@@ -231,15 +231,32 @@ describe('bookMetaSlice — liveInstruct (fs-57 book-scoped)', () => {
         state: { title: 'T', author: 'A', series: '' },
       }),
     );
-    expect(s.liveInstruct['book-A']).toBe(false);
+    expect(s.prosodyEnabled['book-A']).toBeUndefined();
   });
 
-  it('opening Book B (liveInstruct absent) does not inherit Book A liveInstruct:true', () => {
+  it('hydrateFromBookState with prosodyEnabled:undefined (explicit) leaves it undefined — not coerced to false', () => {
+    const s = bookMetaReducer(
+      undefined,
+      bookMetaActions.hydrateFromBookState({
+        bookId: 'book-A',
+        state: { title: 'T', author: 'A', series: '', prosodyEnabled: undefined },
+      }),
+    );
+    expect(s.prosodyEnabled['book-A']).toBeUndefined();
+  });
+
+  it('setProsodyEnabled(false) stores false (explicit opt-out)', () => {
+    const s0 = bookMetaReducer(undefined, { type: '@@init' });
+    const s1 = bookMetaReducer(s0, bookMetaActions.setProsodyEnabled({ bookId: 'book-A', value: false }));
+    expect(s1.prosodyEnabled['book-A']).toBe(false);
+  });
+
+  it('opening Book B (prosodyEnabled absent) does not inherit Book A prosodyEnabled:true', () => {
     let s = bookMetaReducer(
       undefined,
       bookMetaActions.hydrateFromBookState({
         bookId: 'book-A',
-        state: { title: 'TA', author: 'AA', series: '', liveInstruct: true },
+        state: { title: 'TA', author: 'AA', series: '', prosodyEnabled: true },
       }),
     );
     s = bookMetaReducer(
@@ -249,30 +266,32 @@ describe('bookMetaSlice — liveInstruct (fs-57 book-scoped)', () => {
         state: { title: 'TB', author: 'AB', series: '' },
       }),
     );
-    expect(s.liveInstruct['book-A']).toBe(true);
-    expect(s.liveInstruct['book-B']).toBe(false);
+    expect(s.prosodyEnabled['book-A']).toBe(true);
+    expect(s.prosodyEnabled['book-B']).toBeUndefined();
   });
 
-  it('selectLiveInstruct returns false for an unknown bookId', () => {
+  it('selectProsodyEnabled returns undefined for an unknown bookId', () => {
     const rootState = ({ bookMeta: bookMetaReducer(undefined, { type: '@@init' }) }) as unknown as RS;
-    expect(selectLiveInstruct('unknown-book')(rootState)).toBe(false);
+    expect(selectProsodyEnabled('unknown-book')(rootState)).toBeUndefined();
   });
 
-  it('selectLiveInstruct returns true after hydrateFromBookState with liveInstruct:true', () => {
+  it('selectProsodyEnabled returns true after hydrateFromBookState with prosodyEnabled:true', () => {
     const s = bookMetaReducer(
       undefined,
       bookMetaActions.hydrateFromBookState({
         bookId: 'book-A',
-        state: { title: 'T', author: 'A', series: '', liveInstruct: true },
+        state: { title: 'T', author: 'A', series: '', prosodyEnabled: true },
       }),
     );
     const rootState = ({ bookMeta: s }) as unknown as RS;
-    expect(selectLiveInstruct('book-A')(rootState)).toBe(true);
+    expect(selectProsodyEnabled('book-A')(rootState)).toBe(true);
   });
 
-  it('selectLiveInstruct returns false for null bookId', () => {
+  it('selectProsodyEnabled returns undefined for null bookId', () => {
     const rootState = ({ bookMeta: bookMetaReducer(undefined, { type: '@@init' }) }) as unknown as RS;
-    expect(selectLiveInstruct(null)(rootState)).toBe(false);
+    expect(selectProsodyEnabled(null)(rootState)).toBeUndefined();
   });
 });
+
+
 

--- a/src/store/book-meta-slice.ts
+++ b/src/store/book-meta-slice.ts
@@ -165,9 +165,11 @@ export const selectIsDirty = (s: RootState): boolean =>
 /** fs-65 Phase 3 — per-book prosody annotation intent flag.
     Returns undefined for any book that has not been hydrated yet or where
     the flag was absent on disk. The Task-13 trigger gate is
-    `prosodyEnabled !== false` (absent ⇒ on). */
+    `prosodyEnabled !== false` (absent ⇒ on).
+    Guards `s.bookMeta?.prosodyEnabled` so tests that omit the bookMeta
+    slice from their store don't throw (they get the safe undefined/on default). */
 export const selectProsodyEnabled =
   (bookId: string | null) =>
   (s: RootState): boolean | undefined =>
-    bookId != null ? s.bookMeta.prosodyEnabled[bookId] : undefined;
+    bookId != null ? (s.bookMeta?.prosodyEnabled ?? {})[bookId] : undefined;
 

--- a/src/store/book-meta-slice.ts
+++ b/src/store/book-meta-slice.ts
@@ -48,17 +48,18 @@ export interface BookMetaState {
   draft: Partial<EditableBookMeta> | null;
   /** Last-saved snapshot for each book the user has opened this session. */
   saved: Record<string, EditableBookMeta>;
-  /** fs-57 — per-book live-instruct flag keyed by bookId.
-      Default false for any book not yet hydrated. Persisted through
-      the server book-state slice; toggled by the UI (Task 16). Gates
-      the Qwen 1.7B live-instruct synth path (Task 8). */
-  liveInstruct: Record<string, boolean>;
+  /** fs-65 Phase 3 — per-book prosody annotation intent flag keyed by bookId.
+      Eager-default: absent (undefined) ⇒ ON; only an explicit `false` opts out.
+      The Task-13 trigger gate is `prosodyEnabled !== false`.
+      Persisted through the server book-state slice; toggled by the Task-12
+      analysis-form toggle. */
+  prosodyEnabled: Record<string, boolean | undefined>;
 }
 
 const initialState: BookMetaState = {
   draft: null,
   saved: {},
-  liveInstruct: {},
+  prosodyEnabled: {},
 };
 
 interface HydratePayload {
@@ -69,7 +70,7 @@ interface HydratePayload {
     publicationDate?: string | null;
     description?: string | null;
     notes?: string | null;
-    liveInstruct?: boolean;
+    prosodyEnabled?: boolean;
   };
 }
 
@@ -91,7 +92,7 @@ export const bookMetaSlice = createSlice({
         description: state.description ?? null,
         notes: state.notes ?? null,
       };
-      s.liveInstruct[bookId] = state.liveInstruct ?? false;
+      s.prosodyEnabled[bookId] = state.prosodyEnabled;
       s.draft = null;
     },
 
@@ -111,13 +112,12 @@ export const bookMetaSlice = createSlice({
       s.draft = null;
     },
 
-    /* fs-57 — toggle the live-instruct flag for the given book.
-       Dispatched by the UI toggle (Task 16); gates the Qwen 1.7B
-       live-instruct synth path (Task 8). The persistence-middleware
-       watches this action and PUTs `{ slice: 'state', patch: { liveInstruct } }`
-       to the server. */
-    setLiveInstruct: (s, a: PayloadAction<{ bookId: string; value: boolean }>) => {
-      s.liveInstruct[a.payload.bookId] = a.payload.value;
+    /* fs-65 Phase 3 — set the prosody annotation intent flag for the given book.
+       Dispatched by the Task-12 analysis-form toggle. The durable PUT to
+       `{ slice: 'state', patch: { prosodyEnabled } }` is issued by the toggle
+       component directly (no persistence-middleware watches this action). */
+    setProsodyEnabled: (s, a: PayloadAction<{ bookId: string; value: boolean }>) => {
+      s.prosodyEnabled[a.payload.bookId] = a.payload.value;
     },
 
     /* Fold the draft into `saved[bookId]` atomically. This is the action the
@@ -162,10 +162,12 @@ export const selectEffectiveMeta =
 export const selectIsDirty = (s: RootState): boolean =>
   s.bookMeta.draft != null && Object.keys(s.bookMeta.draft).length > 0;
 
-/** fs-57 — per-book live-instruct flag. Returns false for any book that
-    has not been hydrated yet. */
-export const selectLiveInstruct =
+/** fs-65 Phase 3 — per-book prosody annotation intent flag.
+    Returns undefined for any book that has not been hydrated yet or where
+    the flag was absent on disk. The Task-13 trigger gate is
+    `prosodyEnabled !== false` (absent ⇒ on). */
+export const selectProsodyEnabled =
   (bookId: string | null) =>
-  (s: RootState): boolean =>
-    bookId != null ? (s.bookMeta.liveInstruct[bookId] ?? false) : false;
+  (s: RootState): boolean | undefined =>
+    bookId != null ? s.bookMeta.prosodyEnabled[bookId] : undefined;
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -59,6 +59,7 @@ import { configSlice } from './config-slice';
 import { tourSlice } from './tour-slice';
 import { continueListeningSlice } from './continue-listening-slice';
 import { scriptReviewSlice } from './script-review-slice';
+import { prosodySlice } from './prosody-slice';
 import { persistenceMiddleware } from './persistence-middleware';
 import { generationStreamMiddleware } from './generation-stream-middleware';
 import { analysisStreamMiddleware } from './analysis-stream-middleware';
@@ -203,6 +204,7 @@ export const store = configureStore({
     tour: tourSlice.reducer,
     continueListening: continueListeningSlice.reducer,
     scriptReview: scriptReviewSlice.reducer,
+    prosody: prosodySlice.reducer,
   },
   middleware: (getDefault) =>
     getDefault({

--- a/src/store/prosody-autotrigger.test.tsx
+++ b/src/store/prosody-autotrigger.test.tsx
@@ -42,6 +42,7 @@ import { listenProgressSlice } from './listen-progress-slice';
 import { settingsSlice } from './settings-slice';
 import { continueListeningSlice } from './continue-listening-slice';
 import { notificationsSlice } from './notifications-slice';
+import { prosodySlice } from './prosody-slice';
 import type { LibraryBook } from '../lib/types';
 
 /* ── Module mocks ──────────────────────────────────────────────────────── */
@@ -138,6 +139,7 @@ function makeStore() {
       settings: settingsSlice.reducer,
       continueListening: continueListeningSlice.reducer,
       notifications: notificationsSlice.reducer,
+      prosody: prosodySlice.reducer,
     },
   });
 }
@@ -265,7 +267,10 @@ describe('Layout — prosody auto-trigger (Task 13 / fs-65 Phase 3)', () => {
 
     await waitFor(() => {
       expect(runProsodyPassesMock).toHaveBeenCalledTimes(1);
-      expect(runProsodyPassesMock).toHaveBeenCalledWith('b1', { dispatch: store.dispatch });
+      const [calledId, calledOpts] = runProsodyPassesMock.mock.calls[0] as [string, Record<string, unknown>];
+      expect(calledId).toBe('b1');
+      expect(calledOpts.dispatch).toBe(store.dispatch);
+      expect(typeof calledOpts.onProgress).toBe('function');
     });
   });
 
@@ -293,7 +298,10 @@ describe('Layout — prosody auto-trigger (Task 13 / fs-65 Phase 3)', () => {
     });
 
     await waitFor(() => {
-      expect(runProsodyPassesMock).toHaveBeenCalledWith('b2', { dispatch: store.dispatch });
+      expect(runProsodyPassesMock).toHaveBeenCalledTimes(1);
+      const [calledId, calledOpts] = runProsodyPassesMock.mock.calls[0] as [string, Record<string, unknown>];
+      expect(calledId).toBe('b2');
+      expect(calledOpts.dispatch).toBe(store.dispatch);
     });
   });
 
@@ -544,7 +552,9 @@ describe('Layout — prosody auto-trigger (Task 13 / fs-65 Phase 3)', () => {
     });
 
     const [_bookId, opts] = runProsodyPassesMock.mock.calls[0] as [string, Record<string, unknown>];
-    expect(Object.keys(opts)).toEqual(['dispatch']);
+    /* Task 14: onProgress is now passed for the global prosody pill. */
+    expect(Object.keys(opts).sort()).toEqual(['dispatch', 'onProgress'].sort());
     expect(opts.signal).toBeUndefined();
+    expect(typeof opts.onProgress).toBe('function');
   });
 });

--- a/src/store/prosody-autotrigger.test.tsx
+++ b/src/store/prosody-autotrigger.test.tsx
@@ -1,0 +1,542 @@
+/* Task 13 (fs-65 Phase 3) — eager prosody auto-trigger keyed on library status.
+
+   Tests drive the useEffect in layout.tsx by rendering <Layout> with a
+   controlled store and dispatching library.books state changes.
+
+   TDD contracts (per the plan's Task 13 step 1):
+   1. A book appearing as cast_pending AFTER the seeded first render fires
+      runProsodyPasses exactly once.
+   2. A book already complete ON the first render is seeded (considered) and
+      never fires (no backlog auto-spend).
+   3. A background book (no active stage referencing it) transitioning fires.
+   4. getBookState → {prosodyEnabled:false} → no runProsodyPasses (authoritative
+      opt-out, ignores store selector).
+   5. getBookState → {prosodyAnnotated:true} → no-op (watermark respected).
+   6. Two books transitioning → each fires once (dedup by considered ref).
+   7. {failed:1} → no putBookState + book is re-eligible (deleted from considered).
+   8. {failed:0} → putBookState writes prosodyAnnotated:true watermark.
+   9. A rejected runProsodyPasses removes the book from considered (retry-safe). */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+import { uiSlice } from './ui-slice';
+import { castSlice } from './cast-slice';
+import { chaptersSlice } from './chapters-slice';
+import { revisionsSlice } from './revisions-slice';
+import { manuscriptSlice } from './manuscript-slice';
+import { librarySlice } from './library-slice';
+import { voicesSlice } from './voices-slice';
+import { changeLogSlice } from './change-log-slice';
+import { accountSlice } from './account-slice';
+import { bookMetaSlice } from './book-meta-slice';
+import { exportsSlice } from './exports-slice';
+import { analysisSlice } from './analysis-slice';
+import { castDesignSlice } from './cast-design-slice';
+import { queueSlice } from './queue-slice';
+import { tourSlice } from './tour-slice';
+import { listenProgressSlice } from './listen-progress-slice';
+import { settingsSlice } from './settings-slice';
+import { continueListeningSlice } from './continue-listening-slice';
+import { notificationsSlice } from './notifications-slice';
+import type { LibraryBook } from '../lib/types';
+
+/* ── Module mocks ──────────────────────────────────────────────────────── */
+
+const runProsodyPassesMock = vi.fn();
+vi.mock('./prosody-thunk', () => ({
+  runProsodyPasses: (...args: unknown[]) => runProsodyPassesMock(...args),
+}));
+
+const getBookStateMock = vi.fn();
+const putBookStateMock = vi.fn();
+
+vi.mock('../lib/api', () => ({
+  api: {
+    /* Library + base infra */
+    getLibrary: vi.fn(async () => ({ books: [] })),
+    getVoices: vi.fn(async () => ({ voices: [], dropped: [] })),
+    getBaseVoices: vi.fn(async () => ({ voices: [] })),
+    getUserSettings: vi.fn(async () => ({})),
+    getBookState: (...args: unknown[]) => getBookStateMock(...args),
+    putBookState: (...args: unknown[]) => putBookStateMock(...args),
+    getAnalysisState: vi.fn(async () => null),
+    getActiveAnalyses: vi.fn(async () => ({ snapshots: [] })),
+    pollRevisions: vi.fn(async () => ({ pending: [], drift: [] })),
+    pollRevisionsBulk: vi.fn(async () => ({ byBookId: {} })),
+    getSidecarHealth: vi.fn(async () => ({ status: 'unreachable', url: '(test)' })),
+    getGpuQueueState: vi.fn(async () => ({ depth: 0, inFlight: 0, max: 1 })),
+    matchVoices: vi.fn(async () => ({ matches: [] })),
+    getSeriesRoster: vi.fn(async () => ({ characters: [] })),
+    getSetupReadiness: () =>
+      Promise.resolve({
+        ready: true,
+        completedAt: '2026-06-12T00:00:00.000Z',
+        blockers: { sidecar: 'pass', ffmpeg: 'pass', tts: 'pass', analyzer: 'pass' },
+        info: { gpu: 'cuda · 1.2 / 8.0 GB reserved' },
+      }),
+    getTourStatus: vi.fn(async () => ({ completedAt: null })),
+    getChapterAudio: vi.fn(async () => ({
+      url: '/api/books/b1/chapters/1/audio.mp3',
+      durationSec: 600,
+      peaks: [],
+      sampleRate: 44100,
+      segments: [],
+    })),
+    getListenProgress: vi.fn(async () => null),
+    putListenProgress: vi.fn(async () => ({
+      chapterId: 1,
+      currentSec: 0,
+      updatedAt: new Date().toISOString(),
+    })),
+    putListenStats: vi.fn(async () => ({})),
+    setShelfStatus: vi.fn(async () => ({
+      chapterId: 1,
+      currentSec: 0,
+      updatedAt: new Date().toISOString(),
+    })),
+  },
+  AnalysisError: class extends Error {},
+  ExportIncompleteError: class extends Error {
+    missing: string[] = [];
+  },
+}));
+
+/* Route-prefetch stubs — avoid post-teardown EnvironmentTeardownError. */
+vi.mock('../routes/prefetch', () => ({
+  importGenerationView: vi.fn(() => Promise.resolve({})),
+  importUploadView: vi.fn(() => Promise.resolve({})),
+}));
+
+import { Layout } from '../components/layout';
+import { uiActions } from './ui-slice';
+
+/* ── Store factory ─────────────────────────────────────────────────────── */
+
+function makeStore() {
+  return configureStore({
+    reducer: {
+      ui: uiSlice.reducer,
+      account: accountSlice.reducer,
+      cast: castSlice.reducer,
+      chapters: chaptersSlice.reducer,
+      revisions: revisionsSlice.reducer,
+      manuscript: manuscriptSlice.reducer,
+      library: librarySlice.reducer,
+      voices: voicesSlice.reducer,
+      changeLog: changeLogSlice.reducer,
+      bookMeta: bookMetaSlice.reducer,
+      exports: exportsSlice.reducer,
+      analysis: analysisSlice.reducer,
+      castDesign: castDesignSlice.reducer,
+      queue: queueSlice.reducer,
+      tour: tourSlice.reducer,
+      listenProgress: listenProgressSlice.reducer,
+      settings: settingsSlice.reducer,
+      continueListening: continueListeningSlice.reducer,
+      notifications: notificationsSlice.reducer,
+    },
+  });
+}
+
+/* ── LibraryBook builder ────────────────────────────────────────────────── */
+
+function makeBook(
+  bookId: string,
+  status: LibraryBook['status'] = 'cast_pending',
+): LibraryBook {
+  return {
+    bookId,
+    title: `Book ${bookId}`,
+    author: 'Test Author',
+    series: 'Standalones',
+    seriesPosition: null,
+    isStandalone: true,
+    status,
+    chapterCount: 3,
+    completedChapters: 0,
+    characterCount: 2,
+    voiceCount: 1,
+    lastWorkedOn: '2026-06-25',
+    coverGradient: ['#000', '#fff'],
+    tags: [],
+  };
+}
+
+/* Minimal BookStateResponse-shaped payload for getBookState — not opting out
+   and not yet annotated by default. */
+function defaultStateResponse(bookId: string) {
+  return {
+    state: {
+      bookId,
+      manuscriptId: `mns_${bookId}`,
+      title: `Book ${bookId}`,
+      author: 'Test Author',
+      series: 'Standalones',
+      seriesPosition: null,
+      isStandalone: true,
+      manuscriptFile: 'manuscript.txt',
+      castConfirmed: true,
+      chapters: [],
+      coverGradient: ['#000', '#fff'] as [string, string],
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+      prosodyEnabled: undefined,
+      prosodyAnnotated: undefined,
+    },
+    cast: null,
+    manuscript: null,
+    manuscriptEdits: null,
+    revisions: null,
+    completedSlugs: [],
+    chapterCharacters: {},
+    changeLog: null,
+  };
+}
+
+/* ── Render helper ─────────────────────────────────────────────────────── */
+
+function renderLayout(store: ReturnType<typeof makeStore>) {
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/books/b1/cast']}>
+        <Routes>
+          <Route path="/books/:bookId/cast" element={<Layout />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+/* ── Tests ─────────────────────────────────────────────────────────────── */
+
+describe('Layout — prosody auto-trigger (Task 13 / fs-65 Phase 3)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    /* Default: getBookState returns a non-opted-out, non-annotated state. */
+    getBookStateMock.mockResolvedValue(defaultStateResponse('b1'));
+    /* Default: runProsodyPasses succeeds with no failures. */
+    runProsodyPassesMock.mockResolvedValue({ totalAnnotations: 0, totalChapters: 0, failed: 0 });
+    putBookStateMock.mockResolvedValue({});
+  });
+
+  // ── Test 2: seed-on-mount — book complete on first render is NOT triggered ──
+
+  it('does NOT fire runProsodyPasses for a book that is already analysis-complete on first render (seed-on-mount)', async () => {
+    const store = makeStore();
+    /* A book that already exists in the library as cast_pending BEFORE Layout
+       mounts should be seeded into `considered` without firing. */
+    store.dispatch(librarySlice.actions.addBook(makeBook('b1', 'cast_pending')));
+    store.dispatch(uiActions.openBook({ id: 'b1', status: 'cast_pending' }));
+
+    renderLayout(store);
+
+    /* Wait enough time for any async effects to settle. */
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(runProsodyPassesMock).not.toHaveBeenCalled();
+  });
+
+  // ── Test 1: book appearing AFTER the seeded first render fires once ──
+
+  it('fires runProsodyPasses once when a book transitions to cast_pending AFTER the seeded first render', async () => {
+    const store = makeStore();
+    store.dispatch(uiActions.openBook({ id: 'b1', status: 'cast_pending' }));
+
+    renderLayout(store);
+
+    /* Wait for the seed pass (first render with empty library). */
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    expect(runProsodyPassesMock).not.toHaveBeenCalled();
+
+    /* Now a book appears in the library — triggers the effect. */
+    await act(async () => {
+      store.dispatch(librarySlice.actions.addBook(makeBook('b1', 'cast_pending')));
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    await waitFor(() => {
+      expect(runProsodyPassesMock).toHaveBeenCalledTimes(1);
+      expect(runProsodyPassesMock).toHaveBeenCalledWith('b1', { dispatch: store.dispatch });
+    });
+  });
+
+  // ── Test 3: background book (not the active stage) fires ──
+
+  it('fires for a background book even when that bookId is not the active UI stage', async () => {
+    const store = makeStore();
+    /* Active book is b1 (on the confirm stage). */
+    store.dispatch(uiActions.openBook({ id: 'b1', status: 'cast_pending' }));
+    /* Set up getBookState to distinguish the two books. */
+    getBookStateMock.mockImplementation((id: string) => Promise.resolve(defaultStateResponse(id)));
+
+    renderLayout(store);
+
+    /* Wait for the seeded first render. */
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    /* A background book (b2) transitions to cast_pending.
+       It is NOT the active stage book (b1). */
+    await act(async () => {
+      store.dispatch(librarySlice.actions.addBook(makeBook('b2', 'cast_pending')));
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    await waitFor(() => {
+      expect(runProsodyPassesMock).toHaveBeenCalledWith('b2', { dispatch: store.dispatch });
+    });
+  });
+
+  // ── Test 4: getBookState → prosodyEnabled:false → no run ──
+
+  it('skips runProsodyPasses when getBookState returns prosodyEnabled:false (authoritative opt-out)', async () => {
+    const store = makeStore();
+    store.dispatch(uiActions.openBook({ id: 'b1', status: 'cast_pending' }));
+    getBookStateMock.mockResolvedValue({
+      ...defaultStateResponse('b1'),
+      state: { ...defaultStateResponse('b1').state, prosodyEnabled: false },
+    });
+
+    renderLayout(store);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    await act(async () => {
+      store.dispatch(librarySlice.actions.addBook(makeBook('b1', 'cast_pending')));
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    /* getBookState is called but prosodyEnabled:false → no pass. */
+    await waitFor(() => {
+      expect(getBookStateMock).toHaveBeenCalledWith('b1');
+    });
+    expect(runProsodyPassesMock).not.toHaveBeenCalled();
+  });
+
+  // ── Test 5: getBookState → prosodyAnnotated:true → no run (watermark) ──
+
+  it('skips runProsodyPasses when getBookState returns prosodyAnnotated:true (watermark)', async () => {
+    const store = makeStore();
+    store.dispatch(uiActions.openBook({ id: 'b1', status: 'cast_pending' }));
+    getBookStateMock.mockResolvedValue({
+      ...defaultStateResponse('b1'),
+      state: { ...defaultStateResponse('b1').state, prosodyAnnotated: true },
+    });
+
+    renderLayout(store);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    await act(async () => {
+      store.dispatch(librarySlice.actions.addBook(makeBook('b1', 'cast_pending')));
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    await waitFor(() => {
+      expect(getBookStateMock).toHaveBeenCalledWith('b1');
+    });
+    expect(runProsodyPassesMock).not.toHaveBeenCalled();
+  });
+
+  // ── Test 6: two books transitioning → each fires once ──
+
+  it('fires runProsodyPasses once per book when two books transition concurrently', async () => {
+    const store = makeStore();
+    store.dispatch(uiActions.openBook({ id: 'b1', status: 'cast_pending' }));
+    getBookStateMock.mockImplementation((id: string) => Promise.resolve(defaultStateResponse(id)));
+
+    renderLayout(store);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    await act(async () => {
+      store.dispatch(librarySlice.actions.addBook(makeBook('b1', 'cast_pending')));
+      store.dispatch(librarySlice.actions.addBook(makeBook('b2', 'cast_pending')));
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    await waitFor(() => {
+      expect(runProsodyPassesMock).toHaveBeenCalledTimes(2);
+    });
+    const calledIds = runProsodyPassesMock.mock.calls.map((c: unknown[]) => c[0]);
+    expect(calledIds).toContain('b1');
+    expect(calledIds).toContain('b2');
+  });
+
+  // ── Test 7: failed:1 → no putBookState + book re-eligible ──
+
+  it('does NOT write putBookState when failed > 0 and the book is re-eligible on the next transition', async () => {
+    const store = makeStore();
+    store.dispatch(uiActions.openBook({ id: 'b1', status: 'cast_pending' }));
+    runProsodyPassesMock.mockResolvedValueOnce({ totalAnnotations: 5, totalChapters: 2, failed: 1 });
+
+    renderLayout(store);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    await act(async () => {
+      store.dispatch(librarySlice.actions.addBook(makeBook('b1', 'cast_pending')));
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    await waitFor(() => {
+      expect(runProsodyPassesMock).toHaveBeenCalledTimes(1);
+    });
+
+    /* No watermark written because failed > 0. */
+    expect(putBookStateMock).not.toHaveBeenCalled();
+
+    /* Simulate a second appearance: book transitions through a non-complete
+       status and back to complete. This changes completeKey, retriggering
+       the effect. Since the partial run removed b1 from considered, it fires again. */
+    runProsodyPassesMock.mockResolvedValueOnce({ totalAnnotations: 5, totalChapters: 2, failed: 0 });
+
+    await act(async () => {
+      /* Step through not_analysed → cast_pending to change completeKey twice:
+         first removing b1 from completeIds (not_analysed → effect fires, b1 not
+         in completeIds), then re-adding it (cast_pending → b1 back in completeIds,
+         not in considered → fires the second pass). */
+      store.dispatch(librarySlice.actions.addBook(makeBook('b1', 'not_analysed')));
+      await new Promise((r) => setTimeout(r, 10));
+      store.dispatch(librarySlice.actions.addBook(makeBook('b1', 'cast_pending')));
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    await waitFor(() => {
+      expect(runProsodyPassesMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ── Test 8: failed:0 → putBookState writes watermark ──
+
+  it('calls putBookState with prosodyAnnotated:true when failed === 0', async () => {
+    const store = makeStore();
+    store.dispatch(uiActions.openBook({ id: 'b1', status: 'cast_pending' }));
+    runProsodyPassesMock.mockResolvedValue({ totalAnnotations: 10, totalChapters: 3, failed: 0 });
+
+    renderLayout(store);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    await act(async () => {
+      store.dispatch(librarySlice.actions.addBook(makeBook('b1', 'cast_pending')));
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    await waitFor(() => {
+      expect(putBookStateMock).toHaveBeenCalledWith('b1', {
+        slice: 'state',
+        patch: { prosodyAnnotated: true },
+      });
+    });
+  });
+
+  // ── Test 9: rejected runProsodyPasses removes book from considered ──
+
+  it('removes book from considered when runProsodyPasses rejects (retry-safe)', async () => {
+    const store = makeStore();
+    store.dispatch(uiActions.openBook({ id: 'b1', status: 'cast_pending' }));
+    runProsodyPassesMock.mockRejectedValueOnce(new Error('network error'));
+
+    renderLayout(store);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    await act(async () => {
+      store.dispatch(librarySlice.actions.addBook(makeBook('b1', 'cast_pending')));
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    await waitFor(() => {
+      expect(runProsodyPassesMock).toHaveBeenCalledTimes(1);
+    });
+
+    /* No watermark written. */
+    expect(putBookStateMock).not.toHaveBeenCalled();
+
+    /* A subsequent status change should fire again (book was removed from considered).
+       Cycle through a non-complete status to retrigger the effect with a new completeKey. */
+    runProsodyPassesMock.mockResolvedValueOnce({ totalAnnotations: 0, totalChapters: 0, failed: 0 });
+
+    await act(async () => {
+      store.dispatch(librarySlice.actions.addBook(makeBook('b1', 'not_analysed')));
+      await new Promise((r) => setTimeout(r, 10));
+      store.dispatch(librarySlice.actions.addBook(makeBook('b1', 'cast_pending')));
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    await waitFor(() => {
+      expect(runProsodyPassesMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ── Test: 'not_analysed' / 'analysing' / 'unreadable' / 'orphaned' are not considered complete ──
+
+  it('does NOT fire for books with non-complete statuses (not_analysed, analysing, unreadable, orphaned)', async () => {
+    const store = makeStore();
+    store.dispatch(uiActions.openBook({ id: 'b1', status: 'cast_pending' }));
+
+    renderLayout(store);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    for (const status of ['not_analysed', 'analysing', 'unreadable', 'orphaned'] as const) {
+      await act(async () => {
+        store.dispatch(librarySlice.actions.addBook(makeBook('b1', status)));
+        await new Promise((r) => setTimeout(r, 30));
+      });
+    }
+
+    expect(runProsodyPassesMock).not.toHaveBeenCalled();
+  });
+
+  // ── Test: runProsodyPasses is called with { dispatch } only (no signal) ──
+
+  it('calls runProsodyPasses with { dispatch } only — no signal (detached path)', async () => {
+    const store = makeStore();
+    store.dispatch(uiActions.openBook({ id: 'b1', status: 'cast_pending' }));
+
+    renderLayout(store);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    await act(async () => {
+      store.dispatch(librarySlice.actions.addBook(makeBook('b1', 'cast_pending')));
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    await waitFor(() => {
+      expect(runProsodyPassesMock).toHaveBeenCalledTimes(1);
+    });
+
+    const [_bookId, opts] = runProsodyPassesMock.mock.calls[0] as [string, Record<string, unknown>];
+    expect(Object.keys(opts)).toEqual(['dispatch']);
+    expect(opts.signal).toBeUndefined();
+  });
+});

--- a/src/store/prosody-autotrigger.test.tsx
+++ b/src/store/prosody-autotrigger.test.tsx
@@ -423,6 +423,14 @@ describe('Layout — prosody auto-trigger (Task 13 / fs-65 Phase 3)', () => {
     await waitFor(() => {
       expect(runProsodyPassesMock).toHaveBeenCalledTimes(2);
     });
+
+    /* On the successful second pass (failed:0), the watermark IS written. */
+    await waitFor(() => {
+      expect(putBookStateMock).toHaveBeenCalledWith('b1', {
+        slice: 'state',
+        patch: { prosodyAnnotated: true },
+      });
+    });
   });
 
   // ── Test 8: failed:0 → putBookState writes watermark ──

--- a/src/store/prosody-slice.test.ts
+++ b/src/store/prosody-slice.test.ts
@@ -1,0 +1,81 @@
+/* Task 14 (fs-65 Phase 3) — prosody-slice unit tests.
+   TDD: set/update/clear actions; confirms TRANSIENT invariant (not in
+   persistence-middleware or broadcast-middleware). */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { prosodySlice, prosodyActions } from './prosody-slice';
+
+describe('prosodySlice — activeStream reducers', () => {
+  it('starts with activeStream: null', () => {
+    const state = prosodySlice.reducer(undefined, { type: 'noop' });
+    expect(state.activeStream).toBeNull();
+  });
+
+  it('setActive sets the stream with progress and label', () => {
+    const state = prosodySlice.reducer(
+      undefined,
+      prosodyActions.setActive({ bookId: 'b1', progress: 0, label: 'Phase 3 — Detecting prosody' }),
+    );
+    expect(state.activeStream).toEqual({
+      bookId: 'b1',
+      progress: 0,
+      label: 'Phase 3 — Detecting prosody',
+    });
+  });
+
+  it('updateProgress updates progress for the matching bookId (fraction 0..1 → rounded 0..100)', () => {
+    const s1 = prosodySlice.reducer(
+      undefined,
+      prosodyActions.setActive({ bookId: 'b1', progress: 0, label: 'Phase 3 — Detecting prosody' }),
+    );
+    const s2 = prosodySlice.reducer(s1, prosodyActions.updateProgress({ bookId: 'b1', progress: 0.42 }));
+    expect(s2.activeStream?.progress).toBe(42);
+  });
+
+  it('updateProgress is a no-op when bookId does not match', () => {
+    const s1 = prosodySlice.reducer(
+      undefined,
+      prosodyActions.setActive({ bookId: 'b1', progress: 0, label: 'Phase 3 — Detecting prosody' }),
+    );
+    const s2 = prosodySlice.reducer(s1, prosodyActions.updateProgress({ bookId: 'b2', progress: 0.9 }));
+    expect(s2.activeStream?.progress).toBe(0);
+  });
+
+  it('clear sets activeStream to null', () => {
+    const s1 = prosodySlice.reducer(
+      undefined,
+      prosodyActions.setActive({ bookId: 'b1', progress: 50, label: 'Phase 3 — Detecting prosody' }),
+    );
+    const s2 = prosodySlice.reducer(s1, prosodyActions.clear());
+    expect(s2.activeStream).toBeNull();
+  });
+
+  it('updateProgress rounds the fraction to the nearest integer percent', () => {
+    const s1 = prosodySlice.reducer(
+      undefined,
+      prosodyActions.setActive({ bookId: 'b1', progress: 0, label: 'Phase 3' }),
+    );
+    const s2 = prosodySlice.reducer(s1, prosodyActions.updateProgress({ bookId: 'b1', progress: 0.999 }));
+    expect(s2.activeStream?.progress).toBe(100);
+    const s3 = prosodySlice.reducer(s1, prosodyActions.updateProgress({ bookId: 'b1', progress: 0.005 }));
+    expect(s3.activeStream?.progress).toBe(1);
+  });
+});
+
+/* Transient invariant: confirm prosody is NOT wired in persistence-middleware
+   or broadcast-middleware by reading their source files directly. */
+describe('prosodySlice — transient invariant (not persisted, not broadcast)', () => {
+  const storeDir = join(__dirname, '.');
+
+  it('prosody-slice is NOT referenced in persistence-middleware', () => {
+    const src = readFileSync(join(storeDir, 'persistence-middleware.ts'), 'utf8');
+    expect(src).not.toContain('prosody');
+  });
+
+  it('prosody-slice is NOT referenced in broadcast-middleware', () => {
+    const src = readFileSync(join(storeDir, 'broadcast-middleware.ts'), 'utf8');
+    expect(src).not.toContain('prosody');
+  });
+});

--- a/src/store/prosody-slice.test.ts
+++ b/src/store/prosody-slice.test.ts
@@ -46,7 +46,7 @@ describe('prosodySlice — activeStream reducers', () => {
   it('clear sets activeStream to null', () => {
     const s1 = prosodySlice.reducer(
       undefined,
-      prosodyActions.setActive({ bookId: 'b1', progress: 50, label: 'Phase 3 — Detecting prosody' }),
+      prosodyActions.setActive({ bookId: 'b1', progress: 0.5, label: 'Phase 3 — Detecting prosody' }),
     );
     const s2 = prosodySlice.reducer(s1, prosodyActions.clear());
     expect(s2.activeStream).toBeNull();

--- a/src/store/prosody-slice.ts
+++ b/src/store/prosody-slice.ts
@@ -1,0 +1,46 @@
+/* Prosody slice — transient UI-only progress state for the two-pass prosody
+   annotation run (Phase 3, fs-65).
+
+   Like `notifications`, this slice is TRANSIENT: UI-only, no persistence,
+   no cross-tab broadcast. Add ONLY the reducer to the store map in index.ts
+   (do NOT add to persistence-middleware or broadcast-middleware).
+
+   `activeStream` is singular — concurrent multi-book shows one active stream.
+   The auto-trigger (Task 13) and the manual DetectEmotionsButton (optional)
+   both drive the pill via the actions below. */
+
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+export interface ProsodyActiveStream {
+  bookId: string;
+  /** 0..100 integer percent. */
+  progress: number;
+  /** Human-readable label shown beside the percent, e.g. "Phase 3 — Detecting prosody". */
+  label: string;
+}
+
+export interface ProsodyState {
+  activeStream: ProsodyActiveStream | null;
+}
+
+const initialState: ProsodyState = { activeStream: null };
+
+export const prosodySlice = createSlice({
+  name: 'prosody',
+  initialState,
+  reducers: {
+    setActive: (s, a: PayloadAction<{ bookId: string; progress: number; label: string }>) => {
+      s.activeStream = { bookId: a.payload.bookId, progress: a.payload.progress, label: a.payload.label };
+    },
+    updateProgress: (s, a: PayloadAction<{ bookId: string; progress: number }>) => {
+      if (s.activeStream && s.activeStream.bookId === a.payload.bookId) {
+        s.activeStream.progress = Math.round(a.payload.progress * 100);
+      }
+    },
+    clear: (s) => {
+      s.activeStream = null;
+    },
+  },
+});
+
+export const prosodyActions = prosodySlice.actions;

--- a/src/store/prosody-slice.ts
+++ b/src/store/prosody-slice.ts
@@ -30,7 +30,7 @@ export const prosodySlice = createSlice({
   initialState,
   reducers: {
     setActive: (s, a: PayloadAction<{ bookId: string; progress: number; label: string }>) => {
-      s.activeStream = { bookId: a.payload.bookId, progress: a.payload.progress, label: a.payload.label };
+      s.activeStream = { bookId: a.payload.bookId, progress: Math.round(a.payload.progress * 100), label: a.payload.label };
     },
     updateProgress: (s, a: PayloadAction<{ bookId: string; progress: number }>) => {
       if (s.activeStream && s.activeStream.bookId === a.payload.bookId) {

--- a/src/store/prosody-thunk.test.ts
+++ b/src/store/prosody-thunk.test.ts
@@ -1,0 +1,233 @@
+/* Task 10 (fs-65 Phase 3) — unit tests for runProsodyPasses thunk.
+
+   TDD contract:
+   - calls api.detectEmotions then api.detectInstruct in order
+   - dispatches applyDetectedEmotions per annotation from pass 1
+   - dispatches applyDetectedInstruct per annotation from pass 2
+   - a chapter-failed event from either pass increments `failed`
+   - resolves (does NOT throw) on partial failure */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- mock api before importing the thunk ---
+vi.mock('../lib/api', () => ({
+  api: {
+    detectEmotions: vi.fn(),
+    detectInstruct: vi.fn(),
+  },
+}));
+
+import { api } from '../lib/api';
+import type { DetectEmotionsOpts, DetectInstructOpts } from '../lib/api';
+import { manuscriptActions } from './manuscript-slice';
+import { runProsodyPasses } from './prosody-thunk';
+
+const EMPTY_EMOTIONS = { totalAnnotations: 0, annotatedChapters: 0 };
+const EMPTY_INSTRUCT = { totalAnnotations: 0, annotatedChapters: 0 };
+
+describe('runProsodyPasses', () => {
+  const bookId = 'book-1';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls detectEmotions then detectInstruct in order', async () => {
+    const callOrder: string[] = [];
+    vi.mocked(api.detectEmotions).mockImplementation(async () => {
+      callOrder.push('emotions');
+      return EMPTY_EMOTIONS;
+    });
+    vi.mocked(api.detectInstruct).mockImplementation(async () => {
+      callOrder.push('instruct');
+      return EMPTY_INSTRUCT;
+    });
+
+    const dispatch = vi.fn();
+    await runProsodyPasses(bookId, { dispatch });
+
+    expect(callOrder).toEqual(['emotions', 'instruct']);
+  });
+
+  it('dispatches applyDetectedEmotions for each emotion annotation', async () => {
+    const emotionAnnotation = { chapterId: 1, annotations: [{ sentenceId: 1, emotion: 'angry' }] };
+    vi.mocked(api.detectEmotions).mockImplementation(
+      async (_bookId: string, opts: DetectEmotionsOpts = {}) => {
+        opts.onAnnotation?.(emotionAnnotation);
+        return { totalAnnotations: 1, annotatedChapters: 1 };
+      },
+    );
+    vi.mocked(api.detectInstruct).mockResolvedValue(EMPTY_INSTRUCT);
+
+    const dispatch = vi.fn();
+    await runProsodyPasses(bookId, { dispatch });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      manuscriptActions.applyDetectedEmotions(emotionAnnotation),
+    );
+  });
+
+  it('dispatches applyDetectedInstruct for each instruct annotation', async () => {
+    const instructAnnotation = {
+      chapterId: 2,
+      annotations: [{ sentenceId: 3, text: 'Ah!', instruct: 'gasp', vocalization: true }],
+    };
+    vi.mocked(api.detectEmotions).mockResolvedValue(EMPTY_EMOTIONS);
+    vi.mocked(api.detectInstruct).mockImplementation(
+      async (_bookId: string, opts: DetectInstructOpts = {}) => {
+        opts.onAnnotation?.(instructAnnotation);
+        return { totalAnnotations: 1, annotatedChapters: 1 };
+      },
+    );
+
+    const dispatch = vi.fn();
+    await runProsodyPasses(bookId, { dispatch });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      manuscriptActions.applyDetectedInstruct(instructAnnotation),
+    );
+  });
+
+  it('increments failed when detectEmotions reports a chapter-failed', async () => {
+    vi.mocked(api.detectEmotions).mockImplementation(
+      async (_bookId: string, opts: DetectEmotionsOpts = {}) => {
+        opts.onChapterFailed?.({ chapterId: 5, message: 'Chapter annotation failed.' });
+        return EMPTY_EMOTIONS;
+      },
+    );
+    vi.mocked(api.detectInstruct).mockResolvedValue(EMPTY_INSTRUCT);
+
+    const dispatch = vi.fn();
+    const result = await runProsodyPasses(bookId, { dispatch });
+
+    expect(result.failed).toBe(1);
+  });
+
+  it('increments failed when detectInstruct reports a chapter-failed', async () => {
+    vi.mocked(api.detectEmotions).mockResolvedValue(EMPTY_EMOTIONS);
+    vi.mocked(api.detectInstruct).mockImplementation(
+      async (_bookId: string, opts: DetectInstructOpts = {}) => {
+        opts.onChapterFailed?.({ chapterId: 3, message: 'Chapter annotation failed.' });
+        return EMPTY_INSTRUCT;
+      },
+    );
+
+    const dispatch = vi.fn();
+    const result = await runProsodyPasses(bookId, { dispatch });
+
+    expect(result.failed).toBe(1);
+  });
+
+  it('sums failed across both passes', async () => {
+    vi.mocked(api.detectEmotions).mockImplementation(
+      async (_bookId: string, opts: DetectEmotionsOpts = {}) => {
+        opts.onChapterFailed?.({ chapterId: 1, message: 'fail' });
+        opts.onChapterFailed?.({ chapterId: 2, message: 'fail' });
+        return EMPTY_EMOTIONS;
+      },
+    );
+    vi.mocked(api.detectInstruct).mockImplementation(
+      async (_bookId: string, opts: DetectInstructOpts = {}) => {
+        opts.onChapterFailed?.({ chapterId: 3, message: 'fail' });
+        return EMPTY_INSTRUCT;
+      },
+    );
+
+    const dispatch = vi.fn();
+    const result = await runProsodyPasses(bookId, { dispatch });
+
+    expect(result.failed).toBe(3);
+  });
+
+  it('resolves (does NOT throw) on partial failure', async () => {
+    vi.mocked(api.detectEmotions).mockImplementation(
+      async (_bookId: string, opts: DetectEmotionsOpts = {}) => {
+        opts.onChapterFailed?.({ chapterId: 1, message: 'fail' });
+        return EMPTY_EMOTIONS;
+      },
+    );
+    vi.mocked(api.detectInstruct).mockImplementation(
+      async (_bookId: string, opts: DetectInstructOpts = {}) => {
+        opts.onChapterFailed?.({ chapterId: 2, message: 'fail' });
+        return EMPTY_INSTRUCT;
+      },
+    );
+
+    const dispatch = vi.fn();
+    await expect(runProsodyPasses(bookId, { dispatch })).resolves.toMatchObject({ failed: 2 });
+  });
+
+  it('returns correct totalAnnotations and totalChapters', async () => {
+    const emo1 = { chapterId: 1, annotations: [{ sentenceId: 1, emotion: 'happy' }] };
+    const emo2 = { chapterId: 1, annotations: [{ sentenceId: 2, emotion: 'sad' }] };
+    const inst1 = { chapterId: 2, annotations: [{ sentenceId: 10, instruct: 'sigh' }] };
+    vi.mocked(api.detectEmotions).mockImplementation(
+      async (_bookId: string, opts: DetectEmotionsOpts = {}) => {
+        opts.onAnnotation?.(emo1);
+        opts.onAnnotation?.(emo2);
+        return { totalAnnotations: 2, annotatedChapters: 1 };
+      },
+    );
+    vi.mocked(api.detectInstruct).mockImplementation(
+      async (_bookId: string, opts: DetectInstructOpts = {}) => {
+        opts.onAnnotation?.(inst1);
+        return { totalAnnotations: 1, annotatedChapters: 2 };
+      },
+    );
+
+    const dispatch = vi.fn();
+    const result = await runProsodyPasses(bookId, { dispatch });
+
+    expect(result.totalAnnotations).toBe(3); // 2 + 1
+    expect(result.totalChapters).toBe(2);    // max(1, 2)
+    expect(result.failed).toBe(0);
+  });
+
+  it('forwards signal to both api calls', async () => {
+    vi.mocked(api.detectEmotions).mockResolvedValue(EMPTY_EMOTIONS);
+    vi.mocked(api.detectInstruct).mockResolvedValue(EMPTY_INSTRUCT);
+
+    const dispatch = vi.fn();
+    const controller = new AbortController();
+    await runProsodyPasses(bookId, { dispatch, signal: controller.signal });
+
+    expect(vi.mocked(api.detectEmotions).mock.calls[0][1]).toMatchObject({
+      signal: controller.signal,
+    });
+    expect(vi.mocked(api.detectInstruct).mock.calls[0][1]).toMatchObject({
+      signal: controller.signal,
+    });
+  });
+
+  it('works without a signal (Task 13 detached path)', async () => {
+    vi.mocked(api.detectEmotions).mockResolvedValue(EMPTY_EMOTIONS);
+    vi.mocked(api.detectInstruct).mockResolvedValue(EMPTY_INSTRUCT);
+
+    const dispatch = vi.fn();
+    // No signal passed — must not throw
+    await expect(runProsodyPasses(bookId, { dispatch })).resolves.toMatchObject({ failed: 0 });
+  });
+
+  it('calls onProgress with 0–1 fraction during both passes', async () => {
+    vi.mocked(api.detectEmotions).mockImplementation(
+      async (_bookId: string, opts: DetectEmotionsOpts = {}) => {
+        opts.onPhase?.({ progress: 0.5 });
+        return EMPTY_EMOTIONS;
+      },
+    );
+    vi.mocked(api.detectInstruct).mockImplementation(
+      async (_bookId: string, opts: DetectInstructOpts = {}) => {
+        opts.onPhase?.({ progress: 1.0 });
+        return EMPTY_INSTRUCT;
+      },
+    );
+
+    const dispatch = vi.fn();
+    const progressValues: number[] = [];
+    await runProsodyPasses(bookId, { dispatch, onProgress: (f) => progressValues.push(f) });
+
+    // emotions at 0.5 progress → fraction 0.25 (0.5 * 0.5)
+    // instruct at 1.0 progress → fraction 1.0 (0.5 + 1.0 * 0.5)
+    expect(progressValues).toEqual([0.25, 1.0]);
+  });
+});

--- a/src/store/prosody-thunk.test.ts
+++ b/src/store/prosody-thunk.test.ts
@@ -230,4 +230,105 @@ describe('runProsodyPasses', () => {
     // instruct at 1.0 progress → fraction 1.0 (0.5 + 1.0 * 0.5)
     expect(progressValues).toEqual([0.25, 1.0]);
   });
+
+  it('forwards onPhase label strings to onStatus', async () => {
+    vi.mocked(api.detectEmotions).mockImplementation(
+      async (_bookId: string, opts: DetectEmotionsOpts = {}) => {
+        opts.onPhase?.({ progress: 0.5, label: 'Detecting emotions — chapter 3' });
+        return EMPTY_EMOTIONS;
+      },
+    );
+    vi.mocked(api.detectInstruct).mockImplementation(
+      async (_bookId: string, opts: DetectInstructOpts = {}) => {
+        opts.onPhase?.({ progress: 1.0, label: 'Instruct — chapter 5' });
+        return EMPTY_INSTRUCT;
+      },
+    );
+
+    const dispatch = vi.fn();
+    const statusValues: string[] = [];
+    await runProsodyPasses(bookId, { dispatch, onStatus: (s) => statusValues.push(s) });
+
+    // Pass 1 label, then inter-pass message, then pass 2 label
+    expect(statusValues).toEqual([
+      'Detecting emotions — chapter 3',
+      'Adding natural reactions…',
+      'Instruct — chapter 5',
+    ]);
+  });
+
+  it('does NOT call onStatus for onPhase events without a label', async () => {
+    vi.mocked(api.detectEmotions).mockImplementation(
+      async (_bookId: string, opts: DetectEmotionsOpts = {}) => {
+        opts.onPhase?.({ progress: 0.5 }); // no label
+        return EMPTY_EMOTIONS;
+      },
+    );
+    vi.mocked(api.detectInstruct).mockResolvedValue(EMPTY_INSTRUCT);
+
+    const dispatch = vi.fn();
+    const statusValues: string[] = [];
+    await runProsodyPasses(bookId, { dispatch, onStatus: (s) => statusValues.push(s) });
+
+    // Only the inter-pass message fires (no label from pass 1)
+    expect(statusValues).toEqual(['Adding natural reactions…']);
+  });
+
+  it('always calls onStatus with the inter-pass message between pass 1 and pass 2', async () => {
+    vi.mocked(api.detectEmotions).mockResolvedValue(EMPTY_EMOTIONS);
+    vi.mocked(api.detectInstruct).mockResolvedValue(EMPTY_INSTRUCT);
+
+    const dispatch = vi.fn();
+    const statusValues: string[] = [];
+    await runProsodyPasses(bookId, { dispatch, onStatus: (s) => statusValues.push(s) });
+
+    expect(statusValues).toEqual(['Adding natural reactions…']);
+  });
+
+  it('forwards onThrottle from pass 1 to the opts onThrottle callback', async () => {
+    vi.mocked(api.detectEmotions).mockImplementation(
+      async (_bookId: string, opts: DetectEmotionsOpts = {}) => {
+        opts.onThrottle?.({ chapterId: 2, waitMs: 2000, reason: 'rate-limit' });
+        return EMPTY_EMOTIONS;
+      },
+    );
+    vi.mocked(api.detectInstruct).mockResolvedValue(EMPTY_INSTRUCT);
+
+    const dispatch = vi.fn();
+    const onThrottle = vi.fn();
+    await runProsodyPasses(bookId, { dispatch, onThrottle });
+
+    expect(onThrottle).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards onThrottle from pass 2 to the opts onThrottle callback', async () => {
+    vi.mocked(api.detectEmotions).mockResolvedValue(EMPTY_EMOTIONS);
+    vi.mocked(api.detectInstruct).mockImplementation(
+      async (_bookId: string, opts: DetectInstructOpts = {}) => {
+        opts.onThrottle?.({ chapterId: 4, waitMs: 1500, reason: 'rate-limit' });
+        return EMPTY_INSTRUCT;
+      },
+    );
+
+    const dispatch = vi.fn();
+    const onThrottle = vi.fn();
+    await runProsodyPasses(bookId, { dispatch, onThrottle });
+
+    expect(onThrottle).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when onStatus and onThrottle are absent (Task 13 path)', async () => {
+    vi.mocked(api.detectEmotions).mockImplementation(
+      async (_bookId: string, opts: DetectEmotionsOpts = {}) => {
+        opts.onPhase?.({ progress: 0.5, label: 'Detecting emotions — chapter 1' });
+        opts.onThrottle?.({ chapterId: 1, waitMs: 1000, reason: 'rate-limit' });
+        return EMPTY_EMOTIONS;
+      },
+    );
+    vi.mocked(api.detectInstruct).mockResolvedValue(EMPTY_INSTRUCT);
+
+    const dispatch = vi.fn();
+    // Neither onStatus nor onThrottle passed — must not throw
+    await expect(runProsodyPasses(bookId, { dispatch })).resolves.toMatchObject({ failed: 0 });
+  });
 });

--- a/src/store/prosody-thunk.ts
+++ b/src/store/prosody-thunk.ts
@@ -1,0 +1,78 @@
+/* Task 10 (fs-65 Phase 3) — reusable two-pass prosody annotation thunk.
+
+   Extracted from DetectEmotionsButton.run so both the manual trigger
+   (detect-emotions-button.tsx) and the eager auto-trigger (Task 13,
+   layout.tsx) share the same implementation.
+
+   Pass 1: api.detectEmotions — per-quote emotion backfill (fill-only-empty).
+   Pass 2: api.detectInstruct — natural reactions / delivery instructions.
+
+   Progress is reported on a 0–100% scale: emotions occupies 0–50%,
+   instruct occupies 50–100%.
+
+   Returns a summary that is NEVER thrown away on partial failures.
+   `failed` is load-bearing: Task 13 only writes the prosodyAnnotated
+   watermark when failed === 0. */
+
+import { manuscriptActions } from './manuscript-slice';
+import { api } from '../lib/api';
+import type { AppDispatch } from './index';
+
+export interface RunProsodyPassesOpts {
+  dispatch: AppDispatch;
+  /** AbortSignal for cooperative cancellation (optional — Task 13 passes none). */
+  signal?: AbortSignal;
+  /** Called with 0–1 fraction as the two passes progress. */
+  onProgress?: (fraction: number) => void;
+}
+
+export interface RunProsodyPassesResult {
+  totalAnnotations: number;
+  totalChapters: number;
+  /** Number of chapters that failed (emitted a chapter-failed event). */
+  failed: number;
+}
+
+/**
+ * Run the two prosody annotation passes over the whole book.
+ * Always resolves — never throws — so a partial failure is captured in
+ * `failed` rather than propagating as an exception.
+ */
+export async function runProsodyPasses(
+  bookId: string,
+  { dispatch, signal, onProgress }: RunProsodyPassesOpts,
+): Promise<RunProsodyPassesResult> {
+  let failed = 0;
+
+  // Pass 1: emotion backfill — progress 0–50%
+  const emotionResult = await api.detectEmotions(bookId, {
+    signal,
+    onPhase: (e) => {
+      onProgress?.(e.progress * 0.5);
+    },
+    onAnnotation: (e) => dispatch(manuscriptActions.applyDetectedEmotions(e)),
+    onChapterFailed: () => {
+      failed++;
+    },
+  });
+
+  // Pass 2: instruct/vocalization — progress 50–100%
+  const instructResult = await api.detectInstruct(bookId, {
+    signal,
+    onPhase: (e) => {
+      onProgress?.(0.5 + e.progress * 0.5);
+    },
+    onAnnotation: (e) => dispatch(manuscriptActions.applyDetectedInstruct(e)),
+    onChapterFailed: () => {
+      failed++;
+    },
+  });
+
+  const totalAnnotations = emotionResult.totalAnnotations + instructResult.totalAnnotations;
+  const totalChapters = Math.max(
+    emotionResult.annotatedChapters,
+    instructResult.annotatedChapters,
+  );
+
+  return { totalAnnotations, totalChapters, failed };
+}

--- a/src/store/prosody-thunk.ts
+++ b/src/store/prosody-thunk.ts
@@ -24,6 +24,13 @@ export interface RunProsodyPassesOpts {
   signal?: AbortSignal;
   /** Called with 0–1 fraction as the two passes progress. */
   onProgress?: (fraction: number) => void;
+  /** Called with a human-readable status label from each pass's onPhase events,
+   *  and with the inter-pass "Adding natural reactions…" message. Optional —
+   *  Task 13 does not pass this. */
+  onStatus?: (label: string) => void;
+  /** Called when either pass emits an onThrottle event (rate-limit wait). Optional —
+   *  Task 13 does not pass this. */
+  onThrottle?: () => void;
 }
 
 export interface RunProsodyPassesResult {
@@ -40,7 +47,7 @@ export interface RunProsodyPassesResult {
  */
 export async function runProsodyPasses(
   bookId: string,
-  { dispatch, signal, onProgress }: RunProsodyPassesOpts,
+  { dispatch, signal, onProgress, onStatus, onThrottle }: RunProsodyPassesOpts,
 ): Promise<RunProsodyPassesResult> {
   let failed = 0;
 
@@ -49,19 +56,26 @@ export async function runProsodyPasses(
     signal,
     onPhase: (e) => {
       onProgress?.(e.progress * 0.5);
+      if (e.label) onStatus?.(e.label);
     },
+    onThrottle: () => onThrottle?.(),
     onAnnotation: (e) => dispatch(manuscriptActions.applyDetectedEmotions(e)),
     onChapterFailed: () => {
       failed++;
     },
   });
 
+  // Inter-pass status label — mirrors the old button behaviour.
+  onStatus?.('Adding natural reactions…');
+
   // Pass 2: instruct/vocalization — progress 50–100%
   const instructResult = await api.detectInstruct(bookId, {
     signal,
     onPhase: (e) => {
       onProgress?.(0.5 + e.progress * 0.5);
+      if (e.label) onStatus?.(e.label);
     },
+    onThrottle: () => onThrottle?.(),
     onAnnotation: (e) => dispatch(manuscriptActions.applyDetectedInstruct(e)),
     onChapterFailed: () => {
       failed++;

--- a/src/views/analysing-prosody-toggle.test.tsx
+++ b/src/views/analysing-prosody-toggle.test.tsx
@@ -1,0 +1,171 @@
+// Task 12 — fs-65 Phase 3: analysis-form "Expressive directions" toggle (on by default)
+// Pairs with: docs/superpowers/plans/2026-06-25-phase3-prosody-and-scriptreview-chunking.md § Task 12
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import { uiSlice } from '../store/ui-slice';
+import { castSlice } from '../store/cast-slice';
+import { analysisSlice } from '../store/analysis-slice';
+import { accountSlice } from '../store/account-slice';
+import { bookMetaSlice, bookMetaActions } from '../store/book-meta-slice';
+import { AnalysingView } from './analysing';
+import type { BookStateResponse } from '../lib/types';
+
+/* ── api mock ────────────────────────────────────────────────────────────── */
+
+const putBookStateSpy = vi.fn();
+const getOllamaHealthSpy = vi.fn();
+const getSidecarHealthSpy = vi.fn();
+
+let getBookStateImpl: ((bookId: string) => Promise<BookStateResponse | null>) | undefined;
+
+vi.mock('../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../lib/api')>('../lib/api');
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      analyseManuscript: () => new Promise(() => {}),
+      runAnalysisForChapters: () => new Promise(() => {}),
+      getBookState: (bookId: string) =>
+        getBookStateImpl ? getBookStateImpl(bookId) : Promise.resolve(null),
+      getDroppedQuotes: () => Promise.resolve({ manuscriptId: 'm1', batches: [] }),
+      getOllamaHealth: () => getOllamaHealthSpy(),
+      getSidecarHealth: () => getSidecarHealthSpy(),
+      loadAnalyzer: () => Promise.resolve({ status: 'ready' as const }),
+      unloadAnalyzer: () => Promise.resolve({ status: 'unloaded' as const }),
+      loadSidecar: () => Promise.resolve({ status: 'ready' as const }),
+      unloadSidecar: () => Promise.resolve({ status: 'idle' as const }),
+      putBookState: (...args: unknown[]) => putBookStateSpy(...args),
+    },
+  };
+});
+
+/* ── helpers ─────────────────────────────────────────────────────────────── */
+
+function makeStore(prosodyEnabled?: boolean) {
+  const store = configureStore({
+    reducer: {
+      ui: uiSlice.reducer,
+      cast: castSlice.reducer,
+      analysis: analysisSlice.reducer,
+      account: accountSlice.reducer,
+      bookMeta: bookMetaSlice.reducer,
+    },
+  });
+  if (prosodyEnabled !== undefined) {
+    store.dispatch(
+      bookMetaActions.setProsodyEnabled({ bookId: 'book-1', value: prosodyEnabled }),
+    );
+  }
+  return store;
+}
+
+function renderView(opts: { bookId?: string | null; prosodyEnabled?: boolean } = {}) {
+  const { bookId = 'book-1', prosodyEnabled } = opts;
+  const store = makeStore(prosodyEnabled);
+  const result = render(
+    <Provider store={store}>
+      <AnalysingView
+        manuscriptId="m1"
+        bookId={bookId}
+        title="The Coalfall Commission"
+        wordCount={2440}
+        onComplete={() => {}}
+      />
+    </Provider>,
+  );
+  return { store, ...result };
+}
+
+beforeEach(() => {
+  putBookStateSpy.mockReset().mockResolvedValue(undefined);
+  getBookStateImpl = undefined;
+  getSidecarHealthSpy
+    .mockReset()
+    .mockResolvedValue({ status: 'reachable', url: '(test)', modelLoaded: false });
+  getOllamaHealthSpy.mockReset().mockResolvedValue({
+    status: 'reachable',
+    url: '(test)',
+    models: ['qwen3.5:4b'],
+    expectedModel: 'qwen3.5:4b',
+    modelPulled: true,
+    resident: ['qwen3.5:4b'],
+    modelResident: true,
+  });
+});
+
+/* ── tests ───────────────────────────────────────────────────────────────── */
+
+describe('Expressive directions toggle — analysing form (Task 12 / fs-65)', () => {
+  it('renders CHECKED by default when no stored value (eager default)', async () => {
+    renderView(); // no prosodyEnabled override → store has undefined
+    const toggle = await screen.findByRole('checkbox', { name: /expressive directions/i });
+    expect(toggle).toBeChecked();
+  });
+
+  it('renders CHECKED when stored value is true', async () => {
+    renderView({ prosodyEnabled: true });
+    const toggle = await screen.findByRole('checkbox', { name: /expressive directions/i });
+    expect(toggle).toBeChecked();
+  });
+
+  it('renders UNCHECKED when stored value is false', async () => {
+    renderView({ prosodyEnabled: false });
+    const toggle = await screen.findByRole('checkbox', { name: /expressive directions/i });
+    expect(toggle).not.toBeChecked();
+  });
+
+  it('unchecking dispatches setProsodyEnabled({value:false}) and issues PUT with false', async () => {
+    const { store } = renderView(); // starts checked (undefined → eager)
+    const toggle = await screen.findByRole('checkbox', { name: /expressive directions/i });
+
+    fireEvent.click(toggle);
+
+    // Redux store updated
+    const state = store.getState().bookMeta.prosodyEnabled['book-1'];
+    expect(state).toBe(false);
+
+    // Durable PUT issued with prosodyEnabled: false
+    await waitFor(() => {
+      expect(putBookStateSpy).toHaveBeenCalledWith('book-1', {
+        slice: 'state',
+        patch: { prosodyEnabled: false },
+      });
+    });
+  });
+
+  it('re-checking dispatches setProsodyEnabled({value:true}) and issues PUT with true', async () => {
+    renderView({ prosodyEnabled: false }); // start unchecked
+    const toggle = await screen.findByRole('checkbox', { name: /expressive directions/i });
+    expect(toggle).not.toBeChecked();
+
+    fireEvent.click(toggle);
+    expect(toggle).toBeChecked();
+
+    await waitFor(() => {
+      expect(putBookStateSpy).toHaveBeenCalledWith('book-1', {
+        slice: 'state',
+        patch: { prosodyEnabled: true },
+      });
+    });
+  });
+
+  it('hides the toggle when bookId is null', async () => {
+    renderView({ bookId: null });
+    // Toggle should not be rendered at all
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('checkbox', { name: /expressive directions/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders helper text about background annotation', async () => {
+    renderView();
+    await screen.findByRole('checkbox', { name: /expressive directions/i });
+    expect(screen.getByText(/runs in the background after analysis/i)).toBeInTheDocument();
+  });
+});

--- a/src/views/analysing.test.tsx
+++ b/src/views/analysing.test.tsx
@@ -8,6 +8,7 @@ import { uiSlice } from '../store/ui-slice';
 import { castSlice } from '../store/cast-slice';
 import { analysisSlice } from '../store/analysis-slice';
 import { accountSlice } from '../store/account-slice';
+import { bookMetaSlice } from '../store/book-meta-slice';
 import { AnalysingView } from './analysing';
 import type { AnalyseOpts, AnalysisLiveInfo } from '../lib/api';
 import type {
@@ -111,6 +112,7 @@ function renderView() {
       cast: castSlice.reducer,
       analysis: analysisSlice.reducer,
       account: accountSlice.reducer,
+      bookMeta: bookMetaSlice.reducer,
     },
   });
   return {
@@ -536,7 +538,7 @@ describe('AnalysingView — analyzer Load button auto-evicts TTS', () => {
      even pre-analysis so the user can pre-warm Ollama from this screen. */
   function renderNoManuscript() {
     const store = configureStore({
-      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer },
+      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer, bookMeta: bookMetaSlice.reducer },
     });
     return render(
       <Provider store={store}>
@@ -631,6 +633,7 @@ describe('AnalysingView — analyzer Load button auto-evicts TTS', () => {
         cast: castSlice.reducer,
         analysis: analysisSlice.reducer,
         account: accountSlice.reducer,
+      bookMeta: bookMetaSlice.reducer,
       },
     });
     render(
@@ -708,7 +711,7 @@ describe('AnalysingView — analyzer Load button auto-evicts TTS', () => {
 
   it('hides the analyzer pill when a cloud (Gemini) model is selected — nothing to load locally', () => {
     const store = configureStore({
-      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer },
+      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer, bookMeta: bookMetaSlice.reducer },
     });
     render(
       <Provider store={store}>
@@ -899,7 +902,7 @@ describe('AnalysingView — failed-chapter retry', () => {
     getBookStateImpl = () => Promise.resolve(makeBookState([44, 49]));
 
     const store = configureStore({
-      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer },
+      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer, bookMeta: bookMetaSlice.reducer },
     });
     render(
       <Provider store={store}>
@@ -930,7 +933,7 @@ describe('AnalysingView — failed-chapter retry', () => {
     getBookStateImpl = () => Promise.resolve(makeBookState([44]));
 
     const store = configureStore({
-      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer },
+      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer, bookMeta: bookMetaSlice.reducer },
     });
     render(
       <Provider store={store}>
@@ -1008,7 +1011,7 @@ describe('AnalysingView — failed-chapter retry', () => {
     getBookStateImpl = () => Promise.resolve(makeBookState([44, 49]));
 
     const store = configureStore({
-      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer },
+      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer, bookMeta: bookMetaSlice.reducer },
     });
     render(
       <Provider store={store}>
@@ -1056,7 +1059,7 @@ describe('AnalysingView — failed-chapter retry', () => {
     getBookStateImpl = () => Promise.resolve(makeBookState([44]));
 
     const store = configureStore({
-      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer },
+      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer, bookMeta: bookMetaSlice.reducer },
     });
     render(
       <Provider store={store}>
@@ -1121,7 +1124,7 @@ describe('AnalysingView — pre-hydrated cast preview on mount', () => {
 
   it('renders the cast preview from a pre-hydrated cast slice before any SSE event fires', () => {
     const store = configureStore({
-      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer },
+      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer, bookMeta: bookMetaSlice.reducer },
     });
     /* Simulate the layout's getBookState → setCharacters hydration that
        runs ahead of the analysing route mounting. With cast.json now
@@ -1157,7 +1160,7 @@ describe('AnalysingView — pre-hydrated cast preview on mount', () => {
 describe('AnalysingView — dropped-quotes panel', () => {
   function renderWithBookId() {
     const store = configureStore({
-      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer },
+      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer, bookMeta: bookMetaSlice.reducer },
     });
     return render(
       <Provider store={store}>
@@ -1519,6 +1522,7 @@ describe('AnalysingView — cold-boot rehydration from analysis slice', () => {
         cast: castSlice.reducer,
         analysis: analysisSlice.reducer,
         account: accountSlice.reducer,
+      bookMeta: bookMetaSlice.reducer,
       },
       preloadedState: {
         analysis: {
@@ -1612,6 +1616,7 @@ describe('AnalysingView — request-model gating (plan 118)', () => {
         cast: castSlice.reducer,
         analysis: analysisSlice.reducer,
         account: accountSlice.reducer,
+      bookMeta: bookMetaSlice.reducer,
       },
       preloadedState: {
         ui: {
@@ -1672,6 +1677,7 @@ describe('AnalysingView — readiness gate follows the effective per-phase model
         cast: castSlice.reducer,
         analysis: analysisSlice.reducer,
         account: accountSlice.reducer,
+      bookMeta: bookMetaSlice.reducer,
       },
       preloadedState: {
         ui: {
@@ -1784,6 +1790,7 @@ describe('AnalysingView — fs-19 classified failure remediation', () => {
         cast: castSlice.reducer,
         analysis: analysisSlice.reducer,
         account: accountSlice.reducer,
+      bookMeta: bookMetaSlice.reducer,
       },
     });
     render(
@@ -1830,7 +1837,7 @@ describe('AnalysingView — fs-19 classified failure remediation', () => {
       );
 
     const store = configureStore({
-      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer },
+      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer, bookMeta: bookMetaSlice.reducer },
     });
     render(
       <Provider store={store}>
@@ -1854,7 +1861,7 @@ describe('AnalysingView — fs-19 classified failure remediation', () => {
       Promise.resolve(makeBookStateWithErrors([4], {}));
 
     const store = configureStore({
-      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer },
+      reducer: { ui: uiSlice.reducer, cast: castSlice.reducer, account: accountSlice.reducer, bookMeta: bookMetaSlice.reducer },
     });
     render(
       <Provider store={store}>
@@ -1884,6 +1891,7 @@ describe('AnalysingView — fs-19 classified failure remediation', () => {
         cast: castSlice.reducer,
         analysis: analysisSlice.reducer,
         account: accountSlice.reducer,
+      bookMeta: bookMetaSlice.reducer,
       },
     });
     render(
@@ -1927,6 +1935,7 @@ describe('AnalysingView — fs-19 classified failure remediation', () => {
         cast: castSlice.reducer,
         analysis: analysisSlice.reducer,
         account: accountSlice.reducer,
+      bookMeta: bookMetaSlice.reducer,
       },
     });
     render(
@@ -1973,6 +1982,7 @@ describe('AnalysingView — fs-19 classified failure remediation', () => {
         cast: castSlice.reducer,
         analysis: analysisSlice.reducer,
         account: accountSlice.reducer,
+      bookMeta: bookMetaSlice.reducer,
       },
     });
     render(

--- a/src/views/analysing.tsx
+++ b/src/views/analysing.tsx
@@ -32,6 +32,7 @@ import { uiActions } from '../store/ui-slice';
 import { castActions } from '../store/cast-slice';
 import { analysisActions, type AnalysisStreamSnapshot } from '../store/analysis-slice';
 import { selectAnalyzerSplitIsActive, fetchAnalyzerModels } from '../store/account-slice';
+import { bookMetaActions, selectProsodyEnabled } from '../store/book-meta-slice';
 
 /* Heuristic estimate matched to the server's analysis pacing (server/src/
    routes/analysis.ts: STAGE1_BASELINE_RATE × STAGE2_STRETCH ≈ 4 ms per input
@@ -307,6 +308,9 @@ export function AnalysingView({
      preserving the cloud-no-probe invariant. */
   const localAnalyzerModels = useAppSelector((s) => s.account.localAnalyzerModels);
   const analyzerModelGroups = buildModelOptionGroups(buildLocalModelOptions(localAnalyzerModels));
+  /* fs-65 Task 12 — per-book prosody annotation toggle. Eager default: absent
+     (undefined) or true → checked; only an explicit false → unchecked. */
+  const prosodyStored = useAppSelector(selectProsodyEnabled(bookId ?? null));
   /* Populate the local-tag list only after a failure surfaces the retry picker
      — never on a healthy (possibly cloud) run, so the Ollama probe stays off
      the cloud path. */
@@ -1169,6 +1173,35 @@ export function AnalysingView({
               const disabled = !isRunning && !isAnalyzerReady;
               return (
                 <div className="mt-6 flex flex-col items-center gap-2">
+                  {/* fs-65 Task 12 — Expressive directions toggle (eager default ON).
+                      Hidden when bookId is null (setProsodyEnabled needs a non-null id).
+                      Minimum 44px touch target on phone per mobile rule. */}
+                  {bookId != null && (
+                    <label className="flex items-start gap-3 cursor-pointer select-none max-w-sm w-full px-1 min-h-[44px] sm:min-h-0">
+                      <input
+                        type="checkbox"
+                        checked={prosodyStored !== false}
+                        onChange={(e) => {
+                          const value = e.target.checked;
+                          dispatch(
+                            bookMetaActions.setProsodyEnabled({ bookId: bookId, value }),
+                          );
+                          void api.putBookState(bookId, {
+                            slice: 'state',
+                            patch: { prosodyEnabled: value },
+                          });
+                        }}
+                        className="mt-0.5 h-4 w-4 shrink-0 rounded border-ink/30 text-magenta focus:ring-2 focus:ring-magenta/30"
+                      />
+                      <span className="flex flex-col gap-0.5">
+                        <span className="text-sm font-medium text-ink">Expressive directions</span>
+                        <span className="text-[11px] text-ink/50">
+                          Generate per-line emotion + delivery directions for the higher-quality
+                          (1.7B) voice. Runs in the background after analysis.
+                        </span>
+                      </span>
+                    </label>
+                  )}
                   <button
                     type="button"
                     onClick={onClick}

--- a/src/views/analysing.tsx
+++ b/src/views/analysing.tsx
@@ -1177,8 +1177,9 @@ export function AnalysingView({
                       Hidden when bookId is null (setProsodyEnabled needs a non-null id).
                       Minimum 44px touch target on phone per mobile rule. */}
                   {bookId != null && (
-                    <label className="flex items-start gap-3 cursor-pointer select-none max-w-sm w-full px-1 min-h-[44px] sm:min-h-0">
+                    <div className="flex items-start gap-3 cursor-pointer select-none max-w-sm w-full px-1 min-h-[44px] sm:min-h-0">
                       <input
+                        id="prosody-toggle"
                         type="checkbox"
                         checked={prosodyStored !== false}
                         onChange={(e) => {
@@ -1193,14 +1194,14 @@ export function AnalysingView({
                         }}
                         className="mt-0.5 h-4 w-4 shrink-0 rounded border-ink/30 text-magenta focus:ring-2 focus:ring-magenta/30"
                       />
-                      <span className="flex flex-col gap-0.5">
-                        <span className="text-sm font-medium text-ink">Expressive directions</span>
+                      <div className="flex flex-col gap-0.5">
+                        <label htmlFor="prosody-toggle" className="text-sm font-medium text-ink cursor-pointer">Expressive directions</label>
                         <span className="text-[11px] text-ink/50">
                           Generate per-line emotion + delivery directions for the higher-quality
                           (1.7B) voice. Runs in the background after analysis.
                         </span>
-                      </span>
-                    </label>
+                      </div>
+                    </div>
                   )}
                   <button
                     type="button"

--- a/src/views/cast-prosody-hint.test.tsx
+++ b/src/views/cast-prosody-hint.test.tsx
@@ -1,0 +1,245 @@
+// Task 13b — fs-65 Phase 3: opt-out render-time hint on the cast/generate surface
+// Pairs with: docs/superpowers/plans/2026-06-25-phase3-prosody-and-scriptreview-chunking.md § Task 13b
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import { uiSlice } from '../store/ui-slice';
+import { castSlice } from '../store/cast-slice';
+import { castDesignSlice } from '../store/cast-design-slice';
+import { bookMetaSlice, bookMetaActions } from '../store/book-meta-slice';
+import { CastView } from './cast';
+import type { Character, Voice } from '../lib/types';
+
+/* ── api mock ────────────────────────────────────────────────────────────── */
+
+const putBookStateSpy = vi.fn();
+
+vi.mock('../lib/api', () => ({
+  api: {
+    loadSidecar: vi.fn().mockResolvedValue({}),
+    pauseCastDesign: vi.fn().mockResolvedValue(undefined),
+    setCastTier: vi.fn().mockResolvedValue({ updated: 0 }),
+    listMergeSuggestions: vi.fn().mockResolvedValue([]),
+    putBookState: (...args: unknown[]) => putBookStateSpy(...args),
+  },
+}));
+
+vi.mock('../lib/play-sample-with-auto-load', () => ({
+  playSampleWithAutoLoad: vi.fn().mockResolvedValue({ analyzerEvicted: false }),
+}));
+
+vi.mock('../lib/use-sample-playback', () => ({
+  useSamplePlayback: () => ({
+    isPlaying: false,
+    currentUrl: null,
+    play: vi.fn(),
+    stop: vi.fn(),
+    pause: vi.fn(),
+  }),
+}));
+
+/* ── fixtures ────────────────────────────────────────────────────────────── */
+
+const BOOK_ID = 'bk-hint-test';
+
+/** A Qwen character pinned to the 1.7B tier. */
+const char17b: Character = {
+  id: 'wren',
+  name: 'Wren',
+  role: 'Protagonist',
+  color: 'narrator',
+  lines: 120,
+  scenes: 5,
+  attributes: ['determined'],
+  ttsEngine: 'qwen',
+  ttsModelKey: 'qwen3-tts-1.7b',
+  overrideTtsVoices: { qwen: { name: 'qwen-wren' } },
+};
+
+/** A Qwen character on the default 0.6B tier (no ttsModelKey). */
+const char06b: Character = {
+  id: 'marrow',
+  name: 'Mr. Marrow',
+  role: 'Teacher',
+  color: 'mentor',
+  lines: 30,
+  scenes: 2,
+  attributes: ['stern'],
+  ttsEngine: 'qwen',
+  overrideTtsVoices: { qwen: { name: 'qwen-marrow' } },
+};
+
+/** A non-Qwen (Kokoro) character — no 1.7B. */
+const charKokoro: Character = {
+  id: 'narrator',
+  name: 'Narrator',
+  role: 'Third-person observer',
+  color: 'narrator',
+  lines: 500,
+  scenes: 15,
+  attributes: ['calm'],
+};
+
+const emptyLibrary: Voice[] = [];
+
+/* ── store helpers ───────────────────────────────────────────────────────── */
+
+function makeStore(opts: {
+  prosodyEnabled?: boolean;
+  bookId?: string;
+  storeCharacters?: Character[];
+} = {}) {
+  const { prosodyEnabled, bookId = BOOK_ID, storeCharacters = [char17b, char06b] } = opts;
+  const store = configureStore({
+    reducer: {
+      ui: uiSlice.reducer,
+      cast: castSlice.reducer,
+      castDesign: castDesignSlice.reducer,
+      bookMeta: bookMetaSlice.reducer,
+    },
+    preloadedState: {
+      ui: {
+        ...uiSlice.getInitialState(),
+        stage: { kind: 'ready', bookId, view: 'cast' } as never,
+      },
+      cast: {
+        ...castSlice.getInitialState(),
+        characters: storeCharacters,
+      },
+    },
+  });
+  if (prosodyEnabled !== undefined) {
+    store.dispatch(bookMetaActions.setProsodyEnabled({ bookId, value: prosodyEnabled }));
+  }
+  return store;
+}
+
+function renderCast(
+  opts: {
+    characters?: Character[];
+    prosodyEnabled?: boolean;
+    bookId?: string;
+  } = {},
+) {
+  const { characters = [char17b, char06b], prosodyEnabled, bookId = BOOK_ID } = opts;
+  // Sync store characters with the prop so storedTiers reflects the same cast.
+  const store = makeStore({ prosodyEnabled, bookId, storeCharacters: characters });
+  const result = render(
+    <Provider store={store}>
+      <CastView
+        characters={characters}
+        setCharacters={() => {}}
+        library={emptyLibrary}
+        title="The Coalfall Commission"
+        onOpenProfile={() => {}}
+        onShowMatchDetail={() => {}}
+        driftEvents={[]}
+        onShowDrift={() => {}}
+      />
+    </Provider>,
+  );
+  return { store, ...result };
+}
+
+beforeEach(() => {
+  putBookStateSpy.mockReset().mockResolvedValue(undefined);
+});
+
+/* ── tests ───────────────────────────────────────────────────────────────── */
+
+describe('CastView prosody opt-out hint (Task 13b / fs-65)', () => {
+  it('renders the hint when prosodyEnabled===false AND a 1.7B cast member exists', () => {
+    renderCast({ characters: [char17b, char06b], prosodyEnabled: false });
+    expect(
+      screen.getByText(/expressive directions are off for this book/i),
+    ).toBeInTheDocument();
+  });
+
+  it('is absent when prosodyEnabled is undefined (eager default)', () => {
+    renderCast({ characters: [char17b, char06b] }); // no prosodyEnabled override
+    expect(
+      screen.queryByText(/expressive directions are off/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('is absent when prosodyEnabled is true', () => {
+    renderCast({ characters: [char17b, char06b], prosodyEnabled: true });
+    expect(
+      screen.queryByText(/expressive directions are off/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('is absent when prosodyEnabled===false but NO 1.7B cast member exists', () => {
+    // char06b has no ttsModelKey (undefined), charKokoro has no Qwen engine
+    renderCast({ characters: [char06b, charKokoro], prosodyEnabled: false });
+    expect(
+      screen.queryByText(/expressive directions are off/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('is absent when only the non-Qwen (Kokoro) cast member is present', () => {
+    renderCast({ characters: [charKokoro], prosodyEnabled: false });
+    expect(
+      screen.queryByText(/expressive directions are off/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('[Turn on] dispatches setProsodyEnabled(true) and issues PUT with true', async () => {
+    const { store } = renderCast({ characters: [char17b], prosodyEnabled: false });
+
+    const turnOnBtn = screen.getByRole('button', { name: /turn on/i });
+    fireEvent.click(turnOnBtn);
+
+    // Redux store updated
+    expect(store.getState().bookMeta.prosodyEnabled[BOOK_ID]).toBe(true);
+
+    // Durable PUT issued
+    await waitFor(() => {
+      expect(putBookStateSpy).toHaveBeenCalledWith(BOOK_ID, {
+        slice: 'state',
+        patch: { prosodyEnabled: true },
+      });
+    });
+  });
+
+  it('[Turn on] makes the hint disappear (prosodyEnabled flips to true)', async () => {
+    renderCast({ characters: [char17b], prosodyEnabled: false });
+
+    expect(screen.getByText(/expressive directions are off/i)).toBeInTheDocument();
+
+    const turnOnBtn = screen.getByRole('button', { name: /turn on/i });
+    fireEvent.click(turnOnBtn);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/expressive directions are off/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('the hint is dismissible without flipping the flag', async () => {
+    renderCast({ characters: [char17b], prosodyEnabled: false });
+
+    expect(screen.getByText(/expressive directions are off/i)).toBeInTheDocument();
+
+    const dismissBtn = screen.getByRole('button', { name: /dismiss/i });
+    fireEvent.click(dismissBtn);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/expressive directions are off/i),
+      ).not.toBeInTheDocument();
+    });
+
+    // Dismissing should NOT flip the prosodyEnabled flag or issue a PUT
+    expect(putBookStateSpy).not.toHaveBeenCalled();
+  });
+
+  it('[Turn on] has a ≥44px touch target on phone', () => {
+    renderCast({ characters: [char17b], prosodyEnabled: false });
+    const turnOnBtn = screen.getByRole('button', { name: /turn on/i });
+    expect(turnOnBtn.className).toMatch(/min-h-\[44px\]/);
+  });
+});

--- a/src/views/cast.tsx
+++ b/src/views/cast.tsx
@@ -41,6 +41,7 @@ import { voicesActions } from '../store/voices-slice';
 import { castActions } from '../store/cast-slice';
 import { castDesignActions } from '../store/cast-design-slice';
 import { notificationsActions } from '../store/notifications-slice';
+import { bookMetaActions, selectProsodyEnabled } from '../store/book-meta-slice';
 import { distinctDriftChapterCount } from '../store/revisions-slice';
 import { useSamplePlayback } from '../lib/use-sample-playback';
 import { playSampleWithAutoLoad } from '../lib/play-sample-with-auto-load';
@@ -253,6 +254,19 @@ export function CastView({
      analyzer. One-shot per view mount — the user reads it once and the
      pill on the Generation view takes over as the authoritative state. */
   const [evictionBanner, setEvictionBanner] = useState<string | null>(null);
+  /* fs-65 Task 13b — prosody opt-out hint. Dismissible (local state only —
+     dismissing does NOT flip the prosodyEnabled flag). */
+  const [prosodyHintDismissed, setProsodyHintDismissed] = useState(false);
+  const prosodyEnabled = useAppSelector(selectProsodyEnabled(bookId));
+  /* True when at least one cast member is pinned to the 1.7B tier. Reads the
+     store's live ttsModelKey values (via storedTiers, already in scope) so the
+     hint reacts immediately to a bulk pin or reset without a prop cycle. */
+  const has1_7bMember = useMemo(
+    () => [...storedTiers.values()].some((mk) => mk === 'qwen3-tts-1.7b'),
+    [storedTiers],
+  );
+  const showProsodyHint =
+    !prosodyHintDismissed && prosodyEnabled === false && has1_7bMember;
   const setRow = (id: string, patch: { loading?: boolean; error?: string } | null) =>
     setRowState((prev) => {
       const next = { ...prev };
@@ -587,6 +601,14 @@ export function CastView({
     );
   }
 
+  /* fs-65 Task 13b — [Turn on] in the prosody opt-out hint. Flips the flag
+     in Redux and issues the durable PUT so the toggle stays off on reload. */
+  function handleTurnOnProsody() {
+    if (!bookId) return;
+    dispatch(bookMetaActions.setProsodyEnabled({ bookId, value: true }));
+    void api.putBookState(bookId, { slice: 'state', patch: { prosodyEnabled: true } });
+  }
+
   function handleDrop(charId: string) {
     if (!draggingVoiceId) return;
     const voice = findVoice(draggingVoiceId);
@@ -773,6 +795,37 @@ export function CastView({
               onClick={() => setEvictionBanner(null)}
               className="ml-auto text-[11px] text-emerald-700/60 hover:text-emerald-700 font-medium"
               aria-label="Dismiss notice"
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
+
+        {/* fs-65 Task 13b — prosody opt-out render-time hint. Surfaces when
+            the book has prosodyEnabled===false AND at least one cast member is
+            pinned to the 1.7B tier, so the silent "basic emotion phrases only"
+            fallback isn't invisible. [Turn on] flips the flag durably. */}
+        {showProsodyHint && (
+          <div
+            role="status"
+            data-testid="prosody-off-hint"
+            className="w-full mb-4 px-4 py-2.5 rounded-2xl border border-amber-200 bg-amber-50/70 flex items-center gap-3 text-xs text-amber-800"
+          >
+            <span className="flex-1 min-w-0">
+              Expressive directions are off for this book — using basic emotion phrases.
+            </span>
+            <button
+              type="button"
+              onClick={handleTurnOnProsody}
+              className="shrink-0 min-h-[44px] sm:min-h-0 px-3 py-1.5 rounded-full bg-amber-100 hover:bg-amber-200 text-amber-900 text-xs font-semibold"
+            >
+              Turn on
+            </button>
+            <button
+              type="button"
+              onClick={() => setProsodyHintDismissed(true)}
+              className="shrink-0 text-[11px] text-amber-700/60 hover:text-amber-800 font-medium"
+              aria-label="Dismiss"
             >
               Dismiss
             </button>


### PR DESCRIPTION
## Summary

Implements **fs-65 Phase 3** (`Closes #1129`): after a book finishes analysis, the two per-line prosody annotation passes (emotion + instruct/vocalization) run **automatically in the background**, so a later Qwen-1.7B render gets rich per-line delivery instead of the four canned `emotionToInstruct` phrases.

**Gate (eager-default, decided 2026-06-25).** 1.7B is never an account/book default (the picker only offers Qwen 0.6b) — it's chosen late (cast pin / regen override), so there is no analysis-time 1.7B signal. We therefore annotate **eagerly by default**: the gate is `prosodyEnabled !== false` (absent ⇒ on). An analysis-form **"Expressive directions"** toggle (checked by default) lets the user opt out per book.

**Trigger (library-status keyed).** The auto-trigger fires off `library.books` status transitions — for the **active book AND books analysed in the background** (a `confirm`-stage trigger would silently miss background books, since `ui.stage` is singular). Seed-on-mount skips the pre-existing library (no backlog auto-spend); the launch reads `prosodyEnabled`/`prosodyAnnotated` authoritatively from disk; the watermark is written only on `failed === 0`; jobs are detached (survive a book-switch) and retry-safe.

### What changed
- **`liveInstruct` → `prosodyEnabled`** rename (the fs-66-orphaned flag), now a nullable eager-default intent flag across server state, the slice, `types.ts`, and `openapi.yaml`/`api-types.ts`. Synth-path `liveInstruct` references intentionally untouched.
- **`prosodyAnnotated`** completion watermark on book state (server + frontend `BookStateJson`).
- Both annotation routes now **chunk large chapters** via the PR2 sentence-chunker (no silent truncation on huge Cyrillic chapters).
- `chapter-failed` SSE event **surfaced** in the detect-emotions/instruct handlers.
- `runProsodyPasses` thunk extracted from the Detect-emotions button (button UX preserved); the load-bearing `failed` count gates the watermark.
- Analysis-form **toggle** (Task 12), library-status **auto-trigger** (Task 13), opt-out **render-time hint** on the cast view when a book is opted-out but going 1.7B (Task 13b), and a global **"Phase 3 — Detecting prosody" pill** (Task 14).

### Process
Built via SDD (brainstorm → spec → plan → subagent-per-task execution). The gate was reshaped twice by adversarial review: round 1 caught a Critical (cast-derived eligibility read false for the intended user → eager-default), round 2 caught a Critical (active-stage trigger misses background books → library-status keying) plus the opt-out hydration race and a partial-watermark bug. The final whole-branch review (Opus) returned no Critical. Design: `docs/superpowers/specs/2026-06-25-phase3-prosody-and-scriptreview-chunking-design.md`; plan: the sibling plan doc.

### Known non-blocking notes
- **M-1:** `chunkWithContext` orders context by sentence id (assumes monotonic ids) — a pre-existing PR2/script-review pattern; bounded to *prompt context quality* (ownership is set-membership, order-independent), never double-applies/drops an owned annotation.
- **M-3:** `has1_7bMember`'s `useMemo` in `cast.tsx` recomputes each render (the `new Map` selector is pre-existing) — harmless.

## Test plan
- New/updated unit + integration tests for every task: watermark PUT, chunked annotation routes (owned-core, no truncation), `chapter-failed` handlers, `runProsodyPasses` (incl. `failed` count + restored button UX), the `prosodyEnabled` nullable slice, the toggle (checked-by-default + null-bookId guard), the **library-status trigger** (background-book regression, seed-on-mount, authoritative opt-out, `failed===0` watermark, retry-safe — 11 cases), the opt-out hint, and the prosody pill slice/render.
- New e2e `e2e/analysis-prosody-toggle.spec.ts` (toggle present + checked-by-default + uncheckable).
- Full `npm run verify` green locally (lint + typecheck + all unit/integration suites + build + e2e 234 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
