### PR TITLE
fix(server): resolve CodeQL alerts #167-#170 (stack-trace exposure + polynomial regex)

### DIFF
--- a/server/src/routes/cast-create.test.ts
+++ b/server/src/routes/cast-create.test.ts
@@ -130,6 +130,12 @@ describe('POST /api/books/:bookId/cast/create (fs-58 Unit B)', () => {
     expect(res.body.error).toMatch(/name/i);
   });
 
+  it('slugifies leading/trailing punctuation runs without leaving stray underscores', async () => {
+    const res = await callCreate(bookId, { name: '__Weird--Name!!__' });
+    expect(res.status).toBe(200);
+    expect(res.body.character.id).toBe('weird_name');
+  });
+
   it('409s when the book has no cast.json yet', async () => {
     const res = await callCreate(bookIdNoCast, { name: 'Ferra' });
     expect(res.status).toBe(409);

--- a/server/src/routes/cast-create.ts
+++ b/server/src/routes/cast-create.ts
@@ -43,7 +43,7 @@ function slugify(name: string): string {
       .trim()
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, '_')
-      .replace(/^_+|_+$/g, '') || 'character'
+      .replace(/^_+|(?<!_)_+$/g, '') || 'character'
   );
 }
 

--- a/server/tts-sidecar/main.py
+++ b/server/tts-sidecar/main.py
@@ -2531,8 +2531,10 @@ class QwenEngine(Engine):
 
         base_pt, _base_json = self._voice_paths(base_voice_id)
         if not os.path.isfile(base_pt):
+            # Absolute path omitted from the message (it may reach the client
+            # body) — mirrors _load_voice_prompt's raise below.
             raise VoiceNotDesignedError(
-                f"base voice '{base_voice_id}' not designed (no {base_pt})."
+                f"base voice '{base_voice_id}' not designed (no cached embedding)."
             )
         base_prompt, _b, _ = self._load_voice_prompt(base_voice_id)
         base_items = base_prompt if isinstance(base_prompt, list) else [base_prompt]
@@ -4895,11 +4897,18 @@ async def qwen_mint_variant(req: Request) -> Response:
         )
     except VoiceNotDesignedError as exc:
         log.warning("/qwen/mint-variant: base voice not designed — %s", exc)
-        return JSONResponse({"detail": str(exc)}, status_code=409)
+        return JSONResponse(
+            {"detail": f"Base voice '{base_voice_id}' has not been designed yet."},
+            status_code=409,
+        )
     except Base17UnavailableError as exc:
         log.warning("/qwen/mint-variant: 1.7B-Base %s", exc.reason)
         return JSONResponse(
-            {"code": "base17-unavailable", "reason": exc.reason, "detail": str(exc)},
+            {
+                "code": "base17-unavailable",
+                "reason": exc.reason,
+                "detail": f"Qwen 1.7B-Base unavailable ({exc.reason}).",
+            },
             status_code=503,
         )
     except Exception:
@@ -5032,7 +5041,7 @@ async def synthesize(req: Request) -> Response:
             engine_id, voice, exc,
         )
         return JSONResponse(
-            {"detail": str(exc), "code": "voice_not_designed"},
+            {"detail": f"Voice '{voice}' has not been designed yet.", "code": "voice_not_designed"},
             status_code=409,
         )
     except Exception as e:

--- a/server/tts-sidecar/tests/test_qwen3.py
+++ b/server/tts-sidecar/tests/test_qwen3.py
@@ -1211,6 +1211,11 @@ def test_mint_variant_route_409_base_absent(fake_qwen_runtime) -> None:
         },
     )
     assert resp.status_code == 409
+    body = resp.json()
+    assert "designed" in body["detail"].lower()
+    # CodeQL py/stack-trace-exposure #167 — the actionable message must NOT
+    # leak the absolute on-disk .pt path (mirrors the /synthesize 409 check).
+    assert ".pt" not in body["detail"] and ":\\" not in body["detail"]
 
 
 # ── Task 9 (fs-55): synthesize() routes model='1.7b' through 1.7B-Base ──────
@@ -1456,6 +1461,9 @@ def test_mint_variant_route_503_not_installed(fake_qwen_runtime, monkeypatch):
     body = r.json()
     assert body["code"] == "base17-unavailable"
     assert body["reason"] == "not-installed"
+    # CodeQL py/stack-trace-exposure #168 — detail is built from the
+    # controlled `reason` enum, not a raw str(exception).
+    assert body["detail"] == "Qwen 1.7B-Base unavailable (not-installed)."
 
 
 def test_mint_variant_route_500_on_oom(fake_qwen_runtime, monkeypatch):


### PR DESCRIPTION
## Summary
- **#170** (`js/polynomial-redos`, cast-create.ts:42-46): `slugify`'s trailing-underscore trim used CodeQL's textbook ambiguous-anchor pattern (`^_+|_+$`) — only `^` restricted a start position, so the `/g` scan could retry at every index within a run of `_`. Disambiguated with a negative lookbehind (`^_+|(?<!_)_+$`), CodeQL's own documented remediation for this exact pattern. Behavior-preserving (new test covers the trim).
- **#167/#169** (`py/stack-trace-exposure`): `mint_variant`'s base-voice existence check embedded the absolute `.pt` path in `VoiceNotDesignedError`'s message; the sibling check in `_load_voice_prompt` had already been hardened to omit it (per its own comment). Applied the same omission, and stopped funneling `str(exc)` into the `/qwen/mint-variant` and `/synthesize` 409 response bodies — they now build the detail text from validated request-scoped values instead.
- **#168** (`py/stack-trace-exposure`): `/qwen/mint-variant`'s 503 response also passed `str(exc)` straight through for `Base17UnavailableError`; now built from the already-controlled `reason` enum (`not-installed`/`corrupt`) instead of the exception object, severing the taint flow CodeQL tracks.

Full exception detail still reaches the server-side log via the existing `log.warning`/`log.exception` calls — only the client-facing response bodies changed. No behavior change for callers beyond the removed path leak.

## Test plan
- [x] New vitest case for `slugify` (leading/trailing punctuation runs, no stray underscores) — `server/src/routes/cast-create.test.ts`
- [x] `tsc --noEmit` and `eslint` clean on changed TS files
- [x] Two new pytest regressions pinning no-path-leak (`#167`) and controlled `detail` text (`#168`) — `server/tts-sidecar/tests/test_qwen3.py`
- [x] Full `test_qwen3.py` suite: 71 passed
- [x] Full pre-push verify (lint, typecheck, unit, server, sidecar, e2e, e2e:visual) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)