### PR TITLE
fix(frontend,server,openapi,mocks): widen series-memory modal and sort carried cast by lines

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5663,7 +5663,7 @@ components:
               carriedPresent: { type: integer }
     CarriedCharacter:
       type: object
-      required: [character, aliases, voiceId, voiceLabel, voiceKind, firstBookId, lastBookId, bookIndices, carriedFullSpan]
+      required: [character, aliases, voiceId, voiceLabel, voiceKind, firstBookId, lastBookId, bookIndices, carriedFullSpan, totalLines]
       properties:
         character: { type: string }
         aliases: { type: array, items: { type: string } }
@@ -5675,6 +5675,7 @@ components:
         lastBookId: { type: string }
         bookIndices: { type: array, items: { type: integer } }
         carriedFullSpan: { type: boolean }
+        totalLines: { type: integer }
     SeriesMemoryDetail:
       type: object
       required: [series, carried]

--- a/server/src/workspace/scan.ts
+++ b/server/src/workspace/scan.ts
@@ -454,6 +454,7 @@ export async function buildInputsFromBooks(books: LibraryBook[]): Promise<Series
           voiceKind: voiceKindFor(isTtsEngine(engine) ? engine : null),
           isPrincipal: lineCount >= PRINCIPAL_LINE_FLOOR,
           matchedFrom: ch.matchedFrom ?? null,
+          lineCount,
         };
       }),
     });

--- a/server/src/workspace/series-memory.test.ts
+++ b/server/src/workspace/series-memory.test.ts
@@ -234,11 +234,34 @@ describe('deriveSeriesMemory', () => {
     expect(summarize(d).carriedCount).toBe(d.carried.characters.length);
   });
 
