### PR TITLE
feat(server): fs-64 cross-chapter context for reattribute

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -67,12 +67,6 @@ _Full detail + acceptance:_ [#1005](https://github.com/dudarenok-maker/Castwrigh
 - _Benefit (user / strategic):_ a non-English user gets a generate-able demo in their own language out of the box, not a dead English-voiced sample. Surfaced by the `fs-50` Spanish ship.
 _Full detail + acceptance:_ [#1027](https://github.com/dudarenok-maker/Castwright/issues/1027).
 
-#### `fs-64` — cross-chapter context for reattribute (fs-58 Unit B follow-up) ([#1120](https://github.com/dudarenok-maker/Castwright/issues/1120))
-
-- _What:_ `reattribute` runs per-chapter, so a chapter-opening tagless line whose speaker was set by the previous chapter's last turn can mis-resolve. Feed the prior chapter's tail into the review prompt so straddling turn-taking resolves. Weigh against RPD cost.
-- _Benefit (technical):_ closes the per-chapter straddle limitation in the Unit B spec.
-_Full detail + acceptance:_ [#1120](https://github.com/dudarenok-maker/Castwright/issues/1120).
-
 #### `fs-52` — Caption/SRT export (.srt/.vtt; line/sentence/word) ([#975](https://github.com/dudarenok-maker/Castwright/issues/975))
 
 - _What:_ Emit `.srt`/`.vtt` (line + sentence + word modes) from the per-sentence alignment we already compute.

--- a/docs/superpowers/plans/2026-06-26-fs64-cross-chapter-reattribute.md
+++ b/docs/superpowers/plans/2026-06-26-fs64-cross-chapter-reattribute.md
@@ -1,0 +1,710 @@
+# fs-64 — Cross-chapter context for `reattribute` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Feed the prior chapter's final two-speaker exchange into the script-review prompt as read-only context — gated on a genuine alternating exchange — so the LLM can resolve a tagless chapter-opening line via cross-chapter turn-taking.
+
+**Architecture:** Three new pure functions in `server/src/routes/script-review.ts` (a boundary-exchange extractor with the live-exchange gate, a neighbor-chapter selector, and a new optional param on the existing prompt builder), wired into the per-chapter review loop so only the *first* chunk of each chapter carries the block. Strictly additive: when the gate fails, the prompt is byte-identical to today. No schema, api-types, or frontend change.
+
+**Tech Stack:** TypeScript (strict, ESM `.js` import specifiers), Node, Vitest (server suite, node env), `vi.mock` + `supertest` for the route test.
+
+## Global Constraints
+
+- **Spec of record:** `docs/superpowers/specs/2026-06-26-fs64-cross-chapter-reattribute-context-design.md`. Every task implements a part of it.
+- **`NARRATOR_ID` is re-declared locally** in `script-review.ts` (`const NARRATOR_ID = 'narrator';`) — the constant is module-private in `byline-author-guard.ts` and re-declared in five modules; **do NOT** add an `export` there.
+- **No `sentenceId` may appear in the rendered context block** — the block renders only `speakerName`, `speakerId`, and line text. This is the read-only guard (sentence ids are per-chapter `1..N` and collide, so the `ownsOp` filter is NOT a guard here).
+- **Additive only:** no change to `openapi.yaml`, `api-types.ts`, Zod schemas, or any frontend file. The chapter is chunked at **full** `charBudget` (unchanged) — do not modify the budget.
+- **Commits:** `feat(server): …` (or `test(server):` / `docs(skill):` where apt). Branch `feat/server-fs64-cross-chapter-reattribute`.
+- **Constants:** `PRIOR_TURN_LOOKBACK = 6`, `MAX_PRIOR_TURN_CHARS = 240`.
+- **Run server tests with:** `cd server && npm run test -- script-review` (Vitest single-run, node env).
+
+---
+
+### Task 0: Cut the branch
+
+- [ ] **Step 1: Branch off latest main**
+
+```bash
+git switch main && git pull --ff-only && git switch -c feat/server-fs64-cross-chapter-reattribute
+```
+
+*(If you are continuing on the existing `docs/docs-fs64-cross-chapter-reattribute` spec branch, instead rebase it on `main` and keep working there — the spec commits travel with the implementation.)*
+
+---
+
+### Task 1: `priorChapterBoundaryExchange` helper + constants
+
+The heart of the feature: a pure function that returns the prior chapter's final two-speaker exchange, or `null` when the chapter does not end in one.
+
+**Files:**
+- Modify: `server/src/routes/script-review.ts` (add constants + types + the helper, near `buildReviewSentencesInput` at line 60)
+- Test: `server/src/routes/script-review.test.ts` (new `describe` block + a dynamic-import binding in `beforeAll`)
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export const PRIOR_TURN_LOOKBACK = 6;
+  export const MAX_PRIOR_TURN_CHARS = 240;
+  export interface BoundaryTurn { speakerId: string; speakerName: string; text: string; }
+  export interface PriorExchange { turns: BoundaryTurn[]; } // exactly 2, [A, B] in reading order
+  export function priorChapterBoundaryExchange(
+    sentences: Array<{ id: number; characterId: string; text: string; excludeFromSynthesis?: boolean }>,
+    roster: Array<{ id: string; name: string }>,
+  ): PriorExchange | null;
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `server/src/routes/script-review.test.ts`. First extend the type-import line (near line 20) and add a module-level binding (near line 30):
+
+```ts
+import type {
+  buildReviewSentencesInput as BuildReviewSentencesInput,
+  priorChapterBoundaryExchange as PriorChapterBoundaryExchange,
+} from './script-review.js';
+```
+```ts
+let priorChapterBoundaryExchange: typeof PriorChapterBoundaryExchange;
+```
+
+In `beforeAll`, extend the destructuring (currently line 131-133) to bind it:
+
+```ts
+const [{ scriptReviewRouter, buildReviewSentencesInput: build, priorChapterBoundaryExchange: pcbe }, { makeBookId }] =
+  await Promise.all([import('./script-review.js'), import('../workspace/paths.js')]);
+buildReviewSentencesInput = build;
+priorChapterBoundaryExchange = pcbe;
+```
+
+Then add the test block at the end of the file:
+
+```ts
+describe('priorChapterBoundaryExchange (fs-64)', () => {
+  const roster = [
+    { id: 'wren', name: 'Wren' },
+    { id: 'marlow', name: 'Marlow' },
+  ];
+  const s = (id: number, characterId: string, text: string, excludeFromSynthesis?: boolean) =>
+    ({ id, characterId, text, ...(excludeFromSynthesis ? { excludeFromSynthesis } : {}) });
+
+  it('returns both turns when the chapter ends on an A/B exchange', () => {
+    const out = priorChapterBoundaryExchange(
+      [s(1, 'narrator', 'It was late.'), s(2, 'wren', '"Where to?"'), s(3, 'marlow', '"Somewhere safe."')],
+      roster,
+    );
+    expect(out).toEqual({
+      turns: [
+        { speakerId: 'wren', speakerName: 'Wren', text: '"Where to?"' },
+        { speakerId: 'marlow', speakerName: 'Marlow', text: '"Somewhere safe."' },
+      ],
+    });
+  });
+
+  it('returns null when the chapter ends on narration (single speaker in window)', () => {
+    const out = priorChapterBoundaryExchange(
+      [s(1, 'wren', '"Hello?"'), s(2, 'narrator', 'No answer came.'), s(3, 'narrator', 'The hall was empty.')],
+      roster,
+    );
+    expect(out).toBeNull();
+  });
+
+  it('returns null on a single-speaker monologue ending', () => {
+    const out = priorChapterBoundaryExchange(
+      [s(1, 'wren', 'One.'), s(2, 'wren', 'Two.'), s(3, 'wren', 'Three.')],
+      roster,
+    );
+    expect(out).toBeNull();
+  });
+
+  it('returns null when two speakers both folded to one id (unknown-male)', () => {
+    const out = priorChapterBoundaryExchange(
+      [s(1, 'unknown-male', '"Run!"'), s(2, 'unknown-male', '"This way!"')],
+      roster,
+    );
+    expect(out).toBeNull();
+  });
+
+  it('returns null when the exchange is beyond the lookback window', () => {
+    const out = priorChapterBoundaryExchange(
+      [
+        s(1, 'wren', '"Where to?"'), s(2, 'marlow', '"Safe."'),
+        s(3, 'narrator', 'a'), s(4, 'narrator', 'b'), s(5, 'narrator', 'c'),
+        s(6, 'narrator', 'd'), s(7, 'narrator', 'e'), s(8, 'narrator', 'f'),
+      ],
+      roster,
+    );
+    expect(out).toBeNull();
+  });
+
+  it('filters excludeFromSynthesis residue out of the turns', () => {
+    const out = priorChapterBoundaryExchange(
+      [s(1, 'wren', '"Where to?"'), s(2, 'marlow', '"Safe."'), s(3, 'page-header', 'Chapter 4', true)],
+      roster,
+    );
+    expect(out).toEqual({
+      turns: [
+        { speakerId: 'wren', speakerName: 'Wren', text: '"Where to?"' },
+        { speakerId: 'marlow', speakerName: 'Marlow', text: '"Safe."' },
+      ],
+    });
+  });
+
+  it('truncates a long line to MAX_PRIOR_TURN_CHARS with an ellipsis', () => {
+    const long = '"' + 'x'.repeat(400) + '"';
+    const out = priorChapterBoundaryExchange([s(1, 'wren', 'short'), s(2, 'marlow', long)], roster);
+    expect(out!.turns[1].text.length).toBeLessThanOrEqual(240);
+    expect(out!.turns[1].text.endsWith('…')).toBe(true);
+  });
+
+  it('falls back to the id when a speaker is off-roster', () => {
+    const out = priorChapterBoundaryExchange([s(1, 'wren', '"Hi."'), s(2, 'ghost', '"Boo."')], roster);
+    expect(out!.turns[1]).toEqual({ speakerId: 'ghost', speakerName: 'ghost', text: '"Boo."' });
+  });
+
+  it('returns null for an empty chapter', () => {
+    expect(priorChapterBoundaryExchange([], roster)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd server && npm run test -- script-review`
+Expected: FAIL — `priorChapterBoundaryExchange is not a function` (binding is `undefined`).
+
+- [ ] **Step 3: Implement the constants, types, and helper**
+
+In `server/src/routes/script-review.ts`, after the `CastFile` interface (line 48) and before `buildReviewSentencesInput`, add:
+
+```ts
+/* fs-64 — cross-chapter context for the script-review pass. The prior chapter's
+   final two-speaker exchange is fed (read-only) into a chapter's first chunk so
+   the model can resolve a tagless chapter-opening line via turn-taking. */
+const NARRATOR_ID = 'narrator'; // module-private convention (re-declared, never exported)
+export const PRIOR_TURN_LOOKBACK = 6; // sentences (positions) scanned back from the chapter end
+export const MAX_PRIOR_TURN_CHARS = 240; // hard cap per rendered line
+
+export interface BoundaryTurn {
+  speakerId: string;
+  speakerName: string;
+  text: string;
+}
+export interface PriorExchange {
+  turns: BoundaryTurn[]; // exactly two, [A, B] in reading order
+}
+
+function capLine(text: string): string {
+  return text.length > MAX_PRIOR_TURN_CHARS
+    ? text.slice(0, MAX_PRIOR_TURN_CHARS - 1).trimEnd() + '…'
+    : text;
+}
+
+/* The prior chapter's final two-speaker exchange, or null when it does not end
+   in a live exchange. Narration and excludeFromSynthesis residue are filtered;
+   the remaining eligible sentences in the last PRIOR_TURN_LOOKBACK positions are
+   collapsed into contiguous same-speaker turns. Gate: >=2 turns (which, by the
+   collapse, guarantees the last two are different speakers). Two distinct people
+   folded to one id (e.g. unknown-male) collapse to one turn -> null. */
+export function priorChapterBoundaryExchange(
+  sentences: Array<{ id: number; characterId: string; text: string; excludeFromSynthesis?: boolean }>,
+  roster: Array<{ id: string; name: string }>,
+): PriorExchange | null {
+  const eligible = sentences
+    .slice(-PRIOR_TURN_LOOKBACK)
+    .filter((s) => s.characterId !== NARRATOR_ID && s.excludeFromSynthesis !== true);
+
+  const turns: Array<{ speakerId: string; lastText: string }> = [];
+  for (const sentence of eligible) {
+    const prev = turns[turns.length - 1];
+    if (prev && prev.speakerId === sentence.characterId) {
+      prev.lastText = sentence.text; // extend the run; keep its boundary-adjacent line
+    } else {
+      turns.push({ speakerId: sentence.characterId, lastText: sentence.text });
+    }
+  }
+  if (turns.length < 2) return null;
+
+  const nameOf = (id: string): string => roster.find((r) => r.id === id)?.name ?? id;
+  const toTurn = (t: { speakerId: string; lastText: string }): BoundaryTurn => ({
+    speakerId: t.speakerId,
+    speakerName: nameOf(t.speakerId),
+    text: capLine(t.lastText),
+  });
+  const [a, b] = turns.slice(-2);
+  return { turns: [toTurn(a), toTurn(b)] };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd server && npm run test -- script-review`
+Expected: PASS (all 9 new `priorChapterBoundaryExchange` cases green; existing tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/script-review.ts server/src/routes/script-review.test.ts
+git commit -m "feat(server): fs-64 priorChapterBoundaryExchange helper with live-exchange gate"
+```
+
+---
+
+### Task 2: `priorExchange` param on `buildScriptReviewChapterInbox`
+
+Render the read-only context block above the sentences when an exchange is present; emit byte-identical output when absent.
+
+**Files:**
+- Modify: `server/src/routes/script-review.ts` (`buildScriptReviewChapterInbox`, line 78-108)
+- Test: `server/src/routes/script-review.test.ts` (new `describe` block + binding)
+
+**Interfaces:**
+- Consumes: `PriorExchange` (Task 1).
+- Produces: `buildScriptReviewChapterInbox(manuscriptId, chapterId, sentences, roster, priorExchange?: PriorExchange | null)` — 5th param defaults to `null`, so existing 4-arg callers are unaffected.
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend the type-import and add a binding (mirror Task 1):
+
+```ts
+import type {
+  buildReviewSentencesInput as BuildReviewSentencesInput,
+  priorChapterBoundaryExchange as PriorChapterBoundaryExchange,
+  buildScriptReviewChapterInbox as BuildScriptReviewChapterInbox,
+} from './script-review.js';
+```
+```ts
+let buildScriptReviewChapterInbox: typeof BuildScriptReviewChapterInbox;
+```
+In `beforeAll`, add `buildScriptReviewChapterInbox: bsrci` to the destructuring and `buildScriptReviewChapterInbox = bsrci;`.
+
+Add the test block:
+
+```ts
+describe('buildScriptReviewChapterInbox (fs-64 priorExchange)', () => {
+  const roster = [{ id: 'wren', name: 'Wren', role: 'protagonist' }];
+  const sentences = [{ id: 1, characterId: 'narrator', text: 'Hi.' }] as unknown as Parameters<
+    typeof buildScriptReviewChapterInbox
+  >[2];
+
+  it('is byte-identical to today when no priorExchange is given', () => {
+    const expected = `---
+manuscriptId: m1
+task: script-review
+chapterId: 2
+---
+
+## Cast roster (post-fold)
+
+\`\`\`json
+[
+  {
+    "id": "wren",
+    "name": "Wren",
+    "role": "protagonist"
+  }
+]
+\`\`\`
+
+## Sentences (already attributed)
+
+\`\`\`json
+[
+  {
+    "sentenceId": 1,
+    "characterId": "narrator",
+    "text": "Hi."
+  }
+]
+\`\`\`
+`;
+    expect(buildScriptReviewChapterInbox('m1', 2, sentences, roster)).toBe(expected);
+  });
+
+  it('renders the labelled block above the sentences, with no sentenceId', () => {
+    const out = buildScriptReviewChapterInbox('m1', 2, sentences, roster, {
+      turns: [
+        { speakerId: 'wren', speakerName: 'Wren', text: '"Where to?"' },
+        { speakerId: 'marlow', speakerName: 'Marlow', text: '"Somewhere safe."' },
+      ],
+    });
+    expect(out).toContain('Prior chapter');
+    expect(out).toContain('do NOT emit an op');
+    expect(out).toContain('Wren (id: wren): "Where to?"');
+    expect(out).toContain('Marlow (id: marlow): "Somewhere safe."');
+    expect(out).not.toContain('sentenceId": 1\n');
+    // block sits before the sentence list
+    expect(out.indexOf('Prior chapter')).toBeLessThan(out.indexOf('## Sentences'));
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd server && npm run test -- script-review`
+Expected: FAIL — the 5th-arg call is a type/arity error or the block is absent.
+
+- [ ] **Step 3: Implement the param + block**
+
+In `buildScriptReviewChapterInbox`, add the parameter and the block. Change the signature (line 78-83) to add `priorExchange: PriorExchange | null = null,` after `roster`, then build the block and inject it immediately before `## Sentences`:
+
+```ts
+export function buildScriptReviewChapterInbox(
+  manuscriptId: string,
+  chapterId: number,
+  sentences: SentenceOutput[],
+  roster: CastCharacterSlim[],
+  priorExchange: PriorExchange | null = null,
+): string {
+  const sentencePayload = buildReviewSentencesInput(sentences);
+  const rosterPayload = roster.map((c) => ({
+    id: c.id,
+    name: c.name,
+    ...(c.role ? { role: c.role } : {}),
+  }));
+  const priorBlock = priorExchange
+    ? '## Prior chapter — final exchange (reference only — not reviewable lines; do NOT emit an op on them)\n\n' +
+      priorExchange.turns.map((t) => `${t.speakerName} (id: ${t.speakerId}): ${t.text}`).join('\n') +
+      '\n\n'
+    : '';
+  return `---
+manuscriptId: ${manuscriptId}
+task: script-review
+chapterId: ${chapterId}
+---
+
+## Cast roster (post-fold)
+
+\`\`\`json
+${JSON.stringify(rosterPayload, null, 2)}
+\`\`\`
+
+${priorBlock}## Sentences (already attributed)
+
+\`\`\`json
+${JSON.stringify(sentencePayload, null, 2)}
+\`\`\`
+`;
+}
+```
+
+(When `priorBlock === ''`, `${priorBlock}## Sentences` reduces to the exact legacy text — the byte-identical test pins this.)
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd server && npm run test -- script-review`
+Expected: PASS (both new cases + the existing route tests, which call the 4-arg form, stay green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/script-review.ts server/src/routes/script-review.test.ts
+git commit -m "feat(server): fs-64 render prior-chapter exchange block in script-review prompt"
+```
+
+---
+
+### Task 3: `priorChapterIdFor` neighbor selector
+
+Pick the immediately-preceding non-excluded story chapter (no cascade).
+
+**Files:**
+- Modify: `server/src/routes/script-review.ts` (add the pure helper near Task 1's code)
+- Test: `server/src/routes/script-review.test.ts` (new `describe` block + binding)
+
+**Interfaces:**
+- Produces: `priorChapterIdFor(chapterId: number, allChapterIds: number[], excludedIds: Set<number>): number | null` — `allChapterIds` is the sorted-ascending key list of `byChapter`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add the type-import + binding (mirror Task 1), then:
+
+```ts
+describe('priorChapterIdFor (fs-64)', () => {
+  it('returns the nearest lower chapter id', () => {
+    expect(priorChapterIdFor(3, [1, 2, 3, 4], new Set())).toBe(2);
+  });
+  it('skips excluded chapters', () => {
+    expect(priorChapterIdFor(3, [1, 2, 3], new Set([2]))).toBe(1);
+  });
+  it('returns null for the first chapter (no lower id)', () => {
+    expect(priorChapterIdFor(1, [1, 2, 3], new Set())).toBeNull();
+  });
+  it('returns null when every lower chapter is excluded', () => {
+    expect(priorChapterIdFor(3, [1, 2, 3], new Set([1, 2]))).toBeNull();
+  });
+  it('handles non-contiguous ids', () => {
+    expect(priorChapterIdFor(10, [2, 5, 10, 11], new Set())).toBe(5);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd server && npm run test -- script-review`
+Expected: FAIL — `priorChapterIdFor is not a function`.
+
+- [ ] **Step 3: Implement the helper**
+
+In `server/src/routes/script-review.ts`, add near the other fs-64 helpers:
+
+```ts
+/* The immediately-preceding non-excluded story chapter, or null. No cascade:
+   selection skips only excluded chapters; whether that predecessor yields an
+   exchange is a separate gate (priorChapterBoundaryExchange). */
+export function priorChapterIdFor(
+  chapterId: number,
+  allChapterIds: number[],
+  excludedIds: Set<number>,
+): number | null {
+  const lower = allChapterIds.filter((id) => id < chapterId && !excludedIds.has(id));
+  return lower.length ? lower[lower.length - 1] : null;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd server && npm run test -- script-review`
+Expected: PASS (5 new cases green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/script-review.ts server/src/routes/script-review.test.ts
+git commit -m "feat(server): fs-64 priorChapterIdFor neighbor selector (no cascade)"
+```
+
+---
+
+### Task 4: Wire the helpers into the review route
+
+Compute the prior exchange once per chapter and pass it to the first chunk only; lift the excluded-chapter set so it applies on single-chapter requests too.
+
+**Files:**
+- Modify: `server/src/routes/script-review.ts` (route handler, lines 128-142 and the chunk loop 233-291)
+- Test: `server/src/routes/script-review.test.ts` (one new `it` in the existing route `describe`)
+
+**Interfaces:**
+- Consumes: `priorChapterIdFor`, `priorChapterBoundaryExchange` (Tasks 1, 3), `buildScriptReviewChapterInbox` 5th param (Task 2).
+
+- [ ] **Step 1: Write the failing test**
+
+Add inside the existing `describe('POST /api/books/:bookId/script-review', ...)`:
+
+```ts
+it('feeds the prior chapter exchange into the next chapter, first chunk only (fs-64)', async () => {
+  writeBook([
+    { id: 1, chapterId: 1, characterId: 'wren', text: '"Where to?"' },
+    { id: 2, chapterId: 1, characterId: 'marlow', text: '"Somewhere safe."' },
+    { id: 1, chapterId: 2, characterId: 'wren', text: '"I know this place."' },
+  ], [
+    { id: 1, title: 'One', excluded: false },
+    { id: 2, title: 'Two', excluded: false },
+  ]);
+  const prompts: Record<number, string> = {};
+  runReview.mockImplementation((_m: string, c: number, p: string) => {
+    prompts[c] = p;
+    return Promise.resolve({ ops: [] });
+  });
+
+  await request(app).post(`/api/books/${bookId}/script-review`).send({}).expect(200);
+
+  expect(prompts[2]).toContain('Prior chapter');
+  // The seeded cast.json has only `wren`, so `marlow` resolves to its id via the
+  // off-roster fallback — assert the fallback form `marlow (id: marlow)`.
+  expect(prompts[2]).toContain('marlow (id: marlow): "Somewhere safe."');
+  expect(prompts[1] ?? '').not.toContain('Prior chapter'); // chapter 1 has no predecessor
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd server && npm run test -- script-review`
+Expected: FAIL — `prompts[2]` does not contain `Prior chapter` (route not wired yet).
+
+- [ ] **Step 3: Lift the excluded set + compute the prior exchange**
+
+Replace the chapter-id setup block (currently lines 130-142):
+
+```ts
+    /* When chapterId is supplied in the body, limit the pass to that one chapter. */
+    let chapterIds = [...byChapter.keys()].sort((a, b) => a - b);
+    if (requestedChapterId !== undefined) {
+      chapterIds = chapterIds.filter((id) => id === requestedChapterId);
+    } else {
+      /* Whole-book review skips chapters the user excluded from narration
+         (front/back-matter). Mirrors the detect-emotions + generation filters.
+         An explicit per-chapter request above is honoured even when excluded. */
+      const excludedChapterIds = new Set<number>(
+        located.state.chapters.filter((c) => c.excluded).map((c) => c.id),
+      );
+      chapterIds = chapterIds.filter((id) => !excludedChapterIds.has(id));
+    }
+```
+
+with (excluded set lifted so neighbor selection can use it regardless of request mode):
+
+```ts
+    const allChapterIds = [...byChapter.keys()].sort((a, b) => a - b);
+    /* Chapters the user excluded from narration (front/back-matter). Mirrors the
+       detect-emotions + generation filters, and gates fs-64 neighbour selection. */
+    const excludedChapterIds = new Set<number>(
+      located.state.chapters.filter((c) => c.excluded).map((c) => c.id),
+    );
+
+    /* When chapterId is supplied in the body, limit the pass to that one chapter
+       (honoured even when excluded). Otherwise skip the excluded chapters. */
+    let chapterIds = allChapterIds;
+    if (requestedChapterId !== undefined) {
+      chapterIds = allChapterIds.filter((id) => id === requestedChapterId);
+    } else {
+      chapterIds = allChapterIds.filter((id) => !excludedChapterIds.has(id));
+    }
+```
+
+- [ ] **Step 4: Compute `priorExchange` per chapter and pass it to the first chunk**
+
+Inside the chapter loop, after `const chapterId = chapterIds[i];` and the `send({ kind: 'phase', ... })` call (around line 214-221), add:
+
+```ts
+        /* fs-64 — the prior chapter's final exchange (read-only) resolves a
+           tagless chapter-opening line. Null unless the immediately-preceding
+           non-excluded chapter ends in a live A/B exchange. */
+        const priorId = priorChapterIdFor(chapterId, allChapterIds, excludedChapterIds);
+        const priorExchange =
+          priorId !== null ? priorChapterBoundaryExchange(byChapter.get(priorId) ?? [], roster) : null;
+```
+
+Then convert the inner chunk loop (currently `for (const chunk of chunks) {` at line 233) to an indexed loop and pass `priorExchange` to the first chunk only. Change the loop header and the `buildScriptReviewChapterInbox` call:
+
+```ts
+        for (let index = 0; index < chunks.length; index += 1) {
+          const chunk = chunks[index];
+          if (closed) break;
+          const prompt = buildScriptReviewChapterInbox(
+            manuscriptId,
+            chapterId,
+            chunkWithContext(chunk),
+            roster,
+            index === 0 ? priorExchange : null,
+          );
+```
+
+(Leave the rest of the loop body — the `runScriptReviewChapter` call, the `owned` filter, the `catch` — unchanged.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd server && npm run test -- script-review`
+Expected: PASS — `prompts[2]` contains the block; `prompts[1]` does not; all prior tests stay green.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npm run typecheck`
+Expected: clean (no errors). `byChapter.get(priorId)` is `SentenceOutput[]` and `roster` is `CastCharacterSlim[]` — both structurally satisfy the helper's param types.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/routes/script-review.ts server/src/routes/script-review.test.ts
+git commit -m "feat(server): fs-64 wire prior-chapter exchange into the first chunk of each chapter"
+```
+
+---
+
+### Task 5: Document the context block in the review skill prompt
+
+Tell the model the block is read-only, carries no `sentenceId`, and must never be an op target.
+
+**Files:**
+- Modify: `skills/audiobook-script-review.md` (the `## Input` section, after item 2 at line 24; and one line in `## Rules` if a "never target" reinforcement fits the existing list)
+
+- [ ] **Step 1: Add the input description**
+
+In `skills/audiobook-script-review.md`, after item `2.` of `## Input` (line 24), add:
+
+```markdown
+3. OPTIONALLY, a `## Prior chapter — final exchange` block above the sentences.
+   It names the previous chapter's last two speakers and their closing lines —
+   read-only turn-taking context to help you attribute a tagless **opening**
+   line of THIS chapter. It carries **no `sentenceId`** and is **not reviewable**:
+   never emit an op targeting it; use only the named alternation to inform the
+   attribution of this chapter's own opening sentences.
+```
+
+- [ ] **Step 2: Verify the skill file reads coherently**
+
+Run: `git diff skills/audiobook-script-review.md`
+Expected: only the additive paragraph; numbering and surrounding sections intact.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/audiobook-script-review.md
+git commit -m "docs(skill): fs-64 document the read-only prior-chapter exchange block"
+```
+
+---
+
+### Task 6: Full verify + ship docs
+
+**Files:**
+- Modify: `docs/BACKLOG.md` (remove the `fs-64` row, lines 70-74)
+- (PR body carries `Closes #1120`.)
+
+- [ ] **Step 1: Run the full pre-push battery**
+
+Run: `npm run verify`
+Expected: typecheck + all tests + e2e + build green. If a pre-existing/unrelated flake fires (e.g. a `voices` e2e under parallel load — a documented repo flake), re-run that spec in isolation and note it; do not fix unrelated breakage in this branch.
+
+- [ ] **Step 2: Remove the BACKLOG row**
+
+Delete the `fs-64` entry in `docs/BACKLOG.md` (the `#### `fs-64` — cross-chapter context …` heading through its `_Full detail + acceptance:_` line, lines 70-74).
+
+Run: `grep -n "fs-64" docs/BACKLOG.md`
+Expected: no matches.
+
+- [ ] **Step 3: Commit the backlog removal**
+
+```bash
+git add docs/BACKLOG.md
+git commit -m "docs(docs): drop fs-64 backlog row (shipped via #1120)"
+```
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git push -u origin feat/server-fs64-cross-chapter-reattribute
+gh pr create --title "feat(server): fs-64 cross-chapter context for reattribute" \
+  --body "$(cat <<'BODY'
+## Summary
+Feeds the prior chapter's final two-speaker exchange into the script-review prompt as read-only context, gated on a genuine alternating exchange, so the LLM can resolve a tagless chapter-opening line via cross-chapter turn-taking. Strictly additive — gate-fail ⇒ today's prompt byte-for-byte. Zero new LLM calls.
+
+Spec: `docs/superpowers/specs/2026-06-26-fs64-cross-chapter-reattribute-context-design.md`
+
+Closes #1120
+
+## Test plan
+- `npm run verify` — typecheck + all tests + e2e + build green.
+- New unit tests: the live-exchange gate (`priorChapterBoundaryExchange`), the prompt block render + byte-identical-when-absent, the neighbour selector (`priorChapterIdFor`), and a route integration test (block on chapter 2's first chunk, absent on chapter 1).
+- `status: stable` for the spec still owes the on-box render acceptance (§9.5) — NOT included here.
+BODY
+)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** — every section maps to a task:
+- §4.1 helper + gate + constants + cap → **Task 1**.
+- §4.3 prompt block + byte-identical → **Task 2**.
+- §4.2 neighbor selection (no cascade) → **Task 3**.
+- §4.5 first-chunk-only wiring + lifted excluded set + full-budget chunking → **Task 4**.
+- §4.4 skill note → **Task 5**.
+- §4.6 read-only (no `sentenceId`) → enforced in Task 2's render + asserted in Tasks 2/4; documented in Task 5.
+- §6 tests → Tasks 1-4 land them; **Task 6** runs the full battery.
+- §9 ship (Closes #1120, BACKLOG row, on-box deferred to acceptance) → **Task 6**.
+- §5 edge cases → all covered by Task 1's nine cases (narration, monologue, unknown-male, beyond-window, residue, off-roster, empty) + Task 3 (first chapter, excluded, non-contiguous) + Task 4 (first-chunk/no-predecessor).
+
+**2. Placeholder scan** — no `TBD`/`TODO`/"handle edge cases"; every code step shows the full code; every test step shows real assertions.
+
+**3. Type consistency** — `priorChapterBoundaryExchange` returns `PriorExchange | null` (Task 1) and is consumed as the 5th arg of `buildScriptReviewChapterInbox(... , priorExchange: PriorExchange | null = null)` (Task 2) and in the route (Task 4). `priorChapterIdFor(... ): number | null` (Task 3) feeds `byChapter.get(priorId)` (Task 4). `BoundaryTurn`/`PriorExchange` names are identical across tasks. The on-box acceptance (§9.5) is intentionally NOT a task — it gates `status: stable` after merge.

--- a/docs/superpowers/plans/2026-06-26-fs64-cross-chapter-reattribute.md
+++ b/docs/superpowers/plans/2026-06-26-fs64-cross-chapter-reattribute.md
@@ -17,6 +17,7 @@
 - **Commits:** `feat(server): …` (or `test(server):` / `docs(skill):` where apt). Branch `feat/server-fs64-cross-chapter-reattribute`.
 - **Constants:** `PRIOR_TURN_LOOKBACK = 6`, `MAX_PRIOR_TURN_CHARS = 240`.
 - **Run server tests with:** `cd server && npm run test -- script-review` (Vitest single-run, node env).
+- **Test-binding pattern:** Tasks 1-3 each add a dynamic-import binding to the **same** `beforeAll` destructuring (mirroring the existing `buildReviewSentencesInput` binding at `script-review.test.ts:20/30/131-133`). Execute the tasks in order; each task's "extend the destructuring" edit targets the block **as already modified by the previous task**, not the pristine file.
 
 ---
 
@@ -331,7 +332,12 @@ chapterId: 2
     expect(out).toContain('do NOT emit an op');
     expect(out).toContain('Wren (id: wren): "Where to?"');
     expect(out).toContain('Marlow (id: marlow): "Somewhere safe."');
-    expect(out).not.toContain('sentenceId": 1\n');
+    // §4.6 read-only guard: the block region must surface NO sentenceId (so a
+    // block-targeted op is unconstructible). Scan ONLY the block, not the whole
+    // prompt — the legitimate sentence payload below DOES contain "sentenceId".
+    const block = out.slice(out.indexOf('Prior chapter'), out.indexOf('## Sentences'));
+    expect(block).not.toContain('sentenceId');
+    expect(block).not.toMatch(/"id"\s*:\s*\d/); // no numeric id leaks into the block
     // block sits before the sentence list
     expect(out.indexOf('Prior chapter')).toBeLessThan(out.indexOf('## Sentences'));
   });
@@ -341,7 +347,7 @@ chapterId: 2
 - [ ] **Step 2: Run the tests to verify they fail**
 
 Run: `cd server && npm run test -- script-review`
-Expected: FAIL — the 5th-arg call is a type/arity error or the block is absent.
+Expected: the **`renders the labelled block`** test FAILS (the block is absent — the 5th arg isn't read yet). The **`byte-identical`** test is a *regression guard*, not a TDD red: it already passes against today's 4-arg output and must stay green after Step 3 (it pins "the new param adds zero characters when absent"). If the whole file errors instead of just failing that one case, the 5-arg call is a compile error — that's still a valid red; Step 3 resolves it.
 
 - [ ] **Step 3: Implement the param + block**
 
@@ -514,12 +520,86 @@ it('feeds the prior chapter exchange into the next chapter, first chunk only (fs
   expect(prompts[2]).toContain('marlow (id: marlow): "Somewhere safe."');
   expect(prompts[1] ?? '').not.toContain('Prior chapter'); // chapter 1 has no predecessor
 });
+
+it('attaches the block to the FIRST chunk only of a multi-chunk chapter (fs-64)', async () => {
+  // Force the local engine + small num_ctx so chapter 10 splits into >=2 chunks
+  // (mirrors the existing "chunks a large chapter" harness). Chapter 9 ends A/B,
+  // so chapter 10's FIRST chunk must carry the block and later chunks must not.
+  engineState.engine = 'local';
+  process.env.ANALYZER_NUM_CTX = '400'; // → budget 2000
+  const big = Array.from({ length: 12 }, (_, i) => ({
+    id: 100 + i, chapterId: 10, characterId: 'narrator', text: 'A'.repeat(800),
+  }));
+  writeBook([
+    { id: 1, chapterId: 9, characterId: 'wren', text: '"Where to?"' },
+    { id: 2, chapterId: 9, characterId: 'marlow', text: '"Somewhere safe."' },
+    ...big,
+  ], [{ id: 9, title: 'Nine', excluded: false }, { id: 10, title: 'Ten', excluded: false }]);
+
+  const calls: Array<{ chapterId: number; prompt: string }> = [];
+  runReview.mockImplementation((_m: string, c: number, p: string) => {
+    calls.push({ chapterId: c, prompt: p });
+    return Promise.resolve({ ops: [] });
+  });
+
+  await request(app).post(`/api/books/${bookId}/script-review`).send({}).expect(200);
+
+  const ch10 = calls.filter((c) => c.chapterId === 10).map((c) => c.prompt);
+  expect(ch10.length).toBeGreaterThan(1); // the chapter split
+  expect(ch10[0]).toContain('Prior chapter'); // first chunk carries it
+  expect(ch10.slice(1).every((p) => !p.includes('Prior chapter'))).toBe(true); // later chunks don't
+});
+
+it('emits NO block when the predecessor ends on narration — scene break (fs-64)', async () => {
+  // The headline regression guard: a non-exchange ending must not feed a
+  // misleading turn-taking signal into the next chapter.
+  writeBook([
+    { id: 1, chapterId: 1, characterId: 'wren', text: '"Anyone there?"' },
+    { id: 2, chapterId: 1, characterId: 'narrator', text: 'Silence answered.' },
+    { id: 1, chapterId: 2, characterId: 'wren', text: '"I knew it."' },
+  ], [{ id: 1, title: 'One', excluded: false }, { id: 2, title: 'Two', excluded: false }]);
+  const prompts: Record<number, string> = {};
+  runReview.mockImplementation((_m: string, c: number, p: string) => {
+    prompts[c] = p;
+    return Promise.resolve({ ops: [] });
+  });
+
+  await request(app).post(`/api/books/${bookId}/script-review`).send({}).expect(200);
+
+  expect(prompts[2] ?? '').not.toContain('Prior chapter'); // gate failed → no block
+});
+
+it('does NOT cascade past the immediately-preceding chapter (fs-64)', async () => {
+  // ch1 ends A/B, ch2 ends on narration (gate fails). ch3 must NOT pick up ch1's
+  // exchange — selection takes ch2 (immediate predecessor) and stops.
+  writeBook([
+    { id: 1, chapterId: 1, characterId: 'wren', text: '"Where to?"' },
+    { id: 2, chapterId: 1, characterId: 'marlow', text: '"Somewhere safe."' },
+    { id: 1, chapterId: 2, characterId: 'wren', text: '"Wait."' },
+    { id: 2, chapterId: 2, characterId: 'narrator', text: 'The door closed.' },
+    { id: 1, chapterId: 3, characterId: 'wren', text: '"Still here."' },
+  ], [
+    { id: 1, title: 'One', excluded: false },
+    { id: 2, title: 'Two', excluded: false },
+    { id: 3, title: 'Three', excluded: false },
+  ]);
+  const prompts: Record<number, string> = {};
+  runReview.mockImplementation((_m: string, c: number, p: string) => {
+    prompts[c] = p;
+    return Promise.resolve({ ops: [] });
+  });
+
+  await request(app).post(`/api/books/${bookId}/script-review`).send({}).expect(200);
+
+  expect(prompts[2] ?? '').toContain('Prior chapter');       // ch1 ended A/B → ch2 gets it
+  expect(prompts[3] ?? '').not.toContain('Prior chapter');   // ch2 ended narration → no cascade to ch1
+});
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [ ] **Step 2: Run the tests to verify they fail**
 
 Run: `cd server && npm run test -- script-review`
-Expected: FAIL — `prompts[2]` does not contain `Prior chapter` (route not wired yet).
+Expected: the four new fs-64 route tests FAIL — no prompt contains `Prior chapter` (route not wired yet). The two absence-asserting tests (`no block when predecessor ends on narration`, the `ch3` arm of `no cascade`) pass trivially pre-wiring; the positive arms (`first chunk only`, the `ch2 gets it` arm) are the genuine reds that Step 4 turns green.
 
 - [ ] **Step 3: Lift the excluded set + compute the prior exchange**
 
@@ -591,10 +671,10 @@ Then convert the inner chunk loop (currently `for (const chunk of chunks) {` at 
 
 (Leave the rest of the loop body — the `runScriptReviewChapter` call, the `owned` filter, the `catch` — unchanged.)
 
-- [ ] **Step 5: Run the test to verify it passes**
+- [ ] **Step 5: Run the tests to verify they pass**
 
 Run: `cd server && npm run test -- script-review`
-Expected: PASS — `prompts[2]` contains the block; `prompts[1]` does not; all prior tests stay green.
+Expected: PASS — all four fs-64 route tests green (block on the predecessor-has-exchange cases, absent on the scene-break and no-cascade cases, first-chunk-only on the multi-chunk case); all prior tests stay green.
 
 - [ ] **Step 6: Typecheck**
 
@@ -647,7 +727,7 @@ git commit -m "docs(skill): fs-64 document the read-only prior-chapter exchange 
 ### Task 6: Full verify + ship docs
 
 **Files:**
-- Modify: `docs/BACKLOG.md` (remove the `fs-64` row, lines 70-74)
+- Modify: `docs/BACKLOG.md` (remove the `fs-64` row, lines 70-**75** — include the trailing blank line so no double blank is left behind)
 - (PR body carries `Closes #1120`.)
 
 - [ ] **Step 1: Run the full pre-push battery**
@@ -657,10 +737,10 @@ Expected: typecheck + all tests + e2e + build green. If a pre-existing/unrelated
 
 - [ ] **Step 2: Remove the BACKLOG row**
 
-Delete the `fs-64` entry in `docs/BACKLOG.md` (the `#### `fs-64` — cross-chapter context …` heading through its `_Full detail + acceptance:_` line, lines 70-74).
+Delete the `fs-64` entry in `docs/BACKLOG.md` (the `#### `fs-64` — cross-chapter context …` heading through its `_Full detail + acceptance:_` line **plus the following blank line**, lines 70-75 — verify line numbers haven't drifted before deleting).
 
 Run: `grep -n "fs-64" docs/BACKLOG.md`
-Expected: no matches.
+Expected: no matches. Eyeball the diff for a stray double blank line between the neighbouring items.
 
 - [ ] **Step 3: Commit the backlog removal**
 
@@ -698,10 +778,10 @@ BODY
 - §4.1 helper + gate + constants + cap → **Task 1**.
 - §4.3 prompt block + byte-identical → **Task 2**.
 - §4.2 neighbor selection (no cascade) → **Task 3**.
-- §4.5 first-chunk-only wiring + lifted excluded set + full-budget chunking → **Task 4**.
+- §4.5 first-chunk-only wiring + lifted excluded set + full-budget chunking → **Task 4** (the multi-chunk route test pins first-chunk-only and, via the existing "exactly once" test, that the chapter's own ops are unperturbed).
 - §4.4 skill note → **Task 5**.
-- §4.6 read-only (no `sentenceId`) → enforced in Task 2's render + asserted in Tasks 2/4; documented in Task 5.
-- §6 tests → Tasks 1-4 land them; **Task 6** runs the full battery.
+- §4.6 read-only (no `sentenceId`) → enforced by Task 2's render (the block surfaces only character id + text) and **pinned by Task 2's block-region assertion** (`block` between `Prior chapter` and `## Sentences` contains no `sentenceId`/numeric id). NOTE: the §6 line "a model op referencing the context yields no out-of-chapter op" is NOT code-enforceable here (ops are emitted, not applied; `ownsOp` filters by colliding per-chapter ids), so "block carries no sentenceId" is the only handle — and Task 2 now actually pins it. Documented in Task 5.
+- §6 tests → Tasks 1-4 land them, including the route-level **scene-break negative** and **no-cascade** guards (Task 4) for the headline regression; **Task 6** runs the full battery.
 - §9 ship (Closes #1120, BACKLOG row, on-box deferred to acceptance) → **Task 6**.
 - §5 edge cases → all covered by Task 1's nine cases (narration, monologue, unknown-male, beyond-window, residue, off-roster, empty) + Task 3 (first chapter, excluded, non-contiguous) + Task 4 (first-chunk/no-predecessor).
 

--- a/docs/superpowers/plans/2026-06-26-fs64-cross-chapter-reattribute.md
+++ b/docs/superpowers/plans/2026-06-26-fs64-cross-chapter-reattribute.md
@@ -487,7 +487,7 @@ Compute the prior exchange once per chapter and pass it to the first chunk only;
 
 **Files:**
 - Modify: `server/src/routes/script-review.ts` (route handler, lines 128-142 and the chunk loop 233-291)
-- Test: `server/src/routes/script-review.test.ts` (one new `it` in the existing route `describe`)
+- Test: `server/src/routes/script-review.test.ts` (four new `it`s in the existing route `describe`: positive single-chunk, multi-chunk first-chunk-only, scene-break negative, no-cascade)
 
 **Interfaces:**
 - Consumes: `priorChapterIdFor`, `priorChapterBoundaryExchange` (Tasks 1, 3), `buildScriptReviewChapterInbox` 5th param (Task 2).
@@ -599,7 +599,7 @@ it('does NOT cascade past the immediately-preceding chapter (fs-64)', async () =
 - [ ] **Step 2: Run the tests to verify they fail**
 
 Run: `cd server && npm run test -- script-review`
-Expected: the four new fs-64 route tests FAIL — no prompt contains `Prior chapter` (route not wired yet). The two absence-asserting tests (`no block when predecessor ends on narration`, the `ch3` arm of `no cascade`) pass trivially pre-wiring; the positive arms (`first chunk only`, the `ch2 gets it` arm) are the genuine reds that Step 4 turns green.
+Expected: the **three positive arms** go RED — `feeds the prior chapter exchange…`, `attaches the block to the FIRST chunk only…`, and the `ch2`-gets-the-block arm of the no-cascade test (no prompt contains `Prior chapter` yet). The **two pure-absence tests** (`emits NO block when the predecessor ends on narration`, and the `ch3` arm of no-cascade) pass even pre-wiring — that is expected, they are regression guards. Step 4 turns the red arms green.
 
 - [ ] **Step 3: Lift the excluded set + compute the prior exchange**
 
@@ -764,7 +764,7 @@ Closes #1120
 
 ## Test plan
 - `npm run verify` — typecheck + all tests + e2e + build green.
-- New unit tests: the live-exchange gate (`priorChapterBoundaryExchange`), the prompt block render + byte-identical-when-absent, the neighbour selector (`priorChapterIdFor`), and a route integration test (block on chapter 2's first chunk, absent on chapter 1).
+- New unit tests: the live-exchange gate (`priorChapterBoundaryExchange`, 9 cases), the prompt block render + byte-identical-when-absent + block-region read-only guard, the neighbour selector (`priorChapterIdFor`), and four route tests (positive single-chunk, multi-chunk first-chunk-only, scene-break predecessor ⇒ no block, 3-chapter no-cascade).
 - `status: stable` for the spec still owes the on-box render acceptance (§9.5) — NOT included here.
 BODY
 )"

--- a/docs/superpowers/specs/2026-06-26-fs64-cross-chapter-reattribute-context-design.md
+++ b/docs/superpowers/specs/2026-06-26-fs64-cross-chapter-reattribute-context-design.md
@@ -1,0 +1,180 @@
+---
+title: 'fs-64 — Cross-chapter context for `reattribute` (script-review)'
+status: draft
+date: 2026-06-26
+issue: '#1120'
+related:
+  - 2026-06-25-fs58-unit-b-reattribute-flag-nonstory-design.md (Unit B — defines `reattribute`; §3.6 names this straddle limitation, §8 files it as a follow-up)
+  - 2026-06-23-fs58-llm-script-review-design.md (Unit A — the per-chapter review pass + chunker this builds on)
+  - Russian stage-2 attribution under-production (plan 221) — the mis-attribution pain `reattribute` targets
+---
+
+# fs-64 — Cross-chapter context for `reattribute`
+
+> **Follow-up from fs-58 Unit B** (`2026-06-25-fs58-unit-b-reattribute-flag-nonstory-design.md`,
+> PR #1118). Unit B's §3.6 accepted a v1 limitation: `script-review` reviews **one chapter at a
+> time**, so a chapter-opening tagless line whose speaker is set by the *previous* chapter's last
+> turn cannot be resolved by turn-taking — the review pass never sees across the boundary. This
+> spec closes that straddle by feeding the prior chapter's **last speaking turn** into each
+> chapter's existing prompt as read-only context. Strictly additive; **zero new LLM calls**.
+
+## 1. Summary
+
+When the script-review pass reviews a chapter, prepend the **prior chapter's last speaking turn**
+(speaker + their line) to the **first chunk** of that chapter's review prompt, clearly labelled as
+**reference-only** context. This gives the model the turn-taking signal it needs to resolve a
+tagless chapter-opening dialogue line (e.g. `"I know," she said.`) whose speaker is whoever spoke
+last at the end of the previous chapter.
+
+**Additive throughout.** When there is no prior speaking turn (first story chapter, prior chapter is
+pure narration, prior chapter empty), the prompt is **byte-identical to today**. No schema change, no
+`api-types` regen, no frontend change.
+
+## 2. The straddle (what Unit B §3.6 left open)
+
+`script-review` builds a per-chapter prompt in `buildScriptReviewChapterInbox`
+(`server/src/routes/script-review.ts:78`) containing only **that chapter's** sentences plus the
+post-fold roster. A chapter that opens on a tagless dialogue line has nothing in-prompt that tells
+the model who spoke last — the alternation that resolves it lives at the **end of the previous
+chapter**. The within-chapter chunker already carries `overlap: 3` context between chunks of the
+same chapter (`chapter-chunker.ts`), but that overlap stops at the chapter boundary. Result:
+chapter-opening straddle lines are mis-resolved (often defaulting to narrator or the wrong speaker).
+
+## 3. Why the cheap path, not "book-wide runs"
+
+The issue note (#1120) frames this as *"cross-chapter context pushes toward larger / book-wide
+runs"* — weighing the fix against RPD cost. That tradeoff only exists for one implementation
+(stitching whole chapters together into bigger calls). The path here avoids it entirely:
+
+- The route already loads the **whole book** into `byChapter` via
+  `loadPostFoldSentencesByChapter` (`script-review.ts:128`), even on a single-chapter request. The
+  prior chapter's tail is therefore **already in memory** — free to fetch.
+- We add the tail as **a few extra tokens** to a prompt we are **already sending**. No extra call is
+  made → **zero RPD impact**, no change to the per-chapter vs whole-book opt-in.
+
+## 4. Components
+
+### 4.1 New pure helper — `priorChapterSpeakingTurn(sentences, roster)`
+
+Lives in `script-review.ts` (exported, unit-tested like `buildReviewSentencesInput`).
+
+- **Input:** the prior chapter's post-fold sentence array + the roster (for name resolution).
+- **Behaviour:** walk **backward** from the end of the array, skipping narration
+  (`characterId === 'narrator'`; the canonical `NARRATOR_ID` from `byline-author-guard.ts:12`),
+  within a **6-sentence look-back cap**. The first non-narrator sentence found marks the speaker;
+  gather that sentence's **contiguous same-speaker run** (within the array) — that run *is* "the
+  turn". Concatenate its text (trimmed/space-joined). Resolve `speakerName` from the roster (fall
+  back to the raw `characterId` if absent).
+- **Output:** `{ speakerId: string; speakerName: string; text: string } | null`.
+- **Returns `null`** when: the prior chapter is empty, is all narration, or the last speaking turn
+  lies **beyond** the 6-sentence cap (a chapter ending on a long narration block has no live
+  dialogue at the boundary → no useful turn-taking signal, so we send nothing rather than reach
+  arbitrarily far back).
+
+### 4.2 Neighbor selection — "the prior chapter"
+
+The prior chapter = the **nearest lower chapter id present in `byChapter` that is not `excluded` and
+has sentences**. Computed off the full sorted `byChapter` key list (the in-memory whole-book map),
+**not** the filtered `chapterIds`, so it resolves identically on a single-chapter request and on a
+whole-book run. Excluded chapters (front-/back-matter, per `located.state.chapters[].excluded`) are
+skipped so turn-taking continuity holds between **story** chapters. The first story chapter has no
+qualifying prior → no context block.
+
+### 4.3 Prompt change — `buildScriptReviewChapterInbox`
+
+Add an optional `priorTurn?: { speakerName: string; speakerId: string; text: string }` param. When
+present, render a labelled section **above** the `## Sentences` block:
+
+```
+## Prior chapter — last speaking turn (reference only — do NOT emit ops on this)
+
+Aldous (id: aldous): "Then we're agreed. Dawn, at the colliery gate."
+```
+
+When absent, the function emits **exactly today's prompt** (the param defaults to omitted).
+
+### 4.4 Skill-prompt note
+
+`skills/audiobook-script-review.md` gains one short paragraph: the "Prior chapter — last speaking
+turn" block, when present, is **read-only** turn-taking context for resolving a tagless chapter-
+opening line. The model must **never** emit an op targeting it; it carries no reviewable
+`sentenceId`.
+
+### 4.5 Route wiring — first chunk only
+
+In the chunk loop (`script-review.ts:233`), pass `priorTurn` **only to the first chunk of each
+chapter** (`chunkIndex === 0`). The straddle is the chapter *opening*; later chunks already receive
+in-chapter overlap context from the chunker, so prior-chapter context there is wasted tokens. The
+`priorTurn` for chapter *N* is computed once per chapter (§4.2) before the chunk loop.
+
+### 4.6 Read-only enforcement
+
+The context turn is **not a reviewable sentence**: its source `sentenceId` belongs to the prior
+chapter and is therefore **not** in the current chunk's `coreIds`. The existing owned-op filter —
+`result.ops.filter((op) => ownsOp(chunk.coreIds, primarySentenceId(op)))` (`script-review.ts:268`)
+— already drops any op the model emits against it. We keep that as the primary guard **and** add a
+unit test pinning the invariant, so a future chunker change cannot silently let a context-targeted
+op leak into `send({ kind: 'ops' })`.
+
+## 5. Edge cases (all handled — no open questions)
+
+| Case | Behaviour |
+|---|---|
+| First story chapter (no qualifying prior) | No context block; prompt byte-identical to today. |
+| Prior chapter is pure narration | Helper returns `null` → no block. |
+| Prior chapter ends on a long narration block (last speaker beyond cap) | Helper returns `null` → no block (no live boundary turn-taking). |
+| Prior chapter empty / no attributed sentences | Skipped by neighbor selection; next-lower story chapter considered. |
+| Single-chapter request | Prior fetched from the whole-book `byChapter` map → identical behaviour. |
+| Speaker off the current roster | Still labelled by name (or raw id); used purely as turn-taking signal, never as an op target. |
+| Excluded (front/back-matter) chapter as neighbor | Skipped; nearest lower **non-excluded** story chapter used. |
+
+## 6. Testing
+
+- **Unit — `priorChapterSpeakingTurn`:** ends-on-dialogue (returns that turn); ends-on-narration-
+  within-cap (walks back, returns the dialogue turn); ends-on-narration-beyond-cap (`null`);
+  all-narration (`null`); empty (`null`); multi-sentence contiguous run (joined text);
+  speaker-name resolved from roster; off-roster speaker falls back to id.
+- **Unit — `buildScriptReviewChapterInbox`:** renders the labelled block when given `priorTurn`;
+  omits it (byte-identical to today) when not.
+- **Unit/route — read-only guard:** an op whose primary sentence is the prior-chapter context id is
+  dropped (not present in `coreIds`), pinning §4.6.
+- **Neighbor selection:** picks the nearest lower non-excluded chapter; skips excluded; returns no
+  prior for the first story chapter.
+- **No e2e.** This is a server-side prompt-assembly change with no new UI seam, router, or redux
+  path — Playwright would add nothing. (Called out explicitly per the testing-discipline bar.)
+- **Manual / on-box acceptance:** a real Coalfall run where a chapter opens on a tagless line —
+  confirm it now resolves to the prior chapter's last speaker. Folded into the existing fs-58 Unit B
+  on-box acceptance debt.
+
+## 7. New-infra summary
+
+**New — server:** the `priorChapterSpeakingTurn` helper + the `priorTurn` param + section on
+`buildScriptReviewChapterInbox` + the neighbor-selection + first-chunk wiring in the route
+(`script-review.ts`); one paragraph in `skills/audiobook-script-review.md`.
+
+**New — client:** none.
+
+**Schema / api-types:** none.
+
+## 8. Non-goals
+
+- No whole-chapter or whole-book context stitching (the expensive interpretation §3 rejects).
+- No context beyond the **first** chunk of a chapter.
+- No reach past the 6-sentence look-back cap (a chapter ending on long narration gets no boundary
+  context by design).
+- No new endpoint, op class, schema field, or frontend surface.
+- No auto-voicing / cast changes (separate Unit B follow-up #1118).
+
+## 9. Ship checklist
+
+1. Land the helper + prompt change + route wiring + skill note with paired unit tests (§6).
+2. `npm run verify` green (typecheck + tests + e2e + build).
+3. Close **#1120**; remove its `docs/BACKLOG.md` row; update `docs/features/INDEX.md` if this spec
+   moves to `archive/` on ship.
+4. Set this spec `status: stable` + fill Ship notes (date + SHA) once on-box acceptance confirms the
+   straddle resolves; `git mv` to `docs/features/archive/` (or keep under `specs/`, matching the
+   fs-58 sibling specs' home).
+
+## Ship notes
+
+_(filled on ship — date, merge SHA, on-box acceptance result.)_

--- a/docs/superpowers/specs/2026-06-26-fs64-cross-chapter-reattribute-context-design.md
+++ b/docs/superpowers/specs/2026-06-26-fs64-cross-chapter-reattribute-context-design.md
@@ -4,7 +4,7 @@ status: draft
 date: 2026-06-26
 issue: '#1120'
 related:
-  - 2026-06-25-fs58-unit-b-reattribute-flag-nonstory-design.md (Unit B — defines `reattribute`; §3.6 names this straddle limitation, §8 files it as a follow-up)
+  - 2026-06-25-fs58-unit-b-reattribute-flag-nonstory-design.md (Unit B — defines `reattribute`; §3.6 names this straddle limitation, §8 files it as a follow-up; PR #1118 MERGED, so the `reattribute` op this needs already ships)
   - 2026-06-23-fs58-llm-script-review-design.md (Unit A — the per-chapter review pass + chunker this builds on)
   - Russian stage-2 attribution under-production (plan 221) — the mis-attribution pain `reattribute` targets
 ---
@@ -12,23 +12,34 @@ related:
 # fs-64 — Cross-chapter context for `reattribute`
 
 > **Follow-up from fs-58 Unit B** (`2026-06-25-fs58-unit-b-reattribute-flag-nonstory-design.md`,
-> PR #1118). Unit B's §3.6 accepted a v1 limitation: `script-review` reviews **one chapter at a
-> time**, so a chapter-opening tagless line whose speaker is set by the *previous* chapter's last
-> turn cannot be resolved by turn-taking — the review pass never sees across the boundary. This
-> spec closes that straddle by feeding the prior chapter's **last speaking turn** into each
-> chapter's existing prompt as read-only context. Strictly additive; **zero new LLM calls**.
+> PR #1118, merged). Unit B's §3.6 accepted a v1 limitation: `script-review` reviews **one chapter at
+> a time**, so a chapter-opening tagless line whose speaker is set by the *previous* chapter's last
+> turn cannot be resolved by turn-taking — the review pass never sees across the boundary. This spec
+> **feeds the model the signal it needs** to resolve that straddle: the prior chapter's last speaking
+> turn, fed into the chapter's existing prompt as read-only context — **but only when the prior
+> chapter actually ends in a live dialogue exchange** (the common case is a scene break, where the
+> signal would be misleading). Strictly additive; **zero new LLM calls**.
+>
+> **Revised 2026-06-26 after a three-reviewer adversarial round** (code-grounding, design,
+> scope/test-adequacy). The round corrected: a false read-only-guard premise (per-chapter ids, §4.6);
+> an unbounded, non-budget-accounted context block (§4.1/§4.5); array-order vs reading-order and
+> `excludeFromSynthesis` filtering in the tail walk (§4.1); a conflated null/selection fallback
+> (§4.2); a YAGNI run-join (cut); over-claimed "closes the straddle" language (hedged, §6/§9); and the
+> scene-break premise itself — which is now gated, not assumed (§4.1).
 
 ## 1. Summary
 
 When the script-review pass reviews a chapter, prepend the **prior chapter's last speaking turn**
-(speaker + their line) to the **first chunk** of that chapter's review prompt, clearly labelled as
-**reference-only** context. This gives the model the turn-taking signal it needs to resolve a
-tagless chapter-opening dialogue line (e.g. `"I know," she said.`) whose speaker is whoever spoke
-last at the end of the previous chapter.
+(speaker name + their single last line, char-capped) to the **first chunk** of that chapter's review
+prompt, labelled as **reference-only** context — **gated** on the prior chapter ending in a genuine
+alternating exchange (≥2 distinct non-narrator speakers alternating at the boundary). This gives the
+model the turn-taking signal to resolve a tagless chapter-opening line (e.g. `"I know," she said.`)
+*when, and only when,* cross-chapter turn-taking is plausible. On a scene-break / narration /
+monologue ending — the common case — nothing is emitted.
 
-**Additive throughout.** When there is no prior speaking turn (first story chapter, prior chapter is
-pure narration, prior chapter empty), the prompt is **byte-identical to today**. No schema change, no
-`api-types` regen, no frontend change.
+**Additive throughout.** When the gate yields no boundary turn (first story chapter, scene-break
+ending, all-narration, residue-only tail), the prompt is **byte-identical to today**. No schema
+change, no `api-types` regen, no frontend change.
 
 ## 2. The straddle (what Unit B §3.6 left open)
 
@@ -36,144 +47,194 @@ pure narration, prior chapter empty), the prompt is **byte-identical to today**.
 (`server/src/routes/script-review.ts:78`) containing only **that chapter's** sentences plus the
 post-fold roster. A chapter that opens on a tagless dialogue line has nothing in-prompt that tells
 the model who spoke last — the alternation that resolves it lives at the **end of the previous
-chapter**. The within-chapter chunker already carries `overlap: 3` context between chunks of the
-same chapter (`chapter-chunker.ts`), but that overlap stops at the chapter boundary. Result:
-chapter-opening straddle lines are mis-resolved (often defaulting to narrator or the wrong speaker).
+chapter**. The within-chapter chunker carries `overlap: 3` context between chunks of the *same*
+chapter (`chapter-chunker.ts:58`); for the **first** chunk `start === 0`, so the before-context is
+empty (`chunkWithContext`, `chapter-chunker.ts:71`) — and the chunker only ever sees one chapter's
+array (`script-review.ts:227`), so overlap never crosses the boundary. That empty first-chunk
+before-context is exactly the gap.
 
 ## 3. Why the cheap path, not "book-wide runs"
 
 The issue note (#1120) frames this as *"cross-chapter context pushes toward larger / book-wide
 runs"* — weighing the fix against RPD cost. That tradeoff only exists for one implementation
-(stitching whole chapters together into bigger calls). The path here avoids it entirely:
+(stitching whole chapters together into bigger calls). The path here avoids it:
 
-- The route already loads the **whole book** into `byChapter` via
-  `loadPostFoldSentencesByChapter` (`script-review.ts:128`), even on a single-chapter request. The
-  prior chapter's tail is therefore **already in memory** — free to fetch.
-- We add the tail as **a few extra tokens** to a prompt we are **already sending**. No extra call is
-  made → **zero RPD impact**, no change to the per-chapter vs whole-book opt-in.
+- The route already loads the **whole book** into `byChapter` via `loadPostFoldSentencesByChapter`
+  (`script-review.ts:128`); the single-chapter narrowing happens *after*, on the `chapterIds`
+  iteration list only (`script-review.ts:131-133`), never on `byChapter`. So the prior chapter's
+  sentences are **already in memory** on any request — free to fetch via `byChapter.get(priorId)`.
+- We add a **bounded** context block (one sentence, hard char cap — §4.1) to a prompt we are
+  **already sending**. No extra call → **zero RPD impact**. The block's size is **deducted from the
+  first chunk's budget** (§4.5) so it cannot overflow a local model's context window.
 
 ## 4. Components
 
-### 4.1 New pure helper — `priorChapterSpeakingTurn(sentences, roster)`
+### 4.1 New pure helper — `priorChapterBoundaryTurn(sentences, roster)`
 
-Lives in `script-review.ts` (exported, unit-tested like `buildReviewSentencesInput`).
+Lives in `script-review.ts` (exported, unit-tested like `buildReviewSentencesInput`). Constants:
+`PRIOR_TURN_LOOKBACK = 6` (sentences scanned back from the chapter end — "live exchange must be near
+the boundary; a turn further back is a scene break, not a continuation") and
+`MAX_PRIOR_TURN_CHARS = 240` (hard cap on the rendered line; longer text is truncated with `…`).
 
-- **Input:** the prior chapter's post-fold sentence array + the roster (for name resolution).
-- **Behaviour:** walk **backward** from the end of the array, skipping narration
-  (`characterId === 'narrator'`; the canonical `NARRATOR_ID` from `byline-author-guard.ts:12`),
-  within a **6-sentence look-back cap**. The first non-narrator sentence found marks the speaker;
-  gather that sentence's **contiguous same-speaker run** (within the array) — that run *is* "the
-  turn". Concatenate its text (trimmed/space-joined). Resolve `speakerName` from the roster (fall
-  back to the raw `characterId` if absent).
-- **Output:** `{ speakerId: string; speakerName: string; text: string } | null`.
-- **Returns `null`** when: the prior chapter is empty, is all narration, or the last speaking turn
-  lies **beyond** the 6-sentence cap (a chapter ending on a long narration block has no live
-  dialogue at the boundary → no useful turn-taking signal, so we send nothing rather than reach
-  arbitrarily far back).
+- **Input:** the prior chapter's post-fold sentence sequence + the roster (for name resolution).
+- **Reading order:** walk back from the **end of the chapter's post-fold sequence** — the same
+  sequence the chunker reviews (`byChapter.get(id)` order). *(Caveat: end-of-chapter split offspring
+  are appended out of strict reading order — a wrinkle this route already shares with the chunker;
+  out of scope to fix here, noted so the test author doesn't over-specify.)*
+- **Eligible sentences:** skip narration (`characterId === NARRATOR_ID`, imported from
+  `byline-author-guard.ts`) **and** `excludeFromSynthesis === true` residue (mirrors the synth-path
+  filter; a `flag_nonstory` line must never become a turn-taking signal, nor consume the cap).
+- **Turns:** over the last `PRIOR_TURN_LOOKBACK` sentences, collapse eligible sentences into *turns*
+  (contiguous same-speaker runs).
+- **The live-exchange gate:** return a turn **only if** there are ≥2 turns in the window **and the
+  last two turns have different speakers** (genuine alternation at the boundary). A narration ending,
+  a single-speaker monologue ending, or a residue-only tail fails the gate → **`null`**.
+- **Output (gate passed):** `{ speakerId, speakerName, text }` where `text` is the **single last
+  sentence** of the most-recent turn (capped to `MAX_PRIOR_TURN_CHARS`), `speakerName` resolved from
+  the roster (fall back to `speakerId` if absent). **No `sentenceId` is returned** — see §4.6.
 
-### 4.2 Neighbor selection — "the prior chapter"
+### 4.2 Neighbor selection — "the prior chapter" (no cascade)
 
-The prior chapter = the **nearest lower chapter id present in `byChapter` that is not `excluded` and
-has sentences**. Computed off the full sorted `byChapter` key list (the in-memory whole-book map),
-**not** the filtered `chapterIds`, so it resolves identically on a single-chapter request and on a
-whole-book run. Excluded chapters (front-/back-matter, per `located.state.chapters[].excluded`) are
-skipped so turn-taking continuity holds between **story** chapters. The first story chapter has no
-qualifying prior → no context block.
+The prior chapter = the **immediately-preceding non-excluded story chapter**: the nearest lower
+chapter id present in `byChapter` that is not `excluded` (`located.state.chapters[].excluded`,
+computed independently here — the route applies that flag only on the whole-book branch,
+`script-review.ts:138-141`, so single-chapter requests must derive it the same way). Computed off the
+full sorted `byChapter` key list (not the filtered `chapterIds`), so it resolves identically on a
+single-chapter request and a whole-book run.
+
+**No cascade.** If that immediately-preceding chapter exists but `priorChapterBoundaryTurn` returns
+`null` (scene-break ending etc.), we emit **no block** — we do **not** fall back to chapter N‑2.
+Resolving chapter *N*'s opening from chapter *N‑2*'s ending is semantically wrong (an intervening
+chapter broke the exchange). "Has a non-excluded predecessor" gates selection; "that predecessor ends
+in a live exchange" gates emission; the two are distinct and there is deliberately no retry between
+them. First story chapter → no predecessor → no block.
 
 ### 4.3 Prompt change — `buildScriptReviewChapterInbox`
 
 Add an optional `priorTurn?: { speakerName: string; speakerId: string; text: string }` param. When
-present, render a labelled section **above** the `## Sentences` block:
+present, render a labelled section immediately **above** the literal `## Sentences (already
+attributed)` block (`script-review.ts:102`):
 
 ```
-## Prior chapter — last speaking turn (reference only — do NOT emit ops on this)
+## Prior chapter — last speaking turn (reference only — not a reviewable line; do NOT emit an op on it)
 
 Aldous (id: aldous): "Then we're agreed. Dawn, at the colliery gate."
 ```
 
-When absent, the function emits **exactly today's prompt** (the param defaults to omitted).
+The block exposes the **character** id/name and the line text **only — never a `sentenceId`** (§4.6).
+When `priorTurn` is absent the function emits **exactly today's prompt**: the conditional must
+contribute **zero characters** (no stray blank line). §6 pins this with a *frozen full-string
+equality* test, not a `contains` check.
 
 ### 4.4 Skill-prompt note
 
 `skills/audiobook-script-review.md` gains one short paragraph: the "Prior chapter — last speaking
 turn" block, when present, is **read-only** turn-taking context for resolving a tagless chapter-
-opening line. The model must **never** emit an op targeting it; it carries no reviewable
-`sentenceId`.
+opening line. It carries **no `sentenceId`** and is **not reviewable** — never emit an op targeting
+it; use it only to inform the attribution of the chapter's own opening sentences.
 
-### 4.5 Route wiring — first chunk only
+### 4.5 Route wiring — first chunk only, budget-reserved
 
-In the chunk loop (`script-review.ts:233`), pass `priorTurn` **only to the first chunk of each
-chapter** (`chunkIndex === 0`). The straddle is the chapter *opening*; later chunks already receive
-in-chapter overlap context from the chunker, so prior-chapter context there is wasted tokens. The
-`priorTurn` for chapter *N* is computed once per chapter (§4.2) before the chunk loop.
+- Compute `priorTurn` **once per chapter** (§4.2 + §4.1) **before** the chunk loop.
+- When `priorTurn` is non-null, **reduce the chunk `charBudget`** passed to `chunkSentencesByBudget`
+  (`script-review.ts:227`) by a fixed reserve (`MAX_PRIOR_TURN_CHARS` + the section's fixed header
+  overhead) so the first chunk + the injected block stays within the local model's context window.
+  Cloud engines use a `MAX_SAFE_INTEGER` budget, so the reserve is a harmless no-op there.
+- Convert the inner `for (const chunk of chunks)` loop (`script-review.ts:233`) to an **indexed**
+  form and pass `priorTurn` **only to the first chunk** (`index === 0`); later chunks get their
+  in-chapter overlap context from the chunker, so prior-chapter context there is wasted budget.
 
-### 4.6 Read-only enforcement
+### 4.6 Read-only enforcement (corrected — the original premise was false)
 
-The context turn is **not a reviewable sentence**: its source `sentenceId` belongs to the prior
-chapter and is therefore **not** in the current chunk's `coreIds`. The existing owned-op filter —
-`result.ops.filter((op) => ownsOp(chunk.coreIds, primarySentenceId(op)))` (`script-review.ts:268`)
-— already drops any op the model emits against it. We keep that as the primary guard **and** add a
-unit test pinning the invariant, so a future chunker change cannot silently let a context-targeted
-op leak into `send({ kind: 'ops' })`.
+**The original §4.6 was wrong.** It claimed an op targeting the context line is "already dropped
+because its id isn't in `coreIds`." But sentence ids are **per-chapter `1..N`** (`stage2-chunk.ts:259`
+renumbers each chapter from 1; `cast-merges.ts:31` documents that ids are unique only within a
+chapter) — so the prior chapter's ids **collide** with the current chapter's `coreIds`. The numeric
+`ownsOp(chunk.coreIds, primarySentenceId(op))` filter (`script-review.ts:268`) would therefore *not*
+reliably drop such an op; on a collision it would silently apply it to the **wrong current-chapter
+sentence**.
 
-## 5. Edge cases (all handled — no open questions)
+**The actual guard:** the context block **surfaces no `sentenceId`** (§4.3 — only the character id and
+the line text), so the model has nothing to copy as an op target, reinforced by the §4.4 skill
+instruction. The `ownsOp` filter remains as defence-in-depth (it still drops any op whose primary id
+falls outside the current core), but it is **not** the guarantee. **§6 pins the real invariant
+behaviourally:** the rendered context block contains no `sentenceId`, and a review whose model output
+references the context character/text yields no op outside the chapter's own sentences.
+
+## 5. Edge cases
 
 | Case | Behaviour |
 |---|---|
-| First story chapter (no qualifying prior) | No context block; prompt byte-identical to today. |
-| Prior chapter is pure narration | Helper returns `null` → no block. |
-| Prior chapter ends on a long narration block (last speaker beyond cap) | Helper returns `null` → no block (no live boundary turn-taking). |
-| Prior chapter empty / no attributed sentences | Skipped by neighbor selection; next-lower story chapter considered. |
+| First story chapter (no predecessor) | No block; prompt byte-identical to today. |
+| Predecessor ends on narration / a monologue (single speaker) | Gate fails (no alternation) → `null` → no block. |
+| Predecessor ends on a genuine A/B exchange | Block emitted: last speaker + their last line (capped). |
+| Predecessor's last exchange is >`PRIOR_TURN_LOOKBACK` back | Outside the window → gate fails → no block. |
+| Predecessor tail is `flag_nonstory` residue | Filtered out before turns/gate; never a signal, never eats the cap. |
+| Predecessor empty / no attributed sentences | Skipped by neighbor selection; **no cascade** to N‑2 → no block. |
 | Single-chapter request | Prior fetched from the whole-book `byChapter` map → identical behaviour. |
-| Speaker off the current roster | Still labelled by name (or raw id); used purely as turn-taking signal, never as an op target. |
-| Excluded (front/back-matter) chapter as neighbor | Skipped; nearest lower **non-excluded** story chapter used. |
+| Speaker off the current roster | Labelled by name (or raw id); used purely as turn-taking signal, never an op target. |
+| Excluded (front/back-matter) predecessor | Skipped; nearest lower **non-excluded** story chapter used (no cascade past it if *it* fails the gate). |
 
 ## 6. Testing
 
-- **Unit — `priorChapterSpeakingTurn`:** ends-on-dialogue (returns that turn); ends-on-narration-
-  within-cap (walks back, returns the dialogue turn); ends-on-narration-beyond-cap (`null`);
-  all-narration (`null`); empty (`null`); multi-sentence contiguous run (joined text);
-  speaker-name resolved from roster; off-roster speaker falls back to id.
-- **Unit — `buildScriptReviewChapterInbox`:** renders the labelled block when given `priorTurn`;
-  omits it (byte-identical to today) when not.
-- **Unit/route — read-only guard:** an op whose primary sentence is the prior-chapter context id is
-  dropped (not present in `coreIds`), pinning §4.6.
-- **Neighbor selection:** picks the nearest lower non-excluded chapter; skips excluded; returns no
-  prior for the first story chapter.
-- **No e2e.** This is a server-side prompt-assembly change with no new UI seam, router, or redux
-  path — Playwright would add nothing. (Called out explicitly per the testing-discipline bar.)
-- **Manual / on-box acceptance:** a real Coalfall run where a chapter opens on a tagless line —
-  confirm it now resolves to the prior chapter's last speaker. Folded into the existing fs-58 Unit B
-  on-box acceptance debt.
+- **Unit — `priorChapterBoundaryTurn`** (the gate is the heart of the feature):
+  - ends on A/B exchange → returns last speaker + last line;
+  - ends on narration → `null`; ends on single-speaker monologue → `null`;
+  - exchange present but >`PRIOR_TURN_LOOKBACK` back → `null`;
+  - tail is `excludeFromSynthesis` residue (non-narrator) → filtered, `null` (and does not consume the cap);
+  - long last line → truncated to `MAX_PRIOR_TURN_CHARS`;
+  - speaker-name resolved from roster; off-roster speaker falls back to id;
+  - empty chapter → `null`.
+- **Unit — `buildScriptReviewChapterInbox`:** renders the labelled block (with **no `sentenceId`**)
+  when given `priorTurn`; **frozen full-string equality** to today's prompt when absent.
+- **Unit/route — read-only invariant (§4.6):** the rendered block contains no `sentenceId`; a model
+  op referencing the context character/text produces no op outside the chapter's own sentences.
+- **Route — neighbor selection + budget:** picks the immediately-preceding non-excluded chapter;
+  skips excluded; no cascade when the predecessor fails the gate; first chunk's `charBudget` is
+  reduced by the reserve when a block is attached; only the first chunk receives the block.
+- **No e2e.** Server-side prompt assembly with no UI/router/redux/layout seam — Playwright would test
+  nothing (the CLAUDE.md "SHOULD land an e2e" bar is keyed on UI-visible behaviour crossing those
+  seams). Called out explicitly per the testing-discipline bar.
+- **Honest scope of the automated suite.** These unit tests pin **prompt assembly + the gate + the
+  read-only invariant** — the *mechanism*. They do **not** prove the model re-resolves the opening
+  line correctly (that is LLM behaviour, not cheaply unit-testable). **Resolution is confirmed only
+  by the on-box acceptance below, and `status: stable` MUST NOT be set until it passes.**
+- **On-box acceptance:** a real run on `server/src/__fixtures__/the-coalfall-commission.md` (the
+  canonical fixture) — confirm a chapter that opens tagless after a dialogue-ending predecessor now
+  resolves to the prior speaker, **and** that a scene-break opening produces *no* confident-wrong
+  `reattribute` op (the regression that matters). Folded into the fs-58 Unit B on-box debt, which
+  must exercise the `reattribute` op class specifically (already shipped, #1118). *(If the fixture has
+  no tagless-opening boundary, confirm/add one before claiming acceptance.)*
 
 ## 7. New-infra summary
 
-**New — server:** the `priorChapterSpeakingTurn` helper + the `priorTurn` param + section on
-`buildScriptReviewChapterInbox` + the neighbor-selection + first-chunk wiring in the route
+**New — server:** the `priorChapterBoundaryTurn` helper (+ `PRIOR_TURN_LOOKBACK`,
+`MAX_PRIOR_TURN_CHARS` consts) + the `priorTurn` param/section on `buildScriptReviewChapterInbox` +
+neighbor-selection + the indexed-loop / budget-reserve / first-chunk wiring in the route
 (`script-review.ts`); one paragraph in `skills/audiobook-script-review.md`.
 
-**New — client:** none.
-
-**Schema / api-types:** none.
+**New — client:** none. **Schema / api-types:** none.
 
 ## 8. Non-goals
 
 - No whole-chapter or whole-book context stitching (the expensive interpretation §3 rejects).
-- No context beyond the **first** chunk of a chapter.
-- No reach past the 6-sentence look-back cap (a chapter ending on long narration gets no boundary
-  context by design).
-- No new endpoint, op class, schema field, or frontend surface.
-- No auto-voicing / cast changes (separate Unit B follow-up #1118).
+- No context beyond the **first** chunk of a chapter; no block when the gate fails.
+- No multi-turn / two-speaker block, and **no cascade** past the immediately-preceding chapter.
+- No reach past `PRIOR_TURN_LOOKBACK` for the gate, and the emitted line is a **single** sentence
+  capped at `MAX_PRIOR_TURN_CHARS` — the returned text never extends past the cap.
+- No new endpoint, op class, schema field, or frontend surface; no auto-voicing / cast changes.
 
 ## 9. Ship checklist
 
-1. Land the helper + prompt change + route wiring + skill note with paired unit tests (§6).
-2. `npm run verify` green (typecheck + tests + e2e + build).
-3. Close **#1120**; remove its `docs/BACKLOG.md` row; update `docs/features/INDEX.md` if this spec
-   moves to `archive/` on ship.
-4. Set this spec `status: stable` + fill Ship notes (date + SHA) once on-box acceptance confirms the
-   straddle resolves; `git mv` to `docs/features/archive/` (or keep under `specs/`, matching the
-   fs-58 sibling specs' home).
+1. Branch `feat/server-fs64-cross-chapter-reattribute`; `feat(server): …` commits.
+2. Land the helper + gate + prompt change + route wiring + skill note with paired unit tests (§6).
+3. `npm run verify` green (typecheck + tests + e2e + build).
+4. Close **#1120** (`Closes #1120` in the PR body); remove its `docs/BACKLOG.md` row.
+5. **Gate `status: stable` on the on-box acceptance** (§6) — not on green unit tests. Until then the
+   spec stays `active`. On acceptance: set `status: stable`, fill Ship notes (date + merge SHA +
+   acceptance result), and `git mv` to `docs/features/archive/` only if the fs-58 sibling specs move
+   too (they currently live under `docs/superpowers/specs/`; match their home — these specs are **not**
+   tracked in `docs/features/INDEX.md`).
 
 ## Ship notes
 

--- a/docs/superpowers/specs/2026-06-26-fs64-cross-chapter-reattribute-context-design.md
+++ b/docs/superpowers/specs/2026-06-26-fs64-cross-chapter-reattribute-context-design.md
@@ -1,6 +1,6 @@
 ---
 title: 'fs-64 — Cross-chapter context for `reattribute` (script-review)'
-status: draft
+status: deferred
 date: 2026-06-26
 issue: '#1120'
 related:
@@ -14,31 +14,43 @@ related:
 > **Follow-up from fs-58 Unit B** (`2026-06-25-fs58-unit-b-reattribute-flag-nonstory-design.md`,
 > PR #1118, merged). Unit B's §3.6 accepted a v1 limitation: `script-review` reviews **one chapter at
 > a time**, so a chapter-opening tagless line whose speaker is set by the *previous* chapter's last
-> turn cannot be resolved by turn-taking — the review pass never sees across the boundary. This spec
-> **feeds the model the signal it needs** to resolve that straddle: the prior chapter's last speaking
-> turn, fed into the chapter's existing prompt as read-only context — **but only when the prior
-> chapter actually ends in a live dialogue exchange** (the common case is a scene break, where the
-> signal would be misleading). Strictly additive; **zero new LLM calls**.
+> exchange cannot be resolved by turn-taking — the review pass never sees across the boundary. This
+> spec **feeds the model the signal it needs** to resolve that straddle: the prior chapter's final
+> two-speaker exchange, fed into the chapter's existing prompt as read-only context — **but only when
+> the prior chapter actually ends in a live dialogue exchange** (the common case is a scene break,
+> where the signal would be misleading). Strictly additive; **zero new LLM calls**.
 >
-> **Revised 2026-06-26 after a three-reviewer adversarial round** (code-grounding, design,
-> scope/test-adequacy). The round corrected: a false read-only-guard premise (per-chapter ids, §4.6);
-> an unbounded, non-budget-accounted context block (§4.1/§4.5); array-order vs reading-order and
-> `excludeFromSynthesis` filtering in the tail walk (§4.1); a conflated null/selection fallback
-> (§4.2); a YAGNI run-join (cut); over-claimed "closes the straddle" language (hedged, §6/§9); and the
-> scene-break premise itself — which is now gated, not assumed (§4.1).
+> **Disposition (2026-06-26): design FINAL, build DEFERRED.** The design below is complete and
+> reviewer-cleared. Implementation is parked behind the fs-58 Unit B **on-box render acceptance**
+> (fs-64's own `status: stable` acceptance can't complete before it). That debt is nearly cleared —
+> Unit B is done and in `verify` on a separate worktree, not yet merged — so the deferral is short.
+> Pick this spec up for the implementation plan once Unit B merges. See §9.
+>
+> **Revised 2026-06-26 after TWO three-reviewer adversarial rounds** (code-grounding, design,
+> scope/test-adequacy each round). Round 1 corrected: a false read-only-guard premise (per-chapter
+> ids, §4.6); an unbounded, non-budget-accounted block; array-order vs reading-order; missing
+> `excludeFromSynthesis` filtering; a conflated null/selection fallback; a YAGNI run-join (cut);
+> over-claimed "closes the straddle" language; and added the **live-exchange gate**. Round 2 then:
+> upgraded the payload from one turn to the **final two-speaker exchange** (a single turn names the
+> wrong thing — it excludes one candidate but never names the predicted opener, failing the
+> same-gender two-hander, the one case turn-taking alone can resolve); de-ambiguated the gate clause;
+> moved the budget reserve to **chunk 0 only** (a whole-chapter budget cut re-chunks the chapter and
+> perturbs its *own* op emission — not "additive"); fixed a `NARRATOR_ID`-not-exported claim and an
+> `unknown-male` collapse edge; and tightened the §9 acceptance prerequisites.
 
 ## 1. Summary
 
-When the script-review pass reviews a chapter, prepend the **prior chapter's last speaking turn**
-(speaker name + their single last line, char-capped) to the **first chunk** of that chapter's review
-prompt, labelled as **reference-only** context — **gated** on the prior chapter ending in a genuine
-alternating exchange (≥2 distinct non-narrator speakers alternating at the boundary). This gives the
-model the turn-taking signal to resolve a tagless chapter-opening line (e.g. `"I know," she said.`)
-*when, and only when,* cross-chapter turn-taking is plausible. On a scene-break / narration /
-monologue ending — the common case — nothing is emitted.
+When the script-review pass reviews a chapter, prepend the **prior chapter's final two-speaker
+exchange** (the last two alternating speakers — `A …` / `B …`, each a single line, char-capped) to the
+**first chunk** of that chapter's review prompt, labelled as **reference-only** context — **gated** on
+the prior chapter actually ending in such an exchange. This names *both* parties of the boundary
+turn-taking, so the model can resolve a tagless chapter-opening line (e.g. `"I know," he said.`)
+*when, and only when,* cross-chapter turn-taking is plausible — including the same-gender two-hander,
+where the alternation is the sole disambiguator. On a scene-break / narration / monologue ending — the
+common case — nothing is emitted.
 
-**Additive throughout.** When the gate yields no boundary turn (first story chapter, scene-break
-ending, all-narration, residue-only tail), the prompt is **byte-identical to today**. No schema
+**Additive throughout.** When the gate yields no exchange (first story chapter, narration/monologue
+ending, residue-only tail, empty predecessor), the prompt is **byte-identical to today**. No schema
 change, no `api-types` regen, no frontend change.
 
 ## 2. The straddle (what Unit B §3.6 left open)
@@ -46,7 +58,7 @@ change, no `api-types` regen, no frontend change.
 `script-review` builds a per-chapter prompt in `buildScriptReviewChapterInbox`
 (`server/src/routes/script-review.ts:78`) containing only **that chapter's** sentences plus the
 post-fold roster. A chapter that opens on a tagless dialogue line has nothing in-prompt that tells
-the model who spoke last — the alternation that resolves it lives at the **end of the previous
+the model who was speaking — the alternation that resolves it lives at the **end of the previous
 chapter**. The within-chapter chunker carries `overlap: 3` context between chunks of the *same*
 chapter (`chapter-chunker.ts:58`); for the **first** chunk `start === 0`, so the before-context is
 empty (`chunkWithContext`, `chapter-chunker.ts:71`) — and the chunker only ever sees one chapter's
@@ -63,35 +75,43 @@ runs"* — weighing the fix against RPD cost. That tradeoff only exists for one 
   (`script-review.ts:128`); the single-chapter narrowing happens *after*, on the `chapterIds`
   iteration list only (`script-review.ts:131-133`), never on `byChapter`. So the prior chapter's
   sentences are **already in memory** on any request — free to fetch via `byChapter.get(priorId)`.
-- We add a **bounded** context block (one sentence, hard char cap — §4.1) to a prompt we are
-  **already sending**. No extra call → **zero RPD impact**. The block's size is **deducted from the
-  first chunk's budget** (§4.5) so it cannot overflow a local model's context window.
+- We add a **bounded** block (two single sentences, each hard-capped — §4.1) to a prompt we are
+  **already sending**. No extra call → **zero RPD impact**. The block's size is reserved from the
+  **first chunk's** budget (§4.5) so it cannot overflow a local model's context window, and the rest
+  of the chapter chunks at full budget so its own op emission is unperturbed.
 
 ## 4. Components
 
-### 4.1 New pure helper — `priorChapterBoundaryTurn(sentences, roster)`
+### 4.1 New pure helper — `priorChapterBoundaryExchange(sentences, roster)`
 
 Lives in `script-review.ts` (exported, unit-tested like `buildReviewSentencesInput`). Constants:
-`PRIOR_TURN_LOOKBACK = 6` (sentences scanned back from the chapter end — "live exchange must be near
-the boundary; a turn further back is a scene break, not a continuation") and
-`MAX_PRIOR_TURN_CHARS = 240` (hard cap on the rendered line; longer text is truncated with `…`).
+`PRIOR_TURN_LOOKBACK = 6` (sentences — *positions*, not turns — scanned back from the chapter end:
+"a live exchange must be near the boundary; one further back is a scene break, not a continuation")
+and `MAX_PRIOR_TURN_CHARS = 240` (hard cap per rendered line; longer text truncated with `…`).
+`NARRATOR_ID = 'narrator'` is **re-declared locally** in `script-review.ts` (matching the repo
+convention — the constant is module-private and re-declared in five other modules, never exported).
 
 - **Input:** the prior chapter's post-fold sentence sequence + the roster (for name resolution).
 - **Reading order:** walk back from the **end of the chapter's post-fold sequence** — the same
   sequence the chunker reviews (`byChapter.get(id)` order). *(Caveat: end-of-chapter split offspring
   are appended out of strict reading order — a wrinkle this route already shares with the chunker;
-  out of scope to fix here, noted so the test author doesn't over-specify.)*
-- **Eligible sentences:** skip narration (`characterId === NARRATOR_ID`, imported from
-  `byline-author-guard.ts`) **and** `excludeFromSynthesis === true` residue (mirrors the synth-path
-  filter; a `flag_nonstory` line must never become a turn-taking signal, nor consume the cap).
-- **Turns:** over the last `PRIOR_TURN_LOOKBACK` sentences, collapse eligible sentences into *turns*
-  (contiguous same-speaker runs).
-- **The live-exchange gate:** return a turn **only if** there are ≥2 turns in the window **and the
-  last two turns have different speakers** (genuine alternation at the boundary). A narration ending,
-  a single-speaker monologue ending, or a residue-only tail fails the gate → **`null`**.
-- **Output (gate passed):** `{ speakerId, speakerName, text }` where `text` is the **single last
-  sentence** of the most-recent turn (capped to `MAX_PRIOR_TURN_CHARS`), `speakerName` resolved from
-  the roster (fall back to `speakerId` if absent). **No `sentenceId` is returned** — see §4.6.
+  out of scope here. The §9 on-box step sanity-checks the boundary lines.)*
+- **Eligible subsequence:** from the last `PRIOR_TURN_LOOKBACK` sentences, drop narration
+  (`characterId === NARRATOR_ID`) **and** `excludeFromSynthesis === true` residue (mirrors the
+  synth-path filter; a `flag_nonstory` line must never be a turn-taking signal nor consume the
+  window). *(Note: narration sentences still occupy window positions, so stage-business beats shrink
+  the effective dialogue reach — intended.)*
+- **Turns:** collapse the eligible subsequence (gaps closed) into *turns* — contiguous same-speaker
+  runs. By construction adjacent turns have different speakers, and two distinct speakers folded to
+  the same id (e.g. both `unknown-male`) collapse into **one** turn.
+- **The live-exchange gate:** emit **only if there are ≥2 turns** in the eligible subsequence
+  (which, by the collapse property, guarantees the last two turns are different speakers). Otherwise
+  → **`null`** (narration/monologue ending, residue-only tail, or single-speaker window).
+- **Output (gate passed):** `{ turns: [A, B] }` — the **last two** turns in reading order, each
+  `{ speakerId, speakerName, text }` where `text` is that turn's **single boundary-adjacent
+  sentence** (turn A's last line, turn B's last line), capped to `MAX_PRIOR_TURN_CHARS`,
+  `speakerName` resolved from the roster (fall back to `speakerId`). **No `sentenceId` is returned**
+  — see §4.6.
 
 ### 4.2 Neighbor selection — "the prior chapter" (no cascade)
 
@@ -102,63 +122,67 @@ computed independently here — the route applies that flag only on the whole-bo
 full sorted `byChapter` key list (not the filtered `chapterIds`), so it resolves identically on a
 single-chapter request and a whole-book run.
 
-**No cascade.** If that immediately-preceding chapter exists but `priorChapterBoundaryTurn` returns
-`null` (scene-break ending etc.), we emit **no block** — we do **not** fall back to chapter N‑2.
-Resolving chapter *N*'s opening from chapter *N‑2*'s ending is semantically wrong (an intervening
-chapter broke the exchange). "Has a non-excluded predecessor" gates selection; "that predecessor ends
-in a live exchange" gates emission; the two are distinct and there is deliberately no retry between
-them. First story chapter → no predecessor → no block.
+**No cascade.** Selection skips only `excluded` chapters. A *selected* predecessor that is empty or
+yields no exchange makes `priorChapterBoundaryExchange` return `null` → we emit **no block** and do
+**not** fall back to chapter N‑2 (resolving chapter *N*'s opening from chapter *N‑2*'s ending is
+semantically wrong — an intervening chapter broke the exchange). "Has a non-excluded predecessor"
+gates selection; "that predecessor ends in a live exchange" gates emission; the two are distinct and
+there is deliberately no retry between them. First story chapter → no predecessor → no block.
 
 ### 4.3 Prompt change — `buildScriptReviewChapterInbox`
 
-Add an optional `priorTurn?: { speakerName: string; speakerId: string; text: string }` param. When
-present, render a labelled section immediately **above** the literal `## Sentences (already
-attributed)` block (`script-review.ts:102`):
+Add an optional `priorExchange?: { turns: Array<{ speakerName: string; speakerId: string; text: string }> }`
+param. When present, render a labelled section immediately **above** the literal `## Sentences
+(already attributed)` block (`script-review.ts:102`):
 
 ```
-## Prior chapter — last speaking turn (reference only — not a reviewable line; do NOT emit an op on it)
+## Prior chapter — final exchange (reference only — not reviewable lines; do NOT emit an op on them)
 
 Aldous (id: aldous): "Then we're agreed. Dawn, at the colliery gate."
+Berrin (id: berrin): "If the others come."
 ```
 
 The block exposes the **character** id/name and the line text **only — never a `sentenceId`** (§4.6).
-When `priorTurn` is absent the function emits **exactly today's prompt**: the conditional must
+When `priorExchange` is absent the function emits **exactly today's prompt**: the conditional must
 contribute **zero characters** (no stray blank line). §6 pins this with a *frozen full-string
 equality* test, not a `contains` check.
 
 ### 4.4 Skill-prompt note
 
-`skills/audiobook-script-review.md` gains one short paragraph: the "Prior chapter — last speaking
-turn" block, when present, is **read-only** turn-taking context for resolving a tagless chapter-
-opening line. It carries **no `sentenceId`** and is **not reviewable** — never emit an op targeting
-it; use it only to inform the attribution of the chapter's own opening sentences.
+`skills/audiobook-script-review.md` gains one short paragraph: the "Prior chapter — final exchange"
+block, when present, is **read-only** turn-taking context for resolving a tagless chapter-opening
+line. It carries **no `sentenceId`** and is **not reviewable** — never emit an op targeting it; use
+the named alternation only to inform the attribution of the chapter's own opening sentences.
 
-### 4.5 Route wiring — first chunk only, budget-reserved
+### 4.5 Route wiring — first chunk only, chunk-0 budget reserve
 
-- Compute `priorTurn` **once per chapter** (§4.2 + §4.1) **before** the chunk loop.
-- When `priorTurn` is non-null, **reduce the chunk `charBudget`** passed to `chunkSentencesByBudget`
-  (`script-review.ts:227`) by a fixed reserve (`MAX_PRIOR_TURN_CHARS` + the section's fixed header
-  overhead) so the first chunk + the injected block stays within the local model's context window.
-  Cloud engines use a `MAX_SAFE_INTEGER` budget, so the reserve is a harmless no-op there.
+- Compute `priorExchange` **once per chapter** (§4.2 + §4.1) **before** the chunk loop.
 - Convert the inner `for (const chunk of chunks)` loop (`script-review.ts:233`) to an **indexed**
-  form and pass `priorTurn` **only to the first chunk** (`index === 0`); later chunks get their
+  form and pass `priorExchange` **only to the first chunk** (`index === 0`); later chunks get their
   in-chapter overlap context from the chunker, so prior-chapter context there is wasted budget.
+- **Budget: reserve against chunk 0 only.** Chunk the chapter at **full** `charBudget` (so the rest
+  of the chapter's seams — and thus its own op emission — are unchanged from today), then ensure
+  **chunk 0** + the rendered block fits the local context window: trim chunk 0's core to leave room
+  for `2 × MAX_PRIOR_TURN_CHARS` + the section's fixed header overhead, pushing the trimmed
+  sentence(s) into the overlap/next chunk. Do **not** lower the global budget (a whole-chapter
+  reduction greedily re-chunks the chapter and perturbs unrelated ops — rejected). Cloud engines
+  carry a `MAX_SAFE_INTEGER` budget, so the whole reserve is a no-op there.
 
-### 4.6 Read-only enforcement (corrected — the original premise was false)
+### 4.6 Read-only enforcement (the original premise was false)
 
-**The original §4.6 was wrong.** It claimed an op targeting the context line is "already dropped
-because its id isn't in `coreIds`." But sentence ids are **per-chapter `1..N`** (`stage2-chunk.ts:259`
-renumbers each chapter from 1; `cast-merges.ts:31` documents that ids are unique only within a
-chapter) — so the prior chapter's ids **collide** with the current chapter's `coreIds`. The numeric
-`ownsOp(chunk.coreIds, primarySentenceId(op))` filter (`script-review.ts:268`) would therefore *not*
-reliably drop such an op; on a collision it would silently apply it to the **wrong current-chapter
-sentence**.
+**The first draft's §4.6 was wrong.** It claimed an op targeting the context lines is "already
+dropped because its id isn't in `coreIds`." But sentence ids are **per-chapter `1..N`**
+(`stage2-chunk.ts:259` renumbers each chapter from 1; `cast-merges.ts:31` documents that ids are
+unique only within a chapter) — so the prior chapter's ids **collide** with the current chapter's
+`coreIds`, and the numeric `ownsOp(chunk.coreIds, primarySentenceId(op))` filter (`script-review.ts:268`)
+would not reliably drop such an op; on a collision it would silently apply it to the **wrong
+current-chapter sentence**.
 
-**The actual guard:** the context block **surfaces no `sentenceId`** (§4.3 — only the character id and
-the line text), so the model has nothing to copy as an op target, reinforced by the §4.4 skill
-instruction. The `ownsOp` filter remains as defence-in-depth (it still drops any op whose primary id
-falls outside the current core), but it is **not** the guarantee. **§6 pins the real invariant
-behaviourally:** the rendered context block contains no `sentenceId`, and a review whose model output
+**The actual — and only — guard:** the block **surfaces no `sentenceId`** (§4.3 renders only the
+character id and the line text), so a block-targeted op is **unconstructible** by the model,
+reinforced by the §4.4 skill instruction. (`ownsOp` is unrelated to this vector — it dedupes overlap
+ops between chunks; do not lean on it as a read-only guard.) **§6 pins the real invariant
+behaviourally:** the rendered block contains no `sentenceId`, and a review whose model output
 references the context character/text yields no op outside the chapter's own sentences.
 
 ## 5. Edge cases
@@ -166,52 +190,56 @@ references the context character/text yields no op outside the chapter's own sen
 | Case | Behaviour |
 |---|---|
 | First story chapter (no predecessor) | No block; prompt byte-identical to today. |
-| Predecessor ends on narration / a monologue (single speaker) | Gate fails (no alternation) → `null` → no block. |
-| Predecessor ends on a genuine A/B exchange | Block emitted: last speaker + their last line (capped). |
-| Predecessor's last exchange is >`PRIOR_TURN_LOOKBACK` back | Outside the window → gate fails → no block. |
-| Predecessor tail is `flag_nonstory` residue | Filtered out before turns/gate; never a signal, never eats the cap. |
-| Predecessor empty / no attributed sentences | Skipped by neighbor selection; **no cascade** to N‑2 → no block. |
+| Predecessor ends on narration / a monologue (single speaker in window) | <2 turns → `null` → no block. |
+| Predecessor ends on a genuine A/B exchange | Block emitted: the last two turns (A line / B line), each capped. |
+| Predecessor's last exchange is beyond the `PRIOR_TURN_LOOKBACK` window | Outside the window → <2 turns → no block. |
+| Two distinct speakers both folded to one id (e.g. `unknown-male`) | Collapse to one turn → <2 turns → `null` (safe false-negative: can't name the alternation, so don't assert it). |
+| Predecessor tail is `flag_nonstory` residue | Filtered before turns/gate; never a signal, never eats the window. |
+| Predecessor empty / no attributed sentences | **Selected** (present + non-excluded), `priorChapterBoundaryExchange` returns `null` → no cascade → no block. |
 | Single-chapter request | Prior fetched from the whole-book `byChapter` map → identical behaviour. |
 | Speaker off the current roster | Labelled by name (or raw id); used purely as turn-taking signal, never an op target. |
-| Excluded (front/back-matter) predecessor | Skipped; nearest lower **non-excluded** story chapter used (no cascade past it if *it* fails the gate). |
+| Excluded (front/back-matter) predecessor | Skipped by selection; nearest lower **non-excluded** story chapter used (no cascade past it if *it* fails the gate). |
 
 ## 6. Testing
 
-- **Unit — `priorChapterBoundaryTurn`** (the gate is the heart of the feature):
-  - ends on A/B exchange → returns last speaker + last line;
+- **Unit — `priorChapterBoundaryExchange`** (the gate is the heart of the feature):
+  - ends on A/B exchange → returns both turns (A then B), each = boundary-adjacent line;
   - ends on narration → `null`; ends on single-speaker monologue → `null`;
-  - exchange present but >`PRIOR_TURN_LOOKBACK` back → `null`;
-  - tail is `excludeFromSynthesis` residue (non-narrator) → filtered, `null` (and does not consume the cap);
-  - long last line → truncated to `MAX_PRIOR_TURN_CHARS`;
-  - speaker-name resolved from roster; off-roster speaker falls back to id;
+  - both speakers folded to one id (`unknown-male`) → one turn → `null`;
+  - exchange present but beyond `PRIOR_TURN_LOOKBACK` positions → `null`;
+  - tail is `excludeFromSynthesis` residue (non-narrator) → filtered, `null` (and does not consume the window);
+  - long line → truncated to `MAX_PRIOR_TURN_CHARS`; per-turn cap applied to both lines;
+  - speaker names resolved from roster; off-roster speaker falls back to id;
   - empty chapter → `null`.
-- **Unit — `buildScriptReviewChapterInbox`:** renders the labelled block (with **no `sentenceId`**)
-  when given `priorTurn`; **frozen full-string equality** to today's prompt when absent.
+- **Unit — `buildScriptReviewChapterInbox`:** renders the two-line labelled block (with **no
+  `sentenceId`**) when given `priorExchange`; **frozen full-string equality** to today's prompt when absent.
 - **Unit/route — read-only invariant (§4.6):** the rendered block contains no `sentenceId`; a model
   op referencing the context character/text produces no op outside the chapter's own sentences.
 - **Route — neighbor selection + budget:** picks the immediately-preceding non-excluded chapter;
-  skips excluded; no cascade when the predecessor fails the gate; first chunk's `charBudget` is
-  reduced by the reserve when a block is attached; only the first chunk receives the block.
+  skips excluded; no cascade when the predecessor returns `null`; chunk 0's core is trimmed to fit
+  the reserve while the rest of the chapter chunks at full budget (chapter's own ops unchanged);
+  only the first chunk receives the block.
 - **No e2e.** Server-side prompt assembly with no UI/router/redux/layout seam — Playwright would test
   nothing (the CLAUDE.md "SHOULD land an e2e" bar is keyed on UI-visible behaviour crossing those
   seams). Called out explicitly per the testing-discipline bar.
+- **Regression-plan exemption (stated, not silent).** Per CLAUDE.md "Before-shipping checklist" step
+  1, small/localized work skips a `docs/features/` regression plan — "the issue body + paired test is
+  the spec." fs-64 is server-only, single-file (`script-review.ts`) + one skill paragraph, additive,
+  no schema. This spec + the §6 tests are the spec of record (mirroring the fs-58 sibling specs'
+  home under `docs/superpowers/specs/`); **no `docs/features/` plan is owed.**
 - **Honest scope of the automated suite.** These unit tests pin **prompt assembly + the gate + the
   read-only invariant** — the *mechanism*. They do **not** prove the model re-resolves the opening
-  line correctly (that is LLM behaviour, not cheaply unit-testable). **Resolution is confirmed only
-  by the on-box acceptance below, and `status: stable` MUST NOT be set until it passes.**
-- **On-box acceptance:** a real run on `server/src/__fixtures__/the-coalfall-commission.md` (the
-  canonical fixture) — confirm a chapter that opens tagless after a dialogue-ending predecessor now
-  resolves to the prior speaker, **and** that a scene-break opening produces *no* confident-wrong
-  `reattribute` op (the regression that matters). Folded into the fs-58 Unit B on-box debt, which
-  must exercise the `reattribute` op class specifically (already shipped, #1118). *(If the fixture has
-  no tagless-opening boundary, confirm/add one before claiming acceptance.)*
+  line correctly (LLM behaviour, not cheaply unit-testable). **Resolution is confirmed only by the
+  on-box acceptance (§9), and `status: stable` MUST NOT be set until it passes.**
 
 ## 7. New-infra summary
 
-**New — server:** the `priorChapterBoundaryTurn` helper (+ `PRIOR_TURN_LOOKBACK`,
-`MAX_PRIOR_TURN_CHARS` consts) + the `priorTurn` param/section on `buildScriptReviewChapterInbox` +
-neighbor-selection + the indexed-loop / budget-reserve / first-chunk wiring in the route
-(`script-review.ts`); one paragraph in `skills/audiobook-script-review.md`.
+**New — server:** the `priorChapterBoundaryExchange` helper (+ `PRIOR_TURN_LOOKBACK`,
+`MAX_PRIOR_TURN_CHARS`, and a local `NARRATOR_ID` const) + the `priorExchange` param/section on
+`buildScriptReviewChapterInbox` + neighbor-selection + the indexed-loop / chunk-0 budget-reserve /
+first-chunk wiring in the route (`script-review.ts`); one paragraph in
+`skills/audiobook-script-review.md`. **No edit to `byline-author-guard.ts`** (the constant is
+re-declared locally per repo convention).
 
 **New — client:** none. **Schema / api-types:** none.
 
@@ -219,22 +247,32 @@ neighbor-selection + the indexed-loop / budget-reserve / first-chunk wiring in t
 
 - No whole-chapter or whole-book context stitching (the expensive interpretation §3 rejects).
 - No context beyond the **first** chunk of a chapter; no block when the gate fails.
-- No multi-turn / two-speaker block, and **no cascade** past the immediately-preceding chapter.
-- No reach past `PRIOR_TURN_LOOKBACK` for the gate, and the emitted line is a **single** sentence
-  capped at `MAX_PRIOR_TURN_CHARS` — the returned text never extends past the cap.
+- No more than the **two** boundary turns, and **no cascade** past the immediately-preceding chapter.
+- No reach past the `PRIOR_TURN_LOOKBACK` window for the gate; each emitted line is a **single**
+  sentence capped at `MAX_PRIOR_TURN_CHARS`.
 - No new endpoint, op class, schema field, or frontend surface; no auto-voicing / cast changes.
 
-## 9. Ship checklist
+## 9. Ship checklist (when un-deferred)
 
-1. Branch `feat/server-fs64-cross-chapter-reattribute`; `feat(server): …` commits.
+**Unblocks when fs-58 Unit B merges** (its on-box render acceptance is the prerequisite fs-64's own
+acceptance rides on). Then:
+
+1. Cut branch `feat/server-fs64-cross-chapter-reattribute`; `feat(server): …` commits.
 2. Land the helper + gate + prompt change + route wiring + skill note with paired unit tests (§6).
+   (Worth driving via writing-plans → subagent-driven-development, as the fs-58 units were.)
 3. `npm run verify` green (typecheck + tests + e2e + build).
 4. Close **#1120** (`Closes #1120` in the PR body); remove its `docs/BACKLOG.md` row.
-5. **Gate `status: stable` on the on-box acceptance** (§6) — not on green unit tests. Until then the
-   spec stays `active`. On acceptance: set `status: stable`, fill Ship notes (date + merge SHA +
-   acceptance result), and `git mv` to `docs/features/archive/` only if the fs-58 sibling specs move
-   too (they currently live under `docs/superpowers/specs/`; match their home — these specs are **not**
-   tracked in `docs/features/INDEX.md`).
+5. **On-box acceptance** on `server/src/__fixtures__/the-coalfall-commission.md` (canonical fixture):
+   - **Prerequisite:** verify (or add) a chapter that opens tagless *after* a dialogue-ending
+     predecessor — without such a boundary the acceptance can't exercise the path. Sanity-check the
+     boundary lines are the true last spoken lines (the §4.1 split-offspring caveat).
+   - Confirm such an opener now resolves to the prior exchange, **and** that a scene-break opener
+     produces *no* confident-wrong `reattribute` op (the regression that matters).
+6. **Gate `status: stable` on that acceptance** — not on green unit tests. On acceptance: set
+   `status: stable`, fill Ship notes (date + merge SHA + acceptance result), back-link this spec from
+   the fs-58 Unit B spec's §3.6/§8 as the delivered follow-up, and `git mv` to
+   `docs/features/archive/` only if the fs-58 sibling specs move too (they currently live under
+   `docs/superpowers/specs/` and are **not** tracked in `docs/features/INDEX.md`).
 
 ## Ship notes
 

--- a/docs/superpowers/specs/2026-06-26-fs64-cross-chapter-reattribute-context-design.md
+++ b/docs/superpowers/specs/2026-06-26-fs64-cross-chapter-reattribute-context-design.md
@@ -1,6 +1,6 @@
 ---
 title: 'fs-64 — Cross-chapter context for `reattribute` (script-review)'
-status: deferred
+status: active
 date: 2026-06-26
 issue: '#1120'
 related:
@@ -20,11 +20,10 @@ related:
 > the prior chapter actually ends in a live dialogue exchange** (the common case is a scene break,
 > where the signal would be misleading). Strictly additive; **zero new LLM calls**.
 >
-> **Disposition (2026-06-26): design FINAL, build DEFERRED.** The design below is complete and
-> reviewer-cleared. Implementation is parked behind the fs-58 Unit B **on-box render acceptance**
-> (fs-64's own `status: stable` acceptance can't complete before it). That debt is nearly cleared —
-> Unit B is done and in `verify` on a separate worktree, not yet merged — so the deferral is short.
-> Pick this spec up for the implementation plan once Unit B merges. See §9.
+> **Disposition (2026-06-26): build ACTIVE.** fs-58 Unit B has landed, so the dependency is cleared
+> and implementation is in progress against the plan at
+> `docs/superpowers/plans/2026-06-26-fs64-cross-chapter-reattribute.md`. `status: stable` still waits
+> on the on-box render acceptance (§9 step 5).
 >
 > **Revised 2026-06-26 after TWO three-reviewer adversarial rounds** (code-grounding, design,
 > scope/test-adequacy each round). Round 1 corrected: a false read-only-guard premise (per-chapter
@@ -34,9 +33,10 @@ related:
 > upgraded the payload from one turn to the **final two-speaker exchange** (a single turn names the
 > wrong thing — it excludes one candidate but never names the predicted opener, failing the
 > same-gender two-hander, the one case turn-taking alone can resolve); de-ambiguated the gate clause;
-> moved the budget reserve to **chunk 0 only** (a whole-chapter budget cut re-chunks the chapter and
-> perturbs its *own* op emission — not "additive"); fixed a `NARRATOR_ID`-not-exported claim and an
-> `unknown-male` collapse edge; and tightened the §9 acceptance prerequisites.
+> fixed a `NARRATOR_ID`-not-exported claim and an `unknown-male` collapse edge; and tightened the §9
+> acceptance prerequisites. **At plan time** the budget handling simplified further: the bounded block
+> fits the chunk budget's existing ~30%-of-`num_ctx` scaffolding reserve, so the chapter chunks at
+> **full** budget (own ops byte-identical) and no per-chunk reserve is needed (§4.5).
 
 ## 1. Summary
 
@@ -76,9 +76,11 @@ runs"* — weighing the fix against RPD cost. That tradeoff only exists for one 
   iteration list only (`script-review.ts:131-133`), never on `byChapter`. So the prior chapter's
   sentences are **already in memory** on any request — free to fetch via `byChapter.get(priorId)`.
 - We add a **bounded** block (two single sentences, each hard-capped — §4.1) to a prompt we are
-  **already sending**. No extra call → **zero RPD impact**. The block's size is reserved from the
-  **first chunk's** budget (§4.5) so it cannot overflow a local model's context window, and the rest
-  of the chapter chunks at full budget so its own op emission is unperturbed.
+  **already sending**. No extra call → **zero RPD impact**. The block (≤ `2 × MAX_PRIOR_TURN_CHARS`
+  + header) fits inside the chunk budget's **existing ~30%-of-`num_ctx` scaffolding reserve**
+  (`stage1-chunk.ts:42-58` reserves it for "prompt header + roster + output"), so it cannot overflow
+  a local model's window, and the chapter chunks at **full** budget so its own op emission is
+  **byte-identical** to today (§4.5).
 
 ## 4. Components
 
@@ -154,19 +156,20 @@ block, when present, is **read-only** turn-taking context for resolving a tagles
 line. It carries **no `sentenceId`** and is **not reviewable** — never emit an op targeting it; use
 the named alternation only to inform the attribution of the chapter's own opening sentences.
 
-### 4.5 Route wiring — first chunk only, chunk-0 budget reserve
+### 4.5 Route wiring — first chunk only, full-budget chunking (no reserve)
 
 - Compute `priorExchange` **once per chapter** (§4.2 + §4.1) **before** the chunk loop.
 - Convert the inner `for (const chunk of chunks)` loop (`script-review.ts:233`) to an **indexed**
   form and pass `priorExchange` **only to the first chunk** (`index === 0`); later chunks get their
   in-chapter overlap context from the chunker, so prior-chapter context there is wasted budget.
-- **Budget: reserve against chunk 0 only.** Chunk the chapter at **full** `charBudget` (so the rest
-  of the chapter's seams — and thus its own op emission — are unchanged from today), then ensure
-  **chunk 0** + the rendered block fits the local context window: trim chunk 0's core to leave room
-  for `2 × MAX_PRIOR_TURN_CHARS` + the section's fixed header overhead, pushing the trimmed
-  sentence(s) into the overlap/next chunk. Do **not** lower the global budget (a whole-chapter
-  reduction greedily re-chunks the chapter and perturbs unrelated ops — rejected). Cloud engines
-  carry a `MAX_SAFE_INTEGER` budget, so the whole reserve is a no-op there.
+- **No budget change — chunk at full `charBudget`.** The chapter is chunked exactly as today, so its
+  own seams (and thus its own op emission) are **byte-identical**. The block is safe to attach to
+  chunk 0 without trimming because it is **bounded** (≤ `2 × MAX_PRIOR_TURN_CHARS` + the fixed header)
+  and the chunk budget already reserves **~30% of `num_ctx`** for prompt scaffolding — header +
+  roster + output (`stage1-chunk.ts:42-58`) — which the block draws from. (A whole-chapter budget
+  reduction would greedily re-chunk the chapter and perturb unrelated ops — rejected; per-chunk
+  budgets aren't supported by the single-budget chunker API, and aren't needed given the headroom.)
+  Cloud engines carry a `MAX_SAFE_INTEGER` budget, so the block is trivially within budget there.
 
 ### 4.6 Read-only enforcement (the original premise was false)
 
@@ -215,10 +218,10 @@ references the context character/text yields no op outside the chapter's own sen
   `sentenceId`**) when given `priorExchange`; **frozen full-string equality** to today's prompt when absent.
 - **Unit/route — read-only invariant (§4.6):** the rendered block contains no `sentenceId`; a model
   op referencing the context character/text produces no op outside the chapter's own sentences.
-- **Route — neighbor selection + budget:** picks the immediately-preceding non-excluded chapter;
-  skips excluded; no cascade when the predecessor returns `null`; chunk 0's core is trimmed to fit
-  the reserve while the rest of the chapter chunks at full budget (chapter's own ops unchanged);
-  only the first chunk receives the block.
+- **Route — neighbor selection + wiring:** picks the immediately-preceding non-excluded chapter;
+  skips excluded; no cascade when the predecessor returns `null`; **only the first chunk** receives
+  the block (a multi-chunk chapter's later chunks get the unchanged prompt); the chapter is chunked
+  at full budget (the `chunkSentencesByBudget` call's `charBudget` is unchanged from today).
 - **No e2e.** Server-side prompt assembly with no UI/router/redux/layout seam — Playwright would test
   nothing (the CLAUDE.md "SHOULD land an e2e" bar is keyed on UI-visible behaviour crossing those
   seams). Called out explicitly per the testing-discipline bar.
@@ -236,8 +239,8 @@ references the context character/text yields no op outside the chapter's own sen
 
 **New — server:** the `priorChapterBoundaryExchange` helper (+ `PRIOR_TURN_LOOKBACK`,
 `MAX_PRIOR_TURN_CHARS`, and a local `NARRATOR_ID` const) + the `priorExchange` param/section on
-`buildScriptReviewChapterInbox` + neighbor-selection + the indexed-loop / chunk-0 budget-reserve /
-first-chunk wiring in the route (`script-review.ts`); one paragraph in
+`buildScriptReviewChapterInbox` + neighbor-selection + the indexed-loop / first-chunk-only wiring in
+the route (`script-review.ts`, full-budget chunking unchanged); one paragraph in
 `skills/audiobook-script-review.md`. **No edit to `byline-author-guard.ts`** (the constant is
 re-declared locally per repo convention).
 
@@ -252,10 +255,10 @@ re-declared locally per repo convention).
   sentence capped at `MAX_PRIOR_TURN_CHARS`.
 - No new endpoint, op class, schema field, or frontend surface; no auto-voicing / cast changes.
 
-## 9. Ship checklist (when un-deferred)
+## 9. Ship checklist
 
-**Unblocks when fs-58 Unit B merges** (its on-box render acceptance is the prerequisite fs-64's own
-acceptance rides on). Then:
+fs-58 Unit B has landed, so this is active. Build proceeds against the plan
+(`docs/superpowers/plans/2026-06-26-fs64-cross-chapter-reattribute.md`):
 
 1. Cut branch `feat/server-fs64-cross-chapter-reattribute`; `feat(server): …` commits.
 2. Land the helper + gate + prompt change + route wiring + skill note with paired unit tests (§6).

--- a/server/src/routes/script-review.test.ts
+++ b/server/src/routes/script-review.test.ts
@@ -20,6 +20,7 @@ import type { ScriptReviewOutput } from '../handoff/schemas.js';
 import type {
   buildReviewSentencesInput as BuildReviewSentencesInput,
   priorChapterBoundaryExchange as PriorChapterBoundaryExchange,
+  buildScriptReviewChapterInbox as BuildScriptReviewChapterInbox,
 } from './script-review.js';
 
 const AUTHOR = 'Test Author';
@@ -32,6 +33,7 @@ let bookId: string;
 let manuscriptId: string;
 let buildReviewSentencesInput: typeof BuildReviewSentencesInput;
 let priorChapterBoundaryExchange: typeof PriorChapterBoundaryExchange;
+let buildScriptReviewChapterInbox: typeof BuildScriptReviewChapterInbox;
 
 /* The fake analyzer's runScriptReviewChapter — each test swaps its implementation.
    `selectedEngine` lets a test flip the reported engine to 'local' (so the
@@ -132,10 +134,11 @@ const CANNED_OPS: ScriptReviewOutput = {
 beforeAll(async () => {
   workspaceRoot = mkdtempSync(join(tmpdir(), 'audiobook-script-review-test-'));
   process.env.WORKSPACE_DIR = workspaceRoot;
-  const [{ scriptReviewRouter, buildReviewSentencesInput: build, priorChapterBoundaryExchange: pcbe }, { makeBookId }] =
+  const [{ scriptReviewRouter, buildReviewSentencesInput: build, priorChapterBoundaryExchange: pcbe, buildScriptReviewChapterInbox: bsrci }, { makeBookId }] =
     await Promise.all([import('./script-review.js'), import('../workspace/paths.js')]);
   buildReviewSentencesInput = build;
   priorChapterBoundaryExchange = pcbe;
+  buildScriptReviewChapterInbox = bsrci;
   bookId = makeBookId(AUTHOR, SERIES, BOOK);
   manuscriptId = `m_${bookId}`;
   app = express();
@@ -440,5 +443,67 @@ describe('priorChapterBoundaryExchange (fs-64)', () => {
 
   it('returns null for an empty chapter', () => {
     expect(priorChapterBoundaryExchange([], roster)).toBeNull();
+  });
+});
+
+describe('buildScriptReviewChapterInbox (fs-64 priorExchange)', () => {
+  const roster = [{ id: 'wren', name: 'Wren', role: 'protagonist' }];
+  const sentences = [{ id: 1, characterId: 'narrator', text: 'Hi.' }] as unknown as Parameters<
+    typeof buildScriptReviewChapterInbox
+  >[2];
+
+  it('is byte-identical to today when no priorExchange is given', () => {
+    const expected = `---
+manuscriptId: m1
+task: script-review
+chapterId: 2
+---
+
+## Cast roster (post-fold)
+
+\`\`\`json
+[
+  {
+    "id": "wren",
+    "name": "Wren",
+    "role": "protagonist"
+  }
+]
+\`\`\`
+
+## Sentences (already attributed)
+
+\`\`\`json
+[
+  {
+    "sentenceId": 1,
+    "characterId": "narrator",
+    "text": "Hi."
+  }
+]
+\`\`\`
+`;
+    expect(buildScriptReviewChapterInbox('m1', 2, sentences, roster)).toBe(expected);
+  });
+
+  it('renders the labelled block above the sentences, with no sentenceId', () => {
+    const out = buildScriptReviewChapterInbox('m1', 2, sentences, roster, {
+      turns: [
+        { speakerId: 'wren', speakerName: 'Wren', text: '"Where to?"' },
+        { speakerId: 'marlow', speakerName: 'Marlow', text: '"Somewhere safe."' },
+      ],
+    });
+    expect(out).toContain('Prior chapter');
+    expect(out).toContain('do NOT emit an op');
+    expect(out).toContain('Wren (id: wren): "Where to?"');
+    expect(out).toContain('Marlow (id: marlow): "Somewhere safe."');
+    // §4.6 read-only guard: the block region must surface NO sentenceId (so a
+    // block-targeted op is unconstructible). Scan ONLY the block, not the whole
+    // prompt — the legitimate sentence payload below DOES contain "sentenceId".
+    const block = out.slice(out.indexOf('Prior chapter'), out.indexOf('## Sentences'));
+    expect(block).not.toContain('sentenceId');
+    expect(block).not.toMatch(/"id"\s*:\s*\d/); // no numeric id leaks into the block
+    // block sits before the sentence list
+    expect(out.indexOf('Prior chapter')).toBeLessThan(out.indexOf('## Sentences'));
   });
 });

--- a/server/src/routes/script-review.test.ts
+++ b/server/src/routes/script-review.test.ts
@@ -17,7 +17,10 @@ import express, { type Express } from 'express';
 import request from 'supertest';
 import type { Analyzer } from '../analyzer/index.js';
 import type { ScriptReviewOutput } from '../handoff/schemas.js';
-import type { buildReviewSentencesInput as BuildReviewSentencesInput } from './script-review.js';
+import type {
+  buildReviewSentencesInput as BuildReviewSentencesInput,
+  priorChapterBoundaryExchange as PriorChapterBoundaryExchange,
+} from './script-review.js';
 
 const AUTHOR = 'Test Author';
 const SERIES = 'Test Series';
@@ -28,6 +31,7 @@ let app: Express;
 let bookId: string;
 let manuscriptId: string;
 let buildReviewSentencesInput: typeof BuildReviewSentencesInput;
+let priorChapterBoundaryExchange: typeof PriorChapterBoundaryExchange;
 
 /* The fake analyzer's runScriptReviewChapter — each test swaps its implementation.
    `selectedEngine` lets a test flip the reported engine to 'local' (so the
@@ -128,9 +132,10 @@ const CANNED_OPS: ScriptReviewOutput = {
 beforeAll(async () => {
   workspaceRoot = mkdtempSync(join(tmpdir(), 'audiobook-script-review-test-'));
   process.env.WORKSPACE_DIR = workspaceRoot;
-  const [{ scriptReviewRouter, buildReviewSentencesInput: build }, { makeBookId }] =
+  const [{ scriptReviewRouter, buildReviewSentencesInput: build, priorChapterBoundaryExchange: pcbe }, { makeBookId }] =
     await Promise.all([import('./script-review.js'), import('../workspace/paths.js')]);
   buildReviewSentencesInput = build;
+  priorChapterBoundaryExchange = pcbe;
   bookId = makeBookId(AUTHOR, SERIES, BOOK);
   manuscriptId = `m_${bookId}`;
   app = express();
@@ -348,5 +353,92 @@ describe('buildReviewSentencesInput (fs-58)', () => {
       instruct: 'a tired sigh', vocalization: true,
     });
     expect(out[2]).toEqual({ sentenceId: 3, characterId: 'mira', text: 'No instruct.' });
+  });
+});
+
+describe('priorChapterBoundaryExchange (fs-64)', () => {
+  const roster = [
+    { id: 'wren', name: 'Wren' },
+    { id: 'marlow', name: 'Marlow' },
+  ];
+  const s = (id: number, characterId: string, text: string, excludeFromSynthesis?: boolean) =>
+    ({ id, characterId, text, ...(excludeFromSynthesis ? { excludeFromSynthesis } : {}) });
+
+  it('returns both turns when the chapter ends on an A/B exchange', () => {
+    const out = priorChapterBoundaryExchange(
+      [s(1, 'narrator', 'It was late.'), s(2, 'wren', '"Where to?"'), s(3, 'marlow', '"Somewhere safe."')],
+      roster,
+    );
+    expect(out).toEqual({
+      turns: [
+        { speakerId: 'wren', speakerName: 'Wren', text: '"Where to?"' },
+        { speakerId: 'marlow', speakerName: 'Marlow', text: '"Somewhere safe."' },
+      ],
+    });
+  });
+
+  it('returns null when the chapter ends on narration (single speaker in window)', () => {
+    const out = priorChapterBoundaryExchange(
+      [s(1, 'wren', '"Hello?"'), s(2, 'narrator', 'No answer came.'), s(3, 'narrator', 'The hall was empty.')],
+      roster,
+    );
+    expect(out).toBeNull();
+  });
+
+  it('returns null on a single-speaker monologue ending', () => {
+    const out = priorChapterBoundaryExchange(
+      [s(1, 'wren', 'One.'), s(2, 'wren', 'Two.'), s(3, 'wren', 'Three.')],
+      roster,
+    );
+    expect(out).toBeNull();
+  });
+
+  it('returns null when two speakers both folded to one id (unknown-male)', () => {
+    const out = priorChapterBoundaryExchange(
+      [s(1, 'unknown-male', '"Run!"'), s(2, 'unknown-male', '"This way!"')],
+      roster,
+    );
+    expect(out).toBeNull();
+  });
+
+  it('returns null when the exchange is beyond the lookback window', () => {
+    const out = priorChapterBoundaryExchange(
+      [
+        s(1, 'wren', '"Where to?"'), s(2, 'marlow', '"Safe."'),
+        s(3, 'narrator', 'a'), s(4, 'narrator', 'b'), s(5, 'narrator', 'c'),
+        s(6, 'narrator', 'd'), s(7, 'narrator', 'e'), s(8, 'narrator', 'f'),
+      ],
+      roster,
+    );
+    expect(out).toBeNull();
+  });
+
+  it('filters excludeFromSynthesis residue out of the turns', () => {
+    const out = priorChapterBoundaryExchange(
+      [s(1, 'wren', '"Where to?"'), s(2, 'marlow', '"Safe."'), s(3, 'page-header', 'Chapter 4', true)],
+      roster,
+    );
+    expect(out).toEqual({
+      turns: [
+        { speakerId: 'wren', speakerName: 'Wren', text: '"Where to?"' },
+        { speakerId: 'marlow', speakerName: 'Marlow', text: '"Safe."' },
+      ],
+    });
+  });
+
+  it('truncates a long line to MAX_PRIOR_TURN_CHARS with an ellipsis', () => {
+    const long = '"' + 'x'.repeat(400) + '"';
+    const out = priorChapterBoundaryExchange([s(1, 'wren', 'short'), s(2, 'marlow', long)], roster);
+    expect(out!.turns[1].text.length).toBeLessThanOrEqual(240);
+    expect(out!.turns[1].text.endsWith('…')).toBe(true);
+  });
+
+  it('falls back to the id when a speaker is off-roster', () => {
+    const out = priorChapterBoundaryExchange([s(1, 'wren', '"Hi."'), s(2, 'ghost', '"Boo."')], roster);
+    expect(out!.turns[1]).toEqual({ speakerId: 'ghost', speakerName: 'ghost', text: '"Boo."' });
+  });
+
+  it('returns null for an empty chapter', () => {
+    expect(priorChapterBoundaryExchange([], roster)).toBeNull();
   });
 });

--- a/server/src/routes/script-review.test.ts
+++ b/server/src/routes/script-review.test.ts
@@ -344,6 +344,104 @@ describe('POST /api/books/:bookId/script-review', () => {
 
     expect(events.some((e) => e.kind === 'result')).toBe(true);
   });
+
+  it('feeds the prior chapter exchange into the next chapter, first chunk only (fs-64)', async () => {
+    writeBook([
+      { id: 1, chapterId: 1, characterId: 'wren', text: '"Where to?"' },
+      { id: 2, chapterId: 1, characterId: 'marlow', text: '"Somewhere safe."' },
+      { id: 1, chapterId: 2, characterId: 'wren', text: '"I know this place."' },
+    ], [
+      { id: 1, title: 'One', excluded: false },
+      { id: 2, title: 'Two', excluded: false },
+    ]);
+    const prompts: Record<number, string> = {};
+    runReview.mockImplementation((_m: string, c: number, p: string) => {
+      prompts[c] = p;
+      return Promise.resolve({ ops: [] });
+    });
+
+    await request(app).post(`/api/books/${bookId}/script-review`).send({}).expect(200);
+
+    expect(prompts[2]).toContain('Prior chapter');
+    // The seeded cast.json has only `wren`, so `marlow` resolves to its id via the
+    // off-roster fallback — assert the fallback form `marlow (id: marlow)`.
+    expect(prompts[2]).toContain('marlow (id: marlow): "Somewhere safe."');
+    expect(prompts[1] ?? '').not.toContain('Prior chapter'); // chapter 1 has no predecessor
+  });
+
+  it('attaches the block to the FIRST chunk only of a multi-chunk chapter (fs-64)', async () => {
+    // Force the local engine + small num_ctx so chapter 10 splits into >=2 chunks
+    // (mirrors the existing "chunks a large chapter" harness). Chapter 9 ends A/B,
+    // so chapter 10's FIRST chunk must carry the block and later chunks must not.
+    engineState.engine = 'local';
+    process.env.ANALYZER_NUM_CTX = '400'; // → budget 2000
+    const big = Array.from({ length: 12 }, (_, i) => ({
+      id: 100 + i, chapterId: 10, characterId: 'narrator', text: 'A'.repeat(800),
+    }));
+    writeBook([
+      { id: 1, chapterId: 9, characterId: 'wren', text: '"Where to?"' },
+      { id: 2, chapterId: 9, characterId: 'marlow', text: '"Somewhere safe."' },
+      ...big,
+    ], [{ id: 9, title: 'Nine', excluded: false }, { id: 10, title: 'Ten', excluded: false }]);
+
+    const calls: Array<{ chapterId: number; prompt: string }> = [];
+    runReview.mockImplementation((_m: string, c: number, p: string) => {
+      calls.push({ chapterId: c, prompt: p });
+      return Promise.resolve({ ops: [] });
+    });
+
+    await request(app).post(`/api/books/${bookId}/script-review`).send({}).expect(200);
+
+    const ch10 = calls.filter((c) => c.chapterId === 10).map((c) => c.prompt);
+    expect(ch10.length).toBeGreaterThan(1); // the chapter split
+    expect(ch10[0]).toContain('Prior chapter'); // first chunk carries it
+    expect(ch10.slice(1).every((p) => !p.includes('Prior chapter'))).toBe(true); // later chunks don't
+  });
+
+  it('emits NO block when the predecessor ends on narration — scene break (fs-64)', async () => {
+    // The headline regression guard: a non-exchange ending must not feed a
+    // misleading turn-taking signal into the next chapter.
+    writeBook([
+      { id: 1, chapterId: 1, characterId: 'wren', text: '"Anyone there?"' },
+      { id: 2, chapterId: 1, characterId: 'narrator', text: 'Silence answered.' },
+      { id: 1, chapterId: 2, characterId: 'wren', text: '"I knew it."' },
+    ], [{ id: 1, title: 'One', excluded: false }, { id: 2, title: 'Two', excluded: false }]);
+    const prompts: Record<number, string> = {};
+    runReview.mockImplementation((_m: string, c: number, p: string) => {
+      prompts[c] = p;
+      return Promise.resolve({ ops: [] });
+    });
+
+    await request(app).post(`/api/books/${bookId}/script-review`).send({}).expect(200);
+
+    expect(prompts[2] ?? '').not.toContain('Prior chapter'); // gate failed → no block
+  });
+
+  it('does NOT cascade past the immediately-preceding chapter (fs-64)', async () => {
+    // ch1 ends A/B, ch2 ends on narration (gate fails). ch3 must NOT pick up ch1's
+    // exchange — selection takes ch2 (immediate predecessor) and stops.
+    writeBook([
+      { id: 1, chapterId: 1, characterId: 'wren', text: '"Where to?"' },
+      { id: 2, chapterId: 1, characterId: 'marlow', text: '"Somewhere safe."' },
+      { id: 1, chapterId: 2, characterId: 'wren', text: '"Wait."' },
+      { id: 2, chapterId: 2, characterId: 'narrator', text: 'The door closed.' },
+      { id: 1, chapterId: 3, characterId: 'wren', text: '"Still here."' },
+    ], [
+      { id: 1, title: 'One', excluded: false },
+      { id: 2, title: 'Two', excluded: false },
+      { id: 3, title: 'Three', excluded: false },
+    ]);
+    const prompts: Record<number, string> = {};
+    runReview.mockImplementation((_m: string, c: number, p: string) => {
+      prompts[c] = p;
+      return Promise.resolve({ ops: [] });
+    });
+
+    await request(app).post(`/api/books/${bookId}/script-review`).send({}).expect(200);
+
+    expect(prompts[2] ?? '').toContain('Prior chapter');       // ch1 ended A/B → ch2 gets it
+    expect(prompts[3] ?? '').not.toContain('Prior chapter');   // ch2 ended narration → no cascade to ch1
+  });
 });
 
 describe('buildReviewSentencesInput (fs-58)', () => {

--- a/server/src/routes/script-review.test.ts
+++ b/server/src/routes/script-review.test.ts
@@ -21,6 +21,7 @@ import type {
   buildReviewSentencesInput as BuildReviewSentencesInput,
   priorChapterBoundaryExchange as PriorChapterBoundaryExchange,
   buildScriptReviewChapterInbox as BuildScriptReviewChapterInbox,
+  priorChapterIdFor as PriorChapterIdFor,
 } from './script-review.js';
 
 const AUTHOR = 'Test Author';
@@ -34,6 +35,7 @@ let manuscriptId: string;
 let buildReviewSentencesInput: typeof BuildReviewSentencesInput;
 let priorChapterBoundaryExchange: typeof PriorChapterBoundaryExchange;
 let buildScriptReviewChapterInbox: typeof BuildScriptReviewChapterInbox;
+let priorChapterIdFor: typeof PriorChapterIdFor;
 
 /* The fake analyzer's runScriptReviewChapter — each test swaps its implementation.
    `selectedEngine` lets a test flip the reported engine to 'local' (so the
@@ -134,11 +136,12 @@ const CANNED_OPS: ScriptReviewOutput = {
 beforeAll(async () => {
   workspaceRoot = mkdtempSync(join(tmpdir(), 'audiobook-script-review-test-'));
   process.env.WORKSPACE_DIR = workspaceRoot;
-  const [{ scriptReviewRouter, buildReviewSentencesInput: build, priorChapterBoundaryExchange: pcbe, buildScriptReviewChapterInbox: bsrci }, { makeBookId }] =
+  const [{ scriptReviewRouter, buildReviewSentencesInput: build, priorChapterBoundaryExchange: pcbe, buildScriptReviewChapterInbox: bsrci, priorChapterIdFor: pcif }, { makeBookId }] =
     await Promise.all([import('./script-review.js'), import('../workspace/paths.js')]);
   buildReviewSentencesInput = build;
   priorChapterBoundaryExchange = pcbe;
   buildScriptReviewChapterInbox = bsrci;
+  priorChapterIdFor = pcif;
   bookId = makeBookId(AUTHOR, SERIES, BOOK);
   manuscriptId = `m_${bookId}`;
   app = express();
@@ -505,5 +508,23 @@ chapterId: 2
     expect(block).not.toMatch(/"id"\s*:\s*\d/); // no numeric id leaks into the block
     // block sits before the sentence list
     expect(out.indexOf('Prior chapter')).toBeLessThan(out.indexOf('## Sentences'));
+  });
+});
+
+describe('priorChapterIdFor (fs-64)', () => {
+  it('returns the nearest lower chapter id', () => {
+    expect(priorChapterIdFor(3, [1, 2, 3, 4], new Set())).toBe(2);
+  });
+  it('skips excluded chapters', () => {
+    expect(priorChapterIdFor(3, [1, 2, 3], new Set([2]))).toBe(1);
+  });
+  it('returns null for the first chapter (no lower id)', () => {
+    expect(priorChapterIdFor(1, [1, 2, 3], new Set())).toBeNull();
+  });
+  it('returns null when every lower chapter is excluded', () => {
+    expect(priorChapterIdFor(3, [1, 2, 3], new Set([1, 2]))).toBeNull();
+  });
+  it('handles non-contiguous ids', () => {
+    expect(priorChapterIdFor(10, [2, 5, 10, 11], new Set())).toBe(5);
   });
 });

--- a/server/src/routes/script-review.ts
+++ b/server/src/routes/script-review.ts
@@ -69,6 +69,18 @@ function capLine(text: string): string {
     : text;
 }
 
+/* The immediately-preceding non-excluded story chapter, or null. No cascade:
+   selection skips only excluded chapters; whether that predecessor yields an
+   exchange is a separate gate (priorChapterBoundaryExchange). */
+export function priorChapterIdFor(
+  chapterId: number,
+  allChapterIds: number[],
+  excludedIds: Set<number>,
+): number | null {
+  const lower = allChapterIds.filter((id) => id < chapterId && !excludedIds.has(id));
+  return lower.length ? lower[lower.length - 1] : null;
+}
+
 /* The prior chapter's final two-speaker exchange, or null when it does not end
    in a live exchange. Narration and excludeFromSynthesis residue are filtered;
    the remaining eligible sentences in the last PRIOR_TURN_LOOKBACK positions are

--- a/server/src/routes/script-review.ts
+++ b/server/src/routes/script-review.ts
@@ -202,18 +202,20 @@ scriptReviewRouter.post(
 
     const byChapter = await loadPostFoldSentencesByChapter(manuscriptId, located.bookDir);
 
-    /* When chapterId is supplied in the body, limit the pass to that one chapter. */
-    let chapterIds = [...byChapter.keys()].sort((a, b) => a - b);
+    const allChapterIds = [...byChapter.keys()].sort((a, b) => a - b);
+    /* Chapters the user excluded from narration (front/back-matter). Mirrors the
+       detect-emotions + generation filters, and gates fs-64 neighbour selection. */
+    const excludedChapterIds = new Set<number>(
+      located.state.chapters.filter((c) => c.excluded).map((c) => c.id),
+    );
+
+    /* When chapterId is supplied in the body, limit the pass to that one chapter
+       (honoured even when excluded). Otherwise skip the excluded chapters. */
+    let chapterIds = allChapterIds;
     if (requestedChapterId !== undefined) {
-      chapterIds = chapterIds.filter((id) => id === requestedChapterId);
+      chapterIds = allChapterIds.filter((id) => id === requestedChapterId);
     } else {
-      /* Whole-book review skips chapters the user excluded from narration
-         (front/back-matter). Mirrors the detect-emotions + generation filters.
-         An explicit per-chapter request above is honoured even when excluded. */
-      const excludedChapterIds = new Set<number>(
-        located.state.chapters.filter((c) => c.excluded).map((c) => c.id),
-      );
-      chapterIds = chapterIds.filter((id) => !excludedChapterIds.has(id));
+      chapterIds = allChapterIds.filter((id) => !excludedChapterIds.has(id));
     }
 
     /* Load the post-fold cast roster so the prompt carries character names+roles.
@@ -295,6 +297,13 @@ scriptReviewRouter.post(
           chapterId,
         });
 
+        /* fs-64 — the prior chapter's final exchange (read-only) resolves a
+           tagless chapter-opening line. Null unless the immediately-preceding
+           non-excluded chapter ends in a live A/B exchange. */
+        const priorId = priorChapterIdFor(chapterId, allChapterIds, excludedChapterIds);
+        const priorExchange =
+          priorId !== null ? priorChapterBoundaryExchange(byChapter.get(priorId) ?? [], roster) : null;
+
         /* Split the chapter's sentences into budgeted chunks (one call each).
            The owned-core rule keeps each sentence reviewed exactly once across
            the overlapping context windows. A cloud engine gets a huge budget so
@@ -305,13 +314,15 @@ scriptReviewRouter.post(
           serialize: (s) => JSON.stringify({ id: s.id, characterId: s.characterId, text: s.text }),
         });
 
-        for (const chunk of chunks) {
+        for (let index = 0; index < chunks.length; index += 1) {
+          const chunk = chunks[index];
           if (closed) break;
           const prompt = buildScriptReviewChapterInbox(
             manuscriptId,
             chapterId,
             chunkWithContext(chunk),
             roster,
+            index === 0 ? priorExchange : null,
           );
           try {
             const result = await selection.analyzer.runScriptReviewChapter(

--- a/server/src/routes/script-review.ts
+++ b/server/src/routes/script-review.ts
@@ -137,6 +137,7 @@ export function buildScriptReviewChapterInbox(
   chapterId: number,
   sentences: SentenceOutput[],
   roster: CastCharacterSlim[],
+  priorExchange: PriorExchange | null = null,
 ): string {
   const sentencePayload = buildReviewSentencesInput(sentences);
   const rosterPayload = roster.map((c) => ({
@@ -144,6 +145,11 @@ export function buildScriptReviewChapterInbox(
     name: c.name,
     ...(c.role ? { role: c.role } : {}),
   }));
+  const priorBlock = priorExchange
+    ? '## Prior chapter — final exchange (reference only — not reviewable lines; do NOT emit an op on them)\n\n' +
+      priorExchange.turns.map((t) => `${t.speakerName} (id: ${t.speakerId}): ${t.text}`).join('\n') +
+      '\n\n'
+    : '';
   return `---
 manuscriptId: ${manuscriptId}
 task: script-review
@@ -156,7 +162,7 @@ chapterId: ${chapterId}
 ${JSON.stringify(rosterPayload, null, 2)}
 \`\`\`
 
-## Sentences (already attributed)
+${priorBlock}## Sentences (already attributed)
 
 \`\`\`json
 ${JSON.stringify(sentencePayload, null, 2)}

--- a/server/src/routes/script-review.ts
+++ b/server/src/routes/script-review.ts
@@ -47,6 +47,63 @@ interface CastFile {
   characters?: CastCharacterSlim[];
 }
 
+/* fs-64 — cross-chapter context for the script-review pass. The prior chapter's
+   final two-speaker exchange is fed (read-only) into a chapter's first chunk so
+   the model can resolve a tagless chapter-opening line via turn-taking. */
+const NARRATOR_ID = 'narrator'; // module-private convention (re-declared, never exported)
+export const PRIOR_TURN_LOOKBACK = 6; // sentences (positions) scanned back from the chapter end
+export const MAX_PRIOR_TURN_CHARS = 240; // hard cap per rendered line
+
+export interface BoundaryTurn {
+  speakerId: string;
+  speakerName: string;
+  text: string;
+}
+export interface PriorExchange {
+  turns: BoundaryTurn[]; // exactly two, [A, B] in reading order
+}
+
+function capLine(text: string): string {
+  return text.length > MAX_PRIOR_TURN_CHARS
+    ? text.slice(0, MAX_PRIOR_TURN_CHARS - 1).trimEnd() + '…'
+    : text;
+}
+
+/* The prior chapter's final two-speaker exchange, or null when it does not end
+   in a live exchange. Narration and excludeFromSynthesis residue are filtered;
+   the remaining eligible sentences in the last PRIOR_TURN_LOOKBACK positions are
+   collapsed into contiguous same-speaker turns. Gate: >=2 turns (which, by the
+   collapse, guarantees the last two are different speakers). Two distinct people
+   folded to one id (e.g. unknown-male) collapse to one turn -> null. */
+export function priorChapterBoundaryExchange(
+  sentences: Array<{ id: number; characterId: string; text: string; excludeFromSynthesis?: boolean }>,
+  roster: Array<{ id: string; name: string }>,
+): PriorExchange | null {
+  const eligible = sentences
+    .slice(-PRIOR_TURN_LOOKBACK)
+    .filter((s) => s.characterId !== NARRATOR_ID && s.excludeFromSynthesis !== true);
+
+  const turns: Array<{ speakerId: string; lastText: string }> = [];
+  for (const sentence of eligible) {
+    const prev = turns[turns.length - 1];
+    if (prev && prev.speakerId === sentence.characterId) {
+      prev.lastText = sentence.text; // extend the run; keep its boundary-adjacent line
+    } else {
+      turns.push({ speakerId: sentence.characterId, lastText: sentence.text });
+    }
+  }
+  if (turns.length < 2) return null;
+
+  const nameOf = (id: string): string => roster.find((r) => r.id === id)?.name ?? id;
+  const toTurn = (t: { speakerId: string; lastText: string }): BoundaryTurn => ({
+    speakerId: t.speakerId,
+    speakerName: nameOf(t.speakerId),
+    text: capLine(t.lastText),
+  });
+  const [a, b] = turns.slice(-2);
+  return { turns: [toTurn(a), toTurn(b)] };
+}
+
 /* Build the per-chapter script-review prompt. We send the full chapter
    sentence sequence plus the post-fold cast roster (id/name/role) so the
    model can identify characters and propose attribution-level edits.

--- a/skills/audiobook-script-review.md
+++ b/skills/audiobook-script-review.md
@@ -22,6 +22,12 @@ The input contains:
    `instruct` is an English delivery direction; `vocalization: true` marks a
    sentence whose `text` was given a machine-prepended non-verbal sound.
 2. The book's cast (id → name mapping) so you can reference character ids.
+3. OPTIONALLY, a `## Prior chapter — final exchange` block above the sentences.
+   It names the previous chapter's last two speakers and their closing lines —
+   read-only turn-taking context to help you attribute a tagless **opening**
+   line of THIS chapter. It carries **no `sentenceId`** and is **not reviewable**:
+   never emit an op targeting it; use only the named alternation to inform the
+   attribution of this chapter's own opening sentences.
 
 ## Op classes
 


### PR DESCRIPTION
## Summary

Feeds the prior chapter's **final two-speaker exchange** into the script-review LLM prompt as read-only context — gated on the predecessor actually ending in a live alternating exchange — so the model can resolve a tagless chapter-opening line (e.g. `"I know," he said.`) via cross-chapter turn-taking. Strictly additive: when the gate fails (scene-break / narration / monologue ending, first chapter), the prompt is byte-identical to today. **Zero new LLM calls.**

Spec: `docs/superpowers/specs/2026-06-26-fs64-cross-chapter-reattribute-context-design.md`
Plan: `docs/superpowers/plans/2026-06-26-fs64-cross-chapter-reattribute.md`

Built via subagent-driven development (5 TDD tasks + per-task reviews + an opus whole-branch review = READY TO MERGE). The spec and plan each went through two adversarial review rounds before implementation.

Closes #1120

## Test plan

- `npm run verify` — typecheck + all tests + e2e + build, **green** locally.
- New unit tests: the live-exchange gate (`priorChapterBoundaryExchange`, 9 cases incl. narration/monologue→null, `unknown-male` fold→null, beyond-window, residue filter, truncation, off-roster fallback); the prompt block render + **frozen byte-identical-when-absent** + block-region **read-only** guard (no `sentenceId`); the neighbour selector (`priorChapterIdFor`, no cascade); and four route tests — positive single-chunk, **multi-chunk first-chunk-only** (forces a real split), scene-break predecessor ⇒ no block, and 3-chapter **no-cascade**.
- `status: stable` for the spec still owes the on-box render acceptance (§9.5) — NOT in this PR.