### PR TITLE
fix(server): wrap title-narration synth call in withCallTimeout (srv-51)

### DIFF
--- a/docs/release-notes-next.md
+++ b/docs/release-notes-next.md
@@ -46,3 +46,7 @@ time. The previous release's body shipped with the v1.10.0 tag annotation.
   flag, stamped at enqueue by the proceed-anyway path so the per-chapter
   `awaiting_fallback_confirm` gate doesn't re-prompt for that run's fresh
   chapters (later enqueues still get the per-chapter backstop).
+
+## 🔧 Reliability
+
+- **Title-narration synth call now wrapped in per-call timeout** (#1247, srv-51) — matches the defensive timeout protection added to every other synth call site, closing a gap where a wedged title narration could stall a chapter. No user-visible change under normal operation; defensive only.

--- a/server/src/tts/synthesise-chapter.test.ts
+++ b/server/src/tts/synthesise-chapter.test.ts
@@ -2675,6 +2675,34 @@ describe('synthesiseChapter per-call timeout (plan 148)', () => {
     });
     expect(provider.calls.length).toBe(1);
   });
+
+  it('fails with ChapterSynthTimeoutError and aborts the title call when title-narration synth never returns', async () => {
+    let captured: AbortSignal | undefined;
+    const provider: TtsProvider = {
+      synthesize(input: SynthesizeInput): Promise<SynthesizeOutput> {
+        captured = input.signal;
+        /* Never settles — mimics a runaway/hung provider call on the title beat.
+           Without the timeout this would hang the chapter (and, in prod, the queue). */
+        return new Promise<SynthesizeOutput>(() => {});
+      },
+    };
+
+    await expect(
+      synthesiseChapter({
+        sentences: [sentence(1, 'narrator')],
+        cast: soloCast,
+        provider,
+        modelKey: 'gemini-2.5-flash',
+        engine: 'gemini',
+        chapterTitleNarration: 'Chapter One.',
+        callTimeoutMs: 40,
+        groupHeartbeatMs: 0,
+      }),
+    ).rejects.toBeInstanceOf(ChapterSynthTimeoutError);
+
+    // The derived signal was aborted, so the provider cancels its call.
+    expect(captured?.aborted).toBe(true);
+  });
 });
 
 /* Pre-assembly per-sentence QA gate: a sentence whose rendered PCM fails the

--- a/server/src/tts/synthesise-chapter.ts
+++ b/server/src/tts/synthesise-chapter.ts
@@ -979,15 +979,17 @@ export async function synthesiseChapter(
     onTitleStart?.();
 
     const titleResult = await withRecycleRecovery(titleRoute.engine, () =>
-      withTtsRetry(
-        () =>
-          titleRoute.provider.synthesize({
-            text: normaliseForTts(titleText, langCode),
-            voiceName: narratorVoice,
-            modelKey: titleRoute.modelKey,
-            signal,
-          }),
-        { signal },
+      withCallTimeout('title', (sig) =>
+        withTtsRetry(
+          () =>
+            titleRoute.provider.synthesize({
+              text: normaliseForTts(titleText, langCode),
+              voiceName: narratorVoice,
+              modelKey: titleRoute.modelKey,
+              signal: sig,
+            }),
+          { signal: sig },
+        ),
       ),
     );
 


### PR DESCRIPTION
## Summary

Title-narration synth call in `synthesiseChapter` was missing the defensive per-call timeout wrapper (`withCallTimeout`) that every other synth call site has. Without it, a wedged title narration worker has no per-call timeout ceiling, only the whole-chapter stall watchdog (much longer).

This fix adds `withCallTimeout('title', (sig) => ...)` wrapper matching the pattern used for ASR verify (srv-50) and other call sites, and includes a regression test proving the title call is now covered by the timeout.

## Test plan

- Added regression test in `server/src/tts/synthesise-chapter.test.ts` that proves the title narration synth call is now wrapped in the per-call timeout.
- Test confirms that when a title narration provider call hangs, it rejects with `ChapterSynthTimeoutError` and the captured AbortSignal is aborted.
- Ran the full synthesise-chapter test suite: **all 97 tests pass**, including the new test.

Closes #1247