### PR TITLE
test(sidecar): stub speechbrain in spk-degrade test to stop sys.modules poison

### DIFF
--- a/server/tts-sidecar/tests/test_device_parse.py
+++ b/server/tts-sidecar/tests/test_device_parse.py
@@ -36,15 +36,32 @@ def test_spk_indexed_cuda_degrades_when_no_gpu(monkeypatch):
     import types
     fake = types.SimpleNamespace(cuda=types.SimpleNamespace(is_available=lambda: False))
     monkeypatch.setitem(sys.modules, "torch", fake)
-    # exercise only the present-check branch (no real speechbrain load)
+    # Stub speechbrain too. After the degrade, ensure_loaded() still proceeds to a
+    # real cpu _load_on(); a genuine `import speechbrain` under the stubbed torch
+    # fails partway and leaves the package PARTIALLY INITIALIZED in sys.modules
+    # (monkeypatch reverts torch but not speechbrain). That poison then reddens the
+    # real-ECAPA tests in test_speaker_embed under the full battery with a cryptic
+    # "partially initialized module 'speechbrain' has no attribute 'utils'" — the
+    # #1181 "flake". The stub keeps this test to its stated intent: exercise the
+    # degrade decision, never the real model load. (Mirror of test_speaker_embed's
+    # _install_speechbrain_stub.)
+    class _FakeEnc:
+        @staticmethod
+        def from_hparams(**kw):
+            return object()
+    mod_sb = types.ModuleType("speechbrain")
+    mod_inf = types.ModuleType("speechbrain.inference")
+    mod_spk = types.ModuleType("speechbrain.inference.speaker")
+    mod_spk.EncoderClassifier = _FakeEnc
+    mod_inf.speaker = mod_spk
+    mod_sb.inference = mod_inf
+    monkeypatch.setitem(sys.modules, "speechbrain", mod_sb)
+    monkeypatch.setitem(sys.modules, "speechbrain.inference", mod_inf)
+    monkeypatch.setitem(sys.modules, "speechbrain.inference.speaker", mod_spk)
     import asyncio
-    async def run():
-        try:
-            await spk.ensure_loaded()
-        except Exception:
-            pass  # speechbrain import may fail in CI; we only assert the device decision
-    asyncio.run(run())
+    asyncio.run(spk.ensure_loaded())
     assert spk.device == "cpu"
+    assert spk._model is not None  # degraded to cpu AND loaded (via the stub)
 
 
 import types as _types


### PR DESCRIPTION
## Summary

Closes #1181.

The two real-ECAPA tests in `server/tts-sidecar/tests/test_speaker_embed.py` (`test_embed_is_unit_norm_and_192d`, `test_self_cosine_is_one`) reported as a flake that passes alone but reds the gating `test:sidecar` leg under the full battery. **It is not a flake and not a parallel-load race** — the sidecar `pytest` runs serially. It is deterministic test-ordering pollution:

1. `test_device_parse.py::test_spk_indexed_cuda_degrades_when_no_gpu` (collected **before** `test_speaker_embed.py`) installs a stub `torch` into `sys.modules`.
2. It then calls `spk.ensure_loaded()` in a bare `try/except: pass`. With CUDA reported unavailable the engine degrades to cpu but **still proceeds** into a real `_load_on("cpu")`, which does `from speechbrain.inference.speaker import EncoderClassifier`.
3. speechbrain's `__init__` (line 6, `import speechbrain.lobes.models`) drives the real torch API — but it's the stub — so init dies partway, leaving **partially-initialized speechbrain submodules in `sys.modules`**.
4. `monkeypatch` reverts `torch` but not the poisoned speechbrain. The next real import in `test_speaker_embed` then hits `partially initialized module 'speechbrain' has no attribute 'utils' (most likely due to a circular import)`.

The test's own comment claimed "no real speechbrain load" — but it did exactly that.

### Fix

Stub `speechbrain` in that test (mirror of `test_speaker_embed`'s existing `_install_speechbrain_stub`) so it exercises only the cpu-degrade decision and never triggers the poisoning real import; drop the exception-swallowing wrapper and assert `spk._model is not None`. A real root-cause fix — **no quarantine**, so nothing is added to `docs/testing/flaky-register.md` and the gating `test:sidecar` leg stays honest.

## Test plan

- **Reproduced (deterministic):** `pytest tests/test_device_parse.py tests/test_speaker_embed.py` failed every run before the fix with the exact `partially initialized module 'speechbrain' has no attribute 'utils'` error; isolation (`test_speaker_embed` alone) passed.
- **After fix:** the same combined run → 20 passed (×3 loops); full `npm run test:sidecar` battery green (exit 0, `[100%]`, zero poison occurrences).
- Full `npm run verify` battery green at pre-push (typecheck + all tests + e2e + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)