### PR TITLE
chore(scripts): ignore .worktrees/ for agent-created git worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ dist/
 
 # Env
 .env
+
+# Agent-created git worktrees (superpowers:using-git-worktrees)
+/.worktrees/
 .env.local
 .env.*.local
 !.env.example


### PR DESCRIPTION
## Summary
- One-line `.gitignore` addition so a project-local `.worktrees/` directory (created by the `superpowers:using-git-worktrees` skill's fallback path) never shows as untracked content.

## Test plan
- [x] N/A — pure `.gitignore` change, no runtime surface.

Closes #1338