### PR TITLE
ci(ci): rebalance local verify / cloud CI to stop local self-contention

### DIFF
--- a/.github/workflows/cross-os.yml
+++ b/.github/workflows/cross-os.yml
@@ -21,10 +21,12 @@ name: Cross-OS Verify
 on:
   workflow_dispatch:
   schedule:
-    # Sunday 02:00 UTC — well clear of weekday PR contention. Weekly pulse so
-    # cross-OS / mobile regressions on main surface within a week even when
-    # nobody fires the manual button.
-    - cron: '0 2 * * 0'
+    # Twice weekly (was once) — see docs/superpowers/specs/2026-07-06-verify-
+    # ci-rebalance-design.md §5: once local pre-push stops running a full
+    # Windows/Pester/macOS-equivalent pass on every push, this cron becomes
+    # the only regular cross-platform coverage, so the cadence doubles.
+    - cron: '0 2 * * 3' # Wednesday 02:00 UTC
+    - cron: '0 2 * * 0' # Sunday 02:00 UTC — well clear of weekday PR contention
 
 permissions:
   contents: read

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,44 +1,44 @@
 name: Verify
 
-# Plan 60 — CI verify-on-PR. Plan 103 — per-PR cost reduction.
-# Plan 215 — CI is OPT-IN: this battery no longer runs automatically on PRs.
+# Plan 60 — CI verify-on-PR. Plan 103 — per-PR cost reduction. Plan 215 — CI
+# was opt-in (label-gated) while the repo was private and Actions minutes
+# were metered. See docs/superpowers/specs/2026-07-06-verify-ci-rebalance-
+# design.md: the repo is now public (free, uncapped Actions minutes on
+# standard runners), and local `npm run verify` was causing multi-hour
+# self-contention on the dev box, so this workflow flips from opt-in to
+# OPT-OUT (runs on every PR by default) AND becomes a required status check
+# on `main`'s branch-protection ruleset — closing the gap where local
+# pre-push was previously the only thing that refused to push on a red leg.
 #
-# Runs the verify battery ON DEMAND — when a PR carries the `run-ci` label or
-# the workflow is dispatched manually (see the `on:`/`if:` blocks below). It
-# runs only the LEGS whose scope actually changed. A single job does setup
+# It runs only the LEGS whose scope actually changed. A single job does setup
 # once, detects which scopes the PR touched (git diff against the PR base),
 # then gates each expensive leg (server tests, e2e, build, …) behind an `if:`
 # on that scope. A PR that touches only `src/**` skips the server tests; a
-# server-only PR skips the frontend unit suite + Playwright e2e; etc. The
-# local pre-push hook runs the FULL `npm run verify` battery on every push, so
-# the per-PR cloud run is redundant insurance, not the gate — nothing is
-# permanently un-covered. See docs/features/103-ci-cost-reduction.md and
-# docs/features/215-ci-label-gated-verify.md.
+# server-only PR skips the frontend unit suite + Playwright e2e; etc. Local
+# pre-push now only runs a fast, branch-diff-scoped subset
+# (`verify:fast:branch`) — this cloud run is the actual enforcement gate for
+# everything else, not redundant insurance.
 #
 # Why one job with conditional steps (not a job-per-leg matrix): GitHub bills
 # each job's wall-clock separately, summed, rounded UP to the minute per job.
-# Parallel jobs would duplicate `npm ci` + pay a 1-min floor each, which
-# INCREASES billed minutes for multi-scope PRs. One job → setup paid once,
-# skipped legs cost ~0.
+# Parallel jobs would duplicate `npm ci` + pay a 1-min floor each. One job →
+# setup paid once, skipped legs cost ~0. (Billing is no longer the primary
+# driver now that Actions minutes are free on this public repo, but the
+# single-job shape is still the simpler design.)
 #
-# Plan 101 — doc-only PR fast-path. The `paths-ignore` block below skips the
-# whole workflow when EVERY changed file matches a doc glob. The scope
-# detector below is the second tier for non-doc PRs.
-# See docs/features/archive/101-docs-only-ci-skip.md.
+# No `paths-ignore` here (deliberately removed — see design spec): keeping it
+# while this is a required status check would deadlock every docs-only PR,
+# since a required check that never fires blocks merge forever. Every leg's
+# own `if:` scope condition already evaluates false for a docs-only diff, so
+# the job still completes in roughly the time of "Setup Node + deps" alone
+# and reports green — no deadlock, negligible added time. Same reasoning is
+# why the job no longer gates on PR `draft` status either — a draft-gated
+# required check would deadlock every draft PR the same way.
 
 on:
-  # The job `if:` below is the real gate; these triggers just decide WHEN the
-  # workflow is *evaluated*. `labeled` lets adding the `run-ci` label to an
-  # existing PR fire a run immediately; `synchronize` re-runs on new pushes
-  # while the label stays on; `ready_for_review` covers promoting a labeled
-  # draft. An unlabeled PR still evaluates the workflow but the job no-ops.
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - '.github/*.md'
   # Manual on-demand run: Actions tab → Verify → Run workflow, or
   # `gh workflow run verify.yml --ref <branch>`. A dispatch has no PR diff to
   # scope against, so it runs the FULL battery (every leg) — see the scope
@@ -57,21 +57,11 @@ concurrency:
 jobs:
   verify:
     # NOTE: the `name:` "npm run verify" is the historical status-check name.
-    # Branch protection on `main` deliberately does NOT require it as a status
-    # check (the staged ruleset excludes required checks so opt-in/doc-only PRs
-    # can't deadlock — see brand/ruleset-main.json / com-4), so a no-op run on
-    # an unlabeled PR never blocks merge. Keep the name stable anyway in case a
-    # required check is added later.
+    # This check IS required on `main`'s branch-protection ruleset (see the
+    # design spec) — keep this name stable, since renaming the job would
+    # silently detach the required-check rule from it.
     name: npm run verify
     runs-on: ubuntu-latest
-    # Opt-in gate: run ONLY on a manual dispatch, or a non-draft PR carrying
-    # the `run-ci` label. Unlabeled PRs evaluate the workflow but the job is
-    # skipped here → zero runner minutes billed. Local pre-push already runs
-    # the full battery, so this cloud run is on-demand insurance.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.draft == false &&
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     # 30 (was 20): a run that dies AT the cap bills the full cap for nothing and
     # forces a re-run = double charge, so the cap must clear the SLOWEST real run.
     # Full-scope runs were ~13-15 min historically, but a full-stack PR (frontend +
@@ -98,7 +88,7 @@ jobs:
           # A manual dispatch has no PR base/head to diff against — run the
           # FULL battery (every scope true) and skip the diff logic.
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            for k in frontend server sidecar e2e scripts hooks shared; do
+            for k in frontend server sidecar e2e scripts hooks pinokio shared; do
               echo "$k=true" >> "$GITHUB_OUTPUT"
               echo "scope $k=true (workflow_dispatch → full run)"
             done
@@ -112,17 +102,18 @@ jobs:
           echo "---"
           match() { echo "$FILES" | grep -qE "$1"; }
           frontend=false; server=false; sidecar=false
-          e2e=false; scripts=false; hooks=false; shared=false
+          e2e=false; scripts=false; hooks=false; pinokio=false; shared=false
           match '^(src/|index\.html$|vite\.config\.ts$|tailwind\.config\.ts$|tsconfig\.json$|tsconfig\.node\.json$|postcss\.config\.js$|eslint\.config\.(js|mjs)$)' && frontend=true
-          match '^(server/src/|server/package(-lock)?\.json$|server/tsconfig\.json$|server/vitest\.config(\.slow)?\.ts$|openapi\.yaml$)' && server=true
+          match '^(server/src/|server/package(-lock)?\.json$|server/tsconfig\.json$|server/vitest\.config(\.slow)?\.ts$|openapi\.yaml$|server/\.env\.example$|server/scripts/sync-env-example\.ts$)' && server=true
           match '^server/tts-sidecar/' && sidecar=true
           match '^(e2e/|playwright\.config\.ts$)' && e2e=true
           match '^scripts/' && scripts=true
           match '^(\.husky/|scripts/run-hooks-tests\.mjs$|scripts/validate-commit-msg\.mjs$)' && hooks=true
+          match '^(pinokio/|scripts/run-pinokio-tests\.mjs$)' && pinokio=true
           # `shared` = a ROOT dependency manifest changed → treat as global
           # (a dep/lockfile bump can affect every leg), so run everything.
           match '^(package\.json|package-lock\.json)$' && shared=true
-          for k in frontend server sidecar e2e scripts hooks shared; do
+          for k in frontend server sidecar e2e scripts hooks pinokio shared; do
             echo "$k=${!k}" >> "$GITHUB_OUTPUT"
             echo "scope $k=${!k}"
           done
@@ -142,6 +133,13 @@ jobs:
         if: steps.changes.outputs.frontend == 'true' || steps.changes.outputs.server == 'true' || steps.changes.outputs.shared == 'true'
         run: npm run typecheck
 
+      # Drift guard: fails if server/.env.example is out of sync with the
+      # config registry. Previously ONLY ran via local `npm run verify` — see
+      # docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md §3.
+      - name: Config check
+        if: steps.changes.outputs.server == 'true' || steps.changes.outputs.shared == 'true'
+        run: npm run config:check
+
       - name: Hooks tests
         if: steps.changes.outputs.hooks == 'true' || steps.changes.outputs.scripts == 'true' || steps.changes.outputs.shared == 'true'
         run: npm run test:hooks
@@ -153,6 +151,12 @@ jobs:
         # real coverage if/when Pester 5 is bootstrapped on the runner.
         if: steps.changes.outputs.scripts == 'true'
         run: npm run test:scripts
+
+      # Previously ONLY ran via local `npm run verify` — see
+      # docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md §3.
+      - name: Pinokio tests
+        if: steps.changes.outputs.pinokio == 'true' || steps.changes.outputs.shared == 'true'
+        run: npm run test:pinokio
 
       # `--changed <base>` narrows the frontend vitest run to only the tests
       # whose module graph touches this PR's diff (CI cost round 2). Reliable

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,19 +1,28 @@
-# Pre-push guards run before the ~15-min verify. git pipes the pushed-ref list
-# on stdin; capture it ONCE and feed all three checks (stdin can only be read
-# once). Bypass intentionally with `git push --no-verify`.
+# Pre-push guards run before the fast branch-scoped check. git pipes the
+# pushed-ref list on stdin; capture it ONCE and feed all three checks (stdin
+# can only be read once). Bypass intentionally with `git push --no-verify`.
 #   1. guard-protected-push  — refuse force-push / deletion of main (#163).
 #   2. guard-commit-subjects — reject any pushed commit whose subject violates
 #      the Conventional-Commits rule, even if commit-msg was bypassed
 #      (--no-verify / worktree hook couldn't spawn). Backstops the @-leak that
 #      shipped on #856.
-#   3. is-docs-only-push     — skip the verify battery entirely when every
+#   3. is-docs-only-push     — skip the local check entirely when every
 #      changed file is docs (same test as CONTRIBUTING.md's CI doc-only
-#      fast-path) — a docs-only diff has no runtime surface for tests/build/e2e
-#      to exercise, so running the full battery locally just burns time/CPU.
+#      fast-path) — a docs-only diff has no runtime surface to exercise.
+#
+# The heavy legs (e2e, server-slow, scripts/Pester, test:pinokio, etc.) no
+# longer run locally on every push — cloud `verify.yml` is now a
+# required status check covering them (see
+# docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md).
+# `verify:fast:branch` runs only the fast/cheap steps, each scope-gated to
+# whether this branch's diff (vs local `main`) actually touches its inputs —
+# including `test:sidecar`, scope-gated to `server/tts-sidecar/**`, so the
+# one check that genuinely needs this machine still runs automatically
+# exactly when it's relevant.
 PUSH_REFS=$(cat)
 printf '%s\n' "$PUSH_REFS" | node scripts/guard-protected-push.mjs "$@" || exit 1
 printf '%s\n' "$PUSH_REFS" | node scripts/guard-commit-subjects.mjs "$@" || exit 1
 if printf '%s\n' "$PUSH_REFS" | node scripts/is-docs-only-push.mjs "$@"; then
   exit 0
 fi
