### PR TITLE
chore(server): order chunk context structurally, not by sentence id (srv-54)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -371,11 +371,6 @@ _Full detail + acceptance:_ spec `docs/superpowers/specs/2026-06-22-expressive-t
 - _Benefit (technical / community):_ unblocks FA2 on the real stack; community goodwill + visibility.
 _Full detail + acceptance:_ spec `docs/superpowers/specs/2026-06-22-expressive-tts-instruct-tiers-design.md` §4.8/§10 · [#1001](https://github.com/dudarenok-maker/Castwright/issues/1001).
 
-#### `srv-54` — `chunkWithContext` orders chunk context by sentence id (assumes monotonic ids) ([#1143](https://github.com/dudarenok-maker/Castwright/issues/1143))
-
-- _What:_ `chapter-chunker.ts` builds per-chunk context by `s.id` comparison, assuming ids increase in document order; post-fold split offspring (high id, mid-array) break that, so some context sentences are mis-ordered/dropped from the prompt. Ownership uses `coreIds.has` (order-independent), so output correctness is unaffected — prompt-context quality only. Pre-existing pattern shared with script-review (PR2).
-- _Benefit (technical):_ more accurate per-chunk LLM context on books with sentence splits/merges → better annotation + script-review quality on large chunked chapters. Found by the fs-65 Phase 3 whole-branch review (M-1).
-
 ### Revisions & regen
 
 #### `fs-5` — Multi-step rollback / snapshot-per-entry (revision history) ([#415](https://github.com/dudarenok-maker/AudioBook-Generator/issues/415))

--- a/server/src/analyzer/chapter-chunker.test.ts
+++ b/server/src/analyzer/chapter-chunker.test.ts
@@ -24,6 +24,18 @@ describe('chunkSentencesByBudget', () => {
     expect(chunks[0].core.map((s) => s.id)).toEqual([1]);
     expect(chunks.flatMap((c) => c.core.map((s) => s.id))).toEqual([1, 2]);
   });
+  it('chunkWithContext preserves document order when ids are non-monotonic (split offspring)', () => {
+    // Document order [25, 5, 20, 30]: a split offspring (high id 25) sits at the
+    // front, and the second core's ids (20, 30) bracket it numerically. The old
+    // `s.id`-comparison split mis-orders/drops such context sentences from the
+    // prompt; structural ordering (contextBefore ++ core ++ contextAfter) must
+    // keep every sentence, in document order, with none dropped.
+    const docOrder = [25, 5, 20, 30];
+    const sents = docOrder.map((id) => S(id, 30));
+    const chunks = chunkSentencesByBudget(sents, { charBudget: 60, overlap: 2, serialize: (s) => s.text });
+    // second chunk: core = [20, 30], context-before = [25, 5], context-after = []
+    expect(chunkWithContext(chunks[1]).map((s) => s.id)).toEqual([25, 5, 20, 30]);
+  });
 });
 
 describe('ownership', () => {

--- a/server/src/analyzer/chapter-chunker.ts
+++ b/server/src/analyzer/chapter-chunker.ts
@@ -21,7 +21,8 @@ import { resolveStage1ChunkCharBudget } from './stage1-chunk.js';
 
 export interface SentenceChunk<S> {
   core: S[];
-  context: S[];
+  contextBefore: S[];
+  contextAfter: S[];
   coreIds: Set<number>;
 }
 
@@ -59,22 +60,20 @@ export function chunkSentencesByBudget<S extends { id: number; text: string }>(
     const after = sentences.slice(end, Math.min(sentences.length, end + overlap));
     return {
       core,
-      context: [...before, ...after],
+      contextBefore: before,
+      contextAfter: after,
       coreIds: new Set(core.map((s) => s.id)),
     };
   });
 }
 
-/* context-before ++ core ++ context-after, in original sentence order. The
-   context split point is the core's first id: everything in `context` ordered
-   before the core stays before, the rest after. */
-export function chunkWithContext<S extends { id: number }>(chunk: SentenceChunk<S>): S[] {
-  if (chunk.core.length === 0) return [...chunk.context];
-  const firstCoreId = chunk.core[0].id;
-  const lastCoreId = chunk.core[chunk.core.length - 1].id;
-  const before = chunk.context.filter((s) => s.id < firstCoreId);
-  const after = chunk.context.filter((s) => s.id > lastCoreId);
-  return [...before, ...chunk.core, ...after];
+/* context-before ++ core ++ context-after, in original document order. The
+   split is carried structurally from `chunkSentencesByBudget` (which slices the
+   context windows by index), so this never relies on ids increasing with
+   position — post-fold split offspring (high id, mid-array) are ordered
+   correctly and never dropped. */
+export function chunkWithContext<S>(chunk: SentenceChunk<S>): S[] {
+  return [...chunk.contextBefore, ...chunk.core, ...chunk.contextAfter];
 }
 
 export function ownsOp(coreIds: Set<number>, primaryId: number): boolean {


### PR DESCRIPTION
## Summary

`chunkWithContext` (`server/src/analyzer/chapter-chunker.ts`) rebuilt the per-chunk `context-before ++ core ++ context-after` sequence by comparing `s.id` against the core's first/last id — assuming sentence ids increase with document position. **Post-fold split offspring (high id, mid-array) break that assumption:** a context sentence whose id lands between the core ids was silently *dropped* from the LLM prompt, and others were mis-ordered.

`chunkSentencesByBudget` already computes the before/after split by index, so this carries that structure instead of re-deriving it by id:

- `SentenceChunk` now exposes `contextBefore` / `contextAfter` instead of a flat `context`.
- `chunkWithContext` is a plain concatenation — **no id math**. The monotonic-id assumption is gone.

Ownership/dedup uses `coreIds.has` (order-independent), so this only ever affected **prompt-context quality, never output correctness**. All three consumers — `annotate-emotion`, `instruct-annotation`, `script-review` — benefit through the one shared function with **no caller changes**.

Removes the `srv-54` row from `docs/BACKLOG.md`.

## Test plan

- New regression test in `chapter-chunker.test.ts`: document order `[25, 5, 20, 30]`, where the second core's ids `(20, 30)` numerically bracket a split offspring `(25)`. **Fails before** the fix (drops `25` → `[5, 20, 30]`), **passes after** (`[25, 5, 20, 30]`, document order, nothing dropped).
- Local verify: chunker + all three consuming route suites (32/32), server+frontend typecheck clean, full pre-push `npm run verify` battery green.

Closes #1143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)