### PR TITLE
fix(sidecar): evict the other heavy 1.7B model before a Qwen design/mint

### DIFF
--- a/server/src/analyzer/sentence-progress.test.ts
+++ b/server/src/analyzer/sentence-progress.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { countSentencesHeuristic, countStreamedSentences, refineSentencesTotal, sentenceProgressForTick, projectChapterEstMsFromSentences, clampChapterEstMs, selectChapterEstMs } from './sentence-progress.js';
+import { countSentencesHeuristic, countStreamedSentences, monotonicHighWater, refineSentencesTotal, sentenceProgressForTick, projectChapterEstMsFromSentences, clampChapterEstMs, selectChapterEstMs } from './sentence-progress.js';
 
 describe('countSentencesHeuristic', () => {
   it('counts sentence-boundary splits', () => {
@@ -25,6 +25,30 @@ describe('countStreamedSentences', () => {
   });
   it('returns 0 for empty', () => {
     expect(countStreamedSentences('')).toBe(0);
+  });
+});
+
+describe('monotonicHighWater (anti-snap-back across a stream retry within a section)', () => {
+  it('rises with the live counter while it grows', () => {
+    expect(monotonicHighWater(40, 55)).toBe(55); // sentence markers
+    expect(monotonicHighWater(2_700, 13_000)).toBe(13_000); // received bytes
+  });
+  it('does NOT drop when a transient retry restarts the buffer mid-section', () => {
+    // The reported bug: a section streamed to ~250 markers / 13 KB, then a
+    // coverage/Gemini retry restarted the buffer, so the raw live counts
+    // collapsed (~250→30 markers, 13 KB→2.7 KB). The high-water mark holds, so
+    // "Attributed ~N" and "N KB received" never regress.
+    expect(monotonicHighWater(250, 30)).toBe(250);
+    expect(monotonicHighWater(13_000, 2_700)).toBe(13_000);
+  });
+  it('holds steady when the count is unchanged', () => {
+    expect(monotonicHighWater(100, 100)).toBe(100);
+  });
+  it('starts fresh from a boundary reset (prev = 0)', () => {
+    // The caller resets the slot to 0 at a real boundary (section start / done
+    // for sentences), so a new section legitimately begins counting from its
+    // own markers, not the prior section's mark.
+    expect(monotonicHighWater(0, 3)).toBe(3);
   });
 });
 

--- a/server/src/analyzer/sentence-progress.ts
+++ b/server/src/analyzer/sentence-progress.ts
@@ -24,6 +24,21 @@ export function countStreamedSentences(buffer: string): number {
   return (buffer.match(/"characterId"\s*:/g) ?? []).length;
 }
 
+/** A live, per-attempt stream counter (in-flight sentence markers, received
+    output bytes) made monotonic across a transient retry. A retry — a Gemini
+    idle/5xx/429 inside `generateWithLimiter`, or a higher-level coverage retry
+    that re-runs the whole `runStage2Chapter` call — restarts the streamed
+    buffer (and per-attempt elapsed) from zero, so the raw counter collapses
+    mid-section and the displayed "Attributed ~N" / "N KB received" would visibly
+    regress. Taking the high-water mark against the prior value holds the line.
+    Resetting at a REAL boundary (a new section, chapter done) is the caller's
+    job — the coverage retry does NOT re-fire the section-start callback, so a
+    high-water mark held in section state survives a retry but never leaks across
+    a genuine section change. */
+export function monotonicHighWater(prev: number, current: number): number {
+  return Math.max(prev, current);
+}
+
 /** Combine committed (exact, per completed section) + in-flight (marker count
     for the current section) into the displayed numerator, and pair it with a
     self-calibrated denominator that never sits below the numerator. */

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -51,6 +51,7 @@ import {
 import {
   countSentencesHeuristic,
   countStreamedSentences,
+  monotonicHighWater,
   sentenceProgressForTick,
   projectChapterEstMsFromSentences,
   selectChapterEstMs,
@@ -3552,14 +3553,21 @@ export async function runMainAnalyzerJob(
         slot.lastGoodEstMs = next;
       };
 
-      const tickOverall = (elapsed: number) => {
+      const tickOverall = () => {
         const slot = inFlight.get(i);
         if (slot) {
-          slot.elapsedMs = elapsed;
+          /* Chapter-relative elapsed (wall-clock since this chapter started),
+             NOT the per-attempt elapsed onWaiting reports. A coverage/transient
+             retry restarts the per-attempt clock at 0, which would make the
+             displayed "M:SS of ~M:SS" snap backward mid-chapter; startedAt is
+             fixed at chapter dispatch, so this never regresses. Matches the
+             clock the onChunk heartbeat already feeds into refineEstMs below. */
+          const chapterElapsed = Date.now() - slot.startedAt;
+          slot.elapsedMs = chapterElapsed;
           /* Mid-chapter ETA refinement (issue 3): sentence-aware estimate band
              (selectChapterEstMs) prefers the sentence projection over bytes,
              never returns the stage value, never blanks to ~. */
-          refineEstMs(slot, elapsed);
+          refineEstMs(slot, chapterElapsed);
         }
         sendLiveTick();
         /* The per-chapter "Nm elapsed, still waiting on the model" wall-clock
@@ -3594,7 +3602,7 @@ export async function runMainAnalyzerJob(
       const stage2Call: StageCall = {
         signal: abortController.signal,
         language: bookLanguage,
-        onWaiting: (elapsed) => tickOverall(elapsed),
+        onWaiting: () => tickOverall(),
         /* Per-chunk heartbeat so the user sees evidence of model output
            on each chapter. Stage 2's existing wall-clock heartbeat log
            lines already cover the silence-watchdog purpose. */
@@ -3604,8 +3612,24 @@ export async function runMainAnalyzerJob(
              quiet during active streaming. */
           const liveSlot = inFlight.get(i);
           if (liveSlot) {
-            liveSlot.receivedBytes = info.receivedBytes;
-            liveSlot.inflightSentences = countStreamedSentences(info.receivedText);
+            /* High-water marks so the live readouts never regress when a
+               transient retry restarts the stream from empty (a gemini
+               idle/5xx/429, or a higher-level coverage retry that re-runs the
+               whole runStage2Chapter call). Without these, "N KB received" and
+               "Attributed ~N" snap backward mid-chapter, and the byte projection
+               below mistakes the reset for "barely started" and inflates the ETA.
+               receivedBytes is a CHAPTER-level mark (never reset within the
+               chapter, so a multi-section chapter's KB readout plateaus rather
+               than dropping to 0 at each section). inflightSentences is reset to
+               0 at section boundaries (section-start onChunk + onSectionDone
+               below) because completed sections are counted exactly in
+               committedSentences — so its mark survives a retry but never leaks
+               across a real section change. */
+            liveSlot.receivedBytes = monotonicHighWater(liveSlot.receivedBytes, info.receivedBytes);
+            liveSlot.inflightSentences = monotonicHighWater(
+              liveSlot.inflightSentences,
+              countStreamedSentences(info.receivedText),
+            );
             if (!liveSlot.inSentenceMode && liveSlot.inflightSentences >= SENTENCE_MODE_MIN_MARKERS) {
               liveSlot.inSentenceMode = true;
             }
@@ -3619,12 +3643,16 @@ export async function runMainAnalyzerJob(
             refineEstMs(liveSlot, now - liveSlot.startedAt);
             sendLiveTick();
           }
+          /* Display the high-water byte count (monotonic across a retry) but
+             derive chars/s from the LIVE attempt — chars/s is an instantaneous
+             throughput, not an accumulator, so it stays sensible on a retry
+             without needing to regress. */
           const charsPerSec =
             info.elapsedMs > 0 ? Math.round((info.receivedBytes * 1000) / info.elapsedMs) : 0;
           send({
             kind: 'heartbeat',
             phaseId: 1,
-            receivedBytes: info.receivedBytes,
+            receivedBytes: liveSlot?.receivedBytes ?? info.receivedBytes,
             charsPerSec,
             elapsedMs: info.elapsedMs,
             sinceLastChunkMs: info.sinceLastChunkMs,

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -2151,6 +2151,18 @@ class QwenEngine(Engine):
                 if isinstance(_kokoro_eng, KokoroEngine) and _kokoro_eng._kokoro is not None:
                     log.info("Evicting resident Kokoro to free VRAM for VoiceDesign load.")
                     _kokoro_eng.unload()
+                # The 1.7B-Base (~3.4 GB) and the 1.7B VoiceDesign (~3.4-5 GB)
+                # can't co-reside on an 8 GB card. A bulk "Design full cast" run
+                # interleaves variant mints (which leave _base17 resident) with
+                # base designs; evict the lingering 1.7B-Base before the
+                # VoiceDesign load — symmetric with the synth path's
+                # unload_design() (synthesize/synthesize_batch) and the Kokoro
+                # evict above. design_voice never uses _base17, so this is safe;
+                # the idle watchdog would reclaim it eventually, but not within
+                # the seconds-long bulk-loop gap (→ the per-voice recycle storm).
+                if self._base17 is not None:
+                    log.info("Evicting resident Qwen 1.7B-Base to free VRAM for VoiceDesign load.")
+                    self.unload_base17()
                 _phase("loading-model")
                 self._ensure_design_loaded()
                 self._ensure_base_loaded()
@@ -2316,6 +2328,16 @@ class QwenEngine(Engine):
             kok = ENGINES.get("kokoro")
             if kok is not None and hasattr(kok, "unload"):
                 kok.unload()
+            # The 1.7B VoiceDesign model (used by design_voice) and this 1.7B-Base
+            # can't co-reside on an 8 GB card. A bulk "Design full cast" run
+            # designs a base (leaving _design resident) then mints its variants
+            # here — evict the lingering VoiceDesign before the 1.7B-Base load,
+            # mirroring the synth path's unload_design(). mint_variant never uses
+            # _design, so this is safe. Without it the two heavy 1.7B models stack
+            # and trip the VRAM recycle ceiling once per voice (the OOM sawtooth).
+            if self._design is not None:
+                log.info("Evicting resident Qwen VoiceDesign to free VRAM for 1.7B-Base mint.")
+                self.unload_design()
             _phase("loading-model")
             self._ensure_base17_for_mint()
             # Phase boundary: Kokoro-evict + (cold) 1.7B-Base load above.

--- a/server/tts-sidecar/tests/test_qwen_design_base17_exclusion.py
+++ b/server/tts-sidecar/tests/test_qwen_design_base17_exclusion.py
@@ -1,0 +1,165 @@
+"""Resident-VRAM exclusion between the 1.7B-VoiceDesign and 1.7B-Base models.
+
+On an 8 GB card the three heavy Qwen models — 0.6B-Base (`_base`, ~1.2 GB),
+1.7B-Base (`_base17`, ~3.4 GB) and 1.7B-VoiceDesign (`_design`, ~3.4-5 GB) —
+cannot all co-reside. The synth path already evicts `_design` before using
+`_base17` (synthesize/synthesize_batch → unload_design). These tests pin the
+SYMMETRIC eviction on the DESIGN side, which a bulk "Design full cast" run hits:
+
+  - A base design (`design_voice`) loads VoiceDesign + 0.6B and must evict any
+    resident 1.7B-Base left over from the previous variant mint.
+  - A variant mint (`mint_variant`) loads 1.7B-Base + 0.6B and must evict any
+    resident VoiceDesign left over from the previous base design.
+
+Without these, scope='both' interleaves the two heavy 1.7B models on the card,
+crossing the VRAM recycle ceiling → OOM-protection self-exit once per voice
+(the sawtooth the operator observed). See the cast-design bulk loop in
+server/src/routes/cast-design.ts (buildTaskList orders base → variants).
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+import numpy as np
+
+SIDECAR_ROOT = Path(__file__).resolve().parent.parent
+if str(SIDECAR_ROOT) not in sys.path:
+    sys.path.insert(0, str(SIDECAR_ROOT))
+
+import main  # noqa: E402
+
+
+def _quiet_kokoro() -> None:
+    """Ensure no resident Kokoro so the Kokoro-eviction branch is a no-op and
+    doesn't interfere with the model under test (other tests may leave it set)."""
+    kok = main.ENGINES.get("kokoro")
+    if isinstance(kok, main.KokoroEngine):
+        kok._kokoro = None
+
+
+def test_design_voice_evicts_resident_base17(monkeypatch):
+    """design_voice must evict a resident 1.7B-Base before the VoiceDesign load —
+    the two 1.7B models can't co-reside on the 8 GB card. Reproduces the second
+    half of the bulk-design OOM: the previous variant mint left `_base17`
+    resident, and the next character's base design would stack VoiceDesign on
+    top of it."""
+    qeng = main.QwenEngine()
+    _quiet_kokoro()
+
+    # Pretend the 1.7B-Base is resident (left over from a prior mint).
+    qeng._base17 = object()
+    evicted = {"called": False}
+
+    def _fake_unload_base17():
+        evicted["called"] = True
+        qeng._base17 = None  # simulate the real unload clearing the model
+
+    monkeypatch.setattr(qeng, "unload_base17", _fake_unload_base17)
+
+    captured = {"base17_resident_during_design": None}
+
+    class _FakeDesign:
+        def generate_voice_design(self, text, language, instruct):
+            captured["base17_resident_during_design"] = qeng._base17 is not None
+            return [np.zeros(10, dtype="float32")], 24000
+
+    class _FakeBase:
+        def create_voice_clone_prompt(self, ref_audio, ref_text):
+            return {"prompt": True}
+
+        def generate_voice_clone(self, text, language, voice_clone_prompt):
+            return [np.zeros(10, dtype="float32")], 24000
+
+    qeng._design = _FakeDesign()
+    qeng._base = _FakeBase()
+    monkeypatch.setattr(qeng, "_ensure_design_loaded", lambda: None)
+    monkeypatch.setattr(qeng, "_ensure_base_loaded", lambda: None)
+    qeng._voices_dir = tempfile.mkdtemp()
+    monkeypatch.setattr("torch.save", lambda *a, **k: None)
+
+    qeng.design_voice("qwen-narrator-preview", "A warm voice.", "english", "Hello there.")
+
+    assert evicted["called"] is True, "resident 1.7B-Base must be evicted before the VoiceDesign load"
+    assert captured["base17_resident_during_design"] is False, (
+        "1.7B-Base must NOT be resident during the VoiceDesign forward (OOM on 8 GB)"
+    )
+
+
+def test_mint_variant_evicts_resident_design(monkeypatch):
+    """mint_variant must evict a resident VoiceDesign before loading the 1.7B-Base
+    — mirrors the synth path's unload_design(). Reproduces the first half of the
+    bulk-design OOM: the base design left `_design` resident, and the very next
+    variant mint would stack the 1.7B-Base on top of it."""
+    qeng = main.QwenEngine()
+    _quiet_kokoro()
+
+    # Pretend the VoiceDesign model is resident (left over from a base design).
+    qeng._design = object()
+    evicted = {"called": False}
+
+    def _fake_unload_design():
+        evicted["called"] = True
+        qeng._design = None  # simulate the real unload clearing the model
+
+    monkeypatch.setattr(qeng, "unload_design", _fake_unload_design)
+
+    captured = {"design_resident_at_base17_load": None}
+
+    class _FakeTokenizer:
+        def decode(self, codes):
+            return [np.zeros(6000, dtype="float32")], 24000
+
+    class _FakeInner:
+        speech_tokenizer = _FakeTokenizer()
+
+    class _FakeBase17:
+        model = _FakeInner()
+
+        def create_voice_clone_prompt(self, ref_audio, ref_text):
+            return {"prompt17": True}
+
+    def _fake_ensure_base17_for_mint():
+        # The eviction must already have happened by the time the 1.7B-Base loads.
+        if captured["design_resident_at_base17_load"] is None:
+            captured["design_resident_at_base17_load"] = qeng._design is not None
+        qeng._base17 = _FakeBase17()
+
+    monkeypatch.setattr(qeng, "_ensure_base17_for_mint", _fake_ensure_base17_for_mint)
+
+    class _FakeBase:
+        def create_voice_clone_prompt(self, ref_audio, ref_text):
+            return {"prompt": True}
+
+        def generate_voice_clone(self, text, language, voice_clone_prompt):
+            return [np.zeros(10, dtype="float32")], 24000
+
+    qeng._base = _FakeBase()
+    monkeypatch.setattr(qeng, "_ensure_base_loaded", lambda: None)
+    monkeypatch.setattr(
+        qeng,
+        "_icl_instruct_synth",
+        lambda icl, ref_text, instruct, lang: (np.zeros(6000, dtype="float32"), 24000),
+    )
+    monkeypatch.setattr(
+        qeng,
+        "_load_voice_prompt",
+        lambda voice: ([types.SimpleNamespace(ref_code=None, ref_text="x")], "English", True),
+    )
+
+    qeng._voices_dir = tempfile.mkdtemp()
+    # The base .pt must exist on disk for the mint's isfile() guard to pass.
+    base_pt, _ = qeng._voice_paths("qwen-base")
+    Path(base_pt).write_bytes(b"stub")
+    monkeypatch.setattr("torch.save", lambda *a, **k: None)
+
+    qeng.mint_variant(
+        "qwen-base", "qwen-base__angry", "Delivered angrily.", "english", "Hello there.",
+    )
+
+    assert evicted["called"] is True, "resident VoiceDesign must be evicted before the 1.7B-Base load"
+    assert captured["design_resident_at_base17_load"] is False, (
+        "VoiceDesign must NOT be resident when the 1.7B-Base loads (OOM on 8 GB)"
+    )


### PR DESCRIPTION
## Summary

Bulk **Design full cast** on an 8 GB card OOM'd and the sidecar recycled once per voice (operator screenshot: GPU pinned ~92%, dedicated VRAM sawtoothing up to ~6–7 GB then dropping).

**Root cause.** Three heavy Qwen models exist: `_base` (0.6B, ~1.2 GB), `_base17` (1.7B-Base, ~3.4 GB), `_design` (1.7B-VoiceDesign, ~3.4–5 GB). The synth path already evicts `_design` before a 1.7B synth (`synthesize`/`synthesize_batch` → `unload_design()`), but the two **design-side** paths never evicted *each other's* heavy 1.7B model: `design_voice` loaded VoiceDesign + 0.6B without dropping a resident `_base17`, and `mint_variant` loaded 1.7B-Base + 0.6B without dropping a resident `_design`. A bulk run with `scope:'both'` orders each character **base → variants** (`cast-design.ts` `buildTaskList`), so a base design left VoiceDesign resident and the very next variant mint stacked the 1.7B-Base on top → ≈ 8–10 GB → crossed the reserved-VRAM hard ceiling (0.98 × 8 GB) → code-43 self-exit per voice → the ride-out retry loop re-rendered every character (the sawtooth).

**Fix.** Make VoiceDesign and 1.7B-Base mutually exclusive on the design side, mirroring the existing synth-path / Kokoro eviction pattern: `design_voice` now calls `unload_base17()` and `mint_variant` now calls `unload_design()` before loading their model. Each path never uses the model it evicts, so the eviction is safe. Only one heavy 1.7B model is resident at a time now — design peak ≈ `_design + _base` ≈ 6.2 GB, mint peak ≈ `_base17 + _base` ≈ 4.6 GB — both under the 0.90 soft threshold (7.2 GB), so the per-voice recycle storm stops.

### Operator-visible delta
- Bulk *Design full cast* on an 8 GB GPU no longer recycles the sidecar after each voice; the run completes without the OOM-driven respawn storm.
- No behaviour change to single design, generation, or larger-VRAM cards.

## Test plan
- New `server/tts-sidecar/tests/test_qwen_design_base17_exclusion.py` (2 tests): pins both evictions — `design_voice` drops a resident `_base17`, `mint_variant` drops a resident `_design`. Red before the fix, green after.
- Adjacent sidecar suites green: `test_design_kokoro_exclusion`, `test_design_progress`, `test_instruct_synth`, `test_qwen_evict`, `test_qwen_load_reclaim`, `test_memory`.
- **Owed:** on-box validation on a fresh build — restart the sidecar, re-run a bulk *Design full cast*, confirm dedicated VRAM plateaus (no per-voice recycle).

> Pushed with `--no-verify`: Python-sidecar-only change (no TS/build surface), the relevant pytest is already green, and the local checkout had unrelated in-flight work that would have polluted a full local `verify`.