### PR TITLE
fix(frontend): cap RegenerateModal height so footer can't clip (#1135)

### DIFF
--- a/src/modals/regenerate.test.tsx
+++ b/src/modals/regenerate.test.tsx
@@ -119,6 +119,33 @@ describe('RegenerateModal — ETA scales with audio duration × RTF', () => {
   });
 });
 
+describe('RegenerateModal — scroll-safe on short viewports (footer never clipped)', () => {
+  /* Regression: the card is centered with `grid place-items-center` and is
+     `overflow-hidden`. Without a max-height + an internal scroll region, a short
+     desktop window pushes the footer (Cancel + Regenerate) below the viewport
+     with no way to scroll to it. The card must cap its height as a flex column
+     and let the body scroll, keeping header + footer visible — the same pattern
+     CharacterRegenerateModal already uses. */
+  it('caps the card height and makes the body the scroll region', () => {
+    const { container } = render(
+      <RegenerateModal
+        chapter={chapter}
+        defaultModelKey="qwen3-tts-0.6b"
+        onClose={() => {}}
+        onConfirm={() => {}}
+      />,
+    );
+    const card = container.querySelector('.max-w-xl') as HTMLElement;
+    expect(card).not.toBeNull();
+    // Height-capped flex column so the footer can't be pushed off-screen.
+    expect(card.className).toMatch(/max-h-\[90vh\]/);
+    expect(card.className).toContain('flex-col');
+    // The middle region (body) is the scroller; the header + footer stay put.
+    const body = card.children[1] as HTMLElement;
+    expect(body.className).toContain('overflow-y-auto');
+  });
+});
+
 describe('RegenerateModal — per-regenerate model override (#4)', () => {
   it('confirms with the session default model when the picker is untouched', () => {
     const onConfirm = vi.fn();

--- a/src/modals/regenerate.tsx
+++ b/src/modals/regenerate.tsx
@@ -77,7 +77,7 @@ export function RegenerateModal({
     <>
       <div onClick={onClose} className="fixed inset-0 bg-ink/40 z-50 fade-in" />
       <div className="fixed inset-0 z-50 grid place-items-center p-6 pointer-events-none">
-        <div className="bg-white rounded-3xl shadow-float w-full max-w-xl pointer-events-auto fade-in overflow-hidden">
+        <div className="bg-white rounded-3xl shadow-float w-full max-w-xl pointer-events-auto fade-in overflow-hidden max-h-[90vh] flex flex-col">
           <div className="px-6 py-4 border-b border-ink/10 flex items-center gap-3">
             <span className="w-9 h-9 rounded-full bg-peach/15 grid place-items-center text-magenta">
               <IconRefresh className="w-4 h-4" />
@@ -95,7 +95,7 @@ export function RegenerateModal({
             </button>
           </div>
 
-          <div className="p-6 space-y-6">
+          <div className="p-6 space-y-6 overflow-y-auto scrollbar-thin">
             <section>
               <p className="text-[11px] uppercase tracking-wider text-ink/50 font-semibold mb-3">
                 What changed?


### PR DESCRIPTION
## Summary

`RegenerateModal`'s card is centered with `grid place-items-center` and is `overflow-hidden`, but had **no max-height and no internal scroll region**. On a short desktop window the over-tall card centered its overflow, pushing the footer (Cancel + **Regenerate**) below the viewport with no way to reach it.

Fix mirrors the sibling `CharacterRegenerateModal`, which already solved this:
- Card: add `max-h-[90vh] flex flex-col` so the card caps its height as a flex column.
- Body: add `overflow-y-auto scrollbar-thin` so the body becomes the scroll region, keeping the header + footer pinned.

Two-class change; no behaviour or visual change on normal-height windows.

## Test plan

- New regression test in `src/modals/regenerate.test.tsx` locks the scroll-safe class contract (jsdom can't compute layout, so the className contract is the jsdom-level lock). Fails before the fix, passes after.
- Full frontend suite green locally (3306 tests).

Closes #1135

🤖 Generated with [Claude Code](https://claude.com/claude-code)