### PR TITLE
fix(server): green main's post-1.7B gates — .env.example sync + e2e tier-prompt confirm

### DIFF
--- a/e2e/generation-parallel.spec.ts
+++ b/e2e/generation-parallel.spec.ts
@@ -32,7 +32,7 @@
  * promotes min(K, queued.length) chapters in the same tick). */
 
 import { test, expect, type Page } from '@playwright/test';
-import { goToConfirm } from './helpers';
+import { goToConfirm, confirmTierPromptIfPresent } from './helpers';
 
 /* Plan 58 — file-level serial mode keeps long cold-boot walks in one
    worker so SSE phase transitions don't miss their event window when
@@ -121,6 +121,7 @@ test.describe('parallel chapter generation (BACKLOG #26, plan 87)', () => {
     const bookId = await getBookId(page);
     await page.getByRole('button', { name: /Approve cast.*start generating/i }).click();
     await expect(page).toHaveURL(new RegExp(`#/books/${bookId}/generate`), { timeout: 5_000 });
+    await confirmTierPromptIfPresent(page); // #1160 voice-model tier prompt
 
     /* Poll for the parallel-SSE proof: chapter 2's first in_progress
        transition lands BEFORE chapter 1 completes. We track the first

--- a/e2e/generation-resume.spec.ts
+++ b/e2e/generation-resume.spec.ts
@@ -16,7 +16,7 @@
  * jsdom can lie about for the hashchange / middleware timing). */
 
 import { test, expect, type Page } from '@playwright/test';
-import { goToConfirm } from './helpers';
+import { goToConfirm, confirmTierPromptIfPresent } from './helpers';
 
 /* Serial mode: the cold-boot analysis walk is long; keep it in one worker so
    the mock SSE phase transitions don't miss their window under contention
@@ -95,6 +95,9 @@ test.describe('Resume generation button (fe-17)', () => {
     /* Click it → requestStartGeneration → middleware enqueues the queued
        chapters → dispatcher claims them → at least one leaves 'queued'. */
     await resumeBtn.click();
+    /* #1160 — a Qwen book prompts for the voice-model tier before starting;
+       confirm it (keep the default) so the run actually kicks off. */
+    await confirmTierPromptIfPresent(page);
     await expect
       .poll(() => anyQueuedLeft(page, queuedBefore), {
         timeout: 15_000,

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -156,6 +156,19 @@ export async function bootFreshBookIntoAnalysing(page: Page): Promise<void> {
   });
 }
 
