### PR TITLE
fix(server): readiness gate polls /health (stop the 0.6B squatting a 1.7B render) + 1.7B batch defaults 32/3600

### DIFF
--- a/server/src/config/registry.ts
+++ b/server/src/config/registry.ts
@@ -373,9 +373,9 @@ export const KNOBS: ConfigKnob[] = [
     env: 'QWEN_BATCH_SIZE_17B',
     group: 'tts-batching',
     label: 'Qwen 1.7B batch size',
-    help: 'Hard width cap for the 1.7B Quality-tier specifically. The 1.7B-Base is ~3.4 GB resident, so a batch as wide as the 0.6B default blows past an 8 GB card during the batched forward → recycle storm. Kept small so 1.7B renders stay within VRAM (slower than 0.6B, but stable). Only affects 1.7B groups — 0.6B batches use the larger tts.batch.size.',
+    help: 'Hard width cap for the 1.7B Quality-tier specifically. Defaults to the same 32 as the 0.6B tier: once the 0.6B base is no longer co-resident (#1162 readiness-gate fix evicts the unused tier), a 1.7B render fits 32/3600 on an 8 GB card (measured peak ~5.7 GB, ~1.7 GB margin under the recycle line) at ~2× real-time. Lower this (and the budget below) on a smaller card if you hit a recycle storm. Only affects 1.7B groups.',
     type: 'integer', min: 1,
-    default: 8, // ← QWEN_BATCH_SIZE_17B default in tts/synthesise-chapter.ts
+    default: 32, // ← QWEN_BATCH_SIZE_17B default in tts/synthesise-chapter.ts (matches the 0.6B tier post-#1162)
     apply: 'restart-server', risk: 'medium', // read once at Node module-load (module-level constant), not sidecar
   },
   {
@@ -383,9 +383,9 @@ export const KNOBS: ConfigKnob[] = [
     env: 'QWEN_BATCH_TOKEN_BUDGET_17B',
     group: 'tts-batching',
     label: 'Qwen 1.7B batch token budget',
-    help: 'Variable-width packing budget (normalised chars) for the 1.7B Quality tier only. Much smaller than the 0.6B tts.batch.tokenBudget so 1.7B batches stay within an 8 GB card during the batched forward (avoids the recycle-storm OOM). Set to 0 for exact fixed-width slicing on the 1.7B tier (tts.batch.size17b only).',
+    help: 'Variable-width packing budget (normalised chars) for the 1.7B Quality tier only. Defaults to the same 3600 as the 0.6B tier (safe on an 8 GB card post-#1162, since the unused 0.6B base no longer co-resides). Lower it on a smaller card if a 1.7B render trips the VRAM recycle. Set to 0 for exact fixed-width slicing on the 1.7B tier (tts.batch.size17b only).',
     type: 'integer', min: 0,
-    default: 1200, // ← DEFAULT_QWEN_BATCH_TOKEN_BUDGET_17B in tts/synthesise-chapter.ts
+    default: 3600, // ← DEFAULT_QWEN_BATCH_TOKEN_BUDGET_17B in tts/synthesise-chapter.ts
     apply: 'restart-server', risk: 'medium', // read once at Node module-load (module-level constant), not sidecar
   },
   {

--- a/server/src/routes/generation-boundary-recycle.test.ts
+++ b/server/src/routes/generation-boundary-recycle.test.ts
@@ -37,6 +37,7 @@ vi.mock('../tts/ensure-sidecar-loaded.js', () => ({
      doesn't wait out its readiness budget. SIDECAR_ENGINES is the REAL set so
      the boundary check's engine guard is exercised honestly. */
   ensureSidecarEngineReady: async () => undefined,
+  reconcileResidentQwenTiers: async () => undefined,
   SIDECAR_ENGINES: new Set(['qwen', 'kokoro', 'coqui']),
 }));
 vi.mock('../tts/index.js', async (importOriginal) => {

--- a/server/src/routes/generation-fallback-gate.test.ts
+++ b/server/src/routes/generation-fallback-gate.test.ts
@@ -48,6 +48,7 @@ vi.mock('../tts/index.js', async (importOriginal) => {
    doesn't try to reach :9000 for the Kokoro fallback warm. */
 vi.mock('../tts/ensure-sidecar-loaded.js', () => ({
   ensureSidecarEngineReady: async () => undefined,
+  reconcileResidentQwenTiers: async () => undefined,
   /* Empty so the side-11 boundary-recycle check (the only SIDECAR_ENGINES
      consumer) is a no-op here. */
   SIDECAR_ENGINES: new Set(),

--- a/server/src/routes/generation-recycle-recovery.test.ts
+++ b/server/src/routes/generation-recycle-recovery.test.ts
@@ -50,6 +50,7 @@ vi.mock('../tts/ensure-sidecar-loaded.js', () => ({
     ensureReadyCalls += 1;
     return ensureReadyImpl();
   },
+  reconcileResidentQwenTiers: async () => undefined,
   /* Empty so the side-11 boundary-recycle check (the only SIDECAR_ENGINES
      consumer) is a no-op here — this suite drives a gemini run and asserts the
      srv-17c recovery, not the boundary recycle. */

--- a/server/src/routes/generation-resume-from.test.ts
+++ b/server/src/routes/generation-resume-from.test.ts
@@ -32,6 +32,7 @@ vi.mock('../tts/index.js', async (importOriginal) => {
    SSE tests exercise the route, not the (separately-tested) readiness gate. */
 vi.mock('../tts/ensure-sidecar-loaded.js', () => ({
   ensureSidecarEngineReady: async () => undefined,
+  reconcileResidentQwenTiers: async () => undefined,
   /* Empty so the side-11 boundary-recycle check (the only SIDECAR_ENGINES
      consumer) is a no-op here. */
   SIDECAR_ENGINES: new Set(),

--- a/server/src/routes/generation-stall-watchdog.test.ts
+++ b/server/src/routes/generation-stall-watchdog.test.ts
@@ -40,6 +40,7 @@ vi.mock('../tts/synthesise-chapter.js', async (importOriginal) => {
 });
 vi.mock('../tts/ensure-sidecar-loaded.js', () => ({
   ensureSidecarEngineReady: async () => {},
+  reconcileResidentQwenTiers: async () => undefined,
   SIDECAR_ENGINES: new Set(),
 }));
 vi.mock('../tts/index.js', async (importOriginal) => {

--- a/server/src/routes/generation.test.ts
+++ b/server/src/routes/generation.test.ts
@@ -52,6 +52,9 @@ vi.mock('../tts/index.js', async (importOriginal) => {
    directly in ensure-sidecar-loaded.test.ts, not through this route suite. */
 vi.mock('../tts/ensure-sidecar-loaded.js', () => ({
   ensureSidecarEngineReady: async () => undefined,
+  /* Run-start tier reconcile — no-op here (no sidecar at :9000); the real
+     eviction logic is covered in ensure-sidecar-loaded.test.ts. */
+  reconcileResidentQwenTiers: async () => undefined,
   /* Empty so the side-11 boundary-recycle check (the only SIDECAR_ENGINES
      consumer) is a no-op here — these tests don't exercise it and must not
      fire a real /health probe at a dev-box sidecar. */

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -77,7 +77,11 @@ import {
 import { hydrateCastReusedVoices } from '../tts/hydrate-reused-voice-workspace.js';
 import { buildChapterTitleNarration } from '../tts/chapter-title-narration.js';
 import { recordBatchThroughput, recordChapterThroughput } from '../tts/generation-stats.js';
-import { ensureSidecarEngineReady, SIDECAR_ENGINES } from '../tts/ensure-sidecar-loaded.js';
+import {
+  ensureSidecarEngineReady,
+  reconcileResidentQwenTiers,
+  SIDECAR_ENGINES,
+} from '../tts/ensure-sidecar-loaded.js';
 import {
   asrEnabled,
   resolveAsrRerecords,
@@ -760,6 +764,29 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
     } catch (e) {
       console.warn('[generation] disk guard probe failed (continuing):', (e as Error).message);
     }
+  }
+
+  /* Run-start VRAM hygiene: evict any resident Qwen base tier this run won't
+     use, so a pure-1.7B render doesn't co-reside the 0.6B base (~1.2 GB) and
+     vice-versa. Fires ONCE here, before any chapter synth — never per chapter —
+     so the in-use tier stays warm across the book (load price paid on chapter 1
+     only). The needed tiers come from the cast's per-character ttsModelKey + the
+     run default (mirrors synthesise-chapter's routeFor), so a genuinely
+     mixed-tier book keeps both. Best-effort; a down / recycling sidecar skips. */
+  if (qwenInUse && targetChapters.length > 0) {
+    const usedQwenKeys = new Set<TtsModelKey>();
+    for (const c of cast.characters) {
+      if (resolveCharacterEngine(c, engine) !== 'qwen') continue;
+      usedQwenKeys.add(
+        c.ttsModelKey
+          ? canonicalModelKeyForEngine('qwen', c.ttsModelKey)
+          : resolveForEngine('qwen').modelKey,
+      );
+    }
+    await reconcileResidentQwenTiers({
+      keep06: usedQwenKeys.has('qwen3-tts-0.6b'),
+      keep17: usedQwenKeys.has('qwen3-tts-1.7b'),
+    }).catch((e) => console.warn('[generation] tier reconcile skipped:', (e as Error).message));
   }
 
   /* srv-16 — if this queue-driven POST's sole target chapter already has audio

--- a/server/src/tts/ensure-sidecar-loaded.test.ts
+++ b/server/src/tts/ensure-sidecar-loaded.test.ts
@@ -16,7 +16,7 @@ vi.mock('../gpu/gpu-load.js', () => ({
   GpuBusyError: class extends Error {},
 }));
 
-import { ensureSidecarEngineReady } from './ensure-sidecar-loaded.js';
+import { ensureSidecarEngineReady, reconcileResidentQwenTiers } from './ensure-sidecar-loaded.js';
 
 const realFetch = global.fetch;
 afterEach(() => {
@@ -24,7 +24,8 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-const readyResp = { ok: true, json: async () => ({ status: 'ready' }) };
+/* A settled /health response: reachable, not recycling, engine installed. */
+const readyResp = { ok: true, json: async () => ({ qwen_package_installed: true }) };
 
 /* Small budgets keep the poll loop fast + deterministic in tests. */
 const FAST = { timeoutMs: 40, pollIntervalMs: 5 };
@@ -38,7 +39,7 @@ describe('ensureSidecarEngineReady', () => {
     expect(f).not.toHaveBeenCalled();
   });
 
-  it('POSTs /load with the engine and resolves once ready', async () => {
+  it('GETs /health (never /load — loads nothing) and resolves once reachable', async () => {
     const f = vi.fn().mockResolvedValue(readyResp);
     global.fetch = f as unknown as typeof fetch;
 
@@ -46,9 +47,19 @@ describe('ensureSidecarEngineReady', () => {
 
     expect(f).toHaveBeenCalledTimes(1);
     const [target, init] = f.mock.calls[0] as [string, RequestInit];
-    expect(target).toBe('http://localhost:9000/load');
-    expect(init.method).toBe('POST');
-    expect(JSON.parse(init.body as string)).toEqual({ engine: 'qwen' });
+    expect(target).toBe('http://localhost:9000/health');
+    expect(init.method).toBe('GET');
+    expect(init.body).toBeUndefined(); // pure readiness probe, no model load
+  });
+
+  it('waits while the engine package reports not installed, then resolves', async () => {
+    const f = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ qwen_package_installed: false }) })
+      .mockResolvedValue(readyResp);
+    global.fetch = f as unknown as typeof fetch;
+    await expect(ensureSidecarEngineReady('qwen', undefined, PATIENT)).resolves.toBeUndefined();
+    expect(f).toHaveBeenCalledTimes(2);
   });
 
   /* srv-17 core: a respawn window (sidecar unreachable) is RIDDEN OUT, not
@@ -65,10 +76,10 @@ describe('ensureSidecarEngineReady', () => {
     expect(f).toHaveBeenCalledTimes(3); // waited out two failures, then ready
   });
 
-  it('polls through a still-loading model then resolves once ready', async () => {
+  it('polls through a pending recycle (drain fence) then resolves once settled', async () => {
     const f = vi
       .fn()
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ status: 'loading' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ recycle_pending: true }) })
       .mockResolvedValue(readyResp);
     global.fetch = f as unknown as typeof fetch;
 
@@ -76,10 +87,10 @@ describe('ensureSidecarEngineReady', () => {
     expect(f).toHaveBeenCalledTimes(2);
   });
 
-  /* The 2026-05-31 cascade fix: during a recycle DRAIN the sidecar /load now
-     answers the recycling 503 (drain fence) instead of an instant `ready`, so
-     the gate must POLL THROUGH the drain and only proceed once the respawned
-     sidecar is ready — otherwise a queued chapter marches into a 503 and fails. */
+  /* The 2026-05-31 cascade fix: during a recycle DRAIN the sidecar answers a
+     recycling 503 (drain fence), so the gate must POLL THROUGH the drain and
+     only proceed once the respawned sidecar is reachable — otherwise a queued
+     chapter marches into a 503 and fails. */
   it('polls through a recycle drain (recycling 503) then resolves once respawned', async () => {
     const recyclingResp = {
       ok: false,
@@ -137,6 +148,66 @@ describe('ensureSidecarEngineReady', () => {
   });
 });
 
+describe('reconcileResidentQwenTiers (run-start VRAM hygiene)', () => {
+  /* Build a fetch mock: first GET /health returns `health`, every POST /unload
+     is recorded. Returns the recorded /unload bodies. */
+  function mockSidecar(health: Record<string, unknown>): {
+    fetch: ReturnType<typeof vi.fn>;
+    unloads: () => Array<Record<string, unknown>>;
+  } {
+    const unloads: Array<Record<string, unknown>> = [];
+    const f = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith('/health')) return { ok: true, json: async () => health };
+      if (url.endsWith('/unload')) {
+        unloads.push(JSON.parse((init?.body as string) ?? '{}'));
+        return { ok: true, json: async () => ({ status: 'idle' }) };
+      }
+      throw new Error(`unexpected ${url}`);
+    });
+    return { fetch: f, unloads: () => unloads };
+  }
+
+  it('evicts the 0.6B base for a pure-1.7B run, keeps the 1.7B base', async () => {
+    const m = mockSidecar({ qwen_loaded: true, qwen_base17_loaded: true });
+    global.fetch = m.fetch as unknown as typeof fetch;
+    await reconcileResidentQwenTiers({ keep06: false, keep17: true });
+    expect(m.unloads()).toEqual([{ engine: 'qwen' }]); // 0.6B only
+  });
+
+  it('evicts the 1.7B base for a pure-0.6B run, keeps the 0.6B base', async () => {
+    const m = mockSidecar({ qwen_loaded: true, qwen_base17_loaded: true });
+    global.fetch = m.fetch as unknown as typeof fetch;
+    await reconcileResidentQwenTiers({ keep06: true, keep17: false });
+    expect(m.unloads()).toEqual([{ engine: 'qwen', model: '1.7b' }]); // 1.7B only
+  });
+
+  it('evicts nothing for a mixed-tier run (both in use)', async () => {
+    const m = mockSidecar({ qwen_loaded: true, qwen_base17_loaded: true });
+    global.fetch = m.fetch as unknown as typeof fetch;
+    await reconcileResidentQwenTiers({ keep06: true, keep17: true });
+    expect(m.unloads()).toEqual([]);
+  });
+
+  it('no-ops when the unused tier is not resident', async () => {
+    const m = mockSidecar({ qwen_loaded: false, qwen_base17_loaded: true });
+    global.fetch = m.fetch as unknown as typeof fetch;
+    await reconcileResidentQwenTiers({ keep06: false, keep17: true }); // 0.6B not loaded → nothing to evict
+    expect(m.unloads()).toEqual([]);
+  });
+
+  it('skips (no evict) while a recycle is pending', async () => {
+    const m = mockSidecar({ qwen_loaded: true, recycle_pending: true });
+    global.fetch = m.fetch as unknown as typeof fetch;
+    await reconcileResidentQwenTiers({ keep06: false, keep17: true });
+    expect(m.unloads()).toEqual([]);
+  });
+
+  it('is best-effort: a down sidecar does not throw', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED')) as unknown as typeof fetch;
+    await expect(reconcileResidentQwenTiers({ keep06: false, keep17: true })).resolves.toBeUndefined();
+  });
+});
+
 describe('ensureSidecarEngineReady — withGpuLoad gate', () => {
   /* Each test must: vi.resetModules() → vi.doMock() → dynamic import.
      This ensures the dynamic `await import('../gpu/gpu-load.js')` inside
@@ -147,7 +218,7 @@ describe('ensureSidecarEngineReady — withGpuLoad gate', () => {
     vi.resetModules();
   });
 
-  it('wraps the load in withGpuLoad (the gate runs before /load on a constrained card)', async () => {
+  it('wraps the readiness poll in withGpuLoad (surfaces GpuBusy on a constrained card)', async () => {
     const order: string[] = [];
     vi.resetModules();
     vi.doMock('../workspace/user-settings.js', () => ({

--- a/server/src/tts/ensure-sidecar-loaded.ts
+++ b/server/src/tts/ensure-sidecar-loaded.ts
@@ -1,8 +1,20 @@
-/* Preload + READINESS gate (plan 113 follow-up; srv-17 respawn-resilience).
-   Before a generation worker dispatches any synth for a chapter, it POSTs the
-   sidecar `/load` for the chapter's engine and WAITS until the model reports
-   ready — so a cold start (or a supervisor respawn) pauses the queue ON THE
-   GATE instead of N workers all firing synth at a sidecar that isn't up yet.
+/* READINESS gate (plan 113 follow-up; srv-17 respawn-resilience).
+   Before a generation worker dispatches any synth for a chapter, it WAITS until
+   the sidecar is reachable — so a cold start (or a supervisor respawn) pauses
+   the queue ON THE GATE instead of N workers all firing synth at a sidecar that
+   isn't up yet.
+
+   IMPORTANT (2026-06-26): this gate POLLS `GET /health` — it NEVER `/load`s a
+   model. The old gate POSTed `/load {engine}`, which (for Qwen) eagerly warmed
+   the **0.6B base** as a side effect — so on a pure-1.7B render the 0.6B squatted
+   ~1.2 GB of an 8 GB card per chapter and reloaded itself the moment it was
+   evicted (#1162). Model loading is now purely lazy: the synth path loads the
+   CORRECT tier (`_ensure_base17_loaded` for 1.7B / `_ensure_base_loaded` for
+   0.6B) once, under its own single-flight lock, and keeps it warm across the
+   book — so the load price is paid on the first chapter only. Preloading a model
+   at startup is a separate, opt-in concern (`PRELOAD_QWEN` / `PRELOAD_QWEN_BASE17`).
+   VRAM hygiene — evicting a resident tier this run won't use — is the run-start
+   `reconcileResidentQwenTiers` below, NOT this per-chapter gate.
 
    WHY THIS BLOCKS (srv-17). The host-RAM recycle (plan 143) makes the sidecar
    self-exit; the srv-15 supervisor respawns it with backoff [2s,5s,15s] + a
@@ -57,12 +69,15 @@ export interface EnsureReadyOpts {
 
 type LoadOutcome = { ready: true } | { ready: false; reason: string };
 
-/** POST `/load` once. Returns `{ready:true}` when the model reports ready,
-    else a reason. A connection failure (sidecar down / respawning) and a
-    non-ok / non-ready response are both `{ready:false}` so the caller keeps
-    waiting. Re-throws AbortError so a run-level stop propagates cleanly. */
-async function tryLoadOnce(
-  target: string,
+/** GET `/health` once. Returns `{ready:true}` when the sidecar is reachable and
+    settled (not mid-recycle, not poisoned, this engine's package installed) —
+    NO model load. A connection failure (sidecar down / respawning), a non-ok
+    response, a pending recycle, or a poisoned process are all `{ready:false}` so
+    the caller keeps waiting. Re-throws AbortError so a run-level stop propagates
+    cleanly. The actual model is lazy-loaded by the first synth (correct tier,
+    single-flight) — this gate only proves the sidecar is up. */
+async function tryReadyOnce(
+  healthUrl: string,
   engine: TtsEngine,
   signal: AbortSignal | undefined,
 ): Promise<LoadOutcome> {
@@ -71,16 +86,18 @@ async function tryLoadOnce(
   const onAbort = () => controller.abort();
   signal?.addEventListener('abort', onAbort, { once: true });
   try {
-    const res = await fetch(target, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ engine }),
-      signal: controller.signal,
-    });
-    if (!res.ok) return { ready: false, reason: `/load returned ${res.status}` };
-    const body = (await res.json().catch(() => ({}))) as { status?: string };
-    if (body.status === 'ready') return { ready: true };
-    return { ready: false, reason: `status=${body.status ?? 'unknown'}` };
+    const res = await fetch(healthUrl, { method: 'GET', signal: controller.signal });
+    if (!res.ok) return { ready: false, reason: `/health returned ${res.status}` };
+    const h = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    /* Honour the recycle drain fence: a sidecar that is reachable but draining /
+       respawning is NOT ready for new synth — keep waiting (mirrors the old
+       gate's /load drain fence). */
+    if (h.recycle_pending === true) return { ready: false, reason: 'recycle pending' };
+    if (h.poisoned === true) return { ready: false, reason: 'poisoned' };
+    if (h[`${engine}_package_installed`] === false) {
+      return { ready: false, reason: `${engine} package not installed` };
+    }
+    return { ready: true };
   } catch (e) {
     /* A run-level abort propagates as a clean stop. A timeout / connection
        error (sidecar down or respawning) is a "keep waiting" signal, NOT a
@@ -107,21 +124,24 @@ export async function ensureSidecarEngineReady(
   if (signal?.aborted) throw new DOMException('preload aborted', 'AbortError');
 
   const { withGpuLoad } = await import('../gpu/gpu-load.js');
-  const target = `${getResolvedSidecarUrl()}/load`;
+  const target = `${getResolvedSidecarUrl()}/health`;
   const timeoutMs = opts.timeoutMs ?? READINESS_TIMEOUT_MS;
   const pollIntervalMs = opts.pollIntervalMs ?? POLL_INTERVAL_MS;
   const deadline = Date.now() + timeoutMs;
   let lastReason = 'unknown';
 
+  /* withGpuLoad still wraps the wait so a live analysis on a constrained card
+     surfaces as a GpuBusyError → user-facing "Generation paused" (unchanged).
+     The poll itself is a cheap GET — it loads nothing. */
   await withGpuLoad(async () => {
     for (;;) {
       if (signal?.aborted) throw new DOMException('preload aborted', 'AbortError');
-      const outcome = await tryLoadOnce(target, engine, signal);
+      const outcome = await tryReadyOnce(target, engine, signal);
       if (outcome.ready) return; // resolves the withGpuLoad callback; ensureSidecarEngineReady then returns void
       lastReason = outcome.reason;
       if (Date.now() >= deadline) {
         console.warn(
-          `[generation] preload ${engine}: not ready after ${timeoutMs}ms (last: ${lastReason}) — falling back to lazy load.`,
+          `[generation] readiness ${engine}: sidecar not ready after ${timeoutMs}ms (last: ${lastReason}) — proceeding to lazy load.`,
         );
         return;
       }
@@ -130,11 +150,61 @@ export async function ensureSidecarEngineReady(
   });
 
   // fs-45 v1: sample this engine's reserved footprint (env-gated + clean-process
-  // gate inside maybeSampleSidecarEngine). Best-effort, record-only.
+  // gate inside maybeSampleSidecarEngine). Best-effort, record-only. The gate no
+  // longer triggers the load, so this captures the CURRENT resident footprint
+  // (whatever tier is warm) rather than a just-loaded one.
   if (engine === 'qwen' || engine === 'coqui') {
     const { maybeSampleSidecarEngine } = await import('../gpu/sidecar-vram-sample.js');
     await maybeSampleSidecarEngine(engine === 'qwen' ? 'qwen:synth' : 'coqui');
   }
+}
+
+/** Run-start VRAM hygiene (2026-06-26). Evict any resident Qwen base TIER this
+    run will not use, so only the needed tier occupies the GPU — a pure-1.7B
+    render no longer co-resides the 0.6B base (and vice-versa). Fires ONCE at
+    generation start (NOT per chapter), so the in-use tier is never evicted
+    between chapters — the load price is paid on the first chapter only. The
+    needed tiers come from the run's cast (per-character `ttsModelKey` + the run
+    default), so a genuinely mixed-tier book keeps both. Best-effort: a sidecar
+    that is down / mid-recycle just skips (the next run reconciles).
+
+    `keep06` / `keep17` = "this run uses the 0.6B / 1.7B base tier". */
+export async function reconcileResidentQwenTiers(
+  keep: { keep06: boolean; keep17: boolean },
+  signal?: AbortSignal,
+): Promise<void> {
+  const base = getResolvedSidecarUrl();
+  let h: Record<string, unknown> | null = null;
+  try {
+    const res = await fetch(`${base}/health`, { method: 'GET', signal });
+    h = res.ok ? ((await res.json().catch(() => null)) as Record<string, unknown> | null) : null;
+  } catch {
+    return; // sidecar unreachable — nothing to reconcile
+  }
+  if (!h || h.recycle_pending === true) return;
+
+  const unload = async (model?: '1.7b'): Promise<void> => {
+    try {
+      await fetch(`${base}/unload`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(model ? { engine: 'qwen', model } : { engine: 'qwen' }),
+        signal,
+      });
+    } catch {
+      /* best-effort */
+    }
+  };
+
+  const evictions: Promise<void>[] = [];
+  if (h.qwen_loaded === true && !keep.keep06) evictions.push(unload()); // drop the 0.6B base
+  if (h.qwen_base17_loaded === true && !keep.keep17) evictions.push(unload('1.7b')); // drop the 1.7B base
+  if (evictions.length === 0) return;
+  console.info(
+    `[generation] VRAM reconcile: evicting unused Qwen tier(s) ` +
+      `[${!keep.keep06 && h.qwen_loaded ? '0.6B ' : ''}${!keep.keep17 && h.qwen_base17_loaded ? '1.7B' : ''}]`.trim(),
+  );
+  await Promise.allSettled(evictions);
 }
 
 /* Abort-aware sleep — resolves after `ms`, or rejects promptly if `signal`

--- a/server/src/tts/synthesise-chapter.ts
+++ b/server/src/tts/synthesise-chapter.ts
@@ -90,15 +90,15 @@ export function resolveQwenTokenBudget(raw: string | undefined): number {
 }
 const QWEN_BATCH_TOKEN_BUDGET = configValue<number>('tts.batch.tokenBudget');
 
-/* 1.7B tier-aware batch width (8 GB OOM guard). The 1.7B-Base is ~3.4 GB
-   resident; a 1.7B batch as wide as the 0.6B default (size 32 / budget 3600)
-   blows past an 8 GB card's VRAM during the batched forward → supervisor
-   recycle storm (code 43) → RecycleStormError fails the chapter. The packer
-   applies these SMALLER caps to the 1.7B bucket ONLY; 0.6B batches keep the
-   defaults above (a mixed-tier chapter packs each tier to its own width). The
-   1.7B forward is inherently heavier, so narrower batches trade some throughput
-   for staying inside VRAM — the difference between "renders" and "thrashes". */
-export const DEFAULT_QWEN_BATCH_TOKEN_BUDGET_17B = 1200;
+/* 1.7B tier-aware batch width. The packer applies these caps to the 1.7B bucket
+   ONLY; 0.6B batches keep the defaults above (a mixed-tier chapter packs each
+   tier to its own width). Defaults now MATCH the 0.6B tier (32 / 3600): the
+   #1162 readiness-gate fix evicts the unused 0.6B base before a 1.7B run, so the
+   1.7B-Base (~3.4 GB) is no longer co-resident and 32/3600 fits an 8 GB card
+   (measured peak ~5.7 GB, ~1.7 GB margin under the recycle line) at ~2× RT.
+   These knobs remain the small-card safety valve — lower them if a 1.7B render
+   trips the VRAM recycle on a < 8 GB card. */
+export const DEFAULT_QWEN_BATCH_TOKEN_BUDGET_17B = 3600;
 const QWEN_BATCH_SIZE_17B = configValue<number>('tts.batch.size17b');
 const QWEN_BATCH_TOKEN_BUDGET_17B = configValue<number>('tts.batch.tokenBudget17b');
 


### PR DESCRIPTION
## Summary

Follow-up to #1158/#1161. While tuning the 1.7B Quality tier on the 8 GB box we found the 0.6B Qwen base stayed resident through a pure-1.7B render — squatting ~1.2–2 GB and shrinking the 1.7B batch headroom — and **reloaded itself the instant it was evicted**.

**Root cause (#1162):** the per-chapter generation readiness gate POSTed `/load {engine:'qwen'}`, which warms the 0.6B base as a side effect. It was misusing a *mutating* preload as a readiness probe — once per chapter, plus on every respawn-recovery. (The 1.7B synth path itself never loads the 0.6B; verified in the sidecar.)

### Changes

1. **Readiness gate → `GET /health` poll, never `/load`** (`ensure-sidecar-loaded.ts`). It only waits until the sidecar is reachable + settled (not recycling/poisoned, engine installed) and loads **nothing**. Model loading is purely lazy: the synth path loads the **correct tier** once under its single-flight lock and keeps it warm across the book — load price paid on chapter 1 only, in-use tier never re-evicted between chapters. Respawn-resilience (srv-17 drain/respawn fence) preserved via the poll. fs-45 footprint sample retained (best-effort).
2. **Run-start `reconcileResidentQwenTiers`** — fires ONCE at generation start: evicts any resident Qwen base **tier this run won't use** (pure-1.7B drops a stray 0.6B; mixed-tier keeps both), never the in-use tier. Used tiers derived from the cast's per-character `ttsModelKey` + run default (mirrors `routeFor`).
3. **1.7B batch defaults → 32/3600** (match the 0.6B tier). The conservative 8/1200 from #1161 was only needed because of the co-residence; with it gone, 32/3600 fits the 8 GB card. The tier knobs remain the small-card safety valve.

### Measured on the 8 GB box (The Lost Art of World Domination, ch3, 1.7B)

- Startup: nothing preloaded (`vram_reserved=0`). Render: `qwen_loaded` stays **false** throughout — only base17 resident.
- Batch ladder (clean, 0.6B evicted): 8/1200 → peak 4.3 GB, RTF 0.87 · **32/3600 → peak 5.7 GB, RTF 0.49** (~2× RT, ~1.7 GB margin under the 7400 MB soft recycle) · 64/7000 → peak 6.95 GB, RTF 0.475 (only ~3% faster, far less margin). Sweet spot = **32/3600**.
- Operator note: preload is now startup-only/opt-in; `eagerLoadQwen` set off on the box.

## Test plan

- `ensure-sidecar-loaded.test.ts` — gate GETs `/health` (never `/load`, no body); polls through unreachable / pending-recycle / not-installed; **+ `reconcileResidentQwenTiers` suite** (evicts 0.6B for a 1.7B run / 1.7B for a 0.6B run / nothing when mixed or not resident / skips on pending recycle / best-effort on a down sidecar).
- All six generation-route test mocks updated for the new `reconcileResidentQwenTiers` export.
- `ensure-sidecar-vram.test.ts` (fs-45) stays green. Full `npm run test:server` (3806) + server typecheck green. Server-only change — frontend suite unaffected; e2e/build via cloud CI (`run-ci`).

Closes #1162
Refs #1158 #1161

🤖 Generated with [Claude Code](https://claude.com/claude-code)