### PR TITLE
feat(server): QA-cost RTF telemetry in the admin throughput table

### DIFF
--- a/docs/features/127-generation-rtf-telemetry.md
+++ b/docs/features/127-generation-rtf-telemetry.md
@@ -9,7 +9,7 @@ owner: null
 > Status: active
 > Key files: `server/tts-sidecar/main.py` (batch log + `SynthBatchResult` genMs/audioMs + frame header), `server/src/tts/sidecar.ts` (parse perf header), `server/src/tts/generation-stats.ts` (chapter + live-batch windows + per-chapter history ring), `server/src/routes/generation-stats.ts`, `server/src/routes/generation.ts` (rollup + `onBatchComplete`), `server/src/tts/synthesise-chapter.ts` (`onBatchComplete`), `src/components/admin-pill.tsx`, `src/views/admin.tsx` (per-chapter throughput table), `src/lib/api.ts`
 > URL surface: `GET /api/generation/stats`; top-bar Admin pill (all-users since [[172-admin-watch-console]]) + Admin-view throughput table
-> OpenAPI ops: none (dev/observability endpoint, not part of the public contract)
+> OpenAPI ops: `GET /api/generation/stats` (full schema, added PR-2 2026-07-01 — see "QA-cost telemetry" below; was previously undocumented)
 
 ## Benefit / Rationale
 
@@ -65,6 +65,34 @@ written only at chapter completion) looked stalled when it was fine.
   The sidecar `batch synth` line is pure-compute (`gen_ms ÷ Σ audio_ms`); the
   server rollup + pill are end-to-end (chapter synth wall ÷ audio), which is
   higher because it includes HTTP + queueing + cross-engine waits — by design.
+  **Narrowed 2026-07-01 (PR-2):** "chapter synth wall" now excludes the
+  post-synth loudnorm encode + disk write (captured right after
+  `synthesiseChapter` returns, not after `finalizeChapterAudioWrite`) — RTF
+  numbers (route log line, `recordChapterThroughput`'s `rtf`, and the fs-20
+  `resource-telemetry.jsonl` `wallSec`) shift down at this deploy boundary.
+  No version marker distinguishes pre/post records in the JSONL file — this
+  was accepted rather than added: the file is a capped, best-effort
+  observability ring (2000 lines, rotates), the field is advisory (a trend
+  chart), and the step-change ages out of the window within one active book's
+  worth of generation. See `server/src/tts/resource-telemetry.ts`'s `wallSec`
+  doc comment.
+- **QA-cost telemetry (PR-2, 2026-07-01):** `synthesiseChapter` also returns
+  `rerecordMs`/`transcribeMs`/`embedMs` — the wall time its own QA re-record
+  loop (signal-QA + ASR-QA) and speaker-embed pass spent, broken out of the
+  narrowed synth wall above. `generation-stats.ts` derives two more per-chapter
+  fields from these: `rerecordRtf` (rerecordMs ÷ audioSec) and `verifyRtf`
+  ((transcribeMs + embedMs) ÷ audioSec) — both `number | null`. The admin
+  throughput table (`GenerationThroughput` in `src/views/admin.tsx`) renders
+  `rerecordRtf` as a new "QA" column; `verifyRtf` is plumbed end-to-end but not
+  yet rendered. **Gated on ACTUAL concurrency, not a config read:** the split
+  is only meaningful when this chapter's render never overlapped another job's
+  wall-clock — summing per-block time under real interleaving over-counts. The
+  gate is `RunningJob.hadSibling` in `server/src/routes/generation.ts`,
+  flipped true in `registerJob` whenever `inFlightByChapter.size > 1` (global
+  across all books, matching how the queue dispatcher's N workers map onto N
+  concurrent chapter jobs) — NOT `getResolvedGenerationWorkers() === 1`, which
+  can't see two single-worker books rendering simultaneously or a mid-run
+  worker-count change and would mislabel genuinely contended data as clean.
 - **Reversibility:** delete the endpoint mount + the pill swap; the accumulator
   is inert if nothing calls `recordChapterThroughput`.
 
@@ -99,6 +127,11 @@ written only at chapter completion) looked stalled when it was fine.
   history ring stays back-compatible with existing call sites and tests.
 - Each history `rtf` is `null` (not `0`) when the chapter produced no audio, so
   the table renders a dash and skips the trend comparison (no `Infinity` row).
+- `rerecordRtf`/`verifyRtf` are `null` whenever `RunningJob.hadSibling` is true
+  for the completing job (real overlap detected) OR the QA sub-costs are
+  absent (multi-worker path never populates them) — the gate must key off
+  actual concurrency, never a static `generationWorkers` config read
+  (`server/src/routes/generation.ts`).
 
 ## Test plan
 
@@ -122,6 +155,14 @@ written only at chapter completion) looked stalled when it was fine.
 - Vitest server (`server/src/routes/generation-stats.test.ts`) — `GET
   /api/generation/stats` returns the idle shape, reflects a recorded chapter, and
   serialises the per-chapter history with `title`/`bookId`/`modelKey`.
+- Vitest server (`server/src/tts/generation-stats.test.ts`, B1 cases) —
+  `rerecordRtf`/`verifyRtf` derivation from the QA sub-costs, including
+  either-sub-cost-alone and `audioSec===0` edge cases.
+- Vitest server (`server/src/routes/generation.test.ts`, "B1 QA-cost telemetry
+  passthrough") — a lone chapter render reports non-null `rerecordRtf`/
+  `verifyRtf`; two chapters driven through GENUINE concurrent overlap (a gated
+  synth mock, no `generationWorkers` config touched) both report `null` —
+  pins the gate to actual concurrency, not the config value.
 - Vitest frontend (`src/components/worktrees-rtf-pill.test.tsx`) — idle shows
   just "wt"; generating shows the live per-batch RTF; the live per-batch figure
   is preferred over the per-chapter rollup; falls back to per-chapter when no

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -29,4 +29,21 @@ test.describe('Admin watch console', () => {
     // The top-bar dot reflects the mock board's overall: 'ok'.
     await expect(page.getByTestId('topbar-health-dot')).toHaveAttribute('data-status', 'ok');
   });
+
+  test('throughput table shows the QA re-record RTF column', async ({ page }) => {
+    await page.goto('/#/admin');
+
+    // Wait for the generation throughput table to load.
+    const table = page.getByTestId('generation-throughput-table');
+    await expect(table).toBeVisible({ timeout: 10_000 });
+
+    // The "QA" header cell is visible within the throughput table (scoped so
+    // it can't collide with any other "QA" text elsewhere on the page).
+    await expect(table.getByText('QA', { exact: true })).toBeVisible();
+
+    // The mock's newest chapter (id=7) carries rerecordRtf: 0.02, formatted
+    // via fmtRtf — proves the value actually flows through, not just the label.
+    const row7 = page.getByTestId('throughput-row-7');
+    await expect(row7).toContainText('0.02');
+  });
 });

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -42,8 +42,10 @@ test.describe('Admin watch console', () => {
     await expect(table.getByText('QA', { exact: true })).toBeVisible();
 
     // The mock's newest chapter (id=7) carries rerecordRtf: 0.02, formatted
-    // via fmtRtf — proves the value actually flows through, not just the label.
+    // via fmtRtf — proves the value actually flows through the QA cell
+    // specifically, not just present somewhere else in the row (e.g. the
+    // Synth-wall or RTF cells, which carry unrelated numbers).
     const row7 = page.getByTestId('throughput-row-7');
-    await expect(row7).toContainText('0.02');
+    await expect(row7.getByTestId('throughput-qa-cell')).toHaveText('0.02');
   });
 });

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2266,6 +2266,23 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/GpuQueueState' }
 
+  /api/generation/stats:
+    get:
+      summary: Live generation-throughput snapshot for the dev top-bar RTF pill
+      operationId: getGenerationStats
+      description: |
+        Returns a live snapshot of generation throughput: per-chapter rolling-window
+        aggregate (lagging summary), per-batch live window (responsive figure), and
+        a recent-chapter history ring (trend across the run). Backs the dev top-bar
+        RTF pill so the developer can self-monitor speed without grepping logs.
+        All fields go null-or-zero-valued when idle > 10 minutes.
+      responses:
+        '200':
+          description: Live generation-throughput snapshot
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/GenerationStatsResponse' }
+
   /api/generation/telemetry:
     get:
       summary: Per-run resource telemetry for the Admin trend panel (fs-20)
@@ -5141,6 +5158,111 @@ components:
           type: integer
           minimum: 1
           description: "Configured concurrency ceiling — the GPU_CONCURRENCY env var (default 1). Bump only after measuring VRAM headroom on the target GPU."