+/* Start-generation tier prompt (#1160). For a Qwen book, clicking "Approve cast
+   & start generating" / "Resume generation" now opens the StartGenerationModal
+   so the user picks the voice-model tier before the run begins. Confirm it (keep
+   the pre-selected default) so generation actually starts. No-op when the prompt
+   isn't shown (a non-Qwen book starts directly). Call right after the start CTA. */
+export async function confirmTierPromptIfPresent(page: Page): Promise<void> {
+  const heading = page.getByRole('heading', { name: /Choose the voice model/i });
+  if (await heading.isVisible().catch(() => false)) {
+    await page.getByRole('button', { name: 'Start generating', exact: true }).click();
+    await expect(heading).toBeHidden({ timeout: 5_000 });
+  }
+}
+
 export async function stubAccountModelProbes(page: Page): Promise<void> {
   const json = (body: unknown) => ({
     status: 200,

--- a/e2e/queue-modal.spec.ts
+++ b/e2e/queue-modal.spec.ts
@@ -13,7 +13,7 @@
  * prove the queue is authoritative (chapters show up as real entries). */
 
 import { test, expect } from '@playwright/test';
-import { goToConfirm } from './helpers';
+import { goToConfirm, confirmTierPromptIfPresent } from './helpers';
 
 interface QueueEntryShape {
   id: string;
@@ -198,6 +198,7 @@ test.describe('queue modal (plan 102 / 111)', () => {
     await expect(page).toHaveURL(/#\/books\/.+\/manuscript/, { timeout: 5_000 });
     await page.getByRole('button', { name: /Approve cast.*start generating/i }).click();
     await expect(page).toHaveURL(/#\/books\/.+\/generate/, { timeout: 5_000 });
+    await confirmTierPromptIfPresent(page); // #1160 voice-model tier prompt
 
     /* Generation is live once a chapter-row "Generating" pill shows. */
     await expect(page.locator('span', { hasText: /^Generating$/ }).first()).toBeVisible({
@@ -248,6 +249,7 @@ test.describe('queue modal (plan 102 / 111)', () => {
     await expect(page).toHaveURL(/#\/books\/.+\/manuscript/, { timeout: 5_000 });
     await page.getByRole('button', { name: /Approve cast.*start generating/i }).click();
     await expect(page).toHaveURL(/#\/books\/.+\/generate/, { timeout: 5_000 });
+    await confirmTierPromptIfPresent(page); // #1160 voice-model tier prompt
     await expect.poll(queueLen, { timeout: 10_000 }).toBeGreaterThan(0);
   });
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -484,6 +484,10 @@ PRELOAD_QWEN_BASE17=false
 QWEN_BATCH_SIZE=32
 # Variable-width packing budget (normalised chars): keep adding sentences to a batch while (count+1) × maxLen ≤ budget. Short/dialogue batches pack wider; long batches stay narrow. Set to 0 for exact fixed-width slicing (QWEN_BATCH_SIZE only, kill-switch). [restart-server]
 QWEN_BATCH_TOKEN_BUDGET=3600
+# Hard width cap for the 1.7B Quality-tier specifically. Defaults to the same 32 as the 0.6B tier: once the 0.6B base is no longer co-resident (#1162 readiness-gate fix evicts the unused tier), a 1.7B render fits 32/3600 on an 8 GB card (measured peak ~5.7 GB, ~1.7 GB margin under the recycle line) at ~2× real-time. Lower this (and the budget below) on a smaller card if you hit a recycle storm. Only affects 1.7B groups. [restart-server]
+QWEN_BATCH_SIZE_17B=32
+# Variable-width packing budget (normalised chars) for the 1.7B Quality tier only. Defaults to the same 3600 as the 0.6B tier (safe on an 8 GB card post-#1162, since the unused 0.6B base no longer co-resides). Lower it on a smaller card if a 1.7B render trips the VRAM recycle. Set to 0 for exact fixed-width slicing on the 1.7B tier (tts.batch.size17b only). [restart-server]
+QWEN_BATCH_TOKEN_BUDGET_17B=3600
 # Sort batchable Qwen groups by normalised text length before slicing into batches, so similar-length sentences share a batch (less padding waste). Output is byte-identical regardless of batch composition. Set to false to revert to index order. [restart-server]
 QWEN_BATCH_BUCKET=true
 # Number of chapters the generation queue synthesises concurrently. Queue/synthesis concurrency only — the GPU semaphore is the VRAM guard. Default 1: the Qwen forward is serialised, so a 2nd same-book worker just contends on the lock, doubles per-chapter RTF, and accelerates the host-memory leak toward a recycle. Raise only on a multi-GPU / non-Qwen setup. [restart-server]


### PR DESCRIPTION
## Summary

Two follow-ups that turn main's gates green after the 1.7B-tier PRs (#1161/#1163). Both are small, generated-/test-only, no runtime behaviour change.

1. **`config:check` was red on main** (`00c1301e`). The 1.7B batch knobs (`QWEN_BATCH_SIZE_17B` / `QWEN_BATCH_TOKEN_BUDGET_17B`) landed in the config registry but `server/.env.example` was never regenerated via `npm run config:sync`, so the pre-push `config:check` gate failed and blocked every push. Regenerated to match the registry (4 lines, generated-file only).

2. **e2e was red on main** (`1d828f99`). #1160's `StartGenerationModal` intercepts "Approve cast & start generating" / "Resume generation" for a Qwen book — the cast must pick a voice-model tier before the run starts. Four e2e specs clicked the start CTA and asserted generation began (queue fills / chapters in_progress); the prompt blocked the start so the **queue stayed empty** and they failed (confirmed in the failing CI run's log: `queue: { entries: [] }`). Added `confirmTierPromptIfPresent(page)` to `e2e/helpers.ts` and call it after each start CTA in generation-parallel, generation-resume, and queue-modal (×2): it clicks the modal's "Start generating" when shown (keeping the default tier) and is a no-op otherwise.

## Test plan

- `npm run config:check` → `.env.example in sync ✓`.
- e2e queue-modal (both authoritative-queue specs) pass locally with the helper; generation-parallel passes. Full chromium e2e battery verified via cloud CI (`run-ci`) in a clean env (the local box is under GPU load from a live render, which flakes the heavy upload-setup helper).

Refs #1160 #1161 #1163

🤖 Generated with [Claude Code](https://claude.com/claude-code)