### PR TITLE
ci(ci): alias 127.0.0.2 on macOS loopback before cross-OS verify

### DIFF
--- a/.github/workflows/cross-os.yml
+++ b/.github/workflows/cross-os.yml
@@ -65,6 +65,16 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: choco install ffmpeg -y --no-progress
 
+      # macOS only aliases 127.0.0.1 on lo0 by default (unlike Linux/Windows,
+      # which treat the whole 127.0.0.0/8 range as loopback out of the box).
+      # server/src/lan-port-forwarder.ts binds its upstream connection's
+      # localAddress to 127.0.0.2 (a deliberate security invariant, see that
+      # file's comments) — without this alias the bind fails with
+      # EADDRNOTAVAIL and lan-port-forwarder.test.ts fails/times out.
+      - name: Alias 127.0.0.2 on loopback (macOS)
+        if: matrix.os == 'macos-latest'
+        run: sudo ifconfig lo0 alias 127.0.0.2 up
+
       # `verify:quick` is `test:all` (hooks + frontend + server + scripts +
       # sidecar). Sidecar tests skip with a banner when the venv isn't
       # bootstrapped (it won't be on a fresh runner — that's fine).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,16 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: choco install ffmpeg -y --no-progress
 
+      # macOS only aliases 127.0.0.1 on lo0 by default (unlike Linux/Windows,
+      # which treat the whole 127.0.0.0/8 range as loopback out of the box).
+      # server/src/lan-port-forwarder.ts binds its upstream connection's
+      # localAddress to 127.0.0.2 (a deliberate security invariant, see that
+      # file's comments) — without this alias the bind fails with
+      # EADDRNOTAVAIL and lan-port-forwarder.test.ts fails/times out.
+      - name: Alias 127.0.0.2 on loopback (macOS)
+        if: matrix.os == 'macos-latest'
+        run: sudo ifconfig lo0 alias 127.0.0.2 up
+
       # `verify:quick` is `test:all` (hooks + frontend + server + scripts +
       # sidecar; sidecar/Pester skip with a banner on a fresh runner).
       - name: Verify


### PR DESCRIPTION
## Summary
- The scheduled Cross-OS Verify run on 2026-07-05 failed on `macos-latest`: `server/src/lan-port-forwarder.test.ts` bind-fails with `EADDRNOTAVAIL 127.0.0.2` because macOS only aliases `127.0.0.1` on `lo0` by default (Linux/Windows treat the whole `127.0.0.0/8` as loopback out of the box).
- Add a `sudo ifconfig lo0 alias 127.0.0.2 up` step before `Verify` in both `.github/workflows/cross-os.yml` and `release.yml`'s `cross-os-verify` job (the latter mirrors the former and would hit the same failure at the next release cut).

## Test plan
- [x] Root-caused via the failed job's own stderr: `[lan-port-forwarder] upstream connect failed: bind EADDRNOTAVAIL 127.0.0.2`.
- [x] Confirmed via manual `cross-os.yml` dispatch on this branch: https://github.com/dudarenok-maker/Castwright/actions/runs/28732627661 — macOS `Verify` went green on rerun (10/11 `lan-port-forwarder.test.ts` tests fixed by the alias; the first attempt separately hit one unrelated pre-existing flake in a different test — `round 5 (Finding 2)`, an `ECONNRESET` race unrelated to this fix — which passed cleanly on rerun. Filed separately, not fixed here to keep this PR single-scope.)
- N/A regression test / release notes — CI-config-only fix, no app runtime code changed, no user- or operator-visible effect.

Closes #1346

🤖 Generated with [Claude Code](https://claude.com/claude-code)