### PR TITLE
chore(ci): migrate vite chunk config off deprecated advancedChunks

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -119,13 +119,15 @@ export default defineConfig(({ mode }) => {
              of utility libs that don't reach into the react runtime.
 
              fe-19 (Vite 8 / Rolldown): the function-form `manualChunks`
-             this replaced is deprecated under Rolldown; migrated to
-             `advancedChunks.groups`. Groups are first-match-wins in order,
+             this replaced is deprecated under Rolldown. ops-19: migrated to
+             `codeSplitting.groups` — the `advancedChunks` key it briefly used
+             is itself now deprecated in favour of `codeSplitting`, which takes
+             the same `{ groups }` shape. Groups are first-match-wins in order,
              so the `react` group (matched on the same node_modules paths the
              old predicate used) must precede the `vendor` catch-all. The app
              code falls through both (neither matches a non-node_modules id)
              and keeps Rolldown's default per-entry/lazy chunking. */
-          advancedChunks: {
+          codeSplitting: {
             groups: [
               {
                 name: 'react',


### PR DESCRIPTION
## Summary

Migrates the Vite/Rolldown chunk-grouping config off the deprecated `advancedChunks` output option to `codeSplitting`, which accepts the identical `{ groups }` shape. `npm run build` printed `advancedChunks option is deprecated, please use codeSplitting instead.` on every run (Rolldown 1.0.3 / Vite 8); this silences it and future-proofs the config before the deprecated alias is removed.

Pure key rename — the `react` + `vendor` chunk hashes are unchanged across the rename (verified on a built bundle), so the chunk graph is identical and only the warning goes away. Comment at `vite.config.ts` updated to reflect the new API and the `ops-19` migration.

## Test plan

- `npm run build` → no `advancedChunks` deprecation warning (grep count 0).
- `react` chunk (`react-71FOx8VH.js`) byte-identical before/after; `vendor` chunk intact.
- `tsc -b` (frontend + server typecheck, runs first in `build`) green — the `codeSplitting: { groups }` type is accepted.
- Verified on a **production build** (not the dev server), per plan 167 / the macOS-launch chunk-graph caveat.

Closes #1164
