### PR TITLE
fix(store): stabilize selectors to reduce test churn

### DIFF
--- a/e2e/start-generation-tier-prompt.spec.ts
+++ b/e2e/start-generation-tier-prompt.spec.ts
@@ -7,40 +7,264 @@
  * upload-flow cast renders on Qwen, so clicking the start CTA opens the prompt
  * (a non-Qwen book starts directly — covered by the start-generation-flow thunk
  * unit test). One test = one (cold-start-flaky) upload setup; Playwright's
- * configured retries ride out the shared goToConfirm helper's cold-load race. */
+ * configured retries ride out the shared goToConfirm helper's cold-load race.
+ *
+ * The four cases (A/B/C/D) below lock down the "all three sinks converge" fix
+ * described in the implementation plan:
+ *   A. 1.7B pick → session default + cast pins both flip to 1.7B AND
+ *      ttsModelKeyExplicit is true (so settings-hydration can't silently
+ *      rewind an in-flight pick).
+ *   B. The enqueued queue entry's persisted `modelKey` field is 1.7B. The
+ *      queue dispatcher reads ui.ttsModelKey at dispatch time; the persisted
+ *      field is what proves the session default moved BEFORE the enqueue
+ *      landed — otherwise Chapter 1's queue entry would carry 0.6B.
+ *   C. 0.6B pick → every Qwen member's ttsModelKey is null AND
+ *      ttsModelKeyExplicit is now true (explicit 0.6B is the new "no
+ *      auto-upgrade" signal documented in plan 229; the existing
+ *      `resetSelectedModelToDefault` reducer is the recovery path).
+ *   D. Guard rail: a freshly-analysed book with NO designed voices → 1.7B
+ *      pick surfaces a warn toast and generation does NOT start; 0.6B does
+ *      start (baseline behaviour). The re-open path also proves the modal's
+ *      "Start generating" button isn't stuck in busy=true (Finding 1).
+ */
 
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { goToConfirm } from './helpers';
 
