### PR TITLE
chore: ignore .worktrees/ ad-hoc checkouts in eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,6 +36,10 @@ export default tseslint.config(
       // worktrees that carry their own built `dist/` output. Without this, lint
       // walks into `.claude/worktrees/<agent>/server/dist/` and floods errors.
       '.claude/',
+      // Ad-hoc worktree checkouts outside the `.claude/worktrees/` convention
+      // (e.g. `.worktrees/<name>`) carry their own `node_modules`/`dist` too —
+      // same failure mode as above, different root.
+      '.worktrees/',
       'server/dist/',
       'server/tts-sidecar/.venv/',
       'server/handoff/',


### PR DESCRIPTION
## Summary
- Root-level `npm run lint` (and thus `npm run verify`'s pre-push gate) was walking into `.worktrees/<name>` — a worktree checkout sitting outside the documented `.claude/worktrees/` convention — and failing on that worktree's own unrelated lint errors.
- Mirrors the existing `.claude/` global ignore with a `.worktrees/` entry.

Discovered as a side effect of pushing an unrelated fs-68 (wiki Release Notes) branch — this fix unblocks `npm run verify` locally regardless of where a stray/legacy worktree happens to live on disk.

Closes #1341

## Test plan
- [x] `npx eslint . --max-warnings 0` passes
- [x] `npm run verify` (full battery) green on this branch