+
+    # --- Live generation throughput (dev RTF pill) -----
+    ChapterThroughputRecord:
+      type: object
+      required: [chapterId, title, bookId, modelKey, rtf, rerecordRtf, verifyRtf, audioSec, synthSec, at]
+      description: |
+        One finished chapter's own throughput, for the history ring. `rtf` is
+        `synthSec / audioSec` (< 1 = faster than realtime) or null when the
+        chapter produced no audio. QA-cost fields are populated only for single-
+        worker runs; null for multi-worker interleaving (sums over-count).
+      properties:
+        chapterId:
+          oneOf:
+            - type: integer
+            - type: string
+        title: { type: string, nullable: true }
+        bookId: { type: string, nullable: true }
+        modelKey: { type: string, nullable: true }
+        rtf: { type: number, nullable: true, description: 'synth wall ÷ audio (< 1 = faster than realtime).' }
+        rerecordRtf:
+          type: number
+          nullable: true
+          description: QA-driven re-record wall ÷ audio for this chapter; null for multi-worker runs.
+        verifyRtf:
+          type: number
+          nullable: true
+          description: Always-on verify floor (transcribe + embed) ÷ audio; null for multi-worker runs.
+        audioSec: { type: number, description: 'Audio duration in seconds.' }
+        synthSec: { type: number, description: 'Synthesis (TTS wall) duration in seconds.' }
+        at: { type: string, format: date-time, description: 'ISO timestamp when the chapter finished rendering.' }
+
+    GenerationStatsResponse:
+      type: object
+      required: [chapters, audioSec, synthSec, rtf, xRealtime, chaptersPerHour, last, updatedAt, liveBatchRtf, lastBatchRtf, batchesInWindow, batchUpdatedAt, recentChapters]
+      description: |
+        Live generation-throughput snapshot. Groups three time-windows:
+        (1) per-chapter rolling window (lagging summary, updates when chapters finish),
+        (2) per-batch live window (responsive, updates every ~batch),
+        (3) per-chapter history ring (trend, newest-first, bounded).
+        All chapter-window fields go null-or-zero when idle > 10 minutes.
+      properties:
+        chapters:
+          type: integer
+          minimum: 0
+          description: 'Chapters folded in since the window opened (rolling-window aggregate).'
+        audioSec:
+          type: number
+          minimum: 0
+          description: 'Rolling total audio seconds over the window.'
+        synthSec:
+          type: number
+          minimum: 0
+          description: 'Rolling total synth (TTS wall) seconds over the window.'
+        rtf:
+          type: number
+          nullable: true
+          description: 'synthSec ÷ audioSec over the window (< 1 = faster than realtime).'
+        xRealtime:
+          type: number
+          nullable: true
+          description: 'audioSec ÷ synthSec — the "Nx realtime" figure.'
+        chaptersPerHour:
+          type: number
+          nullable: true
+          description: 'chapters ÷ window-wall-hours.'
+        last:
+          type: object
+          nullable: true
+          description: "The most-recently-finished chapter's own figures."
+          required: [chapterId, rtf, audioSec, synthSec, at]
+          properties:
+            chapterId:
+              oneOf:
+                - type: integer
+                - type: string
+            rtf: { type: number }
+            audioSec: { type: number }
+            synthSec: { type: number }
+            at: { type: string, format: date-time }
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: 'ISO timestamp of the last chapter fold, or null when the window is empty.'
+        liveBatchRtf:
+          type: number
+          nullable: true
+          description: 'Aggregate ΣgenMs ÷ ΣaudioMs over the recent-batch window (< 1 = faster than realtime). The headline LIVE figure; null when no batch is recent.'
+        lastBatchRtf:
+          type: number
+          nullable: true
+          description: "The single most-recent batch's rtf."
+        batchesInWindow:
+          type: integer
+          minimum: 0
+          description: 'How many batches the live window is averaging.'
+        batchUpdatedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: 'ISO timestamp of the most-recent batch, or null when none is recent.'
+        recentChapters:
+          type: array
+          items: { $ref: '#/components/schemas/ChapterThroughputRecord' }
+          description: 'Recent finished chapters, NEWEST-FIRST, capped at ~200. Survives rolling-window resets (trend across pauses).'
 
     # --- Per-run resource telemetry (fs-20) ---------------------------
     ResourceTelemetryRecord:

--- a/server/src/routes/generation.test.ts
+++ b/server/src/routes/generation.test.ts
@@ -1391,20 +1391,17 @@ describe('POST /api/books/:bookId/generation — persists generationState on fai
 
 /* B1 (PR-2 QA-cost telemetry) — the route narrows synthMs to the pre-encode
    wall and forwards synthesiseChapter's rerecordMs/transcribeMs/embedMs QA
-   sub-costs into recordChapterThroughput, but ONLY for a single-worker run
-   (generationWorkers === 1): under multi-worker interleaving, summing each
-   block's own wall is physically meaningless, so the route passes `null`
-   instead. getGenerationStats() reads the same in-process accumulator the
-   route feeds, and `recentChapters` is newest-first, so the freshest entry
-   always reflects the chapter this test just drove through the route. */
+   sub-costs into recordChapterThroughput, but ONLY when this chapter's render
+   never overlapped another job's (`job.hadSibling`, tracked from ACTUAL
+   concurrent registration in inFlightByChapter — not a generationWorkers
+   config read, which can't see two single-worker books rendering
+   simultaneously or a mid-run worker-count change): under real interleaving,
+   summing each block's own wall is physically meaningless, so the route
+   passes `null` instead. getGenerationStats() reads the same in-process
+   accumulator the route feeds. */
 describe('POST /api/books/:bookId/generation — B1 QA-cost telemetry passthrough', () => {
-  afterEach(() => {
-    delete process.env.GEN_WORKERS;
-  });
-
-  it('single-worker render reports non-null rerecordRtf/verifyRtf on the stats accumulator', async () => {
+  it('a lone chapter render (no concurrent sibling) reports non-null rerecordRtf/verifyRtf', async () => {
     resetGenerationStats();
-    process.env.GEN_WORKERS = '1';
     synthesiseImpl = async () => ({
       pcm: Buffer.alloc(2),
       sampleRate: 24000,
@@ -1436,38 +1433,63 @@ describe('POST /api/books/:bookId/generation — B1 QA-cost telemetry passthroug
     expect(latest.verifyRtf).toBeCloseTo((500 + 300) / 1000 / 10, 5);
   });
 
-  it('multi-worker render leaves rerecordRtf/verifyRtf null (summed wall is meaningless under interleaving)', async () => {
+  it('two GENUINELY concurrent chapter renders leave rerecordRtf/verifyRtf null for both (real overlap, no generationWorkers config set at all)', async () => {
     resetGenerationStats();
-    process.env.GEN_WORKERS = '2';
-    synthesiseImpl = async () => ({
-      pcm: Buffer.alloc(2),
-      sampleRate: 24000,
-      durationSec: 10,
-      segments: [
-        {
-          characterId: 'narrator',
-          voiceName: 'Zephyr',
-          sampleStart: 0,
-          sampleEnd: 1,
-          sentenceIds: [1],
-        },
-      ],
-      rerecordMs: 2000,
-      transcribeMs: 500,
-      embedMs: 300,
-    });
-    const res = await request(app)
+    /* Gate both synth calls so neither resolves until BOTH are in flight —
+       proves the gate reacts to actual overlap (job.hadSibling), since this
+       test never touches process.env.GEN_WORKERS / generationWorkers. */
+    const resolvers: Array<() => void> = [];
+    synthesiseImpl = (args: unknown) => {
+      const signal = (args as { signal?: AbortSignal }).signal;
+      return new Promise((resolve, reject) => {
+        const settle = () =>
+          resolve({
+            pcm: Buffer.alloc(2),
+            sampleRate: 24000,
+            durationSec: 10,
+            segments: [
+              {
+                characterId: 'narrator',
+                voiceName: 'Zephyr',
+                sampleStart: 0,
+                sampleEnd: 1,
+                sentenceIds: [1],
+              },
+            ],
+            rerecordMs: 2000,
+            transcribeMs: 500,
+            embedMs: 300,
+          });
+        const abortErr = () => Object.assign(new Error('aborted'), { name: 'AbortError' });
+        if (signal?.aborted) return reject(abortErr());
+        signal?.addEventListener('abort', () => reject(abortErr()), { once: true });
+        resolvers.push(settle);
+        if (resolvers.length >= 2) {
+          for (const r of resolvers.splice(0)) r();
+        }
+      });
+    };
+    const p1 = request(app)
       .post(`/api/books/${bookId}/generation`)
-      .send({ modelKey: 'gemini-2.5-flash', chapterIds: [1], force: true });
-    expect(res.status).toBe(200);
+      .send({ modelKey: 'gemini-2.5-flash', force: true, chapterIds: [1] });
+    const p2 = request(app)
+      .post(`/api/books/${bookId}/generation`)
+      .send({ modelKey: 'gemini-2.5-flash', force: true, chapterIds: [2] });
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
 
     const stats = getGenerationStats();
-    const latest = stats.recentChapters[0];
-    expect(latest.chapterId).toBe(1);
-    expect(latest.rerecordRtf).toBeNull();
-    expect(latest.verifyRtf).toBeNull();
+    const byChapter = new Map(stats.recentChapters.map((c) => [c.chapterId, c]));
+    const ch1 = byChapter.get(1)!;
+    const ch2 = byChapter.get(2)!;
+    expect(ch1.rerecordRtf).toBeNull();
+    expect(ch1.verifyRtf).toBeNull();
+    expect(ch2.rerecordRtf).toBeNull();
+    expect(ch2.verifyRtf).toBeNull();
     /* The plain rtf (whole-chapter synth ÷ audio) is unaffected by the gate —
-       only the QA sub-cost split is suppressed under multi-worker. */
-    expect(latest.rtf).not.toBeNull();
-  });
+       only the QA sub-cost split is suppressed under real overlap. */
+    expect(ch1.rtf).not.toBeNull();
+    expect(ch2.rtf).not.toBeNull();
+  }, 15_000);
 });

--- a/server/src/routes/generation.test.ts
+++ b/server/src/routes/generation.test.ts
@@ -82,6 +82,8 @@ let workspaceRoot: string;
 let bookDir: string;
 let app: Express;
 let bookId: string;
+let getGenerationStats: typeof import('../tts/generation-stats.js').getGenerationStats;
+let resetGenerationStats: typeof import('../tts/generation-stats.js').__resetGenerationStatsForTest;
 
 interface ParsedTick {
   type: string;
@@ -107,11 +109,14 @@ beforeAll(async () => {
   workspaceRoot = await mkdtemp(join(tmpdir(), 'audiobook-generation-test-'));
   process.env.WORKSPACE_DIR = workspaceRoot;
 
-  const [{ generationRouter }, { makeBookId }, cacheModule] = await Promise.all([
+  const [{ generationRouter }, { makeBookId }, cacheModule, statsModule] = await Promise.all([
     import('./generation.js'),
     import('../workspace/paths.js'),
     import('../store/analysis-cache.js'),
+    import('../tts/generation-stats.js'),
   ]);
+  getGenerationStats = statsModule.getGenerationStats;
+  resetGenerationStats = statsModule.__resetGenerationStatsForTest;
   bookId = makeBookId(AUTHOR, SERIES, TITLE);
 
   bookDir = join(workspaceRoot, 'books', AUTHOR, SERIES, TITLE);
@@ -1381,5 +1386,88 @@ describe('POST /api/books/:bookId/generation — persists generationState on fai
     const ch1 = (await readState()).chapters.find((c) => c.id === 1)!;
     expect(ch1.generationState).toBeUndefined();
     expect(ch1.generationError).toBeUndefined();
+  });
+});
+
+/* B1 (PR-2 QA-cost telemetry) — the route narrows synthMs to the pre-encode
+   wall and forwards synthesiseChapter's rerecordMs/transcribeMs/embedMs QA
+   sub-costs into recordChapterThroughput, but ONLY for a single-worker run
+   (generationWorkers === 1): under multi-worker interleaving, summing each
+   block's own wall is physically meaningless, so the route passes `null`
+   instead. getGenerationStats() reads the same in-process accumulator the
+   route feeds, and `recentChapters` is newest-first, so the freshest entry
+   always reflects the chapter this test just drove through the route. */
+describe('POST /api/books/:bookId/generation — B1 QA-cost telemetry passthrough', () => {
+  afterEach(() => {
+    delete process.env.GEN_WORKERS;
+  });
+
+  it('single-worker render reports non-null rerecordRtf/verifyRtf on the stats accumulator', async () => {
+    resetGenerationStats();
+    process.env.GEN_WORKERS = '1';
+    synthesiseImpl = async () => ({
+      pcm: Buffer.alloc(2),
+      sampleRate: 24000,
+      durationSec: 10,
+      segments: [
+        {
+          characterId: 'narrator',
+          voiceName: 'Zephyr',
+          sampleStart: 0,
+          sampleEnd: 1,
+          sentenceIds: [1],
+        },
+      ],
+      rerecordMs: 2000,
+      transcribeMs: 500,
+      embedMs: 300,
+    });
+    const res = await request(app)
+      .post(`/api/books/${bookId}/generation`)
+      .send({ modelKey: 'gemini-2.5-flash', chapterIds: [1], force: true });
+    expect(res.status).toBe(200);
+
+    const stats = getGenerationStats();
+    const latest = stats.recentChapters[0];
+    expect(latest.chapterId).toBe(1);
+    expect(latest.rerecordRtf).not.toBeNull();
+    expect(latest.rerecordRtf).toBeCloseTo(2000 / 1000 / 10, 5);
+    expect(latest.verifyRtf).not.toBeNull();
+    expect(latest.verifyRtf).toBeCloseTo((500 + 300) / 1000 / 10, 5);
+  });
+
+  it('multi-worker render leaves rerecordRtf/verifyRtf null (summed wall is meaningless under interleaving)', async () => {
+    resetGenerationStats();
+    process.env.GEN_WORKERS = '2';
+    synthesiseImpl = async () => ({
+      pcm: Buffer.alloc(2),
+      sampleRate: 24000,
+      durationSec: 10,
+      segments: [
+        {
+          characterId: 'narrator',
+          voiceName: 'Zephyr',
+          sampleStart: 0,
+          sampleEnd: 1,
+          sentenceIds: [1],
+        },
+      ],
+      rerecordMs: 2000,
+      transcribeMs: 500,
+      embedMs: 300,
+    });
+    const res = await request(app)
+      .post(`/api/books/${bookId}/generation`)
+      .send({ modelKey: 'gemini-2.5-flash', chapterIds: [1], force: true });
+    expect(res.status).toBe(200);
+
+    const stats = getGenerationStats();
+    const latest = stats.recentChapters[0];
+    expect(latest.chapterId).toBe(1);
+    expect(latest.rerecordRtf).toBeNull();
+    expect(latest.verifyRtf).toBeNull();
+    /* The plain rtf (whole-chapter synth ÷ audio) is unaffected by the gate —
+       only the QA sub-cost split is suppressed under multi-worker. */
+    expect(latest.rtf).not.toBeNull();
   });
 });

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -64,7 +64,6 @@ import { clearMismatchedDesignedVoices } from '../tts/verify-designed-voice-lang
 import {
   getCachedUserSettings,
   getLastKnownQwenInstallState,
-  getResolvedGenerationWorkers,
   getResolvedSidecarUrl,
 } from '../workspace/user-settings.js';
 import { appendTelemetry } from '../tts/resource-telemetry.js';
@@ -277,6 +276,16 @@ interface RunningJob {
       (re)generated in this run. The dynamic `done` count is
       `runDoneBase + completedThisRun.size`. */
   runDoneBase: number;
+  /** True once another job was concurrently registered at any point during
+      this job's life — i.e. this chapter's render genuinely overlapped
+      wall-clock with a sibling (same book or a different one). Drives the
+      QA-cost telemetry gate below: a static generationWorkers===1 config
+      read can't see actual cross-book concurrency (two books each configured
+      for 1 worker, generating simultaneously) or a mid-run worker-count
+      change — this tracks the real thing instead. Set in registerJob, never
+      cleared, so once a chapter's wall time overlapped another render its QA
+      sub-costs stay tainted for the rest of this job's life. */
+  hadSibling: boolean;
   /** Chapter ids the loop has reported chapter_complete for in this
       run. The frontend reads `runDone` as `runDoneBase + this.size`. */
   completedThisRun: Set<number>;
@@ -387,6 +396,15 @@ function registerJob(key: string, job: RunningJob): void {
     inFlightByBook.set(job.bookId, set);
   }
   set.add(job);
+  /* Live concurrency signal for the QA-cost telemetry gate (see `hadSibling`
+     on RunningJob) — mark EVERY currently in-flight job, not just the new
+     arrival: a job that was alone when it registered but now has a sibling
+     is genuinely overlapping too, starting from this instant. Global across
+     inFlightByChapter (all books), matching how the queue dispatcher's N
+     workers map onto N concurrent chapter jobs. */
+  if (inFlightByChapter.size > 1) {
+    for (const j of inFlightByChapter.values()) j.hadSibling = true;
+  }
 }
 
 function deregisterJob(key: string, job: RunningJob): void {
@@ -975,6 +993,7 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
     runDoneBase,
     completedThisRun: new Set(),
     runInProgress: new Set(),
+    hadSibling: false,
   };
   registerJob(key, job);
 
@@ -1549,11 +1568,15 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
       const audioSec = result.durationSec;
       const chapterRtf = audioSec > 0 ? synthSec / audioSec : 0;
       /* B1 — the QA sub-cost split (rerecord/transcribe/embed) is only
-         meaningful as a per-chapter wall when one worker renders at a time;
-         under multi-worker interleaving the summed per-block wall over-counts
-         (concurrent chapters' QA work overlaps in real time), so pass null
-         and let the stats view render n/a rather than a misleading number. */
-      const oneWorker = getResolvedGenerationWorkers() === 1;
+         meaningful as a per-chapter wall when nothing else rendered at the
+         same time; under real interleaving the summed per-block wall
+         over-counts (concurrent chapters' QA work overlaps in real time), so
+         pass null and let the stats view render n/a rather than a misleading
+         number. `job.hadSibling` tracks ACTUAL overlap (see registerJob) —
+         a static generationWorkers===1 config read would miss two
+         single-worker books rendering simultaneously, or a mid-run
+         worker-count change. */
+      const oneWorker = !job.hadSibling;
       const roll = recordChapterThroughput({
         chapterId: chapter.id,
         audioSec,

--- a/server/src/routes/generation.ts
+++ b/server/src/routes/generation.ts
@@ -64,6 +64,7 @@ import { clearMismatchedDesignedVoices } from '../tts/verify-designed-voice-lang
 import {
   getCachedUserSettings,
   getLastKnownQwenInstallState,
+  getResolvedGenerationWorkers,
   getResolvedSidecarUrl,
 } from '../workspace/user-settings.js';
 import { appendTelemetry } from '../tts/resource-telemetry.js';
@@ -1440,6 +1441,11 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
         },
       });
 
+      /* B1/H1 — synth-only wall, captured BEFORE the loudnorm encode + disk
+         write so the RTF rollup measures TTS, not encode. (The old post-
+         finalize capture below wrongly folded encode into synthMs.) */
+      const synthOnlyMs = Date.now() - synthStartMs;
+
       /* All per-group synthesis is done; the next stretch is disk-write
          work (encode MP3 → temp file → segments JSON → atomic rename →
          state.json update). Tell the client so it stops looking like a
@@ -1537,17 +1543,27 @@ generationRouter.post('/:bookId/generation', async (req: Request, res: Response)
       /* RTF rollup. The sidecar logs per-batch compute rtf; this is the
          end-to-end pipeline figure (synth wall ÷ audio) the operator watches
          while a book renders, plus a rolling run average that also feeds the
-         dev top-bar throughput pill (GET /api/generation/stats). */
-      const synthSec = (Date.now() - synthStartMs) / 1000;
+         dev top-bar throughput pill (GET /api/generation/stats). Uses
+         synthOnlyMs (pre-encode) so the logged/recorded RTF match. */
+      const synthSec = synthOnlyMs / 1000;
       const audioSec = result.durationSec;
       const chapterRtf = audioSec > 0 ? synthSec / audioSec : 0;
+      /* B1 — the QA sub-cost split (rerecord/transcribe/embed) is only
+         meaningful as a per-chapter wall when one worker renders at a time;
+         under multi-worker interleaving the summed per-block wall over-counts
+         (concurrent chapters' QA work overlaps in real time), so pass null
+         and let the stats view render n/a rather than a misleading number. */
+      const oneWorker = getResolvedGenerationWorkers() === 1;
       const roll = recordChapterThroughput({
         chapterId: chapter.id,
         audioSec,
-        synthMs: Date.now() - synthStartMs,
+        synthMs: synthOnlyMs,
         title: chapter.title ?? null,
         bookId: job.bookId,
         modelKey,
+        rerecordMs: oneWorker ? result.rerecordMs : null,
+        transcribeMs: oneWorker ? result.transcribeMs : null,
+        embedMs: oneWorker ? result.embedMs : null,
       });
       console.info(
         `[generation] chapter ${chapter.id} "${chapter.title ?? ''}" rendered: ` +

--- a/server/src/tts/generation-stats.test.ts
+++ b/server/src/tts/generation-stats.test.ts
@@ -205,4 +205,42 @@ describe('generation-stats per-chapter history ring', () => {
     expect(s.recentChapters[0].rerecordRtf).toBeNull();
     expect(s.recentChapters[0].verifyRtf).toBeNull();
   });
+
+  it('B1: verifyRtf is computed from transcribeMs alone (embedMs absent, e.g. speaker-QA off)', () => {
+    __resetGenerationStatsForTest();
+    const s = recordChapterThroughput({
+      chapterId: 3,
+      audioSec: 100,
+      synthMs: 120_000,
+      transcribeMs: 8_000, // 8/100 → 0.08, no embedMs term
+    });
+    expect(s.recentChapters[0].rerecordRtf).toBeNull(); // no rerecordMs
+    expect(s.recentChapters[0].verifyRtf).toBeCloseTo(0.08, 3);
+  });
+
+  it('B1: verifyRtf is computed from embedMs alone (transcribeMs absent, e.g. ASR-QA off)', () => {
+    __resetGenerationStatsForTest();
+    const s = recordChapterThroughput({
+      chapterId: 4,
+      audioSec: 100,
+      synthMs: 120_000,
+      embedMs: 2_000, // 2/100 → 0.02, no transcribeMs term
+    });
+    expect(s.recentChapters[0].rerecordRtf).toBeNull();
+    expect(s.recentChapters[0].verifyRtf).toBeCloseTo(0.02, 3);
+  });
+
+  it('B1: QA fields are null (not Infinity/0) when audioSec is 0, even with sub-costs present', () => {
+    __resetGenerationStatsForTest();
+    const s = recordChapterThroughput({
+      chapterId: 5,
+      audioSec: 0,
+      synthMs: 30_000,
+      rerecordMs: 10_000,
+      transcribeMs: 5_000,
+      embedMs: 1_000,
+    });
+    expect(s.recentChapters[0].rerecordRtf).toBeNull();
+    expect(s.recentChapters[0].verifyRtf).toBeNull();
+  });
 });

--- a/server/src/tts/generation-stats.test.ts
+++ b/server/src/tts/generation-stats.test.ts
@@ -127,6 +127,8 @@ describe('generation-stats per-chapter history ring', () => {
       bookId: 'book-a',
       modelKey: 'qwen3-tts',
       rtf: 0.5, // 60 s synth / 120 s audio
+      rerecordRtf: null, // no QA sub-costs
+      verifyRtf: null, // no QA sub-costs
       audioSec: 120,
       synthSec: 60,
       at: new Date(T0).toISOString(),
@@ -181,5 +183,26 @@ describe('generation-stats per-chapter history ring', () => {
     recordChapterThroughput({ chapterId: 1, audioSec: 100, synthMs: 50_000 }, T0);
     __resetGenerationStatsForTest();
     expect(getGenerationStats(T0).recentChapters).toHaveLength(0);
+  });
+
+  it('B1: records rerecordRtf and verifyRtf from QA sub-costs', () => {
+    __resetGenerationStatsForTest();
+    const s = recordChapterThroughput({
+      chapterId: 1,
+      audioSec: 100,
+      synthMs: 120_000,
+      rerecordMs: 30_000, // 30s re-record over 100s audio → 0.30
+      transcribeMs: 8_000,
+      embedMs: 2_000, // (8+2)/100 → 0.10
+    });
+    expect(s.recentChapters[0].rerecordRtf).toBeCloseTo(0.3, 3);
+    expect(s.recentChapters[0].verifyRtf).toBeCloseTo(0.1, 3);
+  });
+
+  it('B1: QA fields are null when sub-costs are absent (multi-worker / no split)', () => {
+    __resetGenerationStatsForTest();
+    const s = recordChapterThroughput({ chapterId: 2, audioSec: 100, synthMs: 120_000 });
+    expect(s.recentChapters[0].rerecordRtf).toBeNull();
+    expect(s.recentChapters[0].verifyRtf).toBeNull();
   });
 });

--- a/server/src/tts/generation-stats.ts
+++ b/server/src/tts/generation-stats.ts
@@ -40,6 +40,11 @@ export interface ChapterThroughputRecord {
   bookId: string | null;
   modelKey: string | null;
   rtf: number | null;
+  /** B1 — QA-driven re-record wall ÷ audio (the cost the gate fixes move).
+      null when not split (generationWorkers > 1) or no audio. */
+  rerecordRtf: number | null;
+  /** B1 — always-on verify floor (transcribe + embed) ÷ audio. null as above. */
+  verifyRtf: number | null;
   audioSec: number;
   synthSec: number;
   at: string;
@@ -182,6 +187,9 @@ export function recordChapterThroughput(
     title?: string | null;
     bookId?: string | null;
     modelKey?: string | null;
+    rerecordMs?: number | null;
+    transcribeMs?: number | null;
+    embedMs?: number | null;
   },
   now: number = Date.now(),
 ): GenerationStats {
@@ -197,12 +205,23 @@ export function recordChapterThroughput(
   /* History ring — push BEFORE the window-reset branch so it always records,
      independent of the RESET_MS idle reset. Newest-first, capped. `rtf` is
      null (not 0) on no-audio so the view renders a dash and skips the tint. */
+  const hasAudio = input.audioSec > 0;
+  const rerecordRtf =
+    hasAudio && input.rerecordMs != null ? input.rerecordMs / 1000 / input.audioSec : null;
+  const verifyMs =
+    input.transcribeMs != null || input.embedMs != null
+      ? (input.transcribeMs ?? 0) + (input.embedMs ?? 0)
+      : null;
+  const verifyRtf = hasAudio && verifyMs != null ? verifyMs / 1000 / input.audioSec : null;
+
   history.unshift({
     chapterId: input.chapterId,
     title: input.title ?? null,
     bookId: input.bookId ?? null,
     modelKey: input.modelKey ?? null,
     rtf: input.audioSec > 0 ? synthSec / input.audioSec : null,
+    rerecordRtf,
+    verifyRtf,
     audioSec: input.audioSec,
     synthSec,
     at: new Date(now).toISOString(),

--- a/server/src/tts/generation-stats.ts
+++ b/server/src/tts/generation-stats.ts
@@ -28,7 +28,12 @@
    faster-than-realtime. `xRealtime` is the inverse (audio / wall). The chapter
    window groups one run; a gap > RESET_MS starts fresh so yesterday's stat
    never dilutes today's. The batch window is independent — it reports while the
-   FIRST chapter is still rendering (when the chapter window is still empty). */
+   FIRST chapter is still rendering (when the chapter window is still empty).
+
+   QA-cost fields (`rerecordRtf`/`verifyRtf`) are populated only for single-
+   worker runs (`generationWorkers === 1`); under multi-worker interleaving
+   the summed per-block wall over-counts, so the route passes them as `null`
+   (rendered n/a). */
 
 /** One finished chapter's own throughput, for the history ring. `rtf` is
     `synthSec / audioSec` (< 1 = faster than realtime) or `null` when the

--- a/server/src/tts/resource-telemetry.ts
+++ b/server/src/tts/resource-telemetry.ts
@@ -25,6 +25,13 @@ export interface ResourceTelemetryRecord {
   modelKey: string | null;
   rtf: number | null;
   audioSec: number;
+  /** Chapter synth wall time. Narrowed 2026-07-01 (PR-2,
+      [[127-generation-rtf-telemetry]]) to exclude the post-synth loudnorm
+      encode + disk write — records from before that change include them, so
+      a trend chart spanning the deploy boundary shows a step-change drop
+      that is NOT a real perf improvement. No version marker distinguishes
+      old vs. new records (see the plan for why this was accepted rather than
+      added). */
   wallSec: number;
   vramReservedMb: number | null;
   vramTotalMb: number | null;

--- a/server/src/tts/synthesise-chapter.embed-failure.test.ts
+++ b/server/src/tts/synthesise-chapter.embed-failure.test.ts
@@ -1,0 +1,121 @@
+/* Regression coverage for the B1 `embedMs` accounting fix (PR-2 telemetry,
+   task review round 2).
+
+   The SPK embed pass (`collectGroupEmbeddings`, gated on
+   `qa.speaker.enabled`) is non-fatal: a failed embed call is caught and
+   logged so synthesis never breaks on a missing/unreachable sidecar. The
+   wall-clock time spent in that pass must still be credited to `embedMs`
+   even when the pass throws — `synthesise-chapter.ts` does this via a
+   `finally` block around the `embT0`/`embedMs` accounting.
+
+   This is a DEDICATED, isolated test file (not added to the giant shared
+   `synthesise-chapter.test.ts`, which has ~97 other tests that all rely on
+   `qa.speaker.enabled` defaulting to `false`) because proving the fix
+   requires a file-wide `vi.mock` of `../config/resolver.js` to force
+   `qa.speaker.enabled: true`, plus a mock of `./embed-client.js` to make
+   `embedSegment` throw after a controlled delay. Bolting that onto the
+   shared file would risk silently changing the other 97 tests' behaviour.
+
+   Proof this test is not a placebo: with the pre-fix code (embedMs
+   accounting inside the `try` block, AFTER the `await collectGroupEmbeddings`
+   call, instead of in a `finally`), a thrown rejection from `embedSegment`
+   skips the `embedMs += …` line entirely and `embedMs` stays at its initial
+   value of `0` — so `expect(result.embedMs).toBeGreaterThan(0)` below would
+   fail. Verified by temporarily reverting the `finally` to the old in-try
+   placement and confirming this test goes red, then restoring the fix and
+   confirming it goes green (see task-1-report.md). */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// ── Module mocks (must come before any imports of the mocked modules) ──────
+
+// Force qa.speaker.enabled on for this file only; delegate every other key
+// to the real configValue (same precedent as
+// src/routes/chapter-qa-repair-spk.test.ts).
+vi.mock('../config/resolver.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../config/resolver.js')>();
+  return {
+    ...real,
+    configValue: vi.fn((key: string) => {
+      if (key === 'qa.speaker.enabled') return true;
+      return real.configValue(key);
+    }),
+  };
+});
+
+// embedSegment: a controlled, non-trivial delay (tens of ms — long enough
+// that a Date.now() delta reliably registers as > 0, short enough to keep
+// the test fast) followed by a rejection, so the embed pass always throws.
+vi.mock('./embed-client.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('./embed-client.js')>();
+  return {
+    ...real,
+    embedSegment: vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      throw new Error('embedSegment: simulated sidecar failure');
+    }),
+  };
+});
+
+import { synthesiseChapter, type CastCharacter } from './synthesise-chapter.js';
+import type { SentenceOutput } from '../handoff/schemas.js';
+import type { SynthesizeInput, SynthesizeOutput, TtsProvider } from './index.js';
+
+function sentence(id: number, characterId: string, text = 'Line.'): SentenceOutput {
+  return { id, chapterId: 1, characterId, text };
+}
+
+/** A tone PCM buffer long enough to clear the SPK embed pass's 3.0s duration
+    floor (`MIN_DURATION_SEC`, src/audio/render-integrity/constants.ts) — a
+    shorter clip would be skipped by `collectGroupEmbeddings` before ever
+    calling `embedSegment`, and the embed pass would never throw. */
+function tonePcm(seconds: number, sampleRate = 24000): Buffer {
+  const n = Math.round(seconds * sampleRate);
+  const buf = Buffer.alloc(n * 2);
+  for (let i = 0; i < n; i += 1) {
+    buf.writeInt16LE(Math.round(Math.sin((2 * Math.PI * 200 * i) / sampleRate) * 0.3 * 32767), i * 2);
+  }
+  return buf;
+}
+
+describe('synthesiseChapter — SPK embed-pass failure path (B1 regression)', () => {
+  it('credits embedMs wall time via the finally block even when the embed pass throws', async () => {
+    const provider: TtsProvider & { calls: SynthesizeInput[] } = {
+      calls: [],
+      async synthesize(input: SynthesizeInput): Promise<SynthesizeOutput> {
+        provider.calls.push(input);
+        // Engine must be 'qwen' or 'coqui' (the stochastic-engine filter in
+        // collectGroupEmbeddings) and long enough to clear MIN_DURATION_SEC,
+        // or the embed pass would skip the group without ever calling
+        // embedSegment.
+        return { pcm: tonePcm(3.5), sampleRate: 24000, mimeType: 'audio/pcm' };
+      },
+    };
+    const cast: CastCharacter[] = [{ id: 'narrator', name: 'Narrator' }];
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await synthesiseChapter({
+      sentences: [
+        sentence(1, 'narrator', 'A line long enough to clear the embed duration floor.'),
+      ],
+      cast,
+      provider,
+      modelKey: 'qwen3-tts-0.6b',
+      engine: 'qwen',
+      groupHeartbeatMs: 0,
+    });
+
+    // The embed pass threw (after the controlled 30ms delay) — the finally
+    // block must still have credited that wall time to embedMs.
+    expect(result.embedMs).toBeGreaterThan(0);
+    // Non-fatal: synthesis must complete and return normally, not throw.
+    expect(result.pcm.length).toBeGreaterThan(0);
+    // The catch block logs the failure (existing behaviour, asserted here
+    // as a secondary check, not the primary regression).
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('render-integrity embed pass failed'),
+    );
+
+    warnSpy.mockRestore();
+  });
+});

--- a/server/src/tts/synthesise-chapter.test.ts
+++ b/server/src/tts/synthesise-chapter.test.ts
@@ -2794,6 +2794,29 @@ describe('synthesiseChapter pre-assembly QA gate', () => {
     expect(result.segments[0].suspect).toBeUndefined();
   });
 
+  it('B1: returns QA-cost fields; rerecordMs is 0 when no re-records run', async () => {
+    // Build a chapter that synthesises clean on the first take with the QA
+    // re-record budget at 0 (maxSegmentRerecords = 0, asr absent) — no re-record
+    // synth happens, so rerecordMs must be exactly 0.
+    const provider = makeContentProvider(() => 'tone');
+    const result = await synthesiseChapter({
+      sentences: [sentence(1, 'narrator', 'A line that renders cleanly.')],
+      cast: gateCast,
+      provider,
+      modelKey: 'gemini-2.5-flash',
+      engine: 'gemini',
+      groupHeartbeatMs: 0,
+      maxSegmentRerecords: 0, // no re-records
+      // asr omitted → no transcribe
+    });
+    expect(typeof result.rerecordMs).toBe('number');
+    expect(typeof result.transcribeMs).toBe('number');
+    expect(typeof result.embedMs).toBe('number');
+    expect(result.rerecordMs).toBe(0); // no re-record synth occurred
+    expect(result.transcribeMs).toBe(0); // asr not configured → no transcribe
+    expect(result.embedMs).toBe(0); // qa.speaker.enabled off → no embed
+  });
+
   it('stamps voiceSubstitutedFrom on the segment when the provider reports a fallback', async () => {
     /* A silent voice fallback (sidecar X-Voice-Substituted-From) must reach the
        segment so the golden-audio gate can fail on it — previously it was only

--- a/server/src/tts/synthesise-chapter.test.ts
+++ b/server/src/tts/synthesise-chapter.test.ts
@@ -2817,36 +2817,16 @@ describe('synthesiseChapter pre-assembly QA gate', () => {
     expect(result.embedMs).toBe(0); // qa.speaker.enabled off → no embed
   });
 
-  it('B1: embedMs accounts for wall time on the failure path via finally block', async () => {
-    // Regression: embedMs accounting was inside the try block AFTER the await,
-    // so if collectGroupEmbeddings threw, the timing was lost. The fix moves
-    // embT0 outside the try and embedMs accounting into a finally block.
-    //
-    // Unit verification: since qa.speaker.enabled is off by default in tests,
-    // we verify the structural fix (finally block is present) via code review.
-    // Functional verification (embedMs > 0 on a real embed failure) requires
-    // on-box acceptance with qa.speaker.enabled:true.
-    //
-    // This test documents the contract: embedMs must be >= 0 always, and on
-    // an embed-pass failure, the wall time is still recorded because the
-    // finally block runs unconditionally.
-
-    const provider = makeContentProvider(() => 'tone');
-    const result = await synthesiseChapter({
-      sentences: [sentence(1, 'narrator', 'A line that renders cleanly.')],
-      cast: gateCast,
-      provider,
-      modelKey: 'gemini-2.5-flash',
-      engine: 'gemini',
-      groupHeartbeatMs: 0,
-      maxSegmentRerecords: 0,
-    });
-
-    // embedMs is always a number, always >= 0. On a real embed-pass throw,
-    // the finally block ensures this is > 0 (time spent in the failed call).
-    expect(typeof result.embedMs).toBe('number');
-    expect(result.embedMs).toBeGreaterThanOrEqual(0);
-  });
+  // B1 "embedMs accounts for wall time on the failure path via finally
+  // block" used to live here but was a placebo — qa.speaker.enabled is off
+  // by default in this file (and the test never overrode it), so the gated
+  // embed pass (and the finally block under test) never executed; the
+  // assertions were trivially satisfied by embedMs's initial value of 0.
+  // The real regression test lives in the dedicated
+  // synthesise-chapter.embed-failure.test.ts, which forces
+  // qa.speaker.enabled:true and the embed call to throw after a controlled
+  // delay — isolated there so it doesn't risk changing this file's other
+  // ~97 tests, which all assume qa.speaker.enabled defaults to false.
 
   it('stamps voiceSubstitutedFrom on the segment when the provider reports a fallback', async () => {
     /* A silent voice fallback (sidecar X-Voice-Substituted-From) must reach the

--- a/server/src/tts/synthesise-chapter.test.ts
+++ b/server/src/tts/synthesise-chapter.test.ts
@@ -11,7 +11,7 @@
    the hint plumbing. They use a fake provider (no real synthesis) and assert
    on the voiceName argument the picker resolves for each speaker. */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   buildSentenceGroups,
   synthesiseChapter,
@@ -2815,6 +2815,37 @@ describe('synthesiseChapter pre-assembly QA gate', () => {
     expect(result.rerecordMs).toBe(0); // no re-record synth occurred
     expect(result.transcribeMs).toBe(0); // asr not configured → no transcribe
     expect(result.embedMs).toBe(0); // qa.speaker.enabled off → no embed
+  });
+
+  it('B1: embedMs accounts for wall time on the failure path via finally block', async () => {
+    // Regression: embedMs accounting was inside the try block AFTER the await,
+    // so if collectGroupEmbeddings threw, the timing was lost. The fix moves
+    // embT0 outside the try and embedMs accounting into a finally block.
+    //
+    // Unit verification: since qa.speaker.enabled is off by default in tests,
+    // we verify the structural fix (finally block is present) via code review.
+    // Functional verification (embedMs > 0 on a real embed failure) requires
+    // on-box acceptance with qa.speaker.enabled:true.
+    //
+    // This test documents the contract: embedMs must be >= 0 always, and on
+    // an embed-pass failure, the wall time is still recorded because the
+    // finally block runs unconditionally.
+
+    const provider = makeContentProvider(() => 'tone');
+    const result = await synthesiseChapter({
+      sentences: [sentence(1, 'narrator', 'A line that renders cleanly.')],
+      cast: gateCast,
+      provider,
+      modelKey: 'gemini-2.5-flash',
+      engine: 'gemini',
+      groupHeartbeatMs: 0,
+      maxSegmentRerecords: 0,
+    });
+
+    // embedMs is always a number, always >= 0. On a real embed-pass throw,
+    // the finally block ensures this is > 0 (time spent in the failed call).
+    expect(typeof result.embedMs).toBe('number');
+    expect(result.embedMs).toBeGreaterThanOrEqual(0);
   });
 
   it('stamps voiceSubstitutedFrom on the segment when the provider reports a fallback', async () => {

--- a/server/src/tts/synthesise-chapter.test.ts
+++ b/server/src/tts/synthesise-chapter.test.ts
@@ -11,7 +11,7 @@
    the hint plumbing. They use a fake provider (no real synthesis) and assert
    on the voiceName argument the picker resolves for each speaker. */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   buildSentenceGroups,
   synthesiseChapter,

--- a/server/src/tts/synthesise-chapter.ts
+++ b/server/src/tts/synthesise-chapter.ts
@@ -386,6 +386,12 @@ export interface ChapterSynthesisResult {
       of ≥ MIN_DURATION_SEC. Populated only when `qa.speaker.enabled` is on;
       absent (undefined) when the gate is off or no eligible groups exist. */
   embeddings?: EmbeddingRow[];
+  /** B1 QA-cost split (ms). `rerecordMs` is QA-driven re-record synth wall (the
+      part the gate fixes move); `transcribeMs`/`embedMs` are the always-on verify
+      floor. Zero when the corresponding gate did not run. */
+  rerecordMs: number;
+  transcribeMs: number;
+  embedMs: number;
 }
 
 /** Minimal shape of a synthesis result as seen by the embed pass. */
@@ -1488,6 +1494,14 @@ export async function synthesiseChapter(
      (byte-identical to pre-gate). Batching the re-records (vs the old one-call-
      per-suspect loop) is the ~2x RTF fix; each suspect group still gets at most
      `maxSegmentRerecords` re-synths (one per round), so the budget is unchanged. */
+  /* B1 — QA-cost wall split out for the rerecordRtf telemetry. Each accumulator
+     wraps exactly one class of await so the chapter wall can be attributed:
+     rerecordMs = QA-driven re-record synth (the part PR-1 moves); transcribeMs +
+     embedMs = the always-on verify floor. */
+  let rerecordMs = 0;
+  let transcribeMs = 0;
+  let embedMs = 0;
+
   const segmentQaByIndex = new Map<number, SegmentQaVerdict>();
   if (maxSegmentRerecords > 0) {
     /* `ok` beats `suspect`; among two suspects, fewer reasons is less-bad. */
@@ -1521,7 +1535,9 @@ export async function synthesiseChapter(
           reasons: segmentQaByIndex.get(group.index)!.reasons,
         });
       }
+      const reT0 = Date.now();
       const fresh = await synthGroupsBatched(pending);
+      rerecordMs += Date.now() - reT0;
       for (const group of pending) {
         const f = fresh.get(group.index);
         if (!f) continue;
@@ -1595,7 +1611,9 @@ export async function synthesiseChapter(
       verifiedCount += 1;
       const r = results[group.index]!;
       best.set(group.index, r);
+      const tT0 = Date.now();
       segmentAsrByIndex.set(group.index, await verify(r.pcm, r.sampleRate, group));
+      transcribeMs += Date.now() - tT0;
     }
     /* Round-based re-records: each round re-synths ALL still-drift groups in one
        batched dispatch, re-verifies, and keeps the better take per group. Each
@@ -1615,11 +1633,15 @@ export async function synthesiseChapter(
           reasons: c.reasons,
         });
       }
+      const asrReT0 = Date.now();
       const fresh = await synthGroupsBatched(pending);
+      rerecordMs += Date.now() - asrReT0;
       for (const group of pending) {
         const f = fresh.get(group.index);
         if (!f) continue;
+        const revT0 = Date.now();
         const freshClass = await verify(f.pcm, f.sampleRate, group);
+        transcribeMs += Date.now() - revT0;
         if (asrBetter(freshClass, segmentAsrByIndex.get(group.index)!)) {
           best.set(group.index, f);
           segmentAsrByIndex.set(group.index, freshClass);
@@ -1643,6 +1665,7 @@ export async function synthesiseChapter(
   if (configValue<boolean>('qa.speaker.enabled')) {
     const groupByIndex = new Map(groups.map((g) => [g.index, g]));
     try {
+      const embT0 = Date.now();
       spkEmbeddings = await collectGroupEmbeddings(
         groups,
         results,
@@ -1650,6 +1673,7 @@ export async function synthesiseChapter(
         embedSegment,
         onEmbedProgress,
       );
+      embedMs += Date.now() - embT0;
     } catch (err) {
       console.warn(`[synthesiseChapter] render-integrity embed pass failed: ${String(err)}`);
     }
@@ -1728,5 +1752,8 @@ export async function synthesiseChapter(
     durationSec: pcmDurationSec(pcm.length, sampleRate),
     segments,
     embeddings: spkEmbeddings,
+    rerecordMs,
+    transcribeMs,
+    embedMs,
   };
 }

--- a/server/src/tts/synthesise-chapter.ts
+++ b/server/src/tts/synthesise-chapter.ts
@@ -1664,8 +1664,8 @@ export async function synthesiseChapter(
   let spkEmbeddings: EmbeddingRow[] | undefined;
   if (configValue<boolean>('qa.speaker.enabled')) {
     const groupByIndex = new Map(groups.map((g) => [g.index, g]));
+    const embT0 = Date.now();
     try {
-      const embT0 = Date.now();
       spkEmbeddings = await collectGroupEmbeddings(
         groups,
         results,
@@ -1673,9 +1673,10 @@ export async function synthesiseChapter(
         embedSegment,
         onEmbedProgress,
       );
-      embedMs += Date.now() - embT0;
     } catch (err) {
       console.warn(`[synthesiseChapter] render-integrity embed pass failed: ${String(err)}`);
+    } finally {
+      embedMs += Date.now() - embT0;
     }
   }
 

--- a/server/src/tts/synthesise-chapter.ts
+++ b/server/src/tts/synthesise-chapter.ts
@@ -1497,10 +1497,16 @@ export async function synthesiseChapter(
   /* B1 — QA-cost wall split out for the rerecordRtf telemetry. Each accumulator
      wraps exactly one class of await so the chapter wall can be attributed:
      rerecordMs = QA-driven re-record synth (the part PR-1 moves); transcribeMs +
-     embedMs = the always-on verify floor. */
+     embedMs = the always-on verify floor. `timed()` below dedupes the
+     Date.now()-before/after bookkeeping shared by every accumulated call. */
   let rerecordMs = 0;
   let transcribeMs = 0;
   let embedMs = 0;
+  const timed = async <T>(fn: () => Promise<T>): Promise<{ value: T; ms: number }> => {
+    const t0 = Date.now();
+    const value = await fn();
+    return { value, ms: Date.now() - t0 };
+  };
 
   const segmentQaByIndex = new Map<number, SegmentQaVerdict>();
   if (maxSegmentRerecords > 0) {
@@ -1535,9 +1541,8 @@ export async function synthesiseChapter(
           reasons: segmentQaByIndex.get(group.index)!.reasons,
         });
       }
-      const reT0 = Date.now();
-      const fresh = await synthGroupsBatched(pending);
-      rerecordMs += Date.now() - reT0;
+      const { value: fresh, ms: reMs } = await timed(() => synthGroupsBatched(pending));
+      rerecordMs += reMs;
       for (const group of pending) {
         const f = fresh.get(group.index);
         if (!f) continue;
@@ -1611,9 +1616,9 @@ export async function synthesiseChapter(
       verifiedCount += 1;
       const r = results[group.index]!;
       best.set(group.index, r);
-      const tT0 = Date.now();
-      segmentAsrByIndex.set(group.index, await verify(r.pcm, r.sampleRate, group));
-      transcribeMs += Date.now() - tT0;
+      const { value: verdict, ms: tMs } = await timed(() => verify(r.pcm, r.sampleRate, group));
+      segmentAsrByIndex.set(group.index, verdict);
+      transcribeMs += tMs;
     }
     /* Round-based re-records: each round re-synths ALL still-drift groups in one
        batched dispatch, re-verifies, and keeps the better take per group. Each
@@ -1633,15 +1638,13 @@ export async function synthesiseChapter(
           reasons: c.reasons,
         });
       }
-      const asrReT0 = Date.now();
-      const fresh = await synthGroupsBatched(pending);
-      rerecordMs += Date.now() - asrReT0;
+      const { value: fresh, ms: asrReMs } = await timed(() => synthGroupsBatched(pending));
+      rerecordMs += asrReMs;
       for (const group of pending) {
         const f = fresh.get(group.index);
         if (!f) continue;
-        const revT0 = Date.now();
-        const freshClass = await verify(f.pcm, f.sampleRate, group);
-        transcribeMs += Date.now() - revT0;
+        const { value: freshClass, ms: revMs } = await timed(() => verify(f.pcm, f.sampleRate, group));
+        transcribeMs += revMs;
         if (asrBetter(freshClass, segmentAsrByIndex.get(group.index)!)) {
           best.set(group.index, f);
           segmentAsrByIndex.set(group.index, freshClass);

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1719,6 +1719,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/generation/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Live generation-throughput snapshot for the dev top-bar RTF pill
+         * @description Returns a live snapshot of generation throughput: per-chapter rolling-window
+         *     aggregate (lagging summary), per-batch live window (responsive figure), and
+         *     a recent-chapter history ring (trend across the run). Backs the dev top-bar
+         *     RTF pill so the developer can self-monitor speed without grepping logs.
+         *     All fields go null-or-zero-valued when idle > 10 minutes.
+         */
+        get: operations["getGenerationStats"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/generation/telemetry": {
         parameters: {
             query?: never;
@@ -3869,6 +3893,81 @@ export interface components {
             inFlight: number;
             /** @description Configured concurrency ceiling — the GPU_CONCURRENCY env var (default 1). Bump only after measuring VRAM headroom on the target GPU. */
             max: number;
+        };
+        /**
+         * @description One finished chapter's own throughput, for the history ring. `rtf` is
+         *     `synthSec / audioSec` (< 1 = faster than realtime) or null when the
+         *     chapter produced no audio. QA-cost fields are populated only for single-
+         *     worker runs; null for multi-worker interleaving (sums over-count).
+         */
+        ChapterThroughputRecord: {
+            chapterId: number | string;
+            title: string | null;
+            bookId: string | null;
+            modelKey: string | null;
+            /** @description synth wall ÷ audio (< 1 = faster than realtime). */
+            rtf: number | null;
+            /** @description QA-driven re-record wall ÷ audio for this chapter; null for multi-worker runs. */
+            rerecordRtf: number | null;
+            /** @description Always-on verify floor (transcribe + embed) ÷ audio; null for multi-worker runs. */
+            verifyRtf: number | null;
+            /** @description Audio duration in seconds. */
+            audioSec: number;
+            /** @description Synthesis (TTS wall) duration in seconds. */
+            synthSec: number;
+            /**
+             * Format: date-time
+             * @description ISO timestamp when the chapter finished rendering.
+             */
+            at: string;
+        };
+        /**
+         * @description Live generation-throughput snapshot. Groups three time-windows:
+         *     (1) per-chapter rolling window (lagging summary, updates when chapters finish),
+         *     (2) per-batch live window (responsive, updates every ~batch),
+         *     (3) per-chapter history ring (trend, newest-first, bounded).
+         *     All chapter-window fields go null-or-zero when idle > 10 minutes.
+         */
+        GenerationStatsResponse: {
+            /** @description Chapters folded in since the window opened (rolling-window aggregate). */
+            chapters: number;
+            /** @description Rolling total audio seconds over the window. */
+            audioSec: number;
+            /** @description Rolling total synth (TTS wall) seconds over the window. */
+            synthSec: number;
+            /** @description synthSec ÷ audioSec over the window (< 1 = faster than realtime). */
+            rtf: number | null;
+            /** @description audioSec ÷ synthSec — the "Nx realtime" figure. */
+            xRealtime: number | null;
+            /** @description chapters ÷ window-wall-hours. */
+            chaptersPerHour: number | null;
+            /** @description The most-recently-finished chapter's own figures. */
+            last: {
+                chapterId: number | string;
+                rtf: number;
+                audioSec: number;
+                synthSec: number;
+                /** Format: date-time */
+                at: string;
+            } | null;
+            /**
+             * Format: date-time
+             * @description ISO timestamp of the last chapter fold, or null when the window is empty.
+             */
+            updatedAt: string | null;
+            /** @description Aggregate ΣgenMs ÷ ΣaudioMs over the recent-batch window (< 1 = faster than realtime). The headline LIVE figure; null when no batch is recent. */
+            liveBatchRtf: number | null;
+            /** @description The single most-recent batch's rtf. */
+            lastBatchRtf: number | null;
+            /** @description How many batches the live window is averaging. */
+            batchesInWindow: number;
+            /**
+             * Format: date-time
+             * @description ISO timestamp of the most-recent batch, or null when none is recent.
+             */
+            batchUpdatedAt: string | null;
+            /** @description Recent finished chapters, NEWEST-FIRST, capped at ~200. Survives rolling-window resets (trend across pauses). */
+            recentChapters: components["schemas"]["ChapterThroughputRecord"][];
         };
         /**
          * @description One per-chapter telemetry sample captured right after a chapter
@@ -6743,6 +6842,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GpuQueueState"];
+                };
+            };
+        };
+    };
+    getGenerationStats: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Live generation-throughput snapshot */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenerationStatsResponse"];
                 };
             };
         };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -7591,6 +7591,9 @@ const mock = {
       bookId: 'mock-book',
       modelKey: 'qwen3-tts',
       rtf,
+      // Newest-first: index 0 is newest → lowest QA cost (post-fix).
+      rerecordRtf: [0.02, 0.05, 0.4, 0.7, 0.9, 1.1, 1.3][i] ?? null,
+      verifyRtf: 0.1,
       audioSec: 600,
       synthSec: Math.round(600 * rtf),
       // Newest-first: index 0 is the latest. 9-minute spacing, fixed base.
@@ -7677,6 +7680,11 @@ export interface RecentChapter {
   bookId: string | null;
   modelKey: string | null;
   rtf: number | null;
+  /** B1 — QA re-record wall ÷ audio (the cost the gate fixes move). null for
+      multi-worker runs. */
+  rerecordRtf: number | null;
+  /** B1 — always-on verify floor (transcribe + embed) ÷ audio. null as above. */
+  verifyRtf: number | null;
   audioSec: number;
   synthSec: number;
   at: string;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -7683,7 +7683,8 @@ export interface RecentChapter {
   /** B1 — QA re-record wall ÷ audio (the cost the gate fixes move). null for
       multi-worker runs. */
   rerecordRtf: number | null;
-  /** B1 — always-on verify floor (transcribe + embed) ÷ audio. null as above. */
+  /** B1 — always-on verify floor (transcribe + embed) ÷ audio. null as above.
+      Carried for the API/history ring; not yet rendered as its own column. */
   verifyRtf: number | null;
   audioSec: number;
   synthSec: number;

--- a/src/views/admin.test.tsx
+++ b/src/views/admin.test.tsx
@@ -239,7 +239,8 @@ describe('AdminView — generation throughput table', () => {
 
     const table = await screen.findByTestId('generation-throughput-table');
     const row = within(table).getByTestId('throughput-row-2');
-    expect(within(row).getByText('–')).toBeInTheDocument();
+    // With B3, both QA and RTF columns show dashes for null values.
+    expect(within(row).getAllByText('–')).toHaveLength(2);
     expect(within(row).queryByText('▲')).toBeNull();
   });
 
@@ -273,6 +274,30 @@ describe('AdminView — generation throughput table', () => {
     renderAdmin();
     await screen.findByTestId('generation-throughput-table');
     expect(screen.queryByTestId('throughput-summary')).toBeNull();
+  });
+
+  it('B3: renders the QA (rerecordRtf) column in the throughput table', async () => {
+    // Newest chapter mock has rerecordRtf 0.02 and chapterId 7
+    mockStats.mockResolvedValue({
+      ...idleStats,
+      recentChapters: [
+        chapter({ chapterId: 7, title: 'Chapter 7', rtf: 2.41, rerecordRtf: 0.02 }),
+        chapter({ chapterId: 6, title: 'Chapter 6', rtf: 2.12, rerecordRtf: 0.05 }),
+        chapter({ chapterId: 5, title: 'Chapter 5', rtf: 1.78, rerecordRtf: 0.4 }),
+      ],
+    });
+    renderAdmin();
+
+    // Check that the "QA" header is rendered
+    expect(await screen.findByText('QA')).toBeInTheDocument();
+
+    // Check that the newest chapter row (7) shows the formatted rerecordRtf value "0.02"
+    const row7 = screen.getByTestId('throughput-row-7');
+    expect(row7).toHaveTextContent('0.02');
+
+    // Also verify other chapters render their QA values
+    const row6 = screen.getByTestId('throughput-row-6');
+    expect(row6).toHaveTextContent('0.05');
   });
 });
 
@@ -356,7 +381,7 @@ describe('AdminView — table scroll regions + header alignment', () => {
      scroller with ONE shared column template so the header tracks line up with
      the data rows instead of drifting on the scrollbar gutter + independent
      `auto` columns. */
-  const THROUGHPUT_COLS = 'md:grid-cols-[1fr_7rem_3.5rem_3.5rem_auto]';
+  const THROUGHPUT_COLS = 'md:grid-cols-[1fr_7rem_3.5rem_3.5rem_3.5rem_auto]';
   const TRENDS_COLS = 'sm:grid-cols-[1fr_7rem_3rem_3.5rem_auto]';
 
   it('scrolls the generation-throughput rows in the inset thin-scrollbar region', async () => {

--- a/src/views/admin.test.tsx
+++ b/src/views/admin.test.tsx
@@ -239,8 +239,9 @@ describe('AdminView — generation throughput table', () => {
 
     const table = await screen.findByTestId('generation-throughput-table');
     const row = within(table).getByTestId('throughput-row-2');
-    // With B3, both QA and RTF columns show dashes for null values.
-    expect(within(row).getAllByText('–')).toHaveLength(2);
+    // With B3, both the QA and RTF cells show a dash for null values.
+    expect(within(row).getByTestId('throughput-qa-cell')).toHaveTextContent('–');
+    expect(within(row).getByTestId('throughput-rtf-cell')).toHaveTextContent('–');
     expect(within(row).queryByText('▲')).toBeNull();
   });
 
@@ -291,13 +292,14 @@ describe('AdminView — generation throughput table', () => {
     // Check that the "QA" header is rendered
     expect(await screen.findByText('QA')).toBeInTheDocument();
 
-    // Check that the newest chapter row (7) shows the formatted rerecordRtf value "0.02"
+    // Check that the newest chapter row (7)'s QA cell specifically shows the
+    // formatted rerecordRtf value "0.02" (not just present somewhere in the row).
     const row7 = screen.getByTestId('throughput-row-7');
-    expect(row7).toHaveTextContent('0.02');
+    expect(within(row7).getByTestId('throughput-qa-cell')).toHaveTextContent('0.02');
 
-    // Also verify other chapters render their QA values
+    // Also verify other chapters render their QA values in the QA cell.
     const row6 = screen.getByTestId('throughput-row-6');
-    expect(row6).toHaveTextContent('0.05');
+    expect(within(row6).getByTestId('throughput-qa-cell')).toHaveTextContent('0.05');
   });
 });
 

--- a/src/views/admin.test.tsx
+++ b/src/views/admin.test.tsx
@@ -63,6 +63,8 @@ const chapter = (over: Partial<RecentChapter>): RecentChapter => ({
   bookId: 'book-a',
   modelKey: 'qwen3-tts',
   rtf: 1,
+  rerecordRtf: null,
+  verifyRtf: 0.1,
   audioSec: 600,
   synthSec: 600,
   at: '2026-06-01T09:00:00Z',

--- a/src/views/admin.tsx
+++ b/src/views/admin.tsx
@@ -664,12 +664,16 @@ function ThroughputRow({ chapter, olderRtf }: { chapter: RecentChapter; olderRtf
       <span className="text-right text-xs text-ink/50 font-mono tabular-nums hidden md:block">
         {formatDuration(chapter.synthSec)}
       </span>
-      <span className="text-right text-xs text-ink/50 font-mono tabular-nums hidden md:block">
+      <span
+        className="text-right text-xs text-ink/50 font-mono tabular-nums hidden md:block"
+        data-testid="throughput-qa-cell"
+      >
         {fmtRtf(chapter.rerecordRtf)}
       </span>
       <span
         className={`text-right font-mono font-medium tabular-nums ${style.cls}`}
         title={`${fmtClock(chapter.at)}${style.label ? ` · ${style.label}` : ''}`}
+        data-testid="throughput-rtf-cell"
       >
         {style.glyph && (
           <span className="mr-1 text-xs" aria-label={style.label}>

--- a/src/views/admin.tsx
+++ b/src/views/admin.tsx
@@ -80,7 +80,7 @@ const TREND_STYLE: Record<Trend, { cls: string; glyph: string; label: string }> 
    (scrollbar-gutter: stable from .scrollbar-thin) — otherwise the header would
    run a gutter-width past the rows. */
 const THROUGHPUT_COLS =
-  'grid grid-cols-[1fr_auto] sm:grid-cols-[1fr_7rem_auto] md:grid-cols-[1fr_7rem_3.5rem_3.5rem_auto] gap-x-3 sm:gap-x-6';
+  'grid grid-cols-[1fr_auto] sm:grid-cols-[1fr_7rem_auto] md:grid-cols-[1fr_7rem_3.5rem_3.5rem_3.5rem_auto] gap-x-3 sm:gap-x-6';
 const TRENDS_COLS =
   'grid grid-cols-[1fr_3rem_3rem_auto] sm:grid-cols-[1fr_7rem_3rem_3.5rem_auto] gap-x-3 sm:gap-x-6';
 
@@ -432,6 +432,7 @@ function GenerationThroughput({ stats }: { stats: GenerationStatsResponse | null
               <span className="text-right hidden sm:block">Engine</span>
               <span className="text-right hidden md:block">Audio</span>
               <span className="text-right hidden md:block">Synth</span>
+              <span className="text-right hidden md:block">QA</span>
               <span className="text-right">RTF</span>
             </div>
             <div className="divide-y divide-ink/5">
@@ -662,6 +663,9 @@ function ThroughputRow({ chapter, olderRtf }: { chapter: RecentChapter; olderRtf
       </span>
       <span className="text-right text-xs text-ink/50 font-mono tabular-nums hidden md:block">
         {formatDuration(chapter.synthSec)}
+      </span>
+      <span className="text-right text-xs text-ink/50 font-mono tabular-nums hidden md:block">
+        {fmtRtf(chapter.rerecordRtf)}
       </span>
       <span
         className={`text-right font-mono font-medium tabular-nums ${style.cls}`}


### PR DESCRIPTION
## Summary

PR-2 of the QA-gate-FP + RTF-telemetry work (follows PR-1/PR-1.1, #1190/#1192). Makes QA cost *observable*: splits the re-record wall out of the per-chapter synth wall and surfaces it as a new `rerecordRtf` column next to RTF in the admin throughput table, so the operator can SEE the cost the PR-1 gate fixes removed.

- **B1** — `synthesiseChapter` now returns `rerecordMs`/`transcribeMs`/`embedMs` (QA-driven re-record synth wall, ASR transcribe wall, SPK embed wall), each `await` wrapped exactly once so there's no double-counting — including on the embed pass's non-fatal failure path (a `finally` block credits wall time even when `collectGroupEmbeddings` throws). The repeated `Date.now()`-before/after bookkeeping is deduped through a small local `timed()` helper.
- **B1** — `generation-stats.ts` derives `rerecordRtf` (the headline: QA-driven re-record cost ÷ audio) and `verifyRtf` (the always-on transcribe+embed floor ÷ audio) per chapter, both `number | null`.
- **B1/H1 — behaviour change:** the route's per-chapter `synthMs` now excludes the loudnorm encode + disk write it previously (incorrectly) included, captured immediately after `synthesiseChapter` returns instead of after `finalizeChapterAudioWrite`. **Existing RTF numbers will shift slightly DOWN** — this is intentional; the log line's RTF now matches the recorded RTF. **This narrowing also propagates to the fs-20 resource-telemetry panel** (`ResourceTrends`'s `wallSec`/`rtf`), which reuses the same narrowed `synthSec` — both admin panels stay in agreement rather than silently disagreeing on the same chapter's RTF, but it's a wider blast radius than "just the throughput pill." Disclosed in `docs/features/127-generation-rtf-telemetry.md` and a doc comment on `ResourceTelemetryRecord.wallSec` — no version marker distinguishes pre/post records (accepted: the JSONL ring is capped/best-effort and the step-change ages out within one book's worth of generation).
- **Concurrency gate — fixed post-review (was: static config read).** The QA-cost fields (`rerecordRtf`/`verifyRtf`/underlying ms fields) are populated only for a chapter whose render never overlapped a sibling job's wall-clock. This now keys off **actual concurrency** — `RunningJob.hadSibling`, flipped true in `registerJob` whenever more than one job is registered in the global `inFlightByChapter` map (across ALL books, matching how the queue dispatcher's N workers map onto N concurrent chapter jobs) — rather than the originally-shipped `getResolvedGenerationWorkers() === 1` config read, which couldn't see two single-worker books rendering simultaneously or a mid-run worker-count change, and could mislabel genuinely contended data as clean. `null` (rendered "n/a") whenever overlap is detected or the sub-costs are absent.
- **OpenAPI** — `GET /api/generation/stats` had no prior OpenAPI coverage at all, so this also documents the full endpoint/schema (a field-for-field mirror of the real server types) rather than just bolting the two new fields onto nothing. `src/lib/api-types.ts` regenerated; the hand-written local `RecentChapter` type + mock in `src/lib/api.ts` are unchanged in kind — CLAUDE.md doesn't actually document an "admin surface is exempt from OpenAPI" exception (it states flatly that OpenAPI is the type source of truth), so this PR's earlier framing of that as a repo convention was wrong. `RecentChapter` predates this PR; this is just the first time the shape gets real OpenAPI coverage, so `api.ts` now hand-maintains a second copy of a shape `api-types.ts` actually generates — a pre-existing pattern this PR makes more visible, not one it invented or that's formally sanctioned.
- **Admin UI** — new "QA" column in the throughput table (`GenerationThroughput`/`ThroughputRow`), right of Synth, hidden below `md` per the mobile protocol. `ResourceTrends` intentionally left untouched (the plan's recommended default — VRAM/wall-focused table, not QA-focused). Note: `verifyRtf` flows through the whole stack (server → OpenAPI → local type → mock) but is not yet rendered as its own column — that's a documented, intentional scope limit of this PR, not an oversight.
- **B2 (sidecar `reload_ms`) deferred** per the design spec's own downgrade — not load-bearing for the RTF story, not implemented here.

Design spec: `docs/superpowers/specs/2026-06-30-qa-gate-false-positives-and-rtf-telemetry-design.md` (§ PR-2). Plan: `docs/superpowers/plans/2026-06-30-qa-cost-telemetry-pr2.md`.

## Process notes

Built via subagent-driven development (6 tasks, fresh implementer + task reviewer per task, plus a final whole-branch review). Worth flagging for reviewers:
- Task 1's `embedMs`-on-failure fix went through 3 review rounds: the initial fix was correct but its first regression test was a placebo (never exercised the gated code path); replaced with a real one that provably fails pre-fix and passes post-fix (traced via a temporary revert).
- Task 4's OpenAPI commit message was corrected after review — it originally undersold that it authors a whole new endpoint/schema (the endpoint had zero prior coverage) rather than just adding two fields to something pre-existing.
- The final whole-branch review (Ready to merge: Yes, no Critical/Important findings) flagged three small test-hardening follow-ups (not blocking): `generation-stats.test.ts` didn't pin the "either rerecordMs-or-embedMs present" case for `verifyRtf`, nor the `audioSec === 0` + sub-costs-present case; the Task 5/6 UI-column assertions checked whole-row text rather than the QA cell specifically. **All three folded in** (commit `c78b7f58`): two new `generation-stats.test.ts` cases pin the either-sub-cost and zero-audio-with-sub-costs branches; `admin.tsx`'s throughput row stamps `data-testid="throughput-qa-cell"`/`"throughput-rtf-cell"` on the two ambiguous cells, and both the unit test and the e2e spec assert against that cell specifically instead of the row's full text.
- **A second, independent review (8-finder multi-agent pass) then caught a real correctness gap** in the original `generationWorkers === 1` concurrency gate — see the "Concurrency gate" bullet above. Also flagged: `docs/features/127-generation-rtf-telemetry.md` (this plan) hadn't been updated despite this PR changing exactly what it documents, and the PR body overstated a "the admin surface is exempt from OpenAPI" convention that isn't written anywhere in CLAUDE.md. All three findings fixed in this round: the gate now tracks live registered-job overlap (`RunningJob.hadSibling`) instead of a static config read, with a rewritten `generation.test.ts` "B1 QA-cost telemetry passthrough" describe block that drives GENUINE concurrent chapter renders (a gated synth mock, `generationWorkers` never touched) rather than asserting on the config value; the plan doc gained a "QA-cost telemetry (PR-2)" section plus an invariant + test-plan entries; the PR body's false-convention claim is corrected above. A Minor duplication finding (5 near-identical `Date.now()`-before/after blocks in `synthesise-chapter.ts`) was also folded in via the local `timed()` helper mentioned in the B1 bullet.

## Test plan

- [x] `npm run verify` green locally (lint, typecheck, config:check, all test tiers incl. sidecar/scripts, e2e + visual, build) — every leg passed on push.
- [x] New/changed automated coverage per task: `synthesise-chapter.test.ts` + a dedicated `synthesise-chapter.embed-failure.test.ts`, `generation-stats.test.ts`, `generation.test.ts`, `admin.test.tsx`, `e2e/admin.spec.ts`.
- [x] Post-review: `generation.test.ts`'s B1 describe block rewritten to prove the concurrency gate reacts to REAL overlap (two chapters driven through a gated synth mock so both are provably mid-synth at once) rather than a `generationWorkers` config value the test no longer even sets.
- [ ] On-box acceptance: confirm `rerecordRtf` actually drops across a real re-render after the PR-1 gate fixes, on the admin page with `generationWorkers=1`.

Closes none directly — this is the PR-2 half of the design spec; PR-1 (#1190) and PR-1.1 (#1192) already shipped the gate-logic fixes this makes observable.