-  it('sorts bespoke (designed/cloned) rows above preset rows', () => {
+  it('sorts bespoke (designed/cloned) rows above preset rows when totalLines ties (all 0)', () => {
     const d = deriveSeriesMemory(baseBooks())!;
     const lastBespokeIdx = d.carried.characters.map((c) => c.voiceKind !== 'preset').lastIndexOf(true);
     const firstPresetIdx = d.carried.characters.findIndex((c) => c.voiceKind === 'preset');
     expect(firstPresetIdx).toBeGreaterThan(lastBespokeIdx); // all bespoke before any preset
+  });
+
+  it('sums totalLines for a carried character across every book it appears in', () => {
+    const books = baseBooks();
+    const marrow = (idx: number) => books[idx].characters.find((c) => c.name === 'Marrow')!;
+    marrow(0).lineCount = 10;
+    marrow(1).lineCount = 20;
+    marrow(2).lineCount = 30;
+    const d = deriveSeriesMemory(books)!;
+    const row = d.carried.characters.find((c) => c.character === 'Marrow')!;
+    expect(row.totalLines).toBe(60);
+  });
+
+  it('sorts by totalLines desc (biggest speaking part first), overriding the bespoke/preset tie-break', () => {
+    const books = baseBooks();
+    // Narrator (preset) speaks far more than the bespoke cast — it should still lead.
+    for (const b of books) {
+      for (const c of b.characters) c.lineCount = c.name === 'Narrator' ? 50 : 5;
+    }
+    const d = deriveSeriesMemory(books)!;
+    expect(d.carried.characters[0].character).toBe('Narrator');
+    expect(d.carried.characters[0].totalLines).toBe(150); // 50 lines * 3 books
+    expect(d.carried.characters.every((c, i, arr) => i === 0 || c.totalLines <= arr[i - 1].totalLines)).toBe(true);
   });
 
   it('does not hang on a cyclic matchedFrom (A→B→A self-cycle)', () => {

--- a/server/src/workspace/series-memory.ts
+++ b/server/src/workspace/series-memory.ts
@@ -13,12 +13,17 @@ export interface SeriesCharacterInput {
   voiceLabel: string; engine: string | null;
   voiceKind: VoiceKind; isPrincipal: boolean;
   matchedFrom: { bookId?: string; characterId?: string } | null;
+  // Lines spoken in THIS book — summed across the chain into CarriedCharacter.totalLines,
+  // the "most-speaking-first" ordering for the reveal list. Optional/defaults to 0 so
+  // existing test fixtures that don't care about ordering need no changes.
+  lineCount?: number;
 }
 export interface SeriesBookInput { bookId: string; index: number; title: string; characters: SeriesCharacterInput[]; }
 export interface CarriedCharacter {
   character: string; aliases: string[]; voiceId: string; voiceLabel: string;
   engine: string | null; voiceKind: VoiceKind;
   firstBookId: string; lastBookId: string; bookIndices: number[]; carriedFullSpan: boolean;
+  totalLines: number;
 }
 export interface SeriesMemorySummary {
   carriedCount: number; bespokeCount: number; designedCount: number;
@@ -153,12 +158,13 @@ export function deriveSeriesMemory(books: SeriesBookInput[]): SeriesMemoryDetail
     // is the confirmed set by contract.
     const fullSpan = indices.length === ordered.length &&
       indices.every((v, i) => v === ordered[i].index);
+    const totalLines = chain.reduce((sum, a) => sum + (a.ch.lineCount ?? 0), 0);
     carried.push({
       character: latest.ch.name, aliases: latest.ch.aliases,
       voiceId: carriedVoiceId, voiceLabel: voiced.ch.voiceLabel,
       engine: voiced.ch.engine, voiceKind: voiced.ch.voiceKind,
       firstBookId: earliest.book.bookId, lastBookId: latest.book.bookId,
-      bookIndices: indices, carriedFullSpan: fullSpan,
+      bookIndices: indices, carriedFullSpan: fullSpan, totalLines,
     });
   }
 
@@ -168,8 +174,10 @@ export function deriveSeriesMemory(books: SeriesBookInput[]): SeriesMemoryDetail
   const designedCount = carried.filter((c) => c.voiceKind === 'designed').length;
   const carriedIndices = new Set(carried.flatMap((c) => c.bookIndices));
   const spanBooks = ordered.filter((b) => carriedIndices.has(b.index)).length;
-  // bespoke first, then by first appearance, then name — the reveal/card sort.
+  // Most lines across the series first (the biggest speaking parts lead the
+  // reveal/card), then bespoke before preset, then by first appearance, then name.
   carried.sort((a, b) =>
+    b.totalLines - a.totalLines ||
     Number(b.voiceKind !== 'preset') - Number(a.voiceKind !== 'preset') ||
     a.bookIndices[0] - b.bookIndices[0] || a.character.localeCompare(b.character));
 

--- a/src/components/series-memory/series-memory-reveal.test.tsx
+++ b/src/components/series-memory/series-memory-reveal.test.tsx
@@ -29,6 +29,7 @@ const detail: SeriesMemoryDetail = {
         lastBookId: 'b3',
         bookIndices: [1, 2, 3],
         carriedFullSpan: true,
+        totalLines: 500,
       },
       {
         character: 'Sela',
@@ -41,6 +42,7 @@ const detail: SeriesMemoryDetail = {
         lastBookId: 'b3',
         bookIndices: [2, 3],
         carriedFullSpan: false,
+        totalLines: 200,
       },
       {
         character: 'Narrator',
@@ -53,6 +55,7 @@ const detail: SeriesMemoryDetail = {
         lastBookId: 'b3',
         bookIndices: [1, 2, 3],
         carriedFullSpan: true,
+        totalLines: 900,
       },
     ],
   },

--- a/src/components/series-memory/series-memory-reveal.tsx
+++ b/src/components/series-memory/series-memory-reveal.tsx
@@ -39,7 +39,7 @@ function exportJson(detail: SeriesMemoryDetail, series: string) {
 function CarriedRow({ c, bookCount }: { c: CarriedCharacter; bookCount: number }) {
   const present = new Set(c.bookIndices);
   return (
-    <div className="grid grid-cols-[110px_1fr] gap-3 items-center py-2 border-t border-white/10">
+    <div className="grid grid-cols-[1fr_auto] gap-3 items-center py-2 border-t border-white/10">
       <div>
         <div className="font-serif text-cream">{c.character}</div>
         <div className="text-[11px] text-cream/55">
@@ -54,7 +54,7 @@ function CarriedRow({ c, bookCount }: { c: CarriedCharacter; bookCount: number }
           )}
         </div>
       </div>
-      <div className="flex gap-1" aria-label={`in books ${rangeLabel(c.bookIndices)}`}>
+      <div className="flex gap-1 shrink-0" aria-label={`in books ${rangeLabel(c.bookIndices)}`}>
         {Array.from({ length: bookCount }, (_, i) => i + 1).map((idx) => (
           <span
             key={idx}
@@ -120,7 +120,7 @@ export function SeriesMemoryReveal({
         // rebaseline). The old `min-h-screen sm:min-h-0 overflow-auto` had NO
         // max-height, so a large carried cast grew the panel past the viewport
         // and pushed the footer (Share / Export) off-screen — unusable.
-        className="bg-[#1b1714] text-cream w-full sm:max-w-xl sm:rounded-2xl p-7 h-full sm:h-auto sm:max-h-[90vh] overflow-y-auto scrollbar-thin"
+        className="bg-[#1b1714] text-cream w-full sm:max-w-2xl sm:rounded-2xl p-7 h-full sm:h-auto sm:max-h-[90vh] overflow-y-auto scrollbar-thin"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Sticky so Close stays reachable while scrolling a long cast list;

--- a/src/components/series-memory/series-share-card.test.tsx
+++ b/src/components/series-memory/series-share-card.test.tsx
@@ -10,7 +10,7 @@ const detail: SeriesMemoryDetail = {
     characters: Array.from({ length: 56 }, (_, i) => ({
       character: `Name${i}`, aliases: [], voiceId: `v${i}`, voiceLabel: 'Designed voice',
       engine: 'qwen', voiceKind: i < 39 ? 'designed' : 'preset', firstBookId: 'b1', lastBookId: 'b12',
-      bookIndices: [1], carriedFullSpan: true,
+      bookIndices: [1], carriedFullSpan: true, totalLines: 56 - i,
     })) as SeriesMemoryDetail['carried']['characters'] },
 };
 

--- a/src/components/series-memory/share-card-modal.test.tsx
+++ b/src/components/series-memory/share-card-modal.test.tsx
@@ -25,6 +25,7 @@ const detail: SeriesMemoryDetail = {
         lastBookId: 'b3',
         bookIndices: [1, 2, 3],
         carriedFullSpan: true,
+        totalLines: 400,
       },
     ],
   },

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -4257,6 +4257,7 @@ export interface components {
             lastBookId: string;
             bookIndices: number[];
             carriedFullSpan: boolean;
+            totalLines: number;
         };
         SeriesMemoryDetail: {
             series: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -627,6 +627,7 @@ export interface CarriedCharacter {
   character: string; aliases: string[]; voiceId: string; voiceLabel: string;
   engine: string | null; voiceKind: 'designed' | 'cloned' | 'preset';
   firstBookId: string; lastBookId: string; bookIndices: number[]; carriedFullSpan: boolean;
+  totalLines: number;
 }
 export interface SeriesMemoryDetail {
   series: { confirmedBookCount: number; spanBooks: number;

--- a/src/mocks/series-memory.ts
+++ b/src/mocks/series-memory.ts
@@ -17,7 +17,21 @@ export const MOCK_SERIES_MEMORY: Record<string, SeriesMemoryDetail> = {
       count: 4,
       bespokeCount: 3,
       designedCount: 3,
+      // Ordered by totalLines desc — matches deriveSeriesMemory's "most-speaking-first" sort.
       characters: [
+        {
+          character: 'Narrator',
+          aliases: [],
+          voiceId: 'narrator',
+          voiceLabel: 'Deep · Female · UK',
+          engine: 'kokoro',
+          voiceKind: 'preset',
+          firstBookId: 'sb',
+          lastBookId: 'cc',
+          bookIndices: [1, 2, 3],
+          carriedFullSpan: true,
+          totalLines: 940,
+        },
         {
           character: 'Carrick',
           aliases: [],
@@ -29,6 +43,7 @@ export const MOCK_SERIES_MEMORY: Record<string, SeriesMemoryDetail> = {
           lastBookId: 'cc',
           bookIndices: [1, 2, 3],
           carriedFullSpan: true,
+          totalLines: 610,
         },
         {
           character: 'Mara',
@@ -41,6 +56,7 @@ export const MOCK_SERIES_MEMORY: Record<string, SeriesMemoryDetail> = {
           lastBookId: 'ns',
           bookIndices: [1, 2],
           carriedFullSpan: false,
+          totalLines: 340,
         },
         {
           character: 'Doran',
@@ -53,18 +69,7 @@ export const MOCK_SERIES_MEMORY: Record<string, SeriesMemoryDetail> = {
           lastBookId: 'cc',
           bookIndices: [1, 3],
           carriedFullSpan: false,
-        },
-        {
-          character: 'Narrator',
-          aliases: [],
-          voiceId: 'narrator',
-          voiceLabel: 'Deep · Female · UK',
-          engine: 'kokoro',
-          voiceKind: 'preset',
-          firstBookId: 'sb',
-          lastBookId: 'cc',
-          bookIndices: [1, 2, 3],
-          carriedFullSpan: true,
+          totalLines: 155,
         },
       ],
     },


### PR DESCRIPTION
Refs #1201 (filed + closed retroactively — this PR predates the repo's PR-gate issue-linkage policy).

## Summary
- Widen the Series Memory reveal modal (`max-w-xl` -> `max-w-2xl`) — there was room to spare.
- Fix the cramped name column: it was a fixed 110px (wrapping multi-word names like "Skulduggery Pleasant" or "Unknown male" badly) while the 3-dot book-presence indicator soaked up the flexible remainder. Swapped to `grid-cols-[1fr_auto]` so the name gets the space and the dots size to content.
- Order the carried-character list by total lines spoken across all books (descending), so the biggest speaking parts lead instead of alphabetical order. Added `totalLines` to `CarriedCharacter` (server sums per-book `lineCount`, which was already computed for `isPrincipal` but previously discarded), threaded it through `openapi.yaml` / regenerated `api-types.ts` / frontend `CarriedCharacter` type, and made it the primary sort key in `deriveSeriesMemory` (existing bespoke-before-preset / first-appearance / name tie-breaks still apply on ties).

## Test plan
- [x] `npm run test:fast` (frontend + server, 3337 + 3862 tests) — green
- [x] New server unit tests: `totalLines` summation across books, and sort-by-lines overriding the bespoke/preset tie-break (`server/src/workspace/series-memory.test.ts`)
- [x] Updated existing fixtures/tests in `src/mocks/series-memory.ts`, `series-memory-reveal.test.tsx`, `share-card-modal.test.tsx`, `series-share-card.test.tsx` for the new required field
- [x] Manually verified in the browser (mock mode): row order matches totalLines desc, and long names ("Skulduggery Pleasant", "Unknown male") no longer wrap
- [x] Full `npm run verify` (typecheck + all tests + e2e + build) — green, run from an isolated worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)