### PR TITLE
chore: ignore local html-artifacts skill output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,7 @@ server/src/parsers/__fixtures__/sample.azw3
 server/repro-*.mts
 server/repro-*.txt
 server/roster.json
+
+# Self-contained HTML artifacts rendered by the html-artifacts skill (plans,
+# reports, mockups). Local scratch output, never committed.
+artifacts/


### PR DESCRIPTION
## Summary
- Adds `artifacts/` to `.gitignore` — local scratch output from the html-artifacts skill, never meant to be committed.

Closes #1204

## Test plan
- N/A (gitignore-only change).