### PR TITLE
fix(frontend,e2e): unbreak main — realign admin TRENDS_COLS + quarantine flaky tier-prompt e2e

### DIFF
--- a/docs/testing/flaky-register.md
+++ b/docs/testing/flaky-register.md
@@ -8,4 +8,4 @@ Empty register = done. See the rewrite playbook in
 
 | Test | File | Class | Symptom | Tracking issue | Quarantined |
 |------|------|-------|---------|----------------|-------------|
-| _(none)_ | | | | | |
+| StartGenerationModal voice-model prompt + three-sink sync (all 6 cases) | `e2e/start-generation-tier-prompt.spec.ts` | cold-load race | `goToConfirm`/`goToStartGenModal` cold-load race exhausts Playwright retries under battery/cold-webServer load; the `Choose the voice model` heading never appears → gate red. Fails 1/6 in the full battery, 5/6 in isolation. | [#1178](https://github.com/dudarenok-maker/Castwright/issues/1178) | 2026-06-30 |

--- a/e2e/start-generation-tier-prompt.spec.ts
+++ b/e2e/start-generation-tier-prompt.spec.ts
@@ -1,5 +1,14 @@
 /* Dedicated e2e for the pre-generation voice-model prompt (#1160 StartGenerationModal).
  *
+ * QUARANTINED (#1178, 2026-06-30): every case is tagged `@quarantine` so the
+ * gating `test:e2e` grep-inverts it out. The shared `goToConfirm`/
+ * `goToStartGenModal` cold-load race exhausts Playwright's retries under
+ * battery / cold-webServer load (fails 1/6 in the full battery, 5/6 in
+ * isolation), reddening the gate on unrelated pushes. Run on demand via
+ * `npm run test:e2e:quarantine`. De-quarantine once `goToStartGenModal` waits
+ * on an explicit ready signal instead of implicit cold-load timing; see the
+ * flaky-register rewrite playbook.
+ *
  * The other generation specs only DISMISS the prompt (confirmTierPromptIfPresent);
  * this spec asserts the prompt's OWN behaviour: for a Qwen book it appears before
  * the run starts, offers both Qwen tiers with the cast-pin-aware default
@@ -98,7 +107,7 @@ async function readCastFromStore(
   });
 }
 
-test('voice-model prompt before a Qwen run: both tiers, 0.6B default, confirm starts (#1160)', async ({
+test('voice-model prompt before a Qwen run: both tiers, 0.6B default, confirm starts (#1160) @quarantine', async ({
   page,
 }) => {
   await goToStartGenModal(page);
@@ -131,7 +140,7 @@ test('voice-model prompt before a Qwen run: both tiers, 0.6B default, confirm st
   });
 });
 
-test.describe('StartGenerationModal: three-sink sync', () => {
+test.describe('StartGenerationModal: three-sink sync @quarantine', () => {
   test('A. 1.7B pick flips session default + every Qwen member pin', async ({ page }) => {
     await goToStartGenModalWithDesignedCast(page);
     const heading = page.getByRole('heading', { name: /Choose the voice model/i });

--- a/src/views/admin.test.tsx
+++ b/src/views/admin.test.tsx
@@ -355,7 +355,7 @@ describe('AdminView — table scroll regions + header alignment', () => {
      the data rows instead of drifting on the scrollbar gutter + independent
      `auto` columns. */
   const THROUGHPUT_COLS = 'md:grid-cols-[1fr_7rem_3.5rem_3.5rem_auto]';
-  const TRENDS_COLS = 'sm:grid-cols-[1fr_3rem_3.5rem_auto]';
+  const TRENDS_COLS = 'sm:grid-cols-[1fr_7rem_3rem_3.5rem_auto]';
 
   it('scrolls the generation-throughput rows in the inset thin-scrollbar region', async () => {
     mockStats.mockResolvedValue({


### PR DESCRIPTION
## Summary

Closes off two regressions left by yesterday's (2026-06-29) delivery that together left `main` red on the pre-push gate.

**1. `admin.test.tsx` realigned (Closes #1176).** PR #1173 (admin model-name telemetry) inserted the Engine column into the Resource Trends grid, widening the row/header template at `src/views/admin.tsx:85` to `sm:grid-cols-[1fr_7rem_3rem_3.5rem_auto]`, but did not update the paired alignment assertion `TRENDS_COLS` in `admin.test.tsx:358`. The new file's own test passed, so the sibling-file regression slipped through and `npm run verify` went red. One-line test-constant realign; no component change.

**2. Quarantined the flaky tier-prompt e2e (Refs #1178).** `e2e/start-generation-tier-prompt.spec.ts` (the #1160/#1174 StartGenerationModal net added by PR #1175) is gating but cold-start-flaky — it fails 1/6 in the full pre-push e2e battery and 5/6 in isolation because the shared `goToConfirm`/`goToStartGenModal` cold-load race exhausts Playwright's retries. All five cases are tagged `@quarantine` so the gating `test:e2e` grep-inverts them out; they still run on demand via `npm run test:e2e:quarantine`. Added the flaky-register row and a header banner with the de-quarantine criteria. A follow-up PR will make the helper deterministic and graduate the spec back (#1178).

## Test plan

- `npx vitest run src/views/admin.test.tsx` → 20/20 (was 1 failed).
- Full frontend suite green (3319/3319) at pre-commit.
- Quarantine routing verified via `--list`: 0 tier-prompt cases in the gating `test:e2e` grep, all 5 in the `test:e2e:quarantine` lane.
- `run-ci` label added for a clean-room cloud verify (the local pre-push battery kept getting interrupted by session boundaries before completing; the cloud run is the gating confirmation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)