### PR TITLE
chore: bump version to 1.10.0

### DIFF
--- a/apps/android/pubspec.yaml
+++ b/apps/android/pubspec.yaml
@@ -21,7 +21,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # 3-digit build-iteration band so successive Play uploads of the same marketing
 # version take base+1, base+2, … via `flutter build … --build-number=<N>`).
 # Plan 188.
-version: 1.9.0+10900000
+version: 1.10.0+11000000
 
 environment:
   sdk: ^3.12.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "castwright",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "castwright",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "castwright",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "castwright-server",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "castwright-server",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "dependencies": {
         "@google/genai": "^2.7.0",
         "@lingo-reader/mobi-parser": "^0.4.6",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "castwright-server",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/tts-sidecar/version.py
+++ b/server/tts-sidecar/version.py
@@ -7,4 +7,4 @@ SIDECAR_PROTOCOL_VERSION in main.py: the protocol version gates adopt/replace of
 a running sidecar, while __version__ is purely informational.
 """
 
-__version__ = "1.9.0"
+__version__ = "1.10.0"


### PR DESCRIPTION
## Summary

Version-bump commit for the **v1.10.0** cut — root + server `package.json`, both lockfiles, sidecar `version.py`, and the companion `pubspec.yaml`, all in lockstep (generated by `scripts/bump-version.mjs`).

Routed through a PR because `main` now hard-blocks direct pushes (the `Verify PR body links a GitHub issue` ruleset). The annotated `v1.10.0` tag (release body = `docs/release-notes-next.md`) is already created locally at this commit and gets pushed after merge to trigger `release.yml`.

**Verification:** cross-OS gate (Windows + macOS verify/build + mobile e2e) passed on the base commit; the full pre-push `npm run verify` battery passed on this bump commit.

## Test plan

Mechanical version-string bump — no runtime behaviour change. `release.yml` re-runs full cross-platform verification on the tag before publishing.

Closes #1260