### PR TITLE
docs(docs): add design spec for GitHub wiki user guide

### DIFF
--- a/docs/superpowers/plans/2026-07-04-github-wiki-user-guide.md
+++ b/docs/superpowers/plans/2026-07-04-github-wiki-user-guide.md
@@ -17,8 +17,9 @@
 - File convention: `docs/wiki/images/<page-slug>/NN-caption.png`, numbered in on-page order (spec "Screenshot workflow").
 - Desktop-viewport screenshots by default; add phone/tablet only where the mobile layout genuinely differs (spec "Screenshot workflow").
 - Waves 1–4 are pure `docs/**`/root `*.md` changes and get the **docs-only CI fast-path and code-review exemption**. **Wave 0 ships `scripts/sync-wiki.mjs`, a `chore`/`build`-shaped change** — it does NOT qualify for the exemption and gets a real (`low`-effort) `code-review` pass per CLAUDE.md's model-routing table.
-- One integration branch, `docs/docs-github-wiki`, off `main`. Every task below branches off that integration branch (not off `main` directly) and merges back into it via its own small PR. Rebase onto the latest `docs/docs-github-wiki` before opening each PR.
-- `fe-46` (issue #1262) is landing in parallel and touches pages 7, 11, and 12 — each of those tasks includes an explicit fe-46-status check immediately before screenshot capture (spec "fe-46 interaction").
+- One integration branch, `docs/docs-github-wiki`, off `main`, **pushed to origin** so every task branch can target it as a PR base. Every task below branches off that integration branch (not off `main` directly) and merges back into it via its own small PR. Rebase onto the latest `docs/docs-github-wiki` before opening each PR.
+- **`fe-46` (issue #1262) is a DEFERRED DRAFT, not in-flight work** — plan `docs/features/240-cast-first-landing-and-voice-readiness-gate.md` is `status: draft`, implementation has not started, and it's explicitly deferred until post-v1.10.0 (already cut). This corrects the spec's "landing in parallel" premise. Tasks 4 and 10 (pages 7, 11, 12) do NOT block or wait on it — both capture the current (pre-fe-46) flow now and file a re-shoot follow-up issue, re-checking fe-46's status at capture time in case it has since shipped.
+- **Image-path convention propagation:** the Wave-0 spike (Task 1) records its outcome in a committed file, `docs/wiki/.image-path-convention` (contents: literal string `relative` or `raw-main`). Every content task (2–10) reads this file before writing any image reference and substitutes the path form it specifies — this is a file check, not reliance on a human re-reading this plan's prose, so it holds even when each task is executed by a fresh subagent with no memory of Task 1.
 - Repo currently has `hasWikiEnabled: false` — enabling it is an admin-scoped repo-setting change; flag it to the user before running, per spec.
 
 ---
@@ -30,6 +31,8 @@ docs/wiki/
   Home.md                              — wiki landing page
   _Sidebar.md                          — persistent nav (3 grouped headings)
   _Footer.md                           — persistent footer
+  .image-path-convention               — literal "relative" or "raw-main", written by the Wave-0 spike;
+                                          every content task reads this before writing image references
   Getting-Started.md
   Installing-Castwright.md
   Uploading-a-Book.md
@@ -100,17 +103,20 @@ Page-file → spec-page-number mapping (for cross-reference while reading the sp
 - Create (spike, deleted by end of this task): `docs/wiki/_Spike.md`, `docs/wiki/images/_spike/01-test.png`
 
 **Interfaces:**
-- Produces: `copyWikiTree(srcDir, destDir)` and `buildCommitMessage(sourceSha)` (exported pure functions from `scripts/sync-wiki.mjs`), the `npm run wiki:sync` command, `docs/wiki/_Sidebar.md`'s 3-heading skeleton (Core journey / Cast & Voices / Full breadth) that every later task appends a page link into, and the confirmed image-path convention (relative `images/<slug>/NN-caption.png` OR `raw.githubusercontent.com` fallback — whichever the spike proves) that every content task (2–11) uses verbatim.
+- Produces: `copyWikiTree(srcDir, destDir)` and `buildCommitMessage(sourceSha)` (exported pure functions from `scripts/sync-wiki.mjs`), the `npm run wiki:sync` command, `docs/wiki/_Sidebar.md` pre-populated with all 19 page links across its 3 headings (Core journey / Cast & Voices / Full breadth) — links to pages not yet shipped by a later wave resolve as GitHub's built-in "create this page" prompt, not a broken link, so this is intentional, not a defect to fix incrementally — and `docs/wiki/.image-path-convention`, the committed file every content task (2–10) reads before writing any image reference.
 - Consumes: nothing (first task).
 
-- [ ] **Step 1: Cut the integration branch and this task's branch**
+- [ ] **Step 1: Cut the integration branch, push it, and cut this task's branch**
 
 ```bash
 git switch main
 git pull
 git switch -c docs/docs-github-wiki
+git push -u origin docs/docs-github-wiki
 git switch -c docs/docs-github-wiki-wave0-infra
 ```
+
+Pushing `docs/docs-github-wiki` now is required — every later task's `gh pr create --base docs/docs-github-wiki` and `git pull` on that branch fail if it only exists locally.
 
 - [ ] **Step 2: Write the failing test for `copyWikiTree`**
 
@@ -337,7 +343,9 @@ Create `docs/wiki/_Footer.md`:
 [Castwright](https://castwright.ai) · [GitHub](https://github.com/dudarenok-maker/Castwright) · [Release Notes](https://github.com/dudarenok-maker/Castwright/blob/main/RELEASE_NOTES.md)
 ```
 
-- [ ] **Step 11: First real sync**
+- [ ] **Step 11: First real sync (deliberate exception to the spec's "sync after merge to main" rule)**
+
+The wiki repo doesn't exist yet and the dual-render spike needs a live page to test against — both require syncing before this Wave-0 PR merges. This is a one-time bootstrap exception, not the standing operating rule; every later wave syncs post-merge as the spec specifies.
 
 ```bash
 npm run wiki:sync
@@ -363,13 +371,14 @@ npm run wiki:sync
 
 Load the live spike page in a browser (via claude-in-chrome or manually) and check whether the image renders.
 
-- [ ] **Step 13: Record the spike result**
+- [ ] **Step 13: Record the spike result in the committed convention file**
 
-If the image rendered: relative `images/<slug>/NN-caption.png` paths stand as written in every later task — no action needed.
+Write `docs/wiki/.image-path-convention`:
 
-If it did NOT render: every content task (2–11) below must instead use absolute
-`https://raw.githubusercontent.com/dudarenok-maker/Castwright/main/docs/wiki/images/<slug>/NN-caption.png`
-URLs in place of the relative path. **Stop here and update this plan's Tasks 2–11 image-path instructions accordingly before proceeding** — this is a load-bearing convention for all 21 pages.
+- If the image rendered: file contains the single line `relative`. Every content task's `images/<slug>/NN-caption.png` snippets stand as written.
+- If it did NOT render: file contains the single line `raw-main`. Every content task must substitute `https://raw.githubusercontent.com/dudarenok-maker/Castwright/main/docs/wiki/images/<slug>/NN-caption.png` for every relative path in its snippets.
+
+**Known limitation of the `raw-main` fallback:** those URLs only resolve once the referenced images actually exist on `main` — which, under this plan's branching model, doesn't happen until Task 11 Step 4 merges `docs/docs-github-wiki` into `main`. If `.image-path-convention` says `raw-main`, every content task's "verify the image renders on the live wiki" step (Tasks 2–10) can only confirm the file exists in the source repo and the markdown references it correctly — NOT that it actually renders live — until Task 11 Step 5 does the first real live-wiki check, once everything is on `main`.
 
 - [ ] **Step 14: Delete the spike and re-sync**
 
@@ -382,21 +391,21 @@ npm run wiki:sync
 - [ ] **Step 15: Commit the nav scaffold, open the PR**
 
 ```bash
-git add docs/wiki/Home.md docs/wiki/_Sidebar.md docs/wiki/_Footer.md
-git commit -m "docs(docs): scaffold wiki Home/Sidebar/Footer"
+git add docs/wiki/Home.md docs/wiki/_Sidebar.md docs/wiki/_Footer.md docs/wiki/.image-path-convention
+git commit -m "docs(docs): scaffold wiki Home/Sidebar/Footer + record image-path convention"
 git push -u origin docs/docs-github-wiki-wave0-infra
 gh pr create --base docs/docs-github-wiki --title "chore(scripts): wiki sync script + scaffold (Wave 0)" --body "$(cat <<'EOF'
 ## Summary
 - Adds scripts/sync-wiki.mjs + test, mirroring docs/wiki/* to the GitHub wiki repo.
 - Enables the repo wiki setting and scaffolds Home/_Sidebar/_Footer.
-- Runs the dual-render spike; relative image paths confirmed working (or: falls back to raw.githubusercontent.com — see plan Step 13).
+- Runs the dual-render spike; records the result in docs/wiki/.image-path-convention for every later content task to read.
 
 Refs #1276
 
 ## Test plan
 - [x] node --test scripts/tests/sync-wiki.test.mjs passes
 - [x] npm run wiki:sync pushes and the live wiki shows Home/Sidebar/Footer
-- [x] Spike page confirmed image render behavior; spike deleted before merge
+- [x] Spike page confirmed image render behavior; spike deleted before merge; outcome recorded in .image-path-convention
 EOF
 )"
 ```
@@ -413,7 +422,7 @@ This PR is `chore`/`build`-shaped, NOT docs-only — run the mandatory `low`-eff
 - Modify: `docs/wiki/_Sidebar.md` (no change needed — both links already scaffolded in Task 1)
 
 **Interfaces:**
-- Consumes: image-path convention confirmed in Task 1 Step 13; `_Sidebar.md` skeleton from Task 1.
+- Consumes: `docs/wiki/.image-path-convention` (Task 1) — read before writing any image reference below; `_Sidebar.md` skeleton from Task 1.
 - Produces: nothing further tasks depend on (Wave 1 pages are leaves in the nav graph aside from cross-links).
 
 - [ ] **Step 1: Branch**
@@ -513,7 +522,7 @@ Pure `docs/**` change — docs-only CI fast-path and code-review exemption apply
 - Create: `docs/wiki/Reviewing-Low-Confidence-Speaker-Tags.md`, `docs/wiki/images/reviewing-low-confidence-speaker-tags/*.png`
 
 **Interfaces:**
-- Consumes: image-path convention from Task 1; views `src/views/upload.tsx`, `src/views/manuscript.tsx`, `src/views/restructure.tsx`, `src/views/confirm-metadata.tsx`, `src/views/analysing.tsx`, `src/views/low-confidence-nav.tsx` (all confirmed to exist).
+- Consumes: `docs/wiki/.image-path-convention` (Task 1) — read before writing any image reference below. Views: `src/views/upload.tsx`, `src/views/manuscript.tsx`, `src/views/restructure.tsx`, `src/views/confirm-metadata.tsx`, `src/views/analysing.tsx`. **Correction:** there is no standalone `low-confidence-nav.tsx` view — the low-confidence review UI is embedded inside `src/views/manuscript.tsx` (confirmed via `low-confidence-nav.test.tsx`, which imports `ManuscriptView from './manuscript'`). Drive it as part of the manuscript view, not as a separate route.
 
 - [ ] **Step 1: Branch**
 
@@ -565,6 +574,8 @@ Drive `analysing.tsx` through an analyzer run and capture:
 1. `01-analysing-progress.png` — the in-progress analysis screen.
 2. `02-analyzer-choice.png` — wherever the app exposes the Ollama / Gemini / pipelined two-model choice (settings or a picker on this screen).
 
+If the analysing screen itself has no visible engine-picker UI (the choice may live only in `.env`/settings rather than on this screen), capture the settings location instead and say so in the page text rather than implying a picker that isn't there.
+
 - [ ] **Step 5: Write `docs/wiki/Analysis-and-the-Analyzer.md`**
 
 ```markdown
@@ -587,10 +598,12 @@ Next: [Reviewing Low-Confidence Speaker Tags](Reviewing-Low-Confidence-Speaker-T
 
 - [ ] **Step 6: Capture Reviewing Low-Confidence Speaker Tags screenshots**
 
-Drive `low-confidence-nav.tsx` (find a manuscript with at least one low-confidence tag, or the demo book if it has one) and capture:
+Drive the low-confidence review UI embedded in `src/views/manuscript.tsx` and capture:
 
 1. `01-low-confidence-nav.png` — the low-confidence review navigator.
 2. `02-resolve-tag.png` — resolving one flagged line.
+
+**If the Coalfall demo book has no low-confidence-tagged line to photograph:** do not fabricate one. Use whichever manuscript in the test/demo fixtures does produce one (check `server/src/__fixtures__/`), or if none does, capture the navigator in its "nothing to review" state, say so explicitly in the page text instead of implying a flagged-line screenshot, and file a follow-up issue to add a low-confidence fixture case.
 
 - [ ] **Step 7: Write `docs/wiki/Reviewing-Low-Confidence-Speaker-Tags.md`**
 
@@ -627,7 +640,7 @@ gh pr create --base docs/docs-github-wiki --title "docs(docs): Uploading a Book 
 - Create: `docs/wiki/The-Quality-Gate.md`, `docs/wiki/images/the-quality-gate/*.png`
 
 **Interfaces:**
-- Consumes: `src/views/generation.tsx`; fe-46 (#1262) merge status.
+- Consumes: `docs/wiki/.image-path-convention` (Task 1); `src/views/generation.tsx`; fe-46 (#1262) merge status (deferred draft as of this plan — see Global Constraints).
 
 - [ ] **Step 1: Branch**
 
@@ -640,9 +653,10 @@ git switch -c docs/docs-github-wiki-wave1c-generation-quality
 
 ```bash
 gh pr list --search "1262 in:body" --state all
+gh issue view 1262 --json state,labels
 ```
 
-If fe-46 has merged: capture its pre-flight voice-readiness gate modal as part of the generation-start flow below. If it has NOT merged (the likely case — Wave 1 runs before Wave 3): capture the current generation-start flow as-is and add a note to this page (Step 4 below) plus a follow-up marker; do not block this task on fe-46.
+`fe-46` is a **deferred draft** as of this plan's writing — plan `docs/features/240-cast-first-landing-and-voice-readiness-gate.md` is `status: draft`, implementation hasn't started, and it's explicitly pushed to post-v1.10.0. Re-check at capture time in case that's changed. If it has since merged: capture its pre-flight voice-readiness gate modal as part of the generation-start flow below. If it's still not merged (the expected case): capture the current generation-start flow as-is, note the discrepancy on the page (Step 4 below), and file a re-shoot follow-up issue. Do not block this task waiting on it.
 
 - [ ] **Step 3: Capture Generating Audio screenshots**
 
@@ -681,6 +695,8 @@ Capture whatever the app surfaces for the acoustic check / transcript verificati
 1. `01-quality-gate-flag.png` — a flagged line/chapter.
 2. `02-quality-gate-rerecord.png` — the automatic re-recording in progress or its result.
 
+If the Coalfall demo book generates cleanly with nothing flagged, don't fabricate a failure — capture the gate's "all clear" state for `01`, skip `02`, note in the page that a flagged/re-recorded example wasn't available from the demo book, and file a follow-up issue to capture it from a run that does trigger the gate.
+
 - [ ] **Step 6: Write `docs/wiki/The-Quality-Gate.md`**
 
 ```markdown
@@ -716,7 +732,7 @@ gh pr create --base docs/docs-github-wiki --title "docs(docs): Generating Audio 
 - Create: `docs/wiki/Exporting.md`, `docs/wiki/images/exporting/*.png`
 
 **Interfaces:**
-- Consumes: `src/views/listen.tsx` + `src/components/listen/listen-header.tsx`, `listen-player-region.tsx`, `listen-download-section.tsx`.
+- Consumes: `docs/wiki/.image-path-convention` (Task 1); `src/views/listen.tsx` + `src/components/listen/listen-header.tsx`, `listen-player-region.tsx`, `listen-download-section.tsx`.
 
 - [ ] **Step 1: Branch**
 
@@ -806,7 +822,7 @@ gh pr create --base docs/docs-github-wiki --title "docs(docs): Listening & Revis
 - Create: `docs/wiki/The-Model-Control-Pill.md`, `docs/wiki/images/the-model-control-pill/*.png`
 
 **Interfaces:**
-- Consumes: `src/components/ModelControlPill.tsx`.
+- Consumes: `docs/wiki/.image-path-convention` (Task 1); `src/components/ModelControlPill.tsx`.
 
 - [ ] **Step 1: Branch**
 
@@ -886,7 +902,7 @@ gh pr create --base docs/docs-github-wiki --title "docs(docs): Voice Engines + M
 - Create: `docs/wiki/Mobile-Tablet-and-Companion-App.md`, `docs/wiki/images/mobile-tablet-and-companion-app/*.png`
 
 **Interfaces:**
-- Consumes: the Books/library view; LAN HTTPS pairing flow; Android companion app.
+- Consumes: `docs/wiki/.image-path-convention` (Task 1); the Books/library view; LAN HTTPS pairing flow; Android companion app.
 
 - [ ] **Step 1: Branch**
 
@@ -899,7 +915,7 @@ git switch -c docs/docs-github-wiki-wave2b-library-mobile
 
 1. `01-library-covers.png` — the library grid with covers/tags.
 2. `02-series-grouping.png` — series grouping.
-3. `03-book-bundle.png` — a book bundle, if one exists in the demo data.
+3. `03-book-bundle.png` — a book bundle, if one exists in the demo data. If not, skip this shot, omit the bundle sub-section from the page rather than describing a screenshot that doesn't exist, and file a follow-up issue.
 
 - [ ] **Step 3: Write `docs/wiki/Library-Management.md`**
 
@@ -962,7 +978,7 @@ gh pr create --base docs/docs-github-wiki --title "docs(docs): Library Managemen
 - Create: `docs/wiki/Account-and-Settings.md`, `docs/wiki/images/account-and-settings/*.png`
 
 **Interfaces:**
-- Consumes: `src/views/admin.tsx`, `src/views/model-manager.tsx`, `src/views/advanced.tsx`, `src/views/account.tsx`.
+- Consumes: `docs/wiki/.image-path-convention` (Task 1); `src/views/admin.tsx`, `src/views/model-manager.tsx`, `src/views/advanced.tsx`, `src/views/account.tsx`.
 
 - [ ] **Step 1: Branch**
 
@@ -1023,7 +1039,7 @@ gh pr create --base docs/docs-github-wiki --title "docs(docs): Admin/Model Manag
 - Create: `docs/wiki/Troubleshooting.md`, `docs/wiki/images/troubleshooting/*.png`
 
 **Interfaces:**
-- Consumes: `INSTALL.md`'s Troubleshooting section; `src/views/help.tsx`.
+- Consumes: `docs/wiki/.image-path-convention` (Task 1); `INSTALL.md`'s Troubleshooting section; `src/views/help.tsx`.
 
 - [ ] **Step 1: Branch**
 
@@ -1069,15 +1085,16 @@ gh pr create --base docs/docs-github-wiki --title "docs(docs): Multi-language Su
 - Create: `docs/wiki/Designing-a-Voice.md`, `docs/wiki/images/designing-a-voice/*.png`
 
 **Interfaces:**
-- Consumes: `src/views/cast.tsx`, `src/views/voices.tsx`, `src/views/confirm-cast.tsx`; fe-46 (#1262) merge status (this task is sequenced LAST specifically to wait on it).
+- Consumes: `docs/wiki/.image-path-convention` (Task 1); `src/views/cast.tsx`, `src/views/voices.tsx`, `src/views/confirm-cast.tsx`; fe-46 (#1262) status.
 
-- [ ] **Step 1: Check fe-46 merge status — this is why this task runs last**
+- [ ] **Step 1: Check fe-46 status — sequenced last to give it the best chance of having landed, but does not block on it**
 
 ```bash
 gh pr list --search "1262 in:body" --state all
+gh issue view 1262 --json state,labels
 ```
 
-If fe-46 has NOT merged yet, wait for it before starting this task (per spec — do not capture pages 11–12 against the pre-fe-46 flow).
+`fe-46` is a **deferred draft** as of this plan's writing (not "in progress in parallel" as the spec assumed) — implementation hasn't started and it's explicitly pushed to post-v1.10.0. This task runs last specifically to give it the best chance of having shipped by then, but **does not block indefinitely waiting for it** — the guide's Cast & Voices pages are too central to leave unshipped over an external, un-dated dependency. If it has merged: capture the post-fe-46 confirmCast → Cast → Manuscript → Generate flow and the readiness-gate modal. If it's still not merged (the expected case): capture the current pre-fe-46 flow, note the discrepancy on both pages, and file a re-shoot follow-up issue — the same treatment Task 4 applies to page 7.
 
 - [ ] **Step 2: Branch**
 
@@ -1162,7 +1179,7 @@ gh pr create --base docs/docs-github-wiki --title "docs(docs): Cast Review + Voi
 - `INSTALL.md` — **unchanged**, per Global Constraints
 
 **Interfaces:**
-- Consumes: every page from Tasks 1–10 (links to them); the confirmed final wiki sidebar structure.
+- Consumes: every page from Tasks 1–10 (links to them); `docs/wiki/.image-path-convention` (determines whether Step 5's live-render check is load-bearing); the confirmed final wiki sidebar structure.
 
 - [ ] **Step 1: Branch**
 
@@ -1196,17 +1213,25 @@ Confirm `README.md` still renders sensibly top to bottom and every link resolves
 git add README.md
 git commit -m "docs(docs): shrink README to a pitch + wiki/INSTALL links (Wave 4)"
 git push -u origin docs/docs-github-wiki-wave4-readme-migration
-gh pr create --base docs/docs-github-wiki --title "docs(docs): shrink README to pitch + links (Wave 4)" --body "Closes #1276"
+gh pr create --base docs/docs-github-wiki --title "docs(docs): shrink README to pitch + links (Wave 4)" --body "Refs #1276"
 ```
+
+`Refs`, not `Closes` — this PR targets the integration branch, not `main`, and GitHub only auto-closes an issue on a merge into the repo's default branch. Only the Step 4 PR below can close #1276.
 
 - [ ] **Step 4: After all wave PRs are merged into `docs/docs-github-wiki`, open the final integration PR into `main`**
 
 ```bash
 git switch docs/docs-github-wiki && git pull
-gh pr create --base main --title "docs(docs): GitHub wiki user guide (all waves)" --body "Closes #1276, closes #1277"
+gh pr create --base main --title "docs(docs): GitHub wiki user guide (all waves)" --body "Closes #1276"
 ```
 
+This PR's diff includes Wave 0's `scripts/sync-wiki.mjs`/`package.json` change, so by the doc-only file-set test it is technically not a pure-docs PR — but that diff already went through its own mandatory `low`-effort `code-review` pass in Task 1's PR. Don't re-run a full review here; just diff this PR against Task 1's already-reviewed PR to confirm no new non-docs changes crept in during integration, and merge via "Create a merge commit" per the repo's PR convention.
+
 Run `npm run wiki:sync` one final time after this merges to `main`, to publish the final README-linked state.
+
+- [ ] **Step 5: First real live-wiki verification (critical if `.image-path-convention` says `raw-main`)**
+
+Everything is now on `main` for the first time, which is the first point `raw-main`-fallback image URLs can actually resolve. Load every one of the 21 live wiki pages in a browser and confirm every image renders and every internal link resolves. File a follow-up issue for any page that fails this check — under the `raw-main` fallback, this step is the only point in the whole plan that catches a broken image before users see it.
 
 ---
 
@@ -1215,3 +1240,15 @@ Run `npm run wiki:sync` one final time after this merges to `main`, to publish t
 - **Spec coverage:** Every spec section maps to a task — Architecture/authoring model → Task 1; Wave 0 spike → Task 1 Steps 12–14; all 21 pages → Tasks 2–10; fe-46 interaction (pages 7, 11, 12) → Tasks 4 and 10; INSTALL.md relationship → Tasks 2 and 11; delivery waves → Tasks 1–11 branch/PR structure; testing/verification → each task's manual-verify step + Task 1's real unit test.
 - **Correction from spec draft:** the spec's Testing/verification section says `scripts/sync-wiki.mjs` "follows the existing convention of testing `scripts/lib/` helpers" (implying Vitest); the actual convention for `.mjs` scripts under `scripts/tests/*.test.mjs` is **`node:test`**, auto-discovered by `npm run test:hooks` (see `scripts/run-hooks-tests.mjs`), not Vitest. Task 1 uses `node:test` — this is what the repo actually does, confirmed against `scripts/tests/build-companion-apk.test.mjs`.
 - **Type/interface consistency:** `copyWikiTree(srcDir, destDir)` and `buildCommitMessage(sourceSha)` are the only two exported functions from `scripts/sync-wiki.mjs`, used identically in both the test (Task 1 Step 2) and no other task references them directly.
+
+### Assumption-checker pass (Opus 4.8) — findings and fixes applied
+
+A mandatory `assumption-checker` pass (CLAUDE.md review gate) found five load-bearing problems, all fixed in this revision:
+
+1. **Image-path convention never reached subagent-executed tasks.** Fixed by writing the spike's outcome to a committed file, `docs/wiki/.image-path-convention`, that every content task (2–10) now explicitly reads before writing image references — a mechanical check instead of relying on shared plan prose surviving across fresh subagent dispatches.
+2. **fe-46 (#1262) is a deferred draft, not "in progress in parallel" as the spec assumed** — confirmed against `docs/features/240-...md` (`status: draft`) and the absence of `src/modals/voice-readiness-gate.tsx` in the tree. Task 10's original "wait for it before starting" would have blocked Wave 3 indefinitely; both Task 4 and Task 10 now capture the current pre-fe-46 flow and file a re-shoot follow-up instead of blocking.
+3. **The integration branch `docs/docs-github-wiki` was never pushed to origin**, which would have broken the very first `gh pr create --base docs/docs-github-wiki` and every task's `git pull`. Fixed in Task 1 Step 1.
+4. **`low-confidence-nav.tsx` doesn't exist as a standalone view** — the low-confidence review UI is embedded in `src/views/manuscript.tsx`. Fixed in Task 3.
+5. **Several screenshot targets assumed unconfirmed demo-book states** (a low-confidence tag, a QA-gate failure, a book bundle, an analyzer-choice picker on the analysing screen). Each now has an explicit non-fabrication fallback: capture the nearest real state, say so on the page, file a follow-up — never invent a mocked state.
+
+Also fixed: `Closes #1276`/`#1277` misuse on non-`main`-base PRs (only the true final `main`-base PR in Task 11 Step 4 can auto-close); the `_Sidebar.md` "appended incrementally" description corrected to match Step 10's actual up-front population (intentional — dead links resolve to GitHub's own "create this page" prompt); the `raw-main` fallback's inherent limitation (URLs can't resolve until Task 11 merges to `main`) is now called out, with a new Task 11 Step 5 doing the first real live-wiki render check once everything is finally on `main`; and the final integration→main PR's review responsibility is now explicit (reuse Wave 0's already-completed code-review via a diff-against-Task-1 sanity check, not a second full pass).

--- a/docs/superpowers/plans/2026-07-04-github-wiki-user-guide.md
+++ b/docs/superpowers/plans/2026-07-04-github-wiki-user-guide.md
@@ -1,0 +1,1217 @@
+# GitHub Wiki User Guide Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a 21-page, screenshot-illustrated GitHub wiki for Castwright, authored in this repo under normal PR review and mirrored to the GitHub wiki repo by a new sync script — giving users a task-oriented "how to actually use this" guide that `README.md`/`INSTALL.md` don't provide today.
+
+**Architecture:** Wiki content lives at `docs/wiki/*.md` + `docs/wiki/images/<slug>/NN-caption.png` in this repo (reviewable via normal PR). `scripts/sync-wiki.mjs` mirrors that directory into the separate `Castwright.wiki.git` repo (clone-or-bootstrap, copy, commit, push), run manually post-merge via `npm run wiki:sync`. Screenshots are captured from the real running app (`npm start`, no mocks) via Chrome browser automation, using the committed Coalfall Commission demo book as the consistent content source.
+
+**Tech Stack:** Plain ESM `.mjs` script (`node:fs`/`node:child_process`, matches `scripts/render-brand-pngs.mjs` conventions) + `node:test` for its unit test (matches `scripts/tests/build-companion-apk.test.mjs`, auto-discovered by `npm run test:hooks` via `scripts/tests/*.test.mjs` glob — no Vitest, no manual test-runner wiring needed). Markdown content, no build tooling. Chrome browser automation (`mcp__claude-in-chrome__*`) for screenshot capture.
+
+## Global Constraints
+
+- Documentation-only content; **no changes to `src/`, `server/`, or the sidecar** (spec Non-goals).
+- English only for v1 — no wiki i18n (spec Non-goals / Open questions).
+- **`INSTALL.md` stays fully intact, unchanged** — the wiki's "Installing Castwright" page is a parallel duplicate, not a migration (spec "INSTALL.md relationship").
+- Every screenshot is captured against the **real running app** (`npm start`, real analyzer/sidecar, no mocks), using **The Coalfall Commission** demo book as the content source — never fabricated/mocked UI states (spec "Screenshot workflow").
+- File convention: `docs/wiki/images/<page-slug>/NN-caption.png`, numbered in on-page order (spec "Screenshot workflow").
+- Desktop-viewport screenshots by default; add phone/tablet only where the mobile layout genuinely differs (spec "Screenshot workflow").
+- Waves 1–4 are pure `docs/**`/root `*.md` changes and get the **docs-only CI fast-path and code-review exemption**. **Wave 0 ships `scripts/sync-wiki.mjs`, a `chore`/`build`-shaped change** — it does NOT qualify for the exemption and gets a real (`low`-effort) `code-review` pass per CLAUDE.md's model-routing table.
+- One integration branch, `docs/docs-github-wiki`, off `main`. Every task below branches off that integration branch (not off `main` directly) and merges back into it via its own small PR. Rebase onto the latest `docs/docs-github-wiki` before opening each PR.
+- `fe-46` (issue #1262) is landing in parallel and touches pages 7, 11, and 12 — each of those tasks includes an explicit fe-46-status check immediately before screenshot capture (spec "fe-46 interaction").
+- Repo currently has `hasWikiEnabled: false` — enabling it is an admin-scoped repo-setting change; flag it to the user before running, per spec.
+
+---
+
+## File Structure
+
+```
+docs/wiki/
+  Home.md                              — wiki landing page
+  _Sidebar.md                          — persistent nav (3 grouped headings)
+  _Footer.md                           — persistent footer
+  Getting-Started.md
+  Installing-Castwright.md
+  Uploading-a-Book.md
+  Analysis-and-the-Analyzer.md
+  Reviewing-Low-Confidence-Speaker-Tags.md
+  Generating-Audio.md
+  The-Quality-Gate.md
+  Listening-and-Revising.md
+  Exporting.md
+  Reviewing-Cast-and-Assigning-Voices.md
+  Designing-a-Voice.md
+  Voice-Engines.md
+  The-Model-Control-Pill.md
+  Library-Management.md
+  Mobile-Tablet-and-Companion-App.md
+  Admin-and-Model-Manager.md
+  Advanced-Settings.md
+  Account-and-Settings.md
+  Multi-language-Support.md
+  Troubleshooting.md
+  images/
+    getting-started/NN-caption.png
+    installing-castwright/NN-caption.png
+    uploading-a-book/NN-caption.png
+    analysis-and-the-analyzer/NN-caption.png
+    reviewing-low-confidence-speaker-tags/NN-caption.png
+    generating-audio/NN-caption.png
+    the-quality-gate/NN-caption.png
+    listening-and-revising/NN-caption.png
+    exporting/NN-caption.png
+    reviewing-cast-and-assigning-voices/NN-caption.png
+    designing-a-voice/NN-caption.png
+    voice-engines/NN-caption.png
+    the-model-control-pill/NN-caption.png
+    library-management/NN-caption.png
+    mobile-tablet-and-companion-app/NN-caption.png
+    admin-and-model-manager/NN-caption.png
+    advanced-settings/NN-caption.png
+    account-and-settings/NN-caption.png
+    multi-language-support/NN-caption.png
+    troubleshooting/NN-caption.png
+
+scripts/sync-wiki.mjs                  — mirrors docs/wiki/* to Castwright.wiki.git
+scripts/tests/sync-wiki.test.mjs       — node:test coverage for its pure copy/commit-message logic
+package.json                           — + "wiki:sync" script entry
+
+README.md                              — shrunk to pitch + links (Wave 4)
+INSTALL.md                             — UNCHANGED (duplicated into wiki page 3, not migrated)
+```
+
+Page-file → spec-page-number mapping (for cross-reference while reading the spec):
+2=Getting-Started, 3=Installing-Castwright, 4=Uploading-a-Book, 5=Analysis-and-the-Analyzer,
+6=Reviewing-Low-Confidence-Speaker-Tags, 7=Generating-Audio, 8=The-Quality-Gate,
+9=Listening-and-Revising, 10=Exporting, 11=Reviewing-Cast-and-Assigning-Voices,
+12=Designing-a-Voice, 13=Voice-Engines, 14=The-Model-Control-Pill, 15=Library-Management,
+16=Mobile-Tablet-and-Companion-App, 17=Admin-and-Model-Manager, 18=Advanced-Settings,
+19=Account-and-Settings, 20=Multi-language-Support, 21=Troubleshooting. Page 1 = Home.
+
+---
+
+## Task 1: Wave 0 — scaffold, sync script, wiki enablement, dual-render spike
+
+**Files:**
+- Create: `scripts/sync-wiki.mjs`
+- Create: `scripts/tests/sync-wiki.test.mjs`
+- Modify: `package.json` (add `wiki:sync` script)
+- Create: `docs/wiki/Home.md`, `docs/wiki/_Sidebar.md`, `docs/wiki/_Footer.md`
+- Create (spike, deleted by end of this task): `docs/wiki/_Spike.md`, `docs/wiki/images/_spike/01-test.png`
+
+**Interfaces:**
+- Produces: `copyWikiTree(srcDir, destDir)` and `buildCommitMessage(sourceSha)` (exported pure functions from `scripts/sync-wiki.mjs`), the `npm run wiki:sync` command, `docs/wiki/_Sidebar.md`'s 3-heading skeleton (Core journey / Cast & Voices / Full breadth) that every later task appends a page link into, and the confirmed image-path convention (relative `images/<slug>/NN-caption.png` OR `raw.githubusercontent.com` fallback — whichever the spike proves) that every content task (2–11) uses verbatim.
+- Consumes: nothing (first task).
+
+- [ ] **Step 1: Cut the integration branch and this task's branch**
+
+```bash
+git switch main
+git pull
+git switch -c docs/docs-github-wiki
+git switch -c docs/docs-github-wiki-wave0-infra
+```
+
+- [ ] **Step 2: Write the failing test for `copyWikiTree`**
+
+Create `scripts/tests/sync-wiki.test.mjs`:
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { copyWikiTree, buildCommitMessage } from '../sync-wiki.mjs';
+
+test('copyWikiTree copies markdown and images, excluding .git', () => {
+  const src = mkdtempSync(path.join(tmpdir(), 'wiki-src-'));
+  const dest = mkdtempSync(path.join(tmpdir(), 'wiki-dest-'));
+  try {
+    writeFileSync(path.join(src, 'Home.md'), '# Home');
+    mkdirSync(path.join(src, 'images', 'home'), { recursive: true });
+    writeFileSync(path.join(src, 'images', 'home', '01-test.png'), 'fake-png');
+    mkdirSync(path.join(src, '.git'), { recursive: true });
+    writeFileSync(path.join(src, '.git', 'HEAD'), 'ref: refs/heads/master');
+
+    copyWikiTree(src, dest);
+
+    assert.equal(readFileSync(path.join(dest, 'Home.md'), 'utf8'), '# Home');
+    assert.equal(
+      readFileSync(path.join(dest, 'images', 'home', '01-test.png'), 'utf8'),
+      'fake-png',
+    );
+    assert.equal(existsSync(path.join(dest, '.git')), false);
+  } finally {
+    rmSync(src, { recursive: true, force: true });
+    rmSync(dest, { recursive: true, force: true });
+  }
+});
+
+test('copyWikiTree throws when the source directory is missing', () => {
+  const dest = mkdtempSync(path.join(tmpdir(), 'wiki-dest-'));
+  try {
+    assert.throws(
+      () => copyWikiTree(path.join(dest, 'does-not-exist'), dest),
+      /source directory not found/,
+    );
+  } finally {
+    rmSync(dest, { recursive: true, force: true });
+  }
+});
+
+test('buildCommitMessage embeds the short source SHA', () => {
+  assert.equal(buildCommitMessage('abc1234'), 'sync wiki from Castwright@abc1234');
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `node --test scripts/tests/sync-wiki.test.mjs`
+Expected: FAIL — `Cannot find module '../sync-wiki.mjs'`
+
+- [ ] **Step 4: Implement `scripts/sync-wiki.mjs`**
+
+```js
+// Mirrors docs/wiki/* into the separate Castwright.wiki.git repo. GitHub
+// wikis have no PR review/CI/branch protection, so the source of truth
+// lives here and this script is the one-way publish step.
+//
+//   npm run wiki:sync
+//
+// Run manually after a merge to main touches docs/wiki/**.
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, cpSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const WIKI_REMOTE = 'https://github.com/dudarenok-maker/Castwright.wiki.git';
+
+export function copyWikiTree(srcDir, destDir) {
+  if (!existsSync(srcDir)) {
+    throw new Error(`sync-wiki: source directory not found: ${srcDir}`);
+  }
+  cpSync(srcDir, destDir, {
+    recursive: true,
+    filter: (source) => path.basename(source) !== '.git',
+  });
+}
+
+export function buildCommitMessage(sourceSha) {
+  return `sync wiki from Castwright@${sourceSha}`;
+}
+
+function run(cmd, args, cwd) {
+  const result = spawnSync(cmd, args, { cwd, encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(`sync-wiki: ${cmd} ${args.join(' ')} failed: ${result.stderr}`);
+  }
+  return result.stdout;
+}
+
+function getSourceSha() {
+  return run('git', ['rev-parse', '--short', 'HEAD'], REPO_ROOT).trim();
+}
+
+// A GitHub wiki's git repo does not exist until at least one page exists —
+// enabling has_wiki alone doesn't create it, so clone fails on a
+// never-touched wiki and we bootstrap it instead.
+function cloneOrInitWikiRepo(cacheDir) {
+  rmSync(cacheDir, { recursive: true, force: true });
+  const clone = spawnSync('git', ['clone', WIKI_REMOTE, cacheDir], { encoding: 'utf8' });
+  if (clone.status === 0) return { fresh: false };
+
+  mkdirSync(cacheDir, { recursive: true });
+  run('git', ['init'], cacheDir);
+  run('git', ['remote', 'add', 'origin', WIKI_REMOTE], cacheDir);
+  return { fresh: true };
+}
+
+async function main() {
+  const cacheDir = path.join(REPO_ROOT, '.wiki-sync-cache');
+  const srcDir = path.join(REPO_ROOT, 'docs', 'wiki');
+
+  const { fresh } = cloneOrInitWikiRepo(cacheDir);
+  copyWikiTree(srcDir, cacheDir);
+
+  run('git', ['add', '-A'], cacheDir);
+  const sha = getSourceSha();
+  run('git', ['commit', '-m', buildCommitMessage(sha), '--allow-empty'], cacheDir);
+  run('git', fresh ? ['push', '-u', 'origin', 'HEAD:master'] : ['push'], cacheDir);
+
+  process.stdout.write(`sync-wiki: pushed docs/wiki -> ${WIKI_REMOTE}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    process.stderr.write(`${err.message}\n`);
+    process.exit(1);
+  });
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `node --test scripts/tests/sync-wiki.test.mjs`
+Expected: PASS (3 tests)
+
+- [ ] **Step 6: Confirm `npm run test:hooks` auto-discovers the new test**
+
+Run: `npm run test:hooks`
+Expected: includes `scripts/tests/sync-wiki.test.mjs` in its glob output (it globs `scripts/tests/*.test.mjs` in `scripts/run-hooks-tests.mjs` — no wiring needed beyond the file existing at that path) and PASSes.
+
+- [ ] **Step 7: Add the `wiki:sync` npm script**
+
+In `package.json`, add alongside the other `scripts` entries (near `apk:companion`):
+
+```json
+    "wiki:sync": "node scripts/sync-wiki.mjs",
+```
+
+- [ ] **Step 8: Commit the script + test + package.json change**
+
+```bash
+git add scripts/sync-wiki.mjs scripts/tests/sync-wiki.test.mjs package.json
+git commit -m "chore(scripts): add sync-wiki.mjs to mirror docs/wiki into the GitHub wiki repo"
+```
+
+- [ ] **Step 9: Flag and enable the wiki repo setting (admin action)**
+
+Tell the user explicitly before running (repo-visibility-adjacent setting change per Global Constraints):
+
+```bash
+gh api -X PATCH repos/dudarenok-maker/Castwright -f has_wiki=true
+```
+
+- [ ] **Step 10: Scaffold the empty wiki nav pages**
+
+Create `docs/wiki/Home.md`:
+
+```markdown
+# Castwright
+
+Any book, performed by a full cast — effortlessly.
+
+This wiki is the user guide: install, upload a book, cast it, generate
+audio, listen, export. See the sidebar for every page.
+
+- Release notes: see [RELEASE_NOTES.md](https://github.com/dudarenok-maker/Castwright/blob/main/RELEASE_NOTES.md)
+```
+
+Create `docs/wiki/_Sidebar.md`:
+
+```markdown
+### Core journey
+- [Home](Home)
+- [Getting Started](Getting-Started)
+- [Installing Castwright](Installing-Castwright)
+- [Uploading a Book](Uploading-a-Book)
+- [Analysis & the Analyzer](Analysis-and-the-Analyzer)
+- [Reviewing Low-Confidence Speaker Tags](Reviewing-Low-Confidence-Speaker-Tags)
+- [Generating Audio](Generating-Audio)
+- [The Quality Gate](The-Quality-Gate)
+- [Listening & Revising](Listening-and-Revising)
+- [Exporting](Exporting)
+
+### Cast & Voices
+- [Reviewing Cast & Assigning Voices](Reviewing-Cast-and-Assigning-Voices)
+- [Designing a Voice](Designing-a-Voice)
+
+### Full breadth
+- [Voice Engines](Voice-Engines)
+- [The Model Control Pill](The-Model-Control-Pill)
+- [Library Management](Library-Management)
+- [Mobile, Tablet & Companion App](Mobile-Tablet-and-Companion-App)
+- [Admin & Model Manager](Admin-and-Model-Manager)
+- [Advanced Settings](Advanced-Settings)
+- [Account & Settings](Account-and-Settings)
+- [Multi-language Support](Multi-language-Support)
+- [Troubleshooting](Troubleshooting)
+```
+
+Create `docs/wiki/_Footer.md`:
+
+```markdown
+---
+[Castwright](https://castwright.ai) · [GitHub](https://github.com/dudarenok-maker/Castwright) · [Release Notes](https://github.com/dudarenok-maker/Castwright/blob/main/RELEASE_NOTES.md)
+```
+
+- [ ] **Step 11: First real sync**
+
+```bash
+npm run wiki:sync
+```
+
+Expected: `sync-wiki: pushed docs/wiki -> https://github.com/dudarenok-maker/Castwright.wiki.git`. Confirm the wiki now shows Home/sidebar/footer at `https://github.com/dudarenok-maker/Castwright/wiki`.
+
+- [ ] **Step 12: Run the dual-render spike**
+
+Create `docs/wiki/_Spike.md`:
+
+```markdown
+# Spike (throwaway — delete before Wave 1)
+
+![test](images/_spike/01-test.png)
+```
+
+Drop any small PNG at `docs/wiki/images/_spike/01-test.png`, then:
+
+```bash
+npm run wiki:sync
+```
+
+Load the live spike page in a browser (via claude-in-chrome or manually) and check whether the image renders.
+
+- [ ] **Step 13: Record the spike result**
+
+If the image rendered: relative `images/<slug>/NN-caption.png` paths stand as written in every later task — no action needed.
+
+If it did NOT render: every content task (2–11) below must instead use absolute
+`https://raw.githubusercontent.com/dudarenok-maker/Castwright/main/docs/wiki/images/<slug>/NN-caption.png`
+URLs in place of the relative path. **Stop here and update this plan's Tasks 2–11 image-path instructions accordingly before proceeding** — this is a load-bearing convention for all 21 pages.
+
+- [ ] **Step 14: Delete the spike and re-sync**
+
+```bash
+rm docs/wiki/_Spike.md
+rm -rf docs/wiki/images/_spike
+npm run wiki:sync
+```
+
+- [ ] **Step 15: Commit the nav scaffold, open the PR**
+
+```bash
+git add docs/wiki/Home.md docs/wiki/_Sidebar.md docs/wiki/_Footer.md
+git commit -m "docs(docs): scaffold wiki Home/Sidebar/Footer"
+git push -u origin docs/docs-github-wiki-wave0-infra
+gh pr create --base docs/docs-github-wiki --title "chore(scripts): wiki sync script + scaffold (Wave 0)" --body "$(cat <<'EOF'
+## Summary
+- Adds scripts/sync-wiki.mjs + test, mirroring docs/wiki/* to the GitHub wiki repo.
+- Enables the repo wiki setting and scaffolds Home/_Sidebar/_Footer.
+- Runs the dual-render spike; relative image paths confirmed working (or: falls back to raw.githubusercontent.com — see plan Step 13).
+
+Refs #1276
+
+## Test plan
+- [x] node --test scripts/tests/sync-wiki.test.mjs passes
+- [x] npm run wiki:sync pushes and the live wiki shows Home/Sidebar/Footer
+- [x] Spike page confirmed image render behavior; spike deleted before merge
+EOF
+)"
+```
+
+This PR is `chore`/`build`-shaped, NOT docs-only — run the mandatory `low`-effort `code-review` pass on it before merge (Global Constraints).
+
+---
+
+## Task 2: Wave 1a — Getting Started + Installing Castwright
+
+**Files:**
+- Create: `docs/wiki/Getting-Started.md`, `docs/wiki/images/getting-started/*.png`
+- Create: `docs/wiki/Installing-Castwright.md`, `docs/wiki/images/installing-castwright/*.png`
+- Modify: `docs/wiki/_Sidebar.md` (no change needed — both links already scaffolded in Task 1)
+
+**Interfaces:**
+- Consumes: image-path convention confirmed in Task 1 Step 13; `_Sidebar.md` skeleton from Task 1.
+- Produces: nothing further tasks depend on (Wave 1 pages are leaves in the nav graph aside from cross-links).
+
+- [ ] **Step 1: Branch**
+
+```bash
+git switch docs/docs-github-wiki
+git pull
+git switch -c docs/docs-github-wiki-wave1a-getting-started
+```
+
+- [ ] **Step 2: Capture Getting Started screenshots**
+
+Run `npm start` (real app, no mocks). Drive the app via Chrome browser automation and capture, in this order:
+
+1. `01-books-view.png` — the initial Books/library view on first launch (empty or with the demo book tile).
+2. `02-try-sample-book.png` — the "try a sample book" demo entry point.
+3. `03-quickstart-flow.png` — the app mid-upload-to-generate flow (whichever single screen best represents "you're now in the pipeline").
+
+- [ ] **Step 3: Write `docs/wiki/Getting-Started.md`**
+
+```markdown
+# Getting Started
+
+A condensed quickstart. For full per-OS install steps, see
+[Installing Castwright](Installing-Castwright).
+
+## 1. Install and launch
+
+Follow [Installing Castwright](Installing-Castwright), then run the app.
+
+![Books view](images/getting-started/01-books-view.png)
+
+## 2. Try the built-in sample book
+
+Castwright ships with a demo book — *The Coalfall Commission* — so you can
+see the full pipeline without uploading anything of your own.
+
+![Try a sample book](images/getting-started/02-try-sample-book.png)
+
+## 3. Upload → Analyze → Cast → Generate → Listen
+
+That's the whole pipeline. Each stage gets its own wiki page — see the
+sidebar's "Core journey" section for [Uploading a Book](Uploading-a-Book)
+onward.
+
+![Mid-pipeline](images/getting-started/03-quickstart-flow.png)
+```
+
+- [ ] **Step 4: Capture Installing Castwright screenshots**
+
+Continue driving the app / OS file browser and capture:
+
+1. `01-prerequisites.png` — whatever prerequisite check/screen the app or installer shows (or a terminal screenshot of the prerequisite command if there's no UI screen).
+2. `02-install-windows.png` — the Windows install/launch step.
+3. `03-configuration.png` — the settings/config screen relevant to first-run configuration.
+
+- [ ] **Step 5: Write `docs/wiki/Installing-Castwright.md`**
+
+Duplicate (not link) `INSTALL.md`'s content, illustrated. Mirror `INSTALL.md`'s existing heading structure so nothing is missed: Prerequisites, Install — Pinokio, Install — Windows/macOS/Linux, Try the demo book, Troubleshooting (short version; full version stays on the [Troubleshooting](Troubleshooting) wiki page), Configuration, Setting up the analyzer, Voice engines: standard vs optional, Installing Qwen3-TTS weights, Adding Coqui XTTS v2, Using Gemini for TTS, Picking a chapter audio format, Mobile + tablet access over LAN HTTPS, Android companion app, Updating. Under each heading, copy `INSTALL.md`'s prose and add the relevant screenshot(s) captured in Step 4 where a screenshot exists for that step; headings with no corresponding screenshot (e.g. "Updating") keep prose-only, copied verbatim from `INSTALL.md`.
+
+Start the file:
+
+```markdown
+# Installing Castwright
+
+This page duplicates [INSTALL.md](https://github.com/dudarenok-maker/Castwright/blob/main/INSTALL.md)
+with screenshots. INSTALL.md remains the authoritative offline reference
+shipped inside the release zip — if the two ever disagree, INSTALL.md wins.
+
+## Prerequisites
+
+![Prerequisites](images/installing-castwright/01-prerequisites.png)
+
+...
+```
+
+- [ ] **Step 6: Verify and commit**
+
+Manually confirm: both pages read cleanly top to bottom, every `![...]` image path matches a file that exists under `docs/wiki/images/`, and `Getting-Started.md`'s links to `Installing-Castwright` and vice versa resolve (same-repo wiki links use the bare page name, no `.md`).
+
+```bash
+git add docs/wiki/Getting-Started.md docs/wiki/Installing-Castwright.md docs/wiki/images/getting-started docs/wiki/images/installing-castwright
+git commit -m "docs(docs): add Getting Started + Installing Castwright wiki pages"
+git push -u origin docs/docs-github-wiki-wave1a-getting-started
+gh pr create --base docs/docs-github-wiki --title "docs(docs): Getting Started + Installing Castwright wiki pages" --body "Refs #1276"
+```
+
+Pure `docs/**` change — docs-only CI fast-path and code-review exemption apply (Global Constraints).
+
+---
+
+## Task 3: Wave 1b — Uploading a Book + Analysis & the Analyzer + Reviewing Low-Confidence Speaker Tags
+
+**Files:**
+- Create: `docs/wiki/Uploading-a-Book.md`, `docs/wiki/images/uploading-a-book/*.png`
+- Create: `docs/wiki/Analysis-and-the-Analyzer.md`, `docs/wiki/images/analysis-and-the-analyzer/*.png`
+- Create: `docs/wiki/Reviewing-Low-Confidence-Speaker-Tags.md`, `docs/wiki/images/reviewing-low-confidence-speaker-tags/*.png`
+
+**Interfaces:**
+- Consumes: image-path convention from Task 1; views `src/views/upload.tsx`, `src/views/manuscript.tsx`, `src/views/restructure.tsx`, `src/views/confirm-metadata.tsx`, `src/views/analysing.tsx`, `src/views/low-confidence-nav.tsx` (all confirmed to exist).
+
+- [ ] **Step 1: Branch**
+
+```bash
+git switch docs/docs-github-wiki && git pull
+git switch -c docs/docs-github-wiki-wave1b-upload-analyze-review
+```
+
+- [ ] **Step 2: Capture Uploading a Book screenshots**
+
+Using the demo book (or a fresh upload of it) drive `upload.tsx` → `manuscript.tsx` → `restructure.tsx` → `confirm-metadata.tsx` and capture:
+
+1. `01-upload.png` — the upload view (drag-drop / file picker state).
+2. `02-manuscript-paragraphs.png` — the manuscript paragraph-boundary editing view.
+3. `03-restructure.png` — the chapter restructure view.
+4. `04-confirm-metadata.png` — the confirm-metadata step (title/author/cover confirmation).
+
+- [ ] **Step 3: Write `docs/wiki/Uploading-a-Book.md`**
+
+```markdown
+# Uploading a Book
+
+## 1. Upload your manuscript
+
+![Upload](images/uploading-a-book/01-upload.png)
+
+## 2. Review paragraph boundaries
+
+Castwright shows the manuscript broken into paragraphs; adjust boundaries
+where the automatic split got it wrong (drag on desktop, tap on touch).
+
+![Manuscript paragraphs](images/uploading-a-book/02-manuscript-paragraphs.png)
+
+## 3. Restructure into chapters
+
+![Restructure](images/uploading-a-book/03-restructure.png)
+
+## 4. Confirm title, author, and cover
+
+![Confirm metadata](images/uploading-a-book/04-confirm-metadata.png)
+
+Next: [Analysis & the Analyzer](Analysis-and-the-Analyzer).
+```
+
+- [ ] **Step 4: Capture Analysis & the Analyzer screenshots**
+
+Drive `analysing.tsx` through an analyzer run and capture:
+
+1. `01-analysing-progress.png` — the in-progress analysis screen.
+2. `02-analyzer-choice.png` — wherever the app exposes the Ollama / Gemini / pipelined two-model choice (settings or a picker on this screen).
+
+- [ ] **Step 5: Write `docs/wiki/Analysis-and-the-Analyzer.md`**
+
+```markdown
+# Analysis & the Analyzer
+
+Castwright reads your manuscript and tags who's speaking each line.
+
+![Analysing](images/analysis-and-the-analyzer/01-analysing-progress.png)
+
+## Choosing an analyzer
+
+Local Ollama (default, free, private) or Gemini (free-tier API, faster on
+low-VRAM machines) — see [Installing Castwright](Installing-Castwright) for
+setup.
+
+![Analyzer choice](images/analysis-and-the-analyzer/02-analyzer-choice.png)
+
+Next: [Reviewing Low-Confidence Speaker Tags](Reviewing-Low-Confidence-Speaker-Tags).
+```
+
+- [ ] **Step 6: Capture Reviewing Low-Confidence Speaker Tags screenshots**
+
+Drive `low-confidence-nav.tsx` (find a manuscript with at least one low-confidence tag, or the demo book if it has one) and capture:
+
+1. `01-low-confidence-nav.png` — the low-confidence review navigator.
+2. `02-resolve-tag.png` — resolving one flagged line.
+
+- [ ] **Step 7: Write `docs/wiki/Reviewing-Low-Confidence-Speaker-Tags.md`**
+
+```markdown
+# Reviewing Low-Confidence Speaker Tags
+
+Before generating audio, Castwright surfaces any line it wasn't confident
+about attributing to a speaker, so you can confirm or correct it.
+
+![Low-confidence navigator](images/reviewing-low-confidence-speaker-tags/01-low-confidence-nav.png)
+
+![Resolve a tag](images/reviewing-low-confidence-speaker-tags/02-resolve-tag.png)
+
+Next: [Generating Audio](Generating-Audio).
+```
+
+- [ ] **Step 8: Verify and commit**
+
+Confirm every image path resolves and every next-page link is correct.
+
+```bash
+git add docs/wiki/Uploading-a-Book.md docs/wiki/Analysis-and-the-Analyzer.md docs/wiki/Reviewing-Low-Confidence-Speaker-Tags.md docs/wiki/images/uploading-a-book docs/wiki/images/analysis-and-the-analyzer docs/wiki/images/reviewing-low-confidence-speaker-tags
+git commit -m "docs(docs): add Uploading, Analysis, and Low-Confidence Review wiki pages"
+git push -u origin docs/docs-github-wiki-wave1b-upload-analyze-review
+gh pr create --base docs/docs-github-wiki --title "docs(docs): Uploading a Book + Analysis + Low-Confidence Review wiki pages" --body "Refs #1276"
+```
+
+---
+
+## Task 4: Wave 1c — Generating Audio (fe-46 flag) + The Quality Gate
+
+**Files:**
+- Create: `docs/wiki/Generating-Audio.md`, `docs/wiki/images/generating-audio/*.png`
+- Create: `docs/wiki/The-Quality-Gate.md`, `docs/wiki/images/the-quality-gate/*.png`
+
+**Interfaces:**
+- Consumes: `src/views/generation.tsx`; fe-46 (#1262) merge status.
+
+- [ ] **Step 1: Branch**
+
+```bash
+git switch docs/docs-github-wiki && git pull
+git switch -c docs/docs-github-wiki-wave1c-generation-quality
+```
+
+- [ ] **Step 2: Check fe-46 status before capture**
+
+```bash
+gh pr list --search "1262 in:body" --state all
+```
+
+If fe-46 has merged: capture its pre-flight voice-readiness gate modal as part of the generation-start flow below. If it has NOT merged (the likely case — Wave 1 runs before Wave 3): capture the current generation-start flow as-is and add a note to this page (Step 4 below) plus a follow-up marker; do not block this task on fe-46.
+
+- [ ] **Step 3: Capture Generating Audio screenshots**
+
+Drive `generation.tsx` through a real generation run and capture:
+
+1. `01-generation-start.png` — the generation-start screen/modal (include fe-46's readiness gate if merged, per Step 2).
+2. `02-generation-progress.png` — in-progress generation with resource trends visible.
+3. `03-generation-complete.png` — completion state.
+
+- [ ] **Step 4: Write `docs/wiki/Generating-Audio.md`**
+
+```markdown
+# Generating Audio
+
+![Start generation](images/generating-audio/01-generation-start.png)
+
+<!-- fe-46 (#1262) flag: if not yet merged when this page was captured, the
+     pre-flight voice-readiness gate shown here reflects the pre-fe-46 flow.
+     Re-shoot 01-generation-start.png once fe-46 ships. -->
+
+## Progress
+
+![Generation progress](images/generating-audio/02-generation-progress.png)
+
+## Done
+
+![Generation complete](images/generating-audio/03-generation-complete.png)
+
+Next: [The Quality Gate](The-Quality-Gate).
+```
+
+- [ ] **Step 5: Capture The Quality Gate screenshots**
+
+Capture whatever the app surfaces for the acoustic check / transcript verification / drift check / automatic re-recording flow:
+
+1. `01-quality-gate-flag.png` — a flagged line/chapter.
+2. `02-quality-gate-rerecord.png` — the automatic re-recording in progress or its result.
+
+- [ ] **Step 6: Write `docs/wiki/The-Quality-Gate.md`**
+
+```markdown
+# The Quality Gate
+
+Every generated line passes an automatic acoustic + transcript check before
+it's considered done. Lines that fail get automatically re-recorded.
+
+![Flagged line](images/the-quality-gate/01-quality-gate-flag.png)
+
+![Automatic re-record](images/the-quality-gate/02-quality-gate-rerecord.png)
+
+Next: [Listening & Revising](Listening-and-Revising).
+```
+
+- [ ] **Step 7: Verify, commit, note the fe-46 follow-up**
+
+If fe-46 was not merged at capture time, open a follow-up issue: `gh issue create --title "docs: re-shoot Generating Audio page 01 screenshot after fe-46 ships" --body "Refs #1276, #1262" --label documentation`.
+
+```bash
+git add docs/wiki/Generating-Audio.md docs/wiki/The-Quality-Gate.md docs/wiki/images/generating-audio docs/wiki/images/the-quality-gate
+git commit -m "docs(docs): add Generating Audio and The Quality Gate wiki pages"
+git push -u origin docs/docs-github-wiki-wave1c-generation-quality
+gh pr create --base docs/docs-github-wiki --title "docs(docs): Generating Audio + Quality Gate wiki pages" --body "Refs #1276"
+```
+
+---
+
+## Task 5: Wave 1d — Listening & Revising + Exporting
+
+**Files:**
+- Create: `docs/wiki/Listening-and-Revising.md`, `docs/wiki/images/listening-and-revising/*.png`
+- Create: `docs/wiki/Exporting.md`, `docs/wiki/images/exporting/*.png`
+
+**Interfaces:**
+- Consumes: `src/views/listen.tsx` + `src/components/listen/listen-header.tsx`, `listen-player-region.tsx`, `listen-download-section.tsx`.
+
+- [ ] **Step 1: Branch**
+
+```bash
+git switch docs/docs-github-wiki && git pull
+git switch -c docs/docs-github-wiki-wave1d-listen-export
+```
+
+- [ ] **Step 2: Capture Listening & Revising screenshots**
+
+Drive `listen.tsx` and capture:
+
+1. `01-listen-header.png` — cover + title + book-meta + Notes card (`listen-header.tsx`).
+2. `02-listen-player.png` — markers + chapter list (`listen-player-region.tsx`).
+3. `03-revision-timeline.png` — the revision timeline / A/B audition affordance.
+4. `04-share-clip.png` — the Share-clip button flow.
+
+- [ ] **Step 3: Write `docs/wiki/Listening-and-Revising.md`**
+
+```markdown
+# Listening & Revising
+
+![Book header](images/listening-and-revising/01-listen-header.png)
+
+## Player and chapters
+
+![Player](images/listening-and-revising/02-listen-player.png)
+
+## Revision timeline and A/B audition
+
+If a line doesn't sound right, regenerate it and compare old vs. new.
+
+![Revision timeline](images/listening-and-revising/03-revision-timeline.png)
+
+## Sharing a clip
+
+![Share clip](images/listening-and-revising/04-share-clip.png)
+
+Next: [Exporting](Exporting).
+```
+
+- [ ] **Step 4: Capture Exporting screenshots**
+
+Drive `listen-download-section.tsx` and capture:
+
+1. `01-download-tiles.png` — the format tiles (M4B/AAC/MP3/Opus).
+2. `02-export-queue.png` — an in-progress export queue entry.
+3. `03-lan-qr.png` — the LAN download + QR code flow.
+
+- [ ] **Step 5: Write `docs/wiki/Exporting.md`**
+
+```markdown
+# Exporting
+
+## Choose a format
+
+M4B, AAC, MP3, or Opus.
+
+![Download tiles](images/exporting/01-download-tiles.png)
+
+## Export queue
+
+![Export queue](images/exporting/02-export-queue.png)
+
+## Download over LAN
+
+Scan the QR code from your phone or tablet to download without a cable.
+
+![LAN QR](images/exporting/03-lan-qr.png)
+```
+
+- [ ] **Step 6: Verify and commit**
+
+```bash
+git add docs/wiki/Listening-and-Revising.md docs/wiki/Exporting.md docs/wiki/images/listening-and-revising docs/wiki/images/exporting
+git commit -m "docs(docs): add Listening & Revising and Exporting wiki pages"
+git push -u origin docs/docs-github-wiki-wave1d-listen-export
+gh pr create --base docs/docs-github-wiki --title "docs(docs): Listening & Revising + Exporting wiki pages" --body "Refs #1276"
+```
+
+---
+
+## Task 6: Wave 2a — Voice Engines + The Model Control Pill
+
+**Files:**
+- Create: `docs/wiki/Voice-Engines.md`, `docs/wiki/images/voice-engines/*.png`
+- Create: `docs/wiki/The-Model-Control-Pill.md`, `docs/wiki/images/the-model-control-pill/*.png`
+
+**Interfaces:**
+- Consumes: `src/components/ModelControlPill.tsx`.
+
+- [ ] **Step 1: Branch**
+
+```bash
+git switch docs/docs-github-wiki && git pull
+git switch -c docs/docs-github-wiki-wave2a-engines-pill
+```
+
+- [ ] **Step 2: Capture Voice Engines screenshots**
+
+Capture one shot per engine's presence in the UI:
+
+1. `01-kokoro.png`, `02-coqui.png`, `03-qwen.png`, `04-gemini.png` — wherever each engine surfaces (voice catalog filter, engine picker, or per-character override picker).
+
+- [ ] **Step 3: Write `docs/wiki/Voice-Engines.md`**
+
+```markdown
+# Voice Engines
+
+Castwright supports four TTS engines. See [Installing Castwright](Installing-Castwright)
+for setup steps for each.
+
+## Kokoro (always-available fallback)
+
+![Kokoro](images/voice-engines/01-kokoro.png)
+
+## Coqui XTTS v2
+
+![Coqui](images/voice-engines/02-coqui.png)
+
+## Qwen (default generation engine)
+
+![Qwen](images/voice-engines/03-qwen.png)
+
+## Gemini
+
+![Gemini](images/voice-engines/04-gemini.png)
+
+Next: [The Model Control Pill](The-Model-Control-Pill).
+```
+
+- [ ] **Step 4: Capture The Model Control Pill screenshots**
+
+Drive `ModelControlPill.tsx` and capture:
+
+1. `01-pill-unloaded.png`, `02-pill-loading.png`, `03-pill-loaded.png` — its load/unload states.
+
+- [ ] **Step 5: Write `docs/wiki/The-Model-Control-Pill.md`**
+
+```markdown
+# The Model Control Pill
+
+Load and unload button-driven engines (Coqui, Qwen Base) directly from the
+UI — the pill shows current VRAM state and arbitrates conflicts between
+engines.
+
+![Unloaded](images/the-model-control-pill/01-pill-unloaded.png)
+![Loading](images/the-model-control-pill/02-pill-loading.png)
+![Loaded](images/the-model-control-pill/03-pill-loaded.png)
+```
+
+- [ ] **Step 6: Verify and commit**
+
+```bash
+git add docs/wiki/Voice-Engines.md docs/wiki/The-Model-Control-Pill.md docs/wiki/images/voice-engines docs/wiki/images/the-model-control-pill
+git commit -m "docs(docs): add Voice Engines and The Model Control Pill wiki pages"
+git push -u origin docs/docs-github-wiki-wave2a-engines-pill
+gh pr create --base docs/docs-github-wiki --title "docs(docs): Voice Engines + Model Control Pill wiki pages" --body "Refs #1276"
+```
+
+---
+
+## Task 7: Wave 2b — Library Management + Mobile, Tablet & Companion App
+
+**Files:**
+- Create: `docs/wiki/Library-Management.md`, `docs/wiki/images/library-management/*.png`
+- Create: `docs/wiki/Mobile-Tablet-and-Companion-App.md`, `docs/wiki/images/mobile-tablet-and-companion-app/*.png`
+
+**Interfaces:**
+- Consumes: the Books/library view; LAN HTTPS pairing flow; Android companion app.
+
+- [ ] **Step 1: Branch**
+
+```bash
+git switch docs/docs-github-wiki && git pull
+git switch -c docs/docs-github-wiki-wave2b-library-mobile
+```
+
+- [ ] **Step 2: Capture Library Management screenshots**
+
+1. `01-library-covers.png` — the library grid with covers/tags.
+2. `02-series-grouping.png` — series grouping.
+3. `03-book-bundle.png` — a book bundle, if one exists in the demo data.
+
+- [ ] **Step 3: Write `docs/wiki/Library-Management.md`**
+
+```markdown
+# Library Management
+
+![Covers and tags](images/library-management/01-library-covers.png)
+
+## Series grouping
+
+![Series](images/library-management/02-series-grouping.png)
+
+## Book bundles
+
+![Bundle](images/library-management/03-book-bundle.png)
+```
+
+- [ ] **Step 4: Capture Mobile, Tablet & Companion App screenshots**
+
+1. `01-lan-pairing-qr.png` — LAN HTTPS QR pairing (per `npm run install:cert-mobile`).
+2. `02-phone-viewport.png` — a phone-viewport screenshot of the app (per the mobile testing protocol).
+3. `03-companion-app.png` — the Android companion app.
+
+- [ ] **Step 5: Write `docs/wiki/Mobile-Tablet-and-Companion-App.md`**
+
+```markdown
+# Mobile, Tablet & Companion App
+
+## LAN access
+
+![LAN pairing](images/mobile-tablet-and-companion-app/01-lan-pairing-qr.png)
+
+## Phone layout
+
+![Phone](images/mobile-tablet-and-companion-app/02-phone-viewport.png)
+
+## Android companion app
+
+Deep-link pairing, offline-finished shelf, cross-device sync.
+
+![Companion app](images/mobile-tablet-and-companion-app/03-companion-app.png)
+```
+
+- [ ] **Step 6: Verify and commit**
+
+```bash
+git add docs/wiki/Library-Management.md docs/wiki/Mobile-Tablet-and-Companion-App.md docs/wiki/images/library-management docs/wiki/images/mobile-tablet-and-companion-app
+git commit -m "docs(docs): add Library Management and Mobile/Tablet/Companion wiki pages"
+git push -u origin docs/docs-github-wiki-wave2b-library-mobile
+gh pr create --base docs/docs-github-wiki --title "docs(docs): Library Management + Mobile/Tablet/Companion wiki pages" --body "Refs #1276"
+```
+
+---
+
+## Task 8: Wave 2c — Admin & Model Manager + Advanced Settings + Account & Settings
+
+**Files:**
+- Create: `docs/wiki/Admin-and-Model-Manager.md`, `docs/wiki/images/admin-and-model-manager/*.png`
+- Create: `docs/wiki/Advanced-Settings.md`, `docs/wiki/images/advanced-settings/*.png`
+- Create: `docs/wiki/Account-and-Settings.md`, `docs/wiki/images/account-and-settings/*.png`
+
+**Interfaces:**
+- Consumes: `src/views/admin.tsx`, `src/views/model-manager.tsx`, `src/views/advanced.tsx`, `src/views/account.tsx`.
+
+- [ ] **Step 1: Branch**
+
+```bash
+git switch docs/docs-github-wiki && git pull
+git switch -c docs/docs-github-wiki-wave2c-admin-advanced-account
+```
+
+- [ ] **Step 2: Capture and write Admin & Model Manager**
+
+Drive `admin.tsx` + `model-manager.tsx`; capture `01-admin-overview.png`, `02-model-manager.png`.
+
+```markdown
+# Admin & Model Manager
+
+![Admin overview](images/admin-and-model-manager/01-admin-overview.png)
+
+![Model manager](images/admin-and-model-manager/02-model-manager.png)
+```
+
+- [ ] **Step 3: Capture and write Advanced Settings**
+
+Drive `advanced.tsx`; capture `01-accelerator-profile.png`.
+
+```markdown
+# Advanced Settings
+
+## Accelerator profile
+
+![Accelerator profile](images/advanced-settings/01-accelerator-profile.png)
+```
+
+- [ ] **Step 4: Capture and write Account & Settings**
+
+Drive `account.tsx`; capture `01-account.png`.
+
+```markdown
+# Account & Settings
+
+![Account](images/account-and-settings/01-account.png)
+```
+
+- [ ] **Step 5: Verify and commit**
+
+```bash
+git add docs/wiki/Admin-and-Model-Manager.md docs/wiki/Advanced-Settings.md docs/wiki/Account-and-Settings.md docs/wiki/images/admin-and-model-manager docs/wiki/images/advanced-settings docs/wiki/images/account-and-settings
+git commit -m "docs(docs): add Admin/Model Manager, Advanced Settings, Account & Settings wiki pages"
+git push -u origin docs/docs-github-wiki-wave2c-admin-advanced-account
+gh pr create --base docs/docs-github-wiki --title "docs(docs): Admin/Model Manager + Advanced Settings + Account wiki pages" --body "Refs #1276"
+```
+
+---
+
+## Task 9: Wave 2d — Multi-language Support + Troubleshooting
+
+**Files:**
+- Create: `docs/wiki/Multi-language-Support.md`, `docs/wiki/images/multi-language-support/*.png`
+- Create: `docs/wiki/Troubleshooting.md`, `docs/wiki/images/troubleshooting/*.png`
+
+**Interfaces:**
+- Consumes: `INSTALL.md`'s Troubleshooting section; `src/views/help.tsx`.
+
+- [ ] **Step 1: Branch**
+
+```bash
+git switch docs/docs-github-wiki && git pull
+git switch -c docs/docs-github-wiki-wave2d-language-troubleshooting
+```
+
+- [ ] **Step 2: Capture and write Multi-language Support**
+
+Upload/analyze the Russian Coalfall variant (`server/src/__fixtures__/the-coalfall-commission.ru.md`) and capture `01-language-detection.png`, `02-non-english-cast.png`.
+
+```markdown
+# Multi-language Support
+
+English, Spanish, Russian are fully supported; French/German are dormant.
+Language is auto-detected from the manuscript.
+
+![Language detection](images/multi-language-support/01-language-detection.png)
+
+![Non-English cast](images/multi-language-support/02-non-english-cast.png)
+```
+
+- [ ] **Step 3: Write Troubleshooting**
+
+Migrate `INSTALL.md`'s Troubleshooting section content, plus `help.tsx`'s FAQ content, verbatim (copied prose, not paraphrased) into `docs/wiki/Troubleshooting.md`. No new screenshots required — this page is content-migration, not a new capture.
+
+- [ ] **Step 4: Verify and commit**
+
+```bash
+git add docs/wiki/Multi-language-Support.md docs/wiki/Troubleshooting.md docs/wiki/images/multi-language-support
+git commit -m "docs(docs): add Multi-language Support and Troubleshooting wiki pages"
+git push -u origin docs/docs-github-wiki-wave2d-language-troubleshooting
+gh pr create --base docs/docs-github-wiki --title "docs(docs): Multi-language Support + Troubleshooting wiki pages" --body "Refs #1276"
+```
+
+---
+
+## Task 10: Wave 3 — Reviewing Cast & Assigning Voices + Designing a Voice
+
+**Files:**
+- Create: `docs/wiki/Reviewing-Cast-and-Assigning-Voices.md`, `docs/wiki/images/reviewing-cast-and-assigning-voices/*.png`
+- Create: `docs/wiki/Designing-a-Voice.md`, `docs/wiki/images/designing-a-voice/*.png`
+
+**Interfaces:**
+- Consumes: `src/views/cast.tsx`, `src/views/voices.tsx`, `src/views/confirm-cast.tsx`; fe-46 (#1262) merge status (this task is sequenced LAST specifically to wait on it).
+
+- [ ] **Step 1: Check fe-46 merge status — this is why this task runs last**
+
+```bash
+gh pr list --search "1262 in:body" --state all
+```
+
+If fe-46 has NOT merged yet, wait for it before starting this task (per spec — do not capture pages 11–12 against the pre-fe-46 flow).
+
+- [ ] **Step 2: Branch**
+
+```bash
+git switch docs/docs-github-wiki && git pull
+git switch -c docs/docs-github-wiki-wave3-cast-voices
+```
+
+- [ ] **Step 3: Capture Reviewing Cast & Assigning Voices screenshots**
+
+Drive `cast.tsx` / `voices.tsx` / `confirm-cast.tsx` (post-fe-46 confirmCast → Cast → Manuscript → Generate sequencing) and capture:
+
+1. `01-cast-review.png`, `02-voice-library-dnd.png`, `03-assign-pill.png`, `04-ab-compare.png`, `05-confirm-cast.png`.
+
+- [ ] **Step 4: Write `docs/wiki/Reviewing-Cast-and-Assigning-Voices.md`**
+
+```markdown
+# Reviewing Cast & Assigning Voices
+
+![Cast review](images/reviewing-cast-and-assigning-voices/01-cast-review.png)
+
+## Assigning a voice
+
+Drag a voice card onto a cast row on desktop, or tap "Assign" then tap the
+row on touch.
+
+![Drag and drop](images/reviewing-cast-and-assigning-voices/02-voice-library-dnd.png)
+![Assign pill](images/reviewing-cast-and-assigning-voices/03-assign-pill.png)
+
+## A/B compare
+
+![A/B compare](images/reviewing-cast-and-assigning-voices/04-ab-compare.png)
+
+## Confirming the cast
+
+![Confirm cast](images/reviewing-cast-and-assigning-voices/05-confirm-cast.png)
+
+Next: [Designing a Voice](Designing-a-Voice).
+```
+
+- [ ] **Step 5: Capture Designing a Voice screenshots**
+
+Drive the Qwen VoiceDesign flow and capture:
+
+1. `01-persona-input.png`, `02-design-progress.png`, `03-emotion-variants.png`, `04-design-scope-picker.png`.
+
+- [ ] **Step 6: Write `docs/wiki/Designing-a-Voice.md`**
+
+```markdown
+# Designing a Voice
+
+Describe a persona and Qwen VoiceDesign generates a matching voice.
+
+![Persona input](images/designing-a-voice/01-persona-input.png)
+
+![Design progress](images/designing-a-voice/02-design-progress.png)
+
+## Emotion variants
+
+![Emotion variants](images/designing-a-voice/03-emotion-variants.png)
+
+## Designing for one character vs. the full cast
+
+![Design-scope picker](images/designing-a-voice/04-design-scope-picker.png)
+```
+
+- [ ] **Step 7: Verify and commit**
+
+```bash
+git add docs/wiki/Reviewing-Cast-and-Assigning-Voices.md docs/wiki/Designing-a-Voice.md docs/wiki/images/reviewing-cast-and-assigning-voices docs/wiki/images/designing-a-voice
+git commit -m "docs(docs): add Reviewing Cast & Assigning Voices and Designing a Voice wiki pages"
+git push -u origin docs/docs-github-wiki-wave3-cast-voices
+gh pr create --base docs/docs-github-wiki --title "docs(docs): Cast Review + Voice Design wiki pages (Wave 3)" --body "Refs #1276"
+```
+
+---
+
+## Task 11: Wave 4 — README.md / INSTALL.md migration
+
+**Files:**
+- Modify: `README.md` (shrink to pitch + links)
+- `INSTALL.md` — **unchanged**, per Global Constraints
+
+**Interfaces:**
+- Consumes: every page from Tasks 1–10 (links to them); the confirmed final wiki sidebar structure.
+
+- [ ] **Step 1: Branch**
+
+```bash
+git switch docs/docs-github-wiki && git pull
+git switch -c docs/docs-github-wiki-wave4-readme-migration
+```
+
+- [ ] **Step 2: Rewrite `README.md`**
+
+Keep `## What you get` (the pitch) and `## License` as-is. Replace `## Features`, `## Quickstart`, `## GPU & VRAM`, `## Companion app (Android)`, `## Releases`, `## How it's built`, `## Documentation` with a single condensed section:
+
+```markdown
+## Documentation
+
+The full user guide — installing, uploading a book, casting, generating
+audio, listening, exporting, and every feature area — lives on the
+[wiki](https://github.com/dudarenok-maker/Castwright/wiki), illustrated
+with real screenshots.
+
+- New here? Start at [Getting Started](https://github.com/dudarenok-maker/Castwright/wiki/Getting-Started).
+- Installing from the release zip? See [INSTALL.md](./INSTALL.md).
+- Release history: [RELEASE_NOTES.md](./RELEASE_NOTES.md).
+```
+
+- [ ] **Step 3: Verify and commit**
+
+Confirm `README.md` still renders sensibly top to bottom and every link resolves.
+
+```bash
+git add README.md
+git commit -m "docs(docs): shrink README to a pitch + wiki/INSTALL links (Wave 4)"
+git push -u origin docs/docs-github-wiki-wave4-readme-migration
+gh pr create --base docs/docs-github-wiki --title "docs(docs): shrink README to pitch + links (Wave 4)" --body "Closes #1276"
+```
+
+- [ ] **Step 4: After all wave PRs are merged into `docs/docs-github-wiki`, open the final integration PR into `main`**
+
+```bash
+git switch docs/docs-github-wiki && git pull
+gh pr create --base main --title "docs(docs): GitHub wiki user guide (all waves)" --body "Closes #1276, closes #1277"
+```
+
+Run `npm run wiki:sync` one final time after this merges to `main`, to publish the final README-linked state.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Every spec section maps to a task — Architecture/authoring model → Task 1; Wave 0 spike → Task 1 Steps 12–14; all 21 pages → Tasks 2–10; fe-46 interaction (pages 7, 11, 12) → Tasks 4 and 10; INSTALL.md relationship → Tasks 2 and 11; delivery waves → Tasks 1–11 branch/PR structure; testing/verification → each task's manual-verify step + Task 1's real unit test.
+- **Correction from spec draft:** the spec's Testing/verification section says `scripts/sync-wiki.mjs` "follows the existing convention of testing `scripts/lib/` helpers" (implying Vitest); the actual convention for `.mjs` scripts under `scripts/tests/*.test.mjs` is **`node:test`**, auto-discovered by `npm run test:hooks` (see `scripts/run-hooks-tests.mjs`), not Vitest. Task 1 uses `node:test` — this is what the repo actually does, confirmed against `scripts/tests/build-companion-apk.test.mjs`.
+- **Type/interface consistency:** `copyWikiTree(srcDir, destDir)` and `buildCommitMessage(sourceSha)` are the only two exported functions from `scripts/sync-wiki.mjs`, used identically in both the test (Task 1 Step 2) and no other task references them directly.

--- a/docs/superpowers/specs/2026-07-04-github-wiki-user-guide-design.md
+++ b/docs/superpowers/specs/2026-07-04-github-wiki-user-guide-design.md
@@ -16,8 +16,9 @@ a features bullet list.
 
 Build a comprehensive GitHub wiki that becomes the **primary documentation
 home** for Castwright: every pipeline stage and every feature area, each
-illustrated with real screenshots from the running app. `README.md` and
-`INSTALL.md`'s content migrates into the wiki rather than being duplicated.
+illustrated with real screenshots from the running app. `README.md` shrinks
+to a pitch + links. `INSTALL.md` stays intact (see "INSTALL.md relationship"
+below) — its content is *duplicated*, not migrated, into the wiki.
 
 ## Non-goals
 
@@ -43,29 +44,65 @@ repo**:
 - `docs/wiki/_Sidebar.md` / `docs/wiki/_Footer.md` — wiki-wide nav chrome
   (GitHub's wiki convention for a persistent sidebar/footer).
 
-Pages are authored on normal feature branches, reviewed via PR (the
-`docs-only` CI fast-path and code-review exemption apply per the existing
-convention — this is a docs-only change-type), and merged to `main` like any
-other change.
+Pages are authored on normal feature branches and reviewed via PR. **Only
+the pure-content waves (1–4, all under `docs/**`/root `*.md`) get the
+`docs-only` CI fast-path and code-review exemption.** Wave 0 adds an
+executable script (`scripts/sync-wiki.mjs`), its test, and a `package.json`
+entry — that's a `chore`/`build`-shaped change outside the doc-only glob, so
+it does **not** qualify for the exemption and gets a real (`low`-effort)
+`code-review` pass like any other non-doc PR.
 
 A new script, `scripts/sync-wiki.mjs`, mirrors `docs/wiki/*` into
 `Castwright.wiki.git`:
 
-1. Clone (or `git -C` pull, if cached) `https://github.com/dudarenok-maker/Castwright.wiki.git`
-   into a scratch/cache location.
-2. Copy `docs/wiki/*` over the clone's working tree (excluding the clone's own
-   `.git/`).
+1. Attempt `git clone https://github.com/dudarenok-maker/Castwright.wiki.git`
+   into a scratch/cache location. **A GitHub wiki's git repo does not exist
+   until at least one page exists** — enabling the `has_wiki` setting alone
+   doesn't create it, so this clone fails on a never-touched wiki. On clone
+   failure, fall back to `git init` + `git remote add origin <url>` +
+   `git push -u origin HEAD:master` to create the wiki repo from scratch
+   (this is the actual bootstrap mechanism, exercised once in the Wave 0
+   spike below — not a hypothetical).
+2. Copy `docs/wiki/*` over the clone's (or freshly-initialized) working tree
+   (excluding `.git/`).
 3. Commit (message references the source commit SHA in the main repo) and
    push.
-4. Exposed as `npm run wiki:sync`, run manually after a merge to `main`
-   touches `docs/wiki/**`. Not wired into any automated hook — a deliberate
-   manual step, since it pushes to a repo outside the normal branch-protection
-   perimeter.
+4. Exposed as `npm run wiki:sync`, run manually by the operator after a merge
+   to `main` touches `docs/wiki/**`, using the operator's own `gh`/git
+   credentials. This is intentionally a manual, human-run step with no CI
+   identity behind it — the wiki repo sits outside `main`'s branch protection
+   by design (GitHub wikis have no PR mechanism to gate on), so there is
+   nothing for automation to gate against; a human running it locally is the
+   actual safeguard, not an accident of scope.
 
 **Repo setting change required:** the repo currently has `hasWikiEnabled:
 false`. Enabling it (`gh api -X PATCH repos/dudarenok-maker/Castwright
 -f has_wiki=true`, needs admin) is a Wave 0 task — call this out to the user
 before running it, since it's a repo-visibility-adjacent setting change.
+
+### Wave 0 spike: prove the authoring model before building content
+
+The dual-render premise — a page + subdirectory image under `docs/wiki/`
+rendering correctly both as a main-repo blob (for PR review) and after
+`sync-wiki.mjs` flattens `docs/wiki/*` to the wiki repo's root (for the
+published wiki) — is unverified and load-bearing for all 21 pages. Before
+any content wave starts, Wave 0 includes a spike:
+
+1. Enable the wiki, run the bootstrap path above once for real.
+2. Commit one throwaway page (`docs/wiki/_Spike.md`) with one image at
+   `docs/wiki/images/_spike/01-test.png`, referenced as
+   `![](images/_spike/01-test.png)`.
+3. Sync it, then check the **live wiki page** in a browser: does the image
+   render?
+4. **If yes:** the page-relative convention in "Screenshot workflow" below
+   stands as written.
+5. **If no:** fall back to absolute `raw.githubusercontent.com/<owner>/<repo>/main/docs/wiki/images/...`
+   URLs. This trades the "self-contained mirror" property for a working
+   render (the wiki page's images point back at `main` in the source repo)
+   — an explicit, accepted tradeoff if the relative-path approach fails,
+   not a silent one.
+6. Delete the spike page/image once the answer is confirmed, before Wave 1
+   starts.
 
 ## Screenshot workflow
 
@@ -133,37 +170,77 @@ file's content.)
 
 `fe-46` (Cast-first landing + pre-flight voice-readiness gate, issue #1262,
 plan `docs/features/240-cast-first-landing-and-voice-readiness-gate.md`) is
-**in progress in parallel** with this wiki work and changes exactly the flow
-pages 11–12 document (confirm → Cast → Manuscript → Generate re-sequencing,
-the pre-flight voice-readiness gate before generation, the "Design full
-cast" / "Proceed anyway" affordances).
+**in progress in parallel** with this wiki work. It touches **three** pages,
+not two:
 
-Mitigation: pages 11 and 12 are captured **last**, in Wave 3, with an
-explicit check of `fe-46`'s merge status immediately before capture. If
-`fe-46` has landed by then, pages 11–12 document the new flow; if not, they
-document the current flow and get a follow-up issue filed for a re-shoot
-once `fe-46` ships (same pattern as any other doc-drift follow-up).
+- Pages 11–12 (Reviewing Cast & Assigning Voices, Designing a Voice) — the
+  `confirmCast` → Cast → Manuscript → Generate re-sequencing and the
+  "Design full cast" / "Proceed anyway" affordances live here.
+- **Page 7 (Generating Audio)** — fe-46's pre-flight voice-readiness gate
+  modal fires at generation start, so it lands squarely on this page too.
+  This page sits in Wave 1 (core journey), captured well before Wave 3.
+
+Mitigation:
+
+- Pages 11–12 are captured **last**, in Wave 3, with an explicit check of
+  `fe-46`'s merge status immediately before capture — same as before.
+- Page 7, captured earlier in Wave 1, gets the **same flag**: at Wave 1
+  capture time, check `fe-46`'s status; if it hasn't landed yet (the likely
+  case, since Wave 1 runs first), page 7 documents the current
+  generation-start flow and picks up an explicit follow-up note (and, once
+  `fe-46` ships, a re-shoot issue) rather than being silently left stale —
+  the same "flagged, not silent" treatment pages 11–12 get, applied to the
+  one Wave-1 page fe-46 actually reaches.
+
+## INSTALL.md relationship
+
+`INSTALL.md` ships inside the offline release zip
+(`castwright-vX.Y.Z.zip`) and is the install contract for a deployer who has
+extracted that zip and may not have a browser open on GitHub yet. It **stays
+fully intact, unchanged** — not stubbed, not retired. The wiki's "Installing
+Castwright" page (page 3) is a **parallel, screenshot-illustrated duplicate**
+for online readers, not a migration target. This means install steps have
+two places to update going forward — a deliberate, scoped exception to the
+"migrate, don't duplicate" decision for `README.md`, made specifically
+because `INSTALL.md` has an offline audience `README.md` doesn't.
+
+`README.md` still shrinks to a pitch + links (to both the wiki and
+`INSTALL.md`) — it isn't shipped as a deployer's only install reference the
+way `INSTALL.md` is, so migrating it away carries no equivalent offline-gap
+risk.
 
 ## Delivery: waves
 
-One integration branch, `docs/docs-github-wiki`, with each wave landing as
-its own PR (normal branch → PR → review → merge flow) rather than one
-all-at-once PR:
+One integration branch, `docs/docs-github-wiki`, off of which every PR below
+branches — each is its own small, independently-reviewable PR (not one
+all-at-once PR, and not one PR per wave — a 9-page wave is too large for a
+single reviewable diff):
 
-- **Wave 0 — infra.** `docs/wiki/` scaffold, `scripts/sync-wiki.mjs` +
-  `npm run wiki:sync`, enable the GitHub wiki setting, `_Sidebar.md` /
-  `_Footer.md`, empty Home page.
-- **Wave 1 — core journey.** Pages 2–10, screenshotted and written.
-- **Wave 2 — full breadth.** Pages 13–21.
-- **Wave 3 — cast & voices.** Pages 11–12, captured last per the fe-46
-  mitigation above.
-- **Wave 4 — migration.** Shrink `README.md` to a pitch + wiki link;
-  retire `INSTALL.md`'s content into page 3, leaving a short redirect stub
-  (`INSTALL.md` becomes "moved to the wiki, see <link>") rather than deleting
-  the file outright (external links to it stay resolvable).
+- **Wave 0 — infra + spike.** One PR: `docs/wiki/` scaffold,
+  `scripts/sync-wiki.mjs` + `npm run wiki:sync` + its test
+  (`scripts/tests/sync-wiki.test.mjs`, Vitest — matching the actual
+  precedent for `.mjs` scripts, not the PowerShell/Pester convention used
+  for `scripts/lib/`), enabling the GitHub wiki setting, `_Sidebar.md` /
+  `_Footer.md`, the render-model spike (above), empty Home page. **This PR
+  is a `chore`/`build` change, not docs-only — it gets the mandatory
+  `low`-effort `code-review` pass**, unlike every other wave below.
+- **Wave 1 — core journey**, split into ~4 small PRs of 2–3 pages each
+  rather than one 9-page PR, e.g.: (a) Getting Started + Installing
+  Castwright; (b) Uploading a Book + Analysis & the Analyzer + Reviewing
+  Low-Confidence Speaker Tags; (c) Generating Audio (with the fe-46 flag
+  above) + The Quality Gate; (d) Listening & Revising + Exporting.
+- **Wave 2 — full breadth**, similarly split into ~3–4 small PRs of 2–3
+  pages each (e.g. engines + pill; library + mobile/companion; admin +
+  advanced + account; multi-language + troubleshooting).
+- **Wave 3 — cast & voices.** One PR, pages 11–12, captured last per the
+  fe-46 mitigation above.
+- **Wave 4 — migration.** One PR: shrink `README.md` to a pitch + links;
+  add the "Installing Castwright" wiki page as `INSTALL.md`'s duplicate per
+  the section above (`INSTALL.md` itself is untouched).
 
-Each wave PR runs `npm run wiki:sync` after merge to publish that wave's
-pages live.
+Waves 1–4's PRs are pure `docs/**`/root `*.md` and qualify for the
+docs-only CI fast-path and code-review exemption; Wave 0 does not (above).
+Each PR runs `npm run wiki:sync` after merge to publish its pages live.
 
 ## Testing / verification
 

--- a/docs/superpowers/specs/2026-07-04-github-wiki-user-guide-design.md
+++ b/docs/superpowers/specs/2026-07-04-github-wiki-user-guide-design.md
@@ -1,0 +1,188 @@
+# GitHub wiki user guide — design
+
+Status: draft
+Date: 2026-07-04
+
+## Problem
+
+`README.md` and `INSTALL.md` thoroughly cover installing, configuring, and
+listing features, but nothing walks a user through actually *using* the app —
+upload a book, review cast, assign or design voices, generate, listen,
+export — with screenshots. There is no visual, task-oriented guide, and no
+single documentation home: a new user has to piece the picture together from
+a features bullet list.
+
+## Goal
+
+Build a comprehensive GitHub wiki that becomes the **primary documentation
+home** for Castwright: every pipeline stage and every feature area, each
+illustrated with real screenshots from the running app. `README.md` and
+`INSTALL.md`'s content migrates into the wiki rather than being duplicated.
+
+## Non-goals
+
+- No product changes. This is documentation-only work; nothing in `src/`,
+  `server/`, or the sidecar changes.
+- Not a visual redesign of the app (out of scope per project conventions
+  regardless).
+- Not a translation effort — the wiki ships in English only for v1.
+
+## Architecture: authoring model
+
+GitHub wikis are their own separate git repo (`Castwright.wiki.git`) with **no
+PR review, no CI, no branch protection** — editing it directly (web UI or
+`git push`) bypasses this repo's entire commit-gate/review discipline
+(pre-commit hooks, the mandatory `code-review` PR gate, etc).
+
+To preserve that discipline, the wiki's **source of truth lives in this
+repo**:
+
+- `docs/wiki/*.md` — one Markdown file per page.
+- `docs/wiki/images/<page-slug>/NN-caption.png` — screenshots, referenced by
+  page-relative path.
+- `docs/wiki/_Sidebar.md` / `docs/wiki/_Footer.md` — wiki-wide nav chrome
+  (GitHub's wiki convention for a persistent sidebar/footer).
+
+Pages are authored on normal feature branches, reviewed via PR (the
+`docs-only` CI fast-path and code-review exemption apply per the existing
+convention — this is a docs-only change-type), and merged to `main` like any
+other change.
+
+A new script, `scripts/sync-wiki.mjs`, mirrors `docs/wiki/*` into
+`Castwright.wiki.git`:
+
+1. Clone (or `git -C` pull, if cached) `https://github.com/dudarenok-maker/Castwright.wiki.git`
+   into a scratch/cache location.
+2. Copy `docs/wiki/*` over the clone's working tree (excluding the clone's own
+   `.git/`).
+3. Commit (message references the source commit SHA in the main repo) and
+   push.
+4. Exposed as `npm run wiki:sync`, run manually after a merge to `main`
+   touches `docs/wiki/**`. Not wired into any automated hook — a deliberate
+   manual step, since it pushes to a repo outside the normal branch-protection
+   perimeter.
+
+**Repo setting change required:** the repo currently has `hasWikiEnabled:
+false`. Enabling it (`gh api -X PATCH repos/dudarenok-maker/Castwright
+-f has_wiki=true`, needs admin) is a Wave 0 task — call this out to the user
+before running it, since it's a repo-visibility-adjacent setting change.
+
+## Screenshot workflow
+
+- Drive the real running app (`npm start` — real analyzer, real sidecar, no
+  mocks) via Chrome browser automation.
+- Use the built-in **"try a sample book"** demo — *The Coalfall Commission*
+  (13-character cast, already a committed fixture) — as the consistent,
+  real-content source for every screenshot. No fabricated/mocked UI states.
+- Desktop-viewport screenshots by default; capture phone/tablet viewports
+  additionally only for pages where the mobile-testing protocol's layout
+  rules produce a genuinely different screenshot worth showing (e.g.
+  Listening & Revising's bottom-sheet player, the hamburger nav).
+- File convention: `docs/wiki/images/<page-slug>/NN-caption.png`, numbered in
+  the order they appear on the page.
+
+## Page structure (21 pages)
+
+Grouped in the wiki sidebar under three headings.
+
+**Core journey**
+
+1. Home (wiki landing page)
+2. Getting Started (condensed quickstart; links to page 3 for full detail)
+3. Installing Castwright (migrated from `INSTALL.md`: per-OS steps, Pinokio,
+   prerequisites, configuration reference)
+4. Uploading a Book (`upload.tsx`, `manuscript.tsx`, `restructure.tsx`,
+   `confirm-metadata.tsx`)
+5. Analysis & the Analyzer (`analysing.tsx`; choosing Ollama / Gemini /
+   pipelined two-model)
+6. Reviewing Low-Confidence Speaker Tags (script-review QA pass,
+   `low-confidence-nav.tsx`)
+7. Generating Audio (`generation.tsx`, resource trends)
+8. The Quality Gate (acoustic check, transcript verification, drift check,
+   automatic re-recording)
+9. Listening & Revising (`listen.tsx`, revision timeline, drift detection,
+   A/B audition)
+10. Exporting (M4B/AAC/MP3/Opus, LAN download + QR)
+
+**Cast & Voices** *(grouped together, sequenced last — see Wave 3 below)*
+
+11. Reviewing Cast & Assigning Voices (`cast.tsx`, `voices.tsx`,
+    `confirm-cast.tsx`, catalog/preset assignment, drag-and-drop, A/B compare)
+12. Designing a Voice (Qwen VoiceDesign: persona → generated voice, emotion
+    variants, design progress, design-scope picker)
+
+**Full breadth**
+
+13. Voice Engines (Kokoro / Coqui / Qwen / Gemini — install and switch)
+14. The Model Control Pill (`ModelControlPill.tsx` — load/unload, VRAM
+    arbitration)
+15. Library Management (covers, tags, series grouping, book bundles)
+16. Mobile, Tablet & Companion App (LAN HTTPS, pairing, Android app)
+17. Admin & Model Manager (`admin.tsx`, `model-manager.tsx`)
+18. Advanced Settings (`advanced.tsx` — accelerator profile, etc.)
+19. Account & Settings (`account.tsx`)
+20. Multi-language Support
+21. Troubleshooting (migrated from `INSTALL.md`'s Troubleshooting section,
+    plus `help.tsx` FAQ content)
+
+(About / Release Notes was folded out as a standalone page — it links to
+`RELEASE_NOTES.md` directly from Home's footer instead of duplicating that
+file's content.)
+
+## fe-46 interaction (flagged risk)
+
+`fe-46` (Cast-first landing + pre-flight voice-readiness gate, issue #1262,
+plan `docs/features/240-cast-first-landing-and-voice-readiness-gate.md`) is
+**in progress in parallel** with this wiki work and changes exactly the flow
+pages 11–12 document (confirm → Cast → Manuscript → Generate re-sequencing,
+the pre-flight voice-readiness gate before generation, the "Design full
+cast" / "Proceed anyway" affordances).
+
+Mitigation: pages 11 and 12 are captured **last**, in Wave 3, with an
+explicit check of `fe-46`'s merge status immediately before capture. If
+`fe-46` has landed by then, pages 11–12 document the new flow; if not, they
+document the current flow and get a follow-up issue filed for a re-shoot
+once `fe-46` ships (same pattern as any other doc-drift follow-up).
+
+## Delivery: waves
+
+One integration branch, `docs/docs-github-wiki`, with each wave landing as
+its own PR (normal branch → PR → review → merge flow) rather than one
+all-at-once PR:
+
+- **Wave 0 — infra.** `docs/wiki/` scaffold, `scripts/sync-wiki.mjs` +
+  `npm run wiki:sync`, enable the GitHub wiki setting, `_Sidebar.md` /
+  `_Footer.md`, empty Home page.
+- **Wave 1 — core journey.** Pages 2–10, screenshotted and written.
+- **Wave 2 — full breadth.** Pages 13–21.
+- **Wave 3 — cast & voices.** Pages 11–12, captured last per the fe-46
+  mitigation above.
+- **Wave 4 — migration.** Shrink `README.md` to a pitch + wiki link;
+  retire `INSTALL.md`'s content into page 3, leaving a short redirect stub
+  (`INSTALL.md` becomes "moved to the wiki, see <link>") rather than deleting
+  the file outright (external links to it stay resolvable).
+
+Each wave PR runs `npm run wiki:sync` after merge to publish that wave's
+pages live.
+
+## Testing / verification
+
+This is documentation content, not app behavior — the project's automated
+test suites don't apply. Verification is manual per page:
+
+- Every screenshot is captured against the real running app (not staged
+  mockups) — verified by the person merging each wave's PR actually loading
+  the described view and comparing.
+- `scripts/sync-wiki.mjs` gets a small unit test (it's a script under
+  `scripts/`, so it follows the existing convention of testing
+  `scripts/lib/` helpers) covering its copy/diff logic — not the actual git
+  push, which isn't unit-testable.
+- Each wave's PR description includes a manual acceptance checklist: every
+  linked page loads, every image renders, internal cross-links resolve.
+
+## Open questions / follow-ups
+
+- The wiki's search/discoverability (GitHub wikis have basic built-in
+  search) is not otherwise tuned — acceptable for v1.
+- No i18n for the wiki itself in v1 (matches "Multi-language Support" being
+  a *documentation topic*, not the wiki being translated).


### PR DESCRIPTION
## Summary

- Adds the design spec for a comprehensive GitHub wiki (21 pages) covering
  every feature area of the app, screenshotted from the running demo book.
- Wiki content authored in `docs/wiki/` in this repo (normal PR review) and
  mirrored to the GitHub wiki repo via a new sync script, preserving this
  repo's commit-gate/review discipline instead of editing the wiki directly.
- README.md/INSTALL.md content migrates into the wiki (Wave 4) rather than
  being duplicated.
- Cast-review + voice-design pages are sequenced last (Wave 3) since `fe-46`
  (#1262) is landing in parallel and changes that flow.

Refs #1276

## Test plan

- [ ] N/A — spec-only change, no runtime surface. Doc-only PR fast-path
      applies (no `npm run verify` required); mandatory code-review gate is
      also exempt per the doc-only carve-out.