### PR TITLE
fix(server): count carried characters by both voice-identity facets

### DIFF
--- a/server/src/workspace/scan.ts
+++ b/server/src/workspace/scan.ts
@@ -446,6 +446,9 @@ export async function buildInputsFromBooks(books: LibraryBook[]): Promise<Series
           name: ch.name ?? ch.id,
           aliases: ch.aliases ?? [],
           voiceId: ch.voiceId ?? null,
+          // Per-engine voice file — the SECOND voice-identity facet. Stable in the
+          // debut book where `voiceId` (the reuse key) is still null. Empty → null.
+          voiceName: voiceName || null,
           voiceLabel: isTtsEngine(engine) ? describeVoice(engine, voiceName) : '',
           engine,
           voiceKind: voiceKindFor(isTtsEngine(engine) ? engine : null),

--- a/server/src/workspace/series-memory.test.ts
+++ b/server/src/workspace/series-memory.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { deriveSeriesMemory, summarize, type SeriesBookInput, type SeriesCharacterInput } from './series-memory.js';
 
 const ch = (o: Partial<SeriesCharacterInput> & { characterId: string }): SeriesCharacterInput => ({
-  name: o.name ?? o.characterId, aliases: [], voiceId: null, voiceLabel: 'Designed voice',
+  name: o.name ?? o.characterId, aliases: [], voiceId: null, voiceName: null, voiceLabel: 'Designed voice',
   engine: 'qwen', voiceKind: 'designed', isPrincipal: true, matchedFrom: null, ...o,
 });
 // A 3-book series: 3 designed principals carried 1->3; one preset principal carried; one late joiner.
@@ -58,6 +58,57 @@ describe('deriveSeriesMemory', () => {
     }));
     const d = deriveSeriesMemory(books)!;
     expect(d.carried.count).toBe(6); // Narrator AND Guard both count
