### PR TITLE
ci(ci,docs): auto-add new issues to the Castwright Kanban board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,43 @@
+name: Add issue to project
+
+# Auto-adds every new (or reopened / transferred-in) issue to the GitHub
+# Projects v2 "Castwright Kanban" board, so nothing ever sits off-board where
+# the planning views (docs/BACKLOG.md via `backlog:sync`) and the kanban views
+# can't see it. This replaces relying solely on the Project's *built-in*
+# "Auto-add to project" workflow, which had been leaking issues onto the floor
+# (e.g. #1386, #1377). See docs/superpowers/specs/2026-07-05-github-issues-kanban-design.md.
+#
+# GitHub offers no way to *block* creating an issue that lacks a project — this
+# is the achievable guarantee: the issue is on the board the instant it exists.
+#
+# REQUIRED SECRET — ADD_TO_PROJECT_PAT:
+#   The default GITHUB_TOKEN CANNOT write a *user-owned* Projects v2 board, so
+#   this needs a personal access token with project write access, stored as the
+#   repo secret `ADD_TO_PROJECT_PAT`:
+#     - Classic PAT: scopes `repo` + `project`, OR
+#     - Fine-grained PAT: repository "Issues: read" on Castwright + account
+#       "Projects: read and write".
+#   Add it at: repo Settings → Secrets and variables → Actions → New secret.
+#   Without it this job fails red on the next issue — a loud signal, not a
+#   silent leak like the built-in workflow.
+
+on:
+  issues:
+    types: [opened, reopened, transferred]
+
+permissions:
+  contents: read
+
+jobs:
+  add-to-project:
+    name: Add issue to Castwright Kanban
+    runs-on: ubuntu-latest
+    # Tiny single-step job; cap explicitly so a hung run can't bill the
+    # 360-min default (same rationale as pr-issue-link.yml).
+    timeout-minutes: 5
+    steps:
+      - name: Add to project
+        uses: actions/add-to-project@v2.0.0
+        with:
+          project-url: https://github.com/users/dudarenok-maker/projects/1
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/docs/superpowers/specs/2026-07-05-github-issues-kanban-design.md
+++ b/docs/superpowers/specs/2026-07-05-github-issues-kanban-design.md
@@ -117,8 +117,15 @@ only the subset of Status values that applies to its track:
   which issues these are, but auto-routing by label isn't part of the
   built-in workflow set below and isn't built now.
 
-**Built-in automation only** (no custom scripting) for the common-path
-transitions: a new issue is auto-added to the board with Status = `Backlog`;
+**Mostly built-in automation** for the common-path transitions: a new issue
+is auto-added to the board with Status = `Backlog`. **Auto-add is now driven
+by a version-controlled Action** (`.github/workflows/add-to-project.yml`, via
+`actions/add-to-project`, ops #1390) rather than the Project's built-in
+"Auto-add to project" workflow, which had been leaking issues onto the floor
+(e.g. #1386, #1377) — the Action fires on `issues: [opened, reopened,
+transferred]` and needs the `ADD_TO_PROJECT_PAT` repo secret (the default
+`GITHUB_TOKEN` can't write a user-owned Projects v2 board). Everything else
+below stays built-in:
 GitHub's separate **"Item closed"** workflow moves that issue's card to
 `Done` when the issue itself closes (including via a PR's `Closes #NN` on
 merge); a reopened issue moves back to `Backlog`. These are two distinct


### PR DESCRIPTION
## Summary

New issues kept landing **off** the GitHub Projects v2 "Castwright Kanban" board (e.g. #1386, #1377), so they were invisible to the planning views and `backlog:sync` — and had to be added to the board by hand. The kanban design intended GitHub's *built-in* "Auto-add to project" workflow to cover this, but it leaks.

This replaces reliance on the built-in with a **version-controlled Action** (`.github/workflows/add-to-project.yml`) that fires on `issues: [opened, reopened, transferred]` and adds each issue to the board via `actions/add-to-project@v2.0.0`. Deterministic, lives in git alongside the other 14 workflows, can't silently un-toggle itself.

GitHub offers no way to *block* creating an issue that lacks a project — auto-add-on-create is the achievable guarantee: the issue is on the board the instant it exists.

### ⚠️ One manual step required before this works
Add a repo secret **`ADD_TO_PROJECT_PAT`** — a PAT with **project write** access. The default `GITHUB_TOKEN` **cannot** write a *user-owned* Projects v2 board (the likely reason the built-in was flaky). Classic PAT: `repo` + `project`. Fine-grained: Issues *read* on Castwright + Projects *read & write* on the account. Repo → Settings → Secrets and variables → Actions → New secret. Without it, the job fails **red** on the next issue — a loud signal, not a silent leak.

## Test plan

- No unit test — the deliverable is a GitHub Actions workflow wrapping a third-party action; there's no local runtime surface to exercise.
- **Live verification:** once `ADD_TO_PROJECT_PAT` is set, open a throwaway issue and confirm it appears on the board at Status `Backlog`, then close it. (I also verified all 86 currently-open issues are already on the board, so there's no backfill needed.)
- Release notes intentionally skipped: CI/process-only change, no user- or app-operator-visible delta.

Closes #1390