### PR TITLE
fix(frontend): memoize remaining unmemoized selectors found in #1308 audit

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -887,7 +887,7 @@ function ListenRoute({ bookId }: { bookId: string }) {
   const characters = useAppSelector((s) => s.cast.characters);
   const voices = useAppSelector((s) => s.voices.voices);
   const currentTrack = useAppSelector((s) => s.ui.currentTrack);
-  const bookMeta = useAppSelector(selectEffectiveMeta(bookId));
+  const bookMeta = useAppSelector((s) => selectEffectiveMeta(s, bookId));
   const isDirty = useAppSelector(selectIsDirty);
   const coverGradient = useAppSelector(
     (s) => s.library.books.find((b) => b.bookId === bookId)?.coverGradient ?? null,

--- a/src/store/book-meta-slice.test.ts
+++ b/src/store/book-meta-slice.test.ts
@@ -156,12 +156,12 @@ describe('selectors', () => {
     ({ bookMeta: sliceState }) as unknown as RootState;
 
   it('selectEffectiveMeta returns null when no saved baseline', () => {
-    expect(selectEffectiveMeta('ns')(baseState(initial()))).toBeNull();
+    expect(selectEffectiveMeta(baseState(initial()), 'ns')).toBeNull();
   });
 
   it('selectEffectiveMeta returns saved snapshot when draft is empty', () => {
     const s = baseState({ draft: null, saved: { ns: fullMeta() }, prosodyEnabled: {} });
-    expect(selectEffectiveMeta('ns')(s)).toEqual(fullMeta());
+    expect(selectEffectiveMeta(s, 'ns')).toEqual(fullMeta());
   });
 
   it('selectEffectiveMeta overlays the draft on top of saved for live preview', () => {
@@ -170,7 +170,16 @@ describe('selectors', () => {
       saved: { ns: fullMeta() },
       prosodyEnabled: {},
     });
-    expect(selectEffectiveMeta('ns')(s)).toEqual(fullMeta({ title: 'Live Edit', genre: null }));
+    expect(selectEffectiveMeta(s, 'ns')).toEqual(fullMeta({ title: 'Live Edit', genre: null }));
+  });
+
+  it('selectEffectiveMeta returns a stable reference across calls with an unchanged draft (#1308)', () => {
+    const s = baseState({
+      draft: { title: 'Live Edit' },
+      saved: { ns: fullMeta() },
+      prosodyEnabled: {},
+    });
+    expect(selectEffectiveMeta(s, 'ns')).toBe(selectEffectiveMeta(s, 'ns'));
   });
 
   it('selectIsDirty is false on a pristine slice', () => {

--- a/src/store/book-meta-slice.ts
+++ b/src/store/book-meta-slice.ts
@@ -15,7 +15,7 @@
    disk — the persistence-middleware watches that action and PUTs a single
    `state` slice patch containing all six fields. */
 
-import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import type { BookStateJson } from '../lib/types';
 import type { RootState } from './index';
 
@@ -147,16 +147,26 @@ export const bookMetaReducer = bookMetaSlice.reducer;
 
 /** Resolves the currently-displayed metadata for a book by overlaying any
     in-flight draft on top of the saved snapshot. Returns null if the book
-    has not been hydrated. */
-export const selectEffectiveMeta =
-  (bookId: string | null) =>
-  (s: RootState): EditableBookMeta | null => {
-    if (!bookId) return null;
-    const saved = s.bookMeta.saved[bookId];
+    has not been hydrated.
+
+    Memoised via createSelector, mirroring `selectDriftForBook` (#1308) — an
+    unmemoized `{ ...saved, ...draft }` allocates a fresh object on every call
+    while a draft is in flight (i.e. while the user is actively editing),
+    which react-redux's dev-mode stability check flags as "returned a
+    different result when called with the same parameters" and forces
+    `ListenRoute` (this selector's caller) to re-render on every store
+    dispatch during that editing session, not just meta-relevant ones. */
+export const selectEffectiveMeta = createSelector(
+  [
+    (s: RootState, bookId: string | null) => (bookId ? s.bookMeta.saved[bookId] : undefined),
+    (s: RootState) => s.bookMeta.draft,
+  ],
+  (saved, draft): EditableBookMeta | null => {
     if (!saved) return null;
-    if (!s.bookMeta.draft || Object.keys(s.bookMeta.draft).length === 0) return saved;
-    return { ...saved, ...s.bookMeta.draft };
-  };
+    if (!draft || Object.keys(draft).length === 0) return saved;
+    return { ...saved, ...draft };
+  },
+);
 
 /** True when the user has made any unsaved edits. */
 export const selectIsDirty = (s: RootState): boolean =>

--- a/src/store/cast-slice.test.ts
+++ b/src/store/cast-slice.test.ts
@@ -1,7 +1,7 @@
 // Pairs with docs/features/archive/09-voice-match-pipeline.md
 
 import { describe, expect, it } from 'vitest';
-import { castSlice, castActions } from './cast-slice';
+import { castSlice, castActions, selectCastTierByCharacterId } from './cast-slice';
 import type { AnalyseResponse, Character, VoiceMatchResponse } from '../lib/types';
 
 const makeChar = (id: string, overrides: Partial<Character> = {}): Character => ({
@@ -1009,5 +1009,24 @@ describe('castSlice — removeCharacterEmotionVariant (fs-34)', () => {
       castActions.removeCharacterEmotionVariant({ characterId: 'maerin', emotion: 'excited' }),
     );
     expect(Object.keys(absent.characters[0].overrideTtsVoices!.qwen!.variants!)).toHaveLength(2);
+  });
+});
+
+describe('selectCastTierByCharacterId (#1308)', () => {
+  it('maps characterId to its pinned ttsModelKey', () => {
+    const s = {
+      cast: baseState([
+        makeChar('marlow', { ttsModelKey: 'qwen3-tts-0.6b' } as Partial<Character>),
+        makeChar('oduvan', { ttsModelKey: 'kokoro-v1' } as Partial<Character>),
+      ]),
+    };
+    const tiers = selectCastTierByCharacterId(s);
+    expect(tiers.get('marlow')).toBe('qwen3-tts-0.6b');
+    expect(tiers.get('oduvan')).toBe('kokoro-v1');
+  });
+
+  it('returns a stable reference across calls with an unchanged characters array', () => {
+    const s = { cast: baseState([makeChar('marlow')]) };
+    expect(selectCastTierByCharacterId(s)).toBe(selectCastTierByCharacterId(s));
   });
 });

--- a/src/store/cast-slice.ts
+++ b/src/store/cast-slice.ts
@@ -1,6 +1,6 @@
 /* Cast slice — characters + their voice assignments. */
 
-import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import type { Character, AnalyseResponse, VoiceMatchResponse } from '../lib/types';
 
 /* Union two alias lists (case-insensitive dedup, original casing, first-seen
@@ -470,3 +470,22 @@ export const castSlice = createSlice({
 });
 
 export const castActions = castSlice.actions;
+
+interface CastRootShape {
+  cast: CastState;
+}
+
+const selectCastCharacters = (s: CastRootShape): Character[] => s.cast.characters;
+
+/** characterId → its currently-pinned `ttsModelKey`, for the roster badge.
+    Memoised on the `characters` reference — an unmemoized `new Map(...)`
+    allocates a fresh Map on every call even when nothing changed, which
+    react-redux's dev-mode stability check flags as "returned a different
+    result when called with the same parameters" and forces the (large,
+    frequently-mounted) Cast view to re-render on every store dispatch, not
+    just cast-relevant ones (#1308). */
+export const selectCastTierByCharacterId = createSelector(
+  [selectCastCharacters],
+  (characters): Map<string, Character['ttsModelKey']> =>
+    new Map(characters.map((c) => [c.id, c.ttsModelKey])),
+);

--- a/src/store/queue-slice.test.ts
+++ b/src/store/queue-slice.test.ts
@@ -301,4 +301,19 @@ describe('active-generation selectors', () => {
     expect(selectActiveGenerationView(s)).toBeNull();
     expect(selectGenerationActivityCount(s)).toBe(0);
   });
+
+  it('returns a stable reference across calls with unchanged queue entries + chapters state (#1308)', () => {
+    const s = {
+      queue: emptyQueue,
+      chapters: chaptersState({
+        activeStream: stream({ done: 2, total: 5, inProgress: 1 }),
+        currentBookId: 'book-A',
+        chapters: [
+          { id: 1, state: 'in_progress' },
+          { id: 2, state: 'queued' },
+        ],
+      }),
+    };
+    expect(selectActiveGenerationView(s)).toBe(selectActiveGenerationView(s));
+  });
 });

--- a/src/store/queue-slice.ts
+++ b/src/store/queue-slice.ts
@@ -186,44 +186,54 @@ export interface ActiveGenerationView {
 /** A view of the in-flight generation run when the workspace queue has no
     real entries to show. Returns `null` when there ARE real entries (the real
     queue always wins) or when no stream is live. Same-book streams carry the
-    per-chapter rows; cross-book streams carry only the done/total summary. */
-export const selectActiveGenerationView = (
-  s: ActiveGenerationRootShape,
-): ActiveGenerationView | null => {
-  if (s.queue.entries.length > 0) return null;
-  const chapters = s.chapters;
-  if (!chapters) return null;
-  /* Prefer the stream for the currently-viewed book (so the overlay lists its
-     rows); else any open stream. With one stream this is exactly the prior
-     single-snapshot behaviour. */
-  const streams = Object.values(chapters.activeStreams);
-  const active =
-    (chapters.currentBookId ? chapters.activeStreams[chapters.currentBookId] : undefined) ??
-    streams[0] ??
-    null;
-  if (!active) return null;
-  const sameBook = chapters.currentBookId === active.bookId;
-  /* Excluded chapters never queue or synthesise — mirror the filter in the
-     runner's snapshotFromChapters + middleware hasWork so the row count agrees
-     with the pill's done/total. */
-  const rows: ActiveGenerationChapterRow[] | null = sameBook
-    ? chapters.chapters
-        .filter(
-          (c) =>
-            !c.excluded &&
-            !c.held &&
-            (c.state === 'in_progress' || c.state === 'queued'),
-        )
-        .map((c) => ({ id: c.id, state: c.state as 'in_progress' | 'queued' }))
-    : null;
-  return {
-    bookId: active.bookId,
-    done: active.done,
-    total: active.total,
-    inProgress: active.inProgress,
-    chapters: rows,
-  };
-};
+    per-chapter rows; cross-book streams carry only the done/total summary.
+
+    Memoised via createSelector (#1308) — an unmemoized version rebuilds the
+    `rows` array and the returned object literal on every call even when
+    nothing changed, which react-redux's dev-mode stability check flags as
+    "returned a different result when called with the same parameters" and
+    forces the queue modal to re-render on every store dispatch, not just
+    generation-relevant ones (the same defect class as #1284/#1285). */
+export const selectActiveGenerationView = createSelector(
+  [
+    (s: ActiveGenerationRootShape) => s.queue.entries,
+    (s: ActiveGenerationRootShape) => s.chapters?.activeStreams,
+    (s: ActiveGenerationRootShape) => s.chapters?.currentBookId,
+    (s: ActiveGenerationRootShape) => s.chapters?.chapters,
+  ],
+  (entries, activeStreams, currentBookId, chapterRows): ActiveGenerationView | null => {
+    if (entries.length > 0) return null;
+    if (!activeStreams || !chapterRows) return null;
+    /* Prefer the stream for the currently-viewed book (so the overlay lists
+       its rows); else any open stream. With one stream this is exactly the
+       prior single-snapshot behaviour. */
+    const streams = Object.values(activeStreams);
+    const active =
+      (currentBookId ? activeStreams[currentBookId] : undefined) ?? streams[0] ?? null;
+    if (!active) return null;
+    const sameBook = currentBookId === active.bookId;
+    /* Excluded chapters never queue or synthesise — mirror the filter in the
+       runner's snapshotFromChapters + middleware hasWork so the row count agrees
+       with the pill's done/total. */
+    const rows: ActiveGenerationChapterRow[] | null = sameBook
+      ? chapterRows
+          .filter(
+            (c) =>
+              !c.excluded &&
+              !c.held &&
+              (c.state === 'in_progress' || c.state === 'queued'),
+          )
+          .map((c) => ({ id: c.id, state: c.state as 'in_progress' | 'queued' }))
+      : null;
+    return {
+      bookId: active.bookId,
+      done: active.done,
+      total: active.total,
+      inProgress: active.inProgress,
+      chapters: rows,
+    };
+  },
+);
 
 /** Count for the "Queue · N" chip + "View queue · N" button. Real queue entries
     win; otherwise reflect the live run so the chip doesn't read 0 / disappear

--- a/src/views/cast.tsx
+++ b/src/views/cast.tsx
@@ -39,7 +39,7 @@ import type {
 } from '../lib/types';
 import { useAppSelector, useAppDispatch } from '../store';
 import { voicesActions } from '../store/voices-slice';
-import { castActions } from '../store/cast-slice';
+import { castActions, selectCastTierByCharacterId } from '../store/cast-slice';
 import { castDesignActions } from '../store/cast-design-slice';
 import { notificationsActions } from '../store/notifications-slice';
 import { bookMetaActions, selectProsodyEnabled } from '../store/book-meta-slice';
@@ -212,9 +212,7 @@ export function CastView({
   /* PR4 — read pinned tiers from the store so the roster badge updates live
      after dispatch(castActions.updateCharacter). The store is the single
      source of truth for ttsModelKey after a bulk pin or reset. */
-  const storedTiers = useAppSelector(
-    (s) => new Map(s.cast.characters.map((c) => [c.id, c.ttsModelKey])),
-  );
+  const storedTiers = useAppSelector(selectCastTierByCharacterId);
   const dispatch = useAppDispatch();
   const playback = useSamplePlayback();
   /* Tier-2b diminutive merge-suggestions — fetched once when the book is ready,


### PR DESCRIPTION
## Summary
Follow-up sweep to PR #1301, which fixed 3 confirmed instances of the same defect class: an unmemoized selector (or inline `useSelector` callback) that allocates a fresh array/object on every call even when the underlying state hasn't changed — react-redux's dev-mode stability check flags this as "returned a different result when called with the same parameters," forcing the calling component to re-render on every store dispatch, not just relevant ones.

Swept every exported `select*` in `src/store/*.ts` (~40 across 15 files) plus every inline `useAppSelector((s) => ...)` body ending in `.filter(`/`.map(`/`.sort(`/`?? []`/`?? {}` across `src/`.

**Fixed (3 real offenders):**
- `queue-slice.ts` `selectActiveGenerationView` — built a fresh `rows` array + object literal every call; used directly by the queue modal (same component class as the #1285 crash). Converted to `createSelector`.
- `cast-slice.ts` new `selectCastTierByCharacterId` replaces an inline `new Map(s.cast.characters.map(...))` in the Cast view that allocated a fresh Map every render.
- `book-meta-slice.ts` `selectEffectiveMeta` allocated a fresh `{ ...saved, ...draft }` object on every call while a draft was in flight, forcing `ListenRoute` to re-render on every unrelated dispatch during active editing. Converted from a curried `(bookId) => (state) => ...` factory (which can't be meaningfully memoized) to the two-arg `createSelector` shape already used by `selectDriftForBook`; updated its one call site and 3 existing unit tests.

**Checked and left as-is (8, with reasoning per selector in the commit body):** `selectActiveStreams` (paired with `useAppSelectorShallow`), several plain lookups/`.find()`s that return existing references or stable constants, `selectContinueListening` (already uses the `EMPTY_ITEMS` pattern), a couple of test-harness-only defensive fallbacks that never fire in production, and `selectPresentLanguages` (already wrapped in `useMemo` at its call site).

## Test plan
- [x] New referential-stability tests (`toBe` across two calls with unchanged state) for every selector newly memoized.
- [x] Full frontend Vitest suite (3525 tests) + typecheck green, verified independently.
- [x] `npm run verify` (typecheck + all tests + e2e + build) green via pre-push hook.

No user-visible behavior change (fewer wasted re-renders only) — release notes intentionally skipped per the before-shipping checklist's no-shippable-delta carve-out.

Closes #1308