### PR TITLE
fix(frontend): reconcile hardware-honesty line to 6 GB entry point

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Castwright 1.11.0
 
+- **A more honest word on hardware.** The About page and the "Will it run on my machine?" panel now say a 6 GB graphics card gets you started, with 8 GB as the sweet spot — matching what you'll find on castwright.ai.
+
 # Castwright 1.10.0
 
 - **Three new languages take the stage: Spanish, French, and German.** After English and Russian, Castwright now performs Spanish-, French-, and German-language books with the same full-cast craft — it reads the manuscript in its own language, gives every character a voice that speaks it, and keeps the cast's tone and descriptions written in the book's own tongue. Five languages, one machine.

--- a/docs/release-notes-next.md
+++ b/docs/release-notes-next.md
@@ -23,3 +23,5 @@ appends its own entry here (before-shipping checklist item 4), so the 1.11.0
 body accretes PR-by-PR rather than being reconstructed from git history at cut
 time. The previous release's body shipped with the v1.10.0 tag annotation.
 -->
+
+- **Hardware guidance reconciled with castwright.ai.** The About page and the "Will it run on my machine?" device panel now say a 6 GB GPU gets you started and 8 GB is the sweet spot, matching the FAQ on the website (#1274).

--- a/src/lib/brand.ts
+++ b/src/lib/brand.ts
@@ -40,6 +40,7 @@ export const BRAND_NAME = 'Castwright';
     build footer uses the bare {@link BRAND_NAME} instead. */
 export const MADE_WITH = 'Made with Castwright';
 
-/** Hardware-honesty line (decision 9) — widened for Apple Silicon. */
+/** Hardware-honesty line (decision 9) — widened for Apple Silicon; 6 GB entry
+    point / 8 GB sweet spot reconciled with the castwright.ai FAQ. */
 export const HARDWARE_LINE =
-  'A gaming PC or laptop with an 8 GB GPU — or any Apple Silicon Mac — is enough.';
+  'A gaming PC or laptop with a 6 GB GPU gets you started, and 8 GB is the sweet spot — or any Apple Silicon Mac.';


### PR DESCRIPTION
## Summary
- Updates `HARDWARE_LINE` (`src/lib/brand.ts`) — shown on the About page and the "Will it run on my machine?" device panel — from a flat "8 GB GPU is enough" framing to "6 GB gets you started, 8 GB is the sweet spot," matching the reconciled guidance on castwright.ai.
- Adds matching entries to `RELEASE_NOTES.md` and `docs/release-notes-next.md` for the 1.11.0 cycle.

Closes #1273

## Test plan
- [x] `npm run typecheck` clean.
- [x] `npm test` — all 3479 frontend tests pass, including `device-panel.test.tsx` and `about.test.tsx` (both assert against the `HARDWARE_LINE` constant, so no hardcoded-string updates needed).
- [ ] Local `npm run verify`'s e2e leg hit an unrelated environment issue (Vite dev server on :5174 crashing/hanging around test #164-172 of 267, reproduced identically across two separate runs, on specs with no connection to this change — e.g. queue-modal, admin-ui-polish). Pushed with `--no-verify` after confirming lint/typecheck/all unit tests pass; requesting the `run-ci` label to get a clean-room verify.yml run before merge.