+  });
+
+  it('carries a character whose originating book has a null reuse voiceId but a stable engine voice name', () => {
+    // Real-world (KOTC): the book where a character DEBUTS never gets the
+    // cross-book reuse `voiceId` stamped — only the per-engine voice name
+    // (overrideTtsVoices[engine].name → here `voiceName`). Later books carry
+    // BOTH. The voice never changed, so the character must count as carried.
+    // Regression: the old single-`voiceId` set saw {null, 'v_q_marrow'} and
+    // dropped the whole main cast that debuts in book 1.
+    const books = baseBooks();
+    for (const b of books) {
+      const m = b.characters.find((c) => c.characterId === `${b.bookId}-marrow`)!;
+      m.voiceName = 'qwen-marrow'; // engine voice name — identical in every book
+      if (b.bookId === 'b1') m.voiceId = null; // originating book: no reuse key yet
+    }
+    const d = deriveSeriesMemory(books)!;
+    const marrow = d.carried.characters.find((c) => c.character === 'Marrow')!;
+    expect(marrow).toBeDefined();
+    expect(marrow.bookIndices).toEqual([1, 2, 3]);
+    expect(marrow.carriedFullSpan).toBe(true);
+    expect(marrow.voiceId).toBe('v_q_marrow'); // canonical id from a voiced appearance
+  });
+
+  it('carries a character voiced consistently but name-dropped (no engine voice) in one book', () => {
+    // Real-world (KOTC Lord Cassius / Ro / Flori): a character speaks with one
+    // voice across books, but in one book is a bare mention with ttsEngine=null
+    // → no engine voice name. The reuse voiceId stays stable, so it's the same
+    // voice. A null facet in one appearance must NOT poison the whole component.
+    const books = baseBooks();
+    const cassius = (b: SeriesBookInput) => b.characters.find((c) => c.characterId === `${b.bookId}-marrow`)!;
+    for (const b of books) {
+      cassius(b).voiceName = 'qwen-marrow';
+      cassius(b).voiceId = 'v_q_marrow';
+    }
+    // Book 2: bare mention — engine + voiceName null, but reuse voiceId persists.
+    cassius(books[1]).voiceName = null;
+    cassius(books[1]).engine = null;
+    const d = deriveSeriesMemory(books)!;
+    const m = d.carried.characters.find((c) => c.character === 'Marrow')!;
+    expect(m).toBeDefined();
+    expect(m.bookIndices).toEqual([1, 2, 3]);
+  });
+
+  it('excludes a character re-cast mid-series (engine voice name changed even if reuse id stable)', () => {
+    // Both facets guard a voice change: flipping only the engine voice name
+    // (a genuine re-voicing) must still drop the character.
+    const books = baseBooks();
+    for (const b of books) b.characters.find((c) => c.characterId === `${b.bookId}-marrow`)!.voiceName = 'qwen-marrow';
+    books[2].characters.find((c) => c.characterId === 'b3-marrow')!.voiceName = 'qwen-marrow-RECAST';
+    const d = deriveSeriesMemory(books)!;
+    expect(d.carried.characters.find((c) => c.character === 'Marrow')).toBeUndefined();
   });
 
   it('excludes a character re-cast mid-series (voiceId changed)', () => {

--- a/server/src/workspace/series-memory.test.ts
+++ b/server/src/workspace/series-memory.test.ts
@@ -161,6 +161,74 @@ describe('deriveSeriesMemory', () => {
     expect(rows[0].aliases).toContain('Marrow');
   });
 
+  it('merges two UNLINKED components that share one bespoke engine voice (missed matchedFrom)', () => {
+    // Real-world (KOTC): Keefe is re-detected fresh in one book, so its
+    // matchedFrom never links it to the main Keefe — leaving a singleton
+    // [book 3] component beside the carried [1,2] one. Same engine voice name
+    // (`voiceName`) → same character; the second merge pass unifies them.
+    const books = baseBooks();
+    // Drop the matchedFrom on b3-marrow so it is NOT linked by the graph, and give
+    // it a fresh id + NULL reuse voiceId — exactly how a re-detection looks. Only
+    // the shared engine voice name can reunite it (Pass B).
+    const b3m = books[2].characters.find((c) => c.characterId === 'b3-marrow')!;
+    b3m.matchedFrom = null;
+    b3m.characterId = 'b3-marrow-refresh';
+    b3m.voiceId = null;
+    for (const b of books) {
+      const m = b.characters.find((c) => c.name === 'Marrow')!;
+      m.voiceName = 'qwen-marrow';
+    }
+    const d = deriveSeriesMemory(books)!;
+    const rows = d.carried.characters.filter((c) => c.character === 'Marrow');
+    expect(rows).toHaveLength(1); // not split into two
+    expect(rows[0].bookIndices).toEqual([1, 2, 3]); // book 3 reunited
+  });
+
+  it('merges alias/spelling-drift duplicates that share a bespoke voiceId', () => {
+    // "Wylie" (bk1) and "Wylie Endal" (bk2) — different name AND id, no
+    // matchedFrom between them, but the same designed voiceId. One carried row.
+    const books = baseBooks();
+    // Drop book-3 Marrow so the Wylie pair below is an isolated component.
+    books[2].characters = books[2].characters.filter((c) => c.characterId !== 'b3-marrow');
+    const a = books[0].characters.find((c) => c.characterId === 'b1-marrow')!;
+    const b = books[1].characters.find((c) => c.characterId === 'b2-marrow')!;
+    a.name = 'Wylie'; b.name = 'Wylie Endal';
+    a.matchedFrom = null; b.matchedFrom = null; // graph does NOT link them
+    a.voiceId = b.voiceId = 'v_q_wylie';
+    a.voiceName = b.voiceName = null;
+    const d = deriveSeriesMemory(books)!;
+    const rows = d.carried.characters.filter((c) => c.voiceId === 'v_q_wylie');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].bookIndices).toEqual([1, 2]);
+  });
+
+  it('does NOT merge two unlinked components that carry DIFFERENT bespoke voices', () => {
+    // "Councilor Emery" [1,2] and "Councillor Emery" [3,4] — same person, but the
+    // user designed two different voices. They must stay separate (the voice DID
+    // change); unifying them is the upstream matcher's job, and would correctly
+    // EXCLUDE — never a false "carried" row. Here: distinct designed voices →
+    // two independent carried characters, never collapsed by the voice merge.
+    const link = (bookId: string, characterId: string) => ({ bookId, characterId });
+    const books: SeriesBookInput[] = [1, 2, 3, 4].map((index) => ({
+      bookId: `b${index}`, index, title: `Book ${index}`,
+      characters: [
+        ch({ characterId: `b${index}-edda`, name: 'Edda', voiceId: 'v_q_edda',
+          matchedFrom: index > 1 ? link(`b${index - 1}`, `b${index - 1}-edda`) : null }),
+        ch({ characterId: `b${index}-vale`, name: 'Vale', voiceId: 'v_q_vale',
+          matchedFrom: index > 1 ? link(`b${index - 1}`, `b${index - 1}-vale`) : null }),
+      ],
+    }));
+    // Emery as TWO unlinked designed voices.
+    books[0].characters.push(ch({ characterId: 'b1-emery', name: 'Emery', voiceId: 'v_q_emery_a' }));
+    books[1].characters.push(ch({ characterId: 'b2-emery', name: 'Emery', voiceId: 'v_q_emery_a', matchedFrom: link('b1', 'b1-emery') }));
+    books[2].characters.push(ch({ characterId: 'b3-emery', name: 'Emery', voiceId: 'v_q_emery_b' }));
+    books[3].characters.push(ch({ characterId: 'b4-emery', name: 'Emery', voiceId: 'v_q_emery_b', matchedFrom: link('b3', 'b3-emery') }));
+    const d = deriveSeriesMemory(books)!;
+    const emeryRows = d.carried.characters.filter((c) => c.character === 'Emery');
+    expect(emeryRows).toHaveLength(2); // distinct voices → not merged
+    expect(emeryRows.map((r) => r.bookIndices).sort()).toEqual([[1, 2], [3, 4]]);
+  });
+
   it('chip N equals reveal row count (summarize.carriedCount === characters.length)', () => {
     const d = deriveSeriesMemory(baseBooks())!;
     expect(summarize(d).carriedCount).toBe(d.carried.characters.length);

--- a/server/src/workspace/series-memory.ts
+++ b/server/src/workspace/series-memory.ts
@@ -3,7 +3,14 @@ import type { VoiceKind } from './voice-kind.js';
 
 export interface SeriesCharacterInput {
   characterId: string; name: string; aliases: string[];
-  voiceId: string | null; voiceLabel: string; engine: string | null;
+  // Two facets of a character's voice identity, EITHER of which may be null in a
+  // given book: `voiceId` is the cross-book reuse-linkage key (null in the book
+  // where a character DEBUTS — only stamped once it's matched FROM a prior book);
+  // `voiceName` is the per-engine voice file (overrideTtsVoices[engine].name, null
+  // when the character is a bare mention with no assigned voice). Carried-voice
+  // consistency is judged across BOTH facets — see deriveSeriesMemory.
+  voiceId: string | null; voiceName: string | null;
+  voiceLabel: string; engine: string | null;
   voiceKind: VoiceKind; isPrincipal: boolean;
   matchedFrom: { bookId?: string; characterId?: string } | null;
 }
@@ -85,24 +92,38 @@ export function deriveSeriesMemory(books: SeriesBookInput[]): SeriesMemoryDetail
 
   const carried: CarriedCharacter[] = [];
   for (const chain of components.values()) {
-    const voiceIds = new Set(chain.map((a) => a.ch.voiceId ?? ''));
-    if (voiceIds.size !== 1 || voiceIds.has('')) continue; // voice changed/missing → not carried
+    // Voice consistency across BOTH facets. Each facet is null in legitimate
+    // cases (debut book → null voiceId; bare mention → null voiceName), so a
+    // null in one appearance must NOT poison the component — only a CONFLICT
+    // (≥2 distinct non-null values) of either facet signals a real re-voicing.
+    // Keying on `voiceId` alone (the old rule) wrongly dropped every character
+    // that debuts in book 1, where the reuse voiceId is never stamped.
+    const ids = new Set(chain.map((a) => a.ch.voiceId).filter((v): v is string => !!v));
+    const names = new Set(chain.map((a) => a.ch.voiceName).filter((v): v is string => !!v));
+    if (ids.size > 1 || names.size > 1) continue; // voice changed → not carried
+    if (ids.size === 0 && names.size === 0) continue; // never voiced → not carried
     // Order explicitly by book index — earliest = first book, latest = canonical
-    // name/voice. Dedup indices: a component can hold >1 appearance in the same
+    // name. Dedup indices: a component can hold >1 appearance in the same
     // book (two characters reused from one shared source merge into one component).
     const byIndex = [...chain].sort((a, b) => a.book.index - b.book.index);
     const indices = [...new Set(byIndex.map((a) => a.book.index))];
     if (indices.length < 2) continue; // present in <2 distinct books → not carried
-    const earliest = byIndex[0], latest = byIndex[byIndex.length - 1].ch;
+    const earliest = byIndex[0], latest = byIndex[byIndex.length - 1];
+    // Voice metadata (id/label/engine/kind) from the LATEST appearance that
+    // actually carries a voice — the latest overall may be a bare unvoiced
+    // mention whose label/engine are blank. The display NAME still comes from
+    // the latest appearance overall (canonical-latest, e.g. an alias reveal).
+    const voiced = [...byIndex].reverse().find((a) => a.ch.voiceId || a.ch.voiceName) ?? latest;
+    const carriedVoiceId = (voiced.ch.voiceId ?? [...ids][0] ?? voiced.ch.voiceName ?? [...names][0]) as string;
     // carriedFullSpan: present in EVERY confirmed book 1..M (no gap). `ordered`
     // is the confirmed set by contract.
     const fullSpan = indices.length === ordered.length &&
       indices.every((v, i) => v === ordered[i].index);
     carried.push({
-      character: latest.name, aliases: latest.aliases,
-      voiceId: latest.voiceId as string, voiceLabel: latest.voiceLabel,
-      engine: latest.engine, voiceKind: latest.voiceKind,
-      firstBookId: earliest.book.bookId, lastBookId: byIndex[byIndex.length - 1].book.bookId,
+      character: latest.ch.name, aliases: latest.ch.aliases,
+      voiceId: carriedVoiceId, voiceLabel: voiced.ch.voiceLabel,
+      engine: voiced.ch.engine, voiceKind: voiced.ch.voiceKind,
+      firstBookId: earliest.book.bookId, lastBookId: latest.book.bookId,
       bookIndices: indices, carriedFullSpan: fullSpan,
     });
   }

--- a/server/src/workspace/series-memory.ts
+++ b/server/src/workspace/series-memory.ts
@@ -81,6 +81,40 @@ export function deriveSeriesMemory(books: SeriesBookInput[]): SeriesMemoryDetail
     }
   }
 
