### PR TITLE
chore(frontend): harden designed-voice check against a stale id-fallback match

### DIFF
--- a/src/lib/voice-status.test.ts
+++ b/src/lib/voice-status.test.ts
@@ -152,6 +152,26 @@ describe('resolveVoiceStatus — Qwen lifecycle', () => {
     });
   });
 
+  it('reads "Needs voice" for a non-reused, non-linked character whose only match is a stale id-fallback Voice (fe-48)', () => {
+    /* Regression (fe-48, #1359): `findVoiceForCharacter`'s id-fallback (Voice.id ===
+       Character.id, used when the character has no explicit `voiceId`) can return a
+       library Voice that is stale — e.g. left behind after this exact character's own
+       design fields were reset/cleared, without the Voice record being retired. Unlike
+       the "reused" case below (trustworthy because of an explicit `voiceId` link or
+       `matchedFrom` reuse provenance), a character with NEITHER carries no signal that
+       the id-fallback match is actually CURRENT, so its own (now-empty) override fields
+       must be the only source of truth — this must read "Needs voice", not "Designed". */
+    const c = char({}); // no overrideTtsVoices, no voiceId, no matchedFrom
+    const staleVoice = voice({
+      id: 'c1', // coincidentally shares id with the character (the fallback match)
+      ttsVoice: { provider: 'qwen', name: 'qwen-x', description: 'Stale design' },
+    });
+    expect(resolveVoiceStatus(c, staleVoice, QWEN).lifecycle).toEqual({
+      label: 'Needs voice',
+      color: 'warning',
+    });
+  });
+
   it('reads "Needs voice" for a reused voice whose matched Qwen Voice has an EMPTY name', () => {
     /* Regression: the matched Voice resolves to the qwen provider but carries no
        designed name (voiceId never linked, or the referenced Voice was lost to a

--- a/src/lib/voice-status.ts
+++ b/src/lib/voice-status.ts
@@ -105,10 +105,24 @@ function resolveLifecyclePill(
        EMPTY name (the designed voiceId was never linked or was lost to a
        persistence bug) is NOT designed → "Needs voice", matching the row's
        "No voice designed yet" sub-line. Checking only the provider let that
-       broken-link state mislabel itself "Designed". */
+       broken-link state mislabel itself "Designed".
+
+       fe-48 (#1359): the matched-Voice-derived signal is only trustworthy when
+       the match is corroborated by the character's OWN link to it — an explicit
+       `voiceId` that the matched Voice's `id` actually satisfies, or reuse
+       provenance (`matchedFrom`). Without either, `findVoiceForCharacter`'s
+       id-fallback (Voice.id === Character.id, used for a character with no
+       explicit voiceId) can only have found this Voice by id-coincidence, which
+       is not necessarily CURRENT — e.g. if this exact character's own design
+       fields were later reset/cleared without the Voice record being retired.
+       In that case the character's own (now-empty) `overrideTtsVoices.qwen.name`
+       must be the only source of truth. */
+    const linkedViaVoiceId = !!c.voiceId && voice?.id === c.voiceId;
     const hasVoice =
       !!c.overrideTtsVoices?.qwen?.name ||
-      (voice?.ttsVoice?.provider === 'qwen' && !!voice.ttsVoice.name);
+      ((linkedViaVoiceId || !!c.matchedFrom) &&
+        voice?.ttsVoice?.provider === 'qwen' &&
+        !!voice.ttsVoice.name);
     if (!hasVoice) return { label: 'Needs voice', color: 'warning' };
     if (voice?.generated) return { label: 'Generated', color: 'success' };
     /* A synthesised 12s audition sits between bare design and rendered


### PR DESCRIPTION
## Summary

- `resolveLifecyclePill`'s (`src/lib/voice-status.ts`) `hasVoice` check trusted **any** matched library Voice carrying a `qwen` provider + non-empty name, regardless of how `findVoiceForCharacter` (`src/lib/voice-character-link.ts`) found it. For a character with no explicit `voiceId` and no `matchedFrom`, the only way a match can exist is the id-coincidence fallback (`Voice.id === Character.id`) — which is not necessarily *current* if this exact character's own design fields were ever reset without the library Voice record being retired.
- The fix corroborates the matched-Voice-derived signal against the character's own link to it: an explicit `voiceId` the matched `Voice.id` actually satisfies, or `matchedFrom` reuse provenance. A character with **neither** now falls back to its own `overrideTtsVoices.qwen.name` as the sole source of truth for "has a designed voice."
- This is the single shared choke point for all four consumers named in #1359 (cast-row lifecycle pills, the voice-readiness gate's `selectUndesignedQwenCharacters`, and the tier-modal 1.7B guard via fe-47's shared selector) — one fix, no re-divergence.

**Investigation finding:** I traced every place a character's `overrideTtsVoices.qwen` field could be cleared/reset (`cast-slice.ts`'s `hydrateFromAnalysis`/`mergeCharacters`/`applyMerge` all explicitly preserve it via `existing ?? inc`; no reducer clears it). **I found no live code path today that produces the stale state described in the issue** — this is defensive hardening for a real architectural gap (the `voices` Redux slice can lag the `cast` slice, per the existing comment in `voices-slice.ts`: "the library only re-hydrates on book/stage/engine/genProgress change"), not a fix for an observed live defect. Picked `chore(frontend)` accordingly rather than `fix(frontend)`.

**Release notes:** Skipped both `docs/release-notes-next.md` and `RELEASE_NOTES.md` — no live user-facing trigger exists today (see investigation finding above), so there's no shippable user-visible delta to describe. Happy to add an entry if a live trigger path surfaces later.

## Test plan

- [x] New regression test in `src/lib/voice-status.test.ts` pins the exact stale-id-fallback scenario (fails before the fix, passes after).
- [x] `npx vitest run src/lib/voice-status.test.ts src/lib/voice-character-link.test.ts src/store/voice-readiness-selectors.test.ts src/views/cast.test.tsx src/components/layout.test.tsx` — 147/147 passed, including the fe-47 tier-modal test (voiceId-linked design) and the reused-voice tests (matchedFrom-linked design), confirming no re-divergence between the four consumers.
- [x] `npm test` (full frontend suite) — 3552/3552 passed, 276/276 files.
- [x] `npm run typecheck` — clean (frontend + server).
- [x] Pushed branch; local pre-push `verify:fast:branch` (lint, typecheck, cached tests, build) passed.

Closes #1359