### PR TITLE
test(e2e): dedicated StartGenerationModal tier-prompt spec

### DIFF
--- a/e2e/start-generation-tier-prompt.spec.ts
+++ b/e2e/start-generation-tier-prompt.spec.ts
@@ -1,0 +1,46 @@
+/* Dedicated e2e for the pre-generation voice-model prompt (#1160 StartGenerationModal).
+ *
+ * The other generation specs only DISMISS the prompt (confirmTierPromptIfPresent);
+ * this spec asserts the prompt's OWN behaviour: for a Qwen book it appears before
+ * the run starts, offers both Qwen tiers with the cast-pin-aware default
+ * pre-selected, and confirming a chosen tier starts generation. The mock
+ * upload-flow cast renders on Qwen, so clicking the start CTA opens the prompt
+ * (a non-Qwen book starts directly — covered by the start-generation-flow thunk
+ * unit test). One test = one (cold-start-flaky) upload setup; Playwright's
+ * configured retries ride out the shared goToConfirm helper's cold-load race. */
+
+import { test, expect } from '@playwright/test';
+import { goToConfirm } from './helpers';
+
+test('voice-model prompt before a Qwen run: both tiers, 0.6B default, confirm starts (#1160)', async ({
+  page,
+}) => {
+  /* Fresh Qwen book: confirm cast → manuscript → "Approve cast & start
+     generating" lands on the generate view with the prompt open. */
+  await goToConfirm(page);
+  await page.getByRole('button', { name: /Confirm cast and review manuscript/i }).click();
+  await expect(page).toHaveURL(/#\/books\/.+\/manuscript/, { timeout: 5_000 });
+  await page.getByRole('button', { name: /Approve cast.*start generating/i }).click();
+  await expect(page).toHaveURL(/#\/books\/.+\/generate/, { timeout: 5_000 });
+
+  /* The prompt appears with both Qwen tiers. */
+  const heading = page.getByRole('heading', { name: /Choose the voice model/i });
+  await expect(heading).toBeVisible({ timeout: 5_000 });
+  const tier06 = page.getByTestId('start-gen-tier-qwen3-tts-0.6b');
+  const tier17 = page.getByTestId('start-gen-tier-qwen3-tts-1.7b');
+  await expect(tier06).toBeVisible();
+  await expect(tier17).toBeVisible();
+  /* A freshly-analysed cast carries no 1.7B pin → 0.6B is the default selection. */
+  await expect(tier06).toHaveAttribute('aria-pressed', 'true');
+  await expect(tier17).toHaveAttribute('aria-pressed', 'false');
+
+  /* Pick 1.7B, then confirm → the prompt closes and generation starts. */
+  await tier17.click();
+  await expect(tier17).toHaveAttribute('aria-pressed', 'true');
+  await page.getByRole('button', { name: 'Start generating', exact: true }).click();
+  await expect(heading).toBeHidden({ timeout: 5_000 });
+  /* Generation is live once a chapter-row "Generating" pill shows. */
+  await expect(page.locator('span', { hasText: /^Generating$/ }).first()).toBeVisible({
+    timeout: 20_000,
+  });
+});

--- a/src/modals/start-generation.tsx
+++ b/src/modals/start-generation.tsx
@@ -66,6 +66,7 @@ export function StartGenerationModal({ defaultTier, busy = false, onClose, onCon
                   key={t.id}
                   type="button"
                   onClick={() => setTier(t.id)}
+                  aria-pressed={tier === t.id}
                   data-testid={`start-gen-tier-${t.id}`}
                   className={`text-left p-3 rounded-2xl border transition-all min-h-[44px] ${tier === t.id ? 'border-peach bg-peach/6' : 'border-ink/10 hover:border-ink/20'}`}
                 >


### PR DESCRIPTION
## Summary

Adds the dedicated e2e spec for the #1160 voice-model prompt that was deferred when it shipped. The other generation specs only *dismiss* the prompt (`confirmTierPromptIfPresent`); this one asserts its own behaviour.

For a Qwen book (the mock upload-flow cast renders on Qwen), clicking "Approve cast & start generating" opens the prompt, and the spec asserts:
- the prompt appears with **both Qwen tiers**;
- the **cast-pin-aware default** is pre-selected (0.6B for a freshly-analysed, unpinned cast) via `aria-pressed`;
- selecting **1.7B** and confirming closes the prompt and **starts generation** (a chapter-row "Generating" pill appears).

Also adds `aria-pressed` to the modal's tier buttons — a small a11y improvement for the toggle-button group that doubles as the selection assertion.

## Test plan

- Verified green locally in a warm battery (`queue-modal` + this spec → 12 passed). Run in isolation it cold-start-flakes the *shared* `goToConfirm` upload helper (the `Start analysis` 5 s wait on a cold mock app), not my assertions — CI runs `workers: 1` + `retries: 2` with a warm webServer, where the goToConfirm specs are reliable.
- Frontend unit suite (3316) green via pre-commit. Full chromium e2e battery verified via cloud CI (`run-ci`).

Refs #1160

🤖 Generated with [Claude Code](https://claude.com/claude-code)