### PR TITLE
docs(docs): add fs-51 per-book QA report design spec + implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-07-05-fs51-qa-report.md
+++ b/docs/superpowers/plans/2026-07-05-fs51-qa-report.md
@@ -1,0 +1,1784 @@
+# fs-51 — Per-book performance-QA report Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a per-book QA report — visible in the app and exportable as text/JSON — that aggregates the existing signal-QA, SEG-ASR content-QA, srv-36 voice-drift, and cast-config-drift signals into one honest receipt, with zero false-clean states.
+
+**Architecture:** A new server-side aggregation module (`server/src/audio/qa-report.ts`) reads existing per-chapter files (`segments.json`, `render-integrity.json`) plus one new endpoint composes it with the existing `getRevisionsForBook` config-drift result into a `BookQaReport`. A handful of small, additive schema changes (retry counters, `chapterId` on voice-drift verdicts, fresh-verdict writes after a splice/repair) close false-pass gaps found during design review. One new frontend component (`QaReportCard`) + fetch hook renders it in both the Listen view (post-generation) and the Generation view (live).
+
+**Tech Stack:** TypeScript, Express (server), React + Redux Toolkit + Vitest + Testing Library (frontend), Playwright (e2e). No new dependencies.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-05-fs51-qa-report-design.md` — every requirement below traces to it.
+- **The report must never show a false pass** — a gate that never ran, had nothing to check, or was checked incompletely must never render as clean. This is the spec's central constraint; several tasks below exist solely to satisfy it.
+- No hex literals in frontend code — use the existing CSS custom properties / Tailwind tokens (`bg-white`, `border-ink/10`, `text-ink/70`, etc. — matches `LoudnessReport`/`drift-report.tsx` conventions already in the codebase).
+- Brand copy: no exclamation marks, no hype words (revolutionary/seamless/magical/etc. — see `brand/_skills/castwright-voice/references/voice-essentials.md` banned-words list), sentence case, one bold span per headline.
+- Every new behavior ships a paired automated test in the same commit (CLAUDE.md "Testing discipline").
+- `npm run openapi:types` regenerates `src/lib/api-types.ts` — never hand-edit that file.
+- Commit convention: `<type>(<scope>): <subject>` — scopes used below: `server`, `frontend`, `openapi`, `e2e`.
+
+---
+
+### Task 1: Export `STOCHASTIC_ENGINES`, add `chapterId` to `VerdictRow`, extend `deriveBookOutline`
+
+**Files:**
+- Modify: `server/src/audio/render-integrity/aggregate.ts:72` (export the const), `:210-215` (add `id` to `ChapterData`), `:237-242` (populate it), `:350-361` (too-short push), `:376-387` (normal push)
+- Modify: `server/src/audio/render-integrity/verdicts-io.ts:8-19` (add field), `:47-83` (extend return)
+- Test: `server/src/audio/render-integrity/verdicts-io.test.ts` (extend existing file — it already exists per the srv-36 plan)
+
+**Interfaces:**
+- Produces: `VerdictRow.chapterId?: number`; `STOCHASTIC_ENGINES: Set<string>` (exported); `deriveBookOutline(bookDir, chapters)` now resolves `{ issues, counts, scoredChapterIds: number[], inconclusiveChapterIds: number[] }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/src/audio/render-integrity/verdicts-io.test.ts`:
+
+```ts
+it('deriveBookOutline reports scoredChapterIds and inconclusiveChapterIds', async () => {
+  const dir = await makeTempBookDir(); // existing test helper in this file
+  await writeVerdicts(join(audioDir(dir), 'ch1.render-integrity.json'), [
+    {
+      characterId: 'wren',
+      sentenceIds: [1, 2],
+      verdict: 'voice-mismatch',
+      cosine: 0.4,
+      severity: 'severe',
+      fixable: true,
+      expectedEngine: 'qwen',
+      renderedEngine: 'qwen',
+      referenceKind: 'in-book',
+      windowed: false,
+      chapterId: 1,
+    },
+  ]);
+  await writeVerdicts(join(audioDir(dir), 'ch2.render-integrity.json'), [
+    {
+      characterId: 'oduvan',
+      sentenceIds: [5],
+      verdict: 'inconclusive',
+      cosine: 0,
+      severity: 'inconclusive',
+      fixable: false,
+      expectedEngine: 'qwen',
+      renderedEngine: 'qwen',
+      referenceKind: 'too-short',
+      windowed: false,
+      chapterId: 2,
+    },
+  ]);
+
+  const outline = await deriveBookOutline(dir, [
+    { id: 1, slug: 'ch1' },
+    { id: 2, slug: 'ch2' },
+    { id: 3, slug: 'ch3' }, // never rendered — no file
+  ]);
+
+  expect(outline.issues).toEqual([expect.objectContaining({ characterId: 'wren', chapterId: 1 })]);
+  expect(outline.scoredChapterIds.sort()).toEqual([1, 2]);
+  expect(outline.inconclusiveChapterIds).toEqual([2]);
+  expect(outline.counts.uncheckedCharacters).toEqual(['oduvan']);
+});
+```
+
+If `makeTempBookDir` doesn't already exist in this test file, check `server/src/audio/render-integrity/aggregate.test.ts` (same directory, same srv-36 feature) for the temp-dir helper it uses and import/reuse it rather than writing a new one.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/audio/render-integrity/verdicts-io.test.ts -t "scoredChapterIds"`
+Expected: FAIL — `chapterId` doesn't exist on `VerdictRow`, `scoredChapterIds`/`inconclusiveChapterIds` don't exist on the return type.
+
+- [ ] **Step 3: Implement**
+
+In `server/src/audio/render-integrity/verdicts-io.ts`, add the field to the interface:
+
+```ts
+export interface VerdictRow {
+  characterId: string;
+  sentenceIds: number[];
+  verdict: Verdict;
+  cosine: number;
+  severity: 'severe' | 'inconclusive' | null;
+  fixable: boolean;
+  expectedEngine: string;
+  renderedEngine: string;
+  referenceKind: 'in-book' | 'audition' | 'too-short';
+  windowed: boolean;
+  /** fs-51 — the chapter this row belongs to. Absent on files written before
+      this field existed (a legacy book); the qa-report aggregator uses that
+      absence to set `voiceDrift.attribution: 'legacy-unattributed'`. */
+  chapterId?: number;
+}
+```
+
+Replace `deriveBookOutline` with:
+
+```ts
+export async function deriveBookOutline(
+  bookDir: string,
+  chapters: { id: number; slug: string }[],
+): Promise<{
+  issues: VerdictRow[];
+  counts: { suspect: number; fixable: number; uncheckedCharacters: string[] };
+  scoredChapterIds: number[];
+  inconclusiveChapterIds: number[];
+}> {
+  const root = audioDir(bookDir);
+  const issues: VerdictRow[] = [];
+  const uncheckedSet = new Set<string>();
+  const scoredChapterIds = new Set<number>();
+  const inconclusiveChapterIds = new Set<number>();
+
+  for (const ch of chapters) {
+    const path = join(root, `${ch.slug}.render-integrity.json`);
+    const rows = await readVerdicts(path);
+    if (!rows) continue;
+    scoredChapterIds.add(ch.id);
+
+    for (const row of rows) {
+      if (row.verdict === 'voice-mismatch') {
+        issues.push(row);
+      }
+      if (row.verdict === 'inconclusive') {
+        inconclusiveChapterIds.add(ch.id);
+      }
+      if (row.referenceKind === 'too-short') {
+        uncheckedSet.add(row.characterId);
+      }
+    }
+  }
+
+  const uncheckedCharacters = Array.from(uncheckedSet).sort();
+
+  return {
+    issues,
+    counts: {
+      suspect: issues.length,
+      fixable: issues.filter((r) => r.fixable).length,
+      uncheckedCharacters,
+    },
+    scoredChapterIds: Array.from(scoredChapterIds).sort((a, b) => a - b),
+    inconclusiveChapterIds: Array.from(inconclusiveChapterIds).sort((a, b) => a - b),
+  };
+}
+```
+
+In `server/src/audio/render-integrity/aggregate.ts`:
+- Line 72: change `const STOCHASTIC_ENGINES = new Set(['qwen', 'coqui']);` to `export const STOCHASTIC_ENGINES = new Set(['qwen', 'coqui']);`
+- Line 210-215: add `id: number;` to the `ChapterData` type:
+  ```ts
+  type ChapterData = {
+    id: number;
+    slug: string;
+    embRows: EmbeddingRow[];
+    segsByKey: Map<string, SegmentsEntry>;
+    snapshots: Record<string, SnapshotView>;
+  };
+  ```
+- Line 237-242: add `id: ch.id,` to the push:
+  ```ts
+  chapterData.push({
+    id: ch.id,
+    slug: ch.slug,
+    embRows: embResult.rows,
+    segsByKey,
+    snapshots: segFile.characterSnapshots ?? {},
+  });
+  ```
+- Line 350-361 (too-short push) and line 376-387 (normal push): add `chapterId: cd.id,` to both `verdictRows.push({...})` object literals.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/audio/render-integrity/verdicts-io.test.ts src/audio/render-integrity/aggregate.test.ts`
+Expected: PASS (the aggregate.test.ts run confirms the `ChapterData`/push edits didn't break existing srv-36 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/audio/render-integrity/verdicts-io.ts server/src/audio/render-integrity/aggregate.ts server/src/audio/render-integrity/verdicts-io.test.ts
+git commit -m "feat(server): add chapterId to voice-drift verdicts, export STOCHASTIC_ENGINES"
+```
+
+---
+
+### Task 2: Add `qaRetries`/`asrRetries` to `ChapterSegment`, stamp them in the re-record loops
+
+**Files:**
+- Modify: `server/src/tts/synthesise-chapter.ts:295-354` (interface), `:1513-1563` (signal-QA loop), `:1574-1670` (ASR loop), `:1745-1760` (final push)
+- Test: `server/src/tts/synthesise-chapter.test.ts` (existing file)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `ChapterSegment.qaRetries?: number`, `ChapterSegment.asrRetries?: number` — read by Task 5's aggregation and relied on by Task 3/4's fresh-verdict fixes.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/src/tts/synthesise-chapter.test.ts` (find the existing describe block that drives the signal-QA re-record loop — it already mocks a suspect-then-clean sequence; add a new `it` alongside it):
+
+```ts
+it('stamps qaRetries/asrRetries counting actual re-record attempts per group', async () => {
+  // Reuse this file's existing mock setup for a 1-sentence chapter where the
+  // first synth is flagged suspect and the retry succeeds (see the
+  // surrounding describe block's beforeEach for the synth/evaluateSegmentPcm
+  // mocks already wired for this exact scenario).
+  const result = await synthesiseChapter({
+    ...baseChapterOpts(), // this file's existing fixture builder
+    maxSegmentRerecords: 2,
+  });
+  expect(result.segments[0].qaRetries).toBe(1);
+});
+```
+
+Match this to whatever fixture/mock helper (`baseChapterOpts` or equivalent) the existing suspect-then-clean test in this file already uses — read the file first and reuse its exact setup rather than re-mocking from scratch, per this codebase's existing test patterns in this file.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/tts/synthesise-chapter.test.ts -t "qaRetries"`
+Expected: FAIL — `qaRetries` is `undefined`.
+
+- [ ] **Step 3: Implement**
+
+In `server/src/tts/synthesise-chapter.ts`, add the two fields to `ChapterSegment` (after `suspect?: boolean;` at line 338, and after `asrSuspect?: boolean;` at line 348):
+
+```ts
+  /** fs-51 — number of times this segment was actually re-recorded by the
+      signal-QA gate (not merely "still suspect" — an attempt that fixed the
+      line still counts). 0/undefined on the title beat and when the gate
+      didn't run for this segment. */
+  qaRetries?: number;
+```
+
+```ts
+  /** fs-51 — same as `qaRetries`, for the ASR content-QA gate's re-record loop. */
+  asrRetries?: number;
+```
+
+In the signal-QA loop, add a counter map right after `const segmentQaByIndex = new Map<number, SegmentQaVerdict>();` (line 1513):
+
+```ts
+  const qaRetryCountByIndex = new Map<number, number>();
+```
+
+Inside the round loop's `for (const group of pending)` (line 1538-1545, where `onSegmentRerecord` fires), increment it:
+
+```ts
+      for (const group of pending) {
+        qaRetryCountByIndex.set(group.index, (qaRetryCountByIndex.get(group.index) ?? 0) + 1);
+        onSegmentRerecord?.({
+          group,
+          attempt,
+          maxRerecords: maxSegmentRerecords,
+          reasons: segmentQaByIndex.get(group.index)!.reasons,
+        });
+      }
+```
+
+Mirror this in the ASR loop: add `const asrRetryCountByIndex = new Map<number, number>();` right after `const segmentAsrByIndex = new Map<number, AsrClassification>();` (line 1574), and increment inside the re-record round's `for (const group of pending)` (line 1643-1652):
+
+```ts
+      for (const group of pending) {
+        asrRetryCountByIndex.set(group.index, (asrRetryCountByIndex.get(group.index) ?? 0) + 1);
+        const c = segmentAsrByIndex.get(group.index)!;
+        asr.onRerecord?.({
+          group,
+          attempt,
+          maxRerecords: maxAsrRerecords,
+          wer: c.wer,
+          reasons: c.reasons,
+        });
+      }
+```
+
+In the final push (line 1745-1760), add the two fields:
+
+```ts
+    segments.push({
+      groupIndex: group.index,
+      characterId: group.characterId,
+      sentenceIds: group.sentenceIds.slice(),
+      textHash: textHashForStale(group.text),
+      instructHash,
+      startSec,
+      endSec,
+      renderedFallbackEngine: resolveGroup(group).renderedFallbackEngine,
+      voiceSubstitutedFrom: r.voiceSubstitutedFrom,
+      qa,
+      suspect: quarantined || qa?.status === 'suspect' ? true : undefined,
+      qaRetries: qaRetryCountByIndex.get(group.index) || undefined,
+      asr: asrClass,
+      asrSuspect: asrClass?.verdict === 'drift' ? true : undefined,
+      asrRetries: asrRetryCountByIndex.get(group.index) || undefined,
+      quarantined: quarantined ? true : undefined,
+    });
+```
+
+(`|| undefined` rather than `?? 0` matches this file's existing convention of leaving zero/absent fields `undefined` rather than `0` — see `suspect`/`quarantined` above.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/tts/synthesise-chapter.test.ts`
+Expected: PASS, including all pre-existing tests in the file (confirms the two new Maps don't disturb the existing signal-QA/ASR loop behavior).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/tts/synthesise-chapter.ts server/src/tts/synthesise-chapter.test.ts
+git commit -m "feat(server): stamp qaRetries/asrRetries on re-recorded segments"
+```
+
+---
+
+### Task 3: Fix `chapter-splice.ts` to write a fresh verdict for re-recorded segments instead of spreading the stale one
+
+**Files:**
+- Modify: `server/src/audio/build-synth-replacement.ts` (SynthOutput + buildSynthReplacements)
+- Modify: `server/src/audio/splice-chapter.ts:24-38` (`SegmentReplacement`), `:180-190` (the single-segment re-record push)
+- Modify: `server/src/routes/chapter-splice.ts:286-310` (the `synth` callback — pass QA/ASR options through)
+- Test: `server/src/audio/build-synth-replacement.test.ts`, `server/src/audio/splice-chapter.test.ts` (both existing files)
+
+**Interfaces:**
+- Consumes: `ChapterSegment.qa/asr/suspect/asrSuspect/qaRetries/asrRetries` (Task 2).
+- Produces: `SegmentReplacement.freshVerdict?: Pick<ChapterSegment, 'qa'|'asr'|'suspect'|'asrSuspect'|'qaRetries'|'asrRetries'>` — a gain-only replacement never sets this (its content didn't change, so the prior verdict is still valid); a re-record replacement always sets it (even when every field inside is `undefined`, i.e. "gate ran, came back clean").
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `server/src/audio/build-synth-replacement.test.ts`:
+
+```ts
+it('carries the fresh verdict from the synth output onto the replacement', async () => {
+  const segments = [makeSegment({ sentenceIds: [1] })]; // this file's existing fixture helper
+  const replacements = await buildSynthReplacements({
+    segments,
+    targetIndices: [0],
+    chapterSampleRate: 24000,
+    synth: async () => ({
+      pcm: Buffer.alloc(100),
+      sampleRate: 24000,
+      qa: { status: 'ok', reasons: [], rms: 0.1, longestSilenceSec: 0, durationSec: 1, expectedSec: 1 },
+      suspect: undefined,
+    }),
+  });
+  expect(replacements[0].freshVerdict).toEqual({
+    qa: { status: 'ok', reasons: [], rms: 0.1, longestSilenceSec: 0, durationSec: 1, expectedSec: 1 },
+    suspect: undefined,
+    asr: undefined,
+    asrSuspect: undefined,
+    qaRetries: undefined,
+    asrRetries: undefined,
+  });
+});
+```
+
+Add to `server/src/audio/splice-chapter.test.ts`, alongside the existing re-record tests:
+
+```ts
+it('uses the replacement freshVerdict instead of the original segment verdict for a re-record', () => {
+  const original = makeSegment({ // this file's existing fixture helper
+    startSec: 0,
+    endSec: 1,
+    suspect: true,
+    qa: { status: 'suspect', reasons: ['old'], rms: 0, longestSilenceSec: 0, durationSec: 1, expectedSec: 1 },
+  });
+  const result = spliceChapterSegments({
+    decodedPcm: makeSilencePcm(1, 24000), // existing helper
+    sampleRate: 24000,
+    segments: [original],
+    replacements: [
+      {
+        startSegmentIndex: 0,
+        endSegmentIndex: 0,
+        pcm: makeSilencePcm(1, 24000),
+        freshVerdict: { qa: undefined, suspect: undefined, asr: undefined, asrSuspect: undefined, qaRetries: undefined, asrRetries: undefined },
+      },
+    ],
+  });
+  expect(result.segments[0].suspect).toBeUndefined();
+  expect(result.segments[0].qa).toBeUndefined();
+});
+```
+
+Use whatever this test file's actual fixture helper names are (`makeSegment`/`makeSilencePcm` are placeholders for whatever it already calls them — read the file first and match its existing names exactly).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd server && npx vitest run src/audio/build-synth-replacement.test.ts src/audio/splice-chapter.test.ts -t "fresh"`
+Expected: FAIL — `freshVerdict` doesn't exist yet; the splice still spreads the original segment's stale `suspect: true`.
+
+- [ ] **Step 3: Implement**
+
+In `server/src/audio/build-synth-replacement.ts`, extend `SynthOutput` and thread it through:
+
+```ts
+export interface SynthOutput {
+  pcm: Buffer;
+  sampleRate: number;
+  /** fs-51 — the freshly-computed QA/ASR verdict for this re-recorded
+      segment, when the caller's synth ran the gates. Absent when the
+      caller didn't run QA/ASR for this call (legacy behavior). */
+  qa?: ChapterSegment['qa'];
+  suspect?: ChapterSegment['suspect'];
+  asr?: ChapterSegment['asr'];
+  asrSuspect?: ChapterSegment['asrSuspect'];
+  qaRetries?: ChapterSegment['qaRetries'];
+  asrRetries?: ChapterSegment['asrRetries'];
+}
+```
+
+In `buildSynthReplacements`, thread the fields onto the pushed replacement:
+
+```ts
+export async function buildSynthReplacements(
+  opts: BuildSynthReplacementsOpts,
+): Promise<SegmentReplacement[]> {
+  const replacements: SegmentReplacement[] = [];
+  for (const i of [...opts.targetIndices].sort((a, b) => a - b)) {
+    const seg = opts.segments[i];
+    const out = await opts.synth(seg);
+    const pcm =
+      out.sampleRate === opts.chapterSampleRate
+        ? out.pcm
+        : resamplePcm16(out.pcm, out.sampleRate, opts.chapterSampleRate);
+    replacements.push({
+      startSegmentIndex: i,
+      endSegmentIndex: i,
+      pcm,
+      freshVerdict: {
+        qa: out.qa,
+        suspect: out.suspect,
+        asr: out.asr,
+        asrSuspect: out.asrSuspect,
+        qaRetries: out.qaRetries,
+        asrRetries: out.asrRetries,
+      },
+    });
+  }
+  return replacements;
+}
+```
+
+In `server/src/audio/splice-chapter.ts`, extend `SegmentReplacement` (line 24-38):
+
+```ts
+export interface SegmentReplacement {
+  startSegmentIndex: number;
+  endSegmentIndex: number;
+  pcm: Buffer;
+  innerSegmentByteLengths?: number[];
+  /** fs-51 — freshly-computed verdict fields for a re-record. Present only
+      when the replacement's audio content actually changed (a re-record);
+      a gain re-mix (same content, different volume) never sets this, so its
+      segment keeps its prior verdict — the content didn't change, so the
+      prior verdict is still true. */
+  freshVerdict?: Pick<ChapterSegment, 'qa' | 'suspect' | 'asr' | 'asrSuspect' | 'qaRetries' | 'asrRetries'>;
+}
+```
+
+In `spliceChapterSegments`'s single-segment re-record branch (the `if (a === b)` block at line 180-190), apply `freshVerdict` after the base spread:
+
+```ts
+          if (a === b) {
+            newSegments.push({
+              ...segments[a],
+              ...(run.freshVerdict ?? {}),
+              startSec: pcmDurationSec(runNewStart, sampleRate),
+              endSec: pcmDurationSec(runNewStart + run.pcm.length, sampleRate),
+            });
+            oldBytes = spanEnd;
+            i = b + 1;
+            continue;
+          }
+```
+
+In `server/src/routes/chapter-splice.ts`, update the `synth` callback (line 290-309) to pass the same gate options generation uses, and return the fresh verdict from the single-sentence result:
+
+```ts
+          synth: async (seg) => {
+            const ids = new Set(seg.sentenceIds);
+            const subset = sentences.filter((s) => ids.has(s.id));
+            send({ type: 'progress', chapterId, characterId, progress: 0.5 });
+            const r = await synthesiseChapter({
+              sentences: subset,
+              cast: cast.characters,
+              provider,
+              modelKey,
+              engine,
+              resolveForEngine,
+              qwenUnavailable,
+              forbidKokoroFallback: nonEnglishBook,
+              bookLanguage,
+              signal: controller.signal,
+              chapterTitleNarration: undefined,
+              narratorCharacterId: 'narrator',
+              maxSegmentRerecords: configValue<number>('qa.seg.maxRerecords'),
+              ...(asrEnabled()
+                ? { asr: { maxRerecords: resolveAsrRerecords(), sampleEvery: resolveAsrSampleEvery() } }
+                : {}),
+            });
+            const s = r.segments[0];
+            return {
+              pcm: r.pcm,
+              sampleRate: r.sampleRate,
+              qa: s?.qa,
+              suspect: s?.suspect,
+              asr: s?.asr,
+              asrSuspect: s?.asrSuspect,
+              qaRetries: s?.qaRetries,
+              asrRetries: s?.asrRetries,
+            };
+          },
+```
+
+Add the two missing imports at the top of `chapter-splice.ts`: `import { configValue } from '../config/resolver.js';` (if not already imported — check first) and `import { asrEnabled, resolveAsrRerecords, resolveAsrSampleEvery } from '../tts/segment-asr-qa.js';`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd server && npx vitest run src/audio/build-synth-replacement.test.ts src/audio/splice-chapter.test.ts src/routes/chapter-splice.test.ts`
+Expected: PASS, including all pre-existing tests (confirms the gain-remix path, which never sets `freshVerdict`, is unaffected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/audio/build-synth-replacement.ts server/src/audio/splice-chapter.ts server/src/routes/chapter-splice.ts server/src/audio/build-synth-replacement.test.ts server/src/audio/splice-chapter.test.ts
+git commit -m "fix(server): splice re-records now carry a fresh QA/ASR verdict instead of the stale one"
+```
+
+---
+
+### Task 4: Fix `chapter-qa-repair.ts` to write the accepted take's verdict onto the segment, and count its own retries
+
+**Files:**
+- Modify: `server/src/routes/chapter-qa-repair.ts` (the repair loop around lines 380-475, and wherever it builds the `replacements` array passed to `spliceChapterSegments` at line 481)
+- Test: `server/src/routes/chapter-qa-repair.test.ts` (existing file)
+
+**Interfaces:**
+- Consumes: `SegmentReplacement.freshVerdict` (Task 3).
+- Produces: a repaired segment's `qa`/`suspect`/`asr`/`asrSuspect`/`qaRetries`/`asrRetries` in the post-repair `segments.json` reflect the accepted take, not the pre-repair segment.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/src/routes/chapter-qa-repair.test.ts` (find the existing "repair a suspect segment" test and add alongside it — reuse its SSE-harness/route-invocation helper):
+
+```ts
+it('writes the accepted take verdict onto the repaired segment, not the stale pre-repair one', async () => {
+  // Arrange a chapter whose segment 0 is suspect, with a repair mock that
+  // returns a clean take on attempt 1 (mirror this file's existing
+  // "repairs a suspect segment" test setup for the synthesiseChapter /
+  // evaluateSegmentPcm mocks).
+  const res = await runRepair({ dryRun: false }); // this file's existing helper
+  const segFile = await readSegmentsJson(bookDir, chapterSlug); // this file's existing helper
+  expect(segFile.segments[0].suspect).toBeUndefined();
+  expect(segFile.segments[0].qa?.status).toBe('ok');
+  expect(segFile.segments[0].qaRetries).toBeGreaterThan(0);
+});
+```
+
+Match helper names to whatever this test file already exports/uses for driving the repair SSE route and reading back `segments.json` — read the file first.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/routes/chapter-qa-repair.test.ts -t "accepted take verdict"`
+Expected: FAIL — the repaired segment still shows the pre-repair `suspect: true`.
+
+- [ ] **Step 3: Implement**
+
+In the repair loop (around lines 412-473, inside the `for (let attempt = 1; ...)` retry loop), track a per-segment retry counter — add before the loop starts (near where `best`/`bestVerdict`/`bestAsr`/`bestCosine` are declared, ~line 382-386):
+
+```ts
+          let retryCount = 0;
+```
+
+Increment it once per attempt (top of the `for (let attempt = 1; attempt <= maxRerecords; attempt++)` body, ~line 412-414):
+
+```ts
+          for (let attempt = 1; attempt <= maxRerecords; attempt++) {
+            if (controller.signal.aborted) break;
+            retryCount += 1;
+            send({ type: 'progress', chapterId, segmentIndex: segIndex, attempt, progress: 0.5 });
+```
+
+Where the function returns `best` (line 473, `return best;`), the return type needs to carry the verdict so the caller can attach it to the replacement. Find where this per-segment closure's return value is consumed to build the `replacements` array (the `buildSynthReplacements`-style call this route makes just above line 380 — read the ~50 lines above line 380 to find the exact call site, since it wasn't included in this plan's research excerpt) and change the closure to return:
+
+```ts
+          return { pcm: best.pcm, sampleRate: best.sampleRate, verdict: {
+            qa: bestVerdict ?? undefined,
+            suspect: accepted ? undefined : true,
+            asr: bestAsr ?? undefined,
+            asrSuspect: accepted || !asrOn ? undefined : bestAsr?.verdict === 'drift' ? true : undefined,
+            qaRetries: retryCount || undefined,
+            asrRetries: asrOn ? retryCount || undefined : undefined,
+          } };
+```
+
+(Note: `accepted` is already computed at line 455 before this return — move the `return best` line's replacement below that point, or restructure so `accepted` is computed before this return; the existing code already has `accepted` in scope by line 456, one line before `return best` at line 473, so this is a same-scope change.)
+
+Then wherever this route builds its `replacements: SegmentReplacement[]` array from these per-segment closures (the call site above line 380 that this plan didn't capture — locate it by searching this file for `SegmentReplacement` or the array variable name), attach `freshVerdict: result.verdict` to each entry instead of a bare `{ startSegmentIndex, endSegmentIndex, pcm }`, mirroring the shape Task 3 introduced in `build-synth-replacement.ts`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/routes/chapter-qa-repair.test.ts`
+Expected: PASS, including every pre-existing test in the file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/chapter-qa-repair.ts server/src/routes/chapter-qa-repair.test.ts
+git commit -m "fix(server): QA-repair writes the accepted take's verdict onto the segment and counts its own retries"
+```
+
+---
+
+### Task 5: New aggregation module `server/src/audio/qa-report.ts`
+
+**Files:**
+- Create: `server/src/audio/qa-report.ts`
+- Create: `server/src/audio/qa-report.test.ts`
+
+**Interfaces:**
+- Consumes: `loadSegmentsFiles` (`segments-io.ts`), `deriveBookOutline` + `STOCHASTIC_ENGINES` (Task 1), `ChapterSegment.qa/asr/qaRetries/asrRetries/sentenceIds` (Task 2).
+- Produces: `buildAudioQaReport(bookDir, chapters): Promise<AudioQaReport>` where
+  ```ts
+  export interface AudioQaReport {
+    chaptersRendered: number;
+    totalLines: number;
+    acoustic: { linesChecked: number; linesRerecorded: number; chaptersFlagged: number };
+    asr: { linesVerified: number; linesFlaggedDrift: number };
+    voiceDrift: {
+      attribution: 'full' | 'legacy-unattributed';
+      chaptersEligible: number;
+      chaptersScored: number;
+      charactersOnRoster: number;
+      charactersChecked: number;
+      mismatches: Array<{ characterId: string; chapterId?: number; fixable: boolean }>;
+      inconclusiveCount: number;
+      uncheckedCharacterIds: string[];
+    };
+  }
+  ```
+  This is `BookQaReport` minus `bookId`/`generatedAt`/`chaptersTotal`/`configDrift` — the route (Task 6) fills those in, since `configDrift` comes from a different module (`routes/revisions.ts`) and the route already knows `bookId`/`chaptersTotal`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `server/src/audio/qa-report.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeJsonAtomic } from '../workspace/state-io.js';
+import { audioDir } from '../workspace/paths.js';
+import { writeVerdicts } from './render-integrity/verdicts-io.js';
+import { buildAudioQaReport } from './qa-report.js';
+
+async function makeBook(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'qa-report-'));
+  await mkdir(audioDir(dir), { recursive: true });
+  return dir;
+}
+
+function seg(overrides: Record<string, unknown> = {}) {
+  return {
+    groupIndex: 0,
+    characterId: 'wren',
+    sentenceIds: [1],
+    startSec: 0,
+    endSec: 1,
+    ...overrides,
+  };
+}
+
+describe('buildAudioQaReport', () => {
+  it('reports full coverage on a clean, fully-gated book', async () => {
+    const dir = await makeBook();
+    await writeJsonAtomic(join(audioDir(dir), 'ch1.segments.json'), {
+      bookId: 'b1',
+      chapterId: 1,
+      chapterTitle: 'One',
+      durationSec: 10,
+      sampleRate: 24000,
+      modelKey: 'qwen3-tts-0.6b',
+      synthesizedAt: new Date(0).toISOString(),
+      segments: [
+        seg({ qa: { status: 'ok', reasons: [], rms: 0.1, longestSilenceSec: 0, durationSec: 1, expectedSec: 1 } }),
+      ],
+      characterSnapshots: { wren: { voiceEngine: 'qwen' } },
+    });
+
+    const report = await buildAudioQaReport(dir, [{ id: 1, slug: 'ch1' }]);
+
+    expect(report.chaptersRendered).toBe(1);
+    expect(report.totalLines).toBe(1);
+    expect(report.acoustic.linesChecked).toBe(1);
+    expect(report.acoustic.linesRerecorded).toBe(0);
+    expect(report.asr.linesVerified).toBe(0); // ASR field absent on this fixture → not verified
+    expect(report.voiceDrift.chaptersEligible).toBe(1); // wren is qwen-voiced
+    expect(report.voiceDrift.chaptersScored).toBe(0); // no render-integrity.json written
+  });
+
+  it('reports chaptersEligible = 0 for an all-Kokoro book, distinct from not-run', async () => {
+    const dir = await makeBook();
+    await writeJsonAtomic(join(audioDir(dir), 'ch1.segments.json'), {
+      bookId: 'b1', chapterId: 1, chapterTitle: 'One', durationSec: 10, sampleRate: 24000,
+      modelKey: 'kokoro', synthesizedAt: new Date(0).toISOString(),
+      segments: [seg()],
+      characterSnapshots: { wren: { voiceEngine: 'kokoro' } },
+    });
+
+    const report = await buildAudioQaReport(dir, [{ id: 1, slug: 'ch1' }]);
+    expect(report.voiceDrift.chaptersEligible).toBe(0);
+    expect(report.voiceDrift.charactersOnRoster).toBe(0);
+  });
+
+  it('counts sentenceIds, not segment-group counts, for lines', async () => {
+    const dir = await makeBook();
+    await writeJsonAtomic(join(audioDir(dir), 'ch1.segments.json'), {
+      bookId: 'b1', chapterId: 1, chapterTitle: 'One', durationSec: 10, sampleRate: 24000,
+      modelKey: 'qwen3-tts-0.6b', synthesizedAt: new Date(0).toISOString(),
+      segments: [seg({ sentenceIds: [1, 2, 3] })], // one group, three sentences
+      characterSnapshots: { wren: { voiceEngine: 'qwen' } },
+    });
+    const report = await buildAudioQaReport(dir, [{ id: 1, slug: 'ch1' }]);
+    expect(report.totalLines).toBe(3);
+  });
+
+  it('sets attribution to legacy-unattributed when a voice-mismatch row has no chapterId', async () => {
+    const dir = await makeBook();
+    await writeJsonAtomic(join(audioDir(dir), 'ch1.segments.json'), {
+      bookId: 'b1', chapterId: 1, chapterTitle: 'One', durationSec: 10, sampleRate: 24000,
+      modelKey: 'qwen3-tts-0.6b', synthesizedAt: new Date(0).toISOString(),
+      segments: [seg()],
+      characterSnapshots: { wren: { voiceEngine: 'qwen' } },
+    });
+    await writeVerdicts(join(audioDir(dir), 'ch1.render-integrity.json'), [
+      {
+        characterId: 'wren', sentenceIds: [1], verdict: 'voice-mismatch', cosine: 0.3,
+        severity: 'severe', fixable: true, expectedEngine: 'qwen', renderedEngine: 'qwen',
+        referenceKind: 'in-book', windowed: false,
+        // no chapterId — simulates a pre-fs-51 render
+      },
+    ]);
+    const report = await buildAudioQaReport(dir, [{ id: 1, slug: 'ch1' }]);
+    expect(report.voiceDrift.attribution).toBe('legacy-unattributed');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd server && npx vitest run src/audio/qa-report.test.ts`
+Expected: FAIL — `./qa-report.js` doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+Create `server/src/audio/qa-report.ts`:
+
+```ts
+/* fs-51 — per-book QA report aggregation. Reads existing per-chapter files
+   (never a new persisted book-level aggregate) and computes one honest
+   summary. See docs/superpowers/specs/2026-07-05-fs51-qa-report-design.md
+   for the "never a false pass" constraint this module is built around —
+   in particular, voiceDrift.chaptersEligible is computed HERE, directly
+   from segments.json, rather than derived from scoreBook's output, because
+   scoreBook's own early-return control flow can't distinguish "nothing to
+   check" from "never ran" (see the spec's round-3 finding). */
+
+import { loadSegmentsFiles } from './segments-io.js';
+import { deriveBookOutline } from './render-integrity/verdicts-io.js';
+import { STOCHASTIC_ENGINES } from './render-integrity/aggregate.js';
+
+export interface AudioQaReport {
+  chaptersRendered: number;
+  totalLines: number;
+  acoustic: { linesChecked: number; linesRerecorded: number; chaptersFlagged: number };
+  asr: { linesVerified: number; linesFlaggedDrift: number };
+  voiceDrift: {
+    attribution: 'full' | 'legacy-unattributed';
+    chaptersEligible: number;
+    chaptersScored: number;
+    charactersOnRoster: number;
+    charactersChecked: number;
+    mismatches: Array<{ characterId: string; chapterId?: number; fixable: boolean }>;
+    inconclusiveCount: number;
+    uncheckedCharacterIds: string[];
+  };
+}
+
+export async function buildAudioQaReport(
+  bookDir: string,
+  chapters: { id: number; slug: string }[],
+): Promise<AudioQaReport> {
+  const segFiles = await loadSegmentsFiles(bookDir, chapters);
+
+  let totalLines = 0;
+  let linesChecked = 0;
+  let linesRerecorded = 0;
+  let linesVerified = 0;
+  let linesFlaggedDrift = 0;
+  const chaptersFlaggedSet = new Set<number>();
+  const eligibleChapterIds = new Set<number>();
+  const stochasticCharacterIds = new Set<string>();
+
+  for (const seg of segFiles) {
+    let chapterHasSuspect = false;
+    for (const s of seg.segments ?? []) {
+      const lineCount = Array.isArray(s.sentenceIds) ? s.sentenceIds.length : 0;
+      totalLines += lineCount;
+      const anySeg = s as unknown as {
+        qa?: unknown; suspect?: boolean; qaRetries?: number;
+        asr?: unknown; asrSuspect?: boolean;
+      };
+      if (anySeg.qa != null) linesChecked += lineCount;
+      if ((anySeg.qaRetries ?? 0) > 0) linesRerecorded += lineCount;
+      if (anySeg.suspect) chapterHasSuspect = true;
+      if (anySeg.asr != null) linesVerified += lineCount;
+      if (anySeg.asrSuspect) linesFlaggedDrift += lineCount;
+    }
+    if (chapterHasSuspect) chaptersFlaggedSet.add(seg.chapterId);
+
+    for (const [charId, snap] of Object.entries(seg.characterSnapshots ?? {})) {
+      if (snap.voiceEngine && STOCHASTIC_ENGINES.has(snap.voiceEngine)) {
+        stochasticCharacterIds.add(charId);
+        eligibleChapterIds.add(seg.chapterId);
+      }
+    }
+  }
+
+  const outline = await deriveBookOutline(bookDir, chapters);
+  const attribution: 'full' | 'legacy-unattributed' = outline.issues.some((r) => r.chapterId == null)
+    ? 'legacy-unattributed'
+    : 'full';
+  const uncheckedSet = new Set(outline.counts.uncheckedCharacters);
+
+  return {
+    chaptersRendered: segFiles.length,
+    totalLines,
+    acoustic: {
+      linesChecked,
+      linesRerecorded,
+      chaptersFlagged: chaptersFlaggedSet.size,
+    },
+    asr: {
+      linesVerified,
+      linesFlaggedDrift,
+    },
+    voiceDrift: {
+      attribution,
+      chaptersEligible: eligibleChapterIds.size,
+      chaptersScored: outline.scoredChapterIds.filter((id) => eligibleChapterIds.has(id)).length,
+      charactersOnRoster: stochasticCharacterIds.size,
+      charactersChecked: Array.from(stochasticCharacterIds).filter((id) => !uncheckedSet.has(id)).length,
+      mismatches: outline.issues.map((r) => ({
+        characterId: r.characterId,
+        chapterId: r.chapterId,
+        fixable: r.fixable,
+      })),
+      inconclusiveCount: outline.inconclusiveChapterIds.length,
+      uncheckedCharacterIds: outline.counts.uncheckedCharacters,
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd server && npx vitest run src/audio/qa-report.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/audio/qa-report.ts server/src/audio/qa-report.test.ts
+git commit -m "feat(server): add buildAudioQaReport aggregation (fs-51)"
+```
+
+---
+
+### Task 6: New route `GET /api/books/:bookId/qa-report`
+
+**Files:**
+- Create: `server/src/routes/qa-report.ts`
+- Create: `server/src/routes/qa-report.test.ts`
+- Modify: `server/src/app.ts:61` (import), `:186` (mount, alongside `revisionsRouter`)
+- Modify: `server/src/routes/revisions.ts:43` (export `DriftEvent`)
+
+**Interfaces:**
+- Consumes: `buildAudioQaReport` (Task 5), `getRevisionsForBook` (`routes/revisions.ts`, already exists).
+- Produces: `GET /api/books/:bookId/qa-report` → 200 `BookQaReport` JSON, 404 if the book doesn't exist.
+
+- [ ] **Step 1: Write the failing test**
+
+Look at `server/src/routes/revisions.test.ts` for this codebase's pattern for spinning up `app` and hitting a `/api/books/:bookId/...` route with `supertest` (or whatever HTTP test client it uses) against a temp book fixture — reuse that exact harness. Create `server/src/routes/qa-report.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+// Mirror revisions.test.ts's imports for: the app instance / request client,
+// and the temp-book-fixture helper (creates a book dir + state.json on disk).
+
+describe('GET /api/books/:bookId/qa-report', () => {
+  it('returns a BookQaReport for an existing book', async () => {
+    const { bookId } = await makeTestBook({ chapters: [] }); // mirror revisions.test.ts's fixture helper
+    const res = await request(app).get(`/api/books/${bookId}/qa-report`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      bookId,
+      chaptersRendered: 0,
+      chaptersTotal: 0,
+      configDrift: { counts: { mild: 0, moderate: 0, severe: 0 } },
+    });
+  });
+
+  it('404s for an unknown book', async () => {
+    const res = await request(app).get('/api/books/does-not-exist/qa-report');
+    expect(res.status).toBe(404);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/routes/qa-report.test.ts`
+Expected: FAIL — 404 (route doesn't exist / not mounted).
+
+- [ ] **Step 3: Implement**
+
+In `server/src/routes/revisions.ts`, export the interface (line 43): change `interface DriftEvent {` to `export interface DriftEvent {`.
+
+Create `server/src/routes/qa-report.ts`:
+
+```ts
+import { Router } from 'express';
+import type { Request, Response } from '../http.js';
+import { findBookByBookId } from '../workspace/scan.js';
+import { buildAudioQaReport } from '../audio/qa-report.js';
+import { getRevisionsForBook } from './revisions.js';
+
+export const qaReportRouter = Router();
+
+qaReportRouter.get('/:bookId/qa-report', async (req: Request, res: Response) => {
+  const { bookId } = req.params;
+  const located = await findBookByBookId(bookId);
+  if (!located) {
+    res.status(404).json({ error: 'Book not found' });
+    return;
+  }
+  const { bookDir, state } = located;
+
+  const [audio, revisions] = await Promise.all([
+    buildAudioQaReport(bookDir, state.chapters),
+    getRevisionsForBook(bookId),
+  ]);
+
+  const drift = revisions?.drift ?? [];
+  const counts = { mild: 0, moderate: 0, severe: 0 } as Record<'mild' | 'moderate' | 'severe', number>;
+  for (const event of drift) counts[event.severity] += 1;
+
+  res.json({
+    bookId,
+    generatedAt: new Date().toISOString(),
+    chaptersTotal: state.chapters.length,
+    ...audio,
+    configDrift: { counts, events: drift },
+  });
+});
+```
+
+In `server/src/app.ts`:
+- Add near line 61: `import { qaReportRouter } from './routes/qa-report.js';`
+- Add near line 186: `app.use('/api/books', qaReportRouter); // fs-51 — mounts /:bookId/qa-report`
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/routes/qa-report.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/qa-report.ts server/src/routes/qa-report.test.ts server/src/routes/revisions.ts server/src/app.ts
+git commit -m "feat(server): add GET /api/books/:bookId/qa-report endpoint"
+```
+
+---
+
+### Task 7: `openapi.yaml` schema + regenerate frontend types
+
+**Files:**
+- Modify: `openapi.yaml` (add `BookQaReport` schema under `components:` near `BookStateResponse` at line 5419; add the path under `paths:`)
+- Modify (generated, do not hand-edit): `src/lib/api-types.ts`
+
+**Interfaces:**
+- Produces: `BookQaReport` TypeScript type, importable from `src/lib/api-types.ts`, consumed by Task 8.
+
+- [ ] **Step 1: Add the schema**
+
+In `openapi.yaml`, under `components:` (near `BookStateResponse`, ~line 5419), add:
+
+```yaml
+    BookQaReport:
+      type: object
+      required: [bookId, generatedAt, chaptersRendered, chaptersTotal, totalLines, acoustic, asr, voiceDrift, configDrift]
+      properties:
+        bookId: { type: string }
+        generatedAt: { type: string, format: date-time }
+        chaptersRendered: { type: integer }
+        chaptersTotal: { type: integer }
+        totalLines: { type: integer }
+        acoustic:
+          type: object
+          required: [linesChecked, linesRerecorded, chaptersFlagged]
+          properties:
+            linesChecked: { type: integer }
+            linesRerecorded: { type: integer }
+            chaptersFlagged: { type: integer }
+        asr:
+          type: object
+          required: [linesVerified, linesFlaggedDrift]
+          properties:
+            linesVerified: { type: integer }
+            linesFlaggedDrift: { type: integer }
+        voiceDrift:
+          type: object
+          required: [attribution, chaptersEligible, chaptersScored, charactersOnRoster, charactersChecked, mismatches, inconclusiveCount, uncheckedCharacterIds]
+          properties:
+            attribution: { type: string, enum: [full, legacy-unattributed] }
+            chaptersEligible: { type: integer }
+            chaptersScored: { type: integer }
+            charactersOnRoster: { type: integer }
+            charactersChecked: { type: integer }
+            mismatches:
+              type: array
+              items:
+                type: object
+                required: [characterId, fixable]
+                properties:
+                  characterId: { type: string }
+                  chapterId: { type: integer, nullable: true }
+                  fixable: { type: boolean }
+            inconclusiveCount: { type: integer }
+            uncheckedCharacterIds:
+              type: array
+              items: { type: string }
+        configDrift:
+          type: object
+          required: [counts, events]
+          properties:
+            counts:
+              type: object
+              required: [mild, moderate, severe]
+              properties:
+                mild: { type: integer }
+                moderate: { type: integer }
+                severe: { type: integer }
+            events:
+              type: array
+              items: {} # reuses whatever the existing DriftEvent schema entry is named in this file — grep openapi.yaml for the drift-report modal's existing schema (search "autoQueueable") and reference it by $ref instead of leaving this untyped.
+```
+
+Before finalizing, grep `openapi.yaml` for `autoQueueable` (a `DriftEvent`-specific field) to find the existing schema component name for drift events (likely `DriftEvent` or similar, backing the `/api/books/{bookId}/revisions` response) and replace the `events` items placeholder above with `{ $ref: '#/components/schemas/<that name>' }`.
+
+Under `paths:`, add (near the existing `/api/books/{bookId}/revisions` path, for proximity):
+
+```yaml
+  /api/books/{bookId}/qa-report:
+    get:
+      summary: Per-book QA report (fs-51) — acoustic, ASR, voice-drift, and config-drift signals aggregated for one book.
+      parameters:
+        - name: bookId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/BookQaReport' }
+        '404':
+          description: Book not found
+```
+
+- [ ] **Step 2: Regenerate types**
+
+Run: `npm run openapi:types`
+Expected: `src/lib/api-types.ts` updates with no errors; diff shows a new `BookQaReport` type and the new path entry.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS (no consumers reference the new type yet, so this just confirms the generated file itself is valid).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add openapi.yaml src/lib/api-types.ts
+git commit -m "feat(openapi): add BookQaReport schema and GET /api/books/{bookId}/qa-report"
+```
+
+---
+
+### Task 8: Frontend `api.ts` client + mock fixture
+
+**Files:**
+- Modify: `src/lib/api.ts` (add `getQaReport` to both the `real` object near line 7486 and the `mock` object near line 7754)
+- Create: `src/data/qa-report.ts` (mock fixture, following the `src/data/drift.ts` / `src/data/revisions.ts` location convention)
+- Test: `src/lib/api.test.ts` (or wherever this file's existing GET-endpoint tests live — check for an `api.test.ts` first; if none exists for this file, add a focused test file `src/lib/api.qa-report.test.ts`)
+
+**Interfaces:**
+- Consumes: `BookQaReport` type from `src/lib/api-types.ts` (Task 7).
+- Produces: `api.getQaReport(bookId: string): Promise<BookQaReport>` — consumed by Task 9's hook.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/api.qa-report.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('api.getQaReport', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ bookId: 'b1', generatedAt: '2026-01-01T00:00:00Z', chaptersRendered: 1, chaptersTotal: 1, totalLines: 10, acoustic: { linesChecked: 10, linesRerecorded: 0, chaptersFlagged: 0 }, asr: { linesVerified: 0, linesFlaggedDrift: 0 }, voiceDrift: { attribution: 'full', chaptersEligible: 0, chaptersScored: 0, charactersOnRoster: 0, charactersChecked: 0, mismatches: [], inconclusiveCount: 0, uncheckedCharacterIds: [] }, configDrift: { counts: { mild: 0, moderate: 0, severe: 0 }, events: [] } }),
+    })));
+  });
+
+  it('fetches the book-scoped QA report endpoint', async () => {
+    const { real } = await import('./api'); // adjust to however this file exposes `real` for direct testing — check an existing api.*.test.ts for the import pattern this codebase already uses to reach past the USE_MOCKS switch
+    const report = await real.getQaReport('b1');
+    expect(report.bookId).toBe('b1');
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/api/books/b1/qa-report'));
+  });
+});
+```
+
+Check an existing focused test file (e.g. any `src/lib/api.*.test.ts`) for exactly how `real`/`mock` are exported/imported for direct testing in this codebase, and match that pattern rather than guessing at the import above.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/api.qa-report.test.ts`
+Expected: FAIL — `getQaReport` doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+Create `src/data/qa-report.ts`:
+
+```ts
+import type { BookQaReport } from '../lib/api-types';
+
+/* fs-51 mock fixture — a clean, fully-covered book, used by the mock API
+   surface (VITE_USE_MOCKS=true) and as the e2e default. */
+export const MOCK_QA_REPORT: BookQaReport = {
+  bookId: 'demo-book',
+  generatedAt: '2026-07-05T00:00:00.000Z',
+  chaptersRendered: 12,
+  chaptersTotal: 12,
+  totalLines: 342,
+  acoustic: { linesChecked: 342, linesRerecorded: 3, chaptersFlagged: 0 },
+  asr: { linesVerified: 342, linesFlaggedDrift: 0 },
+  voiceDrift: {
+    attribution: 'full',
+    chaptersEligible: 12,
+    chaptersScored: 12,
+    charactersOnRoster: 18,
+    charactersChecked: 18,
+    mismatches: [],
+    inconclusiveCount: 0,
+    uncheckedCharacterIds: [],
+  },
+  configDrift: { counts: { mild: 0, moderate: 0, severe: 0 }, events: [] },
+};
+```
+
+In `src/lib/api.ts`, near the `real` object's other book-scoped GET calls (~line 7486), add:
+
+```ts
+  getQaReport: async (bookId: string): Promise<BookQaReport> => {
+    const res = await fetch(`/api/books/${encodeURIComponent(bookId)}/qa-report`);
+    if (!res.ok) throw new Error(`getQaReport failed: ${res.status}`);
+    return res.json();
+  },
+```
+
+Near the `mock` object (~line 7754), add:
+
+```ts
+  getQaReport: async (_bookId: string): Promise<BookQaReport> => MOCK_QA_REPORT,
+```
+
+Add the import at the top of `api.ts` (alongside its other `src/data/*` imports): `import { MOCK_QA_REPORT } from '../data/qa-report';` and `import type { BookQaReport } from './api-types';` (or wherever this file's existing `api-types` type imports are grouped — match the existing import block).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/api.qa-report.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/api.ts src/data/qa-report.ts src/lib/api.qa-report.test.ts
+git commit -m "feat(frontend): add api.getQaReport (real + mock)"
+```
+
+---
+
+### Task 9: `useQaReport` hook + client-side export helpers
+
+**Files:**
+- Create: `src/hooks/use-qa-report.ts`
+- Create: `src/lib/download-file.ts` (factors out the Blob-download pattern currently duplicated inline in `listen.tsx` and `share-card-modal.tsx`, per the spec's export-mechanics section)
+- Create: `src/lib/qa-report-export.ts` (text-summary formatter)
+- Test: `src/hooks/use-qa-report.test.ts`, `src/lib/qa-report-export.test.ts`
+
+**Interfaces:**
+- Consumes: `api.getQaReport` (Task 8).
+- Produces: `useQaReport(bookId: string): { report: BookQaReport | null; loading: boolean; error: boolean; refetch: () => void }`; `downloadFile(filename: string, content: string, mimeType: string): void`; `formatQaReportText(report: BookQaReport, bookTitle: string): string`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/lib/qa-report-export.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { formatQaReportText } from './qa-report-export';
+import { MOCK_QA_REPORT } from '../data/qa-report';
+
+describe('formatQaReportText', () => {
+  it('renders a clean, fully-covered report as a proof-receipt block', () => {
+    const text = formatQaReportText(MOCK_QA_REPORT, 'The Coalfall Commission');
+    expect(text).toContain('The Coalfall Commission');
+    expect(text).toContain('Every line held.');
+    expect(text).toContain('Acoustic — 342 lines checked, 3 needed a second take');
+    expect(text).toContain('Voice match — 18 of 18 characters checked, 0 mismatches');
+    expect(text).toContain('Cast continuity — 0 changes since render');
+  });
+
+  it('states coverage plainly when a gate never ran', () => {
+    const report = { ...MOCK_QA_REPORT, asr: { linesVerified: 0, linesFlaggedDrift: 0 }, totalLines: 342 };
+    const text = formatQaReportText(report, 'Book');
+    expect(text).toContain('Transcript — not run for this book');
+  });
+});
+```
+
+`src/hooks/use-qa-report.test.ts` — check an existing hook test in `src/hooks/` (e.g. `use-tts-lifecycle.test.ts` or similar) for this codebase's hook-testing harness (`@testing-library/react`'s `renderHook`) and mirror its setup:
+
+```ts
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useQaReport } from './use-qa-report';
+import { MOCK_QA_REPORT } from '../data/qa-report';
+
+vi.mock('../lib/api', () => ({ api: { getQaReport: vi.fn(async () => MOCK_QA_REPORT) } }));
+
+describe('useQaReport', () => {
+  it('fetches on mount and exposes the report', async () => {
+    const { result } = renderHook(() => useQaReport('b1'));
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.report).toEqual(MOCK_QA_REPORT);
+    expect(result.current.error).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/hooks/use-qa-report.test.ts src/lib/qa-report-export.test.ts`
+Expected: FAIL — modules don't exist.
+
+- [ ] **Step 3: Implement**
+
+Create `src/lib/download-file.ts`:
+
+```ts
+/* Shared Blob-download helper — extracted from the inline patterns in
+   listen.tsx (portable bundle export) and share-card-modal.tsx (JSON
+   export) so fs-51's text/JSON export reuses one implementation. */
+export function downloadFile(filename: string, content: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+```
+
+Create `src/lib/qa-report-export.ts`:
+
+```ts
+import type { BookQaReport } from './api-types';
+
+function acousticLine(r: BookQaReport): string {
+  return `Acoustic — ${r.acoustic.linesChecked} lines checked, ${r.acoustic.linesRerecorded} needed a second take`;
+}
+
+function asrLine(r: BookQaReport): string {
+  if (r.asr.linesVerified === 0 && r.totalLines > 0) return 'Transcript — not run for this book';
+  return `Transcript — ${r.asr.linesVerified} lines verified, ${r.asr.linesFlaggedDrift} flagged`;
+}
+
+function voiceMatchLine(r: BookQaReport): string {
+  const vd = r.voiceDrift;
+  if (vd.chaptersEligible === 0) return 'Voice match — no stochastic-voiced characters in this book';
+  if (vd.chaptersScored === 0) return 'Voice match — not run for this book';
+  const shortfall = vd.charactersChecked < vd.charactersOnRoster;
+  const base = shortfall
+    ? `Voice match — ${vd.charactersChecked} of ${vd.charactersOnRoster} characters checked`
+    : `Voice match — ${vd.charactersOnRoster} of ${vd.charactersOnRoster} characters checked`;
+  return `${base}, ${vd.mismatches.length} mismatches`;
+}
+
+function castContinuityLine(r: BookQaReport): string {
+  const total = r.configDrift.counts.mild + r.configDrift.counts.moderate + r.configDrift.counts.severe;
+  return `Cast continuity — ${total} changes since render`;
+}
+
+function headline(r: BookQaReport): string {
+  const issues = r.acoustic.chaptersFlagged + r.asr.linesFlaggedDrift + r.voiceDrift.mismatches.length;
+  return issues === 0 ? 'Every line held.' : `${issues} lines needed a second take.`;
+}
+
+export function formatQaReportText(report: BookQaReport, bookTitle: string): string {
+  return [
+    `${bookTitle} — Castwright quality gate`,
+    headline(report),
+    `· ${acousticLine(report)}`,
+    `· ${asrLine(report)}`,
+    `· ${voiceMatchLine(report)}`,
+    `· ${castContinuityLine(report)}`,
+  ].join('\n');
+}
+
+export function formatQaReportJson(report: BookQaReport): string {
+  return JSON.stringify(report, null, 2);
+}
+```
+
+Create `src/hooks/use-qa-report.ts`:
+
+```ts
+import { useCallback, useEffect, useState } from 'react';
+import { api } from '../lib/api';
+import type { BookQaReport } from '../lib/api-types';
+
+export function useQaReport(bookId: string) {
+  const [report, setReport] = useState<BookQaReport | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  const fetchReport = useCallback(async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const r = await api.getQaReport(bookId);
+      setReport(r);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [bookId]);
+
+  useEffect(() => {
+    void fetchReport();
+  }, [fetchReport]);
+
+  return { report, loading, error, refetch: fetchReport };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/hooks/use-qa-report.test.ts src/lib/qa-report-export.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/download-file.ts src/lib/qa-report-export.ts src/hooks/use-qa-report.ts src/hooks/use-qa-report.test.ts src/lib/qa-report-export.test.ts
+git commit -m "feat(frontend): add useQaReport hook and export formatting helpers"
+```
+
+---
+
+### Task 10: `QaReportCard` component
+
+**Files:**
+- Create: `src/components/qa-report-card.tsx`
+- Test: `src/components/qa-report-card.test.tsx`
+
+**Interfaces:**
+- Consumes: `BookQaReport` (Task 7), `downloadFile` + `formatQaReportText`/`formatQaReportJson` (Task 9), `Pill` (`src/components/primitives.tsx`, existing).
+- Produces: `<QaReportCard report={BookQaReport | null} loading={boolean} error={boolean} bookTitle={string} />` — a pure presentational component, no store reads (matches the `listen-header.tsx`/`listen-download-section.tsx` "dumb region" convention the spec calls out).
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+// src/components/qa-report-card.test.tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { QaReportCard } from './qa-report-card';
+import { MOCK_QA_REPORT } from '../data/qa-report';
+
+describe('QaReportCard', () => {
+  it('shows the clean-book headline and all four rows when fully covered', () => {
+    render(<QaReportCard report={MOCK_QA_REPORT} loading={false} error={false} bookTitle="Test Book" />);
+    expect(screen.getByText(/Every line/)).toBeInTheDocument();
+    expect(screen.getByText(/held/)).toBeInTheDocument();
+    expect(screen.getByText(/342 lines checked/)).toBeInTheDocument();
+    expect(screen.getByText(/18 of 18 characters checked/)).toBeInTheDocument();
+  });
+
+  it('shows the not-enabled invitation copy for a gate that never ran', () => {
+    const report = { ...MOCK_QA_REPORT, asr: { linesVerified: 0, linesFlaggedDrift: 0 } };
+    render(<QaReportCard report={report} loading={false} error={false} bookTitle="Test Book" />);
+    expect(screen.getByText(/turn on transcript verification/i)).toBeInTheDocument();
+  });
+
+  it('shows the no-stochastic-characters state distinctly from not-run', () => {
+    const report = { ...MOCK_QA_REPORT, voiceDrift: { ...MOCK_QA_REPORT.voiceDrift, chaptersEligible: 0, chaptersScored: 0, charactersOnRoster: 0, charactersChecked: 0 } };
+    render(<QaReportCard report={report} loading={false} error={false} bookTitle="Test Book" />);
+    expect(screen.getByText(/no stochastic-voiced characters/i)).toBeInTheDocument();
+  });
+
+  it('shows an inline unavailable state on fetch error, without throwing', () => {
+    render(<QaReportCard report={null} loading={false} error={true} bookTitle="Test Book" />);
+    expect(screen.getByText(/qa report unavailable/i)).toBeInTheDocument();
+  });
+
+  it('triggers a text download when the export button is clicked', () => {
+    render(<QaReportCard report={MOCK_QA_REPORT} loading={false} error={false} bookTitle="Test Book" />);
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    screen.getByRole('button', { name: /copy as text/i }).click();
+    expect(clickSpy).toHaveBeenCalled();
+    clickSpy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/components/qa-report-card.test.tsx`
+Expected: FAIL — module doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+Create `src/components/qa-report-card.tsx`:
+
+```tsx
+import type { BookQaReport } from '../lib/api-types';
+import { downloadFile } from '../lib/download-file';
+import { formatQaReportJson, formatQaReportText } from '../lib/qa-report-export';
+import { Pill } from './primitives';
+
+interface QaReportCardProps {
+  report: BookQaReport | null;
+  loading: boolean;
+  error: boolean;
+  bookTitle: string;
+}
+
+function slugify(title: string): string {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+}
+
+function headline(report: BookQaReport): { bold: string; rest: string } {
+  const issues = report.acoustic.chaptersFlagged + report.asr.linesFlaggedDrift + report.voiceDrift.mismatches.length;
+  if (issues === 0) return { bold: 'held', rest: 'Every line ' };
+  return { bold: String(issues), rest: ` lines needed a second take.` };
+}
+
+function AcousticRow({ report }: { report: BookQaReport }) {
+  const { linesChecked, linesRerecorded } = report.acoustic;
+  return (
+    <div className="flex items-center justify-between py-2">
+      <span className="text-sm text-ink/70">Acoustic</span>
+      <span className="text-sm text-ink">{linesChecked} lines checked, {linesRerecorded} needed a second take</span>
+    </div>
+  );
+}
+
+function TranscriptRow({ report }: { report: BookQaReport }) {
+  const { linesVerified, linesFlaggedDrift } = report.asr;
+  if (linesVerified === 0 && report.totalLines > 0) {
+    return (
+      <div className="flex items-center justify-between py-2">
+        <span className="text-sm text-ink/70">Transcript</span>
+        <span className="text-sm text-ink/50">Not run for this book — turn on transcript verification before your next render.</span>
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center justify-between py-2">
+      <span className="text-sm text-ink/70">Transcript</span>
+      <span className="text-sm text-ink">{linesVerified} lines verified, {linesFlaggedDrift} flagged</span>
+    </div>
+  );
+}
+
+function VoiceMatchRow({ report }: { report: BookQaReport }) {
+  const vd = report.voiceDrift;
+  if (vd.chaptersEligible === 0) {
+    return (
+      <div className="flex items-center justify-between py-2">
+        <span className="text-sm text-ink/70">Voice match</span>
+        <span className="text-sm text-ink/50">No stochastic-voiced characters in this book — nothing for this check to do.</span>
+      </div>
+    );
+  }
+  if (vd.chaptersScored === 0) {
+    return (
+      <div className="flex items-center justify-between py-2">
+        <span className="text-sm text-ink/70">Voice match</span>
+        <span className="text-sm text-ink/50">Not run for this book — flip on render-integrity checking to catch mismatches automatically.</span>
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center justify-between py-2">
+      <span className="text-sm text-ink/70">Voice match</span>
+      <span className="text-sm text-ink">
+        {vd.charactersChecked} of {vd.charactersOnRoster} characters checked, {vd.mismatches.length} mismatches
+      </span>
+    </div>
+  );
+}
+
+function CastContinuityRow({ report }: { report: BookQaReport }) {
+  const { mild, moderate, severe } = report.configDrift.counts;
+  const total = mild + moderate + severe;
+  return (
+    <div className="flex items-center justify-between py-2">
+      <span className="text-sm text-ink/70">Cast continuity</span>
+      <div className="flex items-center gap-2">
+        {severe > 0 && <Pill color="danger">{severe} severe</Pill>}
+        {moderate > 0 && <Pill color="warning">{moderate} moderate</Pill>}
+        {mild > 0 && <Pill color="neutral">{mild} mild</Pill>}
+        {total === 0 && <span className="text-sm text-ink">0 changes since render</span>}
+      </div>
+    </div>
+  );
+}
+
+export function QaReportCard({ report, loading, error, bookTitle }: QaReportCardProps) {
+  if (loading) {
+    return <div className="bg-white rounded-3xl border border-ink/10 shadow-card p-6 text-sm text-ink/50">Loading QA report…</div>;
+  }
+  if (error || !report) {
+    return <div className="bg-white rounded-3xl border border-ink/10 shadow-card p-6 text-sm text-ink/50">QA report unavailable.</div>;
+  }
+  const { bold, rest } = headline(report);
+
+  return (
+    <div className="bg-white rounded-3xl border border-ink/10 shadow-card p-6">
+      <p className="text-sm uppercase tracking-widest text-ink/45 font-semibold mb-2">Quality gate</p>
+      <h3 className="text-lg font-medium text-ink mb-1">
+        {rest}<span className="font-bold">{bold}</span>{rest.endsWith(' ') ? '' : ''}
+      </h3>
+      <p className="text-sm text-ink/60 mb-4">
+        Checked, verified, and matched against every character's own voice — automatically, before this book reached you.
+      </p>
+      <div className="divide-y divide-ink/5">
+        <AcousticRow report={report} />
+        <TranscriptRow report={report} />
+        <VoiceMatchRow report={report} />
+        <CastContinuityRow report={report} />
+      </div>
+      <div className="flex gap-2 mt-4">
+        <button
+          onClick={() => downloadFile(`${slugify(bookTitle)}-qa-report.txt`, formatQaReportText(report, bookTitle), 'text/plain')}
+          className="text-xs font-semibold text-ink/70 hover:text-ink px-3 py-1.5 rounded-full border border-ink/10"
+        >
+          Copy as text
+        </button>
+        <button
+          onClick={() => downloadFile(`${slugify(bookTitle)}-qa-report.json`, formatQaReportJson(report), 'application/json')}
+          className="text-xs font-semibold text-ink/70 hover:text-ink px-3 py-1.5 rounded-full border border-ink/10"
+        >
+          Download as JSON
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+Check `src/components/primitives.tsx`'s actual `Pill` prop signature (the `color` prop's accepted values — `drift-report.tsx` uses `'danger' | 'warning' | 'neutral'`, confirm this matches exactly) before finalizing this file — adjust the `color=` values above if the real prop name/values differ.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/components/qa-report-card.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/qa-report-card.tsx src/components/qa-report-card.test.tsx
+git commit -m "feat(frontend): add QaReportCard component"
+```
+
+---
+
+### Task 11: Mount `QaReportCard` in the Listen view
+
+**Files:**
+- Modify: `src/views/listen.tsx` (add the hook call + mount, near the `ListenPlayerRegion` mount at line 188-190)
+- Test: `src/views/listen.test.tsx` (existing file — check it exists; if the view has no dedicated test file, add assertions to whichever test file already covers `listen.tsx`'s rendering)
+
+**Interfaces:**
+- Consumes: `useQaReport` (Task 9), `QaReportCard` (Task 10).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing Listen view test file (find it via `Glob: src/views/listen*.test.tsx`):
+
+```tsx
+it('renders the QA report card', async () => {
+  // Reuse this file's existing renderListenView()-style helper and its
+  // api mock setup; add a getQaReport mock returning MOCK_QA_REPORT if
+  // the helper doesn't already stub every api.* method generically.
+  renderListenView();
+  expect(await screen.findByText(/quality gate/i)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/views/listen.test.tsx -t "QA report"`
+Expected: FAIL — nothing renders "quality gate" yet.
+
+- [ ] **Step 3: Implement**
+
+In `src/views/listen.tsx`:
+- Import `useQaReport` and `QaReportCard`.
+- Call `const { report: qaReport, loading: qaLoading, error: qaError } = useQaReport(bookId);` near this file's other top-level hook calls.
+- Mount `<QaReportCard report={qaReport} loading={qaLoading} error={qaError} bookTitle={bookTitle} />` as a new sibling section directly after the `<ListenPlayerRegion .../>` block (~line 188-190) and before `<ListenDownloadSection .../>`, matching whatever the existing `bookTitle`-equivalent prop/variable is already called in this file (check its existing props for the book title used in `ListenHeader`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/views/listen.test.tsx`
+Expected: PASS, including all pre-existing tests in the file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/views/listen.tsx src/views/listen.test.tsx
+git commit -m "feat(frontend): mount QaReportCard on the Listen view"
+```
+
+---
+
+### Task 12: Mount `QaReportCard` in the Generation view, refetching on `chapter_complete`
+
+**Files:**
+- Modify: `src/views/generation.tsx` (add the hook + mount + refetch trigger)
+- Test: `src/views/generation.test.tsx` (existing file)
+
+**Interfaces:**
+- Consumes: `useQaReport` (Task 9, its `refetch` return value), `QaReportCard` (Task 10), this file's existing `chapter_complete` activity-feed tracking (`ACTIVITY_FEED_TYPES` at line 98-103).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/views/generation.test.tsx`:
+
+```tsx
+it('refetches the QA report when a chapter completes', async () => {
+  // Reuse this file's existing helpers for rendering the view and for
+  // dispatching a chapter_complete change-log event.
+  const getQaReport = vi.fn(async () => MOCK_QA_REPORT);
+  renderGenerationView({ apiOverrides: { getQaReport } }); // adjust to this file's actual render-helper signature
+  await screen.findByText(/quality gate/i);
+  expect(getQaReport).toHaveBeenCalledTimes(1);
+
+  dispatchChapterComplete(); // this file's existing helper for firing a chapter_complete event, or the store action it dispatches directly
+
+  await waitFor(() => expect(getQaReport).toHaveBeenCalledTimes(2));
+});
+```
+
+Match the actual test-rendering and event-dispatch helper names already used elsewhere in this file — read it first.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/views/generation.test.tsx -t "refetches the QA report"`
+Expected: FAIL — the card/hook aren't wired in yet.
+
+- [ ] **Step 3: Implement**
+
+In `src/views/generation.tsx`:
+- Import `useQaReport` and `QaReportCard`.
+- Call `const { report: qaReport, loading: qaLoading, error: qaError, refetch: refetchQaReport } = useQaReport(bookId);`.
+- Find where this view already reacts to a `chapter_complete` entry landing in its activity feed (search for `ACTIVITY_FEED_TYPES` usage — line 98-103 defines the array; find the `useEffect` or reducer that consumes new entries of these types) and add a call to `refetchQaReport()` specifically when the new entry's `type === 'chapter_complete'`.
+- Mount `<QaReportCard report={qaReport} loading={qaLoading} error={qaError} bookTitle={bookTitle} />` in a sensible position in this view's existing layout (near the top-level chapter list/progress summary — match this file's existing structure rather than inventing a new layout region).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/views/generation.test.tsx`
+Expected: PASS, including all pre-existing tests in the file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/views/generation.tsx src/views/generation.test.tsx
+git commit -m "feat(frontend): mount QaReportCard on the Generation view with live refetch"
+```
+
+---
+
+### Task 13: E2E Playwright spec
+
+**Files:**
+- Create: `e2e/qa-report.spec.ts`
+
+**Interfaces:**
+- Consumes: the mocked API surface (`VITE_USE_MOCKS=true`, the default for `npm run test:e2e`), `MOCK_QA_REPORT` fixture (Task 8).
+
+- [ ] **Step 1: Write the spec**
+
+Check an existing simple Listen-view e2e spec (e.g. `e2e/listen.spec.ts` or similar — `Glob: e2e/*.spec.ts` for the closest analog) for this codebase's navigation helpers (how a test gets from the book library to a book's Listen view) and mirror that setup. Create `e2e/qa-report.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test';
+// Import whatever this codebase's existing e2e specs use to navigate to a
+// book's Listen view (a shared helper under e2e/ — check for one before
+// writing raw page.goto/page.click calls).
+
+test('QA report card renders and exports on the Listen view', async ({ page }) => {
+  // navigate to a demo book's Listen view using the existing e2e navigation helper
+  await expect(page.getByText(/quality gate/i)).toBeVisible();
+  await expect(page.getByText(/every line/i)).toBeVisible();
+
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.getByRole('button', { name: /copy as text/i }).click(),
+  ]);
+  expect(download.suggestedFilename()).toMatch(/qa-report\.txt$/);
+
+  const [jsonDownload] = await Promise.all([
+    page.waitForEvent('download'),
+    page.getByRole('button', { name: /download as json/i }).click(),
+  ]);
+  expect(jsonDownload.suggestedFilename()).toMatch(/qa-report\.json$/);
+});
+```
+
+- [ ] **Step 2: Run the spec**
+
+Run: `npm run test:e2e -- qa-report.spec.ts`
+Expected: PASS. If the mock book fixture used by e2e doesn't already return `MOCK_QA_REPORT` from `api.getQaReport` (check whether the e2e mock server reuses the same `src/lib/api.ts` mock branch, or a separate e2e-only mock layer), wire it in so this spec has real coverage rather than exercising an unmocked 404.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/qa-report.spec.ts
+git commit -m "test(e2e): add QA report card + export coverage"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage**: Architecture (Tasks 1, 5, 6), report schema (Task 5), UX/copy (Task 10), export mechanics (Task 9/10), frontend surfaces (Tasks 11/12), the fresh-verdict requirement (Tasks 3/4), retry counters (Task 2), `chapterId`/legacy-attribution (Task 1/5), testing (each task's own test + Task 13 e2e) — all covered. The spec's two "resolved" open questions (splice routes through `synthesiseChapter` but discards verdicts; repair patches `render-integrity.json` directly, doesn't re-trigger `scoreBook`) are directly implemented in Tasks 3 and 4 respectively.
+- **Not in this plan, deliberately** (per the spec's "Out of scope"): srv-36 Phase 2 consistency row, any change to gate on/off behavior itself beyond the fresh-verdict correctness fix, a QA-history-over-time view, backfilling `chapterId` onto existing books' `render-integrity.json` files.
+- **Known research gaps flagged inline rather than guessed**: Task 4's exact `replacements`-array construction site in `chapter-qa-repair.ts` (above the excerpt this plan's research covered) and Task 3/11/12's exact existing test-helper names — both are called out explicitly as "read the file first, match its existing names" rather than invented, so the implementer verifies against real code instead of a plan-author's guess.

--- a/docs/superpowers/plans/2026-07-05-fs51-qa-report.md
+++ b/docs/superpowers/plans/2026-07-05-fs51-qa-report.md
@@ -12,7 +12,9 @@
 
 2026-07-05 round 2 (adversarial pass on the round-1 revision). Found that fix #4 above was only half-done: `chaptersEmbedFailed` was restored to the *schema*, but nothing in Task 9/10's frontend code actually reads it — the voice-match row's partial-coverage condition only checked `charactersChecked < charactersOnRoster`, so a book with an isolated embed failure (full character coverage, one chapter's embeddings failed) still rendered a clean "18 of 18 characters checked, 0 mismatches" — the exact false-clean the field exists to prevent. Also found `MOCK_QA_REPORT` (Task 8) omits the now-required `chaptersEmbedFailed`, which fails `npm run typecheck` (Task 8's own gate) and every downstream test that spreads the fixture. And a headline unit-mismatch: `headline()` summed a chapter count, a line count, and a mismatch count into one number labeled "lines." This round's fixes: `voiceMatchLine`/`VoiceMatchRow` now branch on `chaptersScored < chaptersEligible` too, with its own chapter-fraction copy; `MOCK_QA_REPORT` gained the field; `headline()` in both the export formatter and the card now uses `acoustic.linesRerecorded` specifically (a genuine line count) rather than summing unlike units, falling back to non-numeric copy when the only issues are ASR/voice-drift ones.
 
-2026-07-05 round 3 (final automated pass, per the plan's own 3-round cap). Found the round-2 headline fix was itself inconsistent with its own fixture: `MOCK_QA_REPORT` still carried `acoustic.linesRerecorded: 3` while three tasks' tests (9, 10, 13) asserted the *clean* `"Every line held."` headline against that same fixture — a genuine contradiction that would have failed those tasks' own test gates. Fixed by setting the fixture's `linesRerecorded` to `0`, matching the spec's own clean-receipt example, and updating the one dependent assertion. Two further findings were real scope decisions, put to the user rather than resolved unilaterally: the splice-callback behavior change (Task 3) had a prose acknowledgment but no test asserting the new gate-running behavior actually happens — the user chose to add one, now included as a route-level test in Task 3. And `inconclusiveCount` was computed but never rendered in the card or text export (only the raw JSON export carried it), despite the spec requiring it and the plan's own Self-Review claiming full UX coverage — the user chose to close this now; `voiceMatchLine`/`VoiceMatchRow` both append an inconclusive-chapter note when nonzero. This is the last round allowed under the review-gate cap (initial + 2 re-reviews); the plan is now presented to the user for their own read.
+2026-07-05 round 3 (final automated pass, per the plan's own 3-round cap). Found the round-2 headline fix was itself inconsistent with its own fixture: `MOCK_QA_REPORT` still carried `acoustic.linesRerecorded: 3` while three tasks' tests (9, 10, 13) asserted the *clean* `"Every line held."` headline against that same fixture — a genuine contradiction that would have failed those tasks' own test gates. Fixed by setting the fixture's `linesRerecorded` to `0`, matching the spec's own clean-receipt example, and updating the one dependent assertion. Two further findings were real scope decisions, put to the user rather than resolved unilaterally: the splice-callback behavior change (Task 3) had a prose acknowledgment but no test asserting the new gate-running behavior actually happens — the user chose to add one. And `inconclusiveCount` was computed but never rendered in the card or text export (only the raw JSON export carried it), despite the spec requiring it and the plan's own Self-Review claiming full UX coverage — the user chose to close this now; `voiceMatchLine`/`VoiceMatchRow` both append an inconclusive-chapter note when nonzero.
+
+2026-07-05 round 4 (user-requested extra pass, outside the automated cap, specifically to verify the round-3 fixes the user had just chosen). Found the new splice route-level test (added per the user's round-3 choice) was itself built on a false premise: it named `chapter-splice.test.ts` as already having a `synthesiseChapter` mock to reuse — that file is the real-ffmpeg remix/gain integration test with no synth-boundary mock, whose one re-record test deliberately asserts failure. The actual mock pattern to mirror lives in the sibling `chapter-splice-rerecord-qa.test.ts` (hoisted `vi.mock` of both `../store/analysis-cache.js` and `../tts/synthesise-chapter.js`, real `supertest` driving, real temp-workspace fixtures) — the draft's locally-declared `vi.fn`, invented `runSplice`/`readSegmentsJson` helpers, and missing analysis-cache mock would not have compiled into a working test. Fixed by rewriting the test as a new, self-contained `chapter-splice-fresh-verdict.test.ts` that copies the real sibling's proven scaffold, with a `qa`-bearing synth-mock return and a seeded stale verdict for the re-record to overwrite. Also fixed a cosmetic JSX-comment-as-statement smell in `VoiceMatchRow` (a `{/* */}` block comment sitting between two `if` statements, not inside JSX — compiled fine as a no-op empty block, but read confusingly next to a second, correctly-plain `/* */` comment right below it). The fixture fix, the `freshVerdict` three-site change, and the `inconclusiveCount` UI wiring were all independently re-verified against the real code this round and held up with no further changes needed.
 
 ## Global Constraints
 
@@ -338,9 +340,9 @@ git commit -m "feat(server): stamp qaRetries/asrRetries on re-recorded segments"
 
 **Files:**
 - Modify: `server/src/audio/build-synth-replacement.ts` (SynthOutput + buildSynthReplacements)
-- Modify: `server/src/audio/splice-chapter.ts:24-38` (`SegmentReplacement`), `:180-190` (the single-segment re-record push)
+- Modify: `server/src/audio/splice-chapter.ts:24-38` (`SegmentReplacement`), `:163-204` (all three replacement-run segment-construction sites)
 - Modify: `server/src/routes/chapter-splice.ts:286-310` (the `synth` callback — pass QA/ASR options through)
-- Test: `server/src/audio/build-synth-replacement.test.ts`, `server/src/audio/splice-chapter.test.ts` (both existing files)
+- Test: `server/src/audio/build-synth-replacement.test.ts`, `server/src/audio/splice-chapter.test.ts` (both existing files); `server/src/routes/chapter-splice-fresh-verdict.test.ts` (new file, mirrors the scaffold in the existing `chapter-splice-rerecord-qa.test.ts`)
 
 **Interfaces:**
 - Consumes: `ChapterSegment.qa/asr/suspect/asrSuspect/qaRetries/asrRetries` (Task 2).
@@ -405,42 +407,72 @@ it('uses the replacement freshVerdict instead of the original segment verdict fo
 
 Use whatever this test file's actual fixture helper names are (`makeSegment`/`makeSilencePcm` are placeholders for whatever it already calls them — read the file first and match its existing names exactly).
 
-**fs-51 round-3 review addition**: the two tests above cover the pure `spliceChapterSegments`/`buildSynthReplacements` functions, but neither exercises `chapter-splice.ts`'s route-level change — passing real QA/ASR gate options into its `synth` callback's `synthesiseChapter` call, a genuinely new behavior (manual splice re-records now run gates they didn't before) that this plan's own "every new behavior ships a paired test" rule requires coverage for. Add to `server/src/routes/chapter-splice.test.ts` (mirror this file's existing pattern for mocking `synthesiseChapter` and driving the splice SSE route — it already exists for the pre-fs-51 splice tests):
+**fs-51 round-3 review addition, corrected after a follow-up review pass** (the first draft of this addition named the wrong test file and an idiom that doesn't match this codebase's mocking convention — corrected below against the actual sibling fixture it should mirror): the two tests above cover the pure `spliceChapterSegments`/`buildSynthReplacements` functions, but neither exercises `chapter-splice.ts`'s route-level change — passing real QA/ASR gate options into its `synth` callback's `synthesiseChapter` call, a genuinely new behavior (manual splice re-records now run gates they didn't before) that this plan's own "every new behavior ships a paired test" rule requires coverage for.
+
+`server/src/routes/chapter-splice.test.ts` is the wrong home — it's the real-ffmpeg remix/gain integration file with no synth-boundary mock, and its one re-record test deliberately asserts failure (no analysis-cache fixture). The right pattern to mirror is the sibling `server/src/routes/chapter-splice-rerecord-qa.test.ts`, which already mocks both `../store/analysis-cache.js` and `../tts/synthesise-chapter.js` (via `vi.mock`'s hoisted-factory idiom, not a locally-declared `vi.fn`) and drives the route with real `supertest` + a temp workspace. Create a new, self-contained file rather than editing that one (its mock always returns `segments: []`, which this test needs to override with a `qa`-bearing segment — safer as its own fixture than as a shared-mock edit):
+
+Create `server/src/routes/chapter-splice-fresh-verdict.test.ts`, copying `chapter-splice-rerecord-qa.test.ts`'s full scaffold (the `tone()` PCM helper, the `beforeAll` workspace/state.json/cast.json/segments.json setup, the `afterAll` cleanup) with these changes: the `synthesise-chapter.js` mock's `segments` array returns one segment carrying a clean `qa` verdict (not `[]`), the seeded `<slug>.segments.json` fixture gives Castor's segment a stale `suspect: true`/`qa: {status:'suspect'}` verdict to be overwritten, and the test itself asserts both the gate-options pass-through and the persisted fresh verdict:
 
 ```ts
-it('passes the signal-QA and ASR gate options through to the re-record synth call, and writes a fresh verdict', async () => {
-  const synthesiseChapterMock = vi.fn(async () => ({
-    pcm: Buffer.alloc(100),
-    sampleRate: 24000,
-    segments: [
-      {
-        groupIndex: 0, characterId: 'wren', sentenceIds: [1], startSec: 0, endSec: 1,
-        qa: { status: 'ok', reasons: [], rms: 0.1, longestSilenceSec: 0, durationSec: 1, expectedSec: 1 },
-        suspect: undefined,
-      },
-    ],
-  }));
-  // Mirror this file's existing vi.mock('../tts/synthesise-chapter.js', ...) setup,
-  // substituting synthesiseChapterMock, then drive a splice re-record through the
-  // route exactly as this file's existing splice tests do.
-  await runSplice({ targetIndices: [0] }); // this file's existing helper
+vi.mock('../store/analysis-cache.js', () => ({
+  loadAnalysisCache: vi.fn(async () => ({
+    chapters: { 1: [{ id: 2, characterId: 'castor', text: 'A re-recorded line.' }] },
+  })),
+}));
 
-  expect(synthesiseChapterMock).toHaveBeenCalledWith(
-    expect.objectContaining({
-      maxSegmentRerecords: expect.any(Number),
-    }),
-  );
-  const segFile = await readSegmentsJson(bookDir, chapterSlug); // this file's existing helper
-  expect(segFile.segments[0].qa?.status).toBe('ok');
+vi.mock('../tts/synthesise-chapter.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../tts/synthesise-chapter.js')>();
+  return {
+    ...actual,
+    synthesiseChapter: vi.fn(async () => ({
+      pcm: tone(1.0, 12000),
+      sampleRate: SR,
+      durationSec: 1.0,
+      segments: [
+        {
+          groupIndex: 0, characterId: 'castor', sentenceIds: [2], startSec: 0, endSec: 1.0,
+          qa: { status: 'ok', reasons: [], rms: 0.1, longestSilenceSec: 0, durationSec: 1.0, expectedSec: 1.0 },
+          suspect: undefined,
+        },
+      ],
+    })),
+  };
+});
+
+// ...beforeAll: identical scaffold to chapter-splice-rerecord-qa.test.ts, except
+// the seeded ch1.segments.json's Castor segment (sentenceIds:[2]) carries a
+// stale verdict the re-record must overwrite:
+//   { groupIndex: 1, characterId: 'castor', sentenceIds: [2], startSec: 1.0, endSec: 2.0,
+//     qa: { status: 'suspect', reasons: ['stale'], rms: 0, longestSilenceSec: 0, durationSec: 1.0, expectedSec: 1.0 },
+//     suspect: true }
+
+describe('POST /:bookId/chapters/:chapterId/splice (rerecord) — fs-51 fresh verdict', () => {
+  it('passes the signal-QA/ASR gate options to the re-record synth call and persists its fresh verdict, not the stale one', async () => {
+    const { synthesiseChapter } = await import('../tts/synthesise-chapter.js');
+
+    const res = await request(app)
+      .post(`/api/books/${encodeURIComponent(bookId)}/chapters/1/splice`)
+      .send({ mode: 'rerecord', characterId: 'castor', modelKey: 'kokoro-v1' });
+
+    expect(res.status).toBeLessThan(400);
+    expect(vi.mocked(synthesiseChapter)).toHaveBeenCalledWith(
+      expect.objectContaining({ maxSegmentRerecords: expect.any(Number) }),
+    );
+
+    const segFile = JSON.parse(readFileSync(join(audioRoot, `${SLUG}.segments.json`), 'utf8')) as {
+      segments: Array<{ characterId: string; qa?: { status?: string }; suspect?: boolean }>;
+    };
+    const castorSegment = segFile.segments.find((s) => s.characterId === 'castor');
+    expect(castorSegment?.qa?.status).toBe('ok');
+    expect(castorSegment?.suspect).toBeUndefined();
+  });
 });
 ```
 
-Match helper/mock names to whatever this test file already uses — read it first, same as the note above.
-
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `cd server && npx vitest run src/audio/build-synth-replacement.test.ts src/audio/splice-chapter.test.ts src/routes/chapter-splice.test.ts -t "fresh|gate options"`
-Expected: FAIL — `freshVerdict` doesn't exist yet; the splice still spreads the original segment's stale `suspect: true`; the route-level test fails because the `synth` callback doesn't pass gate options yet.
+Run: `cd server && npx vitest run src/audio/build-synth-replacement.test.ts src/audio/splice-chapter.test.ts src/routes/chapter-splice-fresh-verdict.test.ts`
+Expected: FAIL — `freshVerdict` doesn't exist yet; the splice still spreads the original segment's stale `suspect: true`; the new route-level test fails because the `synth` callback doesn't pass gate options yet.
 
 - [ ] **Step 3: Implement**
 
@@ -610,13 +642,13 @@ Add the two missing imports at the top of `chapter-splice.ts`: `import { configV
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `cd server && npx vitest run src/audio/build-synth-replacement.test.ts src/audio/splice-chapter.test.ts src/routes/chapter-splice.test.ts`
-Expected: PASS, including all pre-existing tests (confirms the gain-remix path, which never sets `freshVerdict`, is unaffected).
+Run: `cd server && npx vitest run src/audio/build-synth-replacement.test.ts src/audio/splice-chapter.test.ts src/routes/chapter-splice-fresh-verdict.test.ts src/routes/chapter-splice.test.ts src/routes/chapter-splice-rerecord-qa.test.ts`
+Expected: PASS, including all pre-existing tests in both `chapter-splice.test.ts` (confirms the gain-remix path, which never sets `freshVerdict`, is unaffected) and `chapter-splice-rerecord-qa.test.ts` (confirms the new gate options don't disturb the fs-32a duration-QA regression it covers).
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add server/src/audio/build-synth-replacement.ts server/src/audio/splice-chapter.ts server/src/routes/chapter-splice.ts server/src/audio/build-synth-replacement.test.ts server/src/audio/splice-chapter.test.ts
+git add server/src/audio/build-synth-replacement.ts server/src/audio/splice-chapter.ts server/src/routes/chapter-splice.ts server/src/audio/build-synth-replacement.test.ts server/src/audio/splice-chapter.test.ts server/src/routes/chapter-splice-fresh-verdict.test.ts
 git commit -m "fix(server): splice re-records now carry a fresh QA/ASR verdict instead of the stale one"
 ```
 
@@ -1735,14 +1767,14 @@ function VoiceMatchRow({ report }: { report: BookQaReport }) {
       </div>
     );
   }
-  {/* fs-51 round-2 review fix: chaptersScored < chaptersEligible (an isolated
-      embed failure) must lead the row, exactly like the character-shortfall
-      case below — otherwise a full-roster book with a failed embed still
-      reads as a clean "N of N characters checked", the false-clean the
-      chaptersEmbedFailed field exists to prevent. */}
-  /* fs-51 round-3 review fix: surface inconclusiveCount (short quotes below
-     the minimum-duration gate) on this row per the spec — it was computed
-     but only ever reached the JSON export. */
+  /* fs-51 round-2 review fix: chaptersScored < chaptersEligible (an isolated
+     embed failure) must lead the row, exactly like the character-shortfall
+     case below — otherwise a full-roster book with a failed embed still
+     reads as a clean "N of N characters checked", the false-clean the
+     chaptersEmbedFailed field exists to prevent.
+     fs-51 round-3 review fix: also surface inconclusiveCount (short quotes
+     below the minimum-duration gate) on this row per the spec — it was
+     computed but only ever reached the JSON export. */
   const inconclusiveNote = vd.inconclusiveCount > 0 ? ` · ${vd.inconclusiveCount} chapters inconclusive` : '';
   if (vd.chaptersScored < vd.chaptersEligible) {
     return (

--- a/docs/superpowers/plans/2026-07-05-fs51-qa-report.md
+++ b/docs/superpowers/plans/2026-07-05-fs51-qa-report.md
@@ -8,6 +8,8 @@
 
 **Tech Stack:** TypeScript, Express (server), React + Redux Toolkit + Vitest + Testing Library (frontend), Playwright (e2e). No new dependencies.
 
+**Revision history:** 2026-07-05 round 1 (adversarial `assumption-checker` pass, code-grounded against the actual current files). Fixed four contradicted claims: (1) frontend code cannot `import type { BookQaReport } from './api-types'` — that module has no bare per-schema exports; Task 7 now adds a named alias to `src/lib/types.ts`, the codebase's actual convention, and Tasks 8-10 import from there. (2) Task 4 assumed `chapter-qa-repair.ts` builds its own replacements array to attach a verdict to — it doesn't; it calls the same `buildSynthReplacements` helper Task 3 modifies, so Task 4 now just makes its `synth` closure return the flat `SynthOutput` shape Task 3 already reads, nothing more. (3) The `freshVerdict` spread in `spliceChapterSegments` only covered the `if (a === b)` branch, which a same-length re-record (exactly what Task 3's own test used) never reaches — the fix now applies to all three segment-construction sites in that function. (4) The spec's `chaptersEmbedFailed` field (distinguishing "gate off" from "an isolated embed failure") was dropped from Task 5/7 — restored to both, computed from evidence already in hand (no new file reads).
+
 ## Global Constraints
 
 - Spec: `docs/superpowers/specs/2026-07-05-fs51-qa-report-design.md` — every requirement below traces to it.
@@ -473,10 +475,29 @@ export interface SegmentReplacement {
 }
 ```
 
-In `spliceChapterSegments`'s single-segment re-record branch (the `if (a === b)` block at line 180-190), apply `freshVerdict` after the base spread:
+**Apply `freshVerdict` at every place `spliceChapterSegments` constructs a segment for a replacement run — not just the `if (a === b)` branch.** `buildSynthReplacements` never sets `innerSegmentByteLengths`, so its replacements always fall into the `else` (length-preserving) branch first; they only reach the `if (a === b)` special case when the new PCM's length happens to differ from the original span's length. When a re-record's new audio happens to be the *same* length as the original (not rare — e.g. a like-for-like re-take), control instead flows through the general per-inner-segment loop at the bottom of that `else` branch, which currently has no `freshVerdict` handling at all. Fix all three segment-construction sites so the fix holds regardless of which branch control takes:
 
 ```ts
+      if (run.innerSegmentByteLengths) {
+        // Re-record: inner segments packed back-to-back; original inner gaps dropped.
+        let cursor = runNewStart;
+        for (let j = a; j <= b; j += 1) {
+          const len = run.innerSegmentByteLengths[j - a];
+          newSegments.push({
+            ...segments[j],
+            ...(run.freshVerdict ?? {}),
+            startSec: pcmDurationSec(cursor, sampleRate),
+            endSec: pcmDurationSec(cursor + len, sampleRate),
+          });
+          cursor += len;
+        }
+      } else {
+        // Gain: length-preserving, so each inner segment keeps its original
+        // relative offset within the run (inner gaps preserved verbatim).
+        const originalSpan = spanEnd - spanStart;
+        if (run.pcm.length !== originalSpan) {
           if (a === b) {
+            // single-segment run: the whole replacement is that one segment
             newSegments.push({
               ...segments[a],
               ...(run.freshVerdict ?? {}),
@@ -487,7 +508,26 @@ In `spliceChapterSegments`'s single-segment re-record branch (the `if (a === b)`
             i = b + 1;
             continue;
           }
+          throw new Error(
+            `splice: gain replacement length ${run.pcm.length} ≠ original span ${originalSpan}; multi-segment runs need innerSegmentByteLengths`,
+          );
+        }
+        for (let j = a; j <= b; j += 1) {
+          const offIn = startByte(j) - spanStart;
+          const offEnd = endByte(j) - spanStart;
+          newSegments.push({
+            ...segments[j],
+            ...(run.freshVerdict ?? {}),
+            startSec: pcmDurationSec(runNewStart + offIn, sampleRate),
+            endSec: pcmDurationSec(runNewStart + offEnd, sampleRate),
+          });
+        }
+      }
 ```
+
+This is the full body of `spliceChapterSegments`'s `if (run)` branch (currently at lines 163-204) with `...(run.freshVerdict ?? {})` added to all three `newSegments.push` call sites. A gain-only replacement (built by the separate gain-remix path elsewhere in `chapter-splice.ts`, not by `buildSynthReplacements`) never sets `freshVerdict`, so `?? {}` makes the spread a no-op there — its segment correctly keeps its prior verdict, since the audio content didn't change.
+
+**Update Task 3's own splice-chapter.ts test** (Step 1, above) so it actually exercises this: as written, that test uses a same-length replacement (`makeSilencePcm(1, 24000)` for both `decodedPcm` and the replacement `pcm`), which — before this fix — would have silently passed through the `else` branch untouched and the assertion would have failed for the wrong reason (or passed vacuously if the original test's expectations happened to align). With the fix above applied to all three sites, that same test now correctly exercises the length-preserving loop path and should pass for the right reason. No test code change needed, just confirming — when running Step 4 below — that this specific test is actually hitting the length-preserving branch (add a temporary `console.log` or check via a debugger if uncertain, then remove it) rather than a branch that happens to already work.
 
 In `server/src/routes/chapter-splice.ts`, update the `synth` callback (line 290-309) to pass the same gate options generation uses, and return the fresh verdict from the single-sentence result:
 
@@ -546,12 +586,14 @@ git commit -m "fix(server): splice re-records now carry a fresh QA/ASR verdict i
 
 ### Task 4: Fix `chapter-qa-repair.ts` to write the accepted take's verdict onto the segment, and count its own retries
 
+**Correction from the plan's adversarial review**: an earlier draft of this task assumed `chapter-qa-repair.ts` builds its own `replacements: SegmentReplacement[]` array that Task 4 would need to locate and attach a verdict to. It doesn't — the repair route calls the exact same `buildSynthReplacements` helper Task 3 already modified (`chapter-qa-repair.ts:371`), which (after Task 3) already reads `out.qa`/`out.suspect`/`out.asr`/`out.asrSuspect`/`out.qaRetries`/`out.asrRetries` off whatever the `synth` closure returns and wraps them into `freshVerdict` automatically. So Task 4 needs **only one change**: make the repair route's per-segment `synth` closure return the same flat `SynthOutput` shape Task 3's interface defines, instead of its current `{ pcm, sampleRate }`. No separate "find the replacements array and attach freshVerdict" step — that would double-apply the fix (or mis-shape it, since the closure's return value goes directly into `buildSynthReplacements`'s `out.qa` etc., not into a nested `verdict` object).
+
 **Files:**
-- Modify: `server/src/routes/chapter-qa-repair.ts` (the repair loop around lines 380-475, and wherever it builds the `replacements` array passed to `spliceChapterSegments` at line 481)
+- Modify: `server/src/routes/chapter-qa-repair.ts` (the repair loop's per-segment `synth` closure passed to `buildSynthReplacements` — the closure spanning roughly lines 380-475, specifically its `let retryCount` declaration point and its final `return best;` at line 473)
 - Test: `server/src/routes/chapter-qa-repair.test.ts` (existing file)
 
 **Interfaces:**
-- Consumes: `SegmentReplacement.freshVerdict` (Task 3).
+- Consumes: `SynthOutput` (Task 3's flat shape — `{ pcm, sampleRate, qa?, suspect?, asr?, asrSuspect?, qaRetries?, asrRetries? }`); `buildSynthReplacements`'s existing behavior of reading these fields off the closure's return value (Task 3, no changes needed to `buildSynthReplacements` itself).
 - Produces: a repaired segment's `qa`/`suspect`/`asr`/`asrSuspect`/`qaRetries`/`asrRetries` in the post-repair `segments.json` reflect the accepted take, not the pre-repair segment.
 
 - [ ] **Step 1: Write the failing test**
@@ -581,7 +623,9 @@ Expected: FAIL — the repaired segment still shows the pre-repair `suspect: tru
 
 - [ ] **Step 3: Implement**
 
-In the repair loop (around lines 412-473, inside the `for (let attempt = 1; ...)` retry loop), track a per-segment retry counter — add before the loop starts (near where `best`/`bestVerdict`/`bestAsr`/`bestCosine` are declared, ~line 382-386):
+Confirm first (per the review that caught the earlier draft's mistake here) that `chapter-qa-repair.ts:371` really does call `buildSynthReplacements({ segments: ..., targetIndices: ..., chapterSampleRate: ..., synth: async (seg) => { ... } })` — the same helper Task 3 modified — and that its `synth` closure is the one spanning roughly lines 380-475 (declares `best`/`bestVerdict`/`bestAsr`/`bestCosine`, ends with `return best;` at line 473). If the actual call site differs from this description, adjust the edit locations below accordingly, but the underlying fix (make the closure return `SynthOutput`'s flat shape) stays the same regardless of exact line numbers.
+
+Track a per-segment retry counter — add near where `best`/`bestVerdict`/`bestAsr`/`bestCosine` are declared (~line 382-386):
 
 ```ts
           let retryCount = 0;
@@ -596,22 +640,22 @@ Increment it once per attempt (top of the `for (let attempt = 1; attempt <= maxR
             send({ type: 'progress', chapterId, segmentIndex: segIndex, attempt, progress: 0.5 });
 ```
 
-Where the function returns `best` (line 473, `return best;`), the return type needs to carry the verdict so the caller can attach it to the replacement. Find where this per-segment closure's return value is consumed to build the `replacements` array (the `buildSynthReplacements`-style call this route makes just above line 380 — read the ~50 lines above line 380 to find the exact call site, since it wasn't included in this plan's research excerpt) and change the closure to return:
+Change the closure's final return (currently `if (!best) throw new Error('Re-record produced no audio.'); const accepted = isAcceptable(...); if (!accepted) { stillSuspect.push(segIndex); } else { repaired.push(segIndex); ... } return best;`, ~lines 454-473) to return the flat `SynthOutput` shape instead of the bare `{ pcm, sampleRate }` — `accepted` is already computed and in scope at this point:
 
 ```ts
-          return { pcm: best.pcm, sampleRate: best.sampleRate, verdict: {
+          return {
+            pcm: best.pcm,
+            sampleRate: best.sampleRate,
             qa: bestVerdict ?? undefined,
             suspect: accepted ? undefined : true,
             asr: bestAsr ?? undefined,
             asrSuspect: accepted || !asrOn ? undefined : bestAsr?.verdict === 'drift' ? true : undefined,
             qaRetries: retryCount || undefined,
             asrRetries: asrOn ? retryCount || undefined : undefined,
-          } };
+          };
 ```
 
-(Note: `accepted` is already computed at line 455 before this return — move the `return best` line's replacement below that point, or restructure so `accepted` is computed before this return; the existing code already has `accepted` in scope by line 456, one line before `return best` at line 473, so this is a same-scope change.)
-
-Then wherever this route builds its `replacements: SegmentReplacement[]` array from these per-segment closures (the call site above line 380 that this plan didn't capture — locate it by searching this file for `SegmentReplacement` or the array variable name), attach `freshVerdict: result.verdict` to each entry instead of a bare `{ startSegmentIndex, endSegmentIndex, pcm }`, mirroring the shape Task 3 introduced in `build-synth-replacement.ts`.
+That's the entire fix — no other file changes are needed for this task. `buildSynthReplacements` (Task 3) already reads exactly these fields off whatever `synth` returns and packages them into `replacements[].freshVerdict`, and `spliceChapterSegments` (Task 3) already applies that `freshVerdict` at every segment-construction site. Do **not** add a second, separate step that builds or edits a `replacements` array directly in this file — there isn't one; `buildSynthReplacements` owns that entirely.
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -646,6 +690,7 @@ git commit -m "fix(server): QA-repair writes the accepted take's verdict onto th
       attribution: 'full' | 'legacy-unattributed';
       chaptersEligible: number;
       chaptersScored: number;
+      chaptersEmbedFailed: number;
       charactersOnRoster: number;
       charactersChecked: number;
       mismatches: Array<{ characterId: string; chapterId?: number; fixable: boolean }>;
@@ -655,6 +700,8 @@ git commit -m "fix(server): QA-repair writes the accepted take's verdict onto th
   }
   ```
   This is `BookQaReport` minus `bookId`/`generatedAt`/`chaptersTotal`/`configDrift` — the route (Task 6) fills those in, since `configDrift` comes from a different module (`routes/revisions.ts`) and the route already knows `bookId`/`chaptersTotal`.
+
+  `chaptersEmbedFailed` closes a gap the spec requires and an earlier draft of this task dropped: an eligible chapter can fail to produce a verdict file because `scoreBook` skipped it for a missing/failed embeddings sibling (`aggregate.ts:224`), not because the gate was off. Distinguishing that from "gate off" from raw counts alone isn't fully decidable per-chapter without reading embeddings files directly (which this module deliberately avoids, to keep eligibility computation independent of `scoreBook`'s own file layout) — but it's decidable at the *book* level: if `chaptersScored > 0` anywhere in the book, the gate demonstrably ran, so every other eligible-but-unscored chapter in that same book must be an embed failure, not "off." When `chaptersScored === 0` book-wide, there's no such evidence, so the shortfall is reported as "not run" instead (the existing behavior) rather than guessed at as embed failure. Concretely: `chaptersEmbedFailed = chaptersScored > 0 ? chaptersEligible - chaptersScored : 0`.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -760,6 +807,33 @@ describe('buildAudioQaReport', () => {
     const report = await buildAudioQaReport(dir, [{ id: 1, slug: 'ch1' }]);
     expect(report.voiceDrift.attribution).toBe('legacy-unattributed');
   });
+
+  it('attributes an eligible-but-unscored chapter to chaptersEmbedFailed once the gate is demonstrably on elsewhere', async () => {
+    const dir = await makeBook();
+    // Chapter 1: eligible AND scored — proves the gate is on for this book.
+    await writeJsonAtomic(join(audioDir(dir), 'ch1.segments.json'), {
+      bookId: 'b1', chapterId: 1, chapterTitle: 'One', durationSec: 10, sampleRate: 24000,
+      modelKey: 'qwen3-tts-0.6b', synthesizedAt: new Date(0).toISOString(),
+      segments: [seg()],
+      characterSnapshots: { wren: { voiceEngine: 'qwen' } },
+    });
+    await writeVerdicts(join(audioDir(dir), 'ch1.render-integrity.json'), [
+      { characterId: 'wren', sentenceIds: [1], verdict: 'voice-match', cosine: 0.9, severity: null, fixable: false, expectedEngine: 'qwen', renderedEngine: 'qwen', referenceKind: 'in-book', windowed: false, chapterId: 1 },
+    ]);
+    // Chapter 2: eligible, but no verdict file — an embed failure, not "off"
+    // (the gate is confirmed on by chapter 1's verdict file above).
+    await writeJsonAtomic(join(audioDir(dir), 'ch2.segments.json'), {
+      bookId: 'b1', chapterId: 2, chapterTitle: 'Two', durationSec: 10, sampleRate: 24000,
+      modelKey: 'qwen3-tts-0.6b', synthesizedAt: new Date(0).toISOString(),
+      segments: [seg({ characterId: 'oduvan' })],
+      characterSnapshots: { oduvan: { voiceEngine: 'qwen' } },
+    });
+
+    const report = await buildAudioQaReport(dir, [{ id: 1, slug: 'ch1' }, { id: 2, slug: 'ch2' }]);
+    expect(report.voiceDrift.chaptersEligible).toBe(2);
+    expect(report.voiceDrift.chaptersScored).toBe(1);
+    expect(report.voiceDrift.chaptersEmbedFailed).toBe(1);
+  });
 });
 ```
 
@@ -795,6 +869,7 @@ export interface AudioQaReport {
     attribution: 'full' | 'legacy-unattributed';
     chaptersEligible: number;
     chaptersScored: number;
+    chaptersEmbedFailed: number;
     charactersOnRoster: number;
     charactersChecked: number;
     mismatches: Array<{ characterId: string; chapterId?: number; fixable: boolean }>;
@@ -848,6 +923,15 @@ export async function buildAudioQaReport(
     ? 'legacy-unattributed'
     : 'full';
   const uncheckedSet = new Set(outline.counts.uncheckedCharacters);
+  const chaptersScored = outline.scoredChapterIds.filter((id) => eligibleChapterIds.has(id)).length;
+  /* fs-51 — an eligible chapter with no verdict file is either "gate off"
+     (chaptersScored is 0 everywhere) or an isolated embeddings failure
+     (the gate demonstrably ran, since something else in the book WAS
+     scored). Only attribute to embed-failure when there's evidence the
+     gate is on — otherwise this would misreport "gate off" as "embed
+     failed" for the same reason presence-based detection failed for the
+     whole-book case (see the spec's round-3 finding). */
+  const chaptersEmbedFailed = chaptersScored > 0 ? eligibleChapterIds.size - chaptersScored : 0;
 
   return {
     chaptersRendered: segFiles.length,
@@ -864,7 +948,8 @@ export async function buildAudioQaReport(
     voiceDrift: {
       attribution,
       chaptersEligible: eligibleChapterIds.size,
-      chaptersScored: outline.scoredChapterIds.filter((id) => eligibleChapterIds.has(id)).length,
+      chaptersScored,
+      chaptersEmbedFailed,
       charactersOnRoster: stochasticCharacterIds.size,
       charactersChecked: Array.from(stochasticCharacterIds).filter((id) => !uncheckedSet.has(id)).length,
       mismatches: outline.issues.map((r) => ({
@@ -1000,14 +1085,17 @@ git commit -m "feat(server): add GET /api/books/:bookId/qa-report endpoint"
 
 ---
 
-### Task 7: `openapi.yaml` schema + regenerate frontend types
+### Task 7: `openapi.yaml` schema + regenerate frontend types + export the type alias
+
+**Correction from the plan's adversarial review**: an earlier draft of this task stopped at regenerating `src/lib/api-types.ts` and assumed frontend code could `import type { BookQaReport } from './api-types'`. It can't — `api-types.ts` exports only the raw `paths`/`components`/etc. namespace types (no bare per-schema names); every existing domain type in this codebase is a named alias re-exported from `src/lib/types.ts` (e.g. `export type Character = components['schemas']['Character'];`). This task adds that alias as its own step; Tasks 8-10 import from `../lib/types` (or `./types`), never from `api-types` directly.
 
 **Files:**
 - Modify: `openapi.yaml` (add `BookQaReport` schema under `components:` near `BookStateResponse` at line 5419; add the path under `paths:`)
 - Modify (generated, do not hand-edit): `src/lib/api-types.ts`
+- Modify: `src/lib/types.ts` (add the `BookQaReport` alias, alongside its other `components['schemas'][...]` re-exports)
 
 **Interfaces:**
-- Produces: `BookQaReport` TypeScript type, importable from `src/lib/api-types.ts`, consumed by Task 8.
+- Produces: `BookQaReport` TypeScript type, importable from `src/lib/types.ts` (**not** `api-types.ts` — see correction above), consumed by Tasks 8, 9, 10.
 
 - [ ] **Step 1: Add the schema**
 
@@ -1038,11 +1126,12 @@ In `openapi.yaml`, under `components:` (near `BookStateResponse`, ~line 5419), a
             linesFlaggedDrift: { type: integer }
         voiceDrift:
           type: object
-          required: [attribution, chaptersEligible, chaptersScored, charactersOnRoster, charactersChecked, mismatches, inconclusiveCount, uncheckedCharacterIds]
+          required: [attribution, chaptersEligible, chaptersScored, chaptersEmbedFailed, charactersOnRoster, charactersChecked, mismatches, inconclusiveCount, uncheckedCharacterIds]
           properties:
             attribution: { type: string, enum: [full, legacy-unattributed] }
             chaptersEligible: { type: integer }
             chaptersScored: { type: integer }
+            chaptersEmbedFailed: { type: integer }
             charactersOnRoster: { type: integer }
             charactersChecked: { type: integer }
             mismatches:
@@ -1102,16 +1191,24 @@ Under `paths:`, add (near the existing `/api/books/{bookId}/revisions` path, for
 Run: `npm run openapi:types`
 Expected: `src/lib/api-types.ts` updates with no errors; diff shows a new `BookQaReport` type and the new path entry.
 
-- [ ] **Step 3: Typecheck**
+- [ ] **Step 3: Add the named type alias**
+
+Open `src/lib/types.ts` and find its existing `export type X = components['schemas']['X'];` re-export lines (e.g. `Character`, `Chapter`). Add, in the same style, alongside them:
+
+```ts
+export type BookQaReport = components['schemas']['BookQaReport'];
+```
+
+- [ ] **Step 4: Typecheck**
 
 Run: `npm run typecheck`
-Expected: PASS (no consumers reference the new type yet, so this just confirms the generated file itself is valid).
+Expected: PASS (no consumers reference the new type yet, so this just confirms the generated file + the new alias are both valid).
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
-git add openapi.yaml src/lib/api-types.ts
-git commit -m "feat(openapi): add BookQaReport schema and GET /api/books/{bookId}/qa-report"
+git add openapi.yaml src/lib/api-types.ts src/lib/types.ts
+git commit -m "feat(openapi): add BookQaReport schema, GET /api/books/{bookId}/qa-report, and the types.ts alias"
 ```
 
 ---
@@ -1124,7 +1221,7 @@ git commit -m "feat(openapi): add BookQaReport schema and GET /api/books/{bookId
 - Test: `src/lib/api.test.ts` (or wherever this file's existing GET-endpoint tests live — check for an `api.test.ts` first; if none exists for this file, add a focused test file `src/lib/api.qa-report.test.ts`)
 
 **Interfaces:**
-- Consumes: `BookQaReport` type from `src/lib/api-types.ts` (Task 7).
+- Consumes: `BookQaReport` type from `src/lib/types.ts` (Task 7 — the alias, not `api-types.ts` directly).
 - Produces: `api.getQaReport(bookId: string): Promise<BookQaReport>` — consumed by Task 9's hook.
 
 - [ ] **Step 1: Write the failing test**
@@ -1162,7 +1259,7 @@ Expected: FAIL — `getQaReport` doesn't exist.
 Create `src/data/qa-report.ts`:
 
 ```ts
-import type { BookQaReport } from '../lib/api-types';
+import type { BookQaReport } from '../lib/types';
 
 /* fs-51 mock fixture — a clean, fully-covered book, used by the mock API
    surface (VITE_USE_MOCKS=true) and as the e2e default. */
@@ -1204,7 +1301,7 @@ Near the `mock` object (~line 7754), add:
   getQaReport: async (_bookId: string): Promise<BookQaReport> => MOCK_QA_REPORT,
 ```
 
-Add the import at the top of `api.ts` (alongside its other `src/data/*` imports): `import { MOCK_QA_REPORT } from '../data/qa-report';` and `import type { BookQaReport } from './api-types';` (or wherever this file's existing `api-types` type imports are grouped — match the existing import block).
+Add the import at the top of `api.ts` (alongside its other `src/data/*` imports): `import { MOCK_QA_REPORT } from '../data/qa-report';` and `import type { BookQaReport } from './types';` (or wherever this file's existing `./types` type imports are grouped — match the existing import block; this file already imports its other domain types this way, never from `./api-types` directly).
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -1307,7 +1404,7 @@ export function downloadFile(filename: string, content: string, mimeType: string
 Create `src/lib/qa-report-export.ts`:
 
 ```ts
-import type { BookQaReport } from './api-types';
+import type { BookQaReport } from './types';
 
 function acousticLine(r: BookQaReport): string {
   return `Acoustic — ${r.acoustic.linesChecked} lines checked, ${r.acoustic.linesRerecorded} needed a second take`;
@@ -1360,7 +1457,7 @@ Create `src/hooks/use-qa-report.ts`:
 ```ts
 import { useCallback, useEffect, useState } from 'react';
 import { api } from '../lib/api';
-import type { BookQaReport } from '../lib/api-types';
+import type { BookQaReport } from '../lib/types';
 
 export function useQaReport(bookId: string) {
   const [report, setReport] = useState<BookQaReport | null>(null);
@@ -1413,6 +1510,8 @@ git commit -m "feat(frontend): add useQaReport hook and export formatting helper
 - Produces: `<QaReportCard report={BookQaReport | null} loading={boolean} error={boolean} bookTitle={string} />` — a pure presentational component, no store reads (matches the `listen-header.tsx`/`listen-download-section.tsx` "dumb region" convention the spec calls out).
 
 - [ ] **Step 1: Write the failing tests**
+
+Note: `qa-report-card.tsx` imports `BookQaReport` from `../lib/types`, not `../lib/api-types` — see Task 7's correction.
 
 ```tsx
 // src/components/qa-report-card.test.tsx
@@ -1467,7 +1566,7 @@ Expected: FAIL — module doesn't exist.
 Create `src/components/qa-report-card.tsx`:
 
 ```tsx
-import type { BookQaReport } from '../lib/api-types';
+import type { BookQaReport } from '../lib/types';
 import { downloadFile } from '../lib/download-file';
 import { formatQaReportJson, formatQaReportText } from '../lib/qa-report-export';
 import { Pill } from './primitives';

--- a/docs/superpowers/plans/2026-07-05-fs51-qa-report.md
+++ b/docs/superpowers/plans/2026-07-05-fs51-qa-report.md
@@ -10,7 +10,9 @@
 
 **Revision history:** 2026-07-05 round 1 (adversarial `assumption-checker` pass, code-grounded against the actual current files). Fixed four contradicted claims: (1) frontend code cannot `import type { BookQaReport } from './api-types'` — that module has no bare per-schema exports; Task 7 now adds a named alias to `src/lib/types.ts`, the codebase's actual convention, and Tasks 8-10 import from there. (2) Task 4 assumed `chapter-qa-repair.ts` builds its own replacements array to attach a verdict to — it doesn't; it calls the same `buildSynthReplacements` helper Task 3 modifies, so Task 4 now just makes its `synth` closure return the flat `SynthOutput` shape Task 3 already reads, nothing more. (3) The `freshVerdict` spread in `spliceChapterSegments` only covered the `if (a === b)` branch, which a same-length re-record (exactly what Task 3's own test used) never reaches — the fix now applies to all three segment-construction sites in that function. (4) The spec's `chaptersEmbedFailed` field (distinguishing "gate off" from "an isolated embed failure") was dropped from Task 5/7 — restored to both, computed from evidence already in hand (no new file reads).
 
-2026-07-05 round 2 (adversarial pass on the round-1 revision). Found that fix #4 above was only half-done: `chaptersEmbedFailed` was restored to the *schema*, but nothing in Task 9/10's frontend code actually reads it — the voice-match row's partial-coverage condition only checked `charactersChecked < charactersOnRoster`, so a book with an isolated embed failure (full character coverage, one chapter's embeddings failed) still rendered a clean "18 of 18 characters checked, 0 mismatches" — the exact false-clean the field exists to prevent. Also found `MOCK_QA_REPORT` (Task 8) omits the now-required `chaptersEmbedFailed`, which fails `npm run typecheck` (Task 8's own gate) and every downstream test that spreads the fixture. And a headline unit-mismatch: `headline()` summed a chapter count, a line count, and a mismatch count into one number labeled "lines." This round's fixes: `voiceMatchLine`/`VoiceMatchRow` now branch on `chaptersScored < chaptersEligible` too, with its own chapter-fraction copy; `MOCK_QA_REPORT` gained the field; `headline()` in both the export formatter and the card now uses `acoustic.linesRerecorded` specifically (a genuine line count) rather than summing unlike units, falling back to non-numeric copy when the only issues are ASR/voice-drift ones. This is round 3 of the plan's own review — the last allowed round — so these fixes are final; any further finding gets flagged to the user rather than triggering a fourth pass.
+2026-07-05 round 2 (adversarial pass on the round-1 revision). Found that fix #4 above was only half-done: `chaptersEmbedFailed` was restored to the *schema*, but nothing in Task 9/10's frontend code actually reads it — the voice-match row's partial-coverage condition only checked `charactersChecked < charactersOnRoster`, so a book with an isolated embed failure (full character coverage, one chapter's embeddings failed) still rendered a clean "18 of 18 characters checked, 0 mismatches" — the exact false-clean the field exists to prevent. Also found `MOCK_QA_REPORT` (Task 8) omits the now-required `chaptersEmbedFailed`, which fails `npm run typecheck` (Task 8's own gate) and every downstream test that spreads the fixture. And a headline unit-mismatch: `headline()` summed a chapter count, a line count, and a mismatch count into one number labeled "lines." This round's fixes: `voiceMatchLine`/`VoiceMatchRow` now branch on `chaptersScored < chaptersEligible` too, with its own chapter-fraction copy; `MOCK_QA_REPORT` gained the field; `headline()` in both the export formatter and the card now uses `acoustic.linesRerecorded` specifically (a genuine line count) rather than summing unlike units, falling back to non-numeric copy when the only issues are ASR/voice-drift ones.
+
+2026-07-05 round 3 (final automated pass, per the plan's own 3-round cap). Found the round-2 headline fix was itself inconsistent with its own fixture: `MOCK_QA_REPORT` still carried `acoustic.linesRerecorded: 3` while three tasks' tests (9, 10, 13) asserted the *clean* `"Every line held."` headline against that same fixture — a genuine contradiction that would have failed those tasks' own test gates. Fixed by setting the fixture's `linesRerecorded` to `0`, matching the spec's own clean-receipt example, and updating the one dependent assertion. Two further findings were real scope decisions, put to the user rather than resolved unilaterally: the splice-callback behavior change (Task 3) had a prose acknowledgment but no test asserting the new gate-running behavior actually happens — the user chose to add one, now included as a route-level test in Task 3. And `inconclusiveCount` was computed but never rendered in the card or text export (only the raw JSON export carried it), despite the spec requiring it and the plan's own Self-Review claiming full UX coverage — the user chose to close this now; `voiceMatchLine`/`VoiceMatchRow` both append an inconclusive-chapter note when nonzero. This is the last round allowed under the review-gate cap (initial + 2 re-reviews); the plan is now presented to the user for their own read.
 
 ## Global Constraints
 
@@ -403,10 +405,42 @@ it('uses the replacement freshVerdict instead of the original segment verdict fo
 
 Use whatever this test file's actual fixture helper names are (`makeSegment`/`makeSilencePcm` are placeholders for whatever it already calls them — read the file first and match its existing names exactly).
 
+**fs-51 round-3 review addition**: the two tests above cover the pure `spliceChapterSegments`/`buildSynthReplacements` functions, but neither exercises `chapter-splice.ts`'s route-level change — passing real QA/ASR gate options into its `synth` callback's `synthesiseChapter` call, a genuinely new behavior (manual splice re-records now run gates they didn't before) that this plan's own "every new behavior ships a paired test" rule requires coverage for. Add to `server/src/routes/chapter-splice.test.ts` (mirror this file's existing pattern for mocking `synthesiseChapter` and driving the splice SSE route — it already exists for the pre-fs-51 splice tests):
+
+```ts
+it('passes the signal-QA and ASR gate options through to the re-record synth call, and writes a fresh verdict', async () => {
+  const synthesiseChapterMock = vi.fn(async () => ({
+    pcm: Buffer.alloc(100),
+    sampleRate: 24000,
+    segments: [
+      {
+        groupIndex: 0, characterId: 'wren', sentenceIds: [1], startSec: 0, endSec: 1,
+        qa: { status: 'ok', reasons: [], rms: 0.1, longestSilenceSec: 0, durationSec: 1, expectedSec: 1 },
+        suspect: undefined,
+      },
+    ],
+  }));
+  // Mirror this file's existing vi.mock('../tts/synthesise-chapter.js', ...) setup,
+  // substituting synthesiseChapterMock, then drive a splice re-record through the
+  // route exactly as this file's existing splice tests do.
+  await runSplice({ targetIndices: [0] }); // this file's existing helper
+
+  expect(synthesiseChapterMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      maxSegmentRerecords: expect.any(Number),
+    }),
+  );
+  const segFile = await readSegmentsJson(bookDir, chapterSlug); // this file's existing helper
+  expect(segFile.segments[0].qa?.status).toBe('ok');
+});
+```
+
+Match helper/mock names to whatever this test file already uses — read it first, same as the note above.
+
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `cd server && npx vitest run src/audio/build-synth-replacement.test.ts src/audio/splice-chapter.test.ts -t "fresh"`
-Expected: FAIL — `freshVerdict` doesn't exist yet; the splice still spreads the original segment's stale `suspect: true`.
+Run: `cd server && npx vitest run src/audio/build-synth-replacement.test.ts src/audio/splice-chapter.test.ts src/routes/chapter-splice.test.ts -t "fresh|gate options"`
+Expected: FAIL — `freshVerdict` doesn't exist yet; the splice still spreads the original segment's stale `suspect: true`; the route-level test fails because the `synth` callback doesn't pass gate options yet.
 
 - [ ] **Step 3: Implement**
 
@@ -1273,7 +1307,7 @@ export const MOCK_QA_REPORT: BookQaReport = {
   chaptersRendered: 12,
   chaptersTotal: 12,
   totalLines: 342,
-  acoustic: { linesChecked: 342, linesRerecorded: 3, chaptersFlagged: 0 },
+  acoustic: { linesChecked: 342, linesRerecorded: 0, chaptersFlagged: 0 },
   asr: { linesVerified: 342, linesFlaggedDrift: 0 },
   voiceDrift: {
     attribution: 'full',
@@ -1348,7 +1382,7 @@ describe('formatQaReportText', () => {
     const text = formatQaReportText(MOCK_QA_REPORT, 'The Coalfall Commission');
     expect(text).toContain('The Coalfall Commission');
     expect(text).toContain('Every line held.');
-    expect(text).toContain('Acoustic — 342 lines checked, 3 needed a second take');
+    expect(text).toContain('Acoustic — 342 lines checked, 0 needed a second take');
     expect(text).toContain('Voice match — 18 of 18 characters checked, 0 mismatches');
     expect(text).toContain('Cast continuity — 0 changes since render');
   });
@@ -1367,6 +1401,12 @@ describe('formatQaReportText', () => {
     const text = formatQaReportText(report, 'Book');
     expect(text).toContain("11 of 12 eligible chapters scored (1 couldn't be embedded)");
     expect(text).not.toContain('18 of 18 characters checked');
+  });
+
+  it('appends the inconclusive-chapter count to the voice-match line when nonzero', () => {
+    const report = { ...MOCK_QA_REPORT, voiceDrift: { ...MOCK_QA_REPORT.voiceDrift, inconclusiveCount: 2 } };
+    const text = formatQaReportText(report, 'Book');
+    expect(text).toContain('2 chapters inconclusive');
   });
 });
 ```
@@ -1434,15 +1474,21 @@ function voiceMatchLine(r: BookQaReport): string {
   const vd = r.voiceDrift;
   if (vd.chaptersEligible === 0) return 'Voice match — no stochastic-voiced characters in this book';
   if (vd.chaptersScored === 0) return 'Voice match — not run for this book';
+  /* fs-51 round-3 review fix — the spec requires the inconclusive-chapter
+     count to be surfaced on this row (usually short quotes below the
+     minimum-duration gate), not silently dropped to the JSON export only.
+     Appended to every non-empty branch below rather than duplicated per
+     branch. */
+  const inconclusiveSuffix = vd.inconclusiveCount > 0 ? `, ${vd.inconclusiveCount} chapters inconclusive` : '';
   const characterShortfall = vd.charactersChecked < vd.charactersOnRoster;
   const embedShortfall = vd.chaptersScored < vd.chaptersEligible;
   if (embedShortfall) {
-    return `Voice match — ${vd.chaptersScored} of ${vd.chaptersEligible} eligible chapters scored (${vd.chaptersEmbedFailed} couldn't be embedded), ${vd.mismatches.length} mismatches`;
+    return `Voice match — ${vd.chaptersScored} of ${vd.chaptersEligible} eligible chapters scored (${vd.chaptersEmbedFailed} couldn't be embedded), ${vd.mismatches.length} mismatches${inconclusiveSuffix}`;
   }
   const base = characterShortfall
     ? `Voice match — ${vd.charactersChecked} of ${vd.charactersOnRoster} characters checked`
     : `Voice match — ${vd.charactersOnRoster} of ${vd.charactersOnRoster} characters checked`;
-  return `${base}, ${vd.mismatches.length} mismatches`;
+  return `${base}, ${vd.mismatches.length} mismatches${inconclusiveSuffix}`;
 }
 
 function castContinuityLine(r: BookQaReport): string {
@@ -1583,6 +1629,12 @@ describe('QaReportCard', () => {
     expect(screen.queryByText(/18 of 18 characters checked/i)).not.toBeInTheDocument();
   });
 
+  it('shows the inconclusive-chapter count on the voice-match row when nonzero', () => {
+    const report = { ...MOCK_QA_REPORT, voiceDrift: { ...MOCK_QA_REPORT.voiceDrift, inconclusiveCount: 2 } };
+    render(<QaReportCard report={report} loading={false} error={false} bookTitle="Test Book" />);
+    expect(screen.getByText(/2 chapters inconclusive/i)).toBeInTheDocument();
+  });
+
   it('shows an inline unavailable state on fetch error, without throwing', () => {
     render(<QaReportCard report={null} loading={false} error={true} bookTitle="Test Book" />);
     expect(screen.getByText(/qa report unavailable/i)).toBeInTheDocument();
@@ -1688,12 +1740,16 @@ function VoiceMatchRow({ report }: { report: BookQaReport }) {
       case below — otherwise a full-roster book with a failed embed still
       reads as a clean "N of N characters checked", the false-clean the
       chaptersEmbedFailed field exists to prevent. */}
+  /* fs-51 round-3 review fix: surface inconclusiveCount (short quotes below
+     the minimum-duration gate) on this row per the spec — it was computed
+     but only ever reached the JSON export. */
+  const inconclusiveNote = vd.inconclusiveCount > 0 ? ` · ${vd.inconclusiveCount} chapters inconclusive` : '';
   if (vd.chaptersScored < vd.chaptersEligible) {
     return (
       <div className="flex items-center justify-between py-2">
         <span className="text-sm text-ink/70">Voice match</span>
         <span className="text-sm text-ink">
-          {vd.chaptersScored} of {vd.chaptersEligible} eligible chapters scored ({vd.chaptersEmbedFailed} couldn't be embedded), {vd.mismatches.length} mismatches
+          {vd.chaptersScored} of {vd.chaptersEligible} eligible chapters scored ({vd.chaptersEmbedFailed} couldn't be embedded), {vd.mismatches.length} mismatches{inconclusiveNote}
         </span>
       </div>
     );
@@ -1702,7 +1758,7 @@ function VoiceMatchRow({ report }: { report: BookQaReport }) {
     <div className="flex items-center justify-between py-2">
       <span className="text-sm text-ink/70">Voice match</span>
       <span className="text-sm text-ink">
-        {vd.charactersChecked} of {vd.charactersOnRoster} characters checked, {vd.mismatches.length} mismatches
+        {vd.charactersChecked} of {vd.charactersOnRoster} characters checked, {vd.mismatches.length} mismatches{inconclusiveNote}
       </span>
     </div>
   );
@@ -1945,4 +2001,4 @@ git commit -m "test(e2e): add QA report card + export coverage"
 - **Spec coverage**: Architecture (Tasks 1, 5, 6), report schema (Task 5), UX/copy (Task 10), export mechanics (Task 9/10), frontend surfaces (Tasks 11/12), the fresh-verdict requirement (Tasks 3/4), retry counters (Task 2), `chapterId`/legacy-attribution (Task 1/5), testing (each task's own test + Task 13 e2e) — all covered. The spec's two "resolved" open questions (splice routes through `synthesiseChapter` but discards verdicts; repair patches `render-integrity.json` directly, doesn't re-trigger `scoreBook`) are directly implemented in Tasks 3 and 4 respectively.
 - **Not in this plan, deliberately** (per the spec's "Out of scope"): srv-36 Phase 2 consistency row, any change to gate on/off behavior itself beyond the fresh-verdict correctness fix, a QA-history-over-time view, backfilling `chapterId` onto existing books' `render-integrity.json` files.
 - **Known research gaps flagged inline rather than guessed**: Task 3/11/12's exact existing test-helper names are called out explicitly as "read the file first, match its existing names" rather than invented, so the implementer verifies against real code instead of a plan-author's guess. (Task 4's originally-uncertain `replacements`-array construction site was resolved during round-1 review — see the "Revision history" note — `chapter-qa-repair.ts` reuses Task 3's `buildSynthReplacements` directly; there is no separate site.)
-- **Plan review history**: this plan went through 3 rounds of the mandatory `assumption-checker` gate (the cap) before being shown to the user — see "Revision history" above for what each round found and fixed. Rounds 1 and 2 both met the re-review threshold; round 3's fixes (embed-failure consumption in the voice-match row/export copy, the `MOCK_QA_REPORT` missing-field typecheck break, the headline unit-mismatch, and an explicit call-out that the splice-callback change adds real latency to manual re-records) are final under the cap — any further finding a human reviewer surfaces should be fixed directly rather than run through a 4th automated pass.
+- **Plan review history**: this plan went through 3 rounds of the mandatory `assumption-checker` gate (the cap) before being shown to the user — see "Revision history" above for what each round found and fixed. All three rounds met the re-review threshold. Round 3's findings included two genuine scope decisions (add a route-level test for the splice behavior change; render `inconclusiveCount` or accept its absence as a cut) that were put to the user rather than resolved unilaterally, per the model-routing judgment-call carve-out — both are now folded in as the user chose to close them. Any further finding a human reviewer surfaces should be fixed directly rather than run through a 4th automated pass.

--- a/docs/superpowers/plans/2026-07-05-fs51-qa-report.md
+++ b/docs/superpowers/plans/2026-07-05-fs51-qa-report.md
@@ -10,6 +10,8 @@
 
 **Revision history:** 2026-07-05 round 1 (adversarial `assumption-checker` pass, code-grounded against the actual current files). Fixed four contradicted claims: (1) frontend code cannot `import type { BookQaReport } from './api-types'` — that module has no bare per-schema exports; Task 7 now adds a named alias to `src/lib/types.ts`, the codebase's actual convention, and Tasks 8-10 import from there. (2) Task 4 assumed `chapter-qa-repair.ts` builds its own replacements array to attach a verdict to — it doesn't; it calls the same `buildSynthReplacements` helper Task 3 modifies, so Task 4 now just makes its `synth` closure return the flat `SynthOutput` shape Task 3 already reads, nothing more. (3) The `freshVerdict` spread in `spliceChapterSegments` only covered the `if (a === b)` branch, which a same-length re-record (exactly what Task 3's own test used) never reaches — the fix now applies to all three segment-construction sites in that function. (4) The spec's `chaptersEmbedFailed` field (distinguishing "gate off" from "an isolated embed failure") was dropped from Task 5/7 — restored to both, computed from evidence already in hand (no new file reads).
 
+2026-07-05 round 2 (adversarial pass on the round-1 revision). Found that fix #4 above was only half-done: `chaptersEmbedFailed` was restored to the *schema*, but nothing in Task 9/10's frontend code actually reads it — the voice-match row's partial-coverage condition only checked `charactersChecked < charactersOnRoster`, so a book with an isolated embed failure (full character coverage, one chapter's embeddings failed) still rendered a clean "18 of 18 characters checked, 0 mismatches" — the exact false-clean the field exists to prevent. Also found `MOCK_QA_REPORT` (Task 8) omits the now-required `chaptersEmbedFailed`, which fails `npm run typecheck` (Task 8's own gate) and every downstream test that spreads the fixture. And a headline unit-mismatch: `headline()` summed a chapter count, a line count, and a mismatch count into one number labeled "lines." This round's fixes: `voiceMatchLine`/`VoiceMatchRow` now branch on `chaptersScored < chaptersEligible` too, with its own chapter-fraction copy; `MOCK_QA_REPORT` gained the field; `headline()` in both the export formatter and the card now uses `acoustic.linesRerecorded` specifically (a genuine line count) rather than summing unlike units, falling back to non-numeric copy when the only issues are ASR/voice-drift ones. This is round 3 of the plan's own review — the last allowed round — so these fixes are final; any further finding gets flagged to the user rather than triggering a fourth pass.
+
 ## Global Constraints
 
 - Spec: `docs/superpowers/specs/2026-07-05-fs51-qa-report-design.md` — every requirement below traces to it.
@@ -528,6 +530,8 @@ export interface SegmentReplacement {
 This is the full body of `spliceChapterSegments`'s `if (run)` branch (currently at lines 163-204) with `...(run.freshVerdict ?? {})` added to all three `newSegments.push` call sites. A gain-only replacement (built by the separate gain-remix path elsewhere in `chapter-splice.ts`, not by `buildSynthReplacements`) never sets `freshVerdict`, so `?? {}` makes the spread a no-op there — its segment correctly keeps its prior verdict, since the audio content didn't change.
 
 **Update Task 3's own splice-chapter.ts test** (Step 1, above) so it actually exercises this: as written, that test uses a same-length replacement (`makeSilencePcm(1, 24000)` for both `decodedPcm` and the replacement `pcm`), which — before this fix — would have silently passed through the `else` branch untouched and the assertion would have failed for the wrong reason (or passed vacuously if the original test's expectations happened to align). With the fix above applied to all three sites, that same test now correctly exercises the length-preserving loop path and should pass for the right reason. No test code change needed, just confirming — when running Step 4 below — that this specific test is actually hitting the length-preserving branch (add a temporary `console.log` or check via a debugger if uncertain, then remove it) rather than a branch that happens to already work.
+
+**This is a deliberate, in-scope behavior change to the manual splice/remix route, not just verdict plumbing** — flagging it explicitly per the plan's round-2 review, which found the draft presenting it as a side-effect-free wiring change. Today, a manual re-record via `chapter-splice.ts` calls `synthesiseChapter` with no QA/ASR options, so it never runs the signal-QA or ASR content-QA gates (or their re-record loops) for that one re-recorded sentence. After this change, it will — meaning a manual splice re-record gains the same latency profile as a normal generation-time render for that one sentence (an extra transcription + possible re-synthesis round trip when ASR is enabled). This is necessary: there is no way to produce an honest `freshVerdict` without actually running the gates that produce it, and shipping a splice-path re-record with no verdict at all would silently regress this report's coverage for every book that uses manual splice. Accept this latency cost as part of the fix.
 
 In `server/src/routes/chapter-splice.ts`, update the `synth` callback (line 290-309) to pass the same gate options generation uses, and return the fresh verdict from the single-sentence result:
 
@@ -1234,7 +1238,7 @@ describe('api.getQaReport', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn(async () => ({
       ok: true,
-      json: async () => ({ bookId: 'b1', generatedAt: '2026-01-01T00:00:00Z', chaptersRendered: 1, chaptersTotal: 1, totalLines: 10, acoustic: { linesChecked: 10, linesRerecorded: 0, chaptersFlagged: 0 }, asr: { linesVerified: 0, linesFlaggedDrift: 0 }, voiceDrift: { attribution: 'full', chaptersEligible: 0, chaptersScored: 0, charactersOnRoster: 0, charactersChecked: 0, mismatches: [], inconclusiveCount: 0, uncheckedCharacterIds: [] }, configDrift: { counts: { mild: 0, moderate: 0, severe: 0 }, events: [] } }),
+      json: async () => ({ bookId: 'b1', generatedAt: '2026-01-01T00:00:00Z', chaptersRendered: 1, chaptersTotal: 1, totalLines: 10, acoustic: { linesChecked: 10, linesRerecorded: 0, chaptersFlagged: 0 }, asr: { linesVerified: 0, linesFlaggedDrift: 0 }, voiceDrift: { attribution: 'full', chaptersEligible: 0, chaptersScored: 0, chaptersEmbedFailed: 0, charactersOnRoster: 0, charactersChecked: 0, mismatches: [], inconclusiveCount: 0, uncheckedCharacterIds: [] }, configDrift: { counts: { mild: 0, moderate: 0, severe: 0 }, events: [] } }),
     })));
   });
 
@@ -1275,6 +1279,7 @@ export const MOCK_QA_REPORT: BookQaReport = {
     attribution: 'full',
     chaptersEligible: 12,
     chaptersScored: 12,
+    chaptersEmbedFailed: 0,
     charactersOnRoster: 18,
     charactersChecked: 18,
     mismatches: [],
@@ -1353,6 +1358,16 @@ describe('formatQaReportText', () => {
     const text = formatQaReportText(report, 'Book');
     expect(text).toContain('Transcript — not run for this book');
   });
+
+  it('leads with the embed-failure fraction even when every character was checked', () => {
+    const report = {
+      ...MOCK_QA_REPORT,
+      voiceDrift: { ...MOCK_QA_REPORT.voiceDrift, chaptersEligible: 12, chaptersScored: 11, chaptersEmbedFailed: 1 },
+    };
+    const text = formatQaReportText(report, 'Book');
+    expect(text).toContain("11 of 12 eligible chapters scored (1 couldn't be embedded)");
+    expect(text).not.toContain('18 of 18 characters checked');
+  });
 });
 ```
 
@@ -1419,8 +1434,12 @@ function voiceMatchLine(r: BookQaReport): string {
   const vd = r.voiceDrift;
   if (vd.chaptersEligible === 0) return 'Voice match — no stochastic-voiced characters in this book';
   if (vd.chaptersScored === 0) return 'Voice match — not run for this book';
-  const shortfall = vd.charactersChecked < vd.charactersOnRoster;
-  const base = shortfall
+  const characterShortfall = vd.charactersChecked < vd.charactersOnRoster;
+  const embedShortfall = vd.chaptersScored < vd.chaptersEligible;
+  if (embedShortfall) {
+    return `Voice match — ${vd.chaptersScored} of ${vd.chaptersEligible} eligible chapters scored (${vd.chaptersEmbedFailed} couldn't be embedded), ${vd.mismatches.length} mismatches`;
+  }
+  const base = characterShortfall
     ? `Voice match — ${vd.charactersChecked} of ${vd.charactersOnRoster} characters checked`
     : `Voice match — ${vd.charactersOnRoster} of ${vd.charactersOnRoster} characters checked`;
   return `${base}, ${vd.mismatches.length} mismatches`;
@@ -1431,9 +1450,17 @@ function castContinuityLine(r: BookQaReport): string {
   return `Cast continuity — ${total} changes since render`;
 }
 
+/* fs-51 round-2 review fix: the headline number must be a genuine line
+   count, not a sum of unlike units (a chapter count + a line count + a
+   mismatch count, mislabeled "lines" — the bug an earlier draft shipped).
+   `acoustic.linesRerecorded` is the one field that's actually a line count;
+   when it's zero but other signals still found something, fall back to
+   non-numeric copy rather than mislabel a different unit as "lines." */
 function headline(r: BookQaReport): string {
-  const issues = r.acoustic.chaptersFlagged + r.asr.linesFlaggedDrift + r.voiceDrift.mismatches.length;
-  return issues === 0 ? 'Every line held.' : `${issues} lines needed a second take.`;
+  const hasOtherIssues = r.asr.linesFlaggedDrift > 0 || r.voiceDrift.mismatches.length > 0;
+  if (r.acoustic.linesRerecorded > 0) return `${r.acoustic.linesRerecorded} lines needed a second take.`;
+  if (hasOtherIssues) return 'Some lines need a second look.';
+  return 'Every line held.';
 }
 
 export function formatQaReportText(report: BookQaReport, bookTitle: string): string {
@@ -1541,6 +1568,21 @@ describe('QaReportCard', () => {
     expect(screen.getByText(/no stochastic-voiced characters/i)).toBeInTheDocument();
   });
 
+  it('leads with the embed-failure fraction even when every character was checked', () => {
+    // Regression for the round-2 review finding: a full-roster book (no
+    // character shortfall) with one chapter's embeddings failed must NOT
+    // render as a clean "N of N characters checked" — chaptersScored <
+    // chaptersEligible has to win even though charactersChecked ===
+    // charactersOnRoster here.
+    const report = {
+      ...MOCK_QA_REPORT,
+      voiceDrift: { ...MOCK_QA_REPORT.voiceDrift, chaptersEligible: 12, chaptersScored: 11, chaptersEmbedFailed: 1 },
+    };
+    render(<QaReportCard report={report} loading={false} error={false} bookTitle="Test Book" />);
+    expect(screen.getByText(/11 of 12 eligible chapters scored/i)).toBeInTheDocument();
+    expect(screen.queryByText(/18 of 18 characters checked/i)).not.toBeInTheDocument();
+  });
+
   it('shows an inline unavailable state on fetch error, without throwing', () => {
     render(<QaReportCard report={null} loading={false} error={true} bookTitle="Test Book" />);
     expect(screen.getByText(/qa report unavailable/i)).toBeInTheDocument();
@@ -1582,10 +1624,17 @@ function slugify(title: string): string {
   return title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
 }
 
-function headline(report: BookQaReport): { bold: string; rest: string } {
-  const issues = report.acoustic.chaptersFlagged + report.asr.linesFlaggedDrift + report.voiceDrift.mismatches.length;
-  if (issues === 0) return { bold: 'held', rest: 'Every line ' };
-  return { bold: String(issues), rest: ` lines needed a second take.` };
+/* fs-51 round-2 review fix — see the matching comment in qa-report-export.ts;
+   the bold span must be a genuine line count (linesRerecorded), never a sum
+   of unlike units mislabeled "lines." `before`/`after` sandwich the bold
+   span so every case (bold-first or bold-last) still ends with a period. */
+function headline(report: BookQaReport): { before: string; bold: string; after: string } {
+  const hasOtherIssues = report.asr.linesFlaggedDrift > 0 || report.voiceDrift.mismatches.length > 0;
+  if (report.acoustic.linesRerecorded > 0) {
+    return { before: '', bold: String(report.acoustic.linesRerecorded), after: ' lines needed a second take.' };
+  }
+  if (hasOtherIssues) return { before: 'Some lines need a ', bold: 'second look', after: '.' };
+  return { before: 'Every line ', bold: 'held', after: '.' };
 }
 
 function AcousticRow({ report }: { report: BookQaReport }) {
@@ -1634,6 +1683,21 @@ function VoiceMatchRow({ report }: { report: BookQaReport }) {
       </div>
     );
   }
+  {/* fs-51 round-2 review fix: chaptersScored < chaptersEligible (an isolated
+      embed failure) must lead the row, exactly like the character-shortfall
+      case below — otherwise a full-roster book with a failed embed still
+      reads as a clean "N of N characters checked", the false-clean the
+      chaptersEmbedFailed field exists to prevent. */}
+  if (vd.chaptersScored < vd.chaptersEligible) {
+    return (
+      <div className="flex items-center justify-between py-2">
+        <span className="text-sm text-ink/70">Voice match</span>
+        <span className="text-sm text-ink">
+          {vd.chaptersScored} of {vd.chaptersEligible} eligible chapters scored ({vd.chaptersEmbedFailed} couldn't be embedded), {vd.mismatches.length} mismatches
+        </span>
+      </div>
+    );
+  }
   return (
     <div className="flex items-center justify-between py-2">
       <span className="text-sm text-ink/70">Voice match</span>
@@ -1667,13 +1731,13 @@ export function QaReportCard({ report, loading, error, bookTitle }: QaReportCard
   if (error || !report) {
     return <div className="bg-white rounded-3xl border border-ink/10 shadow-card p-6 text-sm text-ink/50">QA report unavailable.</div>;
   }
-  const { bold, rest } = headline(report);
+  const { before, bold, after } = headline(report);
 
   return (
     <div className="bg-white rounded-3xl border border-ink/10 shadow-card p-6">
       <p className="text-sm uppercase tracking-widest text-ink/45 font-semibold mb-2">Quality gate</p>
       <h3 className="text-lg font-medium text-ink mb-1">
-        {rest}<span className="font-bold">{bold}</span>{rest.endsWith(' ') ? '' : ''}
+        {before}<span className="font-bold">{bold}</span>{after}
       </h3>
       <p className="text-sm text-ink/60 mb-4">
         Checked, verified, and matched against every character's own voice — automatically, before this book reached you.
@@ -1880,4 +1944,5 @@ git commit -m "test(e2e): add QA report card + export coverage"
 
 - **Spec coverage**: Architecture (Tasks 1, 5, 6), report schema (Task 5), UX/copy (Task 10), export mechanics (Task 9/10), frontend surfaces (Tasks 11/12), the fresh-verdict requirement (Tasks 3/4), retry counters (Task 2), `chapterId`/legacy-attribution (Task 1/5), testing (each task's own test + Task 13 e2e) — all covered. The spec's two "resolved" open questions (splice routes through `synthesiseChapter` but discards verdicts; repair patches `render-integrity.json` directly, doesn't re-trigger `scoreBook`) are directly implemented in Tasks 3 and 4 respectively.
 - **Not in this plan, deliberately** (per the spec's "Out of scope"): srv-36 Phase 2 consistency row, any change to gate on/off behavior itself beyond the fresh-verdict correctness fix, a QA-history-over-time view, backfilling `chapterId` onto existing books' `render-integrity.json` files.
-- **Known research gaps flagged inline rather than guessed**: Task 4's exact `replacements`-array construction site in `chapter-qa-repair.ts` (above the excerpt this plan's research covered) and Task 3/11/12's exact existing test-helper names — both are called out explicitly as "read the file first, match its existing names" rather than invented, so the implementer verifies against real code instead of a plan-author's guess.
+- **Known research gaps flagged inline rather than guessed**: Task 3/11/12's exact existing test-helper names are called out explicitly as "read the file first, match its existing names" rather than invented, so the implementer verifies against real code instead of a plan-author's guess. (Task 4's originally-uncertain `replacements`-array construction site was resolved during round-1 review — see the "Revision history" note — `chapter-qa-repair.ts` reuses Task 3's `buildSynthReplacements` directly; there is no separate site.)
+- **Plan review history**: this plan went through 3 rounds of the mandatory `assumption-checker` gate (the cap) before being shown to the user — see "Revision history" above for what each round found and fixed. Rounds 1 and 2 both met the re-review threshold; round 3's fixes (embed-failure consumption in the voice-match row/export copy, the `MOCK_QA_REPORT` missing-field typecheck break, the headline unit-mismatch, and an explicit call-out that the splice-callback change adds real latency to manual re-records) are final under the cap — any further finding a human reviewer surfaces should be fixed directly rather than run through a 4th automated pass.

--- a/docs/superpowers/specs/2026-07-05-fs51-qa-report-design.md
+++ b/docs/superpowers/specs/2026-07-05-fs51-qa-report-design.md
@@ -21,23 +21,37 @@ revised: |
   2026-07-05 round 2 (adversarial pass on the round-1 revision). Round 1's
   fix was itself Contradicted: a single `qaGatesUsed` object "stamped at
   finalize" can't reflect render-time config on the two *post-render*
-  writers of `segments.json` (`chapter-splice.ts`, `chapter-qa-repair.ts`)
-  because `finalizeChapterAudioWrite` reads config *live* and rebuilds the
-  segments file from scratch — reintroducing the exact false-clean risk the
-  design exists to prevent. Also: `chaptersEligible` can't be sourced from
-  `deriveBookOutline` (it reads only verdict files, never `segments.json`,
-  where engine/eligibility data lives) — conflated with a different function
-  (`scoreBook`) that has no return value at all. And the voice-match
-  headline ("N characters checked") had no defined source, so an
-  all-too-short-reference book could still read as a clean pass. Round 2's
-  fix: moved coverage-stamping to the point where each gate's ground truth
-  is actually known (per-segment inside the render/re-record loops, and
-  inside `aggregate.ts`/`scoreBook` for voice-drift) instead of a shared
-  downstream writer; moved eligibility computation into the report's own
-  aggregation code; added an explicit `charactersChecked` field and put the
-  coverage caveat in the headline, not a footnote; added a legacy-book
-  attribution state for pre-existing `render-integrity.json` files written
-  before `chapterId` existed.
+  writers of `segments.json` (`chapter-splice.ts`, `chapter-qa-repair.ts`).
+  Also: `chaptersEligible` can't be sourced from `deriveBookOutline` (it
+  reads only verdict files, never `segments.json`), and the voice-match
+  headline ("N characters checked") had no defined source. Round 2's fix:
+  moved coverage-stamping into `aggregate.ts`/`scoreBook` (per chapter) and
+  `synthesise-chapter.ts`/`chapter-qa-repair.ts` (per segment) — the code
+  that already knows each gate's ground truth, rather than a shared
+  downstream writer.
+
+  2026-07-05 round 3 (adversarial pass, final automated round per the
+  review-gate cap). Found the round-2 fix still didn't work: `scoreBook`
+  has book-level early returns (`chapterData.length === 0`,
+  `stochasticChars.size === 0`) that fire *before* any per-chapter
+  recording loop, so an all-Kokoro book, a never-run book, and a legacy
+  book all produce zero coverage records — indistinguishable. Also found
+  splice/QA-repair spread a segment's *pre-re-record* `qa`/`asr`/`suspect`
+  verdict forward via `{ ...segments[j] }` rather than writing a fresh one,
+  and `charactersOnRoster` had no defined population. Per the review-gate
+  cap (initial + 2 re-reviews = 3 total), this round did not get another
+  automated pass — the user was shown the findings directly and asked how
+  to proceed; they asked for the fixes to be applied manually. This
+  revision does that: eligibility is now computed directly by the report's
+  own aggregation (reading `segments.json`'s character/engine snapshots via
+  the same `STOCHASTIC_ENGINES` classification `aggregate.ts` already uses)
+  instead of being routed through `scoreBook`'s control flow, which
+  resolves the coverage ambiguity without needing scoreBook to change its
+  early-return behaviour at all. `charactersOnRoster` is now defined as the
+  same stochastic-character population used to compute eligibility — tied
+  to rendered content, not live cast.json. Splice and QA-repair are now
+  required to write a fresh per-segment verdict from the newly-rendered
+  audio instead of spreading the prior one forward.
 ---
 
 # fs-51 — Per-book performance-QA report
@@ -62,9 +76,10 @@ aid.
 **The report must never show a false pass.** Because its entire reason to
 exist is "proof, not promises," a receipt that reads clean for a check that
 either never ran, had nothing to check, or was checked incompletely is worse
-than no receipt at all. Two rounds of adversarial review against this exact
+than no receipt at all. Three rounds of adversarial review against this exact
 constraint reshaped the coverage-tracking design below — see the `revised:`
-frontmatter for what each round found and fixed.
+frontmatter for what each round found and fixed, including the round-3
+findings that were resolved manually after the review-gate cap was reached.
 
 **Correcting the srv-36 dependency.** The GitHub issue says fs-51 "depends on
 srv-36 (drift-threshold calibration)." That framing is stale: it was written
@@ -86,65 +101,110 @@ nothing new is persisted as a running summary:
 GET /api/books/:bookId/qa-report → BookQaReport
 ```
 
-### Design principle: each gate stamps its own coverage, at its own point of truth
+### Design principle: each gate stamps its own coverage, at its own point of truth — except where that point of truth has an early exit
 
-Round 2 found that a single coverage flag stamped generically at
-`finalizeChapterAudioWrite` (a function shared by three callers — the
-generation path, `chapter-splice.ts`, and `chapter-qa-repair.ts`) can't be
-trusted: that function reads config *live* and rebuilds the segments file
-from scratch on every call, so a post-render splice or repair would
-re-stamp (or lose) the original render-time coverage fact for content it
-didn't even touch. The fix is architectural: **coverage is recorded by the
-code that already knows it firsthand, at the moment it runs** — never
-reconstructed downstream from a shared writer that wasn't there when the
-gate actually fired.
+Round 2 established that coverage must be recorded by the code that already
+knows it firsthand, not reconstructed downstream. Round 3 found the one
+place that principle breaks: `aggregate.ts`'s `scoreBook` has **book-level**
+early returns (zero rendered chapters; zero stochastic-engine characters
+anywhere in the book) that fire *before* the per-chapter loop that would
+record a coverage fact — so for exactly the cases where honesty matters most
+(an all-Kokoro book, or a book where the gate never ran), scoreBook never
+gets far enough to say which one happened.
 
-1. **Signal-QA + SEG-ASR** — stamped **per segment**, inside whichever
-   render/re-record loop actually (re)synthesizes that segment:
-   `synthesise-chapter.ts`'s loop for generation, and
-   `chapter-qa-repair.ts`'s own re-record loop for repairs (confirmed as a
-   *separate* implementation from `synthesise-chapter.ts`'s, not a shared
-   call — see the retry-counter note below). Each segment record gets its
-   existing gate-config flags recorded at the exact moment it was rendered,
-   alongside the `qaRetries`/`asrRetries` counters (same write, same
-   reasoning). A segment that isn't touched by a later splice/repair simply
-   keeps its prior record unchanged — there is nothing to "carry forward"
-   because nothing rewrote it. **Whether `chapter-splice.ts`'s "re-record"
-   segments are produced by re-invoking `synthesise-chapter.ts`'s loop or
-   by some other path is not confirmed by this spec — verify at
-   implementation time; if splice has its own separate synthesis call, it
-   needs the same per-segment stamp as the repair path does.**
-2. **Voice drift (srv-36)** — stamped **per chapter, inside
-   `aggregate.ts`'s `scoreBook`**, the single existing choke point for this
-   gate. Today, `scoreBook` silently `continue`s when a chapter has zero
-   stochastic-engine characters or produces zero verdict rows — this spec
-   requires it to also record a small coverage fact for *every* chapter it
-   processes, even in those empty cases: `{ chapterId, eligible: boolean,
-   scored: boolean }`, alongside the file(s) it already writes. This is an
-   additive change to code that already has the answer at hand, not a
-   reconstruction after the fact — it avoids duplicating the
-   `STOCHASTIC_ENGINES` eligibility filter anywhere else (a real risk the
-   round-2 review flagged: computing eligibility a second time, in the
-   report's own code, from `segments.json`, would diverge from
-   `aggregate.ts`'s own filter over time).
-3. **Config drift** — unchanged; always-on, no coverage question. Different
-   time axis from the other three rows (see below).
+**The fix: don't ask scoreBook to answer a question its control flow can't
+reach.** Eligibility — "does this book have any stochastic-engine
+characters at all" — is computed **directly by the report's own
+aggregation code**, reading each chapter's `segments.json` character/engine
+snapshot through the same `STOCHASTIC_ENGINES` classification `aggregate.ts`
+already uses (imported, not reimplemented, so there is exactly one
+definition of "stochastic," not two that can drift apart). This fully
+decouples the eligibility signal from whether `scoreBook` happened to run:
 
-`deriveBookOutline()`
-(`server/src/audio/render-integrity/verdicts-io.ts`) gets one small,
-additive change: `chapterId` on `VerdictRow` (the chapter id is already in
-scope where `scoreBook` writes these rows — confirmed low-risk). It stays a
-pure reader of `render-integrity.json`/the new per-chapter coverage
-records; it does **not** grow a dependency on `segments.json` or the
-eligibility filter, which stays owned by `aggregate.ts` alone.
+- `voiceDrift.chaptersEligible === 0` (computed independently, from
+  `segments.json`) → **"No stochastic-voiced characters in this book —
+  nothing for this check to do."** Its own honest state, shown regardless
+  of whether the gate is on or off, because it's moot either way — this is
+  not a "not run" claim, it's a "there was nothing to check" fact.
+- `chaptersEligible > 0` — there *was* something to check, so if the gate
+  was on, `scoreBook` (which only book-level-returns when
+  `stochasticChars.size === 0`, which is false here) will have entered its
+  per-chapter loop and produced verdict files for at least some chapters.
+  `voiceDrift.chaptersScored` (from `deriveBookOutline`, reading actual
+  `render-integrity.json` files with the added `chapterId`) being `0` here
+  genuinely means "the gate was off" — the ambiguity is gone, because the
+  zero-eligible case is no longer folded into the same `0/0` reading.
+- A narrower, legitimate residual case remains: a chapter can be eligible
+  but skipped by `scoreBook`'s per-chapter (not book-level) check for a
+  missing embeddings sibling (a transient/failed embed, not a config
+  question). This surfaces as its own small `chaptersEmbedFailed` count
+  rather than being folded into either "not run" or "clean" — see schema.
 
-**Legacy books.** Books rendered before this ships have `render-integrity.json`
-files with no `chapterId` and no coverage records. The report detects this
-(`chapterId` absent on any row, or no coverage record for a chapter with
-existing verdict data) and sets `voiceDrift.attribution: 'legacy-unattributed'`
-rather than guessing — the UI shows severity counts and a flat mismatch list
-without per-chapter linking, plus a note that re-rendering or repairing a
-chapter restores full attribution for it.
+`voiceDrift.charactersOnRoster` uses the **same population** this
+eligibility computation already establishes: distinct stochastic-engine
+characters present in the book's rendered chapters. Not live `cast.json`
+(which would inflate the denominator with Kokoro-voiced or cut characters
+that can't drift in the first place, or drift out of sync with what was
+actually rendered) and not scoreBook's internal-only bookkeeping — the
+report's own independently-computed set, reused for both `chaptersEligible`
+and `charactersOnRoster` so they can never disagree with each other.
+
+`deriveBookOutline()` (`server/src/audio/render-integrity/verdicts-io.ts`)
+still gets its one small additive change: `chapterId` on `VerdictRow` (the
+existing per-chapter processing loop in `aggregate.ts` needs the chapter id
+threaded from `ChapterData` — today that struct carries only `slug`, so
+this is a small, real edit, not a zero-touch one). It stays a pure reader of
+`render-integrity.json`; the eligibility computation is not part of it.
+
+### Segments must carry a fresh verdict after any re-record, not a spread-forward one
+
+Round 3 found that both `chapter-splice.ts` and `chapter-qa-repair.ts`
+re-record a segment's audio but then either discard the fresh verdict
+(`splice` calls `synthesiseChapter` per segment but takes only the PCM,
+rebuilding segment metadata via `{ ...segments[j], ... }` — spreading the
+**pre-re-record** segment's `qa`/`asr`/`suspect`/`asrSuspect` fields
+forward) or never compute one at all (`chapter-qa-repair.ts` patches
+`render-integrity.json`'s voice-drift verdict in place but never touches
+the segment's own `qa`/`asr`/`suspect` fields in `segments.json`). Left
+alone, this doesn't just poison coverage bookkeeping — it poisons the
+*result* rows: a chapter successfully repaired can still report `suspect:
+true` and drag down `acoustic.chaptersFlagged` / `asr.linesFlaggedDrift`
+after the fix already landed. That's a "we claimed to catch it and did,
+but we're still showing it as broken" failure — a smaller credibility
+problem than a false pass, but still a real one for a "proof, not promises"
+surface, and one this work should close rather than carry forward.
+
+**Requirement, in scope for this work, not deferred to the report layer:**
+- `chapter-splice.ts`'s per-segment re-record call must pass through the
+  same signal-QA/ASR gate options used at generation time and use the
+  **returned** segment's fresh `qa`/`asr` fields for the spliced-in record,
+  instead of spreading the original segment's verdict forward.
+- `chapter-qa-repair.ts` must, after selecting a winning re-recorded take,
+  write that take's fresh `qa`/`asr`/`suspect`/`asrSuspect` verdict onto the
+  segment record in `segments.json` — today it only patches
+  `render-integrity.json`'s voice-drift row and pushes to the repair
+  route's own SSE `repaired[]`/`stillSuspect[]` arrays, never the
+  segment's own QA fields.
+
+Both routes already have the "new audio + the winning take" in hand at the
+point this needs to happen; this is writing down a verdict that's already
+computed, not adding new QA logic.
+
+### Retry counters
+
+An integer `qaRetries` / `asrRetries` field on each segment record in
+`segments.json`, incremented wherever a segment is actually re-recorded:
+`synthesise-chapter.ts`'s loop for generation, and `chapter-qa-repair.ts`'s
+own re-record loop for repairs — confirmed-separate code paths, so both
+need their own increment. `chapter-splice.ts` needs no extra increment
+logic beyond the fresh-verdict fix above: once it's writing a real,
+freshly-computed segment record instead of a spread of the original, that
+record's own `qaRetries` (from whatever synthesis path produced it) already
+reflects that segment's own history correctly.
+
+This is what makes "N lines re-recorded" an honest attempt-count instead of
+a "still flagged" proxy — without it, only the final verdict survives and a
+retry that *fixed* a line would be invisible.
 
 ### Config drift's own time axis
 
@@ -154,21 +214,17 @@ right now — it answers "has anything changed since this book was rendered,"
 not "did anything go wrong during the render." The report keeps this row
 visually and structurally separate from the other three for that reason.
 
-### Retry counters
+### Legacy books
 
-An integer `qaRetries` / `asrRetries` field on each segment record in
-`segments.json`, incremented at the same two points that now stamp gate
-coverage (above): `synthesise-chapter.ts`'s re-record loop, **and**
-`chapter-qa-repair.ts`'s own re-record loop — these are confirmed-separate
-code paths, so both need their own increment, not one shared increment
-with a "carry-forward" concern. `chapter-splice.ts` needs no extra work
-here: it assembles a chapter's segment array via object-spread
-(`{ ...segments[j], ... }`) for kept/gain/re-record segments, so an
-existing `qaRetries` value on a spread-from segment survives automatically.
-
-This is what makes "N lines re-recorded" an honest attempt-count instead of
-a "still flagged" proxy — without it, only the final verdict survives and a
-retry that *fixed* a line would be invisible.
+Books rendered before this ships have `render-integrity.json` files with no
+`chapterId`. The report detects this (verdict data exists but carries no
+`chapterId`) and sets `voiceDrift.attribution: 'legacy-unattributed'` —
+severity counts and a flat mismatch list still show, without per-chapter
+linking, plus a note that re-rendering or repairing a chapter restores full
+attribution for it. This is a distinct signal from `chaptersEligible`/
+`chaptersScored` (which are computed fresh from `segments.json` regardless
+of file vintage), so a legacy book's coverage numbers are still accurate —
+only the per-mismatch chapter linkage is unavailable until touched.
 
 The endpoint is the single source of truth for both display and export — no
 separate export endpoint. Both the Listen-view card and the live
@@ -188,9 +244,9 @@ BookQaReport {
   },
   voiceDrift: {
     attribution: 'full' | 'legacy-unattributed',
-    chaptersEligible, chaptersScored,
+    chaptersEligible, chaptersScored, chaptersEmbedFailed,
     charactersOnRoster, charactersChecked,
-    mismatches: [{ characterId, chapterId, severity, fixable }],
+    mismatches: [{ characterId, chapterId, severity: 'severe', fixable }],
     inconclusiveCount, uncheckedCharacterIds: string[]
   },
   configDrift: { counts: { mild, moderate, severe }, events: DriftEvent[] },
@@ -202,43 +258,52 @@ BookQaReport {
   rendered chapter; the denominator for the acoustic/ASR coverage fractions
   below. **Known limitation**: pre-108 (legacy) segment records can carry
   absent/empty `sentenceIds`, which silently undercounts rather than
-  overcounts — a "0 of 0" quiet gap on old books, not a false pass. Worth a
-  follow-up if it turns out to matter in practice; not blocking for v1.
+  overcounts — a "0 of 0" quiet gap on old books, not a false pass. Not
+  blocking for v1.
 - `acoustic.linesChecked` / `linesRerecorded` — sums of `sentenceIds.length`
-  (not segment-group counts) across segments whose per-segment coverage
-  stamp shows the signal-QA gate was on. Comparing `linesChecked` against
-  `totalLines` is the acoustic coverage fraction — a partial number here
-  (e.g. `290 of 342`) means the gate was off for part of the book, without
-  needing a separate chapter-level on/off flag.
+  across segments where `seg.qa != null` (present only when the signal-QA
+  gate actually ran for that segment — an existing field, not a new stamp;
+  see the "segments must carry a fresh verdict" requirement above for why
+  this is trustworthy after a splice/repair). `linesChecked` vs. `totalLines`
+  is the acoustic coverage fraction.
 - `acoustic.chaptersFlagged` — chapters containing at least one segment
-  still `suspect` after every retry attempt was exhausted.
+  still `suspect` after every retry attempt was exhausted **and** after any
+  splice/repair has written its fresh verdict.
 - `asr.linesVerified` / `linesFlaggedDrift` — same sentence-sum convention,
-  gated on the per-segment ASR coverage stamp; `linesVerified` vs.
-  `totalLines` is this row's coverage fraction.
-- `voiceDrift.chaptersEligible` — chapters (from `aggregate.ts`'s own
-  per-chapter coverage record) containing at least one stochastic-engine
-  (Qwen/Coqui) character. A chapter voiced entirely by Kokoro is not
-  eligible — this is what distinguishes "nothing to check here" from "not
-  run."
-- `voiceDrift.chaptersScored` — eligible chapters whose coverage record
-  shows `scored: true`. In practice this should equal `chaptersEligible`;
-  tracked separately so a shortfall is visible rather than silently
-  absorbed. `chaptersEligible === 0` and `chaptersScored === 0` together
-  mean "not run for this book" (the gate never produced a coverage record
-  at all); `chaptersEligible > 0` with `chaptersScored < chaptersEligible`
-  means partial coverage.
-- `voiceDrift.charactersOnRoster` / `charactersChecked` — roster size vs.
-  roster minus `uncheckedCharacterIds` (too-short reference audio). The UI
-  headline always states both when they differ (see UX section) — never a
-  bare "N characters checked" that could be roster size in disguise.
-- `voiceDrift.mismatches` — rows where `verdict === 'voice-mismatch'` and
-  `severity === 'severe'`. **Not the same severity scale as `configDrift`**:
-  voice-drift severity is `'severe' | 'inconclusive' | null` (from
-  `VerdictRow`), config-drift severity is `'mild' | 'moderate' | 'severe'`
-  — the UI renders each with its own colour mapping, never a shared legend.
-- `voiceDrift.inconclusiveCount` — verdicts in the inconclusive band
-  (typically short quotes below the minimum-duration gate) — its own line,
-  never folded into "mismatch" or "clean."
+  gated on `seg.asr != null`; `linesVerified` vs. `totalLines` is this
+  row's coverage fraction.
+- `voiceDrift.chaptersEligible` — chapters containing at least one
+  stochastic-engine (Qwen/Coqui) character, computed by the report's own
+  aggregation directly from `segments.json` (the `STOCHASTIC_ENGINES`
+  classification, imported from `aggregate.ts`), independent of whether
+  `scoreBook` ran. `0` means "no stochastic-voiced characters in this
+  book" — its own honest state, not a "not run" claim.
+- `voiceDrift.chaptersScored` — of the eligible chapters, those with actual
+  verdict rows in `render-integrity.json` (via the `chapterId`-extended
+  `deriveBookOutline`). With eligibility computed independently (above),
+  `chaptersEligible > 0` and `chaptersScored === 0` unambiguously means
+  "the gate was off for this book."
+- `voiceDrift.chaptersEmbedFailed` — eligible chapters `scoreBook` skipped
+  for a missing/failed embeddings sibling — a narrow, legitimate residual
+  case distinct from both "off" and "clean," surfaced rather than folded
+  into either.
+- `voiceDrift.charactersOnRoster` / `charactersChecked` — the same
+  stochastic-character population used for `chaptersEligible`, and that
+  population minus `uncheckedCharacterIds` (too-short reference audio).
+  Tied to what was actually rendered, not live `cast.json` — a Kokoro-only
+  character is correctly absent from this denominator (it cannot drift),
+  not an undercount.
+- `voiceDrift.mismatches` — rows where `verdict === 'voice-mismatch'`
+  (severity is always `'severe'` by construction of that filter — not a
+  meaningful third value here). **Not the same severity scale as
+  `configDrift`**: voice-drift's underlying `VerdictRow.severity` is
+  `'severe' | 'inconclusive' | null`, config-drift's is `'mild' |
+  'moderate' | 'severe'` — the UI renders each with its own colour mapping,
+  never a shared legend.
+- `voiceDrift.inconclusiveCount` — a **chapter** count (matching the UX
+  copy's "N chapters inconclusive"), not a raw verdict-row count: chapters
+  containing at least one inconclusive verdict (typically short quotes
+  below the minimum-duration gate).
 - `voiceDrift.uncheckedCharacterIds` — characters excluded from scoring
   because their reference audio was too short to embed
   (`referenceKind === 'too-short'`).
@@ -274,12 +339,12 @@ never an apology, matching the brand's own empty-state example (*"No books
 yet. Drop in an EPUB, PDF, or paste a chapter — we'll find the cast."* —
 `brand-guidelines.md`):
 
-| Row | Full coverage | Partial coverage | Not run |
-|---|---|---|---|
-| Acoustic | "342 lines checked, 0 needed a second take." | "290 of 342 lines checked — the rest were rendered before this pass was on." | "Not run for this book." |
-| Transcript (SEG-ASR) | "342 lines verified against what Whisper heard, 0 flagged." | Same fraction pattern as above. | "Not run for this book — turn on transcript verification before your next render." |
-| Voice match (SEG-SPK) | "18 of 18 characters checked against their own reference take, 0 mismatches." | Leads with the fraction whenever `charactersChecked < charactersOnRoster` or `chaptersScored < chaptersEligible`: e.g. "12 of 18 characters checked — 6 had too little reference audio to check, 0 mismatches among the rest." Plus, when nonzero: "N chapters inconclusive — usually short quotes." | "Not run for this book — flip on render-integrity checking to catch mismatches automatically." |
-| Cast continuity | Severity-coded counts, framed as *"since this book was rendered"* (not a render-time result like the other three). Reuses the `Pill` component with its own `severe→danger, moderate→warning, mild→neutral` mapping — a different severity vocabulary from voice-match, never conflated. A flagged line deep-links into the existing `drift-report.tsx` modal. | *(always on — no coverage question)* | *(always on)* |
+| Row | Full coverage | Partial coverage | Not run | Other honest states |
+|---|---|---|---|---|
+| Acoustic | "342 lines checked, 0 needed a second take." | "290 of 342 lines checked — the rest were rendered before this pass was on." | "Not run for this book." | — |
+| Transcript (SEG-ASR) | "342 lines verified against what Whisper heard, 0 flagged." | Same fraction pattern as above. | "Not run for this book — turn on transcript verification before your next render." | — |
+| Voice match (SEG-SPK) | "18 of 18 characters checked against their own reference take, 0 mismatches." | Leads with the fraction whenever `charactersChecked < charactersOnRoster` or `chaptersScored < chaptersEligible`: "12 of 18 characters checked — 6 had too little reference audio to check, 0 mismatches among the rest." Plus, when nonzero: "N chapters inconclusive — usually short quotes." | "Not run for this book — flip on render-integrity checking to catch mismatches automatically." (Only shown when `chaptersEligible > 0`.) | `chaptersEligible === 0`: **"No stochastic-voiced characters in this book — nothing for this check to do."** Distinct from "not run"; never phrased as a shortfall. |
+| Cast continuity | Severity-coded counts, framed as *"since this book was rendered"* (not a render-time result like the other three). Reuses the `Pill` component with its own `severe→danger, moderate→warning, mild→neutral` mapping — a different severity vocabulary from voice-match, never conflated. A flagged line deep-links into the existing `drift-report.tsx` modal. | *(always on — no coverage question)* | *(always on)* | — |
 
 A legacy-unattributed voice-drift result still shows severity counts, plus:
 *"Chapter detail isn't available for this render — re-rendering or
@@ -346,63 +411,57 @@ identical by construction.
   own coverage fraction.
 - A gate toggled mid-book, or a chapter regenerated after a setting change
   → reported as a partial coverage fraction, never silently rounded to "on"
-  or "off," because coverage is tracked per segment/chapter rather than as
-  one book-level flag.
+  or "off," because coverage is tracked per line/chapter rather than as one
+  book-level flag.
+- A book with no stochastic-engine characters at all → `chaptersEligible
+  === 0`, its own honest state, never conflated with "not run."
 - Mixed-engine chapters and Kokoro-voiced characters are already excluded
-  from voice-drift scoring upstream (`STOCHASTIC_ENGINES` filter in
-  `aggregate.ts`); the report reflects that via `chaptersEligible`, computed
-  once, inside the same code that owns that filter.
+  from voice-drift scoring upstream; the report computes the same
+  exclusion itself (via the shared `STOCHASTIC_ENGINES` constant) rather
+  than depending on `scoreBook` having reached a particular chapter.
 - Legacy books (rendered before this ships) get `attribution:
-  'legacy-unattributed'` for voice-drift rather than a guess at chapter
-  linkage.
+  'legacy-unattributed'` for per-mismatch chapter linking; their coverage
+  counts remain accurate regardless, since those are computed fresh.
 - No staleness/re-fetch logic beyond "derive on read" — a regenerated
-  chapter's files are simply the new ground truth on the next call.
+  chapter's files are simply the new ground truth on the next call, and are
+  trustworthy ground truth per the fresh-verdict requirement above.
 
 ## Testing
 
 - **Server**: unit tests for the aggregation function against fixture
   combinations — all gates on, all off, partial coverage (gate toggled
-  mid-book), an all-Kokoro book (voice-drift on, zero eligible chapters), a
-  book with `inconclusive`/too-short-reference characters, and a legacy
-  book with no `chapterId`/coverage records. A route test for the endpoint.
-  A regression test that both `synthesise-chapter.ts`'s and
-  `chapter-qa-repair.ts`'s re-record loops independently increment
-  `qaRetries`/`asrRetries`, and that a splice preserves existing values via
-  its spread-based assembly. A test that `aggregate.ts`/`scoreBook` writes
-  a coverage record for a chapter even when it has zero stochastic
-  characters or zero verdict rows.
+  mid-book), an all-Kokoro book (`chaptersEligible === 0`), a book with
+  `inconclusive`/too-short-reference characters, a book with an
+  embeddings-failure chapter, and a legacy book with no `chapterId`. A
+  route test for the endpoint. A regression test that both
+  `synthesise-chapter.ts`'s and `chapter-qa-repair.ts`'s re-record loops
+  independently increment `qaRetries`/`asrRetries`. **A regression test
+  that a chapter successfully repaired (or spliced) no longer reports
+  `suspect`/`asrSuspect` from the pre-fix take** — this is the fresh-verdict
+  requirement's own paired test, not optional polish. A test confirming
+  `chaptersEligible`/`charactersOnRoster` are computed identically
+  regardless of whether `scoreBook` ran, early-returned, or was never
+  triggered.
 - **Frontend**: component tests for `QaReportCard` across the full-coverage/
-  partial-coverage/not-run/legacy-unattributed/no-data/mid-generation
-  permutations for each row independently, including the voice-match
-  "roster vs. checked vs. unchecked" headline.
+  partial-coverage/not-run/no-stochastic-characters/legacy-unattributed/
+  no-data/mid-generation permutations for each row independently, including
+  the voice-match "roster vs. checked vs. unchecked" headline.
 - **E2E**: one Playwright spec covering the Listen-view card and both export
   buttons, backed by a new mock `BookQaReport` fixture in `src/data/`
   (mocks are the default e2e mode).
-
-## Open implementation-time questions (not resolved by this spec)
-
-- Whether `chapter-splice.ts`'s "re-record" segments are produced via
-  `synthesise-chapter.ts`'s loop (in which case per-segment coverage
-  stamping there covers splice for free) or a separate synthesis call (in
-  which case that call needs its own stamp, mirroring `chapter-qa-repair.ts`).
-- Whether `chapter-qa-repair.ts`'s repair action re-triggers
-  `aggregate.ts`'s `scoreBook` for voice-drift re-scoring after a repair, or
-  only reads the existing `render-integrity.json` — affects whether a
-  repaired chapter's voice-drift coverage record updates or stays stale
-  until the next full re-render.
-
-These are flagged rather than guessed at, per this spec's own "no false
-pass" rule — the implementation plan should resolve them against the actual
-call graph before writing the stamping code.
 
 ## Out of scope
 
 - srv-36 Phase 2 (cross-book/series voice consistency) — still `status:
   draft`, no production code exists. No consistency row until it ships.
 - Any change to when/whether the underlying gates run — this report only
-  aggregates and presents existing signals.
+  aggregates and presents existing signals (the one exception being the
+  fresh-verdict-on-re-record fix above, which corrects an existing
+  correctness gap the report's own honesty requirement surfaces, not a
+  behavioural change to the gates themselves).
 - A dedicated "QA history over time" view (trend across regenerations) —
   the report reflects the book's current render state only.
-- Backfilling `chapterId`/coverage records onto already-rendered books'
-  existing `render-integrity.json` files — they stay
-  `legacy-unattributed` until next touched.
+- Backfilling `chapterId` onto already-rendered books' existing
+  `render-integrity.json` files — they stay `legacy-unattributed` for
+  per-mismatch chapter linking until next touched. Their coverage counts
+  are unaffected, since those are computed fresh from `segments.json`.

--- a/docs/superpowers/specs/2026-07-05-fs51-qa-report-design.md
+++ b/docs/superpowers/specs/2026-07-05-fs51-qa-report-design.md
@@ -5,7 +5,39 @@ topic: fs-51 — per-book performance-QA report (visible + exportable acoustic+A
 issue: fs-51 (#973)
 depends_on: none (see "Correcting the srv-36 dependency" below — the issue's stated dependency is stale)
 relates_to: srv-36 Phase 1 (#665, shipped — supplies the voice-match row) · srv-31 (ASR content-QA / SEG-ASR gate) · plan 179 (signal-QA) · srv-27 (audio-qa.ts loudness/duration gate) · revisions.ts (config-drift)
-revised: 2026-07-05 (round 1 adversarial pass — code-grounded against origin/main via `assumption-checker`). Fixed: presence-based gate detection was Contradicted by two real book shapes (an all-Kokoro book runs the voice-drift gate but writes no verdict file; the acoustic gate is conditional on `maxSegmentRerecords > 0`, not always-on as originally written) — replaced with per-chapter gate-config stamping + coverage ratios. `deriveBookOutline()` cannot supply `chapterId`/`chaptersScored`/`uncheckedCharacters` as originally assumed — scoped in as a small required extension, not a zero-touch reuse. "Lines" was silently counting segment-groups, not sentences — redefined against `sentenceIds`. Added retry-counter carry-forward requirement across the splice/QA-repair re-write paths. Removed a fabricated brand quote ("an empty screen is an invitation to act" does not exist in `brand/`) in favour of the real empty-state example. Clarified that voice-drift severity (`severe`/`inconclusive`/`null`) and config-drift severity (`mild`/`moderate`/`severe`) are different scales, not one shared vocabulary. Clarified config-drift's "since render" time semantics against the other three rows' "during render" semantics.
+revised: |
+  2026-07-05 round 1 (adversarial pass, code-grounded via `assumption-checker`).
+  Fixed: presence-based gate detection was Contradicted by two real book
+  shapes (an all-Kokoro book runs the voice-drift gate but writes no verdict
+  file; the acoustic gate is conditional on `maxSegmentRerecords > 0`, not
+  always-on) — replaced with per-chapter gate-config stamping + coverage
+  ratios. `deriveBookOutline()` cannot supply `chapterId`/`chaptersScored`/
+  `uncheckedCharacters` as originally assumed. "Lines" was silently counting
+  segment-groups, not sentences. Added retry-counter carry-forward across
+  splice/QA-repair. Removed a fabricated brand quote. Clarified voice-drift
+  vs. config-drift severity are different scales, and config-drift's
+  "since render" vs. the other rows' "during render" time semantics.
+
+  2026-07-05 round 2 (adversarial pass on the round-1 revision). Round 1's
+  fix was itself Contradicted: a single `qaGatesUsed` object "stamped at
+  finalize" can't reflect render-time config on the two *post-render*
+  writers of `segments.json` (`chapter-splice.ts`, `chapter-qa-repair.ts`)
+  because `finalizeChapterAudioWrite` reads config *live* and rebuilds the
+  segments file from scratch — reintroducing the exact false-clean risk the
+  design exists to prevent. Also: `chaptersEligible` can't be sourced from
+  `deriveBookOutline` (it reads only verdict files, never `segments.json`,
+  where engine/eligibility data lives) — conflated with a different function
+  (`scoreBook`) that has no return value at all. And the voice-match
+  headline ("N characters checked") had no defined source, so an
+  all-too-short-reference book could still read as a clean pass. Round 2's
+  fix: moved coverage-stamping to the point where each gate's ground truth
+  is actually known (per-segment inside the render/re-record loops, and
+  inside `aggregate.ts`/`scoreBook` for voice-drift) instead of a shared
+  downstream writer; moved eligibility computation into the report's own
+  aggregation code; added an explicit `charactersChecked` field and put the
+  coverage caveat in the headline, not a footnote; added a legacy-book
+  attribution state for pre-existing `render-integrity.json` files written
+  before `chapterId` existed.
 ---
 
 # fs-51 — Per-book performance-QA report
@@ -29,10 +61,10 @@ aid.
 
 **The report must never show a false pass.** Because its entire reason to
 exist is "proof, not promises," a receipt that reads clean for a check that
-either never ran or had nothing to check is worse than no receipt at all.
-This constraint is why the gate-detection design below is more involved than
-a naive "is there output on disk" check — see "Gate coverage is stamped, not
-inferred."
+either never ran, had nothing to check, or was checked incompletely is worse
+than no receipt at all. Two rounds of adversarial review against this exact
+constraint reshaped the coverage-tracking design below — see the `revised:`
+frontmatter for what each round found and fixed.
 
 **Correcting the srv-36 dependency.** The GitHub issue says fs-51 "depends on
 srv-36 (drift-threshold calibration)." That framing is stale: it was written
@@ -54,112 +86,110 @@ nothing new is persisted as a running summary:
 GET /api/books/:bookId/qa-report → BookQaReport
 ```
 
-It reads four existing sources, per chapter:
+### Design principle: each gate stamps its own coverage, at its own point of truth
 
-1. **Signal-QA** (`<slug>.segments.json`, plan 179) — near-silent/truncated/
-   runaway-duration flags, via the existing `loadSegmentsFiles()`
-   (`server/src/audio/segments-io.ts`). Conditional on
-   `maxSegmentRerecords > 0` — **not** always-on, corrected from an earlier
-   draft of this spec.
-2. **ASR content-QA / SEG-ASR** (`<slug>.segments.json`, srv-31) — transcript
-   drift flags, same file, gated by `SEG_ASR_ENABLED`.
-3. **Voice drift / SEG-SPK** (`<slug>.render-integrity.json`, srv-36 Phase 1)
-   — via a **small required extension** to
-   `server/src/audio/render-integrity/verdicts-io.ts`. `deriveBookOutline()`
-   exists and is tested, but its `VerdictRow` carries no `chapterId` (every
-   chapter's rows are flattened into one array) and its return shape has no
-   per-chapter scored/eligible counts — both are needed for this report's
-   `voiceDrift` section (see schema below). This is not the zero-touch reuse
-   an earlier draft assumed; it's a small, additive change to an already-
-   shipped module (add `chapterId` to `VerdictRow`; add
-   `chaptersEligible`/`chaptersScored` to the aggregate return), not a
-   rewrite. Gated by `SEG_SPK_ENABLED`.
-4. **Config drift** (the server-side equivalent of `revisions-slice`'s
-   `DriftEvent[]`) — cast/voice reassignment drift, severity mild/moderate/
-   severe. Always on, no gate. **Different time axis from the other three**:
-   this compares the render-time snapshot against the *live* cast right now,
-   so it answers "has anything changed since this book was rendered," not
-   "did anything go wrong during the render." The report keeps this row
-   clearly separated from the other three for that reason.
+Round 2 found that a single coverage flag stamped generically at
+`finalizeChapterAudioWrite` (a function shared by three callers — the
+generation path, `chapter-splice.ts`, and `chapter-qa-repair.ts`) can't be
+trusted: that function reads config *live* and rebuilds the segments file
+from scratch on every call, so a post-render splice or repair would
+re-stamp (or lose) the original render-time coverage fact for content it
+didn't even touch. The fix is architectural: **coverage is recorded by the
+code that already knows it firsthand, at the moment it runs** — never
+reconstructed downstream from a shared writer that wasn't there when the
+gate actually fired.
 
-**Gate coverage is stamped, not inferred.** An earlier draft of this spec
-inferred whether a gate ran from whether its output was present on disk
-(`seg.asr != null`; a `render-integrity.json` file exists). That's
-unreliable for two real book shapes, confirmed against the code: an
-all-Kokoro book runs the voice-drift gate (it's enabled) but writes no
-verdict file, because `aggregate.ts` returns early when there are zero
-stochastic-engine characters to score — presence-based detection would
-wrongly report "not run." And the acoustic gate isn't always-on at all (see
-point 1 above) — an earlier draft gave it no "not run" state, so a disabled
-acoustic gate would have rendered as a perfect score.
+1. **Signal-QA + SEG-ASR** — stamped **per segment**, inside whichever
+   render/re-record loop actually (re)synthesizes that segment:
+   `synthesise-chapter.ts`'s loop for generation, and
+   `chapter-qa-repair.ts`'s own re-record loop for repairs (confirmed as a
+   *separate* implementation from `synthesise-chapter.ts`'s, not a shared
+   call — see the retry-counter note below). Each segment record gets its
+   existing gate-config flags recorded at the exact moment it was rendered,
+   alongside the `qaRetries`/`asrRetries` counters (same write, same
+   reasoning). A segment that isn't touched by a later splice/repair simply
+   keeps its prior record unchanged — there is nothing to "carry forward"
+   because nothing rewrote it. **Whether `chapter-splice.ts`'s "re-record"
+   segments are produced by re-invoking `synthesise-chapter.ts`'s loop or
+   by some other path is not confirmed by this spec — verify at
+   implementation time; if splice has its own separate synthesis call, it
+   needs the same per-segment stamp as the repair path does.**
+2. **Voice drift (srv-36)** — stamped **per chapter, inside
+   `aggregate.ts`'s `scoreBook`**, the single existing choke point for this
+   gate. Today, `scoreBook` silently `continue`s when a chapter has zero
+   stochastic-engine characters or produces zero verdict rows — this spec
+   requires it to also record a small coverage fact for *every* chapter it
+   processes, even in those empty cases: `{ chapterId, eligible: boolean,
+   scored: boolean }`, alongside the file(s) it already writes. This is an
+   additive change to code that already has the answer at hand, not a
+   reconstruction after the fact — it avoids duplicating the
+   `STOCHASTIC_ENGINES` eligibility filter anywhere else (a real risk the
+   round-2 review flagged: computing eligibility a second time, in the
+   report's own code, from `segments.json`, would diverge from
+   `aggregate.ts`'s own filter over time).
+3. **Config drift** — unchanged; always-on, no coverage question. Different
+   time axis from the other three rows (see below).
 
-The fix: at the same finalize step that already writes `segments.json`
-(`server/src/audio/finalize-chapter-write.ts`), stamp a small
-`qaGatesUsed: { acoustic: boolean, asr: boolean, voiceDrift: boolean }`
-object onto each chapter record, reflecting the actual registry config
-(`qa.seg.*`/`qa.asr.enabled`/`qa.speaker.enabled`) active *at that chapter's
-render time* — not a guess from output shape, and not today's live config
-(which may have changed since). The report aggregates this per-chapter
-across the book into a coverage ratio (`chaptersGateOn` /
-`chaptersRendered`) for each of the three optional gates, so:
-- `0 / chaptersRendered` → the gate never ran for this book → "not run"
-  copy.
-- `chaptersRendered / chaptersRendered` → full coverage → normal receipt.
-- Anything in between (the gate was toggled mid-book, or a chapter was
-  regenerated after a setting change) → an explicit partial-coverage caveat,
-  never silently rounded to either extreme.
+`deriveBookOutline()`
+(`server/src/audio/render-integrity/verdicts-io.ts`) gets one small,
+additive change: `chapterId` on `VerdictRow` (the chapter id is already in
+scope where `scoreBook` writes these rows — confirmed low-risk). It stays a
+pure reader of `render-integrity.json`/the new per-chapter coverage
+records; it does **not** grow a dependency on `segments.json` or the
+eligibility filter, which stays owned by `aggregate.ts` alone.
 
-For voice-drift specifically, `chaptersGateOn` alone still isn't sufficient
-honesty — a chapter can have the gate on and have nothing to score (no
-stochastic-engine characters). The `voiceDrift` schema section therefore
-separately tracks `chaptersEligible` (gate-on chapters that contain at least
-one stochastic-engine character) and `chaptersScored` (eligible chapters
-that actually produced verdict rows), so "0 mismatches" can never quietly
-mean "nothing was checked."
+**Legacy books.** Books rendered before this ships have `render-integrity.json`
+files with no `chapterId` and no coverage records. The report detects this
+(`chapterId` absent on any row, or no coverage record for a chapter with
+existing verdict data) and sets `voiceDrift.attribution: 'legacy-unattributed'`
+rather than guessing — the UI shows severity counts and a flat mismatch list
+without per-chapter linking, plus a note that re-rendering or repairing a
+chapter restores full attribution for it.
 
-**Two schema additions**, both stamped at the same existing finalize step
-(not new persisted aggregates — just two more fields on data already being
-written):
-- `qaGatesUsed` (above), per chapter.
-- An integer `qaRetries` / `asrRetries` field on each segment record in
-  `segments.json`, incremented in the existing re-record loop in
-  `synthesise-chapter.ts` (where `segmentQaByIndex`/`segmentAsrByIndex`
-  already get refreshed each round). This is what makes "N lines
-  re-recorded" an honest attempt-count instead of a "still flagged" proxy —
-  without it, only the final verdict survives and a retry that *fixed* a
-  line would be invisible.
-  **Carry-forward requirement**: `segments.json` isn't only written by the
-  main generation path — the splice and QA-repair routes
-  (`chapter-splice.ts`, `chapter-qa-repair.ts`) also call
-  `finalizeChapterAudioWrite` and re-persist the file. Whichever path writes
-  `qaRetries`/`asrRetries` must read the segment's *prior* count (if the
-  file already exists) and add to it, not start from the current
-  operation's local counter — otherwise a repair or splice silently resets
-  a segment's retry history to zero, making "N lines re-recorded" go
-  *down* after a repair, which is the same false-clean failure mode as the
-  gate-detection issue above.
+### Config drift's own time axis
+
+Config drift (the server-side equivalent of `revisions-slice`'s
+`DriftEvent[]`) compares the render-time snapshot against the *live* cast
+right now — it answers "has anything changed since this book was rendered,"
+not "did anything go wrong during the render." The report keeps this row
+visually and structurally separate from the other three for that reason.
+
+### Retry counters
+
+An integer `qaRetries` / `asrRetries` field on each segment record in
+`segments.json`, incremented at the same two points that now stamp gate
+coverage (above): `synthesise-chapter.ts`'s re-record loop, **and**
+`chapter-qa-repair.ts`'s own re-record loop — these are confirmed-separate
+code paths, so both need their own increment, not one shared increment
+with a "carry-forward" concern. `chapter-splice.ts` needs no extra work
+here: it assembles a chapter's segment array via object-spread
+(`{ ...segments[j], ... }`) for kept/gain/re-record segments, so an
+existing `qaRetries` value on a spread-from segment survives automatically.
+
+This is what makes "N lines re-recorded" an honest attempt-count instead of
+a "still flagged" proxy — without it, only the final verdict survives and a
+retry that *fixed* a line would be invisible.
 
 The endpoint is the single source of truth for both display and export — no
 separate export endpoint. Both the Listen-view card and the live
 Generation-view panel call the same `GET`, so display and export can never
-diverge from each other. (This does not by itself guarantee the report
-matches "what the gate actually did" in every edge case — that guarantee
-comes from the coverage-stamping design above, not from the single-endpoint
-structure alone.)
+diverge from each other.
 
 ## Report schema
 
 ```
 BookQaReport {
-  bookId, generatedAt, chaptersRendered, chaptersTotal,
+  bookId, generatedAt, chaptersRendered, chaptersTotal, totalLines,
   acoustic: {
-    chaptersGateOn, linesChecked, linesRerecorded, chaptersFlagged
+    linesChecked, linesRerecorded, chaptersFlagged
   },
   asr: {
-    chaptersGateOn, linesVerified, linesFlaggedDrift
+    linesVerified, linesFlaggedDrift
   },
   voiceDrift: {
-    chaptersGateOn, chaptersEligible, chaptersScored,
+    attribution: 'full' | 'legacy-unattributed',
+    chaptersEligible, chaptersScored,
+    charactersOnRoster, charactersChecked,
     mismatches: [{ characterId, chapterId, severity, fixable }],
     inconclusiveCount, uncheckedCharacterIds: string[]
   },
@@ -167,46 +197,51 @@ BookQaReport {
 }
 ```
 
-**Field definitions** (to remove any ambiguity about what each count means):
-- `*.chaptersGateOn` — number of `chaptersRendered` where that gate's config
-  was actually active at render time (from the stamped `qaGatesUsed`, not
-  inferred from output). `0` → not-run copy; equal to `chaptersRendered` →
-  full-coverage copy; anything else → partial-coverage copy (see UX
-  section).
-- `acoustic.linesChecked` / `linesRerecorded` — **counted in sentences, not
-  segment-groups.** A `ChapterSegment` can bundle multiple sentences
-  (`sentenceIds: number[]`); the report sums `sentenceIds.length` across the
-  relevant segments rather than counting segments themselves, so "lines"
-  means what a reader thinks it means. `linesRerecorded` sums
-  `sentenceIds.length` for segments where `qaRetries > 0`.
+**Field definitions:**
+- `totalLines` — sum of `sentenceIds.length` across every segment in every
+  rendered chapter; the denominator for the acoustic/ASR coverage fractions
+  below. **Known limitation**: pre-108 (legacy) segment records can carry
+  absent/empty `sentenceIds`, which silently undercounts rather than
+  overcounts — a "0 of 0" quiet gap on old books, not a false pass. Worth a
+  follow-up if it turns out to matter in practice; not blocking for v1.
+- `acoustic.linesChecked` / `linesRerecorded` — sums of `sentenceIds.length`
+  (not segment-group counts) across segments whose per-segment coverage
+  stamp shows the signal-QA gate was on. Comparing `linesChecked` against
+  `totalLines` is the acoustic coverage fraction — a partial number here
+  (e.g. `290 of 342`) means the gate was off for part of the book, without
+  needing a separate chapter-level on/off flag.
 - `acoustic.chaptersFlagged` — chapters containing at least one segment
   still `suspect` after every retry attempt was exhausted.
-- `asr.linesVerified` — sentences (via `sentenceIds`, same convention as
-  above) in segments where `seg.asr` is present, independent of verdict.
-- `asr.linesFlaggedDrift` — sentences in segments where the final ASR
-  verdict is `'drift'` (`asrSuspect === true`).
-- `voiceDrift.chaptersEligible` — of the gate-on chapters, those containing
-  at least one stochastic-engine (Qwen/Coqui) character. A chapter voiced
-  entirely by Kokoro is gate-on but not eligible — this is what
-  distinguishes "nothing to check here" from "not run."
-- `voiceDrift.chaptersScored` — eligible chapters that actually produced
-  verdict rows. In practice this should equal `chaptersEligible`; the
-  report tracks them separately so a shortfall is visible rather than
-  silently absorbed.
+- `asr.linesVerified` / `linesFlaggedDrift` — same sentence-sum convention,
+  gated on the per-segment ASR coverage stamp; `linesVerified` vs.
+  `totalLines` is this row's coverage fraction.
+- `voiceDrift.chaptersEligible` — chapters (from `aggregate.ts`'s own
+  per-chapter coverage record) containing at least one stochastic-engine
+  (Qwen/Coqui) character. A chapter voiced entirely by Kokoro is not
+  eligible — this is what distinguishes "nothing to check here" from "not
+  run."
+- `voiceDrift.chaptersScored` — eligible chapters whose coverage record
+  shows `scored: true`. In practice this should equal `chaptersEligible`;
+  tracked separately so a shortfall is visible rather than silently
+  absorbed. `chaptersEligible === 0` and `chaptersScored === 0` together
+  mean "not run for this book" (the gate never produced a coverage record
+  at all); `chaptersEligible > 0` with `chaptersScored < chaptersEligible`
+  means partial coverage.
+- `voiceDrift.charactersOnRoster` / `charactersChecked` — roster size vs.
+  roster minus `uncheckedCharacterIds` (too-short reference audio). The UI
+  headline always states both when they differ (see UX section) — never a
+  bare "N characters checked" that could be roster size in disguise.
 - `voiceDrift.mismatches` — rows where `verdict === 'voice-mismatch'` and
   `severity === 'severe'`. **Not the same severity scale as `configDrift`**:
-  voice-drift severity is `'severe' | 'inconclusive' | null`
-  (three-valued, from `VerdictRow`), config-drift severity is
-  `'mild' | 'moderate' | 'severe'` — the UI renders each with its own
-  colour mapping (see UX section), never a shared legend.
-- `voiceDrift.inconclusiveCount` — verdicts that landed in the inconclusive
-  band (typically short quotes below the minimum-duration gate). Shown as
-  its own line, not folded into either "mismatch" or "clean."
+  voice-drift severity is `'severe' | 'inconclusive' | null` (from
+  `VerdictRow`), config-drift severity is `'mild' | 'moderate' | 'severe'`
+  — the UI renders each with its own colour mapping, never a shared legend.
+- `voiceDrift.inconclusiveCount` — verdicts in the inconclusive band
+  (typically short quotes below the minimum-duration gate) — its own line,
+  never folded into "mismatch" or "clean."
 - `voiceDrift.uncheckedCharacterIds` — characters excluded from scoring
   because their reference audio was too short to embed
-  (`referenceKind === 'too-short'`, from the extended `deriveBookOutline`).
-  Surfaced explicitly so "0 mismatches" can't be read as "everyone passed"
-  when some characters were never checkable.
+  (`referenceKind === 'too-short'`).
 
 `openapi.yaml` gets the new `BookQaReport` schema + the `GET
 /api/books/{bookId}/qa-report` path; `npm run openapi:types` regenerates
@@ -217,9 +252,9 @@ BookQaReport {
 This is the surface where Castwright's core quality claim becomes evidence,
 not marketing copy — "we promised, we delivered" made literal and specific
 to *this* book. That governs every choice below, including the harder edges
-introduced by the coverage-stamping design above: **an honest partial
-receipt is more on-brand than a clean-looking one that's actually
-incomplete.**
+the coverage design surfaces: **an honest partial receipt is more on-brand
+than a clean-looking one that's actually incomplete — the coverage caveat
+belongs in the headline, never demoted to a footnote.**
 
 **Frame it as a receipt, not a stats table.** The card's hero line follows
 the brand's own headline rule (medium-weight sentence, one bold span
@@ -227,25 +262,28 @@ carrying the meaning), driven by the real numbers:
 - Clean book, full coverage: *"Every line **held**."*
 - Issues found: *"**3** lines needed a second take."*
 - Mid-generation (Generation view): *"Checking as it renders — **6 of 12**
-  chapters done so far."* — candid about partial coverage, never a
-  premature verdict.
+  chapters done so far."*
 
 Subhead adapted from the brand's canonical "Proof, not promises" line rather
 than invented fresh: *"Checked, verified, and matched against every
 character's own voice — automatically, before this book reached you."*
 
-**Four parallel receipts, not a numbered sequence** — these are independent
-gates, not ordered steps, so no 01/02/03 markers. Each row's off/partial
-copy is an invitation, not an apology or a warning, matching the brand's own
-empty-state example (*"No books yet. Drop in an EPUB, PDF, or paste a
-chapter — we'll find the cast."* — `brand-guidelines.md`):
+**Four parallel receipts, not a numbered sequence** — independent gates, not
+ordered steps, so no 01/02/03 markers. Off/partial copy is an invitation,
+never an apology, matching the brand's own empty-state example (*"No books
+yet. Drop in an EPUB, PDF, or paste a chapter — we'll find the cast."* —
+`brand-guidelines.md`):
 
 | Row | Full coverage | Partial coverage | Not run |
 |---|---|---|---|
-| Acoustic | "342 lines checked, 0 needed a second take." | "Checked for 8 of 12 chapters — the rest were rendered before this pass was on." | "Not run for this book." |
-| Transcript (SEG-ASR) | "342 lines verified against what Whisper heard, 0 flagged." | Same partial pattern as above. | "Not run for this book — turn on transcript verification before your next render." |
-| Voice match (SEG-SPK) | "18 characters checked against their own reference take, 0 mismatches." Plus, when non-empty: "N characters had too little reference audio to check" and/or "N chapters inconclusive — usually short quotes." | Same partial pattern, plus: "N chapters had no stochastic voices to check" when `chaptersEligible < chaptersGateOn`. | "Not run for this book — flip on render-integrity checking to catch mismatches automatically." |
-| Cast continuity (config drift) | Severity-coded counts. Framed explicitly as *"since this book was rendered"* (not a render-time result like the other three). Reuses the `Pill` component with its own `severe→danger, moderate→warning, mild→neutral` mapping — the same component, a different severity vocabulary from voice-match, never conflated. A flagged line deep-links into the existing `drift-report.tsx` modal rather than duplicating its compare view. | *(always on — no gate, so no partial-coverage state applies)* | *(always on)* |
+| Acoustic | "342 lines checked, 0 needed a second take." | "290 of 342 lines checked — the rest were rendered before this pass was on." | "Not run for this book." |
+| Transcript (SEG-ASR) | "342 lines verified against what Whisper heard, 0 flagged." | Same fraction pattern as above. | "Not run for this book — turn on transcript verification before your next render." |
+| Voice match (SEG-SPK) | "18 of 18 characters checked against their own reference take, 0 mismatches." | Leads with the fraction whenever `charactersChecked < charactersOnRoster` or `chaptersScored < chaptersEligible`: e.g. "12 of 18 characters checked — 6 had too little reference audio to check, 0 mismatches among the rest." Plus, when nonzero: "N chapters inconclusive — usually short quotes." | "Not run for this book — flip on render-integrity checking to catch mismatches automatically." |
+| Cast continuity | Severity-coded counts, framed as *"since this book was rendered"* (not a render-time result like the other three). Reuses the `Pill` component with its own `severe→danger, moderate→warning, mild→neutral` mapping — a different severity vocabulary from voice-match, never conflated. A flagged line deep-links into the existing `drift-report.tsx` modal. | *(always on — no coverage question)* | *(always on)* |
+
+A legacy-unattributed voice-drift result still shows severity counts, plus:
+*"Chapter detail isn't available for this render — re-rendering or
+repairing a chapter restores it."*
 
 **Deliberate restraint, twice over:**
 - **No deep-purple on the voice-match row.** Deep purple's defined job is
@@ -258,30 +296,25 @@ chapter — we'll find the cast."* — `brand-guidelines.md`):
   own scarcity rule ("no more than three uses per page... scarcity is what
   keeps it recognisable"), this card stays in the existing disciplined
   white-card chrome (`bg-white rounded-3xl border border-ink/10
-  shadow-card`, matching `LoudnessReport`). The card earns attention through
-  confident, specific copy and structural clarity, not another decorative
-  flourish.
+  shadow-card`, matching `LoudnessReport`).
 
 **Export doubles as word-of-mouth.** The text export is written to be
 legible pasted verbatim into a Discord message or forum post — a real,
-unforced "proof receipt" a reader could show someone, in the same
-benchmark-forward register the brand already trusts from the maintainer
-voice. For a fully-covered, clean book:
+unforced "proof receipt," in the same benchmark-forward register the brand
+already trusts from the maintainer voice. For a fully-covered, clean book:
 
 ```
 The Coalfall Commission — Castwright quality gate
 Every line held.
 · Acoustic — 342 lines checked, 0 needed a second take
 · Transcript — 342 lines verified, 0 flagged
-· Voice match — 18 characters checked, 0 mismatches
+· Voice match — 18 of 18 characters checked, 0 mismatches
 · Cast continuity — 0 changes since render
 ```
 
-A partial-coverage book states its coverage plainly in the same export
-rather than omitting the caveat to look cleaner — the export is exactly
-what's on screen, never a flattering summary of it.
-
-The JSON export is the `BookQaReport` object re-serialized verbatim.
+A partial-coverage book states its coverage fractions plainly in the export
+rather than omitting them to look cleaner. The JSON export is the
+`BookQaReport` object re-serialized verbatim.
 
 ## Frontend surfaces
 
@@ -307,38 +340,60 @@ identical by construction.
 ## Error handling & edge cases
 
 - Report fetch failure → quiet "QA report unavailable" inline state; never
-  blocks the Listen or Generation view. This is a value-add surface, not a
-  gate on anything.
+  blocks the Listen or Generation view.
 - Partially-generated book → `chaptersRendered`/`chaptersTotal` makes
-  partial coverage explicit rather than implying a full-book verdict, on
-  top of (and independent from) each gate's own `chaptersGateOn` coverage.
+  partial coverage explicit, on top of (and independent from) each gate's
+  own coverage fraction.
 - A gate toggled mid-book, or a chapter regenerated after a setting change
-  → reported as partial coverage (see UX table), never silently rounded to
-  "on" or "off."
+  → reported as a partial coverage fraction, never silently rounded to "on"
+  or "off," because coverage is tracked per segment/chapter rather than as
+  one book-level flag.
 - Mixed-engine chapters and Kokoro-voiced characters are already excluded
   from voice-drift scoring upstream (`STOCHASTIC_ENGINES` filter in
-  `aggregate.ts`); the report reflects that via `chaptersEligible`, not as
-  a special case.
+  `aggregate.ts`); the report reflects that via `chaptersEligible`, computed
+  once, inside the same code that owns that filter.
+- Legacy books (rendered before this ships) get `attribution:
+  'legacy-unattributed'` for voice-drift rather than a guess at chapter
+  linkage.
 - No staleness/re-fetch logic beyond "derive on read" — a regenerated
   chapter's files are simply the new ground truth on the next call.
 
 ## Testing
 
 - **Server**: unit tests for the aggregation function against fixture
-  `segments.json`/`render-integrity.json`/state.json combinations — all
-  gates on, all off, partial-book render, an all-Kokoro book (gate on, zero
-  eligible chapters), and a book with `inconclusive`/too-short-reference
-  characters. A route test for the endpoint. A regression test that the
-  re-record loop actually increments `qaRetries`/`asrRetries`, **and** that
-  a subsequent splice/QA-repair write preserves rather than resets those
-  counts.
+  combinations — all gates on, all off, partial coverage (gate toggled
+  mid-book), an all-Kokoro book (voice-drift on, zero eligible chapters), a
+  book with `inconclusive`/too-short-reference characters, and a legacy
+  book with no `chapterId`/coverage records. A route test for the endpoint.
+  A regression test that both `synthesise-chapter.ts`'s and
+  `chapter-qa-repair.ts`'s re-record loops independently increment
+  `qaRetries`/`asrRetries`, and that a splice preserves existing values via
+  its spread-based assembly. A test that `aggregate.ts`/`scoreBook` writes
+  a coverage record for a chapter even when it has zero stochastic
+  characters or zero verdict rows.
 - **Frontend**: component tests for `QaReportCard` across the full-coverage/
-  partial-coverage/not-run/no-data/mid-generation permutations for each
-  gate independently, including the voice-match "eligible vs scored vs
-  unchecked" breakdown.
+  partial-coverage/not-run/legacy-unattributed/no-data/mid-generation
+  permutations for each row independently, including the voice-match
+  "roster vs. checked vs. unchecked" headline.
 - **E2E**: one Playwright spec covering the Listen-view card and both export
   buttons, backed by a new mock `BookQaReport` fixture in `src/data/`
   (mocks are the default e2e mode).
+
+## Open implementation-time questions (not resolved by this spec)
+
+- Whether `chapter-splice.ts`'s "re-record" segments are produced via
+  `synthesise-chapter.ts`'s loop (in which case per-segment coverage
+  stamping there covers splice for free) or a separate synthesis call (in
+  which case that call needs its own stamp, mirroring `chapter-qa-repair.ts`).
+- Whether `chapter-qa-repair.ts`'s repair action re-triggers
+  `aggregate.ts`'s `scoreBook` for voice-drift re-scoring after a repair, or
+  only reads the existing `render-integrity.json` — affects whether a
+  repaired chapter's voice-drift coverage record updates or stays stale
+  until the next full re-render.
+
+These are flagged rather than guessed at, per this spec's own "no false
+pass" rule — the implementation plan should resolve them against the actual
+call graph before writing the stamping code.
 
 ## Out of scope
 
@@ -348,3 +403,6 @@ identical by construction.
   aggregates and presents existing signals.
 - A dedicated "QA history over time" view (trend across regenerations) —
   the report reflects the book's current render state only.
+- Backfilling `chapterId`/coverage records onto already-rendered books'
+  existing `render-integrity.json` files — they stay
+  `legacy-unattributed` until next touched.

--- a/docs/superpowers/specs/2026-07-05-fs51-qa-report-design.md
+++ b/docs/superpowers/specs/2026-07-05-fs51-qa-report-design.md
@@ -1,0 +1,240 @@
+---
+status: draft
+date: 2026-07-05
+topic: fs-51 — per-book performance-QA report (visible + exportable acoustic+ASR+drift summary)
+issue: fs-51 (#973)
+depends_on: none (see "Correcting the srv-36 dependency" below — the issue's stated dependency is stale)
+relates_to: srv-36 Phase 1 (#665, shipped — supplies the voice-match row) · srv-31 (ASR content-QA / SEG-ASR gate) · plan 179 (signal-QA) · srv-27 (audio-qa.ts loudness/duration gate) · revisions.ts (config-drift)
+---
+
+# fs-51 — Per-book performance-QA report
+
+## Context
+
+The generation pipeline already runs four independent QA/drift checks per
+book — signal-QA, ASR content-QA ("SEG-ASR"), srv-36 acoustic voice-drift
+("SEG-SPK"), and cast-config drift — but none of it is aggregated or shown to
+the user. Each check's output is either ephemeral (SSE ticks), buried in a
+per-chapter waveform, or sitting in an on-disk file nobody reads
+(`deriveBookOutline()` for srv-36 is fully built and tested but has zero
+callers). fs-51 turns these into one per-book report: visible in the app,
+exportable, and — per the brand's own "Proof, not promises" claim — the
+literal evidence for Castwright's core quality claim: *every line is
+acoustically checked, transcript-verified, and drift-checked before a chapter
+is assembled, automatically, every time.* This report is where that promise
+gets shown, not just stated. It's `moscow:must` for the beta→full-product
+spine specifically because it's a brand differentiator, not just a debugging
+aid.
+
+**Correcting the srv-36 dependency.** The GitHub issue says fs-51 "depends on
+srv-36 (drift-threshold calibration)." That framing is stale: it was written
+the same day as srv-36's own spec, which explicitly decouples the two —
+srv-36 Phase 1 (the acoustic ECAPA voice-match check) has since shipped and
+been calibrated (merged `372eeeae`, PR #987; cutoffs tuned 2026-06-22,
+27/27 held-out flags confirmed real drift, 0 false positives). fs-51 is not
+blocked on anything. It ships against the QA signals that already exist;
+srv-36's voice-match row is one of those signals, present when the gate ran
+for a given book and absent (not zero) when it didn't. srv-36 Phase 2
+(cross-book/series consistency) is still `status: draft` and out of scope
+here entirely.
+
+## Architecture
+
+One new read endpoint aggregates everything, computed fresh on every call —
+nothing new is persisted as a running summary:
+
+```
+GET /api/books/:bookId/qa-report → BookQaReport
+```
+
+It reads four existing sources, per chapter:
+
+1. **Signal-QA** (`<slug>.segments.json`, plan 179) — near-silent/truncated/
+   runaway-duration flags, via the existing `loadSegmentsFiles()`
+   (`server/src/audio/segments-io.ts`).
+2. **ASR content-QA / SEG-ASR** (`<slug>.segments.json`, srv-31) — transcript
+   drift flags, same file, gated by `SEG_ASR_ENABLED`.
+3. **Voice drift / SEG-SPK** (`<slug>.render-integrity.json`, srv-36 Phase 1)
+   — via `deriveBookOutline()` (`server/src/audio/render-integrity/verdicts-io.ts`),
+   already implemented and unit-tested, currently uncalled from any route.
+   Gated by `SEG_SPK_ENABLED`.
+4. **Config drift** (the server-side equivalent of `revisions-slice`'s
+   `DriftEvent[]`) — cast/voice reassignment drift, severity mild/moderate/
+   severe. Always on, no gate.
+
+**Gate-enabled detection is presence-based, not config-based.** Whether
+`asr`/`voiceDrift` show real numbers or the "not enabled" state is decided by
+whether the relevant per-segment/per-chapter data exists for *that book's
+render* (`seg.asr != null` anywhere; `<slug>.render-integrity.json` exists
+for any rendered chapter) — not by reading the current value of
+`SEG_ASR_ENABLED`/`SEG_SPK_ENABLED`. A book rendered before a gate was
+flipped on correctly shows "not enabled for this book" even if the gate is
+on globally today.
+
+**One schema addition**: an integer `qaRetries` / `asrRetries` field on each
+segment record in `segments.json`, incremented in the existing re-record
+loop in `synthesise-chapter.ts` (where `segmentQaByIndex`/`segmentAsrByIndex`
+already get refreshed each round) and written at the same finalize step that
+already persists `segments.json`
+(`server/src/audio/finalize-chapter-write.ts`). This is what makes "N lines
+re-recorded" an honest attempt-count instead of a "still flagged" proxy —
+without it, only the final verdict survives and a retry that *fixed* a line
+would be invisible.
+
+The endpoint is the single source of truth for both display and export — no
+separate export endpoint. Both the Listen-view card and the live
+Generation-view panel call the same `GET`, so "numbers reconcile with the
+underlying gate output" holds by construction rather than by convention.
+
+## Report schema
+
+```
+BookQaReport {
+  bookId, generatedAt, chaptersRendered, chaptersTotal,
+  acoustic:    { linesChecked, linesRerecorded, chaptersFlagged },
+  asr:         { enabled, linesVerified, linesFlaggedDrift },
+  voiceDrift:  { enabled, chaptersScored, mismatches: [{ characterId, chapterId, severity, fixable }] },
+  configDrift: { counts: { mild, moderate, severe }, events: DriftEvent[] },
+}
+```
+
+`asr.enabled` / `voiceDrift.enabled` are `false` when the gate didn't run for
+this book (see presence-based detection above) — the UI shows an explicit
+"not run for this book" line rather than a bare `0`, so a clean gate result
+is never confused with a gate that never fired. `acoustic` and `configDrift`
+have no enable flag; they always run.
+
+**Field definitions** (to remove any ambiguity about what each count means):
+- `acoustic.linesRerecorded` — segments where `qaRetries > 0` (the signal-QA
+  gate required at least one retry, regardless of the final verdict).
+- `acoustic.chaptersFlagged` — chapters containing at least one segment still
+  `suspect` after every retry attempt was exhausted.
+- `asr.linesVerified` — segments where `seg.asr` is present (ASR actually
+  ran against that line), independent of the verdict.
+- `asr.linesFlaggedDrift` — segments where the final ASR verdict is `'drift'`
+  (`asrSuspect === true`), i.e. still flagged after every retry.
+
+`openapi.yaml` gets the new `BookQaReport` schema + the `GET
+/api/books/{bookId}/qa-report` path; `npm run openapi:types` regenerates
+`src/lib/api-types.ts` from it, per the existing convention.
+
+## UX/UI presentation — the brand moment
+
+This is the surface where Castwright's core quality claim becomes evidence,
+not marketing copy — "we promised, we delivered" made literal and specific
+to *this* book. That governs every choice below.
+
+**Frame it as a receipt, not a stats table.** The card's hero line follows
+the brand's own headline rule (medium-weight sentence, one bold span
+carrying the meaning), driven by the real numbers:
+- Clean book: *"Every line **held**."*
+- Issues found: *"**3** lines needed a second take."*
+- Mid-generation (Generation view): *"Checking as it renders — **6 of 12**
+  chapters done so far."* — candid about partial coverage, never a premature
+  verdict.
+
+Subhead adapted from the brand's canonical "Proof, not promises" line rather
+than invented fresh: *"Checked, verified, and matched against every
+character's own voice — automatically, before this book reached you."*
+
+**Four parallel receipts, not a numbered sequence** — these are independent
+gates, not ordered steps, so no 01/02/03 markers:
+
+| Row | Copy pattern (on) | Copy pattern (off) |
+|---|---|---|
+| Acoustic | "342 lines checked, 0 needed a second take." | *(always on)* |
+| Transcript (SEG-ASR) | "342 lines verified against what Whisper heard, 0 flagged." | "Not run for this book — turn on transcript verification before your next render." |
+| Voice match (SEG-SPK) | "18 characters checked against their own reference take, 0 mismatches." | "Not run for this book — flip on render-integrity checking to catch mismatches automatically." |
+| Cast continuity (config drift) | Severity-coded counts, reusing the exact `Pill` colours (`danger`/`warning`/`neutral`) already established in `drift-report.tsx`; a flagged line deep-links into that same modal rather than duplicating its compare view. | *(always on)* |
+
+Off-state copy is an invitation, not an apology or a warning — matches the
+brand's empty-state register ("an empty screen is an invitation to act").
+
+**Deliberate restraint, twice over:**
+- **No deep-purple on the voice-match row.** Deep purple's defined job is
+  cross-book/library reuse (`visual-system.md` §Colours); this check is
+  chapter-to-chapter *within* one book, so using it here would dilute the
+  token. It's the correct color once srv-36 Phase 2 (cross-book consistency)
+  ships — reserved, not used yet.
+- **No new gradient spend.** The signature 4-stop gradient is already used
+  on this page (the cover-art hero in `listen-header.tsx`); per the brand's
+  own scarcity rule ("no more than three uses per page... scarcity is what
+  keeps it recognisable"), this card stays in the existing disciplined
+  white-card chrome (`bg-white rounded-3xl border border-ink/10
+  shadow-card`, matching `LoudnessReport`). The card earns attention through
+  confident, specific copy and structural clarity, not another decorative
+  flourish.
+
+**Export doubles as word-of-mouth.** The text export is written to be
+legible pasted verbatim into a Discord message or forum post — a real,
+unforced "proof receipt" a reader could show someone, in the same
+benchmark-forward register the brand already trusts from the maintainer
+voice:
+
+```
+The Coalfall Commission — Castwright quality gate
+Every line held.
+· Acoustic — 342 lines checked, 0 needed a second take
+· Transcript — 342 lines verified, 0 flagged
+· Voice match — 18 characters checked, 0 mismatches
+· Cast continuity — 0 changes since render
+```
+
+The JSON export is the `BookQaReport` object re-serialized verbatim.
+
+## Frontend surfaces
+
+One shared presentational component (`QaReportCard`) + one fetch hook
+(`useQaReport(bookId)`):
+
+- **Listen view** (`src/views/listen.tsx`) — mounted as a new sibling
+  section (not folded into the existing `LoudnessReport`, which stays as the
+  acoustic-only detail view). Fetched once on mount.
+- **Generation view** (`src/views/generation.tsx`) — same component,
+  refetched whenever a `chapter_complete` event lands (already tracked in
+  this view's activity feed) rather than on a blind poll interval.
+
+## Export mechanics
+
+Client-side only, reusing the existing Blob-download pattern from
+`share-card-modal.tsx` (`downloadJson`-style helper). JSON export
+re-serializes the already-fetched `BookQaReport`; text export is a small
+formatter producing the shape shown above from the same object. No server
+round-trip beyond the one `GET` — display data and exported data are
+identical by construction.
+
+## Error handling & edge cases
+
+- Report fetch failure → quiet "QA report unavailable" inline state; never
+  blocks the Listen or Generation view. This is a value-add surface, not a
+  gate on anything.
+- Partially-generated book → `chaptersRendered`/`chaptersTotal` makes
+  partial coverage explicit rather than implying a full-book verdict.
+- Mixed-engine chapters and Kokoro-voiced characters are already excluded
+  from voice-drift scoring upstream (`STOCHASTIC_ENGINES` filter in
+  `aggregate.ts`); the report just reflects that, no special-casing needed.
+- No staleness/re-fetch logic beyond "derive on read" — a regenerated
+  chapter's files are simply the new ground truth on the next call.
+
+## Testing
+
+- **Server**: unit tests for the aggregation function against fixture
+  `segments.json`/`render-integrity.json`/state.json combinations (all
+  gates on, all off, partial-book render); a route test for the endpoint; a
+  regression test that the re-record loop actually increments
+  `qaRetries`/`asrRetries`.
+- **Frontend**: component tests for `QaReportCard` across the
+  enabled/disabled/no-data/mid-generation permutations, including the
+  off-state copy and the severity-coded cast-continuity row.
+- **E2E**: one Playwright spec covering the Listen-view card and both export
+  buttons, backed by a new mock `BookQaReport` fixture in `src/data/`
+  (mocks are the default e2e mode).
+
+## Out of scope
+
+- srv-36 Phase 2 (cross-book/series voice consistency) — still `status:
+  draft`, no production code exists. No consistency row until it ships.
+- Any change to when/whether the underlying gates run — this report only
+  aggregates and presents existing signals.
+- A dedicated "QA history over time" view (trend across regenerations) —
+  the report reflects the book's current render state only.

--- a/docs/superpowers/specs/2026-07-05-fs51-qa-report-design.md
+++ b/docs/superpowers/specs/2026-07-05-fs51-qa-report-design.md
@@ -5,6 +5,7 @@ topic: fs-51 — per-book performance-QA report (visible + exportable acoustic+A
 issue: fs-51 (#973)
 depends_on: none (see "Correcting the srv-36 dependency" below — the issue's stated dependency is stale)
 relates_to: srv-36 Phase 1 (#665, shipped — supplies the voice-match row) · srv-31 (ASR content-QA / SEG-ASR gate) · plan 179 (signal-QA) · srv-27 (audio-qa.ts loudness/duration gate) · revisions.ts (config-drift)
+revised: 2026-07-05 (round 1 adversarial pass — code-grounded against origin/main via `assumption-checker`). Fixed: presence-based gate detection was Contradicted by two real book shapes (an all-Kokoro book runs the voice-drift gate but writes no verdict file; the acoustic gate is conditional on `maxSegmentRerecords > 0`, not always-on as originally written) — replaced with per-chapter gate-config stamping + coverage ratios. `deriveBookOutline()` cannot supply `chapterId`/`chaptersScored`/`uncheckedCharacters` as originally assumed — scoped in as a small required extension, not a zero-touch reuse. "Lines" was silently counting segment-groups, not sentences — redefined against `sentenceIds`. Added retry-counter carry-forward requirement across the splice/QA-repair re-write paths. Removed a fabricated brand quote ("an empty screen is an invitation to act" does not exist in `brand/`) in favour of the real empty-state example. Clarified that voice-drift severity (`severe`/`inconclusive`/`null`) and config-drift severity (`mild`/`moderate`/`severe`) are different scales, not one shared vocabulary. Clarified config-drift's "since render" time semantics against the other three rows' "during render" semantics.
 ---
 
 # fs-51 — Per-book performance-QA report
@@ -16,27 +17,33 @@ book — signal-QA, ASR content-QA ("SEG-ASR"), srv-36 acoustic voice-drift
 ("SEG-SPK"), and cast-config drift — but none of it is aggregated or shown to
 the user. Each check's output is either ephemeral (SSE ticks), buried in a
 per-chapter waveform, or sitting in an on-disk file nobody reads
-(`deriveBookOutline()` for srv-36 is fully built and tested but has zero
-callers). fs-51 turns these into one per-book report: visible in the app,
-exportable, and — per the brand's own "Proof, not promises" claim — the
-literal evidence for Castwright's core quality claim: *every line is
+(`deriveBookOutline()` for srv-36 is built and tested but has zero
+production callers). fs-51 turns these into one per-book report: visible in
+the app, exportable, and — per the brand's own "Proof, not promises" claim —
+the literal evidence for Castwright's core quality claim: *every line is
 acoustically checked, transcript-verified, and drift-checked before a chapter
 is assembled, automatically, every time.* This report is where that promise
 gets shown, not just stated. It's `moscow:must` for the beta→full-product
 spine specifically because it's a brand differentiator, not just a debugging
 aid.
 
+**The report must never show a false pass.** Because its entire reason to
+exist is "proof, not promises," a receipt that reads clean for a check that
+either never ran or had nothing to check is worse than no receipt at all.
+This constraint is why the gate-detection design below is more involved than
+a naive "is there output on disk" check — see "Gate coverage is stamped, not
+inferred."
+
 **Correcting the srv-36 dependency.** The GitHub issue says fs-51 "depends on
 srv-36 (drift-threshold calibration)." That framing is stale: it was written
 the same day as srv-36's own spec, which explicitly decouples the two —
 srv-36 Phase 1 (the acoustic ECAPA voice-match check) has since shipped and
-been calibrated (merged `372eeeae`, PR #987; cutoffs tuned 2026-06-22,
-27/27 held-out flags confirmed real drift, 0 false positives). fs-51 is not
-blocked on anything. It ships against the QA signals that already exist;
-srv-36's voice-match row is one of those signals, present when the gate ran
-for a given book and absent (not zero) when it didn't. srv-36 Phase 2
-(cross-book/series consistency) is still `status: draft` and out of scope
-here entirely.
+is calibrated (`status: stable`, referenced as shipped in the Phase 2 spec).
+fs-51 is not blocked on anything. It ships against the QA signals that
+already exist; srv-36's voice-match row is one of those signals, with
+per-chapter coverage reported explicitly rather than a single "did it run"
+guess. srv-36 Phase 2 (cross-book/series consistency) is still `status:
+draft`, has no production code, and is out of scope here entirely.
 
 ## Architecture
 
@@ -51,68 +58,155 @@ It reads four existing sources, per chapter:
 
 1. **Signal-QA** (`<slug>.segments.json`, plan 179) — near-silent/truncated/
    runaway-duration flags, via the existing `loadSegmentsFiles()`
-   (`server/src/audio/segments-io.ts`).
+   (`server/src/audio/segments-io.ts`). Conditional on
+   `maxSegmentRerecords > 0` — **not** always-on, corrected from an earlier
+   draft of this spec.
 2. **ASR content-QA / SEG-ASR** (`<slug>.segments.json`, srv-31) — transcript
    drift flags, same file, gated by `SEG_ASR_ENABLED`.
 3. **Voice drift / SEG-SPK** (`<slug>.render-integrity.json`, srv-36 Phase 1)
-   — via `deriveBookOutline()` (`server/src/audio/render-integrity/verdicts-io.ts`),
-   already implemented and unit-tested, currently uncalled from any route.
-   Gated by `SEG_SPK_ENABLED`.
+   — via a **small required extension** to
+   `server/src/audio/render-integrity/verdicts-io.ts`. `deriveBookOutline()`
+   exists and is tested, but its `VerdictRow` carries no `chapterId` (every
+   chapter's rows are flattened into one array) and its return shape has no
+   per-chapter scored/eligible counts — both are needed for this report's
+   `voiceDrift` section (see schema below). This is not the zero-touch reuse
+   an earlier draft assumed; it's a small, additive change to an already-
+   shipped module (add `chapterId` to `VerdictRow`; add
+   `chaptersEligible`/`chaptersScored` to the aggregate return), not a
+   rewrite. Gated by `SEG_SPK_ENABLED`.
 4. **Config drift** (the server-side equivalent of `revisions-slice`'s
    `DriftEvent[]`) — cast/voice reassignment drift, severity mild/moderate/
-   severe. Always on, no gate.
+   severe. Always on, no gate. **Different time axis from the other three**:
+   this compares the render-time snapshot against the *live* cast right now,
+   so it answers "has anything changed since this book was rendered," not
+   "did anything go wrong during the render." The report keeps this row
+   clearly separated from the other three for that reason.
 
-**Gate-enabled detection is presence-based, not config-based.** Whether
-`asr`/`voiceDrift` show real numbers or the "not enabled" state is decided by
-whether the relevant per-segment/per-chapter data exists for *that book's
-render* (`seg.asr != null` anywhere; `<slug>.render-integrity.json` exists
-for any rendered chapter) — not by reading the current value of
-`SEG_ASR_ENABLED`/`SEG_SPK_ENABLED`. A book rendered before a gate was
-flipped on correctly shows "not enabled for this book" even if the gate is
-on globally today.
+**Gate coverage is stamped, not inferred.** An earlier draft of this spec
+inferred whether a gate ran from whether its output was present on disk
+(`seg.asr != null`; a `render-integrity.json` file exists). That's
+unreliable for two real book shapes, confirmed against the code: an
+all-Kokoro book runs the voice-drift gate (it's enabled) but writes no
+verdict file, because `aggregate.ts` returns early when there are zero
+stochastic-engine characters to score — presence-based detection would
+wrongly report "not run." And the acoustic gate isn't always-on at all (see
+point 1 above) — an earlier draft gave it no "not run" state, so a disabled
+acoustic gate would have rendered as a perfect score.
 
-**One schema addition**: an integer `qaRetries` / `asrRetries` field on each
-segment record in `segments.json`, incremented in the existing re-record
-loop in `synthesise-chapter.ts` (where `segmentQaByIndex`/`segmentAsrByIndex`
-already get refreshed each round) and written at the same finalize step that
-already persists `segments.json`
-(`server/src/audio/finalize-chapter-write.ts`). This is what makes "N lines
-re-recorded" an honest attempt-count instead of a "still flagged" proxy —
-without it, only the final verdict survives and a retry that *fixed* a line
-would be invisible.
+The fix: at the same finalize step that already writes `segments.json`
+(`server/src/audio/finalize-chapter-write.ts`), stamp a small
+`qaGatesUsed: { acoustic: boolean, asr: boolean, voiceDrift: boolean }`
+object onto each chapter record, reflecting the actual registry config
+(`qa.seg.*`/`qa.asr.enabled`/`qa.speaker.enabled`) active *at that chapter's
+render time* — not a guess from output shape, and not today's live config
+(which may have changed since). The report aggregates this per-chapter
+across the book into a coverage ratio (`chaptersGateOn` /
+`chaptersRendered`) for each of the three optional gates, so:
+- `0 / chaptersRendered` → the gate never ran for this book → "not run"
+  copy.
+- `chaptersRendered / chaptersRendered` → full coverage → normal receipt.
+- Anything in between (the gate was toggled mid-book, or a chapter was
+  regenerated after a setting change) → an explicit partial-coverage caveat,
+  never silently rounded to either extreme.
+
+For voice-drift specifically, `chaptersGateOn` alone still isn't sufficient
+honesty — a chapter can have the gate on and have nothing to score (no
+stochastic-engine characters). The `voiceDrift` schema section therefore
+separately tracks `chaptersEligible` (gate-on chapters that contain at least
+one stochastic-engine character) and `chaptersScored` (eligible chapters
+that actually produced verdict rows), so "0 mismatches" can never quietly
+mean "nothing was checked."
+
+**Two schema additions**, both stamped at the same existing finalize step
+(not new persisted aggregates — just two more fields on data already being
+written):
+- `qaGatesUsed` (above), per chapter.
+- An integer `qaRetries` / `asrRetries` field on each segment record in
+  `segments.json`, incremented in the existing re-record loop in
+  `synthesise-chapter.ts` (where `segmentQaByIndex`/`segmentAsrByIndex`
+  already get refreshed each round). This is what makes "N lines
+  re-recorded" an honest attempt-count instead of a "still flagged" proxy —
+  without it, only the final verdict survives and a retry that *fixed* a
+  line would be invisible.
+  **Carry-forward requirement**: `segments.json` isn't only written by the
+  main generation path — the splice and QA-repair routes
+  (`chapter-splice.ts`, `chapter-qa-repair.ts`) also call
+  `finalizeChapterAudioWrite` and re-persist the file. Whichever path writes
+  `qaRetries`/`asrRetries` must read the segment's *prior* count (if the
+  file already exists) and add to it, not start from the current
+  operation's local counter — otherwise a repair or splice silently resets
+  a segment's retry history to zero, making "N lines re-recorded" go
+  *down* after a repair, which is the same false-clean failure mode as the
+  gate-detection issue above.
 
 The endpoint is the single source of truth for both display and export — no
 separate export endpoint. Both the Listen-view card and the live
-Generation-view panel call the same `GET`, so "numbers reconcile with the
-underlying gate output" holds by construction rather than by convention.
+Generation-view panel call the same `GET`, so display and export can never
+diverge from each other. (This does not by itself guarantee the report
+matches "what the gate actually did" in every edge case — that guarantee
+comes from the coverage-stamping design above, not from the single-endpoint
+structure alone.)
 
 ## Report schema
 
 ```
 BookQaReport {
   bookId, generatedAt, chaptersRendered, chaptersTotal,
-  acoustic:    { linesChecked, linesRerecorded, chaptersFlagged },
-  asr:         { enabled, linesVerified, linesFlaggedDrift },
-  voiceDrift:  { enabled, chaptersScored, mismatches: [{ characterId, chapterId, severity, fixable }] },
+  acoustic: {
+    chaptersGateOn, linesChecked, linesRerecorded, chaptersFlagged
+  },
+  asr: {
+    chaptersGateOn, linesVerified, linesFlaggedDrift
+  },
+  voiceDrift: {
+    chaptersGateOn, chaptersEligible, chaptersScored,
+    mismatches: [{ characterId, chapterId, severity, fixable }],
+    inconclusiveCount, uncheckedCharacterIds: string[]
+  },
   configDrift: { counts: { mild, moderate, severe }, events: DriftEvent[] },
 }
 ```
 
-`asr.enabled` / `voiceDrift.enabled` are `false` when the gate didn't run for
-this book (see presence-based detection above) — the UI shows an explicit
-"not run for this book" line rather than a bare `0`, so a clean gate result
-is never confused with a gate that never fired. `acoustic` and `configDrift`
-have no enable flag; they always run.
-
 **Field definitions** (to remove any ambiguity about what each count means):
-- `acoustic.linesRerecorded` — segments where `qaRetries > 0` (the signal-QA
-  gate required at least one retry, regardless of the final verdict).
-- `acoustic.chaptersFlagged` — chapters containing at least one segment still
-  `suspect` after every retry attempt was exhausted.
-- `asr.linesVerified` — segments where `seg.asr` is present (ASR actually
-  ran against that line), independent of the verdict.
-- `asr.linesFlaggedDrift` — segments where the final ASR verdict is `'drift'`
-  (`asrSuspect === true`), i.e. still flagged after every retry.
+- `*.chaptersGateOn` — number of `chaptersRendered` where that gate's config
+  was actually active at render time (from the stamped `qaGatesUsed`, not
+  inferred from output). `0` → not-run copy; equal to `chaptersRendered` →
+  full-coverage copy; anything else → partial-coverage copy (see UX
+  section).
+- `acoustic.linesChecked` / `linesRerecorded` — **counted in sentences, not
+  segment-groups.** A `ChapterSegment` can bundle multiple sentences
+  (`sentenceIds: number[]`); the report sums `sentenceIds.length` across the
+  relevant segments rather than counting segments themselves, so "lines"
+  means what a reader thinks it means. `linesRerecorded` sums
+  `sentenceIds.length` for segments where `qaRetries > 0`.
+- `acoustic.chaptersFlagged` — chapters containing at least one segment
+  still `suspect` after every retry attempt was exhausted.
+- `asr.linesVerified` — sentences (via `sentenceIds`, same convention as
+  above) in segments where `seg.asr` is present, independent of verdict.
+- `asr.linesFlaggedDrift` — sentences in segments where the final ASR
+  verdict is `'drift'` (`asrSuspect === true`).
+- `voiceDrift.chaptersEligible` — of the gate-on chapters, those containing
+  at least one stochastic-engine (Qwen/Coqui) character. A chapter voiced
+  entirely by Kokoro is gate-on but not eligible — this is what
+  distinguishes "nothing to check here" from "not run."
+- `voiceDrift.chaptersScored` — eligible chapters that actually produced
+  verdict rows. In practice this should equal `chaptersEligible`; the
+  report tracks them separately so a shortfall is visible rather than
+  silently absorbed.
+- `voiceDrift.mismatches` — rows where `verdict === 'voice-mismatch'` and
+  `severity === 'severe'`. **Not the same severity scale as `configDrift`**:
+  voice-drift severity is `'severe' | 'inconclusive' | null`
+  (three-valued, from `VerdictRow`), config-drift severity is
+  `'mild' | 'moderate' | 'severe'` — the UI renders each with its own
+  colour mapping (see UX section), never a shared legend.
+- `voiceDrift.inconclusiveCount` — verdicts that landed in the inconclusive
+  band (typically short quotes below the minimum-duration gate). Shown as
+  its own line, not folded into either "mismatch" or "clean."
+- `voiceDrift.uncheckedCharacterIds` — characters excluded from scoring
+  because their reference audio was too short to embed
+  (`referenceKind === 'too-short'`, from the extended `deriveBookOutline`).
+  Surfaced explicitly so "0 mismatches" can't be read as "everyone passed"
+  when some characters were never checkable.
 
 `openapi.yaml` gets the new `BookQaReport` schema + the `GET
 /api/books/{bookId}/qa-report` path; `npm run openapi:types` regenerates
@@ -122,33 +216,36 @@ have no enable flag; they always run.
 
 This is the surface where Castwright's core quality claim becomes evidence,
 not marketing copy — "we promised, we delivered" made literal and specific
-to *this* book. That governs every choice below.
+to *this* book. That governs every choice below, including the harder edges
+introduced by the coverage-stamping design above: **an honest partial
+receipt is more on-brand than a clean-looking one that's actually
+incomplete.**
 
 **Frame it as a receipt, not a stats table.** The card's hero line follows
 the brand's own headline rule (medium-weight sentence, one bold span
 carrying the meaning), driven by the real numbers:
-- Clean book: *"Every line **held**."*
+- Clean book, full coverage: *"Every line **held**."*
 - Issues found: *"**3** lines needed a second take."*
 - Mid-generation (Generation view): *"Checking as it renders — **6 of 12**
-  chapters done so far."* — candid about partial coverage, never a premature
-  verdict.
+  chapters done so far."* — candid about partial coverage, never a
+  premature verdict.
 
 Subhead adapted from the brand's canonical "Proof, not promises" line rather
 than invented fresh: *"Checked, verified, and matched against every
 character's own voice — automatically, before this book reached you."*
 
 **Four parallel receipts, not a numbered sequence** — these are independent
-gates, not ordered steps, so no 01/02/03 markers:
+gates, not ordered steps, so no 01/02/03 markers. Each row's off/partial
+copy is an invitation, not an apology or a warning, matching the brand's own
+empty-state example (*"No books yet. Drop in an EPUB, PDF, or paste a
+chapter — we'll find the cast."* — `brand-guidelines.md`):
 
-| Row | Copy pattern (on) | Copy pattern (off) |
-|---|---|---|
-| Acoustic | "342 lines checked, 0 needed a second take." | *(always on)* |
-| Transcript (SEG-ASR) | "342 lines verified against what Whisper heard, 0 flagged." | "Not run for this book — turn on transcript verification before your next render." |
-| Voice match (SEG-SPK) | "18 characters checked against their own reference take, 0 mismatches." | "Not run for this book — flip on render-integrity checking to catch mismatches automatically." |
-| Cast continuity (config drift) | Severity-coded counts, reusing the exact `Pill` colours (`danger`/`warning`/`neutral`) already established in `drift-report.tsx`; a flagged line deep-links into that same modal rather than duplicating its compare view. | *(always on)* |
-
-Off-state copy is an invitation, not an apology or a warning — matches the
-brand's empty-state register ("an empty screen is an invitation to act").
+| Row | Full coverage | Partial coverage | Not run |
+|---|---|---|---|
+| Acoustic | "342 lines checked, 0 needed a second take." | "Checked for 8 of 12 chapters — the rest were rendered before this pass was on." | "Not run for this book." |
+| Transcript (SEG-ASR) | "342 lines verified against what Whisper heard, 0 flagged." | Same partial pattern as above. | "Not run for this book — turn on transcript verification before your next render." |
+| Voice match (SEG-SPK) | "18 characters checked against their own reference take, 0 mismatches." Plus, when non-empty: "N characters had too little reference audio to check" and/or "N chapters inconclusive — usually short quotes." | Same partial pattern, plus: "N chapters had no stochastic voices to check" when `chaptersEligible < chaptersGateOn`. | "Not run for this book — flip on render-integrity checking to catch mismatches automatically." |
+| Cast continuity (config drift) | Severity-coded counts. Framed explicitly as *"since this book was rendered"* (not a render-time result like the other three). Reuses the `Pill` component with its own `severe→danger, moderate→warning, mild→neutral` mapping — the same component, a different severity vocabulary from voice-match, never conflated. A flagged line deep-links into the existing `drift-report.tsx` modal rather than duplicating its compare view. | *(always on — no gate, so no partial-coverage state applies)* | *(always on)* |
 
 **Deliberate restraint, twice over:**
 - **No deep-purple on the voice-match row.** Deep purple's defined job is
@@ -169,7 +266,7 @@ brand's empty-state register ("an empty screen is an invitation to act").
 legible pasted verbatim into a Discord message or forum post — a real,
 unforced "proof receipt" a reader could show someone, in the same
 benchmark-forward register the brand already trusts from the maintainer
-voice:
+voice. For a fully-covered, clean book:
 
 ```
 The Coalfall Commission — Castwright quality gate
@@ -179,6 +276,10 @@ Every line held.
 · Voice match — 18 characters checked, 0 mismatches
 · Cast continuity — 0 changes since render
 ```
+
+A partial-coverage book states its coverage plainly in the same export
+rather than omitting the caveat to look cleaner — the export is exactly
+what's on screen, never a flattering summary of it.
 
 The JSON export is the `BookQaReport` object re-serialized verbatim.
 
@@ -209,23 +310,32 @@ identical by construction.
   blocks the Listen or Generation view. This is a value-add surface, not a
   gate on anything.
 - Partially-generated book → `chaptersRendered`/`chaptersTotal` makes
-  partial coverage explicit rather than implying a full-book verdict.
+  partial coverage explicit rather than implying a full-book verdict, on
+  top of (and independent from) each gate's own `chaptersGateOn` coverage.
+- A gate toggled mid-book, or a chapter regenerated after a setting change
+  → reported as partial coverage (see UX table), never silently rounded to
+  "on" or "off."
 - Mixed-engine chapters and Kokoro-voiced characters are already excluded
   from voice-drift scoring upstream (`STOCHASTIC_ENGINES` filter in
-  `aggregate.ts`); the report just reflects that, no special-casing needed.
+  `aggregate.ts`); the report reflects that via `chaptersEligible`, not as
+  a special case.
 - No staleness/re-fetch logic beyond "derive on read" — a regenerated
   chapter's files are simply the new ground truth on the next call.
 
 ## Testing
 
 - **Server**: unit tests for the aggregation function against fixture
-  `segments.json`/`render-integrity.json`/state.json combinations (all
-  gates on, all off, partial-book render); a route test for the endpoint; a
-  regression test that the re-record loop actually increments
-  `qaRetries`/`asrRetries`.
-- **Frontend**: component tests for `QaReportCard` across the
-  enabled/disabled/no-data/mid-generation permutations, including the
-  off-state copy and the severity-coded cast-continuity row.
+  `segments.json`/`render-integrity.json`/state.json combinations — all
+  gates on, all off, partial-book render, an all-Kokoro book (gate on, zero
+  eligible chapters), and a book with `inconclusive`/too-short-reference
+  characters. A route test for the endpoint. A regression test that the
+  re-record loop actually increments `qaRetries`/`asrRetries`, **and** that
+  a subsequent splice/QA-repair write preserves rather than resets those
+  counts.
+- **Frontend**: component tests for `QaReportCard` across the full-coverage/
+  partial-coverage/not-run/no-data/mid-generation permutations for each
+  gate independently, including the voice-match "eligible vs scored vs
+  unchecked" breakdown.
 - **E2E**: one Playwright spec covering the Listen-view card and both export
   buttons, backed by a new mock `BookQaReport` fixture in `src/data/`
   (mocks are the default e2e mode).


### PR DESCRIPTION
## Summary
- Adds the validated design spec for fs-51 (per-book performance-QA report — visible + exportable acoustic+ASR+drift summary), corrected against the codebase's actual srv-36 state (Phase 1 shipped, so the issue's stated "depends on srv-36" is stale — fs-51 is not blocked).
- Adds a 13-task TDD implementation plan covering the schema additions (chapterId, qaRetries/asrRetries, chaptersEmbedFailed), the splice/repair fresh-verdict correctness fix, the new qa-report aggregation module + endpoint, and the frontend card/hook/mounts.
- Both documents went through the full mandatory `assumption-checker` adversarial review cycle (3 rounds each, per this repo's review-gate cap), plus one additional user-requested verification pass on the plan's final round-3 fixes. See each document's `revised:`/"Revision history" note for the complete round-by-round record of what was found and fixed.

Docs-only change — no code in this PR. Implementation is tracked separately; this lands the validated spec + plan an implementer works from.

## Test plan
- [x] N/A — docs only, no runtime surface. Exempt from the mandatory code-review gate per CONTRIBUTING.md's doc-only fast-path.

Refs #973