### PR TITLE
fix(sidecar): repair two dev-box-only pytest failures (#1140)

### DIFF
--- a/e2e/advanced-settings.spec.ts
+++ b/e2e/advanced-settings.spec.ts
@@ -19,6 +19,14 @@
 import { test, expect } from '@playwright/test';
 import { waitForRouteReady } from './helpers';
 
+/* Run this file's tests sequentially on a single worker. Each test does a cold
+ * `goto('/#/advanced')` that triggers a route-level React.lazy chunk load; with
+ * fullyParallel + 4 local workers these cold-loads pile onto the single Vite dev
+ * server and the visibility timeouts flake under peak battery contention (passes
+ * on retry in isolation, exhausts retries under full load). Serial mode caps this
+ * file at one concurrent cold-load — the same mitigation 10+ sibling specs use. */
+test.describe.configure({ mode: 'serial' });
+
 test.describe('Advanced Settings — plan 199 golden path', () => {
   test('navigates to #/advanced and shows the heading', async ({ page }) => {
     await page.goto('/#/advanced');

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -39,8 +39,12 @@ export default defineConfig({
      once: N Chromium instances saturate CPU and each page's `load` stalls past
      budget. The `warmup` setup project warms the server transform cache; a
      moderate cap bounds the client-side cold-load herd. Together they keep the
-     parallel battery green. CI stays at 1 (no herd there). */
-  workers: process.env.CI ? 1 : 4,
+     parallel battery green. CI stays at 1 (no herd there). Local dropped 4→2
+     (2026-06-26): 4 Chromium+Vite instances thrashed memory on dev boxes and
+     the cold-load herd exhausted the 2 retries under peak battery load (the
+     advanced-settings flake). Two workers halves peak memory and tames the herd
+     while keeping the suite well under the navigation budget. */
+  workers: process.env.CI ? 1 : 2,
   reporter: process.env.CI ? [['github'], ['list']] : 'list',
   /* Per-platform AND per-project visual-regression baselines. {platform}
      resolves to 'win32' | 'linux' | 'darwin' under Node's process.platform.

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -1586,7 +1586,7 @@ class QwenEngine(Engine):
         try:
             self._ensure_base17_loaded()
         except Exception as e:  # noqa: BLE001 — classify then re-raise
-            msg = str(e).lower()
+            msg = str(e).lower()  # exc-text-safe: OOM-branch classification only, never returned
             if "out of memory" in msg or isinstance(
                 e, getattr(torch.cuda, "OutOfMemoryError", ())
             ):

--- a/server/tts-sidecar/tests/test_design_progress.py
+++ b/server/tts-sidecar/tests/test_design_progress.py
@@ -108,7 +108,7 @@ def test_design_route_posts_progress_when_token_present(monkeypatch):
         def __init__(self):
             pass  # skip the real heavy __init__; the route only calls design_voice
 
-        def design_voice(self, voice_id, instruct, language, calibration_text, voice_uuid=None, report_progress=None):
+        def design_voice(self, voice_id, instruct, language, calibration_text, voice_uuid=None, report_progress=None, mint_method=None, fallback_for=None):
             if report_progress:
                 report_progress("loading-model")
                 report_progress("designing")

--- a/server/tts-sidecar/tests/test_error_responses.py
+++ b/server/tts-sidecar/tests/test_error_responses.py
@@ -15,6 +15,11 @@ def test_error_response_hides_exception_detail():
 def test_no_exception_text_reaches_a_response():
     src = open(os.path.join(SIDECAR_ROOT, "main.py"), encoding="utf-8").read()
     for ln in src.splitlines():
+        # A line may opt out with an audited `# exc-text-safe: <why>` marker when
+        # the str(e)/repr(e) local is used purely for branching (e.g. OOM
+        # classification) and demonstrably never reaches a response body.
+        if "exc-text-safe" in ln:
+            continue
         code = ln.split("#", 1)[0]  # ignore comments
         # (a) no str(e)/repr(e) directly on a response-building line …
         if "JSONResponse" in code or '"error"' in code or '"detail"' in code:


### PR DESCRIPTION
## Summary

Fixes the two deterministic `npm run test:sidecar` failures from #1140 — both invisible to CI because `test:sidecar` is venv-gated (skips in CI; only runs on a dev box with a bootstrapped venv). Bundles a small e2e-stability fix that surfaced while shipping this (the local pre-push e2e leg kept flaking).

### 1. `test_no_exception_text_reaches_a_response` (leak guard) — false positive
The guard's check-(b) regex `=\s*(str|repr)\(e\)` flagged `msg = str(e).lower()` (`main.py:1589`). Tracing the data flow, `msg` is used **only** to classify an OOM (`if "out of memory" in msg`) and then re-raises the original exception or raises `Base17UnavailableError("corrupt")` (a fixed string) — it never reaches a response body. Added an audited `# exc-text-safe: <why>` opt-out the guard honors, and annotated the line. The guard **still** flags any unmarked `= str(e)` (verified).

### 2. `test_design_route_posts_progress_when_token_present` — stale test fake (NOT environmental)
The issue speculated this needed a real GPU model. It doesn't: `TypeError: design_voice() takes from 5 to 7 positional arguments but 9 were given`. The `/qwen/design-voice` route passes `mint_method` + `fallback_for` positionally (`main.py:4439-4440`), but the test's `_FakeQwen.design_voice` override stopped at `report_progress`. Added the two missing params to the fake.

### 3. e2e stability (bundled, separate commit `0ab4a3e2`)
- `advanced-settings.spec.ts`: add `test.describe.configure({ mode: 'serial' })` — the same mitigation 10+ sibling specs use; its cold-load navigations exhausted the 2 retries under peak parallel battery load.
- `playwright.config.ts`: drop local `workers` 4 → 2 (halves peak Chromium+Vite memory, tames the cold-load herd). CI stays at 1.

## Test plan

- `tests/test_error_responses.py` + `tests/test_design_progress.py`: **5 passed** locally (GPU-free — neither loads a model).
- Guard integrity: unmarked `= str(e)` still flagged; only the marked line skipped.
- `npm run test:e2e` at workers:2: **233 passed, 0 failed**; advanced-settings no longer flaky.
- Note: CI does not run `test:sidecar` (venv-gated) — that's why #1140 was CI-invisible; the sidecar fix is validated locally.

Closes #1140

🤖 Generated with [Claude Code](https://claude.com/claude-code)