### PR TITLE
fix(server): wrap pair-redeem rate-limit keyGenerator in ipKeyGenerator

### DIFF
--- a/server/src/routes/pairing.test.ts
+++ b/server/src/routes/pairing.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import express from 'express';
+import { ipKeyGenerator } from 'express-rate-limit';
 import request from 'supertest';
+
+// supertest's loopback socket surfaces as the IPv4-mapped IPv6 address; the
+// redeemLimiter normalises that through ipKeyGenerator, so reset the SAME
+// normalised key (→ '127.0.0.1') or the per-IP bucket bleeds across cases.
+const LOOPBACK_KEY = ipKeyGenerator('::ffff:127.0.0.1');
 
 // A real self-signed cert (parses via node X509Certificate). Its SHA-256's
 // first 10 bytes Crockford-base32-encode to fpTag "5CEE77RAKV3EN9JX".
@@ -78,7 +84,7 @@ function appWith(router: express.Router) {
 describe('pairing routes', () => {
   beforeEach(() => {
     _resetPairingSessionsForTests();
-    redeemLimiter.resetKey('::ffff:127.0.0.1');
+    redeemLimiter.resetKey(LOOPBACK_KEY);
   });
 
   it('POST /session returns a qrPayload + code + fpTag', async () => {
@@ -199,7 +205,7 @@ function appWithPreGuardRouterFirst() {
 describe('pairing body-size cap — parser-order regression', () => {
   beforeEach(() => {
     _resetPairingSessionsForTests();
-    redeemLimiter.resetKey('::ffff:127.0.0.1');
+    redeemLimiter.resetKey(LOOPBACK_KEY);
   });
 
   // These two tests FAIL before the fix (global parser accepts the body, no 413)

--- a/server/src/routes/pairing.ts
+++ b/server/src/routes/pairing.ts
@@ -13,7 +13,7 @@ import { readFileSync } from 'node:fs';
 import { X509Certificate } from 'node:crypto';
 import { Router } from 'express';
 import express from 'express';
-import rateLimit from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import type { Request, Response } from '../http.js';
 import { isLanHttpsEnabled, enumerateLanUrls } from './export-lan.js';
 import { resolveRootCaPath } from './cert-root.js';
@@ -75,7 +75,11 @@ export const redeemLimiter = rateLimit({
   limit: 5,
   standardHeaders: true,
   legacyHeaders: false,
-  keyGenerator: (req) => req.ip ?? 'unknown',
+  // express-rate-limit v8 rejects a custom keyGenerator that reads the IP
+  // without the ipKeyGenerator helper (ERR_ERL_KEY_GEN_IPV6) — it normalises
+  // IPv6 to a /56 subnet so v6 clients can't bypass the cap by rotating the
+  // host bits. Fall back to 'unknown' only when req.ip is genuinely absent.
+  keyGenerator: (req) => (req.ip ? ipKeyGenerator(req.ip) : 'unknown'),
 });
 
 pairRedeemRouter.post('/redeem', redeemLimiter, express.json({ limit: '1kb' }), async (req: Request, res: Response) => {


### PR DESCRIPTION
## Summary

The LAN dev server crashed at startup (`[FAIL] Services did not come up within 60 s: server`). Root cause: `redeemLimiter` in `server/src/routes/pairing.ts` used `keyGenerator: (req) => req.ip ?? 'unknown'`. express-rate-limit v8 rejects a custom keyGenerator that reads the client IP without the `ipKeyGenerator` helper, throwing `ERR_ERL_KEY_GEN_IPV6` **at construction** (module import time, under every `NODE_ENV`). That threw before `listen()`, so the server never bound its port — and it reddened the entire `pairing.test.ts` suite, which imports `redeemLimiter`.

The helper normalises IPv6 to a `/56` subnet so v6 clients can't bypass the per-IP cap by rotating host bits. This wraps `req.ip` in `ipKeyGenerator`, keeping the `'unknown'` fallback only for when `req.ip` is genuinely absent.

Because the helper normalises supertest's loopback `::ffff:127.0.0.1` → `127.0.0.1`, the test's per-IP bucket resets now target the normalised key (`LOOPBACK_KEY`); otherwise the 429-after-5/min cases would bleed across tests.

## Test plan

- `pairing.test.ts` is the fails-before / passes-after regression: it can't even import today (construction throws); now **14/14 pass**, including the 429-after-5/min cases that route through the IPv6-mapped loopback key.
- Reproduced the throw in isolation under default/`production`/`test` `NODE_ENV`; verified the `ipKeyGenerator`-wrapped form constructs cleanly.
- Confirmed live: the running server on `:8443` returns `{"ok":true}` after the fix; it now boots past the import crash.
- `npm run verify` green except the known Windows-only `confirm`/`analysing` visual-baseline flake (a frontend-rendering leg unrelated to this server-only change — passed on isolated re-run, and clears on Linux CI).