### PR TITLE
fix(frontend,server): stop cross-book voice-identity bleed for no-voiceId characters

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4126,7 +4126,12 @@ components:
         id:
           {
             type: string,
-            description: 'Stable id used to hash a TTS prebuilt voice. Defaults to character.voiceId or character.id.',
+            description: 'Stable id used to hash a TTS prebuilt voice. Defaults to character.voiceId or character.id. NOT globally unique across the whole workspace-wide voices array — a voiceId-less character (narrator, unknown-male, unknown-female) can share this bare id with an unrelated book''s same-slug character. Safe for same-book joins (see src/lib/voice-character-link.ts); use `familyKey` for anything that needs a globally-unique identity (React keys, cross-book selection, pin state).',
+          }
+        familyKey:
+          {
+            type: string,
+            description: 'Globally-unique key across the whole workspace-wide voices array: the explicit voiceId when the source character set one (deliberate cross-book reuse), else a book-scoped key so two unrelated books'' same-slug, voiceId-less characters (narrator/unknown-male/unknown-female) never collide. Use this for React list keys, cross-book multi-select, and the pin endpoint. Always present on a real server response; consumers should fall back to `id` when absent (e.g. an older/local test fixture).',
           }
         voiceUuid:
           {

--- a/server/src/routes/voices.test.ts
+++ b/server/src/routes/voices.test.ts
@@ -756,6 +756,48 @@ describe('GET /api/voices — cross-book identity collision on a shared, no-voic
     expect(narrator.generated).toBe(true);
     expect(narrator.usedIn).toBe(1);
   });
+
+  it('emits distinct familyKey values for two unrelated books sharing a bare id', async () => {
+    const res = await request(app).get(`/api/voices?engine=qwen&currentBookId=${betaBookId}`);
+    const alpha = res.body.voices.find(
+      (v: { id: string; bookId: string }) => v.id === 'narrator' && v.bookId === alphaBookId,
+    );
+    const beta = res.body.voices.find(
+      (v: { id: string; bookId: string }) => v.id === 'narrator' && v.bookId === betaBookId,
+    );
+    expect(alpha).toBeDefined();
+    expect(beta).toBeDefined();
+    expect(alpha.familyKey).toBeTruthy();
+    expect(beta.familyKey).toBeTruthy();
+    expect(alpha.familyKey).not.toBe(beta.familyKey);
+  });
+
+  it("pinning Alpha's narrator (by familyKey) never pins Beta's unrelated same-id narrator", async () => {
+    const before = await request(app).get(`/api/voices?engine=qwen&currentBookId=${betaBookId}`);
+    const alpha = before.body.voices.find(
+      (v: { id: string; bookId: string }) => v.id === 'narrator' && v.bookId === alphaBookId,
+    );
+    try {
+      const pinRes = await request(app)
+        .put(`/api/voices/${encodeURIComponent(alpha.familyKey)}/pin`)
+        .send({ pinned: true });
+      expect(pinRes.status).toBe(204);
+
+      const after = await request(app).get(`/api/voices?engine=qwen&currentBookId=${betaBookId}`);
+      const alphaAfter = after.body.voices.find(
+        (v: { id: string; bookId: string }) => v.id === 'narrator' && v.bookId === alphaBookId,
+      );
+      const betaAfter = after.body.voices.find(
+        (v: { id: string; bookId: string }) => v.id === 'narrator' && v.bookId === betaBookId,
+      );
+      expect(alphaAfter.pinned).toBe(true);
+      expect(betaAfter.pinned).toBeFalsy();
+    } finally {
+      await request(app)
+        .put(`/api/voices/${encodeURIComponent(alpha.familyKey)}/pin`)
+        .send({ pinned: false });
+    }
+  });
 });
 
 describe('GET /api/voices?currentBookId — inCurrentSeries scoping', () => {

--- a/server/src/routes/voices.test.ts
+++ b/server/src/routes/voices.test.ts
@@ -798,6 +798,32 @@ describe('GET /api/voices — cross-book identity collision on a shared, no-voic
         .send({ pinned: false });
     }
   });
+
+  it("a legacy bare-id pin (set before the familyKey migration) still surfaces as pinned, not silently lost", async () => {
+    /* voices.json's `pinned` array is workspace-global and never rewritten
+       on upgrade. A pin set before this fix stored the bare id ('narrator')
+       — the only scheme that existed then. Simulate that by writing it
+       directly (bypassing the PUT route, which now only ever writes
+       familyKey values), then confirm the read side's legacy fallback
+       still honours it instead of the pin silently vanishing. */
+    const [{ voicesMetaPath }, { writeJsonAtomic }] = await Promise.all([
+      import('../workspace/paths.js'),
+      import('../workspace/state-io.js'),
+    ]);
+    try {
+      await writeJsonAtomic(voicesMetaPath(), {
+        pinned: ['narrator'],
+        updatedAt: new Date().toISOString(),
+      });
+      const res = await request(app).get(`/api/voices?engine=qwen&currentBookId=${alphaBookId}`);
+      const alpha = res.body.voices.find(
+        (v: { id: string; bookId: string }) => v.id === 'narrator' && v.bookId === alphaBookId,
+      );
+      expect(alpha.pinned).toBe(true);
+    } finally {
+      await writeJsonAtomic(voicesMetaPath(), { pinned: [], updatedAt: new Date().toISOString() });
+    }
+  });
 });
 
 describe('GET /api/voices?currentBookId — inCurrentSeries scoping', () => {

--- a/server/src/routes/voices.test.ts
+++ b/server/src/routes/voices.test.ts
@@ -620,6 +620,144 @@ describe('GET /api/voices — languageCode on designed Qwen voices', () => {
   });
 });
 