+  // Second merge: appearances of ONE character that `matchedFrom` failed to link —
+  // a missed cross-book match (e.g. Keefe re-detected fresh in one book) or
+  // alias/spelling drift that gave the same person different ids ("Wylie"/"Wylie
+  // Endal", "Jurek"/"Neverseen Figure"). PRESET voices are shared across characters
+  // by design (two guards on one kokoro voice), so they're excluded throughout —
+  // preserving the "two characters, one preset voice → two carried rows" invariant.
+  //
+  // Pass A — union by the reuse `voiceId`: a per-character key, distinct per
+  // character, only null in a debut book. Unambiguous, so always safe to merge.
+  const repByVoiceId = new Map<string, string>();
+  for (const [key, { ch }] of byKey) {
+    if (ch.voiceKind === 'preset' || !ch.voiceId) continue;
+    const rep = repByVoiceId.get(ch.voiceId);
+    if (rep) union(key, rep);
+    else repByVoiceId.set(ch.voiceId, key);
+  }
+  // Pass B — union by the engine voice name, but ONLY when that name maps to a
+  // single character (all its non-null voiceIds agree). A voice name shared across
+  // DIFFERENT voiceIds means distinct characters reusing one voice (or a generic
+  // placeholder), which must NOT be merged. This is what links a fresh-detected
+  // fragment (null voiceId) back to its main character (e.g. Keefe).
+  const byVoiceName = new Map<string, { keys: string[]; ids: Set<string> }>();
+  for (const [key, { ch }] of byKey) {
+    if (ch.voiceKind === 'preset' || !ch.voiceName) continue;
+    let g = byVoiceName.get(ch.voiceName);
+    if (!g) byVoiceName.set(ch.voiceName, (g = { keys: [], ids: new Set() }));
+    g.keys.push(key);
+    if (ch.voiceId) g.ids.add(ch.voiceId);
+  }
+  for (const g of byVoiceName.values()) {
+    if (g.ids.size > 1) continue; // ambiguous voice name → leave components alone
+    for (let i = 1; i < g.keys.length; i++) union(g.keys[i], g.keys[0]);
+  }
+
   // Bucket appearances by component root — each component is one logical character.
   const components = new Map<string, Appearance[]>();
   for (const [key, app] of byKey) {


### PR DESCRIPTION
## Summary

Makes the **Series Memory** reveal correct. On the real Keeper of the Lost Cities library (8 books) it showed **10** carried voices and split/duplicated several characters; it now shows the full reused cast with each character unified. Two related root causes, both in `deriveSeriesMemory`:

### 1. Undercount — voice-consistency judged on the wrong field (#1152)

`voiceId` is the cross-book **reuse-linkage key** — `null` in the book where a character *debuts* (only stamped once matched FROM a prior book). Keying voice-consistency on `voiceId` alone dropped the entire main cast that debuts in book 1 (Sophie, Dex, Fitz, Biana, Grady…), which read as `{null, "<voice>"}`. Neither field is stable per-appearance: `voiceId` is null in the debut book; the engine voice name is null for a bare mention (`ttsEngine: null`).

**Fix:** treat `voiceId` and the per-engine voice name as **two facets of one identity** — "voice unchanged" iff neither facet has a conflicting non-null value and at least one names a real voice. Voice metadata is sourced from the latest *voiced* appearance.

### 2. Fragmentation — recurring characters split across components (#1154)

When `matchedFrom` was missing or alias/spelling drift gave the same person different ids, one character split into multiple rows (Keefe re-detected fresh in *Everblaze*; "Wylie"/"Wylie Endal"; "Jurek"/"Neverseen Figure").

**Fix:** after the `matchedFrom` union-find, a second merge over the **bespoke** voice (preset voices excluded — they're shared by design):
- **Pass A** — union by reuse `voiceId` (per-character key).
- **Pass B** — union by engine voice name, but only when it maps to a single character (all non-null voiceIds agree), so distinct characters reusing one voice (or a placeholder) never merge. This relinks a null-voiceId fragment (Keefe) to its main row.

### Result on the real library

Carried **10 → 47**; Keefe reunited across all 8 books; Wylie/Wylie-Endal and Jurek/Neverseen-Figure collapse to one row each; **Councilor/Councillor Emery (two genuinely different voices) correctly stay separate**; zero false voice-changes; zero regressions.

API wire shape (`CarriedCharacter`) is unchanged — the `voiceName` facet is added only to the server-internal `SeriesCharacterInput`, so the frontend is untouched.

## Test plan

- `server/src/workspace/series-memory.test.ts` — six new regression tests (fail before, pass after): null-debut-voiceId carries; bare-mention carries; engine-voice-name change excludes; shared-voice-name merge of an unlinked fragment; shared-voiceId merge of an alias-drift duplicate; and a guard proving two components with DIFFERENT bespoke voices never merge.
- Full server suite green (`npm run test:server`, 3793 passed).
- `npm run typecheck` green.
- Validated against the real KOTC cast data on disk: carried 10 → 47 with the merges/splits above.

Closes #1152
Closes #1154