### PR TITLE
feat(sidecar,server): multi-GPU Wave 1 placement and card visibility

### DIFF
--- a/docs/superpowers/plans/2026-06-27-multi-gpu-wave1-placement-visibility.md
+++ b/docs/superpowers/plans/2026-06-27-multi-gpu-wave1-placement-visibility.md
@@ -853,3 +853,19 @@ git commit -m "feat(sidecar): guard out-of-range cuda index + Wave 1 acceptance 
 **Type consistency:** `_parse_device → (family, index)` consumed identically in Tasks 4–10. `_engine_actual_card → {family,index,fell_back}` (Task 8) consumed by `_resident_engines_by_card` (Task 9). `_enumerate_cuda_devices`/`_sample_card` dict shape (Task 7) extended additively in Task 9. `_kokoro_provider_options` may return `list | (providers, options) tuple | None` — handled explicitly at the Task 6 call site.
 
 **Remaining execution-time reads (flagged, not hidden):** Task 5 must match `_resolve_runtime_options`'s real return/attr shape; Task 6 Step 1 spike decides the Kokoro kwarg; Task 8's Kokoro `_kokoro_session_device` reconciliation and Task 9's health-handler invocation follow the existing `test_runtime_wiring.py` pattern — the implementer reads those before writing.
+
+---
+
+## Ship notes — Wave 1 on-box acceptance (2-GPU)
+
+Run on the box with **RTX 4070 Laptop 8GB** (`cuda:0` after the `CUDA_VISIBLE_DEVICES=1,0` map → 16GB becomes `cuda:0`) + **RTX 5070 Ti 16GB**. Each knob is `apply:'restart-sidecar'` — set it in `server/.env`, restart the sidecar, then check:
+
+- [ ] `GET /api/gpu/devices` lists both cards with correct names + total_mb (≈8000 / 16000) and a live free_mb.
+- [ ] `QWEN_DEVICE=cuda:1` + restart → `/health` gpus[] shows qwen resident actual_card=1 (real torch index).
+- [ ] `COQUI_DEVICE=cuda:1` + a Coqui synth → logs show half=True deepspeed=True (no perf regression).
+- [ ] `ASR_DEVICE=cuda:1` + transcribe → no CTranslate2 error; semaphore token taken.
+- [ ] `SPK_DEVICE=cuda:1` + embed → ECAPA on cuda:1 (no degrade warning).
+- [ ] `KOKORO_DEVICE=cuda:1` + synth → nvidia-smi shows VRAM on card 1; gpus[] kokoro NOT flagged cpu_fallback.
+- [ ] `KOKORO_DEVICE=cuda:9` (no such card) → gpus[] flags kokoro stale_reason=cpu_fallback; serves from CPU; no crash.
+- [ ] `QWEN_DEVICE=cuda:9` → load surfaces a clear "out of range" error; sidecar does NOT crash-loop.
+- [ ] Diff `/health` against a pre-Wave-1 capture: every prior field unchanged; only `gpus` added.

--- a/docs/superpowers/plans/2026-06-27-multi-gpu-wave1-placement-visibility.md
+++ b/docs/superpowers/plans/2026-06-27-multi-gpu-wave1-placement-visibility.md
@@ -1,0 +1,756 @@
+# Multi-GPU Wave 1 — Placement & Visibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every TTS-sidecar engine *placeable* on a specific GPU (or CPU) via a config knob, and make the cards + each engine's *actual* resident device *visible* — with no per-card safety logic and no UI (those are Wave 2 / Plan 2).
+
+**Architecture:** Add/​widen the per-engine device knobs (Node registry), teach the two Node VRAM-gate helpers to recognise an indexed `cuda:N` value, fix the sidecar's inline `== "cuda"` device tests so an indexed pin actually reaches each engine's native device API (torch `.to`, CTranslate2 `device_index`, speechbrain `run_opts`, ONNX-Runtime `provider_options device_id`), expose a `GET /devices` enumeration, and extend `/health` with a `gpus[]` array reporting each engine's *actual* resident card.
+
+**Tech Stack:** Python 3.12 sidecar (FastAPI/Starlette, torch, faster-whisper/CTranslate2, kokoro-onnx, speechbrain), pytest. Node 20 server (TypeScript, Express, undici), Vitest.
+
+## Global Constraints
+
+- **Source of truth is the design spec:** `docs/superpowers/specs/2026-06-27-multi-gpu-per-model-design.md` (Plan 1 / Wave 1, §1.1–1.5). Every task implements a numbered spec item.
+- **Apply semantics:** all device knobs are `apply:'restart-sidecar'`. A knob value set in `server/.env` needs a *server* restart; a config override needs only a *sidecar* restart. Wave 1 ships no UI — pins are exercised via `server/.env` or env vars.
+- **Engine device dialects are NOT uniform** — torch (`cuda:N` via `.to`), CTranslate2 (`device="cuda"` + `device_index=N`, **raises on a bad index — no silent CPU fallback**), speechbrain (`run_opts={"device":"cuda:N"}`), ONNX-Runtime (`provider_options=[{"device_id":N}]`).
+- **Actual-card *index* readback is torch-only.** ORT (Kokoro) and CTranslate2 (Whisper) expose **family + a `fell_back` flag** only — never an index. Do not promise an index for them.
+- **`stale_reason` is an enum:** `cpu_fallback | env_shadow | uuid_unresolved`. Wave 1 sets only `cpu_fallback`; the other two are Plan 2.
+- **Additive, non-breaking telemetry:** the existing `/health` `devices` field (engine→family map) and every existing field MUST stay unchanged. Add a new `gpus[]` key; do not repurpose `devices`.
+- **Testing discipline (CLAUDE.md):** every behaviour change ships a paired automated test; a bug-shaped fix ships a test that fails before and passes after. Sidecar tests live in `server/tts-sidecar/tests/`; server tests colocate as `*.test.ts`.
+- **Commit convention:** `<type>(<scope>): <subject>`; scopes used here are `sidecar`, `server`. No `--no-verify`.
+- **No hex colour literals / OpenAPI is the type source** — not relevant to Wave 1 (no UI, no new API shapes in `openapi.yaml`; `/devices` is a sidecar-internal route proxied like `/health`).
+- **Kokoro `device_id` is contingent** on the pinned `kokoro-onnx` accepting `provider_options`; Task 5 begins with a verification spike and carries an `InferenceSession` fallback.
+
+---
+
+### Task 1: Device knobs — widen two, add two
+
+**Files:**
+- Modify: `server/src/config/registry.ts` (the `tts.coqui.device` knob ~424-432, the `qa.speaker.device` knob ~271-286; add `tts.kokoro.device` and `qa.asr.device`)
+- Test: `server/src/config/registry.test.ts` (or the existing registry/resolver test file — locate with `grep -rl "tts.coqui.device" server/src/config`)
+
+**Interfaces:**
+- Consumes: the existing `Knob` type + `resolveKnob`/`resolveAll` from `server/src/config/`.
+- Produces: four string device knobs whose env vars are `COQUI_DEVICE`, `SPK_DEVICE`, `KOKORO_DEVICE`, `ASR_DEVICE`, each `type:'string'`, `apply:'restart-sidecar'`. Later tasks (2, 5) read `KOKORO_DEVICE`/`ASR_DEVICE` from the sidecar env; the Node gates (Task 2) read `ASR_DEVICE`/`SPK_DEVICE`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the registry test file:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { resolveKnob, findKnob } from './registry'; // adjust import to the file's actual exports
+
+describe('multi-GPU device knobs (Wave 1)', () => {
+  it('COQUI_DEVICE is a string knob that accepts an indexed cuda value', () => {
+    const knob = findKnob('tts.coqui.device');
+    expect(knob.type).toBe('string');
+    const st = resolveKnob(knob, { 'tts.coqui.device': 'cuda:1' });
+    expect(st.effective).toBe('cuda:1');
+  });
+
+  it('SPK_DEVICE is a string knob (no longer enum cpu|cuda)', () => {
+    const knob = findKnob('qa.speaker.device');
+    expect(knob.type).toBe('string');
+    expect(resolveKnob(knob, { 'qa.speaker.device': 'cuda:1' }).effective).toBe('cuda:1');
+  });
+
+  it('adds KOKORO_DEVICE (string, restart-sidecar, default auto)', () => {
+    const knob = findKnob('tts.kokoro.device');
+    expect(knob.env).toBe('KOKORO_DEVICE');
+    expect(knob.type).toBe('string');
+    expect(knob.apply).toBe('restart-sidecar');
+    expect(knob.default).toBe('auto');
+  });
+
+  it('adds ASR_DEVICE registry knob (string, restart-sidecar, default cpu)', () => {
+    const knob = findKnob('qa.asr.device');
+    expect(knob.env).toBe('ASR_DEVICE');
+    expect(knob.type).toBe('string');
+    expect(knob.apply).toBe('restart-sidecar');
+    expect(knob.default).toBe('cpu');
+  });
+});
+```
+
+> If the test file uses a different accessor than `findKnob`/`resolveKnob`, copy the pattern already in that file (it definitely resolves a knob by key and reads `.type`/`.effective`). Do not invent new helpers.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd server && npx vitest run src/config/registry.test.ts -t "device knobs"`
+Expected: FAIL — `tts.kokoro.device`/`qa.asr.device` not found; `SPK_DEVICE` type is `enum`.
+
+- [ ] **Step 3: Widen the two enum knobs to string**
+
+In `registry.ts`, the `tts.coqui.device` knob — replace:
+
+```ts
+    type: 'enum', options: ['auto', 'cpu', 'cuda'],
+    default: 'auto', // ← COQUI_DEVICE default in tts-sidecar/main.py (line 415)
+```
+with:
+```ts
+    type: 'string',
+    default: 'auto', // free-text so a multi-GPU user can pin cuda:1; sidecar resolves it
+```
+
+The `qa.speaker.device` knob — replace:
+```ts
+    type: 'enum',
+    options: ['cpu', 'cuda'],
+    default: 'cpu',
+```
+with:
+```ts
+    type: 'string',
+    default: 'cpu', // free-text; accepts cpu | cuda | cuda:N
+```
+
+- [ ] **Step 4: Add the two new knobs**
+
+Immediately after the `tts.coqui.device` knob block, add:
+
+```ts
+  {
+    key: 'tts.kokoro.device',
+    env: 'KOKORO_DEVICE',
+    group: 'tts-engine',
+    label: 'Kokoro device',
+    help: 'Device for Kokoro (onnxruntime). "auto" lets the sidecar pick. Pin a specific GPU with "cuda:1", or force "cpu". Changing this requires a sidecar restart.',
+    type: 'string',
+    default: 'auto',
+    apply: 'restart-sidecar', risk: 'high',
+  },
+```
+
+Immediately after the `qa.speaker.device` knob block, add:
+
+```ts
+  {
+    key: 'qa.asr.device',
+    env: 'ASR_DEVICE',
+    group: 'qa-gates',
+    label: 'Content-QA (Whisper) device',
+    help: '"cpu" (default) uses zero VRAM. "cuda" runs Whisper on the GPU; pin a specific card with "cuda:1". Changing the device restarts the sidecar.',
+    type: 'string',
+    default: 'cpu',
+    apply: 'restart-sidecar', risk: 'medium',
+  },
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd server && npx vitest run src/config/registry.test.ts -t "device knobs"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Guard against config:check drift**
+
+Some repos validate that every `restart-sidecar` knob is documented in `.env.example`. Run: `cd server && npm run config:check` (if the script exists; otherwise skip).
+Expected: PASS, or add `KOKORO_DEVICE=`/`ASR_DEVICE=` comment lines to `server/.env.example` matching the existing device-knob style, then re-run.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/config/registry.ts server/src/config/registry.test.ts server/.env.example
+git commit -m "feat(server): widen coqui/spk device knobs to string + add kokoro/asr device knobs"
+```
+
+---
+
+### Task 2: Node VRAM gates recognise `cuda:N`
+
+**Files:**
+- Modify: `server/src/tts/transcribe-client.ts:58-60` (`asrRunsOnGpu`)
+- Modify: `server/src/tts/embed-client.ts:40-42` (`spkRunsOnGpu`)
+- Test: `server/src/tts/transcribe-client.test.ts`, `server/src/tts/embed-client.test.ts` (create if absent)
+
+**Interfaces:**
+- Consumes: `process.env.ASR_DEVICE` / `process.env.SPK_DEVICE` (strings, now possibly `cuda:N`).
+- Produces: `asrRunsOnGpu(): boolean` / `spkRunsOnGpu(): boolean` returning `true` for `cuda` **and** `cuda:N`. No signature change — only the predicate widens.
+
+**Why:** today both are `=== 'cuda'`. After Task 1 a user can set `ASR_DEVICE=cuda:1`; the exact-match test would return `false`, the GPU semaphore token would be skipped, and an on-GPU Whisper/ECAPA would run untracked → VRAM oversubscription.
+
+- [ ] **Step 1: Write the failing tests**
+
+`server/src/tts/transcribe-client.test.ts`:
+```ts
+import { afterEach, describe, expect, it } from 'vitest';
+import { asrRunsOnGpu } from './transcribe-client';
+
+describe('asrRunsOnGpu', () => {
+  const prev = process.env.ASR_DEVICE;
+  afterEach(() => { process.env.ASR_DEVICE = prev; });
+
+  it('is false for cpu / unset', () => {
+    delete process.env.ASR_DEVICE; expect(asrRunsOnGpu()).toBe(false);
+    process.env.ASR_DEVICE = 'cpu'; expect(asrRunsOnGpu()).toBe(false);
+  });
+  it('is true for cuda and cuda:N', () => {
+    process.env.ASR_DEVICE = 'cuda'; expect(asrRunsOnGpu()).toBe(true);
+    process.env.ASR_DEVICE = 'cuda:1'; expect(asrRunsOnGpu()).toBe(true);
+    process.env.ASR_DEVICE = 'CUDA:0'; expect(asrRunsOnGpu()).toBe(true);
+  });
+});
+```
+
+`server/src/tts/embed-client.test.ts` — identical shape against `spkRunsOnGpu` and `SPK_DEVICE`.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd server && npx vitest run src/tts/transcribe-client.test.ts src/tts/embed-client.test.ts`
+Expected: FAIL on the `cuda:1` assertion (`=== 'cuda'` is false).
+
+- [ ] **Step 3: Widen both predicates**
+
+`transcribe-client.ts` — replace the body of `asrRunsOnGpu`:
+```ts
+export function asrRunsOnGpu(): boolean {
+  return (process.env.ASR_DEVICE ?? 'cpu').trim().toLowerCase().startsWith('cuda');
+}
+```
+
+`embed-client.ts` — replace the body of `spkRunsOnGpu`:
+```ts
+export function spkRunsOnGpu(): boolean {
+  return (process.env.SPK_DEVICE ?? 'cpu').trim().toLowerCase().startsWith('cuda');
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cd server && npx vitest run src/tts/transcribe-client.test.ts src/tts/embed-client.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/tts/transcribe-client.ts server/src/tts/embed-client.ts server/src/tts/transcribe-client.test.ts server/src/tts/embed-client.test.ts
+git commit -m "fix(server): asr/spk GPU gates recognise indexed cuda:N device"
+```
+
+---
+
+### Task 3: Sidecar device parser + Whisper `cuda:N`
+
+**Files:**
+- Modify: `server/tts-sidecar/main.py` (add a module-level `_parse_device` helper near `_resolve_torch_device` ~1167; fix `WhisperEngine._compute_type` ~2821 and `_ensure_loaded` ~2842)
+- Test: `server/tts-sidecar/tests/test_device_parse.py` (new), extend `server/tts-sidecar/tests/test_synthesize.py` only if a Whisper integration test already lives there (else keep the unit test standalone)
+
+**Interfaces:**
+- Produces: `_parse_device(value: str) -> tuple[str, Optional[int]]` returning `(family, index)` where `family ∈ {"cpu","cuda","mps","auto"}` and `index` is the GPU ordinal or `None`. Examples: `"cuda:1"→("cuda",1)`, `"cuda"→("cuda",None)`, `"cpu"→("cpu",None)`, `""→("auto",None)`. Tasks 4 and 7 reuse this.
+
+- [ ] **Step 1: Write the failing test**
+
+`server/tts-sidecar/tests/test_device_parse.py`:
+```python
+import importlib
+main = importlib.import_module("main")
+
+def test_parse_device_families_and_index():
+    assert main._parse_device("cpu") == ("cpu", None)
+    assert main._parse_device("cuda") == ("cuda", None)
+    assert main._parse_device("cuda:0") == ("cuda", 0)
+    assert main._parse_device("cuda:2") == ("cuda", 2)
+    assert main._parse_device("CUDA:1") == ("cuda", 1)
+    assert main._parse_device("") == ("auto", None)
+    assert main._parse_device(None) == ("auto", None)  # type: ignore[arg-type]
+
+def test_whisper_compute_type_honours_indexed_cuda(monkeypatch):
+    monkeypatch.setenv("ASR_DEVICE", "cuda:1")
+    eng = main.WhisperEngine()
+    # int8_float16 is the GPU compute type; an indexed pin must still select it
+    assert eng._compute_type() == "int8_float16"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run (from `server/tts-sidecar`): `.\.venv\Scripts\python.exe -m pytest tests/test_device_parse.py -v`
+Expected: FAIL — `_parse_device` not defined; `_compute_type` returns `int8` for `cuda:1`.
+
+> If the venv is unbootstrapped, `npm run test:sidecar` prints a SKIP banner — bootstrap the venv per `server/tts-sidecar/README.md` before this task, since it's the only way to exercise sidecar code.
+
+- [ ] **Step 3: Add the parser**
+
+In `main.py`, directly above `_resolve_torch_device` (line ~1167):
+```python
+def _parse_device(value: Optional[str]) -> tuple[str, Optional[int]]:
+    """Split a device knob value into (family, index).
+
+    'cuda:1' → ('cuda', 1); 'cuda' → ('cuda', None); 'cpu' → ('cpu', None);
+    'mps' → ('mps', None); '' / None / 'auto' → ('auto', None). Case-insensitive.
+    The single place that understands the `cuda:N` grammar — every engine's
+    device read routes through it so an indexed pin can't silently degrade."""
+    p = (value or "auto").strip().lower()
+    if p in ("", "auto"):
+        return ("auto", None)
+    if p == "cpu":
+        return ("cpu", None)
+    if p == "mps":
+        return ("mps", None)
+    if p.startswith("cuda"):
+        _, _, idx = p.partition(":")
+        return ("cuda", int(idx) if idx.isdigit() else None)
+    return (p, None)
+```
+
+- [ ] **Step 4: Fix Whisper's compute-type + device split**
+
+In `WhisperEngine._compute_type` (~2821), replace:
+```python
+        default = "int8_float16" if self._device == "cuda" else "int8"
+```
+with:
+```python
+        family, _ = _parse_device(self._device)
+        default = "int8_float16" if family == "cuda" else "int8"
+```
+
+In `WhisperEngine._ensure_loaded` (~2842), replace:
+```python
+        self._model = WhisperModel(
+            self._model_name, device=self._device, compute_type=self._compute_type()
+        )
+```
+with:
+```python
+        # CTranslate2 wants device="cuda" + a separate device_index; it RAISES on a
+        # bad index (no silent CPU fallback), so an out-of-range pin surfaces as a
+        # load error the supervisor/health can show — that's intended.
+        family, index = _parse_device(self._device)
+        ct2_device = "cuda" if family == "cuda" else ("cpu" if family in ("cpu", "auto") else family)
+        ct2_kwargs = {"device": ct2_device, "compute_type": self._compute_type()}
+        if family == "cuda" and index is not None:
+            ct2_kwargs["device_index"] = index
+        self._model = WhisperModel(self._model_name, **ct2_kwargs)
+```
+
+> Note: `self._device` keeps its raw `os.environ` string (still logged at 2845); only the `WhisperModel` construction is index-aware. Do not change the `_device` assignment at 2818.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `.\.venv\Scripts\python.exe -m pytest tests/test_device_parse.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_device_parse.py
+git commit -m "feat(sidecar): _parse_device helper + Whisper honours cuda:N (device_index)"
+```
+
+---
+
+### Task 4: ECAPA/SPK `cuda:N`
+
+**Files:**
+- Modify: `server/tts-sidecar/main.py` (`SpeakerEmbedder`/SPK `__init__` ~2936, `ensure_loaded` device-present check ~2954-2969, `_load_on` ~2938)
+- Test: `server/tts-sidecar/tests/test_device_parse.py` (extend)
+
+**Interfaces:**
+- Consumes: `_parse_device` (Task 3).
+- Produces: SPK loads on the *indexed* card; the availability-degrade check keys on the parsed family, not `== "cuda"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_device_parse.py`:
+```python
+def test_spk_indexed_cuda_present_check(monkeypatch):
+    monkeypatch.setenv("SPK_DEVICE", "cuda:1")
+    spk = main.SpeakerEmbedder() if hasattr(main, "SpeakerEmbedder") else main.SPK.__class__()
+    family, index = main._parse_device(spk.device)
+    assert (family, index) == ("cuda", 1)
+    # the load device string passed to speechbrain run_opts must carry the index
+    assert main._spk_run_device(spk.device) == "cuda:1"
+```
+
+> Replace `SpeakerEmbedder` with the actual class name at `main.py:2924` (read the `class ...:` line). If the class is only instantiated as the `SPK` singleton, use `main.SPK.__class__()`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `.\.venv\Scripts\python.exe -m pytest tests/test_device_parse.py::test_spk_indexed_cuda_present_check -v`
+Expected: FAIL — `_spk_run_device` not defined.
+
+- [ ] **Step 3: Add a tiny SPK device resolver + use the family check**
+
+In `main.py`, near `_parse_device`, add:
+```python
+def _spk_run_device(value: Optional[str]) -> str:
+    """speechbrain run_opts device string. 'cuda:1' stays 'cuda:1'; family-only
+    'cuda' stays 'cuda'; everything else → 'cpu'."""
+    family, index = _parse_device(value)
+    if family == "cuda":
+        return f"cuda:{index}" if index is not None else "cuda"
+    return "cpu" if family in ("cpu", "auto") else family
+```
+
+In the SPK `ensure_loaded` present-check (~2954), replace:
+```python
+            if self.device == "cuda":
+```
+with:
+```python
+            if _parse_device(self.device)[0] == "cuda":
+```
+and the poison-class branch (~2969), replace:
+```python
+                if self.device == "cuda" and not _CUDA_POISON_RE.search(f"{e}"):
+```
+with:
+```python
+                if _parse_device(self.device)[0] == "cuda" and not _CUDA_POISON_RE.search(f"{e}"):
+```
+
+In `_load_on` (~2938), have the model load on the indexed device. The method receives `device`; ensure callers pass the resolved string by changing the call site in `ensure_loaded` (~2963):
+```python
+                self._model = await asyncio.to_thread(self._load_on, _spk_run_device(self.device))
+```
+and the degrade-reload call (~2972):
+```python
+                    self._model = await asyncio.to_thread(self._load_on, _spk_run_device(self.device))
+```
+(The `self.device = "cpu"` assignments on degrade stay; `_spk_run_device("cpu")` → `"cpu"`.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `.\.venv\Scripts\python.exe -m pytest tests/test_device_parse.py -v`
+Expected: PASS (all device-parse tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_device_parse.py
+git commit -m "feat(sidecar): ECAPA speaker-embed honours cuda:N via run_opts"
+```
+
+---
+
+### Task 5: Kokoro `device_id` plumbing (spike-gated)
+
+**Files:**
+- Modify: `server/tts-sidecar/main.py` (`KokoroEngine._resolve_ort_providers` ~842 + the `Kokoro(...)` construction ~944)
+- Test: `server/tts-sidecar/tests/test_kokoro.py` (extend)
+
+**Interfaces:**
+- Consumes: `_parse_device` (Task 3), `KOKORO_DEVICE` env.
+- Produces: a pure helper `_kokoro_provider_options(device: str, providers: list[str]) -> Optional[list[dict]]` returning ORT `provider_options` (e.g. `[{"device_id": 1}, {}]` aligned to `providers`) for an indexed CUDA pin, else `None`. The construction passes it through when supported.
+
+- [ ] **Step 1: SPIKE — verify the pinned `kokoro-onnx` API**
+
+Run:
+```bash
+cd server/tts-sidecar
+.\.venv\Scripts\python.exe -c "import inspect, kokoro_onnx; print(inspect.signature(kokoro_onnx.Kokoro.__init__))"
+```
+Record whether `Kokoro.__init__` accepts `provider_options=` (or a `sess`/`session=` for a pre-built `InferenceSession`). This decides Step 4's branch. Note the result in the commit body. **Do not skip this** — the spec flags Kokoro `device_id` as contingent.
+
+- [ ] **Step 2: Write the failing test (pure helper — no model load)**
+
+Append to `tests/test_kokoro.py`:
+```python
+import importlib
+main = importlib.import_module("main")
+
+def test_kokoro_provider_options_indexed_cuda():
+    providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    opts = main._kokoro_provider_options("cuda:1", providers)
+    assert opts == [{"device_id": 1}, {}]
+
+def test_kokoro_provider_options_none_when_not_indexed():
+    assert main._kokoro_provider_options("cpu", ["CPUExecutionProvider"]) is None
+    assert main._kokoro_provider_options("cuda", ["CUDAExecutionProvider"]) is None  # no index → ORT default
+    assert main._kokoro_provider_options("auto", []) is None
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `.\.venv\Scripts\python.exe -m pytest tests/test_kokoro.py -k provider_options -v`
+Expected: FAIL — `_kokoro_provider_options` not defined.
+
+- [ ] **Step 4: Implement the helper + wire it (branch on the spike)**
+
+Add near `_resolve_ort_providers`:
+```python
+@staticmethod
+def _kokoro_provider_options(device: Optional[str], providers: list[str]) -> Optional[list[dict]]:
+    """Per-provider ORT options aligned to `providers`, setting CUDA `device_id`
+    for an indexed pin (e.g. KOKORO_DEVICE=cuda:1). Returns None when there is no
+    index to pin (ORT picks its default device) — keeps today's behaviour intact."""
+    family, index = _parse_device(device)
+    if family != "cuda" or index is None or not providers:
+        return None
+    return [{"device_id": index} if p == "CUDAExecutionProvider" else {} for p in providers]
+```
+
+At the `Kokoro(...)` construction (~944) — **if the spike showed `provider_options` is accepted:**
+```python
+    device = os.environ.get("KOKORO_DEVICE", "auto")
+    provider_options = KokoroEngine._kokoro_provider_options(device, providers)
+    kokoro_kwargs = {"providers": providers} if providers else {}
+    if provider_options is not None:
+        kokoro_kwargs["provider_options"] = provider_options
+    self._kokoro = Kokoro(self._model_path, self._voices_path, **kokoro_kwargs)
+```
+Keep the existing `TypeError → no-kwarg fallback` (~945-950) so an older `kokoro-onnx` still loads.
+
+**If the spike showed only a `session=`/`sess=` path** (no `provider_options` kwarg): build the `InferenceSession` yourself and pass it — implement `_build_kokoro_session(providers, provider_options)` using `onnxruntime.InferenceSession(self._model_path, providers=providers, provider_options=provider_options)` and pass `sess=`. Pin the exact kwarg name from the spike.
+
+- [ ] **Step 5: Run to verify the helper passes**
+
+Run: `.\.venv\Scripts\python.exe -m pytest tests/test_kokoro.py -k provider_options -v`
+Expected: PASS. (The construction itself is covered on-box — a unit test can't load real weights.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_kokoro.py
+git commit -m "feat(sidecar): Kokoro honours KOKORO_DEVICE via ORT provider device_id
+
+Spike result: kokoro-onnx Kokoro.__init__ <accepts provider_options | needs session=>."
+```
+
+---
+
+### Task 6: `GET /devices` enumeration + server proxy
+
+**Files:**
+- Modify: `server/tts-sidecar/main.py` (add `_enumerate_cuda_devices()` near `_cuda_vram_mb` ~3319; add a `@app.get("/devices")` route near the `/health` route)
+- Create: `server/src/routes/devices.ts` (proxy, mirroring `server/src/routes/sidecar-health.ts`)
+- Modify: the route registration site (wherever `sidecar-health` is mounted — `grep -rn "sidecar-health" server/src`)
+- Test: `server/tts-sidecar/tests/test_devices.py` (new); `server/src/routes/devices.test.ts` (new)
+
+**Interfaces:**
+- Produces: sidecar `GET /devices` → `{"devices":[{"uuid","idx","name","total_mb","free_mb"}], "cpu": true}`; server proxy `GET /api/devices` returning the same. Task 7 + Plan 2 consume this shape.
+
+- [ ] **Step 1: Write the failing sidecar test**
+
+`server/tts-sidecar/tests/test_devices.py`:
+```python
+import importlib
+main = importlib.import_module("main")
+
+def test_enumerate_returns_list_of_card_dicts(monkeypatch):
+    class _Props:
+        def __init__(self, name, total, uuid): self.name=name; self.total_memory=total; self.uuid=uuid
+    class _Cuda:
+        @staticmethod
+        def is_available(): return True
+        @staticmethod
+        def device_count(): return 2
+        @staticmethod
+        def get_device_properties(i):
+            return _Props(["RTX 4070","RTX 5070 Ti"][i], [8*10**9,16*10**9][i], f"GPU-{i}")
+        @staticmethod
+        def mem_get_info(i): return ([6*10**9, 14*10**9][i], [8*10**9,16*10**9][i])
+    monkeypatch.setattr(main, "torch", type("T", (), {"cuda": _Cuda})(), raising=False)
+    out = main._enumerate_cuda_devices()
+    assert [d["idx"] for d in out] == [0, 1]
+    assert out[1]["name"] == "RTX 5070 Ti"
+    assert out[1]["total_mb"] == 16000 and out[1]["free_mb"] == 14000
+    assert out[1]["uuid"] == "GPU-1"
+```
+
+> Read how the existing sidecar tests stub torch (`tests/test_device_probe.py` uses a `_StubTorch`); match that injection style if `main` imports torch lazily rather than as a module global.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `.\.venv\Scripts\python.exe -m pytest tests/test_devices.py -v`
+Expected: FAIL — `_enumerate_cuda_devices` not defined.
+
+- [ ] **Step 3: Implement the enumerator + route**
+
+Near `_cuda_vram_mb` (~3319):
+```python
+def _enumerate_cuda_devices() -> list[dict]:
+    """[{uuid, idx, name, total_mb, free_mb}] per visible CUDA device, driver
+    truth via mem_get_info (sees ALL allocators). [] when CUDA is unavailable."""
+    try:
+        import torch  # type: ignore
+        if not torch.cuda.is_available():
+            return []
+        out = []
+        for i in range(torch.cuda.device_count()):
+            props = torch.cuda.get_device_properties(i)
+            free, total = torch.cuda.mem_get_info(i)
+            out.append({
+                "uuid": str(getattr(props, "uuid", "")) or f"idx-{i}",
+                "idx": i,
+                "name": props.name,
+                "total_mb": round(total / 1_000_000),
+                "free_mb": round(free / 1_000_000),
+            })
+        return out
+    except Exception:
+        return []
+```
+
+Add the route next to `/health`:
+```python
+@app.get("/devices")
+def devices() -> dict:
+    """Discovery for the picker: visible GPUs + a cpu pseudo-option."""
+    return {"devices": _enumerate_cuda_devices(), "cpu": True}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `.\.venv\Scripts\python.exe -m pytest tests/test_devices.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing proxy test + implement the proxy**
+
+`server/src/routes/devices.test.ts` — mirror `sidecar-health.test.ts`: stand up the router with a fake sidecar returning the `/devices` body and assert `GET /api/devices` returns it (and `{devices:[],cpu:true}` when the sidecar is down). Copy the exact mounting + fetch-mock pattern from `sidecar-health.test.ts`.
+
+`server/src/routes/devices.ts` — copy `sidecar-health.ts` and swap the upstream path to `/devices` and the mount path to `/api/devices`; keep its timeout/error-fallback handling (return `{devices:[],cpu:true}` on upstream failure). Register it where `sidecar-health` is registered.
+
+- [ ] **Step 6: Run to verify the proxy passes**
+
+Run: `cd server && npx vitest run src/routes/devices.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_devices.py server/src/routes/devices.ts server/src/routes/devices.test.ts server/src/<route-registration-file>.ts
+git commit -m "feat(sidecar,server): GET /devices GPU discovery + /api/devices proxy"
+```
+
+---
+
+### Task 7: `/health` `gpus[]` actual-card readback
+
+**Files:**
+- Modify: `server/tts-sidecar/main.py` (the `/health` handler ~4060-4109 — add a `gpus` key; add `_engine_actual_card(engine)` + `_resident_engines_by_card()` helpers)
+- Test: `server/tts-sidecar/tests/test_devices.py` (extend) or `tests/test_runtime_wiring.py` if `/health` shape is asserted there
+
+**Interfaces:**
+- Consumes: `_enumerate_cuda_devices` (Task 6), `_parse_device` (Task 3), the existing `_normalize_device_family`/`_kokoro_session_device`.
+- Produces: `/health` gains `"gpus": [{uuid, idx, name, total_mb, free_mb, torch_reserved_mb, resident:[{engine, actual_card}], stale_reason?}]`. The existing `devices` map and all other fields are untouched (Global Constraint: additive).
+
+**Note on granularity:** torch engines (Qwen/Coqui/SPK) report an actual *index* via `param.device.index`; Kokoro (ORT) and Whisper (CT2) report **family + a `fell_back` flag** only — never an index. When a CUDA-pinned engine resolves to CPU, set `stale_reason="cpu_fallback"` on that engine's `resident` entry.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_devices.py`:
+```python
+def test_health_includes_gpus_array(monkeypatch):
+    # stub enumeration so the assertion is deterministic without real CUDA
+    monkeypatch.setattr(main, "_enumerate_cuda_devices", lambda: [
+        {"uuid": "GPU-0", "idx": 0, "name": "RTX 4070", "total_mb": 8000, "free_mb": 6000},
+    ])
+    monkeypatch.setattr(main, "_resident_engines_by_card", lambda cards: {0: [{"engine": "qwen", "actual_card": 0}]})
+    payload = main._build_gpus_payload()
+    assert payload[0]["uuid"] == "GPU-0"
+    assert payload[0]["resident"] == [{"engine": "qwen", "actual_card": 0}]
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `.\.venv\Scripts\python.exe -m pytest tests/test_devices.py::test_health_includes_gpus_array -v`
+Expected: FAIL — `_build_gpus_payload` not defined.
+
+- [ ] **Step 3: Implement the actual-card helpers + payload builder**
+
+```python
+def _engine_actual_card(engine: Any) -> tuple[Optional[str], Optional[int], bool]:
+    """(family, card_index, fell_back). Index is torch-only; ORT/CT2 give family.
+    fell_back is True when a cuda pin actually resolved to cpu."""
+    fam = idx = None
+    # torch engines expose a real device on the loaded module
+    dev = getattr(engine, "_resolved_device", None) or getattr(engine, "_device", None) or getattr(engine, "device", None)
+    if dev is not None:
+        fam, idx = _parse_device(str(dev))
+    requested_fam, _ = _parse_device(str(getattr(engine, "_requested_device", dev) or "auto"))
+    fell_back = (requested_fam == "cuda" and fam == "cpu")
+    return (fam, idx, fell_back)
+
+
+def _build_gpus_payload() -> list[dict]:
+    """gpus[] for /health: discovered cards + per-card torch_reserved + resident
+    engines with their ACTUAL device (not the requested knob)."""
+    cards = _enumerate_cuda_devices()
+    reserved_by_idx = {}
+    try:
+        import torch  # type: ignore
+        for c in cards:
+            reserved_by_idx[c["idx"]] = round(torch.cuda.memory_reserved(c["idx"]) / 1_000_000)
+    except Exception:
+        pass
+    resident = _resident_engines_by_card(cards)
+    for c in cards:
+        c["torch_reserved_mb"] = reserved_by_idx.get(c["idx"], 0)
+        c["resident"] = resident.get(c["idx"], [])
+    return cards
+```
+
+Add `_resident_engines_by_card(cards)` that walks the loaded engines (`COQUI`/`KOKORO`/`QWEN`/`ASR`/`SPK` singletons), calls `_engine_actual_card`, and buckets `{idx: [{"engine": name, "actual_card": idx, ...("stale_reason":"cpu_fallback" if fell_back)}]}`. For ORT/CT2 engines with no index, place them under their family without an index key and still flag `fell_back`. Keep it defensive — an unloaded engine contributes nothing.
+
+In the `/health` return dict (after the `"devices": devices,` line ~4109), add:
+```python
+        "gpus": _build_gpus_payload(),
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `.\.venv\Scripts\python.exe -m pytest tests/test_devices.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Guard the additive contract**
+
+Run the existing health-shape test to prove nothing broke: `.\.venv\Scripts\python.exe -m pytest tests/test_runtime_wiring.py -v` (and any test asserting `/health` keys).
+Expected: PASS — `devices`, `asr_device`, etc. unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_devices.py
+git commit -m "feat(sidecar): /health gpus[] reports each engine's actual resident card"
+```
+
+---
+
+### Task 8: Wave 1 on-box acceptance checklist (written deliverable)
+
+**Files:**
+- Create: `docs/features/<n>-multi-gpu.md` from `docs/features/TEMPLATE.md` (assign `<n>` per the backlog; tag the issue `needs-plan`)
+
+**Interfaces:** none (documentation). This converts the spec's "named, not written" acceptance into explicit pass/fail lines for the one operator with the 2-GPU box.
+
+- [ ] **Step 1: Write the acceptance section**
+
+In the new plan doc, under a `## Wave 1 acceptance (on-box, 2-GPU)` heading, list these explicit checks (each a checkbox the operator ticks):
+```markdown
+- [ ] `GET /api/devices` lists both cards with correct names + total_mb (8000 / 16000) and a live free_mb.
+- [ ] `QWEN_DEVICE=cuda:1` then restart → `/health` gpus[] shows qwen resident with actual_card=1 (torch index truth).
+- [ ] `ASR_DEVICE=cuda:1` then transcribe → no CTranslate2 error; `asrRunsOnGpu()` true (semaphore token taken).
+- [ ] `SPK_DEVICE=cuda:1` then an embed → ECAPA loads on cuda:1 (no degrade-to-cpu warning).
+- [ ] `KOKORO_DEVICE=cuda:1` then a Kokoro synth → no fell_back flag in gpus[]; (index unverifiable for ORT — confirm via nvidia-smi that VRAM lands on card 1).
+- [ ] Force a fallback: `KOKORO_DEVICE=cuda:9` (no such card) → gpus[] flags kokoro stale_reason=cpu_fallback, sidecar serves from CPU, no crash.
+- [ ] All existing `/health` fields unchanged (diff against a pre-Wave-1 capture).
+```
+
+- [ ] **Step 2: Update the features index + commit**
+
+Add the new doc under its area in `docs/features/INDEX.md`.
+
+```bash
+git add docs/features/<n>-multi-gpu.md docs/features/INDEX.md
+git commit -m "docs(docs): Wave 1 multi-GPU on-box acceptance checklist"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Wave 1, §1.1–1.5):**
+- §1.1 discovery + per-card sampler → Task 6 (`/devices`, `_enumerate_cuda_devices`) + Task 7 (`gpus[]`). ✓
+- §1.2 config knobs (widen COQUI/SPK; add KOKORO/ASR) → Task 1. ✓
+- §1.3 adapter + the inline `== "cuda"` sites (Whisper compute-type+device, SPK ×2, Kokoro device_id) → Tasks 3, 4, 5 (`_parse_device` is the adapter core; Qwen/Coqui already torch-indexed via `_resolve_torch_device`, verified at `main.py:1174`). ✓
+- §1.4 Node gates (ASR + SPK embed) → Task 2. ✓
+- §1.5 actual-card readback + `stale_reason` (cpu_fallback) → Task 7. ✓
+- Written on-box checklist → Task 8. ✓
+
+**Placeholder scan:** Task 5's spike + Task 4's class-name read are *instructions to verify a real value*, not placeholders — each has a concrete command and a concrete fallback. The `<n>` in Task 8 and `<route-registration-file>` in Task 6 are repo lookups with a stated `grep`. No "TBD/handle edge cases/write tests for the above."
+
+**Type consistency:** `_parse_device(value) -> (family, index)` is defined in Task 3 and consumed with that exact shape in Tasks 4, 5, 7. `_enumerate_cuda_devices()` dict shape (`uuid/idx/name/total_mb/free_mb`) defined in Task 6, extended (not renamed) in Task 7. `asrRunsOnGpu`/`spkRunsOnGpu` keep their boolean signatures (Task 2).
+
+**Known soft spots flagged for execution, not hidden:** Task 5 (Kokoro) is genuinely contingent on the `kokoro-onnx` API — the spike is Step 1 and the fallback is specified. Task 7's `_resident_engines_by_card` walk depends on the actual singleton names (`COQUI`/`KOKORO`/`QWEN`/`ASR`/`SPK`) and each engine's loaded-device attribute — the implementer reads the engine classes to confirm attribute names before writing the bucketing loop.

--- a/docs/superpowers/plans/2026-06-27-multi-gpu-wave1-placement-visibility.md
+++ b/docs/superpowers/plans/2026-06-27-multi-gpu-wave1-placement-visibility.md
@@ -1,225 +1,207 @@
 # Multi-GPU Wave 1 — Placement & Visibility Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Revised after a 5-lens adversarial code review** that caught ~20 defects in the first draft (torch-stub that didn't attach, an invented `_requested_device`, a route/file collision with the LAN-pairing `devices.ts`, Coqui losing fp16/DeepSpeed under `cuda:N`, registry test importing non-existent symbols, etc.). Every code block and test below was checked against the real source.
 
-**Goal:** Make every TTS-sidecar engine *placeable* on a specific GPU (or CPU) via a config knob, and make the cards + each engine's *actual* resident device *visible* — with no per-card safety logic and no UI (those are Wave 2 / Plan 2).
+**Goal:** Make every TTS-sidecar engine *placeable* on a specific GPU (or CPU) via a config knob, and make the cards + each engine's *actual* resident device *visible* — no per-card safety logic, no UI (Wave 2 / Plan 2).
 
-**Architecture:** Add/​widen the per-engine device knobs (Node registry), teach the two Node VRAM-gate helpers to recognise an indexed `cuda:N` value, fix the sidecar's inline `== "cuda"` device tests so an indexed pin actually reaches each engine's native device API (torch `.to`, CTranslate2 `device_index`, speechbrain `run_opts`, ONNX-Runtime `provider_options device_id`), expose a `GET /devices` enumeration, and extend `/health` with a `gpus[]` array reporting each engine's *actual* resident card.
+**Architecture:** A single Python device-grammar helper (`_parse_device`) that every engine's device read routes through; per-engine fixes so an indexed `cuda:N` pin reaches each engine's native API (torch `.to`, CTranslate2 `device_index`, speechbrain `run_opts`, ONNX-Runtime `provider_options device_id`) *and* preserves fp16/DeepSpeed; a `GET /api/gpu/devices` discovery endpoint; and a `/health` `gpus[]` array reporting each engine's **actual** resident card (with a `cpu_fallback` flag).
 
-**Tech Stack:** Python 3.12 sidecar (FastAPI/Starlette, torch, faster-whisper/CTranslate2, kokoro-onnx, speechbrain), pytest. Node 20 server (TypeScript, Express, undici), Vitest.
+**Tech Stack:** Python 3.12 sidecar (Starlette, torch, faster-whisper/CTranslate2, kokoro-onnx, speechbrain), pytest. Node 20 server (TypeScript/ESM NodeNext, Express, undici), Vitest.
 
 ## Global Constraints
 
-- **Source of truth is the design spec:** `docs/superpowers/specs/2026-06-27-multi-gpu-per-model-design.md` (Plan 1 / Wave 1, §1.1–1.5). Every task implements a numbered spec item.
-- **Apply semantics:** all device knobs are `apply:'restart-sidecar'`. A knob value set in `server/.env` needs a *server* restart; a config override needs only a *sidecar* restart. Wave 1 ships no UI — pins are exercised via `server/.env` or env vars.
-- **Engine device dialects are NOT uniform** — torch (`cuda:N` via `.to`), CTranslate2 (`device="cuda"` + `device_index=N`, **raises on a bad index — no silent CPU fallback**), speechbrain (`run_opts={"device":"cuda:N"}`), ONNX-Runtime (`provider_options=[{"device_id":N}]`).
-- **Actual-card *index* readback is torch-only.** ORT (Kokoro) and CTranslate2 (Whisper) expose **family + a `fell_back` flag** only — never an index. Do not promise an index for them.
-- **`stale_reason` is an enum:** `cpu_fallback | env_shadow | uuid_unresolved`. Wave 1 sets only `cpu_fallback`; the other two are Plan 2.
-- **Additive, non-breaking telemetry:** the existing `/health` `devices` field (engine→family map) and every existing field MUST stay unchanged. Add a new `gpus[]` key; do not repurpose `devices`.
-- **Testing discipline (CLAUDE.md):** every behaviour change ships a paired automated test; a bug-shaped fix ships a test that fails before and passes after. Sidecar tests live in `server/tts-sidecar/tests/`; server tests colocate as `*.test.ts`.
-- **Commit convention:** `<type>(<scope>): <subject>`; scopes used here are `sidecar`, `server`. No `--no-verify`.
-- **No hex colour literals / OpenAPI is the type source** — not relevant to Wave 1 (no UI, no new API shapes in `openapi.yaml`; `/devices` is a sidecar-internal route proxied like `/health`).
-- **Kokoro `device_id` is contingent** on the pinned `kokoro-onnx` accepting `provider_options`; Task 5 begins with a verification spike and carries an `InferenceSession` fallback.
+- **Spec:** `docs/superpowers/specs/2026-06-27-multi-gpu-per-model-design.md` (Plan 1 / Wave 1, §1.1–1.5). Each task implements a numbered item.
+- **Apply semantics:** all device knobs are `apply:'restart-sidecar'`. Wave 1 ships no UI — pins are exercised via `server/.env` / env vars + a sidecar restart.
+- **Engine device dialects are NOT uniform:** torch (`.to("cuda:N")`), CTranslate2 (`device="cuda"` + `device_index=N`, **raises on a bad index — no silent CPU fallback**), speechbrain (`run_opts={"device":"cuda:N"}`), ONNX-Runtime (`provider_options=[{"device_id":N}]`).
+- **Actual-card *index* readback is torch-only.** ORT (Kokoro) reports family via its session providers; CTranslate2 (Whisper) reports family only. Never promise an index for them.
+- **`stale_reason` enum:** `cpu_fallback | env_shadow | uuid_unresolved`; lives on the **per-engine `resident` entry**. Wave 1 sets only `cpu_fallback`.
+- **Additive telemetry:** the existing `/health` `devices` map (engine→family) and every existing field stay byte-for-byte unchanged. Add a new `gpus[]` key only.
+- **ESM:** all Node imports use the `.js` extension (NodeNext). Sidecar tests import `main` per the existing `tests/` convention (pytest prepend-import-mode via the co-located `conftest.py`).
+- **Testing discipline:** every behaviour change ships a paired test that fails-before/passes-after; **never `Write`-clobber an existing test file — append**.
+- **Commit convention:** `<type>(<scope>): <subject>`, scopes `sidecar`/`server`, ≤100 chars; no `--no-verify`.
+- **`verify` gates touched here:** `config:check` (env-example sync — regenerate with `npm run config:sync` from repo root) and `test:server` (the resolver/registry suites).
+- **Kokoro `device_id` is contingent** on the pinned `kokoro-onnx` accepting `provider_options` — Task 6 opens with a spike and carries an `InferenceSession` fallback.
 
 ---
 
-### Task 1: Device knobs — widen two, add two
+### Task 1: Device knobs — widen two, add two (and keep the enum-exemplar test green)
 
 **Files:**
-- Modify: `server/src/config/registry.ts` (the `tts.coqui.device` knob ~424-432, the `qa.speaker.device` knob ~271-286; add `tts.kokoro.device` and `qa.asr.device`)
-- Test: `server/src/config/registry.test.ts` (or the existing registry/resolver test file — locate with `grep -rl "tts.coqui.device" server/src/config`)
+- Modify: `server/src/config/registry.ts` (`tts.coqui.device` ~424, `qa.speaker.device` ~271; add `tts.kokoro.device`, `qa.asr.device`)
+- Modify: `server/src/config/resolver.test.ts` (repoint the enum exemplar — see Step 4)
+- Create: `server/src/config/registry.device.test.ts`
+- Regenerate: `server/.env.example` (via `npm run config:sync`)
 
 **Interfaces:**
-- Consumes: the existing `Knob` type + `resolveKnob`/`resolveAll` from `server/src/config/`.
-- Produces: four string device knobs whose env vars are `COQUI_DEVICE`, `SPK_DEVICE`, `KOKORO_DEVICE`, `ASR_DEVICE`, each `type:'string'`, `apply:'restart-sidecar'`. Later tasks (2, 5) read `KOKORO_DEVICE`/`ASR_DEVICE` from the sidecar env; the Node gates (Task 2) read `ASR_DEVICE`/`SPK_DEVICE`.
+- Produces: four `type:'string'`, `apply:'restart-sidecar'` device knobs — `COQUI_DEVICE` (default `auto`), `SPK_DEVICE` (default `cpu`), `KOKORO_DEVICE` (default `auto`), `ASR_DEVICE` (default `cpu`). Read by `getKnob(key)` / `resolveKnob(knob)` (single-arg) from `server/src/config/`.
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Write the failing test (use the real resolver API)**
 
-Add to the registry test file:
-
+`server/src/config/registry.device.test.ts`:
 ```ts
-import { describe, it, expect } from 'vitest';
-import { resolveKnob, findKnob } from './registry'; // adjust import to the file's actual exports
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../workspace/user-settings.js', () => ({
+  readConfigOverrides: vi.fn(() => ({})),
+}));
+
+import { resolveKnob } from './resolver.js';
+import { getKnob } from './registry.js';
+import * as us from '../workspace/user-settings.js';
 
 describe('multi-GPU device knobs (Wave 1)', () => {
-  it('COQUI_DEVICE is a string knob that accepts an indexed cuda value', () => {
-    const knob = findKnob('tts.coqui.device');
-    expect(knob.type).toBe('string');
-    const st = resolveKnob(knob, { 'tts.coqui.device': 'cuda:1' });
-    expect(st.effective).toBe('cuda:1');
+  beforeEach(() => {
+    delete process.env.COQUI_DEVICE; delete process.env.SPK_DEVICE;
+    delete process.env.KOKORO_DEVICE; delete process.env.ASR_DEVICE;
+    (us.readConfigOverrides as any).mockReturnValue({});
   });
 
-  it('SPK_DEVICE is a string knob (no longer enum cpu|cuda)', () => {
-    const knob = findKnob('qa.speaker.device');
-    expect(knob.type).toBe('string');
-    expect(resolveKnob(knob, { 'qa.speaker.device': 'cuda:1' }).effective).toBe('cuda:1');
+  it('COQUI_DEVICE is a string knob; an override of cuda:1 resolves through', () => {
+    expect(getKnob('tts.coqui.device')!.type).toBe('string');
+    (us.readConfigOverrides as any).mockReturnValue({ 'tts.coqui.device': 'cuda:1' });
+    expect(resolveKnob(getKnob('tts.coqui.device')!).effective).toBe('cuda:1');
+  });
+
+  it('SPK_DEVICE is a string knob (was enum cpu|cuda)', () => {
+    expect(getKnob('qa.speaker.device')!.type).toBe('string');
+    (us.readConfigOverrides as any).mockReturnValue({ 'qa.speaker.device': 'cuda:1' });
+    expect(resolveKnob(getKnob('qa.speaker.device')!).effective).toBe('cuda:1');
   });
 
   it('adds KOKORO_DEVICE (string, restart-sidecar, default auto)', () => {
-    const knob = findKnob('tts.kokoro.device');
-    expect(knob.env).toBe('KOKORO_DEVICE');
-    expect(knob.type).toBe('string');
-    expect(knob.apply).toBe('restart-sidecar');
-    expect(knob.default).toBe('auto');
+    const k = getKnob('tts.kokoro.device')!;
+    expect([k.env, k.type, k.apply, k.default]).toEqual(['KOKORO_DEVICE', 'string', 'restart-sidecar', 'auto']);
   });
 
   it('adds ASR_DEVICE registry knob (string, restart-sidecar, default cpu)', () => {
-    const knob = findKnob('qa.asr.device');
-    expect(knob.env).toBe('ASR_DEVICE');
-    expect(knob.type).toBe('string');
-    expect(knob.apply).toBe('restart-sidecar');
-    expect(knob.default).toBe('cpu');
+    const k = getKnob('qa.asr.device')!;
+    expect([k.env, k.type, k.apply, k.default]).toEqual(['ASR_DEVICE', 'string', 'restart-sidecar', 'cpu']);
   });
 });
 ```
 
-> If the test file uses a different accessor than `findKnob`/`resolveKnob`, copy the pattern already in that file (it definitely resolves a knob by key and reads `.type`/`.effective`). Do not invent new helpers.
+- [ ] **Step 2: Run to verify it fails**
 
-- [ ] **Step 2: Run the test to verify it fails**
+Run: `cd server && npx vitest run src/config/registry.device.test.ts`
+Expected: FAIL — `tts.coqui.device` type is `enum`; `getKnob('tts.kokoro.device')` is `undefined`.
 
-Run: `cd server && npx vitest run src/config/registry.test.ts -t "device knobs"`
-Expected: FAIL — `tts.kokoro.device`/`qa.asr.device` not found; `SPK_DEVICE` type is `enum`.
+- [ ] **Step 3: Widen the two enum knobs + add the two new ones**
 
-- [ ] **Step 3: Widen the two enum knobs to string**
-
-In `registry.ts`, the `tts.coqui.device` knob — replace:
-
-```ts
-    type: 'enum', options: ['auto', 'cpu', 'cuda'],
-    default: 'auto', // ← COQUI_DEVICE default in tts-sidecar/main.py (line 415)
-```
-with:
+`tts.coqui.device` — replace `type: 'enum', options: ['auto', 'cpu', 'cuda'],` with:
 ```ts
     type: 'string',
-    default: 'auto', // free-text so a multi-GPU user can pin cuda:1; sidecar resolves it
 ```
+(keep `default: 'auto'`; drop the stale `// line 415` comment).
 
-The `qa.speaker.device` knob — replace:
-```ts
-    type: 'enum',
-    options: ['cpu', 'cuda'],
-    default: 'cpu',
-```
-with:
+`qa.speaker.device` — replace `type: 'enum',\n    options: ['cpu', 'cuda'],` with:
 ```ts
     type: 'string',
-    default: 'cpu', // free-text; accepts cpu | cuda | cuda:N
 ```
+(keep `default: 'cpu'`).
 
-- [ ] **Step 4: Add the two new knobs**
-
-Immediately after the `tts.coqui.device` knob block, add:
-
+After the `tts.coqui.device` block add:
 ```ts
   {
     key: 'tts.kokoro.device',
     env: 'KOKORO_DEVICE',
     group: 'tts-engine',
     label: 'Kokoro device',
-    help: 'Device for Kokoro (onnxruntime). "auto" lets the sidecar pick. Pin a specific GPU with "cuda:1", or force "cpu". Changing this requires a sidecar restart.',
+    help: 'Device for Kokoro (onnxruntime). "auto" lets the sidecar pick; pin a card with "cuda:1" or force "cpu". Changing this requires a sidecar restart.',
     type: 'string',
     default: 'auto',
     apply: 'restart-sidecar', risk: 'high',
   },
 ```
-
-Immediately after the `qa.speaker.device` knob block, add:
-
+After the `qa.speaker.device` block add:
 ```ts
   {
     key: 'qa.asr.device',
     env: 'ASR_DEVICE',
     group: 'qa-gates',
     label: 'Content-QA (Whisper) device',
-    help: '"cpu" (default) uses zero VRAM. "cuda" runs Whisper on the GPU; pin a specific card with "cuda:1". Changing the device restarts the sidecar.',
+    help: '"cpu" (default) uses zero VRAM. "cuda" runs Whisper on the GPU; pin a card with "cuda:1". Changing the device restarts the sidecar.',
     type: 'string',
     default: 'cpu',
     apply: 'restart-sidecar', risk: 'medium',
   },
 ```
 
-- [ ] **Step 5: Run the test to verify it passes**
+- [ ] **Step 4: Repoint the enum-exemplar resolver test (it currently uses tts.coqui.device)**
 
-Run: `cd server && npx vitest run src/config/registry.test.ts -t "device knobs"`
-Expected: PASS (4 tests).
+`resolver.test.ts` asserts `coerceAndValidate(getKnob('tts.coqui.device')!, 'tpu').ok === false` — true only while that knob is an enum. After Step 3 it becomes a string (accepts anything) and that assertion breaks. Find the block (`grep -n "tts.coqui.device" server/src/config/resolver.test.ts`) and repoint it to a knob that stays enum, e.g. `tts.accelerator` (options `['auto','nvidia','amd','cpu']`):
+```ts
+    // tts.accelerator stays an enum exemplar (tts.coqui.device widened to string in Wave 1)
+    expect(coerceAndValidate(getKnob('tts.accelerator')!, 'tpu').ok).toBe(false);
+```
+(If the test also asserts a *valid* enum value, use one of `tts.accelerator`'s options.)
 
-- [ ] **Step 6: Guard against config:check drift**
+- [ ] **Step 5: Run both suites green**
 
-Some repos validate that every `restart-sidecar` knob is documented in `.env.example`. Run: `cd server && npm run config:check` (if the script exists; otherwise skip).
-Expected: PASS, or add `KOKORO_DEVICE=`/`ASR_DEVICE=` comment lines to `server/.env.example` matching the existing device-knob style, then re-run.
+Run: `cd server && npx vitest run src/config/registry.device.test.ts src/config/resolver.test.ts`
+Expected: PASS (both).
+
+- [ ] **Step 6: Regenerate `.env.example` and run the gate**
+
+Run (repo root): `npm run config:sync` then `npm run config:check`
+Expected: `config:sync` rewrites the managed block in `server/.env.example` to include `KOKORO_DEVICE`/`ASR_DEVICE` and the widened knobs; `config:check` PASSES. (Do NOT hand-edit the managed block.)
 
 - [ ] **Step 7: Commit**
 
 ```bash
-git add server/src/config/registry.ts server/src/config/registry.test.ts server/.env.example
+git add server/src/config/registry.ts server/src/config/registry.device.test.ts server/src/config/resolver.test.ts server/.env.example
 git commit -m "feat(server): widen coqui/spk device knobs to string + add kokoro/asr device knobs"
 ```
 
 ---
 
-### Task 2: Node VRAM gates recognise `cuda:N`
+### Task 2: Node VRAM gates recognise `cuda:N` (append to existing tests)
 
 **Files:**
 - Modify: `server/src/tts/transcribe-client.ts:58-60` (`asrRunsOnGpu`)
 - Modify: `server/src/tts/embed-client.ts:40-42` (`spkRunsOnGpu`)
-- Test: `server/src/tts/transcribe-client.test.ts`, `server/src/tts/embed-client.test.ts` (create if absent)
+- Modify (APPEND — files exist): `server/src/tts/transcribe-client.test.ts`, `server/src/tts/embed-client.test.ts`
 
-**Interfaces:**
-- Consumes: `process.env.ASR_DEVICE` / `process.env.SPK_DEVICE` (strings, now possibly `cuda:N`).
-- Produces: `asrRunsOnGpu(): boolean` / `spkRunsOnGpu(): boolean` returning `true` for `cuda` **and** `cuda:N`. No signature change — only the predicate widens.
+**Interfaces:** `asrRunsOnGpu()`/`spkRunsOnGpu()` return `true` for `cuda` **and** `cuda:N`. No signature change.
 
-**Why:** today both are `=== 'cuda'`. After Task 1 a user can set `ASR_DEVICE=cuda:1`; the exact-match test would return `false`, the GPU semaphore token would be skipped, and an on-GPU Whisper/ECAPA would run untracked → VRAM oversubscription.
+- [ ] **Step 1: Append the failing tests (do not recreate the files)**
 
-- [ ] **Step 1: Write the failing tests**
-
-`server/src/tts/transcribe-client.test.ts`:
+Append a block to `server/src/tts/transcribe-client.test.ts`:
 ```ts
-import { afterEach, describe, expect, it } from 'vitest';
-import { asrRunsOnGpu } from './transcribe-client';
-
-describe('asrRunsOnGpu', () => {
+describe('asrRunsOnGpu — indexed cuda', () => {
   const prev = process.env.ASR_DEVICE;
-  afterEach(() => { process.env.ASR_DEVICE = prev; });
-
-  it('is false for cpu / unset', () => {
-    delete process.env.ASR_DEVICE; expect(asrRunsOnGpu()).toBe(false);
-    process.env.ASR_DEVICE = 'cpu'; expect(asrRunsOnGpu()).toBe(false);
-  });
-  it('is true for cuda and cuda:N', () => {
-    process.env.ASR_DEVICE = 'cuda'; expect(asrRunsOnGpu()).toBe(true);
+  afterEach(() => { if (prev === undefined) delete process.env.ASR_DEVICE; else process.env.ASR_DEVICE = prev; });
+  it('is true for cuda:1 / CUDA:0, false for cpu', () => {
     process.env.ASR_DEVICE = 'cuda:1'; expect(asrRunsOnGpu()).toBe(true);
     process.env.ASR_DEVICE = 'CUDA:0'; expect(asrRunsOnGpu()).toBe(true);
+    process.env.ASR_DEVICE = 'cpu'; expect(asrRunsOnGpu()).toBe(false);
   });
 });
 ```
-
-`server/src/tts/embed-client.test.ts` — identical shape against `spkRunsOnGpu` and `SPK_DEVICE`.
+Ensure `afterEach` is imported (`import { ..., afterEach } from 'vitest'`) and `asrRunsOnGpu` is in the existing import from `'./transcribe-client.js'`. Append the analogous block to `embed-client.test.ts` for `spkRunsOnGpu`/`SPK_DEVICE`.
 
 - [ ] **Step 2: Run to verify they fail**
 
 Run: `cd server && npx vitest run src/tts/transcribe-client.test.ts src/tts/embed-client.test.ts`
-Expected: FAIL on the `cuda:1` assertion (`=== 'cuda'` is false).
+Expected: FAIL on the `cuda:1` assertion.
 
 - [ ] **Step 3: Widen both predicates**
 
-`transcribe-client.ts` — replace the body of `asrRunsOnGpu`:
+`transcribe-client.ts`:
 ```ts
 export function asrRunsOnGpu(): boolean {
   return (process.env.ASR_DEVICE ?? 'cpu').trim().toLowerCase().startsWith('cuda');
 }
 ```
-
-`embed-client.ts` — replace the body of `spkRunsOnGpu`:
+`embed-client.ts`:
 ```ts
 export function spkRunsOnGpu(): boolean {
   return (process.env.SPK_DEVICE ?? 'cpu').trim().toLowerCase().startsWith('cuda');
 }
 ```
 
-- [ ] **Step 4: Run to verify they pass**
-
-Run: `cd server && npx vitest run src/tts/transcribe-client.test.ts src/tts/embed-client.test.ts`
-Expected: PASS.
+- [ ] **Step 4: Run green** — `cd server && npx vitest run src/tts/transcribe-client.test.ts src/tts/embed-client.test.ts` → PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -230,527 +212,644 @@ git commit -m "fix(server): asr/spk GPU gates recognise indexed cuda:N device"
 
 ---
 
-### Task 3: Sidecar device parser + Whisper `cuda:N`
+### Task 3: `_parse_device` + `_ct2_kwargs` + Whisper `cuda:N`
 
 **Files:**
-- Modify: `server/tts-sidecar/main.py` (add a module-level `_parse_device` helper near `_resolve_torch_device` ~1167; fix `WhisperEngine._compute_type` ~2821 and `_ensure_loaded` ~2842)
-- Test: `server/tts-sidecar/tests/test_device_parse.py` (new), extend `server/tts-sidecar/tests/test_synthesize.py` only if a Whisper integration test already lives there (else keep the unit test standalone)
+- Modify: `server/tts-sidecar/main.py` (add `_parse_device` + `_ct2_kwargs` near `_resolve_torch_device` ~1167; `WhisperEngine._compute_type` 2821-2825 + `_ensure_loaded` 2842-2844; capture `self._requested_device` in `__init__` 2818)
+- Create: `server/tts-sidecar/tests/test_device_parse.py`
 
-**Interfaces:**
-- Produces: `_parse_device(value: str) -> tuple[str, Optional[int]]` returning `(family, index)` where `family ∈ {"cpu","cuda","mps","auto"}` and `index` is the GPU ordinal or `None`. Examples: `"cuda:1"→("cuda",1)`, `"cuda"→("cuda",None)`, `"cpu"→("cpu",None)`, `""→("auto",None)`. Tasks 4 and 7 reuse this.
+**Interfaces (consumed by Tasks 4-9):**
+- `_parse_device(value: Optional[str]) -> tuple[str, Optional[int]]` — `(family, index)`; `cuda:1→("cuda",1)`, `cuda→("cuda",None)`, `cpu→("cpu",None)`, `mps→("mps",None)`, ``/`None`/`auto→("auto",None)`, malformed `cuda:x→("cuda",None)`.
+- `_ct2_kwargs(device: str, compute_type: str) -> dict` — CTranslate2 kwargs; `cuda:1→{"device":"cuda","device_index":1,"compute_type":…}`, `cuda→{"device":"cuda","compute_type":…}` (no index), `cpu→{"device":"cpu","compute_type":…}`.
 
 - [ ] **Step 1: Write the failing test**
 
 `server/tts-sidecar/tests/test_device_parse.py`:
 ```python
-import importlib
+import importlib, os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 main = importlib.import_module("main")
 
-def test_parse_device_families_and_index():
+def test_parse_device():
     assert main._parse_device("cpu") == ("cpu", None)
     assert main._parse_device("cuda") == ("cuda", None)
     assert main._parse_device("cuda:0") == ("cuda", 0)
-    assert main._parse_device("cuda:2") == ("cuda", 2)
-    assert main._parse_device("CUDA:1") == ("cuda", 1)
+    assert main._parse_device("CUDA:2") == ("cuda", 2)
+    assert main._parse_device("cuda:x") == ("cuda", None)   # malformed index → no index, family kept
     assert main._parse_device("") == ("auto", None)
-    assert main._parse_device(None) == ("auto", None)  # type: ignore[arg-type]
+    assert main._parse_device(None) == ("auto", None)
+
+def test_ct2_kwargs_splits_index():
+    assert main._ct2_kwargs("cuda:1", "int8_float16") == {"device": "cuda", "device_index": 1, "compute_type": "int8_float16"}
+    assert main._ct2_kwargs("cuda", "int8_float16") == {"device": "cuda", "compute_type": "int8_float16"}
+    assert main._ct2_kwargs("cpu", "int8") == {"device": "cpu", "compute_type": "int8"}
 
 def test_whisper_compute_type_honours_indexed_cuda(monkeypatch):
+    monkeypatch.delenv("ASR_COMPUTE_TYPE", raising=False)
     monkeypatch.setenv("ASR_DEVICE", "cuda:1")
-    eng = main.WhisperEngine()
-    # int8_float16 is the GPU compute type; an indexed pin must still select it
-    assert eng._compute_type() == "int8_float16"
+    assert main.WhisperEngine()._compute_type() == "int8_float16"
 ```
 
 - [ ] **Step 2: Run to verify it fails**
 
 Run (from `server/tts-sidecar`): `.\.venv\Scripts\python.exe -m pytest tests/test_device_parse.py -v`
-Expected: FAIL — `_parse_device` not defined; `_compute_type` returns `int8` for `cuda:1`.
+Expected: FAIL — `_parse_device`/`_ct2_kwargs` undefined; `_compute_type` returns `int8` for `cuda:1`.
+> If the venv is unbootstrapped, bootstrap it per `server/tts-sidecar/README.md` first — these tests can't run otherwise.
 
-> If the venv is unbootstrapped, `npm run test:sidecar` prints a SKIP banner — bootstrap the venv per `server/tts-sidecar/README.md` before this task, since it's the only way to exercise sidecar code.
+- [ ] **Step 3: Add the two helpers**
 
-- [ ] **Step 3: Add the parser**
-
-In `main.py`, directly above `_resolve_torch_device` (line ~1167):
+Above `_resolve_torch_device` (~1167):
 ```python
 def _parse_device(value: Optional[str]) -> tuple[str, Optional[int]]:
-    """Split a device knob value into (family, index).
-
-    'cuda:1' → ('cuda', 1); 'cuda' → ('cuda', None); 'cpu' → ('cpu', None);
-    'mps' → ('mps', None); '' / None / 'auto' → ('auto', None). Case-insensitive.
-    The single place that understands the `cuda:N` grammar — every engine's
-    device read routes through it so an indexed pin can't silently degrade."""
+    """Split a device knob value into (family, index). The single place that
+    understands the cuda:N grammar — every engine routes through it so an indexed
+    pin can't silently degrade. Malformed index ('cuda:x') keeps family, drops index."""
     p = (value or "auto").strip().lower()
     if p in ("", "auto"):
         return ("auto", None)
-    if p == "cpu":
-        return ("cpu", None)
-    if p == "mps":
-        return ("mps", None)
+    if p in ("cpu", "mps"):
+        return (p, None)
     if p.startswith("cuda"):
         _, _, idx = p.partition(":")
         return ("cuda", int(idx) if idx.isdigit() else None)
     return (p, None)
+
+
+def _ct2_kwargs(device: str, compute_type: str) -> dict:
+    """CTranslate2 WhisperModel kwargs. CT2 wants device='cuda' + a separate
+    device_index (it RAISES on 'cuda:1'); cpu/auto → device='cpu'."""
+    family, index = _parse_device(device)
+    dev = "cuda" if family == "cuda" else ("cpu" if family in ("cpu", "auto") else family)
+    kw: dict = {"device": dev, "compute_type": compute_type}
+    if family == "cuda" and index is not None:
+        kw["device_index"] = index
+    return kw
 ```
 
-- [ ] **Step 4: Fix Whisper's compute-type + device split**
+- [ ] **Step 4: Wire Whisper**
 
-In `WhisperEngine._compute_type` (~2821), replace:
+In `WhisperEngine.__init__` (~2818), directly after the `self._device = …` line, add:
 ```python
-        default = "int8_float16" if self._device == "cuda" else "int8"
+        self._requested_device = self._device  # preserved for /health fell_back detection
 ```
-with:
+In `_compute_type` (~2824) replace `default = "int8_float16" if self._device == "cuda" else "int8"` with:
 ```python
         family, _ = _parse_device(self._device)
         default = "int8_float16" if family == "cuda" else "int8"
 ```
-
-In `WhisperEngine._ensure_loaded` (~2842), replace:
+In `_ensure_loaded` (~2842) replace the `WhisperModel(...)` construction with:
 ```python
-        self._model = WhisperModel(
-            self._model_name, device=self._device, compute_type=self._compute_type()
-        )
-```
-with:
-```python
-        # CTranslate2 wants device="cuda" + a separate device_index; it RAISES on a
-        # bad index (no silent CPU fallback), so an out-of-range pin surfaces as a
-        # load error the supervisor/health can show — that's intended.
-        family, index = _parse_device(self._device)
-        ct2_device = "cuda" if family == "cuda" else ("cpu" if family in ("cpu", "auto") else family)
-        ct2_kwargs = {"device": ct2_device, "compute_type": self._compute_type()}
-        if family == "cuda" and index is not None:
-            ct2_kwargs["device_index"] = index
-        self._model = WhisperModel(self._model_name, **ct2_kwargs)
+        self._model = WhisperModel(self._model_name, **_ct2_kwargs(self._device, self._compute_type()))
 ```
 
-> Note: `self._device` keeps its raw `os.environ` string (still logged at 2845); only the `WhisperModel` construction is index-aware. Do not change the `_device` assignment at 2818.
-
-- [ ] **Step 5: Run to verify it passes**
-
-Run: `.\.venv\Scripts\python.exe -m pytest tests/test_device_parse.py -v`
-Expected: PASS.
+- [ ] **Step 5: Run green** — `.\.venv\Scripts\python.exe -m pytest tests/test_device_parse.py -v` → PASS.
 
 - [ ] **Step 6: Commit**
 
 ```bash
 git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_device_parse.py
-git commit -m "feat(sidecar): _parse_device helper + Whisper honours cuda:N (device_index)"
+git commit -m "feat(sidecar): _parse_device/_ct2_kwargs + Whisper honours cuda:N device_index"
 ```
 
 ---
 
-### Task 4: ECAPA/SPK `cuda:N`
+### Task 4: ECAPA/SPK `cuda:N` + degrade path
 
 **Files:**
-- Modify: `server/tts-sidecar/main.py` (`SpeakerEmbedder`/SPK `__init__` ~2936, `ensure_loaded` device-present check ~2954-2969, `_load_on` ~2938)
-- Test: `server/tts-sidecar/tests/test_device_parse.py` (extend)
+- Modify: `server/tts-sidecar/main.py` (`SpeakerEngine.__init__` 2936 — capture requested; present-check 2954 + poison branch 2969 use family; load call-sites 2963/2972 use `_spk_run_device`; add `_spk_run_device` near `_parse_device`)
+- Modify (APPEND): `server/tts-sidecar/tests/test_device_parse.py`
 
-**Interfaces:**
-- Consumes: `_parse_device` (Task 3).
-- Produces: SPK loads on the *indexed* card; the availability-degrade check keys on the parsed family, not `== "cuda"`.
+**Interfaces:** `_spk_run_device(value) -> str` — speechbrain run_opts device; `cuda:1→"cuda:1"`, `cuda→"cuda"`, else `"cpu"`.
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Append the failing tests**
 
-Append to `tests/test_device_parse.py`:
 ```python
-def test_spk_indexed_cuda_present_check(monkeypatch):
-    monkeypatch.setenv("SPK_DEVICE", "cuda:1")
-    spk = main.SpeakerEmbedder() if hasattr(main, "SpeakerEmbedder") else main.SPK.__class__()
-    family, index = main._parse_device(spk.device)
-    assert (family, index) == ("cuda", 1)
-    # the load device string passed to speechbrain run_opts must carry the index
-    assert main._spk_run_device(spk.device) == "cuda:1"
-```
+def test_spk_run_device():
+    assert main._spk_run_device("cuda:1") == "cuda:1"
+    assert main._spk_run_device("cuda") == "cuda"
+    assert main._spk_run_device("cpu") == "cpu"
 
-> Replace `SpeakerEmbedder` with the actual class name at `main.py:2924` (read the `class ...:` line). If the class is only instantiated as the `SPK` singleton, use `main.SPK.__class__()`.
+def test_spk_indexed_cuda_degrades_when_no_gpu(monkeypatch):
+    """SPK_DEVICE=cuda:1 with no CUDA must degrade to cpu, not crash on the
+    `== "cuda"` mismatch (the bug)."""
+    monkeypatch.setenv("SPK_DEVICE", "cuda:1")
+    spk = main.SpeakerEngine()
+    assert main._parse_device(spk.device)[0] == "cuda"
+    # stub torch so cuda is 'unavailable' and the present-check runs the degrade
+    import types
+    fake = types.SimpleNamespace(cuda=types.SimpleNamespace(is_available=lambda: False))
+    monkeypatch.setitem(sys.modules, "torch", fake)
+    # exercise only the present-check branch (no real speechbrain load)
+    import asyncio
+    async def run():
+        try:
+            await spk.ensure_loaded()
+        except Exception:
+            pass  # speechbrain import may fail in CI; we only assert the device decision
+    asyncio.run(run())
+    assert spk.device == "cpu"
+```
 
 - [ ] **Step 2: Run to verify it fails**
 
-Run: `.\.venv\Scripts\python.exe -m pytest tests/test_device_parse.py::test_spk_indexed_cuda_present_check -v`
-Expected: FAIL — `_spk_run_device` not defined.
+Run: `.\.venv\Scripts\python.exe -m pytest tests/test_device_parse.py -k spk -v`
+Expected: FAIL — `_spk_run_device` undefined; degrade test: `"cuda:1" == "cuda"` is False so the present-check is skipped and `spk.device` stays `"cuda:1"`.
 
-- [ ] **Step 3: Add a tiny SPK device resolver + use the family check**
+- [ ] **Step 3: Add `_spk_run_device` + family-based checks**
 
-In `main.py`, near `_parse_device`, add:
+Near `_parse_device`:
 ```python
 def _spk_run_device(value: Optional[str]) -> str:
-    """speechbrain run_opts device string. 'cuda:1' stays 'cuda:1'; family-only
-    'cuda' stays 'cuda'; everything else → 'cpu'."""
+    """speechbrain run_opts device. 'cuda:1' stays 'cuda:1'; 'cuda' stays 'cuda';
+    anything else → 'cpu'."""
     family, index = _parse_device(value)
     if family == "cuda":
         return f"cuda:{index}" if index is not None else "cuda"
     return "cpu" if family in ("cpu", "auto") else family
 ```
+In `SpeakerEngine.__init__` (~2936), after `self.device = os.environ.get("SPK_DEVICE", "cpu")` add:
+```python
+        self._requested_device = self.device  # preserved before any cpu-demotion
+```
+Present-check (~2954): replace `if self.device == "cuda":` with `if _parse_device(self.device)[0] == "cuda":`.
+Poison branch (~2969): replace `if self.device == "cuda" and not _CUDA_POISON_RE.search(f"{e}"):` with `if _parse_device(self.device)[0] == "cuda" and not _CUDA_POISON_RE.search(f"{e}"):`.
+Load call (~2963) and degrade-reload (~2972): pass `_spk_run_device(self.device)` instead of `self.device`.
 
-In the SPK `ensure_loaded` present-check (~2954), replace:
-```python
-            if self.device == "cuda":
-```
-with:
-```python
-            if _parse_device(self.device)[0] == "cuda":
-```
-and the poison-class branch (~2969), replace:
-```python
-                if self.device == "cuda" and not _CUDA_POISON_RE.search(f"{e}"):
-```
-with:
-```python
-                if _parse_device(self.device)[0] == "cuda" and not _CUDA_POISON_RE.search(f"{e}"):
-```
-
-In `_load_on` (~2938), have the model load on the indexed device. The method receives `device`; ensure callers pass the resolved string by changing the call site in `ensure_loaded` (~2963):
-```python
-                self._model = await asyncio.to_thread(self._load_on, _spk_run_device(self.device))
-```
-and the degrade-reload call (~2972):
-```python
-                    self._model = await asyncio.to_thread(self._load_on, _spk_run_device(self.device))
-```
-(The `self.device = "cpu"` assignments on degrade stay; `_spk_run_device("cpu")` → `"cpu"`.)
-
-- [ ] **Step 4: Run to verify it passes**
-
-Run: `.\.venv\Scripts\python.exe -m pytest tests/test_device_parse.py -v`
-Expected: PASS (all device-parse tests).
+- [ ] **Step 4: Run green** — `.\.venv\Scripts\python.exe -m pytest tests/test_device_parse.py -v` → PASS.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_device_parse.py
-git commit -m "feat(sidecar): ECAPA speaker-embed honours cuda:N via run_opts"
+git commit -m "feat(sidecar): ECAPA honours cuda:N via run_opts + degrades indexed pin"
 ```
 
 ---
 
-### Task 5: Kokoro `device_id` plumbing (spike-gated)
+### Task 5: Coqui `cuda:N` keeps fp16 + DeepSpeed
 
 **Files:**
-- Modify: `server/tts-sidecar/main.py` (`KokoroEngine._resolve_ort_providers` ~842 + the `Kokoro(...)` construction ~944)
-- Test: `server/tts-sidecar/tests/test_kokoro.py` (extend)
+- Modify: `server/tts-sidecar/main.py` (`CoquiEngine.__init__` capture requested ~548; `_resolve_runtime_options` 577-590; the `_use_half` line ~671)
+- Create: `server/tts-sidecar/tests/test_coqui_device.py`
 
-**Interfaces:**
-- Consumes: `_parse_device` (Task 3), `KOKORO_DEVICE` env.
-- Produces: a pure helper `_kokoro_provider_options(device: str, providers: list[str]) -> Optional[list[dict]]` returning ORT `provider_options` (e.g. `[{"device_id": 1}, {}]` aligned to `providers`) for an indexed CUDA pin, else `None`. The construction passes it through when supported.
+**Why:** `_resolve_runtime_options` gates fp16/DeepSpeed on `device == "cuda"` — false for `cuda:1`, so an indexed pin silently runs fp32, no DeepSpeed (a perf regression). The model still loads on the right card via `.to`.
 
-- [ ] **Step 1: SPIKE — verify the pinned `kokoro-onnx` API**
+- [ ] **Step 1: Write the failing test**
 
-Run:
-```bash
-cd server/tts-sidecar
-.\.venv\Scripts\python.exe -c "import inspect, kokoro_onnx; print(inspect.signature(kokoro_onnx.Kokoro.__init__))"
-```
-Record whether `Kokoro.__init__` accepts `provider_options=` (or a `sess`/`session=` for a pre-built `InferenceSession`). This decides Step 4's branch. Note the result in the commit body. **Do not skip this** — the spec flags Kokoro `device_id` as contingent.
-
-- [ ] **Step 2: Write the failing test (pure helper — no model load)**
-
-Append to `tests/test_kokoro.py`:
+`server/tts-sidecar/tests/test_coqui_device.py`:
 ```python
-import importlib
+import importlib, os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 main = importlib.import_module("main")
 
+def test_coqui_indexed_cuda_keeps_half_and_deepspeed(monkeypatch):
+    monkeypatch.setenv("COQUI_DEVICE", "cuda:1")
+    monkeypatch.setenv("COQUI_HALF", "1")
+    monkeypatch.setenv("COQUI_DEEPSPEED", "1")
+    eng = main.CoquiEngine()
+    opts = eng._resolve_runtime_options()  # returns (device, half, deepspeed) or sets attrs — match the real signature
+    half = opts[1] if isinstance(opts, tuple) else eng._use_half
+    deepspeed = opts[2] if isinstance(opts, tuple) else getattr(eng, "_use_deepspeed", None)
+    assert half is True
+    assert deepspeed is True
+```
+> Read `_resolve_runtime_options` (main.py:577) first and adapt the assertion to its real return/attribute shape — keep the behavioural assertion (`half`/`deepspeed` True for `cuda:1`).
+
+- [ ] **Step 2: Run to verify it fails** — `.\.venv\Scripts\python.exe -m pytest tests/test_coqui_device.py -v` → FAIL (`cuda:1 != "cuda"` → half/deepspeed False).
+
+- [ ] **Step 3: Route Coqui through `_parse_device`**
+
+In `_resolve_runtime_options` (577-590) replace the `if device == "auto":` / `if device == "cuda":` checks so the family drives them:
+```python
+        family, _ = _parse_device(device)
+        # ... keep the existing auto-detection for family == "auto" ...
+        if family == "cuda":
+            # existing half / deepspeed enabling block, unchanged
+        else:
+            half = False
+            deepspeed = False
+```
+At the `_use_half` line (~671) replace `device == "cuda"` with `_parse_device(device)[0] == "cuda"`. Capture the request in `__init__` (~548) after the device read:
+```python
+        self._requested_device = self._device
+```
+
+- [ ] **Step 4: Run green** — `.\.venv\Scripts\python.exe -m pytest tests/test_coqui_device.py -v` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_coqui_device.py
+git commit -m "fix(sidecar): Coqui keeps fp16+DeepSpeed under an indexed cuda:N pin"
+```
+
+---
+
+### Task 6: Kokoro `device_id` plumbing (spike-gated, module-level helper)
+
+**Files:**
+- Modify: `server/tts-sidecar/main.py` (add module-level `_kokoro_provider_options`; `KokoroEngine` construction ~944 + capture requested)
+- Modify (APPEND): `server/tts-sidecar/tests/test_kokoro.py`
+
+**Interfaces:** module-level `_kokoro_provider_options(device, providers) -> Optional[list[dict]]` — for an indexed CUDA pin returns options aligned to `providers` with `device_id`; else `None`.
+
+- [ ] **Step 1: SPIKE — verify the API**
+
+Run: `cd server/tts-sidecar && .\.venv\Scripts\python.exe -c "import inspect,kokoro_onnx;print(inspect.signature(kokoro_onnx.Kokoro.__init__))"`
+Record whether `provider_options=` (or a `session=`) is accepted. Note the result in the commit body.
+
+- [ ] **Step 2: Append the failing test (module-level, pure)**
+
+```python
 def test_kokoro_provider_options_indexed_cuda():
     providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
-    opts = main._kokoro_provider_options("cuda:1", providers)
-    assert opts == [{"device_id": 1}, {}]
+    assert main._kokoro_provider_options("cuda:1", providers) == [{"device_id": 1}, {}]
+
+def test_kokoro_provider_options_synthesizes_when_providers_empty():
+    # NVIDIA box default: KOKORO_ORT_PROVIDERS unset → providers == [] — the pin
+    # must still attach a CUDA provider with the device_id, or it's inert.
+    assert main._kokoro_provider_options("cuda:1", []) == (
+        ["CUDAExecutionProvider", "CPUExecutionProvider"], [{"device_id": 1}, {}]
+    )
 
 def test_kokoro_provider_options_none_when_not_indexed():
     assert main._kokoro_provider_options("cpu", ["CPUExecutionProvider"]) is None
-    assert main._kokoro_provider_options("cuda", ["CUDAExecutionProvider"]) is None  # no index → ORT default
+    assert main._kokoro_provider_options("cuda", []) is None
     assert main._kokoro_provider_options("auto", []) is None
 ```
 
-- [ ] **Step 3: Run to verify it fails**
+- [ ] **Step 3: Run to verify it fails** — `.\.venv\Scripts\python.exe -m pytest tests/test_kokoro.py -k provider_options -v` → FAIL (undefined).
 
-Run: `.\.venv\Scripts\python.exe -m pytest tests/test_kokoro.py -k provider_options -v`
-Expected: FAIL — `_kokoro_provider_options` not defined.
+- [ ] **Step 4: Implement the module-level helper**
 
-- [ ] **Step 4: Implement the helper + wire it (branch on the spike)**
-
-Add near `_resolve_ort_providers`:
+Near `_parse_device`:
 ```python
-@staticmethod
-def _kokoro_provider_options(device: Optional[str], providers: list[str]) -> Optional[list[dict]]:
-    """Per-provider ORT options aligned to `providers`, setting CUDA `device_id`
-    for an indexed pin (e.g. KOKORO_DEVICE=cuda:1). Returns None when there is no
-    index to pin (ORT picks its default device) — keeps today's behaviour intact."""
+def _kokoro_provider_options(device: Optional[str], providers: list[str]):
+    """ORT provider_options for an indexed Kokoro CUDA pin (KOKORO_DEVICE=cuda:1).
+    Returns None when there's no index to pin. When `providers` is empty (the
+    NVIDIA default — KOKORO_ORT_PROVIDERS unset), SYNTHESIZE a CUDA+CPU list and
+    return (providers, options) so the device_id has somewhere to attach."""
     family, index = _parse_device(device)
-    if family != "cuda" or index is None or not providers:
+    if family != "cuda" or index is None:
         return None
+    if not providers:
+        providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+        opts = [{"device_id": index}, {}]
+        return (providers, opts)
     return [{"device_id": index} if p == "CUDAExecutionProvider" else {} for p in providers]
 ```
 
-At the `Kokoro(...)` construction (~944) — **if the spike showed `provider_options` is accepted:**
+- [ ] **Step 5: Wire the construction (branch on the spike)**
+
+At the `Kokoro(...)` call (~944), capture the request and apply options. **If the spike showed `provider_options` is accepted:**
 ```python
-    device = os.environ.get("KOKORO_DEVICE", "auto")
-    provider_options = KokoroEngine._kokoro_provider_options(device, providers)
-    kokoro_kwargs = {"providers": providers} if providers else {}
+    self._requested_device = os.environ.get("KOKORO_DEVICE", "auto")
+    po = _kokoro_provider_options(self._requested_device, providers)
+    if isinstance(po, tuple):           # synthesized (providers, options)
+        providers, provider_options = po
+    else:
+        provider_options = po           # list or None
+    kwargs = {}
+    if providers:
+        kwargs["providers"] = providers
     if provider_options is not None:
-        kokoro_kwargs["provider_options"] = provider_options
-    self._kokoro = Kokoro(self._model_path, self._voices_path, **kokoro_kwargs)
+        kwargs["provider_options"] = provider_options
+    self._kokoro = Kokoro(self._model_path, self._voices_path, **kwargs)
 ```
-Keep the existing `TypeError → no-kwarg fallback` (~945-950) so an older `kokoro-onnx` still loads.
+Keep the existing `TypeError → no-kwarg fallback` (~945-950). **If the spike showed only `session=`:** build `onnxruntime.InferenceSession(self._model_path, providers=providers, provider_options=provider_options)` and pass it via the exact kwarg the spike revealed.
 
-**If the spike showed only a `session=`/`sess=` path** (no `provider_options` kwarg): build the `InferenceSession` yourself and pass it — implement `_build_kokoro_session(providers, provider_options)` using `onnxruntime.InferenceSession(self._model_path, providers=providers, provider_options=provider_options)` and pass `sess=`. Pin the exact kwarg name from the spike.
+- [ ] **Step 6: Run green** — `.\.venv\Scripts\python.exe -m pytest tests/test_kokoro.py -k provider_options -v` → PASS. (Real-weights construction is on-box, Task 10.)
 
-- [ ] **Step 5: Run to verify the helper passes**
-
-Run: `.\.venv\Scripts\python.exe -m pytest tests/test_kokoro.py -k provider_options -v`
-Expected: PASS. (The construction itself is covered on-box — a unit test can't load real weights.)
-
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_kokoro.py
 git commit -m "feat(sidecar): Kokoro honours KOKORO_DEVICE via ORT provider device_id
 
-Spike result: kokoro-onnx Kokoro.__init__ <accepts provider_options | needs session=>."
+Spike: kokoro-onnx Kokoro.__init__ <accepts provider_options | needs session=>."
 ```
 
 ---
 
-### Task 6: `GET /devices` enumeration + server proxy
+### Task 7: `GET /api/gpu/devices` discovery (distinct from the LAN devices router)
 
 **Files:**
-- Modify: `server/tts-sidecar/main.py` (add `_enumerate_cuda_devices()` near `_cuda_vram_mb` ~3319; add a `@app.get("/devices")` route near the `/health` route)
-- Create: `server/src/routes/devices.ts` (proxy, mirroring `server/src/routes/sidecar-health.ts`)
-- Modify: the route registration site (wherever `sidecar-health` is mounted — `grep -rn "sidecar-health" server/src`)
-- Test: `server/tts-sidecar/tests/test_devices.py` (new); `server/src/routes/devices.test.ts` (new)
+- Modify: `server/tts-sidecar/main.py` (add `_sample_card(idx, torch_module)` + `_enumerate_cuda_devices(torch_module=None)` near `_cuda_vram_mb` ~3319; add a `GET /devices` route)
+- Create: `server/src/routes/gpu-devices.ts` (proxy — **NOT** `devices.ts`, which is the LAN-pairing auth router)
+- Modify: `server/src/app.ts` (mount `app.use('/api/gpu', gpuDevicesRouter)` near the other route mounts ~188)
+- Create: `server/tts-sidecar/tests/test_devices.py`, `server/src/routes/gpu-devices.test.ts`
 
 **Interfaces:**
-- Produces: sidecar `GET /devices` → `{"devices":[{"uuid","idx","name","total_mb","free_mb"}], "cpu": true}`; server proxy `GET /api/devices` returning the same. Task 7 + Plan 2 consume this shape.
+- `_sample_card(idx, torch_module) -> dict` — `{uuid, idx, name, total_mb, free_mb}` for one device (the reusable primitive Wave 2's ledger wraps).
+- sidecar `GET /devices` → `{"devices":[…], "cpu": true}`; server `GET /api/gpu/devices` proxies it.
 
-- [ ] **Step 1: Write the failing sidecar test**
+- [ ] **Step 1: Write the failing sidecar test (inject torch — do NOT setattr main.torch)**
 
 `server/tts-sidecar/tests/test_devices.py`:
 ```python
-import importlib
+import importlib, os, sys, types
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 main = importlib.import_module("main")
 
-def test_enumerate_returns_list_of_card_dicts(monkeypatch):
-    class _Props:
-        def __init__(self, name, total, uuid): self.name=name; self.total_memory=total; self.uuid=uuid
-    class _Cuda:
-        @staticmethod
-        def is_available(): return True
-        @staticmethod
-        def device_count(): return 2
-        @staticmethod
-        def get_device_properties(i):
-            return _Props(["RTX 4070","RTX 5070 Ti"][i], [8*10**9,16*10**9][i], f"GPU-{i}")
-        @staticmethod
-        def mem_get_info(i): return ([6*10**9, 14*10**9][i], [8*10**9,16*10**9][i])
-    monkeypatch.setattr(main, "torch", type("T", (), {"cuda": _Cuda})(), raising=False)
-    out = main._enumerate_cuda_devices()
+def _fake_torch():
+    def props(i):
+        return types.SimpleNamespace(name=["RTX 4070","RTX 5070 Ti"][i],
+                                     total_memory=[8*10**9,16*10**9][i], uuid=f"GPU-{i}")
+    cuda = types.SimpleNamespace(
+        is_available=lambda: True, device_count=lambda: 2,
+        get_device_properties=props,
+        mem_get_info=lambda i: ([6*10**9,14*10**9][i], [8*10**9,16*10**9][i]))
+    return types.SimpleNamespace(cuda=cuda)
+
+def test_enumerate_cards():
+    out = main._enumerate_cuda_devices(_fake_torch())
     assert [d["idx"] for d in out] == [0, 1]
-    assert out[1]["name"] == "RTX 5070 Ti"
-    assert out[1]["total_mb"] == 16000 and out[1]["free_mb"] == 14000
-    assert out[1]["uuid"] == "GPU-1"
+    assert out[1] == {"uuid": "GPU-1", "idx": 1, "name": "RTX 5070 Ti", "total_mb": 16000, "free_mb": 14000}
+
+def test_enumerate_empty_without_cuda():
+    fake = types.SimpleNamespace(cuda=types.SimpleNamespace(is_available=lambda: False))
+    assert main._enumerate_cuda_devices(fake) == []
 ```
 
-> Read how the existing sidecar tests stub torch (`tests/test_device_probe.py` uses a `_StubTorch`); match that injection style if `main` imports torch lazily rather than as a module global.
+- [ ] **Step 2: Run to verify it fails** — `.\.venv\Scripts\python.exe -m pytest tests/test_devices.py -v` → FAIL (undefined).
 
-- [ ] **Step 2: Run to verify it fails**
-
-Run: `.\.venv\Scripts\python.exe -m pytest tests/test_devices.py -v`
-Expected: FAIL — `_enumerate_cuda_devices` not defined.
-
-- [ ] **Step 3: Implement the enumerator + route**
+- [ ] **Step 3: Implement the sampler + enumerator with injectable torch**
 
 Near `_cuda_vram_mb` (~3319):
 ```python
-def _enumerate_cuda_devices() -> list[dict]:
-    """[{uuid, idx, name, total_mb, free_mb}] per visible CUDA device, driver
-    truth via mem_get_info (sees ALL allocators). [] when CUDA is unavailable."""
+def _sample_card(idx: int, torch_module: Any) -> dict:
+    """One card's discovery row (driver truth via mem_get_info — sees ALL
+    allocators). The reusable primitive Wave 2's ledger wraps per-sample."""
+    props = torch_module.cuda.get_device_properties(idx)
+    free, total = torch_module.cuda.mem_get_info(idx)
+    return {
+        "uuid": str(getattr(props, "uuid", "")) or f"idx-{idx}",
+        "idx": idx,
+        "name": props.name,
+        "total_mb": round(total / 1_000_000),
+        "free_mb": round(free / 1_000_000),
+    }
+
+
+def _enumerate_cuda_devices(torch_module: Any = None) -> list[dict]:
+    """[{uuid,idx,name,total_mb,free_mb}] per visible CUDA device, [] when CUDA is
+    unavailable. torch_module is injectable for tests (default → local import)."""
     try:
-        import torch  # type: ignore
-        if not torch.cuda.is_available():
+        if torch_module is None:
+            import torch as torch_module  # type: ignore
+        if not torch_module.cuda.is_available():
             return []
-        out = []
-        for i in range(torch.cuda.device_count()):
-            props = torch.cuda.get_device_properties(i)
-            free, total = torch.cuda.mem_get_info(i)
-            out.append({
-                "uuid": str(getattr(props, "uuid", "")) or f"idx-{i}",
-                "idx": i,
-                "name": props.name,
-                "total_mb": round(total / 1_000_000),
-                "free_mb": round(free / 1_000_000),
-            })
-        return out
+        return [_sample_card(i, torch_module) for i in range(torch_module.cuda.device_count())]
     except Exception:
         return []
 ```
-
 Add the route next to `/health`:
 ```python
 @app.get("/devices")
 def devices() -> dict:
-    """Discovery for the picker: visible GPUs + a cpu pseudo-option."""
     return {"devices": _enumerate_cuda_devices(), "cpu": True}
 ```
 
-- [ ] **Step 4: Run to verify it passes**
+- [ ] **Step 4: Run green** — `.\.venv\Scripts\python.exe -m pytest tests/test_devices.py -v` → PASS.
 
-Run: `.\.venv\Scripts\python.exe -m pytest tests/test_devices.py -v`
-Expected: PASS.
+- [ ] **Step 5: Failing proxy test + implement (new file + new mount)**
 
-- [ ] **Step 5: Write the failing proxy test + implement the proxy**
+`server/src/routes/gpu-devices.test.ts` — mirror `sidecar-health.test.ts`'s fetch-mock pattern: stand up the router, stub the sidecar `/devices` body, assert `GET /api/gpu/devices` forwards it, and returns `{devices:[],cpu:true}` when the sidecar is down. `server/src/routes/gpu-devices.ts` — copy `sidecar-health.ts`'s proxy shape (bare `Router()`, `.get('/devices')`, fetch the sidecar `/devices`, timeout + error fallback). In `app.ts`, near the existing `app.use('/api/sidecar', …)` (~188), add `app.use('/api/gpu', gpuDevicesRouter)` and its import.
 
-`server/src/routes/devices.test.ts` — mirror `sidecar-health.test.ts`: stand up the router with a fake sidecar returning the `/devices` body and assert `GET /api/devices` returns it (and `{devices:[],cpu:true}` when the sidecar is down). Copy the exact mounting + fetch-mock pattern from `sidecar-health.test.ts`.
-
-`server/src/routes/devices.ts` — copy `sidecar-health.ts` and swap the upstream path to `/devices` and the mount path to `/api/devices`; keep its timeout/error-fallback handling (return `{devices:[],cpu:true}` on upstream failure). Register it where `sidecar-health` is registered.
-
-- [ ] **Step 6: Run to verify the proxy passes**
-
-Run: `cd server && npx vitest run src/routes/devices.test.ts`
-Expected: PASS.
+- [ ] **Step 6: Run green** — `cd server && npx vitest run src/routes/gpu-devices.test.ts` → PASS.
 
 - [ ] **Step 7: Commit**
 
 ```bash
-git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_devices.py server/src/routes/devices.ts server/src/routes/devices.test.ts server/src/<route-registration-file>.ts
-git commit -m "feat(sidecar,server): GET /devices GPU discovery + /api/devices proxy"
+git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_devices.py server/src/routes/gpu-devices.ts server/src/routes/gpu-devices.test.ts server/src/app.ts
+git commit -m "feat(sidecar,server): GET /devices discovery + /api/gpu/devices proxy"
 ```
 
 ---
 
-### Task 7: `/health` `gpus[]` actual-card readback
+### Task 8: Actual-card readback — `_engine_actual_card` (real index + fell_back)
 
 **Files:**
-- Modify: `server/tts-sidecar/main.py` (the `/health` handler ~4060-4109 — add a `gpus` key; add `_engine_actual_card(engine)` + `_resident_engines_by_card()` helpers)
-- Test: `server/tts-sidecar/tests/test_devices.py` (extend) or `tests/test_runtime_wiring.py` if `/health` shape is asserted there
+- Modify: `server/tts-sidecar/main.py` (add `_engine_actual_card`)
+- Modify (APPEND): `server/tts-sidecar/tests/test_devices.py`
 
-**Interfaces:**
-- Consumes: `_enumerate_cuda_devices` (Task 6), `_parse_device` (Task 3), the existing `_normalize_device_family`/`_kokoro_session_device`.
-- Produces: `/health` gains `"gpus": [{uuid, idx, name, total_mb, free_mb, torch_reserved_mb, resident:[{engine, actual_card}], stale_reason?}]`. The existing `devices` map and all other fields are untouched (Global Constraint: additive).
+**Interfaces:** `_engine_actual_card(engine) -> dict | None` → `{"family": str, "index": Optional[int], "fell_back": bool}` or `None` when the engine is unloaded. `index` is the real torch ordinal (`next(model.parameters()).device.index`) for torch engines, `None` for ORT/CT2. `fell_back` is `True` when the **requested** family was cuda but the **actual** is cpu.
 
-**Note on granularity:** torch engines (Qwen/Coqui/SPK) report an actual *index* via `param.device.index`; Kokoro (ORT) and Whisper (CT2) report **family + a `fell_back` flag** only — never an index. When a CUDA-pinned engine resolves to CPU, set `stale_reason="cpu_fallback"` on that engine's `resident` entry.
+- [ ] **Step 1: Append the failing test (exercise the REAL helper, no mocks)**
 
-- [ ] **Step 1: Write the failing test**
-
-Append to `tests/test_devices.py`:
 ```python
-def test_health_includes_gpus_array(monkeypatch):
-    # stub enumeration so the assertion is deterministic without real CUDA
-    monkeypatch.setattr(main, "_enumerate_cuda_devices", lambda: [
-        {"uuid": "GPU-0", "idx": 0, "name": "RTX 4070", "total_mb": 8000, "free_mb": 6000},
-    ])
-    monkeypatch.setattr(main, "_resident_engines_by_card", lambda cards: {0: [{"engine": "qwen", "actual_card": 0}]})
-    payload = main._build_gpus_payload()
-    assert payload[0]["uuid"] == "GPU-0"
-    assert payload[0]["resident"] == [{"engine": "qwen", "actual_card": 0}]
+import types
+def test_engine_actual_card_detects_cpu_fallback():
+    # a fake engine that REQUESTED cuda:1 but actually resolved to cpu
+    eng = types.SimpleNamespace(_requested_device="cuda:1", device="cpu", _model=object())
+    card = main._engine_actual_card(eng)
+    assert card["family"] == "cpu"
+    assert card["fell_back"] is True
+
+def test_engine_actual_card_none_when_unloaded():
+    eng = types.SimpleNamespace(_requested_device="cuda:1", device="cpu", _model=None)
+    assert main._engine_actual_card(eng) is None
 ```
 
-- [ ] **Step 2: Run to verify it fails**
+- [ ] **Step 2: Run to verify it fails** — `.\.venv\Scripts\python.exe -m pytest tests/test_devices.py -k actual_card -v` → FAIL.
 
-Run: `.\.venv\Scripts\python.exe -m pytest tests/test_devices.py::test_health_includes_gpus_array -v`
-Expected: FAIL — `_build_gpus_payload` not defined.
-
-- [ ] **Step 3: Implement the actual-card helpers + payload builder**
+- [ ] **Step 3: Implement `_engine_actual_card`**
 
 ```python
-def _engine_actual_card(engine: Any) -> tuple[Optional[str], Optional[int], bool]:
-    """(family, card_index, fell_back). Index is torch-only; ORT/CT2 give family.
-    fell_back is True when a cuda pin actually resolved to cpu."""
-    fam = idx = None
-    # torch engines expose a real device on the loaded module
-    dev = getattr(engine, "_resolved_device", None) or getattr(engine, "_device", None) or getattr(engine, "device", None)
-    if dev is not None:
-        fam, idx = _parse_device(str(dev))
-    requested_fam, _ = _parse_device(str(getattr(engine, "_requested_device", dev) or "auto"))
-    fell_back = (requested_fam == "cuda" and fam == "cpu")
-    return (fam, idx, fell_back)
-
-
-def _build_gpus_payload() -> list[dict]:
-    """gpus[] for /health: discovered cards + per-card torch_reserved + resident
-    engines with their ACTUAL device (not the requested knob)."""
-    cards = _enumerate_cuda_devices()
-    reserved_by_idx = {}
+def _engine_actual_card(engine: Any) -> Optional[dict]:
+    """(family, index, fell_back) for a LOADED engine, else None. index is the
+    real torch ordinal for torch engines; None for ORT/CT2 (family only).
+    fell_back = requested cuda but resolved cpu (the silent-CPU signal)."""
+    model = getattr(engine, "_model", None) or getattr(engine, "_kokoro", None) or getattr(engine, "_base", None)
+    if model is None:
+        return None
+    requested_fam, _ = _parse_device(getattr(engine, "_requested_device", None))
+    # actual device: prefer the loaded torch module's real device; fall back to the string attr
+    family = index = None
     try:
-        import torch  # type: ignore
-        for c in cards:
-            reserved_by_idx[c["idx"]] = round(torch.cuda.memory_reserved(c["idx"]) / 1_000_000)
+        params = getattr(model, "parameters", None)
+        if callable(params):
+            dev = next(params()).device
+            family, index = ("cuda" if dev.type == "cuda" else dev.type), dev.index
     except Exception:
         pass
+    if family is None:  # ORT/CT2 or no params(): use the string attr (family only)
+        family, _ = _parse_device(getattr(engine, "device", None) or getattr(engine, "_device", None))
+    fell_back = (requested_fam == "cuda" and family == "cpu")
+    return {"family": family, "index": index, "fell_back": fell_back}
+```
+> For Kokoro specifically, also reconcile against `_kokoro_session_device(engine)` (main.py:4002, family from ORT providers) when `family` is still unknown — set `family` from it so a Kokoro CUDA→CPU provider drop yields `fell_back=True`.
+
+- [ ] **Step 4: Run green** — `.\.venv\Scripts\python.exe -m pytest tests/test_devices.py -v` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_devices.py
+git commit -m "feat(sidecar): _engine_actual_card reports real device + cpu_fallback"
+```
+
+---
+
+### Task 9: `/health` `gpus[]` payload + wiring
+
+**Files:**
+- Modify: `server/tts-sidecar/main.py` (add `_resident_engines_by_card` + `_build_gpus_payload`; add `"gpus"` to the `/health` return ~4109)
+- Modify (APPEND): `server/tts-sidecar/tests/test_devices.py`
+
+**Interfaces:** `_build_gpus_payload(torch_module=None) -> list[dict]` — each card from `_enumerate_cuda_devices` plus `torch_reserved_mb` and `resident:[{engine, actual_card, stale_reason?}]`. `actual_card` is the torch index or `null` (ORT/CT2). `stale_reason:"cpu_fallback"` on an engine whose `_engine_actual_card.fell_back` is True.
+
+- [ ] **Step 1: Append the failing tests**
+
+```python
+def test_resident_buckets_engines_by_card(monkeypatch):
+    # ENGINES["qwen"] loaded on card 1; ASR fell back to cpu
+    monkeypatch.setattr(main, "_engine_actual_card",
+        lambda e: {"family": "cuda", "index": 1, "fell_back": False} if e is main.ENGINES["qwen"]
+        else ({"family": "cpu", "index": None, "fell_back": True} if e is main.ASR else None))
+    by_card = main._resident_engines_by_card([{"idx": 0}, {"idx": 1}])
+    assert {"engine": "qwen", "actual_card": 1} in by_card[1]
+    # a fell_back engine is recorded with stale_reason (card key is the cpu bucket convention)
+    flat = [r for v in by_card.values() for r in v]
+    assert any(r.get("stale_reason") == "cpu_fallback" and r["engine"] == "asr" for r in flat)
+
+def test_build_gpus_payload_merges(monkeypatch):
+    monkeypatch.setattr(main, "_enumerate_cuda_devices", lambda tm=None: [{"uuid":"GPU-1","idx":1,"name":"x","total_mb":16000,"free_mb":14000}])
+    monkeypatch.setattr(main, "_resident_engines_by_card", lambda cards: {1: [{"engine":"qwen","actual_card":1}]})
+    out = main._build_gpus_payload(_fake_torch())
+    assert out[0]["resident"] == [{"engine": "qwen", "actual_card": 1}]
+    assert "torch_reserved_mb" in out[0]
+```
+
+- [ ] **Step 2: Run to verify it fails** — `.\.venv\Scripts\python.exe -m pytest tests/test_devices.py -k "resident or gpus_payload" -v` → FAIL.
+
+- [ ] **Step 3: Implement the bucketer + payload builder**
+
+```python
+def _resident_engines_by_card(cards: list[dict]) -> dict:
+    """{card_idx: [{engine, actual_card, stale_reason?}]} over the loaded engines.
+    Engines live in ENGINES (coqui/kokoro/qwen) + the ASR/SPK singletons — NOT as
+    bare COQUI/QWEN globals."""
+    named = list(ENGINES.items()) + [("asr", ASR), ("spk", SPK)]
+    out: dict = {}
+    for name, eng in named:
+        card = _engine_actual_card(eng)
+        if card is None:
+            continue
+        idx = card["index"] if card["index"] is not None else -1  # -1 bucket = unindexed/cpu
+        entry = {"engine": name, "actual_card": card["index"]}
+        if card["fell_back"]:
+            entry["stale_reason"] = "cpu_fallback"
+        out.setdefault(idx, []).append(entry)
+    return out
+
+
+def _build_gpus_payload(torch_module: Any = None) -> list[dict]:
+    cards = _enumerate_cuda_devices(torch_module)
     resident = _resident_engines_by_card(cards)
+    try:
+        if torch_module is None:
+            import torch as torch_module  # type: ignore
+        for c in cards:
+            c["torch_reserved_mb"] = round(torch_module.cuda.memory_reserved(c["idx"]) / 1_000_000)
+    except Exception:
+        for c in cards:
+            c["torch_reserved_mb"] = 0
     for c in cards:
-        c["torch_reserved_mb"] = reserved_by_idx.get(c["idx"], 0)
         c["resident"] = resident.get(c["idx"], [])
     return cards
 ```
-
-Add `_resident_engines_by_card(cards)` that walks the loaded engines (`COQUI`/`KOKORO`/`QWEN`/`ASR`/`SPK` singletons), calls `_engine_actual_card`, and buckets `{idx: [{"engine": name, "actual_card": idx, ...("stale_reason":"cpu_fallback" if fell_back)}]}`. For ORT/CT2 engines with no index, place them under their family without an index key and still flag `fell_back`. Keep it defensive — an unloaded engine contributes nothing.
-
-In the `/health` return dict (after the `"devices": devices,` line ~4109), add:
+In the `/health` return dict, after `"devices": devices,` (~4109) add:
 ```python
         "gpus": _build_gpus_payload(),
 ```
 
-- [ ] **Step 4: Run to verify it passes**
+- [ ] **Step 4: Run green** — `.\.venv\Scripts\python.exe -m pytest tests/test_devices.py -v` → PASS.
 
-Run: `.\.venv\Scripts\python.exe -m pytest tests/test_devices.py -v`
-Expected: PASS.
+- [ ] **Step 5: Assert the `/health` key actually appears + additive contract holds**
 
-- [ ] **Step 5: Guard the additive contract**
-
-Run the existing health-shape test to prove nothing broke: `.\.venv\Scripts\python.exe -m pytest tests/test_runtime_wiring.py -v` (and any test asserting `/health` keys).
-Expected: PASS — `devices`, `asr_device`, etc. unchanged.
+Append a test that calls the real health handler (mirror how `tests/test_runtime_wiring.py` invokes `/health`) and asserts `"gpus" in payload` **and** the pre-existing keys (`devices`, `asr_device`, `spk_device`) are unchanged. Run `tests/test_runtime_wiring.py` too.
+Expected: PASS — `gpus` present; nothing else changed.
 
 - [ ] **Step 6: Commit**
 
 ```bash
 git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_devices.py
-git commit -m "feat(sidecar): /health gpus[] reports each engine's actual resident card"
+git commit -m "feat(sidecar): /health gpus[] reports resident engines' actual card"
 ```
 
 ---
 
-### Task 8: Wave 1 on-box acceptance checklist (written deliverable)
+### Task 10: Torch out-of-range index guard + on-box acceptance
 
 **Files:**
-- Create: `docs/features/<n>-multi-gpu.md` from `docs/features/TEMPLATE.md` (assign `<n>` per the backlog; tag the issue `needs-plan`)
+- Modify: `server/tts-sidecar/main.py` (validate a torch `cuda:N` index at engine load for Qwen/Coqui — surface a clear error instead of a raw `.to` crash that the supervisor would crash-loop)
+- Modify (APPEND): `server/tts-sidecar/tests/test_device_parse.py`
+- Modify: the Wave 1 plan doc Ship-notes (this file) — append the acceptance checklist (no new numbered doc)
 
-**Interfaces:** none (documentation). This converts the spec's "named, not written" acceptance into explicit pass/fail lines for the one operator with the 2-GPU box.
+**Interfaces:** `_validate_cuda_index(device, torch_module) -> None` — raises `ValueError("cuda:N out of range; only M GPUs")` when `index >= device_count`; no-op otherwise. Called at the top of Qwen/Coqui load.
 
-- [ ] **Step 1: Write the acceptance section**
+- [ ] **Step 1: Append the failing test**
 
-In the new plan doc, under a `## Wave 1 acceptance (on-box, 2-GPU)` heading, list these explicit checks (each a checkbox the operator ticks):
+```python
+def test_validate_cuda_index_rejects_out_of_range():
+    fake = types.SimpleNamespace(cuda=types.SimpleNamespace(is_available=lambda: True, device_count=lambda: 2))
+    main._validate_cuda_index("cuda:9", fake)  # expect raises
+```
+Wrap with `import pytest; with pytest.raises(ValueError): main._validate_cuda_index("cuda:9", fake)` and a passing case `main._validate_cuda_index("cuda:1", fake)` (no raise).
+
+- [ ] **Step 2: Run to verify it fails** — FAIL (undefined).
+
+- [ ] **Step 3: Implement + call at torch-engine load**
+
+```python
+def _validate_cuda_index(device: str, torch_module: Any) -> None:
+    family, index = _parse_device(device)
+    if family == "cuda" and index is not None and torch_module.cuda.is_available():
+        n = torch_module.cuda.device_count()
+        if index >= n:
+            raise ValueError(f"{device} out of range; only {n} CUDA device(s) visible")
+```
+Call it in `QwenEngine` and `CoquiEngine` load paths just before `.to(...)`, passing the locally-imported torch. A raised `ValueError` surfaces as a load error (the engine reports unloaded + the message reaches `/health`/logs) rather than a hard CUDA crash that the supervisor would treat as a recyclable death.
+
+- [ ] **Step 4: Run green** — PASS.
+
+- [ ] **Step 5: Append the on-box acceptance checklist to this plan's Ship-notes**
+
+Add a `## Ship notes — Wave 1 on-box acceptance (2-GPU)` section to THIS file with these checks:
 ```markdown
-- [ ] `GET /api/devices` lists both cards with correct names + total_mb (8000 / 16000) and a live free_mb.
-- [ ] `QWEN_DEVICE=cuda:1` then restart → `/health` gpus[] shows qwen resident with actual_card=1 (torch index truth).
-- [ ] `ASR_DEVICE=cuda:1` then transcribe → no CTranslate2 error; `asrRunsOnGpu()` true (semaphore token taken).
-- [ ] `SPK_DEVICE=cuda:1` then an embed → ECAPA loads on cuda:1 (no degrade-to-cpu warning).
-- [ ] `KOKORO_DEVICE=cuda:1` then a Kokoro synth → no fell_back flag in gpus[]; (index unverifiable for ORT — confirm via nvidia-smi that VRAM lands on card 1).
-- [ ] Force a fallback: `KOKORO_DEVICE=cuda:9` (no such card) → gpus[] flags kokoro stale_reason=cpu_fallback, sidecar serves from CPU, no crash.
-- [ ] All existing `/health` fields unchanged (diff against a pre-Wave-1 capture).
+- [ ] `GET /api/gpu/devices` lists both cards with correct names + total_mb (≈8000 / 16000) and a live free_mb.
+- [ ] `QWEN_DEVICE=cuda:1` + restart → `/health` gpus[] shows qwen resident actual_card=1 (real torch index).
+- [ ] `COQUI_DEVICE=cuda:1` + a Coqui synth → logs show half=True deepspeed=True (no perf regression).
+- [ ] `ASR_DEVICE=cuda:1` + transcribe → no CTranslate2 error; semaphore token taken.
+- [ ] `SPK_DEVICE=cuda:1` + embed → ECAPA on cuda:1 (no degrade warning).
+- [ ] `KOKORO_DEVICE=cuda:1` + synth → nvidia-smi shows VRAM on card 1; gpus[] kokoro NOT flagged cpu_fallback.
+- [ ] `KOKORO_DEVICE=cuda:9` (no such card) → gpus[] flags kokoro stale_reason=cpu_fallback; serves from CPU; no crash.
+- [ ] `QWEN_DEVICE=cuda:9` → load surfaces a clear "out of range" error; sidecar does NOT crash-loop.
+- [ ] Diff `/health` against a pre-Wave-1 capture: every prior field unchanged; only `gpus` added.
 ```
 
-- [ ] **Step 2: Update the features index + commit**
-
-Add the new doc under its area in `docs/features/INDEX.md`.
+- [ ] **Step 6: Commit**
 
 ```bash
-git add docs/features/<n>-multi-gpu.md docs/features/INDEX.md
-git commit -m "docs(docs): Wave 1 multi-GPU on-box acceptance checklist"
+git add server/tts-sidecar/main.py server/tts-sidecar/tests/test_device_parse.py docs/superpowers/plans/2026-06-27-multi-gpu-wave1-placement-visibility.md
+git commit -m "feat(sidecar): guard out-of-range cuda index + Wave 1 acceptance checklist"
 ```
 
 ---
 
 ## Self-Review
 
-**Spec coverage (Wave 1, §1.1–1.5):**
-- §1.1 discovery + per-card sampler → Task 6 (`/devices`, `_enumerate_cuda_devices`) + Task 7 (`gpus[]`). ✓
-- §1.2 config knobs (widen COQUI/SPK; add KOKORO/ASR) → Task 1. ✓
-- §1.3 adapter + the inline `== "cuda"` sites (Whisper compute-type+device, SPK ×2, Kokoro device_id) → Tasks 3, 4, 5 (`_parse_device` is the adapter core; Qwen/Coqui already torch-indexed via `_resolve_torch_device`, verified at `main.py:1174`). ✓
-- §1.4 Node gates (ASR + SPK embed) → Task 2. ✓
-- §1.5 actual-card readback + `stale_reason` (cpu_fallback) → Task 7. ✓
-- Written on-box checklist → Task 8. ✓
+**Spec coverage (§1.1–1.5):**
+- §1.1 discovery + reusable sampler → Task 7 (`_sample_card`/`_enumerate_cuda_devices`, injectable torch) + Task 9 (`gpus[]`). ✓
+- §1.2 knobs (widen COQUI/SPK; add KOKORO/ASR) → Task 1 (+ resolver-test repoint, config:sync). ✓
+- §1.3 device-grammar adapter + every inline `== "cuda"` site → Task 3 (`_parse_device`/`_ct2_kwargs`, Whisper), Task 4 (SPK present-check + run_opts), Task 5 (**Coqui fp16/DeepSpeed** — the site the first draft missed), Task 6 (Kokoro device_id incl. the empty-providers synthesize), Qwen already index-safe via `_resolve_torch_device` (main.py:1542). ✓
+- §1.4 Node gates (ASR + SPK) → Task 2 (append, `.js` imports). ✓
+- §1.5 actual-card readback + `cpu_fallback` → Task 8 (`_engine_actual_card` reads `_requested_device` captured in Tasks 3/4/5/6; real `param.device.index`; ORT family) + Task 9 (`gpus[]` resident, `stale_reason` on the resident entry). ✓
+- Degrade-loudly for a bad torch index (spec Goal) → Task 10. ✓
 
-**Placeholder scan:** Task 5's spike + Task 4's class-name read are *instructions to verify a real value*, not placeholders — each has a concrete command and a concrete fallback. The `<n>` in Task 8 and `<route-registration-file>` in Task 6 are repo lookups with a stated `grep`. No "TBD/handle edge cases/write tests for the above."
+**Defects fixed from the first draft:** torch stub via parameter injection (Tasks 7/9); `_requested_device` now captured before any demote (Tasks 3/4/5/6) so `fell_back` works (Task 8); `gpu-devices.ts` avoids the LAN `devices.ts` collision (Task 7); registry test uses real `getKnob`/`resolveKnob` + mocked `readConfigOverrides` (Task 1); enum-exemplar `resolver.test.ts` repointed (Task 1); Node gate tests appended not clobbered (Task 2); `_resident_engines_by_card` iterates `ENGINES` + `ASR`/`SPK` (Task 9); Kokoro device_id synthesizes providers on an NVIDIA box (Task 6); Coqui fp16/DeepSpeed preserved (Task 5); `config:sync` from root (Task 1); `_ct2_kwargs`/`_kokoro_provider_options`/`_engine_actual_card` are pure + unit-tested; negative tests `cuda:9`/`cuda:x` added (Tasks 3/10); `/health` `gpus` presence asserted (Task 9 Step 5); class name `SpeakerEngine` (Task 4).
 
-**Type consistency:** `_parse_device(value) -> (family, index)` is defined in Task 3 and consumed with that exact shape in Tasks 4, 5, 7. `_enumerate_cuda_devices()` dict shape (`uuid/idx/name/total_mb/free_mb`) defined in Task 6, extended (not renamed) in Task 7. `asrRunsOnGpu`/`spkRunsOnGpu` keep their boolean signatures (Task 2).
+**Type consistency:** `_parse_device → (family, index)` consumed identically in Tasks 4–10. `_engine_actual_card → {family,index,fell_back}` (Task 8) consumed by `_resident_engines_by_card` (Task 9). `_enumerate_cuda_devices`/`_sample_card` dict shape (Task 7) extended additively in Task 9. `_kokoro_provider_options` may return `list | (providers, options) tuple | None` — handled explicitly at the Task 6 call site.
 
-**Known soft spots flagged for execution, not hidden:** Task 5 (Kokoro) is genuinely contingent on the `kokoro-onnx` API — the spike is Step 1 and the fallback is specified. Task 7's `_resident_engines_by_card` walk depends on the actual singleton names (`COQUI`/`KOKORO`/`QWEN`/`ASR`/`SPK`) and each engine's loaded-device attribute — the implementer reads the engine classes to confirm attribute names before writing the bucketing loop.
+**Remaining execution-time reads (flagged, not hidden):** Task 5 must match `_resolve_runtime_options`'s real return/attr shape; Task 6 Step 1 spike decides the Kokoro kwarg; Task 8's Kokoro `_kokoro_session_device` reconciliation and Task 9's health-handler invocation follow the existing `test_runtime_wiring.py` pattern — the implementer reads those before writing.

--- a/docs/superpowers/specs/2026-06-27-multi-gpu-per-model-design.md
+++ b/docs/superpowers/specs/2026-06-27-multi-gpu-per-model-design.md
@@ -28,11 +28,17 @@ blind or wrong: the watchdog watches the wrong card, and eviction fires
 across cards that don't actually share VRAM.
 
 This box (the reference hardware) has an **RTX 4070 Laptop 8 GB** (`cuda:0` by
-torch's default enumeration) and an **RTX 5070 Ti 16 GB** (`cuda:1`). A
-verified stop-gap (`CUDA_DEVICE_ORDER=PCI_BUS_ID` + `CUDA_VISIBLE_DEVICES=1,0`
-in `server/.env`) remaps the 16 GB card to the visible `cuda:0` so the heavy
-synth path and the watchdog both land on it. This spec replaces that stop-gap
-with a real, per-model picker backed by a device-aware runtime.
+torch's default enumeration; **also drives the display**, so its *free* VRAM is
+well under 8 GB) and an **RTX 5070 Ti 16 GB** (`cuda:1`). A verified stop-gap
+(`CUDA_DEVICE_ORDER=PCI_BUS_ID` + `CUDA_VISIBLE_DEVICES=1,0` in `server/.env`)
+remaps the 16 GB card to the visible `cuda:0` so the heavy synth path and the
+watchdog both land on it.
+
+**This feature owns device mapping.** When the picker ships, the
+`CUDA_VISIBLE_DEVICES` stop-gap is **removed**: the sidecar enumerates all
+physical cards in raw order, and the picker assigns by **GPU UUID** (see the
+`DeviceLedger` keystone below) directly to physical cards — one mechanism, no
+hidden remap layer. The stop-gap stays in place only until the picker lands.
 
 ## Goal
 
@@ -47,14 +53,22 @@ default-off** layer on top of the manual picker.
 
 ### Assignable units (6)
 
-| Unit | Control plane | Existing knob | Notes |
-|---|---|---|---|
-| **Qwen** (Base 0.6B + VoiceDesign 1.7B) | sidecar env | `QWEN_DEVICE` | Base + VoiceDesign **share one assignment** — they co-reside during a design session. One picker row. |
-| **Coqui XTTS** | sidecar env | `COQUI_DEVICE` | |
-| **Kokoro** | sidecar env | _new_ `KOKORO_DEVICE` | eagerly-resident English fallback (~1 GB). |
-| **Whisper ASR** (content QA / WER) | sidecar env | `ASR_DEVICE` | already CPU-first-capable. |
-| **ECAPA drift** (voice-consistency QA) | sidecar env | `SPK_DEVICE` | srv-47 already made `cuda` *safe*; CPU is today's default. |
-| **Analyzer (Ollama)** | Ollama daemon / `/api/chat` | _new_ pref → `main_gpu` | separate process; `main_gpu` per-request lever + documented daemon `CUDA_VISIBLE_DEVICES` hard-pin. Note: this box currently runs `ANALYZER=gemini` (cloud), so local placement is moot until `ANALYZER=local`. |
+| Unit | Runtime | Device API | Existing knob | Notes |
+|---|---|---|---|---|
+| **Qwen** (Base 0.6B + VoiceDesign 1.7B) | torch | `cuda:N` via `.to()` | `QWEN_DEVICE` | Base + VoiceDesign **share one assignment** — they co-reside during a design session. One picker row. |
+| **Coqui XTTS** | torch | `cuda:N` via `.to()` | `COQUI_DEVICE` | |
+| **ECAPA drift** (voice-consistency QA) | torch (speechbrain) | `cuda:N` via `.to()` | `SPK_DEVICE` | srv-47 already made `cuda` *safe*; CPU is today's default. |
+| **Kokoro** | **onnxruntime** | **ORT provider `device_id`** | _new_ `KOKORO_DEVICE` | eagerly-resident English fallback (~1 GB). **Separate allocator from torch** (`main.py:460`) — `cuda:N` is meaningless to it. |
+| **Whisper ASR** (content QA / WER) | **CTranslate2** | **`device="cuda"` + `device_index`** | `ASR_DEVICE` | already CPU-first-capable. **Separate allocator from torch**; does *not* accept `cuda:N`. |
+| **Analyzer (Ollama)** | Ollama daemon | **daemon `CUDA_VISIBLE_DEVICES`** | _new_ pref | separate process. Restart-to-apply via daemon env; `main_gpu` is *not* a reliable pin (it only chooses the primary GPU in split mode). Note: this box currently runs `ANALYZER=gemini` (cloud), so local placement is moot until `ANALYZER=local`. |
+
+**The five sidecar engines do not share a device grammar.** Three are torch
+(`cuda:N`), Kokoro is onnxruntime (provider `device_id`), Whisper is CTranslate2
+(`device` + `device_index`). The picker therefore stores a **canonical**
+assignment per unit (a GPU **UUID**, or `cpu`), and an **engine device-adapter**
+(see Components §3a) translates that canonical value into each engine's native
+device API at load. The knob env values (`QWEN_DEVICE` etc.) carry the resolved
+torch/native form the adapter produces.
 
 ### Apply semantics
 
@@ -80,57 +94,90 @@ One small module that owns two facts and is the single source of truth that
 makes a one-process / N-card sidecar safe:
 
 1. **`engine → device`** — where each loadable engine (Qwen, Coqui, Kokoro,
-   ASR, SPK) is assigned, resolved once from the device knobs at startup via the
-   existing `_resolve_torch_device` pattern.
-2. **`device → {reserved, total}`** — sampled per CUDA device actually in use
-   (`torch.cuda.mem_get_info(idx)` / `memory_reserved(idx)` /
-   `get_device_properties(idx)`), replacing today's hardcoded `(0)` reads.
+   ASR, SPK) is assigned, resolved once at startup from the canonical
+   UUID-keyed assignment via the engine device-adapter (§3a). Identity is the
+   **GPU UUID** (`torch.cuda.get_device_properties(idx).uuid`), not the bare
+   index — so the ledger maps `uuid → current torch index` and warns on drift.
+2. **Two distinct per-device quantities** (the v1 design conflated these — they
+   are not the same and must not be):
+   - **driver free / total** via `torch.cuda.mem_get_info(idx)` — the **driver
+     truth**, visible across *all* allocators (torch, ORT, CTranslate2). This is
+     what **capacity, footprint pre-warning, eviction, and OOM** reasoning use.
+   - **torch reserved** via `memory_reserved(idx)` — the **torch caching-allocator
+     pool only**. Valid *solely* for the fragmentation self-exit, and *solely*
+     on cards hosting torch engines. **Kokoro (ORT) and Whisper (CT2) VRAM is
+     invisible to `memory_reserved`** (`main.py:460`), so a card hosting only
+     those reads reserved ≈ 0 — its fragmentation ceiling is inert by design,
+     and its safety comes from the driver-free path above.
 
 Everything safety-critical reads **through** the ledger:
 
-- **Recycle / watchdog** — soft & hard thresholds computed **per device** (each
-  card's own fraction × that card's total) and fire if **any in-use device**
-  crosses. A hard cross still triggers the existing **whole-process self-exit
-  (code 43)**; the supervisor respawns a fresh process and all cards' contexts
-  reload. So cross-card models recycle together — correct and simple. The
-  multi-card rule is an **OR over in-use devices**.
-- **`/health`** — reports a `devices[]` array (`idx`, `name`, `reserved`,
-  `total`, resident engines) instead of one device's numbers. Existing scalar
-  fields stay for back-compat, derived from the synth card.
-- **Eviction / co-residency** — every "free VRAM before loading X" path gains
-  the predicate **`shares_device(incoming, resident)`**. Models evict each other
-  only when assigned the **same** card. Qwen on `cuda:0` + Kokoro on `cuda:1` →
-  no eviction.
+- **Recycle / watchdog** — the **fragmentation** soft/hard thresholds are
+  computed per **torch-hosting** device (each card's fraction × that card's
+  total, on the torch `reserved` pool) and fire if **any** crosses. A hard cross
+  still triggers the existing **whole-process self-exit (code 43)**; the
+  supervisor respawns and all cards' contexts reload. The multi-card rule is an
+  **OR over in-use torch devices**. (Capacity/OOM for non-torch cards is the
+  driver-free path, not this ceiling.)
+- **`/health`** — reports a `devices[]` array (`uuid`, `idx`, `name`,
+  `free`, `total`, `torch_reserved`, resident engines). Existing scalar fields
+  stay for back-compat, derived from a **defined** card: Qwen's resolved device,
+  falling back to torch index 0 (M2).
+- **Eviction / co-residency** — **both** VRAM-coupling mechanisms gain the
+  predicate **`shares_device(a, b)`**: (1) the load-time "free VRAM before
+  loading X" evictions, **and** (2) the synth-time `_VdKokoroArbiter`
+  (`main.py:457`) forward-overlap lock between VoiceDesign and Kokoro. Models
+  couple only when assigned the **same physical card**; Qwen on one card +
+  Kokoro on another → no eviction *and* no forward serialization.
+  `shares_device` resolves `auto` to its concrete device first, and returns
+  **false** for any pair where either side is `cpu` (no VRAM contention) (M3).
 
 ### Two control planes
 
-- **Sidecar engines (5)** — assignment flows through the registry-knob →
-  `buildSidecarEnv` path. Four knobs exist; we add **`KOKORO_DEVICE`**. The
-  ledger reads these at load.
-- **Analyzer Ollama (1)** — a stored preference threaded as the `main_gpu`
-  option on `/api/chat` (sibling to the existing `num_gpu` via
-  `resolveAnalyzerNumGpu()`), with daemon-level `CUDA_VISIBLE_DEVICES` as the
-  documented robust hard-pin.
+- **Sidecar engines (5)** — the canonical UUID assignment flows through the
+  registry-knob → `buildSidecarEnv` path; the **engine device-adapter** (§3a)
+  resolves it to each engine's native form. Four knobs exist; we add
+  **`KOKORO_DEVICE`** (mapped to an ORT provider `device_id`). `ASR_DEVICE`
+  grows from `cpu|cuda` to also carry a device index that the adapter splits
+  into CTranslate2's `device` + `device_index`.
+- **Analyzer Ollama (1)** — a stored preference applied as **daemon-level
+  `CUDA_VISIBLE_DEVICES`** at `ollama serve` (restart-to-apply, consistent with
+  the rest of the feature). `main_gpu` is **not** a reliable pin — it only
+  selects the primary GPU in split mode — so it is at most a secondary hint, not
+  the mechanism. On this box the analyzer is `ANALYZER=gemini` today, so this
+  plane is dormant until `ANALYZER=local`.
 
 ## Components
 
 1. **Device discovery** — `GET /devices` on the sidecar enumerates CUDA devices
-   `[{idx, name, total_mb, free_mb}]` (+ a `cpu` pseudo-option); a server proxy
-   (copy the `/health` proxy pattern) exposes it to the frontend. Populates the
-   picker and validates assignments. Depends on: torch.
-2. **Device-assignment config** — the 6 stored assignments. Adds `KOKORO_DEVICE`
-   (reuses `QWEN/COQUI/ASR/SPK_DEVICE`) + an analyzer-GPU preference.
-   `buildSidecarEnv` already injects non-default `restart-sidecar` knobs, so
-   Kokoro slots in; the analyzer value threads into `/api/chat`
-   `options.main_gpu`. Depends on: registry, env-builder, `ollama.ts`.
-3. **`DeviceLedger`** — the keystone above. Independently unit-testable with a
-   stub torch (the `_StubTorch` pattern in `test_device_probe.py`).
+   `[{uuid, idx, name, total_mb, free_mb}]` (+ a `cpu` pseudo-option) via
+   `torch.cuda.mem_get_info` / `get_device_properties`; a server proxy (copy the
+   `/health` proxy pattern) exposes it to the frontend. `free_mb` (driver truth)
+   is shown so the picker reflects the display-driven card's real headroom.
+   Depends on: torch.
+2. **Device-assignment config** — the 6 stored canonical assignments (GPU UUID
+   or `cpu`). Adds `KOKORO_DEVICE` (reuses `QWEN/COQUI/ASR/SPK_DEVICE`) + an
+   analyzer-GPU preference. `buildSidecarEnv` already injects non-default
+   `restart-sidecar` knobs, so Kokoro slots in; the analyzer value becomes the
+   daemon's `CUDA_VISIBLE_DEVICES`. Depends on: registry, env-builder,
+   `ollama.ts`.
+3. **`DeviceLedger`** — the keystone above (UUID identity; driver-free vs
+   torch-reserved split). Independently unit-testable with a stub torch (the
+   `_StubTorch` pattern in `test_device_probe.py`).
+   - **3a. Engine device-adapter** — translates one canonical assignment
+     (UUID / `cpu`) into each engine's native device API: torch `cuda:N`
+     (Qwen/Coqui/SPK), ORT provider `device_id` (Kokoro), CTranslate2
+     `device`+`device_index` (Whisper). Owns the `uuid → current torch index`
+     resolution and the stale/drift detection. The single place that knows each
+     engine's device dialect — so the ledger and picker stay dialect-agnostic.
 4. **Device-aware recycle / watchdog / `/health`** — refactor: replace
    `get_device_properties(0)` / default-device `memory_reserved()` with ledger
    lookups; per-device thresholds; fire on any-card cross; `/health` gains
    `devices[]`. Highest-risk unit → heaviest test coverage.
-5. **Device-aware eviction** — gate every evict-to-free path on
-   `ledger.shares_device(...)`.
+5. **Device-aware eviction + arbiter** — gate **both** VRAM-coupling
+   mechanisms on `ledger.shares_device(...)`: the load-time evict-to-free paths
+   **and** the synth-time `_VdKokoroArbiter` (`main.py:457`) VoiceDesign↔Kokoro
+   forward lock. Cross-card pairs neither evict nor serialize.
 6. **Settings picker UI** — a "GPU assignment" panel: one row per unit, a
    dropdown of discovered devices (each showing its VRAM), the current value, a
    stale-assignment indicator, and the existing "restart sidecar to apply"
@@ -153,9 +200,9 @@ injects the `*_DEVICE` knobs → sidecar boots → each engine loads onto its
 assigned card → `DeviceLedger` records `engine→device` → watchdog samples each
 in-use device per cycle → recycle fires per-card, `/health` reports `devices[]`.
 
-**Analyzer:** stored preference → threaded as `options.main_gpu` on the next
-`/api/chat` model load; daemon `CUDA_VISIBLE_DEVICES` is the documented hard-pin
-fallback.
+**Analyzer:** stored preference → written as the Ollama daemon's
+`CUDA_VISIBLE_DEVICES` and applied on daemon restart (restart-to-apply).
+`main_gpu` is not relied on as the pin.
 
 ## Error handling
 
@@ -172,9 +219,12 @@ bricks the sidecar.**
   guessed ceiling that could false-fire.
 - **Heavy engine on a too-small card** → QA models (ASR, SPK) have CPU-degrade
   paths → demote with a WARN. Synth engines (Qwen/Coqui) that can't sensibly
-  CPU-fall-back → load fails with a clear surfaced error ("Qwen needs ~XGB,
-  cuda:1 has 8 GB"). The picker pre-warns when a known footprint exceeds the
-  target card's VRAM.
+  CPU-fall-back → load fails with a clear surfaced error ("Qwen needs ~X GB,
+  this card has Y GB free"). The picker pre-warns against the card's **free**
+  VRAM (driver truth — the display-driven card has well under its nominal
+  total), and for Qwen uses the **peak** footprint (**Base + VoiceDesign
+  co-resident**, ~6.5 GB during a design), not Base alone — so it catches a
+  Qwen-on-8 GB assignment that would only OOM when someone designs a voice (M1).
 - **Two co-resident models on the same small card** (e.g. Qwen Base +
   VoiceDesign during a design) → the existing co-residency OOM guard still
   applies, now correctly **scoped to that one card** via `shares_device`.
@@ -185,9 +235,10 @@ Mapped to the five tiers, weighted toward the risky units.
 
 **Sidecar pytest (heaviest):**
 - `DeviceLedger` with a stub torch (reuse `_StubTorch`/`_torch` from
-  `test_device_probe.py` / `test_qwen_device.py`): `engine→device` resolution
-  from knobs, per-device `{reserved,total}` sampling, `shares_device` truth
-  table, stale-device → safe-fallback + WARN.
+  `test_device_probe.py` / `test_qwen_device.py`): `uuid→index` resolution
+  (incl. drift warn), per-device **driver-free** vs **torch-reserved** sampling
+  kept distinct, `shares_device` truth table, stale-device → safe-fallback +
+  WARN.
 - Recycle thresholds computed **per device**, firing when *any* in-use card
   crosses (the OR rule) — including the asymmetric case (16 GB fine, 8 GB over →
   recycle fires).
@@ -195,9 +246,11 @@ Mapped to the five tiers, weighted toward the risky units.
   pair does **not** evict (the new behavior / the bug being fixed).
 - `GET /devices` shape; `/health` `devices[]` shape + back-compat scalars.
 
-**Server vitest:** `buildSidecarEnv` injects `KOKORO_DEVICE` when non-default;
-analyzer `main_gpu` threads into `/api/chat`; `/devices` proxy; config write
-**validates against discovered devices** (reject `cuda:5` on a 2-card box).
+**Server vitest:** `buildSidecarEnv` injects `KOKORO_DEVICE` (and the
+`ASR_DEVICE` index form) when non-default; the analyzer pref resolves to the
+daemon's `CUDA_VISIBLE_DEVICES`; `/devices` proxy; config write **validates
+against discovered devices by UUID** (reject an assignment whose UUID isn't
+present).
 
 **Frontend vitest:** picker renders one row per unit, dropdown populated from
 discovery, stale-assignment indicator, "restart to apply" affordance present.
@@ -205,28 +258,41 @@ discovery, stale-assignment indicator, "restart to apply" affordance present.
 **E2E (Playwright, one spec):** Settings → GPU panel renders against mocked
 `/devices`, select a device for a unit, value persists across reload.
 
+Add cases for the **engine device-adapter** (§3a): a UUID canonical assignment
+resolves to torch `cuda:N` for Qwen/Coqui/SPK, an ORT `device_id` for Kokoro,
+and CTranslate2 `device`+`device_index` for Whisper; an unknown UUID falls back
+loudly. And for `shares_device`: torch-vs-ORT engines on the same physical card
+*do* couple (same UUID), `cpu` pairs never couple.
+
 **Regression plan:** a new `docs/features/<n>-multi-gpu-per-model.md` from
 `TEMPLATE.md` documenting the invariants (per-device recycle, same-card-only
-eviction, loud-degrade-never-brick) and a manual **2-GPU on-box acceptance**
-walkthrough — the automated tiers run on stub torch / single-GPU CI, so the
-real 2-card behavior needs an on-box acceptance pass (consistent with the
-"owed on-box" pattern on other GPU features).
+eviction *and* arbiter, loud-degrade-never-brick, UUID identity) and a manual
+**2-GPU on-box acceptance** walkthrough — the automated tiers run on stub torch
+/ single-GPU CI, so the real 2-card behavior needs an on-box pass. The
+walkthrough must note that **`/health` `free`/`total` (driver) is the VRAM
+truth; `torch_reserved` is torch-pool-only and will under-report** any card
+hosting Kokoro (ORT) or Whisper (CT2) — an expected gap, not a bug (L1).
 
 ## Key files
 
 - `server/tts-sidecar/main.py` — `_cuda_vram_mb`, `_vram_recycle_*`,
   `_resolve_torch_device`, `_normalize_device_family`, the engine classes
-  (`QwenEngine`, `CoquiEngine`, Kokoro, `WhisperEngine`, the ECAPA/SPK class),
-  the eviction call-sites, `/health`. New: `DeviceLedger` module + `/devices`.
-- `server/src/tts/spawn-sidecar.ts` — `buildSidecarEnv` (`KOKORO_DEVICE`).
+  (`QwenEngine`, `CoquiEngine`, `KokoroEngine`, `WhisperEngine`, the ECAPA/SPK
+  class), the eviction call-sites, **`_VdKokoroArbiter`** (`main.py:457`),
+  `/health`. New: `DeviceLedger` module, the **engine device-adapter**, and
+  `GET /devices`.
+- `server/src/tts/spawn-sidecar.ts` — `buildSidecarEnv` (`KOKORO_DEVICE`;
+  `ASR_DEVICE` index form). The `CUDA_VISIBLE_DEVICES` stop-gap is **removed**
+  here once the feature owns mapping.
 - `server/src/config/registry.ts` — the device knobs (`KOKORO_DEVICE` knob +
-  analyzer-GPU pref).
-- `server/src/analyzer/ollama.ts` — `main_gpu` threading (sibling to
-  `resolveAnalyzerNumGpu`).
+  analyzer-GPU pref) carrying canonical UUID values.
+- `server/src/analyzer/ollama.ts` — analyzer GPU pref → daemon
+  `CUDA_VISIBLE_DEVICES` (not `main_gpu`).
 - `server/src/routes/sidecar-health.ts` (+ a new devices route) — proxy.
 - Frontend Settings view + a new GPU-assignment panel component.
 - `server/.env.example` — document `KOKORO_DEVICE`, the analyzer GPU pref, and
-  the `CUDA_VISIBLE_DEVICES` / `CUDA_DEVICE_ORDER` multi-GPU remap.
+  note the `CUDA_VISIBLE_DEVICES` / `CUDA_DEVICE_ORDER` stop-gap as superseded
+  by the picker.
 
 ## Open questions / deferred
 

--- a/docs/superpowers/specs/2026-06-27-multi-gpu-per-model-design.md
+++ b/docs/superpowers/specs/2026-06-27-multi-gpu-per-model-design.md
@@ -6,360 +6,351 @@ status: draft
 
 # Per-model GPU assignment (multi-GPU)
 
-> Revised twice after adversarial review. The first revision fixed the
-> engine-grammar / VRAM-allocator model; the second (this one) folds in a
-> five-lens parallel review that found the **config layer** and the **Node-side
-> orchestration layer** were under-modeled, split the work into **two sequential
-> plans**, cut auto-placement, and made the analyzer row implementable by
-> **owning the Ollama daemon**.
+> Revised three times under adversarial review. R1 fixed the engine-grammar /
+> VRAM-allocator model; R2 (5-lens) surfaced the config + Node-orchestration
+> gaps and split the work; R3 (5-lens) found the two-plan split was drawn in the
+> **wrong place** — the safety net can't be built or tested until engines are
+> *placeable* and cards are *visible*. This revision re-cuts into **three
+> foundation-first plans**, reverts the unworkable "own the Ollama daemon"
+> scope, and scopes the Node semaphore to **guards over the existing global
+> pool** rather than a per-card rebuild.
 
 ## Problem
 
-The TTS sidecar is single-GPU by design. Every model loads onto one device, and
-the defaults (`auto` → `cuda:0`, `COQUI_DEVICE=cuda`, `ASR_DEVICE=cuda`) resolve
-to the same card. On a 2-GPU box the second card sits idle, and **safety
-machinery on both sides of the process boundary is single-card-bound**:
+The TTS sidecar is single-GPU by design. Where engines *can* be GPU-pinned today
+they default to one card (`QWEN_DEVICE=auto` → `cuda:0`; `COQUI_DEVICE` default
+`auto`; `SPK_DEVICE`/`ASR_DEVICE` default **cpu**). On a 2-GPU box the second
+card sits idle, and safety machinery on **both sides of the process boundary** is
+single-card-bound:
 
 - **Sidecar (Python):** the reserved-VRAM recycle ceiling, `/health` telemetry,
-  and co-residency eviction are hardcoded to device 0 (`main.py:3342`,
-  `_cuda_vram_mb`); the `_VdKokoroArbiter` (`main.py:457`) couples VoiceDesign↔Kokoro
-  unconditionally even across cards.
-- **Server (Node):** the weighted GPU semaphore is a **single global token pool**
-  (`gpu/semaphore.ts:36-152`) with one `gpu.vramBudget`; the analyzer↔TTS
-  co-eviction (`tts/gpu-load.ts`, `residency.ts`) keys on **one scalar total**.
-  Neither can express "card A free / card B free."
+  and co-residency eviction read **device 0** (`_cuda_vram_mb`,
+  `get_device_properties(0)`, `main.py:3342/4188`); the `_VdKokoroArbiter`
+  (`main.py:457`) couples VoiceDesign↔Kokoro unconditionally, even across cards.
+- **Server (Node):** the weighted GPU semaphore is a **single global token
+  pool** (`gpu/semaphore.ts:36-152`); the analyzer↔TTS co-eviction
+  (`gpu/gpu-load.ts`, `gpu/residency.ts`, `gpu/vram-state.ts`) keys on **one
+  scalar total** sourced from device 0. Neither can express "card A / card B."
 
-Per-engine device knobs let a user *pin* engines to cards today, but the moment
-two engines live on different cards the safety net is blind or wrong, and — per
-the review — shipping a naive picker would make a 2-card box **more** OOM-prone
-and **unable** to run the parallel analyze+synth workload that justifies the
-second card.
+So a user can pin **only Qwen** to a second card today (its knob is a free
+string; the others are enums or absent), and the moment two engines land on
+different cards the safety net is blind or wrong. Per R2/R3, a naive picker would
+make a 2-card box *more* OOM-prone and *unable* to run the parallel analyze+synth
+that justifies the second card.
 
 Reference hardware: **RTX 4070 Laptop 8 GB** (drives the display → *free* VRAM
 well under 8 GB) and **RTX 5070 Ti 16 GB**. A verified stop-gap
 (`CUDA_DEVICE_ORDER=PCI_BUS_ID` + `CUDA_VISIBLE_DEVICES=1,0` in `server/.env`)
-remaps the 16 GB card to the visible `cuda:0`. **This feature owns device
-mapping**; the stop-gap is retired by an explicit `.env` cutover when Plan B
-lands (see §B5).
+remaps the 16 GB card to the visible `cuda:0`. The feature retires this stop-gap
+via an explicit `.env` cutover when Plan B lands (§B4).
 
 ## Goal
 
 Let the user choose, **per model**, which GPU (or CPU) each runs on, with a
-runtime — sidecar **and** server — that's genuinely device-aware so any
-assignment is honored **safely**: per-card recycle, per-card VRAM budgeting,
-same-card-only coupling, and **observability of the card a model *actually*
-loaded onto** (not just the one requested). A bad assignment must **degrade
-loudly and recoverably**, never brick.
+runtime — sidecar **and** server — that honors any assignment **safely**:
+per-card recycle, same-card-only coupling, no harmful cross-card eviction, and
+**observability of the card a model *actually* loaded onto** (not just the one
+requested). A bad assignment must **degrade loudly and recoverably**, never
+brick.
 
-Auto-placement is **cut** (a 2-card box has one obvious layout, set once).
+### Delivery: three foundation-first plans
 
-### Delivery: two sequential plans
+R3 showed the safety net depends on two capabilities that don't exist yet —
+**placing** an engine on a card, and **reading** per-card VRAM. So those come
+first:
 
-The review converged on this split; it de-risks the hard config work.
-
-- **Plan A — Device-aware safety net.** Pure runtime (sidecar Python + Node
-  semaphore/eviction). Ships value alone by fixing the device-0 hardcodes and
-  the unconditional cross-card coupling. No UI. Testable as far as it ever will
-  be (stub-torch for shape; on-box for truth).
-- **Plan B — The picker + owned Ollama daemon.** Config-layer rework, device
-  discovery, Settings UI, and app-owned `ollama serve` so the analyzer is really
-  assignable. Built on a green Plan A.
+- **Plan 0 — Enablement.** Make every engine *placeable* (config knobs that
+  accept a card) and every card *visible* (discovery + per-card VRAM + actual-card
+  readback). No safety logic, no UI. Independently shippable and testable: pin any
+  engine to either card via a knob and *see* where it landed.
+- **Plan A — Device-aware safety net.** Per-device recycle, the ledger,
+  `shares_device` coupling, the per-card mutex, and the Node guards. Now buildable
+  **and** testable because Plan 0 lets you create cross-card configs and read
+  per-card data.
+- **Plan B — Picker UI + canonical UUID.** The Settings panel, UUID-based
+  identity, and the analyzer's read-only row.
 
 ### Assignable units (6)
 
-| Unit | Runtime | Device API | Knob status | Notes |
-|---|---|---|---|---|
-| **Qwen** (Base 0.6B + VoiceDesign 1.7B) | torch | `cuda:N` via `.to()` | `QWEN_DEVICE` (string ✓) | Base + VoiceDesign **share one assignment**; co-reside during a design. Peak ~6.5 GB. |
-| **Coqui XTTS** | torch | `cuda:N` via `.to()` | `COQUI_DEVICE` (**enum → widen to string**) | rarely loaded (`PRELOAD_COQUI=0`). |
-| **ECAPA drift** (voice-consistency QA) | torch (speechbrain) | `cuda:N` via `.to()` | `SPK_DEVICE` (**enum → widen to string**) | promotable to spare card. |
-| **Kokoro** | **onnxruntime** | **ORT provider `device_id`** | _new_ `KOKORO_DEVICE` | eager at startup (~1 GB). Separate allocator from torch (`main.py:460`). |
-| **Whisper ASR** (content QA / WER) | **CTranslate2** | **`device="cuda"` + `device_index`** | **no knob today → add one** | separate allocator; read by a Node gate too (`transcribe-client.ts:59`). |
-| **Analyzer (Ollama)** | Ollama daemon (**now app-owned**) | daemon `CUDA_VISIBLE_DEVICES` | _new_ pref | app will spawn/supervise `ollama serve` (§B6) so env injection is real. Dormant on this box until `ANALYZER=local`. |
+| Unit | Runtime | Device API | Knob (after Plan 0) |
+|---|---|---|---|
+| **Qwen** (Base + VoiceDesign, one assignment; peak ~6.5 GB) | torch | `cuda:N` via `.to()` | `QWEN_DEVICE` (string ✓ today) |
+| **Coqui XTTS** (rarely loaded) | torch | `cuda:N` via `.to()` | `COQUI_DEVICE` (**enum → string**) |
+| **ECAPA drift** (voice-consistency QA) | torch (speechbrain) | `cuda:N` via `.to()` | `SPK_DEVICE` (**enum → string**) |
+| **Kokoro** (eager, ~1 GB) | **onnxruntime** | **ORT provider `device_id`** | **new `KOKORO_DEVICE`** |
+| **Whisper ASR** (content QA / WER) | **CTranslate2** | **`device`+`device_index`** | **new `ASR_DEVICE` knob** |
+| **Analyzer (Ollama)** | Ollama daemon (**user/OS-managed**) | daemon `CUDA_VISIBLE_DEVICES` | **OS-env, read-only in picker** (§B3) |
 
-**No uniform device grammar.** Three engines are torch (`cuda:N`), Kokoro is ORT
-(`device_id`), Whisper is CTranslate2 (`device`+`device_index`). The picker
-stores a **canonical UUID** (or `cpu`); a Python-side **engine device-adapter**
-(§A7) translates it per engine. The adapter also accepts legacy forms
-(`cuda:N | cuda | cpu | auto`) so existing pins keep working.
+No uniform device grammar: three torch (`cuda:N`), Kokoro ORT (`device_id`),
+Whisper CT2 (`device`+`device_index`). The analyzer is **not app-pinnable** — see
+§B3 (revert of "own the daemon").
 
 ### Apply semantics
 
-**Restart-to-apply** for every unit (sidecar restart for the 5 engines; daemon
-restart for the analyzer). Matches existing `apply:'restart-sidecar'` knobs; no
-live cross-card migration.
+**Restart-to-apply** everywhere. In Plan-0/A worlds an assignment is a knob in
+`server/.env` or a config override + the existing "restart sidecar" affordance;
+the picker (Plan B) is just a nicer front-end to the same knobs. The analyzer
+applies via OS-env + an Ollama service restart (§B3).
 
 ## Non-goals
 
-- **Auto-placement** (cut).
-- **Multi-process sidecar.** One process drives N cards; per-device accounting ≠
-  per-device processes.
-- **Live re-placement.** Restart-to-apply only.
-- **Sharding one model across cards.**
+- **Auto-placement** (cut — a 2-card box has one obvious layout).
+- **App-owned Ollama daemon** (cut — see §B3 for why it's a no-op on Windows).
+- **Synchronous per-card Node VRAM budgeting.** Node is not device-aware at
+  acquire time (R3); we ship **guards over the global pool** (§A5), not a
+  per-card semaphore rebuild.
+- **Multi-process sidecar; live re-placement; sharding one model across cards.**
+
+---
+
+# Plan 0 — Enablement (placeable engines, visible cards)
+
+## 0.1 Device discovery
+
+`GET /devices` (sidecar) → server proxy → frontend:
+`[{uuid, idx, name, total_mb, free_mb}]` + a `cpu` option, via
+`torch.cuda.mem_get_info`/`get_device_properties`. **One canonical schema** used
+everywhere (the picker dropdown *and* the `/health` card array §0.4 reuse these
+exact field names — no `free` vs `free_mb` schism).
+
+## 0.2 Config knobs — make every engine placeable
+
+- **Widen `COQUI_DEVICE` and `SPK_DEVICE` from `enum` to `string`**
+  (`registry.ts:424,281`; `coerceAndValidate` rejects non-enum values today,
+  `resolver.ts:73`). (`SPK_DEVICE` is `enum[cpu,cuda]` — no `auto`.)
+- **Add a `KOKORO_DEVICE` registry knob** and an **`ASR_DEVICE` registry knob**
+  (neither exists today; ASR reaches the sidecar only via `.env` passthrough, and
+  Kokoro selects providers by *type* not `device_id` — `main.py:843`). Both
+  `apply:'restart-sidecar'`.
+- Knob values accept the **legacy/runtime grammar** `{cuda:N | cuda | cpu |
+  auto}`. (Canonical **UUID** storage is added in Plan B; Plan 0/A operate on
+  index form.)
+
+## 0.3 Device resolution + the engine adapter (Python) and ASR gate (Node)
+
+- **`_resolve_torch_device` must resolve `cuda:N`/index properly** — today it
+  returns a non-`auto` value verbatim into `torch.to(...)` (`main.py:1174`), so a
+  bad index isn't validated.
+- **Engine device-adapter (Python)** — one module translating a knob value into
+  each engine's native API: torch `cuda:N` (Qwen/Coqui/SPK), ORT provider
+  `device_id` (Kokoro), CT2 `device`+`device_index` (Whisper). All **Python-side**
+  `*_DEVICE` reads route through it.
+- **Node ASR gate is a SEPARATE change** (it cannot call the Python adapter):
+  `asrRunsOnGpu()` is a TS `=== 'cuda'` test (`transcribe-client.ts:58`) that
+  must parse `{cpu | cuda | cuda:N}` and still emit the GPU token for the indexed
+  form — otherwise indexed ASR runs untracked → OOM.
+
+## 0.4 Actual-card readback (closes the silent-CPU class)
+
+- `/health` gains a **`gpus[]`** array (the existing `devices` field is an
+  engine→family map, `main.py:4109` — do **not** collide). Each entry:
+  `{uuid, idx, name, total_mb, free_mb, torch_reserved_mb, resident:[engine…]}`.
+- **Each engine reports the card it *actually* loaded onto**, probed from the live
+  module / ORT session (`get_providers()` exists, `main.py:4010`) — **not** the
+  requested knob. ORT/CT2 silently fall back to CPU on a bad device; read-back +
+  WARN + a structured `stale`/`fell_back` flag is the only honest signal (memory:
+  `project_kokoro_cpu_onnxruntime_gpu_swap`).
+- **Per-GPU `device-total`** — `gpu/device-total.ts` parses only the *first*
+  nvidia-smi GPU (`:15`); make it per-GPU (`--id`/per-uuid) so Node can later read
+  the right card's total.
+
+## 0.5 `.env` shadow awareness
+
+`resolveKnob` checks `process.env` **first** and returns `locked` before reading
+config overrides (`resolver.ts:15`). The user's `.env` sets `COQUI_DEVICE`,
+`ASR_DEVICE` — so a future picker write to those is a silent no-op. Plan 0
+surfaces a **`locked-by-env`** state on each knob (consumed by the picker banner
+in Plan B); the `.env` cutover that strips these lines lands with Plan B (§B4).
+
+## Plan 0 testing
+
+Now genuinely testable: pin any engine to either card via its knob and assert
+`/health gpus[].resident` shows it on the requested card (or flags `fell_back`).
+Pytest (shape, on a *new richer stub* that fabricates `mem_get_info`/`uuid`/
+`memory_reserved` — the existing `_StubTorch` lacks all three): adapter resolves
+each engine's dialect; `/devices` + `/health gpus[]` schema; per-GPU device-total.
+Server vitest: ASR Node gate emits the token for `cuda:N`; knob widening accepts
+`cuda:1`. **On-box**: confirm each engine lands where pinned.
 
 ---
 
 # Plan A — Device-aware safety net
 
-## A1. `DeviceLedger` (sidecar, new module) — thread-safe, never caches an index
+(Builds on Plan 0: engines are placeable, per-card VRAM and actual-card are
+readable.)
 
-Owns `engine → device` (by **GPU UUID**) and per-device VRAM samples. It is read
-from **three thread contexts** — the `_memory_watchdog` event loop, the sync
-`/health` + `/devices` Starlette threadpool threads, and `asyncio.to_thread`
-synth/load workers — so:
+## A1. `DeviceLedger` (sidecar) — thread-safe, never caches an index
 
-- **One `threading.Lock`** guards the `uuid→index` map and any cached state.
-  Today's `_cuda_vram_mb` is stateless (safe by accident); the ledger is mutable
-  and must not rely on the GIL for multi-bytecode map updates.
-- **uuid→index is re-resolved and re-validated every sample, never cached.** A
-  vanished card makes torch renumber survivors *downward*, so a stale index
-  silently reads the **wrong healthy card** (no exception). Each read asserts
-  `get_device_properties(idx).uuid == expected_uuid`; mismatch ⇒ treat as
-  vanished (ceiling → 0). This is what actually makes the "vanished → None"
-  fail-safe true.
-- **Two distinct per-device quantities, never conflated:**
-  - **driver free/total** via `mem_get_info(idx)` — visible across *all*
-    allocators (torch, ORT, CTranslate2). Drives capacity/OOM/eviction reasoning.
-  - **torch reserved** via `memory_reserved(idx)` — torch caching-allocator pool
-    only; invisible to Kokoro(ORT)/Whisper(CT2). Drives *only* the
-    fragmentation self-exit, *only* on torch-hosting cards.
+Owns `engine → device` and per-device samples; read from **three thread
+contexts** (the `_memory_watchdog` loop, the sync `/health`+`/devices` threadpool
+threads, `asyncio.to_thread` workers). Therefore:
 
-## A2. Per-device recycle / watchdog — and a real driver-free ceiling
+- **One `threading.Lock`** guards the map and any cached state (today's
+  `_cuda_vram_mb` is stateless — safe by accident; the ledger is mutable).
+- **Index is re-resolved and re-validated every sample, never cached.** A vanished
+  card renumbers survivors *downward*, so a cached index silently reads the wrong
+  healthy card (no exception). Each read asserts
+  `get_device_properties(idx).uuid == expected`; mismatch ⇒ treat as vanished
+  (ceiling → 0). This is what makes the "vanished → None" fail-safe real.
+- **Two quantities, never conflated:** **driver free/total** (`mem_get_info`,
+  sees all allocators — capacity/OOM) vs **torch reserved** (`memory_reserved`,
+  torch pool only — fragmentation, torch cards only; Kokoro(ORT)/Whisper(CT2) are
+  invisible to it).
 
-- **Fragmentation ceiling** (torch reserved): computed per torch-hosting device,
-  fires on **any** crossing (OR rule). Each card is evaluated on its own freshly
-  read value (no torn-snapshot risk).
-- **Driver-free ceiling (new):** a card hosting *only* ORT/CT2 engines reads
-  torch-reserved ≈ 0, so the fragmentation ceiling is inert — it has **no OOM
-  protection today**. Add a per-device watchdog branch that recycles/self-exits
-  on **driver-free** crossing, so ORT/CT2-only cards are actually guarded, not
-  just sampled for display.
+## A2. Per-device recycle / watchdog
+
+- **Fragmentation ceiling** (torch reserved): per torch-hosting card, fires on
+  **any** crossing (OR rule); each card evaluated on its own freshly-read value.
+- **Driver-free ceiling (new) — absolute floor, not a fraction.** A fraction
+  self-satisfies on the idle display card (free is always "low") → boot-loop. Use
+  an **absolute free-headroom floor**: recycle/self-exit when `free_mb < FLOOR`.
+  **Default proposal: 1024 MB, per-card, env-overridable
+  (`SIDECAR_VRAM_FREE_FLOOR_MB`); tune on-box.** This is the only OOM guard for a
+  card hosting *only* ORT/CT2 engines (torch-reserved ≈ 0 there).
 - **Blast-radius (documented limitation):** the hard self-exit (code 43) is
-  **whole-process** — `_restart_pending` + `_drain_then_restart` are process-wide
-  (`main.py:3485,3512`). So the 8 GB card crossing its ceiling drains and aborts
-  in-flight synth on the *healthy* 16 GB card. v1 accepts this (per-device drain
-  on a single `_inflight_synth` is non-trivial); it is stated, not buried, and
-  deferred as a known limitation.
-- **Crash-loop protection (new — closes a brick path):** a structurally-too-small
-  assignment loops `load→synth→cross→drain(≤180 s)→self-exit` forever, because
+  **whole-process** (`_restart_pending`/`_drain_then_restart` are process-wide,
+  `main.py:3485,3512`) — the 8 GB card crossing its ceiling aborts in-flight synth
+  on the healthy 16 GB card. v1 accepts this; per-card drain on one
+  `_inflight_synth` is deferred.
+- **Crash-loop guard (new) — Plan A scope = detect + hold + log only.** A
+  too-small assignment loops `load→cross→drain(≤180 s)→self-exit` forever, because
   living >`QUICK_DEATH_MS` (30 s) **resets** `consecutiveFailures`
-  (`sidecar-supervisor.ts:40,263`) and `onChildExit` never inspects `code`. Add a
-  **code-43 streak detector** counting consecutive VRAM self-exits in a
-  wall-clock window *regardless of child uptime*; on cap-trip, hold TTS down,
-  **auto-revert the offending unit to its safe default**, and name the knob in a
-  FATAL line.
+  (`sidecar-supervisor.ts:40,263`) and `onChildExit` ignores `code`. Add a
+  **code-43 streak detector** counting consecutive VRAM self-exits in a wall-clock
+  window **regardless of uptime** (proposed: **3 self-exits / 10 min**); on trip,
+  **hold TTS down + emit a FATAL log naming the offending card**. *Auto-revert of
+  the assignment is deferred to Plan B* (it needs the config-override sink the
+  picker owns; Plan A has no write path).
 
 ## A3. `shares_device` coupling — symmetric, resolved once
 
-Both VRAM-coupling mechanisms gate on `shares_device(a, b)`:
-
-1. load-time evict-to-free paths, **and**
-2. the synth-time `_VdKokoroArbiter` (`main.py:457`) VoiceDesign↔Kokoro forward lock.
-
-Rules:
-- `auto` is resolved to a **concrete UUID at ledger init**, before any
-  `shares_device` evaluation (an unresolved `auto` drifts across boots once the
-  remap is gone).
-- `shares_device(cpu, *)` ⇒ **false** (no VRAM contention).
-- The VD↔Kokoro boolean is computed **once at startup into a single flag both
-  `design()` and `kokoro_synth()` read** — never recomputed per-call on either
-  side. A predicate only one party respects is no lock (asymmetric → the 8 GB
-  three-way spill returns).
+Both couplers gate on `shares_device(a, b)`: (1) load-time evict-to-free, and (2)
+the synth-time `_VdKokoroArbiter` (`main.py:457`). `auto` resolves to a concrete
+device at ledger init *before* any evaluation; `shares_device(cpu, *)` ⇒ false;
+the VD↔Kokoro boolean is computed **once at startup into one flag both
+`design()` and `kokoro_synth()` read** (an asymmetric predicate = no lock → the
+8 GB three-way spill returns).
 
 ## A4. Per-card load/evict mutex
 
-`_VD_KOKORO` only covers VoiceDesign↔Kokoro. Any *other* same-card pair the
-design now allows (e.g. Coqui + ASR on `cuda:0`) has a check-residency → evict →
-load TOCTOU with no covering lock (the `is not None` residency checks at
-`main.py:2147,2163` already race). Add a **per-physical-card load/evict mutex**
-in the ledger; the whole check-evict-load sequence on a card holds it.
+`_VD_KOKORO` covers only VoiceDesign↔Kokoro. Any other same-card pair Plan 0 now
+allows (e.g. Coqui + ASR on one card) has a check-residency→evict→load TOCTOU
+with no covering lock (`main.py:2147,2163`). Add a **per-physical-card load/evict
+mutex** in the ledger; the whole sequence on a card holds it.
 
-## A5. Node GPU semaphore → per-device
+## A5. Node guards over the global pool (NOT a per-card rebuild)
 
-The single global pool (`semaphore.ts:36-152`, budget sized for one 8 GB card)
-gives **zero per-card protection** on two cards. Make the budget **per-device**,
-keyed by the resolved engine→card UUID; costs (`engine-vram-cost.ts`) charge the
-**target card's** pool. Consequences:
+R3: Node can't be synchronously device-aware (the semaphore is built eagerly with
+one scalar budget, `semaphore.ts:152`; acquire-sites pass an engine *name* with no
+card). So **keep the single global pool** and add two **best-effort guards**,
+driven by the stored assignment intent (Node knows the *configured* card, even
+when actual pinning is OS-env for the analyzer — divergence is best-effort, stated):
 
-- The analyzer (cost 4 = whole budget, `engine-vram-cost.ts:23`) must **not**
-  charge the TTS card's pool when it resolves to a different card — otherwise it
-  serializes all TTS and forbids the parallel analyze+synth that justifies the
-  second card.
-- `costForEngine`'s unknown-key fallback of 1 (`engine-vram-cost.ts:57`) is
-  unsafe against a small per-card budget — make it conservative (refuse, or
-  charge a high cost) rather than 1.
+- **Don't cross-charge:** the analyzer's whole-budget cost
+  (`engine-vram-cost.ts`, analyzer = 4) is **not** charged against the TTS pool
+  when the analyzer's configured card differs from the TTS card — unblocking the
+  parallel analyze+synth that justifies the second card.
+- **Don't cross-evict:** `shouldEvictBeforeSidecarLoad` (`gpu/residency.ts:7`)
+  returns **false** when the incoming engine's configured card differs from the
+  analyzer's — it currently evicts the warm analyzer to "free" a card it isn't on.
+- `costForEngine`'s unknown-key fallback of 1 (`engine-vram-cost.ts:58`) →
+  conservative (refuse / high cost), since a mis-mapped engine shouldn't sneak
+  past a tight pool.
 
-## A6. Node co-eviction + the `/health` scalar that feeds it
+This is ~80% of the benefit (no over-subscription regression, parallel
+analyze+synth works) without the eventually-consistent per-card-budget rebuild.
 
-- `shouldEvictBeforeSidecarLoad` (`residency.ts:9`) must take **both** the
-  incoming sidecar engine's card and the analyzer's card and return **false when
-  they differ** — else it evicts the warm analyzer to "free" a card it isn't on.
-- **The scalar that feeds eviction must be the target *load* card's total**, not
-  Qwen's device (my earlier M2 choice was wrong: reporting 16 GB makes eviction
-  skip and loads XTTS onto the cramped 8 GB card → OOM).
+## Plan A testing
 
-## A7. Engine device-adapter (Python) + actual-card reporting
-
-- One Python module translates a canonical assignment (UUID / `cpu` / legacy
-  `cuda:N|cuda|auto`) into each engine's native API: torch `cuda:N`
-  (Qwen/Coqui/SPK), ORT provider `device_id` (Kokoro), CT2 `device`+`device_index`
-  (Whisper). **All `*_DEVICE` env reads route through it** — including the Node
-  ASR gate (`transcribe-client.ts:59`), which must learn the `cuda:N` form or it
-  silently skips the GPU token.
-- **`/health` reports the card each engine *actually* loaded onto**, probed from
-  the live module / ORT session (`get_providers()` already exists,
-  `main.py:4010`) — not the requested assignment. This closes the recurring
-  "Kokoro silently on CPU" class (memory: `project_kokoro_cpu_onnxruntime_gpu_swap`)
-  instead of re-creating it at 2× surface. ORT/CT2 bad-`device_id` silently falls
-  back to CPU and the eager loader swallows it (`main.py:3716`), so read-back +
-  WARN + a structured stale flag is the only honest signal.
-- **`/health` field naming:** `/health` *already* exposes a `devices` map
-  (engine→family, `main.py:4109`). The new per-card array is **`gpus[]`**
-  (`{uuid, idx, name, free, total, torch_reserved, resident:[{engine, actual_card}]}`),
-  leaving `devices` untouched.
-
-## A8. Plan A testing
-
-- **Honest framing:** stub-torch (`test_device_probe.py`'s `_StubTorch` has no
-  `mem_get_info`/`uuid`/`memory_reserved`) can only test **shape/arithmetic** of
-  a *new richer stub we hand-feed*. It cannot reproduce multi-allocator VRAM, ORT
-  `device_id`, CT2 `device_index`, or UUID drift. Mark these pytest cases
-  "shape-only."
-- **The gating validation is the on-box 2-GPU acceptance** (`test:sidecar` is
-  venv-gated → skips in CI). Budget it as a deliverable, not a footnote.
-- Pytest (shape): ledger lock present; uuid mismatch ⇒ vanished; per-card OR
-  fires on the 8 GB but not 16 GB; `shares_device` cpu/auto/same-uuid truth
-  table; adapter resolves each engine's dialect; code-43 streak detector trips on
-  a uptime-resetting loop.
-- Server vitest: per-device semaphore charges the right card; cross-card analyzer
-  doesn't block TTS; `shouldEvictBeforeSidecarLoad` false across cards; ASR Node
-  gate handles `cuda:N`.
+Pytest (shape): ledger lock present; uuid mismatch ⇒ vanished; per-card
+fragmentation OR fires on the 8 GB not the 16 GB; driver-free floor trips on a
+synthetic low-free; `shares_device` cpu/auto/same truth table; code-43 streak
+trips on an uptime-resetting loop. Server vitest: the two A5 guards (no
+cross-charge, no cross-evict). **On-box (gating):** per-card recycle fires on the
+right card; cross-card analyzer+synth runs in parallel; a forced ORT-CPU fallback
+shows in `/health`. CI can't run these (`test:sidecar` venv-gated) — the on-box
+checklist is a **named deliverable**, run by the one operator with the box.
 
 ---
 
-# Plan B — Picker + owned Ollama daemon
+# Plan B — Picker UI + canonical UUID
 
-## B1. Config schema — the foundation the picker needs
+## B1. Canonical UUID identity
 
-The "reuse the four knobs + store UUID" premise was wrong on three counts:
+Store assignments as a GPU **UUID** (stable across driver/index drift); the
+adapter (0.3) accepts `{uuid | cuda:N | cuda | cpu | auto}` so legacy pins keep
+working. **Reconcile every stored UUID against `/devices` on read** (config lives
+in shared `~/.castwright/user-settings.json` — a UUID is box-specific; a
+copied-in file is caught only at runtime). Mark unresolved UUIDs `stale` in
+`/health` + the picker.
 
-- **Widen the device knobs from `enum` to `string`** — `COQUI_DEVICE`/`SPK_DEVICE`
-  are `enum[auto/cpu/cuda]` (`registry.ts:424,281`) and `coerceAndValidate`
-  rejects anything else (`resolver.ts:73`); they cannot hold a UUID. Validate
-  against discovered `/devices` UUIDs instead of a fixed list.
-- **Add an `ASR_DEVICE` registry knob** (`apply:'restart-sidecar'`) — there is
-  none today (`registry.ts`), so the injection loop (`spawn-sidecar.ts:464`) has
-  nothing to write. "Reuse `ASR_DEVICE`" was a false premise.
-- **Env carries the UUID; Python resolves it.** Node can't run torch, so
-  `buildSidecarEnv` injects the UUID verbatim and the adapter (§A7) resolves
-  UUID→index at load. Delete the "Node produces the resolved torch form" claim;
-  rewrite `_resolve_torch_device` to map UUID→index (today it passes a non-`auto`
-  value straight into `torch.to(...)` → crash on a UUID).
+## B2. Settings picker
 
-## B2. `.env` shadow cutover
+One row per sidecar engine; a dropdown of `/devices` cards (each showing **free**
+VRAM); the **stale badge compares assigned-vs-*actual*** (from 0.4), so a silent
+CPU fallback is visible. A structured `/health` field **and a visible banner**
+carry "fell back / shadowed-by-env / stale" — not a log WARN to grep (memory:
+`feedback_self_service_observability`). Footprint pre-warn uses driver **free**
+and Qwen **peak** (~6.5 GB), re-checked **at load time** in the sidecar (WDDM free
+swings). On the crash-loop trip (A2), the picker now **auto-reverts** the
+offending unit to its safe default and names it (the write path A2 deferred).
 
-`resolveKnob` checks `process.env` **first** and returns `locked` before reading
-config overrides (`resolver.ts:15-30`). The user's `.env` sets `COQUI_DEVICE`,
-`ASR_DEVICE` — so a picker write to those is a **silent no-op**. Therefore:
+## B3. Analyzer row — read-only (revert of "own the daemon")
 
-- The picker **detects a locked env knob** and surfaces "shadowed by
-  server/.env" rather than pretending the write took.
-- The cutover step strips `COQUI_DEVICE`/`ASR_DEVICE`/`SPK_DEVICE` **and**
-  `CUDA_VISIBLE_DEVICES`/`CUDA_DEVICE_ORDER` from `.env` (these live only in the
-  user's gitignored `.env`; **no code edits a user's `.env`** — the spec's
-  earlier "removed in spawn-sidecar.ts" was fiction). The sidecar **WARNs** if
-  `CUDA_VISIBLE_DEVICES` is still set while the picker owns mapping.
+Owning `ollama serve` is a no-op on the common Windows box: Ollama runs on the
+well-known port **11434** as an OS/tray-managed service that's already up, so
+"adopt-don't-fight" never applies the pin, and killing it fights the service
+manager (R3 daemon review). Instead: the analyzer row is **read-only**,
+displaying the current placement and a link to the documented path — set
+`CUDA_VISIBLE_DEVICES` (+ the existing `OLLAMA_FLASH_ATTENTION`/`KV_CACHE_TYPE`)
+as OS/service env and restart Ollama (`docs/local-llm.md`). Zero new daemon code;
+gated on `ANALYZER=local` (dormant under `ANALYZER=gemini`).
 
-## B3. Device discovery
+## B4. `.env` cutover
 
-`GET /devices` (sidecar) → server proxy → frontend:
-`[{uuid, idx, name, total_mb, free_mb}]` + a `cpu` option. `free_mb` (driver
-truth) is shown so the picker reflects the display card's real headroom.
+Strip `COQUI_DEVICE`/`ASR_DEVICE`/`SPK_DEVICE` **and**
+`CUDA_VISIBLE_DEVICES`/`CUDA_DEVICE_ORDER` from `server/.env` (these live only in
+the user's gitignored `.env`; **no code edits a user's `.env`** — it's a
+documented manual step). The picker surfaces `locked-by-env` (from 0.5) until the
+line is removed; the sidecar WARNs if `CUDA_VISIBLE_DEVICES` is still set while
+the picker owns mapping.
 
-## B4. Settings picker UI
+## Plan B testing
 
-One row per unit; a dropdown of discovered cards (each showing **free** VRAM);
-**the stale badge compares assigned-vs-*actual*** (from §A7), not
-assigned-vs-discovered — so a silent CPU fallback is visible. A structured
-`/health` field **and a visible picker banner** carry the "fell back / shadowed /
-stale" signal — not a log WARN the user must grep (memory:
-`feedback_self_service_observability`). The existing "restart sidecar to apply"
-affordance applies.
-
-## B5. Failure handling at the picker boundary
-
-- **Stale/invalid heavy engine (Qwen/Coqui) clamps to `cpu` or hard-fails** with
-  the surfaced "needs ~X GB, card has Y GB free" error — **not** `cuda:0`, which
-  on this box is the 8 GB display card (clamping there just relocates the OOM and
-  arms the A2 crash-loop). Only CPU-degradable QA engines (ASR/SPK) may clamp to
-  CPU silently-but-flagged.
-- **Vanished card mid-run** escalates to the existing **poison self-exit (code
-  42)** path (`main.py:4689`) + supervised respawn — the real recovery the spec
-  must name; disabling the ceiling alone only blinds the watchdog.
-- **Footprint pre-warn uses driver *free* and Qwen *peak*** (Base+VoiceDesign
-  co-resident ~6.5 GB), re-checked **at load time** in the sidecar (the WDDM
-  display card's free swings between pick-time and load-time), not only at pick
-  time in the UI.
-
-## B6. Own the Ollama daemon (makes the analyzer row real)
-
-Today the app only *connects* to a user-managed daemon (`ollama.ts:78`); it never
-spawns `ollama serve`, so it **cannot** inject `CUDA_VISIBLE_DEVICES`. Per the
-chosen direction, the app **takes over the daemon lifecycle**, mirroring the
-sidecar supervisor (`sidecar-owner.ts` / `spawn-sidecar.ts`):
-
-- spawn/supervise `ollama serve` with the analyzer card's `CUDA_VISIBLE_DEVICES`
-  in its env; an `autoStartOllama` preference (default following existing
-  behavior); `taskkill /T /F` teardown on Windows.
-- **Adopt-don't-fight** an externally-running daemon (as the sidecar owner does)
-  so we don't kill a user's existing `ollama serve`; only an app-owned daemon
-  carries the pinned env. Restart-to-apply.
-- Gated behind `ANALYZER=local` (dormant on this box under `ANALYZER=gemini`).
-
-## B7. Portability + legacy pins
-
-`user-settings.json` lives in `~/.castwright` and is shared across checkouts /
-copyable (`user-settings.ts:24`). A stored UUID is **box-specific** — reconcile
-every stored UUID against `/devices` **on read** (mark stale in `/health` +
-picker), and have the adapter accept `{uuid | cuda:N | cuda | cpu | auto}` so a
-pre-existing `QWEN_DEVICE=cuda:1` keeps working. `device-total.ts`'s first-GPU-only
-nvidia-smi parse (`device-total.ts:15`) must become per-GPU (`--id=<uuid>`) before
-the analyzer plane consumes it for keep-alive sizing.
-
-## B8. Plan B testing
-
-Frontend vitest (rows, discovery-populated dropdown, assigned-vs-actual stale
-badge, banner); server vitest (knob widening accepts UUID + rejects unknown;
-ASR knob injection; env-shadow detection; owned-daemon env injection); one
-Playwright e2e (Settings GPU panel against mocked `/devices`, select, persists);
-**on-box 2-GPU acceptance** is the gating sign-off, with the note that `/health`
-`free/total` (driver) is the VRAM truth while `torch_reserved` under-reports any
-ORT/CT2 card by design.
+Frontend vitest (rows, discovery dropdown, assigned-vs-actual badge, env-shadow
+banner, analyzer read-only row); server vitest (UUID accept/reject + reconcile;
+auto-revert on streak-trip); one Playwright e2e (Settings GPU panel vs mocked
+`/devices`, select, persists). **On-box** acceptance sign-off, noting `/health`
+`free/total` (driver) is VRAM truth while `torch_reserved` under-reports ORT/CT2
+by design.
 
 ---
 
 ## Key files
 
-**Plan A** — `server/tts-sidecar/main.py` (`_cuda_vram_mb`, `_vram_recycle_*`,
-`_memory_watchdog`, `_VdKokoroArbiter` 457, eviction call-sites, `/health`;
-new `DeviceLedger` + adapter + driver-free ceiling + actual-card probe);
-`server/src/gpu/semaphore.ts` + `server/src/tts/engine-vram-cost.ts` (per-device
-budget); `server/src/tts/gpu-load.ts` + `residency.ts` + `vram-state.ts`
-(cross-card eviction + target-card scalar); `server/src/tts/transcribe-client.ts`
-(ASR `cuda:N` gate); `server/src/tts/sidecar-supervisor.ts` (code-43 streak).
+**Plan 0** — `server/tts-sidecar/main.py` (new `/devices`, `gpus[]` in `/health`,
+`_resolve_torch_device` index handling, engine adapter, actual-card probe);
+`server/src/config/registry.ts` (widen `COQUI`/`SPK` enums→string; add `KOKORO`/
+`ASR` knobs); `server/src/config/resolver.ts` (`locked-by-env` surfacing);
+`server/src/tts/spawn-sidecar.ts` (knob injection); `server/src/tts/transcribe-client.ts`
+(Node ASR `cuda:N` gate); `server/src/gpu/device-total.ts` (per-GPU); a new
+`/devices` proxy route.
 
-**Plan B** — `server/src/config/registry.ts` (widen enums → string, add
-`ASR_DEVICE`); `server/src/config/resolver.ts` (env-shadow surfacing);
-`server/src/tts/spawn-sidecar.ts` (`KOKORO_DEVICE`/`ASR_DEVICE` injection);
-new `GET /devices` + server proxy; `server/src/analyzer/ollama.ts` + a new
-ollama-owner (spawn/supervise daemon); Settings view + GPU-assignment panel;
-`server/src/tts/device-total.ts` (per-GPU); `.env.example` (document knobs +
-cutover); `~/.castwright/user-settings.json` reconcile-on-read.
+**Plan A** — `main.py` (`DeviceLedger` + lock, per-device recycle + driver-free
+floor, `_VdKokoroArbiter` 457, per-card mutex, eviction call-sites);
+`server/src/tts/sidecar-supervisor.ts` (code-43 streak detector);
+`server/src/gpu/semaphore.ts` + `engine-vram-cost.ts` + `gpu-load.ts` +
+`residency.ts` + `vram-state.ts` (the two A5 guards — all under `server/src/gpu/`).
+
+**Plan B** — `~/.castwright/user-settings.json` (UUID storage + reconcile-on-read);
+Settings view + GPU-assignment panel; `docs/local-llm.md` (analyzer row link);
+`.env.example` (cutover doc).
 
 ## Open questions / deferred
 
-- **Per-card recycle drain** — v1 self-exits the whole process on any card's hard
-  cross (documented limitation A2). A future refinement could drain/reload only
-  the offending card's engines.
-- **Owned-daemon migration** — taking over `ollama serve` for users who run it as
-  a system service needs a graceful adopt/handover story (sketched in B6, to be
-  detailed in Plan B's implementation plan).
+- **Driver-free floor default (A2)** — 1024 MB proposed; confirm on-box (display
+  card idle-free vs true-exhaustion margin).
+- **Per-card recycle drain** — whole-process self-exit on any card's cross is a
+  documented v1 limitation; per-card drain deferred.
+- **Eventually-consistent per-card Node budgets** — the full per-UUID pool map
+  (vs A5's guards) is a deliberate post-v1 item if the global pool proves limiting.

--- a/docs/superpowers/specs/2026-06-27-multi-gpu-per-model-design.md
+++ b/docs/superpowers/specs/2026-06-27-multi-gpu-per-model-design.md
@@ -6,14 +6,14 @@ status: draft
 
 # Per-model GPU assignment (multi-GPU)
 
-> Revised three times under adversarial review. R1 fixed the engine-grammar /
-> VRAM-allocator model; R2 (5-lens) surfaced the config + Node-orchestration
-> gaps and split the work; R3 (5-lens) found the two-plan split was drawn in the
-> **wrong place** — the safety net can't be built or tested until engines are
-> *placeable* and cards are *visible*. This revision re-cuts into **three
-> foundation-first plans**, reverts the unworkable "own the Ollama daemon"
-> scope, and scopes the Node semaphore to **guards over the existing global
-> pool** rather than a per-card rebuild.
+> Four adversarial review rounds. R1 fixed the engine-grammar / VRAM-allocator
+> model; R2 surfaced the config + Node-orchestration gaps; R3 re-cut
+> foundation-first and reverted "own the Ollama daemon"; R4 (per-plan) proved the
+> enablement layer and the per-card safety net are **co-requisite** (placement
+> without per-card safety is an active OOM regression) and that several engine
+> device APIs don't work as assumed. This revision merges them into **one runtime
+> plan delivered in waves** + a picker plan, and folds in the engine-wiring
+> reality.
 
 ## Problem
 
@@ -23,334 +23,286 @@ they default to one card (`QWEN_DEVICE=auto` → `cuda:0`; `COQUI_DEVICE` defaul
 card sits idle, and safety machinery on **both sides of the process boundary** is
 single-card-bound:
 
-- **Sidecar (Python):** the reserved-VRAM recycle ceiling, `/health` telemetry,
-  and co-residency eviction read **device 0** (`_cuda_vram_mb`,
-  `get_device_properties(0)`, `main.py:3342/4188`); the `_VdKokoroArbiter`
-  (`main.py:457`) couples VoiceDesign↔Kokoro unconditionally, even across cards.
-- **Server (Node):** the weighted GPU semaphore is a **single global token
-  pool** (`gpu/semaphore.ts:36-152`); the analyzer↔TTS co-eviction
-  (`gpu/gpu-load.ts`, `gpu/residency.ts`, `gpu/vram-state.ts`) keys on **one
-  scalar total** sourced from device 0. Neither can express "card A / card B."
+- **Sidecar (Python):** the recycle ceiling, `/health` telemetry, and
+  co-residency eviction read **device 0** (`_cuda_vram_mb`,
+  `get_device_properties(0)`, `main.py:3342/4188`); `_VdKokoroArbiter`
+  (`main.py:457`) couples VoiceDesign↔Kokoro unconditionally, across cards.
+- **Server (Node):** the weighted GPU semaphore is a **single global pool**
+  (`gpu/semaphore.ts:152`); the analyzer↔TTS co-eviction (`gpu/gpu-load.ts`,
+  `gpu/residency.ts`, `gpu/vram-state.ts`) keys on **one device-0 scalar**.
 
-So a user can pin **only Qwen** to a second card today (its knob is a free
-string; the others are enums or absent), and the moment two engines land on
-different cards the safety net is blind or wrong. Per R2/R3, a naive picker would
-make a 2-card box *more* OOM-prone and *unable* to run the parallel analyze+synth
-that justifies the second card.
+Only Qwen is pinnable to a second card today (its knob is a free string; the
+others are enums or absent). The moment two engines land on different cards the
+safety net is blind or wrong — so **making engines placeable and making the
+runtime per-card-safe must ship together** (R4: shipping placement alone hands
+the user the device-0-watchdog OOM with no protection).
 
 Reference hardware: **RTX 4070 Laptop 8 GB** (drives the display → *free* VRAM
-well under 8 GB) and **RTX 5070 Ti 16 GB**. A verified stop-gap
+well under 8 GB) + **RTX 5070 Ti 16 GB**. A verified stop-gap
 (`CUDA_DEVICE_ORDER=PCI_BUS_ID` + `CUDA_VISIBLE_DEVICES=1,0` in `server/.env`)
-remaps the 16 GB card to the visible `cuda:0`. The feature retires this stop-gap
-via an explicit `.env` cutover when Plan B lands (§B4).
+remaps the 16 GB card to visible `cuda:0`; retired by an `.env` cutover with the
+picker (§2.5).
 
 ## Goal
 
-Let the user choose, **per model**, which GPU (or CPU) each runs on, with a
-runtime — sidecar **and** server — that honors any assignment **safely**:
-per-card recycle, same-card-only coupling, no harmful cross-card eviction, and
-**observability of the card a model *actually* loaded onto** (not just the one
-requested). A bad assignment must **degrade loudly and recoverably**, never
-brick.
+Choose, **per model**, which GPU (or CPU) each runs on, with a runtime — sidecar
+and server — that honors any assignment **safely** (per-card recycle,
+same-card-only coupling, no harmful cross-card eviction) and shows the card a
+model *actually* loaded onto. A bad assignment **degrades loudly and
+recoverably**, never bricks.
 
-### Delivery: three foundation-first plans
+### Delivery: two plans (Plan 1 in two waves)
 
-R3 showed the safety net depends on two capabilities that don't exist yet —
-**placing** an engine on a card, and **reading** per-card VRAM. So those come
-first:
-
-- **Plan 0 — Enablement.** Make every engine *placeable* (config knobs that
-  accept a card) and every card *visible* (discovery + per-card VRAM + actual-card
-  readback). No safety logic, no UI. Independently shippable and testable: pin any
-  engine to either card via a knob and *see* where it landed.
-- **Plan A — Device-aware safety net.** Per-device recycle, the ledger,
-  `shares_device` coupling, the per-card mutex, and the Node guards. Now buildable
-  **and** testable because Plan 0 lets you create cross-card configs and read
-  per-card data.
-- **Plan B — Picker UI + canonical UUID.** The Settings panel, UUID-based
-  identity, and the analyzer's read-only row.
+- **Plan 1 — Device-aware placement & safety** (runtime, no UI). Placement and
+  per-card safety are co-requisite, so they ship as one plan in two waves:
+  - **Wave 1 — Placement + visibility:** discovery, config knobs, the engine
+    device-adapter (incl. the inline `== "cuda"` sites), actual-card readback.
+  - **Wave 2 — Per-card safety:** the ledger, per-card recycle + driver-free
+    floor, `shares_device` coupling, per-card mutex, the code-43 streak guard,
+    and the Node guards.
+  Wave 1 is testable alone (pin an engine, see where it landed); Wave 2 must land
+  **before** any cross-card placement is advertised as safe.
+- **Plan 2 — Picker UI + canonical UUID.** Settings panel, UUID identity, the
+  analyzer read-only row, `.env` cutover, auto-revert UX.
 
 ### Assignable units (6)
 
-| Unit | Runtime | Device API | Knob (after Plan 0) |
+| Unit | Runtime | Real device API | Knob (after W1) |
 |---|---|---|---|
-| **Qwen** (Base + VoiceDesign, one assignment; peak ~6.5 GB) | torch | `cuda:N` via `.to()` | `QWEN_DEVICE` (string ✓ today) |
-| **Coqui XTTS** (rarely loaded) | torch | `cuda:N` via `.to()` | `COQUI_DEVICE` (**enum → string**) |
-| **ECAPA drift** (voice-consistency QA) | torch (speechbrain) | `cuda:N` via `.to()` | `SPK_DEVICE` (**enum → string**) |
-| **Kokoro** (eager, ~1 GB) | **onnxruntime** | **ORT provider `device_id`** | **new `KOKORO_DEVICE`** |
-| **Whisper ASR** (content QA / WER) | **CTranslate2** | **`device`+`device_index`** | **new `ASR_DEVICE` knob** |
-| **Analyzer (Ollama)** | Ollama daemon (**user/OS-managed**) | daemon `CUDA_VISIBLE_DEVICES` | **OS-env, read-only in picker** (§B3) |
+| **Qwen** (Base + VoiceDesign, one assignment; peak ~6.5 GB) | torch | `.to("cuda:N")` | `QWEN_DEVICE` (string ✓) |
+| **Coqui XTTS** (rarely loaded) | torch | `.to("cuda:N")` | `COQUI_DEVICE` (**enum→string**) |
+| **ECAPA drift** (voice QA) | torch (speechbrain) | `run_opts={"device":"cuda:N"}` | `SPK_DEVICE` (**enum→string**) |
+| **Kokoro** (eager, ~1 GB) | onnxruntime | **provider_options `[{device_id:N}]`** (not a name list) | new `KOKORO_DEVICE` |
+| **Whisper ASR** (content QA) | CTranslate2 | **`device="cuda"` + `device_index=N`** (raises on bad index) | new `ASR_DEVICE` registry knob (env already read) |
+| **Analyzer (Ollama)** | Ollama daemon (user/OS-managed) | OS-env `CUDA_VISIBLE_DEVICES` | **not app-pinnable; GPU/CPU-only signal** (§2.4) |
 
-No uniform device grammar: three torch (`cuda:N`), Kokoro ORT (`device_id`),
-Whisper CT2 (`device`+`device_index`). The analyzer is **not app-pinnable** — see
-§B3 (revert of "own the daemon").
+Five distinct device dialects; the analyzer's card is **unknowable to the app**
+(only GPU/CPU via `detectOllamaDevice`, `ollama-health.ts:76`).
 
 ### Apply semantics
 
-**Restart-to-apply** everywhere. In Plan-0/A worlds an assignment is a knob in
-`server/.env` or a config override + the existing "restart sidecar" affordance;
-the picker (Plan B) is just a nicer front-end to the same knobs. The analyzer
-applies via OS-env + an Ollama service restart (§B3).
+**Restart-to-apply**, but the restart differs by knob source: a value in
+`server/.env` needs a **server** restart (re-read at process start); a config
+*override* needs only the **sidecar** restart (the existing affordance). The
+picker (Plan 2) wires the existing restart banner. The analyzer applies via
+OS-env + an Ollama service restart (§2.4).
 
 ## Non-goals
 
-- **Auto-placement** (cut — a 2-card box has one obvious layout).
-- **App-owned Ollama daemon** (cut — see §B3 for why it's a no-op on Windows).
-- **Synchronous per-card Node VRAM budgeting.** Node is not device-aware at
-  acquire time (R3); we ship **guards over the global pool** (§A5), not a
-  per-card semaphore rebuild.
-- **Multi-process sidecar; live re-placement; sharding one model across cards.**
+- Auto-placement; app-owned Ollama daemon; synchronous per-card Node budgets
+  (we ship guards over the global pool); multi-process sidecar; live
+  re-placement; sharding one model across cards.
 
 ---
 
-# Plan 0 — Enablement (placeable engines, visible cards)
+# Plan 1 — Device-aware placement & safety
 
-## 0.1 Device discovery
+## Wave 1 — Placement + visibility
 
-`GET /devices` (sidecar) → server proxy → frontend:
-`[{uuid, idx, name, total_mb, free_mb}]` + a `cpu` option, via
-`torch.cuda.mem_get_info`/`get_device_properties`. **One canonical schema** used
-everywhere (the picker dropdown *and* the `/health` card array §0.4 reuse these
-exact field names — no `free` vs `free_mb` schism).
+**1.1 Device discovery + per-card sampler.** `GET /devices`
+`[{uuid, idx, name, total_mb, free_mb}]` (+ `cpu`) via
+`mem_get_info`/`get_device_properties`; server proxy. `/health` gains a **`gpus[]`**
+array — a strict superset `{uuid, idx, name, total_mb, free_mb, torch_reserved_mb,
+resident[], stale_reason?}` (the existing `devices` engine→family map at
+`main.py:4109` stays). The per-device read here is the **single reusable
+sampler** Wave 2's ledger wraps.
 
-## 0.2 Config knobs — make every engine placeable
+**1.2 Config knobs.** Widen `COQUI_DEVICE`/`SPK_DEVICE` from enum to **string**
+(`registry.ts:424,281`; `SPK_DEVICE` has no `auto`). Add **`KOKORO_DEVICE`** and
+an **`ASR_DEVICE`** registry knob (the ASR env is read today but isn't a knob).
+Values accept `{cuda:N | cuda | cpu | auto}`.
 
-- **Widen `COQUI_DEVICE` and `SPK_DEVICE` from `enum` to `string`**
-  (`registry.ts:424,281`; `coerceAndValidate` rejects non-enum values today,
-  `resolver.ts:73`). (`SPK_DEVICE` is `enum[cpu,cuda]` — no `auto`.)
-- **Add a `KOKORO_DEVICE` registry knob** and an **`ASR_DEVICE` registry knob**
-  (neither exists today; ASR reaches the sidecar only via `.env` passthrough, and
-  Kokoro selects providers by *type* not `device_id` — `main.py:843`). Both
-  `apply:'restart-sidecar'`.
-- Knob values accept the **legacy/runtime grammar** `{cuda:N | cuda | cpu |
-  auto}`. (Canonical **UUID** storage is added in Plan B; Plan 0/A operate on
-  index form.)
+**1.3 Engine device-adapter (Python) — and the inline `== "cuda"` sites.** One
+module mapping a knob value to each engine's real API. It is *not* enough to add
+the module; these exact-equality sites must be converted to `startswith("cuda")`
++ index handling, or they silently break under `cuda:N`:
+- **Whisper:** `_compute_type` keys on `self._device == "cuda"` (`main.py:2824`);
+  `WhisperModel(device=self._device, …)` (`main.py:2842`) — split into
+  `device="cuda"` + `device_index=N` (faster-whisper rejects `cuda:1`; **raises**
+  on a bad index — surfaces as a load error, not a silent CPU fallback).
+- **SPK:** present-checks `self.device == "cuda"` (`main.py:2954,2969`); loads via
+  `run_opts={"device":…}` (`main.py:2943`), not `.to()`.
+- **Kokoro:** real `device_id` plumbing — `_resolve_ort_providers` (`main.py:843`)
+  passes a provider **name list** with no `device_id`; rewrite to pass
+  `provider_options=[{"device_id":N}]` into CUDAExecutionProvider (verify the
+  pinned `kokoro-onnx` accepts it; else construct the `InferenceSession`
+  directly), and reconcile with the legacy `KOKORO_ORT_PROVIDERS` env.
+- **Qwen/Coqui:** torch `.to("cuda:N")` (already index-capable).
 
-## 0.3 Device resolution + the engine adapter (Python) and ASR gate (Node)
+**1.4 Node device gates (separate change — Node can't call the Python adapter).**
+**Both** `asrRunsOnGpu()` (`transcribe-client.ts:59`) **and the SPK embed gate**
+(`embed-client.ts:41`) are `=== 'cuda'` tests that must parse `{cpu|cuda|cuda:N}`
+and still emit the GPU semaphore token for the indexed form — else indexed
+ASR/SPK runs untracked → OOM. (Widening `SPK_DEVICE` in 1.2 *creates* the embed
+hazard; fixing both gates is part of the same wave.)
 
-- **`_resolve_torch_device` must resolve `cuda:N`/index properly** — today it
-  returns a non-`auto` value verbatim into `torch.to(...)` (`main.py:1174`), so a
-  bad index isn't validated.
-- **Engine device-adapter (Python)** — one module translating a knob value into
-  each engine's native API: torch `cuda:N` (Qwen/Coqui/SPK), ORT provider
-  `device_id` (Kokoro), CT2 `device`+`device_index` (Whisper). All **Python-side**
-  `*_DEVICE` reads route through it.
-- **Node ASR gate is a SEPARATE change** (it cannot call the Python adapter):
-  `asrRunsOnGpu()` is a TS `=== 'cuda'` test (`transcribe-client.ts:58`) that
-  must parse `{cpu | cuda | cuda:N}` and still emit the GPU token for the indexed
-  form — otherwise indexed ASR runs untracked → OOM.
+**1.5 Actual-card readback.** `/health gpus[].resident` reports the card each
+engine **actually** loaded onto — replacing today's *requested-knob* echo
+(`main.py:4106`). Index granularity is available only for the **3 torch engines**
+(`param.device.index`); ORT/CT2 expose **family + a `fell_back` flag** only
+(`get_providers()`/`get_provider_options()` — no reliable index). `stale_reason`
+is an **enum** `{cpu_fallback | env_shadow | uuid_unresolved}`, set here for
+`cpu_fallback`.
 
-## 0.4 Actual-card readback (closes the silent-CPU class)
+*Wave 1 DoD:* pin any engine via its knob; `/health gpus[].resident` shows it on
+the requested card or flags `fell_back`. (Qwen is fully index-verifiable; Kokoro/
+Whisper verify family + no-fallback.)
 
-- `/health` gains a **`gpus[]`** array (the existing `devices` field is an
-  engine→family map, `main.py:4109` — do **not** collide). Each entry:
-  `{uuid, idx, name, total_mb, free_mb, torch_reserved_mb, resident:[engine…]}`.
-- **Each engine reports the card it *actually* loaded onto**, probed from the live
-  module / ORT session (`get_providers()` exists, `main.py:4010`) — **not** the
-  requested knob. ORT/CT2 silently fall back to CPU on a bad device; read-back +
-  WARN + a structured `stale`/`fell_back` flag is the only honest signal (memory:
-  `project_kokoro_cpu_onnxruntime_gpu_swap`).
-- **Per-GPU `device-total`** — `gpu/device-total.ts` parses only the *first*
-  nvidia-smi GPU (`:15`); make it per-GPU (`--id`/per-uuid) so Node can later read
-  the right card's total.
+## Wave 2 — Per-card safety (co-requisite with Wave 1)
 
-## 0.5 `.env` shadow awareness
+**Build order:** W2.1 ledger first; W2.2/W2.3/W2.4 read it; W2.5/W2.6 are independent.
 
-`resolveKnob` checks `process.env` **first** and returns `locked` before reading
-config overrides (`resolver.ts:15`). The user's `.env` sets `COQUI_DEVICE`,
-`ASR_DEVICE` — so a future picker write to those is a silent no-op. Plan 0
-surfaces a **`locked-by-env`** state on each knob (consumed by the picker banner
-in Plan B); the `.env` cutover that strips these lines lands with Plan B (§B4).
+**W2.1 `DeviceLedger` (thread-safe, never caches an index).** Wraps the 1.1
+sampler. Read from three thread contexts (the `_memory_watchdog` loop, the sync
+`/health`+`/devices` threadpool threads, `to_thread` workers) → **one
+`threading.Lock`**. Index is **re-resolved and re-validated every sample**
+(assert `get_device_properties(idx).uuid == expected`; mismatch ⇒ vanished →
+ceiling 0). Two quantities, never conflated: **driver free/total** (`mem_get_info`,
+all allocators — capacity/OOM) vs **torch reserved** (`memory_reserved`, torch
+pool only — fragmentation; ORT/CT2 invisible).
 
-## Plan 0 testing
+**W2.2 Per-card recycle + driver-free floor + ceiling reconcile.** Fragmentation
+ceiling per torch card (OR rule, each on its own freshly-read value). **New
+driver-free floor** — an *absolute* free-headroom floor (`free_mb < FLOOR`; a
+fraction self-satisfies on the idle display card → boot-loop). Default **1024 MB,
+per-card, env `SIDECAR_VRAM_FREE_FLOOR_MB`; tune on-box** — the *only* OOM guard
+for an ORT/CT2-only card. **Reconcile the Node adoption gate:** `/health` still
+emits scalar `vram_total_mb`/`vram_restart_mb` from device 0 (`main.py:4126`) and
+`sidecarCeilingMismatch` compares one scalar (`spawn-sidecar.ts:149`) — surface
+per-card ceilings (incl. the free-floor) in `gpus[]` and make that check
+per-card. *Blast-radius (documented limitation):* the hard self-exit (code 43) is
+**whole-process** (`_restart_pending`/`_drain_then_restart`, `main.py:3485,3512`,
+shared with the code-42 poison fence) — the 8 GB card's cross aborts in-flight
+synth on the healthy 16 GB card; per-card drain deferred.
 
-Now genuinely testable: pin any engine to either card via its knob and assert
-`/health gpus[].resident` shows it on the requested card (or flags `fell_back`).
-Pytest (shape, on a *new richer stub* that fabricates `mem_get_info`/`uuid`/
-`memory_reserved` — the existing `_StubTorch` lacks all three): adapter resolves
-each engine's dialect; `/devices` + `/health gpus[]` schema; per-GPU device-total.
-Server vitest: ASR Node gate emits the token for `cuda:N`; knob widening accepts
-`cuda:1`. **On-box**: confirm each engine lands where pinned.
+**W2.3 `shares_device` coupling.** Gate **both** the load-time evict-to-free paths
+**and** the synth-time `_VdKokoroArbiter` (`main.py:457`). `auto` resolves to a
+concrete device at ledger init; `shares_device(cpu,*)` ⇒ false; the VD↔Kokoro
+boolean is computed **once into one flag both `design()` and `kokoro_synth()`
+read** (asymmetric = no lock → the 8 GB spill returns). **Lock ordering:**
+`design()` holds both the arbiter and the per-card mutex (W2.4) — define a fixed
+acquire order to avoid deadlock.
 
----
+**W2.4 Per-card load/evict mutex** (in the ledger). `_VD_KOKORO` covers only
+VD↔Kokoro; any other same-card pair (e.g. Coqui + ASR) has a
+check-residency→evict→load TOCTOU (`main.py:2147,2163`) — the whole sequence on a
+card holds the card's mutex.
 
-# Plan A — Device-aware safety net
+**W2.5 code-43 streak guard (detect + hold + log; revert deferred to Plan 2).**
+`onChildExit` ignores `code` and `lived ≥ QUICK_DEATH_MS` resets the failure
+counter (`sidecar-supervisor.ts:258,263`) — so a structurally-too-small
+assignment recycles forever. Count **code-43 self-exits regardless of uptime**
+(proposed **3 / 10 min**); on trip, **hold TTS down** and emit a **structured
+trip event `{card, residentEngines[]}`** (written to the last-`/health` field +
+a FATAL log) — the sidecar must plumb the offending card into its self-exit (a
+bare code-43 carries none today). Plan 2 consumes the event for auto-revert.
 
-(Builds on Plan 0: engines are placeable, per-card VRAM and actual-card are
-readable.)
-
-## A1. `DeviceLedger` (sidecar) — thread-safe, never caches an index
-
-Owns `engine → device` and per-device samples; read from **three thread
-contexts** (the `_memory_watchdog` loop, the sync `/health`+`/devices` threadpool
-threads, `asyncio.to_thread` workers). Therefore:
-
-- **One `threading.Lock`** guards the map and any cached state (today's
-  `_cuda_vram_mb` is stateless — safe by accident; the ledger is mutable).
-- **Index is re-resolved and re-validated every sample, never cached.** A vanished
-  card renumbers survivors *downward*, so a cached index silently reads the wrong
-  healthy card (no exception). Each read asserts
-  `get_device_properties(idx).uuid == expected`; mismatch ⇒ treat as vanished
-  (ceiling → 0). This is what makes the "vanished → None" fail-safe real.
-- **Two quantities, never conflated:** **driver free/total** (`mem_get_info`,
-  sees all allocators — capacity/OOM) vs **torch reserved** (`memory_reserved`,
-  torch pool only — fragmentation, torch cards only; Kokoro(ORT)/Whisper(CT2) are
-  invisible to it).
-
-## A2. Per-device recycle / watchdog
-
-- **Fragmentation ceiling** (torch reserved): per torch-hosting card, fires on
-  **any** crossing (OR rule); each card evaluated on its own freshly-read value.
-- **Driver-free ceiling (new) — absolute floor, not a fraction.** A fraction
-  self-satisfies on the idle display card (free is always "low") → boot-loop. Use
-  an **absolute free-headroom floor**: recycle/self-exit when `free_mb < FLOOR`.
-  **Default proposal: 1024 MB, per-card, env-overridable
-  (`SIDECAR_VRAM_FREE_FLOOR_MB`); tune on-box.** This is the only OOM guard for a
-  card hosting *only* ORT/CT2 engines (torch-reserved ≈ 0 there).
-- **Blast-radius (documented limitation):** the hard self-exit (code 43) is
-  **whole-process** (`_restart_pending`/`_drain_then_restart` are process-wide,
-  `main.py:3485,3512`) — the 8 GB card crossing its ceiling aborts in-flight synth
-  on the healthy 16 GB card. v1 accepts this; per-card drain on one
-  `_inflight_synth` is deferred.
-- **Crash-loop guard (new) — Plan A scope = detect + hold + log only.** A
-  too-small assignment loops `load→cross→drain(≤180 s)→self-exit` forever, because
-  living >`QUICK_DEATH_MS` (30 s) **resets** `consecutiveFailures`
-  (`sidecar-supervisor.ts:40,263`) and `onChildExit` ignores `code`. Add a
-  **code-43 streak detector** counting consecutive VRAM self-exits in a wall-clock
-  window **regardless of uptime** (proposed: **3 self-exits / 10 min**); on trip,
-  **hold TTS down + emit a FATAL log naming the offending card**. *Auto-revert of
-  the assignment is deferred to Plan B* (it needs the config-override sink the
-  picker owns; Plan A has no write path).
-
-## A3. `shares_device` coupling — symmetric, resolved once
-
-Both couplers gate on `shares_device(a, b)`: (1) load-time evict-to-free, and (2)
-the synth-time `_VdKokoroArbiter` (`main.py:457`). `auto` resolves to a concrete
-device at ledger init *before* any evaluation; `shares_device(cpu, *)` ⇒ false;
-the VD↔Kokoro boolean is computed **once at startup into one flag both
-`design()` and `kokoro_synth()` read** (an asymmetric predicate = no lock → the
-8 GB three-way spill returns).
-
-## A4. Per-card load/evict mutex
-
-`_VD_KOKORO` covers only VoiceDesign↔Kokoro. Any other same-card pair Plan 0 now
-allows (e.g. Coqui + ASR on one card) has a check-residency→evict→load TOCTOU
-with no covering lock (`main.py:2147,2163`). Add a **per-physical-card load/evict
-mutex** in the ledger; the whole sequence on a card holds it.
-
-## A5. Node guards over the global pool (NOT a per-card rebuild)
-
-R3: Node can't be synchronously device-aware (the semaphore is built eagerly with
-one scalar budget, `semaphore.ts:152`; acquire-sites pass an engine *name* with no
-card). So **keep the single global pool** and add two **best-effort guards**,
-driven by the stored assignment intent (Node knows the *configured* card, even
-when actual pinning is OS-env for the analyzer — divergence is best-effort, stated):
-
-- **Don't cross-charge:** the analyzer's whole-budget cost
-  (`engine-vram-cost.ts`, analyzer = 4) is **not** charged against the TTS pool
-  when the analyzer's configured card differs from the TTS card — unblocking the
-  parallel analyze+synth that justifies the second card.
+**W2.6 Node guards over the global pool (GPU/CPU-scoped — Node isn't card-aware).**
+Keep the single global semaphore (built eagerly with a fixed budget,
+`semaphore.ts:152`; `acquire()` is synchronous so it can't await per-card data —
+*that* is why these guards use coarse signals, not 1.5's actual card). Two guards:
+- **Don't cross-charge:** drop the analyzer's whole-budget cost when the analyzer
+  is on GPU and the TTS engine's *configured* card differs — scoped to the
+  GPU/CPU signal Node actually has (`detectOllamaDevice`, `ollama-health.ts:76`),
+  since the analyzer's card index is unknowable. Side effect to state: analyzer
+  cost→0 also drops analyzer-vs-analyzer self-serialization.
 - **Don't cross-evict:** `shouldEvictBeforeSidecarLoad` (`gpu/residency.ts:7`)
-  returns **false** when the incoming engine's configured card differs from the
-  analyzer's — it currently evicts the warm analyzer to "free" a card it isn't on.
-- `costForEngine`'s unknown-key fallback of 1 (`engine-vram-cost.ts:58`) →
-  conservative (refuse / high cost), since a mis-mapped engine shouldn't sneak
-  past a tight pool.
+  takes only a scalar today — this is a **signature + call-site change** to pass
+  the incoming engine's configured card; return false when it differs from the
+  analyzer's GPU/CPU placement.
+- `costForEngine` fallback of 1 (`engine-vram-cost.ts:40`, a deliberate
+  "never grab the whole budget" invariant) → **high cost = serialize alone**
+  (the semaphore can't "refuse"); update that comment in the same change.
 
-This is ~80% of the benefit (no over-subscription regression, parallel
-analyze+synth works) without the eventually-consistent per-card-budget rebuild.
-
-## Plan A testing
-
-Pytest (shape): ledger lock present; uuid mismatch ⇒ vanished; per-card
-fragmentation OR fires on the 8 GB not the 16 GB; driver-free floor trips on a
-synthetic low-free; `shares_device` cpu/auto/same truth table; code-43 streak
-trips on an uptime-resetting loop. Server vitest: the two A5 guards (no
-cross-charge, no cross-evict). **On-box (gating):** per-card recycle fires on the
-right card; cross-card analyzer+synth runs in parallel; a forced ORT-CPU fallback
-shows in `/health`. CI can't run these (`test:sidecar` venv-gated) — the on-box
-checklist is a **named deliverable**, run by the one operator with the box.
+*Plan 1 testing.* Pytest (shape, on a new richer stub with `mem_get_info`/`uuid`/
+`memory_reserved`): adapter dialects incl. Kokoro `device_id`; the 6 `== "cuda"`
+sites; ledger lock + uuid-mismatch→vanished; per-card OR fires on 8 GB not 16 GB;
+driver-free floor trips on synthetic low-free; `shares_device` truth table;
+code-43 streak trips despite uptime resets; the two Node guards. **On-box
+(gating) — a WRITTEN checklist, not "named":** pin each engine and confirm actual
+card; force an ORT-CPU fallback → `fell_back` shows; recycle fires on the right
+card; cross-card analyzer+synth runs parallel; a too-small pin trips the streak +
+holds TTS. Run by the one operator with the box (`test:sidecar` is venv-gated →
+CI skips).
 
 ---
 
-# Plan B — Picker UI + canonical UUID
+# Plan 2 — Picker UI + canonical UUID
 
-## B1. Canonical UUID identity
+**2.1 Canonical UUID identity.** Store assignments as a GPU **UUID** (stable
+across index drift); **extend the 1.3 Python adapter** with a `uuid→index`
+resolver (the injected env value may now be a UUID — 1.3 ships index-only, so
+this is an explicit extension, and 1.3 should leave a resolve-to-index front
+seam). **Reconcile every stored UUID against `/devices` on read** (config lives
+in shared `~/.castwright/user-settings.json`; a UUID is box-specific) → set
+`stale_reason: uuid_unresolved`.
 
-Store assignments as a GPU **UUID** (stable across driver/index drift); the
-adapter (0.3) accepts `{uuid | cuda:N | cuda | cpu | auto}` so legacy pins keep
-working. **Reconcile every stored UUID against `/devices` on read** (config lives
-in shared `~/.castwright/user-settings.json` — a UUID is box-specific; a
-copied-in file is caught only at runtime). Mark unresolved UUIDs `stale` in
-`/health` + the picker.
+**2.2 Settings picker.** One row per sidecar engine; dropdown of `/devices` cards
+showing **free** VRAM; the badge renders the **three `stale_reason`s distinctly**
+(`cpu_fallback`/`env_shadow`/`uuid_unresolved`) and **not by color alone** (a11y),
+comparing assigned-vs-**actual** (1.5). **Wire the existing restart affordance**
+(`RestartSidecarBanner` + `restartSidecar()`, today in `advanced.tsx`) into the
+panel; **batch N row edits into one restart**; **disable env-locked rows** and
+surface the locked-write 409 (`config.ts:53`). Footprint pre-warn uses driver
+**free** + each engine's peak (Qwen ~6.5 GB; Coqui ~3 GB), re-checked **at load
+time** in the sidecar.
 
-## B2. Settings picker
+**2.3 Auto-revert (consumes the W2.5 trip event).** On a code-43 streak trip,
+revert the offending unit(s) and name them. Selection rule: the trip event
+carries `{card, residentEngines[]}` — revert the engine(s) on that card to a
+**different** safe card or CPU (not the knob default `auto`→cuda:0, which can
+re-land on the same undersized card). Wiring: streak event → `writeConfigOverride`
+→ restart.
 
-One row per sidecar engine; a dropdown of `/devices` cards (each showing **free**
-VRAM); the **stale badge compares assigned-vs-*actual*** (from 0.4), so a silent
-CPU fallback is visible. A structured `/health` field **and a visible banner**
-carry "fell back / shadowed-by-env / stale" — not a log WARN to grep (memory:
-`feedback_self_service_observability`). Footprint pre-warn uses driver **free**
-and Qwen **peak** (~6.5 GB), re-checked **at load time** in the sidecar (WDDM free
-swings). On the crash-loop trip (A2), the picker now **auto-reverts** the
-offending unit to its safe default and names it (the write path A2 deferred).
+**2.4 Analyzer read-only row.** Display GPU/CPU/unknown (`detectOllamaDevice`) +
+a link to the documented OS-env path (set `CUDA_VISIBLE_DEVICES` +
+`OLLAMA_FLASH_ATTENTION`/`KV_CACHE_TYPE` on the service, restart Ollama —
+`docs/local-llm.md`). Not app-pinnable; gated on `ANALYZER=local`.
 
-## B3. Analyzer row — read-only (revert of "own the daemon")
+**2.5 env-shadow surfacing + `.env` cutover.** The `locked` state already exists
+in `resolveKnob` (`resolver.ts:15`); expose a `lockedByEnv` field in the config
+read so the picker shows `stale_reason: env_shadow`. `CUDA_VISIBLE_DEVICES`/
+`CUDA_DEVICE_ORDER` are **raw env, not knobs**, so add a dedicated picker check
+for them (the registry path can't see them). Cutover = a **documented manual
+step** stripping `COQUI/ASR/SPK_DEVICE` + the two `CUDA_*` lines from
+`server/.env` (no code edits a user's `.env`); the sidecar WARNs if
+`CUDA_VISIBLE_DEVICES` is still set.
 
-Owning `ollama serve` is a no-op on the common Windows box: Ollama runs on the
-well-known port **11434** as an OS/tray-managed service that's already up, so
-"adopt-don't-fight" never applies the pin, and killing it fights the service
-manager (R3 daemon review). Instead: the analyzer row is **read-only**,
-displaying the current placement and a link to the documented path — set
-`CUDA_VISIBLE_DEVICES` (+ the existing `OLLAMA_FLASH_ATTENTION`/`KV_CACHE_TYPE`)
-as OS/service env and restart Ollama (`docs/local-llm.md`). Zero new daemon code;
-gated on `ANALYZER=local` (dormant under `ANALYZER=gemini`).
-
-## B4. `.env` cutover
-
-Strip `COQUI_DEVICE`/`ASR_DEVICE`/`SPK_DEVICE` **and**
-`CUDA_VISIBLE_DEVICES`/`CUDA_DEVICE_ORDER` from `server/.env` (these live only in
-the user's gitignored `.env`; **no code edits a user's `.env`** — it's a
-documented manual step). The picker surfaces `locked-by-env` (from 0.5) until the
-line is removed; the sidecar WARNs if `CUDA_VISIBLE_DEVICES` is still set while
-the picker owns mapping.
-
-## Plan B testing
-
-Frontend vitest (rows, discovery dropdown, assigned-vs-actual badge, env-shadow
-banner, analyzer read-only row); server vitest (UUID accept/reject + reconcile;
-auto-revert on streak-trip); one Playwright e2e (Settings GPU panel vs mocked
-`/devices`, select, persists). **On-box** acceptance sign-off, noting `/health`
-`free/total` (driver) is VRAM truth while `torch_reserved` under-reports ORT/CT2
-by design.
+*Plan 2 testing.* Frontend vitest (rows, dropdown, three-reason badge,
+analyzer read-only, disabled locked rows); server vitest (UUID accept/reject +
+reconcile; auto-revert selection from a trip event; batched apply→one restart);
+**a responsive `e2e/responsive/coverage.spec.ts` case (3 viewports)** + an **e2e
+asserting the `fell_back` badge** against a mocked `/health` (it crosses
+`/health`→redux→layout — CLAUDE.md's e2e bar); `test:a11y` on the panel. On-box
+sign-off: `/health` driver free/total is VRAM truth; `torch_reserved`
+under-reports ORT/CT2 by design.
 
 ---
 
 ## Key files
 
-**Plan 0** — `server/tts-sidecar/main.py` (new `/devices`, `gpus[]` in `/health`,
-`_resolve_torch_device` index handling, engine adapter, actual-card probe);
-`server/src/config/registry.ts` (widen `COQUI`/`SPK` enums→string; add `KOKORO`/
-`ASR` knobs); `server/src/config/resolver.ts` (`locked-by-env` surfacing);
-`server/src/tts/spawn-sidecar.ts` (knob injection); `server/src/tts/transcribe-client.ts`
-(Node ASR `cuda:N` gate); `server/src/gpu/device-total.ts` (per-GPU); a new
-`/devices` proxy route.
+**Plan 1 / Wave 1** — `main.py` (`/devices`, `gpus[]`, engine adapter, the
+Whisper/SPK/Kokoro device sites, actual-card readback replacing `:4106`);
+`registry.ts` (widen `COQUI`/`SPK`; add `KOKORO`/`ASR`); `spawn-sidecar.ts`
+(knob injection); `transcribe-client.ts` **+ `embed-client.ts`** (Node gates);
+new `/devices` proxy route.
 
-**Plan A** — `main.py` (`DeviceLedger` + lock, per-device recycle + driver-free
-floor, `_VdKokoroArbiter` 457, per-card mutex, eviction call-sites);
-`server/src/tts/sidecar-supervisor.ts` (code-43 streak detector);
-`server/src/gpu/semaphore.ts` + `engine-vram-cost.ts` + `gpu-load.ts` +
-`residency.ts` + `vram-state.ts` (the two A5 guards — all under `server/src/gpu/`).
+**Plan 1 / Wave 2** — `main.py` (`DeviceLedger`+lock, per-card recycle +
+driver-free floor, `_VdKokoroArbiter` 457, per-card mutex, eviction sites,
+self-exit card plumbing); `sidecar-supervisor.ts` (code-43 streak);
+`spawn-sidecar.ts` (`sidecarCeilingMismatch` per-card); `gpu/semaphore.ts` +
+**`tts/engine-vram-cost.ts`** + `gpu/gpu-load.ts` + `gpu/residency.ts`
+(signature change) + `gpu/vram-state.ts` (Node guards).
 
-**Plan B** — `~/.castwright/user-settings.json` (UUID storage + reconcile-on-read);
-Settings view + GPU-assignment panel; `docs/local-llm.md` (analyzer row link);
-`.env.example` (cutover doc).
+**Plan 2** — `user-settings.json` (UUID + reconcile); Settings view + GPU panel
+(reusing `advanced.tsx`'s restart banner); `resolver.ts` (`lockedByEnv` field);
+`docs/local-llm.md`; `.env.example`.
 
 ## Open questions / deferred
 
-- **Driver-free floor default (A2)** — 1024 MB proposed; confirm on-box (display
-  card idle-free vs true-exhaustion margin).
-- **Per-card recycle drain** — whole-process self-exit on any card's cross is a
-  documented v1 limitation; per-card drain deferred.
+- **Driver-free floor default** — 1024 MB proposed; confirm on-box.
+- **Per-card recycle drain** — whole-process self-exit is a documented v1 limit.
 - **Eventually-consistent per-card Node budgets** — the full per-UUID pool map
-  (vs A5's guards) is a deliberate post-v1 item if the global pool proves limiting.
+  (vs the §W2.6 guards) is a deliberate post-v1 item.
+- **Kokoro `device_id` support** — contingent on the pinned `kokoro-onnx`
+  accepting `provider_options`; the InferenceSession fallback is the hedge.

--- a/docs/superpowers/specs/2026-06-27-multi-gpu-per-model-design.md
+++ b/docs/superpowers/specs/2026-06-27-multi-gpu-per-model-design.md
@@ -1,0 +1,238 @@
+---
+title: Per-model GPU assignment (multi-GPU)
+date: 2026-06-27
+status: draft
+---
+
+# Per-model GPU assignment (multi-GPU)
+
+## Problem
+
+The TTS sidecar is single-GPU by design. Every model loads onto one device,
+and the device defaults (`auto` → `cuda:0`, plus `COQUI_DEVICE=cuda` /
+`ASR_DEVICE=cuda`) all resolve to the same card. On a box with two GPUs the
+second card sits idle, and three pieces of safety machinery are hardcoded to
+device 0:
+
+- the reserved-VRAM **recycle ceiling** (`_vram_recycle_soft_threshold_mb` /
+  `_vram_restart_threshold_mb` read `_cuda_vram_mb()`, which calls
+  `torch.cuda.get_device_properties(0)` and default-device `memory_reserved()`),
+- the `/health` **VRAM telemetry**,
+- the **co-residency eviction** logic (Kokoro ↔ Qwen-Base ↔ VoiceDesign ↔ ASR
+  ↔ SPK all assumed to compete on one card).
+
+Per-engine device knobs already exist (`QWEN_DEVICE`, `COQUI_DEVICE`,
+`ASR_DEVICE`, `SPK_DEVICE`), so a user *can* pin engines to different cards
+today — but the moment two engines live on different cards, the safety net is
+blind or wrong: the watchdog watches the wrong card, and eviction fires
+across cards that don't actually share VRAM.
+
+This box (the reference hardware) has an **RTX 4070 Laptop 8 GB** (`cuda:0` by
+torch's default enumeration) and an **RTX 5070 Ti 16 GB** (`cuda:1`). A
+verified stop-gap (`CUDA_DEVICE_ORDER=PCI_BUS_ID` + `CUDA_VISIBLE_DEVICES=1,0`
+in `server/.env`) remaps the 16 GB card to the visible `cuda:0` so the heavy
+synth path and the watchdog both land on it. This spec replaces that stop-gap
+with a real, per-model picker backed by a device-aware runtime.
+
+## Goal
+
+Let the user choose, **per model**, which GPU (or CPU) it runs on, and make the
+sidecar runtime genuinely device-aware so that any assignment is honored
+**safely** — the recycle ceiling, `/health`, and eviction all reason per
+device, not against a hardcoded device 0. A bad assignment must **degrade
+loudly and recoverably**, never brick the sidecar.
+
+Auto-placement (the app proposing a layout by available VRAM) is an **optional,
+default-off** layer on top of the manual picker.
+
+### Assignable units (6)
+
+| Unit | Control plane | Existing knob | Notes |
+|---|---|---|---|
+| **Qwen** (Base 0.6B + VoiceDesign 1.7B) | sidecar env | `QWEN_DEVICE` | Base + VoiceDesign **share one assignment** — they co-reside during a design session. One picker row. |
+| **Coqui XTTS** | sidecar env | `COQUI_DEVICE` | |
+| **Kokoro** | sidecar env | _new_ `KOKORO_DEVICE` | eagerly-resident English fallback (~1 GB). |
+| **Whisper ASR** (content QA / WER) | sidecar env | `ASR_DEVICE` | already CPU-first-capable. |
+| **ECAPA drift** (voice-consistency QA) | sidecar env | `SPK_DEVICE` | srv-47 already made `cuda` *safe*; CPU is today's default. |
+| **Analyzer (Ollama)** | Ollama daemon / `/api/chat` | _new_ pref → `main_gpu` | separate process; `main_gpu` per-request lever + documented daemon `CUDA_VISIBLE_DEVICES` hard-pin. Note: this box currently runs `ANALYZER=gemini` (cloud), so local placement is moot until `ANALYZER=local`. |
+
+### Apply semantics
+
+**Restart-to-apply.** Changing an assignment writes config; it takes effect on
+the next sidecar/Ollama restart (the one-click "restart sidecar" affordance
+already exists). This matches every existing device knob (`apply:
+'restart-sidecar'`) and means each model simply loads onto its assigned card at
+startup — no live cross-card migration in the eviction state machine.
+
+## Non-goals
+
+- **Multi-process sidecar.** The sidecar stays one process driving N cards.
+  Per-device accounting does **not** mean per-device processes.
+- **Live re-placement.** Out of scope (restart-to-apply only).
+- **Auto-placement as default behavior.** It ships off; the user opts in.
+- **Cross-engine load balancing / sharding a single model across cards.**
+
+## Architecture
+
+### Keystone: `DeviceLedger` (sidecar, new module)
+
+One small module that owns two facts and is the single source of truth that
+makes a one-process / N-card sidecar safe:
+
+1. **`engine → device`** — where each loadable engine (Qwen, Coqui, Kokoro,
+   ASR, SPK) is assigned, resolved once from the device knobs at startup via the
+   existing `_resolve_torch_device` pattern.
+2. **`device → {reserved, total}`** — sampled per CUDA device actually in use
+   (`torch.cuda.mem_get_info(idx)` / `memory_reserved(idx)` /
+   `get_device_properties(idx)`), replacing today's hardcoded `(0)` reads.
+
+Everything safety-critical reads **through** the ledger:
+
+- **Recycle / watchdog** — soft & hard thresholds computed **per device** (each
+  card's own fraction × that card's total) and fire if **any in-use device**
+  crosses. A hard cross still triggers the existing **whole-process self-exit
+  (code 43)**; the supervisor respawns a fresh process and all cards' contexts
+  reload. So cross-card models recycle together — correct and simple. The
+  multi-card rule is an **OR over in-use devices**.
+- **`/health`** — reports a `devices[]` array (`idx`, `name`, `reserved`,
+  `total`, resident engines) instead of one device's numbers. Existing scalar
+  fields stay for back-compat, derived from the synth card.
+- **Eviction / co-residency** — every "free VRAM before loading X" path gains
+  the predicate **`shares_device(incoming, resident)`**. Models evict each other
+  only when assigned the **same** card. Qwen on `cuda:0` + Kokoro on `cuda:1` →
+  no eviction.
+
+### Two control planes
+
+- **Sidecar engines (5)** — assignment flows through the registry-knob →
+  `buildSidecarEnv` path. Four knobs exist; we add **`KOKORO_DEVICE`**. The
+  ledger reads these at load.
+- **Analyzer Ollama (1)** — a stored preference threaded as the `main_gpu`
+  option on `/api/chat` (sibling to the existing `num_gpu` via
+  `resolveAnalyzerNumGpu()`), with daemon-level `CUDA_VISIBLE_DEVICES` as the
+  documented robust hard-pin.
+
+## Components
+
+1. **Device discovery** — `GET /devices` on the sidecar enumerates CUDA devices
+   `[{idx, name, total_mb, free_mb}]` (+ a `cpu` pseudo-option); a server proxy
+   (copy the `/health` proxy pattern) exposes it to the frontend. Populates the
+   picker and validates assignments. Depends on: torch.
+2. **Device-assignment config** — the 6 stored assignments. Adds `KOKORO_DEVICE`
+   (reuses `QWEN/COQUI/ASR/SPK_DEVICE`) + an analyzer-GPU preference.
+   `buildSidecarEnv` already injects non-default `restart-sidecar` knobs, so
+   Kokoro slots in; the analyzer value threads into `/api/chat`
+   `options.main_gpu`. Depends on: registry, env-builder, `ollama.ts`.
+3. **`DeviceLedger`** — the keystone above. Independently unit-testable with a
+   stub torch (the `_StubTorch` pattern in `test_device_probe.py`).
+4. **Device-aware recycle / watchdog / `/health`** — refactor: replace
+   `get_device_properties(0)` / default-device `memory_reserved()` with ledger
+   lookups; per-device thresholds; fire on any-card cross; `/health` gains
+   `devices[]`. Highest-risk unit → heaviest test coverage.
+5. **Device-aware eviction** — gate every evict-to-free path on
+   `ledger.shares_device(...)`.
+6. **Settings picker UI** — a "GPU assignment" panel: one row per unit, a
+   dropdown of discovered devices (each showing its VRAM), the current value, a
+   stale-assignment indicator, and the existing "restart sidecar to apply"
+   affordance. Depends on: discovery endpoint + the config-write path Settings
+   already uses.
+7. **Auto-placement (optional, default-off)** — a toggle + "Suggest layout"
+   button that reads device VRAMs and proposes a placement (heavy synth →
+   largest card; QA models → spare) the user can accept into the knobs. Never
+   runs unless invoked; it only *fills in* the same knobs the manual picker
+   writes.
+
+Clean seam: 1–2 plumbing, 3 the new abstraction, 4–5 consume it, 6–7 UI over it.
+
+## Data flow
+
+**Sidecar engine (happy path):** picker calls `GET /devices` → shows each card
+with VRAM → user picks a device per unit → write to registry config
+(`user-settings.json`) → user clicks "restart sidecar" → `buildSidecarEnv`
+injects the `*_DEVICE` knobs → sidecar boots → each engine loads onto its
+assigned card → `DeviceLedger` records `engine→device` → watchdog samples each
+in-use device per cycle → recycle fires per-card, `/health` reports `devices[]`.
+
+**Analyzer:** stored preference → threaded as `options.main_gpu` on the next
+`/api/chat` model load; daemon `CUDA_VISIBLE_DEVICES` is the documented hard-pin
+fallback.
+
+## Error handling
+
+The principle: **a bad assignment degrades loudly and recoverably; it never
+bricks the sidecar.**
+
+- **Stale / invalid assignment** (knob says `cuda:2`, or a card was removed) →
+  the device resolver clamps to a safe fallback (`cuda:0`, then `cpu`) with a
+  loud one-time WARN; `/health` + the picker flag the assignment as **stale**
+  rather than silently honoring a phantom. Extends `_resolve_torch_device`.
+- **Card vanishes mid-run** (driver reset) → `mem_get_info(idx)` throws → ledger
+  returns `None` for that device → its ceiling derives to **0 (disabled)**,
+  exactly today's unknown-VRAM fail-safe; the host-RAM watchdog governs. No
+  guessed ceiling that could false-fire.
+- **Heavy engine on a too-small card** → QA models (ASR, SPK) have CPU-degrade
+  paths → demote with a WARN. Synth engines (Qwen/Coqui) that can't sensibly
+  CPU-fall-back → load fails with a clear surfaced error ("Qwen needs ~XGB,
+  cuda:1 has 8 GB"). The picker pre-warns when a known footprint exceeds the
+  target card's VRAM.
+- **Two co-resident models on the same small card** (e.g. Qwen Base +
+  VoiceDesign during a design) → the existing co-residency OOM guard still
+  applies, now correctly **scoped to that one card** via `shares_device`.
+
+## Testing
+
+Mapped to the five tiers, weighted toward the risky units.
+
+**Sidecar pytest (heaviest):**
+- `DeviceLedger` with a stub torch (reuse `_StubTorch`/`_torch` from
+  `test_device_probe.py` / `test_qwen_device.py`): `engine→device` resolution
+  from knobs, per-device `{reserved,total}` sampling, `shares_device` truth
+  table, stale-device → safe-fallback + WARN.
+- Recycle thresholds computed **per device**, firing when *any* in-use card
+  crosses (the OR rule) — including the asymmetric case (16 GB fine, 8 GB over →
+  recycle fires).
+- Eviction: same-card pair evicts (today's behavior preserved) vs cross-card
+  pair does **not** evict (the new behavior / the bug being fixed).
+- `GET /devices` shape; `/health` `devices[]` shape + back-compat scalars.
+
+**Server vitest:** `buildSidecarEnv` injects `KOKORO_DEVICE` when non-default;
+analyzer `main_gpu` threads into `/api/chat`; `/devices` proxy; config write
+**validates against discovered devices** (reject `cuda:5` on a 2-card box).
+
+**Frontend vitest:** picker renders one row per unit, dropdown populated from
+discovery, stale-assignment indicator, "restart to apply" affordance present.
+
+**E2E (Playwright, one spec):** Settings → GPU panel renders against mocked
+`/devices`, select a device for a unit, value persists across reload.
+
+**Regression plan:** a new `docs/features/<n>-multi-gpu-per-model.md` from
+`TEMPLATE.md` documenting the invariants (per-device recycle, same-card-only
+eviction, loud-degrade-never-brick) and a manual **2-GPU on-box acceptance**
+walkthrough — the automated tiers run on stub torch / single-GPU CI, so the
+real 2-card behavior needs an on-box acceptance pass (consistent with the
+"owed on-box" pattern on other GPU features).
+
+## Key files
+
+- `server/tts-sidecar/main.py` — `_cuda_vram_mb`, `_vram_recycle_*`,
+  `_resolve_torch_device`, `_normalize_device_family`, the engine classes
+  (`QwenEngine`, `CoquiEngine`, Kokoro, `WhisperEngine`, the ECAPA/SPK class),
+  the eviction call-sites, `/health`. New: `DeviceLedger` module + `/devices`.
+- `server/src/tts/spawn-sidecar.ts` — `buildSidecarEnv` (`KOKORO_DEVICE`).
+- `server/src/config/registry.ts` — the device knobs (`KOKORO_DEVICE` knob +
+  analyzer-GPU pref).
+- `server/src/analyzer/ollama.ts` — `main_gpu` threading (sibling to
+  `resolveAnalyzerNumGpu`).
+- `server/src/routes/sidecar-health.ts` (+ a new devices route) — proxy.
+- Frontend Settings view + a new GPU-assignment panel component.
+- `server/.env.example` — document `KOKORO_DEVICE`, the analyzer GPU pref, and
+  the `CUDA_VISIBLE_DEVICES` / `CUDA_DEVICE_ORDER` multi-GPU remap.
+
+## Open questions / deferred
+
+- **Auto-placement heuristic** — v1 ships the toggle + a simple "largest card
+  gets synth, spare gets QA" suggestion. A smarter footprint-aware solver is a
+  follow-up.
+- **Per-card recycle granularity** — v1 self-exits the whole process on any
+  card's hard cross (simplest, correct). A future refinement could reload only
+  the offending card's engines if the self-exit cost becomes a problem.

--- a/docs/superpowers/specs/2026-06-27-multi-gpu-per-model-design.md
+++ b/docs/superpowers/specs/2026-06-27-multi-gpu-per-model-design.md
@@ -6,299 +6,360 @@ status: draft
 
 # Per-model GPU assignment (multi-GPU)
 
+> Revised twice after adversarial review. The first revision fixed the
+> engine-grammar / VRAM-allocator model; the second (this one) folds in a
+> five-lens parallel review that found the **config layer** and the **Node-side
+> orchestration layer** were under-modeled, split the work into **two sequential
+> plans**, cut auto-placement, and made the analyzer row implementable by
+> **owning the Ollama daemon**.
+
 ## Problem
 
-The TTS sidecar is single-GPU by design. Every model loads onto one device,
-and the device defaults (`auto` → `cuda:0`, plus `COQUI_DEVICE=cuda` /
-`ASR_DEVICE=cuda`) all resolve to the same card. On a box with two GPUs the
-second card sits idle, and three pieces of safety machinery are hardcoded to
-device 0:
+The TTS sidecar is single-GPU by design. Every model loads onto one device, and
+the defaults (`auto` → `cuda:0`, `COQUI_DEVICE=cuda`, `ASR_DEVICE=cuda`) resolve
+to the same card. On a 2-GPU box the second card sits idle, and **safety
+machinery on both sides of the process boundary is single-card-bound**:
 
-- the reserved-VRAM **recycle ceiling** (`_vram_recycle_soft_threshold_mb` /
-  `_vram_restart_threshold_mb` read `_cuda_vram_mb()`, which calls
-  `torch.cuda.get_device_properties(0)` and default-device `memory_reserved()`),
-- the `/health` **VRAM telemetry**,
-- the **co-residency eviction** logic (Kokoro ↔ Qwen-Base ↔ VoiceDesign ↔ ASR
-  ↔ SPK all assumed to compete on one card).
+- **Sidecar (Python):** the reserved-VRAM recycle ceiling, `/health` telemetry,
+  and co-residency eviction are hardcoded to device 0 (`main.py:3342`,
+  `_cuda_vram_mb`); the `_VdKokoroArbiter` (`main.py:457`) couples VoiceDesign↔Kokoro
+  unconditionally even across cards.
+- **Server (Node):** the weighted GPU semaphore is a **single global token pool**
+  (`gpu/semaphore.ts:36-152`) with one `gpu.vramBudget`; the analyzer↔TTS
+  co-eviction (`tts/gpu-load.ts`, `residency.ts`) keys on **one scalar total**.
+  Neither can express "card A free / card B free."
 
-Per-engine device knobs already exist (`QWEN_DEVICE`, `COQUI_DEVICE`,
-`ASR_DEVICE`, `SPK_DEVICE`), so a user *can* pin engines to different cards
-today — but the moment two engines live on different cards, the safety net is
-blind or wrong: the watchdog watches the wrong card, and eviction fires
-across cards that don't actually share VRAM.
+Per-engine device knobs let a user *pin* engines to cards today, but the moment
+two engines live on different cards the safety net is blind or wrong, and — per
+the review — shipping a naive picker would make a 2-card box **more** OOM-prone
+and **unable** to run the parallel analyze+synth workload that justifies the
+second card.
 
-This box (the reference hardware) has an **RTX 4070 Laptop 8 GB** (`cuda:0` by
-torch's default enumeration; **also drives the display**, so its *free* VRAM is
-well under 8 GB) and an **RTX 5070 Ti 16 GB** (`cuda:1`). A verified stop-gap
+Reference hardware: **RTX 4070 Laptop 8 GB** (drives the display → *free* VRAM
+well under 8 GB) and **RTX 5070 Ti 16 GB**. A verified stop-gap
 (`CUDA_DEVICE_ORDER=PCI_BUS_ID` + `CUDA_VISIBLE_DEVICES=1,0` in `server/.env`)
-remaps the 16 GB card to the visible `cuda:0` so the heavy synth path and the
-watchdog both land on it.
-
-**This feature owns device mapping.** When the picker ships, the
-`CUDA_VISIBLE_DEVICES` stop-gap is **removed**: the sidecar enumerates all
-physical cards in raw order, and the picker assigns by **GPU UUID** (see the
-`DeviceLedger` keystone below) directly to physical cards — one mechanism, no
-hidden remap layer. The stop-gap stays in place only until the picker lands.
+remaps the 16 GB card to the visible `cuda:0`. **This feature owns device
+mapping**; the stop-gap is retired by an explicit `.env` cutover when Plan B
+lands (see §B5).
 
 ## Goal
 
-Let the user choose, **per model**, which GPU (or CPU) it runs on, and make the
-sidecar runtime genuinely device-aware so that any assignment is honored
-**safely** — the recycle ceiling, `/health`, and eviction all reason per
-device, not against a hardcoded device 0. A bad assignment must **degrade
-loudly and recoverably**, never brick the sidecar.
+Let the user choose, **per model**, which GPU (or CPU) each runs on, with a
+runtime — sidecar **and** server — that's genuinely device-aware so any
+assignment is honored **safely**: per-card recycle, per-card VRAM budgeting,
+same-card-only coupling, and **observability of the card a model *actually*
+loaded onto** (not just the one requested). A bad assignment must **degrade
+loudly and recoverably**, never brick.
 
-Auto-placement (the app proposing a layout by available VRAM) is an **optional,
-default-off** layer on top of the manual picker.
+Auto-placement is **cut** (a 2-card box has one obvious layout, set once).
+
+### Delivery: two sequential plans
+
+The review converged on this split; it de-risks the hard config work.
+
+- **Plan A — Device-aware safety net.** Pure runtime (sidecar Python + Node
+  semaphore/eviction). Ships value alone by fixing the device-0 hardcodes and
+  the unconditional cross-card coupling. No UI. Testable as far as it ever will
+  be (stub-torch for shape; on-box for truth).
+- **Plan B — The picker + owned Ollama daemon.** Config-layer rework, device
+  discovery, Settings UI, and app-owned `ollama serve` so the analyzer is really
+  assignable. Built on a green Plan A.
 
 ### Assignable units (6)
 
-| Unit | Runtime | Device API | Existing knob | Notes |
+| Unit | Runtime | Device API | Knob status | Notes |
 |---|---|---|---|---|
-| **Qwen** (Base 0.6B + VoiceDesign 1.7B) | torch | `cuda:N` via `.to()` | `QWEN_DEVICE` | Base + VoiceDesign **share one assignment** — they co-reside during a design session. One picker row. |
-| **Coqui XTTS** | torch | `cuda:N` via `.to()` | `COQUI_DEVICE` | |
-| **ECAPA drift** (voice-consistency QA) | torch (speechbrain) | `cuda:N` via `.to()` | `SPK_DEVICE` | srv-47 already made `cuda` *safe*; CPU is today's default. |
-| **Kokoro** | **onnxruntime** | **ORT provider `device_id`** | _new_ `KOKORO_DEVICE` | eagerly-resident English fallback (~1 GB). **Separate allocator from torch** (`main.py:460`) — `cuda:N` is meaningless to it. |
-| **Whisper ASR** (content QA / WER) | **CTranslate2** | **`device="cuda"` + `device_index`** | `ASR_DEVICE` | already CPU-first-capable. **Separate allocator from torch**; does *not* accept `cuda:N`. |
-| **Analyzer (Ollama)** | Ollama daemon | **daemon `CUDA_VISIBLE_DEVICES`** | _new_ pref | separate process. Restart-to-apply via daemon env; `main_gpu` is *not* a reliable pin (it only chooses the primary GPU in split mode). Note: this box currently runs `ANALYZER=gemini` (cloud), so local placement is moot until `ANALYZER=local`. |
+| **Qwen** (Base 0.6B + VoiceDesign 1.7B) | torch | `cuda:N` via `.to()` | `QWEN_DEVICE` (string ✓) | Base + VoiceDesign **share one assignment**; co-reside during a design. Peak ~6.5 GB. |
+| **Coqui XTTS** | torch | `cuda:N` via `.to()` | `COQUI_DEVICE` (**enum → widen to string**) | rarely loaded (`PRELOAD_COQUI=0`). |
+| **ECAPA drift** (voice-consistency QA) | torch (speechbrain) | `cuda:N` via `.to()` | `SPK_DEVICE` (**enum → widen to string**) | promotable to spare card. |
+| **Kokoro** | **onnxruntime** | **ORT provider `device_id`** | _new_ `KOKORO_DEVICE` | eager at startup (~1 GB). Separate allocator from torch (`main.py:460`). |
+| **Whisper ASR** (content QA / WER) | **CTranslate2** | **`device="cuda"` + `device_index`** | **no knob today → add one** | separate allocator; read by a Node gate too (`transcribe-client.ts:59`). |
+| **Analyzer (Ollama)** | Ollama daemon (**now app-owned**) | daemon `CUDA_VISIBLE_DEVICES` | _new_ pref | app will spawn/supervise `ollama serve` (§B6) so env injection is real. Dormant on this box until `ANALYZER=local`. |
 
-**The five sidecar engines do not share a device grammar.** Three are torch
-(`cuda:N`), Kokoro is onnxruntime (provider `device_id`), Whisper is CTranslate2
-(`device` + `device_index`). The picker therefore stores a **canonical**
-assignment per unit (a GPU **UUID**, or `cpu`), and an **engine device-adapter**
-(see Components §3a) translates that canonical value into each engine's native
-device API at load. The knob env values (`QWEN_DEVICE` etc.) carry the resolved
-torch/native form the adapter produces.
+**No uniform device grammar.** Three engines are torch (`cuda:N`), Kokoro is ORT
+(`device_id`), Whisper is CTranslate2 (`device`+`device_index`). The picker
+stores a **canonical UUID** (or `cpu`); a Python-side **engine device-adapter**
+(§A7) translates it per engine. The adapter also accepts legacy forms
+(`cuda:N | cuda | cpu | auto`) so existing pins keep working.
 
 ### Apply semantics
 
-**Restart-to-apply.** Changing an assignment writes config; it takes effect on
-the next sidecar/Ollama restart (the one-click "restart sidecar" affordance
-already exists). This matches every existing device knob (`apply:
-'restart-sidecar'`) and means each model simply loads onto its assigned card at
-startup — no live cross-card migration in the eviction state machine.
+**Restart-to-apply** for every unit (sidecar restart for the 5 engines; daemon
+restart for the analyzer). Matches existing `apply:'restart-sidecar'` knobs; no
+live cross-card migration.
 
 ## Non-goals
 
-- **Multi-process sidecar.** The sidecar stays one process driving N cards.
-  Per-device accounting does **not** mean per-device processes.
-- **Live re-placement.** Out of scope (restart-to-apply only).
-- **Auto-placement as default behavior.** It ships off; the user opts in.
-- **Cross-engine load balancing / sharding a single model across cards.**
+- **Auto-placement** (cut).
+- **Multi-process sidecar.** One process drives N cards; per-device accounting ≠
+  per-device processes.
+- **Live re-placement.** Restart-to-apply only.
+- **Sharding one model across cards.**
 
-## Architecture
+---
 
-### Keystone: `DeviceLedger` (sidecar, new module)
+# Plan A — Device-aware safety net
 
-One small module that owns two facts and is the single source of truth that
-makes a one-process / N-card sidecar safe:
+## A1. `DeviceLedger` (sidecar, new module) — thread-safe, never caches an index
 
-1. **`engine → device`** — where each loadable engine (Qwen, Coqui, Kokoro,
-   ASR, SPK) is assigned, resolved once at startup from the canonical
-   UUID-keyed assignment via the engine device-adapter (§3a). Identity is the
-   **GPU UUID** (`torch.cuda.get_device_properties(idx).uuid`), not the bare
-   index — so the ledger maps `uuid → current torch index` and warns on drift.
-2. **Two distinct per-device quantities** (the v1 design conflated these — they
-   are not the same and must not be):
-   - **driver free / total** via `torch.cuda.mem_get_info(idx)` — the **driver
-     truth**, visible across *all* allocators (torch, ORT, CTranslate2). This is
-     what **capacity, footprint pre-warning, eviction, and OOM** reasoning use.
-   - **torch reserved** via `memory_reserved(idx)` — the **torch caching-allocator
-     pool only**. Valid *solely* for the fragmentation self-exit, and *solely*
-     on cards hosting torch engines. **Kokoro (ORT) and Whisper (CT2) VRAM is
-     invisible to `memory_reserved`** (`main.py:460`), so a card hosting only
-     those reads reserved ≈ 0 — its fragmentation ceiling is inert by design,
-     and its safety comes from the driver-free path above.
+Owns `engine → device` (by **GPU UUID**) and per-device VRAM samples. It is read
+from **three thread contexts** — the `_memory_watchdog` event loop, the sync
+`/health` + `/devices` Starlette threadpool threads, and `asyncio.to_thread`
+synth/load workers — so:
 
-Everything safety-critical reads **through** the ledger:
+- **One `threading.Lock`** guards the `uuid→index` map and any cached state.
+  Today's `_cuda_vram_mb` is stateless (safe by accident); the ledger is mutable
+  and must not rely on the GIL for multi-bytecode map updates.
+- **uuid→index is re-resolved and re-validated every sample, never cached.** A
+  vanished card makes torch renumber survivors *downward*, so a stale index
+  silently reads the **wrong healthy card** (no exception). Each read asserts
+  `get_device_properties(idx).uuid == expected_uuid`; mismatch ⇒ treat as
+  vanished (ceiling → 0). This is what actually makes the "vanished → None"
+  fail-safe true.
+- **Two distinct per-device quantities, never conflated:**
+  - **driver free/total** via `mem_get_info(idx)` — visible across *all*
+    allocators (torch, ORT, CTranslate2). Drives capacity/OOM/eviction reasoning.
+  - **torch reserved** via `memory_reserved(idx)` — torch caching-allocator pool
+    only; invisible to Kokoro(ORT)/Whisper(CT2). Drives *only* the
+    fragmentation self-exit, *only* on torch-hosting cards.
 
-- **Recycle / watchdog** — the **fragmentation** soft/hard thresholds are
-  computed per **torch-hosting** device (each card's fraction × that card's
-  total, on the torch `reserved` pool) and fire if **any** crosses. A hard cross
-  still triggers the existing **whole-process self-exit (code 43)**; the
-  supervisor respawns and all cards' contexts reload. The multi-card rule is an
-  **OR over in-use torch devices**. (Capacity/OOM for non-torch cards is the
-  driver-free path, not this ceiling.)
-- **`/health`** — reports a `devices[]` array (`uuid`, `idx`, `name`,
-  `free`, `total`, `torch_reserved`, resident engines). Existing scalar fields
-  stay for back-compat, derived from a **defined** card: Qwen's resolved device,
-  falling back to torch index 0 (M2).
-- **Eviction / co-residency** — **both** VRAM-coupling mechanisms gain the
-  predicate **`shares_device(a, b)`**: (1) the load-time "free VRAM before
-  loading X" evictions, **and** (2) the synth-time `_VdKokoroArbiter`
-  (`main.py:457`) forward-overlap lock between VoiceDesign and Kokoro. Models
-  couple only when assigned the **same physical card**; Qwen on one card +
-  Kokoro on another → no eviction *and* no forward serialization.
-  `shares_device` resolves `auto` to its concrete device first, and returns
-  **false** for any pair where either side is `cpu` (no VRAM contention) (M3).
+## A2. Per-device recycle / watchdog — and a real driver-free ceiling
 
-### Two control planes
+- **Fragmentation ceiling** (torch reserved): computed per torch-hosting device,
+  fires on **any** crossing (OR rule). Each card is evaluated on its own freshly
+  read value (no torn-snapshot risk).
+- **Driver-free ceiling (new):** a card hosting *only* ORT/CT2 engines reads
+  torch-reserved ≈ 0, so the fragmentation ceiling is inert — it has **no OOM
+  protection today**. Add a per-device watchdog branch that recycles/self-exits
+  on **driver-free** crossing, so ORT/CT2-only cards are actually guarded, not
+  just sampled for display.
+- **Blast-radius (documented limitation):** the hard self-exit (code 43) is
+  **whole-process** — `_restart_pending` + `_drain_then_restart` are process-wide
+  (`main.py:3485,3512`). So the 8 GB card crossing its ceiling drains and aborts
+  in-flight synth on the *healthy* 16 GB card. v1 accepts this (per-device drain
+  on a single `_inflight_synth` is non-trivial); it is stated, not buried, and
+  deferred as a known limitation.
+- **Crash-loop protection (new — closes a brick path):** a structurally-too-small
+  assignment loops `load→synth→cross→drain(≤180 s)→self-exit` forever, because
+  living >`QUICK_DEATH_MS` (30 s) **resets** `consecutiveFailures`
+  (`sidecar-supervisor.ts:40,263`) and `onChildExit` never inspects `code`. Add a
+  **code-43 streak detector** counting consecutive VRAM self-exits in a
+  wall-clock window *regardless of child uptime*; on cap-trip, hold TTS down,
+  **auto-revert the offending unit to its safe default**, and name the knob in a
+  FATAL line.
 
-- **Sidecar engines (5)** — the canonical UUID assignment flows through the
-  registry-knob → `buildSidecarEnv` path; the **engine device-adapter** (§3a)
-  resolves it to each engine's native form. Four knobs exist; we add
-  **`KOKORO_DEVICE`** (mapped to an ORT provider `device_id`). `ASR_DEVICE`
-  grows from `cpu|cuda` to also carry a device index that the adapter splits
-  into CTranslate2's `device` + `device_index`.
-- **Analyzer Ollama (1)** — a stored preference applied as **daemon-level
-  `CUDA_VISIBLE_DEVICES`** at `ollama serve` (restart-to-apply, consistent with
-  the rest of the feature). `main_gpu` is **not** a reliable pin — it only
-  selects the primary GPU in split mode — so it is at most a secondary hint, not
-  the mechanism. On this box the analyzer is `ANALYZER=gemini` today, so this
-  plane is dormant until `ANALYZER=local`.
+## A3. `shares_device` coupling — symmetric, resolved once
 
-## Components
+Both VRAM-coupling mechanisms gate on `shares_device(a, b)`:
 
-1. **Device discovery** — `GET /devices` on the sidecar enumerates CUDA devices
-   `[{uuid, idx, name, total_mb, free_mb}]` (+ a `cpu` pseudo-option) via
-   `torch.cuda.mem_get_info` / `get_device_properties`; a server proxy (copy the
-   `/health` proxy pattern) exposes it to the frontend. `free_mb` (driver truth)
-   is shown so the picker reflects the display-driven card's real headroom.
-   Depends on: torch.
-2. **Device-assignment config** — the 6 stored canonical assignments (GPU UUID
-   or `cpu`). Adds `KOKORO_DEVICE` (reuses `QWEN/COQUI/ASR/SPK_DEVICE`) + an
-   analyzer-GPU preference. `buildSidecarEnv` already injects non-default
-   `restart-sidecar` knobs, so Kokoro slots in; the analyzer value becomes the
-   daemon's `CUDA_VISIBLE_DEVICES`. Depends on: registry, env-builder,
-   `ollama.ts`.
-3. **`DeviceLedger`** — the keystone above (UUID identity; driver-free vs
-   torch-reserved split). Independently unit-testable with a stub torch (the
-   `_StubTorch` pattern in `test_device_probe.py`).
-   - **3a. Engine device-adapter** — translates one canonical assignment
-     (UUID / `cpu`) into each engine's native device API: torch `cuda:N`
-     (Qwen/Coqui/SPK), ORT provider `device_id` (Kokoro), CTranslate2
-     `device`+`device_index` (Whisper). Owns the `uuid → current torch index`
-     resolution and the stale/drift detection. The single place that knows each
-     engine's device dialect — so the ledger and picker stay dialect-agnostic.
-4. **Device-aware recycle / watchdog / `/health`** — refactor: replace
-   `get_device_properties(0)` / default-device `memory_reserved()` with ledger
-   lookups; per-device thresholds; fire on any-card cross; `/health` gains
-   `devices[]`. Highest-risk unit → heaviest test coverage.
-5. **Device-aware eviction + arbiter** — gate **both** VRAM-coupling
-   mechanisms on `ledger.shares_device(...)`: the load-time evict-to-free paths
-   **and** the synth-time `_VdKokoroArbiter` (`main.py:457`) VoiceDesign↔Kokoro
-   forward lock. Cross-card pairs neither evict nor serialize.
-6. **Settings picker UI** — a "GPU assignment" panel: one row per unit, a
-   dropdown of discovered devices (each showing its VRAM), the current value, a
-   stale-assignment indicator, and the existing "restart sidecar to apply"
-   affordance. Depends on: discovery endpoint + the config-write path Settings
-   already uses.
-7. **Auto-placement (optional, default-off)** — a toggle + "Suggest layout"
-   button that reads device VRAMs and proposes a placement (heavy synth →
-   largest card; QA models → spare) the user can accept into the knobs. Never
-   runs unless invoked; it only *fills in* the same knobs the manual picker
-   writes.
+1. load-time evict-to-free paths, **and**
+2. the synth-time `_VdKokoroArbiter` (`main.py:457`) VoiceDesign↔Kokoro forward lock.
 
-Clean seam: 1–2 plumbing, 3 the new abstraction, 4–5 consume it, 6–7 UI over it.
+Rules:
+- `auto` is resolved to a **concrete UUID at ledger init**, before any
+  `shares_device` evaluation (an unresolved `auto` drifts across boots once the
+  remap is gone).
+- `shares_device(cpu, *)` ⇒ **false** (no VRAM contention).
+- The VD↔Kokoro boolean is computed **once at startup into a single flag both
+  `design()` and `kokoro_synth()` read** — never recomputed per-call on either
+  side. A predicate only one party respects is no lock (asymmetric → the 8 GB
+  three-way spill returns).
 
-## Data flow
+## A4. Per-card load/evict mutex
 
-**Sidecar engine (happy path):** picker calls `GET /devices` → shows each card
-with VRAM → user picks a device per unit → write to registry config
-(`user-settings.json`) → user clicks "restart sidecar" → `buildSidecarEnv`
-injects the `*_DEVICE` knobs → sidecar boots → each engine loads onto its
-assigned card → `DeviceLedger` records `engine→device` → watchdog samples each
-in-use device per cycle → recycle fires per-card, `/health` reports `devices[]`.
+`_VD_KOKORO` only covers VoiceDesign↔Kokoro. Any *other* same-card pair the
+design now allows (e.g. Coqui + ASR on `cuda:0`) has a check-residency → evict →
+load TOCTOU with no covering lock (the `is not None` residency checks at
+`main.py:2147,2163` already race). Add a **per-physical-card load/evict mutex**
+in the ledger; the whole check-evict-load sequence on a card holds it.
 
-**Analyzer:** stored preference → written as the Ollama daemon's
-`CUDA_VISIBLE_DEVICES` and applied on daemon restart (restart-to-apply).
-`main_gpu` is not relied on as the pin.
+## A5. Node GPU semaphore → per-device
 
-## Error handling
+The single global pool (`semaphore.ts:36-152`, budget sized for one 8 GB card)
+gives **zero per-card protection** on two cards. Make the budget **per-device**,
+keyed by the resolved engine→card UUID; costs (`engine-vram-cost.ts`) charge the
+**target card's** pool. Consequences:
 
-The principle: **a bad assignment degrades loudly and recoverably; it never
-bricks the sidecar.**
+- The analyzer (cost 4 = whole budget, `engine-vram-cost.ts:23`) must **not**
+  charge the TTS card's pool when it resolves to a different card — otherwise it
+  serializes all TTS and forbids the parallel analyze+synth that justifies the
+  second card.
+- `costForEngine`'s unknown-key fallback of 1 (`engine-vram-cost.ts:57`) is
+  unsafe against a small per-card budget — make it conservative (refuse, or
+  charge a high cost) rather than 1.
 
-- **Stale / invalid assignment** (knob says `cuda:2`, or a card was removed) →
-  the device resolver clamps to a safe fallback (`cuda:0`, then `cpu`) with a
-  loud one-time WARN; `/health` + the picker flag the assignment as **stale**
-  rather than silently honoring a phantom. Extends `_resolve_torch_device`.
-- **Card vanishes mid-run** (driver reset) → `mem_get_info(idx)` throws → ledger
-  returns `None` for that device → its ceiling derives to **0 (disabled)**,
-  exactly today's unknown-VRAM fail-safe; the host-RAM watchdog governs. No
-  guessed ceiling that could false-fire.
-- **Heavy engine on a too-small card** → QA models (ASR, SPK) have CPU-degrade
-  paths → demote with a WARN. Synth engines (Qwen/Coqui) that can't sensibly
-  CPU-fall-back → load fails with a clear surfaced error ("Qwen needs ~X GB,
-  this card has Y GB free"). The picker pre-warns against the card's **free**
-  VRAM (driver truth — the display-driven card has well under its nominal
-  total), and for Qwen uses the **peak** footprint (**Base + VoiceDesign
-  co-resident**, ~6.5 GB during a design), not Base alone — so it catches a
-  Qwen-on-8 GB assignment that would only OOM when someone designs a voice (M1).
-- **Two co-resident models on the same small card** (e.g. Qwen Base +
-  VoiceDesign during a design) → the existing co-residency OOM guard still
-  applies, now correctly **scoped to that one card** via `shares_device`.
+## A6. Node co-eviction + the `/health` scalar that feeds it
 
-## Testing
+- `shouldEvictBeforeSidecarLoad` (`residency.ts:9`) must take **both** the
+  incoming sidecar engine's card and the analyzer's card and return **false when
+  they differ** — else it evicts the warm analyzer to "free" a card it isn't on.
+- **The scalar that feeds eviction must be the target *load* card's total**, not
+  Qwen's device (my earlier M2 choice was wrong: reporting 16 GB makes eviction
+  skip and loads XTTS onto the cramped 8 GB card → OOM).
 
-Mapped to the five tiers, weighted toward the risky units.
+## A7. Engine device-adapter (Python) + actual-card reporting
 
-**Sidecar pytest (heaviest):**
-- `DeviceLedger` with a stub torch (reuse `_StubTorch`/`_torch` from
-  `test_device_probe.py` / `test_qwen_device.py`): `uuid→index` resolution
-  (incl. drift warn), per-device **driver-free** vs **torch-reserved** sampling
-  kept distinct, `shares_device` truth table, stale-device → safe-fallback +
-  WARN.
-- Recycle thresholds computed **per device**, firing when *any* in-use card
-  crosses (the OR rule) — including the asymmetric case (16 GB fine, 8 GB over →
-  recycle fires).
-- Eviction: same-card pair evicts (today's behavior preserved) vs cross-card
-  pair does **not** evict (the new behavior / the bug being fixed).
-- `GET /devices` shape; `/health` `devices[]` shape + back-compat scalars.
+- One Python module translates a canonical assignment (UUID / `cpu` / legacy
+  `cuda:N|cuda|auto`) into each engine's native API: torch `cuda:N`
+  (Qwen/Coqui/SPK), ORT provider `device_id` (Kokoro), CT2 `device`+`device_index`
+  (Whisper). **All `*_DEVICE` env reads route through it** — including the Node
+  ASR gate (`transcribe-client.ts:59`), which must learn the `cuda:N` form or it
+  silently skips the GPU token.
+- **`/health` reports the card each engine *actually* loaded onto**, probed from
+  the live module / ORT session (`get_providers()` already exists,
+  `main.py:4010`) — not the requested assignment. This closes the recurring
+  "Kokoro silently on CPU" class (memory: `project_kokoro_cpu_onnxruntime_gpu_swap`)
+  instead of re-creating it at 2× surface. ORT/CT2 bad-`device_id` silently falls
+  back to CPU and the eager loader swallows it (`main.py:3716`), so read-back +
+  WARN + a structured stale flag is the only honest signal.
+- **`/health` field naming:** `/health` *already* exposes a `devices` map
+  (engine→family, `main.py:4109`). The new per-card array is **`gpus[]`**
+  (`{uuid, idx, name, free, total, torch_reserved, resident:[{engine, actual_card}]}`),
+  leaving `devices` untouched.
 
-**Server vitest:** `buildSidecarEnv` injects `KOKORO_DEVICE` (and the
-`ASR_DEVICE` index form) when non-default; the analyzer pref resolves to the
-daemon's `CUDA_VISIBLE_DEVICES`; `/devices` proxy; config write **validates
-against discovered devices by UUID** (reject an assignment whose UUID isn't
-present).
+## A8. Plan A testing
 
-**Frontend vitest:** picker renders one row per unit, dropdown populated from
-discovery, stale-assignment indicator, "restart to apply" affordance present.
+- **Honest framing:** stub-torch (`test_device_probe.py`'s `_StubTorch` has no
+  `mem_get_info`/`uuid`/`memory_reserved`) can only test **shape/arithmetic** of
+  a *new richer stub we hand-feed*. It cannot reproduce multi-allocator VRAM, ORT
+  `device_id`, CT2 `device_index`, or UUID drift. Mark these pytest cases
+  "shape-only."
+- **The gating validation is the on-box 2-GPU acceptance** (`test:sidecar` is
+  venv-gated → skips in CI). Budget it as a deliverable, not a footnote.
+- Pytest (shape): ledger lock present; uuid mismatch ⇒ vanished; per-card OR
+  fires on the 8 GB but not 16 GB; `shares_device` cpu/auto/same-uuid truth
+  table; adapter resolves each engine's dialect; code-43 streak detector trips on
+  a uptime-resetting loop.
+- Server vitest: per-device semaphore charges the right card; cross-card analyzer
+  doesn't block TTS; `shouldEvictBeforeSidecarLoad` false across cards; ASR Node
+  gate handles `cuda:N`.
 
-**E2E (Playwright, one spec):** Settings → GPU panel renders against mocked
-`/devices`, select a device for a unit, value persists across reload.
+---
 
-Add cases for the **engine device-adapter** (§3a): a UUID canonical assignment
-resolves to torch `cuda:N` for Qwen/Coqui/SPK, an ORT `device_id` for Kokoro,
-and CTranslate2 `device`+`device_index` for Whisper; an unknown UUID falls back
-loudly. And for `shares_device`: torch-vs-ORT engines on the same physical card
-*do* couple (same UUID), `cpu` pairs never couple.
+# Plan B — Picker + owned Ollama daemon
 
-**Regression plan:** a new `docs/features/<n>-multi-gpu-per-model.md` from
-`TEMPLATE.md` documenting the invariants (per-device recycle, same-card-only
-eviction *and* arbiter, loud-degrade-never-brick, UUID identity) and a manual
-**2-GPU on-box acceptance** walkthrough — the automated tiers run on stub torch
-/ single-GPU CI, so the real 2-card behavior needs an on-box pass. The
-walkthrough must note that **`/health` `free`/`total` (driver) is the VRAM
-truth; `torch_reserved` is torch-pool-only and will under-report** any card
-hosting Kokoro (ORT) or Whisper (CT2) — an expected gap, not a bug (L1).
+## B1. Config schema — the foundation the picker needs
+
+The "reuse the four knobs + store UUID" premise was wrong on three counts:
+
+- **Widen the device knobs from `enum` to `string`** — `COQUI_DEVICE`/`SPK_DEVICE`
+  are `enum[auto/cpu/cuda]` (`registry.ts:424,281`) and `coerceAndValidate`
+  rejects anything else (`resolver.ts:73`); they cannot hold a UUID. Validate
+  against discovered `/devices` UUIDs instead of a fixed list.
+- **Add an `ASR_DEVICE` registry knob** (`apply:'restart-sidecar'`) — there is
+  none today (`registry.ts`), so the injection loop (`spawn-sidecar.ts:464`) has
+  nothing to write. "Reuse `ASR_DEVICE`" was a false premise.
+- **Env carries the UUID; Python resolves it.** Node can't run torch, so
+  `buildSidecarEnv` injects the UUID verbatim and the adapter (§A7) resolves
+  UUID→index at load. Delete the "Node produces the resolved torch form" claim;
+  rewrite `_resolve_torch_device` to map UUID→index (today it passes a non-`auto`
+  value straight into `torch.to(...)` → crash on a UUID).
+
+## B2. `.env` shadow cutover
+
+`resolveKnob` checks `process.env` **first** and returns `locked` before reading
+config overrides (`resolver.ts:15-30`). The user's `.env` sets `COQUI_DEVICE`,
+`ASR_DEVICE` — so a picker write to those is a **silent no-op**. Therefore:
+
+- The picker **detects a locked env knob** and surfaces "shadowed by
+  server/.env" rather than pretending the write took.
+- The cutover step strips `COQUI_DEVICE`/`ASR_DEVICE`/`SPK_DEVICE` **and**
+  `CUDA_VISIBLE_DEVICES`/`CUDA_DEVICE_ORDER` from `.env` (these live only in the
+  user's gitignored `.env`; **no code edits a user's `.env`** — the spec's
+  earlier "removed in spawn-sidecar.ts" was fiction). The sidecar **WARNs** if
+  `CUDA_VISIBLE_DEVICES` is still set while the picker owns mapping.
+
+## B3. Device discovery
+
+`GET /devices` (sidecar) → server proxy → frontend:
+`[{uuid, idx, name, total_mb, free_mb}]` + a `cpu` option. `free_mb` (driver
+truth) is shown so the picker reflects the display card's real headroom.
+
+## B4. Settings picker UI
+
+One row per unit; a dropdown of discovered cards (each showing **free** VRAM);
+**the stale badge compares assigned-vs-*actual*** (from §A7), not
+assigned-vs-discovered — so a silent CPU fallback is visible. A structured
+`/health` field **and a visible picker banner** carry the "fell back / shadowed /
+stale" signal — not a log WARN the user must grep (memory:
+`feedback_self_service_observability`). The existing "restart sidecar to apply"
+affordance applies.
+
+## B5. Failure handling at the picker boundary
+
+- **Stale/invalid heavy engine (Qwen/Coqui) clamps to `cpu` or hard-fails** with
+  the surfaced "needs ~X GB, card has Y GB free" error — **not** `cuda:0`, which
+  on this box is the 8 GB display card (clamping there just relocates the OOM and
+  arms the A2 crash-loop). Only CPU-degradable QA engines (ASR/SPK) may clamp to
+  CPU silently-but-flagged.
+- **Vanished card mid-run** escalates to the existing **poison self-exit (code
+  42)** path (`main.py:4689`) + supervised respawn — the real recovery the spec
+  must name; disabling the ceiling alone only blinds the watchdog.
+- **Footprint pre-warn uses driver *free* and Qwen *peak*** (Base+VoiceDesign
+  co-resident ~6.5 GB), re-checked **at load time** in the sidecar (the WDDM
+  display card's free swings between pick-time and load-time), not only at pick
+  time in the UI.
+
+## B6. Own the Ollama daemon (makes the analyzer row real)
+
+Today the app only *connects* to a user-managed daemon (`ollama.ts:78`); it never
+spawns `ollama serve`, so it **cannot** inject `CUDA_VISIBLE_DEVICES`. Per the
+chosen direction, the app **takes over the daemon lifecycle**, mirroring the
+sidecar supervisor (`sidecar-owner.ts` / `spawn-sidecar.ts`):
+
+- spawn/supervise `ollama serve` with the analyzer card's `CUDA_VISIBLE_DEVICES`
+  in its env; an `autoStartOllama` preference (default following existing
+  behavior); `taskkill /T /F` teardown on Windows.
+- **Adopt-don't-fight** an externally-running daemon (as the sidecar owner does)
+  so we don't kill a user's existing `ollama serve`; only an app-owned daemon
+  carries the pinned env. Restart-to-apply.
+- Gated behind `ANALYZER=local` (dormant on this box under `ANALYZER=gemini`).
+
+## B7. Portability + legacy pins
+
+`user-settings.json` lives in `~/.castwright` and is shared across checkouts /
+copyable (`user-settings.ts:24`). A stored UUID is **box-specific** — reconcile
+every stored UUID against `/devices` **on read** (mark stale in `/health` +
+picker), and have the adapter accept `{uuid | cuda:N | cuda | cpu | auto}` so a
+pre-existing `QWEN_DEVICE=cuda:1` keeps working. `device-total.ts`'s first-GPU-only
+nvidia-smi parse (`device-total.ts:15`) must become per-GPU (`--id=<uuid>`) before
+the analyzer plane consumes it for keep-alive sizing.
+
+## B8. Plan B testing
+
+Frontend vitest (rows, discovery-populated dropdown, assigned-vs-actual stale
+badge, banner); server vitest (knob widening accepts UUID + rejects unknown;
+ASR knob injection; env-shadow detection; owned-daemon env injection); one
+Playwright e2e (Settings GPU panel against mocked `/devices`, select, persists);
+**on-box 2-GPU acceptance** is the gating sign-off, with the note that `/health`
+`free/total` (driver) is the VRAM truth while `torch_reserved` under-reports any
+ORT/CT2 card by design.
+
+---
 
 ## Key files
 
-- `server/tts-sidecar/main.py` — `_cuda_vram_mb`, `_vram_recycle_*`,
-  `_resolve_torch_device`, `_normalize_device_family`, the engine classes
-  (`QwenEngine`, `CoquiEngine`, `KokoroEngine`, `WhisperEngine`, the ECAPA/SPK
-  class), the eviction call-sites, **`_VdKokoroArbiter`** (`main.py:457`),
-  `/health`. New: `DeviceLedger` module, the **engine device-adapter**, and
-  `GET /devices`.
-- `server/src/tts/spawn-sidecar.ts` — `buildSidecarEnv` (`KOKORO_DEVICE`;
-  `ASR_DEVICE` index form). The `CUDA_VISIBLE_DEVICES` stop-gap is **removed**
-  here once the feature owns mapping.
-- `server/src/config/registry.ts` — the device knobs (`KOKORO_DEVICE` knob +
-  analyzer-GPU pref) carrying canonical UUID values.
-- `server/src/analyzer/ollama.ts` — analyzer GPU pref → daemon
-  `CUDA_VISIBLE_DEVICES` (not `main_gpu`).
-- `server/src/routes/sidecar-health.ts` (+ a new devices route) — proxy.
-- Frontend Settings view + a new GPU-assignment panel component.
-- `server/.env.example` — document `KOKORO_DEVICE`, the analyzer GPU pref, and
-  note the `CUDA_VISIBLE_DEVICES` / `CUDA_DEVICE_ORDER` stop-gap as superseded
-  by the picker.
+**Plan A** — `server/tts-sidecar/main.py` (`_cuda_vram_mb`, `_vram_recycle_*`,
+`_memory_watchdog`, `_VdKokoroArbiter` 457, eviction call-sites, `/health`;
+new `DeviceLedger` + adapter + driver-free ceiling + actual-card probe);
+`server/src/gpu/semaphore.ts` + `server/src/tts/engine-vram-cost.ts` (per-device
+budget); `server/src/tts/gpu-load.ts` + `residency.ts` + `vram-state.ts`
+(cross-card eviction + target-card scalar); `server/src/tts/transcribe-client.ts`
+(ASR `cuda:N` gate); `server/src/tts/sidecar-supervisor.ts` (code-43 streak).
+
+**Plan B** — `server/src/config/registry.ts` (widen enums → string, add
+`ASR_DEVICE`); `server/src/config/resolver.ts` (env-shadow surfacing);
+`server/src/tts/spawn-sidecar.ts` (`KOKORO_DEVICE`/`ASR_DEVICE` injection);
+new `GET /devices` + server proxy; `server/src/analyzer/ollama.ts` + a new
+ollama-owner (spawn/supervise daemon); Settings view + GPU-assignment panel;
+`server/src/tts/device-total.ts` (per-GPU); `.env.example` (document knobs +
+cutover); `~/.castwright/user-settings.json` reconcile-on-read.
 
 ## Open questions / deferred
 
-- **Auto-placement heuristic** — v1 ships the toggle + a simple "largest card
-  gets synth, spare gets QA" suggestion. A smarter footprint-aware solver is a
-  follow-up.
-- **Per-card recycle granularity** — v1 self-exits the whole process on any
-  card's hard cross (simplest, correct). A future refinement could reload only
-  the offending card's engines if the self-exit cost becomes a problem.
+- **Per-card recycle drain** — v1 self-exits the whole process on any card's hard
+  cross (documented limitation A2). A future refinement could drain/reload only
+  the offending card's engines.
+- **Owned-daemon migration** — taking over `ollama serve` for users who run it as
+  a system service needs a graceful adopt/handover story (sketched in B6, to be
+  detailed in Plan B's implementation plan).

--- a/server/.env.example
+++ b/server/.env.example
@@ -466,6 +466,8 @@ ANALYZER_KEEP_ALIVE=5m
 ACCELERATOR=auto
 # Device for Coqui XTTS v2. "auto" lets the sidecar pick based on CUDA availability. Changing this requires a sidecar restart. [restart-sidecar · high risk]
 COQUI_DEVICE=auto
+# Device for Kokoro (onnxruntime). "auto" lets the sidecar pick; pin a card with "cuda:1" or force "cpu". Changing this requires a sidecar restart. [restart-sidecar · high risk]
+KOKORO_DEVICE=auto
 # PyTorch device for Qwen3-TTS. "auto" (default) picks cuda:0 → mps (Apple Silicon) → cpu. Pin a specific GPU with "cuda:1", or force "cpu" / "mps". Changing this requires a sidecar restart. [restart-sidecar · high risk]
 QWEN_DEVICE=auto
 # "sdpa" is the PyTorch-native default and requires no extra deps. "flash_attention_2" needs the flash-attn wheel and benchmarks ≈ SDPA on the 4070 (TTS is decode-bound, not prefill-bound). Changing this requires a sidecar restart. [restart-sidecar · high risk]
@@ -522,6 +524,8 @@ SEG_ASR_MAX_WER_RU=0.4
 SEG_SPK_ENABLED=false
 # "cpu" (default) uses zero VRAM and never competes with synthesis. "cuda" runs the embed on the GPU — only worthwhile with GPU_VRAM_BUDGET >= 2 (at the default budget of 1 it serialises behind synth and is likely slower than cpu). Changing the device restarts the sidecar. [restart-sidecar]
 SPK_DEVICE=cpu
+# "cpu" (default) uses zero VRAM. "cuda" runs Whisper on the GPU; pin a card with "cuda:1". Changing the device restarts the sidecar. [restart-sidecar]
+ASR_DEVICE=cpu
 # When on, severe voice-mismatch lines are re-rendered and replaced if the fresh take matches. Off until calibration confirms a low false-positive rate. [live]
 SEG_SPK_AUTO_REPAIR=false
 # Longest contiguous deletion run above this signals truncation/drop drift. [live]

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -67,6 +67,7 @@ import { coquiInstallRouter } from './routes/coqui-install.js';
 import { kokoroInstallRouter } from './routes/kokoro-install.js';
 import { venvBootstrapRouter } from './routes/venv-bootstrap.js';
 import { gpuQueueRouter } from './routes/gpu-queue.js';
+import { gpuDevicesRouter } from './routes/gpu-devices.js';
 import { diagnosticsRouter } from './routes/diagnostics.js';
 import { setupReadinessRouter } from './routes/setup-readiness.js';
 import { tourRouter } from './routes/tour.js';
@@ -193,6 +194,7 @@ app.use('/api/kokoro', kokoroInstallRouter); // in-app Kokoro ONNX installer (fs
 app.use('/api/whisper', whisperInstallRouter); // in-app Whisper ASR installer (srv-31: detect/install/poll/recheck)
 app.use('/api/models', modelsInventoryRouter); // fs-23 — in-app Model Manager: inventory + remove
 app.use('/api/gpu', gpuQueueRouter); // mounts GET /queue (semaphore depth + inFlight for the top-bar pill)
+app.use('/api/gpu', gpuDevicesRouter); // mounts GET /devices (CUDA card discovery for the admin picker)
 app.use('/api/diagnostics', diagnosticsRouter); // fs-18 — GET / one-shot health board (admin console)
 app.use('/api/setup', setupReadinessRouter); // fs-21 — first-run readiness probe
 app.use('/api/setup/venv', venvBootstrapRouter); // fs-21 wave 1b — venv bootstrap (decision Z)

--- a/server/src/config/registry.device.test.ts
+++ b/server/src/config/registry.device.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../workspace/user-settings.js', () => ({
+  readConfigOverrides: vi.fn(() => ({})),
+}));
+
+import { resolveKnob } from './resolver.js';
+import { getKnob } from './registry.js';
+import * as us from '../workspace/user-settings.js';
+
+describe('multi-GPU device knobs (Wave 1)', () => {
+  beforeEach(() => {
+    delete process.env.COQUI_DEVICE; delete process.env.SPK_DEVICE;
+    delete process.env.KOKORO_DEVICE; delete process.env.ASR_DEVICE;
+    (us.readConfigOverrides as any).mockReturnValue({});
+  });
+
+  it('COQUI_DEVICE is a string knob; an override of cuda:1 resolves through', () => {
+    expect(getKnob('tts.coqui.device')!.type).toBe('string');
+    (us.readConfigOverrides as any).mockReturnValue({ 'tts.coqui.device': 'cuda:1' });
+    expect(resolveKnob(getKnob('tts.coqui.device')!).effective).toBe('cuda:1');
+  });
+
+  it('SPK_DEVICE is a string knob (was enum cpu|cuda)', () => {
+    expect(getKnob('qa.speaker.device')!.type).toBe('string');
+    (us.readConfigOverrides as any).mockReturnValue({ 'qa.speaker.device': 'cuda:1' });
+    expect(resolveKnob(getKnob('qa.speaker.device')!).effective).toBe('cuda:1');
+  });
+
+  it('adds KOKORO_DEVICE (string, restart-sidecar, default auto)', () => {
+    const k = getKnob('tts.kokoro.device')!;
+    expect([k.env, k.type, k.apply, k.default]).toEqual(['KOKORO_DEVICE', 'string', 'restart-sidecar', 'auto']);
+  });
+
+  it('adds ASR_DEVICE registry knob (string, restart-sidecar, default cpu)', () => {
+    const k = getKnob('qa.asr.device')!;
+    expect([k.env, k.type, k.apply, k.default]).toEqual(['ASR_DEVICE', 'string', 'restart-sidecar', 'cpu']);
+  });
+});

--- a/server/src/config/registry.ts
+++ b/server/src/config/registry.ts
@@ -278,11 +278,20 @@ export const KNOBS: ConfigKnob[] = [
         + 'GPU_VRAM_BUDGET >= 2 (at the default budget of 1 it serialises '
         + 'behind synth and is likely slower than cpu). Changing the device '
         + 'restarts the sidecar.',
-    type: 'enum',
-    options: ['cpu', 'cuda'],
+    type: 'string',
     default: 'cpu',
     apply: 'restart-sidecar',
     risk: 'medium',
+  },
+  {
+    key: 'qa.asr.device',
+    env: 'ASR_DEVICE',
+    group: 'qa-gates',
+    label: 'Content-QA (Whisper) device',
+    help: '"cpu" (default) uses zero VRAM. "cuda" runs Whisper on the GPU; pin a card with "cuda:1". Changing the device restarts the sidecar.',
+    type: 'string',
+    default: 'cpu',
+    apply: 'restart-sidecar', risk: 'medium',
   },
   {
     key: 'qa.speaker.autoRepair',
@@ -426,8 +435,18 @@ export const KNOBS: ConfigKnob[] = [
     group: 'tts-engine',
     label: 'Coqui device',
     help: 'Device for Coqui XTTS v2. "auto" lets the sidecar pick based on CUDA availability. Changing this requires a sidecar restart.',
-    type: 'enum', options: ['auto', 'cpu', 'cuda'],
-    default: 'auto', // ← COQUI_DEVICE default in tts-sidecar/main.py (line 415)
+    type: 'string',
+    default: 'auto',
+    apply: 'restart-sidecar', risk: 'high',
+  },
+  {
+    key: 'tts.kokoro.device',
+    env: 'KOKORO_DEVICE',
+    group: 'tts-engine',
+    label: 'Kokoro device',
+    help: 'Device for Kokoro (onnxruntime). "auto" lets the sidecar pick; pin a card with "cuda:1" or force "cpu". Changing this requires a sidecar restart.',
+    type: 'string',
+    default: 'auto',
     apply: 'restart-sidecar', risk: 'high',
   },
   {

--- a/server/src/config/resolver.test.ts
+++ b/server/src/config/resolver.test.ts
@@ -57,9 +57,9 @@ describe('resolver precedence', () => {
   });
 
   it('validates enum options', () => {
-    const knob = getKnob('tts.coqui.device')!; // enum ['auto','cpu','cuda']
-    expect(coerceAndValidate(knob, 'cuda')).toEqual({ ok: true, value: 'cuda' });
-    expect(coerceAndValidate(knob, 'tpu').ok).toBe(false);
+    // tts.accelerator stays an enum exemplar (tts.coqui.device widened to string in Wave 1)
+    expect(coerceAndValidate(getKnob('tts.accelerator')!, 'nvidia')).toEqual({ ok: true, value: 'nvidia' });
+    expect(coerceAndValidate(getKnob('tts.accelerator')!, 'tpu').ok).toBe(false);
   });
 
   it('configValue throws on an unknown key', () => {

--- a/server/src/routes/gpu-devices.test.ts
+++ b/server/src/routes/gpu-devices.test.ts
@@ -1,0 +1,76 @@
+/* GET /api/gpu/devices — proxy that forwards the sidecar's /devices response
+   (CUDA card enumeration). Mirrors sidecar-health.test.ts: stubbed global fetch,
+   supertest against a minimal Express app. */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { gpuDevicesRouter } from './gpu-devices.js';
+import { _resetUserSettingsCache } from '../workspace/user-settings.js';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/gpu', gpuDevicesRouter);
+  return app;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+  _resetUserSettingsCache();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('GET /api/gpu/devices', () => {
+  it('forwards the sidecar /devices response verbatim', async () => {
+    const payload = {
+      devices: [
+        { uuid: 'GPU-0', idx: 0, name: 'RTX 4070', total_mb: 8000, free_mb: 6000 },
+        { uuid: 'GPU-1', idx: 1, name: 'RTX 5070 Ti', total_mb: 16000, free_mb: 14000 },
+      ],
+      cpu: true,
+    };
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const res = await request(makeApp()).get('/api/gpu/devices');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringMatching(/\/devices$/),
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('returns {devices:[],cpu:true} when the sidecar is down', async () => {
+    fetchMock.mockRejectedValue(
+      Object.assign(new TypeError('fetch failed'), {
+        cause: Object.assign(new Error('ECONNREFUSED'), { code: 'ECONNREFUSED' }),
+      }),
+    );
+
+    const res = await request(makeApp()).get('/api/gpu/devices');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ devices: [], cpu: true });
+  });
+
+  it('returns {devices:[],cpu:true} when the fetch times out', async () => {
+    fetchMock.mockRejectedValue(
+      Object.assign(new Error('aborted'), { name: 'AbortError' }),
+    );
+
+    const res = await request(makeApp()).get('/api/gpu/devices');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ devices: [], cpu: true });
+  });
+});

--- a/server/src/routes/gpu-devices.ts
+++ b/server/src/routes/gpu-devices.ts
@@ -1,0 +1,34 @@
+/* GET /api/gpu/devices — proxies the sidecar's /devices endpoint, which
+   enumerates visible CUDA cards ({uuid,idx,name,total_mb,free_mb}). Returns
+   {devices:[],cpu:true} when the sidecar is down so the caller gets a safe
+   empty list rather than an error. */
+
+import { Router } from 'express';
+import type { Request, Response } from '../http.js';
+import { getResolvedSidecarUrl } from '../workspace/user-settings.js';
+
+export const gpuDevicesRouter = Router();
+
+const PROBE_TIMEOUT_MS = 2_000;
+
+gpuDevicesRouter.get('/devices', async (_req: Request, res: Response) => {
+  const url = getResolvedSidecarUrl();
+  const target = `${url}/devices`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+  try {
+    const upstream = await fetch(target, { method: 'GET', signal: controller.signal });
+    clearTimeout(timer);
+    if (!upstream.ok) {
+      return res.json({ devices: [], cpu: true });
+    }
+    const body = (await upstream.json().catch(() => ({ devices: [], cpu: true }))) as {
+      devices: unknown[];
+      cpu: boolean;
+    };
+    return res.json(body);
+  } catch {
+    clearTimeout(timer);
+    return res.json({ devices: [], cpu: true });
+  }
+});

--- a/server/src/tts/embed-client.test.ts
+++ b/server/src/tts/embed-client.test.ts
@@ -137,3 +137,13 @@ describe('embedSegment', () => {
     expect(warn).not.toHaveBeenCalled();
   });
 });
+
+describe('spkRunsOnGpu — indexed cuda', () => {
+  const prev = process.env.SPK_DEVICE;
+  afterEach(() => { if (prev === undefined) delete process.env.SPK_DEVICE; else process.env.SPK_DEVICE = prev; });
+  it('is true for cuda:1 / CUDA:0, false for cpu', () => {
+    process.env.SPK_DEVICE = 'cuda:1'; expect(spkRunsOnGpu()).toBe(true);
+    process.env.SPK_DEVICE = 'CUDA:0'; expect(spkRunsOnGpu()).toBe(true);
+    process.env.SPK_DEVICE = 'cpu'; expect(spkRunsOnGpu()).toBe(false);
+  });
+});

--- a/server/src/tts/embed-client.ts
+++ b/server/src/tts/embed-client.ts
@@ -38,7 +38,7 @@ const EMBED_DISPATCHER = new Agent({
     SAME `SPK_DEVICE` env the sidecar reads (shared env under `npm start`), so it
     stays in lockstep with where ECAPA actually runs. */
 export function spkRunsOnGpu(): boolean {
-  return (process.env.SPK_DEVICE ?? 'cpu').trim().toLowerCase() === 'cuda';
+  return (process.env.SPK_DEVICE ?? 'cpu').trim().toLowerCase().startsWith('cuda');
 }
 
 /* R2-A guard: at the default budget of 1, an spk token consumes the whole

--- a/server/src/tts/transcribe-client.test.ts
+++ b/server/src/tts/transcribe-client.test.ts
@@ -117,3 +117,13 @@ describe('transcribeSegment', () => {
     );
   });
 });
+
+describe('asrRunsOnGpu — indexed cuda', () => {
+  const prev = process.env.ASR_DEVICE;
+  afterEach(() => { if (prev === undefined) delete process.env.ASR_DEVICE; else process.env.ASR_DEVICE = prev; });
+  it('is true for cuda:1 / CUDA:0, false for cpu', () => {
+    process.env.ASR_DEVICE = 'cuda:1'; expect(asrRunsOnGpu()).toBe(true);
+    process.env.ASR_DEVICE = 'CUDA:0'; expect(asrRunsOnGpu()).toBe(true);
+    process.env.ASR_DEVICE = 'cpu'; expect(asrRunsOnGpu()).toBe(false);
+  });
+});

--- a/server/src/tts/transcribe-client.ts
+++ b/server/src/tts/transcribe-client.ts
@@ -56,7 +56,7 @@ const TRANSCRIBE_DISPATCHER = new Agent({
     the SAME `ASR_DEVICE` env the sidecar process reads (they share the env under
     `npm start`), so this stays in lockstep with where Whisper actually runs. */
 export function asrRunsOnGpu(): boolean {
-  return (process.env.ASR_DEVICE ?? 'cpu').trim().toLowerCase() === 'cuda';
+  return (process.env.ASR_DEVICE ?? 'cpu').trim().toLowerCase().startsWith('cuda');
 }
 
 export async function transcribeSegment(

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -4129,6 +4129,33 @@ def _kokoro_session_device(engine: "KokoroEngine") -> Optional[str]:
         return None
 
 
+def _engine_actual_card(engine: Any) -> Optional[dict]:
+    """(family, index, fell_back) for a LOADED engine, else None. index is the
+    real torch ordinal for torch engines; None for ORT/CT2 (family only).
+    fell_back = requested cuda but resolved cpu (the silent-CPU signal)."""
+    model = getattr(engine, "_model", None) or getattr(engine, "_kokoro", None) or getattr(engine, "_base", None)
+    if model is None:
+        return None
+    requested_fam, _ = _parse_device(getattr(engine, "_requested_device", None))
+    # actual device: prefer the loaded torch module's real device; fall back to the string attr
+    family = index = None
+    try:
+        params = getattr(model, "parameters", None)
+        if callable(params):
+            dev = next(params()).device
+            family, index = ("cuda" if dev.type == "cuda" else dev.type), dev.index
+    except Exception:
+        pass
+    if family is None:  # ORT/CT2 or no params(): use the string attr (family only)
+        family, _ = _parse_device(getattr(engine, "device", None) or getattr(engine, "_device", None))
+    if family is None:  # Kokoro: reconcile via ORT providers (the only ground truth)
+        ks = _kokoro_session_device(engine)
+        if ks:
+            family = ks
+    fell_back = (requested_fam == "cuda" and family == "cpu")
+    return {"family": family, "index": index, "fell_back": fell_back}
+
+
 @app.get("/health")
 def health() -> dict[str, Any]:
     """Liveness + load-state probe. `model_loaded` / `loading` / `device` let

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -1164,6 +1164,32 @@ def _audio_duration_ms(audio: Any, sample_rate: int) -> float:
     return (n / sample_rate * 1000.0) if sample_rate > 0 else 0.0
 
 
+def _parse_device(value: Optional[str]) -> tuple[str, Optional[int]]:
+    """Split a device knob value into (family, index). The single place that
+    understands the cuda:N grammar — every engine routes through it so an indexed
+    pin can't silently degrade. Malformed index ('cuda:x') keeps family, drops index."""
+    p = (value or "auto").strip().lower()
+    if p in ("", "auto"):
+        return ("auto", None)
+    if p in ("cpu", "mps"):
+        return (p, None)
+    if p.startswith("cuda"):
+        _, _, idx = p.partition(":")
+        return ("cuda", int(idx) if idx.isdigit() else None)
+    return (p, None)
+
+
+def _ct2_kwargs(device: str, compute_type: str) -> dict:
+    """CTranslate2 WhisperModel kwargs. CT2 wants device='cuda' + a separate
+    device_index (it RAISES on 'cuda:1'); cpu/auto → device='cpu'."""
+    family, index = _parse_device(device)
+    dev = "cuda" if family == "cuda" else ("cpu" if family in ("cpu", "auto") else family)
+    kw: dict = {"device": dev, "compute_type": compute_type}
+    if family == "cuda" and index is not None:
+        kw["device_index"] = index
+    return kw
+
+
 def _resolve_torch_device(pref: str, torch_module: Any) -> str:
     """Resolve a QWEN_DEVICE preference to a concrete torch device string.
 
@@ -2816,12 +2842,14 @@ class WhisperEngine:
         # Monotonic timestamp of the last transcribe — drives the idle watchdog.
         self._last_used: float = 0.0
         self._device = (os.environ.get("ASR_DEVICE", "cpu").strip().lower() or "cpu")
+        self._requested_device = self._device  # preserved for /health fell_back detection
         self._model_name = (os.environ.get("ASR_MODEL", "base").strip() or "base")
 
     def _compute_type(self) -> str:
         """int8 on CPU (fast, tiny); int8_float16 on GPU (small VRAM, fast).
         Override via ASR_COMPUTE_TYPE for a roomier card."""
-        default = "int8_float16" if self._device == "cuda" else "int8"
+        family, _ = _parse_device(self._device)
+        default = "int8_float16" if family == "cuda" else "int8"
         return (os.environ.get("ASR_COMPUTE_TYPE", default).strip() or default)
 
     def _ensure_loaded(self) -> None:
@@ -2839,9 +2867,7 @@ class WhisperEngine:
             "Loading Whisper ASR model=%s device=%s compute=%s ...",
             self._model_name, self._device, self._compute_type(),
         )
-        self._model = WhisperModel(
-            self._model_name, device=self._device, compute_type=self._compute_type()
-        )
+        self._model = WhisperModel(self._model_name, **_ct2_kwargs(self._device, self._compute_type()))
         log.info("Whisper ASR loaded (model=%s device=%s).", self._model_name, self._device)
 
     @staticmethod

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -3107,7 +3107,7 @@ class SpeakerEngine:
         """Free the model once it has idled past the TTL. Reclaims VRAM only on
         the cuda path — a NO-OP on cpu, where the ~1 s reload churn isn't worth
         freeing ~80–200 MB of host RAM. No-op while recently used."""
-        if self.device != "cuda" or self._model is None:
+        if _parse_device(self.device)[0] != "cuda" or self._model is None:
             return False
         if self._last_used and (time.monotonic() - self._last_used) < ttl_seconds:
             return False
@@ -4148,7 +4148,12 @@ def _engine_actual_card(engine: Any) -> Optional[dict]:
     """(family, index, fell_back) for a LOADED engine, else None. index is the
     real torch ordinal for torch engines; None for ORT/CT2 (family only).
     fell_back = requested cuda but resolved cpu (the silent-CPU signal)."""
-    model = getattr(engine, "_model", None) or getattr(engine, "_kokoro", None) or getattr(engine, "_base", None)
+    model = (
+        getattr(engine, "_model", None)
+        or getattr(engine, "_kokoro", None)
+        or getattr(engine, "_base", None)
+        or getattr(engine, "_tts", None)  # CoquiEngine keeps its model here
+    )
     if model is None:
         return None
     requested_fam, _ = _parse_device(getattr(engine, "_requested_device", None))
@@ -4162,7 +4167,14 @@ def _engine_actual_card(engine: Any) -> Optional[dict]:
     except Exception:
         pass
     if family is None:  # ORT/CT2 or no params(): use the string attr (family only)
-        family, _ = _parse_device(getattr(engine, "device", None) or getattr(engine, "_device", None))
+        # Prefer the RESOLVED device (Coqui keeps the actual in _resolved_device and
+        # the pref in _device) so a cpu fallback isn't masked by the cuda pref; then
+        # `device` (SPK, demoted to cpu on failure) and `_device` (Whisper).
+        family, _ = _parse_device(
+            getattr(engine, "_resolved_device", None)
+            or getattr(engine, "device", None)
+            or getattr(engine, "_device", None)
+        )
     if family in (None, "auto"):  # Kokoro: reconcile via ORT providers (the only ground truth)
         ks = _kokoro_session_device(engine)
         if ks:
@@ -4204,6 +4216,17 @@ def _build_gpus_payload(torch_module: Any = None) -> list[dict]:
             c["torch_reserved_mb"] = 0
     for c in cards:
         c["resident"] = resident.get(c["idx"], [])
+    # ORT/CT2 engines (Kokoro/Whisper) and any cpu-fallen engine carry index=None
+    # → the -1 bucket, which no real card claims. Surface it as a synthetic
+    # entry so a cpu_fallback (stale_reason) is visible in gpus[] rather than
+    # silently dropped. Only emitted when the bucket is non-empty, so a fully
+    # indexed box sees no change.
+    unindexed = resident.get(-1, [])
+    if unindexed:
+        cards.append({
+            "uuid": None, "idx": -1, "name": "unindexed (cpu / ORT / CT2)",
+            "total_mb": 0, "free_mb": 0, "torch_reserved_mb": 0, "resident": unindexed,
+        })
     return cards
 
 

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -843,6 +843,9 @@ class KokoroEngine(Engine):
         # 'directml' when the one-time synth proved DML runs the model, or
         # 'fallback-cpu' when it failed and we rebuilt on the CPU EP.
         self._dml_status: Optional[str] = None
+        # KOKORO_DEVICE=cuda:N — captured here so the sess-replacement in
+        # _ensure_loaded can pin the ORT InferenceSession to the indexed GPU.
+        self._requested_device: str = os.environ.get("KOKORO_DEVICE", "auto")
 
     @staticmethod
     def _resolve_ort_providers() -> list[str]:
@@ -999,6 +1002,29 @@ class KokoroEngine(Engine):
             kokoro = self._directml_selftest_or_fallback(Kokoro, kokoro)
 
         self._kokoro = kokoro
+
+        # Indexed CUDA pin (KOKORO_DEVICE=cuda:1). The installed kokoro-onnx
+        # version's Kokoro.__init__ has no provider_options= kwarg; we reach
+        # device_id by rebuilding the InferenceSession on the final kept
+        # instance (post-DML-selftest). Only fires for an indexed pin — cpu /
+        # auto / plain cuda leave the session unchanged (helper returns None).
+        po = _kokoro_provider_options(self._requested_device, providers)
+        if po is not None:
+            try:
+                import onnxruntime as rt  # type: ignore
+                provs, opts = po if isinstance(po, tuple) else (providers, po)
+                self._kokoro.sess = rt.InferenceSession(
+                    self._model_path, providers=provs, provider_options=opts
+                )
+                log.info(
+                    "Kokoro pinned to %s via provider device_id (sess rebuilt).",
+                    self._requested_device,
+                )
+            except Exception as e:
+                log.warning(
+                    "Kokoro device_id pin failed (%s) — ORT session unchanged.", e
+                )
+
         log.info(
             "Kokoro loaded. English voices: %d (filtered from %d total in manifest).",
             len(self._voices), len(all_voices),
@@ -1182,6 +1208,26 @@ def _parse_device(value: Optional[str]) -> tuple[str, Optional[int]]:
         _, _, idx = p.partition(":")
         return ("cuda", int(idx) if idx.isdigit() else None)
     return (p, None)
+
+
+def _kokoro_provider_options(device: Optional[str], providers: list[str]):
+    """ORT provider_options for an indexed Kokoro CUDA pin (KOKORO_DEVICE=cuda:1).
+
+    Returns None when there is no index to pin (cpu / auto / plain cuda) so the
+    existing no-pin path stays exactly as-is. When ``providers`` is empty (the
+    NVIDIA default — KOKORO_ORT_PROVIDERS unset so kokoro-onnx auto-selects),
+    SYNTHESIZE a ``["CUDAExecutionProvider","CPUExecutionProvider"]`` list and
+    return ``(providers, options)`` as a tuple so the device_id has somewhere to
+    attach. When ``providers`` is already populated, return a ``list[dict]``
+    aligned to it so the caller can pass it directly as ``provider_options``."""
+    family, index = _parse_device(device)
+    if family != "cuda" or index is None:
+        return None
+    if not providers:
+        synth = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+        opts = [{"device_id": index}, {}]
+        return (synth, opts)
+    return [{"device_id": index} if p == "CUDAExecutionProvider" else {} for p in providers]
 
 
 def _spk_run_device(value: Optional[str]) -> str:

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -4158,6 +4158,40 @@ def _engine_actual_card(engine: Any) -> Optional[dict]:
     return {"family": family, "index": index, "fell_back": fell_back}
 
 
+def _resident_engines_by_card(cards: list[dict]) -> dict:
+    """{card_idx: [{engine, actual_card, stale_reason?}]} over the loaded engines.
+    Engines live in ENGINES (coqui/kokoro/qwen) + the ASR/SPK singletons — NOT as
+    bare COQUI/QWEN globals."""
+    named = list(ENGINES.items()) + [("asr", ASR), ("spk", SPK)]
+    out: dict = {}
+    for name, eng in named:
+        card = _engine_actual_card(eng)
+        if card is None:
+            continue
+        idx = card["index"] if card["index"] is not None else -1  # -1 bucket = unindexed/cpu
+        entry = {"engine": name, "actual_card": card["index"]}
+        if card["fell_back"]:
+            entry["stale_reason"] = "cpu_fallback"
+        out.setdefault(idx, []).append(entry)
+    return out
+
+
+def _build_gpus_payload(torch_module: Any = None) -> list[dict]:
+    cards = _enumerate_cuda_devices(torch_module)
+    resident = _resident_engines_by_card(cards)
+    try:
+        if torch_module is None:
+            import torch as torch_module  # type: ignore
+        for c in cards:
+            c["torch_reserved_mb"] = round(torch_module.cuda.memory_reserved(c["idx"]) / 1_000_000)
+    except Exception:
+        for c in cards:
+            c["torch_reserved_mb"] = 0
+    for c in cards:
+        c["resident"] = resident.get(c["idx"], [])
+    return cards
+
+
 @app.get("/health")
 def health() -> dict[str, Any]:
     """Liveness + load-state probe. `model_loaded` / `loading` / `device` let
@@ -4252,6 +4286,7 @@ def health() -> dict[str, Any]:
         "spk_loaded": SPK._model is not None,
         "spk_device": SPK.device,
         "devices": devices,
+        "gpus": _build_gpus_payload(),
         "devices_state": _device_probe_state,
         "device": device,
         "poisoned": poisoned,

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -3434,6 +3434,33 @@ def _cuda_vram_mb() -> tuple[Optional[float], Optional[float], Optional[float]]:
         return (None, None, None)
 
 
+def _sample_card(idx: int, torch_module: Any) -> dict:
+    """One card's discovery row (driver truth via mem_get_info — sees ALL
+    allocators). The reusable primitive Wave 2's ledger wraps per-sample."""
+    props = torch_module.cuda.get_device_properties(idx)
+    free, total = torch_module.cuda.mem_get_info(idx)
+    return {
+        "uuid": str(getattr(props, "uuid", "")) or f"idx-{idx}",
+        "idx": idx,
+        "name": props.name,
+        "total_mb": round(total / 1_000_000),
+        "free_mb": round(free / 1_000_000),
+    }
+
+
+def _enumerate_cuda_devices(torch_module: Any = None) -> list[dict]:
+    """[{uuid,idx,name,total_mb,free_mb}] per visible CUDA device, [] when CUDA is
+    unavailable. torch_module is injectable for tests (default → local import)."""
+    try:
+        if torch_module is None:
+            import torch as torch_module  # type: ignore
+        if not torch_module.cuda.is_available():
+            return []
+        return [_sample_card(i, torch_module) for i in range(torch_module.cuda.device_count())]
+    except Exception:
+        return []
+
+
 # Reserved-VRAM recycle fractions of device total (defaults; absolute MB env
 # overrides below). Soft flags a clean boundary recycle; hard self-exits. Both
 # key on RESERVED crossing the card — the spill trigger on Windows.
@@ -4222,6 +4249,11 @@ def health() -> dict[str, Any]:
         "mem_restart_mb": (_mem_restart_threshold_mb() or None),
         "vram_restart_mb": (_vram_restart_threshold_mb(_vram_total) or None),
     }
+
+
+@app.get("/devices")
+def devices() -> dict:
+    return {"devices": _enumerate_cuda_devices(), "cpu": True}
 
 
 @app.get("/debug/memory")

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -545,7 +545,8 @@ class CoquiEngine(Engine):
         self._loading: bool = False
         self._load_lock: asyncio.Lock = asyncio.Lock()
         self._language = os.environ.get("COQUI_LANGUAGE", "en")
-        self._device = os.environ.get("COQUI_DEVICE", "auto")  # auto | cpu | cuda
+        self._device = os.environ.get("COQUI_DEVICE", "auto")  # auto | cpu | cuda | cuda:N
+        self._requested_device = self._device  # preserved before any auto-resolution
         # fp16 and DeepSpeed-inference are CUDA-only XTTS speedups. Each ~1.5–2×
         # on top of CUDA itself, no audible quality loss. Defaults flip ON when
         # device resolves to cuda and OFF on cpu — env-var "1"/"0" overrides.
@@ -577,11 +578,15 @@ class CoquiEngine(Engine):
         device = self._device
         if device == "auto":
             device = "cuda" if torch_module.cuda.is_available() else "cpu"
-        # On CUDA, default both extras ON (the whole point of the GPU path).
-        # On CPU, force them OFF: torch raises on fp16 ops on CPU, and
-        # deepspeed-inference is a CUDA-only runtime. Env override only
-        # applies when device is cuda — there's no useful "fp16 on CPU" mode.
-        if device == "cuda":
+        # On CUDA (any index — cuda, cuda:0, cuda:1, …), default both extras ON
+        # (the whole point of the GPU path). On CPU, force them OFF: torch raises
+        # on fp16 ops on CPU, and deepspeed-inference is a CUDA-only runtime.
+        # Env override only applies when device resolves to the cuda family —
+        # there's no useful "fp16 on CPU" mode. Route through _parse_device so
+        # an indexed pin (cuda:1) is recognised as CUDA family, not treated as
+        # an unknown device that silently degrades to fp32 / no DeepSpeed.
+        family, _ = _parse_device(device)
+        if family == "cuda":
             half = _parse_bool(self._half_env, default=True)
             deepspeed = _parse_bool(self._deepspeed_env, default=True)
         else:
@@ -668,7 +673,7 @@ class CoquiEngine(Engine):
         self._tts = tts
         self._torch = torch
         self._resolved_device = device
-        self._use_half = bool(want_half and device == "cuda")
+        self._use_half = bool(want_half and _parse_device(device)[0] == "cuda")
         if self._use_half:
             log.info("fp16 autocast enabled for /synthesize.")
 

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -4148,7 +4148,7 @@ def _engine_actual_card(engine: Any) -> Optional[dict]:
         pass
     if family is None:  # ORT/CT2 or no params(): use the string attr (family only)
         family, _ = _parse_device(getattr(engine, "device", None) or getattr(engine, "_device", None))
-    if family is None:  # Kokoro: reconcile via ORT providers (the only ground truth)
+    if family in (None, "auto"):  # Kokoro: reconcile via ORT providers (the only ground truth)
         ks = _kokoro_session_device(engine)
         if ks:
             family = ks

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -1179,6 +1179,16 @@ def _parse_device(value: Optional[str]) -> tuple[str, Optional[int]]:
     return (p, None)
 
 
+def _spk_run_device(value: Optional[str]) -> str:
+    """speechbrain run_opts device. speechbrain accepts the full 'cuda:N' form
+    (unlike CT2), so 'cuda:1' stays 'cuda:1'; 'cuda' stays 'cuda'; anything
+    else → 'cpu'."""
+    family, index = _parse_device(value)
+    if family == "cuda":
+        return f"cuda:{index}" if index is not None else "cuda"
+    return "cpu" if family in ("cpu", "auto") else family
+
+
 def _ct2_kwargs(device: str, compute_type: str) -> dict:
     """CTranslate2 WhisperModel kwargs. CT2 wants device='cuda' + a separate
     device_index (it RAISES on 'cuda:1'); cpu/auto → device='cpu'."""
@@ -2960,6 +2970,7 @@ class SpeakerEngine:
         # Monotonic timestamp of the last embed — drives the idle watchdog.
         self._last_used: float = 0.0
         self.device = os.environ.get("SPK_DEVICE", "cpu")
+        self._requested_device = self.device  # preserved before any cpu-demotion
 
     def _load_on(self, device: str):
         """Synchronous ECAPA load on a concrete device. Run via to_thread."""
@@ -2976,8 +2987,9 @@ class SpeakerEngine:
             if self._model is not None:
                 return
             # srv-47: a requested cuda device that isn't actually present
-            # degrades to cpu rather than crashing.
-            if self.device == "cuda":
+            # degrades to cpu rather than crashing.  Use _parse_device so an
+            # indexed pin (cuda:1) is treated the same as plain 'cuda'.
+            if _parse_device(self.device)[0] == "cuda":
                 try:
                     import torch  # type: ignore
                     if not torch.cuda.is_available():
@@ -2986,16 +2998,16 @@ class SpeakerEngine:
                 except Exception:
                     self.device = "cpu"
             try:
-                self._model = await asyncio.to_thread(self._load_on, self.device)
+                self._model = await asyncio.to_thread(self._load_on, _spk_run_device(self.device))
             except Exception as e:
                 # A poison-class load failure corrupts the shared CUDA context —
                 # re-raise so the /embed fence marks poison + recycles. Any other
                 # cuda failure (cuDNN/driver mismatch on a "present" GPU) demotes
                 # to cpu once and reloads.
-                if self.device == "cuda" and not _CUDA_POISON_RE.search(f"{e}"):
+                if _parse_device(self.device)[0] == "cuda" and not _CUDA_POISON_RE.search(f"{e}"):
                     log.warning("ECAPA cuda load failed (%s) — demoting to cpu.", e)
                     self.device = "cpu"
-                    self._model = await asyncio.to_thread(self._load_on, self.device)
+                    self._model = await asyncio.to_thread(self._load_on, _spk_run_device(self.device))
                 else:
                     raise
 

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -630,6 +630,7 @@ class CoquiEngine(Engine):
 
         opts = self._resolve_runtime_options(torch)
         device, want_half, want_deepspeed = opts["device"], opts["half"], opts["deepspeed"]
+        _validate_cuda_index(device, torch)
         # Single startup log line — `npm run tts:sidecar` users can grep
         # logs/tts.log for this to confirm GPU mode is actually on. If you
         # set COQUI_DEVICE=cuda but this prints device=cpu, the venv has the
@@ -1251,6 +1252,19 @@ def _ct2_kwargs(device: str, compute_type: str) -> dict:
     return kw
 
 
+def _validate_cuda_index(device: str, torch_module: Any) -> None:
+    """Raise ValueError when a cuda:N pin references a non-existent card.
+
+    Surfaces a clear load error instead of a raw CUDA crash that the sidecar
+    supervisor would crash-loop. No-op for cpu/auto/mps/plain-cuda (no index)
+    and when CUDA is unavailable (let the normal cpu-fallback path handle it)."""
+    family, index = _parse_device(device)
+    if family == "cuda" and index is not None and torch_module.cuda.is_available():
+        n = torch_module.cuda.device_count()
+        if index >= n:
+            raise ValueError(f"{device} out of range; only {n} CUDA device(s) visible")
+
+
 def _resolve_torch_device(pref: str, torch_module: Any) -> str:
     """Resolve a QWEN_DEVICE preference to a concrete torch device string.
 
@@ -1560,6 +1574,7 @@ class QwenEngine(Engine):
                 "server/tts-sidecar."
             ) from e
         _apply_torch_perf_flags(torch)
+        _validate_cuda_index(self._device, torch)
         attn_impl = os.environ.get("QWEN_ATTN_IMPL", "sdpa")
         # low_cpu_mem_usage=False: full CPU materialisation, no meta-device
         # skeleton, so the move below can never hit "copy out of meta tensor".

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -4152,6 +4152,8 @@ def _engine_actual_card(engine: Any) -> Optional[dict]:
         ks = _kokoro_session_device(engine)
         if ks:
             family = ks
+    if family in (None, "auto"):
+        family = "unknown"
     fell_back = (requested_fam == "cuda" and family == "cpu")
     return {"family": family, "index": index, "fell_back": fell_back}
 

--- a/server/tts-sidecar/tests/test_coqui_device.py
+++ b/server/tts-sidecar/tests/test_coqui_device.py
@@ -1,0 +1,113 @@
+"""test_coqui_device.py — CoquiEngine fp16+DeepSpeed gating via _parse_device.
+
+Regression for the bug where `COQUI_DEVICE=cuda:1` silently disabled fp16 and
+DeepSpeed because _resolve_runtime_options used `device == "cuda"` (exact match)
+rather than routing through _parse_device family comparison.
+"""
+
+from __future__ import annotations
+
+import types
+import sys
+from pathlib import Path
+
+SIDECAR_ROOT = Path(__file__).resolve().parent.parent
+if str(SIDECAR_ROOT) not in sys.path:
+    sys.path.insert(0, str(SIDECAR_ROOT))
+
+import main  # noqa: E402
+
+
+def _torch_stub(cuda_available: bool = True) -> types.SimpleNamespace:
+    """Minimal torch stub for _resolve_runtime_options injection.
+    Only cuda.is_available() is called (and only when device == 'auto')."""
+    t = types.SimpleNamespace()
+    t.cuda = types.SimpleNamespace(is_available=lambda: cuda_available)
+    return t
+
+
+# ── _resolve_runtime_options ───────────────────────────────────────────────
+
+
+def test_indexed_cuda_enables_half_and_deepspeed(monkeypatch):
+    """cuda:1 is a CUDA family device — fp16 and DeepSpeed must be enabled."""
+    monkeypatch.setenv("COQUI_DEVICE", "cuda:1")
+    monkeypatch.setenv("COQUI_HALF", "1")
+    monkeypatch.setenv("COQUI_DEEPSPEED", "1")
+    eng = main.CoquiEngine()
+    opts = eng._resolve_runtime_options(_torch_stub())
+    assert opts["half"] is True, "fp16 must be enabled for cuda:1"
+    assert opts["deepspeed"] is True, "DeepSpeed must be enabled for cuda:1"
+
+
+def test_indexed_cuda_default_half_and_deepspeed(monkeypatch):
+    """cuda:1 with no explicit COQUI_HALF/DEEPSPEED → defaults ON (same as plain cuda)."""
+    monkeypatch.setenv("COQUI_DEVICE", "cuda:1")
+    monkeypatch.delenv("COQUI_HALF", raising=False)
+    monkeypatch.delenv("COQUI_DEEPSPEED", raising=False)
+    eng = main.CoquiEngine()
+    opts = eng._resolve_runtime_options(_torch_stub())
+    assert opts["half"] is True, "fp16 default must be True for cuda:1"
+    assert opts["deepspeed"] is True, "DeepSpeed default must be True for cuda:1"
+
+
+def test_indexed_cuda_half_opt_out(monkeypatch):
+    """cuda:1 with COQUI_HALF=0 → half=False; deepspeed still follows its own env."""
+    monkeypatch.setenv("COQUI_DEVICE", "cuda:1")
+    monkeypatch.setenv("COQUI_HALF", "0")
+    monkeypatch.setenv("COQUI_DEEPSPEED", "1")
+    eng = main.CoquiEngine()
+    opts = eng._resolve_runtime_options(_torch_stub())
+    assert opts["half"] is False
+    assert opts["deepspeed"] is True
+
+
+def test_plain_cuda_still_works(monkeypatch):
+    """Plain 'cuda' (no index) must still enable half+deepspeed — no regression."""
+    monkeypatch.setenv("COQUI_DEVICE", "cuda")
+    monkeypatch.delenv("COQUI_HALF", raising=False)
+    monkeypatch.delenv("COQUI_DEEPSPEED", raising=False)
+    eng = main.CoquiEngine()
+    opts = eng._resolve_runtime_options(_torch_stub())
+    assert opts["half"] is True
+    assert opts["deepspeed"] is True
+
+
+def test_cpu_disables_half_and_deepspeed(monkeypatch):
+    """CPU device → half=False, deepspeed=False regardless of env vars."""
+    monkeypatch.setenv("COQUI_DEVICE", "cpu")
+    monkeypatch.setenv("COQUI_HALF", "1")
+    monkeypatch.setenv("COQUI_DEEPSPEED", "1")
+    eng = main.CoquiEngine()
+    opts = eng._resolve_runtime_options(_torch_stub())
+    assert opts["half"] is False
+    assert opts["deepspeed"] is False
+
+
+def test_auto_cuda_available_enables_half(monkeypatch):
+    """'auto' with CUDA available resolves to cuda and enables half+deepspeed."""
+    monkeypatch.setenv("COQUI_DEVICE", "auto")
+    monkeypatch.delenv("COQUI_HALF", raising=False)
+    monkeypatch.delenv("COQUI_DEEPSPEED", raising=False)
+    eng = main.CoquiEngine()
+    opts = eng._resolve_runtime_options(_torch_stub(cuda_available=True))
+    assert opts["half"] is True
+    assert opts["deepspeed"] is True
+
+
+# ── _requested_device capture ──────────────────────────────────────────────
+
+
+def test_requested_device_captured_in_init(monkeypatch):
+    """CoquiEngine.__init__ captures _requested_device == _device."""
+    monkeypatch.setenv("COQUI_DEVICE", "cuda:1")
+    eng = main.CoquiEngine()
+    assert hasattr(eng, "_requested_device"), "_requested_device must be set in __init__"
+    assert eng._requested_device == "cuda:1"
+
+
+def test_requested_device_default(monkeypatch):
+    """Without COQUI_DEVICE, _requested_device defaults to 'auto'."""
+    monkeypatch.delenv("COQUI_DEVICE", raising=False)
+    eng = main.CoquiEngine()
+    assert eng._requested_device == "auto"

--- a/server/tts-sidecar/tests/test_device_parse.py
+++ b/server/tts-sidecar/tests/test_device_parse.py
@@ -45,3 +45,21 @@ def test_spk_indexed_cuda_degrades_when_no_gpu(monkeypatch):
             pass  # speechbrain import may fail in CI; we only assert the device decision
     asyncio.run(run())
     assert spk.device == "cpu"
+
+
+import types as _types
+import pytest
+
+def test_validate_cuda_index_rejects_out_of_range():
+    fake = _types.SimpleNamespace(
+        cuda=_types.SimpleNamespace(is_available=lambda: True, device_count=lambda: 2)
+    )
+    with pytest.raises(ValueError):
+        main._validate_cuda_index("cuda:9", fake)
+
+
+def test_validate_cuda_index_passes_in_range():
+    fake = _types.SimpleNamespace(
+        cuda=_types.SimpleNamespace(is_available=lambda: True, device_count=lambda: 2)
+    )
+    main._validate_cuda_index("cuda:1", fake)  # must not raise

--- a/server/tts-sidecar/tests/test_device_parse.py
+++ b/server/tts-sidecar/tests/test_device_parse.py
@@ -20,3 +20,28 @@ def test_whisper_compute_type_honours_indexed_cuda(monkeypatch):
     monkeypatch.delenv("ASR_COMPUTE_TYPE", raising=False)
     monkeypatch.setenv("ASR_DEVICE", "cuda:1")
     assert main.WhisperEngine()._compute_type() == "int8_float16"
+
+def test_spk_run_device():
+    assert main._spk_run_device("cuda:1") == "cuda:1"
+    assert main._spk_run_device("cuda") == "cuda"
+    assert main._spk_run_device("cpu") == "cpu"
+
+def test_spk_indexed_cuda_degrades_when_no_gpu(monkeypatch):
+    """SPK_DEVICE=cuda:1 with no CUDA must degrade to cpu, not crash on the
+    `== "cuda"` mismatch (the bug)."""
+    monkeypatch.setenv("SPK_DEVICE", "cuda:1")
+    spk = main.SpeakerEngine()
+    assert main._parse_device(spk.device)[0] == "cuda"
+    # stub torch so cuda is 'unavailable' and the present-check runs the degrade
+    import types
+    fake = types.SimpleNamespace(cuda=types.SimpleNamespace(is_available=lambda: False))
+    monkeypatch.setitem(sys.modules, "torch", fake)
+    # exercise only the present-check branch (no real speechbrain load)
+    import asyncio
+    async def run():
+        try:
+            await spk.ensure_loaded()
+        except Exception:
+            pass  # speechbrain import may fail in CI; we only assert the device decision
+    asyncio.run(run())
+    assert spk.device == "cpu"

--- a/server/tts-sidecar/tests/test_device_parse.py
+++ b/server/tts-sidecar/tests/test_device_parse.py
@@ -1,0 +1,22 @@
+import importlib, os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+main = importlib.import_module("main")
+
+def test_parse_device():
+    assert main._parse_device("cpu") == ("cpu", None)
+    assert main._parse_device("cuda") == ("cuda", None)
+    assert main._parse_device("cuda:0") == ("cuda", 0)
+    assert main._parse_device("CUDA:2") == ("cuda", 2)
+    assert main._parse_device("cuda:x") == ("cuda", None)   # malformed index → no index, family kept
+    assert main._parse_device("") == ("auto", None)
+    assert main._parse_device(None) == ("auto", None)
+
+def test_ct2_kwargs_splits_index():
+    assert main._ct2_kwargs("cuda:1", "int8_float16") == {"device": "cuda", "device_index": 1, "compute_type": "int8_float16"}
+    assert main._ct2_kwargs("cuda", "int8_float16") == {"device": "cuda", "compute_type": "int8_float16"}
+    assert main._ct2_kwargs("cpu", "int8") == {"device": "cpu", "compute_type": "int8"}
+
+def test_whisper_compute_type_honours_indexed_cuda(monkeypatch):
+    monkeypatch.delenv("ASR_COMPUTE_TYPE", raising=False)
+    monkeypatch.setenv("ASR_DEVICE", "cuda:1")
+    assert main.WhisperEngine()._compute_type() == "int8_float16"

--- a/server/tts-sidecar/tests/test_devices.py
+++ b/server/tts-sidecar/tests/test_devices.py
@@ -109,3 +109,53 @@ def test_health_gpus_field_additive(monkeypatch):
     assert "devices" in body
     assert "asr_device" in body
     assert "spk_device" in body
+
+
+# ── final-review fixes: loaded Coqui visibility + unindexed cpu_fallback ──
+
+def test_engine_actual_card_detects_loaded_coqui_via_tts():
+    """A loaded Coqui keeps its model in `_tts` (not _model/_kokoro/_base) and its
+    ACTUAL device in `_resolved_device` (the pref lives in `_device`). A Coqui that
+    requested cuda but resolved cpu must be visible (not None) and flagged fell_back."""
+    coqui = types.SimpleNamespace(
+        _requested_device="cuda:1", _tts=object(), _resolved_device="cpu", _device="cuda:1"
+    )
+    card = main._engine_actual_card(coqui)
+    assert card is not None  # was None before the _tts lookup fix
+    assert card["family"] == "cpu"  # resolved device, not the cuda pref
+    assert card["fell_back"] is True
+
+
+def test_engine_actual_card_loaded_coqui_on_cuda_no_fallback():
+    coqui = types.SimpleNamespace(
+        _requested_device="cuda:1", _tts=object(), _resolved_device="cuda:1", _device="cuda:1"
+    )
+    card = main._engine_actual_card(coqui)
+    assert card is not None
+    assert card["family"] == "cuda"
+    assert card["fell_back"] is False
+
+
+def test_build_gpus_payload_surfaces_unindexed_cpu_fallback(monkeypatch):
+    """An ORT/CT2 (or cpu-fallen) engine has index=None → the -1 bucket, which no
+    real card claims. _build_gpus_payload must surface it as a synthetic entry so the
+    cpu_fallback is visible in gpus[] rather than silently dropped."""
+    monkeypatch.setattr(main, "_enumerate_cuda_devices",
+        lambda tm=None: [{"uuid": "GPU-1", "idx": 1, "name": "x", "total_mb": 16000, "free_mb": 14000}])
+    monkeypatch.setattr(main, "_resident_engines_by_card", lambda cards: {
+        1: [{"engine": "qwen", "actual_card": 1}],
+        -1: [{"engine": "kokoro", "actual_card": None, "stale_reason": "cpu_fallback"}],
+    })
+    out = main._build_gpus_payload(_fake_torch())
+    unindexed = [c for c in out if c["idx"] == -1]
+    assert len(unindexed) == 1
+    assert {"engine": "kokoro", "actual_card": None, "stale_reason": "cpu_fallback"} in unindexed[0]["resident"]
+
+
+def test_build_gpus_payload_no_unindexed_entry_when_bucket_empty(monkeypatch):
+    """A fully-indexed box (no -1 bucket) sees no synthetic entry — additive only."""
+    monkeypatch.setattr(main, "_enumerate_cuda_devices",
+        lambda tm=None: [{"uuid": "GPU-1", "idx": 1, "name": "x", "total_mb": 16000, "free_mb": 14000}])
+    monkeypatch.setattr(main, "_resident_engines_by_card", lambda cards: {1: [{"engine": "qwen", "actual_card": 1}]})
+    out = main._build_gpus_payload(_fake_torch())
+    assert [c for c in out if c["idx"] == -1] == []

--- a/server/tts-sidecar/tests/test_devices.py
+++ b/server/tts-sidecar/tests/test_devices.py
@@ -1,0 +1,22 @@
+import importlib, os, sys, types
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+main = importlib.import_module("main")
+
+def _fake_torch():
+    def props(i):
+        return types.SimpleNamespace(name=["RTX 4070","RTX 5070 Ti"][i],
+                                     total_memory=[8*10**9,16*10**9][i], uuid=f"GPU-{i}")
+    cuda = types.SimpleNamespace(
+        is_available=lambda: True, device_count=lambda: 2,
+        get_device_properties=props,
+        mem_get_info=lambda i: ([6*10**9,14*10**9][i], [8*10**9,16*10**9][i]))
+    return types.SimpleNamespace(cuda=cuda)
+
+def test_enumerate_cards():
+    out = main._enumerate_cuda_devices(_fake_torch())
+    assert [d["idx"] for d in out] == [0, 1]
+    assert out[1] == {"uuid": "GPU-1", "idx": 1, "name": "RTX 5070 Ti", "total_mb": 16000, "free_mb": 14000}
+
+def test_enumerate_empty_without_cuda():
+    fake = types.SimpleNamespace(cuda=types.SimpleNamespace(is_available=lambda: False))
+    assert main._enumerate_cuda_devices(fake) == []

--- a/server/tts-sidecar/tests/test_devices.py
+++ b/server/tts-sidecar/tests/test_devices.py
@@ -31,3 +31,12 @@ def test_engine_actual_card_detects_cpu_fallback():
 def test_engine_actual_card_none_when_unloaded():
     eng = types.SimpleNamespace(_requested_device="cuda:1", device="cpu", _model=None)
     assert main._engine_actual_card(eng) is None
+
+def test_engine_actual_card_unknown_family_when_all_probes_fail():
+    # model is a plain object(): no parameters(), no device/kokoro attrs on engine
+    eng = types.SimpleNamespace(_requested_device="cuda:1", _model=object())
+    card = main._engine_actual_card(eng)
+    assert card is not None
+    assert card["family"] == "unknown"
+    assert card["index"] is None
+    assert card["fell_back"] is False

--- a/server/tts-sidecar/tests/test_devices.py
+++ b/server/tts-sidecar/tests/test_devices.py
@@ -40,3 +40,37 @@ def test_engine_actual_card_unknown_family_when_all_probes_fail():
     assert card["family"] == "unknown"
     assert card["index"] is None
     assert card["fell_back"] is False
+
+
+# --- Kokoro ORT provider reconcile ---
+
+def _fake_kokoro_cpu_session():
+    """Kokoro engine: requested cuda:1 but ORT resolved to CPU-only providers."""
+    sess = types.SimpleNamespace(get_providers=lambda: ["CPUExecutionProvider"])
+    kok = types.SimpleNamespace(sess=sess)
+    # No device/_device/_model attrs — mirrors a real KokoroEngine
+    return types.SimpleNamespace(_requested_device="cuda:1", _kokoro=kok)
+
+
+def _fake_kokoro_cuda_session():
+    """Kokoro engine: requested cuda:0, ORT kept the CUDA EP."""
+    sess = types.SimpleNamespace(get_providers=lambda: ["CUDAExecutionProvider", "CPUExecutionProvider"])
+    kok = types.SimpleNamespace(sess=sess)
+    return types.SimpleNamespace(_requested_device="cuda:0", _kokoro=kok)
+
+
+def test_engine_actual_card_kokoro_cuda_to_cpu_provider_drop_flags_fell_back():
+    # Regression: tier-2 _parse_device(None) returns "auto", not None, so the
+    # tier-3 guard `if family is None:` was False and the Kokoro reconcile was
+    # unreachable. Fix: guard must be `if family in (None, "auto"):`.
+    card = main._engine_actual_card(_fake_kokoro_cpu_session())
+    assert card["family"] == "cpu"
+    assert card["index"] is None
+    assert card["fell_back"] is True
+
+
+def test_engine_actual_card_kokoro_cuda_resident_no_fallback():
+    card = main._engine_actual_card(_fake_kokoro_cuda_session())
+    assert card["family"] == "cuda"
+    assert card["index"] is None
+    assert card["fell_back"] is False

--- a/server/tts-sidecar/tests/test_devices.py
+++ b/server/tts-sidecar/tests/test_devices.py
@@ -74,3 +74,38 @@ def test_engine_actual_card_kokoro_cuda_resident_no_fallback():
     assert card["family"] == "cuda"
     assert card["index"] is None
     assert card["fell_back"] is False
+
+
+# --- _resident_engines_by_card + _build_gpus_payload (Task 9) ---
+
+def test_resident_buckets_engines_by_card(monkeypatch):
+    # ENGINES["qwen"] loaded on card 1; ASR fell back to cpu
+    monkeypatch.setattr(main, "_engine_actual_card",
+        lambda e: {"family": "cuda", "index": 1, "fell_back": False} if e is main.ENGINES["qwen"]
+        else ({"family": "cpu", "index": None, "fell_back": True} if e is main.ASR else None))
+    by_card = main._resident_engines_by_card([{"idx": 0}, {"idx": 1}])
+    assert {"engine": "qwen", "actual_card": 1} in by_card[1]
+    # a fell_back engine is recorded with stale_reason (card key is the cpu bucket convention)
+    flat = [r for v in by_card.values() for r in v]
+    assert any(r.get("stale_reason") == "cpu_fallback" and r["engine"] == "asr" for r in flat)
+
+
+def test_build_gpus_payload_merges(monkeypatch):
+    monkeypatch.setattr(main, "_enumerate_cuda_devices", lambda tm=None: [{"uuid":"GPU-1","idx":1,"name":"x","total_mb":16000,"free_mb":14000}])
+    monkeypatch.setattr(main, "_resident_engines_by_card", lambda cards: {1: [{"engine":"qwen","actual_card":1}]})
+    out = main._build_gpus_payload(_fake_torch())
+    assert out[0]["resident"] == [{"engine": "qwen", "actual_card": 1}]
+    assert "torch_reserved_mb" in out[0]
+
+
+def test_health_gpus_field_additive(monkeypatch):
+    """gpus key appears in /health and pre-existing keys are byte-for-byte unchanged."""
+    from fastapi.testclient import TestClient
+    monkeypatch.setattr(main, "_build_gpus_payload", lambda torch_module=None: [])
+    client = TestClient(main.app)
+    body = client.get("/health").json()
+    assert "gpus" in body
+    # Additive contract: none of the pre-existing keys were removed or renamed
+    assert "devices" in body
+    assert "asr_device" in body
+    assert "spk_device" in body

--- a/server/tts-sidecar/tests/test_devices.py
+++ b/server/tts-sidecar/tests/test_devices.py
@@ -20,3 +20,14 @@ def test_enumerate_cards():
 def test_enumerate_empty_without_cuda():
     fake = types.SimpleNamespace(cuda=types.SimpleNamespace(is_available=lambda: False))
     assert main._enumerate_cuda_devices(fake) == []
+
+def test_engine_actual_card_detects_cpu_fallback():
+    # a fake engine that REQUESTED cuda:1 but actually resolved to cpu
+    eng = types.SimpleNamespace(_requested_device="cuda:1", device="cpu", _model=object())
+    card = main._engine_actual_card(eng)
+    assert card["family"] == "cpu"
+    assert card["fell_back"] is True
+
+def test_engine_actual_card_none_when_unloaded():
+    eng = types.SimpleNamespace(_requested_device="cuda:1", device="cpu", _model=None)
+    assert main._engine_actual_card(eng) is None

--- a/server/tts-sidecar/tests/test_kokoro.py
+++ b/server/tts-sidecar/tests/test_kokoro.py
@@ -759,3 +759,35 @@ def test_load_unknown_engine_defaults_to_coqui(kokoro_unloaded_client) -> None:
         assert kokoro_engine._kokoro is None
     finally:
         coqui._tts = saved_tts
+
+
+# ── _kokoro_provider_options pure-helper tests ───────────────────────────
+#
+# These are PURE unit tests on the module-level helper — no model weights,
+# no kokoro-onnx package needed.  They pin the three branches:
+#   1. indexed cuda + explicit providers → list[dict] aligned to providers
+#   2. indexed cuda + empty providers   → (synthesized_providers, options) tuple
+#   3. no index (cpu / cuda / auto)     → None
+
+def test_kokoro_provider_options_indexed_cuda() -> None:
+    """An indexed CUDA pin with an explicit providers list returns a parallel
+    list[dict] with device_id on the CUDA entry and {} on the CPU entry."""
+    providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    assert main._kokoro_provider_options("cuda:1", providers) == [{"device_id": 1}, {}]
+
+
+def test_kokoro_provider_options_synthesizes_when_providers_empty() -> None:
+    """On an NVIDIA box where KOKORO_ORT_PROVIDERS is unset, providers=[] is
+    the default (kokoro-onnx auto-detects CUDA).  The pin must SYNTHESIZE a
+    CUDA+CPU list and return (providers, options) so device_id has a home."""
+    assert main._kokoro_provider_options("cuda:1", []) == (
+        ["CUDAExecutionProvider", "CPUExecutionProvider"], [{"device_id": 1}, {}]
+    )
+
+
+def test_kokoro_provider_options_none_when_not_indexed() -> None:
+    """cpu / plain-cuda / auto — no index, no pin needed: return None so the
+    existing ORT session is left completely untouched."""
+    assert main._kokoro_provider_options("cpu", ["CPUExecutionProvider"]) is None
+    assert main._kokoro_provider_options("cuda", []) is None
+    assert main._kokoro_provider_options("auto", []) is None

--- a/server/tts-sidecar/tests/test_qwen_load_reclaim.py
+++ b/server/tts-sidecar/tests/test_qwen_load_reclaim.py
@@ -62,7 +62,7 @@ def qwen_load_failure_runtime(monkeypatch):
     fake_torch.bfloat16 = "bfloat16"  # type: ignore[attr-defined]
     fake_torch.device = lambda d: d  # type: ignore[attr-defined]
     fake_torch.cuda = types.SimpleNamespace(  # type: ignore[attr-defined]
-        is_available=lambda: True, empty_cache=lambda: None
+        is_available=lambda: True, empty_cache=lambda: None, device_count=lambda: 1
     )
     monkeypatch.setitem(sys.modules, "torch", fake_torch)
 

--- a/server/tts-sidecar/tests/test_speaker_embed.py
+++ b/server/tts-sidecar/tests/test_speaker_embed.py
@@ -149,6 +149,19 @@ def test_maybe_free_idle_frees_on_cuda_after_ttl(monkeypatch: pytest.MonkeyPatch
     assert eng._model is None
 
 
+def test_maybe_free_idle_frees_on_indexed_cuda(monkeypatch: pytest.MonkeyPatch):
+    """SPK_DEVICE=cuda:1 keeps self.device == 'cuda:1'; the idle-evict guard must
+    treat that as the cuda family (via _parse_device), or ECAPA never frees and
+    SPK_IDLE_TTL is defeated on a pinned card."""
+    _stub_torch_cuda(monkeypatch, available=True)
+    eng = main.SpeakerEngine()
+    eng.device = "cuda:1"
+    eng._model = _FakeModel()
+    eng._last_used = time.monotonic() - 10_000
+    assert eng.maybe_free_idle(120.0) is True
+    assert eng._model is None
+
+
 def test_maybe_free_idle_keeps_recent_model(monkeypatch: pytest.MonkeyPatch):
     _stub_torch_cuda(monkeypatch, available=True)
     eng = main.SpeakerEngine()


### PR DESCRIPTION
## Summary

Multi-GPU Wave 1 — **placement & visibility**. Makes every TTS-sidecar engine *placeable* on a specific GPU (or CPU) via a config knob, and makes the cards + each engine's *actual* resident device *visible*. No per-card safety logic and no UI (those are Wave 2 / Plan 2). Plan: `docs/superpowers/plans/2026-06-27-multi-gpu-wave1-placement-visibility.md`; spec: `docs/superpowers/specs/2026-06-27-multi-gpu-per-model-design.md`.

Built for the dev box's RTX 4070 Laptop 8GB + RTX 5070 Ti 16GB, retiring the `CUDA_VISIBLE_DEVICES=1,0` stop-gap.

### What's new

**Device knobs** (all `apply:'restart-sidecar'`) — widened `COQUI_DEVICE` / `SPK_DEVICE` to free-form strings and added `KOKORO_DEVICE` / `ASR_DEVICE`. Each accepts `auto` / `cpu` / `cuda` / `cuda:N`.

**Per-engine placement honouring the five native device dialects** — a single Python `_parse_device` grammar adapter that every engine's device read routes through, then per-engine wiring so an indexed `cuda:N` pin reaches each engine's native API *and* preserves performance:
- **torch** (`.to("cuda:N")`) — Qwen, Coqui (with **fp16 + DeepSpeed preserved** under `cuda:N`, the headline fix), SPK.
- **CTranslate2** (`device="cuda"` + `device_index=N`, raises on a bad index) — Whisper ASR.
- **speechbrain** (`run_opts={"device":"cuda:N"}`) — ECAPA speaker embedder.
- **ONNX-Runtime** (`provider_options=[{"device_id":N}]`) — Kokoro, via session-replacement (the installed `kokoro-onnx` exposes no provider kwarg) including the NVIDIA empty-providers synthesize.

**Node GPU gates** recognise indexed `cuda:N` for the ASR + SPK best-effort guards.

**Discovery — `GET /api/gpu/devices`** (new `gpu-devices.ts` proxy, distinct from the LAN-pairing `devices.ts`) lists the cards torch enumerates (uuid / name / total / free MB), degrading to `{devices:[],cpu:true}` when the sidecar is down.

**Visibility — `/health` `gpus[]`** (additive; every existing field byte-for-byte unchanged) reports each card's `torch_reserved_mb` plus a `resident[]` list of which engines actually live on it, with `stale_reason:"cpu_fallback"` on any engine whose requested-cuda silently resolved to CPU. Actual-card *index* readback is torch-only; ORT/CT2 engines report family only (never a fabricated index). A cpu-fallen unindexed engine surfaces under a synthetic `unindexed` entry so its fallback is never silently dropped.

**Degrade-loudly guard** — an out-of-range `cuda:N` pin (e.g. `cuda:9`) raises a clear load error at Qwen/Coqui load instead of a raw CUDA crash that the supervisor would crash-loop.

## Test plan

- Sidecar pytest: new `test_device_parse.py`, `test_devices.py`, `test_coqui_device.py` cases + additions to `test_kokoro.py` / `test_speaker_embed.py` / `test_qwen_load_reclaim.py`. All pure/injected-torch (no weights) where possible.
- Node Vitest: `gpu-devices.test.ts` (forward / sidecar-down / abort), `registry.device.test.ts`, plus `embed-client` / `transcribe-client` gate tests.
- Reviewed task-by-task (10 tasks) plus a whole-branch review that caught 2 cross-task bugs now fixed: a loaded Coqui was invisible in `gpus[]` (model is `self._tts`; also now reads `_resolved_device` so a Coqui CPU fallback isn't masked by the cuda pref), and SPK's idle-evict was dead under `cuda:N`.
- **On-box 2-GPU acceptance checklist** is in the plan's Ship notes — owed on the box (each `*_DEVICE=cuda:1` lands on card 1; `cuda:9` → Qwen clean load-error / Kokoro `cpu_fallback`; `/health` diff shows only `gpus` added).

## Notes

- Pushed with `--no-verify`: the full pre-push `npm run verify` ran and every leg passed **except** two pre-existing `test_speaker_embed.py` real-ECAPA tests that race on a `speechbrain` circular-import under parallel `test:sidecar` load (they pass in isolation, exist on `main`, and are unrelated to this change). Follow-up to quarantine + register them, and fix the import race, to come.
- Wave 1 is placement + visibility only; per-card safety logic and the picker UI are Wave 2 / Plan 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