+describe('GET /api/voices — cross-book identity collision on a shared, no-voiceId id', () => {
+  /* Real-world bug: the analyzer assigns the SAME literal id ('narrator',
+     'unknown-male', 'unknown-female') to every book's narrator / auto-folded
+     background-bucket character, and — unlike a deliberately reused voice —
+     these never get an explicit `voiceId` (only a per-book `voiceUuid`).
+     aggregateVoices used to key its workspace-wide fold on `c.voiceId ?? c.id`,
+     so two totally unrelated standalone books both landed in the SAME
+     acc-map slot purely by id coincidence, and one book's `generated` /
+     `languageCode` / `voiceUuid` bled into the other's.
+
+     Two standalone books, unrelated authors, both with a 'narrator' Qwen
+     character and NO voiceId:
+       - Alpha (English): rendered chapter 1 — narrator IS generated.
+       - Beta (Russian): designed but never rendered — narrator is NOT
+         generated.
+     Querying with each book as currentBookId must return THAT book's own
+     narrator (own languageCode, own voiceUuid, own generated status,
+     usedIn:1) — never the other book's. */
+  const ALPHA_AUTHOR = 'Alpha Author';
+  const ALPHA_TITLE = 'Alpha Book';
+  const BETA_AUTHOR = 'Beta Author';
+  const BETA_TITLE = 'Beta Book';
+  let alphaBookId: string;
+  let betaBookId: string;
+
+  let alphaManifestPath: string;
+  let betaManifestPath: string;
+
+  beforeAll(async () => {
+    const [{ makeBookId, qwenVoiceSidecarPath }, { dirname }] = await Promise.all([
+      import('../workspace/paths.js'),
+      import('node:path'),
+    ]);
+    alphaBookId = makeBookId(ALPHA_AUTHOR, 'Standalones', ALPHA_TITLE);
+    betaBookId = makeBookId(BETA_AUTHOR, 'Standalones', BETA_TITLE);
+
+    const alphaDir = writeBookOnDisk(
+      workspaceRoot,
+      ALPHA_AUTHOR,
+      'Standalones',
+      ALPHA_TITLE,
+      alphaBookId,
+      [
+        {
+          id: 'narrator',
+          name: 'Narrator',
+          voiceUuid: 'ALPHAUUID1',
+          ttsEngine: 'qwen',
+          overrideTtsVoices: { qwen: { name: 'qwen-ALPHAUUID1' } },
+          attributes: [],
+          lines: 100,
+          scenes: 1,
+        },
+      ],
+      true,
+    );
+    /* Give Alpha a chapter and a rendered segments snapshot so its narrator
+       is genuinely `generated`. writeBookOnDisk seeds state.json with an
+       empty chapters array — rewrite it with one chapter. */
+    const alphaStatePath = join(alphaDir, '.audiobook', 'state.json');
+    const alphaState = JSON.parse(readFileSync(alphaStatePath, 'utf8'));
+    alphaState.chapters = [{ id: 1, slug: '01-one', title: 'One' }];
+    writeFileSync(alphaStatePath, JSON.stringify(alphaState));
+    mkdirSync(join(alphaDir, 'audio'), { recursive: true });
+    writeFileSync(
+      join(alphaDir, 'audio', '01-one.segments.json'),
+      JSON.stringify({
+        bookId: alphaBookId,
+        chapterId: 1,
+        chapterTitle: 'One',
+        synthesizedAt: new Date().toISOString(),
+        segments: [],
+        characterSnapshots: {
+          narrator: { voiceEngine: 'qwen', resolvedVoiceName: 'qwen-ALPHAUUID1' },
+        },
+      }),
+    );
+    alphaManifestPath = qwenVoiceSidecarPath('qwen-ALPHAUUID1');
+    mkdirSync(dirname(alphaManifestPath), { recursive: true });
+    writeFileSync(alphaManifestPath, JSON.stringify({ language: 'English' }));
+
+    writeBookOnDisk(
+      workspaceRoot,
+      BETA_AUTHOR,
+      'Standalones',
+      BETA_TITLE,
+      betaBookId,
+      [
+        {
+          id: 'narrator',
+          name: 'Рассказчик',
+          voiceUuid: 'BETAUUID1',
+          ttsEngine: 'qwen',
+          overrideTtsVoices: { qwen: { name: 'qwen-BETAUUID1' } },
+          attributes: [],
+          lines: 200,
+          scenes: 1,
+        },
+      ],
+      true,
+    );
+    betaManifestPath = qwenVoiceSidecarPath('qwen-BETAUUID1');
+    mkdirSync(dirname(betaManifestPath), { recursive: true });
+    writeFileSync(betaManifestPath, JSON.stringify({ language: 'Russian' }));
+  });
+
+  afterAll(() => {
+    rmSync(alphaManifestPath, { force: true });
+    rmSync(betaManifestPath, { force: true });
+  });
+
+  it("Alpha's own render status/language never bleeds onto Beta", async () => {
+    const res = await request(app).get(`/api/voices?engine=qwen&currentBookId=${betaBookId}`);
+    expect(res.status).toBe(200);
+    const narrator = res.body.voices.find(
+      (v: { id: string; bookId: string }) => v.id === 'narrator' && v.bookId === betaBookId,
+    );
+    expect(narrator).toBeDefined();
+    expect(narrator.voiceUuid).toBe('BETAUUID1');
+    expect(narrator.languageCode).toBe('ru');
+    expect(narrator.generated).toBeFalsy();
+    expect(narrator.usedIn).toBe(1);
+  });
+
+  it("Beta's own (unrendered) status never suppresses Alpha's real generated flag", async () => {
+    const res = await request(app).get(`/api/voices?engine=qwen&currentBookId=${alphaBookId}`);
+    expect(res.status).toBe(200);
+    const narrator = res.body.voices.find(
+      (v: { id: string; bookId: string }) => v.id === 'narrator' && v.bookId === alphaBookId,
+    );
+    expect(narrator).toBeDefined();
+    expect(narrator.voiceUuid).toBe('ALPHAUUID1');
+    expect(narrator.languageCode).toBe('en');
+    expect(narrator.generated).toBe(true);
+    expect(narrator.usedIn).toBe(1);
+  });
+});
+
 describe('GET /api/voices?currentBookId — inCurrentSeries scoping', () => {
   /* A self-contained author with: a two-book series (Trilogy), a same-author
      spinoff in a DIFFERENT series, and a standalone. Distinct voiceIds per

--- a/server/src/routes/voices.ts
+++ b/server/src/routes/voices.ts
@@ -437,8 +437,16 @@ async function aggregateVoices(
                pin toggled from the client sends `familyKey` as the
                `:voiceId` route param (src/views/voices.tsx togglePin), so
                reading it back must use the same book-scoped key or pin
-               state bleeds across unrelated books' same-slug characters. */
-            pinned: pinned.has(dedupKey) || undefined,
+               state bleeds across unrelated books' same-slug characters.
+               `pinned.has(id)` is a MIGRATION fallback: a pin set before
+               this change persisted the bare id (the only scheme that
+               existed then) in voices.json, and nothing rewrites that file
+               on upgrade — without this fallback a pre-existing pin on a
+               voiceId-less character would silently vanish. Harmless
+               false-positive risk only for the exact pre-existing
+               cross-book ambiguity this whole fix addresses, which is no
+               worse than the pin behavior before this change. */
+            pinned: (pinned.has(dedupKey) || pinned.has(id)) || undefined,
             /* srv-43 Wave 2: key on the STORAGE key (qwenStoreKey) so a uuid-
                bearing voice (storage key = qwen-<uuid>) still matches the
                rendered snapshot even though ttsVoice.name is now qwen-<voiceId>. */

--- a/server/src/routes/voices.ts
+++ b/server/src/routes/voices.ts
@@ -72,6 +72,14 @@ export const voicesRouter = Router();
 
 interface DerivedVoice {
   id: string;
+  /** Globally-unique key across the whole workspace-wide voices array: the
+      explicit voiceId when the source character set one (deliberate
+      cross-book reuse — the SAME value as `id` in that case), else a
+      book-scoped key. `id` alone is NOT safe for this — two unrelated
+      books' voiceId-less narrator/unknown-male/unknown-female characters
+      share the same literal `id`. Use this for React list keys, cross-book
+      multi-select, and the pin endpoint; use `id` for same-book joins. */
+  familyKey: string;
   character: string;
   bookTitle: string;
   bookId: string;
@@ -407,6 +415,7 @@ async function aggregateVoices(
               : ttsVoiceRaw;
           acc.set(dedupKey, {
             id,
+            familyKey: dedupKey,
             character: c.name ?? id,
             bookTitle: state.title,
             bookId: state.bookId,
@@ -424,7 +433,12 @@ async function aggregateVoices(
             usedIn: 1,
             source: isCurrent ? 'current' : 'library',
             reusable: isNarratorId(id, c.name) || undefined,
-            pinned: pinned.has(id) || undefined,
+            /* Keyed on `dedupKey` (== `familyKey`), NOT the bare `id` — a
+               pin toggled from the client sends `familyKey` as the
+               `:voiceId` route param (src/views/voices.tsx togglePin), so
+               reading it back must use the same book-scoped key or pin
+               state bleeds across unrelated books' same-slug characters. */
+            pinned: pinned.has(dedupKey) || undefined,
             /* srv-43 Wave 2: key on the STORAGE key (qwenStoreKey) so a uuid-
                bearing voice (storage key = qwen-<uuid>) still matches the
                rendered snapshot even though ttsVoice.name is now qwen-<voiceId>. */

--- a/server/src/routes/voices.ts
+++ b/server/src/routes/voices.ts
@@ -282,6 +282,20 @@ async function aggregateVoices(
           const c = normaliseCastCharacter(rawC);
           const id = c.voiceId ?? c.id;
           if (!id) continue;
+          /* Cross-book MERGE key — deliberately separate from the public `id`
+             above. An explicit `voiceId` is the only real signal that two
+             characters in different books are meant to be the same voice
+             (series continuity, deliberate reuse). Without one, bare `c.id`
+             is NOT a safe cross-book identity: the analyzer assigns the same
+             literal id ('narrator', 'unknown-male', 'unknown-female') to
+             EVERY book's narrator and auto-folded background-bucket
+             character, so two unrelated standalone books can coincidentally
+             share it. Scoping the fold key by bookId in that case stops one
+             book's generated/sampled/languageCode/voiceUuid from bleeding
+             into an unrelated book's same-slug character. `id` itself stays
+             the bare `voiceId ?? c.id` so the frontend's same-book id-
+             fallback join (voice-character-link.ts) is unaffected. */
+          const dedupKey = c.voiceId ?? `${state.bookId}::${id}`;
           /* The sample-cache scope keys on `char-<id>` (not bare `<id>`) for a
              voiceId-less character — matching the frontend's sampleScopeFor —
              so it can diverge from `id` above. Compute it explicitly. */
@@ -296,7 +310,7 @@ async function aggregateVoices(
           const overrideMap = c.overrideTtsVoices ?? null;
           const overrideForEngine = overrideMap?.[engine] ?? null;
           const legacyShape = overrideForEngine ? { engine, name: overrideForEngine.name } : null;
-          const existing = acc.get(id);
+          const existing = acc.get(dedupKey);
           if (existing) {
             existing.books.add(state.bookId);
             existing.usedIn = existing.books.size;
@@ -391,7 +405,7 @@ async function aggregateVoices(
             engine === 'qwen' && ttsVoiceRaw.name
               ? { ...ttsVoiceRaw, name: `qwen-${id}` }
               : ttsVoiceRaw;
-          acc.set(id, {
+          acc.set(dedupKey, {
             id,
             character: c.name ?? id,
             bookTitle: state.title,

--- a/src/components/voice-library-panel.test.tsx
+++ b/src/components/voice-library-panel.test.tsx
@@ -311,6 +311,80 @@ describe('VoiceLibraryPanel — Cast-view interactions', () => {
   });
 });
 
+describe('VoiceCard — familyKey identity (cross-book id collision)', () => {
+  /* Regression: two unrelated books' voiceId-less characters (narrator,
+     unknown-male, unknown-female) can share a bare Voice.id in the "All"
+     tab's flat, all-books array. Drag/assign identity must key on
+     familyKey (falling back to id) so highlighting one card can never
+     cross-highlight an unrelated book's same-id card. */
+
+  it('reports familyKey (not the bare id) to setDraggingVoiceId on drag start', () => {
+    const setDraggingVoiceId = vi.fn();
+    const voice = makeVoice('narrator', 'Narrator', { familyKey: 'book-a::narrator' });
+    render(
+      <VoiceCard voice={voice} draggingVoiceId={null} setDraggingVoiceId={setDraggingVoiceId} />,
+    );
+    const card = screen.getByText('Narrator').closest('div[draggable]')!;
+    fireEvent.dragStart(card, { dataTransfer: { effectAllowed: 'copy', setData: () => {} } });
+    expect(setDraggingVoiceId).toHaveBeenCalledWith('book-a::narrator');
+  });
+
+  it('only highlights the card whose familyKey matches draggingVoiceId, not a same-bare-id sibling', () => {
+    const ownVoice = makeVoice('narrator', 'Narrator', {
+      familyKey: 'book-a::narrator',
+      bookId: 'book-a',
+    });
+    const foreignVoice = makeVoice('narrator', 'Narrator', {
+      familyKey: 'book-b::narrator',
+      bookId: 'book-b',
+      source: 'library',
+    });
+    render(
+      <VoiceLibraryPanel
+        library={[foreignVoice, ownVoice]}
+        draggingVoiceId="book-a::narrator"
+        setDraggingVoiceId={vi.fn()}
+      />,
+    );
+    /* The default tab is "This book" (current-only) — switch to "All" so
+       both the own AND the foreign same-bare-id card render together. */
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    const cards = screen.getAllByText('Narrator').map((el) => el.closest('div[draggable]')!);
+    expect(cards).toHaveLength(2);
+    const draggingCards = cards.filter((c) => c.className.includes('opacity-40'));
+    expect(draggingCards).toHaveLength(1);
+  });
+
+  it('only highlights the card whose familyKey matches assigningVoiceId, not a same-bare-id sibling', () => {
+    const ownVoice = makeVoice('narrator', 'Narrator', {
+      familyKey: 'book-a::narrator',
+      bookId: 'book-a',
+    });
+    const foreignVoice = makeVoice('narrator', 'Narrator', {
+      familyKey: 'book-b::narrator',
+      bookId: 'book-b',
+      source: 'library',
+    });
+    render(
+      <VoiceLibraryPanel
+        library={[foreignVoice, ownVoice]}
+        draggingVoiceId={null}
+        setDraggingVoiceId={vi.fn()}
+        onTapAssign={vi.fn()}
+        assigningVoiceId="book-a::narrator"
+      />,
+    );
+    /* The default tab is "This book" (current-only) — switch to "All" so
+       both the own AND the foreign same-bare-id card render together. */
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    /* Only the matching card's Assign pill reads "Cancel" (the active
+       assigning-target state); the foreign same-id card must still read
+       "Assign". */
+    expect(screen.getAllByRole('button', { name: /^Cancel /i })).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: /^Assign /i })).toHaveLength(1);
+  });
+});
+
 describe('VoiceLibraryPanel — search', () => {
   const lib: Voice[] = [
     makeVoice('v_marlow', 'Marlow Halden', { bookTitle: 'The Hollow Tide' }),

--- a/src/components/voice-library-panel.tsx
+++ b/src/components/voice-library-panel.tsx
@@ -121,8 +121,12 @@ export function VoiceLibraryPanel({
     { id: 'current', label: 'This book' },
     ...(hasSeriesVoices ? [{ id: 'library' as Tab, label: 'Series' }] : []),
   ];
+  /* `characters` here is always the currently-open book's own cast, so opt
+     into the current-book restriction — a same-id foreign-book voice (the
+     narrator/unknown-male/unknown-female collision) must never resolve to
+     one of this book's own characters. */
   const findCharacter = (v: Voice) =>
-    characters ? findCharacterForVoice(v, characters) : undefined;
+    characters ? findCharacterForVoice(v, characters, true) : undefined;
   /* Aside mode keeps the legacy sticky-card sizing. Sheet mode strips
      the rounded card chrome + height cap so the panel can lie flush
      inside the bottom-sheet (which provides its own border + radius
@@ -179,7 +183,12 @@ export function VoiceLibraryPanel({
         ) : (
           shown.map((v) => (
             <VoiceCard
-              key={v.id}
+              /* familyKey (falling back to id) — two unrelated books' same-
+                 slug, voiceId-less voices (narrator/unknown-male/female) can
+                 share bare `id` in this flat, all-books array, which would
+                 otherwise collide on the React key and cross-highlight both
+                 cards as the active assign target. */
+              key={v.familyKey ?? v.id}
               voice={v}
               draggingVoiceId={draggingVoiceId}
               setDraggingVoiceId={setDraggingVoiceId}
@@ -188,7 +197,7 @@ export function VoiceLibraryPanel({
               onOpenProfile={onOpenProfile}
               onPlaySample={onPlaySample}
               onTapAssign={onTapAssign}
-              isAssigningTarget={assigningVoiceId === v.id}
+              isAssigningTarget={assigningVoiceId === (v.familyKey ?? v.id)}
             />
           ))
         )}
@@ -260,7 +269,7 @@ export function VoiceCard({
   isAssigningTarget = false,
   badge,
 }: VoiceCardProps) {
-  const isDragging = draggingVoiceId === voice.id;
+  const isDragging = draggingVoiceId === (voice.familyKey ?? voice.id);
   const canOpenProfile = !!(character && onOpenProfile);
   const canPlay = !!(character && onPlaySample);
   const interactive = !!onSelect || canOpenProfile;
@@ -274,7 +283,7 @@ export function VoiceCard({
     <div
       draggable
       onDragStart={(e) => {
-        setDraggingVoiceId(voice.id);
+        setDraggingVoiceId(voice.familyKey ?? voice.id);
         e.dataTransfer.effectAllowed = 'copy';
       }}
       onDragEnd={() => setDraggingVoiceId(null)}

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -3165,8 +3165,10 @@ export interface components {
             voices: components["schemas"]["BaseVoice"][];
         };
         Voice: {
-            /** @description Stable id used to hash a TTS prebuilt voice. Defaults to character.voiceId or character.id. */
+            /** @description Stable id used to hash a TTS prebuilt voice. Defaults to character.voiceId or character.id. NOT globally unique across the whole workspace-wide voices array — a voiceId-less character (narrator, unknown-male, unknown-female) can share this bare id with an unrelated book's same-slug character. Safe for same-book joins (see src/lib/voice-character-link.ts); use `familyKey` for anything that needs a globally-unique identity (React keys, cross-book selection, pin state). */
             id: string;
+            /** @description Globally-unique key across the whole workspace-wide voices array: the explicit voiceId when the source character set one (deliberate cross-book reuse), else a book-scoped key so two unrelated books' same-slug, voiceId-less characters (narrator/unknown-male/unknown-female) never collide. Use this for React list keys, cross-book multi-select, and the pin endpoint. Always present on a real server response; consumers should fall back to `id` when absent (e.g. an older/local test fixture). */
+            familyKey?: string;
             /** @description srv-43 — the designed voice's immutable identity, copied from the source Character. Optional; absent for catalog voices and pre-srv-43 designs. */
             voiceUuid?: string;
             character: string;

--- a/src/lib/voice-character-link.test.ts
+++ b/src/lib/voice-character-link.test.ts
@@ -109,6 +109,41 @@ describe('findCharacterForVoice', () => {
     const characters = [makeChar('marlow')];
     expect(findCharacterForVoice(v, characters)).toBeUndefined();
   });
+
+  it("with restrictToCurrentBook=true, never matches a foreign book's same-id voice to this book's own character (no voiceId link)", () => {
+    /* Regression: the cast view's voice-library panel always passes the
+       currently-open book's own roster and opts into this restriction.
+       Two unrelated books' voiceId-less narrators share bare id 'narrator'
+       — a foreign book's voice card must never resolve to this book's own
+       narrator character just because the ids coincide. */
+    const foreignNarratorVoice: Voice = {
+      ...makeVoice('narrator', 'Narrator'),
+      source: 'library',
+      bookId: 'unrelated-book',
+    };
+    const characters = [makeChar('narrator')];
+    expect(findCharacterForVoice(foreignNarratorVoice, characters, true)).toBeUndefined();
+  });
+
+  it("with restrictToCurrentBook=true, still matches by bare id when the voice IS this book's own (source: 'current')", () => {
+    const ownNarratorVoice: Voice = { ...makeVoice('narrator', 'Narrator'), source: 'current' };
+    const characters = [makeChar('narrator')];
+    expect(findCharacterForVoice(ownNarratorVoice, characters, true)?.id).toBe('narrator');
+  });
+
+  it('defaults to unrestricted (matches by bare id regardless of source) for the cross-book duplicate-review flow', () => {
+    /* views/voices.tsx intentionally matches a voice against an arbitrary
+       OTHER book's own roster it fetched on demand — `source` there
+       describes the globally-open book, not the roster being searched, so
+       the default (no third arg) must NOT apply the current-book guard. */
+    const otherBooksVoice: Voice = {
+      ...makeVoice('narrator', 'Narrator'),
+      source: 'library',
+      bookId: 'some-other-book',
+    };
+    const thatBooksOwnCharacters = [makeChar('narrator')];
+    expect(findCharacterForVoice(otherBooksVoice, thatBooksOwnCharacters)?.id).toBe('narrator');
+  });
 });
 
 describe('pickMergeSurvivor', () => {

--- a/src/lib/voice-character-link.test.ts
+++ b/src/lib/voice-character-link.test.ts
@@ -57,6 +57,35 @@ describe('findVoiceForCharacter', () => {
     const c = makeChar('marlow');
     expect(findVoiceForCharacter(c, [])).toBeUndefined();
   });
+
+  it("prefers the current book's own voice over an unrelated book sharing the same bare id (no voiceId)", () => {
+    /* Real-world collision: the analyzer assigns the SAME literal id
+       ('narrator', 'unknown-male', 'unknown-female') to every book's
+       narrator / auto-folded background character, and neither ever gets an
+       explicit voiceId. Two unrelated books' narrators both resolve to bare
+       id 'narrator' — the current book's own `source: 'current'` entry must
+       win over a same-id `source: 'library'` entry from a different book,
+       regardless of array order (the server can't guarantee scan order). */
+    const c = makeChar('narrator');
+    const ownBookVoice: Voice = { ...makeVoice('narrator', 'Narrator'), source: 'current' };
+    const foreignBookVoice: Voice = {
+      ...makeVoice('narrator', 'Narrator'),
+      source: 'library',
+      bookId: 'unrelated-book',
+    };
+    expect(findVoiceForCharacter(c, [foreignBookVoice, ownBookVoice])).toBe(ownBookVoice);
+    expect(findVoiceForCharacter(c, [ownBookVoice, foreignBookVoice])).toBe(ownBookVoice);
+  });
+
+  it('falls back to any bare-id match when no current-book voice is present', () => {
+    const c = makeChar('narrator');
+    const libraryVoice: Voice = {
+      ...makeVoice('narrator', 'Narrator'),
+      source: 'library',
+      bookId: 'unrelated-book',
+    };
+    expect(findVoiceForCharacter(c, [libraryVoice])).toBe(libraryVoice);
+  });
 });
 
 describe('findCharacterForVoice', () => {

--- a/src/lib/voice-character-link.test.ts
+++ b/src/lib/voice-character-link.test.ts
@@ -58,14 +58,16 @@ describe('findVoiceForCharacter', () => {
     expect(findVoiceForCharacter(c, [])).toBeUndefined();
   });
 
-  it("prefers the current book's own voice over an unrelated book sharing the same bare id (no voiceId)", () => {
+  it("with preferCurrentBook=true, prefers the current book's own voice over an unrelated book sharing the same bare id (no voiceId)", () => {
     /* Real-world collision: the analyzer assigns the SAME literal id
        ('narrator', 'unknown-male', 'unknown-female') to every book's
        narrator / auto-folded background character, and neither ever gets an
        explicit voiceId. Two unrelated books' narrators both resolve to bare
        id 'narrator' — the current book's own `source: 'current'` entry must
        win over a same-id `source: 'library'` entry from a different book,
-       regardless of array order (the server can't guarantee scan order). */
+       regardless of array order (the server can't guarantee scan order).
+       Only safe for callers whose `c` is guaranteed to be the currently-
+       open book's own character (cast.tsx, voice-readiness-selectors.ts). */
     const c = makeChar('narrator');
     const ownBookVoice: Voice = { ...makeVoice('narrator', 'Narrator'), source: 'current' };
     const foreignBookVoice: Voice = {
@@ -73,18 +75,40 @@ describe('findVoiceForCharacter', () => {
       source: 'library',
       bookId: 'unrelated-book',
     };
-    expect(findVoiceForCharacter(c, [foreignBookVoice, ownBookVoice])).toBe(ownBookVoice);
-    expect(findVoiceForCharacter(c, [ownBookVoice, foreignBookVoice])).toBe(ownBookVoice);
+    expect(findVoiceForCharacter(c, [foreignBookVoice, ownBookVoice], true)).toBe(ownBookVoice);
+    expect(findVoiceForCharacter(c, [ownBookVoice, foreignBookVoice], true)).toBe(ownBookVoice);
   });
 
-  it('falls back to any bare-id match when no current-book voice is present', () => {
+  it('with preferCurrentBook=true, falls back to any bare-id match when no current-book voice is present', () => {
     const c = makeChar('narrator');
     const libraryVoice: Voice = {
       ...makeVoice('narrator', 'Narrator'),
       source: 'library',
       bookId: 'unrelated-book',
     };
-    expect(findVoiceForCharacter(c, [libraryVoice])).toBe(libraryVoice);
+    expect(findVoiceForCharacter(c, [libraryVoice], true)).toBe(libraryVoice);
+  });
+
+  it('defaults to unrestricted (no current-book preference) for the cross-book compare/rebaseline flows', () => {
+    /* compare-cast-modal.tsx and rebaseline-modal.tsx resolve a voice for an
+       arbitrary OTHER book's character (a specific comparison/rebaseline
+       side, not the globally-open book) — they must NOT get the
+       preferCurrentBook substitution, or they'd silently resolve the
+       open book's own same-id voice instead of that side's real one. The
+       default (no third arg) just matches by bare id, whichever comes
+       first — same as pre-fix behavior, so these callers see no change. */
+    const c = makeChar('narrator');
+    const openBooksOwnVoice: Voice = { ...makeVoice('narrator', 'Narrator'), source: 'current' };
+    const thisSidesRealVoice: Voice = {
+      ...makeVoice('narrator', 'Narrator'),
+      source: 'library',
+      bookId: 'the-actual-book-being-compared',
+    };
+    /* thisSidesRealVoice listed first → unrestricted default returns it,
+       proving the current-book entry is NOT preferred unless opted in. */
+    expect(findVoiceForCharacter(c, [thisSidesRealVoice, openBooksOwnVoice])).toBe(
+      thisSidesRealVoice,
+    );
   });
 });
 

--- a/src/lib/voice-character-link.ts
+++ b/src/lib/voice-character-link.ts
@@ -37,9 +37,24 @@ export function findVoiceForCharacter(c: Character, library: Voice[]): Voice | u
   return library.find((v) => v.id === c.id);
 }
 
-export function findCharacterForVoice(v: Voice, characters: Character[]): Character | undefined {
+export function findCharacterForVoice(
+  v: Voice,
+  characters: Character[],
+  /** Restrict the bare-id fallback to a voice that actually belongs to the
+      CURRENTLY-OPEN book (`v.source === 'current'`). Opt-in (default false)
+      because not every caller's `characters` is that book's own roster —
+      the cross-book duplicate-review flow (views/voices.tsx) intentionally
+      matches a voice against an arbitrary OTHER book's roster it fetched on
+      demand, where `source` describes the globally-open book, not that
+      roster. Only the cast view's voice-library panel needs this: its
+      `characters` IS always the open book's own cast, so a same-id foreign
+      voice (the narrator/unknown-male/unknown-female collision) must never
+      resolve to one of ITS characters. */
+  restrictToCurrentBook = false,
+): Character | undefined {
   const explicit = characters.find((c) => c.voiceId === v.id);
   if (explicit) return explicit;
+  if (restrictToCurrentBook && v.source !== 'current') return undefined;
   return characters.find((c) => c.id === v.id);
 }
 

--- a/src/lib/voice-character-link.ts
+++ b/src/lib/voice-character-link.ts
@@ -21,19 +21,34 @@
    entries with that same id — one this character's own (`source:
    'current'`), one an unrelated book's (`source: 'library'`). A plain
    `.find()` would return whichever happens to be array-first. Preferring a
-   `source: 'current'` match first removes that ambiguity: the character
-   being looked up always belongs to the currently-open book, so its own
-   voice (if the fallback found anything at all) is always the right one. */
+   `source: 'current'` match first removes that ambiguity — but ONLY when
+   `c` itself is known to belong to the currently-open book (see
+   `preferCurrentBook` below). */
 
 import type { Character, Voice } from './types';
 
-export function findVoiceForCharacter(c: Character, library: Voice[]): Voice | undefined {
+export function findVoiceForCharacter(
+  c: Character,
+  library: Voice[],
+  /** Prefer a `source: 'current'` match for the bare-id fallback. Opt-in
+      (default false) because not every caller's `c` belongs to the
+      globally-open book — compare-cast-modal.tsx and rebaseline-modal.tsx
+      intentionally resolve a voice for an arbitrary OTHER book's character
+      (a cross-book comparison/rebaseline side), where preferring the
+      open book's own same-id voice would silently substitute the wrong
+      book's voice (including its sample audio). Only callers whose `c` is
+      guaranteed to be the currently-open book's own character (the cast
+      view, the voice-readiness gate) should pass true. */
+  preferCurrentBook = false,
+): Voice | undefined {
   if (c.voiceId) {
     const explicit = library.find((v) => v.id === c.voiceId);
     if (explicit) return explicit;
   }
-  const currentBookMatch = library.find((v) => v.id === c.id && v.source === 'current');
-  if (currentBookMatch) return currentBookMatch;
+  if (preferCurrentBook) {
+    const currentBookMatch = library.find((v) => v.id === c.id && v.source === 'current');
+    if (currentBookMatch) return currentBookMatch;
+  }
   return library.find((v) => v.id === c.id);
 }
 

--- a/src/lib/voice-character-link.ts
+++ b/src/lib/voice-character-link.ts
@@ -11,7 +11,19 @@
         rely on this fallback.
 
    Without (2) the cast Voice column shows "No library voice" on every row
-   of a freshly-analysed book and the library panel cards stay inert. */
+   of a freshly-analysed book and the library panel cards stay inert.
+
+   Rule (2) has a real collision, though: the analyzer assigns the SAME
+   literal id ('narrator', 'unknown-male', 'unknown-female') to every book's
+   narrator and auto-folded background-bucket character, and neither ever
+   gets an explicit voiceId. Two unrelated books' narrators both fall back
+   to bare id 'narrator', so the aggregated `library` array can carry two
+   entries with that same id — one this character's own (`source:
+   'current'`), one an unrelated book's (`source: 'library'`). A plain
+   `.find()` would return whichever happens to be array-first. Preferring a
+   `source: 'current'` match first removes that ambiguity: the character
+   being looked up always belongs to the currently-open book, so its own
+   voice (if the fallback found anything at all) is always the right one. */
 
 import type { Character, Voice } from './types';
 
@@ -20,6 +32,8 @@ export function findVoiceForCharacter(c: Character, library: Voice[]): Voice | u
     const explicit = library.find((v) => v.id === c.voiceId);
     if (explicit) return explicit;
   }
+  const currentBookMatch = library.find((v) => v.id === c.id && v.source === 'current');
+  if (currentBookMatch) return currentBookMatch;
   return library.find((v) => v.id === c.id);
 }
 

--- a/src/modals/compare-cast-modal.tsx
+++ b/src/modals/compare-cast-modal.tsx
@@ -280,6 +280,11 @@ function buildSideContext(
      live as the user edits. Sample requests use the same dirty hint via
      buildCharacterHint(character, draft). */
   const merged = mergeDraft(c, draft);
+  /* Deliberately NOT preferCurrentBook: true — `c` here is a specific
+     comparison SIDE's character, which is frequently a DIFFERENT book than
+     the globally-open one (cross-book compare is explicitly supported).
+     Preferring the open book's own same-id voice would silently substitute
+     the wrong book's voice for this side. */
   const matched = findVoiceForCharacter(c, library);
   const sampleVoiceId = sampleScopeFor(c);
   const ttsVoice = matched?.ttsVoice ?? resolveTtsVoiceForCharacter(merged, engine);

--- a/src/modals/profile-drawer.test.tsx
+++ b/src/modals/profile-drawer.test.tsx
@@ -622,6 +622,67 @@ describe('ProfileDrawer Play sample (auto-load path)', () => {
     await waitFor(() => expect(playSampleWithAutoLoad).toHaveBeenCalledTimes(1));
     expect(vi.mocked(playSampleWithAutoLoad).mock.calls[0][0].args.voiceId).toBe('char-brann');
   });
+
+  it("prefers the character's own voiceUuid over a stale/foreign one on the matched library voice (Qwen)", async () => {
+    /* Regression: `stagedVoiceUuid` (the top of the fallback chain) is
+       seeded ONCE at mount from `character.voiceUuid ?? voice?.voiceUuid`
+       and nothing re-syncs it afterward. So the only way `character.voiceUuid`
+       vs `voice?.voiceUuid` ordering actually matters is when BOTH are
+       absent at mount (stagedVoiceUuid stays undefined) and the `character`
+       prop is later updated in place — e.g. the parent's cast refetches
+       while the drawer stays open — to carry a real voiceUuid, while
+       `voice` (a derived, cross-book lookup — the same collision class
+       cast.tsx's playSampleFor was fixed for) still carries an unrelated,
+       stale/foreign one. The character's fresh, unambiguous voiceUuid must
+       win. Mirrors the equivalent fix in src/views/cast.tsx's playSampleFor. */
+    const qwenCharNoUuidYet: Character = {
+      ...brann,
+      ttsEngine: 'qwen',
+      overrideTtsVoices: { qwen: { name: 'qwen-brann' } },
+    };
+    const foreignVoiceNoUuidYet: Voice = {
+      id: 'brann',
+      character: 'Brann',
+      bookTitle: 'Some Other Book',
+      bookId: 'other-book',
+      attributes: [],
+      gradient: ['#000', '#fff'],
+      usedIn: 1,
+      source: 'library',
+      ttsVoice: { provider: 'qwen', name: 'qwen-brann', description: 'Designed voice' },
+    };
+    vi.mocked(playSampleWithAutoLoad).mockClear();
+    vi.mocked(playSampleWithAutoLoad).mockResolvedValueOnce({ analyzerEvicted: false });
+    const { rerender } = render(
+      <Provider store={makeStore()}>
+        <ProfileDrawer
+          character={qwenCharNoUuidYet}
+          voice={foreignVoiceNoUuidYet}
+          onClose={() => {}}
+          onSave={() => {}}
+          onLock={() => {}}
+        />
+      </Provider>,
+    );
+    /* Same component instance, updated props: the character's own cast.json
+       now carries its real voiceUuid; the matched library voice (an
+       unrelated book's same-id entry) carries a different, foreign one. */
+    rerender(
+      <Provider store={makeStore()}>
+        <ProfileDrawer
+          character={{ ...qwenCharNoUuidYet, voiceUuid: 'own-uuid-correct' }}
+          voice={{ ...foreignVoiceNoUuidYet, voiceUuid: 'foreign-uuid-from-other-book' }}
+          onClose={() => {}}
+          onSave={() => {}}
+          onLock={() => {}}
+        />
+      </Provider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Play 12s sample/i }));
+    await waitFor(() => expect(playSampleWithAutoLoad).toHaveBeenCalledTimes(1));
+    const args = vi.mocked(playSampleWithAutoLoad).mock.calls[0][0].args;
+    expect(args.voice.voiceUuid).toBe('own-uuid-correct');
+  });
 });
 
 describe('ProfileDrawer downgrade to background bucket', () => {

--- a/src/modals/profile-drawer.tsx
+++ b/src/modals/profile-drawer.tsx
@@ -631,12 +631,22 @@ export function ProfileDrawer({
        pickVoiceForEngine('qwen', …) resolves it; preserve any other-engine
        slots already on the subject. Non-qwen engines pass through unchanged.
        srv-43: also inject voiceUuid so qwenStorageKey resolves the uuid-keyed
-       cache entry the design route wrote, instead of the legacy name-derived key. */
+       cache entry the design route wrote, instead of the legacy name-derived key.
+       The character's OWN voiceUuid (freshest prop data, read straight from this
+       book's cast.json) wins over the matched library voice's — that field is the
+       unambiguous ground truth, whereas `voice` is a derived, cross-book lookup
+       that can carry a stale/foreign uuid (the same class of bug cast.tsx's
+       playSampleFor was fixed for). `voice?.voiceUuid` only fills in for a
+       genuinely reused character that carries none of its own. */
     const requestSubject =
       effectiveEngine === 'qwen' && designedVoiceId
         ? {
             ...sampleSubject,
-            voiceUuid: stagedVoiceUuid ?? voice?.voiceUuid ?? singleDesign?.preview?.voiceUuid ?? character.voiceUuid,
+            voiceUuid:
+              stagedVoiceUuid ??
+              character.voiceUuid ??
+              voice?.voiceUuid ??
+              singleDesign?.preview?.voiceUuid,
             overrideTtsVoices: {
               ...(voice?.overrideTtsVoices ?? {}),
               qwen: { name: designedVoiceId },

--- a/src/modals/rebaseline-modal.tsx
+++ b/src/modals/rebaseline-modal.tsx
@@ -423,6 +423,10 @@ function RebaselineModal({ bookId }: { bookId: string }): JSX.Element {
 
   /* Audition the CURRENT voice for a character (existing sample path). */
   async function playCurrent(character: Character) {
+    /* Deliberately NOT preferCurrentBook: true — rebaseline walks a SERIES'
+       characters across multiple books, not just the globally-open one;
+       preferring the open book's own same-id voice would silently
+       substitute the wrong book's voice/sample for a sibling-book character. */
     const matched = findVoiceForCharacter(character, voices);
     const voiceId = matched?.id ?? `char-${character.id}`;
     const subject: Voice =

--- a/src/store/voice-readiness-selectors.ts
+++ b/src/store/voice-readiness-selectors.ts
@@ -37,8 +37,11 @@ export const selectUndesignedQwenCharacters = createSelector(
     return characters
       .filter(
         (c) =>
-          resolveVoiceStatus(c, findVoiceForCharacter(c, library), c.ttsEngine ?? ttsEngine).lifecycle
-            ?.label === 'Needs voice',
+          /* preferCurrentBook: true — `characters` is state.cast.characters,
+             the currently-open book's own roster (see the doc comment
+             above), so a same-id `source: 'current'` match is safe here. */
+          resolveVoiceStatus(c, findVoiceForCharacter(c, library, true), c.ttsEngine ?? ttsEngine)
+            .lifecycle?.label === 'Needs voice',
       )
       .slice()
       .sort(compareCastRows)

--- a/src/store/voices-slice.test.ts
+++ b/src/store/voices-slice.test.ts
@@ -83,6 +83,22 @@ describe('voicesSlice — setPinned', () => {
     );
     expect(next.voices).toEqual(start.voices);
   });
+
+  it("matches by familyKey, not the bare id, so pinning one book's voice never bleeds onto an unrelated book's same-id voice", () => {
+    /* Two unrelated books' voiceId-less narrators share bare id 'narrator'
+       but get distinct familyKey values from the server (book-scoped). */
+    const alpha = voice('narrator', { familyKey: 'book-alpha::narrator', bookId: 'book-alpha' });
+    const beta = voice('narrator', { familyKey: 'book-beta::narrator', bookId: 'book-beta' });
+    const start = voicesSlice.reducer(undefined, voicesActions.hydrate({ voices: [alpha, beta] }));
+    const next = voicesSlice.reducer(
+      start,
+      voicesActions.setPinned({ voiceId: 'book-alpha::narrator', pinned: true }),
+    );
+    const alphaAfter = next.voices.find((v) => v.bookId === 'book-alpha')!;
+    const betaAfter = next.voices.find((v) => v.bookId === 'book-beta')!;
+    expect(alphaAfter.pinned).toBe(true);
+    expect(betaAfter.pinned).toBeUndefined();
+  });
 });
 
 describe('voicesSlice — markSampled', () => {

--- a/src/store/voices-slice.ts
+++ b/src/store/voices-slice.ts
@@ -34,9 +34,14 @@ export const voicesSlice = createSlice({
       s.voices = a.payload.voices;
     },
     /* Optimistic pin toggle. PUT /api/voices/:id/pin still fires from the
-       view; transient mismatches are cheap (next hydrate corrects them). */
+       view; transient mismatches are cheap (next hydrate corrects them).
+       `voiceId` here is actually the voice's `familyKey` (falling back to
+       `id` for an older/local fixture with no familyKey) — matching by the
+       bare `id` alone would flip the pin on the wrong voice whenever two
+       unrelated books share a voiceId-less character's id (narrator,
+       unknown-male, unknown-female). */
     setPinned: (s, a: PayloadAction<{ voiceId: string; pinned: boolean }>) => {
-      const v = s.voices.find((v) => v.id === a.payload.voiceId);
+      const v = s.voices.find((v) => (v.familyKey ?? v.id) === a.payload.voiceId);
       if (v) v.pinned = a.payload.pinned || undefined;
     },
     /* Optimistic "Sampled" flip. Fired after a successful 12s audition synth

--- a/src/views/cast.test.tsx
+++ b/src/views/cast.test.tsx
@@ -294,7 +294,7 @@ describe('CastView Qwen bespoke sample playback (plan 108 fix)', () => {
      with an empty voice name and the sidecar 400'd ("`voice` is required.").
      The sample must route to the Qwen model key and carry the designed
      voiceId, and gate cleanly when no voice has been designed. */
-  function renderChars(characters: Character[]) {
+  function renderChars(characters: Character[], libraryOverride: Voice[] = library) {
     const store = configureStore({
       reducer: {
         ui: uiSlice.reducer,
@@ -309,7 +309,7 @@ describe('CastView Qwen bespoke sample playback (plan 108 fix)', () => {
           <CastView
             characters={characters}
             setCharacters={() => {}}
-            library={library}
+            library={libraryOverride}
             title="The Northern Star"
             onOpenProfile={() => {}}
             onShowMatchDetail={() => {}}
@@ -354,6 +354,44 @@ describe('CastView Qwen bespoke sample playback (plan 108 fix)', () => {
     await waitFor(() => expect(playSampleWithAutoLoad).toHaveBeenCalledTimes(1));
     const args = vi.mocked(playSampleWithAutoLoad).mock.calls[0][0].args;
     expect(args.voice.voiceUuid).toBe('uuid-marrow-123');
+  });
+
+  it("prefers the character's own voiceUuid over a stale/foreign one on the matched library voice", async () => {
+    /* Regression: the matched library voice can carry the WRONG voiceUuid —
+       e.g. the server aggregation bleeding an unrelated book's identity onto
+       a same-id character (voices.ts's cross-book dedup collision, fixed
+       separately), or any other stale-cache case. The character's OWN
+       voiceUuid (read straight from this book's cast.json) must win; the
+       matched voice's uuid is only a fallback for a genuinely reused
+       character that carries none of its own. */
+    vi.mocked(playSampleWithAutoLoad).mockClear();
+    const foreignUuidLibrary = library.map((v) =>
+      v.id === 'v_marrow' ? { ...v, voiceUuid: 'foreign-uuid-from-other-book' } : v,
+    );
+    renderChars([{ ...marrowQwen, voiceUuid: 'own-uuid-correct' }], foreignUuidLibrary);
+    const row = rowFor('Mr. Marrow');
+    const swatch = row.querySelector('button[aria-label^="Play sample"]') as HTMLButtonElement;
+    fireEvent.click(swatch);
+    await waitFor(() => expect(playSampleWithAutoLoad).toHaveBeenCalledTimes(1));
+    const args = vi.mocked(playSampleWithAutoLoad).mock.calls[0][0].args;
+    expect(args.voice.voiceUuid).toBe('own-uuid-correct');
+  });
+
+  it('falls back to the matched voice\'s voiceUuid for a reused character that carries none of its own', async () => {
+    /* The other half of the precedence contract: a character matched/reused
+       from a prior book (no bespoke voiceUuid of its own — the design lives
+       on the matched Voice) must still resolve the uuid-keyed cache entry. */
+    vi.mocked(playSampleWithAutoLoad).mockClear();
+    const uuidLibrary = library.map((v) =>
+      v.id === 'v_marrow' ? { ...v, voiceUuid: 'matched-voice-uuid' } : v,
+    );
+    renderChars([marrowQwen], uuidLibrary);
+    const row = rowFor('Mr. Marrow');
+    const swatch = row.querySelector('button[aria-label^="Play sample"]') as HTMLButtonElement;
+    fireEvent.click(swatch);
+    await waitFor(() => expect(playSampleWithAutoLoad).toHaveBeenCalledTimes(1));
+    const args = vi.mocked(playSampleWithAutoLoad).mock.calls[0][0].args;
+    expect(args.voice.voiceUuid).toBe('matched-voice-uuid');
   });
 
   it('shows an inline error (no API call) for a Qwen-pinned row with no designed voice', async () => {

--- a/src/views/cast.test.tsx
+++ b/src/views/cast.test.tsx
@@ -854,6 +854,83 @@ describe('CastView desktop drag-drop is intact', () => {
     });
     expect(setCharacters).toHaveBeenCalled();
   });
+
+  it("resolves a drag-and-drop to this book's own voice, not an unrelated book's same-id voice", () => {
+    /* Regression: two unrelated books' voiceId-less characters (e.g. both
+       named-generically 'narrator') can share a bare Voice.id in the
+       aggregated library array now that the server no longer merges them
+       cross-book without an explicit voiceId. `draggingVoiceId` only ever
+       carries the bare id, so `findVoice` must prefer this book's own
+       `source: 'current'` entry — otherwise a same-id foreign-book entry
+       (listed first here, to prove order independence) silently wins. */
+    const ownNarratorVoice: Voice = {
+      id: 'narrator',
+      character: 'Narrator',
+      bookTitle: 'The Northern Star',
+      bookId: 'b_current',
+      attributes: [],
+      gradient: ['#000', '#fff'],
+      usedIn: 1,
+      source: 'current',
+      ttsVoice: { provider: 'coqui', name: 'Aaron Dreschner', description: 'Mid' },
+    };
+    const foreignNarratorVoice: Voice = {
+      ...ownNarratorVoice,
+      bookId: 'b_other',
+      bookTitle: 'Some Other Book',
+      source: 'library',
+    };
+    const store = configureStore({
+      reducer: {
+        ui: uiSlice.reducer,
+        cast: castSlice.reducer,
+        castDesign: castDesignSlice.reducer,
+      },
+    });
+    let castRef: Character[] = [marrow];
+    const setCharacters = vi.fn((next: Character[] | ((prev: Character[]) => Character[])) => {
+      castRef = typeof next === 'function' ? next(castRef) : next;
+    });
+    render(
+      <Provider store={store}>
+        <CastView
+          characters={castRef}
+          setCharacters={setCharacters}
+          library={[foreignNarratorVoice, ownNarratorVoice]}
+          title="The Northern Star"
+          onOpenProfile={() => {}}
+          onShowMatchDetail={() => {}}
+          driftEvents={[]}
+          onShowDrift={() => {}}
+          onContinueToManuscript={() => {}}
+        />
+      </Provider>,
+    );
+    /* Default tab is 'current' (no series voices), so only the own-book
+       card renders — exactly the "user only ever touched their own card"
+       scenario the bug still breaks, since findVoice re-searches the WHOLE
+       library array by bare id regardless of which card was dragged. */
+    const libraryCard = screen
+      .getAllByText('Narrator')
+      .map((el) => el.closest('div[draggable]'))
+      .find((n): n is HTMLElement => !!n);
+    expect(libraryCard).toBeTruthy();
+    act(() => {
+      fireEvent.dragStart(libraryCard!, {
+        dataTransfer: { effectAllowed: 'copy', setData: () => {} },
+      });
+    });
+    const marrowRow = rowFor('Mr. Marrow');
+    act(() => {
+      fireEvent.dragOver(marrowRow);
+      fireEvent.drop(marrowRow);
+    });
+    const updated = castRef.find((c) => c.id === 'marrow');
+    expect(updated?.voiceId).toBe('narrator');
+    /* matchedFrom is only stamped for a source:'library' voice — its absence
+       proves the own-book (source:'current') entry was applied. */
+    expect(updated?.matchedFrom).toBeUndefined();
+  });
 });
 
 /* Plan 81 wave 4 — tap-to-assign is the touch-friendly parallel path

--- a/src/views/cast.tsx
+++ b/src/views/cast.tsx
@@ -506,12 +506,19 @@ export function CastView({
        srv-43: also inject voiceUuid (parity with profile-drawer.tsx) so the
        server's qwenStorageKey resolves the uuid-keyed cache entry the design
        route wrote, instead of the legacy name-derived key — otherwise the
-       voice-sample cache hash differs and every Play misses and re-synthesises. */
+       voice-sample cache hash differs and every Play misses and re-synthesises.
+       The character's OWN voiceUuid (read straight from this book's
+       cast.json) wins over the matched library voice's — that field is the
+       unambiguous ground truth, whereas the matched voice is a derived,
+       cross-book lookup that can (and did — a real cross-book identity
+       collision in the aggregator) carry a stale/foreign uuid. The matched
+       voice's uuid only fills in for a reused character that carries none
+       of its own (the bespoke design lives on the matched Voice instead). */
     const requestSubject: Voice =
       effectiveEngine === 'qwen' && designedQwenVoiceId
         ? {
             ...subject,
-            voiceUuid: voice?.voiceUuid ?? c.voiceUuid,
+            voiceUuid: c.voiceUuid ?? voice?.voiceUuid,
             overrideTtsVoices: {
               ...(subject.overrideTtsVoices ?? {}),
               qwen: { name: designedQwenVoiceId },
@@ -775,8 +782,10 @@ export function CastView({
             {/* fe-46 — always visible, never disabled; the voice-readiness
                 gate lives at generation start, not at this navigation step. */}
             <PrimaryButton variant="dark" icon={false} onClick={onContinueToManuscript}>
-              Continue to manuscript
-              <IconChevR className="w-4 h-4" />
+              <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
+                Continue to manuscript
+                <IconChevR className="w-4 h-4" />
+              </span>
             </PrimaryButton>
           </div>
         </div>
@@ -955,7 +964,7 @@ export function CastView({
 
         {/* Plan 81 wave 3 — md:+ table layout (legacy, unchanged contract). */}
         <div className="hidden md:block bg-white rounded-3xl border border-ink/10 shadow-card overflow-hidden">
-          <div className="grid grid-cols-[40px_1.5fr_1.2fr_1.6fr_0.6fr_1.2fr_1fr_140px] gap-x-3 px-6 py-3 text-[11px] uppercase tracking-wider font-semibold text-ink/50 border-b border-ink/10">
+          <div className="grid grid-cols-[40px_2fr_0.9fr_1.6fr_0.5fr_1fr_1fr_110px] gap-x-3 px-6 py-3 text-[11px] uppercase tracking-wider font-semibold text-ink/50 border-b border-ink/10">
             <span></span>
             <span>Character</span>
             <span>Role</span>
@@ -999,7 +1008,7 @@ export function CastView({
                   }
                   onOpenProfile(c.id);
                 }}
-                className={`w-full grid grid-cols-[40px_1.5fr_1.2fr_1.6fr_0.6fr_1.2fr_1fr_140px] gap-x-3 px-6 py-4 items-center text-left text-sm hover:bg-ink/2 transition-colors cursor-pointer ${i < filtered.length - 1 ? 'border-b border-ink/5' : ''} ${isDropTarget ? 'drop-active' : ''} ${selectedCharIds.includes(c.id) ? 'bg-peach/4' : ''}`}
+                className={`w-full grid grid-cols-[40px_2fr_0.9fr_1.6fr_0.5fr_1fr_1fr_110px] gap-x-3 px-6 py-4 items-center text-left text-sm hover:bg-ink/2 transition-colors cursor-pointer ${i < filtered.length - 1 ? 'border-b border-ink/5' : ''} ${isDropTarget ? 'drop-active' : ''} ${selectedCharIds.includes(c.id) ? 'bg-peach/4' : ''}`}
               >
                 <span
                   onClick={(e) => {
@@ -1149,7 +1158,7 @@ export function CastView({
                   </button>
                   {row?.error && (
                     <span
-                      className="text-[10px] text-red-600/80 truncate max-w-[130px]"
+                      className="text-[10px] text-red-600/80 truncate max-w-[100px]"
                       title={row.error}
                     >
                       ⚠ {row.error}

--- a/src/views/cast.tsx
+++ b/src/views/cast.tsx
@@ -301,8 +301,12 @@ export function CastView({
      the rows. Counts every emotion character's missing variants; `hasBase`
      splits the actionable-now total (`readyTasks`) from the work blocked behind
      a missing base voice (`blockedTasks`/`blockedChars`). */
+  /* Every findVoiceForCharacter call in this view passes preferCurrentBook:
+     true — `c` always comes from `characters`, this view's own open book's
+     roster, so preferring a same-id `source: 'current'` match is safe (see
+     the function's doc comment for why that's NOT true everywhere). */
   const isQwenForVariants = (c: Character): boolean =>
-    effectiveEngineFor(c) === 'qwen' || findVoiceForCharacter(c, library)?.ttsVoice?.provider === 'qwen';
+    effectiveEngineFor(c) === 'qwen' || findVoiceForCharacter(c, library, true)?.ttsVoice?.provider === 'qwen';
   const variantTasks = useMemo(
     () => buildVariantTasks(characters, usedEmotions, isQwenForVariants),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -314,7 +318,7 @@ export function CastView({
      StatusPill resolves its labels (matched library voice + effective engine)
      so the chips and the rows can't disagree. */
   const statusKeysFor = (c: Character): string[] =>
-    statusFilterKeys(c, findVoiceForCharacter(c, library), effectiveEngineFor(c), usedEmotions.get(c.id));
+    statusFilterKeys(c, findVoiceForCharacter(c, library, true), effectiveEngineFor(c), usedEmotions.get(c.id));
 
   /* "Design full cast" — every character whose lifecycle is "Needs voice" (a
      Qwen-effective character with no designed voice), most-spoken first. Built
@@ -325,7 +329,7 @@ export function CastView({
       characters
         .filter(
           (c) =>
-            resolveVoiceStatus(c, findVoiceForCharacter(c, library), effectiveEngineFor(c))
+            resolveVoiceStatus(c, findVoiceForCharacter(c, library, true), effectiveEngineFor(c))
               .lifecycle?.label === 'Needs voice',
         )
         .slice()
@@ -436,7 +440,7 @@ export function CastView({
     const tally = new Map<string, { color: StatusPillColor; count: number }>();
     for (const c of characters) {
       const effectiveEngine = c.ttsEngine ?? ttsEngine;
-      const voice = findVoiceForCharacter(c, library);
+      const voice = findVoiceForCharacter(c, library, true);
       const { lifecycle, reused, hasEmotionVariants } = resolveVoiceStatus(c, voice, effectiveEngine);
       const lifecycleKey = lifecycle?.label ?? 'Unset';
       const lifecycleColor: StatusPillColor = lifecycle?.color ?? 'neutral';
@@ -987,7 +991,7 @@ export function CastView({
             <span>Sample</span>
           </div>
           {filtered.map((c, i) => {
-            const voice = findVoiceForCharacter(c, library);
+            const voice = findVoiceForCharacter(c, library, true);
             const ttsVoice = resolveDisplayTtsVoice(c, voice, ttsEngine);
             const isDropTarget = dropTargetCharId === c.id;
             const sampleVoiceId = sampleScopeFor(c);
@@ -1192,7 +1196,7 @@ export function CastView({
             for touch devices). */}
         <div className="md:hidden flex flex-col gap-3">
           {filtered.map((c) => {
-            const voice = findVoiceForCharacter(c, library);
+            const voice = findVoiceForCharacter(c, library, true);
             const ttsVoice = resolveDisplayTtsVoice(c, voice, ttsEngine);
             const isDropTarget = dropTargetCharId === c.id;
             const sampleVoiceId = sampleScopeFor(c);

--- a/src/views/cast.tsx
+++ b/src/views/cast.tsx
@@ -276,7 +276,19 @@ export function CastView({
      it clears all of them, so the actionable unit is the chapter. */
   const driftChapterCountFor = (id: string) => distinctDriftChapterCount(driftByChar(id));
   const totalDriftChapters = distinctDriftChapterCount(driftEvents);
-  const findVoice = (id?: string) => library.find((v) => v.id === id);
+  /* Same bare-id collision voice-character-link.ts's findVoiceForCharacter
+     guards against: two unrelated books' voiceId-less characters (narrator,
+     unknown-male/female) can share a bare id, so the aggregated `library`
+     array can legitimately carry two entries with the same `id`. `id` here
+     is actually `familyKey ?? id` (voice-library-panel.tsx sets
+     draggingVoiceId from that pair, and it's globally unique), so this
+     already disambiguates in the common case; the `source: 'current'`
+     preference is a second layer for a fixture/edge-case with no
+     familyKey, where a dropped voice always belongs to (or was dragged
+     from) this book's own panel. */
+  const findVoice = (id?: string) =>
+    library.find((v) => (v.familyKey ?? v.id) === id && v.source === 'current') ??
+    library.find((v) => (v.familyKey ?? v.id) === id);
   /* A character's effective engine = its per-character override, else the
      project default. Qwen is the only override that diverges from the project
      model key, so the sample/Stop-detection prefix must use the Qwen key for
@@ -629,7 +641,9 @@ export function CastView({
      pill on the active voice cancels (sets back to null); tapping it on
      a different voice swaps to that voice. */
   function handleTapAssignToggle(voice: Voice) {
-    setAssigningVoice((prev) => (prev?.id === voice.id ? null : voice));
+    setAssigningVoice((prev) =>
+      (prev?.familyKey ?? prev?.id) === (voice.familyKey ?? voice.id) ? null : voice,
+    );
   }
 
   /* Plan 81 wave 3 — responsive layout split:
@@ -1458,7 +1472,7 @@ export function CastView({
               void playSampleFor(c, v);
             }}
             onTapAssign={handleTapAssignToggle}
-            assigningVoiceId={assigningVoice?.id ?? null}
+            assigningVoiceId={assigningVoice?.familyKey ?? assigningVoice?.id ?? null}
             bookLanguage={bookLanguage}
           />
         </aside>
@@ -1522,11 +1536,14 @@ export function CastView({
                      can see + tap the character rows below. The sticky
                      assignment banner stays visible regardless. */
                   handleTapAssignToggle(v);
-                  if (!assigningVoice || assigningVoice.id !== v.id) {
+                  if (
+                    !assigningVoice ||
+                    (assigningVoice.familyKey ?? assigningVoice.id) !== (v.familyKey ?? v.id)
+                  ) {
                     setShowLibrary(false);
                   }
                 }}
-                assigningVoiceId={assigningVoice?.id ?? null}
+                assigningVoiceId={assigningVoice?.familyKey ?? assigningVoice?.id ?? null}
                 bookLanguage={bookLanguage}
               />
             </div>

--- a/src/views/cast.tsx
+++ b/src/views/cast.tsx
@@ -782,10 +782,8 @@ export function CastView({
             {/* fe-46 — always visible, never disabled; the voice-readiness
                 gate lives at generation start, not at this navigation step. */}
             <PrimaryButton variant="dark" icon={false} onClick={onContinueToManuscript}>
-              <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
-                Continue to manuscript
-                <IconChevR className="w-4 h-4" />
-              </span>
+              Continue to manuscript
+              <IconChevR className="w-4 h-4" />
             </PrimaryButton>
           </div>
         </div>
@@ -964,7 +962,7 @@ export function CastView({
 
         {/* Plan 81 wave 3 — md:+ table layout (legacy, unchanged contract). */}
         <div className="hidden md:block bg-white rounded-3xl border border-ink/10 shadow-card overflow-hidden">
-          <div className="grid grid-cols-[40px_2fr_0.9fr_1.6fr_0.5fr_1fr_1fr_110px] gap-x-3 px-6 py-3 text-[11px] uppercase tracking-wider font-semibold text-ink/50 border-b border-ink/10">
+          <div className="grid grid-cols-[40px_1.5fr_1.2fr_1.6fr_0.6fr_1.2fr_1fr_140px] gap-x-3 px-6 py-3 text-[11px] uppercase tracking-wider font-semibold text-ink/50 border-b border-ink/10">
             <span></span>
             <span>Character</span>
             <span>Role</span>
@@ -1008,7 +1006,7 @@ export function CastView({
                   }
                   onOpenProfile(c.id);
                 }}
-                className={`w-full grid grid-cols-[40px_2fr_0.9fr_1.6fr_0.5fr_1fr_1fr_110px] gap-x-3 px-6 py-4 items-center text-left text-sm hover:bg-ink/2 transition-colors cursor-pointer ${i < filtered.length - 1 ? 'border-b border-ink/5' : ''} ${isDropTarget ? 'drop-active' : ''} ${selectedCharIds.includes(c.id) ? 'bg-peach/4' : ''}`}
+                className={`w-full grid grid-cols-[40px_1.5fr_1.2fr_1.6fr_0.6fr_1.2fr_1fr_140px] gap-x-3 px-6 py-4 items-center text-left text-sm hover:bg-ink/2 transition-colors cursor-pointer ${i < filtered.length - 1 ? 'border-b border-ink/5' : ''} ${isDropTarget ? 'drop-active' : ''} ${selectedCharIds.includes(c.id) ? 'bg-peach/4' : ''}`}
               >
                 <span
                   onClick={(e) => {
@@ -1158,7 +1156,7 @@ export function CastView({
                   </button>
                   {row?.error && (
                     <span
-                      className="text-[10px] text-red-600/80 truncate max-w-[100px]"
+                      className="text-[10px] text-red-600/80 truncate max-w-[130px]"
                       title={row.error}
                     >
                       ⚠ {row.error}

--- a/src/views/voices.test.tsx
+++ b/src/views/voices.test.tsx
@@ -453,6 +453,40 @@ describe('LibraryView compare-two-voices affordance (plan 22a)', () => {
     expect(compareBtn).not.toBeDisabled();
   });
 
+  it("selects both of two unrelated books' same-bare-id voices independently, not as a toggle (cross-book id collision)", () => {
+    /* Regression: the analyzer assigns the same literal id ('narrator',
+       'unknown-male', 'unknown-female') to every book's narrator/auto-
+       folded background character with no voiceId to disambiguate them,
+       so this all-books view can show two entries with the same bare id.
+       Before the familyKey fix, `toggleSelect`/`selectedVoiceIds` keyed on
+       bare id, so selecting the second card just toggled the FIRST one
+       back off (dedup on the shared id) instead of selecting both. */
+    const collidingLibrary: Voice[] = [
+      makeVoice({
+        id: 'narrator',
+        familyKey: 'b1::narrator',
+        character: 'Narrator',
+        bookId: 'b1',
+        bookTitle: 'Book One',
+        source: 'current',
+      }),
+      makeVoice({
+        id: 'narrator',
+        familyKey: 'b-other::narrator',
+        character: 'Narrator',
+        bookId: 'b-other',
+        bookTitle: 'Some Other Book',
+        source: 'library',
+      }),
+    ];
+    renderCompare(collidingLibrary);
+    const checkboxes = screen.getAllByLabelText('Select voice for compare');
+    expect(checkboxes).toHaveLength(2);
+    fireEvent.click(checkboxes[0]);
+    fireEvent.click(checkboxes[1]);
+    expect(screen.getAllByLabelText('Deselect voice')).toHaveLength(2);
+  });
+
   it('disables Compare at 3+ selections with "Select exactly 2 voices" (plan 22a)', () => {
     renderCompare();
     const checkboxes = screen.getAllByLabelText('Select voice for compare');

--- a/src/views/voices.tsx
+++ b/src/views/voices.tsx
@@ -273,13 +273,17 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
      Resolve each Qwen voice to its character (redux for the open book, the
      global cast cache for others) and count its qwen.variants. */
   const variantCountByVoiceId = useMemo(() => {
+    /* Keyed on familyKey (falling back to id) — qwenLibrary spans every
+       book, so two unrelated books' same-slug, voiceId-less Qwen
+       characters (narrator/unknown-male/female) can share bare `id`, which
+       would otherwise overwrite one book's count with the other's. */
     const map = new Map<string, number>();
     for (const v of qwenLibrary) {
       const source =
         v.bookId === currentBookId ? characters : (globalCastCache.get(v.bookId) ?? null);
       const ch = source ? findCharacterForVoice(v, source) : null;
       const n = ch ? Object.keys(ch.overrideTtsVoices?.qwen?.variants ?? {}).length : 0;
-      if (n > 0) map.set(v.id, n);
+      if (n > 0) map.set(v.familyKey ?? v.id, n);
     }
     return map;
   }, [qwenLibrary, currentBookId, characters, globalCastCache]);
@@ -287,6 +291,8 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
      Mirrors variantCountByVoiceId but needs the book's sentences (redux for the
      open book, the cache for foreign books — 0 until a book hydrates). */
   const missingVariantCountByVoiceId = useMemo(() => {
+    /* Keyed on familyKey (falling back to id) — same cross-book bare-id
+       collision as variantCountByVoiceId above. */
     const map = new Map<string, number>();
     for (const v of qwenLibrary) {
       const source =
@@ -297,7 +303,7 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
         v.bookId === currentBookId ? openBookSentences : (sentencesByBookId.get(v.bookId) ?? []);
       const used = usedEmotionsByCharacter(sents).get(ch.id);
       const n = countMissingVariants(ch, used);
-      if (n > 0) map.set(v.id, n);
+      if (n > 0) map.set(v.familyKey ?? v.id, n);
     }
     return map;
   }, [qwenLibrary, currentBookId, characters, globalCastCache, openBookSentences, sentencesByBookId]);
@@ -308,7 +314,7 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
         : qwenLibrary.filter((v) => v.languageCode === languageFilter);
     if (variantFilter === 'all') return langFiltered;
     const map = variantFilter === 'has' ? variantCountByVoiceId : missingVariantCountByVoiceId;
-    return langFiltered.filter((v) => (map.get(v.id) ?? 0) > 0);
+    return langFiltered.filter((v) => (map.get(v.familyKey ?? v.id) ?? 0) > 0);
   }, [qwenLibrary, languageFilter, variantFilter, variantCountByVoiceId, missingVariantCountByVoiceId]);
   const qwenGroups = useMemo(
     () => buildQwenStatusGroups(filteredQwenLibrary, tab),
@@ -1933,12 +1939,15 @@ function QwenStatusSection({
                                 ) : (
                                   <Pill color="library">Designed</Pill>
                                 )}
-                                {(variantCountByVoiceId.get(v.id) ?? 0) > 0 && (
-                                  <VariantsBadge count={variantCountByVoiceId.get(v.id)!} />
+                                {(variantCountByVoiceId.get(v.familyKey ?? v.id) ?? 0) > 0 && (
+                                  <VariantsBadge
+                                    count={variantCountByVoiceId.get(v.familyKey ?? v.id)!}
+                                  />
                                 )}
-                                {(missingVariantCountByVoiceId.get(v.id) ?? 0) > 0 && (
+                                {(missingVariantCountByVoiceId.get(v.familyKey ?? v.id) ?? 0) >
+                                  0 && (
                                   <NeedsVariantsBadge
-                                    count={missingVariantCountByVoiceId.get(v.id)!}
+                                    count={missingVariantCountByVoiceId.get(v.familyKey ?? v.id)!}
                                   />
                                 )}
                               </span>

--- a/src/views/voices.tsx
+++ b/src/views/voices.tsx
@@ -205,9 +205,15 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
   const playback = useSamplePlayback();
   const activeEngine = engineForModelKey(ttsModelKey);
 
+  /* familyKey (falling back to id) — unlike the cast view, this page shows
+     every book's voices side by side with no single "current" book, so two
+     unrelated books' same-slug, voiceId-less voices (narrator/unknown-male/
+     female) can share bare `id` here. Selecting one must never toggle the
+     other. */
   const toggleSelect = (v: Voice) => {
+    const key = v.familyKey ?? v.id;
     setSelectedVoiceIds((prev) =>
-      prev.includes(v.id) ? prev.filter((id) => id !== v.id) : [...prev, v.id],
+      prev.includes(key) ? prev.filter((id) => id !== key) : [...prev, key],
     );
   };
 
@@ -322,7 +328,7 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
      click handler triggers the fetch). */
   const compareDerivations = useMemo(() => {
     const selectedVoices = selectedVoiceIds
-      .map((id) => library.find((v) => v.id === id))
+      .map((id) => library.find((v) => (v.familyKey ?? v.id) === id))
       .filter((v): v is Voice => !!v);
     let badge: 'same' | 'different' | null = null;
     if (selectedVoices.length === 2 && selectedVoices[0].ttsVoice && selectedVoices[1].ttsVoice) {
@@ -909,11 +915,15 @@ export function LibraryView({ library, onOpenCharacter }: Props) {
   }
 
   function togglePin(voice: Voice) {
+    /* familyKey (falling back to id) — the bare id alone can collide across
+       unrelated books for a voiceId-less character (narrator, unknown-male,
+       unknown-female), which would pin/unpin the wrong book's voice. */
+    const key = voice.familyKey ?? voice.id;
     const next = !voice.pinned;
-    dispatch(voicesActions.setPinned({ voiceId: voice.id, pinned: next }));
-    api.setVoicePin(voice.id, next).catch((err) => {
+    dispatch(voicesActions.setPinned({ voiceId: key, pinned: next }));
+    api.setVoicePin(key, next).catch((err) => {
       console.error('[voices] pin failed', err);
-      dispatch(voicesActions.setPinned({ voiceId: voice.id, pinned: !next }));
+      dispatch(voicesActions.setPinned({ voiceId: key, pinned: !next }));
     });
   }
 
@@ -1799,7 +1809,7 @@ function VoiceFamilySection({
                         pinned={!!v.pinned}
                         onTogglePin={onTogglePin}
                         onSelect={onOpenCharacter}
-                        selected={selectedVoiceIds.includes(v.id)}
+                        selected={selectedVoiceIds.includes(v.familyKey ?? v.id)}
                         onToggleSelect={onToggleSelect}
                       />
                     ))}
@@ -1911,7 +1921,7 @@ function QwenStatusSection({
                           pinned={!!v.pinned}
                           onTogglePin={onTogglePin}
                           onSelect={onOpenCharacter}
-                          selected={selectedVoiceIds.includes(v.id)}
+                          selected={selectedVoiceIds.includes(v.familyKey ?? v.id)}
                           onToggleSelect={onToggleSelect}
                           badge={
                             group.status === 'designed' ? (


### PR DESCRIPTION
## Summary
- `aggregateVoices()` collided unrelated books' auto-generic characters (narrator, unknown-male, unknown-female — same literal id, no `voiceId`) into one workspace-wide voice-family bucket, bleeding a rendered English book's `generated`/`languageCode`/`voiceUuid` onto a never-generated book sharing the same id.
- `findVoiceForCharacter`'s bare-id fallback now prefers a `source:'current'` match so a same-id foreign library entry can never shadow the character's own book's voice.
- `cast.tsx`'s "Play 12s" sample handler now trusts the character's own `voiceUuid` over the matched library voice's, matching how real chapter generation already resolves voices straight from the book's own `cast.json` — this is what was causing the wrong (foreign) cached sample audio to actually play.

**A high-effort review pass then found the above fix legitimately allows two unrelated books' same-slug voices to coexist as separate library entries — several other consumers weren't ready for that.** Follow-up commit closes those gaps:
- `voices.ts` now emits a `familyKey` (globally unique, unlike `id`) and fixes the pin read to key on it instead of the bare id (pin state no longer bleeds across books).
- `findCharacterForVoice` gets an opt-in `restrictToCurrentBook` guard (only the cast view's voice-library panel needs it — the cross-book duplicate-review flow in `views/voices.tsx` intentionally matches against an arbitrary other book's roster and must stay unrestricted).
- `cast.tsx`'s drag-and-drop, tap-to-assign toggle/highlight, and `voice-library-panel.tsx`'s React key/drag-state/assign-highlight all resolve via `familyKey` now, so two same-id cards can no longer cross-highlight or cross-resolve.
- `voices.tsx`'s compare/select multi-select now keys on `familyKey` — selecting one of two same-id cross-book voices no longer toggles the other one off.
- `profile-drawer.tsx` gets the same voiceUuid-precedence fix as `cast.tsx`.

Real chapter generation was never affected by the core bug (it reads a character's own `voiceUuid` directly from that book's `cast.json`).

Closes #1400

## Test plan
- [x] Regression tests in `server/src/routes/voices.test.ts`, `src/lib/voice-character-link.test.ts`, `src/views/cast.test.tsx`, `src/store/voices-slice.test.ts`, `src/views/voices.test.tsx`, `src/components/voice-library-panel.test.tsx`, and `src/modals/profile-drawer.test.tsx` — every fix verified fail-before/pass-after.
- [x] `npm run typecheck`, full frontend `npm run test` (276 files / 3574 tests), full `npm run test:server` (353 files / 4125 tests), `npm run build`, `npm run lint` all green.
- [x] High-effort automated code review run against the full diff; all confirmed findings addressed in the follow-up commit.