### PR TITLE
docs(docs): close out doc 235's required-status-check ruleset item

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,7 +296,7 @@ Run this before declaring any non-trivial task "done." Skipping a step is fine w
 2. **Land paired automated test(s).** New behaviour → new test. Bug fix → regression test (fails before, passes after). UI-visible behaviour crossing router/redux/layout seams → Playwright e2e spec under `e2e/`.
 3. **Update `docs/features/INDEX.md`** if the plan is new or moved (new entry under its area, or move to `## Shipped (archive)` per `archive/README.md` when shipping a plan).
 4. **Update the two release-notes documents, in this PR.** Append an entry to `docs/release-notes-next.md` (technical register, PR-refed) AND a matching user-facing, brand-voice line to the in-progress version section at the top of `RELEASE_NOTES.md`. Land both PR-by-PR, not reconstructed from git history at cut time — that's the whole point of this step. The first-PR-after-a-cut bootstrap case (resetting both files) is documented once, in [CONTRIBUTING.md "Release notes"](CONTRIBUTING.md#release-notes) — check there, don't re-derive it. Skip only when the change has no shippable delta (pure docs/process, CI-only, internal chore with no user- or operator-visible effect) — say so explicitly rather than silently omitting.
-5. **Close or advance the linked issue.** Put `Closes #NN` in the PR body for a full delivery (`Refs #NN` for a partial), and confirm the issue's `area:`/`moscow:` labels still reflect reality. Bugs link their `bug` issue with `Closes #NN` too. This link is verified, not assumed — if none exists at PR-creation time, one is auto-filed and linked without pausing to ask, including for bug-shaped work (a deliberate, scoped override of "The backlog" section's general "the user files [bugs] as they hit them" convention, for this gate only — see [Model routing → PR-gate issue verification](.claude/skills/model-routing/SKILL.md#pr-gate-issue-verification)); `.github/workflows/pr-issue-link.yml` mechanically backstops the check on every PR. Once `main`'s required-status-check ruleset for it is wired (a one-time, user-run setup step — see `docs/features/235-model-routing-review-gates.md`), a missing link blocks merge; until then it only fails a visible check.
+5. **Close or advance the linked issue.** Put `Closes #NN` in the PR body for a full delivery (`Refs #NN` for a partial), and confirm the issue's `area:`/`moscow:` labels still reflect reality. Bugs link their `bug` issue with `Closes #NN` too. This link is verified, not assumed — if none exists at PR-creation time, one is auto-filed and linked without pausing to ask, including for bug-shaped work (a deliberate, scoped override of "The backlog" section's general "the user files [bugs] as they hit them" convention, for this gate only — see [Model routing → PR-gate issue verification](.claude/skills/model-routing/SKILL.md#pr-gate-issue-verification)); `.github/workflows/pr-issue-link.yml` mechanically backstops the check on every PR, and (since 2026-07-06) a missing link blocks merge outright via `main`'s required-status-check ruleset — see `docs/features/235-model-routing-review-gates.md`.
 6. **Run `npm run verify:fast:branch`** locally (same battery as pre-push) — or the full `npm run verify` if you want more than the branch-scoped subset. Cloud `verify.yml` is the required, authoritative gate either way (see "Commit gate").
 7. **If shipping a plan** (status → `stable`): fill its **Ship notes** section with the shipped date and the commit SHA, then `git mv` it under `docs/features/archive/` and re-link any active plan that pointed at it.
 8. **Surface what changed** in the end-of-turn summary in 1–2 sentences. Do not narrate the diff — point at the user-visible delta and the test that locks it.
@@ -540,12 +540,10 @@ files [bugs] as they hit them" convention, for this gate only — labeled per
 `CONTRIBUTING.md`'s two-shape convention (bug-shaped work → standalone `bug`
 label; backlog-shaped work → `type:feature`/`type:chore` + `area:<prefix>`,
 `moscow:` left for you to set). `.github/workflows/pr-issue-link.yml` surfaces a failing
-check on every PR that skips this, mirroring `pr-title-lint.yml`. Once wired
-into `main`'s required status checks (a one-time, user-run ruleset setup —
-see
-[docs/features/235-model-routing-review-gates.md](docs/features/235-model-routing-review-gates.md)),
-a missing link blocks merge; until that setup is done, a missing link only
-fails a visible, non-blocking check.
+check on every PR that skips this, mirroring `pr-title-lint.yml`, and (since
+2026-07-06) a missing link blocks merge outright — wired into `main`'s
+required status checks alongside `verify.yml` in the same ruleset action;
+see [docs/features/235-model-routing-review-gates.md](docs/features/235-model-routing-review-gates.md).
 Full mechanics: [`.claude/skills/model-routing/SKILL.md`](.claude/skills/model-routing/SKILL.md#pr-gate-issue-verification).
 
 **Requesting a clean-room CI run on a PR.** CI now runs automatically on

--- a/docs/features/235-model-routing-review-gates.md
+++ b/docs/features/235-model-routing-review-gates.md
@@ -22,14 +22,14 @@ owner: null
 - **New seams**: a new project skill directory (`.claude/skills/model-routing/`); a new validator module shape (`scripts/validate-*.mjs` + CLI mode) alongside the existing `validate-commit-msg.mjs`; a second always-on `pull_request` workflow alongside `pr-title-lint.yml`.
 - **Invariants preserved**: no application code, test suite, or product surface changes (spec "Out of scope"); `brainstorming`/`writing-plans` (global plugin skills) are not edited, only project-level `CLAUDE.md` / `.claude/skills/` content, which the standing instruction-precedence rule already gives priority over skill defaults.
 - **Migration story**: none — no stored data shape changes.
-- **Reversibility**: every CLAUDE.md edit and the skill file are plain markdown, revertible with a single `git revert`. The workflow is inert until wired into a required-status-check ruleset (Task 7 Step 8, the manual step — see the implementation plan); if that step is reverted, the check becomes advisory-only again, not broken.
+- **Reversibility**: every CLAUDE.md edit and the skill file are plain markdown, revertible with a single `git revert`. The workflow's status check was wired into `main`'s required-status-check ruleset (`id 17654264`) on 2026-07-06, bundled with the `verify.yml` required-check action from the verify/CI rebalance work; if that ruleset rule is reverted, the check becomes advisory-only again, not broken.
 
 ## Invariants to preserve
 
 1. The four-tier routing table (`CLAUDE.md` "Model routing" section, and the full copy in `.claude/skills/model-routing/SKILL.md`) never routes a fork — forks always inherit the dispatching session's model (`Agent` tool schema; see Decision 1 in the design spec).
 2. `scripts/validate-pr-issue-link.mjs`'s `hasIssueLink()` strips fenced + inline code spans before testing for `Closes #NN` / `Refs #NN` — a backtick-wrapped keyword must not satisfy the check (it doesn't actually auto-close on GitHub either).
