### PR TITLE
fix(frontend): series cast-carried sparkline no longer stretches full-width

### DIFF
--- a/src/components/library/library-grid.tsx
+++ b/src/components/library/library-grid.tsx
@@ -93,29 +93,31 @@ export function LibraryGrid({
           <div className="mt-4 space-y-8">
             {author.series.map((series) => (
               <div key={series.name}>
-                <div className="flex items-baseline justify-between mb-3">
-                  <h3 className="text-[11px] uppercase tracking-[0.18em] font-semibold text-ink/55">
+                <div className="flex items-start justify-between mb-4">
+                  <h3 className="text-[11px] uppercase tracking-[0.18em] font-semibold text-ink/55 pt-0.5">
                     {series.name}
                   </h3>
-                  <div className="flex items-center gap-2.5">
+                  <div className="flex flex-col items-end gap-2">
+                    <div className="flex items-center gap-2.5">
+                      {series.seriesMemory && (
+                        <SeriesMemoryChip
+                          summary={series.seriesMemory}
+                          bookCount={series.seriesMemory.confirmedBookCount}
+                          onOpen={() => onOpenSeriesMemory?.(series)}
+                        />
+                      )}
+                      <span className="text-[11px] text-ink/40">
+                        {series.books.length} {series.books.length === 1 ? 'book' : 'books'}
+                      </span>
+                    </div>
                     {series.seriesMemory && (
-                      <SeriesMemoryChip
+                      <SeriesSparkline
                         summary={series.seriesMemory}
-                        bookCount={series.seriesMemory.confirmedBookCount}
                         onOpen={() => onOpenSeriesMemory?.(series)}
                       />
                     )}
-                    <span className="text-[11px] text-ink/40">
-                      {series.books.length} {series.books.length === 1 ? 'book' : 'books'}
-                    </span>
                   </div>
                 </div>
-                {series.seriesMemory && (
-                  <SeriesSparkline
-                    summary={series.seriesMemory}
-                    onOpen={() => onOpenSeriesMemory?.(series)}
-                  />
-                )}
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
                   {series.books.map((b) => (
                     <BookCard

--- a/src/components/series-memory/series-sparkline.tsx
+++ b/src/components/series-memory/series-sparkline.tsx
@@ -7,7 +7,7 @@ export function SeriesSparkline({ summary, onOpen }: { summary: SeriesMemorySumm
   const baseFor = (p: SeriesMemorySummary['perBook'][number]) => Math.max(p.principalCount, p.carriedPresent, 1);
   const max = Math.max(1, ...summary.perBook.map(baseFor));
   return (
-    <div className="mt-1 rounded-xl border border-peach/20 bg-peach/8 px-3.5 py-2.5">
+    <div className="inline-flex max-w-full flex-col gap-2 rounded-xl border border-peach/20 bg-peach/8 px-4 py-3">
       <button
         type="button" onClick={onOpen}
         data-testid="series-sparkline"
@@ -27,8 +27,8 @@ export function SeriesSparkline({ summary, onOpen }: { summary: SeriesMemorySumm
           );
         })}
       </button>
-      <p className="mt-2 text-xs text-ink/60">{summary.carriedCount} of your cast, kept true across the series.</p>
-      <div className="mt-1.5 flex items-center gap-3 text-[11px] text-ink/50">
+      <p className="text-xs text-ink/60">{summary.carriedCount} of your cast, kept true across the series.</p>
+      <div className="flex items-center gap-3 text-[11px] text-ink/50">
         <span className="flex items-center gap-1">
           <span className="inline-block w-2.5 h-2.5 rounded-sm bg-gradient-to-t from-peach to-magenta" />
           Carried


### PR DESCRIPTION
## Summary
- The per-series "cast carried" sparkline stretched to the full row width even though its actual content (a tiny bar chart + caption) was much narrower, leaving a large empty tinted rectangle on wide screens and sitting flush against the book cards grid below with no spacing.
- Shrunk the sparkline to its content width (`inline-flex`) and moved it out of its own full-width row to sit right-aligned under the "Your cast · N voices" pill, so the two related stats read as one grouped block.

Closes #1253

## Test plan
- [x] `vitest run` (series-sparkline, library-grid, book-library) — 45 tests passing
- [x] Full pre-push verify: lint, typecheck, full vitest suite (3456 tests), full e2e + visual-baseline suites (266 tests), production build — all green
- [x] Manually verified in-browser at 1600px width (mock library data) and confirmed the fix visually