### PR TITLE
refactor(server): centralize off-GPU semaphore-gating idiom + shared engine list

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -397,12 +397,6 @@ _Full detail + acceptance:_ [#893](https://github.com/dudarenok-maker/Castwright
 - _Benefit (technical):_ closes the one open verification gap from PR #1324 before relying on the MPS path in production; `COQUI_DEVICE=cpu` stays available as an explicit rollback if inference proves broken.
 _Full detail + acceptance:_ [#1326](https://github.com/dudarenok-maker/Castwright/issues/1326).
 
-#### `srv-56` — Centralize the off-GPU semaphore-gating idiom + shared engine-list constant ([#1327](https://github.com/dudarenok-maker/Castwright/issues/1327))
-
-- _What:_ PR #1324's device-aware GPU semaphore gating duplicated the same "skip acquire when off-GPU" idiom across 3 new call sites, on top of 3 pre-existing, differently-shaped copies elsewhere — and duplicated a 3-element engine-list constant between `engine-device-state.ts` and `sidecar-health.ts`. A code review flagged both as real but non-blocking (fixing them in #1324 would have expanded that PR into unrelated files).
-- _Benefit (technical):_ a shared helper would have caught (rather than merely fixed after the fact) the exact "qwen-voice.ts's acquire left ungated" mistake PR #1324's own adversarial review needed to catch by hand; removes a duplicated constant two files must otherwise keep in sync by convention alone.
-_Full detail + acceptance:_ [#1327](https://github.com/dudarenok-maker/Castwright/issues/1327).
-
 #### `side-21` — FA2: fix the stale pin + conditional auto-enable on the real stack ([#1000](https://github.com/dudarenok-maker/Castwright/issues/1000))
 
 - _What:_ `install-qwen3.mjs` pins a cp311/torch2.6/cu124 FlashAttention-2 wheel, but the venv is **cp312/torch2.11/cu128** — so FA2 silently skips (SDPA in use). Fix the gate to the real stack; auto-install+activate only when a matching wheel exists; SDPA fallback otherwise. Do NOT downgrade torch for FA2 (modest win on short TTS decode).

--- a/server/src/analyzer/ollama.ts
+++ b/server/src/analyzer/ollama.ts
@@ -15,6 +15,7 @@ import { z } from 'zod';
 import { sampleAndRecordVram } from './model-vram-stats.js';
 import { gpuSemaphore } from '../gpu/semaphore.js';
 import { costForEngine } from '../tts/engine-vram-cost.js';
+import { acquireGpuTokenIfOnGpu } from '../gpu/gpu-semaphore-gate.js';
 import { getResolvedOllamaUrl } from '../workspace/user-settings.js';
 import { configValue } from '../config/resolver.js';
 import type { Accelerator } from '../gpu/vram-state.js';
@@ -730,7 +731,7 @@ export async function generatePersonaViaOllama(
     },
   };
 
-  const release = onCpu ? null : await gpuSemaphore.acquire(costForEngine('analyzer'));
+  const release = await acquireGpuTokenIfOnGpu(!onCpu, costForEngine('analyzer'));
   try {
     let response: Response;
     try {

--- a/server/src/gpu/engine-device-state.ts
+++ b/server/src/gpu/engine-device-state.ts
@@ -8,11 +8,9 @@
    ground truth. */
 
 import type { SidecarDeviceMap } from '../routes/sidecar-health.js';
+import { TRACKED_ENGINES, type TrackedEngine } from './tracked-engines.js';
 
 export type EngineDeviceFamily = 'cuda' | 'rocm' | 'directml' | 'mps' | 'cpu' | 'unknown';
-
-const TRACKED_ENGINES = ['kokoro', 'coqui', 'qwen'] as const;
-type TrackedEngine = (typeof TRACKED_ENGINES)[number];
 
 function emptyState(): Record<TrackedEngine, EngineDeviceFamily> {
   return { kokoro: 'unknown', coqui: 'unknown', qwen: 'unknown' };

--- a/server/src/gpu/gpu-semaphore-gate.test.ts
+++ b/server/src/gpu/gpu-semaphore-gate.test.ts
@@ -1,0 +1,34 @@
+/* Shared off-GPU semaphore-skip idiom (srv-56). Pins the two behaviours every
+   call site relies on: an off-GPU engine never touches the semaphore at all
+   (no token consumed, release is a no-op null), and an on-GPU engine acquires
+   through the given semaphore instance at the given cost. */
+
+import { describe, it, expect } from 'vitest';
+import { GpuSemaphore } from './semaphore.js';
+import { acquireGpuTokenIfOnGpu } from './gpu-semaphore-gate.js';
+
+describe('acquireGpuTokenIfOnGpu', () => {
+  it('skips the semaphore entirely when onGpu is false — no token consumed', async () => {
+    const sem = new GpuSemaphore(1);
+    const release = await acquireGpuTokenIfOnGpu(false, 1, sem);
+    expect(release).toBeNull();
+    expect(sem.usedTokens).toBe(0);
+    // A second off-GPU caller isn't blocked by the first — proves no token was held.
+    const release2 = await acquireGpuTokenIfOnGpu(false, 1, sem);
+    expect(release2).toBeNull();
+  });
+
+  it('acquires through the given semaphore at the given cost when onGpu is true', async () => {
+    const sem = new GpuSemaphore(4);
+    const release = await acquireGpuTokenIfOnGpu(true, 3, sem);
+    expect(release).not.toBeNull();
+    expect(sem.usedTokens).toBe(3);
+    release!();
+    expect(sem.usedTokens).toBe(0);
+  });
+
+  it('defaults to the module-level gpuSemaphore singleton when no instance is passed', async () => {
+    const release = await acquireGpuTokenIfOnGpu(false, 1);
+    expect(release).toBeNull();
+  });
+});

--- a/server/src/gpu/gpu-semaphore-gate.ts
+++ b/server/src/gpu/gpu-semaphore-gate.ts
@@ -1,0 +1,26 @@
+/* Shared "skip the GPU semaphore when off-GPU" idiom (srv-56). Every caller
+   that arbitrates GPU access for an engine that CAN run off-GPU (TTS synth,
+   Qwen voice design, ASR, the speaker embed, the analyzer) needs the exact
+   same shape: acquire a weighted token when the engine is confirmed running
+   on-GPU, skip the semaphore entirely otherwise. A returned cost of 0 would
+   NOT achieve the skip on its own — GpuSemaphore.acquire()'s clampCost floors
+   any cost below 1 back up to 1 — so the call site must branch before
+   acquiring, not just pass a zero cost. Centralized here after PR #1324 added
+   three more copies of this same branch (on top of three pre-existing,
+   differently-shaped ones) and its own review had to catch one of the new
+   copies leaving the acquire ungated by hand. */
+
+import { gpuSemaphore, GpuSemaphore } from './semaphore.js';
+
+/** Acquire a GPU semaphore token only when `onGpu` is true; otherwise skip
+    the semaphore entirely and resolve to `null`. Callers `await` this and
+    invoke the returned release function (if non-null) in a `finally`,
+    exactly like a direct `sem.acquire()` call. `sem` defaults to the
+    module-level singleton — pass an injected instance for tests. */
+export async function acquireGpuTokenIfOnGpu(
+  onGpu: boolean,
+  cost: number,
+  sem: GpuSemaphore = gpuSemaphore,
+): Promise<(() => void) | null> {
+  return onGpu ? await sem.acquire(cost) : null;
+}

--- a/server/src/gpu/tracked-engines.ts
+++ b/server/src/gpu/tracked-engines.ts
@@ -1,0 +1,7 @@
+/* Shared engine-list constant (srv-56) — the three local TTS engines whose
+   runtime device the sidecar reports (side-14) and the server tracks.
+   Centralized so engine-device-state.ts and sidecar-health.ts, which both
+   need this exact list, can't drift out of sync with each other. */
+
+export const TRACKED_ENGINES = ['kokoro', 'coqui', 'qwen'] as const;
+export type TrackedEngine = (typeof TRACKED_ENGINES)[number];

--- a/server/src/routes/qwen-voice.ts
+++ b/server/src/routes/qwen-voice.ts
@@ -38,8 +38,8 @@ import { EMOTIONS, type Emotion } from '../handoff/schemas.js';
 import { getResolvedSidecarUrl } from '../workspace/user-settings.js';
 import { isTtsModelKey, TTS_MODEL_LABELS, type TtsModelKey } from '../tts/index.js';
 import { encodePcmToAudio } from '../tts/mp3.js';
-import { gpuSemaphore } from '../gpu/semaphore.js';
 import { costForEngine } from '../tts/engine-vram-cost.js';
+import { acquireGpuTokenIfOnGpu } from '../gpu/gpu-semaphore-gate.js';
 import { withDesignLock, isDesignBusy } from '../tts/design-lock.js';
 import { buildHintFromCast, toVoiceLike, type CastCharacter } from '../tts/synthesise-chapter.js';
 import { forEachMatchingCastCharacter } from './voices.js';
@@ -330,7 +330,7 @@ export async function designQwenVoiceForCharacter(
        unconditional, still charging a token for VoiceDesign on cpu/mps. */
     const onGpu = engineDeviceIsGpu('qwen');
     return withGpuLoad(async () => {
-      const releaseGpu = onGpu ? await gpuSemaphore.acquire(costForEngine('qwen')) : null;
+      const releaseGpu = await acquireGpuTokenIfOnGpu(onGpu, costForEngine('qwen'));
       const sidecarUrl = getResolvedSidecarUrl();
 
       const postDesignAndCache = async (

--- a/server/src/routes/sidecar-health.ts
+++ b/server/src/routes/sidecar-health.ts
@@ -16,6 +16,7 @@ import { asrEnabled } from '../tts/segment-asr-qa.js';
 import { getActiveSupervisor } from '../tts/sidecar-supervisor.js';
 import { setLastKnownVram } from '../gpu/vram-state.js';
 import { setLastKnownEngineDevices } from '../gpu/engine-device-state.js';
+import { TRACKED_ENGINES, type TrackedEngine } from '../gpu/tracked-engines.js';
 
 export const sidecarHealthRouter = Router();
 
@@ -117,10 +118,7 @@ interface SidecarHealthBody {
    imported in the background, 'ready', or 'error' when torch is missing/broken).
    rocm/directml are the AMD families (phase 2). Absent on an older sidecar → null. */
 export type SidecarDeviceFamily = 'cuda' | 'rocm' | 'directml' | 'mps' | 'cpu';
-export type SidecarDeviceMap = Record<
-  'kokoro' | 'coqui' | 'qwen',
-  SidecarDeviceFamily | null
->;
+export type SidecarDeviceMap = Record<TrackedEngine, SidecarDeviceFamily | null>;
 export type SidecarDevicesState = 'pending' | 'ready' | 'error';
 
 const DEVICE_FAMILIES: readonly SidecarDeviceFamily[] = [
@@ -131,7 +129,6 @@ const DEVICE_FAMILIES: readonly SidecarDeviceFamily[] = [
   'cpu',
 ];
 const DEVICES_STATES: readonly SidecarDevicesState[] = ['pending', 'ready', 'error'];
-const DEVICE_ENGINES = ['kokoro', 'coqui', 'qwen'] as const;
 
 /* side-14 — normalise the sidecar's devices map. Old sidecar omits it → null;
    junk values per-slot → null (never forward an unknown string to the UI). */
@@ -139,7 +136,7 @@ export function normaliseDevices(raw: unknown): SidecarDeviceMap | null {
   if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return null;
   const rec = raw as Record<string, unknown>;
   const out = {} as SidecarDeviceMap;
-  for (const engine of DEVICE_ENGINES) {
+  for (const engine of TRACKED_ENGINES) {
     const v = rec[engine];
     out[engine] = DEVICE_FAMILIES.includes(v as SidecarDeviceFamily)
       ? (v as SidecarDeviceFamily)

--- a/server/src/tts/embed-client.ts
+++ b/server/src/tts/embed-client.ts
@@ -18,6 +18,7 @@ import { fetch as undiciFetch, Agent } from 'undici';
 import { gpuSemaphore } from '../gpu/semaphore.js';
 import { costForEngine } from './engine-vram-cost.js';
 import { getResolvedSidecarUrl } from '../workspace/user-settings.js';
+import { acquireGpuTokenIfOnGpu } from '../gpu/gpu-semaphore-gate.js';
 
 export interface EmbedOptions {
   signal?: AbortSignal;
@@ -66,7 +67,7 @@ export async function embedSegment(
 
   const onGpu = spkRunsOnGpu();
   if (onGpu) warnIfBudgetTooLow();
-  const release = onGpu ? await gpuSemaphore.acquire(costForEngine('spk')) : null;
+  const release = await acquireGpuTokenIfOnGpu(onGpu, costForEngine('spk'));
   try {
     let response: Response;
     try {

--- a/server/src/tts/sidecar.ts
+++ b/server/src/tts/sidecar.ts
@@ -28,6 +28,7 @@ import { sidecarModelId } from './model-keys.js';
 import { gpuSemaphore, GpuSemaphore } from '../gpu/semaphore.js';
 import { costForEngine } from './engine-vram-cost.js';
 import { engineDeviceIsGpu } from '../gpu/engine-device.js';
+import { acquireGpuTokenIfOnGpu } from '../gpu/gpu-semaphore-gate.js';
 
 /* Per-engine serialisation: at most ONE synth call per engine in-flight at a
    time, mirroring the sidecar's own _synth_lock.  With a VRAM budget > 1, two
@@ -117,12 +118,12 @@ export class SidecarTtsProvider implements TtsProvider {
          VRAM weight (engine-vram-cost.ts) so a heavy engine takes more of the
          budget than a light one. See server/src/gpu/semaphore.ts. */
       /* Skipped entirely (releaseGpu = null) when this.engine is confirmed
-         running off-GPU (cpu/mps) — mirrors the analyzer/ASR/spk convention
-         (see server/src/gpu/engine-device.ts). A returned cost of 0 would NOT
-         achieve this: GpuSemaphore.acquire()'s clampCost floors any cost
-         below 1 back up to 1, so the call site itself must skip acquire(). */
-      const onGpu = engineDeviceIsGpu(this.engine);
-      const releaseGpu = onGpu ? await this.gpuSem.acquire(costForEngine(this.engine)) : null;
+         running off-GPU (cpu/mps) — see server/src/gpu/gpu-semaphore-gate.ts. */
+      const releaseGpu = await acquireGpuTokenIfOnGpu(
+        engineDeviceIsGpu(this.engine),
+        costForEngine(this.engine),
+        this.gpuSem,
+      );
 
       try {
         const response = await this.post('/synthesize', body, signal);
@@ -198,8 +199,11 @@ export class SidecarTtsProvider implements TtsProvider {
     /* Per-engine serialisation — outer gate, same rationale as synthesize(). */
     const releaseEngine = await engineSynthSem(this.engineSynths, this.engine).acquire();
     try {
-      const onGpu = engineDeviceIsGpu(this.engine);
-      const releaseGpu = onGpu ? await this.gpuSem.acquire(costForEngine(this.engine)) : null;
+      const releaseGpu = await acquireGpuTokenIfOnGpu(
+        engineDeviceIsGpu(this.engine),
+        costForEngine(this.engine),
+        this.gpuSem,
+      );
       try {
         const response = await this.post('/synthesize-batch', body, signal);
         if (!response.ok) await throwForResponse(response);

--- a/server/src/tts/transcribe-client.ts
+++ b/server/src/tts/transcribe-client.ts
@@ -18,9 +18,9 @@
    we skip the semaphore entirely there. */
 
 import { fetch as undiciFetch, Agent } from 'undici';
-import { gpuSemaphore } from '../gpu/semaphore.js';
 import { costForEngine } from './engine-vram-cost.js';
 import { getResolvedSidecarUrl } from '../workspace/user-settings.js';
+import { acquireGpuTokenIfOnGpu } from '../gpu/gpu-semaphore-gate.js';
 
 export interface TranscribeResult {
   text: string;
@@ -74,7 +74,7 @@ export async function transcribeSegment(
   const lang = normalizeWhisperLanguage(opts.language);
   if (lang) headers['x-language'] = lang;
 
-  const release = asrRunsOnGpu() ? await gpuSemaphore.acquire(costForEngine('asr')) : null;
+  const release = await acquireGpuTokenIfOnGpu(asrRunsOnGpu(), costForEngine('asr'));
   try {
     let response: Response;
     try {


### PR DESCRIPTION
## Summary
- Extract `acquireGpuTokenIfOnGpu()` (`server/src/gpu/gpu-semaphore-gate.ts`) — the shared "skip `GpuSemaphore.acquire()` when the engine is confirmed off-GPU" idiom. Rewires all 6 call sites onto it: the 3 PR #1324 added (`sidecar.ts` synth + synth-batch, `qwen-voice.ts` design) and the 3 pre-existing, differently-shaped copies (`transcribe-client.ts` ASR, `embed-client.ts` speaker embed, `ollama.ts` persona generation).
- Extract the duplicated `kokoro`/`coqui`/`qwen` engine-list constant into `server/src/gpu/tracked-engines.ts`, consumed by both `engine-device-state.ts` and `sidecar-health.ts` (previously each declared its own copy).
- Pure refactor — behavior unchanged. New `gpu-semaphore-gate.test.ts` covers the shared helper; all existing call-site tests stay green untouched.

## Test plan
- [x] `npm run typecheck` — clean
- [x] New `server/src/gpu/gpu-semaphore-gate.test.ts` + existing suites for every touched call site (`sidecar.test.ts`, `qwen-voice.test.ts`, `transcribe-client.test.ts`, `embed-client.test.ts`, `ollama.test.ts`, `engine-device-state.test.ts`, `sidecar-health.test.ts`) — 200/200 pass
- [x] `npm run test:server` — 4059 passed (1 unrelated worker-fork flake, known infra issue)
- [x] `npm run test` (frontend) — 3527 passed
- [x] `npm run verify` (full battery: lint/typecheck/tests/e2e/build) — green; 10 flaky e2e specs in unrelated UI areas (cast, manuscript, queue-modal, etc.) passed on retry

No release-notes entry — pure internal refactor, no user- or operator-visible behavior change.

Closes #1327