-npm run verify
+npm run verify:fast:branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -577,11 +577,16 @@ feat/server-foo` and tell the agent in its prompt to check it out as its
   verified once — not N separate PRs.** Reconcile the branches via the
   [`integration/<date>` pattern](CONTRIBUTING.md#reconciliation-pattern): fresh
   branch off `main`, merge each agent branch one at a time, run `npm run verify`
-  between merges. Open that integration branch as a **draft** PR and only
-  `gh pr ready` once the whole reconciliation is locally green — so the round
-  bills ONE verify run instead of one (or several) per agent branch. This is the
-  largest CI-cost lever alongside draft-by-default; see
-  [docs/features/118-ci-cost-round-2.md](docs/features/118-ci-cost-round-2.md).
+  between merges. Open that integration branch as a **draft** PR while
+  reconciling — draft is a work-in-progress signal, not a cost lever now that
+  cloud `verify.yml` runs automatically (and posts a required status) on every
+  push regardless of draft state — and `gh pr ready` once the whole
+  reconciliation is locally green, so reviewers see one settled PR per round
+  instead of N in-flight ones. See
+  [docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md)
+  for why the opt-in/draft-batching cost framing in
+  [docs/features/118-ci-cost-round-2.md](docs/features/118-ci-cost-round-2.md)
+  is now historical.
 
 ### Planning agents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,9 +141,10 @@ Design rationale:
 - `npm run test:e2e:visual` — Playwright visual-snapshot specs at `e2e/responsive/visual.spec.ts`, chromium-only, `--workers=1` so per-snapshot Windows font-hinting drift can't race against the parallel `test:e2e` battery. Baselines are per-platform (`e2e/{linux,win32}/**`). Lands in pre-push `verify` AND label-gated PR CI (`verify.yml`, Ubuntu → `e2e/linux` baselines), so visual regressions surface at PR time rather than only at release.
 - `npm run test:fast` — frontend + server only (matches the pre-commit hook).
 - `npm run test:all` — frontend + server + server-slow + PowerShell-scripts + sidecar tests (no e2e).
-- `npm run verify` — full battery: typecheck + all tests + e2e + build (matches the pre-push hook).
+- `npm run verify` — full battery: typecheck + all tests + e2e + build. No longer the pre-push default (see "Commit gate") — run manually when you want the full local battery (e.g. before a release cut).
 - `npm run verify:quick` — all tests (no e2e, no typecheck, no build) — alias for `test:all`.
 - `npm run verify:fast` — fast tests only (alias for `test:fast`) — pre-commit gate.
+- `npm run verify:fast:branch` — lint + typecheck + config:check + test:hooks + test + test:server + build, each scope-gated to whether the current branch's diff (vs local `main`) touches its inputs, plus `test:sidecar` scope-gated to `server/tts-sidecar/**`. This is the new pre-push default (see "Commit gate") — the fast, branch-scoped smoke check; cloud `verify.yml` is now the actual enforcement gate for everything else.
 - `npm run build` — production build into `dist/`.
 - `npm run apk:companion` — build the Android companion APK and drop it at
   `companion/castwright-companion.apk` (the path `GET /api/companion/apk` serves;
@@ -233,7 +234,9 @@ Harnesses (five tiers):
   invoked via `npm run test:e2e`. Browser-level golden paths + on-ramp for
   visual regression (`toHaveScreenshot()`). See `docs/features/37-e2e-playwright.md`.
 - Top-level `npm run test:all` runs the four unit/integration harnesses.
-  `npm run verify` adds typecheck + e2e + build on top (pre-push gate).
+  `npm run verify` adds typecheck + e2e + build on top (no longer the
+  pre-push default — see "Commit gate" — but still the full local battery
+  when you want to run it).
 
 Canonical end-to-end manuscript for full-pipeline regression:
 `server/src/__fixtures__/the-coalfall-commission.md` — _The Coalfall Commission_,
@@ -294,7 +297,7 @@ Run this before declaring any non-trivial task "done." Skipping a step is fine w
 3. **Update `docs/features/INDEX.md`** if the plan is new or moved (new entry under its area, or move to `## Shipped (archive)` per `archive/README.md` when shipping a plan).
 4. **Update the two release-notes documents, in this PR.** Append an entry to `docs/release-notes-next.md` (technical register, PR-refed) AND a matching user-facing, brand-voice line to the in-progress version section at the top of `RELEASE_NOTES.md`. Land both PR-by-PR, not reconstructed from git history at cut time — that's the whole point of this step. The first-PR-after-a-cut bootstrap case (resetting both files) is documented once, in [CONTRIBUTING.md "Release notes"](CONTRIBUTING.md#release-notes) — check there, don't re-derive it. Skip only when the change has no shippable delta (pure docs/process, CI-only, internal chore with no user- or operator-visible effect) — say so explicitly rather than silently omitting.
 5. **Close or advance the linked issue.** Put `Closes #NN` in the PR body for a full delivery (`Refs #NN` for a partial), and confirm the issue's `area:`/`moscow:` labels still reflect reality. Bugs link their `bug` issue with `Closes #NN` too. This link is verified, not assumed — if none exists at PR-creation time, one is auto-filed and linked without pausing to ask, including for bug-shaped work (a deliberate, scoped override of "The backlog" section's general "the user files [bugs] as they hit them" convention, for this gate only — see [Model routing → PR-gate issue verification](.claude/skills/model-routing/SKILL.md#pr-gate-issue-verification)); `.github/workflows/pr-issue-link.yml` mechanically backstops the check on every PR. Once `main`'s required-status-check ruleset for it is wired (a one-time, user-run setup step — see `docs/features/235-model-routing-review-gates.md`), a missing link blocks merge; until then it only fails a visible check.
-6. **Run `npm run verify`** locally — same battery as pre-push. Catches typecheck + all tests + e2e + build in one shot.
+6. **Run `npm run verify:fast:branch`** locally (same battery as pre-push) — or the full `npm run verify` if you want more than the branch-scoped subset. Cloud `verify.yml` is the required, authoritative gate either way (see "Commit gate").
 7. **If shipping a plan** (status → `stable`): fill its **Ship notes** section with the shipped date and the commit SHA, then `git mv` it under `docs/features/archive/` and re-link any active plan that pointed at it.
 8. **Surface what changed** in the end-of-turn summary in 1–2 sentences. Do not narrate the diff — point at the user-visible delta and the test that locks it.
 9. **Independent PR review.** Once every item above is done (or explicitly marked not-applicable) and the branch is pushed, run the mandatory `code-review` pass — see [Model routing → Mandatory independent review (PRs)](.claude/skills/model-routing/SKILL.md#mandatory-independent-review-prs). Triage and fold findings before merge.
@@ -425,16 +428,22 @@ Three-tier automated gate, enforced by husky hooks in `.husky/`:
   belt-and-suspenders; see
   [docs/features/163-protected-push-guard.md](docs/features/163-protected-push-guard.md);
   bypass the local hook intentionally with `git push --no-verify`). Then, unless
-  the push is docs-only (below), runs `npm run verify` — typecheck + all tests
-  + e2e + build. Refuses the push if any step fails.
+  the push is docs-only (below), runs `npm run verify:fast:branch` — a fast,
+  branch-diff-scoped subset (lint, typecheck, config:check, test:hooks, test,
+  test:server, build, plus test:sidecar when the diff touches
+  `server/tts-sidecar/**`). Refuses the push if any in-scope step fails. This
+  replaced running the full `npm run verify` battery on every push (see
+  [docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md))
+  — the heavy legs (e2e, server-slow, scripts, test:pinokio) now run in the
+  cloud instead, which is now the required, enforcing gate (see below).
 
-**Docs-only pushes skip `npm run verify` entirely** — `scripts/is-docs-only-push.mjs`
+**Docs-only pushes skip `npm run verify:fast:branch` entirely** — `scripts/is-docs-only-push.mjs`
 checks the pushed commits' changed-file set against the same doc-glob test as
 CONTRIBUTING.md's "Doc-only PR fast-path" (`docs/**`, root `*.md`, `.github/*.md`);
-a doc-only diff has no runtime surface for tests/build/e2e to exercise, so
-paying the ~15-min battery locally is wasted time/CPU on top of the CI-side
-skip. Conservative by design: any uncertainty (git error, unresolvable
-merge-base) runs the full battery rather than guessing.
+a doc-only diff has no runtime surface for tests/build to exercise, so paying
+even the fast local check is wasted time/CPU. Conservative by design: any
+uncertainty (git error, unresolvable merge-base) runs the full selected-steps
+battery rather than guessing.
 
 `npm run verify` is cache-aware (see
 [docs/features/archive/50-verify-cache.md](docs/features/archive/50-verify-cache.md)):
@@ -447,34 +456,45 @@ core views) — see [docs/features/archive/46-lint-format-a11y.md](docs/features
 for the rulesets, the autofix-baseline shape, and the rationale for each
 relaxed rule.
 
-**GitHub CI is OPT-IN (plan 215)**: the `verify.yml` battery does **not** run
-automatically on PRs. The local pre-push hook already runs the FULL `npm run
-verify` battery on every push, so a per-PR cloud run is redundant spend on
-Actions minutes. Push freely — every PR push bills **0 CI minutes** by default.
-Run the cloud battery on demand when you want a clean-room check: add the
-**`run-ci`** label to the PR (fires one run; re-runs on each new push while the
-label is on), or dispatch it manually (Actions tab → Verify → Run workflow, or
-`gh workflow run verify.yml --ref <branch>`). A manual dispatch runs the full
-battery; a labeled PR runs only the **scope-filtered** legs the diff touched
-(plan 103 — `git diff` against the PR base; a frontend-only PR skips server
-tests, a server-only PR skips Playwright e2e + the frontend unit suite, a root
-`package.json`/`package-lock.json` change runs every leg).
+**GitHub CI is OPT-OUT (2026-07-06, superseding plan 215's opt-in design)**:
+the `verify.yml` battery runs automatically on every PR by default and is a
+**required status check** on `main` — it actually blocks merge on red. This
+replaces the prior opt-in/label-gated design, which existed to control
+Actions-minute cost while the repo was private; the repo is now public, so
+standard-runner Actions minutes are free and uncapped, and that rationale no
+longer applies. Local pre-push now only runs a fast, branch-scoped subset
+(`verify:fast:branch`) — this cloud run is the real enforcement gate for
+everything else, not redundant insurance. Every leg is still
+**scope-filtered** to what the PR's diff actually touched (plan 103 — `git
+diff` against the PR base; a frontend-only PR skips server tests, a
+server-only PR skips Playwright e2e + the frontend unit suite, a root
+`package.json`/`package-lock.json` change runs every leg) — that scoping is
+now about not running tests that can't fail, not about saving money. A
+manual dispatch (Actions tab → Verify → Run workflow, or `gh workflow run
+verify.yml --ref <branch>`) still runs the full unscoped battery, useful for
+a clean-room check off a non-PR ref.
 
 What still runs automatically: `pr-title-lint.yml` and `pr-issue-link.yml` on
 every PR, `app.yml` on `apps/android/**` changes (the only automated coverage
 for the Flutter companion — no local hook runs `flutter analyze`/`test`),
-`release.yml` on a `vX.Y.Z` tag, and `cross-os.yml` on its weekly Sunday cron. **Every release tag
-now runs COMPLETE cross-platform verification before it publishes** (plan 215):
-`release.yml` gates publish on full `npm run verify` (Ubuntu) + `test:e2e:mobile`
-(Ubuntu) + `verify:quick`+build on macOS **and** Windows — a red leg on any
-deployer OS blocks the public-beta release, so you no longer fire cross-OS by
-hand before a release. `cross-os.yml` (`workflow_dispatch` + weekly cron on
-`main`) stays as the between-releases pulse + ad-hoc cross-OS/mobile run. The
-doc-only `paths-ignore` fast-path (plan 101) is a second layer — a `run-ci`-labeled
-PR whose files are all docs still won't spin up the battery.
-See [docs/features/215-ci-label-gated-verify.md](docs/features/215-ci-label-gated-verify.md),
-[103](docs/features/103-ci-cost-reduction.md), and
-[archive/101](docs/features/archive/101-docs-only-ci-skip.md).
+`release.yml` on a `vX.Y.Z` tag, and `cross-os.yml` on its **twice-weekly**
+(Wednesday + Sunday) cron. **Every release tag now runs COMPLETE
+cross-platform verification before it publishes** (plan 215): `release.yml`
+gates publish on full `npm run verify` (Ubuntu) + `test:e2e:mobile` (Ubuntu)
++ `verify:quick`+build on macOS **and** Windows — a red leg on any deployer
+OS blocks the public-beta release, so you no longer fire cross-OS by hand
+before a release. `cross-os.yml` (`workflow_dispatch` + twice-weekly cron on
+`main`) stays as the between-releases pulse + ad-hoc cross-OS/mobile run.
+Docs-only PRs still complete `verify.yml` in seconds rather than deadlocking
+the required check — every leg's own scope condition is false for a
+docs-only diff, so the job just does env setup and reports green (see
+[docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md)
+for why `paths-ignore` was deliberately removed rather than kept).
+See [docs/features/215-ci-label-gated-verify.md](docs/features/215-ci-label-gated-verify.md)
+and [103](docs/features/103-ci-cost-reduction.md) for the superseded opt-in
+design's history/rationale, and
+[docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md)
+for the current design.
 
 Branching model and the full commit convention (allowed types, allowed scopes,
 multi-scope syntax, worktrees for parallel agent work) are documented in
@@ -528,17 +548,15 @@ a missing link blocks merge; until that setup is done, a missing link only
 fails a visible, non-blocking check.
 Full mechanics: [`.claude/skills/model-routing/SKILL.md`](.claude/skills/model-routing/SKILL.md#pr-gate-issue-verification).
 
-**Requesting a CI run on a PR (plan 215).** CI is opt-in (see "Commit gate"
-above): push freely — drafts and ready PRs alike bill **0 Actions minutes**.
-The local pre-push hook is the real gate and runs the full `npm run verify`
-battery on every push. When you want a clean-room cloud check (typically right
-before merge, or to confirm something you couldn't verify locally), add the
-**`run-ci`** label to the PR or dispatch `verify.yml` manually — the labeled
-run is insurance, not the gate. (Draft status no longer affects CI cost, so the
-old draft-by-default dance is unnecessary; still open as draft if you simply
-want to signal work-in-progress.) Rationale + measurements:
+**Requesting a clean-room CI run on a PR.** CI now runs automatically on
+every PR push (see "Commit gate" above) and is the real, required gate —
+you don't need to request it. Dispatch `verify.yml` manually (Actions tab →
+Verify → Run workflow, or `gh workflow run verify.yml --ref <branch>`) only
+when you want an unscoped, full-battery run off a non-PR ref. Rationale +
+history of the prior opt-in design:
 [docs/features/118-ci-cost-round-2.md](docs/features/118-ci-cost-round-2.md)
-and [215](docs/features/215-ci-label-gated-verify.md).
+and [215](docs/features/215-ci-label-gated-verify.md); current design:
+[docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md).
 
 ### Parallel agents
 
@@ -596,9 +614,13 @@ Additional one-time setup:
 
 Working practice:
 
-- Before committing anything non-trivial, run `npm run verify` — same battery
-  as pre-push. Catching failures in the same turn beats catching them at
-  push time.
+- Default loop for non-trivial work: finalize the change → run
+  `npm run verify:fast:branch` (same branch-scoped check pre-push now runs)
+  → open the PR → cloud `verify.yml` (required, opt-out) and the mandatory
+  code-review pass run independently → merge once both are green. Run the
+  full `npm run verify` manually only when you specifically want the full
+  local battery (e.g. before a release cut, or debugging something scope-
+  filtering might be hiding).
 - `npm run verify:fast` matches pre-commit; `npm run verify:quick` is `test:all` without typecheck/build/e2e.
 - **Do not use `--no-verify` to bypass.** If a hook fails:
   1. **Triage first.** Categorise the failure as **related to my change** vs. **pre-existing** (i.e. the same test would fail on `main`). A `git stash && git checkout main && <run the failing test>` round-trip settles it in 30 seconds.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ in service of keeping it shippable.
 - Cut every change on a branch named `<type>/<scope>-<slug>` (e.g. `feat/server-batch-retry`).
 - Every commit subject MUST be `<type>(<scope>): <subject>` — `chore: <subject>` is the no-scope catch-all. A pre-commit-msg hook rejects anything else.
 - Long-running parallel work goes in a `git worktree`, not a second clone. Reconcile multiple agent branches via an `integration/<date>` branch with `npm run verify` between merges.
-- `main` is always shippable. `npm run verify` is the pre-push gate.
+- `main` is always shippable. `npm run verify:fast:branch` is the pre-push gate; cloud `verify.yml` is the required, authoritative gate.
 
 ## Contributing & licensing
 
@@ -125,11 +125,11 @@ When N parallel agent branches finish:
    the agent branches once it merges.
 
 Reconcile on the integration branch, run `npm run verify` locally until green,
-and only then (if you want a cloud check) add the **`run-ci`** label to the
-integration PR or dispatch `verify.yml` — see
-[§ Requesting a CI run](#requesting-a-ci-run-ci-is-opt-in). The whole round then
-bills at most a **single** CI verify run, on demand, rather than one (or
-several) per agent branch. See
+then open the integration PR — CI now runs automatically on every push and is
+the required gate (see
+[§ Requesting a CI run](#requesting-a-ci-run-ci-is-opt-out-and-required)). The
+whole round then bills a **single** CI verify run for the integration PR,
+rather than one (or several) per agent branch. See
 [docs/features/118-ci-cost-round-2.md](docs/features/118-ci-cost-round-2.md).
 
 If a merge breaks `verify` and the fix isn't obvious, drop the offending branch
@@ -389,10 +389,10 @@ the durable reference, `#NN` is the GitHub hook.
 ### Server-side enforcement
 
 Issue templates + labels are a **soft convention** (the same posture as the
-commit/PR-title rules). CI is opt-in (plan 215), so we deliberately don't spend
-Actions minutes on label-lint or required-field enforcement beyond the forms
-themselves; the `blank_issues_enabled: false` config funnels every issue through
-a template.
+commit/PR-title rules) — deliberately not enforced by a dedicated CI check
+(label-lint or required-field validation) beyond the issue-form fields
+themselves; the `blank_issues_enabled: false` config funnels every issue
+through a template.
 
 ## Pull requests
 
@@ -431,8 +431,9 @@ Two required sections:
    `docs/features/archive/44-pr-hygiene.md`."_). If the PR fills a plan's Ship notes,
    say so.
 2. **`## Test plan`** — checklist of what was run and what reviewers should
-   look at. Always start with `- [ ] npm run verify — green` (the pre-push
-   hook will fail your push if it isn't anyway).
+   look at. Always start with `- [ ] npm run verify:fast:branch — green`
+   (the pre-push hook will fail your push if it isn't anyway) — cloud
+   `verify.yml` is the required, authoritative gate on top of that.
 
 If the PR delivers or advances a backlog/bug issue, link it in `## Summary`:
 `Closes #NN` (full delivery) or `Refs #NN` (partial). The keyword in the PR
@@ -442,31 +443,32 @@ The template's HTML comments are guidance — strip them before submitting, or
 leave them; they don't render. The Summary and Test plan headings are the
 load-bearing structure that reviewers (and future-me) skim first.
 
-### Requesting a CI run (CI is opt-in)
+### Requesting a CI run (CI is opt-out and required)
 
-The `verify.yml` battery does **not** run automatically on PRs (plan 215). The
-pre-push husky hook already runs the full `npm run verify` battery on every
-push, so a per-PR cloud run is redundant spend on Actions minutes. Push freely
-— every PR push (draft or ready) bills **0 CI minutes** by default. When you
-want a clean-room cloud check (typically right before merge, or to sanity-check
-a change you couldn't fully verify locally):
+The `verify.yml` battery runs automatically on every PR push and is a
+**required status check** on `main` — it must go green before merge. This
+replaced the prior label-gated opt-in design (plan 215) now that the repo is
+public and standard-runner Actions minutes are free/uncapped; local pre-push
+now only runs a fast, branch-scoped subset (`verify:fast:branch`), so the
+cloud run is the actual enforcement gate, not optional insurance. Dispatch
+it manually (Actions tab → Verify → Run workflow, or `gh workflow run
+verify.yml --ref <branch>`) only when you want an unscoped, full-battery run
+off a non-PR ref.
 
-- add the **`run-ci`** label to the PR — fires one run, and re-runs on each new
-  push while the label stays on; **or**
-- dispatch it manually: Actions tab → Verify → Run workflow, or
-  `gh workflow run verify.yml --ref <branch>`.
-
-A labeled PR run is scope-filtered to the legs the diff touched (plan 103); a
-manual dispatch runs the full battery. What still runs automatically on its own:
-`pr-title-lint.yml` on every PR, `app.yml` on `apps/android/**` changes,
-`release.yml` on a `vX.Y.Z` tag, and `cross-os.yml` (macOS + Windows + mobile
-e2e) on its weekly cron + manual dispatch. **Every release tag runs the complete
-cross-platform battery before publishing** (full `npm run verify` + mobile e2e on
-Ubuntu, plus `verify:quick`+build on macOS and Windows — see `release.yml`), so
-cross-OS coverage for a release is automatic, not a manual pre-announce step.
-Rationale + measurements:
+Every PR run is still scope-filtered to the legs the diff touched (plan
+103); a manual dispatch runs the full battery. What still runs automatically
+on its own: `pr-title-lint.yml` on every PR, `app.yml` on `apps/android/**`
+changes, `release.yml` on a `vX.Y.Z` tag, and `cross-os.yml` (macOS +
+Windows + mobile e2e) on its **twice-weekly** (Wednesday + Sunday) cron +
+manual dispatch. **Every release tag runs the complete cross-platform
+battery before publishing** (full `npm run verify` + mobile e2e on Ubuntu,
+plus `verify:quick`+build on macOS and Windows — see `release.yml`), so
+cross-OS coverage for a release is automatic, not a manual pre-announce
+step. Rationale + history of the prior opt-in design:
 [docs/features/215-ci-label-gated-verify.md](docs/features/215-ci-label-gated-verify.md),
-[docs/features/118-ci-cost-round-2.md](docs/features/118-ci-cost-round-2.md).
+[docs/features/118-ci-cost-round-2.md](docs/features/118-ci-cost-round-2.md);
+current design:
+[docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md).
 
 ### Merge policy
 
@@ -491,7 +493,7 @@ Rationale + measurements:
 
 ### Before requesting review
 
-- `npm run verify` green locally (pre-push hook already enforces this).
+- `npm run verify:fast:branch` green locally (pre-push hook already enforces this) — and the required cloud `verify.yml` check green on the PR.
 - The regression plan under `docs/features/` is updated or added in the same
   diff if the PR changes behaviour the plan cites.
 - The end-of-turn summary names the branch + commit SHAs so the reviewer can
@@ -502,10 +504,14 @@ Rationale + measurements:
 `main` has **server-side branch protection** as of 2026-06-14: a GitHub ruleset
 (`id 17654264`, `enforcement: active`) blocks force-push + deletion, enabled
 after the **GitHub Pro** upgrade (the feature 403'd on the old Free private
-plan). It **deliberately excludes required status checks** — so it stays
-compatible with opt-in CI (plan 215) and the doc-only `paths-ignore` skip
-without deadlocking PRs that never run `verify` — and adds no required-PR rule,
-so direct-to-`main` trivial fixes and tag-based releases keep working. The local
+plan). As of the verify/CI rebalance
+([docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md))
+the ruleset also **requires** the `npm run verify` status check (`verify.yml`'s
+job name) — this is safe against the doc-only-PR deadlock risk the prior
+design avoided by excluding required checks entirely, because `verify.yml` no
+longer has a `paths-ignore` that could prevent it from ever posting a status
+(see that spec for why). It still adds no required-PR-review rule, so
+direct-to-`main` trivial fixes and tag-based releases keep working. The local
 `guard-protected-push.mjs` pre-push hook (plan 163) is now belt-and-suspenders.
 Enablement + the ruleset JSON live in `com-4` / `brand/ruleset-main.json`. The
 conventions above remain soft enforcement plus the `pr-title-lint.yml` workflow.
@@ -514,22 +520,25 @@ conventions above remain soft enforcement plus the `pr-title-lint.yml` workflow.
 
 A PR whose changed-file set lives entirely under `docs/**`, root-level
 `*.md` (`README.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `CHANGELOG.md`), or
-`.github/*.md` (e.g. `.github/pull_request_template.md`) skips
-[`verify.yml`](.github/workflows/verify.yml) via `paths-ignore`.
-The PR still requires a valid title (`pr-title-lint.yml` runs on every
-PR) and GitHub's native `mergeable` status still surfaces conflicts —
-the gate stays "PR required + title valid + no conflicts", just without
-the 10–15 min full battery. Since plan 215 CI is opt-in for _every_ PR, this
-`paths-ignore` is now a second layer — it additionally ensures that even a
-`run-ci`-labeled PR whose files are all docs won't spin up the battery.
-Rationale and the exact glob list:
+`.github/*.md` (e.g. `.github/pull_request_template.md`) still triggers
+[`verify.yml`](.github/workflows/verify.yml) (its `paths-ignore` was
+deliberately removed — see
+[docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md)
+for why: keeping it while the check is required would deadlock every
+docs-only PR forever). Every leg's own scope condition evaluates false for
+a docs-only diff, though, so the job completes in roughly the time of "Setup
+Node + deps" alone (~20-40s) and reports green — the gate stays "PR required
++ title valid + no conflicts + a fast green required check", not the 10-15
+min full battery. Rationale and the exact glob list for the underlying
+scope-matching (unrelated to the removed `paths-ignore`):
 [docs/features/archive/101-docs-only-ci-skip.md](docs/features/archive/101-docs-only-ci-skip.md).
 
-The same file-set test also skips the **local** pre-push `npm run verify`
-battery (`scripts/is-docs-only-push.mjs`, wired into `.husky/pre-push`) — a
-docs-only push has no runtime surface for tests/build/e2e to exercise, so the
-~15-min battery would otherwise run twice (locally, then again in CI) for zero
-signal. See [CLAUDE.md "Commit gate"](CLAUDE.md#commit-gate).
+The same file-set test also skips the **local** pre-push
+`npm run verify:fast:branch` check (`scripts/is-docs-only-push.mjs`, wired
+into `.husky/pre-push`) — a docs-only push has no runtime surface for the
+fast checks to exercise, so paying even that fast local cost is wasted
+time/CPU for zero signal. See
+[CLAUDE.md "Commit gate"](CLAUDE.md#commit-gate).
 
 ## When you ship a change
 
@@ -541,7 +550,7 @@ The compact version:
 3. Update `docs/features/INDEX.md` and `docs/BACKLOG.md` if relevant.
 4. Update `docs/release-notes-next.md` and `RELEASE_NOTES.md` in this PR (see
    "Release notes" below) — skip only when the change has no shippable delta.
-5. Run `npm run verify` locally.
+5. Run `npm run verify:fast:branch` locally (pre-push already enforces it) — the required cloud `verify.yml` check covers the rest.
 6. Surface the user-visible delta in the end-of-turn summary.
 7. No budgeted polling loops in tests (await an event or drain to quiescence);
    no `page.waitForTimeout` in new e2e (use state-based waits); no oversized

--- a/docs/features/118-ci-cost-round-2.md
+++ b/docs/features/118-ci-cost-round-2.md
@@ -11,6 +11,15 @@ owner: null
 > URL surface: none (CI / process)
 > OpenAPI ops: none
 
+> **Update 2026-07-06:** the cost-minimization *posture* this doc describes
+> (opt-in CI, draft-PR batching to avoid billed runs) is superseded by
+> [docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](../superpowers/specs/2026-07-06-verify-ci-rebalance-design.md)
+> now that the repo is public — Actions minutes on standard runners are free
+> and uncapped, so CI flips from opt-in to opt-out and required. This doc's
+> test-impact-selection mechanism (`--changed <base>`) and its cost analysis
+> remain accurate history/rationale for why that mechanism exists; only the
+> "minimize run count" framing is stale.
+
 ## Benefit / Rationale
 
 GitHub Actions metered usage hit ~$17 for May 2026 on a steeply accelerating

--- a/docs/features/215-ci-label-gated-verify.md
+++ b/docs/features/215-ci-label-gated-verify.md
@@ -11,6 +11,15 @@ owner: null
 > URL surface: none (CI / process)
 > OpenAPI ops: none
 
+> **Update 2026-07-06:** superseded by
+> [docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](../superpowers/specs/2026-07-06-verify-ci-rebalance-design.md)
+> — the opt-in/label-gated design this doc describes flips to opt-out (CI
+> runs on every PR by default) and the check becomes required on `main`'s
+> ruleset, now that the repo is public and Actions minutes are free/uncapped
+> (the reason this doc's opt-in design existed no longer applies). This
+> doc's per-run cost-reduction mechanisms (scope-gated legs, one-job design)
+> remain in effect and accurate.
+
 ## Benefit / Rationale
 
 The local pre-push husky hook already runs the FULL `npm run verify` battery on

--- a/docs/features/235-model-routing-review-gates.md
+++ b/docs/features/235-model-routing-review-gates.md
@@ -29,6 +29,7 @@ owner: null
 1. The four-tier routing table (`CLAUDE.md` "Model routing" section, and the full copy in `.claude/skills/model-routing/SKILL.md`) never routes a fork — forks always inherit the dispatching session's model (`Agent` tool schema; see Decision 1 in the design spec).
 2. `scripts/validate-pr-issue-link.mjs`'s `hasIssueLink()` strips fenced + inline code spans before testing for `Closes #NN` / `Refs #NN` — a backtick-wrapped keyword must not satisfy the check (it doesn't actually auto-close on GitHub either).
 3. `.github/workflows/pr-issue-link.yml`'s job `name:` field ("Verify PR body links a GitHub issue") is the exact string referenced by the required-status-check ruleset (Task 7 Step 8, the manual step) — renaming the job without updating the ruleset silently breaks the required-check binding.
+4. That same manual ruleset step now also needs to bind `verify.yml`'s `npm run verify` job name (see [docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](../superpowers/specs/2026-07-06-verify-ci-rebalance-design.md)) — do both required-check bindings in the same GitHub settings visit if convenient, but they're independent action items; this doc's Task 7 Step 8 landing does not depend on the other one landing, or vice versa.
 
 ## Test plan
 

--- a/docs/superpowers/plans/2026-07-06-verify-ci-rebalance.md
+++ b/docs/superpowers/plans/2026-07-06-verify-ci-rebalance.md
@@ -81,11 +81,13 @@ import {
 } from '../verify-cache.mjs';
 ```
 
-Then replace the entire `parseFlags` test block (currently the 11 tests
-between `test('parseFlags recognizes --no-cache anywhere in argv', ...)` and
-`test('parseFlags recognizes --scope-staged', ...)`, i.e. lines 197-273 of
-the current file) with this — every existing assertion gains the new
-`scopeBranch: false` key, and one new test is added at the end:
+Then replace the entire `parseFlags` test block — the 8 existing tests
+from `test('parseFlags recognizes --no-cache anywhere in argv', ...)`
+through `test('parseFlags recognizes --scope-staged', ...)` inclusive
+(around lines 197-273 in the file before this step's own import edits shift
+line numbers down slightly — match by test-block content, not line number)
+— with this. Every existing assertion gains the new `scopeBranch: false`
+key, and one new test is added at the end:
 
 ```js
 test('parseFlags recognizes --no-cache anywhere in argv', () => {
@@ -414,13 +416,14 @@ Add immediately after it:
 - [ ] **Step 8: Manually spot-check the new script**
 
 Run: `npm run verify:fast:branch`
-Expected: since this branch (`docs/verify-ci-rebalance-design`) so far only
-touches `docs/superpowers/specs/**` and (after this task) `scripts/`,
-`package.json`, `scripts/tests/**` — steps whose scope includes those paths
-run (e.g. `test:hooks` since it now covers `scripts/tests/*.test.mjs`);
-steps like `test:sidecar` (scope `server/tts-sidecar/**`) print
-`[skip] test:sidecar (out of scope)`. Confirm no step errors out and the
-scope decisions look sane in the printed `[skip]`/`[run]` lines.
+Expected: `branchDiffFiles` diffs COMMITTED history (`merge-base(HEAD,main)`
+vs `HEAD`), not the working tree — so at this point, before this task's own
+changes are committed (Step 9 below), it only sees this branch's
+already-committed diff (the spec + plan docs under `docs/superpowers/**`),
+which touches none of the 8 selected steps' scopes. Every step should print
+`[skip] ... (out of scope)` and the command exits 0. This is correct: it
+confirms the filter is diff-based on git history, not on uncommitted files.
+Don't be alarmed that nothing actually runs yet.
 
 - [ ] **Step 9: Commit**
 
@@ -428,6 +431,20 @@ scope decisions look sane in the printed `[skip]`/`[run]` lines.
 git add scripts/verify-cache.mjs scripts/tests/verify-cache.test.mjs package.json
 git commit -m "feat(scripts): add --scope-branch mode to verify-cache for branch-diff-scoped pre-push checks"
 ```
+
+- [ ] **Step 10: Re-check after committing (note the `computeShared` interaction)**
+
+Now that Step 9 has committed `package.json` on this branch, run
+`npm run verify:fast:branch` again.
+Expected: this time EVERY selected step runs (no skips) — because
+`package.json` is now part of the branch's diff vs `main`, and
+`verify-cache.mjs`'s existing `computeShared()` treats any root
+`package.json`/`package-lock.json` change as global (a dep/lockfile bump can
+affect every leg), overriding the per-step scope filter for the rest of
+this branch's life. This is pre-existing, correct behavior (the same rule
+`--scope-staged` already honors) — not a bug, and not something to "fix."
+From this point on, every `verify:fast:branch` run on this branch runs the
+full 8-step list until the branch merges.
 
 ---
 
@@ -479,8 +496,12 @@ npm run verify:fast:branch
 
 Run: `git add -A && git commit -m "test: dummy commit for hook check" --allow-empty` (a throwaway empty commit — do NOT push it)
 Then run: `bash .husky/pre-push <<< "refs/heads/docs/verify-ci-rebalance-design"`
-Expected: the guard scripts run, then `npm run verify:fast:branch` runs
-(same scope-filtered output as Task 1 Step 8), exiting 0 on success.
+Expected: the guard scripts run, then `npm run verify:fast:branch` runs. By
+this point Task 1 has already committed `package.json` on this branch, so
+per Task 1 Step 10's note, `computeShared` is in effect and the FULL
+8-step list runs (not a scoped subset) — that's correct here, not a
+regression. Confirm the hook exits 0 on success (or fails loudly if a step
+is genuinely red).
 Then run: `git reset --hard HEAD~1` to remove the throwaway commit (it was
 never pushed, so this is safe and doesn't touch the real commit history).
 
@@ -1226,6 +1247,9 @@ Rationale and the exact glob list:
 
 The same file-set test also skips the **local** pre-push `npm run verify`
 battery (`scripts/is-docs-only-push.mjs`, wired into `.husky/pre-push`) — a
+docs-only push has no runtime surface for tests/build/e2e to exercise, so the
+~15-min battery would otherwise run twice (locally, then again in CI) for zero
+signal. See [CLAUDE.md "Commit gate"](CLAUDE.md#commit-gate).
 ```
 
 Replace with:
@@ -1250,7 +1274,10 @@ scope-matching (unrelated to the removed `paths-ignore`):
 
 The same file-set test also skips the **local** pre-push
 `npm run verify:fast:branch` check (`scripts/is-docs-only-push.mjs`, wired
-into `.husky/pre-push`) — a
+into `.husky/pre-push`) — a docs-only push has no runtime surface for the
+fast checks to exercise, so paying even that fast local cost is wasted
+time/CPU for zero signal. See
+[CLAUDE.md "Commit gate"](CLAUDE.md#commit-gate).
 ```
 
 - [ ] **Step 5: Fix five more stale "pre-push gate" / "npm run verify" references**
@@ -1455,28 +1482,59 @@ the still-pending equivalent action for `pr-issue-link.yml` (doc 235, Task 7
 Step 8) has been treated. Do this only after Tasks 1-7 are merged to `main`
 (the ruleset should reference a check that's already running there).
 
-- [ ] **Step 1: Confirm current ruleset state**
+**Do not let this task stall.** Doc 235's identical manual ruleset step for
+`pr-issue-link.yml` has sat pending since it was written — that is the
+concrete precedent for this exact class of action not happening promptly.
+Between Tasks 1-7 landing and this task completing, the repo is in a
+**strictly weaker** enforcement state than before this plan started: local
+pre-push no longer runs the full battery (Task 2), and cloud `verify.yml`
+runs but is merely advisory (not required) until this task lands. Treat
+this window as something to close quickly, not a "whenever" follow-up —
+ideally attempt it in the same working session that merges Tasks 1-7,
+before moving on to unrelated work.
 
-Run: `gh api repos/dudarenok-maker/Castwright/rulesets` and identify the
-ruleset covering `main` (per CONTRIBUTING.md, `id 17654264`). Read its
-current `rules` array to confirm it has no `required_status_checks` rule
-yet (matches the documented "deliberately excludes required checks" state).
+- [ ] **Step 1: Fetch the FULL current ruleset, don't assume its shape**
+
+Run: `gh api repos/dudarenok-maker/Castwright/rulesets/17654264 > /tmp/ruleset-current.json`
+(per CONTRIBUTING.md, `id 17654264` is the ruleset covering `main`). Read
+the saved JSON in full. Confirm its `rules` array has no
+`required_status_checks` entry yet (matches the documented "deliberately
+excludes required checks" state), and note down every OTHER rule present
+(expected: at minimum a rule blocking force-push and a rule blocking
+deletion — CONTRIBUTING.md describes these as "blocks force-push +
+deletion"). **These existing rules MUST be preserved** in Step 3 — GitHub's
+ruleset update endpoint is `PUT /repos/{owner}/{repo}/rulesets/{id}` with
+**replace semantics on the whole `rules` array**, not a per-rule merge.
+There is no PATCH-style "add one rule" call for rulesets. A `PUT` sent with
+only a new `required_status_checks` rule and none of the existing rules
+would silently **delete** the force-push/deletion protection — this is the
+single highest-risk mistake in this entire plan; do not rush this step.
 
 - [ ] **Step 2: Present the exact change to the user and get explicit go-ahead**
 
-State plainly: this will add a `required_status_checks` rule to ruleset
-`17654264` requiring the `npm run verify` check (the `verify.yml` job name)
-to pass before merge on `main`. Ask the user to confirm before proceeding —
-do not run Step 3 without an explicit yes in this session.
+State plainly: this will `PUT` an updated ruleset body to
+`repos/dudarenok-maker/Castwright/rulesets/17654264` that contains **every
+rule from Step 1's fetch, unchanged, PLUS one new
+`required_status_checks` rule** requiring the `npm run verify` check (the
+`verify.yml` job name) to pass before merge on `main`. Show the user the
+full diff between Step 1's saved JSON and the body you're about to send —
+every field should match except the added rule. Ask for explicit
+confirmation before proceeding — do not run Step 3 without an explicit yes
+in this session.
 
 - [ ] **Step 3: Apply the ruleset change**
 
-Once confirmed, use `gh api` (PATCH or PUT against
-`repos/dudarenok-maker/Castwright/rulesets/17654264`) to add a
-`required_status_checks` rule listing `npm run verify` as a required check
-(add `Verify PR body links a GitHub issue` too in the same call if the user
-wants doc 235's pending item bundled in — ask which they want per the plan's
-Task 8 framing, don't assume).
+Once confirmed: take Step 1's saved JSON, add ONE new entry to its `rules`
+array —
+`{"type": "required_status_checks", "parameters": {"required_status_checks": [{"context": "npm run verify"}], "strict_required_status_checks_policy": false}}`
+(add a second entry in the same `required_status_checks` array,
+`{"context": "Verify PR body links a GitHub issue"}`, only if the user
+confirms they want doc 235's pending item bundled in during Step 2 — ask,
+don't assume) — leaving every other existing field and rule byte-for-byte
+untouched. `PUT` the complete modified JSON body to
+`repos/dudarenok-maker/Castwright/rulesets/17654264` via `gh api --method
+PUT --input <file>`. Immediately re-fetch (repeat Step 1's `GET`) and diff
+against what was intended, to confirm nothing else changed.
 
 - [ ] **Step 4: Verify**
 
@@ -1530,3 +1588,21 @@ full-`npm run verify` usage in parallel-agent integration-branch
 reconciliation) describe behavior that's still accurate and were
 deliberately left untouched — noted here so a reviewer doesn't have to
 re-derive why they're not in the task list.
+
+**Revision history (round-1 adversarial plan review):** an Opus pass found
+one Critical/Contradicted issue and several Significant/Contradicted ones,
+all fixed in this version: Task 8's `gh api` guidance was rewritten to
+fetch-preserve-modify-PUT the full ruleset body instead of risking a bare
+`PUT`/`PATCH` that could silently drop the existing force-push/deletion
+protection rules; Task 1 Step 8 and Task 2 Step 2's manual checks
+were corrected to predict the ACTUAL scope-filter behavior on this branch
+(all-skip before this task's own commit, since `branchDiffFiles` reads
+committed history not the working tree; all-run after, since this task's
+own `package.json` change trips the existing `computeShared` global-override
+for the rest of the branch's life) instead of a plausible-but-wrong guess;
+the `parseFlags` test-block instructions dropped a stale exact line-number
+anchor in favor of a content anchor; and the Doc-only PR fast-path
+CONTRIBUTING.md edit was extended to cover a trailing clause it had
+previously left stale ("~15-min battery", "tests/build/e2e"). Task 8 also
+gained an explicit warning against letting the ruleset step stall the way
+doc 235's identical pending item has.

--- a/docs/superpowers/plans/2026-07-06-verify-ci-rebalance.md
+++ b/docs/superpowers/plans/2026-07-06-verify-ci-rebalance.md
@@ -474,8 +474,8 @@ script). Replace the entire file content with:
 #      changed file is docs (same test as CONTRIBUTING.md's CI doc-only
 #      fast-path) — a docs-only diff has no runtime surface to exercise.
 #
-# The heavy legs (e2e, server-slow, scripts/Pester, build's full battery,
-# etc.) no longer run locally on every push — cloud `verify.yml` is now a
+# The heavy legs (e2e, server-slow, scripts/Pester, test:pinokio, etc.) no
+# longer run locally on every push — cloud `verify.yml` is now a
 # required status check covering them (see
 # docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md).
 # `verify:fast:branch` runs only the fast/cheap steps, each scope-gated to

--- a/docs/superpowers/plans/2026-07-06-verify-ci-rebalance.md
+++ b/docs/superpowers/plans/2026-07-06-verify-ci-rebalance.md
@@ -1,0 +1,1532 @@
+# Verify / CI Rebalance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop routine local `npm run verify` runs from self-contending on
+the dev box by moving the heavy legs to a now-free, opt-out cloud CI gate,
+while keeping the local machine automatically covering the one thing it
+alone can do (scope-gated sidecar tests).
+
+**Architecture:** A new `--scope-branch` mode in `scripts/verify-cache.mjs`
+(diffing the branch vs local `main`, reusing the existing uniform per-step
+scope-filter engine) powers a new `verify:fast:branch` npm script that
+replaces `npm run verify` in `.husky/pre-push`. `.github/workflows/verify.yml`
+flips from label-gated opt-in to opt-out-by-default and gains two previously
+cloud-uncovered legs (`config:check`, `test:pinokio`) plus two scope-matcher
+fixes; it also gets wired into `main`'s required-status-check ruleset (the
+one manual, non-subagent step). `cross-os.yml`'s cron doubles up. Docs
+(`CLAUDE.md`, `CONTRIBUTING.md`, `docs/features/118`/`215`/`235`) are updated
+to describe the new posture.
+
+**Tech Stack:** Node.js (`node:test`, `node:child_process`), GitHub Actions
+YAML, Bash (workflow `run:` steps), Husky git hooks, Markdown docs.
+
+## Global Constraints
+
+- Every commit message follows `<type>(<scope>): <subject>` (CLAUDE.md commit
+  convention) — this work is `chore(scripts)` / `ci` / `docs` scoped, per
+  file touched.
+- No placeholders, no deferred "add tests later" — every code task ships its
+  own paired test in the same commit (CLAUDE.md testing discipline).
+- Reference doc for every design decision below:
+  `docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md` (already
+  merged through 3 rounds of adversarial review) — don't re-derive or
+  second-guess a decision it already settled; if something here seems to
+  contradict it, the spec wins and this plan has a bug.
+- Work happens on branch `docs/verify-ci-rebalance-design` (already checked
+  out, already has the spec's 3 commits). Continue committing there.
+
+---
+
+### Task 1: `--scope-branch` mode + `branchDiffFiles` in `verify-cache.mjs`
+
+**Files:**
+- Modify: `scripts/verify-cache.mjs`
+- Modify: `scripts/tests/verify-cache.test.mjs`
+- Modify: `package.json` (new `verify:fast:branch` script)
+
+**Interfaces:**
+- Produces: `parseFlags(argv)` return shape gains a `scopeBranch: boolean`
+  field (alongside existing `noCache`, `steps`, `scopeStaged`).
+- Produces: `export function branchDiffFiles(cwd)` — returns `string[]`
+  (POSIX-relative paths) on success (including an empty array for a
+  legitimate zero-file diff), or `null` if the underlying git commands
+  fail. Mirrors `stagedDiffFiles`'s contract but is exported (that one
+  isn't) specifically so it's independently unit-testable.
+- Consumes (Task 2 depends on this): the new `verify:fast:branch` npm
+  script, which Task 2's `.husky/pre-push` edit calls.
+
+- [ ] **Step 1: Write the failing tests**
+
+Open `scripts/tests/verify-cache.test.mjs`. First, add `branchDiffFiles` to
+the import list at the top of the file:
+
+```js
+import {
+  composeInputHash,
+  decide,
+  hashFile,
+  hashEntries,
+  loadCache,
+  saveCache,
+  parseFlags,
+  selectStepFiles,
+  stepTouchedByDiff,
+  computeShared,
+  parseNvidiaSmiUtil,
+  isVitestPoolCrash,
+  branchDiffFiles,
+  STEPS,
+  _internals,
+} from '../verify-cache.mjs';
+```
+
+Then replace the entire `parseFlags` test block (currently the 11 tests
+between `test('parseFlags recognizes --no-cache anywhere in argv', ...)` and
+`test('parseFlags recognizes --scope-staged', ...)`, i.e. lines 197-273 of
+the current file) with this — every existing assertion gains the new
+`scopeBranch: false` key, and one new test is added at the end:
+
+```js
+test('parseFlags recognizes --no-cache anywhere in argv', () => {
+  assert.deepEqual(parseFlags([]), {
+    noCache: false,
+    steps: null,
+    scopeStaged: false,
+    scopeBranch: false,
+  });
+  assert.deepEqual(parseFlags(['--no-cache']), {
+    noCache: true,
+    steps: null,
+    scopeStaged: false,
+    scopeBranch: false,
+  });
+  assert.deepEqual(parseFlags(['a', 'b', '--no-cache', 'c']), {
+    noCache: true,
+    steps: null,
+    scopeStaged: false,
+    scopeBranch: false,
+  });
+});
+
+test('parseFlags --steps with space-separated form', () => {
+  assert.deepEqual(parseFlags(['--steps', 'test:hooks,test,test:server']), {
+    noCache: false,
+    steps: ['test:hooks', 'test', 'test:server'],
+    scopeStaged: false,
+    scopeBranch: false,
+  });
+});
+
+test('parseFlags --steps with = form', () => {
+  assert.deepEqual(parseFlags(['--steps=test:hooks,test,test:server']), {
+    noCache: false,
+    steps: ['test:hooks', 'test', 'test:server'],
+    scopeStaged: false,
+    scopeBranch: false,
+  });
+});
+
+test('parseFlags --steps trims whitespace and drops empty segments', () => {
+  assert.deepEqual(parseFlags(['--steps=test:hooks , , test']), {
+    noCache: false,
+    steps: ['test:hooks', 'test'],
+    scopeStaged: false,
+    scopeBranch: false,
+  });
+});
+
+test('parseFlags --steps combines with --no-cache', () => {
+  assert.deepEqual(parseFlags(['--steps=test:hooks,test', '--no-cache']), {
+    noCache: true,
+    steps: ['test:hooks', 'test'],
+    scopeStaged: false,
+    scopeBranch: false,
+  });
+});
+
+test('parseFlags missing --steps argument yields empty list (caller errors out)', () => {
+  // `--steps` with no following arg, or followed by another `--flag`, is a
+  // user-error case that runPipeline surfaces as a non-zero exit rather than
+  // silently running the full pipeline.
+  assert.deepEqual(parseFlags(['--steps']), {
+    noCache: false,
+    steps: [],
+    scopeStaged: false,
+    scopeBranch: false,
+  });
+  assert.deepEqual(parseFlags(['--steps', '--no-cache']), {
+    noCache: true,
+    steps: [],
+    scopeStaged: false,
+    scopeBranch: false,
+  });
+});
+
+test('parseFlags absent --steps leaves steps null (full pipeline)', () => {
+  assert.deepEqual(parseFlags(['some', 'other', 'arg']), {
+    noCache: false,
+    steps: null,
+    scopeStaged: false,
+    scopeBranch: false,
+  });
+});
+
+test('parseFlags recognizes --scope-staged', () => {
+  assert.deepEqual(parseFlags(['--scope-staged']), {
+    noCache: false,
+    steps: null,
+    scopeStaged: true,
+    scopeBranch: false,
+  });
+});
+
+test('parseFlags recognizes --scope-branch', () => {
+  assert.deepEqual(parseFlags(['--scope-branch']), {
+    noCache: false,
+    steps: null,
+    scopeStaged: false,
+    scopeBranch: true,
+  });
+});
+```
+
+Finally, add a new section at the very end of the file (after the last
+`parseNvidiaSmiUtil` test) for `branchDiffFiles`:
+
+```js
+// --- Branch-diff scope filter (verify/CI rebalance, 2026-07-06) --------
+
+function gitAt(cwd, args) {
+  const r = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  if (r.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
+  }
+  return r.stdout;
+}
+
+// Builds a throwaway repo with one commit on a `main` branch, so tests can
+// exercise branchDiffFiles' real `git merge-base` + `git diff` calls without
+// touching this actual repo.
+function makeGitFixture() {
+  const dir = mkTmp();
+  gitAt(dir, ['init', '-q', '-b', 'main']);
+  gitAt(dir, ['config', 'user.email', 'test@example.com']);
+  gitAt(dir, ['config', 'user.name', 'Test']);
+  writeFileSync(join(dir, 'base.txt'), 'base', 'utf8');
+  gitAt(dir, ['add', '.']);
+  gitAt(dir, ['commit', '-q', '-m', 'base']);
+  return dir;
+}
+
+test('branchDiffFiles: returns files changed since branching off main', () => {
+  const dir = makeGitFixture();
+  gitAt(dir, ['switch', '-q', '-c', 'feature']);
+  writeFileSync(join(dir, 'feature.txt'), 'x', 'utf8');
+  gitAt(dir, ['add', '.']);
+  gitAt(dir, ['commit', '-q', '-m', 'feature commit']);
+  const files = branchDiffFiles(dir);
+  assert.deepEqual(files, ['feature.txt']);
+});
+
+test('branchDiffFiles: empty array (not null) when run directly on main with nothing new', () => {
+  const dir = makeGitFixture();
+  const files = branchDiffFiles(dir);
+  assert.deepEqual(files, []);
+});
+
+test('branchDiffFiles: returns null when cwd is not a git repo', () => {
+  const dir = mkTmp(); // no git init — merge-base has nothing to find
+  const files = branchDiffFiles(dir);
+  assert.equal(files, null);
+});
+```
+
+This last block needs `spawnSync` in scope — add it to the existing
+`node:child_process` import at the top of the test file (currently the file
+only imports from `node:fs`, `node:os`, `node:path`; add a new import line):
+
+```js
+import { spawnSync } from 'node:child_process';
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test:hooks`
+Expected: FAIL — `branchDiffFiles is not a function` (not exported yet) and
+`parseFlags` deepEqual mismatches (missing `scopeBranch` key).
+
+- [ ] **Step 3: Implement `scopeBranch` in `parseFlags`**
+
+In `scripts/verify-cache.mjs`, find `parseFlags`'s return statement:
+
+```js
+  return {
+    noCache: argv.includes('--no-cache'),
+    steps,
+    scopeStaged: argv.includes('--scope-staged'),
+  };
+```
+
+Replace with:
+
+```js
+  return {
+    noCache: argv.includes('--no-cache'),
+    steps,
+    scopeStaged: argv.includes('--scope-staged'),
+    scopeBranch: argv.includes('--scope-branch'),
+  };
+```
+
+- [ ] **Step 4: Implement `branchDiffFiles`**
+
+In `scripts/verify-cache.mjs`, find the existing `stagedDiffFiles` function:
+
+```js
+// Files staged for commit. Returns POSIX paths, or null if git fails (→ caller
+// disables the scope filter and runs everything; never skip on uncertainty).
+function stagedDiffFiles(cwd) {
+  const r = spawnSync('git', ['diff', '--cached', '--name-only'], {
+    cwd,
+    encoding: 'utf8',
+  });
+  if (r.error || r.status !== 0) return null;
+  return r.stdout
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(toPosix);
+}
+```
+
+Immediately after it, add:
+
+```js
+// Files touched by every commit on the current branch since it diverged
+// from local `main` — the right basis for a pre-push-time check, where
+// "staged" is usually empty (commits already exist). Returns POSIX paths,
+// or null if the underlying git commands fail (→ caller disables the scope
+// filter and runs everything; never skip on uncertainty). Distinct from
+// that failure case: a SUCCESSFUL merge-base+diff that finds no changed
+// files (branch fully merged into main, running directly on main, or a
+// commit-less branch) legitimately returns an empty array — the scope
+// filter correctly skips every step for that, which is fine given
+// verify.yml is now the required backstop. Exported (unlike
+// stagedDiffFiles) so it can be unit-tested directly.
+export function branchDiffFiles(cwd) {
+  const base = spawnSync('git', ['merge-base', 'HEAD', 'main'], {
+    cwd,
+    encoding: 'utf8',
+  });
+  if (base.error || base.status !== 0) return null;
+  const baseSha = base.stdout.trim();
+  const r = spawnSync('git', ['diff', '--name-only', baseSha, 'HEAD'], {
+    cwd,
+    encoding: 'utf8',
+  });
+  if (r.error || r.status !== 0) return null;
+  return r.stdout
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(toPosix);
+}
+```
+
+- [ ] **Step 5: Wire `--scope-branch` into `runPipeline`**
+
+In `scripts/verify-cache.mjs`, find the scope-filter block inside
+`runPipeline`:
+
+```js
+  // Scope filter (pre-commit) — compute the staged diff once; per-step skip
+  // happens at the top of the loop below.
+  let scopeDiff = null;
+  let scopeShared = false;
+  if (flags.scopeStaged) {
+    scopeDiff = stagedDiffFiles(cwd);
+    if (scopeDiff === null) {
+      console.log('[scope] git diff --cached failed; running all selected steps');
+    } else if (computeShared(scopeDiff)) {
+      scopeShared = true;
+      console.log('[scope] root manifest changed — all selected steps in scope');
+    }
+  }
+```
+
+Replace with:
+
+```js
+  // Scope filter (pre-commit / pre-push) — compute the diff once; per-step
+  // skip happens at the top of the loop below. --scope-staged (staged diff)
+  // and --scope-branch (branch-vs-main diff) are mutually exclusive scope
+  // bases feeding the SAME per-step filter.
+  let scopeDiff = null;
+  let scopeShared = false;
+  if (flags.scopeStaged) {
+    scopeDiff = stagedDiffFiles(cwd);
+    if (scopeDiff === null) {
+      console.log('[scope] git diff --cached failed; running all selected steps');
+    } else if (computeShared(scopeDiff)) {
+      scopeShared = true;
+      console.log('[scope] root manifest changed — all selected steps in scope');
+    }
+  } else if (flags.scopeBranch) {
+    scopeDiff = branchDiffFiles(cwd);
+    if (scopeDiff === null) {
+      console.log('[scope] git merge-base/diff against main failed; running all selected steps');
+    } else if (scopeDiff.length === 0) {
+      console.log('[scope] no diff vs main — nothing in scope, selected steps will skip');
+    } else if (computeShared(scopeDiff)) {
+      scopeShared = true;
+      console.log('[scope] root manifest changed — all selected steps in scope');
+    }
+  }
+```
+
+No other change is needed — the existing loop condition
+(`if (scopeDiff !== null && !scopeShared && !stepTouchedByDiff(step, scopeDiff))`)
+already correctly skips every step when `scopeDiff` is `[]`, since
+`stepTouchedByDiff` returns `false` for an empty diff list (already covered
+by the existing test `'stepTouchedByDiff: an empty diff touches nothing'`).
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npm run test:hooks`
+Expected: PASS — all tests green, including the 3 new `branchDiffFiles`
+tests and the updated `parseFlags` tests.
+
+- [ ] **Step 7: Add the `verify:fast:branch` npm script**
+
+In `package.json`, find this line (in the `scripts` block):
+
+```json
+    "verify:fast:scoped": "node scripts/verify-cache.mjs --steps test:hooks,test,test:server --scope-staged",
+```
+
+Add immediately after it:
+
+```json
+    "verify:fast:branch": "node scripts/verify-cache.mjs --steps lint,typecheck,config:check,test:hooks,test,test:server,build,test:sidecar --scope-branch",
+```
+
+- [ ] **Step 8: Manually spot-check the new script**
+
+Run: `npm run verify:fast:branch`
+Expected: since this branch (`docs/verify-ci-rebalance-design`) so far only
+touches `docs/superpowers/specs/**` and (after this task) `scripts/`,
+`package.json`, `scripts/tests/**` — steps whose scope includes those paths
+run (e.g. `test:hooks` since it now covers `scripts/tests/*.test.mjs`);
+steps like `test:sidecar` (scope `server/tts-sidecar/**`) print
+`[skip] test:sidecar (out of scope)`. Confirm no step errors out and the
+scope decisions look sane in the printed `[skip]`/`[run]` lines.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add scripts/verify-cache.mjs scripts/tests/verify-cache.test.mjs package.json
+git commit -m "feat(scripts): add --scope-branch mode to verify-cache for branch-diff-scoped pre-push checks"
+```
+
+---
+
+### Task 2: Wire `.husky/pre-push` to `verify:fast:branch`
+
+**Files:**
+- Modify: `.husky/pre-push`
+
+**Interfaces:**
+- Consumes: `npm run verify:fast:branch` (Task 1).
+
+- [ ] **Step 1: Replace the pre-push hook body**
+
+Read the current `.husky/pre-push` (10 lines of guard comments + 6 lines of
+script). Replace the entire file content with:
+
+```bash
+# Pre-push guards run before the fast branch-scoped check. git pipes the
+# pushed-ref list on stdin; capture it ONCE and feed all three checks (stdin
+# can only be read once). Bypass intentionally with `git push --no-verify`.
+#   1. guard-protected-push  — refuse force-push / deletion of main (#163).
+#   2. guard-commit-subjects — reject any pushed commit whose subject violates
+#      the Conventional-Commits rule, even if commit-msg was bypassed
+#      (--no-verify / worktree hook couldn't spawn). Backstops the @-leak that
+#      shipped on #856.
+#   3. is-docs-only-push     — skip the local check entirely when every
+#      changed file is docs (same test as CONTRIBUTING.md's CI doc-only
+#      fast-path) — a docs-only diff has no runtime surface to exercise.
+#
+# The heavy legs (e2e, server-slow, scripts/Pester, build's full battery,
+# etc.) no longer run locally on every push — cloud `verify.yml` is now a
+# required status check covering them (see
+# docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md).
+# `verify:fast:branch` runs only the fast/cheap steps, each scope-gated to
+# whether this branch's diff (vs local `main`) actually touches its inputs —
+# including `test:sidecar`, scope-gated to `server/tts-sidecar/**`, so the
+# one check that genuinely needs this machine still runs automatically
+# exactly when it's relevant.
+PUSH_REFS=$(cat)
+printf '%s\n' "$PUSH_REFS" | node scripts/guard-protected-push.mjs "$@" || exit 1
+printf '%s\n' "$PUSH_REFS" | node scripts/guard-commit-subjects.mjs "$@" || exit 1
+if printf '%s\n' "$PUSH_REFS" | node scripts/is-docs-only-push.mjs "$@"; then
+  exit 0
+fi
+npm run verify:fast:branch
+```
+
+- [ ] **Step 2: Manually verify the hook fires correctly**
+
+Run: `git add -A && git commit -m "test: dummy commit for hook check" --allow-empty` (a throwaway empty commit — do NOT push it)
+Then run: `bash .husky/pre-push <<< "refs/heads/docs/verify-ci-rebalance-design"`
+Expected: the guard scripts run, then `npm run verify:fast:branch` runs
+(same scope-filtered output as Task 1 Step 8), exiting 0 on success.
+Then run: `git reset --hard HEAD~1` to remove the throwaway commit (it was
+never pushed, so this is safe and doesn't touch the real commit history).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .husky/pre-push
+git commit -m "fix(scripts): swap pre-push from full verify to branch-scoped fast check"
+```
+
+---
+
+### Task 3: `.github/workflows/verify.yml` — opt-out, required-check-ready, new legs
+
+**Files:**
+- Modify: `.github/workflows/verify.yml`
+
+**Interfaces:**
+- Produces: the `npm run verify` job name (unchanged) — Task 8 (manual
+  ruleset step) binds to this exact job name.
+- No code interface — this is a workflow YAML file, verified by reading the
+  diff carefully and (optionally) a `workflow_dispatch` run once pushed.
+
+- [ ] **Step 1: Replace the file header (top-of-file comment block, `on:` block through `permissions:`)**
+
+Replace lines 1–49 (from `name: Verify` through `permissions:\n  contents: read`) with:
+
+```yaml
+name: Verify
+
+# Plan 60 — CI verify-on-PR. Plan 103 — per-PR cost reduction. Plan 215 — CI
+# was opt-in (label-gated) while the repo was private and Actions minutes
+# were metered. See docs/superpowers/specs/2026-07-06-verify-ci-rebalance-
+# design.md: the repo is now public (free, uncapped Actions minutes on
+# standard runners), and local `npm run verify` was causing multi-hour
+# self-contention on the dev box, so this workflow flips from opt-in to
+# OPT-OUT (runs on every PR by default) AND becomes a required status check
+# on `main`'s branch-protection ruleset — closing the gap where local
+# pre-push was previously the only thing that refused to push on a red leg.
+#
+# It runs only the LEGS whose scope actually changed. A single job does setup
+# once, detects which scopes the PR touched (git diff against the PR base),
+# then gates each expensive leg (server tests, e2e, build, …) behind an `if:`
+# on that scope. A PR that touches only `src/**` skips the server tests; a
+# server-only PR skips the frontend unit suite + Playwright e2e; etc. Local
+# pre-push now only runs a fast, branch-diff-scoped subset
+# (`verify:fast:branch`) — this cloud run is the actual enforcement gate for
+# everything else, not redundant insurance.
+#
+# Why one job with conditional steps (not a job-per-leg matrix): GitHub bills
+# each job's wall-clock separately, summed, rounded UP to the minute per job.
+# Parallel jobs would duplicate `npm ci` + pay a 1-min floor each. One job →
+# setup paid once, skipped legs cost ~0. (Billing is no longer the primary
+# driver now that Actions minutes are free on this public repo, but the
+# single-job shape is still the simpler design.)
+#
+# No `paths-ignore` here (deliberately removed — see design spec): keeping it
+# while this is a required status check would deadlock every docs-only PR,
+# since a required check that never fires blocks merge forever. Every leg's
+# own `if:` scope condition already evaluates false for a docs-only diff, so
+# the job still completes in roughly the time of "Setup Node + deps" alone
+# and reports green — no deadlock, negligible added time. Same reasoning is
+# why the job no longer gates on PR `draft` status either — a draft-gated
+# required check would deadlock every draft PR the same way.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+  # Manual on-demand run: Actions tab → Verify → Run workflow, or
+  # `gh workflow run verify.yml --ref <branch>`. A dispatch has no PR diff to
+  # scope against, so it runs the FULL battery (every leg) — see the scope
+  # detector below.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+```
+
+- [ ] **Step 2: Replace the job header (`jobs:` through the `timeout-minutes` line)**
+
+Find:
+
+```yaml
+jobs:
+  verify:
+    # NOTE: the `name:` "npm run verify" is the historical status-check name.
+    # Branch protection on `main` deliberately does NOT require it as a status
+    # check (the staged ruleset excludes required checks so opt-in/doc-only PRs
+    # can't deadlock — see brand/ruleset-main.json / com-4), so a no-op run on
+    # an unlabeled PR never blocks merge. Keep the name stable anyway in case a
+    # required check is added later.
+    name: npm run verify
+    runs-on: ubuntu-latest
+    # Opt-in gate: run ONLY on a manual dispatch, or a non-draft PR carrying
+    # the `run-ci` label. Unlabeled PRs evaluate the workflow but the job is
+    # skipped here → zero runner minutes billed. Local pre-push already runs
+    # the full battery, so this cloud run is on-demand insurance.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.draft == false &&
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
+    # 30 (was 20): a run that dies AT the cap bills the full cap for nothing and
+```
+
+Replace with:
+
+```yaml
+jobs:
+  verify:
+    # NOTE: the `name:` "npm run verify" is the historical status-check name.
+    # This check IS required on `main`'s branch-protection ruleset (see the
+    # design spec) — keep this name stable, since renaming the job would
+    # silently detach the required-check rule from it.
+    name: npm run verify
+    runs-on: ubuntu-latest
+    # 30 (was 20): a run that dies AT the cap bills the full cap for nothing and
+```
+
+(The job now has no `if:` gate at all — it runs unconditionally whenever the
+`on:` trigger fires. Everything after `timeout-minutes: 30` through the
+`Checkout` step stays exactly as-is; only this header block changes.)
+
+- [ ] **Step 3: Update the scope-detection step**
+
+Find the `Detect changed scopes` step's `run:` block:
+
+```yaml
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            for k in frontend server sidecar e2e scripts hooks shared; do
+              echo "$k=true" >> "$GITHUB_OUTPUT"
+              echo "scope $k=true (workflow_dispatch → full run)"
+            done
+            exit 0
+          fi
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          FILES="$(git diff --name-only "$BASE" "$HEAD")"
+          echo "Changed files in this PR:"
+          echo "$FILES"
+          echo "---"
+          match() { echo "$FILES" | grep -qE "$1"; }
+          frontend=false; server=false; sidecar=false
+          e2e=false; scripts=false; hooks=false; shared=false
+          match '^(src/|index\.html$|vite\.config\.ts$|tailwind\.config\.ts$|tsconfig\.json$|tsconfig\.node\.json$|postcss\.config\.js$|eslint\.config\.(js|mjs)$)' && frontend=true
+          match '^(server/src/|server/package(-lock)?\.json$|server/tsconfig\.json$|server/vitest\.config(\.slow)?\.ts$|openapi\.yaml$)' && server=true
+          match '^server/tts-sidecar/' && sidecar=true
+          match '^(e2e/|playwright\.config\.ts$)' && e2e=true
+          match '^scripts/' && scripts=true
+          match '^(\.husky/|scripts/run-hooks-tests\.mjs$|scripts/validate-commit-msg\.mjs$)' && hooks=true
+          # `shared` = a ROOT dependency manifest changed → treat as global
+          # (a dep/lockfile bump can affect every leg), so run everything.
+          match '^(package\.json|package-lock\.json)$' && shared=true
+          for k in frontend server sidecar e2e scripts hooks shared; do
+            echo "$k=${!k}" >> "$GITHUB_OUTPUT"
+            echo "scope $k=${!k}"
+          done
+```
+
+Replace with:
+
+```yaml
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            for k in frontend server sidecar e2e scripts hooks pinokio shared; do
+              echo "$k=true" >> "$GITHUB_OUTPUT"
+              echo "scope $k=true (workflow_dispatch → full run)"
+            done
+            exit 0
+          fi
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          FILES="$(git diff --name-only "$BASE" "$HEAD")"
+          echo "Changed files in this PR:"
+          echo "$FILES"
+          echo "---"
+          match() { echo "$FILES" | grep -qE "$1"; }
+          frontend=false; server=false; sidecar=false
+          e2e=false; scripts=false; hooks=false; pinokio=false; shared=false
+          match '^(src/|index\.html$|vite\.config\.ts$|tailwind\.config\.ts$|tsconfig\.json$|tsconfig\.node\.json$|postcss\.config\.js$|eslint\.config\.(js|mjs)$)' && frontend=true
+          match '^(server/src/|server/package(-lock)?\.json$|server/tsconfig\.json$|server/vitest\.config(\.slow)?\.ts$|openapi\.yaml$|server/\.env\.example$|server/scripts/sync-env-example\.ts$)' && server=true
+          match '^server/tts-sidecar/' && sidecar=true
+          match '^(e2e/|playwright\.config\.ts$)' && e2e=true
+          match '^scripts/' && scripts=true
+          match '^(\.husky/|scripts/run-hooks-tests\.mjs$|scripts/validate-commit-msg\.mjs$)' && hooks=true
+          match '^(pinokio/|scripts/run-pinokio-tests\.mjs$)' && pinokio=true
+          # `shared` = a ROOT dependency manifest changed → treat as global
+          # (a dep/lockfile bump can affect every leg), so run everything.
+          match '^(package\.json|package-lock\.json)$' && shared=true
+          for k in frontend server sidecar e2e scripts hooks pinokio shared; do
+            echo "$k=${!k}" >> "$GITHUB_OUTPUT"
+            echo "scope $k=${!k}"
+          done
+```
+
+- [ ] **Step 4: Add the "Config check" step**
+
+Find the `Typecheck` step:
+
+```yaml
+      - name: Typecheck
+        if: steps.changes.outputs.frontend == 'true' || steps.changes.outputs.server == 'true' || steps.changes.outputs.shared == 'true'
+        run: npm run typecheck
+
+      - name: Hooks tests
+```
+
+Insert a new step between them:
+
+```yaml
+      - name: Typecheck
+        if: steps.changes.outputs.frontend == 'true' || steps.changes.outputs.server == 'true' || steps.changes.outputs.shared == 'true'
+        run: npm run typecheck
+
+      # Drift guard: fails if server/.env.example is out of sync with the
+      # config registry. Previously ONLY ran via local `npm run verify` — see
+      # docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md §3.
+      - name: Config check
+        if: steps.changes.outputs.server == 'true' || steps.changes.outputs.shared == 'true'
+        run: npm run config:check
+
+      - name: Hooks tests
+```
+
+- [ ] **Step 5: Add the "Pinokio tests" step**
+
+Find the `PowerShell-helper tests (Pester)` step:
+
+```yaml
+      - name: PowerShell-helper tests (Pester)
+        # No-ops with a banner on a runner without Pester 5 (the GitHub
+        # ubuntu image ships pwsh but not Pester 5), exactly as the old
+        # `npm run verify` leg did. Kept gated on `scripts` so it provides
+        # real coverage if/when Pester 5 is bootstrapped on the runner.
+        if: steps.changes.outputs.scripts == 'true'
+        run: npm run test:scripts
+
+      # `--changed <base>` narrows the frontend vitest run to only the tests
+```
+
+Insert a new step between them:
+
+```yaml
+      - name: PowerShell-helper tests (Pester)
+        # No-ops with a banner on a runner without Pester 5 (the GitHub
+        # ubuntu image ships pwsh but not Pester 5), exactly as the old
+        # `npm run verify` leg did. Kept gated on `scripts` so it provides
+        # real coverage if/when Pester 5 is bootstrapped on the runner.
+        if: steps.changes.outputs.scripts == 'true'
+        run: npm run test:scripts
+
+      # Previously ONLY ran via local `npm run verify` — see
+      # docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md §3.
+      - name: Pinokio tests
+        if: steps.changes.outputs.pinokio == 'true' || steps.changes.outputs.shared == 'true'
+        run: npm run test:pinokio
+
+      # `--changed <base>` narrows the frontend vitest run to only the tests
+```
+
+- [ ] **Step 6: Validate the YAML**
+
+Run: `node -e "require('yaml').parse(require('fs').readFileSync('.github/workflows/verify.yml', 'utf8'))"` if the `yaml` package is available, otherwise: `npx -y js-yaml .github/workflows/verify.yml > /dev/null && echo YAML_OK`
+Expected: `YAML_OK` printed, no parse errors. (If neither tool is available,
+visually re-read the full file for indentation consistency instead — every
+`- name:` step must be indented exactly 6 spaces under `steps:`, matching
+the surrounding unchanged steps.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .github/workflows/verify.yml
+git commit -m "ci: flip verify.yml from opt-in to opt-out, add config-check + pinokio legs"
+```
+
+---
+
+### Task 4: `.github/workflows/cross-os.yml` — twice-weekly cron
+
+**Files:**
+- Modify: `.github/workflows/cross-os.yml`
+
+- [ ] **Step 1: Replace the schedule block**
+
+Find:
+
+```yaml
+on:
+  workflow_dispatch:
+  schedule:
+    # Sunday 02:00 UTC — well clear of weekday PR contention. Weekly pulse so
+    # cross-OS / mobile regressions on main surface within a week even when
+    # nobody fires the manual button.
+    - cron: '0 2 * * 0'
+```
+
+Replace with:
+
+```yaml
+on:
+  workflow_dispatch:
+  schedule:
+    # Twice weekly (was once) — see docs/superpowers/specs/2026-07-06-verify-
+    # ci-rebalance-design.md §5: once local pre-push stops running a full
+    # Windows/Pester/macOS-equivalent pass on every push, this cron becomes
+    # the only regular cross-platform coverage, so the cadence doubles.
+    - cron: '0 2 * * 3' # Wednesday 02:00 UTC
+    - cron: '0 2 * * 0' # Sunday 02:00 UTC — well clear of weekday PR contention
+```
+
+- [ ] **Step 2: Validate the YAML**
+
+Run the same validation approach as Task 3 Step 6, pointed at
+`.github/workflows/cross-os.yml`.
+Expected: no parse errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/cross-os.yml
+git commit -m "ci: bump cross-os.yml cron from weekly to twice-weekly (Wed+Sun)"
+```
+
+---
+
+### Task 5: `CLAUDE.md` updates
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Update the Commands list (new `verify:fast:branch` line)**
+
+Find:
+
+```
+- `npm run verify` — full battery: typecheck + all tests + e2e + build (matches the pre-push hook).
+- `npm run verify:quick` — all tests (no e2e, no typecheck, no build) — alias for `test:all`.
+- `npm run verify:fast` — fast tests only (alias for `test:fast`) — pre-commit gate.
+```
+
+Replace with:
+
+```
+- `npm run verify` — full battery: typecheck + all tests + e2e + build. No longer the pre-push default (see "Commit gate") — run manually when you want the full local battery (e.g. before a release cut).
+- `npm run verify:quick` — all tests (no e2e, no typecheck, no build) — alias for `test:all`.
+- `npm run verify:fast` — fast tests only (alias for `test:fast`) — pre-commit gate.
+- `npm run verify:fast:branch` — lint + typecheck + config:check + test:hooks + test + test:server + build, each scope-gated to whether the current branch's diff (vs local `main`) touches its inputs, plus `test:sidecar` scope-gated to `server/tts-sidecar/**`. This is the new pre-push default (see "Commit gate") — the fast, branch-scoped smoke check; cloud `verify.yml` is now the actual enforcement gate for everything else.
+```
+
+- [ ] **Step 2: Rewrite the pre-push bullet in "Commit gate"**
+
+Find:
+
+```
+- **pre-push** (`.husky/pre-push`): first runs `scripts/guard-protected-push.mjs`,
+  which refuses a force-push or deletion of a protected branch (`main`) before
+  the battery even starts (a local guard; since 2026-06-14 `main` ALSO has
+  server-side branch protection — a GitHub ruleset blocking force-push +
+  deletion, enabled after the Pro upgrade per `com-4` — so this hook is now
+  belt-and-suspenders; see
+  [docs/features/163-protected-push-guard.md](docs/features/163-protected-push-guard.md);
+  bypass the local hook intentionally with `git push --no-verify`). Then, unless
+  the push is docs-only (below), runs `npm run verify` — typecheck + all tests
+  + e2e + build. Refuses the push if any step fails.
+```
+
+Replace with:
+
+```
+- **pre-push** (`.husky/pre-push`): first runs `scripts/guard-protected-push.mjs`,
+  which refuses a force-push or deletion of a protected branch (`main`) before
+  the battery even starts (a local guard; since 2026-06-14 `main` ALSO has
+  server-side branch protection — a GitHub ruleset blocking force-push +
+  deletion, enabled after the Pro upgrade per `com-4` — so this hook is now
+  belt-and-suspenders; see
+  [docs/features/163-protected-push-guard.md](docs/features/163-protected-push-guard.md);
+  bypass the local hook intentionally with `git push --no-verify`). Then, unless
+  the push is docs-only (below), runs `npm run verify:fast:branch` — a fast,
+  branch-diff-scoped subset (lint, typecheck, config:check, test:hooks, test,
+  test:server, build, plus test:sidecar when the diff touches
+  `server/tts-sidecar/**`). Refuses the push if any in-scope step fails. This
+  replaced running the full `npm run verify` battery on every push (see
+  [docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md))
+  — the heavy legs (e2e, server-slow, scripts, test:pinokio) now run in the
+  cloud instead, which is now the required, enforcing gate (see below).
+```
+
+- [ ] **Step 3: Rewrite the docs-only-pushes paragraph**
+
+Find:
+
+```
+**Docs-only pushes skip `npm run verify` entirely** — `scripts/is-docs-only-push.mjs`
+checks the pushed commits' changed-file set against the same doc-glob test as
+CONTRIBUTING.md's "Doc-only PR fast-path" (`docs/**`, root `*.md`, `.github/*.md`);
+a doc-only diff has no runtime surface for tests/build/e2e to exercise, so
+paying the ~15-min battery locally is wasted time/CPU on top of the CI-side
+skip. Conservative by design: any uncertainty (git error, unresolvable
+merge-base) runs the full battery rather than guessing.
+```
+
+Replace with:
+
+```
+**Docs-only pushes skip `npm run verify:fast:branch` entirely** — `scripts/is-docs-only-push.mjs`
+checks the pushed commits' changed-file set against the same doc-glob test as
+CONTRIBUTING.md's "Doc-only PR fast-path" (`docs/**`, root `*.md`, `.github/*.md`);
+a doc-only diff has no runtime surface for tests/build to exercise, so paying
+even the fast local check is wasted time/CPU. Conservative by design: any
+uncertainty (git error, unresolvable merge-base) runs the full selected-steps
+battery rather than guessing.
+```
+
+- [ ] **Step 4: Rewrite the "GitHub CI is OPT-IN" paragraph**
+
+Find the entire block from `**GitHub CI is OPT-IN (plan 215)**:` through the
+`[archive/101]` reference line just before `Branching model and the full
+commit convention...`:
+
+```
+**GitHub CI is OPT-IN (plan 215)**: the `verify.yml` battery does **not** run
+automatically on PRs. The local pre-push hook already runs the FULL `npm run
+verify` battery on every push, so a per-PR cloud run is redundant spend on
+Actions minutes. Push freely — every PR push bills **0 CI minutes** by default.
+Run the cloud battery on demand when you want a clean-room check: add the
+**`run-ci`** label to the PR (fires one run; re-runs on each new push while the
+label is on), or dispatch it manually (Actions tab → Verify → Run workflow, or
+`gh workflow run verify.yml --ref <branch>`). A manual dispatch runs the full
+battery; a labeled PR runs only the **scope-filtered** legs the diff touched
+(plan 103 — `git diff` against the PR base; a frontend-only PR skips server
+tests, a server-only PR skips Playwright e2e + the frontend unit suite, a root
+`package.json`/`package-lock.json` change runs every leg).
+
+What still runs automatically: `pr-title-lint.yml` and `pr-issue-link.yml` on
+every PR, `app.yml` on `apps/android/**` changes (the only automated coverage
+for the Flutter companion — no local hook runs `flutter analyze`/`test`),
+`release.yml` on a `vX.Y.Z` tag, and `cross-os.yml` on its weekly Sunday cron. **Every release tag
+now runs COMPLETE cross-platform verification before it publishes** (plan 215):
+`release.yml` gates publish on full `npm run verify` (Ubuntu) + `test:e2e:mobile`
+(Ubuntu) + `verify:quick`+build on macOS **and** Windows — a red leg on any
+deployer OS blocks the public-beta release, so you no longer fire cross-OS by
+hand before a release. `cross-os.yml` (`workflow_dispatch` + weekly cron on
+`main`) stays as the between-releases pulse + ad-hoc cross-OS/mobile run. The
+doc-only `paths-ignore` fast-path (plan 101) is a second layer — a `run-ci`-labeled
+PR whose files are all docs still won't spin up the battery.
+See [docs/features/215-ci-label-gated-verify.md](docs/features/215-ci-label-gated-verify.md),
+[103](docs/features/103-ci-cost-reduction.md), and
+[archive/101](docs/features/archive/101-docs-only-ci-skip.md).
+```
+
+Replace with:
+
+```
+**GitHub CI is OPT-OUT (2026-07-06, superseding plan 215's opt-in design)**:
+the `verify.yml` battery runs automatically on every PR by default and is a
+**required status check** on `main` — it actually blocks merge on red. This
+replaces the prior opt-in/label-gated design, which existed to control
+Actions-minute cost while the repo was private; the repo is now public, so
+standard-runner Actions minutes are free and uncapped, and that rationale no
+longer applies. Local pre-push now only runs a fast, branch-scoped subset
+(`verify:fast:branch`) — this cloud run is the real enforcement gate for
+everything else, not redundant insurance. Every leg is still
+**scope-filtered** to what the PR's diff actually touched (plan 103 — `git
+diff` against the PR base; a frontend-only PR skips server tests, a
+server-only PR skips Playwright e2e + the frontend unit suite, a root
+`package.json`/`package-lock.json` change runs every leg) — that scoping is
+now about not running tests that can't fail, not about saving money. A
+manual dispatch (Actions tab → Verify → Run workflow, or `gh workflow run
+verify.yml --ref <branch>`) still runs the full unscoped battery, useful for
+a clean-room check off a non-PR ref.
+
+What still runs automatically: `pr-title-lint.yml` and `pr-issue-link.yml` on
+every PR, `app.yml` on `apps/android/**` changes (the only automated coverage
+for the Flutter companion — no local hook runs `flutter analyze`/`test`),
+`release.yml` on a `vX.Y.Z` tag, and `cross-os.yml` on its **twice-weekly**
+(Wednesday + Sunday) cron. **Every release tag now runs COMPLETE
+cross-platform verification before it publishes** (plan 215): `release.yml`
+gates publish on full `npm run verify` (Ubuntu) + `test:e2e:mobile` (Ubuntu)
++ `verify:quick`+build on macOS **and** Windows — a red leg on any deployer
+OS blocks the public-beta release, so you no longer fire cross-OS by hand
+before a release. `cross-os.yml` (`workflow_dispatch` + twice-weekly cron on
+`main`) stays as the between-releases pulse + ad-hoc cross-OS/mobile run.
+Docs-only PRs still complete `verify.yml` in seconds rather than deadlocking
+the required check — every leg's own scope condition is false for a
+docs-only diff, so the job just does env setup and reports green (see
+[docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md)
+for why `paths-ignore` was deliberately removed rather than kept).
+See [docs/features/215-ci-label-gated-verify.md](docs/features/215-ci-label-gated-verify.md)
+and [103](docs/features/103-ci-cost-reduction.md) for the superseded opt-in
+design's history/rationale, and
+[docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md)
+for the current design.
+```
+
+- [ ] **Step 5: Rewrite the "Requesting a CI run on a PR" paragraph**
+
+Find:
+
+```
+**Requesting a CI run on a PR (plan 215).** CI is opt-in (see "Commit gate"
+above): push freely — drafts and ready PRs alike bill **0 Actions minutes**.
+The local pre-push hook is the real gate and runs the full `npm run verify`
+battery on every push. When you want a clean-room cloud check (typically right
+before merge, or to confirm something you couldn't verify locally), add the
+**`run-ci`** label to the PR or dispatch `verify.yml` manually — the labeled
+run is insurance, not the gate. (Draft status no longer affects CI cost, so the
+old draft-by-default dance is unnecessary; still open as draft if you simply
+want to signal work-in-progress.) Rationale + measurements:
+[docs/features/118-ci-cost-round-2.md](docs/features/118-ci-cost-round-2.md)
+and [215](docs/features/215-ci-label-gated-verify.md).
+```
+
+Replace with:
+
+```
+**Requesting a clean-room CI run on a PR.** CI now runs automatically on
+every PR push (see "Commit gate" above) and is the real, required gate —
+you don't need to request it. Dispatch `verify.yml` manually (Actions tab →
+Verify → Run workflow, or `gh workflow run verify.yml --ref <branch>`) only
+when you want an unscoped, full-battery run off a non-PR ref. Rationale +
+history of the prior opt-in design:
+[docs/features/118-ci-cost-round-2.md](docs/features/118-ci-cost-round-2.md)
+and [215](docs/features/215-ci-label-gated-verify.md); current design:
+[docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md).
+```
+
+- [ ] **Step 6: Rewrite the "Working practice" first bullet**
+
+Find:
+
+```
+Working practice:
+
+- Before committing anything non-trivial, run `npm run verify` — same battery
+  as pre-push. Catching failures in the same turn beats catching them at
+  push time.
+- `npm run verify:fast` matches pre-commit; `npm run verify:quick` is `test:all` without typecheck/build/e2e.
+```
+
+Replace with:
+
+```
+Working practice:
+
+- Default loop for non-trivial work: finalize the change → run
+  `npm run verify:fast:branch` (same branch-scoped check pre-push now runs)
+  → open the PR → cloud `verify.yml` (required, opt-out) and the mandatory
+  code-review pass run independently → merge once both are green. Run the
+  full `npm run verify` manually only when you specifically want the full
+  local battery (e.g. before a release cut, or debugging something scope-
+  filtering might be hiding).
+- `npm run verify:fast` matches pre-commit; `npm run verify:quick` is `test:all` without typecheck/build/e2e.
+```
+
+- [ ] **Step 7: Fix two more stale "pre-push gate" references**
+
+Find (in the "Harnesses" test-tier list):
+
+```
+- Top-level `npm run test:all` runs the four unit/integration harnesses.
+  `npm run verify` adds typecheck + e2e + build on top (pre-push gate).
+```
+
+Replace with:
+
+```
+- Top-level `npm run test:all` runs the four unit/integration harnesses.
+  `npm run verify` adds typecheck + e2e + build on top (no longer the
+  pre-push default — see "Commit gate" — but still the full local battery
+  when you want to run it).
+```
+
+Find (in the "Before-shipping checklist", item 6):
+
+```
+6. **Run `npm run verify`** locally — same battery as pre-push. Catches typecheck + all tests + e2e + build in one shot.
+```
+
+Replace with:
+
+```
+6. **Run `npm run verify:fast:branch`** locally (same battery as pre-push) — or the full `npm run verify` if you want more than the branch-scoped subset. Cloud `verify.yml` is the required, authoritative gate either way (see "Commit gate").
+```
+
+- [ ] **Step 8: Validate every internal link still resolves**
+
+Run: `grep -c "verify-ci-rebalance-design.md" CLAUDE.md`
+Expected: `4` or more (confirms the new spec is now cross-linked from
+CLAUDE.md at least 4 places per the edits above — pre-push bullet, OPT-OUT
+paragraph ×2, Requesting-a-CI-run paragraph).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(docs): update CLAUDE.md for opt-out required CI + branch-scoped pre-push"
+```
+
+---
+
+### Task 6: `CONTRIBUTING.md` updates
+
+**Files:**
+- Modify: `CONTRIBUTING.md`
+
+- [ ] **Step 1: Rewrite the "Requesting a CI run" section**
+
+Find the entire section from `### Requesting a CI run (CI is opt-in)` through
+the `[docs/features/118-ci-cost-round-2.md]` reference line just before
+`### Merge policy`:
+
+```
+### Requesting a CI run (CI is opt-in)
+
+The `verify.yml` battery does **not** run automatically on PRs (plan 215). The
+pre-push husky hook already runs the full `npm run verify` battery on every
+push, so a per-PR cloud run is redundant spend on Actions minutes. Push freely
+— every PR push (draft or ready) bills **0 CI minutes** by default. When you
+want a clean-room cloud check (typically right before merge, or to sanity-check
+a change you couldn't fully verify locally):
+
+- add the **`run-ci`** label to the PR — fires one run, and re-runs on each new
+  push while the label stays on; **or**
+- dispatch it manually: Actions tab → Verify → Run workflow, or
+  `gh workflow run verify.yml --ref <branch>`.
+
+A labeled PR run is scope-filtered to the legs the diff touched (plan 103); a
+manual dispatch runs the full battery. What still runs automatically on its own:
+`pr-title-lint.yml` on every PR, `app.yml` on `apps/android/**` changes,
+`release.yml` on a `vX.Y.Z` tag, and `cross-os.yml` (macOS + Windows + mobile
+e2e) on its weekly cron + manual dispatch. **Every release tag runs the complete
+cross-platform battery before publishing** (full `npm run verify` + mobile e2e on
+Ubuntu, plus `verify:quick`+build on macOS and Windows — see `release.yml`), so
+cross-OS coverage for a release is automatic, not a manual pre-announce step.
+Rationale + measurements:
+[docs/features/215-ci-label-gated-verify.md](docs/features/215-ci-label-gated-verify.md),
+[docs/features/118-ci-cost-round-2.md](docs/features/118-ci-cost-round-2.md).
+```
+
+Replace with:
+
+```
+### Requesting a CI run (CI is opt-out and required)
+
+The `verify.yml` battery runs automatically on every PR push and is a
+**required status check** on `main` — it must go green before merge. This
+replaced the prior label-gated opt-in design (plan 215) now that the repo is
+public and standard-runner Actions minutes are free/uncapped; local pre-push
+now only runs a fast, branch-scoped subset (`verify:fast:branch`), so the
+cloud run is the actual enforcement gate, not optional insurance. Dispatch
+it manually (Actions tab → Verify → Run workflow, or `gh workflow run
+verify.yml --ref <branch>`) only when you want an unscoped, full-battery run
+off a non-PR ref.
+
+Every PR run is still scope-filtered to the legs the diff touched (plan
+103); a manual dispatch runs the full battery. What still runs automatically
+on its own: `pr-title-lint.yml` on every PR, `app.yml` on `apps/android/**`
+changes, `release.yml` on a `vX.Y.Z` tag, and `cross-os.yml` (macOS +
+Windows + mobile e2e) on its **twice-weekly** (Wednesday + Sunday) cron +
+manual dispatch. **Every release tag runs the complete cross-platform
+battery before publishing** (full `npm run verify` + mobile e2e on Ubuntu,
+plus `verify:quick`+build on macOS and Windows — see `release.yml`), so
+cross-OS coverage for a release is automatic, not a manual pre-announce
+step. Rationale + history of the prior opt-in design:
+[docs/features/215-ci-label-gated-verify.md](docs/features/215-ci-label-gated-verify.md),
+[docs/features/118-ci-cost-round-2.md](docs/features/118-ci-cost-round-2.md);
+current design:
+[docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md).
+```
+
+- [ ] **Step 2: Update the cross-reference near "add the `run-ci` label"**
+
+Find (near line 128-133, in an earlier section referencing the CI-run
+section):
+
+```
+and only then (if you want a cloud check) add the **`run-ci`** label to the
+```
+
+Read the surrounding paragraph (a few lines before/after this fragment) to
+capture full context, then rewrite that sentence to remove the now-inaccurate
+"add the run-ci label" instruction — replace it with a sentence noting CI now
+runs automatically on every PR push, linking to
+`[§ Requesting a CI run](#requesting-a-ci-run-ci-is-opt-out-and-required)`
+(the anchor changes because the heading text changed in Step 1 — GitHub
+slugifies headings, so `### Requesting a CI run (CI is opt-out and
+required)` becomes `#requesting-a-ci-run-ci-is-opt-out-and-required`).
+
+- [ ] **Step 3: Update the "Server-side enforcement (branch protection)" paragraph**
+
+Find:
+
+```
+`main` has **server-side branch protection** as of 2026-06-14: a GitHub ruleset
+(`id 17654264`, `enforcement: active`) blocks force-push + deletion, enabled
+after the **GitHub Pro** upgrade (the feature 403'd on the old Free private
+plan). It **deliberately excludes required status checks** — so it stays
+compatible with opt-in CI (plan 215) and the doc-only `paths-ignore` skip
+without deadlocking PRs that never run `verify` — and adds no required-PR rule,
+so direct-to-`main` trivial fixes and tag-based releases keep working. The local
+`guard-protected-push.mjs` pre-push hook (plan 163) is now belt-and-suspenders.
+Enablement + the ruleset JSON live in `com-4` / `brand/ruleset-main.json`. The
+conventions above remain soft enforcement plus the `pr-title-lint.yml` workflow.
+```
+
+Replace with:
+
+```
+`main` has **server-side branch protection** as of 2026-06-14: a GitHub ruleset
+(`id 17654264`, `enforcement: active`) blocks force-push + deletion, enabled
+after the **GitHub Pro** upgrade (the feature 403'd on the old Free private
+plan). As of the verify/CI rebalance
+([docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md))
+the ruleset also **requires** the `npm run verify` status check (`verify.yml`'s
+job name) — this is safe against the doc-only-PR deadlock risk the prior
+design avoided by excluding required checks entirely, because `verify.yml` no
+longer has a `paths-ignore` that could prevent it from ever posting a status
+(see that spec for why). It still adds no required-PR-review rule, so
+direct-to-`main` trivial fixes and tag-based releases keep working. The local
+`guard-protected-push.mjs` pre-push hook (plan 163) is now belt-and-suspenders.
+Enablement + the ruleset JSON live in `com-4` / `brand/ruleset-main.json`. The
+conventions above remain soft enforcement plus the `pr-title-lint.yml` workflow.
+```
+
+- [ ] **Step 4: Update the "Doc-only PR fast-path" section**
+
+Find:
+
+```
+### Doc-only PR fast-path
+
+A PR whose changed-file set lives entirely under `docs/**`, root-level
+`*.md` (`README.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `CHANGELOG.md`), or
+`.github/*.md` (e.g. `.github/pull_request_template.md`) skips
+[`verify.yml`](.github/workflows/verify.yml) via `paths-ignore`.
+The PR still requires a valid title (`pr-title-lint.yml` runs on every
+PR) and GitHub's native `mergeable` status still surfaces conflicts —
+the gate stays "PR required + title valid + no conflicts", just without
+the 10–15 min full battery. Since plan 215 CI is opt-in for _every_ PR, this
+`paths-ignore` is now a second layer — it additionally ensures that even a
+`run-ci`-labeled PR whose files are all docs won't spin up the battery.
+Rationale and the exact glob list:
+[docs/features/archive/101-docs-only-ci-skip.md](docs/features/archive/101-docs-only-ci-skip.md).
+
+The same file-set test also skips the **local** pre-push `npm run verify`
+battery (`scripts/is-docs-only-push.mjs`, wired into `.husky/pre-push`) — a
+```
+
+Replace with:
+
+```
+### Doc-only PR fast-path
+
+A PR whose changed-file set lives entirely under `docs/**`, root-level
+`*.md` (`README.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `CHANGELOG.md`), or
+`.github/*.md` (e.g. `.github/pull_request_template.md`) still triggers
+[`verify.yml`](.github/workflows/verify.yml) (its `paths-ignore` was
+deliberately removed — see
+[docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md)
+for why: keeping it while the check is required would deadlock every
+docs-only PR forever). Every leg's own scope condition evaluates false for
+a docs-only diff, though, so the job completes in roughly the time of "Setup
+Node + deps" alone (~20-40s) and reports green — the gate stays "PR required
++ title valid + no conflicts + a fast green required check", not the 10-15
+min full battery. Rationale and the exact glob list for the underlying
+scope-matching (unrelated to the removed `paths-ignore`):
+[docs/features/archive/101-docs-only-ci-skip.md](docs/features/archive/101-docs-only-ci-skip.md).
+
+The same file-set test also skips the **local** pre-push
+`npm run verify:fast:branch` check (`scripts/is-docs-only-push.mjs`, wired
+into `.husky/pre-push`) — a
+```
+
+- [ ] **Step 5: Fix five more stale "pre-push gate" / "npm run verify" references**
+
+Find (in the `## TL;DR` list):
+
+```
+- `main` is always shippable. `npm run verify` is the pre-push gate.
+```
+
+Replace with:
+
+```
+- `main` is always shippable. `npm run verify:fast:branch` is the pre-push gate; cloud `verify.yml` is the required, authoritative gate.
+```
+
+Find (in "PR body", the `## Test plan` bullet):
+
+```
+2. **`## Test plan`** — checklist of what was run and what reviewers should
+   look at. Always start with `- [ ] npm run verify — green` (the pre-push
+   hook will fail your push if it isn't anyway).
+```
+
+Replace with:
+
+```
+2. **`## Test plan`** — checklist of what was run and what reviewers should
+   look at. Always start with `- [ ] npm run verify:fast:branch — green`
+   (the pre-push hook will fail your push if it isn't anyway) — cloud
+   `verify.yml` is the required, authoritative gate on top of that.
+```
+
+Find (in "Before requesting review"):
+
+```
+- `npm run verify` green locally (pre-push hook already enforces this).
+```
+
+Replace with:
+
+```
+- `npm run verify:fast:branch` green locally (pre-push hook already enforces this) — and the required cloud `verify.yml` check green on the PR.
+```
+
+Find (in the numbered pre-shipping checklist near the end of the file):
+
+```
+5. Run `npm run verify` locally.
+```
+
+Replace with:
+
+```
+5. Run `npm run verify:fast:branch` locally (pre-push already enforces it) — the required cloud `verify.yml` check covers the rest.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CONTRIBUTING.md
+git commit -m "docs(docs): update CONTRIBUTING.md for opt-out required CI"
+```
+
+---
+
+### Task 7: `docs/features/118`, `215`, `235` — superseded/cross-reference notes
+
+**Files:**
+- Modify: `docs/features/118-ci-cost-round-2.md`
+- Modify: `docs/features/215-ci-label-gated-verify.md`
+- Modify: `docs/features/235-model-routing-review-gates.md`
+
+- [ ] **Step 1: Add a superseded note to doc 118**
+
+Find (the frontmatter + header block):
+
+```
+---
+status: active
+shipped: null
+owner: null
+---
+
+# CI cost reduction — round 2 (run-count + test-impact selection)
+
+> Status: active
+> Key files: `.github/workflows/verify.yml`, `.github/workflows/pr-title-lint.yml`, `.github/workflows/release.yml`, `vitest.config.ts`, `CLAUDE.md`, `CONTRIBUTING.md`
+> URL surface: none (CI / process)
+> OpenAPI ops: none
+
+## Benefit / Rationale
+```
+
+Replace with:
+
+```
+---
+status: active
+shipped: null
+owner: null
+---
+
+# CI cost reduction — round 2 (run-count + test-impact selection)
+
+> Status: active
+> Key files: `.github/workflows/verify.yml`, `.github/workflows/pr-title-lint.yml`, `.github/workflows/release.yml`, `vitest.config.ts`, `CLAUDE.md`, `CONTRIBUTING.md`
+> URL surface: none (CI / process)
+> OpenAPI ops: none
+
+> **Update 2026-07-06:** the cost-minimization *posture* this doc describes
+> (opt-in CI, draft-PR batching to avoid billed runs) is superseded by
+> [docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](../superpowers/specs/2026-07-06-verify-ci-rebalance-design.md)
+> now that the repo is public — Actions minutes on standard runners are free
+> and uncapped, so CI flips from opt-in to opt-out and required. This doc's
+> test-impact-selection mechanism (`--changed <base>`) and its cost analysis
+> remain accurate history/rationale for why that mechanism exists; only the
+> "minimize run count" framing is stale.
+
+## Benefit / Rationale
+```
+
+- [ ] **Step 2: Add a superseded note to doc 215**
+
+Find:
+
+```
+---
+status: active
+shipped: null
+owner: null
+---
+
+# CI is opt-in — label-gated / dispatch-only verify
+
+> Status: active
+> Key files: `.github/workflows/verify.yml`, `CLAUDE.md`, `CONTRIBUTING.md`
+> URL surface: none (CI / process)
+> OpenAPI ops: none
+
+## Benefit / Rationale
+```
+
+Replace with:
+
+```
+---
+status: active
+shipped: null
+owner: null
+---
+
+# CI is opt-in — label-gated / dispatch-only verify
+
+> Status: active
+> Key files: `.github/workflows/verify.yml`, `CLAUDE.md`, `CONTRIBUTING.md`
+> URL surface: none (CI / process)
+> OpenAPI ops: none
+
+> **Update 2026-07-06:** superseded by
+> [docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](../superpowers/specs/2026-07-06-verify-ci-rebalance-design.md)
+> — the opt-in/label-gated design this doc describes flips to opt-out (CI
+> runs on every PR by default) and the check becomes required on `main`'s
+> ruleset, now that the repo is public and Actions minutes are free/uncapped
+> (the reason this doc's opt-in design existed no longer applies). This
+> doc's per-run cost-reduction mechanisms (scope-gated legs, one-job design)
+> remain in effect and accurate.
+
+## Benefit / Rationale
+```
+
+- [ ] **Step 3: Note the shared ruleset action in doc 235**
+
+Find (in the "Invariants to preserve" list):
+
+```
+3. `.github/workflows/pr-issue-link.yml`'s job `name:` field ("Verify PR body links a GitHub issue") is the exact string referenced by the required-status-check ruleset (Task 7 Step 8, the manual step) — renaming the job without updating the ruleset silently breaks the required-check binding.
+```
+
+Replace with:
+
+```
+3. `.github/workflows/pr-issue-link.yml`'s job `name:` field ("Verify PR body links a GitHub issue") is the exact string referenced by the required-status-check ruleset (Task 7 Step 8, the manual step) — renaming the job without updating the ruleset silently breaks the required-check binding.
+4. That same manual ruleset step now also needs to bind `verify.yml`'s `npm run verify` job name (see [docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](../superpowers/specs/2026-07-06-verify-ci-rebalance-design.md)) — do both required-check bindings in the same GitHub settings visit if convenient, but they're independent action items; this doc's Task 7 Step 8 landing does not depend on the other one landing, or vice versa.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/features/118-ci-cost-round-2.md docs/features/215-ci-label-gated-verify.md docs/features/235-model-routing-review-gates.md
+git commit -m "docs(docs): cross-reference the verify/CI rebalance spec from docs 118, 215, 235"
+```
+
+---
+
+### Task 8: Configure the required-status-check ruleset (MANUAL — orchestrator + user, not a subagent)
+
+**This task is NOT dispatched to a subagent.** It changes `main`'s branch
+protection — a shared, hard-to-reverse GitHub setting — so it must be done
+by the orchestrating session with the user present to confirm, exactly like
+the still-pending equivalent action for `pr-issue-link.yml` (doc 235, Task 7
+Step 8) has been treated. Do this only after Tasks 1-7 are merged to `main`
+(the ruleset should reference a check that's already running there).
+
+- [ ] **Step 1: Confirm current ruleset state**
+
+Run: `gh api repos/dudarenok-maker/Castwright/rulesets` and identify the
+ruleset covering `main` (per CONTRIBUTING.md, `id 17654264`). Read its
+current `rules` array to confirm it has no `required_status_checks` rule
+yet (matches the documented "deliberately excludes required checks" state).
+
+- [ ] **Step 2: Present the exact change to the user and get explicit go-ahead**
+
+State plainly: this will add a `required_status_checks` rule to ruleset
+`17654264` requiring the `npm run verify` check (the `verify.yml` job name)
+to pass before merge on `main`. Ask the user to confirm before proceeding —
+do not run Step 3 without an explicit yes in this session.
+
+- [ ] **Step 3: Apply the ruleset change**
+
+Once confirmed, use `gh api` (PATCH or PUT against
+`repos/dudarenok-maker/Castwright/rulesets/17654264`) to add a
+`required_status_checks` rule listing `npm run verify` as a required check
+(add `Verify PR body links a GitHub issue` too in the same call if the user
+wants doc 235's pending item bundled in — ask which they want per the plan's
+Task 8 framing, don't assume).
+
+- [ ] **Step 4: Verify**
+
+Open a throwaway test PR (or use the PR this plan's work will ship through)
+and confirm the `npm run verify` check now shows as required (GitHub's PR
+merge-box UI shows "Required" next to it, and the merge button stays
+disabled until it's green).
+
+- [ ] **Step 5: Update doc 235 if bundled**
+
+If Step 3 also bound `pr-issue-link.yml`'s check, update
+`docs/features/235-model-routing-review-gates.md`'s "Reversibility" bullet
+and Task 7 Step 8 references to say the ruleset step is now DONE, not
+pending. (If only `verify.yml` was bound this round, leave doc 235's
+pending-step language as-is — it's now handled by whichever task actually
+lands it.)
+
+---
+
+## Self-Review Notes (from the writing-plans skill's required self-check)
+
+**Spec coverage:** every numbered design section (§1-§6) of
+`docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md` maps to a
+task above: §1 (new default loop) → Task 5 Step 6 (Working practice
+rewrite); §2 (STEPS reclassification) → reflected in Task 1's step list and
+Task 3's new legs; §3 (CI trigger) → Task 3 + Task 8; §4 (pre-push +
+verify:fast:branch) → Tasks 1-2; §5 (cross-os cadence) → Task 4; §6 (what
+stays the same) → deliberately NOT touched by any task (pre-commit,
+commit-msg, code-review gate, `npm run verify` itself, `release.yml`,
+`test:golden-audio`). "Docs to update" → Tasks 5-7. "Risks/follow-ups" → the
+routine-server-push residual-contention risk and the local-`main`-staleness
+risk are accepted as documented tradeoffs, not additional tasks (the spec
+itself says they're open/accepted, not blockers).
+
+**Placeholder scan:** no TBD/TODO; every code block above is complete,
+copy-pasteable text, not a description of what to write.
+
+**Type/name consistency:** `branchDiffFiles(cwd)` (Task 1) is the exact name
+Task 1's own wiring step (Step 5) and test step (Step 1) both use — no
+naming drift. `verify:fast:branch` (Task 1 Step 7) is the exact script name
+Task 2 (pre-push), Task 5 (CLAUDE.md, 5 places), and Task 6 (CONTRIBUTING.md)
+all reference — checked for literal string match across every task above.
+
+**Completeness sweep:** ran `grep -n "npm run verify\b" CLAUDE.md
+CONTRIBUTING.md` against the finished task list and reconciled every hit —
+9 additional stale "pre-push gate"/"npm run verify" references beyond the
+ones the spec called out directly were found this way and folded into Task
+5 Step 7 and Task 6 Step 5. The remaining hits (cache-aware/lint-prepend
+paragraphs, `release.yml`'s own full-battery description, the deliberate
+full-`npm run verify` usage in parallel-agent integration-branch
+reconciliation) describe behavior that's still accurate and were
+deliberately left untouched — noted here so a reviewer doesn't have to
+re-derive why they're not in the task list.

--- a/docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md
+++ b/docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md
@@ -38,8 +38,12 @@ private-repo minute costs that no longer apply. Its rationale is stale.
 ## Goals
 
 - Local pre-push/pre-commit work stops running the heavy, contention-prone
-  legs (server/frontend integration suites, Playwright, build) as routine,
-  on-every-push behavior *when they're not relevant to the change*.
+  legs (server/frontend integration suites, Playwright, build)
+  *unconditionally on every push* — every step in the new local command is
+  scope-gated to whether the branch diff actually touches its own declared
+  inputs, the same uniform mechanism `--scope-staged` already uses for
+  pre-commit, just applied to a branch-level diff instead of a staged one.
+  Nothing is special-cased to "always run regardless of relevance."
 - Nothing loses **enforcement**: every cloud-safe leg still runs on every
   PR, in the cloud instead of locally, AND `verify.yml` becomes a **required
   status check** on `main` — so it actually blocks merge on red, closing the
@@ -47,19 +51,22 @@ private-repo minute costs that no longer apply. Its rationale is stale.
   (An earlier draft of this spec claimed cloud coverage alone was
   equivalent to today's local gate; adversarial review found that's false
   while `verify.yml` isn't required — see the design-doc history / PR
-  discussion for that correction.)
-- The local machine is reserved for what genuinely requires it: real
-  GPU/CUDA + the bootstrapped Python sidecar venv + actual model weights.
-  `test:golden-audio` and manual generation/model testing become
-  deliberate, on-demand, manual commands. `test:sidecar` is the one
-  exception that stays in the **automatic** local gate, but scope-gated —
-  it auto-runs in the new pre-push hook only when the branch diff actually
-  touches `server/tts-sidecar/**`, so it doesn't burden unrelated commits
-  but still catches sidecar regressions on the one path where the machine
-  is genuinely needed and the work is actually relevant. None of this runs
-  in the cloud (cloud runners can't load real models).
+  discussion for that correction. This action is required regardless of
+  whether the separately-pending `pr-issue-link.yml` required-check wiring
+  in doc 235 has happened yet — see §3.)
+- The local machine is reserved for what genuinely requires it: things CI
+  cannot do at all — real GPU/CUDA + actual model weights
+  (`test:golden-audio`, manual generation/model testing) — and things CI
+  merely doesn't have set up (the bootstrapped Python sidecar venv/deps,
+  `test:sidecar`). These stay local; only `test:golden-audio` and manual
+  model work are fully manual-only. `test:sidecar` itself is **model-free**
+  (`-m "not golden"`) — it's local because CI has no bootstrapped venv, not
+  because it needs a GPU — and rejoins the automatic local gate like every
+  other step, scope-gated to its own real inputs (§4). None of this runs in
+  the cloud.
 - CI flips from opt-in (`run-ci` label / manual dispatch) to opt-out
-  (runs by default on every PR; docs-only PRs stay exempt, same as today).
+  (runs by default on every PR, including docs-only — see §3 for why
+  docs-only can't stay exempt once the check is required).
 
 ## Non-goals
 
@@ -85,9 +92,11 @@ code-review subagent is dispatched in parallel → merge once both are green.
 ### 2. STEPS reclassification
 
 Audited every step in `scripts/verify-cache.mjs`'s `STEPS` array against
-whether it needs this machine's actual hardware (GPU + bootstrapped
-sidecar venv + real model weights) or can run on a stock GitHub-hosted
-runner:
+whether it needs something a stock GitHub-hosted runner doesn't have —
+either the bootstrapped Python sidecar venv/deps (`test:sidecar`) or real
+GPU/CUDA + actual model weights (`test:golden-audio`, not itself a `STEPS`
+entry) — versus everything else, which is plain Node/TS/Python-mock work
+any runner can do:
 
 | Step | Cloud-safe? | Notes |
 |---|---|---|
@@ -100,7 +109,7 @@ runner:
 | test:server | yes | already cloud (`--changed` narrowed), unchanged |
 | test:server-slow | yes | already cloud, unchanged |
 | test:scripts (Pester) | yes | already cloud (ubuntu has pwsh), unchanged |
-| test:sidecar | **no** (local-only, auto) | needs the bootstrapped venv + real model weights. **There is no `test:sidecar` step in `verify.yml` today at all** — cloud coverage has always been zero, not "skipped." Stays out of the cloud workflow, but rejoins the local automatic gate scope-gated (§4) |
+| test:sidecar | **no** (local-only, auto) | needs the bootstrapped Python venv/deps CI doesn't have — **not** real model weights (it runs `-m "not golden"`, explicitly model-free). **There is no `test:sidecar` step in `verify.yml` today at all** — cloud coverage has always been zero, not "skipped." Stays out of the cloud workflow, but rejoins the local automatic gate scope-gated to its own real inputs, same as every other step (§4) |
 | test:e2e | yes | already cloud, unchanged |
 | test:e2e:visual | yes | already cloud, unchanged |
 | build | yes | already cloud, unchanged |
@@ -129,17 +138,33 @@ so it only fires when relevant (§4).
 - Drop the `labeled` event and the `run-ci` label requirement from the job
   `if:` gate — the workflow runs on every `pull_request` (opened,
   synchronize, reopened, ready_for_review) by default.
-- Keep the existing `paths-ignore` docs-only fast-path and the per-scope
-  `if:` gating on each leg (still worth skipping legs a PR didn't touch —
-  now framed as "don't run tests that can't fail," not "save money").
+- **Drop the `paths-ignore: [docs/**, *.md, .github/*.md]` block entirely.**
+  Keeping it while also making this a required status check would deadlock
+  every docs-only PR: `verify.yml`'s own header explains branch protection
+  today *deliberately* excludes it as required specifically so doc-only PRs
+  "can't deadlock" against a check that never fires. Once required, the
+  workflow must always trigger. This isn't a new cost, though: the existing
+  per-leg scope `if:` gating already makes every leg's condition false for
+  a genuinely docs-only diff (none of `frontend`/`server`/`sidecar`/`e2e`/
+  `scripts`/`hooks`/`pinokio` match a docs-only file set), so the job still
+  completes in roughly the time of "Setup Node + deps" alone (~20-40s) and
+  reports green — no deadlock, negligible added time, no new logic needed.
+- Keep the per-scope `if:` gating on each leg otherwise (still worth
+  skipping legs a PR didn't touch — now framed as "don't run tests that
+  can't fail," not "save money").
 - **Add its check as a required status check** in `main`'s branch-protection
   ruleset. This is the load-bearing change: without it, cloud verify running
   on every PR is only *advisory* — mergeable-past on red — which is a net
   enforcement regression versus today's push-refusing local pre-push. This
-  is a one-time, manual GitHub settings action (same category as the
-  pending `pr-issue-link.yml` required-check wiring already noted in
-  `docs/features/235-model-routing-review-gates.md` — bundle both into the
-  same ruleset-setup step rather than doing it twice).
+  is a one-time, manual GitHub settings action that must happen as part of
+  implementing this spec, **independently of** whether the separately
+  pending `pr-issue-link.yml` required-check wiring
+  (`docs/features/235-model-routing-review-gates.md`) has landed yet — do
+  the ruleset edit for both checks together if 235's wiring happens to be
+  done at the same time, but don't make this spec's completion contingent
+  on that other item finally landing (it's been pending independently;
+  treat them as two separate action items that happen to touch the same
+  GitHub settings page).
 - Add a `pinokio` key to the scope-detection step. Match both the test
   files and the runner script, not just the directory: `match
   '^(pinokio/|scripts/run-pinokio-tests\.mjs$)'` — the plain `^pinokio/`
@@ -180,20 +205,30 @@ New npm script:
 "verify:fast:branch": "node scripts/verify-cache.mjs --steps lint,typecheck,config:check,test:hooks,test,test:server,build,test:sidecar --scope-branch"
 ```
 
-`test:sidecar` is in this list, but — unlike every other step here — it
-should remain scope-gated to fire **only** when the branch diff touches
-`server/tts-sidecar/**`, even though `--scope-branch` is otherwise just a
-speed/diff-basis choice, not an exclusion mechanism. Concretely: pass it
-through the same `stepTouchedByDiff` scope check that `--scope-staged`
-already uses (verify-cache.mjs:391-399) — `test:sidecar` runs only when
-its own step-scope (`server/tts-sidecar/**`) intersects the branch diff;
-every other step in the list still always runs (they're fast/CPU-only, no
-reason to skip them for speed). This is the one place local pre-push does
-real, unconditional model/venv work — deliberately, since that's the
-"machine reserved for what needs it" case (§ Goals) — and it runs
-automatically (not just a reminder) because a silently-skipped sidecar
-regression on the one branch that's actively touching sidecar code is a
-worse outcome than the extra local runtime when it fires.
+`--scope-branch` applies the **same uniform per-step scope filter**
+`--scope-staged` already applies today (verify-cache.mjs's main loop
+checks `stepTouchedByDiff(step, scopeDiff)` for every step in the active
+list, not a hand-picked subset — see `runPipeline`'s loop). No special-
+casing: `test:sidecar` isn't treated differently from `test:server` or
+`build` in the mechanism, it just happens to have narrower globs
+(`server/tts-sidecar/**/*.py`, `requirements*.txt`, `run-tests.ps1` — its
+own already-declared `STEPS` entry, reused as-is, not a new
+`server/tts-sidecar/**` match invented for this spec) so it fires less
+often in practice. `test:server`/`build`/`test` are scope-gated by their
+own existing globs (`server/src/**`, `src/** + server/src/**`, `src/**`
+respectively) exactly the same way — an earlier draft of this spec
+incorrectly described them as "always run regardless of relevance," which
+would have defeated the point of the whole redesign (`test:server` is one
+of only two `RETRIABLE_POOL_STEPS`, i.e. the exact fork-pool-crash-prone
+leg the Problem section is about). `lint`/`typecheck`/`test:hooks`/
+`config:check` have broad-enough globs that they'll still fire on nearly
+every code PR — that's expected and fine, they're cheap.
+
+This means on a branch that touches `server/tts-sidecar/**`, `test:sidecar`
+auto-runs and blocks the push on failure — real, automatic local coverage
+on the one path where the machine is genuinely relevant — without any new
+selective-gating logic beyond what the existing scope-filter engine
+already does for `--scope-staged`.
 
 This single command serves two purposes with no duplication:
 
@@ -216,11 +251,17 @@ discipline):** `scripts/tests/verify-cache.test.mjs`'s existing `parseFlags`
 tests assert an exact `deepEqual` against today's return shape
 (`{ noCache, steps, scopeStaged }`); adding a `scopeBranch` field breaks
 every one of them and must be updated in the same change, not left for CI
-to discover. The new `--scope-branch` diff path (`git merge-base HEAD
-main` → `git diff --name-only`) and the `test:sidecar`-only scope
-exclusion inside a `--scope-branch` run are both new behavior with zero
-existing coverage — both need new test cases, mirroring how
-`stagedDiffFiles`/`--scope-staged` are already tested.
+to discover. The new `git merge-base HEAD main` → `git diff --name-only`
+logic has no equivalent to mirror: `stagedDiffFiles` (the `--scope-staged`
+counterpart) isn't exported and isn't unit-tested today — only the pure
+predicates `stepTouchedByDiff`/`computeShared` are, and `runPipeline`
+itself is explicitly documented as exercised by manual walkthrough, not
+unit tests. Don't assert test parity that doesn't exist: the new function
+(name it e.g. `branchDiffFiles`) should be **exported** specifically so it
+can be unit-tested directly (with `cwd` pointed at a throwaway git repo
+fixture, or by injecting a `spawnSync`-like seam), closing a gap that
+`stagedDiffFiles` itself still has rather than just matching its
+(non-)existing coverage.
 
 `.husky/pre-commit` (`npm run verify:fast:scoped`, staged-diff based) is
 unchanged — it's already fast/scoped and wasn't implicated in the waste.
@@ -257,9 +298,11 @@ to twice weekly: add Wednesday 02:00 UTC alongside the existing Sunday
   opt-in design existed while the repo was private).
 - `docs/features/235-model-routing-review-gates.md`: this already documents
   a pending, one-time required-status-check ruleset setup for
-  `pr-issue-link.yml`. Update it to also cover `verify.yml` in the same
-  ruleset action (§3), so the manual setup step is done once for both
-  rather than as two separate asks of the user.
+  `pr-issue-link.yml`. Note that `verify.yml` also needs the same
+  ruleset-required treatment (§3) — do both in one GitHub settings visit if
+  235's item happens to still be open at the same time, but treat them as
+  independent action items rather than coupling this spec's completion to
+  235's.
 - `feedback_ci_cost_shipping_practice` memory: update once implemented —
   the draft-PR-to-save-minutes rationale is retired (repo is public, cost
   is no longer the reason); note whether the draft-PR practice itself is
@@ -286,8 +329,16 @@ to twice weekly: add Wednesday 02:00 UTC alongside the existing Sunday
 - The `main` branch-protection ruleset change (§3) is a manual, one-time
   GitHub settings action this spec's file changes cannot perform by
   themselves — implementation must call this out explicitly rather than
-  quietly assume it's done as a side effect of merging code.
+  quietly assume it's done as a side effect of merging code. It's
+  deliberately treated as its own action item, not contingent on doc 235's
+  separate (still-pending) `pr-issue-link.yml` wiring actually landing.
 - `scripts/tests/verify-cache.test.mjs` needs updating in the same change
   as the `--scope-branch`/`scopeBranch` work (see §4) — flagged here again
   since a plan that treats this as a follow-up rather than in-scope would
-  violate CLAUDE.md's testing discipline.
+  violate CLAUDE.md's testing discipline. The new diff-listing function
+  needs to be exported and directly unit-tested (§4) rather than assumed
+  covered by analogy to `stagedDiffFiles`, which has no such test itself.
+- Dropping `verify.yml`'s `paths-ignore` (§3) means every docs-only PR now
+  spins up the workflow (env setup only, ~20-40s) instead of never
+  triggering — a deliberate, confirmed tradeoff to avoid the required-check
+  deadlock, not an oversight.

--- a/docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md
+++ b/docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md
@@ -12,17 +12,23 @@ test:hooks, test:pinokio, test, test:server, test:server-slow, test:scripts,
 test:sidecar, test:e2e, test:e2e:visual, build) locally on every push, per
 the current `.husky/pre-push` hook, wasted 2-3 hours in a single day this
 week. The user confirmed no external workload (e.g. a generation run) was
-competing — verify was contending with itself. The most likely mechanism:
-the current branch's changes touched sidecar/server code (side-11 work), so
-`test:sidecar` and `test:server*` re-ran (their cached input hash changed),
-and a killed/timed-out attempt leaves orphaned vitest/Playwright/pytest
-child processes behind (documented already in
-`feedback_merge_via_ci_when_gpu_throttles_local_verify` memory); each retry
-then contends with the prior attempt's zombies, compounding until a
-different step fails each time and the whole thing crawls. This spec does
-not chase that zombie-process bug directly — it removes the underlying
-reason to run the heavy battery locally at all, which makes the failure
-mode moot for routine work.
+competing — verify was contending with itself, with different steps failing
+across retries and the whole run getting progressively slower.
+
+**The exact mechanism is not fully pinned down, and this spec does not
+depend on it being.** A candidate explanation (self-contention from the
+battery's own heavy fork-pool/Playwright/pytest concurrency, possibly
+compounded by orphaned child processes left behind by a prior killed/
+timed-out attempt) is plausible but only partially evidenced — the
+documented zombie-process precedent (`feedback_merge_via_ci_when_gpu_
+throttles_local_verify` memory) describes that mechanism specifically under
+an *active competing GPU generation*, which the user says wasn't the case
+here. Rather than chase the exact cause, this spec removes the reason to
+run the heavy battery locally **at all** for routine work, which makes
+whatever the mechanism was moot for that path. It does NOT resolve
+contention for the one path that still runs heavy local work on purpose
+(scope-gated sidecar testing, §4) — that remains a real, open risk (see
+Risks).
 
 Separately: the repo went public (`castwright.ai` live). GitHub-hosted
 Actions runners are free and uncapped for public repos. The current
@@ -32,24 +38,36 @@ private-repo minute costs that no longer apply. Its rationale is stale.
 ## Goals
 
 - Local pre-push/pre-commit work stops running the heavy, contention-prone
-  legs (server/frontend integration suites, Playwright, sidecar pytest,
-  build) as routine, on-every-push behavior.
-- Nothing loses coverage: every leg that's cloud-safe still runs on every
-  PR, just in the cloud instead of locally.
+  legs (server/frontend integration suites, Playwright, build) as routine,
+  on-every-push behavior *when they're not relevant to the change*.
+- Nothing loses **enforcement**: every cloud-safe leg still runs on every
+  PR, in the cloud instead of locally, AND `verify.yml` becomes a **required
+  status check** on `main` — so it actually blocks merge on red, closing the
+  gap where today's local pre-push is the only thing that refuses a push.
+  (An earlier draft of this spec claimed cloud coverage alone was
+  equivalent to today's local gate; adversarial review found that's false
+  while `verify.yml` isn't required — see the design-doc history / PR
+  discussion for that correction.)
 - The local machine is reserved for what genuinely requires it: real
-  GPU/CUDA + the bootstrapped Python sidecar venv + actual model weights
-  (`test:sidecar`, `test:golden-audio`, manual generation/model testing).
-  These become deliberate, on-demand, manual commands — never triggered
-  automatically by routine commits/pushes on unrelated work, in EITHER
-  local hooks or cloud CI (cloud runners can't load models either).
+  GPU/CUDA + the bootstrapped Python sidecar venv + actual model weights.
+  `test:golden-audio` and manual generation/model testing become
+  deliberate, on-demand, manual commands. `test:sidecar` is the one
+  exception that stays in the **automatic** local gate, but scope-gated —
+  it auto-runs in the new pre-push hook only when the branch diff actually
+  touches `server/tts-sidecar/**`, so it doesn't burden unrelated commits
+  but still catches sidecar regressions on the one path where the machine
+  is genuinely needed and the work is actually relevant. None of this runs
+  in the cloud (cloud runners can't load real models).
 - CI flips from opt-in (`run-ci` label / manual dispatch) to opt-out
   (runs by default on every PR; docs-only PRs stay exempt, same as today).
 
 ## Non-goals
 
-- Not fixing the orphaned-child-process bug directly (no longer load-bearing
-  once the heavy battery isn't run routinely; can be a separate follow-up if
-  it recurs during genuine local sidecar work).
+- Not fixing a specific orphaned-child-process bug directly — its existence
+  as *the* cause here isn't confirmed (see Problem). It remains a real,
+  open risk specifically for the one path that still runs heavy local work
+  on purpose (scope-gated `test:sidecar`, §4) — flagged in Risks, not
+  resolved by this spec.
 - Not changing the mandatory code-review gate, PR-issue-link gate, or
   commit-msg validation — those are unaffected.
 - Not touching `test:golden-audio` mechanics — it's already opt-in/manual
@@ -82,23 +100,29 @@ runner:
 | test:server | yes | already cloud (`--changed` narrowed), unchanged |
 | test:server-slow | yes | already cloud, unchanged |
 | test:scripts (Pester) | yes | already cloud (ubuntu has pwsh), unchanged |
-| test:sidecar | **no** | needs the bootstrapped venv + real model weights; CI already skips it today (venv absent) — this was already silently zero-coverage in the cloud |
+| test:sidecar | **no** (local-only, auto) | needs the bootstrapped venv + real model weights. **There is no `test:sidecar` step in `verify.yml` today at all** — cloud coverage has always been zero, not "skipped." Stays out of the cloud workflow, but rejoins the local automatic gate scope-gated (§4) |
 | test:e2e | yes | already cloud, unchanged |
 | test:e2e:visual | yes | already cloud, unchanged |
 | build | yes | already cloud, unchanged |
-| test:golden-audio | **no** | not in STEPS today (already separate opt-in command); stays manual-only |
+| test:golden-audio | **no** (manual-only) | not in STEPS today (already separate opt-in command); stays manual-only, never auto-triggered anywhere |
 
 Two gaps found: `config:check` and `test:pinokio` are cloud-safe but are
 **not currently in `verify.yml` at all** — they only ever ran via the local
 full `npm run verify`. Once pre-push stops running that, they'd silently
-lose all coverage unless added to the cloud workflow. This spec adds them.
+lose all coverage unless added to the cloud workflow. This spec adds them
+(§3), with scope-matcher fixes for both (§3) since the obvious matches
+turned out to miss real inputs.
 
-`test:sidecar` was already effectively cloud-uncovered (CI's venv isn't
-bootstrapped, so it would skip-with-banner even if invoked) — formalizing
-it as local-manual-only changes nothing about actual coverage, just removes
-the illusion that it was part of the automatic gate.
+On this dev box specifically, the sidecar venv is bootstrapped, so today's
+local pre-push actually runs all of `test:sidecar`'s pytest files on **every
+push**, regardless of whether the push touches sidecar code. Simply
+dropping it to a fully-manual command (as an earlier draft of this spec
+did) would be a real regression on the one path most relevant to current
+work (the side-11 sidecar branch) — nobody would remember to run it by
+hand consistently. Instead it rejoins the automatic local gate, scope-gated
+so it only fires when relevant (§4).
 
-### 3. CI trigger: opt-in → opt-out
+### 3. CI trigger: opt-in → opt-out, and made a real gate
 
 `.github/workflows/verify.yml`:
 
@@ -108,12 +132,35 @@ the illusion that it was part of the automatic gate.
 - Keep the existing `paths-ignore` docs-only fast-path and the per-scope
   `if:` gating on each leg (still worth skipping legs a PR didn't touch —
   now framed as "don't run tests that can't fail," not "save money").
-- Add a `pinokio` key to the scope-detection step (`match '^pinokio/'`) and
-  a `Config check` step (`npm run config:check`, gated on
-  `server == 'true' || shared == 'true'`) and a `Pinokio tests` step
-  (`npm run test:pinokio`, gated on `pinokio == 'true' || shared == 'true'`).
+- **Add its check as a required status check** in `main`'s branch-protection
+  ruleset. This is the load-bearing change: without it, cloud verify running
+  on every PR is only *advisory* — mergeable-past on red — which is a net
+  enforcement regression versus today's push-refusing local pre-push. This
+  is a one-time, manual GitHub settings action (same category as the
+  pending `pr-issue-link.yml` required-check wiring already noted in
+  `docs/features/235-model-routing-review-gates.md` — bundle both into the
+  same ruleset-setup step rather than doing it twice).
+- Add a `pinokio` key to the scope-detection step. Match both the test
+  files and the runner script, not just the directory: `match
+  '^(pinokio/|scripts/run-pinokio-tests\.mjs$)'` — the plain `^pinokio/`
+  match alone misses a runner-only edit, since `test:pinokio`'s actual
+  `extraFiles` entry (`scripts/run-pinokio-tests.mjs`) lives outside
+  `pinokio/`.
+- Add a `Config check` step (`npm run config:check`) gated on
+  `server == 'true' || shared == 'true'`, **and widen the `server` scope
+  match** to also catch `config:check`'s real inputs that fall outside the
+  current regex: `server/.env.example` and
+  `server/scripts/sync-env-example.ts`. Today's `server` matcher
+  (`^(server/src/|server/package(-lock)?\.json$|server/tsconfig\.json$|
+  server/vitest\.config(\.slow)?\.ts$|openapi\.yaml$)`) doesn't cover
+  either — a direct edit to `.env.example` (exactly the drift this guard
+  exists to catch) would silently never trigger it. New matcher: add
+  `|server/\.env\.example$|server/scripts/sync-env-example\.ts$` to the
+  existing alternation.
+- Add a `Pinokio tests` step (`npm run test:pinokio`), gated on
+  `pinokio == 'true' || shared == 'true'`.
 - Comment/header text describing "OPT-IN" gets rewritten to describe the
-  new opt-out default and why (public repo, free runners).
+  new opt-out-and-required default and why (public repo, free runners).
 
 ### 4. Pre-push hook trim + new `verify:fast:branch`
 
@@ -130,8 +177,23 @@ existing tolerant-on-uncertainty behavior for `--scope-staged`.
 New npm script:
 
 ```
-"verify:fast:branch": "node scripts/verify-cache.mjs --steps lint,typecheck,config:check,test:hooks,test,test:server,build --scope-branch"
+"verify:fast:branch": "node scripts/verify-cache.mjs --steps lint,typecheck,config:check,test:hooks,test,test:server,build,test:sidecar --scope-branch"
 ```
+
+`test:sidecar` is in this list, but — unlike every other step here — it
+should remain scope-gated to fire **only** when the branch diff touches
+`server/tts-sidecar/**`, even though `--scope-branch` is otherwise just a
+speed/diff-basis choice, not an exclusion mechanism. Concretely: pass it
+through the same `stepTouchedByDiff` scope check that `--scope-staged`
+already uses (verify-cache.mjs:391-399) — `test:sidecar` runs only when
+its own step-scope (`server/tts-sidecar/**`) intersects the branch diff;
+every other step in the list still always runs (they're fast/CPU-only, no
+reason to skip them for speed). This is the one place local pre-push does
+real, unconditional model/venv work — deliberately, since that's the
+"machine reserved for what needs it" case (§ Goals) — and it runs
+automatically (not just a reminder) because a silently-skipped sidecar
+regression on the one branch that's actively touching sidecar code is a
+worse outcome than the extra local runtime when it fires.
 
 This single command serves two purposes with no duplication:
 
@@ -145,9 +207,20 @@ This single command serves two purposes with no duplication:
 `npm run verify:fast:branch`, after the existing guard scripts
 (`guard-protected-push`, `guard-commit-subjects`, `is-docs-only-push`),
 unchanged. Drops entirely from local pre-push: `test:pinokio`,
-`test:server-slow`, `test:scripts`, `test:sidecar`, `test:e2e`,
-`test:e2e:visual` — all now covered by cloud verify per §3 (or, for
-`test:sidecar`, intentionally left manual-only per §2).
+`test:server-slow`, `test:scripts`, `test:e2e`, `test:e2e:visual` — all now
+covered by cloud verify per §3. `test:golden-audio` stays fully manual,
+never in this list.
+
+**Implementation note (test-coverage obligation, per CLAUDE.md's testing
+discipline):** `scripts/tests/verify-cache.test.mjs`'s existing `parseFlags`
+tests assert an exact `deepEqual` against today's return shape
+(`{ noCache, steps, scopeStaged }`); adding a `scopeBranch` field breaks
+every one of them and must be updated in the same change, not left for CI
+to discover. The new `--scope-branch` diff path (`git merge-base HEAD
+main` → `git diff --name-only`) and the `test:sidecar`-only scope
+exclusion inside a `--scope-branch` run are both new behavior with zero
+existing coverage — both need new test cases, mirroring how
+`stagedDiffFiles`/`--scope-staged` are already tested.
 
 `.husky/pre-commit` (`npm run verify:fast:scoped`, staged-diff based) is
 unchanged — it's already fast/scoped and wasn't implicated in the waste.
@@ -182,6 +255,11 @@ to twice weekly: add Wednesday 02:00 UTC alongside the existing Sunday
   `docs/features/215-ci-label-gated-verify.md`: add a superseded/updated
   note pointing at this spec, don't delete (historical record of why the
   opt-in design existed while the repo was private).
+- `docs/features/235-model-routing-review-gates.md`: this already documents
+  a pending, one-time required-status-check ruleset setup for
+  `pr-issue-link.yml`. Update it to also cover `verify.yml` in the same
+  ruleset action (§3), so the manual setup step is done once for both
+  rather than as two separate asks of the user.
 - `feedback_ci_cost_shipping_practice` memory: update once implemented —
   the draft-PR-to-save-minutes rationale is retired (repo is public, cost
   is no longer the reason); note whether the draft-PR practice itself is
@@ -189,12 +267,27 @@ to twice weekly: add Wednesday 02:00 UTC alongside the existing Sunday
 
 ## Risks / follow-ups
 
-- If the zombie-process contention bug recurs during genuine local
-  `test:sidecar`/manual generation work (the one case still run locally),
-  it isn't fixed by this spec — only made rare (routine commits no longer
-  trigger it). A follow-up cleanup-on-kill fix may still be worth doing
-  separately if it bites again.
+- **Open, not resolved by this spec:** if the (unconfirmed) self-contention
+  mechanism recurs specifically during scope-gated local `test:sidecar` runs
+  or manual generation/model work — the one case that still does real local
+  work automatically — it isn't fixed here. A follow-up cleanup-on-kill fix
+  (or actually root-causing the original 2-3h/day incident, which this spec
+  deliberately did not chase) may still be worth doing if it bites again on
+  that path.
 - `verify:fast:branch`'s `--scope-branch` diffs against local `main`, not
   `origin/main` — assumes the developer's local `main` is reasonably
-  current. Acceptable for a pre-push speed check (cloud verify is the real
-  gate); flagged here rather than silently assumed.
+  current. This is a materially bigger deal now than an earlier draft
+  treated it: with `verify.yml` required (§3) covering the branch's actual
+  diff on the PR side, the local pre-push's job is narrower (fast smoke +
+  scope-gated sidecar), so an under-approximated local scope mostly just
+  means the cloud gate catches it instead — acceptable, but worth being
+  explicit that local pre-push is deliberately not the last line of defense
+  anymore, `verify.yml`-as-required-check is.
+- The `main` branch-protection ruleset change (§3) is a manual, one-time
+  GitHub settings action this spec's file changes cannot perform by
+  themselves — implementation must call this out explicitly rather than
+  quietly assume it's done as a side effect of merging code.
+- `scripts/tests/verify-cache.test.mjs` needs updating in the same change
+  as the `--scope-branch`/`scopeBranch` work (see §4) — flagged here again
+  since a plan that treats this as a follow-up rather than in-scope would
+  violate CLAUDE.md's testing discipline.

--- a/docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md
+++ b/docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md
@@ -197,7 +197,15 @@ every commit on the current branch since it diverged from local `main`.
 This is the right basis for a pre-push-time check, where "staged" is
 usually empty or meaningless (commits already exist). Falls back to
 running everything if the merge-base/diff git calls fail, mirroring the
-existing tolerant-on-uncertainty behavior for `--scope-staged`.
+existing tolerant-on-uncertainty behavior for `--scope-staged`. Distinct
+from that failure case: a **successful** merge-base diff that comes back
+*empty* (branch fully merged into local `main`, run directly on `main`, or
+a branch with no commits yet) must NOT be treated the same as "git
+failed" — it's a legitimate zero-file diff, and the existing scope-filter
+semantics would correctly skip every step for it. That's fine given
+`verify.yml` is now the required backstop (§3), but it should be a
+deliberate, documented behavior of `branchDiffFiles`, not an accidental
+side effect an implementer discovers later.
 
 New npm script:
 
@@ -220,9 +228,13 @@ respectively) exactly the same way — an earlier draft of this spec
 incorrectly described them as "always run regardless of relevance," which
 would have defeated the point of the whole redesign (`test:server` is one
 of only two `RETRIABLE_POOL_STEPS`, i.e. the exact fork-pool-crash-prone
-leg the Problem section is about). `lint`/`typecheck`/`test:hooks`/
-`config:check` have broad-enough globs that they'll still fire on nearly
-every code PR — that's expected and fine, they're cheap.
+leg the Problem section is about). Of the remaining steps, `lint` (`**/*.
+{ts,tsx,js,jsx,cjs,mjs}`) and `typecheck` (`src/**`, `server/src/**`) have
+broad-enough globs that they'll fire on nearly every code PR — that's
+expected and fine, they're cheap. `test:hooks` and `config:check` are
+actually narrow (`scripts/tests/*.test.mjs` / `.husky`+validator, and
+`server/src/config/*.ts` + the two extraFiles respectively) and correctly
+skip on PRs outside their scope — narrow-but-correct, not "broad."
 
 This means on a branch that touches `server/tts-sidecar/**`, `test:sidecar`
 auto-runs and blocks the push on failure — real, automatic local coverage
@@ -317,6 +329,19 @@ to twice weekly: add Wednesday 02:00 UTC alongside the existing Sunday
   (or actually root-causing the original 2-3h/day incident, which this spec
   deliberately did not chase) may still be worth doing if it bites again on
   that path.
+- **Also open, narrower than the above:** on any server- or full-stack-
+  touching branch (not just sidecar work), `verify:fast:branch` still runs
+  `test:server` — one of only two `RETRIABLE_POOL_STEPS`, i.e. the exact
+  fork-pool-crash-prone leg named in the Problem section — plus `test` and
+  `build`, whenever that branch's diff actually touches their scopes (which
+  is the common case for backend/full-stack work). Scope-gating removes
+  these from *irrelevant* pushes, and the steps run sequentially rather
+  than concurrently, so the residual load per push is real but smaller
+  than today's full parallel battery — but this spec does not claim, and
+  should not be read as claiming, that a routine server-touching push can
+  no longer reproduce any version of the original contention. If the
+  incident recurs there, that's a signal to revisit this leg specifically,
+  not evidence the whole redesign failed.
 - `verify:fast:branch`'s `--scope-branch` diffs against local `main`, not
   `origin/main` — assumes the developer's local `main` is reasonably
   current. This is a materially bigger deal now than an earlier draft

--- a/docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md
+++ b/docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md
@@ -1,0 +1,200 @@
+---
+status: draft
+date: 2026-07-06
+---
+
+# Verify / CI rebalance: cloud-first gating, machine reserved for model-bound work
+
+## Problem
+
+Running `npm run verify` (the full battery: lint, typecheck, config:check,
+test:hooks, test:pinokio, test, test:server, test:server-slow, test:scripts,
+test:sidecar, test:e2e, test:e2e:visual, build) locally on every push, per
+the current `.husky/pre-push` hook, wasted 2-3 hours in a single day this
+week. The user confirmed no external workload (e.g. a generation run) was
+competing — verify was contending with itself. The most likely mechanism:
+the current branch's changes touched sidecar/server code (side-11 work), so
+`test:sidecar` and `test:server*` re-ran (their cached input hash changed),
+and a killed/timed-out attempt leaves orphaned vitest/Playwright/pytest
+child processes behind (documented already in
+`feedback_merge_via_ci_when_gpu_throttles_local_verify` memory); each retry
+then contends with the prior attempt's zombies, compounding until a
+different step fails each time and the whole thing crawls. This spec does
+not chase that zombie-process bug directly — it removes the underlying
+reason to run the heavy battery locally at all, which makes the failure
+mode moot for routine work.
+
+Separately: the repo went public (`castwright.ai` live). GitHub-hosted
+Actions runners are free and uncapped for public repos. The current
+"CI is opt-in, minimize runs" design (plans 103, 118, 215) was built around
+private-repo minute costs that no longer apply. Its rationale is stale.
+
+## Goals
+
+- Local pre-push/pre-commit work stops running the heavy, contention-prone
+  legs (server/frontend integration suites, Playwright, sidecar pytest,
+  build) as routine, on-every-push behavior.
+- Nothing loses coverage: every leg that's cloud-safe still runs on every
+  PR, just in the cloud instead of locally.
+- The local machine is reserved for what genuinely requires it: real
+  GPU/CUDA + the bootstrapped Python sidecar venv + actual model weights
+  (`test:sidecar`, `test:golden-audio`, manual generation/model testing).
+  These become deliberate, on-demand, manual commands — never triggered
+  automatically by routine commits/pushes on unrelated work, in EITHER
+  local hooks or cloud CI (cloud runners can't load models either).
+- CI flips from opt-in (`run-ci` label / manual dispatch) to opt-out
+  (runs by default on every PR; docs-only PRs stay exempt, same as today).
+
+## Non-goals
+
+- Not fixing the orphaned-child-process bug directly (no longer load-bearing
+  once the heavy battery isn't run routinely; can be a separate follow-up if
+  it recurs during genuine local sidecar work).
+- Not changing the mandatory code-review gate, PR-issue-link gate, or
+  commit-msg validation — those are unaffected.
+- Not touching `test:golden-audio` mechanics — it's already opt-in/manual
+  today; this spec just confirms it stays that way and stays out of both
+  local-hook and cloud-CI automatic paths.
+
+## Design
+
+### 1. New default dev loop
+
+Finalize the code change → run the new branch-scoped fast command (§4) →
+open the PR → cloud verify fires automatically (§3) and the mandatory
+code-review subagent is dispatched in parallel → merge once both are green.
+
+### 2. STEPS reclassification
+
+Audited every step in `scripts/verify-cache.mjs`'s `STEPS` array against
+whether it needs this machine's actual hardware (GPU + bootstrapped
+sidecar venv + real model weights) or can run on a stock GitHub-hosted
+runner:
+
+| Step | Cloud-safe? | Notes |
+|---|---|---|
+| lint | yes | already cloud, unchanged |
+| typecheck | yes | already cloud, unchanged |
+| config:check | yes | **new to cloud** — currently only ran via local full `verify` |
+| test:hooks | yes | already cloud, unchanged |
+| test:pinokio | yes | **new to cloud** — currently only ran via local full `verify` |
+| test | yes | already cloud (`--changed` narrowed), unchanged |
+| test:server | yes | already cloud (`--changed` narrowed), unchanged |
+| test:server-slow | yes | already cloud, unchanged |
+| test:scripts (Pester) | yes | already cloud (ubuntu has pwsh), unchanged |
+| test:sidecar | **no** | needs the bootstrapped venv + real model weights; CI already skips it today (venv absent) — this was already silently zero-coverage in the cloud |
+| test:e2e | yes | already cloud, unchanged |
+| test:e2e:visual | yes | already cloud, unchanged |
+| build | yes | already cloud, unchanged |
+| test:golden-audio | **no** | not in STEPS today (already separate opt-in command); stays manual-only |
+
+Two gaps found: `config:check` and `test:pinokio` are cloud-safe but are
+**not currently in `verify.yml` at all** — they only ever ran via the local
+full `npm run verify`. Once pre-push stops running that, they'd silently
+lose all coverage unless added to the cloud workflow. This spec adds them.
+
+`test:sidecar` was already effectively cloud-uncovered (CI's venv isn't
+bootstrapped, so it would skip-with-banner even if invoked) — formalizing
+it as local-manual-only changes nothing about actual coverage, just removes
+the illusion that it was part of the automatic gate.
+
+### 3. CI trigger: opt-in → opt-out
+
+`.github/workflows/verify.yml`:
+
+- Drop the `labeled` event and the `run-ci` label requirement from the job
+  `if:` gate — the workflow runs on every `pull_request` (opened,
+  synchronize, reopened, ready_for_review) by default.
+- Keep the existing `paths-ignore` docs-only fast-path and the per-scope
+  `if:` gating on each leg (still worth skipping legs a PR didn't touch —
+  now framed as "don't run tests that can't fail," not "save money").
+- Add a `pinokio` key to the scope-detection step (`match '^pinokio/'`) and
+  a `Config check` step (`npm run config:check`, gated on
+  `server == 'true' || shared == 'true'`) and a `Pinokio tests` step
+  (`npm run test:pinokio`, gated on `pinokio == 'true' || shared == 'true'`).
+- Comment/header text describing "OPT-IN" gets rewritten to describe the
+  new opt-out default and why (public repo, free runners).
+
+### 4. Pre-push hook trim + new `verify:fast:branch`
+
+`scripts/verify-cache.mjs` gets a new scope basis alongside the existing
+`--scope-staged` (which diffs `git diff --cached`, correct for
+pre-commit): `--scope-branch`, which diffs
+`git merge-base HEAD main` against `HEAD` — i.e. every file touched by
+every commit on the current branch since it diverged from local `main`.
+This is the right basis for a pre-push-time check, where "staged" is
+usually empty or meaningless (commits already exist). Falls back to
+running everything if the merge-base/diff git calls fail, mirroring the
+existing tolerant-on-uncertainty behavior for `--scope-staged`.
+
+New npm script:
+
+```
+"verify:fast:branch": "node scripts/verify-cache.mjs --steps lint,typecheck,config:check,test:hooks,test,test:server,build --scope-branch"
+```
+
+This single command serves two purposes with no duplication:
+
+1. **The developer's own "test what I touched" step** in the new default
+   loop (§1) — run manually before opening the PR.
+2. **The new pre-push hook body** — the same command runs automatically as
+   a backstop, so an accidental unstaged/unbuilt push still gets caught
+   fast, locally, before round-tripping through a 10-15 min cloud run.
+
+`.husky/pre-push` changes from calling `npm run verify` to calling
+`npm run verify:fast:branch`, after the existing guard scripts
+(`guard-protected-push`, `guard-commit-subjects`, `is-docs-only-push`),
+unchanged. Drops entirely from local pre-push: `test:pinokio`,
+`test:server-slow`, `test:scripts`, `test:sidecar`, `test:e2e`,
+`test:e2e:visual` — all now covered by cloud verify per §3 (or, for
+`test:sidecar`, intentionally left manual-only per §2).
+
+`.husky/pre-commit` (`npm run verify:fast:scoped`, staged-diff based) is
+unchanged — it's already fast/scoped and wasn't implicated in the waste.
+
+### 5. `cross-os.yml` cadence bump
+
+Once local pre-push no longer runs `test:scripts` (Pester/Windows) or a
+real Windows/macOS pass at all, the weekly `cross-os.yml` cron becomes the
+only regular cross-platform coverage. Bump from weekly (Sunday 02:00 UTC)
+to twice weekly: add Wednesday 02:00 UTC alongside the existing Sunday
+02:00 UTC slot (`cron: '0 2 * * 3'` and `'0 2 * * 0'`).
+
+### 6. What stays the same
+
+- `.husky/pre-commit` (staged-scoped fast tests).
+- commit-msg validation (`.husky/commit-msg`).
+- Mandatory code-review gate and PR-issue-link gate (model-routing SKILL.md).
+- `npm run verify` still exists as a full local command for manual use
+  (e.g. before a release cut, or when actually debugging something that
+  needs the full battery) — it's just no longer force-invoked by the hook.
+- `release.yml`'s full cross-platform gate on a version tag.
+- `test:golden-audio` — already opt-in/manual, unaffected.
+
+## Docs to update
+
+- `CLAUDE.md`: "Commit gate" section (pre-push behavior, new
+  `verify:fast:branch`), "GitHub CI is OPT-IN" section (rewrite framing to
+  opt-out + why), "Working practice" (drop "run `npm run verify` before
+  every push" as the primary loop; describe the new default loop).
+- `CONTRIBUTING.md`: any CI-cost / opt-in language mirrored from CLAUDE.md.
+- `docs/features/118-ci-cost-round-2.md` and
+  `docs/features/215-ci-label-gated-verify.md`: add a superseded/updated
+  note pointing at this spec, don't delete (historical record of why the
+  opt-in design existed while the repo was private).
+- `feedback_ci_cost_shipping_practice` memory: update once implemented —
+  the draft-PR-to-save-minutes rationale is retired (repo is public, cost
+  is no longer the reason); note whether the draft-PR practice itself is
+  kept for other reasons (signal/noise) or dropped.
+
+## Risks / follow-ups
+
+- If the zombie-process contention bug recurs during genuine local
+  `test:sidecar`/manual generation work (the one case still run locally),
+  it isn't fixed by this spec — only made rare (routine commits no longer
+  trigger it). A follow-up cleanup-on-kill fix may still be worth doing
+  separately if it bites again.
+- `verify:fast:branch`'s `--scope-branch` diffs against local `main`, not
+  `origin/main` — assumes the developer's local `main` is reasonably
+  current. Acceptable for a pre-push speed check (cloud verify is the real
+  gate); flagged here rather than silently assumed.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "verify:quick": "npm run test:all",
     "verify:fast": "node scripts/verify-cache.mjs --steps test:hooks,test,test:server",
     "verify:fast:scoped": "node scripts/verify-cache.mjs --steps test:hooks,test,test:server --scope-staged",
+    "verify:fast:branch": "node scripts/verify-cache.mjs --steps lint,typecheck,config:check,test:hooks,test,test:server,build,test:sidecar --scope-branch",
     "openapi:types": "openapi-typescript ./openapi.yaml -o ./src/lib/api-types.ts",
     "stats": "node scripts/code-stats.mjs",
     "backlog:sync": "node scripts/backlog-sync.mjs",

--- a/scripts/tests/verify-cache.test.mjs
+++ b/scripts/tests/verify-cache.test.mjs
@@ -8,6 +8,7 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
 
 import {
   composeInputHash,
@@ -22,6 +23,7 @@ import {
   computeShared,
   parseNvidiaSmiUtil,
   isVitestPoolCrash,
+  branchDiffFiles,
   STEPS,
   _internals,
 } from '../verify-cache.mjs';
@@ -195,16 +197,23 @@ test('path normalization — Windows and POSIX produce identical hashes', () => 
 });
 
 test('parseFlags recognizes --no-cache anywhere in argv', () => {
-  assert.deepEqual(parseFlags([]), { noCache: false, steps: null, scopeStaged: false });
+  assert.deepEqual(parseFlags([]), {
+    noCache: false,
+    steps: null,
+    scopeStaged: false,
+    scopeBranch: false,
+  });
   assert.deepEqual(parseFlags(['--no-cache']), {
     noCache: true,
     steps: null,
     scopeStaged: false,
+    scopeBranch: false,
   });
   assert.deepEqual(parseFlags(['a', 'b', '--no-cache', 'c']), {
     noCache: true,
     steps: null,
     scopeStaged: false,
+    scopeBranch: false,
   });
 });
 
@@ -213,6 +222,7 @@ test('parseFlags --steps with space-separated form', () => {
     noCache: false,
     steps: ['test:hooks', 'test', 'test:server'],
     scopeStaged: false,
+    scopeBranch: false,
   });
 });
 
@@ -221,6 +231,7 @@ test('parseFlags --steps with = form', () => {
     noCache: false,
     steps: ['test:hooks', 'test', 'test:server'],
     scopeStaged: false,
+    scopeBranch: false,
   });
 });
 
@@ -229,6 +240,7 @@ test('parseFlags --steps trims whitespace and drops empty segments', () => {
     noCache: false,
     steps: ['test:hooks', 'test'],
     scopeStaged: false,
+    scopeBranch: false,
   });
 });
 
@@ -237,6 +249,7 @@ test('parseFlags --steps combines with --no-cache', () => {
     noCache: true,
     steps: ['test:hooks', 'test'],
     scopeStaged: false,
+    scopeBranch: false,
   });
 });
 
@@ -248,11 +261,13 @@ test('parseFlags missing --steps argument yields empty list (caller errors out)'
     noCache: false,
     steps: [],
     scopeStaged: false,
+    scopeBranch: false,
   });
   assert.deepEqual(parseFlags(['--steps', '--no-cache']), {
     noCache: true,
     steps: [],
     scopeStaged: false,
+    scopeBranch: false,
   });
 });
 
@@ -261,6 +276,7 @@ test('parseFlags absent --steps leaves steps null (full pipeline)', () => {
     noCache: false,
     steps: null,
     scopeStaged: false,
+    scopeBranch: false,
   });
 });
 
@@ -269,6 +285,16 @@ test('parseFlags recognizes --scope-staged', () => {
     noCache: false,
     steps: null,
     scopeStaged: true,
+    scopeBranch: false,
+  });
+});
+
+test('parseFlags recognizes --scope-branch', () => {
+  assert.deepEqual(parseFlags(['--scope-branch']), {
+    noCache: false,
+    steps: null,
+    scopeStaged: false,
+    scopeBranch: true,
   });
 });
 
@@ -427,4 +453,56 @@ test('parseNvidiaSmiUtil returns null on empty / unparseable output', () => {
   assert.equal(parseNvidiaSmiUtil(''), null);
   assert.equal(parseNvidiaSmiUtil('\n'), null);
   assert.equal(parseNvidiaSmiUtil('N/A\n'), null);
+});
+
+// --- Branch-diff scope filter (verify/CI rebalance, 2026-07-06) --------
+
+function gitAt(cwd, args) {
+  // Strip ambient GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE/GIT_PREFIX before
+  // spawning: when this suite runs inside a real git hook (pre-commit calls
+  // `npm run verify:fast:scoped` -> `npm run test:hooks`), git sets these in
+  // the process env for the hook, and without stripping them these fixture
+  // commands would operate on the REAL repo instead of the throwaway `cwd`.
+  const { GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE, GIT_PREFIX, ...cleanEnv } = process.env;
+  const r = spawnSync('git', args, { cwd, encoding: 'utf8', env: cleanEnv });
+  if (r.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
+  }
+  return r.stdout;
+}
+
+// Builds a throwaway repo with one commit on a `main` branch, so tests can
+// exercise branchDiffFiles' real `git merge-base` + `git diff` calls without
+// touching this actual repo.
+function makeGitFixture() {
+  const dir = mkTmp();
+  gitAt(dir, ['init', '-q', '-b', 'main']);
+  gitAt(dir, ['config', 'user.email', 'test@example.com']);
+  gitAt(dir, ['config', 'user.name', 'Test']);
+  writeFileSync(join(dir, 'base.txt'), 'base', 'utf8');
+  gitAt(dir, ['add', '.']);
+  gitAt(dir, ['commit', '-q', '-m', 'base']);
+  return dir;
+}
+
+test('branchDiffFiles: returns files changed since branching off main', () => {
+  const dir = makeGitFixture();
+  gitAt(dir, ['switch', '-q', '-c', 'feature']);
+  writeFileSync(join(dir, 'feature.txt'), 'x', 'utf8');
+  gitAt(dir, ['add', '.']);
+  gitAt(dir, ['commit', '-q', '-m', 'feature commit']);
+  const files = branchDiffFiles(dir);
+  assert.deepEqual(files, ['feature.txt']);
+});
+
+test('branchDiffFiles: empty array (not null) when run directly on main with nothing new', () => {
+  const dir = makeGitFixture();
+  const files = branchDiffFiles(dir);
+  assert.deepEqual(files, []);
+});
+
+test('branchDiffFiles: returns null when cwd is not a git repo', () => {
+  const dir = mkTmp(); // no git init — merge-base has nothing to find
+  const files = branchDiffFiles(dir);
+  assert.equal(files, null);
 });

--- a/scripts/tests/verify-cache.test.mjs
+++ b/scripts/tests/verify-cache.test.mjs
@@ -123,8 +123,16 @@ test('saveCache + loadCache round-trips deep-equal', () => {
   const original = {
     schemaVersion: SCHEMA_VERSION,
     steps: {
-      lint: { inputHash: 'a'.repeat(64), lastGreenAt: '2026-05-18T00:00:00.000Z', durationMs: 1234 },
-      test: { inputHash: 'b'.repeat(64), lastGreenAt: '2026-05-18T00:00:01.000Z', durationMs: 5678 },
+      lint: {
+        inputHash: 'a'.repeat(64),
+        lastGreenAt: '2026-05-18T00:00:00.000Z',
+        durationMs: 1234,
+      },
+      test: {
+        inputHash: 'b'.repeat(64),
+        lastGreenAt: '2026-05-18T00:00:01.000Z',
+        durationMs: 5678,
+      },
     },
   };
   saveCache(path, original);
@@ -463,7 +471,13 @@ function gitAt(cwd, args) {
   // `npm run verify:fast:scoped` -> `npm run test:hooks`), git sets these in
   // the process env for the hook, and without stripping them these fixture
   // commands would operate on the REAL repo instead of the throwaway `cwd`.
-  const { GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE, GIT_PREFIX, ...cleanEnv } = process.env;
+  const {
+    GIT_DIR: _GIT_DIR,
+    GIT_WORK_TREE: _GIT_WORK_TREE,
+    GIT_INDEX_FILE: _GIT_INDEX_FILE,
+    GIT_PREFIX: _GIT_PREFIX,
+    ...cleanEnv
+  } = process.env;
   const r = spawnSync('git', args, { cwd, encoding: 'utf8', env: cleanEnv });
   if (r.status !== 0) {
     throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
@@ -505,4 +519,29 @@ test('branchDiffFiles: returns null when cwd is not a git repo', () => {
   const dir = mkTmp(); // no git init — merge-base has nothing to find
   const files = branchDiffFiles(dir);
   assert.equal(files, null);
+});
+
+test('branchDiffFiles: ignores an ambient GIT_DIR pointing elsewhere', () => {
+  // Regression test for a real incident: branchDiffFiles must resolve git
+  // state strictly relative to its `cwd` argument, even when invoked from
+  // inside a process that already has GIT_DIR/GIT_WORK_TREE set for a
+  // DIFFERENT repo (exactly what happens when this suite runs inside the
+  // real pre-commit hook). Deterministic — doesn't depend on actually being
+  // inside a hook to catch a regression.
+  const dir = makeGitFixture();
+  gitAt(dir, ['switch', '-q', '-c', 'feature']);
+  writeFileSync(join(dir, 'feature.txt'), 'x', 'utf8');
+  gitAt(dir, ['add', '.']);
+  gitAt(dir, ['commit', '-q', '-m', 'feature commit']);
+
+  const bogusGitDir = join(mkTmp(), 'unrelated-repo', '.git');
+  const prevGitDir = process.env.GIT_DIR;
+  process.env.GIT_DIR = bogusGitDir;
+  try {
+    const files = branchDiffFiles(dir);
+    assert.deepEqual(files, ['feature.txt']);
+  } finally {
+    if (prevGitDir === undefined) delete process.env.GIT_DIR;
+    else process.env.GIT_DIR = prevGitDir;
+  }
 });

--- a/scripts/verify-cache.mjs
+++ b/scripts/verify-cache.mjs
@@ -7,13 +7,7 @@
 
 import { createHash } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
-import {
-  readFileSync,
-  renameSync,
-  writeFileSync,
-  existsSync,
-  statSync,
-} from 'node:fs';
+import { readFileSync, renameSync, writeFileSync, existsSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { lowConcurrency } from './test-concurrency.mjs';
@@ -36,12 +30,7 @@ export const STEPS = [
     name: 'typecheck',
     inputs: {
       globs: ['src/**', 'server/src/**'],
-      extraFiles: [
-        'tsconfig.json',
-        'server/tsconfig.json',
-        'vite.config.ts',
-        'vitest.config.ts',
-      ],
+      extraFiles: ['tsconfig.json', 'server/tsconfig.json', 'vite.config.ts', 'vitest.config.ts'],
       includeLockfiles: ['root', 'server'],
     },
   },
@@ -103,7 +92,11 @@ export const STEPS = [
     name: 'test:server-slow',
     inputs: {
       globs: ['server/src/**'],
-      extraFiles: ['server/vitest.config.slow.ts', 'server/vitest.config.ts', 'server/tsconfig.json'],
+      extraFiles: [
+        'server/vitest.config.slow.ts',
+        'server/vitest.config.ts',
+        'server/tsconfig.json',
+      ],
       includeLockfiles: ['server'],
     },
   },
@@ -425,16 +418,39 @@ function stagedDiffFiles(cwd) {
 // filter correctly skips every step for that, which is fine given
 // verify.yml is now the required backstop. Exported (unlike
 // stagedDiffFiles) so it can be unit-tested directly.
+//
+// Strips ambient GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE/GIT_PREFIX before
+// spawning: this function is invoked with an explicit `cwd` and must resolve
+// git state strictly relative to it. Without stripping, a caller running
+// inside an enclosing git process that already has these set (e.g. this
+// very function running inside the pre-push hook it's part of) would have
+// git resolve against the ENCLOSING process's repo instead of `cwd` — harmless
+// when `cwd` happens to be that same repo (the real pre-push path), but wrong
+// whenever `cwd` points elsewhere (exactly what this file's own unit tests do).
+function gitEnv() {
+  const {
+    GIT_DIR: _GIT_DIR,
+    GIT_WORK_TREE: _GIT_WORK_TREE,
+    GIT_INDEX_FILE: _GIT_INDEX_FILE,
+    GIT_PREFIX: _GIT_PREFIX,
+    ...cleanEnv
+  } = process.env;
+  return cleanEnv;
+}
+
 export function branchDiffFiles(cwd) {
+  const env = gitEnv();
   const base = spawnSync('git', ['merge-base', 'HEAD', 'main'], {
     cwd,
     encoding: 'utf8',
+    env,
   });
   if (base.error || base.status !== 0) return null;
   const baseSha = base.stdout.trim();
   const r = spawnSync('git', ['diff', '--name-only', baseSha, 'HEAD'], {
     cwd,
     encoding: 'utf8',
+    env,
   });
   if (r.error || r.status !== 0) return null;
   return r.stdout
@@ -515,11 +531,10 @@ function sidecarFingerprint() {
 }
 
 function gitFileList(cwd) {
-  const r = spawnSync(
-    'git',
-    ['ls-files', '--cached', '--others', '--exclude-standard'],
-    { cwd, encoding: 'utf8' },
-  );
+  const r = spawnSync('git', ['ls-files', '--cached', '--others', '--exclude-standard'], {
+    cwd,
+    encoding: 'utf8',
+  });
   if (r.error || r.status !== 0) return null;
   return r.stdout
     .split('\n')
@@ -554,7 +569,9 @@ const RETRIABLE_POOL_STEPS = new Set(['test:server', 'test:server-slow']);
     died), as opposed to a normal test failure. A real test failure must NOT match
     — retrying that would mask a flaky test. */
 export function isVitestPoolCrash(stderr) {
-  return /Worker exited unexpectedly|Worker forks emitted error|\[vitest-pool\]/i.test(stderr || '');
+  return /Worker exited unexpectedly|Worker forks emitted error|\[vitest-pool\]/i.test(
+    stderr || '',
+  );
 }
 
 /** Run one pipeline step (`npm run <name>`) and return its exit code. Retriable
@@ -609,9 +626,7 @@ export function runPipeline({ argv = [], cwd = process.cwd(), env = process.env 
   if (!env.SKIP_CONTENTION_CHECK && !lowConcurrency(env)) {
     const { busy, util } = detectGpuContention();
     if (busy) {
-      console.log(
-        `[contention] GPU busy (~${util}% util) — a generation run may be active.`,
-      );
+      console.log(`[contention] GPU busy (~${util}% util) — a generation run may be active.`);
       console.log(
         '[contention] Throttling test concurrency (LOW_CONCURRENCY=1). Set SKIP_CONTENTION_CHECK=1 to disable.',
       );

--- a/scripts/verify-cache.mjs
+++ b/scripts/verify-cache.mjs
@@ -181,6 +181,7 @@ export function parseFlags(argv) {
     noCache: argv.includes('--no-cache'),
     steps,
     scopeStaged: argv.includes('--scope-staged'),
+    scopeBranch: argv.includes('--scope-branch'),
   };
 }
 
@@ -413,6 +414,36 @@ function stagedDiffFiles(cwd) {
     .map(toPosix);
 }
 
+// Files touched by every commit on the current branch since it diverged
+// from local `main` — the right basis for a pre-push-time check, where
+// "staged" is usually empty (commits already exist). Returns POSIX paths,
+// or null if the underlying git commands fail (→ caller disables the scope
+// filter and runs everything; never skip on uncertainty). Distinct from
+// that failure case: a SUCCESSFUL merge-base+diff that finds no changed
+// files (branch fully merged into main, running directly on main, or a
+// commit-less branch) legitimately returns an empty array — the scope
+// filter correctly skips every step for that, which is fine given
+// verify.yml is now the required backstop. Exported (unlike
+// stagedDiffFiles) so it can be unit-tested directly.
+export function branchDiffFiles(cwd) {
+  const base = spawnSync('git', ['merge-base', 'HEAD', 'main'], {
+    cwd,
+    encoding: 'utf8',
+  });
+  if (base.error || base.status !== 0) return null;
+  const baseSha = base.stdout.trim();
+  const r = spawnSync('git', ['diff', '--name-only', baseSha, 'HEAD'], {
+    cwd,
+    encoding: 'utf8',
+  });
+  if (r.error || r.status !== 0) return null;
+  return r.stdout
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(toPosix);
+}
+
 // --- Contention guard ----------------------------------------------------
 // A co-running GPU generation hammers CPU/disk and is the documented cause of
 // "Worker exited unexpectedly" crashes and 250s+ environment-setup stalls in
@@ -588,14 +619,26 @@ export function runPipeline({ argv = [], cwd = process.cwd(), env = process.env 
     }
   }
 
-  // Scope filter (pre-commit) — compute the staged diff once; per-step skip
-  // happens at the top of the loop below.
+  // Scope filter (pre-commit / pre-push) — compute the diff once; per-step
+  // skip happens at the top of the loop below. --scope-staged (staged diff)
+  // and --scope-branch (branch-vs-main diff) are mutually exclusive scope
+  // bases feeding the SAME per-step filter.
   let scopeDiff = null;
   let scopeShared = false;
   if (flags.scopeStaged) {
     scopeDiff = stagedDiffFiles(cwd);
     if (scopeDiff === null) {
       console.log('[scope] git diff --cached failed; running all selected steps');
+    } else if (computeShared(scopeDiff)) {
+      scopeShared = true;
+      console.log('[scope] root manifest changed — all selected steps in scope');
+    }
+  } else if (flags.scopeBranch) {
+    scopeDiff = branchDiffFiles(cwd);
+    if (scopeDiff === null) {
+      console.log('[scope] git merge-base/diff against main failed; running all selected steps');
+    } else if (scopeDiff.length === 0) {
+      console.log('[scope] no diff vs main — nothing in scope, selected steps will skip');
     } else if (computeShared(scopeDiff)) {
       scopeShared = true;
       console.log('[scope] root manifest changed — all selected steps in scope');


### PR DESCRIPTION
## Summary

Local `npm run verify` was self-contending on the dev box and wasting
hours a day. Separately, the repo went public so cloud Actions minutes on
standard runners are free/uncapped, invalidating the prior opt-in-CI
design. This PR:

- Adds `--scope-branch` mode + `branchDiffFiles` to `scripts/verify-cache.mjs`,
  powering a new `verify:fast:branch` npm script that swaps in for the
  full battery in `.husky/pre-push`. Each step (including `test:sidecar`,
  the one thing that genuinely needs this machine) is scope-gated to
  whether the branch's diff touches its inputs.
- Flips `.github/workflows/verify.yml` from label-gated opt-in to running
  on every PR by default, drops the now-dangerous `paths-ignore` (would
  deadlock docs-only PRs once the check is required), and adds two
  previously cloud-uncovered legs (`config:check`, `test:pinokio`).
- Bumps `.github/workflows/cross-os.yml`'s cron from weekly to
  twice-weekly, since it becomes the only regular Windows/Pester/macOS
  coverage once local pre-push stops running that.
- Updates `CLAUDE.md`, `CONTRIBUTING.md`, and cross-references the
  superseded `docs/features/118`/`215` docs.

Full design (3 rounds of adversarial review before implementation):
`docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md`
Full plan (2 rounds of adversarial review): `docs/superpowers/plans/2026-07-06-verify-ci-rebalance.md`

**Not in this PR:** wiring `verify.yml` into `main`'s required-status-check
branch-protection ruleset. That's a manual, one-time GitHub settings
action that needs to happen after this merges, with the repo owner
present to confirm — tracked as a follow-up, not code.

**Note on CI coverage timing:** real Windows Pester + win32 visual-baseline
regression coverage moves from every-push to `cross-os.yml`'s twice-weekly
cron (plus `release.yml` on tag). This is a deliberate, spec-acknowledged
tradeoff (the cadence bump is the mitigation), not an oversight.

## Test plan

- [x] `npm run verify:fast:branch` — green (full 8-step battery,
      lint/typecheck/config:check/test:hooks/test/test:server/test:sidecar/build)
- [x] `scripts/tests/verify-cache.test.mjs` — 546/546 passing, including a
      new deterministic regression test for the `branchDiffFiles` git-env
      isolation fix (verified RED before the fix, GREEN after)
- [x] `.github/workflows/verify.yml` / `cross-os.yml` — YAML validated
      (`js-yaml` parse clean), indentation checked against untouched
      surrounding steps
- [x] Each of the 7 implementation tasks passed an individual task-level
      code review (several required one fix-and-re-review round)
- [x] Final whole-branch review (Opus) — one Important finding (a stale
      "CI is opt-in" doc line contradicting this PR's own posture) found
      and fixed; no Critical/functional issues

Closes #1371