### PR TITLE
fix(openapi): match QueueEnqueueRequest schema to real entries[] shape

### DIFF
--- a/docs/release-notes-next.md
+++ b/docs/release-notes-next.md
@@ -50,3 +50,4 @@ time. The previous release's body shipped with the v1.10.0 tag annotation.
 ## 🔧 Reliability
 
 - **Title-narration synth call now wrapped in per-call timeout** (#1247, srv-51) — matches the defensive timeout protection added to every other synth call site, closing a gap where a wedged title narration could stall a chapter. No user-visible change under normal operation; defensive only.
+- **`openapi.yaml`'s `QueueEnqueueRequest` now matches the real `/api/queue/enqueue` request shape** (#1264, srv-55) — was documented as `{ bookId, chapterIds[] }`; the route actually takes a per-entry `entries[]` array (new `QueueEnqueueEntry` schema: `id`, `bookId`, `chapterId`, `scope`, optional `characterId`/`modelKey`/`addedAt`/`fallbackConfirmed`). `src/lib/api-types.ts` regenerated to match. Docs/contract fix only — no runtime behaviour change.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3882,20 +3882,50 @@ components:
 
     QueueEnqueueRequest:
       type: object
-      required: [bookId, chapterIds]
+      required: [entries]
       properties:
-        bookId: { type: string }
-        chapterIds:
+        entries:
           type: array
-          items: { type: integer }
-          description: One or more chapter ids to enqueue. The frontend pre-expands `forward` scope into per-chapter ids before posting.
+          minItems: 1
+          items: { $ref: '#/components/schemas/QueueEnqueueEntry' }
+          description: One or more entries to enqueue. The frontend pre-expands `scope:'forward'` (regenerate chapter N + all subsequent) into per-chapter entries before posting.
+
+    QueueEnqueueEntry:
+      type: object
+      required: [id, bookId, chapterId, scope]
+      properties:
+        id:
+          type: string
+          description: Frontend-minted unique entry id (kept deterministic in tests; a crypto.randomUUID()-based id in production) — lets the broadcast layer correlate ticks to entries without a server-issued id round-trip.
+        bookId: { type: string }
+        chapterId: { type: integer }
         scope:
           type: string
           enum: [this, character]
-          default: this
+          description: |
+            `this` = (re)generate the named chapter. `character` = regenerate
+            the named character's lines in this chapter only.
         characterId:
           type: string
           description: Required when scope === 'character'.
+        modelKey:
+          type: string
+          enum: [kokoro-v1, qwen3-tts-0.6b, qwen3-tts-1.7b, coqui-xtts-v2, gemini-2.5-flash, gemini-3.1-flash]
+          description: |
+            Optional per-entry TTS model override (e.g. a regenerate that should
+            run at the Qwen 1.7B quality tier instead of the session default).
+            When absent the dispatcher uses the global `ui.ttsModelKey`.
+        addedAt:
+          type: string
+          format: date-time
+          description: Optional ISO 8601 timestamp; server defaults to now() when omitted.
+        fallbackConfirmed:
+          type: boolean
+          description: |
+            Optional — true when the caller already confirmed this entry's
+            Qwen→Kokoro fallback (e.g. the voice-readiness gate's "proceed
+            anyway"), so the per-chapter `awaiting_confirm` gate doesn't
+            re-prompt for it.
 
     QueueReorderRequest:
       type: object

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -2993,16 +2993,41 @@ export interface components {
             recycling: boolean;
         };
         QueueEnqueueRequest: {
+            /** @description One or more entries to enqueue. The frontend pre-expands `scope:'forward'` (regenerate chapter N + all subsequent) into per-chapter entries before posting. */
+            entries: components["schemas"]["QueueEnqueueEntry"][];
+        };
+        QueueEnqueueEntry: {
+            /** @description Frontend-minted unique entry id (kept deterministic in tests; a crypto.randomUUID()-based id in production) — lets the broadcast layer correlate ticks to entries without a server-issued id round-trip. */
+            id: string;
             bookId: string;
-            /** @description One or more chapter ids to enqueue. The frontend pre-expands `forward` scope into per-chapter ids before posting. */
-            chapterIds: number[];
+            chapterId: number;
             /**
-             * @default this
+             * @description `this` = (re)generate the named chapter. `character` = regenerate
+             *     the named character's lines in this chapter only.
              * @enum {string}
              */
             scope: "this" | "character";
             /** @description Required when scope === 'character'. */
             characterId?: string;
+            /**
+             * @description Optional per-entry TTS model override (e.g. a regenerate that should
+             *     run at the Qwen 1.7B quality tier instead of the session default).
+             *     When absent the dispatcher uses the global `ui.ttsModelKey`.
+             * @enum {string}
+             */
+            modelKey?: "kokoro-v1" | "qwen3-tts-0.6b" | "qwen3-tts-1.7b" | "coqui-xtts-v2" | "gemini-2.5-flash" | "gemini-3.1-flash";
+            /**
+             * Format: date-time
+             * @description Optional ISO 8601 timestamp; server defaults to now() when omitted.
+             */
+            addedAt?: string;
+            /**
+             * @description Optional — true when the caller already confirmed this entry's
+             *     Qwen→Kokoro fallback (e.g. the voice-readiness gate's "proceed
+             *     anyway"), so the per-chapter `awaiting_confirm` gate doesn't
+             *     re-prompt for it.
+             */
+            fallbackConfirmed?: boolean;
         };
         QueueReorderRequest: {
             /** @description Full list of entry ids in the desired final order. Server validates the list matches the current queue minus the in-flight pinned entry; mismatch returns 409 (concurrent enqueue happened; client refetches and retries). */


### PR DESCRIPTION
## Summary

- `openapi.yaml`'s `QueueEnqueueRequest` documented `POST /api/queue/enqueue` as `{ bookId, chapterIds[] }`, but the route (`server/src/routes/queue.ts`) actually takes a per-entry `entries[]` array.
- Replaced it with `{ entries: QueueEnqueueEntry[] }` and added the `QueueEnqueueEntry` schema (`id`, `bookId`, `chapterId`, `scope`, optional `characterId`/`modelKey`/`addedAt`/`fallbackConfirmed`), matching `EnqueueRequestEntry` exactly.
- Regenerated `src/lib/api-types.ts` via `npm run openapi:types`. No client code referenced the stale `QueueEnqueueRequest` shape, so no other files needed changes.
- Docs/contract fix only — no runtime behaviour change. Added a technical-register line to `docs/release-notes-next.md`; skipped the user-facing `RELEASE_NOTES.md` since this has no user- or operator-visible effect (internal API-contract chore).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test:fast` (frontend 275 files/3511 tests + server 345 files/4019 tests) — all pass
- [x] `npx eslint . --max-warnings 0` — clean
- [x] `npm run verify` (pre-push hook, full battery incl. e2e + e2e:visual + build) — green

Closes #1264

🤖 Generated with [Claude Code](https://claude.com/claude-code)