### PR TITLE
docs(docs): add backlog rows for PR #1324 follow-ups

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -391,6 +391,18 @@ _Full detail + acceptance:_ plan [222](features/222-gpu-residency-and-analysing-
 - _Benefit (technical):_ keeps the sidecar's engine stack current and CVE-clear once the bumps are validated against real model output, without risking the TTS pipeline on a blind bump.
 _Full detail + acceptance:_ [#893](https://github.com/dudarenok-maker/Castwright/issues/893).
 
+#### `side-24` — Verify Coqui XTTS v2 inference on real Apple Silicon hardware (MPS) ([#1326](https://github.com/dudarenok-maker/Castwright/issues/1326))
+
+- _What:_ PR #1324 fixed Coqui's `auto` device resolution to pick up MPS on Apple Silicon (matching Qwen's existing resolver). Automated tests only confirm the device STRING resolves to `mps`, not that XTTS v2 inference actually produces correct audio there — `.to("mps")` not throwing is a different claim, and XTTS has a documented history of unimplemented MPS ops.
+- _Benefit (technical):_ closes the one open verification gap from PR #1324 before relying on the MPS path in production; `COQUI_DEVICE=cpu` stays available as an explicit rollback if inference proves broken.
+_Full detail + acceptance:_ [#1326](https://github.com/dudarenok-maker/Castwright/issues/1326).
+
+#### `srv-56` — Centralize the off-GPU semaphore-gating idiom + shared engine-list constant ([#1327](https://github.com/dudarenok-maker/Castwright/issues/1327))
+
+- _What:_ PR #1324's device-aware GPU semaphore gating duplicated the same "skip acquire when off-GPU" idiom across 3 new call sites, on top of 3 pre-existing, differently-shaped copies elsewhere — and duplicated a 3-element engine-list constant between `engine-device-state.ts` and `sidecar-health.ts`. A code review flagged both as real but non-blocking (fixing them in #1324 would have expanded that PR into unrelated files).
+- _Benefit (technical):_ a shared helper would have caught (rather than merely fixed after the fact) the exact "qwen-voice.ts's acquire left ungated" mistake PR #1324's own adversarial review needed to catch by hand; removes a duplicated constant two files must otherwise keep in sync by convention alone.
+_Full detail + acceptance:_ [#1327](https://github.com/dudarenok-maker/Castwright/issues/1327).
+
 #### `side-21` — FA2: fix the stale pin + conditional auto-enable on the real stack ([#1000](https://github.com/dudarenok-maker/Castwright/issues/1000))
 
 - _What:_ `install-qwen3.mjs` pins a cp311/torch2.6/cu124 FlashAttention-2 wheel, but the venv is **cp312/torch2.11/cu128** — so FA2 silently skips (SDPA in use). Fix the gate to the real stack; auto-install+activate only when a matching wheel exists; SDPA fallback otherwise. Do NOT downgrade torch for FA2 (modest win on short TTS decode).


### PR DESCRIPTION
## Summary
- Adds `side-24` and `srv-56` rows to `docs/BACKLOG.md`'s Could section
  (Reliability & observability), tracking two non-blocking follow-ups
  surfaced by PR #1324's mandatory code review so they aren't lost:
  - `side-24` (#1326): verify Coqui XTTS v2 actually produces correct audio
    on real Apple Silicon MPS hardware (automated tests only confirm the
    device string resolves correctly).
  - `srv-56` (#1327): centralize the off-GPU semaphore-gating idiom
    (duplicated across 6 call sites) and a duplicated engine-list constant.

Docs-only change, no code/behavior change.

## Test plan
- [x] Docs-only — no automated test surface.

Refs #1326
Refs #1327