### PR TITLE
docs(docs): manuscript analysis pill + Generate-gate spec & plan

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -299,6 +299,12 @@ _Full detail + acceptance:_ [#644](https://github.com/dudarenok-maker/AudioBook-
 - _Benefit (user):_ an intentional "no emotion here" survives a later Detect-emotions run.
 _Full detail + acceptance:_ [#593](https://github.com/dudarenok-maker/AudioBook-Generator/issues/593).
 
+#### `fe-44` — App-wide user-facing "TTS" → "Voice engines" copy rename ([#1182](https://github.com/dudarenok-maker/Castwright/issues/1182))
+
+- _What:_ Rename the user-facing term "TTS" → "Voice engines" across UI copy (eviction banners "TTS unloaded to free VRAM", admin "local TTS / analyzer / ASR", etc.) for terminology consistency with the brand voice language. Copy-only — engine proper nouns (Coqui XTTS, Qwen3-TTS, Kokoro) and code identifiers (`ttsLifecycle`, `TTS_MODEL_OPTIONS`, the `status-popover-tts` testid) stay as-is. The manuscript-analysis-pill feature renamed only the in-scope Status-popover label; this is the broad follow-up.
+- _Benefit (user / brand):_ jargon-free terminology — listeners see "Voice engines", not the engineering acronym, matching the rest of the Castwright voice language. Low-cost copy polish.
+_Full detail + acceptance:_ [#1182](https://github.com/dudarenok-maker/Castwright/issues/1182).
+
 ### Ingest & languages
 
 #### `srv-46` — OCR ingest for scanned / image-only PDFs ([#977](https://github.com/dudarenok-maker/Castwright/issues/977))

--- a/docs/superpowers/plans/2026-06-30-manuscript-analysis-pill-gate.md
+++ b/docs/superpowers/plans/2026-06-30-manuscript-analysis-pill-gate.md
@@ -28,7 +28,9 @@
 **Files:**
 - Modify: `src/store/prosody-slice.ts` (full rewrite of the slice body)
 - Modify: `src/components/layout.tsx:163` (the `prosodyStream` selector read), `layout.tsx:1044/1048/1050/1057` (auto-trigger dispatches), `layout.tsx:1356-1362` (the `prosodyPill` derivation)
-- Test: `src/store/prosody-slice.test.ts` (rewrite for the map shape)
+- Test: `src/store/prosody-slice.test.ts` (rewrite for the map shape), `src/components/layout-prosody-pill.test.tsx` (migrate to the map shape so this commit stays green — Task 3 deletes it when the pill is retired)
+
+> **Green-between-commits note:** `layout-prosody-pill.test.tsx` preloads the singular `{ activeStream }` and calls `prosodyActions.clear()` with no argument. After this migration both break (`clear()` is a typecheck error; the preload no longer renders the pill), and the pre-commit gate runs the frontend suite for a frontend change — so this test MUST be migrated in the same commit (Step 5 below), not deferred to Task 3. (`prosody-autotrigger.test.tsx` mocks `runProsodyPasses` and never reads `activeStream`/`clear()`, so it is unaffected.)
 
 **Interfaces:**
 - Produces:
@@ -185,15 +187,44 @@ if (pillActive) dispatch(prosodyActions.clear({ bookId: id }));  // catch path (
 
 (`useAppSelectorShallow` is already imported in `layout.tsx` — see line 161.)
 
-- [ ] **Step 5: Run the slice test + typecheck**
+- [ ] **Step 5: Migrate `layout-prosody-pill.test.tsx` to the map shape (keeps the commit green)**
 
-Run: `npm run test -- src/store/prosody-slice.test.ts && npm run typecheck`
-Expected: slice test PASS; typecheck PASS.
+In `src/components/layout-prosody-pill.test.tsx`, change the store factory's preloaded state from the singular `activeStream` to the `activeStreams` map, and every `prosodyActions.clear()` call to `prosodyActions.clear({ bookId: 'b1' })`:
 
-- [ ] **Step 6: Commit**
+```ts
+// store factory: preload the map, not the singular field
+function makeStore(prosodyState?: Partial<ReturnType<typeof prosodySlice.getInitialState>>) {
+  // ...reducer map unchanged...
+  return configureStore({
+    reducer: { /* ...unchanged... */ prosody: prosodySlice.reducer },
+    preloadedState: prosodyState ? { prosody: prosodyState as ReturnType<typeof prosodySlice.getInitialState> } : undefined,
+  });
+}
+
+// test 1 — pill renders:
+const store = makeStore({ activeStreams: { b1: { progress: 42, label: 'Detecting emotions' } } });
+// assert pill text contains 'Detecting emotions' and '42%'
+
+// test 2 — absent when empty:
+const store = makeStore({ activeStreams: {} });
+
+// test 3 — updates with store changes:
+store.dispatch(prosodyActions.setActive({ bookId: 'b1', progress: 0, label: 'Detecting emotions' }));
+store.dispatch(prosodyActions.updateProgress({ bookId: 'b1', progress: 0.77 }));
+store.dispatch(prosodyActions.clear({ bookId: 'b1' }));   // was clear()
+```
+
+(The pill text assertion changes from `'Phase 3 — Detecting prosody'` to `'Detecting emotions'` because the labels are now user-facing.)
+
+- [ ] **Step 6: Run the slice test + the pill test + typecheck**
+
+Run: `npm run test -- src/store/prosody-slice.test.ts src/components/layout-prosody-pill.test.tsx && npm run typecheck`
+Expected: both tests PASS; typecheck PASS.
+
+- [ ] **Step 7: Commit**
 
 ```bash
-git add src/store/prosody-slice.ts src/store/prosody-slice.test.ts src/components/layout.tsx
+git add src/store/prosody-slice.ts src/store/prosody-slice.test.ts src/components/layout.tsx src/components/layout-prosody-pill.test.tsx
 git commit -m "refactor(frontend): migrate prosody-slice to per-book activeStreams map"
 ```
 
@@ -326,8 +357,9 @@ git commit -m "feat(frontend): add per-book activeStreams progress map to script
   - `selectProsodyRunningForBook(state, bookId): boolean`
   - `selectReviewRunningForBook(state, bookId): boolean`
   - `selectAnalysisBusyForBook(state, bookId): boolean`
+  - `analysisBusyMessage(state, bookId): string | null` (per-pass "Generate blocked" copy)
   - `selectAnalysisSubstage(state): { kind: 'prosody' | 'review'; label: string; percent: number } | null` (memoized)
-  - `StatusInput` gains `analysisSubstage: { kind: 'prosody' | 'review'; percent: number } | null`.
+  - `StatusInput` gains optional `analysisSubstage?: { kind: 'prosody' | 'review'; percent: number } | null`; `StatusDetail` gains optional `analysisSubstage?: { label: string; percent: number } | null`.
 
 - [ ] **Step 1: Write the selector test**
 
@@ -404,6 +436,14 @@ export const selectReviewRunningForBook = (state: RootState, bookId: string): bo
 export const selectAnalysisBusyForBook = (state: RootState, bookId: string): boolean =>
   selectProsodyRunningForBook(state, bookId) || selectReviewRunningForBook(state, bookId);
 
+/** User-facing "why is Generate blocked" copy for a busy book — per-pass
+    wording (spec copy). Returns null when the book isn't busy. */
+export const analysisBusyMessage = (state: RootState, bookId: string): string | null => {
+  if (selectProsodyRunningForBook(state, bookId)) return 'Wait — emotions are still being detected';
+  if (selectReviewRunningForBook(state, bookId)) return 'Wait — script review is in progress';
+  return null;
+};
+
 const firstByLowestBookId = (m: Record<string, SubstageEntry>): { bookId: string; entry: SubstageEntry } | null => {
   const ids = Object.keys(m).sort();
   return ids.length ? { bookId: ids[0], entry: m[ids[0]] } : null;
@@ -452,7 +492,7 @@ it('shows an Analysing rung for an active analysis sub-stage (below real analysi
 });
 ```
 
-(If existing `summarizeStatus` calls in this file omit `analysisSubstage`, add `analysisSubstage: null` to their input objects — TypeScript will flag the missing field.)
+(No need to touch the other `summarizeStatus` calls in this file — the field is optional.)
 
 - [ ] **Step 6: Run to verify it fails**
 
@@ -461,25 +501,25 @@ Expected: FAIL — `analysisSubstage` not a valid `StatusInput` field.
 
 - [ ] **Step 7: Implement the rung**
 
-In `src/components/top-bar.tsx`, add to the `StatusInput` interface (after `anyModelLoading`):
+In `src/components/top-bar.tsx`, add to the `StatusInput` interface (after `anyModelLoading`). **Declare it optional** (`?`) so the dozens of existing `summarizeStatus` calls in `top-bar.test.tsx` don't all need a new field — the `if (analysisSubstage)` guard treats `undefined` and `null` identically:
 
 ```ts
-  /** The active analysis sub-stage (prosody/review) progress, or null. Folds
-      into the "Analysing" rung below the primary analysis pass. */
-  analysisSubstage: { kind: 'prosody' | 'review'; percent: number } | null;
+  /** The active analysis sub-stage (prosody/review) progress, or null/absent.
+      Folds into the "Analysing" rung below the primary analysis pass. */
+  analysisSubstage?: { kind: 'prosody' | 'review'; percent: number } | null;
 ```
 
-Add `analysisSubstage` to the destructured params of `summarizeStatus`, and insert the rung **directly after** the `analysis?.state === 'running'` block (and before `design?.state === 'running'`):
+Add `analysisSubstage` to the destructured params of `summarizeStatus` (`analysisSubstage = null` as the default), and insert the rung **directly after** the `analysis?.state === 'running'` block (and before `design?.state === 'running'`):
 
 ```ts
   if (analysisSubstage)
     return { label: 'Analysing', tone: 'peach', icon: 'spinner', detail: `${analysisSubstage.percent}%` };
 ```
 
-Add `analysisSubstage` to the `StatusDetail` interface too:
+Add `analysisSubstage` to the `StatusDetail` interface too — **carrying the `label`** (the popover renders it, so the selector's `label` field is not dead):
 
 ```ts
-  analysisSubstage: { kind: 'prosody' | 'review'; percent: number } | null;
+  analysisSubstage?: { label: string; percent: number } | null;
 ```
 
 - [ ] **Step 8: Wire Layout, render the popover row, and retire the standalone pill**
@@ -509,7 +549,7 @@ Pass it into both `summarizeStatus` and `statusDetail`:
     : null;
 ```
 
-Add `analysisSubstage: analysisSubstage ? { kind: analysisSubstage.kind, percent: analysisSubstage.percent } : null,` to the `statusDetail` object literal (line 1429+).
+Add `analysisSubstage: analysisSubstage ? { label: analysisSubstage.label, percent: analysisSubstage.percent } : null,` to the `statusDetail` object literal (line 1429+).
 
 Also update `showStatus` so the pill appears when a sub-stage is the only activity:
 
@@ -530,13 +570,13 @@ In `src/components/status-popover.tsx`, render a sub-stage row inside the analys
 ```tsx
 {detail.analysisSubstage && (
   <div data-testid="substage-row" className="flex items-center justify-between text-sm text-ink/70">
-    <span>{detail.analysisSubstage.kind === 'prosody' ? 'Detecting emotions' : 'Reviewing'}</span>
+    <span>{detail.analysisSubstage.label}</span>
     <span className="tabular-nums">{detail.analysisSubstage.percent}%</span>
   </div>
 )}
 ```
 
-(Place it adjacent to the existing `AnalysisPill` render in the analysis section.)
+(Place it adjacent to the existing `AnalysisPill` render in the analysis section. The `label` is the user-facing phase text the dispatch sites set — "Detecting emotions" / "Reviewing".)
 
 - [ ] **Step 9: Delete the standalone-pill unit test and re-point the e2e**
 
@@ -570,29 +610,44 @@ git commit -m "feat(frontend): fold analysis sub-stage progress into the Status 
 
 - [ ] **Step 1: Add a failing test**
 
-In `src/components/detect-emotions-button.test.tsx`, add a test that the button drives the slice and clears on error. Use the store + a mocked `runProsodyPasses`:
+In `src/components/detect-emotions-button.test.tsx`, the existing `makeStore()` only wires `manuscript`/`ui`/`chapters`. **Add the `prosody` and `scriptReview` reducers to it** (needed here and by Task 6), and add this test. The component clicks `detect-emotions-button` → `detect-emotions-confirm` → `run()` (testids confirmed in the component at lines 101/146).
+
+Extend `makeStore()`:
 
 ```ts
-import { vi } from 'vitest';
-vi.mock('../store/prosody-thunk', () => ({
-  runProsodyPasses: vi.fn(async (_bookId, opts) => {
-    opts.onProgress?.(0.5);
-    throw new Error('boom'); // exercise the error path
-  }),
-}));
+import { prosodySlice } from '../store/prosody-slice';
+import { scriptReviewSlice } from '../store/script-review-slice';
+// in configureStore.reducer add:  prosody: prosodySlice.reducer, scriptReview: scriptReviewSlice.reducer,
 ```
 
+Add a mock for the thunk and the test (place the mock near the existing `../lib/api` mock):
+
 ```ts
-it('sets and clears the prosody stream around a (failing) run', async () => {
-  // render with a store whose ui.stage.bookId === 'b1', click the confirm button…
-  // (follow the existing render helper in this file)
-  // after the run rejects:
-  const state = store.getState();
-  expect(state.prosody.activeStreams.b1).toBeUndefined(); // cleared in finally despite the throw
+import { runProsodyPasses } from '../store/prosody-thunk';
+vi.mock('../store/prosody-thunk', () => ({ runProsodyPasses: vi.fn() }));
+
+it('sets the prosody stream during a run and clears it in finally even on throw', async () => {
+  let streamWhileRunning: unknown;
+  (runProsodyPasses as unknown as vi.Mock).mockImplementation(async (bookId: string, opts: { onProgress?: (f: number) => void }) => {
+    opts.onProgress?.(0.5);
+    streamWhileRunning = store.getState().prosody.activeStreams[bookId]; // captured mid-run
+    throw new Error('boom'); // exercise the error path
+  });
+  const store = makeStore();
+  render(
+    <Provider store={store}>
+      <DetectEmotionsButton />
+    </Provider>,
+  );
+  fireEvent.click(screen.getByTestId('detect-emotions-button'));
+  fireEvent.click(screen.getByTestId('detect-emotions-confirm'));
+  await waitFor(() => expect(runProsodyPasses).toHaveBeenCalled());
+  // set while running:
+  expect(streamWhileRunning).toMatchObject({ label: 'Detecting emotions' });
+  // cleared in finally despite the throw:
+  await waitFor(() => expect(store.getState().prosody.activeStreams.b1).toBeUndefined());
 });
 ```
-
-(Model the render + confirm-click on the existing tests in this file. The key assertion is that `prosody.activeStreams[bookId]` is set while running and **absent after** even though `runProsodyPasses` threw.)
 
 - [ ] **Step 2: Run to verify it fails**
 
@@ -675,7 +730,7 @@ git commit -m "feat(frontend): drive the prosody pill from DetectEmotionsButton,
 
 **Interfaces:**
 - Consumes: `scriptReviewActions.setActive/updateProgress/clear/setReview`, `api.reviewScript`, `planApply`, `notificationsActions`.
-- Produces: `runReviewScript(bookId, { wholeBook, chapterId?, model, sentences, characterIds }): Promise<void>` — a plain async function (matches `runProsodyPasses`' shape: takes `dispatch` in its options bag, not a thunk-creator).
+- Produces: `runReviewScript(bookId, { dispatch, wholeBook, chapterId?, model, sentences, characterIds, totalChapters }): Promise<void>` — a plain async function (matches `runProsodyPasses`' shape: takes `dispatch` in its options bag, not a thunk-creator). **`api.reviewScript` has no `onProgress`** (verified in `api.ts` — its callbacks are `onOps`/`onPhase`/`onThrottle`/`onChapterFailed`), so progress is derived from `onOps`, which fires once per chapter: the thunk dispatches `updateProgress({ bookId, progress: chaptersDone / totalChapters })` on each `onOps`. `totalChapters` = `reviewableChapterCount` for whole-book, `1` for a single chapter.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -696,19 +751,26 @@ import { scriptReviewActions } from './script-review-slice';
 describe('runReviewScript', () => {
   beforeEach(() => reviewScript.mockReset());
 
-  it('sets active, then clears in finally on success', async () => {
-    reviewScript.mockResolvedValue(undefined);
+  it('sets active, advances progress per chapter via onOps, then clears in finally on success', async () => {
+    reviewScript.mockImplementation(async (_bookId: string, opts: { onOps?: (e: { chapterId: number; ops: unknown[] }) => void }) => {
+      opts.onOps?.({ chapterId: 1, ops: [] });
+      opts.onOps?.({ chapterId: 2, ops: [] });
+    });
     const dispatch = vi.fn();
-    await runReviewScript('b1', { dispatch, wholeBook: true, model: 'gemma', sentences: [], characterIds: new Set<number>() });
+    await runReviewScript('b1', { dispatch, wholeBook: true, model: 'gemma', sentences: [], characterIds: new Set<number>(), totalChapters: 2 });
     const types = dispatch.mock.calls.map((c) => c[0].type);
     expect(types).toContain(scriptReviewActions.setActive.type);
+    expect(types).toContain(scriptReviewActions.updateProgress.type); // fired from onOps
+    // last updateProgress payload reached 2/2 → 1.0
+    const lastProg = dispatch.mock.calls.map((c) => c[0]).filter((a) => a.type === scriptReviewActions.updateProgress.type).pop();
+    expect(lastProg.payload).toEqual({ bookId: 'b1', progress: 1 });
     expect(types[types.length - 1]).toBe(scriptReviewActions.clear.type);
   });
 
   it('clears in finally even when the API throws', async () => {
     reviewScript.mockRejectedValue(new Error('boom'));
     const dispatch = vi.fn();
-    await runReviewScript('b1', { dispatch, wholeBook: true, model: 'gemma', sentences: [], characterIds: new Set<number>() });
+    await runReviewScript('b1', { dispatch, wholeBook: true, model: 'gemma', sentences: [], characterIds: new Set<number>(), totalChapters: 1 });
     const types = dispatch.mock.calls.map((c) => c[0].type);
     expect(types[types.length - 1]).toBe(scriptReviewActions.clear.type);
   });
@@ -748,12 +810,16 @@ export interface RunReviewScriptOpts {
   /** Live sentences for index-mapped planApply (caller passes sentencesRef.current). */
   sentences: ReviewLiveSentence[];
   characterIds: Set<number>;
+  /** Reviewable chapter count for the progress denominator (1 for a single chapter). */
+  totalChapters: number;
 }
 
 export async function runReviewScript(bookId: string, opts: RunReviewScriptOpts): Promise<void> {
-  const { dispatch, wholeBook, chapterId, model, sentences, characterIds } = opts;
+  const { dispatch, wholeBook, chapterId, model, sentences, characterIds, totalChapters } = opts;
   const allOps: ReviewOpWithChapter[] = [];
   const failed: Array<{ chapterId: number; message: string }> = [];
+  const total = Math.max(1, totalChapters);
+  let chaptersDone = 0;
   dispatch(scriptReviewActions.setActive({ bookId, progress: 0, label: 'Reviewing' }));
   try {
     await api.reviewScript(bookId, {
@@ -761,6 +827,8 @@ export async function runReviewScript(bookId: string, opts: RunReviewScriptOpts)
       model,
       onOps: ({ chapterId: chId, ops }: { chapterId: number; ops: ReviewOp[] }) => {
         for (const op of ops) allOps.push({ ...op, chapterId: chId });
+        chaptersDone += 1; // onOps fires once per reviewed chapter
+        dispatch(scriptReviewActions.updateProgress({ bookId, progress: Math.min(1, chaptersDone / total) }));
       },
       onChapterFailed: (e: { chapterId: number; message: string }) => failed.push(e),
     });
@@ -794,7 +862,7 @@ export async function runReviewScript(bookId: string, opts: RunReviewScriptOpts)
 }
 ```
 
-(If `api.reviewScript` has no progress callback today, `updateProgress` isn't dispatched yet — the pill shows an indeterminate "Reviewing · 0%". Step 4 of Task 9 extends `mockReviewScript` to emit progress; if the real `api.reviewScript` gains an `onProgress`, wire it the same way as `runProsodyPasses`.)
+(Progress is chapter-granular — `onOps` fires once per reviewed chapter, so the pill steps 1/N, 2/N … N/N. For a single-chapter review `totalChapters` is 1, so the pill jumps 0% → 100% on completion, which is correct for one unit of work.)
 
 - [ ] **Step 4: Delegate from `manuscript.tsx`**
 
@@ -821,12 +889,15 @@ Replace the body of `handleReviewScript` (`manuscript.tsx:697-758`) with a thin 
           vocalization: s.vocalization,
         })),
         characterIds: new Set(characters.map((c) => c.id)),
+        totalChapters: wholeBook ? reviewableChapterCount : 1,
       });
     } finally {
       setReviewLoading(false);
     }
   }
 ```
+
+(`reviewableChapterCount` already exists in `manuscript.tsx` — it feeds the whole-book menu label and the RPD warning.)
 
 Add the import: `import { runReviewScript } from '../store/script-review-thunk';`. Remove now-unused imports in `manuscript.tsx` that the lifted code orphaned (e.g. `planApply` if nothing else uses it — verify with a grep before deleting).
 
@@ -856,15 +927,24 @@ git commit -m "feat(frontend): extract runReviewScript thunk that drives the rev
 
 - [ ] **Step 1: Write the failing tests**
 
-In `detect-emotions-button.test.tsx`, add: when `scriptReview.activeStreams[bookId]` is set (a review running), the Detect-emotions trigger button is `disabled`. In a manuscript test, add: when `prosody.activeStreams[bookId]` is set, `getByTestId('review-script-chapter')` is `disabled`, and a different book's button is not.
+In `detect-emotions-button.test.tsx`, add a concrete test using the `makeStore()` (now wired with `scriptReview` from Task 4). Set a review active for `b1`, then assert the Detect-emotions trigger is disabled:
 
 ```ts
+import { scriptReviewActions } from '../store/script-review-slice';
+
 it('disables Detect emotions while a review runs on the same book', () => {
-  // store with scriptReview.activeStreams = { b1: { progress: 5, label: 'Reviewing' } }, ui.stage.bookId = 'b1'
-  // render <DetectEmotionsButton />
-  expect(screen.getByRole('button', { name: /detect emotions/i })).toBeDisabled();
+  const store = makeStore(); // ui.stage.bookId === 'b1'
+  store.dispatch(scriptReviewActions.setActive({ bookId: 'b1', progress: 0.05, label: 'Reviewing' }));
+  render(
+    <Provider store={store}>
+      <DetectEmotionsButton />
+    </Provider>,
+  );
+  expect(screen.getByTestId('detect-emotions-button')).toBeDisabled();
 });
 ```
+
+The symmetric direction — the three Review buttons disabled while a prosody pass runs — is covered by the e2e in Task 10 (`generate-disabled-while-analysing.spec.ts` extends to assert `review-script-chapter` is disabled mid-prosody), because a focused unit render of the full `manuscript.tsx` view is disproportionately heavy for this one-line `disabled` wiring.
 
 - [ ] **Step 2: Run to verify it fails**
 
@@ -1027,19 +1107,41 @@ git commit -m "feat(frontend): guard the prosody auto-trigger against double-fir
 
 In `src/store/queue-thunks.test.ts` (create if absent), add: `enqueueQueueEntries` drops entries whose book is busy and toasts, enqueuing only the rest.
 
+Mock the network seam this file already uses (check the top of `queue-thunks.ts` for whether `queueRequest`/`readSnapshot` are module-locals or imported; if locals, mock `fetch`). Concrete test capturing the POST body:
+
 ```ts
-it('filters out entries whose book has an active analysis sub-stage', async () => {
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { enqueueQueueEntries } from './queue-thunks';
+import { scriptReviewActions } from './script-review-slice';
+
+const posted: unknown[] = [];
+beforeEach(() => { posted.length = 0; });
+// Stub global fetch to capture the enqueue body and return a snapshot echoing it.
+vi.stubGlobal('fetch', vi.fn(async (_url: string, init: { body: string }) => {
+  const body = JSON.parse(init.body) as { entries: unknown[] };
+  posted.push(...body.entries);
+  return { ok: true, json: async () => ({ entries: body.entries, paused: false, recycling: false, loaded: true }) } as Response;
+}));
+
+it('enqueues only un-gated entries and toasts the gated pass', async () => {
   const dispatch = vi.fn();
-  const getState = () =>
-    ({ prosody: { activeStreams: { b1: { progress: 0, label: 'x' } } }, scriptReview: { activeStreams: {} } }) as never;
-  // mock queueRequest/readSnapshot to echo back the posted entries…
+  const getState = () => ({
+    prosody: { activeStreams: { b1: { progress: 0, label: 'Detecting emotions' } } },
+    scriptReview: { activeStreams: {} },
+  }) as never;
   await enqueueQueueEntries([
     { id: 'e1', bookId: 'b1', chapterId: 1, scope: 'this' },
     { id: 'e2', bookId: 'b2', chapterId: 1, scope: 'this' },
-  ])(dispatch as never, getState as never, undefined as never);
-  // assert only the b2 entry was POSTed, and a warn toast naming b1 fired.
+  ])(dispatch as never, getState as never);
+  // Only the un-gated b2 entry was POSTed:
+  expect(posted).toEqual([{ id: 'e2', bookId: 'b2', chapterId: 1, scope: 'this' }]);
+  // A warn toast with the per-pass (prosody) copy fired:
+  const toasts = dispatch.mock.calls.map((c) => c[0]).filter((a) => a.type?.includes('pushToast'));
+  expect(toasts.some((t) => t.payload.message === 'Wait — emotions are still being detected')).toBe(true);
 });
 ```
+
+(If `queue-thunks.ts` wraps `fetch` in a `queueRequest` helper that sets a base URL/headers, the global-`fetch` stub still intercepts it; adjust the returned shape to match `readSnapshot`'s expectations — read those two helpers first.)
 
 - [ ] **Step 2: Run to verify it fails**
 
@@ -1051,25 +1153,26 @@ Expected: FAIL — guard not present / `getState` unused.
 In `src/store/queue-thunks.ts`, give `enqueueQueueEntries` access to `getState` and filter:
 
 ```ts
-import { selectAnalysisBusyForBook } from './analysis-substage-selectors';
+import type { RootState } from './index';
+import { selectAnalysisBusyForBook, analysisBusyMessage } from './analysis-substage-selectors';
 
 export function enqueueQueueEntries(entries: EnqueueInput[], opts: { silent?: boolean } = {}) {
   return async (dispatch: AppDispatch, getState: () => RootState): Promise<QueueSnapshotResponse> => {
     const state = getState();
-    const gated = entries.filter((e) => selectAnalysisBusyForBook(state, e.bookId));
     const allowed = entries.filter((e) => !selectAnalysisBusyForBook(state, e.bookId));
+    const gated = entries.filter((e) => selectAnalysisBusyForBook(state, e.bookId));
     if (gated.length > 0) {
       dispatch(
         notificationsActions.pushToast({
           kind: 'warn',
-          message: 'Wait — analysis is still running on this book.',
+          message: analysisBusyMessage(state, gated[0].bookId) ?? 'Wait — analysis is still running on this book.',
           dedupeKey: 'gen-gated-by-analysis',
         }),
       );
     }
-    if (allowed.length === 0) {
-      return getState().queue as unknown as QueueSnapshotResponse; // nothing to enqueue
-    }
+    /* Always POST `allowed` (even []), so the return is a real snapshot — no
+       unsafe cast of QueueState. An empty enqueue is a server-side no-op that
+       returns the current snapshot. */
     const res = await queueRequest('/api/queue/enqueue', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -1077,12 +1180,11 @@ export function enqueueQueueEntries(entries: EnqueueInput[], opts: { silent?: bo
     });
     const snapshot = await readSnapshot(res);
     dispatch(queueActions.setSnapshot(snapshot));
-    if (!opts.silent) {
-      const count = snapshot.entries.length;
+    if (!opts.silent && allowed.length > 0) {
       dispatch(
         notificationsActions.pushToast({
           kind: 'info',
-          message: `Added to queue · ${count} ${count === 1 ? 'entry' : 'entries'} pending.`,
+          message: `Added to queue · ${allowed.length} ${allowed.length === 1 ? 'entry' : 'entries'} pending.`,
           dedupeKey: 'queue-enqueue',
         }),
       );
@@ -1092,7 +1194,7 @@ export function enqueueQueueEntries(entries: EnqueueInput[], opts: { silent?: bo
 }
 ```
 
-(Import `RootState` from `./index` if not already. The `allowed.length === 0` early-return shape: return the current queue snapshot so callers awaiting a `QueueSnapshotResponse` don't break — adjust to whatever the existing `QueueState`→response shape is; if simpler, return `{ entries: getState().queue.entries, ... }`.)
+(Import `RootState` from `./index`. No early-return cast: `allowed` is always POSTed, so the typed `QueueSnapshotResponse` always comes from `readSnapshot`. The info toast counts `allowed.length`, not the whole snapshot, so a partially-gated batch reports the right number.)
 
 - [ ] **Step 4: Disable the Generate UI**
 
@@ -1107,14 +1209,17 @@ Guard `handleGenerateChapter` and disable the primary Generate / bulk-regenerate
 ```ts
   function handleGenerateChapter(ch: Chapter): void {
     if (analysisBusy) {
-      dispatch(notificationsActions.pushToast({ kind: 'warn', message: 'Wait — analysis is still running on this book.', dedupeKey: 'gen-gated-by-analysis' }));
+      const msg = analysisBusyMessage(store.getState(), bookId) ?? 'Wait — analysis is still running on this book.';
+      dispatch(notificationsActions.pushToast({ kind: 'warn', message: msg, dedupeKey: 'gen-gated-by-analysis' }));
       return;
     }
     // …existing body…
   }
 ```
 
-And add `disabled={analysisBusy || …}` to the rendered Generate / "Generate all" / RegenerateModal-confirm buttons (grep `enqueueQueueEntries`/`onRegenerate`/`Generate` within `generation.tsx` for the button sites). Import `selectAnalysisBusyForBook` + `notificationsActions`.
+(`analysisBusyMessage` needs the live state; read it via the `useStore()` hook (`const store = useStore<RootState>()`) so the message reflects which pass is running. The enqueue thunk guard (Step 3) is the real backstop — this UI early-return is just immediate feedback.)
+
+And add `disabled={analysisBusy || …}` to the rendered Generate / "Generate all" / RegenerateModal-confirm buttons (grep `enqueueQueueEntries`/`onRegenerate`/`Generate` within `generation.tsx` for the button sites). Import `selectAnalysisBusyForBook` + `analysisBusyMessage` + `notificationsActions`.
 
 - [ ] **Step 5: Run to verify**
 
@@ -1141,30 +1246,64 @@ git commit -m "feat(frontend): gate Generate while a book's analysis sub-stage r
 
 - [ ] **Step 1: Write the failing test**
 
-In `src/store/broadcast-middleware.test.ts`, add cases using `createBroadcastMiddleware({ channel })` with a mock channel (mirror the existing analysis/chapters tests in this file):
+In `src/store/broadcast-middleware.test.ts`, add a self-contained harness that injects a fake channel into `createBroadcastMiddleware` (the factory sets `channel.onmessage` to the inbound handler, so the test can both read `posted` and fire inbound messages):
 
 ```ts
-it('broadcasts sync:substage set on prosody/setActive and clear on prosody/clear', () => {
-  // build middleware with a mock channel that records postMessage payloads
-  // dispatch prosodyActions.setActive({ bookId: 'b1', progress: 0.4, label: 'Detecting emotions' })
-  // expect a posted { kind: 'sync:substage', stream: 'prosody', bookId: 'b1', mode: 'set', entry: { progress: 40, label: 'Detecting emotions' } }
-  // dispatch prosodyActions.clear({ bookId: 'b1' })
-  // expect a posted { kind: 'sync:substage', stream: 'prosody', bookId: 'b1', mode: 'clear' }
-});
+import { describe, it, expect } from 'vitest';
+import { configureStore } from '@reduxjs/toolkit';
+import { createBroadcastMiddleware, type BroadcastMessage } from './broadcast-middleware';
+import { prosodySlice, prosodyActions } from './prosody-slice';
+import { scriptReviewSlice } from './script-review-slice';
 
-it('inbound sync:substage applies via applyExternalSet/Clear and does NOT re-broadcast', () => {
-  // fire channel.onmessage with a foreign instanceId set message
-  // expect store.dispatch(prosodyActions.applyExternalSet(...)) and NO new postMessage
-});
+function harness(instanceId = 'self') {
+  const posted: BroadcastMessage[] = [];
+  const channel = {
+    postMessage: (m: BroadcastMessage) => posted.push(m),
+    onmessage: null as null | ((e: { data: BroadcastMessage }) => void),
+    close: () => {},
+  } as unknown as BroadcastChannel;
+  const store = configureStore({
+    reducer: { prosody: prosodySlice.reducer, scriptReview: scriptReviewSlice.reducer },
+    middleware: (gdm) => gdm({ serializableCheck: false }).concat(createBroadcastMiddleware({ channel, instanceId })),
+  });
+  const inbound = (m: BroadcastMessage) => channel.onmessage!({ data: m });
+  return { store, posted, inbound };
+}
 
-it('drops self-echo by instanceId', () => {
-  // onmessage with msg.instanceId === self → no dispatch
-});
+describe('broadcast-middleware sync:substage', () => {
+  it('posts set on setActive and clear on clear (book taken from payload)', () => {
+    const { store, posted } = harness();
+    store.dispatch(prosodyActions.setActive({ bookId: 'b1', progress: 0.4, label: 'Detecting emotions' }));
+    expect(posted.at(-1)).toMatchObject({ kind: 'sync:substage', stream: 'prosody', bookId: 'b1', mode: 'set', entry: { progress: 40, label: 'Detecting emotions' } });
+    store.dispatch(prosodyActions.clear({ bookId: 'b1' }));
+    expect(posted.at(-1)).toMatchObject({ kind: 'sync:substage', stream: 'prosody', bookId: 'b1', mode: 'clear' });
+  });
 
-it('a clear on book X leaves book Y intact across tabs (finding-2 regression)', () => {
-  // receiver has b1+b2; inbound clear for b1 → b2 entry remains
+  it('applies a foreign inbound set and does NOT re-broadcast', () => {
+    const { store, posted, inbound } = harness('self');
+    inbound({ kind: 'sync:substage', instanceId: 'other', stream: 'prosody', bookId: 'bX', mode: 'set', entry: { progress: 22, label: 'Detecting emotions' } });
+    expect(store.getState().prosody.activeStreams.bX).toEqual({ progress: 22, label: 'Detecting emotions' });
+    expect(posted).toHaveLength(0); // applyExternalSet is not in the outbound match set
+  });
+
+  it('drops self-echo by instanceId', () => {
+    const { store, inbound } = harness('self');
+    inbound({ kind: 'sync:substage', instanceId: 'self', stream: 'prosody', bookId: 'bSelf', mode: 'set', entry: { progress: 5, label: 'x' } });
+    expect(store.getState().prosody.activeStreams.bSelf).toBeUndefined();
+  });
+
+  it('a clear on book X leaves book Y intact (finding-2 regression)', () => {
+    const { store, inbound } = harness('self');
+    inbound({ kind: 'sync:substage', instanceId: 'other', stream: 'prosody', bookId: 'b1', mode: 'set', entry: { progress: 1, label: 'x' } });
+    inbound({ kind: 'sync:substage', instanceId: 'other', stream: 'prosody', bookId: 'b2', mode: 'set', entry: { progress: 2, label: 'y' } });
+    inbound({ kind: 'sync:substage', instanceId: 'other', stream: 'prosody', bookId: 'b1', mode: 'clear' });
+    expect(store.getState().prosody.activeStreams.b1).toBeUndefined();
+    expect(store.getState().prosody.activeStreams.b2).toEqual({ progress: 2, label: 'y' });
+  });
 });
 ```
+
+(`scriptReviewSlice` is imported so the minimal store has both reducers the middleware's substage branch reads; the analysis/chapters branches aren't exercised here, so those slices can be omitted.)
 
 - [ ] **Step 2: Run to verify it fails**
 
@@ -1249,7 +1388,9 @@ In the outbound middleware return (after the `CHAPTERS_BROADCAST_ACTIONS` block,
       }
 ```
 
-(Note: the cleared book is taken from `action.payload.bookId`, not post-state — finding 9. A simple per-`(stream,bookId)` debounce for `updateProgress` can be added mirroring the analysis path; v1 may ship without it since prosody progress ticks are coarse — confirm tick rate before deciding.)
+(Note: the cleared book is taken from `action.payload.bookId`, not post-state — finding 9.)
+
+**Debounce decision (finding 7):** v1 ships **without** a progress-tick debounce on `sync:substage`. Rationale: prosody `onProgress` is chapter-granular (emotions 0–50%, instruct 50–100% over the chapter list) and review progress is one tick per chapter — both far coarser than the analyzer phase ticks the existing `PROGRESS_DEBOUNCE_MS` path was built for (which fire ~10×/sec). A handful of cross-tab messages per book-pass is negligible. **Log this in the regression plan** (Task 11) as a deliberate omission, not an oversight; if a future engine emits sub-second prosody ticks, add a `(stream, bookId)`-keyed debounce mirroring the analysis block.
 
 Update the `BroadcastableRootState` interface to include the two substage maps if the outbound block reads them through it.
 
@@ -1277,7 +1418,7 @@ git commit -m "feat(frontend): sync analysis sub-stage progress cross-tab via sy
 
 - [ ] **Step 1: Extend the review mock cadence**
 
-Find the mock backing `api.reviewScript` (grep `reviewScript` under `src/mocks/`). Make it emit ops over a few `await delay()` ticks so the "Reviewing" pill is observable in e2e, then resolve. Keep it deterministic (fixed delays, no randomness).
+Find the mock backing `api.reviewScript` (it's `mockReviewScript` — `api.ts:7469`). Make it call `onOps({ chapterId, ops })` **once per chapter** with a fixed `await delay(...)` between chapters, then resolve — so `runReviewScript` steps the pill 1/N, 2/N … (the progress is derived from `onOps` count, per Task 5). Deterministic delays only (no randomness — see the project's e2e-flake notes).
 
 - [ ] **Step 2: Write `e2e/detect-emotions-pill-progress.spec.ts`**
 
@@ -1302,7 +1443,7 @@ Pre-seed/drive an active prosody stream for a book, then trigger the auto-trigge
 
 - [ ] **Step 5: Write `e2e/generate-disabled-while-analysing.spec.ts`**
 
-While a sub-stage runs on book X, the Generate control on book X is `disabled` with the warning copy; a different book's Generate stays enabled.
+While a sub-stage runs on book X: (a) the Generate control on the Generate view is `disabled`; (b) on the Manuscript view the `review-script-chapter` button is `disabled` too (the pass mutual-exclusion from Task 6 — this is the e2e that covers the Manuscript-side wiring, per Task 6 Step 1); (c) clicking a still-enabled Generate path surfaces the warn toast with the per-pass copy. Reuse the book-open/nav helper from `e2e/script-review.spec.ts`; drive the sub-stage by clicking `detect-emotions-button` → `detect-emotions-confirm` (the mock keeps it running long enough to assert).
 
 - [ ] **Step 6: Run the new e2e specs**
 
@@ -1350,5 +1491,6 @@ PR body: enumerate every user/operator/dev-visible delta (pill rung, retired pro
 ## Self-Review
 
 - **Spec coverage:** §1 state model → Tasks 1, 2, 3 (selectors), 9 (broadcast); §2 progress wiring + pill → Tasks 3, 4, 5; pass mutual-exclusion → Task 6; §3 Generate-gate → Task 8; §4 auto-trigger guard → Task 7; toasts → Tasks 4/5/8; tests → every task + Task 10; shipping → Task 11. All 14 adversarial findings map to code: 8/9 → Task 9; 2 → Tasks 1/2 + Task 9 regression test; 3 → Tasks 4/5/7 (`finally`); 4 → Task 3 (e2e re-point + delete); 10 → Task 6; 11 → Task 3 (`createSelector`); 12 → Task 7; 13 → Task 9 (echo layer 1); 14 → Task 1.
-- **Type consistency:** `SubstageEntry` defined in Task 1, imported by Tasks 2/3/9; `selectAnalysisBusyForBook` defined in Task 3, consumed by Tasks 6/7/8; `runReviewScript` signature fixed in Task 5; `analysisSubstage` field shape (`{ kind, percent }` on `StatusInput`/`StatusDetail`, `{ kind, label, percent }` from the selector) consistent between Tasks 3 and its consumers.
+- **Type consistency:** `SubstageEntry` defined in Task 1, imported by Tasks 2/3/9; `selectAnalysisBusyForBook` + `analysisBusyMessage` defined in Task 3, consumed by Tasks 6/7/8; `runReviewScript` signature (incl. `totalChapters`) fixed in Task 5 and matched by the Task 5 delegate; `analysisSubstage` shapes are intentionally distinct per consumer and consistent with what Layout passes — `StatusInput` gets `{ kind, percent }` (rung needs only percent), `StatusDetail` gets `{ label, percent }` (popover renders the label), and the selector returns `{ kind, label, percent }` (superset).
+- **Round-2 fixes folded:** P1 (Task 1 migrates `layout-prosody-pill.test.tsx` in-commit), P2 (review progress derived from `onOps`/`totalChapters`), P3 (concrete test code in Tasks 4/6/8/9; e2e reference the real nav helpers + testids), P4 (`analysisSubstage` optional), P5 (no unsafe cast — always POST `allowed`), P6 (per-pass copy via `analysisBusyMessage`), P7 (debounce omission is a logged decision), P8 (popover uses the selector's `label`).
 - **Known residual ambiguities** (flagged inline, not placeholders): exact button sites in `generation.tsx` (grep-located in Task 8); whether `api.reviewScript` exposes an `onProgress` (Task 5 ships indeterminate "Reviewing · 0%" until the mock/real API emits ticks — Task 10 mock adds cadence); `enqueueQueueEntries` early-return response shape (Task 8 returns the current queue snapshot).

--- a/docs/superpowers/plans/2026-06-30-manuscript-analysis-pill-gate.md
+++ b/docs/superpowers/plans/2026-06-30-manuscript-analysis-pill-gate.md
@@ -1,0 +1,1354 @@
+# Manuscript analysis pill + Generate-gate — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface live progress of the two manuscript analysis sub-stages (Detect emotions, Review Script) inside the Status pill, hard-disable Generate per-book while either runs, make the two passes mutually exclusive per book, and guard the fs-65 auto-trigger against double-firing — with the progress synced cross-tab.
+
+**Architecture:** Two transient Redux slices (`prosody`, `scriptReview`) hold per-book progress in a `Record<bookId, SubstageEntry>` map. A new `sync:substage` `BroadcastChannel` message keeps those maps consistent across tabs. `summarizeStatus` gains an "analysis sub-stage" rung; the standalone prosody pill is retired. Generate and both analysis buttons gate on a shared `selectAnalysisBusyForBook` selector.
+
+**Tech Stack:** Vite + React 18 + TypeScript + Redux Toolkit (Immer), Vitest + React Testing Library (jsdom), Playwright (chromium, mock mode).
+
+**Source spec:** `docs/superpowers/specs/2026-06-30-manuscript-analysis-pill-gate-design.md` (two adversarial review rounds; 14 findings resolved).
+
+## Global Constraints
+
+- **Design tokens only** — no hex literals in component code; use the CSS custom properties / Tailwind tokens already in use (`--peach`, `--magenta`, `--ink`, etc.).
+- **OpenAPI is the type source of truth** — do not hand-write `Chapter`/`QueueEntry`/etc.; import from `src/lib/api-types.ts`.
+- **RTK Immer** — slice reducers mutate drafts; do not rewrite to spreads.
+- **UI copy never says "prosody"** — user-facing strings are "Detecting emotions" / "Reviewing".
+- **Branch:** all work lands on `docs/docs-manuscript-analysis-pill-gate` is the spec branch; cut a fresh `feat/frontend-analysis-pill-gate` off latest `main` for the implementation (per CONTRIBUTING branching workflow).
+- **Commit convention:** `<type>(<scope>): <subject>` — scope `frontend` for app code.
+- **Verify before declaring done:** `npm run verify` (typecheck + all tests + e2e + build).
+- **`SubstageEntry.progress` is a 0..100 integer**; `setActive`/`updateProgress` accept a 0..1 fraction and round it (preserves the current `prosody-slice` contract so call sites don't change their math).
+
+---
+
+### Task 1: Migrate `prosody-slice` to a per-book map (+ external reducers)
+
+**Files:**
+- Modify: `src/store/prosody-slice.ts` (full rewrite of the slice body)
+- Modify: `src/components/layout.tsx:163` (the `prosodyStream` selector read), `layout.tsx:1044/1048/1050/1057` (auto-trigger dispatches), `layout.tsx:1356-1362` (the `prosodyPill` derivation)
+- Test: `src/store/prosody-slice.test.ts` (rewrite for the map shape)
+
+**Interfaces:**
+- Produces:
+  - `interface SubstageEntry { progress: number; label: string }`
+  - `interface ProsodyState { activeStreams: Record<string, SubstageEntry> }`
+  - `prosodyActions.setActive({ bookId: string; progress: number; label: string })` (progress is a 0..1 fraction, stored as `Math.round(progress*100)`)
+  - `prosodyActions.updateProgress({ bookId: string; progress: number })`
+  - `prosodyActions.clear({ bookId: string })`
+  - `prosodyActions.applyExternalSet({ bookId: string; entry: SubstageEntry })`
+  - `prosodyActions.applyExternalClear({ bookId: string })`
+
+- [ ] **Step 1: Rewrite the slice test for the map shape**
+
+Replace the contents of `src/store/prosody-slice.test.ts` with:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { prosodySlice, prosodyActions, type SubstageEntry } from './prosody-slice';
+
+const reduce = (actions: { type: string; payload?: unknown }[]) =>
+  actions.reduce((s, a) => prosodySlice.reducer(s, a), prosodySlice.getInitialState());
+
+describe('prosody-slice (per-book map)', () => {
+  it('setActive stores a rounded-percent entry keyed by bookId', () => {
+    const s = reduce([prosodyActions.setActive({ bookId: 'b1', progress: 0.5, label: 'Detecting emotions' })]);
+    expect(s.activeStreams.b1).toEqual<SubstageEntry>({ progress: 50, label: 'Detecting emotions' });
+  });
+
+  it('updateProgress only touches the named book', () => {
+    const s = reduce([
+      prosodyActions.setActive({ bookId: 'b1', progress: 0, label: 'Detecting emotions' }),
+      prosodyActions.setActive({ bookId: 'b2', progress: 0, label: 'Detecting emotions' }),
+      prosodyActions.updateProgress({ bookId: 'b1', progress: 0.42 }),
+    ]);
+    expect(s.activeStreams.b1.progress).toBe(42);
+    expect(s.activeStreams.b2.progress).toBe(0);
+  });
+
+  it('clear removes only the named book, leaving others intact', () => {
+    const s = reduce([
+      prosodyActions.setActive({ bookId: 'b1', progress: 0, label: 'x' }),
+      prosodyActions.setActive({ bookId: 'b2', progress: 0, label: 'y' }),
+      prosodyActions.clear({ bookId: 'b1' }),
+    ]);
+    expect(s.activeStreams.b1).toBeUndefined();
+    expect(s.activeStreams.b2).toBeDefined();
+  });
+
+  it('applyExternalSet / applyExternalClear touch only the named key', () => {
+    const s1 = reduce([prosodyActions.applyExternalSet({ bookId: 'b9', entry: { progress: 30, label: 'Detecting emotions' } })]);
+    expect(s1.activeStreams.b9).toEqual({ progress: 30, label: 'Detecting emotions' });
+    const s2 = prosodySlice.reducer(s1, prosodyActions.applyExternalClear({ bookId: 'b9' }));
+    expect(s2.activeStreams.b9).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test -- src/store/prosody-slice.test.ts`
+Expected: FAIL — `activeStreams` undefined / `setActive` payload shape mismatch.
+
+- [ ] **Step 3: Rewrite the slice**
+
+Replace `src/store/prosody-slice.ts` with:
+
+```ts
+/* Prosody slice — transient UI-only progress for the two-pass prosody
+   annotation run (Phase 3, fs-65).
+
+   Progress is a per-book map so concurrent multi-book passes never collide.
+   Like `notifications`, this slice is TRANSIENT: UI-only, no persistence.
+   Its progress map IS broadcast cross-tab via the `sync:substage` message in
+   broadcast-middleware (Generate-gate consistency); the inbound
+   applyExternalSet/applyExternalClear reducers are deliberately NOT in the
+   middleware's outbound match set so they can't re-broadcast (echo layer 2).
+   Results land in the manuscript slice, not here. */
+
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+export interface SubstageEntry {
+  /** 0..100 integer percent. */
+  progress: number;
+  /** User-facing phase label, e.g. "Detecting emotions". */
+  label: string;
+}
+
+export interface ProsodyState {
+  activeStreams: Record<string, SubstageEntry>;
+}
+
+const initialState: ProsodyState = { activeStreams: {} };
+
+export const prosodySlice = createSlice({
+  name: 'prosody',
+  initialState,
+  reducers: {
+    setActive: (s, a: PayloadAction<{ bookId: string; progress: number; label: string }>) => {
+      s.activeStreams[a.payload.bookId] = {
+        progress: Math.round(a.payload.progress * 100),
+        label: a.payload.label,
+      };
+    },
+    updateProgress: (s, a: PayloadAction<{ bookId: string; progress: number }>) => {
+      const e = s.activeStreams[a.payload.bookId];
+      if (e) e.progress = Math.round(a.payload.progress * 100);
+    },
+    clear: (s, a: PayloadAction<{ bookId: string }>) => {
+      delete s.activeStreams[a.payload.bookId];
+    },
+    /** Inbound from broadcast — NEVER add to the outbound match set. */
+    applyExternalSet: (s, a: PayloadAction<{ bookId: string; entry: SubstageEntry }>) => {
+      s.activeStreams[a.payload.bookId] = a.payload.entry;
+    },
+    applyExternalClear: (s, a: PayloadAction<{ bookId: string }>) => {
+      delete s.activeStreams[a.payload.bookId];
+    },
+  },
+});
+
+export const prosodyActions = prosodySlice.actions;
+```
+
+- [ ] **Step 4: Update the three `layout.tsx` consumers so the app still compiles & the standalone pill still works (it's retired in Task 3)**
+
+In `src/components/layout.tsx`, change the selector at line 163:
+
+```ts
+// was: const prosodyStream = useAppSelector((s) => s.prosody.activeStream);
+const prosodyStreams = useAppSelectorShallow((s) => s.prosody.activeStreams);
+```
+
+Change the `prosodyPill` derivation (lines 1356-1362) to read the first active entry from the map:
+
+```ts
+/* Phase 3 prosody-progress pill — first active per-book entry. Retired in a
+   later task once the Status-pill rung lands; kept working here so this task
+   leaves the tree green. */
+const prosodyPill: { label: string; percent: number } | null = (() => {
+  const first = Object.values(prosodyStreams)[0];
+  return first ? { label: first.label, percent: first.progress } : null;
+})();
+```
+
+Change the auto-trigger dispatches (lines 1044/1050/1057) to the keyed `clear` and a user-facing label:
+
+```ts
+dispatch(prosodyActions.setActive({ bookId: id, progress: 0, label: 'Detecting emotions' }));
+// ...
+dispatch(prosodyActions.clear({ bookId: id }));   // success path (was clear())
+// ...
+if (pillActive) dispatch(prosodyActions.clear({ bookId: id }));  // catch path (was clear())
+```
+
+(`useAppSelectorShallow` is already imported in `layout.tsx` — see line 161.)
+
+- [ ] **Step 5: Run the slice test + typecheck**
+
+Run: `npm run test -- src/store/prosody-slice.test.ts && npm run typecheck`
+Expected: slice test PASS; typecheck PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/store/prosody-slice.ts src/store/prosody-slice.test.ts src/components/layout.tsx
+git commit -m "refactor(frontend): migrate prosody-slice to per-book activeStreams map"
+```
+
+---
+
+### Task 2: Add the `activeStreams` map to `script-review-slice`
+
+**Files:**
+- Modify: `src/store/script-review-slice.ts`
+- Test: `src/store/script-review-slice.test.ts`
+
+**Interfaces:**
+- Consumes: `SubstageEntry` from `./prosody-slice` (Task 1).
+- Produces (on `scriptReviewActions`): `setActive`, `updateProgress`, `clear`, `applyExternalSet`, `applyExternalClear` — same payload shapes as the prosody equivalents. New state field `activeStreams: Record<string, SubstageEntry>`.
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `src/store/script-review-slice.test.ts`:
+
+```ts
+import { SubstageEntry } from './prosody-slice';
+
+describe('script-review-slice activeStreams', () => {
+  const reduceR = (actions: { type: string; payload?: unknown }[]) =>
+    actions.reduce((s, a) => scriptReviewSlice.reducer(s, a), scriptReviewSlice.getInitialState());
+
+  it('setActive/updateProgress/clear are per-book', () => {
+    const s = reduceR([
+      scriptReviewActions.setActive({ bookId: 'b1', progress: 0, label: 'Reviewing' }),
+      scriptReviewActions.setActive({ bookId: 'b2', progress: 0, label: 'Reviewing' }),
+      scriptReviewActions.updateProgress({ bookId: 'b1', progress: 0.6 }),
+      scriptReviewActions.clear({ bookId: 'b2' }),
+    ]);
+    expect(s.activeStreams.b1).toEqual<SubstageEntry>({ progress: 60, label: 'Reviewing' });
+    expect(s.activeStreams.b2).toBeUndefined();
+  });
+
+  it('applyExternalSet/applyExternalClear touch only the named key', () => {
+    const s1 = reduceR([scriptReviewActions.applyExternalSet({ bookId: 'bX', entry: { progress: 10, label: 'Reviewing' } })]);
+    expect(s1.activeStreams.bX).toEqual({ progress: 10, label: 'Reviewing' });
+    const s2 = scriptReviewSlice.reducer(s1, scriptReviewActions.applyExternalClear({ bookId: 'bX' }));
+    expect(s2.activeStreams.bX).toBeUndefined();
+  });
+});
+```
+
+(Ensure `scriptReviewSlice` and `scriptReviewActions` are imported at the top of the test file — they already are for the existing `byBook` tests.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test -- src/store/script-review-slice.test.ts`
+Expected: FAIL — `setActive` / `activeStreams` don't exist.
+
+- [ ] **Step 3: Implement**
+
+In `src/store/script-review-slice.ts`:
+
+Add the import and extend the state interface + initial state:
+
+```ts
+import type { SubstageEntry } from './prosody-slice';
+```
+
+```ts
+export interface ScriptReviewState {
+  byBook: Record<string, ScriptReviewBucket | undefined>;
+  activeStreams: Record<string, SubstageEntry>;
+}
+
+const initialState: ScriptReviewState = {
+  byBook: {},
+  activeStreams: {},
+};
+```
+
+Add these reducers inside the existing `reducers: { ... }` object (alongside `setReview`/`toggleOp`/...):
+
+```ts
+    setActive: (s, a: PayloadAction<{ bookId: string; progress: number; label: string }>) => {
+      s.activeStreams[a.payload.bookId] = {
+        progress: Math.round(a.payload.progress * 100),
+        label: a.payload.label,
+      };
+    },
+    updateProgress: (s, a: PayloadAction<{ bookId: string; progress: number }>) => {
+      const e = s.activeStreams[a.payload.bookId];
+      if (e) e.progress = Math.round(a.payload.progress * 100);
+    },
+    clear: (s, a: PayloadAction<{ bookId: string }>) => {
+      delete s.activeStreams[a.payload.bookId];
+    },
+    applyExternalSet: (s, a: PayloadAction<{ bookId: string; entry: SubstageEntry }>) => {
+      s.activeStreams[a.payload.bookId] = a.payload.entry;
+    },
+    applyExternalClear: (s, a: PayloadAction<{ bookId: string }>) => {
+      delete s.activeStreams[a.payload.bookId];
+    },
+```
+
+Update the slice header comment's "non-broadcast" note to: "the activeStreams progress map IS broadcast cross-tab via sync:substage; byBook results stay tab-local."
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm run test -- src/store/script-review-slice.test.ts && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/script-review-slice.ts src/store/script-review-slice.test.ts
+git commit -m "feat(frontend): add per-book activeStreams progress map to script-review-slice"
+```
+
+---
+
+### Task 3: Selectors + `summarizeStatus` rung + retire the standalone pill
+
+**Files:**
+- Create: `src/store/analysis-substage-selectors.ts`
+- Modify: `src/components/top-bar.tsx` (`StatusInput`, `summarizeStatus`, `StatusDetail`)
+- Modify: `src/components/layout.tsx` (compute `analysisSubstage`, pass to `summarizeStatus` + `statusDetail`; delete the `prosodyPill` derivation + its JSX block)
+- Modify: `src/components/status-popover.tsx` (render the sub-stage row)
+- Delete: `src/components/layout-prosody-pill.test.tsx`
+- Modify: `e2e/analysis-prosody-toggle.spec.ts` (re-point off `prosody-pill`)
+- Test: `src/store/analysis-substage-selectors.test.ts`, `src/components/top-bar.test.tsx`
+
+**Interfaces:**
+- Consumes: `prosody.activeStreams`, `scriptReview.activeStreams` (Tasks 1-2).
+- Produces:
+  - `selectProsodyRunningForBook(state, bookId): boolean`
+  - `selectReviewRunningForBook(state, bookId): boolean`
+  - `selectAnalysisBusyForBook(state, bookId): boolean`
+  - `selectAnalysisSubstage(state): { kind: 'prosody' | 'review'; label: string; percent: number } | null` (memoized)
+  - `StatusInput` gains `analysisSubstage: { kind: 'prosody' | 'review'; percent: number } | null`.
+
+- [ ] **Step 1: Write the selector test**
+
+Create `src/store/analysis-substage-selectors.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  selectProsodyRunningForBook,
+  selectReviewRunningForBook,
+  selectAnalysisBusyForBook,
+  selectAnalysisSubstage,
+} from './analysis-substage-selectors';
+import type { RootState } from './index';
+
+const mk = (prosody: Record<string, { progress: number; label: string }>, review: Record<string, { progress: number; label: string }>) =>
+  ({ prosody: { activeStreams: prosody }, scriptReview: { activeStreams: review } } as unknown as RootState);
+
+describe('analysis-substage selectors', () => {
+  it('per-book running flags', () => {
+    const s = mk({ b1: { progress: 10, label: 'Detecting emotions' } }, { b2: { progress: 5, label: 'Reviewing' } });
+    expect(selectProsodyRunningForBook(s, 'b1')).toBe(true);
+    expect(selectProsodyRunningForBook(s, 'b2')).toBe(false);
+    expect(selectReviewRunningForBook(s, 'b2')).toBe(true);
+    expect(selectAnalysisBusyForBook(s, 'b1')).toBe(true);
+    expect(selectAnalysisBusyForBook(s, 'b2')).toBe(true);
+    expect(selectAnalysisBusyForBook(s, 'b3')).toBe(false);
+  });
+
+  it('selectAnalysisSubstage prefers prosody, then lowest bookId', () => {
+    const s = mk(
+      { b2: { progress: 40, label: 'Detecting emotions' }, b1: { progress: 70, label: 'Detecting emotions' } },
+      { b9: { progress: 5, label: 'Reviewing' } },
+    );
+    expect(selectAnalysisSubstage(s)).toEqual({ kind: 'prosody', label: 'Detecting emotions', percent: 70 });
+  });
+
+  it('falls back to review when no prosody runs; null when idle', () => {
+    expect(selectAnalysisSubstage(mk({}, { b5: { progress: 12, label: 'Reviewing' } }))).toEqual({
+      kind: 'review',
+      label: 'Reviewing',
+      percent: 12,
+    });
+    expect(selectAnalysisSubstage(mk({}, {}))).toBeNull();
+  });
+
+  it('selectAnalysisSubstage returns a stable reference for unchanged input (memoized)', () => {
+    const s = mk({ b1: { progress: 40, label: 'Detecting emotions' } }, {});
+    expect(selectAnalysisSubstage(s)).toBe(selectAnalysisSubstage(s));
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test -- src/store/analysis-substage-selectors.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the selectors**
+
+Create `src/store/analysis-substage-selectors.ts`:
+
+```ts
+import { createSelector } from '@reduxjs/toolkit';
+import type { RootState } from './index';
+import type { SubstageEntry } from './prosody-slice';
+
+export const selectProsodyRunningForBook = (state: RootState, bookId: string): boolean =>
+  bookId in state.prosody.activeStreams;
+
+export const selectReviewRunningForBook = (state: RootState, bookId: string): boolean =>
+  bookId in state.scriptReview.activeStreams;
+
+export const selectAnalysisBusyForBook = (state: RootState, bookId: string): boolean =>
+  selectProsodyRunningForBook(state, bookId) || selectReviewRunningForBook(state, bookId);
+
+const firstByLowestBookId = (m: Record<string, SubstageEntry>): { bookId: string; entry: SubstageEntry } | null => {
+  const ids = Object.keys(m).sort();
+  return ids.length ? { bookId: ids[0], entry: m[ids[0]] } : null;
+};
+
+/** Memoized so an unchanged map returns a stable reference (avoids the
+    "selector returned a different result" re-render churn). Prefers a prosody
+    pass over a review pass; ties broken by lowest bookId. */
+export const selectAnalysisSubstage = createSelector(
+  [(s: RootState) => s.prosody.activeStreams, (s: RootState) => s.scriptReview.activeStreams],
+  (prosody, review): { kind: 'prosody' | 'review'; label: string; percent: number } | null => {
+    const p = firstByLowestBookId(prosody);
+    if (p) return { kind: 'prosody', label: p.entry.label, percent: p.entry.progress };
+    const r = firstByLowestBookId(review);
+    if (r) return { kind: 'review', label: r.entry.label, percent: r.entry.progress };
+    return null;
+  },
+);
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm run test -- src/store/analysis-substage-selectors.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Add the `summarizeStatus` rung test**
+
+In `src/components/top-bar.test.tsx`, inside the existing `summarizeStatus` describe block, add:
+
+```ts
+it('shows an Analysing rung for an active analysis sub-stage (below real analysis)', () => {
+  const base = { analysis: null, generation: null, design: null, pendingRevisionsCount: 0, anyModelLoading: false };
+  expect(summarizeStatus({ ...base, analysisSubstage: { kind: 'prosody', percent: 40 } })).toMatchObject({
+    label: 'Analysing',
+    detail: '40%',
+    icon: 'spinner',
+  });
+  // Real analysis still outranks a sub-stage.
+  expect(
+    summarizeStatus({
+      ...base,
+      analysis: { state: 'running', percent: 12, kind: 'full' } as never,
+      analysisSubstage: { kind: 'review', percent: 90 },
+    }),
+  ).toMatchObject({ detail: '12%' });
+});
+```
+
+(If existing `summarizeStatus` calls in this file omit `analysisSubstage`, add `analysisSubstage: null` to their input objects — TypeScript will flag the missing field.)
+
+- [ ] **Step 6: Run to verify it fails**
+
+Run: `npm run test -- top-bar.test.tsx`
+Expected: FAIL — `analysisSubstage` not a valid `StatusInput` field.
+
+- [ ] **Step 7: Implement the rung**
+
+In `src/components/top-bar.tsx`, add to the `StatusInput` interface (after `anyModelLoading`):
+
+```ts
+  /** The active analysis sub-stage (prosody/review) progress, or null. Folds
+      into the "Analysing" rung below the primary analysis pass. */
+  analysisSubstage: { kind: 'prosody' | 'review'; percent: number } | null;
+```
+
+Add `analysisSubstage` to the destructured params of `summarizeStatus`, and insert the rung **directly after** the `analysis?.state === 'running'` block (and before `design?.state === 'running'`):
+
+```ts
+  if (analysisSubstage)
+    return { label: 'Analysing', tone: 'peach', icon: 'spinner', detail: `${analysisSubstage.percent}%` };
+```
+
+Add `analysisSubstage` to the `StatusDetail` interface too:
+
+```ts
+  analysisSubstage: { kind: 'prosody' | 'review'; percent: number } | null;
+```
+
+- [ ] **Step 8: Wire Layout, render the popover row, and retire the standalone pill**
+
+In `src/components/layout.tsx`:
+
+Add the selector read near the other status selectors (after line 163):
+
+```ts
+const analysisSubstage = useAppSelector(selectAnalysisSubstage);
+```
+
+(Import it: `import { selectAnalysisSubstage } from '../store/analysis-substage-selectors';`)
+
+Pass it into both `summarizeStatus` and `statusDetail`:
+
+```ts
+  const statusSummary = showStatus
+    ? summarizeStatus({
+        analysis: analysisPill,
+        generation: generationPill,
+        design: designPill,
+        pendingRevisionsCount: pending.length,
+        anyModelLoading,
+        analysisSubstage: analysisSubstage ? { kind: analysisSubstage.kind, percent: analysisSubstage.percent } : null,
+      })
+    : null;
+```
+
+Add `analysisSubstage: analysisSubstage ? { kind: analysisSubstage.kind, percent: analysisSubstage.percent } : null,` to the `statusDetail` object literal (line 1429+).
+
+Also update `showStatus` so the pill appears when a sub-stage is the only activity:
+
+```ts
+  const showStatus =
+    showTtsControls ||
+    analysisPill !== null ||
+    generationPill !== null ||
+    designPill !== null ||
+    analysisSubstage !== null ||
+    pending.length > 0;
+```
+
+Delete the `prosodyPill` derivation (the lines 1356-1362 block you edited in Task 1) AND the `{prosodyPill && ( ... )}` JSX block at lines 1515-1525. Remove the now-unused `prosodyStreams` selector from line 163 if nothing else uses it (the popover reads the substage selector instead).
+
+In `src/components/status-popover.tsx`, render a sub-stage row inside the analysis section when `detail.analysisSubstage` is set:
+
+```tsx
+{detail.analysisSubstage && (
+  <div data-testid="substage-row" className="flex items-center justify-between text-sm text-ink/70">
+    <span>{detail.analysisSubstage.kind === 'prosody' ? 'Detecting emotions' : 'Reviewing'}</span>
+    <span className="tabular-nums">{detail.analysisSubstage.percent}%</span>
+  </div>
+)}
+```
+
+(Place it adjacent to the existing `AnalysisPill` render in the analysis section.)
+
+- [ ] **Step 9: Delete the standalone-pill unit test and re-point the e2e**
+
+Delete `src/components/layout-prosody-pill.test.tsx`.
+
+In `e2e/analysis-prosody-toggle.spec.ts`, replace any `getByTestId('prosody-pill')` assertion with the Status-pill path. Read the spec first; the substage now surfaces on the top-bar Status pill (`getByTestId('status-pill')`, label "Analysing") and its popover row (`getByTestId('substage-row')`). If the spec only asserted the toggle (enable/disable prosody) and used the pill as a progress proxy, assert on `substage-row` after opening the Status popover instead.
+
+- [ ] **Step 10: Run the affected tests + typecheck**
+
+Run: `npm run test -- top-bar.test.tsx src/store/analysis-substage-selectors.test.ts && npm run typecheck`
+Expected: PASS. (Confirm `layout-prosody-pill.test.tsx` is gone, not failing.)
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/store/analysis-substage-selectors.ts src/store/analysis-substage-selectors.test.ts src/components/top-bar.tsx src/components/top-bar.test.tsx src/components/layout.tsx src/components/status-popover.tsx e2e/analysis-prosody-toggle.spec.ts
+git rm src/components/layout-prosody-pill.test.tsx
+git commit -m "feat(frontend): fold analysis sub-stage progress into the Status pill"
+```
+
+---
+
+### Task 4: Manual `DetectEmotionsButton` drives the slice (clear in `finally`)
+
+**Files:**
+- Modify: `src/components/detect-emotions-button.tsx`
+- Test: `src/components/detect-emotions-button.test.tsx`
+
+**Interfaces:**
+- Consumes: `prosodyActions.setActive/updateProgress/clear` (Task 1); `runProsodyPasses` (existing).
+
+- [ ] **Step 1: Add a failing test**
+
+In `src/components/detect-emotions-button.test.tsx`, add a test that the button drives the slice and clears on error. Use the store + a mocked `runProsodyPasses`:
+
+```ts
+import { vi } from 'vitest';
+vi.mock('../store/prosody-thunk', () => ({
+  runProsodyPasses: vi.fn(async (_bookId, opts) => {
+    opts.onProgress?.(0.5);
+    throw new Error('boom'); // exercise the error path
+  }),
+}));
+```
+
+```ts
+it('sets and clears the prosody stream around a (failing) run', async () => {
+  // render with a store whose ui.stage.bookId === 'b1', click the confirm button…
+  // (follow the existing render helper in this file)
+  // after the run rejects:
+  const state = store.getState();
+  expect(state.prosody.activeStreams.b1).toBeUndefined(); // cleared in finally despite the throw
+});
+```
+
+(Model the render + confirm-click on the existing tests in this file. The key assertion is that `prosody.activeStreams[bookId]` is set while running and **absent after** even though `runProsodyPasses` threw.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test -- detect-emotions-button.test.tsx`
+Expected: FAIL — stream never set / not cleared on throw.
+
+- [ ] **Step 3: Implement**
+
+In `src/components/detect-emotions-button.tsx`, rewrite the `run` body so the pill is driven from the slice and cleared in `finally`:
+
+```ts
+  const run = async () => {
+    if (!bookId) return;
+    setPhase('running');
+    setProgress(0);
+    setError(null);
+    setStatus('Starting…');
+    const controller = new AbortController();
+    abortRef.current = controller;
+    dispatch(prosodyActions.setActive({ bookId, progress: 0, label: 'Detecting emotions' }));
+    try {
+      const { totalAnnotations, totalChapters } = await runProsodyPasses(bookId, {
+        dispatch,
+        signal: controller.signal,
+        onProgress: (fraction) => {
+          setProgress(fraction);
+          dispatch(prosodyActions.updateProgress({ bookId, progress: fraction }));
+        },
+        onStatus: (label) => setStatus(label),
+        onThrottle: () => setStatus('Waiting on the analyzer rate limit…'),
+      });
+      setStatus(
+        `Tagged ${totalAnnotations} line${totalAnnotations === 1 ? '' : 's'} across ` +
+          `${totalChapters} chapter${totalChapters === 1 ? '' : 's'}.`,
+      );
+      setPhase('idle');
+    } catch (e) {
+      if ((e as Error).name === 'AbortError') {
+        setStatus(null);
+        setPhase('idle');
+      } else if (e instanceof DetectEmotionsError && e.code === 'no_attribution') {
+        setError('Run analysis first — there are no attributed lines to tag.');
+        setPhase('idle');
+      } else if (e instanceof DetectInstructError) {
+        setError(e.message);
+        setPhase('idle');
+      } else {
+        setError((e as Error).message);
+        setPhase('idle');
+      }
+    } finally {
+      dispatch(prosodyActions.clear({ bookId }));
+      abortRef.current = null;
+    }
+  };
+```
+
+Add the import: `import { prosodyActions } from '../store/prosody-slice';`
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm run test -- detect-emotions-button.test.tsx && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/detect-emotions-button.tsx src/components/detect-emotions-button.test.tsx
+git commit -m "feat(frontend): drive the prosody pill from DetectEmotionsButton, clear in finally"
+```
+
+---
+
+### Task 5: `runReviewScript` thunk (clear in `finally`) + delegate `handleReviewScript`
+
+**Files:**
+- Create: `src/store/script-review-thunk.ts`
+- Modify: `src/views/manuscript.tsx` (`handleReviewScript` delegates to the thunk)
+- Test: `src/store/script-review-thunk.test.ts`
+
+**Interfaces:**
+- Consumes: `scriptReviewActions.setActive/updateProgress/clear/setReview`, `api.reviewScript`, `planApply`, `notificationsActions`.
+- Produces: `runReviewScript(bookId, { wholeBook, chapterId?, model, sentences, characterIds }): Promise<void>` — a plain async function (matches `runProsodyPasses`' shape: takes `dispatch` in its options bag, not a thunk-creator).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/store/script-review-thunk.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const reviewScript = vi.fn();
+vi.mock('../lib/api', () => ({ api: { reviewScript: (...a: unknown[]) => reviewScript(...a) } }));
+vi.mock('../lib/script-review-apply', () => ({
+  planApply: () => ({ appliable: [], unappliable: [] }),
+}));
+
+import { runReviewScript } from './script-review-thunk';
+import { scriptReviewActions } from './script-review-slice';
+
+describe('runReviewScript', () => {
+  beforeEach(() => reviewScript.mockReset());
+
+  it('sets active, then clears in finally on success', async () => {
+    reviewScript.mockResolvedValue(undefined);
+    const dispatch = vi.fn();
+    await runReviewScript('b1', { dispatch, wholeBook: true, model: 'gemma', sentences: [], characterIds: new Set<number>() });
+    const types = dispatch.mock.calls.map((c) => c[0].type);
+    expect(types).toContain(scriptReviewActions.setActive.type);
+    expect(types[types.length - 1]).toBe(scriptReviewActions.clear.type);
+  });
+
+  it('clears in finally even when the API throws', async () => {
+    reviewScript.mockRejectedValue(new Error('boom'));
+    const dispatch = vi.fn();
+    await runReviewScript('b1', { dispatch, wholeBook: true, model: 'gemma', sentences: [], characterIds: new Set<number>() });
+    const types = dispatch.mock.calls.map((c) => c[0].type);
+    expect(types[types.length - 1]).toBe(scriptReviewActions.clear.type);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test -- src/store/script-review-thunk.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the thunk**
+
+Create `src/store/script-review-thunk.ts`. Lift the body of `handleReviewScript` (`manuscript.tsx:697-758`) into a reusable function, adding the `setActive`/`updateProgress`/`clear({bookId})` dispatches with `clear` in `finally`:
+
+```ts
+import type { AppDispatch } from './index';
+import { api } from '../lib/api';
+import { planApply, type ReviewOp } from '../lib/script-review-apply';
+import { scriptReviewActions, type ReviewOpWithChapter } from './script-review-slice';
+import { notificationsActions } from './notifications-slice';
+
+export interface ReviewLiveSentence {
+  id: number;
+  chapterId: number;
+  text: string;
+  characterId: number | null;
+  instruct?: string;
+  vocalization?: string;
+}
+
+export interface RunReviewScriptOpts {
+  dispatch: AppDispatch;
+  wholeBook: boolean;
+  chapterId?: number;
+  model: string;
+  /** Live sentences for index-mapped planApply (caller passes sentencesRef.current). */
+  sentences: ReviewLiveSentence[];
+  characterIds: Set<number>;
+}
+
+export async function runReviewScript(bookId: string, opts: RunReviewScriptOpts): Promise<void> {
+  const { dispatch, wholeBook, chapterId, model, sentences, characterIds } = opts;
+  const allOps: ReviewOpWithChapter[] = [];
+  const failed: Array<{ chapterId: number; message: string }> = [];
+  dispatch(scriptReviewActions.setActive({ bookId, progress: 0, label: 'Reviewing' }));
+  try {
+    await api.reviewScript(bookId, {
+      ...(wholeBook ? {} : { chapterId }),
+      model,
+      onOps: ({ chapterId: chId, ops }: { chapterId: number; ops: ReviewOp[] }) => {
+        for (const op of ops) allOps.push({ ...op, chapterId: chId });
+      },
+      onChapterFailed: (e: { chapterId: number; message: string }) => failed.push(e),
+    });
+    const { appliable, unappliable } = planApply(allOps, sentences, characterIds) as {
+      appliable: ReviewOpWithChapter[];
+      unappliable: Array<{ op: ReviewOpWithChapter; reason: string }>;
+    };
+    if (appliable.length === 0 && unappliable.length === 0 && failed.length > 0) {
+      dispatch(
+        notificationsActions.pushToast({
+          kind: 'warn',
+          message: failed.length === 1 ? failed[0].message : `${failed.length} chapters couldn't be reviewed (too large or failed).`,
+        }),
+      );
+    } else {
+      if (failed.length > 0) {
+        dispatch(notificationsActions.pushToast({ kind: 'warn', message: `${failed.length} chapter(s) skipped; showing the rest.` }));
+      }
+      dispatch(scriptReviewActions.setReview({ bookId, ops: appliable, unappliable }));
+    }
+  } catch (err) {
+    dispatch(
+      notificationsActions.pushToast({
+        kind: 'error',
+        message: err instanceof Error ? err.message : 'Script review failed.',
+      }),
+    );
+  } finally {
+    dispatch(scriptReviewActions.clear({ bookId }));
+  }
+}
+```
+
+(If `api.reviewScript` has no progress callback today, `updateProgress` isn't dispatched yet — the pill shows an indeterminate "Reviewing · 0%". Step 4 of Task 9 extends `mockReviewScript` to emit progress; if the real `api.reviewScript` gains an `onProgress`, wire it the same way as `runProsodyPasses`.)
+
+- [ ] **Step 4: Delegate from `manuscript.tsx`**
+
+Replace the body of `handleReviewScript` (`manuscript.tsx:697-758`) with a thin delegate:
+
+```ts
+  async function handleReviewScript(wholeBook: boolean) {
+    if (!bookId || reviewLoading) return;
+    if (!wholeBook && currentChapterId == null) return;
+    setReviewLoading(true);
+    setReviewMenuOpen(false);
+    try {
+      await runReviewScript(bookId, {
+        dispatch,
+        wholeBook,
+        chapterId: wholeBook ? undefined : currentChapterId ?? undefined,
+        model: reviewModel,
+        sentences: sentencesRef.current.map((s) => ({
+          id: s.id,
+          chapterId: s.chapterId,
+          text: s.text,
+          characterId: s.characterId,
+          instruct: s.instruct,
+          vocalization: s.vocalization,
+        })),
+        characterIds: new Set(characters.map((c) => c.id)),
+      });
+    } finally {
+      setReviewLoading(false);
+    }
+  }
+```
+
+Add the import: `import { runReviewScript } from '../store/script-review-thunk';`. Remove now-unused imports in `manuscript.tsx` that the lifted code orphaned (e.g. `planApply` if nothing else uses it — verify with a grep before deleting).
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `npm run test -- src/store/script-review-thunk.test.ts && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/store/script-review-thunk.ts src/store/script-review-thunk.test.ts src/views/manuscript.tsx
+git commit -m "feat(frontend): extract runReviewScript thunk that drives the review pill"
+```
+
+---
+
+### Task 6: Pass mutual-exclusion (both analysis buttons gate per book)
+
+**Files:**
+- Modify: `src/components/detect-emotions-button.tsx` (disable when busy)
+- Modify: `src/views/manuscript.tsx` (the three Review buttons disable when busy)
+- Test: `src/components/detect-emotions-button.test.tsx`, a manuscript review-button test
+
+**Interfaces:**
+- Consumes: `selectAnalysisBusyForBook` (Task 3).
+
+- [ ] **Step 1: Write the failing tests**
+
+In `detect-emotions-button.test.tsx`, add: when `scriptReview.activeStreams[bookId]` is set (a review running), the Detect-emotions trigger button is `disabled`. In a manuscript test, add: when `prosody.activeStreams[bookId]` is set, `getByTestId('review-script-chapter')` is `disabled`, and a different book's button is not.
+
+```ts
+it('disables Detect emotions while a review runs on the same book', () => {
+  // store with scriptReview.activeStreams = { b1: { progress: 5, label: 'Reviewing' } }, ui.stage.bookId = 'b1'
+  // render <DetectEmotionsButton />
+  expect(screen.getByRole('button', { name: /detect emotions/i })).toBeDisabled();
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test -- detect-emotions-button.test.tsx`
+Expected: FAIL — button enabled.
+
+- [ ] **Step 3: Implement**
+
+In `detect-emotions-button.tsx`, read the busy flag and fold it into the rendered button's `disabled`:
+
+```ts
+const busy = useAppSelector((s) => (bookId ? selectAnalysisBusyForBook(s, bookId) : false));
+```
+
+In the idle-render `<button>`, change `disabled={disabled}` to `disabled={disabled || busy}`. Import `selectAnalysisBusyForBook`.
+
+In `manuscript.tsx`, near the existing `reviewLoading` state, add:
+
+```ts
+const analysisBusy = useAppSelector((s) => (bookId ? selectAnalysisBusyForBook(s, bookId) : false));
+```
+
+Change each of the three Review buttons' `disabled={reviewLoading || !bookId}` (lines 827/835/850) to `disabled={reviewLoading || !bookId || analysisBusy}`. Import the selector.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm run test -- detect-emotions-button.test.tsx && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/detect-emotions-button.tsx src/components/detect-emotions-button.test.tsx src/views/manuscript.tsx
+git commit -m "feat(frontend): make the two analysis passes mutually exclusive per book"
+```
+
+---
+
+### Task 7: `shouldAutoTriggerProsody` + auto-trigger guard
+
+**Files:**
+- Create: `src/store/should-auto-trigger-prosody.ts`
+- Modify: `src/components/layout.tsx` (auto-trigger effect calls it)
+- Test: `src/store/should-auto-trigger-prosody.test.ts`, `src/store/prosody-autotrigger.test.tsx` (update)
+
+**Interfaces:**
+- Consumes: `selectAnalysisBusyForBook` (Task 3).
+- Produces: `shouldAutoTriggerProsody(state: RootState, bookId: string): boolean`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/store/should-auto-trigger-prosody.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { shouldAutoTriggerProsody } from './should-auto-trigger-prosody';
+import type { RootState } from './index';
+
+const mk = (prosody = {}, review = {}) =>
+  ({ prosody: { activeStreams: prosody }, scriptReview: { activeStreams: review } } as unknown as RootState);
+
+describe('shouldAutoTriggerProsody', () => {
+  it('true when idle', () => expect(shouldAutoTriggerProsody(mk(), 'b1')).toBe(true));
+  it('false when prosody runs for the book', () =>
+    expect(shouldAutoTriggerProsody(mk({ b1: { progress: 0, label: 'x' } }), 'b1')).toBe(false));
+  it('false when review runs for the book', () =>
+    expect(shouldAutoTriggerProsody(mk({}, { b1: { progress: 0, label: 'x' } }), 'b1')).toBe(false));
+  it('true when another book is busy', () =>
+    expect(shouldAutoTriggerProsody(mk({ b2: { progress: 0, label: 'x' } }), 'b1')).toBe(true));
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test -- src/store/should-auto-trigger-prosody.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `src/store/should-auto-trigger-prosody.ts`:
+
+```ts
+import type { RootState } from './index';
+import { selectAnalysisBusyForBook } from './analysis-substage-selectors';
+
+/** Pure in-memory gate for the fs-65 auto-trigger: don't fire while any
+    analysis sub-stage is already running for this book (manual button or a
+    cross-tab broadcast). The disk `prosodyAnnotated` watermark remains the
+    separate "already done" gate, checked async in the effect. */
+export function shouldAutoTriggerProsody(state: RootState, bookId: string): boolean {
+  return !selectAnalysisBusyForBook(state, bookId);
+}
+```
+
+- [ ] **Step 4: Wire it into the auto-trigger effect**
+
+In `src/components/layout.tsx`, inside the detached async job (after `prosodyConsidered.current.add(id)`, before/after the `api.getBookState` gate), add the in-memory guard. Use the store's `getState` (Layout has `store` via `useStore`, or read through a ref). Simplest: read via the `useStore()` hook already available, or capture a `store` reference. Add at the top of the async body:
+
+```ts
+        if (!shouldAutoTriggerProsody(store.getState(), id)) return; // already running here / cross-tab
+```
+
+(If `store` isn't in scope, add `const store = useStore<RootState>();` near the other hooks and `import { useStore } from 'react-redux';`.) Import `shouldAutoTriggerProsody`.
+
+Also make the auto-trigger's clear finally-safe — wrap the existing try/catch so `clear({ bookId: id })` runs once on all paths:
+
+```ts
+        let pillActive = false;
+        try {
+          const st = await api.getBookState(id);
+          if (!st || st.state.prosodyEnabled === false) return;
+          if (st.state.prosodyAnnotated) return;
+          dispatch(prosodyActions.setActive({ bookId: id, progress: 0, label: 'Detecting emotions' }));
+          pillActive = true;
+          const { failed } = await runProsodyPasses(id, {
+            dispatch,
+            onProgress: (f) => dispatch(prosodyActions.updateProgress({ bookId: id, progress: f })),
+          });
+          if (failed === 0) {
+            await api.putBookState(id, { slice: 'state', patch: { prosodyAnnotated: true } });
+          } else {
+            prosodyConsidered.current.delete(id);
+          }
+        } catch {
+          prosodyConsidered.current.delete(id);
+        } finally {
+          if (pillActive) dispatch(prosodyActions.clear({ bookId: id }));
+        }
+```
+
+- [ ] **Step 5: Update the auto-trigger integration test**
+
+In `src/store/prosody-autotrigger.test.tsx`, add a case: when `prosody.activeStreams[bookId]` is already set before the complete-transition fires, `runProsodyPasses` is NOT called again for that book. (Mock `runProsodyPasses`; pre-seed the store; assert call count stays 0.)
+
+- [ ] **Step 6: Run to verify**
+
+Run: `npm run test -- src/store/should-auto-trigger-prosody.test.ts src/store/prosody-autotrigger.test.tsx && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/store/should-auto-trigger-prosody.ts src/store/should-auto-trigger-prosody.test.ts src/store/prosody-autotrigger.test.tsx src/components/layout.tsx
+git commit -m "feat(frontend): guard the prosody auto-trigger against double-fire"
+```
+
+---
+
+### Task 8: Generate-gate (UI disable + enqueue thunk filter)
+
+**Files:**
+- Modify: `src/views/generation.tsx` (disable Generate/regenerate for a busy book)
+- Modify: `src/store/queue-thunks.ts` (`enqueueQueueEntries` filters gated entries)
+- Test: `src/store/queue-thunks.test.ts` (guard), e2e in Task 9
+
+**Interfaces:**
+- Consumes: `selectAnalysisBusyForBook` (Task 3).
+
+- [ ] **Step 1: Write the failing thunk test**
+
+In `src/store/queue-thunks.test.ts` (create if absent), add: `enqueueQueueEntries` drops entries whose book is busy and toasts, enqueuing only the rest.
+
+```ts
+it('filters out entries whose book has an active analysis sub-stage', async () => {
+  const dispatch = vi.fn();
+  const getState = () =>
+    ({ prosody: { activeStreams: { b1: { progress: 0, label: 'x' } } }, scriptReview: { activeStreams: {} } }) as never;
+  // mock queueRequest/readSnapshot to echo back the posted entries…
+  await enqueueQueueEntries([
+    { id: 'e1', bookId: 'b1', chapterId: 1, scope: 'this' },
+    { id: 'e2', bookId: 'b2', chapterId: 1, scope: 'this' },
+  ])(dispatch as never, getState as never, undefined as never);
+  // assert only the b2 entry was POSTed, and a warn toast naming b1 fired.
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test -- src/store/queue-thunks.test.ts`
+Expected: FAIL — guard not present / `getState` unused.
+
+- [ ] **Step 3: Implement the thunk guard**
+
+In `src/store/queue-thunks.ts`, give `enqueueQueueEntries` access to `getState` and filter:
+
+```ts
+import { selectAnalysisBusyForBook } from './analysis-substage-selectors';
+
+export function enqueueQueueEntries(entries: EnqueueInput[], opts: { silent?: boolean } = {}) {
+  return async (dispatch: AppDispatch, getState: () => RootState): Promise<QueueSnapshotResponse> => {
+    const state = getState();
+    const gated = entries.filter((e) => selectAnalysisBusyForBook(state, e.bookId));
+    const allowed = entries.filter((e) => !selectAnalysisBusyForBook(state, e.bookId));
+    if (gated.length > 0) {
+      dispatch(
+        notificationsActions.pushToast({
+          kind: 'warn',
+          message: 'Wait — analysis is still running on this book.',
+          dedupeKey: 'gen-gated-by-analysis',
+        }),
+      );
+    }
+    if (allowed.length === 0) {
+      return getState().queue as unknown as QueueSnapshotResponse; // nothing to enqueue
+    }
+    const res = await queueRequest('/api/queue/enqueue', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ entries: allowed }),
+    });
+    const snapshot = await readSnapshot(res);
+    dispatch(queueActions.setSnapshot(snapshot));
+    if (!opts.silent) {
+      const count = snapshot.entries.length;
+      dispatch(
+        notificationsActions.pushToast({
+          kind: 'info',
+          message: `Added to queue · ${count} ${count === 1 ? 'entry' : 'entries'} pending.`,
+          dedupeKey: 'queue-enqueue',
+        }),
+      );
+    }
+    return snapshot;
+  };
+}
+```
+
+(Import `RootState` from `./index` if not already. The `allowed.length === 0` early-return shape: return the current queue snapshot so callers awaiting a `QueueSnapshotResponse` don't break — adjust to whatever the existing `QueueState`→response shape is; if simpler, return `{ entries: getState().queue.entries, ... }`.)
+
+- [ ] **Step 4: Disable the Generate UI**
+
+In `src/views/generation.tsx`, read the busy flag near the top of the component:
+
+```ts
+const analysisBusy = useAppSelector((s) => (bookId ? selectAnalysisBusyForBook(s, bookId) : false));
+```
+
+Guard `handleGenerateChapter` and disable the primary Generate / bulk-regenerate buttons. At minimum, early-return + toast inside `handleGenerateChapter`:
+
+```ts
+  function handleGenerateChapter(ch: Chapter): void {
+    if (analysisBusy) {
+      dispatch(notificationsActions.pushToast({ kind: 'warn', message: 'Wait — analysis is still running on this book.', dedupeKey: 'gen-gated-by-analysis' }));
+      return;
+    }
+    // …existing body…
+  }
+```
+
+And add `disabled={analysisBusy || …}` to the rendered Generate / "Generate all" / RegenerateModal-confirm buttons (grep `enqueueQueueEntries`/`onRegenerate`/`Generate` within `generation.tsx` for the button sites). Import `selectAnalysisBusyForBook` + `notificationsActions`.
+
+- [ ] **Step 5: Run to verify**
+
+Run: `npm run test -- src/store/queue-thunks.test.ts && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/store/queue-thunks.ts src/store/queue-thunks.test.ts src/views/generation.tsx
+git commit -m "feat(frontend): gate Generate while a book's analysis sub-stage runs"
+```
+
+---
+
+### Task 9: Cross-tab broadcast (`sync:substage`)
+
+**Files:**
+- Modify: `src/store/broadcast-middleware.ts`
+- Test: `src/store/broadcast-middleware.test.ts`
+
+**Interfaces:**
+- Consumes: `prosodyActions.applyExternalSet/applyExternalClear`, `scriptReviewActions.applyExternalSet/applyExternalClear`, `SubstageEntry`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/store/broadcast-middleware.test.ts`, add cases using `createBroadcastMiddleware({ channel })` with a mock channel (mirror the existing analysis/chapters tests in this file):
+
+```ts
+it('broadcasts sync:substage set on prosody/setActive and clear on prosody/clear', () => {
+  // build middleware with a mock channel that records postMessage payloads
+  // dispatch prosodyActions.setActive({ bookId: 'b1', progress: 0.4, label: 'Detecting emotions' })
+  // expect a posted { kind: 'sync:substage', stream: 'prosody', bookId: 'b1', mode: 'set', entry: { progress: 40, label: 'Detecting emotions' } }
+  // dispatch prosodyActions.clear({ bookId: 'b1' })
+  // expect a posted { kind: 'sync:substage', stream: 'prosody', bookId: 'b1', mode: 'clear' }
+});
+
+it('inbound sync:substage applies via applyExternalSet/Clear and does NOT re-broadcast', () => {
+  // fire channel.onmessage with a foreign instanceId set message
+  // expect store.dispatch(prosodyActions.applyExternalSet(...)) and NO new postMessage
+});
+
+it('drops self-echo by instanceId', () => {
+  // onmessage with msg.instanceId === self → no dispatch
+});
+
+it('a clear on book X leaves book Y intact across tabs (finding-2 regression)', () => {
+  // receiver has b1+b2; inbound clear for b1 → b2 entry remains
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test -- src/store/broadcast-middleware.test.ts`
+Expected: FAIL — no `sync:substage` handling.
+
+- [ ] **Step 3: Implement**
+
+In `src/store/broadcast-middleware.ts`:
+
+Add imports:
+
+```ts
+import { prosodyActions } from './prosody-slice';
+import { scriptReviewActions, } from './script-review-slice';
+import type { SubstageEntry } from './prosody-slice';
+```
+
+Extend the `BroadcastMessage` union with:
+
+```ts
+  | {
+      kind: 'sync:substage';
+      instanceId: string;
+      stream: 'prosody' | 'review';
+      bookId: string;
+      mode: 'set';
+      entry: SubstageEntry;
+    }
+  | {
+      kind: 'sync:substage';
+      instanceId: string;
+      stream: 'prosody' | 'review';
+      bookId: string;
+      mode: 'clear';
+    };
+```
+
+Add the outbound match sets (do NOT include the `applyExternal*` actions — echo layer 2):
+
+```ts
+const SUBSTAGE_BROADCAST_ACTIONS: ReadonlySet<string> = new Set([
+  'prosody/setActive', 'prosody/updateProgress', 'prosody/clear',
+  'scriptReview/setActive', 'scriptReview/updateProgress', 'scriptReview/clear',
+]);
+```
+
+In the inbound `channel.onmessage` handler (after the existing `sync:analysis` / `sync:chapters` branches, with the `instanceId === self` drop already at the top), add:
+
+```ts
+        if (msg.kind === 'sync:substage') {
+          const actions = msg.stream === 'prosody' ? prosodyActions : scriptReviewActions;
+          if (msg.mode === 'clear') {
+            store.dispatch(actions.applyExternalClear({ bookId: msg.bookId }));
+          } else {
+            store.dispatch(actions.applyExternalSet({ bookId: msg.bookId, entry: msg.entry }));
+          }
+          return;
+        }
+```
+
+In the outbound middleware return (after the `CHAPTERS_BROADCAST_ACTIONS` block, before `return result`), add:
+
+```ts
+      if (SUBSTAGE_BROADCAST_ACTIONS.has(type)) {
+        const [sliceName] = type.split('/');
+        const stream: 'prosody' | 'review' = sliceName === 'prosody' ? 'prosody' : 'review';
+        const bookId = (a.payload as { bookId?: string })?.bookId;
+        if (!bookId) return result;
+        const state = store.getState() as unknown as {
+          prosody: { activeStreams: Record<string, SubstageEntry> };
+          scriptReview: { activeStreams: Record<string, SubstageEntry> };
+        };
+        const map = stream === 'prosody' ? state.prosody.activeStreams : state.scriptReview.activeStreams;
+        const entry = map[bookId]; // present for set/updateProgress; absent after clear
+        if (entry) {
+          send({ kind: 'sync:substage', instanceId, stream, bookId, mode: 'set', entry });
+        } else {
+          send({ kind: 'sync:substage', instanceId, stream, bookId, mode: 'clear' });
+        }
+        return result;
+      }
+```
+
+(Note: the cleared book is taken from `action.payload.bookId`, not post-state — finding 9. A simple per-`(stream,bookId)` debounce for `updateProgress` can be added mirroring the analysis path; v1 may ship without it since prosody progress ticks are coarse — confirm tick rate before deciding.)
+
+Update the `BroadcastableRootState` interface to include the two substage maps if the outbound block reads them through it.
+
+- [ ] **Step 4: Run to verify**
+
+Run: `npm run test -- src/store/broadcast-middleware.test.ts && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/broadcast-middleware.ts src/store/broadcast-middleware.test.ts
+git commit -m "feat(frontend): sync analysis sub-stage progress cross-tab via sync:substage"
+```
+
+---
+
+### Task 10: E2E specs + mock cadence
+
+**Files:**
+- Create: `e2e/detect-emotions-pill-progress.spec.ts`, `e2e/script-review-pill-progress.spec.ts`, `e2e/prosody-auto-trigger-guard.spec.ts`, `e2e/generate-disabled-while-analysing.spec.ts`
+- Modify: the mock for `reviewScript` (`src/mocks/*` — find `mockReviewScript`) for a predictable progress cadence
+
+**Interfaces:** consumes the UI testids: `status-pill`, `substage-row`, `detect-emotions-progress`, `review-script-chapter`, `review-script-wholebook`.
+
+- [ ] **Step 1: Extend the review mock cadence**
+
+Find the mock backing `api.reviewScript` (grep `reviewScript` under `src/mocks/`). Make it emit ops over a few `await delay()` ticks so the "Reviewing" pill is observable in e2e, then resolve. Keep it deterministic (fixed delays, no randomness).
+
+- [ ] **Step 2: Write `e2e/detect-emotions-pill-progress.spec.ts`**
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test('manual Detect emotions surfaces on the Status pill and survives navigation', async ({ page }) => {
+  await page.goto('/'); // mock mode; open a book → manuscript view (reuse existing nav helpers/fixtures)
+  // click Detect emotions → confirm
+  await expect(page.getByTestId('status-pill')).toContainText('Analysing');
+  // navigate to Listen, assert the pill is still present/updating, navigate back, assert completion toast
+});
+```
+
+- [ ] **Step 3: Write `e2e/script-review-pill-progress.spec.ts`**
+
+Whole-book review → `status-pill` shows "Analysing" → navigate away → pill persists → toast + diff modal on completion.
+
+- [ ] **Step 4: Write `e2e/prosody-auto-trigger-guard.spec.ts`**
+
+Pre-seed/drive an active prosody stream for a book, then trigger the auto-trigger condition, and assert `runProsodyPasses` doesn't double-run (assert single "Analysing" pill / single completion toast, no duplicate annotations).
+
+- [ ] **Step 5: Write `e2e/generate-disabled-while-analysing.spec.ts`**
+
+While a sub-stage runs on book X, the Generate control on book X is `disabled` with the warning copy; a different book's Generate stays enabled.
+
+- [ ] **Step 6: Run the new e2e specs**
+
+Run: `npm run test:e2e -- e2e/detect-emotions-pill-progress.spec.ts e2e/script-review-pill-progress.spec.ts e2e/prosody-auto-trigger-guard.spec.ts e2e/generate-disabled-while-analysing.spec.ts`
+Expected: PASS. (If a spec passes alone but flakes in the battery, wrap its `describe` in `{ mode: 'serial' }` per the project's known parallel-worker state-race note.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add e2e/detect-emotions-pill-progress.spec.ts e2e/script-review-pill-progress.spec.ts e2e/prosody-auto-trigger-guard.spec.ts e2e/generate-disabled-while-analysing.spec.ts src/mocks
+git commit -m "test(frontend): e2e for analysis pill progress + Generate-gate"
+```
+
+---
+
+### Task 11: Regression doc, INDEX, ship
+
+**Files:**
+- Create: `docs/features/<id>-manuscript-analysis-pill-gate.md` (from `docs/features/TEMPLATE.md`) OR extend the fs-65 plan
+- Modify: `docs/features/INDEX.md`
+- File a Backlog-item GitHub issue and add its thin row to `docs/BACKLOG.md`
+
+- [ ] **Step 1: Write the regression plan** documenting the invariants: per-book maps; Generate-gate + pass mutual-exclusion via `selectAnalysisBusyForBook`; auto-trigger guard via `shouldAutoTriggerProsody` (+ disk watermark); cross-tab `sync:substage`; the accepted limitations (mid-run tab open, TOCTOU, %-discontinuity). Link the spec.
+
+- [ ] **Step 2: Add the INDEX entry** under the relevant area.
+
+- [ ] **Step 3: Run the full battery**
+
+Run: `npm run verify`
+Expected: typecheck + all tests + e2e + build all green (cache-aware).
+
+- [ ] **Step 4: Commit + open the PR**
+
+```bash
+git add docs/features docs/BACKLOG.md
+git commit -m "docs(docs): regression plan + backlog row for analysis pill gate"
+git push -u origin feat/frontend-analysis-pill-gate
+gh pr create --title "feat(frontend): manuscript analysis pill feedback + Generate-gate" --body "..."
+```
+
+PR body: enumerate every user/operator/dev-visible delta (pill rung, retired prosody pill, Generate-gate, pass exclusion, auto-trigger guard, cross-tab sync), link the spec + regression plan, and `Closes #NN` for the backlog issue.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §1 state model → Tasks 1, 2, 3 (selectors), 9 (broadcast); §2 progress wiring + pill → Tasks 3, 4, 5; pass mutual-exclusion → Task 6; §3 Generate-gate → Task 8; §4 auto-trigger guard → Task 7; toasts → Tasks 4/5/8; tests → every task + Task 10; shipping → Task 11. All 14 adversarial findings map to code: 8/9 → Task 9; 2 → Tasks 1/2 + Task 9 regression test; 3 → Tasks 4/5/7 (`finally`); 4 → Task 3 (e2e re-point + delete); 10 → Task 6; 11 → Task 3 (`createSelector`); 12 → Task 7; 13 → Task 9 (echo layer 1); 14 → Task 1.
+- **Type consistency:** `SubstageEntry` defined in Task 1, imported by Tasks 2/3/9; `selectAnalysisBusyForBook` defined in Task 3, consumed by Tasks 6/7/8; `runReviewScript` signature fixed in Task 5; `analysisSubstage` field shape (`{ kind, percent }` on `StatusInput`/`StatusDetail`, `{ kind, label, percent }` from the selector) consistent between Tasks 3 and its consumers.
+- **Known residual ambiguities** (flagged inline, not placeholders): exact button sites in `generation.tsx` (grep-located in Task 8); whether `api.reviewScript` exposes an `onProgress` (Task 5 ships indeterminate "Reviewing · 0%" until the mock/real API emits ticks — Task 10 mock adds cadence); `enqueueQueueEntries` early-return response shape (Task 8 returns the current queue snapshot).

--- a/docs/superpowers/plans/2026-06-30-manuscript-analysis-pill-gate.md
+++ b/docs/superpowers/plans/2026-06-30-manuscript-analysis-pill-gate.md
@@ -348,9 +348,9 @@ git commit -m "feat(frontend): add per-book activeStreams progress map to script
 - Create: `src/store/analysis-substage-selectors.ts`
 - Modify: `src/components/top-bar.tsx` (`StatusInput`, `summarizeStatus`, `StatusDetail`)
 - Modify: `src/components/layout.tsx` (compute `analysisSubstage`, pass to `summarizeStatus` + `statusDetail`; delete the `prosodyPill` derivation + its JSX block)
-- Modify: `src/components/status-popover.tsx` (render the sub-stage row)
+- Modify: `src/components/status-popover.tsx` (render the sub-stage row; rename the "TTS engines" section → "Voice engines")
 - Delete: `src/components/layout-prosody-pill.test.tsx`
-- Modify: `e2e/analysis-prosody-toggle.spec.ts` (re-point off `prosody-pill`)
+- Modify: `e2e/analysis-prosody-toggle.spec.ts` (clean the stale `prosody-pill` *comment* at line 10 — it has no assertion to re-point; finding H2)
 - Test: `src/store/analysis-substage-selectors.test.ts`, `src/components/top-bar.test.tsx`
 
 **Interfaces:**
@@ -473,28 +473,33 @@ Expected: PASS.
 
 - [ ] **Step 5: Add the `summarizeStatus` rung test**
 
-In `src/components/top-bar.test.tsx`, inside the existing `summarizeStatus` describe block, add:
+In `src/components/top-bar.test.tsx`, inside the existing `summarizeStatus` describe block, add the rung + the regrouped-ladder ordering:
 
 ```ts
-it('shows an Analysing rung for an active analysis sub-stage (below real analysis)', () => {
+it('shows an Analysing rung for an active analysis sub-stage', () => {
   const base = { analysis: null, generation: null, design: null, pendingRevisionsCount: 0, anyModelLoading: false };
   expect(summarizeStatus({ ...base, analysisSubstage: { kind: 'prosody', percent: 40 } })).toMatchObject({
-    label: 'Analysing',
-    detail: '40%',
-    icon: 'spinner',
+    label: 'Analysing', detail: '40%', icon: 'spinner',
   });
-  // Real analysis still outranks a sub-stage.
-  expect(
-    summarizeStatus({
-      ...base,
-      analysis: { state: 'running', percent: 12, kind: 'full' } as never,
-      analysisSubstage: { kind: 'review', percent: 90 },
-    }),
-  ).toMatchObject({ detail: '12%' });
+});
+
+it('voice-engine states (Generating, Loading model) outrank Analysis and the sub-stage', () => {
+  const base = { analysis: null, generation: null, design: null, pendingRevisionsCount: 0, anyModelLoading: false };
+  // Generating is the heaviest — always wins:
+  expect(summarizeStatus({ ...base, generation: { state: 'running', percent: 10 } as never, analysisSubstage: { kind: 'review', percent: 90 } }))
+    .toMatchObject({ label: 'Generating' });
+  // Loading model now outranks a real analysis pass AND a sub-stage (regrouped ladder):
+  expect(summarizeStatus({ ...base, anyModelLoading: true, analysis: { state: 'running', percent: 12, kind: 'full' } as never }))
+    .toMatchObject({ label: 'Loading model' });
+  expect(summarizeStatus({ ...base, anyModelLoading: true, analysisSubstage: { kind: 'review', percent: 90 } }))
+    .toMatchObject({ label: 'Loading model' });
+  // Real analysis still outranks its own sub-stage:
+  expect(summarizeStatus({ ...base, analysis: { state: 'running', percent: 12, kind: 'full' } as never, analysisSubstage: { kind: 'review', percent: 90 } }))
+    .toMatchObject({ detail: '12%' });
 });
 ```
 
-(No need to touch the other `summarizeStatus` calls in this file — the field is optional.)
+**Also update the existing ladder tests in this file:** the regroup moves `Loading model` above `Analysing`/`Designing` (it was below `Designing`), so any existing case asserting "analysis/design wins over model-loading" must flip. Grep the describe block for `anyModelLoading` / `Loading model` and adjust. (No need to touch `summarizeStatus` calls that omit `analysisSubstage` — the field is optional.)
 
 - [ ] **Step 6: Run to verify it fails**
 
@@ -511,12 +516,17 @@ In `src/components/top-bar.tsx`, add to the `StatusInput` interface (after `anyM
   analysisSubstage?: { kind: 'prosody' | 'review'; percent: number } | null;
 ```
 
-Add `analysisSubstage` to the destructured params of `summarizeStatus` (`analysisSubstage = null` as the default), and insert the rung **directly after** the `analysis?.state === 'running'` block (and before `design?.state === 'running'`):
+Add `analysisSubstage` to the destructured params of `summarizeStatus` (`analysisSubstage = null` as the default). Then **regroup the ladder to Voice-engine → Analysis → Design** (operator decision):
+
+1. **Move the existing `if (anyModelLoading) return { label: 'Loading model', … }` block UP** — to immediately after the `generation?.state === 'running'` block and **before** `analysis?.state === 'running'`. (Today it sits after `design?.state === 'running'`.) This groups both voice-engine states — `Generating` then `Loading model` — at the top of the active rungs. Update the ladder comment above the function to match.
+2. **Insert the sub-stage rung directly after `analysis?.state === 'running'`** (and before `design?.state === 'running'`):
 
 ```ts
   if (analysisSubstage)
     return { label: 'Analysing', tone: 'peach', icon: 'spinner', detail: `${analysisSubstage.percent}%` };
 ```
+
+Resulting order: `Halted > Stalled > Generating > Loading model > Analysing > analysis-substage > Designing > Paused > Revisions > idle`. `Generating` stays the dominant active rung (heaviest process, shown on the chip without opening the popover).
 
 Add `analysisSubstage` to the `StatusDetail` interface too — **carrying the `label`** (the popover renders it, so the selector's `label` field is not dead):
 
@@ -580,11 +590,13 @@ In `src/components/status-popover.tsx`, render a sub-stage row inside the analys
 
 (Place it adjacent to the existing `AnalysisPill` render in the analysis section. The `label` is the user-facing phase text the dispatch sites set — "Detecting emotions" / "Reviewing".)
 
-- [ ] **Step 9: Delete the standalone-pill unit test and re-point the e2e**
+**In-scope copy rename:** while in `status-popover.tsx`, rename the visible voice-engine label — `<Section title="TTS engines" …>` (line 156) → `title="Voice engines"`, and the hint "TTS controls appear once a manuscript is open." → "Voice engine controls appear once a manuscript is open." (Do NOT rename code identifiers like `ttsControls`/`status-popover-tts` testid — copy only. The app-wide "TTS"→"Voice engines" rename in banners/admin/etc. is a separate change, see Task 11 note.)
+
+- [ ] **Step 9: Delete the standalone-pill unit test; clean the stale e2e comment (H2)**
 
 Delete `src/components/layout-prosody-pill.test.tsx`.
 
-In `e2e/analysis-prosody-toggle.spec.ts`, replace any `getByTestId('prosody-pill')` assertion with the Status-pill path. Read the spec first; the substage now surfaces on the top-bar Status pill (`getByTestId('status-pill')`, label "Analysing") and its popover row (`getByTestId('substage-row')`). If the spec only asserted the toggle (enable/disable prosody) and used the pill as a progress proxy, assert on `substage-row` after opening the Status popover instead.
+`e2e/analysis-prosody-toggle.spec.ts` does **not** assert on `prosody-pill` — verified, its only reference is a code _comment_ at line 10 naming the (now-deleted) unit test. Just update/remove that stale comment; there is no assertion to re-point and the spec keeps passing untouched.
 
 - [ ] **Step 10: Run the affected tests + typecheck**
 
@@ -622,19 +634,18 @@ import { scriptReviewSlice } from '../store/script-review-slice';
 // in configureStore.reducer add:  prosody: prosodySlice.reducer, scriptReview: scriptReviewSlice.reducer,
 ```
 
-Add a mock for the thunk and the test (place the mock near the existing `../lib/api` mock):
+**Do NOT module-mock `runProsodyPasses`** (finding H1) — `vi.mock` is hoisted file-wide, so a bare `vi.fn()` would replace the real thunk for the existing tests too (`detect-emotions-button.test.tsx:48-130` depend on the real thunk applying annotations / showing "done" / forwarding the abort signal) and turn the whole file red at the commit gate. Instead drive the new test through the **existing `../lib/api` mock** (`detectEmotions`/`detectInstruct`, already wired via `vi.hoisted` at the top of the file). Make `detectEmotions` capture mid-run state, then reject — the real thunk propagates the error, the component's `catch` runs, and `finally` must clear:
 
 ```ts
-import { runProsodyPasses } from '../store/prosody-thunk';
-vi.mock('../store/prosody-thunk', () => ({ runProsodyPasses: vi.fn() }));
-
-it('sets the prosody stream during a run and clears it in finally even on throw', async () => {
+it('clears the prosody stream in finally even when a pass throws', async () => {
   let streamWhileRunning: unknown;
-  vi.mocked(runProsodyPasses).mockImplementation(async (bookId: string, opts: { onProgress?: (f: number) => void }) => {
-    opts.onProgress?.(0.5);
-    streamWhileRunning = store.getState().prosody.activeStreams[bookId]; // captured mid-run
-    throw new Error('boom'); // exercise the error path
+  detectEmotions.mockImplementation((_id: string, opts?: any) => {
+    /* tinyspy may probe with no args; the real call always passes opts. */
+    if (!opts) return Promise.resolve({ annotatedChapters: 0, totalAnnotations: 0 });
+    streamWhileRunning = store.getState().prosody.activeStreams['b1']; // setActive ran before the thunk awaited the API
+    return Promise.reject(new Error('boom'));
   });
+  detectInstruct.mockResolvedValue({ annotatedChapters: 0, totalAnnotations: 0 }); // safe if the thunk continues to pass 2
   const store = makeStore();
   render(
     <Provider store={store}>
@@ -643,13 +654,14 @@ it('sets the prosody stream during a run and clears it in finally even on throw'
   );
   fireEvent.click(screen.getByTestId('detect-emotions-button'));
   fireEvent.click(screen.getByTestId('detect-emotions-confirm'));
-  await waitFor(() => expect(runProsodyPasses).toHaveBeenCalled());
-  // set while running:
-  expect(streamWhileRunning).toMatchObject({ label: 'Detecting emotions' });
   // cleared in finally despite the throw:
-  await waitFor(() => expect(store.getState().prosody.activeStreams.b1).toBeUndefined());
+  await waitFor(() => expect(store.getState().prosody.activeStreams['b1']).toBeUndefined());
+  // and it was set while running:
+  expect(streamWhileRunning).toMatchObject({ label: 'Detecting emotions' });
 });
 ```
+
+(This leaves the real `runProsodyPasses` intact, so the three existing tests stay green. The assertion holds whether the thunk propagates the error or absorbs it into its `failed` count — either way the component's `finally` clears the stream.)
 
 - [ ] **Step 2: Run to verify it fails**
 
@@ -1099,9 +1111,7 @@ git commit -m "feat(frontend): guard the prosody auto-trigger against double-fir
 
 - [ ] **Step 1: Write the failing thunk test**
 
-In `src/store/queue-thunks.test.ts` (create if absent), add: `enqueueQueueEntries` drops entries whose book is busy and toasts, enqueuing only the rest.
-
-Mock the network seam this file already uses (check the top of `queue-thunks.ts` for whether `queueRequest`/`readSnapshot` are module-locals or imported; if locals, mock `fetch`). Concrete test capturing the POST body:
+`src/store/queue-thunks.test.ts` **already exists** (finding H4) and already stubs the network via `vi.stubGlobal('fetch', …)` — `USE_MOCKS` is false in the vitest env so `queueRequest` hits real `fetch`. **Append** this test (don't recreate the file), reusing the file's existing fetch-stub style:
 
 ```ts
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -1114,7 +1124,7 @@ beforeEach(() => { posted.length = 0; });
 vi.stubGlobal('fetch', vi.fn(async (_url: string, init: { body: string }) => {
   const body = JSON.parse(init.body) as { entries: unknown[] };
   posted.push(...body.entries);
-  return { ok: true, json: async () => ({ entries: body.entries, paused: false, recycling: false, loaded: true }) } as Response;
+  return { ok: true, json: async () => ({ entries: body.entries, paused: false, recycling: false }) } as Response; // QueueSnapshotResponse: {entries,paused,recycling?} — no `loaded`
 }));
 
 it('enqueues only un-gated entries and toasts the gated pass', async () => {
@@ -1189,7 +1199,7 @@ export function enqueueQueueEntries(entries: EnqueueInput[], opts: { silent?: bo
 ```
 
 > **VERIFY before implementing (finding R2):** the original code never POSTed an empty `entries` array, so don't assume `/api/queue/enqueue` treats `[]` as a no-op — read `server/.../queue` route handler first. Two correct shapes, pick by what the route does:
-> 1. **All-gated early-return (shown above, preferred):** when `allowed.length === 0`, return the current snapshot *without* a network call. Implement `snapshotFromState` by mapping the `queue` slice to the `QueueSnapshotResponse` shape (read `readSnapshot`'s return type + the `queue-slice` `QueueState` to confirm the fields line up — they're the same `entries/paused/recycling/loaded` shape today, so it's a structural copy, **not** an `as unknown as` cast). If the shapes have diverged, instead narrow this function's return type to `Promise<QueueSnapshotResponse | null>` and `return null` (all current callers `void` the result — grep to confirm before relying on this).
+> 1. **All-gated early-return (shown above, preferred):** when `allowed.length === 0`, return the current snapshot *without* a network call. Implement `snapshotFromState` by mapping the `queue` slice to the `QueueSnapshotResponse` shape — which is `{ entries; paused; recycling? }` (`queue-thunks.ts:55`); note `loaded` lives on the slice's `QueueState` but is **not** part of the response type, so map only the three real fields (a structural copy, **not** an `as unknown as` cast). If the shapes have diverged, instead narrow this function's return type to `Promise<QueueSnapshotResponse | null>` and `return null` (all current callers `void` the result — grep to confirm before relying on this).
 > 2. **Only if the route is confirmed to no-op on `[]`:** delete the early-return and always POST `allowed`; the typed snapshot then always comes from `readSnapshot`.
 
 (Import `RootState` from `./index`.)
@@ -1463,6 +1473,7 @@ git commit -m "test(frontend): e2e for analysis pill progress + Generate-gate"
 - Create: `docs/features/<id>-manuscript-analysis-pill-gate.md` (from `docs/features/TEMPLATE.md`) OR extend the fs-65 plan
 - Modify: `docs/features/INDEX.md`
 - File a Backlog-item GitHub issue and add its thin row to `docs/BACKLOG.md`
+- **Separate follow-up (do NOT fold into this branch):** file a small Backlog issue for the app-wide user-facing **"TTS" → "Voice engines"** copy rename (eviction banners like "TTS unloaded to free VRAM" in `analysing.tsx:1007`/`cast.tsx`/`profile-drawer`, the admin page "local TTS / analyzer / ASR" at `admin.tsx:145`, etc.). This feature only renames the in-scope Status-popover label (Task 3 Step 8); the broad rename is its own cohesive change with its own tests (e.g. `analysing.test.tsx:582` asserts the banner text) and must not pollute this branch's diff. Engine *proper nouns* (Coqui XTTS, Qwen3-TTS) and code identifiers (`ttsLifecycle`, `TTS_MODEL_OPTIONS`) stay as-is.
 
 - [ ] **Step 1: Write the regression plan** documenting the invariants: per-book maps; Generate-gate + pass mutual-exclusion via `selectAnalysisBusyForBook`; auto-trigger guard via `shouldAutoTriggerProsody` (+ disk watermark); cross-tab `sync:substage`; the accepted limitations (mid-run tab open, TOCTOU, %-discontinuity). Link the spec.
 
@@ -1488,8 +1499,10 @@ PR body: enumerate every user/operator/dev-visible delta (pill rung, retired pro
 
 ## Self-Review
 
-- **Spec coverage:** §1 state model → Tasks 1, 2, 3 (selectors), 9 (broadcast); §2 progress wiring + pill → Tasks 3, 4, 5; pass mutual-exclusion → Task 6; §3 Generate-gate → Task 8; §4 auto-trigger guard → Task 7; toasts → Tasks 4/5/8; tests → every task + Task 10; shipping → Task 11. All 14 adversarial findings map to code: 8/9 → Task 9; 2 → Tasks 1/2 + Task 9 regression test; 3 → Tasks 4/5/7 (`finally`); 4 → Task 3 (e2e re-point + delete); 10 → Task 6; 11 → Task 3 (`createSelector`); 12 → Task 7; 13 → Task 9 (echo layer 1); 14 → Task 1.
-- **Type consistency:** `SubstageEntry` defined in Task 1, imported by Tasks 2/3/9; `selectAnalysisBusyForBook` + `analysisBusyMessage` defined in Task 3, consumed by Tasks 6/7/8; `runReviewScript` signature (incl. `totalChapters`) fixed in Task 5 and matched by the Task 5 delegate; `analysisSubstage` shapes are intentionally distinct per consumer and consistent with what Layout passes — `StatusInput` gets `{ kind, percent }` (rung needs only percent), `StatusDetail` gets `{ label, percent }` (popover renders the label), and the selector returns `{ kind, label, percent }` (superset).
+- **Spec coverage:** §1 state model → Tasks 1, 2, 3 (selectors), 9 (broadcast); §2 progress wiring + pill → Tasks 3, 4, 5; pass mutual-exclusion → Task 6; §3 Generate-gate → Task 8; §4 auto-trigger guard → Task 7; toasts → Tasks 4/5/8; tests → every task + Task 10; shipping → Task 11. All 14 adversarial findings map to code: 8/9 → Task 9; 2 → Tasks 1/2 + Task 9 regression test; 3 → Tasks 4/5/7 (`finally`); 4 → Task 3 (delete unit test + clean stale e2e comment, per H2); 10 → Task 6; 11 → Task 3 (`createSelector`); 12 → Task 7; 13 → Task 9 (echo layer 1); 14 → Task 1.
+- **Type consistency:** `SubstageEntry` defined in Task 1, imported by Tasks 2/3/9; `selectAnalysisBusyForBook` + `analysisBusyMessage` defined in Task 3, consumed by Tasks 6/7/8; `runReviewScript` (no `totalChapters` — progress is `onPhase`-driven) defined in Task 5 and matched by the Task 5 delegate; `analysisSubstage` shapes are intentionally distinct per consumer and consistent with what Layout passes — `StatusInput` gets `{ kind, percent }` (rung needs only percent), `StatusDetail` gets `{ label, percent }` (popover renders the label), and the selector returns `{ kind, label, percent }` (superset).
 - **Round-2 fixes folded:** P1 (Task 1 migrates `layout-prosody-pill.test.tsx` in-commit), P2 (review progress wired from a real callback), P3 (concrete test code in Tasks 4/6/8/9; e2e reference the real nav helpers + testids), P4 (`analysisSubstage` optional), P5 (no unsafe cast), P6 (per-pass copy via `analysisBusyMessage`), P7 (debounce omission is a logged decision), P8 (popover uses the selector's `label`).
-- **Round-3 fixes folded:** R1 (review progress comes from `onPhase`'s real 0..1 value, **not** an `onOps` count that would stall on empty chapters — `totalChapters` removed), R2 (the all-gated path early-returns a typed snapshot, with a VERIFY note on the queue route instead of an unverified empty-POST), R3 (`vi.mocked` not `as unknown as vi.Mock`), R4 (migrate-then-delete of the pill test is a logged deliberate choice), R5 (grep `getInitialState` assertion before widening `script-review-slice` state).
-- **Known residual ambiguities** (flagged inline, not placeholders): exact button sites in `generation.tsx` (grep-located in Task 8); whether `api.reviewScript` exposes an `onProgress` (Task 5 ships indeterminate "Reviewing · 0%" until the mock/real API emits ticks — Task 10 mock adds cadence); `enqueueQueueEntries` early-return response shape (Task 8 returns the current queue snapshot).
+- **Round-3 fixes folded:** R1 (review progress comes from `onPhase`'s real 0..1 value, **not** an `onOps` count that would stall on empty chapters — `totalChapters` removed), R2 (the all-gated path early-returns a typed snapshot, with a VERIFY note on the queue route instead of an unverified empty-POST), R4 (migrate-then-delete of the pill test is a logged deliberate choice), R5 (grep `getInitialState` assertion before widening `script-review-slice` state). _(Round-3 R3 — `vi.mocked` — is superseded by round-4 H1, which drops the thunk mock entirely.)_
+- **Round-4 fixes folded (independent reviewer):** H1 (Task 4 drives the new test through the existing `../lib/api` mock, **not** a hoisted `vi.mock` of `runProsodyPasses` that would red the file's other three tests at the commit gate), H2 (`e2e/analysis-prosody-toggle.spec.ts` has no `prosody-pill` assertion — only a stale comment to clean), H3 (operator regroup of the pill ladder to **Voice-engine → Analysis → Design**, which also resolves the substage-vs-model-load tie), H4 (`queue-thunks.test.ts` already exists — append, not create; `QueueSnapshotResponse` has no `loaded` field).
+- **Operator changes folded (2026-06-30):** pill ladder regrouped (Generating stays the dominant chip; `Loading model` moves above Analysis); in-scope Status-popover "TTS engines" → "Voice engines" rename (Task 3); the app-wide "TTS"→"Voice engines" copy rename filed as a **separate** Backlog item (Task 11), not in this branch.
+- **Known residual ambiguities** (flagged inline, not placeholders): exact Generate/regenerate button sites in `generation.tsx` (grep-located in Task 8); the queue route's empty-`entries` contract (Task 8 VERIFY note — early-return without a network call by default).

--- a/docs/superpowers/plans/2026-06-30-manuscript-analysis-pill-gate.md
+++ b/docs/superpowers/plans/2026-06-30-manuscript-analysis-pill-gate.md
@@ -30,7 +30,7 @@
 - Modify: `src/components/layout.tsx:163` (the `prosodyStream` selector read), `layout.tsx:1044/1048/1050/1057` (auto-trigger dispatches), `layout.tsx:1356-1362` (the `prosodyPill` derivation)
 - Test: `src/store/prosody-slice.test.ts` (rewrite for the map shape), `src/components/layout-prosody-pill.test.tsx` (migrate to the map shape so this commit stays green — Task 3 deletes it when the pill is retired)
 
-> **Green-between-commits note:** `layout-prosody-pill.test.tsx` preloads the singular `{ activeStream }` and calls `prosodyActions.clear()` with no argument. After this migration both break (`clear()` is a typecheck error; the preload no longer renders the pill), and the pre-commit gate runs the frontend suite for a frontend change — so this test MUST be migrated in the same commit (Step 5 below), not deferred to Task 3. (`prosody-autotrigger.test.tsx` mocks `runProsodyPasses` and never reads `activeStream`/`clear()`, so it is unaffected.)
+> **Green-between-commits note:** `layout-prosody-pill.test.tsx` preloads the singular `{ activeStream }` and calls `prosodyActions.clear()` with no argument. After this migration both break (`clear()` is a typecheck error; the preload no longer renders the pill), and the pre-commit gate runs the frontend suite for a frontend change — so this test MUST be migrated in the same commit (Step 5 below), not deferred to Task 3. (`prosody-autotrigger.test.tsx` mocks `runProsodyPasses` and never reads `activeStream`/`clear()`, so it is unaffected.) Task 3 deletes this test when the pill is retired — the brief migrate-then-delete (finding R4) is deliberate: it keeps every commit green and avoids any window where prosody progress goes invisible.
 
 **Interfaces:**
 - Produces:
@@ -325,6 +325,8 @@ Add these reducers inside the existing `reducers: { ... }` object (alongside `se
 ```
 
 Update the slice header comment's "non-broadcast" note to: "the activeStreams progress map IS broadcast cross-tab via sync:substage; byBook results stay tab-local."
+
+(Finding R5: if any existing test asserts `scriptReviewSlice.getInitialState()` deep-equals `{ byBook: {} }`, widen it to include `activeStreams: {}` — grep `getInitialState` in `script-review-slice.test.ts` before running.)
 
 - [ ] **Step 4: Run to verify it passes**
 
@@ -628,7 +630,7 @@ vi.mock('../store/prosody-thunk', () => ({ runProsodyPasses: vi.fn() }));
 
 it('sets the prosody stream during a run and clears it in finally even on throw', async () => {
   let streamWhileRunning: unknown;
-  (runProsodyPasses as unknown as vi.Mock).mockImplementation(async (bookId: string, opts: { onProgress?: (f: number) => void }) => {
+  vi.mocked(runProsodyPasses).mockImplementation(async (bookId: string, opts: { onProgress?: (f: number) => void }) => {
     opts.onProgress?.(0.5);
     streamWhileRunning = store.getState().prosody.activeStreams[bookId]; // captured mid-run
     throw new Error('boom'); // exercise the error path
@@ -730,7 +732,7 @@ git commit -m "feat(frontend): drive the prosody pill from DetectEmotionsButton,
 
 **Interfaces:**
 - Consumes: `scriptReviewActions.setActive/updateProgress/clear/setReview`, `api.reviewScript`, `planApply`, `notificationsActions`.
-- Produces: `runReviewScript(bookId, { dispatch, wholeBook, chapterId?, model, sentences, characterIds, totalChapters }): Promise<void>` — a plain async function (matches `runProsodyPasses`' shape: takes `dispatch` in its options bag, not a thunk-creator). **`api.reviewScript` has no `onProgress`** (verified in `api.ts` — its callbacks are `onOps`/`onPhase`/`onThrottle`/`onChapterFailed`), so progress is derived from `onOps`, which fires once per chapter: the thunk dispatches `updateProgress({ bookId, progress: chaptersDone / totalChapters })` on each `onOps`. `totalChapters` = `reviewableChapterCount` for whole-book, `1` for a single chapter.
+- Produces: `runReviewScript(bookId, { dispatch, wholeBook, chapterId?, model, sentences, characterIds }): Promise<void>` — a plain async function (matches `runProsodyPasses`' shape: takes `dispatch` in its options bag, not a thunk-creator). **Progress comes from `api.reviewScript`'s `onPhase` callback** (verified `api.ts:2942` — `onPhase?: (e: { progress: number; label?; chapterId? }) => void`; the server streams real 0..1 progress via `phase` events). Do **not** count `onOps` for progress — `onOps` fires only for chapters that *have* ops, so a book with empty chapters would stall the pill below 100%.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -751,17 +753,16 @@ import { scriptReviewActions } from './script-review-slice';
 describe('runReviewScript', () => {
   beforeEach(() => reviewScript.mockReset());
 
-  it('sets active, advances progress per chapter via onOps, then clears in finally on success', async () => {
-    reviewScript.mockImplementation(async (_bookId: string, opts: { onOps?: (e: { chapterId: number; ops: unknown[] }) => void }) => {
-      opts.onOps?.({ chapterId: 1, ops: [] });
-      opts.onOps?.({ chapterId: 2, ops: [] });
+  it('sets active, forwards onPhase progress, then clears in finally on success', async () => {
+    reviewScript.mockImplementation(async (_bookId: string, opts: { onPhase?: (e: { progress: number }) => void }) => {
+      opts.onPhase?.({ progress: 0.5 });
+      opts.onPhase?.({ progress: 1 });
     });
     const dispatch = vi.fn();
-    await runReviewScript('b1', { dispatch, wholeBook: true, model: 'gemma', sentences: [], characterIds: new Set<number>(), totalChapters: 2 });
+    await runReviewScript('b1', { dispatch, wholeBook: true, model: 'gemma', sentences: [], characterIds: new Set<number>() });
     const types = dispatch.mock.calls.map((c) => c[0].type);
     expect(types).toContain(scriptReviewActions.setActive.type);
-    expect(types).toContain(scriptReviewActions.updateProgress.type); // fired from onOps
-    // last updateProgress payload reached 2/2 → 1.0
+    expect(types).toContain(scriptReviewActions.updateProgress.type); // fired from onPhase
     const lastProg = dispatch.mock.calls.map((c) => c[0]).filter((a) => a.type === scriptReviewActions.updateProgress.type).pop();
     expect(lastProg.payload).toEqual({ bookId: 'b1', progress: 1 });
     expect(types[types.length - 1]).toBe(scriptReviewActions.clear.type);
@@ -770,7 +771,7 @@ describe('runReviewScript', () => {
   it('clears in finally even when the API throws', async () => {
     reviewScript.mockRejectedValue(new Error('boom'));
     const dispatch = vi.fn();
-    await runReviewScript('b1', { dispatch, wholeBook: true, model: 'gemma', sentences: [], characterIds: new Set<number>(), totalChapters: 1 });
+    await runReviewScript('b1', { dispatch, wholeBook: true, model: 'gemma', sentences: [], characterIds: new Set<number>() });
     const types = dispatch.mock.calls.map((c) => c[0].type);
     expect(types[types.length - 1]).toBe(scriptReviewActions.clear.type);
   });
@@ -810,25 +811,21 @@ export interface RunReviewScriptOpts {
   /** Live sentences for index-mapped planApply (caller passes sentencesRef.current). */
   sentences: ReviewLiveSentence[];
   characterIds: Set<number>;
-  /** Reviewable chapter count for the progress denominator (1 for a single chapter). */
-  totalChapters: number;
 }
 
 export async function runReviewScript(bookId: string, opts: RunReviewScriptOpts): Promise<void> {
-  const { dispatch, wholeBook, chapterId, model, sentences, characterIds, totalChapters } = opts;
+  const { dispatch, wholeBook, chapterId, model, sentences, characterIds } = opts;
   const allOps: ReviewOpWithChapter[] = [];
   const failed: Array<{ chapterId: number; message: string }> = [];
-  const total = Math.max(1, totalChapters);
-  let chaptersDone = 0;
   dispatch(scriptReviewActions.setActive({ bookId, progress: 0, label: 'Reviewing' }));
   try {
     await api.reviewScript(bookId, {
       ...(wholeBook ? {} : { chapterId }),
       model,
+      onPhase: ({ progress }: { progress: number }) =>
+        dispatch(scriptReviewActions.updateProgress({ bookId, progress })),
       onOps: ({ chapterId: chId, ops }: { chapterId: number; ops: ReviewOp[] }) => {
         for (const op of ops) allOps.push({ ...op, chapterId: chId });
-        chaptersDone += 1; // onOps fires once per reviewed chapter
-        dispatch(scriptReviewActions.updateProgress({ bookId, progress: Math.min(1, chaptersDone / total) }));
       },
       onChapterFailed: (e: { chapterId: number; message: string }) => failed.push(e),
     });
@@ -862,7 +859,7 @@ export async function runReviewScript(bookId: string, opts: RunReviewScriptOpts)
 }
 ```
 
-(Progress is chapter-granular — `onOps` fires once per reviewed chapter, so the pill steps 1/N, 2/N … N/N. For a single-chapter review `totalChapters` is 1, so the pill jumps 0% → 100% on completion, which is correct for one unit of work.)
+(Progress is the server's own 0..1 `onPhase` value — monotonic and reaching ~1.0 before the stream's terminal `result` event, so the pill doesn't stall mid-bar. `setReview` is dispatched from the collected `allOps` after the stream ends, unchanged.)
 
 - [ ] **Step 4: Delegate from `manuscript.tsx`**
 
@@ -889,15 +886,12 @@ Replace the body of `handleReviewScript` (`manuscript.tsx:697-758`) with a thin 
           vocalization: s.vocalization,
         })),
         characterIds: new Set(characters.map((c) => c.id)),
-        totalChapters: wholeBook ? reviewableChapterCount : 1,
       });
     } finally {
       setReviewLoading(false);
     }
   }
 ```
-
-(`reviewableChapterCount` already exists in `manuscript.tsx` — it feeds the whole-book menu label and the RPD warning.)
 
 Add the import: `import { runReviewScript } from '../store/script-review-thunk';`. Remove now-unused imports in `manuscript.tsx` that the lifted code orphaned (e.g. `planApply` if nothing else uses it — verify with a grep before deleting).
 
@@ -1170,9 +1164,9 @@ export function enqueueQueueEntries(entries: EnqueueInput[], opts: { silent?: bo
         }),
       );
     }
-    /* Always POST `allowed` (even []), so the return is a real snapshot — no
-       unsafe cast of QueueState. An empty enqueue is a server-side no-op that
-       returns the current snapshot. */
+    /* If every entry was gated, return without a network call — see the
+       VERIFY note below for why we don't POST an empty array. */
+    if (allowed.length === 0) return snapshotFromState(getState());
     const res = await queueRequest('/api/queue/enqueue', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -1180,7 +1174,7 @@ export function enqueueQueueEntries(entries: EnqueueInput[], opts: { silent?: bo
     });
     const snapshot = await readSnapshot(res);
     dispatch(queueActions.setSnapshot(snapshot));
-    if (!opts.silent && allowed.length > 0) {
+    if (!opts.silent) {
       dispatch(
         notificationsActions.pushToast({
           kind: 'info',
@@ -1194,7 +1188,11 @@ export function enqueueQueueEntries(entries: EnqueueInput[], opts: { silent?: bo
 }
 ```
 
-(Import `RootState` from `./index`. No early-return cast: `allowed` is always POSTed, so the typed `QueueSnapshotResponse` always comes from `readSnapshot`. The info toast counts `allowed.length`, not the whole snapshot, so a partially-gated batch reports the right number.)
+> **VERIFY before implementing (finding R2):** the original code never POSTed an empty `entries` array, so don't assume `/api/queue/enqueue` treats `[]` as a no-op — read `server/.../queue` route handler first. Two correct shapes, pick by what the route does:
+> 1. **All-gated early-return (shown above, preferred):** when `allowed.length === 0`, return the current snapshot *without* a network call. Implement `snapshotFromState` by mapping the `queue` slice to the `QueueSnapshotResponse` shape (read `readSnapshot`'s return type + the `queue-slice` `QueueState` to confirm the fields line up — they're the same `entries/paused/recycling/loaded` shape today, so it's a structural copy, **not** an `as unknown as` cast). If the shapes have diverged, instead narrow this function's return type to `Promise<QueueSnapshotResponse | null>` and `return null` (all current callers `void` the result — grep to confirm before relying on this).
+> 2. **Only if the route is confirmed to no-op on `[]`:** delete the early-return and always POST `allowed`; the typed snapshot then always comes from `readSnapshot`.
+
+(Import `RootState` from `./index`.)
 
 - [ ] **Step 4: Disable the Generate UI**
 
@@ -1418,7 +1416,7 @@ git commit -m "feat(frontend): sync analysis sub-stage progress cross-tab via sy
 
 - [ ] **Step 1: Extend the review mock cadence**
 
-Find the mock backing `api.reviewScript` (it's `mockReviewScript` — `api.ts:7469`). Make it call `onOps({ chapterId, ops })` **once per chapter** with a fixed `await delay(...)` between chapters, then resolve — so `runReviewScript` steps the pill 1/N, 2/N … (the progress is derived from `onOps` count, per Task 5). Deterministic delays only (no randomness — see the project's e2e-flake notes).
+Find the mock backing `api.reviewScript` (it's `mockReviewScript` — `api.ts:3050`). It already emits one `onPhase({ progress: 0.5, ... })`; add a couple more `onPhase` ticks (e.g. `0.25`, `0.5`, `0.85`) with a fixed `await wait(...)` between them before the existing `onOps` calls, so the "Reviewing" pill is observably mid-progress in e2e (progress is read from `onPhase`, per Task 5). Deterministic delays only (no randomness — see the project's e2e-flake notes).
 
 - [ ] **Step 2: Write `e2e/detect-emotions-pill-progress.spec.ts`**
 
@@ -1492,5 +1490,6 @@ PR body: enumerate every user/operator/dev-visible delta (pill rung, retired pro
 
 - **Spec coverage:** §1 state model → Tasks 1, 2, 3 (selectors), 9 (broadcast); §2 progress wiring + pill → Tasks 3, 4, 5; pass mutual-exclusion → Task 6; §3 Generate-gate → Task 8; §4 auto-trigger guard → Task 7; toasts → Tasks 4/5/8; tests → every task + Task 10; shipping → Task 11. All 14 adversarial findings map to code: 8/9 → Task 9; 2 → Tasks 1/2 + Task 9 regression test; 3 → Tasks 4/5/7 (`finally`); 4 → Task 3 (e2e re-point + delete); 10 → Task 6; 11 → Task 3 (`createSelector`); 12 → Task 7; 13 → Task 9 (echo layer 1); 14 → Task 1.
 - **Type consistency:** `SubstageEntry` defined in Task 1, imported by Tasks 2/3/9; `selectAnalysisBusyForBook` + `analysisBusyMessage` defined in Task 3, consumed by Tasks 6/7/8; `runReviewScript` signature (incl. `totalChapters`) fixed in Task 5 and matched by the Task 5 delegate; `analysisSubstage` shapes are intentionally distinct per consumer and consistent with what Layout passes — `StatusInput` gets `{ kind, percent }` (rung needs only percent), `StatusDetail` gets `{ label, percent }` (popover renders the label), and the selector returns `{ kind, label, percent }` (superset).
-- **Round-2 fixes folded:** P1 (Task 1 migrates `layout-prosody-pill.test.tsx` in-commit), P2 (review progress derived from `onOps`/`totalChapters`), P3 (concrete test code in Tasks 4/6/8/9; e2e reference the real nav helpers + testids), P4 (`analysisSubstage` optional), P5 (no unsafe cast — always POST `allowed`), P6 (per-pass copy via `analysisBusyMessage`), P7 (debounce omission is a logged decision), P8 (popover uses the selector's `label`).
+- **Round-2 fixes folded:** P1 (Task 1 migrates `layout-prosody-pill.test.tsx` in-commit), P2 (review progress wired from a real callback), P3 (concrete test code in Tasks 4/6/8/9; e2e reference the real nav helpers + testids), P4 (`analysisSubstage` optional), P5 (no unsafe cast), P6 (per-pass copy via `analysisBusyMessage`), P7 (debounce omission is a logged decision), P8 (popover uses the selector's `label`).
+- **Round-3 fixes folded:** R1 (review progress comes from `onPhase`'s real 0..1 value, **not** an `onOps` count that would stall on empty chapters — `totalChapters` removed), R2 (the all-gated path early-returns a typed snapshot, with a VERIFY note on the queue route instead of an unverified empty-POST), R3 (`vi.mocked` not `as unknown as vi.Mock`), R4 (migrate-then-delete of the pill test is a logged deliberate choice), R5 (grep `getInitialState` assertion before widening `script-review-slice` state).
 - **Known residual ambiguities** (flagged inline, not placeholders): exact button sites in `generation.tsx` (grep-located in Task 8); whether `api.reviewScript` exposes an `onProgress` (Task 5 ships indeterminate "Reviewing · 0%" until the mock/real API emits ticks — Task 10 mock adds cadence); `enqueueQueueEntries` early-return response shape (Task 8 returns the current queue snapshot).

--- a/docs/superpowers/specs/2026-06-30-manuscript-analysis-pill-gate-design.md
+++ b/docs/superpowers/specs/2026-06-30-manuscript-analysis-pill-gate-design.md
@@ -38,20 +38,23 @@ Corrections folded in silently (stale claims in the originating plan): file path
 ```ts
 export interface SubstageEntry { progress: number /* 0..100 int */; label: string; }
 // state field on each slice:  activeStreams: Record<string /* bookId */, SubstageEntry>
-// reducers on each slice:     setActive({bookId,progress,label})
-//                             updateProgress({bookId,progress})
-//                             clear({bookId})            // per-book, not global
-//                             applyExternalStreams(Record<bookId,SubstageEntry>)  // inbound from broadcast; NOT broadcast itself
+// local reducers:   setActive({bookId,progress,label})
+//                   updateProgress({bookId,progress})
+//                   clear({bookId})                       // per-book, not global
+// inbound-only:     applyExternalSet({bookId,entry})      // from broadcast; NOT in the outbound match set
+//                   applyExternalClear({bookId})          // — so they can't re-broadcast (echo layer 2)
 ```
 
-- **`prosody-slice.ts` (migrate).** Replace the singular `activeStream: … | null` with `activeStreams: Record<bookId, SubstageEntry>`. `clear()` gains a `{bookId}` payload. Update the two auto-trigger call sites in `layout.tsx` (~1050/1057) and `prosody-slice.test.ts`.
+The inbound reducers are **per-book** (set/clear a single key) to match the per-book wire shape — a whole-map `applyExternalStreams(Record)` could not express a deletion and would wipe the receiving tab's other in-flight books (finding 8).
+
+- **`prosody-slice.ts` (migrate).** Replace the singular `activeStream: … | null` with `activeStreams: Record<bookId, SubstageEntry>`. `clear()` gains a `{bookId}` payload. Update **all** readers/writers: the `prosodyStream` selector at `layout.tsx:163`, the two auto-trigger call sites (~1050/1057), and `prosody-slice.test.ts`. (Verified blast radius is limited to these — no other `state.prosody.activeStream` reader exists.)
 - **`script-review-slice.ts` (extend).** Add the same `activeStreams` map + the four reducers. `byBook` (results) is unchanged.
 
 **Broadcast (proper protocol — see findings 1 & 2).** The middleware is **not** a generic action allow-set; it's a bespoke per-slice snapshot protocol with a closed message union and separate inbound reducers (echo-suppression layer 2). So:
 
-- Add a **new message kind** `sync:substage` carrying `{ stream: 'prosody' | 'review'; bookId; mode: 'set' | 'clear'; entry? }`.
-- The **outbound** watcher matches `prosody/setActive|updateProgress|clear` and `scriptReview/setActive|updateProgress|clear`, re-derives the changed book's entry from `getState()`, and sends a per-book `set`/`clear`. `updateProgress`-only ticks reuse the existing `PROGRESS_DEBOUNCE_MS` debounce, keyed by `(stream, bookId)`.
-- The **inbound** handler dispatches `prosodyActions.applyExternalStreams` / `scriptReviewActions.applyExternalStreams` — which are **deliberately absent** from the outbound match set, so they can't re-broadcast (same pattern as `applyExternalAnalysisSnapshot`).
+- Add a **new message kind** `sync:substage` carrying `{ instanceId; stream: 'prosody' | 'review'; bookId; mode: 'set' | 'clear'; entry? }`.
+- The **outbound** watcher matches `prosody/setActive|updateProgress|clear` and `scriptReview/setActive|updateProgress|clear`. It takes the affected `bookId` from **`action.payload.bookId`** — NOT from post-state, because after a `clear` the entry is already deleted and `getState()` can't tell you which book cleared (finding 9). For `set`/`updateProgress` it reads that book's entry from state; for `clear` it sends `mode: 'clear'`. `updateProgress`-only ticks reuse the existing `PROGRESS_DEBOUNCE_MS` debounce, keyed by `(stream, bookId)`.
+- The **inbound** handler drops self-echo (`if (msg.instanceId === self) return`, echo layer 1) and dispatches `applyExternalSet` / `applyExternalClear` on the matching slice — which are **deliberately absent** from the outbound match set, so they can't re-broadcast (echo layer 2, same pattern as `applyExternalAnalysisSnapshot`).
 - **Result** actions (`scriptReview/setReview`, `toggleOp`, `toggleClass`, `clearReview`) stay **tab-local** — a passive tab must not pop the review diff modal. Prosody results land in the manuscript slice (separately handled), so prosody-slice has no result action.
 
 Update both slice header comments: replace the "do NOT broadcast" note with "progress map broadcast cross-tab via `sync:substage`; results stay tab-local."
@@ -60,7 +63,8 @@ Update both slice header comments: replace the "do NOT broadcast" note with "pro
 
 - `selectProsodyRunningForBook(state, bookId): boolean` → `bookId in state.prosody.activeStreams`
 - `selectReviewRunningForBook(state, bookId): boolean` → `bookId in state.scriptReview.activeStreams`
-- `selectAnalysisSubstage(state): { kind: 'prosody' | 'review'; label: string; percent: number } | null` — feeds the (singular) pill; when multiple books run it surfaces one deterministically (prosody before review, then lowest bookId) and the popover can list the rest.
+- `selectAnalysisBusyForBook(state, bookId): boolean` → either of the above; the single gate used by both the Generate-gate and the pass-mutual-exclusion (finding 10).
+- `selectAnalysisSubstage(state): { kind: 'prosody' | 'review'; label: string; percent: number } | null` — feeds the (singular) pill; when multiple books run it surfaces one deterministically (prosody before review, then lowest bookId) and the popover lists the rest. **Memoize via `createSelector`** (or have the pill read primitives / use `useAppSelectorShallow`) — a fresh-object return each tick would trip the "selector returned a different result" churn the store is already hardened against (finding 11).
 
 ### 2. Progress wiring & the pill
 
@@ -74,18 +78,20 @@ Update both slice header comments: replace the "do NOT broadcast" note with "pro
   ```
 
   Real analysis still outranks it — the sub-stages run _after_ the main analysis pass completes, so in practice they don't overlap; the ordering only matters for the degenerate manual-trigger-during-analysis case, where the primary pass correctly wins. **Known UX wart (finding 6, accepted):** when the main analysis finishes at "Analysing · 100%" and prosody starts at "Analysing · 0%", the pill's percent resets under the same label — it reads briefly like a regression. Accepted for v1 because it _is_ a genuine new phase; the popover names the active sub-stage, which disambiguates.
+- **Pass mutual-exclusion (finding 10).** The two analysis passes share the analyzer (Ollama/Gemini), so they must not run together on one book. Both `DetectEmotionsButton` and the Review Script buttons (`manuscript.tsx:827/835/850`) gain `disabled={… || selectAnalysisBusyForBook(state, bookId)}` — so while _either_ pass runs on a book, _both_ buttons disable for that book. (Each button keeps its existing local `phase`/`reviewLoading` flag too, for instant feedback before the slice settles.) Other books are unaffected.
 - **Popover** (`status-popover.tsx` / `StatusDetail`): the analysis section renders the active sub-stage row with user-facing wording — "Detecting emotions · NN%" / "Reviewing · NN%" (never the word "prosody" in UI copy).
 - **Retire** the standalone prosody pill block in `layout.tsx` (~1512). **Blast radius (finding 4):** `data-testid="prosody-pill"` is referenced by `layout.tsx`, `layout-prosody-pill.test.tsx`, **and `e2e/analysis-prosody-toggle.spec.ts`** — delete the unit test and **re-point the e2e spec** at the new analysis-rung pill, don't just drop the unit test.
 
 ### 3. Generate-gate (per-book, defense-in-depth)
 
-- **UI.** In `generation.tsx`, disable the Generate / regenerate triggers for **the current book** when `selectProsodyRunningForBook(state, bookId) || selectReviewRunningForBook(state, bookId)`. Other books' Generate stays live (concurrent multi-book invariant).
+- **UI.** In `generation.tsx`, disable the Generate / regenerate triggers for **the current book** when `selectAnalysisBusyForBook(state, bookId)`. Other books' Generate stays live (concurrent multi-book invariant).
 - **Thunk guard.** `enqueueQueueEntries` is the authoritative backstop (covers cross-tab and stale-state clicks). For a batch it **filters out** entries whose book has an active sub-stage and enqueues the rest (rather than dropping the whole batch), then fires one toast naming the gated book(s). In practice enqueue is per-book, but the filter keeps a mixed-book batch correct.
 - **Copy.** "Wait — emotions are still being detected" / "Wait — script review is in progress."
 
 ### 4. Auto-trigger double-fire guard
 
-- Extract a pure `shouldAutoTriggerProsody(state, bookId): boolean` returning `false` when `selectProsodyRunningForBook || selectReviewRunningForBook`. The `layout.tsx` auto-trigger effect calls it as the single in-memory source of truth.
+- Extract a pure `shouldAutoTriggerProsody(state, bookId): boolean` returning `false` when `selectAnalysisBusyForBook(state, bookId)`. The `layout.tsx` auto-trigger effect calls it as the single in-memory source of truth.
+- The auto-trigger's own clear (today at `layout.tsx:1050`/`1057`) migrates to `clear({bookId})` and must fire on **every** exit path (finding 12) — extend the finally-discipline here too, so a transient auto-trigger failure can't strand a stream that, broadcast, would jam Generate in every tab.
 - The existing **disk** `prosodyAnnotated` watermark stays the separate "already done" gate — it reads `api.getBookState`, so it is _not_ part of the pure Redux function and is not folded in. (This is narrower than the originating plan's "four cases idle/prosody-active/review-active/already-annotated" — the already-annotated case remains a disk-state async check, by design.)
 - **Cross-tab (finding 5 — reduces, doesn't eliminate):** once tab A's `setActive` has broadcast, tab B's auto-trigger early-returns and its Generate disables. But `BroadcastChannel` is asynchronous, so two tabs that detect analysis-complete in the same tick can both pass `shouldAutoTriggerProsody` _before_ either's `setActive` arrives → a residual double-run TOCTOU window. The disk `prosodyAnnotated` watermark dedups the eventual _write_, not the concurrent _run_. This is a narrow single-user-two-tabs edge; documented, not closed in v1.
 
@@ -111,17 +117,28 @@ The spec was attacked against the live code after the first draft. Dispositions:
 6. **Pill "Analysing %" discontinuity (Low → accepted).** Percent resets between phases; popover disambiguates.
 7. **Enqueue guard, mixed-book batch (Low → fixed).** Filters gated entries, enqueues the rest.
 
+**Round 2** (attacking the keyed-map + `sync:substage` design added in round 1):
+
+8. **Message shape vs reducer shape mismatch (High → fixed).** Per-book wire (`set`/`clear`) needs per-book inbound reducers (`applyExternalSet` / `applyExternalClear`); a whole-map apply couldn't express a deletion and would wipe other books.
+9. **Outbound `clear` can't derive the book from post-state (High → fixed).** Reads `action.payload.bookId`, not `getState()` (the entry is gone by then).
+10. **Two analyzer passes could run together on one book (Medium → fixed, user-confirmed).** Both analysis buttons mutually exclude per book via `selectAnalysisBusyForBook`.
+11. **`selectAnalysisSubstage` identity churn (Medium → fixed).** Memoized via `createSelector`.
+12. **Auto-trigger clear not in the finally-discipline (Low–Med → fixed).** Extended to the auto-trigger's `clear({bookId})`.
+13. **Echo layer 1 not restated for the new kind (Low → fixed).** Inbound drops `msg.instanceId === self`.
+14. **Migration-reader completeness (Low → fixed).** Names the `layout.tsx:163` selector; blast radius verified contained.
+
 ## Test plan
 
 **Unit (Vitest):**
-- `prosody-slice.test.ts` (migrate) — singular → `activeStreams` map; `clear({bookId})` removes only that book; concurrent books coexist.
-- `script-review-slice.test.ts` — new `activeStreams` map reducers + `applyExternalStreams`.
+- `prosody-slice.test.ts` (migrate) — singular → `activeStreams` map; `clear({bookId})` removes only that book; concurrent books coexist; `applyExternalSet`/`applyExternalClear` touch only the named key.
+- `script-review-slice.test.ts` — new `activeStreams` map reducers + `applyExternalSet`/`applyExternalClear`.
 - `script-review-thunk.test.ts` — `runReviewScript` dispatch sequence (setActive → updateProgress → setReview, with `clear({bookId})` in `finally` on the success AND error paths).
 - `prosody-thunk.test.ts` (update) + `prosody-autotrigger.test.tsx` — manual button now drives the slice and clears in `finally`; auto-trigger uses keyed actions.
 - `shouldAutoTriggerProsody.test.ts` — idle → true; prosody-active(book) → false; review-active(book) → false; active-on-_other_-book → true.
 - `top-bar.test.tsx` — new `analysisSubstage` rung at the correct priority.
 - selector tests — per-book `selectProsodyRunningForBook` / `selectReviewRunningForBook` / `selectAnalysisSubstage` (incl. multi-book tie-break determinism).
-- `broadcast-middleware.test.ts` — `sync:substage` round-trips `set`/`clear` per book; inbound `applyExternalStreams` does **not** re-broadcast (echo layer 2); `updateProgress` debounces per `(stream, bookId)`; a `clear` on book X leaves book Y's entry intact (the finding-2 regression).
+- `broadcast-middleware.test.ts` — `sync:substage` round-trips `set`/`clear` per book; inbound `applyExternalSet`/`applyExternalClear` do **not** re-broadcast (echo layer 2) and self-echo drops on `instanceId` (echo layer 1); a `clear` derives its book from the action payload (finding 9); `updateProgress` debounces per `(stream, bookId)`; a `clear` on book X leaves book Y's entry intact (the finding-2 regression).
+- `detect-emotions-button.test.tsx` + a manuscript review-button test — **pass mutual-exclusion**: while one pass runs on a book, both analysis buttons are `disabled` for that book and enabled for a different book (finding 10).
 
 **E2E (Playwright, mock mode):**
 - `detect-emotions-pill-progress.spec.ts` — manual prosody → analysis-substage pill updates → navigate away → still updating → completion toast.

--- a/docs/superpowers/specs/2026-06-30-manuscript-analysis-pill-gate-design.md
+++ b/docs/superpowers/specs/2026-06-30-manuscript-analysis-pill-gate-design.md
@@ -1,0 +1,134 @@
+# Manuscript analysis passes — pill feedback + Generate-gate
+
+_Design spec — 2026-06-30_
+
+## Problem
+
+Two buttons in the Manuscript header — **Detect emotions** (`DetectEmotionsButton`, the two-pass prosody annotation) and **Review Script** (the fs-58 LLM script-review pass, with per-chapter and whole-book variants) — run long, block the page, and give no durable feedback once the user navigates away. The whole-book review can run for minutes with no visible progress. Worse, while either pass is mid-flight a user can still press **Generate**, racing the analysis against TTS generation.
+
+Both passes already push their _results_ into Redux correctly. The work here is UI/state plumbing: surface live progress, and prevent the race.
+
+## Current state (verified against the codebase)
+
+- `prosody-slice.ts` is **fully built** — `activeStream: { bookId; progress; label } | null` with `setActive` / `updateProgress` / `clear`. The **auto-trigger** (`layout.tsx:985`, Task 13/fs-65) already drives it and renders a **standalone** prosody pill (`layout.tsx:1512`, `data-testid="prosody-pill"`).
+- The **manual** `DetectEmotionsButton` (`src/components/detect-emotions-button.tsx`) drives **only local component state** — so its progress is invisible from the Status pill and is lost on navigation.
+- `runProsodyPasses` (`src/store/prosody-thunk.ts:48`) is **shared** by the manual button and the auto-trigger, and already accepts an `onProgress` callback.
+- `script-review-slice.ts` **exists** (transient, non-broadcast, bookId-keyed `byBook` of review ops). It has **no** progress/`activeStream` field. `handleReviewScript` (`src/views/manuscript.tsx:697`) runs the pass inline and dispatches `scriptReviewActions.setReview` on completion.
+- `summarizeStatus` (`src/components/top-bar.tsx:111`) is the pure helper feeding the unified **Status pill**. Its ladder is `halted > stalled > generation-running > analysis-running > design-running > model-loading > analysis-paused > revisions-pending > idle`. It has **no** prosody/review rung today.
+- **Neither** `prosody` nor `scriptReview` is in `broadcast-middleware.ts`. `prosody-slice.ts`'s header explicitly says _do not broadcast_.
+- **Generate is not gated** on either pass anywhere. The real Generate path is `generation.tsx` → `enqueueQueueEntries` (`src/store/queue-thunks.ts`). `ModelControlPill` is the TTS model load/stop control, **not** Generate.
+- **No double-fire guard** exists between the manual button and the auto-trigger — both call `runProsodyPasses` for the same book with no shared mutex. `shouldAutoTriggerProsody` does not exist.
+
+## Decisions
+
+These three were resolved interactively during brainstorming; they supersede the corresponding lines in the originating plan.
+
+1. **Pill architecture — fold into the analysing section.** Prosody and script-review are sub-stages of _book analysis_, so their progress belongs **inside the `summarizeStatus` "Analysing" rung**, not in a separate floating pill. The standalone `prosody-pill` is **retired**.
+2. **Review progress storage — extend `script-review-slice.ts`.** Add a transient `activeStream` to the existing slice rather than creating a new `review-slice.ts`. The slice is already transient and non-broadcast and already owns review state.
+3. **Cross-tab — broadcast the progress.** Add the prosody + scriptReview _progress_ actions to `broadcast-middleware.ts` so the Generate-gate and auto-trigger guard hold across tabs. (The originating plan assumed this worked "for free"; it did not — the slices were never broadcast.)
+
+Corrections folded in silently (stale claims in the originating plan): file paths (`summarizeStatus` is in `components/top-bar.tsx`, the auto-trigger is in `components/layout.tsx`, there is no `src/store/layout.tsx`); `prosody-slice.activeStream` is fully built, not "half-built"; the Generate-gate target is `generation.tsx`, not `ModelControlPill`.
+
+## Design
+
+### 1. State model
+
+**`script-review-slice.ts` (extend).** Add a transient field, a structural twin of `prosody-slice`:
+
+```ts
+export interface ReviewActiveStream { bookId: string; progress: number /* 0..100 int */; label: string; }
+// in ScriptReviewState:  activeStream: ReviewActiveStream | null
+// reducers:              setActive, updateProgress, clear   (mirror prosody-slice)
+```
+
+`byBook` (results) is unchanged.
+
+**Broadcast.** In `broadcast-middleware.ts`, add **only the progress actions** to the broadcast allow-set:
+
+- `prosody/setActive`, `prosody/updateProgress`, `prosody/clear`
+- `scriptReview/setActive`, `scriptReview/updateProgress`, `scriptReview/clear`
+
+The **result** actions (`scriptReview/setReview`, `toggleOp`, `toggleClass`, `clearReview`) stay **tab-local** — a passive tab must not have the review diff modal pop open. Prosody results already land in the (separately-handled) manuscript slice, so prosody-slice has no result action to worry about.
+
+Update both slice header comments: replace the "do NOT broadcast" note with "progress actions broadcast for cross-tab gating; results stay tab-local."
+
+**Selectors (new, bookId-aware).** Because `activeStream` is _singular_ (one active pass at a time) and concurrent multi-book is a first-class invariant, the gate is **per-book**:
+
+- `selectProsodyRunningForBook(state, bookId): boolean`
+- `selectReviewRunningForBook(state, bookId): boolean`
+- `selectAnalysisSubstage(state): { kind: 'prosody' | 'review'; label: string; percent: number } | null` — whichever stream is active; feeds the pill.
+
+### 2. Progress wiring & the pill
+
+- **Manual `DetectEmotionsButton`** dispatches `prosodyActions.setActive` on start, `updateProgress` via the existing `runProsodyPasses` `onProgress` callback, and `clear` on completion/cancel. The inline badge re-sources from the slice so it survives navigation. (The auto-trigger already does exactly this; the manual path simply joins it.)
+- **Review** gains a thunk `runReviewScript(bookId, { wholeBook })` in `src/store/script-review-thunk.ts` that dispatches `scriptReviewActions.setActive/updateProgress/clear` around the pass and `setReview` on completion. `handleReviewScript` in `manuscript.tsx` delegates to it. Whole-book RPD gating stays where it is.
+- **`summarizeStatus`** gains `analysisSubstage` on `StatusInput`. A new rung sits **directly below `analysis?.state === 'running'`**:
+
+  ```ts
+  if (analysisSubstage)
+    return { label: 'Analysing', tone: 'peach', icon: 'spinner', detail: `${analysisSubstage.percent}%` };
+  ```
+
+  Real analysis still outranks it — the sub-stages run _after_ the main analysis pass completes, so in practice they don't overlap; the ordering only matters for the degenerate manual-trigger-during-analysis case, where the primary pass correctly wins.
+- **Popover** (`status-popover.tsx` / `StatusDetail`): the analysis section renders the active sub-stage row with user-facing wording — "Detecting emotions · NN%" / "Reviewing · NN%" (never the word "prosody" in UI copy).
+- **Retire** the standalone prosody pill block in `layout.tsx` (~1512) and delete `layout-prosody-pill.test.tsx` (replaced by the summarizeStatus rung test).
+
+### 3. Generate-gate (per-book, defense-in-depth)
+
+- **UI.** In `generation.tsx`, disable the Generate / regenerate triggers for **the current book** when `selectProsodyRunningForBook(state, bookId) || selectReviewRunningForBook(state, bookId)`. Other books' Generate stays live (concurrent multi-book invariant).
+- **Thunk guard.** `enqueueQueueEntries` early-returns and fires a toast when a sub-stage targets the entry's book — the authoritative backstop that also covers the cross-tab case and any stale-state click.
+- **Copy.** "Wait — emotions are still being detected" / "Wait — script review is in progress."
+
+### 4. Auto-trigger double-fire guard
+
+- Extract a pure `shouldAutoTriggerProsody(state, bookId): boolean` returning `false` when `selectProsodyRunningForBook || selectReviewRunningForBook`. The `layout.tsx` auto-trigger effect calls it as the single in-memory source of truth.
+- The existing **disk** `prosodyAnnotated` watermark stays the separate "already done" gate — it reads `api.getBookState`, so it is _not_ part of the pure Redux function and is not folded in. (This is narrower than the originating plan's "four cases idle/prosody-active/review-active/already-annotated" — the already-annotated case remains a disk-state async check, by design.)
+- **Cross-tab:** now genuinely covered — tab B sees tab A's broadcast `activeStream`, so its auto-trigger early-returns and its Generate disables.
+
+### Toasts
+
+Start toasts read as a live process, never as a queued item: "Detecting emotions…" / "Reviewing…". Completion fires a success toast (and, for review, the existing diff modal). A cancel mid-run fires a partial-result toast and clears the stream.
+
+## Out of scope / limitations (documented honestly)
+
+- **Mid-run tab open.** Broadcast is action-replay, not state-sync, so a tab opened _while_ a pass is already running won't retroactively learn of it (matches all existing broadcast-middleware behavior). The server queue remains the ultimate backstop against an actual generation race.
+- **Popover Cancel.** Cancel stays inline-only on the originating button; a Cancel control in the popover would require storing the `AbortController` on the slice — deferred.
+- **No queue-slice reuse.** `queue-slice.ts` / its dispatcher assume TTS-shaped per-chapter `QueueEntry` rows; analysis passes are not modelled as queue entries. Widening `QueueEntry.scope` for future analysis jobs is explicitly out of scope.
+
+## Test plan
+
+**Unit (Vitest):**
+- `script-review-slice.test.ts` — new `activeStream` reducers.
+- `script-review-thunk.test.ts` — `runReviewScript` dispatch sequence (setActive → updateProgress → setReview → clear; cancel path).
+- `prosody-thunk.test.ts` (update) + `prosody-autotrigger.test.tsx` — manual button now drives the slice; auto-trigger unchanged.
+- `shouldAutoTriggerProsody.test.ts` — idle → true; prosody-active → false; review-active → false.
+- `top-bar.test.tsx` — new `analysisSubstage` rung at the correct priority.
+- selector tests — per-book `selectProsodyRunningForBook` / `selectReviewRunningForBook` / `selectAnalysisSubstage`.
+- broadcast-middleware test — the six progress actions broadcast; the result actions do not.
+
+**E2E (Playwright, mock mode):**
+- `detect-emotions-pill-progress.spec.ts` — manual prosody → analysis-substage pill updates → navigate away → still updating → completion toast.
+- `script-review-pill-progress.spec.ts` — whole-book review → pill updates → navigate away → toast + diff modal.
+- `prosody-auto-trigger-guard.spec.ts` — auto-trigger skips `runProsodyPasses` while a stream is active for the same book.
+- `generate-disabled-while-analysing.spec.ts` — Generate disabled with the warning copy while a sub-stage runs; other books unaffected.
+- extend `mockReviewScript` for a predictable progress cadence.
+
+**Verification commands:**
+- `npm run typecheck`
+- `npm run test -- top-bar.test.tsx prosody-thunk.test.ts src/store/script-review-slice.test.ts src/store/script-review-thunk.test.ts src/store/shouldAutoTriggerProsody.test.ts`
+- `npm test` (full unit)
+- `npm run test:e2e -- e2e/detect-emotions-pill-progress.spec.ts e2e/script-review-pill-progress.spec.ts e2e/prosody-auto-trigger-guard.spec.ts e2e/generate-disabled-while-analysing.spec.ts`
+- `npm run verify` (full battery)
+
+**Manual smoke (mock mode):**
+1. Cold-boot a book → auto-trigger fires → Status pill shows "Analysing · NN%" → Generate disabled with warning copy → navigate to Listen mid-stream → pill keeps updating → return → completion toast.
+2. Open a fresh book already past its first emotion pass → click Detect emotions → manual pass runs (auto-trigger won't re-fire, manual still does) → pill updates.
+3. Review Script ▾ → Review whole book → "Analysing · NN%" → Generate disabled → navigate away → pill keeps updating → toast + diff modal on completion.
+4. Cancel mid-run from the inline badge → pill resets, partial-result toast.
+
+## Shipping checklist
+
+- New `docs/features/` regression plan (or extend the fs-65 plan) + GH issue.
+- `docs/features/INDEX.md` entry.
+- `npm run verify` green.
+- End-of-turn summary names the user-visible delta and the locking tests.

--- a/docs/superpowers/specs/2026-06-30-manuscript-analysis-pill-gate-design.md
+++ b/docs/superpowers/specs/2026-06-30-manuscript-analysis-pill-gate-design.md
@@ -21,11 +21,11 @@ Both passes already push their _results_ into Redux correctly. The work here is 
 
 ## Decisions
 
-These three were resolved interactively during brainstorming; they supersede the corresponding lines in the originating plan.
+These were resolved interactively during brainstorming and hardened by an adversarial review of the spec (see "Adversarial review outcomes" below); they supersede the corresponding lines in the originating plan.
 
 1. **Pill architecture — fold into the analysing section.** Prosody and script-review are sub-stages of _book analysis_, so their progress belongs **inside the `summarizeStatus` "Analysing" rung**, not in a separate floating pill. The standalone `prosody-pill` is **retired**.
-2. **Review progress storage — extend `script-review-slice.ts`.** Add a transient `activeStream` to the existing slice rather than creating a new `review-slice.ts`. The slice is already transient and non-broadcast and already owns review state.
-3. **Cross-tab — broadcast the progress.** Add the prosody + scriptReview _progress_ actions to `broadcast-middleware.ts` so the Generate-gate and auto-trigger guard hold across tabs. (The originating plan assumed this worked "for free"; it did not — the slices were never broadcast.)
+2. **Progress storage — bookId-keyed maps, twin slices.** Review progress extends the existing `script-review-slice.ts` (not a new `review-slice.ts`). **Both** prosody and review progress are stored as a **`Record<bookId, …>` map**, not a singular slot — so concurrent multi-book passes (a first-class invariant) and cross-tab broadcast can't clobber each other. **`prosody-slice` therefore migrates from its current singular `activeStream` to the map shape** (its auto-trigger call sites in `layout.tsx` and `prosody-slice.test.ts` migrate with it).
+3. **Cross-tab — broadcast done properly.** Progress syncs across tabs via a **new dedicated message kind** in `broadcast-middleware.ts` (`sync:substage`) with **external-apply reducers** that don't re-broadcast — _not_ by adding the existing progress actions to an allow-set (which would infinite-loop; see finding 1). The keyed-map shape (Decision 2) makes the broadcast collision-free, so the gate holds across tabs without one book's `clear()` releasing another's.
 
 Corrections folded in silently (stale claims in the originating plan): file paths (`summarizeStatus` is in `components/top-bar.tsx`, the auto-trigger is in `components/layout.tsx`, there is no `src/store/layout.tsx`); `prosody-slice.activeStream` is fully built, not "half-built"; the Generate-gate target is `generation.tsx`, not `ModelControlPill`.
 
@@ -33,35 +33,39 @@ Corrections folded in silently (stale claims in the originating plan): file path
 
 ### 1. State model
 
-**`script-review-slice.ts` (extend).** Add a transient field, a structural twin of `prosody-slice`:
+**Shared entry shape.** Both slices key their progress by `bookId` (mirrors `chapters.activeStreams`), so concurrent books never collide:
 
 ```ts
-export interface ReviewActiveStream { bookId: string; progress: number /* 0..100 int */; label: string; }
-// in ScriptReviewState:  activeStream: ReviewActiveStream | null
-// reducers:              setActive, updateProgress, clear   (mirror prosody-slice)
+export interface SubstageEntry { progress: number /* 0..100 int */; label: string; }
+// state field on each slice:  activeStreams: Record<string /* bookId */, SubstageEntry>
+// reducers on each slice:     setActive({bookId,progress,label})
+//                             updateProgress({bookId,progress})
+//                             clear({bookId})            // per-book, not global
+//                             applyExternalStreams(Record<bookId,SubstageEntry>)  // inbound from broadcast; NOT broadcast itself
 ```
 
-`byBook` (results) is unchanged.
+- **`prosody-slice.ts` (migrate).** Replace the singular `activeStream: … | null` with `activeStreams: Record<bookId, SubstageEntry>`. `clear()` gains a `{bookId}` payload. Update the two auto-trigger call sites in `layout.tsx` (~1050/1057) and `prosody-slice.test.ts`.
+- **`script-review-slice.ts` (extend).** Add the same `activeStreams` map + the four reducers. `byBook` (results) is unchanged.
 
-**Broadcast.** In `broadcast-middleware.ts`, add **only the progress actions** to the broadcast allow-set:
+**Broadcast (proper protocol — see findings 1 & 2).** The middleware is **not** a generic action allow-set; it's a bespoke per-slice snapshot protocol with a closed message union and separate inbound reducers (echo-suppression layer 2). So:
 
-- `prosody/setActive`, `prosody/updateProgress`, `prosody/clear`
-- `scriptReview/setActive`, `scriptReview/updateProgress`, `scriptReview/clear`
+- Add a **new message kind** `sync:substage` carrying `{ stream: 'prosody' | 'review'; bookId; mode: 'set' | 'clear'; entry? }`.
+- The **outbound** watcher matches `prosody/setActive|updateProgress|clear` and `scriptReview/setActive|updateProgress|clear`, re-derives the changed book's entry from `getState()`, and sends a per-book `set`/`clear`. `updateProgress`-only ticks reuse the existing `PROGRESS_DEBOUNCE_MS` debounce, keyed by `(stream, bookId)`.
+- The **inbound** handler dispatches `prosodyActions.applyExternalStreams` / `scriptReviewActions.applyExternalStreams` — which are **deliberately absent** from the outbound match set, so they can't re-broadcast (same pattern as `applyExternalAnalysisSnapshot`).
+- **Result** actions (`scriptReview/setReview`, `toggleOp`, `toggleClass`, `clearReview`) stay **tab-local** — a passive tab must not pop the review diff modal. Prosody results land in the manuscript slice (separately handled), so prosody-slice has no result action.
 
-The **result** actions (`scriptReview/setReview`, `toggleOp`, `toggleClass`, `clearReview`) stay **tab-local** — a passive tab must not have the review diff modal pop open. Prosody results already land in the (separately-handled) manuscript slice, so prosody-slice has no result action to worry about.
+Update both slice header comments: replace the "do NOT broadcast" note with "progress map broadcast cross-tab via `sync:substage`; results stay tab-local."
 
-Update both slice header comments: replace the "do NOT broadcast" note with "progress actions broadcast for cross-tab gating; results stay tab-local."
+**Selectors (bookId-aware).** The keyed map makes per-book gating exact:
 
-**Selectors (new, bookId-aware).** Because `activeStream` is _singular_ (one active pass at a time) and concurrent multi-book is a first-class invariant, the gate is **per-book**:
-
-- `selectProsodyRunningForBook(state, bookId): boolean`
-- `selectReviewRunningForBook(state, bookId): boolean`
-- `selectAnalysisSubstage(state): { kind: 'prosody' | 'review'; label: string; percent: number } | null` — whichever stream is active; feeds the pill.
+- `selectProsodyRunningForBook(state, bookId): boolean` → `bookId in state.prosody.activeStreams`
+- `selectReviewRunningForBook(state, bookId): boolean` → `bookId in state.scriptReview.activeStreams`
+- `selectAnalysisSubstage(state): { kind: 'prosody' | 'review'; label: string; percent: number } | null` — feeds the (singular) pill; when multiple books run it surfaces one deterministically (prosody before review, then lowest bookId) and the popover can list the rest.
 
 ### 2. Progress wiring & the pill
 
-- **Manual `DetectEmotionsButton`** dispatches `prosodyActions.setActive` on start, `updateProgress` via the existing `runProsodyPasses` `onProgress` callback, and `clear` on completion/cancel. The inline badge re-sources from the slice so it survives navigation. (The auto-trigger already does exactly this; the manual path simply joins it.)
-- **Review** gains a thunk `runReviewScript(bookId, { wholeBook })` in `src/store/script-review-thunk.ts` that dispatches `scriptReviewActions.setActive/updateProgress/clear` around the pass and `setReview` on completion. `handleReviewScript` in `manuscript.tsx` delegates to it. Whole-book RPD gating stays where it is.
+- **Manual `DetectEmotionsButton`** dispatches `prosodyActions.setActive({bookId})` on start and `updateProgress({bookId})` via the existing `runProsodyPasses` `onProgress` callback. **`clear({bookId})` MUST be in a `finally`** — covering success, error, _and_ abort — so a failed/aborted pass can never leave a stuck stream (which, broadcast cross-tab, would disable Generate in every tab). The button's current `run()` clears `phase` per-branch but has no pill `clear` in `finally` (`detect-emotions-button.tsx:58–74`); the migration adds it. The inline badge re-sources from the slice so it survives navigation.
+- **Review** gains a thunk `runReviewScript(bookId, { wholeBook })` in `src/store/script-review-thunk.ts` that dispatches `scriptReviewActions.setActive/updateProgress` around the pass and `setReview` on completion. `handleReviewScript` (`manuscript.tsx:697`) already has a `try/finally` (resets `reviewLoading`); the thunk's `clear({bookId})` lands in that same `finally`. Whole-book RPD gating stays where it is.
 - **`summarizeStatus`** gains `analysisSubstage` on `StatusInput`. A new rung sits **directly below `analysis?.state === 'running'`**:
 
   ```ts
@@ -69,21 +73,21 @@ Update both slice header comments: replace the "do NOT broadcast" note with "pro
     return { label: 'Analysing', tone: 'peach', icon: 'spinner', detail: `${analysisSubstage.percent}%` };
   ```
 
-  Real analysis still outranks it — the sub-stages run _after_ the main analysis pass completes, so in practice they don't overlap; the ordering only matters for the degenerate manual-trigger-during-analysis case, where the primary pass correctly wins.
+  Real analysis still outranks it — the sub-stages run _after_ the main analysis pass completes, so in practice they don't overlap; the ordering only matters for the degenerate manual-trigger-during-analysis case, where the primary pass correctly wins. **Known UX wart (finding 6, accepted):** when the main analysis finishes at "Analysing · 100%" and prosody starts at "Analysing · 0%", the pill's percent resets under the same label — it reads briefly like a regression. Accepted for v1 because it _is_ a genuine new phase; the popover names the active sub-stage, which disambiguates.
 - **Popover** (`status-popover.tsx` / `StatusDetail`): the analysis section renders the active sub-stage row with user-facing wording — "Detecting emotions · NN%" / "Reviewing · NN%" (never the word "prosody" in UI copy).
-- **Retire** the standalone prosody pill block in `layout.tsx` (~1512) and delete `layout-prosody-pill.test.tsx` (replaced by the summarizeStatus rung test).
+- **Retire** the standalone prosody pill block in `layout.tsx` (~1512). **Blast radius (finding 4):** `data-testid="prosody-pill"` is referenced by `layout.tsx`, `layout-prosody-pill.test.tsx`, **and `e2e/analysis-prosody-toggle.spec.ts`** — delete the unit test and **re-point the e2e spec** at the new analysis-rung pill, don't just drop the unit test.
 
 ### 3. Generate-gate (per-book, defense-in-depth)
 
 - **UI.** In `generation.tsx`, disable the Generate / regenerate triggers for **the current book** when `selectProsodyRunningForBook(state, bookId) || selectReviewRunningForBook(state, bookId)`. Other books' Generate stays live (concurrent multi-book invariant).
-- **Thunk guard.** `enqueueQueueEntries` early-returns and fires a toast when a sub-stage targets the entry's book — the authoritative backstop that also covers the cross-tab case and any stale-state click.
+- **Thunk guard.** `enqueueQueueEntries` is the authoritative backstop (covers cross-tab and stale-state clicks). For a batch it **filters out** entries whose book has an active sub-stage and enqueues the rest (rather than dropping the whole batch), then fires one toast naming the gated book(s). In practice enqueue is per-book, but the filter keeps a mixed-book batch correct.
 - **Copy.** "Wait — emotions are still being detected" / "Wait — script review is in progress."
 
 ### 4. Auto-trigger double-fire guard
 
 - Extract a pure `shouldAutoTriggerProsody(state, bookId): boolean` returning `false` when `selectProsodyRunningForBook || selectReviewRunningForBook`. The `layout.tsx` auto-trigger effect calls it as the single in-memory source of truth.
 - The existing **disk** `prosodyAnnotated` watermark stays the separate "already done" gate — it reads `api.getBookState`, so it is _not_ part of the pure Redux function and is not folded in. (This is narrower than the originating plan's "four cases idle/prosody-active/review-active/already-annotated" — the already-annotated case remains a disk-state async check, by design.)
-- **Cross-tab:** now genuinely covered — tab B sees tab A's broadcast `activeStream`, so its auto-trigger early-returns and its Generate disables.
+- **Cross-tab (finding 5 — reduces, doesn't eliminate):** once tab A's `setActive` has broadcast, tab B's auto-trigger early-returns and its Generate disables. But `BroadcastChannel` is asynchronous, so two tabs that detect analysis-complete in the same tick can both pass `shouldAutoTriggerProsody` _before_ either's `setActive` arrives → a residual double-run TOCTOU window. The disk `prosodyAnnotated` watermark dedups the eventual _write_, not the concurrent _run_. This is a narrow single-user-two-tabs edge; documented, not closed in v1.
 
 ### Toasts
 
@@ -95,27 +99,41 @@ Start toasts read as a live process, never as a queued item: "Detecting emotions
 - **Popover Cancel.** Cancel stays inline-only on the originating button; a Cancel control in the popover would require storing the `AbortController` on the slice — deferred.
 - **No queue-slice reuse.** `queue-slice.ts` / its dispatcher assume TTS-shaped per-chapter `QueueEntry` rows; analysis passes are not modelled as queue entries. Widening `QueueEntry.scope` for future analysis jobs is explicitly out of scope.
 
+## Adversarial review outcomes
+
+The spec was attacked against the live code after the first draft. Dispositions:
+
+1. **Broadcast is not a generic allow-set (Critical → fixed).** `broadcast-middleware.ts` is a bespoke per-slice snapshot protocol with separate inbound reducers; naively adding progress actions would infinite-loop. Resolved by Decision 3's dedicated `sync:substage` kind + `applyExternal*` reducers.
+2. **Singular gate-bearing stream clobbers cross-tab (High → fixed).** A `clear()` from book X would release book Y's gate in another tab. Resolved by Decision 2's bookId-keyed map; locked by a `broadcast-middleware.test.ts` case.
+3. **Missing `clear()` on the error path jams the gate globally (High → fixed).** Both thunks now `clear({bookId})` in `finally`.
+4. **`prosody-pill` retirement under-scoped (Medium → fixed).** `e2e/analysis-prosody-toggle.spec.ts` is re-pointed, not just the unit test.
+5. **Cross-tab auto-trigger guard is a TOCTOU (Medium → documented).** Reduces double-fire, doesn't eliminate the same-tick race; accepted for v1.
+6. **Pill "Analysing %" discontinuity (Low → accepted).** Percent resets between phases; popover disambiguates.
+7. **Enqueue guard, mixed-book batch (Low → fixed).** Filters gated entries, enqueues the rest.
+
 ## Test plan
 
 **Unit (Vitest):**
-- `script-review-slice.test.ts` — new `activeStream` reducers.
-- `script-review-thunk.test.ts` — `runReviewScript` dispatch sequence (setActive → updateProgress → setReview → clear; cancel path).
-- `prosody-thunk.test.ts` (update) + `prosody-autotrigger.test.tsx` — manual button now drives the slice; auto-trigger unchanged.
-- `shouldAutoTriggerProsody.test.ts` — idle → true; prosody-active → false; review-active → false.
+- `prosody-slice.test.ts` (migrate) — singular → `activeStreams` map; `clear({bookId})` removes only that book; concurrent books coexist.
+- `script-review-slice.test.ts` — new `activeStreams` map reducers + `applyExternalStreams`.
+- `script-review-thunk.test.ts` — `runReviewScript` dispatch sequence (setActive → updateProgress → setReview, with `clear({bookId})` in `finally` on the success AND error paths).
+- `prosody-thunk.test.ts` (update) + `prosody-autotrigger.test.tsx` — manual button now drives the slice and clears in `finally`; auto-trigger uses keyed actions.
+- `shouldAutoTriggerProsody.test.ts` — idle → true; prosody-active(book) → false; review-active(book) → false; active-on-_other_-book → true.
 - `top-bar.test.tsx` — new `analysisSubstage` rung at the correct priority.
-- selector tests — per-book `selectProsodyRunningForBook` / `selectReviewRunningForBook` / `selectAnalysisSubstage`.
-- broadcast-middleware test — the six progress actions broadcast; the result actions do not.
+- selector tests — per-book `selectProsodyRunningForBook` / `selectReviewRunningForBook` / `selectAnalysisSubstage` (incl. multi-book tie-break determinism).
+- `broadcast-middleware.test.ts` — `sync:substage` round-trips `set`/`clear` per book; inbound `applyExternalStreams` does **not** re-broadcast (echo layer 2); `updateProgress` debounces per `(stream, bookId)`; a `clear` on book X leaves book Y's entry intact (the finding-2 regression).
 
 **E2E (Playwright, mock mode):**
 - `detect-emotions-pill-progress.spec.ts` — manual prosody → analysis-substage pill updates → navigate away → still updating → completion toast.
 - `script-review-pill-progress.spec.ts` — whole-book review → pill updates → navigate away → toast + diff modal.
 - `prosody-auto-trigger-guard.spec.ts` — auto-trigger skips `runProsodyPasses` while a stream is active for the same book.
 - `generate-disabled-while-analysing.spec.ts` — Generate disabled with the warning copy while a sub-stage runs; other books unaffected.
+- **Re-point `e2e/analysis-prosody-toggle.spec.ts`** off the retired `prosody-pill` testid onto the new analysis-rung pill (finding 4).
 - extend `mockReviewScript` for a predictable progress cadence.
 
 **Verification commands:**
 - `npm run typecheck`
-- `npm run test -- top-bar.test.tsx prosody-thunk.test.ts src/store/script-review-slice.test.ts src/store/script-review-thunk.test.ts src/store/shouldAutoTriggerProsody.test.ts`
+- `npm run test -- top-bar.test.tsx prosody-slice.test.ts prosody-thunk.test.ts src/store/script-review-slice.test.ts src/store/script-review-thunk.test.ts src/store/shouldAutoTriggerProsody.test.ts src/store/broadcast-middleware.test.ts`
 - `npm test` (full unit)
 - `npm run test:e2e -- e2e/detect-emotions-pill-progress.spec.ts e2e/script-review-pill-progress.spec.ts e2e/prosody-auto-trigger-guard.spec.ts e2e/generate-disabled-while-analysing.spec.ts`
 - `npm run verify` (full battery)

--- a/docs/superpowers/specs/2026-06-30-manuscript-analysis-pill-gate-design.md
+++ b/docs/superpowers/specs/2026-06-30-manuscript-analysis-pill-gate-design.md
@@ -70,17 +70,29 @@ Update both slice header comments: replace the "do NOT broadcast" note with "pro
 
 - **Manual `DetectEmotionsButton`** dispatches `prosodyActions.setActive({bookId})` on start and `updateProgress({bookId})` via the existing `runProsodyPasses` `onProgress` callback. **`clear({bookId})` MUST be in a `finally`** — covering success, error, _and_ abort — so a failed/aborted pass can never leave a stuck stream (which, broadcast cross-tab, would disable Generate in every tab). The button's current `run()` clears `phase` per-branch but has no pill `clear` in `finally` (`detect-emotions-button.tsx:58–74`); the migration adds it. The inline badge re-sources from the slice so it survives navigation.
 - **Review** gains a thunk `runReviewScript(bookId, { wholeBook })` in `src/store/script-review-thunk.ts` that dispatches `scriptReviewActions.setActive/updateProgress` around the pass and `setReview` on completion. `handleReviewScript` (`manuscript.tsx:697`) already has a `try/finally` (resets `reviewLoading`); the thunk's `clear({bookId})` lands in that same `finally`. Whole-book RPD gating stays where it is.
-- **`summarizeStatus`** gains `analysisSubstage` on `StatusInput`. A new rung sits **directly below `analysis?.state === 'running'`**:
+- **`summarizeStatus`** gains `analysisSubstage` on `StatusInput`, AND its priority ladder is regrouped into **Voice-engine → Analysis → Design** order (operator decision, 2026-06-30). Today the ladder is `Halted > Stalled > Generating > Analysing > Designing > Loading model > Paused > Revisions`; "Loading model" is a voice-engine state stranded below Design. The new ladder groups the voice-engine states together at the top of the active rungs:
+
+  ```
+  Halted > Stalled                       (attention — unchanged)
+    > Generating                         (Voice engines — heaviest; always wins the chip, no popover needed)
+    > Loading model                      (Voice engines — MOVED UP from below Design)
+    > Analysing                          (Analysis)
+    > Analysing-substage                 (Analysis — NEW rung)
+    > Designing                          (Design)
+    > Paused > Revisions > idle
+  ```
+
+  Implementation: move the `anyModelLoading` check **above** the `analysis?.state === 'running'` block, then add the substage rung **directly below** `analysis-running`:
 
   ```ts
   if (analysisSubstage)
     return { label: 'Analysing', tone: 'peach', icon: 'spinner', detail: `${analysisSubstage.percent}%` };
   ```
 
-  Real analysis still outranks it — the sub-stages run _after_ the main analysis pass completes, so in practice they don't overlap; the ordering only matters for the degenerate manual-trigger-during-analysis case, where the primary pass correctly wins. **Known UX wart (finding 6, accepted):** when the main analysis finishes at "Analysing · 100%" and prosody starts at "Analysing · 0%", the pill's percent resets under the same label — it reads briefly like a regression. Accepted for v1 because it _is_ a genuine new phase; the popover names the active sub-stage, which disambiguates.
+  Consequences of the regroup: (a) **Generating** stays the top active rung — the heaviest process dominates the chip without opening the popover; (b) a voice-engine **model-load now outranks both an active analysis pass and an analysis sub-stage** (so the H3 substage-vs-model-load tie resolves in model-load's favour for free) — acceptable because the analyzer (Ollama) and a TTS model-load evict each other on one GPU and rarely coexist, and the analysis % stays visible in the popover. **Known UX wart (finding 6, accepted):** main analysis ends at "Analysing · 100%", then a sub-stage starts at "Analysing · 0%" — the percent resets under the same label. Accepted for v1 (it _is_ a genuine new phase); the popover names the active sub-stage.
 - **Pass mutual-exclusion (finding 10).** The two analysis passes share the analyzer (Ollama/Gemini), so they must not run together on one book. Both `DetectEmotionsButton` and the Review Script buttons (`manuscript.tsx:827/835/850`) gain `disabled={… || selectAnalysisBusyForBook(state, bookId)}` — so while _either_ pass runs on a book, _both_ buttons disable for that book. (Each button keeps its existing local `phase`/`reviewLoading` flag too, for instant feedback before the slice settles.) Other books are unaffected.
-- **Popover** (`status-popover.tsx` / `StatusDetail`): the analysis section renders the active sub-stage row with user-facing wording — "Detecting emotions · NN%" / "Reviewing · NN%" (never the word "prosody" in UI copy).
-- **Retire** the standalone prosody pill block in `layout.tsx` (~1512). **Blast radius (finding 4):** `data-testid="prosody-pill"` is referenced by `layout.tsx`, `layout-prosody-pill.test.tsx`, **and `e2e/analysis-prosody-toggle.spec.ts`** — delete the unit test and **re-point the e2e spec** at the new analysis-rung pill, don't just drop the unit test.
+- **Popover** (`status-popover.tsx` / `StatusDetail`): the analysis section renders the active sub-stage row with user-facing wording — "Detecting emotions · NN%" / "Reviewing · NN%" (never the word "prosody" in UI copy). **In-scope copy rename (operator, 2026-06-30):** the popover's `Section title="TTS engines"` (`status-popover.tsx:156`) and its "TTS controls appear…" hint become **"Voice engines"** / "Voice engine controls appear…". (The broader app-wide "TTS" → "Voice engines" rename — eviction banners, admin page, etc. — is tracked as a SEPARATE change; it is not folded into this feature branch.)
+- **Retire** the standalone prosody pill block in `layout.tsx` (~1512). **Blast radius (finding 4, corrected by H2):** `data-testid="prosody-pill"` is only in `layout.tsx` (the JSX) and `layout-prosody-pill.test.tsx` (deleted). `e2e/analysis-prosody-toggle.spec.ts` does **not** assert on it — it only has a stale code _comment_ mentioning the unit test (line 10); clean that comment when deleting the test, no e2e re-point needed.
 
 ### 3. Generate-gate (per-book, defense-in-depth)
 
@@ -112,7 +124,7 @@ The spec was attacked against the live code after the first draft. Dispositions:
 1. **Broadcast is not a generic allow-set (Critical → fixed).** `broadcast-middleware.ts` is a bespoke per-slice snapshot protocol with separate inbound reducers; naively adding progress actions would infinite-loop. Resolved by Decision 3's dedicated `sync:substage` kind + `applyExternal*` reducers.
 2. **Singular gate-bearing stream clobbers cross-tab (High → fixed).** A `clear()` from book X would release book Y's gate in another tab. Resolved by Decision 2's bookId-keyed map; locked by a `broadcast-middleware.test.ts` case.
 3. **Missing `clear()` on the error path jams the gate globally (High → fixed).** Both thunks now `clear({bookId})` in `finally`.
-4. **`prosody-pill` retirement under-scoped (Medium → fixed).** `e2e/analysis-prosody-toggle.spec.ts` is re-pointed, not just the unit test.
+4. **`prosody-pill` retirement scope (Medium → corrected in round 4/H2).** Originally thought `e2e/analysis-prosody-toggle.spec.ts` needed re-pointing; an independent pass found it only has a stale _comment_ (no assertion). Blast radius is just `layout.tsx` JSX + the deleted `layout-prosody-pill.test.tsx`; clean the comment.
 5. **Cross-tab auto-trigger guard is a TOCTOU (Medium → documented).** Reduces double-fire, doesn't eliminate the same-tick race; accepted for v1.
 6. **Pill "Analysing %" discontinuity (Low → accepted).** Percent resets between phases; popover disambiguates.
 7. **Enqueue guard, mixed-book batch (Low → fixed).** Filters gated entries, enqueues the rest.
@@ -145,7 +157,7 @@ The spec was attacked against the live code after the first draft. Dispositions:
 - `script-review-pill-progress.spec.ts` — whole-book review → pill updates → navigate away → toast + diff modal.
 - `prosody-auto-trigger-guard.spec.ts` — auto-trigger skips `runProsodyPasses` while a stream is active for the same book.
 - `generate-disabled-while-analysing.spec.ts` — Generate disabled with the warning copy while a sub-stage runs; other books unaffected.
-- **Re-point `e2e/analysis-prosody-toggle.spec.ts`** off the retired `prosody-pill` testid onto the new analysis-rung pill (finding 4).
+- **Clean the stale `prosody-pill` comment** in `e2e/analysis-prosody-toggle.spec.ts` (line 10) when deleting the unit test — the spec has no `prosody-pill` assertion to re-point (finding 4 / H2).
 - extend `mockReviewScript` for a predictable progress cadence.
 
 **Verification commands:**


### PR DESCRIPTION
## Summary

Lands the **spec** and **implementation plan** for the manuscript analysis-pill + Generate-gate feature so they aren't stranded on an unmerged branch while the implementation agent works off them. Docs-only — no app code.

- `docs/superpowers/specs/2026-06-30-manuscript-analysis-pill-gate-design.md` — design spec, hardened over 4 adversarial review rounds (spec rounds 1–2: 14 findings; plan rounds 3–4: R1–R5 + H1–H4 by an independent reviewer).
- `docs/superpowers/plans/2026-06-30-manuscript-analysis-pill-gate.md` — 11-task TDD implementation plan (full code in every step).
- `docs/BACKLOG.md` — thin row for **fe-44** (the deliberately-deferred app-wide "TTS" → "Voice engines" copy rename follow-up).

The feature itself (per-book analysis-progress on the Status pill, hard Generate-gate while a pass runs, pass mutual-exclusion, auto-trigger double-fire guard, cross-tab `sync:substage`) is being implemented on a separate `feat/frontend-analysis-pill-gate` branch — not in this PR.

## Test plan

Docs-only change; no automated tests apply. The plan's own tests land with the implementation PR.

Refs #1182