-3. `.github/workflows/pr-issue-link.yml`'s job `name:` field ("Verify PR body links a GitHub issue") is the exact string referenced by the required-status-check ruleset (Task 7 Step 8, the manual step) — renaming the job without updating the ruleset silently breaks the required-check binding.
-4. That same manual ruleset step now also needs to bind `verify.yml`'s `npm run verify` job name (see [docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](../superpowers/specs/2026-07-06-verify-ci-rebalance-design.md)) — do both required-check bindings in the same GitHub settings visit if convenient, but they're independent action items; this doc's Task 7 Step 8 landing does not depend on the other one landing, or vice versa.
+3. `.github/workflows/pr-issue-link.yml`'s job `name:` field ("Verify PR body links a GitHub issue") is the exact string referenced by the required-status-check ruleset (`id 17654264`, wired 2026-07-06) — renaming the job without updating the ruleset silently breaks the required-check binding.
+4. That same ruleset also binds `verify.yml`'s `npm run verify` job name (see [docs/superpowers/specs/2026-07-06-verify-ci-rebalance-design.md](../superpowers/specs/2026-07-06-verify-ci-rebalance-design.md)) — both required-check bindings were done in the same GitHub settings action, but they remain independent: renaming either job's `name:` only breaks its own binding.
 
 ## Test plan
 
@@ -43,7 +43,7 @@ owner: null
 1. Open a PR against `main` with a body that does **not** contain `Closes` or `Refs` → expect the `Verify PR body links a GitHub issue` check to fail (red ✗) on the PR.
 2. Edit the PR body to add `Closes #<some real issue number>` (plain, not inside backticks) → expect the check to re-run (the `edited` trigger) and turn green.
 3. Confirm `pr-title-lint.yml` (`.github/workflows/pr-title-lint.yml`) is unaffected — both workflows run independently on the same PR events.
-4. After Task 7 Step 8 (the manual ruleset step) is applied: repeat step 1 and confirm the PR's merge button is now disabled/blocked by GitHub until the check passes (not just red).
+4. The required-check ruleset step is applied (2026-07-06): repeat step 1 and confirm the PR's merge button is now disabled/blocked by GitHub until the check passes (not just red).
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary

Follow-up to #1372: the manual required-status-check ruleset action
(Task 8 of that PR's plan) is done — `main`'s ruleset (`id 17654264`)
now requires both `npm run verify` and `Verify PR body links a GitHub
issue`, alongside the existing force-push/deletion protection (verified
unchanged). Updates the "still pending" / "one-time, user-run setup"
references in `docs/features/235-model-routing-review-gates.md` and
`CLAUDE.md` to reflect that it shipped 2026-07-06.

Docs-only change, no runtime surface.

## Test plan

- [x] Not applicable — docs-only change (CONTRIBUTING.md doc-only fast-path)

Refs #1371