### PR TITLE
fix(frontend): gate Phase 3 prosody seed on library.loaded (boot seed-race)

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1010,9 +1010,19 @@ export function Layout() {
   );
   const completeKey = completeIds.join('|');
   useEffect(() => {
+    /* Wait for the library to actually hydrate before seeding. `library.books`
+       is [] until getLibrary() resolves (a separate, async effect). Seeding on
+       the first effect run — while the library is still empty — captured an
+       EMPTY baseline, so when the real library landed every pre-existing
+       complete book looked brand-new and the trigger fired runProsodyPasses for
+       the whole backlog at once (boot seed-race: floods SSE connections + the
+       GPU queue + VRAM, the app-wide hang on restart). Gating the seed on
+       `loaded` makes the FIRST loaded snapshot the baseline, so only genuine
+       post-load transitions fire. */
+    if (!library.loaded) return;
     if (!prosodySeeded.current) {
-      // First run: mark all currently-complete books as already considered
-      // (no backlog auto-spend; makes a remount self-healing).
+      // First loaded snapshot: mark all currently-complete books as already
+      // considered (no backlog auto-spend; makes a remount self-healing).
       completeIds.forEach((id) => prosodyConsidered.current.add(id));
       prosodySeeded.current = true;
       return;
@@ -1046,7 +1056,7 @@ export function Layout() {
       })();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [completeKey]);
+  }, [completeKey, library.loaded]);
 
   if (ui.previewMode) {
     return (

--- a/src/store/prosody-autotrigger.test.tsx
+++ b/src/store/prosody-autotrigger.test.tsx
@@ -114,6 +114,7 @@ vi.mock('../routes/prefetch', () => ({
 
 import { Layout } from '../components/layout';
 import { uiActions } from './ui-slice';
+import { api } from '../lib/api';
 
 /* ── Store factory ─────────────────────────────────────────────────────── */
 
@@ -166,6 +167,14 @@ function makeBook(
     coverGradient: ['#000', '#fff'],
     tags: [],
   };
+}
+
+/* Wrap a flat list of books into a LibraryResponse so a test can dispatch
+   `librarySlice.actions.hydrate(...)` — the action that flips `loaded` to true.
+   The seed-on-mount baseline only runs once the library is actually loaded
+   (mirrors getLibrary() resolving in production). */
+function libResponse(books: LibraryBook[]) {
+  return { authors: [{ name: 'Test Author', series: [{ name: 'Standalones', books }] }] };
 }
 
 /* Minimal BookStateResponse-shaped payload for getBookState — not opting out
@@ -229,9 +238,9 @@ describe('Layout — prosody auto-trigger (Task 13 / fs-65 Phase 3)', () => {
 
   it('does NOT fire runProsodyPasses for a book that is already analysis-complete on first render (seed-on-mount)', async () => {
     const store = makeStore();
-    /* A book that already exists in the library as cast_pending BEFORE Layout
-       mounts should be seeded into `considered` without firing. */
-    store.dispatch(librarySlice.actions.addBook(makeBook('b1', 'cast_pending')));
+    /* The library hydrates (loaded=true) with a book ALREADY complete — it is
+       seeded into `considered` as the baseline and must not fire. */
+    store.dispatch(librarySlice.actions.hydrate(libResponse([makeBook('b1', 'cast_pending')])));
     store.dispatch(uiActions.openBook({ id: 'b1', status: 'cast_pending' }));
 
     renderLayout(store);
@@ -239,6 +248,35 @@ describe('Layout — prosody auto-trigger (Task 13 / fs-65 Phase 3)', () => {
     /* Wait enough time for any async effects to settle. */
     await act(async () => {
       await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(runProsodyPassesMock).not.toHaveBeenCalled();
+  });
+
+  // ── Regression (boot seed-race): library hydrates AFTER mount ──
+  // Reproduces the production hang: getLibrary() resolves after Layout mounts,
+  // so the whole backlog of already-complete books arrives in ONE hydrate.
+  // Before the fix, the seed ran against the empty pre-hydrate library, so every
+  // book looked brand-new and fired runProsodyPasses at once (SSE/GPU/VRAM flood).
+
+  it('does NOT fire for pre-existing complete books that arrive via async library hydrate AFTER mount (boot seed-race)', async () => {
+    const store = makeStore();
+    store.dispatch(uiActions.openBook({ id: 'b1', status: 'cast_pending' }));
+
+    /* The real boot path: Layout mounts with an empty, unloaded library, then
+       its own getLibrary() effect resolves with the WHOLE backlog of already-
+       complete books in one hydrate. That first loaded snapshot is the seed
+       baseline — nothing should fire. (Before the fix the seed ran against the
+       empty pre-hydrate library, so all 15 books looked brand-new and fired at
+       once — the SSE/GPU/VRAM flood that hung the app on restart.) */
+    vi.mocked(api.getLibrary).mockResolvedValueOnce(
+      libResponse([makeBook('b1', 'cast_pending'), makeBook('b2', 'cast_pending')]) as never,
+    );
+
+    renderLayout(store);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 80));
     });
 
     expect(runProsodyPassesMock).not.toHaveBeenCalled();
@@ -253,7 +291,10 @@ describe('Layout — prosody auto-trigger (Task 13 / fs-65 Phase 3)', () => {
     renderLayout(store);
 
     /* Wait for the seed pass (first render with empty library). */
+    /* getLibrary() resolves (empty) — flips loaded=true and runs the seed
+       baseline pass. Mirrors the real boot ordering. */
     await act(async () => {
+      store.dispatch(librarySlice.actions.hydrate(libResponse([])));
       await new Promise((r) => setTimeout(r, 20));
     });
 
@@ -286,7 +327,10 @@ describe('Layout — prosody auto-trigger (Task 13 / fs-65 Phase 3)', () => {
     renderLayout(store);
 
     /* Wait for the seeded first render. */
+    /* getLibrary() resolves (empty) — flips loaded=true and runs the seed
+       baseline pass. Mirrors the real boot ordering. */
     await act(async () => {
+      store.dispatch(librarySlice.actions.hydrate(libResponse([])));
       await new Promise((r) => setTimeout(r, 20));
     });
 
@@ -317,7 +361,10 @@ describe('Layout — prosody auto-trigger (Task 13 / fs-65 Phase 3)', () => {
 
     renderLayout(store);
 
+    /* getLibrary() resolves (empty) — flips loaded=true and runs the seed
+       baseline pass. Mirrors the real boot ordering. */
     await act(async () => {
+      store.dispatch(librarySlice.actions.hydrate(libResponse([])));
       await new Promise((r) => setTimeout(r, 20));
     });
 
@@ -345,7 +392,10 @@ describe('Layout — prosody auto-trigger (Task 13 / fs-65 Phase 3)', () => {
 
     renderLayout(store);
 
+    /* getLibrary() resolves (empty) — flips loaded=true and runs the seed
+       baseline pass. Mirrors the real boot ordering. */
     await act(async () => {
+      store.dispatch(librarySlice.actions.hydrate(libResponse([])));
       await new Promise((r) => setTimeout(r, 20));
     });
 
@@ -369,7 +419,10 @@ describe('Layout — prosody auto-trigger (Task 13 / fs-65 Phase 3)', () => {
 
     renderLayout(store);
 
+    /* getLibrary() resolves (empty) — flips loaded=true and runs the seed
+       baseline pass. Mirrors the real boot ordering. */
     await act(async () => {
+      store.dispatch(librarySlice.actions.hydrate(libResponse([])));
       await new Promise((r) => setTimeout(r, 20));
     });
 
@@ -396,7 +449,10 @@ describe('Layout — prosody auto-trigger (Task 13 / fs-65 Phase 3)', () => {
 
     renderLayout(store);
 
+    /* getLibrary() resolves (empty) — flips loaded=true and runs the seed
+       baseline pass. Mirrors the real boot ordering. */
     await act(async () => {
+      store.dispatch(librarySlice.actions.hydrate(libResponse([])));
       await new Promise((r) => setTimeout(r, 20));
     });
 
@@ -450,7 +506,10 @@ describe('Layout — prosody auto-trigger (Task 13 / fs-65 Phase 3)', () => {
 
     renderLayout(store);
 
+    /* getLibrary() resolves (empty) — flips loaded=true and runs the seed
+       baseline pass. Mirrors the real boot ordering. */
     await act(async () => {
+      store.dispatch(librarySlice.actions.hydrate(libResponse([])));
       await new Promise((r) => setTimeout(r, 20));
     });
 
@@ -476,7 +535,10 @@ describe('Layout — prosody auto-trigger (Task 13 / fs-65 Phase 3)', () => {
 
     renderLayout(store);
 
+    /* getLibrary() resolves (empty) — flips loaded=true and runs the seed
+       baseline pass. Mirrors the real boot ordering. */
     await act(async () => {
+      store.dispatch(librarySlice.actions.hydrate(libResponse([])));
       await new Promise((r) => setTimeout(r, 20));
     });
 
@@ -516,7 +578,10 @@ describe('Layout — prosody auto-trigger (Task 13 / fs-65 Phase 3)', () => {
 
     renderLayout(store);
 
+    /* getLibrary() resolves (empty) — flips loaded=true and runs the seed
+       baseline pass. Mirrors the real boot ordering. */
     await act(async () => {
+      store.dispatch(librarySlice.actions.hydrate(libResponse([])));
       await new Promise((r) => setTimeout(r, 20));
     });
 
@@ -538,7 +603,10 @@ describe('Layout — prosody auto-trigger (Task 13 / fs-65 Phase 3)', () => {
 
     renderLayout(store);
 
+    /* getLibrary() resolves (empty) — flips loaded=true and runs the seed
+       baseline pass. Mirrors the real boot ordering. */
     await act(async () => {
+      store.dispatch(librarySlice.actions.hydrate(libResponse([])));
       await new Promise((r) => setTimeout(r, 20));
     });
 


### PR DESCRIPTION
## Summary

Fixes an app-wide hang on restart caused by the fs-65 Phase 3 prosody auto-trigger (PR #1142).

On boot — **with no new analysis run** — the app became unusable: the `Phase 3 — Detecting prosody · 0%` pill froze, pages/gallery images stopped loading, GPU pinned ~99% and VRAM went near-OOM. The Node server stayed responsive (`/api/gpu/queue` answered in ~250 ms with `depth:7`) — it was **buried in self-inflicted work**, not looping.

### Root cause (boot seed-race)

The auto-trigger seeds all pre-existing analysis-complete books into a `considered` set *without firing*, and only fires `runProsodyPasses` for books that transition to complete **after** mount. But the seed ran on the **first effect run**, while `library.books` was still `[]` (the library hydrates asynchronously via a separate `getLibrary()` effect). So it captured an **empty baseline**. When the real library then hydrated with all ~15 complete books, every one looked brand-new and the trigger fired `runProsodyPasses` for the **whole backlog at once** — each opening 2 long-lived analyzer SSE streams. That starves the browser's ~6-connection-per-host pool (pages/images can't load), stacks the GPU queue, and pushes VRAM near OOM via the local-Ollama analyzer fallback co-resident with the Qwen sidecar.

### Fix

Gate the seed on `library.loaded`, so the **first loaded library snapshot** (the full `getLibrary()` result) becomes the seed baseline. Only genuine post-load transitions fire. One-line behavioural change in `src/components/layout.tsx` (Task 13 effect).

## Test plan

- New regression test in `src/store/prosody-autotrigger.test.tsx` drives the real boot ordering (`getLibrary()` resolves *after* mount with the backlog) and asserts **zero** `runProsodyPasses` calls. Proven **fail-before / pass-after**: 2 calls without the fix, 0 with it.
- Existing 11 auto-trigger tests updated to model the `loaded` flip (genuine post-load transitions still fire as before).
- Full local `npm run verify` battery green (typecheck + 3306 frontend + server tests + e2e + build).

Closes #1150
Refs #1142