### PR TITLE
chore(scripts): wiki sync script + scaffold (Wave 0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,8 @@ server/roster.json
 # Self-contained HTML artifacts rendered by the html-artifacts skill (plans,
 # reports, mockups). Local scratch output, never committed.
 artifacts/
+
+# Local clone of the separate Castwright.wiki.git repo, used by
+# scripts/sync-wiki.mjs as its push staging area. Recreated fresh on every
+# `npm run wiki:sync` run; never committed.
+.wiki-sync-cache/

--- a/docs/wiki/.image-path-convention
+++ b/docs/wiki/.image-path-convention
@@ -1,0 +1,1 @@
+relative

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,8 @@
+# Castwright
+
+Any book, performed by a full cast — effortlessly.
+
+This wiki is the user guide: install, upload a book, cast it, generate
+audio, listen, export. See the sidebar for every page.
+
+- Release notes: see [RELEASE_NOTES.md](https://github.com/dudarenok-maker/Castwright/blob/main/RELEASE_NOTES.md)

--- a/docs/wiki/_Footer.md
+++ b/docs/wiki/_Footer.md
@@ -1,0 +1,2 @@
+---
+[Castwright](https://castwright.ai) · [GitHub](https://github.com/dudarenok-maker/Castwright) · [Release Notes](https://github.com/dudarenok-maker/Castwright/blob/main/RELEASE_NOTES.md)

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,0 +1,26 @@
+### Core journey
+- [Home](Home)
+- [Getting Started](Getting-Started)
+- [Installing Castwright](Installing-Castwright)
+- [Uploading a Book](Uploading-a-Book)
+- [Analysis & the Analyzer](Analysis-and-the-Analyzer)
+- [Reviewing Low-Confidence Speaker Tags](Reviewing-Low-Confidence-Speaker-Tags)
+- [Generating Audio](Generating-Audio)
+- [The Quality Gate](The-Quality-Gate)
+- [Listening & Revising](Listening-and-Revising)
+- [Exporting](Exporting)
+
+### Cast & Voices
+- [Reviewing Cast & Assigning Voices](Reviewing-Cast-and-Assigning-Voices)
+- [Designing a Voice](Designing-a-Voice)
+
+### Full breadth
+- [Voice Engines](Voice-Engines)
+- [The Model Control Pill](The-Model-Control-Pill)
+- [Library Management](Library-Management)
+- [Mobile, Tablet & Companion App](Mobile-Tablet-and-Companion-App)
+- [Admin & Model Manager](Admin-and-Model-Manager)
+- [Advanced Settings](Advanced-Settings)
+- [Account & Settings](Account-and-Settings)
+- [Multi-language Support](Multi-language-Support)
+- [Troubleshooting](Troubleshooting)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "install:cert-mobile": "node scripts/print-cert-install-instructions.mjs",
     "tts:sidecar": "node scripts/launch-sidecar.mjs",
     "apk:companion": "node scripts/build-companion-apk.mjs",
+    "wiki:sync": "node scripts/sync-wiki.mjs",
     "prebuild": "node scripts/sync-docs-to-public.mjs",
     "build": "tsc -b && vite build && npm --prefix server run build",
     "preview": "vite preview",

--- a/scripts/sync-wiki.mjs
+++ b/scripts/sync-wiki.mjs
@@ -6,7 +6,7 @@
 //
 // Run manually after a merge to main touches docs/wiki/**.
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, cpSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, cpSync, rmSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -16,6 +16,15 @@ const WIKI_REMOTE = 'https://github.com/dudarenok-maker/Castwright.wiki.git';
 export function copyWikiTree(srcDir, destDir) {
   if (!existsSync(srcDir)) {
     throw new Error(`sync-wiki: source directory not found: ${srcDir}`);
+  }
+  // Mirror, not overlay: clear any pre-existing dest entries (e.g. from a
+  // freshly-cloned wiki repo) other than .git, so a page/image deleted from
+  // srcDir actually disappears from destDir instead of lingering forever.
+  if (existsSync(destDir)) {
+    for (const entry of readdirSync(destDir)) {
+      if (entry === '.git') continue;
+      rmSync(path.join(destDir, entry), { recursive: true, force: true });
+    }
   }
   cpSync(srcDir, destDir, {
     recursive: true,

--- a/scripts/sync-wiki.mjs
+++ b/scripts/sync-wiki.mjs
@@ -1,0 +1,76 @@
+// Mirrors docs/wiki/* into the separate Castwright.wiki.git repo. GitHub
+// wikis have no PR review/CI/branch protection, so the source of truth
+// lives here and this script is the one-way publish step.
+//
+//   npm run wiki:sync
+//
+// Run manually after a merge to main touches docs/wiki/**.
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, cpSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const WIKI_REMOTE = 'https://github.com/dudarenok-maker/Castwright.wiki.git';
+
+export function copyWikiTree(srcDir, destDir) {
+  if (!existsSync(srcDir)) {
+    throw new Error(`sync-wiki: source directory not found: ${srcDir}`);
+  }
+  cpSync(srcDir, destDir, {
+    recursive: true,
+    filter: (source) => path.basename(source) !== '.git',
+  });
+}
+
+export function buildCommitMessage(sourceSha) {
+  return `sync wiki from Castwright@${sourceSha}`;
+}
+
+function run(cmd, args, cwd) {
+  const result = spawnSync(cmd, args, { cwd, encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(`sync-wiki: ${cmd} ${args.join(' ')} failed: ${result.stderr}`);
+  }
+  return result.stdout;
+}
+
+function getSourceSha() {
+  return run('git', ['rev-parse', '--short', 'HEAD'], REPO_ROOT).trim();
+}
+
+// A GitHub wiki's git repo does not exist until at least one page exists —
+// enabling has_wiki alone doesn't create it, so clone fails on a
+// never-touched wiki and we bootstrap it instead.
+function cloneOrInitWikiRepo(cacheDir) {
+  rmSync(cacheDir, { recursive: true, force: true });
+  const clone = spawnSync('git', ['clone', WIKI_REMOTE, cacheDir], { encoding: 'utf8' });
+  if (clone.status === 0) return { fresh: false };
+
+  mkdirSync(cacheDir, { recursive: true });
+  run('git', ['init'], cacheDir);
+  run('git', ['remote', 'add', 'origin', WIKI_REMOTE], cacheDir);
+  return { fresh: true };
+}
+
+async function main() {
+  const cacheDir = path.join(REPO_ROOT, '.wiki-sync-cache');
+  const srcDir = path.join(REPO_ROOT, 'docs', 'wiki');
+
+  const { fresh } = cloneOrInitWikiRepo(cacheDir);
+  copyWikiTree(srcDir, cacheDir);
+
+  run('git', ['add', '-A'], cacheDir);
+  const sha = getSourceSha();
+  run('git', ['commit', '-m', buildCommitMessage(sha), '--allow-empty'], cacheDir);
+  run('git', fresh ? ['push', '-u', 'origin', 'HEAD:master'] : ['push'], cacheDir);
+
+  process.stdout.write(`sync-wiki: pushed docs/wiki -> ${WIKI_REMOTE}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    process.stderr.write(`${err.message}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/tests/sync-wiki.test.mjs
+++ b/scripts/tests/sync-wiki.test.mjs
@@ -29,6 +29,29 @@ test('copyWikiTree copies markdown and images, excluding .git', () => {
   }
 });
 
+test('copyWikiTree mirrors: removes stale dest files no longer in source, preserves .git', () => {
+  const src = mkdtempSync(path.join(tmpdir(), 'wiki-src-'));
+  const dest = mkdtempSync(path.join(tmpdir(), 'wiki-dest-'));
+  try {
+    writeFileSync(path.join(src, 'Home.md'), '# Home');
+
+    // Simulate a freshly-cloned wiki repo: a page that no longer exists in
+    // srcDir (deleted locally) plus a .git dir that must survive the sync.
+    writeFileSync(path.join(dest, 'Stale.md'), 'stale page');
+    mkdirSync(path.join(dest, '.git'), { recursive: true });
+    writeFileSync(path.join(dest, '.git', 'HEAD'), 'ref: refs/heads/master');
+
+    copyWikiTree(src, dest);
+
+    assert.equal(existsSync(path.join(dest, 'Stale.md')), false);
+    assert.equal(readFileSync(path.join(dest, '.git', 'HEAD'), 'utf8'), 'ref: refs/heads/master');
+    assert.equal(readFileSync(path.join(dest, 'Home.md'), 'utf8'), '# Home');
+  } finally {
+    rmSync(src, { recursive: true, force: true });
+    rmSync(dest, { recursive: true, force: true });
+  }
+});
+
 test('copyWikiTree throws when the source directory is missing', () => {
   const dest = mkdtempSync(path.join(tmpdir(), 'wiki-dest-'));
   try {

--- a/scripts/tests/sync-wiki.test.mjs
+++ b/scripts/tests/sync-wiki.test.mjs
@@ -1,0 +1,46 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { copyWikiTree, buildCommitMessage } from '../sync-wiki.mjs';
+
+test('copyWikiTree copies markdown and images, excluding .git', () => {
+  const src = mkdtempSync(path.join(tmpdir(), 'wiki-src-'));
+  const dest = mkdtempSync(path.join(tmpdir(), 'wiki-dest-'));
+  try {
+    writeFileSync(path.join(src, 'Home.md'), '# Home');
+    mkdirSync(path.join(src, 'images', 'home'), { recursive: true });
+    writeFileSync(path.join(src, 'images', 'home', '01-test.png'), 'fake-png');
+    mkdirSync(path.join(src, '.git'), { recursive: true });
+    writeFileSync(path.join(src, '.git', 'HEAD'), 'ref: refs/heads/master');
+
+    copyWikiTree(src, dest);
+
+    assert.equal(readFileSync(path.join(dest, 'Home.md'), 'utf8'), '# Home');
+    assert.equal(
+      readFileSync(path.join(dest, 'images', 'home', '01-test.png'), 'utf8'),
+      'fake-png',
+    );
+    assert.equal(existsSync(path.join(dest, '.git')), false);
+  } finally {
+    rmSync(src, { recursive: true, force: true });
+    rmSync(dest, { recursive: true, force: true });
+  }
+});
+
+test('copyWikiTree throws when the source directory is missing', () => {
+  const dest = mkdtempSync(path.join(tmpdir(), 'wiki-dest-'));
+  try {
+    assert.throws(
+      () => copyWikiTree(path.join(dest, 'does-not-exist'), dest),
+      /source directory not found/,
+    );
+  } finally {
+    rmSync(dest, { recursive: true, force: true });
+  }
+});
+
+test('buildCommitMessage embeds the short source SHA', () => {
+  assert.equal(buildCommitMessage('abc1234'), 'sync wiki from Castwright@abc1234');
+});


### PR DESCRIPTION
## Summary
- Adds scripts/sync-wiki.mjs + test, mirroring docs/wiki/* to the GitHub wiki repo.
- Enables the repo wiki setting and scaffolds Home/_Sidebar/_Footer.
- Runs the dual-render spike; records the result in docs/wiki/.image-path-convention for every later content task to read.
- Fixes a bug found during the spike: copyWikiTree only overlaid files via cpSync, so a page/image deleted from docs/wiki lingered in the wiki repo after a re-sync. It now mirrors (clears the destination, preserving .git, before copying), with a regression test.

Refs #1276

## Test plan
- [x] node --test scripts/tests/sync-wiki.test.mjs passes (4 tests, incl. the new mirror-deletion regression case)
- [x] npm run wiki:sync pushes and the live wiki shows Home/Sidebar/Footer
- [x] Spike page confirmed image render behavior (relative path, verified via network status 200 + naturalWidth/Height in-browser); spike deleted before merge and confirmed gone from the live wiki; outcome recorded in .image-path-convention