### PR TITLE
chore(frontend): migrate Tailwind v4 to the @tailwindcss/vite plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "devDependencies": {
         "@eslint/js": "^9",
         "@playwright/test": "^1.60.0",
-        "@tailwindcss/postcss": "^4.3.0",
+        "@tailwindcss/vite": "^4.3.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -67,19 +67,6 @@
       "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@alloc/quick-lru": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",
@@ -1800,18 +1787,19 @@
         "node": ">= 20"
       }
     },
-    "node_modules/@tailwindcss/postcss": {
+    "node_modules/@tailwindcss/vite": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.1.tgz",
-      "integrity": "sha512-dNJuNbdEJT/SWRuXTYP1WSamelsz3ztkUsdtWQPjrexysrTpaEPM40P/71knXiXLYEojqPOEGitVLLpPMS5T6A==",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.1.tgz",
+      "integrity": "sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
         "@tailwindcss/node": "4.3.1",
         "@tailwindcss/oxide": "4.3.1",
-        "postcss": "8.5.15",
         "tailwindcss": "4.3.1"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/@tanstack/react-virtual": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   "devDependencies": {
     "@eslint/js": "^9",
     "@playwright/test": "^1.60.0",
-    "@tailwindcss/postcss": "^4.3.0",
+    "@tailwindcss/vite": "^4.3.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,0 @@
-export default {
-  plugins: {
-    '@tailwindcss/postcss': {},
-  },
-};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig, loadEnv, type PluginOption } from 'vite';
 import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
 import mkcert from 'vite-plugin-mkcert';
 import { execSync } from 'node:child_process';
 import { createRequire } from 'node:module';
@@ -75,7 +76,10 @@ export default defineConfig(({ mode }) => {
   // (no VITE_HTTPS) keeps http://…:8080. VITE_API_PORT/PORT still override.
   const apiPort = Number(env.VITE_API_PORT ?? env.PORT ?? (useHttps ? 8443 : 8080));
   const apiTarget = `${useHttps ? 'https' : 'http'}://localhost:${apiPort}`;
-  const plugins: PluginOption[] = [react()];
+  // ops-20: Tailwind v4 runs through its dedicated Vite plugin rather than the
+  // `@tailwindcss/postcss` PostCSS pass (which executed inside vite:css). The
+  // Vite plugin hooks the pipeline directly, so postcss.config.js is gone.
+  const plugins: PluginOption[] = [react(), tailwindcss()];
   if (useHttps) plugins.push(mkcert());
   return {
     plugins,


### PR DESCRIPTION
## Summary

Migrates Tailwind v4 off the `@tailwindcss/postcss` PostCSS plugin to its dedicated **`@tailwindcss/vite`** plugin (Tailwind's recommended integration for Vite). Previously Tailwind's content-scan + CSS codegen ran as a PostCSS pass *inside* `vite:css`, which is what tripped Rolldown's `[PLUGIN_TIMINGS] significant time in plugin vite:css` hint (#1165). The Vite plugin hooks the pipeline directly; `postcss.config.js` held only the Tailwind plugin and is removed.

### Investigation finding

The `PLUGIN_TIMINGS` hint is a **cold-disk first-build artifact** — it fires only when `vite:css` is a large fraction of a truly cold build (disk caches cold). It does **not** reproduce on warm or cache-cleared builds (those already run ~1.1s with no hint). So this isn't a persistent inefficiency; the migration removes the PostCSS layer that caused it and moves onto Tailwind's supported path regardless.

### Measurements (isolated worktree, 3 cold-cache builds each)

| | vite build | CSS output | PLUGIN_TIMINGS |
|---|---|---|---|
| Before (`@tailwindcss/postcss`) | ~1.08–1.29s | `index-Dtb_3PgK.css` sha256 `6496fdbf…`, 128,644 B | (cold-only) |
| After (`@tailwindcss/vite`) | ~0.86–0.96s | **byte-identical** (same hash) | none |

~15–20% faster vite build; **CSS output is byte-identical** (same `@theme` tokens + utilities), so zero visual risk.

## Test plan

- `tsc -b` green (the `@tailwindcss/vite` import resolves types).
- 3× cold `vite build` → no `advancedChunks` warning, no `PLUGIN_TIMINGS`, no errors; `react` + `vendor` chunks intact (composes cleanly with ops-19's `codeSplitting`).
- CSS output sha256 identical before/after.
- Scoped pre-commit gate (frontend + server, 3806 tests) green.

Note: `postcss` stays a direct devDependency (base dep I didn't introduce); a follow-up could check whether it's now orphaned.

Closes #1165
