### PR TITLE
docs(frontend): refresh Help troubleshooting/FAQ for v1.10.0

### DIFF
--- a/src/data/help-topics.ts
+++ b/src/data/help-topics.ts
@@ -19,6 +19,17 @@ export const HELP_TOPICS: HelpTopic[] = [
       'before the first start.',
   },
   {
+    id: 'setup-not-ready',
+    title: '"Not ready" — what do I click?',
+    body:
+      "When a voice engine or the analyzer isn't ready yet, both the Setup screen (first launch) " +
+      "and the Status menu (the top-bar pill, any time after) now say exactly what's missing " +
+      'instead of a bare "not ready" — and where a safe fix exists, a button does it for you: ' +
+      "setting up the voice engine, installing an engine's model, or connecting the local " +
+      'analyzer. Model Manager still has the fuller picture (package installed, weights on disk, ' +
+      'whether the two match) if you want to look closer.',
+  },
+  {
     id: 'models-missing',
     title: 'Voices or models are missing',
     body:
@@ -29,14 +40,50 @@ export const HELP_TOPICS: HelpTopic[] = [
       'in the top bar and wait for it to turn green.',
   },
   {
+    id: 'languages-supported',
+    title: 'What languages does Castwright perform?',
+    body:
+      'English, Russian, Spanish, French and German today, all with the same full-cast craft — ' +
+      'the manuscript is read in its own language, every character gets a voice that speaks it, ' +
+      "and the cast's tone and descriptions stay written in the book's own tongue. Drop in a " +
+      'manuscript and Castwright detects its language the moment you import it, showing you what ' +
+      "it found — before you commit — on the Confirm details screen. A language it can't perform " +
+      'yet falls back to English rather than guessing. More languages are on the way.',
+  },
+  {
+    id: 'voices-hidden-wrong-language',
+    title: "Casting a character, but some voices aren't showing up",
+    body:
+      "For a non-English book, the voice picker hides voices that don't speak the book's " +
+      "language — a French cast doesn't want a Spanish-only voice turning up as an option. A " +
+      'small note under the list says how many are hidden and why ("N hidden · can\'t read ' +
+      'French"); tap "show all" to bring them back if you want to browse anyway. English books ' +
+      'are unaffected — every voice you own is available.',
+  },
+  {
+    id: 'higher-quality-tier',
+    title: 'What does "Higher quality" mean, and should I turn it on?',
+    body:
+      'Every Qwen voice can render on two models: the everyday 0.6B (fast) or the larger 1.7B — ' +
+      'better prosody and emotional range, noticeably slower and heavier on VRAM. Pin it per ' +
+      'character from the voice picker, for a whole book at Start Generation, for a single ' +
+      'chapter at Regenerate, or for your whole cast in one tap from the Cast view ("Pin 1.7B ' +
+      'quality to all Qwen cast"). It also unlocks per-line direction and the vocal reactions ' +
+      '(gasps, sighs, laughs) — those only render on the 1.7B tier. Worth it for a book you care ' +
+      'about; leave everyday books on the fast tier.',
+  },
+  {
     id: 'generation-slow',
     title: 'Generation is much slower than usual',
     body:
       "The usual culprit is a crowded GPU. Check it isn't sharing the card with something heavy " +
       '(games, a second model), and keep only one heavy voice engine loaded — unload the analyzer ' +
-      'Ollama or a second engine from the model pills. If the slowdown crept in after hours of ' +
-      "generating, restart the voice engine (it reclaims leaked memory). The Admin view's " +
-      'Resource trends panel shows the per-chapter speed history.',
+      'Ollama or a second engine from the model pills. Rendering on the Higher-quality (1.7B) ' +
+      'tier is also simply slower by design — that is expected, not a fault. Castwright now ' +
+      'watches for a voice engine that has gone quiet without crashing and restarts it on its ' +
+      "own, so a stalled render usually recovers by itself; if it doesn't pick back up within a " +
+      "minute or two, restart the voice engine yourself from its pill. The Admin view's Resource " +
+      'trends panel shows the per-chapter speed history.',
   },
   {
     id: 'amd-gpu',
@@ -51,6 +98,89 @@ export const HELP_TOPICS: HelpTopic[] = [
       're-bootstrap) — your books and designed voices are safe, they live in the workspace, not the ' +
       'venv. To stay on CPU and silence the warning, set the Accelerator to CPU in Advanced ' +
       'settings; changing the accelerator rebuilds the Python environment, so it is not instant.',
+  },
+  {
+    id: 'multi-gpu-placement',
+    title: 'I have two graphics cards — how do I put engines on different ones?',
+    body:
+      "In Advanced Configuration each voice engine has its own device pin, listed by the card's " +
+      'real name and how much room it has free, so a second GPU no longer sits idle. A pin ' +
+      'survives a driver update reshuffling which card is "first" — it tracks the actual device, ' +
+      'not a slot number. If something is off, the picker says so plainly: a card that has gone ' +
+      'missing, an engine that quietly landed on the CPU instead of the card you chose, or a ' +
+      'card genuinely too small for what you asked — that last one now stops cleanly with a ' +
+      "clear message instead of struggling in the background. The analyzer's device is shown too, " +
+      "though it isn't yours to place there — set CUDA_VISIBLE_DEVICES in server/.env if you need " +
+      'to move it, which overrides every per-engine pin.',
+  },
+  {
+    id: 'design-without-cloud-key',
+    title: 'Can I design voices without a Gemini API key?',
+    body:
+      "Yes — voice design's description-writing step follows the same analyzer engine you've " +
+      'already chosen (Local or Gemini, in Advanced settings). Set the analyzer to Local and ' +
+      "Castwright drafts each character's voice from a model running entirely on your machine, so " +
+      'a fully offline setup, or one with no cloud key, can still design a full cast from scratch. ' +
+      'Gemini stays the default for the richest descriptions; Local is the road for a no-key or ' +
+      'offline setup.',
+  },
+  {
+    id: 'vocalizations',
+    title: "Why is my character gasping, sighing, or laughing when the book doesn't say so?",
+    body:
+      'Beyond the words on the page, Castwright can perform the small human sounds between them — ' +
+      'a caught breath, a soft laugh, a sigh. It reads these in automatically as part of analysis ' +
+      '(the "Expressive directions" option, on by default) and they come alive whenever a chapter ' +
+      'renders on the Higher-quality (1.7B) tier — an everyday-tier performance is left exactly as ' +
+      'it was. Turn "Expressive directions" off before you analyse a book if you would rather it ' +
+      'stuck to the words on the page.',
+  },
+  {
+    id: 'line-direction',
+    title: 'Can I direct a single line myself?',
+    body:
+      'Yes — every line in the Manuscript view, narration included, has a small direction chip ' +
+      'you can open and fill in with your own words: a whispered aside, a shout, a knowing pause. ' +
+      'It sits alongside whatever Castwright detected automatically, and a hand-written direction ' +
+      'always wins. Like the automatic directions, a custom one only comes through on the ' +
+      'Higher-quality (1.7B) tier — pin the character (or the chapter, at Regenerate) to that tier ' +
+      'to hear it.',
+  },
+  {
+    id: 'voice-consistency-flag',
+    title: 'What does it mean when a line is flagged as "out of character"?',
+    body:
+      'Render-integrity QA (Advanced Configuration → QA gates, off by default) measures every ' +
+      "rendered line against that character's own established voice and flags the ones that " +
+      'drift — sounding like someone else even though the words are right. It runs on the CPU by ' +
+      'default, at no VRAM cost, so switch it on in Advanced settings if you want the extra ' +
+      "scrutiny. It's a detector, not an auto-fix: a flagged line is worth a listen, and " +
+      're-rendering the chapter is the usual next step once you have confirmed it is really off.',
+  },
+  {
+    id: 'script-review-fixes',
+    title: 'Can Castwright fix who-said-what mistakes for me?',
+    body:
+      'Review Script, in the Manuscript view, reads back over a chapter for the small mistakes ' +
+      'that creep into attribution — a stray speaker tag, a line split between two people, ' +
+      "dialogue buried in narration, an emotion that doesn't fit. It can now propose the fix " +
+      'directly: reassign a line to the right character (creating one on the spot if the review ' +
+      "finds someone new), set aside a stray heading or page number that isn't really part of the " +
+      'story, and follow a line across a chapter break to whoever opens the next one. Accept each ' +
+      'fix or wave it off, one at a time or all at once — and if a new character shows up, ' +
+      'Castwright offers to design their voice right there.',
+  },
+  {
+    id: 'cast-carried-across-books',
+    title: 'How does Castwright know a character already has a voice?',
+    body:
+      'Link a character to one from an earlier book in the series — offered on the Confirm Cast ' +
+      'screen — and they keep the voice you designed for them, no redesigning a returning ' +
+      'character book after book. Once a real cast has carried across books, a chip appears on ' +
+      'your library shelf tallying how many voices and how many books; open it to see the ' +
+      'returning cast, which books each one appears in, and how steady the run has been. It only ' +
+      'shows up once carried voices exist, so a shelf of stock voices never sees it. From that ' +
+      'panel you can also lift a shareable card naming the voices you have designed.',
   },
   {
     id: 'engine-needs-repair',
@@ -69,9 +199,11 @@ export const HELP_TOPICS: HelpTopic[] = [
     title: "My phone can't reach the app (LAN / HTTPS)",
     body:
       'Real devices need the LAN HTTPS mode: run `npm run dev:lan` (or `npm run start:lan` for the ' +
-      'production build) and open the printed https:// address. Each device must trust the local ' +
-      'certificate once — run `npm run install:cert-mobile` and follow the per-OS steps it prints. ' +
-      'Both devices must be on the same network.',
+      'production build) and open the printed address — it now reads `https://castwright.local` ' +
+      '(or `castwright.dev.local` while developing) instead of a raw IP that changes every time ' +
+      'your router hands out a new one. Each device must trust the local certificate once — run ' +
+      '`npm run install:cert-mobile` and follow the per-OS steps it prints. Both devices must be ' +
+      'on the same network.',
   },
   {
     id: 'where-files-live',
@@ -84,6 +216,16 @@ export const HELP_TOPICS: HelpTopic[] = [
       "you've backed up your whole library.",
   },
   {
+    id: 'audiobookshelf-export',
+    title: 'How do I send a book to Audiobookshelf?',
+    body:
+      'From the Listen view, export straight to Audiobookshelf: point it at the library folder ' +
+      'your sync app mirrors to the server, and pick either a single chaptered M4B or an MP3 ' +
+      'folder (with the metadata.json Audiobookshelf reads directly) — whichever your library ' +
+      'prefers. Series, cover and metadata travel with the book either way; Audiobookshelf picks ' +
+      'it up on its next scheduled library scan.',
+  },
+  {
     id: 'analysis-reloads-or-gpu-busy',
     title: 'Analysis keeps reloading the model, or says "GPU busy"',
     body:
@@ -92,7 +234,7 @@ export const HELP_TOPICS: HelpTopic[] = [
       'Castwright frees the analyzer before it loads a voice — and if you kick off generation while ' +
       'analysis is still running, you\'ll see a brief "GPU busy with analysis" note: let the analysis ' +
       "finish, then generate. One thing to watch — if you've pointed the two analysis passes at two " +
-      'different local models (Advanced settings, a per-phase analysis model), a smaller card can\'t ' +
+      "different local models (Advanced settings, a per-phase analysis model), a smaller card can't " +
       'hold both, so it reloads between passes and the run drags. Keep the same local model for both ' +
       'passes, pair one local model with a cloud one (Gemini uses no GPU at all), or run on a roomier ' +
       'card (12 GB and up), where both sit side by side.',
@@ -102,8 +244,8 @@ export const HELP_TOPICS: HelpTopic[] = [
     title: "I pulled a model but it's not in the analysis-model list",
     body:
       "The analysis-model menu lists the models you've already installed into Ollama — the built-in " +
-      'suggestions you pulled, plus any others you added yourself. A suggested model you haven\'t ' +
-      'pulled yet won\'t be in this menu; install it from the Model Manager\'s list first (or ' +
+      "suggestions you pulled, plus any others you added yourself. A suggested model you haven't " +
+      "pulled yet won't be in this menu; install it from the Model Manager's list first (or " +
       '`ollama pull <name>` in a terminal) and it joins the menu the moment the pull finishes. ' +
       "Reopen the menu, or hit Refresh in the Model Manager, if it hasn't appeared yet. Still " +
       'missing? Check that Ollama is running and the model shows up in `ollama list`.',
@@ -113,7 +255,7 @@ export const HELP_TOPICS: HelpTopic[] = [
     title: 'I chose a model on my machine, but the analysis ran on Gemini',
     body:
       "When your analyzer engine is set to Local and Ollama can't be reached, Castwright falls back " +
-      'to Gemini — if you\'ve added a Gemini API key — so a stalled daemon doesn\'t stall your book. ' +
+      "to Gemini — if you've added a Gemini API key — so a stalled daemon doesn't stall your book. " +
       'The on-machine models still show in the menu while Ollama is down, which is why a "Local" ' +
       'choice can land on Gemini. Want it to stop and tell you instead? Start Ollama before you ' +
       'analyse, or set the analyzer engine to Gemini outright.',


### PR DESCRIPTION
## Summary
- The in-app Help view's curated FAQ (`src/data/help-topics.ts`) hadn't been touched since before the v1.9.0 cut, so it had zero coverage of everything shipped in v1.10.0.
- Adds 12 new topics: languages supported (EN/RU/ES/FR/DE + import-time language detection), voices hidden by language mismatch when casting, the "Higher quality" 1.7B tier, multi-GPU per-engine placement (and its failure modes), designing voices without a Gemini key, vocalizations (gasps/sighs/laughs), per-line direction, the render-integrity voice-consistency flag, Review Script's new auto-fix capabilities, Series Memory (cast carried across books), Audiobookshelf export, and the Setup screen/Status menu one-click fixes.
- Updates 2 existing topics: `generation-slow` now mentions the auto-recovering stalled voice engine; `phone-cant-reach` now reflects `castwright.local`/`castwright.dev.local` instead of a raw LAN IP.
- All copy was verified against the actual UI/config code (component labels, toggle names, settings paths) rather than paraphrased from release notes.

Closes #1267

## Test plan
- [x] `npx vitest run src/data/help-failures.test.ts src/views/help.test.tsx` — passing
- [x] Full suite via pre-commit hook — 272 files / 3479 tests passing
- [x] `npx eslint src/data/help-topics.ts` — clean
- [x] `npx prettier --check src/data/help-topics.ts` — clean
- [x] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)