### PR TITLE
chore(app,deps): bump audio_session 0.2.3 -> 0.2.4 (ops-17 / #790)

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -67,7 +67,8 @@ jobs:
       - run: flutter build appbundle --release
       # ops-17 / #790 — Trip B. The KGP escape-hatch flags must stay present:
       # deleting them silently re-breaks the build under AGP 9 (the unmigrated
-      # audio_session / flutter_foreground_task / mobile_scanner plugins).
+      # flutter_foreground_task / mobile_scanner plugins; audio_session dropped
+      # off this list at 0.2.4).
       - name: Guard KGP escape-hatch flags (ops-17 / #790)
         run: |
           set -euo pipefail

--- a/apps/android/android/gradle.properties
+++ b/apps/android/android/gradle.properties
@@ -1,9 +1,10 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 # KGP escape hatch (ops-17 / #790): these two flags keep Flutter's built-in
-# Kotlin OFF so the still-unmigrated KGP plugins (audio_session,
-# flutter_foreground_task, mobile_scanner) keep building under AGP 9. Do NOT
-# delete until those plugins ship built-in-Kotlin releases — app.yml asserts
-# both are present and that the Flutter pin stays in lockstep with app-deps-watch.yml.
+# Kotlin OFF so the still-unmigrated KGP plugins (flutter_foreground_task,
+# mobile_scanner) keep building under AGP 9. audio_session dropped off this
+# list at 0.2.4 (confirmed built-in-Kotlin-clean). Do NOT delete until the
+# remaining plugins ship built-in-Kotlin releases — app.yml asserts both are
+# present and that the Flutter pin stays in lockstep with app-deps-watch.yml.
 android.newDsl=false
 android.builtInKotlin=false

--- a/apps/android/pubspec.lock
+++ b/apps/android/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: "direct main"
     description:
       name: audio_session
-      sha256: "7217b229db57cc4dc577a8abb56b7429a5a212b978517a5be578704bfe5e568b"
+      sha256: f9e7711a0e24ca8b40f5d7ac374c3c6e55016f3157912badd18199cdbbca5c4d
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.3"
+    version: "0.2.4"
   boolean_selector:
     dependency: transitive
     description:

--- a/apps/android/pubspec.yaml
+++ b/apps/android/pubspec.yaml
@@ -58,7 +58,7 @@ dependencies:
   # headset/route change) in main(). Already resolved transitively via
   # just_audio/audio_service; pinned here as a direct dep because main.dart
   # imports it. Constraint tracks the resolved version.
-  audio_session: ^0.2.3
+  audio_session: ^0.2.4
   # app-9: per-folder BehaviorSubjects backing AudioHandler.subscribeToChildren,
   # so the car browse tree can push a "children changed" refresh to Android Auto.
   # Already resolved transitively via audio_service; pinned here as a direct dep.


### PR DESCRIPTION
## Summary
- Bumps `audio_session` 0.2.3 -> 0.2.4 per the monthly `app-deps-watch` A2 nudge on #790.
- Verified via `flutter build apk --release`: the KGP warning no longer lists `audio_session` — only `flutter_foreground_task` and `mobile_scanner` remain.
- Updated the two stale comments (`app.yml` Trip B guard, `apps/android/android/gradle.properties`) that named `audio_session` among the still-unmigrated plugins, since it's confirmed clean as of 0.2.4.
- Escape-hatch flags (`android.newDsl=false` / `android.builtInKotlin=false`) stay — `flutter_foreground_task` and `mobile_scanner` still apply KGP, so #790 is **not** closed (recipe's close condition needs the warning fully gone).
- Left `KGP_PLUGINS` in `scripts/deps-watch.mjs` unchanged (still tracks `audio_session`) — removing it would mean rewriting the ~20 unit tests that use it as example data; flagged as a follow-up rather than folded into this pin bump.

## Test plan
- [x] `flutter pub get` resolved the new pin
- [x] `flutter build apk --release` succeeded, KGP warning confirmed reduced to 2 plugins
- [x] `node --test scripts/tests/deps-watch.test.mjs` — 22/22 still pass (literals, unaffected by live pin)

Refs #790