### PR TITLE
feat(frontend): promote first sentence to chapter title

### DIFF
--- a/e2e/manuscript-promote-first-sentence.spec.ts
+++ b/e2e/manuscript-promote-first-sentence.spec.ts
@@ -1,0 +1,75 @@
+/* PR-gate review finding 4 (2026-07-01) — the "Use first line as title"
+ * trigger in the manuscript header lets the user promote a chapter's first
+ * sentence into its title (api.renameChapter + manuscriptActions.
+ * promoteSentenceToTitle). Mirrors manuscript-detect-emotions.spec.ts
+ * (button → confirm popover → action → result) and listen-rename-chapter.
+ * spec.ts (rename flow assertions).
+ *
+ * The canned mock analysis (ANALYSIS_NORTHERN_STAR) puts every sentence
+ * under chapter 3 ("What the Captain Knew") — and `ui-slice`'s
+ * READY_DEFAULTS lands the manuscript view on chapter 3 by default, so no
+ * extra chapter navigation is needed to reach a chapter with sentences. */
+
+import { test, expect } from '@playwright/test';
+import { goToConfirm } from './helpers';
+
+const FIRST_SENTENCE =
+  'The wind had turned by the time Halloran reached the wheelhouse';
+
+test.describe('manuscript — promote first sentence to title (PR-gate finding 4)', () => {
+  test('confirm renames the chapter to the first sentence and removes it from narration', async ({
+    page,
+  }) => {
+    await goToConfirm(page);
+    await page.getByRole('button', { name: /Confirm cast and review manuscript/i }).click();
+    await expect(page).toHaveURL(/#\/books\/.+\/manuscript$/, { timeout: 5_000 });
+
+    const button = page.getByTestId('promote-first-sentence-button');
+    await expect(button).toBeVisible({ timeout: 5_000 });
+    await expect(button).toBeEnabled();
+
+    await button.click();
+    const dialog = page.getByRole('dialog', { name: 'Use first line as title' });
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText(FIRST_SENTENCE);
+
+    await page.getByTestId('promote-first-sentence-confirm').click();
+
+    // Popover closes once the (mock) rename resolves.
+    await expect(dialog).toHaveCount(0, { timeout: 3_000 });
+
+    // The chapter heading now shows the promoted sentence as its title.
+    const heading = page.getByRole('heading', { level: 1 });
+    await expect(heading).toContainText(FIRST_SENTENCE, { timeout: 3_000 });
+
+    // The promoted sentence is gone from the manuscript body — only the
+    // heading shows it now, not the article text.
+    const article = page.locator('article');
+    await expect(article).not.toContainText(FIRST_SENTENCE);
+  });
+
+  test('cancel closes the popover with no title change', async ({ page }) => {
+    await goToConfirm(page);
+    await page.getByRole('button', { name: /Confirm cast and review manuscript/i }).click();
+    await expect(page).toHaveURL(/#\/books\/.+\/manuscript$/, { timeout: 5_000 });
+
+    const button = page.getByTestId('promote-first-sentence-button');
+    await expect(button).toBeVisible({ timeout: 5_000 });
+    await expect(button).toBeEnabled();
+
+    const heading = page.getByRole('heading', { level: 1 });
+    const originalHeadingText = (await heading.textContent()) ?? '';
+
+    await button.click();
+    const dialog = page.getByRole('dialog', { name: 'Use first line as title' });
+    await expect(dialog).toBeVisible();
+
+    await page.getByText('Cancel', { exact: true }).click();
+    await expect(dialog).toHaveCount(0);
+
+    // No rename happened — heading text is unchanged, and the promoted
+    // sentence is still present in the manuscript body.
+    await expect(heading).toHaveText(originalHeadingText);
+    await expect(page.locator('article')).toContainText(FIRST_SENTENCE);
+  });
+});

--- a/src/components/promote-first-sentence-button.test.tsx
+++ b/src/components/promote-first-sentence-button.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { configureStore } from '@reduxjs/toolkit';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { manuscriptSlice } from '../store/manuscript-slice';
+import { chaptersSlice } from '../store/chapters-slice';
+import { notificationsSlice } from '../store/notifications-slice';
+import { PromoteFirstSentenceButton } from './promote-first-sentence-button';
+import type { Sentence } from '../lib/types';
+
+const { renameChapter } = vi.hoisted(() => ({ renameChapter: vi.fn() }));
+vi.mock('../lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/api')>();
+  return { ...actual, api: { renameChapter } };
+});
+
+const firstSentence: Sentence = {
+  id: 1,
+  chapterId: 3,
+  characterId: 'narrator',
+  text: 'PUPPY TRAINING.',
+} as never;
+
+function makeStore() {
+  return configureStore({
+    reducer: {
+      manuscript: manuscriptSlice.reducer,
+      chapters: chaptersSlice.reducer,
+      notifications: notificationsSlice.reducer,
+    },
+    preloadedState: {
+      manuscript: {
+        ...manuscriptSlice.getInitialState(),
+        sentences: [
+          firstSentence,
+          { id: 2, chapterId: 3, characterId: 'narrator', text: 'You brought home a puppy.' } as never,
+        ],
+      },
+      chapters: {
+        ...chaptersSlice.getInitialState(),
+        chapters: [{ id: 3, title: 'Chapter 3', titleOverridden: false } as never],
+      },
+    },
+  });
+}
+
+beforeEach(() => {
+  renameChapter.mockReset();
+});
+
+describe('PromoteFirstSentenceButton', () => {
+  it('is disabled when there is no first sentence', () => {
+    render(
+      <Provider store={makeStore()}>
+        <PromoteFirstSentenceButton bookId="b1" chapterId={3} firstSentence={null} />
+      </Provider>,
+    );
+    expect(screen.getByTestId('promote-first-sentence-button')).toBeDisabled();
+  });
+
+  it('is disabled when the cleaned text exceeds 200 chars', () => {
+    const long = { ...firstSentence, text: 'x'.repeat(201) };
+    render(
+      <Provider store={makeStore()}>
+        <PromoteFirstSentenceButton bookId="b1" chapterId={3} firstSentence={long} />
+      </Provider>,
+    );
+    expect(screen.getByTestId('promote-first-sentence-button')).toBeDisabled();
+  });
+
+  it('shows the trimmed, trailing-period-stripped text in the confirm preview', () => {
+    render(
+      <Provider store={makeStore()}>
+        <PromoteFirstSentenceButton
+          bookId="b1"
+          chapterId={3}
+          firstSentence={{ ...firstSentence, text: '  PUPPY TRAINING.  ' }}
+        />
+      </Provider>,
+    );
+    fireEvent.click(screen.getByTestId('promote-first-sentence-button'));
+    expect(screen.getByRole('dialog')).toHaveTextContent('PUPPY TRAINING');
+    expect(screen.getByRole('dialog')).not.toHaveTextContent('PUPPY TRAINING.');
+  });
+
+  it('Cancel closes the dialog with no dispatch or api call', () => {
+    render(
+      <Provider store={makeStore()}>
+        <PromoteFirstSentenceButton bookId="b1" chapterId={3} firstSentence={firstSentence} />
+      </Provider>,
+    );
+    fireEvent.click(screen.getByTestId('promote-first-sentence-button'));
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(renameChapter).not.toHaveBeenCalled();
+  });
+
+  it('Confirm renames the chapter, removes the sentence, and tombstones it', async () => {
+    renameChapter.mockResolvedValue(undefined);
+    const store = makeStore();
+    render(
+      <Provider store={store}>
+        <PromoteFirstSentenceButton bookId="b1" chapterId={3} firstSentence={firstSentence} />
+      </Provider>,
+    );
+    fireEvent.click(screen.getByTestId('promote-first-sentence-button'));
+    fireEvent.click(screen.getByTestId('promote-first-sentence-confirm'));
+    await waitFor(() => expect(renameChapter).toHaveBeenCalledWith('b1', 3, 'PUPPY TRAINING'));
+    const state = store.getState();
+    expect(state.chapters.chapters[0].title).toBe('PUPPY TRAINING');
+    expect(state.chapters.chapters[0].titleOverridden).toBe(true);
+    expect(state.manuscript.sentences.map((s: Sentence) => s.id)).toEqual([2]);
+    expect(state.manuscript.mergedAwayKeys).toContain('3:1');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('a failed rename shows an error toast and leaves the sentence untouched', async () => {
+    renameChapter.mockRejectedValue(new Error('network down'));
+    const store = makeStore();
+    render(
+      <Provider store={store}>
+        <PromoteFirstSentenceButton bookId="b1" chapterId={3} firstSentence={firstSentence} />
+      </Provider>,
+    );
+    fireEvent.click(screen.getByTestId('promote-first-sentence-button'));
+    fireEvent.click(screen.getByTestId('promote-first-sentence-confirm'));
+    await waitFor(() => expect(store.getState().notifications.toasts).toHaveLength(1));
+    expect(store.getState().notifications.toasts[0].message).toBe('network down');
+    expect(store.getState().manuscript.sentences).toHaveLength(2);
+    expect(store.getState().chapters.chapters[0].title).toBe('Chapter 3');
+  });
+});

--- a/src/components/promote-first-sentence-button.test.tsx
+++ b/src/components/promote-first-sentence-button.test.tsx
@@ -158,6 +158,45 @@ describe('PromoteFirstSentenceButton', () => {
     expect(store.getState().chapters.chapters[0].title).toBe('Chapter 3');
   });
 
+  it('disables Confirm (not just the trigger) if firstSentence becomes invalid while the popover is open (PR-gate round 3)', () => {
+    /* Regression: the popover doesn't reopen/remount on a sentence-content
+       change (only a chapter switch remounts it, via the `key` in
+       manuscript.tsx), so `cleaned`/`disabled` are recomputed live from
+       whatever `firstSentence` prop is current. A concurrent edit (e.g. a
+       script-review apply) could rewrite the same sentence to empty text
+       while the popover is already open — Confirm must re-validate, not
+       just check `busy`. */
+    const store = makeStore();
+    const { rerender } = render(
+      <Provider store={store}>
+        <PromoteFirstSentenceButton
+          bookId="b1"
+          chapterId={3}
+          firstSentence={firstSentence}
+          isOnlySentence={false}
+        />
+      </Provider>,
+    );
+    fireEvent.click(screen.getByTestId('promote-first-sentence-button'));
+    expect(screen.getByTestId('promote-first-sentence-confirm')).toBeEnabled();
+
+    // Simulate a concurrent edit emptying the sentence's text.
+    rerender(
+      <Provider store={store}>
+        <PromoteFirstSentenceButton
+          bookId="b1"
+          chapterId={3}
+          firstSentence={{ ...firstSentence, text: '   ' }}
+          isOnlySentence={false}
+        />
+      </Provider>,
+    );
+
+    expect(screen.getByTestId('promote-first-sentence-confirm')).toBeDisabled();
+    fireEvent.click(screen.getByTestId('promote-first-sentence-confirm'));
+    expect(renameChapter).not.toHaveBeenCalled();
+  });
+
   it('shows the normal confirm copy (no "only sentence" warning) when isOnlySentence is false', () => {
     render(
       <Provider store={makeStore()}>

--- a/src/components/promote-first-sentence-button.test.tsx
+++ b/src/components/promote-first-sentence-button.test.tsx
@@ -52,7 +52,12 @@ describe('PromoteFirstSentenceButton', () => {
   it('is disabled when there is no first sentence', () => {
     render(
       <Provider store={makeStore()}>
-        <PromoteFirstSentenceButton bookId="b1" chapterId={3} firstSentence={null} />
+        <PromoteFirstSentenceButton
+          bookId="b1"
+          chapterId={3}
+          firstSentence={null}
+          isOnlySentence={false}
+        />
       </Provider>,
     );
     expect(screen.getByTestId('promote-first-sentence-button')).toBeDisabled();
@@ -62,7 +67,12 @@ describe('PromoteFirstSentenceButton', () => {
     const long = { ...firstSentence, text: 'x'.repeat(201) };
     render(
       <Provider store={makeStore()}>
-        <PromoteFirstSentenceButton bookId="b1" chapterId={3} firstSentence={long} />
+        <PromoteFirstSentenceButton
+          bookId="b1"
+          chapterId={3}
+          firstSentence={long}
+          isOnlySentence={false}
+        />
       </Provider>,
     );
     expect(screen.getByTestId('promote-first-sentence-button')).toBeDisabled();
@@ -75,6 +85,7 @@ describe('PromoteFirstSentenceButton', () => {
           bookId="b1"
           chapterId={3}
           firstSentence={{ ...firstSentence, text: '  PUPPY TRAINING.  ' }}
+          isOnlySentence={false}
         />
       </Provider>,
     );
@@ -86,7 +97,12 @@ describe('PromoteFirstSentenceButton', () => {
   it('Cancel closes the dialog with no dispatch or api call', () => {
     render(
       <Provider store={makeStore()}>
-        <PromoteFirstSentenceButton bookId="b1" chapterId={3} firstSentence={firstSentence} />
+        <PromoteFirstSentenceButton
+          bookId="b1"
+          chapterId={3}
+          firstSentence={firstSentence}
+          isOnlySentence={false}
+        />
       </Provider>,
     );
     fireEvent.click(screen.getByTestId('promote-first-sentence-button'));
@@ -100,7 +116,12 @@ describe('PromoteFirstSentenceButton', () => {
     const store = makeStore();
     render(
       <Provider store={store}>
-        <PromoteFirstSentenceButton bookId="b1" chapterId={3} firstSentence={firstSentence} />
+        <PromoteFirstSentenceButton
+          bookId="b1"
+          chapterId={3}
+          firstSentence={firstSentence}
+          isOnlySentence={false}
+        />
       </Provider>,
     );
     fireEvent.click(screen.getByTestId('promote-first-sentence-button'));
@@ -119,7 +140,12 @@ describe('PromoteFirstSentenceButton', () => {
     const store = makeStore();
     render(
       <Provider store={store}>
-        <PromoteFirstSentenceButton bookId="b1" chapterId={3} firstSentence={firstSentence} />
+        <PromoteFirstSentenceButton
+          bookId="b1"
+          chapterId={3}
+          firstSentence={firstSentence}
+          isOnlySentence={false}
+        />
       </Provider>,
     );
     fireEvent.click(screen.getByTestId('promote-first-sentence-button'));
@@ -128,5 +154,40 @@ describe('PromoteFirstSentenceButton', () => {
     expect(store.getState().notifications.toasts[0].message).toBe('network down');
     expect(store.getState().manuscript.sentences).toHaveLength(2);
     expect(store.getState().chapters.chapters[0].title).toBe('Chapter 3');
+  });
+
+  it('shows the normal confirm copy (no "only sentence" warning) when isOnlySentence is false', () => {
+    render(
+      <Provider store={makeStore()}>
+        <PromoteFirstSentenceButton
+          bookId="b1"
+          chapterId={3}
+          firstSentence={firstSentence}
+          isOnlySentence={false}
+        />
+      </Provider>,
+    );
+    fireEvent.click(screen.getByTestId('promote-first-sentence-button'));
+    expect(screen.getByRole('dialog')).toHaveTextContent(
+      'Set title to "PUPPY TRAINING" and remove it from narration?',
+    );
+    expect(screen.getByRole('dialog')).not.toHaveTextContent("chapter's only sentence");
+  });
+
+  it('shows the stronger "only sentence" warning copy when isOnlySentence is true', () => {
+    render(
+      <Provider store={makeStore()}>
+        <PromoteFirstSentenceButton
+          bookId="b1"
+          chapterId={3}
+          firstSentence={firstSentence}
+          isOnlySentence={true}
+        />
+      </Provider>,
+    );
+    fireEvent.click(screen.getByTestId('promote-first-sentence-button'));
+    expect(screen.getByRole('dialog')).toHaveTextContent(
+      "This is the chapter's only sentence — the chapter will have no narrated content until you add more.",
+    );
   });
 });

--- a/src/components/promote-first-sentence-button.test.tsx
+++ b/src/components/promote-first-sentence-button.test.tsx
@@ -151,7 +151,9 @@ describe('PromoteFirstSentenceButton', () => {
     fireEvent.click(screen.getByTestId('promote-first-sentence-button'));
     fireEvent.click(screen.getByTestId('promote-first-sentence-confirm'));
     await waitFor(() => expect(store.getState().notifications.toasts).toHaveLength(1));
-    expect(store.getState().notifications.toasts[0].message).toBe('network down');
+    expect(store.getState().notifications.toasts[0].message).toBe(
+      'Could not rename chapter 3: network down',
+    );
     expect(store.getState().manuscript.sentences).toHaveLength(2);
     expect(store.getState().chapters.chapters[0].title).toBe('Chapter 3');
   });

--- a/src/components/promote-first-sentence-button.tsx
+++ b/src/components/promote-first-sentence-button.tsx
@@ -1,0 +1,111 @@
+/* Promote-first-sentence-to-title (2026-07-01 spec) — a quick fix for
+   unstructured manuscripts where the analyzer never detected a real
+   chapter title and the actual title text sits as the chapter's first
+   sentence instead. Promoting it renames the chapter (api.renameChapter,
+   the same endpoint EditChapterTitleModal uses) and removes the sentence
+   from narration (manuscriptActions.promoteSentenceToTitle), tombstoning
+   it the same way mergeSentences does.
+
+   Styled after DetectEmotionsButton's idle/confirm popover pattern.
+   See docs/superpowers/specs/2026-07-01-promote-first-sentence-to-title-design.md. */
+
+import { useState } from 'react';
+import { useAppDispatch } from '../store';
+import { chaptersActions } from '../store/chapters-slice';
+import { manuscriptActions } from '../store/manuscript-slice';
+import { notificationsActions } from '../store/notifications-slice';
+import { api } from '../lib/api';
+import { MAX_TITLE_LEN } from '../modals/edit-chapter-title';
+import type { Sentence } from '../lib/types';
+
+type Phase = 'idle' | 'confirm' | 'busy';
+
+interface Props {
+  bookId: string | null;
+  chapterId: number;
+  firstSentence: Sentence | null;
+}
+
+/** Trim + drop one trailing period — verbatim otherwise (spec Decision 5).
+    No casing changes. */
+function cleanTitle(text: string): string {
+  return text.trim().replace(/\.$/, '');
+}
+
+export function PromoteFirstSentenceButton({ bookId, chapterId, firstSentence }: Props) {
+  const dispatch = useAppDispatch();
+  const [phase, setPhase] = useState<Phase>('idle');
+
+  const cleaned = firstSentence ? cleanTitle(firstSentence.text) : '';
+  const disabled = !bookId || !firstSentence || cleaned.length === 0 || cleaned.length > MAX_TITLE_LEN;
+
+  async function handleConfirm() {
+    if (!bookId || !firstSentence) return;
+    setPhase('busy');
+    try {
+      await api.renameChapter(bookId, chapterId, cleaned);
+      dispatch(chaptersActions.renameChapter({ chapterId, title: cleaned }));
+      dispatch(manuscriptActions.promoteSentenceToTitle({ chapterId, sentenceId: firstSentence.id }));
+      setPhase('idle');
+    } catch (err) {
+      dispatch(
+        notificationsActions.pushToast({
+          kind: 'error',
+          message: (err as Error).message || 'Could not rename the chapter.',
+          dedupeKey: `chapter-rename-${chapterId}`,
+        }),
+      );
+      setPhase('idle');
+    }
+  }
+
+  return (
+    <span className="relative inline-block">
+      <button
+        type="button"
+        data-testid="promote-first-sentence-button"
+        disabled={disabled || phase === 'busy'}
+        onClick={() => setPhase((p) => (p === 'confirm' ? 'idle' : 'confirm'))}
+        title={
+          firstSentence
+            ? "Use this chapter's first line as its title, and remove it from narration"
+            : 'This chapter has no sentences to promote'
+        }
+        className="shrink-0 inline-flex items-center gap-2 px-4 min-h-11 rounded-full border border-ink/15 text-sm font-semibold text-ink hover:bg-ink/5 disabled:opacity-40"
+      >
+        Use first line as title
+      </button>
+      {(phase === 'confirm' || phase === 'busy') && firstSentence && (
+        <span
+          role="dialog"
+          aria-label="Use first line as title"
+          className="absolute z-50 left-0 top-full mt-2 w-72 rounded-xl border border-ink/10 bg-white picker-surface shadow-lg p-3 text-left"
+        >
+          <p className="text-xs text-ink/70 leading-snug">
+            Set title to "<span className="font-semibold text-ink">{cleaned}</span>" and remove it
+            from narration?
+          </p>
+          <div className="mt-3 flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => setPhase('idle')}
+              disabled={phase === 'busy'}
+              className="px-3 py-1.5 text-xs text-ink/60 hover:text-ink disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              data-testid="promote-first-sentence-confirm"
+              disabled={phase === 'busy'}
+              onClick={() => void handleConfirm()}
+              className="px-3 py-1.5 rounded-full bg-ink text-canvas text-xs font-semibold hover:bg-ink/90 disabled:opacity-50"
+            >
+              {phase === 'busy' ? 'Saving…' : 'Confirm'}
+            </button>
+          </div>
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/components/promote-first-sentence-button.tsx
+++ b/src/components/promote-first-sentence-button.tsx
@@ -57,10 +57,17 @@ export function PromoteFirstSentenceButton({
       dispatch(manuscriptActions.promoteSentenceToTitle({ chapterId, sentenceId: firstSentence.id }));
       setPhase('idle');
     } catch (err) {
+      /* PR-gate review round 2 — a fired-off promise isn't cancelled by the
+         `key`-driven remount (finding 1's fix): if the user switches chapters
+         before this settles, the toast must still say WHICH chapter failed,
+         since the user may already be looking at a different one. */
+      const detail = (err as Error).message;
       dispatch(
         notificationsActions.pushToast({
           kind: 'error',
-          message: (err as Error).message || 'Could not rename the chapter.',
+          message: detail
+            ? `Could not rename chapter ${chapterId}: ${detail}`
+            : `Could not rename chapter ${chapterId}.`,
           dedupeKey: `chapter-rename-${chapterId}`,
         }),
       );

--- a/src/components/promote-first-sentence-button.tsx
+++ b/src/components/promote-first-sentence-button.tsx
@@ -49,7 +49,7 @@ export function PromoteFirstSentenceButton({
   const disabled = !bookId || !firstSentence || cleaned.length === 0 || cleaned.length > MAX_TITLE_LEN;
 
   async function handleConfirm() {
-    if (!bookId || !firstSentence) return;
+    if (disabled || !bookId || !firstSentence) return;
     setPhase('busy');
     try {
       await api.renameChapter(bookId, chapterId, cleaned);
@@ -120,7 +120,13 @@ export function PromoteFirstSentenceButton({
             <button
               type="button"
               data-testid="promote-first-sentence-confirm"
-              disabled={phase === 'busy'}
+              /* PR-gate review round 3 — must re-check the same validity
+                 condition as the trigger button, not just `busy`: a
+                 concurrent edit to this exact sentence (e.g. a script-review
+                 apply) while the popover is open can make `cleaned` empty or
+                 over-length between open and click, since it's recomputed
+                 live from the current `firstSentence` prop every render. */
+              disabled={phase === 'busy' || disabled}
               onClick={() => void handleConfirm()}
               className="px-3 py-1.5 rounded-full bg-ink text-canvas text-xs font-semibold hover:bg-ink/90 disabled:opacity-50"
             >

--- a/src/components/promote-first-sentence-button.tsx
+++ b/src/components/promote-first-sentence-button.tsx
@@ -15,7 +15,7 @@ import { chaptersActions } from '../store/chapters-slice';
 import { manuscriptActions } from '../store/manuscript-slice';
 import { notificationsActions } from '../store/notifications-slice';
 import { api } from '../lib/api';
-import { MAX_TITLE_LEN } from '../modals/edit-chapter-title';
+import { MAX_TITLE_LEN } from '../lib/chapter-title';
 import type { Sentence } from '../lib/types';
 
 type Phase = 'idle' | 'confirm' | 'busy';
@@ -24,6 +24,10 @@ interface Props {
   bookId: string | null;
   chapterId: number;
   firstSentence: Sentence | null;
+  /* PR-gate review finding 2 — true when `firstSentence` is the chapter's
+     ONLY sentence, so confirming would leave the chapter with zero narrated
+     content. Strengthens the confirm-popover copy to make that explicit. */
+  isOnlySentence: boolean;
 }
 
 /** Trim + drop one trailing period — verbatim otherwise (spec Decision 5).
@@ -32,7 +36,12 @@ function cleanTitle(text: string): string {
   return text.trim().replace(/\.$/, '');
 }
 
-export function PromoteFirstSentenceButton({ bookId, chapterId, firstSentence }: Props) {
+export function PromoteFirstSentenceButton({
+  bookId,
+  chapterId,
+  firstSentence,
+  isOnlySentence,
+}: Props) {
   const dispatch = useAppDispatch();
   const [phase, setPhase] = useState<Phase>('idle');
 
@@ -84,6 +93,13 @@ export function PromoteFirstSentenceButton({ bookId, chapterId, firstSentence }:
           <p className="text-xs text-ink/70 leading-snug">
             Set title to "<span className="font-semibold text-ink">{cleaned}</span>" and remove it
             from narration?
+            {isOnlySentence && (
+              <>
+                {' '}
+                This is the chapter's only sentence — the chapter will have no
+                narrated content until you add more.
+              </>
+            )}
           </p>
           <div className="mt-3 flex items-center justify-end gap-2">
             <button

--- a/src/lib/chapter-title.ts
+++ b/src/lib/chapter-title.ts
@@ -1,0 +1,6 @@
+/* Shared chapter-title constants. Split out from edit-chapter-title.tsx
+   (PR-gate review finding 3) so a lazy-loaded route that only needs
+   MAX_TITLE_LEN — e.g. manuscript.tsx's PromoteFirstSentenceButton — doesn't
+   pull the entire EditChapterTitleModal chunk into its bundle. */
+
+export const MAX_TITLE_LEN = 200;

--- a/src/modals/edit-chapter-title.tsx
+++ b/src/modals/edit-chapter-title.tsx
@@ -23,11 +23,6 @@ import type { Chapter } from '../lib/types';
 import { stripChapterPrefix } from '../lib/format-chapter-title';
 import { MAX_TITLE_LEN } from '../lib/chapter-title';
 
-/* Re-exported so any existing import of MAX_TITLE_LEN from this module keeps
-   working (PR-gate review finding 3 moved the constant to lib/chapter-title
-   so it can be imported without pulling in this modal's chunk). */
-export { MAX_TITLE_LEN };
-
 interface Props {
   open: boolean;
   bookId: string;

--- a/src/modals/edit-chapter-title.tsx
+++ b/src/modals/edit-chapter-title.tsx
@@ -29,7 +29,7 @@ interface Props {
   onClose: () => void;
 }
 
-const MAX_TITLE_LEN = 200;
+export const MAX_TITLE_LEN = 200;
 
 export function EditChapterTitleModal({ open, bookId, chapter, onClose }: Props) {
   /* Seed the input from the chapter the pencil was clicked against.

--- a/src/modals/edit-chapter-title.tsx
+++ b/src/modals/edit-chapter-title.tsx
@@ -21,6 +21,12 @@ import { notificationsActions } from '../store/notifications-slice';
 import { api } from '../lib/api';
 import type { Chapter } from '../lib/types';
 import { stripChapterPrefix } from '../lib/format-chapter-title';
+import { MAX_TITLE_LEN } from '../lib/chapter-title';
+
+/* Re-exported so any existing import of MAX_TITLE_LEN from this module keeps
+   working (PR-gate review finding 3 moved the constant to lib/chapter-title
+   so it can be imported without pulling in this modal's chunk). */
+export { MAX_TITLE_LEN };
 
 interface Props {
   open: boolean;
@@ -28,8 +34,6 @@ interface Props {
   chapter: Chapter | null;
   onClose: () => void;
 }
-
-export const MAX_TITLE_LEN = 200;
 
 export function EditChapterTitleModal({ open, bookId, chapter, onClose }: Props) {
   /* Seed the input from the chapter the pencil was clicked against.

--- a/src/store/manuscript-slice.test.ts
+++ b/src/store/manuscript-slice.test.ts
@@ -962,6 +962,37 @@ describe('mergeSentences', () => {
   });
 });
 
+describe('promoteSentenceToTitle', () => {
+  it('removes the sentence and tombstones it', () => {
+    const s = start([
+      { id: 1, chapterId: 3, characterId: 'narrator', text: 'PUPPY TRAINING.' },
+      { id: 2, chapterId: 3, characterId: 'narrator', text: 'You brought home a puppy.' },
+    ]);
+    const next = reducer(s, manuscriptActions.promoteSentenceToTitle({ chapterId: 3, sentenceId: 1 }));
+    const ch3 = next.sentences.filter((x) => x.chapterId === 3);
+    expect(ch3.map((x) => x.id)).toEqual([2]);
+    expect(next.mergedAwayKeys).toContain('3:1');
+  });
+
+  it('is a no-op when the sentence id does not exist in that chapter', () => {
+    const s = start([{ id: 1, chapterId: 3, characterId: 'narrator', text: 'A.' }]);
+    const next = reducer(s, manuscriptActions.promoteSentenceToTitle({ chapterId: 3, sentenceId: 99 }));
+    expect(next.sentences).toHaveLength(1);
+    expect(next.mergedAwayKeys).toEqual([]);
+  });
+
+  it('does not touch a same-id sentence in a different chapter', () => {
+    const s = start([
+      { id: 1, chapterId: 1, characterId: 'narrator', text: 'Chapter 1 heading.' },
+      { id: 1, chapterId: 2, characterId: 'narrator', text: 'Chapter 2 heading.' },
+    ]);
+    const next = reducer(s, manuscriptActions.promoteSentenceToTitle({ chapterId: 2, sentenceId: 1 }));
+    expect(next.sentences.filter((x) => x.chapterId === 1)).toHaveLength(1);
+    expect(next.sentences.filter((x) => x.chapterId === 2)).toHaveLength(0);
+    expect(next.mergedAwayKeys).toEqual(['2:1']);
+  });
+});
+
 describe('hydrateFromBookState — merge tombstone persistence (task-2b)', () => {
   it('rehydrates and book-scopes the merge tombstone', () => {
     const a = reducer(undefined, manuscriptActions.hydrateFromBookState({

--- a/src/store/manuscript-slice.ts
+++ b/src/store/manuscript-slice.ts
@@ -543,6 +543,21 @@ export const manuscriptSlice = createSlice({
         s.mergedAwayKeys.push(`${a.payload.chapterId}:${m.id}`);
       }
     },
+
+    /* promote-first-sentence-to-title (2026-07-01 spec) — deletes a sentence
+       and tombstones it, same pattern as mergeSentences, so a re-analysis
+       can't resurrect it. Used when the user promotes a chapter's first
+       sentence to be the chapter title; the chapter-rename half of that
+       action lives in chaptersActions.renameChapter, dispatched separately
+       by PromoteFirstSentenceButton. */
+    promoteSentenceToTitle: (s, a: PayloadAction<{ chapterId: number; sentenceId: number }>) => {
+      const i = s.sentences.findIndex(
+        (x) => x.chapterId === a.payload.chapterId && x.id === a.payload.sentenceId,
+      );
+      if (i < 0) return; // no-op if the sentence is already gone
+      s.sentences.splice(i, 1);
+      s.mergedAwayKeys.push(`${a.payload.chapterId}:${a.payload.sentenceId}`);
+    },
   },
 });
 

--- a/src/store/persistence-middleware.test.ts
+++ b/src/store/persistence-middleware.test.ts
@@ -424,6 +424,28 @@ describe('persistenceMiddleware — payload shape', () => {
       },
     });
   });
+
+  it('2026-07-01 — dispatching promoteSentenceToTitle triggers a manuscript PUT with the tombstone', async () => {
+    /* Without a PERSIST_RULES entry the promoted-away sentence would
+       resurface on the next page load even though the chapter title
+       already changed via the (separately-persisted) rename endpoint. */
+    const next = vi.fn((x) => x);
+    const state = baseState({
+      manuscript: {
+        sentences: [{ id: 2, chapterId: 3, text: 'You brought home a puppy.' }],
+        mergedAwayKeys: ['3:1'],
+      },
+    });
+    persistenceMiddleware(makeStore(state))(next)({ type: 'manuscript/promoteSentenceToTitle' });
+    await advance(500);
+    expect(putBookState).toHaveBeenCalledWith('book-1', {
+      slice: 'manuscript',
+      patch: {
+        sentences: [{ id: 2, chapterId: 3, text: 'You brought home a puppy.' }],
+        mergedAwayKeys: ['3:1'],
+      },
+    });
+  });
 });
 
 describe('persistenceMiddleware — error handling', () => {

--- a/src/store/persistence-middleware.ts
+++ b/src/store/persistence-middleware.ts
@@ -116,6 +116,12 @@ const PERSIST_RULES: Record<
     slice: 'manuscript',
     build: (s) => ({ sentences: s.manuscript.sentences, mergedAwayKeys: s.manuscript.mergedAwayKeys }),
   },
+  /* 2026-07-01 — sibling to mergeSentences. Deleting the sentence promoted
+     into a chapter title must survive reload the same way a merge does. */
+  'manuscript/promoteSentenceToTitle': {
+    slice: 'manuscript',
+    build: (s) => ({ sentences: s.manuscript.sentences, mergedAwayKeys: s.manuscript.mergedAwayKeys }),
+  },
   /* fs-58 — text edit (strip_tag review op). Persisted the same way as other
      sentence edits so the corrected text survives reload. */
   'manuscript/setSentenceText': {

--- a/src/views/manuscript.test.tsx
+++ b/src/views/manuscript.test.tsx
@@ -1555,3 +1555,48 @@ describe('isExcludedSentenceId', () => {
     expect(isExcludedSentenceId(rows, 9, 9)).toBe(false);
   });
 });
+
+describe('ManuscriptView — promote first sentence to title (2026-07-01)', () => {
+  function renderPromote(currentChapterId: number, chapterSentences: Sentence[]) {
+    const store = configureStore({
+      reducer: {
+        manuscript: manuscriptSlice.reducer,
+        changeLog: changeLogSlice.reducer,
+        ui: uiSlice.reducer,
+      },
+      preloadedState: {
+        ui: {
+          ...uiSlice.getInitialState(),
+          stage: { kind: 'ready', bookId: 'b1', view: 'manuscript', currentChapterId } as never,
+        },
+      },
+    });
+    return render(
+      <Provider store={store}>
+        <ManuscriptView
+          characters={characters}
+          chapters={[chapter1, chapter2]}
+          currentChapterId={currentChapterId}
+          setCurrentChapterId={() => {}}
+          sentencesFromStore={chapterSentences}
+        />
+      </Provider>,
+    );
+  }
+
+  it('promotes the minimum-id sentence even when it is not first in the array (finding 1 regression)', () => {
+    renderPromote(2, [
+      { id: 2, chapterId: 2, characterId: 'narrator', text: 'It was a quiet morning.' } as never,
+      { id: 1, chapterId: 2, characterId: 'narrator', text: 'PUPPY TRAINING.' } as never,
+    ]);
+    fireEvent.click(screen.getByTestId('promote-first-sentence-button'));
+    expect(screen.getByRole('dialog', { name: 'Use first line as title' })).toHaveTextContent(
+      'PUPPY TRAINING',
+    );
+  });
+
+  it('disables the button and does not crash on a zero-sentence chapter (finding 4 regression)', () => {
+    renderPromote(2, []);
+    expect(screen.getByTestId('promote-first-sentence-button')).toBeDisabled();
+  });
+});

--- a/src/views/manuscript.test.tsx
+++ b/src/views/manuscript.test.tsx
@@ -1599,4 +1599,71 @@ describe('ManuscriptView — promote first sentence to title (2026-07-01)', () =
     renderPromote(2, []);
     expect(screen.getByTestId('promote-first-sentence-button')).toBeDisabled();
   });
+
+  it('wires isOnlySentence=true for a chapter with exactly one sentence (PR-gate finding 2)', () => {
+    renderPromote(2, [
+      { id: 1, chapterId: 2, characterId: 'narrator', text: 'PUPPY TRAINING.' } as never,
+    ]);
+    fireEvent.click(screen.getByTestId('promote-first-sentence-button'));
+    expect(screen.getByRole('dialog')).toHaveTextContent("chapter's only sentence");
+  });
+
+  it('wires isOnlySentence=false for a chapter with more than one sentence (PR-gate finding 2)', () => {
+    renderPromote(2, [
+      { id: 1, chapterId: 2, characterId: 'narrator', text: 'PUPPY TRAINING.' } as never,
+      { id: 2, chapterId: 2, characterId: 'narrator', text: 'You brought home a puppy.' } as never,
+    ]);
+    fireEvent.click(screen.getByTestId('promote-first-sentence-button'));
+    expect(screen.getByRole('dialog')).not.toHaveTextContent("chapter's only sentence");
+  });
+
+  it('resets the confirm popover to idle when the current chapter changes without clicking Cancel (PR-gate finding 1)', () => {
+    /* Regression for the stale-popover bug: PromoteFirstSentenceButton is
+       mounted without a `key` tied to the chapter, so switching chapters
+       WITHOUT clicking Cancel first used to leave the popover open,
+       silently retargeting at the new chapter (its `cleaned` text and
+       `chapterId` are derived fresh from props each render). The fix keys
+       the mount on `currentChapter.id` so a chapter switch unmounts and
+       remounts the button, resetting its internal `phase` state to
+       'idle'. */
+    const store = configureStore({
+      reducer: {
+        manuscript: manuscriptSlice.reducer,
+        changeLog: changeLogSlice.reducer,
+        ui: uiSlice.reducer,
+      },
+      preloadedState: {
+        ui: {
+          ...uiSlice.getInitialState(),
+          stage: { kind: 'ready', bookId: 'b1', view: 'manuscript', currentChapterId: 2 } as never,
+        },
+      },
+    });
+    const sentencesBothChapters: Sentence[] = [
+      { id: 1, chapterId: 2, characterId: 'narrator', text: 'PUPPY TRAINING.' } as never,
+      { id: 1, chapterId: 1, characterId: 'narrator', text: 'A different opener.' } as never,
+    ];
+    function renderAt(currentChapterId: number) {
+      return (
+        <Provider store={store}>
+          <ManuscriptView
+            characters={characters}
+            chapters={[chapter1, chapter2]}
+            currentChapterId={currentChapterId}
+            setCurrentChapterId={() => {}}
+            sentencesFromStore={sentencesBothChapters}
+          />
+        </Provider>
+      );
+    }
+
+    const { rerender } = render(renderAt(2));
+    fireEvent.click(screen.getByTestId('promote-first-sentence-button'));
+    expect(screen.getByRole('dialog')).toHaveTextContent('PUPPY TRAINING');
+
+    // Simulate switching to a different chapter WITHOUT clicking Cancel first.
+    rerender(renderAt(1));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
 });

--- a/src/views/manuscript.tsx
+++ b/src/views/manuscript.tsx
@@ -333,15 +333,26 @@ export function ManuscriptView({
      empty the chapter's narration entirely) is derived from the SAME
      `inChapter` filter this memo already computes, not a second `.filter()`
      call — PR-gate review round 2 caught that the sibling-memo version ran
-     the filter twice per render for no reason. */
+     the filter twice per render for no reason.
+
+     PR-gate review round 3 — also reuses `chapterSentences` above instead of
+     re-filtering `sentences` from scratch, in the common case where it's
+     already scoped to `currentChapter.id` (i.e. `currentChapterId` is set
+     and matches). Only falls back to a fresh filter in the rare case they
+     diverge — `currentChapterId` is null/stale but `currentChapter` still
+     resolved via the `|| chapters[0]` fallback below, where `chapterSentences`
+     would incorrectly be the whole book. */
   const { firstSentence, isOnlySentence } = useMemo(() => {
-    const inChapter = sentences.filter((s) => s.chapterId === currentChapter?.id);
+    const inChapter =
+      currentChapterId === currentChapter?.id
+        ? chapterSentences
+        : sentences.filter((s) => s.chapterId === currentChapter?.id);
     if (inChapter.length === 0) return { firstSentence: null, isOnlySentence: false };
     return {
       firstSentence: inChapter.reduce((min, s) => (s.id < min.id ? s : min)),
       isOnlySentence: inChapter.length === 1,
     };
-  }, [sentences, currentChapter?.id]);
+  }, [sentences, chapterSentences, currentChapterId, currentChapter?.id]);
 
   const findChar = useCallback((id: string) => characters.find((c) => c.id === id), [characters]);
 

--- a/src/views/manuscript.tsx
+++ b/src/views/manuscript.tsx
@@ -38,6 +38,7 @@ import { changeLogActions } from '../store/change-log-slice';
 import { uiActions } from '../store/ui-slice';
 import { RestructureChaptersButton } from '../components/restructure-chapters-button';
 import { DetectEmotionsButton } from '../components/detect-emotions-button';
+import { PromoteFirstSentenceButton } from '../components/promote-first-sentence-button';
 import { ManuscriptStickyStatsBar } from '../components/manuscript/sticky-stats-bar';
 import { ScriptReviewDiff } from '../components/script-review-diff';
 import { api } from '../lib/api';
@@ -311,6 +312,28 @@ export function ManuscriptView({
     if (currentChapterId == null) return sentences;
     return sentences.filter((s) => s.chapterId === currentChapterId);
   }, [sentences, currentChapterId]);
+
+  /* Promote-first-sentence-to-title (2026-07-01 spec) — the first sentence
+     by MINIMUM id within the current chapter, never array position (that
+     array isn't guaranteed id-ordered — see the design spec). Filtered
+     directly against `currentChapter?.id` rather than reusing
+     `chapterSentences` above: that memo falls back to the WHOLE BOOK when
+     `currentChapterId` is null, which would pick the wrong chapter's
+     sentence. This is a deliberate deviation from the spec's literal
+     `chapterSentences.reduce(...)` — the spec's guard was `chapterSentences.length
+     > 0`; this guard is `currentChapter?.id`, which is `undefined` only when
+     `chapters` is empty. `currentChapter` is `chapters.find(...) || chapters[0]`
+     (a few lines above), itself `undefined` on an empty `chapters` array — the
+     optional-chaining here (both in the filter and the dep array) means an
+     empty-chapters render still resolves this memo to `null` instead of
+     throwing, consistent with the existing `if (!currentChapter) return null`
+     guard further down. Also guarded to null on an empty chapter's sentence
+     list — an unguarded `.reduce()` throws on `[]`. */
+  const firstSentence = useMemo(() => {
+    const inChapter = sentences.filter((s) => s.chapterId === currentChapter?.id);
+    if (inChapter.length === 0) return null;
+    return inChapter.reduce((min, s) => (s.id < min.id ? s : min));
+  }, [sentences, currentChapter?.id]);
 
   const findChar = useCallback((id: string) => characters.find((c) => c.id === id), [characters]);
 
@@ -784,6 +807,11 @@ export function ManuscriptView({
                 onClick={() => dispatch(uiActions.changeView('restructure'))}
               />
               <DetectEmotionsButton disabled={sentences.length === 0} />
+              <PromoteFirstSentenceButton
+                bookId={bookId}
+                chapterId={currentChapter.id}
+                firstSentence={firstSentence}
+              />
               {/* fs-58 — LLM script-review trigger. Primary = per-chapter
                   (low-cost default); the ⌄ disclosure opens the whole-book
                   opt-in, which is RPD-gated when the book is longer than the

--- a/src/views/manuscript.tsx
+++ b/src/views/manuscript.tsx
@@ -335,6 +335,16 @@ export function ManuscriptView({
     return inChapter.reduce((min, s) => (s.id < min.id ? s : min));
   }, [sentences, currentChapter?.id]);
 
+  /* PR-gate review finding 2 — whether `firstSentence` is the chapter's ONLY
+     sentence, so PromoteFirstSentenceButton can warn that promoting it empties
+     the chapter's narration entirely. Sibling memo over the SAME filtered
+     array the memo above builds (rather than recomputing a second, possibly
+     divergent sentence count). */
+  const isOnlySentence = useMemo(
+    () => sentences.filter((s) => s.chapterId === currentChapter?.id).length === 1,
+    [sentences, currentChapter?.id],
+  );
+
   const findChar = useCallback((id: string) => characters.find((c) => c.id === id), [characters]);
 
   /* Plan 92 — virtualise the segment list above ~60 segments. Below
@@ -808,9 +818,17 @@ export function ManuscriptView({
               />
               <DetectEmotionsButton disabled={sentences.length === 0} />
               <PromoteFirstSentenceButton
+                /* PR-gate review finding 1 — key the instance to the current
+                   chapter so switching chapters unmounts/remounts the button,
+                   resetting its internal `phase` state to 'idle'. Without
+                   this, an open confirm popover survives a chapter switch and
+                   silently retargets (its `cleaned` text and `chapterId` are
+                   derived fresh from props each render) at the NEW chapter. */
+                key={currentChapter.id}
                 bookId={bookId}
                 chapterId={currentChapter.id}
                 firstSentence={firstSentence}
+                isOnlySentence={isOnlySentence}
               />
               {/* fs-58 — LLM script-review trigger. Primary = per-chapter
                   (low-cost default); the ⌄ disclosure opens the whole-book

--- a/src/views/manuscript.tsx
+++ b/src/views/manuscript.tsx
@@ -329,21 +329,19 @@ export function ManuscriptView({
      throwing, consistent with the existing `if (!currentChapter) return null`
      guard further down. Also guarded to null on an empty chapter's sentence
      list — an unguarded `.reduce()` throws on `[]`. */
-  const firstSentence = useMemo(() => {
+  /* `isOnlySentence` (PR-gate review finding 2 — true when promoting would
+     empty the chapter's narration entirely) is derived from the SAME
+     `inChapter` filter this memo already computes, not a second `.filter()`
+     call — PR-gate review round 2 caught that the sibling-memo version ran
+     the filter twice per render for no reason. */
+  const { firstSentence, isOnlySentence } = useMemo(() => {
     const inChapter = sentences.filter((s) => s.chapterId === currentChapter?.id);
-    if (inChapter.length === 0) return null;
-    return inChapter.reduce((min, s) => (s.id < min.id ? s : min));
+    if (inChapter.length === 0) return { firstSentence: null, isOnlySentence: false };
+    return {
+      firstSentence: inChapter.reduce((min, s) => (s.id < min.id ? s : min)),
+      isOnlySentence: inChapter.length === 1,
+    };
   }, [sentences, currentChapter?.id]);
-
-  /* PR-gate review finding 2 — whether `firstSentence` is the chapter's ONLY
-     sentence, so PromoteFirstSentenceButton can warn that promoting it empties
-     the chapter's narration entirely. Sibling memo over the SAME filtered
-     array the memo above builds (rather than recomputing a second, possibly
-     divergent sentence count). */
-  const isOnlySentence = useMemo(
-    () => sentences.filter((s) => s.chapterId === currentChapter?.id).length === 1,
-    [sentences, currentChapter?.id],
-  );
 
   const findChar = useCallback((id: string) => characters.find((c) => c.id === id), [characters]);
 


### PR DESCRIPTION
## Summary

- Unstructured manuscripts sometimes leave the real chapter title sitting as the chapter's first narrated sentence (the analyzer never detected it as a title). Adds a "Use first line as title" button to the Manuscript view's chapter-heading action row that renames the chapter to that sentence's (cleaned) text and permanently removes it from narration.
- Confirmation is inline (shows the exact text before committing); on failure nothing changes and an error toast fires.
- The "first sentence" is the minimum-`id` sentence in the chapter, not `array[0]` — the sentence array isn't guaranteed id-ordered, and an earlier draft's array-index approach would have picked the wrong sentence after a re-analysis merge.
- Closes #1210

## Test plan

- [x] `npm run verify` — green (pre-push hook; 244/244 e2e, full frontend+server suite, typecheck, lint, build)
- [x] New reducer tests (`manuscript-slice.test.ts`): removes + tombstones the right sentence, no-op on missing id, doesn't cross chapter boundaries
- [x] Persistence-middleware test: the removal survives the debounced manuscript-state PUT
- [x] Component tests (`promote-first-sentence-button.test.tsx`): disabled states, confirm-preview text (trimmed/period-stripped), Cancel, Confirm success (both dispatches fire), Confirm failure (toast, no state change)
- [x] View-wiring regression tests (`manuscript.test.tsx`): picks the minimum-id sentence even when it isn't first in the array; doesn't crash on a zero-sentence chapter
- [x] Every task passed its own spec+quality review, plus a final whole-branch review (Ready to merge: Yes) during implementation