### PR TITLE
fix(server)+feat(frontend): make the Qwen 1.7B tier usable + honest on an 8GB GPU

### DIFF
--- a/docs/features/233-book-quality-tier.md
+++ b/docs/features/233-book-quality-tier.md
@@ -111,3 +111,11 @@ migration + #1100 toggle removal, series-tier endpoint, cast bulk pin). Built vi
 (spec ×2 review rounds + plan ×2 review rounds + per-task reviews + opus whole-branch
 review). Full `npm run verify` green before merge. Follow-up: [#1135](https://github.com/dudarenok-maker/Castwright/issues/1135)
 (pre-existing clipped RegenerateModal footer, surfaced by the e2e).
+
+### Follow-ups (2026-06-26) — making the 1.7B tier usable + honest on an 8 GB box
+
+Three issues surfaced when a whole cast was pinned to 1.7B and generated on an 8 GB GPU:
+
+- **#1158 (bug) — 1.7B OOM-storm.** The batch packer (`server/src/tts/synthesise-chapter.ts`) used one width for both tiers (`QWEN_BATCH_SIZE=32` / `QWEN_BATCH_TOKEN_BUDGET=3600`, tuned for 0.6B). The ~3.4 GB-resident 1.7B-Base plus a 32-wide batch's activations blew past the supervisor's `vram_restart_mb: 8000` threshold → `recycle code 43` storm → `RecycleStormError`. Fixed with tier-aware caps applied to the 1.7B bucket only: `QWEN_BATCH_SIZE_17B` (default 8) + `QWEN_BATCH_TOKEN_BUDGET_17B` (default 1200), both in Advanced Settings → *Voice batching & throughput*.
+- **#1159 (bug) — misleading header.** The Generate header read the global model picker (0.6B), not the effective per-character tier, so a 1.7B-pinned cast looked like it rendered at 0.6B (it didn't — `qwen_base17_loaded: true`). Fixed with `effectiveEngineLabel` (`src/lib/tts-models.ts`).
+- **#1160 (feat) — tier prompt at generation start.** The first generate auto-started silently. A `StartGenerationModal` now prompts for the tier (default = the cast's pin state) and applies it to the whole cast via `setCastTier` before starting; non-Qwen books start directly.

--- a/server/src/config/registry.ts
+++ b/server/src/config/registry.ts
@@ -369,6 +369,26 @@ export const KNOBS: ConfigKnob[] = [
     apply: 'restart-server', risk: 'medium', // read once at Node module-load (module-level constant), not sidecar
   },
   {
+    key: 'tts.batch.size17b',
+    env: 'QWEN_BATCH_SIZE_17B',
+    group: 'tts-batching',
+    label: 'Qwen 1.7B batch size',
+    help: 'Hard width cap for the 1.7B Quality-tier specifically. The 1.7B-Base is ~3.4 GB resident, so a batch as wide as the 0.6B default blows past an 8 GB card during the batched forward → recycle storm. Kept small so 1.7B renders stay within VRAM (slower than 0.6B, but stable). Only affects 1.7B groups — 0.6B batches use the larger tts.batch.size.',
+    type: 'integer', min: 1,
+    default: 8, // ← QWEN_BATCH_SIZE_17B default in tts/synthesise-chapter.ts
+    apply: 'restart-server', risk: 'medium', // read once at Node module-load (module-level constant), not sidecar
+  },
+  {
+    key: 'tts.batch.tokenBudget17b',
+    env: 'QWEN_BATCH_TOKEN_BUDGET_17B',
+    group: 'tts-batching',
+    label: 'Qwen 1.7B batch token budget',
+    help: 'Variable-width packing budget (normalised chars) for the 1.7B Quality tier only. Much smaller than the 0.6B tts.batch.tokenBudget so 1.7B batches stay within an 8 GB card during the batched forward (avoids the recycle-storm OOM). Set to 0 for exact fixed-width slicing on the 1.7B tier (tts.batch.size17b only).',
+    type: 'integer', min: 0,
+    default: 1200, // ← DEFAULT_QWEN_BATCH_TOKEN_BUDGET_17B in tts/synthesise-chapter.ts
+    apply: 'restart-server', risk: 'medium', // read once at Node module-load (module-level constant), not sidecar
+  },
+  {
     key: 'tts.batch.bucket',
     env: 'QWEN_BATCH_BUCKET',
     group: 'tts-batching',

--- a/server/src/tts/synthesise-chapter.test.ts
+++ b/server/src/tts/synthesise-chapter.test.ts
@@ -2083,7 +2083,9 @@ describe('synthesiseChapter Qwen true batching (plan 112)', () => {
       modelKey: 'qwen3-tts-1.7b',
       engine: 'qwen',
       qwenBatchSize: 8,
-      qwenBatchTokenBudget: budget,
+      /* 1.7B bucket reads the tier-specific budget (the generic one is the 0.6B
+         budget now), so drive that to exercise the 1.7B instruct-aware packing. */
+      qwenBatchTokenBudget17b: budget,
     });
     /* With instruct accounted (is17b=true), effective length per item = 40; 2×40=80 > 50, so
        every body group gets its own work item → no batch calls; only singles. */
@@ -2238,6 +2240,106 @@ describe('synthesiseChapter Qwen true batching (plan 112)', () => {
     }
     /* At least one 1.7B batch must have been dispatched. */
     expect(batchModelKeys.some((mk) => mk === 'qwen3-tts-1.7b')).toBe(true);
+  });
+
+  /* ── 1.7B tier-aware batch width (8 GB OOM guard) ───────────────────────
+     The 1.7B-Base is ~3.4 GB resident; a batch as wide as the 0.6B default
+     (size 32 / budget 3600 chars) blows past an 8 GB card's VRAM during the
+     batched forward → supervisor recycle storm → RecycleStormError. The packer
+     must apply a SMALLER, tier-specific width to 1.7B batches while leaving
+     0.6B batches on the default. */
+  it('caps 1.7B batches at the smaller tier-specific batch size', async () => {
+    const cast: CastCharacter[] = [
+      {
+        id: 'q',
+        name: 'Q',
+        ttsEngine: 'qwen',
+        overrideTtsVoices: { qwen: { name: 'qwen-q' } },
+        ttsModelKey: 'qwen3-tts-1.7b',
+      },
+    ];
+    const provider: TtsProvider & { batchSizes: number[] } = {
+      batchSizes: [],
+      async synthesize(input: SynthesizeInput): Promise<SynthesizeOutput> {
+        return { pcm: Buffer.alloc(input.text.length * 2), sampleRate: 24000, mimeType: 'audio/pcm' };
+      },
+      async synthesizeBatch({ items }: SynthesizeBatchInput): Promise<SynthesizeBatchOutput> {
+        provider.batchSizes.push(items.length);
+        return { pcms: items.map((it) => Buffer.alloc(it.text.length * 2)), sampleRate: 24000 };
+      },
+    };
+    await synthesiseChapter({
+      sentences: [1, 2, 3, 4, 5, 6].map((i) => sentence(i, 'q', `Line ${i}.`)),
+      cast,
+      provider,
+      modelKey: 'qwen3-tts-1.7b',
+      engine: 'qwen',
+      qwenBatchSize: 8, // 0.6B-tier cap (large)
+      qwenBatchSize17b: 2, // 1.7B-tier cap (small)
+      qwenBatchTokenBudget: 0, // fixed-width slicing isolates the size cap
+      qwenBatchBucket: false,
+    });
+    expect(provider.batchSizes.length).toBeGreaterThan(0);
+    for (const n of provider.batchSizes) expect(n).toBeLessThanOrEqual(2);
+  });
+
+  it('applies the smaller 1.7B token budget to 1.7B batches only', async () => {
+    /* 0.6B narrator + 1.7B quality, all short uniform-length lines. With a tiny
+       1.7B budget but a generous 0.6B budget, the 1.7B groups pack narrow while
+       the 0.6B groups pack wide — proving the budget is tier-scoped. */
+    const cast: CastCharacter[] = [
+      { id: 'narrator', name: 'Narrator', ttsEngine: 'qwen', overrideTtsVoices: { qwen: { name: 'qwen-narrator' } } },
+      {
+        id: 'quality',
+        name: 'Quality',
+        ttsEngine: 'qwen',
+        overrideTtsVoices: { qwen: { name: 'qwen-quality' } },
+        ttsModelKey: 'qwen3-tts-1.7b',
+      },
+    ];
+    const batches: { is17b: boolean; size: number }[] = [];
+    const provider: TtsProvider = {
+      async synthesize(input: SynthesizeInput): Promise<SynthesizeOutput> {
+        return { pcm: Buffer.alloc(input.text.length * 2), sampleRate: 24000, mimeType: 'audio/pcm' };
+      },
+      async synthesizeBatch({ items }: SynthesizeBatchInput): Promise<SynthesizeBatchOutput> {
+        batches.push({ is17b: items[0].voiceName === 'qwen-quality', size: items.length });
+        return { pcms: items.map((it) => Buffer.alloc(it.text.length * 2)), sampleRate: 24000 };
+      },
+    };
+    /* 4 of each speaker, each "Word." = 5 normalised chars. 0.6B budget 1000 →
+       packs all 4 (4×5=20 ≤ 1000). 1.7B budget 10 → each batch holds at most
+       2 (2×5=10 ≤ 10, 3×5=15 > 10). */
+    await synthesiseChapter({
+      sentences: [
+        sentence(1, 'narrator', 'Word.'),
+        sentence(2, 'narrator', 'Word.'),
+        sentence(3, 'narrator', 'Word.'),
+        sentence(4, 'narrator', 'Word.'),
+        sentence(5, 'quality', 'Word.'),
+        sentence(6, 'quality', 'Word.'),
+        sentence(7, 'quality', 'Word.'),
+        sentence(8, 'quality', 'Word.'),
+      ],
+      cast,
+      provider,
+      modelKey: 'qwen3-tts-0.6b',
+      engine: 'qwen',
+      qwenBatchSize: 8,
+      qwenBatchTokenBudget: 1000, // 0.6B budget (wide)
+      qwenBatchTokenBudget17b: 10, // 1.7B budget (narrow)
+      qwenBatchBucket: false,
+    });
+    const seventeen = batches.filter((b) => b.is17b);
+    const six = batches.filter((b) => !b.is17b);
+    expect(seventeen.length).toBeGreaterThan(0);
+    for (const b of seventeen) expect(b.size).toBeLessThanOrEqual(2);
+    /* The 0.6B groups packed WIDER than the 1.7B cap — budget is tier-scoped.
+       (The first body group is the sample-rate anchor single, so the 4 narrator
+       sentences become anchor + a batch of 3; the 1.7B batches stay ≤ 2.) */
+    const maxSix = Math.max(...six.map((b) => b.size));
+    const maxSeventeen = Math.max(...seventeen.map((b) => b.size));
+    expect(maxSix).toBeGreaterThan(maxSeventeen);
   });
 
   it('dispatches a 1.7B batch with modelKey qwen3-tts-1.7b (not 0.6b)', async () => {

--- a/server/src/tts/synthesise-chapter.ts
+++ b/server/src/tts/synthesise-chapter.ts
@@ -90,6 +90,18 @@ export function resolveQwenTokenBudget(raw: string | undefined): number {
 }
 const QWEN_BATCH_TOKEN_BUDGET = configValue<number>('tts.batch.tokenBudget');
 
+/* 1.7B tier-aware batch width (8 GB OOM guard). The 1.7B-Base is ~3.4 GB
+   resident; a 1.7B batch as wide as the 0.6B default (size 32 / budget 3600)
+   blows past an 8 GB card's VRAM during the batched forward → supervisor
+   recycle storm (code 43) → RecycleStormError fails the chapter. The packer
+   applies these SMALLER caps to the 1.7B bucket ONLY; 0.6B batches keep the
+   defaults above (a mixed-tier chapter packs each tier to its own width). The
+   1.7B forward is inherently heavier, so narrower batches trade some throughput
+   for staying inside VRAM — the difference between "renders" and "thrashes". */
+export const DEFAULT_QWEN_BATCH_TOKEN_BUDGET_17B = 1200;
+const QWEN_BATCH_SIZE_17B = configValue<number>('tts.batch.size17b');
+const QWEN_BATCH_TOKEN_BUDGET_17B = configValue<number>('tts.batch.tokenBudget17b');
+
 /* Defensive per-call ceiling (plan 148). A single provider call that never
    returns — e.g. Qwen's open-ended decode running away on degenerate, non-prose
    input (a table-of-contents page, a copyright block) — would otherwise hang the
@@ -573,6 +585,18 @@ export interface SynthesiseChapterOpts {
       splitting without touching process env. Clamped to >= 1. Only Qwen
       sentences are ever batched — see the dispatch partition below. */
   qwenBatchSize?: number;
+  /** Hard width cap for the 1.7B Quality tier specifically (8 GB OOM guard).
+      The 1.7B-Base is ~3.4 GB resident, so a 1.7B batch as wide as the 0.6B
+      default OOMs an 8 GB card mid-forward → recycle storm. The packer applies
+      this to the 1.7B bucket only; 0.6B groups keep `qwenBatchSize`. Defaults to
+      the module-level `QWEN_BATCH_SIZE_17B` (env `QWEN_BATCH_SIZE_17B`, default
+      8). Clamped to >= 1. */
+  qwenBatchSize17b?: number;
+  /** Token-budget for the 1.7B tier only (env `QWEN_BATCH_TOKEN_BUDGET_17B`,
+      default 1200 — far below the 0.6B `qwenBatchTokenBudget`). Keeps 1.7B
+      batches within an 8 GB card; `0` = exact fixed-width slicing on the 1.7B
+      tier (`qwenBatchSize17b` only). 0.6B groups keep `qwenBatchTokenBudget`. */
+  qwenBatchTokenBudget17b?: number;
   /** Length-bucketing (plan 128): sort batchable Qwen groups by their
       normalised text length before slicing into batches, so similar-length
       sentences share a batch and the batched forward decodes to a tight
@@ -779,8 +803,10 @@ export async function synthesiseChapter(
     groupHeartbeatMs = 10_000,
     callTimeoutMs = SYNTH_CALL_TIMEOUT_MS,
     qwenBatchSize = QWEN_BATCH_SIZE,
+    qwenBatchSize17b = QWEN_BATCH_SIZE_17B,
     qwenBatchBucket = QWEN_BATCH_BUCKET,
     qwenBatchTokenBudget = QWEN_BATCH_TOKEN_BUDGET,
+    qwenBatchTokenBudget17b = QWEN_BATCH_TOKEN_BUDGET_17B,
     maxSegmentRerecords = 0,
     segmentQaThresholds,
     onSegmentRerecord,
@@ -1304,6 +1330,9 @@ export async function synthesiseChapter(
           group, so a long batched call keeps feeding the no-progress watchdog. */
   const batchSize = Math.max(1, Math.floor(qwenBatchSize));
   const tokenBudget = Math.floor(qwenBatchTokenBudget);
+  /* 1.7B tier-aware caps (8 GB OOM guard) — applied to the 1.7B bucket only. */
+  const batchSize17b = Math.max(1, Math.floor(qwenBatchSize17b));
+  const tokenBudget17b = Math.floor(qwenBatchTokenBudget17b);
   type WorkItem =
     | { kind: 'single'; group: SentenceGroup }
     | { kind: 'batch'; groups: SentenceGroup[] };
@@ -1351,21 +1380,26 @@ export async function synthesiseChapter(
       );
     };
     /* Process each per-modelKey bucket independently so a slice never crosses a
-       model-tier boundary. */
-    for (const batchable of batchableByModel.values()) {
+       model-tier boundary. The 1.7B bucket packs to its own SMALLER caps (8 GB
+       OOM guard) while 0.6B keeps the defaults — a mixed-tier chapter sizes each
+       tier's batches to that tier's VRAM cost. */
+    for (const [bucketModelKey, batchable] of batchableByModel.entries()) {
+      const is17bBucket = bucketModelKey === 'qwen3-tts-1.7b';
+      const effBatchSize = is17bBucket ? batchSize17b : batchSize;
+      const effTokenBudget = is17bBucket ? tokenBudget17b : tokenBudget;
       /* Length-bucketing (plan 128): order by model-side length, tie-break by
          `group.index`. Output-preserving: scatter-back is by `group.index`. */
       if (qwenBatchBucket && batchable.length > 1) {
         batchable.sort((a, b) => lenOf.get(a)! - lenOf.get(b)! || a.index - b.index);
       }
-      if (tokenBudget <= 0) {
+      if (effTokenBudget <= 0) {
         /* Fixed-width slicing (plans 113/128) — back-compat path + kill-switch. */
-        for (let i = 0; i < batchable.length; i += batchSize) {
-          pushBatch(batchable.slice(i, i + batchSize));
+        for (let i = 0; i < batchable.length; i += effBatchSize) {
+          pushBatch(batchable.slice(i, i + effBatchSize));
         }
       } else {
         /* Token-budget packing (plan 136): greedily fill while
-           `count × maxLenInBatch <= tokenBudget` AND `count <= batchSize`; a
+           `count × maxLenInBatch <= effTokenBudget` AND `count <= effBatchSize`; a
            single item that alone exceeds the budget forms its own batch. */
         let current: SentenceGroup[] = [];
         let currentMax = 0;
@@ -1373,7 +1407,7 @@ export async function synthesiseChapter(
           const candLen = lenOf.get(g)!;
           let candMax = Math.max(currentMax, candLen);
           const nextCount = current.length + 1;
-          if (current.length > 0 && (nextCount * candMax > tokenBudget || nextCount > batchSize)) {
+          if (current.length > 0 && (nextCount * candMax > effTokenBudget || nextCount > effBatchSize)) {
             pushBatch(current);
             current = [];
             currentMax = 0;

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -66,6 +66,7 @@ import { MiniPlayer } from './mini-player';
 import { PreviewListenerView } from '../views/preview-listener';
 import { MatchDetailDrawer } from '../modals/match-detail';
 import { RegenerateModal } from '../modals/regenerate';
+import { StartGenerationModal } from '../modals/start-generation';
 import { CharacterRegenerateModal } from '../modals/character-regenerate';
 import { DriftReportModal } from '../modals/drift-report';
 import { ProfileDrawer } from '../modals/profile-drawer';
@@ -648,6 +649,9 @@ export function Layout() {
      user sat on the cast or voices view stayed "Designed" until they navigated
      away and back. */
   const ttsEngine = useAppSelector((s) => engineForModelKey(s.ui.ttsModelKey));
+  /* P3 — true while the pre-generation tier prompt applies the chosen tier to
+     the cast (setCastTier) before starting the run. */
+  const [startGenBusy, setStartGenBusy] = useState(false);
   const genProgress = useAppSelector((s) =>
     Object.values(s.chapters.activeStreams).reduce((n, st) => n + st.done, 0),
   );
@@ -1562,6 +1566,48 @@ export function Layout() {
           onDecline={() => {
             if (ui.matchDetailFor) dispatch(castActions.declineMatch(ui.matchDetailFor));
             dispatch(uiActions.setMatchDetailFor(null));
+          }}
+        />
+      )}
+      {ui.startGenPrompt && (
+        <StartGenerationModal
+          defaultTier={
+            characters.some((c) => c.ttsModelKey === 'qwen3-tts-1.7b')
+              ? 'qwen3-tts-1.7b'
+              : 'qwen3-tts-0.6b'
+          }
+          busy={startGenBusy}
+          onClose={() => dispatch(uiActions.closeStartGenPrompt())}
+          onConfirm={async (tier) => {
+            /* Apply the chosen tier to the whole cast (authoritative over any
+               existing per-character pins), then start. 1.7B → pin; 0.6B →
+               clear (null). Qwen members only — the tier is ignored for other
+               engines (server `routeFor`). voiceId ?? id is the storage key the
+               cast/tier endpoint matches on (server matches `voiceId ?? id`),
+               so voiceId-less characters are covered too. */
+            const pin: 'qwen3-tts-1.7b' | null = tier === 'qwen3-tts-1.7b' ? 'qwen3-tts-1.7b' : null;
+            const qwenMembers = characters.filter((c) => (c.ttsEngine ?? ttsEngine) === 'qwen');
+            setStartGenBusy(true);
+            try {
+              if (bookId) {
+                const ids = [...new Set(qwenMembers.map((c) => c.voiceId ?? c.id))];
+                await Promise.all(ids.map((id) => api.setCastTier(bookId, id, pin)));
+              }
+              qwenMembers.forEach((c) =>
+                dispatch(castActions.updateCharacter({ ...c, ttsModelKey: pin })),
+              );
+              setStartGenBusy(false);
+              dispatch(uiActions.closeStartGenPrompt());
+              dispatch(uiActions.requestStartGeneration());
+            } catch {
+              setStartGenBusy(false);
+              dispatch(
+                notificationsActions.pushToast({
+                  kind: 'error',
+                  message: "Couldn't apply the voice model. Please try again.",
+                }),
+              );
+            }
           }}
         />
       )}

--- a/src/components/theme-toggle.test.tsx
+++ b/src/components/theme-toggle.test.tsx
@@ -46,6 +46,7 @@ function makeStore({
     queueModalOpen: false,
     rebaselineModalOpen: false,
     rebaselineBookId: null,
+    startGenPrompt: false,
   };
   const accountPreloaded: AccountState = {
     ...FRONTEND_ACCOUNT_DEFAULTS,

--- a/src/lib/tts-models.test.ts
+++ b/src/lib/tts-models.test.ts
@@ -3,6 +3,7 @@ import {
   TTS_ENGINES,
   TTS_MODEL_OPTIONS,
   ttsModelLabel,
+  effectiveEngineLabel,
   engineForModelKey,
   engineGroupForModelKey,
   formatEngineBreakdown,
@@ -47,5 +48,35 @@ describe('tts-models catalog includes Qwen3-TTS (plan 108)', () => {
     expect(engineForModelKey('coqui-xtts-v2')).toBe('coqui');
     expect(engineForModelKey('gemini-2.5-flash')).toBe('gemini');
     expect(engineGroupForModelKey('gemini-2.5-flash')).toBe('gemini');
+  });
+
+  it('labels the 1.7B Quality tier (absent from the picker options)', () => {
+    /* 1.7B is applied via cast pinning, not the picker, so it is NOT in
+       TTS_MODEL_OPTIONS — ttsModelLabel must still render a human label. */
+    expect(TTS_MODEL_OPTIONS.map((m) => m.id)).not.toContain('qwen3-tts-1.7b');
+    expect(ttsModelLabel('qwen3-tts-1.7b')).toBe('Qwen3-TTS 1.7B');
+  });
+});
+
+describe('effectiveEngineLabel (truthful generation-header tier)', () => {
+  it('returns the run-default label when no character is pinned', () => {
+    const cast = [{ ttsModelKey: null }, { ttsModelKey: undefined }];
+    expect(effectiveEngineLabel(cast, 'qwen3-tts-0.6b')).toBe('Qwen3-TTS 0.6B');
+  });
+
+  it('reflects 1.7B when the whole cast is pinned to it (the reported bug)', () => {
+    const cast = [{ ttsModelKey: 'qwen3-tts-1.7b' as const }, { ttsModelKey: 'qwen3-tts-1.7b' as const }];
+    /* Run default is 0.6B (global picker) but every character renders at 1.7B. */
+    expect(effectiveEngineLabel(cast, 'qwen3-tts-0.6b')).toBe('Qwen3-TTS 1.7B');
+  });
+
+  it('shows a Mixed label when tiers differ across the cast', () => {
+    const cast = [{ ttsModelKey: 'qwen3-tts-1.7b' as const }, { ttsModelKey: null }];
+    expect(effectiveEngineLabel(cast, 'qwen3-tts-0.6b')).toBe('Mixed: Qwen3-TTS 0.6B + Qwen3-TTS 1.7B');
+  });
+
+  it('collapses to a single label when an un-pinned character matches the run default tier', () => {
+    const cast = [{ ttsModelKey: 'qwen3-tts-0.6b' as const }, { ttsModelKey: null }];
+    expect(effectiveEngineLabel(cast, 'qwen3-tts-0.6b')).toBe('Qwen3-TTS 0.6B');
   });
 });

--- a/src/lib/tts-models.ts
+++ b/src/lib/tts-models.ts
@@ -58,12 +58,42 @@ export const TTS_ENGINES: TtsEngineGroup[] = [
    visible. */
 export const TTS_MODEL_OPTIONS: TtsModelOption[] = TTS_ENGINES.flatMap((g) => g.models);
 
+/* Quality-tier model keys applied via per-character cast pinning (fs-56/fs-66),
+   NOT offered as a top-level picker option, so they're absent from
+   TTS_MODEL_OPTIONS. ttsModelLabel still needs a human label for them (the
+   generation header + the effective-tier label below). */
+const EXTRA_MODEL_LABELS: Partial<Record<TtsModelKey, string>> = {
+  'qwen3-tts-1.7b': 'Qwen3-TTS 1.7B',
+};
+
 /** Human-readable label for a model key. Falls back to the raw key when an
     unknown id appears (e.g. an older saved state pointing at a model we've
     since removed) so the UI shows *something* identifiable rather than
     blanking. */
 export function ttsModelLabel(key: TtsModelKey): string {
-  return TTS_MODEL_OPTIONS.find((m) => m.id === key)?.label ?? key;
+  return TTS_MODEL_OPTIONS.find((m) => m.id === key)?.label ?? EXTRA_MODEL_LABELS[key] ?? key;
+}
+
+/** The Qwen tier(s) a book's cast will ACTUALLY render in. Per-character
+    `ttsModelKey` overrides win over the run-default `modelKey` in synthesis
+    (`synthesise-chapter.ts` `routeFor`), so the generation header must reflect
+    the effective tier — not the global model picker (which is what made a
+    1.7B-pinned cast misleadingly read "0.6B"). Returns one label when the whole
+    cast resolves to a single tier, a "Mixed: A + B" label when tiers differ, and
+    the plain run-default label when nothing is pinned (byte-identical to the
+    pre-override header). */
+export function effectiveEngineLabel(
+  characters: ReadonlyArray<{ ttsModelKey?: string | null }>,
+  modelKey: TtsModelKey,
+): string {
+  const anyPinned = characters.some((c) => c.ttsModelKey);
+  if (!anyPinned) return ttsModelLabel(modelKey);
+  const effective = new Set<string>(characters.map((c) => c.ttsModelKey ?? modelKey));
+  if (effective.size === 1) return ttsModelLabel([...effective][0] as TtsModelKey);
+  return `Mixed: ${[...effective]
+    .map((k) => ttsModelLabel(k as TtsModelKey))
+    .sort()
+    .join(' + ')}`;
 }
 
 /* Short, engine-level labels (not model-level) for the mixed-engine chapter

--- a/src/lib/use-theme.test.tsx
+++ b/src/lib/use-theme.test.tsx
@@ -47,6 +47,7 @@ function makeStore({
     queueModalOpen: false,
     rebaselineModalOpen: false,
     rebaselineBookId: null,
+    startGenPrompt: false,
   };
   const accountPreloaded: AccountState = {
     ...FRONTEND_ACCOUNT_DEFAULTS,

--- a/src/modals/start-generation.tsx
+++ b/src/modals/start-generation.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react';
+import { IconPlay, IconClose } from '../lib/icons';
+import { PrimaryButton } from '../components/primitives';
+import type { TtsModelKey } from '../lib/types';
+
+/* P3 — the pre-generation "Choose voice model" prompt. Shown for Qwen books the
+   moment the user starts a run, so the quality tier is an explicit choice rather
+   than a silent default. The two Qwen tiers mirror the RegenerateModal picker;
+   the selected tier is applied to the whole cast (authoritative) by the host
+   before generation starts. */
+const TIERS: { id: TtsModelKey; label: string; hint: string }[] = [
+  { id: 'qwen3-tts-0.6b', label: 'Qwen3-TTS 0.6B', hint: 'Faster · lighter on VRAM' },
+  {
+    id: 'qwen3-tts-1.7b',
+    label: 'Qwen3-TTS 1.7B',
+    hint: 'Higher quality + expressive prosody · slower, heavier',
+  },
+];
+
+interface Props {
+  /** Pre-selected tier — 1.7B when the cast is already pinned to it, else 0.6B. */
+  defaultTier: TtsModelKey;
+  /** True while the host applies the chosen tier to the cast (disables the CTA). */
+  busy?: boolean;
+  onClose: () => void;
+  onConfirm: (tier: TtsModelKey) => void;
+}
+
+export function StartGenerationModal({ defaultTier, busy = false, onClose, onConfirm }: Props) {
+  /* If the cast is pinned to a tier not in TIERS (shouldn't happen), fall back
+     to 0.6B so the modal always has a valid selection. */
+  const initial = TIERS.some((t) => t.id === defaultTier) ? defaultTier : 'qwen3-tts-0.6b';
+  const [tier, setTier] = useState<TtsModelKey>(initial);
+  return (
+    <>
+      <div onClick={busy ? undefined : onClose} className="fixed inset-0 bg-ink/40 z-50 fade-in" />
+      <div className="fixed inset-0 z-50 grid place-items-center p-6 pointer-events-none">
+        <div className="bg-white rounded-3xl shadow-float w-full max-w-lg pointer-events-auto fade-in overflow-hidden flex flex-col">
+          <div className="px-6 py-4 border-b border-ink/10 flex items-center gap-3">
+            <span className="w-9 h-9 rounded-full bg-peach/15 grid place-items-center text-magenta">
+              <IconPlay className="w-4 h-4" />
+            </span>
+            <div className="flex-1 min-w-0">
+              <p className="text-[10px] uppercase tracking-widest text-ink/50 font-semibold">
+                Start generation
+              </p>
+              <h3 className="text-base font-bold text-ink truncate">Choose the voice model</h3>
+            </div>
+            <button
+              onClick={onClose}
+              disabled={busy}
+              className="p-2 rounded-full hover:bg-ink/5 text-ink/60 disabled:opacity-40"
+            >
+              <IconClose className="w-4 h-4" />
+            </button>
+          </div>
+
+          <div className="p-6 space-y-3">
+            <p className="text-xs text-ink/60 leading-relaxed">
+              The higher-quality 1.7B model renders more expressive prosody but is slower and uses
+              more VRAM. Applied to the whole cast for this book.
+            </p>
+            <div className="grid grid-cols-1 gap-2">
+              {TIERS.map((t) => (
+                <button
+                  key={t.id}
+                  type="button"
+                  onClick={() => setTier(t.id)}
+                  data-testid={`start-gen-tier-${t.id}`}
+                  className={`text-left p-3 rounded-2xl border transition-all min-h-[44px] ${tier === t.id ? 'border-peach bg-peach/6' : 'border-ink/10 hover:border-ink/20'}`}
+                >
+                  <p className="text-sm font-semibold text-ink">{t.label}</p>
+                  <p className="text-xs text-ink/55 mt-0.5">{t.hint}</p>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="px-6 py-4 border-t border-ink/10 flex items-center justify-end gap-3">
+            <button
+              onClick={onClose}
+              disabled={busy}
+              className="text-sm font-medium text-ink/60 hover:text-ink disabled:opacity-40"
+            >
+              Cancel
+            </button>
+            <PrimaryButton variant="dark" disabled={busy} onClick={() => onConfirm(tier)}>
+              {busy ? 'Applying…' : 'Start generating'}
+            </PrimaryButton>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -14,6 +14,7 @@ import {
 } from 'react-router-dom';
 import { useAppDispatch, useAppSelector, useAppSelectorShallow, store } from '../store';
 import { uiActions } from '../store/ui-slice';
+import { startGenerationFlow } from '../store/start-generation-flow';
 import { castActions } from '../store/cast-slice';
 import { chaptersActions } from '../store/chapters-slice';
 import { manuscriptActions } from '../store/manuscript-slice';
@@ -768,7 +769,9 @@ function ReadyViewSwitch({
           onOpenProfile={(id) => dispatch(uiActions.setOpenProfileId(id))}
           onStartGenerating={() => {
             dispatch(uiActions.changeView('generate'));
-            dispatch(uiActions.requestStartGeneration());
+            /* P3 — Qwen books prompt for the voice-model tier before starting;
+               non-Qwen books start immediately. */
+            dispatch(startGenerationFlow());
           }}
           priorRoster={priorRoster}
           onAddFromSeriesRoster={async (entry) => {

--- a/src/store/start-generation-flow.test.ts
+++ b/src/store/start-generation-flow.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { castRendersOnQwen, startGenerationFlow } from './start-generation-flow';
+import { uiActions } from './ui-slice';
+import type { Character } from '../lib/types';
+import type { RootState } from './index';
+
+const char = (over: Partial<Character>): Character => ({ id: 'c', name: 'C', ...over }) as Character;
+
+describe('castRendersOnQwen', () => {
+  it('is true when a character explicitly renders on Qwen, even off a non-Qwen run default', () => {
+    expect(castRendersOnQwen([char({ ttsEngine: 'qwen' })], 'kokoro-v1')).toBe(true);
+  });
+
+  it('is true when an engineless character falls to a Qwen run default', () => {
+    expect(castRendersOnQwen([char({ ttsEngine: null })], 'qwen3-tts-0.6b')).toBe(true);
+  });
+
+  it('is false when no character resolves to Qwen', () => {
+    expect(castRendersOnQwen([char({ ttsEngine: 'kokoro' }), char({ ttsEngine: null })], 'kokoro-v1')).toBe(
+      false,
+    );
+  });
+});
+
+describe('startGenerationFlow thunk', () => {
+  const run = (characters: Character[], ttsModelKey: string) => {
+    const dispatch = vi.fn();
+    const getState = () =>
+      ({ cast: { characters }, ui: { ttsModelKey } }) as unknown as RootState;
+    startGenerationFlow()(dispatch, getState);
+    return dispatch;
+  };
+
+  it('opens the tier prompt for a Qwen book', () => {
+    const dispatch = run([char({ ttsEngine: 'qwen' })], 'qwen3-tts-0.6b');
+    expect(dispatch).toHaveBeenCalledWith(uiActions.openStartGenPrompt());
+    expect(dispatch).not.toHaveBeenCalledWith(uiActions.requestStartGeneration());
+  });
+
+  it('starts immediately for a non-Qwen book (no tier choice to make)', () => {
+    const dispatch = run([char({ ttsEngine: 'kokoro' })], 'kokoro-v1');
+    expect(dispatch).toHaveBeenCalledWith(uiActions.requestStartGeneration());
+    expect(dispatch).not.toHaveBeenCalledWith(uiActions.openStartGenPrompt());
+  });
+});

--- a/src/store/start-generation-flow.ts
+++ b/src/store/start-generation-flow.ts
@@ -1,0 +1,38 @@
+/* Start-generation flow (P3 — pre-generation voice-model prompt).
+ *
+ * The "Approve cast & start generating" / "Resume generation" CTAs route through
+ * this thunk instead of dispatching `requestStartGeneration` directly. For a
+ * Qwen book it opens the "Choose voice model" prompt so the user picks the tier
+ * (0.6B fast / 1.7B quality) at the moment of starting — defaulting to whatever
+ * the cast is pinned to. For a non-Qwen book (Kokoro / Coqui / Gemini) the tier
+ * choice is meaningless, so it starts immediately (byte-identical to the old
+ * direct dispatch). The modal's confirm applies the chosen tier to the cast and
+ * then dispatches the real `requestStartGeneration`. */
+
+import { uiActions } from './ui-slice';
+import { engineForModelKey } from '../lib/tts-models';
+import type { AppDispatch, RootState } from './index';
+import type { Character } from '../lib/types';
+
+/** A character renders on Qwen iff its own engine (or the run default when it
+    has none) resolves to 'qwen' — mirrors the server's `resolveCharacterEngine`
+    (`server/src/tts/per-character-engine.ts`), so the prompt shows exactly when
+    at least one line will actually be synthesised by Qwen. */
+export function castRendersOnQwen(
+  characters: ReadonlyArray<Character>,
+  runModelKey: Parameters<typeof engineForModelKey>[0],
+): boolean {
+  const runEngine = engineForModelKey(runModelKey);
+  return characters.some((c) => (c.ttsEngine ?? runEngine) === 'qwen');
+}
+
+export function startGenerationFlow() {
+  return (dispatch: AppDispatch, getState: () => RootState): void => {
+    const { cast, ui } = getState();
+    if (castRendersOnQwen(cast.characters, ui.ttsModelKey)) {
+      dispatch(uiActions.openStartGenPrompt());
+    } else {
+      dispatch(uiActions.requestStartGeneration());
+    }
+  };
+}

--- a/src/store/ui-slice.test.ts
+++ b/src/store/ui-slice.test.ts
@@ -31,6 +31,7 @@ const baseState = (stage: Stage): UiState => ({
   queueModalOpen: false,
   rebaselineModalOpen: false,
   rebaselineBookId: null,
+  startGenPrompt: false,
 });
 
 describe('uiSlice — openBook status→stage routing', () => {

--- a/src/store/ui-slice.ts
+++ b/src/store/ui-slice.ts
@@ -104,6 +104,12 @@ export interface UiState {
       on the global Voices view pass the series' representative book (the
       one whose principal cast seeds the modal). Null when closed. */
   rebaselineBookId: string | null;
+  /** True while the "Choose voice model" prompt shown before a generation
+      run is open. Lets the user pick the Qwen tier (0.6B fast / 1.7B quality)
+      at the moment they start generating, defaulting to whatever the cast is
+      pinned to. The actual start (`requestStartGeneration`) is dispatched by
+      the modal's confirm, after the tier is applied to the cast. Transient. */
+  startGenPrompt: boolean;
 }
 
 const initialState: UiState = {
@@ -129,6 +135,7 @@ const initialState: UiState = {
   queueModalOpen: false,
   rebaselineModalOpen: false,
   rebaselineBookId: null,
+  startGenPrompt: false,
 };
 
 export const uiSlice = createSlice({
@@ -234,6 +241,13 @@ export const uiSlice = createSlice({
        and never on a passive open/hydrate/view-switch. See
        docs/features/archive/137-reopen-never-auto-enqueues.md. */
     requestStartGeneration: () => {},
+    /* Open / close the pre-generation "Choose voice model" prompt (P3). */
+    openStartGenPrompt: (s) => {
+      s.startGenPrompt = true;
+    },
+    closeStartGenPrompt: (s) => {
+      s.startGenPrompt = false;
+    },
     setCurrentChapterId: (s, a: PayloadAction<number>) => {
       if (s.stage.kind !== 'ready') return;
       s.stage.currentChapterId = a.payload;

--- a/src/views/generation.test.tsx
+++ b/src/views/generation.test.tsx
@@ -2372,10 +2372,14 @@ describe('GenerationView — Resume generation button (fe-17)', () => {
 
   const inProgressChapter2: Chapter = { ...chapter2, state: 'in_progress' };
 
-  it('renders and dispatches requestStartGeneration when there is queued work and nothing in flight', () => {
+  it('initiates the start-generation flow when there is queued work and nothing in flight', () => {
     /* chapter1 done, chapter2 queued → queued > 0, inProgress = 0, no error.
        Spy on dispatch BEFORE render so the view's useDispatch captures the
-       spy, not the original store method. */
+       spy, not the original store method. The resume button now routes through
+       the startGenerationFlow thunk (P3): a Qwen book opens the tier prompt, a
+       non-Qwen book dispatches requestStartGeneration directly — both branches
+       covered in start-generation-flow.test.ts. Here we only assert the button
+       is wired to that flow. */
     const store = makeResumeStore([chapter1, chapter2]);
     const dispatchSpy = vi.spyOn(store, 'dispatch');
     render(
@@ -2398,7 +2402,18 @@ describe('GenerationView — Resume generation button (fe-17)', () => {
     expect(btn).toBeInTheDocument();
 
     fireEvent.click(btn);
-    expect(dispatchSpy).toHaveBeenCalledWith(uiSlice.actions.requestStartGeneration());
+    /* The thunk is dispatched as a function; whichever branch it takes, one of
+       these is true. */
+    const dispatched = dispatchSpy.mock.calls.map((c) => c[0]) as Array<
+      ((...a: unknown[]) => unknown) | { type?: string }
+    >;
+    const initiatedFlow = dispatched.some(
+      (a) =>
+        typeof a === 'function' ||
+        a?.type === uiSlice.actions.requestStartGeneration().type ||
+        a?.type === uiSlice.actions.openStartGenPrompt().type,
+    );
+    expect(initiatedFlow).toBe(true);
   });
 
   it('is hidden while a chapter is in progress (a run is live)', () => {

--- a/src/views/generation.tsx
+++ b/src/views/generation.tsx
@@ -46,6 +46,7 @@ import { ConfirmDialog } from '../modals/confirm-dialog';
 import { EditChapterTitleModal } from '../modals/edit-chapter-title';
 import { useAppDispatch, useAppSelector } from '../store';
 import { chaptersActions, STALL_THRESHOLD_MS } from '../store/chapters-slice';
+import { startGenerationFlow } from '../store/start-generation-flow';
 import { castActions } from '../store/cast-slice';
 import { manuscriptActions } from '../store/manuscript-slice';
 import { analysisActions } from '../store/analysis-slice';
@@ -57,7 +58,7 @@ import { useLocalAnalyzerGuard } from '../hooks/use-local-analyzer-guard';
 import { useReverseLocalAnalyzerGuard } from '../hooks/use-reverse-local-analyzer-guard';
 import { ANALYSIS_PHASES } from '../data/analysis-phases';
 import { engineForModelId } from '../lib/models';
-import { ttsModelLabel, formatEngineBreakdown } from '../lib/tts-models';
+import { ttsModelLabel, effectiveEngineLabel, formatEngineBreakdown } from '../lib/tts-models';
 import { parseDuration, formatTime } from '../lib/time';
 import { CHAR_COLORS } from '../lib/colors';
 import { deriveIssues } from '../lib/chapter-issues';
@@ -820,7 +821,10 @@ export function GenerationView({
     .reduce((s, c) => s + parseDuration(c.duration), 0);
 
   const blocked = lastError != null;
-  const engineLabel = ttsModelLabel(modelKey);
+  /* Truthful effective-tier label (P2): per-character ttsModelKey overrides win
+     over the run-default in synthesis, so reflect what will actually render —
+     not the global picker. A 1.7B-pinned cast now reads "Qwen3-TTS 1.7B". */
+  const engineLabel = effectiveEngineLabel(characters, modelKey);
 
   /* "Stalled" = there's an in-progress chapter but the SSE has been silent
      for longer than STALL_THRESHOLD_MS. Reading `Date.now()` directly is fine
@@ -968,7 +972,7 @@ export function GenerationView({
           {queued > 0 && inProgressCnt === 0 && !lastError && (
             <button
               type="button"
-              onClick={() => dispatch(uiActions.requestStartGeneration())}
+              onClick={() => dispatch(startGenerationFlow())}
               data-testid="generation-view-resume"
               data-tour-id="generate-resume-btn"
               className="min-h-[44px] px-4 py-2.5 rounded-full border border-magenta/30 bg-magenta/5 text-sm font-medium text-magenta hover:bg-magenta/10 inline-flex items-center gap-2"


### PR DESCRIPTION
## Summary

Three issues surfaced when a whole cast was pinned to the **1.7B Quality tier** and generated on an 8 GB GPU. The 1.7B render was actually correct (the 1.7B model was loaded, 0.6B wasn't) — but it OOM-stormed, and the UI made it look like the override was ignored.

- **#1158 (bug) — 1.7B OOM recycle storm.** The batch packer (`server/src/tts/synthesise-chapter.ts`) applied one width to both tiers (`QWEN_BATCH_SIZE=32` / `QWEN_BATCH_TOKEN_BUDGET=3600`, tuned for 0.6B). The ~3.4 GB-resident 1.7B-Base plus a 32-wide batch's activations blew past the supervisor's `vram_restart_mb=8000` threshold during the batched forward → `recycle code 43` storm (`synthesize-batch` bouncing 200 → 503 → 409) → `RecycleStormError`. **Fix:** tier-aware caps applied to the 1.7B bucket only — `QWEN_BATCH_SIZE_17B` (default 8) + `QWEN_BATCH_TOKEN_BUDGET_17B` (default 1200), both in **Advanced Settings → Voice batching & throughput**. 0.6B batches keep the old defaults.

- **#1159 (bug) — misleading "0.6B" header.** The Generate header read the session-global model picker (`ui.ttsModelKey`), not the per-character tier that wins in synthesis (`routeFor`), so a 1.7B-pinned cast read "Qwen3-TTS 0.6B". **Fix:** `effectiveEngineLabel(characters, modelKey)` derives the header from the cast's effective tier (single label when uniform, `Mixed: A + B` when split) + a human label for the 1.7B key.

- **#1160 (feat) — tier prompt at generation start.** Generation auto-started with the global default and never surfaced the quality-tier choice. **Fix:** a `StartGenerationModal` prompts for the tier on start, defaulting to **1.7B when the cast is pinned to it, else 0.6B**, applying the choice to the whole cast via `setCastTier` (`voiceId ?? id` — covers voiceId-less members) before starting. Non-Qwen books start directly (`startGenerationFlow` thunk).

## Test plan

- `server/src/tts/synthesise-chapter.test.ts` — new: 1.7B bucket caps at the tier-specific size; tier-scoped token budget (1.7B narrow while 0.6B stays wide). Existing 1.7B instruct-packing test migrated to drive the new knob.
- `server/src/config/registry.test.ts`, `routes/config.test.ts` — new knobs validate + serve to Advanced Settings.
- `src/lib/tts-models.test.ts` — `effectiveEngineLabel` (0.6B default / 1.7B pinned / Mixed) + the 1.7B label.
- `src/store/start-generation-flow.test.ts` — `castRendersOnQwen` + thunk branches (Qwen → prompt, non-Qwen → start).
- `src/views/generation.test.tsx` — resume button routes through the start flow.
- Full local `npm run test` (frontend, 3316) + `npm run test:server` (3801) + `npm run typecheck` green. e2e/build deferred to cloud CI (`run-ci`).

Plan: `docs/features/233-book-quality-tier.md` (Follow-ups section).

Closes #1158
Closes #1159
Closes #1160

🤖 Generated with [Claude Code](https://claude.com/claude-code)