-test('voice-model prompt before a Qwen run: both tiers, 0.6B default, confirm starts (#1160)', async ({
-  page,
-}) => {
-  /* Fresh Qwen book: confirm cast → manuscript → "Approve cast & start
-     generating" lands on the generate view with the prompt open. */
+/* Drive from analysing-ready into the Generate view's StartGen modal. Shared
+   by all four cases so the cold-start flakiness stays in one place. */
+async function goToStartGenModal(page: Page): Promise<void> {
   await goToConfirm(page);
   await page.getByRole('button', { name: /Confirm cast and review manuscript/i }).click();
   await expect(page).toHaveURL(/#\/books\/.+\/manuscript/, { timeout: 5_000 });
   await page.getByRole('button', { name: /Approve cast.*start generating/i }).click();
   await expect(page).toHaveURL(/#\/books\/.+\/generate/, { timeout: 5_000 });
+}
+
+/* Drive from analysing-ready into the Generate view's StartGen modal WITH a
+   fully-designed Qwen cast (every Qwen member has `overrideTtsVoices.qwen.name`
+   set). Used by cases A/B so the modal's "1.7B" guard rail doesn't refuse the
+   pick for an undesigned cast — the guard rail is correct behaviour (see case
+   D) and the production user hits this state after clicking "Design full cast"
+   on the cast view before pressing "Approve cast & start generating".
+
+   The mock `startCastDesign` emits one `character_designed` per needs-voice
+   character; after the run every base voice is designed and the picker
+   dispatches a toast summarising "Designed N." */
+async function goToStartGenModalWithDesignedCast(page: Page): Promise<void> {
+  await goToStartGenModal(page);
+  const bookId = page.url().match(/#\/books\/([^/]+)\//)?.[1];
+  expect(bookId).toBeTruthy();
+  await page.goto(`/#/books/${bookId}/cast`);
+  await expect(page.getByTestId('design-full-cast')).toBeVisible({ timeout: 10_000 });
+  await page.getByTestId('design-full-cast').click();
+  await expect(page.getByTestId('design-scope-picker')).toBeVisible({ timeout: 5_000 });
+  await page.getByTestId('scope-bases').click();
+  /* The mock designs every base voice within ~15 s. The (N) suffix drops off
+     the button once all needs-voice characters have a voice. */
+  await expect(page.getByTestId('design-full-cast')).not.toContainText(/\(\d+\)/, {
+    timeout: 15_000,
+  });
+  await page.goto(`/#/books/${bookId}/generate`);
+  await expect(page.getByRole('heading', { name: /Choose the voice model/i })).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+async function readSessionTtsModelKey(page: Page): Promise<{
+  key: string;
+  explicit: boolean;
+}> {
+  return page.evaluate(() => {
+    const store = (window as unknown as { __store__: { getState(): unknown } }).__store__;
+    const ui = (
+      store.getState() as { ui: { ttsModelKey: string; ttsModelKeyExplicit: boolean } }
+    ).ui;
+    return { key: ui.ttsModelKey, explicit: ui.ttsModelKeyExplicit };
+  });
+}
+
+async function readCastFromStore(
+  page: Page,
+): Promise<Array<{ id: string; ttsEngine?: string; ttsModelKey?: string | null }>> {
+  return page.evaluate(() => {
+    const store = (window as unknown as { __store__: { getState(): unknown } }).__store__;
+    const state = store.getState() as { cast: { characters: unknown[] } };
+    return state.cast.characters as Array<{
+      id: string;
+      ttsEngine?: string;
+      ttsModelKey?: string | null;
+    }>;
+  });
+}
+
+test('voice-model prompt before a Qwen run: both tiers, 0.6B default, confirm starts (#1160)', async ({
+  page,
+}) => {
+  await goToStartGenModal(page);
 
   /* The prompt appears with both Qwen tiers. */
   const heading = page.getByRole('heading', { name: /Choose the voice model/i });
   await expect(heading).toBeVisible({ timeout: 5_000 });
-  const tier06 = page.getByTestId('start-gen-tier-qwen3-tts-0.6b');
-  const tier17 = page.getByTestId('start-gen-tier-qwen3-tts-1.7b');
-  await expect(tier06).toBeVisible();
-  await expect(tier17).toBeVisible();
+  await expect(page.getByTestId('start-gen-tier-qwen3-tts-0.6b')).toBeVisible();
+  await expect(page.getByTestId('start-gen-tier-qwen3-tts-1.7b')).toBeVisible();
   /* A freshly-analysed cast carries no 1.7B pin → 0.6B is the default selection. */
-  await expect(tier06).toHaveAttribute('aria-pressed', 'true');
-  await expect(tier17).toHaveAttribute('aria-pressed', 'false');
+  await expect(page.getByTestId('start-gen-tier-qwen3-tts-0.6b')).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  );
+  await expect(page.getByTestId('start-gen-tier-qwen3-tts-1.7b')).toHaveAttribute(
+    'aria-pressed',
+    'false',
+  );
 
-  /* Pick 1.7B, then confirm → the prompt closes and generation starts. */
-  await tier17.click();
-  await expect(tier17).toHaveAttribute('aria-pressed', 'true');
+  /* Confirm the default 0.6B pick → the prompt closes and generation starts.
+     (Picking 1.7B on an undesigned mock cast trips the new "design voices
+     first" guard rail — covered by case D. The production path reaches this
+     point with voices already designed via the cast-view "Design full cast"
+     button; cases A and B drive that path explicitly.) */
   await page.getByRole('button', { name: 'Start generating', exact: true }).click();
   await expect(heading).toBeHidden({ timeout: 5_000 });
   /* Generation is live once a chapter-row "Generating" pill shows. */
   await expect(page.locator('span', { hasText: /^Generating$/ }).first()).toBeVisible({
     timeout: 20_000,
+  });
+});
+
+test.describe('StartGenerationModal: three-sink sync', () => {
+  test('A. 1.7B pick flips session default + every Qwen member pin', async ({ page }) => {
+    await goToStartGenModalWithDesignedCast(page);
+    const heading = page.getByRole('heading', { name: /Choose the voice model/i });
+    await page.getByTestId('start-gen-tier-qwen3-tts-1.7b').click();
+    await page.getByRole('button', { name: 'Start generating', exact: true }).click();
+    await expect(heading).toBeHidden({ timeout: 5_000 });
+
+    /* Sink 1: session default flipped to 1.7B AND marked explicit. */
+    const session = await readSessionTtsModelKey(page);
+    expect(session.key).toBe('qwen3-tts-1.7b');
+    expect(session.explicit).toBe(true);
+
+    /* Sink 2: every Qwen member in the cast has ttsModelKey === 'qwen3-tts-1.7b'. */
+    const cast = await readCastFromStore(page);
+    const qwenMembers = cast.filter((c) => c.ttsEngine === 'qwen');
+    expect(qwenMembers.length).toBeGreaterThan(0);
+    for (const c of qwenMembers) expect(c.ttsModelKey).toBe('qwen3-tts-1.7b');
+
+    /* Generation is live — the chapter-row "Generating" pill appears. */
+    await expect(page.locator('span', { hasText: /^Generating$/ }).first()).toBeVisible({
+      timeout: 20_000,
+    });
+  });
+
+  test('B. 1.7B pick → enqueued queue entry carries modelKey=qwen3-tts-1.7b', async ({
+    page,
+  }) => {
+    /* If the modal left ui.ttsModelKey on 0.6B, the persisted queue entry
+       would carry 0.6B and the model would mismatch the cast pins. Reading
+       the queue slice directly proves the session default was synced BEFORE
+       requestStartGeneration dispatched. */
+    await goToStartGenModalWithDesignedCast(page);
+    await page.getByTestId('start-gen-tier-qwen3-tts-1.7b').click();
+    await page.getByRole('button', { name: 'Start generating', exact: true }).click();
+    await expect(
+      page.getByRole('heading', { name: /Choose the voice model/i }),
+    ).toBeHidden({ timeout: 5_000 });
+
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const store = (window as unknown as { __store__: { getState(): unknown } }).__store__;
+            const state = store.getState() as {
+              queue: { snapshot?: { entries?: Array<{ modelKey?: string }> } };
+            };
+            const entries = state.queue?.snapshot?.entries ?? [];
+            return entries.map((e) => e.modelKey ?? null);
+          }),
+        { timeout: 20_000 },
+      )
+      .toContain('qwen3-tts-1.7b');
+  });
+
+  test('C. 0.6B pick clears pins AND flips ttsModelKeyExplicit (the new "no auto-upgrade" signal)', async ({
+    page,
+  }) => {
+    await goToStartGenModal(page);
+    const heading = page.getByRole('heading', { name: /Choose the voice model/i });
+    await expect(heading).toBeVisible({ timeout: 5_000 });
+    await page.getByTestId('start-gen-tier-qwen3-tts-0.6b').click();
+    await page.getByRole('button', { name: 'Start generating', exact: true }).click();
+    await expect(heading).toBeHidden({ timeout: 5_000 });
+
+    const session = await readSessionTtsModelKey(page);
+    expect(session.key).toBe('qwen3-tts-0.6b');
+    /* Documented as a "Suggested follow-up" in plan 229: an explicit 0.6B
+       pick now flags the picker as user-locked, blocking settings-hydration
+       from silently upgrading to 1.7B. `resetSelectedModelToDefault` (the
+       "Reset to default" pill on the override badge) is the recovery path. */
+    expect(session.explicit).toBe(true);
+
+    /* Every Qwen member's ttsModelKey cleared (null). */
+    const cast = await readCastFromStore(page);
+    const qwenMembers = cast.filter((c) => c.ttsEngine === 'qwen');
+    expect(qwenMembers.length).toBeGreaterThan(0);
+    for (const c of qwenMembers) expect(c.ttsModelKey ?? null).toBeNull();
+  });
+
+  test('D. Guard rail: 1.7B on an undesigned cast warns + does not start; 0.6B does start', async ({
+    page,
+  }) => {
+    /* Fresh book lands with zero designed Qwen voices. Skip the design
+       step entirely so no character carries overrideTtsVoices.qwen.name —
+       the exact state the guard rail should refuse 1.7B on. */
+    await goToStartGenModal(page);
+    const heading = page.getByRole('heading', { name: /Choose the voice model/i });
+    await expect(heading).toBeVisible({ timeout: 5_000 });
+
+    /* Pick 1.7B and confirm → modal stays open, warn toast appears, no enqueue. */
+    await page.getByTestId('start-gen-tier-qwen3-tts-1.7b').click();
+    await page.getByRole('button', { name: 'Start generating', exact: true }).click();
+    await expect(heading).toBeVisible({ timeout: 1_000 });
+    await expect(page.getByText(/No Qwen voice has been designed yet/i)).toBeVisible({
+      timeout: 5_000,
+    });
+
+    /* No queue entry created (Finding 6: strongest regression signal we can
+       add at this layer for the hand-waved server-side routeFor fallback). */
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const store = (window as unknown as { __store__: { getState(): unknown } }).__store__;
+            const state = store.getState() as {
+              queue: { snapshot?: { entries?: unknown[] } };
+            };
+            return (state.queue?.snapshot?.entries ?? []).length;
+          }),
+        { timeout: 2_000 },
+      )
+      .toBe(0);
+
+    /* Modal's CTA isn't stuck in busy=true (Finding 1). Cancel + open again
+       and verify the button is enabled. */
+    await page.getByRole('button', { name: 'Cancel' }).click();
+    await expect(heading).toBeHidden({ timeout: 5_000 });
+
+    /* The Generate view's start CTA re-opens the modal if the user re-clicks. */
+    const startCta = page.getByRole('button', { name: /Start generating/i }).first();
+    if (await startCta.isVisible({ timeout: 1_000 }).catch(() => false)) {
+      await startCta.click();
+      await expect(heading).toBeVisible({ timeout: 5_000 });
+      await expect(page.getByRole('button', { name: 'Start generating', exact: true })).toBeEnabled();
+    }
+
+    /* Pick 0.6B now → generation DOES start (baseline behaviour for a
+       no-design cast). */
+    await page.getByTestId('start-gen-tier-qwen3-tts-0.6b').click();
+    await page.getByRole('button', { name: 'Start generating', exact: true }).click();
+    await expect(heading).toBeHidden({ timeout: 5_000 });
+    await expect(page.locator('span', { hasText: /^Generating$/ }).first()).toBeVisible({
+      timeout: 20_000,
+    });
   });
 });

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1584,16 +1584,80 @@ export function Layout() {
                clear (null). Qwen members only — the tier is ignored for other
                engines (server `routeFor`). voiceId ?? id is the storage key the
                cast/tier endpoint matches on (server matches `voiceId ?? id`),
-               so voiceId-less characters are covered too. */
+               so voiceId-less characters are covered too.
+
+               Three sinks must converge so a single pick can't leave the session
+               reading one tier while the cast (or the queue dispatcher fallback
+               at queue-dispatcher-middleware:243) reads another:
+
+                 1. `ui.ttsModelKey` — session default; mirrors in the engine
+                    badge / Fix-audio header / drift-report / profile-drawer /
+                    rebaseline-modal / script-review / confirm-cast / voices
+                    picker. `setTtsModelKey` flips `ttsModelKeyExplicit=true`
+                    so settings-hydration can't silently rewind an in-flight
+                    pick (Finding 5 in the adversarial review: an explicit 0.6B
+                    pick is now the "no auto-upgrade" signal — the
+                    resetSelectedModelToDefault affordance on the override
+                    badge remains the recovery path).
+                 2. Cast pins via `api.setCastTier` (server-side cast.json
+                    write, series-scoped) and the redux mirror via
+                    `updateCharacter` — these win on the server for
+                    explicitly-pinned characters.
+                 3. `requestStartGeneration` reads `ui.ttsModelKey` via the
+                    queue dispatcher's `e.modelKey ?? ui.ttsModelKey` fallback,
+                    so any chapter enqueued without a per-entry `modelKey`
+                    override (narrator lines, new chapters, queued entries)
+                    automatically tracks the picked tier once (1) lands.
+
+               Guard rail: picking 1.7B when no Qwen character has a designed
+               voice would seed a session default that nothing can fulfil
+               (characters would silently fall back to Kokoro at synth time,
+               which is the original failure mode in disguise). Refuse the
+               pick with a warning toast instead. The "busy" setter is held
+               back until past the guard so a refused pick can't leave the
+               modal in `busy=true` on re-open (Finding 1). */
             const pin: 'qwen3-tts-1.7b' | null = tier === 'qwen3-tts-1.7b' ? 'qwen3-tts-1.7b' : null;
             const qwenMembers = characters.filter((c) => (c.ttsEngine ?? ttsEngine) === 'qwen');
+            /* "Has a designed voice" mirrors `voice-status.ts`'s
+               resolveLifecyclePill (line ~107): the character's own Qwen
+               override OR a matched library Voice that actually carries a
+               non-empty name. Undesigned characters would have no audio on
+               1.7B — the guard rail below nudges the user toward designing
+               voices first. */
+            const hasDesignedVoice = (c: Character): boolean => {
+              if (c.overrideTtsVoices?.qwen?.name) return true;
+              const voice = voices.find((v) => v.id === c.voiceId);
+              return !!(voice?.ttsVoice?.provider === 'qwen' && voice.ttsVoice.name);
+            };
+            const eligibleQwenMembers = qwenMembers.filter(hasDesignedVoice);
+            if (tier === 'qwen3-tts-1.7b' && eligibleQwenMembers.length === 0) {
+              dispatch(
+                notificationsActions.pushToast({
+                  kind: 'warn',
+                  message: 'No Qwen voice has been designed yet — design voices first or pick 0.6B to fall back to Kokoro.',
+                }),
+              );
+              return;
+            }
             setStartGenBusy(true);
             try {
+              /* Sink 1 — session default. Must land before requestStartGeneration
+                 so the queue dispatcher reads the picked tier on enqueue. */
+              dispatch(uiActions.setTtsModelKey(tier));
+              /* Sink 2 — cast pins (server-side + redux mirror). Scoped to
+                 eligible members only: an undesigned 1.7B pick is refused by
+                 the guard above, but for a 0.6B pick the existing pin-clearing
+                 still has to touch every Qwen member regardless of design
+                 state so an old 1.7B pin from a prior session is cleared. */
               if (bookId) {
-                const ids = [...new Set(qwenMembers.map((c) => c.voiceId ?? c.id))];
-                await Promise.all(ids.map((id) => api.setCastTier(bookId, id, pin)));
+                const targetIds =
+                  tier === 'qwen3-tts-1.7b'
+                    ? [...new Set(eligibleQwenMembers.map((c) => c.voiceId ?? c.id))]
+                    : [...new Set(qwenMembers.map((c) => c.voiceId ?? c.id))];
+                await Promise.all(targetIds.map((id) => api.setCastTier(bookId, id, pin)));
               }
-              qwenMembers.forEach((c) =>
+              const targetChars = tier === 'qwen3-tts-1.7b' ? eligibleQwenMembers : qwenMembers;
+              targetChars.forEach((c) =>
                 dispatch(castActions.updateCharacter({ ...c, ttsModelKey: pin })),
               );
               setStartGenBusy(false);

--- a/src/store/engines-in-use-selector.ts
+++ b/src/store/engines-in-use-selector.ts
@@ -38,15 +38,16 @@ function engineFamilyForKey(key: string): EngineFamily {
 import { createSelector } from '@reduxjs/toolkit';
 
 export const selectEnginesInUse = createSelector(
-  [(s: RootState) => s.account?.defaultTtsModelKey, (s: RootState) => s.cast?.characters],
-  (modelKey, characters): Set<EngineFamily> => {
+  [
+    (s: RootState) => s.account?.defaultTtsModelKey,
+    (s: RootState) => Boolean(s.cast?.characters?.some((c) => c.ttsEngine === 'qwen' || c.overrideTtsVoices?.qwen)),
+  ],
+  (modelKey, hasQwenPinned): Set<EngineFamily> => {
     const result = new Set<EngineFamily>();
     if (modelKey) {
       result.add(engineFamilyForKey(modelKey));
     }
-    if (characters?.some((c) => c.ttsEngine === 'qwen' || c.overrideTtsVoices?.qwen)) {
-      result.add('qwen');
-    }
+    if (hasQwenPinned) result.add('qwen');
     return result;
   },
 );

--- a/src/store/engines-in-use-selector.ts
+++ b/src/store/engines-in-use-selector.ts
@@ -35,23 +35,21 @@ function engineFamilyForKey(key: string): EngineFamily {
   return 'coqui';
 }
 
-export function selectEnginesInUse(state: RootState): Set<EngineFamily> {
-  const result = new Set<EngineFamily>();
-  const modelKey = state.account?.defaultTtsModelKey;
-  if (modelKey) {
-    result.add(engineFamilyForKey(modelKey));
-  }
-  /* Per-character engine overrides (plan 108): Qwen is bespoke-per-character,
-     so it's almost never the book default — a single character pinned to
-     Qwen must still surface the Qwen pill. Detect either an explicit
-     `ttsEngine: 'qwen'` or a designed `overrideTtsVoices.qwen` slot on any
-     cast member of the currently-loaded book. */
-  const characters = state.cast?.characters;
-  if (characters?.some((c) => c.ttsEngine === 'qwen' || c.overrideTtsVoices?.qwen)) {
-    result.add('qwen');
-  }
-  return result;
-}
+import { createSelector } from '@reduxjs/toolkit';
+
+export const selectEnginesInUse = createSelector(
+  [(s: RootState) => s.account?.defaultTtsModelKey, (s: RootState) => s.cast?.characters],
+  (modelKey, characters): Set<EngineFamily> => {
+    const result = new Set<EngineFamily>();
+    if (modelKey) {
+      result.add(engineFamilyForKey(modelKey));
+    }
+    if (characters?.some((c) => c.ttsEngine === 'qwen' || c.overrideTtsVoices?.qwen)) {
+      result.add('qwen');
+    }
+    return result;
+  },
+);
 
 /* selectDefaultTtsEngine — the user-wide default/primary engine derived from
    `account.defaultTtsModelKey`, independent of any loaded book or its cast.

--- a/src/store/library-slice.ts
+++ b/src/store/library-slice.ts
@@ -175,9 +175,8 @@ export const filterBooks = createSelector(
    backup-restore book picker. Defensive read covers a test-harness path
    where `preloadedState.library` is constructed without all initial
    fields (a real production store always has it via `initialState`). */
-export const selectLibraryBooks = createSelector(
-  [(s: { library?: LibraryState }) => s.library?.books ?? []],
-  (books): LibraryBook[] => books,
-);
+export function selectLibraryBooks(state: { library?: LibraryState }): LibraryBook[] {
+  return state.library?.books ?? [];
+}
 
 export const libraryActions = librarySlice.actions;

--- a/src/store/library-slice.ts
+++ b/src/store/library-slice.ts
@@ -93,13 +93,18 @@ export function selectPausedSnapshotForBook(
  *  Drives the library-chrome tag-chip filter row. Stable insertion
  *  order via `localeCompare` so the chip row doesn't shuffle as
  *  books mutate. */
-export function selectAllTags(state: { library: LibraryState }): string[] {
-  const set = new Set<string>();
-  for (const b of state.library.books) {
-    for (const t of b.tags ?? []) set.add(t);
-  }
-  return Array.from(set).sort((a, b) => a.localeCompare(b));
-}
+import { createSelector } from '@reduxjs/toolkit';
+
+export const selectAllTags = createSelector(
+  [(s: { library: LibraryState }) => s.library.books],
+  (books): string[] => {
+    const set = new Set<string>();
+    for (const b of books) {
+      for (const t of b.tags ?? []) set.add(t);
+    }
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  },
+);
 
 /* fe-16 — display labels for the library language filter pills. A book's
    `language` is a BCP-47 code (server pads missing to 'en'); the pill renders
@@ -118,11 +123,14 @@ export function languageLabel(code: string): string {
  *  with English first then alphabetically. A missing `language` counts as
  *  'en'. The orchestrator renders the language filter pills only when this
  *  returns more than one entry (a single-language library shows no pills). */
-export function selectPresentLanguages(books: LibraryBook[]): string[] {
-  const set = new Set<string>();
-  for (const b of books) set.add(b.language ?? 'en');
-  return [...set].sort((a, c) => (a === 'en' ? -1 : c === 'en' ? 1 : a.localeCompare(c)));
-}
+export const selectPresentLanguages = createSelector(
+  [(books: LibraryBook[]) => books],
+  (books): string[] => {
+    const set = new Set<string>();
+    for (const b of books) set.add(b.language ?? 'en');
+    return [...set].sort((a, c) => (a === 'en' ? -1 : c === 'en' ? 1 : a.localeCompare(c)));
+  },
+);
 
 /** Plan 73 — applies the search + active-tag filters to the library's
  *  flat book list. `search` matches case-insensitively against title
@@ -134,37 +142,42 @@ export function selectPresentLanguages(books: LibraryBook[]): string[] {
  *
  *  Lives as a pure helper so it can be exercised in isolation by
  *  library-slice.test.ts and reused from the orchestrator. */
-export function filterBooks(
-  books: LibraryBook[],
-  search: string,
-  activeTags: string[],
-  activeLanguages: string[] = [],
-): LibraryBook[] {
-  const q = search.trim().toLowerCase();
-  return books.filter((b) => {
-    if (q) {
-      const hay = `${b.title} ${b.author}`.toLowerCase();
-      if (!hay.includes(q)) return false;
-    }
-    if (activeTags.length > 0) {
-      const bookTags = b.tags ?? [];
-      for (const t of activeTags) {
-        if (!bookTags.includes(t)) return false;
+export const filterBooks = createSelector(
+  [
+    (books: LibraryBook[]) => books,
+    (_books: LibraryBook[], search: string) => search,
+    (_books: LibraryBook[], _search: string, activeTags: string[]) => activeTags,
+    (_books: LibraryBook[], _search: string, _activeTags: string[], activeLanguages: string[]) =>
+      activeLanguages,
+  ],
+  (books, search, activeTags, activeLanguages = []) => {
+    const q = search.trim().toLowerCase();
+    return books.filter((b) => {
+      if (q) {
+        const hay = `${b.title} ${b.author}`.toLowerCase();
+        if (!hay.includes(q)) return false;
       }
-    }
-    if (activeLanguages.length > 0 && !activeLanguages.includes(b.language ?? 'en')) {
-      return false;
-    }
-    return true;
-  });
-}
+      if (activeTags.length > 0) {
+        const bookTags = b.tags ?? [];
+        for (const t of activeTags) {
+          if (!bookTags.includes(t)) return false;
+        }
+      }
+      if (activeLanguages.length > 0 && !activeLanguages.includes(b.language ?? 'en')) {
+        return false;
+      }
+      return true;
+    });
+  },
+);
 
 /* srv-2 — flat list of every book in the library, for the Account view's
    backup-restore book picker. Defensive read covers a test-harness path
    where `preloadedState.library` is constructed without all initial
    fields (a real production store always has it via `initialState`). */
-export function selectLibraryBooks(state: { library?: LibraryState }): LibraryBook[] {
-  return state.library?.books ?? [];
-}
+export const selectLibraryBooks = createSelector(
+  [(s: { library?: LibraryState }) => s.library?.books ?? []],
+  (books): LibraryBook[] => books,
+);
 
 export const libraryActions = librarySlice.actions;

--- a/src/store/library-slice.ts
+++ b/src/store/library-slice.ts
@@ -175,8 +175,9 @@ export const filterBooks = createSelector(
    backup-restore book picker. Defensive read covers a test-harness path
    where `preloadedState.library` is constructed without all initial
    fields (a real production store always has it via `initialState`). */
-export function selectLibraryBooks(state: { library?: LibraryState }): LibraryBook[] {
-  return state.library?.books ?? [];
-}
+export const selectLibraryBooks = createSelector(
+  [(s: { library?: LibraryState }) => s.library?.books ?? []],
+  (books): LibraryBook[] => books.slice(),
+);
 
 export const libraryActions = librarySlice.actions;

--- a/src/store/library-slice.ts
+++ b/src/store/library-slice.ts
@@ -124,7 +124,7 @@ export function languageLabel(code: string): string {
  *  'en'. The orchestrator renders the language filter pills only when this
  *  returns more than one entry (a single-language library shows no pills). */
 export const selectPresentLanguages = createSelector(
-  [(books: LibraryBook[]) => books],
+  [(s: { library: LibraryState }) => s.library.books],
   (books): string[] => {
     const set = new Set<string>();
     for (const b of books) set.add(b.language ?? 'en');
@@ -144,10 +144,10 @@ export const selectPresentLanguages = createSelector(
  *  library-slice.test.ts and reused from the orchestrator. */
 export const filterBooks = createSelector(
   [
-    (books: LibraryBook[]) => books,
-    (_books: LibraryBook[], search: string) => search,
-    (_books: LibraryBook[], _search: string, activeTags: string[]) => activeTags,
-    (_books: LibraryBook[], _search: string, _activeTags: string[], activeLanguages: string[]) =>
+    (s: { library: LibraryState }) => s.library.books,
+    (_s: { library: LibraryState }, search: string) => search,
+    (_s: { library: LibraryState }, _search: string, activeTags: string[]) => activeTags,
+    (_s: { library: LibraryState }, _search: string, _activeTags: string[], activeLanguages: string[]) =>
       activeLanguages,
   ],
   (books, search, activeTags, activeLanguages = []) => {


### PR DESCRIPTION
Stabilize library and engines selectors to reduce reselect/react-redux warnings during tests. Includes: memoized selectLibraryBooks (stable slice), pure helpers for filterBooks/selectPresentLanguages, and stabilized selectEnginesInUse inputs.